### PR TITLE
chore(pr-review): declare graph.v2 contract on mol-pr-from-issue and mol-pr-iterate

### DIFF
--- a/pr-review/formulas/mol-pr-from-issue.formula.toml
+++ b/pr-review/formulas/mol-pr-from-issue.formula.toml
@@ -58,6 +58,7 @@ notes and metadata. Crash-safe: `bd mol current` resumes at the right step.
 formula = "mol-pr-from-issue"
 phase = "vapor"
 version = 1
+contract = "graph.v2"
 
 [vars]
 [vars.issue]

--- a/pr-review/formulas/mol-pr-iterate.formula.toml
+++ b/pr-review/formulas/mol-pr-iterate.formula.toml
@@ -76,6 +76,7 @@ bd close "$ROOT_ID" --reason "<reason>"
   reads it to decide whether the halt-after-2 condition has fired."""
 formula = "mol-pr-iterate"
 version = 1
+contract = "graph.v2"
 
 [vars]
 [vars.pr]


### PR DESCRIPTION
## Summary

Adds `contract = "graph.v2"` to `mol-pr-from-issue` and `mol-pr-iterate` so dispatches mint a workflow-root bead city-side and appear as lanes in the gas-city-dashboard Workflows view.

## Why

The dashboard builds Workflow lanes only from beads with `gc.kind=workflow + gc.formula_contract=graph.v2`. Roots are minted iff (1) `[daemon] formula_v2` is enabled (already on cityside) AND (2) the rig-resolved formula declares `contract = "graph.v2"`. Without (2), polecat dispatches from these formulas never surface as lanes.

## Scope

- 2 files, 2 lines added (one `contract = "graph.v2"` declaration per formula).
- No step shape changes — both formulas remain linear DAGs.
- `ApplyGraphControls` + `toRecipeWithGraph` are exercised on resolution, but no graph-only constructs are introduced.

## Effect

- New `mol-pr-from-issue` and `mol-pr-iterate` runs mint a workflow-root bead in the city store + show as a lane in the dashboard.
- In-flight molecules don't retroactively become lanes — affects NEW runs only.
- Companion changes for `mol-focus-review` and `mol-do-work` already applied rig-locally in `/home/ds/gas-city/formulas/`.
