### PR TITLE
feat(pr-pipeline,pr-review): adopt Claude Code Agent Teams for adversarial PR review

### DIFF
--- a/pr-pipeline/formulas/mol-pr-ship.formula.toml
+++ b/pr-pipeline/formulas/mol-pr-ship.formula.toml
@@ -166,10 +166,11 @@ before reporting consensus. This is stronger than one-shot
 synthesis because reviewers can interrogate each other's
 blocker/major flags.
 
-Requires CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 in your env
-(configured at agent.toml level for the polecat pool). Verify
-before spawning the team:
+Resolve the root bead ID (used by the env-gate and the iteration
+notes below), then verify CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 in
+your env (configured at agent.toml level for the polecat pool):
 
+    ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
     [[ "$CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS" = "1" ]] || {
         bd update "$ROOT_ID" --notes "review_mode: blocked-env-missing"
         echo "review-iterate blocked: CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS not set in env"
@@ -178,9 +179,13 @@ before spawning the team:
 
 ## Iteration loop (cap at 3 iterations)
 
-1. Prepare the diff context:
+1. Prepare the diff context. `BRANCH` is sanitized for the temp-file
+   name so `/` characters in the branch name (e.g. `feat/foo`) don't
+   create unintended directory paths:
 
-       git diff origin/main..HEAD > /tmp/pr-ship-${BRANCH//\\//-}-iter${ITER_N}.patch
+       SAFE_BRANCH="${BRANCH//\\//-}"
+       PATCH_PATH=$(mktemp -t "pr-ship-${SAFE_BRANCH}-iter${ITER_N}.XXXXXX.patch")
+       git diff origin/main..HEAD > "$PATCH_PATH"
 
 2. Create the agent team with a natural-language spawn instruction.
    The "competing hypotheses" pattern from the Agent Teams docs:
@@ -222,12 +227,17 @@ before spawning the team:
    (`git commit -m "fix: ..."`), increment ITER_N, go to step 1.
    Cap at 3 iterations.
 
-6. Record per-iteration state:
+6. Record per-iteration state. Use a heredoc so the multi-line note
+   is robust against shell copy-paste (literal newlines inside a
+   double-quoted string can pick up unintended leading whitespace):
 
-       ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
-       bd update "$ROOT_ID" --notes "review_iter_$ITER_N: blockers=<n>, majors=<n>, minors=<n>
+       bd update "$ROOT_ID" --notes "$(cat <<EOF
+       review_iter_$ITER_N: blockers=<n>, majors=<n>, minors=<n>
        review_fix_commits_$ITER_N: <sha>,<sha>,...
-       review_team_synthesis_$ITER_N: <path to synthesis report>"
+       review_team_synthesis_$ITER_N: <path to synthesis report>
+       review_team_patch_$ITER_N: $PATCH_PATH
+       EOF
+       )"
 
 7. Clean up the team before exiting the step. Tell the lead to
    "Clean up the team" — always cleanup via the lead, never via a

--- a/pr-pipeline/formulas/mol-pr-ship.formula.toml
+++ b/pr-pipeline/formulas/mol-pr-ship.formula.toml
@@ -155,61 +155,104 @@ outcome recorded.
 
 [[steps]]
 id = "review-iterate"
-title = "Stage 2 — iterate self-review until no blockers/majors"
+title = "Stage 2 — multi-agent adversarial review via Agent Teams"
 needs = ["simplify"]
 description = """
-Iterate `mol-pr-review` (or equivalent self-review) until there are no
-blocker or major findings. This is the load-bearing stage.
+Stage 2 — multi-agent adversarial review via Claude Code Agent
+Teams. The polecat (you) is the team lead; you spawn 3-4 reviewer
+teammates referencing existing subagent definitions, then conduct
+a structured debate where teammates challenge each other's findings
+before reporting consensus. This is stronger than one-shot
+synthesis because reviewers can interrogate each other's
+blocker/major flags.
 
-The loop:
+Requires CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 in your env
+(configured at agent.toml level for the polecat pool). Verify
+before spawning the team:
 
-1. Run a self-review pass against the diff. If a real `mol-pr-review`
-   sub-formula or `gh pr` exists for this branch, use it. Otherwise,
-   walk the diff against the 11 scorecard categories inline:
-   - Cat 1 Behavioral Correctness, Cat 2 Contract Fidelity,
-     Cat 3 Blast Radius, Cat 4 Concurrency,
-     Cat 5 Error Handling, Cat 6 Security,
-     Cat 7 Resource Lifecycle, Cat 8 Release Safety,
-     Cat 9 Test Evidence, Cat 10 Architectural Consistency,
-     Cat 11 Debuggability.
+    [[ "$CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS" = "1" ]] || {
+        bd update "$ROOT_ID" --notes "review_mode: blocked-env-missing"
+        echo "review-iterate blocked: CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS not set in env"
+        exit 2
+    }
 
-2. Pre-flag the seven recurring themes (see `mol-pr-review` for the
-   full list — test isolation, test retry, stale-state guards,
-   fail-closed, bootstrap init, API contract, transient retry).
+## Iteration loop (cap at 3 iterations)
 
-3. Classify findings as **blocker**, **major**, or **minor**:
-   - blocker: correctness/safety defect that must be fixed before merge
-   - major:   design/precision defect a careful reviewer will flag
-   - minor:   style or nice-to-have
+1. Prepare the diff context:
 
-4. If any blocker or major remains:
-   - Fix in-place
-   - Commit (`git commit -m "fix: ..."`)
-   - Go to step 1 of the loop
+       git diff origin/main..HEAD > /tmp/pr-ship-${BRANCH//\\//-}-iter${ITER_N}.patch
 
-5. Exit the loop when no blockers/majors remain (minors OK to ship).
+2. Create the agent team with a natural-language spawn instruction.
+   The "competing hypotheses" pattern from the Agent Teams docs:
 
-**Cap at 3 iterations.** If iteration 3 still has blockers or majors,
-report as **blocked — review not converging** and stop the formula.
+       Create an agent team to adversarially review the staged branch
+       <BRANCH> for regression risk. Spawn 4 reviewer teammates by
+       name, each referencing an existing subagent definition:
 
-Record per-iteration state:
+         - reviewer-go using go-reviewer agent type
+         - reviewer-sec using security-reviewer agent type
+         - reviewer-code using code-reviewer agent type
+         - reviewer-codex using codex:codex-rescue agent type
 
-```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
-ITER_N=<1|2|3>
-bd update "$ROOT_ID" --notes "review_iter_$ITER_N: blockers=<n>, majors=<n>, minors=<n>
-review_fix_commits_$ITER_N: <sha>,<sha>,..."
-```
+       Each teammate reads /tmp/pr-ship-<...>-iterN.patch and reviews
+       against the 11-category rubric (Behavioral Correctness,
+       Contract Fidelity, Change Impact / Blast Radius, Concurrency,
+       Error Handling, Security, Resource Lifecycle, Release Safety,
+       Test Evidence, Architectural Consistency, Debuggability) with
+       severity (blocker/major/minor/nit) + confidence (high/medium/low).
+
+       After each teammate produces an initial review, have them
+       CHALLENGE each other's blocker and major findings directly via
+       teammate messaging — like a scientific debate. Each teammate
+       attempts to disprove the others' high-severity flags. The
+       review that survives debate is the final report.
+
+       Lead (you, polecat) waits for all teammates to finish the
+       debate phase, synthesizes the post-debate consensus, and writes
+       the per-iteration scorecard.
+
+3. Wait for the team's debate to finish. The shared task list
+   coordinates progress. Use the `TeammateIdle` checkpoint when
+   available.
+
+4. Synthesize: read the consensus output and classify remaining
+   findings as blocker / major / minor.
+
+5. If any blocker or major remains → fix in-place, commit
+   (`git commit -m "fix: ..."`), increment ITER_N, go to step 1.
+   Cap at 3 iterations.
+
+6. Record per-iteration state:
+
+       ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+       bd update "$ROOT_ID" --notes "review_iter_$ITER_N: blockers=<n>, majors=<n>, minors=<n>
+       review_fix_commits_$ITER_N: <sha>,<sha>,...
+       review_team_synthesis_$ITER_N: <path to synthesis report>"
+
+7. Clean up the team before exiting the step. Tell the lead to
+   "Clean up the team" — always cleanup via the lead, never via a
+   teammate (per Agent Teams docs warning).
+
+## Exit criteria
+
+Same as today's formula:
+  - Converged: no blockers, no majors remain. Minors OK to ship.
+  - Cap-hit: iteration 3 still has blockers/majors. Report blocked
+    at Stage 4 with `review_status: not_converged` on the root bead.
 
 After convergence (or 3-iter cap):
 
-```bash
-bd update "$ROOT_ID" --notes "review_status: <converged | not_converged>
-review_final: blockers=<n>, majors=<n>, minors=<n>"
-```
+    bd update "$ROOT_ID" --notes "review_status: <converged | not_converged>
+    review_final: blockers=<n>, majors=<n>, minors=<n>"
 
-**Exit criteria:** Either converged (no blockers/majors) or hit 3-iter
-cap (formula reports blocked and stops at Stage 4).
+## Fallback
+
+If agent teams cannot be created in this session (env var unset,
+version mismatch, lead-already-managing-a-team), fall back to
+spawning the same 4 reviewers as standalone parallel subagents
+(single Agent tool message with 4 calls), synthesize without the
+debate phase, and note `review_mode: subagent-fallback` on the
+bead. Subagent fallback is degraded but functional.
 """
 
 [[steps]]

--- a/pr-pipeline/formulas/mol-pr-ship.formula.toml
+++ b/pr-pipeline/formulas/mol-pr-ship.formula.toml
@@ -79,9 +79,16 @@ fi
 mkdir -p .gc/pr-pipeline/ship
 SAFE=$(echo "$BRANCH" | tr '/' '_')
 REPORT_PATH=".gc/pr-pipeline/ship/${SAFE}.md"
-bd update "$ROOT_ID" --notes "branch: $BRANCH
+
+# Multi-line notes go via heredoc: literal newlines inside a double-quoted
+# string are not robust to shell copy-paste (leading whitespace can get
+# baked into the value). This is the canonical pattern across this pack.
+bd update "$ROOT_ID" --notes "$(cat <<EOF
+branch: $BRANCH
 report_path: $REPORT_PATH
-status: in_progress"
+status: in_progress
+EOF
+)"
 ```
 
 **Exit criteria:** Branch resolved, report path set, not on default branch.
@@ -145,8 +152,11 @@ Record stage outcome:
 
 ```bash
 ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
