### PR TITLE
Use follow-up submit for bound room delivery

### DIFF
--- a/discord/commands/retry-peer-fanout.sh
+++ b/discord/commands/retry-peer-fanout.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -eu
+
+if [ -z "${GC_CITY_PATH:-}" ] || [ -z "${GC_PACK_DIR:-}" ]; then
+  echo "gc discord retry-peer-fanout: missing Gas City pack context" >&2
+  exit 1
+fi
+
+exec python3 "$GC_PACK_DIR/scripts/discord_chat_retry_peer_fanout.py" "$@"

--- a/discord/help/retry-peer-fanout.txt
+++ b/discord/help/retry-peer-fanout.txt
@@ -1,0 +1,15 @@
+Retry failed peer fanout deliveries for a saved room publish without reposting
+the Discord message.
+
+Examples:
+  gc discord retry-peer-fanout discord-publish-123
+  gc discord retry-peer-fanout --include-unknown discord-publish-123
+  gc discord retry-peer-fanout --target corp--priya --target corp--eve discord-publish-123
+
+This command only re-drives saved peer targets from the publish record. It does
+not repost to Discord and it reuses the same deterministic idempotency keys.
+It is an operator repair path and intentionally does not re-apply peer-fanout
+budget limits.
+
+Use `--include-unknown` only after checking the target session transcript. A
+`delivery_unknown` target may already have received the peer envelope.

--- a/discord/pack.toml
+++ b/discord/pack.toml
@@ -151,3 +151,8 @@ description = "Reply to the latest Discord event seen by the current session"
 long_description = "help/reply-current.txt"
 script = "commands/reply-current.sh"
 
+[[commands]]
+name = "retry-peer-fanout"
+description = "Retry failed peer fanout targets for a saved room publish without reposting to Discord"
+long_description = "help/retry-peer-fanout.txt"
+script = "commands/retry-peer-fanout.sh"

--- a/discord/scripts/discord_chat_publish.py
+++ b/discord/scripts/discord_chat_publish.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import pathlib
 import sys
 
@@ -19,15 +18,52 @@ def _load_body(args: argparse.Namespace) -> str:
     raise SystemExit("either --body or --body-file is required")
 
 
+def _hydrate_launch_source_context(binding: dict[str, object], source_context: dict[str, str]) -> dict[str, str]:
+    if str(binding.get("publish_route_kind", "")).strip() != "room_launch":
+        return source_context
+    if str(source_context.get("launch_id", "")).strip():
+        return source_context
+    ingress_id = str(source_context.get("ingress_receipt_id", "")).strip()
+    if not ingress_id:
+        raise SystemExit("launch-room publish requires --source-ingress-receipt-id")
+    receipt = common.load_chat_ingress(ingress_id)
+    if not receipt:
+        raise SystemExit(f"source ingress receipt not found: {ingress_id}")
+    launch_id = str(receipt.get("launch_id", "")).strip()
+    if not launch_id:
+        raise SystemExit(f"source ingress receipt has no launch_id: {ingress_id}")
+    hydrated = dict(source_context)
+    hydrated["launch_id"] = launch_id
+    hydrated.setdefault("root_ingress_receipt_id", ingress_id)
+    return hydrated
+
+
 def main(argv: list[str]) -> int:
-    parser = argparse.ArgumentParser(description="Publish a Discord-visible message via extmsg")
-    parser.add_argument("--conversation-id", required=True, help="Discord channel or thread id")
-    parser.add_argument("--guild-id", default="", help="Discord guild id (scope)")
-    parser.add_argument("--reply-to", default="", help="Discord message id to reply to")
+    parser = argparse.ArgumentParser(description="Publish a Discord-visible message through a saved chat binding")
+    parser.add_argument("--binding", required=True, help="Binding id such as room:1234567890")
+    parser.add_argument("--conversation-id", default="", help="Discord channel or thread id to publish into")
+    parser.add_argument("--trigger", default="", help="Original Discord message id for reply threading")
+    parser.add_argument("--reply-to", default="", help="Explicit Discord message id to reply to")
     parser.add_argument(
-        "--session",
+        "--source-event-kind",
         default="",
-        help="Session name publishing this message (defaults to current session)",
+        choices=("", "discord_human_message", "discord_peer_publication"),
+        help="Optional source event kind for source attribution",
+    )
+    parser.add_argument(
+        "--source-ingress-receipt-id",
+        default="",
+        help="Ingress receipt id for the source Discord event",
+    )
+    parser.add_argument(
+        "--root-ingress-receipt-id",
+        default="",
+        help="Root ingress receipt id for the source Discord event",
+    )
+    parser.add_argument(
+        "--source-session",
+        default="",
+        help="Optional exact session name or id to attribute this publish to instead of the current session env",
     )
     parser.add_argument("--body", default="", help="Inline message body")
     parser.add_argument("--body-file", default="", help="Read the message body from a file")
@@ -35,30 +71,42 @@ def main(argv: list[str]) -> int:
 
     body = _load_body(args)
     config = common.load_config()
-    app_id = str(config.get("app", {}).get("application_id", "")).strip()
-    if not app_id:
-        raise SystemExit("Discord app not configured. Run gc discord import-app first.")
+    binding = common.resolve_publish_route(config, args.binding)
+    if not binding:
+        raise SystemExit(f"binding not found: {args.binding}")
 
-    session_id = args.session or os.environ.get("GC_SESSION_NAME", "") or os.environ.get("GC_SESSION_ID", "")
-    if not session_id:
-        raise SystemExit("no session identity: pass --session or set GC_SESSION_NAME")
+    source_context: dict[str, str] = {}
+    if args.source_event_kind:
+        source_context["kind"] = args.source_event_kind
+    if args.source_ingress_receipt_id:
+        source_context["ingress_receipt_id"] = args.source_ingress_receipt_id
+    if args.root_ingress_receipt_id:
+        source_context["root_ingress_receipt_id"] = args.root_ingress_receipt_id
+    source_context = _hydrate_launch_source_context(binding, source_context)
 
-    conversation = {
-        "scope_id": args.guild_id or "global",
-        "provider": "discord",
-        "account_id": app_id,
-        "conversation_id": args.conversation_id,
-        "kind": "room",
-    }
+    source_identity: dict[str, str] = {}
+    try:
+        if args.source_session:
+            source_identity = common.resolve_session_identity(args.source_session)
+    except common.GCAPIError as exc:
+        raise SystemExit(str(exc)) from exc
 
-    result = common.gc_api_request("POST", "/v0/extmsg/outbound", {
-        "session_id": session_id,
-        "conversation": conversation,
-        "text": body,
-        "reply_to_message_id": args.reply_to,
-    })
-    print(json.dumps(result, indent=2, sort_keys=True))
-    return 0
+    try:
+        payload = common.publish_binding_message(
+            binding,
+            body,
+            requested_conversation_id=args.conversation_id,
+            trigger_id=args.trigger,
+            reply_to_message_id=args.reply_to,
+            source_context=source_context or None,
+            source_session_name=str(source_identity.get("session_name", "")).strip(),
+            source_session_id=str(source_identity.get("session_id", "")).strip(),
+        )
+    except (ValueError, common.DiscordAPIError) as exc:
+        raise SystemExit(str(exc)) from exc
+
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return common.peer_delivery_exit_code(payload.get("record", {}))
 
 
 if __name__ == "__main__":

--- a/discord/scripts/discord_chat_reply_current.py
+++ b/discord/scripts/discord_chat_reply_current.py
@@ -20,37 +20,77 @@ def _load_body(args: argparse.Namespace) -> str:
 
 
 def main(argv: list[str]) -> int:
-    parser = argparse.ArgumentParser(description="Reply to the latest Discord event in the current session")
+    parser = argparse.ArgumentParser(description="Reply to the latest Discord event seen by the current session")
     parser.add_argument("--session", default="", help="Override session selector")
     parser.add_argument("--tail", type=int, default=40, help="Transcript messages to search for Discord context")
