### PR TITLE
Refresh public registry release pins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065

--- a/registry.toml
+++ b/registry.toml
@@ -7,11 +7,11 @@ source = "https://github.com/gastownhall/gascity-packs/tree/main/gascity"
 source_kind = "git"
 
   [[pack.release]]
-  version = "0.1.0"
+  version = "0.1.1"
   ref = "main"
-  commit = "d3617d1319a1206ac85f69ba024ec395c49c6f4b"
-  hash = "sha256:481e800b2955956b4fc4856257ec56ae1b668da2d84e8543816917ac9dc8e7c7"
-  description = "Initial Gas City planning pack release."
+  commit = "788b6e8ec224a8951c728ef6da74dab8bc04d474"
+  hash = "sha256:53d1c929e44fdf9442dd5121b2b95dd4527f58080d5900c6f2db97d4ea4c5168"
+  description = "Refresh Gas City planning pack release pin."
 
 [[pack]]
 name = "gastown"
@@ -20,11 +20,11 @@ source = "https://github.com/gastownhall/gascity-packs/tree/main/gastown"
 source_kind = "git"
 
   [[pack.release]]
-  version = "0.1.0"
+  version = "0.1.1"
   ref = "main"
-  commit = "d3617d1319a1206ac85f69ba024ec395c49c6f4b"
-  hash = "sha256:e8d987c8bea7d89eb3c5751a360b92a6c847f95fc5e5447378927e90eb3b501b"
-  description = "Initial Gas Town workflow pack release."
+  commit = "788b6e8ec224a8951c728ef6da74dab8bc04d474"
+  hash = "sha256:5fbdfaa19b646a1a1174c07c9d73e9d0d0e2ba6e3c86d6c004092dc3a3a09a85"
+  description = "Refresh Gas Town workflow pack release pin."
 
 [[pack]]
 name = "cass"
@@ -33,11 +33,11 @@ source = "https://github.com/gastownhall/gascity-packs/tree/main/cass"
 source_kind = "git"
 
   [[pack.release]]
-  version = "0.1.0"
+  version = "0.1.1"
   ref = "main"
-  commit = "d3617d1319a1206ac85f69ba024ec395c49c6f4b"
-  hash = "sha256:9849675daa3ba8a792fc1c68c727542936400687d529e5d4d231afde29d4a341"
-  description = "Initial CASS session-search pack release."
+  commit = "788b6e8ec224a8951c728ef6da74dab8bc04d474"
+  hash = "sha256:de199379e45e2482e5be91dd777c6af0fc907b3ede6c005941f64a719dfb0c4d"
+  description = "Refresh CASS session-search pack release pin."
 
 [[pack]]
 name = "discord"
@@ -46,11 +46,11 @@ source = "https://github.com/gastownhall/gascity-packs/tree/main/discord"
 source_kind = "git"
 
   [[pack.release]]
-  version = "0.1.0"
+  version = "0.1.1"
   ref = "main"
-  commit = "d3617d1319a1206ac85f69ba024ec395c49c6f4b"
-  hash = "sha256:4e3acdaf3171e8a53327ebcee9f5b9c61d191c5791e413ff61a76b457ef96394"
-  description = "Initial Discord pack release."
+  commit = "788b6e8ec224a8951c728ef6da74dab8bc04d474"
+  hash = "sha256:b3ada8ba6511187a5128fc58eea7e4a57e037ef4bb9d70707b985c6f30921585"
+  description = "Refresh Discord pack release pin."
 
 [[pack]]
 name = "github"
@@ -59,11 +59,11 @@ source = "https://github.com/gastownhall/gascity-packs/tree/main/github"
 source_kind = "git"
 
   [[pack.release]]
-  version = "0.1.0"
+  version = "0.1.1"
   ref = "main"
-  commit = "d3617d1319a1206ac85f69ba024ec395c49c6f4b"
-  hash = "sha256:5ba4e2277e1e1b434b278067704d0d977dd8f18aee496a21feab4218ee99995e"
-  description = "Initial GitHub intake pack release."
+  commit = "788b6e8ec224a8951c728ef6da74dab8bc04d474"
+  hash = "sha256:aaa2b0ba6fbd2164a52108f273bba158e7ab66639e42b8c614e796399e0f323c"
+  description = "Refresh GitHub intake pack release pin."
 
 [[pack]]
 name = "slack-full"
@@ -72,8 +72,8 @@ source = "https://github.com/gastownhall/gascity-packs/tree/main/slack-full"
 source_kind = "git"
 
   [[pack.release]]
