### PR TITLE
fix(slack-channel,slack-mini): standalone-TCP callback_url + persistence 500 (salvaged from #45)

### DIFF
--- a/slack-channel/adapter/config.go
+++ b/slack-channel/adapter/config.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -114,6 +115,11 @@ func loadConfigFromEnv(getenv func(string) string) (config, error) {
 			return cfg, errors.New("GC_SERVICE_SOCKET is set but GC_SERVICE_URL_PREFIX is empty — controller-injected env is incomplete")
 		}
 		cfg.internalCallbackURL = cfg.gcAPIBase + urlPrefix
+	} else {
+		// Standalone TCP mode: no controller-injected URL prefix, so derive
+		// the callback base from the internal listener. Leaving it empty would
+		// self-register an empty callback_url and break gc→adapter callbacks.
+		cfg.internalCallbackURL = tcpCallbackURL(cfg.internalListen)
 	}
 
 	var missing []string
@@ -144,4 +150,21 @@ func loadConfigFromEnv(getenv func(string) string) (config, error) {
 		return cfg, fmt.Errorf("GC_CITY_NAME must not contain '/', '?', '#', or '%%': %q", cfg.cityName)
 	}
 	return cfg, nil
+}
+
+// tcpCallbackURL derives the gc→adapter callback base from the internal
+// listener address for standalone (TCP) mode, where there is no
+// proxy_process URL prefix. gc appends the endpoint path itself, so the
+// returned URL carries no trailing path. A wildcard or empty bind host is
+// rewritten to loopback because gc dials a concrete address.
+func tcpCallbackURL(internalListen string) string {
+	host, port, err := net.SplitHostPort(internalListen)
+	if err != nil {
+		return "http://" + internalListen
+	}
+	switch host {
+	case "", "0.0.0.0", "::":
+		host = "127.0.0.1"
+	}
+	return "http://" + net.JoinHostPort(host, port)
 }

--- a/slack-channel/adapter/config_test.go
+++ b/slack-channel/adapter/config_test.go
@@ -133,4 +133,27 @@ func TestLoadConfigFromEnv(t *testing.T) {
 			t.Errorf("slackAPIBase = %q, want trimmed", cfg.slackAPIBase)
 		}
 	})
+
+	t.Run("tcp mode derives callback url from internal listener", func(t *testing.T) {
+		// No GC_SERVICE_SOCKET → standalone TCP mode. The callback must not be
+		// empty (an empty callback_url breaks gc→adapter callbacks).
+		cfg, err := loadConfigFromEnv(clone(nil))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := "http://" + defaultInternalListen
+		if cfg.internalCallbackURL != want {
+			t.Errorf("internalCallbackURL = %q, want %q", cfg.internalCallbackURL, want)
+		}
+	})
+
+	t.Run("tcp mode normalizes wildcard internal host to loopback", func(t *testing.T) {
+		cfg, err := loadConfigFromEnv(clone(map[string]string{"LISTEN_INTERNAL": "0.0.0.0:9001"}))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.internalCallbackURL != "http://127.0.0.1:9001" {
+			t.Errorf("internalCallbackURL = %q, want loopback-normalized", cfg.internalCallbackURL)
+		}
+	})
 }

--- a/slack-channel/adapter/registries_http.go
+++ b/slack-channel/adapter/registries_http.go
@@ -2,11 +2,23 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
 	"strings"
 )