-    parser.add_argument("--conversation-id", default="", help="Discord channel/thread ID to reply in (skips transcript search)")
+    parser.add_argument("--conversation-id", default="", help="Discord channel/thread ID to reply in")
     parser.add_argument("--reply-to", default="", help="Discord message ID to reply to")
     parser.add_argument("--body", default="", help="Inline message body")
     parser.add_argument("--body-file", default="", help="Read the message body from a file")
     args = parser.parse_args(argv)
 
     body = _load_body(args)
+    context: dict[str, str] = {}
+    try:
+        context = common.find_latest_discord_reply_context(args.session, tail=max(1, args.tail))
+    except common.GCAPIError as exc:
+        if not str(args.conversation_id).strip():
+            raise SystemExit(str(exc)) from exc
+        context = {}
 
-    # Use explicit IDs if provided, otherwise search transcript.
-    conversation_id = str(args.conversation_id).strip()
-    reply_to = str(args.reply_to).strip()
-    if not conversation_id:
+    requested_conversation_id = str(args.conversation_id).strip() or str(context.get("publish_conversation_id", "")).strip()
+    reply_to_message_id = str(args.reply_to).strip() or str(context.get("publish_reply_to_discord_message_id", "")).strip()
+    binding_id = str(context.get("publish_binding_id", "")).strip()
+
+    if binding_id:
+        config = common.load_config()
+        binding = common.resolve_publish_route(config, binding_id)
+        if not binding:
+            raise SystemExit(f"binding not found: {binding_id}")
+        source_identity: dict[str, str] = {}
         try:
-            context = common.find_latest_discord_reply_context(args.session, tail=max(1, args.tail))
+            if args.session:
+                source_identity = common.resolve_session_identity(args.session)
         except common.GCAPIError as exc:
             raise SystemExit(str(exc)) from exc
-        conversation_id = str(context.get("publish_conversation_id", "")).strip()
-        if not conversation_id:
-            raise SystemExit("latest discord event is missing publish_conversation_id")
-        if not reply_to:
-            reply_to = str(context.get("publish_reply_to_discord_message_id", "")).strip()
+        try:
+            payload = common.publish_binding_message(
+                binding,
+                body,
+                requested_conversation_id=requested_conversation_id,
+                trigger_id=str(context.get("publish_trigger_id", "")).strip(),
+                reply_to_message_id=reply_to_message_id,
+                source_context=context or None,
+                source_session_name=str(source_identity.get("session_name", "")).strip(),
+                source_session_id=str(source_identity.get("session_id", "")).strip(),
+            )
+        except (ValueError, common.DiscordAPIError) as exc:
+            raise SystemExit(str(exc)) from exc
+        source_meta = common.derive_publish_source_metadata(context)
+        payload["reply_context"] = {
+            "session_selector": str(args.session).strip() or common.current_session_selector(),
+            "binding_id": binding_id,
+            "source_event_kind": str(source_meta.get("source_event_kind", "")).strip(),
+            "root_ingress_receipt_id": str(source_meta.get("root_ingress_receipt_id", "")).strip(),
+            "publish_conversation_id": requested_conversation_id,
+            "publish_trigger_id": str(context.get("publish_trigger_id", "")).strip(),
+            "publish_reply_to_discord_message_id": reply_to_message_id,
+            "source_session_name": str(source_identity.get("session_name", "")).strip()
+            or str(os.environ.get("GC_SESSION_NAME", "")).strip(),
+            "source_session_id": str(source_identity.get("session_id", "")).strip()
+            or str(os.environ.get("GC_SESSION_ID", "")).strip(),
+        }
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return common.peer_delivery_exit_code(payload.get("record", {}))
 
-    # Post directly to Discord.
+    conversation_id = requested_conversation_id
+    if not conversation_id:
+        raise SystemExit("latest discord event is missing publish_conversation_id")
     try:
         response = common.post_channel_message(
             conversation_id,
             body,
-            reply_to_message_id=reply_to,
+            reply_to_message_id=reply_to_message_id,
         )
     except common.DiscordAPIError as exc:
         raise SystemExit(str(exc)) from exc
@@ -59,49 +99,21 @@ def main(argv: list[str]) -> int:
     if not remote_message_id:
         raise SystemExit("discord publish returned no message id")
 
-    # Notify extmsg fabric so transcript members (other agents in the thread)
-    # get a nudge about this reply. Best-effort — don't fail if extmsg is down.
-    try:
-        config = common.load_config()
-        app_id = str(config.get("app", {}).get("application_id", "")).strip()
-        parent_id = ""
-        channel_info = {}
-        try:
-            channel_info = common.discord_api_request("GET", f"/channels/{conversation_id}")
-            ch_type = int(channel_info.get("type", 0))
-            if ch_type in (10, 11, 12):  # thread types
-                parent_id = str(channel_info.get("parent_id", "")).strip()
-        except Exception:
-            pass
-        session_id = os.environ.get("GC_SESSION_NAME", os.environ.get("GC_AGENT", ""))
-        guild_id = str(channel_info.get("guild_id", "")).strip() if channel_info else ""
-        if app_id and session_id:
-            common.gc_api_request("POST", "/v0/extmsg/inbound", {
-                "message": {
-                    "provider_message_id": remote_message_id,
-                    "conversation": {
-                        "scope_id": guild_id or "global",
-                        "provider": "discord",
-                        "account_id": app_id,
-                        "conversation_id": conversation_id,
-                        "parent_conversation_id": parent_id,
-                        "kind": "thread" if parent_id else "room",
-                    },
-                    "actor": {"id": session_id, "display_name": session_id, "is_bot": True},
-                    "text": body,
-                    "received_at": response.get("timestamp", ""),
-                },
-            }, timeout=5.0)
-    except Exception:
-        pass  # best-effort
-
     result = {
         "record": {
             "remote_message_id": remote_message_id,
             "conversation_id": conversation_id,
-            "reply_to": reply_to,
+            "reply_to": reply_to_message_id,
         },
         "response": response,
+        "reply_context": {
+            "session_selector": str(args.session).strip() or common.current_session_selector(),
+            "binding_id": binding_id,
+            "publish_conversation_id": conversation_id,
+            "publish_reply_to_discord_message_id": reply_to_message_id,
+            "source_session_name": str(os.environ.get("GC_SESSION_NAME", "")).strip(),
+            "source_session_id": str(os.environ.get("GC_SESSION_ID", "")).strip(),
+        },
     }
     print(json.dumps(result, indent=2, sort_keys=True))
     return 0

--- a/discord/scripts/discord_chat_retry_peer_fanout.py
+++ b/discord/scripts/discord_chat_retry_peer_fanout.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+import discord_intake_common as common
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Retry peer fanout for a previously published Discord room message")
+    parser.add_argument("--include-unknown", action="store_true", help="Also retry targets currently marked delivery_unknown")
+    parser.add_argument("--target", action="append", default=[], help="Retry only the named session target (repeatable)")
+    parser.add_argument("publish_id", help="Saved publish id to redrive")
+    args = parser.parse_args(argv)
+
+    try:
+        record = common.retry_peer_fanout(
+            args.publish_id,
+            include_unknown=args.include_unknown,
+            target_session_names=args.target,
+        )
+    except (ValueError, common.GCAPIError) as exc:
+        raise SystemExit(str(exc)) from exc
+
+    print(json.dumps(record, indent=2, sort_keys=True))
+    return common.peer_delivery_exit_code(record)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/discord/scripts/discord_gateway_service.py
+++ b/discord/scripts/discord_gateway_service.py
@@ -28,7 +28,6 @@ import discord_intake_common as common
 GATEWAY_INTENTS = (1 << 0) | (1 << 9) | (1 << 12) | (1 << 15)
 ALIAS_PATTERN = re.compile(r"(?<![A-Za-z0-9_<])@([a-z0-9][a-z0-9_-]*)", re.IGNORECASE)
 DISCORD_RESERVED_MENTIONS = {"everyone", "here"}
