### PR TITLE
Add registry publish workflow and refresh release hashes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,62 @@
+GC ?= gc
+PYTHON ?= python3
+REGISTRY ?= registry.toml
+REGISTRY_REF ?= main
+REGISTRY_COMMIT ?= HEAD
+REGISTRY_SOURCE_BASE ?= https://github.com/gastownhall/gascity-packs/tree/main
+
+PACK_PATH ?= $(PACK)
+SOURCE ?= .
+CATALOG_SOURCE ?= $(REGISTRY_SOURCE_BASE)/$(PACK_PATH)
+
+STAMP_PACK_DESCRIPTION :=
+ifneq ($(strip $(PACK_DESCRIPTION)),)
+STAMP_PACK_DESCRIPTION := --pack-description "$(PACK_DESCRIPTION)"
+endif
+
+.PHONY: registry-help registry-format-validate registry-validate registry-validate-all registry-publish registry-withdraw
+
+registry-help:
+	@printf '%s\n' 'Registry targets:'
+	@printf '%s\n' '  make registry-format-validate'
+	@printf '%s\n' '  make registry-validate GC=/path/to/gc'
+	@printf '%s\n' '  make registry-validate-all GC=/path/to/gc'
+	@printf '%s\n' '  make registry-publish GC=/path/to/gc PACK=<name> VERSION=<semver> DESCRIPTION="..." [PACK_PATH=<path>] [PACK_DESCRIPTION="..."]'
+	@printf '%s\n' '  make registry-withdraw PACK=<name> VERSION=<semver> REASON="..."'
+
+registry-format-validate:
+	$(PYTHON) validate_registry.py $(REGISTRY)
+
+registry-validate:
+	$(GC) pack release validate $(REGISTRY)
+
+registry-validate-all:
+	$(GC) pack release validate $(REGISTRY) --include-withdrawn
+
+registry-publish:
+	@test -n "$(PACK)" || { echo "PACK is required"; exit 2; }
+	@test -n "$(PACK_PATH)" || { echo "PACK_PATH is required"; exit 2; }
+	@test -n "$(VERSION)" || { echo "VERSION is required"; exit 2; }
+	@test -n "$(DESCRIPTION)" || { echo "DESCRIPTION is required"; exit 2; }
+	$(GC) pack release stamp $(REGISTRY) "$(PACK)" \
+		--version "$(VERSION)" \
+		--ref "$(REGISTRY_REF)" \
+		--commit "$(REGISTRY_COMMIT)" \
+		--description "$(DESCRIPTION)" \
+		--source "$(SOURCE)" \
+		--path "$(PACK_PATH)" \
+		$(STAMP_PACK_DESCRIPTION)
+	$(PYTHON) scripts/registry_release.py set-source \
+		--registry "$(REGISTRY)" \
+		--pack "$(PACK)" \
+		--source "$(CATALOG_SOURCE)"
+
+registry-withdraw:
+	@test -n "$(PACK)" || { echo "PACK is required"; exit 2; }
+	@test -n "$(VERSION)" || { echo "VERSION is required"; exit 2; }
+	@test -n "$(REASON)" || { echo "REASON is required"; exit 2; }
+	$(PYTHON) scripts/registry_release.py withdraw \
+		--registry "$(REGISTRY)" \
+		--pack "$(PACK)" \
+		--version "$(VERSION)" \
+		--reason "$(REASON)"

--- a/README.md
+++ b/README.md
@@ -193,3 +193,35 @@ rationale.
 
 Issues and pull requests are welcome. When a pack's surface changes, update
 its README in the same PR so the docs stay current with the code.
+
+### Publishing registry releases
+
+Registry releases are content-addressed. Use the Make targets so the release
+commit and hash are stamped by `gc` instead of hand-authored:
+
+```sh
+GC=/path/to/gc make registry-publish \
+  PACK=slack-mini \
+  VERSION=0.1.1 \
+  DESCRIPTION="Release summary."
+```
+
+`GC` defaults to `gc`, so local testing can point it at an uninstalled build.
+`REGISTRY_COMMIT` defaults to `HEAD`, and only tracked files at that commit are
+hashed; commit pack content before publishing. For new packs, also pass
+`PACK_DESCRIPTION="..."`. To withdraw a bad consumed release without rewriting
+it:
+
+```sh
+make registry-withdraw \
+  PACK=slack-mini \
+  VERSION=0.1.0 \
+  REASON="Superseded by 0.1.1."
+```
+
+Before opening a PR, run:
+
+```sh
+make registry-format-validate
+GC=/path/to/gc make registry-validate
+```