+
+// statusForError maps a server-layer error to an HTTP status. Persistence
+// failures (errPersistence) are operational 500s; everything else is treated
+// as a caller error (400). Decode and required-field checks are handled
+// inline by each handler before reaching the server layer.
+func statusForError(err error) int {
+	if errors.Is(err, errPersistence) {
+		return http.StatusInternalServerError
+	}
+	return http.StatusBadRequest
+}
 
 type bindRequest struct {
 	ChannelID  string   `json:"channel_id"`
@@ -36,7 +48,7 @@ func (s *server) handleBind() http.HandlerFunc {
 		}
 		rec, err := s.upsertBinding(req.ChannelID, req.Kind, req.SessionIDs)
 		if err != nil {
-			writeJSONError(w, http.StatusBadRequest, err.Error())
+			writeJSONError(w, statusForError(err), err.Error())
 			return
 		}
 		log.Printf("bind: channel=%s kind=%s sessions=%s", rec.ChannelID, rec.Kind, strings.Join(rec.SessionIDs, ","))
@@ -54,7 +66,7 @@ func (s *server) handleIdentitySet() http.HandlerFunc {
 		}
 		rec, err := s.upsertIdentity(req.SessionID, req.Username, req.IconURL, req.IconEmoji)
 		if err != nil {
-			writeJSONError(w, http.StatusBadRequest, err.Error())
+			writeJSONError(w, statusForError(err), err.Error())
 			return
 		}
 		log.Printf("identity set: session=%s username=%q", rec.SessionID, rec.Username)
@@ -76,7 +88,7 @@ func (s *server) handleIdentityRemove() http.HandlerFunc {
 		}
 		removed, err := s.removeIdentity(req.SessionID)
 		if err != nil {
-			writeJSONError(w, http.StatusInternalServerError, err.Error())
+			writeJSONError(w, statusForError(err), err.Error())
 			return
 		}
 		log.Printf("identity remove: session=%s removed=%v", req.SessionID, removed)
@@ -94,7 +106,7 @@ func (s *server) handleAliasSet() http.HandlerFunc {
 		}
 		rec, err := s.upsertHandleAlias(req.Handle, req.SessionID)
 		if err != nil {
-			writeJSONError(w, http.StatusBadRequest, err.Error())
+			writeJSONError(w, statusForError(err), err.Error())
 			return
 		}
 		log.Printf("handle-alias set: handle=%s session=%s", rec.Handle, rec.SessionID)
@@ -116,7 +128,7 @@ func (s *server) handleAliasRemove() http.HandlerFunc {
 		}
 		removed, err := s.removeHandleAlias(req.Handle)
 		if err != nil {
-			writeJSONError(w, http.StatusInternalServerError, err.Error())
+			writeJSONError(w, statusForError(err), err.Error())
 			return
 		}
 		log.Printf("handle-alias remove: handle=%s removed=%v", normalizeHandle(req.Handle), removed)

--- a/slack-channel/adapter/registries_http_test.go
+++ b/slack-channel/adapter/registries_http_test.go
@@ -133,23 +133,41 @@ func TestHandleAliasRemoveRejectsEmptyHandle(t *testing.T) {
 	}
 }
 
-func TestRemoveSaveErrors(t *testing.T) {
+// TestPersistenceErrorsReturn500 verifies that registry handlers surface
+// on-disk save failures as 500 (operational) rather than 400 (caller error),
+// so operators can distinguish persistence problems from bad requests.
+func TestPersistenceErrorsReturn500(t *testing.T) {
 	srv := newTestServer(t)
+	// Seed records so the remove handlers reach the save path.
 	if _, err := srv.upsertIdentity("s1", "PL", "", ""); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := srv.upsertHandleAlias("mayor", "s1"); err != nil {
 		t.Fatal(err)
 	}
+	// Make the registry dir read-only so every saveJSONAtomic fails.
 	if err := os.Chmod(srv.cfg.registryDir, 0o500); err != nil {
 		t.Skip("chmod unsupported on this platform")
 	}
 	t.Cleanup(func() { _ = os.Chmod(srv.cfg.registryDir, 0o700) })
 
-	if rec := doMethod(http.MethodDelete, srv.handleIdentityRemove(), `{"session_id":"s1"}`); rec.Code != http.StatusInternalServerError {
-		t.Errorf("identity remove save error status=%d, want 500", rec.Code)
+	cases := []struct {
+		name   string
+		method string
+		h      http.HandlerFunc
+		body   string
+	}{
+		{"bind", http.MethodPost, srv.handleBind(), `{"channel_id":"C1","kind":"room","session_ids":["s1"]}`},
+		{"identity-set", http.MethodPost, srv.handleIdentitySet(), `{"session_id":"s2","username":"PL"}`},
+		{"identity-remove", http.MethodDelete, srv.handleIdentityRemove(), `{"session_id":"s1"}`},
+		{"alias-set", http.MethodPost, srv.handleAliasSet(), `{"handle":"ops","session_id":"s1"}`},
+		{"alias-remove", http.MethodDelete, srv.handleAliasRemove(), `{"handle":"mayor"}`},
 	}
-	if rec := doMethod(http.MethodDelete, srv.handleAliasRemove(), `{"handle":"mayor"}`); rec.Code != http.StatusInternalServerError {
-		t.Errorf("alias remove save error status=%d, want 500", rec.Code)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if rec := doMethod(tc.method, tc.h, tc.body); rec.Code != http.StatusInternalServerError {
+				t.Errorf("save error status=%d, want 500", rec.Code)
+			}
+		})
 	}
 }

--- a/slack-channel/adapter/server.go
+++ b/slack-channel/adapter/server.go
@@ -1,12 +1,20 @@
 package main
 
 import (
+	"errors"
+	"fmt"
 	"maps"
 	"net/http"
 	"sort"
 	"sync"
 	"time"
 )
