### PR TITLE
Fix tmux theme status badges

### DIFF
--- a/tmux-theme/README.md
+++ b/tmux-theme/README.md
@@ -12,8 +12,9 @@ a small set of navigation keybindings scoped to GC sessions on the socket.
   10-color palette, chosen by consistent hash of the agent name so the same
   agent always gets the same color. Matches the Go `DefaultPalette` in
   `internal/session/tmux/theme.go`.
-- **Live status-right** — refreshes every 5 seconds via `gc hook` and
-  `gc mail check`; shows pending hooks and unread mail counts per agent.
+- **Live status-right** — refreshes every 5 seconds with bounded read-only
+  Beads queries; shows pending hook nudges and unread mail counts per agent
+  without blocking tmux status rendering.
 - **Prefix keybindings** — `n` / `p` cycle through related agent sessions
   (rig ops, rig crew, town group, dog pool), `g` opens a popup menu of all
   agent sessions on the socket.
@@ -32,7 +33,8 @@ through a `gcmux` wrapper so per-city socket isolation keeps working.
 source = "../packs/tmux-theme"
 ```
 
-No prerequisites beyond `tmux` itself, which Gas City already requires.
+Requires `tmux`, `bd`, and `jq`, which Gas City local development lanes
+already install.
 
 ## Keybindings
 

--- a/tmux-theme/scripts/bind-key.sh
+++ b/tmux-theme/scripts/bind-key.sh
@@ -21,9 +21,10 @@ guard_pattern="${3:-GC_AGENT}"
 
 [ -z "$key" ] || [ -z "$gc_command" ] && exit 1
 
-# Check if already a GC binding (idempotent).
+# Check if already a GC binding (idempotent). Theme bindings are installed as
+# run-shell wrappers, so they may not contain a literal `gc ` command string.
 existing=$(gcmux list-keys -T prefix "$key" 2>/dev/null || true)
-if printf '%s' "$existing" | grep -q 'if-shell' && printf '%s' "$existing" | grep -q 'gc '; then
+if printf '%s' "$existing" | grep -q 'if-shell' && printf '%s' "$existing" | grep -Eq 'GC_AGENT|agent-menu\.sh|cycle\.sh'; then
     exit 0
 fi
 

--- a/tmux-theme/scripts/status-line.sh
+++ b/tmux-theme/scripts/status-line.sh
@@ -5,15 +5,44 @@
 # Always exits 0 — tmux must never see errors.
 
 agent="$1"
+city="${2:-${GC_CITY:-${GT_ROOT:-${GC_DIR:-}}}}"
 [ -z "$agent" ] && exit 0
 
-# Count pending work items (non-empty lines from gc hook).
-w=$(gc hook "$agent" 2>/dev/null | grep -c . || true)
+if [ -n "$city" ] && [ -d "$city" ]; then
+    cd "$city" 2>/dev/null || true
+fi
 
-# Count unread mail (first word of gc mail check output is the count).
-m=$(gc mail check "$agent" 2>/dev/null | awk '{print $1+0}' || true)
+run_bounded() {
+    if command -v timeout >/dev/null 2>&1; then
+        timeout 2s "$@"
+    else
+        "$@"
+    fi
+}
+
+json_array_count() {
+    if ! command -v jq >/dev/null 2>&1; then
+        printf '0'
+        return 0
+    fi
+
+    n=$(run_bounded "$@" 2>/dev/null | jq 'length' 2>/dev/null || true)
+    case "$n" in
+        ''|*[!0-9]*) printf '0' ;;
+        *) printf '%s' "$n" ;;
+    esac
+}
+
+# Count pending hook nudges with a bounded read-only Beads query. `gc hook`
+# can block long enough for tmux to suppress status output.
+w=$(json_array_count bd list --include-infra --label gc:nudge --status open --metadata-field "agent=$agent" --json --limit 0)
+
+# Count unread/open message beads with a bounded read-only Beads query.
+# `gc mail check` can be too slow for tmux status-right refreshes.
+m=$(json_array_count bd list --include-infra --type message --status open --assignee "$agent" --json --limit 0)
 
 # Format: agent | hook-icon N | mail-icon N  (omit segments that are 0)
 printf '%s' "$agent"
 [ "${w:-0}" -gt 0 ] && printf ' | 🪝 %d' "$w"
 [ "${m:-0}" -gt 0 ] && printf ' | 📬 %d' "$m"
+exit 0

--- a/tmux-theme/scripts/tmux-theme.sh
+++ b/tmux-theme/scripts/tmux-theme.sh
@@ -28,6 +28,7 @@ idx=$(printf '%s' "$AGENT" | cksum | awk "{print \$1 % $# + 1}")
 eval "theme=\${$idx}"
 bg="${theme%%:*}"
 fg="${theme##*:}"
+city="${GC_CITY:-${GT_ROOT:-${GC_DIR:-}}}"
 
 # ── Apply theme ─────────────────────────────────────────────────────────
 gcmux set-option -t "$SESSION" status-position bottom
@@ -36,7 +37,11 @@ gcmux set-option -t "$SESSION" status-left-length 25
 gcmux set-option -t "$SESSION" status-left " $AGENT "
 gcmux set-option -t "$SESSION" status-right-length 80
 gcmux set-option -t "$SESSION" status-interval 5
-gcmux set-option -t "$SESSION" status-right "#($CONFIGDIR/scripts/status-line.sh $AGENT) %H:%M"
+if [ -n "$city" ]; then
+    gcmux set-option -t "$SESSION" status-right "#($CONFIGDIR/scripts/status-line.sh $AGENT $city) %H:%M"
+else
+    gcmux set-option -t "$SESSION" status-right "#($CONFIGDIR/scripts/status-line.sh $AGENT) %H:%M"
+fi
 
 # ── Mouse + clipboard ─────────────────────────────────────────────────
 gcmux set-option -t "$SESSION" mouse on

--- a/tmux-theme/tests/test_tmux_theme_scripts.sh
+++ b/tmux-theme/tests/test_tmux_theme_scripts.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "${TMPDIR}"' EXIT
+
+fail() {
+  printf 'not ok - %s\n' "$*" >&2
+  exit 1
+}
+
+assert_eq() {
+  local want="$1"
+  local got="$2"
+  local label="$3"
+  [[ "${got}" == "${want}" ]] || fail "${label}: expected [${want}], got [${got}]"
+}
+
+mkdir -p "${TMPDIR}/bin"
+
+cat >"${TMPDIR}/bin/timeout" <<'STUB_TIMEOUT'
+#!/bin/sh
+shift
+exec "$@"
+STUB_TIMEOUT
+
+cat >"${TMPDIR}/bin/bd" <<'STUB_BD'
+#!/bin/sh
+printf '%s\n' "$*" >> "${TMUX_THEME_TEST_BD_ARGS}"
+pwd >> "${TMUX_THEME_TEST_BD_PWD}"
+case "$*" in
+  *"--label gc:nudge"*)
+    printf '[{"id":"n1"},{"id":"n2"}]\n'
+    ;;
+  *"--type message"*)
+    printf '[{"id":"m1"}]\n'
+    ;;
+  *)
+    printf '[]\n'
+    ;;
+esac
+STUB_BD
+
+chmod +x "${TMPDIR}/bin/timeout" "${TMPDIR}/bin/bd"
+
+TMUX_THEME_TEST_BD_ARGS="${TMPDIR}/bd.args"
+TMUX_THEME_TEST_BD_PWD="${TMPDIR}/bd.pwd"
+export TMUX_THEME_TEST_BD_ARGS
+export TMUX_THEME_TEST_BD_PWD
+mkdir -p "${TMPDIR}/city"
+status_output="$(PATH="${TMPDIR}/bin:${PATH}" "${ROOT}/scripts/status-line.sh" ora_gascity.mayor "${TMPDIR}/city")"
+assert_eq "ora_gascity.mayor | 🪝 2 | 📬 1" "${status_output}" "status-line renders hook and mail badges"
+
+grep -F -- '--label gc:nudge --status open --metadata-field agent=ora_gascity.mayor --json --limit 0' "${TMUX_THEME_TEST_BD_ARGS}" >/dev/null \
+  || fail "status-line should query hook nudges through bd"
+grep -F -- '--type message --status open --assignee ora_gascity.mayor --json --limit 0' "${TMUX_THEME_TEST_BD_ARGS}" >/dev/null \
+  || fail "status-line should query unread mail through bd"
+grep -Fx "${TMPDIR}/city" "${TMUX_THEME_TEST_BD_PWD}" >/dev/null \
+  || fail "status-line should run Beads queries from the provided city path"
+
+cat >"${TMPDIR}/bin/jq" <<'STUB_JQ_FAIL'
+#!/bin/sh
+exit 1
+STUB_JQ_FAIL
+chmod +x "${TMPDIR}/bin/jq"
+fallback_output="$(PATH="${TMPDIR}/bin:${PATH}" "${ROOT}/scripts/status-line.sh" ora_gascity.mayor)"
+assert_eq "ora_gascity.mayor" "${fallback_output}" "status-line suppresses badges when JSON count fails"
+rm -f "${TMPDIR}/bin/jq"
+
+cat >"${TMPDIR}/bin/tmux" <<'STUB_TMUX_IDEMPOTENT'
+#!/bin/sh
+case "$*" in
+  *"list-keys -T prefix n"*)
+    printf "%s\n" "bind-key -T prefix n if-shell \"tmux -L city show-environment -t '#{session_name}' GC_AGENT >/dev/null 2>&1\" \"run-shell '/tmp/tmux-theme/scripts/cycle.sh next #{session_name} #{client_tty}'\" next-window"
+    ;;
+  *"bind-key"*)
+    printf '%s\n' "$*" >> "${TMUX_THEME_TEST_TMUX_BINDS}"
+    ;;
+esac
+STUB_TMUX_IDEMPOTENT
+chmod +x "${TMPDIR}/bin/tmux"
+
+TMUX_THEME_TEST_TMUX_BINDS="${TMPDIR}/tmux.binds"
+export TMUX_THEME_TEST_TMUX_BINDS
+PATH="${TMPDIR}/bin:${PATH}" "${ROOT}/scripts/bind-key.sh" n "run-shell '/tmp/tmux-theme/scripts/cycle.sh next #{session_name} #{client_tty}'"
+[[ ! -s "${TMUX_THEME_TEST_TMUX_BINDS}" ]] || fail "bind-key should not wrap an existing theme run-shell binding"
+
+cat >"${TMPDIR}/bin/tmux" <<'STUB_TMUX_BIND'
+#!/bin/sh
+case "$*" in
+  *"list-keys -T prefix x"*)
+    printf "%s\n" "bind-key -T prefix x display-message fallback"
+    ;;
+  *"bind-key"*)
+    printf '%s\n' "$*" >> "${TMUX_THEME_TEST_TMUX_BINDS}"
+    ;;
+esac
+STUB_TMUX_BIND
+chmod +x "${TMPDIR}/bin/tmux"
+
+: >"${TMUX_THEME_TEST_TMUX_BINDS}"
+PATH="${TMPDIR}/bin:${PATH}" "${ROOT}/scripts/bind-key.sh" x "run-shell '/tmp/tmux-theme/scripts/agent-menu.sh #{client_tty}'"
+grep -F 'bind-key -T prefix x if-shell' "${TMUX_THEME_TEST_TMUX_BINDS}" >/dev/null \
+  || fail "bind-key should install a theme binding when no theme binding exists"
+
+printf 'tmux-theme-script-tests=passed\n'


### PR DESCRIPTION
## Summary
Make the tmux-theme status helper fast and reliable by replacing slow status-bar calls to `gc hook` and `gc mail check` with bounded read-only Beads counts. Also make prefix keybinding setup idempotent for the pack's run-shell bindings.

## What changed
- `status-line.sh` now uses bounded `bd list --json --limit 0` queries for open nudges and messages.
- The helper exits 0 even when there are no badges or count queries fail.
- `tmux-theme.sh` passes the active city path to the status helper so tmux `#()`
  refreshes do not depend on the tmux server's cwd.
- `bind-key.sh` detects existing theme run-shell bindings instead of looking only for a literal `gc ` command.
- Added focused shell tests for badge rendering, fallback behavior, and idempotent binding setup.
- Updated README prerequisites/status wording.

## Validation
- `bash -n tmux-theme/scripts/status-line.sh tmux-theme/scripts/bind-key.sh tmux-theme/scripts/tmux-theme.sh tmux-theme/tests/test_tmux_theme_scripts.sh`
- `bash tmux-theme/tests/test_tmux_theme_scripts.sh`
- `git diff --check`

## Context
This avoids requiring downstream bootstrap scripts to rewrite the imported tmux-theme pack after materialization.