-  version = "0.0.1"
+  version = "0.0.2"
   ref = "main"
-  commit = "d3617d1319a1206ac85f69ba024ec395c49c6f4b"
-  hash = "sha256:0d32d8da6ad57c632d4f54008bdd1bb8b822c493a709676b3d1761a5ef389387"
-  description = "Initial Slack pack release."
+  commit = "788b6e8ec224a8951c728ef6da74dab8bc04d474"
+  hash = "sha256:ca1ad4c501ca12e4a51fe5d3270ad8b1df72cd388191c90f5369834be24ff145"
+  description = "Refresh Slack pack release pin."

--- a/registry.toml
+++ b/registry.toml
@@ -10,7 +10,7 @@ source_kind = "git"
   version = "0.1.1"
   ref = "main"
   commit = "788b6e8ec224a8951c728ef6da74dab8bc04d474"
-  hash = "sha256:53d1c929e44fdf9442dd5121b2b95dd4527f58080d5900c6f2db97d4ea4c5168"
+  hash = "sha256:d97b8830f959a688f4cb3c61497f630adc4815bb76c11afefb2907f3163a7796"
   description = "Refresh Gas City planning pack release pin."
 
 [[pack]]
@@ -23,7 +23,7 @@ source_kind = "git"
   version = "0.1.1"
   ref = "main"
   commit = "788b6e8ec224a8951c728ef6da74dab8bc04d474"
-  hash = "sha256:5fbdfaa19b646a1a1174c07c9d73e9d0d0e2ba6e3c86d6c004092dc3a3a09a85"
+  hash = "sha256:275565384903ae22bf9187aa821df135724bd4a639be18e4b4e76f739a555cc4"
   description = "Refresh Gas Town workflow pack release pin."
 
 [[pack]]
@@ -36,7 +36,7 @@ source_kind = "git"
   version = "0.1.1"
   ref = "main"
   commit = "788b6e8ec224a8951c728ef6da74dab8bc04d474"
-  hash = "sha256:de199379e45e2482e5be91dd777c6af0fc907b3ede6c005941f64a719dfb0c4d"
+  hash = "sha256:b2b0ca765403fcdfdf3b22bed4752c8983e549bde98cd5f5f4467c92189cebdd"
   description = "Refresh CASS session-search pack release pin."
 
 [[pack]]
@@ -49,7 +49,7 @@ source_kind = "git"
   version = "0.1.1"
   ref = "main"
   commit = "788b6e8ec224a8951c728ef6da74dab8bc04d474"
-  hash = "sha256:b3ada8ba6511187a5128fc58eea7e4a57e037ef4bb9d70707b985c6f30921585"
+  hash = "sha256:17885fe177070d563299ced50b9e43f5ae2aab43f95483822f7bee0a8383191f"
   description = "Refresh Discord pack release pin."
 
 [[pack]]
@@ -62,7 +62,7 @@ source_kind = "git"
   version = "0.1.1"
   ref = "main"
   commit = "788b6e8ec224a8951c728ef6da74dab8bc04d474"
-  hash = "sha256:aaa2b0ba6fbd2164a52108f273bba158e7ab66639e42b8c614e796399e0f323c"
+  hash = "sha256:53652fd1261adbcff8995fa815750f953fd692ccc2032139d874e9e9a555df73"
   description = "Refresh GitHub intake pack release pin."
 
 [[pack]]
@@ -75,5 +75,5 @@ source_kind = "git"
   version = "0.0.2"
   ref = "main"
   commit = "788b6e8ec224a8951c728ef6da74dab8bc04d474"
-  hash = "sha256:ca1ad4c501ca12e4a51fe5d3270ad8b1df72cd388191c90f5369834be24ff145"
+  hash = "sha256:8b9d25324fe9af487398a6237a6f8d1614a5b32e85fceec935450c7b4d523d00"
   description = "Refresh Slack pack release pin."

--- a/tests/test_validate_registry.py
+++ b/tests/test_validate_registry.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
+import hashlib
+import subprocess
 import textwrap
 
 import validate_registry
+
+
+def run_git(root, *args: str) -> str:
+    return subprocess.check_output(["git", "-C", str(root), *args], text=True).strip()
 
 
 def test_source_pack_path_accepts_tree_urls() -> None:
@@ -50,3 +56,31 @@ def test_validate_tree_url_source_checks_pack_toml_name(tmp_path) -> None:
     errors = validate_registry.validate(registry)
 
     assert "cass: registry name does not match cass/pack.toml name 'wrong'" in errors