-bd update "$ROOT_ID" --notes "simplify: <complete | reverted | skipped>
-simplify_commits: <sha1>,<sha2>,..."
+bd update "$ROOT_ID" --notes "$(cat <<EOF
+simplify: <complete | reverted | skipped>
+simplify_commits: <sha1>,<sha2>,...
+EOF
+)"
 ```
 
 **Exit criteria:** Diff simplified (or skipped/reverted), build green,
@@ -166,9 +176,11 @@ before reporting consensus. This is stronger than one-shot
 synthesis because reviewers can interrogate each other's
 blocker/major flags.
 
-Resolve the root bead ID (used by the env-gate and the iteration
-notes below), then verify CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 in
-your env (configured at agent.toml level for the polecat pool):
+**1. Resolve root bead + env-gate.**
+
+Resolve `ROOT_ID` first (the env-gate's `bd update` needs it), then verify
+`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` in your env (configured at
+agent.toml level for the polecat pool):
 
     ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
     [[ "$CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS" = "1" ]] || {
@@ -179,15 +191,16 @@ your env (configured at agent.toml level for the polecat pool):
 
 ## Iteration loop (cap at 3 iterations)
 
-1. Prepare the diff context. `BRANCH` is sanitized for the temp-file
+2. Prepare the diff context. `BRANCH` is sanitized for the temp-file
    name so `/` characters in the branch name (e.g. `feat/foo`) don't
-   create unintended directory paths:
+   create unintended directory paths. Use `tr` to avoid bash parameter-
+   expansion ambiguity with escaped slashes inside a TOML basic string:
 
-       SAFE_BRANCH="${BRANCH//\\//-}"
+       SAFE_BRANCH=$(printf '%s' "$BRANCH" | tr '/' '-')
        PATCH_PATH=$(mktemp -t "pr-ship-${SAFE_BRANCH}-iter${ITER_N}.XXXXXX.patch")
        git diff origin/main..HEAD > "$PATCH_PATH"
 
-2. Create the agent team with a natural-language spawn instruction.
+3. Create the agent team with a natural-language spawn instruction.
    The "competing hypotheses" pattern from the Agent Teams docs:
 
        Create an agent team to adversarially review the staged branch
@@ -216,18 +229,18 @@ your env (configured at agent.toml level for the polecat pool):
        debate phase, synthesizes the post-debate consensus, and writes
        the per-iteration scorecard.
 
-3. Wait for the team's debate to finish. The shared task list
+4. Wait for the team's debate to finish. The shared task list
    coordinates progress. Use the `TeammateIdle` checkpoint when
    available.
 
-4. Synthesize: read the consensus output and classify remaining
+5. Synthesize: read the consensus output and classify remaining
    findings as blocker / major / minor.
 
-5. If any blocker or major remains → fix in-place, commit
-   (`git commit -m "fix: ..."`), increment ITER_N, go to step 1.
+6. If any blocker or major remains → fix in-place, commit
+   (`git commit -m "fix: ..."`), increment ITER_N, go to step 2.
    Cap at 3 iterations.
 
-6. Record per-iteration state. Use a heredoc so the multi-line note
+7. Record per-iteration state. Use a heredoc so the multi-line note
    is robust against shell copy-paste (literal newlines inside a
    double-quoted string can pick up unintended leading whitespace):
 
@@ -239,7 +252,7 @@ your env (configured at agent.toml level for the polecat pool):
        EOF
        )"
 
-7. Clean up the team before exiting the step. Tell the lead to
+8. Clean up the team before exiting the step. Tell the lead to
    "Clean up the team" — always cleanup via the lead, never via a
    teammate (per Agent Teams docs warning).
 
@@ -252,8 +265,11 @@ Same as today's formula:
 
 After convergence (or 3-iter cap):
 
-    bd update "$ROOT_ID" --notes "review_status: <converged | not_converged>
-    review_final: blockers=<n>, majors=<n>, minors=<n>"
+    bd update "$ROOT_ID" --notes "$(cat <<EOF
+    review_status: <converged | not_converged>
+    review_final: blockers=<n>, majors=<n>, minors=<n>
+    EOF
+    )"
 
 ## Fallback
 
@@ -331,8 +347,11 @@ fi
 Record outcomes:
 
 ```bash
