### PR TITLE
fix(slack-pack): bound find_latest_inbound_for_session events query with since=2h

### DIFF
--- a/slack-pack/scripts/slack_intake_common.py
+++ b/slack-pack/scripts/slack_intake_common.py
@@ -305,8 +305,17 @@ def find_latest_inbound_for_session(session_id: str) -> dict[str, Any] | None:
 
     Queries the gc events stream (HTTP, not SSE — single shot snapshot).
     Returns the parsed event dict, or None if no match found.
+
+    Uses `since=2h` to bound the query window: the endpoint returns
+    events oldest-first by default, so on busy cities (event log >700k
+    seqs) `limit=50` would return only ancient history and a recent
+    extmsg.inbound at the tail would never appear in the response.
+    The time bound is the primary filter; limit=500 is a defensive cap.
+    Without this, `gc slack reply-current --thread-current` bails with
+    'no inbound event...' and the agent falls back to a non-threaded
+    publish-to-channel.
     """
-    url = f"{gc_api_base()}/v0/city/{gc_city_name()}/events?type=extmsg.inbound&limit=50"
+    url = f"{gc_api_base()}/v0/city/{gc_city_name()}/events?type=extmsg.inbound&since=2h&limit=500"
     raw = _request("GET", url, csrf=False).get("items", [])
     matches = [e for e in raw if (e.get("payload") or {}).get("target_session") == session_id]
     if not matches:


### PR DESCRIPTION
## Problem

`gc slack reply-current --thread-current` bails on busy cities and the agent falls back to a non-threaded `gc slack publish-to-channel`. Symptom from the operator side: PL agents reply at channel level instead of in-thread, and the eyes :react: never fires (because the protocol's react step uses the same lookup).

## Root cause

`find_latest_inbound_for_session()` in `slack-pack/scripts/slack_intake_common.py` queries the gc events stream with `limit=50` and no time bound:

```python
url = f"{gc_api_base()}/v0/city/{gc_city_name()}/events?type=extmsg.inbound&limit=50"
```

The events API returns oldest-first by default. On an active city's event log of >700k seqs, the oldest 50 are all historical — a recent `extmsg.inbound` at e.g. seq 740676 never appears in the response. `find_latest_inbound_for_session` returns `None` even when the inbound it's looking for very much exists.

That breaks the PL agent's reply protocol per its bind-time-injected prompt:

1. React with eyes — uses `find_latest_inbound_message_id_for_session` (same lookup chain) → fails
2. `gc slack reply-current --thread-current` — same lookup → bails with `'no inbound event and no binding found for this session; pass --conversation-id explicitly'`
3. Agent falls back to `gc slack publish-to-channel` → reply lands as a top-level channel post, eyes emoji ends up embedded in the message body instead of as a react

## Fix

Add `since=2h` to the query so the request returns events from the last 2 hours instead of the oldest 50 ever recorded. Bump `limit` to 500 as a defensive cap; the time bound is the primary filter.

```python
url = f"{gc_api_base()}/v0/city/{gc_city_name()}/events?type=extmsg.inbound&since=2h&limit=500"
```

## Verification

End-to-end on `ds-research` city 2026-05-09 with two PL agents (gascity-maintenance, zeldascension):

- **Pre-fix**: `reply-current --thread-current` returned `'no inbound event...'`; PL fell back to channel-level publish; `:eyes:` ended up in body; user-visible reply landed as top-level channel post.
- **Post-fix**: lookup returns the recent inbound; `reply-current --thread-current` succeeds; reply threads under the original message; eyes react fires properly.

## History

This fix originally landed in `gastownhall/gascity` on the local feature branch `feat/slack-pack-px8-import` (commit 3fa31d51). That branch never made it upstream, and PR #8 (slack-pack import) brought a pre-fix snapshot into this repo. Re-applying here.