### PR TITLE
feat(pr-review): add mol-pr-from-issue macro chain formula

### DIFF
--- a/pr-review/formulas/mol-pr-from-issue.formula.toml
+++ b/pr-review/formulas/mol-pr-from-issue.formula.toml
@@ -1,0 +1,524 @@
+description = """
+From a triaged issue to an open PR. Runs pr-start → ship → open-PR with
+halt-on-flag gates between steps. This is the outbound-PR analogue of
+mol-adopt-pr (which is for INCOMING PRs).
+
+A coding agent (polecat or equivalent) follows the chain. Each gate step
+inspects the prior step's evidence and either halts the chain or proceeds.
+When a gate halts, the polecat writes `metadata.summary_for_human` on the
+ROOT bead and closes its step. Per dr-1lf4h3 Phase 2, a downstream
+loop-close handler picks up the root bead close and surfaces the halt to
+the originating Slack thread via the PL.
+
+The molecule root bead IS the control bead — run state is recorded in its
+notes and metadata. Crash-safe: `bd mol current` resumes at the right step.
+
+## Contract
+
+1. Caller slings with `--var issue=<number>` (and optionally `--var skip_open_pr=true`)
+2. Polecat works through 6 sequential steps with explicit per-step gates
+3. Chain ends with either:
+   - an opened PR on `gastownhall/gascity`, OR
+   - a halt with `metadata.summary_for_human` set on the root bead
+
+## Variables
+
+| Variable | Source | Description |
+|----------|--------|-------------|
+| issue | caller | Upstream GitHub issue number (required) |
+| skip_open_pr | caller | "true" to stop at ship-green/branch-ready; do not actually open the PR (default: "false") |
+
+## Failure Modes
+
+| Situation | Action |
+|-----------|--------|
+| pr-start raises critical flag (gate, scope, duplicate PR) | gate-after-pr-start halts; summary_for_human set |
+| ship readiness verdict != READY | gate-after-ship halts; summary_for_human set |
+| git push fails with 403 (maintainerCanModify) | open-pr halts; recovery is supersede-via-our-fork (see step description) |
+| gh pr create fails | open-pr halts; raw error captured in evidence and summary_for_human |
+
+## Known scope notes (vapor phase — needs validation)
+
+- **Implementation gap.** mol-pr-start's contract says "no code is
+  written" — it only produces a plan markdown. mol-pr-ship operates on
+  an already-implemented branch (its simplify and review-iterate stages
+  can modify files but they expect implementation to exist). This
+  formula's `pr-start` step is therefore explicitly broader than
+  mol-pr-start: it does plan + create branch + WRITE THE CODE per the
+  plan. The `ship` step then operates on the implemented branch as a
+  pre-push gate.
+- **PL-mediated halt surface.** Halt steps write
+  `metadata.summary_for_human` on the root bead. Without dr-1lf4h3
+  Phase 2, halts land as flat direct-post via the existing loop-close
+  handler. With Phase 2, they surface in PL voice on the originating
+  Slack thread."""
+formula = "mol-pr-from-issue"
+phase = "vapor"
+version = 1
+
+[vars]
+[vars.issue]
+description = "Upstream GitHub issue number to author a PR for"
+required = true
+
+[vars.skip_open_pr]
+description = "Stop at the ship-green / branch-ready state; do NOT actually open the PR. Default false."
+default = "false"
+
+[[steps]]
+id = "pr-start"
+title = "Plan + scaffold the PR for issue {{issue}}"
+description = """
+Plan + create branch + implement per plan. Combines mol-pr-start's
+planning workflow (copy-with-prune) with the implementation work that
+mol-pr-start's contract defers. Writes `evidence.*` on close.
+
+**Contract extension rationale:** mol-pr-start's stated contract is "no
+code is written" — it produces only a plan markdown. This step
+extends that contract because the downstream `ship` step expects an
+implemented branch to operate against. Planning alone is insufficient
+in a chain that ends with an opened PR. The extension is intentional
+and scoped to this macro formula.
+
+**1. Find the root bead and confirm we're in a git repo:**
+```bash
+ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
+    echo "Not in a git repository — cannot plan."
+    bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
+                         --set-metadata "summary_for_human=Cannot plan issue #{{issue}}: not in a git checkout. No PR opened."
+    bd close "$ROOT_ID" --reason "not a git checkout"
+    exit 1
+}
+cd "$REPO_ROOT"
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+```
+
+**2. Run the mol-pr-start planning pipeline against issue {{issue}}.**
+
+Follow mol-pr-start's six step bodies in order (copy-with-prune from
+`/home/ds/gascity-packs/pr-pipeline/formulas/mol-pr-start.formula.toml`):
+
+  a. **intake** — read the issue via `gh issue view {{issue}}`; record
+     `issue: {{issue}}`, `repo: $REPO`, `repo_root: $REPO_ROOT` on the
+     root bead.
+
+  b. **gates** — Two BLOCKING gates. Either fires → halt the chain:
+
+     - **Gate 1 (Competing PR)**: any open PR already addresses this
+       issue, OR `gh issue view {{issue}} --json state` is `CLOSED`.
+     - **Gate 2 (Architectural refactor)**: active design docs marked
+       Accepted/Implementing, open consolidation PRs from maintainers,
+       or recent supersedes-pattern PRs in the area.
+
+     If either gate triggers:
+     ```bash
+     bd update "$ROOT_ID" \\
+       --set-metadata "gc.halt_chain=true" \\
+       --set-metadata "summary_for_human=Issue #{{issue}} blocked by <gate>: <detail>. Recommended pivot: <one-line suggestion based on which gate fired>."
+     ```
+     Then close this step and stop (the gate-after-pr-start step picks
+     up the halt). Do NOT proceed to implementation.
+
+  c. **blast-radius** — Map callers, configs, concurrency, domain
+     boundaries. Record the summary in root bead notes.
+
+  d. **conventions** — Read CONTRIBUTING.md / AGENTS.md / CLAUDE.md if
+     present; inspect sibling files; pick a test strategy.
+
+  e. **produce-plan** — Write `.gc/pr-pipeline/plans/issue-{{issue}}.md`
+     with sections: Root cause, Files to change, Blast radius,
+     Convention notes, Test plan, Risks, Branch (name + base).
+
+  f. **themes-audit** — Walk the plan against the 19 recurring adoption
+     themes (silent errors, parallel call-path siblings, golden snapshot
+     drift, etc.). Update the plan in-place where a theme applies.
+
+**3. Create the branch.**
+Read the branch name from the plan's "Branch" section, then:
+```bash
+git checkout -B "<branch-name>" origin/main
+```
+
+**4. Implement per the plan.**
+mol-pr-start's contract says "no code is written" — this step extends
+the contract with the implementation work. Walk the plan's "Files to
+change" section and the test plan, write the code, commit as you go:
+```bash
+git add <files>
+git commit -m "<conventional commit per plan>"
+```
+
+Implementation rules:
+- Test-first when the test plan calls for it.
+- Each commit should leave the build green; if a build break is needed
+  for a multi-step refactor, sequence the commits so the breakage is
+  bounded to a contiguous sequence.
+- Stay within the plan's stated Files to change unless extending the
+  scope is genuinely required. If scope expands, note it in root bead
+  notes (`scope_extension: <reason>`).
+
+**5. Write evidence on close:**
+```bash
+bd update "$ROOT_ID" \\
+  --set-metadata "evidence.artifact_path=.gc/pr-pipeline/plans/issue-{{issue}}.md" \\
+  --set-metadata "evidence.reviewer_verdict=pass" \\
+  --set-metadata "evidence.reviewer_agent=<this polecat session>" \\
+  --set-metadata "evidence.commit_sha=$(git rev-parse HEAD)" \\
+  --set-metadata "evidence.branch=<branch-name>"
+```
+
+If implementation can't be done (e.g., plan says "this issue is
+actually a question, not a fix"), set `gc.halt_chain=true` and
+`summary_for_human=...` describing why and close the step.
+
+**Exit criteria:** Plan written, branch created, implementation committed,
+evidence written. OR: gc.halt_chain=true set with a clear summary."""
+
+[[steps]]
+id = "gate-after-pr-start"
+title = "Gate: critical flags on pr-start?"
+needs = ["pr-start"]
+description = """
+Inspect pr-start's evidence and metadata. Halt the chain if a critical
+flag is present; otherwise close cleanly and proceed.
+
+**1. Find the root bead and read pr-start state:**
+```bash
+ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+HALT=$(bd show "$ROOT_ID" --json | jq -r '.[0].metadata."gc.halt_chain" // "false"')
+VERDICT=$(bd show "$ROOT_ID" --json | jq -r '.[0].metadata."evidence.reviewer_verdict" // ""')
+```
+
+**2. Decide:**
+
+- If `HALT == "true"` OR `VERDICT` is empty (pr-start didn't write
+  evidence) OR `VERDICT == "blocked"`:
+  - **Preserve any existing `summary_for_human` written by pr-start
+    itself** (pr-start's internal gates already write specific halt
+    summaries). Only write a fallback if the field is still empty:
+    ```bash
+    EXISTING=$(bd show "$ROOT_ID" --json | jq -r '.[0].metadata.summary_for_human // ""')
+    if [ -z "$EXISTING" ]; then
+        bd update "$ROOT_ID" --set-metadata \\
+          "summary_for_human=Halt at gate-after-pr-start for issue #{{issue}}: <one-line synthesis of why>. No PR opened."
+    fi
+    ```
+  - Close THIS step with status=closed:
+    ```bash
+    bd close "$ROOT_ID" --reason "halt_chain set after pr-start"
+    ```
+  - Do NOT proceed. The downstream ship/open-pr steps will not run
+    because the chain is halted. The loop-close handler picks up the
+    root bead close downstream.
+
+- Otherwise (verdict is pass and no halt flag), proceed without closing the
+  root bead — the molecule advances to the `ship` step automatically once
+  this step body completes. Display:
+  ```
+  [pr-from-issue] gate-after-pr-start: cleared. Proceeding to ship.
+  ```
+
+**Exit criteria:** Either halted (root closed, summary_for_human set) or
+cleared (step body completes; molecule advances)."""
+
+[[steps]]
+id = "ship"
+title = "Pre-push gate — run mol-pr-ship checks"
+needs = ["gate-after-pr-start"]
+description = """
+Run mol-pr-ship's pre-push gate against the implemented branch.
+Copy-with-prune from
+`/home/ds/gascity-packs/pr-pipeline/formulas/mol-pr-ship.formula.toml`.
+
+**1. Find the root bead and resolve the branch:**
+```bash
+ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "$REPO_ROOT"
+BRANCH=$(git branch --show-current)
+DEFAULT=$(git remote show origin 2>/dev/null | sed -n 's/.*HEAD branch: //p' || echo "main")
+if [ "$BRANCH" = "$DEFAULT" ] || [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then
+    bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
+      --set-metadata "summary_for_human=Cannot ship from default branch ($BRANCH). pr-start did not create a feature branch — chain stopped."
+    bd close "$ROOT_ID" --reason "on default branch"
+    exit 0
+fi
+mkdir -p .gc/pr-pipeline/ship
+SAFE=$(echo "$BRANCH" | tr '/' '_')
+REPORT_PATH=".gc/pr-pipeline/ship/${SAFE}.md"
+```
+
+**2. Run mol-pr-ship's four-stage pipeline:**
+
+  a. **Stage 1 — simplify**: walk the diff, remove dead code, consolidate
+     duplicates, fix naming, drop unused imports. Apply in-place commits.
+     Verify the build is green after; revert simplify commits if not.
+
+  b. **Stage 2 — review-iterate**: iterate self-review against the 11
+     scorecard categories (Behavioral Correctness, Contract Fidelity,
+     Blast Radius, Concurrency, Error Handling, Security, Resource
+     Lifecycle, Release Safety, Test Evidence, Architectural Consistency,
+     Debuggability). Pre-flag the seven recurring themes (test
+     isolation, test retry, stale-state guards, fail-closed, bootstrap
+     init, API contract, transient retry — see mol-pr-review for the
+     canonical descriptions in
+     `/home/ds/gascity-packs/pr-pipeline/formulas/mol-pr-review.formula.toml`).
+     Fix blockers and majors in-place; commit each fix. Cap at 3
+     iterations. If iteration 3 still has blockers/majors →
+     readiness=BLOCKED.
+
+  c. **Stage 3 — contributor-check**: mechanical gates per repo stack
+     (build, lint/vet, tests, docs if Makefile target exists and docs
+     touched). Record pass/fail per gate.
+
+  d. **Stage 4 — report**: write the combined readiness report to
+     `$REPORT_PATH`. Verdict is mechanical:
+     - READY only when: simplify ∈ {complete, skipped} AND review_status =
+       converged AND no required gate failed
+     - Otherwise: BLOCKED
+
+**3. Write evidence on close:**
+
+Note: this step **overwrites** `evidence.artifact_path` set by pr-start
+(which pointed to the plan markdown). The semantics of `evidence.*`
+in this macro are "most-recent step's evidence" — chain-time ordering
+matters. If a crash-resume brings ship back before pr-start re-runs,
+the artifact_path key may still point to the plan path; verify it
+points to the ship report (`.gc/pr-pipeline/ship/...`) before reading
+it in gate-after-ship.
+
+```bash
+bd update "$ROOT_ID" \\
+  --set-metadata "evidence.artifact_path=$REPORT_PATH" \\
+  --set-metadata "evidence.reviewer_verdict=<pass|blocked>" \\
+  --set-metadata "evidence.reviewer_agent=<this polecat session>" \\
+  --set-metadata "evidence.commit_sha=$(git rev-parse HEAD)"
+```
+
+Map readiness → verdict:
+- readiness=READY → `reviewer_verdict=pass`
+- readiness=BLOCKED → `reviewer_verdict=blocked`
+
+**Critical:** This step MUST NOT run `git push` or `gh pr create`.
+Push and PR open happen in the `open-pr` step, gated on the
+`gate-after-ship` decision.
+
+**Exit criteria:** Report written, verdict recorded, evidence set."""
+
+[[steps]]
+id = "gate-after-ship"
+title = "Gate: major concerns on ship?"
+needs = ["ship"]
+description = """
+Inspect ship's evidence.reviewer_verdict. Halt the chain if not pass;
+otherwise close cleanly and proceed to open-pr.
+
+**1. Find the root bead and read ship state:**
+```bash
+ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+VERDICT=$(bd show "$ROOT_ID" --json | jq -r '.[0].metadata."evidence.reviewer_verdict" // ""')
+REPORT_PATH=$(bd show "$ROOT_ID" --json | jq -r '.[0].metadata."evidence.artifact_path" // ""')
+```
+
+**2. Decide:**
+
+- If `VERDICT != "pass"`:
+  - Read the blockers section of the ship report at `$REPORT_PATH`.
+  - Write `summary_for_human` synthesizing the blockers:
+    ```bash
+    bd update "$ROOT_ID" --set-metadata \\
+      "summary_for_human=Ship gate halted on issue #{{issue}}: <one-line blocker summary>. Full readiness report at $REPORT_PATH. Branch left ready for human review — no PR opened."
+    ```
+  - Set halt_chain:
+    ```bash
+    bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true"
+    ```
+  - Close THIS step:
+    ```bash
+    bd close "$ROOT_ID" --reason "ship verdict != pass"
+    ```
+  - Do NOT proceed to open-pr.
+
+- Otherwise (verdict = pass), proceed without closing the root bead —
+  the molecule advances to the `open-pr` step automatically once this
+  step body completes. Display:
+  ```
+  [pr-from-issue] gate-after-ship: cleared. Proceeding to open-pr.
+  ```
+
+**Exit criteria:** Either halted (root closed, summary_for_human + halt_chain
+set) or cleared (step body completes; molecule advances)."""
+
+[[steps]]
+id = "open-pr"
+title = "Push fork + open PR upstream"
+needs = ["gate-after-ship"]
+description = """
+Push the implementation branch to the contributor's fork and open the PR
+on `gastownhall/gascity`. The first step that performs WRITES to the
+upstream — everything before this is local-only or read-only against
+upstream.
+
+**1. Find the root bead and resolve identifiers:**
+```bash
+ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+BRANCH=$(git branch --show-current)
+ISSUE_NUM={{issue}}
+SKIP_OPEN_PR="{{skip_open_pr}}"
+```
+
+**2. Honor skip_open_pr=true (early-exit before any write):**
+
+If `SKIP_OPEN_PR == "true"`:
+```bash
+COMMIT_SHA=$(git rev-parse HEAD)
+bd update "$ROOT_ID" \\
+  --set-metadata "evidence.artifact_path=git:$COMMIT_SHA" \\
+  --set-metadata "evidence.reviewer_verdict=pass" \\
+  --set-metadata "evidence.reviewer_agent=<this polecat session>" \\
+  --set-metadata "evidence.branch=$BRANCH" \\
+  --set-metadata "summary_for_human=Branch $BRANCH ready at $COMMIT_SHA for issue #$ISSUE_NUM. skip_open_pr=true — no push, no PR. Run: git push <fork-remote> $BRANCH when ready."
+bd close "$ROOT_ID" --reason "skip_open_pr=true; branch ready for human-driven open"
+exit 0
+```
+
+Note: this is a soft-success close. The loop-close handler surfaces the
+`summary_for_human` as the molecule's final message; from a Slack-thread
+reader's perspective, it reads as "halted at the open-pr step by your own
+flag" rather than a full success. That's intentional — the chain
+intentionally stopped short of opening the PR.
+
+**3. Resolve the fork and upstream identities.**
+
+The local checkout is the contributor's fork. Resolve:
+```bash
+FORK_REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
+FORK_OWNER=$(echo "$FORK_REPO" | cut -d/ -f1)
+UPSTREAM_REPO=$(gh repo view --json parent --jq '.parent.nameWithOwner // empty')
+if [ -z "$UPSTREAM_REPO" ]; then
+    # Not a fork — open the PR against the same repo.
+    UPSTREAM_REPO="$FORK_REPO"
+fi
+UPSTREAM_BASE=$(gh repo view "$UPSTREAM_REPO" --json defaultBranchRef --jq '.defaultBranchRef.name // "main"')
+```
+
+The fork remote is the local push remote (typically `origin`):
+```bash
+FORK_REMOTE=$(git remote -v | awk -v fork="$FORK_REPO" 'index($2, fork) && /\\(push\\)/ {print $1; exit}')
+[ -z "$FORK_REMOTE" ] && FORK_REMOTE="origin"
+```
+
+**4. Push the branch:**
+```bash
+git push -u "$FORK_REMOTE" "$BRANCH"
+PUSH_EXIT=$?
+```
+
+If the push fails with `403` or "Permission to ... denied":
+
+This is the `maintainerCanModify` misleading case (see memory
+`reference_maintainer_can_modify_misleading`). It typically means the
+fork doesn't allow this push direction. The recovery is "supersede via
+our fork":
+- Create a new branch on a fork the polecat does own
+- Cherry-pick the implementation commits to it
+- Open the PR from that fork instead
+
+If you cannot complete this recovery automatically, halt:
+```bash
+bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
+  --set-metadata "summary_for_human=Push to fork failed with 403 for branch $BRANCH (maintainerCanModify gap). Implementation is local at $(git rev-parse HEAD); manual supersede-via-our-fork recovery needed before PR can be opened."
+bd close "$ROOT_ID" --reason "push 403; manual recovery required"
+exit 0
+```
+
+**5. Read the issue title + plan to compose the PR body.**
+
+```bash
+ISSUE_TITLE=$(gh issue view "$ISSUE_NUM" --repo "$UPSTREAM_REPO" --json title --jq '.title')
+PLAN_PATH=".gc/pr-pipeline/plans/issue-${ISSUE_NUM}.md"
+```
+
+PR title: a conventional-commit style summary derived from the issue.
+PR body: short summary + reference to issue + link to plan path (in the
+contributor's fork; can be inlined if the maintainer prefers).
+
+**6. Open the PR upstream.**
+
+```bash
+PR_URL=$(gh pr create \\
+    --repo "$UPSTREAM_REPO" \\
+    --base "$UPSTREAM_BASE" \\
+    --head "$FORK_OWNER:$BRANCH" \\
+    --title "<conventional commit summary>" \\
+    --body "<body referencing issue #$ISSUE_NUM and the plan>" 2>&1)
+PR_EXIT=$?
+```
+
+`gh pr create` can exit 0 with no URL on stdout when a PR for that
+branch already exists (it prints a warning instead). Recover:
+```bash
+if [ "$PR_EXIT" -eq 0 ] && [ -z "$(echo "$PR_URL" | grep -E 'https://[^ ]+/pull/[0-9]+')" ]; then
+    # No URL captured — look up an existing PR on this head.
+    PR_URL=$(gh pr list --repo "$UPSTREAM_REPO" --head "$BRANCH" --state open \\
+              --json url --jq '.[0].url // empty')
+fi
+
+if [ "$PR_EXIT" -ne 0 ] || [ -z "$PR_URL" ]; then
+    bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
+      --set-metadata "summary_for_human=Branch $BRANCH pushed to fork but gh pr create failed or no PR URL captured. Investigate before retrying."
+    bd close "$ROOT_ID" --reason "gh pr create failed or url empty"
+    exit 0
+fi
+
+# Extract the PR number from the URL (last path segment after /pull/).
+PR_NUM=$(echo "$PR_URL" | grep -oE '/pull/[0-9]+' | head -1 | sed 's|/pull/||')
+```
+
+**7. Check CI status (best-effort, non-blocking):**
+
+```bash
+CI_STATUS=$(gh pr view "$PR_NUM" --repo "$UPSTREAM_REPO" --json statusCheckRollup --jq '.statusCheckRollup | length' 2>/dev/null || echo "0")
+if [ "$CI_STATUS" = "0" ]; then
+    CI_NOTE="no checks reported yet"
+else
+    CI_NOTE="$CI_STATUS checks running"
+fi
+```
+
+**8. Write evidence and summary_for_human:**
+```bash
+bd update "$ROOT_ID" \\
+  --set-metadata "evidence.artifact_path=github-pr:gastownhall/gascity/$PR_NUM" \\
+  --set-metadata "evidence.reviewer_verdict=pass" \\
+  --set-metadata "evidence.reviewer_agent=<this polecat session>" \\
+  --set-metadata "evidence.pr_url=$PR_URL" \\
+  --set-metadata "summary_for_human=Opened PR #$PR_NUM for issue #$ISSUE_NUM: $ISSUE_TITLE. URL: $PR_URL. CI status: $CI_NOTE."
+```
+
+**9. Close the molecule:**
+```bash
+bd close "$ROOT_ID" --reason "PR #$PR_NUM opened"
+```
+
+**Exit criteria:** PR opened upstream (or halt set with summary_for_human
+on recovery-needed failure path)."""
+
+[[steps]]
+id = "drain"
+title = "Signal completion"
+needs = ["open-pr"]
+description = """
+Final step. Signal the controller to reclaim this polecat session.
+
+```bash
+gc runtime drain-ack
+```
+
+Run this command and nothing else. The molecule completes when this step
+closes. The downstream loop-close handler picks up the root bead close
+and surfaces `metadata.summary_for_human` to the originating Slack thread
+via the PL.
+
+**Exit criteria:** drain-ack signaled; molecule complete."""


