### PR TITLE
docs(slack-pack): refresh README to match shipped surface

### DIFF
--- a/slack-pack/README.md
+++ b/slack-pack/README.md
@@ -1,14 +1,14 @@
-# Slack pack (v0.1.0 preview — scaffold)
+# Slack pack (v0.0.1 preview — scaffold)
 
 A Slack provider extension for Gas City. Modeled directly on the
 upstream `discord` pack
 (https://github.com/gastownhall/gascity-packs/tree/main/discord) so
 the same primitives can be ported one at a time.
 
-This pack lives in-tree at `examples/slack-pack/` for the moment. It
-is intended to be promoted to the `gastownhall/gascity-packs` repo
-(or a sibling) once the upstream-prep blockers tracked under bd
-`gc-ywe` close.
+This pack lives at `slack-pack/` in the
+[`gastownhall/gascity-packs`](https://github.com/gastownhall/gascity-packs)
+catalog. A city opts in by path-importing its `pack.toml` (see
+"Install" below).
 
 > **Scope: not yet at parity with the discord pack.** The discord pack
 > ships ~350K LOC of provider-agnostic Python state-machine logic.
@@ -60,7 +60,7 @@ Implemented:
       adapter TCP `:8775` (Funnel unchanged). See "Adapter as a
       proxy_process service" below for the cutover.
 
-Not yet implemented (planned):
+Slash-command / launcher / projection surface (operator CLI verbs):
 
 - [x] `gc slack import-app` — register a Slack app manifest with the gc
       city ([`manifest/README.md`](./manifest/README.md#importing-into-gc-gc-slack-import-app))
@@ -78,6 +78,9 @@ Not yet implemented (planned):
       record; `--remove-channels c1,c2` drops just the listed channels
       (the record itself is deleted if the set becomes empty). Both
       removal paths are idempotent.
+- [x] `gc slack sync-commands` — register/refresh the city's slash
+      commands against the Slack app (read by the adapter's
+      `/slack/interactions` dispatcher).
 - [x] `gc slack sync-subteam-aliases` — reconcile
       `<city>/.gc/slack/subteam-aliases.json` (the Slack User Group
       ("subteam") id → gc handle map) with the workspace's live User
@@ -91,12 +94,23 @@ Not yet implemented (planned):
       carry the `usergroups:read` scope; without it the verb reports a
       readable `missing_scope` error and writes nothing. After a write it
       prints the same SIGHUP reminder as the other registry-writing verbs.
-- [ ] `gc slack enable-room-launch` (`@@handle` thread-scoped sessions)
-- [ ] `gc slack post-message` (workflow status projection)
+- [x] `gc slack post-message` — post (or `--update <ts>`) a Block Kit
+      message to a channel via `chat.postMessage`/`chat.update`. The
+      one-shot verb is shipped; automatic workflow-status projection
+      from gc events is not yet wired.
 - [x] `gc slack retry-peer-fanout` (walks `extmsg.peer_fanout_failed`
       events, dedupes against successful `extmsg.peer_fanout_retried`
       events, re-issues each notification via the gc retry endpoint with
       a small cooldown between attempts)
+
+Not yet implemented (planned):
+
+- [ ] `gc slack enable-room-launch` — the CLI verb writes the
+      `(workspace_id, channel_id) → pool_template` mapping today, but the
+      adapter-side `@@<handle>` thread-scoped session spawn is still a
+      stub: an `@@<handle>` post in an enabled channel currently gets an
+      ephemeral "launcher not yet available" reply rather than spawning a
+      session (tracked under the gc-cby epic).
 
 The adapter exposes `POST /slack/interactions` (HMAC-verified) for
 slash-command, `block_actions`, and `view_submission` dispatch.
@@ -133,13 +147,13 @@ tracked under the gc-cby epic.
 This pack ships **two** Go binaries, each with its own `go.mod` so
 either can travel intact when the pack is mirrored upstream:
 
-- **Adapter** — `examples/slack-pack/adapter/gc-slack-adapter`,
+- **Adapter** — `slack-pack/adapter/gc-slack-adapter`,
   built from `adapter/main.go`. The public-facing webhook receiver
   (Slack → `:8775` over Tailscale Funnel) and outbound publisher
   (`/publish` over the controller-managed UDS). Long-running; gc
   supervises it via the `[[service]]` block in `pack.toml`.
 
-- **Operator CLI** — `examples/slack-pack/cli/gc-slack-cli`, built
+- **Operator CLI** — `slack-pack/cli/gc-slack-cli`, built
   from `cli/main.go` + `cli/cmd/`. Backs the `gc slack <cmd>` verb
   surface (import-app, map-channel, map-rig, sync-commands,
   sync-subteam-aliases, enable-room-launch, post-message). One-shot per invocation; not
@@ -152,7 +166,7 @@ Build commands and CI for both binaries are documented in
 
 ## Architecture (current)
 
-The Go adapter at `examples/slack-pack/adapter/gc-slack-adapter`
+The Go adapter at `slack-pack/adapter/gc-slack-adapter`
 (built from `adapter/main.go` colocated with this pack) is the
 public-facing webhook receiver and outbound publisher. This
 pack adds CLI surface around it: `bind-dm` writes to gc's
@@ -170,6 +184,11 @@ Slack  ──HMAC──▶  Go adapter :8775  ──▶ gc /extmsg/inbound
                                     ◀── (--via adapter) ─────── gc slack reply-current
                    └────────────────┘
 ```
+
+The `:8775` public port above is the reference Funnel-fronted
+deployment (`LISTEN_PUBLIC=:8775`, with a Tailscale Funnel rule
+`:443 → :8775`). The bare adapter default is `:8765` — see the
+`LISTEN_PUBLIC` row in "Adapter env contract" below.
 
 The adapter's `/publish` endpoint **requires session attribution**: every
 request must carry a `session_id` (or, for older gc binaries, the legacy
@@ -190,7 +209,7 @@ which bypasses `/publish` entirely and is unaffected by this guard.
 ```toml
 # city.toml
 [imports.slack]
-source = "/path/to/examples/slack-pack"
+source = "/path/to/gascity-packs/slack-pack"
 ```
 
 Then `gc reload` (or wait for the supervisor to pick up the change).
@@ -291,7 +310,7 @@ When `GC_SERVICE_SOCKET` is set, the adapter:
 ### Adapter env contract
 
 The full adapter env contract — what the binary at
-`examples/slack-pack/adapter/main.go` reads — is enumerated in the
+`slack-pack/adapter/main.go` reads — is enumerated in the
 package docstring at the top of that file. Summary:
 
 **Must-set** (no default; adapter exits at startup if missing):
@@ -411,7 +430,7 @@ GC_CITY_NAME=<your-city-name>
 
 ```
 # 1. Build the adapter binary in place (source colocated with the pack)
-( cd examples/slack-pack/adapter && go build -o gc-slack-adapter )
+( cd slack-pack/adapter && go build -o gc-slack-adapter )
 
 # 2. Source the secrets so the supervisor inherits them
 set -a; source "${XDG_CONFIG_HOME:-$HOME/.config}/gc-slack-adapter/env"; set +a
@@ -444,7 +463,7 @@ Rollback: remove (or comment out) the `[[service]]` block in
 legacy script:
 
 ```
-( cd examples/slack-pack/adapter \
+( cd slack-pack/adapter \
     && nohup ./run.sh > /tmp/gc-slack-adapter/run.log 2>&1 & disown )
 ```
 


### PR DESCRIPTION
## What

Reconciles `slack-pack/README.md` with the pack's actual shipped surface. The README had drifted since the pack was imported into `gascity-packs`.

## Why

The README is the pack's contract; several claims were stale:

- **Pre-promotion framing / paths.** It still said the pack lived at `examples/slack-pack/` awaiting promotion under bd `gc-ywe`. It's now in the catalog at `slack-pack/`. All `examples/slack-pack/...` path refs and the install snippet `source` were fixed.
- **Contradictory status section.** `import-app`, `map-channel`, `map-rig`, `sync-commands`, `sync-subteam-aliases`, `post-message`, and `retry-peer-fanout` were listed under a "Not yet implemented (planned)" header but all ship today. Moved them under an accurate header. `sync-commands` had no status entry at all.
- **`enable-room-launch` corrected, not promoted.** Kept under "planned" — the CLI verb writes the mapping, but the adapter-side `@@<handle>` thread-scoped session spawn is still a stub (verified against `adapter/double_handle_dispatch_test.go`, which asserts a "launcher not yet available" ephemeral and no inbound post).
- **Version mismatch.** Header said `v0.1.0`; `pack.toml` says `0.0.1`. Aligned to `v0.0.1`.
- **Port inconsistency.** The diagram/prose use `:8775` while the documented default (`LISTEN_PUBLIC`) is `:8765`. Added a note clarifying `:8775` is the Funnel-fronted reference-deployment override of the `:8765` default rather than changing deployment values.

## Scope

Doc-only — single file, `slack-pack/README.md` (+34 / −15). No code or sibling-pack changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)