### PR TITLE
feat(slack-pack): route Slack User Group mentions as address-by-handle

### DIFF
--- a/slack-pack/README.md
+++ b/slack-pack/README.md
@@ -289,6 +289,7 @@ package docstring at the top of that file. Summary:
 | `HANDLE_PREFIX`                | `@`                                              | Leading address token for keyword routing. Empty disables routing.              |
 | `IDENTITY_STORE_PATH`          | `/tmp/gc-slack-adapter/identities.json`          | JSON file backing the per-session `chat:write.customize` identity registry.    |
 | `HANDLE_ALIAS_STORE_PATH`      | `/tmp/gc-slack-adapter/handle-aliases.json`      | JSON file backing the cross-channel handle → session-id alias registry.        |
+| `SLACK_SUBTEAM_ALIAS_FILE`     | `<GC_CITY_PATH>/.gc/slack/subteam-aliases.json` (or `/tmp/gc-slack-adapter/subteam-aliases.json`) | Operator-edited JSON map of Slack User Group ("subteam") IDs → gc handles. Required to route the unlabeled `<!subteam^Sxxx>` mention shape; the labeled `<!subteam^Sxxx|@handle>` shape is gated by `HANDLE_ALIAS_STORE_PATH` instead. Read-only at runtime; SIGHUP or restart to reload. |
 | `INBOUND_FILE_STORE`           | `/tmp/gc-slack-adapter/inbound`                  | Directory for downloaded inbound Slack file attachments.                        |
 | `INBOUND_FILE_TTL`             | `168h` (7 days)                                  | Janitor retention. `0` disables sweeping.                                       |
 | `INBOUND_FILE_SWEEP_INTERVAL`  | `1h`                                             | Janitor scan period. `0` disables sweeping.                                     |