+
+// errPersistence marks an error that originates from the on-disk registry
+// save path (saveJSONAtomic) rather than caller input. HTTP handlers map it
+// to 500 so operators can distinguish server-side persistence failures from
+// bad requests; validation errors are left unwrapped and map to 400.
+var errPersistence = errors.New("registry persistence failure")
 
 // inboundRef remembers the last inbound message delivered to a session so
 // `reply-current` and `react` can act on "the message I just received"
@@ -118,7 +126,7 @@ func (s *server) upsertBinding(channelID, kind string, sessionIDs []string) (cha
 	s.regMu.Unlock()
 
 	if err := saveJSONAtomic(s.cfg.channelMappingsPath(), snapshot); err != nil {
-		return channelBinding{}, err
+		return channelBinding{}, fmt.Errorf("%w: %v", errPersistence, err)
 	}
 	return rec, nil
 }
@@ -178,7 +186,7 @@ func (s *server) upsertIdentity(sessionID, username, iconURL, iconEmoji string) 
 	s.regMu.Unlock()
 
 	if err := saveJSONAtomic(s.cfg.identitiesPath(), snapshot); err != nil {
-		return identity{}, err
+		return identity{}, fmt.Errorf("%w: %v", errPersistence, err)
 	}
 	return rec, nil
 }
@@ -199,7 +207,7 @@ func (s *server) removeIdentity(sessionID string) (bool, error) {
 	s.regMu.Unlock()
 
 	if err := saveJSONAtomic(s.cfg.identitiesPath(), snapshot); err != nil {
-		return false, err
+		return false, fmt.Errorf("%w: %v", errPersistence, err)
 	}
 	return true, nil
 }
@@ -232,7 +240,7 @@ func (s *server) upsertHandleAlias(handle, sessionID string) (handleAlias, error
 	s.regMu.Unlock()
 
 	if err := saveJSONAtomic(s.cfg.handleAliasesPath(), snapshot); err != nil {
-		return handleAlias{}, err
+		return handleAlias{}, fmt.Errorf("%w: %v", errPersistence, err)
 	}
 	return rec, nil
 }
@@ -256,7 +264,7 @@ func (s *server) removeHandleAlias(handle string) (bool, error) {
 	s.regMu.Unlock()
 
 	if err := saveJSONAtomic(s.cfg.handleAliasesPath(), snapshot); err != nil {
-		return false, err
+		return false, fmt.Errorf("%w: %v", errPersistence, err)
 	}
 	return true, nil
 }

--- a/slack-channel/adapter/server.go
+++ b/slack-channel/adapter/server.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"errors"
-	"fmt"
 	"maps"
 	"net/http"
 	"sort"
@@ -126,7 +125,7 @@ func (s *server) upsertBinding(channelID, kind string, sessionIDs []string) (cha
 	s.regMu.Unlock()
 
 	if err := saveJSONAtomic(s.cfg.channelMappingsPath(), snapshot); err != nil {
-		return channelBinding{}, fmt.Errorf("%w: %v", errPersistence, err)
+		return channelBinding{}, errors.Join(errPersistence, err)
 	}
 	return rec, nil
 }
@@ -186,7 +185,7 @@ func (s *server) upsertIdentity(sessionID, username, iconURL, iconEmoji string) 
 	s.regMu.Unlock()
 
 	if err := saveJSONAtomic(s.cfg.identitiesPath(), snapshot); err != nil {
-		return identity{}, fmt.Errorf("%w: %v", errPersistence, err)
+		return identity{}, errors.Join(errPersistence, err)
 	}
 	return rec, nil
 }
@@ -207,7 +206,7 @@ func (s *server) removeIdentity(sessionID string) (bool, error) {
 	s.regMu.Unlock()
 
 	if err := saveJSONAtomic(s.cfg.identitiesPath(), snapshot); err != nil {
-		return false, fmt.Errorf("%w: %v", errPersistence, err)
+		return false, errors.Join(errPersistence, err)
 	}
 	return true, nil
 }
@@ -240,7 +239,7 @@ func (s *server) upsertHandleAlias(handle, sessionID string) (handleAlias, error
 	s.regMu.Unlock()
 
 	if err := saveJSONAtomic(s.cfg.handleAliasesPath(), snapshot); err != nil {
-		return handleAlias{}, fmt.Errorf("%w: %v", errPersistence, err)
+		return handleAlias{}, errors.Join(errPersistence, err)
 	}
 	return rec, nil
 }
