### PR TITLE
Rename gc planning skills and surface artifacts out of .gc/

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -347,9 +347,9 @@ _Avoid_: Output directory, workspace
   path, generated context bundle path, initial implementation convoy id, drain
   policy, and loop limits.
 - **Build Workflow** orchestrates planning, design, and decomposition as phases.
-- `plan`, `design`, and `decompose` remain separately callable interactive
+- `gather-requirements`, `plan-implementation`, and `create-beads` remain separately callable interactive
   skills for humans.
-- `decompose` writes `tasks.md` and creates the approved beads/convoy after
+- `create-beads` writes `tasks.md` and creates the approved beads/convoy after
   human approval.
 - **Build Workflow** reuses the convoy id produced by decomposition.
 - **Build Workflow** generates the initial context bundle after decomposition
@@ -371,7 +371,7 @@ _Avoid_: Output directory, workspace
 - Direct **Implement Formula** does not run gap-analysis or review before
   push/PR.
 - Use **Build Workflow** for implementation with gap-analysis and review loops.
-- Standalone `decompose` does not need to emit a context bundle in v0.
+- Standalone `create-beads` does not need to emit a context bundle in v0.
 - **Build Workflow** requires explicit human approval before advancing from
   planning to design, from design to decomposition, and from decomposition to
   implementation.

--- a/gc/DESIGN.md
+++ b/gc/DESIGN.md
@@ -18,7 +18,7 @@ workflow pack.
 
 The pack provides:
 
-- interactive skills for `plan`, `design`, `decompose`, and the interactive
+- interactive skills for `gather-requirements`, `plan-implementation`, `create-beads`, and the interactive
   front half of `build`
 - public durable formulas for `implement`, `gap-analysis`, `review`, and
   `do-work`
@@ -47,10 +47,10 @@ The current `gc` pack is a starter implementation:
 
 - [gc/README.md](./README.md) documents three manual planning skills and one
   `implement` formula.
-- [gc/skills/plan/SKILL.md](./skills/plan/SKILL.md) writes
+- [gc/skills/gather-requirements/SKILL.md](./skills/gather-requirements/SKILL.md) writes
   `requirements.md`.
-- [gc/skills/design/SKILL.md](./skills/design/SKILL.md) writes `design.md`.
-- [gc/skills/decompose/SKILL.md](./skills/decompose/SKILL.md) writes
+- [gc/skills/plan-implementation/SKILL.md](./skills/plan-implementation/SKILL.md) writes `implementation-plan.md`.
+- [gc/skills/create-beads/SKILL.md](./skills/create-beads/SKILL.md) writes
   `tasks.md` and then runs `assets/scripts/create_beads_from_tasks.py`.
 - the legacy bead-creation script reads a payload with `epics[]` and `beads[]`,
   creates epic/task beads, and wires dependencies.
@@ -92,7 +92,7 @@ This does not match the desired v0:
 - Do not duplicate the existing bugflow or adopt-pr workflow internals in the
   GitHub adapter formulas. The GitHub workflows are thin edge adapters over
   the generic `gc` primitives.
-- Do not require standalone `decompose` to generate context bundles.
+- Do not require standalone `create-beads` to generate context bundles.
 - Do not close convoy heads as a side effect of implementation or build.
 - Do not make direct `implement` run gap-analysis or review loops.
 
@@ -148,7 +148,7 @@ missing primitive, checked phase, and next action.
 | graph.v2 targeted invocation and reserved `convoy_id` injection | `implement`, `do-work`, `same-session-implement` | formula entry | `GC_CONTRACT_GRAPH_V2_UNAVAILABLE` |
 | reserved-input collision rejection for `convoy_id`, `issue`, and `bead_id` | all graph.v2 formulas | formula entry | `GC_CONTRACT_RESERVED_INPUT` |
 | visible singleton convoy normalization for bare bead targets | `implement`, `do-work` | formula entry | `GC_CONTRACT_SINGLETON_CONVOY_UNAVAILABLE` |
