### PR TITLE
Add bluewater pointer (independent pack at boylec/bluewater)

### DIFF
--- a/bluewater/README.md
+++ b/bluewater/README.md
@@ -1,0 +1,49 @@
+# Bluewater
+
+**Independent pack repository:** [github.com/boylec/bluewater](https://github.com/boylec/bluewater)
+
+Bluewater is a naval-doctrine multi-agent orchestration pack —
+opinionated alternative to gastown with CO/XO/OOD command continuity,
+formal watch turnover, pre-composed casualty response, and
+cross-provider two-key launches.
+
+It lives in its own repository (it's large enough to deserve one — 175
+files, ~8200 lines including six required departments inline plus three
+optional sub-packs for flight-deck choreography, Discord, and Slack
+intake). This entry exists in `gascity-packs` as a discovery pointer,
+not as a vendored copy.
+
+## Install
+
+```bash
+gc pack add github.com/boylec/bluewater
+```
+
+## Optional sub-packs
+
+```bash
+gc pack add github.com/boylec/bluewater/packs/bluewater-air      # carrier-class production deploys
+gc pack add github.com/boylec/bluewater/packs/bluewater-discord  # Discord intake
+gc pack add github.com/boylec/bluewater/packs/bluewater-slack    # Slack intake
+```
+
+## Documentation
+
+All docs live in the bluewater repo:
+
+- [`README.md`](https://github.com/boylec/bluewater/blob/main/README.md) — overview + department table
+- [`docs/install.mdx`](https://github.com/boylec/bluewater/blob/main/docs/install.mdx) — install walkthrough + provider/model tier table
+- [`docs/quickstart.mdx`](https://github.com/boylec/bluewater/blob/main/docs/quickstart.mdx) — six steps to a running smoke-test convoy
+- [`docs/use_cases.mdx`](https://github.com/boylec/bluewater/blob/main/docs/use_cases.mdx) — what to do when, with verification
+- [`docs/first_watch.mdx`](https://github.com/boylec/bluewater/blob/main/docs/first_watch.mdx) — narrative walkthrough of one OOD watch
+- [`doctrine/`](https://github.com/boylec/bluewater/tree/main/doctrine) — DOCTRINE, BATTLE_BILL, WATCH_BILL, BREVITY, RATING_PROGRESSION, GLOSSARY
+
+## Status
+
+`v0.1.0` tagged 2026-04-27. See
+[`CHANGELOG.md`](https://github.com/boylec/bluewater/blob/main/CHANGELOG.md)
+for the full inventory and known unfinished items.
+
+## License
+
+MIT.


### PR DESCRIPTION
## Summary

Adds a discovery pointer for **Bluewater** — a naval-doctrine multi-agent orchestration pack at [github.com/boylec/bluewater](https://github.com/boylec/bluewater). Tagged \`v0.1.0\` 2026-04-27.

Bluewater is an opinionated alternative to gastown with:
- CO / XO / OOD command continuity
- Formal watch turnover with handoff quality scoring
- Pre-composed casualty response (general_quarters, man_overboard, fire_in_compartment, flooding, collision_at_sea, grounding, radiation_leak)
- Cross-provider two-key launches for risky operations
- 24 named evolutions, 47 ratings (real-navy aligned), six required departments inline + three optional sub-packs

## Why a pointer instead of vendoring

Bluewater is 175 files / ~8200 lines and lives in its own repository so it can iterate independently. The other packs in \`gascity-packs\` are smaller and were vendored directly.

Happy to reshape this however you'd like:
- Vendor the entire pack here (would inflate the repo significantly)
- Drop this entry entirely; rely on \`gc pack add github.com/boylec/bluewater\` discovery via search/social
- Link from a top-level index file if one exists / is desired
- Any other shape that fits the project's conventions

This PR is the lowest-friction way to open the conversation.

## What's in the bluewater repo

- Umbrella \`bluewater\` with six inlined departments (Engineering, Operations, Combat Systems, Supply, Medical, Admin) plus the wardroom (CO, XO, OOD, COB, CSOOW)
- Optional sub-packs: \`bluewater-air\` (flight-deck deploys), \`bluewater-discord\`, \`bluewater-slack\`
- Doctrine layer (DOCTRINE.md, BATTLE_BILL.md, WATCH_BILL.md, BREVITY.md, RATING_PROGRESSION.md, GLOSSARY.md) with template-fragment plumbing
- Built against Gas City \`>= 1.0.0\` (Pack V2 only; no V1 layouts shipped)

## Test plan

- [x] Fork created at boylec/gascity-packs
- [x] Branch \`add-bluewater-pointer\` pushed
- [x] README links to bluewater repo verified live (boylec/bluewater is public, v0.1.0 tagged and pushed)
- [ ] Maintainers review the shape decision (vendor vs pointer vs alternative)