### PR TITLE
fix(slack-channel): PR #3 review follow-ups — alias-remove 500, icon_url https, shell hardening, docs

### DIFF
--- a/slack-channel/README.md
+++ b/slack-channel/README.md
@@ -184,6 +184,38 @@ app and point its Request URL at `https://<your-funnel-host>/slack/interactions`
 The adapter verifies the signature and acks with `200` so Slack dismisses
 the interaction; it does no custom modal handling (that is Tier 3).
 
+## Security posture
+
+A few deliberate choices in the shipped manifest and adapter are worth
+understanding before you install:
+
+- **`chat:write.public` (manifest scope).** This lets the bot post to any
+  *public* channel without first being invited — `publish-to-channel
+  --channel <id>` reaches any public channel in the workspace, and a bound
+  session can publish to a public channel it was bound to without a join
+  step. The blast radius is "every public channel in this workspace." If
+  that is broader than you want, drop `chat:write.public` from
+  [`manifest/app.json`](./manifest/app.json) and invite the bot to each
+  channel it should post in (Slack then requires `conversations.join` /
+  manual membership instead).
+- **`token_rotation_enabled: false` (manifest setting).** The adapter
+  authenticates with a long-lived bot token (`SLACK_BOT_TOKEN`) rather than
+  rotating, expiring tokens. Rotation would require the adapter to persist
+  and refresh credentials; for a single-workspace Tier-2 bridge the static
+  token is simpler and the token never leaves the adapter (verbs never see
+  it). Treat the token as a secret, scope it to one workspace, and rotate it
+  by hand if it is exposed. Enable rotation in the Slack app settings if your
+  deployment policy requires it.
+- **Internal verb listener is loopback / dev-only.** When the adapter is
+  *not* run as a gc `proxy_process` service (`GC_SERVICE_SOCKET` unset), the
+  verb endpoints are served over plain TCP on `127.0.0.1:8776`
+  (`LISTEN_INTERNAL`) with no authentication — anything that can reach that
+  loopback port can mutate the registries. This mode is for local
+  development only. In production gc runs the adapter as a `proxy_process`
+  service and the verb endpoints bind a `0600` Unix-domain socket
+  (`GC_SERVICE_SOCKET`) that only the gc supervisor can reach; do not expose
+  `127.0.0.1:8776` beyond loopback.
+
 ## Choosing a tier
 
 - **slack-mini** (Tier 1) — one outbound verb, `app_mention` → mayor. No

--- a/slack-channel/adapter/registries.go
+++ b/slack-channel/adapter/registries.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"net/url"
 	"regexp"
 	"sort"
 	"strings"
@@ -111,6 +112,18 @@ func validateIdentity(sessionID, username, iconURL, iconEmoji string) error {
 	}
 	if username == "" && iconURL == "" && iconEmoji == "" {
 		return fmt.Errorf("at least one of username, icon_url, icon_emoji is required")
+	}
+	if iconURL != "" {
+		// The icon_url is forwarded verbatim to Slack's chat.postMessage. A
+		// non-https (or scheme-relative) URL would either be rejected by
+		// Slack or, worse, fetched over plaintext, so require https up front.
+		u, err := url.Parse(iconURL)
+		if err != nil {
+			return fmt.Errorf("icon_url is not a valid URL: %w", err)
+		}
+		if u.Scheme != "https" || u.Host == "" {
+			return fmt.Errorf("icon_url must be an absolute https:// URL (got %q)", iconURL)
+		}
 	}
 	return nil
 }

--- a/slack-channel/adapter/registries_http.go
+++ b/slack-channel/adapter/registries_http.go
@@ -110,9 +110,13 @@ func (s *server) handleAliasRemove() http.HandlerFunc {
 			writeJSONError(w, http.StatusBadRequest, fmt.Sprintf("decode: %v", err))
 			return
 		}
+		if normalizeHandle(req.Handle) == "" {
+			writeJSONError(w, http.StatusBadRequest, "handle is required")
+			return
+		}
 		removed, err := s.removeHandleAlias(req.Handle)
 		if err != nil {
-			writeJSONError(w, http.StatusBadRequest, err.Error())
+			writeJSONError(w, http.StatusInternalServerError, err.Error())
 			return
 		}
 		log.Printf("handle-alias remove: handle=%s removed=%v", normalizeHandle(req.Handle), removed)