-| convoy membership primitives and stable member traversal | `decompose`, `implement`, `same-session-implement` | pre-create or pre-drain | `GC_CONTRACT_CONVOY_MEMBERSHIP_UNAVAILABLE` |
+| convoy membership primitives and stable member traversal | `create-beads`, `implement`, `same-session-implement` | pre-create or pre-drain | `GC_CONTRACT_CONVOY_MEMBERSHIP_UNAVAILABLE` |
 | graph.v2 drain materialization and dispatcher wakeup | `implement`, separate-session drain, `do-work` | pre-drain | `GC_CONTRACT_DRAIN_MATERIALIZER_UNAVAILABLE` |
 | drain control beads and drain-unit convoys | `implement`, `same-session-implement` | pre-drain | `GC_CONTRACT_DRAIN_UNAVAILABLE` |
 | core shared-drain context `shared`, item formula reference, `single_lane = true`, and selected `on_item_failure` policy | `same-session-implement` | pre-drain | `GC_CONTRACT_SHARED_DRAIN_UNAVAILABLE` |
@@ -251,23 +251,23 @@ attempts to route a `type=epic` bead as a graph.v2 target.
 
 ### Interactive Skills
 
-`plan`
+`gather-requirements`
 
 - Input: freeform human idea.
 - Output: approved `requirements.md`.
 - Behavior: interview one question at a time, inspect repo for discoverable
   answers, write front matter with `status: draft|approved`.
 
-`design`
+`plan-implementation`
 
 - Input: approved `requirements.md`.
-- Output: approved `design.md`.
+- Output: approved `implementation-plan.md`.
 - Behavior: repo-grounded architecture document, concrete enough for
   decomposition.
 
-`decompose`
+`create-beads`
 
-- Input: approved `requirements.md` and `design.md`.
+- Input: approved `requirements.md` and `implementation-plan.md`.
 - Output: approved `tasks.md`, then created beads and convoys.
 - Behavior: validate the task forest against requirements/design before bead
   creation. Human approval is required before creation.
@@ -695,7 +695,7 @@ GitHub adapter artifacts live under:
     fix/
       <run-id>/
         requirements.md
-        design.md
+        implementation-plan.md
         tasks.md
         context.yaml
         status-comment.md
@@ -854,7 +854,7 @@ detect a problem, the earlier no-side-effect layer owns the public error code.
 Artifacts live under an artifact root, defaulting to:
 
 ```text
-<rig-root>/.gc/plans/<plan-slug>/
+<rig-root>/plans/<plan-slug>/
 ```
 
 Build uses a deterministic plan slug. If build creates a branch, the default
@@ -865,7 +865,7 @@ Required artifact paths:
 
 ```text
 requirements.md
-design.md
+implementation-plan.md
 tasks.md
 context/implementation-context.yaml
 implementation/summary.md
@@ -929,7 +929,7 @@ items:
     path: ../requirements.md
     description: Product requirements and acceptance criteria.
   - name: Design
-    path: ../design.md
+    path: ../implementation-plan.md
     description: Engineering design and constraints.
 ```
 
