### PR TITLE
feat(slack-pack): add gc slack sync-subteam-aliases verb + relax @-in-label requirement

### DIFF
--- a/slack-pack/README.md
+++ b/slack-pack/README.md
@@ -78,6 +78,19 @@ Not yet implemented (planned):
       record; `--remove-channels c1,c2` drops just the listed channels
       (the record itself is deleted if the set becomes empty). Both
       removal paths are idempotent.
+- [x] `gc slack sync-subteam-aliases` — reconcile
+      `<city>/.gc/slack/subteam-aliases.json` (the Slack User Group
+      ("subteam") id → gc handle map) with the workspace's live User
+      Groups via Slack `usergroups.list`. Like `sync-commands`, it diffs
+      live against on-disk and supports `--dry-run` and
+      `--output text|json`; unlike it, the write is a non-destructive
+      MERGE — existing entries are preserved, handles are refreshed where
+      the live name differs, new User Groups are added, and entries with
+      no matching live group are kept and reported as "local-only" rather
+      than dropped. The bot token (`--token` / `$SLACK_BOT_TOKEN`) must
+      carry the `usergroups:read` scope; without it the verb reports a
+      readable `missing_scope` error and writes nothing. After a write it
+      prints the same SIGHUP reminder as the other registry-writing verbs.
 - [ ] `gc slack enable-room-launch` (`@@handle` thread-scoped sessions)
 - [ ] `gc slack post-message` (workflow status projection)
 - [x] `gc slack retry-peer-fanout` (walks `extmsg.peer_fanout_failed`
@@ -129,7 +142,7 @@ either can travel intact when the pack is mirrored upstream:
 - **Operator CLI** — `examples/slack-pack/cli/gc-slack-cli`, built
   from `cli/main.go` + `cli/cmd/`. Backs the `gc slack <cmd>` verb
   surface (import-app, map-channel, map-rig, sync-commands,
-  enable-room-launch, post-message). One-shot per invocation; not
+  sync-subteam-aliases, enable-room-launch, post-message). One-shot per invocation; not
   supervised. The pack's `commands/<cmd>.sh` wrappers exec it at
   `$GC_PACK_DIR/cli/gc-slack-cli` so operator command-line ergonomics
   stay identical to the pre-relocation gc-binary verbs.
@@ -289,7 +302,7 @@ package docstring at the top of that file. Summary:
 | `HANDLE_PREFIX`                | `@`                                              | Leading address token for keyword routing. Empty disables routing.              |
 | `IDENTITY_STORE_PATH`          | `/tmp/gc-slack-adapter/identities.json`          | JSON file backing the per-session `chat:write.customize` identity registry.    |
 | `HANDLE_ALIAS_STORE_PATH`      | `/tmp/gc-slack-adapter/handle-aliases.json`      | JSON file backing the cross-channel handle → session-id alias registry.        |
-| `SLACK_SUBTEAM_ALIAS_FILE`     | `<GC_CITY_PATH>/.gc/slack/subteam-aliases.json` (or `/tmp/gc-slack-adapter/subteam-aliases.json`) | Operator-edited JSON map of Slack User Group ("subteam") IDs → gc handles. Required to route the unlabeled `<!subteam^Sxxx>` mention shape; the labeled `<!subteam^Sxxx|@handle>` shape is gated by `HANDLE_ALIAS_STORE_PATH` instead. Read-only at runtime; SIGHUP or restart to reload. |
+| `SLACK_SUBTEAM_ALIAS_FILE`     | `<GC_CITY_PATH>/.gc/slack/subteam-aliases.json` (or `/tmp/gc-slack-adapter/subteam-aliases.json`) | JSON map of Slack User Group ("subteam") IDs → gc handles, hand-edited or written by `gc slack sync-subteam-aliases`. Required to route the unlabeled `<!subteam^Sxxx>` mention shape; the labeled `<!subteam^Sxxx\|@handle>` / `<!subteam^Sxxx\|handle>` shape is gated by `HANDLE_ALIAS_STORE_PATH` instead. Read-only at runtime; SIGHUP or restart to reload. |
 | `INBOUND_FILE_STORE`           | `/tmp/gc-slack-adapter/inbound`                  | Directory for downloaded inbound Slack file attachments.                        |
 | `INBOUND_FILE_TTL`             | `168h` (7 days)                                  | Janitor retention. `0` disables sweeping.                                       |
 | `INBOUND_FILE_SWEEP_INTERVAL`  | `1h`                                             | Janitor scan period. `0` disables sweeping.                                     |
@@ -318,15 +331,16 @@ the adapter runs as a `[[service]]`; do not set them by hand):
 
 ### SIGHUP-driven reload
 
-Four of the adapter's registries are written by `gc slack` CLI
+Five of the adapter's registries are written by `gc slack` CLI
 commands and read by the adapter at startup:
 
-| Registry             | File                          | CLI writer                    |
-| -------------------- | ----------------------------- | ----------------------------- |
-| Apps                 | `apps.json`                   | `gc slack import-app`         |
-| Channel mappings     | `channel_mappings.json`       | `gc slack map-channel`        |
-| Rig mappings         | `rig_mappings.json`           | `gc slack map-rig`            |
-| Room launch mappings | `room_launch_mappings.json`   | `gc slack enable-room-launch` |
+| Registry             | File                          | CLI writer                      |
+| -------------------- | ----------------------------- | ------------------------------- |
+| Apps                 | `apps.json`                   | `gc slack import-app`           |
+| Channel mappings     | `channel_mappings.json`       | `gc slack map-channel`          |
+| Rig mappings         | `rig_mappings.json`           | `gc slack map-rig`              |
+| Room launch mappings | `room_launch_mappings.json`   | `gc slack enable-room-launch`   |
+| Subteam aliases      | `subteam-aliases.json`        | `gc slack sync-subteam-aliases` |
 
 Send `SIGHUP` to the running adapter to pick up CLI-driven changes
 without a full restart:
@@ -335,7 +349,7 @@ without a full restart:
 pkill -HUP gc-slack-adapter
 ```
 
-Reload is all-or-nothing across the four files — a single parse
+Reload is all-or-nothing across the five files — a single parse
 failure (corrupt JSON, unknown `target_kind`, missing required field,
 file >10 MiB) aborts the cycle with the live in-memory state
 untouched. Errors are logged at WARN; the adapter keeps serving.

--- a/slack-pack/adapter/subteam_mention_dispatch_test.go
+++ b/slack-pack/adapter/subteam_mention_dispatch_test.go
@@ -309,6 +309,121 @@ func TestProcessSlackEventSingleAtHandleStillDispatches(t *testing.T) {
 	}
 }
 
+// TestProcessSlackEventSubteamMentionLabelWithoutAtRoutesToHandle is the
+// gpk-ee3 happy path: Slack omits the `@` in a User Group label when a
+// human types the mention naturally (e.g. `@zelda-pl` expands to
+// `<!subteam^Sxxx|zelda-pl>`). That bare-label form must route through
+// the same address-by-handle dispatch path the `@`-labeled form uses —
+// before gpk-ee3 it landed with target="" and no dispatch fired.
+func TestProcessSlackEventSubteamMentionLabelWithoutAtRoutesToHandle(t *testing.T) {
+	capture := &subteamCapture{}
+	gcStub := httptest.NewServer(capture.handler())
+	t.Cleanup(gcStub.Close)
+
+	cfg := config{
+		gcAPIBase:     gcStub.URL,
+		cityName:      "test-city",
+		provider:      "slack",
+		accountID:     "T1",
+		handlePrefix:  "@",
+		slackBotToken: "xoxb-test",
+		dispatchSem:   defaultTestDispatchSem,
+	}
+	aliasReg := newTestHandleAliasRegistry(t)
+	if err := aliasReg.Set("zelda-pl", "gc-9001"); err != nil {
+		t.Fatalf("aliasReg.Set: %v", err)
+	}
+
+	rawMsg, _ := json.Marshal(slackMessageEvent{
+		Type:    "message",
+		Channel: "C1",
+		User:    "U1",
+		TS:      "1700000000.000900",
+		Text:    "<!subteam^S0ZELDA|zelda-pl> ship it",
+	})
+	env := slackEventEnvelope{Type: "event_callback", Event: rawMsg}
+
+	processSlackEvent(cfg, aliasReg, nil, nil, nil, nil, env, func() {})
+
+	inbounds := capture.snapshotInbounds()
+	if len(inbounds) != 1 {
+		t.Fatalf("got %d inbound POSTs, want 1", len(inbounds))
+	}
+	if inbounds[0].ExplicitTarget != "zelda-pl" {
+		t.Errorf("ExplicitTarget = %q, want %q (bare label must route as handle)",
+			inbounds[0].ExplicitTarget, "zelda-pl")
+	}
+	if inbounds[0].Text != "ship it" {
+		t.Errorf("Text = %q, want %q (subteam token must be stripped)", inbounds[0].Text, "ship it")
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if atomic.LoadInt32(&capture.sessionHits) > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := atomic.LoadInt32(&capture.sessionHits); got != 1 {
+		t.Fatalf("session-message hits = %d, want 1 (bare-label alias dispatch should fire)", got)
+	}
+	capture.mu.Lock()
+	gotPath := capture.sessionPath
+	capture.mu.Unlock()
+	if !strings.Contains(gotPath, "/session/gc-9001/messages") {
+		t.Errorf("session path = %q, want to contain %q", gotPath, "/session/gc-9001/messages")
+	}
+}
+
+// TestProcessSlackEventSubteamMentionBareLabelInvalidCharFallsThrough is
+// the gpk-ee3 safety case: a bare label containing an invalid handle
+// character (a space here) must NOT parse as a subteam mention. The
+// parser returns ok=false, the inbound posts with the full original
+// text and an empty ExplicitTarget, and no alias dispatch fires.
+func TestProcessSlackEventSubteamMentionBareLabelInvalidCharFallsThrough(t *testing.T) {
+	capture := &subteamCapture{}
+	gcStub := httptest.NewServer(capture.handler())
+	t.Cleanup(gcStub.Close)
+
+	cfg := config{
+		gcAPIBase:     gcStub.URL,
+		cityName:      "test-city",
+		provider:      "slack",
+		accountID:     "T1",
+		handlePrefix:  "@",
+		slackBotToken: "xoxb-test",
+		dispatchSem:   defaultTestDispatchSem,
+	}
+	aliasReg := newTestHandleAliasRegistry(t)
+
+	rawMsg, _ := json.Marshal(slackMessageEvent{
+		Type:    "message",
+		Channel: "C1",
+		User:    "U1",
+		TS:      "1700000000.001000",
+		Text:    "<!subteam^S0XXX|foo bar> hello",
+	})
+	env := slackEventEnvelope{Type: "event_callback", Event: rawMsg}
+
+	processSlackEvent(cfg, aliasReg, nil, nil, nil, nil, env, func() {})
+
+	inbounds := capture.snapshotInbounds()
+	if len(inbounds) != 1 {
+		t.Fatalf("got %d inbound POSTs, want 1", len(inbounds))
+	}
+	if inbounds[0].ExplicitTarget != "" {
+		t.Errorf("ExplicitTarget = %q, want empty (invalid bare label must not parse)", inbounds[0].ExplicitTarget)
+	}
+	if inbounds[0].Text != "<!subteam^S0XXX|foo bar> hello" {
+		t.Errorf("Text = %q, want full original preserved (parse miss)", inbounds[0].Text)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	if got := atomic.LoadInt32(&capture.sessionHits); got != 0 {
+		t.Errorf("session-message hits = %d, want 0 (no valid handle, no dispatch)", got)
+	}
+}
+
 // newTestSubteamAliasMap builds a subteamAliasMap from an in-memory
 // {subteam_id: handle} map by staging it through a tmpfile. Tests that
 // need a populated map use this rather than touching production

--- a/slack-pack/adapter/subteam_mention_prefix.go
+++ b/slack-pack/adapter/subteam_mention_prefix.go
@@ -42,11 +42,14 @@ import "strings"
 //
 //   - Leading whitespace is tolerated; the token must start at the
 //     trimmed text's first byte.
-//   - For the labeled form, the label is the longest run of
-//     [A-Za-z0-9_-] following the `@`. Empty label or a label with
-//     other characters returns ok=false (operators should populate
-//     subteamAliasMap directly rather than relying on a malformed
-//     label).
+//   - For the labeled form, the label is the run of [A-Za-z0-9_-]
+//     after an OPTIONAL single leading `@`. Slack's native
+//     @-autocomplete emits `|@handle`, but a User Group mention typed
+//     by a human commonly arrives as `|handle` with no `@` — both are
+//     accepted and normalized to the same `@`-stripped handle. Empty
+//     label, a bare `@`, or a label containing any other character
+//     returns ok=false (operators should populate subteamAliasMap
+//     directly rather than relying on a malformed label).
 //   - For the unlabeled form, TEAMID is everything between `^` and
 //     `>`; empty TEAMID returns ok=false.
 //   - After the closing `>`, any leading colon (`:`) is trimmed,
@@ -57,7 +60,7 @@ import "strings"
 //   - text whose trimmed head is not `<!subteam^`
 //   - missing closing `>`
 //   - empty subteam ID (`<!subteam^>`, `<!subteam^|@h>`)
-//   - empty label in the labeled form (`<!subteam^Sxxx|@>`)
+//   - empty label in the labeled form (`<!subteam^Sxxx|>` or `<!subteam^Sxxx|@>`)
 //   - label with an invalid character (`<!subteam^X|@bad.handle>`)
 //
 // On any non-match the returned strings are empty so the caller cannot
@@ -95,11 +98,16 @@ func parseSubteamMentionPrefix(text string) (handle, subteamID, remainder string
 
 	var parsedHandle string
 	if pipe >= 0 {
-		// Labeled form: validate the `@<handle>` shape.
-		if len(label) == 0 || label[0] != '@' {
-			return "", "", "", false
+		// Labeled form: accept `@handle` (Slack @-autocomplete) and the
+		// bare `handle` shape (human-typed User Group mention — Slack
+		// omits the `@` in the label for those). Strip one optional
+		// leading `@`, then require the remainder be a valid handle
+		// character run. An empty label, or a label that is just `@`,
+		// leaves an empty candidate and is rejected below.
+		candidate := label
+		if len(candidate) > 0 && candidate[0] == '@' {
+			candidate = candidate[1:]
 		}
-		candidate := label[1:]
 		handleEnd := 0
 		for i := 0; i < len(candidate); i++ {
 			r := candidate[i]

--- a/slack-pack/adapter/subteam_mention_prefix_test.go
+++ b/slack-pack/adapter/subteam_mention_prefix_test.go
@@ -157,10 +157,47 @@ func TestParseSubteamMentionPrefix(t *testing.T) {
 			wantOK:        true,
 		},
 
+		// --- labeled form without `@` (gpk-ee3 new behavior) -----------
+		// Slack omits the `@` in the label when a human types a User
+		// Group mention (e.g. `@zelda-pl` expands to `<!subteam^Sxxx|zelda-pl>`).
+		// The label is treated as the handle, identical to the `@`-form.
+		{
+			name:          "label without leading at sign accepted",
+			text:          "<!subteam^S012|mayor> hi",
+			wantHandle:    "mayor",
+			wantSubteamID: "S012",
+			wantRemainder: "hi",
+			wantOK:        true,
+		},
+		{
+			name:          "label without at sign, dash handle, no remainder",
+			text:          "<!subteam^S0XXX|zelda-pl>",
+			wantHandle:    "zelda-pl",
+			wantSubteamID: "S0XXX",
+			wantRemainder: "",
+			wantOK:        true,
+		},
+		{
+			name:          "label without at sign, colon-space remainder",
+			text:          "<!subteam^S0XXX|zelda-pl>: deploy now",
+			wantHandle:    "zelda-pl",
+			wantSubteamID: "S0XXX",
+			wantRemainder: "deploy now",
+			wantOK:        true,
+		},
+		{
+			name:          "label without at sign, invalid char rejected",
+			text:          "<!subteam^S0XXX|foo bar> hi",
+			wantHandle:    "",
+			wantSubteamID: "",
+			wantRemainder: "",
+			wantOK:        false,
+		},
+
 		// --- rejected shapes -------------------------------------------
 		{
-			name:          "label missing leading at sign rejected",
-			text:          "<!subteam^S012|mayor> hi",
+			name:          "empty label (bare pipe) rejected",
+			text:          "<!subteam^S012|> hi",
 			wantHandle:    "",
 			wantSubteamID: "",
 			wantRemainder: "",

--- a/slack-pack/cli/cmd/sync_subteam_aliases.go
+++ b/slack-pack/cli/cmd/sync_subteam_aliases.go
@@ -1,0 +1,483 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/sjarmak/gc-slack-cli/internal/state/workspace"
+)
+
+// sync-subteam-aliases reconciles <city>/.gc/slack/subteam-aliases.json
+// — the operator-edited Slack User Group ("subteam") ID → gc handle map
+// the adapter consults when routing unlabeled `<!subteam^Sxxx>` mentions
+// — with the workspace's live Slack User Groups.
+//
+// The write is a MERGE, never a replace: every entry already on disk is
+// preserved. Entries whose subteam ID matches a live User Group have
+// their handle refreshed to the live value; brand-new live User Groups
+// are added; entries with no matching live User Group are left in place
+// and reported under "local-only" so a hand-added or now-deleted binding
+// is visible without being clobbered.
+//
+// usergroups.list needs the bot token to carry the `usergroups:read`
+// scope. Apps without it get a readable `missing_scope` error — the
+// operator can still hand-edit the file, exactly as before this verb
+// existed.
+
+const (
+	// subteamAliasesFilename is the on-disk name under <city>/.gc/slack/.
+	// Must match the adapter's default subteamAliasStorePath so a write
+	// here is the same file the adapter reads on SIGHUP.
+	subteamAliasesFilename = "subteam-aliases.json"
+
+	// slackUsergroupsListMethod is the Slack web API method this verb
+	// calls. Documented at https://api.slack.com/methods/usergroups.list
+	slackUsergroupsListMethod = "usergroups.list"
+)
+
+type subteamSyncOpts struct {
+	workspaceID string
+	token       string
+	apiBase     string
+	dryRun      bool
+	output      string
+	timeout     time.Duration
+}
+
+// subteamAliasEntry is a (subteam_id, handle) pair used for the added,
+// unchanged, and local-only diff buckets.
+type subteamAliasEntry struct {
+	SubteamID string `json:"subteam_id"`
+	Handle    string `json:"handle"`
+}
+
+// subteamAliasChange records a binding whose handle differs between the
+// saved file and the live Slack User Group.
+type subteamAliasChange struct {
+	SubteamID string `json:"subteam_id"`
+	From      string `json:"from"`
+	To        string `json:"to"`
+}
+
+// subteamAliasDiff is the structured diff between the saved file and the
+// live usergroups list.
+//
+// LocalOnly entries are on disk but absent from the live list. They are
+// PRESERVED in the written file — operator-added bindings are never
+// dropped — and surfaced here only so the operator can spot a binding
+// Slack no longer knows about (e.g. a deleted User Group, or a hand-
+// added entry whose ID was mistyped).
+type subteamAliasDiff struct {
+	Added     []subteamAliasEntry  `json:"added"`
+	Changed   []subteamAliasChange `json:"changed"`
+	Unchanged []subteamAliasEntry  `json:"unchanged"`
+	LocalOnly []subteamAliasEntry  `json:"local_only"`
+}
+
+// writeNeeded reports whether the merge would alter the file. Only adds
+// and handle changes mutate disk; unchanged and local-only entries
+// round-trip identically, so a diff with only those is a no-op write we
+// skip.
+func (d subteamAliasDiff) writeNeeded() bool {
+	return len(d.Added) > 0 || len(d.Changed) > 0
+}
+
+// NewSyncSubteamAliasesCmd wires the cobra verb. The runner is split out
+// so tests can drive the same code path without re-parsing flags
+// (mirrors NewSyncCommandsCmd).
+func NewSyncSubteamAliasesCmd(stdout, _ io.Writer) *cobra.Command {
+	var o subteamSyncOpts
+	cmd := &cobra.Command{
+		Use:   "sync-subteam-aliases",
+		Short: "Reconcile subteam-aliases.json with the workspace's live Slack User Groups",
+		Long: `Reconcile <city>/.gc/slack/subteam-aliases.json with the workspace's
+live Slack User Groups.
+
+Calls Slack usergroups.list, then MERGES the result into the on-disk
+map of Slack User Group ("subteam") ids → gc handles. The merge is
+non-destructive: existing entries are preserved, handles are refreshed
+where the live User Group name differs, and brand-new User Groups are
+added. Entries with no matching live User Group are left in place and
+reported as "local-only".
+
+The adapter reads this file at startup and on SIGHUP to route the
+unlabeled '<!subteam^Sxxx>' mention shape to the bound handle.
+
+The Slack bot token (xoxb-...) is read from --token or $` + slackBotTokenEnv + `
+and MUST carry the usergroups:read scope; without it the verb reports
+a readable missing_scope error and writes nothing.
+
+Schema: https://api.slack.com/methods/usergroups.list`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runSlackSyncSubteamAliases(cmd.Context(), stdout, o)
+		},
+	}
+	defaultWorkspace := workspace.IDDefault()
+	cmd.Flags().StringVar(&o.workspaceID, "workspace-id", defaultWorkspace,
+		workspace.IDFlagUsage)
+	cmd.Flags().StringVar(&o.token, "token", "",
+		"Slack bot token (xoxb-...) with the usergroups:read scope. Falls back to $"+slackBotTokenEnv)
+	cmd.Flags().StringVar(&o.apiBase, "api-base", "",
+		"Slack web API base URL (defaults to $"+slackAPIBaseEnv+" or "+slackChatAPIDefaultBase+"). "+
+			"Trusted operator-only flag — do not source from untrusted input; the verb sends the bot token to whatever host this resolves to.")
+	cmd.Flags().BoolVar(&o.dryRun, "dry-run", false,
+		"Print the diff and exit without writing subteam-aliases.json")
+	cmd.Flags().StringVar(&o.output, "output", "text",
+		"Output format: text|json")
+	cmd.Flags().DurationVar(&o.timeout, "timeout", 30*time.Second,
+		"Hard timeout for the entire operation")
+	if defaultWorkspace == "" {
+		_ = cmd.MarkFlagRequired("workspace-id")
+	}
+	return cmd
+}
+
+func runSlackSyncSubteamAliases(ctx context.Context, stdout io.Writer, o subteamSyncOpts) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if o.timeout <= 0 {
+		return fmt.Errorf("--timeout must be positive (got %v)", o.timeout)
+	}
+	if o.output != "text" && o.output != "json" {
+		return fmt.Errorf("--output %q: unsupported format; choose text or json", o.output)
+	}
+	ctx, cancel := context.WithTimeout(ctx, o.timeout)
+	defer cancel()
+
+	token := o.token
+	if token == "" {
+		token = strings.TrimSpace(os.Getenv(slackBotTokenEnv))
+	}
+	if token == "" {
+		return fmt.Errorf("slack bot token not provided (--token or $%s); it must carry the usergroups:read scope", slackBotTokenEnv)
+	}
+
+	apiBase := o.apiBase
+	if apiBase == "" {
+		apiBase = strings.TrimSpace(os.Getenv(slackAPIBaseEnv))
+	}
+	if apiBase == "" {
+		apiBase = slackChatAPIDefaultBase
+	}
+
+	cityPath, err := ResolveCityPath()
+	if err != nil {
+		return fmt.Errorf("resolve city: %w", err)
+	}
+	path := filepath.Join(cityPath, ".gc", "slack", subteamAliasesFilename)
+
+	existing, err := loadSubteamAliasFile(path)
+	if err != nil {
+		return err
+	}
+
+	live, err := slackUsergroupsList(ctx, apiBase, token, o.workspaceID)
+	if err != nil {
+		return err
+	}
+
+	diff, merged := computeSubteamAliasDiff(existing, live)
+
+	wrote := false
+	if !o.dryRun && diff.writeNeeded() {
+		if err := writeSubteamAliasFile(path, merged); err != nil {
+			return err
+		}
+		wrote = true
+	}
+
+	if o.output == "json" {
+		return emitSubteamSyncJSON(stdout, o, path, diff, wrote, len(merged))
+	}
+
+	printSubteamDiffText(stdout, diff)
+	switch {
+	case o.dryRun:
+		fmt.Fprintf(stdout, "Dry run: would write %d entries to %s (no changes applied).\n", len(merged), path) //nolint:errcheck // best-effort stdout
+	case wrote:
+		fmt.Fprintf(stdout, "Wrote %d entries to %s\n", len(merged), path) //nolint:errcheck // best-effort stdout
+		fmt.Fprintln(stdout, MapRigRestartReminder)                        //nolint:errcheck // best-effort stdout
+	default:
+		fmt.Fprintf(stdout, "subteam-aliases.json already in sync (%d entries); no write issued.\n", len(merged)) //nolint:errcheck // best-effort stdout
+	}
+	return nil
+}
+
+// --- Slack API client -----------------------------------------------------
+
+// slackUsergroup is the subset of a usergroups.list entry we consume.
+// `handle` is the workspace-admin-chosen short name (e.g. "zelda-pl")
+// and is what an adapter routes a `<!subteam^Sxxx>` mention to.
+type slackUsergroup struct {
+	ID     string `json:"id"`
+	TeamID string `json:"team_id"`
+	Handle string `json:"handle"`
+	Name   string `json:"name"`
+}
+
+// slackUsergroupsListResponse is the usergroups.list envelope. `needed`
+// / `provided` accompany an `ok:false` missing_scope error and let the
+// verb name the exact scope to add.
+type slackUsergroupsListResponse struct {
+	OK         bool             `json:"ok"`
+	Error      string           `json:"error,omitempty"`
+	Needed     string           `json:"needed,omitempty"`
+	Provided   string           `json:"provided,omitempty"`
+	Usergroups []slackUsergroup `json:"usergroups,omitempty"`
+}
+
+// slackUsergroupsList calls usergroups.list with the bot token and
+// returns the live User Groups. When workspaceID is set, results are
+// filtered to that team client-side (a regular workspace bot token is
+// already single-workspace; this also keeps an org-level token from
+// polluting the file with other workspaces' groups). The `team_id`
+// request param is deliberately NOT sent — it is only valid for
+// org-level tokens and would error on a plain workspace token.
+func slackUsergroupsList(ctx context.Context, apiBase, token, workspaceID string) ([]slackUsergroup, error) {
+	endpoint := strings.TrimRight(apiBase, "/") + "/" + slackUsergroupsListMethod
+	form := url.Values{}
+	// include_disabled defaults to false; deleted/disabled groups are
+	// excluded so they surface as "local-only" rather than being
+	// re-confirmed.
+	form.Set("include_disabled", "false")
+	form.Set("include_count", "false")
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("build %s request: %w", slackUsergroupsListMethod, err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Authorization", "Bearer "+token)
+	client := &http.Client{Timeout: 15 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		// %w preserves *url.Error, which references the URL but not the
+		// Authorization header, so the token does not leak here.
+		return nil, fmt.Errorf("post %s: %w", endpoint, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("read %s response: %w", slackUsergroupsListMethod, err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("slack %s http %d: %s", slackUsergroupsListMethod, resp.StatusCode, truncatePost(string(body), slackErrorBodyMaxLen))
+	}
+	var out slackUsergroupsListResponse
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, fmt.Errorf("decode %s response: %w (body=%s)", slackUsergroupsListMethod, err, truncatePost(string(body), slackErrorBodyMaxLen))
+	}
+	if !out.OK {
+		if out.Error == "missing_scope" {
+			needed := out.Needed
+			if needed == "" {
+				needed = "usergroups:read"
+			}
+			return nil, fmt.Errorf("slack %s: missing_scope — the bot token needs the %q scope (provided: %q). Add it to the Slack app's bot OAuth scopes, reinstall the app, then retry.",
+				slackUsergroupsListMethod, needed, out.Provided)
+		}
+		return nil, fmt.Errorf("slack %s api error: %s", slackUsergroupsListMethod, out.Error)
+	}
+
+	if workspaceID == "" {
+		return out.Usergroups, nil
+	}
+	filtered := out.Usergroups[:0:0]
+	for _, ug := range out.Usergroups {
+		if ug.TeamID != "" && ug.TeamID != workspaceID {
+			continue
+		}
+		filtered = append(filtered, ug)
+	}
+	return filtered, nil
+}
+
+// --- Diff & merge ----------------------------------------------------------
+
+// computeSubteamAliasDiff classifies each live User Group against the
+// saved map and returns both the diff (for reporting) and the merged
+// map to write. The merged map starts as a copy of existing — so no
+// on-disk binding is ever dropped — with live handles layered on top.
+func computeSubteamAliasDiff(existing map[string]string, live []slackUsergroup) (subteamAliasDiff, map[string]string) {
+	merged := make(map[string]string, len(existing)+len(live))
+	for id, h := range existing {
+		merged[id] = h
+	}
+
+	diff := subteamAliasDiff{
+		Added:     []subteamAliasEntry{},
+		Changed:   []subteamAliasChange{},
+		Unchanged: []subteamAliasEntry{},
+		LocalOnly: []subteamAliasEntry{},
+	}
+
+	liveIDs := make(map[string]struct{}, len(live))
+	for _, ug := range live {
+		// The adapter's parseSubteamAliasMap rejects empty ids and empty
+		// handles; never write one or a SIGHUP reload would fail. Skip
+		// defensively rather than poison the file.
+		if ug.ID == "" || ug.Handle == "" {
+			continue
+		}
+		liveIDs[ug.ID] = struct{}{}
+		switch prev, ok := existing[ug.ID]; {
+		case !ok:
+			diff.Added = append(diff.Added, subteamAliasEntry{SubteamID: ug.ID, Handle: ug.Handle})
+		case prev != ug.Handle:
+			diff.Changed = append(diff.Changed, subteamAliasChange{SubteamID: ug.ID, From: prev, To: ug.Handle})
+		default:
+			diff.Unchanged = append(diff.Unchanged, subteamAliasEntry{SubteamID: ug.ID, Handle: ug.Handle})
+		}
+		merged[ug.ID] = ug.Handle
+	}
+
+	for id, h := range existing {
+		if _, ok := liveIDs[id]; !ok {
+			diff.LocalOnly = append(diff.LocalOnly, subteamAliasEntry{SubteamID: id, Handle: h})
+		}
+	}
+
+	sortSubteamEntries(diff.Added)
+	sortSubteamEntries(diff.Unchanged)
+	sortSubteamEntries(diff.LocalOnly)
+	sort.Slice(diff.Changed, func(i, j int) bool { return diff.Changed[i].SubteamID < diff.Changed[j].SubteamID })
+	return diff, merged
+}
+
+func sortSubteamEntries(es []subteamAliasEntry) {
+	sort.Slice(es, func(i, j int) bool { return es[i].SubteamID < es[j].SubteamID })
+}
+
+// --- File IO ---------------------------------------------------------------
+
+// loadSubteamAliasFile reads the on-disk map. A missing file yields an
+// empty map (first sync), matching the adapter's "missing file = empty"
+// semantics.
+func loadSubteamAliasFile(path string) (map[string]string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return map[string]string{}, nil
+		}
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	var m map[string]string
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("decode %s: %w", path, err)
+	}
+	if m == nil {
+		m = map[string]string{}
+	}
+	return m, nil
+}
+
+// writeSubteamAliasFile atomically writes the merged map with 0600 perms
+// under a 0700 dir, mirroring the rigs/channels registry write so the
+// adapter's permission-tightener never has to loosen anything.
+func writeSubteamAliasFile(path string, m map[string]string) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("mkdir slack runtime dir %q: %w", dir, err)
+	}
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode subteam alias map: %w", err)
+	}
+	data = append(data, '\n')
+	f, err := os.CreateTemp(dir, "subteam-aliases-*.json.tmp")
+	if err != nil {
+		return fmt.Errorf("create subteam alias store tmp: %w", err)
+	}
+	tmpName := f.Name()
+	cleanup := func() { _ = os.Remove(tmpName) }
+	if err := f.Chmod(0o600); err != nil {
+		_ = f.Close()
+		cleanup()
+		return fmt.Errorf("chmod subteam alias store tmp: %w", err)
+	}
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		cleanup()
+		return fmt.Errorf("write subteam alias store tmp: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		cleanup()
+		return fmt.Errorf("close subteam alias store tmp: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		cleanup()
+		return fmt.Errorf("rename subteam alias store: %w", err)
+	}
+	return nil
+}
+
+// --- Output ----------------------------------------------------------------
+
+func printSubteamDiffText(w io.Writer, d subteamAliasDiff) {
+	if len(d.Added) > 0 {
+		fmt.Fprintln(w, "Added (live User Group, not on disk):") //nolint:errcheck // best-effort writer
+		for _, e := range d.Added {
+			fmt.Fprintf(w, "  + %s -> %s\n", e.SubteamID, e.Handle) //nolint:errcheck // best-effort writer
+		}
+	}
+	if len(d.Changed) > 0 {
+		fmt.Fprintln(w, "Changed (handle differs from live):") //nolint:errcheck // best-effort writer
+		for _, c := range d.Changed {
+			fmt.Fprintf(w, "  ~ %s: %s -> %s\n", c.SubteamID, c.From, c.To) //nolint:errcheck // best-effort writer
+		}
+	}
+	if len(d.LocalOnly) > 0 {
+		fmt.Fprintln(w, "Local-only (on disk, not in live Slack — preserved, not removed):") //nolint:errcheck // best-effort writer
+		for _, e := range d.LocalOnly {
+			fmt.Fprintf(w, "  = %s -> %s\n", e.SubteamID, e.Handle) //nolint:errcheck // best-effort writer
+		}
+	}
+	if len(d.Unchanged) > 0 {
+		fmt.Fprintf(w, "Unchanged: %d entr%s\n", len(d.Unchanged), plural(len(d.Unchanged))) //nolint:errcheck // best-effort writer
+	}
+}
+
+func plural(n int) string {
+	if n == 1 {
+		return "y"
+	}
+	return "ies"
+}
+
+// subteamSyncEnvelope is the structured --output json schema.
+type subteamSyncEnvelope struct {
+	WorkspaceID string           `json:"workspace_id"`
+	Path        string           `json:"path"`
+	Diff        subteamAliasDiff `json:"diff"`
+	WriteIssued bool             `json:"write_issued"`
+	DryRun      bool             `json:"dry_run"`
+	Total       int              `json:"total"`
+}
+
+func emitSubteamSyncJSON(w io.Writer, o subteamSyncOpts, path string, diff subteamAliasDiff, wrote bool, total int) error {
+	env := subteamSyncEnvelope{
+		WorkspaceID: o.workspaceID,
+		Path:        path,
+		Diff:        diff,
+		WriteIssued: wrote,
+		DryRun:      o.dryRun,
+		Total:       total,
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(env)
+}

--- a/slack-pack/cli/cmd/sync_subteam_aliases_test.go
+++ b/slack-pack/cli/cmd/sync_subteam_aliases_test.go
@@ -1,0 +1,305 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// usergroupsListStub returns an httptest server that answers
+// usergroups.list with the supplied response body and records how many
+// times it was hit. Non-usergroups.list paths 404 so a wrong endpoint
+// fails loudly.
+func usergroupsListStub(t *testing.T, respBody string) (*httptest.Server, *int) {
+	t.Helper()
+	hits := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/"+slackUsergroupsListMethod) {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		hits++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(respBody))
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &hits
+}
+
+// stageCity points GC_CITY_PATH at a fresh temp city (with a .gc marker
+// so ResolveCityPath accepts it) and returns the city path plus the
+// subteam-aliases.json path beneath it. When seed is non-nil it is
+// written as the pre-existing file.
+func stageCity(t *testing.T, seed map[string]string) (cityPath, aliasPath string) {
+	t.Helper()
+	cityPath = t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc", "slack"), 0o700); err != nil {
+		t.Fatalf("mkdir city: %v", err)
+	}
+	t.Setenv(cityPathEnv, cityPath)
+	aliasPath = filepath.Join(cityPath, ".gc", "slack", subteamAliasesFilename)
+	if seed != nil {
+		data, err := json.MarshalIndent(seed, "", "  ")
+		if err != nil {
+			t.Fatalf("marshal seed: %v", err)
+		}
+		if err := os.WriteFile(aliasPath, data, 0o600); err != nil {
+			t.Fatalf("write seed: %v", err)
+		}
+	}
+	return cityPath, aliasPath
+}
+
+func readAliasFile(t *testing.T, path string) map[string]string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read alias file: %v", err)
+	}
+	var m map[string]string
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("decode alias file %q: %v", string(data), err)
+	}
+	return m
+}
+
+// TestSyncSubteamAliasesHappyPath: three live User Groups, no existing
+// file → three entries written.
+func TestSyncSubteamAliasesHappyPath(t *testing.T) {
+	srv, hits := usergroupsListStub(t, `{
+		"ok": true,
+		"usergroups": [
+			{"id": "S001", "team_id": "T1", "handle": "mayor", "name": "Mayor"},
+			{"id": "S002", "team_id": "T1", "handle": "cos", "name": "Chief of Staff"},
+			{"id": "S003", "team_id": "T1", "handle": "zelda-pl", "name": "Zelda Polecats"}
+		]
+	}`)
+	_, aliasPath := stageCity(t, nil)
+
+	var out bytes.Buffer
+	opts := subteamSyncOpts{
+		workspaceID: "T1",
+		token:       "xoxb-test",
+		apiBase:     srv.URL,
+		output:      "json",
+		timeout:     defaultTestTimeout(),
+	}
+	if err := runSlackSyncSubteamAliases(context.Background(), &out, opts); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if *hits != 1 {
+		t.Errorf("usergroups.list hits = %d, want 1", *hits)
+	}
+
+	got := readAliasFile(t, aliasPath)
+	want := map[string]string{"S001": "mayor", "S002": "cos", "S003": "zelda-pl"}
+	if len(got) != len(want) {
+		t.Fatalf("wrote %d entries, want %d (%v)", len(got), len(want), got)
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("entry %s = %q, want %q", k, got[k], v)
+		}
+	}
+
+	var env subteamSyncEnvelope
+	if err := json.Unmarshal(out.Bytes(), &env); err != nil {
+		t.Fatalf("decode json envelope: %v", err)
+	}
+	if !env.WriteIssued {
+		t.Errorf("WriteIssued = false, want true")
+	}
+	if len(env.Diff.Added) != 3 {
+		t.Errorf("Added = %d, want 3", len(env.Diff.Added))
+	}
+	if env.Total != 3 {
+		t.Errorf("Total = %d, want 3", env.Total)
+	}
+}
+
+// TestSyncSubteamAliasesMissingScope: an ok:false missing_scope response
+// becomes a readable error that names the needed scope and writes
+// nothing.
+func TestSyncSubteamAliasesMissingScope(t *testing.T) {
+	srv, _ := usergroupsListStub(t, `{
+		"ok": false,
+		"error": "missing_scope",
+		"needed": "usergroups:read",
+		"provided": "chat:write,commands"
+	}`)
+	_, aliasPath := stageCity(t, nil)
+
+	var out bytes.Buffer
+	opts := subteamSyncOpts{
+		workspaceID: "T1",
+		token:       "xoxb-test",
+		apiBase:     srv.URL,
+		output:      "text",
+		timeout:     defaultTestTimeout(),
+	}
+	err := runSlackSyncSubteamAliases(context.Background(), &out, opts)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "missing_scope") {
+		t.Errorf("error %q does not mention missing_scope", msg)
+	}
+	if !strings.Contains(msg, "usergroups:read") {
+		t.Errorf("error %q does not name the needed scope", msg)
+	}
+	if _, statErr := os.Stat(aliasPath); !os.IsNotExist(statErr) {
+		t.Errorf("alias file was written on missing_scope failure (stat err = %v)", statErr)
+	}
+}
+
+// TestSyncSubteamAliasesMergePreservesUnrelatedKeys: a pre-existing file
+// has a hand-added entry whose id is NOT in the live list, plus one that
+// IS (with a stale handle). The merge must update the live one, add the
+// new one, and keep the unrelated hand-added key untouched.
+func TestSyncSubteamAliasesMergePreservesUnrelatedKeys(t *testing.T) {
+	srv, _ := usergroupsListStub(t, `{
+		"ok": true,
+		"usergroups": [
+			{"id": "S001", "team_id": "T1", "handle": "mayor", "name": "Mayor"},
+			{"id": "S009", "team_id": "T1", "handle": "newgroup", "name": "New Group"}
+		]
+	}`)
+	_, aliasPath := stageCity(t, map[string]string{
+		"S001":     "old-mayor-handle", // live id, stale handle -> changed
+		"S0MANUAL": "hand-added",       // not in live -> preserved
+	})
+
+	var out bytes.Buffer
+	opts := subteamSyncOpts{
+		workspaceID: "T1",
+		token:       "xoxb-test",
+		apiBase:     srv.URL,
+		output:      "json",
+		timeout:     defaultTestTimeout(),
+	}
+	if err := runSlackSyncSubteamAliases(context.Background(), &out, opts); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	got := readAliasFile(t, aliasPath)
+	want := map[string]string{
+		"S001":     "mayor",      // refreshed from live
+		"S009":     "newgroup",   // added from live
+		"S0MANUAL": "hand-added", // preserved untouched
+	}
+	if len(got) != len(want) {
+		t.Fatalf("merged map = %v, want %v", got, want)
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("entry %s = %q, want %q", k, got[k], v)
+		}
+	}
+
+	var env subteamSyncEnvelope
+	if err := json.Unmarshal(out.Bytes(), &env); err != nil {
+		t.Fatalf("decode json envelope: %v", err)
+	}
+	if len(env.Diff.Added) != 1 || env.Diff.Added[0].SubteamID != "S009" {
+		t.Errorf("Added = %+v, want one S009", env.Diff.Added)
+	}
+	if len(env.Diff.Changed) != 1 || env.Diff.Changed[0].SubteamID != "S001" {
+		t.Errorf("Changed = %+v, want one S001", env.Diff.Changed)
+	}
+	if len(env.Diff.LocalOnly) != 1 || env.Diff.LocalOnly[0].SubteamID != "S0MANUAL" {
+		t.Errorf("LocalOnly = %+v, want one S0MANUAL", env.Diff.LocalOnly)
+	}
+}
+
+// TestSyncSubteamAliasesDryRun: --dry-run reports the diff but leaves the
+// file exactly as it was.
+func TestSyncSubteamAliasesDryRun(t *testing.T) {
+	srv, _ := usergroupsListStub(t, `{
+		"ok": true,
+		"usergroups": [
+			{"id": "S001", "team_id": "T1", "handle": "mayor", "name": "Mayor"},
+			{"id": "S002", "team_id": "T1", "handle": "cos", "name": "Chief of Staff"}
+		]
+	}`)
+	seed := map[string]string{"S001": "mayor"} // S002 would be added
+	_, aliasPath := stageCity(t, seed)
+	before := readAliasFile(t, aliasPath)
+
+	var out bytes.Buffer
+	opts := subteamSyncOpts{
+		workspaceID: "T1",
+		token:       "xoxb-test",
+		apiBase:     srv.URL,
+		dryRun:      true,
+		output:      "json",
+		timeout:     defaultTestTimeout(),
+	}
+	if err := runSlackSyncSubteamAliases(context.Background(), &out, opts); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	after := readAliasFile(t, aliasPath)
+	if len(after) != len(before) || after["S001"] != before["S001"] {
+		t.Errorf("dry-run mutated file: before=%v after=%v", before, after)
+	}
+	if _, ok := after["S002"]; ok {
+		t.Errorf("dry-run added S002 to file: %v", after)
+	}
+
+	var env subteamSyncEnvelope
+	if err := json.Unmarshal(out.Bytes(), &env); err != nil {
+		t.Fatalf("decode json envelope: %v", err)
+	}
+	if env.WriteIssued {
+		t.Errorf("WriteIssued = true on dry-run, want false")
+	}
+	if !env.DryRun {
+		t.Errorf("DryRun = false, want true")
+	}
+	if len(env.Diff.Added) != 1 || env.Diff.Added[0].SubteamID != "S002" {
+		t.Errorf("Added = %+v, want one S002 in the diff", env.Diff.Added)
+	}
+}
+
+// TestSyncSubteamAliasesFiltersOtherWorkspaces: an org-level token may
+// return User Groups from other teams; with --workspace-id set, those
+// must be filtered out of the written file.
+func TestSyncSubteamAliasesFiltersOtherWorkspaces(t *testing.T) {
+	srv, _ := usergroupsListStub(t, `{
+		"ok": true,
+		"usergroups": [
+			{"id": "S001", "team_id": "T1", "handle": "mayor", "name": "Mayor"},
+			{"id": "S002", "team_id": "T2", "handle": "other-team", "name": "Other"}
+		]
+	}`)
+	_, aliasPath := stageCity(t, nil)
+
+	var out bytes.Buffer
+	opts := subteamSyncOpts{
+		workspaceID: "T1",
+		token:       "xoxb-test",
+		apiBase:     srv.URL,
+		output:      "text",
+		timeout:     defaultTestTimeout(),
+	}
+	if err := runSlackSyncSubteamAliases(context.Background(), &out, opts); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	got := readAliasFile(t, aliasPath)
+	if _, ok := got["S002"]; ok {
+		t.Errorf("entry from other workspace T2 leaked into file: %v", got)
+	}
+	if got["S001"] != "mayor" {
+		t.Errorf("own-workspace entry missing/wrong: %v", got)
+	}
+}
+
+func defaultTestTimeout() time.Duration { return 30 * time.Second }

