### PR TITLE
feat: add rig-based routing to discord intake slash commands

### DIFF
--- a/discord-intake/commands/map-rig.sh
+++ b/discord-intake/commands/map-rig.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -eu
+
+if [ -z "${GC_CITY_PATH:-}" ] || [ -z "${GC_PACK_DIR:-}" ]; then
+  echo "gc discord-intake map-rig: missing Gas City pack context" >&2
+  exit 1
+fi
+
+exec python3 "$GC_PACK_DIR/scripts/discord_intake_map_rig.py" "$@"

--- a/discord-intake/help/map-rig.txt
+++ b/discord-intake/help/map-rig.txt
@@ -1,0 +1,17 @@
+Map a Discord guild rig name to a workflow dispatch target.
+
+Example:
+  gc discord-intake map-rig 123456789012345678 mission-control mission-control/polecat \
+    --fix-formula mol-discord-fix-issue
+
+Arguments:
+  <guild_id>    Discord guild id
+  <rig_name>    Rig name as used in /gc fix <rig>
+  <target>      rig/pool sling target
+
+Flags:
+  --fix-formula <name>  formula to use for `/gc fix`, default: mol-discord-fix-issue
+
+Users type `/gc fix mission-control "summary"` in any channel. The rig
+parameter routes the request to the configured target regardless of which
+channel the command is invoked from.

--- a/discord-intake/pack.toml
+++ b/discord-intake/pack.toml
@@ -66,6 +66,12 @@ long_description = "help/map-channel.txt"
 script = "commands/map-channel.sh"
 
 [[commands]]
+name = "map-rig"
+description = "Map a Discord guild rig name to a slash-command dispatch target"
+long_description = "help/map-rig.txt"
+script = "commands/map-rig.sh"
+
+[[commands]]
 name = "sync-commands"
 description = "Register guild-scoped /gc commands with Discord"
 long_description = "help/sync-commands.txt"

--- a/discord-intake/scripts/discord_intake_common.py
+++ b/discord-intake/scripts/discord_intake_common.py
@@ -161,6 +161,7 @@ def default_config() -> dict[str, Any]:
             "role_allowlist": [],
         },
         "channels": {},
+        "rigs": {},
     }
 
 
@@ -218,6 +219,35 @@ def normalize_config(raw: dict[str, Any] | None) -> dict[str, Any]:
                 },
             }
         config["channels"] = normalized_channels
+    rigs = raw.get("rigs")
+    if isinstance(rigs, dict):
+        normalized_rigs: dict[str, Any] = {}
+        for key, value in rigs.items():
+            if not isinstance(value, dict):
+                continue
+            guild_id = str(value.get("guild_id", "")).strip()
+            rig_name = str(value.get("rig_name", "")).strip()
+            target = str(value.get("target", "")).strip()
+            if not guild_id or not rig_name or not target:
+                continue
+            commands = value.get("commands")
+            if not isinstance(commands, dict):
+                commands = {}
+            fix_cfg = commands.get("fix")
+            if not isinstance(fix_cfg, dict):
+                fix_cfg = {}
+            fix_formula = str(fix_cfg.get("formula", FIX_FORMULA_DEFAULT)).strip() or FIX_FORMULA_DEFAULT
+            normalized_rigs[str(key)] = {
+                "guild_id": guild_id,
+                "rig_name": rig_name,
+                "target": target,
+                "commands": {
+                    "fix": {
+                        "formula": fix_formula,
+                    }
+                },
+            }
+        config["rigs"] = normalized_rigs
     config["schema_version"] = SCHEMA_VERSION
     return config
 
