### PR TITLE
fix(slack-pack): auto-deliver protocol nudge on bind + fix(pr-pipeline): triage report writes to city-scope path

### DIFF
--- a/pr-pipeline/formulas/mol-pr-triage.formula.toml
+++ b/pr-pipeline/formulas/mol-pr-triage.formula.toml
@@ -81,13 +81,24 @@ gate: gh_not_authed"
 ```
 
 **3. Resolve vars and record initial state:**
+
+Triage report is written to a city-scope path (via `$GC_CITY_PATH`) so the
+caller (typically a PL) can read it after the polecat exits. The polecat's
+own worktree is transient and may be cleaned up; the city scope persists.
+Falls back to the polecat-local relative path if `$GC_CITY_PATH` isn't
+set (e.g. running outside a managed city).
+
 ```bash
 LIMIT="{{limit}}"
 [ -z "$LIMIT" ] && LIMIT=10
 CATEGORY="{{category}}"
 [ -z "$CATEGORY" ] && CATEGORY="all"
 TS=$(date +%Y%m%d-%H%M%S)
-TRIAGE_DIR=".gc/pr-pipeline/triage"
+if [ -n "${GC_CITY_PATH:-}" ]; then
+    TRIAGE_DIR="${GC_CITY_PATH}/.gc/pr-pipeline/triage"
+else
+    TRIAGE_DIR=".gc/pr-pipeline/triage"
+fi
 mkdir -p "$TRIAGE_DIR"
 TRIAGE_PATH="$TRIAGE_DIR/$TS.md"
 

--- a/slack-pack/scripts/slack_chat_bind_room.py
+++ b/slack-pack/scripts/slack_chat_bind_room.py
@@ -18,10 +18,76 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import subprocess
 import sys
 from typing import Any
 
 import slack_intake_common as common
+
+
+# Reply protocol delivered to each newly-bound participant. Sent on every
+# bind (idempotent — duplicate nudges are harmless). Without this, a
+# participant session that respawned after the original bind would lose
+# the protocol contract and revert to its baseline prompt's reply path.
+PROTOCOL_NUDGE_TEMPLATE = """<system-reminder>
+Slack channel binding established for {conversation_id}.
+You are a slack-bound agent in this conversation.
+
+Reply protocol when you receive a `New message in shared conversation slack/...` reminder:
+
+  1. **FIRST**: react with eyes — BEFORE you compose anything, BEFORE you
+     read context, BEFORE you think about the reply.
+       gc slack react --emoji eyes
+     This is non-blocking and signals to the human that you've seen the
+     message. Replying first means the human waits in silence until your
+     full reply lands, even when you have an instant answer.
+
+  2. THEN compose your reply to a tmpfile.
+
+  3. THEN publish as a threaded reply (NOT publish-to-channel):
+       gc slack reply-current --body-file <tmpfile> --thread-current
+
+  4. THEN ack so the inbound is marked read:
+       gc transcript read --ack
+
+The order is non-negotiable even when you have an instant answer. Even
+when the inbound is a re-ping of an active thread. Even when it's a
+"ping" or "ack". React first, every time.
+
+Use `gc slack publish-to-channel --conversation-id ... --no-thread` ONLY
+for explicit top-level status broadcasts initiated by you, never as a
+reply to an inbound. Eyes-react is for inbound-replies only — proactive
+posts (e.g. surfacing slung work completion) skip the react and just
+publish-to-thread.
+</system-reminder>
+"""
+
+
+def deliver_protocol_nudge(session_id: str, conversation_id: str) -> None:
+    """Send the slack reply-protocol nudge to a session via `gc session nudge`.
+
+    Best-effort — failures (session asleep, unknown target, gc binary
+    missing) are logged to stderr and do not abort the bind. The nudge is
+    idempotent so re-delivery on every bind is safe.
+    """
+    body = PROTOCOL_NUDGE_TEMPLATE.format(conversation_id=conversation_id)
+    try:
+        result = subprocess.run(
+            ["gc", "session", "nudge", session_id, body],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        sys.stderr.write(
+            f"warn: protocol nudge to {session_id} failed: {exc}\n"
+        )
+        return
+    if result.returncode != 0:
+        sys.stderr.write(
+            f"warn: protocol nudge to {session_id} returned "
+            f"rc={result.returncode}: {result.stderr.strip()[:200]}\n"
+        )
 
 
 def _slack_workspace_id() -> str:
@@ -154,6 +220,12 @@ def main(argv: list[str]) -> int:
                         help="Cap peer-triggered publishes per inbound (0 = unlimited)")
     parser.add_argument("--max-total-peer-deliveries", type=int, default=0,
                         help="Cap total peer deliveries per inbound (0 = unlimited)")
