### PR TITLE
docs(gastown): replace deprecated inline-crew pack comment with v2 directory-agent + named_session

### DIFF
--- a/gastown/pack.toml
+++ b/gastown/pack.toml
@@ -9,7 +9,9 @@
 #   workspace.pack → expands city-scoped agents only (mayor, deacon, boot)
 #   rigs[].pack    → expands rig agents only (witness, refinery, polecat)
 #
-# Crew members are individually named and declared inline in city.toml.
+# Crew members are individually named, so they can't be pack-stamped: define
+# each as a directory agent (agents/<name>/ in the host city) plus a matching
+# [[named_session]] that keeps it alive.
 
 [pack]
 name = "gastown"


### PR DESCRIPTION
## What

The live public `gastown` pack's `pack.toml` header (line 12) still tells readers:

```toml
# Crew members are individually named and declared inline in city.toml.
```

That teaches the **v2-deprecated inline `[[agent]]` crew pattern** — which `gc` no longer registers or starts. This change replaces it with the directory-agent + `[[named_session]]` shape that actually works:

```toml
# Crew members are individually named, so they can't be pack-stamped: define
# each as a directory agent (agents/<name>/ in the host city) plus a matching
# [[named_session]] that keeps it alive.
```

## Why

This **ports the pack-comment hunk** from gastownhall/gascity#2469 to the live public pack, per @donbox's port-or-obsolete request on that PR.

PR #2469 fixed the deprecated crew example in the **gascity** repo:
- `examples/gastown/city.toml` — the city-level worked example (stays on #2469; it's a test fixture, not the live pack)
- `examples/gastown/packs/gastown/pack.toml` — the **same stale comment** in the example's pack copy

Since `gastownhall/gascity-packs#27` merged, the public `gastown` pack advertised by this repo's `registry.toml` is what actually runs on `gc` import. I verified the live pack still carries the identical stale comment, so the example fix does **not** supersede it — it needs porting here. This PR is that port.

The example's `see examples/gastown/city.toml` cross-reference is dropped, since that worked example lives in the `gascity` repo, not this packs repo; the replacement comment is self-contained.

## Scope

Comment-only, one line → three. No behavior change. The rest of the pack (no `session_setup`/`overlay_dir`/inline-`[[agent]]` references) is already clean.

Refs: gastownhall/gascity#2469, gastownhall/gascity#2468

🤖 Generated with [Claude Code](https://claude.com/claude-code)