### PR TITLE
deacon: mark freshly-created patrol wisp in_progress so next cycle resumes it

### DIFF
--- a/gastown/agents/deacon/prompt.template.md
+++ b/gastown/agents/deacon/prompt.template.md
@@ -66,7 +66,7 @@ gc mail inbox
 
 # Step 3: Still nothing? Create patrol wisp (root-only — no child step beads)
 NEW_WISP=$(gc bd mol wisp mol-deacon-patrol --root-only --var binding_prefix={{ .BindingPrefix }} --json | jq -r '.new_epic_id')
-gc bd update "$NEW_WISP" --assignee="$GC_ALIAS"
+gc bd update "$NEW_WISP" --assignee="$GC_ALIAS" --status=in_progress
 
 # Step 4: Read the formula recipe — these are the steps to execute
 # (Use 'gc bd formula show' for the recipe on disk; 'gc bd mol show' is


### PR DESCRIPTION
Carries the "deacon resume protocol" one-liner from gastownhall/gascity#2332 by @eric-jones — thank you! Re-homed here because the `gastown` pack moved out of `gascity` into this repo (#27), so this prompt's canonical home is now `gastownhall/gascity-packs`.

## What

In the deacon patrol prompt, Step 3 creates a patrol wisp and updates it to set the assignee, but does not set its status to `in_progress`. The very next cycle's Step 1 lists work with `--status=in_progress`, so a just-created wisp is invisible to that filter and the deacon never resumes its own open wisp.

This adds `--status=in_progress` to the Step-3 update call so the creation step and the resume filter agree, closing the loop.

## Change

Single line, in `gastown/agents/deacon/prompt.template.md`:

```
-gc bd update "$NEW_WISP" --assignee="$GC_ALIAS"
+gc bd update "$NEW_WISP" --assignee="$GC_ALIAS" --status=in_progress
```

Nothing else on the line changes. Full credit to @eric-jones for the diagnosis and the fix.