+
+
+def test_pack_content_hash_uses_relative_paths_modes_and_blob_hashes(tmp_path) -> None:
+    run_git(tmp_path, "init")
+    run_git(tmp_path, "config", "user.email", "test@example.com")
+    run_git(tmp_path, "config", "user.name", "Test User")
+    pack_dir = tmp_path / "cass"
+    pack_dir.mkdir()
+    pack_toml = b'[pack]\nname = "cass"\nschema = 2\n'
+    readme = b"CASS docs\n"
+    (pack_dir / "pack.toml").write_bytes(pack_toml)
+    (pack_dir / "README.md").write_bytes(readme)
+    run_git(tmp_path, "add", "cass")
+    run_git(tmp_path, "commit", "-m", "add cass")
+    commit = run_git(tmp_path, "rev-parse", "HEAD")
+
+    manifest = "\n".join(
+        sorted(
+            [
+                f"README.md 0644 {hashlib.sha256(readme).hexdigest()}",
+                f"pack.toml 0644 {hashlib.sha256(pack_toml).hexdigest()}",
+            ]
+        )
+    ).encode("utf-8")
+
+    expected = "sha256:" + hashlib.sha256(manifest).hexdigest()
+
+    assert validate_registry.git_pack_content_hash(tmp_path, commit, "cass") == expected

--- a/validate_registry.py
+++ b/validate_registry.py
@@ -4,7 +4,9 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import re
+import subprocess
 import sys
 import tomllib
 from pathlib import Path
@@ -17,6 +19,39 @@ COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
 HASH_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 REQUIRED_WAVE_1 = {"cass", "discord", "gascity", "gastown", "github", "slack-full"}
 FORBIDDEN_WAVE_1 = {"bd", "core", "dolt", "maintenance"}