-bd update "$ROOT_ID" --notes "gates_passed:$GATES_PASSED
-gates_failed:$GATES_FAILED"
+bd update "$ROOT_ID" --notes "$(cat <<EOF
+gates_passed:$GATES_PASSED
+gates_failed:$GATES_FAILED
+EOF
+)"
 ```
 
 **Note on test failures:** if a failure is documented as a baseline
@@ -410,9 +429,12 @@ Decide verdict mechanically:
 ```bash
 VERDICT="<READY | BLOCKED>"
 BLOCKERS="<one-line summary of what blocks, or 'none'>"
-bd update "$ROOT_ID" --notes "readiness: $VERDICT
+bd update "$ROOT_ID" --notes "$(cat <<EOF
+readiness: $VERDICT
 blockers: $BLOCKERS
-status: complete"
+status: complete
+EOF
+)"
 echo "[ship] Pipeline complete for branch $BRANCH"
 echo "[ship]   Verdict: $VERDICT"
 echo "[ship]   Path: $REPORT_PATH"

--- a/pr-review/formulas/mol-adopt-pr.formula.toml
+++ b/pr-review/formulas/mol-adopt-pr.formula.toml
@@ -209,9 +209,11 @@ consensus. This is the incoming-PR-side counterpart to mol-pr-ship's
 review-iterate stage — same Agent Teams mechanism, different scope
 (one-shot review producing a synthesis artifact for the human-gate step).
 
