### PR TITLE
docs(pr-review): sync mol-adopt-pr step count to 5 (re-land #37 copilot fix)

### DIFF
--- a/pr-pipeline/README.md
+++ b/pr-pipeline/README.md
@@ -28,9 +28,9 @@ stay with the caller.
 ## Sibling pack
 
 `pr-review` (in this same repo) covers the **maintainer-side incoming-PR
-review/merge workflow** with `mol-adopt-pr` — a 6-step formula for
+review/merge workflow** with `mol-adopt-pr` — a 5-step formula for
 adopting contributor PRs (intake → rebase → review → human-gate →
-finalize → merge). The two packs are complementary:
+finalize). The two packs are complementary:
 
 - `pr-review` → reviewing PRs that arrive at your repo
 - `pr-pipeline` → planning, building, and shipping PRs your city sends out

--- a/pr-review/README.md
+++ b/pr-review/README.md
@@ -6,8 +6,8 @@ gate between review and merge.
 
 ## What's Included
 
-- **`mol-adopt-pr` formula** — 6-step molecule: intake, rebase-check, review,
-  human-gate, finalize, complete
+- **`mol-adopt-pr` formula** — 5-step molecule: intake, rebase-check, review,
+  human-gate, finalize
 - **`/review-pr` skill** — multi-model code review engine (overlay)
 
 ## Prerequisites
@@ -47,8 +47,7 @@ gc sling <rig>/polecat mol-adopt-pr --formula \
    ```bash
    bd close <human-gate-step-id>
    ```
-5. **Finalize** — Determine merge path, push, post synthesis comment, wait for CI, merge
-6. **Complete** — Clean up refs, update root bead
+5. **Finalize** — Resolve merge path, prepare local artifacts (squash/rebase/branch/synthesis), hand publish + merge to mayor, then clean up refs and update the root bead
 
 ## Merge Paths
 

--- a/pr-review/pack.toml
+++ b/pr-review/pack.toml
@@ -1,6 +1,6 @@
 # PR Review — formula-driven adopt-PR workflow.
 #
-# Provides a 6-step molecule formula for reviewing and merging contributor PRs.
+# Provides a 5-step molecule formula for reviewing and merging contributor PRs.
 # The polecat follows the formula steps; a human gate after review blocks until
 # the maintainer is ready to finalize.
 #


### PR DESCRIPTION
## Re-land: mol-adopt-pr docs step-count sync (5-step)

PR #37 (`refactor(adopt-pr): fold redundant complete step into finalize cleanup`) merged **without** the follow-up doc-sync that Copilot's review requested, so `pr-review/` and `pr-pipeline/` docs still describe mol-adopt-pr as a 6-step molecule.

This re-lands that fix on current `main`:
- `pr-review/pack.toml` — 6-step → 5-step
- `pr-review/README.md` — drop step 6 *Complete*, fold cleanup into step 5 *Finalize*, correct Finalize to the hands-off-to-mayor model
- `pr-pipeline/README.md` — sibling-pack blurb 6-step → 5-step, drop `-> merge`

Other formulas' legitimate 6-step references (mol-pr-start, mol-pr-revert, mol-pr-iterate, mol-pr-from-issue) are intentionally left untouched. Docs/TOML only; `pack.toml` parses.

Addresses the Copilot review on #37 (review 4395944384).