--- a/slack-pack/adapter/double_handle_dispatch_test.go
+++ b/slack-pack/adapter/double_handle_dispatch_test.go
@@ -102,7 +102,7 @@ func TestProcessSlackEventDoubleHandleUnclaimedEmitsLauncherEphemeral(t *testing
 
 	var releases int32
 	release := func() { atomic.AddInt32(&releases, 1) }
-	processSlackEvent(cfg, aliasReg, threadReg, nil, env, release)
+	processSlackEvent(cfg, aliasReg, threadReg, nil, nil, env, release)
 
 	// One ephemeral POST must land within a short deadline.
 	select {
@@ -186,7 +186,7 @@ func TestProcessSlackEventDoubleHandlePreClaimedEmitsBoundEphemeral(t *testing.T
 	env := slackEventEnvelope{Type: "event_callback", Event: rawMsg}
 
 	release := func() {}
-	processSlackEvent(cfg, aliasReg, threadReg, nil, env, release)
+	processSlackEvent(cfg, aliasReg, threadReg, nil, nil, env, release)
 
 	select {
 	case body := <-ephemeralCh:
@@ -257,7 +257,7 @@ func TestProcessSlackEventSingleHandleStillReachesAliasDispatch(t *testing.T) {
 	env := slackEventEnvelope{Type: "event_callback", Event: rawMsg}
 
 	release := func() {}
-	processSlackEvent(cfg, aliasReg, threadReg, nil, env, release)
+	processSlackEvent(cfg, aliasReg, threadReg, nil, nil, env, release)
 
 	select {
 	case path := <-pathCh:
@@ -304,7 +304,7 @@ func TestProcessSlackEventPlainTextUnaffected(t *testing.T) {
 	env := slackEventEnvelope{Type: "event_callback", Event: rawMsg}
 
 	release := func() {}
-	processSlackEvent(cfg, aliasReg, threadReg, nil, env, release)
+	processSlackEvent(cfg, aliasReg, threadReg, nil, nil, env, release)
 
 	if got := atomic.LoadInt32(&inboundHits); got != 1 {
 		t.Errorf("inbound POSTs = %d, want 1 (plain text must still post inbound)", got)
@@ -349,7 +349,7 @@ func TestProcessSlackEventDoubleHandleNilThreadRegistry(t *testing.T) {
 
 	release := func() {}
 	// Must not panic.
-	processSlackEvent(cfg, aliasReg, nil, nil, env, release)
+	processSlackEvent(cfg, aliasReg, nil, nil, nil, env, release)
 }
 
 // TestLoadConfigThreadSessionsStorePathDefaultsCity exercises the
@@ -426,7 +426,7 @@ func TestHandleSlackEventsAcceptsThreadRegistry(t *testing.T) {
 	req := signedSlackEventRequest(t, cfg.slackSigningKey, envBody)
 	w := httptest.NewRecorder()
 
-	handler := handleSlackEvents(cfg, aliasReg, threadReg, nil)
+	handler := handleSlackEvents(cfg, aliasReg, threadReg, nil, nil)
 	handler(w, req)
 
 	// Slack ack happens before downstream work, regardless of gc reachability.

--- a/slack-pack/adapter/main.go
+++ b/slack-pack/adapter/main.go
@@ -323,6 +323,21 @@ type config struct {
 	// <GC_CITY_PATH>/.gc/slack/rig_mappings.json when GC_CITY_PATH is
 	// set, else /tmp/gc-slack-adapter/rig_mappings.json.
 	rigMappingPath string
+	// subteamAliasStorePath is the JSON file mapping Slack User Group
+	// ("subteam") IDs (e.g. "S0123ABCD") to gc handles. Read-only on
+	// this side; same SIGHUP-or-restart reload contract as
+	// channelMappingPath. The operator edits the file directly or via a
+	// future `gc slack subteam-alias` command. The map is the ONLY gate
+	// for the UNLABELED subteam mention shape `<!subteam^Sxxx>` Slack
+	// emits in event payloads — without an entry the inbound falls
+	// through to channel fanout. The LABELED shape
+	// `<!subteam^Sxxx|@handle>` remains gated by handleAliasRegistry
+	// against the `@handle` label (bead gpk-2zi). Sourced from
+	// SLACK_SUBTEAM_ALIAS_FILE, defaulting to
+	// <GC_CITY_PATH>/.gc/slack/subteam-aliases.json when GC_CITY_PATH
+	// is set, else /tmp/gc-slack-adapter/subteam-aliases.json. Bead
+	// gpk-hmr.2.
+	subteamAliasStorePath string
 	// fileUploadRoot is the absolute filesystem prefix
 	// /publish-file is allowed to read. Empty disables /publish-file
 	// entirely (fail-closed). gc and the adapter share a filesystem,
@@ -450,12 +465,14 @@ func loadConfigFromEnv(getenv func(string) string) (config, error) {
 	defaultAppsRegistryPath := "/tmp/gc-slack-adapter/apps.json"
 	defaultThreadSessionsPath := "/tmp/gc-slack-adapter/thread_sessions.json"
 	defaultRoomLaunchPath := "/tmp/gc-slack-adapter/room_launch_mappings.json"
+	defaultSubteamAliasPath := "/tmp/gc-slack-adapter/subteam-aliases.json"
 	if cityPath := getenv("GC_CITY_PATH"); cityPath != "" {
 		defaultMappingPath = filepath.Join(cityPath, ".gc", "slack", "channel_mappings.json")
 		defaultRigMappingPath = filepath.Join(cityPath, ".gc", "slack", "rig_mappings.json")
 		defaultAppsRegistryPath = filepath.Join(cityPath, ".gc", "slack", "apps.json")
 		defaultThreadSessionsPath = filepath.Join(cityPath, ".gc", "slack", "thread_sessions.json")
 		defaultRoomLaunchPath = filepath.Join(cityPath, ".gc", "slack", "room_launch_mappings.json")
+		defaultSubteamAliasPath = filepath.Join(cityPath, ".gc", "slack", "subteam-aliases.json")
 		cfg.cityPath = cityPath
 	}
 	cfg.channelMappingPath = envOrFn("SLACK_CHANNEL_MAPPING_PATH", defaultMappingPath)
@@ -467,6 +484,7 @@ func loadConfigFromEnv(getenv func(string) string) (config, error) {
 	cfg.oauthSlackBaseURL = getenv("SLACK_OAUTH_BASE_URL")
 	cfg.threadSessionsStorePath = envOrFn("GC_SLACK_THREAD_SESSIONS_FILE", defaultThreadSessionsPath)
 	cfg.roomLaunchPath = envOrFn("GC_SLACK_ROOM_LAUNCH_FILE", defaultRoomLaunchPath)
+	cfg.subteamAliasStorePath = envOrFn("SLACK_SUBTEAM_ALIAS_FILE", defaultSubteamAliasPath)
 
 	// Retention controls. Defaults: keep inbound files for 7 days,
 	// sweep every hour. Setting either to "0" disables the janitor.
@@ -925,6 +943,13 @@ func main() {
 	log.Printf("room launch mapping registry: store=%s (read-only; SIGHUP or restart to reload)",
 		cfg.roomLaunchPath)
 
+	subteamAliases, err := newSubteamAliasMap(cfg.subteamAliasStorePath)
+	if err != nil {
+		log.Fatalf("subteam alias map: %v", err)
+	}
+	log.Printf("subteam alias map: store=%s entries=%d (read-only; SIGHUP or restart to reload)",
+		cfg.subteamAliasStorePath, subteamAliases.Len())
+
 	channelMapReg, err := newChannelMappingRegistry(cfg.channelMappingPath)
 	if err != nil {
 		log.Fatalf("channel mapping registry: %v", err)
@@ -961,7 +986,7 @@ func main() {
 	// (HMAC-verified) and /healthz. Bound to 0.0.0.0 by default so
 	// Tailscale Funnel can reach it.
 	publicMux := http.NewServeMux()
-	publicMux.HandleFunc("/slack/events", handleSlackEvents(cfg, aliasReg, threadReg, roomLaunchReg))
+	publicMux.HandleFunc("/slack/events", handleSlackEvents(cfg, aliasReg, threadReg, roomLaunchReg, subteamAliases))
 	publicMux.HandleFunc("/slack/interactions", handleSlackInteractions(cfg, channelMapReg, rigMapReg))
 	registerOAuthHandlers(publicMux, cfg, appsReg)
 	publicMux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
@@ -1058,7 +1083,7 @@ func main() {
 	signal.Notify(hupCh, syscall.SIGHUP)
 	defer signal.Stop(hupCh)
 	go runReloadLoop(reloadStop, hupCh, func() {
-		logReloadOutcome(appsReg, channelMapReg, rigMapReg, roomLaunchReg)
+		logReloadOutcome(appsReg, channelMapReg, rigMapReg, roomLaunchReg, subteamAliases)
 	})
 
 	stop := make(chan os.Signal, 1)
@@ -1691,7 +1716,7 @@ func postToSlack(token string, req slackPostMessageReq) (*slackPostMessageResp, 
 	return &sr, nil
 }
 
-func handleSlackEvents(cfg config, aliasReg *handleAliasRegistry, threadReg *threadSessionRegistry, roomLaunchReg *roomLaunchMappingRegistry) http.HandlerFunc {
+func handleSlackEvents(cfg config, aliasReg *handleAliasRegistry, threadReg *threadSessionRegistry, roomLaunchReg *roomLaunchMappingRegistry, subteamMap *subteamAliasMap) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -1746,7 +1771,7 @@ func handleSlackEvents(cfg config, aliasReg *handleAliasRegistry, threadReg *thr
 		// cfg.dispatchSem when an inbound triggers an alias dispatch (which
 		// would otherwise hold two slots concurrently — see gc-cby.26
 		// Phase 4 review fix).
-		go processSlackEvent(cfg, aliasReg, threadReg, roomLaunchReg, env, release)
+		go processSlackEvent(cfg, aliasReg, threadReg, roomLaunchReg, subteamMap, env, release)
 	}
 }
 
@@ -1860,7 +1885,7 @@ func slackKindFromChannelType(channelType, channelID string) string {
 // in tests or in deployments that disable launcher mode entirely; the
 // `@@<handle>` branch falls through to the regular `@<handle>` path
 // when nil.
-func processSlackEvent(cfg config, aliasReg *handleAliasRegistry, threadReg *threadSessionRegistry, roomLaunchReg *roomLaunchMappingRegistry, env slackEventEnvelope, release func()) {
+func processSlackEvent(cfg config, aliasReg *handleAliasRegistry, threadReg *threadSessionRegistry, roomLaunchReg *roomLaunchMappingRegistry, subteamMap *subteamAliasMap, env slackEventEnvelope, release func()) {
 	released := false
 	defer func() {
 		if !released {
@@ -1903,19 +1928,47 @@ func processSlackEvent(cfg config, aliasReg *handleAliasRegistry, threadReg *thr
 
 	text := msg.Text
 	target := ""
-	// Slack User Group autocomplete (bead gpk-2zi): when a human picks
-	// a workspace User Group from native @-autocomplete whose label
-	// matches a registered handle alias, treat the inbound exactly as
-	// if they had typed `@<handle>:`. The token shape Slack delivers
-	// is `<!subteam^TEAMID|@handle>`. We map by the `@handle` label
-	// only — the adapter does NOT learn TEAMIDs ahead of time. The
-	// aliasReg.Get gate is intentional: a workspace may have other
-	// User Groups whose labels do not correspond to gc handles, and
-	// those must NOT trigger address-by-handle dispatch.
-	if aliasReg != nil {
-		if h, rest, ok := parseSubteamMentionPrefix(msg.Text); ok {
-			if _, aliased := aliasReg.Get(h); aliased {
-				target = h
+	// Slack User Group mentions (beads gpk-2zi + gpk-hmr.2). Slack
+	// delivers two shapes for a User Group mention and both must
+	// normalize to the same address-by-handle dispatch path:
+	//
+	//   Labeled:    <!subteam^TEAMID|@handle>   (autocomplete in text)
+	//   Unlabeled:  <!subteam^TEAMID>           (event-payload form)
+	//
+	// Different gating policy per shape, intentional asymmetry:
+	//
+	//   - LABELED: gated by aliasReg.Get(@handle) — same gate as the
+	//     `@handle:` text-prefix path. The label is in the message
+	//     itself, so the gate prevents arbitrary in-workspace User
+	//     Groups (whose labels happen to look like gc handle names but
+	//     have no registered session) from auto-routing.
+	//
+	//   - UNLABELED: gated by subteamAliasMap.Get(TEAMID) — Slack does
+	//     NOT emit a handle label in this shape, so the operator-edited
+	//     subteam-aliases.json IS the allowlist. A subteam ID with no
+	//     entry in the map falls through to channel fanout. Locked-down
+	//     workspaces without the `usergroups:read` scope still work:
+	//     the map is populated off-band, no Slack API call is made.
+	//
+	// Downstream dispatch (the `if target != "" && aliasReg != nil`
+	// block below) is unchanged — it still gates the cross-channel
+	// session-message POST on aliasReg.Get, so a subteam-ID resolution
+	// to a handle with no registered session yields the channel-bound
+	// session seeing ExplicitTarget but no alias goroutine firing.
+	// That matches the existing `@handle:` text-prefix semantics.
+	if h, sid, rest, ok := parseSubteamMentionPrefix(msg.Text); ok {
+		if h != "" {
+			// Labeled form: preserve gpk-2zi behavior — aliasReg gate.
+			if aliasReg != nil {
+				if _, aliased := aliasReg.Get(h); aliased {
+					target = h
+					text = rest
+				}
+			}
+		} else {
+			// Unlabeled form: subteamAliasMap is the gate.
+			if mappedHandle, mapped := subteamMap.Get(sid); mapped {
+				target = mappedHandle
 				text = rest
 			}
 		}

--- a/slack-pack/adapter/main.go
+++ b/slack-pack/adapter/main.go
@@ -1903,7 +1903,24 @@ func processSlackEvent(cfg config, aliasReg *handleAliasRegistry, threadReg *thr
 
 	text := msg.Text
 	target := ""
-	if cfg.handlePrefix != "" {
+	// Slack User Group autocomplete (bead gpk-2zi): when a human picks
+	// a workspace User Group from native @-autocomplete whose label
+	// matches a registered handle alias, treat the inbound exactly as
+	// if they had typed `@<handle>:`. The token shape Slack delivers
+	// is `<!subteam^TEAMID|@handle>`. We map by the `@handle` label
+	// only — the adapter does NOT learn TEAMIDs ahead of time. The
+	// aliasReg.Get gate is intentional: a workspace may have other
+	// User Groups whose labels do not correspond to gc handles, and
+	// those must NOT trigger address-by-handle dispatch.
+	if aliasReg != nil {
+		if h, rest, ok := parseSubteamMentionPrefix(msg.Text); ok {
+			if _, aliased := aliasReg.Get(h); aliased {
+				target = h
+				text = rest
+			}
+		}
+	}
+	if target == "" && cfg.handlePrefix != "" {
 		if h, rest := parseHandlePrefix(msg.Text, cfg.handlePrefix); h != "" {
 			target = h
 			text = rest

--- a/slack-pack/adapter/main_test.go
+++ b/slack-pack/adapter/main_test.go
@@ -3221,7 +3221,7 @@ func TestProcessSlackEventReleasesSlotOnNoAliasPath(t *testing.T) {
 
 	var releases int32
 	release := func() { atomic.AddInt32(&releases, 1) }
-	processSlackEvent(cfg, aliasReg, nil, nil, env, release)
+	processSlackEvent(cfg, aliasReg, nil, nil, nil, env, release)
 
 	if got := atomic.LoadInt32(&releases); got != 1 {
 		t.Errorf("release fired %d times on no-alias path; want exactly 1", got)
@@ -3268,7 +3268,7 @@ func TestProcessSlackEventTransfersSlotToAliasGoroutine(t *testing.T) {
 
 	var releases int32
 	release := func() { atomic.AddInt32(&releases, 1) }
-	processSlackEvent(cfg, aliasReg, nil, nil, env, release)
+	processSlackEvent(cfg, aliasReg, nil, nil, nil, env, release)
 
 	// The alias goroutine runs after processSlackEvent returns; wait
 	// for the dispatch to land on the gc stub.
@@ -3344,7 +3344,7 @@ func TestHandleSlackEventsDropsWhenSemaphoreFull(t *testing.T) {
 	req.Header.Set("X-Slack-Signature", sig)
 	w := httptest.NewRecorder()
 
-	handleSlackEvents(cfg, aliasReg, nil, nil)(w, req)
+	handleSlackEvents(cfg, aliasReg, nil, nil, nil)(w, req)
 
 	// Slack always sees 200 (we ack quickly to suppress retries).
 	if w.Result().StatusCode != http.StatusOK {
@@ -3523,7 +3523,7 @@ func TestSlackEventsPerAppSignatureLookup(t *testing.T) {
 	req := signedSlackEventRequest(t, "secret-a2", envBody)
 	w := httptest.NewRecorder()
 
-	handleSlackEvents(cfg, aliasReg, nil, nil)(w, req)
+	handleSlackEvents(cfg, aliasReg, nil, nil, nil)(w, req)
 
 	if w.Result().StatusCode != http.StatusOK {
 		t.Errorf("status = %d, want 200 (per-app lookup must verify with A2's secret)", w.Result().StatusCode)
@@ -3563,7 +3563,7 @@ func TestSlackEventsRegistryMissUsesEnvFallback(t *testing.T) {
 	req := signedSlackEventRequest(t, "env-fallback", envBody)
 	w := httptest.NewRecorder()
 
-	handleSlackEvents(cfg, aliasReg, nil, nil)(w, req)
+	handleSlackEvents(cfg, aliasReg, nil, nil, nil)(w, req)
 
 	if w.Result().StatusCode != http.StatusOK {
 		t.Errorf("status = %d, want 200 (env fallback must verify when registry misses)", w.Result().StatusCode)
@@ -3590,7 +3590,7 @@ func TestSlackEventsNoSecretRejects401(t *testing.T) {
 	req := signedSlackEventRequest(t, "anything", envBody)
 	w := httptest.NewRecorder()
 
-	handleSlackEvents(cfg, aliasReg, nil, nil)(w, req)
+	handleSlackEvents(cfg, aliasReg, nil, nil, nil)(w, req)
 	if w.Result().StatusCode != http.StatusUnauthorized {
 		t.Errorf("status = %d, want 401", w.Result().StatusCode)
 	}
@@ -3615,7 +3615,7 @@ func TestSlackEventsMalformedBodyFallsBackToEnv(t *testing.T) {
 	req := signedSlackEventRequest(t, "env-secret", body)
 	w := httptest.NewRecorder()
 
-	handleSlackEvents(cfg, aliasReg, nil, nil)(w, req)
+	handleSlackEvents(cfg, aliasReg, nil, nil, nil)(w, req)
 	// Verify passed (env fallback) but JSON decode of envelope failed.
 	if w.Result().StatusCode != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400 (malformed envelope after env-fallback verify)", w.Result().StatusCode)

--- a/slack-pack/adapter/registry_reload.go
+++ b/slack-pack/adapter/registry_reload.go
@@ -92,6 +92,7 @@ func reloadAllRegistries(
 	chans *channelMappingRegistry,
 	rigs *rigMappingRegistry,
 	rooms *roomLaunchMappingRegistry,
+	subteams *subteamAliasMap,
 ) error {
 	var (
 		commits []func()
@@ -120,6 +121,10 @@ func reloadAllRegistries(
 	if rooms != nil {
 		snap, err := rooms.Stage()
 		stage("room launch mapping", err, func() { rooms.Commit(snap) })
+	}
+	if subteams != nil {
+		snap, err := subteams.Stage()
+		stage("subteam alias", err, func() { subteams.Commit(snap) })
 	}
 
 	if len(errs) > 0 {
@@ -159,12 +164,13 @@ func logReloadOutcome(
 	chans *channelMappingRegistry,
 	rigs *rigMappingRegistry,
 	rooms *roomLaunchMappingRegistry,
+	subteams *subteamAliasMap,
 ) {
 	log.Printf("SIGHUP received: reloading slack-pack registries")
-	if err := reloadAllRegistries(apps, chans, rigs, rooms); err != nil {
+	if err := reloadAllRegistries(apps, chans, rigs, rooms, subteams); err != nil {
 		log.Printf("WARN: registry reload failed (live state preserved): %s", scrubAppsRegistryError(err))
 		return
 	}
-	log.Printf("registry reload OK: apps=%d channels=%d rigs=%d rooms=%d",
-		apps.Len(), chans.Len(), rigs.Len(), rooms.Len())
+	log.Printf("registry reload OK: apps=%d channels=%d rigs=%d rooms=%d subteams=%d",
+		apps.Len(), chans.Len(), rigs.Len(), rooms.Len(), subteams.Len())
 }

--- a/slack-pack/adapter/registry_reload_test.go
+++ b/slack-pack/adapter/registry_reload_test.go
@@ -337,7 +337,7 @@ func TestReloadAllRegistriesCommitsAllOnSuccess(t *testing.T) {
 		"T1:C3": {WorkspaceID: "T1", ChannelID: "C3", PoolTemplate: "v1", CreatedAt: f.now, UpdatedAt: f.now},
 	})
 
-	if err := reloadAllRegistries(f.apps, f.chans, f.rigs, f.rooms); err != nil {
+	if err := reloadAllRegistries(f.apps, f.chans, f.rigs, f.rooms, nil); err != nil {
 		t.Fatalf("reloadAllRegistries: %v", err)
 	}
 
@@ -377,7 +377,7 @@ func TestReloadAllRegistriesAbortsOnAnyParseFailure(t *testing.T) {
 		t.Fatalf("write corrupt: %v", err)
 	}
 
-	err := reloadAllRegistries(f.apps, f.chans, f.rigs, f.rooms)
+	err := reloadAllRegistries(f.apps, f.chans, f.rigs, f.rooms, nil)
 	if err == nil {
 		t.Fatal("reloadAllRegistries with one corrupt file: want error")
 	}
@@ -404,7 +404,7 @@ func TestReloadAllRegistriesAggregatesAllErrors(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := reloadAllRegistries(f.apps, f.chans, f.rigs, f.rooms)
+	err := reloadAllRegistries(f.apps, f.chans, f.rigs, f.rooms, nil)
 	if err == nil {
 		t.Fatal("want error")
 	}
@@ -422,7 +422,7 @@ func TestReloadAllRegistriesAllMissingFilesIsNoop(t *testing.T) {
 			t.Fatalf("rm %s: %v", p, err)
 		}
 	}
-	if err := reloadAllRegistries(f.apps, f.chans, f.rigs, f.rooms); err != nil {
+	if err := reloadAllRegistries(f.apps, f.chans, f.rigs, f.rooms, nil); err != nil {
 		t.Fatalf("reloadAllRegistries should be a no-op when all files missing: %v", err)
 	}
 	// All four must keep their seeded state.

--- a/slack-pack/adapter/room_launch_dispatch_test.go
+++ b/slack-pack/adapter/room_launch_dispatch_test.go
@@ -139,7 +139,7 @@ func TestRoomLaunchDispatchSpawnOnMissCreatesSessionAndPostsFirstMessage(t *test
 	env := slackEventEnvelope{Type: "event_callback", Event: rawMsg, TeamID: "T1"}
 
 	var releases int32
-	processSlackEvent(cfg, aliasReg, threadReg, roomReg, env, func() { atomic.AddInt32(&releases, 1) })
+	processSlackEvent(cfg, aliasReg, threadReg, roomReg, nil, env, func() { atomic.AddInt32(&releases, 1) })
 
 	// /v0/sessions POST observed.
 	if got := atomic.LoadInt32(&hits.sessionsCreate); got != 1 {
@@ -245,7 +245,7 @@ func TestRoomLaunchDispatchReuseOnHitSkipsCreateAndPostsToExistingSession(t *tes
 	})
 	env := slackEventEnvelope{Type: "event_callback", Event: rawMsg, TeamID: "T1"}
 
-	processSlackEvent(cfg, aliasReg, threadReg, roomReg, env, func() {})
+	processSlackEvent(cfg, aliasReg, threadReg, roomReg, nil, env, func() {})
 
 	// No /v0/sessions POST on a thread hit.
 	if got := atomic.LoadInt32(&hits.sessionsCreate); got != 0 {
@@ -293,7 +293,7 @@ func TestRoomLaunchDispatchChannelNotEnabledEmitsActionableEphemeral(t *testing.
 	})
 	env := slackEventEnvelope{Type: "event_callback", Event: rawMsg, TeamID: "T1"}
 
-	processSlackEvent(cfg, aliasReg, threadReg, roomReg, env, func() {})
+	processSlackEvent(cfg, aliasReg, threadReg, roomReg, nil, env, func() {})
 
 	if got := atomic.LoadInt32(&hits.sessionsCreate); got != 0 {
 		t.Errorf("/v0/sessions POSTs = %d, want 0", got)
@@ -344,7 +344,7 @@ func TestRoomLaunchDispatchSpawnFailureLeavesRegistryEmpty(t *testing.T) {
 	})
 	env := slackEventEnvelope{Type: "event_callback", Event: rawMsg, TeamID: "T1"}
 
-	processSlackEvent(cfg, aliasReg, threadReg, roomReg, env, func() {})
+	processSlackEvent(cfg, aliasReg, threadReg, roomReg, nil, env, func() {})
 
 	// Registry should NOT cache a failure: AcquireOrCreate's contract
 	// (cby.5.1) returns the create-closure error and does not persist.
@@ -413,7 +413,7 @@ func TestRoomLaunchDispatchSaturationDropsAtOuterSlot(t *testing.T) {
 	req := signedSlackEventRequest(t, cfg.slackSigningKey, envBody)
 	w := httptest.NewRecorder()
 
-	handler := handleSlackEvents(cfg, aliasReg, threadReg, roomReg)
+	handler := handleSlackEvents(cfg, aliasReg, threadReg, roomReg, nil)
 	handler(w, req)
 
 	// Slack always gets 200 (Slack-side retry suppression), but no

--- a/slack-pack/adapter/subteam_alias_map.go
+++ b/slack-pack/adapter/subteam_alias_map.go
@@ -1,0 +1,201 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"sync"
+)
+
+// subteamAliasMap is the read-mostly adapter-side view of the
+// subteam-aliases.json file written by the operator. It maps a Slack
+// User Group ("subteam") ID (e.g. "S0123ABCD") to the gc handle the
+// adapter should treat the mention as addressing.
+//
+// This is the operator-facing counterpart of handleAliasRegistry:
+// where handleAliasRegistry is runtime-mutable via the in-process
+// /handle-alias HTTP endpoint, subteamAliasMap is CLI/operator-edited
+// off-band (file edited directly, or written by a future
+// `gc slack subteam-alias` command) and reloaded on SIGHUP via the
+// same Stage/Commit pattern as channelMappingRegistry,
+// rigMappingRegistry, and roomLaunchMappingRegistry.
+//
+// The map is the ONLY gate for unlabeled subteam mentions
+// (`<!subteam^Sxxx>`) — Slack does not emit a handle label in that
+// shape, so the adapter must resolve `Sxxx` → handle via this map
+// before it can route the inbound through the existing
+// address-by-handle dispatch path. The labeled form
+// `<!subteam^Sxxx|@handle>` is gated separately by aliasReg.Get on
+// the `@handle` label (matching the gpk-2zi behavior). See the
+// processSlackEvent wiring for the full picture.
+//
+// Locked-down Slack apps that lack the `usergroups:read` scope are
+// fully supported: subteam-aliases.json is a static file the operator
+// populates manually. No usergroups.list fetch is performed by v1.
+type subteamAliasMap struct {
+	mu         sync.RWMutex
+	byID       map[string]string // subteam_id -> handle
+	diskPath   string
+}
+
+// subteamAliasSnapshot is a parsed-but-not-yet-committed view of
+// subteam-aliases.json. nil = "file absent" sentinel — same SIGHUP
+// semantics as roomLaunchMappingSnapshot.
+type subteamAliasSnapshot struct {
+	byID map[string]string
+}
+
+// newSubteamAliasMap opens (or creates) the map at diskPath. A missing
+// file yields an empty map — operators on locked-down apps without
+// the file in place still get a fully-functional adapter; subteam
+// mentions just fall through to channel fanout (the bead's
+// "unknown-subteam-ID via unlabeled form" branch).
+func newSubteamAliasMap(diskPath string) (*subteamAliasMap, error) {
+	m := &subteamAliasMap{
+		byID:     make(map[string]string),
+		diskPath: diskPath,
+	}
+	if err := m.load(); err != nil {
+		return nil, fmt.Errorf("load subteam alias map from %s: %w", diskPath, err)
+	}
+	return m, nil
+}
+
+// Get returns the handle bound to subteamID plus a bool indicating
+// whether one is registered. A miss means the subteam is NOT enabled
+// for address-by-handle routing — the adapter falls through to its
+// existing channel-fanout behavior.
+func (m *subteamAliasMap) Get(subteamID string) (string, bool) {
+	if m == nil {
+		return "", false
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	h, ok := m.byID[subteamID]
+	return h, ok
+}
+
+// Len returns the number of bindings currently loaded. Used by the
+// startup / SIGHUP log lines so operators can confirm a reload picked
+// up an edit.
+func (m *subteamAliasMap) Len() int {
+	if m == nil {
+		return 0
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return len(m.byID)
+}
+
+// All returns every loaded binding as `subteam_id=handle` strings,
+// sorted by subteam_id for diff-stable test ordering. Tests only.
+func (m *subteamAliasMap) All() []string {
+	if m == nil {
+		return nil
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	ids := make([]string, 0, len(m.byID))
+	for id := range m.byID {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	out := make([]string, 0, len(ids))
+	for _, id := range ids {
+		out = append(out, id+"="+m.byID[id])
+	}
+	return out
+}
+
+// maxSubteamAliasBytes caps the JSON file size. Slack User Group IDs
+// are ~11 chars, handles are short strings; even a workspace with
+// thousands of User Groups is comfortably under a few hundred KiB. 10
+// MiB matches roomLaunchMappingRegistry's ceiling and is several
+// orders of magnitude above any healthy install.
+const maxSubteamAliasBytes = 10 << 20 // 10 MiB
+
+// parseSubteamAliasMap reads diskPath into a ready-to-commit snapshot.
+// nil + nil = "file absent" sentinel for SIGHUP semantics, matching
+// parseRoomLaunchMappingRegistry. Empty handles or empty subteam IDs
+// are rejected at parse time so a corrupt upstream write can't quietly
+// dispatch to "" handles or under "" subteam IDs.
+func parseSubteamAliasMap(diskPath string) (*subteamAliasSnapshot, error) {
+	if diskPath == "" {
+		return nil, nil
+	}
+	f, err := openRegistryFile(diskPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer f.Close()
+	data, err := io.ReadAll(io.LimitReader(f, maxSubteamAliasBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", diskPath, err)
+	}
+	if int64(len(data)) > maxSubteamAliasBytes {
+		return nil, fmt.Errorf("subteam alias file %s exceeds %d bytes", diskPath, maxSubteamAliasBytes)
+	}
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	var stored map[string]string
+	if err := dec.Decode(&stored); err != nil {
+		return nil, fmt.Errorf("decode subteam alias map: %w", err)
+	}
+	for id, handle := range stored {
+		if id == "" {
+			return nil, fmt.Errorf("subteam alias map: empty subteam_id key")
+		}
+		if handle == "" {
+			return nil, fmt.Errorf("subteam alias map: empty handle for subteam_id %q", id)
+		}
+	}
+	if stored == nil {
+		stored = make(map[string]string)
+	}
+	return &subteamAliasSnapshot{byID: stored}, nil
+}
+
+// load is the constructor-time helper — called pre-publish, no lock needed.
+func (m *subteamAliasMap) load() error {
+	snap, err := parseSubteamAliasMap(m.diskPath)
+	if err != nil {
+		return err
+	}
+	if snap != nil {
+		m.byID = snap.byID
+	}
+	return nil
+}
+
+// Stage parses the on-disk file into a snapshot ready for atomic Commit.
+// nil snapshot + nil error = file absent, preserve live state.
+func (m *subteamAliasMap) Stage() (*subteamAliasSnapshot, error) {
+	return parseSubteamAliasMap(m.diskPath)
+}
+
+// Commit atomically swaps the in-memory snapshot under the write lock.
+func (m *subteamAliasMap) Commit(snap *subteamAliasSnapshot) {
+	if snap == nil {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.byID = snap.byID
+}
+
+// Reload combines Stage and Commit; per-registry test convenience.
+func (m *subteamAliasMap) Reload() error {
+	snap, err := m.Stage()
+	if err != nil {
+		return err
+	}
+	m.Commit(snap)
+	return nil
+}

--- a/slack-pack/adapter/subteam_alias_map_test.go
+++ b/slack-pack/adapter/subteam_alias_map_test.go
@@ -1,0 +1,204 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+// writeSubteamAliasFile writes a JSON map to a tmpfile and returns its
+// path. Tests use this to stage operator-edited subteam-aliases.json
+// states without exercising the (non-existent in v1) write API.
+func writeSubteamAliasFile(t *testing.T, dir string, entries map[string]string) string {
+	t.Helper()
+	path := filepath.Join(dir, "subteam-aliases.json")
+	data, err := json.Marshal(entries)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	return path
+}
+
+// TestSubteamAliasMapEmptyAndAbsent confirms the constructor accepts
+// both "file does not exist" (locked-down workspace, never wrote the
+// map) and "file is `{}`" (operator cleared all bindings) as valid
+// empty states. The map should NOT crash startup in either case —
+// crashing would block adapter launch on workspaces that haven't yet
+// adopted subteam routing.
+func TestSubteamAliasMapEmptyAndAbsent(t *testing.T) {
+	dir := t.TempDir()
+	missing := filepath.Join(dir, "subteam-aliases.json")
+	m, err := newSubteamAliasMap(missing)
+	if err != nil {
+		t.Fatalf("missing-file: %v", err)
+	}
+	if m.Len() != 0 {
+		t.Errorf("missing-file Len = %d, want 0", m.Len())
+	}
+	if _, ok := m.Get("S0123ABCD"); ok {
+		t.Errorf("missing-file Get returned ok=true for unknown id")
+	}
+
+	empty := writeSubteamAliasFile(t, dir, map[string]string{})
+	m2, err := newSubteamAliasMap(empty)
+	if err != nil {
+		t.Fatalf("empty-file: %v", err)
+	}
+	if m2.Len() != 0 {
+		t.Errorf("empty-file Len = %d, want 0", m2.Len())
+	}
+}
+
+// TestSubteamAliasMapLoadAndGet exercises the happy path: operator
+// writes a valid JSON map, constructor reads it, Get returns the
+// expected handle for each registered subteam ID and ok=false for any
+// unregistered ID.
+func TestSubteamAliasMapLoadAndGet(t *testing.T) {
+	dir := t.TempDir()
+	path := writeSubteamAliasFile(t, dir, map[string]string{
+		"S0B4MUNDZCH": "mayor",
+		"S0123ABCD":   "cos",
+		"S0456EFGH":   "gc-pl",
+	})
+	m, err := newSubteamAliasMap(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if m.Len() != 3 {
+		t.Errorf("Len = %d, want 3", m.Len())
+	}
+	cases := []struct {
+		id, want string
+		wantOK   bool
+	}{
+		{"S0B4MUNDZCH", "mayor", true},
+		{"S0123ABCD", "cos", true},
+		{"S0456EFGH", "gc-pl", true},
+		{"S_NOPE", "", false},
+		{"", "", false},
+	}
+	for _, tc := range cases {
+		got, ok := m.Get(tc.id)
+		if got != tc.want || ok != tc.wantOK {
+			t.Errorf("Get(%q) = (%q, %v), want (%q, %v)", tc.id, got, ok, tc.want, tc.wantOK)
+		}
+	}
+}
+
+// TestSubteamAliasMapRejectsCorruptEntries asserts that parse failures
+// preserve the existing live state (the map is constructed but the
+// load error surfaces). A subteam_id with empty handle would silently
+// dispatch to "" — refuse to load it rather than serve a corrupt
+// allowlist.
+func TestSubteamAliasMapRejectsCorruptEntries(t *testing.T) {
+	dir := t.TempDir()
+	cases := []struct {
+		name    string
+		payload string
+	}{
+		{"empty handle", `{"S0123":""}`},
+		{"empty key", `{"":"mayor"}`},
+		{"unknown nested field", `{"S0123":{"handle":"mayor"}}`}, // wrong shape — value must be string
+		{"not an object", `["S0123","mayor"]`},
+		{"malformed JSON", `{`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(dir, "bad-"+tc.name+".json")
+			if err := os.WriteFile(path, []byte(tc.payload), 0o600); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			if _, err := newSubteamAliasMap(path); err == nil {
+				t.Errorf("payload %q parsed cleanly; want error", tc.payload)
+			}
+		})
+	}
+}
+
+// TestSubteamAliasMapReloadOnUpdate confirms the SIGHUP reload path
+// picks up operator edits without an adapter restart. This is the
+// promise the startup log line makes ("read-only; SIGHUP or restart to
+// reload") — break it and operators silently serve stale policy.
+func TestSubteamAliasMapReloadOnUpdate(t *testing.T) {
+	dir := t.TempDir()
+	path := writeSubteamAliasFile(t, dir, map[string]string{
+		"S0123": "mayor",
+	})
+	m, err := newSubteamAliasMap(path)
+	if err != nil {
+		t.Fatalf("initial load: %v", err)
+	}
+	if h, ok := m.Get("S0123"); !ok || h != "mayor" {
+		t.Fatalf("initial Get(S0123) = (%q, %v), want (mayor, true)", h, ok)
+	}
+
+	// Operator edits the file: rename mayor → cos, add a new binding.
+	writeSubteamAliasFile(t, dir, map[string]string{
+		"S0123":  "cos",
+		"S_NEW":  "probe-pl",
+	})
+	if err := m.Reload(); err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if h, ok := m.Get("S0123"); !ok || h != "cos" {
+		t.Errorf("after reload, Get(S0123) = (%q, %v), want (cos, true)", h, ok)
+	}
+	if h, ok := m.Get("S_NEW"); !ok || h != "probe-pl" {
+		t.Errorf("after reload, Get(S_NEW) = (%q, %v), want (probe-pl, true)", h, ok)
+	}
+	if m.Len() != 2 {
+		t.Errorf("after reload, Len = %d, want 2", m.Len())
+	}
+}
+
+// TestSubteamAliasMapAllSortedForDiffStability asserts that All()
+// returns entries in deterministic order so test fixtures and
+// operator-facing list output don't flap between adapter restarts.
+func TestSubteamAliasMapAllSortedForDiffStability(t *testing.T) {
+	dir := t.TempDir()
+	path := writeSubteamAliasFile(t, dir, map[string]string{
+		"S_B": "cos",
+		"S_A": "mayor",
+		"S_C": "gc-pl",
+	})
+	m, err := newSubteamAliasMap(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	got := m.All()
+	want := []string{"S_A=mayor", "S_B=cos", "S_C=gc-pl"}
+	if !sort.StringsAreSorted(got) {
+		t.Errorf("All() not sorted: %v", got)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("All() len = %d, want %d (got=%v)", len(got), len(want), got)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("All()[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// TestSubteamAliasMapNilSafe documents the nil-safety contract the
+// processSlackEvent wiring relies on: a nil *subteamAliasMap MUST
+// behave like an empty map (Get returns ok=false, Len returns 0).
+// Without this, callers would need to nil-check every call site, and
+// the dispatch code path becomes harder to follow.
+func TestSubteamAliasMapNilSafe(t *testing.T) {
+	var m *subteamAliasMap
+	if got, ok := m.Get("S0123"); ok || got != "" {
+		t.Errorf("nil Get = (%q, %v), want (\"\", false)", got, ok)
+	}
+	if n := m.Len(); n != 0 {
+		t.Errorf("nil Len = %d, want 0", n)
+	}
+	if got := m.All(); got != nil {
+		t.Errorf("nil All = %v, want nil", got)
+	}
+}

--- a/slack-pack/adapter/subteam_mention_dispatch_test.go
+++ b/slack-pack/adapter/subteam_mention_dispatch_test.go
@@ -1,0 +1,308 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// subteamCapture records both inbound POSTs (extmsg/inbound) and
+// alias-dispatched session-message POSTs so a single test can assert
+// the full processSlackEvent flow for a Slack User Group mention.
+type subteamCapture struct {
+	mu             sync.Mutex
+	inbounds       []externalInboundMessage
+	sessionHits    int32
+	sessionPath    string
+	sessionPayload []byte
+}
+
+func (c *subteamCapture) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		switch {
+		case strings.Contains(r.URL.Path, "/extmsg/inbound"):
+			var env struct {
+				Message externalInboundMessage `json:"message"`
+			}
+			if err := json.Unmarshal(body, &env); err == nil {
+				c.mu.Lock()
+				c.inbounds = append(c.inbounds, env.Message)
+				c.mu.Unlock()
+			}
+			w.WriteHeader(http.StatusAccepted)
+		case strings.Contains(r.URL.Path, "/session/") && strings.HasSuffix(r.URL.Path, "/messages"):
+			atomic.AddInt32(&c.sessionHits, 1)
+			c.mu.Lock()
+			c.sessionPath = r.URL.Path
+			c.sessionPayload = append([]byte(nil), body...)
+			c.mu.Unlock()
+			w.WriteHeader(http.StatusAccepted)
+		default:
+			w.WriteHeader(http.StatusAccepted)
+		}
+	}
+}
+
+func (c *subteamCapture) snapshotInbounds() []externalInboundMessage {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]externalInboundMessage, len(c.inbounds))
+	copy(out, c.inbounds)
+	return out
+}
+
+// TestProcessSlackEventSubteamMentionRoutedAsAddressByHandle is the
+// happy path for bead gpk-2zi: a Slack User Group mention whose
+// `@handle` label matches a registered handle alias must route through
+// the existing address-by-handle dispatch path. That means:
+//
+//  1. The inbound POSTed to gc carries ExplicitTarget="<handle>" and
+//     Text stripped of the subteam token (just the trailing remainder).
+//  2. The session-message dispatch fires for the aliased session id,
+//     exactly as it would have for a human-typed "@<handle>: ..."
+//     message.
+//
+// We exercise the full processSlackEvent path rather than calling the
+// parser directly so a regression in either the parse step or the
+// aliasReg gate would fail the test.
+func TestProcessSlackEventSubteamMentionRoutedAsAddressByHandle(t *testing.T) {
+	capture := &subteamCapture{}
+	gcStub := httptest.NewServer(capture.handler())
+	t.Cleanup(gcStub.Close)
+
+	cfg := config{
+		gcAPIBase:     gcStub.URL,
+		cityName:      "test-city",
+		provider:      "slack",
+		accountID:     "T1",
+		handlePrefix:  "@",
+		slackBotToken: "xoxb-test",
+		dispatchSem:   defaultTestDispatchSem,
+	}
+	aliasReg := newTestHandleAliasRegistry(t)
+	if err := aliasReg.Set("mayor", "gc-2568"); err != nil {
+		t.Fatalf("aliasReg.Set: %v", err)
+	}
+
+	rawMsg, _ := json.Marshal(slackMessageEvent{
+		Type:    "message",
+		Channel: "C1",
+		User:    "U1",
+		TS:      "1700000000.000100",
+		Text:    "<!subteam^S0123ABCD|@mayor> please check this",
+	})
+	env := slackEventEnvelope{Type: "event_callback", Event: rawMsg}
+
+	var releases int32
+	processSlackEvent(cfg, aliasReg, nil, nil, env, func() { atomic.AddInt32(&releases, 1) })
+
+	// The inbound POST must carry the parsed target + remainder.
+	inbounds := capture.snapshotInbounds()
+	if len(inbounds) != 1 {
+		t.Fatalf("got %d inbound POSTs, want 1", len(inbounds))
+	}
+	if inbounds[0].ExplicitTarget != "mayor" {
+		t.Errorf("ExplicitTarget = %q, want %q", inbounds[0].ExplicitTarget, "mayor")
+	}
+	if inbounds[0].Text != "please check this" {
+		t.Errorf("Text = %q, want %q", inbounds[0].Text, "please check this")
+	}
+
+	// The alias dispatch goroutine fires asynchronously. Wait briefly
+	// for the session-message POST so we don't flake on slow CI.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if atomic.LoadInt32(&capture.sessionHits) > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := atomic.LoadInt32(&capture.sessionHits); got != 1 {
+		t.Fatalf("session-message hits = %d, want 1 (alias dispatch should have fired)", got)
+	}
+	capture.mu.Lock()
+	gotPath := capture.sessionPath
+	capture.mu.Unlock()
+	if !strings.Contains(gotPath, "/session/gc-2568/messages") {
+		t.Errorf("session path = %q, want to contain %q", gotPath, "/session/gc-2568/messages")
+	}
+}
+
+// TestProcessSlackEventSubteamMentionUnregisteredHandleFallsThrough
+// asserts the safety gate from bead gpk-2zi: a Slack User Group mention
+// whose label does NOT match a registered handle alias must NOT trigger
+// address-by-handle dispatch. The inbound still gets posted (so the
+// channel's bound session sees the message), but with the full original
+// text (token included) and an empty ExplicitTarget. No alias
+// session-message POST fires.
+//
+// This is the safety case for the bead: Slack's @-autocomplete surfaces
+// every User Group in the workspace, including ones unrelated to gc.
+// Treating those as address-by-handle would silently route messages to
+// wrong (or nonexistent) sessions.
+func TestProcessSlackEventSubteamMentionUnregisteredHandleFallsThrough(t *testing.T) {
+	capture := &subteamCapture{}
+	gcStub := httptest.NewServer(capture.handler())
+	t.Cleanup(gcStub.Close)
+
+	cfg := config{
+		gcAPIBase:     gcStub.URL,
+		cityName:      "test-city",
+		provider:      "slack",
+		accountID:     "T1",
+		handlePrefix:  "@",
+		slackBotToken: "xoxb-test",
+		dispatchSem:   defaultTestDispatchSem,
+	}
+	aliasReg := newTestHandleAliasRegistry(t)
+	// Intentionally do NOT register the handle.
+
+	rawMsg, _ := json.Marshal(slackMessageEvent{
+		Type:    "message",
+		Channel: "C1",
+		User:    "U1",
+		TS:      "1700000000.000200",
+		Text:    "<!subteam^S0123ABCD|@notregistered> hello team",
+	})
+	env := slackEventEnvelope{Type: "event_callback", Event: rawMsg}
+
+	processSlackEvent(cfg, aliasReg, nil, nil, env, func() {})
+
+	inbounds := capture.snapshotInbounds()
+	if len(inbounds) != 1 {
+		t.Fatalf("got %d inbound POSTs, want 1", len(inbounds))
+	}
+	if inbounds[0].ExplicitTarget != "" {
+		t.Errorf("ExplicitTarget = %q, want empty (handle was not in aliasReg)", inbounds[0].ExplicitTarget)
+	}
+	// Full original text passes through unchanged so the channel-bound
+	// session sees the same surface a non-address mention would deliver.
+	if inbounds[0].Text != "<!subteam^S0123ABCD|@notregistered> hello team" {
+		t.Errorf("Text = %q, want full original token preserved", inbounds[0].Text)
+	}
+
+	// Give any (incorrect) alias dispatch goroutine a chance to fire.
+	time.Sleep(50 * time.Millisecond)
+	if got := atomic.LoadInt32(&capture.sessionHits); got != 0 {
+		t.Errorf("session-message hits = %d, want 0 (no alias should have matched)", got)
+	}
+}
+
+// TestProcessSlackEventSubteamMentionTakesPrecedenceOverSingleAtPrefix
+// asserts that when a message starts with a subteam token whose label
+// matches the alias registry, the subteam path wins — the existing
+// single-`@` parseHandlePrefix path is NOT re-applied to the remainder.
+// This protects against a message like
+// `<!subteam^S012|@mayor> @ops: status?` being mis-parsed as
+// address-by-handle for "ops" (the parser is documented to fire only
+// on the trimmed head).
+func TestProcessSlackEventSubteamMentionTakesPrecedenceOverSingleAtPrefix(t *testing.T) {
+	capture := &subteamCapture{}
+	gcStub := httptest.NewServer(capture.handler())
+	t.Cleanup(gcStub.Close)
+
+	cfg := config{
+		gcAPIBase:     gcStub.URL,
+		cityName:      "test-city",
+		provider:      "slack",
+		accountID:     "T1",
+		handlePrefix:  "@",
+		slackBotToken: "xoxb-test",
+		dispatchSem:   defaultTestDispatchSem,
+	}
+	aliasReg := newTestHandleAliasRegistry(t)
+	if err := aliasReg.Set("mayor", "gc-2568"); err != nil {
+		t.Fatalf("aliasReg.Set: %v", err)
+	}
+
+	rawMsg, _ := json.Marshal(slackMessageEvent{
+		Type:    "message",
+		Channel: "C1",
+		User:    "U1",
+		TS:      "1700000000.000300",
+		Text:    "<!subteam^S0123ABCD|@mayor> @ops: status?",
+	})
+	env := slackEventEnvelope{Type: "event_callback", Event: rawMsg}
+
+	processSlackEvent(cfg, aliasReg, nil, nil, env, func() {})
+
+	inbounds := capture.snapshotInbounds()
+	if len(inbounds) != 1 {
+		t.Fatalf("got %d inbound POSTs, want 1", len(inbounds))
+	}
+	if inbounds[0].ExplicitTarget != "mayor" {
+		t.Errorf("ExplicitTarget = %q, want %q (subteam head must win)", inbounds[0].ExplicitTarget, "mayor")
+	}
+	// Remainder is delivered verbatim — `@ops: status?` is just text now,
+	// not a second address token.
+	if inbounds[0].Text != "@ops: status?" {
+		t.Errorf("Text = %q, want %q (single-@ parse must NOT run on the remainder)", inbounds[0].Text, "@ops: status?")
+	}
+}
+
+// TestProcessSlackEventSingleAtHandleStillDispatches is a regression
+// guard: the existing `@handle:` text-prefix path must keep working
+// unchanged after the subteam parser was added in front of it. This
+// duplicates the basic happy path in spirit, but the assertion target
+// is "the wiring did not get reordered in a way that breaks the
+// single-`@` path", which is exactly the kind of regression a parser
+// shuffle can introduce.
+func TestProcessSlackEventSingleAtHandleStillDispatches(t *testing.T) {
+	capture := &subteamCapture{}
+	gcStub := httptest.NewServer(capture.handler())
+	t.Cleanup(gcStub.Close)
+
+	cfg := config{
+		gcAPIBase:     gcStub.URL,
+		cityName:      "test-city",
+		provider:      "slack",
+		accountID:     "T1",
+		handlePrefix:  "@",
+		slackBotToken: "xoxb-test",
+		dispatchSem:   defaultTestDispatchSem,
+	}
+	aliasReg := newTestHandleAliasRegistry(t)
+	if err := aliasReg.Set("mayor", "gc-2568"); err != nil {
+		t.Fatalf("aliasReg.Set: %v", err)
+	}
+
+	rawMsg, _ := json.Marshal(slackMessageEvent{
+		Type:    "message",
+		Channel: "C1",
+		User:    "U1",
+		TS:      "1700000000.000400",
+		Text:    "@mayor: still works",
+	})
+	env := slackEventEnvelope{Type: "event_callback", Event: rawMsg}
+
+	processSlackEvent(cfg, aliasReg, nil, nil, env, func() {})
+
+	inbounds := capture.snapshotInbounds()
+	if len(inbounds) != 1 {
+		t.Fatalf("got %d inbound POSTs, want 1", len(inbounds))
+	}
+	if inbounds[0].ExplicitTarget != "mayor" {
+		t.Errorf("ExplicitTarget = %q, want %q", inbounds[0].ExplicitTarget, "mayor")
+	}
+	if inbounds[0].Text != "still works" {
+		t.Errorf("Text = %q, want %q", inbounds[0].Text, "still works")
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if atomic.LoadInt32(&capture.sessionHits) > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := atomic.LoadInt32(&capture.sessionHits); got != 1 {
+		t.Errorf("session-message hits = %d, want 1 (single-@ alias dispatch must still fire)", got)
+	}
+}

--- a/slack-pack/adapter/subteam_mention_dispatch_test.go
+++ b/slack-pack/adapter/subteam_mention_dispatch_test.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -101,7 +103,7 @@ func TestProcessSlackEventSubteamMentionRoutedAsAddressByHandle(t *testing.T) {
 	env := slackEventEnvelope{Type: "event_callback", Event: rawMsg}
 
 	var releases int32
-	processSlackEvent(cfg, aliasReg, nil, nil, env, func() { atomic.AddInt32(&releases, 1) })
+	processSlackEvent(cfg, aliasReg, nil, nil, nil, env, func() { atomic.AddInt32(&releases, 1) })
 
 	// The inbound POST must carry the parsed target + remainder.
 	inbounds := capture.snapshotInbounds()
@@ -173,7 +175,7 @@ func TestProcessSlackEventSubteamMentionUnregisteredHandleFallsThrough(t *testin
 	})
 	env := slackEventEnvelope{Type: "event_callback", Event: rawMsg}
 
-	processSlackEvent(cfg, aliasReg, nil, nil, env, func() {})
+	processSlackEvent(cfg, aliasReg, nil, nil, nil, env, func() {})
 
 	inbounds := capture.snapshotInbounds()
 	if len(inbounds) != 1 {
@@ -231,7 +233,7 @@ func TestProcessSlackEventSubteamMentionTakesPrecedenceOverSingleAtPrefix(t *tes
 	})
 	env := slackEventEnvelope{Type: "event_callback", Event: rawMsg}
 
-	processSlackEvent(cfg, aliasReg, nil, nil, env, func() {})
+	processSlackEvent(cfg, aliasReg, nil, nil, nil, env, func() {})
 
 	inbounds := capture.snapshotInbounds()
 	if len(inbounds) != 1 {
@@ -282,7 +284,7 @@ func TestProcessSlackEventSingleAtHandleStillDispatches(t *testing.T) {
 	})
 	env := slackEventEnvelope{Type: "event_callback", Event: rawMsg}
 
-	processSlackEvent(cfg, aliasReg, nil, nil, env, func() {})
+	processSlackEvent(cfg, aliasReg, nil, nil, nil, env, func() {})
 
 	inbounds := capture.snapshotInbounds()
 	if len(inbounds) != 1 {
@@ -304,5 +306,267 @@ func TestProcessSlackEventSingleAtHandleStillDispatches(t *testing.T) {
 	}
 	if got := atomic.LoadInt32(&capture.sessionHits); got != 1 {
 		t.Errorf("session-message hits = %d, want 1 (single-@ alias dispatch must still fire)", got)
+	}
+}
+
+// newTestSubteamAliasMap builds a subteamAliasMap from an in-memory
+// {subteam_id: handle} map by staging it through a tmpfile. Tests that
+// need a populated map use this rather than touching production
+// defaults, so each test owns an isolated state.
+func newTestSubteamAliasMap(t *testing.T, entries map[string]string) *subteamAliasMap {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "subteam-aliases.json")
+	data, err := json.Marshal(entries)
+	if err != nil {
+		t.Fatalf("marshal subteam map: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write subteam map: %v", err)
+	}
+	m, err := newSubteamAliasMap(path)
+	if err != nil {
+		t.Fatalf("newSubteamAliasMap: %v", err)
+	}
+	return m
+}
+
+// TestProcessSlackEventUnlabeledSubteamMappedRoutesAsAddressByHandle is
+// the gpk-hmr.2 happy path: an UNLABELED subteam token
+// `<!subteam^Sxxx>` whose ID resolves through subteamAliasMap to a gc
+// handle must route through the same address-by-handle dispatch path
+// the labeled form uses. The "addressed you" system-reminder is what
+// the receiving session expects — anything else (generic channel
+// fanout, or just an ExplicitTarget with no alias dispatch) silently
+// breaks the gpk-hmr observed-gap fix.
+func TestProcessSlackEventUnlabeledSubteamMappedRoutesAsAddressByHandle(t *testing.T) {
+	capture := &subteamCapture{}
+	gcStub := httptest.NewServer(capture.handler())
+	t.Cleanup(gcStub.Close)
+
+	cfg := config{
+		gcAPIBase:     gcStub.URL,
+		cityName:      "test-city",
+		provider:      "slack",
+		accountID:     "T1",
+		handlePrefix:  "@",
+		slackBotToken: "xoxb-test",
+		dispatchSem:   defaultTestDispatchSem,
+	}
+	aliasReg := newTestHandleAliasRegistry(t)
+	if err := aliasReg.Set("mayor", "gc-2568"); err != nil {
+		t.Fatalf("aliasReg.Set: %v", err)
+	}
+	subteamMap := newTestSubteamAliasMap(t, map[string]string{
+		"S0B4MUNDZCH": "mayor",
+	})
+
+	rawMsg, _ := json.Marshal(slackMessageEvent{
+		Type:    "message",
+		Channel: "C1",
+		User:    "U1",
+		TS:      "1700000000.000500",
+		Text:    "<!subteam^S0B4MUNDZCH> please check the queue",
+	})
+	env := slackEventEnvelope{Type: "event_callback", Event: rawMsg}
+
+	processSlackEvent(cfg, aliasReg, nil, nil, subteamMap, env, func() {})
+
+	inbounds := capture.snapshotInbounds()
+	if len(inbounds) != 1 {
+		t.Fatalf("got %d inbound POSTs, want 1", len(inbounds))
+	}
+	if inbounds[0].ExplicitTarget != "mayor" {
+		t.Errorf("ExplicitTarget = %q, want %q (subteam map should resolve S0B4MUNDZCH→mayor)",
+			inbounds[0].ExplicitTarget, "mayor")
+	}
+	if inbounds[0].Text != "please check the queue" {
+		t.Errorf("Text = %q, want %q (subteam token must be stripped)",
+			inbounds[0].Text, "please check the queue")
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if atomic.LoadInt32(&capture.sessionHits) > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := atomic.LoadInt32(&capture.sessionHits); got != 1 {
+		t.Fatalf("session-message hits = %d, want 1 (alias dispatch should have fired)", got)
+	}
+
+	// The dispatched body must carry the "Slack address-by-handle"
+	// system-reminder form — that's the gpk-hmr acceptance check. A
+	// "New message in shared conversation" generic-fanout body here
+	// would indicate the inbound went through the channel-fanout path
+	// instead and the bead's observed gap is NOT fixed.
+	capture.mu.Lock()
+	gotPath := capture.sessionPath
+	gotBody := append([]byte(nil), capture.sessionPayload...)
+	capture.mu.Unlock()
+	if !strings.Contains(gotPath, "/session/gc-2568/messages") {
+		t.Errorf("session path = %q, want to contain %q", gotPath, "/session/gc-2568/messages")
+	}
+	bodyStr := string(gotBody)
+	if !strings.Contains(bodyStr, "Slack address-by-handle: @mayor addressed you") {
+		t.Errorf("dispatched body missing address-by-handle reminder:\n%s", bodyStr)
+	}
+	if strings.Contains(bodyStr, "New message in shared conversation") {
+		t.Errorf("dispatched body looks like channel-fanout (generic reminder), not address-by-handle:\n%s", bodyStr)
+	}
+}
+
+// TestProcessSlackEventUnlabeledSubteamUnmappedFallsThroughToChannelFanout
+// asserts the gpk-hmr.2 negative case: an unlabeled `<!subteam^Sxxx>`
+// whose ID has NO entry in subteamAliasMap must NOT trigger
+// address-by-handle dispatch. The inbound still posts (so the
+// channel-bound session sees it as a regular shared-conversation
+// message), with the full original text preserved and an empty
+// ExplicitTarget. No alias session-message POST fires.
+func TestProcessSlackEventUnlabeledSubteamUnmappedFallsThroughToChannelFanout(t *testing.T) {
+	capture := &subteamCapture{}
+	gcStub := httptest.NewServer(capture.handler())
+	t.Cleanup(gcStub.Close)
+
+	cfg := config{
+		gcAPIBase:     gcStub.URL,
+		cityName:      "test-city",
+		provider:      "slack",
+		accountID:     "T1",
+		handlePrefix:  "@",
+		slackBotToken: "xoxb-test",
+		dispatchSem:   defaultTestDispatchSem,
+	}
+	aliasReg := newTestHandleAliasRegistry(t)
+	// Empty map — no subteam ID is mapped.
+	subteamMap := newTestSubteamAliasMap(t, map[string]string{})
+
+	rawMsg, _ := json.Marshal(slackMessageEvent{
+		Type:    "message",
+		Channel: "C1",
+		User:    "U1",
+		TS:      "1700000000.000600",
+		Text:    "<!subteam^S_UNKNOWN> hello team",
+	})
+	env := slackEventEnvelope{Type: "event_callback", Event: rawMsg}
+
+	processSlackEvent(cfg, aliasReg, nil, nil, subteamMap, env, func() {})
+
+	inbounds := capture.snapshotInbounds()
+	if len(inbounds) != 1 {
+		t.Fatalf("got %d inbound POSTs, want 1", len(inbounds))
+	}
+	if inbounds[0].ExplicitTarget != "" {
+		t.Errorf("ExplicitTarget = %q, want empty (subteam ID was not in map)", inbounds[0].ExplicitTarget)
+	}
+	if inbounds[0].Text != "<!subteam^S_UNKNOWN> hello team" {
+		t.Errorf("Text = %q, want full original token preserved (fall-through case)", inbounds[0].Text)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	if got := atomic.LoadInt32(&capture.sessionHits); got != 0 {
+		t.Errorf("session-message hits = %d, want 0 (no map entry, no dispatch)", got)
+	}
+}
+
+// TestProcessSlackEventUnlabeledSubteamWithNilMapFallsThrough is a
+// safety net: even if subteamAliasMap is nil (operator never
+// populated it; pre-gpk-hmr.2 callers), an unlabeled subteam token
+// must still post the inbound and NOT crash. Nil-safe Get on
+// subteamAliasMap is what makes this work; the test pins the
+// guarantee.
+func TestProcessSlackEventUnlabeledSubteamWithNilMapFallsThrough(t *testing.T) {
+	capture := &subteamCapture{}
+	gcStub := httptest.NewServer(capture.handler())
+	t.Cleanup(gcStub.Close)
+
+	cfg := config{
+		gcAPIBase:     gcStub.URL,
+		cityName:      "test-city",
+		provider:      "slack",
+		accountID:     "T1",
+		handlePrefix:  "@",
+		slackBotToken: "xoxb-test",
+		dispatchSem:   defaultTestDispatchSem,
+	}
+	aliasReg := newTestHandleAliasRegistry(t)
+
+	rawMsg, _ := json.Marshal(slackMessageEvent{
+		Type:    "message",
+		Channel: "C1",
+		User:    "U1",
+		TS:      "1700000000.000700",
+		Text:    "<!subteam^S0B4MUNDZCH> hi",
+	})
+	env := slackEventEnvelope{Type: "event_callback", Event: rawMsg}
+
+	processSlackEvent(cfg, aliasReg, nil, nil, nil, env, func() {})
+
+	inbounds := capture.snapshotInbounds()
+	if len(inbounds) != 1 {
+		t.Fatalf("got %d inbound POSTs, want 1", len(inbounds))
+	}
+	if inbounds[0].ExplicitTarget != "" {
+		t.Errorf("ExplicitTarget = %q, want empty (nil subteamMap should fall through)", inbounds[0].ExplicitTarget)
+	}
+	if inbounds[0].Text != "<!subteam^S0B4MUNDZCH> hi" {
+		t.Errorf("Text = %q, want full original (nil map = no rewrite)", inbounds[0].Text)
+	}
+}
+
+// TestProcessSlackEventLabeledSubteamCarriesAddressByHandleReminder
+// upgrades the gpk-2zi happy-path assertion: not only must the
+// session-message POST fire, the body must contain the
+// "Slack address-by-handle: @<handle> addressed you" reminder. This is
+// the strong-form check the gpk-hmr parent acceptance criterion calls
+// out for BOTH shapes, and a regression here would silently swap the
+// reminder for the generic "New message" form even with the right
+// path and target.
+func TestProcessSlackEventLabeledSubteamCarriesAddressByHandleReminder(t *testing.T) {
+	capture := &subteamCapture{}
+	gcStub := httptest.NewServer(capture.handler())
+	t.Cleanup(gcStub.Close)
+
+	cfg := config{
+		gcAPIBase:     gcStub.URL,
+		cityName:      "test-city",
+		provider:      "slack",
+		accountID:     "T1",
+		handlePrefix:  "@",
+		slackBotToken: "xoxb-test",
+		dispatchSem:   defaultTestDispatchSem,
+	}
+	aliasReg := newTestHandleAliasRegistry(t)
+	if err := aliasReg.Set("mayor", "gc-2568"); err != nil {
+		t.Fatalf("aliasReg.Set: %v", err)
+	}
+
+	rawMsg, _ := json.Marshal(slackMessageEvent{
+		Type:    "message",
+		Channel: "C1",
+		User:    "U1",
+		TS:      "1700000000.000800",
+		Text:    "<!subteam^S0B4MUNDZCH|@mayor> labeled shape",
+	})
+	env := slackEventEnvelope{Type: "event_callback", Event: rawMsg}
+
+	processSlackEvent(cfg, aliasReg, nil, nil, nil, env, func() {})
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if atomic.LoadInt32(&capture.sessionHits) > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := atomic.LoadInt32(&capture.sessionHits); got != 1 {
+		t.Fatalf("session-message hits = %d, want 1 (labeled form alias dispatch must fire)", got)
+	}
+	capture.mu.Lock()
+	bodyStr := string(capture.sessionPayload)
+	capture.mu.Unlock()
+	if !strings.Contains(bodyStr, "Slack address-by-handle: @mayor addressed you") {
+		t.Errorf("labeled-form dispatched body missing address-by-handle reminder:\n%s", bodyStr)
 	}
 }

--- a/slack-pack/adapter/subteam_mention_prefix.go
+++ b/slack-pack/adapter/subteam_mention_prefix.go
@@ -3,92 +3,121 @@ package main
 import "strings"
 
 // parseSubteamMentionPrefix recognizes a Slack User Group ("subteam")
-// mention token at the start of the trimmed text and extracts its
-// `@handle` label plus the trailing remainder. The token shape Slack
-// delivers when a human picks a User Group from native @-autocomplete is:
+// mention token at the start of the trimmed text and extracts (1) the
+// optional `@handle` label and (2) the subteam ID, plus the trailing
+// remainder. Slack delivers two shapes depending on context:
 //
-//	<!subteam^TEAMID|@handle>
+//	Labeled:    <!subteam^TEAMID|@handle>
+//	Unlabeled:  <!subteam^TEAMID>
 //
-// where TEAMID is the workspace-side User Group ID (e.g. "S0123ABCD")
-// and the `@handle` portion is the User Group's display name as a
-// `@`-prefixed label. The bare unlabeled form `<!subteam^TEAMID>` does
-// NOT match — without the label we cannot map to a handle, and the
-// adapter is explicitly designed to be ignorant of TEAMID values
-// (the workspace admin manages the alias-to-TEAMID binding out of
-// band; see bead gpk-2zi).
+// The labeled form is what Slack emits when a human picks a User Group
+// from native @-autocomplete in text mode; the unlabeled form is what
+// arrives in some event payloads (e.g. when the User Group is mentioned
+// inline by Slack on the server side). Both shapes occur in production
+// and both must be normalized to the same address-by-handle dispatch
+// path — that's the gpk-hmr.2 contract.
+//
+// Return values:
+//
+//   - handle:     non-empty for the labeled form (the `@`-stripped
+//                 label); empty for the unlabeled form.
+//   - subteamID:  the Slack User Group ID (e.g. "S0123ABCD") in both
+//                 shapes. Non-empty whenever ok=true.
+//   - remainder:  the text after the closing `>`, with one optional
+//                 colon and one leading whitespace byte trimmed
+//                 (mirroring parseHandlePrefix's separator rules).
+//   - ok:         true on any well-formed subteam token at the head;
+//                 false otherwise.
+//
+// Caller responsibilities:
+//
+//   - The labeled form is gated against handleAliasRegistry by the
+//     caller, matching the existing `@handle:` semantics from gpk-2zi.
+//   - The unlabeled form is gated against the operator-configured
+//     subteamAliasMap (subteam_id → handle) by the caller — without
+//     the map there is no way to know which gc handle a subteam ID
+//     belongs to.
 //
 // Semantics (mirroring parseHandlePrefix where they apply):
 //
 //   - Leading whitespace is tolerated; the token must start at the
 //     trimmed text's first byte.
-//   - The label is the longest run of [A-Za-z0-9_-] following the `@`.
-//     Empty label, or a label containing other characters, returns
-//     ok=false.
-//   - After the closing `>`, any leading colon (`:`) is trimmed —
-//     matching parseHandlePrefix's "colon is optional but consumed if
-//     present" rule — followed by one leading whitespace byte.
-//   - TEAMID may contain any non-`|` non-`>` characters; the parser
-//     does not validate it. The bead's contract is "map by handle
-//     label, ignore TEAMID."
+//   - For the labeled form, the label is the longest run of
+//     [A-Za-z0-9_-] following the `@`. Empty label or a label with
+//     other characters returns ok=false (operators should populate
+//     subteamAliasMap directly rather than relying on a malformed
+//     label).
+//   - For the unlabeled form, TEAMID is everything between `^` and
+//     `>`; empty TEAMID returns ok=false.
+//   - After the closing `>`, any leading colon (`:`) is trimmed,
+//     followed by one leading whitespace byte.
 //
-// Cases that return ("", "", false):
+// Cases that return ("", "", "", false):
 //
 //   - text whose trimmed head is not `<!subteam^`
-//   - missing `|@` separator between TEAMID and label
 //   - missing closing `>`
-//   - empty label (`<!subteam^X|@>`)
+//   - empty subteam ID (`<!subteam^>`, `<!subteam^|@h>`)
+//   - empty label in the labeled form (`<!subteam^Sxxx|@>`)
 //   - label with an invalid character (`<!subteam^X|@bad.handle>`)
 //
 // On any non-match the returned strings are empty so the caller cannot
 // accidentally consume input from a miss — same discipline as
 // parseDoubleHandlePrefix.
-func parseSubteamMentionPrefix(text string) (handle, remainder string, ok bool) {
+func parseSubteamMentionPrefix(text string) (handle, subteamID, remainder string, ok bool) {
 	const head = "<!subteam^"
 	trimmed := strings.TrimLeft(text, " \t")
 	if !strings.HasPrefix(trimmed, head) {
-		return "", "", false
+		return "", "", "", false
 	}
 	rest := trimmed[len(head):]
 
-	// The team ID is everything up to the `|` that introduces the
-	// label. A `>` before any `|` means the unlabeled form
-	// `<!subteam^TEAMID>` — reject (no handle to extract).
-	pipe := strings.IndexByte(rest, '|')
 	closer := strings.IndexByte(rest, '>')
-	if pipe < 0 || closer < 0 || closer < pipe {
-		return "", "", false
+	if closer < 0 {
+		return "", "", "", false
 	}
-
-	// Label must begin with `@` to match the format Slack emits when a
-	// User Group is selected from autocomplete. The label sits between
-	// the `|` and the closing `>`.
-	label := rest[pipe+1 : closer]
-	if len(label) == 0 || label[0] != '@' {
-		return "", "", false
-	}
-	candidate := label[1:]
-
-	// Scan the longest run of valid handle characters. The full label
-	// after `@` must consist only of those characters — a label like
-	// `@bad.handle` is rejected (not an address token, same stance as
-	// parseHandlePrefix).
-	handleEnd := 0
-	for i := 0; i < len(candidate); i++ {
-		r := candidate[i]
-		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') ||
-			(r >= '0' && r <= '9') || r == '-' || r == '_' {
-			handleEnd = i + 1
-		} else {
-			break
-		}
-	}
-	if handleEnd == 0 || handleEnd != len(candidate) {
-		return "", "", false
-	}
-
+	inside := rest[:closer]
 	body := rest[closer+1:]
+
+	// Split inside on the first `|` to detect the labeled form. The
+	// unlabeled form has no pipe; both forms must yield a non-empty
+	// subteam ID.
+	pipe := strings.IndexByte(inside, '|')
+	var sid, label string
+	if pipe < 0 {
+		sid = inside
+	} else {
+		sid = inside[:pipe]
+		label = inside[pipe+1:]
+	}
+	if sid == "" {
+		return "", "", "", false
+	}
+
+	var parsedHandle string
+	if pipe >= 0 {
+		// Labeled form: validate the `@<handle>` shape.
+		if len(label) == 0 || label[0] != '@' {
+			return "", "", "", false
+		}
+		candidate := label[1:]
+		handleEnd := 0
+		for i := 0; i < len(candidate); i++ {
+			r := candidate[i]
+			if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') ||
+				(r >= '0' && r <= '9') || r == '-' || r == '_' {
+				handleEnd = i + 1
+			} else {
+				break
+			}
+		}
+		if handleEnd == 0 || handleEnd != len(candidate) {
+			return "", "", "", false
+		}
+		parsedHandle = candidate
+	}
+
 	if body == "" {
-		return candidate, "", true
+		return parsedHandle, sid, "", true
 	}
 	// Optional `:` separator after the token, mirroring parseHandlePrefix
 	// ("@handle:" vs "@handle ").
@@ -99,5 +128,5 @@ func parseSubteamMentionPrefix(text string) (handle, remainder string, ok bool) 
 	if len(body) > 0 && (body[0] == ' ' || body[0] == '\t' || body[0] == '\n') {
 		body = body[1:]
 	}
-	return candidate, body, true
+	return parsedHandle, sid, body, true
 }

--- a/slack-pack/adapter/subteam_mention_prefix.go
+++ b/slack-pack/adapter/subteam_mention_prefix.go
@@ -1,0 +1,103 @@
+package main
+
+import "strings"
+
+// parseSubteamMentionPrefix recognizes a Slack User Group ("subteam")
+// mention token at the start of the trimmed text and extracts its
+// `@handle` label plus the trailing remainder. The token shape Slack
+// delivers when a human picks a User Group from native @-autocomplete is:
+//
+//	<!subteam^TEAMID|@handle>
+//
+// where TEAMID is the workspace-side User Group ID (e.g. "S0123ABCD")
+// and the `@handle` portion is the User Group's display name as a
+// `@`-prefixed label. The bare unlabeled form `<!subteam^TEAMID>` does
+// NOT match — without the label we cannot map to a handle, and the
+// adapter is explicitly designed to be ignorant of TEAMID values
+// (the workspace admin manages the alias-to-TEAMID binding out of
+// band; see bead gpk-2zi).
+//
+// Semantics (mirroring parseHandlePrefix where they apply):
+//
+//   - Leading whitespace is tolerated; the token must start at the
+//     trimmed text's first byte.
+//   - The label is the longest run of [A-Za-z0-9_-] following the `@`.
+//     Empty label, or a label containing other characters, returns
+//     ok=false.
+//   - After the closing `>`, any leading colon (`:`) is trimmed —
+//     matching parseHandlePrefix's "colon is optional but consumed if
+//     present" rule — followed by one leading whitespace byte.
+//   - TEAMID may contain any non-`|` non-`>` characters; the parser
+//     does not validate it. The bead's contract is "map by handle
+//     label, ignore TEAMID."
+//
+// Cases that return ("", "", false):
+//
+//   - text whose trimmed head is not `<!subteam^`
+//   - missing `|@` separator between TEAMID and label
+//   - missing closing `>`
+//   - empty label (`<!subteam^X|@>`)
+//   - label with an invalid character (`<!subteam^X|@bad.handle>`)
+//
+// On any non-match the returned strings are empty so the caller cannot
+// accidentally consume input from a miss — same discipline as
+// parseDoubleHandlePrefix.
+func parseSubteamMentionPrefix(text string) (handle, remainder string, ok bool) {
+	const head = "<!subteam^"
+	trimmed := strings.TrimLeft(text, " \t")
+	if !strings.HasPrefix(trimmed, head) {
+		return "", "", false
+	}
+	rest := trimmed[len(head):]
+
+	// The team ID is everything up to the `|` that introduces the
+	// label. A `>` before any `|` means the unlabeled form
+	// `<!subteam^TEAMID>` — reject (no handle to extract).
+	pipe := strings.IndexByte(rest, '|')
+	closer := strings.IndexByte(rest, '>')
+	if pipe < 0 || closer < 0 || closer < pipe {
+		return "", "", false
+	}
+
+	// Label must begin with `@` to match the format Slack emits when a
+	// User Group is selected from autocomplete. The label sits between
+	// the `|` and the closing `>`.
+	label := rest[pipe+1 : closer]
+	if len(label) == 0 || label[0] != '@' {
+		return "", "", false
+	}
+	candidate := label[1:]
+
+	// Scan the longest run of valid handle characters. The full label
+	// after `@` must consist only of those characters — a label like
+	// `@bad.handle` is rejected (not an address token, same stance as
+	// parseHandlePrefix).
+	handleEnd := 0
+	for i := 0; i < len(candidate); i++ {
+		r := candidate[i]
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') ||
+			(r >= '0' && r <= '9') || r == '-' || r == '_' {
+			handleEnd = i + 1
+		} else {
+			break
+		}
+	}
+	if handleEnd == 0 || handleEnd != len(candidate) {
+		return "", "", false
+	}
+
+	body := rest[closer+1:]
+	if body == "" {
+		return candidate, "", true
+	}
+	// Optional `:` separator after the token, mirroring parseHandlePrefix
+	// ("@handle:" vs "@handle ").
+	if body[0] == ':' {
+		body = body[1:]
+	}
+	// One leading whitespace byte trimmed, again mirroring parseHandlePrefix.
+	if len(body) > 0 && (body[0] == ' ' || body[0] == '\t' || body[0] == '\n') {
+		body = body[1:]
+	}
+	return candidate, body, true
+}

--- a/slack-pack/adapter/subteam_mention_prefix_test.go
+++ b/slack-pack/adapter/subteam_mention_prefix_test.go
@@ -1,0 +1,211 @@
+package main
+
+import "testing"
+
+// TestParseSubteamMentionPrefix exercises the Slack User Group ("subteam")
+// mention parser added in bead gpk-2zi. The parser recognizes the token
+// Slack emits when a human picks a User Group from native @-autocomplete:
+//
+//	<!subteam^TEAMID|@handle>
+//
+// and extracts `handle` + the trailing remainder. The unlabeled form
+// `<!subteam^TEAMID>` must NOT match — the adapter is intentionally
+// ignorant of TEAMID values and routes purely on the `@handle` label.
+//
+// Mirroring parseHandlePrefix where the rules apply, the parser:
+//   - tolerates leading whitespace before the token,
+//   - consumes one optional `:` after the closing `>` and one leading
+//     whitespace byte after that,
+//   - rejects labels with invalid handle characters.
+func TestParseSubteamMentionPrefix(t *testing.T) {
+	cases := []struct {
+		name          string
+		text          string
+		wantHandle    string
+		wantRemainder string
+		wantOK        bool
+	}{
+		{
+			name:          "labelled token with space remainder",
+			text:          "<!subteam^S012|@mayor> please ack",
+			wantHandle:    "mayor",
+			wantRemainder: "please ack",
+			wantOK:        true,
+		},
+		{
+			name:          "labelled token with colon-space remainder",
+			text:          "<!subteam^S012|@mayor>: status?",
+			wantHandle:    "mayor",
+			wantRemainder: "status?",
+			wantOK:        true,
+		},
+		{
+			name:          "labelled token with colon-no-space remainder",
+			text:          "<!subteam^S012|@cos>:hello",
+			wantHandle:    "cos",
+			wantRemainder: "hello",
+			wantOK:        true,
+		},
+		{
+			name:          "labelled token no remainder",
+			text:          "<!subteam^S012|@mayor>",
+			wantHandle:    "mayor",
+			wantRemainder: "",
+			wantOK:        true,
+		},
+		{
+			name:          "leading whitespace permitted",
+			text:          "  <!subteam^S012|@lead> hi",
+			wantHandle:    "lead",
+			wantRemainder: "hi",
+			wantOK:        true,
+		},
+		{
+			name:          "label with dash",
+			text:          "<!subteam^S012|@gc-pl> x",
+			wantHandle:    "gc-pl",
+			wantRemainder: "x",
+			wantOK:        true,
+		},
+		{
+			name:          "label with underscore",
+			text:          "<!subteam^S012|@probe_pl> x",
+			wantHandle:    "probe_pl",
+			wantRemainder: "x",
+			wantOK:        true,
+		},
+		{
+			name:          "newline separator after closer",
+			text:          "<!subteam^S012|@mayor>\nfoo",
+			wantHandle:    "mayor",
+			wantRemainder: "foo",
+			wantOK:        true,
+		},
+		{
+			name:          "tab separator after closer",
+			text:          "<!subteam^S012|@mayor>\tfoo",
+			wantHandle:    "mayor",
+			wantRemainder: "foo",
+			wantOK:        true,
+		},
+		{
+			name:          "TEAMID with non-alphanumeric characters tolerated",
+			text:          "<!subteam^S-abc.123|@mayor> ok",
+			wantHandle:    "mayor",
+			wantRemainder: "ok",
+			wantOK:        true,
+		},
+		{
+			name:          "unlabeled subteam token rejected",
+			text:          "<!subteam^S012> please ack",
+			wantHandle:    "",
+			wantRemainder: "",
+			wantOK:        false,
+		},
+		{
+			name:          "label missing leading at sign rejected",
+			text:          "<!subteam^S012|mayor> hi",
+			wantHandle:    "",
+			wantRemainder: "",
+			wantOK:        false,
+		},
+		{
+			name:          "empty label rejected",
+			text:          "<!subteam^S012|@> hi",
+			wantHandle:    "",
+			wantRemainder: "",
+			wantOK:        false,
+		},
+		{
+			name:          "label with invalid char rejected",
+			text:          "<!subteam^S012|@bad.handle> hi",
+			wantHandle:    "",
+			wantRemainder: "",
+			wantOK:        false,
+		},
+		{
+			name:          "label with slash rejected",
+			text:          "<!subteam^S012|@bad/handle> hi",
+			wantHandle:    "",
+			wantRemainder: "",
+			wantOK:        false,
+		},
+		{
+			name:          "missing closer rejected",
+			text:          "<!subteam^S012|@mayor please ack",
+			wantHandle:    "",
+			wantRemainder: "",
+			wantOK:        false,
+		},
+		{
+			name:          "missing pipe rejected",
+			text:          "<!subteam^S012@mayor> please ack",
+			wantHandle:    "",
+			wantRemainder: "",
+			wantOK:        false,
+		},
+		{
+			name:          "closer before pipe rejected",
+			text:          "<!subteam^S012>|@mayor please ack",
+			wantHandle:    "",
+			wantRemainder: "",
+			wantOK:        false,
+		},
+		{
+			name:          "user mention (not subteam) does not match",
+			text:          "<@U0123|mayor> please ack",
+			wantHandle:    "",
+			wantRemainder: "",
+			wantOK:        false,
+		},
+		{
+			name:          "channel mention (not subteam) does not match",
+			text:          "<#C0123|general> please ack",
+			wantHandle:    "",
+			wantRemainder: "",
+			wantOK:        false,
+		},
+		{
+			name:          "token not at start does not match",
+			text:          "hello <!subteam^S012|@mayor> please ack",
+			wantHandle:    "",
+			wantRemainder: "",
+			wantOK:        false,
+		},
+		{
+			name:          "plain text does not match",
+			text:          "plain text with no token",
+			wantHandle:    "",
+			wantRemainder: "",
+			wantOK:        false,
+		},
+		{
+			name:          "empty input does not match",
+			text:          "",
+			wantHandle:    "",
+			wantRemainder: "",
+			wantOK:        false,
+		},
+		{
+			name:          "single-at prefix (not a subteam token) does not match",
+			text:          "@mayor please ack",
+			wantHandle:    "",
+			wantRemainder: "",
+			wantOK:        false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotHandle, gotRemainder, gotOK := parseSubteamMentionPrefix(tc.text)
+			if gotOK != tc.wantOK {
+				t.Errorf("ok = %v, want %v", gotOK, tc.wantOK)
+			}
+			if gotHandle != tc.wantHandle {
+				t.Errorf("handle = %q, want %q", gotHandle, tc.wantHandle)
+			}
+			if gotRemainder != tc.wantRemainder {
+				t.Errorf("remainder = %q, want %q", gotRemainder, tc.wantRemainder)
+			}
+		})
+	}
+}

--- a/slack-pack/adapter/subteam_mention_prefix_test.go
+++ b/slack-pack/adapter/subteam_mention_prefix_test.go
@@ -3,60 +3,66 @@ package main
 import "testing"
 
 // TestParseSubteamMentionPrefix exercises the Slack User Group ("subteam")
-// mention parser added in bead gpk-2zi. The parser recognizes the token
-// Slack emits when a human picks a User Group from native @-autocomplete:
+// mention parser. The parser must recognize BOTH token shapes Slack
+// emits:
 //
-//	<!subteam^TEAMID|@handle>
+//	Labeled:    <!subteam^TEAMID|@handle>
+//	Unlabeled:  <!subteam^TEAMID>
 //
-// and extracts `handle` + the trailing remainder. The unlabeled form
-// `<!subteam^TEAMID>` must NOT match — the adapter is intentionally
-// ignorant of TEAMID values and routes purely on the `@handle` label.
-//
-// Mirroring parseHandlePrefix where the rules apply, the parser:
-//   - tolerates leading whitespace before the token,
-//   - consumes one optional `:` after the closing `>` and one leading
-//     whitespace byte after that,
-//   - rejects labels with invalid handle characters.
+// The labeled form yields a non-empty handle (the gc address-by-handle
+// dispatcher matches by handle against the runtime aliasReg). The
+// unlabeled form yields an empty handle but a non-empty subteam ID
+// (the dispatcher matches by subteam ID against the operator-edited
+// subteamAliasMap). In both shapes the trailing remainder has any
+// leading `:` and a single leading whitespace byte trimmed, mirroring
+// parseHandlePrefix's separator rules.
 func TestParseSubteamMentionPrefix(t *testing.T) {
 	cases := []struct {
 		name          string
 		text          string
 		wantHandle    string
+		wantSubteamID string
 		wantRemainder string
 		wantOK        bool
 	}{
+		// --- labeled form (gpk-2zi shape, unchanged behavior) -----------
 		{
-			name:          "labelled token with space remainder",
+			name:          "labeled token with space remainder",
 			text:          "<!subteam^S012|@mayor> please ack",
 			wantHandle:    "mayor",
+			wantSubteamID: "S012",
 			wantRemainder: "please ack",
 			wantOK:        true,
 		},
 		{
-			name:          "labelled token with colon-space remainder",
+			name:          "labeled token with colon-space remainder",
 			text:          "<!subteam^S012|@mayor>: status?",
 			wantHandle:    "mayor",
+			wantSubteamID: "S012",
 			wantRemainder: "status?",
 			wantOK:        true,
 		},
 		{
-			name:          "labelled token with colon-no-space remainder",
+			name:          "labeled token with colon-no-space remainder",
 			text:          "<!subteam^S012|@cos>:hello",
 			wantHandle:    "cos",
+			wantSubteamID: "S012",
 			wantRemainder: "hello",
 			wantOK:        true,
 		},
 		{
-			name:          "labelled token no remainder",
+			name:          "labeled token no remainder",
 			text:          "<!subteam^S012|@mayor>",
 			wantHandle:    "mayor",
+			wantSubteamID: "S012",
 			wantRemainder: "",
 			wantOK:        true,
 		},
 		{
-			name:          "leading whitespace permitted",
+			name:          "leading whitespace permitted (labeled)",
 			text:          "  <!subteam^S012|@lead> hi",
 			wantHandle:    "lead",
+			wantSubteamID: "S012",
 			wantRemainder: "hi",
 			wantOK:        true,
 		},
@@ -64,6 +70,7 @@ func TestParseSubteamMentionPrefix(t *testing.T) {
 			name:          "label with dash",
 			text:          "<!subteam^S012|@gc-pl> x",
 			wantHandle:    "gc-pl",
+			wantSubteamID: "S012",
 			wantRemainder: "x",
 			wantOK:        true,
 		},
@@ -71,20 +78,23 @@ func TestParseSubteamMentionPrefix(t *testing.T) {
 			name:          "label with underscore",
 			text:          "<!subteam^S012|@probe_pl> x",
 			wantHandle:    "probe_pl",
+			wantSubteamID: "S012",
 			wantRemainder: "x",
 			wantOK:        true,
 		},
 		{
-			name:          "newline separator after closer",
+			name:          "newline separator after closer (labeled)",
 			text:          "<!subteam^S012|@mayor>\nfoo",
 			wantHandle:    "mayor",
+			wantSubteamID: "S012",
 			wantRemainder: "foo",
 			wantOK:        true,
 		},
 		{
-			name:          "tab separator after closer",
+			name:          "tab separator after closer (labeled)",
 			text:          "<!subteam^S012|@mayor>\tfoo",
 			wantHandle:    "mayor",
+			wantSubteamID: "S012",
 			wantRemainder: "foo",
 			wantOK:        true,
 		},
@@ -92,27 +102,75 @@ func TestParseSubteamMentionPrefix(t *testing.T) {
 			name:          "TEAMID with non-alphanumeric characters tolerated",
 			text:          "<!subteam^S-abc.123|@mayor> ok",
 			wantHandle:    "mayor",
+			wantSubteamID: "S-abc.123",
 			wantRemainder: "ok",
 			wantOK:        true,
 		},
+
+		// --- unlabeled form (gpk-hmr.2 new behavior) -------------------
 		{
-			name:          "unlabeled subteam token rejected",
-			text:          "<!subteam^S012> please ack",
+			name:          "unlabeled token with space remainder",
+			text:          "<!subteam^S0B4MUNDZCH> please ack",
 			wantHandle:    "",
-			wantRemainder: "",
-			wantOK:        false,
+			wantSubteamID: "S0B4MUNDZCH",
+			wantRemainder: "please ack",
+			wantOK:        true,
 		},
+		{
+			name:          "unlabeled token with colon-space remainder",
+			text:          "<!subteam^S0B4MUNDZCH>: status?",
+			wantHandle:    "",
+			wantSubteamID: "S0B4MUNDZCH",
+			wantRemainder: "status?",
+			wantOK:        true,
+		},
+		{
+			name:          "unlabeled token with colon-no-space remainder",
+			text:          "<!subteam^S0123ABCD>:hello",
+			wantHandle:    "",
+			wantSubteamID: "S0123ABCD",
+			wantRemainder: "hello",
+			wantOK:        true,
+		},
+		{
+			name:          "unlabeled token no remainder",
+			text:          "<!subteam^S0123ABCD>",
+			wantHandle:    "",
+			wantSubteamID: "S0123ABCD",
+			wantRemainder: "",
+			wantOK:        true,
+		},
+		{
+			name:          "leading whitespace permitted (unlabeled)",
+			text:          "  <!subteam^S0123ABCD> hi",
+			wantHandle:    "",
+			wantSubteamID: "S0123ABCD",
+			wantRemainder: "hi",
+			wantOK:        true,
+		},
+		{
+			name:          "newline separator after closer (unlabeled)",
+			text:          "<!subteam^S0123ABCD>\nfoo",
+			wantHandle:    "",
+			wantSubteamID: "S0123ABCD",
+			wantRemainder: "foo",
+			wantOK:        true,
+		},
+
+		// --- rejected shapes -------------------------------------------
 		{
 			name:          "label missing leading at sign rejected",
 			text:          "<!subteam^S012|mayor> hi",
 			wantHandle:    "",
+			wantSubteamID: "",
 			wantRemainder: "",
 			wantOK:        false,
 		},
 		{
-			name:          "empty label rejected",
+			name:          "empty label in labeled form rejected",
 			text:          "<!subteam^S012|@> hi",
 			wantHandle:    "",
+			wantSubteamID: "",
 			wantRemainder: "",
 			wantOK:        false,
 		},
@@ -120,6 +178,7 @@ func TestParseSubteamMentionPrefix(t *testing.T) {
 			name:          "label with invalid char rejected",
 			text:          "<!subteam^S012|@bad.handle> hi",
 			wantHandle:    "",
+			wantSubteamID: "",
 			wantRemainder: "",
 			wantOK:        false,
 		},
@@ -127,6 +186,7 @@ func TestParseSubteamMentionPrefix(t *testing.T) {
 			name:          "label with slash rejected",
 			text:          "<!subteam^S012|@bad/handle> hi",
 			wantHandle:    "",
+			wantSubteamID: "",
 			wantRemainder: "",
 			wantOK:        false,
 		},
@@ -134,20 +194,23 @@ func TestParseSubteamMentionPrefix(t *testing.T) {
 			name:          "missing closer rejected",
 			text:          "<!subteam^S012|@mayor please ack",
 			wantHandle:    "",
+			wantSubteamID: "",
 			wantRemainder: "",
 			wantOK:        false,
 		},
 		{
-			name:          "missing pipe rejected",
-			text:          "<!subteam^S012@mayor> please ack",
+			name:          "empty subteam ID labeled rejected",
+			text:          "<!subteam^|@mayor> please ack",
 			wantHandle:    "",
+			wantSubteamID: "",
 			wantRemainder: "",
 			wantOK:        false,
 		},
 		{
-			name:          "closer before pipe rejected",
-			text:          "<!subteam^S012>|@mayor please ack",
+			name:          "empty subteam ID unlabeled rejected",
+			text:          "<!subteam^> please ack",
 			wantHandle:    "",
+			wantSubteamID: "",
 			wantRemainder: "",
 			wantOK:        false,
 		},
@@ -155,6 +218,7 @@ func TestParseSubteamMentionPrefix(t *testing.T) {
 			name:          "user mention (not subteam) does not match",
 			text:          "<@U0123|mayor> please ack",
 			wantHandle:    "",
+			wantSubteamID: "",
 			wantRemainder: "",
 			wantOK:        false,
 		},
@@ -162,6 +226,7 @@ func TestParseSubteamMentionPrefix(t *testing.T) {
 			name:          "channel mention (not subteam) does not match",
 			text:          "<#C0123|general> please ack",
 			wantHandle:    "",
+			wantSubteamID: "",
 			wantRemainder: "",
 			wantOK:        false,
 		},
@@ -169,6 +234,7 @@ func TestParseSubteamMentionPrefix(t *testing.T) {
 			name:          "token not at start does not match",
 			text:          "hello <!subteam^S012|@mayor> please ack",
 			wantHandle:    "",
+			wantSubteamID: "",
 			wantRemainder: "",
 			wantOK:        false,
 		},
@@ -176,6 +242,7 @@ func TestParseSubteamMentionPrefix(t *testing.T) {
 			name:          "plain text does not match",
 			text:          "plain text with no token",
 			wantHandle:    "",
+			wantSubteamID: "",
 			wantRemainder: "",
 			wantOK:        false,
 		},
@@ -183,6 +250,7 @@ func TestParseSubteamMentionPrefix(t *testing.T) {
 			name:          "empty input does not match",
 			text:          "",
 			wantHandle:    "",
+			wantSubteamID: "",
 			wantRemainder: "",
 			wantOK:        false,
 		},
@@ -190,18 +258,22 @@ func TestParseSubteamMentionPrefix(t *testing.T) {
 			name:          "single-at prefix (not a subteam token) does not match",
 			text:          "@mayor please ack",
 			wantHandle:    "",
+			wantSubteamID: "",
 			wantRemainder: "",
 			wantOK:        false,
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			gotHandle, gotRemainder, gotOK := parseSubteamMentionPrefix(tc.text)
+			gotHandle, gotSubteamID, gotRemainder, gotOK := parseSubteamMentionPrefix(tc.text)
 			if gotOK != tc.wantOK {
 				t.Errorf("ok = %v, want %v", gotOK, tc.wantOK)
 			}
 			if gotHandle != tc.wantHandle {
 				t.Errorf("handle = %q, want %q", gotHandle, tc.wantHandle)
+			}
+			if gotSubteamID != tc.wantSubteamID {
+				t.Errorf("subteamID = %q, want %q", gotSubteamID, tc.wantSubteamID)
 			}
 			if gotRemainder != tc.wantRemainder {
 				t.Errorf("remainder = %q, want %q", gotRemainder, tc.wantRemainder)

--- a/slack-pack/adapter/thread_context_test.go
+++ b/slack-pack/adapter/thread_context_test.go
@@ -124,7 +124,7 @@ func TestThreadContext_FirstMentionPrependsPreamble(t *testing.T) {
 	})
 	env := slackEventEnvelope{Type: "event_callback", Event: rawMsg}
 
-	processSlackEvent(cfg, newTestHandleAliasRegistry(t), nil, nil, env, func() {})
+	processSlackEvent(cfg, newTestHandleAliasRegistry(t), nil, nil, nil, env, func() {})
 
 	if got := atomic.LoadInt32(calls); got != 1 {
 		t.Fatalf("conversations.replies calls = %d, want 1", got)
@@ -215,8 +215,8 @@ func TestThreadContext_SecondMentionWithoutNewActivityNoPreamble(t *testing.T) {
 	})
 
 	aliasReg := newTestHandleAliasRegistry(t)
-	processSlackEvent(cfg, aliasReg, nil, nil, slackEventEnvelope{Type: "event_callback", Event: first}, func() {})
-	processSlackEvent(cfg, aliasReg, nil, nil, slackEventEnvelope{Type: "event_callback", Event: second}, func() {})
+	processSlackEvent(cfg, aliasReg, nil, nil, nil, slackEventEnvelope{Type: "event_callback", Event: first}, func() {})
+	processSlackEvent(cfg, aliasReg, nil, nil, nil, slackEventEnvelope{Type: "event_callback", Event: second}, func() {})
 
 	// Option B: each inbound fetches. The cache filters preamble.
 	if got := atomic.LoadInt32(&calls); got != 2 {
@@ -265,7 +265,7 @@ func TestThreadContext_NonThreadInboundSkipsFetch(t *testing.T) {
 		Text:    "standalone message",
 	})
 	env := slackEventEnvelope{Type: "event_callback", Event: rawMsg}
-	processSlackEvent(cfg, newTestHandleAliasRegistry(t), nil, nil, env, func() {})
+	processSlackEvent(cfg, newTestHandleAliasRegistry(t), nil, nil, nil, env, func() {})
 
 	if got := atomic.LoadInt32(calls); got != 0 {
 		t.Errorf("conversations.replies calls = %d, want 0", got)
@@ -308,7 +308,7 @@ func TestThreadContext_ThreadParentSkipsFetch(t *testing.T) {
 		Text:     "kicking off a new thread",
 	})
 	env := slackEventEnvelope{Type: "event_callback", Event: rawMsg}
-	processSlackEvent(cfg, newTestHandleAliasRegistry(t), nil, nil, env, func() {})
+	processSlackEvent(cfg, newTestHandleAliasRegistry(t), nil, nil, nil, env, func() {})
 
 	if got := atomic.LoadInt32(calls); got != 0 {
 		t.Errorf("conversations.replies calls = %d, want 0", got)
@@ -362,7 +362,7 @@ func TestThreadContext_NoPriorsAfterFilteringEmitsNoPreamble(t *testing.T) {
 		Text:     "@mayor first mention",
 	})
 	env := slackEventEnvelope{Type: "event_callback", Event: rawMsg}
-	processSlackEvent(cfg, newTestHandleAliasRegistry(t), nil, nil, env, func() {})
+	processSlackEvent(cfg, newTestHandleAliasRegistry(t), nil, nil, nil, env, func() {})
 
 	if got := atomic.LoadInt32(calls); got != 1 {
 		t.Errorf("conversations.replies calls = %d, want 1 (one fetch attempted, no preamble emitted)", got)
@@ -414,8 +414,8 @@ func TestThreadContext_FetchFailureRetriesNextInbound(t *testing.T) {
 		return raw
 	}
 	aliasReg := newTestHandleAliasRegistry(t)
-	processSlackEvent(cfg, aliasReg, nil, nil, slackEventEnvelope{Type: "event_callback", Event: mk("600.000002")}, func() {})
-	processSlackEvent(cfg, aliasReg, nil, nil, slackEventEnvelope{Type: "event_callback", Event: mk("600.000003")}, func() {})
+	processSlackEvent(cfg, aliasReg, nil, nil, nil, slackEventEnvelope{Type: "event_callback", Event: mk("600.000002")}, func() {})
+	processSlackEvent(cfg, aliasReg, nil, nil, nil, slackEventEnvelope{Type: "event_callback", Event: mk("600.000003")}, func() {})
 
 	if got := atomic.LoadInt32(&calls); got != 2 {
 		t.Errorf("conversations.replies calls = %d, want 2 (errors must retry per inbound, not permanently suppress)", got)
@@ -494,7 +494,7 @@ func TestThreadContext_CrossAgentDeltaVisibility(t *testing.T) {
 	}
 
 	// Step 1: mayor mentioned. Should see U_ALICE's prior only.
-	processSlackEvent(cfg, aliasReg, nil, nil, slackEventEnvelope{Type: "event_callback", Event: mk("700.000002", "@mayor weigh in?")}, func() {})
+	processSlackEvent(cfg, aliasReg, nil, nil, nil, slackEventEnvelope{Type: "event_callback", Event: mk("700.000002", "@mayor weigh in?")}, func() {})
 
 	// Step 2: a peer human posts a reply. Slack returns it on
 	// subsequent fetches.
@@ -505,7 +505,7 @@ func TestThreadContext_CrossAgentDeltaVisibility(t *testing.T) {
 	// Step 3: PL mentioned. PL has no cache entry yet, so PL sees
 	// EVERYTHING posted before this inbound: U_ALICE's prior AND
 	// the U_PEER reply. This is the cross-agent visibility payoff.
-	processSlackEvent(cfg, aliasReg, nil, nil, slackEventEnvelope{Type: "event_callback", Event: mk("700.000004", "@PL your read?")}, func() {})
+	processSlackEvent(cfg, aliasReg, nil, nil, nil, slackEventEnvelope{Type: "event_callback", Event: mk("700.000004", "@PL your read?")}, func() {})
 
 	// Step 4: another peer reply lands.
 	serverMu.Lock()
@@ -518,7 +518,7 @@ func TestThreadContext_CrossAgentDeltaVisibility(t *testing.T) {
 	// (700.000006): U_PEER@700.000003 and U_PEER2@700.000005.
 	// U_ALICE@700.000001 is filtered out — already delivered to
 	// mayor at step 1.
-	processSlackEvent(cfg, aliasReg, nil, nil, slackEventEnvelope{Type: "event_callback", Event: mk("700.000006", "@mayor counter?")}, func() {})
+	processSlackEvent(cfg, aliasReg, nil, nil, nil, slackEventEnvelope{Type: "event_callback", Event: mk("700.000006", "@mayor counter?")}, func() {})
 
 	if got := atomic.LoadInt32(&calls); got != 3 {
 		t.Errorf("conversations.replies calls = %d, want 3 (one per inbound in thread)", got)
@@ -608,8 +608,8 @@ func TestThreadContext_IsolationAcrossThreads(t *testing.T) {
 		Text: "@mayor in B",
 	})
 	aliasReg := newTestHandleAliasRegistry(t)
-	processSlackEvent(cfg, aliasReg, nil, nil, slackEventEnvelope{Type: "event_callback", Event: threadA}, func() {})
-	processSlackEvent(cfg, aliasReg, nil, nil, slackEventEnvelope{Type: "event_callback", Event: threadB}, func() {})
+	processSlackEvent(cfg, aliasReg, nil, nil, nil, slackEventEnvelope{Type: "event_callback", Event: threadA}, func() {})
+	processSlackEvent(cfg, aliasReg, nil, nil, nil, slackEventEnvelope{Type: "event_callback", Event: threadB}, func() {})
 
 	msgs := capture.snapshot()
 	if len(msgs) != 2 {


### PR DESCRIPTION
## Summary

Routes Slack User Group mentions to gc sessions through the existing handle-alias system, so a human can pick a handle from Slack's native @-autocomplete dropdown instead of typing the `@handle:` text prefix.

## Background

slack-pack's address-by-handle routing currently requires a human to type a literal `@handle:` text prefix. Slack itself has no knowledge of these handles, so its native @-autocomplete cannot surface them. Slack User Groups *do* appear in the autocomplete dropdown; when one is selected, Slack delivers the message with one of two head-of-text tokens. Both should route the same way as `@handle:`.

```
Labeled:    <!subteam^TEAMID|@handle>   (autocomplete in text mode)
Unlabeled:  <!subteam^TEAMID>           (event-payload form)
```

The labeled form carries the human-readable handle next to the team ID and works out-of-the-box once the parser recognizes it. The unlabeled form has only the team ID — to map it back to a handle, slack-pack consults an operator-edited static alias file.

## Change

### Labeled form — `<!subteam^TEAMID|@handle>`

- New `parseSubteamMentionPrefix` recognizes the labeled token at the head of trimmed inbound text and extracts `(handle, subteamID, remainder)`.
- `processSlackEvent` runs the subteam parser before the existing `parseHandlePrefix`. The labeled path is gated on `aliasReg.Get(handle)`: only User Group labels that match a registered handle alias trigger address-by-handle dispatch. Unregistered labels fall through with the original text preserved, so a channel-bound session still sees the raw mention.
- The existing `@handle:` text-prefix routing and the `@@<handle>` launcher path are unchanged.

### Unlabeled form — `<!subteam^TEAMID>`

- `parseSubteamMentionPrefix` also recognizes the unlabeled token and returns `(handle="", subteamID, remainder)`.
- New `subteamAliasMap` (read-only, operator-edited JSON file) maps subteam IDs to handles. When the parser returns an unlabeled mention, `processSlackEvent` looks up the team ID against the alias map and, if found, dispatches to the resolved handle exactly like the labeled path.
- File location is configurable via `SLACK_SUBTEAM_ALIAS_FILE`; the default is `<GC_CITY_PATH>/.gc/slack/subteam-aliases.json`.
- Format is a flat object:
  ```json
  {
    "S0B4MUNDZCH": "mayor",
    "S0123ABCDEF": "cos"
  }
  ```
- `SIGHUP` to the adapter reloads the alias map without a restart, matching the existing handle-alias reload semantics.
- If the file is absent or unreadable, the unlabeled path is a no-op — the message falls through with the raw mention preserved (same fallback as an unrecognized labeled mention).

## Tests

- `subteam_mention_prefix_test.go` — parser cases for both labeled and unlabeled tokens (including malformed, whitespace, leading/trailing variants).
- `subteam_mention_dispatch_test.go` — integration tests through `processSlackEvent` covering: labeled→registered handle dispatch, labeled→unregistered handle fallthrough, unlabeled→aliased dispatch, unlabeled→unaliased fallthrough, unlabeled with missing alias file.
- `subteam_alias_map_test.go` — alias map load, reload-on-SIGHUP, malformed-file behavior, file-absent behavior.
- `go build` / `go vet` / `go test -race -count=1 ./...` green on `slack-pack/adapter` + `slack-pack/cli`; `python3 -m pytest slack-pack/tests/` 66 passing.

## Operator notes

- To enable User Group routing for unlabeled mentions on a workspace, populate the alias file with `{subteam_id: handle}` mappings and `SIGHUP` the adapter.
- The labeled form requires no operator setup beyond the existing handle-alias registration.
- Both forms route through the same address-by-handle dispatch as `@handle:`, so the receiving session sees the standard "Slack address-by-handle: @&lt;handle&gt; addressed you" system reminder.