-Requires CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 in your env (configured
-at agent.toml level for the polecat pool). Verify before spawning:
+Resolve the root bead ID (used by the env-gate and the notes
+recorded below), then verify CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1
+in your env (configured at agent.toml level for the polecat pool):
 
+    ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
     [[ "$CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS" = "1" ]] || {
         bd update "$ROOT_ID" --notes "review_mode: blocked-env-missing"
         echo "review blocked: CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS not set in env"
@@ -220,18 +222,22 @@ at agent.toml level for the polecat pool). Verify before spawning:
 
 **1. Read root bead notes:**
 
-```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
-```
-Extract `pr_number`, `repo`, `base_branch`, `skip_gemini` from notes.
+Extract `pr_number`, `repo`, `base_branch`, `skip_gemini` from the
+notes on `$ROOT_ID` (already resolved above).
 
 **2. Fetch canonical upstream base + prepare diff context:**
+
+Use `mktemp` so concurrent runs against the same PR number from
+different repos/users don't collide on `/tmp/adopt-pr-<N>.patch`.
+The path is recorded in the root bead notes so the synthesis step
+can find it:
 
 ```bash
 UPSTREAM_URL="https://github.com/<owner>/<repo>.git"
 git fetch "$UPSTREAM_URL" <base_branch>:refs/adopt-pr/upstream-base
-DIFF_PATH=/tmp/adopt-pr-${pr_number}.patch
+DIFF_PATH=$(mktemp -t "adopt-pr-${pr_number}-XXXXXX.patch")
 gh pr diff $pr_number --repo <owner>/<repo> > "$DIFF_PATH"
+bd update "$ROOT_ID" --notes "review_team_patch_path: $DIFF_PATH"
 ```
 
 **3. Create the agent team with a natural-language spawn instruction.**
