### PR TITLE
feat(pr-pipeline): add mol-pr-triage formula + .gitignore allowlist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,9 @@
 .dolt/
 *.db
 .beads-credential-key
-.beads/
 .gc/
+
+# Gas City
+.beads/*
+!.beads/config.yaml
+!.beads/metadata.json

--- a/pr-pipeline/formulas/mol-pr-triage.formula.toml
+++ b/pr-pipeline/formulas/mol-pr-triage.formula.toml
@@ -1,0 +1,341 @@
+description = """
+PR triage workflow — scan open issues on the upstream repo, classify by
+contributor-actionability, cross-reference with open PRs, and produce a
+ranked work-queue report.
+
+Mirrors the contributor-shape output of the local `/gascity-triage` skill,
+but runs inside a polecat session so the maintenance PL can dispatch it
+on demand. The deliverable is a markdown report at
+`.gc/pr-pipeline/triage/<timestamp>.md` with Tier 1-4 classifications,
+competing-PR detection, maintainer-decision-gate fires, and a recommended
+next pick. **No code is written. No labels/comments are applied.** The
+human caller reviews the report and decides which issue to dispatch via
+`mol-pr-start`, which incoming PR to review via `mol-adopt-pr`, etc.
+
+The molecule root bead IS the control bead — run state is recorded in its
+notes via `bd update <root-id> --notes "<key>: <value>"`.
+
+## Contract
+
+1. Caller slings with optional `--var limit=<N>` (default 10) and
+   `--var category=<filter>` (default "all"; accepts "p0", "p1", "p2",
+   "good-first-issue", "all", or any single kind/priority label name)
+2. Agent works through 5 sequential steps
+3. Triage report written to `.gc/pr-pipeline/triage/<timestamp>.md`
+4. Root-bead notes record `triage_path:` + tier counts + recommended pick
+5. Agent exits — no implementation, labeling, or PR creation happens here
+
+## Failure Modes
+
+| Situation | Action |
+|-----------|--------|
+| Repo is not a git checkout | Record cwd, close bead |
+| Repo has no remote / not gascity | Record error, close bead |
+| `gh` not authenticated | Record error, close bead |
+| No open issues match category | Write empty-queue report, close bead with note |"""
+formula = "mol-pr-triage"
+version = 1
+
+[vars]
+[vars.limit]
+description = "Maximum number of candidate issues to evaluate (default 10)"
+required = false
+
+[vars.category]
+description = "Issue category filter — 'p0', 'p1', 'p2', 'good-first-issue', 'all', or any kind/priority label name (default 'all')"
+required = false
+
+[[steps]]
+id = "setup"
+title = "Establish working state and verify repo"
+description = """
+**1. Find the root bead and confirm we're in the upstream gascity tree:**
+```bash
+ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
+    echo "Not in a git repository — cannot triage."
+    bd close "$ROOT_ID" --reason "not a git checkout"
+    exit 1
+}
+cd "$REPO_ROOT"
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+
+if [ "$REPO" != "gastownhall/gascity" ]; then
+    echo "Triage formula is gastownhall/gascity-specific. Got: $REPO"
+    bd update "$ROOT_ID" --notes "status: blocked
+gate: wrong_repo
+detail: $REPO"
+    bd close "$ROOT_ID" --reason "wrong repo for triage"
+    exit 0
+fi
+```
+
+**2. Verify gh auth:**
+```bash
+gh auth status >/dev/null 2>&1 || {
+    bd update "$ROOT_ID" --notes "status: blocked
+gate: gh_not_authed"
+    bd close "$ROOT_ID" --reason "gh not authenticated"
+    exit 1
+}
+```
+
+**3. Resolve vars and record initial state:**
+```bash
+LIMIT="{{limit}}"
+[ -z "$LIMIT" ] && LIMIT=10
+CATEGORY="{{category}}"
+[ -z "$CATEGORY" ] && CATEGORY="all"
+TS=$(date +%Y%m%d-%H%M%S)
+TRIAGE_DIR=".gc/pr-pipeline/triage"
+mkdir -p "$TRIAGE_DIR"
+TRIAGE_PATH="$TRIAGE_DIR/$TS.md"
+
+bd update "$ROOT_ID" --notes "category: $CATEGORY
+limit: $LIMIT
+repo: $REPO
+triage_path: $TRIAGE_PATH
+status: in_progress"
+```
+
+**Exit criteria:** In gastownhall/gascity repo root, gh auth ok, vars + paths recorded.
+"""
+
+[[steps]]
+id = "fetch"
+title = "Pull open issues, our PRs, and all open PRs"
+needs = ["setup"]
+description = """
+Three lists feed the classification:
+
+```bash
+ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+TS=$(grep -A1 'triage_path:' <(bd show "$ROOT_ID") | head -1 | sed 's|.*triage/||;s|\\.md$||')
+LIMIT=$(bd show "$ROOT_ID" --json | jq -r '.notes // "" | capture("limit: (?<v>\\\\d+)").v // "10"')
+CATEGORY=$(bd show "$ROOT_ID" --json | jq -r '.notes // "" | capture("category: (?<v>\\\\S+)").v // "all"')
+```
+
+**1. Open issues (filtered by category):**
+```bash
+SEARCH="state:open repo:gastownhall/gascity"
+case "$CATEGORY" in
+    p0|p1|p2)        SEARCH="$SEARCH label:priority/$CATEGORY" ;;
+    good-first-issue) SEARCH="$SEARCH label:good-first-issue" ;;
+    all)             ;;
+    *)               SEARCH="$SEARCH label:$CATEGORY" ;;
+esac
+gh search issues "$SEARCH" --limit 200 \\
+    --json number,title,labels,assignees,createdAt,updatedAt,body \\
+    > /tmp/triage-issues.json
+```
+
+**2. Our open PRs (sjarmak-authored) — extract issue refs from titles + bodies:**
+```bash
+gh pr list --repo gastownhall/gascity --author sjarmak --state open \\
+    --json number,title,body \\
+    > /tmp/triage-our-prs.json
+```
+
+**3. All open PRs — for competing-PR detection:**
+```bash
+gh pr list --repo gastownhall/gascity --state open \\
+    --json number,title,body,author \\
+    > /tmp/triage-all-prs.json
+```
+
+Record counts:
+```bash
+ISSUE_COUNT=$(jq 'length' /tmp/triage-issues.json)
+OUR_PR_COUNT=$(jq 'length' /tmp/triage-our-prs.json)
+ALL_PR_COUNT=$(jq 'length' /tmp/triage-all-prs.json)
+bd update "$ROOT_ID" --notes "issue_count: $ISSUE_COUNT
+our_pr_count: $OUR_PR_COUNT
+all_pr_count: $ALL_PR_COUNT"
+```
+
+**Exit criteria:** Three JSON files written to /tmp; counts recorded in bead notes.
+"""
+
+[[steps]]
+id = "classify"
+title = "Classify each issue into Tier 1-4"
+needs = ["fetch"]
+description = """
+Apply the 4-tier classification to every issue. The agent uses semantic
+judgment over the issue body, comments, labels, and PR cross-references.
+The four tiers:
+
+- **Tier 1 (GRAB NOW)** — Unassigned, clear bug, scope is bounded, no
+  competing PR, no maintainer-decision gate fires, milestone matches a
+  shippable target.
+- **Tier 2 (GOOD CANDIDATE)** — Solid fix opportunity but needs a small
+  amount of investigation (which file, which test, which sibling pattern).
+- **Tier 3 (INVESTIGATE FIRST)** — Scope unclear, OR a maintainer-decision
+  gate fires (design conflict, author uncertainty, maintainer ambivalence,
+  product question disguised as bug).
+- **Tier 4 (SKIP)** — Assigned to a non-self maintainer, OR an open PR
+  already covers it, OR labelled won't-fix / on-hold / post-release.
+
+**Competing-PR detection (CRITICAL — three methods, ANY hit demotes to Tier 4):**
+1. Search by issue number: `gh pr list --repo gastownhall/gascity --search '<num>' --state open`
+2. Search by issue title keywords: `gh pr list ... --search '<key phrases>' --state open`
+3. Issue timeline: `gh api repos/gastownhall/gascity/issues/<num>/timeline --paginate` and
+   look for `cross-referenced` events with `pull_request` source.
+
+**Maintainer-decision gates (any fire demotes to Tier 3):**
+- **DD (design-doc conflict):** grep `engdocs/design/*.md` for issue symbols; if an
+  Accepted/Implementing doc contradicts the issue's proposed direction, fire.
+- **AU (author uncertainty):** issue body ends with '?' or contains 'is this a bug or',
+  'intended behavior', 'or at least', or proposes 2+ alternatives → fire.
+- **MA (maintainer ambivalence):** a COLLABORATOR/MEMBER/OWNER comment with
+  'great feedback' / 'good point' / 'we should' but no directive and no linked PR → fire.
+- **PD (product decision):** Expected/Actual sections argue product opinions
+  ('should be light', 'feels counter-intuitive') rather than pointing at a defect → fire.
+
+For every Tier 1 and Tier 2 candidate, emit a `Gates: [DD AU MA PD]` line
+where each letter is `.` (clear) or `!` (fire). Any `!` demotes the issue
+to Tier 3 with the gate name in the demotion note.
+
+The classification produces an in-memory list (or a temp JSON file) of:
+```
+{ "number": <N>, "title": "...", "tier": 1-4, "gates": "....",
+  "rationale": "...", "competing_pr": <N or null>, "labels": [...],
+  "assignee": "..." }
+```
+
+Cap the report at LIMIT issues per tier, sorted within each tier by:
+- Tier 1: priority label > recency
+- Tier 2: priority label > recency
+- Tier 3: gate severity (DD > MA > AU > PD) > recency
+- Tier 4: covering PR # ascending
+
+Save the classified list to /tmp/triage-classified.json.
+
+**Exit criteria:** /tmp/triage-classified.json contains one entry per
+evaluated issue with tier, gates, and rationale fields populated.
+"""
+
+[[steps]]
+id = "report"
+title = "Write the structured triage report"
+needs = ["classify"]
+description = """
+Produce the markdown report at the path recorded in step 1.
+
+```bash
+ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+TRIAGE_PATH=$(bd show "$ROOT_ID" --json | jq -r '.notes // ""' | grep -m1 '^triage_path:' | sed 's/^triage_path: //')
+```
+
+Report structure:
+
+```markdown
+# Gas City triage — <ISO timestamp>
+
+## Inputs
+
+- Category filter: <category>
+- Limit per tier: <limit>
+- Open issues evaluated: <issue_count>
+- Our open PRs: <our_pr_count>
+- All open PRs: <all_pr_count>
+
+## Counts by tier
+
+- Tier 1 (GRAB NOW): <n>
+- Tier 2 (GOOD CANDIDATE): <n>
+- Tier 3 (INVESTIGATE FIRST): <n>
+- Tier 4 (SKIP): <n>
+
+## Tier 1 — GRAB NOW
+
+For each issue:
+### #<N> <title>
+- Labels: <comma-separated>
+- Gates: [DD AU MA PD]   ← all `.`
+- Rationale: <one sentence on why this is grabbable now>
+- Suggested dispatch: `mol-pr-start --var issue=<N>`
+
+(repeat per Tier 1 issue, sorted by priority then recency)
+
+## Tier 2 — GOOD CANDIDATE
+(same shape as Tier 1)
+
+## Tier 3 — INVESTIGATE FIRST
+For each issue:
+### #<N> <title>
+- Labels: <...>
+- Gates: [DD AU MA PD]   ← any `!`
+- Demotion reason: <which gate fired and why>
+- Suggested next step: read the relevant design doc / ask author / etc.
+
+## Tier 4 — SKIP
+For each issue:
+### #<N> <title>
+- Skip reason: assigned to <user> | covered by PR #<M> | label:wontfix | etc.
+
+## Recommended next pick
+
+The single best Tier 1 (or Tier 2 if no Tier 1) candidate, with:
+- Issue # and title
+- Why it's the best pick (priority, scope, no gates, no competing PR)
+- The exact dispatch command:
+  `gc-sling polecat <new-bead-id> --on mol-pr-start --var issue=<N>`
+
+If no Tier 1 OR Tier 2 candidates exist, recommend a Tier 3 to investigate
+or note that the queue is empty and triage should wait for new issues.
+```
+
+After writing the file:
+
+```bash
+TIER1=$(jq '[.[] | select(.tier==1)] | length' /tmp/triage-classified.json)
+TIER2=$(jq '[.[] | select(.tier==2)] | length' /tmp/triage-classified.json)
+TIER3=$(jq '[.[] | select(.tier==3)] | length' /tmp/triage-classified.json)
+TIER4=$(jq '[.[] | select(.tier==4)] | length' /tmp/triage-classified.json)
+RECOMMENDED=$(jq -r '[.[] | select(.tier <= 2)] | sort_by(.tier, -.priority_score) | .[0].number // "none"' /tmp/triage-classified.json)
+
+bd update "$ROOT_ID" --notes "triage_path: $TRIAGE_PATH
+tier1: $TIER1
+tier2: $TIER2
+tier3: $TIER3
+tier4: $TIER4
+recommended: $RECOMMENDED
+status: report_written"
+```
+
+**Exit criteria:** Markdown report written; bead notes record path + tier counts + recommended pick.
+"""
+
+[[steps]]
+id = "finalize"
+title = "Surface report path and exit"
+needs = ["report"]
+description = """
+Display the report path and recommended pick on stdout for the maintenance
+PL to relay back to Slack:
+
+```bash
+ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+NOTES=$(bd show "$ROOT_ID" --json | jq -r '.notes // ""')
+TRIAGE_PATH=$(echo "$NOTES" | grep -m1 '^triage_path:' | sed 's/^triage_path: //')
+TIER1=$(echo "$NOTES" | grep -m1 '^tier1:' | sed 's/^tier1: //')
+TIER2=$(echo "$NOTES" | grep -m1 '^tier2:' | sed 's/^tier2: //')
+TIER3=$(echo "$NOTES" | grep -m1 '^tier3:' | sed 's/^tier3: //')
+TIER4=$(echo "$NOTES" | grep -m1 '^tier4:' | sed 's/^tier4: //')
+RECOMMENDED=$(echo "$NOTES" | grep -m1 '^recommended:' | sed 's/^recommended: //')
+
+cat <<EOF
+[pr-triage] Triage report ready
+[pr-triage]   Path: $TRIAGE_PATH
+[pr-triage]   Counts: T1=$TIER1 T2=$TIER2 T3=$TIER3 T4=$TIER4
+[pr-triage]   Recommended next pick: #$RECOMMENDED
+[pr-triage] Next: human reviews report, picks an issue, dispatches mol-pr-start.
+EOF
+
+bd update "$ROOT_ID" --notes "status: complete"
+bd close "$ROOT_ID" --reason "triage report written: $TRIAGE_PATH"
+```
+
+**Exit criteria:** Report path printed, root bead closed with status:complete.
+"""


### PR DESCRIPTION
Two leftover improvements from local pr-pipeline work that missed the #7 cut. Tracked in dr-g52nry.

## 1. Add mol-pr-triage formula

Maintainer-dispatchable PR triage workflow. Scans open issues on the upstream repo, classifies by contributor-actionability into Tier 1-4, cross-references with open PRs, writes a ranked work-queue report at \`.gc/pr-pipeline/triage/<timestamp>.md\`.

Mirrors the contributor-shape output of the local \`/gascity-triage\` skill but runs inside a polecat session so the maintenance PL can dispatch it on demand. Pure read+report — no code is written, no labels/comments are applied. The human caller reviews the report and decides which issue to dispatch via \`mol-pr-start\`, which incoming PR to review via \`mol-adopt-pr\`, etc.

Natural sibling to \`mol-pr-{start,blast-radius,review,ship}\` from #7. Logical entry point to the pipeline ('what should I work on next?') before \`mol-pr-start\` picks up a specific issue.

## 2. Allowlist .beads/{config.yaml,metadata.json} in .gitignore

Currently \`.gitignore\` excludes all of \`.beads/\`. Two files in there contain rig configuration that downstream tools (gc, bd) expect to find on every checkout — without them tracked, operators have to hand-restore them after every clone.

Update the rule to allowlist the two config files while still ignoring the working tree state (issues.jsonl, dependencies.jsonl, dolt data dir, etc.).

## Verified

- \`gc formula list\` on a city consuming this pack shows \`mol-pr-triage\` alongside the other \`mol-pr-*\` formulas.
- maintenance PL successfully dispatched a triage run after the formula was restored locally (was stashed during the slack-pack cutover).

## Known follow-up (not in scope)

\`gc sling --on mol-pr-triage <bead>\` may fail with 'formula not found in search paths' on some setups. Workaround: \`gc formula cook mol-pr-triage --attach <bead> --rig <rig>\` then \`gc sling polecat <bead> --no-formula --rig <rig>\`. Confirmed 2026-05-07 with mol-pr-triage on bead gc-9wa. May warrant a separate gascity issue but mol-pr-triage works through the cook+sling fallback regardless.