### PR TITLE
docs: add missing READMEs across packs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,51 @@
+# gascity-packs
+
+A collection of opt-in [Gas City](https://github.com/gastownhall/gascity) packs.
+
+## What's a pack?
+
+Gas City is an orchestration-builder SDK for multi-agent coding workflows. A
+*pack* is a unit of workspace configuration: agents, commands, services,
+formulas, skills, hooks, template fragments, or any combination. Packs compose
+through `pack.toml` imports, so a city can opt into any subset of the packs in
+this repo without forking.
+
+For the full model (cities, rigs, formulas, beads, runtime providers) see the
+[Gas City README](https://github.com/gastownhall/gascity).
+
+## Using a pack
+
+Packs live next to the consuming workspace. A typical layout:
+
+```text
+your-city/
+  pack.toml
+packs/
+  pr-review/          # pack from this repo
+  discord/
+  ...
+```
+
+Inside your workspace `pack.toml`:
+
+```toml
+[imports.pr-review]
+source = "../packs/pr-review"
+```
+
+Each pack documents its own prerequisites, import snippet, and usage.
+
+## Layout
+
+Each top-level directory is either a pack or a group of related packs:
+
+- A directory containing `pack.toml` is itself a pack; import it by path.
+- A directory without `pack.toml` groups related subpacks and typically ships
+  an `all/` rollup that imports the group as one.
+
+Browse the tree for the current set; each pack has its own README.
+
+## Contributing
+
+Issues and pull requests are welcome. When a pack's surface changes, update
+its README in the same PR so the docs stay current with the code.

--- a/flywheel/README.md
+++ b/flywheel/README.md
@@ -1,0 +1,24 @@
+# Flywheel
+
+Agent-enhancement stack inspired by [Agent Flywheel](https://agent-flywheel.com/).
+
+This directory is not a pack itself; it groups related subpacks. Each subpack
+adds one capability (messaging, search, memory, scanning) to agents in a city.
+
+## Subpacks
+
+- `all/` — rollup that imports the full stack
+- `mcp-agent-mail/` — inter-agent messaging
+- `cass/` — past-session search
+- `cm/` — persistent memory / playbook
+- `ubs/` — pre-commit bug scanning
+
+Import the whole stack:
+
+```toml
+[imports.flywheel]
+source = "../packs/flywheel/all"
+```
+
+Or cherry-pick individual subpacks; see each subpack's README for
+prerequisites and configuration.

--- a/jeffrey/README.md
+++ b/jeffrey/README.md
@@ -1,0 +1,27 @@
+# Jeffrey
+
+Gas City adaptations of [Jeffrey Emanuel](https://github.com/Dicklesworthstone)
+(@doodlestein)'s prompt library, packaged as Claude skill overlays.
+
+This directory is not a pack itself; it groups related subpacks. Each subpack
+contributes one skill that agents can invoke with `/<skill-name>` in Claude.
+
+## Subpacks
+
+- `all/` — rollup that imports every skill below
+- `planning-workflow/` — multi-phase plan-before-code workflow
+- `code-review/` — four-pass review (correctness, security, performance, maintainability)
+- `idea-wizard/` — diverge / evaluate / converge brainstorming
+- `ui-polish/` — iterative refinement loop for UI components
+- `robot-mode/` — design an agent-friendly CLI (JSON, exit codes, structured errors)
+- `readme-revise/` — evaluate and polish documentation
+- `de-slopify/` — strip AI-telltale writing patterns
+
+Import the full set:
+
+```toml
+[imports.jeffrey]
+source = "../packs/jeffrey/all"
+```
+
+Or import one at a time; each subpack has its own README.

--- a/jeffrey/all/README.md
+++ b/jeffrey/all/README.md
@@ -1,0 +1,29 @@
+# Jeffrey All Pack
+
+Roll-up pack that imports every [Jeffrey](../README.md) subpack as one.
+
+## What's Included
+
+- `planning-workflow` — plan before code
+- `code-review` — four-pass code review
+- `idea-wizard` — structured brainstorming
+- `ui-polish` — iterative UI refinement
+- `robot-mode` — agent-friendly CLI design
+- `readme-revise` — documentation evaluation and polish
+- `de-slopify` — strip AI writing tells
+
+## Usage
+
+Full stack:
+
+```toml
+[imports.jeffrey]
+source = "../packs/jeffrey/all"
+```
+
+Or cherry-pick the individual subpacks from their own directories.
+
+## Attribution
+
+Adapted from [Jeffrey Emanuel](https://github.com/Dicklesworthstone)
+(@doodlestein)'s prompt library.

--- a/jeffrey/code-review/README.md
+++ b/jeffrey/code-review/README.md
@@ -1,0 +1,31 @@
+# Jeffrey Code Review Pack
+
+Four-pass code review as a Claude skill.
+
+## What It Provides
+
+- Skill overlay at `overlay/.claude/skills/code-review/SKILL.md`
+- Invocable as `/code-review` in Claude
+
+The skill runs four sequential passes over a diff, file, or recent changes:
+
+1. **Correctness** — logic, error handling, races, edge cases
+2. **Security** — OWASP Top 10 patterns at system boundaries
+3. **Performance** — complexity, N+1, unbounded growth, blocking I/O
+4. **Maintainability** — naming, abstractions, dead code, coverage gaps
+
+Findings carry a severity (`CRITICAL`, `HIGH`, `MEDIUM`, `LOW`, `NIT`), a
+location, and a suggested fix. The skill closes with a verdict: `APPROVE`,
+`REQUEST CHANGES`, or `COMMENT`.
+
+## Import It
+
+```toml
+[imports.code-review]
+source = "../packs/jeffrey/code-review"
+```
+
+## Attribution
+
+Adapted from [Jeffrey Emanuel](https://github.com/Dicklesworthstone)
+(@doodlestein)'s Peer Code Reviewer.

--- a/jeffrey/de-slopify/README.md
+++ b/jeffrey/de-slopify/README.md
@@ -1,0 +1,32 @@
+# Jeffrey De-Slopify Pack
+
+Remove AI-telltale writing patterns from text, via a Claude skill.
+
+## What It Provides
+
+- Skill overlay at `overlay/.claude/skills/de-slopify/SKILL.md`
+- Invocable as `/de-slopify` in Claude
+
+The skill reads text line by line and strips the usual tells:
+
+- Em dashes (replaced with semicolons, commas, or recast sentences)
+- "It's not X, it's Y" constructions, "Here's why", "Let's dive in"
+- Filler openers ("Certainly!", "Great question!", "Absolutely!")
+- Hedging ("I think maybe", "It's worth noting that")
+- Excessive bullets where prose works better
+- Gratuitous emoji and self-referential AI meta-commentary
+- Redundant transitions ("Furthermore", "Moreover") used as paragraph openers
+
+This is intentionally a manual read-and-revise pass, not a regex substitution.
+
+## Import It
+
+```toml
+[imports.de-slopify]
+source = "../packs/jeffrey/de-slopify"
+```
+
+## Attribution
+
+Adapted from [Jeffrey Emanuel](https://github.com/Dicklesworthstone)
+(@doodlestein)'s De-Slopifier.

--- a/jeffrey/idea-wizard/README.md
+++ b/jeffrey/idea-wizard/README.md
@@ -1,0 +1,29 @@
+# Jeffrey Idea Wizard Pack
+
+Structured brainstorming as a Claude skill.
+
+## What It Provides
+
+- Skill overlay at `overlay/.claude/skills/idea-wizard/SKILL.md`
+- Invocable as `/idea-wizard` in Claude
+
+The skill runs four phases:
+
+1. **Diverge** — generate 30 one-liner ideas using analogies, inversions,
+   cross-domain combinations, and constraint relaxation.
+2. **Evaluate** — reject the weak ones with explicit reasons.
+3. **Converge** — for survivors, detail the *what*, *why*, downsides, and
+   a confidence score; rank by (impact × confidence) / effort.
+4. **Implement** — start on the top-ranked idea.
+
+## Import It
+
+```toml
+[imports.idea-wizard]
+source = "../packs/jeffrey/idea-wizard"
+```
+
+## Attribution
+
+Adapted from [Jeffrey Emanuel](https://github.com/Dicklesworthstone)
+(@doodlestein)'s Idea Wizard.

--- a/jeffrey/planning-workflow/README.md
+++ b/jeffrey/planning-workflow/README.md
@@ -1,0 +1,24 @@
+# Jeffrey Planning Workflow Pack
+
+Multi-phase plan-before-code workflow as a Claude skill.
+
+## What It Provides
+
+- Skill overlay at `overlay/.claude/skills/planning-workflow/SKILL.md`
+- Invocable as `/planning-workflow` in Claude
+
+The skill drives five phases in order — understand, decompose, design,
+validate, implement — with the rule that no code is written before validation
+is complete.
+
+## Import It
+
+```toml
+[imports.planning-workflow]
+source = "../packs/jeffrey/planning-workflow"
+```
+
+## Attribution
+
+Adapted from [Jeffrey Emanuel](https://github.com/Dicklesworthstone)
+(@doodlestein)'s planning workflow.

--- a/jeffrey/readme-revise/README.md
+++ b/jeffrey/readme-revise/README.md
@@ -1,0 +1,28 @@
+# Jeffrey README Revise Pack
+
+Evaluate and polish project documentation, via a Claude skill.
+
+## What It Provides
+
+- Skill overlay at `overlay/.claude/skills/readme-revise/SKILL.md`
+- Invocable as `/readme-revise` in Claude
+
+The skill walks a checklist (one-sentence purpose, install instructions,
+runnable examples, architecture overview, contributing, API reference,
+changelog), updates content to match the current state of the project, and
+then applies de-slopify rules for tone and concision. It iterates: find the
+single biggest remaining improvement, apply it, repeat.
+
+Framing rule: describe the project as it is, not "we added X" or "X is now Y."
+
+## Import It
+
+```toml
+[imports.readme-revise]
+source = "../packs/jeffrey/readme-revise"
+```
+
+## Attribution
+
+Adapted from [Jeffrey Emanuel](https://github.com/Dicklesworthstone)
+(@doodlestein)'s README Reviser.

--- a/jeffrey/robot-mode/README.md
+++ b/jeffrey/robot-mode/README.md
@@ -1,0 +1,31 @@
+# Jeffrey Robot Mode Pack
+
+Design an agent-friendly CLI for a project, via a Claude skill.
+
+## What It Provides
+
+- Skill overlay at `overlay/.claude/skills/robot-mode/SKILL.md`
+- Invocable as `/robot-mode` in Claude
+
+The skill guides a CLI redesign focused on machine consumers:
+
+- `--json` on every command with stable key ordering
+- TTY detection that flips to JSON automatically when stdout is piped
+- Meaningful exit codes (`0` success, `1` not found, `2` invalid args,
+  `3` permission denied, `4` conflict)
+- Structured error bodies with code, message, and 1–2 corrected-example
+  suggestions
+- Dense, token-efficient output; help summaries under ~100 tokens
+- Error tolerance that honors legible intent and teaches correct syntax
+
+## Import It
+
+```toml
+[imports.robot-mode]
+source = "../packs/jeffrey/robot-mode"
+```
+
+## Attribution
+
+Adapted from [Jeffrey Emanuel](https://github.com/Dicklesworthstone)
+(@doodlestein)'s Robot-Mode Maker and CLI Error Tolerance prompts.

--- a/jeffrey/ui-polish/README.md
+++ b/jeffrey/ui-polish/README.md
@@ -1,0 +1,25 @@
+# Jeffrey UI Polish Pack
+
+Iterative UI/UX refinement loop as a Claude skill.
+
+## What It Provides
+
+- Skill overlay at `overlay/.claude/skills/ui-polish/SKILL.md`
+- Invocable as `/ui-polish` in Claude
+
+The skill runs a repeated evaluate-identify-apply-review loop (at least ten
+iterations or until diminishing returns) across spacing, typography, color,
+alignment, micro-interactions, loading states, empty states, and error states.
+Target quality bar is Stripe / Linear / Vercel dashboard polish.
+
+## Import It
+
+```toml
+[imports.ui-polish]
+source = "../packs/jeffrey/ui-polish"
+```
+
+## Attribution
+
+Adapted from [Jeffrey Emanuel](https://github.com/Dicklesworthstone)
+(@doodlestein)'s Stripe-Level UI prompt.

--- a/tmux-theme/README.md
+++ b/tmux-theme/README.md
@@ -1,0 +1,56 @@
+# tmux Theme Pack
+
+tmux status-bar theming and navigation keybindings for Gas City agent sessions.
+
+This pack installs a `session_live` hook that runs on every agent session
+start. The hook applies a colored status bar, live hook/mail indicators, and
+a small set of navigation keybindings scoped to GC sessions on the socket.
+
+## What It Provides
+
+- **Status bar theme** — per-agent background/foreground colors from a
+  10-color palette, chosen by consistent hash of the agent name so the same
+  agent always gets the same color. Matches the Go `DefaultPalette` in
+  `internal/session/tmux/theme.go`.
+- **Live status-right** — refreshes every 5 seconds via `gc hook` and
+  `gc mail check`; shows pending hooks and unread mail counts per agent.
+- **Prefix keybindings** — `n` / `p` cycle through related agent sessions
+  (rig ops, rig crew, town group, dog pool), `g` opens a popup menu of all
+  agent sessions on the socket.
+- **Mail click binding** — left-click the status-right region to pop up
+  `gc mail peek` for the current session. Preserves any pre-existing root
+  `MouseDown1StatusRight` binding as the non-GC fallback.
+- **Mouse and clipboard** — turned on for every agent session.
+
+All tmux commands are socket-aware; `GC_TMUX_SOCKET`, when set, is forwarded
+through a `gcmux` wrapper so per-city socket isolation keeps working.
+
+## Import It
+
+```toml
+[imports.tmux-theme]
+source = "../packs/tmux-theme"
+```
+
+No prerequisites beyond `tmux` itself, which Gas City already requires.
+
+## Keybindings
+
+All bindings live on the tmux prefix table and fire only inside GC sessions
+(guarded by the `GC_AGENT` environment variable); non-GC sessions keep their
+original bindings.
+
+| Binding | Action |
+|---------|--------|
+| `prefix n` | Next session in the current agent group |
+| `prefix p` | Previous session in the current agent group |
+| `prefix g` | Popup menu of all agent sessions on this socket |
+| Click status-right | Popup preview of unread mail for the current session |
+
+Grouping rules for `n`/`p`:
+
+- Rig ops: `{rig}--witness` ↔ `{rig}--refinery` ↔ `{rig}--polecat-*`
+- Rig crew: other `{rig}--{name}` members in the same rig
+- Town group: `mayor` ↔ `deacon`
+- Dog pool: `dog-1` ↔ `dog-2` ↔ `dog-3`
+- Fallback: all sessions on the socket


### PR DESCRIPTION
I arrived from https://sellsbrothers.com/orchestration-is-all-you-need and looked for readmes.

## Summary
- Adds a repo-level `README.md` that frames the repo as a collection of opt-in Gas City packs and points at [gastownhall/gascity](https://github.com/gastownhall/gascity) for the underlying model, rather than enumerating subdirs that would rot.
- Adds group-level READMEs for `flywheel/` and `jeffrey/` (neither has a `pack.toml`, so they needed a landing page).
- Adds a README for the `jeffrey/all` rollup and for each of the seven `jeffrey/*` skill subpacks (`planning-workflow`, `code-review`, `idea-wizard`, `ui-polish`, `robot-mode`, `readme-revise`, `de-slopify`), sourced from the wrapped `SKILL.md` content.
- Adds a README for `tmux-theme/`, documenting the session-live hooks, status bar theme, keybindings, and mouse bindings.
- Import snippets follow the existing `source = "../packs/<pack>"` convention used by the other pack READMEs.