@@ -247,8 +253,9 @@ Use the "competing hypotheses" pattern from the Agent Teams docs:
       - reviewer-code using code-reviewer agent type
       - reviewer-codex using codex:codex-rescue agent type
 
-    Each teammate reads /tmp/adopt-pr-<PR_NUMBER>.patch and reviews
-    against the 11-category rubric (Behavioral Correctness, Contract
+    Each teammate reads the patch at $DIFF_PATH (recorded on
+    `$ROOT_ID` as `review_team_patch_path`) and reviews against the
+    11-category rubric (Behavioral Correctness, Contract
     Fidelity, Change Impact / Blast Radius, Concurrency, Error Handling,
     Security, Resource Lifecycle, Release Safety, Test Evidence,
     Architectural Consistency, Debuggability) with severity
@@ -267,13 +274,17 @@ Use the "competing hypotheses" pattern from the Agent Teams docs:
     validations (if applicable), new findings with severity + source
     attribution + suggested fixes, and a category coverage summary.
 
-**4. Save artifact path on root bead:**
+**4. Save artifact path on root bead.** Use a heredoc so the
+multi-line note doesn't pick up unintended leading whitespace when
+copy-pasted:
 
 ```bash
 SYNTHESIS_PATH=".gc/adopt-pr/reviews/pr-${pr_number}.md"
-bd update $ROOT_ID --notes "<existing notes>
+bd update "$ROOT_ID" --notes "$(cat <<EOF
 review_synthesis_path: $SYNTHESIS_PATH
-review_team_completed_at: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+review_team_completed_at: $(date -u +%Y-%m-%dT%H:%M:%SZ)
+EOF
+)"
 ```
 
 **5. Present findings summary to orient the human reviewer:**
@@ -282,7 +293,7 @@ review_team_completed_at: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
 [adopt-pr] Multi-agent review complete (Agent Teams)
 [adopt-pr]   Decision: <approve|request_changes|block>
 [adopt-pr]   Findings: <N> total (<blockers>, <majors>, <minors>)
-[adopt-pr]   Synthesis: .gc/adopt-pr/reviews/pr-<N>.md
+[adopt-pr]   Synthesis: .gc/adopt-pr/reviews/pr-<PR_NUMBER>.md
 [adopt-pr]   Reviewers: go-reviewer + security-reviewer + code-reviewer + codex:codex-rescue
 ```
 

--- a/pr-review/formulas/mol-adopt-pr.formula.toml
+++ b/pr-review/formulas/mol-adopt-pr.formula.toml
@@ -89,9 +89,15 @@ If false, warn but continue — Phase 6 uses Path C if maintainer changes exist.
 gh pr checkout <number>
 ```
 
-**7. Record state in root bead notes:**
+**7. Record state in root bead notes.**
+
+Multi-line notes must be passed via a heredoc — a literal newline-bearing
+double-quoted string is not safe across shells (leading whitespace can be
+included in the value, and some shells reinterpret embedded `$` differently).
+The canonical pattern used throughout this pack:
 ```bash
-bd update $ROOT_ID --notes "pr_number: <N>
+bd update "$ROOT_ID" --notes "$(cat <<EOF
+pr_number: <PR_NUMBER>
 pr_url: <url>
 repo: <owner/repo>
 pr_title: <title>
@@ -103,13 +109,15 @@ original_head: pending
 rebase_status: pending
 merge_path: undetermined
 skip_gemini: {{skip_gemini}}
-review_run_dir: pending"
+review_run_dir: pending
+EOF
+)"
 ```
 
 **8. Display summary:**
 ```
 [adopt-pr] Intake complete
-[adopt-pr]   PR #<N>: "<title>"
+[adopt-pr]   PR #<PR_NUMBER>: "<title>"
 [adopt-pr]   Author: <author.login>
 [adopt-pr]   Base: <baseRefName> <- Head: <headRefName>
 [adopt-pr]   Stats: +<additions> -<deletions> across <changedFiles> files
@@ -209,26 +217,29 @@ consensus. This is the incoming-PR-side counterpart to mol-pr-ship's
 review-iterate stage — same Agent Teams mechanism, different scope
 (one-shot review producing a synthesis artifact for the human-gate step).
 
-Resolve the root bead ID (used by the env-gate and the notes
-recorded below), then verify CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1
-in your env (configured at agent.toml level for the polecat pool):
+**1. Resolve root bead + env-gate.**
 
-    ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
-    [[ "$CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS" = "1" ]] || {
-        bd update "$ROOT_ID" --notes "review_mode: blocked-env-missing"
-        echo "review blocked: CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS not set in env"
-        exit 2
-    }
+Resolve `ROOT_ID` first (the env-gate's `bd update` needs it), then verify
+`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` in your env (configured at
+agent.toml level for the polecat pool):
+```bash
+ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+[[ "$CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS" = "1" ]] || {
+    bd update "$ROOT_ID" --notes "review_mode: blocked-env-missing"
+    echo "review blocked: CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS not set in env"
+    exit 2
+}
+```
 
-**1. Read root bead notes:**
+**2. Read root bead notes:**
 
 Extract `pr_number`, `repo`, `base_branch`, `skip_gemini` from the
-notes on `$ROOT_ID` (already resolved above).
+notes on `$ROOT_ID` (already resolved in step 1).
 
-**2. Fetch canonical upstream base + prepare diff context:**
+**3. Fetch canonical upstream base + prepare diff context:**
 
 Use `mktemp` so concurrent runs against the same PR number from
-different repos/users don't collide on `/tmp/adopt-pr-<N>.patch`.
+different repos/users don't collide on `/tmp/adopt-pr-<PR_NUMBER>.patch`.
 The path is recorded in the root bead notes so the synthesis step
 can find it:
 
@@ -240,7 +251,7 @@ gh pr diff $pr_number --repo <owner>/<repo> > "$DIFF_PATH"
 bd update "$ROOT_ID" --notes "review_team_patch_path: $DIFF_PATH"
 ```
 
-**3. Create the agent team with a natural-language spawn instruction.**
+**4. Create the agent team with a natural-language spawn instruction.**
 
 Use the "competing hypotheses" pattern from the Agent Teams docs:
 
@@ -274,7 +285,7 @@ Use the "competing hypotheses" pattern from the Agent Teams docs:
     validations (if applicable), new findings with severity + source
     attribution + suggested fixes, and a category coverage summary.
 
-**4. Save artifact path on root bead.** Use a heredoc so the
+**5. Save artifact path on root bead.** Use a heredoc so the
 multi-line note doesn't pick up unintended leading whitespace when
 copy-pasted:
 
@@ -287,7 +298,7 @@ EOF
 )"
 ```
 
-**5. Present findings summary to orient the human reviewer:**
+**6. Present findings summary to orient the human reviewer:**
 
 ```
 [adopt-pr] Multi-agent review complete (Agent Teams)