--- a/registry.toml
+++ b/registry.toml
@@ -112,3 +112,29 @@ source_kind = "git"
   commit = "788b6e8ec224a8951c728ef6da74dab8bc04d474"
   hash = "sha256:8b9d25324fe9af487398a6237a6f8d1614a5b32e85fceec935450c7b4d523d00"
   description = "Refresh Slack pack release pin."
+
+[[pack]]
+name = "slack-channel"
+description = "Shared Slack channel routing and session identity pack for Gas City."
+source = "https://github.com/gastownhall/gascity-packs/tree/main/slack-channel"
+source_kind = "git"
+
+  [[pack.release]]
+  version = "0.1.0"
+  ref = "main"
+  commit = "788b6e8ec224a8951c728ef6da74dab8bc04d474"
+  hash = "sha256:dfcb2d64eede2c939b8f157e47348b8d103ff149b8945d91774770844abb752d"
+  description = "Initial Slack channel pack release with canonical content hash."
+
+[[pack]]
+name = "slack-mini"
+description = "Minimal Slack mention bridge and outbound message pack for Gas City."
+source = "https://github.com/gastownhall/gascity-packs/tree/main/slack-mini"
+source_kind = "git"
+
+  [[pack.release]]
+  version = "0.1.0"
+  ref = "main"
+  commit = "788b6e8ec224a8951c728ef6da74dab8bc04d474"
+  hash = "sha256:fff2523a9ab32e0812815c8d2addb08e6349d3885052d095bd76600eec87921a"
+  description = "Initial Slack mini pack release with canonical content hash."