--- a/slack-pack/cli/main.go
+++ b/slack-pack/cli/main.go
@@ -66,6 +66,7 @@ func newRootCmd() *cobra.Command {
 	cmd.AddCommand(cmdpkg.NewMapRigCmd(os.Stdout, os.Stderr))
 	cmd.AddCommand(cmdpkg.NewPostMessageCmd(os.Stdout, os.Stderr))
 	cmd.AddCommand(cmdpkg.NewSyncCommandsCmd(os.Stdout, os.Stderr))
+	cmd.AddCommand(cmdpkg.NewSyncSubteamAliasesCmd(os.Stdout, os.Stderr))
 	return cmd
 }
 


### PR DESCRIPTION
Two-part fix enabling Slack User Group (subteam) dispatch in workspaces where contributors create per-PL subteams.

## Part 1: relax `@`-in-label requirement

Slack's native @-autocomplete delivers labeled subteam tokens like `<!subteam^TEAMID|handle>` WITHOUT a leading `@` in the label. The existing `parseSubteamMentionPrefix` required `<!subteam^TEAMID|@handle>` (with `@`) and returned no-match for the un-`@`'d form, so natural User-Group mentions silently dropped through to `target=""` and never dispatched.

The labeled-form path now accepts the label as a valid handle character sequence with OR without a leading `@`. Existing `<!subteam^...|@handle>` mentions parse identically (backward compat).