@@ -297,7 +308,7 @@ EOF
 [adopt-pr]   Reviewers: go-reviewer + security-reviewer + code-reviewer + codex:codex-rescue
 ```
 
-**6. Clean up the team before exiting the step.** Tell the lead to "Clean
+**7. Clean up the team before exiting the step.** Tell the lead to "Clean
 up the team" — always cleanup via the lead, never via a teammate (per
 Agent Teams docs warning).
 
@@ -314,7 +325,7 @@ with 4 calls), synthesize without the debate phase, and note
 degraded but functional.
 
 **Exit criteria:** Review complete, synthesis written to
-`.gc/adopt-pr/reviews/pr-<N>.md`, root bead notes updated with the path."""
+`.gc/adopt-pr/reviews/pr-<PR_NUMBER>.md`, root bead notes updated with the path."""
 
 [[steps]]
 id = "human-gate"

--- a/pr-review/formulas/mol-adopt-pr.formula.toml
+++ b/pr-review/formulas/mol-adopt-pr.formula.toml
@@ -198,62 +198,112 @@ Update notes with:
 
 [[steps]]
 id = "review"
-title = "Run multi-model review"
+title = "Run multi-agent adversarial review via Agent Teams"
 needs = ["rebase-check"]
 description = """
-Fetch the canonical upstream base and invoke the multi-model review engine.
+Run multi-agent adversarial review via Claude Code Agent Teams. The
+polecat (you) is the team lead; you spawn 3-4 reviewer teammates
+referencing existing subagent definitions, then conduct a structured
+debate where teammates challenge each other's findings before reporting
+consensus. This is the incoming-PR-side counterpart to mol-pr-ship's
+review-iterate stage — same Agent Teams mechanism, different scope
+(one-shot review producing a synthesis artifact for the human-gate step).
+
+Requires CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 in your env (configured
+at agent.toml level for the polecat pool). Verify before spawning:
+
+    [[ "$CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS" = "1" ]] || {
+        bd update "$ROOT_ID" --notes "review_mode: blocked-env-missing"
+        echo "review blocked: CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS not set in env"
+        exit 2
+    }
 
 **1. Read root bead notes:**
+
 ```bash
 ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
 ```
 Extract `pr_number`, `repo`, `base_branch`, `skip_gemini` from notes.
 
-**2. Fetch canonical upstream base:**
+**2. Fetch canonical upstream base + prepare diff context:**
+
 ```bash
 UPSTREAM_URL="https://github.com/<owner>/<repo>.git"
 git fetch "$UPSTREAM_URL" <base_branch>:refs/adopt-pr/upstream-base