--- a/scripts/registry_release.py
+++ b/scripts/registry_release.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Line-preserving helpers for registry release maintenance."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+
+PACK_HEADER_RE = re.compile(r"^\[\[pack\]\]\s*$")
+RELEASE_HEADER_RE = re.compile(r"^\s*\[\[pack\.release\]\]\s*$")
+FIELD_RE = re.compile(r"^(\s*)([A-Za-z_]+)\s*=")
+
+
+def set_source(registry: Path, pack_name: str, source: str) -> None:
+    lines = registry.read_text(encoding="utf-8").splitlines(keepends=True)
+    start, end = find_pack(lines, pack_name)
+    changed = replace_field(lines, start, end, "source", toml_string(source), "  ")
+    if not changed:
+        raise ValueError(f'{pack_name}: missing "source" field')
+    registry.write_text("".join(lines), encoding="utf-8")
+
+
+def withdraw(registry: Path, pack_name: str, version: str, reason: str) -> None:
+    lines = registry.read_text(encoding="utf-8").splitlines(keepends=True)
+    pack_start, pack_end = find_pack(lines, pack_name)
+    release_start, release_end = find_release(lines, pack_start, pack_end, version)
+    release_lines = lines[release_start:release_end]
+    release_lines = upsert_field(release_lines, "withdrawn_reason", toml_string(reason), "  ")
+    release_lines = upsert_field(release_lines, "withdrawn", "true", "  ")
+    lines[release_start:release_end] = release_lines
+    registry.write_text("".join(lines), encoding="utf-8")
+
+
+def find_pack(lines: list[str], pack_name: str) -> tuple[int, int]:
+    pack_starts = [index for index, line in enumerate(lines) if PACK_HEADER_RE.match(line)]
+    for offset, start in enumerate(pack_starts):
+        end = pack_starts[offset + 1] if offset + 1 < len(pack_starts) else len(lines)
+        name = field_value(lines[start:end], "name")
+        if name == pack_name:
+            return start, end
+    raise ValueError(f'pack "{pack_name}" not found')
+
+
+def find_release(lines: list[str], pack_start: int, pack_end: int, version: str) -> tuple[int, int]:
+    release_starts = [
+        index for index in range(pack_start, pack_end) if RELEASE_HEADER_RE.match(lines[index])
+    ]
+    for offset, start in enumerate(release_starts):
+        end = release_starts[offset + 1] if offset + 1 < len(release_starts) else pack_end
+        actual = field_value(lines[start:end], "version")
+        if actual == version:
+            return start, end
+    raise ValueError(f'release "{version}" not found')
+
+
+def field_value(lines: list[str], key: str) -> str | None:
+    pattern = re.compile(rf"^\s*{re.escape(key)}\s*=\s*\"([^\"]*)\"")
+    for line in lines:
+        match = pattern.match(line)
+        if match:
+            return match.group(1)
+    return None
+
+
+def replace_field(lines: list[str], start: int, end: int, key: str, value: str, indent: str) -> bool:
+    for index in range(start, end):
+        match = FIELD_RE.match(lines[index])
+        if match and match.group(2) == key:
+            lines[index] = f"{indent}{key} = {value}\n"
+            return True
+    return False
+
+
+def upsert_field(lines: list[str], key: str, value: str, indent: str) -> list[str]:
+    next_lines = list(lines)
+    if replace_field(next_lines, 0, len(next_lines), key, value, indent):
+        return next_lines
+
+    insert_at = len(next_lines)
+    for index, line in enumerate(next_lines):
+        match = FIELD_RE.match(line)
+        if match and match.group(2) == "description":
+            insert_at = index + 1
+    next_lines.insert(insert_at, f"{indent}{key} = {value}\n")
+    return next_lines
+
+
+def toml_string(value: str) -> str:
+    return json.dumps(value)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subcommands = parser.add_subparsers(dest="command", required=True)
+
+    set_source_parser = subcommands.add_parser("set-source")
+    set_source_parser.add_argument("--registry", default="registry.toml")
+    set_source_parser.add_argument("--pack", required=True)
+    set_source_parser.add_argument("--source", required=True)
+
+    withdraw_parser = subcommands.add_parser("withdraw")
+    withdraw_parser.add_argument("--registry", default="registry.toml")
+    withdraw_parser.add_argument("--pack", required=True)
+    withdraw_parser.add_argument("--version", required=True)
+    withdraw_parser.add_argument("--reason", required=True)
+
+    args = parser.parse_args()
+    if args.command == "set-source":
+        set_source(Path(args.registry), args.pack, args.source)
+    elif args.command == "withdraw":
+        withdraw(Path(args.registry), args.pack, args.version, args.reason)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_registry_release.py
+++ b/tests/test_registry_release.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import textwrap
+
+from scripts import registry_release
+
+
+def test_withdraw_adds_release_metadata(tmp_path) -> None:
+    registry = tmp_path / "registry.toml"
+    registry.write_text(
+        textwrap.dedent(
+            """\
+            schema = 1
+
+            [[pack]]
+            name = "demo"
+            description = "Demo pack."
+            source = "https://example.com/repo/tree/main/demo"
+            source_kind = "git"
+
+              [[pack.release]]
+              version = "0.1.0"
+              ref = "main"
+              commit = "0123456789abcdef0123456789abcdef01234567"
+              hash = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+              description = "Initial release."
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    registry_release.withdraw(registry, "demo", "0.1.0", "Superseded by 0.1.1.")
+
+    assert (
+        '  description = "Initial release."\n'
+        "  withdrawn = true\n"
+        '  withdrawn_reason = "Superseded by 0.1.1."\n'
+    ) in registry.read_text(encoding="utf-8")
+
+
+def test_set_source_updates_only_requested_pack(tmp_path) -> None:
+    registry = tmp_path / "registry.toml"
+    registry.write_text(
+        textwrap.dedent(
+            """\
+            schema = 1
+
+            [[pack]]
+            name = "demo"
+            description = "Demo pack."
+            source = "/tmp/local/demo"
+            source_kind = "git"
+
+            [[pack]]
+            name = "other"
+            description = "Other pack."
+            source = "/tmp/local/other"
+            source_kind = "git"
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    registry_release.set_source(registry, "demo", "https://example.com/repo/tree/main/demo")
+
+    text = registry.read_text(encoding="utf-8")
+    assert 'source = "https://example.com/repo/tree/main/demo"' in text
+    assert 'source = "/tmp/local/other"' in text

--- a/validate_registry.py
+++ b/validate_registry.py
@@ -17,7 +17,16 @@ PACK_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]*(/[a-z0-9][a-z0-9-]*)?$")
 RELEASE_VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+(\.[0-9]+)?$")
 COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
 HASH_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
-REQUIRED_WAVE_1 = {"cass", "discord", "gascity", "gastown", "github", "slack-full"}
+REQUIRED_WAVE_1 = {
+    "cass",
+    "discord",
+    "gascity",
+    "gastown",
+    "github",
+    "slack-channel",
+    "slack-full",
+    "slack-mini",
+}
 FORBIDDEN_WAVE_1 = {"bd", "core", "dolt", "maintenance"}
 
 


### PR DESCRIPTION
## Summary

- add Make targets for registry publish, withdraw, and validation workflows with `GC` override support
- add a small line-preserving helper for withdrawal metadata and canonical source normalization
- withdraw consumed legacy releases whose hashes were not content-derived
- publish fresh active releases for current pack content, including `slack-channel` and `slack-mini`

## Notes

The active registry releases were stamped with a local build of the new `gc pack release` command. `make registry-validate` depends on that `gc` surface being available via `GC=/path/to/gc` until it lands in the released CLI.

New active releases point at commit `788b6e8ec224a8951c728ef6da74dab8bc04d474` and have content hashes computed from tracked files at that commit.

## Verification

```sh
make registry-format-validate
GC=/tmp/gc-registry-release make registry-validate
python3 -m pytest tests/test_validate_registry.py tests/test_registry_release.py -q
git diff --check
```

Closes: #53 