### PR TITLE
feat(slack-pack): defense-in-depth — fail closed on session-less /publish requests

### DIFF
--- a/slack-pack/README.md
+++ b/slack-pack/README.md
@@ -158,6 +158,16 @@ Slack  ──HMAC──▶  Go adapter :8775  ──▶ gc /extmsg/inbound
                    └────────────────┘
 ```
 
+The adapter's `/publish` endpoint **requires session attribution**: every
+request must carry a `session_id` (or, for older gc binaries, the legacy
+`metadata.source_session_id`). A request with neither is rejected with HTTP
+400 (`{"error": "publish requires session attribution: provide session_id or
+metadata.source_session_id"}`) and nothing is posted to Slack. This fails
+closed against identity-less channel-root posts under the default bot
+identity. System/bot status notifications that intentionally post as the bot
+go through `gc slack post-message` (direct to Slack `chat.postMessage`),
+which bypasses `/publish` entirely and is unaffected by this guard.
+
 ## Install
 
 ```toml

--- a/slack-pack/README.md
+++ b/slack-pack/README.md
@@ -161,10 +161,14 @@ Slack  ──HMAC──▶  Go adapter :8775  ──▶ gc /extmsg/inbound
 The adapter's `/publish` endpoint **requires session attribution**: every
 request must carry a `session_id` (or, for older gc binaries, the legacy
 `metadata.source_session_id`). A request with neither is rejected with HTTP
-400 (`{"error": "publish requires session attribution: provide session_id or
-metadata.source_session_id"}`) and nothing is posted to Slack. This fails
-closed against identity-less channel-root posts under the default bot
-identity. System/bot status notifications that intentionally post as the bot
+400 and nothing is posted to Slack:
+
+```json
+{"error": "publish requires session attribution: provide session_id or metadata.source_session_id"}
+```
+
+This fails closed against identity-less channel-root posts under the default
+bot identity. System/bot status notifications that intentionally post as the bot
 go through `gc slack post-message` (direct to Slack `chat.postMessage`),
 which bypasses `/publish` entirely and is unaffected by this guard.
 

--- a/slack-pack/adapter/main.go
+++ b/slack-pack/adapter/main.go
@@ -1177,11 +1177,6 @@ func handlePublish(cfg config, reg *identityRegistry) http.HandlerFunc {
 			return
 		}
 
-		post := slackPostMessageReq{
-			Channel:  req.Conversation.ConversationID,
-			Text:     req.Text,
-			ThreadTS: req.ReplyToMessageID,
-		}
 		// SessionID precedence: explicit field wins (used by direct-to-adapter
 		// callers like smoke tests). Otherwise fall back to the wire-metadata
 		// key gc populates when forwarding from /v0/city/.../extmsg/outbound.
@@ -1189,8 +1184,33 @@ func handlePublish(cfg config, reg *identityRegistry) http.HandlerFunc {
 		if identitySessionID == "" {
 			identitySessionID = req.Metadata[metadataKeySourceSessionID]
 		}
+		// Fail closed on identity-less publishes (gpk-jqou). With neither the
+		// native session_id nor the legacy metadata.source_session_id set, the
+		// adapter would otherwise post at channel root under the default bot
+		// identity (as=""), which surfaced as the spurious "gc oversight PL
+		// replied in channel" anomaly on 2026-05-25. Every legitimate /publish
+		// caller carries a session — the gc HandleOutbound path and the
+		// publish / publish-to-channel / reply-current CLIs all resolve one (or
+		// fail closed) before reaching here, and system bot notifications use
+		// `gc slack post-message`, which posts to Slack directly and never
+		// traverses this endpoint. So rejecting attribution-less requests has
+		// no legitimate caller to break; it only closes the regression door.
+		if identitySessionID == "" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"error": "publish requires session attribution: provide session_id or metadata.source_session_id",
+			})
+			return
+		}
+
+		post := slackPostMessageReq{
+			Channel:  req.Conversation.ConversationID,
+			Text:     req.Text,
+			ThreadTS: req.ReplyToMessageID,
+		}
 		identityApplied := ""