+DIFF_PATH=/tmp/adopt-pr-${pr_number}.patch
+gh pr diff $pr_number --repo <owner>/<repo> > "$DIFF_PATH"
 ```
 
-**3. Invoke /review-pr:**
-```
-/review-pr <pr_number>
-```
-If `skip_gemini` is "true", append `--skip-gemini`:
-```
-/review-pr <pr_number> --skip-gemini
-```
+**3. Create the agent team with a natural-language spawn instruction.**
 
-**CRITICAL:** When the review completes and asks whether to post the comment
-to GitHub, **DECLINE** (do not post). The finalize step posts its own
-synthesized comment.
+Use the "competing hypotheses" pattern from the Agent Teams docs:
 
-**4. Save the run_dir:**
+    Create an agent team to adversarially review incoming PR <PR_NUMBER>
+    for regression risk. Spawn 4 reviewer teammates by name, each
+    referencing an existing subagent definition:
 
-After the review completes, note the run_dir path from the output.
-Update root bead notes:
+      - reviewer-go using go-reviewer agent type
+      - reviewer-sec using security-reviewer agent type
+      - reviewer-code using code-reviewer agent type
+      - reviewer-codex using codex:codex-rescue agent type
+
+    Each teammate reads /tmp/adopt-pr-<PR_NUMBER>.patch and reviews
+    against the 11-category rubric (Behavioral Correctness, Contract
+    Fidelity, Change Impact / Blast Radius, Concurrency, Error Handling,
+    Security, Resource Lifecycle, Release Safety, Test Evidence,
+    Architectural Consistency, Debuggability) with severity
+    (blocker/major/minor/nit) + confidence (high/medium/low).
+
+    After each teammate produces an initial review, have them CHALLENGE
+    each other's blocker and major findings directly via teammate
+    messaging — like a scientific debate. Each teammate attempts to
+    disprove the others' high-severity flags. The review that survives
+    debate is the final report.
+
+    Lead (you, polecat) waits for all teammates to finish the debate
+    phase, synthesizes the post-debate consensus, and writes a single
+    decision artifact at .gc/adopt-pr/reviews/pr-<PR_NUMBER>.md
+    containing: decision (approve/request_changes/block), fix
+    validations (if applicable), new findings with severity + source
+    attribution + suggested fixes, and a category coverage summary.
+
+**4. Save artifact path on root bead:**
+
 ```bash
+SYNTHESIS_PATH=".gc/adopt-pr/reviews/pr-${pr_number}.md"
 bd update $ROOT_ID --notes "<existing notes>
