### PR TITLE
feat: restore cass as a first-order pack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         run: python3 validate_registry.py
 
       - name: Run Python pack tests
-        run: python3 -m pytest gascity/tests discord/tests github/tests slack-full/tests slack-channel/tests -q
+        run: python3 -m pytest tests gascity/tests discord/tests github/tests slack-full/tests slack-channel/tests -q
 
       - name: Run Slack full adapter tests
         working-directory: slack-full/adapter

--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ Each top-level directory is either a pack or a group of related packs:
 
 Browse the tree for the current set; each pack has its own README.
 
+### Agent context packs
+
+- [cass](./cass) adds a shared `cass-search` prompt fragment and Claude skill
+  overlay for searching past coding-agent sessions.
+
 ### Slack packs (tiered)
 
 The Slack provider ships as three tiers — pick the smallest one that covers

--- a/cass/README.md
+++ b/cass/README.md
@@ -1,0 +1,58 @@
+# CASS Pack
+
+Search past coding-agent sessions with
+[`cass`](https://github.com/Dicklesworthstone/coding_agent_session_search).
+
+## What It Provides
+
+- Claude skill overlay at `overlay/.claude/skills/search-sessions/SKILL.md`
+- Shared prompt fragment at `template-fragments/cass-search.template.md`
+
+The overlay skill is Claude-only. The shared prompt fragment is the
+recommended cross-provider path for Claude, Codex, and Gemini cities.
+
+## Prerequisites
+
+Install `cass` and keep it on `PATH`.
+
+Latest release:
+
+```bash
+curl -fsSL "https://raw.githubusercontent.com/Dicklesworthstone/coding_agent_session_search/main/install.sh?$(date +%s)" \
+  | bash -s -- --easy-mode --verify
+```
+
+Build from source:
+
+```bash
+git clone https://github.com/Dicklesworthstone/coding_agent_session_search.git
+cd coding_agent_session_search
+cargo build --release
+install -m 0755 target/release/cass ~/.local/bin/cass
+```
+
+## Import It
+
+Local checkout:
+
+```toml
+# pack.toml
+[imports.cass]
+source = "../packs/cass"
+
+[agent_defaults]
+append_fragments = ["cass-search"]
+```
+
+Optional deployment hooks still belong in `city.toml`:
+
+```toml
+[workspace]
+install_agent_hooks = ["claude", "codex", "gemini"] # optional
+```
+
+## Notes
+
+- Do not run bare `cass` in agent contexts; use `--json` or `--robot`.
+- If your city already defines a local `cass-search` fragment, remove or rename
+  it before enabling the pack-provided fragment.

--- a/cass/overlay/.claude/skills/search-sessions/SKILL.md
+++ b/cass/overlay/.claude/skills/search-sessions/SKILL.md
@@ -1,0 +1,48 @@
+# /search-sessions — Search past agent sessions
+
+Use `cass` to search past coding-agent sessions for relevant solutions,
+debugging history, and prior decisions.
+
+Never run bare `cass` in an agent context. Use non-interactive mode only.
+
+## Preflight
+
+```bash
+cass health --json || cass index --full
+```
+
+## Find relevant sessions
+
+Current workspace and recent matches:
+
+```bash
+cass sessions --current --json
+cass sessions --workspace "$(pwd)" --json --limit 5
+```
+
+Direct search:
+
+```bash
+cass search "error message or subsystem" --json --limit 5 --fields minimal
+```
+
+## Inspect a hit
+
+Use `source_path` and `line_number` from search output:
+
+```bash
+cass view <source_path> -n <line_number> --json
+cass expand <source_path> -n <line_number> -C 3 --json
+```
+
+## If expected history is missing
+
+```bash
+cass diag --json
+```
+
+## Tips
+
+- Start with an exact error string, workspace path, or subsystem name.
+- Use `--fields minimal` first, then inspect only the strongest hits.
+- Check prior sessions before re-debugging an unfamiliar failure.

--- a/cass/pack.toml
+++ b/cass/pack.toml
@@ -1,0 +1,4 @@
+[pack]
+name = "cass"
+version = "0.1.0"
+schema = 2

--- a/cass/template-fragments/cass-search.template.md
+++ b/cass/template-fragments/cass-search.template.md
@@ -1,0 +1,32 @@
+{{ define "cass-search" }}
+## Session Search
+
+When debugging, investigating prior failures, or entering an unfamiliar
+subsystem, check past agent sessions before starting from scratch.
+
+Use non-interactive `cass` commands only:
+
+```bash
+cass health --json || cass index --full
+cass sessions --current --json
+cass sessions --workspace "$(pwd)" --json --limit 5
+cass search "<query>" --json --limit 5 --fields minimal
+```
+
+If a hit looks relevant, inspect it with:
+
+```bash
+cass view <source_path> -n <line_number> --json
+cass expand <source_path> -n <line_number> -C 3 --json
+```
+
+If you expect prior history but search returns nothing, verify ingestion
+before assuming there is no precedent:
+
+```bash
+cass diag --json
+```
+
+Prefer a short, specific query first: an error string, workspace path,
+subsystem name, or command.
+{{ end }}

--- a/registry.toml
+++ b/registry.toml
@@ -27,6 +27,19 @@ source_kind = "git"
   description = "Initial Gas Town workflow pack release."
 
 [[pack]]
+name = "cass"
+description = "Coding Agent Session Search prompt fragments and skill overlays for Gas City."
+source = "https://github.com/gastownhall/gascity-packs/tree/main/cass"
+source_kind = "git"
+
+  [[pack.release]]
+  version = "0.1.0"
+  ref = "main"
+  commit = "d3617d1319a1206ac85f69ba024ec395c49c6f4b"
+  hash = "sha256:9849675daa3ba8a792fc1c68c727542936400687d529e5d4d231afde29d4a341"
+  description = "Initial CASS session-search pack release."
+
+[[pack]]
 name = "discord"
 description = "Discord services, commands, and prompt fragments for Gas City."
 source = "https://github.com/gastownhall/gascity-packs/tree/main/discord"

--- a/tests/test_validate_registry.py
+++ b/tests/test_validate_registry.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import textwrap
+
+import validate_registry
+
+
+def test_source_pack_path_accepts_tree_urls() -> None:
+    source = "https://github.com/gastownhall/gascity-packs/tree/main/cass"
+
+    assert validate_registry.source_pack_path(source) == "cass"
+
+
+def test_validate_tree_url_source_checks_pack_toml_name(tmp_path) -> None:
+    pack_dir = tmp_path / "cass"
+    pack_dir.mkdir()
+    (pack_dir / "pack.toml").write_text(
+        textwrap.dedent(
+            """\
+            [pack]
+            name = "wrong"
+            schema = 2
+            """
+        ),
+        encoding="utf-8",
+    )
+    registry = tmp_path / "registry.toml"
+    registry.write_text(
+        textwrap.dedent(
+            """\
+            schema = 1
+
+            [[pack]]
+            name = "cass"
+            description = "CASS session search pack."
+            source = "https://github.com/gastownhall/gascity-packs/tree/main/cass"
+            source_kind = "git"
+
+              [[pack.release]]
+              version = "0.1.0"
+              ref = "main"
+              commit = "d3617d1319a1206ac85f69ba024ec395c49c6f4b"
+              hash = "sha256:9849675daa3ba8a792fc1c68c727542936400687d529e5d4d231afde29d4a341"
+              description = "Initial CASS session-search pack release."
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    errors = validate_registry.validate(registry)
+
+    assert "cass: registry name does not match cass/pack.toml name 'wrong'" in errors

--- a/validate_registry.py
+++ b/validate_registry.py
@@ -15,8 +15,18 @@ PACK_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]*(/[a-z0-9][a-z0-9-]*)?$")
 RELEASE_VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+(\.[0-9]+)?$")
 COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
 HASH_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
-REQUIRED_WAVE_1 = {"discord", "gascity", "gastown", "github", "slack-full"}
+REQUIRED_WAVE_1 = {"cass", "discord", "gascity", "gastown", "github", "slack-full"}
 FORBIDDEN_WAVE_1 = {"bd", "core", "dolt", "maintenance"}
+
+
+def source_pack_path(source: str) -> str:
+    git_subdir = re.search(r"\.git//([^#]+)", source)
+    if git_subdir:
+        return git_subdir.group(1).strip("/")
+    tree_path = re.search(r"/tree/[^/]+/([^#]+)", source)
+    if tree_path:
+        return tree_path.group(1).strip("/")
+    return ""
 
 
 def validate(path: Path) -> list[str]:
@@ -76,9 +86,8 @@ def validate(path: Path) -> list[str]:
             errors.append(f"{label}: source must not embed a ref fragment; use [[pack.release]].ref")
             continue
 
-        match = re.search(r"\.git//([^#]+)", source)
-        if match:
-            pack_path = match.group(1)
+        pack_path = source_pack_path(source)
+        if pack_path:
             pack_toml = path.parent / pack_path / "pack.toml"
             if not pack_toml.exists():
                 errors.append(f"{label}: source path {pack_path!r} does not contain pack.toml")


### PR DESCRIPTION
Restores the former flywheel/cass pack as top-level `cass`, registers it as a first-order pack, and updates registry validation to check GitHub tree source paths against local pack metadata.

Validation:
- `python3 validate_registry.py`
- `python3 -m pytest tests gascity/tests discord/tests github/tests slack-full/tests slack-channel/tests -q`
- Slack Go module tests