@@ -264,7 +263,7 @@ func (s *server) removeHandleAlias(handle string) (bool, error) {
 	s.regMu.Unlock()
 
 	if err := saveJSONAtomic(s.cfg.handleAliasesPath(), snapshot); err != nil {
-		return false, fmt.Errorf("%w: %v", errPersistence, err)
+		return false, errors.Join(errPersistence, err)
 	}
 	return true, nil
 }

--- a/slack-mini/adapter/main.go
+++ b/slack-mini/adapter/main.go
@@ -234,6 +234,11 @@ func loadConfigFromEnv(getenv func(string) string) (config, error) {
 			return cfg, errors.New("GC_SERVICE_SOCKET is set but GC_SERVICE_URL_PREFIX is empty — controller-injected env is incomplete")
 		}
 		cfg.internalCallbackURL = cfg.gcAPIBase + urlPrefix
+	} else {
+		// Standalone TCP mode: no controller-injected URL prefix, so derive
+		// the callback base from the internal listener. Leaving it empty would
+		// self-register an empty callback_url and break gc→adapter callbacks.
+		cfg.internalCallbackURL = tcpCallbackURL(cfg.internalListen)
 	}
 
 	var missing []string
@@ -258,6 +263,23 @@ func loadConfigFromEnv(getenv func(string) string) (config, error) {
 		return cfg, fmt.Errorf("GC_CITY_NAME must not contain '/', '?', '#', or '%%': %q", cfg.cityName)
 	}
 	return cfg, nil
+}
+
+// tcpCallbackURL derives the gc→adapter callback base from the internal
+// listener address for standalone (TCP) mode, where there is no
+// proxy_process URL prefix. gc appends the endpoint path itself, so the
+// returned URL carries no trailing path. A wildcard or empty bind host is
+// rewritten to loopback because gc dials a concrete address.
+func tcpCallbackURL(internalListen string) string {
+	host, port, err := net.SplitHostPort(internalListen)
+	if err != nil {
+		return "http://" + internalListen
+	}
+	switch host {
+	case "", "0.0.0.0", "::":
+		host = "127.0.0.1"
+	}
+	return "http://" + net.JoinHostPort(host, port)
 }
 
 // --- inbound: Slack events → gc extmsg ------------------------------------

--- a/slack-mini/adapter/main_test.go
+++ b/slack-mini/adapter/main_test.go
@@ -189,6 +189,29 @@ func TestLoadConfigFromEnv(t *testing.T) {
 			t.Errorf("internalCallbackURL = %q, want %q", cfg.internalCallbackURL, want)
 		}
 	})
+
+	t.Run("tcp mode derives callback url from internal listener", func(t *testing.T) {
+		// No GC_SERVICE_SOCKET → standalone TCP mode. The callback must not be
+		// empty (an empty callback_url breaks gc→adapter callbacks).
+		cfg, err := loadConfigFromEnv(clone(nil))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := "http://" + defaultInternalListen
+		if cfg.internalCallbackURL != want {
+			t.Errorf("internalCallbackURL = %q, want %q", cfg.internalCallbackURL, want)
+		}
+	})
+
+	t.Run("tcp mode normalizes wildcard internal host to loopback", func(t *testing.T) {
+		cfg, err := loadConfigFromEnv(clone(map[string]string{"LISTEN_INTERNAL": "0.0.0.0:9001"}))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.internalCallbackURL != "http://127.0.0.1:9001" {
+			t.Errorf("internalCallbackURL = %q, want loopback-normalized", cfg.internalCallbackURL)
+		}
+	})
 }
 
 func TestHandleSlackEventsURLVerification(t *testing.T) {


### PR DESCRIPTION
## Summary

Salvaged from #45 (closed as superseded). #45's Tier 2 slack-channel bulk is already on `main`; the only net-new content was a real bug fix, extracted here as a single clean commit.

## Fix

- **Standalone-TCP empty `callback_url` self-registration bug** — when `GC_SERVICE_SOCKET` is unset (standalone TCP mode), the adapter self-registered with an empty `callback_url`, breaking gc→adapter callbacks. Fixed by deriving the TCP callback URL in both `slack-channel` and `slack-mini` adapters.
- **Persistence errors return 500, not 400** — `errPersistence` sentinel + `statusForError`, so a save failure is no longer misclassified as a client error.

7 files, +144/-16. Tests ship with the fix.

## Test plan

- [x] `slack-channel/adapter` + `slack-mini/adapter`: `go build` / `go vet` / `go test` green.
- [x] New config tests cover the standalone-TCP callback-URL derivation; HTTP tests cover the 500 persistence path.