-review_run_dir: <run_dir_path>"
+review_synthesis_path: $SYNTHESIS_PATH
+review_team_completed_at: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
 ```
 
-The synthesis artifact is at `<run_dir>/outputs/synthesis.md`.
-
-**5. Present findings summary:**
-
-Read the synthesis and present a brief summary to orient the human reviewer:
-- Decision (approve/request_changes)
-- Top findings by severity
-- Key files affected
+**5. Present findings summary to orient the human reviewer:**
 
 ```
-[adopt-pr] Review complete
-[adopt-pr]   Decision: <approve|request_changes>
+[adopt-pr] Multi-agent review complete (Agent Teams)
+[adopt-pr]   Decision: <approve|request_changes|block>
 [adopt-pr]   Findings: <N> total (<blockers>, <majors>, <minors>)
-[adopt-pr]   Run dir: <path>
+[adopt-pr]   Synthesis: .gc/adopt-pr/reviews/pr-<N>.md
+[adopt-pr]   Reviewers: go-reviewer + security-reviewer + code-reviewer + codex:codex-rescue
 ```
 
-**Exit criteria:** Review complete, findings presented, run_dir saved in notes."""
+**6. Clean up the team before exiting the step.** Tell the lead to "Clean
+up the team" — always cleanup via the lead, never via a teammate (per
+Agent Teams docs warning).
+
+**CRITICAL:** Do NOT post the synthesis as a PR comment here. The finalize
+step posts its own synthesized comment after the human-gate closes.
+
+## Fallback
+
+If agent teams cannot be created in this session (env var unset, version
+mismatch, lead-already-managing-a-team), fall back to spawning the same
+4 reviewers as standalone parallel subagents (single Agent tool message
+with 4 calls), synthesize without the debate phase, and note
+`review_mode: subagent-fallback` on the bead. Subagent fallback is
+degraded but functional.
+
+**Exit criteria:** Review complete, synthesis written to
+`.gc/adopt-pr/reviews/pr-<N>.md`, root bead notes updated with the path."""
 
 [[steps]]
 id = "human-gate"


### PR DESCRIPTION
## Summary

Rewrites the review step in two PR-pipeline formulas to use Claude Code's experimental Agent Teams mechanism for adversarial multi-agent review:

- `mol-pr-ship` (outgoing pre-push gate) — the `review-iterate` stage
- `mol-adopt-pr` (incoming-PR review/merge) — the `review` stage

The polecat (formula runner) becomes the team lead and spawns 3-4 reviewer teammates referencing existing subagent definitions: `go-reviewer`, `security-reviewer`, `code-reviewer`, and `codex:codex-rescue`. Teammates conduct a structured debate where they challenge each other's findings before reporting consensus.

## Why

The previous single-reviewer pattern is a single point of failure — a blind spot in one model becomes a missed finding in the review. Empirically, `codex:codex-rescue` consistently catches majors that all 3 Claude-family reviewers miss; keeping it in every review team as the adversarial element raises the floor on what slips through.

This has been driving the ds-research workspace's PR pipeline for ~24 hours. PRs #1989 (incoming, brandonmartin) and #2072 (outgoing, our #2021 take-the-good) both shipped through full multi-fixup chains via this flow with no regressions.

## Requirements

Polecat pools (or any consumer agent) must set `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` in their env. The formula verifies the var before spawning the team and halts cleanly with `review_mode: blocked-env-missing` notes if it's unset.

## Diff scope

```
 pr-pipeline/formulas/mol-pr-ship.formula.toml | 123 +++++++++++++++---------
 pr-review/formulas/mol-adopt-pr.formula.toml  | 110 ++++++++++++++-------
 2 files changed, 163 insertions(+), 70 deletions(-)
```

Only the review step changes in each formula. Iteration scaffolding, notes recording, blocker/major/minor classification, and the downstream human-gate step are all preserved unchanged.

## Test plan

- [ ] Polecat pool with `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` runs `mol-pr-ship` on a staged branch and lands a 4-reviewer adversarial debate in `review_iter_*` notes
- [ ] Polecat pool with the env var unset runs `mol-pr-ship` and halts at the env check with `review_mode: blocked-env-missing`
- [ ] Same two scenarios for `mol-adopt-pr` review step
- [ ] Iteration cap (3) still applies and converges or halts at iter 3 with `blocked — review not converging`