@@ -1670,7 +1670,7 @@ Approval records live under `<artifact-root>/approvals/`:
 {
   "schema": "gc.approval.v1",
   "artifact_kind": "design",
-  "artifact_path": "design.md",
+  "artifact_path": "implementation-plan.md",
   "content_hash": "sha256:<canonical-content>",
   "phase_unblocked": "decompose",
   "actor": "user@example.com",
@@ -1692,11 +1692,11 @@ approval from prose.
 Expected pack changes:
 
 - Rewrite [gc/README.md](./README.md) around the new public surface.
-- Update [gc/skills/plan/SKILL.md](./skills/plan/SKILL.md) for build-compatible
+- Update [gc/skills/gather-requirements/SKILL.md](./skills/gather-requirements/SKILL.md) for build-compatible
   artifact conventions.
-- Update [gc/skills/design/SKILL.md](./skills/design/SKILL.md) for the same
+- Update [gc/skills/plan-implementation/SKILL.md](./skills/plan-implementation/SKILL.md) for the same
   artifact conventions.
-- Rewrite [gc/skills/decompose/SKILL.md](./skills/decompose/SKILL.md) to use
+- Rewrite [gc/skills/create-beads/SKILL.md](./skills/create-beads/SKILL.md) to use
   nested convoys, not epics.
 - Add [gc/skills/build/SKILL.md](./skills/build/SKILL.md).
 - Add thin launch skills for implement/review/gap-analysis if the pack wants
@@ -1814,7 +1814,7 @@ Compatibility and rollout matrix:
 | Feature | Required capability | Validator/test gate | Rollout gate | Failure mode |
 | --- | --- | --- | --- | --- |
 | graph.v2 formula launch | reserved target injection, singleton convoy normalization | formula asset and fake-city capability tests | install formulas only after core advertises graph.v2 | fail closed before work creation |
-| task payload creation | convoy membership primitives, dependency storage | schema validator and dry-run/reload invariant checks | enable `decompose` after validator passes in temp city | reject payload before beads |
+| task payload creation | convoy membership primitives, dependency storage | schema validator and dry-run/reload invariant checks | enable `create-beads` after validator passes in temp city | reject payload before beads |
 | separate drain | graph.v2 drain materializer, drain control beads | temp-city multi-member drain test | enable `implement` separate policy | fail with no routed item work |
 | same-session drain | structured `gc hook`, continuation affinity, `gc.closed_seq` | wait/empty, stale-session, dependency-order tests | keep behind explicit `same-session` opt-in | abnormal drain summary |
 | build-run loops | conditional store primitives and durable artifact writes | checkpoint/resume and idempotent fix-convoy tests | enable `build` back half after recovery tests | final report with recovery status |

--- a/gc/README.md
+++ b/gc/README.md
@@ -3,9 +3,9 @@
 This pack provides a convoy-first planning and implementation workflow for Gas
 City work:
 
-- `gc.plan` gathers requirements and writes `requirements.md`.
-- `gc.design` turns approved requirements into an engineering design.
-- `gc.decompose` turns an approved design into a convoy/bead task plan, then
+- `gc.gather-requirements` gathers requirements and writes `requirements.md`.
+- `gc.plan-implementation` turns approved requirements into an implementation plan and writes `implementation-plan.md`.
+- `gc.create-beads` turns an approved implementation plan into a convoy/bead task plan, then
   creates convoys and runnable beads.
 - `gc.implement` runs implementation for an approved convoy without the full
   build loop.
@@ -26,9 +26,9 @@ source = "../gascity-packs/gc"
 Run the skills manually in order:
 
 ```text
-Use skill gc.plan
-Use skill gc.design
-Use skill gc.decompose
+Use skill gc.gather-requirements
+Use skill gc.plan-implementation
+Use skill gc.create-beads
 ```
 
 Then launch implementation against the created implementation convoy:
@@ -49,9 +49,9 @@ conversation is explicitly desired and core shared drain support is available.
 By default artifacts go under the target rig:
 
 ```text
-<rig-root>/.gc/plans/<plan-slug>/
+<rig-root>/plans/<plan-slug>/
   requirements.md
-  design.md
+  implementation-plan.md
   tasks.md
   context.yaml
   build/final-report.md
@@ -60,7 +60,7 @@ By default artifacts go under the target rig:
 Each skill may use a different artifact root when the user explicitly asks for
 one. The same `<plan-slug>/` structure should be used under the override root.
 
-`gc.decompose` uses `assets/scripts/create_beads_from_tasks.py` after approval.
+`gc.create-beads` uses `assets/scripts/create_beads_from_tasks.py` after approval.
 The script requires Python 3 with PyYAML available, invokes `gc bd --rig
 <target_rig>` for runnable beads, invokes `gc convoy --rig <target_rig>` for
 convoy heads and membership, and records the created mapping in `tasks.md`.

--- a/gc/assets/scripts/artifacts.py
+++ b/gc/assets/scripts/artifacts.py
@@ -11,6 +11,11 @@ class ArtifactError(Exception):
     pass
 
 
+_GC_PLAN_ARTIFACTS = frozenset(
+    {"requirements.md", "implementation-plan.md", "tasks.md", "context.yaml"}
+)
+
+
 def resolve_artifact_root(override: str, *, rig_root: str = "") -> Path:
     raw_override = override.strip()
     if raw_override:
@@ -19,7 +24,49 @@ def resolve_artifact_root(override: str, *, rig_root: str = "") -> Path:
     raw_rig_root = rig_root.strip() or first_env("GC_RIG_ROOT", "GC_DIR", "GC_BEADS_SCOPE_ROOT")
     if not raw_rig_root:
         raise ArtifactError("artifact root override is empty and no rig root environment is available")
-    return (Path(raw_rig_root).expanduser().resolve() / ".gc" / "plans").resolve()
+    rig = Path(raw_rig_root).expanduser().resolve()
+    default_root = rig / "plans"
+    if _plans_root_is_foreign(default_root):
+        return (rig / "gc-plans").resolve()
+    return default_root.resolve()
+
+
+def _plans_root_is_foreign(plans_dir: Path) -> bool:
+    """Return True when ``plans_dir`` already exists and is used for something
+    other than gc workflow artifacts, so ``resolve_artifact_root`` should fall
+    back to ``<rig>/gc-plans`` instead of colliding with it.
+
+    Resolution must be stable across repeated runs, so a directory gc owns is
+    never reported as foreign. A ``plans`` directory counts as gc-owned when it
+    is empty, carries a ``.gc-plans`` marker, or already holds gc plan artifacts
+    (``requirements.md`` and friends) at the top level or one level down in a
+    plan-slug subdirectory. Only a non-empty directory with no gc signature --
+    or a ``plans`` entry that is not a directory at all -- is treated as
+    foreign.
+    """
+    if not plans_dir.exists():
+        return False
+    if not plans_dir.is_dir():
+        return True
+    if (plans_dir / ".gc-plans").exists():
+        return False
+    try:
+        children = list(plans_dir.iterdir())
+    except OSError:
+        # Cannot introspect the directory; be conservative and do not clobber it.
+        return True
+    if not children:
+        return False
+    for child in children:
+        if child.name in _GC_PLAN_ARTIFACTS:
+            return False
+        if child.is_dir():
+            try:
+                if any(grandchild.name in _GC_PLAN_ARTIFACTS for grandchild in child.iterdir()):
+                    return False
+            except OSError:
+                continue
+    return True
 
 
 def resolve_artifact_path(override: str, relative: str, *, rig_root: str = "") -> Path:

--- a/gc/assets/scripts/create_beads_from_tasks.py
+++ b/gc/assets/scripts/create_beads_from_tasks.py
@@ -647,7 +647,7 @@ def create_from_tasks(path: Path, *, city: str | None, dry_run: bool, force: boo
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Create Gas City beads and convoys from a gc.decompose tasks.md file")
+    parser = argparse.ArgumentParser(description="Create Gas City beads and convoys from a gc.create-beads tasks.md file")
     parser.add_argument("tasks_md", help="Path to tasks.md")
     parser.add_argument("--city", help="Optional city path/name passed through to gc")
     parser.add_argument("--dry-run", action="store_true", help="Validate and print gc commands without creating beads")

--- a/gc/skills/build/SKILL.md
+++ b/gc/skills/build/SKILL.md
@@ -11,12 +11,12 @@ review/fix loops, and an optional publish step.
 
 ## Workflow
 
-1. Create or update `requirements.md` using `gc.plan`. Build starts with no
+1. Create or update `requirements.md` using `gc.gather-requirements`. Build starts with no
    required context beyond the user's request.
 2. Stop for explicit human approval of requirements.
-3. Create or update `design.md` using `gc.design`.
+3. Create or update `implementation-plan.md` using `gc.plan-implementation`.
 4. Stop for explicit human approval of design.
-5. Create or update `tasks.md` using `gc.decompose`, then create the initial
+5. Create or update `tasks.md` using `gc.create-beads`, then create the initial
    implementation convoy.
 6. Stop for explicit human approval of the task plan/start gate.
 7. Write `context.yaml` with freeform context entries for requirements, design,
@@ -31,9 +31,9 @@ review/fix loops, and an optional publish step.
 Default to:
 
 ```text
-<rig-root>/.gc/plans/<plan-slug>/
+<rig-root>/plans/<plan-slug>/
   requirements.md
-  design.md
+  implementation-plan.md
   tasks.md
   context.yaml
   build/

--- a/gc/skills/create-beads/SKILL.md
+++ b/gc/skills/create-beads/SKILL.md
@@ -1,19 +1,19 @@
 ---
-name: decompose
-description: Turn an approved requirements/design pair into an approved bead plan and create the beads.
+name: create-beads
+description: Turn an approved requirements/implementation-plan pair into an approved bead plan and create the beads.
 ---
 
-# GC Decompose
+# GC Create Beads
 
-Use this skill after `gc.plan` and `gc.design` have approved artifacts. This is
+Use this skill after `gc.gather-requirements` and `gc.plan-implementation` have approved artifacts. This is
 a planning and task-creation skill: it may write `tasks.md` and create convoys
 and runnable beads, but it must not implement those beads.
 
 ## Workflow
 
 1. Confirm the target rig/root path, plan slug, and artifact root. Default to:
-   `<rig-root>/.gc/plans/<plan-slug>/`.
-2. Read `requirements.md` and `design.md`. Refuse to proceed unless both are
+   `<rig-root>/plans/<plan-slug>/`.
+2. Read `requirements.md` and `implementation-plan.md`. Refuse to proceed unless both are
    `approved`, unless the user explicitly overrides that gate.
 3. Inspect the target codebase enough to validate task boundaries,
    dependencies, file ownership, and test strategy.
@@ -35,9 +35,9 @@ plan_slug: example-slug
 phase: tasks
 rig: backend
 rig_root: /absolute/path/to/rig
-artifact_root: /absolute/path/to/rig/.gc/plans
+artifact_root: /absolute/path/to/rig/plans
 requirements_file: /absolute/path/to/requirements.md
-design_file: /absolute/path/to/design.md
+implementation_plan_file: /absolute/path/to/implementation-plan.md
 status: draft
 created_at: 2026-05-10T00:00:00Z
 updated_at: 2026-05-10T00:00:00Z

--- a/gc/skills/gather-requirements/SKILL.md
+++ b/gc/skills/gather-requirements/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: plan
+name: gather-requirements
 description: Develop compact requirements for a Gas City work item through an interactive, repo-aware interview.
 ---
 
-# GC Plan
+# GC Gather Requirements
 
 Use this skill to create or revise the requirements artifact for a planned unit
 of work. This is a planning-only skill: inspect files as needed and write the
@@ -13,7 +13,7 @@ requirements document, but do not implement product/source changes.
 
 1. Ask for an overview of what needs to be accomplished. Invite a wall of text.
 2. Identify the target rig/root path, plan slug, and artifact root. Default to:
-   `<rig-root>/.gc/plans/<plan-slug>/`.
+   `<rig-root>/plans/<plan-slug>/`.
 3. After the overview, inspect the target codebase enough to avoid asking
    questions whose answers are discoverable from the repository.
 4. Interview the user one question at a time:
@@ -36,7 +36,7 @@ plan_slug: example-slug
 phase: requirements
 rig: backend
 rig_root: /absolute/path/to/rig
-artifact_root: /absolute/path/to/rig/.gc/plans
+artifact_root: /absolute/path/to/rig/plans
 status: draft
 created_at: 2026-05-10T00:00:00Z
 updated_at: 2026-05-10T00:00:00Z

--- a/gc/skills/plan-implementation/SKILL.md
+++ b/gc/skills/plan-implementation/SKILL.md
@@ -1,18 +1,18 @@
 ---
-name: design
-description: Turn approved requirements into a repo-grounded engineering design document.
+name: plan-implementation
+description: Turn approved requirements into a repo-grounded implementation plan document.
 ---
 
-# GC Design
+# GC Plan Implementation
 
-Use this skill after `gc.plan` has produced an approved `requirements.md`. This
+Use this skill after `gc.gather-requirements` has produced an approved `requirements.md`. This
 is a planning-only skill: inspect code and write the design document, but do not
 implement product/source changes.
 
 ## Workflow
 
 1. Confirm the target rig/root path, plan slug, and artifact root. Default to:
-   `<rig-root>/.gc/plans/<plan-slug>/`.
+   `<rig-root>/plans/<plan-slug>/`.
 2. Read `requirements.md`. Refuse to proceed if its front matter status is not
    `approved`, unless the user explicitly overrides that gate.
 3. Inspect the target codebase before writing the design. Ground the design in
@@ -21,7 +21,7 @@ implement product/source changes.
    - Provide your recommended answer with each question.
    - Ask only questions that materially affect the design.
    - Inspect the repository instead of asking when the answer is discoverable.
-5. Write or overwrite `design.md`.
+5. Write or overwrite `implementation-plan.md`.
 6. Ask the user to review. When the user explicitly approves, update
    `status: approved`. Otherwise leave `status: draft` or `status: questions`.
 7. For build-compatible designs, include the implementation context that later
@@ -30,15 +30,15 @@ implement product/source changes.
 
 ## Artifact
 
-`design.md` must begin with YAML front matter:
+`implementation-plan.md` must begin with YAML front matter:
 
 ```yaml
 ---
 plan_slug: example-slug
-phase: design
+phase: implementation-plan
 rig: backend
 rig_root: /absolute/path/to/rig
-artifact_root: /absolute/path/to/rig/.gc/plans
+artifact_root: /absolute/path/to/rig/plans
 requirements_file: /absolute/path/to/requirements.md
 status: draft
 created_at: 2026-05-10T00:00:00Z
@@ -49,7 +49,7 @@ updated_at: 2026-05-10T00:00:00Z
 Use this body structure:
 
 ```markdown
-# Design: <title>
+# Implementation Plan: <title>
 
 ## Summary
 

--- a/gc/tests/test_artifacts.py
+++ b/gc/tests/test_artifacts.py
@@ -36,8 +36,52 @@ class ArtifactHelperTests(unittest.TestCase):
             os.environ["GC_RIG_ROOT"] = temp_dir
             self.assertEqual(
                 module.resolve_artifact_root(""),
-                pathlib.Path(temp_dir).resolve() / ".gc" / "plans",
+                pathlib.Path(temp_dir).resolve() / "plans",
             )
+
+    def test_default_plans_dir_reused_when_gc_owned(self) -> None:
+        module = load_artifacts_module()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            os.environ["GC_RIG_ROOT"] = temp_dir
+            rig = pathlib.Path(temp_dir).resolve()
+            (rig / "plans" / "demo").mkdir(parents=True)
+            (rig / "plans" / "demo" / "requirements.md").write_text("x", encoding="utf-8")
+            self.assertEqual(module.resolve_artifact_root(""), rig / "plans")
+
+    def test_empty_plans_dir_is_treated_as_gc_owned(self) -> None:
+        module = load_artifacts_module()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            os.environ["GC_RIG_ROOT"] = temp_dir
+            rig = pathlib.Path(temp_dir).resolve()
+            (rig / "plans").mkdir()
+            self.assertEqual(module.resolve_artifact_root(""), rig / "plans")
+
+    def test_marker_makes_nonempty_plans_dir_gc_owned(self) -> None:
+        module = load_artifacts_module()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            os.environ["GC_RIG_ROOT"] = temp_dir
+            rig = pathlib.Path(temp_dir).resolve()
+            (rig / "plans").mkdir()
+            (rig / "plans" / ".gc-plans").write_text("", encoding="utf-8")
+            (rig / "plans" / "unrelated.txt").write_text("x", encoding="utf-8")
+            self.assertEqual(module.resolve_artifact_root(""), rig / "plans")
+
+    def test_foreign_plans_dir_falls_back_to_gc_plans(self) -> None:
+        module = load_artifacts_module()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            os.environ["GC_RIG_ROOT"] = temp_dir
+            rig = pathlib.Path(temp_dir).resolve()
+            (rig / "plans" / "roadmap").mkdir(parents=True)
+            (rig / "plans" / "roadmap" / "q3.md").write_text("x", encoding="utf-8")
+            self.assertEqual(module.resolve_artifact_root(""), rig / "gc-plans")
+
+    def test_plans_path_that_is_a_file_falls_back_to_gc_plans(self) -> None:
+        module = load_artifacts_module()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            os.environ["GC_RIG_ROOT"] = temp_dir
+            rig = pathlib.Path(temp_dir).resolve()
+            (rig / "plans").write_text("not a dir", encoding="utf-8")
+            self.assertEqual(module.resolve_artifact_root(""), rig / "gc-plans")
 
     def test_leading_slash_paths_are_artifact_root_relative(self) -> None:
         module = load_artifacts_module()

--- a/gc/tests/test_create_beads_from_tasks.py
+++ b/gc/tests/test_create_beads_from_tasks.py
@@ -18,9 +18,9 @@ plan_slug: demo
 phase: tasks
 rig: backend
 rig_root: /repo
-artifact_root: /repo/.gc/plans
-requirements_file: /repo/.gc/plans/demo/requirements.md
-design_file: /repo/.gc/plans/demo/design.md
+artifact_root: /repo/plans
+requirements_file: /repo/plans/demo/requirements.md
+implementation_plan_file: /repo/plans/demo/implementation-plan.md
 status: approved
 created_at: 2026-05-10T00:00:00Z
 updated_at: 2026-05-10T00:00:00Z

--- a/gc/tests/test_skill_frontmatter.py
+++ b/gc/tests/test_skill_frontmatter.py
@@ -14,14 +14,14 @@ class SkillFrontmatterTests(unittest.TestCase):
             [path.parent.name for path in skill_files],
             [
                 "build",
-                "decompose",
-                "design",
+                "create-beads",
                 "gap-analysis",
+                "gather-requirements",
                 "gh-issue-fix",
                 "gh-issue-triage",
                 "gh-pr-review",
                 "implement",
-                "plan",
+                "plan-implementation",
                 "review",
             ],
         )