### PR DESCRIPTION
## Summary

Adds `mol-pr-from-issue.formula.toml` to `pr-review/` — a 6-step macro chain formula encapsulating the issue-to-PR pipeline with halt-on-flag gates between steps.

Steps: `pr-start` → `gate-after-pr-start` → `ship` → `gate-after-ship` → `open-pr` → `drain`.

Each gate halts the chain and surfaces a `summary_for_human` on the root bead when a critical or major flag is detected, rather than running the full pipeline blindly. Step bodies are copy-with-prune from `mol-adopt-pr` per the bitter-lesson lens (narrow contracts over coupling via skip flags).

## Why

Current state: each step in the issue-to-PR pipeline (`mol-pr-start`, `mol-pr-ship`, manual open-PR) is an independent formula. The PL slings one, waits for a fresh human direction, then slings the next. v1.5 application work tracked at city-scope `dr-1lf4h3` + `dr-i06w09` (Lexler augmented-coding-patterns map) identified this as the "chain-of-small-steps" pattern from Lexler's catalog. This formula encodes the chain as one dispatch unit with explicit gates.

## Test plan

- [x] `bd cook --dry-run --var issue=42` succeeds
- [x] `bd cook --mode=runtime --var issue=42` succeeds (with and without `--var skip_open_pr=true`)
- [x] code-reviewer agent pass found 2 BLOCKERs (close-pattern + step-id placeholder) and 4 MAJORs (prose tightening, evidence overwrite docs, hardcoded repo/base, gh-pr-create empty URL); all resolved
- [ ] Multi-model `/review` not run pre-push — maintainer's call
- [ ] End-to-end validation on a real issue deferred — needs a maintainer push of the chain into a worker workflow

## Context

Filed in city as `gpk-g5d`. Parent design: city `dr-1lf4h3` (loop-close wiring) + `dr-i06w09` (Lexler patterns map → city primitives). Halt-on-flag gates surface via the loop-close handler's PL-mediated path (Phase 2 of dr-1lf4h3).

Tested with bd cook in both default and skip-open-pr modes. Both succeed and produce the expected step graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)