## Part 2: `gc slack sync-subteam-aliases` verb

New verb mirrors the shape of `sync-commands`:
- Calls Slack's `usergroups.list` (requires `usergroups:read` scope on the bot token)
- Non-destructive MERGE into `$CITY/.gc/slack/subteam-aliases.json` — preserves any operator-added entries (removed→`local_only` bucket, never dropped)
- Prints a summary diff (added / changed / unchanged / local_only) and a `MapRigRestartReminder` for the operator to apply (CLI has no adapter PID for in-process SIGHUP)
- `--dry-run` flag for preview

## Testing

- adapter: `go build/vet/test -race` PASS (new dispatch test `TestProcessSlackEventSubteamMentionLabelWithoutAtRoutesToHandle` + regression for backward compat)
- cli: `go build/vet/test` PASS (happy path, missing-scope error, merge-with-existing, dry-run)

## Files

7 files changed, all under `slack-pack/`:
- `adapter/subteam_mention_prefix.go` — parser relaxation
- `adapter/subteam_mention_dispatch_test.go` — new test cases
- `cli/cmd/sync_subteam_aliases.go` (new) + test
- `cli/main.go` — verb registration
- `README.md` — verb docs + SIGHUP table

## Design notes (flagged for review)

1. **SIGHUP delivery via printed reminder** (not in-process signal) — CLI has no adapter PID. Matches `map-rig` precedent.
2. **Removed bucket reported as `local_only`** — preserved verbatim per non-destructive-merge contract.
3. **Auth model is bot-token** (`SLACK_BOT_TOKEN` + `usergroups:read` scope) rather than the config-token model used by `sync-commands`. Different scope surface; lower governance overhead for the typical use case.

## Operator workflow

1. Add `usergroups:read` to the Slack app's Bot Token Scopes and reinstall.
2. Create the User Group in Slack (e.g. `zelda-pl`).
3. Run `gc slack sync-subteam-aliases` — the verb fetches the mapping and merges into `subteam-aliases.json`.
4. Run `gc slack handle-alias --handle <name> --session <session-id>` (separately) to register the handle→session route.
5. SIGHUP the adapter or restart per the printed reminder.
6. `@<handle>` now works in both text-mode (`@zelda-pl: hi`) and native subteam autocomplete (the labeled form).