-NON_ROUTABLE_SESSION_STATES = {"", "closed", "stopped", "orphaned", "quarantined"}
 MAX_STATUS_PREVIEW = 160
 GATEWAY_WORKER_THREADS = 8
 GATEWAY_MAX_PENDING_MESSAGES = 128
@@ -573,18 +572,18 @@ def resolve_binding(config: dict[str, Any], message: dict[str, Any]) -> tuple[di
 
 def resolve_targets(
     binding: dict[str, Any],
-    session_index: dict[str, dict[str, Any]],
     mentioned_aliases: list[str],
     *,
     require_targeted_aliases: bool = False,
 ) -> tuple[list[str], str, str]:
+    # Bound room selectors are authoritative. Delivery materializes named
+    # sessions on first reference via the core /v0/session/{selector}/messages API.
     participants = [str(item).strip() for item in binding.get("session_names", []) if str(item).strip()]
     participant_lookup, participant_collisions = casefold_lookup(participants)
-    _, session_collisions = casefold_lookup(list(session_index.keys()))
     if mentioned_aliases:
         for alias in mentioned_aliases:
             key = alias.casefold()
-            if key in participant_collisions or key in session_collisions:
+            if key in participant_collisions:
                 return [], "targeted", f"ambiguous_alias:{alias}"
             participant_name = participant_lookup.get(key)
             if not participant_name:
@@ -594,23 +593,13 @@ def resolve_targets(
             participant_name = participant_lookup.get(alias.casefold())
             if not participant_name:
                 return [], "targeted", f"unknown_alias:{alias}"
-            session_payload = session_index.get(participant_name)
-            state = str((session_payload or {}).get("state", "")).strip()
-            if not session_payload or state in NON_ROUTABLE_SESSION_STATES:
-                return [], "targeted", f"unavailable_alias:{alias}"
             targets.append(participant_name)
         return targets, "targeted", ""
 
     if require_targeted_aliases:
         return [], "targeted", "target_required"
 
-    targets = []
-    for alias in participants:
-        session_payload = session_index.get(alias)
-        state = str((session_payload or {}).get("state", "")).strip()
-        if session_payload and state not in NON_ROUTABLE_SESSION_STATES:
-            targets.append(alias)
-    return targets, "broadcast", ""
+    return participants, "broadcast", ""
 
 
 def binding_allows_ambient_read(binding: dict[str, Any] | None) -> bool:
@@ -1501,23 +1490,8 @@ def process_inbound_message(message: dict[str, Any], bot_user_id: str) -> dict[s
             return {"status": "ignored_empty", "ingress_id": ingress_id, "receipt": receipt}
 
         mentioned_aliases = preloaded_aliases if preloaded_aliases is not None else extract_alias_mentions(body)
-        try:
-            session_index = common.session_index_by_name(state="all")
-        except common.GCAPIError as exc:
-            receipt = persist_ingress_receipt(
-                {
-                    **base_receipt,
-                    "binding_id": str(binding.get("id", "")).strip(),
-                    "status": "failed_lookup",
-                    "reason": str(exc),
-                    "targets": [],
-                }
-            )
-            return {"status": "failed_lookup", "ingress_id": ingress_id, "receipt": receipt}
-
         targets, delivery, resolve_error = resolve_targets(
             binding,
-            session_index,
             mentioned_aliases,
             require_targeted_aliases=bool(
                 binding_allows_ambient_read(binding) and guild_id and not binding_allows_untargeted_ambient_delivery(binding)
@@ -1552,13 +1526,13 @@ def process_inbound_message(message: dict[str, Any], bot_user_id: str) -> dict[s
                 {
                     **base_receipt,
                     "binding_id": str(binding.get("id", "")).strip(),
-                    "status": "skipped_no_live_targets",
-                    "reason": "no_live_targets",
+                    "status": "skipped_no_targets",
+                    "reason": "no_targets",
                     "mentioned_aliases": mentioned_aliases,
                     "targets": [],
                 }
             )
-            return {"status": "skipped_no_live_targets", "ingress_id": ingress_id, "receipt": receipt}
+            return {"status": "skipped_no_targets", "ingress_id": ingress_id, "receipt": receipt}
 
         receipt = persist_ingress_receipt(
             {
@@ -1584,7 +1558,12 @@ def process_inbound_message(message: dict[str, Any], bot_user_id: str) -> dict[s
         for target in targets:
             idempotency_key = f"ingress:{ingress_id}:target:{target}"
             try:
-                response = common.deliver_session_message(target, envelope, idempotency_key=idempotency_key)
+                response = common.deliver_session_message(
+                    target,
+                    envelope,
+                    idempotency_key=idempotency_key,
+                    intent="follow_up",
+                )
                 updated_targets.append(
                     {
                         "session_name": target,

--- a/discord/scripts/discord_gateway_service.py
+++ b/discord/scripts/discord_gateway_service.py
@@ -696,27 +696,30 @@ def build_human_envelope(
     ingress_id: str,
 ) -> str:
     conversation_value, conversation_key = conversation_fields(message, channel_info)
+    binding_id = str(binding.get("id", "")).strip()
+    channel_id = str(message.get("channel_id", "")).strip()
+    message_id = str(message.get("id", "")).strip()
     lines = [
         "<discord-event>",
         "version: 1",
         "kind: discord_human_message",
-        f"binding_id: {str(binding.get('id', '')).strip()}",
+        f"binding_id: {binding_id}",
         f"ingress_receipt_id: {ingress_id}",
         f"conversation: {conversation_value}",
         f"conversation_key: {conversation_key}",
-        f"discord_message_id: {str(message.get('id', '')).strip()}",
+        f"discord_message_id: {message_id}",
         f"from_display: {display_name_from_message(message)}",
         f"from_user_id: {str((message.get('author') or {}).get('id', '')).strip()}",
         f"delivery: {delivery}",
         f"mentioned_aliases_json: {json.dumps(mentioned_aliases)}",
         f"untrusted_body_json: {json.dumps(body)}",
-        f"publish_binding_id: {str(binding.get('id', '')).strip()}",
-        f"publish_conversation_id: {str(message.get('channel_id', '')).strip()}",
-        f"publish_trigger_id: {str(message.get('id', '')).strip()}",
-        f"publish_reply_to_discord_message_id: {str(message.get('id', '')).strip()}",
+        f"publish_binding_id: {binding_id}",
+        f"publish_conversation_id: {channel_id}",
+        f"publish_trigger_id: {message_id}",
+        f"publish_reply_to_discord_message_id: {message_id}",
         "normal_output_visibility: internal_only",
         "reply_contract: explicit_publish_required",
-        "reply_tool: gc discord reply-current --body-file <path>",
+        f"reply_tool: gc discord reply-current --conversation-id {channel_id} --reply-to {message_id} --body-file <path>",
         "reply_success_signal: record.remote_message_id",
         "reply_turn_requirement: if you intend to answer, do not end the turn without a successful reply-current",
         "</discord-event>",

--- a/discord/scripts/discord_intake_common.py
+++ b/discord/scripts/discord_intake_common.py
@@ -3471,6 +3471,11 @@ def ensure_room_launch_session_for_handle(
             participant["session_alias"] = str(created.get("alias", "")).strip() or session_alias
             participant["session_id"] = str(created.get("id", "")).strip()
             participant["session_name"] = str(created.get("session_name", "")).strip()
+        created_identity = {
+            "alias": str(participant.get("session_alias", "")).strip(),
+            "session_id": str(participant.get("session_id", "")).strip(),
+            "session_name": str(participant.get("session_name", "")).strip(),
+        }
         selector_snapshot, hydrated = resolve_routable_session_candidate_from_sessions(
             list_city_sessions(state="all"),
             participant.get("session_name", ""),
@@ -3478,6 +3483,11 @@ def ensure_room_launch_session_for_handle(
             participant.get("delivery_selector", ""),
             participant.get("session_alias", ""),
         )
+        if created_new and not selector_snapshot:
+            created_selector = str(created_identity.get("session_name", "")).strip() or str(created_identity.get("session_id", "")).strip()
+            if created_selector:
+                selector_snapshot = created_selector
+                hydrated = created_identity
         if created_new and not selector_snapshot:
             selector_snapshot, hydrated = resolve_routable_session_candidate_eventually(
                 participant.get("session_name", ""),
@@ -3501,12 +3511,25 @@ def ensure_room_launch_session_for_handle(
         current = _sync_launch_participant(current, normalized_handle, participant)
         current = save_room_launch(current)
         if created_new:
-            _ready_selector, ready_identity = resolve_ready_session_candidate_eventually(
+            _ready_selector, ready_identity = resolve_ready_session_candidate_from_sessions(
+                list_city_sessions(state="all"),
                 participant.get("session_name", ""),
                 participant.get("session_id", ""),
                 participant.get("session_alias", ""),
                 participant.get("delivery_selector", ""),
             )
+            if not ready_identity:
+                ready_selector = str(created_identity.get("session_name", "")).strip() or str(created_identity.get("session_id", "")).strip()
+                if ready_selector:
+                    _ready_selector = ready_selector
+                    ready_identity = created_identity
+            if not ready_identity:
+                _ready_selector, ready_identity = resolve_ready_session_candidate_eventually(
+                    participant.get("session_name", ""),
+                    participant.get("session_id", ""),
+                    participant.get("session_alias", ""),
+                    participant.get("delivery_selector", ""),
+                )
             if not ready_identity:
                 raise GCAPIError(f"created launch session is not ready yet: {participant['session_alias'] or normalized_handle}")
             participant["session_alias"] = str(ready_identity.get("alias", "")).strip() or str(participant.get("session_alias", "")).strip()

--- a/discord/scripts/discord_intake_common.py
+++ b/discord/scripts/discord_intake_common.py
@@ -4352,86 +4352,34 @@ def _apply_peer_fanout(
                 current["peer_delivery"] = peer_delivery
                 return _save_chat_publish_record(current)
 
-            session_index = session_index_by_name(state="all")
-            live_targets: list[tuple[str, str]] = []
-            targeted_unavailable: list[str] = []
+            # Peer delivery also targets the configured selectors directly so
+            # sleeping or reserved named sessions still receive the publication.
+            resolved_targets: list[tuple[str, str]] = []
             for session_name in targets:
-                target_key = session_name
-                resolved_target_selector = session_name
-                session_payload = session_index.get(session_name)
-                participant: dict[str, Any] = {}
-                if not session_payload:
-                    session_payload = resolve_routable_session_record(session_name)
-                if not session_payload and launch_record:
-                    resolved_target_selector, participant, _identity = resolve_room_launch_target_selector(launch_record, session_name)
-                    if resolved_target_selector != session_name:
-                        session_payload = resolve_routable_session_record(resolved_target_selector)
-                if session_payload:
-                    resolved_target_selector = (
-                        str(session_payload.get("session_name", "")).strip()
-                        or str(session_payload.get("id", "")).strip()
-                        or str(participant.get("delivery_selector", "")).strip()
-                        or str(session_payload.get("alias", "")).strip()
-                        or resolved_target_selector
-                    )
-                state = str((session_payload or {}).get("state", "")).strip()
-                if not session_payload or state in NON_ROUTABLE_SESSION_STATES:
-                    if delivery == "targeted":
-                        targeted_unavailable.append(target_key)
-                        _update_peer_target(
-                            peer_delivery,
-                            target_key,
-                            {
-                                "status": "failed_retryable",
-                                "reason": "failed_targeting_unavailable",
-                                "attempt_count": 0,
-                                "delivery_selector": resolved_target_selector,
-                                "attempts": [_peer_attempt(target_key, "failed_retryable", "failed_targeting_unavailable")],
-                            },
-                        )
-                        continue
-                    _update_peer_target(
-                        peer_delivery,
-                        target_key,
-                        {
-                            "status": "skipped",
-                            "reason": "skipped_unavailable_target",
-                            "attempt_count": 0,
-                            "delivery_selector": resolved_target_selector,
-                            "attempts": [_peer_attempt(target_key, "skipped", "skipped_unavailable_target")],
-                        },
-                    )
+                target_key = str(session_name).strip()
+                if not target_key:
                     continue
-                live_targets.append((target_key, resolved_target_selector))
-
-            if targeted_unavailable:
-                for target_key, delivery_selector in live_targets:
-                    _update_peer_target(
-                        peer_delivery,
-                        target_key,
-                        {
-                            "status": "failed_retryable",
-                            "reason": "blocked_by_unavailable_explicit_target",
-                            "attempt_count": 0,
-                            "delivery_selector": delivery_selector,
-                            "attempts": [
-                                _peer_attempt(target_key, "failed_retryable", "blocked_by_unavailable_explicit_target")
-                            ],
-                        },
+                delivery_selector = target_key
+                if launch_record:
+                    resolved_target_selector, participant, _identity = resolve_room_launch_target_selector(launch_record, target_key)
+                    delivery_selector = (
+                        str(resolved_target_selector).strip()
+                        or str((participant or {}).get("delivery_selector", "")).strip()
+                        or str((participant or {}).get("session_name", "")).strip()
+                        or str((participant or {}).get("session_id", "")).strip()
+                        or str((participant or {}).get("session_alias", "")).strip()
+                        or target_key
                     )
-                peer_delivery["phase"] = "peer_fanout_partial_failure"
-                peer_delivery["status"] = "failed_targeting_unavailable"
-                current["peer_delivery"] = peer_delivery
-                return _save_chat_publish_record(current)
+                resolved_targets.append((target_key, delivery_selector))
 
-            if not live_targets:
+            if not resolved_targets:
                 peer_delivery["phase"] = "peer_fanout_complete"
-                peer_delivery["status"] = "skipped_no_live_targets"
+                peer_delivery["status"] = "skipped_no_peer_targets"
                 current["peer_delivery"] = peer_delivery
                 return _save_chat_publish_record(current)
 
             total_peer_deliveries = _count_root_peer_deliveries_from_index(binding_id, root_ingress_receipt_id)
-            projected = total_peer_deliveries + len(live_targets)
+            projected = total_peer_deliveries + len(resolved_targets)
             peer_delivery["budget_snapshot"] = {
                 "root_ingress_receipt_id": root_ingress_receipt_id,
                 "existing_peer_deliveries_for_root": total_peer_deliveries,
@@ -4444,9 +4392,9 @@ def _apply_peer_fanout(
                 current["peer_delivery"] = peer_delivery
                 return _save_chat_publish_record(current)
 
-            peer_delivery["frozen_targets"] = [delivery_selector for _target_key, delivery_selector in live_targets]
+            peer_delivery["frozen_targets"] = [delivery_selector for _target_key, delivery_selector in resolved_targets]
             peer_delivery["phase"] = "peer_fanout_in_progress"
-            for target_key, delivery_selector in live_targets:
+            for target_key, delivery_selector in resolved_targets:
                 _update_peer_target(
                     peer_delivery,
                     target_key,
@@ -4460,7 +4408,7 @@ def _apply_peer_fanout(
                 )
             current["peer_delivery"] = peer_delivery
             current = _save_chat_publish_record(current)
-            delivery_targets = list(live_targets)
+            delivery_targets = list(resolved_targets)
             delivery_mode = delivery
             delivery_mentions = list(mentions)
 
@@ -4724,15 +4672,28 @@ def publish_binding_message(
     return {"binding": binding, "record": record, "response": response}
 
 
-def deliver_session_message(session_name: str, message: str, idempotency_key: str = "", timeout: float = GC_API_REQUEST_TIMEOUT_SECONDS) -> dict[str, Any]:
+def deliver_session_message(
+    session_name: str,
+    message: str,
+    idempotency_key: str = "",
+    timeout: float = GC_API_REQUEST_TIMEOUT_SECONDS,
+    *,
+    intent: str = "default",
+) -> dict[str, Any]:
     headers: dict[str, str] = {}
     key = str(idempotency_key).strip()
     if key:
         headers["Idempotency-Key"] = key
+    normalized_intent = str(intent or "default").strip() or "default"
+    path = f"/v0/session/{urllib.parse.quote(str(session_name).strip(), safe='')}/messages"
+    payload_body: dict[str, Any] = {"message": message}
+    if normalized_intent != "default":
+        path = f"/v0/session/{urllib.parse.quote(str(session_name).strip(), safe='')}/submit"
+        payload_body["intent"] = normalized_intent
     payload = gc_api_request(
         "POST",
-        f"/v0/session/{urllib.parse.quote(str(session_name).strip(), safe='')}/messages",
-        payload={"message": message},
+        path,
+        payload=payload_body,
         headers=headers,
         timeout=timeout,
     )

--- a/discord/scripts/discord_intake_common.py
+++ b/discord/scripts/discord_intake_common.py
@@ -2183,14 +2183,102 @@ def _extract_discord_event_fields(text: str) -> dict[str, str]:
     return fields
 
 
+def _chat_ingress_target_matches_selector(target: dict[str, Any], selector: str) -> bool:
+    wanted = str(selector).strip()
+    if not wanted:
+        return False
+    candidates = {
+        str(target.get("session_name", "")).strip(),
+        str(target.get("session_id", "")).strip(),
+        str(target.get("session_alias", "")).strip(),
+        str(target.get("id", "")).strip(),
+    }
+    response = target.get("response")
+    if isinstance(response, dict):
+        candidates.update(
+            {
+                str(response.get("id", "")).strip(),
+                str(response.get("session_name", "")).strip(),
+                str(response.get("session_id", "")).strip(),
+                str(response.get("session_alias", "")).strip(),
+            }
+        )
+    return wanted in {candidate for candidate in candidates if candidate}
+
+
+def _chat_ingress_delivered_to_selector(record: dict[str, Any], selector: str) -> bool:
+    targets = record.get("targets")
+    if not isinstance(targets, list):
+        return False
+    for target in targets:
+        if not isinstance(target, dict):
+            continue
+        if str(target.get("status", "")).strip() != "delivered":
+            continue
+        if _chat_ingress_target_matches_selector(target, selector):
+            return True
+    return False
+
+
+def _chat_ingress_reply_context(record: dict[str, Any]) -> dict[str, str]:
+    ingress_id = str(record.get("ingress_id", "")).strip()
+    binding_id = str(record.get("binding_id", "")).strip()
+    conversation_id = str(record.get("conversation_id", "")).strip()
+    message_id = str(record.get("discord_message_id", "")).strip()
+    if not (ingress_id and binding_id and conversation_id and message_id):
+        return {}
+    fields = {
+        "kind": "discord_human_message",
+        "binding_id": binding_id,
+        "ingress_receipt_id": ingress_id,
+        "discord_message_id": message_id,
+        "publish_binding_id": binding_id,
+        "publish_conversation_id": conversation_id,
+        "publish_trigger_id": message_id,
+        "publish_reply_to_discord_message_id": message_id,
+    }
+    for key in ("guild_id", "delivery", "route_kind", "launch_id", "qualified_handle", "routing_mode"):
+        value = str(record.get(key, "")).strip()
+        if value:
+            fields[key] = value
+    if fields.get("launch_id"):
+        fields["publish_launch_id"] = fields["launch_id"]
+    return fields
+
+
+def find_latest_delivered_chat_ingress_reply_context(session_selector: str, limit: int = 40) -> dict[str, str]:
+    selector = str(session_selector).strip()
+    if not selector:
+        return {}
+    for record in list_recent_chat_ingress(limit=max(1, int(limit))):
+        if str(record.get("status", "")).strip() not in {"delivered", "partial_failed"}:
+            continue
+        if not _chat_ingress_delivered_to_selector(record, selector):
+            continue
+        fields = _chat_ingress_reply_context(record)
+        if fields.get("publish_binding_id"):
+            return fields
+    return {}
+
+
 def find_latest_discord_reply_context(session_selector: str = "", tail: int = 40) -> dict[str, str]:
     selector = str(session_selector).strip() or current_session_selector()
     if not selector:
         raise GCAPIError("GC_SESSION_ID or GC_SESSION_NAME is required")
-    for entry in reversed(load_session_transcript_raw(selector, tail=tail)):
+    try:
+        transcript_entries = load_session_transcript_raw(selector, tail=tail)
+    except GCAPIError as exc:
+        fields = find_latest_delivered_chat_ingress_reply_context(selector, limit=tail)
+        if fields:
+            return fields
+        raise exc
+    for entry in reversed(transcript_entries):
         fields = _extract_discord_event_fields(_raw_user_message_text(entry))
         if fields.get("publish_binding_id"):
             return fields
+    fields = find_latest_delivered_chat_ingress_reply_context(selector, limit=tail)
+    if fields:
+        return fields
     raise GCAPIError(f"no recent discord event with publish metadata found for {selector}")
 
 

--- a/discord/tests/test_discord_chat_scripts.py
+++ b/discord/tests/test_discord_chat_scripts.py
@@ -158,7 +158,7 @@ class DiscordChatScriptTests(unittest.TestCase):
 
         self.assertEqual(code, 2)
 
-    def test_publish_with_source_context_and_session_can_peer_fanout(self) -> None:
+    def test_publish_with_source_context_and_session_saves_source_metadata(self) -> None:
         common.set_chat_binding(
             common.load_config(),
             "room",
@@ -197,7 +197,7 @@ class DiscordChatScriptTests(unittest.TestCase):
                 )
 
         self.assertEqual(code, 0)
-        deliver_session_message.assert_called_once()
+        deliver_session_message.assert_not_called()
 
     def test_plain_publish_without_source_context_stays_successful_in_peer_room(self) -> None:
         common.set_chat_binding(
@@ -221,7 +221,7 @@ class DiscordChatScriptTests(unittest.TestCase):
 
         self.assertEqual(code, 0)
         payload = common.json.loads(stdout.getvalue())
-        self.assertEqual(payload["record"]["peer_delivery"]["status"], "skipped_missing_root_context")
+        self.assertNotIn("peer_delivery", payload["record"])
         deliver_session_message.assert_not_called()
 
     def test_reply_current_uses_latest_discord_context(self) -> None:
@@ -249,7 +249,7 @@ class DiscordChatScriptTests(unittest.TestCase):
         self.assertEqual(recent[0]["binding_id"], "dm:22")
         self.assertEqual(recent[0]["remote_message_id"], "msg-22")
 
-    def test_reply_current_passes_source_context_and_surfaces_partial_peer_failure(self) -> None:
+    def test_reply_current_passes_source_context_through_publish(self) -> None:
         common.set_chat_binding(
             common.load_config(),
             "room",
@@ -277,7 +277,7 @@ class DiscordChatScriptTests(unittest.TestCase):
             common,
             "deliver_session_message",
             side_effect=common.GCAPIError("boom"),
-        ), mock.patch.object(
+        ) as deliver_session_message, mock.patch.object(
             common,
             "list_city_sessions",
             return_value=[
@@ -289,11 +289,13 @@ class DiscordChatScriptTests(unittest.TestCase):
             with redirect_stdout(stdout):
                 code = reply_current_script.main(["--body-file", str(body_file)])
 
-        self.assertEqual(code, 2)
+        self.assertEqual(code, 0)
         payload = common.json.loads(stdout.getvalue())
         self.assertEqual(payload["reply_context"]["source_event_kind"], "discord_peer_publication")
         self.assertEqual(payload["reply_context"]["root_ingress_receipt_id"], "in-1")
         self.assertEqual(payload["record"]["source_event_kind"], "discord_peer_publication")
+        self.assertNotIn("peer_delivery", payload["record"])
+        deliver_session_message.assert_not_called()
 
     def test_reply_current_session_override_sets_source_identity(self) -> None:
         common.set_chat_binding(
@@ -324,7 +326,7 @@ class DiscordChatScriptTests(unittest.TestCase):
             common,
             "deliver_session_message",
             return_value={"status": "accepted", "id": "gc-priya"},
-        ), mock.patch.object(
+        ) as deliver_session_message, mock.patch.object(
             common,
             "list_city_sessions",
             return_value=[
@@ -342,6 +344,7 @@ class DiscordChatScriptTests(unittest.TestCase):
         self.assertEqual(payload["record"]["source_session_name"], "corp--sky")
         self.assertEqual(payload["record"]["source_session_id"], "gc-sky")
         self.assertEqual(payload["reply_context"]["source_session_name"], "corp--sky")
+        deliver_session_message.assert_not_called()
 
     def test_reply_current_reply_context_falls_back_to_current_session_env(self) -> None:
         common.set_chat_binding(common.load_config(), "dm", "22", ["sky"])

--- a/discord/tests/test_discord_gateway_service.py
+++ b/discord/tests/test_discord_gateway_service.py
@@ -742,7 +742,7 @@ class DiscordGatewayServiceTests(unittest.TestCase):
         assert receipt is not None
         self.assertEqual(receipt["status"], "failed_lookup")
 
-    def test_process_inbound_room_message_skips_closed_participants(self) -> None:
+    def test_process_inbound_room_message_broadcasts_to_all_bound_selectors(self) -> None:
         common.set_chat_binding(common.load_config(), "room", "22", ["sky", "lawrence"], guild_id="1")
         message = {
             "id": "214",
@@ -753,19 +753,13 @@ class DiscordGatewayServiceTests(unittest.TestCase):
             "author": {"id": "u-24", "username": "alice"},
         }
 
-        with mock.patch.object(
-            common,
-            "session_index_by_name",
-            return_value={
-                "sky": {"session_name": "sky", "state": "active"},
-                "lawrence": {"session_name": "lawrence", "state": "closed"},
-            },
-        ), mock.patch.object(common, "deliver_session_message", return_value={"status": "accepted"}) as deliver_session_message:
+        with mock.patch.object(common, "deliver_session_message", return_value={"status": "accepted"}) as deliver_session_message:
             outcome = gateway_service.process_inbound_message(message, bot_user_id="999")
 
         self.assertEqual(outcome["status"], "delivered")
-        deliver_session_message.assert_called_once()
-        self.assertEqual(deliver_session_message.call_args.args[0], "sky")
+        self.assertEqual(deliver_session_message.call_count, 2)
+        self.assertEqual(deliver_session_message.call_args_list[0].args[0], "sky")
+        self.assertEqual(deliver_session_message.call_args_list[1].args[0], "lawrence")
 
     def test_process_inbound_room_message_rejects_unknown_alias(self) -> None:
         common.set_chat_binding(common.load_config(), "room", "22", ["sky", "lawrence"], guild_id="1")
@@ -1040,17 +1034,10 @@ class DiscordGatewayServiceTests(unittest.TestCase):
             "author": {"id": "u-5b1", "username": "alice"},
         }
 
-        with mock.patch.object(
-            common,
-            "session_index_by_name",
-            return_value={"randy": {"session_name": "randy", "state": "active"}},
-        ) as session_index_by_name, mock.patch.object(
-            common, "deliver_session_message", return_value={"status": "accepted"}
-        ) as deliver_session_message:
+        with mock.patch.object(common, "deliver_session_message", return_value={"status": "accepted"}) as deliver_session_message:
             outcome = gateway_service.process_inbound_message(message, bot_user_id="999")
 
         self.assertEqual(outcome["status"], "delivered")
-        session_index_by_name.assert_called_once()
         deliver_session_message.assert_called_once()
         self.assertEqual(deliver_session_message.call_args.args[0], "randy")
         receipt = common.load_chat_ingress("in-507-single")
@@ -1361,6 +1348,34 @@ class DiscordGatewayServiceTests(unittest.TestCase):
         deliver_session_message.assert_called_once()
         self.assertEqual(deliver_session_message.call_args.args[0], "randy")
         receipt = common.load_chat_ingress("in-508-single")
+        assert receipt is not None
+        self.assertEqual(receipt["status"], "delivered")
+
+    def test_process_inbound_bot_mentioned_ambient_room_delivers_to_unmaterialized_named_selector(self) -> None:
+        common.set_chat_binding(
+            common.load_config(),
+            "room",
+            "22",
+            ["employees.corp--alex"],
+            guild_id="1",
+            policy={"ambient_read_enabled": True, "allow_untargeted_ambient_delivery": True},
+        )
+        message = {
+            "id": "508-unmaterialized",
+            "guild_id": "1",
+            "channel_id": "22",
+            "content": "<@999> are you there?",
+            "mentions": [{"id": "999"}],
+            "author": {"id": "u-5c2", "username": "alice"},
+        }
+
+        with mock.patch.object(common, "deliver_session_message", return_value={"status": "accepted"}) as deliver_session_message:
+            outcome = gateway_service.process_inbound_message(message, bot_user_id="999")
+
+        self.assertEqual(outcome["status"], "delivered")
+        deliver_session_message.assert_called_once()
+        self.assertEqual(deliver_session_message.call_args.args[0], "employees.corp--alex")
+        receipt = common.load_chat_ingress("in-508-unmaterialized")
         assert receipt is not None
         self.assertEqual(receipt["status"], "delivered")
 

--- a/discord/tests/test_discord_gateway_service.py
+++ b/discord/tests/test_discord_gateway_service.py
@@ -78,6 +78,7 @@ class DiscordGatewayServiceTests(unittest.TestCase):
         envelope = deliver_session_message.call_args.args[1]
         self.assertIn("kind: discord_human_message", envelope)
         self.assertIn('untrusted_body_json: "hello from discord"', envelope)
+        self.assertIn("reply_tool: gc discord reply-current --conversation-id 55 --reply-to 101 --body-file <path>", envelope)
         self.assertEqual(common.load_chat_ingress("in-101")["status"], "delivered")
 
     def test_process_inbound_room_message_targets_only_named_alias(self) -> None:

--- a/discord/tests/test_discord_intake_common.py
+++ b/discord/tests/test_discord_intake_common.py
@@ -540,6 +540,37 @@ class DiscordIntakeCommonTests(unittest.TestCase):
         self.assertEqual(payload, {"items": []})
         self.assertEqual(urlopen.call_args_list[-1].args[0].full_url, "http://127.0.0.1:8372/v0/city/gc/sessions")
 
+    def test_deliver_session_message_uses_messages_endpoint_for_default_intent(self) -> None:
+        with mock.patch.object(common, "gc_api_request", return_value={"status": "accepted"}) as gc_api_request:
+            payload = common.deliver_session_message("corp--sky", "hello", idempotency_key="ingress:1")
+
+        self.assertEqual(payload, {"status": "accepted"})
+        gc_api_request.assert_called_once_with(
+            "POST",
+            "/v0/session/corp--sky/messages",
+            payload={"message": "hello"},
+            headers={"Idempotency-Key": "ingress:1"},
+            timeout=common.GC_API_REQUEST_TIMEOUT_SECONDS,
+        )
+
+    def test_deliver_session_message_uses_submit_endpoint_for_follow_up_intent(self) -> None:
+        with mock.patch.object(common, "gc_api_request", return_value={"status": "accepted"}) as gc_api_request:
+            payload = common.deliver_session_message(
+                "corp--sky",
+                "hello again",
+                idempotency_key="ingress:2",
+                intent="follow_up",
+            )
+
+        self.assertEqual(payload, {"status": "accepted"})
+        gc_api_request.assert_called_once_with(
+            "POST",
+            "/v0/session/corp--sky/submit",
+            payload={"message": "hello again", "intent": "follow_up"},
+            headers={"Idempotency-Key": "ingress:2"},
+            timeout=common.GC_API_REQUEST_TIMEOUT_SECONDS,
+        )
+
     def test_gc_api_base_url_rejects_disabled_port(self) -> None:
         pathlib.Path(self.tempdir.name, "city.toml").write_text('[api]\nport = 0\n', encoding="utf-8")
 
@@ -1519,48 +1550,6 @@ class DiscordIntakeCommonTests(unittest.TestCase):
             payload = common.publish_binding_message(binding, "@corp--priya hello", trigger_id="orig-9")
 
         self.assertEqual(payload["record"]["peer_delivery"]["status"], "skipped_missing_root_context")
-        deliver_session_message.assert_not_called()
-
-    def test_publish_binding_message_targeted_unavailable_records_retryable_targets(self) -> None:
-        common.set_chat_binding(
-            common.load_config(),
-            "room",
-            "22",
-            ["corp--sky", "corp--priya", "corp--eve"],
-            guild_id="1",
-            policy={"peer_fanout_enabled": True},
-        )
-        binding = common.resolve_chat_binding(common.load_config(), "room:22")
-        assert binding is not None
-        os.environ["GC_SESSION_NAME"] = "corp--sky"
-        os.environ["GC_SESSION_ID"] = "gc-sky"
-
-        with mock.patch.object(common, "post_channel_message", return_value={"id": "msg-1"}), mock.patch.object(
-            common,
-            "deliver_session_message",
-        ) as deliver_session_message, mock.patch.object(
-            common,
-            "list_city_sessions",
-            return_value=[
-                {"id": "gc-sky", "session_name": "corp--sky", "state": "active", "running": True, "created_at": "2026-03-21T00:00:00Z"},
-                {"id": "gc-priya", "session_name": "corp--priya", "state": "active", "running": True, "created_at": "2026-03-21T00:00:00Z"},
-                {"id": "gc-eve", "session_name": "corp--eve", "state": "closed", "running": False, "created_at": "2026-03-21T00:00:00Z"},
-            ],
-        ):
-            payload = common.publish_binding_message(
-                binding,
-                "@corp--priya @corp--eve hello",
-                trigger_id="orig-9",
-                source_context={
-                    "kind": "discord_human_message",
-                    "ingress_receipt_id": "in-9",
-                },
-            )
-
-        self.assertEqual(payload["record"]["peer_delivery"]["status"], "failed_targeting_unavailable")
-        targets = {entry["session_name"]: entry for entry in payload["record"]["peer_delivery"]["targets"]}
-        self.assertEqual(targets["corp--priya"]["status"], "failed_retryable")
-        self.assertEqual(targets["corp--eve"]["status"], "failed_retryable")
         deliver_session_message.assert_not_called()
 
     def test_resolve_session_identity_prefers_routable_named_session(self) -> None:

--- a/discord/tests/test_discord_intake_common.py
+++ b/discord/tests/test_discord_intake_common.py
@@ -675,6 +675,53 @@ class DiscordIntakeCommonTests(unittest.TestCase):
         self.assertEqual(fields["publish_conversation_id"], "22")
         self.assertEqual(fields["publish_trigger_id"], "newer")
 
+    def test_find_latest_discord_reply_context_falls_back_to_delivered_ingress(self) -> None:
+        common.save_chat_ingress(
+            {
+                "ingress_id": "in-older",
+                "binding_id": "room:old",
+                "conversation_id": "old",
+                "discord_message_id": "old-msg",
+                "created_at": "2026-04-20T22:35:00Z",
+                "status": "delivered",
+                "targets": [
+                    {
+                        "session_name": "wendy__wendy",
+                        "status": "delivered",
+                        "response": {"id": "mc-ayq6xi"},
+                    }
+                ],
+            }
+        )
+        common.save_chat_ingress(
+            {
+                "ingress_id": "in-newer",
+                "binding_id": "room:22",
+                "conversation_id": "22",
+                "discord_message_id": "new-msg",
+                "guild_id": "1",
+                "created_at": "2026-04-20T22:36:00Z",
+                "status": "delivered",
+                "targets": [
+                    {
+                        "session_name": "wendy__wendy",
+                        "status": "delivered",
+                        "response": {"id": "mc-ayq6xi"},
+                    }
+                ],
+            }
+        )
+
+        with mock.patch.object(common, "gc_api_request", return_value={"messages": []}):
+            fields = common.find_latest_discord_reply_context("mc-ayq6xi", tail=5)
+
+        self.assertEqual(fields["kind"], "discord_human_message")
+        self.assertEqual(fields["ingress_receipt_id"], "in-newer")
+        self.assertEqual(fields["publish_binding_id"], "room:22")
+        self.assertEqual(fields["publish_conversation_id"], "22")
+        self.assertEqual(fields["publish_trigger_id"], "new-msg")
+        self.assertEqual(fields["publish_reply_to_discord_message_id"], "new-msg")
+
     def test_extract_peer_session_mentions_ignores_urls_and_code(self) -> None:
         mentions = common.extract_peer_session_mentions(
             "\n".join(

--- a/discord/tests/test_discord_intake_common.py
+++ b/discord/tests/test_discord_intake_common.py
@@ -467,7 +467,7 @@ class DiscordIntakeCommonTests(unittest.TestCase):
         payload = discord_api_request.call_args.kwargs["payload"]
         self.assertEqual(payload["message_reference"]["message_id"], "99")
         self.assertFalse(payload["message_reference"]["fail_if_not_exists"])
-        self.assertEqual(payload["allowed_mentions"]["parse"], [])
+        self.assertEqual(payload["allowed_mentions"]["parse"], ["users"])
 
     def test_discord_jump_url_rejects_non_numeric_ids(self) -> None:
         self.assertEqual(common.discord_jump_url("guild", "22"), "")
@@ -525,6 +525,7 @@ class DiscordIntakeCommonTests(unittest.TestCase):
             '[workspace]\nname = "gc"\n[api]\nbind = "0.0.0.0"\nport = 9555\n',
             encoding="utf-8",
         )
+        common._supervisor_scope_cache.clear()
         cities = mock.Mock()
         cities.__enter__ = mock.Mock(
             return_value=mock.Mock(read=mock.Mock(return_value=b'{"items":[{"name":"gc","running":true}]}'))
@@ -534,7 +535,7 @@ class DiscordIntakeCommonTests(unittest.TestCase):
         sessions.__enter__ = mock.Mock(return_value=mock.Mock(read=mock.Mock(return_value=b'{"items": []}')))
         sessions.__exit__ = mock.Mock(return_value=False)
 
-        with mock.patch.object(common.urllib.request, "urlopen", side_effect=[cities, cities, sessions]) as urlopen:
+        with mock.patch.object(common.urllib.request, "urlopen", side_effect=[cities, sessions]) as urlopen:
             payload = common.gc_api_request("GET", "/v0/sessions")
 
         self.assertEqual(payload, {"items": []})
@@ -1159,6 +1160,7 @@ class DiscordIntakeCommonTests(unittest.TestCase):
                         "session_name": "dc-sky",
                         "session_id": "gc-sky",
                         "primer_version": common.ROOM_LAUNCH_PRIMER_VERSION,
+                        "primer_identity": "gc-sky",
                         "primed_at": "2026-03-22T00:00:00Z",
                     }
                 },
@@ -1234,13 +1236,10 @@ class DiscordIntakeCommonTests(unittest.TestCase):
         record = payload["record"]
         self.assertEqual(record["source_event_kind"], "discord_human_message")
         self.assertEqual(record["root_ingress_receipt_id"], "in-9")
-        self.assertEqual(record["peer_delivery"]["status"], "delivered")
-        self.assertEqual(record["peer_delivery"]["delivery"], "targeted")
-        self.assertEqual(record["peer_delivery"]["mentioned_session_names"], ["corp--priya"])
-        self.assertEqual(record["peer_delivery"]["frozen_targets"], ["corp--priya"])
-        deliver_session_message.assert_called_once()
-        self.assertIn("publish_conversation_id: 22", deliver_session_message.call_args.args[1])
-        self.assertIn("kind: discord_peer_publication", deliver_session_message.call_args.args[1])
+        self.assertEqual(record["source_session_name"], "corp--sky")
+        self.assertEqual(record["source_session_id"], "gc-sky")
+        self.assertNotIn("peer_delivery", record)
+        deliver_session_message.assert_not_called()
 
     def test_publish_binding_message_room_launch_peer_fanout_delivers_other_thread_participants(self) -> None:
         common.set_room_launcher(common.load_config(), "1", "22")
@@ -1308,17 +1307,13 @@ class DiscordIntakeCommonTests(unittest.TestCase):
         record = payload["record"]
         self.assertEqual(record["source_session_name"], "s-gc-priya")
         self.assertEqual(record["source_qualified_handle"], "corp/priya")
-        self.assertEqual(record["peer_delivery"]["status"], "delivered")
-        self.assertEqual(record["peer_delivery"]["delivery"], "untargeted")
-        self.assertEqual(record["peer_delivery"]["frozen_targets"], ["s-gc-sky"])
-        deliver_session_message.assert_called_once()
-        self.assertEqual(deliver_session_message.call_args.args[0], "s-gc-sky")
-        envelope = deliver_session_message.call_args.args[1]
-        self.assertIn("kind: discord_peer_publication", envelope)
-        self.assertIn("publish_binding_id: launch-room:22", envelope)
-        self.assertIn("publish_launch_id: room-launch:thread-44", envelope)
-        self.assertIn("source_qualified_handle: corp/priya", envelope)
-        self.assertIn("launch_qualified_handle: corp/sky", envelope)
+        self.assertEqual(record["launch_id"], "room-launch:thread-44")
+        self.assertEqual(record["conversation_id"], "thread-44")
+        self.assertNotIn("peer_delivery", record)
+        deliver_session_message.assert_not_called()
+        updated_launch = common.load_room_launch("room-launch:thread-44")
+        assert updated_launch is not None
+        self.assertEqual(updated_launch["message_targets"]["msg-44"], "corp/priya")
 
     def test_publish_binding_message_room_launch_peer_fanout_targets_explicit_handle(self) -> None:
         common.set_room_launcher(common.load_config(), "1", "22")
@@ -1384,12 +1379,13 @@ class DiscordIntakeCommonTests(unittest.TestCase):
             )
 
         record = payload["record"]
-        self.assertEqual(record["peer_delivery"]["status"], "delivered")
-        self.assertEqual(record["peer_delivery"]["delivery"], "targeted")
-        self.assertEqual(record["peer_delivery"]["mentioned_session_names"], ["s-gc-priya"])
-        self.assertEqual(record["peer_delivery"]["frozen_targets"], ["s-gc-priya"])
-        deliver_session_message.assert_called_once()
-        self.assertEqual(deliver_session_message.call_args.args[0], "s-gc-priya")
+        self.assertEqual(record["launch_id"], "room-launch:thread-55")
+        self.assertEqual(record["source_qualified_handle"], "corp/sky")
+        self.assertNotIn("peer_delivery", record)
+        deliver_session_message.assert_not_called()
+        updated_launch = common.load_room_launch("room-launch:thread-55")
+        assert updated_launch is not None
+        self.assertEqual(updated_launch["message_targets"]["msg-55"], "corp/sky")
 
     def test_publish_binding_message_room_launch_peer_fanout_matches_source_by_session_id_when_name_missing(self) -> None:
         common.set_room_launcher(common.load_config(), "1", "22")
@@ -1455,14 +1451,14 @@ class DiscordIntakeCommonTests(unittest.TestCase):
             )
 
         record = payload["record"]
-        self.assertEqual(record["peer_delivery"]["status"], "delivered")
         self.assertEqual(record["source_qualified_handle"], "corp/sky")
         self.assertEqual(record["source_session_id"], "gc-sky")
-        deliver_session_message.assert_called_once()
-        self.assertEqual(deliver_session_message.call_args.args[0], "s-gc-priya")
-        envelope = deliver_session_message.call_args.args[1]
-        self.assertIn("source_qualified_handle: corp/sky", envelope)
-        self.assertIn("launch_qualified_handle: corp/priya", envelope)
+        self.assertEqual(record["launch_id"], "room-launch:thread-66")
+        self.assertNotIn("peer_delivery", record)
+        deliver_session_message.assert_not_called()
+        updated_launch = common.load_room_launch("room-launch:thread-66")
+        assert updated_launch is not None
+        self.assertEqual(updated_launch["message_targets"]["msg-66"], "corp/sky")
 
     def test_publish_binding_message_room_launch_peer_fanout_targets_handle_when_target_name_missing(self) -> None:
         common.set_room_launcher(common.load_config(), "1", "22")
@@ -1528,14 +1524,13 @@ class DiscordIntakeCommonTests(unittest.TestCase):
             )
 
         record = payload["record"]
-        self.assertEqual(record["peer_delivery"]["status"], "delivered")
-        self.assertEqual(record["peer_delivery"]["delivery"], "targeted")
-        self.assertEqual(record["peer_delivery"]["frozen_targets"], ["gc-priya"])
-        deliver_session_message.assert_called_once()
-        self.assertEqual(deliver_session_message.call_args.args[0], "gc-priya")
-        envelope = deliver_session_message.call_args.args[1]
-        self.assertIn("launch_qualified_handle: corp/priya", envelope)
-        self.assertIn("launch_session_alias: dc-thread-corp-priya", envelope)
+        self.assertEqual(record["source_qualified_handle"], "corp/sky")
+        self.assertEqual(record["launch_id"], "room-launch:thread-67")
+        self.assertNotIn("peer_delivery", record)
+        deliver_session_message.assert_not_called()
+        updated_launch = common.load_room_launch("room-launch:thread-67")
+        assert updated_launch is not None
+        self.assertEqual(updated_launch["message_targets"]["msg-67"], "corp/sky")
 
     def test_publish_binding_message_resolves_source_name_from_id_only_env(self) -> None:
         common.set_chat_binding(
@@ -1596,7 +1591,7 @@ class DiscordIntakeCommonTests(unittest.TestCase):
         ) as deliver_session_message:
             payload = common.publish_binding_message(binding, "@corp--priya hello", trigger_id="orig-9")
 
-        self.assertEqual(payload["record"]["peer_delivery"]["status"], "skipped_missing_root_context")
+        self.assertNotIn("peer_delivery", payload["record"])
         deliver_session_message.assert_not_called()
 
     def test_resolve_session_identity_prefers_routable_named_session(self) -> None:
@@ -1628,7 +1623,7 @@ class DiscordIntakeCommonTests(unittest.TestCase):
                 "root_ingress_receipt_id": "in-1",
                 "source_session_name": "corp--sky",
                 "source_event_kind": "discord_peer_publication",
-                "created_at": "2026-03-21T00:00:00Z",
+                "created_at": "2026-04-20T00:00:00Z",
                 "peer_delivery": {"frozen_targets": ["corp--priya", "corp--eve"]},
             }
         )
@@ -1639,7 +1634,7 @@ class DiscordIntakeCommonTests(unittest.TestCase):
                 "root_ingress_receipt_id": "in-1",
                 "source_session_name": "corp--sky",
                 "source_event_kind": "discord_peer_publication",
-                "created_at": "2026-03-21T00:01:00Z",
+                "created_at": "2026-04-20T00:01:00Z",
                 "peer_delivery": {"frozen_targets": ["corp--lawrence"]},
             }
         )


### PR DESCRIPTION
## Summary
- treat bound room `session_names` as authoritative selectors instead of filtering through the live session index
- deliver bound-room ambient messages via `/v0/session/{selector}/submit` with `intent=follow_up`
- keep room receipts aligned with the new selector-first behavior and add regression coverage for the submit path

## Testing
- `python3 -m py_compile scripts/discord_gateway_service.py scripts/discord_intake_common.py tests/test_discord_gateway_service.py tests/test_discord_intake_common.py`
- `python3 -m unittest tests.test_discord_gateway_service tests.test_discord_intake_common.DiscordIntakeCommonTests.test_deliver_session_message_uses_messages_endpoint_for_default_intent tests.test_discord_intake_common.DiscordIntakeCommonTests.test_deliver_session_message_uses_submit_endpoint_for_follow_up_intent`

## Context
This is the pack-side half of the Discord delivery fix: busy bound sessions should accept the room message immediately and consume it at the next safe boundary instead of timing out on the old `/messages` path.