@@ -319,6 +349,37 @@ def set_channel_mapping(
 def resolve_channel_mapping(config: dict[str, Any], guild_id: str, channel_id: str) -> dict[str, Any] | None:
     channels = normalize_config(config).get("channels", {})
     return channels.get(normalize_channel_key(guild_id, channel_id))
+
+
+def normalize_rig_key(guild_id: str, rig_name: str) -> str:
+    return f"{str(guild_id).strip()}/{str(rig_name).strip()}"
+
+
+def set_rig_mapping(
+    config: dict[str, Any],
+    guild_id: str,
+    rig_name: str,
+    target: str,
+    fix_formula: str | None,
+) -> dict[str, Any]:
+    cfg = normalize_config(config)
+    key = normalize_rig_key(guild_id, rig_name)
+    cfg["rigs"][key] = {
+        "guild_id": str(guild_id).strip(),
+        "rig_name": str(rig_name).strip(),
+        "target": str(target).strip(),
+        "commands": {
+            "fix": {
+                "formula": str(fix_formula or FIX_FORMULA_DEFAULT).strip() or FIX_FORMULA_DEFAULT,
+            }
+        },
+    }
+    return save_config(cfg)
+
+
+def resolve_rig_mapping(config: dict[str, Any], guild_id: str, rig_name: str) -> dict[str, Any] | None:
+    rigs = normalize_config(config).get("rigs", {})
+    return rigs.get(normalize_rig_key(guild_id, rig_name))
 
 
 def load_channel_context(
@@ -721,6 +782,12 @@ def build_command_payload(command_name_value: str, scope: str = "guild") -> list
                 "name": "fix",
                 "description": "Create a GC fix workflow",
                 "options": [
+                    {
+                        "type": 3,
+                        "name": "rig",
+                        "description": "Target rig for the fix workflow",
+                        "required": True,
+                    },
                     {
                         "type": 3,
                         "name": "prompt",

--- a/discord-intake/scripts/discord_intake_map_rig.py
+++ b/discord-intake/scripts/discord_intake_map_rig.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+import discord_intake_common as common
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Map a Discord guild rig name to a workflow target")
+    parser.add_argument("guild_id", help="Discord guild id")
+    parser.add_argument("rig_name", help="Rig name used in /gc fix <rig>")
+    parser.add_argument("target", help="gc sling target, usually rig/pool")
+    parser.add_argument("--fix-formula", default=common.FIX_FORMULA_DEFAULT, help="Formula for /gc fix")
+    args = parser.parse_args(argv)
+
+    config = common.set_rig_mapping(
+        common.load_config(),
+        args.guild_id,
+        args.rig_name,
+        args.target,
+        args.fix_formula,
+    )
+    key = common.normalize_rig_key(args.guild_id, args.rig_name)
+    print(json.dumps(config["rigs"][key], indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/discord-intake/scripts/discord_intake_service.py
+++ b/discord-intake/scripts/discord_intake_service.py
@@ -72,6 +72,7 @@ def human_reason(code: str) -> str:
     mapping = {
         "command_not_supported": "this Discord intake slice only supports /gc fix",
         "channel_mapping_missing": "no channel mapping exists for this conversation",
+        "rig_mapping_missing": "no rig mapping exists for that rig in this guild",
         "command_not_configured": "this channel does not configure that /gc command",
         "guild_only": "Discord /gc fix is only accepted inside a guild",
         "guild_not_allowed": "this guild is not allowed to dispatch /gc fix",
@@ -211,6 +212,7 @@ def parse_application_command(payload: dict[str, Any], command_name_value: str) 
         return {}
     command = str(subcommand.get("name", "")).strip().lower()
     prompt = ""
+    rig = ""
     sub_options = subcommand.get("options") or []
     if isinstance(sub_options, list):
         for option in sub_options:
@@ -218,10 +220,12 @@ def parse_application_command(payload: dict[str, Any], command_name_value: str) 
                 continue
             if str(option.get("name", "")) == "prompt":
                 prompt = str(option.get("value", "")).strip()
-                break
+            if str(option.get("name", "")) == "rig":
+                rig = str(option.get("value", "")).strip()
     return {
         "command": command,
         "prompt": prompt,
+        "rig": rig,
     }
 
 
@@ -641,13 +645,15 @@ def build_request(
     summary: str,
     context_markdown: str,
     channel_context: dict[str, Any],
+    mapping: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     guild_id = str(payload.get("guild_id", "")).strip()
     conversation_id = str(payload.get("channel_id", "")).strip()
     interaction_id = str(payload.get("id", "")).strip()
     thread_id = str(channel_context.get("thread_id", "")).strip()
     channel_id = str(channel_context.get("parent_channel_id", "")).strip() or conversation_id
-    mapping = channel_context.get("mapping") or {}
+    if mapping is None:
+        mapping = channel_context.get("mapping") or {}
     request_id = common.build_request_id(interaction_id, "fix")
     return {
         "request_id": request_id,
@@ -736,27 +742,40 @@ def accept_fix_request(
     summary: str,
     context_markdown: str,
     interaction_id: str,
+    rig_name: str = "",
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     config = common.load_config()
-    if not str(payload.get("guild_id", "")).strip():
+    guild_id = str(payload.get("guild_id", "")).strip()
+    if not guild_id:
         response = build_message_response(human_reason("guild_only"), ephemeral=True)
         return response, receipt_payload(response, response_kind="message")
     if not common.load_bot_token():
         response = build_message_response(human_reason("discord_app_not_configured"), ephemeral=True)
         return response, receipt_payload(response, response_kind="message")
-    channel_context = common.load_channel_context(
-        config,
-        str(payload.get("guild_id", "")),
-        str(payload.get("channel_id", "")),
-        str((payload.get("channel") or {}).get("parent_id", "")),
-    )
-    mapping = channel_context.get("mapping") or {}
-    if not mapping:
-        response = build_message_response(human_reason("channel_mapping_missing"), ephemeral=True)
-        return response, receipt_payload(response, response_kind="message")
+
+    # Resolve dispatch target: rig mapping takes priority, channel mapping as fallback.
+    mapping: dict[str, Any] | None = None
+    channel_context: dict[str, Any] = {}
+    if rig_name:
+        mapping = common.resolve_rig_mapping(config, guild_id, rig_name)
+        if not mapping:
+            response = build_message_response(human_reason("rig_mapping_missing"), ephemeral=True)
+            return response, receipt_payload(response, response_kind="message")
+    else:
+        channel_context = common.load_channel_context(
+            config,
+            guild_id,
+            str(payload.get("channel_id", "")),
+            str((payload.get("channel") or {}).get("parent_id", "")),
+        )
+        mapping = channel_context.get("mapping") or {}
+        if not mapping:
+            response = build_message_response(human_reason("channel_mapping_missing"), ephemeral=True)
+            return response, receipt_payload(response, response_kind="message")
+
     reason = common.policy_reason(
         config,
-        str(payload.get("guild_id", "")),
+        guild_id,
         str(channel_context.get("parent_channel_id", payload.get("channel_id", ""))),
         role_ids(payload),
     )
@@ -770,7 +789,7 @@ def accept_fix_request(
     if not summary:
         response = build_message_response(human_reason("summary_required"), ephemeral=True)
         return response, receipt_payload(response, response_kind="message")
-    request = build_request(payload, summary, context_markdown, channel_context)
+    request = build_request(payload, summary, context_markdown, channel_context, mapping)
     behavior = command_behavior("fix")
     if not behavior:
         response = build_message_response(human_reason("command_not_supported"), ephemeral=True)
@@ -958,10 +977,11 @@ class IntakeHandler(BaseHTTPRequestHandler):
             if command != "fix":
                 interaction_response(self, build_message_response(human_reason("command_not_supported"), ephemeral=True))
                 return
+            rig_name = str(parsed_command.get("rig", "")).strip()
             prompt = str(parsed_command.get("prompt", "")).strip()
             if prompt:
                 summary, context_markdown = prompt_to_summary_context(prompt)
-                response, _ = accept_fix_request(payload, summary, context_markdown, interaction_id)
+                response, _ = accept_fix_request(payload, summary, context_markdown, interaction_id, rig_name=rig_name)
                 interaction_response(self, response)
                 return
             nonce = secrets.token_hex(12)
@@ -973,6 +993,7 @@ class IntakeHandler(BaseHTTPRequestHandler):
                     "user_id": str(((payload.get("member") or {}).get("user") or {}).get("id", "")),
                     "interaction_id": interaction_id,
                     "command": command,
+                    "rig_name": rig_name,
                 }
             )
             common.save_interaction_receipt(
@@ -999,8 +1020,9 @@ class IntakeHandler(BaseHTTPRequestHandler):
             fields = extract_modal_fields(payload)
             summary = str(fields.get("summary", "")).strip()
             context_markdown = str(fields.get("context", "")).strip()
+            rig_name = str(pending.get("rig_name", "")).strip()
             common.remove_pending_modal(nonce)
-            response, receipt = accept_fix_request(payload, summary, context_markdown, interaction_id)
+            response, receipt = accept_fix_request(payload, summary, context_markdown, interaction_id, rig_name=rig_name)
             finalize_modal_origin_receipt(str(pending.get("interaction_id", "")), response, receipt)
             interaction_response(self, response)
             return

--- a/discord-intake/scripts/discord_intake_status.py
+++ b/discord-intake/scripts/discord_intake_status.py
@@ -20,6 +20,7 @@ def render_text(snapshot: dict[str, object]) -> str:
         f"  command_name:     {((config or {}).get('app') or {}).get('command_name', common.COMMAND_NAME_DEFAULT)}",
         f"  bot_token:        {'present' if ((config or {}).get('app') or {}).get('bot_token_present') else 'missing'}",
         f"  channel_mappings: {len(((config or {}).get('channels') or {}))}",
+        f"  rig_mappings:     {len(((config or {}).get('rigs') or {}))}",
         "",
         "Recent Requests:",
     ]

--- a/discord-intake/tests/test_discord_intake_common.py
+++ b/discord-intake/tests/test_discord_intake_common.py
@@ -32,7 +32,8 @@ class DiscordIntakeCommonTests(unittest.TestCase):
         self.assertNotIn("integration_types", payload[0])
         self.assertNotIn("default_member_permissions", payload[0])
         self.assertEqual(payload[0]["options"][0]["name"], "fix")
-        self.assertEqual(payload[0]["options"][0]["options"][0]["name"], "prompt")
+        self.assertEqual(payload[0]["options"][0]["options"][0]["name"], "rig")
+        self.assertEqual(payload[0]["options"][0]["options"][1]["name"], "prompt")
 
     def test_build_global_command_payload_adds_global_only_fields(self) -> None:
         payload = common.build_command_payload("gc", scope="global")
@@ -132,6 +133,26 @@ class DiscordIntakeCommonTests(unittest.TestCase):
         receipt = common.load_interaction_receipt("abc")
         self.assertEqual(receipt["response_kind"], "accepted")
         self.assertEqual(receipt["request_id"], "dc-1")
+
+    def test_set_rig_mapping_persists_fix_formula(self) -> None:
+        config = common.set_rig_mapping(common.load_config(), "1", "mission-control", "mission-control/polecat", "mol-discord-fix-issue")
+
+        mapping = common.resolve_rig_mapping(config, "1", "mission-control")
+
+        self.assertIsNotNone(mapping)
+        assert mapping is not None
+        self.assertEqual(mapping["target"], "mission-control/polecat")
+        self.assertEqual(mapping["rig_name"], "mission-control")
+        self.assertEqual(mapping["commands"]["fix"]["formula"], "mol-discord-fix-issue")
+
+    def test_build_command_payload_includes_rig_option(self) -> None:
+        payload = common.build_command_payload("gc")
+
+        fix_options = payload[0]["options"][0]["options"]
+        rig_opt = next((o for o in fix_options if o["name"] == "rig"), None)
+        self.assertIsNotNone(rig_opt)
+        self.assertTrue(rig_opt["required"])
+        self.assertEqual(rig_opt["type"], 3)
 
     def test_verify_discord_signature_returns_true_when_openssl_verifies(self) -> None:
         with mock.patch.object(common.subprocess, "run", return_value=mock.Mock(returncode=0)):

--- a/discord-intake/tests/test_discord_intake_service.py
+++ b/discord-intake/tests/test_discord_intake_service.py
@@ -288,6 +288,64 @@ class DiscordIntakeServiceTests(unittest.TestCase):
         self.assertIn("internal error occurred", post_channel_message.call_args.args[1])
         self.assertNotIn("leak this path", post_channel_message.call_args.args[1])
 
+    def test_parse_application_command_extracts_rig_option(self) -> None:
+        payload = {
+            "data": {
+                "name": "gc",
+                "options": [
+                    {
+                        "type": 1,
+                        "name": "fix",
+                        "options": [
+                            {"type": 3, "name": "rig", "value": "mission-control"},
+                            {"type": 3, "name": "prompt", "value": "crash on startup"},
+                        ],
+                    }
+                ],
+            }
+        }
+
+        parsed = service.parse_application_command(payload, "gc")
+
+        self.assertEqual(parsed["command"], "fix")
+        self.assertEqual(parsed["rig"], "mission-control")
+        self.assertEqual(parsed["prompt"], "crash on startup")
+
+    def test_accept_fix_request_routes_via_rig_mapping(self) -> None:
+        common.import_app_config(common.load_config(), {"application_id": "1", "public_key": "ab" * 32})
+        common.set_rig_mapping(common.load_config(), "1", "mission-control", "mission-control/polecat", "mol-discord-fix-issue")
+        common.save_bot_token("bot-token")
+        payload = {
+            "id": "interaction-2",
+            "guild_id": "1",
+            "channel_id": "55",
+            "member": {"user": {"id": "99", "username": "alice"}, "roles": []},
+        }
+
+        with mock.patch.object(service, "enqueue_request") as enqueue_request:
+            response, receipt = service.accept_fix_request(payload, "Crash on startup", "unset env X", "interaction-2", rig_name="mission-control")
+
+        self.assertEqual(response["type"], 4)
+        self.assertIn("Accepted /gc fix", response["data"]["content"])
+        request = common.list_recent_requests(limit=1)[0]
+        self.assertEqual(request["dispatch_target"], "mission-control/polecat")
+        enqueue_request.assert_called_once()
+
+    def test_accept_fix_request_rejects_unknown_rig(self) -> None:
+        common.import_app_config(common.load_config(), {"application_id": "1", "public_key": "ab" * 32})
+        common.save_bot_token("bot-token")
+        payload = {
+            "id": "interaction-3",
+            "guild_id": "1",
+            "channel_id": "55",
+            "member": {"user": {"id": "99", "username": "alice"}, "roles": []},
+        }
+
+        response, receipt = service.accept_fix_request(payload, "Crash", "", "interaction-3", rig_name="nonexistent")
+
+        self.assertIn("no rig mapping", response["data"]["content"])
+        self.assertEqual(response["data"]["flags"], 64)
+
     def test_finalize_modal_origin_receipt_replaces_stale_modal_replay(self) -> None:
         common.save_interaction_receipt("slash-1", {"response_kind": "modal", "modal_nonce": "nonce-1"})
         response = service.build_message_response("Accepted /gc fix for this conversation.", ephemeral=False)


### PR DESCRIPTION
## Summary
- Users can now type `/gc fix <rig> [prompt]` to route work to a specific rig from any channel
- Rig mappings configured per-guild via `gc discord-intake map-rig <guild_id> <rig_name> <target>`
- Channel mappings remain as backwards-compatible fallback
- New `map-rig` command, help text, and tests

## Test plan
- [x] All 30 existing + new tests pass (`python3 -m pytest discord-intake/tests/ -v`)
- [ ] Deploy and run `gc discord-intake sync-commands <guild_id>` to register updated slash command
- [ ] Verify `/gc fix <rig>` shows modal and dispatches to correct target
- [ ] Verify channel-mapped `/gc fix` still works (backwards compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)