### PR TITLE
fix(gastown/refinery): route rejected beads to the polecat pool; add merge-bookkeeping guidance

### DIFF
--- a/gastown/agents/refinery/prompt.template.md
+++ b/gastown/agents/refinery/prompt.template.md
@@ -111,13 +111,29 @@ Never infer a branch name. If `metadata.branch` is missing, reject the bead.
 
 ## Rejection Flow
 
-On rebase conflict or test failure:
-1. Put work bead back in pool:
-   `gc bd update $WORK --status=open --assignee="" --set-metadata rejection_reason="..."`
-2. Branch handling depends on failure type:
-   - Conflict: leave branch intact (polecat needs it for rebase)
-   - Test failure: delete branch (polecat redoes work)
-3. Pour next wisp, burn current one
+On rebase conflict or test failure, follow `mol-refinery-patrol`'s
+rebase / handle-failures step verbatim. Do not compose your own
+shorter version of the bd update — the full update is required,
+including `gc.routed_to`:
+
+```bash
+gc bd update $WORK \
+  --status=open \
+  --assignee="" \
+  --set-metadata rejection_reason="..." \
+  --set-metadata gc.routed_to="${GC_RIG:+$GC_RIG/}{{ .BindingPrefix }}polecat"
+```
+
+`gc.routed_to=...polecat` is load-bearing: the pool reconciler matches
+on `gc.routed_to`, not `rejection_reason`, so a rejected bead with the
+old `gc.routed_to=...refinery` value (set when the polecat first
+submitted) sits in the queue forever — no polecat is ever spawned.
+
+Branch handling depends on failure type:
+- Conflict: leave branch intact (polecat needs it for rebase)
+- Test failure: delete branch (polecat redoes work)
+
+Then pour the next wisp and burn the current one.
 
 A new polecat picks up the bead, sees `metadata.branch` and
 `metadata.rejection_reason`, rebases or redoes work, reassigns to refinery.
@@ -157,6 +173,34 @@ closing the work.
 If `metadata.existing_pr` is present while `merge_strategy` is unset or
 `direct`, treat the handoff as `mr`. An existing PR cannot be validated
 and then ignored by landing directly to the target branch.
+
+## Merge Bookkeeping
+
+Two non-negotiable obligations on every merge, regardless of merge
+strategy, remote presence, or merge shape (fast-forward / merge
+commit):
+
+- **`merged_sha` and `merged_target` MUST be written via
+  `gc bd update --set-metadata` BEFORE `gc bd close`.** They are the
+  only forensic breadcrumbs tying a closed bead to its merge commit on
+  `$TARGET`. Skipping the metadata write — even on a rig with no
+  remote, even when `gc bd close --reason` already names the SHA in
+  prose — leaves downstream tools with no way to verify the bead
+  actually merged. The formula chains both writes with `&&`; do not
+  split them, and do not skip the metadata write because the close
+  reason looks redundant.
+
+- **Use `git update-ref refs/heads/$TARGET <sha>` to advance the
+  target branch.** The formula's `merge-push` step uses this instead
+  of `git checkout $TARGET; git merge --ff-only temp` for a reason:
+  checking out a branch that another worktree has open silently
+  merges into the wrong worktree's HEAD instead of `$TARGET`. Follow
+  the formula's command shape verbatim — do not substitute a simpler
+  `git merge --ff-only` even when it looks equivalent.
+
+If `git push` is impossible (no remote, push-disabled rig), still run
+the metadata write and the close. The local merge happened; the bead
+records that merge.
 
 ---
 


### PR DESCRIPTION
## Summary

Two fixes to the `gastown` pack's refinery agent prompt, both originally opened against `gastownhall/gascity` (#1934, #1935) and re-homed here after the pack migrated to this repo (#27).

1. **Rejected beads can strand in the pool.** When the refinery rejects a work bead, the prompt set `rejection_reason` and cleared the assignee but left the bead's `gc.routed_to` at the value it arrived with (the refinery target). Pool-demand spawning and an agent's own work-discovery share one predicate — `bd ready --metadata-field gc.routed_to=<target> --unassigned --exclude-type=epic` (in gascity, `internal/config/config.go`; the reconciler reaches it via `EffectivePoolDemandQuery`). A bead still pointing at the refinery target matches neither a polecat's work query nor the polecat pool-demand count, so no polecat is spawned and it stalls. The fix has the rejection step re-stamp `gc.routed_to` to the polecat pool target.

2. **Merge bookkeeping was under-specified.** Adds a section making two obligations explicit: write `merged_sha`/`merged_target` before close, and advance the target branch with `git update-ref refs/heads/$TARGET <sha>` rather than `git checkout $TARGET; git merge --ff-only`, which silently merges into another worktree's HEAD when `$TARGET` is checked out elsewhere.

## Change

`gastown/agents/refinery/prompt.template.md`:

- **Rejection Flow** — the bead-return step now sets `gc.routed_to=<polecat>` alongside `rejection_reason`, with a note on why it is load-bearing. Preserves the existing "clear `rejection_reason` on the next merge" guidance.
- **New "Merge Bookkeeping" section** — the `merged_sha`/`merged_target`-before-close obligation and the `git update-ref` worktree-safety rule.

## What this does not solve

- This is prompt guidance, not an enforced invariant. A controller-side guard that re-stamped a stale `gc.routed_to` on rejection (rather than relying on the agent) would be stronger; this lands the behavior where the agent already owns the rejection decision. Happy to redraft toward a controller-side shape if you'd prefer.
- On `merged_sha`/`merged_target`: there is already a test asserting `merged_sha` is written, but I did not find a Go consumer that *reads* it — so today these are a machine-readable record more than a tooling input. This section reinforces the existing expectation and adds the `update-ref` safety; it does not add a consumer.

## Test plan

- [x] Diff is the two prompt hunks only; Go-template braces balanced; the sections render coherently in context.
- [ ] Pack-level validation per this repo's conventions. No `*_test.go` is touched here; the assertion test for these behaviors lives in `gastownhall/gascity`'s `examples/gastown/gastown_test.go`, left untouched — see the open question.

## Open question for maintainers

With the prompt now in this repo but the assertion test (`gastown_test.go`) still in `gastownhall/gascity`, how would you like the example-copy / canonical relationship handled — should the in-tree gascity copy track this repo, or should the test assert against the imported pack? Happy to follow whatever convention you have settled on post-migration.

## Credit

Ports `gastownhall/gascity#1934` and `#1935`; thanks to @julianknutsen for the review prompt that flagged the missing behavioral verification.
