### PR TITLE
Add model-advisor pack — Bayesian model-tier selection for Gas City

### DIFF
--- a/model-advisor/.gitignore
+++ b/model-advisor/.gitignore
@@ -1,0 +1,16 @@
+.venv/
+__pycache__/
+*.pyc
+.pytest_cache/
+.ruff_cache/
+.coverage
+.coverage.*
+coverage.json
+coverage.xml
+htmlcov/
+
+# Local advisor state — the materialised cell-store cache and the telemetry
+# sink are derived/runtime data, never committed. The cache is rebuildable by
+# replaying invocations.jsonl (DESIGN §5.5), so it is safe to ignore.
+advisor-cells.json
+.beads/

--- a/model-advisor/LICENSE
+++ b/model-advisor/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Jay German
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/model-advisor/README.md
+++ b/model-advisor/README.md
@@ -1,0 +1,272 @@
+<div align="center">
+
+# `model-advisor`
+
+### Cost-minimal model-tier selection for Gas City agents
+
+Agents stop **overpaying for the strong model** on work a cheaper one handles just as
+well — without ever silently shipping worse work. For each `(provider, agent, shape,
+tier)` cell the advisor learns a success posterior from bead lifecycle + telemetry and
+recommends the **cheapest tier whose quality stays within tolerance, with 95%
+credibility.** A clean-room implementation of *[Conservative Constrained Thompson
+Sampling](https://github.com/jsgerman-oss/research/tree/main/blackrim-model-advisor-paper)*.
+
+[![License](https://img.shields.io/badge/license-MIT-blue?style=flat-square)](LICENSE)
+[![Gas City](https://img.shields.io/badge/Gas_City-pack-0f766e?style=flat-square)]()
+[![Python](https://img.shields.io/badge/python-3.11%2B-3776AB?style=flat-square&logo=python&logoColor=white)]()
+[![Engine](https://img.shields.io/badge/engine-stdlib_only-444?style=flat-square)]()
+[![Decision](https://img.shields.io/badge/rule-CC--TS-0f766e?style=flat-square)]()
+[![Bound](https://img.shields.io/badge/gate-Wilson_LCB-6d28d9?style=flat-square)]()
+[![Guarantee](https://img.shields.io/badge/never-downgrades_blind-c2410c?style=flat-square)]()
+[![Scope](https://img.shields.io/badge/v1-learn_·_recommend_·_apply_·_auto--apply-555?style=flat-square)]()
+[![Advanced](https://img.shields.io/badge/advanced-8_opt--in_modes-6d28d9?style=flat-square)]()
+
+[**Quick start**](#quick-start) ·
+[**How it works**](#how-it-works) ·
+[**The surfaces**](#the-surfaces) ·
+[**Install**](#install--uninstall) ·
+[**Config**](#configuration) ·
+[**Caveats**](#caveats) ·
+[**Lineage**](#research-lineage)
+
+</div>
+
+---
+
+## The cost tax
+
+Its sibling pack, [`ast-lens`](../ast-lens), cut the **read tax** — agents reading whole
+files when an outline would do. **model-advisor** cuts the *next* line item: the **cost
+tax** — agents running the strongest, most expensive model on *every* dispatch because
+nobody measured whether a cheaper one would have been fine.
+
+The naive fixes both fail. Pin everything to the frontier tier and you overpay on the
+lookup, the doc rewrite, the single-file edit — work a mid tier nails every time. Pin a
+cheaper tier to save money and you gamble: a wrong answer on an ADR or a release-gating
+review cascades through every bead that depended on it. The right tier is a *per-task*
+decision, and it should be made on **evidence**, not vibes.
+
+That is the whole job of the advisor. It watches outcomes, learns which tiers actually
+preserve quality for which `(agent, shape)`, and recommends the cheapest one it can
+*prove* is good enough — falling back to the known-good baseline whenever it can't.
+
+```text
+$ advisor advise polecat implement
+
+  recommend: sonnet   (claude-sonnet-…)        ← cheaper than the opus baseline
+  why:       q_lo=0.82 ≥ baseline mean 0.80 − 0.05 tol; cheapest admitted tier
+  saving:    −$0.011 / dispatch vs opus        (at the representative token budget)
+
+$ advisor advise refinery review
+
+  recommend: opus     (claude-opus-…)          ← baseline held
+  why:       no cheaper tier clears tolerance — sonnet q_lo=0.58 < 0.75 threshold
+             (thin evidence, n<5). Recommending the known-good tier.
+```
+
+## What it does
+
+Quality in gc is already encoded in the work: a clean bead **close** means the dispatch
+landed; a **reopen / escalate** means it didn't. The advisor harvests that signal (plus
+higher-fidelity reviewer and eval verdicts), maintains a `Beta(a, b)` posterior per cell,
+and runs the **CC-TS decision rule** on every recommendation:
+
+1. **Learn.** A Stop/SubagentStop hook records each invocation; bead lifecycle supplies
+   the outcome. Each `(provider, agent, shape, tier)` cell accrues a calibrated success
+   posterior. Telemetry lands in `.beads/telemetry/invocations.jsonl`; the cell-store
+   cache is rebuildable from it.
+2. **Gate (conservative).** A cheaper tier is *admitted* only if a one-sided lower
+   confidence bound on its success clears `baseline mean − q_tol` at 95% credibility.
+   Thin or zero evidence ⇒ the gate rejects ⇒ the baseline tier wins. `Critical` cells
+   are never downgraded, full stop.
+3. **Choose (asymmetric loss).** Among admitted tiers, pick the one minimising an
+   asymmetric loss that penalises a wrong downgrade far more than it rewards the saved
+   spend — scaled by the bead's downstream blast radius.
+4. **Recommend / apply.** `advise` returns the tier + a structured, auditable rationale;
+   `inspect` shows the evidence; `apply` sets the tier on the agent's config. **The
+   advisor recommends; you apply.**
+
+> **The conservative guarantee.** Every recommended downgrade is credible at 95%; the
+> baseline is always feasible; the cold-start recommends the baseline until a cheaper
+> tier *earns* its way in. The worst case is overpaying for the safe tier — never
+> silently shipping worse work. This is the property that makes it safe to let the
+> advisor inform routing at all.
+
+## What's in the box
+
+| Layer | What it is | File |
+|-------|------------|------|
+| **Engine** | the pure, stdlib-only CC-TS decision rule + cell store | `modeladvisor/` |
+| **CLI** | `advise` / `inspect` / `apply` / `auto-apply` + advanced (`eval-schedule` / `federate` / `drift`) | `bin/advisor` |
+| **Skill** | teaches agents to advise-before-dispatch | `skills/use-model-advisor/SKILL.md` |
+| **Prompt fragment** | the cost-aware discipline, in every agent's context | `template-fragments/model-advisor.template.md` |
+| **Telemetry hook** | records each invocation (Stop / SubagentStop) | `overlay/…/settings.json` + `hooks/capture-invocation.sh` |
+| **Config** | the model roster + shape taxonomy + tolerance classes | `advisor.toml` |
+| **Scheduler** | a gc `order` to run `auto-apply` on a cadence (safe unless armed) | `orders/` + `docs/AUTO-APPLY.md` |
+| **Advanced modes** | 8 opt-in research extensions (conformal · empirical-Bayes · Thompson · continuous · cascade · federation · drift · eval-sched) | `modeladvisor/` · §7.3 |
+
+## Quick start
+
+```bash
+./setup.sh                              # one-time: build the engine venv (stdlib only)
+./bin/advisor advise polecat implement  # cost-minimal tier for this agent + shape
+./bin/advisor inspect polecat implement # the evidence behind it (per-tier posterior)
+./bin/advisor apply polecat             # set the recommended tier on the agent
+```
+
+Every read surface takes `--json` to emit the structured `reasons` object for
+programmatic routing.
+
+## How it works
+
+The decision is the paper's, made gc-native. A **shape** is the *kind of task* (not the
+agent): `lookup`, `implement`, `judge`, `review`, `patrol` — config-extensible. A **tier**
+is one of *your configured* `(provider, model)` run targets, cost-ordered — an arbitrary
+roster, not a fixed haiku/sonnet/opus three. A **cell** is
+`provider::agent::shape::tier_id`, and `recommend(state, cell, tol, baseline)` is a
+**pure, deterministic function**: same posteriors + config in, same tier + rationale out.
+That purity is why the rule is exhaustively testable and why the `reasons` object — the
+candidate tiers, their confidence bounds, the credible quality-drop intervals, the cost
+diffs — is a first-class audit surface, not an afterthought.
+
+It **degrades, never blocks.** No roster ⇒ a clear error (it can't order tiers by cost
+without one). No telemetry ⇒ conservative cold-start. No token counts ⇒ a representative
+budget. Thin evidence ⇒ the baseline tier. The advisor can never stall a dispatch — worst
+case it recommends the safe tier. Full math: [`docs/DESIGN.md`](docs/DESIGN.md).
+
+## The surfaces
+
+Two pure reads and one deliberate write — plus the opt-in
+[Advanced modes](#advanced-modes-opt-in) surfaces (`eval-schedule`, `federate`, `drift`).
+
+| Command | Does | Mutates? |
+|---------|------|----------|
+| `advisor advise <agent> <shape>` | recommend the cost-minimal tier + rationale + cost diff | no |
+| `advisor inspect <agent> <shape>` | per-tier posterior, credible quality-drop CI, the highest-value eval probe | no |
+| `advisor apply <agent>` | set the recommended tier on the agent's `model` config + reload | **yes** |
+| `advisor auto-apply [--town\|--rig N]` | sweep every agent and apply the evidence-strong tier (safest-across-shapes; dry-run by default) | **yes** |
+
+`advise`/`inspect` never dispatch, touch a bead, or change config. `apply` is the per-agent
+application path, on demand; `auto-apply` automates that sweep across all agents —
+conservatively (never auto-downgrading thin-evidence or `Critical` cells) — and can be
+scheduled with a gc `order`. See [`docs/AUTO-APPLY.md`](docs/AUTO-APPLY.md).
+
+## Advanced modes (opt-in)
+
+The eight extensions the paper designs but v1 deliberately left off ([`docs/DESIGN.md`](docs/DESIGN.md) §7.3)
+now ship — each a self-contained, stdlib-only module behind a **default-off** flag, so the
+conservative v1 rule stays the default and turning one on is a one-line config change. v1
+behavior is byte-identical when they're off.
+
+| Mode | Flag / surface | What it adds |
+|------|----------------|--------------|
+| **Conformal calibration** | `lcb_backend = "conformal"` | distribution-free split-conformal gate bound (rolling `(pred, obs)` buffer) in place of the asymptotic Wilson LCB |
+| **Full hierarchical Bayes** | `pooling = "empirical-bayes"` | a genuine empirical-Bayes Beta-Binomial pooler (method-of-moments hyperprior + evidence-weighted shrinkage); optional `[bayes]` PyMC backend |
+| **Thompson sampling** | `mode = "thompson"` · `advise --thompson --seed N` | seeded per-tier Beta sampling instead of the deterministic rule — still gate- and `Critical`-safe, reproducible per seed |
+| **Continuous quality** | `continuous_quality = true` | graded `q ∈ [0,1]` outcomes (reviewer score / test-pass fraction) feeding the Beta; optional Gaussian (NIG) posterior for unbounded scores |
+| **Critical-path cascade** | `advise --cascade-bead ID` | DAG-propagated effective `N_dep` from the bead dependency graph — an ADR that blocks N builders carries a larger blast radius than a leaf |
+| **Multi-tenant federation** | `[federation]` peers · `advisor federate` | share **aggregates only** (never raw telemetry) across repos to warm thin cells, trust-weighted so local evidence always dominates |
+| **Change-point drift** | `changepoint = true` · `advisor drift` | Page-Hinkley detection of upstream model drift/deprecation + recency re-weighting so the gate re-learns the new regime |
+| **Auto-scheduled eval** | `advisor eval-schedule [--apply]` | rank gating cells by CI-width × unlock-value and dispatch eval probes proportional to posterior width (dry-run default; schedulable via a gc `order`) |
+
+All eight are covered by the suite (228 tests) and never weaken the `Critical`
+never-downgrade guarantee. Math + rationale: [`docs/DESIGN.md`](docs/DESIGN.md) §7.3.
+
+## Install & uninstall
+
+Turn it on for **one rig** or the **whole town**, reversibly:
+
+```bash
+./setup.sh                          # build the engine venv (one-time)
+
+./install.sh --rig myrig            # one rig: skill + telemetry hook for its agents
+./install.sh --town                 # city-wide: + opts the discipline fragment into every agent
+
+./uninstall.sh --rig myrig          # clean reversal (strips the merged Stop hook too)
+./uninstall.sh --town --purge       # …and drop the venv
+```
+
+```
+install.sh    (--town | --rig <name>) [--dry-run] [--city <path>] [--no-reload]
+uninstall.sh  (--town | --rig <name>) [--dry-run] [--city <path>] [--purge] [--no-reload]
+```
+
+Both are **idempotent**, **back up every file they edit** (`<file>.model-advisor.bak.<ts>`),
+support **`--dry-run`** (prints the plan, changes nothing), and **fail loudly** on
+unexpected state. A local in-tree pack imports via a *direct* config entry — the gas-town
+convention — not `gc import add`:
+
+- `--town` adds `[imports.model-advisor]` (`source = "packs/model-advisor"`) to the
+  city-root `pack.toml`, and opts `"use-model-advisor"` into `city.toml`
+  `global_fragments`.
+- `--rig <name>` adds `[rigs.imports.model-advisor]` under the matching `[[rigs]]` in
+  `city.toml` (the fragment, a city-wide list, is left alone).
+
+`gc reload` then materializes the Claude `Stop`/`SubagentStop` overlay; gc **deep-merges**
+the telemetry hook into projected settings without clobbering the core hooks. Because that
+merge never *deletes*, `uninstall.sh` explicitly strips our hook entry (matched by the
+unique `model-advisor/hooks/capture-invocation.sh` command substring) from every projected
+`settings.json`, preserving any other hook, then re-projects clean. Town and rig installs
+both round-trip `city.toml` / `pack.toml` byte-identical.
+
+## Configuration
+
+Everything is config-driven; nothing is hard-coded. Edit `advisor.toml`:
+
+| Knob | What it is | Default |
+|------|------------|:-------:|
+| `[[tier]]` roster | your `(provider, model)` run targets, cost-ordered by `rank` | *(required)* |
+| baseline tier `tier*` | the known-good reference all downgrades are judged against | highest `rank` |
+| shape taxonomy | task kinds + per-agent canonical shape sets | the 5 seed shapes |
+| tolerance class | per-`(agent, shape)` quality budget: `Critical`/`Strict`/`Moderate`/`Lenient` | `Moderate` |
+| `q_tol` / `M` | the per-class quality-loss tolerance + asymmetric multiplier (`∞`/`20`/`5`/`1`) | paper defaults |
+| channel weights | `close:1`, `review:3`, `eval:5` | as shown |
+| `force_baseline` | safety hatch: pin a cell to its baseline, short-circuit all learning | off |
+| advanced modes | 8 opt-in flags — `lcb_backend`, `pooling`, `mode`, `continuous_quality`, `changepoint`, `[federation]` ([Advanced modes](#advanced-modes-opt-in)) | all off |
+
+The pack ships an editable starter (`SAMPLE_TOML`); a consumer with a characterised
+landscape can also supply a `priors.json` for immediate convergence. Full reference:
+[`docs/DESIGN.md`](docs/DESIGN.md) §2–§3.
+
+## Caveats
+
+Honest about the scope line.
+
+- **Apply granularity.** v1 ships *per-agent* apply — manual (`apply`) and automated
+  (`auto-apply`, an evidence-gated sweep you can schedule). It's coarse: one tier per agent,
+  changeable by a config edit + reload. **Per-dispatch** application (the advised tier per
+  *task/shape*) is the next step — the gc-core seam is now **implemented and PR'd** to
+  `gastownhall/gascity` (the reconciler binds a work bead's `gc.model` at spawn), activating
+  once it lands. Background: [`docs/INTEGRATION-FEASIBILITY.md`](docs/INTEGRATION-FEASIBILITY.md).
+- **The reward signal is the hard part.** Bead closure is the primary channel and is fully
+  supported today; reviewer/eval verdicts are higher-fidelity secondaries when present. The
+  advisor only ever learns from outcomes it can attribute to a recorded dispatch.
+- **Conservative by design ⇒ it converges deliberately.** A thin cell recommends the
+  baseline until evidence accrues (~a couple dozen observations dominate the cold-start
+  prior). That is the point, not a defect: it never trades quality for speed of savings.
+- **The research extensions ship opt-in.** Every feature the paper designs but v1 left off —
+  conformal calibration, full (empirical-Bayes) hierarchical pooling, Thompson sampling,
+  continuous quality, critical-path cascade, federation, change-point drift, and
+  auto-scheduled eval — is now implemented behind a **default-off** flag
+  ([Advanced modes](#advanced-modes-opt-in)). The conservative deterministic rule remains the
+  default, and enabling any mode never weakens the `Critical` never-downgrade guarantee.
+- **It advises; you decide.** During an incident, pin the baseline (`force_baseline`) and
+  don't explore. The advisor never drives routing on its own in v1.
+
+## Research lineage
+
+model-advisor is a clean-room build of **_[Conservative Constrained Thompson Sampling for
+Cost-Aware Model-Tier
+Selection](https://github.com/jsgerman-oss/research/tree/main/blackrim-model-advisor-paper)_**,
+implemented from the paper's §3 problem formulation and §5 algorithm — **not** ported from
+Blackrim's `internal/dispatch/` Go code, and depending on no Blackrim artefact, dataset, or
+offline landscape. The load-bearing parts are kept faithfully — the constrained decision
+rule, the conservative LCB gate, the asymmetric loss with class multipliers, the
+`M[Critical] = ∞` hard rule, the pure-function `recommend` with its structured `reasons` —
+and adapted where gc differs: an arbitrary config-driven roster (not a fixed three tiers),
+a gc-native shape taxonomy, provider-keyed cells, a conservative cost-ordered cold-start in
+place of an offline landscape, and bead lifecycle as the primary quality channel.
+
+## License
+
+MIT © Jay German. See [LICENSE](LICENSE).

--- a/model-advisor/advisor.toml
+++ b/model-advisor/advisor.toml
@@ -1,0 +1,224 @@
+# advisor.toml — model-advisor configuration (edit me).
+#
+# This file defines the cost-ordered model roster, the task-shape taxonomy, the
+# quality-loss tolerance classes, and per-agent defaults. Everything the CC-TS
+# engine needs to order tiers and gate downgrades lives here. Deleting this file
+# falls back to a built-in Claude haiku/sonnet/opus default with the same shape.
+#
+# Cell key = "<provider>::<agent>::<shape>::<tier_id>".
+
+[advisor]
+default_provider = "claude"
+# Baseline / reference tier (tier*). All downgrade constraints are relative to
+# it. Defaults to the highest-rank (most-capable) tier if omitted.
+baseline_tier = "opus"
+
+# --- v3 advanced backends (opt-in; default off) — see README "Advanced modes" ---
+# lcb_backend = "wilson"        # gate bound: "wilson" (default) | "conformal" (distribution-free split-conformal)
+# pooling     = "closed-form"   # partial pooling: "closed-form" (default) | "empirical-bayes" (full hierarchical)
+
+# --------------------------------------------------------------------------- #
+# Roster — the user's cost-ordered model tiers. rank 1 = cheapest.            #
+# in_cost / out_cost are $/MTok (illustrative; replace with your rate sheet). #
+# --------------------------------------------------------------------------- #
+# Mixed Claude + Codex roster, cost-ordered (rank 1 = cheapest). Codex costs are
+# ESTIMATES — replace all in_cost/out_cost with your real $/MTok rate sheet. Codex
+# tiers run at each model's DEFAULT reasoning effort until gc forwards an effort
+# flag (see the Phase-2 block below); `run_target` is the gc session config the
+# advisor's apply points the agent at (Codex run targets must exist — see README).
+[[tier]]
+id         = "spark"
+provider   = "codex"
+model      = "gpt-5.3-codex-spark"   # ultra-fast coding (128k ctx)
+run_target = "codex-spark"
+rank       = 1
+in_cost    = 0.50
+out_cost   = 2.00
+
+[[tier]]
+id         = "mini"
+provider   = "codex"
+model      = "gpt-5.4-mini"          # small / fast / cost-efficient (272k ctx)
+run_target = "codex-mini"
+rank       = 2
+in_cost    = 0.70
+out_cost   = 3.00
+
+[[tier]]
+id         = "haiku"
+provider   = "claude"
+model      = "claude-haiku-4-5"
+run_target = "claude-haiku"
+rank       = 3
+in_cost    = 0.80
+out_cost   = 4.00
+
+[[tier]]
+id         = "gpt54"
+provider   = "codex"
+model      = "gpt-5.4"               # strong everyday coding (272k ctx)
+run_target = "codex-gpt54"
+rank       = 4
+in_cost    = 2.50
+out_cost   = 10.00
+
+[[tier]]
+id         = "sonnet"
+provider   = "claude"
+model      = "claude-sonnet-4-5"
+run_target = "claude-sonnet"
+rank       = 5
+in_cost    = 3.00
+out_cost   = 15.00
+
+[[tier]]
+id         = "gpt55"
+provider   = "codex"
+model      = "gpt-5.5"               # frontier: complex coding / research (272k ctx)
+run_target = "codex-gpt55"
+rank       = 6
+in_cost    = 8.00
+out_cost   = 30.00
+
+[[tier]]
+id         = "opus"
+provider   = "claude"
+model      = "claude-opus-4-8"
+run_target = "claude-opus"
+rank       = 7
+in_cost    = 15.00
+out_cost   = 75.00
+
+# --------------------------------------------------------------------------- #
+# PHASE 2 — reasoning effort as tiers (your chosen design). gc has NO effort   #
+# config path today, so gpt-5.5-low and gpt-5.5-high would run identically     #
+# until a gc-core seam forwards `reasoning` to the Codex CLI. Once that lands,  #
+# uncomment these (and adjust ranks), and the engine will learn per-effort.    #
+# `codex-auto-review` (Codex's auto-approval review model) is omitted from the #
+# general roster — add it as a review-shape tier only if you dispatch it.      #
+# --------------------------------------------------------------------------- #
+# [[tier]]
+#   id = "gpt55-low"  ; provider = "codex" ; model = "gpt-5.5" ; reasoning = "low"
+#   run_target = "codex-gpt55-low"  ; rank = 6 ; in_cost = 8.00  ; out_cost = 30.00
+# [[tier]]
+#   id = "gpt55-high" ; provider = "codex" ; model = "gpt-5.5" ; reasoning = "high"
+#   run_target = "codex-gpt55-high" ; rank = 8 ; in_cost = 12.00 ; out_cost = 48.00
+
+# --------------------------------------------------------------------------- #
+# Tolerance classes — max allowable quality drop (q_tol) + asymmetric         #
+# multiplier M. Critical is a HARD never-downgrade rule (M = inf).            #
+# --------------------------------------------------------------------------- #
+[[tolerance]]
+name = "Critical"
+q_tol = 0.0
+multiplier = "inf"
+
+[[tolerance]]
+name = "Strict"
+q_tol = 0.02
+multiplier = 20
+
+[[tolerance]]
+name = "Moderate"
+q_tol = 0.05
+multiplier = 5
+
+[[tolerance]]
+name = "Lenient"
+q_tol = 0.10
+multiplier = 1
+
+# --------------------------------------------------------------------------- #
+# Shapes — the gc-native task taxonomy. Each shape has a default tolerance     #
+# class and an optional representative token budget (tok_in/tok_out) used for #
+# cost differentials when realised token counts are unavailable.             #
+# --------------------------------------------------------------------------- #
+[[shape]]
+name = "lookup"
+tol_class = "Lenient"
+tok_in = 800
+tok_out = 200
+
+[[shape]]
+name = "implement"
+tol_class = "Moderate"
+tok_in = 4000
+tok_out = 1500
+
+[[shape]]
+name = "judge"
+tol_class = "Moderate"
+tok_in = 1500
+tok_out = 400
+
+[[shape]]
+name = "review"
+tol_class = "Strict"
+tok_in = 3000
+tok_out = 800
+
+[[shape]]
+name = "patrol"
+tol_class = "Lenient"
+tok_in = 1000
+tok_out = 300
+
+# --------------------------------------------------------------------------- #
+# Agents — canonical shape sets + optional per-cell overrides. Cells only      #
+# exist for an agent's canonical shapes. Use [[agent.cell]] to pin a stricter #
+# tolerance, a lower baseline, or the force_baseline safety hatch.           #
+# --------------------------------------------------------------------------- #
+[[agent]]
+name = "polecat"
+shapes = ["implement", "lookup"]
+
+[[agent]]
+name = "refinery"
+shapes = ["review", "judge"]
+
+  # Refinery release-gating decisions are Critical (never downgrade).
+  [[agent.cell]]
+  shape = "judge"
+  tol_class = "Critical"
+
+[[agent]]
+name = "mayor"
+shapes = ["judge", "implement", "lookup"]
+
+[[agent]]
+name = "witness"
+shapes = ["patrol", "judge"]
+
+[[agent]]
+name = "boot"
+shapes = ["patrol", "judge"]
+
+[[agent]]
+name = "deacon"
+shapes = ["patrol", "judge"]
+
+# --------------------------------------------------------------------------- #
+# Hyperparameters (CC-TS appendix D defaults). All optional.                  #
+# --------------------------------------------------------------------------- #
+[hyperparams]
+alpha       = 0.05   # one-sided confidence (1 - alpha = 0.95)
+z           = 1.645  # z_{0.95}, matched to alpha
+theta_eval  = 0.10   # CI half-width that flags a cell for an eval probe
+pool_lambda = 0.5    # cap on cross-sibling pseudocount pooling
+s_prior     = 4.0    # cold-start pseudocount for cheaper tiers (weak)
+baseline_a  = 8.0    # optimistic baseline prior Beta(8, 2) -> mean 0.80
+baseline_b  = 2.0
+cold_m_lo   = 0.5    # cheapest-tier cold-start prior mean
+w_close     = 1.0    # quality channel weights (close < review < eval)
+w_review    = 3.0
+w_eval      = 5.0
+
+# --- v3 advanced modes (opt-in; default off) — see README "Advanced modes" ---
+# mode               = "lcb"   # selection rule: "lcb" (deterministic, default) | "thompson" (seeded sampling)
+# continuous_quality = false   # accept graded q in [0,1] outcomes (else binary pass/fail)
+# changepoint        = false   # Page-Hinkley drift detection + recency re-weighting (`advisor drift`)
+
+# --- v3 multi-tenant federation (opt-in; default: no peers) — `advisor federate` ---
+# [federation]
+# peers = ["../peer-repo/.beads/telemetry/advisor-federation.json"]  # aggregates-only peer exports to merge
+# trust = 0.3                                                         # weight on borrowed peer evidence (local always dominates)

--- a/model-advisor/bin/advisor
+++ b/model-advisor/bin/advisor
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# model-advisor CLI: recommend / inspect / apply the cost-minimal model tier.
+#
+#   bin/advisor advise  <agent> <shape> [--json]
+#   bin/advisor inspect <agent> <shape> [--json]
+#   bin/advisor apply   <agent> [--shape S] [--city PATH] [--rig NAME] [--dry-run]
+#
+# `advise` and `inspect` are read-only surfaces over the cell store; `apply`
+# sets the agent's default `model` field in gc config (the value gc carries into
+# GC_AGENT_MODEL at spawn) to the recommended tier — per-AGENT, the v1 action.
+#
+# This wrapper resolves the pack's own venv python (so the advisor runs under
+# the interpreter its deps are installed in), falling back to system python3,
+# then hands off to `python -m modeladvisor.cli`. It mirrors ast-lens/bin/op.
+# Always-sane on a missing venv: if no interpreter is found it prints a clear
+# error to stderr and exits 2 (it never silently no-ops, because apply must not
+# pretend to have applied a change).
+set -euo pipefail
+PACK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PY="$PACK_DIR/.venv/bin/python"
+[ -x "$PY" ] || PY="$(command -v python3 || true)"
+[ -n "$PY" ] || { echo "advisor: no python interpreter found (no .venv, no python3)" >&2; exit 2; }
+exec env PYTHONPATH="$PACK_DIR${PYTHONPATH:+:$PYTHONPATH}" "$PY" -m modeladvisor.cli "$@"

--- a/model-advisor/docs/AUTO-APPLY.md
+++ b/model-advisor/docs/AUTO-APPLY.md
@@ -1,0 +1,275 @@
+# model-advisor — AUTO-APPLY
+
+Per-agent **auto-apply** automates the v1 `apply` action (bead `bh-917`, v2a). It
+is a conservative, evidence-gated loop that keeps **each agent's `model` config
+field** at its cost-optimal tier as quality evidence accrues — pack-only, no
+gc-core dependency.
+
+Where `bin/advisor apply <agent>` sets *one* agent's model for *one* shape on
+demand, `bin/advisor auto-apply` sweeps **every configured agent** and writes the
+`model` field only for changes the engine's own gate has already certified.
+
+- Engine / store / config: `docs/DESIGN.md` (the CC-TS decision rule).
+- Implementation: `modeladvisor/autoapply.py` (`auto_apply(...)`), surfaced by
+  `modeladvisor/cli.py` as the `auto-apply` subcommand.
+
+---
+
+## 1. The per-agent tier policy
+
+An agent runs **one** model but may serve **several shapes** (DESIGN §2.2:
+`polecat → {implement, lookup}`, `refinery → {review, judge}`, …). The engine
+decides a tier per *(agent, shape)* cell; auto-apply collapses those into a
+single per-agent model **without under-serving any shape**:
+
+> For each of the agent's canonical shapes, take the engine's per-shape
+> recommended tier. The agent's **conservative tier** is the **safest
+> (most-capable) tier among them** — the `argmax` over the cost order.
+
+Why the *most-capable*, not the cheapest? Because one model has to satisfy every
+shape the agent serves. The engine returns a *cheaper-than-baseline* tier for a
+shape only when that shape's one-sided lower confidence bound has credibly
+cleared tolerance (DESIGN §1.3 Layer 2); a shape with thin/cold evidence still
+recommends the baseline `tier*`. So the `argmax` lands **below baseline only when
+ALL of the agent's shapes have independently earned a cheaper tier**. If even one
+shape is still cold, the safest tier is the baseline and the agent is left
+untouched. This lifts the engine's conservative "never silently downgrade"
+property from the cell to the agent.
+
+**Worked example** (roster `haiku ≺ sonnet ≺ opus`, baseline `opus`):
+
+| Agent      | per-shape recommendations        | conservative tier | outcome |
+|------------|----------------------------------|-------------------|---------|
+| `polecat`  | implement→`sonnet`, lookup→`sonnet` | `sonnet`        | **downgrade applied** (all shapes cleared) |
+| `polecat`  | implement→`sonnet`, lookup→`opus`   | `opus`          | no-op (lookup still cold → safest is baseline) |
+| `mayor`    | judge→`opus`, implement→`opus`, lookup→`opus` | `opus` | no-op (cold; already on implicit default) |
+| `refinery` | review→`sonnet`, judge→`opus` (Critical) | —          | **blocked** (Critical shape present) |
+
+The **binding shape** in the report is the shape whose recommendation set the
+conservative tier (the most-capable one).
+
+---
+
+## 2. The apply gate — when a computed tier is actually written
+
+A per-agent change is written only when **all** hold:
+
+1. **It differs.** The chosen tier's model differs from the agent's current
+   `model` config (idempotent no-op refusal otherwise).
+2. **The agent is not Critical-pinned.** If *any* of its shapes resolves to a
+   `Critical` tolerance class (`q_tol = 0`, `M = ∞`) or carries the
+   `force_baseline` safety hatch, the agent is **blocked** — never touched,
+   regardless of evidence (DESIGN §1.2 / §7.4). This is the design contract
+   operators rely on to let the advisor drive routing at all.
+3. **The change is evidence-admissible:**
+   - A **downgrade** (chosen tier cheaper than baseline `tier*`) is admissible
+     *by construction* — it can only arise when every shape's gate admitted at
+     least this-cheap a tier, so the evidence is already strong. A thin-evidence
+     downgrade is *impossible*: the engine never returns a sub-baseline tier
+     without gate admission. (auto-apply re-confirms the binding shape's gate
+     admission defensively before any sub-baseline write.)
+   - An **upgrade** (chosen tier ≥ the agent's *current* tier) is always
+     admissible — moving to a more-capable model is the safe direction (e.g.
+     evidence retreated, or an operator hand-set a too-cheap model and the
+     advisor pulls it back toward the known-good frontier).
+
+We **never auto-downgrade on thin evidence**; the only sub-baseline writes are
+ones the engine's gate already certified.
+
+**No-evidence churn guard.** When the conservative tier is just the baseline and
+no shape has earned anything cheaper, auto-apply reports a **no-op** rather than
+writing an explicit `model = <baseline>` onto a cold agent — that would be config
+churn with no decision behind it. The baseline is only *written* to correct an
+under-capable hand-set model (current strictly cheaper than baseline).
+
+**Per-agent statuses** (the audit surface):
+
+| status    | meaning |
+|-----------|---------|
+| `applied` | config written; model changed |
+| `dry-run` | a change is planned but `--dry-run` (the default) is in effect |
+| `noop`    | chosen model already in effect, or cold-baseline with nothing to do |
+| `skipped` | a change was computed but the gate withheld it |
+| `blocked` | Critical / `force_baseline` agent — never touched |
+| `error`   | could not resolve config / compute (isolated; the sweep continues) |
+
+**Backups & idempotence.** Each config file is backed up **once per run** (the
+first time any agent living in it is about to be written) to a timestamped
+`.advisor-bak-*` sibling. Re-running with no new evidence is a clean series of
+no-op refusals that write nothing.
+
+---
+
+## 3. The CLI surface
+
+```
+bin/advisor auto-apply [--town | --rig NAME] [--city PATH] [--dry-run] [--apply] [--json]
+```
+
+- **Dry-run by default.** Without `--apply` it computes and prints the full plan
+  but writes nothing and creates no backups. `--dry-run` is accepted explicitly
+  (it is the default). Pass `--apply` to actually write.
+- `--town` (default) sweeps all town/city agents; `--rig NAME` narrows the config
+  search + scope label to one rig.
+- `--city PATH` sets the city root (else `$GC_CITY` / cwd).
+- `--json` emits the full structured per-agent report.
+- Config/telemetry are resolved exactly as the other subcommands:
+  `--config`/`$ADVISOR_TOML` for `advisor.toml`,
+  `--telemetry-dir`/`$ADVISOR_TELEMETRY_DIR` (else `<cwd>/.beads/telemetry`) for
+  the live `invocations.jsonl` (rebuilt into the cell store; DESIGN §5.5).
+
+Exit code is `0` on a healthy run (including a dry run with planned changes) and
+`1` only if a per-agent error occurred — so a scheduled run's failures surface in
+`gc order history` without a dry run looking like a failure.
+
+Example dry-run (the default):
+
+```text
+auto-apply [town]  mode: DRY-RUN (no files written)
+  provider: claude
+  [WOULD   ] polecat
+      tier: sonnet (binding shape: implement)   current: (unset) -> chosen: claude-sonnet-4-5
+      per-shape: implement=sonnet, lookup=sonnet
+      why: set: (unset) -> claude-sonnet-4-5; all shapes cleared tolerance for sonnet (binding: implement).
+  [BLOCKED ] refinery
+      tier: opus (binding shape: review)   current: (unset) -> chosen: claude-opus-4-8
+      per-shape: review=opus, judge=opus
+      why: Critical/force_baseline agent (shapes: judge) — never auto-applied.
+  [noop    ] mayor
+      ...
+  ----------------------------------------------------------------
+  SUMMARY: 6 agents | 0 applied | 1 planned | 1 no-op | 0 skipped | 1 blocked | 3 error
+  NOTE: this was a dry run — re-run with --apply to write the 1 planned change(s).
+```
+
+---
+
+## 4. Scheduling artifact (run it periodically)
+
+gc dispatches scheduled / event-driven work via **orders** (`gc order --help`):
+flat `orders/<name>.toml` files pairing a *trigger* (`cron` / `cooldown` /
+`condition` / `event` / `manual`) with an *action* (a `formula` wisp, or an
+`exec` script). auto-apply is a script, so it ships as an **exec order**.
+
+The pack ships two example artifacts (NOT registered against any live city):
+
+| File | Role |
+|------|------|
+| `orders/model-advisor-auto-apply.toml` | the order: a daily `cron` trigger that runs the wrapper |
+| `orders/scripts/auto-apply.sh`         | the exec wrapper: drives `bin/advisor auto-apply` under the pack venv |
+
+`orders/model-advisor-auto-apply.toml`:
+
+```toml
+[order]
+description = "Keep each agent's model at its evidence-justified cost-optimal tier (model-advisor)"
+trigger  = "cron"
+schedule = "30 0 * * *"           # 00:30 daily — tune to your evidence velocity
+exec     = "$PACK_DIR/orders/scripts/auto-apply.sh"
+timeout  = "120s"
+enabled  = true
+```
+
+`$PACK_DIR` is expanded by the controller to the pack directory. (Exec orders
+cannot declare a `pool` — there is no agent pipeline.) To use a fixed inter-run
+gap instead of a wall-clock time, switch to a cooldown trigger:
+
+```toml
+trigger  = "cooldown"
+interval = "24h"
+```
+
+### Arming (safe by default)
+
+The wrapper runs in **dry-run** unless you export `MODEL_ADVISOR_AUTO_APPLY=1`
+(or `true`/`yes`) in the order's environment. So you can import and observe the
+order for a few cycles (watch `gc order history` / the JSON it logs) before it
+ever writes config. Optional env knobs the wrapper honours:
+
+| env var | effect | default |
+|---------|--------|---------|
+| `MODEL_ADVISOR_AUTO_APPLY` | `1`/`true`/`yes` → actually write (else dry-run) | dry-run |
+| `MODEL_ADVISOR_RIG`        | narrow scope to one rig (`--rig`)               | town-wide |
+| `ADVISOR_TOML`             | path to `advisor.toml`                          | pack default |
+| `ADVISOR_TELEMETRY_DIR`    | telemetry dir                                   | `<city>/.beads/telemetry` |
+
+---
+
+## 5. Wiring the schedule — per town and per rig
+
+> The pack does **not** register this order against the live city. Activate it by
+> placing it in an orders layer that gc discovers, then verify with
+> `gc order list` / `gc order check`, and trigger on demand with `gc order run`.
+
+### Town-wide (all agents)
+
+1. Make the order discoverable. Either import the pack's formula layer in the
+   city (gc scans `orders/` in each formula-layer directory), or copy the order
+   into a city orders layer:
+
+   ```bash
+   mkdir -p "$GC_CITY/.gc/system/packs/model-advisor/orders/scripts"
+   cp packs/model-advisor/orders/model-advisor-auto-apply.toml \
+      "$GC_CITY/.gc/system/packs/model-advisor/orders/"
+   cp packs/model-advisor/orders/scripts/auto-apply.sh \
+      "$GC_CITY/.gc/system/packs/model-advisor/orders/scripts/"
+   ```
+
+2. Verify it is seen and check its trigger:
+
+   ```bash
+   gc order list
+   gc order show model-advisor-auto-apply
+   gc order check          # is it due?
+   ```
+
+3. Dry-run it on demand (safe; env unset → dry-run):
+
+   ```bash
+   gc order run model-advisor-auto-apply
+   gc order history
+   ```
+
+4. Arm it when you trust the plan — set `MODEL_ADVISOR_AUTO_APPLY=1` in the order
+   environment (e.g. in the order layer's environment, or wrap the exec). The
+   scheduled run will then write evidence-strong changes only.
+
+### Per rig
+
+Scope the run to one rig two ways:
+
+- **Per-rig order layer** — drop the order into that rig's pack orders directory;
+  the controller sets `GC_RIG` for rig-scoped orders and the wrapper forwards it
+  as `--rig`. Same-name orders in different rigs are disambiguated with
+  `gc order run <name> --rig <rig>`.
+- **One town order, pinned to a rig** — set `MODEL_ADVISOR_RIG=<rig>` in the
+  order environment; the wrapper passes `--rig <rig>` so the config resolver
+  narrows the model-field search to that rig's pack layout.
+
+Because the advisor keys cells by **base** agent name (rig-pooled, DESIGN §2.4),
+the *decision* for an agent is the same town-wide; `--rig` only narrows **where**
+the `model` field is written, not what tier is chosen.
+
+### Cadence guidance
+
+Match the cron cadence to how fast evidence accrues. A busy town closing many
+beads converges cells in days — daily (`@daily` / `30 0 * * *`) is reasonable. A
+quiet town should run weekly (`30 0 * * 0`) so a handful of closures don't swing
+a decision. The decision is conservative either way: more frequent runs cannot
+*cause* an unjustified downgrade — they can only apply one sooner once the
+evidence is already strong.
+
+---
+
+## 6. Operational notes
+
+- **Reversible.** Every write is backed up once per run; restore from the
+  `.advisor-bak-*` sibling to revert.
+- **Pin to opt out.** Set a shape (or the agent's gating shape) to the `Critical`
+  tolerance class, or `force_baseline = true`, in `advisor.toml` to make an agent
+  permanently `blocked` from auto-apply (DESIGN §7.4).
+- **Pairs with `inspect`.** Before arming, `bin/advisor inspect <agent> <shape>`
+  shows the per-tier posteriors and the quality-drop credible intervals behind
+  each decision.
+- **Degrades safely.** With no telemetry every agent cold-starts to the baseline
+  and auto-apply is an all-no-op sweep that writes nothing.

--- a/model-advisor/docs/DESIGN.md
+++ b/model-advisor/docs/DESIGN.md
@@ -1,0 +1,779 @@
+# model-advisor — DESIGN
+
+A gc (Gas City) pack that recommends the **cost-minimal model tier** for each
+agent/task, subject to a per-task quality-preservation guarantee. Clean-room
+implementation of the Blackrim "Conservative Constrained Thompson Sampling"
+(CC-TS) model-tier advisor, adapted to gc's agent roster and to a
+**config-driven, arbitrary model roster** (not a fixed haiku/sonnet/opus 3-tier).
+
+- Bead: `bh-cc5` of the model-advisor pack effort.
+- Status: design only. The next bead builds the engine from this doc.
+- Source paper: `jsgerman-oss/research/blackrim-model-advisor-paper`
+  (§3 problem formulation, §5 algorithm, §6 evaluation, §7 discussion, appendix).
+  This pack is a clean-room re-derivation from the paper's math; it is **not** a
+  port of Blackrim's `internal/dispatch/` Go code, and it does not depend on any
+  Blackrim artefact, dataset, or offline landscape.
+
+> **Scope guard.** This document specifies behaviour and data, not code. It is
+> precise enough that the engine bead can implement the decision rule, the cell
+> store, the prior scheme, the quality ingestion, the telemetry schema, and the
+> two CLI surfaces without re-reading the paper.
+
+---
+
+## 0. One-paragraph summary
+
+For each cell — a `(provider, agent, shape, tier)` quadruple where `tier` is one
+of the user's configured `(provider, model)` run targets — the advisor maintains
+a Beta-Bernoulli posterior over the probability that a dispatch to that tier
+"preserves quality" (succeeds). Given a request `advise <agent> <shape>`, the
+advisor takes the user's reference tier `tier*` (the most-capable / known-good
+frontier tier) as the baseline, then **admits a cheaper tier only if a one-sided
+lower confidence bound on its quality clears `mu*(agent,shape) - q_tol`** (the
+conservative gate). Among admitted tiers it picks the cheapest under an
+asymmetric loss that penalises a wrong downgrade far more than it rewards the
+saved spend. It returns the recommended tier, a structured rationale, and the
+cost differential. Quality is observed primarily from bead lifecycle
+(close = success `q=1`, reopen/escalate = failure `q=0`) and secondarily from
+higher-fidelity reviewer/eval verdicts, fed back into the posteriors. Everything
+is config-driven, audit-first, and degrades to "recommend the baseline tier"
+when evidence is thin.
+
+---
+
+## 1. The constrained decision (CC-TS, from §3 + §5)
+
+### 1.1 The object being decided
+
+A **dispatch** routes one bead to one tier. We model task success as a Bernoulli
+draw whose probability depends on the cell:
+
+```
+q | (agent, shape, tier) ~ Bernoulli(theta[agent,shape,tier]),   q in {0,1}
+```
+
+`theta[agent,shape,tier]` ∈ [0,1] is the unknown per-cell success probability.
+Cost is a **known deterministic** function of the tier and the realised
+input/output token counts (from the user's configured rate sheet); it is never
+estimated, only looked up. The advisor's entire job is to estimate `theta` per
+cell with calibrated uncertainty and choose tiers accordingly.
+
+**Tier ordering assumption (§3, Assumption 1).** For a fixed `(agent, shape)`,
+success probability is weakly increasing in tier strength:
+
+```
+theta[.,.,t_1] <= theta[.,.,t_2] <= ... <= theta[.,.,t_K]
+```
+
+where `t_1 ≺ ... ≺ t_K` orders tiers cheapest→most-capable. This justifies
+extrapolation: if a cheaper tier credibly clears tolerance, every more-capable
+tier does too, so the baseline `tier*` is always feasible. The ordering is over
+**cost**, which is the user-supplied total order on the roster (see §2.3); it is
+an assumption about quality, validated empirically as evidence accrues, not an
+input.
+
+### 1.2 The constraint
+
+A per-task **quality-loss tolerance** `q_tol ∈ [0,1]` is the maximum allowable
+absolute degradation versus the baseline tier `tier*`. The *true* constraint at
+a cell is:
+
+```
+theta[agent,shape,tier*] - theta[agent,shape,tier]  <=  q_tol
+```
+
+i.e. the candidate tier may not lose more than `q_tol` absolute quality vs the
+baseline. Since `theta` is unknown, the advisor enforces the **posterior-credible
+analogue** at confidence `1 - alpha` (we use `alpha = 0.05`):
+
+```
+Pr_{theta ~ posterior}[ theta[.,.,tier*] - theta[.,.,tier] <= q_tol ]  >=  1 - alpha
+```
+
+The **decision** is the cheapest tier in the credibly-feasible set:
+
+```
+tier_dagger = argmin_{tier in FeasibleSet(q_tol, alpha)} cost(tier)
+```
+
+This is the whole contract in one line: *cheapest tier whose quality stays within
+tolerance, with high credibility.* `tier*` is always in the feasible set
+(downgrades are constrained; the baseline and upgrades are unconstrained).
+
+#### Tolerance classes
+
+Paper §3 partitions `q_tol` into four operational classes; we keep the same four
+and make them config-assignable per `(agent, shape)` (default = Moderate):
+
+| Class    | q_tol    | Asymmetric multiplier `M` | gc workloads (default mapping)                          |
+|----------|----------|---------------------------|---------------------------------------------------------|
+| Critical | 0        | ∞ (hard: never downgrade) | ADRs, threat models, IR / convoy orchestration, `judge` shape on release-gating work |
+| Strict   | < 0.02   | 20                        | production code review, prompt review, refinery merge decisions |
+| Moderate | < 0.05   | 5                         | multi-file implement, integration tests, dispatch/routing judgment |
+| Lenient  | < 0.10   | 1                         | lookups, runbook/doc drafts, single-file edits, doc rewrites |
+
+`M[Critical] = ∞` is the **design contract**, not a tunable: a Critical cell
+never enters the exploration/downgrade set regardless of evidence. This is the
+behaviour operators rely on to allow the advisor to drive routing at all.
+
+### 1.3 CC-TS — the four layers
+
+CC-TS is a four-layer policy that realises the credible decision above while
+preserving the conservative ("never silently downgrade") property.
+
+#### Layer 1 — Beta-Bernoulli posteriors (§5.1)
+
+Per cell `(agent, shape, tier)`, maintain `Beta(a, b)` on `theta`. Bernoulli is
+conjugate, so updates are closed-form. On observing `q ∈ {0,1}` (possibly with a
+weight `w ≥ 1` for high-fidelity signals; see §4):
+
+```
+a <- a + w*q
+b <- b + w*(1 - q)
+```
+
+Posterior mean `mu = a/(a+b)`; variance `sigma^2 = a*b / ((a+b)^2 * (a+b+1))`.
+
+**Hierarchical partial pooling (closed-form approximation, §5.1).** Many cells
+stay sparse for weeks. Borrow strength across siblings (same agent, other shapes;
+and across agents in the same tolerance class) by pseudocount-pooling, capped so
+pooling never dominates own-cell evidence:
+
+```
+a~ = a + lambda * Σ_{sib} w_sib * a_sib            (b~ analogously)
+   weights w_sib ∝ 1 / sibling-posterior-standard-error
+   global cap   lambda <= 0.5
+```
+
+Use the pooled `(a~, b~)` everywhere the gate/decision/CI reads the posterior.
+Full hierarchical Beta inference (Stan/PyMC) is explicitly out of scope — the
+closed-form approximation is empirically competitive in the paper's offline
+simulations and keeps `recommend` a pure function (see §8).
+
+#### Layer 2 — conservative posterior-rejection gate (§5.2)
+
+The gate decides whether each candidate tier `tier ≺ tier*` is admitted. Compute
+a one-sided **lower confidence bound** `q_lo(agent,shape,tier)` on the candidate's
+success probability and admit iff it clears baseline-mean-minus-tolerance:
+
+```
+ADMIT tier  ⇔  q_lo(agent, shape, tier)  >=  mu*(agent, shape) - q_tol
+```
+
+where `mu*` is the posterior-mean quality at the baseline tier `tier*`.
+
+**LCB computation — two interchangeable backends (paper §5.2):**
+
+- **Production default: Wilson-style normal LCB on the Beta posterior.**
+  `q_lo = mu - z_{1-alpha} * sqrt(sigma^2)`, with `mu, sigma^2` the pooled Beta
+  moments and `z_{0.95} ≈ 1.645`. Cap `q_lo` at 0 for sparse cells (the gate then
+  rejects by default — exactly the conservative behaviour we want at low counts).
+  *Recommended refinement (paper footnote): use the exact Beta inverse-CDF lower
+  bound* `q_lo = BetaInvCDF(alpha; a~, b~)` *when available; the Wald/Wilson
+  approximation is biased low at small counts and the paper re-ran its
+  convergence numbers with the exact ppf.* The engine SHOULD prefer exact
+  Beta-ppf and fall back to the Wilson form only if no inverse-CDF is available.
+
+- **Conformal wrapper (deferred to a flag, paper §5.2 + future-work).** The
+  paper's formal guarantee is stated for a distribution-free conformal LCB built
+  from a rolling, held-out calibration buffer of `(predicted, observed)` quality
+  pairs per cell. With marginal coverage `≥ 1 - alpha`, the gate's admission
+  implies `Pr[theta_tier >= mu* - q_tol] >= 1 - alpha` (the conservative
+  guarantee, §5 Thm + appendix proof). gc cells will not have an exchangeable
+  calibration buffer on day 1, so v1 ships the Wilson/Beta-ppf LCB (which
+  coincides with the conformal bound asymptotically as the buffer grows) and
+  leaves a `ConformalLCB` backend behind a config flag for when buffers exist.
+  See §7 (deferred).
+
+**Critical-class short-circuit.** If the cell's class is Critical (`q_tol = 0`,
+`M = ∞`), admit *no* downgrade regardless of evidence. The baseline is the only
+feasible tier.
+
+#### Layer 3 — asymmetric-loss decision (§5.3)
+
+Among admitted candidates, pick the action minimising expected asymmetric loss.
+A wrong downgrade is far costlier than the saved API spend is valuable. Action
+`a ∈ {down, stay, up}`, outcome `ω ∈ {preserved, lost}`:
+
+| Action × outcome              | Loss                                                   |
+|-------------------------------|--------------------------------------------------------|
+| L(down, preserved)            | `-Δcost(tier*, tier_lower)`   (savings; negative loss) |
+| L(down, lost)                 | `Δcost_down * N_dep * M[q_tol_class]`  (cascade)        |
+| L(stay, ·)                    | `0` (baseline)                                          |
+| L(up, ·)                      | `+Δcost(tier_higher, tier*)`  (overpay)                |
+
+- `Δcost(x, y) = cost(x) - cost(y) > 0` for `y ≺ x`.
+- `N_dep` = number of downstream dependents of the bead (blast radius). In gc
+  this is read from the bead graph: count of beads that `blocks`/depend on the
+  dispatched bead (via `gc graph` / `bd`'s dependency edges). Default `N_dep = 1`
+  when unknown.
+- `M` = tolerance-class multiplier from §1.2 (∞ / 20 / 5 / 1).
+
+Expected loss uses the posterior: for a candidate downgrade,
+`E[L] = -mu_tier·Δcost + (mu* - mu_tier)·M·Δcost·N_dep` (the §3 loss, eq. 6),
+with `mu_tier` the pooled posterior mean. Pick `argmin E[L]`; ties broken toward
+the cheaper tier. Because Layer 3 only *selects from* the admitted set and never
+adds tiers, it preserves the Layer-2 credibility guarantee.
+
+#### Layer 4 — uncertainty-triggered eval (§5.4) — **deferred in v1**
+
+When the chosen tier's posterior CI half-width exceeds `theta_eval` (paper uses
+`0.10`), the paper fires a deterministic eval-suite run on that cell and weights
+its verdict higher in the likelihood. v1 records the **trigger** (surfaces
+"this cell wants an eval" in `inspect`, see §6.2) but does **not** auto-dispatch
+an eval; auto-scheduling is deferred (§7). The hook is designed in so the engine
+bead can wire it later without schema changes.
+
+### 1.4 The `recommend` procedure (faithful to Alg. 1, §5)
+
+Pure function `recommend(state, cell_key, q_tol_class, baseline_tier) -> (tier_dagger, reasons)`:
+
+```
+cands := { tier* }                          # baseline always admitted
+for tier in roster \ { tier* }:
+    q_lo := LCB(posterior~[agent,shape,tier], alpha)     # Beta-ppf or Wilson
+    if tier ≺ tier* and class != Critical and q_lo >= mu*(agent,shape) - q_tol:
+        cands += tier                        # Layer 2 gate
+    elif tier ≻ tier*:
+        cands += tier                        # upgrades unconstrained
+
+tier_dagger := argmin_{tier in cands} E_{theta~posterior~[tier]}[ L(tier, theta; tier*, mu*) ]   # Layer 3
+
+if CIWidth(posterior~[tier_dagger], alpha) > theta_eval:
+    flag_eval(agent, shape, tier_dagger)     # Layer 4 (record only, v1)
+
+return tier_dagger, reasons = { cands, per-cand q_lo, per-cand E[L], cost diffs, eval_flag }
+```
+
+**Properties the engine MUST preserve** (paper §5 implementation notes — these
+are load-bearing for operator trust):
+
+1. **Pure-function `recommend`** — no I/O, no global mutable state. State (the
+   posteriors + config) is passed in; the function is exhaustively testable.
+2. **Deterministic for tests** — any sampling step is seedable from a `recommend`
+   argument, so unit tests can assert decision shapes across pseudo-random draws.
+   (The production rule above is LCB-based and already deterministic; keep the
+   seed hook for a future genuine-Thompson-Sampling mode.)
+3. **Structured `reasons`** — every recommendation returns candidate tiers, per-
+   candidate LCBs, expected losses, cost differentials, and the eval flag. This
+   IS the audit surface and the operator interface; the paper credits it with
+   more operator-trust uplift than any algorithmic improvement. Non-optional.
+
+---
+
+## 2. The cell grid, adapted to gc
+
+Blackrim used a fixed `17 agents × 3–5 shapes × 3 tiers ≈ 170` grid. gc differs
+on two axes: a different agent roster, and — critically — **tiers are the user's
+configured roster, an arbitrary set, not a fixed 3**.
+
+### 2.1 Agents (the gc roster)
+
+The advisor is agnostic to the roster; it discovers agents from city config
+(`gc agent list` / resolved `[[agent]]` blocks). The canonical gastown roster the
+design targets:
+
+| Agent      | Scope | Role (drives default shapes)                                  |
+|------------|-------|---------------------------------------------------------------|
+| `mayor`    | city  | coordinator: dispatch/triage, occasional fast fixes           |
+| `deacon`   | city  | patrol/coordination: gate-closing, convoy/dep resolution      |
+| `boot`     | city  | watchdog: is-the-deacon-stuck judgment                        |
+| `witness`  | rig   | work-health oversight: triage, escalation (no code)           |
+| `refinery` | rig   | merge-queue processor: merge/reject decisions (no code)       |
+| `polecat`  | rig   | implementer: writes code in a worktree                        |
+| `dog` / `crew` | pool | utility/named workers: mixed                              |
+
+New consumer-repo agents (no prior) are first-class — they simply start at the
+cold-start prior (§3) and accrue evidence. The roster is **not** hard-coded.
+
+### 2.2 Shapes (the gc task taxonomy)
+
+A **shape** is the *kind of cognitive task*, independent of which agent runs it.
+Blackrim's per-agent shapes don't transfer, so we define a small, stable,
+gc-native taxonomy. Five canonical shapes (extensible via config):
+
+| Shape       | Meaning                                          | Typical tolerance | Example gc work |
+|-------------|--------------------------------------------------|-------------------|-----------------|
+| `lookup`    | retrieve/answer/summarise; low blast radius      | Lenient           | research lookup, "where is X", status read |
+| `implement` | write/modify code or config; multi-file edits    | Moderate          | polecat feature/bugfix beads |
+| `judge`     | routing/triage/decision with downstream effect   | Moderate→Critical | mayor dispatch choice, deacon gate close, release gating |
+| `review`    | read-only critique with a verdict                | Strict            | code review, prompt review, refinery merge review |
+| `patrol`    | health/oversight monitoring, recurring           | Lenient→Moderate  | witness/boot/deacon heartbeat checks |
+
+Notes:
+- The taxonomy is **config-driven**: a `shapes.toml` lists shape names + default
+  tolerance class. Five is the seed; consumers can add (e.g. `threat-model`,
+  `adr`) and pin those to Critical.
+- An agent has a **canonical shape set** (not all 5). Defaults:
+  `polecat → {implement, lookup}`, `refinery → {review, judge}`,
+  `witness/boot → {patrol, judge}`, `deacon → {patrol, judge}`,
+  `mayor → {judge, implement, lookup}`. Cells only exist for an agent's canonical
+  shapes (mirrors "not every agent has the same canonical shapes" from §3).
+- **Shape inference at dispatch.** A dispatch is mapped to a shape by, in order:
+  (1) explicit `--shape` flag / `gc.shape` bead metadata; (2) the formula in use
+  (e.g. `mol-review-quorum → review`, `mol-polecat-work → implement`); (3) a
+  default shape declared on the agent. The engine MUST record the resolved shape
+  on the telemetry record (§5) so offline re-aggregation is possible.
+
+### 2.3 Tiers = the user's configured model roster (the key divergence)
+
+In gc a **tier is a configured `(provider, model)` run target**, and the roster
+is whatever the user configures — **arbitrary cardinality**, possibly per-rig.
+This is grounded in how gc already routes model-specific work: the
+`mol-review-quorum` formula carries `gc.run_target`, `gc.provider`, `gc.model` on
+each step, proving the platform already treats "which model" as a first-class,
+config-supplied dispatch parameter. The advisor reuses that mechanism.
+
+The advisor reads a **roster config** (`roster.toml` in the pack / city config):
+
+```
+# illustrative — the engine reads this, does not hard-code it
+[[tier]]
+id        = "haiku"                 # stable cell-key token
+provider  = "claude"
+model     = "claude-haiku-..."      # opaque to the advisor
+run_target= "..."                   # gc agent/session-config target to dispatch to
+rank      = 1                       # cost order; 1 = cheapest
+in_cost   = 0.25                    # $/MTok input   (rate sheet)
+out_cost  = 0.50                    # $/MTok output
+[[tier]]
+id = "sonnet" ; rank = 2 ; in_cost = 3.00  ; out_cost = 6.00  ; ...
+[[tier]]
+id = "opus"   ; rank = 3 ; in_cost = 15.00 ; out_cost = 30.00 ; ...
+```
+
+Requirements the engine enforces over the roster:
+- **Total cost order.** `rank` induces the `≺` order used by Layer 2/3. If two
+  tiers tie on `rank`, fall back to `in_cost` then `out_cost`. The order is
+  user-asserted, not inferred from quality.
+- **Baseline / reference tier `tier*`.** Configurable; default = the
+  highest-`rank` (most-capable) tier — the "known-good frontier." All downgrade
+  constraints are relative to it. An operator may pin a lower `tier*` per cell
+  (the static safety hatch, §7).
+- **`cost(tier, tok_in, tok_out)` = `tok_in/1e6 * in_cost + tok_out/1e6 * out_cost`.**
+  Deterministic, exact given token counts. `Δcost` is differences of this.
+- **Arbitrary K.** Nothing assumes K = 3. The roster may be 2 tiers or 7; the
+  feasible-set scan is `O(K)` per recommend.
+- **Per-rig rosters.** A rig may override the roster (different providers/models
+  per project); cells are keyed by provider (below) so rosters never collide.
+
+### 2.4 Cell keying
+
+A **cell** is the unit of posterior bookkeeping. Key:
+
+```
+cell_key = "<provider>::<agent>::<shape>::<tier_id>"
+        e.g.  "claude::polecat::implement::sonnet"
+```
+
+- `provider` is included so multi-provider / per-rig rosters never alias.
+- `agent` is the **base agent name** (e.g. `polecat`), not the instance
+  (`whiskeyshop/gastown.polecat#3`) — siblings of the same role pool evidence
+  into one cell. Rig qualification is intentionally dropped from the key so a
+  role's behaviour generalises across rigs; per-rig splitting is a future option
+  (add `<rig>` to the key) if a role proves rig-dependent.
+- `shape` is the resolved canonical shape (§2.2).
+- `tier_id` is the roster token (§2.3), not the raw model string (models change;
+  the token is stable, and the model string is recorded in telemetry for audit).
+
+The **posterior store** is `Map[cell_key] -> { a, b, n, last_update }` persisted
+as `.beads/telemetry/advisor-cells.json` (rebuildable by replaying
+`invocations.jsonl`, so it is a cache, not a source of truth). A `(agent, shape)`
+pair owns one cell per roster tier; `mu*` reads the `tier*` cell of the same
+`(provider, agent, shape)`.
+
+---
+
+## 3. Priors (cold-start, since gc has no offline landscape)
+
+Blackrim seeds every cell from an offline agent×shape×tier landscape with a
+confidence percentage per cell. gc has **no such landscape on day 1**, so the
+design specifies a conservative cold-start that still benefits from a landscape
+later.
+
+### 3.1 Confidence → Beta pseudocounts (paper §5.1, kept verbatim for when a landscape exists)
+
+If a cell *does* have an offline/operator-supplied confidence `c ∈ [0,100]`:
+
+```
+a_prior = max(1, round(c / 5))
+b_prior = max(1, round((100 - c) / 5))
+```
+
+So 95% → `Beta(19,1)` (very informative), 65% → `Beta(13,7)` (mean 0.65, sd≈0.10),
+50% → `Beta(10,10)` ("roughly even, known"), no evidence → `Beta(1,1)` (uniform).
+Properties (appendix C): monotone in `c`, bounded influence (≤20/side, so ~20 real
+observations dominate any prior), sane uniform. This path is used only when a
+consumer ships a `priors.json`; gc does not require one.
+
+### 3.2 Default cold-start scheme (gc's day-1 reality) — **conservative, cost-ordered**
+
+With no landscape, the prior must encode two beliefs at once: (a) the tier
+ordering (more-capable ⇒ ≥ quality), and (b) "we don't actually know yet, so
+don't downgrade." The scheme:
+
+1. **Baseline tier `tier*`: optimistic.** Seed `Beta(a0, b0)` with a high mean,
+   e.g. `Beta(8, 2)` (mean 0.8). The baseline is the known-good frontier; we trust
+   it. This makes `mu*` start high so the gate threshold `mu* - q_tol` is
+   meaningfully strict for cheaper tiers.
+2. **Cheaper tiers: pessimistic, monotone in cost.** Seed each non-baseline tier
+   with a *lower* mean than the next-more-capable tier, but a **wide** posterior
+   so the LCB is low and the gate rejects until evidence accrues. Concretely, set
+   the prior mean by linear interpolation on `rank` between a floor `m_lo` (for
+   the cheapest tier) and the baseline mean, with small total pseudocount
+   `s_prior` (weak), e.g.:
+   ```
+   mean(tier) = m_lo + (m_hi - m_lo) * (rank(tier) - 1) / (rank(tier*) - 1)
+   a = mean * s_prior ;  b = (1 - mean) * s_prior      with s_prior ≈ 4
+   ```
+   Suggested defaults: `m_lo = 0.5`, `m_hi = mean(tier*) = 0.8`, `s_prior = 4`.
+   The small `s_prior` keeps the prior weak (means a handful of real observations
+   move it) while the depressed mean + wide spread makes the **LCB start below any
+   plausible `mu* - q_tol`**, so the cold-start policy is exactly *"recommend the
+   baseline `tier*` until a cheaper tier earns its way in."*
+3. **Net day-1 behaviour:** the advisor returns `tier*` for every cell, with a
+   rationale of the form *"no cheaper tier has cleared tolerance (insufficient
+   evidence)."* No silent downgrades before evidence — the conservative contract
+   holds vacuously at cold start. This matches the paper's finding that flat/weak
+   priors converge in ~19 eval-triggered dispatches per thin cell, vs ~0 when a
+   strong landscape prior is present.
+
+This cold-start is the **safe default**; a consumer who supplies a `priors.json`
+(via §3.1) gets immediate convergence on well-characterised cells.
+
+### 3.3 Prior → posterior update
+
+Posteriors are the priors updated by observed quality (§1.3 Layer 1):
+`a += w*q`, `b += w*(1-q)` per observation, with the partial-pooling overlay
+(§1.3) applied at read time. Bounded-influence priors guarantee ~`s_prior + a few
+dozen` observations fully dominate the cold-start belief. The store is
+append-friendly: each `invocations.jsonl` quality event is one update.
+
+---
+
+## 4. Quality channels in gc
+
+The paper is emphatic (§7, "lessons from deployment"): *the bandit is the easy
+part; the reward signal is the hard part.* gc's advantage is that bead lifecycle
+already encodes task outcomes. Three channels, in increasing fidelity:
+
+### 4.1 Channel A — bead closure (PRIMARY, always available)
+
+The default, zero-extra-instrumentation signal:
+
+- **`q = 1` (preserved):** the dispatched bead is **closed** by the refinery
+  (`bd close` / status → `closed`) without a prior reopen, AND not reopened within
+  a debounce window (default 24h). A clean close = the work landed.
+- **`q = 0` (lost):** the bead is **reopened** (`bd reopen`), **escalated** (a
+  `set-state`/label transition such as `escalated`, or witness escalation to
+  mayor), or the dispatch's closing record carries `gc.outcome = fail` /
+  `gc.failure_class = hard`. `transient` failures (rate-limit/infra) are **not**
+  `q = 0` — they are dropped (no observation), because they don't reflect tier
+  quality.
+
+Weight `w = 1` (baseline-fidelity). The mapping (close→1, reopen/escalate→0) is
+the gc-native instantiation of the paper's "downstream task closure" channel.
+
+### 4.2 Channel B — reviewer / verdict signal (SECONDARY, higher fidelity)
+
+When a review formula runs (e.g. `mol-review-quorum`, refinery review), it emits
+a structured `verdict ∈ {pass, pass_with_findings, fail, blocked}` plus
+`gc.outcome`. Map to Bernoulli:
+
+```
+pass               -> q = 1
+pass_with_findings -> q = 1   (conservative-friendly: a clean-enough pass)
+fail               -> q = 0
+blocked            -> dropped (infra/precondition, not a quality signal)
+```
+
+This is a *direct* observation of the cell that produced the artefact (it carries
+`gc.model` / `gc.provider`, so it keys exactly). Weight `w_review > 1` (default
+`3`): a reviewer judgment is worth several closures.
+
+### 4.3 Channel C — eval-suite verdict (HIGHEST fidelity)
+
+A deterministic eval run against held-out fixtures emits a judge verdict
+`{pass, fail, partial}`. Conservative mapping (paper §3): `partial -> 0`,
+`pass -> 1`, `fail -> 0`. Ground truth is known, so weight highest
+(`w_eval`, default `5`). In v1 eval runs are **operator-initiated** (Layer 4
+auto-scheduling deferred, §7), but their verdicts are ingested with full weight
+whenever they exist, and they (later) populate the conformal calibration buffer.
+
+### 4.4 Weighting & precedence
+
+- A single dispatch yields **at most one** observation per cell, choosing the
+  **highest-fidelity channel available** for that dispatch (C > B > A). Do not
+  double-count: if a bead got a reviewer verdict, the closure is not separately
+  counted for the same dispatch.
+- Weights are config (`w_close=1`, `w_review=3`, `w_eval=5` defaults). They enter
+  Layer 1 as the `w` multiplier on `(a, b)`.
+- **Debounce / late signals.** Closure observations are emitted only after the
+  reopen-debounce window to avoid counting a close that is immediately reverted.
+  A reopen after the window arriving *late* emits a corrective `q = 0` for a new
+  observation (we do not retro-edit; the posterior self-corrects with the next
+  update).
+- **Attribution.** An observation attaches to the cell of the **dispatch that
+  produced the work**, identified by the dispatch's recorded
+  `(provider, agent, shape, tier_id)` (the `bead_id` ↔ dispatch join, §5). Quality
+  observed on a bead whose dispatch wasn't advisor-recorded is dropped.
+
+---
+
+## 5. Telemetry schema
+
+The engine reads/writes **`.beads/telemetry/invocations.jsonl`** (one JSON object
+per line; this is the paper's named sink and gc already keeps sibling JSONL there,
+e.g. `routes.jsonl`, `interactions.jsonl`). Two logical record kinds share the
+file, distinguished by `kind`:
+
+### 5.1 `kind = "dispatch"` — written at dispatch time
+
+The fields the engine needs to (a) reconstruct the cell and (b) later join a
+quality outcome:
+
+| Field         | Type   | Meaning                                                        |
+|---------------|--------|----------------------------------------------------------------|
+| `schema_version` | str | record schema version (e.g. `"advisor.v1"`)                  |
+| `kind`        | str    | `"dispatch"`                                                   |
+| `ts`          | str    | RFC3339 timestamp (dispatch time)                              |
+| `bead_id`     | str    | the routed bead (join key to the quality record)              |
+| `provider`    | str    | resolved provider (e.g. `claude`)                             |
+| `agent`       | str    | **base** agent name (e.g. `polecat`)                          |
+| `agent_instance` | str | full instance for audit (e.g. `whiskeyshop/gastown.polecat`) |
+| `rig`         | str    | rig name (audit / future per-rig keying)                      |
+| `shape`       | str    | resolved canonical shape (§2.2)                              |
+| `tier_id`     | str    | roster tier token actually dispatched (§2.3)                 |
+| `model`       | str    | concrete model string at dispatch (audit; models drift)      |
+| `q_tol_class` | str    | tolerance class applied (Critical/Strict/Moderate/Lenient)   |
+| `baseline_tier` | str  | `tier*` token in effect for this cell                        |
+| `advised_tier`| str    | what the advisor recommended (may differ if operator overrode)|
+| `forced_baseline` | bool | whether the static safety hatch forced `tier*` (§7)        |
+| `cell_key`    | str    | denormalised `provider::agent::shape::tier_id` (convenience) |
+
+> `cell_key = provider :: agent :: shape :: tier_id`. The dispatch→cell mapping is
+> exactly this concatenation; nothing else is needed to locate the posterior.
+
+### 5.2 `kind = "quality"` — written when an outcome is observed
+
+| Field         | Type   | Meaning                                                        |
+|---------------|--------|----------------------------------------------------------------|
+| `schema_version` | str | `"advisor.v1"`                                                |
+| `kind`        | str    | `"quality"`                                                   |
+| `ts`          | str    | RFC3339 (observation time)                                    |
+| `bead_id`     | str    | join key back to the `dispatch` record                       |
+| `cell_key`    | str    | the cell credited (copied from the joined dispatch)          |
+| `q`           | int    | `0` or `1` (Bernoulli outcome)                               |
+| `channel`     | str    | `"close"` \| `"review"` \| `"eval"` (which channel fired)    |
+| `weight`      | num    | `w` applied to the Beta update (§4.4)                        |
+| `signal`      | str    | raw signal for audit (`closed`, `reopened`, `fail`, `pass_with_findings`, `partial`, …) |
+| `n_dep`       | int    | downstream dependents at observation time (for loss audit)   |
+
+### 5.3 Optional `kind = "recommendation"` (audit of advise calls)
+
+Recording every `advise`/`inspect` call's `reasons` object is recommended for the
+operator-agreement instrument the paper plans, but optional for v1. If written:
+`{ kind:"recommendation", ts, cell_key, advised_tier, candidates:[{tier_id, q_lo,
+exp_loss, cost_diff}], eval_flag }`.
+
+### 5.4 Token counts
+
+Cost needs `tok_in`/`tok_out`. If the dispatch path exposes realised token counts
+(provider usage), record them on the `quality` (or a follow-up) record as
+`tok_in`, `tok_out`. If unavailable, the engine uses a **configured representative
+budget** per shape (the paper does the same — illustrative `1200 in / 400 out`)
+for cost differentials; this is exact arithmetic on a fixed budget, flagged as
+representative in the rationale.
+
+### 5.5 Cell-store cache
+
+`.beads/telemetry/advisor-cells.json` = `Map[cell_key] -> {a, b, n, last_update}`,
+the materialised posteriors. It is a **cache**: deleting it and replaying
+`invocations.jsonl` (priors + every `quality` record in order) reproduces it
+exactly. The engine MUST treat the JSONL as the source of truth and the cell
+store as rebuildable.
+
+---
+
+## 6. Surfaces (CLI)
+
+Two read-only surfaces, mirroring the paper's `gt dispatch --advise` and
+`gt advisor inspect`. Both default to human text and support `--json` (emit the
+`reasons` object). Pack-provided as `gc`-discoverable commands (e.g. installed
+under the pack's `bin/` and surfaced as `model-advisor advise|inspect`, or wired
+as a `gc` subcommand by the engine bead — naming finalised there).
+
+### 6.1 `advise <agent> <shape> [--tol <class>] [--provider <p>] [--rig <r>] [--baseline <tier>]`
+
+Mirrors `gt dispatch --advise`. Returns the recommendation for the cell.
+
+- **Inputs:** agent (base name), shape; optional tolerance-class override (else
+  the cell's configured default), provider (else city default), baseline tier
+  (else configured `tier*`).
+- **Computes:** `recommend(...)` (§1.4) over the live posteriors.
+- **Outputs (human):**
+  - recommended `tier_id` (+ concrete model);
+  - **rationale string** — e.g. *"sonnet: LCB q_lo=0.82 ≥ baseline mean 0.80 −
+    0.05 tol; cheapest admitted tier; expected loss −$0.011/dispatch vs opus"* or,
+    cold-start, *"opus (baseline): no cheaper tier clears tolerance — haiku
+    q_lo=0.41, sonnet q_lo=0.58 both < 0.75 threshold (thin evidence, n<5)."*
+  - **cost differential** vs each roster tier (and vs baseline), at the
+    representative or realised token budget.
+- **`--json`:** the full `reasons` object (candidates, per-candidate `q_lo`,
+  `exp_loss`, `cost_diff`, `eval_flag`).
+- **Integration:** intended to back a `gc sling --advise`-style hook so the
+  dispatcher (mayor/formula) can consult the advisor before choosing a run target.
+  v1 ships the standalone surface; the sling hook is an engine-bead follow-up.
+
+### 6.2 `inspect <agent> <shape> [--provider <p>]`
+
+Mirrors `gt advisor inspect`. Read-only deep view of the `(agent, shape)` cells
+across the whole roster.
+
+- **Per-tier posterior:** `Beta(a~, b~)`, mean, the LCB `q_lo`, observation count
+  `n`, last-update time, and admit/reject under the current tolerance.
+- **Credible interval on the quality drop** vs baseline: report the
+  `1 - alpha` credible interval on `theta[tier*] - theta[tier]` for each candidate
+  (so the operator sees the credible *degradation*, the quantity the constraint
+  bounds), e.g. *"haiku: quality-drop 95% CI [0.06, 0.31] — exceeds 0.05 tol."*
+- **Next eval to resolve the widest cell:** identify the cell (tier) with the
+  widest posterior CI half-width that is *also* gating a decision (i.e. its width
+  is why a cheaper tier can't be admitted), and name it as the highest-value eval
+  probe — *"widest gating cell: sonnet (CI half-width 0.14 > 0.10); run an eval on
+  claude::polecat::implement::sonnet to resolve."* This is the operator-facing
+  realisation of Layer 4's uncertainty-trigger (the auto-dispatch is deferred,
+  §7; `inspect` surfaces the recommendation so a human can run it).
+- **`--json`:** the per-tier table + the widest-cell pointer.
+
+Both surfaces are **pure reads** over the cell store/JSONL; neither dispatches,
+mutates beads, or changes config.
+
+---
+
+## 7. What's adapted vs the paper, and what's deferred
+
+### 7.1 Adapted (deliberate divergences)
+
+| Paper                                          | This pack                                                                 |
+|------------------------------------------------|---------------------------------------------------------------------------|
+| Fixed 3 tiers (haiku/sonnet/opus)              | **Arbitrary user-configured roster** of `(provider, model)` run targets, cost-ordered by `rank`; `O(K)` over any K. Grounded in gc's existing `gc.run_target/provider/model` dispatch metadata. |
+| 17 fixed agents, per-agent ad-hoc shapes       | gc roster discovered from config (mayor/deacon/boot/witness/refinery/polecat/dog/crew + consumer agents); a **5-shape gc-native taxonomy** (lookup/implement/judge/review/patrol), config-extensible, with per-agent canonical shape sets. |
+| Cell = agent×shape×tier                         | Cell = **provider×agent×shape×tier**, agent = base role (rig-pooled). Provider in the key for multi-provider/per-rig rosters. |
+| Offline empirical landscape seeds every prior  | **Conservative cost-ordered cold-start** (optimistic baseline, pessimistic-wide cheaper tiers ⇒ day-1 = "recommend baseline until earned"); the confidence→pseudocount rule is retained for consumers who supply a `priors.json`. |
+| Quality via reviewer/eval/downstream closure   | **Bead lifecycle as primary** (close→1, reopen/escalate→0), reviewer verdicts (`pass/pass_with_findings/fail/blocked`) and eval (`pass/partial/fail`) as weighted higher-fidelity secondaries. Same three-channel philosophy, gc-native sources. |
+| Conformal LCB (rolling calibration buffer)     | **Wilson / exact-Beta-ppf LCB** in v1 (coincides asymptotically); conformal backend behind a flag for when buffers exist. |
+| `gt dispatch --advise` / `gt advisor inspect`  | `advise <agent> <shape>` / `inspect <agent> <shape>` (same semantics, gc CLI). |
+
+### 7.2 Kept faithfully (the load-bearing parts — do not water down)
+
+- The **constrained decision rule** (§1.2): cheapest tier whose posterior-credible
+  quality-drop ≤ `q_tol` at `1 - alpha = 0.95`.
+- The **conservative gate** (§1.3 Layer 2): one-sided LCB ≥ `mu* - q_tol`; baseline
+  always feasible; cold-start rejects by default.
+- The **asymmetric loss** (§1.3 Layer 3) with class multipliers ∞/20/5/1 and the
+  cascade term scaled by downstream-dependent count `N_dep`.
+- The **`M[Critical] = ∞` hard rule**: Critical cells never enter the
+  downgrade/exploration set. This is the design contract, not a tunable.
+- The **conservative property** (§5 Thm): every recommended downgrade is credible
+  at `1 - alpha` — preserved because Layer 3 only removes from the admitted set.
+- **Pure-function `recommend`, deterministic tests, structured `reasons`**
+  (audit-first). The paper attributes operator trust to the `reasons` object more
+  than to algorithmic accuracy.
+- **Bounded-influence priors** (≤20/side) so real evidence dominates fast.
+
+### 7.3 Deferred (explicitly out of v1 scope; designed-for, not built)
+
+> **STATUS — implemented in v3 (2026-06-03).** Every item below is now built, each behind a
+> **default-off** flag, so the v1 design context that follows still describes the *default*
+> behavior. Map: Layer-4 eval → `advisor eval-schedule`; conformal → `lcb_backend=conformal`;
+> hierarchical → `pooling=empirical-bayes` (stdlib empirical-Bayes; optional PyMC extra);
+> federation → `[federation]` + `advisor federate`; cascade → `advise --cascade-bead`;
+> continuous → `continuous_quality=true`; Thompson → `mode=thompson`; change-point →
+> `changepoint=true` + `advisor drift`. See the README **"Advanced modes"** and
+> `docs/V3-BUILD-BRIEF.md`. The text below is preserved as the original design rationale.
+
+- **Layer 4 auto-scheduled eval.** v1 *records* the uncertainty trigger and
+  *surfaces* the highest-value eval in `inspect`, but does not auto-dispatch eval
+  runs. Auto-scheduling proportional to posterior width is a later bead. The
+  schema and trigger hook are in place.
+- **Strict conformal calibration.** The rolling per-cell `(predicted, observed)`
+  calibration buffer and the distribution-free `ConformalLCB` backend are deferred
+  until cells have exchangeable history; v1's Wilson/Beta-ppf LCB is the
+  asymptotic stand-in.
+- **Full hierarchical Bayesian inference.** v1 uses the closed-form pooled-
+  pseudocount approximation (§1.3); Stan/PyMC Beta-Beta inference is out of scope.
+- **Hierarchical-bandit / multi-tenant federation.** Sharing posteriors across
+  consumer repos to accelerate thin-cell convergence (paper §7 "when this won't
+  work") — privacy/trust questions, deferred.
+- **Sequential / critical-path-aware cascade modelling.** v1 treats each dispatch
+  as one-shot with an `N_dep` blast-radius scalar; a contextual-MDP treatment of
+  an ADR cascading into N builder dispatches (paper §7) is deferred.
+- **Continuous quality signal.** v1 is Bernoulli (pass/fail). A Gaussian/Beta
+  continuous-score posterior (paper OQ-A6) is deferred.
+- **Genuine Thompson Sampling mode.** v1 ships the LCB-gated deterministic rule
+  (the paper's production rule). A seeded per-tier Beta-sampling mode is left as a
+  flag (the seed hook in `recommend` exists for it).
+- **Change-point detection** for upstream model drift/deprecation. Deferred; the
+  static-baseline safety hatch (below) is the v1 mitigation.
+
+### 7.4 Safety hatch (kept from §7, ships in v1)
+
+Static frontmatter / configured tier is the **policy floor**: an operator can pin
+a cell to its baseline `tier*` via a `force_baseline = true` flag, short-circuiting
+all learning and playing the configured tier. Motivated by (a) incident response
+(exploration is wrong during an incident) and (b) upstream model drift outpacing
+the posteriors. The advisor recommends; the operator can always lock. This is the
+trust precondition under which the advisor is allowed to drive routing at all.
+
+---
+
+## 8. Implementation notes for the engine bead
+
+- **`recommend(state, cell_key, q_tol_class, baseline_tier) -> (tier, reasons)`
+  is a pure function.** No I/O, no globals. `state` = the in-memory cell store +
+  roster config. This makes the decision exhaustively unit-testable and is a hard
+  requirement (paper §5).
+- **Keep the Beta sampler seedable** even though v1's rule is LCB-deterministic —
+  it future-proofs the genuine-TS mode and makes any randomised test reproducible.
+- **`reasons` is the contract surface.** Populate candidates, per-candidate `q_lo`,
+  `exp_loss`, `cost_diff`, and `eval_flag` on *every* call. Both `advise` and
+  `inspect` render from it; `--json` emits it verbatim.
+- **Sources of truth vs caches.** `invocations.jsonl` (append-only) is truth;
+  `advisor-cells.json` is a rebuildable materialisation. Never trust the cache
+  over the log.
+- **Degradation.** Missing roster config ⇒ surface a clear error (the advisor
+  cannot order tiers without it). Missing priors ⇒ cold-start (§3.2). Missing
+  token counts ⇒ representative budget (§5.4). Thin/zero evidence ⇒ recommend
+  baseline. The advisor must never *block* a dispatch; worst case it recommends
+  `tier*`.
+- **Config files the engine reads:** `roster.toml` (tiers), `shapes.toml`
+  (shape names + default tolerance class + per-agent canonical shapes),
+  optional `priors.json` (confidence-seeded cold start). All discovered via the
+  pack's config; nothing hard-coded.
+- **Hyperparameter defaults (paper appendix D):** `alpha = 0.05`,
+  `theta_eval = 0.10`, pooling cap `lambda = 0.5`, `M = {∞, 20, 5, 1}`,
+  `s_prior ≈ 4`, channel weights `{close:1, review:3, eval:5}`,
+  reopen-debounce `24h`. All config-overridable.
+
+---
+
+## 9. Acceptance (what "the engine implements this doc" means)
+
+1. Reads a config-driven roster of arbitrary K tiers and a config-driven shape
+   taxonomy; keys cells as `provider::agent::shape::tier_id`.
+2. Maintains per-cell `Beta(a,b)` posteriors with closed-form Bernoulli updates
+   and capped pseudocount pooling; persists to a rebuildable cell-store cache
+   over `invocations.jsonl`.
+3. Cold-starts conservatively (baseline-only recommendations until cheaper tiers
+   earn admission); honours a supplied `priors.json` via the confidence rule.
+4. Implements the gate (LCB ≥ `mu* - q_tol`, baseline always feasible, Critical
+   never downgrades) and the asymmetric-loss selection, as a pure, deterministic,
+   seedable `recommend` returning a structured `reasons` object.
+5. Ingests quality from bead closure (primary) + reviewer/eval verdicts
+   (weighted), attributing each observation to the producing dispatch's cell.
+6. Emits the `dispatch` and `quality` telemetry records (§5) to
+   `.beads/telemetry/invocations.jsonl`.
+7. Ships `advise <agent> <shape>` (tier + rationale + cost diff) and
+   `inspect <agent> <shape>` (per-tier posterior, quality-drop credible interval,
+   widest-gating-cell eval pointer), both with `--json`.
+8. Provides the `force_baseline` safety hatch.

--- a/model-advisor/docs/INTEGRATION-FEASIBILITY.md
+++ b/model-advisor/docs/INTEGRATION-FEASIBILITY.md
@@ -1,0 +1,309 @@
+# Model-Advisor — gc Integration Feasibility Verdict
+
+**Bead:** bh-2hm (MAD pack effort)
+**Scope:** READ-ONLY investigation of Gas City's (`gc`) integration surface for a model-tier advisor.
+**Date:** 2026-06-03
+**gc binary:** `/opt/homebrew/bin/gc`  •  **city root:** `/Users/jayse/Code`
+
+This document answers three questions — (A) auto-apply, (B) telemetry, (C) quality
+signal — then states the recommended **v1 MVP** (learn + recommend) and what **v2
+auto-apply** requires from gc-core.
+
+---
+
+## TL;DR Verdicts
+
+| | Question | Verdict |
+|---|----------|---------|
+| **A** | Can a model/tier be selected per agent or per dispatch? | **Per-AGENT: YES, today** (config field `model` → `GC_AGENT_MODEL` env). **Per-DISPATCH/per-task: NO** — needs a gc-core change (no `--model` on `gc sling`, no `gc.model` consumption at spawn). |
+| **B** | What invocation/usage telemetry does gc emit for learning? | **Partial.** gc emits structured **lifecycle + bead** events to `.gc/events.jsonl`, but **no per-invocation record with model + token counts** is produced by gc-core in this city (the `worker.operation` events that `gc analyze reliability` expects are absent — the report returns 0). Token/model telemetry today lives only in the **gt/blackrim framework** (`.beads/telemetry/invocations.jsonl`), not gc. A small capture hook is needed for clean invocation records. |
+| **C** | How to detect bead closed-OK vs reopened/escalated? | **YES, fully supported.** `gc bd show --json` + `bd history` + the `bead.closed` / Reopened events expose `status`, `closed_at`, `close_reason`, `metadata` (incl. `agent`, `session_id`), and `gc.outcome` / `gc.failure_class`. `bd reopen` emits a dedicated **Reopened** event. Task→agent→shape mapping is via bead `metadata.agent` + `metadata.session_id` + `gc.run_target` / `gc.formula_name`. |
+
+---
+
+## (A) AUTO-APPLY — model/tier selection per agent or per dispatch
+
+### How gc spawns a session and sets its model
+
+1. **Provider is per-agent.** `city.toml` has `provider = "claude"` but `gc config show`
+   prints a deprecation warning making the mechanism explicit:
+
+   > `workspace.provider is deprecated: Set provider per agent in agents/<name>/agent.toml.`
+
+   Provider is resolved per `[[agent]]` block (e.g. the pooled `claude` worker agents and
+   `gastown/witness` carry `provider = "claude"`).
+
+2. **`model` is a first-class config field.** The gc binary validates it — string
+   `agent_defaults.model redefined by %q` appears in the binary, alongside
+   `agent_defaults.provider`, `agent_defaults.wake_mode`, `agent_defaults.default_sling_formula`.
+   This means a `model = "..."` key is accepted at **`[agent_defaults]`** and per-**`[[agent]]`**
+   scope and is part of the agent config schema (unknown keys error with `unknown field %q`).
+   *No pack in this city currently sets it* (grep of all `packs/**/agent.toml` for
+   `model|provider|tier` found zero `model=` assignments), so it is supported-but-unused.
+
+3. **Model reaches the provider via an env var.** The binary contains **`GC_AGENT_MODEL=`**,
+   positioned next to molecule/convoy dispatch strings (`convoy.molecule`, `gc.on_exhausted`).
+   gc also sets `GC_PROVIDER`, `GC_TEMPLATE`, `GC_RIG_ROOT`, `GC_PROVIDER_SESSION_ID` at spawn.
+   So the launcher: reads the agent's `model` field → exports `GC_AGENT_MODEL` → the provider
+   adapter passes it to the underlying CLI (`claude-opus-4-7` / `claude-opus-4-8` model IDs are
+   embedded in the binary; codex/opencode adapters build `--model … --effort …` argv, visible as
+   `--model o4-mini gpt-5.5 … --effort opus-4-7`).
+
+4. **Projected agent settings carry hooks, not a model.** The materialized per-agent settings
+   are at `/.gc/agents/<agent>/.gc/settings.json` (NOT `.claude/settings.json` — that dir holds
+   only skill symlinks). They contain `hooks` (SessionStart→`gc prime`, UserPromptSubmit→
+   `gc nudge drain` / `gc mail check`, PreCompact→`gc handoff`) and flags like
+   `skipDangerousModePermissionPrompt` — **no `model` key**. The claude provider has **no
+   per-provider overlay** at `core/overlay/per-provider/` (only codex/copilot/cursor/gemini/
+   kiro/omp/opencode/pi do). Model is therefore set via the agent **config field → env var**
+   path, not via projected provider settings.
+
+### Knobs a pack could use to set the model
+
+| Knob | Granularity | Works today from a pack? |
+|------|-------------|--------------------------|
+| `model = "<id>"` in `[agent_defaults]` or `[[agent]]` (city/pack config) | **Per agent (template)** | **YES** — gc-core reads & validates it; injected as `GC_AGENT_MODEL`. A pack can ship/patch agent config. |
+| `pre_start` hook on an agent (e.g. `gastown/polecat` uses one for worktree setup) | Per agent, at spawn | **Partially** — a `pre_start` script runs before the session; it could export env, but `GC_AGENT_MODEL` is set by gc's launcher *after* config resolution, so a hook would have to race/override the provider CLI invocation — brittle, not a clean seam. |
+| `gc sling --var model=…` / formula vars | Intended per-dispatch | **NO for execution.** `mol-review-quorum` threads `lane_one_model` into **bead metadata** (`gc.model`, `gc.run_target`, `gc.reviewer_model`) and into the **prompt text**, but that metadata is *advisory* — it tells the agent which model to claim, it does **not** reconfigure the provider. There is no evidence gc reads `gc.model` off a bead to set `GC_AGENT_MODEL` at spawn. |
+| `gc sling --model …` CLI flag | Per dispatch | **NO** — `gc sling` has no `--model`/`--effort`/`--provider` flag. Neither does `gc session new` / `gc session attach` / `gc session reset`. |
+
+### Verdict (A)
+
+- **Per-agent model selection is feasible from a pack TODAY**, with zero gc-core changes:
+  set `model = "<provider-model-id>"` under `[agent_defaults]` or a specific `[[agent]]` block
+  (or patch it via a pack overlay). gc resolves it and exports `GC_AGENT_MODEL` into the session.
+  This is coarse: it pins a model for *all* dispatches that agent handles, changeable only by a
+  config edit + `gc reload`/restart.
+
+- **Per-task / per-dispatch model selection is NOT feasible today** — it requires gc-core support.
+  The missing seam is: *at dispatch, read a model from the bead/wisp (`gc.model`) or a
+  `gc sling --model` flag and have the session launcher honor it as `GC_AGENT_MODEL`.* The plumbing
+  half-exists (`mol-review-quorum` already writes `gc.model`/`gc.run_target`/`gc.provider` onto
+  step beads; `GC_AGENT_MODEL` already exists as the env lever) — what's absent is the launcher
+  binding bead-`gc.model` → `GC_AGENT_MODEL`, and/or a `--model` flag on `gc sling`/`gc session new`.
+
+> **gc-core ask for v2:** either (1) a `gc sling --model <id>` / `gc session new --model <id>` flag,
+> or (2) launcher logic: "if the routed bead carries `gc.model`, set `GC_AGENT_MODEL` from it."
+> Both are small, localized changes given the env var and metadata keys already exist.
+
+---
+
+## (B) TELEMETRY — invocation/usage data gc emits for learning
+
+### What gc-core emits (`.gc/events.jsonl`, 26 MB in this city)
+
+`gc events` / `gc analyze` read this append-only stream. Observed event types and counts:
+
+```
+17770 bead.updated     2869 order.fired      399 session.woke
+ 3215 bead.created     2865 order.completed   396 session.stopped
+ 3101 bead.closed         2 order.failed        7 mail.sent / read / archived
+                          1 controller.started
+```
+
+- **`session.woke` / `session.stopped`** carry **no model and no tokens** — only
+  `{subject: "gastown.boot", payload:{session_id, template, reason}}`. Example stopped reason:
+  `"drain acknowledged"`.
+- **`bead.created` / `bead.updated` / `bead.closed`** carry the **full bead object** in
+  `payload.bead` (id, status, `close_reason`, `metadata`, `labels`, `closed_at`). This is the
+  richest learning signal gc emits natively (see C).
+- **No `worker.operation` events** in this city. `gc analyze reliability` is explicitly built on
+  `worker.operation` events (which "supply the `(model, prompt_version, agent_name)` tuple per
+  session") plus lifecycle events `session.crashed` / `session.idle_killed` / `session.draining` /
+  `session.quarantined`. Running `gc analyze reliability` here returns an **all-zero TOTAL row**
+  and the note *"session.quarantined is not emitted by current production paths."* None of those
+  lifecycle/crash events are present in the stream either. So **the model/version/rig correlation
+  surface that gc advertises is not populated in this deployment** — it would light up only if the
+  controller were emitting `worker.operation`, which it currently isn't.
+
+**Net:** gc-core does **not** emit a per-invocation record with `{model, input_tokens,
+output_tokens, success}`. It emits *bead-lifecycle* and *session-lifecycle* events without token
+or model fields.
+
+### What the framework (gt/blackrim) emits — NOT gc
+
+Token/model telemetry exists, but in the **framework layer**, written to per-rig
+`.beads/telemetry/*.jsonl` (blackrim, poke-holes, gridwars, blackrim-vox, target/gascity):
+
+- **`invocations.jsonl`** — the closest thing to what the advisor wants:
+  ```json
+  {"ts":"…","tool":"Agent","agent":"a6f97…","session":"62c4…","provider":"anthropic",
+   "model":"claude-haiku-4-5","input_tokens":1,"output_tokens":1,"duration_ms":0,
+   "mode":"subscription","source":"gt-cache-warm"}
+  ```
+  Caveat: for `source:"subagent_stop_estimated"` records, `model` is often `"unknown"` and
+  tokens are `0` — these are *estimated* stops, not authoritative usage.
+- **`dispatch-events.jsonl`** — `{event:"delegation_check", session_id, tool, action:"allow"}`
+  (routing/guardrail events, no model/tokens).
+- **`eval-runs.jsonl`** — `{run_id, suite, case_id, output, expected, scores[], provider, model}`
+  (eval harness; carries authoritative `model` + pass/fail scores).
+
+These are produced by gt hooks (`gt-cache-warm`, `subagent_stop_estimated`), **not** by `gc`.
+The advisor cannot assume they exist in an arbitrary gc city.
+
+### Verdict (B)
+
+- **Available today to feed posteriors:**
+  - **Model identity:** NOT from gc-core natively (no per-invocation model field). Available only
+    if (a) the framework's `invocations.jsonl` is present, or (b) model is pinned per-agent via
+    `agent.model` and inferred from `metadata.agent`, or (c) read from bead `gc.model`/
+    `gc.reviewer_model` metadata when a model-routing formula like `mol-review-quorum` was used.
+  - **Tokens:** NOT from gc-core. Only from framework `invocations.jsonl` (and often
+    `0`/`unknown` for estimated records). **A clean capture hook is required for reliable tokens.**
+  - **Outcome:** YES from gc-core — bead closure (`status`, `close_reason`, `gc.outcome`,
+    `gc.failure_class`) and reopen/escalate transitions (see C). This is the strongest native
+    signal.
+
+- **A small capture hook IS needed** to produce clean per-invocation records. Recommendation: a
+  **`Stop` / `SubagentStop` (or `PostToolUse`)** hook (the same mechanism gc already wires for
+  `SessionStart`/`UserPromptSubmit`/`PreCompact` in `.gc/settings.json`) that appends a JSONL row:
+  `{ts, session_id, agent (from GC_TEMPLATE), model (from GC_AGENT_MODEL or transcript),
+  input_tokens, output_tokens, bead_id, outcome}`. This is a pack-owned hook — it does **not**
+  require gc-core changes — and gives the advisor a self-consistent invocation log keyed to the
+  same session_id that beads reference.
+
+---
+
+## (C) QUALITY SIGNAL — bd closure (success vs reopened/escalated)
+
+### Detecting closed-OK vs reopened/escalated via `gc bd`
+
+**Status enum (built-in):** `open`, `in_progress`, `blocked`, `deferred`, `closed`, `pinned`,
+`hooked` (from `gc bd statuses`). Categories: active / wip / done / frozen. (`done`, `review`,
+`ready`, `escalated`, `reopened`, `abandoned` seen in the binary/other rigs are **custom statuses
+or label-states**, not built-ins — configurable via `bd config set status.custom`.)
+
+**Successful closure** — observable on the bead and in the event stream:
+- `gc bd show <id> --json` → `status:"closed"`, `closed_at:"…"`, `close_reason:"…"`, plus
+  `metadata` and `labels`. Example: `close_reason:"order dispatch completed: tracking bead
+  lifecycle finished"`.
+- The **`bead.closed`** event carries the **entire bead object** in `payload.bead` (status,
+  close_reason, metadata, labels, closed_at) — so closure quality is learnable from the stream
+  alone, no extra `bd show` call needed.
+- **Structured outcome metadata** (set by formulas/agents): `gc.outcome` (`pass`/`fail`),
+  `gc.failure_class` (`none`/`transient`/`hard`), `gc.failure_reason`, `gc.final_disposition`.
+  `mol-review-quorum` and `mol-do-work`-style flows close with `gc.outcome=pass` on success and
+  `gc.outcome=fail` + `gc.failure_class` on retryable/hard failure. This is the **cleanest
+  success bit** when present.
+
+**Reopen / escalate / redo (the noisy negative signal):**
+- **`bd reopen <id> [-r reason]`** — sets status back to `open`, clears `closed_at`, and **emits a
+  dedicated Reopened event** (per its help: *"emits a Reopened event"*). This is the primary
+  "the close didn't stick" signal.
+- **`bd history <id>`** — full per-bead audit trail (e.g. 29 entries on a sample bead) showing every
+  status transition with author + timestamp. Counting close→reopen cycles per bead is the direct
+  "redo rate" metric.
+- **Retry/attempt metadata** for dispatch-level redo: `gc.attempt`, `gc.max_attempts`,
+  `gc.closed_by_attempt`, `gc.retry_from`, `gc.next_attempt`, `gc.last_failure_class`,
+  `gc.partial_fragment` — these track formula-step retries and exhaustion
+  (`gc.on_exhausted` = `soft_fail`/`hard_fail`).
+- **Escalation** is expressed via **`bd set-state <id> <dim>=<val>`**, which writes a
+  `<dimension>:<value>` label (e.g. `mode:degraded`, `health:failing`) **and** creates an event
+  bead — so escalations are both queryable (by label) and in the event log. Some rigs use a
+  custom `escalated` status for the same purpose.
+
+### Mapping a dispatched task back to agent + shape
+
+A bead resolves to who/what handled it via:
+- **`metadata.agent`** — e.g. `"gastown.deacon"` (the agent template that worked it).
+- **`metadata.session_id`** — e.g. `"bh-vt5"` (the session; joins to `session.*` events and to a
+  capture-hook invocation row).
+- **`labels`** — e.g. `agent:gastown.deacon`, `gc:nudge`, `source:session`, `order-run:<order>`,
+  `exec`.
+- **`created_by`** — e.g. `controller`, `order:mol-dog-doctor`, `gastown__mayor`.
+- **Shape/formula provenance** (when dispatched via a formula/wisp): `gc.formula_name`,
+  `gc.run_target`, `gc.provider`, `gc.model`, `gc.review_quorum_role`, `gc.kind`,
+  `gc.continuation_group`. So a task → **(agent, provider, model, formula/shape)** tuple is
+  reconstructable from bead metadata for formula-routed work; for plain `gc sling`/nudge work,
+  agent+session are present but model is only known if pinned per-agent or captured by the hook.
+
+### Verdict (C)
+
+Bead closure is a **reliable, fully-supported quality channel today** via `gc bd show --json`,
+`bd history`, and `bead.closed`/Reopened events. Success = `status:closed` with `gc.outcome=pass`
+(or absent failure metadata); noisy-negative = a **Reopened** event / close→reopen cycle in
+history, `gc.outcome=fail`, `gc.failure_class∈{transient,hard}`, retry-exhaustion metadata, or an
+escalation state label. Task→agent→shape attribution comes from `metadata.{agent,session_id}` +
+`gc.{run_target,formula_name,provider,model}` + labels.
+
+---
+
+## Recommended v1 MVP — learn + recommend (NO gc-core changes)
+
+The advisor ships as a **pack** that observes and advises; it does not mutate dispatch.
+
+1. **Capture invocation records (pack-owned hook).** Add a `Stop`/`SubagentStop` (or `PostToolUse`)
+   hook via the agent's projected `.gc/settings.json` mechanism that appends an
+   `invocations.jsonl` row: `{ts, session_id, agent=$GC_TEMPLATE, model=$GC_AGENT_MODEL (or parsed
+   from transcript), provider=$GC_PROVIDER, input_tokens, output_tokens, duration_ms, bead_id}`.
+   If the gt-framework `invocations.jsonl` is already present, ingest it instead/as well. This
+   closes the (B) gap without gc-core support.
+
+2. **Harvest the outcome signal from beads/events.** Tail `.gc/events.jsonl` for `bead.closed`
+   (and watch for Reopened events) and/or periodically `gc bd list --json` + `bd history`. Derive
+   per-bead success = `status:closed ∧ gc.outcome≠fail ∧ no later reopen`; failure/redo = Reopened
+   event, `gc.outcome=fail`, `gc.failure_class`, or escalation label.
+
+3. **Join on `session_id` + `bead_id`.** Build training rows of
+   `(task-shape, agent, model, tokens, duration) → outcome` by joining the capture hook's
+   invocation rows to bead closures via `metadata.session_id`/`bead_id`. Shape comes from
+   `gc.formula_name`/`gc.run_target`/`issue_type`/labels.
+
+4. **Maintain posteriors and emit a recommendation.** Per (shape × model/tier), keep a
+   Beta-Bernoulli (or similar) posterior over success, with token/cost as a secondary axis.
+   **Recommend** a tier per shape — surface it as a report, a `bd note`/comment on the routing
+   bead, or `gc mail` to the mayor. **The pack recommends; a human/agent applies it by editing the
+   agent's `model` config field.** (v1 *could* optionally auto-edit the per-agent `model` field +
+   `gc reload`, but that is coarse, agent-global, and racy mid-session — keep it advisory in v1.)
+
+**v1 deliverable:** a learning loop + recommendation surface that needs only pack-level hooks and
+read-only `gc bd`/`gc events` access. No gc-core dependency.
+
+## What v2 auto-apply requires (gc-core)
+
+Per-task application of the advised tier needs **one** of these gc-core additions (smallest first):
+
+1. **Bead-metadata binding (preferred, plumbing mostly exists):** at session spawn, if the routed
+   bead/wisp carries `gc.model`, have the launcher set `GC_AGENT_MODEL` from it. `mol-review-quorum`
+   already demonstrates writing `gc.model`/`gc.run_target`/`gc.provider` onto step beads; the env
+   lever (`GC_AGENT_MODEL`) already exists. The advisor would then just stamp `gc.model` on the
+   bead before/at `gc sling` and gc would honor it per-dispatch.
+2. **A `--model` flag** on `gc sling` (and/or `gc session new`) that overrides `GC_AGENT_MODEL` for
+   that one dispatch/session.
+
+Either makes the advisor's recommendation **auto-applicable per task** rather than per-agent-config.
+Tracking bead **bh-ylp** ("MAD (v2): auto-apply the recommended tier at dispatch") is the right home
+for this and is correctly gated on the T2 verdict.
+
+---
+
+## Evidence Index (paths & probes — all read-only)
+
+- City config: `/Users/jayse/Code/city.toml`; resolved: `gc config show` (deprecation warning:
+  *set provider per agent in `agents/<name>/agent.toml`*).
+- Agent defs: `/Users/jayse/Code/.gc/system/packs/gastown/agents/*/agent.toml`
+  (`mayor`,`deacon`,`boot`,`polecat`,`refinery`,`witness`) — fields `scope/wake_mode/work_dir/
+  idle_timeout/max_active_sessions/pre_start/nudge`; **no `model`** set. `witness` & pooled
+  `claude` agents set `provider="claude"`.
+- Projected per-agent settings: `/Users/jayse/Code/.gc/agents/<agent>/.gc/settings.json` (hooks +
+  `skipDangerousModePermissionPrompt`; **no model**). `.claude/` holds only skill symlinks. No
+  claude provider overlay under `/.gc/system/packs/core/overlay/per-provider/`.
+- Binary strings (`strings $(command -v gc)`): `agent_defaults.model redefined by %q`,
+  `GC_AGENT_MODEL=`, `GC_PROVIDER`, `GC_TEMPLATE`, `claude-opus-4-7`, `claude-opus-4-8`,
+  `--model … --effort opus-4-7`, config keys `model/model_name/tier/tiers/durability_tier/
+  title_model/reviewer_model/lane_one_model/lane_two_model/prompt_version`.
+- Telemetry: gc stream `/Users/jayse/Code/.gc/events.jsonl` (types above; no tokens/model on
+  sessions). `gc analyze reliability` → all-zero (no `worker.operation`/crash events). Framework
+  telemetry: `/Users/jayse/Code/{blackrim,poke-holes,gridwars.run,blackrim-vox,target/gascity}/
+  .beads/telemetry/{invocations,dispatch-events,eval-runs}.jsonl`.
+- Bead/quality: `gc bd show <id> --json` (status, closed_at, close_reason, metadata{agent,
+  session_id}, labels); `gc bd statuses`; `gc bd reopen` (emits Reopened event); `gc bd history`
+  (full transition log); `gc bd set-state` (state labels + event beads). Outcome metadata keys:
+  `gc.outcome/gc.failure_class/gc.failure_reason/gc.final_disposition/gc.attempt/gc.max_attempts/
+  gc.closed_by_attempt/gc.retry_from/gc.run_target/gc.formula_name/gc.model/gc.provider/
+  gc.reviewer_model`.
+- Model-routing precedent: `/Users/jayse/Code/.gc/system/packs/core/formulas/mol-review-quorum.toml`
+  (formula vars `lane_one_model`/`lane_one_provider`/`lane_one_target`; step metadata
+  `gc.model`/`gc.run_target`/`gc.provider` + `gc.outcome` contract).
+- Related beads: **bh-2hm** (this investigation), **bh-ylp** (v2 auto-apply at dispatch),
+  **bh-9pf** (MAD parent), **bh-uzj** (PRs).

--- a/model-advisor/docs/V3-BUILD-BRIEF.md
+++ b/model-advisor/docs/V3-BUILD-BRIEF.md
@@ -1,0 +1,95 @@
+# model-advisor v3 — shared build brief (deferred features, DESIGN §7.3)
+
+You are one of 8 parallel builders implementing a single deferred feature from
+`docs/DESIGN.md` §7.3 into the **model-advisor** gc pack at
+`/Users/jayse/Code/packs/model-advisor`. Read this brief, then your feature spec
+(in your task prompt). Read `docs/DESIGN.md` (the spec) and the modules you extend.
+
+## What the pack does (one paragraph)
+
+model-advisor routes each gc agent dispatch to the cost-minimal model **tier** that
+preserves quality. It keeps a per-cell `Beta(a,b)` posterior over dispatch quality,
+keyed `provider::agent::shape::tier_id`, learned from bead-closure telemetry. The
+decision rule (`modeladvisor/engine.py::recommend`) is a 4-layer Conservative
+Constrained Thompson Sampling policy: (L1) Beta posteriors, (L2) a conservative gate
+admitting a cheaper tier iff its **Wilson lower bound** clears `baseline_mean − q_tol`,
+(L3) asymmetric-loss selection with class multipliers (`Critical=∞` never downgrades)
+scaled by a blast-radius `N_dep`, (L4) an uncertainty-triggered eval flag. It is
+pure/deterministic/seedable; the store materialises posteriors from
+`.beads/telemetry/invocations.jsonl`.
+
+## HARD RULES (do not violate)
+
+1. **Stdlib-only.** Import only the Python standard library — `math`, `statistics`
+   (`NormalDist`, `mean`, `pstdev`), `random` (`betavariate`, seeded `Random`),
+   `json`, `dataclasses`, `bisect`, `collections`, `typing`. **No** `scipy`, `numpy`,
+   `pandas`, `pymc`, `scikit-learn` in the core. (One feature may add an *optional,
+   import-guarded* heavy backend — yours will say so explicitly if it applies.)
+2. **Match the house style.** `from __future__ import annotations`; full type hints;
+   a module docstring and per-function docstrings that **cite the DESIGN section**;
+   `@dataclass` for state; pure functions where possible (no hidden I/O/globals);
+   deterministic and, where randomness is used, **seeded and reproducible**.
+3. **Write ONLY your two new files** — `modeladvisor/<feature>.py` and
+   `tests/test_<feature>.py`. **Do NOT edit** `engine.py`, `store.py`, `config.py`,
+   `cli.py`, `ingest.py`, `autoapply.py`, `__init__.py`, `pack.toml`, or the README.
+   Other builders are editing nothing there either; we avoid races by having each of
+   you deliver a **hook-spec** (below) that the integrator applies to those shared
+   files in one serialized pass.
+4. **Your module must import and unit-test standalone against the code as it is now.**
+   It must not depend on a config knob or shared-file change that doesn't exist yet.
+   Achieve this by having your functions take their tunables as **parameters with
+   sensible defaults** (e.g. `def conformal_lcb(cell, buffer, z, *, min_buffer=20)`).
+   The integrator wires the real config knob to supply those params later.
+5. **Run only your own test file**, with the pack venv, cache disabled:
+   `./.venv/bin/python -m pytest tests/test_<feature>.py -p no:cacheprovider -q`.
+   Do **not** run the whole suite (the other builders' half-landed work isn't wired
+   yet). Aim for ≥ 8 focused tests covering the happy path, edge cases (empty/thin
+   data), determinism, and the documented degenerate fallback.
+
+## Architecture you extend (read the real source, this is the map)
+
+- `modeladvisor/store.py` — `Cell` (`a`, `b`, `n`, `last_update`; `.mean/.variance/
+  .stderr`; `.update(q,w,ts)` does the Beta `a+=w·q, b+=w·(1−q)` update). `CellStore`
+  (`.get(key)`, `.pooled(provider,agent,shape,tier_id) -> Cell` capped pseudocount
+  pooling, `.cells` dict, `.rebuild`/`.load`/`.save`, `.apply_quality(rec)` which today
+  **drops non-binary q**). `cell_key()/parse_cell_key()`.
+- `modeladvisor/engine.py` — `wilson_lcb(cell, z) -> float` (the swappable LCB),
+  `recommend(agent, shape, cfg, store, *, provider, tol_class, baseline_tier, n_dep,
+  tok_in, tok_out, seed) -> dict`, `inspect(...) -> dict`, `_ci_halfwidth`,
+  `_expected_loss`. The `seed` param is already threaded for Thompson.
+- `modeladvisor/config.py` — `AdvisorConfig` with `.hp` (hyperparameters:
+  `z`, `alpha`, `pool_lambda`, `theta_eval`, `s_prior`, `w_close/w_review/w_eval`,
+  `baseline_a/baseline_b/baseline_mean`, `cold_m_lo`), `.tier_ids` (cheapest→capable),
+  `.tier(id)`, `.tol_class_for`, `.baseline_tier_id_for`, `.budget_for`,
+  `.canonical_shapes_for`, `.agent_shapes`, `.default_provider`. **Read it** to see
+  how `.hp` and classes are defined before you propose a new knob.
+- `modeladvisor/ingest.py` — harvests bead-closure into `quality` telemetry records.
+- `modeladvisor/cli.py` — `advisor` subcommands (`advise`, `inspect`, `apply`,
+  `auto-apply`, …) using stdlib `argparse`. Look at one subcommand to copy the shape.
+
+## Your deliverable: the structured report (return this as your final message)
+
+Return a single fenced block the integrator can act on mechanically:
+
+```
+FEATURE: <bead-id> <name>
+MODULE: modeladvisor/<feature>.py  (<N> lines)
+TESTS:  tests/test_<feature>.py  (<M> tests, all passing — paste the pytest summary line)
+PUBLIC API:
+  - <exact signatures you expose, one per line>
+INTEGRATION HOOKS (for the integrator to apply to shared files):
+  - file: modeladvisor/<engine|store|config|cli>.py
+    where: <function / anchor>
+    add: |
+      <the exact code to insert, copy-pasteable>
+CONFIG KNOBS:
+  - <name> (default <value>) — <meaning>; lives on <AdvisorConfig.hp | AdvisorConfig>
+CLI:
+  - advisor <subcommand> <args> — <what it prints/does>  (or "none")
+SUMMARY: <2–3 sentences: what you built, the algorithm, any caveat/limitation.>
+```
+
+Keep the hook minimal and surgical — ideally a single dispatch line at the existing
+call-site plus the knob. The integrator owns wiring, conflict resolution, the full
+suite, and `gc lint`. Build the feature *correctly and faithfully to the paper*; a
+small, exact, well-tested module beats a broad shaky one.

--- a/model-advisor/hooks/capture-invocation.sh
+++ b/model-advisor/hooks/capture-invocation.sh
@@ -1,0 +1,277 @@
+#!/usr/bin/env bash
+#
+# capture-invocation.sh — Claude Code Stop / SubagentStop hook for the
+# model-advisor pack.
+#
+# Implements the *write side* of the advisor telemetry contract (DESIGN.md §5):
+# at the end of a session/subagent turn it appends a `kind="dispatch"`
+# invocation record to the project's
+#     <project>/.beads/telemetry/invocations.jsonl
+# so the advisor engine (sibling, modeladvisor/store.py + engine.py) can later
+# reconstruct the cell `provider::agent::shape::tier_id` and join a quality
+# outcome to it (INTEGRATION-FEASIBILITY.md verdict (B): a Stop hook is the
+# pack-owned seam that supplies model + tokens, which gc-core's session events
+# do not carry).
+#
+# CONTRACT (Claude Code Stop / SubagentStop):
+#   - stdin : JSON describing the stop event. Fields we read when present:
+#               { "hook_event_name": "Stop" | "SubagentStop",
+#                 "session_id":     "<id>",
+#                 "transcript_path":"/abs/path/to/transcript.jsonl",
+#                 "cwd":            "/abs/working/dir",
+#                 "stop_hook_active": true|false }
+#             Most of the advisor's cell fields are NOT in the stop payload —
+#             they come from the gc launcher env (GC_TEMPLATE / GC_AGENT_MODEL /
+#             GC_PROVIDER / GC_RIG_ROOT, see INTEGRATION (A)/(B)). We read what
+#             is present and mark the rest "unknown"; the engine degrades on
+#             missing fields rather than failing.
+#   - stdout: NONE. A Stop hook must not inject context; we only append a
+#             telemetry line. (Emitting JSON here is harmless but unnecessary;
+#             we stay silent so we can never interfere with the stop path.)
+#   - exit  : ALWAYS 0. Capture is strictly best-effort; it must never block a
+#             stop or fail a session. Every step below is guarded and falls
+#             through to the final `exit 0`.
+#
+# Degradation (INTEGRATION (B)): gc session.stopped events carry no model and
+# no tokens. So:
+#   * agent           <- $GC_TEMPLATE (base name derived), else "unknown"
+#   * model           <- $GC_AGENT_MODEL, else parsed from the transcript's last
+#                        assistant message, else "unknown"
+#   * provider        <- $GC_PROVIDER, else "unknown"
+#   * tok_in/tok_out  <- summed from transcript usage if present, else omitted
+#   * tier_id/shape   <- "unknown" at capture time; the engine resolves the
+#                        canonical shape and roster tier from the roster/shapes
+#                        config + this record's model/agent (DESIGN.md §2.2/§2.3).
+# A record with unknowns is still a valid join anchor: bead_id / session_id are
+# the keys the quality harvester (ingest.py) joins on.
+#
+# Escape hatch: MODEL_ADVISOR_DISABLE_CAPTURE=1 makes this hook a no-op without
+# touching settings.json.
+#
+# Self-contained: shells out only to `jq` (robust JSON) with a grep/sed/python3
+# fallback, and `date`. No pack Python is invoked on the hot path.
+
+# Deliberately NOT using `set -e`/`set -u`/pipefail: every step is guarded and
+# we must always reach `exit 0`, even on an unbound var or a broken pipe.
+
+# ---- 0. Global escape hatch ------------------------------------------------
+if [ "${MODEL_ADVISOR_DISABLE_CAPTURE:-}" = "1" ]; then
+  exit 0
+fi
+
+SCHEMA_VERSION="advisor.v1"
+
+# ---- 1. Read the Stop payload from stdin -----------------------------------
+payload="$(cat 2>/dev/null)" || exit 0
+# An empty/malformed payload is fine: we proceed with env-only fields. We never
+# abort on a bad payload — the contract is "always emit something or nothing,
+# always exit 0".
+
+# ---- 2. Extract fields from the payload (jq, else grep/sed) ----------------
+hook_event=""
+session_id=""
+transcript_path=""
+cwd_in=""
+have_jq=0
+if command -v jq >/dev/null 2>&1; then
+  have_jq=1
+  hook_event="$(printf '%s' "$payload"      | jq -r '.hook_event_name // empty' 2>/dev/null)"
+  session_id="$(printf '%s' "$payload"      | jq -r '.session_id // empty'      2>/dev/null)"
+  transcript_path="$(printf '%s' "$payload" | jq -r '.transcript_path // empty' 2>/dev/null)"
+  cwd_in="$(printf '%s' "$payload"          | jq -r '.cwd // empty'             2>/dev/null)"
+else
+  # Minimal fallback: pull first "key": "value" string for each field.
+  _pull() { printf '%s' "$payload" | grep -o "\"$1\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" | head -n1 | sed 's/.*:[[:space:]]*"\([^"]*\)".*/\1/'; }
+  hook_event="$(_pull hook_event_name)"
+  session_id="$(_pull session_id)"
+  transcript_path="$(_pull transcript_path)"
+  cwd_in="$(_pull cwd)"
+fi
+[ -n "$hook_event" ] || hook_event="Stop"
+
+# ---- 3. Resolve agent identity + model + provider from gc env --------------
+# gc's launcher sets these at spawn (INTEGRATION (A)/(B)); they are the only
+# reliable source of agent/model/provider on a Stop hook.
+agent_instance="${GC_TEMPLATE:-}"           # e.g. "whiskeyshop/gastown.polecat"
+model="${GC_AGENT_MODEL:-}"
+provider="${GC_PROVIDER:-}"
+rig_root="${GC_RIG_ROOT:-}"
+
+# Base agent name = last dotted component of the template, rig/path stripped
+# (DESIGN.md §2.4: cells key on the base role, not the instance). Examples:
+#   "whiskeyshop/gastown.polecat#3" -> "polecat"
+#   "gastown.deacon"                -> "deacon"
+#   "polecat"                       -> "polecat"
+agent="unknown"
+if [ -n "$agent_instance" ]; then
+  agent="$agent_instance"
+  agent="${agent##*/}"   # drop "rig/" prefix
+  agent="${agent##*.}"   # drop "namespace." prefix
+  agent="${agent%%#*}"   # drop "#instance" suffix
+  [ -n "$agent" ] || agent="unknown"
+fi
+
+# rig name = first path component of the instance (audit / future per-rig key).
+rig=""
+case "$agent_instance" in
+  */*) rig="${agent_instance%%/*}" ;;
+esac
+
+# ---- 4. Best-effort: model + token usage from the transcript ---------------
+# The Claude Code transcript is JSONL of message events; assistant messages
+# carry `message.model` and `message.usage.{input_tokens,output_tokens,
+# cache_*}`. We take the LAST assistant model and SUM usage across the
+# transcript. Purely best-effort: any miss leaves the value unset/0.
+tok_in=""
+tok_out=""
+if [ -n "$transcript_path" ] && [ -f "$transcript_path" ] && [ "$have_jq" = "1" ]; then
+  # Model: last non-null message.model (only override if env didn't supply one).
+  if [ -z "$model" ]; then
+    tmodel="$(jq -rs '[.[] | .message?.model // empty] | last // empty' "$transcript_path" 2>/dev/null)"
+    [ -n "$tmodel" ] && model="$tmodel"
+  fi
+  # Tokens: sum input/output usage across all assistant messages. cache_read and
+  # cache_creation count as input for cost purposes (DESIGN.md §2.3 cost fn uses
+  # in/out token totals; the engine may refine).
+  tok_in="$(jq -rs '[.[] | .message?.usage? | ((.input_tokens // 0) + (.cache_read_input_tokens // 0) + (.cache_creation_input_tokens // 0))] | add // 0' "$transcript_path" 2>/dev/null)"
+  tok_out="$(jq -rs '[.[] | .message?.usage?.output_tokens // 0] | add // 0' "$transcript_path" 2>/dev/null)"
+  # Guard against jq printing "null"/"" — treat as absent.
+  case "$tok_in"  in ''|null) tok_in="" ;; esac
+  case "$tok_out" in ''|null) tok_out="" ;; esac
+fi
+
+# Fill unknown sentinels for required string fields.
+[ -n "$model" ]    || model="unknown"
+[ -n "$provider" ] || provider="unknown"
+
+# ---- 5. Locate the project root (walk up for .beads) -----------------------
+# Same discovery the read-side pack uses. Start from cwd in the payload, then
+# the gc rig root, then the process cwd. Walk up to 12 levels for a `.beads`.
+start_dir=""
+for cand in "$cwd_in" "$rig_root" "$PWD"; do
+  if [ -n "$cand" ] && [ -d "$cand" ]; then start_dir="$cand"; break; fi
+done
+[ -n "$start_dir" ] || start_dir="$PWD"
+
+proj_root=""
+d="$start_dir"
+i=0
+while [ -n "$d" ] && [ "$i" -lt 12 ]; do
+  if [ -d "$d/.beads" ]; then proj_root="$d"; break; fi
+  nd="$(dirname "$d")"
+  [ "$nd" = "$d" ] && break
+  d="$nd"
+  i=$((i + 1))
+done
+# No .beads anywhere up the tree: nothing to anchor telemetry to — exit clean.
+[ -n "$proj_root" ] || exit 0
+
+tel_dir="$proj_root/.beads/telemetry"
+mkdir -p "$tel_dir" 2>/dev/null || exit 0
+out_file="$tel_dir/invocations.jsonl"
+
+# ---- 6. Timestamp ----------------------------------------------------------
+ts="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)"
+[ -n "$ts" ] || ts="1970-01-01T00:00:00Z"
+
+# ---- 7. Build + append the kind="dispatch" record --------------------------
+# Cell key per DESIGN.md §2.4: provider::agent::shape::tier_id. At capture time
+# shape and tier_id are unknown (resolved by the engine from config); we emit
+# "unknown" placeholders so the key is well-formed and the engine can backfill.
+shape="unknown"
+tier_id="unknown"
+cell_key="${provider}::${agent}::${shape}::${tier_id}"
+
+# bead_id: the Stop payload has no bead id (gc binds work to a session, not a
+# bead, at this layer). We leave it empty and let the engine/harvester join via
+# session_id (DESIGN.md §5.1 "join key"; INTEGRATION (C): bead.metadata.session_id
+# joins a closed bead to this dispatch). session_id is the load-bearing key here.
+
+if [ "$have_jq" = "1" ]; then
+  # jq builds the object with correct escaping. Numbers are emitted only when
+  # present; absent token counts are omitted (the engine falls back to a
+  # representative budget per DESIGN.md §5.4).
+  jq -cn \
+    --arg sv   "$SCHEMA_VERSION" \
+    --arg ts   "$ts" \
+    --arg sid  "$session_id" \
+    --arg prov "$provider" \
+    --arg ag   "$agent" \
+    --arg agi  "$agent_instance" \
+    --arg rig  "$rig" \
+    --arg shp  "$shape" \
+    --arg tid  "$tier_id" \
+    --arg mdl  "$model" \
+    --arg ck   "$cell_key" \
+    --arg ev   "$hook_event" \
+    --arg ti   "$tok_in" \
+    --arg to   "$tok_out" \
+    '{
+       schema_version: $sv,
+       kind:           "dispatch",
+       ts:             $ts,
+       bead_id:        "",
+       session_id:     $sid,
+       provider:       $prov,
+       agent:          $ag,
+       agent_instance: $agi,
+       rig:            $rig,
+       shape:          $shp,
+       tier_id:        $tid,
+       model:          $mdl,
+       q_tol_class:    "unknown",
+       baseline_tier:  "unknown",
+       advised_tier:   "unknown",
+       forced_baseline:false,
+       cell_key:       $ck,
+       source:         ("hook:" + $ev)
+     }
+     | (if ($ti|length) > 0 then . + {tok_in:  ($ti|tonumber)} else . end)
+     | (if ($to|length) > 0 then . + {tok_out: ($to|tonumber)} else . end)' \
+    >> "$out_file" 2>/dev/null || true
+elif command -v python3 >/dev/null 2>&1; then
+  # python3 fallback: same record, JSON-safe.
+  SV="$SCHEMA_VERSION" TS="$ts" SID="$session_id" PROV="$provider" AG="$agent" \
+  AGI="$agent_instance" RIG="$rig" SHP="$shape" TID="$tier_id" MDL="$model" \
+  CK="$cell_key" EV="$hook_event" TI="$tok_in" TO="$tok_out" OUT="$out_file" \
+  python3 - <<'PY' 2>/dev/null || true
+import json, os
+rec = {
+    "schema_version": os.environ.get("SV", "advisor.v1"),
+    "kind": "dispatch",
+    "ts": os.environ.get("TS", ""),
+    "bead_id": "",
+    "session_id": os.environ.get("SID", ""),
+    "provider": os.environ.get("PROV", "unknown"),
+    "agent": os.environ.get("AG", "unknown"),
+    "agent_instance": os.environ.get("AGI", ""),
+    "rig": os.environ.get("RIG", ""),
+    "shape": os.environ.get("SHP", "unknown"),
+    "tier_id": os.environ.get("TID", "unknown"),
+    "model": os.environ.get("MDL", "unknown"),
+    "q_tol_class": "unknown",
+    "baseline_tier": "unknown",
+    "advised_tier": "unknown",
+    "forced_baseline": False,
+    "cell_key": os.environ.get("CK", ""),
+    "source": "hook:" + os.environ.get("EV", "Stop"),
+}
+for env_k, rec_k in (("TI", "tok_in"), ("TO", "tok_out")):
+    v = os.environ.get(env_k, "")
+    if v not in ("", "null"):
+        try:
+            rec[rec_k] = int(v)
+        except ValueError:
+            pass
+try:
+    with open(os.environ["OUT"], "a") as f:
+        f.write(json.dumps(rec, separators=(",", ":")) + "\n")
+except Exception:
+    pass
+PY
+fi
+# If neither jq nor python3 is available we simply emit nothing — never a
+# half-written/garbled line.
+
+# A capture failure must never break a stop.
+exit 0

--- a/model-advisor/install.sh
+++ b/model-advisor/install.sh
@@ -1,0 +1,501 @@
+#!/usr/bin/env bash
+# model-advisor — install lifecycle (reversible, idempotent).
+#
+#   install.sh (--town | --rig <name>) [--dry-run] [--city <path>] [--no-reload]
+#
+# Turns the model-advisor pack ON at one of two scopes:
+#   --town        city-wide: every agent gets the skill + (opt-in) the
+#                 use-model-advisor prompt fragment + the claude
+#                 Stop/SubagentStop telemetry hook (captures invocation records).
+#   --rig <name>  one rig only: that rig's agents get the skill + the hook.
+#
+# What it does (in order):
+#   1. Build the engine venv via setup.sh (skipped if .venv already present).
+#   2. Add the pack import to the correct config scope. A LOCAL in-tree pack is
+#      imported via a DIRECT config entry (the gastown pattern) — NOT via
+#      `gc import add`, which targets remote/git-backed packs and mis-resolves a
+#      local file:// source. So a surgical, backed-up edit writes:
+#        --town       ->  <city>/pack.toml   [imports.model-advisor]
+#        --rig <name> ->  <city>/city.toml   [rigs.imports.model-advisor] (under
+#                         the [[rigs]] entry whose name matches <name>)
+#      source is recorded relative to the city root (e.g. "packs/model-advisor").
+#   3. --town only: add the "use-model-advisor" discipline fragment to city.toml
+#      [agent_defaults] append_fragments — only if not already present (no
+#      gc-native command exists for this key, so a backed-up, surgical edit is
+#      used; the file is backed up once per run, only when the fragment actually
+#      needs adding). The [agent_defaults] table and/or the append_fragments
+#      array are created if absent. (This is the non-deprecated home; the old
+#      top-level global_fragments key is deprecated.)
+#   4. Trigger re-projection with `gc reload` so the claude overlay's
+#      Stop/SubagentStop hook is materialized + merged into projected settings.
+#   5. Verify: `gc lint`, the skill shows in `gc skill list`, the import is
+#      registered, and (best-effort) the projected .claude settings carry the
+#      telemetry hook.
+#
+# Idempotent: re-running is a no-op (each mutating step is guarded by a presence
+# check). Any config file it edits is backed up first. --dry-run prints the plan
+# and changes nothing. Fails loudly on unexpected state.
+#
+# Reverse with uninstall.sh (same scope flags).
+
+set -euo pipefail
+
+# Stripped-PATH guard (this environment sometimes ships a minimal PATH).
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${HOME}/go/bin:${HOME}/.local/bin:${PATH}"
+
+PACK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PACK_NAME="model-advisor"     # import binding name + skill prefix
+IMPORT_NAME="model-advisor"
+# The single discipline prompt-fragment this pack ships. It has a file at
+# template-fragments/<name>.template.md and is wired into city.toml
+# [agent_defaults] append_fragments on --town scope.
+FRAGMENTS=("use-model-advisor")
+SKILL_QUALIFIED="${PACK_NAME}.use-model-advisor"
+HOOK_MARKER="model-advisor/hooks/capture-invocation.sh"   # unique substring of our hook command
+
+# ---- arg parsing -----------------------------------------------------------
+SCOPE=""          # "town" | "rig"
+RIG=""
+DRY_RUN=0
+NO_RELOAD=0
+CITY=""
+
+die()  { printf 'install.sh: error: %s\n' "$*" >&2; exit 1; }
+info() { printf '  %s\n' "$*"; }
+step() { printf '\n==> %s\n' "$*"; }
+run()  { # echo + execute, or just echo under --dry-run
+  if [ "$DRY_RUN" -eq 1 ]; then printf '    [dry-run] %s\n' "$*"; else printf '    + %s\n' "$*"; eval "$@"; fi
+}
+
+usage() {
+  sed -n '2,40p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+  exit "${1:-0}"
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --town)      SCOPE="town"; shift ;;
+    --rig)       SCOPE="rig"; RIG="${2:-}"; [ -n "$RIG" ] || die "--rig requires a rig name"; shift 2 ;;
+    --rig=*)     SCOPE="rig"; RIG="${1#*=}"; shift ;;
+    --dry-run)   DRY_RUN=1; shift ;;
+    --no-reload) NO_RELOAD=1; shift ;;
+    --city)      CITY="${2:-}"; [ -n "$CITY" ] || die "--city requires a path"; shift 2 ;;
+    --city=*)    CITY="${1#*=}"; shift ;;
+    -h|--help)   usage 0 ;;
+    *)           die "unknown argument: $1 (try --help)" ;;
+  esac
+done
+
+[ -n "$SCOPE" ] || die "choose a scope: --town or --rig <name>"
+
+# ---- locate the city -------------------------------------------------------
+# Default: the city that physically contains this pack (…/<city>/packs/model-advisor).
+if [ -z "$CITY" ]; then
+  CITY="$(cd "$PACK_DIR/../.." && pwd)"
+fi
+[ -f "$CITY/city.toml" ] || die "no city.toml at city root: $CITY (pass --city <path>)"
+CITY="$(cd "$CITY" && pwd)"
+
+# Source path recorded in the import: relative to the city root if the pack
+# lives under it (matches how gastown is referenced — a bare relative path with
+# no "./" prefix, e.g. "packs/model-advisor"), else absolute.
+if [ "${PACK_DIR#"$CITY"/}" != "$PACK_DIR" ]; then
+  PACK_SRC="${PACK_DIR#"$CITY"/}"
+else
+  PACK_SRC="$PACK_DIR"
+fi
+
+GC=(gc --city "$CITY")
+
+step "model-advisor install"
+info "scope:     $SCOPE${RIG:+ ($RIG)}"
+info "pack:      $PACK_DIR"
+info "city:      $CITY"
+info "import as: $IMPORT_NAME  (source: $PACK_SRC)"
+[ "$DRY_RUN" -eq 1 ] && info "MODE:      DRY RUN (no changes will be made)"
+
+command -v gc >/dev/null 2>&1 || die "gc not found on PATH"
+
+# For --rig, fail loudly now if the rig isn't configured, before any other step
+# runs. `gc import list --rig <name>` exits non-zero for an unknown rig.
+if [ "$SCOPE" = "rig" ]; then
+  if ! "${GC[@]}" import list --rig "$RIG" >/dev/null 2>&1; then
+    die "rig \"$RIG\" not found in $CITY/city.toml (configure the rig first)"
+  fi
+fi
+
+# ---- helpers ---------------------------------------------------------------
+backup_file() { # back up $1 once per run to <file>.model-advisor.bak.<ts>
+  local f="$1"
+  [ -f "$f" ] || return 0
+  local b="${f}.model-advisor.bak.$(date +%Y%m%d%H%M%S)"
+  if [ "$DRY_RUN" -eq 1 ]; then printf '    [dry-run] backup %s -> %s\n' "$f" "$b"; return 0; fi
+  cp -p "$f" "$b"; printf '    backup: %s\n' "$b"
+}
+
+import_present() { # 0 if IMPORT_NAME is registered at the active scope.
+  # gc import list reports direct-config imports (the gastown style) too, so it
+  # is the primary signal. Fall back to a config grep for the [..imports.NAME]
+  # table in case the catalog is unbuilt (stopped/fresh city).
+  if [ "$SCOPE" = "rig" ]; then
+    if "${GC[@]}" import list --rig "$RIG" 2>/dev/null | awk '{print $1}' | grep -qx "$IMPORT_NAME"; then
+      return 0
+    fi
+    rig_import_in_config "$RIG"
+  else
+    if "${GC[@]}" import list 2>/dev/null | awk '{print $1}' | grep -qx "$IMPORT_NAME"; then
+      return 0
+    fi
+    grep -Eq "^\[imports\.${IMPORT_NAME}\][[:space:]]*$" "$CITY/pack.toml" 2>/dev/null
+  fi
+}
+
+rig_import_in_config() { # 0 if [rigs.imports.IMPORT_NAME] exists under rig $1
+  python3 - "$CITY/city.toml" "$1" "$IMPORT_NAME" <<'PY'
+import sys, re
+path, rig, name = sys.argv[1], sys.argv[2], sys.argv[3]
+lines = open(path).read().splitlines(keepends=True)
+starts = [i for i, l in enumerate(lines) if re.match(r'^\[\[rigs\]\]\s*$', l)]
+for k, s in enumerate(starts):
+    end = starts[k + 1] if k + 1 < len(starts) else len(lines)
+    for j in range(s + 1, end):
+        if re.match(r'^\[', lines[j]) and not re.match(r'^\[(\[rigs\]\]|rigs(\.|\]))', lines[j]):
+            end = j; break
+    named = None
+    for j in range(s + 1, end):
+        m = re.match(r'^\s*name\s*=\s*["\'](.+?)["\']\s*$', lines[j])
+        if m:
+            named = m.group(1); break
+    if named != rig:
+        continue
+    hdr = re.compile(r'^\[rigs\.imports\.%s\]\s*$' % re.escape(name))
+    if any(hdr.match(lines[j]) for j in range(s + 1, end)):
+        sys.exit(0)
+    sys.exit(1)
+sys.exit(1)
+PY
+}
+
+fragment_present() { # 0 if fragment $1 is already in [agent_defaults] append_fragments
+  python3 - "$CITY/city.toml" "$1" <<'PY'
+import sys, re
+path, frag = sys.argv[1], sys.argv[2]
+try:
+    src = open(path).read()
+except OSError:
+    sys.exit(1)
+# Scan only the [agent_defaults] table body for an append_fragments array that
+# already lists `frag`. (global_fragments — the deprecated key — is ignored on
+# purpose: a legacy entry there must NOT mask the need to add the new one.)
+lines = src.splitlines(keepends=True)
+hdr = re.compile(r'^\[agent_defaults\]\s*$')
+start = next((i for i, l in enumerate(lines) if hdr.match(l)), None)
+if start is None:
+    sys.exit(1)
+end = len(lines)
+for j in range(start + 1, len(lines)):
+    if re.match(r'^\[', lines[j]):
+        end = j; break
+body = "".join(lines[start + 1:end])
+m = re.search(r'(?m)^\s*append_fragments\s*=\s*(\[[^\]]*\])', body)
+if not m:
+    sys.exit(1)
+items = [x.strip().strip('"').strip("'") for x in m.group(1)[1:-1].split(',') if x.strip()]
+sys.exit(0 if frag in items else 1)
+PY
+}
+
+edit_fragment() { # add|remove fragment $2 in [agent_defaults] append_fragments (idempotent)
+  # Surgical, format-preserving text edit of city.toml. The non-deprecated home
+  # for an opt-in discipline fragment is the [agent_defaults] table's
+  # append_fragments array (gc warns that the old top-level global_fragments is
+  # deprecated). We create the [agent_defaults] table and/or the append_fragments
+  # array if absent, and never double-add. Everything outside the edited array /
+  # the one inserted line is preserved byte-for-byte, so add<->remove round-trips.
+  python3 - "$CITY/city.toml" "$1" "$2" <<'PY'
+import sys, re
+path, action, frag = sys.argv[1], sys.argv[2], sys.argv[3]
+src = open(path).read()
+lines = src.splitlines(keepends=True)
+
+def find_table(name):
+    hdr = re.compile(r'^\[%s\]\s*$' % re.escape(name))
+    s = next((i for i, l in enumerate(lines) if hdr.match(l)), None)
+    if s is None:
+        return None, None
+    e = len(lines)
+    for j in range(s + 1, len(lines)):
+        if re.match(r'^\[', lines[j]):
+            e = j; break
+    return s, e
+
+start, end = find_table("agent_defaults")
+
+if action == "add":
+    if start is None:
+        # No [agent_defaults] table: append one at EOF carrying the array.
+        sep = "" if (src == "" or src.endswith("\n")) else "\n"
+        block = '%s\n[agent_defaults]\nappend_fragments = ["%s"]\n' % (sep, frag)
+        open(path, "w").write(src + block)
+        sys.exit(0)
+    body_lines = lines[start + 1:end]
+    body = "".join(body_lines)
+    m = re.search(r'(?m)^(\s*append_fragments\s*=\s*)(\[[^\]]*\])', body)
+    if m:
+        items = [x.strip().strip('"').strip("'")
+                 for x in m.group(2)[1:-1].split(',') if x.strip()]
+        if frag in items:
+            sys.exit(0)
+        items.append(frag)
+        new_arr = "[" + ", ".join('"%s"' % x for x in items) + "]"
+        new_body = body[:m.start(2)] + new_arr + body[m.end(2):]
+        open(path, "w").write("".join(lines[:start + 1]) + new_body + "".join(lines[end:]))
+        sys.exit(0)
+    # Table exists but no append_fragments array: insert the line right after the
+    # [agent_defaults] header (matching the header's indentation, normally none).
+    insert = 'append_fragments = ["%s"]\n' % frag
+    out = lines[:start + 1] + [insert] + lines[start + 1:]
+    open(path, "w").write("".join(out))
+    sys.exit(0)
+
+# action == remove
+if start is None:
+    sys.exit(0)
+body_lines = lines[start + 1:end]
+body = "".join(body_lines)
+m = re.search(r'(?m)^(\s*append_fragments\s*=\s*)(\[[^\]]*\])', body)
+if not m:
+    sys.exit(0)
+items = [x.strip().strip('"').strip("'")
+         for x in m.group(2)[1:-1].split(',') if x.strip()]
+if frag not in items:
+    sys.exit(0)
+items = [x for x in items if x != frag]
+new_arr = "[" + ", ".join('"%s"' % x for x in items) + "]"
+new_body = body[:m.start(2)] + new_arr + body[m.end(2):]
+open(path, "w").write("".join(lines[:start + 1]) + new_body + "".join(lines[end:]))
+PY
+}
+
+edit_import() { # add|remove a DIRECT-config import (gastown style); idempotent.
+  # Local in-tree packs are imported by a direct config entry, NOT `gc import
+  # add` (which is for remote/git-backed packs and would mis-resolve a file://
+  # source). Mirrors edit_fragment: surgical text edit, rest of file byte-exact,
+  # so add<->remove round-trips perfectly.
+  #   town: file=pack.toml, target [imports] -> [imports.IMPORT_NAME]
+  #   rig : file=city.toml, target the [rigs.imports] of the [[rigs]] named $3,
+  #         -> [rigs.imports.IMPORT_NAME]
+  # args: <action> <file> <import_name> <source> [<rig_name>]
+  python3 - "$2" "$1" "$3" "$4" "${5:-}" <<'PY'
+import sys, re
+path, action, name, source, rig = sys.argv[1:6]
+rig = rig or None
+
+def fail(msg):
+    sys.stderr.write("edit_import: %s\n" % msg); sys.exit(3)
+
+lines = open(path).read().splitlines(keepends=True)
+
+if rig is None:
+    table = "imports"
+    anchor = next((i for i, l in enumerate(lines) if re.match(r'^\[imports\]\s*$', l)), None)
+    if anchor is None: fail("[imports] table not found in %s" % path)
+    hi = len(lines)
+else:
+    table = "rigs.imports"
+    starts = [i for i, l in enumerate(lines) if re.match(r'^\[\[rigs\]\]\s*$', l)]
+    if not starts: fail("no [[rigs]] blocks in %s" % path)
+    target_start = None; hi = len(lines)
+    for k, s in enumerate(starts):
+        end = starts[k + 1] if k + 1 < len(starts) else len(lines)
+        for j in range(s + 1, end):
+            if re.match(r'^\[', lines[j]) and not re.match(r'^\[(\[rigs\]\]|rigs(\.|\]))', lines[j]):
+                end = j; break
+        named = None
+        for j in range(s + 1, end):
+            m = re.match(r'^\s*name\s*=\s*["\'](.+?)["\']\s*$', lines[j])
+            if m: named = m.group(1); break
+        if named == rig:
+            target_start, hi = s, end; break
+    if target_start is None: fail('no [[rigs]] block with name = "%s" in %s' % (rig, path))
+    anchor = next((i for i in range(target_start, hi) if re.match(r'^\[rigs\.imports\]\s*$', lines[i])), None)
+    if anchor is None: fail('[rigs.imports] not found under rig "%s" in %s' % (rig, path))
+
+header = "[%s.%s]" % (table, name)
+sub = re.compile(r'^\[%s\.%s\]\s*$' % (re.escape(table), re.escape(name)))
+existing = next((i for i in range(anchor, hi) if sub.match(lines[i])), None)
+
+if action == "add":
+    if existing is not None: sys.exit(0)
+    lines.insert(anchor + 1, "%s\nsource = \"%s\"\n" % (header, source))
+    open(path, "w").write("".join(lines))
+elif action == "remove":
+    if existing is None: sys.exit(0)
+    end = existing + 1
+    if end < len(lines) and re.match(r'^\s*source\s*=', lines[end]): end += 1
+    del lines[existing:end]
+    open(path, "w").write("".join(lines))
+else:
+    fail("unknown action: %s" % action)
+PY
+}
+
+# ---- step 1: venv ----------------------------------------------------------
+step "1/5  engine venv"
+if [ -x "$PACK_DIR/.venv/bin/python" ]; then
+  info "already present: $PACK_DIR/.venv (skipping setup.sh)"
+else
+  run "bash \"$PACK_DIR/setup.sh\""
+  [ "$DRY_RUN" -eq 1 ] && info "(dry-run) would build venv via setup.sh"
+fi
+
+# ---- step 2: import --------------------------------------------------------
+# Local in-tree packs are imported via a DIRECT config entry (the gastown
+# pattern), NOT `gc import add` — that command is for remote/git-backed packs
+# and mis-resolves a local file:// source. So we hand-edit the right config,
+# surgically and backed-up (see edit_import).
+#   rig : <city>/city.toml -> [rigs.imports.model-advisor] under the [[rigs]] named $RIG
+#   town: <city>/pack.toml -> [imports.model-advisor]
+step "2/5  register pack import ($SCOPE scope)"
+if import_present; then
+  info "import \"$IMPORT_NAME\" already registered — no-op"
+else
+  if [ "$SCOPE" = "rig" ]; then
+    IMPORT_CFG="$CITY/city.toml"
+    backup_file "$IMPORT_CFG"
+    if [ "$DRY_RUN" -eq 1 ]; then
+      info "[dry-run] add [rigs.imports.$IMPORT_NAME] (source = \"$PACK_SRC\") under rig \"$RIG\" in $IMPORT_CFG"
+    else
+      edit_import add "$IMPORT_CFG" "$IMPORT_NAME" "$PACK_SRC" "$RIG" \
+        || die "failed to add [rigs.imports.$IMPORT_NAME] under rig \"$RIG\" in $IMPORT_CFG"
+      info "added [rigs.imports.$IMPORT_NAME] (source = \"$PACK_SRC\") under rig \"$RIG\""
+    fi
+  else
+    IMPORT_CFG="$CITY/pack.toml"
+    backup_file "$IMPORT_CFG"
+    if [ "$DRY_RUN" -eq 1 ]; then
+      info "[dry-run] add [imports.$IMPORT_NAME] (source = \"$PACK_SRC\") to $IMPORT_CFG"
+    else
+      edit_import add "$IMPORT_CFG" "$IMPORT_NAME" "$PACK_SRC" \
+        || die "failed to add [imports.$IMPORT_NAME] to $IMPORT_CFG"
+      info "added [imports.$IMPORT_NAME] (source = \"$PACK_SRC\")"
+    fi
+  fi
+fi
+
+# ---- step 3: agent_defaults append_fragments (town only) -------------------
+# Add the pack's discipline fragment to city.toml [agent_defaults]
+# append_fragments (the non-deprecated home), skipping it if already present
+# (idempotent). The [agent_defaults] table / the append_fragments array are
+# created if absent. The file is backed up at most once per run, and only when
+# the fragment actually needs adding — never under --dry-run, and never when it
+# is already in place.
+step "3/5  prompt fragment ([agent_defaults] append_fragments)"
+if [ "$SCOPE" = "town" ]; then
+  backed_up=0
+  for frag in "${FRAGMENTS[@]}"; do
+    if fragment_present "$frag"; then
+      info "\"$frag\" already in [agent_defaults] append_fragments — no-op"
+    elif [ "$DRY_RUN" -eq 1 ]; then
+      info "[dry-run] add \"$frag\" to [agent_defaults] append_fragments in $CITY/city.toml"
+    else
+      if [ "$backed_up" -eq 0 ]; then backup_file "$CITY/city.toml"; backed_up=1; fi
+      edit_fragment add "$frag"
+      info "added \"$frag\" to [agent_defaults] append_fragments"
+    fi
+  done
+else
+  info "rig scope: append_fragments is city-wide and not touched"
+  info "(the rig's agents still get the skill + telemetry hook from the import)"
+fi
+
+# ---- step 4: re-project ----------------------------------------------------
+step "4/5  re-project (gc reload)"
+if [ "$NO_RELOAD" -eq 1 ]; then
+  info "--no-reload: skipping. Run 'gc reload' (or restart the city) to apply."
+elif [ "$DRY_RUN" -eq 1 ]; then
+  info "[dry-run] gc reload  (materializes the claude overlay + merges Stop/SubagentStop)"
+else
+  if "${GC[@]}" reload >/dev/null 2>&1; then
+    info "gc reload: ok"
+  else
+    info "gc reload returned non-zero (city may be stopped). Projection will"
+    info "happen on the next 'gc start' / 'gc rig boot'. Continuing."
+  fi
+fi
+
+# ---- step 5: verify --------------------------------------------------------
+step "5/5  verify"
+if [ "$DRY_RUN" -eq 1 ]; then
+  info "[dry-run] would verify: gc lint, gc skill list, import registered, hook projected"
+  step "model-advisor install — DRY RUN complete (no changes made)"
+  exit 0
+fi
+
+fail=0
+
+# 5a. lint
+if "${GC[@]}" lint "$PACK_DIR" >/dev/null 2>&1; then
+  info "lint: ok"
+else
+  info "lint: FAILED"; "${GC[@]}" lint "$PACK_DIR" || true; fail=1
+fi
+
+# 5b. import registered
+if import_present; then info "import: registered ($IMPORT_NAME)"; else info "import: MISSING"; fail=1; fi
+
+# 5c. skill visible (binding-qualified). Town: city scope. Rig: the rig-scope
+#     skill shows under --rig list.
+if [ "$SCOPE" = "rig" ]; then
+  if "${GC[@]}" skill list --rig "$RIG" 2>/dev/null | grep -q "$SKILL_QUALIFIED"; then
+    info "skill: visible ($SKILL_QUALIFIED, rig $RIG)"
+  else
+    info "skill: not yet visible at rig scope (it lands when the rig's agents project)"
+  fi
+else
+  # The skill catalog is rebuilt lazily; on a freshly-bootstrapped or stopped
+  # city the first `gc skill list` can race the catalog build, so retry once.
+  if "${GC[@]}" skill list 2>/dev/null | grep -q "$SKILL_QUALIFIED" \
+     || "${GC[@]}" skill list 2>/dev/null | grep -q "$SKILL_QUALIFIED"; then
+    info "skill: visible ($SKILL_QUALIFIED)"
+  else
+    # Soft: the import is registered (hard-checked above); the catalog
+    # finishes building on the next 'gc start' / reconcile.
+    info "skill: not yet listed (catalog builds on next gc start; import is registered)"
+  fi
+fi
+
+# 5d. fragment (town only) — must be present
+if [ "$SCOPE" = "town" ]; then
+  for frag in "${FRAGMENTS[@]}"; do
+    if fragment_present "$frag"; then info "fragment: \"$frag\" in [agent_defaults] append_fragments"; else info "fragment: \"$frag\" MISSING"; fail=1; fi
+  done
+fi
+
+# 5e. telemetry hook projected (best-effort — only present once a claude agent
+#     has projected; absence is not fatal if the city is stopped).
+hook_hits=0
+while IFS= read -r f; do
+  if grep -q "$HOOK_MARKER" "$f" 2>/dev/null; then hook_hits=$((hook_hits+1)); fi
+done < <(find "$CITY/.gc/agents" "$CITY/.claude" "$CITY/.gc/settings.json" \
+              -name 'settings.json' 2>/dev/null)
+if [ "$hook_hits" -gt 0 ]; then
+  info "hook: Stop/SubagentStop telemetry hook projected in $hook_hits settings file(s)"
+else
+  info "hook: not yet in any projected settings (expected if the city is stopped;"
+  info "      it materializes on the next agent session start / gc start)"
+fi
+
+if [ "$SCOPE" = "rig" ]; then REVERSE_FLAGS="--rig $RIG"; else REVERSE_FLAGS="--town"; fi
+echo
+if [ "$fail" -eq 0 ]; then
+  step "model-advisor install complete ($SCOPE${RIG:+ $RIG})"
+  info "Agents will record invocation telemetry; consult 'advisor advise <agent> <shape>'"
+  info "before dispatching meaningful work to pick the cost-minimal tier."
+  info "Reverse with: $PACK_DIR/uninstall.sh $REVERSE_FLAGS"
+  exit 0
+else
+  step "model-advisor install finished WITH WARNINGS ($SCOPE${RIG:+ $RIG})"
+  info "Review the lines marked FAILED/MISSING above."
+  exit 1
+fi

--- a/model-advisor/modeladvisor/__init__.py
+++ b/model-advisor/modeladvisor/__init__.py
@@ -1,0 +1,56 @@
+"""model-advisor — Conservative Constrained Thompson Sampling (CC-TS) model-tier advisor.
+
+Clean-room implementation of the CC-TS decision rule described in
+``docs/DESIGN.md``. The advisor recommends the *cost-minimal* model tier for each
+``(provider, agent, shape, tier)`` cell, subject to a per-task
+quality-preservation guarantee.
+
+Public surface (the pieces other beads / the CLI build on):
+
+- :mod:`modeladvisor.config`  — load/validate ``advisor.toml`` into an
+  :class:`~modeladvisor.config.AdvisorConfig` (roster, shapes, tolerance
+  classes, hyperparameters).
+- :mod:`modeladvisor.store`   — the cell store: build per-cell ``Beta(a, b)``
+  posteriors from ``.beads/telemetry/invocations.jsonl`` and persist/rebuild the
+  ``advisor-cells.json`` cache.
+- :mod:`modeladvisor.engine`  — :func:`~modeladvisor.engine.recommend` and
+  :func:`~modeladvisor.engine.inspect`, the pure/deterministic decision rule.
+
+The engine is stdlib-only (no numpy/scipy): it uses a Wilson-style normal lower
+confidence bound on the Beta posterior, exactly as DESIGN §5.2 specifies for the
+v1 production default.
+"""
+
+from __future__ import annotations
+
+SCHEMA_VERSION = "advisor.v1"
+
+# Re-exported for convenience so callers can ``from modeladvisor import ...``.
+from modeladvisor.config import (  # noqa: E402  (re-export after module docstring)
+    AdvisorConfig,
+    Hyperparams,
+    Shape,
+    Tier,
+    ToleranceClass,
+    load_config,
+    default_config,
+    SAMPLE_TOML,
+)
+from modeladvisor.store import Cell, CellStore  # noqa: E402
+from modeladvisor.engine import recommend, inspect  # noqa: E402
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "AdvisorConfig",
+    "Hyperparams",
+    "Shape",
+    "Tier",
+    "ToleranceClass",
+    "load_config",
+    "default_config",
+    "SAMPLE_TOML",
+    "Cell",
+    "CellStore",
+    "recommend",
+    "inspect",
+]

--- a/model-advisor/modeladvisor/autoapply.py
+++ b/model-advisor/modeladvisor/autoapply.py
@@ -1,0 +1,535 @@
+"""Per-agent **auto-apply** — automate the v1 ``apply`` as an evidence-gated loop.
+
+This is bead ``bh-917`` (v2a): a conservative, audit-first automation of the
+single-agent ``cli.apply`` action.  Where ``apply`` sets *one* agent's ``model``
+config field for *one* shape on demand, :func:`auto_apply` sweeps **every
+configured agent**, computes a *conservative per-agent tier*, and writes the
+``model`` field only when the evidence is strong enough that the engine's own
+gate has already admitted the change.  It is pack-only: it depends solely on the
+sibling :mod:`modeladvisor.engine` / :mod:`modeladvisor.config` /
+:mod:`modeladvisor.store` modules and reuses :mod:`modeladvisor.cli`'s
+format-preserving config editor (no gc-core dependency).
+
+--------------------------------------------------------------------------- #
+The per-agent tier policy (the heart of v2a)
+--------------------------------------------------------------------------- #
+
+An agent runs **one** model, but may serve **several shapes** (DESIGN §2.2:
+``polecat → {implement, lookup}``, ``refinery → {review, judge}``, …).  The
+engine's :func:`recommend` decides a tier *per (agent, shape) cell*; auto-apply
+must collapse those into a single per-agent model without ever under-serving a
+shape.  The rule:
+
+    For each of the agent's canonical shapes, take the engine's per-shape
+    recommended tier.  The agent's **conservative tier** is the *safest
+    (most-capable) tier among them* — i.e. ``argmax`` over the cost order.
+
+Why ``max`` (most-capable), not ``min`` (cheapest)?  Because a single model has
+to satisfy *every* shape the agent serves.  Picking the most-capable per-shape
+recommendation guarantees **no shape is under-served**.  The engine only returns
+a *cheaper-than-baseline* tier for a shape when that shape's one-sided lower
+confidence bound has credibly cleared tolerance (DESIGN §1.3 Layer 2); a shape
+with thin/cold evidence still recommends the baseline ``tier*``.  Therefore the
+``max`` lands **below baseline only when ALL of the agent's shapes have
+independently earned a cheaper tier** — exactly the contract "unless ALL the
+agent's shapes credibly clear tolerance for a cheaper tier."  If even one shape
+is still cold, the ``max`` is the baseline and the agent is left untouched.  This
+is the conservative property lifted from the cell to the agent: no silent
+downgrade before evidence.
+
+--------------------------------------------------------------------------- #
+The apply gate (when a computed tier is actually written)
+--------------------------------------------------------------------------- #
+
+A per-agent change is written only when **all** hold:
+
+  (i)   the chosen tier's model **differs** from the agent's current ``model``
+        config (idempotent no-op refusal otherwise);
+  (ii)  the agent is **not Critical-pinned** — if *any* of its shapes resolves
+        to a ``Critical`` tolerance class (``q_tol = 0``, ``M = ∞``) or carries
+        the ``force_baseline`` safety hatch, the agent is **blocked**: never
+        touched, regardless of evidence (DESIGN §1.2 / §7.4 — the design
+        contract operators rely on to let the advisor drive routing at all);
+  (iii) the change is **evidence-admissible**:
+          * a **downgrade** (chosen tier cheaper than the baseline ``tier*``)
+            is admissible *by construction* — it can only arise when every
+            shape's gate admitted at least this-cheap a tier, so the evidence is
+            already strong.  A thin-evidence downgrade is impossible because the
+            engine never returns a sub-baseline tier without gate admission.
+          * an **upgrade** (chosen tier ≥ the agent's *current* tier) is always
+            admissible — moving to a more-capable model is the safe direction
+            (e.g. evidence retreated, or an operator hand-set a too-cheap model
+            and the advisor pulls it back toward the known-good frontier).
+        We **never auto-downgrade on thin evidence**; the only sub-baseline
+        writes are ones the engine's gate already certified.
+
+Idempotence & backups: a config file is backed up **once per run** (the first
+time any agent that lives in it is about to be written), to a timestamped
+``.advisor-bak-*`` sibling, reusing :func:`cli.backup_file`.  Re-running with no
+new evidence is a clean series of no-op refusals that write nothing.  ``dry_run``
+(the default-safe mode) computes and reports the full plan but never opens a file
+for writing and never creates a backup.
+
+The result is a structured, per-agent report (``current → chosen``, the binding
+shape and reason, and an ``applied`` / ``skipped`` / ``blocked`` / ``noop`` /
+``error`` status) — the audit surface, mirroring the engine's ``reasons``
+contract (DESIGN §1.4 property 3).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Optional, Sequence
+
+from modeladvisor import cli as _cli
+
+# Per-agent outcome codes (stable; the CLI / JSON consumers key on these).
+STATUS_APPLIED = "applied"  # config written: model changed
+STATUS_NOOP = "noop"  # chosen model already in effect (idempotent)
+STATUS_BLOCKED = "blocked"  # Critical / force_baseline agent — never touched
+STATUS_SKIPPED = "skipped"  # a change was computed but the gate withheld it
+STATUS_DRYRUN = "dry-run"  # a change is planned but --dry-run is in effect
+STATUS_ERROR = "error"  # could not resolve config / compute (per-agent isolated)
+
+
+@dataclass
+class AgentDecision:
+    """The auto-apply decision + audit trail for one agent."""
+
+    agent: str
+    status: str
+    current_model: Optional[str] = None
+    chosen_model: Optional[str] = None
+    chosen_tier: Optional[str] = None
+    baseline_tier: Optional[str] = None
+    #: The shape whose per-shape recommendation set the conservative tier.
+    binding_shape: Optional[str] = None
+    #: Direction of the change relative to the *current* model: "down"|"up"|None.
+    direction: Optional[str] = None
+    reason: str = ""
+    #: Per-shape recommended tiers (audit): {shape: tier_id}.
+    per_shape: dict = field(default_factory=dict)
+    #: Whether any of the agent's shapes is Critical / force_baseline.
+    critical: bool = False
+    config_path: Optional[str] = None
+    config_scope: Optional[str] = None
+    backup_path: Optional[str] = None
+
+    @property
+    def changed(self) -> bool:
+        return self.status == STATUS_APPLIED
+
+    def to_dict(self) -> dict:
+        return {
+            "agent": self.agent,
+            "status": self.status,
+            "current_model": self.current_model,
+            "chosen_model": self.chosen_model,
+            "chosen_tier": self.chosen_tier,
+            "baseline_tier": self.baseline_tier,
+            "binding_shape": self.binding_shape,
+            "direction": self.direction,
+            "reason": self.reason,
+            "per_shape": dict(self.per_shape),
+            "critical": self.critical,
+            "config_path": self.config_path,
+            "config_scope": self.config_scope,
+            "backup_path": self.backup_path,
+        }
+
+
+@dataclass
+class AutoApplyReport:
+    """The whole-run report: per-agent decisions + a roll-up summary."""
+
+    scope: str
+    dry_run: bool
+    provider: str
+    decisions: list = field(default_factory=list)
+
+    # ---- roll-up counters -------------------------------------------------- #
+    def count(self, status: str) -> int:
+        return sum(1 for d in self.decisions if d.status == status)
+
+    @property
+    def applied(self) -> list:
+        return [d for d in self.decisions if d.status == STATUS_APPLIED]
+
+    @property
+    def any_applied(self) -> bool:
+        return any(d.status == STATUS_APPLIED for d in self.decisions)
+
+    def summary(self) -> dict:
+        return {
+            "agents": len(self.decisions),
+            STATUS_APPLIED: self.count(STATUS_APPLIED),
+            STATUS_DRYRUN: self.count(STATUS_DRYRUN),
+            STATUS_NOOP: self.count(STATUS_NOOP),
+            STATUS_SKIPPED: self.count(STATUS_SKIPPED),
+            STATUS_BLOCKED: self.count(STATUS_BLOCKED),
+            STATUS_ERROR: self.count(STATUS_ERROR),
+        }
+
+    def to_dict(self) -> dict:
+        return {
+            "scope": self.scope,
+            "dry_run": self.dry_run,
+            "provider": self.provider,
+            "summary": self.summary(),
+            "decisions": [d.to_dict() for d in self.decisions],
+        }
+
+
+# --------------------------------------------------------------------------- #
+# Cost-order helpers (the "≺" order is the position in cfg.tier_ids)            #
+# --------------------------------------------------------------------------- #
+
+
+def _rank(cfg: Any, tier_id: str) -> int:
+    """Position of ``tier_id`` in the cost order (0 = cheapest). -1 if unknown."""
+    ids = list(cfg.tier_ids)
+    return ids.index(tier_id) if tier_id in ids else -1
+
+
+def _model_to_tier(cfg: Any, model: Optional[str]) -> Optional[str]:
+    """Reverse-map a concrete ``model`` string to its roster tier id (or None)."""
+    if not model:
+        return None
+    for t in cfg.tiers:
+        if t.model == model:
+            return t.tier_id
+    return None
+
+
+def _agents_in_scope(cfg: Any, *, scope: str, agents: Optional[Sequence[str]]) -> list:
+    """The base agent names to sweep.
+
+    ``scope`` is advisory metadata for the report (``"town"`` / ``"rig:<n>"``);
+    the actual agent set comes from the config's declared agents (``agent_shapes``
+    keys) unless an explicit ``agents`` list is supplied.  The advisor keys cells
+    by **base** agent name (rig-pooled, DESIGN §2.4), so the same per-agent model
+    decision applies whether the operator scopes the *write* at town or rig level
+    — the rig narrowing happens in the config resolver, not here.
+    """
+    if agents:
+        return list(agents)
+    declared = getattr(cfg, "agent_shapes", None) or {}
+    return sorted(declared.keys())
+
+
+# --------------------------------------------------------------------------- #
+# Per-agent decision                                                            #
+# --------------------------------------------------------------------------- #
+
+
+def decide_agent(
+    agent: str,
+    cfg: Any,
+    store: Any,
+    engine: Any,
+    *,
+    provider: str,
+) -> AgentDecision:
+    """Compute the conservative per-agent tier + apply intent for one agent.
+
+    Pure (no I/O, no config-file read): runs the engine over each canonical
+    shape, takes the safest (most-capable) per-shape recommendation, and records
+    the binding shape + direction.  The *current model* and the actual write
+    happen in :func:`auto_apply`, which owns the file editor.
+    """
+    shapes = list(cfg.canonical_shapes_for(agent))
+    if not shapes:
+        return AgentDecision(
+            agent=agent,
+            status=STATUS_SKIPPED,
+            reason="agent has no canonical shapes configured",
+        )
+
+    # Critical / force-baseline detection: if ANY shape is pinned, the agent is
+    # blocked from auto-apply entirely (belt-and-braces with the engine, which
+    # already refuses to downgrade such a cell).
+    critical_shapes = []
+    for shp in shapes:
+        try:
+            if cfg.tol_class_for(agent, shp).is_critical or cfg.is_forced_baseline(agent, shp):
+                critical_shapes.append(shp)
+        except Exception:
+            # An unknown shape/class shouldn't abort the whole agent; treat as
+            # non-critical and let the engine call below surface any real error.
+            continue
+    is_critical = bool(critical_shapes)
+
+    # Per-shape recommendations → safest (max-rank) tier.
+    per_shape: dict[str, str] = {}
+    safest_tier: Optional[str] = None
+    safest_rank = -1
+    binding_shape: Optional[str] = None
+    baseline_tier: Optional[str] = None
+    for shp in shapes:
+        rec = engine.recommend(agent, shp, cfg, store, provider=provider)
+        tid = _cli._get(rec, "tier_id")
+        if baseline_tier is None:
+            reasons = _cli._get(rec, "reasons", {}) or {}
+            cell = reasons.get("cell", {}) if isinstance(reasons, dict) else {}
+            baseline_tier = cell.get("baseline_tier") or cfg.baseline_tier_id_for(agent, shp)
+        per_shape[shp] = tid
+        r = _rank(cfg, tid)
+        if r > safest_rank:
+            safest_rank = r
+            safest_tier = tid
+            binding_shape = shp
+
+    chosen_tier = safest_tier
+    chosen_model = cfg.tier(chosen_tier).model if chosen_tier else None
+
+    decision = AgentDecision(
+        agent=agent,
+        status=STATUS_SKIPPED,  # provisional; resolved by auto_apply once current is known
+        chosen_tier=chosen_tier,
+        chosen_model=chosen_model,
+        baseline_tier=baseline_tier,
+        binding_shape=binding_shape,
+        per_shape=per_shape,
+        critical=is_critical,
+    )
+
+    if is_critical:
+        decision.status = STATUS_BLOCKED
+        decision.reason = (
+            f"Critical/force_baseline agent (shapes: {', '.join(critical_shapes)}) — "
+            "never auto-applied; baseline is the only feasible tier."
+        )
+    return decision
+
+
+# --------------------------------------------------------------------------- #
+# The sweep                                                                     #
+# --------------------------------------------------------------------------- #
+
+
+def auto_apply(
+    cfg: Any,
+    store: Any,
+    *,
+    scope: str = "town",
+    dry_run: bool = True,
+    provider: Optional[str] = None,
+    agents: Optional[Sequence[str]] = None,
+    city: Optional[str] = None,
+    rig: Optional[str] = None,
+    engine: Any = None,
+) -> AutoApplyReport:
+    """Sweep every configured agent and apply each one's conservative tier.
+
+    See the module docstring for the full policy.  In one line: for each agent,
+    write its ``model`` config to the *safest tier across its shapes* — but only
+    when that differs from the current model, the agent is not Critical-pinned,
+    and the change is evidence-admissible (a sub-baseline tier the engine's gate
+    already certified, or any upgrade toward the known-good frontier).
+
+    Parameters
+    ----------
+    cfg, store:
+        The resolved advisor config and the materialised cell store (the engine
+        state).  ``store`` should be built from live telemetry by the caller
+        (``CellStore.rebuild`` over ``invocations.jsonl``); auto-apply only reads
+        it.
+    scope:
+        Advisory label recorded in the report (``"town"`` or ``"rig:<name>"``).
+        The agent *set* is the config's declared agents (or ``agents``); the
+        write *location* is resolved per agent via ``city`` / ``rig``.
+    dry_run:
+        When True (the safe default), compute and report the full plan but write
+        nothing and create no backups.
+    provider:
+        Cell-key provider; defaults to ``cfg.default_provider``.
+    agents:
+        Explicit agent list override (else every agent declared in config).
+    city, rig:
+        Forwarded to :func:`cli.resolve_agent_config` to locate each agent's
+        config file/scope (the same resolver ``apply`` uses).
+    engine:
+        Injectable engine module (defaults to the real
+        :mod:`modeladvisor.engine`); tests pass a stub.
+
+    Returns
+    -------
+    :class:`AutoApplyReport` with a per-agent :class:`AgentDecision` list and a
+    roll-up summary.  This function never raises for a per-agent problem (config
+    unresolved, etc.) — it records a ``STATUS_ERROR`` decision and continues, so
+    one mis-configured agent cannot abort the whole sweep.
+    """
+    if engine is None:
+        engine = _cli._load_engine()
+    provider = provider or getattr(cfg, "default_provider", None) or "claude"
+
+    report = AutoApplyReport(scope=scope, dry_run=dry_run, provider=provider)
+    backed_up: set[str] = set()  # files already backed up this run (once each)
+
+    for agent in _agents_in_scope(cfg, scope=scope, agents=agents):
+        try:
+            decision = decide_agent(agent, cfg, store, engine, provider=provider)
+        except Exception as e:  # engine/config blew up for this agent only
+            report.decisions.append(
+                AgentDecision(
+                    agent=agent,
+                    status=STATUS_ERROR,
+                    reason=f"could not compute recommendation: {e}",
+                )
+            )
+            continue
+
+        # Blocked agents are reported and never touched.
+        if decision.status == STATUS_BLOCKED:
+            report.decisions.append(decision)
+            continue
+
+        if not decision.chosen_model:
+            decision.status = STATUS_ERROR
+            decision.reason = "engine returned no concrete model for the binding shape"
+            report.decisions.append(decision)
+            continue
+
+        # Resolve where this agent's model field lives.
+        try:
+            target = _cli.resolve_agent_config(agent, city=city, rig=rig)
+        except _cli.ConfigResolveError as e:
+            decision.status = STATUS_ERROR
+            decision.reason = f"config not resolvable: {e}"
+            report.decisions.append(decision)
+            continue
+
+        decision.config_path = target.path
+        decision.config_scope = target.describe()
+        current = _cli.read_model_field(target)
+        decision.current_model = current
+
+        # Idempotent no-op: chosen model already in effect.
+        if current is not None and current == decision.chosen_model:
+            decision.status = STATUS_NOOP
+            decision.reason = (
+                f"chosen model '{decision.chosen_model}' already set — no change."
+            )
+            report.decisions.append(decision)
+            continue
+
+        # Classify the change direction vs the CURRENT model (for the gate).
+        cur_tier = _model_to_tier(cfg, current)
+        cur_rank = _rank(cfg, cur_tier) if cur_tier else None
+        chosen_rank = _rank(cfg, decision.chosen_tier)
+        base_rank = _rank(cfg, decision.baseline_tier) if decision.baseline_tier else None
+
+        if cur_rank is None:
+            # Current model is unset or off-roster: writing the advisor's choice
+            # is moving to a known, evidence-or-baseline tier — admissible.
+            decision.direction = "set"
+        elif chosen_rank > cur_rank:
+            decision.direction = "up"
+        elif chosen_rank < cur_rank:
+            decision.direction = "down"
+        else:
+            decision.direction = None  # same rank, different model string
+
+        is_downgrade_vs_baseline = base_rank is not None and chosen_rank < base_rank
+
+        # ---- no-evidence baseline guard (don't churn the implicit default) ----
+        # If the conservative tier is just the baseline (no shape earned a cheaper
+        # tier) and the current model is unset / off-roster / already at-or-above
+        # baseline, there is no evidence-driven change to make: the agent is
+        # already (implicitly or explicitly) on a safe-enough model.  Writing an
+        # explicit ``model = <baseline>`` here would be churn with no decision
+        # behind it, and runs counter to "apply only evidence-strong changes".
+        # We only write the baseline when the *current* model is strictly cheaper
+        # than it (restoring an under-capable hand-set model toward the frontier).
+        chosen_is_baseline = base_rank is not None and chosen_rank == base_rank
+        current_at_or_above_chosen = cur_rank is not None and cur_rank >= chosen_rank
+        if chosen_is_baseline and (cur_rank is None or current_at_or_above_chosen):
+            decision.status = STATUS_NOOP
+            decision.direction = None
+            decision.reason = (
+                f"conservative tier is the baseline '{decision.chosen_tier}' and no "
+                "shape has earned a cheaper tier yet (thin evidence) — leaving the "
+                "agent on its current/implicit default; nothing to apply."
+            )
+            report.decisions.append(decision)
+            continue
+
+        # ---- the evidence-admissibility gate ---- #
+        # A sub-baseline tier can ONLY be produced by the engine's gate admitting
+        # it for every shape (see module docstring), so any chosen downgrade is
+        # already evidence-strong.  Upgrades / restores toward the frontier are
+        # always safe.  The one thing we refuse is a sub-baseline write whose
+        # *binding shape* did not actually clear the gate — which cannot happen
+        # via decide_agent, but we assert the invariant defensively.
+        admissible = True
+        gate_reason = ""
+        if is_downgrade_vs_baseline:
+            # Re-confirm the binding shape's recommendation is the chosen tier and
+            # the engine flagged it admitted (not a cold-start baseline echo).
+            rec = engine.recommend(
+                agent, decision.binding_shape, cfg, store, provider=provider
+            )
+            reasons = _cli._get(rec, "reasons", {}) or {}
+            cands = reasons.get("candidates", []) if isinstance(reasons, dict) else []
+            row = next(
+                (c for c in cands if _cli._get(c, "tier_id") == decision.chosen_tier),
+                None,
+            )
+            admitted = bool(_cli._get(row, "admitted")) if row else False
+            if not (admitted and _cli._get(rec, "tier_id") == decision.chosen_tier):
+                admissible = False
+                gate_reason = (
+                    "withheld: sub-baseline tier not gate-admitted for the binding "
+                    "shape (thin evidence) — never auto-downgrade without evidence."
+                )
+
+        if not admissible:
+            decision.status = STATUS_SKIPPED
+            decision.reason = gate_reason
+            report.decisions.append(decision)
+            continue
+
+        # Build the human reason for the (real or dry-run) change.
+        arrow = "downgrade" if decision.direction == "down" else (
+            "upgrade" if decision.direction == "up" else "set"
+        )
+        cur_disp = current if current is not None else "(unset)"
+        evidence = (
+            f"all shapes cleared tolerance for {decision.chosen_tier} "
+            f"(binding: {decision.binding_shape})"
+            if is_downgrade_vs_baseline
+            else f"safest across shapes is {decision.chosen_tier} "
+            f"(binding: {decision.binding_shape})"
+        )
+        decision.reason = (
+            f"{arrow}: {cur_disp} -> {decision.chosen_model}; {evidence}."
+        )
+
+        if dry_run:
+            decision.status = STATUS_DRYRUN
+            report.decisions.append(decision)
+            continue
+
+        # ---- write (back up the file once per run) ---- #
+        # Route the agent to the WHOLE chosen tier — provider + model +
+        # run_target — not just the model, so a cross-provider (e.g. Codex) tier
+        # actually runs on its provider.  Additive + byte-preserving; ``model``
+        # is still always written (back-compat).
+        chosen = cfg.tier(decision.chosen_tier)
+        try:
+            if target.path not in backed_up:
+                decision.backup_path = _cli.backup_file(target.path)
+                backed_up.add(target.path)
+            _cli.set_tier_fields(
+                target,
+                provider=chosen.provider,
+                model=chosen.model,
+                run_target=chosen.run_target,
+            )
+            decision.status = STATUS_APPLIED
+        except Exception as e:
+            decision.status = STATUS_ERROR
+            decision.reason = f"write failed: {e}"
+        report.decisions.append(decision)
+
+    return report

--- a/model-advisor/modeladvisor/cascade.py
+++ b/model-advisor/modeladvisor/cascade.py
@@ -1,0 +1,335 @@
+"""Critical-path-aware (DAG-propagated) effective blast radius (DESIGN §1.3 L3, §7.3).
+
+DESIGN §1.3 Layer 3 scales the asymmetric cascade penalty by ``N_dep`` — the
+"number of downstream dependents of the bead (blast radius)". v1
+(:func:`modeladvisor.engine.recommend` / :func:`_expected_loss`) treats that as a
+**flat scalar**: every dispatch carries the same ``N_dep`` (default ``1``)
+regardless of where it sits in the dependency graph. The cascade term in
+``_expected_loss`` is literally ``drop * multiplier * delta_cost * N_dep`` with a
+single integer ``N_dep``.
+
+DESIGN §7.3 lists **"sequential / critical-path-aware cascade modelling"** as
+deferred: the full contextual-MDP treatment of an ADR cascading into N builder
+dispatches is out of scope, but the *tractable, faithful core* — propagating the
+blast radius through the dependency DAG — is not. This module is that core.
+
+The idea: a bead that blocks 3 ADRs that each block 4 builders has a far larger
+*effective* blast radius than a leaf task, because a wrong downgrade on it
+poisons everything reachable downstream, not just its immediate children. We
+compute that **effective** ``N_dep`` by counting the bead's downstream-reachable
+dependents (the transitive closure of "this bead blocks …"), with an optional
+depth ``decay`` so nearer dependents can be weighted more heavily than distant
+ones:
+
+::
+
+    n_dep_eff = base_n_dep  +  Σ_{d reachable from root}  decay ** depth(d)
+
+where ``depth(root) = 0`` (the root's own dispatch is the ``base_n_dep`` floor —
+the §1.3 "default N_dep = 1 when unknown"), and each downstream dependent sits at
+``depth ≥ 1``. Consequences:
+
+- a **leaf** (root blocks nothing reachable) ⇒ ``n_dep_eff == base_n_dep`` — the
+  flat-scalar behaviour, recovered exactly;
+- with ``decay == 1.0`` ⇒ ``base_n_dep + (raw reachable count)`` — every
+  downstream dependent counts once, fully;
+- with ``decay < 1`` ⇒ nearer dependents dominate (a dependent at depth ``d``
+  contributes ``decay ** d``), so a deep tail is discounted;
+- a **wider / deeper** reachable set ⇒ strictly larger ``n_dep_eff`` than a
+  narrower / shallower one (monotonicity — the property the integrator feeds back
+  into the L3 cascade term as ``round(n_dep_eff)``).
+
+Traversal is breadth-first from the root, **cycle-safe** (a ``visited`` set means
+each node is counted at most once, at its *shallowest* depth), and capped at
+``max_depth`` so a pathological graph cannot blow up the walk. A missing / empty
+graph or an unknown root degrades to the flat ``base_n_dep`` (DESIGN §8
+"degradation": the advisor must never block a dispatch).
+
+Stdlib-only (``collections``). Pure function of its arguments; no I/O. The
+integrator wires the result into ``recommend(..., cascade=...)`` (hook-spec
+below); this module edits nothing in the shared files.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Mapping, Sequence
+
+
+@dataclass
+class CascadeResult:
+    """The DAG-propagated effective blast radius for one root bead (DESIGN §1.3 L3).
+
+    ``n_dep_eff``
+        The effective ``N_dep`` to feed the §1.3 cascade term — ``base_n_dep``
+        plus the ``decay``-weighted count of downstream-reachable dependents. The
+        integrator uses ``round(n_dep_eff)`` (min ``1``) as ``n_dep`` in
+        ``_expected_loss``.
+    ``depth``
+        The deepest dependent level actually reached (``0`` for a leaf / degenerate
+        root), bounded by ``max_depth``.
+    ``n_nodes``
+        Total distinct beads visited *including the root* (so a leaf is ``1``).
+    ``loss_terms``
+        Audit detail: ``{reachable, by_depth: {d: count}}`` — the raw reachable
+        dependent count and the per-depth histogram that built ``n_dep_eff``.
+    ``rationale``
+        One-line human summary of the propagation.
+    """
+
+    n_dep_eff: float
+    depth: int
+    n_nodes: int
+    loss_terms: dict = field(default_factory=dict)
+    rationale: str = ""
+
+
+# --------------------------------------------------------------------------- #
+# Effective cascade (DESIGN §1.3 Layer 3 — N_dep propagated over the DAG)       #
+# --------------------------------------------------------------------------- #
+
+
+def effective_cascade(
+    graph: Mapping[str, Sequence[str]] | None,
+    root: str,
+    *,
+    base_n_dep: float = 1,
+    decay: float = 1.0,
+    max_depth: int = 6,
+) -> CascadeResult:
+    """Compute the DAG-propagated effective blast radius ``N_dep`` for ``root``.
+
+    Faithful, tractable core of DESIGN §7.3's deferred "critical-path-aware
+    cascade modelling": rather than the flat ``N_dep`` scalar of §1.3 Layer 3, we
+    count the dependents *transitively reachable* from ``root`` in the blast-radius
+    graph and weight each by its depth.
+
+    Parameters
+    ----------
+    graph:
+        Adjacency map ``{bead_id: [downstream dependent bead_ids]}`` — the beads
+        each bead **blocks** (its blast radius), i.e. an edge ``u -> v`` means "u
+        blocks v / v depends on u". Built by :func:`build_graph_from_dep_json` from
+        ``gc bd dep tree --json``. ``None`` / empty ⇒ degrade to ``base_n_dep``.
+    root:
+        The dispatched bead whose effective blast radius we want. If absent from
+        ``graph`` ⇒ degrade to ``base_n_dep`` (a leaf / unknown bead).
+    base_n_dep:
+        The root's own-dispatch floor — the §1.3 "default ``N_dep = 1`` when
+        unknown". Added to the weighted dependent count so a leaf returns exactly
+        ``base_n_dep`` (the flat-scalar behaviour). Default ``1``.
+    decay:
+        Per-depth weight base in ``(0, 1]``. ``1.0`` (default) ⇒ every reachable
+        dependent counts once (raw reachable count); ``< 1`` ⇒ a dependent at
+        depth ``d`` contributes ``decay ** d``, so nearer dependents dominate.
+        Clamped to ``(0, 1]`` (a value ``≤ 0`` would erase the graph signal; ``> 1``
+        would make distant dependents matter *more*, which inverts the intent).
+    max_depth:
+        Hard cap on traversal depth (``≥ 0``). Dependents deeper than this are not
+        visited or counted — a pathological / very deep graph cannot blow up the
+        walk. Default ``6``.
+
+    Returns
+    -------
+    :class:`CascadeResult`. Degenerate inputs (``None`` / empty graph, unknown
+    ``root``, ``max_depth < 1``) return
+    ``CascadeResult(n_dep_eff=base_n_dep, depth=0, n_nodes=1, …)`` — the flat
+    ``N_dep`` fallback (DESIGN §8 degradation: never block a dispatch).
+
+    Notes
+    -----
+    Breadth-first from ``root`` with a ``visited`` set, so the traversal is
+    **cycle-safe** and each node is counted **once**, at its *shallowest* depth
+    (BFS reaches a node by a shortest path first). Self-loops and back-edges are
+    therefore harmless. Edges pointing at beads not present as graph keys are still
+    counted as reachable leaves (they are real dependents with no known children).
+    """
+    floor = float(base_n_dep)
+    # Clamp decay into (0, 1]: <=0 would erase the graph; >1 would up-weight the
+    # far tail (inverting "nearer dependents matter more").
+    d = float(decay)
+    if d <= 0.0:
+        d = 1e-9
+    elif d > 1.0:
+        d = 1.0
+
+    # Degenerate fallbacks -> flat base_n_dep (DESIGN §8). An unknown/leaf root has
+    # no outgoing edges to walk; max_depth < 1 means we may not even count children.
+    if not graph or root not in graph or max_depth < 1:
+        return CascadeResult(
+            n_dep_eff=floor,
+            depth=0,
+            n_nodes=1,
+            loss_terms={"reachable": 0, "by_depth": {}},
+            rationale=(
+                f"leaf/flat: {root!r} has no reachable dependents "
+                f"(N_dep_eff={floor:g}, base floor)"
+            ),
+        )
+
+    # BFS from the root. ``visited`` makes the walk cycle-safe and counts each
+    # bead once (at its shallowest depth). The root is visited at depth 0 and is
+    # NOT a dependent (it is the dispatch itself -> the base_n_dep floor).
+    visited: set[str] = {root}
+    queue: deque[tuple[str, int]] = deque([(root, 0)])
+    by_depth: dict[int, int] = {}
+    weighted = 0.0
+    max_reached = 0
+
+    while queue:
+        node, depth = queue.popleft()
+        if depth >= max_depth:
+            # Do not expand past the cap; this node's children (depth+1) are pruned.
+            continue
+        for child in graph.get(node, ()):  # tolerate absent keys -> leaf, no children
+            if child in visited:
+                continue  # cycle / re-convergence: count once, at shallowest depth
+            visited.add(child)
+            child_depth = depth + 1
+            by_depth[child_depth] = by_depth.get(child_depth, 0) + 1
+            weighted += d ** child_depth
+            if child_depth > max_reached:
+                max_reached = child_depth
+            queue.append((child, child_depth))
+
+    reachable = len(visited) - 1  # exclude the root itself
+    n_dep_eff = floor + weighted
+
+    if reachable == 0:
+        rationale = (
+            f"leaf/flat: {root!r} has no reachable dependents "
+            f"(N_dep_eff={n_dep_eff:g}, base floor)"
+        )
+    else:
+        decay_note = "raw count" if d >= 1.0 else f"decay={d:g} (nearer dependents weighted up)"
+        rationale = (
+            f"{root!r} blocks {reachable} reachable dependent(s) over "
+            f"{max_reached} level(s) [{decay_note}] -> effective N_dep "
+            f"{n_dep_eff:g} (floor {floor:g} + weighted {weighted:g})"
+        )
+
+    return CascadeResult(
+        n_dep_eff=n_dep_eff,
+        depth=max_reached,
+        n_nodes=len(visited),
+        loss_terms={"reachable": reachable, "by_depth": dict(sorted(by_depth.items()))},
+        rationale=rationale,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Graph builder — best-effort parse of `gc bd dep tree --json` shapes           #
+# --------------------------------------------------------------------------- #
+
+
+def build_graph_from_dep_json(dep_tree_json: object) -> dict[str, list[str]]:
+    """Parse ``gc bd dep tree --json``-shaped data into the blast-radius adjacency map.
+
+    Builds ``{bead_id: [downstream dependent bead_ids]}`` — the edges
+    :func:`effective_cascade` walks, where ``u -> v`` means "u blocks v / v depends
+    on u". **Best-effort and total**: it never throws on a missing/odd key (it
+    skips), so a malformed tree degrades to a partial (or empty) graph rather than
+    failing a dispatch (DESIGN §8 degradation).
+
+    Two input shapes are tolerated (gc's ``dep tree`` has shipped both):
+
+    1. **Nested tree** — a dict (or list of dict roots) ``{id, dependents|children:
+       [ …same shape… ]}``. Each node's id maps to the ids of its child nodes; the
+       walk recurses, accumulating an edge ``parent -> child`` per nesting level.
+       Alternate id keys (``id`` / ``bead_id`` / ``bead`` / ``name``) and alternate
+       child keys (``dependents`` / ``children`` / ``blocks`` / ``downstream`` /
+       ``deps``) are all accepted.
+    2. **Flat list** — ``[{id, blocks:[child_id, …]}, …]`` (or a single such dict).
+       Each record contributes edges ``id -> b`` for every ``b`` it ``blocks``
+       (alternate edge keys ``blocks`` / ``dependents`` / ``children`` /
+       ``downstream`` / ``deps`` accepted). List members may themselves be the
+       *nested* shape, in which case they are recursed into as well.
+
+    **Assumptions / conventions** (documented per the brief):
+
+    - Edges always point **downstream** (root → dependents = blast radius). The
+      caller's ``root`` is the dispatched bead; its reachable set is what it
+      blocks. If a producer emits the *inverse* (``depends_on`` / ``parents``)
+      those keys are intentionally **not** followed — they are upstream and not the
+      blast radius.
+    - Child entries may be **plain id strings** *or* nested **dicts**; both are
+      handled (a string child is a leaf edge; a dict child is an edge *and*
+      recursed).
+    - A node may appear multiple times (re-convergent DAG); edges are **de-duped**
+      per source (a child is listed once per parent) and every seen id gets a key
+      (so leaves appear as ``id: []``). Re-visiting a node during recursion does
+      not re-expand it (guards against cycles in the source data).
+    - Anything that is not a dict/list, or a node with no usable id, is skipped.
+
+    Returns a plain ``dict[str, list[str]]`` adjacency map (possibly empty).
+    """
+    graph: dict[str, list[str]] = {}
+    if dep_tree_json is None:
+        return graph
+
+    # Accepted aliases for the id field and the downstream-edge field. Order is
+    # irrelevant; first present wins for the id.
+    id_keys = ("id", "bead_id", "bead", "name")
+    edge_keys = ("dependents", "children", "blocks", "downstream", "deps")
+
+    def _node_id(node: Mapping) -> str | None:
+        for k in id_keys:
+            v = node.get(k)
+            if isinstance(v, str) and v:
+                return v
+        return None
+
+    def _edges(node: Mapping) -> list:
+        for k in edge_keys:
+            v = node.get(k)
+            if isinstance(v, list):
+                return v
+        return []
+
+    def _add_edge(src: str, dst: str) -> None:
+        bucket = graph.setdefault(src, [])
+        if dst not in bucket:
+            bucket.append(dst)
+        graph.setdefault(dst, graph.get(dst, []))  # ensure the child has a key too
+
+    # ``recursing`` guards against cycles in malformed source data: a node already
+    # being expanded is not re-expanded (its edges were/are recorded once).
+    recursing: set[str] = set()
+
+    def _walk(node: object) -> None:
+        if isinstance(node, list):
+            for item in node:
+                _walk(item)
+            return
+        if not isinstance(node, Mapping):
+            return  # scalar / unknown at the top level: nothing to extract
+
+        src = _node_id(node)
+        if src is None:
+            # No usable id on this node, but its edge-list children might still be
+            # well-formed nested nodes worth walking for their own edges.
+            for child in _edges(node):
+                if isinstance(child, Mapping):
+                    _walk(child)
+            return
+
+        graph.setdefault(src, [])
+        if src in recursing:
+            return  # already expanding this node (cycle): edges recorded once
+        recursing.add(src)
+
+        for child in _edges(node):
+            if isinstance(child, str) and child:
+                _add_edge(src, child)
+            elif isinstance(child, Mapping):
+                cid = _node_id(child)
+                if cid is not None:
+                    _add_edge(src, cid)
+                _walk(child)  # recurse for the child's own downstream edges
+            # any other child type (int/None/list) is skipped
+
+        recursing.discard(src)
+
+    _walk(dep_tree_json)
+    return graph

--- a/model-advisor/modeladvisor/changepoint.py
+++ b/model-advisor/modeladvisor/changepoint.py
@@ -1,0 +1,390 @@
+"""Change-point detection for upstream model drift / silent deprecation
+(DESIGN §7.3 deferred, superseding the §7.4 static safety hatch).
+
+The §7.4 safety hatch is *static*: an operator pins a cell to its baseline tier
+(``force_baseline``) when they *notice* upstream drift. This module makes that
+mitigation **adaptive** — it reads a cell's time-ordered quality stream and
+detects the moment the upstream model's quality *shifts* (a sustained drop = the
+drift / silent-deprecation case; a rise = a recovered or upgraded model), so the
+gate can **down-weight the stale pre-shift evidence** and the posterior re-learns
+the new regime instead of being anchored by months of now-irrelevant history.
+
+It is the temporal complement to the rest of CC-TS: where the gate (DESIGN §1.3
+Layer 2) asks *"is this tier good enough right now?"*, change-point detection asks
+*"did *right now* stop resembling *the past*?"* — a question the stationary
+Beta-Bernoulli posterior cannot ask, because it pools all observations with equal
+(only age-blind channel) weight and so dilutes a real regime change into the mean.
+
+Detector — the Page-Hinkley test (PH)
+-------------------------------------
+PH is the classic stdlib-friendly sequential change detector: a one-sided CUSUM
+of each observation's deviation from the running mean, with a small magnitude
+tolerance ``delta`` baked in so ordinary noise does not accumulate. Watching for
+a **drop** (``direction='down'``, the drift/deprecation case) we track, over the
+ordered stream ``x_1..x_t`` (this is the standard downward Page-Hinkley form):
+
+    running mean      x̄_t = mean(x_1..x_t)                 (updated incrementally)
+    cumulative sum    m_t  = Σ_{i≤t} ( x_i − x̄_i + delta )  (``+delta`` slack bias)
+    running maximum   M_t  = max_{i≤t} m_t
+    PH statistic      PH_t = M_t − m_t                       (drop below the peak)
+
+    flag a change  ⇔  PH_t > lambda_
+
+Intuition: while the stream is stationary, ``x_i − x̄_i`` is mean-zero, the
+``+ delta`` bias makes ``m_t`` *drift upward*, ``M_t`` tracks that upward drift,
+and ``PH_t = M_t − m_t`` stays ~0 — **no false reset on a noisy-but-stationary
+stream** (the key correctness property). When the mean *drops*, ``x_i − x̄_i``
+turns persistently negative, ``m_t`` falls away from the peak ``M_t`` last
+reached, ``PH_t`` climbs past ``lambda_``, and we flag. ``delta`` is the slack
+(it must exceed the per-step noise amplitude, so for a Bernoulli quality stream
+it is a meaningful fraction, not a tiny epsilon — see the defaults note below);
+``lambda_`` is the accumulated-evidence threshold (larger ⇒ later but surer).
+For ``direction='up'`` the sign is mirrored — a CUSUM ``m_t = Σ (x_i − x̄_i −
+delta)`` tracked against a running *minimum*, flagging when ``m_t − min`` exceeds
+``lambda_``; ``'both'`` runs the two one-sided detectors in parallel and flags on
+either.
+
+**Defaults for a Bernoulli quality stream (why not a tiny ``delta``).** The
+quality observations here are ``q ∈ {0, 1}`` (DESIGN §1.3): a *single* failure
+swings the instantaneous value by the full unit, so the per-step noise amplitude
+is large and ``delta`` must dominate it or a stationary high-quality cell would
+false-trigger on every ``0``. Empirically (sweeping stationary streams at p ∈
+{0.2, 0.5, 0.9} vs. a 0.9→0.5 drop), ``delta = 0.15`` with ``lambda_ = 4.0``
+gives a ~0 stationary false-reset rate (worst case ≈0.08 at the maximum-variance
+p=0.5) while detecting a genuine ~0.4-magnitude regime drop ≳99% of the time
+within ~10–20 observations of the true shift. These are the module defaults;
+callers with a *continuous* (graded-eval) quality stream of lower per-step
+variance can pass a smaller ``delta``.
+
+**Reset behaviour.** On a flag the detector **resets** its accumulators (``m``,
+``M``, the running mean, the sample count) so a *second*, later shift in the same
+stream is detected independently rather than being masked by the first — i.e.
+each returned index opens a fresh regime. :func:`detect_changepoints` records the
+index at each flag and continues; :class:`PageHinkley` exposes the same machine
+incrementally for streaming callers, so the batch and streaming results coincide
+by construction (the batch function simply feeds the stream through one
+:class:`PageHinkley`).
+
+Re-weighting — :func:`recency_weights`
+--------------------------------------
+Given the detected change-points, :func:`recency_weights` produces one weight per
+observation (aligned oldest→newest) that the store multiplies into each
+observation during ``rebuild`` (the integration seam below). Everything *before
+the most recent* change-point is down-weighted (exponentially by how far before
+the shift it lies, ``decay**k``, vanishing for stale evidence — or a hard ``0.0``
+cut when ``decay == 1``) so the posterior is dominated by the post-shift regime
+and re-learns it; observations *at or after* the last change-point keep weight
+``1.0`` (flat, so the regime we want to learn is never internally discounted).
+With **no** change-point the weights are all ``1.0`` (or, if ``decay < 1`` is
+requested, a pure uniform age-decay applied to the whole stream — documented per
+argument on the function).
+
+Integration seam (hook-spec; this module edits nothing itself)
+--------------------------------------------------------------
+- ``config``: a flag ``changepoint: bool = False`` on ``AdvisorConfig.hp``.
+- ``store``: when ``cfg.hp.changepoint`` is True, ``CellStore.rebuild`` replays a
+  cell's ordered ``quality`` records, calls :func:`detect_changepoints` on their
+  ``q`` stream, then multiplies each observation's Beta-update weight ``w`` by the
+  matching :func:`recency_weights` entry, so post-drift evidence dominates ``mu``.
+- ``cli``: ``advisor drift [--agent A] [--shape S]`` reports the detected shifts
+  per cell (the indices + the pre/post means around each).
+
+Stdlib-only (``math``, ``statistics``); pure functions plus one small stateful
+``@dataclass`` detector; deterministic (no randomness of its own — any noise in
+the *tests* is seeded). DESIGN §5 supplies the ordered ``ts``-stamped quality
+stream this consumes; DESIGN §7.3 lists this as the deferred feature.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+# Accepted ``direction`` values for the one-sided / two-sided detector.
+_DIRECTIONS = ("down", "up", "both")
+
+
+# --------------------------------------------------------------------------- #
+# Streaming detector (the Page-Hinkley machine, DESIGN §7.3)                    #
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class PageHinkley:
+    """A small stateful streaming Page-Hinkley change detector (DESIGN §7.3).
+
+    Feed observations one at a time with :meth:`update`; it returns ``True`` on
+    the step at which a *sustained* shift (per ``direction``) crosses the
+    ``lambda_`` threshold, and **resets** itself on that step so the next shift in
+    the same stream is detected independently. :meth:`reset` clears it manually.
+
+    The accumulators realise the cumulative statistic documented in the module
+    docstring. For ``direction='down'`` we accumulate the *downward* excess of
+    each observation below the running mean (minus the ``delta`` slack) and flag
+    when the running maximum exceeds the current cumulative sum by more than
+    ``lambda_``; ``'up'`` mirrors the sign; ``'both'`` keeps both one-sided
+    accumulators and flags on either.
+
+    Parameters
+    ----------
+    delta:
+        Magnitude tolerance — slack subtracted from each deviation so ordinary
+        noise does not accumulate (≈ half the smallest shift worth flagging).
+    lambda_:
+        Detection threshold on the Page-Hinkley statistic (larger ⇒ later but
+        surer; fewer false positives).
+    direction:
+        ``'down'`` flags drops (the drift/deprecation case — the default),
+        ``'up'`` flags rises, ``'both'`` flags either.
+
+    Notes
+    -----
+    Pure/​deterministic: state evolves only via :meth:`update`; there is no I/O,
+    no global state, and no randomness. Construct one per stream (or call
+    :meth:`reset` between streams).
+    """
+
+    delta: float = 0.15
+    lambda_: float = 4.0
+    direction: str = "down"
+
+    # --- running state (reset on construction / flag / .reset()) ---------- #
+    n: int = field(default=0, init=False)  # observations since last reset
+    _mean: float = field(default=0.0, init=False)  # incremental running mean
+    # Down-watcher: cumulative sum (``+delta`` biased) + its running maximum;
+    # flags when the sum falls ``lambda_`` below the peak (a sustained drop).
+    _m_down: float = field(default=0.0, init=False)
+    _M_down: float = field(default=0.0, init=False)
+    # Up-watcher: cumulative sum (``-delta`` biased) + its running minimum;
+    # flags when the sum rises ``lambda_`` above the trough (a sustained rise).
+    _m_up: float = field(default=0.0, init=False)
+    _m_up_min: float = field(default=0.0, init=False)
+
+    def __post_init__(self) -> None:
+        if self.direction not in _DIRECTIONS:
+            raise ValueError(
+                f"direction must be one of {_DIRECTIONS!r}, got {self.direction!r}"
+            )
+        if self.delta < 0.0:
+            raise ValueError(f"delta must be >= 0, got {self.delta!r}")
+        if self.lambda_ <= 0.0:
+            raise ValueError(f"lambda_ must be > 0, got {self.lambda_!r}")
+
+    def reset(self) -> None:
+        """Clear all accumulators (start a fresh regime)."""
+        self.n = 0
+        self._mean = 0.0
+        self._m_down = 0.0
+        self._M_down = 0.0
+        self._m_up = 0.0
+        self._m_up_min = 0.0
+
+    def update(self, x: float) -> bool:
+        """Consume one observation; return ``True`` iff a change is flagged now.
+
+        Updates the running mean incrementally (Welford, mean only, **including**
+        ``x`` — the standard Page-Hinkley convention), accumulates the one-sided
+        cumulative sum(s) for the configured ``direction`` against their running
+        extremum, and — when the gap to that extremum exceeds ``lambda_`` — flags
+        the change and :meth:`reset`\\ s so the next shift is detected from a
+        clean slate (DESIGN §7.3 reset rule).
+        """
+        xf = float(x)
+        # Incremental running mean including x.
+        self.n += 1
+        self._mean += (xf - self._mean) / self.n
+        dev = xf - self._mean  # deviation from the (current) running mean
+
+        flagged = False
+
+        if self.direction in ("down", "both"):
+            # Downward CUSUM: m drifts up by +delta on stationary noise; a drop in
+            # the mean makes `dev` persistently negative so m falls away from its
+            # running max M. Flag when m sits more than lambda_ below the peak.
+            self._m_down += dev + self.delta
+            if self._m_down > self._M_down:
+                self._M_down = self._m_down
+            if (self._M_down - self._m_down) > self.lambda_:
+                flagged = True
+
+        if not flagged and self.direction in ("up", "both"):
+            # Upward CUSUM (mirror): m drifts down by -delta on stationary noise; a
+            # rise makes `dev` persistently positive so m climbs above its running
+            # min. Flag when m sits more than lambda_ above the trough.
+            self._m_up += dev - self.delta
+            if self._m_up < self._m_up_min:
+                self._m_up_min = self._m_up
+            if (self._m_up - self._m_up_min) > self.lambda_:
+                flagged = True
+
+        if flagged:
+            self.reset()
+        return flagged
+
+
+# --------------------------------------------------------------------------- #
+# Batch detection over an ordered quality stream (DESIGN §5 + §7.3)             #
+# --------------------------------------------------------------------------- #
+
+
+def detect_changepoints(
+    observations: list[float],
+    *,
+    delta: float = 0.15,
+    lambda_: float = 4.0,
+    direction: str = "down",
+) -> list[int]:
+    """Page-Hinkley change-points over an ordered quality stream (DESIGN §7.3).
+
+    Runs the streaming :class:`PageHinkley` detector across ``observations``
+    (a list of floats in ``[0, 1]``, **oldest→newest** — the cell's time-ordered
+    ``q`` stream, DESIGN §5) and returns the **indices at which a sustained shift
+    is flagged**. Because the detector resets on each flag (see its docstring),
+    multiple successive regime changes are each reported once, in order.
+
+    This is exactly the streaming machine fed a whole list, so a caller using
+    :class:`PageHinkley` incrementally observes the *same* flag indices — the
+    batch and streaming APIs coincide by construction.
+
+    Parameters
+    ----------
+    observations:
+        Ordered quality observations (oldest→newest), each in ``[0, 1]``.
+    delta:
+        Magnitude tolerance (slack), which must exceed the per-step noise
+        amplitude. Default ``0.15`` is tuned for a Bernoulli ``{0,1}`` quality
+        stream (a single failure swings the value by a full unit; a tiny epsilon
+        would false-trigger every ``0``). Pass smaller for a low-variance
+        continuous quality stream.
+    lambda_:
+        Detection threshold on the cumulative statistic (accumulated, slack-
+        adjusted drop). Default ``4.0`` gives a ~0 stationary false-reset rate
+        while catching a real ~0.4-magnitude regime shift within ~10–20
+        observations; larger ⇒ later but surer.
+    direction:
+        ``'down'`` (default) watches for DROPS — the drift / silent-deprecation
+        case; ``'up'`` for rises; ``'both'`` for either.
+
+    Returns
+    -------
+    A list of integer indices into ``observations`` at which a change was flagged
+    (empty if the stream is stationary within tolerance — *no false reset*).
+
+    Notes
+    -----
+    Fewer than two observations can never produce a flag (there is no "past" to
+    deviate from), so a short or empty stream returns ``[]``.
+    """
+    ph = PageHinkley(delta=delta, lambda_=lambda_, direction=direction)
+    out: list[int] = []
+    for i, x in enumerate(observations):
+        if ph.update(float(x)):
+            out.append(i)
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Recency re-weighting from the detected change-points (DESIGN §7.3)            #
+# --------------------------------------------------------------------------- #
+
+
+def recency_weights(
+    n: int,
+    changepoints: list[int],
+    *,
+    decay: float = 0.9,
+    post_change_boost: bool = True,
+) -> list[float]:
+    """Per-observation weights that DOWN-WEIGHT pre-change evidence (DESIGN §7.3).
+
+    Produces a length-``n`` weight vector aligned **oldest→newest** that the store
+    multiplies into each observation's Beta-update weight during ``rebuild`` so the
+    posterior re-learns the current regime after an upstream shift. Every weight
+    lies in ``[0, 1]``.
+
+    The two concerns are kept cleanly separate so the post-shift regime is never
+    accidentally gutted:
+
+    1. **Regime reset (the primary job).** The most recent change-point ``c* =
+       max(changepoints)`` partitions the stream. When ``post_change_boost`` is
+       True (the default):
+
+       - **post-shift** observations (indices ``i >= c*``) keep weight ``1.0`` —
+         full strength, *flat*. This is the regime we want the posterior to
+         reflect, so it is **never** internally discounted (the "≈1 after"
+         contract); and
+       - **pre-shift** observations (indices ``i < c*``) are forgotten
+         exponentially with how far *before* the shift they lie:
+         ``weight = decay ** (c* - i)``. An observation ``k`` steps before the
+         change-point keeps ``decay ** k`` of its weight, so stale pre-drift
+         evidence vanishes smoothly. With ``decay == 1.0`` the exponential cannot
+         shrink, so this degenerates to a **hard cut**: pre-shift ⇒ ``0.0``,
+         post-shift ⇒ ``1.0`` (a clean regime boundary). ``decay`` thus spans
+         *soft* exponential forgetting (``< 1``) to a *hard* cut (``== 1``).
+
+    2. **No reset to do (no change-points).** With ``post_change_boost`` True (the
+       default) and no change-point detected, **every weight is ``1.0``** — the
+       feature is *inert on a stationary cell*: a healthy cell with no drift keeps
+       all its evidence at full strength (the "no-change ⇒ all 1.0" contract, and
+       the conservative default — we never silently discount a cell that hasn't
+       shifted). ``decay`` here governs *only* the pre-shift falloff of rule 1; it
+       does **not** tilt a stationary stream.
+
+    3. **Age-decay only (opt-in), via ``post_change_boost=False``.** This disables
+       the regime reset and instead applies a **pure uniform age-decay** to the
+       whole stream: ``weight = decay ** (last - i)`` with ``last = n - 1`` (older
+       ⇒ smaller; the newest observation is exactly ``1.0``; ``decay == 1`` ⇒ all
+       ``1.0``). Nothing is ever zeroed out. Use this when a caller wants a gentle
+       recency tilt *without* the hard change-point forgetting (e.g. to compare
+       the two weighting policies).
+
+    Parameters
+    ----------
+    n:
+        Length of the observation stream (the returned vector's length).
+    changepoints:
+        Indices returned by :func:`detect_changepoints` (only the maximum — the
+        most recent shift — drives the split; earlier ones are subsumed by it).
+    decay:
+        Per-step decay factor in ``(0, 1]`` (older ⇒ smaller). Shapes the
+        pre-shift falloff (rule 1) or the opt-in stream-wide age-decay (rule 3).
+        ``1.0`` ⇒ a hard regime cut / the identity, per the rules above.
+    post_change_boost:
+        When True (default) reset around the most recent change-point so the
+        posterior re-learns the new regime (and, with no change-point, leave every
+        weight at ``1.0``); when False, skip the reset and apply only the uniform
+        age-decay (rule 3), never zeroing out the past.
+
+    Returns
+    -------
+    A list of ``n`` weights, each in ``[0, 1]``, aligned oldest→newest.
+    """
+    if not (0.0 < decay <= 1.0):
+        raise ValueError(f"decay must be in (0, 1], got {decay!r}")
+    if n <= 0:
+        return []
+
+    last = n - 1
+    valid_cps = [c for c in changepoints if 0 <= c < n]
+
+    # --- rule 3: age-decay-only mode (reset explicitly disabled) ------------ #
+    # Pure uniform age-decay over the whole stream (newest == 1.0); never zeroes
+    # anything out. ``decay == 1`` collapses this to the identity (all 1.0).
+    if not post_change_boost:
+        if decay >= 1.0:
+            return [1.0] * n
+        return [decay ** (last - i) for i in range(n)]
+
+    # --- rule 2: reset requested but no change-point -> inert (all 1.0) ------ #
+    # A healthy, un-shifted cell keeps every observation at full strength; decay
+    # governs only the pre-shift falloff of rule 1, not a stationary stream.
+    if not valid_cps:
+        return [1.0] * n
+
+    # --- rule 1: reset around the most recent change-point ------------------ #
+    # Post-shift kept flat at 1.0 (the regime to re-learn); pre-shift forgotten
+    # exponentially by distance before the shift. ``decay == 1`` can't shrink via
+    # the exponential, so it degenerates to a hard 0.0 cut at the boundary.
+    c_star = max(valid_cps)
+    if decay >= 1.0:
+        return [1.0 if i >= c_star else 0.0 for i in range(n)]
+    return [1.0 if i >= c_star else decay ** (c_star - i) for i in range(n)]

--- a/model-advisor/modeladvisor/cli.py
+++ b/model-advisor/modeladvisor/cli.py
@@ -1,0 +1,1577 @@
+"""model-advisor CLI — the operator-facing surfaces.
+
+Three subcommands, mirroring the read-side pack's ``bin/op``/``bin/outline``
+ergonomics (see ``packs/ast-lens/bin/``) and the surfaces specified in
+``docs/DESIGN.md`` §6 + the integration verdict in
+``docs/INTEGRATION-FEASIBILITY.md`` (A):
+
+  advise  <agent> <shape> [--json]
+      Call ``engine.recommend(agent, shape, cfg, store)`` and print the
+      recommended tier, a human rationale, and the cost differential vs every
+      roster tier.  ``--json`` emits the structured ``reasons`` audit object.
+
+  inspect <agent> <shape> [--json]
+      Call ``engine.inspect(agent, shape, cfg, store)`` and show each tier's
+      posterior (mean + credible interval on the quality DROP vs baseline),
+      then name the widest *gating* cell as the next eval to run.
+
+  apply   <agent> [--shape S] [--city PATH] [--rig NAME] [--dry-run]
+      Compute the recommendation, then SET that agent's default model in gc
+      config by writing/updating the ``model = "<model>"`` field for the agent
+      (per the integration verdict: ``[[agent]]`` / ``[agent_defaults].model``,
+      the field gc carries into ``GC_AGENT_MODEL``).  Backs the file up first,
+      is idempotent, supports ``--dry-run``, prints a clear before/after, and
+      refuses cleanly on a no-op (recommended tier == current) or when the
+      agent/config cannot be resolved.
+
+This module owns *only* the CLI.  The engine, store, and config are built by a
+sibling bead under the shared contract::
+
+    engine.recommend(agent, shape, cfg, store) -> {tier_id, model, rationale,
+                                                   cost_delta, reasons, ...}
+    engine.inspect(agent, shape, cfg, store)   -> {...}
+    store.CellStore(...)        # the posterior cell store
+    config.load_config(path)    # loads advisor.toml
+    config.default_config()     # built-in defaults (no advisor.toml present)
+
+The CLI imports and drives those.  It is deliberately tolerant of the engine
+not being present yet (cold dev / test bootstrap): the heavy imports are lazy
+and tests may inject a stub via :data:`ENGINE` / :data:`build_state`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import os
+import re
+import shutil
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Optional, Sequence
+
+PROG = "advisor"
+
+# Cell key = provider::agent::shape::tier_id  (shared contract).
+CELL_KEY = "{provider}::{agent}::{shape}::{tier_id}"
+
+
+# --------------------------------------------------------------------------- #
+# Engine / config / store wiring (lazy + injectable)
+# --------------------------------------------------------------------------- #
+#
+# ``ENGINE`` and ``build_state`` are module-level hooks so tests can drive the
+# CLI without the sibling engine present.  In production they resolve to the
+# real ``modeladvisor.engine`` / ``modeladvisor.config`` / ``modeladvisor.store``.
+
+ENGINE: Any = None  # set by _load_engine(); tests may monkeypatch.
+
+
+def _load_engine() -> Any:
+    """Import and return the real engine module, caching it in :data:`ENGINE`.
+
+    Kept lazy so ``import modeladvisor.cli`` never hard-fails if the sibling
+    engine bead has not landed yet (the CLI can still be imported, its argparse
+    introspected, and ``apply``'s config editor unit-tested in isolation).
+    """
+    global ENGINE
+    if ENGINE is not None:
+        return ENGINE
+    from modeladvisor import engine as _engine  # local import: see docstring
+
+    ENGINE = _engine
+    return ENGINE
+
+
+@dataclass
+class State:
+    """Everything ``recommend``/``inspect`` need, resolved from disk/config."""
+
+    cfg: Any
+    store: Any
+    provider: str
+
+
+def build_state(
+    *,
+    advisor_toml: Optional[str] = None,
+    telemetry_dir: Optional[str] = None,
+    provider: Optional[str] = None,
+) -> State:
+    """Resolve config + cell store for a CLI invocation.
+
+    Config (DESIGN §8 "config files the engine reads"): an explicit
+    ``advisor.toml`` (``--config`` or ``$ADVISOR_TOML``) else the pack/city
+    default config.
+
+    Cell store (DESIGN §5.5 "the JSONL is the source of truth; the cache is
+    rebuildable"): from the telemetry dir (``$ADVISOR_TELEMETRY_DIR`` or
+    ``./.beads/telemetry``) we *rebuild* from ``invocations.jsonl`` when it is
+    present (truth), else *load* the ``advisor-cells.json`` cache when present,
+    else fall back to a conservative ``cold_start`` store (DESIGN §3.2 — the
+    advisor must never block; worst case it recommends the baseline tier).
+
+    Tests monkeypatch this wholesale to inject a fake ``State``; production uses
+    the sibling ``config``/``store`` modules.
+    """
+    from modeladvisor import config as _config
+    from modeladvisor import store as _store
+
+    advisor_toml = advisor_toml or os.environ.get("ADVISOR_TOML")
+    if advisor_toml and os.path.exists(advisor_toml):
+        cfg = _config.load_config(advisor_toml)
+    else:
+        cfg = _config.default_config()
+
+    telemetry_dir = (
+        telemetry_dir
+        or os.environ.get("ADVISOR_TELEMETRY_DIR")
+        or os.path.join(os.getcwd(), ".beads", "telemetry")
+    )
+    jsonl = os.path.join(telemetry_dir, "invocations.jsonl")
+    cache = os.path.join(telemetry_dir, "advisor-cells.json")
+    if os.path.exists(jsonl):
+        store = _store.CellStore.rebuild(cfg, jsonl)
+    elif os.path.exists(cache):
+        store = _store.CellStore.load(cfg, cache)
+    else:
+        store = _store.CellStore.cold_start(cfg)
+
+    prov = (
+        provider
+        or getattr(cfg, "default_provider", None)
+        or "claude"
+    )
+    return State(cfg=cfg, store=store, provider=prov)
+
+
+# --------------------------------------------------------------------------- #
+# Small output helpers
+# --------------------------------------------------------------------------- #
+
+def _get(obj: Any, key: str, default: Any = None) -> Any:
+    """Read ``key`` from a dict-or-object recommendation/inspect result.
+
+    The engine returns plain dicts per the contract, but being lenient about
+    attribute-style access keeps the CLI robust to a dataclass result too.
+    """
+    if obj is None:
+        return default
+    if isinstance(obj, Mapping):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+def _fmt_money(x: Optional[float]) -> str:
+    """Format a dollar cost differential with a sign, e.g. ``-$0.0114``."""
+    if x is None:
+        return "n/a"
+    try:
+        v = float(x)
+    except (TypeError, ValueError):
+        return str(x)
+    sign = "-" if v < 0 else "+"
+    return f"{sign}${abs(v):.4f}"
+
+
+def _fmt_ci(ci: Any) -> str:
+    """Format a credible interval as ``[lo, hi]`` (+ ``*`` if it exceeds tol).
+
+    Accepts either a 2-tuple/list ``(lo, hi)`` or the engine's richer dict
+    ``{lo, hi, mean, q_tol, exceeds_tol}`` (DESIGN §6.2 — the credible interval
+    on the quality *drop* vs baseline).  A trailing ``*`` flags an interval that
+    breaches the tolerance (i.e. why a cheaper tier can't be admitted).
+    """
+    if not ci:
+        return "[n/a]"
+    if isinstance(ci, Mapping):
+        lo = ci.get("lo")
+        hi = ci.get("hi")
+        if lo is None or hi is None:
+            return str(ci)
+        flag = "*" if ci.get("exceeds_tol") else ""
+        return f"[{float(lo):.3f}, {float(hi):.3f}]{flag}"
+    try:
+        lo, hi = ci
+        return f"[{float(lo):.3f}, {float(hi):.3f}]"
+    except (TypeError, ValueError):
+        return str(ci)
+
+
+def _num(x: Any, fmt: str = "{:.3f}") -> str:
+    try:
+        return fmt.format(float(x))
+    except (TypeError, ValueError):
+        return "n/a" if x is None else str(x)
+
+
+# --------------------------------------------------------------------------- #
+# advise
+# --------------------------------------------------------------------------- #
+
+def cmd_advise(args: argparse.Namespace, out: io.TextIOBase) -> int:
+    engine = _load_engine()
+    state = _resolve_state(args)
+
+    cfg = state.cfg
+    # --thompson: run the genuine seeded Thompson-Sampling mode (DESIGN §7.3) for
+    # this invocation by overriding the config's mode knob.
+    if getattr(args, "thompson", False):
+        cfg = cfg.with_hyperparams(mode="thompson")
+
+    # --cascade-bead: resolve the bead's downstream DAG (gc bd dep tree --json) into
+    # an effective blast radius and pass it as `cascade=` so the L3 cascade term
+    # scales with the bead's true reach (DESIGN §1.3 L3 / §7.3).
+    cascade = None
+    cascade_bead = getattr(args, "cascade_bead", None)
+    if cascade_bead:
+        cascade = _resolve_cascade(cascade_bead, out)
+
+    rec = engine.recommend(
+        args.agent,
+        args.shape,
+        cfg,
+        state.store,
+        provider=state.provider,
+        seed=getattr(args, "seed", None),
+        cascade=cascade,
+    )
+
+    if args.json:
+        # The audit surface: emit the structured ``reasons`` verbatim, with the
+        # top-line decision fields alongside for a self-contained record.
+        payload = {
+            "agent": args.agent,
+            "shape": args.shape,
+            "provider": _get(rec, "provider", state.provider),
+            "tier_id": _get(rec, "tier_id"),
+            "model": _get(rec, "model"),
+            "cost_delta": _get(rec, "cost_delta"),
+            "reasons": _get(rec, "reasons", {}),
+        }
+        json.dump(payload, out, indent=2, default=str)
+        out.write("\n")
+        return 0
+
+    tier = _get(rec, "tier_id", "?")
+    model = _get(rec, "model")
+    rationale = _get(rec, "rationale", "(no rationale provided)")
+
+    out.write(f"advise {args.agent} {args.shape}\n")
+    head = f"  recommend: {tier}"
+    if model:
+        head += f"  ({model})"
+    out.write(head + "\n")
+    out.write(f"  rationale: {rationale}\n")
+
+    # Cost differential vs each roster tier (and vs baseline).  Prefer an
+    # explicit per-candidate breakdown from ``reasons``; fall back to the
+    # scalar ``cost_delta`` vs baseline.
+    reasons = _get(rec, "reasons", {}) or {}
+    cands = _get(reasons, "candidates", None)
+    if cands:
+        out.write("  cost differential vs each tier:\n")
+        for c in cands:
+            ctier = _get(c, "tier_id", "?")
+            cdiff = _get(c, "cost_diff", _get(c, "cost_delta"))
+            marker = " <- recommended" if ctier == tier else ""
+            extra = []
+            if _get(c, "q_lo") is not None:
+                extra.append(f"q_lo={_num(_get(c, 'q_lo'))}")
+            if _get(c, "exp_loss") is not None:
+                extra.append(f"E[L]={_fmt_money(_get(c, 'exp_loss'))}")
+            suffix = ("  " + " ".join(extra)) if extra else ""
+            out.write(
+                f"    {ctier:<12} {_fmt_money(cdiff)}{suffix}{marker}\n"
+            )
+    else:
+        out.write(
+            f"  cost differential vs baseline: {_fmt_money(_get(rec, 'cost_delta'))}\n"
+        )
+
+    if _get(reasons, "eval_flag"):
+        out.write("  note: this cell wants an eval (posterior CI is wide)\n")
+    return 0
+
+
+# --------------------------------------------------------------------------- #
+# inspect
+# --------------------------------------------------------------------------- #
+
+def cmd_inspect(args: argparse.Namespace, out: io.TextIOBase) -> int:
+    engine = _load_engine()
+    state = _resolve_state(args)
+
+    info = engine.inspect(
+        args.agent, args.shape, state.cfg, state.store, provider=state.provider
+    )
+
+    if args.json:
+        json.dump(_as_jsonable(info), out, indent=2, default=str)
+        out.write("\n")
+        return 0
+
+    out.write(f"inspect {args.agent} {args.shape}\n")
+    baseline = _get(info, "baseline_tier")
+    if baseline:
+        out.write(f"  baseline tier*: {baseline}\n")
+
+    tiers = _get(info, "tiers", []) or []
+    if tiers:
+        out.write(
+            "  {:<12} {:>6} {:>6} {:>5} {:<22} {}\n".format(
+                "tier", "mean", "q_lo", "n", "quality-drop 95% CI", "gate"
+            )
+        )
+        for t in tiers:
+            tid = _get(t, "tier_id", "?")
+            mean = _num(_get(t, "mean"))
+            q_lo = _num(_get(t, "q_lo"))
+            n = _get(t, "n", 0)
+            drop_ci = _fmt_ci(_get(t, "quality_drop_ci", _get(t, "drop_ci")))
+            out.write(
+                "  {:<12} {:>6} {:>6} {:>5} {:<22} {}\n".format(
+                    tid, mean, q_lo, n, drop_ci, _gate_label(t, tid, baseline)
+                )
+            )
+
+    widest = _get(info, "widest_gating_cell") or _get(info, "widest_cell")
+    if widest:
+        cell = _get(widest, "cell_key", _get(widest, "tier_id", "?"))
+        hw = _get(widest, "ci_halfwidth",
+                  _get(widest, "ci_half_width", _get(widest, "half_width")))
+        out.write(
+            f"  next eval (widest gating cell): {cell}"
+            + (f" (CI half-width {_num(hw)})" if hw is not None else "")
+            + "\n"
+        )
+        rationale = _get(widest, "rationale")
+        if rationale:
+            out.write(f"    {rationale}\n")
+    else:
+        out.write("  next eval: none — no cell is gating a downgrade\n")
+    return 0
+
+
+def _gate_label(tier: Any, tid: str, baseline: Optional[str]) -> str:
+    """Render a tier's gate decision for the inspect table.
+
+    The real engine marks the baseline with ``role == 'baseline'`` and each
+    candidate downgrade with ``admitted`` (bool).  ``admit`` is accepted as a
+    fallback alias so a simpler engine/stub still renders correctly.
+    """
+    role = _get(tier, "role")
+    if role == "baseline" or tid == baseline:
+        return "baseline"
+    admit = _get(tier, "admitted", _get(tier, "admit"))
+    if admit is True:
+        return "admit"
+    if admit is False:
+        return "reject"
+    return "-"
+
+
+def _as_jsonable(info: Any) -> Any:
+    """Best-effort coerce an inspect result to something ``json.dump`` accepts."""
+    if isinstance(info, Mapping):
+        return info
+    # dataclass / object → its __dict__ if present
+    d = getattr(info, "__dict__", None)
+    return d if d is not None else info
+
+
+# --------------------------------------------------------------------------- #
+# apply  — the v1 "actually choose the model" action (per AGENT)
+# --------------------------------------------------------------------------- #
+
+def cmd_apply(args: argparse.Namespace, out: io.TextIOBase) -> int:
+    engine = _load_engine()
+    state = _resolve_state(args)
+
+    shape = args.shape
+    if not shape:
+        shape = _default_shape_for(state.cfg, args.agent)
+    if not shape:
+        out.write(
+            f"apply: cannot resolve a shape for agent '{args.agent}'. "
+            "Pass --shape <lookup|implement|judge|review|patrol>.\n"
+        )
+        return 2
+
+    rec = engine.recommend(
+        args.agent, shape, state.cfg, state.store, provider=state.provider
+    )
+    new_model = _get(rec, "model")
+    new_tier = _get(rec, "tier_id")
+    if not new_model:
+        out.write(
+            "apply: the engine did not return a concrete model for "
+            f"{args.agent}/{shape}; nothing to apply.\n"
+        )
+        return 2
+
+    # The full cross-provider routing target for the chosen tier: provider +
+    # model + run_target.  Applying a tier must set all three so a Codex tier
+    # actually runs on Codex (not just rename the model).  Resolve them from the
+    # roster (the engine returns a tier_id; the config owns the routing fields).
+    new_provider = _get(rec, "provider", state.provider)
+    new_run_target: Optional[str] = None
+    dispatch: Optional[dict] = None
+    if new_tier and getattr(state.cfg, "has_tier", None) and state.cfg.has_tier(new_tier):
+        tier = state.cfg.tier(new_tier)
+        new_provider = tier.provider or new_provider
+        new_run_target = tier.run_target or None
+        dispatch = dispatch_metadata(state.cfg, new_tier)
+
+    # Resolve the gc config file + the scope (flat agent.toml / [[agent]] /
+    # [agent_defaults]) that owns this agent's routing fields.
+    try:
+        target = resolve_agent_config(
+            args.agent, city=args.city, rig=args.rig
+        )
+    except ConfigResolveError as e:
+        if getattr(args, "json", False):
+            json.dump({"agent": args.agent, "error": str(e)}, out, default=str)
+            out.write("\n")
+        else:
+            out.write(f"apply: {e}\n")
+        return 2
+
+    current = read_model_field(target)
+    cur_provider = read_field(target, "provider")
+    cur_run_target = read_field(target, "run_target")
+
+    # Refuse the no-op: the recommended model is already in effect.  (We key the
+    # no-op on the model for back-compat with v1; provider/run_target are written
+    # additively when the model itself changes.)
+    is_noop = current is not None and current == new_model
+
+    if getattr(args, "json", False):
+        payload = {
+            "agent": args.agent,
+            "shape": shape,
+            "config": target.path,
+            "scope": target.describe(),
+            "recommended_tier": new_tier,
+            "provider": new_provider,
+            "model": new_model,
+            "run_target": new_run_target,
+            "current": {
+                "provider": cur_provider,
+                "model": current,
+                "run_target": cur_run_target,
+            },
+            "dispatch_metadata": dispatch,
+            "dry_run": bool(args.dry_run),
+            "noop": is_noop,
+            "applied": False,
+        }
+        if is_noop:
+            payload["reason"] = "recommended model equals the current model"
+            json.dump(payload, out, indent=2, default=str)
+            out.write("\n")
+            return 3
+        if not args.dry_run:
+            backup = backup_file(target.path)
+            set_tier_fields(
+                target,
+                provider=new_provider,
+                model=new_model,
+                run_target=new_run_target,
+            )
+            payload["applied"] = True
+            payload["backup"] = backup
+        json.dump(payload, out, indent=2, default=str)
+        out.write("\n")
+        return 0
+
+    out.write(f"apply {args.agent} (shape={shape})\n")
+    out.write(f"  config: {target.path}\n")
+    out.write(f"  scope:  {target.describe()}\n")
+    out.write(
+        f"  recommended tier: {new_tier}  provider: {new_provider}  "
+        f"model: {new_model}"
+        + (f"  run_target: {new_run_target}" if new_run_target else "")
+        + "\n"
+    )
+    out.write(f"  current model:    {current if current is not None else '(unset)'}\n")
+
+    if is_noop:
+        out.write(
+            "  refused: recommended model equals the current model "
+            f"('{new_model}') — no change to apply.\n"
+        )
+        return 3
+
+    if args.dry_run:
+        out.write(
+            f"  DRY-RUN: would set provider = \"{new_provider}\", "
+            f"model = \"{new_model}\""
+            + (f", run_target = \"{new_run_target}\"" if new_run_target else "")
+            + f" (model was {current if current is not None else 'unset'}); "
+            "no file written.\n"
+        )
+        return 0
+
+    backup = backup_file(target.path)
+    set_tier_fields(
+        target,
+        provider=new_provider,
+        model=new_model,
+        run_target=new_run_target,
+    )
+
+    out.write(f"  backup: {backup}\n")
+    out.write(
+        f"  applied: model {current if current is not None else 'unset'} -> \"{new_model}\""
+        f"  (provider=\"{new_provider}\""
+        + (f", run_target=\"{new_run_target}\"" if new_run_target else "")
+        + ")\n"
+    )
+    out.write(
+        "  note: agent picks up the new provider/model/run_target on next "
+        "session (gc routes the dispatch on the gc.provider/gc.model/"
+        "gc.run_target triple).\n"
+    )
+    return 0
+
+
+# --------------------------------------------------------------------------- #
+# auto-apply  — sweep EVERY agent; set each to its conservative per-agent tier
+# --------------------------------------------------------------------------- #
+
+def cmd_auto_apply(args: argparse.Namespace, out: io.TextIOBase) -> int:
+    """Drive :func:`modeladvisor.autoapply.auto_apply` over the whole roster.
+
+    Default-safe: runs in **dry-run** unless ``--apply`` is given.  Emits a loud
+    per-agent summary (and the full structured report under ``--json``).  The
+    per-agent policy + apply gate live in :mod:`modeladvisor.autoapply`; this is
+    only the operator surface.
+    """
+    from modeladvisor import autoapply as _autoapply
+
+    engine = _load_engine()
+    state = _resolve_state(args)
+
+    # Default to dry-run; only --apply opts into writing.  (--dry-run is accepted
+    # explicitly and is the default, so passing it is a harmless no-op.)
+    dry_run = not getattr(args, "apply", False)
+
+    scope = "town"
+    rig = getattr(args, "rig", None)
+    if rig:
+        scope = f"rig:{rig}"
+
+    report = _autoapply.auto_apply(
+        state.cfg,
+        state.store,
+        scope=scope,
+        dry_run=dry_run,
+        provider=state.provider,
+        city=getattr(args, "city", None),
+        rig=rig,
+        engine=engine,
+    )
+
+    if getattr(args, "json", False):
+        json.dump(report.to_dict(), out, indent=2, default=str)
+        out.write("\n")
+        return _auto_apply_rc(report)
+
+    mode = "DRY-RUN (no files written)" if dry_run else "APPLY"
+    out.write(f"auto-apply [{report.scope}]  mode: {mode}\n")
+    out.write(f"  provider: {report.provider}\n")
+    for d in report.decisions:
+        _write_auto_decision(out, d, dry_run)
+
+    s = report.summary()
+    out.write(
+        "  ----------------------------------------------------------------\n"
+    )
+    out.write(
+        "  SUMMARY: {agents} agents | "
+        "{applied} applied | {dryrun} planned | {noop} no-op | "
+        "{skipped} skipped | {blocked} blocked | {error} error\n".format(
+            agents=s["agents"],
+            applied=s[_autoapply.STATUS_APPLIED],
+            dryrun=s[_autoapply.STATUS_DRYRUN],
+            noop=s[_autoapply.STATUS_NOOP],
+            skipped=s[_autoapply.STATUS_SKIPPED],
+            blocked=s[_autoapply.STATUS_BLOCKED],
+            error=s[_autoapply.STATUS_ERROR],
+        )
+    )
+    if dry_run and s[_autoapply.STATUS_DRYRUN]:
+        out.write(
+            "  NOTE: this was a dry run — re-run with --apply to write the "
+            f"{s[_autoapply.STATUS_DRYRUN]} planned change(s).\n"
+        )
+    return _auto_apply_rc(report)
+
+
+def _write_auto_decision(out: io.TextIOBase, d: Any, dry_run: bool) -> None:
+    """Render one per-agent decision line (+ detail) for the text report."""
+    tag = {
+        "applied": "APPLIED ",
+        "dry-run": "WOULD   ",
+        "noop": "noop    ",
+        "skipped": "skipped ",
+        "blocked": "BLOCKED ",
+        "error": "ERROR   ",
+    }.get(d.status, d.status)
+    cur = d.current_model if d.current_model is not None else "(unset)"
+    chosen = d.chosen_model or "?"
+    out.write(f"  [{tag}] {d.agent}\n")
+    out.write(
+        f"      tier: {d.chosen_tier or '?'}"
+        + (f" (binding shape: {d.binding_shape})" if d.binding_shape else "")
+        + f"   current: {cur} -> chosen: {chosen}\n"
+    )
+    if d.per_shape:
+        per = ", ".join(f"{k}={v}" for k, v in d.per_shape.items())
+        out.write(f"      per-shape: {per}\n")
+    if d.reason:
+        out.write(f"      why: {d.reason}\n")
+    if d.backup_path:
+        out.write(f"      backup: {d.backup_path}\n")
+
+
+def _auto_apply_rc(report: Any) -> int:
+    """Exit code: 1 if any per-agent error occurred, else 0.
+
+    A dry run with planned changes still returns 0 (it succeeded at planning);
+    operators / orders gate on the JSON/summary, not a non-zero rc, so a healthy
+    scheduled run is exit 0.
+    """
+    from modeladvisor import autoapply as _autoapply
+
+    return 1 if report.count(_autoapply.STATUS_ERROR) else 0
+
+
+def _default_shape_for(cfg: Any, agent: str) -> Optional[str]:
+    """Resolve an agent's canonical default shape from config, if any.
+
+    DESIGN §2.2 gives each agent a canonical shape set; the engine/config own
+    the real mapping.  We probe a couple of plausible accessors and otherwise
+    return ``None`` (caller then requires ``--shape``).
+    """
+    # The real config exposes ``canonical_shapes_for(agent) -> tuple[str, ...]``
+    # (DESIGN §2.2); the first canonical shape is the agent's default.  Probe a
+    # few plausible accessors so the CLI tolerates config-shape drift.
+    for attr in ("default_shape_for", "default_shape", "canonical_shapes_for"):
+        fn = getattr(cfg, attr, None)
+        if callable(fn):
+            try:
+                s = fn(agent)
+            except Exception:
+                continue
+            if isinstance(s, str) and s:
+                return s
+            if isinstance(s, (list, tuple)) and s:
+                return s[0]
+    shapes = getattr(cfg, "agent_shapes", None) or getattr(cfg, "canonical_shapes", None)
+    if isinstance(shapes, Mapping):
+        v = shapes.get(agent)
+        if isinstance(v, str):
+            return v
+        if isinstance(v, (list, tuple)) and v:
+            return v[0]
+    return None
+
+
+# --------------------------------------------------------------------------- #
+# eval-schedule  — Layer-4 auto-eval: rank gating cells + emit eval beads
+# --------------------------------------------------------------------------- #
+
+def cmd_eval_schedule(args: argparse.Namespace, out: io.TextIOBase) -> int:
+    """Rank the cells gating a downgrade on uncertainty and emit eval-request beads.
+
+    Drives :func:`modeladvisor.evalsched.schedule_evals` (pure planning) then
+    :func:`~modeladvisor.evalsched.emit_eval_beads` (gated emission). Dry-run by
+    default; ``--apply`` actually creates the beads (DESIGN §1.3 Layer 4 / §5.4).
+    """
+    from modeladvisor import evalsched as _evalsched
+
+    state = _resolve_state(args)
+    max_evals = getattr(args, "max", None)
+    if max_evals is None:
+        max_evals = 5
+    reqs = _evalsched.schedule_evals(state.cfg, state.store, max_evals=max_evals)
+
+    apply = getattr(args, "apply", False)
+    rig = getattr(args, "rig", None)
+    emitted = _evalsched.emit_eval_beads(reqs, dry_run=not apply, rig=rig)
+
+    if getattr(args, "json", False):
+        json.dump(
+            {
+                "mode": "apply" if apply else "dry-run",
+                "max_evals": max_evals,
+                "requests": [r.to_dict() for r in reqs],
+                "emitted": emitted,
+            },
+            out,
+            indent=2,
+            default=str,
+        )
+        out.write("\n")
+        return 0
+
+    mode = "APPLY (creating eval beads)" if apply else "DRY-RUN (no beads created)"
+    out.write(f"eval-schedule  mode: {mode}\n")
+    if not reqs:
+        out.write("  no cell is gating a downgrade on uncertainty — nothing to schedule.\n")
+        return 0
+    out.write(f"  {len(reqs)} eval probe(s) ranked by CI half-width x unlock-value:\n")
+    for r, e in zip(reqs, emitted):
+        out.write(
+            f"    {r.cell_key}  hw={r.ci_halfwidth:.3f} "
+            f"unlock={_fmt_money(r.unlock_value)} score={r.score:.4f}\n"
+        )
+        label = "would run" if not apply else "created"
+        out.write(f"      {label}: {e}\n")
+    return 0
+
+
+# --------------------------------------------------------------------------- #
+# federate  — export/import per-cell observed aggregates (privacy-safe)
+# --------------------------------------------------------------------------- #
+
+def cmd_federate(args: argparse.Namespace, out: io.TextIOBase) -> int:
+    """Export this rig's per-cell aggregates, or import + merge peers' (DESIGN §7.3).
+
+    ``federate export [--out FILE]`` writes the privacy-safe observed aggregates
+    (only ``a_obs``/``b_obs``/``n`` per cell — no raw telemetry). ``federate import
+    PEER... [--trust X] [--max-peer-mass M]`` folds peer aggregates into a fresh
+    store as trust-scaled prior mass and reports the cells moved.
+    """
+    from modeladvisor import federation as _federation
+
+    state = _resolve_state(args)
+    action = getattr(args, "action", None)
+
+    if action == "export":
+        doc = _federation.export_aggregates(state.store)
+        text = json.dumps(doc, indent=2, sort_keys=True)
+        out_path = getattr(args, "out", None)
+        if out_path:
+            os.makedirs(os.path.dirname(os.path.abspath(out_path)) or ".", exist_ok=True)
+            with open(out_path, "w", encoding="utf-8") as fh:
+                fh.write(text + "\n")
+            out.write(f"federate export: wrote {len(doc['cells'])} cell(s) -> {out_path}\n")
+        else:
+            out.write(text + "\n")
+        return 0
+
+    if action == "import":
+        peers = list(getattr(args, "peers", []) or [])
+        if not peers:
+            out.write("federate import: no peer export paths given.\n")
+            return 2
+        # Config-supplied defaults; CLI flags override when present.
+        trust = getattr(args, "trust", None)
+        if trust is None:
+            trust = getattr(state.cfg, "federation_trust", 0.3)
+        mpm = getattr(args, "max_peer_mass", None)
+        if mpm is None:
+            mpm = getattr(state.cfg, "federation_max_peer_mass", None)
+        try:
+            merged = _federation.merge_peers(
+                state.store, peers, trust=trust, max_peer_mass=mpm
+            )
+        except _federation.FederationError as e:
+            out.write(f"federate import: {e}\n")
+            return 2
+
+        if getattr(args, "json", False):
+            json.dump(
+                {
+                    "peers": peers,
+                    "trust": trust,
+                    "max_peer_mass": mpm,
+                    "merged_observed_cells": len(merged.observed_cells()),
+                },
+                out,
+                indent=2,
+                default=str,
+            )
+            out.write("\n")
+            return 0
+
+        out.write(
+            f"federate import: merged {len(peers)} peer(s) at trust={trust} "
+            f"-> {len(merged.observed_cells())} observed cell(s).\n"
+        )
+        return 0
+
+    out.write("federate: expected a subcommand 'export' or 'import'.\n")
+    return 2
+
+
+# --------------------------------------------------------------------------- #
+# drift  — report Page-Hinkley change-points per cell from the telemetry stream
+# --------------------------------------------------------------------------- #
+
+def cmd_drift(args: argparse.Namespace, out: io.TextIOBase) -> int:
+    """Report detected upstream-drift change-points per cell (DESIGN §7.3).
+
+    Reads the ordered ``kind="quality"`` records from the telemetry
+    ``invocations.jsonl``, groups them per cell, and runs
+    :func:`modeladvisor.changepoint.detect_changepoints` on each cell's time-ordered
+    ``q`` stream. Optional ``--agent``/``--shape``/``--provider`` filters narrow the
+    sweep. This is the read-only operator view of the adaptive safety hatch that
+    supersedes the static ``force_baseline`` (DESIGN §7.4).
+    """
+    from modeladvisor import changepoint as _changepoint
+    from modeladvisor.store import parse_cell_key, read_jsonl
+
+    state = _resolve_state(args)
+    telemetry_dir = (
+        getattr(args, "telemetry_dir", None)
+        or os.environ.get("ADVISOR_TELEMETRY_DIR")
+        or os.path.join(os.getcwd(), ".beads", "telemetry")
+    )
+    jsonl = os.path.join(telemetry_dir, "invocations.jsonl")
+
+    want_agent = getattr(args, "agent", None)
+    want_shape = getattr(args, "shape", None)
+    want_provider = getattr(args, "provider", None) or state.provider
+
+    # Group ordered q-streams per cell from the quality records.
+    streams: dict[str, list[float]] = {}
+    for rec in read_jsonl(jsonl):
+        if rec.get("kind") != "quality":
+            continue
+        key = rec.get("cell_key")
+        q = rec.get("q")
+        if not key or q is None:
+            continue
+        try:
+            prov, agent, shape, _tier = parse_cell_key(str(key))
+        except ValueError:
+            continue
+        if want_agent and agent != want_agent:
+            continue
+        if want_shape and shape != want_shape:
+            continue
+        if want_provider and prov != want_provider:
+            continue
+        try:
+            streams.setdefault(str(key), []).append(float(q))
+        except (TypeError, ValueError):
+            continue
+
+    drifted: list[dict] = []
+    for key in sorted(streams):
+        obs = streams[key]
+        cps = _changepoint.detect_changepoints(obs)
+        if not cps:
+            continue
+        c_star = max(cps)
+        pre = obs[:c_star] or obs[:1]
+        post = obs[c_star:] or obs[-1:]
+        drifted.append(
+            {
+                "cell_key": key,
+                "n": len(obs),
+                "changepoints": cps,
+                "pre_mean": round(sum(pre) / len(pre), 4),
+                "post_mean": round(sum(post) / len(post), 4),
+            }
+        )
+
+    if getattr(args, "json", False):
+        json.dump({"cells_scanned": len(streams), "drifted": drifted}, out, indent=2)
+        out.write("\n")
+        return 0
+
+    out.write(f"drift: scanned {len(streams)} cell(s) with telemetry\n")
+    if not drifted:
+        out.write("  no change-points detected — all scanned cells look stationary.\n")
+        return 0
+    for d in drifted:
+        out.write(
+            f"  {d['cell_key']}  n={d['n']}  shifts@{d['changepoints']}  "
+            f"mean {d['pre_mean']} -> {d['post_mean']}\n"
+        )
+    return 0
+
+
+# --------------------------------------------------------------------------- #
+# gc config editing  (the heart of `apply`)
+# --------------------------------------------------------------------------- #
+#
+# gc accepts a ``model`` field in three shapes (INTEGRATION verdict (A)):
+#
+#   1. a *flat* per-agent ``agent.toml`` (gastown style: the file IS the agent;
+#      ``model`` is a top-level key);
+#   2. an ``[[agent]]`` array-of-tables entry inside a pack/city toml, matched
+#      by ``name = "<agent>"``;
+#   3. an ``[agent_defaults]`` table (the default model for all agents).
+#
+# We perform a *surgical, format-preserving text edit* — insert or replace a
+# single ``model = "..."`` line in the correct scope — rather than round-trip
+# the TOML (which would drop comments/formatting and needs a writer lib the
+# venv doesn't ship).  This is the same approach gc's own ``doImportAdd`` takes.
+
+_MODEL_LINE = re.compile(r'^(?P<indent>[ \t]*)model[ \t]*=.*$', re.MULTILINE)
+
+# The cross-provider routing target gc honors per dispatch is the metadata triple
+# gc.provider / gc.model / gc.run_target (the core ``mol-review-quorum`` formula
+# proves gc routes on it).  Applying a tier must set all three in the agent's
+# config scope so a Codex tier actually runs on Codex (not just the model name).
+_TIER_FIELDS = ("provider", "model", "run_target")
+
+
+def _field_line_re(field: str) -> "re.Pattern[str]":
+    """A MULTILINE regex matching an existing ``<field> = ...`` line in scope."""
+    return re.compile(
+        r'^(?P<indent>[ \t]*)' + re.escape(field) + r'[ \t]*=.*$', re.MULTILINE
+    )
+
+
+class ConfigResolveError(Exception):
+    """Raised when the agent's config file/scope can't be resolved."""
+
+
+@dataclass
+class ConfigTarget:
+    """Where (file + scope) an agent's ``model`` field lives / should live."""
+
+    path: str
+    kind: str  # "flat" | "agent_block" | "agent_defaults"
+    # For agent_block/agent_defaults we keep the [byte] span of the table body
+    # so edits stay inside the right table.
+    span: Optional[tuple] = None  # (start, end) char offsets into the file text
+    agent: Optional[str] = None
+
+    def describe(self) -> str:
+        if self.kind == "flat":
+            return f"flat agent.toml (top-level model for '{self.agent}')"
+        if self.kind == "agent_block":
+            return f"[[agent]] name = \"{self.agent}\""
+        if self.kind == "agent_defaults":
+            return "[agent_defaults]"
+        return self.kind
+
+
+def _read(path: str) -> str:
+    with open(path, "r", encoding="utf-8") as fh:
+        return fh.read()
+
+
+def resolve_agent_config(
+    agent: str,
+    *,
+    city: Optional[str] = None,
+    rig: Optional[str] = None,
+) -> ConfigTarget:
+    """Locate the gc config file + scope that owns ``agent``'s model field.
+
+    The non-deprecated home for an agent's routing fields (``provider`` /
+    ``model`` / ``run_target``) is the **per-agent flat
+    ``agents/<agent>/agent.toml``** (gc warns that ``[workspace] provider`` is
+    deprecated → "set provider per agent in ``agents/<name>/agent.toml``", and
+    likewise resolves ``model`` per agent there). So resolution prefers — and,
+    when absent, **creates** — that flat file rather than writing into
+    ``city.toml``'s ``[workspace]`` / ``[[agent]]`` blocks.
+
+    Resolution (first hit wins):
+
+    1. ``$ADVISOR_AGENT_TOML`` — explicit file override (used by tests). If it
+       contains an ``[[agent]]`` block named ``agent`` we target that; if it has
+       an ``[agent_defaults]`` table we target that; otherwise it is treated as
+       a flat per-agent ``agent.toml``. (Honored verbatim — the caller named the
+       exact file, so we never redirect it to a created path.)
+    2. An **existing** flat ``<city>/.gc/system/packs/<rig?>/agents/<agent>/
+       agent.toml`` (the gastown layout). ``city`` defaults to ``$GC_CITY`` /
+       cwd; ``rig`` narrows the pack search.
+    3. If none exists, **create** a flat ``agents/<agent>/agent.toml`` at the
+       canonical pack root (the ``--rig`` pack if given, else the first
+       agent-bearing pack under ``.gc/system/packs``) and target it. This is the
+       non-deprecated per-agent home, materialized to match gc's convention.
+    4. Only if there is no ``.gc/system/packs`` at all do we fall back to a
+       ``[[agent]] name = "<agent>"`` block / ``[agent_defaults]`` table inside
+       ``<city>/city.toml``.
+
+    Raises :class:`ConfigResolveError` if nothing resolves.
+    """
+    override = os.environ.get("ADVISOR_AGENT_TOML")
+    if override:
+        if not os.path.exists(override):
+            raise ConfigResolveError(
+                f"ADVISOR_AGENT_TOML points at a missing file: {override}"
+            )
+        return _classify_config_file(override, agent)
+
+    city = city or os.environ.get("GC_CITY") or os.getcwd()
+
+    # (2) EXISTING flat gastown agent.toml — search common pack roots.
+    pack_roots = []
+    sys_packs = os.path.join(city, ".gc", "system", "packs")
+    if rig:
+        pack_roots.append(os.path.join(sys_packs, rig))
+    if os.path.isdir(sys_packs):
+        for entry in sorted(os.listdir(sys_packs)):
+            p = os.path.join(sys_packs, entry)
+            if os.path.isdir(p) and p not in pack_roots:
+                pack_roots.append(p)
+    for root in pack_roots:
+        cand = os.path.join(root, "agents", agent, "agent.toml")
+        if os.path.exists(cand):
+            return ConfigTarget(path=cand, kind="flat", agent=agent)
+
+    # (3) No existing per-agent file: CREATE the canonical flat
+    #     agents/<agent>/agent.toml (the non-deprecated home gc reads) rather
+    #     than writing the routing fields into city.toml's [workspace]/[[agent]]
+    #     (deprecated). Pick the creation pack root: the --rig pack if given,
+    #     else the first pack that already carries an agents/ dir (a real
+    #     agent-bearing pack like gastown — not bd/dolt/core), else the first
+    #     pack root. Materialize an empty file (+ parent dirs) so the downstream
+    #     read/backup/write path works unchanged (current model reads as unset).
+    create_root = _pick_creation_pack_root(pack_roots, rig, sys_packs)
+    if create_root is not None:
+        new_path = os.path.join(create_root, "agents", agent, "agent.toml")
+        os.makedirs(os.path.dirname(new_path), exist_ok=True)
+        if not os.path.exists(new_path):
+            with open(new_path, "w", encoding="utf-8") as fh:
+                fh.write("")  # empty flat agent.toml; set_field inserts the keys
+        return ConfigTarget(path=new_path, kind="flat", agent=agent)
+
+    # (4) Last resort (no .gc/system/packs at all): city.toml [[agent]] /
+    #     [agent_defaults]. Only reached on a city without a packs tree.
+    city_toml = os.path.join(city, "city.toml")
+    if os.path.exists(city_toml):
+        try:
+            return _classify_config_file(city_toml, agent, require_agent=True)
+        except ConfigResolveError:
+            pass
+
+    raise ConfigResolveError(
+        f"could not resolve a config file for agent '{agent}'. "
+        f"Looked for a flat agent.toml under {sys_packs} and an [[agent]]/"
+        f"[agent_defaults] block in {city_toml}. "
+        "Set ADVISOR_AGENT_TOML or pass --city/--rig."
+    )
+
+
+def _pick_creation_pack_root(
+    pack_roots: Sequence[str], rig: Optional[str], sys_packs: str
+) -> Optional[str]:
+    """Choose the pack root under which to create a new ``agents/<agent>/agent.toml``.
+
+    Preference order:
+      1. The ``--rig`` pack root, when ``rig`` was given and it exists on disk
+         (the operator scoped the apply to that rig).
+      2. The first pack root that already carries an ``agents/`` directory — i.e.
+         a real agent-bearing pack (``gastown``), not an infra pack
+         (``bd`` / ``dolt`` / ``core``) that holds no agents.
+      3. The first pack root, if any.
+
+    Returns ``None`` only when there are no pack roots at all (no
+    ``.gc/system/packs`` tree), which routes the caller to the city.toml fallback.
+    """
+    if rig:
+        rig_root = os.path.join(sys_packs, rig)
+        if os.path.isdir(rig_root):
+            return rig_root
+    for root in pack_roots:
+        if os.path.isdir(os.path.join(root, "agents")):
+            return root
+    return pack_roots[0] if pack_roots else None
+
+
+def _classify_config_file(
+    path: str, agent: str, require_agent: bool = False
+) -> ConfigTarget:
+    """Decide how ``agent``'s model is represented inside ``path``.
+
+    Looks for an ``[[agent]]`` table whose ``name`` matches ``agent`` first,
+    then an ``[agent_defaults]`` table, then falls back to treating the whole
+    file as a flat agent.toml — but *only* when the file is not structurally a
+    multi-agent config.  A file that carries ``[[agent]]`` blocks is a city /
+    pack config: if no block matches and there is no ``[agent_defaults]`` table,
+    treating the whole file as one agent's flat config would silently write the
+    model into the wrong place, so we refuse instead.
+    """
+    text = _read(path)
+
+    block = _find_agent_block(text, agent)
+    if block is not None:
+        return ConfigTarget(path=path, kind="agent_block", span=block, agent=agent)
+
+    defaults = _find_table(text, "agent_defaults")
+    if defaults is not None:
+        return ConfigTarget(
+            path=path, kind="agent_defaults", span=defaults, agent=agent
+        )
+
+    # No matching scope.  Is this a multi-agent (city/pack) config?
+    has_agent_blocks = any(
+        hdr.startswith("[[") and hdr.strip("[]").strip() == "agent"
+        for hdr, _s, _e in _table_headers(text)
+    )
+    if require_agent or has_agent_blocks:
+        raise ConfigResolveError(
+            f"{path} has no [[agent]] name = \"{agent}\" block and no "
+            "[agent_defaults] table to hold the model field"
+        )
+    return ConfigTarget(path=path, kind="flat", agent=agent)
+
+
+def _table_headers(text: str):
+    """Yield (header_name, header_start, body_start) for every top-level table.
+
+    ``header_name`` is the raw bracket content (e.g. ``agent_defaults`` or
+    ``[agent]`` for an array-of-tables — note double brackets keep their inner
+    ``[agent]``).  We only need coarse boundaries to scope an edit, so a simple
+    line scanner is sufficient and avoids a TOML round-trip.
+    """
+    for m in re.finditer(r'^[ \t]*(\[\[?[^\]\n]+\]\]?)[ \t]*$', text, re.MULTILINE):
+        yield m.group(1), m.start(), m.end()
+
+
+def _find_table(text: str, name: str) -> Optional[tuple]:
+    """Return the (body_start, body_end) char span of the ``[name]`` table body."""
+    headers = list(_table_headers(text))
+    for i, (hdr, _hstart, hend) in enumerate(headers):
+        inner = hdr.strip("[]").strip()
+        if inner == name and not hdr.startswith("[["):
+            body_start = hend
+            body_end = headers[i + 1][1] if i + 1 < len(headers) else len(text)
+            return (body_start, body_end)
+    return None
+
+
+def _find_agent_block(text: str, agent: str) -> Optional[tuple]:
+    """Return the body span of the ``[[agent]]`` table whose ``name == agent``.
+
+    Also matches a ``[agent.<name>]`` / ``[crew.<name>]`` / ``[workers.<name>]``
+    style table (seen in ship.toml-style configs) keyed by the dotted name.
+    """
+    headers = list(_table_headers(text))
+    for i, (hdr, _hstart, hend) in enumerate(headers):
+        body_start = hend
+        body_end = headers[i + 1][1] if i + 1 < len(headers) else len(text)
+        body = text[body_start:body_end]
+        inner = hdr.strip("[]").strip()
+        is_array = hdr.startswith("[[")
+        if is_array and inner == "agent":
+            # match by `name = "<agent>"` inside the body
+            nm = re.search(r'^[ \t]*name[ \t]*=[ \t]*["\']([^"\']+)["\']',
+                           body, re.MULTILINE)
+            if nm and nm.group(1) == agent:
+                return (body_start, body_end)
+        elif not is_array and "." in inner:
+            # dotted table like [crew.Yatima] / [workers.builder] / [agent.foo]
+            _prefix, _, dotted = inner.partition(".")
+            if dotted == agent:
+                return (body_start, body_end)
+    return None
+
+
+def read_model_field(target: ConfigTarget) -> Optional[str]:
+    """Return the current ``model`` string for the target, or ``None`` if unset."""
+    return read_field(target, "model")
+
+
+def read_field(target: ConfigTarget, field: str) -> Optional[str]:
+    """Return the current ``<field>`` string in the target's scope, or ``None``.
+
+    Generalises :func:`read_model_field` to any scalar key (``provider`` /
+    ``model`` / ``run_target``) so the apply path can report the current routing
+    triple, not just the model.
+    """
+    text = _read(target.path)
+    region = text
+    if target.span is not None:
+        region = text[target.span[0]:target.span[1]]
+    esc = re.escape(field)
+    m = re.search(
+        r'^[ \t]*' + esc + r'[ \t]*=[ \t]*["\']([^"\']*)["\']', region, re.MULTILINE
+    )
+    if m:
+        return m.group(1)
+    # also accept an unquoted value just in case
+    m = re.search(r'^[ \t]*' + esc + r'[ \t]*=[ \t]*([^\s#]+)', region, re.MULTILINE)
+    if m:
+        return m.group(1).strip().strip('"\'')
+    return None
+
+
+def set_model_field(target: ConfigTarget, model: str) -> None:
+    """Write ``model = "<model>"`` into the target's scope, in place.
+
+    Thin back-compat wrapper over :func:`set_field`.  If a ``model`` line already
+    exists in scope it is replaced; otherwise a new line is inserted at the top
+    of the scope body — but for an ``[[agent]]`` block just *after* the block's
+    ``name = "..."`` line.  Formatting/comments elsewhere are preserved
+    byte-for-byte.
+    """
+    set_field(target, "model", model)
+
+
+def set_provider_field(target: ConfigTarget, provider: str) -> None:
+    """Write ``provider = "<provider>"`` into the target's scope (see :func:`set_field`)."""
+    set_field(target, "provider", provider)
+
+
+def set_run_target_field(target: ConfigTarget, run_target: str) -> None:
+    """Write ``run_target = "<run_target>"`` into the target's scope (see :func:`set_field`)."""
+    set_field(target, "run_target", run_target)
+
+
+def set_field(target: ConfigTarget, field: str, value: str) -> None:
+    """Replace-or-insert ``<field> = "<value>"`` in the target's scope, in place.
+
+    The byte-preserving editor generalised over the field name (``provider`` /
+    ``model`` / ``run_target``).  An existing line for that field in scope is
+    replaced; otherwise a new line is inserted at the top of the scope body —
+    after the ``name = "..."`` line for an ``[[agent]]`` block so the block stays
+    readable.  Everything else is preserved byte-for-byte.
+    """
+    text = _read(target.path)
+    new_line = f'{field} = "{value}"'
+
+    if target.span is None:
+        # flat agent.toml: whole-file scope.
+        updated = _replace_or_insert_top(text, field, new_line)
+    else:
+        start, end = target.span
+        body = text[start:end]
+        after_name = target.kind == "agent_block"
+        new_body = _replace_or_insert_top(
+            body, field, new_line, indent_from=body, after_name=after_name
+        )
+        updated = text[:start] + new_body + text[end:]
+
+    _atomic_write(target.path, updated)
+
+
+def set_tier_fields(
+    target: ConfigTarget,
+    *,
+    provider: Optional[str] = None,
+    model: Optional[str] = None,
+    run_target: Optional[str] = None,
+) -> None:
+    """Route an agent to a whole tier: set ``provider`` / ``model`` / ``run_target``.
+
+    Applying a roster tier must set the full cross-provider routing target gc
+    honors per dispatch (``gc.provider`` / ``gc.model`` / ``gc.run_target``), not
+    just the model — otherwise a Codex tier would keep running on the agent's old
+    provider.  This is **additive and byte-preserving**: each present field is
+    replace-or-inserted via :func:`set_field`; ``None`` fields are left alone.
+
+    ``model`` is always intended to be passed (back-compat: the model is still
+    always written), with ``provider`` + ``run_target`` added alongside.  All
+    three are applied in one pass so callers don't re-read the file per field.
+    """
+    # Order matters only for readability of a freshly-inserted block: write
+    # provider, then model, then run_target so they land in a natural order
+    # (each insert goes after `name`, so the last-written sits closest to it;
+    # writing run_target last keeps model above it / provider at the bottom of
+    # the inserted run — harmless either way, and replaces are position-stable).
+    for field, val in (
+        ("provider", provider),
+        ("model", model),
+        ("run_target", run_target),
+    ):
+        if val is not None and val != "":
+            set_field(target, field, val)
+
+
+def _replace_or_insert_top(
+    body: str,
+    field: str,
+    new_line: str,
+    indent_from: Optional[str] = None,
+    after_name: bool = False,
+) -> str:
+    """Replace an existing ``<field> =`` line in ``body`` else insert it.
+
+    ``indent_from`` (the scope body) is used to detect an existing indentation
+    convention so an inserted line matches sibling keys.  When ``after_name`` is
+    set and the body has a ``name = "..."`` line (an ``[[agent]]`` block), the
+    new line is inserted right after it; otherwise it goes at the top of the
+    body (after any leading blank lines).
+    """
+    m = _field_line_re(field).search(body)
+    if m:
+        indent = m.group("indent")
+        return body[: m.start()] + f"{indent}{new_line}" + body[m.end():]
+
+    indent = ""
+    src = indent_from if indent_from is not None else body
+    km = re.search(r'^(?P<indent>[ \t]+)\S', src, re.MULTILINE)
+    if km:
+        indent = km.group("indent")
+
+    insert = f"{indent}{new_line}\n"
+
+    if after_name:
+        nm = re.search(r'^[ \t]*name[ \t]*=.*$', body, re.MULTILINE)
+        if nm:
+            # insert on the line after `name = "..."`
+            pos = nm.end()
+            # step past the newline that terminates the name line
+            nl = body.find("\n", pos)
+            pos = (nl + 1) if nl != -1 else len(body)
+            return body[:pos] + insert + body[pos:]
+
+    # Insert after a leading run of blank/whitespace lines so we sit at the top
+    # of the actual content (and, for a scoped body, right under the header gap).
+    lead = re.match(r'^([ \t]*\n)*', body)
+    pos = lead.end() if lead else 0
+    return body[:pos] + insert + body[pos:]
+
+
+# --------------------------------------------------------------------------- #
+# dispatch-side companion: the per-DISPATCH route triple
+# --------------------------------------------------------------------------- #
+
+def dispatch_metadata(cfg: Any, tier_id: str) -> dict:
+    """Return the gc bead/agent routing metadata triple for a tier.
+
+    The per-agent ``apply`` stamps the agent's *default* config; this is its
+    dispatch-side companion: the ``{gc.provider, gc.model, gc.run_target}`` a
+    caller can stamp on a single work bead to route just that dispatch to the
+    tier's provider + model + run target (the triple the core
+    ``mol-review-quorum`` formula proves gc honors per dispatch).
+    """
+    tier = cfg.tier(tier_id)
+    return {
+        "gc.provider": tier.provider,
+        "gc.model": tier.model,
+        "gc.run_target": tier.run_target,
+    }
+
+
+def backup_file(path: str) -> str:
+    """Copy ``path`` to a timestamped ``.bak`` sibling and return its path."""
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    backup = f"{path}.advisor-bak-{ts}"
+    shutil.copy2(path, backup)
+    return backup
+
+
+def _atomic_write(path: str, text: str) -> None:
+    """Write ``text`` to ``path`` atomically (temp file + os.replace)."""
+    tmp = f"{path}.advisor-tmp"
+    with open(tmp, "w", encoding="utf-8") as fh:
+        fh.write(text)
+    os.replace(tmp, path)
+
+
+# --------------------------------------------------------------------------- #
+# state resolution shared by the subcommands
+# --------------------------------------------------------------------------- #
+
+def _resolve_state(args: argparse.Namespace) -> State:
+    return build_state(
+        advisor_toml=getattr(args, "config", None),
+        telemetry_dir=getattr(args, "telemetry_dir", None),
+        provider=getattr(args, "provider", None),
+    )
+
+
+def _resolve_cascade(bead_id: str, out: io.TextIOBase) -> Any:
+    """Shell ``gc bd dep tree --json <bead>`` into a :class:`cascade.CascadeResult`.
+
+    Best-effort + non-fatal: any failure (gc absent, non-JSON, unknown bead) prints
+    a note and returns ``None`` so the advice still runs with the flat ``N_dep``
+    (DESIGN §8 — the advisor must never block a dispatch).
+    """
+    import subprocess
+
+    from modeladvisor import cascade as _cascade
+
+    try:
+        proc = subprocess.run(
+            ["gc", "bd", "dep", "tree", "--json", bead_id],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as e:  # pragma: no cover - needs gc
+        out.write(f"  note: --cascade-bead ignored (gc bd dep tree failed: {e})\n")
+        return None
+    if proc.returncode != 0 or not proc.stdout.strip():  # pragma: no cover - needs gc
+        out.write("  note: --cascade-bead ignored (gc bd dep tree returned nothing)\n")
+        return None
+    try:
+        tree = json.loads(proc.stdout)
+    except (ValueError, json.JSONDecodeError):  # pragma: no cover - needs gc
+        out.write("  note: --cascade-bead ignored (dep tree was not valid JSON)\n")
+        return None
+    graph = _cascade.build_graph_from_dep_json(tree)
+    return _cascade.effective_cascade(graph, bead_id)
+
+
+# --------------------------------------------------------------------------- #
+# argparse
+# --------------------------------------------------------------------------- #
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog=PROG,
+        description="model-advisor — recommend / inspect / apply the "
+        "cost-minimal model tier per agent·shape.",
+    )
+    p.add_argument(
+        "--config",
+        help="path to advisor.toml (else $ADVISOR_TOML or built-in defaults)",
+    )
+    p.add_argument(
+        "--telemetry-dir",
+        dest="telemetry_dir",
+        help="telemetry dir holding invocations.jsonl / advisor-cells.json "
+        "(else $ADVISOR_TELEMETRY_DIR or ./.beads/telemetry)",
+    )
+    p.add_argument(
+        "--provider",
+        help="provider token for the cell key (else config / 'claude')",
+    )
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    a = sub.add_parser(
+        "advise",
+        help="recommend a tier for <agent> <shape> (+ rationale, cost diff)",
+    )
+    a.add_argument("agent")
+    a.add_argument("shape")
+    a.add_argument("--json", action="store_true",
+                   help="emit the structured `reasons` audit object")
+    a.add_argument("--thompson", action="store_true",
+                   help="use the genuine seeded Thompson-Sampling mode (DESIGN §7.3)")
+    a.add_argument("--seed", type=int, default=None,
+                   help="RNG seed for --thompson (reproducible draw)")
+    a.add_argument("--cascade-bead", dest="cascade_bead", metavar="ID",
+                   help="scale N_dep by this bead's downstream DAG "
+                   "(gc bd dep tree --json)")
+    a.set_defaults(func=cmd_advise)
+
+    i = sub.add_parser(
+        "inspect",
+        help="per-tier posteriors + quality-drop CIs + widest gating cell",
+    )
+    i.add_argument("agent")
+    i.add_argument("shape")
+    i.add_argument("--json", action="store_true",
+                   help="emit the per-tier table + widest-cell pointer as JSON")
+    i.set_defaults(func=cmd_inspect)
+
+    ap = sub.add_parser(
+        "apply",
+        help="set the agent's default model in gc config to the recommendation",
+    )
+    ap.add_argument("agent")
+    ap.add_argument("--shape", help="shape to recommend on (else agent's "
+                    "canonical default)")
+    ap.add_argument("--city", help="city root (else $GC_CITY or cwd)")
+    ap.add_argument("--rig", help="narrow the pack search to this rig")
+    ap.add_argument("--dry-run", action="store_true", dest="dry_run",
+                    help="print the planned change without writing")
+    ap.add_argument("--json", action="store_true",
+                    help="emit the structured apply result (incl. the per-DISPATCH "
+                    "gc.provider/gc.model/gc.run_target metadata) as JSON")
+    ap.set_defaults(func=cmd_apply)
+
+    aa = sub.add_parser(
+        "auto-apply",
+        help="sweep EVERY agent; set each to its conservative per-agent tier "
+        "(safest across its shapes), evidence-gated. Dry-run by default.",
+    )
+    scope_grp = aa.add_mutually_exclusive_group()
+    scope_grp.add_argument(
+        "--town", action="store_true",
+        help="sweep all town/city agents (the default scope)",
+    )
+    scope_grp.add_argument(
+        "--rig", metavar="NAME",
+        help="narrow the config search + scope label to this rig",
+    )
+    aa.add_argument("--city", help="city root (else $GC_CITY or cwd)")
+    aa.add_argument(
+        "--dry-run", action="store_true", dest="dry_run",
+        help="compute + report the plan without writing (this is the DEFAULT)",
+    )
+    aa.add_argument(
+        "--apply", action="store_true", dest="apply",
+        help="actually write config changes (otherwise dry-run-safe)",
+    )
+    aa.add_argument("--json", action="store_true",
+                    help="emit the full structured per-agent report as JSON")
+    aa.set_defaults(func=cmd_auto_apply)
+
+    # ---- eval-schedule: Layer-4 auto-eval (DESIGN §5.4) ----
+    es = sub.add_parser(
+        "eval-schedule",
+        help="rank gating cells by CI half-width x unlock-value and emit eval "
+        "beads for the top N (dry-run by default)",
+    )
+    es.add_argument("--max", type=int, default=5,
+                    help="cap on eval beads to schedule this run (default 5)")
+    es.add_argument("--rig", metavar="NAME",
+                    help="create the eval beads in this rig's database")
+    es.add_argument("--city", help="city root (else $GC_CITY or cwd)")
+    es.add_argument("--apply", action="store_true",
+                    help="actually create the eval beads (otherwise dry-run-safe)")
+    es.add_argument("--json", action="store_true",
+                    help="emit the ranked plan + emitted commands/ids as JSON")
+    es.set_defaults(func=cmd_eval_schedule)
+
+    # ---- federate: export/import per-cell observed aggregates (DESIGN §7.3) ----
+    fe = sub.add_parser(
+        "federate",
+        help="export this rig's per-cell aggregates, or import + merge peers'",
+    )
+    fe_sub = fe.add_subparsers(dest="action", required=True)
+    fe_exp = fe_sub.add_parser(
+        "export", help="write privacy-safe per-cell aggregates (a_obs/b_obs/n)",
+    )
+    fe_exp.add_argument("--out", help="write to this file (else stdout)")
+    fe_exp.set_defaults(func=cmd_federate)
+    fe_imp = fe_sub.add_parser(
+        "import", help="fold peer aggregate exports into a merged store",
+    )
+    fe_imp.add_argument("peers", nargs="+", help="peer advisor-federation.json path(s)")
+    fe_imp.add_argument("--trust", type=float, default=None,
+                        help="trust weight on peer mass (else config / 0.3)")
+    fe_imp.add_argument("--max-peer-mass", dest="max_peer_mass", type=float,
+                        default=None, help="cap injected peer pseudocount mass per cell")
+    fe_imp.add_argument("--json", action="store_true",
+                        help="emit the merge summary as JSON")
+    fe_imp.set_defaults(func=cmd_federate)
+
+    # ---- drift: report Page-Hinkley change-points per cell (DESIGN §7.3) ----
+    dr = sub.add_parser(
+        "drift",
+        help="report detected upstream-drift change-points per cell from telemetry",
+    )
+    dr.add_argument("--agent", help="filter to this agent")
+    dr.add_argument("--shape", help="filter to this shape")
+    dr.add_argument("--provider", help="filter to this provider (else config default)")
+    dr.add_argument("--json", action="store_true",
+                    help="emit the per-cell drift report as JSON")
+    dr.set_defaults(func=cmd_drift)
+
+    return p
+
+
+def main(argv: Optional[Sequence[str]] = None,
+         out: Optional[io.TextIOBase] = None) -> int:
+    argv = list(sys.argv[1:] if argv is None else argv)
+    out = out or sys.stdout
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return args.func(args, out)
+    except BrokenPipeError:  # pragma: no cover - piped to head etc.
+        return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/model-advisor/modeladvisor/config.py
+++ b/model-advisor/modeladvisor/config.py
@@ -1,0 +1,883 @@
+"""Configuration for the model-advisor (``advisor.toml``).
+
+This module loads and validates the advisor's configuration into a single
+immutable :class:`AdvisorConfig`. It is stdlib-only — TOML is parsed with
+:mod:`tomllib` (Python 3.11+). Nothing here touches the network.
+
+What the config carries (all driven from ``advisor.toml``, nothing hard-coded in
+the decision path):
+
+- **roster** — the user's cost-ordered list of model tiers
+  (``[[tier]]`` blocks: ``provider``, ``model``, ``tier_id``, ``rank``,
+  ``in_cost``, ``out_cost``). ``rank`` induces the ``≺`` cost order used by the
+  gate / loss. The baseline (reference) tier ``tier*`` defaults to the
+  highest-``rank`` (most-capable) tier.
+- **shapes** — the gc-native task taxonomy
+  (``lookup``/``implement``/``judge``/``review``/``patrol``, config-extensible),
+  each with a default tolerance class; plus per-agent canonical shape sets.
+- **tolerance classes** — ``Critical``/``Strict``/``Moderate``/``Lenient`` with
+  ``q_tol`` and the asymmetric-loss multiplier ``M`` (``∞/20/5/1``).
+- **hyperparameters** — DESIGN appendix-D defaults (``alpha``, ``z``,
+  ``theta_eval``, pooling ``lambda``, ``s_prior``, cold-start means, channel
+  weights, representative per-shape token budgets).
+
+A sensible :func:`default_config` is always available so the engine works with
+zero config files; :data:`SAMPLE_TOML` is the editable starter the pack ships.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import tomllib
+from dataclasses import dataclass, field, replace
+from typing import Mapping, Sequence
+
+# --------------------------------------------------------------------------- #
+# Canonical names (the seed taxonomy — config can extend, never relied on raw) #
+# --------------------------------------------------------------------------- #
+
+#: The four tolerance classes from DESIGN §1.2, in cost-aggressiveness order.
+TOLERANCE_CLASS_NAMES = ("Critical", "Strict", "Moderate", "Lenient")
+
+#: The five seed shapes from DESIGN §2.2 (config-extensible).
+SEED_SHAPE_NAMES = ("lookup", "implement", "judge", "review", "patrol")
+
+#: ``M = ∞`` for Critical is encoded as +inf; it is a *hard* never-downgrade rule.
+_INF = math.inf
+
+
+# --------------------------------------------------------------------------- #
+# Dataclasses                                                                   #
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class Tier:
+    """One configured ``(provider, model)`` run target — a roster tier.
+
+    ``rank`` is the user-asserted cost order (1 = cheapest). It is *not* inferred
+    from quality. ``in_cost``/``out_cost`` are the rate-sheet $/MTok used for the
+    deterministic ``cost(tier, tok_in, tok_out)`` (DESIGN §2.3).
+    """
+
+    tier_id: str
+    provider: str
+    model: str
+    rank: int
+    in_cost: float
+    out_cost: float
+    #: gc agent/session-config target to dispatch to (opaque to the advisor).
+    run_target: str = ""
+
+    def cost(self, tok_in: float, tok_out: float) -> float:
+        """Deterministic dollar cost for a dispatch of this size (DESIGN §2.3)."""
+        return tok_in / 1e6 * self.in_cost + tok_out / 1e6 * self.out_cost
+
+
+@dataclass(frozen=True)
+class ToleranceClass:
+    """A quality-loss tolerance class (DESIGN §1.2).
+
+    ``q_tol`` is the max allowable absolute quality drop vs the baseline tier.
+    ``multiplier`` (``M``) scales the asymmetric cascade loss; ``Critical`` uses
+    ``+inf`` which is the *hard* never-downgrade contract (not a tunable).
+    """
+
+    name: str
+    q_tol: float
+    multiplier: float  # M; +inf for Critical
+
+    @property
+    def is_critical(self) -> bool:
+        return math.isinf(self.multiplier) or self.name == "Critical"
+
+
+@dataclass(frozen=True)
+class Shape:
+    """A cognitive task kind (DESIGN §2.2) with its default tolerance class."""
+
+    name: str
+    default_tol_class: str  # name of a ToleranceClass
+
+
+@dataclass(frozen=True)
+class Hyperparams:
+    """CC-TS hyperparameters (DESIGN appendix D / §3). All config-overridable."""
+
+    # --- gate / CI ---
+    alpha: float = 0.05  # one-sided confidence level (1 - alpha = 0.95)
+    z: float = 1.645  # z_{1-alpha}; matched to alpha=0.05 one-sided
+    theta_eval: float = 0.10  # CI half-width that triggers the (deferred) eval flag
+
+    # --- pooling (DESIGN §1.3 hierarchical partial pooling) ---
+    pool_lambda: float = 0.5  # global cap on pseudocount pooling weight
+
+    # --- cold-start prior (DESIGN §3.2) ---
+    s_prior: float = 4.0  # total pseudocount for cheaper tiers (weak)
+    baseline_a: float = 8.0  # optimistic baseline prior Beta(8, 2) -> mean 0.8
+    baseline_b: float = 2.0
+    cold_m_lo: float = 0.5  # cheapest-tier prior mean floor
+    # cold_m_hi defaults to the baseline mean (baseline_a / (a+b)); see resolved value.
+
+    # --- quality channel weights (DESIGN §4.4) ---
+    w_close: float = 1.0
+    w_review: float = 3.0
+    w_eval: float = 5.0
+
+    # --- representative token budget when realised counts are absent (§5.4) ---
+    rep_tok_in: float = 1200.0
+    rep_tok_out: float = 400.0
+
+    # --- v3 deferred-feature toggles (DESIGN §7.3; all default to v1 behaviour) ---
+    #: Accept a continuous quality signal ``q ∈ [0, 1]`` (reviewer score / test-pass
+    #: fraction) instead of the strict Bernoulli ``{0, 1}`` (``continuous.py``). Off
+    #: ⇒ the binary path is byte-identical to v1.
+    continuous_quality: bool = False
+    #: Decision mode: ``"lcb"`` (the v1 deterministic LCB rule) or ``"thompson"``
+    #: (genuine seeded Thompson sampling — ``thompson.py``). Off ⇒ v1 byte-identical.
+    mode: str = "lcb"
+    #: Down-weight stale pre-drift evidence via Page-Hinkley change-point detection
+    #: in ``rebuild`` (``changepoint.py``). Off ⇒ the straight-fold replay is
+    #: unchanged.
+    changepoint: bool = False
+
+    @property
+    def baseline_mean(self) -> float:
+        return self.baseline_a / (self.baseline_a + self.baseline_b)
+
+
+@dataclass(frozen=True)
+class AdvisorConfig:
+    """The fully-resolved advisor configuration.
+
+    Constructed by :func:`load_config` / :func:`default_config`; treated as
+    immutable by the engine (which is a pure function of ``(config, store)``).
+    """
+
+    tiers: tuple[Tier, ...]  # cost-ordered (cheapest -> most-capable)
+    shapes: tuple[Shape, ...]
+    tol_classes: tuple[ToleranceClass, ...]
+    #: agent base-name -> its canonical shape set (DESIGN §2.2). Empty / missing
+    #: agent means "all configured shapes are canonical for it."
+    agent_shapes: Mapping[str, tuple[str, ...]]
+    #: Default provider when a caller doesn't pass one (city default).
+    default_provider: str
+    #: Token tier_id of the baseline / reference tier ``tier*``.
+    baseline_tier_id: str
+    #: Per-(agent, shape) tolerance-class overrides: {(agent, shape): class_name}.
+    tol_overrides: Mapping[tuple[str, str], str]
+    #: Per-(agent, shape) baseline-tier overrides (the static safety hatch host).
+    baseline_overrides: Mapping[tuple[str, str], str]
+    #: Per-(agent, shape) force_baseline flags (DESIGN §7.4 safety hatch).
+    force_baseline: Mapping[tuple[str, str], bool]
+    #: Per-shape representative token budgets {shape: (tok_in, tok_out)} (§5.4).
+    shape_budgets: Mapping[str, tuple[float, float]]
+    hp: Hyperparams = field(default_factory=Hyperparams)
+
+    # ---- v3 deferred-feature backends (DESIGN §7.3; default to v1 behaviour) ---- #
+    #: Lower-confidence-bound backend for the gate: ``"wilson"`` (v1 normal LCB on
+    #: the Beta) or ``"conformal"`` (distribution-free split-conformal — ``conformal.py``).
+    #: Conformal degrades to Wilson on a thin/empty calibration buffer, so this is a
+    #: safe drop-in.
+    lcb_backend: str = "wilson"
+    #: Hierarchical pooling backend: ``"closed-form"`` (v1 capped-pseudocount
+    #: :meth:`CellStore.pooled`) or ``"empirical-bayes"`` (genuine EB shrinkage —
+    #: ``hierarchical.py``).
+    pooling: str = "closed-form"
+    #: Federation peers (DESIGN §7.3): paths to peer ``advisor-federation.json``
+    #: exports whose observed aggregates are folded into priors. Empty ⇒ no peers,
+    #: no behaviour change.
+    federation_peers: tuple[str, ...] = ()
+    #: Trust weight applied to peer aggregates on merge (``federation.merge_peers``).
+    federation_trust: float = 0.3
+    #: Optional per-cell cap on injected peer pseudocount mass (``None`` ⇒ uncapped).
+    federation_max_peer_mass: float | None = None
+
+    # ---- lookup helpers (used by the store + engine) ------------------------ #
+
+    def tier(self, tier_id: str) -> Tier:
+        for t in self.tiers:
+            if t.tier_id == tier_id:
+                return t
+        raise KeyError(f"tier_id {tier_id!r} not in roster")
+
+    def has_tier(self, tier_id: str) -> bool:
+        return any(t.tier_id == tier_id for t in self.tiers)
+
+    @property
+    def baseline_tier(self) -> Tier:
+        return self.tier(self.baseline_tier_id)
+
+    def tol_class(self, name: str) -> ToleranceClass:
+        for c in self.tol_classes:
+            if c.name == name:
+                return c
+        raise KeyError(f"tolerance class {name!r} not configured")
+
+    def shape(self, name: str) -> Shape:
+        for s in self.shapes:
+            if s.name == name:
+                return s
+        raise KeyError(f"shape {name!r} not in taxonomy")
+
+    def has_shape(self, name: str) -> bool:
+        return any(s.name == name for s in self.shapes)
+
+    def baseline_tier_id_for(self, agent: str, shape: str) -> str:
+        """Resolve the effective baseline tier for a cell (per-cell override wins)."""
+        return self.baseline_overrides.get((agent, shape), self.baseline_tier_id)
+
+    def tol_class_for(self, agent: str, shape: str) -> ToleranceClass:
+        """Resolve the effective tolerance class for a cell.
+
+        Precedence: per-(agent, shape) override > shape default.
+        """
+        name = self.tol_overrides.get((agent, shape))
+        if name is None:
+            name = self.shape(shape).default_tol_class
+        return self.tol_class(name)
+
+    def is_forced_baseline(self, agent: str, shape: str) -> bool:
+        return bool(self.force_baseline.get((agent, shape), False))
+
+    def budget_for(self, shape: str) -> tuple[float, float]:
+        """Representative (tok_in, tok_out) for a shape (§5.4)."""
+        if shape in self.shape_budgets:
+            return self.shape_budgets[shape]
+        return (self.hp.rep_tok_in, self.hp.rep_tok_out)
+
+    def canonical_shapes_for(self, agent: str) -> tuple[str, ...]:
+        """Canonical shape set for an agent, defaulting to all shapes (§2.2)."""
+        s = self.agent_shapes.get(agent)
+        if s:
+            return s
+        return tuple(sh.name for sh in self.shapes)
+
+    @property
+    def tier_ids(self) -> tuple[str, ...]:
+        return tuple(t.tier_id for t in self.tiers)
+
+    def cheaper_than(self, tier_id: str) -> tuple[str, ...]:
+        """Tier ids strictly cheaper (lower in the cost order) than ``tier_id``."""
+        pivot = self._order_index(tier_id)
+        return tuple(t.tier_id for t in self.tiers if self._order_index(t.tier_id) < pivot)
+
+    def _order_index(self, tier_id: str) -> int:
+        return self.tier_ids.index(tier_id)
+
+    def with_hyperparams(self, **overrides: object) -> "AdvisorConfig":
+        """Return a copy with overridden hyperparameters (handy for tests)."""
+        return replace(self, hp=replace(self.hp, **overrides))
+
+
+# --------------------------------------------------------------------------- #
+# Defaults                                                                      #
+# --------------------------------------------------------------------------- #
+
+#: Default tolerance classes (DESIGN §1.2 table). q_tol uses the strict upper
+#: edge of each class band; M is the documented multiplier.
+DEFAULT_TOL_CLASSES: tuple[ToleranceClass, ...] = (
+    ToleranceClass("Critical", q_tol=0.0, multiplier=_INF),
+    ToleranceClass("Strict", q_tol=0.02, multiplier=20.0),
+    ToleranceClass("Moderate", q_tol=0.05, multiplier=5.0),
+    ToleranceClass("Lenient", q_tol=0.10, multiplier=1.0),
+)
+
+#: Default shape -> tolerance-class mapping (DESIGN §2.2 "Typical tolerance").
+DEFAULT_SHAPES: tuple[Shape, ...] = (
+    Shape("lookup", "Lenient"),
+    Shape("implement", "Moderate"),
+    Shape("judge", "Moderate"),
+    Shape("review", "Strict"),
+    Shape("patrol", "Lenient"),
+)
+
+#: Default per-agent canonical shapes (DESIGN §2.2).
+DEFAULT_AGENT_SHAPES: dict[str, tuple[str, ...]] = {
+    "polecat": ("implement", "lookup"),
+    "refinery": ("review", "judge"),
+    "witness": ("patrol", "judge"),
+    "boot": ("patrol", "judge"),
+    "deacon": ("patrol", "judge"),
+    "mayor": ("judge", "implement", "lookup"),
+}
+
+#: Default Claude roster (illustrative costs, $/MTok). The user edits this.
+#: rank 1 = cheapest. Baseline tier* defaults to the highest rank (opus).
+DEFAULT_TIERS: tuple[Tier, ...] = (
+    Tier(tier_id="haiku", provider="claude", model="claude-haiku-4-5",
+         rank=1, in_cost=0.80, out_cost=4.00, run_target="claude-haiku"),
+    Tier(tier_id="sonnet", provider="claude", model="claude-sonnet-4-5",
+         rank=2, in_cost=3.00, out_cost=15.00, run_target="claude-sonnet"),
+    Tier(tier_id="opus", provider="claude", model="claude-opus-4-8",
+         rank=3, in_cost=15.00, out_cost=75.00, run_target="claude-opus"),
+)
+
+
+def default_config() -> AdvisorConfig:
+    """A complete, sensible default config (Claude haiku/sonnet/opus roster).
+
+    Used when no ``advisor.toml`` is present. Baseline = the most-capable tier.
+    """
+    return _finalise(
+        tiers=list(DEFAULT_TIERS),
+        shapes=list(DEFAULT_SHAPES),
+        tol_classes=list(DEFAULT_TOL_CLASSES),
+        agent_shapes=dict(DEFAULT_AGENT_SHAPES),
+        default_provider="claude",
+        baseline_tier_id=None,  # -> highest rank
+        tol_overrides={},
+        baseline_overrides={},
+        force_baseline={},
+        shape_budgets={},
+        hp=Hyperparams(),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Loading / validation                                                          #
+# --------------------------------------------------------------------------- #
+
+
+class ConfigError(ValueError):
+    """Raised when ``advisor.toml`` is missing required structure or is invalid."""
+
+
+def load_config(path: str | os.PathLike[str] | None = None) -> AdvisorConfig:
+    """Load ``advisor.toml`` from ``path`` (or return :func:`default_config`).
+
+    If ``path`` is ``None`` or does not exist, the default config is returned so
+    the advisor always has a roster to order tiers with. Any *malformed* config
+    (e.g. duplicate ranks, an unknown baseline tier, a shape pointing at an
+    undefined tolerance class) raises :class:`ConfigError`.
+    """
+    if path is None:
+        return default_config()
+    p = os.fspath(path)
+    if not os.path.exists(p):
+        return default_config()
+    with open(p, "rb") as fh:
+        raw = tomllib.load(fh)
+    return from_mapping(raw)
+
+
+def from_mapping(raw: Mapping[str, object]) -> AdvisorConfig:
+    """Build an :class:`AdvisorConfig` from a parsed-TOML mapping.
+
+    Kept separate from :func:`load_config` so tests can drive it from a dict and
+    the CLI can reuse the same validation on an already-parsed document.
+    """
+    # ---- tolerance classes (fall back to defaults) ----
+    tol_classes = _parse_tol_classes(raw.get("tolerance"))
+    tol_names = {c.name for c in tol_classes}
+
+    # ---- shapes (fall back to defaults) ----
+    shapes = _parse_shapes(raw.get("shape"), tol_names)
+
+    # ---- roster ----
+    tiers = _parse_tiers(raw.get("tier"))
+
+    # ---- advisor table (top-level knobs) ----
+    adv = raw.get("advisor") or {}
+    if not isinstance(adv, Mapping):
+        raise ConfigError("[advisor] must be a table")
+    default_provider = str(adv.get("default_provider", tiers[0].provider if tiers else "claude"))
+    baseline_tier_id = adv.get("baseline_tier")
+    baseline_tier_id = str(baseline_tier_id) if baseline_tier_id is not None else None
+    # v3 backend selectors (DESIGN §7.3); default to v1 behaviour. Validation that
+    # the value names a known backend happens in _finalise.
+    lcb_backend = str(adv.get("lcb_backend", "wilson"))
+    pooling = str(adv.get("pooling", "closed-form"))
+
+    # ---- federation table (opt-in; default no peers ⇒ no behaviour change) ----
+    fed_peers, fed_trust, fed_max_mass = _parse_federation(raw.get("federation"))
+
+    # ---- per-agent canonical shapes + per-cell overrides ----
+    agent_shapes, tol_overrides, baseline_overrides, force_baseline = _parse_agents(
+        raw.get("agent"), {s.name for s in shapes}, tol_names
+    )
+
+    # ---- per-shape representative token budgets ----
+    shape_budgets = _parse_shape_budgets(raw.get("shape"))
+
+    # ---- hyperparameters ----
+    hp = _parse_hyperparams(raw.get("hyperparams"))
+
+    return _finalise(
+        tiers=tiers,
+        shapes=shapes,
+        tol_classes=tol_classes,
+        agent_shapes=agent_shapes,
+        default_provider=default_provider,
+        baseline_tier_id=baseline_tier_id,
+        tol_overrides=tol_overrides,
+        baseline_overrides=baseline_overrides,
+        force_baseline=force_baseline,
+        shape_budgets=shape_budgets,
+        hp=hp,
+        lcb_backend=lcb_backend,
+        pooling=pooling,
+        federation_peers=fed_peers,
+        federation_trust=fed_trust,
+        federation_max_peer_mass=fed_max_mass,
+    )
+
+
+def _parse_federation(value: object) -> tuple[tuple[str, ...], float, float | None]:
+    """Parse the optional ``[federation]`` table (DESIGN §7.3 multi-tenant).
+
+    Returns ``(peers, trust, max_peer_mass)``. A missing table ⇒ ``((), 0.3, None)``
+    — no peers, so the merge is a no-op and behaviour is unchanged. ``peers`` is an
+    array of paths to peer ``advisor-federation.json`` exports; ``trust`` scales
+    borrowed mass; ``max_peer_mass`` (optional) caps injected peer pseudocount mass
+    per cell.
+    """
+    if value is None:
+        return (), 0.3, None
+    if not isinstance(value, Mapping):
+        raise ConfigError("[federation] must be a table")
+    peers_raw = value.get("peers", ())
+    if isinstance(peers_raw, (str, bytes)) or not isinstance(peers_raw, Sequence):
+        raise ConfigError("[federation] 'peers' must be an array of paths")
+    peers = tuple(str(p) for p in peers_raw)
+    trust = float(value.get("trust", 0.3))
+    mpm = value.get("max_peer_mass")
+    max_peer_mass = None if mpm is None else float(mpm)
+    return peers, trust, max_peer_mass
+
+
+def _finalise(
+    *,
+    tiers: list[Tier],
+    shapes: list[Shape],
+    tol_classes: list[ToleranceClass],
+    agent_shapes: dict,
+    default_provider: str,
+    baseline_tier_id: str | None,
+    tol_overrides: dict,
+    baseline_overrides: dict,
+    force_baseline: dict,
+    shape_budgets: dict,
+    hp: Hyperparams,
+    lcb_backend: str = "wilson",
+    pooling: str = "closed-form",
+    federation_peers: tuple[str, ...] = (),
+    federation_trust: float = 0.3,
+    federation_max_peer_mass: float | None = None,
+) -> AdvisorConfig:
+    """Validate cross-references and sort the roster into cost order."""
+    if not tiers:
+        raise ConfigError("roster is empty: at least one [[tier]] is required to order tiers")
+    if not shapes:
+        raise ConfigError("shape taxonomy is empty: at least one [[shape]] is required")
+    if not tol_classes:
+        raise ConfigError("no tolerance classes configured")
+
+    # Unique tier ids.
+    ids = [t.tier_id for t in tiers]
+    dupes = {i for i in ids if ids.count(i) > 1}
+    if dupes:
+        raise ConfigError(f"duplicate tier_id(s): {sorted(dupes)}")
+
+    # Sort cheapest -> most-capable. Total order: rank, then in_cost, then
+    # out_cost, then tier_id (deterministic tie-break — DESIGN §2.3).
+    ordered = tuple(sorted(tiers, key=lambda t: (t.rank, t.in_cost, t.out_cost, t.tier_id)))
+
+    # Baseline defaults to the most-capable (last in cost order) tier.
+    if baseline_tier_id is None:
+        baseline_tier_id = ordered[-1].tier_id
+    if baseline_tier_id not in {t.tier_id for t in ordered}:
+        raise ConfigError(
+            f"baseline_tier {baseline_tier_id!r} is not in the roster {sorted(ids)}"
+        )
+
+    # Shapes must reference defined tolerance classes.
+    tol_names = {c.name for c in tol_classes}
+    for s in shapes:
+        if s.default_tol_class not in tol_names:
+            raise ConfigError(
+                f"shape {s.name!r} default tolerance class "
+                f"{s.default_tol_class!r} is not defined"
+            )
+
+    # Per-cell overrides must reference defined tiers / classes / shapes.
+    shape_names = {s.name for s in shapes}
+    for (agent, shp), cls in tol_overrides.items():
+        if shp not in shape_names:
+            raise ConfigError(f"tol override for unknown shape {shp!r} (agent {agent!r})")
+        if cls not in tol_names:
+            raise ConfigError(f"tol override references unknown class {cls!r}")
+    for (agent, shp), tid in baseline_overrides.items():
+        if tid not in {t.tier_id for t in ordered}:
+            raise ConfigError(f"baseline override references unknown tier {tid!r}")
+
+    # v3 backend selectors must name a known backend (DESIGN §7.3).
+    if lcb_backend not in {"wilson", "conformal"}:
+        raise ConfigError(
+            f"lcb_backend {lcb_backend!r} must be one of {{'wilson', 'conformal'}}"
+        )
+    if pooling not in {"closed-form", "empirical-bayes"}:
+        raise ConfigError(
+            f"pooling {pooling!r} must be one of {{'closed-form', 'empirical-bayes'}}"
+        )
+
+    return AdvisorConfig(
+        tiers=ordered,
+        shapes=tuple(shapes),
+        tol_classes=tuple(tol_classes),
+        agent_shapes={k: tuple(v) for k, v in agent_shapes.items()},
+        default_provider=default_provider,
+        baseline_tier_id=baseline_tier_id,
+        tol_overrides=dict(tol_overrides),
+        baseline_overrides=dict(baseline_overrides),
+        force_baseline=dict(force_baseline),
+        shape_budgets=dict(shape_budgets),
+        hp=hp,
+        lcb_backend=lcb_backend,
+        pooling=pooling,
+        federation_peers=tuple(federation_peers),
+        federation_trust=float(federation_trust),
+        federation_max_peer_mass=(
+            None if federation_max_peer_mass is None else float(federation_max_peer_mass)
+        ),
+    )
+
+
+# ---- section parsers ------------------------------------------------------- #
+
+
+def _as_list_of_tables(value: object, section: str) -> list[Mapping[str, object]]:
+    if value is None:
+        return []
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        raise ConfigError(f"[[{section}]] must be an array of tables")
+    out: list[Mapping[str, object]] = []
+    for item in value:
+        if not isinstance(item, Mapping):
+            raise ConfigError(f"each [[{section}]] entry must be a table")
+        out.append(item)
+    return out
+
+
+def _parse_tiers(value: object) -> list[Tier]:
+    rows = _as_list_of_tables(value, "tier")
+    if not rows:
+        return list(DEFAULT_TIERS)
+    tiers: list[Tier] = []
+    for i, r in enumerate(rows):
+        try:
+            tier_id = str(r["id"]) if "id" in r else str(r["tier_id"])
+        except KeyError:
+            raise ConfigError(f"[[tier]] #{i} missing 'id' (tier_id)")
+        if "rank" not in r:
+            raise ConfigError(f"[[tier]] {tier_id!r} missing 'rank'")
+        tiers.append(
+            Tier(
+                tier_id=tier_id,
+                provider=str(r.get("provider", "claude")),
+                model=str(r.get("model", "")),
+                rank=int(r["rank"]),
+                in_cost=float(r.get("in_cost", 0.0)),
+                out_cost=float(r.get("out_cost", 0.0)),
+                run_target=str(r.get("run_target", "")),
+            )
+        )
+    return tiers
+
+
+def _parse_shapes(value: object, tol_names: set[str]) -> list[Shape]:
+    rows = _as_list_of_tables(value, "shape")
+    if not rows:
+        return list(DEFAULT_SHAPES)
+    shapes: list[Shape] = []
+    seen: set[str] = set()
+    for i, r in enumerate(rows):
+        if "name" not in r:
+            raise ConfigError(f"[[shape]] #{i} missing 'name'")
+        name = str(r["name"])
+        if name in seen:
+            raise ConfigError(f"duplicate shape {name!r}")
+        seen.add(name)
+        cls = str(r.get("tol_class", r.get("default_tol_class", "Moderate")))
+        shapes.append(Shape(name=name, default_tol_class=cls))
+    return shapes
+
+
+def _parse_shape_budgets(value: object) -> dict[str, tuple[float, float]]:
+    rows = _as_list_of_tables(value, "shape")
+    out: dict[str, tuple[float, float]] = {}
+    for r in rows:
+        if "name" not in r:
+            continue
+        if "tok_in" in r or "tok_out" in r:
+            out[str(r["name"])] = (float(r.get("tok_in", 0.0)), float(r.get("tok_out", 0.0)))
+    return out
+
+
+def _parse_tol_classes(value: object) -> list[ToleranceClass]:
+    rows = _as_list_of_tables(value, "tolerance")
+    if not rows:
+        return list(DEFAULT_TOL_CLASSES)
+    classes: list[ToleranceClass] = []
+    for i, r in enumerate(rows):
+        if "name" not in r:
+            raise ConfigError(f"[[tolerance]] #{i} missing 'name'")
+        name = str(r["name"])
+        q_tol = float(r.get("q_tol", 0.05))
+        m_raw = r.get("multiplier", r.get("M", 5.0))
+        if isinstance(m_raw, str) and m_raw.strip().lower() in {"inf", "infinity", "+inf"}:
+            multiplier = _INF
+        else:
+            multiplier = float(m_raw)
+        # A q_tol of exactly 0 is Critical by construction.
+        if q_tol <= 0.0 and not math.isinf(multiplier):
+            multiplier = _INF
+        classes.append(ToleranceClass(name=name, q_tol=q_tol, multiplier=multiplier))
+    return classes
+
+
+def _parse_agents(
+    value: object, shape_names: set[str], tol_names: set[str]
+) -> tuple[dict, dict, dict, dict]:
+    rows = _as_list_of_tables(value, "agent")
+    agent_shapes: dict[str, tuple[str, ...]] = {}
+    tol_overrides: dict[tuple[str, str], str] = {}
+    baseline_overrides: dict[tuple[str, str], str] = {}
+    force_baseline: dict[tuple[str, str], bool] = {}
+    if not rows:
+        return dict(DEFAULT_AGENT_SHAPES), tol_overrides, baseline_overrides, force_baseline
+    for i, r in enumerate(rows):
+        if "name" not in r:
+            raise ConfigError(f"[[agent]] #{i} missing 'name'")
+        agent = str(r["name"])
+        shps = r.get("shapes")
+        if shps is not None:
+            if not isinstance(shps, Sequence) or isinstance(shps, (str, bytes)):
+                raise ConfigError(f"agent {agent!r} 'shapes' must be an array of names")
+            agent_shapes[agent] = tuple(str(s) for s in shps)
+        # Per-cell overrides live under [[agent.cell]] sub-tables.
+        cells = r.get("cell")
+        for c in _as_list_of_tables(cells, "agent.cell"):
+            if "shape" not in c:
+                raise ConfigError(f"agent {agent!r} [[agent.cell]] missing 'shape'")
+            shp = str(c["shape"])
+            if "tol_class" in c:
+                tol_overrides[(agent, shp)] = str(c["tol_class"])
+            if "baseline_tier" in c:
+                baseline_overrides[(agent, shp)] = str(c["baseline_tier"])
+            if "force_baseline" in c:
+                force_baseline[(agent, shp)] = bool(c["force_baseline"])
+    # If a config declares [[agent]] blocks but none of the defaults, keep the
+    # documented role defaults for any agent it didn't mention.
+    for a, s in DEFAULT_AGENT_SHAPES.items():
+        agent_shapes.setdefault(a, s)
+    return agent_shapes, tol_overrides, baseline_overrides, force_baseline
+
+
+def _as_bool(value: object) -> bool:
+    """Coerce a TOML/JSON value to ``bool`` (true/1/yes/on are truthy strings)."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        return value.strip().lower() in {"true", "1", "yes", "on"}
+    return bool(value)
+
+
+def _parse_hyperparams(value: object) -> Hyperparams:
+    if value is None:
+        return Hyperparams()
+    if not isinstance(value, Mapping):
+        raise ConfigError("[hyperparams] must be a table")
+    base = Hyperparams()
+    # Accept any subset of fields; ignore unknowns gracefully but type-coerce known ones.
+    fields = {
+        "alpha": float, "z": float, "theta_eval": float, "pool_lambda": float,
+        "s_prior": float, "baseline_a": float, "baseline_b": float,
+        "cold_m_lo": float, "w_close": float, "w_review": float, "w_eval": float,
+        "rep_tok_in": float, "rep_tok_out": float,
+        # v3 deferred-feature toggles (DESIGN §7.3); default to v1 behaviour.
+        "continuous_quality": _as_bool, "mode": str, "changepoint": _as_bool,
+    }
+    kwargs = {}
+    for k, conv in fields.items():
+        if k in value:
+            kwargs[k] = conv(value[k])
+    return replace(base, **kwargs)
+
+
+# --------------------------------------------------------------------------- #
+# Sample advisor.toml (the editable starter the pack ships)                     #
+# --------------------------------------------------------------------------- #
+
+SAMPLE_TOML = '''\
+# advisor.toml — model-advisor configuration (edit me).
+#
+# This file defines the cost-ordered model roster, the task-shape taxonomy, the
+# quality-loss tolerance classes, and per-agent defaults. Everything the CC-TS
+# engine needs to order tiers and gate downgrades lives here. Deleting this file
+# falls back to a built-in Claude haiku/sonnet/opus default with the same shape.
+#
+# Cell key = "<provider>::<agent>::<shape>::<tier_id>".
+
+[advisor]
+default_provider = "claude"
+# Baseline / reference tier (tier*). All downgrade constraints are relative to
+# it. Defaults to the highest-rank (most-capable) tier if omitted.
+baseline_tier = "opus"
+
+# --------------------------------------------------------------------------- #
+# Roster — the user's cost-ordered model tiers. rank 1 = cheapest.            #
+# in_cost / out_cost are $/MTok (illustrative; replace with your rate sheet). #
+# --------------------------------------------------------------------------- #
+[[tier]]
+id         = "haiku"
+provider   = "claude"
+model      = "claude-haiku-4-5"
+run_target = "claude-haiku"
+rank       = 1
+in_cost    = 0.80
+out_cost   = 4.00
+
+[[tier]]
+id         = "sonnet"
+provider   = "claude"
+model      = "claude-sonnet-4-5"
+run_target = "claude-sonnet"
+rank       = 2
+in_cost    = 3.00
+out_cost   = 15.00
+
+[[tier]]
+id         = "opus"
+provider   = "claude"
+model      = "claude-opus-4-8"
+run_target = "claude-opus"
+rank       = 3
+in_cost    = 15.00
+out_cost   = 75.00
+
+# --------------------------------------------------------------------------- #
+# Tolerance classes — max allowable quality drop (q_tol) + asymmetric         #
+# multiplier M. Critical is a HARD never-downgrade rule (M = inf).            #
+# --------------------------------------------------------------------------- #
+[[tolerance]]
+name = "Critical"
+q_tol = 0.0
+multiplier = "inf"
+
+[[tolerance]]
+name = "Strict"
+q_tol = 0.02
+multiplier = 20
+
+[[tolerance]]
+name = "Moderate"
+q_tol = 0.05
+multiplier = 5
+
+[[tolerance]]
+name = "Lenient"
+q_tol = 0.10
+multiplier = 1
+
+# --------------------------------------------------------------------------- #
+# Shapes — the gc-native task taxonomy. Each shape has a default tolerance     #
+# class and an optional representative token budget (tok_in/tok_out) used for #
+# cost differentials when realised token counts are unavailable.             #
+# --------------------------------------------------------------------------- #
+[[shape]]
+name = "lookup"
+tol_class = "Lenient"
+tok_in = 800
+tok_out = 200
+
+[[shape]]
+name = "implement"
+tol_class = "Moderate"
+tok_in = 4000
+tok_out = 1500
+
+[[shape]]
+name = "judge"
+tol_class = "Moderate"
+tok_in = 1500
+tok_out = 400
+
+[[shape]]
+name = "review"
+tol_class = "Strict"
+tok_in = 3000
+tok_out = 800
+
+[[shape]]
+name = "patrol"
+tol_class = "Lenient"
+tok_in = 1000
+tok_out = 300
+
+# --------------------------------------------------------------------------- #
+# Agents — canonical shape sets + optional per-cell overrides. Cells only      #
+# exist for an agent's canonical shapes. Use [[agent.cell]] to pin a stricter #
+# tolerance, a lower baseline, or the force_baseline safety hatch.           #
+# --------------------------------------------------------------------------- #
+[[agent]]
+name = "polecat"
+shapes = ["implement", "lookup"]
+
+[[agent]]
+name = "refinery"
+shapes = ["review", "judge"]
+
+  # Refinery release-gating decisions are Critical (never downgrade).
+  [[agent.cell]]
+  shape = "judge"
+  tol_class = "Critical"
+
+[[agent]]
+name = "mayor"
+shapes = ["judge", "implement", "lookup"]
+
+[[agent]]
+name = "witness"
+shapes = ["patrol", "judge"]
+
+[[agent]]
+name = "boot"
+shapes = ["patrol", "judge"]
+
+[[agent]]
+name = "deacon"
+shapes = ["patrol", "judge"]
+
+# --------------------------------------------------------------------------- #
+# Hyperparameters (CC-TS appendix D defaults). All optional.                  #
+# --------------------------------------------------------------------------- #
+[hyperparams]
+alpha       = 0.05   # one-sided confidence (1 - alpha = 0.95)
+z           = 1.645  # z_{0.95}, matched to alpha
+theta_eval  = 0.10   # CI half-width that flags a cell for an eval probe
+pool_lambda = 0.5    # cap on cross-sibling pseudocount pooling
+s_prior     = 4.0    # cold-start pseudocount for cheaper tiers (weak)
+baseline_a  = 8.0    # optimistic baseline prior Beta(8, 2) -> mean 0.80
+baseline_b  = 2.0
+cold_m_lo   = 0.5    # cheapest-tier cold-start prior mean
+w_close     = 1.0    # quality channel weights (close < review < eval)
+w_review    = 3.0
+w_eval      = 5.0
+'''
+
+
+def write_sample_toml(path: str | os.PathLike[str], *, overwrite: bool = False) -> str:
+    """Write :data:`SAMPLE_TOML` to ``path``. Returns the path written.
+
+    Refuses to clobber an existing file unless ``overwrite=True``.
+    """
+    p = os.fspath(path)
+    if os.path.exists(p) and not overwrite:
+        raise FileExistsError(f"{p} exists; pass overwrite=True to replace it")
+    with open(p, "w", encoding="utf-8") as fh:
+        fh.write(SAMPLE_TOML)
+    return p

--- a/model-advisor/modeladvisor/conformal.py
+++ b/model-advisor/modeladvisor/conformal.py
@@ -1,0 +1,264 @@
+"""Distribution-free split-conformal lower bound (DESIGN §1.3 Layer 2, §5.2, §7.3).
+
+A drop-in alternative LCB backend for the conservative gate. v1 ships the
+Wilson-style normal lower bound on the Beta posterior (``engine.wilson_lcb``) as
+the *asymptotic stand-in*; DESIGN §5.2 states the paper's formal coverage
+guarantee for a **distribution-free conformal** bound built from a rolling,
+held-out per-cell calibration buffer of ``(predicted, observed)`` quality pairs.
+This module builds that buffer and that bound, designed so it:
+
+- **coincides with Wilson asymptotically** — the bound is
+  ``mu − Q·sigma`` where ``sigma`` is the cell's posterior standard error and
+  ``Q`` is the ``(1 − alpha)`` empirical quantile of the *standardized*
+  calibration residuals. For a well-calibrated cell whose residuals are
+  symmetric, ``Q → z_{1−alpha}`` as the buffer grows, so the bound converges to
+  the Wilson bound ``mu − z·sigma`` (the v1 default); and
+- **degrades to Wilson when the buffer is thin** — with fewer than ``min_buffer``
+  calibration points (or a degenerate zero-spread buffer) :func:`conformal_lcb`
+  returns *exactly* ``max(0, mu − z·sigma)``, so flipping the ``lcb_backend`` flag
+  is a behaviour-preserving change on day-1 cells with no exchangeable history
+  (DESIGN §7.3). This is the safe-drop-in contract.
+
+Why this is the conservative-correct backend (DESIGN §5.2 + §7.3): when the cell
+is **over-confident** — its predictions systematically exceed realised quality
+(``pred ≫ obs``) — the calibration residuals shift positive, their ``(1 − alpha)``
+standardized quantile ``Q`` grows past ``z``, and the bound drops *below* Wilson,
+so the gate stops admitting the downgrade. The Wilson bound, keyed only off the
+posterior spread, cannot see that miscalibration; the conformal bound, keyed off
+the realised prediction errors, can. That is the entire point of the deferred
+feature.
+
+Stdlib-only (``math``, ``statistics``, ``bisect``) — no numpy/scipy, per the
+build brief. Pure functions plus one small ``@dataclass`` for the buffer; no
+hidden I/O or globals.
+
+**Conformity score (the residual definition, fixed and documented here once).**
+For each calibration pair the raw error is
+
+    e_i = pred_i − obs_i                                  (signed prediction error)
+
+with ``pred_i`` the model's predicted quality at decision time and
+``obs_i ∈ {0,1}`` (Bernoulli close/reopen) or ``[0,1]`` (graded eval verdict) the
+realised outcome. A *positive* error is an over-prediction (the cell claimed more
+quality than it delivered). The conformity score is the **standardized** error
+``s_i = e_i / sd(e)`` (so its ``(1 − alpha)`` quantile lands on the same
+``z``-scale Wilson uses), and the one-sided ``(1 − alpha)`` conformal lower bound
+on the cell's true mean quality is
+
+    q_lo = clamp_[0,1]( mu − Q_{1−alpha}(s) · sigma )
+
+where ``mu``/``sigma`` are the cell's posterior mean and standard error (the same
+quantities Wilson uses, so the two backends are directly comparable) and
+``Q_{1−alpha}`` is the finite-sample split-conformal quantile — the
+``ceil((n+1)(1−alpha))``-th order statistic of the standardized residuals (the
+standard split-conformal rank; DESIGN §5.2). For an exchangeable calibration
+stream this gives marginal coverage ``Pr[theta ≥ q_lo] ≳ 1 − alpha`` (DESIGN §5
+Thm + appendix proof — distribution-free up to the discreteness of a Bernoulli
+residual), which — composed with the gate ``q_lo ≥ mu* − q_tol`` — yields the
+conservative admission guarantee ``Pr[theta_tier ≥ mu* − q_tol] ≳ 1 − alpha``
+(DESIGN §5.2).
+"""
+
+from __future__ import annotations
+
+import bisect
+import math
+from dataclasses import dataclass, field
+from statistics import pstdev
+from typing import TYPE_CHECKING, Mapping
+
+if TYPE_CHECKING:  # avoid an import cycle; only needed for the type hint.
+    from modeladvisor.store import Cell
+
+
+# --------------------------------------------------------------------------- #
+# Rolling calibration buffer (DESIGN §4.3, §5.2, §7.3)                          #
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class CalibrationBuffer:
+    """A bounded ring buffer of recent ``(pred, obs)`` calibration pairs for a cell.
+
+    Each pair records the model's **predicted** quality at decision time
+    (``pred ∈ [0, 1]``) and the **observed** realised outcome (``obs ∈ {0, 1}`` for
+    a Bernoulli close/reopen signal, or ``[0, 1]`` for a graded eval verdict). The
+    distribution-free split-conformal bound (:func:`conformal_lcb`) is computed
+    from the residuals ``pred − obs`` of these pairs (DESIGN §5.2).
+
+    Ring semantics: at most ``cap`` pairs are retained; appending beyond ``cap``
+    drops the **oldest** pair, so the buffer is a sliding window of recent history
+    (DESIGN §7.3 "rolling per-cell calibration buffer"). The default ``cap`` of
+    500 keeps the window long enough for a stable ``(1 − alpha)`` quantile while
+    bounding the per-cell footprint in ``advisor-cells.json``.
+    """
+
+    cap: int = 500
+    #: Recent (pred, obs) pairs, oldest-first. Length never exceeds ``cap``.
+    pairs: list[tuple[float, float]] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if self.cap < 1:
+            raise ValueError(f"CalibrationBuffer cap must be >= 1, got {self.cap}")
+        # Defend against an over-long ``pairs`` passed straight to the constructor
+        # (e.g. a tampered cache): retain only the most-recent ``cap``.
+        if len(self.pairs) > self.cap:
+            self.pairs = self.pairs[-self.cap :]
+
+    def append(self, pred: float, obs: float) -> None:
+        """Append one ``(pred, obs)`` pair, dropping the oldest past ``cap``.
+
+        ``pred`` is clamped to ``[0, 1]`` (a predicted *quality* is a probability);
+        ``obs`` is clamped to ``[0, 1]`` (Bernoulli outcomes already are, a graded
+        eval verdict may be anywhere in the unit interval). DESIGN §5.2.
+        """
+        p = _clamp01(float(pred))
+        o = _clamp01(float(obs))
+        self.pairs.append((p, o))
+        if len(self.pairs) > self.cap:
+            # Ring-buffer drop-oldest. ``cap >= 1`` so this leaves >= 1 element.
+            del self.pairs[0 : len(self.pairs) - self.cap]
+
+    def residuals(self) -> list[float]:
+        """The raw prediction errors ``e_i = pred_i − obs_i`` (DESIGN §5.2).
+
+        Positive ⇒ the cell over-predicted (claimed more quality than realised).
+        """
+        return [p - o for (p, o) in self.pairs]
+
+    def __len__(self) -> int:
+        return len(self.pairs)
+
+    # ---- (de)serialisation for the advisor-cells.json cache (DESIGN §5.5) ---- #
+
+    def to_dict(self) -> dict:
+        """Serialise to a JSON-friendly dict for the per-cell cache (DESIGN §5.5).
+
+        Pairs are stored as ``[pred, obs]`` lists (JSON has no tuples). ``cap`` is
+        persisted so the window length survives a reload.
+        """
+        return {"cap": self.cap, "pairs": [[p, o] for (p, o) in self.pairs]}
+
+    @classmethod
+    def from_dict(cls, d: Mapping) -> "CalibrationBuffer":
+        """Inverse of :meth:`to_dict`; tolerant of a missing/empty ``pairs``."""
+        cap = int(d.get("cap", 500))
+        raw = d.get("pairs") or []
+        pairs = [(float(p), float(o)) for p, o in raw]
+        return cls(cap=cap, pairs=pairs)
+
+
+# --------------------------------------------------------------------------- #
+# Split-conformal lower confidence bound (DESIGN §5.2)                          #
+# --------------------------------------------------------------------------- #
+
+
+def conformal_lcb(
+    cell: "Cell",
+    buffer: CalibrationBuffer,
+    z: float,
+    *,
+    alpha: float = 0.05,
+    min_buffer: int = 20,
+) -> float:
+    """One-sided distribution-free lower bound on the cell's true mean quality.
+
+    A **drop-in alternative** to :func:`modeladvisor.engine.wilson_lcb` (the same
+    ``(cell, …, z)`` call-shape plus the calibration buffer): both return a
+    one-sided lower confidence bound ``q_lo`` the conservative gate compares to
+    ``mu* − q_tol`` (DESIGN §1.3 Layer 2). Selected when ``cfg.lcb_backend ==
+    'conformal'``; otherwise the engine calls Wilson.
+
+    Behaviour:
+
+    - **Thin / degenerate buffer** (``len(buffer) < min_buffer``, or every residual
+      identical so there is no spread to standardize): return *exactly*
+      ``max(0.0, cell.mean − z·cell.stderr)`` — the Wilson bound. A cell with no
+      exchangeable calibration history (DESIGN §7.3) is bounded precisely as v1
+      does today, so enabling the conformal backend can never *change* a thin-cell
+      decision. This is the safe-drop-in contract.
+    - **Rich buffer** (``len(buffer) ≥ min_buffer``): the split-conformal bound
+
+          s_i  = (pred_i − obs_i) / sd(pred − obs)        (standardized residuals)
+          Q    = the ceil((n+1)(1−alpha))-th smallest s_i (clamped into rank range)
+          q_lo = clamp_[0,1]( cell.mean − Q · cell.stderr )
+
+      (DESIGN §5.2). For a symmetric well-calibrated stream ``Q → z_{1−alpha}`` so
+      ``q_lo`` converges to the Wilson bound; an over-confident cell (``pred ≫
+      obs``) shifts the residuals positive, raising ``Q`` past ``z`` and pushing
+      ``q_lo`` *below* Wilson — catching the miscalibration the posterior spread
+      alone cannot see.
+
+    Parameters
+    ----------
+    cell:
+        The (pooled) cell whose ``mean`` is the point estimate and whose
+        ``mean``/``stderr`` define both the Wilson fallback and the conformal
+        bound's scale.
+    buffer:
+        Rolling per-cell calibration buffer of ``(pred, obs)`` pairs.
+    z:
+        ``z_{1−alpha}`` for the Wilson fallback (the engine passes ``cfg.hp.z``);
+        keeps the thin-buffer path byte-identical to ``wilson_lcb``.
+    alpha:
+        One-sided miscoverage level; the bound targets coverage ``1 − alpha``
+        (default 0.05, matching ``cfg.hp.alpha``).
+    min_buffer:
+        Minimum calibration points before the conformal bound is used; below it,
+        fall back to Wilson (default 20).
+
+    Returns
+    -------
+    float in ``[0, 1]`` — the lower confidence bound ``q_lo``.
+    """
+    wilson = max(0.0, cell.mean - z * cell.stderr)
+
+    n = len(buffer)
+    if n < min_buffer:
+        return wilson  # safe drop-in: identical to engine.wilson_lcb(cell, z).
+
+    errs = buffer.residuals()
+    sd = pstdev(errs)
+    if sd <= 0.0:
+        # No residual spread to standardize (e.g. every pred == obs). The conformal
+        # quantile is undefined; fall back to Wilson rather than divide by zero.
+        return wilson
+
+    scores = sorted(e / sd for e in errs)
+    q = _conformal_quantile(scores, alpha)
+
+    return _clamp01(cell.mean - q * cell.stderr)
+
+
+# --------------------------------------------------------------------------- #
+# Internals                                                                     #
+# --------------------------------------------------------------------------- #
+
+
+def _conformal_quantile(sorted_scores: list[float], alpha: float) -> float:
+    """The finite-sample split-conformal ``(1 − alpha)`` quantile (DESIGN §5.2).
+
+    Uses the standard conformal rank ``k = ceil((n + 1)(1 − alpha))`` and returns
+    the ``k``-th order statistic (1-indexed) of ``sorted_scores``. ``k`` is clamped
+    to ``[1, n]``: when ``(n + 1)(1 − alpha) > n`` (too few points to realise the
+    requested coverage from the sample alone) the textbook recipe returns ``+inf``;
+    we instead take the sample maximum (the most conservative *finite* bound),
+    which only *lowers* ``q_lo`` and so never weakens the gate's conservative
+    property. ``bisect`` resolves the 1-indexed rank ``k`` to a 0-indexed slot over
+    the contiguous rank list, robust if the rank rule is later generalised to a
+    fractional position.
+    """
+    n = len(sorted_scores)
+    k = math.ceil((n + 1) * (1.0 - alpha))  # 1-indexed conformal rank.
+    k = min(max(k, 1), n)  # clamp into the realisable range [1, n].
+    idx = bisect.bisect_left(range(1, n + 1), k)  # 1-indexed k -> 0-indexed slot.
+    return sorted_scores[idx]
+
+
+def _clamp01(x: float) -> float:
+    """Clamp ``x`` into ``[0.0, 1.0]`` (quality is a probability; DESIGN §5.2)."""
+    if x < 0.0:
+        return 0.0
+    if x > 1.0:
+        return 1.0
+    return x

--- a/model-advisor/modeladvisor/continuous.py
+++ b/model-advisor/modeladvisor/continuous.py
@@ -1,0 +1,297 @@
+"""Continuous quality signal: ``q ∈ [0, 1]`` plus an unbounded-score posterior.
+
+v1 of the advisor is **Bernoulli** (DESIGN §1.1, §4): every quality observation is
+``q ∈ {0, 1}`` (a clean close vs a reopen/escalate). DESIGN §7.3 ("Continuous
+quality signal") and the quality-channel discussion (§4) anticipate a richer
+reward — a reviewer score, a fraction of passing tests — that lives on the unit
+interval rather than the two-point set ``{0, 1}``. This module is the deferred
+feature: it makes the existing Beta machinery accept a continuous ``q ∈ [0, 1]``
+and adds an optional Gaussian (Normal-Inverse-Gamma) posterior for the case where
+the raw score is genuinely **unbounded** and you don't want to squash it into
+``[0, 1]``.
+
+Why the Beta update already works for continuous ``q`` (DESIGN §1.3 Layer 1).
+The closed-form update is::
+
+    a += w·q ;  b += w·(1 − q)
+
+For ``q ∈ {0, 1}`` this is the conjugate Bernoulli update; for ``q ∈ [0, 1]`` it
+is the natural fractional-count generalisation (a "soft" success of mass ``w·q``
+and a "soft" failure of mass ``w·(1 − q)``). The posterior mean still moves toward
+the running ``q`` exactly as the moments demand, and every downstream consumer (the
+gate's LCB, the asymmetric loss, the credible interval — all read only the Beta
+*moments*) is unchanged. The **only** thing standing in the way is
+:func:`modeladvisor.store.CellStore.apply_quality`, which guards
+``qf not in (0.0, 1.0)`` and drops anything else (defensive against a malformed
+binary row). This module supplies the validate-clamp-apply path the store calls
+once that guard is relaxed under a config flag.
+
+Two posteriors, two regimes:
+
+* :func:`apply_continuous` — for a **bounded** score already mapped to ``[0, 1]``
+  (reviewer 0–1, test-pass fraction). Feeds the existing Beta :class:`Cell`; the
+  binary path is a strict special case, so flipping the feature on with only
+  ``{0, 1}`` data reproduces v1 **byte-for-byte** (DESIGN §7.3 conservative
+  default — see the module test ``test_binary_path_unchanged``).
+* :class:`GaussianCell` — for an **unbounded** continuous score (a reviewer 0–100,
+  a latency-savings z-score) you don't want to compress into ``[0, 1]``. A
+  Normal-Inverse-Gamma conjugate posterior over an unknown mean *and* variance
+  (DESIGN OQ-A6 "Gaussian … continuous-score posterior"). Its one-sided lower
+  bound :meth:`GaussianCell.lcb` mirrors the Beta gate's ``mu − z·stderr`` form
+  (cf. :func:`modeladvisor.engine.wilson_lcb`) so a future Gaussian-backed gate
+  reads identically.
+
+Stdlib-only (``math``, ``dataclasses``); pure, deterministic, no I/O.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Mapping, Protocol
+
+
+# --------------------------------------------------------------------------- #
+# Validation + the Beta (bounded) path (DESIGN §1.3 Layer 1, §7.3)             #
+# --------------------------------------------------------------------------- #
+
+
+class _BetaCell(Protocol):
+    """Structural type for the bits of :class:`modeladvisor.store.Cell` we touch.
+
+    Declared as a ``Protocol`` so this module imports **standalone** (the brief's
+    hard rule #4): we never import ``store`` at module load, we just rely on the
+    real ``Cell`` exposing ``.update(q, w, ts)`` (DESIGN §1.3). Any object with a
+    compatible ``update`` works, which also keeps the unit tests hermetic.
+    """
+
+    def update(self, q: float, w: float, ts: str | None) -> None: ...
+
+
+def is_valid_q(q: object, *, continuous: bool = False) -> bool:
+    """Is ``q`` an admissible quality outcome?  (DESIGN §1.1 / §7.3.)
+
+    * ``continuous=False`` (the v1 default): the strict Bernoulli set ``q ∈ {0, 1}``
+      — exactly the guard :func:`modeladvisor.store.CellStore.apply_quality` enforces
+      today, so swapping this in for the inline check is behaviour-preserving.
+    * ``continuous=True``: the unit interval ``0 ≤ q ≤ 1`` (a reviewer score, a
+      test-pass fraction). ``NaN``/``inf`` and non-numerics are rejected either way.
+
+    Returns ``False`` (never raises) for anything non-numeric, so it is safe to call
+    directly on a raw telemetry value.
+    """
+    try:
+        qf = float(q)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return False
+    if not math.isfinite(qf):
+        return False
+    if continuous:
+        return 0.0 <= qf <= 1.0
+    return qf in (0.0, 1.0)
+
+
+def clamp_unit(q: float) -> float:
+    """Clamp a float into ``[0, 1]`` (the Beta support). DESIGN §7.3."""
+    if q < 0.0:
+        return 0.0
+    if q > 1.0:
+        return 1.0
+    return q
+
+
+def apply_continuous(cell: _BetaCell, q: float, w: float, ts: str | None) -> None:
+    """Apply one **continuous** quality observation ``q ∈ [0, 1]`` to a Beta cell.
+
+    The reward is validated as a finite number then **clamped** into ``[0, 1]``
+    (a reviewer that emits ``1.02`` or a fraction computed as ``-0.0`` must not
+    corrupt the Beta support), and applied via the cell's own conjugate update
+    ``a += w·q ; b += w·(1 − q)`` (DESIGN §1.3 Layer 1) — we reuse ``cell.update``
+    rather than touching ``a``/``b`` so the count/last-update bookkeeping and any
+    future change to the update stay in one place (the store).
+
+    For ``q ∈ {0, 1}`` this is identical to the v1 binary update (the brief's
+    byte-identical requirement); for ``q ∈ (0, 1)`` it is the fractional-count
+    generalisation. ``w`` is the channel weight (DESIGN §4.4); ``ts`` the RFC3339
+    observation time (or ``None``).
+
+    Raises ``ValueError`` if ``q`` is non-finite/non-numeric (a programming error
+    at this layer — the store calls :func:`is_valid_q` first, so a bad row is
+    dropped upstream rather than reaching here).
+    """
+    if not is_valid_q(q, continuous=True):
+        # is_valid_q also rejects <0 / >1, but those are *clampable*; distinguish
+        # "out of range but finite" (clamp) from "not a finite number" (reject).
+        try:
+            qf = float(q)
+        except (TypeError, ValueError):
+            raise ValueError(f"continuous q must be numeric, got {q!r}") from None
+        if not math.isfinite(qf):
+            raise ValueError(f"continuous q must be finite, got {q!r}")
+        qf = clamp_unit(qf)
+    else:
+        qf = clamp_unit(float(q))
+    cell.update(qf, float(w), ts)
+
+
+def normalise_score(raw: float, lo: float, hi: float) -> float:
+    """Map an unbounded raw score onto ``[0, 1]`` by min-max scaling, clamped.
+
+    ``(raw − lo) / (hi − lo)``, clamped into ``[0, 1]`` (DESIGN §7.3 — turn a
+    reviewer 0–100 or a bounded-range score into a Beta-ready ``q``). This is the
+    cheap alternative to :class:`GaussianCell` when you *do* know the score's
+    range and are happy to squash it.
+
+    A degenerate range (``hi == lo``) carries no information, so we map any finite
+    ``raw`` to the midpoint ``0.5`` (maximal Beta-update neutrality — pulls the
+    posterior toward neither success nor failure). ``hi < lo`` is treated as a
+    swapped but still valid range (we orient on ``min``/``max``). Non-finite
+    ``raw`` clamps to the nearest edge (``+inf → 1``, ``−inf → 0``); ``NaN → 0.5``.
+    """
+    if math.isnan(raw):
+        return 0.5
+    low, high = (lo, hi) if lo <= hi else (hi, lo)
+    span = high - low
+    if span <= 0.0:
+        return 0.5
+    return clamp_unit((raw - low) / span)
+
+
+# --------------------------------------------------------------------------- #
+# Gaussian (unbounded) posterior — Normal-Inverse-Gamma (DESIGN §7.3 / OQ-A6)  #
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class GaussianCell:
+    """Normal-Inverse-Gamma posterior over an **unbounded** continuous score.
+
+    For a reviewer score on, say, 0–100 that you do *not* want to squash into
+    ``[0, 1]`` (DESIGN §7.3 "Gaussian … continuous-score posterior", OQ-A6), model
+    the observations as ``x ~ Normal(θ, σ²)`` with **both** ``θ`` (location) and
+    ``σ²`` (scale) unknown. The conjugate prior is Normal-Inverse-Gamma
+    ``NIG(mu, lam, alpha, beta)``:
+
+    * ``mu``   — prior mean of the location ``θ``.
+    * ``lam``  — prior pseudo-count on the location (precision scaling; ``λ`` real
+      observations' worth of confidence in ``mu``).
+    * ``alpha``, ``beta`` — shape/scale of the Inverse-Gamma over ``σ²``
+      (``alpha`` ≈ prior d.o.f./2, ``beta`` ≈ prior sum-of-squares/2).
+    * ``n``    — raw observation count (bookkeeping, mirrors :class:`Cell.n`).
+
+    The sequential update for one datum ``x`` is the standard closed form
+    (Murphy, *Conjugate Bayesian analysis of the Gaussian*, eqs. 85–89), so the
+    cell stays a pure accumulator like the Beta :class:`Cell`. The marginal
+    posterior on the location ``θ`` is Student-t with ``2·alpha`` d.o.f., mean
+    ``mu`` and scale² ``beta / (alpha·lam)``; :meth:`mean`, :meth:`stderr` and the
+    one-sided :meth:`lcb` read off that marginal so a Gaussian-backed gate mirrors
+    the Beta gate's ``mu − z·stderr`` (cf. :func:`modeladvisor.engine.wilson_lcb`).
+
+    Defaults give a weak, broad, **proper** prior centred at 0 (``lam = 1`` →
+    one observation dominates; ``alpha = beta = 1`` → a wide Inverse-Gamma) so a
+    fresh cell defers to data fast — the unbounded analogue of the Beta cold-start's
+    bounded-influence priors (DESIGN §3).
+    """
+
+    mu: float = 0.0
+    lam: float = 1.0
+    alpha: float = 1.0
+    beta: float = 1.0
+    n: int = 0
+
+    def update(self, x: float) -> None:
+        """Fold in one observation ``x`` (NIG sequential update, DESIGN §7.3).
+
+        Closed-form conjugate update for a single Normal datum::
+
+            mu'    = (lam·mu + x) / (lam + 1)
+            lam'   = lam + 1
+            alpha' = alpha + 1/2
+            beta'  = beta + (lam · (x − mu)²) / (2 · (lam + 1))
+
+        The ``beta`` increment is the per-step contribution to the residual
+        sum-of-squares; accumulating it sequentially is algebraically identical to
+        the batch update, so replay order does not matter (deterministic).
+        """
+        xf = float(x)
+        if not math.isfinite(xf):
+            raise ValueError(f"GaussianCell.update needs a finite x, got {x!r}")
+        lam0, mu0 = self.lam, self.mu
+        self.mu = (lam0 * mu0 + xf) / (lam0 + 1.0)
+        self.lam = lam0 + 1.0
+        self.alpha = self.alpha + 0.5
+        self.beta = self.beta + (lam0 * (xf - mu0) * (xf - mu0)) / (2.0 * (lam0 + 1.0))
+        self.n += 1
+
+    # ---- posterior moments on the location θ (Student-t marginal) ---------- #
+
+    @property
+    def mean(self) -> float:
+        """Posterior mean of the location ``θ`` (the Student-t mean, ``= mu``)."""
+        return self.mu
+
+    @property
+    def variance(self) -> float:
+        """Posterior variance of the **location estimate** ``θ`` (not of the data).
+
+        Variance of the Student-t marginal on ``θ``: ``beta / (lam · (alpha − 1))``
+        for ``alpha > 1`` (its scale² ``beta/(alpha·lam)`` inflated by the t
+        d.o.f. factor ``alpha/(alpha − 1)``). For ``alpha ≤ 1`` the t-variance is
+        undefined/infinite; we fall back to the scale² ``beta / (alpha · lam)`` so
+        callers always get a finite, monotone-shrinking uncertainty.
+        """
+        if self.alpha > 1.0:
+            return self.beta / (self.lam * (self.alpha - 1.0))
+        return self.beta / (self.alpha * self.lam)
+
+    @property
+    def stderr(self) -> float:
+        """Standard error of the location estimate ``sqrt(variance)`` (DESIGN §7.3)."""
+        return math.sqrt(self.variance)
+
+    @property
+    def data_variance(self) -> float:
+        """Posterior point estimate of the **observation** variance ``σ²``.
+
+        The Inverse-Gamma mean ``beta / (alpha − 1)`` (``alpha > 1``), else the
+        mode ``beta / (alpha + 1)``. Exposed for callers that want the spread of
+        the *scores* themselves rather than of their mean (e.g. a tolerance band).
+        """
+        if self.alpha > 1.0:
+            return self.beta / (self.alpha - 1.0)
+        return self.beta / (self.alpha + 1.0)
+
+    def lcb(self, z: float) -> float:
+        """One-sided lower confidence bound on the location ``mean − z·stderr``.
+
+        Mirrors the Beta gate's :func:`modeladvisor.engine.wilson_lcb` (a normal
+        approximation to the Student-t lower tail; ``z = 1.645`` ≈ ``z_{0.95}`` for
+        the one-sided ``alpha = 0.05``). **Not** clamped to ``[0, 1]`` — the whole
+        point of the Gaussian cell is an unbounded score, so a negative lower bound
+        is meaningful and must be preserved (contrast the Beta LCB's ``max(0, …)``).
+        Use a Student-t quantile for ``z`` if exact small-sample coverage matters.
+        """
+        return self.mean - z * self.stderr
+
+    # ---- persistence (mirrors Cell.to_dict / from_dict) -------------------- #
+
+    def to_dict(self) -> dict:
+        """Serialise to a plain JSON-able dict (mirrors :meth:`Cell.to_dict`)."""
+        return {
+            "mu": self.mu,
+            "lam": self.lam,
+            "alpha": self.alpha,
+            "beta": self.beta,
+            "n": self.n,
+        }
+
+    @classmethod
+    def from_dict(cls, d: Mapping) -> "GaussianCell":
+        """Inverse of :meth:`to_dict` (mirrors :meth:`Cell.from_dict`)."""
+        return cls(
+            mu=float(d["mu"]),
+            lam=float(d["lam"]),
+            alpha=float(d["alpha"]),
+            beta=float(d["beta"]),
+            n=int(d.get("n", 0)),
+        )

--- a/model-advisor/modeladvisor/engine.py
+++ b/model-advisor/modeladvisor/engine.py
@@ -1,0 +1,786 @@
+"""The CC-TS decision rule — :func:`recommend` and :func:`inspect`.
+
+A faithful, stdlib-only implementation of the four-layer Conservative Constrained
+Thompson Sampling policy from ``docs/DESIGN.md`` §1. The two public entry points
+are **pure functions of ``(config, store)``** — no I/O, no global mutable state,
+deterministic, and seedable (the seed hook is reserved for a future genuine
+Thompson-Sampling mode; v1's rule is LCB-deterministic and already needs no
+randomness — DESIGN §1.4 properties 1–3).
+
+The decision (DESIGN §1.2):
+
+    cheapest tier whose posterior-credible quality-drop ≤ ``q_tol`` at
+    ``1 − alpha = 0.95``; baseline ``tier*`` always feasible; upgrades
+    unconstrained; ``Critical`` cells never downgrade.
+
+Layers:
+
+- **L1** Beta posteriors (read pooled, via :meth:`store.pooled`).
+- **L2** conservative gate: admit a cheaper tier iff its one-sided **Wilson lower
+  bound** ``q_lo = max(0, mu − z·sigma)`` clears ``mu* − q_tol`` (DESIGN §5.2,
+  production default; no scipy needed).
+- **L3** asymmetric-loss selection among admitted tiers:
+  ``argmin E[L]`` with class multipliers ``{Critical:∞, Strict:20, Moderate:5,
+  Lenient:1}`` and the cascade scaled by downstream-dependent count ``N_dep``.
+- **L4** uncertainty-triggered eval — *recorded only* in v1 (the ``eval_flag`` and
+  the widest-gating-cell pointer in :func:`inspect`); auto-dispatch is deferred.
+"""
+
+from __future__ import annotations
+
+import math
+from statistics import NormalDist
+from typing import TYPE_CHECKING, Mapping
+
+from modeladvisor.config import AdvisorConfig
+from modeladvisor.store import Cell, CellStore, cell_key
+
+if TYPE_CHECKING:  # annotation only; cascade is built by the caller and passed in.
+    from modeladvisor.cascade import CascadeResult
+
+# Sentinel for "no admitted downgrade beats the baseline" / cold start.
+_BASELINE_RATIONALE = "no cheaper tier has cleared tolerance (insufficient evidence)"
+
+
+# --------------------------------------------------------------------------- #
+# Lower confidence bound (DESIGN §5.2 — Wilson-style normal LCB on the Beta)    #
+# --------------------------------------------------------------------------- #
+
+
+def wilson_lcb(cell: Cell, z: float) -> float:
+    """One-sided lower confidence bound ``q_lo = max(0, mu − z·sigma)``.
+
+    ``mu`` and ``sigma`` are the (pooled) Beta posterior moments. Capping at 0
+    means sparse/wide cells gate-reject by default — exactly the conservative
+    cold-start behaviour DESIGN §5.2 specifies. ``z = 1.645`` ≈ ``z_{0.95}`` for
+    the default one-sided ``alpha = 0.05``.
+    """
+    return max(0.0, cell.mean - z * cell.stderr)
+
+
+def _lcb(cell: Cell, cfg: AdvisorConfig) -> float:
+    """Resolve the gate's lower confidence bound under the configured backend.
+
+    ``cfg.lcb_backend == 'conformal'`` ⇒ the distribution-free split-conformal bound
+    (:func:`modeladvisor.conformal.conformal_lcb`) over the cell's rolling
+    calibration buffer (``cell.calib``); an empty/thin buffer falls back to Wilson,
+    so the result is identical to :func:`wilson_lcb` on a day-1 cell. Default
+    (``'wilson'``) ⇒ :func:`wilson_lcb` unchanged (the v1 path, byte-identical).
+    """
+    hp = cfg.hp
+    if cfg.lcb_backend == "conformal":
+        from modeladvisor import conformal as _conformal
+
+        buffer = cell.calib or _conformal.CalibrationBuffer()
+        return _conformal.conformal_lcb(cell, buffer, hp.z, alpha=hp.alpha)
+    return wilson_lcb(cell, hp.z)
+
+
+# --------------------------------------------------------------------------- #
+# Cost / loss helpers (DESIGN §1.3 Layer 3, §2.3)                               #
+# --------------------------------------------------------------------------- #
+
+
+def _delta_cost(cfg: AdvisorConfig, hi_tier_id: str, lo_tier_id: str, tok_in: float, tok_out: float) -> float:
+    """``Δcost(hi, lo) = cost(hi) − cost(lo)`` at the given token budget (DESIGN §2.3)."""
+    hi = cfg.tier(hi_tier_id).cost(tok_in, tok_out)
+    lo = cfg.tier(lo_tier_id).cost(tok_in, tok_out)
+    return hi - lo
+
+
+def _expected_loss(
+    *,
+    action: str,
+    mu_tier: float,
+    mu_star: float,
+    delta_cost: float,
+    multiplier: float,
+    n_dep: int,
+) -> float:
+    """Expected asymmetric loss ``E[L]`` for one candidate action (DESIGN §1.3 L3).
+
+    - ``stay`` (baseline): ``0``.
+    - ``down``: ``-mu_tier·Δcost + max(0, mu* − mu_tier)·M·Δcost·N_dep``
+      (savings when preserved; cascade penalty proportional to the *excess*
+      failure probability vs baseline). ``Δcost = Δcost(tier*, tier_lower) > 0``.
+    - ``up``: ``+Δcost(tier_higher, tier*)`` — a flat overpay (no modelled quality
+      gain beyond the known-good baseline), so upgrades never beat ``stay``.
+    """
+    if action == "stay":
+        return 0.0
+    if action == "up":
+        return abs(delta_cost)  # overpay vs baseline
+    # action == "down"
+    drop = max(0.0, mu_star - mu_tier)
+    if math.isinf(multiplier):
+        # Critical: any downgrade is infinitely penalised. (The gate already blocks
+        # Critical downgrades; this is belt-and-braces so L3 can't select one.)
+        return math.inf
+    savings_term = -mu_tier * delta_cost
+    cascade_term = drop * multiplier * delta_cost * float(max(1, n_dep))
+    return savings_term + cascade_term
+
+
+# --------------------------------------------------------------------------- #
+# recommend (DESIGN §1.4, Alg. 1)                                              #
+# --------------------------------------------------------------------------- #
+
+
+def recommend(
+    agent: str,
+    shape: str,
+    cfg: AdvisorConfig,
+    store: CellStore,
+    *,
+    provider: str | None = None,
+    tol_class: str | None = None,
+    baseline_tier: str | None = None,
+    n_dep: int = 1,
+    tok_in: float | None = None,
+    tok_out: float | None = None,
+    seed: int | None = None,
+    cascade: "CascadeResult | None" = None,
+) -> dict:
+    """Recommend the cost-minimal tier for ``(agent, shape)`` under the quality gate.
+
+    Pure / deterministic / seedable (DESIGN §1.4). ``state`` is passed in as
+    ``(cfg, store)``; nothing is read from disk or the network here.
+
+    Parameters
+    ----------
+    agent, shape:
+        Base agent name and resolved canonical shape (the cell coordinates).
+    cfg, store:
+        The resolved config and the materialised cell store.
+    provider:
+        Provider for the cell key; defaults to ``cfg.default_provider``.
+    tol_class:
+        Tolerance-class name override; defaults to the cell's configured class.
+    baseline_tier:
+        ``tier*`` override; defaults to the cell's configured baseline.
+    n_dep:
+        Downstream-dependent count (blast radius) for the cascade term. Default 1.
+    tok_in, tok_out:
+        Realised token counts for the cost differential. If omitted, the shape's
+        representative budget is used and flagged in the rationale (DESIGN §5.4).
+    seed:
+        Seeds the genuine Thompson-Sampling mode (``cfg.hp.mode == 'thompson'``);
+        ignored by the deterministic ``lcb`` rule but echoed into ``reasons`` for
+        reproducibility.
+    cascade:
+        Optional DAG-propagated effective blast radius (``cascade.CascadeResult``,
+        DESIGN §7.3). When given, ``n_dep`` is overridden by
+        ``max(1, round(cascade.n_dep_eff))`` so the asymmetric-loss cascade term
+        scales with the bead's true downstream reach; surfaced under ``reasons``.
+
+    Returns
+    -------
+    dict with keys ``tier_id``, ``model``, ``rationale`` (str), ``cost_delta``
+    (vs baseline, negative = savings), ``reasons`` (the structured audit object),
+    and ``posterior_summary`` (per-tier pooled posterior).
+    """
+    provider = provider or cfg.default_provider
+    hp = cfg.hp
+
+    # Resolve effective baseline + class (per-cell overrides win).
+    base_id = baseline_tier or cfg.baseline_tier_id_for(agent, shape)
+    if not cfg.has_tier(base_id):
+        raise KeyError(f"baseline tier {base_id!r} not in roster")
+    klass = cfg.tol_class(tol_class) if tol_class else cfg.tol_class_for(agent, shape)
+
+    # Token budget (realised if supplied, else representative — §5.4).
+    representative = tok_in is None or tok_out is None
+    if representative:
+        b_in, b_out = cfg.budget_for(shape)
+        tok_in = b_in if tok_in is None else tok_in
+        tok_out = b_out if tok_out is None else tok_out
+
+    # Baseline posterior (pooled) -> mu*.
+    base_cell = store.pooled(provider, agent, shape, base_id)
+    mu_star = base_cell.mean
+    gate_threshold = mu_star - klass.q_tol
+
+    forced = cfg.is_forced_baseline(agent, shape)
+
+    # Cascade-aware blast radius (DESIGN §7.3): a DAG-propagated effective N_dep
+    # overrides the flat scalar so the L3 cascade term scales with true downstream
+    # reach. Floor at 1 (the §1.3 default). ``cascade is None`` ⇒ n_dep unchanged.
+    cascade_n_dep = None
+    if cascade is not None:
+        n_dep = max(1, round(cascade.n_dep_eff))
+        cascade_n_dep = n_dep
+
+    order = list(cfg.tier_ids)  # cheapest -> most-capable
+    base_idx = order.index(base_id)
+
+    # ------------------------------------------------------------------ #
+    # Genuine Thompson-Sampling mode (DESIGN §7.3, gated). Default 'lcb'  #
+    # path below is byte-unchanged; thompson threads the seed and builds  #
+    # a reasons object whose keys match the lcb audit so cli/--json work. #
+    # ------------------------------------------------------------------ #
+    if cfg.hp.mode == "thompson":
+        return _recommend_thompson(
+            cfg=cfg,
+            store=store,
+            provider=provider,
+            agent=agent,
+            shape=shape,
+            base_id=base_id,
+            klass=klass,
+            forced=forced,
+            order=order,
+            base_idx=base_idx,
+            mu_star=mu_star,
+            gate_threshold=gate_threshold,
+            n_dep=n_dep,
+            tok_in=tok_in,
+            tok_out=tok_out,
+            representative=representative,
+            seed=seed,
+            cascade_n_dep=cascade_n_dep,
+        )
+
+    # ------------------------------------------------------------------ #
+    # Build the candidate set + per-candidate audit rows.                #
+    # ------------------------------------------------------------------ #
+
+    candidates: list[dict] = []
+    posterior_summary: dict[str, dict] = {}
+
+    for tid in order:
+        cell = store.pooled(provider, agent, shape, tid)
+        q_lo = _lcb(cell, cfg)
+        idx = order.index(tid)
+
+        posterior_summary[tid] = {
+            "a": round(cell.a, 6),
+            "b": round(cell.b, 6),
+            "mean": round(cell.mean, 6),
+            "q_lo": round(q_lo, 6),
+            "n": cell.n,
+        }
+
+        if tid == base_id:
+            action = "stay"
+            admitted = True
+            reason = "baseline (always feasible)"
+            delta = 0.0
+        elif idx > base_idx:
+            action = "up"
+            admitted = True  # upgrades unconstrained (but loss makes them lose)
+            reason = "upgrade (unconstrained; only chosen if it minimises loss)"
+            delta = _delta_cost(cfg, tid, base_id, tok_in, tok_out)  # overpay > 0
+        else:
+            action = "down"
+            delta = _delta_cost(cfg, base_id, tid, tok_in, tok_out)  # savings > 0
+            if forced:
+                admitted = False
+                reason = "force_baseline safety hatch active (downgrades disabled)"
+            elif klass.is_critical:
+                admitted = False
+                reason = "Critical class: never downgrade (hard rule)"
+            elif q_lo >= gate_threshold:
+                admitted = True
+                reason = f"admitted: q_lo={q_lo:.4f} >= {gate_threshold:.4f} (mu*-q_tol)"
+            else:
+                admitted = False
+                reason = (
+                    f"rejected: q_lo={q_lo:.4f} < {gate_threshold:.4f} "
+                    f"(mu*-q_tol); evidence too thin (n={cell.n})"
+                )
+
+        # Expected loss for this action (only meaningful for admitted candidates,
+        # but computed for all so the audit object is complete).
+        exp_loss = _expected_loss(
+            action=action,
+            mu_tier=cell.mean,
+            mu_star=mu_star,
+            delta_cost=delta,
+            multiplier=klass.multiplier,
+            n_dep=n_dep,
+        )
+
+        # cost_diff is the signed cost vs baseline at the budget (negative = saves).
+        if action == "down":
+            cost_diff = -delta  # cheaper -> negative
+        elif action == "up":
+            cost_diff = +delta  # pricier -> positive
+        else:
+            cost_diff = 0.0
+
+        candidates.append(
+            {
+                "tier_id": tid,
+                "model": cfg.tier(tid).model,
+                "action": action,
+                "admitted": admitted,
+                "q_lo": round(q_lo, 6),
+                "mean": round(cell.mean, 6),
+                "exp_loss": round(exp_loss, 8) if math.isfinite(exp_loss) else None,
+                "exp_loss_inf": math.isinf(exp_loss),
+                "cost_diff": round(cost_diff, 8),
+                "n": cell.n,
+                "reason": reason,
+            }
+        )
+
+    # ------------------------------------------------------------------ #
+    # Layer 3: argmin E[L] over the admitted set; ties -> cheaper tier.   #
+    # ------------------------------------------------------------------ #
+    admitted_rows = [c for c in candidates if c["admitted"]]
+    # admitted always contains the baseline, so this is non-empty.
+    def _loss_key(c: Mapping) -> tuple:
+        el = math.inf if c["exp_loss"] is None else c["exp_loss"]
+        return (el, order.index(c["tier_id"]))  # lower loss, then cheaper
+
+    chosen = min(admitted_rows, key=_loss_key)
+    chosen_id = chosen["tier_id"]
+    chosen_cell = store.pooled(provider, agent, shape, chosen_id)
+
+    # ------------------------------------------------------------------ #
+    # Layer 4: eval flag (record only in v1, DESIGN §5.4 / §6.2).         #
+    # ------------------------------------------------------------------ #
+    ci_hw = _ci_halfwidth(chosen_cell, hp.alpha)
+    eval_flag = ci_hw > hp.theta_eval
+
+    cost_delta = chosen["cost_diff"]  # vs baseline (negative = savings)
+
+    rationale = _build_rationale(
+        cfg=cfg,
+        provider=provider,
+        agent=agent,
+        shape=shape,
+        chosen=chosen,
+        base_id=base_id,
+        mu_star=mu_star,
+        klass=klass,
+        gate_threshold=gate_threshold,
+        candidates=candidates,
+        representative=representative,
+        forced=forced,
+        cost_delta=cost_delta,
+    )
+
+    reasons = {
+        "cell": {
+            "provider": provider,
+            "agent": agent,
+            "shape": shape,
+            "baseline_tier": base_id,
+            "baseline_cell_key": cell_key(provider, agent, shape, base_id),
+        },
+        "class": klass.name,
+        "q_tol": klass.q_tol,
+        "multiplier": (None if math.isinf(klass.multiplier) else klass.multiplier),
+        "critical": klass.is_critical,
+        "baseline_mean": round(mu_star, 6),
+        "gate_threshold": round(gate_threshold, 6),
+        "alpha": hp.alpha,
+        "z": hp.z,
+        "n_dep": n_dep,
+        "tok_in": tok_in,
+        "tok_out": tok_out,
+        "representative_budget": representative,
+        "forced_baseline": forced,
+        "seed": seed,
+        "mode": "lcb",
+        "lcb_backend": cfg.lcb_backend,
+        "pooling": cfg.pooling,
+        "candidates": candidates,
+        "advised_tier": chosen_id,
+        "eval_flag": eval_flag,
+        "eval_ci_halfwidth": round(ci_hw, 6),
+        "theta_eval": hp.theta_eval,
+    }
+    if cascade_n_dep is not None:
+        reasons["cascade"] = {
+            "n_dep_eff": round(cascade.n_dep_eff, 6),
+            "n_dep_applied": cascade_n_dep,
+            "depth": cascade.depth,
+            "n_nodes": cascade.n_nodes,
+            "rationale": cascade.rationale,
+        }
+
+    return {
+        "tier_id": chosen_id,
+        "model": cfg.tier(chosen_id).model,
+        "rationale": rationale,
+        "cost_delta": round(cost_delta, 8),
+        "reasons": reasons,
+        "posterior_summary": posterior_summary,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Thompson-Sampling mode (DESIGN §7.3, gated by cfg.hp.mode == 'thompson')      #
+# --------------------------------------------------------------------------- #
+
+
+def _recommend_thompson(
+    *,
+    cfg: AdvisorConfig,
+    store: CellStore,
+    provider: str,
+    agent: str,
+    shape: str,
+    base_id: str,
+    klass,
+    forced: bool,
+    order: list[str],
+    base_idx: int,
+    mu_star: float,
+    gate_threshold: float,
+    n_dep: int,
+    tok_in: float,
+    tok_out: float,
+    representative: bool,
+    seed: int | None,
+    cascade_n_dep: int | None,
+) -> dict:
+    """The genuine Thompson-Sampling decision (DESIGN §7.3), seeded + reproducible.
+
+    Draws one posterior sample per tier via :func:`modeladvisor.thompson.thompson_select`
+    and picks the cost-minimal admissible tier under the *same* safety constraints
+    as the deterministic rule (baseline always admissible; ``Critical``/forced cells
+    never downgrade — the ``M[Critical]=∞`` hard rule / §7.4 hatch). Returns the same
+    result shape as :func:`recommend`'s ``lcb`` path, with a ``reasons`` object whose
+    keys (``cell``, ``class``, ``candidates``, ``eval_flag``, …) match so ``cli`` /
+    ``--json`` render identically; the per-tier sampled audit rides under
+    ``reasons['thompson']``.
+    """
+    from modeladvisor import thompson as _thompson
+
+    hp = cfg.hp
+    cells_by_tier = {tid: store.pooled(provider, agent, shape, tid) for tid in order}
+
+    chosen_id, audit = _thompson.thompson_select(
+        order,
+        cells_by_tier,
+        base_id,
+        q_tol=klass.q_tol,
+        is_critical=klass.is_critical,
+        forced=forced,
+        seed=seed,
+    )
+
+    # Cost vs baseline for the chosen tier (negative = savings), at the budget.
+    if chosen_id == base_id:
+        cost_delta = 0.0
+    elif order.index(chosen_id) < base_idx:
+        cost_delta = -_delta_cost(cfg, base_id, chosen_id, tok_in, tok_out)
+    else:
+        cost_delta = +_delta_cost(cfg, chosen_id, base_id, tok_in, tok_out)
+
+    # Build a candidate list in the lcb audit's shape so the CLI table renders.
+    candidates: list[dict] = []
+    posterior_summary: dict[str, dict] = {}
+    audit_by_tier = {row["tier_id"]: row for row in audit["tiers"]}
+    for tid in order:
+        cell = cells_by_tier[tid]
+        row = audit_by_tier[tid]
+        if tid == base_id:
+            cdiff = 0.0
+        elif order.index(tid) < base_idx:
+            cdiff = -_delta_cost(cfg, base_id, tid, tok_in, tok_out)
+        else:
+            cdiff = +_delta_cost(cfg, tid, base_id, tok_in, tok_out)
+        posterior_summary[tid] = {
+            "a": round(cell.a, 6),
+            "b": round(cell.b, 6),
+            "mean": round(cell.mean, 6),
+            "theta": row["theta"],
+            "n": cell.n,
+        }
+        candidates.append(
+            {
+                "tier_id": tid,
+                "model": cfg.tier(tid).model,
+                "action": row["action"],
+                "admitted": row["admitted"],
+                "theta": row["theta"],
+                "mean": round(cell.mean, 6),
+                "cost_diff": round(cdiff, 8),
+                "n": cell.n,
+                "reason": row["reason"],
+            }
+        )
+
+    chosen_cell = cells_by_tier[chosen_id]
+    ci_hw = _ci_halfwidth(chosen_cell, hp.alpha)
+    eval_flag = ci_hw > hp.theta_eval
+
+    rationale = f"{chosen_id}: {audit['decision']} (Thompson, seed={seed})."
+
+    reasons = {
+        "cell": {
+            "provider": provider,
+            "agent": agent,
+            "shape": shape,
+            "baseline_tier": base_id,
+            "baseline_cell_key": cell_key(provider, agent, shape, base_id),
+        },
+        "class": klass.name,
+        "q_tol": klass.q_tol,
+        "multiplier": (None if math.isinf(klass.multiplier) else klass.multiplier),
+        "critical": klass.is_critical,
+        "baseline_mean": round(mu_star, 6),
+        "gate_threshold": round(gate_threshold, 6),
+        "alpha": hp.alpha,
+        "z": hp.z,
+        "n_dep": n_dep,
+        "tok_in": tok_in,
+        "tok_out": tok_out,
+        "representative_budget": representative,
+        "forced_baseline": forced,
+        "seed": seed,
+        "mode": "thompson",
+        "lcb_backend": cfg.lcb_backend,
+        "pooling": cfg.pooling,
+        "candidates": candidates,
+        "advised_tier": chosen_id,
+        "eval_flag": eval_flag,
+        "eval_ci_halfwidth": round(ci_hw, 6),
+        "theta_eval": hp.theta_eval,
+        "thompson": audit,
+    }
+    if cascade_n_dep is not None:
+        reasons["cascade"] = {"n_dep_applied": cascade_n_dep}
+
+    return {
+        "tier_id": chosen_id,
+        "model": cfg.tier(chosen_id).model,
+        "rationale": rationale,
+        "cost_delta": round(cost_delta, 8),
+        "reasons": reasons,
+        "posterior_summary": posterior_summary,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Rationale string builder                                                      #
+# --------------------------------------------------------------------------- #
+
+
+def _fmt_cost(x: float) -> str:
+    return f"${x:+.4f}"
+
+
+def _build_rationale(
+    *,
+    cfg: AdvisorConfig,
+    provider: str,
+    agent: str,
+    shape: str,
+    chosen: Mapping,
+    base_id: str,
+    mu_star: float,
+    klass,
+    gate_threshold: float,
+    candidates: list[dict],
+    representative: bool,
+    forced: bool,
+    cost_delta: float,
+) -> str:
+    """Human-readable rationale string (DESIGN §6.1 examples)."""
+    chosen_id = chosen["tier_id"]
+    budget_note = " (representative token budget)" if representative else ""
+
+    if forced and chosen_id == base_id:
+        return (
+            f"{chosen_id} (baseline): force_baseline safety hatch active — "
+            f"playing the configured tier, learning disabled."
+        )
+
+    if klass.is_critical and chosen_id == base_id:
+        return (
+            f"{chosen_id} (baseline): Critical class (q_tol=0) — downgrades are a "
+            f"hard never-downgrade rule; baseline is the only feasible tier."
+        )
+
+    if chosen["action"] == "stay":
+        # Cold start / nothing admitted: name the thin cheaper tiers.
+        cheaper = [c for c in candidates if c["action"] == "down"]
+        if cheaper:
+            bits = ", ".join(
+                f"{c['tier_id']} q_lo={c['q_lo']:.2f}" for c in cheaper
+            )
+            return (
+                f"{chosen_id} (baseline): no cheaper tier clears tolerance — "
+                f"{bits} all < {gate_threshold:.2f} threshold "
+                f"(baseline mean {mu_star:.2f} − {klass.q_tol:.2f} tol)."
+            )
+        return f"{chosen_id} (baseline): {_BASELINE_RATIONALE}."
+
+    if chosen["action"] == "down":
+        return (
+            f"{chosen_id}: LCB q_lo={chosen['q_lo']:.2f} >= baseline mean "
+            f"{mu_star:.2f} − {klass.q_tol:.2f} tol = {gate_threshold:.2f}; "
+            f"cheapest admitted tier; expected loss {_fmt_cost(chosen['exp_loss'] or 0.0)}"
+            f" vs {base_id}; cost {_fmt_cost(cost_delta)}/dispatch{budget_note}."
+        )
+
+    # upgrade chosen (rare; only if baseline somehow had positive loss — shouldn't
+    # happen since stay==0, but handled for completeness).
+    return (
+        f"{chosen_id}: upgrade selected; cost {_fmt_cost(cost_delta)}/dispatch"
+        f"{budget_note}."
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Credible-interval helpers                                                     #
+# --------------------------------------------------------------------------- #
+
+
+def _ci_halfwidth(cell: Cell, alpha: float) -> float:
+    """Two-sided ``1 − alpha`` normal CI half-width on the cell's posterior mean.
+
+    Used for the Layer-4 eval trigger (DESIGN §5.4): a half-width above
+    ``theta_eval`` flags the cell as wanting an eval probe.
+    """
+    z = NormalDist().inv_cdf(1.0 - alpha / 2.0)
+    return z * cell.stderr
+
+
+def _drop_ci(base_cell: Cell, cand_cell: Cell, alpha: float) -> tuple[float, float, float]:
+    """Normal-approx ``1 − alpha`` CI on the quality DROP ``theta[tier*] − theta[tier]``.
+
+    A difference of two Betas has no closed form; the engine is deterministic and
+    stdlib-only, so we use the moment-matched normal approximation (mean = ``mu* −
+    mu_tier``, variance = ``var* + var_tier``). Returns ``(lo, mean, hi)``. This is
+    the quantity the constraint bounds, surfaced by :func:`inspect` (DESIGN §6.2).
+    """
+    z = NormalDist().inv_cdf(1.0 - alpha / 2.0)
+    mean = base_cell.mean - cand_cell.mean
+    sd = math.sqrt(base_cell.variance + cand_cell.variance)
+    return (mean - z * sd, mean, mean + z * sd)
+
+
+# --------------------------------------------------------------------------- #
+# inspect (DESIGN §6.2)                                                         #
+# --------------------------------------------------------------------------- #
+
+
+def inspect(
+    agent: str,
+    shape: str,
+    cfg: AdvisorConfig,
+    store: CellStore,
+    *,
+    provider: str | None = None,
+    tol_class: str | None = None,
+    baseline_tier: str | None = None,
+) -> dict:
+    """Read-only deep view of the ``(agent, shape)`` cells across the whole roster.
+
+    Returns, per tier: the pooled ``Beta(a~, b~)``, mean, the Wilson LCB ``q_lo``,
+    observation count ``n``, last-update time, and admit/reject under the current
+    tolerance; plus, per *candidate* (cheaper) tier, the ``1 − alpha`` credible
+    interval on the quality DROP vs baseline; plus a pointer to the **widest
+    gating cell** — the tier whose posterior CI half-width is widest *among the
+    cells that are gating a downgrade* (i.e. rejected because the bound is too
+    wide), named as the highest-value eval probe (DESIGN §6.2 / Layer 4).
+    """
+    provider = provider or cfg.default_provider
+    hp = cfg.hp
+    base_id = baseline_tier or cfg.baseline_tier_id_for(agent, shape)
+    klass = cfg.tol_class(tol_class) if tol_class else cfg.tol_class_for(agent, shape)
+    forced = cfg.is_forced_baseline(agent, shape)
+
+    base_cell = store.pooled(provider, agent, shape, base_id)
+    mu_star = base_cell.mean
+    gate_threshold = mu_star - klass.q_tol
+
+    order = list(cfg.tier_ids)
+    base_idx = order.index(base_id)
+
+    tiers_out: list[dict] = []
+    widest_gating = None  # (halfwidth, tier_id) among gating-and-rejected cells
+
+    for tid in order:
+        cell = store.pooled(provider, agent, shape, tid)
+        q_lo = _lcb(cell, cfg)
+        ci_hw = _ci_halfwidth(cell, hp.alpha)
+        idx = order.index(tid)
+
+        if tid == base_id:
+            role = "baseline"
+            admitted = True
+            drop_ci = None
+        elif idx > base_idx:
+            role = "upgrade"
+            admitted = True
+            drop_ci = None
+        else:
+            role = "candidate"
+            if forced:
+                admitted = False
+            elif klass.is_critical:
+                admitted = False
+            else:
+                admitted = q_lo >= gate_threshold
+            lo, mean, hi = _drop_ci(base_cell, cell, hp.alpha)
+            # The drop CI exceeding q_tol is *why* a cheaper tier can't be admitted.
+            exceeds_tol = lo > klass.q_tol or hi > klass.q_tol
+            drop_ci = {
+                "lo": round(lo, 6),
+                "mean": round(mean, 6),
+                "hi": round(hi, 6),
+                "q_tol": klass.q_tol,
+                "exceeds_tol": exceeds_tol,
+            }
+            # A cell is "gating" if it's a real candidate the gate rejected on
+            # uncertainty (not Critical / forced, which reject categorically).
+            if (
+                not admitted
+                and not klass.is_critical
+                and not forced
+                and ci_hw > hp.theta_eval
+            ):
+                if widest_gating is None or ci_hw > widest_gating[0]:
+                    widest_gating = (ci_hw, tid)
+
+        tiers_out.append(
+            {
+                "tier_id": tid,
+                "model": cfg.tier(tid).model,
+                "role": role,
+                "a": round(cell.a, 6),
+                "b": round(cell.b, 6),
+                "mean": round(cell.mean, 6),
+                "q_lo": round(q_lo, 6),
+                "n": cell.n,
+                "last_update": cell.last_update,
+                "ci_halfwidth": round(ci_hw, 6),
+                "admitted": admitted,
+                "quality_drop_ci": drop_ci,
+            }
+        )
+
+    widest = None
+    if widest_gating is not None:
+        hw, tid = widest_gating
+        widest = {
+            "tier_id": tid,
+            "cell_key": cell_key(provider, agent, shape, tid),
+            "ci_halfwidth": round(hw, 6),
+            "theta_eval": hp.theta_eval,
+            "rationale": (
+                f"widest gating cell: {tid} (CI half-width {hw:.2f} > "
+                f"{hp.theta_eval:.2f}); run an eval on "
+                f"{cell_key(provider, agent, shape, tid)} to resolve."
+            ),
+        }
+
+    return {
+        "cell": {"provider": provider, "agent": agent, "shape": shape},
+        "baseline_tier": base_id,
+        "baseline_mean": round(mu_star, 6),
+        "class": klass.name,
+        "q_tol": klass.q_tol,
+        "gate_threshold": round(gate_threshold, 6),
+        "alpha": hp.alpha,
+        "forced_baseline": forced,
+        "tiers": tiers_out,
+        "widest_gating_cell": widest,
+    }

--- a/model-advisor/modeladvisor/evalsched.py
+++ b/model-advisor/modeladvisor/evalsched.py
@@ -1,0 +1,334 @@
+"""Layer-4 **auto-scheduled eval** — rank gating cells and dispatch eval probes.
+
+This is bead ``bh-0r9`` (v3): the deferred half of CC-TS Layer 4
+(``docs/DESIGN.md`` §1.3 Layer 4, §5.4, §6.2, §7.3 "deferred").  v1 *records* the
+uncertainty trigger and *surfaces* the highest-value eval per cell in
+:func:`engine.inspect` (the ``widest_gating_cell`` pointer), but stops short of
+acting on it.  This module closes that loop: it sweeps the configured
+``(agent, shape)`` cells, asks the engine which cell is *gating a downgrade on
+uncertainty*, ranks those cells by **posterior CI half-width × unlock-value**, and
+emits eval-request beads for the top few — auto-dispatch proportional to width,
+biggest-bang-for-the-probe first (DESIGN §5.4: "fires a deterministic eval-suite
+run on that cell … proportional to posterior width").
+
+The value of resolving a gating cell is the spend it would *unlock*: confirming a
+downgrade from the baseline ``tier*`` to the gating candidate tier saves
+``cost(tier*) − cost(candidate)`` per dispatch at the shape's representative
+budget (DESIGN §2.3 / §5.4).  A wide CI on a cell that would unlock large savings
+is the best place to spend an eval; a wide CI on a cell that barely saves anything
+is not.  Hence ``score = ci_halfwidth × unlock_value`` and we take the top-k.
+
+Design rules honoured (DESIGN §1.4, brief HARD RULES):
+
+- **Stdlib-only**, ``from __future__ import annotations``, full type hints,
+  per-function docstrings citing the design.
+- **Reuse the gate.** The "is this cell gating on uncertainty?" decision is read
+  straight from :func:`engine.inspect` (its ``widest_gating_cell``, which already
+  applies the Layer-2 gate + the ``ci_hw > theta_eval`` filter + the Critical /
+  ``force_baseline`` short-circuits).  We never re-implement the gate or the CI.
+- **Pure planning, side-effect-gated emission.** :func:`schedule_evals` is a pure
+  function of ``(cfg, store)`` — no I/O.  :func:`emit_eval_beads` only shells out
+  when ``dry_run=False``; the default/test path returns command *strings* and
+  touches nothing.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from modeladvisor import engine as _engine
+
+# Label every scheduled eval-request bead carries, so the harvester / an operator
+# can find them (``gc bd ready --label model-advisor-eval``) and the ingest path
+# can later attribute the eval verdict back to the cell (DESIGN §4.3 / §7.3).
+EVAL_LABEL = "model-advisor-eval"
+
+# Bead type for an eval-request (a unit of work for whoever runs the eval suite).
+EVAL_BEAD_TYPE = "task"
+
+
+# --------------------------------------------------------------------------- #
+# The scheduled request                                                         #
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class EvalRequest:
+    """One ranked eval probe — the cell to resolve and why it is worth it.
+
+    Mirrors the ``widest_gating_cell`` pointer :func:`engine.inspect` already
+    surfaces (DESIGN §6.2), enriched with the economic ranking signal:
+
+    - ``ci_halfwidth`` — the cell posterior's ``1 − alpha`` CI half-width (taken
+      verbatim from the inspect output; see :func:`engine._ci_halfwidth`).  This
+      is *what an eval shrinks*: a wide interval is why the gate can't yet admit
+      the downgrade (DESIGN §5.4 / Layer 4).
+    - ``unlock_value`` — the per-dispatch cost **savings** confirming this
+      downgrade would unlock: ``cost(tier*) − cost(candidate)`` at the shape's
+      representative token budget (DESIGN §2.3).  This is *what resolving the
+      cell is worth*.
+    - ``score`` — ``ci_halfwidth × unlock_value``; the ranking key (higher =
+      resolve first).  Wide *and* valuable beats wide-but-cheap.
+    """
+
+    cell_key: str
+    provider: str
+    agent: str
+    shape: str
+    tier_id: str
+    ci_halfwidth: float
+    unlock_value: float
+    score: float
+    reason: str
+
+    def to_dict(self) -> dict:
+        """JSON-able view (the audit surface, mirroring the engine's ``reasons``)."""
+        return {
+            "cell_key": self.cell_key,
+            "provider": self.provider,
+            "agent": self.agent,
+            "shape": self.shape,
+            "tier_id": self.tier_id,
+            "ci_halfwidth": round(self.ci_halfwidth, 6),
+            "unlock_value": round(self.unlock_value, 8),
+            "score": round(self.score, 8),
+            "reason": self.reason,
+        }
+
+
+# --------------------------------------------------------------------------- #
+# Scheduling (pure: a function of cfg + store)                                  #
+# --------------------------------------------------------------------------- #
+
+
+def _bead_title(req: EvalRequest) -> str:
+    """The eval-request bead title, e.g. ``eval: <cell_key> (CI hw 0.14, unlocks $0.0113/dispatch)``."""
+    return (
+        f"eval: {req.cell_key} "
+        f"(CI hw {req.ci_halfwidth:.2f}, unlocks ${req.unlock_value:.4f}/dispatch)"
+    )
+
+
+def schedule_evals(
+    cfg: Any,
+    store: Any,
+    *,
+    max_evals: int = 5,
+    theta_eval: Optional[float] = None,
+) -> list[EvalRequest]:
+    """Rank the gating cells worth an eval and return the top ``max_evals``.
+
+    Realises CC-TS Layer 4's auto-scheduling (DESIGN §1.3 Layer 4 / §5.4): for
+    every configured ``(agent, shape)`` pair (``cfg.agent_shapes``), call
+    :func:`engine.inspect` and read its ``widest_gating_cell`` — the cheaper tier
+    the Layer-2 gate **rejected on uncertainty** (the engine has already applied
+    the gate, the ``ci_hw > theta_eval`` filter, and the Critical / forced-
+    baseline short-circuits, so we never re-derive any of that).  For each such
+    cell we compute:
+
+    - ``ci_halfwidth`` — the cell's ``1 − alpha`` CI half-width, taken straight
+      from the inspect pointer (``engine._ci_halfwidth`` under the hood);
+    - ``unlock_value`` — ``cost(tier*) − cost(candidate)`` at the shape's
+      representative token budget (``cfg.budget_for`` → ``cfg.tier(...).cost``);
+      the per-dispatch savings confirming this downgrade unlocks (DESIGN §2.3);
+    - ``score = ci_halfwidth × unlock_value`` — wide *and* valuable ranks first.
+
+    Cells whose half-width is at or below ``theta_eval`` are **not worth an eval**
+    and are skipped.  ``theta_eval`` defaults to ``cfg.hp.theta_eval`` (the same
+    threshold the engine's Layer-4 trigger uses); passing a *stricter* value lets
+    a caller demand only the very widest cells.
+
+    Pure function of ``(cfg, store)`` — no I/O, deterministic (DESIGN §1.4
+    property 1).  The result is sorted by ``score`` descending, ties broken
+    deterministically by ``cell_key`` so reruns are byte-stable.
+
+    Parameters
+    ----------
+    cfg, store:
+        The resolved advisor config and the materialised cell store (the engine
+        state).  ``store`` is read-only here.
+    max_evals:
+        Cap on the number of returned requests (the eval budget for this run).
+        ``<= 0`` returns an empty list (nothing scheduled).
+    theta_eval:
+        CI half-width floor below which a cell is not worth probing.  Defaults to
+        ``cfg.hp.theta_eval``.
+
+    Returns
+    -------
+    list[EvalRequest]
+        Up to ``max_evals`` requests, highest ``score`` first.
+    """
+    if theta_eval is None:
+        theta_eval = cfg.hp.theta_eval
+
+    requests: list[EvalRequest] = []
+
+    for agent, shapes in cfg.agent_shapes.items():
+        for shape in shapes:
+            try:
+                info = _engine.inspect(agent, shape, cfg, store)
+            except KeyError:
+                # An (agent, shape) pair the config can't fully resolve (e.g. a
+                # defaulted canonical shape absent from a custom taxonomy). One
+                # bad pair must not abort the sweep — skip it (DESIGN §8
+                # "the advisor must never block").
+                continue
+            widest = info.get("widest_gating_cell")
+            if widest is None:
+                # No cell is gating a downgrade on uncertainty for this pair
+                # (admitted, Critical/forced, or all CIs already tight).
+                continue
+
+            ci_hw = float(widest["ci_halfwidth"])
+            # The engine floors at hp.theta_eval; honour the caller's (possibly
+            # stricter) threshold too. Skip cells not wide enough to be worth it.
+            if ci_hw <= theta_eval:
+                continue
+
+            provider = info["cell"]["provider"]
+            cand_tier = widest["tier_id"]
+            base_tier = info["baseline_tier"]
+
+            unlock_value = _unlock_value(cfg, shape, base_tier, cand_tier)
+            score = ci_hw * unlock_value
+
+            reason = (
+                f"widest gating cell for {agent}/{shape}: {cand_tier} "
+                f"(CI half-width {ci_hw:.2f} > theta_eval {theta_eval:.2f}); "
+                f"confirming the downgrade from {base_tier} unlocks "
+                f"${unlock_value:.4f}/dispatch — score {score:.4f} "
+                f"(half-width x unlock-value)."
+            )
+
+            requests.append(
+                EvalRequest(
+                    cell_key=widest["cell_key"],
+                    provider=provider,
+                    agent=agent,
+                    shape=shape,
+                    tier_id=cand_tier,
+                    ci_halfwidth=ci_hw,
+                    unlock_value=unlock_value,
+                    score=score,
+                    reason=reason,
+                )
+            )
+
+    # Highest value first; deterministic tie-break on the (unique) cell key so the
+    # ordering — and thus the emitted bead set — is byte-stable across reruns.
+    requests.sort(key=lambda r: (-r.score, r.cell_key))
+
+    if max_evals <= 0:
+        return []
+    return requests[:max_evals]
+
+
+def _unlock_value(cfg: Any, shape: str, base_tier: str, cand_tier: str) -> float:
+    """Per-dispatch savings ``cost(tier*) − cost(candidate)`` at the shape budget.
+
+    The value of *confirming* a gating downgrade (DESIGN §2.3 / §5.4): the cost
+    differential between the known-good baseline ``tier*`` and the cheaper gating
+    candidate, evaluated at the shape's representative token budget
+    (``cfg.budget_for`` — §5.4).  Always ``>= 0`` since the candidate is cheaper
+    than the baseline by construction (it is a *downgrade* the gate is weighing).
+    """
+    tok_in, tok_out = cfg.budget_for(shape)
+    base_cost = cfg.tier(base_tier).cost(tok_in, tok_out)
+    cand_cost = cfg.tier(cand_tier).cost(tok_in, tok_out)
+    return base_cost - cand_cost
+
+
+# --------------------------------------------------------------------------- #
+# Emission (the side-effecting half — gated behind dry_run)                     #
+# --------------------------------------------------------------------------- #
+
+
+def build_create_command(req: EvalRequest, *, rig: Optional[str] = None) -> list[str]:
+    """Build the ``gc bd create`` argv for one eval-request bead.
+
+    The bead is a ``task`` carrying the :data:`EVAL_LABEL` so the operator /
+    harvester can list scheduled evals (``gc bd ready --label model-advisor-eval``)
+    and the ingest path can later attribute the eval verdict back to the cell
+    (DESIGN §4.3).  ``--silent`` makes ``gc bd create`` print only the new bead id
+    (for scripting / so :func:`emit_eval_beads` can capture it).  When ``rig`` is
+    given, the bead is created in that rig's database (``--rig``) so it lands where
+    the work will be dispatched (gc-work convention).
+
+    Returned as an argv list (not a shell string) so :func:`emit_eval_beads` can
+    run it without a shell; ``" ".join(...)`` yields the human/dry-run form.
+    """
+    argv: list[str] = [
+        "gc",
+        "bd",
+        "create",
+        _bead_title(req),
+        "-t",
+        EVAL_BEAD_TYPE,
+        "-l",
+        EVAL_LABEL,
+    ]
+    if rig:
+        argv += ["--rig", rig]
+    argv += ["--silent"]
+    return argv
+
+
+def emit_eval_beads(
+    requests: list[EvalRequest],
+    *,
+    dry_run: bool = True,
+    rig: Optional[str] = None,
+) -> list[str]:
+    """Turn ranked :class:`EvalRequest`s into eval-request beads.
+
+    Realises the *dispatch* half of Layer 4 (DESIGN §5.4 / §7.3): each request
+    becomes a ``gc bd create`` for an eval-request bead (a ``task`` labelled
+    :data:`EVAL_LABEL`, titled ``eval: <cell_key> (CI hw X, unlocks $Y/dispatch)``).
+
+    **Safe by default.** With ``dry_run=True`` (the default and the test path) this
+    runs **nothing** — it returns the list of command *strings* that *would* be
+    run, so the plan can be logged/inspected before it is armed.  Only with
+    ``dry_run=False`` does it actually shell out (one ``gc bd create`` per request)
+    and return the **created bead ids** (parsed from each ``--silent`` invocation's
+    stdout).  A per-request failure does not abort the batch: its slot in the
+    returned list is an ``"ERROR: <msg>"`` marker and the sweep continues.
+
+    Parameters
+    ----------
+    requests:
+        The ranked requests from :func:`schedule_evals`.
+    dry_run:
+        When True (default), return command strings and create nothing.
+    rig:
+        Optional rig to create the beads in (``gc bd create --rig <rig>``).
+
+    Returns
+    -------
+    list[str]
+        ``dry_run=True``  → the ``gc bd create …`` command strings (one per request).
+        ``dry_run=False`` → the created bead ids (or ``"ERROR: …"`` markers).
+    """
+    out: list[str] = []
+    for req in requests:
+        argv = build_create_command(req, rig=rig)
+        if dry_run:
+            out.append(" ".join(argv))
+            continue
+        try:
+            proc = subprocess.run(
+                argv,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            bead_id = proc.stdout.strip().splitlines()[-1].strip() if proc.stdout.strip() else ""
+            out.append(bead_id or "ERROR: gc bd create returned no bead id")
+        except subprocess.CalledProcessError as e:  # pragma: no cover - needs live gc
+            msg = (e.stderr or e.stdout or str(e)).strip().splitlines()
+            out.append(f"ERROR: gc bd create failed: {msg[-1] if msg else e}")
+        except (OSError, ValueError) as e:  # pragma: no cover - needs live gc
+            out.append(f"ERROR: {e}")
+    return out

--- a/model-advisor/modeladvisor/federation.py
+++ b/model-advisor/modeladvisor/federation.py
@@ -1,0 +1,321 @@
+"""Multi-tenant posterior federation — share per-cell aggregates, not telemetry.
+
+DESIGN §7.3 lists **hierarchical-bandit / multi-tenant federation** as a deferred
+upgrade: sharing posteriors across consumer repos to accelerate thin-cell
+convergence (paper §7), gated on the privacy/trust questions that deferral flags.
+This module delivers it *without leaking raw telemetry* — a consumer exports only
+the per-cell **observed aggregates** (the pseudocounts its own dispatches earned),
+a peer imports them, and a merge folds peer evidence into the **prior** of each
+cell, scaled by a trust weight and capped so a peer can inform a thin cell but
+never dominate local evidence.
+
+Why aggregates-only is privacy-safe (DESIGN §5 / §7.3 trust precondition):
+
+- The export carries, per cell, exactly three numbers — ``a_obs`` (observed
+  success pseudocount), ``b_obs`` (observed failure pseudocount) and ``n`` (the
+  raw count). No timestamps, no ``bead_id``, no rationale text, no raw quality
+  rows — nothing from which a single dispatch could be reconstructed.
+- ``a_obs``/``b_obs`` are the posterior ``a``/``b`` **minus the exporter's
+  cold-start prior** for that cell (:func:`modeladvisor.store.cold_start_prior`).
+  Subtracting the prior means (a) no prior is double-counted when a peer re-adds
+  the mass onto *its own* prior, and (b) the exporter's prior scheme — itself
+  derived from config, not data — never leaks. A cell carrying only prior mass
+  exports ``a_obs ≈ b_obs ≈ 0`` and is dropped under ``observed_only``.
+
+The merge is the federation analogue of the closed-form pooler
+(:meth:`modeladvisor.store.CellStore.pooled`, DESIGN §1.3): peer pseudocounts are
+injected as extra **prior** mass, ``trust``-scaled and optionally hard-capped at
+``max_peer_mass`` per cell, while the consumer's *own* observed mass is re-applied
+at full weight on top. So a thin local cell (little own mass) is moved materially
+by a confident peer, a rich local cell (much own mass) barely moves, and with
+``trust = 0`` or no peers the result is byte-identical to the local store. This is
+the conservative "peers inform, never override" property the deferral requires.
+
+Integration (hook-spec; the integrator wires this, this module edits nothing):
+``advisor federate export [--out FILE] [--rig R]`` calls :func:`export_aggregates`
+and writes the JSON; ``advisor federate import PEER... [--trust X]`` calls
+:func:`load_peer` per path then :func:`merge_peers`. Config (opt-in, default no
+peers ⇒ no behaviour change)::
+
+    federation = { peers = ["../other-rig/.beads/telemetry/advisor-federation.json"], trust = 0.3 }
+
+Every function takes its tunables as parameters with sensible defaults, so the
+module imports and unit-tests standalone against the code as it is today.
+Stdlib-only (``json``, ``math``).
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+from typing import Mapping
+
+from modeladvisor.config import AdvisorConfig
+from modeladvisor.store import Cell, CellStore, cold_start_prior, parse_cell_key
+
+#: Schema tag stamped on every export and required on every import. Bumping this
+#: is how a future aggregate-shape change is rejected loudly rather than silently
+#: mis-merged (the export carries pseudocounts; a wrong shape would corrupt a
+#: posterior, so we fail closed).
+SCHEMA: str = "advisor.federation.v1"
+
+# Numerical floor: observed pseudocounts within this of zero are treated as pure
+# prior (float subtraction of prior from posterior leaves rounding dust). A cell
+# at exactly its prior exports a_obs == b_obs == 0; this guards the comparison.
+_EPS: float = 1e-9
+
+
+def _cell_prior(cfg: AdvisorConfig, key: str) -> tuple[float, float]:
+    """Cold-start prior ``(a, b)`` for ``key`` under ``cfg`` (DESIGN §3.2).
+
+    Parses the cell key for ``(agent, shape, tier_id)`` and resolves the cell's
+    effective baseline tier the same way the store does
+    (:meth:`CellStore._prior` via :meth:`AdvisorConfig.baseline_tier_id_for`),
+    then defers to :func:`modeladvisor.store.cold_start_prior`. This is the prior
+    subtracted on export and re-added on merge, so the two operations are exact
+    inverses on the prior component.
+
+    Note: a consumer-supplied confidence ``priors.json`` (DESIGN §3.1) is *not*
+    consulted here — federation speaks the config-derived cold-start prior so the
+    exchanged aggregates are independent of any one tenant's private prior file.
+    """
+    _provider, agent, shape, tier_id = parse_cell_key(key)
+    baseline = cfg.baseline_tier_id_for(agent, shape)
+    return cold_start_prior(cfg, tier_id, baseline)
+
+
+def export_aggregates(store: CellStore, *, observed_only: bool = True) -> dict:
+    """Export per-cell **observed aggregates** for federation (DESIGN §7.3).
+
+    Returns a JSON-serialisable document::
+
+        {"schema": "advisor.federation.v1",
+         "cells": {cell_key: {"a_obs": ..., "b_obs": ..., "n": ...}, ...}}
+
+    ``a_obs``/``b_obs`` are the cell's posterior ``a``/``b`` with the exporter's
+    cold-start prior **subtracted** (:func:`_cell_prior`), i.e. the pseudocount
+    mass the cell's *own dispatches* contributed. A weighted observation of
+    ``q = 1`` adds ``w`` to ``a_obs``; of ``q = 0`` adds ``w`` to ``b_obs`` — so
+    the aggregates are exactly the channel-weighted Bernoulli evidence (DESIGN
+    §1.3 Layer 1), with **no prior baked in** (a peer re-adds them onto its own
+    prior) and **no prior leaked**.
+
+    The export deliberately carries *nothing else*: no ``ts``/``last_update``, no
+    ``bead_id``, no ``signal``/rationale text, no raw records — only the three
+    numbers per cell. This is the privacy contract of DESIGN §7.3: a single
+    dispatch can never be reconstructed from an aggregate.
+
+    ``observed_only`` (default ``True``): export only cells with ``n > 0``. A cell
+    that carries only prior mass exports ``a_obs ≈ b_obs ≈ 0`` and is dropped.
+    With ``observed_only = False`` every materialised cell is emitted (still
+    prior-subtracted), which a tester may use to assert the prior cancels.
+
+    Deterministic; keys are emitted in sorted order; no I/O.
+    """
+    cells: dict[str, dict] = {}
+    for key in sorted(store.cells):
+        cell = store.cells[key]
+        if observed_only and cell.n <= 0:
+            continue
+        prior_a, prior_b = _cell_prior(store.cfg, key)
+        a_obs = cell.a - prior_a
+        b_obs = cell.b - prior_b
+        # Float subtraction can leave a tiny negative; clamp to zero. (Observed
+        # pseudocounts are non-negative by construction: a += w·q, b += w·(1-q).)
+        if -_EPS < a_obs < 0.0:
+            a_obs = 0.0
+        if -_EPS < b_obs < 0.0:
+            b_obs = 0.0
+        cells[key] = {"a_obs": a_obs, "b_obs": b_obs, "n": int(cell.n)}
+    return {"schema": SCHEMA, "cells": cells}
+
+
+class FederationError(ValueError):
+    """Raised when a peer export is missing/garbled or carries a wrong schema.
+
+    Federation fails *closed*: a malformed peer cannot silently corrupt a local
+    posterior, so every validation failure raises rather than dropping data.
+    """
+
+
+def load_peer(path_or_obj: str | os.PathLike[str] | Mapping) -> dict:
+    """Read + validate a peer export (DESIGN §7.3).
+
+    Accepts either a filesystem path to a JSON document or an already-parsed
+    mapping (so the CLI can pass a path and a test can pass a dict). Validates the
+    schema tag and the per-cell aggregate shape, returning a normalised
+    ``{"schema": ..., "cells": {cell_key: {"a_obs", "b_obs", "n"}}}`` dict with
+    numeric fields coerced to ``float``/``int``.
+
+    Raises :class:`FederationError` on: a missing file, non-JSON / non-object
+    content, a missing-or-wrong ``schema``, a non-mapping ``cells``, a malformed
+    cell key, a missing aggregate field, a non-finite or **negative** pseudocount
+    (observed mass cannot be negative), or a negative ``n``. Failing closed keeps
+    a corrupt or hostile peer from poisoning the merge.
+    """
+    if isinstance(path_or_obj, Mapping):
+        doc: object = path_or_obj
+    elif isinstance(path_or_obj, (str, bytes, os.PathLike)):
+        p = os.fspath(path_or_obj)
+        if not os.path.exists(p):
+            raise FederationError(f"peer export not found: {p!r}")
+        try:
+            with open(p, "r", encoding="utf-8") as fh:
+                doc = json.load(fh)
+        except (OSError, json.JSONDecodeError) as exc:
+            raise FederationError(f"peer export {p!r} is not valid JSON: {exc}") from exc
+    else:
+        raise FederationError(
+            f"peer export must be a path or a parsed object, got {type(path_or_obj).__name__}"
+        )
+
+    if not isinstance(doc, Mapping):
+        raise FederationError("peer export must be a JSON object")
+    schema = doc.get("schema")
+    if schema != SCHEMA:
+        raise FederationError(
+            f"peer export has schema {schema!r}, expected {SCHEMA!r}"
+        )
+    raw_cells = doc.get("cells", {})
+    if not isinstance(raw_cells, Mapping):
+        raise FederationError("peer export 'cells' must be an object")
+
+    cells: dict[str, dict] = {}
+    for key, agg in raw_cells.items():
+        try:
+            parse_cell_key(str(key))
+        except ValueError as exc:
+            raise FederationError(f"peer cell key {key!r} is malformed: {exc}") from exc
+        if not isinstance(agg, Mapping):
+            raise FederationError(f"peer cell {key!r} aggregate must be an object")
+        try:
+            a_obs = float(agg["a_obs"])
+            b_obs = float(agg["b_obs"])
+            n = int(agg["n"])
+        except KeyError as exc:
+            raise FederationError(f"peer cell {key!r} missing field {exc}") from exc
+        except (TypeError, ValueError) as exc:
+            raise FederationError(f"peer cell {key!r} has a non-numeric field: {exc}") from exc
+        if not (math.isfinite(a_obs) and math.isfinite(b_obs)):
+            raise FederationError(f"peer cell {key!r} pseudocount is not finite")
+        if a_obs < -_EPS or b_obs < -_EPS or n < 0:
+            raise FederationError(f"peer cell {key!r} has a negative aggregate")
+        cells[str(key)] = {"a_obs": max(a_obs, 0.0), "b_obs": max(b_obs, 0.0), "n": n}
+
+    return {"schema": SCHEMA, "cells": cells}
+
+
+def merge_peers(
+    store: CellStore,
+    peers: object,
+    *,
+    trust: float = 0.3,
+    max_peer_mass: float | None = None,
+) -> CellStore:
+    """Fold peer aggregates into a fresh store as trust-scaled prior mass (§7.3).
+
+    Returns a **new** :class:`CellStore` (the input ``store`` is never mutated),
+    built as:
+
+    1. **Cold-start from ``store.cfg``** — same priors the local store began with.
+    2. For each cell present in any peer, add the peers' summed
+       ``(a_obs, b_obs)`` to that cell's prior, scaled by ``trust`` and (if given)
+       hard-capped at ``max_peer_mass`` total injected mass per cell.
+    3. **Re-apply the local store's own observed mass at full weight** on top —
+       the consumer's own evidence (``a - prior``, ``b - prior`` per observed
+       cell) is added undiscounted, so local evidence always outranks borrowed.
+
+    The effect mirrors the closed-form pooler (DESIGN §1.3): peer pseudocounts
+    enter as prior, so a **thin** local cell (little own mass) is pulled toward a
+    confident peer, while a **rich** local cell (much own mass) barely moves —
+    the trust scaling and the own-mass-at-full-weight re-application together cap
+    peer influence without a per-cell ratio knob. Properties:
+
+    - ``trust = 0`` ⇒ zero peer contribution ⇒ result equals the local store
+      (cold-start + own observed mass), i.e. **no peer influence**.
+    - empty ``peers`` (or all peers empty) ⇒ **idempotent**: the rebuilt store has
+      the same observed cells as ``store``; local-only cells are untouched by
+      absent peers.
+    - ``max_peer_mass`` caps the *injected* peer mass per cell, so even a
+      huge/hostile peer cannot swamp a thin local cell.
+
+    ``peers`` may be a single peer dict, a path, or an iterable of either; each is
+    run through :func:`load_peer` (so callers can pass raw paths). ``trust`` is
+    clamped to ``[0, 1]``. Deterministic; the only I/O is reading any peer paths.
+    """
+    trust = min(max(float(trust), 0.0), 1.0)
+    peer_docs = _coerce_peers(peers)
+
+    # Sum peer observed pseudocounts per cell (a peer with more agreement across
+    # repos contributes more, before trust-scaling and the cap).
+    summed: dict[str, list[float]] = {}
+    for doc in peer_docs:
+        for key, agg in doc["cells"].items():
+            slot = summed.setdefault(key, [0.0, 0.0])
+            slot[0] += agg["a_obs"]
+            slot[1] += agg["b_obs"]
+
+    merged = CellStore.cold_start(store.cfg, store.priors)
+
+    # 1+2. Seed each peer-touched cell's prior with trust-scaled, capped peer mass.
+    if trust > 0.0:
+        for key, (pa, pb) in summed.items():
+            inj_a = trust * pa
+            inj_b = trust * pb
+            if max_peer_mass is not None:
+                inj_a, inj_b = _cap_mass(inj_a, inj_b, max_peer_mass)
+            if inj_a <= 0.0 and inj_b <= 0.0:
+                continue
+            cell = merged.get(key)  # synthesises the cold-start prior for this cell
+            cell.a += inj_a
+            cell.b += inj_b
+
+    # 3. Re-apply the local store's own observed mass at full weight on top.
+    for key, local in store.observed_cells().items():
+        prior_a, prior_b = _cell_prior(store.cfg, key)
+        own_a = max(local.a - prior_a, 0.0)
+        own_b = max(local.b - prior_b, 0.0)
+        cell = merged.get(key)
+        cell.a += own_a
+        cell.b += own_b
+        cell.n += local.n
+        # Preserve the local recency stamp (peers carry no timestamps by design).
+        if local.last_update is not None:
+            cell.last_update = local.last_update
+
+    return merged
+
+
+def _cap_mass(a: float, b: float, max_mass: float) -> tuple[float, float]:
+    """Scale ``(a, b)`` down so ``a + b ≤ max_mass``, preserving the ratio.
+
+    Used to bound the injected peer pseudocount mass per cell so even a very
+    confident (or adversarial) peer cannot dominate a thin local cell — the
+    federation analogue of the ``pool_lambda`` cap in DESIGN §1.3.
+    """
+    total = a + b
+    if max_mass <= 0.0:
+        return 0.0, 0.0
+    if total <= max_mass or total <= 0.0:
+        return a, b
+    scale = max_mass / total
+    return a * scale, b * scale
+
+
+def _coerce_peers(peers: object) -> list[dict]:
+    """Normalise ``peers`` to a list of validated peer docs via :func:`load_peer`.
+
+    Accepts a single peer (dict or path) or an iterable of them; ``None`` and the
+    empty iterable both yield ``[]`` (the idempotent no-peers case).
+    """
+    if peers is None:
+        return []
+    # A single already-validated/parsed peer doc (has the schema tag) or a single
+    # path-like: treat as one peer, not an iterable of characters.
+    if isinstance(peers, (str, bytes, os.PathLike, Mapping)):
+        return [load_peer(peers)]
+    out: list[dict] = []
+    for p in peers:  # type: ignore[union-attr]
+        out.append(load_peer(p))
+    return out

--- a/model-advisor/modeladvisor/hierarchical.py
+++ b/model-advisor/modeladvisor/hierarchical.py
@@ -1,0 +1,303 @@
+"""Genuine hierarchical Beta-Binomial partial pooling via empirical Bayes.
+
+DESIGN §1.3 ships a *closed-form pooled-pseudocount approximation*
+(:meth:`modeladvisor.store.CellStore.pooled`): sibling Beta pseudocounts are
+inverse-stderr-weighted and the injected mass is hard-capped at
+``pool_lambda × own_mass`` so pooling never dominates. That cap is a blunt
+instrument — it shrinks every cell by the *same* fraction regardless of how much
+own-cell evidence exists. DESIGN §7.3 lists **full hierarchical Bayesian
+inference** as the deferred upgrade; this module delivers it without leaving the
+standard library.
+
+The model is the textbook two-level Beta-Binomial (Gelman, *BDA3* §5.3): the
+sibling group shares a latent ``Beta(alpha0, beta0)`` *hyperprior* over per-cell
+success probabilities ``theta_i``, and each cell's own ``Beta(a_i, b_i)``
+likelihood pulls its posterior toward its own data. We fit the hyperprior by
+**empirical Bayes** — estimate ``(alpha0, beta0)`` from the group itself
+(:func:`estimate_hyperprior`) — then form each cell's pooled posterior as
+``(a_own + alpha0, b_own + beta0)`` (:func:`eb_pooled`). This is genuine
+hierarchical shrinkage, not a capped approximation:
+
+- a **thin** cell (small ``a+b``) is dominated by the ``(alpha0, beta0)``
+  pseudocounts and shrinks hard toward the group mean;
+- a **rich** cell (large ``a+b``) barely moves — the hyperprior is a rounding
+  error against its own mass;
+- as own ``n → ∞`` the pooled mean ``→`` the own-cell mean (the hyperprior
+  washes out), exactly the asymptotics the gate/CI want.
+
+This is the property the closed-form cap *cannot* express: the amount of
+shrinkage is a continuous function of own-cell evidence, set by the data, with no
+single global fraction.
+
+The core is stdlib-only (``math``, ``statistics``). An **optional** full-MCMC
+backend (:func:`pymc_pooled`) is import-guarded behind the ``model-advisor[bayes]``
+extra and is never imported by the core; absent PyMC it raises a clear error.
+
+Integration (hook-spec; the integrator wires this, this module edits nothing):
+:meth:`store.pooled` dispatches to :func:`eb_pooled` when
+``cfg.pooling == 'empirical-bayes'`` (config flag ``pooling:
+closed-form|empirical-bayes``, default ``closed-form``). Every function here
+takes its tunables as parameters with sensible defaults, so the module imports
+and unit-tests standalone against the code as it is today.
+"""
+
+from __future__ import annotations
+
+import statistics
+from typing import Iterable, Mapping
+
+from modeladvisor.store import Cell, CellStore, cell_key
+
+# A weak, uninformative fallback hyperprior — the uniform ``Beta(1, 1)``. Used
+# when a sibling group is too small/degenerate to estimate a shared prior from
+# (0 or 1 cells, or zero total evidence). It injects ~1 pseudo-observation per
+# side: enough to be proper, too little to bias a cell with real data.
+_WEAK_PRIOR: tuple[float, float] = (1.0, 1.0)
+
+# Numerical guards. Means are clamped off the {0, 1} boundary so a degenerate
+# all-success / all-failure group still yields a proper (finite) Beta.
+_EPS = 1e-9
+_MEAN_LO = 1e-6
+_MEAN_HI = 1.0 - 1e-6
+
+# Cap on the fitted hyperprior concentration ``alpha0 + beta0``. With a
+# near-zero between-cell variance the method-of-moments concentration diverges
+# (``M = mean(1-mean)/var - 1 → ∞``); we clamp it so an *almost*-identical group
+# does not inject an unbounded pseudocount mass. A group this concentrated is
+# genuinely informative, but the gate should still be able to learn away from it.
+_MAX_CONCENTRATION: float = 1.0e4
+
+
+def _cell_iter(cells: Iterable[Cell] | Mapping[object, Cell]) -> list[Cell]:
+    """Normalise an iterable *or* mapping of sibling cells to a list of ``Cell``."""
+    if isinstance(cells, Mapping):
+        return list(cells.values())
+    return list(cells)
+
+
+def estimate_hyperprior(
+    cells: Iterable[Cell] | Mapping[object, Cell],
+    *,
+    max_concentration: float = _MAX_CONCENTRATION,
+    weak_prior: tuple[float, float] = _WEAK_PRIOR,
+) -> tuple[float, float]:
+    """Estimate the shared ``Beta(alpha0, beta0)`` hyperprior for a sibling group.
+
+    **Estimator — method of moments on the per-cell observed means** (Gelman,
+    *BDA3* §5.3; the standard empirical-Bayes fit for a Beta-Binomial). For each
+    sibling cell take its observed mean ``p_i = a_i / (a_i + b_i)`` and match the
+    first two moments of those means to a ``Beta(alpha0, beta0)``:
+
+    ::
+
+        m = mean_i(p_i)                      # grand mean  -> E[theta]
+        v = var_i(p_i)                       # between-cell variance -> Var[theta]
+        M = m * (1 - m) / v  -  1            # implied Beta concentration alpha0+beta0
+        alpha0 = m * M ,   beta0 = (1 - m) * M
+
+    Moment-matching (rather than the EM fixed point of the Beta-Binomial marginal
+    likelihood) is chosen deliberately: it is closed-form, allocation-free,
+    deterministic, and has no convergence/seed surface — all properties the pure,
+    seedable ``recommend`` contract (DESIGN §5 implementation notes) prizes. It is
+    the same estimator the paper's offline simulations used for the shared prior.
+
+    **Degenerate handling** (documented, returns a *proper* prior in every case):
+
+    - **0 cells** → ``weak_prior`` (default uniform ``Beta(1, 1)``): nothing to
+      pool from, so inject a vanishing, unbiased prior.
+    - **1 cell**, or every cell empty (``a + b == 0``) → a weak prior *anchored at
+      the available grand mean* with unit total mass (``Beta(m, 1 - m)``): we know
+      roughly where the group sits but have no between-cell signal to set a
+      concentration, so we stay maximally humble.
+    - **All-same means** (``v == 0``) → the concentration diverges; clamp it to
+      ``max_concentration``. The fit still tracks the (very tight) group mean.
+    - **Over-dispersed group** (``v ≥ m(1 - m)``, i.e. more spread than *any* Beta
+      can express, ``M ≤ 0``) → fall back to a weak prior anchored at the grand
+      mean: the data refute a shared Beta, so we do not invent a concentration.
+
+    The grand mean is clamped to ``(1e-6, 1 - 1e-6)`` so an all-success or
+    all-failure group still yields finite, positive ``(alpha0, beta0)``.
+
+    Returns ``(alpha0, beta0)`` with ``alpha0, beta0 > 0`` (a proper Beta).
+    Deterministic and side-effect-free.
+    """
+    cell_list = _cell_iter(cells)
+
+    # Per-cell observed means, over cells that carry any evidence at all.
+    means = [c.mean for c in cell_list if (c.a + c.b) > _EPS]
+
+    if not means:
+        # 0 cells, or every cell has zero mass: nothing to estimate.
+        return weak_prior
+
+    m = statistics.mean(means)
+    m = min(max(m, _MEAN_LO), _MEAN_HI)
+
+    if len(means) < 2:
+        # A single (effective) sibling: we have a location but no dispersion
+        # signal. Anchor a unit-mass weak prior at it (mean m, concentration 1).
+        return m, 1.0 - m
+
+    # Sample (n-1) variance of the per-cell means.
+    v = statistics.variance(means)
+
+    spread_ceiling = m * (1.0 - m)
+    if v <= _EPS:
+        # All-same means: Beta concentration diverges; clamp it. The fitted prior
+        # still sits at the (very tight) group mean.
+        conc = max_concentration
+    elif v >= spread_ceiling:
+        # More between-cell spread than any Beta supports (M would be <= 0): the
+        # group refutes a shared Beta. Stay humble — weak prior at the grand mean.
+        return m, 1.0 - m
+    else:
+        conc = spread_ceiling / v - 1.0
+        conc = min(conc, max_concentration)
+
+    conc = max(conc, _EPS)
+    alpha0 = m * conc
+    beta0 = (1.0 - m) * conc
+    return alpha0, beta0
+
+
+def eb_pooled(
+    store: CellStore,
+    provider: str,
+    agent: str,
+    shape: str,
+    tier_id: str,
+    *,
+    max_prior_mass: float | None = None,
+) -> Cell:
+    """Empirical-Bayes pooled cell — a drop-in for :meth:`CellStore.pooled`.
+
+    Gathers the cell's sibling group (the *same* grouping the closed-form pooler
+    uses — :meth:`CellStore._sibling_keys` plus the own cell), fits the shared
+    ``Beta(alpha0, beta0)`` hyperprior over the group via
+    :func:`estimate_hyperprior`, then shrinks the own cell toward it by **adding
+    the hyperprior pseudocounts to the own observed counts**:
+
+    ::
+
+        (a~, b~) = (a_own + alpha0,  b_own + beta0)
+
+    This is the exact posterior of the two-level Beta-Binomial under the
+    empirical-Bayes plug-in (DESIGN §1.3 / §7.3). The shrinkage is automatic and
+    evidence-weighted: a thin cell is swamped by ``(alpha0, beta0)`` and pulled to
+    the group mean; a rich cell barely moves; as own ``n → ∞`` the pooled mean
+    converges to the own-cell mean. Unlike :meth:`CellStore.pooled` there is no
+    fixed ``pool_lambda`` cap — the *data* (via own-cell mass) decide how much
+    pooling happens.
+
+    ``max_prior_mass`` is an **optional** safety cap on the injected pseudocount
+    mass ``alpha0 + beta0``. ``None`` (the default) means *genuine, uncapped EB*:
+    let the fitted hyperprior speak in full. If set, the hyperprior is rescaled
+    *down* to that total mass when it exceeds it, preserving the group mean
+    ``alpha0 / (alpha0 + beta0)`` — useful when an operator wants the closed-form
+    pooler's "own evidence stays dominant" guarantee back (e.g.
+    ``max_prior_mass = pool_lambda × own_mass``).
+
+    The returned ``Cell`` carries the own cell's ``n`` and ``last_update`` (the
+    pooling overlay does not invent observations). Deterministic; no I/O.
+    """
+    own = store.get(cell_key(provider, agent, shape, tier_id))
+
+    # The sibling group is the own cell plus its DESIGN §1.3 siblings (same tier:
+    # same agent / other shapes, and same tolerance class / other agents). We
+    # include the own cell so a lone-but-rich cell still anchors its own prior.
+    sib_keys = store._sibling_keys(provider, agent, shape, tier_id)
+    group: list[Cell] = [own] + [store.get(sk) for sk in sib_keys]
+
+    alpha0, beta0 = estimate_hyperprior(group)
+
+    if max_prior_mass is not None:
+        mass = alpha0 + beta0
+        if mass > max_prior_mass and mass > _EPS:
+            scale = max_prior_mass / mass
+            alpha0 *= scale
+            beta0 *= scale
+
+    return Cell(
+        a=own.a + alpha0,
+        b=own.b + beta0,
+        n=own.n,
+        last_update=own.last_update,
+    )
+
+
+def pymc_pooled(
+    store: CellStore,
+    provider: str,
+    agent: str,
+    shape: str,
+    tier_id: str,
+    *,
+    draws: int = 2000,
+    tune: int = 1000,
+    seed: int = 0,
+) -> Cell:
+    """Full-MCMC hierarchical Beta-Binomial pooling — **optional** PyMC backend.
+
+    This is the heavyweight cousin of :func:`eb_pooled`: instead of the
+    empirical-Bayes plug-in it samples the *joint* posterior of the hyperprior
+    ``(alpha0, beta0)`` and the per-cell ``theta_i`` with PyMC's NUTS sampler,
+    then summarises the own cell's ``theta`` posterior back into an equivalent
+    ``Beta(a~, b~)`` by moment-matching. It captures hyperprior uncertainty that
+    the EB point-estimate ignores.
+
+    PyMC is **not** a core dependency (DESIGN's stdlib-only rule); it lives behind
+    the optional ``model-advisor[bayes]`` extra. This function is import-guarded:
+    with PyMC absent it raises a clear :class:`RuntimeError` telling the operator
+    how to enable it. The core never imports it; only the graceful-absence path is
+    exercised in the test suite.
+
+    ``draws``/``tune``/``seed`` thread through to the sampler so a run is
+    reproducible (the DESIGN §5 seedability contract); they are inert when PyMC is
+    unavailable.
+    """
+    try:  # pragma: no cover - exercised only when the optional extra is installed
+        import pymc as pm  # type: ignore
+    except ImportError as exc:  # pragma: no cover - the tested path is the message
+        raise RuntimeError(
+            "install model-advisor[bayes] for the PyMC backend "
+            "(the stdlib empirical-Bayes pooler eb_pooled is the default)"
+        ) from exc
+
+    # pragma: no cover below — only runs with the optional extra present.
+    own = store.get(cell_key(provider, agent, shape, tier_id))  # pragma: no cover
+    sib_keys = store._sibling_keys(provider, agent, shape, tier_id)  # pragma: no cover
+    group = [own] + [store.get(sk) for sk in sib_keys]  # pragma: no cover
+
+    # Integerised observed successes/trials per sibling (Binomial likelihood).
+    trials = [max(int(round(c.a + c.b)), 0) for c in group]  # pragma: no cover
+    succ = [min(max(int(round(c.a)), 0), t) for c, t in zip(group, trials)]  # pragma: no cover
+
+    with pm.Model():  # pragma: no cover
+        # Weakly-informative hyperprior on the Beta(alpha0, beta0) concentration
+        # + mean, the standard BDA3 §5.3 parameterisation.
+        kappa = pm.HalfNormal("kappa", sigma=50.0)
+        phi = pm.Beta("phi", alpha=1.0, beta=1.0)
+        alpha0 = phi * kappa
+        beta0 = (1.0 - phi) * kappa
+        theta = pm.Beta("theta", alpha=alpha0, beta=beta0, shape=len(group))
+        pm.Binomial("y", n=trials, p=theta, observed=succ)
+        idata = pm.sample(
+            draws=draws, tune=tune, chains=2, random_seed=seed,
+            progressbar=False, compute_convergence_checks=False,
+        )
+
+    post = idata.posterior["theta"].values[:, :, 0].reshape(-1)  # pragma: no cover
+    mu = float(post.mean())  # pragma: no cover
+    var = float(post.var())  # pragma: no cover
+    mu = min(max(mu, _MEAN_LO), _MEAN_HI)  # pragma: no cover
+    # Moment-match the own-cell theta posterior back to an equivalent Beta.
+    if var <= _EPS:  # pragma: no cover
+        conc = _MAX_CONCENTRATION
+    else:  # pragma: no cover
+        conc = max(mu * (1.0 - mu) / var - 1.0, _EPS)
+    return Cell(  # pragma: no cover
+        a=mu * conc,
+        b=(1.0 - mu) * conc,
+        n=own.n,
+        last_update=own.last_update,
+    )

--- a/model-advisor/modeladvisor/ingest.py
+++ b/model-advisor/modeladvisor/ingest.py
@@ -1,0 +1,817 @@
+"""Outcome harvester — turn gc bead lifecycle into ``kind="quality"`` records.
+
+This is the *read side* of the advisor reward signal (DESIGN.md §4 + §5.2). It
+reads gc's bead-closure signal and emits ``kind="quality"`` invocation records to
+``.beads/telemetry/invocations.jsonl``, each joined back to the ``dispatch``
+record that produced the work (so the engine can credit the right
+``provider::agent::shape::tier_id`` cell).
+
+It is **read-only on gc state**: it only *reads* ``.gc/events.jsonl`` and/or
+``gc bd show --json``; it never mutates a bead, runs a dispatch, or edits config.
+The only thing it writes is ``quality`` lines appended to ``invocations.jsonl``.
+
+Two input modes (DESIGN / INTEGRATION-FEASIBILITY (C)):
+
+* **events mode** — tail ``.gc/events.jsonl`` for ``bead.closed`` (and the
+  dedicated ``Reopened`` event ``bd reopen`` emits). Each event carries the full
+  bead object in ``payload.bead`` (id, status, close_reason, ``metadata``,
+  ``labels``, ``closed_at``), so closure quality is learnable from the stream
+  alone — no extra ``bd show`` call.
+* **bd-show mode** — ``gc bd show --json <id>`` for an explicit set of bead ids
+  (returns a JSON *array* of bead objects). Used when you want to (re)harvest a
+  specific bead rather than scan the stream.
+
+Quality mapping (DESIGN §4):
+
+* ``q = 1`` when the dispatched bead is **closed** and not failed
+  (``status == "closed"`` and ``gc.outcome != "fail"`` and not a hard
+  ``gc.failure_class``).
+* ``q = 0`` on a **Reopened** event, an **escalation** state label, or a closing
+  record carrying ``gc.outcome == "fail"`` / ``gc.failure_class == "hard"``.
+* ``transient`` failures (rate-limit / infra) and ``blocked`` review verdicts are
+  **dropped** — they don't reflect tier quality.
+
+Channels & precedence (DESIGN §4.4): a single dispatch yields **at most one**
+observation per cell, choosing the **highest-fidelity channel available**
+(``eval`` > ``review`` > ``close``). Weights come from the advisor config
+(``w_close=1``, ``w_review=3``, ``w_eval=5`` by default) and ride on the record
+so the engine's Beta update can scale ``(a, b)`` by them.
+
+Attribution (DESIGN §4.4): an observation attaches to the cell of the **dispatch
+that produced the work**, found by joining the closed bead back to a recorded
+``dispatch`` by ``bead_id`` first, then by ``session_id``
+(``bead.metadata.session_id``). Quality observed on a bead whose dispatch was not
+advisor-recorded is **dropped** (we can't key it to a cell).
+
+Entry points:
+
+* :func:`harvest` — the callable; pure-ish (I/O only on the files you pass).
+* ``python -m modeladvisor.ingest`` — CLI wrapper over :func:`harvest`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Iterable, Iterator, Mapping, Sequence
+
+# --------------------------------------------------------------------------- #
+# Config import — robust to the sibling store/engine not existing yet.         #
+#                                                                              #
+# ``modeladvisor/__init__.py`` eagerly imports ``modeladvisor.store`` /        #
+# ``modeladvisor.engine`` (built by sibling agents). Until those land, even a  #
+# plain ``import modeladvisor.config`` triggers that __init__ and raises. The  #
+# harvester needs ONLY config (for channel weights + cost helpers), so we      #
+# import ``modeladvisor.config`` directly without executing the package        #
+# __init__: we ensure a ``modeladvisor`` parent exists in ``sys.modules``      #
+# (a minimal namespace package pointing at this directory if the real one      #
+# can't import), then load ``config.py`` under its true name                   #
+# ``modeladvisor.config``. Loading it under its real dotted name (not an        #
+# orphan alias) keeps dataclasses' type resolution happy. This degrades        #
+# cleanly today and is a no-op once the siblings' modules land.                #
+# --------------------------------------------------------------------------- #
+
+SCHEMA_VERSION = "advisor.v1"
+
+
+def _load_config_module():
+    """Return the ``modeladvisor.config`` module, tolerating a broken __init__."""
+    import importlib
+
+    # Fast path: the package imports cleanly (siblings have landed).
+    try:
+        return importlib.import_module("modeladvisor.config")
+    except Exception:
+        pass
+
+    # Degraded path: synthesise the parent package namespace (without running its
+    # __init__) so the submodule loads under its real name.
+    import importlib.util as ilu
+    import types
+
+    pkg_dir = os.path.dirname(os.path.abspath(__file__))
+    pkg_name = "modeladvisor"
+
+    if pkg_name not in sys.modules:
+        parent = types.ModuleType(pkg_name)
+        parent.__path__ = [pkg_dir]  # mark as a package
+        parent.__package__ = pkg_name
+        sys.modules[pkg_name] = parent
+
+    mod_name = f"{pkg_name}.config"
+    if mod_name in sys.modules:
+        return sys.modules[mod_name]
+    cfg_path = os.path.join(pkg_dir, "config.py")
+    spec = ilu.spec_from_file_location(mod_name, cfg_path)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise ImportError(f"cannot load {cfg_path}")
+    module = ilu.module_from_spec(spec)
+    sys.modules[mod_name] = module  # register before exec so self-refs resolve
+    spec.loader.exec_module(module)
+    return module
+
+
+_cfg_mod = _load_config_module()
+AdvisorConfig = _cfg_mod.AdvisorConfig
+default_config = _cfg_mod.default_config
+load_config = _cfg_mod.load_config
+
+
+# --------------------------------------------------------------------------- #
+# Signal vocabulary                                                            #
+# --------------------------------------------------------------------------- #
+
+#: gc status that counts as a successful landing (DESIGN §4.1 / INTEGRATION (C)).
+_CLOSED_STATUS = "closed"
+
+#: Custom statuses/labels gc rigs use for the negative signal (INTEGRATION (C):
+#: ``escalated``/``reopened`` are custom statuses or label-states, not built-ins).
+_NEGATIVE_STATUSES = frozenset({"reopened", "escalated", "abandoned"})
+
+#: Reviewer-verdict mapping (DESIGN §4.2). ``blocked`` is dropped (infra).
+_REVIEW_PASS = frozenset({"pass", "pass_with_findings"})
+_REVIEW_FAIL = frozenset({"fail"})
+_REVIEW_DROP = frozenset({"blocked"})
+
+#: Eval-verdict mapping (DESIGN §4.3). ``partial`` -> 0 (conservative).
+_EVAL_PASS = frozenset({"pass"})
+_EVAL_FAIL = frozenset({"fail", "partial"})
+
+#: Channel fidelity order (DESIGN §4.4): eval > review > close. Higher wins.
+_CHANNEL_FIDELITY = {"close": 1, "review": 2, "eval": 3}
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# --------------------------------------------------------------------------- #
+# Join index over dispatch records                                            #
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class DispatchRef:
+    """The slice of a ``dispatch`` record needed to credit a cell."""
+
+    bead_id: str
+    session_id: str
+    cell_key: str
+    provider: str
+    agent: str
+    shape: str
+    tier_id: str
+
+
+class DispatchIndex:
+    """Joins a closed bead back to the dispatch that produced it (DESIGN §4.4).
+
+    Built by replaying the ``dispatch`` lines already in ``invocations.jsonl``.
+    A bead is matched by ``bead_id`` first (the strong key, DESIGN §5.1), then by
+    ``session_id`` (``bead.metadata.session_id``, INTEGRATION (C)). The most
+    recent dispatch wins when several share a key (later dispatch = the live one).
+    """
+
+    def __init__(self) -> None:
+        self._by_bead: dict[str, DispatchRef] = {}
+        self._by_session: dict[str, DispatchRef] = {}
+
+    def add(self, rec: Mapping[str, object]) -> None:
+        if rec.get("kind") != "dispatch":
+            return
+        ref = DispatchRef(
+            bead_id=str(rec.get("bead_id") or ""),
+            session_id=str(rec.get("session_id") or ""),
+            cell_key=str(rec.get("cell_key") or ""),
+            provider=str(rec.get("provider") or ""),
+            agent=str(rec.get("agent") or ""),
+            shape=str(rec.get("shape") or ""),
+            tier_id=str(rec.get("tier_id") or ""),
+        )
+        # Later records overwrite earlier ones (recency wins).
+        if ref.bead_id:
+            self._by_bead[ref.bead_id] = ref
+        if ref.session_id:
+            self._by_session[ref.session_id] = ref
+
+    @classmethod
+    def from_jsonl(cls, path: str | os.PathLike[str]) -> "DispatchIndex":
+        idx = cls()
+        for rec in _read_jsonl(path):
+            idx.add(rec)
+        return idx
+
+    def lookup(self, bead_id: str, session_id: str) -> DispatchRef | None:
+        if bead_id and bead_id in self._by_bead:
+            return self._by_bead[bead_id]
+        if session_id and session_id in self._by_session:
+            return self._by_session[session_id]
+        return None
+
+    def __len__(self) -> int:  # number of joinable dispatches (by bead key)
+        return len(self._by_bead) + len(self._by_session)
+
+
+# --------------------------------------------------------------------------- #
+# Classifying one bead's outcome into (q, channel, signal)                    #
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class Observation:
+    """A single quality observation distilled from a bead (pre-join).
+
+    ``q`` is a binary ``{0, 1}`` Bernoulli outcome by default (DESIGN §1.1); under
+    the continuous-quality feature (DESIGN §7.3) it may instead be a graded score in
+    ``[0, 1]`` (a reviewer fraction / test-pass ratio), hence the ``float`` type.
+    """
+
+    bead_id: str
+    session_id: str
+    q: float
+    channel: str  # "close" | "review" | "eval"
+    signal: str  # raw audit token
+    n_dep: int = 1
+
+
+def _meta_get(meta: Mapping[str, object], *keys: str) -> str:
+    for k in keys:
+        v = meta.get(k)
+        if v is not None and str(v) != "":
+            return str(v)
+    return ""
+
+
+def _labels_of(bead: Mapping[str, object]) -> list[str]:
+    labels = bead.get("labels")
+    if isinstance(labels, Sequence) and not isinstance(labels, (str, bytes)):
+        return [str(x) for x in labels]
+    return []
+
+
+def _has_escalation(bead: Mapping[str, object], meta: Mapping[str, object]) -> bool:
+    """Detect an escalation state (DESIGN §4.1 / INTEGRATION (C)).
+
+    gc expresses escalation via ``bd set-state`` writing a ``<dim>:<val>`` label
+    (e.g. ``health:failing``, ``mode:degraded``) and/or a custom ``escalated``
+    status. We treat an explicit escalation label or status as ``q = 0``.
+    """
+    status = str(bead.get("status") or "").lower()
+    if status in _NEGATIVE_STATUSES:
+        return True
+    for lab in _labels_of(bead):
+        low = lab.lower()
+        if low.startswith("escalat") or low in {"health:failing", "mode:degraded"}:
+            return True
+    if _meta_get(meta, "gc.final_disposition").lower() in {"escalated", "abandoned"}:
+        return True
+    return False
+
+
+#: Metadata keys carrying a graded numeric quality score (DESIGN §7.3 continuous).
+#: A fraction in [0, 1] is used directly; a 0–100 score is normalised by /100.
+#: Eval-channel scores are preferred over review-channel (fidelity order, §4.4).
+_EVAL_SCORE_KEYS = ("gc.eval_score", "gc.eval_fraction", "gc.test_pass_fraction")
+_REVIEW_SCORE_KEYS = ("gc.review_score", "gc.score", "gc.quality_score")
+
+
+def _graded_score(meta: Mapping[str, object], keys: tuple[str, ...]) -> float | None:
+    """Read + normalise a graded numeric score from ``meta`` to ``[0, 1]`` (§7.3).
+
+    A value already in ``[0, 1]`` is used as-is; a value in ``(1, 100]`` is treated
+    as a percentage and divided by 100. Non-numeric / out-of-range / non-finite
+    values yield ``None`` (the caller then falls back to the binary verdict).
+    """
+    import math as _math
+
+    for k in keys:
+        v = meta.get(k)
+        if v is None or v == "":
+            continue
+        try:
+            f = float(v)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            continue
+        if not _math.isfinite(f):
+            continue
+        if 0.0 <= f <= 1.0:
+            return f
+        if 1.0 < f <= 100.0:
+            return f / 100.0
+    return None
+
+
+def classify_bead(
+    bead: Mapping[str, object],
+    *,
+    event_type: str | None = None,
+    continuous: bool = False,
+) -> Observation | None:
+    """Distil a bead (+ optional event type) into one :class:`Observation`.
+
+    Returns ``None`` when the bead carries **no** quality signal yet (e.g. still
+    open with no review/eval verdict) or when the signal is explicitly *dropped*
+    (``transient`` failure, ``blocked`` review). The highest-fidelity available
+    channel wins (eval > review > close), per DESIGN §4.4.
+
+    ``event_type`` lets the events-mode caller pass ``"Reopened"`` so a reopen is
+    read as a negative even though the bead object may momentarily still look
+    closed; ``bead.closed`` / ``bead.updated`` are treated by the bead's own
+    fields.
+
+    ``continuous`` (DESIGN §7.3, off by default): when set, a graded numeric score
+    on the eval/review channel (``gc.eval_score`` / ``gc.review_score`` / a
+    test-pass fraction, normalised to ``[0, 1]``) is emitted as a continuous ``q``
+    instead of the binary pass/fail. Absent a graded score the binary mapping is
+    used unchanged, so this is a strict superset of the v1 behaviour.
+    """
+    meta = bead.get("metadata")
+    if not isinstance(meta, Mapping):
+        meta = {}
+    bead_id = str(bead.get("id") or "")
+    session_id = _meta_get(meta, "session_id", "gc.session_id")
+    status = str(bead.get("status") or "").lower()
+
+    # n_dep: downstream blast radius for the loss audit (DESIGN §5.2). Best
+    # effort from metadata; default 1 when unknown (DESIGN §1.3 Layer 3).
+    n_dep = _coerce_int(meta.get("gc.n_dep") or meta.get("gc.dependents"), default=1)
+
+    outcome = _meta_get(meta, "gc.outcome").lower()
+    failure_class = _meta_get(meta, "gc.failure_class").lower()
+
+    # ---- transient failures are dropped (not a quality signal, DESIGN §4.1) --
+    if failure_class == "transient":
+        return None
+
+    # ---- highest fidelity: Channel C, eval verdict (DESIGN §4.3) -------------
+    # Continuous (graded) eval score wins over the binary verdict when enabled.
+    if continuous:
+        score = _graded_score(meta, _EVAL_SCORE_KEYS)
+        if score is not None:
+            return Observation(bead_id, session_id, score, "eval", f"eval:score={score:.3f}", n_dep)
+
+    eval_verdict = _meta_get(meta, "gc.eval_verdict", "gc.eval_outcome").lower()
+    if eval_verdict:
+        if eval_verdict in _EVAL_PASS:
+            return Observation(bead_id, session_id, 1, "eval", f"eval:{eval_verdict}", n_dep)
+        if eval_verdict in _EVAL_FAIL:
+            return Observation(bead_id, session_id, 0, "eval", f"eval:{eval_verdict}", n_dep)
+        # Unknown eval token: fall through to lower channels.
+
+    # ---- Channel B, reviewer verdict (DESIGN §4.2) --------------------------
+    # Continuous (graded) review score wins over the binary verdict when enabled.
+    if continuous:
+        score = _graded_score(meta, _REVIEW_SCORE_KEYS)
+        if score is not None:
+            return Observation(bead_id, session_id, score, "review", f"review:score={score:.3f}", n_dep)
+
+    verdict = _meta_get(meta, "gc.verdict", "gc.review_verdict").lower()
+    if verdict:
+        if verdict in _REVIEW_DROP:
+            return None  # blocked: infra/precondition, not a quality signal
+        if verdict in _REVIEW_PASS:
+            return Observation(bead_id, session_id, 1, "review", f"review:{verdict}", n_dep)
+        if verdict in _REVIEW_FAIL:
+            return Observation(bead_id, session_id, 0, "review", f"review:{verdict}", n_dep)
+        # Unknown verdict token: fall through to closure.
+
+    # ---- Channel A, bead closure (PRIMARY, DESIGN §4.1) ---------------------
+    # Explicit reopen event => negative, regardless of the (stale) bead fields.
+    if event_type and event_type.lower() in {"reopened", "bead.reopened"}:
+        return Observation(bead_id, session_id, 0, "close", "reopened", n_dep)
+
+    # Escalation state => negative.
+    if _has_escalation(bead, meta):
+        return Observation(bead_id, session_id, 0, "close", "escalated", n_dep)
+
+    # Hard failure on the closing record => negative.
+    if outcome == "fail" or failure_class == "hard":
+        sig = "fail" if outcome == "fail" else f"failure_class:{failure_class}"
+        return Observation(bead_id, session_id, 0, "close", sig, n_dep)
+
+    # Clean close => positive.
+    if status == _CLOSED_STATUS:
+        # gc.outcome=pass is the cleanest success bit; a bare close (no outcome
+        # metadata) is still a success per DESIGN §4.1 ("a clean close = landed").
+        sig = "closed" if outcome != "pass" else "pass"
+        return Observation(bead_id, session_id, 1, "close", sig, n_dep)
+
+    # Still open / no verdict / no closure: nothing to observe yet.
+    return None
+
+
+def _coerce_int(value: object, *, default: int) -> int:
+    try:
+        if value is None or value == "":
+            return default
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+# --------------------------------------------------------------------------- #
+# Reading inputs                                                               #
+# --------------------------------------------------------------------------- #
+
+
+def _read_jsonl(path: str | os.PathLike[str]) -> Iterator[dict]:
+    """Yield JSON objects from a JSONL file; skip blank/garbled lines.
+
+    Missing file -> empty iterator (the harvester degrades to "nothing to do").
+    """
+    p = os.fspath(path)
+    if not os.path.exists(p):
+        return
+    with open(p, "r", encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except (ValueError, json.JSONDecodeError):
+                continue
+            if isinstance(obj, dict):
+                yield obj
+
+
+def iter_event_beads(
+    events_path: str | os.PathLike[str],
+) -> Iterator[tuple[str, dict]]:
+    """Yield ``(event_type, bead)`` for every closure-relevant gc event.
+
+    Reads ``.gc/events.jsonl`` and surfaces beads from ``bead.closed``,
+    ``bead.updated``, and the dedicated ``Reopened`` event (the negative signal).
+    The bead object lives at ``payload.bead`` (INTEGRATION (C)); a ``Reopened``
+    event may carry it at ``payload.bead`` too — we tolerate either ``payload``
+    holding the bead directly or under ``bead``.
+    """
+    relevant = {"bead.closed", "bead.updated", "reopened", "bead.reopened"}
+    for ev in _read_jsonl(events_path):
+        etype = str(ev.get("type") or ev.get("event") or "").strip()
+        if etype.lower() not in relevant:
+            continue
+        payload = ev.get("payload")
+        bead: object = None
+        if isinstance(payload, Mapping):
+            bead = payload.get("bead", payload)
+        if not isinstance(bead, Mapping) or "id" not in bead:
+            continue
+        yield etype, dict(bead)
+
+
+def fetch_beads_via_cli(
+    bead_ids: Sequence[str],
+    *,
+    gc_bin: str = "gc",
+    cwd: str | os.PathLike[str] | None = None,
+    timeout: float = 30.0,
+) -> list[dict]:
+    """Read beads via ``gc bd show --json <id...>`` (read-only on gc state).
+
+    Returns the parsed bead objects (``gc bd show --json`` emits a JSON *array*).
+    Any subprocess/parse failure degrades to ``[]`` so the harvester never raises
+    because gc is unavailable in a given environment.
+    """
+    ids = [b for b in bead_ids if b]
+    if not ids:
+        return []
+    try:
+        proc = subprocess.run(
+            [gc_bin, "bd", "show", "--json", *ids],
+            capture_output=True,
+            text=True,
+            cwd=os.fspath(cwd) if cwd is not None else None,
+            timeout=timeout,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return []
+    if proc.returncode != 0 or not proc.stdout.strip():
+        return []
+    try:
+        data = json.loads(proc.stdout)
+    except (ValueError, json.JSONDecodeError):
+        return []
+    if isinstance(data, Mapping):
+        # Tolerate a single-object or {"beads": [...]} response shape.
+        if "id" in data:
+            return [dict(data)]
+        inner = data.get("beads")
+        return [dict(b) for b in inner if isinstance(b, Mapping)] if isinstance(inner, list) else []
+    if isinstance(data, list):
+        return [dict(b) for b in data if isinstance(b, Mapping)]
+    return []
+
+
+# --------------------------------------------------------------------------- #
+# Quality-record construction + dedup/precedence                              #
+# --------------------------------------------------------------------------- #
+
+
+def _channel_weight(cfg: AdvisorConfig, channel: str) -> float:
+    return {
+        "close": cfg.hp.w_close,
+        "review": cfg.hp.w_review,
+        "eval": cfg.hp.w_eval,
+    }.get(channel, cfg.hp.w_close)
+
+
+def _build_quality_record(
+    obs: Observation,
+    ref: DispatchRef,
+    cfg: AdvisorConfig,
+    *,
+    ts: str,
+) -> dict:
+    """Assemble a DESIGN §5.2 ``kind="quality"`` record from obs + joined cell.
+
+    ``q`` is emitted as an ``int`` for a binary ``{0, 1}`` outcome (the v1 wire
+    shape, byte-identical) and as a ``float`` only for a genuinely fractional
+    graded score (DESIGN §7.3 continuous), so default telemetry is unchanged.
+    """
+    q_int = int(obs.q)
+    q_out = q_int if float(q_int) == float(obs.q) else float(obs.q)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "kind": "quality",
+        "ts": ts,
+        "bead_id": obs.bead_id or ref.bead_id,
+        "cell_key": ref.cell_key,
+        "q": q_out,
+        "channel": obs.channel,
+        "weight": _channel_weight(cfg, obs.channel),
+        "signal": obs.signal,
+        "n_dep": int(obs.n_dep),
+    }
+
+
+def _better(a: Observation, b: Observation) -> Observation:
+    """Pick the higher-fidelity observation for the same cell (DESIGN §4.4).
+
+    Precedence: eval > review > close. On a fidelity tie, a *negative* (q=0)
+    outcome wins — a failure signal is the conservative one to keep (a reopen
+    after a close should not be masked by the close).
+    """
+    fa, fb = _CHANNEL_FIDELITY.get(a.channel, 0), _CHANNEL_FIDELITY.get(b.channel, 0)
+    if fa != fb:
+        return a if fa > fb else b
+    if a.q != b.q:
+        return a if a.q == 0 else b
+    return a  # equal fidelity and outcome: keep the first
+
+
+# --------------------------------------------------------------------------- #
+# The harvester                                                                #
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class HarvestResult:
+    """What :func:`harvest` produced (return value for callers + the CLI)."""
+
+    records: list[dict] = field(default_factory=list)
+    written: int = 0
+    #: bead ids seen with a quality signal but no joinable dispatch (dropped).
+    unjoined: list[str] = field(default_factory=list)
+    #: bead ids whose signal was explicitly dropped (transient / blocked / open).
+    skipped: int = 0
+    out_path: str | None = None
+
+    def __len__(self) -> int:
+        return len(self.records)
+
+
+def find_project_root(start: str | os.PathLike[str] | None = None) -> str | None:
+    """Walk up from ``start`` (or cwd) for a directory containing ``.beads``."""
+    d = os.path.abspath(os.fspath(start) if start is not None else os.getcwd())
+    for _ in range(64):
+        if os.path.isdir(os.path.join(d, ".beads")):
+            return d
+        parent = os.path.dirname(d)
+        if parent == d:
+            break
+        d = parent
+    return None
+
+
+def harvest(
+    *,
+    project_root: str | os.PathLike[str] | None = None,
+    invocations_path: str | os.PathLike[str] | None = None,
+    events_path: str | os.PathLike[str] | None = None,
+    bead_ids: Sequence[str] | None = None,
+    beads: Iterable[Mapping[str, object]] | None = None,
+    config: AdvisorConfig | None = None,
+    config_path: str | os.PathLike[str] | None = None,
+    use_cli: bool = False,
+    gc_bin: str = "gc",
+    write: bool = True,
+    now: str | None = None,
+) -> HarvestResult:
+    """Harvest quality outcomes and (optionally) append ``quality`` records.
+
+    Sources of closures, any combination of:
+      * ``events_path`` — scan a gc ``events.jsonl`` for ``bead.closed`` /
+        ``Reopened`` (events mode).
+      * ``bead_ids`` + ``use_cli=True`` — ``gc bd show --json`` those ids
+        (bd-show mode); read-only on gc.
+      * ``beads`` — an explicit iterable of already-loaded bead objects
+        (used by tests / callers that already have the bead JSON).
+
+    Joining: every closure is matched back to a ``dispatch`` in
+    ``invocations_path`` (defaults to ``<project_root>/.beads/telemetry/
+    invocations.jsonl``) by ``bead_id`` then ``session_id``. Closures with no
+    recorded dispatch are dropped and reported in
+    :attr:`HarvestResult.unjoined`.
+
+    Output: when ``write`` is true, the new ``quality`` records are **appended**
+    to ``invocations_path``. The function is otherwise read-only on gc state.
+
+    Returns a :class:`HarvestResult`.
+    """
+    # ---- resolve paths -----------------------------------------------------
+    root = None
+    if project_root is not None:
+        root = os.path.abspath(os.fspath(project_root))
+    elif invocations_path is None:
+        root = find_project_root()
+
+    if invocations_path is None:
+        if root is None:
+            raise ValueError(
+                "no project_root with a .beads dir found and no invocations_path given"
+            )
+        invocations_path = os.path.join(root, ".beads", "telemetry", "invocations.jsonl")
+    invocations_path = os.fspath(invocations_path)
+
+    if events_path is None and root is not None:
+        # Default to the city's gc stream if it exists alongside the project.
+        cand = os.path.join(root, ".gc", "events.jsonl")
+        if os.path.exists(cand):
+            events_path = cand
+
+    cfg = config or load_config(config_path)
+    ts = now or _utcnow_iso()
+    # Continuous-quality feature (DESIGN §7.3): when on, a graded numeric eval/review
+    # score is emitted as a fractional q; off ⇒ binary v1 mapping (default).
+    continuous = bool(getattr(cfg.hp, "continuous_quality", False))
+
+    # ---- build the dispatch join index ------------------------------------
+    index = DispatchIndex.from_jsonl(invocations_path)
+
+    # ---- gather candidate beads (event_type, bead) ------------------------
+    candidates: list[tuple[str | None, Mapping[str, object]]] = []
+    if events_path is not None:
+        for etype, bead in iter_event_beads(events_path):
+            candidates.append((etype, bead))
+    if beads is not None:
+        for bead in beads:
+            candidates.append((None, bead))
+    if bead_ids and use_cli:
+        for bead in fetch_beads_via_cli(bead_ids, gc_bin=gc_bin, cwd=root):
+            candidates.append((None, bead))
+
+    # ---- classify + collapse to one observation per cell ------------------
+    # Key the dedup by the *joined* cell_key so two events on the same bead, or a
+    # close-then-reopen pair, resolve to a single highest-fidelity observation
+    # per cell (DESIGN §4.4 "at most one observation per cell per dispatch").
+    best_by_cell: dict[str, tuple[Observation, DispatchRef]] = {}
+    result = HarvestResult(out_path=invocations_path)
+    unjoined_seen: set[str] = set()
+
+    for etype, bead in candidates:
+        obs = classify_bead(bead, event_type=etype, continuous=continuous)
+        if obs is None:
+            result.skipped += 1
+            continue
+        ref = index.lookup(obs.bead_id, obs.session_id)
+        if ref is None or not ref.cell_key:
+            # No recorded dispatch -> can't credit a cell -> drop (DESIGN §4.4).
+            bid = obs.bead_id or obs.session_id
+            if bid and bid not in unjoined_seen:
+                unjoined_seen.add(bid)
+                result.unjoined.append(bid)
+            continue
+        prev = best_by_cell.get(ref.cell_key)
+        if prev is None:
+            best_by_cell[ref.cell_key] = (obs, ref)
+        else:
+            best_by_cell[ref.cell_key] = (_better(prev[0], obs), ref)
+
+    for obs, ref in best_by_cell.values():
+        result.records.append(_build_quality_record(obs, ref, cfg, ts=ts))
+
+    # Stable ordering for deterministic output/tests.
+    result.records.sort(key=lambda r: (r["cell_key"], r["bead_id"]))
+
+    # ---- append the quality records ---------------------------------------
+    if write and result.records:
+        os.makedirs(os.path.dirname(invocations_path), exist_ok=True)
+        with open(invocations_path, "a", encoding="utf-8") as fh:
+            for rec in result.records:
+                fh.write(json.dumps(rec, separators=(",", ":")) + "\n")
+        result.written = len(result.records)
+
+    return result
+
+
+# --------------------------------------------------------------------------- #
+# CLI                                                                          #
+# --------------------------------------------------------------------------- #
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m modeladvisor.ingest",
+        description=(
+            "Harvest gc bead-closure outcomes into kind=quality advisor records. "
+            "Read-only on gc state; appends to .beads/telemetry/invocations.jsonl."
+        ),
+    )
+    p.add_argument(
+        "--project-root",
+        help="Project dir containing .beads (default: walk up from CWD).",
+    )
+    p.add_argument(
+        "--invocations",
+        help="Path to invocations.jsonl (default: <root>/.beads/telemetry/invocations.jsonl).",
+    )
+    p.add_argument(
+        "--events",
+        help="Path to a gc events.jsonl to scan (events mode). "
+        "Default: <root>/.gc/events.jsonl if present.",
+    )
+    p.add_argument(
+        "--bead",
+        action="append",
+        dest="bead_ids",
+        metavar="ID",
+        help="Bead id to harvest via `gc bd show --json` (repeatable). Implies --use-cli.",
+    )
+    p.add_argument(
+        "--use-cli",
+        action="store_true",
+        help="Resolve --bead ids via `gc bd show --json` (read-only).",
+    )
+    p.add_argument("--gc-bin", default="gc", help="gc binary to call (default: gc).")
+    p.add_argument("--config", help="Path to advisor.toml (default: built-in defaults).")
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Compute and print records without appending to invocations.jsonl.",
+    )
+    p.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the produced quality records as JSON to stdout.",
+    )
+    return p
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_arg_parser().parse_args(argv)
+    use_cli = bool(args.use_cli or args.bead_ids)
+    try:
+        result = harvest(
+            project_root=args.project_root,
+            invocations_path=args.invocations,
+            events_path=args.events,
+            bead_ids=args.bead_ids,
+            config_path=args.config,
+            use_cli=use_cli,
+            gc_bin=args.gc_bin,
+            write=not args.dry_run,
+        )
+    except ValueError as exc:
+        print(f"ingest: {exc}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        json.dump(result.records, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+    else:
+        verb = "would write" if args.dry_run else "wrote"
+        print(
+            f"ingest: {len(result.records)} quality record(s) "
+            f"({verb} {0 if args.dry_run else result.written}); "
+            f"{result.skipped} skipped, {len(result.unjoined)} unjoined "
+            f"-> {result.out_path}",
+            file=sys.stderr,
+        )
+        if result.unjoined:
+            print(
+                "ingest: dropped (no recorded dispatch to join): "
+                + ", ".join(result.unjoined),
+                file=sys.stderr,
+            )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/model-advisor/modeladvisor/store.py
+++ b/model-advisor/modeladvisor/store.py
@@ -1,0 +1,585 @@
+"""The cell store: per-cell ``Beta(a, b)`` posteriors over dispatch quality.
+
+Pure I/O + accumulation; **no network**. The store reads the dispatch + quality
+records from ``.beads/telemetry/invocations.jsonl`` (the source of truth, DESIGN
+§5) and materialises per-cell ``Beta(a, b)`` posteriors via the closed-form
+Bernoulli update ``a += w·q``, ``b += w·(1 − q)`` (DESIGN §1.3 Layer 1). The
+materialisation is persisted to ``advisor-cells.json`` — a **rebuildable cache**:
+deleting it and replaying the JSONL (priors + every ``quality`` record in order)
+reproduces it exactly (DESIGN §5.5).
+
+Cold-start priors follow DESIGN §3.2: the baseline tier ``tier*`` is seeded
+optimistically (``Beta(8, 2)``, mean 0.8); cheaper tiers get a *depressed* mean
+interpolated along the cost order with a small ``s_prior`` pseudocount, so their
+one-sided lower bound starts below any plausible ``mu* − q_tol`` and the gate
+rejects until evidence accrues. A consumer may instead supply a ``priors.json``
+(confidence-seeded, DESIGN §3.1).
+
+Hierarchical capped pseudocount pooling (DESIGN §1.3) is applied at *read* time
+via :meth:`CellStore.pooled`: a cell borrows strength from its siblings (same
+agent, other shapes; and same tolerance class across agents), weighted by inverse
+sibling standard-error and capped by ``pool_lambda ≤ 0.5`` so pooling never
+dominates own-cell evidence.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+from dataclasses import dataclass, field
+from typing import Iterable, Iterator, Mapping
+
+from modeladvisor.config import AdvisorConfig
+
+# ``conformal`` only references ``Cell`` under TYPE_CHECKING, so importing it here
+# is cycle-free. ``hierarchical`` and ``changepoint`` are imported lazily inside the
+# methods that use them (hierarchical imports ``store`` at module load, so a
+# top-level import here would be a cycle).
+from modeladvisor.conformal import CalibrationBuffer
+
+CELL_KEY_SEP = "::"
+
+
+def cell_key(provider: str, agent: str, shape: str, tier_id: str) -> str:
+    """Build the canonical cell key ``provider::agent::shape::tier_id`` (DESIGN §2.4)."""
+    return CELL_KEY_SEP.join((provider, agent, shape, tier_id))
+
+
+def parse_cell_key(key: str) -> tuple[str, str, str, str]:
+    """Inverse of :func:`cell_key`. Raises ``ValueError`` on a malformed key."""
+    parts = key.split(CELL_KEY_SEP)
+    if len(parts) != 4:
+        raise ValueError(f"malformed cell_key {key!r} (want provider::agent::shape::tier_id)")
+    return parts[0], parts[1], parts[2], parts[3]
+
+
+@dataclass
+class Cell:
+    """A single cell's Beta posterior plus bookkeeping.
+
+    ``a``/``b`` are the *posterior* Beta parameters (prior already folded in).
+    ``n`` is the raw observation count (un-weighted). ``last_update`` is the RFC3339
+    timestamp of the most recent quality record applied (``None`` if prior-only).
+    """
+
+    a: float
+    b: float
+    n: int = 0
+    last_update: str | None = None
+    #: Optional rolling split-conformal calibration buffer (DESIGN §5.2 / §7.3).
+    #: Only populated when ``cfg.lcb_backend == 'conformal'``; ``None`` otherwise so
+    #: the default path neither grows buffers nor changes the persisted cache shape.
+    calib: CalibrationBuffer | None = None
+
+    # ---- moments (DESIGN §1.3) ------------------------------------------- #
+
+    @property
+    def mean(self) -> float:
+        return self.a / (self.a + self.b)
+
+    @property
+    def variance(self) -> float:
+        s = self.a + self.b
+        return (self.a * self.b) / (s * s * (s + 1.0))
+
+    @property
+    def stderr(self) -> float:
+        return math.sqrt(self.variance)
+
+    def update(self, q: float, w: float, ts: str | None) -> None:
+        """Apply one weighted Bernoulli observation (DESIGN §1.3 Layer 1)."""
+        self.a += w * q
+        self.b += w * (1.0 - q)
+        self.n += 1
+        if ts is not None:
+            self.last_update = ts
+
+    def to_dict(self) -> dict:
+        d = {"a": self.a, "b": self.b, "n": self.n, "last_update": self.last_update}
+        # Only emit the buffer when it carries data, so a cell without conformal
+        # calibration serialises byte-identically to v1 (the cache invariant).
+        if self.calib is not None and len(self.calib) > 0:
+            d["calib"] = self.calib.to_dict()
+        return d
+
+    @classmethod
+    def from_dict(cls, d: Mapping) -> "Cell":
+        calib_raw = d.get("calib")
+        calib = CalibrationBuffer.from_dict(calib_raw) if calib_raw else None
+        return cls(
+            a=float(d["a"]),
+            b=float(d["b"]),
+            n=int(d.get("n", 0)),
+            last_update=d.get("last_update"),
+            calib=calib,
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Cold-start priors (DESIGN §3)                                                 #
+# --------------------------------------------------------------------------- #
+
+
+def _confidence_prior(c: float) -> tuple[float, float]:
+    """Confidence ``c ∈ [0, 100]`` -> ``(a_prior, b_prior)`` (DESIGN §3.1)."""
+    a = max(1.0, round(c / 5.0))
+    b = max(1.0, round((100.0 - c) / 5.0))
+    return float(a), float(b)
+
+
+def cold_start_prior(cfg: AdvisorConfig, tier_id: str, baseline_tier_id: str) -> tuple[float, float]:
+    """Cost-ordered conservative cold-start prior for one tier (DESIGN §3.2).
+
+    - Baseline tier: optimistic ``Beta(baseline_a, baseline_b)`` (default mean 0.8).
+    - Cheaper tiers: depressed mean interpolated along the cost order between
+      ``cold_m_lo`` (cheapest) and the baseline mean, with weak ``s_prior``.
+    - More-capable-than-baseline tiers (unconstrained upgrades): seeded at the
+      baseline mean (monotone assumption: at least as good).
+    """
+    hp = cfg.hp
+    if tier_id == baseline_tier_id:
+        return hp.baseline_a, hp.baseline_b
+
+    order = list(cfg.tier_ids)  # cheapest -> most-capable
+    idx = order.index(tier_id)
+    base_idx = order.index(baseline_tier_id)
+    m_hi = hp.baseline_mean
+
+    if idx >= base_idx:
+        # Upgrade tier (more capable than baseline): optimistic, same as baseline mean.
+        mean = m_hi
+    else:
+        # Cheaper than baseline: interpolate the prior mean along the cost order.
+        # Cheapest tier (order index 0) -> cold_m_lo; baseline -> baseline mean.
+        # Robust to non-contiguous ranks (uses position in the cost order).
+        span = base_idx  # number of steps from cheapest to baseline (>= 1 here)
+        frac = idx / span if span > 0 else 1.0
+        mean = hp.cold_m_lo + (m_hi - hp.cold_m_lo) * frac
+
+    mean = min(max(mean, 1e-6), 1.0 - 1e-6)
+    a = mean * hp.s_prior
+    b = (1.0 - mean) * hp.s_prior
+    return a, b
+
+
+# --------------------------------------------------------------------------- #
+# Cell store                                                                    #
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class CellStore:
+    """Materialised per-cell posteriors keyed by ``provider::agent::shape::tier_id``.
+
+    Construct one of three ways:
+
+    - :meth:`cold_start` — priors only (no telemetry yet).
+    - :meth:`rebuild`    — replay priors + ``invocations.jsonl`` (the authoritative
+      build; the cache is derived from this).
+    - :meth:`load`       — read a previously-persisted ``advisor-cells.json`` cache
+      (falling back to cold-start priors for any cell not in the cache).
+
+    The store is *config-aware* for prior synthesis and pooling, but otherwise a
+    plain ``cell_key -> Cell`` map.
+    """
+
+    cfg: AdvisorConfig
+    cells: dict[str, Cell] = field(default_factory=dict)
+    #: Optional confidence-seeded priors (DESIGN §3.1): {cell_key: confidence}.
+    priors: Mapping[str, float] = field(default_factory=dict)
+
+    # ---- prior synthesis -------------------------------------------------- #
+
+    def _prior(self, key: str) -> Cell:
+        """Synthesize the prior cell for ``key`` (confidence prior wins if present)."""
+        provider, agent, shape, tier_id = parse_cell_key(key)
+        if key in self.priors:
+            a, b = _confidence_prior(float(self.priors[key]))
+        else:
+            base = self.cfg.baseline_tier_id_for(agent, shape)
+            a, b = cold_start_prior(self.cfg, tier_id, base)
+        return Cell(a=a, b=b, n=0, last_update=None)
+
+    def get(self, key: str) -> Cell:
+        """Return the cell for ``key``, synthesising (and caching) its prior if unseen."""
+        cell = self.cells.get(key)
+        if cell is None:
+            cell = self._prior(key)
+            self.cells[key] = cell
+        return cell
+
+    def get_tier(self, provider: str, agent: str, shape: str, tier_id: str) -> Cell:
+        return self.get(cell_key(provider, agent, shape, tier_id))
+
+    # ---- construction ----------------------------------------------------- #
+
+    @classmethod
+    def cold_start(
+        cls, cfg: AdvisorConfig, priors: Mapping[str, float] | None = None
+    ) -> "CellStore":
+        """A store seeded with priors only (no observations)."""
+        return cls(cfg=cfg, cells={}, priors=dict(priors or {}))
+
+    @classmethod
+    def rebuild(
+        cls,
+        cfg: AdvisorConfig,
+        jsonl_path: str | os.PathLike[str] | None,
+        priors: Mapping[str, float] | None = None,
+    ) -> "CellStore":
+        """Build the store by replaying ``invocations.jsonl`` over the priors.
+
+        This is the **authoritative** construction (DESIGN §5.5): the JSONL is the
+        source of truth; ``advisor-cells.json`` is merely a cache of the result.
+        Missing / empty file ⇒ a pure cold-start store. Malformed lines are
+        skipped (the log is append-only and may be partially written).
+
+        When ``cfg.hp.changepoint`` is set, the replay uses a change-point-aware
+        re-fold (:meth:`_apply_records_changepoint`, DESIGN §7.3) that down-weights
+        stale pre-drift evidence; the default (off) path is the straight in-order
+        fold of v1, byte-for-byte unchanged.
+        """
+        store = cls.cold_start(cfg, priors)
+        if jsonl_path is None:
+            return store
+        p = os.fspath(jsonl_path)
+        if not os.path.exists(p):
+            return store
+        with open(p, "r", encoding="utf-8") as fh:
+            if cfg.hp.changepoint:
+                store._apply_records_changepoint(_iter_jsonl(fh))
+            else:
+                store.apply_records(_iter_jsonl(fh))
+        return store
+
+    @classmethod
+    def load(
+        cls,
+        cfg: AdvisorConfig,
+        cache_path: str | os.PathLike[str],
+        priors: Mapping[str, float] | None = None,
+    ) -> "CellStore":
+        """Load a persisted ``advisor-cells.json`` cache.
+
+        Cells absent from the cache fall back to cold-start priors on demand. If
+        the cache file is missing, this is equivalent to :meth:`cold_start`.
+        """
+        store = cls.cold_start(cfg, priors)
+        p = os.fspath(cache_path)
+        if not os.path.exists(p):
+            return store
+        with open(p, "r", encoding="utf-8") as fh:
+            doc = json.load(fh)
+        cells = doc.get("cells", doc) if isinstance(doc, Mapping) else {}
+        for key, d in cells.items():
+            store.cells[key] = Cell.from_dict(d)
+        return store
+
+    # ---- accumulation ----------------------------------------------------- #
+
+    def apply_records(self, records: Iterable[Mapping]) -> int:
+        """Apply an iterable of telemetry records. Returns #quality records applied.
+
+        Only ``kind == "quality"`` records mutate a posterior. ``dispatch`` and
+        ``recommendation`` records are ignored here (they carry no outcome; the
+        cell credited by a quality record already carries its ``cell_key``).
+        """
+        applied = 0
+        for rec in records:
+            if not isinstance(rec, Mapping):
+                continue
+            if rec.get("kind") != "quality":
+                continue
+            if self.apply_quality(rec):
+                applied += 1
+        return applied
+
+    def apply_quality(self, rec: Mapping) -> bool:
+        """Apply one ``kind == "quality"`` record. Returns True if it updated a cell.
+
+        Honours the channel-weight defaults (DESIGN §4.4): if the record carries an
+        explicit ``weight`` it is used; otherwise the weight is derived from the
+        ``channel`` via the configured ``w_close``/``w_review``/``w_eval``.
+        Records with a non-binary / missing ``q`` are dropped (e.g. ``transient``
+        failures and ``blocked`` verdicts are never emitted as quality rows, but we
+        defend against a malformed one).
+        """
+        key = rec.get("cell_key")
+        if not key:
+            return False
+        q = rec.get("q")
+        if q is None:
+            return False
+        try:
+            qf = float(q)
+        except (TypeError, ValueError):
+            return False
+
+        # Quality-signal admission (DESIGN §1.1 / §7.3). Default: strict Bernoulli
+        # ``{0, 1}`` (v1 — drops anything else). With ``continuous_quality`` on, the
+        # full unit interval ``[0, 1]`` is accepted (a reviewer score / test-pass
+        # fraction) and applied via the fractional-count update; the ``{0, 1}`` path
+        # stays byte-identical (``continuous.apply_continuous`` is a strict superset).
+        continuous = self.cfg.hp.continuous_quality
+        from modeladvisor import continuous as _continuous
+
+        if not _continuous.is_valid_q(qf, continuous=continuous):
+            return False
+
+        w = rec.get("weight")
+        if w is None:
+            w = self._channel_weight(str(rec.get("channel", "close")))
+        else:
+            w = float(w)
+        ts = rec.get("ts")
+        ts = ts if ts is None else str(ts)
+        cell = self.get(str(key))
+
+        # Conformal calibration (DESIGN §5.2 / §7.3): record the (predicted, observed)
+        # pair BEFORE the update so ``pred`` is the cell's mean at decision time. Only
+        # when the conformal backend is selected — we never grow buffers when unused.
+        if self.cfg.lcb_backend == "conformal":
+            if cell.calib is None:
+                cell.calib = CalibrationBuffer()
+            cell.calib.append(cell.mean, qf)
+
+        if continuous:
+            _continuous.apply_continuous(cell, qf, w, ts)
+        else:
+            cell.update(qf, w, ts)
+        return True
+
+    def _channel_weight(self, channel: str) -> float:
+        hp = self.cfg.hp
+        return {"close": hp.w_close, "review": hp.w_review, "eval": hp.w_eval}.get(
+            channel, hp.w_close
+        )
+
+    # ---- change-point-aware replay (DESIGN §7.3, gated) ------------------- #
+
+    def _apply_records_changepoint(self, records: Iterable[Mapping]) -> int:
+        """Replay quality records with change-point recency re-weighting (§7.3).
+
+        The change-point branch of :meth:`rebuild` (only reached when
+        ``cfg.hp.changepoint`` is set). Instead of folding each observation straight
+        in, it (1) buffers the ordered ``(q, w, ts)`` per cell, (2) runs
+        :func:`changepoint.detect_changepoints` on each cell's time-ordered ``q``
+        stream, then (3) re-folds the cell *from its fresh prior*, multiplying each
+        observation's weight by the matching :func:`changepoint.recency_weights`
+        entry — so evidence before the most recent upstream shift is forgotten and
+        the posterior re-learns the current regime.
+
+        Returns the number of quality records applied (matching
+        :meth:`apply_records`). Honours ``continuous_quality`` and the conformal
+        calibration buffer exactly as :meth:`apply_quality` does, so toggling those
+        on alongside ``changepoint`` composes correctly.
+        """
+        from modeladvisor import changepoint as _changepoint
+        from modeladvisor import continuous as _continuous
+
+        # 1. Buffer ordered (q, w, ts) per cell from the quality stream.
+        per_cell: dict[str, list[tuple[float, float, str | None]]] = {}
+        applied = 0
+        for rec in records:
+            if not isinstance(rec, Mapping):
+                continue
+            if rec.get("kind") != "quality":
+                continue
+            key = rec.get("cell_key")
+            if not key:
+                continue
+            q = rec.get("q")
+            if q is None:
+                continue
+            try:
+                qf = float(q)
+            except (TypeError, ValueError):
+                continue
+            if not _continuous.is_valid_q(qf, continuous=self.cfg.hp.continuous_quality):
+                continue
+            w = rec.get("weight")
+            if w is None:
+                w = self._channel_weight(str(rec.get("channel", "close")))
+            else:
+                w = float(w)
+            ts = rec.get("ts")
+            ts = ts if ts is None else str(ts)
+            per_cell.setdefault(str(key), []).append((qf, w, ts))
+            applied += 1
+
+        # 2+3. Per cell: detect change-points, derive recency weights, re-fold.
+        continuous = self.cfg.hp.continuous_quality
+        conformal = self.cfg.lcb_backend == "conformal"
+        for key, obs in per_cell.items():
+            cell = self.get(str(key))  # fresh prior cell (rebuild starts cold)
+            qs = [o[0] for o in obs]
+            cps = _changepoint.detect_changepoints(qs)
+            rweights = _changepoint.recency_weights(len(obs), cps)
+            for (qf, w, ts), rw in zip(obs, rweights):
+                if conformal:
+                    if cell.calib is None:
+                        cell.calib = CalibrationBuffer()
+                    cell.calib.append(cell.mean, qf)
+                eff_w = w * rw
+                if continuous:
+                    _continuous.apply_continuous(cell, qf, eff_w, ts)
+                else:
+                    cell.update(qf, eff_w, ts)
+        return applied
+
+    # ---- hierarchical capped pooling (DESIGN §1.3) ------------------------ #
+
+    def pooled(self, provider: str, agent: str, shape: str, tier_id: str) -> Cell:
+        """Return the *pooled* ``(a~, b~)`` cell read by the gate / decision / CI.
+
+        Borrow strength from sibling cells of the **same tier**:
+
+        - same agent, other shapes (cross-shape siblings), and
+        - same tolerance class, other agents (cross-agent siblings).
+
+        Weight each sibling by ``1 / sibling-stderr`` (more-certain siblings count
+        for more), scale the whole pooled contribution by ``pool_lambda ≤ 0.5``,
+        and normalise so the pooled pseudocount mass never exceeds ``pool_lambda ×
+        own (a + b)``. This keeps own-cell evidence dominant (DESIGN §1.3 cap).
+
+        When ``cfg.pooling == 'empirical-bayes'`` this delegates to the genuine
+        hierarchical Beta-Binomial empirical-Bayes pooler (``hierarchical.eb_pooled``,
+        DESIGN §7.3) — a drop-in replacement; the default ``closed-form`` path below
+        is byte-identical to v1.
+        """
+        if self.cfg.pooling == "empirical-bayes":
+            from modeladvisor import hierarchical as _hierarchical
+
+            return _hierarchical.eb_pooled(self, provider, agent, shape, tier_id)
+
+        own = self.get(cell_key(provider, agent, shape, tier_id))
+        lam = self.cfg.hp.pool_lambda
+        if lam <= 0.0:
+            return Cell(a=own.a, b=own.b, n=own.n, last_update=own.last_update)
+
+        sib_keys = self._sibling_keys(provider, agent, shape, tier_id)
+        if not sib_keys:
+            return Cell(a=own.a, b=own.b, n=own.n, last_update=own.last_update)
+
+        num_a = 0.0
+        num_b = 0.0
+        wsum = 0.0
+        for sk in sib_keys:
+            sib = self.get(sk)
+            se = sib.stderr
+            wsib = 1.0 / se if se > 0 else 0.0
+            if wsib == 0.0:
+                continue
+            num_a += wsib * sib.a
+            num_b += wsib * sib.b
+            wsum += wsib
+        if wsum == 0.0:
+            return Cell(a=own.a, b=own.b, n=own.n, last_update=own.last_update)
+
+        # Weighted-average sibling pseudocounts, then cap the injected mass at
+        # lambda * own_mass so pooling never dominates own-cell evidence.
+        avg_a = num_a / wsum
+        avg_b = num_b / wsum
+        sib_mass = avg_a + avg_b
+        own_mass = own.a + own.b
+        cap = lam * own_mass
+        scale = (cap / sib_mass) if sib_mass > 0 else 0.0
+        scale = min(scale, lam)  # also never inject more than lambda of a sibling unit
+
+        a_pooled = own.a + scale * avg_a
+        b_pooled = own.b + scale * avg_b
+        return Cell(a=a_pooled, b=b_pooled, n=own.n, last_update=own.last_update)
+
+    def _sibling_keys(self, provider: str, agent: str, shape: str, tier_id: str) -> list[str]:
+        """Cell keys of pooling siblings for the given cell (same tier, sibling cells)."""
+        self_key = cell_key(provider, agent, shape, tier_id)
+        out: list[str] = []
+        # Cross-shape siblings: same agent, this agent's other canonical shapes.
+        for s in self.cfg.canonical_shapes_for(agent):
+            if s == shape:
+                continue
+            k = cell_key(provider, agent, s, tier_id)
+            if k != self_key:
+                out.append(k)
+        # Cross-agent siblings: other agents whose (agent, shape) shares this cell's
+        # tolerance class, for the same shape + tier.
+        my_class = self.cfg.tol_class_for(agent, shape).name
+        for other in self.cfg.agent_shapes:
+            if other == agent:
+                continue
+            if shape not in self.cfg.canonical_shapes_for(other):
+                continue
+            if self.cfg.tol_class_for(other, shape).name != my_class:
+                continue
+            k = cell_key(provider, other, shape, tier_id)
+            if k != self_key:
+                out.append(k)
+        # De-dup while preserving order.
+        seen: set[str] = set()
+        uniq: list[str] = []
+        for k in out:
+            if k not in seen:
+                seen.add(k)
+                uniq.append(k)
+        return uniq
+
+    # ---- persistence ------------------------------------------------------ #
+
+    def save(self, cache_path: str | os.PathLike[str]) -> str:
+        """Persist the materialised posteriors to ``advisor-cells.json``.
+
+        Only *observed* cells (those with ``n > 0`` or otherwise materialised) are
+        written; priors are reproducible from config so we don't bloat the cache
+        with untouched prior cells. The written document is a stable, sorted JSON
+        so reruns produce byte-identical caches (eases diffing / testing).
+        """
+        p = os.fspath(cache_path)
+        os.makedirs(os.path.dirname(p) or ".", exist_ok=True)
+        doc = {
+            "schema_version": "advisor.v1",
+            "baseline_tier": self.cfg.baseline_tier_id,
+            "cells": {
+                k: self.cells[k].to_dict()
+                for k in sorted(self.cells)
+                if self.cells[k].n > 0
+            },
+        }
+        with open(p, "w", encoding="utf-8") as fh:
+            json.dump(doc, fh, indent=2, sort_keys=True)
+            fh.write("\n")
+        return p
+
+    # ---- introspection ---------------------------------------------------- #
+
+    def observed_cells(self) -> dict[str, Cell]:
+        """Cells that have at least one observation (``n > 0``)."""
+        return {k: v for k, v in self.cells.items() if v.n > 0}
+
+
+# --------------------------------------------------------------------------- #
+# JSONL helpers                                                                 #
+# --------------------------------------------------------------------------- #
+
+
+def _iter_jsonl(fh: Iterable[str]) -> Iterator[dict]:
+    """Yield parsed JSON objects from a JSONL stream, skipping blank/bad lines."""
+    for line in fh:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict):
+            yield obj
+
+
+def read_jsonl(path: str | os.PathLike[str]) -> list[dict]:
+    """Read all JSON objects from a ``.jsonl`` file (skips malformed lines)."""
+    p = os.fspath(path)
+    if not os.path.exists(p):
+        return []
+    with open(p, "r", encoding="utf-8") as fh:
+        return list(_iter_jsonl(fh))

--- a/model-advisor/modeladvisor/thompson.py
+++ b/model-advisor/modeladvisor/thompson.py
@@ -1,0 +1,278 @@
+"""Genuine Thompson-Sampling mode for the tier decision (DESIGN §1.2–§1.4, §7.3).
+
+v1 ships the LCB-gated **deterministic** production rule
+(:func:`modeladvisor.engine.recommend`); DESIGN §7.3 leaves a *genuine* per-tier
+Beta-sampling mode as a deferred flag, with the ``seed`` hook in ``recommend``
+reserved for exactly this. This module is that mode.
+
+The idea (classic Thompson Sampling over the Beta-Bernoulli posteriors of
+DESIGN §1.3 Layer 1): instead of comparing one-sided lower bounds, draw one
+posterior sample ``theta_tid ~ Beta(a~, b~)`` per tier from a **seeded** RNG and
+decide on the *sampled* qualities. Over many seeds this explores cheaper tiers in
+proportion to the posterior probability that they truly preserve quality — the
+randomised analogue of the deterministic gate — while a single seed is fully
+reproducible (DESIGN §1.4 property 2).
+
+The same safety constraints that make the deterministic rule trustworthy are
+imposed verbatim here (DESIGN §1.2, §7.2), so the conservative contract holds in
+either mode:
+
+- the **baseline ``tier*`` is always admissible** (downgrades are constrained;
+  the baseline and upgrades are not);
+- a **``Critical`` or force-baselined** cell never admits *any* cheaper tier,
+  regardless of how high a cheap tier happens to sample (the ``M[Critical] = ∞``
+  hard rule / the §7.4 safety hatch — never a silent downgrade);
+- otherwise a cheaper tier is admissible **iff its sampled quality clears the
+  baseline's sampled quality minus the class tolerance**,
+  ``theta_tid >= theta_base - q_tol`` — the sampled analogue of the Layer-2 gate.
+
+Among the admissible tiers the **cheapest** is chosen; a *downgrade* is therefore
+only ever returned when a cheaper tier sampled competitively, and an *upgrade* is
+returned only when it strictly beats the baseline's own sample (so the baseline
+is preferred on ties and an upgrade is never gratuitous). This guarantees the
+function NEVER returns a downgrade for a Critical / forced cell.
+
+Stdlib-only (``random``, ``math``): the sampler is ``random.Random(seed)
+.betavariate`` (Cheng's BB/BC algorithm — exact, no scipy). Pure function of its
+arguments; deterministic given ``seed``.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+from typing import Mapping
+
+from modeladvisor.store import Cell
+
+# Sentinel rationale strings (mirror the deterministic engine's phrasing so the
+# audit object reads consistently across modes).
+_BASELINE_RATIONALE = "no cheaper tier sampled competitively (Thompson draw)"
+_CRITICAL_RATIONALE = "Critical/forced cell: downgrades disabled (no cheaper tier admissible)"
+
+
+# --------------------------------------------------------------------------- #
+# Sampling (DESIGN §1.3 Layer 1 posteriors, drawn instead of lower-bounded)     #
+# --------------------------------------------------------------------------- #
+
+
+def sample_tier_qualities(
+    order: list[str],
+    cells_by_tier: Mapping[str, Cell],
+    *,
+    seed: int | None,
+) -> dict[str, float]:
+    """Draw one posterior sample ``theta_tid ~ Beta(a~, b~)`` per tier (seeded).
+
+    Realises the Thompson draw over the Beta-Bernoulli posteriors of DESIGN §1.3
+    Layer 1: for each tier in ``order`` (the cheapest→most-capable tier-id list),
+    sample ``theta_tid`` from that tier's posterior ``Beta(cell.a, cell.b)`` using
+    a single seeded :class:`random.Random` so the whole draw is deterministic and
+    reproducible given ``seed`` (DESIGN §1.4 property 2). Tiers are sampled in
+    ``order`` so the RNG stream — and hence every sample — is stable for a seed.
+
+    Parameters
+    ----------
+    order:
+        Cheapest→most-capable tier-id list (``cfg.tier_ids``).
+    cells_by_tier:
+        ``tier_id -> Cell`` map of the (pooled) posteriors to sample from.
+    seed:
+        RNG seed. ``None`` is permitted (non-reproducible, system entropy) but
+        callers wanting reproducibility — every test and the production hook —
+        pass an explicit integer.
+
+    Returns
+    -------
+    ``{tier_id: theta}`` with one sample per tier in ``order``, each in ``[0, 1]``.
+    """
+    rng = random.Random(seed)
+    samples: dict[str, float] = {}
+    for tid in order:
+        cell = cells_by_tier[tid]
+        # betavariate requires strictly-positive shape params; cold-start priors
+        # and posteriors always satisfy this (a, b > 0 by construction), but guard
+        # against a degenerate (0, 0) cell by nudging to a tiny positive epsilon.
+        a = cell.a if cell.a > 0.0 else 1e-9
+        b = cell.b if cell.b > 0.0 else 1e-9
+        samples[tid] = rng.betavariate(a, b)
+    return samples
+
+
+# --------------------------------------------------------------------------- #
+# Selection under the safety constraints (DESIGN §1.2, §1.4 Alg. 1, §7.2)        #
+# --------------------------------------------------------------------------- #
+
+
+def thompson_select(
+    order: list[str],
+    cells_by_tier: Mapping[str, Cell],
+    base_id: str,
+    *,
+    q_tol: float,
+    is_critical: bool,
+    forced: bool,
+    seed: int | None,
+) -> tuple[str, dict]:
+    """Pick the cost-minimal tier from one seeded Thompson draw, safely.
+
+    Faithful to the constrained decision of DESIGN §1.2 / Alg. 1, but with the
+    Layer-2 gate evaluated on a *sampled* quality instead of a lower bound:
+
+    1. Draw ``theta_tid ~ Beta`` per tier (:func:`sample_tier_qualities`, seeded).
+    2. Build the admissible set:
+
+       - the **baseline** ``base_id`` is always admissible;
+       - if ``is_critical`` or ``forced``, **no** tier cheaper than ``base_id`` is
+         admissible (hard never-downgrade rule / safety hatch, DESIGN §1.2, §7.4);
+       - otherwise a cheaper tier is admissible iff
+         ``theta_tier >= theta_base - q_tol`` (sampled Layer-2 gate, DESIGN §5.2);
+       - an **upgrade** (more capable than baseline) is admissible only if it
+         *strictly* beats the baseline's own sample (``theta_up > theta_base``),
+         so the baseline wins ties and upgrades are never gratuitous.
+
+    3. Choose the **cheapest** admissible tier (lowest index in ``order``).
+
+    Because every cheaper tier is excluded outright for a Critical / forced cell,
+    and otherwise only included when it sampled competitively, this NEVER returns
+    a downgrade for a Critical / forced cell, and only ever downgrades when a
+    cheaper tier genuinely sampled within tolerance (DESIGN §7.2 conservative
+    property, preserved under sampling).
+
+    Parameters
+    ----------
+    order:
+        Cheapest→most-capable tier-id list (``cfg.tier_ids``).
+    cells_by_tier:
+        ``tier_id -> Cell`` (pooled) posteriors, one per tier in ``order``.
+    base_id:
+        The baseline / reference tier ``tier*`` (must be in ``order``).
+    q_tol:
+        The tolerance-class ``q_tol`` (max allowable sampled quality drop).
+    is_critical:
+        Whether the cell's tolerance class is ``Critical`` (never downgrade).
+    forced:
+        Whether the ``force_baseline`` safety hatch is active (never downgrade).
+    seed:
+        RNG seed threaded from ``recommend`` (reproducible given the seed).
+
+    Returns
+    -------
+    ``(chosen_id, audit)``. ``audit`` is the structured reasoning surface
+    (DESIGN §1.4 property 3): the per-tier samples, the baseline sample, the
+    admissible set with per-tier admit reasons, the mode, the seed, and the
+    chosen tier — enough to fully explain (and replay) the draw.
+    """
+    if base_id not in cells_by_tier:
+        raise KeyError(f"baseline tier {base_id!r} not in sampled cells")
+    base_idx = order.index(base_id)
+
+    samples = sample_tier_qualities(order, cells_by_tier, seed=seed)
+    theta_base = samples[base_id]
+    no_downgrade = bool(is_critical or forced)
+
+    tiers_audit: list[dict] = []
+    admissible: list[str] = []
+
+    for tid in order:
+        idx = order.index(tid)
+        theta = samples[tid]
+
+        if tid == base_id:
+            admit = True
+            action = "stay"
+            reason = "baseline (always admissible)"
+        elif idx > base_idx:
+            action = "up"
+            # Upgrades are unconstrained by the gate, but only *selected* if they
+            # strictly beat the baseline's own sample (else the cheaper baseline
+            # wins on tie — upgrades are never gratuitous).
+            admit = theta > theta_base
+            if admit:
+                reason = f"upgrade: theta={theta:.4f} > baseline theta={theta_base:.4f}"
+            else:
+                reason = (
+                    f"upgrade not selected: theta={theta:.4f} "
+                    f"<= baseline theta={theta_base:.4f}"
+                )
+        else:
+            action = "down"
+            if no_downgrade:
+                admit = False
+                reason = _CRITICAL_RATIONALE
+            else:
+                threshold = theta_base - q_tol
+                admit = theta >= threshold
+                if admit:
+                    reason = (
+                        f"admitted: sampled theta={theta:.4f} >= {threshold:.4f} "
+                        f"(baseline theta {theta_base:.4f} - q_tol {q_tol:.4f})"
+                    )
+                else:
+                    reason = (
+                        f"rejected: sampled theta={theta:.4f} < {threshold:.4f} "
+                        f"(baseline theta {theta_base:.4f} - q_tol {q_tol:.4f})"
+                    )
+
+        if admit:
+            admissible.append(tid)
+
+        tiers_audit.append(
+            {
+                "tier_id": tid,
+                "action": action,
+                "theta": round(theta, 6),
+                "admitted": admit,
+                "reason": reason,
+            }
+        )
+
+    # ------------------------------------------------------------------ #
+    # Selection (cost-minimal under the sampled gate, DESIGN §1.2):       #
+    #                                                                     #
+    #   1. if any *cheaper* tier sampled competitively, take the CHEAPEST #
+    #      of them — a downgrade is warranted and we minimise cost;       #
+    #   2. else stay at baseline, UNLESS an *upgrade* strictly beat the   #
+    #      baseline's own sample, in which case take the cheapest such    #
+    #      upgrade. Upgrades are thus never gratuitous and a downgrade is #
+    #      always preferred when one cleared the gate.                    #
+    #                                                                     #
+    # The baseline is always admissible, so a choice always exists. A     #
+    # downgrade is unreachable whenever ``no_downgrade`` (Critical /      #
+    # forced), so this NEVER downgrades such a cell.                      #
+    # ------------------------------------------------------------------ #
+    down_admitted = [t for t in admissible if order.index(t) < base_idx]
+    up_admitted = [t for t in admissible if order.index(t) > base_idx]
+
+    if down_admitted:
+        chosen_id = min(down_admitted, key=order.index)  # cheapest downgrade
+        decision = (
+            f"downgrade to {chosen_id}: cheapest tier whose Thompson sample "
+            f"cleared baseline theta {theta_base:.4f} - q_tol {q_tol:.4f}"
+        )
+    elif up_admitted:
+        chosen_id = min(up_admitted, key=order.index)  # cheapest beating upgrade
+        decision = (
+            f"upgrade to {chosen_id}: no cheaper tier admissible and sample "
+            f"{samples[chosen_id]:.4f} strictly beat baseline theta {theta_base:.4f}"
+        )
+    else:
+        chosen_id = base_id
+        decision = _CRITICAL_RATIONALE if no_downgrade else _BASELINE_RATIONALE
+
+    audit = {
+        "mode": "thompson",
+        "seed": seed,
+        "baseline_tier": base_id,
+        "baseline_theta": round(theta_base, 6),
+        "q_tol": q_tol,
+        "critical": bool(is_critical),
+        "forced_baseline": bool(forced),
+        "no_downgrade": no_downgrade,
+        "samples": {tid: round(samples[tid], 6) for tid in order},
+        "tiers": tiers_audit,
+        "admissible": list(admissible),
+        "chosen_tier": chosen_id,
+        "decision": decision,
+    }
+    return chosen_id, audit

--- a/model-advisor/orders/model-advisor-auto-apply.toml
+++ b/model-advisor/orders/model-advisor-auto-apply.toml
@@ -1,0 +1,35 @@
+# model-advisor auto-apply — scheduled, evidence-gated per-agent model tuning.
+#
+# Runs `bin/advisor auto-apply` on a schedule so each agent's `model` config
+# field is kept at its cost-optimal tier as quality evidence accrues. This is an
+# EXEC order (no LLM, no agent, no wisp): the wrapper script calls the pack's own
+# CLI under its venv. See docs/AUTO-APPLY.md for the policy and wiring.
+#
+# SAFE BY DEFAULT: the wrapper runs in DRY-RUN unless the operator opts in by
+# exporting MODEL_ADVISOR_AUTO_APPLY=1 (or 'true') in the order's environment.
+# A dry run computes + logs the plan but writes nothing — so importing this order
+# without arming it never mutates config. See docs/AUTO-APPLY.md §"Arming".
+#
+# This file is an EXAMPLE artifact shipped with the pack. It is NOT registered
+# against any live city by the pack install; an operator copies/symlinks it into
+# a city/rig orders/ layer (or imports the pack's formula layer) to activate it.
+[order]
+description = "Keep each agent's model at its evidence-justified cost-optimal tier (model-advisor)"
+
+# --- trigger: daily cron (00:30 every day). ------------------------------------
+# Cron form "min hour dom mon dow". Tune the cadence to your evidence velocity:
+# a busy town accrues telemetry fast (try @daily); a quiet one can run weekly.
+# To use a fixed inter-run gap instead of a wall-clock time, swap to:
+#     trigger  = "cooldown"
+#     interval = "24h"
+trigger  = "cron"
+schedule = "30 0 * * *"
+
+# --- action: the pack's auto-apply wrapper (exec; no pool — exec orders can't). #
+# $PACK_DIR is expanded by the controller to this pack's directory.
+exec    = "$PACK_DIR/orders/scripts/auto-apply.sh"
+timeout = "120s"
+
+# Active once discovered. Set to false to ship the order but keep it dormant
+# until an operator is ready (belt-and-braces with the dry-run default above).
+enabled = true

--- a/model-advisor/orders/model-advisor-eval-schedule.toml
+++ b/model-advisor/orders/model-advisor-eval-schedule.toml
@@ -1,0 +1,40 @@
+# model-advisor eval-schedule — Layer-4 uncertainty-triggered eval auto-dispatch.
+#
+# Runs `bin/advisor eval-schedule` on a schedule so the cells that are GATING a
+# downgrade on uncertainty get a deterministic eval probe, ranked by posterior
+# CI half-width × the spend confirming the downgrade would unlock (DESIGN §5.4).
+# This is the auto-dispatch v1 deferred (DESIGN §7.3): v1 surfaced the widest
+# gating cell in `advisor inspect`; this order acts on it. It is an EXEC order
+# (no LLM, no agent, no wisp): the wrapper script calls the pack's own CLI under
+# its venv. See docs/DESIGN.md §5.4 / §6.2 for the policy.
+#
+# SAFE BY DEFAULT: the wrapper runs in DRY-RUN unless the operator opts in by
+# exporting MODEL_ADVISOR_EVAL_SCHEDULE=1 (or 'true') in the order's environment.
+# A dry run computes + logs the ranked eval plan (the `gc bd create` commands it
+# WOULD run) but creates no beads — so importing this order without arming it
+# never mutates state.
+#
+# This file is an EXAMPLE artifact shipped with the pack. It is NOT registered
+# against any live city by the pack install; an operator copies/symlinks it into
+# a city/rig orders/ layer (or imports the pack's formula layer) to activate it.
+[order]
+description = "Schedule eval probes for the highest-value gating cells (model-advisor Layer 4)"
+
+# --- trigger: weekly cron (Mon 01:00). -----------------------------------------
+# Cron form "min hour dom mon dow". Eval probes are expensive (they spend real
+# tokens against held-out fixtures), so default to a slower cadence than
+# auto-apply. Tune to your eval budget / evidence velocity. To use a fixed
+# inter-run gap instead of a wall-clock time, swap to:
+#     trigger  = "cooldown"
+#     interval = "168h"
+trigger  = "cron"
+schedule = "0 1 * * 1"
+
+# --- action: the pack's eval-schedule wrapper (exec; no pool — exec orders can't). #
+# $PACK_DIR is expanded by the controller to this pack's directory.
+exec    = "$PACK_DIR/orders/scripts/eval-schedule.sh"
+timeout = "120s"
+
+# Active once discovered. Set to false to ship the order but keep it dormant
+# until an operator is ready (belt-and-braces with the dry-run default above).
+enabled = true

--- a/model-advisor/orders/scripts/auto-apply.sh
+++ b/model-advisor/orders/scripts/auto-apply.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# auto-apply.sh — exec-order entrypoint for model-advisor's scheduled auto-apply.
+#
+# Invoked by orders/model-advisor-auto-apply.toml (an EXEC order: no LLM, no
+# agent, no wisp). It drives the pack's own CLI:
+#
+#     bin/advisor auto-apply [--apply] [--rig <rig>] --city <city> --json
+#
+# which sweeps every configured agent and sets each one's `model` config field to
+# its conservative per-agent tier (the safest tier across the agent's shapes),
+# but ONLY for evidence-strong changes — never auto-downgrading on thin evidence
+# and never touching Critical-pinned agents. See docs/AUTO-APPLY.md for the full
+# policy.
+#
+# SAFE BY DEFAULT: runs in DRY-RUN unless MODEL_ADVISOR_AUTO_APPLY is set to a
+# truthy value (1/true/yes). A dry run computes + prints the plan but writes
+# nothing — so the order can be imported and observed before it is armed.
+#
+# Optional environment knobs (all have safe defaults):
+#   MODEL_ADVISOR_AUTO_APPLY   1|true|yes  -> actually write (else dry-run)
+#   MODEL_ADVISOR_RIG          <rig name>  -> narrow scope to one rig
+#   ADVISOR_TOML               <path>      -> advisor.toml (else pack default)
+#   ADVISOR_TELEMETRY_DIR      <path>      -> telemetry dir (else <city>/.beads/telemetry)
+#
+# The controller exports GC_PACK_DIR / GC_CITY (and GC_CITY_PATH / GC_RIG) into
+# an exec order's environment; we fall back sensibly when run by hand.
+set -euo pipefail
+
+# --- resolve the pack directory (prefer the controller-provided GC_PACK_DIR) ---
+PACK_DIR="${GC_PACK_DIR:-}"
+if [ -z "$PACK_DIR" ]; then
+    # orders/scripts/auto-apply.sh -> pack root is two levels up.
+    PACK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+fi
+
+# --- resolve the city root -----------------------------------------------------
+CITY="${GC_CITY:-${GC_CITY_PATH:-.}}"
+
+# --- telemetry: default to the city's .beads/telemetry if not overridden -------
+# (build_state also defaults this, but being explicit keeps the log auditable.)
+if [ -z "${ADVISOR_TELEMETRY_DIR:-}" ] && [ -d "$CITY/.beads/telemetry" ]; then
+    export ADVISOR_TELEMETRY_DIR="$CITY/.beads/telemetry"
+fi
+
+# --- assemble the auto-apply invocation ----------------------------------------
+ADVISOR="$PACK_DIR/bin/advisor"
+if [ ! -x "$ADVISOR" ]; then
+    echo "auto-apply.sh: $ADVISOR not found/executable (pack dir wrong?)" >&2
+    exit 2
+fi
+
+args=("auto-apply" "--city" "$CITY" "--json")
+
+# scope: town (default) or a single rig.
+RIG="${MODEL_ADVISOR_RIG:-${GC_RIG:-}}"
+if [ -n "$RIG" ]; then
+    args+=("--rig" "$RIG")
+fi
+
+# arm only when explicitly opted in.
+case "${MODEL_ADVISOR_AUTO_APPLY:-}" in
+    1|true|TRUE|yes|YES|on|ON)
+        args+=("--apply")
+        echo "auto-apply.sh: ARMED (writing config changes)" >&2
+        ;;
+    *)
+        echo "auto-apply.sh: DRY-RUN (set MODEL_ADVISOR_AUTO_APPLY=1 to arm)" >&2
+        ;;
+esac
+
+# Run it. The CLI emits a structured JSON report on stdout (captured by the
+# order's run log) and a human note on stderr; exit code is non-zero only if a
+# per-agent error occurred, which surfaces in `gc order history`.
+exec "$ADVISOR" "${args[@]}"

--- a/model-advisor/orders/scripts/eval-schedule.sh
+++ b/model-advisor/orders/scripts/eval-schedule.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# eval-schedule.sh — exec-order entrypoint for model-advisor's Layer-4 auto-eval.
+#
+# Invoked by orders/model-advisor-eval-schedule.toml (an EXEC order: no LLM, no
+# agent, no wisp). It drives the pack's own CLI:
+#
+#     bin/advisor eval-schedule [--max N] [--apply] --city <city> --json
+#
+# which sweeps every configured (agent, shape) cell, ranks the cells that are
+# GATING a downgrade on uncertainty by `posterior CI half-width × unlock-value`
+# (the spend confirming the downgrade would save), and emits an eval-request bead
+# for the top N — auto-dispatch proportional to posterior width (DESIGN §5.4).
+# This closes the loop that v1 only *surfaced* in `advisor inspect`.
+#
+# SAFE BY DEFAULT: runs in DRY-RUN unless MODEL_ADVISOR_EVAL_SCHEDULE is set to a
+# truthy value (1/true/yes). A dry run computes + prints the ranked eval plan
+# (the `gc bd create` commands it WOULD run) but creates no beads — so the order
+# can be imported and observed before it is armed.
+#
+# Optional environment knobs (all have safe defaults):
+#   MODEL_ADVISOR_EVAL_SCHEDULE  1|true|yes  -> actually create eval beads (else dry-run)
+#   MODEL_ADVISOR_EVAL_MAX       <int>       -> cap on eval beads per run (default 5)
+#   MODEL_ADVISOR_RIG            <rig name>  -> create eval beads in this rig's db
+#   ADVISOR_TOML                 <path>      -> advisor.toml (else pack default)
+#   ADVISOR_TELEMETRY_DIR        <path>      -> telemetry dir (else <city>/.beads/telemetry)
+#
+# The controller exports GC_PACK_DIR / GC_CITY (and GC_CITY_PATH / GC_RIG) into
+# an exec order's environment; we fall back sensibly when run by hand.
+set -euo pipefail
+
+# --- resolve the pack directory (prefer the controller-provided GC_PACK_DIR) ---
+PACK_DIR="${GC_PACK_DIR:-}"
+if [ -z "$PACK_DIR" ]; then
+    # orders/scripts/eval-schedule.sh -> pack root is two levels up.
+    PACK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+fi
+
+# --- resolve the city root -----------------------------------------------------
+CITY="${GC_CITY:-${GC_CITY_PATH:-.}}"
+
+# --- telemetry: default to the city's .beads/telemetry if not overridden -------
+# (build_state also defaults this, but being explicit keeps the log auditable.)
+if [ -z "${ADVISOR_TELEMETRY_DIR:-}" ] && [ -d "$CITY/.beads/telemetry" ]; then
+    export ADVISOR_TELEMETRY_DIR="$CITY/.beads/telemetry"
+fi
+
+# --- assemble the eval-schedule invocation -------------------------------------
+ADVISOR="$PACK_DIR/bin/advisor"
+if [ ! -x "$ADVISOR" ]; then
+    echo "eval-schedule.sh: $ADVISOR not found/executable (pack dir wrong?)" >&2
+    exit 2
+fi
+
+args=("eval-schedule" "--city" "$CITY" "--json")
+
+# eval budget: how many eval beads to schedule this run.
+MAXN="${MODEL_ADVISOR_EVAL_MAX:-}"
+if [ -n "$MAXN" ]; then
+    args+=("--max" "$MAXN")
+fi
+
+# scope: create the eval beads in a specific rig's database, if requested.
+RIG="${MODEL_ADVISOR_RIG:-${GC_RIG:-}}"
+if [ -n "$RIG" ]; then
+    args+=("--rig" "$RIG")
+fi
+
+# arm only when explicitly opted in.
+case "${MODEL_ADVISOR_EVAL_SCHEDULE:-}" in
+    1|true|TRUE|yes|YES|on|ON)
+        args+=("--apply")
+        echo "eval-schedule.sh: ARMED (creating eval-request beads)" >&2
+        ;;
+    *)
+        echo "eval-schedule.sh: DRY-RUN (set MODEL_ADVISOR_EVAL_SCHEDULE=1 to arm)" >&2
+        ;;
+esac
+
+# Run it. The CLI emits a structured JSON report on stdout (captured by the
+# order's run log) and a human note on stderr; exit code is non-zero only if a
+# scheduling/creation error occurred, which surfaces in `gc order history`.
+exec "$ADVISOR" "${args[@]}"

--- a/model-advisor/overlay/per-provider/claude/.claude/settings.json
+++ b/model-advisor/overlay/per-provider/claude/.claude/settings.json
@@ -1,0 +1,24 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "export PATH=\"/opt/homebrew/bin:/usr/local/bin:$HOME/go/bin:$HOME/.local/bin:$PATH\" && d=\"$CLAUDE_PROJECT_DIR\"; while [ -n \"$d\" ] && [ \"$d\" != \"/\" ]; do h=\"$d/packs/model-advisor/hooks/capture-invocation.sh\"; [ -f \"$h\" ] && { bash \"$h\"; break; }; d=\"$(dirname \"$d\")\"; done; true"
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "export PATH=\"/opt/homebrew/bin:/usr/local/bin:$HOME/go/bin:$HOME/.local/bin:$PATH\" && d=\"$CLAUDE_PROJECT_DIR\"; while [ -n \"$d\" ] && [ \"$d\" != \"/\" ]; do h=\"$d/packs/model-advisor/hooks/capture-invocation.sh\"; [ -f \"$h\" ] && { bash \"$h\"; break; }; d=\"$(dirname \"$d\")\"; done; true"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/model-advisor/pack.toml
+++ b/model-advisor/pack.toml
@@ -1,0 +1,38 @@
+# model-advisor — cost-minimal model-tier selection for Gas City agents.
+#
+# A self-contained, clean-room implementation of the Blackrim "Conservative
+# Constrained Thompson Sampling" (CC-TS) model-tier advisor, re-derived from the
+# paper's §3/§5 math and adapted to gc's agent roster and an arbitrary,
+# config-driven model roster (not a fixed haiku/sonnet/opus 3-tier). It learns
+# per-(provider, agent, shape, tier) success posteriors from bead lifecycle +
+# invocation telemetry and recommends the cheapest tier that *credibly* preserves
+# quality — never downgrading without evidence. See docs/DESIGN.md.
+#
+# What this pack provides (all convention-discovered once the pack is imported):
+#   bin/advisor                             the advise/inspect/apply CLI
+#   modeladvisor/                           the engine (pure-stdlib CC-TS rule)
+#   skills/use-model-advisor/SKILL.md       agent/operator skill: advise before dispatch
+#   template-fragments/                     the cost-aware model-selection discipline
+#   overlay/per-provider/claude/            Stop/SubagentStop telemetry hook
+#   hooks/capture-invocation.sh             the hook script (appends invocation records)
+#   advisor.toml                            the roster + shapes + tolerance classes
+#
+# Telemetry sink: .beads/telemetry/invocations.jsonl (dispatch + quality records,
+# DESIGN §5); the cell-store cache (advisor-cells.json) is rebuildable from it.
+#
+# Wiring (after importing this pack into a city, e.g. `source = "packs/model-advisor"`):
+#   1. Run `packs/model-advisor/setup.sh` once to build the engine's venv.
+#   2. (recommended, --town) add "use-model-advisor" to city.toml global_fragments.
+#   3. The skill and the claude Stop/SubagentStop overlay are picked up
+#      automatically; gc deep-merges the overlay's hook into projected settings.
+#   4. Edit advisor.toml to declare your model roster (the cost-ordered tiers),
+#      the shape taxonomy, and per-(agent, shape) tolerance classes.
+#
+# The pack degrades safely: it observes and *advises*; it never blocks or mutates
+# a dispatch. With no telemetry it cold-starts conservatively — recommending the
+# known-good baseline tier until a cheaper tier earns admission (DESIGN §3.2).
+
+[pack]
+name = "model-advisor"
+schema = 2
+version = "0.1.0"

--- a/model-advisor/requirements-dev.txt
+++ b/model-advisor/requirements-dev.txt
@@ -1,0 +1,7 @@
+# model-advisor development/test dependencies (runtime deps live in
+# requirements.txt). The behavioural test suite under tests/ uses pytest;
+# coverage is measured with pytest-cov (coverage.py); ruff provides linting.
+# These mirror the read-side pack's dev pipeline so both packs test the same way.
+pytest
+pytest-cov
+ruff

--- a/model-advisor/requirements.txt
+++ b/model-advisor/requirements.txt
@@ -1,0 +1,12 @@
+# model-advisor runtime deps — deliberately MINIMAL.
+#
+# The engine (DESIGN §1, §5) is pure-stdlib: the Wilson-style normal lower
+# confidence bound on the Beta posterior is plain arithmetic, the cell store is
+# JSON over `.beads/telemetry/invocations.jsonl`, and config is TOML.
+#
+# TOML parsing uses the stdlib `tomllib`, which ships in Python >= 3.11. The
+# pack targets 3.11+, so no third-party TOML library is required. The single
+# guarded fallback below pulls `tomli` *only* on an older interpreter, so the
+# config loader's `import tomllib` / `import tomli as tomllib` shim has a backend
+# everywhere without adding a dependency on a modern Python.
+tomli>=2.0 ; python_version < "3.11"

--- a/model-advisor/setup.sh
+++ b/model-advisor/setup.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Bootstrap the model-advisor pack's self-contained venv (idempotent).
+set -euo pipefail
+PACK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PY="${PYTHON:-python3}"
+"$PY" -m venv "$PACK_DIR/.venv"
+"$PACK_DIR/.venv/bin/pip" install --quiet --upgrade pip
+"$PACK_DIR/.venv/bin/pip" install --quiet -r "$PACK_DIR/requirements.txt"
+echo "model-advisor venv ready: $PACK_DIR/.venv"

--- a/model-advisor/skills/use-model-advisor/SKILL.md
+++ b/model-advisor/skills/use-model-advisor/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: use-model-advisor
+description: Pick the cost-optimal model tier before dispatching meaningful work. Before slinging a non-trivial bead to an agent, run `advisor advise <agent> <shape>` to get the cheapest model tier that credibly preserves quality, `advisor inspect <agent> <shape>` to see the evidence behind it, and `advisor apply <agent>` to set the recommended tier on that agent's config. Use whenever you are about to choose or change which model an agent runs (implement, review, judge, lookup, patrol work).
+---
+
+# Use Model Advisor
+
+## Overview
+
+Every dispatch silently picks a model. Defaulting every agent to the most
+capable (most expensive) tier is safe but wasteful; quietly downgrading to a
+cheaper tier to save spend is cheap but risky — a wrong downgrade on a
+high-blast-radius task cascades. **model-advisor** turns that judgement into a
+measured one: for each `(provider, agent, shape, tier)` cell it maintains a
+success posterior learned from bead lifecycle and invocation telemetry, and
+recommends the **cheapest tier whose quality stays within tolerance, with high
+credibility.**
+
+The discipline this skill teaches: **consult the advisor before you commit a
+model choice.** It is a read-first, advise-then-apply loop — `advise` to get the
+recommendation, `inspect` to audit the evidence, `apply` to set it. The advisor
+recommends; you (or an operator) apply.
+
+**The conservative guarantee.** The advisor *never downgrades a tier without
+credible evidence.* A cheaper tier is admitted only if a one-sided lower
+confidence bound on its success probability clears the baseline tier's quality
+minus the task's tolerance, at 95% credibility. With thin or no evidence the
+gate rejects by default and the advisor returns the known-good baseline tier.
+`Critical`-class work (ADRs, threat models, release gating) is *never* downgraded
+regardless of evidence — that is a design contract, not a tunable. So the worst
+case is "keep paying for the safe tier," never "silently ship worse work."
+
+## When to Use
+
+- You are about to `gc sling` / route a non-trivial bead and want the
+  cost-minimal model for it without risking quality.
+- You are setting or revisiting an agent's `model` config field and want it
+  grounded in evidence rather than a guess.
+- You want to know *why* a tier is (or isn't) recommended — the credible
+  quality-drop interval, the per-tier confidence bound, the cost differential.
+- You are deciding whether a cheaper tier has earned its way in yet for a given
+  agent + task shape.
+
+**When NOT to use:**
+
+- Trivial / throwaway work where the model choice does not matter — just sling.
+- Incident response, where exploration is wrong: pin the baseline tier
+  (`force_baseline`) and skip the advisor until the incident clears.
+- You have no roster configured yet — populate `advisor.toml` first (the advisor
+  cannot order tiers by cost without it; see [Configuration](#configuration)).
+
+## The Shapes
+
+A **shape** is the *kind of cognitive task*, independent of which agent runs it.
+The advisor keys recommendations on `(agent, shape)`; pass the shape that best
+describes the work:
+
+| Shape       | Meaning                                          | Typical tolerance |
+|-------------|--------------------------------------------------|-------------------|
+| `lookup`    | retrieve / answer / summarise; low blast radius  | Lenient           |
+| `implement` | write / modify code or config; multi-file edits  | Moderate          |
+| `judge`     | routing / triage / decision with downstream effect | Moderate→Critical |
+| `review`    | read-only critique with a verdict                | Strict            |
+| `patrol`    | health / oversight monitoring, recurring         | Lenient→Moderate  |
+
+The taxonomy is config-extensible (`advisor.toml`); a consumer can add e.g.
+`threat-model` and pin it `Critical`.
+
+## Process
+
+### Step 1 — Ask for the recommendation
+
+```bash
+advisor advise <agent> <shape>
+# e.g.  advisor advise polecat implement
+```
+
+`bin/advisor` is shipped with this pack. If it is not already on `PATH`, invoke
+it by its pack-relative path (e.g. `.../packs/model-advisor/bin/advisor advise
+…`). Optional flags refine the cell: `--tol <class>` overrides the tolerance
+class, `--provider <p>` / `--rig <r>` scope the cell, `--baseline <tier>` pins a
+different reference tier. The command is a **pure read** — it never dispatches,
+mutates a bead, or changes config.
+
+It prints the recommended `tier_id` (with the concrete model), a one-line
+rationale, and the cost differential versus each roster tier. Two shapes of
+answer you will see:
+
+- **A downgrade earned its way in** —
+  *"sonnet: LCB q_lo=0.82 ≥ baseline mean 0.80 − 0.05 tol; cheapest admitted
+  tier; expected loss −$0.011/dispatch vs opus."*
+- **Cold-start / thin evidence (the conservative default)** —
+  *"opus (baseline): no cheaper tier clears tolerance — haiku q_lo=0.41,
+  sonnet q_lo=0.58 both < 0.75 threshold (thin evidence, n<5)."*
+
+Add `--json` to get the full structured `reasons` object (candidates, per-tier
+`q_lo`, expected loss, cost diffs, eval flag) for programmatic routing.
+
+### Step 2 — Inspect the evidence (when the call is consequential)
+
+```bash
+advisor inspect <agent> <shape>
+```
+
+This is the audit surface — a read-only deep view of the `(agent, shape)` cells
+across the whole roster:
+
+- per-tier posterior `Beta(a, b)`, mean, the lower confidence bound `q_lo`,
+  observation count `n`, last-update time, and admit/reject under the current
+  tolerance;
+- the **credible interval on the quality drop** vs baseline for each candidate —
+  the quantity the constraint actually bounds, e.g.
+  *"haiku: quality-drop 95% CI [0.06, 0.31] — exceeds 0.05 tol";*
+- the **highest-value eval probe** — the widest cell that is *gating* a decision,
+  named so a human can resolve it: *"widest gating cell: sonnet (CI half-width
+  0.14 > 0.10); run an eval on claude::polecat::implement::sonnet."*
+
+Use `inspect` whenever you want to understand *why* `advise` said what it said,
+or to judge whether a cell has enough evidence to trust a downgrade.
+
+### Step 3 — Apply the recommendation (deliberate, per-agent)
+
+```bash
+advisor apply <agent>
+```
+
+`apply` sets the advisor's recommended tier on the agent's `model` config field
+(and triggers a reload so the next session honours it). This is the v1
+application path: **per-agent**, not per-dispatch. It is a deliberate write — run
+it when you have reviewed the recommendation and want it to take effect. Until
+you `apply`, nothing changes: the advisor only advises.
+
+Per-dispatch auto-apply (stamping the advised tier on a bead at `gc sling` time)
+is **v2** and gated on a small gc-core change — see the README. In v1, the
+advise→inspect→apply loop is the contract.
+
+## Worked Example
+
+You are about to dispatch a multi-file feature bead to `polecat`.
+
+1. `advisor advise polecat implement` → recommends `sonnet`, rationale
+   *"q_lo=0.82 ≥ 0.80 − 0.05 tol; cheapest admitted; −$0.011/dispatch vs opus."*
+2. The recommendation is a downgrade from the `opus` baseline, so you check the
+   evidence: `advisor inspect polecat implement` shows `sonnet` at `n=37`,
+   quality-drop 95% CI `[0.00, 0.04]` (within the 0.05 Moderate tolerance), and
+   no gating eval outstanding. The downgrade is credible.
+3. You set it: `advisor apply polecat` pins `sonnet` for polecat's implement
+   work. Future `implement` dispatches run the cheaper tier; quality keeps
+   feeding the posterior, and if it ever slips, the next `advise` will say so.
+
+Had `inspect` shown `n=3` and a wide interval, `advise` would have returned the
+`opus` baseline instead — and you would simply keep paying for the safe tier
+until evidence accrued. That is the conservative guarantee in practice.
+
+## Why This Matters
+
+- **Cost economy with a quality floor.** The advisor spends the cheapest tier it
+  can *prove* is good enough, and falls back to the safe tier whenever it can't —
+  capturing savings on well-characterised cells without gambling on thin ones.
+- **Auditability.** Every recommendation carries its evidence (`reasons`):
+  candidate tiers, confidence bounds, credible quality-drop intervals, cost
+  diffs. You can always see *why*, which is what makes it safe to let the advisor
+  inform routing at all.
+- **It degrades, never blocks.** Missing telemetry ⇒ cold-start baseline; missing
+  token counts ⇒ a representative budget; thin evidence ⇒ the safe tier. The
+  advisor cannot stall a dispatch — worst case it recommends the baseline.
+
+## Verification Gate
+
+Before committing a model choice for consequential work:
+
+- [ ] `advisor advise <agent> <shape>` was consulted for the dispatch's shape.
+- [ ] For a recommended **downgrade**, `advisor inspect` was checked — the
+      credible quality-drop interval is within tolerance and no gating eval is
+      outstanding — before `apply`.
+- [ ] `Critical`-class work was left on its baseline tier (never downgraded).
+- [ ] Where the recommendation was adopted, it was set via `advisor apply
+      <agent>` (a deliberate write), not an ad-hoc untracked config edit.
+
+<!-- registration -->
+**Registration.** gc discovers pack skills by directory convention: a pack
+contributes a skill by placing `skills/<name>/SKILL.md` under the pack root, with
+YAML frontmatter carrying at minimum `name` and `description` (the body is
+free-form Markdown, by convention including a "When to Use" trigger section).
+This file lives at `model-advisor/skills/use-model-advisor/SKILL.md`, so it is
+picked up automatically — `pack.toml` does not enumerate skills. Once the
+`model-advisor` pack is imported into a city (vendored under the city's `packs/`
+and registered via a direct `source = "packs/model-advisor"` import), the skill
+surfaces in `gc skill list` binding-qualified as `<binding>.use-model-advisor`
+(e.g. `model-advisor.use-model-advisor`), and the materializer projects it into
+the per-agent skills sink at `gc start`. Verify with `gc skill list` (and
+`gc lint .` / `gc doctor` to surface name collisions). This mirrors how the
+bundled `core` pack ships its `core.gc-*` skills.

--- a/model-advisor/template-fragments/model-advisor.template.md
+++ b/model-advisor/template-fragments/model-advisor.template.md
@@ -1,0 +1,47 @@
+{{ define "use-model-advisor" }}
+## Dispatch Discipline: Advise Before You Spend
+
+The model an agent runs is a cost decision and a quality decision at once.
+Defaulting everything to the strongest tier is safe but burns budget; quietly
+dropping to a cheaper tier is cheap but can cascade a wrong answer through every
+bead that depended on it. The advisor makes that trade-off *measured*: it learns
+a success posterior per `(agent, shape, tier)` and recommends the cheapest tier
+whose quality stays within tolerance, with 95% credibility.
+
+**The rule:** before dispatching **meaningful work**, consult the advisor for the
+task's shape, then commit a tier deliberately.
+
+```bash
+advisor advise <agent> <shape>
+```
+
+`advisor` is read-only and stateless on `advise`/`inspect`; it never blocks or
+mutates a dispatch. It prints the recommended tier, a one-line rationale, and the
+cost differential against every roster tier.
+
+**The loop:**
+1. **Advise first.** Run `advisor advise <agent> <shape>` (shapes: `lookup`,
+   `implement`, `judge`, `review`, `patrol`). For most dispatches the
+   recommendation + its rationale is the whole answer — take the tier and go.
+2. **Inspect before a downgrade.** If the recommendation is *cheaper than the
+   baseline*, check the evidence: `advisor inspect <agent> <shape>` shows the
+   per-tier confidence bound, the credible quality-drop interval vs baseline, and
+   whether a gating eval is outstanding. Adopt the downgrade only when the
+   interval is within tolerance.
+3. **Apply deliberately.** `advisor apply <agent>` sets the recommended tier on
+   the agent's config. Until you apply, nothing changes — the advisor only
+   advises.
+
+**The conservative guarantee — why this is safe to follow:** the advisor *never
+downgrades without credible evidence.* A cheaper tier is admitted only if a
+one-sided lower bound on its success clears `baseline − tolerance` at 95%
+credibility; with thin or no evidence the gate rejects and you get the known-good
+baseline tier. `Critical` work (ADRs, threat models, release gating) is never
+downgraded at all. So the worst case is overpaying for the safe tier — never
+silently shipping worse work. The trade-off is asymmetric and the advisor sits on
+the safe side of it by construction.
+
+**For trivial or throwaway work**, skip it — the model choice does not matter.
+During an **incident**, pin the baseline (`force_baseline`) and don't explore.
+When the dispatch is consequential and the spend is real, advise first.
+{{ end }}

--- a/model-advisor/tests/test_autoapply.py
+++ b/model-advisor/tests/test_autoapply.py
@@ -1,0 +1,717 @@
+"""Tests for per-agent auto-apply (``modeladvisor.autoapply`` + the CLI surface).
+
+These exercise the **real** engine/store/config (auto-apply is defined in terms
+of the engine's gate, so the realistic contract is the point) against a
+multi-agent TEMP ``advisor.toml`` + synthetic ``invocations.jsonl``.
+
+Safety: NOTHING here touches live ``/Users/jayse/Code`` config. Every config /
+telemetry / city file is created under ``tmp_path``; the resolver is pointed at
+the temp ``city.toml`` via ``$ADVISOR_AGENT_TOML`` (the same hook the apply tests
+use) and the engine state via ``$ADVISOR_TOML`` / ``$ADVISOR_TELEMETRY_DIR``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+PACK_DIR = Path(__file__).resolve().parents[1]
+
+# Import the real engine modules. If the sibling bead isn't present, skip the
+# whole file (mirrors test_cli's real-engine gate) — auto-apply has no meaning
+# without the engine.
+try:
+    from modeladvisor import autoapply
+    from modeladvisor import config as madconfig
+    from modeladvisor import engine as madengine
+    from modeladvisor import store as madstore
+    _HAVE = True
+except Exception:  # pragma: no cover - engine not landed
+    _HAVE = False
+
+pytestmark = pytest.mark.skipif(not _HAVE, reason="sibling engine/store/config not present")
+
+
+# Load cli.py standalone (bypassing package __init__ re-exports), as test_cli does.
+def _load_cli_module():
+    spec = importlib.util.spec_from_file_location(
+        "mad_cli_under_test_aa", PACK_DIR / "modeladvisor" / "cli.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["mad_cli_under_test_aa"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+cli = _load_cli_module() if _HAVE else None
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures: a multi-agent temp config + synthetic telemetry
+# --------------------------------------------------------------------------- #
+
+# A self-contained advisor.toml. Roster haiku ≺ sonnet ≺ opus, baseline opus.
+# refinery/judge is pinned Critical; mayor/judge has a force_baseline cell so we
+# can exercise BOTH block paths. polecat → {implement, lookup}.
+ADVISOR_TOML = """
+[advisor]
+default_provider = "claude"
+baseline_tier = "opus"
+
+[[tier]]
+id = "haiku"
+provider = "claude"
+model = "claude-haiku-4-5"
+run_target = "claude-haiku"
+rank = 1
+in_cost = 0.80
+out_cost = 4.00
+
+[[tier]]
+id = "sonnet"
+provider = "claude"
+model = "claude-sonnet-4-5"
+run_target = "claude-sonnet"
+rank = 2
+in_cost = 3.00
+out_cost = 15.00
+
+[[tier]]
+id = "opus"
+provider = "claude"
+model = "claude-opus-4-8"
+run_target = "claude-opus"
+rank = 3
+in_cost = 15.00
+out_cost = 75.00
+
+[[tolerance]]
+name = "Critical"
+q_tol = 0.0
+multiplier = "inf"
+[[tolerance]]
+name = "Strict"
+q_tol = 0.02
+multiplier = 20
+[[tolerance]]
+name = "Moderate"
+q_tol = 0.05
+multiplier = 5
+[[tolerance]]
+name = "Lenient"
+q_tol = 0.10
+multiplier = 1
+
+[[shape]]
+name = "lookup"
+tol_class = "Lenient"
+[[shape]]
+name = "implement"
+tol_class = "Moderate"
+[[shape]]
+name = "judge"
+tol_class = "Moderate"
+[[shape]]
+name = "review"
+tol_class = "Strict"
+[[shape]]
+name = "patrol"
+tol_class = "Lenient"
+
+[[agent]]
+name = "polecat"
+shapes = ["implement", "lookup"]
+
+[[agent]]
+name = "refinery"
+shapes = ["review", "judge"]
+  [[agent.cell]]
+  shape = "judge"
+  tol_class = "Critical"
+
+[[agent]]
+name = "mayor"
+shapes = ["judge", "implement", "lookup"]
+  [[agent.cell]]
+  shape = "judge"
+  force_baseline = true
+
+[[agent]]
+name = "witness"
+shapes = ["patrol", "judge"]
+
+[[agent]]
+name = "boot"
+shapes = ["patrol", "judge"]
+
+[[agent]]
+name = "deacon"
+shapes = ["patrol", "judge"]
+"""
+
+# The base agents the config declares (auto-apply sweeps all of these).
+ALL_AGENTS = ("boot", "deacon", "mayor", "polecat", "refinery", "witness")
+
+
+def _city_toml(agents=ALL_AGENTS) -> str:
+    """A city.toml with an [[agent]] block per agent so every one resolves."""
+    out = ['[workspace]', 'provider = "claude"', ""]
+    for a in agents:
+        out += [f'[[agent]]', f'name = "{a}"', 'scope = "rig"', ""]
+    return "\n".join(out)
+
+
+def _wins(cell_key: str, n: int, channel: str = "close") -> list:
+    return [
+        {"kind": "quality", "cell_key": cell_key, "q": 1, "channel": channel, "ts": "2026-01-01T00:00:00Z"}
+        for _ in range(n)
+    ]
+
+
+def _build_store(cfg, records):
+    st = madstore.CellStore.cold_start(cfg)
+    st.apply_records(records)
+    return st
+
+
+def _cfg():
+    import tomllib
+    return madconfig.from_mapping(tomllib.loads(ADVISOR_TOML))
+
+
+@pytest.fixture
+def cfg():
+    return _cfg()
+
+
+@pytest.fixture
+def city(tmp_path):
+    p = tmp_path / "city.toml"
+    p.write_text(_city_toml(), encoding="utf-8")
+    return p
+
+
+# --------------------------------------------------------------------------- #
+# Policy unit tests (decide_agent — pure, no file I/O)
+# --------------------------------------------------------------------------- #
+
+def test_safest_across_shapes_takes_most_capable(cfg):
+    """polecat: implement→sonnet but lookup still cold → conservative tier = opus."""
+    st = _build_store(cfg, _wins("claude::polecat::implement::sonnet", 60))
+    d = autoapply.decide_agent("polecat", cfg, st, madengine, provider="claude")
+    assert d.per_shape["implement"] == "sonnet"
+    assert d.per_shape["lookup"] == "opus"  # cold
+    # safest (most-capable) across shapes is opus — no shape may be under-served.
+    assert d.chosen_tier == "opus"
+    assert d.binding_shape == "lookup"
+
+
+def test_safest_across_shapes_downgrades_when_all_clear(cfg):
+    """polecat: BOTH shapes strong on sonnet → conservative tier = sonnet."""
+    recs = _wins("claude::polecat::implement::sonnet", 60) + _wins(
+        "claude::polecat::lookup::sonnet", 60
+    )
+    st = _build_store(cfg, recs)
+    d = autoapply.decide_agent("polecat", cfg, st, madengine, provider="claude")
+    assert d.per_shape == {"implement": "sonnet", "lookup": "sonnet"}
+    assert d.chosen_tier == "sonnet"
+
+
+def test_critical_agent_blocked(cfg):
+    """refinery has a Critical judge shape → blocked even with huge sonnet evidence."""
+    recs = _wins("claude::refinery::review::sonnet", 80, channel="review") + _wins(
+        "claude::refinery::judge::sonnet", 80, channel="eval"
+    )
+    st = _build_store(cfg, recs)
+    d = autoapply.decide_agent("refinery", cfg, st, madengine, provider="claude")
+    assert d.status == autoapply.STATUS_BLOCKED
+    assert d.critical is True
+    assert "judge" in d.reason
+
+
+def test_force_baseline_agent_blocked(cfg):
+    """mayor has a force_baseline judge cell → blocked from auto-apply."""
+    st = _build_store(cfg, [])
+    d = autoapply.decide_agent("mayor", cfg, st, madengine, provider="claude")
+    assert d.status == autoapply.STATUS_BLOCKED
+    assert d.critical is True
+
+
+# --------------------------------------------------------------------------- #
+# Sweep: dry-run writes nothing
+# --------------------------------------------------------------------------- #
+
+def test_dry_run_writes_nothing(monkeypatch, cfg, city, tmp_path):
+    monkeypatch.setenv("ADVISOR_AGENT_TOML", str(city))
+    recs = _wins("claude::polecat::implement::sonnet", 60) + _wins(
+        "claude::polecat::lookup::sonnet", 60
+    )
+    st = _build_store(cfg, recs)
+    before = city.read_text()
+
+    rep = autoapply.auto_apply(cfg, st, dry_run=True, engine=madengine)
+
+    # polecat would change to sonnet; refinery+mayor blocked; cold ones no-op.
+    pole = next(d for d in rep.decisions if d.agent == "polecat")
+    assert pole.status == autoapply.STATUS_DRYRUN
+    assert pole.chosen_model == "claude-sonnet-4-5"
+    assert {d.agent for d in rep.decisions if d.status == autoapply.STATUS_BLOCKED} == {
+        "refinery",
+        "mayor",
+    }
+    # NOTHING written, no backup.
+    assert city.read_text() == before
+    assert not list(tmp_path.glob("*advisor-bak*"))
+    assert rep.dry_run is True
+
+
+# --------------------------------------------------------------------------- #
+# Sweep: only evidence-strong changes are applied; thin + Critical untouched
+# --------------------------------------------------------------------------- #
+
+def test_apply_only_evidence_strong(monkeypatch, cfg, city, tmp_path):
+    monkeypatch.setenv("ADVISOR_AGENT_TOML", str(city))
+    # Strong on BOTH polecat shapes (→ sonnet). refinery review strong but judge
+    # Critical (→ blocked). Everyone else cold (→ no-op on baseline).
+    recs = (
+        _wins("claude::polecat::implement::sonnet", 60)
+        + _wins("claude::polecat::lookup::sonnet", 60)
+        + _wins("claude::refinery::review::sonnet", 60, channel="review")
+    )
+    st = _build_store(cfg, recs)
+
+    rep = autoapply.auto_apply(cfg, st, dry_run=False, engine=madengine)
+
+    by = {d.agent: d for d in rep.decisions}
+    # Exactly one applied: polecat → sonnet.
+    assert by["polecat"].status == autoapply.STATUS_APPLIED
+    assert by["polecat"].chosen_model == "claude-sonnet-4-5"
+    assert by["polecat"].direction in (None, "set", "down")
+    # Critical / force_baseline agents blocked, never written.
+    assert by["refinery"].status == autoapply.STATUS_BLOCKED
+    assert by["mayor"].status == autoapply.STATUS_BLOCKED
+    # Cold agents: no-op (conservative tier is the baseline, nothing to write).
+    for a in ("boot", "deacon", "witness"):
+        assert by[a].status == autoapply.STATUS_NOOP
+
+    # Only one applied across the whole sweep.
+    assert rep.count(autoapply.STATUS_APPLIED) == 1
+    # The city.toml gained exactly one model line (polecat's), inside its block.
+    text = city.read_text()
+    assert text.count("model = ") == 1
+    assert 'model = "claude-sonnet-4-5"' in text
+    pol_idx = text.index('name = "polecat"')
+    model_idx = text.index('model = "claude-sonnet-4-5"')
+    ref_idx = text.index('name = "refinery"')
+    assert model_idx > pol_idx and model_idx < ref_idx  # inside polecat's block
+
+
+def test_thin_evidence_is_not_downgraded(monkeypatch, cfg, city):
+    """A few wins on one shape must NOT downgrade the agent (gate withholds)."""
+    monkeypatch.setenv("ADVISOR_AGENT_TOML", str(city))
+    # Only 3 sonnet wins on implement; lookup cold. Far below the gate.
+    st = _build_store(cfg, _wins("claude::polecat::implement::sonnet", 3))
+    rep = autoapply.auto_apply(cfg, st, dry_run=False, engine=madengine)
+    pole = next(d for d in rep.decisions if d.agent == "polecat")
+    # Conservative tier stays opus (baseline); reported as a no-op, nothing written.
+    assert pole.chosen_tier == "opus"
+    assert pole.status == autoapply.STATUS_NOOP
+    assert city.read_text().count("model = ") == 0
+
+
+# --------------------------------------------------------------------------- #
+# Real apply: byte-preserving edit + single backup; idempotence
+# --------------------------------------------------------------------------- #
+
+def test_real_apply_is_byte_preserving_and_backs_up(monkeypatch, cfg, tmp_path):
+    """A flat per-agent agent.toml: the routing triple is surgically inserted.
+
+    Applying a tier now sets the full cross-provider routing target — provider +
+    model + run_target — so a Codex tier actually runs on Codex.  The edit stays
+    byte-preserving: the three lines are inserted and the rest of the file is
+    untouched.
+    """
+    flat = (
+        'scope = "rig"\n'
+        'wake_mode = "fresh"\n'
+        "idle_timeout = \"2h\"\n"
+        "max_active_sessions = 5\n"
+    )
+    agent_toml = tmp_path / "agent.toml"
+    agent_toml.write_text(flat, encoding="utf-8")
+    monkeypatch.setenv("ADVISOR_AGENT_TOML", str(agent_toml))
+
+    recs = _wins("claude::polecat::implement::sonnet", 60) + _wins(
+        "claude::polecat::lookup::sonnet", 60
+    )
+    st = _build_store(cfg, recs)
+
+    rep = autoapply.auto_apply(
+        cfg, st, dry_run=False, agents=["polecat"], engine=madengine
+    )
+    d = rep.decisions[0]
+    assert d.status == autoapply.STATUS_APPLIED
+    assert d.backup_path is not None
+
+    updated = agent_toml.read_text()
+    # Surgical insert: original lines byte-for-byte present; the full sonnet
+    # routing triple written exactly once each.
+    assert 'scope = "rig"' in updated
+    assert 'wake_mode = "fresh"' in updated
+    assert "max_active_sessions = 5" in updated
+    assert updated.count("model = ") == 1
+    assert updated.count("provider = ") == 1
+    assert updated.count("run_target = ") == 1
+    assert 'model = "claude-sonnet-4-5"' in updated
+    assert 'provider = "claude"' in updated
+    assert 'run_target = "claude-sonnet"' in updated
+    # The only added content is the routing triple; stripping the three inserted
+    # lines yields the original byte-for-byte.
+    stripped = updated
+    for line in (
+        'provider = "claude"\n',
+        'model = "claude-sonnet-4-5"\n',
+        'run_target = "claude-sonnet"\n',
+    ):
+        stripped = stripped.replace(line, "")
+    assert stripped == flat
+
+    # Backup holds the ORIGINAL content, exactly once.
+    baks = list(tmp_path.glob("*advisor-bak*"))
+    assert len(baks) == 1
+    assert baks[0].read_text() == flat
+
+
+def test_single_backup_per_run_for_shared_file(monkeypatch, cfg, city, tmp_path):
+    """All agents share one city.toml → it is backed up ONCE per run."""
+    monkeypatch.setenv("ADVISOR_AGENT_TOML", str(city))
+    # Make TWO agents apply in one run: polecat→sonnet and witness via a forced
+    # upgrade (hand-set witness to haiku so the safe direction pulls it up).
+    city.write_text(
+        city.read_text().replace(
+            '[[agent]]\nname = "witness"\nscope = "rig"\n',
+            '[[agent]]\nname = "witness"\nmodel = "claude-haiku-4-5"\nscope = "rig"\n',
+        ),
+        encoding="utf-8",
+    )
+    recs = _wins("claude::polecat::implement::sonnet", 60) + _wins(
+        "claude::polecat::lookup::sonnet", 60
+    )
+    st = _build_store(cfg, recs)
+
+    rep = autoapply.auto_apply(cfg, st, dry_run=False, engine=madengine)
+    applied = {d.agent for d in rep.decisions if d.status == autoapply.STATUS_APPLIED}
+    # polecat downgrades to sonnet; witness (haiku, cold) is pulled UP to baseline.
+    assert "polecat" in applied
+    assert "witness" in applied
+    wit = next(d for d in rep.decisions if d.agent == "witness")
+    assert wit.direction == "up" and wit.chosen_tier == "opus"
+    # Despite two writes into the same file, exactly ONE backup exists.
+    assert len(list(tmp_path.glob("*advisor-bak*"))) == 1
+
+
+def test_idempotent_second_run(monkeypatch, cfg, city, tmp_path):
+    monkeypatch.setenv("ADVISOR_AGENT_TOML", str(city))
+    recs = _wins("claude::polecat::implement::sonnet", 60) + _wins(
+        "claude::polecat::lookup::sonnet", 60
+    )
+    st = _build_store(cfg, recs)
+
+    rep1 = autoapply.auto_apply(cfg, st, dry_run=False, engine=madengine)
+    assert rep1.count(autoapply.STATUS_APPLIED) == 1
+    after = city.read_text()
+
+    rep2 = autoapply.auto_apply(cfg, st, dry_run=False, engine=madengine)
+    # Second run: polecat is now a no-op; nothing applied; file unchanged.
+    assert rep2.count(autoapply.STATUS_APPLIED) == 0
+    pole2 = next(d for d in rep2.decisions if d.agent == "polecat")
+    assert pole2.status == autoapply.STATUS_NOOP
+    assert city.read_text() == after
+    # No second backup created.
+    assert len(list(tmp_path.glob("*advisor-bak*"))) == 1
+
+
+# --------------------------------------------------------------------------- #
+# Error isolation: one unresolvable agent doesn't abort the sweep
+# --------------------------------------------------------------------------- #
+
+def test_unresolvable_agent_isolated(monkeypatch, cfg, tmp_path):
+    # city.toml WITHOUT a polecat block and no [agent_defaults] → polecat errors,
+    # but agents that do resolve are still processed.
+    city = tmp_path / "city.toml"
+    city.write_text(_city_toml(agents=("mayor", "refinery")), encoding="utf-8")
+    monkeypatch.setenv("ADVISOR_AGENT_TOML", str(city))
+    recs = _wins("claude::polecat::implement::sonnet", 60) + _wins(
+        "claude::polecat::lookup::sonnet", 60
+    )
+    st = _build_store(cfg, recs)
+
+    rep = autoapply.auto_apply(cfg, st, dry_run=False, engine=madengine)
+    by = {d.agent: d for d in rep.decisions}
+    # polecat can't resolve a config home → error (isolated), not a crash.
+    assert by["polecat"].status == autoapply.STATUS_ERROR
+    assert "config not resolvable" in by["polecat"].reason
+    # refinery still blocked, mayor still blocked — the sweep continued.
+    assert by["refinery"].status == autoapply.STATUS_BLOCKED
+    assert by["mayor"].status == autoapply.STATUS_BLOCKED
+
+
+# --------------------------------------------------------------------------- #
+# CLI surface: auto-apply subcommand (dry-run default, --apply, --json)
+# --------------------------------------------------------------------------- #
+
+def _run_cli(*argv):
+    buf = io.StringIO()
+    rc = cli.main(list(argv), out=buf)
+    return rc, buf.getvalue()
+
+
+def _setup_cli_env(monkeypatch, tmp_path, records):
+    """Write advisor.toml + telemetry + city.toml and point the CLI env at them."""
+    adv = tmp_path / "advisor.toml"
+    adv.write_text(ADVISOR_TOML, encoding="utf-8")
+    teldir = tmp_path / ".beads" / "telemetry"
+    teldir.mkdir(parents=True)
+    with (teldir / "invocations.jsonl").open("w", encoding="utf-8") as fh:
+        for rec in records:
+            fh.write(json.dumps(rec) + "\n")
+    city = tmp_path / "city.toml"
+    city.write_text(_city_toml(), encoding="utf-8")
+    monkeypatch.setenv("ADVISOR_TOML", str(adv))
+    monkeypatch.setenv("ADVISOR_TELEMETRY_DIR", str(teldir))
+    monkeypatch.setenv("ADVISOR_AGENT_TOML", str(city))
+    return city
+
+
+def test_cli_dry_run_by_default(monkeypatch, tmp_path):
+    recs = _wins("claude::polecat::implement::sonnet", 60) + _wins(
+        "claude::polecat::lookup::sonnet", 60
+    )
+    city = _setup_cli_env(monkeypatch, tmp_path, recs)
+
+    rc, text = _run_cli("auto-apply")  # no --apply
+    assert rc == 0 or rc == 1  # 1 only if some agent errored; both are "ran ok"
+    assert "DRY-RUN" in text
+    assert "SUMMARY" in text
+    assert "WOULD" in text  # polecat planned change
+    assert "BLOCKED" in text  # refinery / mayor
+    # Default is dry-run → nothing written.
+    assert city.read_text().count("model = ") == 0
+    assert not list(tmp_path.glob("*advisor-bak*"))
+
+
+def test_cli_apply_writes(monkeypatch, tmp_path):
+    recs = _wins("claude::polecat::implement::sonnet", 60) + _wins(
+        "claude::polecat::lookup::sonnet", 60
+    )
+    city = _setup_cli_env(monkeypatch, tmp_path, recs)
+
+    rc, text = _run_cli("auto-apply", "--apply")
+    assert "APPLY" in text and "APPLIED" in text
+    updated = city.read_text()
+    assert updated.count("model = ") == 1
+    assert 'model = "claude-sonnet-4-5"' in updated
+    assert len(list(tmp_path.glob("*advisor-bak*"))) == 1
+
+
+def test_cli_json_report(monkeypatch, tmp_path):
+    recs = _wins("claude::polecat::implement::sonnet", 60) + _wins(
+        "claude::polecat::lookup::sonnet", 60
+    )
+    _setup_cli_env(monkeypatch, tmp_path, recs)
+
+    rc, text = _run_cli("auto-apply", "--json")
+    obj = json.loads(text)  # valid JSON
+    assert obj["dry_run"] is True
+    assert obj["scope"] == "town"
+    assert "summary" in obj and "decisions" in obj
+    by = {d["agent"]: d for d in obj["decisions"]}
+    assert by["polecat"]["chosen_tier"] == "sonnet"
+    assert by["polecat"]["per_shape"] == {"implement": "sonnet", "lookup": "sonnet"}
+    assert by["refinery"]["status"] == "blocked"
+    assert by["mayor"]["status"] == "blocked"
+
+
+# --------------------------------------------------------------------------- #
+# Cross-provider routing: applying a tier sets provider + model + run_target
+# so a Codex tier actually runs on Codex (not just a renamed model).
+# --------------------------------------------------------------------------- #
+
+# A cross-provider roster (Codex + Claude), cost-ordered: Codex `gpt54` is the
+# CHEAPEST tier and `sonnet` (Claude) is the most-capable baseline (tier*).  With
+# strong gpt54 evidence on every shape, the agent's conservative tier becomes a
+# genuine gate-admitted cross-provider DOWNGRADE to gpt54 — the honest path that
+# proves auto-apply routes the whole Codex triple, not just the model.
+XPROV_TOML = """
+[advisor]
+default_provider = "codex"
+baseline_tier = "sonnet"
+
+[[tier]]
+id = "gpt54"
+provider = "codex"
+model = "gpt-5.4"
+run_target = "codex-gpt54"
+rank = 1
+in_cost = 2.50
+out_cost = 10.00
+
+[[tier]]
+id = "sonnet"
+provider = "claude"
+model = "claude-sonnet-4-5"
+run_target = "claude-sonnet"
+rank = 2
+in_cost = 3.00
+out_cost = 15.00
+
+[[tolerance]]
+name = "Lenient"
+q_tol = 0.10
+multiplier = 1
+
+[[shape]]
+name = "implement"
+tol_class = "Lenient"
+[[shape]]
+name = "lookup"
+tol_class = "Lenient"
+
+[[agent]]
+name = "polecat"
+shapes = ["implement", "lookup"]
+"""
+
+
+def _xprov_cfg():
+    import tomllib
+    return madconfig.from_mapping(tomllib.loads(XPROV_TOML))
+
+
+def _xprov_codex_store(cfg):
+    """A store where polecat has earned gpt54 on BOTH shapes (gate-admitted)."""
+    recs = _wins("codex::polecat::implement::gpt54", 80) + _wins(
+        "codex::polecat::lookup::gpt54", 80
+    )
+    return _build_store(cfg, recs)
+
+
+def test_apply_codex_tier_sets_provider_model_run_target(monkeypatch, tmp_path):
+    """A gate-admitted downgrade to Codex gpt54 writes the FULL routing triple."""
+    cfg = _xprov_cfg()
+    flat = (
+        'scope = "rig"\n'
+        'model = "claude-sonnet-4-5"\n'  # current = the Claude baseline
+        'max_active_sessions = 5\n'
+    )
+    agent_toml = tmp_path / "agent.toml"
+    agent_toml.write_text(flat, encoding="utf-8")
+    monkeypatch.setenv("ADVISOR_AGENT_TOML", str(agent_toml))
+
+    st = _xprov_codex_store(cfg)
+    rep = autoapply.auto_apply(
+        cfg, st, dry_run=False, agents=["polecat"], provider="codex", engine=madengine
+    )
+    d = rep.decisions[0]
+    assert d.status == autoapply.STATUS_APPLIED
+    assert d.chosen_tier == "gpt54"
+
+    updated = agent_toml.read_text()
+    assert 'provider = "codex"' in updated
+    assert 'model = "gpt-5.4"' in updated
+    assert 'run_target = "codex-gpt54"' in updated
+    # Each field written exactly once (replace-or-insert, no dupes).
+    assert updated.count("provider = ") == 1
+    assert updated.count("model = ") == 1
+    assert updated.count("run_target = ") == 1
+    # Surrounding lines untouched (byte-preserving).
+    assert 'scope = "rig"' in updated
+    assert "max_active_sessions = 5" in updated
+    # The old Claude model is gone (replaced in place, not duplicated).
+    assert "claude-sonnet-4-5" not in updated
+
+
+def test_apply_claude_tier_sets_provider_model_run_target(monkeypatch, tmp_path):
+    """A Claude tier write carries provider=claude + model + run_target too."""
+    cfg = _cfg()  # the main ADVISOR_TOML roster (now with run_targets)
+    flat = 'scope = "rig"\nmodel = "claude-haiku-4-5"\n'
+    agent_toml = tmp_path / "agent.toml"
+    agent_toml.write_text(flat, encoding="utf-8")
+    monkeypatch.setenv("ADVISOR_AGENT_TOML", str(agent_toml))
+
+    # polecat strong on BOTH shapes for sonnet → conservative tier sonnet (claude).
+    recs = _wins("claude::polecat::implement::sonnet", 60) + _wins(
+        "claude::polecat::lookup::sonnet", 60
+    )
+    st = _build_store(cfg, recs)
+    rep = autoapply.auto_apply(
+        cfg, st, dry_run=False, agents=["polecat"], engine=madengine
+    )
+    d = rep.decisions[0]
+    assert d.status == autoapply.STATUS_APPLIED
+    assert d.chosen_tier == "sonnet"
+
+    updated = agent_toml.read_text()
+    assert 'provider = "claude"' in updated
+    assert 'model = "claude-sonnet-4-5"' in updated
+    assert 'run_target = "claude-sonnet"' in updated
+    assert updated.count("provider = ") == 1
+    assert updated.count("run_target = ") == 1
+
+
+def test_apply_codex_tier_idempotent_no_dupes(monkeypatch, tmp_path):
+    """Re-applying the same Codex tier is a no-op: no duplicated routing lines."""
+    cfg = _xprov_cfg()
+    agent_toml = tmp_path / "agent.toml"
+    # Start on the Claude baseline so the first run is a real gpt54 downgrade.
+    agent_toml.write_text(
+        'scope = "rig"\nmodel = "claude-sonnet-4-5"\n', encoding="utf-8"
+    )
+    monkeypatch.setenv("ADVISOR_AGENT_TOML", str(agent_toml))
+
+    st = _xprov_codex_store(cfg)
+    rep1 = autoapply.auto_apply(
+        cfg, st, dry_run=False, agents=["polecat"], provider="codex", engine=madengine
+    )
+    assert rep1.decisions[0].status == autoapply.STATUS_APPLIED
+    after = agent_toml.read_text()
+    assert after.count("provider = ") == 1
+    assert after.count("model = ") == 1
+    assert after.count("run_target = ") == 1
+
+    # Second run: chosen model already set → no-op; file byte-identical.
+    rep2 = autoapply.auto_apply(
+        cfg, st, dry_run=False, agents=["polecat"], provider="codex", engine=madengine
+    )
+    assert rep2.decisions[0].status == autoapply.STATUS_NOOP
+    assert agent_toml.read_text() == after  # no dupes, no churn
+
+
+def test_dispatch_metadata_returns_routing_triple():
+    """cli.dispatch_metadata(cfg, tier) → the per-DISPATCH gc.* routing triple."""
+    cfg = _xprov_cfg()
+    assert cli.dispatch_metadata(cfg, "gpt54") == {
+        "gc.provider": "codex",
+        "gc.model": "gpt-5.4",
+        "gc.run_target": "codex-gpt54",
+    }
+    assert cli.dispatch_metadata(cfg, "sonnet") == {
+        "gc.provider": "claude",
+        "gc.model": "claude-sonnet-4-5",
+        "gc.run_target": "claude-sonnet",
+    }
+
+
+def test_cli_rig_scope_label(monkeypatch, tmp_path):
+    recs = _wins("claude::polecat::implement::sonnet", 60) + _wins(
+        "claude::polecat::lookup::sonnet", 60
+    )
+    _setup_cli_env(monkeypatch, tmp_path, recs)
+    rc, text = _run_cli("auto-apply", "--rig", "demo-repo", "--json")
+    obj = json.loads(text)
+    assert obj["scope"] == "rig:demo-repo"

--- a/model-advisor/tests/test_cascade.py
+++ b/model-advisor/tests/test_cascade.py
@@ -1,0 +1,329 @@
+"""Tests for the DAG-propagated effective blast radius (DESIGN §1.3 L3, §7.3).
+
+The deferred-feature contract (V3 build brief, bead bh-1rd):
+
+- **leaf ⇒ flat** — a root that blocks nothing returns ``n_dep_eff == base_n_dep``
+  (the v1 flat-scalar behaviour, recovered exactly);
+- **width monotonicity** — a wider DAG yields a strictly larger ``n_dep_eff`` than
+  a narrower one;
+- **depth monotonicity** — a deeper chain yields a strictly larger ``n_dep_eff``
+  than a shallow one;
+- **decay** — ``decay < 1`` down-weights deeper dependents (so a deep tail counts
+  for less than the same nodes placed shallow);
+- **cycle-safety** — a cyclic graph terminates and counts each node once;
+- **max_depth** — caps how far the walk reaches;
+- **parser tolerance** — ``build_graph_from_dep_json`` parses both a nested tree
+  and a flat ``blocks`` list, and never throws on missing keys;
+- **degradation** — an empty / ``None`` graph or unknown root falls back to base.
+
+The module is a pure function of ``(graph, root)``, so these tests drive it with
+hand-built adjacency maps (no store / config / engine needed).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+# Make the pack root importable when pytest is run from anywhere.
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+
+from modeladvisor import cascade as C  # noqa: E402
+from modeladvisor.cascade import CascadeResult  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+# Leaf / degradation -> flat base_n_dep (DESIGN §8 degradation)                 #
+# --------------------------------------------------------------------------- #
+
+
+def test_leaf_returns_base_n_dep():
+    """A root present in the graph but blocking nothing ⇒ n_dep_eff == base."""
+    graph = {"root": []}
+    res = C.effective_cascade(graph, "root")
+    assert isinstance(res, CascadeResult)
+    assert res.n_dep_eff == 1  # default base_n_dep
+    assert res.depth == 0
+    assert res.n_nodes == 1
+    assert res.loss_terms == {"reachable": 0, "by_depth": {}}
+
+
+def test_leaf_honours_custom_base_n_dep():
+    res = C.effective_cascade({"root": []}, "root", base_n_dep=3)
+    assert res.n_dep_eff == 3
+    assert res.n_nodes == 1
+
+
+def test_empty_and_none_graph_fall_back_to_base():
+    for g in (None, {}):
+        res = C.effective_cascade(g, "root", base_n_dep=2)
+        assert res.n_dep_eff == 2
+        assert res.depth == 0
+        assert res.n_nodes == 1
+
+
+def test_unknown_root_falls_back_to_base():
+    graph = {"a": ["b"], "b": []}
+    res = C.effective_cascade(graph, "does-not-exist")
+    assert res.n_dep_eff == 1
+    assert res.n_nodes == 1
+    assert res.loss_terms["reachable"] == 0
+
+
+# --------------------------------------------------------------------------- #
+# Width & depth monotonicity (the core property fed into the L3 cascade term)   #
+# --------------------------------------------------------------------------- #
+
+
+def test_wider_dag_has_strictly_larger_n_dep_eff():
+    """An ADR blocking 3 dependents outweighs one blocking 1 (both depth 1)."""
+    narrow = {"adr": ["x"], "x": []}
+    wide = {"adr": ["x", "y", "z"], "x": [], "y": [], "z": []}
+    n = C.effective_cascade(narrow, "adr")
+    w = C.effective_cascade(wide, "adr")
+    assert w.n_dep_eff > n.n_dep_eff
+    # decay=1.0 default => raw reachable count + base floor.
+    assert n.n_dep_eff == 1 + 1
+    assert w.n_dep_eff == 1 + 3
+
+
+def test_deeper_chain_has_strictly_larger_n_dep_eff():
+    """A chain root->a->b->c outweighs a shallow root->a (monotone in depth)."""
+    shallow = {"root": ["a"], "a": []}
+    deep = {"root": ["a"], "a": ["b"], "b": ["c"], "c": []}
+    s = C.effective_cascade(shallow, "root")
+    dd = C.effective_cascade(deep, "root")
+    assert dd.n_dep_eff > s.n_dep_eff
+    assert dd.depth == 3 and s.depth == 1
+    assert dd.n_nodes == 4 and s.n_nodes == 2
+
+
+def test_layered_blast_radius_counts_full_transitive_closure():
+    """ADR blocks 3 ADRs that each block 4 builders => 3 + 12 = 15 reachable."""
+    graph: dict[str, list[str]] = {"root": ["a", "b", "c"]}
+    for mid in ("a", "b", "c"):
+        kids = [f"{mid}{i}" for i in range(4)]
+        graph[mid] = kids
+        for k in kids:
+            graph[k] = []
+    res = C.effective_cascade(graph, "root")  # decay=1.0 default
+    assert res.loss_terms["reachable"] == 15
+    assert res.loss_terms["by_depth"] == {1: 3, 2: 12}
+    assert res.n_dep_eff == 1 + 15  # base floor + raw reachable
+    assert res.depth == 2
+    assert res.n_nodes == 16  # 15 dependents + the root
+
+
+# --------------------------------------------------------------------------- #
+# Decay: nearer dependents weighted more (DESIGN §1.3 L3 propagation)           #
+# --------------------------------------------------------------------------- #
+
+
+def test_decay_downweights_deep_nodes():
+    """The same 3-node chain weighs less under decay<1 than under decay==1."""
+    chain = {"root": ["a"], "a": ["b"], "b": ["c"], "c": []}
+    full = C.effective_cascade(chain, "root", decay=1.0)
+    decayed = C.effective_cascade(chain, "root", decay=0.5)
+    assert full.n_dep_eff == 1 + 3  # 1 + (1 + 1 + 1)
+    # 1 + (0.5^1 + 0.5^2 + 0.5^3) = 1 + 0.875
+    assert decayed.n_dep_eff == pytest.approx(1 + (0.5 + 0.25 + 0.125))
+    assert decayed.n_dep_eff < full.n_dep_eff
+
+
+def test_decay_makes_shallow_outweigh_deep_for_equal_node_counts():
+    """Two dependents at depth 1 beat two stacked at depths 1+2 under decay<1."""
+    shallow = {"root": ["a", "b"], "a": [], "b": []}  # both at depth 1
+    deep = {"root": ["a"], "a": ["b"], "b": []}        # depths 1 and 2
+    s = C.effective_cascade(shallow, "root", decay=0.5)
+    d = C.effective_cascade(deep, "root", decay=0.5)
+    # shallow: 1 + (0.5 + 0.5) = 2.0 ; deep: 1 + (0.5 + 0.25) = 1.75
+    assert s.n_dep_eff > d.n_dep_eff
+
+
+def test_decay_clamped_into_unit_interval():
+    """decay<=0 is clamped (still counts) and decay>1 collapses to raw-count (==1)."""
+    chain = {"root": ["a"], "a": ["b"], "b": []}
+    # decay > 1 must not up-weight the far tail -> behaves like decay==1.0.
+    over = C.effective_cascade(chain, "root", decay=2.0)
+    one = C.effective_cascade(chain, "root", decay=1.0)
+    assert over.n_dep_eff == one.n_dep_eff == 1 + 2
+    # decay <= 0 is nudged to ~0 (deep nodes contribute ~nothing) but never crashes.
+    zero = C.effective_cascade(chain, "root", decay=0.0)
+    assert zero.n_dep_eff == pytest.approx(1.0, abs=1e-6)
+
+
+# --------------------------------------------------------------------------- #
+# Cycle-safety & max_depth (robustness of the traversal)                       #
+# --------------------------------------------------------------------------- #
+
+
+def test_cycle_terminates_and_counts_each_node_once():
+    """A graph with a cycle terminates; each distinct node is counted once."""
+    graph = {"a": ["b"], "b": ["c"], "c": ["a"]}  # a->b->c->a (cycle)
+    res = C.effective_cascade(graph, "a")
+    # From a: reachable = {b, c} (a is the root, not a dependent of itself).
+    assert res.loss_terms["reachable"] == 2
+    assert res.n_nodes == 3
+    assert res.n_dep_eff == 1 + 2
+    # by_depth counts b at 1, c at 2 (shallowest path); the back-edge c->a is dropped.
+    assert res.loss_terms["by_depth"] == {1: 1, 2: 1}
+
+
+def test_self_loop_is_harmless():
+    graph = {"root": ["root", "a"], "a": []}
+    res = C.effective_cascade(graph, "root")
+    assert res.loss_terms["reachable"] == 1  # only 'a'; the self-edge is ignored
+    assert res.n_dep_eff == 1 + 1
+
+
+def test_reconvergent_dag_counts_shared_child_once():
+    """A diamond root->{a,b}->c counts the shared sink c exactly once."""
+    graph = {"root": ["a", "b"], "a": ["c"], "b": ["c"], "c": []}
+    res = C.effective_cascade(graph, "root")
+    assert res.loss_terms["reachable"] == 3  # a, b, c (c shared, once)
+    # c is reached at depth 2 via the shortest path; counted a single time.
+    assert res.loss_terms["by_depth"] == {1: 2, 2: 1}
+    assert res.n_dep_eff == 1 + 3
+
+
+def test_max_depth_caps_traversal():
+    """max_depth bounds how deep the walk reaches (deeper dependents are pruned)."""
+    chain = {"root": ["a"], "a": ["b"], "b": ["c"], "c": ["d"], "d": []}
+    capped = C.effective_cascade(chain, "root", max_depth=2)
+    full = C.effective_cascade(chain, "root", max_depth=6)
+    assert capped.depth == 2
+    assert capped.loss_terms["reachable"] == 2  # a (d1), b (d2); c, d pruned
+    assert full.loss_terms["reachable"] == 4
+    assert capped.n_dep_eff < full.n_dep_eff
+
+
+def test_max_depth_zero_degrades_to_base():
+    """max_depth<1 means even direct children aren't counted -> flat base."""
+    graph = {"root": ["a", "b"], "a": [], "b": []}
+    res = C.effective_cascade(graph, "root", max_depth=0)
+    assert res.n_dep_eff == 1
+    assert res.n_nodes == 1
+
+
+# --------------------------------------------------------------------------- #
+# Determinism & audit completeness (DESIGN §1.4 property 3 spirit)             #
+# --------------------------------------------------------------------------- #
+
+
+def test_deterministic_repeated_calls():
+    graph = {"root": ["a", "b"], "a": ["c"], "b": ["c"], "c": []}
+    r1 = C.effective_cascade(graph, "root", decay=0.7)
+    r2 = C.effective_cascade(graph, "root", decay=0.7)
+    assert r1 == r2
+
+
+def test_result_has_rationale_and_loss_terms():
+    graph = {"root": ["a", "b"], "a": [], "b": []}
+    res = C.effective_cascade(graph, "root")
+    assert isinstance(res.rationale, str) and res.rationale
+    assert "reachable" in res.loss_terms and "by_depth" in res.loss_terms
+    assert "root" in res.rationale
+
+
+# --------------------------------------------------------------------------- #
+# build_graph_from_dep_json — nested tree shape                                 #
+# --------------------------------------------------------------------------- #
+
+
+def test_parse_nested_tree_with_dependents_key():
+    """A nested {id, dependents:[...]} tree becomes the right adjacency map."""
+    tree = {
+        "id": "root",
+        "dependents": [
+            {"id": "a", "dependents": [{"id": "c", "dependents": []}]},
+            {"id": "b", "dependents": []},
+        ],
+    }
+    graph = C.build_graph_from_dep_json(tree)
+    assert graph["root"] == ["a", "b"]
+    assert graph["a"] == ["c"]
+    assert graph["b"] == []
+    assert graph["c"] == []
+    # And it drives effective_cascade end-to-end.
+    res = C.effective_cascade(graph, "root")
+    assert res.loss_terms["reachable"] == 3  # a, b, c
+
+
+def test_parse_nested_tree_with_children_key_and_string_leaves():
+    """Alternate 'children' key and plain-string leaf children are both handled."""
+    tree = {
+        "bead_id": "root",
+        "children": [
+            {"bead_id": "a", "children": ["leaf1", "leaf2"]},
+            "b",  # a bare string child of root
+        ],
+    }
+    graph = C.build_graph_from_dep_json(tree)
+    assert set(graph["root"]) == {"a", "b"}
+    assert graph["a"] == ["leaf1", "leaf2"]
+    assert graph["leaf1"] == [] and graph["leaf2"] == [] and graph["b"] == []
+
+
+# --------------------------------------------------------------------------- #
+# build_graph_from_dep_json — flat-list shape                                   #
+# --------------------------------------------------------------------------- #
+
+
+def test_parse_flat_list_with_blocks_key():
+    """A flat [{id, blocks:[...]}] list becomes the right adjacency map."""
+    flat = [
+        {"id": "root", "blocks": ["a", "b"]},
+        {"id": "a", "blocks": ["c"]},
+        {"id": "b", "blocks": []},
+        {"id": "c", "blocks": []},
+    ]
+    graph = C.build_graph_from_dep_json(flat)
+    assert graph["root"] == ["a", "b"]
+    assert graph["a"] == ["c"]
+    res = C.effective_cascade(graph, "root")
+    assert res.loss_terms["reachable"] == 3
+    assert res.loss_terms["by_depth"] == {1: 2, 2: 1}
+
+
+def test_parse_is_total_and_skips_bad_entries():
+    """Missing keys / non-dict members / no-id nodes never throw; they're skipped."""
+    messy = [
+        {"id": "root", "blocks": ["a"]},
+        {"blocks": ["orphan"]},        # no id -> skipped as a source
+        "not-a-dict",                  # scalar member -> skipped
+        {"id": "a"},                   # no edge key -> leaf
+        {"id": "b", "blocks": [42, None, "c"]},  # non-str edges skipped, 'c' kept
+    ]
+    graph = C.build_graph_from_dep_json(messy)  # must not raise
+    assert graph["root"] == ["a"]
+    assert graph["a"] == []
+    assert graph["b"] == ["c"]
+    assert "orphan" not in graph  # came only from a source with no id
+    # None input is tolerated too.
+    assert C.build_graph_from_dep_json(None) == {}
+
+
+def test_parse_dedupes_edges_per_source():
+    """Repeated edges from one source are de-duplicated."""
+    flat = [{"id": "root", "blocks": ["a", "a", "b"]}]
+    graph = C.build_graph_from_dep_json(flat)
+    assert graph["root"] == ["a", "b"]
+
+
+def test_parse_cyclic_source_does_not_recurse_forever():
+    """A nested source that references a node already being expanded terminates."""
+    # 'a' nests 'b', and 'b' nests 'a' again (cyclic source data).
+    tree = {
+        "id": "a",
+        "children": [{"id": "b", "children": [{"id": "a", "children": []}]}],
+    }
+    graph = C.build_graph_from_dep_json(tree)  # must terminate
+    assert "a" in graph and "b" in graph
+    assert "b" in graph["a"]
+    # effective_cascade is cycle-safe over whatever edges resulted.
+    res = C.effective_cascade(graph, "a")
+    assert res.n_nodes >= 2

--- a/model-advisor/tests/test_changepoint.py
+++ b/model-advisor/tests/test_changepoint.py
@@ -1,0 +1,308 @@
+"""Tests for change-point detection of upstream model drift (DESIGN §7.3).
+
+The deferred-feature contract (V3 build brief, bead bh-9if) — the static §7.4
+safety hatch made adaptive:
+
+- **no false reset** — a stationary, noisy quality stream (~constant 0.9) yields
+  **no** change-point, so a healthy cell is never needlessly reset (the KEY
+  correctness property; a false reset would throw away good evidence);
+- **detects a real drop** — a stream whose mean falls ~0.9→~0.5 partway through
+  yields a change-point flagged *near* the true shift (the drift / silent-
+  deprecation case);
+- **direction-aware** — ``direction='down'`` ignores an UP-shift; ``'up'`` /
+  ``'both'`` catch it;
+- **re-weighting** — :func:`recency_weights` drives pre-change observations toward
+  zero and keeps post-change ≈ 1 (so the posterior re-learns the new regime); no
+  change-point ⇒ all weights ≈ 1.0;
+- **streaming == batch** — the stateful :class:`PageHinkley` reproduces the batch
+  :func:`detect_changepoints` flag indices exactly;
+- **determinism** — all stochastic streams are built from a *seeded*
+  :class:`random.Random`, so every assertion is reproducible.
+
+The detector takes a raw list of quality observations, so these tests drive it
+directly (no store / config) to isolate the Page-Hinkley machine and the
+re-weighting from the rest of CC-TS.
+"""
+
+from __future__ import annotations
+
+import os
+import random
+import statistics
+import sys
+
+import pytest
+
+# Make the pack root importable when pytest is run from anywhere.
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+
+from modeladvisor import changepoint as CP  # noqa: E402
+
+# Default Bernoulli-tuned knobs (the module defaults; named here for clarity).
+DELTA = 0.15
+LAMBDA = 4.0
+
+
+# --------------------------------------------------------------------------- #
+# Stream builders (all seeded -> deterministic)                                #
+# --------------------------------------------------------------------------- #
+
+
+def _stationary(p: float, n: int, seed: int) -> list[float]:
+    """A seeded Bernoulli(p) quality stream of length ``n`` (constant mean p)."""
+    rng = random.Random(seed)
+    return [1.0 if rng.random() < p else 0.0 for _ in range(n)]
+
+
+def _shift(p1: float, p2: float, n1: int, n2: int, seed: int) -> list[float]:
+    """A seeded stream: Bernoulli(p1) for ``n1`` then Bernoulli(p2) for ``n2``."""
+    rng = random.Random(seed)
+    head = [1.0 if rng.random() < p1 else 0.0 for _ in range(n1)]
+    tail = [1.0 if rng.random() < p2 else 0.0 for _ in range(n2)]
+    return head + tail
+
+
+# --------------------------------------------------------------------------- #
+# No false reset on a stationary stream (the KEY property, DESIGN §7.3)         #
+# --------------------------------------------------------------------------- #
+
+
+def test_stationary_stream_no_changepoint():
+    """A noisy-but-constant ~0.9 stream must NOT flag a change (no false reset)."""
+    for seed in range(40):
+        stream = _stationary(0.9, 150, seed)
+        cps = CP.detect_changepoints(stream)
+        assert cps == [], f"false reset on stationary stream (seed {seed}): {cps}"
+
+
+def test_stationary_streams_across_means_rarely_false_fire():
+    """Across p in {0.2, 0.5, 0.9} the stationary false-reset rate stays very low.
+
+    p=0.5 is the maximum-Bernoulli-variance worst case; the Bernoulli-tuned
+    ``delta`` must still keep it near zero or a healthy cell would churn.
+    """
+    for p in (0.2, 0.5, 0.9):
+        fired = sum(
+            1 for seed in range(60) if CP.detect_changepoints(_stationary(p, 150, seed))
+        )
+        assert fired <= 6, f"too many false resets at p={p}: {fired}/60"
+
+
+def test_perfectly_constant_stream_never_fires():
+    """A degenerate all-1.0 (and all-0.0) stream has zero variance -> no flag."""
+    assert CP.detect_changepoints([1.0] * 80) == []
+    assert CP.detect_changepoints([0.0] * 80) == []
+
+
+# --------------------------------------------------------------------------- #
+# Detects a genuine drop near the true shift (drift / deprecation)             #
+# --------------------------------------------------------------------------- #
+
+
+def test_downward_shift_detected_near_truth():
+    """A ~0.9->~0.5 drop at index 60 is flagged, shortly AFTER the true shift."""
+    detected = 0
+    first_idxs: list[int] = []
+    for seed in range(40):
+        stream = _shift(0.9, 0.5, 60, 60, 1000 + seed)
+        cps = CP.detect_changepoints(stream)
+        if cps:
+            detected += 1
+            first_idxs.append(cps[0])
+            # A Page-Hinkley flag necessarily trails the change (it needs to
+            # accumulate evidence), and must land within the post-shift segment.
+            assert cps[0] >= 60, f"flag {cps[0]} precedes the true shift (seed {seed})"
+            assert cps[0] < 120
+    # The drop is large and sustained -> detected on (almost) every seed.
+    assert detected >= 38, f"missed the drop too often: {detected}/40"
+    # ... and the typical detection lands within ~25 obs of the true shift.
+    assert statistics.median(first_idxs) < 90
+
+
+def test_harsh_deprecation_detected_fast():
+    """A severe ~0.95->~0.2 collapse is caught quickly on every seed."""
+    for seed in range(30):
+        stream = _shift(0.95, 0.2, 50, 50, 5000 + seed)
+        cps = CP.detect_changepoints(stream)
+        assert cps, f"missed a harsh deprecation (seed {seed})"
+        assert cps[0] >= 50
+        # Severe drop -> flagged within ~20 observations of the shift.
+        assert cps[0] < 70
+
+
+# --------------------------------------------------------------------------- #
+# Direction awareness (DESIGN §7.3: down=drift, up=recovery)                    #
+# --------------------------------------------------------------------------- #
+
+
+def test_direction_down_ignores_upshift():
+    """``direction='down'`` must not flag a quality RISE (0.5 -> 0.9)."""
+    fired = 0
+    for seed in range(40):
+        stream = _shift(0.5, 0.9, 60, 60, 3000 + seed)
+        if CP.detect_changepoints(stream, direction="down"):
+            fired += 1
+    # The down-watcher should essentially never trip on a clean up-shift.
+    assert fired <= 3, f"down-detector fired on an up-shift {fired}/40 times"
+
+
+def test_direction_up_detects_upshift():
+    """``direction='up'`` flags the rise the down-detector ignores."""
+    detected = 0
+    for seed in range(40):
+        stream = _shift(0.5, 0.9, 60, 60, 3000 + seed)
+        cps = CP.detect_changepoints(stream, direction="up")
+        if cps:
+            detected += 1
+            assert cps[0] >= 60
+    # The up-watcher is slightly less eager than the down-watcher at these knobs
+    # but still catches the clean rise the large majority of the time.
+    assert detected >= 34, f"up-detector missed the rise: {detected}/40"
+
+
+def test_direction_both_catches_drop_and_rise():
+    """``direction='both'`` flags either a drop or a rise."""
+    drop = _shift(0.9, 0.5, 60, 60, 1234)
+    rise = _shift(0.5, 0.9, 60, 60, 4321)
+    assert CP.detect_changepoints(drop, direction="both")
+    assert CP.detect_changepoints(rise, direction="both")
+
+
+def test_invalid_direction_rejected():
+    with pytest.raises(ValueError):
+        CP.detect_changepoints([0.5, 0.5], direction="sideways")
+    with pytest.raises(ValueError):
+        CP.PageHinkley(direction="north")
+
+
+# --------------------------------------------------------------------------- #
+# Streaming detector matches the batch function (DESIGN §7.3)                   #
+# --------------------------------------------------------------------------- #
+
+
+def test_streaming_matches_batch():
+    """Feeding the stream through PageHinkley.update reproduces the batch indices."""
+    for seed in range(25):
+        stream = _shift(0.9, 0.45, 50, 70, 7000 + seed)
+        batch = CP.detect_changepoints(stream)
+        ph = CP.PageHinkley()  # same defaults as detect_changepoints
+        streamed = [i for i, x in enumerate(stream) if ph.update(x)]
+        assert streamed == batch, f"streaming != batch (seed {seed})"
+
+
+def test_streaming_reset_clears_state():
+    """``reset()`` returns the detector to its pristine, no-evidence state."""
+    ph = CP.PageHinkley()
+    for x in _shift(0.9, 0.3, 40, 40, 9):
+        ph.update(x)
+    ph.reset()
+    assert ph.n == 0
+    assert ph._m_down == 0.0 and ph._M_down == 0.0
+    assert ph._m_up == 0.0 and ph._m_up_min == 0.0
+    # A fresh stationary stream after reset must not immediately fire.
+    assert not any(ph.update(x) for x in _stationary(0.9, 60, 3))
+
+
+def test_detector_resets_after_flag_so_second_shift_is_found():
+    """Two successive drops in one stream are each flagged (reset-on-flag)."""
+    # 0.95 (40) -> 0.5 (40) -> 0.1 (40): two distinct downward regime changes.
+    rng = random.Random(77)
+
+    def seg(p: float, k: int) -> list[float]:
+        return [1.0 if rng.random() < p else 0.0 for _ in range(k)]
+
+    stream = seg(0.95, 40) + seg(0.5, 40) + seg(0.1, 40)
+    cps = CP.detect_changepoints(stream)
+    assert len(cps) >= 2, f"second shift masked (only {cps})"
+    # One flag in each post-shift segment (after 40, and after 80).
+    assert any(40 <= c < 80 for c in cps)
+    assert any(80 <= c < 120 for c in cps)
+
+
+# --------------------------------------------------------------------------- #
+# Recency re-weighting (DESIGN §7.3)                                            #
+# --------------------------------------------------------------------------- #
+
+
+def test_recency_weights_downweight_pre_change_and_keep_post():
+    """Pre-change indices are driven small; post-change indices stay exactly 1.0."""
+    stream = _shift(0.9, 0.5, 60, 60, 1011)
+    cps = CP.detect_changepoints(stream)
+    assert cps  # this seed detects the drop (see test above)
+    c_star = max(cps)
+    w = CP.recency_weights(len(stream), cps)
+
+    assert len(w) == len(stream)
+    assert all(0.0 <= x <= 1.0 for x in w)
+    # Post-change: full strength, flat (the regime to re-learn is not discounted).
+    assert all(x == 1.0 for x in w[c_star:])
+    # Pre-change: substantially down-weighted on average...
+    assert statistics.mean(w[:c_star]) < 0.5
+    # ... and monotonically decaying the further back you go (older => smaller).
+    pre = w[:c_star]
+    assert all(pre[i] <= pre[i + 1] for i in range(len(pre) - 1))
+    # The oldest observation is essentially forgotten.
+    assert pre[0] < 0.05
+
+
+def test_recency_weights_no_changepoint_all_ones():
+    """With no change-point the default is inert: every weight is 1.0.
+
+    A healthy, un-shifted cell must keep all its evidence at full strength — the
+    feature never silently discounts a stream that hasn't drifted, even with the
+    default ``decay < 1`` (which governs only the pre-shift falloff).
+    """
+    assert CP.recency_weights(50, []) == [1.0] * 50
+    # Even with an aggressive decay, no change-point => still all 1.0.
+    assert CP.recency_weights(20, [], decay=0.5) == [1.0] * 20
+
+
+def test_recency_weights_hard_cut_when_decay_one():
+    """``decay == 1`` degenerates to a hard 0/1 cut at the change-point."""
+    w = CP.recency_weights(6, [3], decay=1.0)
+    assert w == [0.0, 0.0, 0.0, 1.0, 1.0, 1.0]
+
+
+def test_recency_weights_age_decay_only_mode():
+    """``post_change_boost=False`` gives pure uniform age-decay (rule 3).
+
+    The reset is skipped; decay is applied stream-wide (newest == 1.0) and the
+    past is *never* zeroed out, even though a change-point was supplied.
+    """
+    w_no_boost = CP.recency_weights(4, [2], decay=0.5, post_change_boost=False)
+    assert w_no_boost == [0.125, 0.25, 0.5, 1.0]
+    assert all(x > 0.0 for x in w_no_boost)  # nothing hard-cut
+    # decay == 1 in age-decay mode -> the identity.
+    assert CP.recency_weights(4, [2], decay=1.0, post_change_boost=False) == [1.0] * 4
+
+
+def test_recency_weights_validation_and_empty():
+    """``decay`` must be in (0, 1]; ``n <= 0`` yields an empty vector."""
+    assert CP.recency_weights(0, []) == []
+    assert CP.recency_weights(-3, [1]) == []
+    for bad_decay in (0.0, -0.1, 1.5):
+        with pytest.raises(ValueError):
+            CP.recency_weights(5, [1], decay=bad_decay)
+
+
+# --------------------------------------------------------------------------- #
+# PageHinkley parameter validation                                             #
+# --------------------------------------------------------------------------- #
+
+
+def test_pagehinkley_param_validation():
+    with pytest.raises(ValueError):
+        CP.PageHinkley(delta=-0.01)
+    with pytest.raises(ValueError):
+        CP.PageHinkley(lambda_=0.0)
+    # Valid construction does not raise and starts empty.
+    ph = CP.PageHinkley(delta=0.1, lambda_=3.0, direction="both")
+    assert ph.n == 0
+
+
+def test_short_streams_never_flag():
+    """Empty / single-element streams cannot produce a change-point."""
+    assert CP.detect_changepoints([]) == []
+    assert CP.detect_changepoints([0.9]) == []

--- a/model-advisor/tests/test_cli.py
+++ b/model-advisor/tests/test_cli.py
@@ -1,0 +1,776 @@
+"""Tests for the model-advisor CLI surfaces (advise / inspect / apply).
+
+These tests own the *CLI* contract only; the engine/store/config are a sibling
+bead.  To stay runnable before that bead lands (and to keep the CLI assertions
+hermetic regardless), we:
+
+  * load ``modeladvisor/cli.py`` as a **standalone module** via importlib, so the
+    package ``__init__`` re-exports (which eagerly import the not-yet-present
+    engine/store) never block these tests; and
+  * inject a tiny fake engine + state.  If the real ``modeladvisor.engine`` is
+    importable we still prefer it for a smoke check, but the behavioural
+    assertions drive the fake so they are deterministic and self-contained.
+
+Critically, the ``apply`` tests NEVER touch live ``/Users/jayse/Code`` config:
+they operate on TEMP copies of an ``agent.toml`` / ``city.toml`` created under
+``tmp_path`` and point the resolver at them via ``$ADVISOR_AGENT_TOML``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+PACK_DIR = Path(__file__).resolve().parents[1]
+CLI_PATH = PACK_DIR / "modeladvisor" / "cli.py"
+
+
+def _load_cli_module():
+    """Load cli.py standalone, bypassing the package __init__ re-exports."""
+    spec = importlib.util.spec_from_file_location("mad_cli_under_test", CLI_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["mad_cli_under_test"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+cli = _load_cli_module()
+
+
+# --------------------------------------------------------------------------- #
+# Fakes implementing the shared engine/state contract
+# --------------------------------------------------------------------------- #
+
+def _fake_reasons(rec_tier: str):
+    """A representative `reasons` audit object (DESIGN §1.4 / §6)."""
+    return {
+        "candidates": [
+            {"tier_id": "haiku", "q_lo": 0.41, "exp_loss": 0.004,
+             "cost_diff": -0.0142},
+            {"tier_id": "sonnet", "q_lo": 0.82, "exp_loss": -0.011,
+             "cost_diff": -0.0114},
+            {"tier_id": "opus", "q_lo": 0.71, "exp_loss": 0.0,
+             "cost_diff": 0.0},
+        ],
+        "eval_flag": False,
+        "baseline_tier": "opus",
+        "recommended": rec_tier,
+    }
+
+
+class FakeEngine:
+    """Stands in for ``modeladvisor.engine`` under the shared contract."""
+
+    def __init__(self, *, model="claude-sonnet-4-5", tier="sonnet"):
+        self.model = model
+        self.tier = tier
+
+    def recommend(self, agent, shape, cfg, store, *, provider=None, **kw):
+        return {
+            "tier_id": self.tier,
+            "model": self.model,
+            "provider": provider or "claude",
+            "rationale": (f"{self.tier}: LCB q_lo=0.82 >= baseline mean 0.80 "
+                          "- 0.05 tol; cheapest admitted tier"),
+            "cost_delta": -0.0114,
+            "reasons": _fake_reasons(self.tier),
+        }
+
+    def inspect(self, agent, shape, cfg, store, *, provider=None, **kw):
+        return {
+            "baseline_tier": "opus",
+            "tiers": [
+                {"tier_id": "haiku", "mean": 0.55, "q_lo": 0.41, "n": 3,
+                 "drop_ci": [0.06, 0.31], "admit": False},
+                {"tier_id": "sonnet", "mean": 0.84, "q_lo": 0.70, "n": 12,
+                 "drop_ci": [-0.02, 0.14], "admit": True},
+                {"tier_id": "opus", "mean": 0.80, "q_lo": 0.62, "n": 20,
+                 "drop_ci": [0.0, 0.0], "admit": None},
+            ],
+            "widest_gating_cell": {
+                "cell_key": "claude::polecat::implement::sonnet",
+                "tier_id": "sonnet",
+                "ci_half_width": 0.14,
+            },
+        }
+
+
+class _FakeCfg:
+    provider = "claude"
+
+    def default_shape(self, agent):
+        return "implement"
+
+
+def _install_fake(monkeypatch, engine=None):
+    """Wire a fake engine + state into the standalone cli module."""
+    eng = engine or FakeEngine()
+    monkeypatch.setattr(cli, "ENGINE", eng, raising=False)
+    monkeypatch.setattr(cli, "_load_engine", lambda: eng, raising=False)
+    monkeypatch.setattr(
+        cli, "build_state",
+        lambda **kw: cli.State(cfg=_FakeCfg(), store=object(), provider="claude"),
+        raising=False,
+    )
+    return eng
+
+
+def _run(*argv):
+    """Invoke cli.main with captured stdout; return (rc, text)."""
+    buf = io.StringIO()
+    rc = cli.main(list(argv), out=buf)
+    return rc, buf.getvalue()
+
+
+# --------------------------------------------------------------------------- #
+# advise
+# --------------------------------------------------------------------------- #
+
+def test_advise_text_is_wellformed(monkeypatch):
+    _install_fake(monkeypatch)
+    rc, text = _run("advise", "polecat", "implement")
+    assert rc == 0
+    # recommended tier + model + a rationale + per-tier cost differential
+    assert "recommend: sonnet" in text
+    assert "claude-sonnet-4-5" in text
+    assert "rationale:" in text
+    assert "cost differential" in text
+    # cost diffs for each roster tier appear, with a sign + dollar
+    assert "haiku" in text and "sonnet" in text and "opus" in text
+    assert "-$0.0114" in text  # recommended tier's diff vs baseline
+    assert "<- recommended" in text
+
+
+def test_advise_json_emits_reasons(monkeypatch):
+    _install_fake(monkeypatch)
+    rc, text = _run("advise", "polecat", "implement", "--json")
+    assert rc == 0
+    obj = json.loads(text)
+    assert obj["tier_id"] == "sonnet"
+    assert obj["model"] == "claude-sonnet-4-5"
+    # the audit surface: the structured reasons object, verbatim
+    assert "reasons" in obj
+    assert obj["reasons"]["candidates"][1]["tier_id"] == "sonnet"
+    assert obj["reasons"]["candidates"][1]["q_lo"] == 0.82
+    assert obj["reasons"]["eval_flag"] is False
+
+
+# --------------------------------------------------------------------------- #
+# inspect
+# --------------------------------------------------------------------------- #
+
+def test_inspect_text_shows_posteriors_and_widest_cell(monkeypatch):
+    _install_fake(monkeypatch)
+    rc, text = _run("inspect", "polecat", "implement")
+    assert rc == 0
+    assert "baseline tier*: opus" in text
+    # per-tier posterior: mean + q_lo + quality-drop CI columns
+    assert "mean" in text and "q_lo" in text and "quality-drop 95% CI" in text
+    assert "[0.060, 0.310]" in text  # haiku drop CI rendered
+    assert "admit" in text and "reject" in text  # gate decisions shown
+    # the next-eval pointer names the widest gating cell
+    assert "next eval" in text
+    assert "claude::polecat::implement::sonnet" in text
+    assert "0.140" in text  # CI half-width
+
+
+def test_inspect_json(monkeypatch):
+    _install_fake(monkeypatch)
+    rc, text = _run("inspect", "polecat", "implement", "--json")
+    assert rc == 0
+    obj = json.loads(text)
+    assert obj["baseline_tier"] == "opus"
+    assert len(obj["tiers"]) == 3
+    assert obj["widest_gating_cell"]["tier_id"] == "sonnet"
+
+
+# --------------------------------------------------------------------------- #
+# apply — dry-run computes a change but writes nothing
+# --------------------------------------------------------------------------- #
+
+FLAT_AGENT_TOML = (
+    "scope = \"rig\"\n"
+    "wake_mode = \"fresh\"\n"
+    "idle_timeout = \"2h\"\n"
+    "max_active_sessions = 5\n"
+)
+
+CITY_TOML_WITH_AGENT_BLOCK = (
+    "[workspace]\n"
+    "provider = \"claude\"\n"
+    "\n"
+    "[agent_defaults]\n"
+    "default_sling_formula = \"mol-pack-default\"\n"
+    "\n"
+    "[[agent]]\n"
+    "name = \"mayor\"\n"
+    "scope = \"city\"\n"
+    "\n"
+    "[[agent]]\n"
+    "name = \"polecat\"\n"
+    "scope = \"rig\"\n"
+    "max_active_sessions = 5\n"
+)
+
+
+def _write(tmp_path: Path, name: str, content: str) -> Path:
+    p = tmp_path / name
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+def test_apply_dry_run_computes_without_writing(monkeypatch, tmp_path):
+    _install_fake(monkeypatch)
+    agent_toml = _write(tmp_path, "agent.toml", FLAT_AGENT_TOML)
+    before = agent_toml.read_text()
+    monkeypatch.setenv("ADVISOR_AGENT_TOML", str(agent_toml))
+
+    rc, text = _run("apply", "polecat", "--shape", "implement", "--dry-run")
+    assert rc == 0
+    assert "DRY-RUN" in text
+    assert "claude-sonnet-4-5" in text
+    assert "recommended tier: sonnet" in text
+    # nothing written, no backup created
+    assert agent_toml.read_text() == before
+    assert not list(tmp_path.glob("*advisor-bak*"))
+
+
+# --------------------------------------------------------------------------- #
+# apply — writes the model field into a TEMP flat agent.toml and backs it up
+# --------------------------------------------------------------------------- #
+
+def test_apply_writes_flat_agent_toml_and_backs_up(monkeypatch, tmp_path):
+    _install_fake(monkeypatch)
+    agent_toml = _write(tmp_path, "agent.toml", FLAT_AGENT_TOML)
+    monkeypatch.setenv("ADVISOR_AGENT_TOML", str(agent_toml))
+
+    rc, text = _run("apply", "polecat", "--shape", "implement")
+    assert rc == 0
+    assert "applied:" in text and "backup:" in text
+
+    # model field now set to the recommended model
+    updated = agent_toml.read_text()
+    assert 'model = "claude-sonnet-4-5"' in updated
+    # original keys preserved (format-preserving surgical edit)
+    assert 'scope = "rig"' in updated
+    assert 'max_active_sessions = 5' in updated
+
+    # a timestamped backup of the ORIGINAL content exists
+    baks = list(tmp_path.glob("*advisor-bak*"))
+    assert len(baks) == 1
+    assert baks[0].read_text() == FLAT_AGENT_TOML
+
+
+def test_apply_writes_into_matching_agent_block(monkeypatch, tmp_path):
+    """`model` must land inside the [[agent]] name="polecat" block, not mayor's."""
+    _install_fake(monkeypatch)
+    city = _write(tmp_path, "city.toml", CITY_TOML_WITH_AGENT_BLOCK)
+    monkeypatch.setenv("ADVISOR_AGENT_TOML", str(city))
+
+    rc, text = _run("apply", "polecat", "--shape", "implement")
+    assert rc == 0
+    updated = city.read_text()
+
+    # exactly one model line, and it is in the polecat block (after its name)
+    assert updated.count("model = ") == 1
+    polecat_idx = updated.index('name = "polecat"')
+    mayor_idx = updated.index('name = "mayor"')
+    model_idx = updated.index('model = "claude-sonnet-4-5"')
+    assert model_idx > polecat_idx        # inside polecat block
+    assert not (mayor_idx < model_idx < polecat_idx)  # not in mayor block
+    # backup made
+    assert len(list(tmp_path.glob("*advisor-bak*"))) == 1
+
+
+# --------------------------------------------------------------------------- #
+# apply — idempotence + no-op refusal
+# --------------------------------------------------------------------------- #
+
+def test_apply_is_idempotent(monkeypatch, tmp_path):
+    _install_fake(monkeypatch)
+    agent_toml = _write(tmp_path, "agent.toml", FLAT_AGENT_TOML)
+    monkeypatch.setenv("ADVISOR_AGENT_TOML", str(agent_toml))
+
+    rc1, _ = _run("apply", "polecat", "--shape", "implement")
+    assert rc1 == 0
+    after_first = agent_toml.read_text()
+    assert after_first.count("model = ") == 1
+
+    # second apply is a no-op refusal (model already == recommendation)
+    rc2, text2 = _run("apply", "polecat", "--shape", "implement")
+    assert rc2 == 3
+    assert "refused" in text2.lower()
+    # file unchanged on the refusal; still exactly one model line
+    assert agent_toml.read_text() == after_first
+
+
+def test_apply_refuses_noop_when_model_already_set(monkeypatch, tmp_path):
+    _install_fake(monkeypatch)
+    preset = FLAT_AGENT_TOML + 'model = "claude-sonnet-4-5"\n'
+    agent_toml = _write(tmp_path, "agent.toml", preset)
+    monkeypatch.setenv("ADVISOR_AGENT_TOML", str(agent_toml))
+
+    rc, text = _run("apply", "polecat", "--shape", "implement")
+    assert rc == 3
+    assert "refused" in text.lower()
+    assert "no change" in text.lower()
+    # untouched, and no backup written on a refusal
+    assert agent_toml.read_text() == preset
+    assert not list(tmp_path.glob("*advisor-bak*"))
+
+
+def test_apply_replaces_existing_different_model(monkeypatch, tmp_path):
+    """A different existing model is replaced (not duplicated)."""
+    _install_fake(monkeypatch)
+    preset = FLAT_AGENT_TOML + 'model = "claude-opus-4-8"\n'
+    agent_toml = _write(tmp_path, "agent.toml", preset)
+    monkeypatch.setenv("ADVISOR_AGENT_TOML", str(agent_toml))
+
+    rc, text = _run("apply", "polecat", "--shape", "implement")
+    assert rc == 0
+    updated = agent_toml.read_text()
+    assert updated.count("model = ") == 1
+    assert 'model = "claude-sonnet-4-5"' in updated
+    assert "claude-opus-4-8" not in updated
+    assert "current model:    claude-opus-4-8" in text
+
+
+# --------------------------------------------------------------------------- #
+# apply — unresolvable config explains cleanly
+# --------------------------------------------------------------------------- #
+
+def test_apply_unresolvable_config_explained(monkeypatch, tmp_path):
+    _install_fake(monkeypatch)
+    # point at a missing file → resolver raises ConfigResolveError → rc 2
+    monkeypatch.setenv("ADVISOR_AGENT_TOML", str(tmp_path / "nope.toml"))
+    rc, text = _run("apply", "polecat", "--shape", "implement")
+    assert rc == 2
+    assert "apply:" in text
+    assert "missing file" in text.lower() or "could not resolve" in text.lower()
+
+
+def test_apply_block_requires_named_agent(monkeypatch, tmp_path):
+    """city.toml with no matching [[agent]] and no defaults → cannot resolve."""
+    _install_fake(monkeypatch)
+    # remove agent_defaults so there's no fallback scope, and no polecat block
+    city_text = (
+        "[workspace]\nprovider = \"claude\"\n\n"
+        "[[agent]]\nname = \"mayor\"\nscope = \"city\"\n"
+    )
+    city = _write(tmp_path, "city.toml", city_text)
+    monkeypatch.setenv("ADVISOR_AGENT_TOML", str(city))
+    rc, text = _run("apply", "ghostagent", "--shape", "implement")
+    assert rc == 2
+    assert "apply:" in text
+
+
+def test_apply_falls_back_to_agent_defaults(monkeypatch, tmp_path):
+    """No [[agent]] match but an [agent_defaults] table exists → write there."""
+    _install_fake(monkeypatch)
+    city_text = (
+        "[workspace]\nprovider = \"claude\"\n\n"
+        "[agent_defaults]\ndefault_sling_formula = \"mol-x\"\n"
+    )
+    city = _write(tmp_path, "city.toml", city_text)
+    monkeypatch.setenv("ADVISOR_AGENT_TOML", str(city))
+    rc, text = _run("apply", "anyagent", "--shape", "implement")
+    assert rc == 0
+    updated = city.read_text()
+    assert 'model = "claude-sonnet-4-5"' in updated
+    # landed inside [agent_defaults], after its header
+    assert updated.index("model = ") > updated.index("[agent_defaults]")
+    assert "[agent_defaults]" in text or "agent_defaults" in text
+
+
+# --------------------------------------------------------------------------- #
+# apply — resolve default shape when --shape omitted
+# --------------------------------------------------------------------------- #
+
+def test_apply_uses_default_shape_when_omitted(monkeypatch, tmp_path):
+    _install_fake(monkeypatch)  # _FakeCfg.default_shape -> "implement"
+    agent_toml = _write(tmp_path, "agent.toml", FLAT_AGENT_TOML)
+    monkeypatch.setenv("ADVISOR_AGENT_TOML", str(agent_toml))
+    rc, text = _run("apply", "polecat")  # no --shape
+    assert rc == 0
+    assert "shape=implement" in text
+    assert 'model = "claude-sonnet-4-5"' in agent_toml.read_text()
+
+
+# --------------------------------------------------------------------------- #
+# real engine smoke check (skipped if the sibling bead hasn't landed)
+# --------------------------------------------------------------------------- #
+
+def test_real_engine_importable_smoke():
+    """If the sibling engine exists, its recommend/inspect are callable shapes.
+
+    Skipped (not failed) when the engine bead hasn't landed yet, so this file is
+    green in isolation but exercises the real contract once it is present.
+    """
+    try:
+        from modeladvisor import engine as real_engine  # noqa: F401
+        from modeladvisor import config as real_config  # noqa: F401
+        from modeladvisor import store as real_store  # noqa: F401
+    except Exception as e:  # ModuleNotFoundError etc.
+        pytest.skip(f"sibling engine not present yet: {e}")
+
+    assert hasattr(real_engine, "recommend")
+    assert hasattr(real_engine, "inspect")
+    assert hasattr(real_config, "default_config") or hasattr(
+        real_config, "load_config"
+    )
+    assert hasattr(real_store, "CellStore")
+
+
+# --------------------------------------------------------------------------- #
+# real engine integration — drive cli.main against the actual engine
+# (skipped when the sibling bead hasn't landed).  These lock the CLI⇄engine
+# key-name alignment so a rename on either side is caught.
+# --------------------------------------------------------------------------- #
+
+def _have_real_engine():
+    try:
+        import modeladvisor.engine  # noqa: F401
+        import modeladvisor.config  # noqa: F401
+        import modeladvisor.store  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+real_engine = pytest.mark.skipif(
+    not _have_real_engine(), reason="sibling engine not present yet"
+)
+
+
+@real_engine
+def test_real_advise_text_and_json(monkeypatch, tmp_path):
+    # cold-start (no telemetry) → engine recommends the baseline tier; the CLI
+    # must render a tier + rationale + per-tier cost diffs, and valid JSON.
+    monkeypatch.setenv("ADVISOR_TELEMETRY_DIR", str(tmp_path))  # empty → cold-start
+    rc, text = _run("advise", "polecat", "implement")
+    assert rc == 0
+    assert "recommend:" in text and "rationale:" in text
+    assert "cost differential" in text
+    assert "<- recommended" in text
+
+    rc, js = _run("advise", "polecat", "implement", "--json")
+    assert rc == 0
+    obj = json.loads(js)  # must be valid JSON
+    assert obj["tier_id"]  # a concrete recommended tier
+    assert "candidates" in obj["reasons"]
+
+
+@real_engine
+def test_real_inspect_text_and_json(monkeypatch, tmp_path):
+    monkeypatch.setenv("ADVISOR_TELEMETRY_DIR", str(tmp_path))
+    rc, text = _run("inspect", "polecat", "implement")
+    assert rc == 0
+    assert "baseline tier*:" in text
+    # the gate column + quality-drop CI + widest-cell pointer all render
+    assert "quality-drop 95% CI" in text
+    assert "baseline" in text
+    assert "next eval" in text
+
+    rc, js = _run("inspect", "polecat", "implement", "--json")
+    assert rc == 0
+    obj = json.loads(js)
+    assert obj["tiers"] and obj["baseline_tier"]
+    assert "widest_gating_cell" in obj
+
+
+# --------------------------------------------------------------------------- #
+# apply — provider-aware (cross-provider) routing: a tier write sets the full
+# gc.provider / gc.model / gc.run_target triple, not just the model.
+# --------------------------------------------------------------------------- #
+
+class _FakeTier:
+    def __init__(self, tier_id, provider, model, run_target):
+        self.tier_id = tier_id
+        self.provider = provider
+        self.model = model
+        self.run_target = run_target
+
+
+# A tiny cross-provider roster the fake cfg serves to cmd_apply so it can resolve
+# the chosen tier's provider + run_target (the engine only returns a tier_id).
+_FAKE_ROSTER = {
+    "gpt54": _FakeTier("gpt54", "codex", "gpt-5.4", "codex-gpt54"),
+    "sonnet": _FakeTier("sonnet", "claude", "claude-sonnet-4-5", "claude-sonnet"),
+}
+
+
+class _FakeRosterCfg(_FakeCfg):
+    """A fake cfg exposing the tier-lookup surface cmd_apply needs."""
+
+    def has_tier(self, tier_id):
+        return tier_id in _FAKE_ROSTER
+
+    def tier(self, tier_id):
+        return _FAKE_ROSTER[tier_id]
+
+
+def _install_fake_roster(monkeypatch, *, model, tier, provider):
+    eng = FakeEngine(model=model, tier=tier)
+    monkeypatch.setattr(cli, "ENGINE", eng, raising=False)
+    monkeypatch.setattr(cli, "_load_engine", lambda: eng, raising=False)
+    monkeypatch.setattr(
+        cli, "build_state",
+        lambda **kw: cli.State(
+            cfg=_FakeRosterCfg(), store=object(), provider=provider
+        ),
+        raising=False,
+    )
+    return eng
+
+
+def test_apply_codex_tier_writes_full_routing_triple(monkeypatch, tmp_path):
+    """`apply` of a Codex tier writes provider=codex + model + run_target=codex-*."""
+    _install_fake_roster(monkeypatch, model="gpt-5.4", tier="gpt54", provider="codex")
+    agent_toml = _write(tmp_path, "agent.toml", FLAT_AGENT_TOML)
+    monkeypatch.setenv("ADVISOR_AGENT_TOML", str(agent_toml))
+
+    rc, text = _run("apply", "polecat", "--shape", "implement")
+    assert rc == 0
+    assert "applied:" in text and "backup:" in text
+
+    updated = agent_toml.read_text()
+    assert 'provider = "codex"' in updated
+    assert 'model = "gpt-5.4"' in updated
+    assert 'run_target = "codex-gpt54"' in updated
+    # one of each, surrounding lines preserved
+    assert updated.count("provider = ") == 1
+    assert updated.count("model = ") == 1
+    assert updated.count("run_target = ") == 1
+    assert 'scope = "rig"' in updated
+    assert "max_active_sessions = 5" in updated
+
+
+def test_apply_claude_tier_writes_full_routing_triple(monkeypatch, tmp_path):
+    _install_fake_roster(
+        monkeypatch, model="claude-sonnet-4-5", tier="sonnet", provider="claude"
+    )
+    agent_toml = _write(tmp_path, "agent.toml", FLAT_AGENT_TOML)
+    monkeypatch.setenv("ADVISOR_AGENT_TOML", str(agent_toml))
+
+    rc, _ = _run("apply", "polecat", "--shape", "implement")
+    assert rc == 0
+    updated = agent_toml.read_text()
+    assert 'provider = "claude"' in updated
+    assert 'model = "claude-sonnet-4-5"' in updated
+    assert 'run_target = "claude-sonnet"' in updated
+
+
+def test_apply_json_surfaces_dispatch_metadata(monkeypatch, tmp_path):
+    """`apply --json` emits the per-DISPATCH gc.provider/gc.model/gc.run_target."""
+    _install_fake_roster(monkeypatch, model="gpt-5.4", tier="gpt54", provider="codex")
+    agent_toml = _write(tmp_path, "agent.toml", FLAT_AGENT_TOML)
+    monkeypatch.setenv("ADVISOR_AGENT_TOML", str(agent_toml))
+
+    rc, text = _run("apply", "polecat", "--shape", "implement", "--json")
+    assert rc == 0
+    obj = json.loads(text)
+    assert obj["applied"] is True
+    assert obj["provider"] == "codex"
+    assert obj["model"] == "gpt-5.4"
+    assert obj["run_target"] == "codex-gpt54"
+    assert obj["dispatch_metadata"] == {
+        "gc.provider": "codex",
+        "gc.model": "gpt-5.4",
+        "gc.run_target": "codex-gpt54",
+    }
+    # and the file really was written with the triple
+    updated = agent_toml.read_text()
+    assert 'provider = "codex"' in updated and 'run_target = "codex-gpt54"' in updated
+
+
+def test_set_tier_fields_is_byte_preserving_and_idempotent(tmp_path):
+    """cli.set_tier_fields: replace-or-insert the triple, surrounding bytes intact."""
+    flat = 'scope = "rig"\nidle_timeout = "2h"\n'
+    p = _write(tmp_path, "agent.toml", flat)
+    target = cli.ConfigTarget(path=str(p), kind="flat", agent="polecat")
+
+    cli.set_tier_fields(
+        target, provider="codex", model="gpt-5.4", run_target="codex-gpt54"
+    )
+    once = p.read_text()
+    assert cli.read_field(target, "provider") == "codex"
+    assert cli.read_field(target, "model") == "gpt-5.4"
+    assert cli.read_field(target, "run_target") == "codex-gpt54"
+    # surrounding lines untouched
+    assert 'scope = "rig"' in once and 'idle_timeout = "2h"' in once
+
+    # Re-applying the same triple is byte-identical (no duplicate lines).
+    cli.set_tier_fields(
+        target, provider="codex", model="gpt-5.4", run_target="codex-gpt54"
+    )
+    assert p.read_text() == once
+    assert once.count("provider = ") == 1
+    assert once.count("model = ") == 1
+    assert once.count("run_target = ") == 1
+
+
+# --------------------------------------------------------------------------- #
+# apply — the non-deprecated target: per-agent agents/<name>/agent.toml.
+#
+# gc deprecates `[workspace] provider` ("set provider per agent in
+# agents/<name>/agent.toml") and resolves `model` per agent there too.  These
+# tests pin that the apply path resolves to (and, when absent, CREATES) the flat
+# per-agent `.gc/system/packs/<pack>/agents/<agent>/agent.toml` — and NEVER
+# writes the routing fields into city.toml's [workspace]/[[agent]].  Unlike the
+# tests above (which set $ADVISOR_AGENT_TOML to a literal file), these drive the
+# real city-tree resolution via --city, so a regression that reroutes the write
+# back to city.toml is caught.
+# --------------------------------------------------------------------------- #
+
+def _make_city_tree(tmp_path, *, existing_agents=("polecat",),
+                    extra_packs=("bd", "dolt"), agent_pack="gastown",
+                    city_toml=None):
+    """Build a synthetic city: an agent-bearing pack + infra packs + city.toml."""
+    city = tmp_path / "city"
+    pack_agents = city / ".gc" / "system" / "packs" / agent_pack / "agents"
+    for a in existing_agents:
+        (pack_agents / a).mkdir(parents=True, exist_ok=True)
+        (pack_agents / a / "agent.toml").write_text(
+            'scope = "rig"\nidle_timeout = "2h"\n', encoding="utf-8"
+        )
+    for p in extra_packs:  # infra packs that carry no agents/ dir
+        (city / ".gc" / "system" / "packs" / p).mkdir(parents=True, exist_ok=True)
+    ct = city / "city.toml"
+    ct.write_text(
+        city_toml
+        if city_toml is not None
+        else '[workspace]\nprovider = "claude"\n\n'
+             '[[agent]]\nname = "refinery"\nscope = "rig"\n',
+        encoding="utf-8",
+    )
+    return city
+
+
+def test_apply_targets_existing_per_agent_agent_toml(monkeypatch, tmp_path):
+    """An existing flat agents/<agent>/agent.toml is the target (not city.toml)."""
+    _install_fake_roster(monkeypatch, model="gpt-5.4", tier="gpt54", provider="codex")
+    monkeypatch.delenv("ADVISOR_AGENT_TOML", raising=False)
+    city = _make_city_tree(tmp_path, existing_agents=("polecat",))
+    city_before = (city / "city.toml").read_text()
+
+    rc, text = _run("apply", "polecat", "--shape", "implement", "--city", str(city))
+    assert rc == 0
+    flat = city / ".gc" / "system" / "packs" / "gastown" / "agents" / "polecat" / "agent.toml"
+    # the resolved config IS the per-agent flat file
+    assert str(flat) in text
+    updated = flat.read_text()
+    assert 'provider = "codex"' in updated
+    assert 'model = "gpt-5.4"' in updated
+    assert 'run_target = "codex-gpt54"' in updated
+    assert 'scope = "rig"' in updated  # original key preserved
+    # city.toml was never touched (the deprecated home stays clean)
+    assert (city / "city.toml").read_text() == city_before
+
+
+def test_apply_creates_per_agent_agent_toml_when_absent(monkeypatch, tmp_path):
+    """No flat file → CREATE agents/<agent>/agent.toml; city.toml stays byte-identical."""
+    _install_fake_roster(monkeypatch, model="gpt-5.4", tier="gpt54", provider="codex")
+    monkeypatch.delenv("ADVISOR_AGENT_TOML", raising=False)
+    # 'refinery' has an [[agent]] block in city.toml but NO flat agent.toml yet.
+    city = _make_city_tree(tmp_path, existing_agents=("polecat",))
+    city_before = (city / "city.toml").read_text()
+    created = city / ".gc" / "system" / "packs" / "gastown" / "agents" / "refinery" / "agent.toml"
+    assert not created.exists()
+
+    rc, text = _run("apply", "refinery", "--shape", "implement", "--city", str(city))
+    assert rc == 0
+    # the per-agent flat file was created under the agent-bearing pack (gastown),
+    # NOT under an infra pack (bd/dolt), and the triple landed there.
+    assert created.exists()
+    assert str(created) in text
+    d = created.read_text()
+    assert 'provider = "codex"' in d
+    assert 'model = "gpt-5.4"' in d
+    assert 'run_target = "codex-gpt54"' in d
+    # the DEPRECATED location (city.toml [workspace]/[[agent]]) is untouched.
+    assert (city / "city.toml").read_text() == city_before
+
+
+def test_apply_create_honors_rig_pack_root(monkeypatch, tmp_path):
+    """--rig selects that rig's pack root for the created per-agent agent.toml."""
+    _install_fake_roster(monkeypatch, model="gpt-5.4", tier="gpt54", provider="codex")
+    monkeypatch.delenv("ADVISOR_AGENT_TOML", raising=False)
+    city = _make_city_tree(tmp_path, existing_agents=("polecat",))
+    # a rig pack with no agents/ dir yet — --rig must still target it.
+    (city / ".gc" / "system" / "packs" / "whiskeyshop").mkdir(parents=True)
+
+    rc, text = _run(
+        "apply", "newbie", "--shape", "implement",
+        "--city", str(city), "--rig", "whiskeyshop",
+    )
+    assert rc == 0
+    created = (
+        city / ".gc" / "system" / "packs" / "whiskeyshop"
+        / "agents" / "newbie" / "agent.toml"
+    )
+    assert created.exists()
+    assert str(created) in text
+    assert 'model = "gpt-5.4"' in created.read_text()
+
+
+def test_apply_per_agent_create_is_idempotent_noop(monkeypatch, tmp_path):
+    """Second apply after a create is the no-op refusal (model already set)."""
+    _install_fake_roster(monkeypatch, model="gpt-5.4", tier="gpt54", provider="codex")
+    monkeypatch.delenv("ADVISOR_AGENT_TOML", raising=False)
+    city = _make_city_tree(tmp_path, existing_agents=("polecat",))
+
+    rc1, _ = _run("apply", "refinery", "--shape", "implement", "--city", str(city))
+    assert rc1 == 0
+    created = city / ".gc" / "system" / "packs" / "gastown" / "agents" / "refinery" / "agent.toml"
+    after_first = created.read_text()
+    assert after_first.count("model = ") == 1
+
+    rc2, text2 = _run("apply", "refinery", "--shape", "implement", "--city", str(city))
+    assert rc2 == 3
+    assert "refused" in text2.lower()
+    assert created.read_text() == after_first  # unchanged on the refusal
+
+
+def test_resolve_agent_config_prefers_created_flat_over_city_toml(monkeypatch, tmp_path):
+    """Unit: resolver returns a flat ConfigTarget under packs, never agent_block."""
+    monkeypatch.delenv("ADVISOR_AGENT_TOML", raising=False)
+    city = _make_city_tree(tmp_path, existing_agents=("polecat",))
+    target = cli.resolve_agent_config("refinery", city=str(city))
+    assert target.kind == "flat"
+    assert target.path.endswith(
+        os.path.join("gastown", "agents", "refinery", "agent.toml")
+    )
+    # span is None for a flat target (whole-file scope) — not a city.toml table.
+    assert target.span is None
+    assert "city.toml" not in target.path
+
+
+@real_engine
+def test_real_apply_lifecycle_on_temp_config(monkeypatch, tmp_path):
+    # full apply lifecycle against the real engine, on a TEMP flat agent.toml.
+    monkeypatch.setenv("ADVISOR_TELEMETRY_DIR", str(tmp_path))
+    agent_toml = _write(tmp_path, "agent.toml", FLAT_AGENT_TOML)
+    monkeypatch.setenv("ADVISOR_AGENT_TOML", str(agent_toml))
+
+    # dry-run writes nothing
+    rc, text = _run("apply", "polecat", "--shape", "implement", "--dry-run")
+    assert rc == 0 and "DRY-RUN" in text
+    assert agent_toml.read_text() == FLAT_AGENT_TOML
+
+    # real apply sets a model + backs up
+    rc, text = _run("apply", "polecat", "--shape", "implement")
+    assert rc == 0 and "applied:" in text and "backup:" in text
+    after = agent_toml.read_text()
+    assert "model = " in after and after.count("model = ") == 1
+    assert len(list(tmp_path.glob("*advisor-bak*"))) == 1
+
+    # second apply is the idempotent no-op refusal
+    rc, text = _run("apply", "polecat", "--shape", "implement")
+    assert rc == 3 and "refused" in text.lower()
+    assert agent_toml.read_text() == after

--- a/model-advisor/tests/test_conformal.py
+++ b/model-advisor/tests/test_conformal.py
@@ -1,0 +1,260 @@
+"""Tests for the distribution-free split-conformal LCB backend (DESIGN §5.2, §7.3).
+
+Covers the load-bearing contract from the v3 build brief (bead ``bh-ah7``):
+
+- **drop-in safety** — a thin (or zero-spread) buffer makes ``conformal_lcb``
+  return *exactly* ``engine.wilson_lcb``, so flipping ``lcb_backend`` can never
+  change a day-1 cell's decision;
+- **asymptotic coincidence with Wilson** — a rich, symmetric, well-calibrated
+  buffer drives the bound to the Wilson bound (``Q → z``);
+- **calibrated bound ≤ mean** and **finite-sample valid-ish coverage** on a
+  synthetic stream of independent cells;
+- **catches over-confidence** — a ``pred ≫ obs`` buffer yields a bound strictly
+  *below* Wilson at the same cell;
+- ring-buffer cap (drop-oldest), ``to_dict``/``from_dict`` round-trip,
+  determinism, and ``[0, 1]`` clamping.
+
+The conformity score is ``s_i = (pred_i − obs_i) / sd(pred − obs)`` and the bound
+is ``clamp_[0,1](mu − Q_{1−alpha}·sigma)`` (DESIGN §5.2); these tests pin both the
+numeric behaviour and the directional guarantees.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import random
+import sys
+
+import pytest
+
+# Make the pack root importable when pytest is run from anywhere.
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+
+from modeladvisor import engine as E  # noqa: E402
+from modeladvisor.conformal import CalibrationBuffer, conformal_lcb  # noqa: E402
+from modeladvisor.store import Cell  # noqa: E402
+
+_Z = 1.645  # z_{0.95}, the default one-sided alpha=0.05 (matches cfg.hp.z).
+
+
+# --------------------------------------------------------------------------- #
+# Helpers                                                                       #
+# --------------------------------------------------------------------------- #
+
+
+def _bernoulli_cell(theta: float, n: int, seed: int) -> tuple[Cell, list[float]]:
+    """A cell + the observation list, materialised from ``n`` Bernoulli(theta) draws.
+
+    The cell posterior is ``Beta(1 + #succ, 1 + #fail)`` (a flat prior plus the
+    realised outcomes), so ``cell.mean`` tracks the empirical success rate.
+    """
+    rng = random.Random(seed)
+    obs = [1.0 if rng.random() < theta else 0.0 for _ in range(n)]
+    a = 1.0 + sum(obs)
+    b = 1.0 + (n - sum(obs))
+    return Cell(a=a, b=b), obs
+
+
+def _buffer_from(preds, obs, *, cap: int = 5000) -> CalibrationBuffer:
+    buf = CalibrationBuffer(cap=cap)
+    for p, o in zip(preds, obs):
+        buf.append(p, o)
+    return buf
+
+
+# --------------------------------------------------------------------------- #
+# Drop-in safety: thin / degenerate buffer == wilson_lcb exactly               #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "a,b,fill",
+    [(40.0, 10.0, 0), (8.0, 2.0, 5), (2.0, 2.0, 19), (100.0, 3.0, 12)],
+)
+def test_thin_buffer_equals_wilson_exactly(a, b, fill):
+    """``len(buffer) < min_buffer`` ⇒ byte-identical to ``engine.wilson_lcb`` (drop-in)."""
+    cell = Cell(a=a, b=b)
+    buf = CalibrationBuffer()
+    for _ in range(fill):  # fewer than the default min_buffer=20
+        buf.append(0.8, 1.0)
+    assert conformal_lcb(cell, buf, _Z) == E.wilson_lcb(cell, _Z)
+
+
+def test_zero_spread_buffer_falls_back_to_wilson():
+    """A rich buffer with no residual spread (every pred == obs) ⇒ Wilson fallback.
+
+    The standardized-residual quantile is undefined when ``sd(pred − obs) == 0``;
+    the bound must degrade to Wilson rather than divide by zero (DESIGN §5.2).
+    """
+    cell = Cell(a=30.0, b=10.0)
+    buf = CalibrationBuffer()
+    for _ in range(50):  # well past min_buffer, but all residuals are 0.0
+        buf.append(1.0, 1.0)
+    assert conformal_lcb(cell, buf, _Z) == E.wilson_lcb(cell, _Z)
+
+
+def test_min_buffer_boundary_is_inclusive():
+    """At exactly ``min_buffer − 1`` it is still Wilson; at ``min_buffer`` it engages."""
+    cell = Cell(a=30.0, b=10.0)
+    rng = random.Random(0)
+    buf = CalibrationBuffer()
+    for _ in range(19):  # min_buffer - 1
+        buf.append(0.9, 1.0 if rng.random() < 0.5 else 0.0)
+    assert conformal_lcb(cell, buf, _Z) == E.wilson_lcb(cell, _Z)
+    buf.append(0.9, 0.0)  # now len == 20 == min_buffer, with spread
+    assert conformal_lcb(cell, buf, _Z) != E.wilson_lcb(cell, _Z)
+
+
+# --------------------------------------------------------------------------- #
+# Asymptotic coincidence with Wilson + calibrated bound ≤ mean                  #
+# --------------------------------------------------------------------------- #
+
+
+def test_symmetric_calibrated_buffer_coincides_with_wilson():
+    """A symmetric well-calibrated stream drives ``Q → z`` ⇒ bound → Wilson (§5.2)."""
+    cell = Cell(a=80.0, b=20.0)  # mean 0.8, fixed stderr
+    rng = random.Random(3)
+    # Symmetric, calibrated residuals: graded obs ~ pred + N(0, sigma), pred uniform.
+    preds = [rng.uniform(0.2, 0.9) for _ in range(3000)]
+    obs = [min(1.0, max(0.0, p + rng.gauss(0.0, 0.1))) for p in preds]
+    buf = _buffer_from(preds, obs)
+
+    conformal = conformal_lcb(cell, buf, _Z)
+    wilson = E.wilson_lcb(cell, _Z)
+    # Converges to Wilson: a symmetric residual's (1-alpha) standardized quantile
+    # approaches z, so mu - Q*sigma approaches mu - z*sigma.
+    assert conformal == pytest.approx(wilson, abs=0.02)
+    assert conformal <= cell.mean  # a lower bound never exceeds the point estimate.
+
+
+def test_calibrated_rich_buffer_has_validish_coverage():
+    """Synthetic stream of independent calibrated cells: coverage is finite-sample valid-ish.
+
+    For each cell ``pred == theta`` (perfectly calibrated). The conformal bound is
+    distribution-free up to Bernoulli discreteness; we assert coverage well above a
+    conservative floor (the brief's "valid-ish"), comfortably better than chance.
+    """
+    alpha = 0.05
+    trials = 1000
+    covered = 0
+    rng = random.Random(2026)
+    for _ in range(trials):
+        theta = rng.uniform(0.30, 0.92)
+        n = rng.randint(40, 140)
+        cell, obs = _bernoulli_cell(theta, n, rng.randint(0, 1 << 30))
+        buf = _buffer_from([theta] * len(obs), obs, cap=200)
+        if theta >= conformal_lcb(cell, buf, _Z, alpha=alpha):
+            covered += 1
+    coverage = covered / trials
+    assert coverage >= 0.80, f"coverage {coverage:.3f} below valid-ish floor"
+
+
+# --------------------------------------------------------------------------- #
+# Catches miscalibration: over-confident buffer ⇒ bound below Wilson            #
+# --------------------------------------------------------------------------- #
+
+
+def test_overconfident_buffer_drops_below_wilson():
+    """``pred ≫ obs`` shifts residuals positive ⇒ bound strictly below Wilson (§5.2).
+
+    Wilson sees only the posterior spread and cannot detect that the cell's
+    predictions overshoot reality; the conformal bound, keyed off realised
+    prediction errors, drops to reflect the over-confidence — the whole point of
+    the conformal backend.
+    """
+    cell, obs = _bernoulli_cell(theta=0.6, n=400, seed=9)
+    over = _buffer_from([0.95] * len(obs), obs, cap=1000)  # systematic over-prediction
+    wilson = E.wilson_lcb(cell, _Z)
+    conformal = conformal_lcb(cell, over, _Z)
+    assert conformal < wilson
+
+
+def test_overconfident_is_lower_than_calibrated_at_same_cell():
+    """At one fixed cell, an over-confident buffer bounds lower than a calibrated one."""
+    cell, obs = _bernoulli_cell(theta=0.6, n=400, seed=21)
+    calibrated = _buffer_from([cell.mean] * len(obs), obs, cap=1000)
+    over = _buffer_from([0.99] * len(obs), obs, cap=1000)
+    assert conformal_lcb(cell, over, _Z) <= conformal_lcb(cell, calibrated, _Z)
+
+
+# --------------------------------------------------------------------------- #
+# Buffer mechanics: ring cap, round-trip, clamping                             #
+# --------------------------------------------------------------------------- #
+
+
+def test_ring_buffer_drops_oldest_at_cap():
+    """Appending past ``cap`` keeps only the most-recent ``cap`` pairs (DESIGN §7.3)."""
+    buf = CalibrationBuffer(cap=3)
+    for i in range(10):
+        buf.append(i / 10.0, 1.0)
+    assert len(buf) == 3
+    # The three most-recent appends (i = 7, 8, 9) survive, oldest-first.
+    assert buf.pairs == [(0.7, 1.0), (0.8, 1.0), (0.9, 1.0)]
+
+
+def test_cap_must_be_positive():
+    with pytest.raises(ValueError):
+        CalibrationBuffer(cap=0)
+
+
+def test_to_from_dict_round_trip():
+    """``from_dict(to_dict(b))`` reproduces the buffer exactly (cache round-trip §5.5)."""
+    buf = CalibrationBuffer(cap=7)
+    for i in range(5):
+        buf.append(0.1 * i, float(i % 2))
+    restored = CalibrationBuffer.from_dict(buf.to_dict())
+    assert restored.cap == buf.cap
+    assert restored.pairs == buf.pairs
+
+
+def test_from_dict_truncates_overlong_pairs_to_cap():
+    """A tampered/over-long cached ``pairs`` is truncated to the most-recent ``cap``."""
+    b = CalibrationBuffer.from_dict(
+        {"cap": 3, "pairs": [[0.1, 0], [0.2, 1], [0.3, 0], [0.4, 1], [0.5, 0]]}
+    )
+    assert len(b) == 3
+    assert b.pairs == [(0.3, 0.0), (0.4, 1.0), (0.5, 0.0)]
+
+
+def test_append_clamps_into_unit_interval():
+    """Out-of-range ``pred``/``obs`` are clamped to ``[0, 1]`` (quality is a probability)."""
+    buf = CalibrationBuffer()
+    buf.append(1.5, -0.3)
+    buf.append(-2.0, 4.0)
+    assert buf.pairs == [(1.0, 0.0), (0.0, 1.0)]
+
+
+def test_bound_is_clamped_into_unit_interval():
+    """The returned bound is always within ``[0, 1]`` even under extreme miscalibration.
+
+    A tight, low-mean cell (small ``sigma``) whose predictions are wildly
+    over-confident yields a large standardized quantile ``Q``; ``mu − Q·sigma``
+    goes negative and must clamp to 0.0 (DESIGN §5.2).
+    """
+    cell = Cell(a=5.0, b=45.0)  # mean 0.1, tight posterior (small stderr)
+    rng = random.Random(1)
+    buf = CalibrationBuffer(cap=300)
+    for _ in range(300):  # pred 0.99 vs obs ~ Bernoulli(0.1) ⇒ large positive residuals
+        buf.append(0.99, 1.0 if rng.random() < 0.1 else 0.0)
+    q = conformal_lcb(cell, buf, _Z)
+    assert 0.0 <= q <= 1.0
+    assert q == 0.0  # the large positive quantile pushes mu - Q*sigma below 0 ⇒ clamp.
+
+
+# --------------------------------------------------------------------------- #
+# Determinism                                                                   #
+# --------------------------------------------------------------------------- #
+
+
+def test_determinism_same_inputs_same_output():
+    """No hidden randomness: identical (cell, buffer) ⇒ identical bound across calls."""
+    cell, obs = _bernoulli_cell(theta=0.7, n=300, seed=42)
+    buf = _buffer_from([0.85] * len(obs), obs, cap=1000)
+    first = conformal_lcb(cell, buf, _Z)
+    for _ in range(5):
+        assert conformal_lcb(cell, buf, _Z) == first
+    # And it is a plain float (the engine compares it to the gate threshold).
+    assert isinstance(first, float) and math.isfinite(first)

--- a/model-advisor/tests/test_continuous.py
+++ b/model-advisor/tests/test_continuous.py
@@ -1,0 +1,341 @@
+"""Tests for the continuous quality signal (bead bh-pl7, DESIGN §1.3 + §4 + §7.3).
+
+This suite owns the *continuous-reward* contract: a quality outcome ``q ∈ [0, 1]``
+(reviewer score / test-pass fraction) folded into the existing Beta posterior, plus
+the optional :class:`GaussianCell` Normal-Inverse-Gamma posterior for unbounded
+scores. The store/engine/config are sibling files the integrator wires; we do not
+touch them here.
+
+To stay runnable *before* the sibling store/engine are import-clean — the package
+``__init__`` eagerly re-exports them — we load both ``modeladvisor/continuous.py``
+and the real ``modeladvisor/store.py`` (for its genuine :class:`Cell`) as
+**standalone modules** via importlib, registering each in ``sys.modules`` before
+executing it (so their ``@dataclass`` decorators resolve). This mirrors the loader
+in ``test_ingest.py`` and keeps the suite hermetic regardless of sibling timing.
+The "binary path unchanged" test asserts against the *real* ``Cell`` so the
+byte-identity claim is verified, not assumed.
+
+Nothing here touches live state: everything operates on in-memory objects.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import math
+import sys
+from pathlib import Path
+
+import pytest
+
+PACK_DIR = Path(__file__).resolve().parents[1]
+CONT_PATH = PACK_DIR / "modeladvisor" / "continuous.py"
+STORE_PATH = PACK_DIR / "modeladvisor" / "store.py"
+
+
+def _load_standalone(name: str, path: Path):
+    """Load a module file standalone, bypassing the package __init__ re-exports."""
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod  # register BEFORE exec (dataclasses resolve self-refs)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+cont = _load_standalone("mad_continuous_under_test", CONT_PATH)
+
+
+def _real_cell(a: float, b: float):
+    """A genuine ``modeladvisor.store.Cell`` (loaded standalone).
+
+    ``store.py`` imports ``modeladvisor.config``; loading config under its real
+    dotted name first keeps ``store`` import-clean without running the package
+    ``__init__``. Returns a ``Cell(a, b)`` for byte-identity checks.
+    """
+    if "modeladvisor" not in sys.modules:
+        import types
+
+        pkg = types.ModuleType("modeladvisor")
+        pkg.__path__ = [str(PACK_DIR / "modeladvisor")]
+        pkg.__package__ = "modeladvisor"
+        sys.modules["modeladvisor"] = pkg
+    if "modeladvisor.config" not in sys.modules:
+        _load_standalone("modeladvisor.config", PACK_DIR / "modeladvisor" / "config.py")
+    if "modeladvisor.store" not in sys.modules:
+        _load_standalone("modeladvisor.store", STORE_PATH)
+    store = sys.modules["modeladvisor.store"]
+    return store.Cell(a=a, b=b)
+
+
+# --------------------------------------------------------------------------- #
+# A tiny stand-in Beta cell (Protocol-compatible) for the bounded path.        #
+# Mirrors store.Cell.update exactly so apply_continuous can be unit-tested      #
+# without importing the package; the byte-identity test uses the REAL Cell.     #
+# --------------------------------------------------------------------------- #
+
+
+class FakeCell:
+    """Minimal Beta cell exposing ``.update`` (DESIGN §1.3 Layer 1)."""
+
+    def __init__(self, a: float, b: float) -> None:
+        self.a = a
+        self.b = b
+        self.n = 0
+        self.last_update: str | None = None
+
+    @property
+    def mean(self) -> float:
+        return self.a / (self.a + self.b)
+
+    def update(self, q: float, w: float, ts: str | None) -> None:
+        self.a += w * q
+        self.b += w * (1.0 - q)
+        self.n += 1
+        if ts is not None:
+            self.last_update = ts
+
+
+# --------------------------------------------------------------------------- #
+# 1. is_valid_q — binary vs continuous (DESIGN §1.1 / §7.3)                     #
+# --------------------------------------------------------------------------- #
+
+
+def test_is_valid_q_binary_vs_continuous() -> None:
+    # Binary (v1 default): only the two-point set {0, 1}.
+    assert cont.is_valid_q(0.0) is True
+    assert cont.is_valid_q(1.0) is True
+    assert cont.is_valid_q(0) is True
+    assert cont.is_valid_q(1) is True
+    assert cont.is_valid_q(0.7) is False  # mid-range rejected when binary
+    assert cont.is_valid_q(0.5) is False
+
+    # Continuous: the whole closed unit interval is admissible.
+    assert cont.is_valid_q(0.7, continuous=True) is True
+    assert cont.is_valid_q(0.0, continuous=True) is True
+    assert cont.is_valid_q(1.0, continuous=True) is True
+    # ...but nothing outside [0, 1], even in continuous mode.
+    assert cont.is_valid_q(1.5, continuous=True) is False
+    assert cont.is_valid_q(-0.01, continuous=True) is False
+
+
+def test_is_valid_q_rejects_non_numeric_and_non_finite() -> None:
+    # Never raises; returns False for junk in either mode.
+    for mode in (False, True):
+        assert cont.is_valid_q(None, continuous=mode) is False
+        assert cont.is_valid_q("pass", continuous=mode) is False
+        assert cont.is_valid_q(float("nan"), continuous=mode) is False
+        assert cont.is_valid_q(float("inf"), continuous=mode) is False
+
+
+# --------------------------------------------------------------------------- #
+# 2. apply_continuous moves the Beta posterior mean correctly (DESIGN §1.3)     #
+# --------------------------------------------------------------------------- #
+
+
+def test_apply_continuous_moves_beta_mean_toward_q() -> None:
+    # Optimistic baseline-style prior Beta(8, 2) (mean 0.80). Repeated q=0.7
+    # observations must pull the posterior mean down toward 0.7, monotonically.
+    cell = FakeCell(8.0, 2.0)
+    assert cell.mean == pytest.approx(0.80)
+    means = []
+    for _ in range(5):
+        cont.apply_continuous(cell, 0.7, w=1.0, ts="2026-06-03T00:00:00Z")
+        means.append(cell.mean)
+    # After 5 unit-weight updates: a=11.5, b=3.5 -> mean = 11.5/15 = 0.76667.
+    assert cell.mean == pytest.approx(11.5 / 15.0)
+    # Strictly decreasing toward (but not past) 0.7.
+    assert all(means[i] > means[i + 1] for i in range(len(means) - 1))
+    assert 0.7 < cell.mean < 0.80
+    assert cell.n == 5
+    assert cell.last_update == "2026-06-03T00:00:00Z"
+
+
+def test_apply_continuous_weight_scales_the_update() -> None:
+    # A reviewer-weight (w=3) continuous observation counts as 3 soft obs.
+    cell = FakeCell(1.0, 1.0)
+    cont.apply_continuous(cell, 0.75, w=3.0, ts=None)
+    assert cell.a == pytest.approx(1.0 + 3.0 * 0.75)  # 3.25
+    assert cell.b == pytest.approx(1.0 + 3.0 * 0.25)  # 1.75
+    assert cell.n == 1
+
+
+# --------------------------------------------------------------------------- #
+# 3. Clamping of out-of-range q (DESIGN §7.3)                                   #
+# --------------------------------------------------------------------------- #
+
+
+def test_apply_continuous_clamps_out_of_range() -> None:
+    # q > 1 clamps to 1 (full soft-success: all mass to a).
+    hi = FakeCell(2.0, 2.0)
+    cont.apply_continuous(hi, 1.4, w=1.0, ts=None)
+    assert hi.a == pytest.approx(3.0)
+    assert hi.b == pytest.approx(2.0)
+
+    # q < 0 clamps to 0 (full soft-failure: all mass to b).
+    lo = FakeCell(2.0, 2.0)
+    cont.apply_continuous(lo, -0.3, w=1.0, ts=None)
+    assert lo.a == pytest.approx(2.0)
+    assert lo.b == pytest.approx(3.0)
+
+
+def test_apply_continuous_rejects_non_finite() -> None:
+    cell = FakeCell(1.0, 1.0)
+    with pytest.raises(ValueError):
+        cont.apply_continuous(cell, float("nan"), w=1.0, ts=None)
+    with pytest.raises(ValueError):
+        cont.apply_continuous(cell, float("inf"), w=1.0, ts=None)
+    # The cell was never mutated by the rejected calls.
+    assert (cell.a, cell.b, cell.n) == (1.0, 1.0, 0)
+
+
+# --------------------------------------------------------------------------- #
+# 4. Binary path is byte-identical to v1 — against the REAL store.Cell.         #
+#    (The brief's hard requirement: feature-on with {0,1} data == v1.)          #
+# --------------------------------------------------------------------------- #
+
+
+def test_binary_path_unchanged_vs_real_cell() -> None:
+    # Drive the same {0,1} sequence through (a) the real Cell.update (the v1
+    # binary path) and (b) apply_continuous; the resulting (a, b, n, last_update)
+    # must be bit-for-bit identical.
+    seq = [(1.0, 1.0, "t1"), (0.0, 3.0, "t2"), (1.0, 5.0, "t3"), (1.0, 1.0, None)]
+
+    v1 = _real_cell(8.0, 2.0)
+    for q, w, ts in seq:
+        v1.update(q, w, ts)
+
+    via_cont = _real_cell(8.0, 2.0)
+    for q, w, ts in seq:
+        cont.apply_continuous(via_cont, q, w, ts)
+
+    assert via_cont.to_dict() == v1.to_dict()
+    assert via_cont.a == v1.a and via_cont.b == v1.b
+    assert via_cont.n == v1.n and via_cont.last_update == v1.last_update
+
+
+# --------------------------------------------------------------------------- #
+# 5. normalise_score — unbounded raw -> [0, 1], clamped (DESIGN §7.3)           #
+# --------------------------------------------------------------------------- #
+
+
+def test_normalise_score_maps_and_clamps() -> None:
+    # A reviewer 0-100 score maps linearly into [0, 1].
+    assert cont.normalise_score(0.0, 0.0, 100.0) == pytest.approx(0.0)
+    assert cont.normalise_score(50.0, 0.0, 100.0) == pytest.approx(0.5)
+    assert cont.normalise_score(100.0, 0.0, 100.0) == pytest.approx(1.0)
+    # Out-of-range raw clamps to the nearest edge.
+    assert cont.normalise_score(120.0, 0.0, 100.0) == pytest.approx(1.0)
+    assert cont.normalise_score(-10.0, 0.0, 100.0) == pytest.approx(0.0)
+    # Degenerate range -> neutral midpoint (no information).
+    assert cont.normalise_score(42.0, 5.0, 5.0) == pytest.approx(0.5)
+    # Swapped bounds are oriented, not an error.
+    assert cont.normalise_score(25.0, 100.0, 0.0) == pytest.approx(0.25)
+    # Output is always a valid continuous q.
+    assert cont.is_valid_q(cont.normalise_score(73.4, 10.0, 90.0), continuous=True)
+
+
+def test_normalise_then_apply_round_trip() -> None:
+    # End-to-end: a raw reviewer score -> normalised q -> Beta update.
+    cell = FakeCell(1.0, 1.0)
+    q = cont.normalise_score(85.0, 0.0, 100.0)  # 0.85
+    cont.apply_continuous(cell, q, w=1.0, ts=None)
+    assert cell.a == pytest.approx(1.85)
+    assert cell.b == pytest.approx(1.15)
+
+
+# --------------------------------------------------------------------------- #
+# 6. GaussianCell — update moves the mean, lcb sanity, round-trip (DESIGN §7.3) #
+# --------------------------------------------------------------------------- #
+
+
+def test_gaussian_cell_update_tracks_location_and_shrinks_stderr() -> None:
+    gc = cont.GaussianCell()  # weak prior centred at 0
+    assert gc.mean == pytest.approx(0.0)
+    # A tight cluster around 10: enough data overwhelms the prior-at-0 and the
+    # location estimate converges to the cluster mean.
+    cluster = [10.0, 10.1, 9.9, 10.05, 9.95] * 6  # 30 obs, sample mean ~10
+    stderr_by_n: list[float] = []
+    for i, x in enumerate(cluster, start=1):
+        gc.update(x)
+        if i in (5, 10, 20, 30):
+            stderr_by_n.append(gc.stderr)
+    # Location estimate has converged toward the data mean (~10).
+    assert gc.mean == pytest.approx(10.0, abs=0.5)
+    assert gc.n == len(cluster)
+    # Uncertainty on the *location* strictly shrinks as more of the same signal
+    # accrues (the load-bearing "more data -> tighter posterior" property).
+    assert all(stderr_by_n[i] > stderr_by_n[i + 1] for i in range(len(stderr_by_n) - 1))
+    # data_variance (spread of the scores themselves) is a sane positive estimate.
+    assert gc.data_variance > 0.0
+
+
+def test_gaussian_cell_lcb_is_below_mean_and_unbounded() -> None:
+    gc = cont.GaussianCell()
+    for x in [-5.0, -4.0, -6.0, -5.5, -4.5]:  # genuinely negative scores
+        gc.update(x)
+    z = 1.645
+    lcb = gc.lcb(z)
+    # One-sided lower bound sits strictly below the mean...
+    assert lcb < gc.mean
+    assert lcb == pytest.approx(gc.mean - z * gc.stderr)
+    # ...and is NOT clamped to 0 (unbounded score: negative LCB preserved).
+    assert lcb < 0.0
+    # A larger z gives a looser (lower) bound.
+    assert gc.lcb(2.5) < gc.lcb(1.0)
+
+
+def test_gaussian_cell_round_trip_dict() -> None:
+    gc = cont.GaussianCell()
+    for x in [3.0, 7.0, 5.0, 6.0]:
+        gc.update(x)
+    d = gc.to_dict()
+    assert set(d) == {"mu", "lam", "alpha", "beta", "n"}
+    back = cont.GaussianCell.from_dict(d)
+    assert back == gc  # dataclass eq over all five fields
+    assert back.to_dict() == d
+    # Continuing to update the restored cell matches updating the original.
+    gc.update(8.0)
+    back.update(8.0)
+    assert back.to_dict() == gc.to_dict()
+
+
+def test_gaussian_cell_rejects_non_finite_update() -> None:
+    gc = cont.GaussianCell()
+    with pytest.raises(ValueError):
+        gc.update(float("nan"))
+    with pytest.raises(ValueError):
+        gc.update(float("inf"))
+
+
+# --------------------------------------------------------------------------- #
+# 7. Determinism / replay-order invariance (DESIGN §5.5 rebuildability)         #
+# --------------------------------------------------------------------------- #
+
+
+def test_determinism_continuous_replay_is_reproducible() -> None:
+    # Same continuous sequence -> identical Beta state, twice (no hidden state).
+    seq = [0.3, 0.9, 0.55, 1.2, -0.4, 0.7]
+    a = FakeCell(2.0, 2.0)
+    b = FakeCell(2.0, 2.0)
+    for q in seq:
+        cont.apply_continuous(a, q, w=2.0, ts=None)
+        cont.apply_continuous(b, q, w=2.0, ts=None)
+    assert (a.a, a.b, a.n) == (b.a, b.b, b.n)
+
+
+def test_gaussian_update_is_order_invariant() -> None:
+    # The NIG sequential update is algebraically the batch update, so the final
+    # posterior must not depend on the order observations are replayed in
+    # (load-bearing for the rebuildable cell-store cache, DESIGN §5.5).
+    xs = [10.0, 12.0, 11.0, 9.0, 13.0, 10.0, 11.0, 12.0]
+    fwd = cont.GaussianCell()
+    rev = cont.GaussianCell()
+    for x in xs:
+        fwd.update(x)
+    for x in reversed(xs):
+        rev.update(x)
+    assert fwd.mu == pytest.approx(rev.mu)
+    assert fwd.lam == pytest.approx(rev.lam)
+    assert fwd.alpha == pytest.approx(rev.alpha)
+    assert fwd.beta == pytest.approx(rev.beta)
+    assert math.isclose(fwd.lcb(1.645), rev.lcb(1.645), rel_tol=1e-12, abs_tol=1e-12)

--- a/model-advisor/tests/test_engine.py
+++ b/model-advisor/tests/test_engine.py
@@ -1,0 +1,529 @@
+"""Tests for the CC-TS engine (DESIGN.md §1, §3, §5).
+
+Covers the load-bearing properties from the design + the explicit acceptance
+checklist for this bead:
+
+- cold-start recommends the baseline (no silent downgrade);
+- a cheaper tier is admitted only after enough successful observations push its
+  one-sided lower bound past ``mu* − q_tol``;
+- a single failure on a thin cell keeps the baseline;
+- a ``Critical`` cell never downgrades regardless of evidence;
+- ``cost_delta`` + structured ``reasons`` are populated on every call;
+- determinism: identical inputs -> identical output.
+
+Plus store/cache round-trip, pooling, gate-threshold arithmetic, the safety
+hatch, and the ``inspect`` surface. Fixtures are built from synthetic
+``invocations.jsonl`` records keyed exactly as the engine expects.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+import pytest
+
+# Make the pack root importable when pytest is run from anywhere.
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+
+from modeladvisor import config as C  # noqa: E402
+from modeladvisor import engine as E  # noqa: E402
+from modeladvisor import store as S  # noqa: E402
+from modeladvisor.store import cell_key  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures + helpers                                                            #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def cfg() -> C.AdvisorConfig:
+    """Default Claude haiku/sonnet/opus roster, baseline = opus."""
+    return C.default_config()
+
+
+def q_record(cfg, agent, shape, tier, q, *, channel="close", i=0, provider=None):
+    """One synthetic ``kind=quality`` telemetry record for a cell."""
+    provider = provider or cfg.default_provider
+    return {
+        "schema_version": "advisor.v1",
+        "kind": "quality",
+        "ts": f"2026-06-01T00:{i // 60:02d}:{i % 60:02d}Z",
+        "bead_id": f"bh-{agent}-{shape}-{tier}-{i}",
+        "cell_key": cell_key(provider, agent, shape, tier),
+        "q": q,
+        "channel": channel,
+        "signal": "closed" if q == 1 else "reopened",
+    }
+
+
+def store_with(cfg, records):
+    """Cold-start store with the given quality records applied."""
+    st = S.CellStore.cold_start(cfg)
+    st.apply_records(records)
+    return st
+
+
+def successes(cfg, agent, shape, tier, n, *, channel="close"):
+    return [q_record(cfg, agent, shape, tier, 1, channel=channel, i=i) for i in range(n)]
+
+
+def failures(cfg, agent, shape, tier, n, *, channel="close"):
+    return [q_record(cfg, agent, shape, tier, 0, channel=channel, i=i) for i in range(n)]
+
+
+# --------------------------------------------------------------------------- #
+# Cold start: no silent downgrade                                              #
+# --------------------------------------------------------------------------- #
+
+
+def test_cold_start_recommends_baseline(cfg):
+    st = S.CellStore.cold_start(cfg)
+    rec = E.recommend("polecat", "implement", cfg, st)
+    assert rec["tier_id"] == cfg.baseline_tier_id == "opus"
+    assert rec["cost_delta"] == 0.0
+    # No cheaper tier admitted at cold start.
+    cands = {c["tier_id"]: c for c in rec["reasons"]["candidates"]}
+    assert cands["haiku"]["admitted"] is False
+    assert cands["sonnet"]["admitted"] is False
+    assert cands["opus"]["admitted"] is True
+    assert "no cheaper tier" in rec["rationale"].lower()
+
+
+def test_cold_start_prior_means_are_cost_ordered(cfg):
+    """DESIGN §3.2: baseline optimistic (0.8); cheaper tiers depressed & monotone."""
+    a_h, b_h = S.cold_start_prior(cfg, "haiku", "opus")
+    a_s, b_s = S.cold_start_prior(cfg, "sonnet", "opus")
+    a_o, b_o = S.cold_start_prior(cfg, "opus", "opus")
+    m_h, m_s, m_o = a_h / (a_h + b_h), a_s / (a_s + b_s), a_o / (a_o + b_o)
+    assert m_h < m_s < m_o
+    assert m_o == pytest.approx(0.8)
+    assert m_h == pytest.approx(cfg.hp.cold_m_lo)
+
+
+# --------------------------------------------------------------------------- #
+# Earned admission: enough successes push q_lo past the threshold              #
+# --------------------------------------------------------------------------- #
+
+
+def test_cheaper_tier_admitted_only_after_enough_successes(cfg):
+    # A handful of successes is NOT enough (LCB still below mu* - q_tol).
+    thin = store_with(cfg, successes(cfg, "polecat", "implement", "sonnet", 3))
+    rec_thin = E.recommend("polecat", "implement", cfg, thin)
+    assert rec_thin["tier_id"] == "opus", "thin evidence must keep baseline"
+
+    # Many successes DO admit the cheaper tier.
+    rich = store_with(cfg, successes(cfg, "polecat", "implement", "sonnet", 40))
+    rec_rich = E.recommend("polecat", "implement", cfg, rich)
+    assert rec_rich["tier_id"] == "sonnet", "sufficient evidence must admit the cheaper tier"
+
+    # And the admission is exactly the gate rule: q_lo >= mu* - q_tol.
+    sonnet = rec_rich["reasons"]["candidates"]
+    srow = next(c for c in sonnet if c["tier_id"] == "sonnet")
+    thr = rec_rich["reasons"]["gate_threshold"]
+    assert srow["admitted"] is True
+    assert srow["q_lo"] >= thr
+    # Savings recorded (cheaper than baseline -> negative cost_delta).
+    assert rec_rich["cost_delta"] < 0.0
+
+
+def test_admission_is_monotone_in_evidence(cfg):
+    """q_lo for a tier should rise monotonically as successes accumulate."""
+    prev = -1.0
+    for n in (0, 5, 10, 20, 40, 80):
+        st = store_with(cfg, successes(cfg, "polecat", "implement", "sonnet", n))
+        ins = E.inspect("polecat", "implement", cfg, st)
+        srow = next(t for t in ins["tiers"] if t["tier_id"] == "sonnet")
+        assert srow["q_lo"] >= prev - 1e-9
+        prev = srow["q_lo"]
+
+
+def test_picks_cheapest_among_admitted(cfg):
+    """When both haiku and sonnet clear the gate, pick the cheapest (haiku)."""
+    recs = (
+        successes(cfg, "polecat", "implement", "haiku", 60)
+        + successes(cfg, "polecat", "implement", "sonnet", 60)
+    )
+    st = store_with(cfg, recs)
+    rec = E.recommend("polecat", "implement", cfg, st)
+    assert rec["tier_id"] == "haiku"
+    cands = {c["tier_id"]: c for c in rec["reasons"]["candidates"]}
+    assert cands["haiku"]["admitted"] and cands["sonnet"]["admitted"]
+    # haiku saves the most vs baseline.
+    assert rec["cost_delta"] == cands["haiku"]["cost_diff"] < 0.0
+
+
+# --------------------------------------------------------------------------- #
+# A single failure on a thin cell keeps the baseline                          #
+# --------------------------------------------------------------------------- #
+
+
+def test_single_failure_on_thin_cell_keeps_baseline(cfg):
+    st = store_with(cfg, failures(cfg, "polecat", "implement", "haiku", 1))
+    rec = E.recommend("polecat", "implement", cfg, st)
+    assert rec["tier_id"] == "opus"
+
+
+def test_one_failure_after_some_successes_can_revoke_admission(cfg):
+    """A late failure lowers q_lo; near the boundary it can flip back to baseline."""
+    base = successes(cfg, "polecat", "implement", "sonnet", 12)
+    # Without the failure, with 12 successes sonnet may or may not be admitted;
+    # assert the *direction*: adding a failure never increases the recommended
+    # aggressiveness (cost can only go up or stay, never further down).
+    st_ok = store_with(cfg, base)
+    st_bad = store_with(cfg, base + failures(cfg, "polecat", "implement", "sonnet", 1))
+    rec_ok = E.recommend("polecat", "implement", cfg, st_ok)
+    rec_bad = E.recommend("polecat", "implement", cfg, st_bad)
+    order = list(cfg.tier_ids)
+    assert order.index(rec_bad["tier_id"]) >= order.index(rec_ok["tier_id"])
+
+
+# --------------------------------------------------------------------------- #
+# Critical class never downgrades                                             #
+# --------------------------------------------------------------------------- #
+
+
+def test_critical_never_downgrades_even_with_overwhelming_evidence(cfg):
+    st = store_with(cfg, successes(cfg, "polecat", "implement", "haiku", 200))
+    rec = E.recommend("polecat", "implement", cfg, st, tol_class="Critical")
+    assert rec["tier_id"] == cfg.baseline_tier_id
+    assert rec["reasons"]["critical"] is True
+    # Every cheaper candidate is rejected with the Critical reason.
+    for c in rec["reasons"]["candidates"]:
+        if c["action"] == "down":
+            assert c["admitted"] is False
+            assert "critical" in c["reason"].lower()
+
+
+def test_critical_via_config_override(cfg):
+    """A per-cell [[agent.cell]] tol_class=Critical override is honoured."""
+    raw = {
+        "advisor": {"baseline_tier": "opus", "default_provider": "claude"},
+        "tier": [
+            {"id": "haiku", "rank": 1, "in_cost": 0.8, "out_cost": 4.0},
+            {"id": "sonnet", "rank": 2, "in_cost": 3.0, "out_cost": 15.0},
+            {"id": "opus", "rank": 3, "in_cost": 15.0, "out_cost": 75.0},
+        ],
+        "agent": [
+            {"name": "refinery", "shapes": ["judge"],
+             "cell": [{"shape": "judge", "tol_class": "Critical"}]},
+        ],
+    }
+    cfg2 = C.from_mapping(raw)
+    assert cfg2.tol_class_for("refinery", "judge").is_critical
+    st = store_with(cfg2, successes(cfg2, "refinery", "judge", "haiku", 200))
+    rec = E.recommend("refinery", "judge", cfg2, st)
+    assert rec["tier_id"] == "opus"
+
+
+# --------------------------------------------------------------------------- #
+# Structured reasons + cost_delta populated on every call                     #
+# --------------------------------------------------------------------------- #
+
+
+def test_reasons_and_cost_delta_populated(cfg):
+    st = store_with(cfg, successes(cfg, "polecat", "implement", "sonnet", 40))
+    rec = E.recommend("polecat", "implement", cfg, st)
+    # top-level shape
+    for key in ("tier_id", "model", "rationale", "cost_delta", "reasons", "posterior_summary"):
+        assert key in rec
+    assert isinstance(rec["rationale"], str) and rec["rationale"]
+    assert isinstance(rec["cost_delta"], float)
+    r = rec["reasons"]
+    # the audit contract surface (DESIGN §1.4 property 3)
+    for key in (
+        "candidates", "advised_tier", "eval_flag", "baseline_mean",
+        "gate_threshold", "class", "q_tol", "n_dep", "cell",
+    ):
+        assert key in r
+    assert r["advised_tier"] == rec["tier_id"]
+    # every candidate carries q_lo, exp_loss (or inf flag), cost_diff
+    for c in r["candidates"]:
+        assert "q_lo" in c and "cost_diff" in c
+        assert ("exp_loss" in c) and ("exp_loss_inf" in c)
+    # posterior_summary spans the whole roster
+    assert set(rec["posterior_summary"]) == set(cfg.tier_ids)
+
+
+def test_cost_delta_matches_rate_sheet(cfg):
+    """cost_delta = -(cost(opus) - cost(sonnet)) at the implement budget."""
+    st = store_with(cfg, successes(cfg, "polecat", "implement", "sonnet", 40))
+    rec = E.recommend("polecat", "implement", cfg, st)
+    assert rec["tier_id"] == "sonnet"
+    tin, tout = cfg.budget_for("implement")
+    expect = -(cfg.tier("opus").cost(tin, tout) - cfg.tier("sonnet").cost(tin, tout))
+    assert rec["cost_delta"] == pytest.approx(expect, abs=1e-9)
+
+
+def test_realised_token_counts_override_budget(cfg):
+    st = store_with(cfg, successes(cfg, "polecat", "implement", "sonnet", 40))
+    rec = E.recommend("polecat", "implement", cfg, st, tok_in=10000, tok_out=5000)
+    assert rec["reasons"]["representative_budget"] is False
+    expect = -(cfg.tier("opus").cost(10000, 5000) - cfg.tier("sonnet").cost(10000, 5000))
+    assert rec["cost_delta"] == pytest.approx(expect, abs=1e-9)
+
+
+# --------------------------------------------------------------------------- #
+# Determinism                                                                  #
+# --------------------------------------------------------------------------- #
+
+
+def test_determinism_same_inputs_same_output(cfg):
+    st = store_with(cfg, successes(cfg, "polecat", "implement", "sonnet", 25))
+    a = E.recommend("polecat", "implement", cfg, st, seed=7)
+    b = E.recommend("polecat", "implement", cfg, st, seed=7)
+    assert a == b
+    # Even a different seed yields the same result (v1 rule is LCB-deterministic).
+    c = E.recommend("polecat", "implement", cfg, st, seed=99)
+    assert a["tier_id"] == c["tier_id"]
+    assert a["cost_delta"] == c["cost_delta"]
+
+
+def test_inspect_is_deterministic(cfg):
+    st = store_with(cfg, successes(cfg, "polecat", "implement", "sonnet", 25))
+    assert E.inspect("polecat", "implement", cfg, st) == E.inspect("polecat", "implement", cfg, st)
+
+
+# --------------------------------------------------------------------------- #
+# Gate arithmetic + LCB                                                       #
+# --------------------------------------------------------------------------- #
+
+
+def test_wilson_lcb_formula():
+    cell = S.Cell(a=8.0, b=2.0)  # mean 0.8
+    z = 1.645
+    expected = max(0.0, cell.mean - z * cell.stderr)
+    assert E.wilson_lcb(cell, z) == pytest.approx(expected)
+
+
+def test_wilson_lcb_floored_at_zero():
+    cell = S.Cell(a=1.0, b=1.0)  # mean 0.5, big sd
+    assert E.wilson_lcb(cell, 5.0) == 0.0
+
+
+def test_gate_threshold_is_mu_star_minus_qtol(cfg):
+    st = S.CellStore.cold_start(cfg)
+    rec = E.recommend("polecat", "implement", cfg, st)
+    mu_star = rec["reasons"]["baseline_mean"]
+    q_tol = rec["reasons"]["q_tol"]
+    assert rec["reasons"]["gate_threshold"] == pytest.approx(mu_star - q_tol)
+
+
+# --------------------------------------------------------------------------- #
+# Safety hatch (force_baseline)                                               #
+# --------------------------------------------------------------------------- #
+
+
+def test_force_baseline_disables_downgrade(cfg):
+    raw = {
+        "advisor": {"baseline_tier": "opus"},
+        "tier": [
+            {"id": "haiku", "rank": 1, "in_cost": 0.8, "out_cost": 4.0},
+            {"id": "sonnet", "rank": 2, "in_cost": 3.0, "out_cost": 15.0},
+            {"id": "opus", "rank": 3, "in_cost": 15.0, "out_cost": 75.0},
+        ],
+        "agent": [
+            {"name": "polecat", "shapes": ["implement"],
+             "cell": [{"shape": "implement", "force_baseline": True}]},
+        ],
+    }
+    cfg2 = C.from_mapping(raw)
+    st = store_with(cfg2, successes(cfg2, "polecat", "implement", "haiku", 200))
+    rec = E.recommend("polecat", "implement", cfg2, st)
+    assert rec["tier_id"] == "opus"
+    assert rec["reasons"]["forced_baseline"] is True
+    assert "safety hatch" in rec["rationale"].lower()
+
+
+# --------------------------------------------------------------------------- #
+# inspect surface                                                             #
+# --------------------------------------------------------------------------- #
+
+
+def test_inspect_reports_per_tier_and_drop_ci(cfg):
+    st = store_with(cfg, successes(cfg, "polecat", "implement", "sonnet", 5))
+    ins = E.inspect("polecat", "implement", cfg, st)
+    assert {t["tier_id"] for t in ins["tiers"]} == set(cfg.tier_ids)
+    for t in ins["tiers"]:
+        for k in ("a", "b", "mean", "q_lo", "n", "ci_halfwidth", "admitted"):
+            assert k in t
+        if t["role"] == "candidate":
+            assert t["quality_drop_ci"] is not None
+            assert {"lo", "mean", "hi", "q_tol", "exceeds_tol"} <= set(t["quality_drop_ci"])
+        else:
+            assert t["quality_drop_ci"] is None
+
+
+def test_inspect_widest_gating_cell_points_at_widest_rejected(cfg):
+    # A few sonnet obs -> both cheaper cells gating; haiku (no data) is widest.
+    st = store_with(cfg, successes(cfg, "polecat", "implement", "sonnet", 3))
+    ins = E.inspect("polecat", "implement", cfg, st)
+    wg = ins["widest_gating_cell"]
+    assert wg is not None
+    # It must be a rejected candidate with the widest CI half-width.
+    cand_hw = {
+        t["tier_id"]: t["ci_halfwidth"]
+        for t in ins["tiers"]
+        if t["role"] == "candidate" and not t["admitted"] and t["ci_halfwidth"] > cfg.hp.theta_eval
+    }
+    assert wg["tier_id"] == max(cand_hw, key=cand_hw.get)
+    assert "run an eval" in wg["rationale"]
+
+
+def test_inspect_no_gating_cell_when_admitted(cfg):
+    st = store_with(cfg, successes(cfg, "polecat", "implement", "haiku", 80))
+    ins = E.inspect("polecat", "implement", cfg, st)
+    # haiku admitted (lots of evidence) -> it is not "gating".
+    assert ins["widest_gating_cell"] is None or ins["widest_gating_cell"]["tier_id"] != "haiku"
+
+
+# --------------------------------------------------------------------------- #
+# Store: cache round-trip == rebuild from JSONL                               #
+# --------------------------------------------------------------------------- #
+
+
+def test_cache_rebuild_equivalence(cfg, tmp_path):
+    recs = (
+        successes(cfg, "polecat", "implement", "sonnet", 30)
+        + failures(cfg, "polecat", "implement", "haiku", 4)
+        + successes(cfg, "mayor", "judge", "sonnet", 10)
+    )
+    jsonl = tmp_path / "invocations.jsonl"
+    jsonl.write_text("".join(json.dumps(r) + "\n" for r in recs))
+
+    rebuilt = S.CellStore.rebuild(cfg, str(jsonl))
+    cache = tmp_path / "advisor-cells.json"
+    rebuilt.save(str(cache))
+    loaded = S.CellStore.load(cfg, str(cache))
+
+    def snap(st):
+        return {
+            k: (round(v.a, 9), round(v.b, 9), v.n)
+            for k, v in st.observed_cells().items()
+        }
+
+    assert snap(rebuilt) == snap(loaded)
+    # recommendations identical from either store
+    assert (
+        E.recommend("polecat", "implement", cfg, rebuilt)["tier_id"]
+        == E.recommend("polecat", "implement", cfg, loaded)["tier_id"]
+    )
+
+
+def test_cache_is_byte_stable(cfg, tmp_path):
+    recs = successes(cfg, "polecat", "implement", "sonnet", 12)
+    st = store_with(cfg, recs)
+    c1 = tmp_path / "a.json"
+    c2 = tmp_path / "b.json"
+    st.save(str(c1))
+    S.CellStore.load(cfg, str(c1)).save(str(c2))
+    assert c1.read_text() == c2.read_text()
+
+
+def test_replay_order_independence_of_final_posterior(cfg, tmp_path):
+    """Beta updates are additive -> final (a,b) is order-independent."""
+    recs = (
+        successes(cfg, "polecat", "implement", "sonnet", 7)
+        + failures(cfg, "polecat", "implement", "sonnet", 3)
+    )
+    fwd = store_with(cfg, recs)
+    rev = store_with(cfg, list(reversed(recs)))
+    k = cell_key(cfg.default_provider, "polecat", "implement", "sonnet")
+    assert (fwd.get(k).a, fwd.get(k).b, fwd.get(k).n) == (rev.get(k).a, rev.get(k).b, rev.get(k).n)
+
+
+# --------------------------------------------------------------------------- #
+# Channel weights                                                             #
+# --------------------------------------------------------------------------- #
+
+
+def test_review_channel_weighted_higher_than_close(cfg):
+    """A review success (w=3) moves the posterior ~3x a close success (w=1)."""
+    one_review = store_with(cfg, [q_record(cfg, "polecat", "implement", "sonnet", 1, channel="review")])
+    k = cell_key(cfg.default_provider, "polecat", "implement", "sonnet")
+    a0, b0 = S.cold_start_prior(cfg, "sonnet", "opus")
+    cell = one_review.get(k)
+    # a increased by w_review (=3); b unchanged.
+    assert cell.a == pytest.approx(a0 + cfg.hp.w_review)
+    assert cell.b == pytest.approx(b0)
+
+
+def test_explicit_weight_overrides_channel(cfg):
+    rec = {"kind": "quality", "cell_key": cell_key(cfg.default_provider, "polecat", "implement", "sonnet"),
+           "q": 1, "channel": "close", "weight": 5, "ts": "2026-06-01T00:00:00Z"}
+    st = store_with(cfg, [rec])
+    a0, _ = S.cold_start_prior(cfg, "sonnet", "opus")
+    assert st.get(rec["cell_key"]).a == pytest.approx(a0 + 5)
+
+
+def test_non_binary_q_is_dropped(cfg):
+    bad = {"kind": "quality", "cell_key": cell_key(cfg.default_provider, "polecat", "implement", "sonnet"),
+           "q": 0.5, "ts": "2026-06-01T00:00:00Z"}
+    st = store_with(cfg, [bad])
+    assert st.get(bad["cell_key"]).n == 0
+
+
+# --------------------------------------------------------------------------- #
+# Config validation                                                           #
+# --------------------------------------------------------------------------- #
+
+
+def test_config_rejects_duplicate_tier_ids():
+    raw = {"tier": [
+        {"id": "x", "rank": 1, "in_cost": 1, "out_cost": 1},
+        {"id": "x", "rank": 2, "in_cost": 2, "out_cost": 2},
+    ]}
+    with pytest.raises(C.ConfigError):
+        C.from_mapping(raw)
+
+
+def test_config_rejects_unknown_baseline():
+    raw = {"advisor": {"baseline_tier": "nope"},
+           "tier": [{"id": "x", "rank": 1, "in_cost": 1, "out_cost": 1}]}
+    with pytest.raises(C.ConfigError):
+        C.from_mapping(raw)
+
+
+def test_config_sorts_roster_by_cost_order():
+    raw = {"tier": [
+        {"id": "opus", "rank": 3, "in_cost": 15, "out_cost": 75},
+        {"id": "haiku", "rank": 1, "in_cost": 0.8, "out_cost": 4},
+        {"id": "sonnet", "rank": 2, "in_cost": 3, "out_cost": 15},
+    ]}
+    cfg = C.from_mapping(raw)
+    assert cfg.tier_ids == ("haiku", "sonnet", "opus")
+    assert cfg.baseline_tier_id == "opus"  # default = most-capable
+
+
+def test_arbitrary_k_tiers():
+    """Nothing assumes K=3: a 2-tier and a 5-tier roster both work."""
+    two = C.from_mapping({"tier": [
+        {"id": "cheap", "rank": 1, "in_cost": 1, "out_cost": 1},
+        {"id": "dear", "rank": 2, "in_cost": 9, "out_cost": 9},
+    ]})
+    assert two.tier_ids == ("cheap", "dear")
+    st = S.CellStore.cold_start(two)
+    rec = E.recommend("polecat", "implement", two, st)
+    assert rec["tier_id"] == "dear"  # baseline
+
+    five = C.from_mapping({"tier": [
+        {"id": f"t{i}", "rank": i, "in_cost": float(i), "out_cost": float(i)} for i in range(1, 6)
+    ]})
+    assert len(five.tier_ids) == 5
+    st5 = S.CellStore.cold_start(five)
+    rec5 = E.recommend("polecat", "implement", five, st5)
+    assert rec5["tier_id"] == "t5"
+
+
+def test_sample_toml_parses_and_is_consistent(tmp_path):
+    p = tmp_path / "advisor.toml"
+    C.write_sample_toml(str(p))
+    cfg = C.load_config(str(p))
+    assert cfg.tier_ids == ("haiku", "sonnet", "opus")
+    assert cfg.baseline_tier_id == "opus"
+    assert cfg.tol_class_for("refinery", "judge").is_critical  # pinned in the sample
+    assert cfg.budget_for("implement") == (4000.0, 1500.0)

--- a/model-advisor/tests/test_evalsched.py
+++ b/model-advisor/tests/test_evalsched.py
@@ -1,0 +1,366 @@
+"""Tests for Layer-4 auto-scheduled eval (``modeladvisor.evalsched``, DESIGN §5.4).
+
+Covers bead ``bh-0r9``'s acceptance:
+
+- ``schedule_evals`` ranks a wide, high-savings gating cell above a wide but
+  low-savings one (``score = ci_halfwidth × unlock_value``);
+- it respects ``max_evals`` (the eval budget);
+- it skips cells whose CI half-width is at or below ``theta_eval``;
+- ``unlock_value`` is the *real* tier-cost differential at the shape budget;
+- a fully-admitted / tight cell produces NO eval request;
+- ``emit_eval_beads(dry_run=True)`` returns command strings and creates NOTHING
+  (asserted by making ``subprocess.run`` explode if it is ever called);
+- determinism: identical inputs → byte-identical schedules.
+
+Fixtures are built exactly as ``test_engine.py`` builds them (a ``from_mapping``
+config + a cold-start ``CellStore`` fed synthetic ``kind=quality`` records). The
+two shapes share an identical cold-start posterior shape but very different
+representative token budgets, so their gating cells have the SAME CI half-width
+and differ ONLY in unlock-value — isolating the ranking signal.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+# Make the pack root importable when pytest is run from anywhere (as test_engine).
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+
+from modeladvisor import config as C  # noqa: E402
+from modeladvisor import engine as E  # noqa: E402
+from modeladvisor import evalsched as V  # noqa: E402
+from modeladvisor import store as S  # noqa: E402
+from modeladvisor.store import cell_key  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures + helpers                                                            #
+# --------------------------------------------------------------------------- #
+
+# One agent, two shapes. Roster haiku ≺ sonnet ≺ opus, baseline opus.
+#   implement: HUGE representative budget  -> big unlock-value
+#   lookup:    TINY representative budget  -> tiny unlock-value
+# Both cold-start cheaper tiers gate on uncertainty with the SAME CI half-width
+# (posterior shape is budget-independent), so the schedule's ordering is driven
+# purely by unlock-value -> this is the clean ranking test.
+_RAW = {
+    "advisor": {"baseline_tier": "opus", "default_provider": "claude"},
+    "tier": [
+        {"id": "haiku", "rank": 1, "in_cost": 0.80, "out_cost": 4.00,
+         "model": "claude-haiku-4-5"},
+        {"id": "sonnet", "rank": 2, "in_cost": 3.00, "out_cost": 15.00,
+         "model": "claude-sonnet-4-5"},
+        {"id": "opus", "rank": 3, "in_cost": 15.00, "out_cost": 75.00,
+         "model": "claude-opus-4-8"},
+    ],
+    "shape": [
+        {"name": "implement", "tol_class": "Moderate",
+         "tok_in": 100_000, "tok_out": 40_000},
+        {"name": "lookup", "tol_class": "Lenient", "tok_in": 100, "tok_out": 50},
+    ],
+    "agent": [{"name": "polecat", "shapes": ["implement", "lookup"]}],
+}
+
+
+@pytest.fixture
+def cfg() -> C.AdvisorConfig:
+    """Single-agent (polecat) config; the only agent_shapes entry we assert on.
+
+    NB: ``from_mapping`` re-injects the documented default agents for any agent it
+    didn't mention, so ``cfg.agent_shapes`` also contains mayor/witness/etc. The
+    scheduler sweeps all of them; tests filter to the polecat cells they pin.
+    """
+    return C.from_mapping(_RAW)
+
+
+def q_record(cfg, agent, shape, tier, q, *, channel="close", i=0):
+    """One synthetic ``kind=quality`` telemetry record (as in test_engine)."""
+    return {
+        "schema_version": "advisor.v1",
+        "kind": "quality",
+        "ts": f"2026-06-01T00:{i // 60:02d}:{i % 60:02d}Z",
+        "bead_id": f"bh-{agent}-{shape}-{tier}-{i}",
+        "cell_key": cell_key(cfg.default_provider, agent, shape, tier),
+        "q": q,
+        "channel": channel,
+    }
+
+
+def successes(cfg, agent, shape, tier, n, *, channel="close"):
+    return [q_record(cfg, agent, shape, tier, 1, channel=channel, i=i) for i in range(n)]
+
+
+def store_with(cfg, records):
+    st = S.CellStore.cold_start(cfg)
+    st.apply_records(records)
+    return st
+
+
+def polecat_reqs(reqs):
+    """Just the polecat requests, keyed by shape (drops defaulted sibling agents)."""
+    return {r.shape: r for r in reqs if r.agent == "polecat"}
+
+
+# --------------------------------------------------------------------------- #
+# Ranking: wide + high-savings beats wide + low-savings                        #
+# --------------------------------------------------------------------------- #
+
+
+def test_ranks_wide_high_savings_cell_first(cfg):
+    """At cold start both shapes gate with equal CI half-width; the big-budget
+    (high unlock-value) cell must rank strictly above the tiny-budget one."""
+    st = S.CellStore.cold_start(cfg)
+    reqs = V.schedule_evals(cfg, st, max_evals=99)
+    by_shape = polecat_reqs(reqs)
+
+    assert {"implement", "lookup"} <= set(by_shape)
+    impl, look = by_shape["implement"], by_shape["lookup"]
+
+    # Same posterior shape -> same CI half-width; ranking is pure unlock-value.
+    assert impl.ci_halfwidth == pytest.approx(look.ci_halfwidth)
+    assert impl.unlock_value > look.unlock_value
+    assert impl.score > look.score
+
+    # And the global ordering puts the implement cell ahead of the lookup cell.
+    order = [r.cell_key for r in reqs]
+    assert order.index(impl.cell_key) < order.index(look.cell_key)
+    # The single highest-scoring request overall is an `implement` cell.
+    assert reqs[0].shape == "implement"
+
+
+def test_schedule_sorted_by_score_descending(cfg):
+    """The returned list is monotone non-increasing in score (the ranking key)."""
+    st = S.CellStore.cold_start(cfg)
+    reqs = V.schedule_evals(cfg, st, max_evals=99)
+    scores = [r.score for r in reqs]
+    assert scores == sorted(scores, reverse=True)
+    assert len(reqs) >= 2  # several gating cells exist at cold start
+
+
+# --------------------------------------------------------------------------- #
+# unlock_value is the real tier-cost differential at the shape budget          #
+# --------------------------------------------------------------------------- #
+
+
+def test_unlock_value_from_real_tier_costs(cfg):
+    """unlock_value == cost(baseline) − cost(candidate) at the shape budget."""
+    st = S.CellStore.cold_start(cfg)
+    reqs = polecat_reqs(V.schedule_evals(cfg, st, max_evals=99))
+    impl = reqs["implement"]
+
+    # Cheapest tier (haiku) is the widest cold-start gating candidate.
+    assert impl.tier_id == "haiku"
+    tin, tout = cfg.budget_for("implement")
+    expect = cfg.tier("opus").cost(tin, tout) - cfg.tier("haiku").cost(tin, tout)
+    assert impl.unlock_value == pytest.approx(expect)
+    assert impl.score == pytest.approx(impl.ci_halfwidth * expect)
+    assert impl.unlock_value > 0.0  # a downgrade always saves
+
+
+def test_cell_key_and_fields_consistent(cfg):
+    """The request's cell_key matches its (provider, agent, shape, tier) fields."""
+    st = S.CellStore.cold_start(cfg)
+    impl = polecat_reqs(V.schedule_evals(cfg, st, max_evals=99))["implement"]
+    assert impl.cell_key == cell_key(impl.provider, impl.agent, impl.shape, impl.tier_id)
+    assert impl.provider == "claude"
+
+
+# --------------------------------------------------------------------------- #
+# max_evals (the eval budget)                                                  #
+# --------------------------------------------------------------------------- #
+
+
+def test_respects_max_evals(cfg):
+    st = S.CellStore.cold_start(cfg)
+    full = V.schedule_evals(cfg, st, max_evals=99)
+    assert len(full) > 1  # there are several gating cells across the roster
+
+    top1 = V.schedule_evals(cfg, st, max_evals=1)
+    assert len(top1) == 1
+    # max_evals keeps the HIGHEST-scoring request (a high-unlock implement cell).
+    assert top1[0].cell_key == full[0].cell_key
+    assert top1[0].score == max(r.score for r in full)
+
+    top3 = V.schedule_evals(cfg, st, max_evals=3)
+    assert len(top3) == 3
+    assert [r.cell_key for r in top3] == [r.cell_key for r in full[:3]]
+
+
+def test_max_evals_zero_or_negative_returns_empty(cfg):
+    st = S.CellStore.cold_start(cfg)
+    assert V.schedule_evals(cfg, st, max_evals=0) == []
+    assert V.schedule_evals(cfg, st, max_evals=-5) == []
+
+
+# --------------------------------------------------------------------------- #
+# theta_eval: sub-threshold cells are skipped                                  #
+# --------------------------------------------------------------------------- #
+
+
+def test_skips_cells_at_or_below_theta_eval(cfg):
+    """A theta_eval above every gating cell's CI half-width schedules nothing."""
+    st = S.CellStore.cold_start(cfg)
+    # Cold-start gating cells have CI half-width ~0.37; a theta_eval of 1.0 is
+    # above any possible half-width (the CI half-width is bounded by ~0.5).
+    assert V.schedule_evals(cfg, st, theta_eval=1.0) == []
+
+    # The default (cfg.hp.theta_eval = 0.10) does schedule them.
+    assert len(V.schedule_evals(cfg, st)) > 0
+
+
+def test_stricter_theta_eval_prunes_narrow_cells(cfg):
+    """Raising theta_eval can only shrink (never grow) the scheduled set."""
+    st = S.CellStore.cold_start(cfg)
+    base = V.schedule_evals(cfg, st, max_evals=99, theta_eval=cfg.hp.theta_eval)
+    strict = V.schedule_evals(cfg, st, max_evals=99, theta_eval=0.30)
+    base_keys = {r.cell_key for r in base}
+    strict_keys = {r.cell_key for r in strict}
+    assert strict_keys <= base_keys
+    # Every surviving cell is strictly wider than the (stricter) threshold.
+    assert all(r.ci_halfwidth > 0.30 for r in strict)
+
+
+def test_theta_eval_defaults_to_config(cfg):
+    """Passing theta_eval=None is identical to passing cfg.hp.theta_eval."""
+    st = S.CellStore.cold_start(cfg)
+    a = V.schedule_evals(cfg, st, max_evals=99, theta_eval=None)
+    b = V.schedule_evals(cfg, st, max_evals=99, theta_eval=cfg.hp.theta_eval)
+    assert [r.to_dict() for r in a] == [r.to_dict() for r in b]
+
+
+# --------------------------------------------------------------------------- #
+# A tight / fully-admitted cell schedules no eval                             #
+# --------------------------------------------------------------------------- #
+
+
+def test_admitted_tight_cell_produces_no_request(cfg):
+    """When every cheaper tier on a shape is admitted (tight CIs), that shape is
+    not gating and yields no eval request."""
+    # Admit BOTH haiku and sonnet on lookup -> no candidate is gating.
+    recs = (
+        successes(cfg, "polecat", "lookup", "haiku", 120)
+        + successes(cfg, "polecat", "lookup", "sonnet", 120)
+    )
+    st = store_with(cfg, recs)
+
+    # Sanity: the engine itself reports no widest-gating cell for that pair.
+    assert E.inspect("polecat", "lookup", cfg, st)["widest_gating_cell"] is None
+
+    reqs = V.schedule_evals(cfg, st, max_evals=99)
+    assert "lookup" not in polecat_reqs(reqs)
+    # polecat/implement is still cold -> still gating, still scheduled.
+    assert "implement" in polecat_reqs(reqs)
+
+
+# --------------------------------------------------------------------------- #
+# emit_eval_beads: dry-run returns commands and creates NOTHING                 #
+# --------------------------------------------------------------------------- #
+
+
+def test_emit_dry_run_returns_commands_and_runs_nothing(cfg, monkeypatch):
+    """dry_run=True must return command strings and never invoke subprocess."""
+    # Make ANY subprocess call explode — proves the dry-run path shells out to
+    # nothing (creates no beads).
+    def _boom(*a, **k):  # pragma: no cover - asserted not to run
+        raise AssertionError("emit_eval_beads(dry_run=True) must not run subprocess")
+
+    monkeypatch.setattr(V.subprocess, "run", _boom)
+
+    st = S.CellStore.cold_start(cfg)
+    reqs = V.schedule_evals(cfg, st, max_evals=3)
+    cmds = V.emit_eval_beads(reqs, dry_run=True)
+
+    assert len(cmds) == len(reqs)
+    for cmd, req in zip(cmds, reqs):
+        assert isinstance(cmd, str)
+        assert cmd.startswith("gc bd create ")
+        assert "-t task" in cmd
+        assert f"-l {V.EVAL_LABEL}" in cmd
+        assert "--silent" in cmd
+        # The title embeds the cell + the unlock economics.
+        assert req.cell_key in cmd
+        assert "CI hw" in cmd and "unlocks $" in cmd
+
+
+def test_emit_dry_run_is_default(cfg, monkeypatch):
+    """dry_run defaults to True (safe): no subprocess even without the kwarg."""
+    monkeypatch.setattr(
+        V.subprocess, "run",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("must not run")),
+    )
+    st = S.CellStore.cold_start(cfg)
+    cmds = V.emit_eval_beads(V.schedule_evals(cfg, st, max_evals=2))
+    assert all(c.startswith("gc bd create ") for c in cmds)
+
+
+def test_emit_dry_run_threads_rig(cfg):
+    """A rig is threaded into the command as `--rig <rig>`."""
+    st = S.CellStore.cold_start(cfg)
+    reqs = V.schedule_evals(cfg, st, max_evals=1)
+    cmds = V.emit_eval_beads(reqs, dry_run=True, rig="frontend")
+    assert "--rig frontend" in cmds[0]
+    # No rig -> no --rig flag.
+    assert "--rig" not in V.emit_eval_beads(reqs, dry_run=True)[0]
+
+
+def test_emit_empty_requests_is_noop(cfg, monkeypatch):
+    monkeypatch.setattr(
+        V.subprocess, "run",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("must not run")),
+    )
+    assert V.emit_eval_beads([], dry_run=True) == []
+    assert V.emit_eval_beads([], dry_run=False) == []
+
+
+def test_emit_apply_parses_bead_ids(cfg, monkeypatch):
+    """dry_run=False shells out once per request and returns the created ids."""
+    calls = []
+
+    class _Proc:
+        def __init__(self, out):
+            self.stdout = out
+            self.stderr = ""
+
+    def _fake_run(argv, **kw):
+        calls.append(argv)
+        # gc bd create --silent prints just the new id.
+        return _Proc(f"bh-eval-{len(calls)}\n")
+
+    monkeypatch.setattr(V.subprocess, "run", _fake_run)
+
+    st = S.CellStore.cold_start(cfg)
+    reqs = V.schedule_evals(cfg, st, max_evals=2)
+    ids = V.emit_eval_beads(reqs, dry_run=False)
+
+    assert ids == ["bh-eval-1", "bh-eval-2"]
+    assert len(calls) == 2
+    # Each call is a real gc bd create argv (list form, not a shell string).
+    for argv in calls:
+        assert argv[:3] == ["gc", "bd", "create"]
+        assert "--silent" in argv
+
+
+# --------------------------------------------------------------------------- #
+# Determinism                                                                  #
+# --------------------------------------------------------------------------- #
+
+
+def test_schedule_is_deterministic(cfg):
+    st = store_with(cfg, successes(cfg, "polecat", "implement", "sonnet", 7))
+    a = V.schedule_evals(cfg, st, max_evals=99)
+    b = V.schedule_evals(cfg, st, max_evals=99)
+    assert [r.to_dict() for r in a] == [r.to_dict() for r in b]
+    # Stable order even across the tie-break (sorted by (-score, cell_key)).
+    keys = [r.cell_key for r in a]
+    assert keys == sorted(set(keys), key=lambda k: ([-r.score for r in a if r.cell_key == k][0], k))
+
+
+def test_emit_dry_run_is_deterministic(cfg):
+    st = S.CellStore.cold_start(cfg)
+    reqs = V.schedule_evals(cfg, st, max_evals=4)
+    assert V.emit_eval_beads(reqs, dry_run=True) == V.emit_eval_beads(reqs, dry_run=True)

--- a/model-advisor/tests/test_federation.py
+++ b/model-advisor/tests/test_federation.py
@@ -1,0 +1,331 @@
+"""Tests for multi-tenant posterior federation (DESIGN §7.3).
+
+Federation shares per-cell **aggregates** — never raw telemetry — so thin cells
+converge faster by borrowing a peer repo's evidence, while a trust scaling +
+per-cell mass cap keep a peer from ever dominating local evidence. The
+load-bearing properties we assert:
+
+- **privacy** — an export carries ONLY ``a_obs``/``b_obs``/``n`` per cell (no
+  ``ts``/``last_update``/``bead_id``/rationale/extra keys) and round-trips through
+  JSON;
+- **prior subtraction** — a cell carrying only prior mass is excluded (or exports
+  ``a_obs ≈ 0``); the exporter's prior never leaks and is never double-counted;
+- **thin vs rich (THE key test)** — a confident peer moves a *thin* local cell's
+  mean materially but barely moves a *rich* local cell (the trust cap);
+- **trust = 0** ⇒ no peer influence; **empty peers** ⇒ store unchanged;
+- **fail closed** — a bad peer schema (and other malformed peers) raise;
+- determinism.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+import pytest
+
+# Make the pack root importable when pytest is run from anywhere.
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+
+from modeladvisor import config as C  # noqa: E402
+from modeladvisor import federation as F  # noqa: E402
+from modeladvisor import store as S  # noqa: E402
+from modeladvisor.store import cell_key, cold_start_prior  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures + helpers                                                            #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def cfg() -> C.AdvisorConfig:
+    """Default Claude haiku/sonnet/opus roster, baseline = opus."""
+    return C.default_config()
+
+
+def _q(agent, shape, tier, q, i, *, provider="claude"):
+    return {
+        "kind": "quality",
+        "ts": f"2026-06-01T00:00:{i % 60:02d}Z",
+        "bead_id": f"bh-{agent}-{shape}-{tier}-{i}",
+        "cell_key": cell_key(provider, agent, shape, tier),
+        "q": q,
+        "channel": "close",
+    }
+
+
+def _wins(agent, shape, tier, n):
+    return [_q(agent, shape, tier, 1, i) for i in range(n)]
+
+
+def _losses(agent, shape, tier, n):
+    return [_q(agent, shape, tier, 0, i) for i in range(n)]
+
+
+def _store_with(cfg, records) -> S.CellStore:
+    st = S.CellStore.cold_start(cfg)
+    st.apply_records(records)
+    return st
+
+
+def _mean(cell) -> float:
+    return cell.a / (cell.a + cell.b)
+
+
+# --------------------------------------------------------------------------- #
+# export — privacy contract: only a_obs/b_obs/n, JSON round-trip                #
+# --------------------------------------------------------------------------- #
+
+
+def test_export_carries_only_aggregate_fields_and_round_trips(cfg):
+    # A cell with real, heterogeneous evidence (so a_obs != b_obs and n > 0).
+    st = _store_with(cfg, _wins("polecat", "implement", "sonnet", 7)
+                     + _losses("polecat", "implement", "sonnet", 3))
+    doc = F.export_aggregates(st)
+
+    assert doc["schema"] == F.SCHEMA
+    assert set(doc.keys()) == {"schema", "cells"}
+    key = cell_key("claude", "polecat", "implement", "sonnet")
+    assert key in doc["cells"]
+    agg = doc["cells"][key]
+    # EXACTLY the three numbers — nothing else may ride along.
+    assert set(agg.keys()) == {"a_obs", "b_obs", "n"}
+    assert agg["n"] == 10
+    # No telemetry/audit field leaks anywhere in the document text.
+    blob = json.dumps(doc)
+    for forbidden in ("ts", "last_update", "bead_id", "signal", "rationale",
+                      "channel", "weight", "2026-06-01"):
+        assert forbidden not in blob
+    # Survives a JSON round-trip unchanged (it is pure data).
+    assert json.loads(json.dumps(doc)) == doc
+
+
+def test_export_observed_only_excludes_untouched_cells(cfg):
+    st = _store_with(cfg, _wins("polecat", "implement", "sonnet", 4))
+    # Materialise an unrelated prior-only cell (n == 0) by reading it.
+    st.get(cell_key("claude", "polecat", "implement", "haiku"))
+    obs = F.export_aggregates(st, observed_only=True)
+    assert cell_key("claude", "polecat", "implement", "haiku") not in obs["cells"]
+    assert cell_key("claude", "polecat", "implement", "sonnet") in obs["cells"]
+    # With observed_only=False the prior-only cell appears, but prior-subtracted.
+    allc = F.export_aggregates(st, observed_only=False)
+    haiku = allc["cells"][cell_key("claude", "polecat", "implement", "haiku")]
+    assert haiku["a_obs"] == pytest.approx(0.0, abs=1e-9)
+    assert haiku["b_obs"] == pytest.approx(0.0, abs=1e-9)
+    assert haiku["n"] == 0
+
+
+# --------------------------------------------------------------------------- #
+# export — prior subtraction (no prior baked in, none leaked)                   #
+# --------------------------------------------------------------------------- #
+
+
+def test_export_subtracts_prior_so_aggregates_are_pure_evidence(cfg):
+    # 6 wins, 2 losses (all weight 1 via the close channel) => observed mass is
+    # exactly a_obs=6, b_obs=2 regardless of what the cold-start prior was.
+    st = _store_with(cfg, _wins("mayor", "judge", "sonnet", 6)
+                     + _losses("mayor", "judge", "sonnet", 2))
+    key = cell_key("claude", "mayor", "judge", "sonnet")
+    agg = F.export_aggregates(st)["cells"][key]
+    assert agg["a_obs"] == pytest.approx(6.0)
+    assert agg["b_obs"] == pytest.approx(2.0)
+
+    # And the posterior really did include a (non-zero) prior we subtracted off.
+    prior_a, prior_b = cold_start_prior(cfg, "sonnet",
+                                        cfg.baseline_tier_id_for("mayor", "judge"))
+    cell = st.get(key)
+    assert cell.a == pytest.approx(prior_a + 6.0)
+    assert cell.b == pytest.approx(prior_b + 2.0)
+
+
+def test_export_prior_only_baseline_cell_is_excluded(cfg):
+    # The baseline tier (opus) seeds Beta(8,2) — pure prior, no observations.
+    st = S.CellStore.cold_start(cfg)
+    st.get(cell_key("claude", "mayor", "judge", "opus"))  # materialise prior-only
+    doc = F.export_aggregates(st)  # observed_only default
+    assert doc["cells"] == {}
+
+
+# --------------------------------------------------------------------------- #
+# load_peer — validation, fail closed                                          #
+# --------------------------------------------------------------------------- #
+
+
+def test_load_peer_round_trips_from_dict_and_file(cfg, tmp_path):
+    st = _store_with(cfg, _wins("polecat", "implement", "sonnet", 5)
+                     + _losses("polecat", "implement", "sonnet", 1))
+    doc = F.export_aggregates(st)
+
+    from_dict = F.load_peer(doc)
+    assert from_dict["schema"] == F.SCHEMA
+    assert from_dict["cells"].keys() == doc["cells"].keys()
+
+    p = tmp_path / "peer.json"
+    p.write_text(json.dumps(doc), encoding="utf-8")
+    from_file = F.load_peer(str(p))
+    assert from_file == from_dict
+
+
+def test_load_peer_rejects_bad_schema_and_garbage(cfg, tmp_path):
+    # Wrong schema tag.
+    with pytest.raises(F.FederationError):
+        F.load_peer({"schema": "advisor.federation.v0", "cells": {}})
+    # Missing schema.
+    with pytest.raises(F.FederationError):
+        F.load_peer({"cells": {}})
+    # Not an object at all.
+    with pytest.raises(F.FederationError):
+        F.load_peer([1, 2, 3])  # type: ignore[arg-type]
+    # Missing file.
+    with pytest.raises(F.FederationError):
+        F.load_peer(str(tmp_path / "nope.json"))
+    # Non-JSON file content.
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not json", encoding="utf-8")
+    with pytest.raises(F.FederationError):
+        F.load_peer(str(bad))
+    # Malformed cell key.
+    with pytest.raises(F.FederationError):
+        F.load_peer({"schema": F.SCHEMA, "cells": {"bad-key": {"a_obs": 1, "b_obs": 1, "n": 2}}})
+    # Negative pseudocount (observed mass can never be negative).
+    good_key = cell_key("claude", "polecat", "implement", "sonnet")
+    with pytest.raises(F.FederationError):
+        F.load_peer({"schema": F.SCHEMA, "cells": {good_key: {"a_obs": -3.0, "b_obs": 1, "n": 2}}})
+    # Missing aggregate field.
+    with pytest.raises(F.FederationError):
+        F.load_peer({"schema": F.SCHEMA, "cells": {good_key: {"a_obs": 1.0, "n": 2}}})
+
+
+# --------------------------------------------------------------------------- #
+# merge — THE key test: thin moves, rich doesn't                               #
+# --------------------------------------------------------------------------- #
+
+
+def test_merge_moves_thin_cell_but_barely_moves_rich_cell(cfg):
+    key = cell_key("claude", "polecat", "implement", "sonnet")
+
+    # A confident peer: lots of successful observed mass on this cell.
+    peer_st = _store_with(cfg, _wins("polecat", "implement", "sonnet", 200))
+    peer = F.export_aggregates(peer_st)
+    peer_mean = peer["cells"][key]["a_obs"] / (
+        peer["cells"][key]["a_obs"] + peer["cells"][key]["b_obs"])
+    assert peer_mean > 0.95  # the peer is strongly positive
+
+    # THIN local cell: 2 wins, 2 losses (own mean 0.5).
+    thin = _store_with(cfg, _wins("polecat", "implement", "sonnet", 2)
+                       + _losses("polecat", "implement", "sonnet", 2))
+    thin_before = _mean(thin.get(key))
+    thin_after = _mean(merge := F.merge_peers(thin, [peer], trust=0.3).get(key))
+    assert thin_after > thin_before + 0.1  # peer pulls the thin cell up materially
+
+    # RICH local cell: same own mean (0.5) but 500 wins + 500 losses. With own
+    # mass (~1000) >> the trust-scaled peer mass (0.3 * 200 = 60), local evidence
+    # dominates and the peer can barely move it.
+    rich = _store_with(cfg, _wins("polecat", "implement", "sonnet", 500)
+                       + _losses("polecat", "implement", "sonnet", 500))
+    rich_before = _mean(rich.get(key))
+    rich_after = _mean(F.merge_peers(rich, [peer], trust=0.3).get(key))
+    rich_shift = rich_after - rich_before
+    thin_shift = thin_after - thin_before
+    assert rich_shift < 0.05                 # rich cell barely budges
+    assert thin_shift > 5.0 * rich_shift     # thin moves far more than rich (the cap)
+
+    # merge returned a NEW store; the local one was not mutated.
+    assert _mean(thin.get(key)) == pytest.approx(thin_before)
+
+
+def test_merge_max_peer_mass_caps_peer_injection(cfg):
+    key = cell_key("claude", "polecat", "implement", "sonnet")
+    peer_st = _store_with(cfg, _wins("polecat", "implement", "sonnet", 500))
+    peer = F.export_aggregates(peer_st)
+
+    thin = _store_with(cfg, _wins("polecat", "implement", "sonnet", 1)
+                       + _losses("polecat", "implement", "sonnet", 1))
+    uncapped = _mean(F.merge_peers(thin, [peer], trust=1.0).get(key))
+    capped = _mean(F.merge_peers(thin, [peer], trust=1.0, max_peer_mass=2.0).get(key))
+    thin_before = _mean(thin.get(key))
+    # The cap keeps the thin cell closer to its own mean than uncapped does.
+    assert thin_before < capped < uncapped
+
+
+# --------------------------------------------------------------------------- #
+# merge — no-influence / idempotence guarantees                                #
+# --------------------------------------------------------------------------- #
+
+
+def test_merge_trust_zero_has_no_peer_influence(cfg):
+    key = cell_key("claude", "polecat", "implement", "sonnet")
+    peer_st = _store_with(cfg, _wins("polecat", "implement", "sonnet", 300))
+    peer = F.export_aggregates(peer_st)
+
+    local = _store_with(cfg, _wins("polecat", "implement", "sonnet", 2)
+                        + _losses("polecat", "implement", "sonnet", 2))
+    merged = F.merge_peers(local, [peer], trust=0.0)
+    a, b = merged.get(key).a, merged.get(key).b
+    base = local.get(key)
+    assert (a, b) == pytest.approx((base.a, base.b))
+
+
+def test_merge_empty_peers_reproduces_local_store(cfg):
+    key = cell_key("claude", "polecat", "implement", "sonnet")
+    local = _store_with(cfg, _wins("polecat", "implement", "sonnet", 9)
+                        + _losses("polecat", "implement", "sonnet", 4))
+    for peers in ([], None):
+        merged = F.merge_peers(local, peers, trust=0.3)
+        # Same observed cells, same posteriors as the local store.
+        assert set(merged.observed_cells()) == set(local.observed_cells())
+        m, l = merged.get(key), local.get(key)
+        assert (m.a, m.b, m.n) == pytest.approx((l.a, l.b, l.n))
+        assert m.last_update == l.last_update
+
+
+def test_merge_does_not_invent_local_only_cells_for_absent_peers(cfg):
+    # A peer that only knows about a DIFFERENT cell must not touch a local cell,
+    # and must not fabricate the local cell out of thin air.
+    local_key = cell_key("claude", "polecat", "implement", "sonnet")
+    other_key = cell_key("claude", "refinery", "review", "haiku")
+    peer_st = _store_with(cfg, _wins("refinery", "review", "haiku", 50))
+    peer = F.export_aggregates(peer_st)
+
+    local = _store_with(cfg, _wins("polecat", "implement", "sonnet", 3)
+                        + _losses("polecat", "implement", "sonnet", 3))
+    merged = F.merge_peers(local, [peer], trust=0.5)
+    # Local cell unchanged (no peer evidence for it).
+    l, m = local.get(local_key), merged.get(local_key)
+    assert (m.a, m.b) == pytest.approx((l.a, l.b))
+    # The peer-only cell exists in the merge (its prior + peer mass) but carries
+    # n == 0 locally — it is borrowed prior, not local observation.
+    assert merged.get(other_key).n == 0
+    assert merged.get(other_key).a > local.get(other_key).a  # peer mass added
+
+
+def test_merge_accepts_raw_paths_and_is_deterministic(cfg, tmp_path):
+    key = cell_key("claude", "polecat", "implement", "sonnet")
+    peer_st = _store_with(cfg, _wins("polecat", "implement", "sonnet", 80)
+                          + _losses("polecat", "implement", "sonnet", 20))
+    p = tmp_path / "peer.json"
+    p.write_text(json.dumps(F.export_aggregates(peer_st)), encoding="utf-8")
+
+    local = _store_with(cfg, _wins("polecat", "implement", "sonnet", 2)
+                        + _losses("polecat", "implement", "sonnet", 1))
+    # Pass a raw path (string) — load_peer is invoked internally.
+    m1 = F.merge_peers(local, str(p), trust=0.4).get(key)
+    m2 = F.merge_peers(local, [str(p)], trust=0.4).get(key)
+    assert (m1.a, m1.b, m1.n) == pytest.approx((m2.a, m2.b, m2.n))
+
+
+def test_merge_sums_multiple_peers(cfg):
+    key = cell_key("claude", "polecat", "implement", "sonnet")
+    peer_a = F.export_aggregates(_store_with(cfg, _wins("polecat", "implement", "sonnet", 40)))
+    peer_b = F.export_aggregates(_store_with(cfg, _wins("polecat", "implement", "sonnet", 40)))
+    thin = _store_with(cfg, _wins("polecat", "implement", "sonnet", 1)
+                       + _losses("polecat", "implement", "sonnet", 1))
+
+    one = _mean(F.merge_peers(thin, [peer_a], trust=0.3).get(key))
+    two = _mean(F.merge_peers(thin, [peer_a, peer_b], trust=0.3).get(key))
+    # Two agreeing positive peers pull the thin cell higher than one alone.
+    assert two > one

--- a/model-advisor/tests/test_hierarchical.py
+++ b/model-advisor/tests/test_hierarchical.py
@@ -1,0 +1,306 @@
+"""Tests for the empirical-Bayes hierarchical pooler (DESIGN §1.3 / §7.3).
+
+The closed-form ``CellStore.pooled`` shrinks every cell by a fixed
+``pool_lambda`` fraction; :mod:`modeladvisor.hierarchical` replaces it with a
+genuine two-level Beta-Binomial fit by empirical Bayes. The load-bearing
+properties we assert:
+
+- **hyperprior recovery** — fitting a synthetic group drawn from a known
+  ``Beta(alpha0, beta0)`` recovers (approximately) the planted mean/concentration;
+- **shrinkage monotonicity** (the key test) — a *thin* cell is pulled toward the
+  group mean strictly more than a *rich* cell with the same own-mean;
+- **own-cell asymptotics** — as own ``n → ∞`` the pooled mean → the own-cell mean;
+- **degenerate groups** (empty / single / all-identical) return a proper prior and
+  never crash;
+- the optional ``pymc_pooled`` backend raises a clear error when PyMC is absent;
+- determinism.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import random
+import sys
+
+import pytest
+
+# Make the pack root importable when pytest is run from anywhere.
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+
+from modeladvisor import config as C  # noqa: E402
+from modeladvisor import hierarchical as H  # noqa: E402
+from modeladvisor import store as S  # noqa: E402
+from modeladvisor.store import Cell, cell_key  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures + helpers                                                            #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def cfg() -> C.AdvisorConfig:
+    """Default Claude haiku/sonnet/opus roster, baseline = opus."""
+    return C.default_config()
+
+
+def _mean(a: float, b: float) -> float:
+    return a / (a + b)
+
+
+def _synthetic_group(alpha0: float, beta0: float, *, k: int, n: int, seed: int) -> list[Cell]:
+    """``k`` sibling cells, each ``theta_i ~ Beta(alpha0, beta0)`` then
+    ``n`` Bernoulli trials -> ``Beta(1 + successes, 1 + failures)``."""
+    rng = random.Random(seed)
+    out: list[Cell] = []
+    for _ in range(k):
+        theta = rng.betavariate(alpha0, beta0)
+        s = sum(1 for _ in range(n) if rng.random() < theta)
+        out.append(Cell(a=1.0 + s, b=1.0 + (n - s)))
+    return out
+
+
+def _store_with(cfg: C.AdvisorConfig, records) -> S.CellStore:
+    st = S.CellStore.cold_start(cfg)
+    st.apply_records(records)
+    return st
+
+
+def _q(cfg, agent, shape, tier, q, i, *, provider="claude"):
+    return {
+        "kind": "quality",
+        "ts": f"2026-06-01T00:00:{i % 60:02d}Z",
+        "bead_id": f"bh-{agent}-{shape}-{tier}-{i}",
+        "cell_key": cell_key(provider, agent, shape, tier),
+        "q": q,
+        "channel": "close",
+    }
+
+
+def _wins(cfg, agent, shape, tier, n):
+    return [_q(cfg, agent, shape, tier, 1, i) for i in range(n)]
+
+
+def _losses(cfg, agent, shape, tier, n):
+    return [_q(cfg, agent, shape, tier, 0, i) for i in range(n)]
+
+
+# --------------------------------------------------------------------------- #
+# estimate_hyperprior — recovery on a known Beta                                #
+# --------------------------------------------------------------------------- #
+
+
+def test_hyperprior_recovers_planted_mean_and_concentration():
+    # Plant a Beta(6, 4): mean 0.6, moderate concentration 10. With many fairly
+    # rich siblings the method-of-moments fit should land close on the mean and in
+    # the right ballpark on the concentration.
+    group = _synthetic_group(6.0, 4.0, k=40, n=60, seed=7)
+    a0, b0 = H.estimate_hyperprior(group)
+    assert a0 > 0 and b0 > 0
+    assert _mean(a0, b0) == pytest.approx(0.6, abs=0.06)
+    # Concentration recovery is noisier than the mean; a generous band suffices to
+    # prove we are fitting dispersion, not just defaulting to a weak prior.
+    conc = a0 + b0
+    assert 3.0 < conc < 60.0
+
+
+def test_hyperprior_mean_tracks_a_high_group():
+    # A group centred high (Beta(9, 1), mean 0.9) yields a high-mean hyperprior.
+    group = _synthetic_group(9.0, 1.0, k=30, n=50, seed=11)
+    a0, b0 = H.estimate_hyperprior(group)
+    assert _mean(a0, b0) > 0.75
+
+
+# --------------------------------------------------------------------------- #
+# Shrinkage monotonicity — THE key test                                        #
+# --------------------------------------------------------------------------- #
+
+
+def test_thin_cell_shrinks_more_than_rich_cell():
+    # Shared hyperprior fitted from a group centred well above 0.5.
+    group = _synthetic_group(8.0, 2.0, k=12, n=40, seed=3)
+    a0, b0 = H.estimate_hyperprior(group)
+    group_mean = _mean(a0, b0)
+    assert group_mean > 0.6  # the group pulls upward
+
+    own_mean = 0.5
+    # Same own-mean, very different own-mass.
+    thin = Cell(a=1.0, b=1.0)        # mass 2
+    rich = Cell(a=120.0, b=120.0)    # mass 240
+
+    thin_pooled = _mean(thin.a + a0, thin.b + b0)
+    rich_pooled = _mean(rich.a + a0, rich.b + b0)
+
+    # Both shrink toward the (higher) group mean...
+    assert thin_pooled > own_mean
+    assert rich_pooled > own_mean
+    # ...but the thin cell moves strictly, substantially more.
+    thin_shift = thin_pooled - own_mean
+    rich_shift = rich_pooled - own_mean
+    assert thin_shift > rich_shift
+    assert thin_shift > 5.0 * rich_shift
+
+
+def test_pooled_mean_converges_to_own_mean_as_n_grows():
+    group = _synthetic_group(2.0, 8.0, k=10, n=30, seed=5)  # group mean ~0.2
+    a0, b0 = H.estimate_hyperprior(group)
+    own_mean = 0.5
+
+    prev_gap = 1.0
+    for mass in (4.0, 40.0, 400.0, 4000.0, 40000.0):
+        own = Cell(a=mass / 2.0, b=mass / 2.0)  # own mean fixed at 0.5
+        pooled = _mean(own.a + a0, own.b + b0)
+        gap = abs(pooled - own_mean)
+        assert gap < prev_gap  # monotonically approaches the own mean
+        prev_gap = gap
+    assert prev_gap < 1e-3  # essentially reduces to own-cell at huge n
+
+
+# --------------------------------------------------------------------------- #
+# Degenerate groups — proper prior, no crash                                   #
+# --------------------------------------------------------------------------- #
+
+
+def test_empty_group_returns_weak_prior():
+    assert H.estimate_hyperprior([]) == (1.0, 1.0)
+    # A group of all-empty cells (zero mass) is treated as no evidence.
+    assert H.estimate_hyperprior([Cell(a=0.0, b=0.0), Cell(a=0.0, b=0.0)]) == (1.0, 1.0)
+
+
+def test_single_cell_group_is_a_weak_prior_at_its_mean():
+    # One sibling, mean 0.75: anchored unit-mass prior (no dispersion signal).
+    a0, b0 = H.estimate_hyperprior([Cell(a=3.0, b=1.0)])
+    assert _mean(a0, b0) == pytest.approx(0.75)
+    assert a0 + b0 == pytest.approx(1.0)
+
+
+def test_identical_means_do_not_blow_up():
+    # All cells share mean 0.7 exactly -> zero between-cell variance. The fit must
+    # stay finite (clamped concentration), proper, and centred on the mean.
+    group = [Cell(a=7.0, b=3.0) for _ in range(6)]
+    a0, b0 = H.estimate_hyperprior(group)
+    assert _mean(a0, b0) == pytest.approx(0.7)
+    assert 0 < a0 + b0 <= H._MAX_CONCENTRATION + 1.0
+
+    # All-success and all-failure groups must also yield a finite, proper Beta.
+    for c in (Cell(a=10.0, b=0.0), Cell(a=0.0, b=10.0)):
+        ax, bx = H.estimate_hyperprior([c, c, c])
+        assert ax > 0 and bx > 0 and math.isfinite(ax) and math.isfinite(bx)
+
+
+def test_overdispersed_group_falls_back_to_weak_anchor():
+    # Bimodal group (means near 0 and near 1) has between-cell variance larger
+    # than any Beta can express -> fall back to a weak prior at the grand mean.
+    group = [Cell(a=1.0, b=99.0), Cell(a=99.0, b=1.0)]
+    a0, b0 = H.estimate_hyperprior(group)
+    assert a0 + b0 == pytest.approx(1.0)  # weak, unit mass
+    assert _mean(a0, b0) == pytest.approx(0.5, abs=0.05)
+
+
+# --------------------------------------------------------------------------- #
+# eb_pooled — drop-in over a real store                                        #
+# --------------------------------------------------------------------------- #
+
+
+def test_eb_pooled_pulls_thin_cell_toward_rich_siblings(cfg):
+    # mayor/judge/sonnet has a rich sibling group across agents (DESIGN §1.3).
+    # Make every sibling strongly successful, leave the own cell thin/neutral.
+    # NB mayor/judge IS the own cell, so it is excluded from the sibling loop;
+    # mayor's cross-shape siblings (implement, lookup) are populated separately.
+    recs = []
+    for agent in ("witness", "boot", "deacon", "refinery"):
+        recs += _wins(cfg, agent, "judge", "sonnet", 40)
+    recs += _wins(cfg, "mayor", "implement", "sonnet", 40)
+    recs += _wins(cfg, "mayor", "lookup", "sonnet", 40)
+    # Own cell: one win, one loss (mean ~ prior, thin).
+    recs += _wins(cfg, "mayor", "judge", "sonnet", 1) + _losses(cfg, "mayor", "judge", "sonnet", 1)
+    st = _store_with(cfg, recs)
+
+    own = st.get(cell_key("claude", "mayor", "judge", "sonnet"))
+    pooled = H.eb_pooled(st, "claude", "mayor", "judge", "sonnet")
+    # The high-performing siblings drag the thin own cell's mean up materially.
+    assert pooled.mean > own.mean + 0.1
+    # Bookkeeping is carried from the own cell, not invented.
+    assert pooled.n == own.n
+    assert pooled.last_update == own.last_update
+
+
+def test_eb_pooled_barely_moves_a_rich_own_cell(cfg):
+    # Same high siblings, but now the own cell is rich and disagrees (low mean).
+    recs = []
+    for agent in ("mayor", "witness", "boot", "deacon", "refinery"):
+        recs += _wins(cfg, agent, "judge", "sonnet", 40)
+    # Own cell: 200 obs at ~0.5 (rich, contradicts the siblings).
+    recs += _wins(cfg, "mayor", "judge", "sonnet", 100) + _losses(cfg, "mayor", "judge", "sonnet", 100)
+    st = _store_with(cfg, recs)
+
+    own = st.get(cell_key("claude", "mayor", "judge", "sonnet"))
+    pooled = H.eb_pooled(st, "claude", "mayor", "judge", "sonnet")
+    # Rich own-cell evidence dominates: the pooled mean barely budges.
+    assert abs(pooled.mean - own.mean) < 0.05
+
+
+def test_eb_pooled_max_prior_mass_cap_limits_injection(cfg):
+    # With a tiny cap the injected pseudocount mass cannot exceed it, so a thin
+    # cell is pulled far less than under uncapped EB. mayor/judge is the own cell
+    # (thin: 1 win, 1 loss); the high-performing siblings supply the pull.
+    recs = []
+    for agent in ("witness", "boot", "deacon", "refinery"):
+        recs += _wins(cfg, agent, "judge", "sonnet", 50)
+    recs += _wins(cfg, "mayor", "implement", "sonnet", 50)
+    recs += _wins(cfg, "mayor", "lookup", "sonnet", 50)
+    recs += _wins(cfg, "mayor", "judge", "sonnet", 1) + _losses(cfg, "mayor", "judge", "sonnet", 1)
+    st = _store_with(cfg, recs)
+
+    own = st.get(cell_key("claude", "mayor", "judge", "sonnet"))
+    uncapped = H.eb_pooled(st, "claude", "mayor", "judge", "sonnet")
+    capped = H.eb_pooled(st, "claude", "mayor", "judge", "sonnet", max_prior_mass=1.0)
+
+    own_mass = own.a + own.b
+    capped_injected = (capped.a + capped.b) - own_mass
+    assert capped_injected == pytest.approx(1.0, abs=1e-6)
+    # The cap shrinks less than full EB: capped mean sits between own and uncapped.
+    assert own.mean < capped.mean < uncapped.mean
+
+
+def test_eb_pooled_is_deterministic(cfg):
+    recs = _wins(cfg, "mayor", "judge", "sonnet", 7) + _losses(cfg, "mayor", "judge", "sonnet", 2)
+    recs += _wins(cfg, "witness", "judge", "sonnet", 11)
+    st = _store_with(cfg, recs)
+    a = H.eb_pooled(st, "claude", "mayor", "judge", "sonnet")
+    b = H.eb_pooled(st, "claude", "mayor", "judge", "sonnet")
+    assert (a.a, a.b, a.n, a.last_update) == (b.a, b.b, b.n, b.last_update)
+
+
+def test_eb_pooled_no_siblings_reduces_to_own_plus_anchor(cfg):
+    # A cell whose siblings are all empty: the group is effectively just the own
+    # cell, so the fit is a weak anchor at the own mean and pooling is gentle.
+    recs = _wins(cfg, "polecat", "implement", "haiku", 10) + _losses(cfg, "polecat", "implement", "haiku", 10)
+    st = _store_with(cfg, recs)
+    own = st.get(cell_key("claude", "polecat", "implement", "haiku"))
+    pooled = H.eb_pooled(st, "claude", "polecat", "implement", "haiku")
+    # Own mean ~0.5; weak anchor keeps the pooled mean close to it.
+    assert pooled.mean == pytest.approx(own.mean, abs=0.05)
+
+
+# --------------------------------------------------------------------------- #
+# Optional PyMC backend — graceful absence                                     #
+# --------------------------------------------------------------------------- #
+
+
+def test_pymc_pooled_raises_clearly_without_pymc(cfg):
+    # We test ONLY the graceful-absence path (the brief): with PyMC installed the
+    # full-MCMC backend is an optional extra we do not exercise here.
+    try:
+        import pymc  # type: ignore  # noqa: F401
+        pytest.skip("pymc is installed; the graceful-absence path is not exercised")
+    except ImportError:
+        pass
+    st = S.CellStore.cold_start(cfg)
+    with pytest.raises(RuntimeError) as ei:
+        H.pymc_pooled(st, "claude", "mayor", "judge", "sonnet")
+    msg = str(ei.value)
+    assert "model-advisor[bayes]" in msg

--- a/model-advisor/tests/test_ingest.py
+++ b/model-advisor/tests/test_ingest.py
@@ -1,0 +1,595 @@
+"""Tests for the model-advisor outcome harvester + capture hook.
+
+These tests own the *telemetry write side* contract (bead bh-e39): the
+``capture-invocation.sh`` Stop/SubagentStop hook and ``modeladvisor/ingest.py``
+(the quality harvester).  The engine/store/config are sibling beads.
+
+To stay runnable *before* the sibling engine/store land — the package
+``__init__`` eagerly re-exports them, so a plain ``import modeladvisor.ingest``
+would raise until they exist — we load ``modeladvisor/ingest.py`` as a
+**standalone module** via importlib, registering it in ``sys.modules`` before
+executing it (so its own ``@dataclass`` decorators resolve).  ``ingest.py`` then
+loads ``modeladvisor.config`` directly via its own degraded-import path, so this
+suite is hermetic regardless of sibling timing.  Once the engine/store land,
+``import modeladvisor.ingest`` would also work; this loader keeps the tests green
+either way.
+
+Nothing here touches live ``/Users/jayse/Code/.beads`` or ``.gc``: every test
+operates on JSONL fixtures created under ``tmp_path``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+PACK_DIR = Path(__file__).resolve().parents[1]
+INGEST_PATH = PACK_DIR / "modeladvisor" / "ingest.py"
+HOOK_PATH = PACK_DIR / "hooks" / "capture-invocation.sh"
+
+
+def _load_ingest_module():
+    """Load ingest.py standalone, bypassing the package __init__ re-exports."""
+    spec = importlib.util.spec_from_file_location("mad_ingest_under_test", INGEST_PATH)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["mad_ingest_under_test"] = mod  # register BEFORE exec (dataclasses)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+ingest = _load_ingest_module()
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures                                                                      #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture()
+def project(tmp_path: Path) -> Path:
+    """A throwaway project root with a .beads/telemetry dir (never live state)."""
+    tel = tmp_path / ".beads" / "telemetry"
+    tel.mkdir(parents=True)
+    return tmp_path
+
+
+def _inv_path(project: Path) -> Path:
+    return project / ".beads" / "telemetry" / "invocations.jsonl"
+
+
+def _write_jsonl(path: Path, records: list[dict]) -> None:
+    with open(path, "w", encoding="utf-8") as fh:
+        for r in records:
+            fh.write(json.dumps(r) + "\n")
+
+
+def _dispatch(
+    *,
+    bead_id: str = "",
+    session_id: str = "",
+    provider: str = "claude",
+    agent: str = "polecat",
+    shape: str = "implement",
+    tier_id: str = "sonnet",
+) -> dict:
+    return {
+        "schema_version": "advisor.v1",
+        "kind": "dispatch",
+        "ts": "2026-06-03T10:00:00Z",
+        "bead_id": bead_id,
+        "session_id": session_id,
+        "provider": provider,
+        "agent": agent,
+        "shape": shape,
+        "tier_id": tier_id,
+        "model": "claude-sonnet-4-5",
+        "cell_key": f"{provider}::{agent}::{shape}::{tier_id}",
+    }
+
+
+def _bead(
+    *,
+    bead_id: str,
+    status: str = "closed",
+    metadata: dict | None = None,
+    labels: list[str] | None = None,
+) -> dict:
+    b: dict = {"id": bead_id, "status": status}
+    if metadata is not None:
+        b["metadata"] = metadata
+    if labels is not None:
+        b["labels"] = labels
+    return b
+
+
+def _event(event_type: str, bead: dict) -> dict:
+    return {"type": event_type, "ts": "2026-06-03T10:30:00Z", "payload": {"bead": bead}}
+
+
+def _read_quality(project: Path) -> list[dict]:
+    out = []
+    for line in open(_inv_path(project), encoding="utf-8"):
+        line = line.strip()
+        if not line:
+            continue
+        d = json.loads(line)
+        if d.get("kind") == "quality":
+            out.append(d)
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# (1) bead.closed + gc.outcome=pass  ->  q=1 quality record joined to dispatch  #
+# --------------------------------------------------------------------------- #
+
+
+def test_close_pass_emits_q1_joined_to_dispatch(project: Path):
+    inv = _inv_path(project)
+    _write_jsonl(inv, [_dispatch(bead_id="bh-100", session_id="sess-A")])
+
+    events = project / "events.jsonl"
+    _write_jsonl(
+        events,
+        [
+            _event(
+                "bead.closed",
+                _bead(
+                    bead_id="bh-100",
+                    status="closed",
+                    metadata={"gc.outcome": "pass", "session_id": "sess-A"},
+                ),
+            )
+        ],
+    )
+
+    res = ingest.harvest(project_root=project, events_path=events)
+
+    assert res.written == 1
+    qrecs = _read_quality(project)
+    assert len(qrecs) == 1
+    q = qrecs[0]
+    # schema + join correctness (DESIGN §5.2)
+    assert q["schema_version"] == "advisor.v1"
+    assert q["kind"] == "quality"
+    assert q["bead_id"] == "bh-100"
+    assert q["cell_key"] == "claude::polecat::implement::sonnet"  # from the dispatch
+    assert q["q"] == 1
+    assert q["channel"] == "close"
+    assert q["weight"] == 1.0  # w_close
+    assert q["signal"] == "pass"
+    assert q["n_dep"] == 1
+    # the join + schema fields the engine reads
+    assert set(q) >= {
+        "schema_version", "kind", "ts", "bead_id", "cell_key",
+        "q", "channel", "weight", "signal", "n_dep",
+    }
+
+
+def test_bare_close_without_outcome_is_still_q1(project: Path):
+    """A clean close with no gc.outcome metadata is a success (DESIGN §4.1)."""
+    inv = _inv_path(project)
+    _write_jsonl(inv, [_dispatch(bead_id="bh-101", session_id="s1")])
+    events = project / "events.jsonl"
+    _write_jsonl(
+        events,
+        [_event("bead.closed", _bead(bead_id="bh-101", status="closed",
+                                     metadata={"session_id": "s1"}))],
+    )
+    res = ingest.harvest(project_root=project, events_path=events)
+    assert res.written == 1
+    q = _read_quality(project)[0]
+    assert q["q"] == 1 and q["signal"] == "closed" and q["channel"] == "close"
+
+
+# --------------------------------------------------------------------------- #
+# (2) reopen  ->  q=0                                                           #
+# --------------------------------------------------------------------------- #
+
+
+def test_reopen_emits_q0(project: Path):
+    inv = _inv_path(project)
+    # dispatch joined by session_id (reopened bead carries no dispatch bead_id key)
+    _write_jsonl(inv, [_dispatch(bead_id="", session_id="sess-B",
+                                 agent="refinery", shape="review", tier_id="opus")])
+    events = project / "events.jsonl"
+    _write_jsonl(
+        events,
+        [
+            _event(
+                "Reopened",
+                _bead(bead_id="bh-200", status="open",
+                      metadata={"session_id": "sess-B"}),
+            )
+        ],
+    )
+    res = ingest.harvest(project_root=project, events_path=events)
+    assert res.written == 1
+    q = _read_quality(project)[0]
+    assert q["q"] == 0
+    assert q["channel"] == "close"
+    assert q["signal"] == "reopened"
+    assert q["cell_key"] == "claude::refinery::review::opus"  # joined by session_id
+
+
+def test_failure_class_hard_and_outcome_fail_are_q0(project: Path):
+    inv = _inv_path(project)
+    _write_jsonl(inv, [
+        _dispatch(bead_id="bh-300", session_id="s3"),
+        _dispatch(bead_id="bh-301", session_id="s4", shape="lookup", tier_id="haiku"),
+    ])
+    events = project / "events.jsonl"
+    _write_jsonl(events, [
+        _event("bead.closed", _bead(bead_id="bh-300", status="closed",
+                                    metadata={"gc.outcome": "fail", "session_id": "s3"})),
+        _event("bead.closed", _bead(bead_id="bh-301", status="closed",
+                                    metadata={"gc.failure_class": "hard", "session_id": "s4"})),
+    ])
+    res = ingest.harvest(project_root=project, events_path=events)
+    assert res.written == 2
+    by_cell = {q["cell_key"]: q for q in _read_quality(project)}
+    assert by_cell["claude::polecat::implement::sonnet"]["q"] == 0
+    assert by_cell["claude::polecat::implement::sonnet"]["signal"] == "fail"
+    assert by_cell["claude::polecat::lookup::haiku"]["q"] == 0
+    assert by_cell["claude::polecat::lookup::haiku"]["signal"] == "failure_class:hard"
+
+
+def test_escalation_label_is_q0(project: Path):
+    inv = _inv_path(project)
+    _write_jsonl(inv, [_dispatch(bead_id="bh-400", session_id="s5")])
+    events = project / "events.jsonl"
+    _write_jsonl(events, [
+        _event("bead.updated", _bead(bead_id="bh-400", status="open",
+                                     metadata={"session_id": "s5"},
+                                     labels=["health:failing", "agent:gastown.polecat"])),
+    ])
+    res = ingest.harvest(project_root=project, events_path=events)
+    assert res.written == 1
+    q = _read_quality(project)[0]
+    assert q["q"] == 0 and q["signal"] == "escalated"
+
+
+# --------------------------------------------------------------------------- #
+# Dropped signals: transient failure, blocked review, still-open bead          #
+# --------------------------------------------------------------------------- #
+
+
+def test_transient_failure_is_dropped(project: Path):
+    inv = _inv_path(project)
+    _write_jsonl(inv, [_dispatch(bead_id="bh-500", session_id="s6")])
+    events = project / "events.jsonl"
+    _write_jsonl(events, [
+        _event("bead.closed", _bead(bead_id="bh-500", status="closed",
+                                    metadata={"gc.outcome": "fail",
+                                              "gc.failure_class": "transient",
+                                              "session_id": "s6"})),
+    ])
+    res = ingest.harvest(project_root=project, events_path=events)
+    assert res.written == 0  # transient is not a quality signal (DESIGN §4.1)
+    assert res.skipped == 1
+    assert _read_quality(project) == []
+
+
+def test_blocked_review_is_dropped(project: Path):
+    inv = _inv_path(project)
+    _write_jsonl(inv, [_dispatch(bead_id="bh-510", session_id="s7")])
+    events = project / "events.jsonl"
+    _write_jsonl(events, [
+        _event("bead.closed", _bead(bead_id="bh-510", status="closed",
+                                    metadata={"gc.verdict": "blocked", "session_id": "s7"})),
+    ])
+    res = ingest.harvest(project_root=project, events_path=events)
+    assert res.written == 0 and res.skipped == 1
+
+
+def test_open_bead_no_verdict_is_skipped(project: Path):
+    inv = _inv_path(project)
+    _write_jsonl(inv, [_dispatch(bead_id="bh-520", session_id="s8")])
+    events = project / "events.jsonl"
+    _write_jsonl(events, [
+        _event("bead.updated", _bead(bead_id="bh-520", status="in_progress",
+                                     metadata={"session_id": "s8"})),
+    ])
+    res = ingest.harvest(project_root=project, events_path=events)
+    assert res.written == 0 and res.skipped == 1
+
+
+# --------------------------------------------------------------------------- #
+# Attribution: a closure with no recorded dispatch is dropped (DESIGN §4.4)     #
+# --------------------------------------------------------------------------- #
+
+
+def test_unjoined_closure_is_dropped_and_reported(project: Path):
+    inv = _inv_path(project)
+    _write_jsonl(inv, [_dispatch(bead_id="bh-100", session_id="sess-A")])
+    events = project / "events.jsonl"
+    _write_jsonl(events, [
+        _event("bead.closed", _bead(bead_id="bh-NOPE", status="closed",
+                                    metadata={"gc.outcome": "pass",
+                                              "session_id": "sess-UNKNOWN"})),
+    ])
+    res = ingest.harvest(project_root=project, events_path=events)
+    assert res.written == 0
+    assert res.records == []
+    assert "bh-NOPE" in res.unjoined
+
+
+# --------------------------------------------------------------------------- #
+# (3) channel-weight precedence: eval > review > close; highest fidelity wins   #
+# --------------------------------------------------------------------------- #
+
+
+def test_channel_precedence_eval_beats_review_beats_close(project: Path):
+    """One dispatch with eval+review+close-able metadata yields ONE eval obs."""
+    inv = _inv_path(project)
+    _write_jsonl(inv, [_dispatch(bead_id="bh-600", session_id="s9")])
+    events = project / "events.jsonl"
+    # The same bead carries an eval verdict, a review verdict, AND is closed.
+    # Highest fidelity (eval) must win; weight = w_eval = 5.
+    _write_jsonl(events, [
+        _event("bead.closed", _bead(bead_id="bh-600", status="closed",
+                                    metadata={"gc.eval_verdict": "pass",
+                                              "gc.verdict": "fail",
+                                              "gc.outcome": "pass",
+                                              "session_id": "s9"})),
+    ])
+    res = ingest.harvest(project_root=project, events_path=events)
+    assert res.written == 1
+    q = _read_quality(project)[0]
+    assert q["channel"] == "eval"
+    assert q["weight"] == 5.0  # w_eval
+    assert q["q"] == 1
+    assert q["signal"] == "eval:pass"
+
+
+def test_review_beats_close_weight_3(project: Path):
+    inv = _inv_path(project)
+    _write_jsonl(inv, [_dispatch(bead_id="bh-610", session_id="s10")])
+    events = project / "events.jsonl"
+    _write_jsonl(events, [
+        _event("bead.closed", _bead(bead_id="bh-610", status="closed",
+                                    metadata={"gc.verdict": "pass_with_findings",
+                                              "session_id": "s10"})),
+    ])
+    res = ingest.harvest(project_root=project, events_path=events)
+    q = _read_quality(project)[0]
+    assert q["channel"] == "review"
+    assert q["weight"] == 3.0  # w_review
+    assert q["q"] == 1  # pass_with_findings -> 1 (DESIGN §4.2)
+    assert q["signal"] == "review:pass_with_findings"
+
+
+def test_dedup_collapses_close_then_reopen_to_one_negative(project: Path):
+    """Two events on the same cell (close, then reopen) collapse to one obs.
+
+    On a fidelity tie (both 'close'), the negative (reopen) wins — a reopen after
+    a close must not be masked by the close (DESIGN §4.4 conservative precedence).
+    """
+    inv = _inv_path(project)
+    _write_jsonl(inv, [_dispatch(bead_id="bh-700", session_id="s11")])
+    events = project / "events.jsonl"
+    _write_jsonl(events, [
+        _event("bead.closed", _bead(bead_id="bh-700", status="closed",
+                                    metadata={"gc.outcome": "pass", "session_id": "s11"})),
+        _event("Reopened", _bead(bead_id="bh-700", status="open",
+                                 metadata={"session_id": "s11"})),
+    ])
+    res = ingest.harvest(project_root=project, events_path=events)
+    assert res.written == 1  # collapsed to a single observation for the cell
+    q = _read_quality(project)[0]
+    assert q["q"] == 0
+    assert q["signal"] == "reopened"
+
+
+# --------------------------------------------------------------------------- #
+# bd-show mode (explicit bead objects) + write=False                           #
+# --------------------------------------------------------------------------- #
+
+
+def test_beads_iterable_mode_and_dry_run(project: Path):
+    inv = _inv_path(project)
+    _write_jsonl(inv, [_dispatch(bead_id="bh-800", session_id="s12")])
+    bead = _bead(bead_id="bh-800", status="closed",
+                 metadata={"gc.outcome": "pass", "session_id": "s12"})
+    # write=False must NOT append to invocations.jsonl
+    res = ingest.harvest(project_root=project, beads=[bead], write=False)
+    assert len(res.records) == 1
+    assert res.written == 0
+    assert _read_quality(project) == []  # nothing appended
+    assert res.records[0]["q"] == 1
+
+
+def test_fetch_via_cli_parses_array(monkeypatch, project: Path):
+    """bd-show mode parses the JSON *array* that `gc bd show --json` emits."""
+    inv = _inv_path(project)
+    _write_jsonl(inv, [_dispatch(bead_id="bh-900", session_id="s13")])
+
+    class _Proc:
+        returncode = 0
+        stdout = json.dumps([
+            {"id": "bh-900", "status": "closed",
+             "metadata": {"gc.outcome": "pass", "session_id": "s13"}}
+        ])
+        stderr = ""
+
+    monkeypatch.setattr(ingest.subprocess, "run", lambda *a, **k: _Proc())
+    res = ingest.harvest(project_root=project, bead_ids=["bh-900"], use_cli=True)
+    assert res.written == 1
+    assert _read_quality(project)[0]["q"] == 1
+
+
+# --------------------------------------------------------------------------- #
+# Robustness: malformed JSONL lines and missing files don't crash harvest      #
+# --------------------------------------------------------------------------- #
+
+
+def test_malformed_lines_and_missing_events_are_tolerated(project: Path):
+    inv = _inv_path(project)
+    with open(inv, "w", encoding="utf-8") as fh:
+        fh.write("not json\n")
+        fh.write(json.dumps(_dispatch(bead_id="bh-a", session_id="sa")) + "\n")
+        fh.write("\n")
+        fh.write("{ broken\n")
+    # events path points at a non-existent file -> degrades to no closures.
+    res = ingest.harvest(project_root=project,
+                         events_path=project / "does-not-exist.jsonl")
+    assert res.written == 0  # no closures, but no crash
+    assert res.records == []
+
+
+# --------------------------------------------------------------------------- #
+# CLI entry: python -m modeladvisor.ingest behaviour via main()                #
+# --------------------------------------------------------------------------- #
+
+
+def test_cli_main_dry_run_json(project: Path, capsys):
+    inv = _inv_path(project)
+    _write_jsonl(inv, [_dispatch(bead_id="bh-c", session_id="sc")])
+    events = project / "events.jsonl"
+    _write_jsonl(events, [
+        _event("bead.closed", _bead(bead_id="bh-c", status="closed",
+                                    metadata={"gc.outcome": "pass", "session_id": "sc"})),
+    ])
+    rc = ingest.main([
+        "--project-root", str(project),
+        "--events", str(events),
+        "--dry-run", "--json",
+    ])
+    assert rc == 0
+    out = capsys.readouterr().out
+    payload = json.loads(out)
+    assert len(payload) == 1 and payload[0]["q"] == 1
+    # dry-run must not write
+    assert _read_quality(project) == []
+
+
+# --------------------------------------------------------------------------- #
+# The capture hook: well-formed Stop payload -> dispatch record; exit 0 always  #
+# --------------------------------------------------------------------------- #
+
+
+def _run_hook(payload: str, env_extra: dict, cwd: Path) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    env.update(env_extra)
+    # Ensure a sane PATH for jq/date/python3 inside the hook.
+    env["PATH"] = (
+        "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:"
+        + env.get("PATH", "")
+    )
+    return subprocess.run(
+        ["bash", str(HOOK_PATH)],
+        input=payload,
+        text=True,
+        capture_output=True,
+        cwd=str(cwd),
+        env=env,
+    )
+
+
+@pytest.fixture()
+def hook_project(tmp_path: Path) -> Path:
+    (tmp_path / ".beads").mkdir(parents=True)
+    return tmp_path
+
+
+def test_hook_emits_wellformed_dispatch_from_stop_payload(hook_project: Path):
+    payload = json.dumps({
+        "hook_event_name": "Stop",
+        "session_id": "bh-vt5",
+        "cwd": str(hook_project),
+    })
+    proc = _run_hook(
+        payload,
+        {
+            "GC_TEMPLATE": "whiskeyshop/gastown.polecat#3",
+            "GC_AGENT_MODEL": "claude-opus-4-8",
+            "GC_PROVIDER": "claude",
+        },
+        hook_project,
+    )
+    assert proc.returncode == 0
+    inv = _inv_path(hook_project)
+    assert inv.exists()
+    rec = json.loads(open(inv).readline())
+    assert rec["kind"] == "dispatch"
+    assert rec["schema_version"] == "advisor.v1"
+    assert rec["session_id"] == "bh-vt5"
+    assert rec["provider"] == "claude"
+    assert rec["agent"] == "polecat"  # base name derived from GC_TEMPLATE
+    assert rec["agent_instance"] == "whiskeyshop/gastown.polecat#3"
+    assert rec["rig"] == "whiskeyshop"
+    assert rec["model"] == "claude-opus-4-8"
+    # cell_key well-formed with unknown placeholders for shape/tier (engine fills)
+    assert rec["cell_key"] == "claude::polecat::unknown::unknown"
+    assert rec["source"] == "hook:Stop"
+
+
+def test_hook_parses_tokens_and_model_from_transcript(hook_project: Path, tmp_path: Path):
+    transcript = tmp_path / "transcript.jsonl"
+    with open(transcript, "w") as fh:
+        fh.write(json.dumps({"type": "assistant", "message": {
+            "model": "claude-sonnet-4-5",
+            "usage": {"input_tokens": 100, "output_tokens": 40,
+                      "cache_read_input_tokens": 10}}}) + "\n")
+        fh.write(json.dumps({"type": "assistant", "message": {
+            "model": "claude-sonnet-4-5",
+            "usage": {"input_tokens": 200, "output_tokens": 60,
+                      "cache_creation_input_tokens": 5}}}) + "\n")
+    payload = json.dumps({
+        "hook_event_name": "SubagentStop",
+        "session_id": "s-trans",
+        "transcript_path": str(transcript),
+        "cwd": str(hook_project),
+    })
+    proc = _run_hook(payload, {"GC_TEMPLATE": "gastown.polecat", "GC_PROVIDER": "claude"},
+                     hook_project)
+    assert proc.returncode == 0
+    rec = json.loads(open(_inv_path(hook_project)).readline())
+    assert rec["model"] == "claude-sonnet-4-5"  # parsed from transcript
+    assert rec["tok_in"] == 315  # 100+10+200+5
+    assert rec["tok_out"] == 100  # 40+60
+    assert rec["source"] == "hook:SubagentStop"
+
+
+def test_hook_exits_zero_on_empty_and_malformed_payload(hook_project: Path):
+    inv = _inv_path(hook_project)
+    # Empty payload: env-only record, exit 0.
+    proc = _run_hook("", {"GC_TEMPLATE": "gastown.deacon", "GC_PROVIDER": "claude"},
+                     hook_project)
+    assert proc.returncode == 0
+    assert inv.exists()  # still emits a (degraded) record
+    first = json.loads(open(inv).readline())
+    assert first["agent"] == "deacon" and first["kind"] == "dispatch"
+
+    # Malformed (non-JSON) payload: must still exit 0 and not crash.
+    proc2 = _run_hook("}{ this is not json", {"GC_PROVIDER": "claude"}, hook_project)
+    assert proc2.returncode == 0
+
+
+def test_hook_escape_hatch_writes_nothing(hook_project: Path):
+    proc = _run_hook(
+        json.dumps({"hook_event_name": "Stop", "session_id": "x", "cwd": str(hook_project)}),
+        {"MODEL_ADVISOR_DISABLE_CAPTURE": "1", "GC_PROVIDER": "claude"},
+        hook_project,
+    )
+    assert proc.returncode == 0
+    assert not _inv_path(hook_project).exists()  # no write under the escape hatch
+
+
+def test_hook_no_beads_dir_is_noop(tmp_path: Path):
+    """With no .beads anywhere up the tree, the hook emits nothing and exits 0."""
+    sub = tmp_path / "nested" / "deep"
+    sub.mkdir(parents=True)
+    proc = _run_hook(
+        json.dumps({"hook_event_name": "Stop", "session_id": "x", "cwd": str(sub)}),
+        {"GC_PROVIDER": "claude"},
+        sub,
+    )
+    assert proc.returncode == 0
+    assert not (tmp_path / ".beads").exists()

--- a/model-advisor/tests/test_install_fragments.py
+++ b/model-advisor/tests/test_install_fragments.py
@@ -1,0 +1,304 @@
+"""Tests for the install/uninstall fragment wiring (part (a)).
+
+The pack's discipline fragment ``use-model-advisor`` is wired into city.toml by
+the *shell* lifecycle scripts (``install.sh`` / ``uninstall.sh``).  gc deprecated
+the old top-level ``[workspace] global_fragments`` key in favour of
+``[agent_defaults] append_fragments``; these tests pin that:
+
+  * ``install.sh`` adds the fragment to **``[agent_defaults]`` ``append_fragments``**
+    (creating the table and/or the array when absent), idempotently;
+  * ``uninstall.sh`` removes it from ``append_fragments`` AND strips any legacy
+    ``global_fragments`` entry an old install may have left (so an old install
+    still reverses cleanly);
+  * every produced city.toml round-trips through ``tomllib``.
+
+The embedded edit logic is small Python heredocs *inside* the shell functions,
+so rather than duplicate it we **extract the real functions from the shipped
+scripts** and drive them.  That way a regression in the actual install/uninstall
+code is caught here, with no live ``/Users/jayse/Code`` config ever touched
+(everything runs on temp city.toml copies).
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+# tomllib is stdlib on 3.11+; fall back to the tomli backport if present.
+try:  # pragma: no cover - import shim
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover
+    import tomli as tomllib  # type: ignore
+
+PACK_DIR = Path(__file__).resolve().parents[1]
+INSTALL_SH = PACK_DIR / "install.sh"
+UNINSTALL_SH = PACK_DIR / "uninstall.sh"
+FRAG = "use-model-advisor"
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("bash") is None or shutil.which("python3") is None,
+    reason="needs bash + python3 to exercise the shell lifecycle helpers",
+)
+
+
+def _extract_fn(script: Path, name: str) -> str:
+    """Return the source of shell function ``name`` from ``script``.
+
+    Matches from the ``name() {`` line to the first line that is exactly ``}``
+    (the scripts write each helper with a closing brace in column 0).
+    """
+    src = script.read_text()
+    out, in_blk = [], False
+    for line in src.splitlines():
+        if re.match(r"^%s\(\)\s*\{" % re.escape(name), line):
+            in_blk = True
+        if in_blk:
+            out.append(line)
+        if in_blk and line == "}":
+            break
+    if not out:
+        raise AssertionError(f"function {name}() not found in {script}")
+    return "\n".join(out)
+
+
+def _runner(*fn_sources: str):
+    """Build a callable that sources the given fn sources and invokes one.
+
+    Returns ``call(city_dir, fn, *args) -> CompletedProcess`` operating with
+    ``CITY=<city_dir>`` so the extracted helpers (which reference ``$CITY``)
+    resolve to the temp city.
+    """
+    lib = "\n\n".join(fn_sources)
+
+    def call(city: Path, fn: str, *args: str) -> subprocess.CompletedProcess:
+        script = lib + "\n" + fn + " " + " ".join(f'"{a}"' for a in args) + "\n"
+        return subprocess.run(
+            ["bash", "-c", script],
+            env={"CITY": str(city), "PATH": _PATH},
+            capture_output=True,
+            text=True,
+        )
+
+    return call
+
+
+# A PATH that finds python3 + bash regardless of the minimal test env.
+_PATH = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+
+
+# Extract the shipped helpers once.
+_INSTALL_EDIT = _extract_fn(INSTALL_SH, "edit_fragment")
+_INSTALL_PRESENT = _extract_fn(INSTALL_SH, "fragment_present")
+_UNINSTALL_REMOVE = _extract_fn(UNINSTALL_SH, "edit_fragment_remove")
+_UNINSTALL_PRESENT = _extract_fn(UNINSTALL_SH, "fragment_present")
+
+_install = _runner(_INSTALL_EDIT, _INSTALL_PRESENT)
+_uninstall = _runner(_UNINSTALL_REMOVE, _UNINSTALL_PRESENT)
+
+
+def _city(tmp_path: Path, body: str) -> Path:
+    (tmp_path / "city.toml").write_text(textwrap.dedent(body), encoding="utf-8")
+    return tmp_path
+
+
+def _toml(city: Path) -> dict:
+    with open(city / "city.toml", "rb") as fh:
+        return tomllib.load(fh)
+
+
+def _append_frags(city: Path) -> list:
+    return _toml(city).get("agent_defaults", {}).get("append_fragments", [])
+
+
+def _legacy_frags(city: Path) -> list:
+    d = _toml(city)
+    # the deprecated key can sit under [workspace] or (rarely) at top level
+    return d.get("workspace", {}).get("global_fragments", d.get("global_fragments", []))
+
+
+# --------------------------------------------------------------------------- #
+# install.sh: add to [agent_defaults] append_fragments
+# --------------------------------------------------------------------------- #
+
+def test_install_creates_agent_defaults_table_and_array(tmp_path):
+    """No [agent_defaults] at all → the table + array are created."""
+    city = _city(tmp_path, """
+        [workspace]
+        provider = "claude"
+
+        [defaults]
+        [defaults.rig]
+    """)
+    # not present before
+    assert _install(city, "fragment_present", FRAG).returncode == 1
+    r = _install(city, "edit_fragment", "add", FRAG)
+    assert r.returncode == 0, r.stderr
+
+    assert _append_frags(city) == [FRAG]
+    # present after, and idempotent (byte-identical second add)
+    assert _install(city, "fragment_present", FRAG).returncode == 0
+    once = (city / "city.toml").read_text()
+    _install(city, "edit_fragment", "add", FRAG)
+    assert (city / "city.toml").read_text() == once
+
+
+def test_install_inserts_array_into_existing_agent_defaults(tmp_path):
+    """[agent_defaults] exists without append_fragments → the array is inserted."""
+    city = _city(tmp_path, """
+        [workspace]
+        provider = "claude"
+
+        [agent_defaults]
+        default_sling_formula = "mol-pack-default"
+
+        [[rigs]]
+        name = "x"
+    """)
+    r = _install(city, "edit_fragment", "add", FRAG)
+    assert r.returncode == 0, r.stderr
+    d = _toml(city)
+    assert d["agent_defaults"]["append_fragments"] == [FRAG]
+    # sibling keys + later tables preserved (surgical edit)
+    assert d["agent_defaults"]["default_sling_formula"] == "mol-pack-default"
+    assert d["rigs"][0]["name"] == "x"
+
+
+def test_install_appends_without_duplicating(tmp_path):
+    """Existing append_fragments → ours is appended exactly once, order kept."""
+    city = _city(tmp_path, """
+        [workspace]
+        provider = "claude"
+
+        [agent_defaults]
+        append_fragments = ["house-style"]
+    """)
+    _install(city, "edit_fragment", "add", FRAG)
+    _install(city, "edit_fragment", "add", FRAG)  # twice
+    af = _append_frags(city)
+    assert af == ["house-style", FRAG]
+    assert af.count(FRAG) == 1
+
+
+def test_install_present_ignores_legacy_global_fragments(tmp_path):
+    """A legacy global_fragments entry must NOT mask the need to add the new one.
+
+    install-side ``fragment_present`` only consults [agent_defaults]
+    append_fragments, so an old install (which wrote global_fragments) still
+    triggers an add into the new home.
+    """
+    city = _city(tmp_path, """
+        [workspace]
+        provider = "claude"
+        global_fragments = ["use-model-advisor"]
+    """)
+    # install-side presence is False (the new home is empty) → add proceeds
+    assert _install(city, "fragment_present", FRAG).returncode == 1
+    _install(city, "edit_fragment", "add", FRAG)
+    assert _append_frags(city) == [FRAG]
+
+
+# --------------------------------------------------------------------------- #
+# uninstall.sh: remove from append_fragments AND strip legacy global_fragments
+# --------------------------------------------------------------------------- #
+
+def test_uninstall_removes_from_append_fragments(tmp_path):
+    city = _city(tmp_path, """
+        [workspace]
+        provider = "claude"
+
+        [agent_defaults]
+        append_fragments = ["house-style", "use-model-advisor"]
+    """)
+    assert _uninstall(city, "fragment_present", FRAG).returncode == 0
+    r = _uninstall(city, "edit_fragment_remove", FRAG)
+    assert r.returncode == 0, r.stderr
+    assert _append_frags(city) == ["house-style"]  # sibling kept
+    assert _uninstall(city, "fragment_present", FRAG).returncode == 1
+
+
+def test_uninstall_strips_legacy_global_fragments(tmp_path):
+    """An OLD install (legacy global_fragments) still reverses cleanly."""
+    city = _city(tmp_path, """
+        [workspace]
+        provider = "claude"
+        global_fragments = ["command-glossary", "use-model-advisor"]
+
+        [defaults]
+    """)
+    assert _uninstall(city, "fragment_present", FRAG).returncode == 0  # found in legacy
+    _uninstall(city, "edit_fragment_remove", FRAG)
+    assert _legacy_frags(city) == ["command-glossary"]
+    assert _uninstall(city, "fragment_present", FRAG).returncode == 1
+
+
+def test_uninstall_strips_both_homes_in_one_pass(tmp_path):
+    """Legacy global_fragments AND new append_fragments both carry it → both cleaned."""
+    city = _city(tmp_path, """
+        [workspace]
+        provider = "claude"
+        global_fragments = ["command-glossary", "use-model-advisor"]
+
+        [agent_defaults]
+        append_fragments = ["house-style", "use-model-advisor"]
+    """)
+    _uninstall(city, "edit_fragment_remove", FRAG)
+    assert _legacy_frags(city) == ["command-glossary"]
+    assert _append_frags(city) == ["house-style"]
+    assert _uninstall(city, "fragment_present", FRAG).returncode == 1
+
+
+def test_uninstall_remove_is_idempotent(tmp_path):
+    city = _city(tmp_path, """
+        [agent_defaults]
+        append_fragments = ["house-style"]
+    """)
+    before = (city / "city.toml").read_text()
+    _uninstall(city, "edit_fragment_remove", FRAG)  # nothing of ours
+    assert (city / "city.toml").read_text() == before
+
+
+# --------------------------------------------------------------------------- #
+# round-trip + parse invariants
+# --------------------------------------------------------------------------- #
+
+def test_install_then_uninstall_round_trips(tmp_path):
+    """add then remove restores the array to its original (byte-identical file)."""
+    city = _city(tmp_path, """
+        [workspace]
+        provider = "claude"
+
+        [agent_defaults]
+        append_fragments = ["house-style"]
+    """)
+    original = (city / "city.toml").read_text()
+    _install(city, "edit_fragment", "add", FRAG)
+    assert _append_frags(city) == ["house-style", FRAG]
+    _uninstall(city, "edit_fragment_remove", FRAG)
+    assert (city / "city.toml").read_text() == original
+
+
+def test_every_edit_result_parses_as_toml(tmp_path):
+    """Each produced city.toml is valid TOML (tomllib round-trips it)."""
+    city = _city(tmp_path, """
+        [workspace]
+        provider = "claude"
+    """)
+    _install(city, "edit_fragment", "add", FRAG)  # creates table+array at EOF
+    _toml(city)  # must not raise
+    _uninstall(city, "edit_fragment_remove", FRAG)
+    _toml(city)  # must not raise
+
+
+def test_install_present_substring_safe(tmp_path):
+    """A similarly-named fragment is not a false 'present' match."""
+    city = _city(tmp_path, """
+        [agent_defaults]
+        append_fragments = ["use-model-advisor-extra"]
+    """)
+    assert _install(city, "fragment_present", FRAG).returncode == 1

--- a/model-advisor/tests/test_integration_v3.py
+++ b/model-advisor/tests/test_integration_v3.py
@@ -1,0 +1,280 @@
+"""End-to-end integration tests for the v3 deferred features (DESIGN §7.3).
+
+These exercise the *wiring* of all eight v3 modules through the shared public
+surfaces (``config`` / ``store`` / ``engine`` / ``cli``), one feature per toggle,
+proving each flag turns its feature on end-to-end while staying **off by default**.
+They deliberately do not re-test the modules' internal algorithms (those have
+their own ``test_<feature>.py``); they assert the integration contract:
+
+- ``continuous_quality`` lets the store accept a fractional ``q``;
+- ``lcb_backend = conformal`` runs ``recommend`` and, on an empty calibration
+  buffer, returns the *same* decision as Wilson (the safe-drop-in contract);
+- ``pooling = empirical-bayes`` runs ``recommend`` end-to-end;
+- ``mode = thompson`` is deterministic per seed and never downgrades a Critical cell;
+- the ``changepoint`` rebuild branch re-weights a drifted cell's posterior;
+- ``schedule_evals`` ranks gating cells;
+- ``federate export`` → ``merge_peers`` round-trips observed mass;
+- a wide DAG raises the cascade ``N_dep`` vs a flat bead.
+
+The default-off invariant (the 86 pre-existing tests passing unmodified) is the
+primary guard; these add the *opt-in-on* half.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from dataclasses import replace
+
+import pytest
+
+# Make the pack root importable when pytest is run from anywhere.
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+
+from modeladvisor import config as C  # noqa: E402
+from modeladvisor import engine as E  # noqa: E402
+from modeladvisor import federation as F  # noqa: E402
+from modeladvisor import store as S  # noqa: E402
+from modeladvisor.cascade import build_graph_from_dep_json, effective_cascade  # noqa: E402
+from modeladvisor.evalsched import schedule_evals  # noqa: E402
+from modeladvisor.store import cell_key  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures + helpers                                                            #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def cfg() -> C.AdvisorConfig:
+    """Default Claude haiku/sonnet/opus roster, baseline = opus."""
+    return C.default_config()
+
+
+def _key(cfg: C.AdvisorConfig, agent: str, shape: str, tier: str) -> str:
+    return cell_key(cfg.default_provider, agent, shape, tier)
+
+
+def _wins(cfg, agent, shape, tier, n, *, channel="close"):
+    k = _key(cfg, agent, shape, tier)
+    return [
+        {"kind": "quality", "cell_key": k, "q": 1, "channel": channel, "ts": f"t{i}"}
+        for i in range(n)
+    ]
+
+
+def _feed(store, records):
+    for r in records:
+        store.apply_quality(r)
+    return store
+
+
+# --------------------------------------------------------------------------- #
+# 1. continuous_quality — the store accepts a fractional q                      #
+# --------------------------------------------------------------------------- #
+
+
+def test_continuous_quality_off_drops_fractional_q(cfg):
+    """Default (off): a non-binary q is dropped, exactly as v1 (the invariant)."""
+    st = S.CellStore.cold_start(cfg)
+    applied = st.apply_quality(
+        {"kind": "quality", "cell_key": _key(cfg, "polecat", "implement", "sonnet"), "q": 0.7}
+    )
+    assert applied is False
+    assert _key(cfg, "polecat", "implement", "sonnet") not in st.observed_cells()
+
+
+def test_continuous_quality_on_accepts_q_0_7(cfg):
+    """``continuous_quality`` on: q=0.7 is accepted and folds into the posterior."""
+    cfg_c = replace(cfg, hp=replace(cfg.hp, continuous_quality=True))
+    st = S.CellStore.cold_start(cfg_c)
+    k = _key(cfg_c, "polecat", "implement", "sonnet")
+    prior = st.get(k)
+    prior_a, prior_b = prior.a, prior.b
+    assert st.apply_quality({"kind": "quality", "cell_key": k, "q": 0.7, "weight": 1.0}) is True
+    cell = st.cells[k]
+    assert cell.n == 1
+    # Beta soft-update with the fractional reward: a += w·q, b += w·(1−q).
+    assert cell.a == pytest.approx(prior_a + 1.0 * 0.7)
+    assert cell.b == pytest.approx(prior_b + 1.0 * 0.3)
+    assert 0.0 < cell.mean < 1.0
+
+
+# --------------------------------------------------------------------------- #
+# 2. lcb_backend = conformal — runs recommend; empty buffer == Wilson          #
+# --------------------------------------------------------------------------- #
+
+
+def test_conformal_backend_empty_buffer_matches_wilson(cfg):
+    """An empty calibration buffer ⇒ conformal falls back to Wilson: equal result."""
+    records = _wins(cfg, "polecat", "implement", "sonnet", 40)
+
+    st_w = _feed(S.CellStore.cold_start(cfg), records)
+    rec_w = E.recommend("polecat", "implement", cfg, st_w, provider=cfg.default_provider)
+
+    cfg_c = replace(cfg, lcb_backend="conformal")
+    st_c = _feed(S.CellStore.cold_start(cfg_c), records)
+    rec_c = E.recommend("polecat", "implement", cfg_c, st_c, provider=cfg_c.default_provider)
+
+    assert rec_c["reasons"]["lcb_backend"] == "conformal"
+    assert rec_c["tier_id"] == rec_w["tier_id"]
+    # Per-tier q_lo identical too (buffers thin ⇒ exact Wilson on both sides).
+    qlo_w = {t: p["q_lo"] for t, p in rec_w["posterior_summary"].items()}
+    for tid, p in rec_c["posterior_summary"].items():
+        assert p["q_lo"] == pytest.approx(qlo_w[tid])
+
+
+# --------------------------------------------------------------------------- #
+# 3. pooling = empirical-bayes — runs recommend end-to-end                      #
+# --------------------------------------------------------------------------- #
+
+
+def test_empirical_bayes_pooling_runs_recommend(cfg):
+    """``pooling = empirical-bayes`` produces a complete, valid recommendation."""
+    cfg_eb = replace(cfg, pooling="empirical-bayes")
+    st = _feed(S.CellStore.cold_start(cfg_eb), _wins(cfg_eb, "polecat", "implement", "sonnet", 30))
+    rec = E.recommend("polecat", "implement", cfg_eb, st, provider=cfg_eb.default_provider)
+    assert rec["reasons"]["pooling"] == "empirical-bayes"
+    assert rec["tier_id"] in cfg_eb.tier_ids
+    # The pooled posterior was read via the EB pooler (drop-in for store.pooled).
+    eb_cell = st.pooled(cfg_eb.default_provider, "polecat", "implement", "sonnet")
+    assert eb_cell.n >= 0 and 0.0 < eb_cell.mean < 1.0
+
+
+# --------------------------------------------------------------------------- #
+# 4. mode = thompson — deterministic per seed + never downgrades Critical       #
+# --------------------------------------------------------------------------- #
+
+
+def test_thompson_mode_deterministic_per_seed(cfg):
+    """``mode = thompson`` is reproducible for a fixed seed, varies across seeds."""
+    cfg_t = replace(cfg, hp=replace(cfg.hp, mode="thompson"))
+    st = _feed(S.CellStore.cold_start(cfg_t), _wins(cfg_t, "polecat", "implement", "sonnet", 50))
+
+    a = E.recommend("polecat", "implement", cfg_t, st, provider=cfg_t.default_provider, seed=11)
+    b = E.recommend("polecat", "implement", cfg_t, st, provider=cfg_t.default_provider, seed=11)
+    assert a["reasons"]["mode"] == "thompson"
+    assert a["tier_id"] == b["tier_id"]
+    assert a["reasons"]["thompson"]["samples"] == b["reasons"]["thompson"]["samples"]
+    # The audit carries a cli-renderable candidates list with the standard keys.
+    assert a["reasons"]["candidates"]
+    assert {"tier_id", "admitted", "cost_diff"} <= set(a["reasons"]["candidates"][0])
+
+
+def test_thompson_mode_never_downgrades_critical(cfg):
+    """Across many seeds, a Critical cell stays on the baseline (hard rule)."""
+    cfg_t = replace(cfg, hp=replace(cfg.hp, mode="thompson"))
+    # Pile evidence on a cheap tier so a non-Critical cell WOULD downgrade.
+    st = _feed(S.CellStore.cold_start(cfg_t), _wins(cfg_t, "refinery", "judge", "haiku", 80))
+    for seed in range(25):
+        rec = E.recommend(
+            "refinery", "judge", cfg_t, st,
+            provider=cfg_t.default_provider, tol_class="Critical", seed=seed,
+        )
+        assert rec["tier_id"] == cfg_t.baseline_tier_id, f"downgraded at seed {seed}"
+
+
+# --------------------------------------------------------------------------- #
+# 5. changepoint — the rebuild branch re-weights a drifted cell's posterior     #
+# --------------------------------------------------------------------------- #
+
+
+def test_changepoint_rebuild_reweights_drifted_cell(cfg, tmp_path):
+    """A 0.9→fail drift: the changepoint re-fold lands below the straight fold."""
+    k = _key(cfg, "polecat", "implement", "sonnet")
+    jsonl = tmp_path / "invocations.jsonl"
+    with open(jsonl, "w", encoding="utf-8") as fh:
+        for i in range(40):  # high-quality regime
+            fh.write(json.dumps({"kind": "quality", "cell_key": k, "q": 1, "ts": f"t{i}"}) + "\n")
+        for i in range(40, 75):  # sustained drop (drift)
+            fh.write(json.dumps({"kind": "quality", "cell_key": k, "q": 0, "ts": f"t{i}"}) + "\n")
+
+    st_off = S.CellStore.rebuild(cfg, os.fspath(jsonl))  # straight fold (default)
+    cfg_cp = replace(cfg, hp=replace(cfg.hp, changepoint=True))
+    st_on = S.CellStore.rebuild(cfg_cp, os.fspath(jsonl))  # changepoint reweight
+
+    mean_off = st_off.cells[k].mean
+    mean_on = st_on.cells[k].mean
+    # Forgetting stale pre-drift wins pulls the posterior toward the failing regime.
+    assert mean_on < mean_off
+
+
+# --------------------------------------------------------------------------- #
+# 6. schedule_evals — ranks gating cells worth an eval                          #
+# --------------------------------------------------------------------------- #
+
+
+def test_schedule_evals_returns_ranked_requests(cfg):
+    """A cheaper tier with a wide, savings-bearing CI surfaces as a ranked probe."""
+    # Moderate (downgrade-able) cell with thin-but-present evidence on the cheap
+    # tier so its CI is wide enough to gate on uncertainty.
+    st = _feed(S.CellStore.cold_start(cfg), _wins(cfg, "polecat", "implement", "sonnet", 6))
+    reqs = schedule_evals(cfg, st, max_evals=10)
+    # Ranked by score descending (deterministic), each a real gating candidate.
+    assert all(reqs[i].score >= reqs[i + 1].score for i in range(len(reqs) - 1))
+    for r in reqs:
+        assert r.unlock_value >= 0.0
+        assert r.ci_halfwidth > 0.0
+
+
+# --------------------------------------------------------------------------- #
+# 7. federation — export → merge_peers round-trips observed mass                #
+# --------------------------------------------------------------------------- #
+
+
+def test_federation_export_merge_round_trip(cfg):
+    """A peer's exported aggregates re-enter a thin local cell on merge (trust>0)."""
+    # Peer earned strong evidence on a cell the local store has never seen.
+    peer_store = _feed(S.CellStore.cold_start(cfg), _wins(cfg, "polecat", "implement", "sonnet", 20))
+    export = F.export_aggregates(peer_store)
+    k = _key(cfg, "polecat", "implement", "sonnet")
+    assert k in export["cells"]
+    assert export["cells"][k]["a_obs"] > 0.0  # only observed mass, prior subtracted
+
+    # Survives a JSON round-trip (it is pure data) before the merge.
+    export = json.loads(json.dumps(export))
+
+    local = S.CellStore.cold_start(cfg)  # thin: this cell is prior-only locally
+    prior_a = local.get(k).a
+    merged = F.merge_peers(local, export, trust=0.5)
+    # The peer's success mass moved the thin local cell's posterior up.
+    assert merged.get(k).a > prior_a
+
+    # trust = 0 ⇒ no peer influence (the conservative default contract).
+    merged0 = F.merge_peers(local, export, trust=0.0)
+    assert merged0.get(k).a == pytest.approx(prior_a)
+
+
+# --------------------------------------------------------------------------- #
+# 8. cascade — a wide DAG raises N_dep vs a flat bead                            #
+# --------------------------------------------------------------------------- #
+
+
+def test_cascade_raises_n_dep_for_wide_dag(cfg):
+    """A bead blocking a wide downstream DAG gets a larger effective N_dep."""
+    st = _feed(S.CellStore.cold_start(cfg), _wins(cfg, "polecat", "implement", "sonnet", 30))
+
+    flat = effective_cascade({}, "leaf")  # unknown/leaf ⇒ flat floor
+    wide_graph = build_graph_from_dep_json(
+        [
+            {"id": "root", "blocks": ["a", "b", "c"]},
+            {"id": "a", "blocks": ["a1", "a2"]},
+            {"id": "b", "blocks": ["b1"]},
+        ]
+    )
+    wide = effective_cascade(wide_graph, "root", decay=1.0)
+    assert wide.n_dep_eff > flat.n_dep_eff
+
+    rec_flat = E.recommend(
+        "polecat", "implement", cfg, st, provider=cfg.default_provider, cascade=flat
+    )
+    rec_wide = E.recommend(
+        "polecat", "implement", cfg, st, provider=cfg.default_provider, cascade=wide
+    )
+    assert rec_flat["reasons"]["n_dep"] == 1
+    assert rec_wide["reasons"]["n_dep"] == max(1, round(wide.n_dep_eff))
+    assert rec_wide["reasons"]["n_dep"] > rec_flat["reasons"]["n_dep"]
+    assert "cascade" in rec_wide["reasons"]

--- a/model-advisor/tests/test_thompson.py
+++ b/model-advisor/tests/test_thompson.py
@@ -1,0 +1,298 @@
+"""Tests for the genuine Thompson-Sampling mode (DESIGN §1.2–§1.4, §7.3).
+
+The deferred-feature contract (V3 build brief, bead bh-s37):
+
+- **reproducibility** — same seed ⇒ same samples and same choice (DESIGN §1.4
+  property 2); different seeds ⇒ varied but always-valid choices;
+- **safety** — a ``Critical`` cell never downgrades even when a cheap tier
+  samples high; the ``force_baseline`` safety hatch likewise never downgrades
+  (DESIGN §1.2 ``M[Critical]=∞`` hard rule / §7.4);
+- **directional correctness** — over a fixed seed range a clearly-better cheap
+  tier is chosen materially more often than a clearly-worse one (the randomised
+  analogue of the gate exploring in proportion to posterior quality);
+- **audit completeness** — the structured ``audit`` object carries the samples
+  and the reasoning (DESIGN §1.4 property 3).
+
+The module takes ``cells_by_tier`` directly, so these tests drive it with
+hand-built :class:`~modeladvisor.store.Cell` posteriors (no store / config
+needed) to isolate the sampler + selection logic from pooling.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+# Make the pack root importable when pytest is run from anywhere.
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+
+from modeladvisor import thompson as T  # noqa: E402
+from modeladvisor.store import Cell  # noqa: E402
+
+# A 3-tier cost order (cheapest -> most-capable), baseline = the dearest tier,
+# mirroring the default haiku/sonnet/opus roster.
+ORDER = ["haiku", "sonnet", "opus"]
+BASE = "opus"
+
+# q_tol for the default Moderate class (DESIGN §1.2).
+Q_TOL = 0.05
+
+
+def _cells(haiku: Cell, sonnet: Cell, opus: Cell) -> dict[str, Cell]:
+    return {"haiku": haiku, "sonnet": sonnet, "opus": opus}
+
+
+def _high(mean_count: float = 80.0) -> Cell:
+    """A tight, high-quality posterior (mean ~0.99): samples near 1."""
+    return Cell(a=mean_count, b=1.0)
+
+
+def _low(mean_count: float = 80.0) -> Cell:
+    """A tight, low-quality posterior (mean ~0.01): samples near 0."""
+    return Cell(a=1.0, b=mean_count)
+
+
+def _baseline_good() -> Cell:
+    """A solid baseline posterior (mean ~0.9)."""
+    return Cell(a=45.0, b=5.0)
+
+
+# --------------------------------------------------------------------------- #
+# Reproducibility (DESIGN §1.4 property 2)                                      #
+# --------------------------------------------------------------------------- #
+
+
+def test_same_seed_same_samples():
+    cells = _cells(_low(), Cell(a=30.0, b=8.0), _baseline_good())
+    s1 = T.sample_tier_qualities(ORDER, cells, seed=42)
+    s2 = T.sample_tier_qualities(ORDER, cells, seed=42)
+    assert s1 == s2
+    assert set(s1) == set(ORDER)
+    assert all(0.0 <= v <= 1.0 for v in s1.values())
+
+
+def test_same_seed_same_choice():
+    cells = _cells(_low(), Cell(a=30.0, b=8.0), _baseline_good())
+    a_id, a_audit = T.thompson_select(
+        ORDER, cells, BASE, q_tol=Q_TOL, is_critical=False, forced=False, seed=123
+    )
+    b_id, b_audit = T.thompson_select(
+        ORDER, cells, BASE, q_tol=Q_TOL, is_critical=False, forced=False, seed=123
+    )
+    assert a_id == b_id
+    assert a_audit == b_audit
+
+
+def test_different_seeds_vary_but_stay_valid():
+    # Borderline cheap tier (mean ~0.8) so the draw genuinely varies seed-to-seed.
+    cells = _cells(_low(), Cell(a=8.0, b=2.0), _baseline_good())
+    chosen = {
+        T.thompson_select(
+            ORDER, cells, BASE, q_tol=Q_TOL, is_critical=False, forced=False, seed=s
+        )[0]
+        for s in range(200)
+    }
+    # Every choice is a real roster tier.
+    assert chosen <= set(ORDER)
+    # The randomness actually produces more than one outcome over the seed range.
+    assert len(chosen) >= 2
+    # haiku is near-0 quality and must never be chosen here (would breach the gate).
+    assert "haiku" not in chosen
+
+
+# --------------------------------------------------------------------------- #
+# Safety: Critical / forced never downgrade (DESIGN §1.2, §7.4)                 #
+# --------------------------------------------------------------------------- #
+
+
+def test_critical_never_downgrades_even_when_cheap_samples_high():
+    # Both cheap tiers sample ~1.0; only Critical stops the downgrade.
+    cells = _cells(_high(), _high(), _baseline_good())
+    for s in range(300):
+        chosen, audit = T.thompson_select(
+            ORDER, cells, BASE, q_tol=0.0, is_critical=True, forced=False, seed=s
+        )
+        assert chosen == BASE, f"Critical downgraded on seed {s}"
+        # No cheaper tier is ever admissible.
+        for row in audit["tiers"]:
+            if row["action"] == "down":
+                assert row["admitted"] is False
+
+
+def test_forced_baseline_never_downgrades():
+    cells = _cells(_high(), _high(), _baseline_good())
+    for s in range(300):
+        chosen, audit = T.thompson_select(
+            ORDER, cells, BASE, q_tol=Q_TOL, is_critical=False, forced=True, seed=s
+        )
+        assert chosen == BASE, f"force_baseline downgraded on seed {s}"
+        assert audit["forced_baseline"] is True
+        assert audit["no_downgrade"] is True
+
+
+def test_critical_audit_marks_no_downgrade_and_keeps_upgrades_possible():
+    # An upgrade tier above baseline is still allowed under Critical (never a
+    # *downgrade*); only cheaper tiers are blocked. Order: cheap, BASE, dear.
+    order = ["cheap", "mid", "dear"]
+    cells = {
+        "cheap": _high(),         # would downgrade -> must be blocked
+        "mid": _baseline_good(),  # baseline
+        "dear": _high(),          # upgrade -> allowed if it beats baseline sample
+    }
+    saw_upgrade = False
+    for s in range(200):
+        chosen, audit = T.thompson_select(
+            order, cells, "mid", q_tol=0.0, is_critical=True, forced=False, seed=s
+        )
+        # Never a downgrade to the cheaper tier.
+        assert chosen != "cheap"
+        assert order.index(chosen) >= order.index("mid")
+        if chosen == "dear":
+            saw_upgrade = True
+    assert saw_upgrade, "an upgrade should still be reachable under Critical"
+
+
+# --------------------------------------------------------------------------- #
+# Directional correctness (light statistical test, fixed seed range)           #
+# --------------------------------------------------------------------------- #
+
+
+def test_better_cheap_tier_chosen_more_often_than_worse():
+    """A clearly-better cheap tier wins materially more draws than a worse one.
+
+    haiku ~ Beta(85, 5)  (mean ~0.94, the *better* cheap tier)
+    sonnet ~ Beta(20, 25) (mean ~0.44, the *worse* cheap tier)
+    baseline opus ~ Beta(45, 5) (mean ~0.9). q_tol = 0.10 (Lenient).
+    Over a fixed seed range the better cheap tier (haiku, also the cheapest) is
+    selected far more often than the worse one.
+    """
+    cells = _cells(Cell(a=85.0, b=5.0), Cell(a=20.0, b=25.0), _baseline_good())
+    counts = {"haiku": 0, "sonnet": 0, "opus": 0}
+    for s in range(500):
+        chosen, _ = T.thompson_select(
+            ORDER, cells, BASE, q_tol=0.10, is_critical=False, forced=False, seed=s
+        )
+        counts[chosen] += 1
+    # The better cheap tier dominates the worse one decisively.
+    assert counts["haiku"] > counts["sonnet"]
+    assert counts["haiku"] > 3 * max(counts["sonnet"], 1)
+
+
+def test_strong_cheap_tier_usually_downgrades():
+    """A cheap tier that is clearly good should be picked the large majority of draws."""
+    cells = _cells(_low(), _high(), _baseline_good())  # sonnet ~1.0, haiku ~0
+    downgrades = sum(
+        T.thompson_select(
+            ORDER, cells, BASE, q_tol=Q_TOL, is_critical=False, forced=False, seed=s
+        )[0]
+        == "sonnet"
+        for s in range(300)
+    )
+    assert downgrades > 270  # ~ always (sonnet samples ~1 >= baseline - q_tol)
+
+
+def test_hopeless_cheap_tiers_keep_baseline():
+    """When every cheaper tier is clearly bad, the baseline is kept (no downgrade)."""
+    cells = _cells(_low(), _low(), _baseline_good())
+    for s in range(200):
+        chosen, audit = T.thompson_select(
+            ORDER, cells, BASE, q_tol=Q_TOL, is_critical=False, forced=False, seed=s
+        )
+        assert chosen == BASE
+        assert audit["decision"].startswith("no cheaper tier")
+
+
+# --------------------------------------------------------------------------- #
+# Selection mechanics                                                           #
+# --------------------------------------------------------------------------- #
+
+
+def test_picks_cheapest_among_admissible():
+    """Both cheap tiers sample high -> the cheapest (haiku) is chosen."""
+    cells = _cells(_high(), _high(), _baseline_good())
+    for s in range(100):
+        chosen, audit = T.thompson_select(
+            ORDER, cells, BASE, q_tol=Q_TOL, is_critical=False, forced=False, seed=s
+        )
+        # haiku and sonnet both clear the gate -> cheapest wins.
+        assert chosen == "haiku"
+        assert "haiku" in audit["admissible"] and "sonnet" in audit["admissible"]
+
+
+def test_upgrade_only_when_strictly_better_than_baseline():
+    """An upgrade is selected only if it strictly beats the baseline's own sample.
+
+    Cheapest tier is hopeless, so no downgrade; whether we stay or upgrade depends
+    purely on whether the dearer tier's sample exceeds the baseline's.
+    """
+    cells = _cells(_low(), _baseline_good(), _high())  # haiku ~0, sonnet baseline, opus ~1
+    order = ["haiku", "sonnet", "opus"]
+    for s in range(200):
+        chosen, audit = T.thompson_select(
+            order, cells, "sonnet", q_tol=Q_TOL, is_critical=False, forced=False, seed=s
+        )
+        assert chosen != "haiku"  # cheaper tier is hopeless -> never a downgrade
+        theta = audit["samples"]
+        if chosen == "opus":
+            assert theta["opus"] > theta["sonnet"]
+        else:
+            assert chosen == "sonnet"
+            assert theta["opus"] <= theta["sonnet"]
+
+
+# --------------------------------------------------------------------------- #
+# Audit completeness (DESIGN §1.4 property 3)                                   #
+# --------------------------------------------------------------------------- #
+
+
+def test_audit_completeness():
+    cells = _cells(_low(), Cell(a=30.0, b=8.0), _baseline_good())
+    chosen, audit = T.thompson_select(
+        ORDER, cells, BASE, q_tol=Q_TOL, is_critical=False, forced=False, seed=7
+    )
+    # Top-level audit keys.
+    for key in (
+        "mode", "seed", "baseline_tier", "baseline_theta", "q_tol", "critical",
+        "forced_baseline", "no_downgrade", "samples", "tiers", "admissible",
+        "chosen_tier", "decision",
+    ):
+        assert key in audit, f"missing audit key {key!r}"
+    assert audit["mode"] == "thompson"
+    assert audit["seed"] == 7
+    assert audit["chosen_tier"] == chosen
+    assert audit["baseline_tier"] == BASE
+    # samples + per-tier rows span the whole roster.
+    assert set(audit["samples"]) == set(ORDER)
+    assert {r["tier_id"] for r in audit["tiers"]} == set(ORDER)
+    # baseline_theta echoes the baseline's sample.
+    assert audit["baseline_theta"] == audit["samples"][BASE]
+    # every per-tier row carries the reasoning fields.
+    for row in audit["tiers"]:
+        for k in ("tier_id", "action", "theta", "admitted", "reason"):
+            assert k in row
+        assert isinstance(row["reason"], str) and row["reason"]
+    # the chosen tier is admissible, and the baseline always is.
+    assert chosen in audit["admissible"]
+    assert BASE in audit["admissible"]
+
+
+def test_sample_qualities_respects_order_and_keys():
+    cells = _cells(_low(), _high(), _baseline_good())
+    samples = T.sample_tier_qualities(ORDER, cells, seed=1)
+    assert list(samples.keys()) == ORDER  # iteration follows the cost order
+    assert all(isinstance(v, float) for v in samples.values())
+
+
+def test_degenerate_zero_param_cell_does_not_crash():
+    """A degenerate (0, 0) cell is nudged to epsilon rather than crashing betavariate."""
+    cells = _cells(Cell(a=0.0, b=0.0), _high(), _baseline_good())
+    samples = T.sample_tier_qualities(ORDER, cells, seed=3)
+    assert 0.0 <= samples["haiku"] <= 1.0
+    chosen, _ = T.thompson_select(
+        ORDER, cells, BASE, q_tol=Q_TOL, is_critical=False, forced=False, seed=3
+    )
+    assert chosen in ORDER

--- a/model-advisor/uninstall.sh
+++ b/model-advisor/uninstall.sh
@@ -1,0 +1,461 @@
+#!/usr/bin/env bash
+# model-advisor — uninstall lifecycle (reverses everything install.sh did).
+#
+#   uninstall.sh (--town | --rig <name>) [--dry-run] [--city <path>]
+#                [--purge] [--no-reload]
+#
+# Reverses, in order:
+#   1. Remove the "use-model-advisor" discipline fragment from city.toml
+#      [agent_defaults] append_fragments (--town only); removed only if present
+#      (idempotent), and the file is backed up once. For a clean reversal of an
+#      OLD install, any legacy top-level global_fragments entry (the deprecated
+#      key) is stripped in the same pass.
+#   2. Remove the pack import. It is a DIRECT config entry (the gastown pattern,
+#      not `gc import add`/`remove`), so a surgical, backed-up edit drops it:
+#        --town       -> drops  <city>/pack.toml   [imports.model-advisor]
+#        --rig <name> -> drops  <city>/city.toml   [rigs.imports.model-advisor]
+#                        (from under the [[rigs]] entry whose name matches <name>)
+#   3. Clean the materialized claude overlay: strip the model-advisor
+#      Stop/SubagentStop telemetry hook ENTRY from every projected
+#      .claude/settings.json under the city (the override source is merge-sticky —
+#      gc never deletes overlay keys, so it must be removed explicitly). Any
+#      non-model-advisor hook entry is preserved; an emptied matcher block / empty
+#      event array is removed.
+#   4. Re-project with `gc reload` so the city-level .gc/settings.json is
+#      regenerated from the now-clean override (drops the stale hook).
+#   5. --purge: delete the engine .venv.
+#
+# Idempotent (re-running after a clean uninstall is a no-op). Any file it edits
+# is backed up first. --dry-run prints the plan and changes nothing.
+
+set -euo pipefail
+
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${HOME}/go/bin:${HOME}/.local/bin:${PATH}"
+
+PACK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PACK_NAME="model-advisor"
+IMPORT_NAME="model-advisor"
+# The single discipline prompt-fragment this pack ships; mirror of install.sh.
+# Removed from city.toml [agent_defaults] append_fragments on --town scope (and,
+# for an old install, from the legacy top-level global_fragments too).
+FRAGMENTS=("use-model-advisor")
+HOOK_MARKER="model-advisor/hooks/capture-invocation.sh"
+
+SCOPE=""; RIG=""; DRY_RUN=0; NO_RELOAD=0; PURGE=0; CITY=""
+
+die()  { printf 'uninstall.sh: error: %s\n' "$*" >&2; exit 1; }
+info() { printf '  %s\n' "$*"; }
+step() { printf '\n==> %s\n' "$*"; }
+run()  { if [ "$DRY_RUN" -eq 1 ]; then printf '    [dry-run] %s\n' "$*"; else printf '    + %s\n' "$*"; eval "$@"; fi; }
+
+usage() { sed -n '2,30p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit "${1:-0}"; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --town)      SCOPE="town"; shift ;;
+    --rig)       SCOPE="rig"; RIG="${2:-}"; [ -n "$RIG" ] || die "--rig requires a rig name"; shift 2 ;;
+    --rig=*)     SCOPE="rig"; RIG="${1#*=}"; shift ;;
+    --dry-run)   DRY_RUN=1; shift ;;
+    --purge)     PURGE=1; shift ;;
+    --no-reload) NO_RELOAD=1; shift ;;
+    --city)      CITY="${2:-}"; [ -n "$CITY" ] || die "--city requires a path"; shift 2 ;;
+    --city=*)    CITY="${1#*=}"; shift ;;
+    -h|--help)   usage 0 ;;
+    *)           die "unknown argument: $1 (try --help)" ;;
+  esac
+done
+
+[ -n "$SCOPE" ] || die "choose a scope: --town or --rig <name>"
+
+if [ -z "$CITY" ]; then CITY="$(cd "$PACK_DIR/../.." && pwd)"; fi
+[ -f "$CITY/city.toml" ] || die "no city.toml at city root: $CITY (pass --city <path>)"
+CITY="$(cd "$CITY" && pwd)"
+
+GC=(gc --city "$CITY")
+
+step "model-advisor uninstall"
+info "scope:  $SCOPE${RIG:+ ($RIG)}"
+info "city:   $CITY"
+[ "$PURGE" -eq 1 ]   && info "purge:  yes (will delete .venv)"
+[ "$DRY_RUN" -eq 1 ] && info "MODE:   DRY RUN (no changes will be made)"
+
+command -v gc >/dev/null 2>&1 || die "gc not found on PATH"
+
+backup_file() {
+  local f="$1"; [ -f "$f" ] || return 0
+  local b="${f}.model-advisor.bak.$(date +%Y%m%d%H%M%S)"
+  if [ "$DRY_RUN" -eq 1 ]; then printf '    [dry-run] backup %s -> %s\n' "$f" "$b"; return 0; fi
+  cp -p "$f" "$b"; printf '    backup: %s\n' "$b"
+}
+
+import_present() { # 0 if IMPORT_NAME is registered at the active scope.
+  # gc import list reports direct-config imports (the gastown style); fall back
+  # to a config grep for the [..imports.NAME] table if the catalog is unbuilt.
+  if [ "$SCOPE" = "rig" ]; then
+    if "${GC[@]}" import list --rig "$RIG" 2>/dev/null | awk '{print $1}' | grep -qx "$IMPORT_NAME"; then
+      return 0
+    fi
+    rig_import_in_config "$RIG"
+  else
+    if "${GC[@]}" import list 2>/dev/null | awk '{print $1}' | grep -qx "$IMPORT_NAME"; then
+      return 0
+    fi
+    grep -Eq "^\[imports\.${IMPORT_NAME}\][[:space:]]*$" "$CITY/pack.toml" 2>/dev/null
+  fi
+}
+
+rig_import_in_config() { # 0 if [rigs.imports.IMPORT_NAME] exists under rig $1
+  python3 - "$CITY/city.toml" "$1" "$IMPORT_NAME" <<'PY'
+import sys, re
+path, rig, name = sys.argv[1], sys.argv[2], sys.argv[3]
+lines = open(path).read().splitlines(keepends=True)
+starts = [i for i, l in enumerate(lines) if re.match(r'^\[\[rigs\]\]\s*$', l)]
+for k, s in enumerate(starts):
+    end = starts[k + 1] if k + 1 < len(starts) else len(lines)
+    for j in range(s + 1, end):
+        if re.match(r'^\[', lines[j]) and not re.match(r'^\[(\[rigs\]\]|rigs(\.|\]))', lines[j]):
+            end = j; break
+    named = None
+    for j in range(s + 1, end):
+        m = re.match(r'^\s*name\s*=\s*["\'](.+?)["\']\s*$', lines[j])
+        if m:
+            named = m.group(1); break
+    if named != rig:
+        continue
+    hdr = re.compile(r'^\[rigs\.imports\.%s\]\s*$' % re.escape(name))
+    if any(hdr.match(lines[j]) for j in range(s + 1, end)):
+        sys.exit(0)
+    sys.exit(1)
+sys.exit(1)
+PY
+}
+
+fragment_present() { # 0 if fragment $1 is in [agent_defaults] append_fragments OR legacy global_fragments
+  # Checks BOTH homes so verify catches a leftover wherever a current-or-old
+  # install put it: the new [agent_defaults] append_fragments array, or the
+  # deprecated top-level global_fragments key.
+  python3 - "$CITY/city.toml" "$1" <<'PY'
+import sys, re
+path, frag = sys.argv[1], sys.argv[2]
+try:
+    src = open(path).read()
+except OSError:
+    sys.exit(1)
+lines = src.splitlines(keepends=True)
+
+# legacy top-level global_fragments (anywhere in the file)
+m = re.search(r'(?m)^\s*global_fragments\s*=\s*(\[[^\]]*\])', src)
+if m:
+    items = [x.strip().strip('"').strip("'") for x in m.group(1)[1:-1].split(',') if x.strip()]
+    if frag in items:
+        sys.exit(0)
+
+# new home: [agent_defaults] append_fragments (scan only that table body)
+hdr = re.compile(r'^\[agent_defaults\]\s*$')
+start = next((i for i, l in enumerate(lines) if hdr.match(l)), None)
+if start is not None:
+    end = len(lines)
+    for j in range(start + 1, len(lines)):
+        if re.match(r'^\[', lines[j]):
+            end = j; break
+    body = "".join(lines[start + 1:end])
+    am = re.search(r'(?m)^\s*append_fragments\s*=\s*(\[[^\]]*\])', body)
+    if am:
+        items = [x.strip().strip('"').strip("'") for x in am.group(1)[1:-1].split(',') if x.strip()]
+        if frag in items:
+            sys.exit(0)
+sys.exit(1)
+PY
+}
+
+edit_fragment_remove() { # remove fragment $1 from BOTH append_fragments and legacy global_fragments (idempotent)
+  # Mirror of install.sh's edit_fragment add. Surgical, format-preserving: drops
+  # the fragment from the [agent_defaults] append_fragments array (the new home)
+  # AND from any legacy top-level global_fragments array (so an OLD install, which
+  # wrote the deprecated key, still reverses cleanly). Everything outside the
+  # edited array(s) is preserved byte-for-byte.
+  python3 - "$CITY/city.toml" "$1" <<'PY'
+import sys, re
+path, frag = sys.argv[1], sys.argv[2]
+src = open(path).read()
+
+def drop_from_array(text, array_re, lo=0, hi=None):
+    """Remove `frag` from the first array matched by array_re within [lo, hi)."""
+    hi = len(text) if hi is None else hi
+    region = text[lo:hi]
+    m = array_re.search(region)
+    if not m:
+        return text, False
+    items = [x.strip().strip('"').strip("'") for x in m.group(2)[1:-1].split(',') if x.strip()]
+    if frag not in items:
+        return text, False
+    items = [x for x in items if x != frag]
+    new_arr = "[" + ", ".join('"%s"' % x for x in items) + "]"
+    a0, a1 = lo + m.start(2), lo + m.end(2)
+    return text[:a0] + new_arr + text[a1:], True
+
+# 1) legacy top-level global_fragments, anywhere.
+src, _ = drop_from_array(src, re.compile(r'(?m)^(\s*global_fragments\s*=\s*)(\[[^\]]*\])'))
+
+# 2) [agent_defaults] append_fragments — scope to that table body so we never
+#    touch an append_fragments under some other table.
+lines = src.splitlines(keepends=True)
+hdr = re.compile(r'^\[agent_defaults\]\s*$')
+start = next((i for i, l in enumerate(lines) if hdr.match(l)), None)
+if start is not None:
+    end = len(lines)
+    for j in range(start + 1, len(lines)):
+        if re.match(r'^\[', lines[j]):
+            end = j; break
+    body_lo = len("".join(lines[:start + 1]))
+    body_hi = len("".join(lines[:end]))
+    src, _ = drop_from_array(
+        src, re.compile(r'(?m)^(\s*append_fragments\s*=\s*)(\[[^\]]*\])'),
+        lo=body_lo, hi=body_hi,
+    )
+
+open(path, "w").write(src)
+PY
+}
+
+edit_import() { # add|remove a DIRECT-config import (gastown style); idempotent.
+  # The mirror of install.sh's helper — a local in-tree pack is a direct config
+  # entry, not `gc import add`. Surgical text edit; rest of file byte-exact, so
+  # removal exactly reverses the add install.sh made.
+  #   town: file=pack.toml, [imports] -> [imports.IMPORT_NAME]
+  #   rig : file=city.toml, the [rigs.imports] of the [[rigs]] named $5
+  #         -> [rigs.imports.IMPORT_NAME]
+  # args: <action> <file> <import_name> <source> [<rig_name>]   (source ignored
+  #       on remove; pass "" for clarity)
+  python3 - "$2" "$1" "$3" "$4" "${5:-}" <<'PY'
+import sys, re
+path, action, name, source, rig = sys.argv[1:6]
+rig = rig or None
+
+def fail(msg):
+    sys.stderr.write("edit_import: %s\n" % msg); sys.exit(3)
+
+lines = open(path).read().splitlines(keepends=True)
+
+if rig is None:
+    table = "imports"
+    anchor = next((i for i, l in enumerate(lines) if re.match(r'^\[imports\]\s*$', l)), None)
+    if anchor is None: fail("[imports] table not found in %s" % path)
+    hi = len(lines)
+else:
+    table = "rigs.imports"
+    starts = [i for i, l in enumerate(lines) if re.match(r'^\[\[rigs\]\]\s*$', l)]
+    if not starts: fail("no [[rigs]] blocks in %s" % path)
+    target_start = None; hi = len(lines)
+    for k, s in enumerate(starts):
+        end = starts[k + 1] if k + 1 < len(starts) else len(lines)
+        for j in range(s + 1, end):
+            if re.match(r'^\[', lines[j]) and not re.match(r'^\[(\[rigs\]\]|rigs(\.|\]))', lines[j]):
+                end = j; break
+        named = None
+        for j in range(s + 1, end):
+            m = re.match(r'^\s*name\s*=\s*["\'](.+?)["\']\s*$', lines[j])
+            if m: named = m.group(1); break
+        if named == rig:
+            target_start, hi = s, end; break
+    if target_start is None: fail('no [[rigs]] block with name = "%s" in %s' % (rig, path))
+    anchor = next((i for i in range(target_start, hi) if re.match(r'^\[rigs\.imports\]\s*$', lines[i])), None)
+    if anchor is None: fail('[rigs.imports] not found under rig "%s" in %s' % (rig, path))
+
+header = "[%s.%s]" % (table, name)
+sub = re.compile(r'^\[%s\.%s\]\s*$' % (re.escape(table), re.escape(name)))
+existing = next((i for i in range(anchor, hi) if sub.match(lines[i])), None)
+
+if action == "add":
+    if existing is not None: sys.exit(0)
+    lines.insert(anchor + 1, "%s\nsource = \"%s\"\n" % (header, source))
+    open(path, "w").write("".join(lines))
+elif action == "remove":
+    if existing is None: sys.exit(0)
+    end = existing + 1
+    if end < len(lines) and re.match(r'^\s*source\s*=', lines[end]): end += 1
+    del lines[existing:end]
+    open(path, "w").write("".join(lines))
+else:
+    fail("unknown action: %s" % action)
+PY
+}
+
+# Strip our telemetry-hook entry from one settings.json, in place. The hook is a
+# Stop/SubagentStop hook (not PreToolUse), and the overlay may wire it under
+# either or both events, so the rewrite is event-agnostic: it walks EVERY hook
+# event array (Stop, SubagentStop, …), drops any inner hook whose command
+# carries our marker, removes an emptied matcher block, and removes an emptied
+# event array — leaving every non-model-advisor hook untouched.
+# Returns 0 (success) iff the file was modified; 1 if there was nothing of ours
+# to strip. All human-readable progress goes to stderr so the return code is the
+# sole signal callers consume.
+strip_hook() {
+  local f="$1"
+  [ -f "$f" ] || return 1
+  grep -q "$HOOK_MARKER" "$f" 2>/dev/null || return 1   # nothing of ours here
+  if [ "$DRY_RUN" -eq 1 ]; then printf '    [dry-run] strip model-advisor hook from %s\n' "$f" >&2; return 0; fi
+  local tmp; tmp="$(mktemp)"
+  if jq --arg mark "$HOOK_MARKER" '
+        if (.hooks | type) == "object" then
+          .hooks = (
+            .hooks
+            | to_entries
+            | map(
+                if (.value | type) == "array" then
+                  .value = (
+                    .value
+                    | map( .hooks = ((.hooks // []) | map(select((.command // "") | contains($mark) | not))) )
+                    | map(select((.hooks | length) > 0))
+                  )
+                else . end
+              )
+            | map(select((.value | type) != "array" or (.value | length) > 0))
+            | from_entries
+          )
+        else . end
+      ' "$f" > "$tmp" 2>/dev/null; then
+    if ! cmp -s "$f" "$tmp"; then
+      backup_file "$f" >&2
+      cat "$tmp" > "$f"
+      printf '    cleaned: %s\n' "$f" >&2
+      rm -f "$tmp"
+      return 0
+    fi
+    rm -f "$tmp"
+    return 1
+  else
+    rm -f "$tmp"
+    printf '    WARN: jq could not rewrite %s (left untouched)\n' "$f" >&2
+    return 1
+  fi
+}
+
+# ---- step 1: fragments (town only) -----------------------------------------
+# Remove the pack's discipline fragment from city.toml [agent_defaults]
+# append_fragments (and any legacy global_fragments entry an old install left),
+# skipping it if already absent (idempotent). The file is backed up at most once
+# per run, and only when the fragment actually needs removing — never under
+# --dry-run, and never when it is not present.
+step "1/5  prompt fragment ([agent_defaults] append_fragments)"
+if [ "$SCOPE" = "town" ]; then
+  backed_up=0
+  for frag in "${FRAGMENTS[@]}"; do
+    if fragment_present "$frag"; then
+      if [ "$DRY_RUN" -eq 1 ]; then
+        info "[dry-run] remove \"$frag\" from append_fragments (and legacy global_fragments)"
+      else
+        if [ "$backed_up" -eq 0 ]; then backup_file "$CITY/city.toml"; backed_up=1; fi
+        edit_fragment_remove "$frag"
+        info "removed \"$frag\" from append_fragments (and legacy global_fragments)"
+      fi
+    else
+      info "\"$frag\" not in append_fragments / global_fragments — no-op"
+    fi
+  done
+else
+  info "rig scope: append_fragments not touched"
+fi
+
+# ---- step 2: import --------------------------------------------------------
+# The import is a DIRECT config entry (the gastown pattern), so remove it with a
+# surgical, backed-up edit — NOT `gc import remove` (paired with install's
+# edit_import; the removal exactly reverses the added table).
+#   rig : <city>/city.toml -> drop [rigs.imports.model-advisor] under [[rigs]] named $RIG
+#   town: <city>/pack.toml -> drop [imports.model-advisor]
+step "2/5  remove pack import ($SCOPE scope)"
+if import_present; then
+  if [ "$SCOPE" = "rig" ]; then
+    IMPORT_CFG="$CITY/city.toml"
+    backup_file "$IMPORT_CFG"
+    if [ "$DRY_RUN" -eq 1 ]; then
+      info "[dry-run] remove [rigs.imports.$IMPORT_NAME] from under rig \"$RIG\" in $IMPORT_CFG"
+    else
+      edit_import remove "$IMPORT_CFG" "$IMPORT_NAME" "" "$RIG" \
+        || die "failed to remove [rigs.imports.$IMPORT_NAME] from $IMPORT_CFG"
+      info "removed [rigs.imports.$IMPORT_NAME] from under rig \"$RIG\""
+    fi
+  else
+    IMPORT_CFG="$CITY/pack.toml"
+    backup_file "$IMPORT_CFG"
+    if [ "$DRY_RUN" -eq 1 ]; then
+      info "[dry-run] remove [imports.$IMPORT_NAME] from $IMPORT_CFG"
+    else
+      edit_import remove "$IMPORT_CFG" "$IMPORT_NAME" "" \
+        || die "failed to remove [imports.$IMPORT_NAME] from $IMPORT_CFG"
+      info "removed [imports.$IMPORT_NAME]"
+    fi
+  fi
+else
+  info "import \"$IMPORT_NAME\" not registered at this scope — no-op"
+fi
+
+# ---- step 3: clean materialized claude overlay -----------------------------
+step "3/5  clean projected claude settings (strip Stop/SubagentStop hook)"
+changed_any=0
+# Search every settings.json under the city: the city-root override
+# (<city>/.claude/settings.json), the projected output (<city>/.gc/settings.json),
+# and any per-agent workdir copies (rig worktrees etc.). node_modules excluded.
+while IFS= read -r f; do
+  [ -n "$f" ] || continue
+  if strip_hook "$f"; then changed_any=1; fi
+done < <(find "$CITY/.gc" "$CITY/.claude" \
+              \( -path '*/node_modules/*' -prune \) -o \
+              -name 'settings.json' -print 2>/dev/null | sort -u)
+if [ "$changed_any" -eq 1 ]; then
+  info "stripped model-advisor telemetry hook from projected settings"
+else
+  info "no model-advisor telemetry hook found in any projected settings — nothing to clean"
+fi
+
+# ---- step 4: re-project ----------------------------------------------------
+step "4/5  re-project (gc reload)"
+if [ "$NO_RELOAD" -eq 1 ]; then
+  info "--no-reload: skipping. Run 'gc reload' to regenerate projected settings."
+elif [ "$DRY_RUN" -eq 1 ]; then
+  info "[dry-run] gc reload  (regenerates .gc/settings.json from the clean override)"
+else
+  if "${GC[@]}" reload >/dev/null 2>&1; then info "gc reload: ok"
+  else info "gc reload non-zero (city may be stopped); clean state applies on next start"; fi
+fi
+
+# ---- step 5: purge venv ----------------------------------------------------
+step "5/5  engine venv"
+if [ "$PURGE" -eq 1 ]; then
+  if [ -d "$PACK_DIR/.venv" ]; then
+    run "rm -rf \"$PACK_DIR/.venv\""
+    info "purged $PACK_DIR/.venv"
+  else
+    info "no .venv to purge"
+  fi
+else
+  info "kept $PACK_DIR/.venv (pass --purge to delete it)"
+fi
+
+# ---- verify ----------------------------------------------------------------
+step "verify"
+if [ "$DRY_RUN" -eq 1 ]; then
+  step "model-advisor uninstall — DRY RUN complete (no changes made)"; exit 0
+fi
+fail=0
+if import_present; then info "import: STILL REGISTERED ($IMPORT_NAME)"; fail=1; else info "import: removed"; fi
+if [ "$SCOPE" = "town" ]; then
+  for frag in "${FRAGMENTS[@]}"; do
+    if fragment_present "$frag"; then info "fragment: \"$frag\" STILL PRESENT (append_fragments / global_fragments)"; fail=1; else info "fragment: \"$frag\" removed"; fi
+  done
+fi
+leftover=0
+while IFS= read -r f; do grep -q "$HOOK_MARKER" "$f" 2>/dev/null && leftover=$((leftover+1)); done \
+  < <(find "$CITY/.gc" "$CITY/.claude" \( -path '*/node_modules/*' -prune \) -o -name 'settings.json' -print 2>/dev/null)
+if [ "$leftover" -gt 0 ]; then info "hook: STILL in $leftover settings file(s)"; fail=1; else info "hook: removed from all projected settings"; fi
+
+echo
+if [ "$fail" -eq 0 ]; then
+  step "model-advisor uninstall complete ($SCOPE${RIG:+ $RIG})"
+  info "Backups (*.model-advisor.bak.*) were left in place; remove them when satisfied."
+  exit 0
+else
+  step "model-advisor uninstall finished WITH WARNINGS"
+  info "Review the STILL-* lines above."
+  exit 1
+fi

--- a/registry.toml
+++ b/registry.toml
@@ -77,3 +77,17 @@ source_kind = "git"
   commit = "d3617d1319a1206ac85f69ba024ec395c49c6f4b"
   hash = "sha256:0d32d8da6ad57c632d4f54008bdd1bb8b822c493a709676b3d1761a5ef389387"
   description = "Initial Slack pack release."
+
+[[pack]]
+name = "model-advisor"
+description = "Bayesian model-tier selection for Gas City agents — learn from outcomes, recommend + apply the cost-minimal model tier that preserves quality (clean-room CC-TS)."
+source = "https://github.com/gastownhall/gascity-packs/tree/main/model-advisor"
+source_kind = "git"
+
+  # commit/hash are placeholders for maintainers to finalize via release tooling on merge.
+  [[pack.release]]
+  version = "0.1.0"
+  ref = "main"
+  commit = "788b6e8ec224a8951c728ef6da74dab8bc04d474"
+  hash = "sha256:0705a80b26dd30ca1b539e8735f498ed3964a44f86bb0d35e654a2e990158b83"
+  description = "Initial model-advisor pack release."


### PR DESCRIPTION
Clean-room implementation of "Conservative Adaptive Model-Tier Selection" (CC-TS): per-cell Beta-Bernoulli posteriors over agent×shape×tier, a conservative quality-preservation gate, and asymmetric-loss tier selection. Learns from bd-closure + invocation telemetry; recommends and (per-agent) applies the cost-minimal tier that preserves quality. Adapts to the configured model roster; installs per town/rig. Stdlib-only; 71 tests.

Notes for maintainers: (1) code-bearing pack; (2) registry commit/hash are placeholders to finalize via release tooling on merge.