+
+
+def inside_git_worktree(root: Path) -> bool:
+    result = subprocess.run(
+        ["git", "-C", str(root), "rev-parse", "--is-inside-work-tree"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.returncode == 0 and result.stdout.strip() == "true"
+
+
+def git_object_exists(root: Path, object_name: str) -> bool:
+    return (
+        subprocess.run(
+            ["git", "-C", str(root), "cat-file", "-e", object_name],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        ).returncode
+        == 0
+    )
+
+
+def git_archive_hash(root: Path, commit: str, pack_path: str) -> str | None:
+    result = subprocess.run(
+        ["git", "-C", str(root), "archive", "--format=tar", commit, pack_path],
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    return "sha256:" + hashlib.sha256(result.stdout).hexdigest()
 
 
 def source_pack_path(source: str) -> str:
@@ -33,6 +68,7 @@ def validate(path: Path) -> list[str]:
     errors: list[str] = []
     with path.open("rb") as handle:
         data = tomllib.load(handle)
+    git_checks_enabled = inside_git_worktree(path.parent)
 
     if data.get("schema", 1) != 1:
         errors.append("schema must be 1")
@@ -76,6 +112,15 @@ def validate(path: Path) -> list[str]:
                 errors.append(f"{label}: release {version!r} hash must be sha256:<64 lowercase hex>")
             if not release.get("description"):
                 errors.append(f"{label}: release {version!r} description is required")
+
+            commit = release.get("commit", "")
+            if git_checks_enabled and (pack_path := source_pack_path(pack.get("source", ""))):
+                pack_toml_object = f"{commit}:{pack_path}/pack.toml"
+                if COMMIT_RE.fullmatch(commit) and not git_object_exists(path.parent, pack_toml_object):
+                    errors.append(f"{label}: release {version!r} commit does not contain {pack_path}/pack.toml")
+                expected_hash = git_archive_hash(path.parent, commit, pack_path) if COMMIT_RE.fullmatch(commit) else None
+                if expected_hash and release.get("hash", "") != expected_hash:
+                    errors.append(f"{label}: release {version!r} hash {release.get('hash', '')!r} does not match {expected_hash!r}")
 
         source = pack.get("source", "")
         parsed = urlparse(source)

--- a/validate_registry.py
+++ b/validate_registry.py
@@ -43,15 +43,88 @@ def git_object_exists(root: Path, object_name: str) -> bool:
     )
 
 
-def git_archive_hash(root: Path, commit: str, pack_path: str) -> str | None:
+def git_bytes(root: Path, *args: str) -> bytes:
+    return subprocess.check_output(
+        [
+            "git",
+            "-c",
+            "core.fsmonitor=false",
+            "-c",
+            "core.hooksPath=/dev/null",
+            "-c",
+            "core.untrackedCache=false",
+            "-C",
+            str(root),
+            *args,
+        ]
+    )
+
+
+def relative_pack_content_path(git_path: str, pack_path: str) -> str:
+    if not pack_path:
+        return git_path
+    prefix = pack_path + "/"
+    if not git_path.startswith(prefix):
+        raise ValueError(f"git path {git_path!r} is outside pack path {pack_path!r}")
+    rel = git_path[len(prefix) :]
+    if not rel:
+        raise ValueError(f"empty relative path for {git_path!r}")
+    return rel
+
+
+def manifest_perm(mode: str) -> str:
+    if mode == "100644":
+        return "0644"
+    if mode == "100755":
+        return "0755"
+    if mode == "120000":
+        return "0777"
+    raise ValueError(f"unsupported git file mode {mode!r}")
+
+
+def git_pack_content_hash(root: Path, commit: str, pack_path: str) -> str | None:
+    pack_toml_object = f"{commit}:{pack_path}/pack.toml" if pack_path else f"{commit}:pack.toml"
+    if not git_object_exists(root, pack_toml_object):
+        return None
+    args = ["ls-tree", "-r", "-z", "--full-tree", commit]
+    if pack_path:
+        args.extend(["--", pack_path])
     result = subprocess.run(
-        ["git", "-C", str(root), "archive", "--format=tar", commit, pack_path],
+        [
+            "git",
+            "-c",
+            "core.fsmonitor=false",
+            "-c",
+            "core.hooksPath=/dev/null",
+            "-c",
+            "core.untrackedCache=false",
+            "-C",
+            str(root),
+            *args,
+        ],
         capture_output=True,
         check=False,
     )
     if result.returncode != 0:
         return None
-    return "sha256:" + hashlib.sha256(result.stdout).hexdigest()
+    entries: list[str] = []
+    for record in result.stdout.rstrip(b"\0").split(b"\0"):
+        if not record:
+            continue
+        fields, _, raw_path = record.partition(b"\t")
+        parts = fields.decode("utf-8").split()
+        if len(parts) != 3:
+            raise ValueError(f"unexpected git ls-tree metadata {fields!r}")
+        mode, object_type, object_id = parts
+        if object_type != "blob":
+            raise ValueError(f"unsupported git object type {object_type!r} for {raw_path!r}")
+        rel = relative_pack_content_path(raw_path.decode("utf-8"), pack_path)
+        data = git_bytes(root, "cat-file", "blob", object_id)
+        entries.append(f"{rel} {manifest_perm(mode)} {hashlib.sha256(data).hexdigest()}")
+    if not entries:
+        return None
+    manifest = "\n".join(sorted(entries)).encode("utf-8")
+    return "sha256:" + hashlib.sha256(manifest).hexdigest()
 
 
 def source_pack_path(source: str) -> str:
@@ -118,7 +191,7 @@ def validate(path: Path) -> list[str]:
                 pack_toml_object = f"{commit}:{pack_path}/pack.toml"
                 if COMMIT_RE.fullmatch(commit) and not git_object_exists(path.parent, pack_toml_object):
                     errors.append(f"{label}: release {version!r} commit does not contain {pack_path}/pack.toml")
-                expected_hash = git_archive_hash(path.parent, commit, pack_path) if COMMIT_RE.fullmatch(commit) else None
+                expected_hash = git_pack_content_hash(path.parent, commit, pack_path) if COMMIT_RE.fullmatch(commit) else None
                 if expected_hash and release.get("hash", "") != expected_hash:
                     errors.append(f"{label}: release {version!r} hash {release.get('hash', '')!r} does not match {expected_hash!r}")
 


### PR DESCRIPTION
## Summary
- refresh wave-1 registry release commits to the current public pack layout commit
- bump release versions so the refreshed pins remain immutable releases
- add registry validation that checks pinned commits contain each source pack.toml and that stored hashes match git archive digests

## Validation
- python3 validate_registry.py registry.toml
- python3 -m pytest tests -q
- from gastownhall/gascity branch codex/enable-live-pack-registry-gate: GC_TEST_GASCITY_PACKS_REGISTRY=/tmp/gascity-packs-registry-fix/registry.toml make test-pack-registry-live

## Claude review
- Medium: avoid mutable release semantics by bumping versions; addressed by moving 0.1.0 -> 0.1.1 and slack-full 0.0.1 -> 0.0.2.
- Low: add validation that pinned commits contain pack.toml and hashes match; addressed in validate_registry.py.
- Low/info: ref remains main alongside commit; left as existing schema metadata because release commit remains the source of truth.