### PR TITLE
feat(gastown): fall back to CLAUDE.md/AGENTS.md for quality-gate commands

### DIFF
--- a/gastown/formulas/mol-refinery-patrol.toml
+++ b/gastown/formulas/mol-refinery-patrol.toml
@@ -243,6 +243,12 @@ If run_tests = "true":
 
 If run_tests = "false": skip tests entirely.
 
+**If ALL commands above are empty**, check the repo's CLAUDE.md or AGENTS.md
+(whichever your provider uses) for quality-gate guidance. Look for sections
+named "Quality Gates", "CI", "Testing", "Build", or "Lint" and run any
+commands found in their code blocks. This ensures the refinery does not
+silently skip quality checks when commands were not configured.
+
 Track results: which checks ran, pass/fail, specific failures.
 Close this step when all checks complete (pass or fail)."""
 


### PR DESCRIPTION
## Summary

Add a CLAUDE.md / AGENTS.md fallback to `gastown/formulas/mol-refinery-patrol.toml` so refineries instantiated without explicit `setup_command` / `typecheck_command` / `lint_command` / `build_command` / `test_command` don't silently skip quality checks. When all five vars are empty, the rendered step now directs the agent to the repo's instruction file for quality-gate guidance instead of an empty code block.

## Companion to gastownhall/gascity#78

[gastownhall/gascity#78](https://github.com/gastownhall/gascity/pull/78) added the same fallback to two places:

1. **Core**: `internal/bootstrap/packs/core/formulas/mol-polecat-base.toml` — stays in `gastownhall/gascity` (maintenance/core boundary per gastownhall/gascity#2479, #2504).
2. **Gastown public pack**: `examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml` — moved to this repo via #27. **This PR ports that half.**

After this lands, the gastown half can be dropped from `gastownhall/gascity#78`.

## Diff

```diff
@@ -243,6 +243,12 @@ If run_tests = "true":
 
 If run_tests = "false": skip tests entirely.
 
+**If ALL commands above are empty**, check the repo's CLAUDE.md or AGENTS.md
+(whichever your provider uses) for quality-gate guidance. Look for sections
+named "Quality Gates", "CI", "Testing", "Build", or "Lint" and run any
+commands found in their code blocks. This ensures the refinery does not
+silently skip quality checks when commands were not configured.
+
 Track results: which checks ran, pass/fail, specific failures.
 Close this step when all checks complete (pass or fail)."""
```

## Test plan

- [x] TOML parses cleanly (`python3 -c "import tomllib; tomllib.load(open(...))"`).
- [x] Insertion preserves the surrounding step description structure.
- [ ] (deferred to gastownhall/gascity#78) Go test asserting the fallback string renders when all five vars are empty — that test currently lives in `cmd/gc/quality_gate_fallback_test.go` against the gascity in-repo copy; once `gc` resolves the gastown pack from this repo (per the registry/import work in gastownhall/gascity#2479), the same test can be retargeted here.