+    parser.add_argument("--no-protocol-nudge", action="store_true",
+                        help="Skip auto-delivery of the slack reply-protocol nudge "
+                             "(react first, threaded reply, ack) to each newly-bound "
+                             "participant. By default the nudge is sent on every bind, "
+                             "which is idempotent and safe — disable only if a caller "
+                             "is composing its own protocol delivery.")
     parser.add_argument("--binding-owner", default="",
                         metavar="SESSION",
                         help="Also bind this session to the conversation as the publisher "
@@ -236,6 +308,18 @@ def main(argv: list[str]) -> int:
     }
     common.save_pack_config(cfg)
 
+    # Deliver the protocol nudge to each participant session so respawned
+    # sessions don't lose the reply contract. Best-effort, opt-out via flag.
+    nudged: list[str] = []
+    nudge_failures: list[str] = []
+    if not args.no_protocol_nudge:
+        for _, session in participants:
+            try:
+                deliver_protocol_nudge(session, args.conversation_id)
+                nudged.append(session)
+            except Exception as exc:  # noqa: BLE001 — best-effort, never abort bind
+                nudge_failures.append(f"{session}: {exc}")
+
     print(json.dumps({
         "binding_key": binding_key,
         "group_id": group_id,
@@ -244,6 +328,11 @@ def main(argv: list[str]) -> int:
         "participants": participant_records,
         "binding_owner": binding_owner or None,
         "binding_record": binding_record,
+        "protocol_nudge": {
+            "delivered_to": nudged,
+            "failures": nudge_failures,
+            "skipped": args.no_protocol_nudge,
+        },
     }, indent=2, default=str))
     return 0
 


### PR DESCRIPTION
Two related fixes from the slack-pack cutover debug 2026-05-09. Tracked in dr-rg5hl4 (bind-time nudge) and dr-rbyxvg (path resolution sub-gap A).

## 1. Auto-deliver reply protocol nudge on `slack_chat_bind_room`

When a slack-bound session is respawned (e.g. by supervisor restart), the previously-delivered reply-protocol nudge stays queued for the retired session ID and is never re-delivered to the new one. The new session reverts to its baseline prompt, which is less forceful about the eyes-react-then-threaded-reply contract — agents end up replying channel-level instead of in-thread, with the eyes emoji embedded in the message body instead of fired as a Slack reaction.

**Fix**: `slack_chat_bind_room` now delivers the protocol nudge to each newly-bound participant via `gc session nudge <session>`. Idempotent (safe to re-deliver on every bind), best-effort (failures don't abort the bind), opt-out via `--no-protocol-nudge` for callers that want to compose their own delivery.

The nudge text codifies the strict order:

1. React with eyes FIRST (non-blocking signal that you've seen it)
2. THEN compose reply to a tmpfile
3. THEN publish as threaded reply via `gc slack reply-current --thread-current` (NOT publish-to-channel)
4. THEN ack via `gc transcript read --ack`

Order is non-negotiable even for short replies / re-pings of an active thread. Eyes-react is for inbound-replies only — proactive posts (e.g. surfacing slung-work completion) skip the react and just publish-to-thread.

## 2. `mol-pr-triage` writes report to city-scope path

`mol-pr-triage` runs in a polecat session whose worktree is transient. The formula was writing the triage report to a relative path (`.gc/pr-pipeline/triage/<timestamp>.md`), which resolves under the polecat's worktree — not under the city scope. After the polecat exits and the worktree is cleaned up, the originating PL can't read the report.

**Fix**: when `GC_CITY_PATH` is set in the polecat's env (always true under a managed city), write to `$GC_CITY_PATH/.gc/pr-pipeline/triage/` so the artifact persists in the city scope and the PL can read it after the polecat exits. Falls back to the polecat-local relative path if `GC_CITY_PATH` is unset (e.g. running outside a managed city).

## Verification

Both fixes verified end-to-end on ds-research city 2026-05-09:

- Bind-time nudge: traced through subprocess.run → `gc session nudge` succeeds (idempotent), CLI flag works (`--help` shows it, `--no-protocol-nudge` is opt-out)
- Path resolution: `$GC_CITY_PATH/.gc/pr-pipeline/triage/<ts>.md` is reachable from the city scope and from the maintenance PL session post-polecat-exit

## Out of scope

- The companion `wake-mayor-on-blocker-close` enhancement that nudges the bead OWNER on close (so PLs get notified when their slung work completes) lives in this fork's local `gas-city/bin/` and isn't part of the gascity-packs distribution. Tracked separately.