-		if reg != nil && identitySessionID != "" {
+		if reg != nil {
 			if rec, ok := reg.Get(identitySessionID); ok {
 				post.Username = rec.Username
 				post.IconURL = rec.IconURL

--- a/slack-pack/adapter/main_test.go
+++ b/slack-pack/adapter/main_test.go
@@ -600,12 +600,6 @@ func TestHandlePublishInjectsIdentity(t *testing.T) {
 			publishBody: `{"session_id":"gc-pl-99","conversation":{"conversation_id":"C3","kind":"room"},"text":"y"}`,
 			// All want* zero — no override should be sent.
 		},
-		{
-			name:        "empty session id skips lookup entirely",
-			registerSID: "gc-pl-1",
-			registerRec: identityRecord{Username: "Gascity PL"},
-			publishBody: `{"conversation":{"conversation_id":"C4","kind":"room"},"text":"z"}`,
-		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -671,11 +665,6 @@ func TestHandlePublishIdentityFallsBackToMetadataSourceSessionID(t *testing.T) {
 			wantUsername: "Gascity PL",
 		},
 		{
-			name:         "no session anywhere posts under default identity",
-			body:         `{"conversation":{"conversation_id":"C1"},"text":"x"}`,
-			wantUsername: "",
-		},
-		{
 			name:         "metadata with unknown session id has no identity",
 			body:         `{"conversation":{"conversation_id":"C1"},"text":"x","metadata":{"source_session_id":"gc-unknown"}}`,
 			wantUsername: "",
@@ -712,6 +701,70 @@ func TestHandlePublishIdentityFallsBackToMetadataSourceSessionID(t *testing.T) {
 			}
 			if captured.Username != tc.wantUsername {
 				t.Errorf("slack username = %q, want %q", captured.Username, tc.wantUsername)
+			}
+		})
+	}
+}
+
+func TestHandlePublishRejectsEmptySession(t *testing.T) {
+	// gpk-jqou: an attribution-less /publish (no session_id and no
+	// metadata.source_session_id) must fail closed with HTTP 400 and must
+	// NOT post to Slack. Previously it fell through to a channel-root post
+	// under the default bot identity (as=""), the root cause of the spurious
+	// "gc oversight PL replied in channel" anomaly.
+	cases := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "no session_id and no metadata",
+			body: `{"conversation":{"conversation_id":"C1","kind":"room"},"text":"x"}`,
+		},
+		{
+			name: "empty session_id, empty metadata source_session_id",
+			body: `{"session_id":"","conversation":{"conversation_id":"C1","kind":"room"},"text":"x","metadata":{"source_session_id":""}}`,
+		},
+		{
+			name: "metadata present but unrelated keys only",
+			body: `{"conversation":{"conversation_id":"C1","kind":"room"},"text":"x","metadata":{"idempotency_key":"abc"}}`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reg, err := newIdentityRegistry(filepath.Join(t.TempDir(), "id.json"))
+			if err != nil {
+				t.Fatalf("newIdentityRegistry: %v", err)
+			}
+
+			origBase := slackAPIBase
+			t.Cleanup(func() { slackAPIBase = origBase })
+			var slackCalled bool
+			fakeSlack := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				slackCalled = true
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"ok":true,"ts":"1.2"}`))
+			}))
+			t.Cleanup(fakeSlack.Close)
+			slackAPIBase = fakeSlack.URL
+
+			cfg := config{slackBotToken: "xoxb-test"}
+			req := httptest.NewRequest(http.MethodPost, "/publish", strings.NewReader(tc.body))
+			rec := httptest.NewRecorder()
+			handlePublish(cfg, reg)(rec, req)
+
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400 (body=%q)", rec.Code, rec.Body.String())
+			}
+			if slackCalled {
+				t.Error("Slack chat.postMessage was called for an attribution-less publish; want no post")
+			}
+			var got map[string]string
+			if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+				t.Fatalf("decode error body %q: %v", rec.Body.String(), err)
+			}
+			const want = "publish requires session attribution: provide session_id or metadata.source_session_id"
+			if got["error"] != want {
+				t.Errorf("error = %q, want %q", got["error"], want)
 			}
 		})
 	}
@@ -1051,10 +1104,10 @@ func TestRegisterAdapterEscapesCityName(t *testing.T) {
 	t.Cleanup(gcStub.Close)
 
 	cfg := config{
-		gcAPIBase: gcStub.URL,
-		cityName:  "city/with slash",
-		provider:  "slack",
-		accountID: "T0",
+		gcAPIBase:   gcStub.URL,
+		cityName:    "city/with slash",
+		provider:    "slack",
+		accountID:   "T0",
 		dispatchSem: defaultTestDispatchSem,
 	}
 	if err := registerAdapter(cfg); err != nil {
@@ -2112,7 +2165,7 @@ func TestDownloadSlackFiles(t *testing.T) {
 			cfg := config{
 				slackBotToken:    "xoxb-test",
 				inboundFileStore: filepath.Join(t.TempDir(), "inbound"),
-				dispatchSem: defaultTestDispatchSem,
+				dispatchSem:      defaultTestDispatchSem,
 			}
 			if tc.emptyStore {
 				cfg.inboundFileStore = ""
@@ -2458,7 +2511,7 @@ func TestDownloadSlackFilesPermissions(t *testing.T) {
 	cfg := config{
 		slackBotToken:    "xoxb-test",
 		inboundFileStore: filepath.Join(t.TempDir(), "inbound"),
-		dispatchSem: defaultTestDispatchSem,
+		dispatchSem:      defaultTestDispatchSem,
 	}
 	files := []slackFile{{
 		ID:         "F1",
@@ -2542,7 +2595,7 @@ func TestTightenStorePermissions(t *testing.T) {
 			identityStorePath:    idFile,
 			handleAliasStorePath: aliasFile,
 			inboundFileStore:     inboundDir,
-			dispatchSem: defaultTestDispatchSem,
+			dispatchSem:          defaultTestDispatchSem,
 		}
 		tightenStorePermissions(cfg)
 
@@ -2592,7 +2645,7 @@ func TestTightenStorePermissions(t *testing.T) {
 			identityStorePath:    filepath.Join(dir, "missing-id", "id.json"),
 			handleAliasStorePath: filepath.Join(dir, "missing-alias", "alias.json"),
 			inboundFileStore:     filepath.Join(dir, "missing-inbound"),
-			dispatchSem: defaultTestDispatchSem,
+			dispatchSem:          defaultTestDispatchSem,
 		}
 		// Should not panic, should not error to caller (helper returns void).
 		tightenStorePermissions(cfg)
@@ -3208,7 +3261,7 @@ func TestProcessSlackEventReleasesSlotOnNoAliasPath(t *testing.T) {
 		provider:     "slack",
 		accountID:    "T1",
 		handlePrefix: "@",
-		dispatchSem: defaultTestDispatchSem,
+		dispatchSem:  defaultTestDispatchSem,
 	}
 	aliasReg := newTestHandleAliasRegistry(t)
 
@@ -3253,7 +3306,7 @@ func TestProcessSlackEventTransfersSlotToAliasGoroutine(t *testing.T) {
 		provider:     "slack",
 		accountID:    "T1",
 		handlePrefix: "@",
-		dispatchSem: defaultTestDispatchSem,
+		dispatchSem:  defaultTestDispatchSem,
 	}
 	aliasReg := newTestHandleAliasRegistry(t)
 	if err := aliasReg.Set("mayor", "gc-2568"); err != nil {
@@ -3550,7 +3603,7 @@ func TestSlackEventsRegistryMissUsesEnvFallback(t *testing.T) {
 		accountID:       "T1",
 		slackSigningKey: "env-fallback",
 		appsRegistry:    appsReg,
-		dispatchSem: defaultTestDispatchSem,
+		dispatchSem:     defaultTestDispatchSem,
 	}
 	aliasReg := newTestHandleAliasRegistry(t)
 


### PR DESCRIPTION
Adds a defense-in-depth guard at the adapter's `/publish` HTTP handler so attribution-less publishes return HTTP 400 + post nothing, instead of falling back to the bot's default identity at channel root.

## Motivation

On 2026-05-25 22:02:39 a Slack message authored by the bot's default identity ("gc oversight PL") landed at channel root in #zeldascension while the correct zeldascension PL reply landed in-thread 20s later. Polecat-1's investigation (full report at `/home/ds/.gc/external-issues/gc-joeqh-slack-identityless-publish.md`) traced the mechanism to `handlePublish` falling back to bot identity when both `req.SessionID` and `req.Metadata.SourceSessionID` are empty.

This PR is the defense-in-depth half of the fix. The structural fix (porting the unmerged `gc-kvt` session_id propagation) is a sibling PR.

## Behavior

Before: `/publish` with no session attribution → `as=""` rendered as bot default, posted at channel root.
After: `/publish` with no session attribution → HTTP 400 `{"error": "publish requires session attribution: provide session_id or metadata.source_session_id"}`, no Slack call.

## Call-site audit

Polecat verified no legitimate publisher relies on the bot-default fallback through `/publish`:
- `gc slack publish` / `publish-to-channel` / `reply-current` — all fail closed via `current_session_id()` before reaching the adapter.
- `gc slack post-message` (the intentional bot-status surface) calls Slack's `chat.postMessage` directly and bypasses `/publish` — unaffected.
- `gc HandleOutbound` — the only `/publish` caller — always carries a session.

No `--allow-no-session` escape hatch was added because no caller needed it.

## Tests

- `TestHandlePublishRejectsEmptySession` — asserts 400 + no Slack call when both attribution fields empty.
- Existing happy-path tests with session_id continue to pass.
- `go vet ./adapter` + `go test ./adapter -race` (3× clean).

## README

Updated the Publish API section to document the new attribution requirement.

## Files

3 files changed:
- `slack-pack/adapter/main.go` — handler guard
- `slack-pack/adapter/main_test.go` — regression test
- `slack-pack/README.md` — Publish API attribution requirement

Co-authored-by: gas-city polecat-1 (gpk-jqou)