--- a/slack-channel/adapter/registries_http_test.go
+++ b/slack-channel/adapter/registries_http_test.go
@@ -149,7 +149,7 @@ func TestRemoveSaveErrors(t *testing.T) {
 	if rec := doMethod(http.MethodDelete, srv.handleIdentityRemove(), `{"session_id":"s1"}`); rec.Code != http.StatusInternalServerError {
 		t.Errorf("identity remove save error status=%d, want 500", rec.Code)
 	}
-	if rec := doMethod(http.MethodDelete, srv.handleAliasRemove(), `{"handle":"mayor"}`); rec.Code != http.StatusBadRequest {
-		t.Errorf("alias remove save error status=%d, want 400", rec.Code)
+	if rec := doMethod(http.MethodDelete, srv.handleAliasRemove(), `{"handle":"mayor"}`); rec.Code != http.StatusInternalServerError {
+		t.Errorf("alias remove save error status=%d, want 500", rec.Code)
 	}
 }

--- a/slack-channel/adapter/registries_test.go
+++ b/slack-channel/adapter/registries_test.go
@@ -61,6 +61,9 @@ func TestValidateIdentity(t *testing.T) {
 		{"no session", "", "PL", "", "", "session_id"},
 		{"both icons", "s1", "", "u", "e", "mutually exclusive"},
 		{"all empty", "s1", "", "", "", "at least one"},
+		{"http icon", "s1", "", "http://x/y.png", "", "https"},
+		{"scheme-relative icon", "s1", "", "//x/y.png", "", "https"},
+		{"schemeless icon", "s1", "", "x/y.png", "", "https"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/slack-channel/adapter/server.go
+++ b/slack-channel/adapter/server.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"maps"
 	"net/http"
 	"sort"
@@ -238,11 +237,12 @@ func (s *server) upsertHandleAlias(handle, sessionID string) (handleAlias, error
 	return rec, nil
 }
 
+// removeHandleAlias deletes a handle alias. Like removeIdentity it is
+// idempotent and does not re-validate the handle: callers (the verb
+// endpoint) reject an empty handle up front, so the only error it can
+// surface is a registry write failure.
 func (s *server) removeHandleAlias(handle string) (bool, error) {
 	h := normalizeHandle(handle)
-	if h == "" {
-		return false, fmt.Errorf("handle is required")
-	}
 	s.writeMu.Lock()
 	defer s.writeMu.Unlock()
 

--- a/slack-channel/commands/_lib.sh
+++ b/slack-channel/commands/_lib.sh
@@ -18,6 +18,13 @@ sc_require() {
 
 sc_city() {
   [ -n "${GC_CITY_NAME:-}" ] || sc_die "GC_CITY_NAME is not set" 1
+  # GC_CITY_NAME is interpolated into the adapter URL path (sc_adapter_base),
+  # so reject characters that would alter the path or smuggle a query/fragment.
+  case "$GC_CITY_NAME" in
+    *[/?#%]* | *[[:space:]]*)
+      sc_die "GC_CITY_NAME contains characters not allowed in a URL path: '$GC_CITY_NAME'" 1
+      ;;
+  esac
   printf '%s' "$GC_CITY_NAME"
 }
 
@@ -74,7 +81,8 @@ sc_help() {
 }
 
 # sc_load_body BODY BODY_FILE — resolve a message body from --body or
-# --body-file (mutually exclusive, exactly one required).
+# --body-file (mutually exclusive, exactly one required). --body-file must
+# name a readable regular file (not a directory, device, or missing path).
 sc_load_body() {
   if [ -n "$1" ] && [ -n "$2" ]; then
     sc_die "pass --body OR --body-file, not both" 2
@@ -84,6 +92,7 @@ sc_load_body() {
     return
   fi
   [ -n "$2" ] || sc_die "either --body or --body-file is required" 2
+  [ -f "$2" ] || sc_die "--body-file is not a regular file: $2" 2
   cat "$2"
 }
 

--- a/slack-channel/commands/publish-to-channel/help.md
+++ b/slack-channel/commands/publish-to-channel/help.md
@@ -13,7 +13,7 @@ Usage:
 Flags:
   --channel    Slack channel id (C..., G..., or D...) — required.
   --body       Message text. Mutually exclusive with --body-file.
-  --body-file  Read the message body from a file.
+  --body-file  Read the message body from a file (must be a regular file).
   --session    Session to attribute the post to (identity override).
                Defaults to the current session ($GC_SESSION_ID).
   --thread-ts  Slack message ts to thread under (optional).

--- a/slack-channel/commands/publish/help.md
+++ b/slack-channel/commands/publish/help.md
@@ -20,7 +20,7 @@ Flags:
   --session    Session whose binding to publish into. Defaults to the
                current session ($GC_SESSION_ID).
   --body       Message text. Mutually exclusive with --body-file.
-  --body-file  Read the message body from a file.
+  --body-file  Read the message body from a file (must be a regular file).
   --reply-to   Slack message ts to thread under (optional).
 
 Examples:

--- a/slack-channel/commands/reply-current/help.md
+++ b/slack-channel/commands/reply-current/help.md
@@ -19,7 +19,7 @@ Usage:
 Flags:
   --session         Override the session id (default: $GC_SESSION_ID).
   --body            Message text. Mutually exclusive with --body-file.
-  --body-file       Read the message body from a file.
+  --body-file       Read the message body from a file (must be a regular file).
   --thread-current  Thread under the latest inbound message. Mutually
                     exclusive with --reply-to.
   --reply-to        Slack message ts to thread under.

--- a/slack-channel/schema/channel_mappings.schema.json
+++ b/slack-channel/schema/channel_mappings.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/gastownhall/gascity-packs/slack-channel/schema/channel_mappings.schema.json",
+  "$id": "https://github.com/gastownhall/gascity-packs/blob/main/slack-channel/schema/channel_mappings.schema.json",
   "title": "slack-channel channel_mappings.json",
   "description": "Authoritative schema for the channel binding registry persisted at <GC_CITY_PATH>/.gc/slack-channel/channel_mappings.json. The slack-channel adapter is the sole writer (via the bind-dm / bind-room verb endpoints) and reader (on the inbound path). The JSON object key is the composite '<workspace_id>:<channel_id>'. A message arriving in a bound channel is delivered to every session in session_ids.",
   "type": "object",

--- a/slack-channel/schema/handle_aliases.schema.json
+++ b/slack-channel/schema/handle_aliases.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/gastownhall/gascity-packs/slack-channel/schema/handle_aliases.schema.json",
+  "$id": "https://github.com/gastownhall/gascity-packs/blob/main/slack-channel/schema/handle_aliases.schema.json",
   "title": "slack-channel handle_aliases.json",
   "description": "Authoritative schema for the handle-alias registry persisted at <GC_CITY_PATH>/.gc/slack-channel/handle_aliases.json. The slack-channel adapter is the sole writer (via the handle-alias verb endpoint) and reader (on the inbound path). The JSON object key is the normalized handle (lowercased, leading '@' stripped). When an inbound message leads with '@<handle>[:]', it is routed to the aliased session regardless of channel binding. Single-workspace at Tier 2 — aliases are not scoped per workspace.",
   "type": "object",

--- a/slack-channel/schema/identities.schema.json
+++ b/slack-channel/schema/identities.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/gastownhall/gascity-packs/slack-channel/schema/identities.schema.json",
+  "$id": "https://github.com/gastownhall/gascity-packs/blob/main/slack-channel/schema/identities.schema.json",
   "title": "slack-channel identities.json",
   "description": "Authoritative schema for the per-session identity registry persisted at <GC_CITY_PATH>/.gc/slack-channel/identities.json. The slack-channel adapter is the sole writer (via the identity verb endpoint) and reader (injected into chat.postMessage on every outbound). The JSON object key is the gc session id. icon_url and icon_emoji are mutually exclusive; at least one of username / icon_url / icon_emoji is set.",
   "type": "object",

--- a/slack-channel/tests/test_schemas.py
+++ b/slack-channel/tests/test_schemas.py
@@ -46,12 +46,27 @@ def test_channel_mappings_valid():
     _validator(CHANNEL_V).validate(doc)
 
 
+def test_channel_mappings_dm_kind_valid():
+    doc = {
+        "T123:D1": {
+            "workspace_id": "T123",
+            "channel_id": "D1",
+            "kind": "dm",
+            "session_ids": ["s1"],
+            "created_at": "2026-05-30T12:00:00Z",
+            "updated_at": "2026-05-30T12:00:00Z",
+        }
+    }
+    _validator(CHANNEL_V).validate(doc)
+
+
 @pytest.mark.parametrize(
     "mutate",
     [
         lambda r: r.pop("kind"),
         lambda r: r.update(kind="thread"),
         lambda r: r.update(session_ids=[]),
+        lambda r: r.update(session_ids=["s1", "s1"]),
         lambda r: r.update(extra="nope"),
     ],
 )


### PR DESCRIPTION
Eight non-blocking review follow-ups for the `slack-channel` pack (Tier 2), all under `slack-channel/`. Branch off `main` (slack-channel itself already merged via #3).

## Changes
1. **[correctness MED]** `handleAliasRemove` → 400 on a bad handle, 500 on disk-write failure (previously 400 for both); dropped the now-redundant guard in `removeHandleAlias`.
2. **[sec LOW]** `validateIdentity` rejects `icon_url` unless absolute `https://` (+3 Go test cases).
3. **[sec LOW]** `_lib.sh`: `sc_city` rejects `GC_CITY_NAME` containing `/ ? # %` or whitespace; `sc_load_body` requires `--body-file` to be a regular file (`-f`), with help notes.
4. **[sec MED ×2]** README documents the `chat:write.public` blast radius and the `token_rotation_enabled: false` rationale.
5. **[sec LOW]** README documents the loopback/dev-only internal verb listener (`127.0.0.1:8776`) vs the prod UDS.
6. **[LOW]** schema `$id` → canonical GitHub blob URLs; pytest adds `dm-kind` valid + `uniqueItems(session_ids)` reject cases.

## Verification
- `go build` + `go vet` clean; `go test -race ./...` ok; `pytest` 15 passed; `sh -n` clean.
- Review: go-reviewer PASS + code-reviewer APPROVE (0 findings; README claims verified line-by-line against code).

Diff: 14 files, +90/-14, all under `slack-channel/`.
