### PR TITLE
feat(pr-review,pr-pipeline): claim root bead at intake before checkout (gpk-9vv)

### DIFF
--- a/pr-pipeline/formulas/mol-pr-review.formula.toml
+++ b/pr-pipeline/formulas/mol-pr-review.formula.toml
@@ -54,8 +54,15 @@ title = "Fetch PR metadata and diff"
 description = """
 Resolve the PR identifier, fetch its data, and prepare the workspace.
 
+**Claim the root bead BEFORE any review work begins.** `bd update --claim`
+atomically sets assignee to your session and transitions status to
+`in_progress` (idempotent if already claimed by you). Without the claim,
+the bead stays `OPEN/assignee=none/started=no` while review work is in
+flight, and monitoring reads false stalls.
+
 ```bash
 ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+bd update "$ROOT_ID" --claim
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
     echo "Not in a git repository — cannot review PR."
     bd close "$ROOT_ID" --reason "not a git checkout"

--- a/pr-review/formulas/mol-adopt-pr.formula.toml
+++ b/pr-review/formulas/mol-adopt-pr.formula.toml
@@ -51,10 +51,17 @@ description = """
 Parse the PR, fetch metadata, validate scope, checkout the branch, and record
 initial state in the root bead notes.
 
-**1. Find the root bead:**
+**1. Find the root bead and claim it (BEFORE any `git checkout`):**
 ```bash
 ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+bd update "$ROOT_ID" --claim
 ```
+
+`bd update --claim` atomically sets assignee to your session and transitions
+status to `in_progress` (idempotent if already claimed by you). The claim
+**MUST** happen before any `git checkout` of the contributor's branch.
+Otherwise the bead stays `OPEN/assignee=none/started=no` while real review
+work is in flight, and monitoring reads false stalls.
 
 **2. Parse PR identifier from `{{pr}}`:**
 - If `{{pr}}` matches `https://github.com/.*/pull/\\d+` → extract owner, repo, PR number from URL


### PR DESCRIPTION
## Summary

Adds `bd update "$ROOT_ID" --claim` as the first observable action of the intake step in both formulas, so the bead is claimed BEFORE `gh pr view`/`gh pr diff` work begins. Fixes the false-stall pattern where a polecat starts intake work but a dispatcher sees the bead as unclaimed and re-routes.

Files:
- `pr-review/formulas/mol-adopt-pr.formula.toml` (intake step 1)
- `pr-pipeline/formulas/mol-pr-review.formula.toml` (intake first bash block)

## Why both formulas

`mol-pr-review` had the same shape as `mol-adopt-pr` — intake started `gh pr view` / `gh pr diff` work without claiming. Fixing only one would have left the dispatch race in place on the review path.

The claim is atomic + idempotent (`bd update --claim` sets assignee + status=in_progress; no-op if already claimed by you), so it's safe under compaction-resume and re-dispatch.

## Trigger-case cross-ref

Maintenance-PL Path B fan-out across beads `gc-n13e2 / gc-z1oqt / gc-85vld / gc-0ofz4 / gc-d74e6 / gc-ti8so / gc-9arvq` appeared as false stalls because intake didn't claim before checkout. This change removes that race.

## Test plan

- [x] TOML parse passes for both formulas
- [ ] Maintenance-PL Path B fan-out no longer shows false-stall pattern