### PR DESCRIPTION
## Summary

Renames the three `gc` planning skills so each name describes what it produces, and moves the default plan-artifact root out of the hidden `.gc/` directory. Implements the rename plan in gastownhall/gascity-packs#28 (see the [plan comment](https://github.com/gastownhall/gascity-packs/issues/28#issuecomment-4575472349)).

**Skill + artifact renames**
- `skills/plan` → `skills/gather-requirements` (`gc.plan` → `gc.gather-requirements`); `requirements.md` unchanged.
- `skills/design` → `skills/plan-implementation` (`gc.design` → `gc.plan-implementation`); artifact `design.md` → `implementation-plan.md`; front-matter `phase: design` → `phase: implementation-plan`.
- `skills/decompose` → `skills/create-beads` (`gc.decompose` → `gc.create-beads`); still writes `tasks.md`.

**Artifact location**
- `resolve_artifact_root` now defaults to `<rig-root>/plans` instead of `<rig-root>/.gc/plans`. If a pre-existing, non-gc `plans/` directory is already present, it falls back to `<rig-root>/gc-plans`. The choice is stable across runs — an empty, `.gc-plans`-marked, or gc-artifact-bearing `plans/` is treated as gc-owned.

**Decisions applied (from #28)**
- `tasks.md` is intentionally **not** renamed.
- Clean rename: **no** read-time `design.md`→`implementation-plan.md` fallback and **no** legacy `.gc/plans` fallback.
- The `gc.plan.*` convoy-metadata namespace (bead metadata keys in `create_beads_from_tasks.py`) is **unchanged** — only the `gc.plan` *skill* identifier was renamed.

**Notes for reviewers**
- The `create-beads` `tasks.md` front-matter field `design_file:` was renamed to `implementation_plan_file:` (informational pass-through; the script reads only `status`, so this is documentation/fixtures only).
- In `DESIGN.md`/`CONTEXT.md` I renamed skill identifiers, skill-dir links, the `design.md` artifact, and the `.gc/plans` path. I deliberately left conceptual narrative prose (e.g. "the design", "decomposition") and example approval-record values (`artifact_kind: "design"`, `phase_unblocked: "decompose"`) untouched — happy to extend the prose sweep if you'd prefer.
- Root `PR_DRAFT.md` documents `slack-pack` (not this pack) and was left untouched.

## Test plan
- [x] `python3` unittest suite under `gc/tests/` passes (all 7 files). `test_artifacts` was extended with 5 cases covering `plans`/`gc-plans` resolution; `test_skill_frontmatter` updated for the new dir names.
- [ ] Reviewer: confirm the skill renames + artifact move match the intent in #28.

---
> Generated by the operator's software factory.
> • City: `factory-main` · Agent: `local-core.builder-2`
> • On behalf of: @austinborn
