### PR TITLE
feat(provider-forge) Add provider-forge pack

### DIFF
--- a/provider-forge/.gitignore
+++ b/provider-forge/.gitignore
@@ -1,0 +1,14 @@
+.venv/
+__pycache__/
+*.pyc
+.pytest_cache/
+.ruff_cache/
+.coverage
+.coverage.*
+coverage.json
+coverage.xml
+htmlcov/
+
+# install.sh / uninstall.sh leave timestamped config backups next to the files
+# they edit; never commit those.
+*.provider-forge.bak.*

--- a/provider-forge/LICENSE
+++ b/provider-forge/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Jay German
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/provider-forge/README.md
+++ b/provider-forge/README.md
@@ -1,0 +1,278 @@
+<div align="center">
+
+# `provider-forge`
+
+### The canonical provider × model catalog for Gas City
+
+Gas City already knows how to send a dispatch to a *different provider and model* — the
+routing primitives are in core. What it lacks is a single, machine-readable answer to
+**which `(provider, model)` pairs exist**, what they cost, which `run_target` each maps to,
+and which ones are actually runnable right now. **provider-forge** is that catalog — one
+source of truth that powers enablement checks, builds run targets for cross-provider
+dispatch, and **generates [`model-advisor`](../model-advisor)'s tier roster** so the model
+list is maintained in exactly one place.
+
+[![License](https://img.shields.io/badge/license-MIT-blue?style=flat-square)](LICENSE)
+[![Gas City](https://img.shields.io/badge/Gas_City-pack-0f766e?style=flat-square)]()
+[![Layer](https://img.shields.io/badge/adds-catalog_·_enablement_·_effort-0f766e?style=flat-square)]()
+[![Routing](https://img.shields.io/badge/builds_on-gc.run__target_·_overlays-6d28d9?style=flat-square)]()
+[![Source of truth](https://img.shields.io/badge/roster-generated_from_catalog-6d28d9?style=flat-square)]()
+[![Providers](https://img.shields.io/badge/providers-2_live_·_7_scaffold-c2410c?style=flat-square)]()
+[![Schema](https://img.shields.io/badge/schema-provider--forge.v1-444?style=flat-square)]()
+[![No new routing](https://img.shields.io/badge/reinvents_routing-no-555?style=flat-square)]()
+
+[**What it is**](#what-it-is) ·
+[**The mechanism**](#the-mechanism-it-builds-on) ·
+[**The catalog**](#the-catalog) ·
+[**The surfaces**](#the-surfaces) ·
+[**Install**](#install--uninstall) ·
+[**model-advisor**](#model-advisor-integration) ·
+[**Caveats**](#caveats)
+
+</div>
+
+---
+
+## The gap
+
+Routing across providers is a *solved* problem in gc. The core formula
+[`mol-review-quorum`](#the-mechanism-it-builds-on) fans two read-only review lanes out to two
+**different** providers and models, then routes a third agent to synthesize them — and it does
+this today, with no extra machinery, by stamping `gc.run_target` / `gc.provider` / `gc.model`
+onto each step bead. The lever exists. The metadata keys exist. The per-provider overlays that
+make a non-native CLI behave like a gc agent exist.
+
+What does *not* exist is the **list**. To send a lane to "the cheapest Codex coding model" you
+have to already know that it is `gpt-5.3-codex-spark`, that it maps to the `codex-spark` run
+target, that the Codex CLI is installed and authed, that it wants `reasoning = high`, and that
+it costs roughly $0.50/$2.00 per MTok. That knowledge lives in people's heads and in scattered
+config. Worse, [`model-advisor`](../model-advisor) needs the *same* list — its cost-ordered
+`[[tier]]` roster — and maintaining two copies guarantees they drift.
+
+provider-forge fills exactly that gap and nothing more. It is the **catalog + enablement +
+effort layer** on top of gc's existing routing. It does **not** reinvent routing, ship a new
+dispatch path, or wrap `gc sling`.
+
+## What it is
+
+A small, declarative pack built around one file — `catalog.toml` — plus a read-only CLI
+(`bin/forge`) that interrogates it. The catalog enumerates every provider gc can target and,
+for each, the concrete models, their costs and context limits, their reasoning-effort
+options, and the `run_target` each `(provider, model)` resolves to. The CLI turns that data
+into the three things a human or an agent actually needs:
+
+| You want… | provider-forge gives you |
+|-----------|--------------------------|
+| **to know what exists & what's runnable** | `forge list` — the catalog, live vs scaffold, costs, effort |
+| **to know what's actually wired up** | `forge doctor` — CLI-installed + auth checks per provider |
+| **to dispatch to a specific provider+model** | `forge targets` — every live `run_target` / `gc.provider` / `gc.model` triple to stamp on a bead |
+| **to keep model-advisor's roster current** | `forge roster` — emits the cost-ordered `[[tier]]` block from the catalog |
+
+It is **all reads and one generator**. provider-forge never spawns a session, never mutates a
+bead, never edits an agent's config. It tells you the facts; you (or `model-advisor`, or a
+formula) act on them.
+
+## The mechanism it builds on
+
+provider-forge is deliberately thin because gc already carries the load. Two core primitives do
+the actual work of multi-provider routing:
+
+**1. Per-provider overlays.** For each non-native provider, gc ships an overlay under
+`.gc/system/packs/core/overlay/per-provider/<provider>/` that teaches that provider's CLI to
+behave like a gc agent — wiring its native hook surface to the gc lifecycle (`gc prime` on
+session start, `gc nudge drain` / `gc mail check` on prompt submit, `gc handoff` on compaction).
+Today gc ships overlays for **codex, copilot, cursor, gemini, kiro, omp, opencode, pi** — eight
+providers. (Claude is gc's *native* provider; it needs no overlay — its model is selected by the
+agent `model` config field, exported to the session as `GC_AGENT_MODEL`.) The overlay is what
+makes "run this work on Codex" mean something to gc at all.
+
+**2. Per-dispatch metadata: `gc.run_target` / `gc.provider` / `gc.model`.** A dispatch carries
+metadata, and three keys name *where it should run*:
+
+- `gc.run_target` — the configured gc agent/target that executes the step,
+- `gc.provider` — the provider identifier (must have an overlay, or be native),
+- `gc.model` — the concrete model the provider should use.
+
+The precedent is core's own [`mol-review-quorum`](#) formula. Each reviewer lane sets, verbatim:
+
+```toml
+# review-lane-one — stamped onto the step bead by the formula
+metadata = { "gc.run_target" = "{{lane_one_target}}",
+             "gc.provider"   = "{{lane_one_provider}}",
+             "gc.model"      = "{{lane_one_model}}",
+             "gc.reviewer_model" = "{{lane_one_model}}", … }
+```
+
+Lane one and lane two get *different* `(target, provider, model)` triples, so the same review
+runs on two independent providers and a third agent synthesizes the quorum. **That is the entire
+multi-provider routing pattern**, and it is already in the box. provider-forge's job is only to
+tell you *which triples are valid* — which `lane_one_provider` / `lane_one_model` /
+`lane_one_target` values are real, runnable, and cost what.
+
+> **The honest seam.** The metadata is consumed end-to-end for `provider`/`model`/`run_target`.
+> Reasoning **effort** (Codex's `low`/`medium`/`high`/`xhigh`) is the one field with no plumbing
+> yet — see [Caveats](#caveats). provider-forge *records* the right effort per model so it is
+> ready the day gc grows the seam to forward it.
+
+## The catalog
+
+`catalog.toml` (`schema_version = "provider-forge.v1"`) is the source of truth. Each provider is
+a table; each model is an array entry under it.
+
+```toml
+default_provider = "claude"            # gc's [workspace] provider
+
+[providers.codex]
+cli  = "codex"                         # the binary forge doctor probes
+overlay = "codex"                      # the gc per-provider overlay it uses
+status = "live"                        # "live" = CLI installed + authed; "scaffold" = overlay only
+auth = "~/.codex/auth.json"            # checked by forge doctor
+reasoning_levels   = ["low", "medium", "high", "xhigh"]
+default_reasoning  = "medium"
+
+[[providers.codex.models]]
+id    = "spark"                        # short handle
+model = "gpt-5.3-codex-spark"          # the concrete model → gc.model
+context = 128000
+default_reasoning = "high"             # advisory until the effort seam lands
+in_cost  = 0.50                        # $/MTok in   (Codex costs are ESTIMATES)
+out_cost = 2.00                        # $/MTok out
+run_target = "codex-spark"             # → gc.run_target
+note  = "ultra-fast coding"
+```
+
+The shape in one glance:
+
+| Field | On | Meaning |
+|-------|----|---------|
+| `cli`, `overlay`, `status`, `auth` | provider | what to probe, which gc overlay, live/scaffold, where auth lives |
+| `reasoning_levels`, `default_reasoning` | provider | the effort dial this provider exposes (empty ⇒ flat, e.g. Claude) |
+| `id`, `model`, `run_target` | model | the handle, the concrete `gc.model`, and its `gc.run_target` |
+| `context`, `in_cost`, `out_cost` | model | token limit and the rate sheet (`$/MTok`) |
+| `default_reasoning`, `note` | model | per-model effort default; free-text hint |
+| `exclude_from_roster` | model | set true to keep a specialized model out of the generated `[[tier]]` roster |
+
+Editing one model — adding a row, fixing a price, flipping a provider `live` — updates every
+surface at once: what `forge list` shows, what `forge targets` will hand a formula, and the
+roster `forge roster` regenerates for model-advisor.
+
+## The surfaces
+
+`bin/forge` is shipped by this pack (the sibling builder writes `pack.toml` + `bin/forge`). Four
+subcommands, all reads except where noted; every one takes `--json` for programmatic use.
+
+| Command | Does | Mutates? |
+|---------|------|----------|
+| `forge list [--all] [--json]` | the catalog as a table — providers, models, costs, context, effort; **live by default**, `--all` adds scaffolds | no |
+| `forge doctor [--json]` | enablement: for each live provider, is the `cli` on `PATH`? does `auth` exist? → `ready` / `missing-cli` / `missing-auth` | no |
+| `forge roster [--out FILE] [--provider P…]` | emit model-advisor's cost-ordered `[[tier]]` block from the catalog (stdout, or write a file) | no* |
+| `forge targets [--json]` | every live `gc.run_target` / `gc.provider` / `gc.model` triple — the dispatch lookup table | no |
+
+\* `roster` is a pure generator; it only writes if you pass `--out` (and then it writes
+*advisor* config, never the catalog).
+
+```bash
+forge list                            # what can I actually run right now? (live; --all for scaffolds)
+forge doctor                          # are my live providers truly wired? (CLI on PATH? auth present?)
+forge targets                         # the run_target / provider / model rows to stamp on a bead
+#   RUN TARGET     PROVIDER   MODEL
+#   codex-gpt54    codex      gpt-5.4
+#   …
+forge roster --out ../model-advisor/advisor.tiers.toml   # regenerate the tier list
+```
+
+`list` / `doctor` / `targets` are read-only and side-effect-free; they never dispatch or touch a
+bead. `targets` is the bridge to the [mechanism above](#the-mechanism-it-builds-on): it lists the
+`{ run_target, provider, model }` rows — pick the one for the model you want and stamp exactly
+those three values onto a step, the way `mol-review-quorum` (or any graph formula) does. (`--json`
+makes that pick scriptable.)
+
+## Install & uninstall
+
+provider-forge is a declarative, in-tree pack — a catalog and a read CLI. It carries no engine,
+no venv, no hooks; importing it is just registering it so its skill is discovered and `bin/forge`
+is on hand. Following the gas-town convention for a local pack, it imports via a **direct config
+entry**, not `gc import add`:
+
+```bash
+# whole town
+#   add to the city-root pack.toml:
+#     [imports.provider-forge]
+#     source = "packs/provider-forge"
+#   (optional) opt the skill in city-wide:
+#     city.toml  global_fragments += "use-provider-forge"
+gc reload
+
+# one rig
+#   add under the matching [[rigs]] in city.toml:
+#     [rigs.imports.provider-forge]
+#     source = "packs/provider-forge"
+gc reload
+```
+
+`gc reload` makes the `use-provider-forge` skill discoverable (by directory convention — see the
+[skill](skills/use-provider-forge/SKILL.md)); verify with `gc skill list` (it appears
+binding-qualified, e.g. `provider-forge.use-provider-forge`). To uninstall, drop the import block
+(and any `global_fragments` entry) and `gc reload`. Nothing else is materialized, so removal is a
+config revert — the pack mutates no projected settings and no agent config.
+
+## model-advisor integration
+
+provider-forge and [`model-advisor`](../model-advisor) are two halves of one story:
+**provider-forge owns *what models exist and cost*; model-advisor owns *which one to use*.** The
+seam between them is the roster.
+
+- **Catalog → roster (maintain the list once).** model-advisor's decision rule needs a
+  cost-ordered `[[tier]]` roster — its `(provider, model)` run targets ranked cheapest→dearest.
+  Rather than hand-maintain that beside the catalog, `forge roster` **generates** it: it reads
+  every `live` provider's models (skipping any `exclude_from_roster = true`), orders them by cost,
+  and emits the `[[tier]]` block (or writes it with `--out`). One edit to `catalog.toml`, one
+  `forge roster`, and the advisor's roster is current. No drift.
+
+- **Advisor → cross-provider apply.** When model-advisor recommends a tier that lives on a
+  *different* provider, *applying* it is exactly the [routing pattern above](#the-mechanism-it-builds-on):
+  set `gc.provider` / `gc.model` / `gc.run_target` on the work bead (the per-dispatch path
+  model-advisor is wiring to the gc-core spawn seam) — and those three values come straight from
+  the catalog via `forge targets`. provider-forge supplies the *vocabulary*; model-advisor makes
+  the *choice*; gc's metadata mechanism carries it.
+
+The division of labor: **catalog (provider-forge) → recommendation (model-advisor) → dispatch
+metadata (gc core).** Neither pack reimplements the other's job, and neither reimplements routing.
+
+## Caveats
+
+Honest about the scope line.
+
+- **Live vs scaffold providers.** Only **codex** and **claude** are *live* — CLI installed and
+  authed, runnable now. The other seven gc providers (**gemini, copilot, cursor, kiro, omp,
+  opencode, pi**) ship as **scaffolds**: gc *has* their per-provider overlays, but each needs its
+  CLI installed, its models filled into `catalog.toml`, and `status` flipped to `live` before it
+  can be dispatched to. `forge list --all` shows which providers are still scaffold; once you set
+  one `live`, `forge doctor` then verifies its CLI + auth are actually wired. The scaffold model
+  lists are intentionally empty — fill them from each provider's own docs when you enable it.
+
+- **Effort enforcement is pending a gc-core seam.** Reasoning **effort** (Codex's
+  `low`/`medium`/`high`/`xhigh`) is captured per model in the catalog, but gc has **no effort
+  path today** — the launcher forwards `gc.model` (via `GC_AGENT_MODEL`) but nothing forwards a
+  non-default effort to the provider CLI. So the `reasoning` / `default_reasoning` fields are
+  **advisory** until a small gc-core change lands to forward them — the **same shape** as
+  model-advisor's per-dispatch gc-core ask (bind a bead's routing metadata at spawn). The catalog
+  records the right effort now so it is ready the day the seam exists.
+
+- **Codex costs are estimates.** The `in_cost` / `out_cost` figures for Codex models are
+  **placeholders**, not a billed rate sheet — replace them with your real numbers. They are
+  good enough to *cost-order* the roster; they are not invoice-accurate.
+
+- **Catalog is declarative, not auto-discovered.** provider-forge does not scrape provider APIs
+  for new models or live prices. It is a curated file you maintain. `forge doctor` verifies
+  *enablement* (CLI + auth); it does not verify that a model ID still exists upstream or that a
+  price is current.
+
+- **It catalogs; it does not route.** provider-forge adds the missing data layer. The actual
+  dispatch is gc's: the overlays, the `gc.run_target` / `gc.provider` / `gc.model` metadata, and
+  formulas like `mol-review-quorum` that stamp them. provider-forge never wraps `gc sling`, never
+  spawns a session, and never edits agent config.
+
+## License
+
+MIT © Jay German. See [LICENSE](LICENSE).

--- a/provider-forge/bin/forge
+++ b/provider-forge/bin/forge
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# provider-forge CLI: list / doctor / roster / targets over the catalog.
+#
+#   bin/forge list   [--all] [--json]
+#   bin/forge doctor [--json]
+#   bin/forge roster [--out FILE] [--provider P ...]
+#   bin/forge targets [--json]
+#
+# This wrapper resolves the pack's own venv python (so forge runs under the
+# interpreter its deps are installed in), falling back to system python3, then
+# hands off to `python -m forge.cli`. It mirrors model-advisor/bin/advisor.
+#
+# Degrades gracefully: the engine is pure-stdlib (tomllib on Python >= 3.11), so
+# it runs fine with no .venv as long as some python3 is present. If NO
+# interpreter is found it prints a clear error to stderr and exits 2 — it never
+# silently no-ops.
+set -euo pipefail
+PACK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PY="$PACK_DIR/.venv/bin/python"
+[ -x "$PY" ] || PY="$(command -v python3 || true)"
+[ -n "$PY" ] || { echo "forge: no python interpreter found (no .venv, no python3)" >&2; exit 2; }
+exec env PYTHONPATH="$PACK_DIR${PYTHONPATH:+:$PYTHONPATH}" "$PY" -m forge.cli "$@"

--- a/provider-forge/catalog.toml
+++ b/provider-forge/catalog.toml
@@ -1,0 +1,168 @@
+# provider-forge — canonical provider × model catalog for Gas City.
+#
+# gc already ships the routing primitives: per-provider overlays
+# (.gc/system/packs/core/overlay/per-provider/<provider>/) and per-dispatch
+# metadata `gc.run_target` / `gc.provider` / `gc.model` (see core formula
+# mol-review-quorum). What gc lacks is a single, machine-readable list of WHICH
+# (provider, model) pairs exist, their costs/limits, and the run_target each maps
+# to. This file is that list — the source of truth that:
+#   • model-advisor's [[tier]] roster is generated from (one place to edit), and
+#   • `bin/forge` reads to verify auth, build run targets, and dispatch.
+#
+# COSTS under flat-rate subscriptions: both providers run on subscriptions here
+# (Claude Max 20x + Codex), NOT per-token API billing — so in_cost/out_cost are not
+# dollars. Treat them as RELATIVE QUOTA / COMPUTE WEIGHT: bigger models burn more of
+# the 5h/weekly quota and run slower, so the advisor still rightly prefers the smallest
+# model that holds quality. (A true quota-/rate-limit-aware cost model — balancing load
+# across the two subscriptions — is a worthwhile model-advisor refinement, tracked apart.)
+# reasoning effort is captured per model; ENFORCING a non-default effort needs a
+# gc-core seam to forward it to the provider CLI (gc has no effort path today),
+# so the `reasoning` field is advisory until that lands (tracked as a gc-core PR).
+
+schema_version = "provider-forge.v1"
+default_provider = "claude"           # gc [workspace] provider
+
+# =========================================================================== #
+# LIVE providers — CLI installed + authed, runnable now.                       #
+# =========================================================================== #
+
+[providers.claude]
+cli = "claude"
+overlay = ""                          # native — gc's default provider; no overlay dir (model set via the agent `model` field / GC_AGENT_MODEL)
+status = "live"
+native = true                         # gc's default provider
+reasoning_levels = []                 # Claude tiers are flat (no effort dial)
+
+[[providers.claude.models]]
+id = "haiku"
+model = "claude-haiku-4-5"
+context = 200000
+in_cost = 0.80
+out_cost = 4.00
+run_target = "claude-haiku"
+
+[[providers.claude.models]]
+id = "sonnet"
+model = "claude-sonnet-4-5"
+context = 200000
+in_cost = 3.00
+out_cost = 15.00
+run_target = "claude-sonnet"
+
+[[providers.claude.models]]
+id = "opus"
+model = "claude-opus-4-8"
+context = 200000
+in_cost = 15.00
+out_cost = 75.00
+run_target = "claude-opus"
+
+[providers.codex]
+cli = "codex"
+overlay = "codex"
+status = "live"
+auth = "~/.codex/auth.json"
+models_cache = "~/.codex/models_cache.json"
+reasoning_levels = ["low", "medium", "high", "xhigh"]
+default_reasoning = "medium"
+
+[[providers.codex.models]]
+id = "spark"
+model = "gpt-5.3-codex-spark"
+context = 128000
+default_reasoning = "high"
+in_cost = 0.50
+out_cost = 2.00
+run_target = "codex-spark"
+note = "ultra-fast coding"
+
+[[providers.codex.models]]
+id = "mini"
+model = "gpt-5.4-mini"
+context = 272000
+default_reasoning = "medium"
+in_cost = 0.70
+out_cost = 3.00
+run_target = "codex-mini"
+note = "small / fast / cost-efficient"
+
+[[providers.codex.models]]
+id = "gpt54"
+model = "gpt-5.4"
+context = 272000
+default_reasoning = "medium"
+in_cost = 2.50
+out_cost = 10.00
+run_target = "codex-gpt54"
+note = "strong everyday coding"
+
+[[providers.codex.models]]
+id = "gpt55"
+model = "gpt-5.5"
+context = 272000
+default_reasoning = "medium"
+in_cost = 8.00
+out_cost = 30.00
+run_target = "codex-gpt55"
+note = "frontier: complex coding / research"
+
+[[providers.codex.models]]
+id = "auto-review"
+model = "codex-auto-review"
+context = 272000
+default_reasoning = "medium"
+in_cost = 3.00
+out_cost = 15.00
+run_target = "codex-auto-review"
+note = "Codex auto-approval review model — specialized; omit from a general roster unless you dispatch reviews to it"
+exclude_from_roster = true
+
+# =========================================================================== #
+# SCAFFOLD providers — gc has the overlay, CLI NOT installed. Install the CLI,  #
+# add models below, and set status = "live" to activate. Model lists/costs are  #
+# intentionally empty (fill from each provider's docs when you enable it).      #
+# =========================================================================== #
+
+[providers.gemini]
+cli = "gemini"
+overlay = "gemini"
+status = "scaffold"
+reasoning_levels = []
+# [[providers.gemini.models]]
+#   id = "..." ; model = "..." ; context = ... ; in_cost = ... ; out_cost = ... ; run_target = "gemini-..."
+
+[providers.copilot]
+cli = "copilot"
+overlay = "copilot"
+status = "scaffold"
+reasoning_levels = []
+
+[providers.cursor]
+cli = "cursor"
+overlay = "cursor"
+status = "scaffold"
+reasoning_levels = []
+
+[providers.kiro]
+cli = "kiro"
+overlay = "kiro"
+status = "scaffold"
+reasoning_levels = []
+
+[providers.omp]
+cli = "omp"
+overlay = "omp"
+status = "scaffold"
+reasoning_levels = []
+
+[providers.opencode]
+cli = "opencode"
+overlay = "opencode"
+status = "scaffold"
+reasoning_levels = []
+
+[providers.pi]
+cli = "pi"
+overlay = "pi"
+status = "scaffold"
+reasoning_levels = []

--- a/provider-forge/docs/DESIGN.md
+++ b/provider-forge/docs/DESIGN.md
@@ -1,0 +1,350 @@
+# provider-forge — DESIGN
+
+A gc (Gas City) pack that supplies the **canonical provider × model catalog** — the single,
+machine-readable list of which `(provider, model)` pairs exist, what they cost, which
+`run_target` each maps to, and which are runnable today. It is the **catalog + enablement +
+effort layer** on top of gc's *existing* multi-provider routing primitives; it does not add a
+new routing path.
+
+- Schema: `provider-forge.v1` (`catalog.toml`).
+- Status: catalog + read CLI. The CLI (`bin/forge`) and `pack.toml` are built alongside this
+  doc by the sibling builder; this document specifies the data, the mechanism it rides on, and
+  the two integration seams (model-advisor roster; cross-provider apply).
+
+> **Scope guard.** This document specifies the catalog's data model and how it plugs into gc's
+> routing, not the CLI's internals. It is precise enough that `bin/forge` can implement
+> `list` / `doctor` / `roster` / `targets` against the schema, and that a reader can see exactly
+> where provider-forge stops and gc-core begins.
+
+---
+
+## 0. One-paragraph summary
+
+gc can already dispatch a unit of work to an arbitrary provider and model: each non-native
+provider has a per-provider overlay that makes its CLI behave like a gc agent, and a dispatch
+names its destination with three metadata keys — `gc.run_target`, `gc.provider`, `gc.model` —
+the exact pattern core's `mol-review-quorum` formula uses to fan review lanes across providers.
+What gc lacks is a registry of *which* `(provider, model)` triples are valid, runnable, and
+priced. `catalog.toml` is that registry. From it, `bin/forge` answers three questions —
+**what exists** (`list`), **what's actually wired** (`doctor`), and **what to stamp on a bead to
+route there** (`targets`) — and **generates** model-advisor's cost-ordered `[[tier]]` roster
+(`roster`) so the model list is maintained once. The catalog also records reasoning **effort**
+per model, ready for a small gc-core seam that does not exist yet. provider-forge is declarative,
+read-only, and additive: it owns *data*, gc-core owns *routing*, model-advisor owns *choice*.
+
+---
+
+## 1. The catalog schema (`catalog.toml`)
+
+### 1.1 Top level
+
+```toml
+schema_version  = "provider-forge.v1"
+default_provider = "claude"            # mirrors gc's [workspace] provider
+```
+
+`default_provider` records gc's native/default provider so surfaces can mark it and so the
+roster generator knows which provider needs no overlay.
+
+### 1.2 A provider table
+
+```toml
+[providers.<name>]
+cli     = "<binary>"        # the executable forge doctor probes on PATH
+overlay = "<name>"          # the gc per-provider overlay this provider uses (§2.1)
+status  = "live" | "scaffold"
+native  = true              # optional; true only for gc's default provider (Claude)
+auth    = "~/path"          # optional; a file whose existence forge doctor checks
+models_cache = "~/path"     # optional; provider-maintained model cache, informational
+reasoning_levels  = [ ... ] # the effort dial this provider exposes; [] ⇒ flat (no dial)
+default_reasoning = "medium" # provider-level effort default (when levels are non-empty)
+```
+
+| Field | Required | Meaning |
+|-------|:--------:|---------|
+| `cli` | yes | binary name `forge doctor` looks for on `PATH` |
+| `overlay` | yes | the `core/overlay/per-provider/<overlay>/` gc ships for this provider |
+| `status` | yes | `live` = CLI installed + authed, dispatchable now; `scaffold` = overlay exists, CLI/models not yet present |
+| `native` | no | `true` for gc's default provider only; native providers need no overlay |
+| `auth` | no | path whose presence indicates the CLI is authed (probed by `doctor`) |
+| `models_cache` | no | provider-side model cache path; informational |
+| `reasoning_levels` | yes | ordered effort options (e.g. `["low","medium","high","xhigh"]`); `[]` means the provider has no effort dial |
+| `default_reasoning` | no | provider default effort; per-model `default_reasoning` overrides it |
+
+### 1.3 A model entry
+
+```toml
+[[providers.<name>.models]]
+id      = "<handle>"        # short, human handle (unique within the provider)
+model   = "<concrete-id>"   # the exact model string → bead gc.model
+context = 272000            # token context window
+in_cost  = 2.50             # $/MTok input
+out_cost = 10.00            # $/MTok output
+run_target = "<target>"     # the gc run target → bead gc.run_target
+default_reasoning = "high"  # optional; per-model effort (advisory; see §4)
+note    = "free text"       # optional; one-line hint
+exclude_from_roster = true  # optional; keep this model out of the generated [[tier]] roster (§5)
+```
+
+| Field | Required | Meaning |
+|-------|:--------:|---------|
+| `id` | yes | short handle, unique per provider; labels the model in `forge list` / `targets` |
+| `model` | yes | concrete model string the provider CLI uses; becomes `gc.model` |
+| `run_target` | yes | the configured gc target that runs it; becomes `gc.run_target` |
+| `context` | yes | context-window size (tokens) |
+| `in_cost` / `out_cost` | yes | rate sheet in `$/MTok`; the basis for cost-ordering the roster |
+| `default_reasoning` | no | per-model effort default (advisory until §4's seam lands) |
+| `note` | no | free-text hint surfaced by `forge list` |
+| `exclude_from_roster` | no | `true` ⇒ omit from `forge roster` output (specialized models, e.g. an auto-review model) |
+
+### 1.4 Invariants
+
+- `run_target` values are unique across the whole catalog (one target ⇒ one `(provider, model)`).
+- `model.id` is unique within its provider; `(provider, id)` is globally unique.
+- A `live` provider should have ≥ 1 model; a `scaffold` provider may have zero (model lists are
+  filled in when the provider is enabled).
+- Costs are `$/MTok`; they need only be *ordinally* correct to cost-order the roster, but should
+  be replaced with real figures where they are estimates (Codex — see §7).
+- `reasoning_levels = []` ⇒ the provider has no effort dial; any per-model `default_reasoning`
+  is then meaningless and should be omitted (e.g. Claude tiers are flat).
+
+---
+
+## 2. How gc's multi-provider mechanism works
+
+provider-forge adds **no** routing. It is worth stating precisely what it rides on, because the
+catalog's whole value is being the registry for these two primitives.
+
+### 2.1 Per-provider overlays
+
+For each **non-native** provider, gc ships an overlay at
+`.gc/system/packs/core/overlay/per-provider/<provider>/`. The overlay teaches that provider's
+*own* CLI to participate in the gc lifecycle by writing into the CLI's native hook surface — e.g.
+the Codex overlay is `.codex/hooks.json` mapping:
+
+- `SessionStart → gc prime --hook --hook-format codex`
+- `UserPromptSubmit → gc nudge drain --inject` and `gc mail check --inject`
+- `PreCompact → gc handoff --auto`
+
+Each provider's overlay targets its native format: `.codex/hooks.json` (codex),
+`.cursor/hooks.json` (cursor), `.gemini/settings.json` (gemini), `.github/…` (copilot),
+`AGENTS.md` + `.kiro/…` (kiro), `.omp/hooks/gc-hook.ts` (omp), `.opencode/plugins/…` (opencode),
+`.pi/extensions/…` (pi). gc ships overlays for **eight** providers: **codex, copilot, cursor,
+gemini, kiro, omp, opencode, pi**.
+
+**Claude is the native provider and has no overlay.** Its model is selected by the agent `model`
+config field, which gc resolves and exports to the session as `GC_AGENT_MODEL`; the Claude
+adapter is built in. (The catalog still records `overlay = "claude"` as a label for symmetry, but
+no such overlay directory is shipped — Claude needs none. `doctor` treats native providers
+accordingly.)
+
+The overlay is the precondition for "run this work on provider X" to mean anything: without it,
+gc has no way to make that CLI behave like one of its agents.
+
+### 2.2 Per-dispatch metadata: the routing triple
+
+A dispatch carries metadata. Three keys name **where it runs**:
+
+| Key | Value | Constraint |
+|-----|-------|------------|
+| `gc.run_target` | the configured gc target/agent that executes the step | must be a real target |
+| `gc.provider` | provider identifier | must be native, or have an overlay (§2.1) |
+| `gc.model` | the concrete model string | must be valid for that provider |
+
+A formula step (or a work bead) sets these in its `metadata` map. gc routes the step to the named
+target; the provider/model travel with it. (`gc.model` reaches the provider via `GC_AGENT_MODEL`
+on the per-agent path; the per-dispatch binding of bead-`gc.model` at spawn is the gc-core seam
+model-advisor is wiring — §6.2.)
+
+### 2.3 The precedent: `mol-review-quorum`
+
+Core's `mol-review-quorum` formula (`.gc/system/packs/core/formulas/mol-review-quorum.toml`,
+`contract = "graph.v2"`) is the canonical demonstration. It takes per-lane variables —
+`lane_one_provider`, `lane_one_model`, `lane_one_target` (and the same for lane two) — and stamps
+each reviewer step:
+
+```toml
+# step "review-lane-one"
+metadata = { "gc.run_target" = "{{lane_one_target}}",
+             "gc.provider"   = "{{lane_one_provider}}",
+             "gc.model"      = "{{lane_one_model}}",
+             "gc.review_quorum_lane" = "{{lane_one_id}}",
+             "gc.reviewer_model"     = "{{lane_one_model}}",
+             "gc.output_json_schema" = "review-quorum.lane.v1",
+             "gc.output_json_required" = "true" }
+```
+
+Lane two gets a *different* triple; a third step (`synthesize-review-quorum`,
+`needs = [lane-one, lane-two]`) routes to `synthesis_target` and combines the two durable
+outputs. The result: one review fanned across two independent providers/models, synthesized by a
+third — using nothing but the metadata triple. **This is the multi-provider routing pattern in
+its entirety.** provider-forge exists only to make the lane variables *answerable*: which
+`lane_one_provider` / `lane_one_model` / `lane_one_target` values are valid, live, and priced.
+
+---
+
+## 3. The run_target model
+
+A `run_target` is gc's stable name for "a configured place a step can run." In the catalog it is
+the join key between an abstract model and a concrete dispatch:
+
+```
+(provider, model)  ──catalog──►  run_target  ──gc──►  a spawned session on that provider+model
+```
+
+- The catalog declares the mapping `(provider, model) → run_target` (one-to-one, §1.4).
+- A dispatch references it as `gc.run_target` and pairs it with `gc.provider` + `gc.model`.
+- `forge targets` is the lookup: it lists every live `{ run_target, provider, model }` triple —
+  pick the row for the model you want and stamp those three values on a step, i.e. exactly the
+  values §2.3 puts in a formula's `metadata`. (`--json` makes the pick scriptable.)
+
+`run_target` is intentionally a *name*, not a spawn recipe: provider-forge does not own how gc
+realizes a target into a session (that is gc-core's launcher). It owns the **catalog of valid
+names** and their model/cost/effort facts. This keeps the boundary clean — provider-forge is data
+about routing, never the act of routing.
+
+---
+
+## 4. The effort gap and the gc-core seam it needs
+
+Reasoning **effort** is a per-model dial on some providers — Codex exposes
+`low` / `medium` / `high` / `xhigh`. The catalog captures it (`reasoning_levels` on the provider,
+`default_reasoning` on the provider and per model) because the *right* effort is part of a model's
+identity for routing (e.g. `spark` wants `high`).
+
+**But gc has no effort path today.** The launcher forwards the model (resolved agent `model` →
+`GC_AGENT_MODEL`), and the Codex adapter is even seen to build `--model … --effort …` argv — but
+nothing carries a *non-default* effort from a dispatch through to that argv. There is no agent
+config field for it and no metadata key gc consumes for it. So:
+
+> **Effort is advisory.** The `reasoning_levels` / `default_reasoning` fields document the
+> intended effort and let surfaces display it, but provider-forge cannot *enforce* a non-default
+> effort. The model runs at the provider's own default.
+
+**The seam needed** is small and the *same shape* as model-advisor's per-dispatch ask: have gc
+forward a routing field from the dispatch to the provider CLI. Concretely, either
+
+1. a metadata key (e.g. `gc.reasoning` / `gc.effort`) that the launcher reads off the routed bead
+   and forwards to the provider adapter's `--effort` argv (mirroring how `gc.model` →
+   `GC_AGENT_MODEL` would bind at spawn), or
+2. an agent/dispatch config field that resolves into the adapter argv the way `model` resolves
+   into `GC_AGENT_MODEL`.
+
+Both are localized: the adapter *already* accepts `--effort`; what is missing is the wire from a
+dispatch to it. The day that lands, the catalog's effort fields become enforceable with no schema
+change. (Tracked as a gc-core PR alongside model-advisor's per-dispatch binding.)
+
+---
+
+## 5. The model-advisor integration (catalog → roster)
+
+[`model-advisor`](../model-advisor) recommends the cost-minimal model tier per `(agent, shape)`.
+Its decision rule needs a cost-ordered `[[tier]]` roster — each tier a `(provider, model)` run
+target with a cost rank. That roster is the **same list** as the catalog, projected. Maintaining
+two copies guarantees drift, so the catalog is the source and `forge roster` is the generator.
+
+**`forge roster` algorithm:**
+
+1. Collect every model under every `status = "live"` provider.
+2. Drop any model with `exclude_from_roster = true` (specialized models — e.g. an auto-review
+   model — that should not be in a general roster).
+3. Order the remainder by cost (a blended `in_cost`/`out_cost` measure, cheapest → dearest) and
+   assign `rank`.
+4. Emit a `[[tier]]` block in model-advisor's config shape — for each tier: `id` (from model
+   `id`), `provider`, `model` (concrete), `run_target`, `in_cost`, `out_cost`, `rank`.
+5. Print to stdout, or write to a file with `--out FILE` (it writes *advisor* config, never the
+   catalog).
+
+So the maintenance loop is: edit `catalog.toml` (add a model, fix a price, flip a provider to
+`live`) → `forge roster --out …` → model-advisor's roster is current. One edit, one place.
+
+> **Scaffold providers are excluded automatically** — only `live` models reach the roster, so
+> model-advisor never ranks a tier you cannot actually dispatch to. As you enable a scaffold
+> provider (install CLI, fill models, set `live`), re-running `forge roster` folds it in.
+
+---
+
+## 6. The dispatch integration (advisor → cross-provider apply)
+
+### 6.1 The division of labor
+
+```
+provider-forge          model-advisor              gc core
+──────────────          ─────────────              ───────
+catalog of valid    →   chooses the cheapest   →   carries the choice as the
+(provider, model)       tier that credibly         routing triple on a bead
+run targets + costs     preserves quality          (gc.run_target/provider/model)
+```
+
+Each pack owns one layer and reimplements nothing of the others. provider-forge supplies the
+*vocabulary* (which triples exist), model-advisor makes the *choice*, gc's metadata mechanism
+(§2) carries it.
+
+### 6.2 Cross-provider apply is the routing triple
+
+model-advisor's roster (§5) can include tiers on *different providers*. When it recommends a tier
+that is not the agent's current provider, applying it is exactly the §2.3 pattern: set
+**`gc.provider` / `gc.model` / `gc.run_target`** on the work bead. Those three values are precisely
+the `forge targets` row for that model. So a cross-provider apply is:
+
+1. model-advisor recommends tier *T* (provider *P*, model *M*).
+2. `forge targets` → pick the row whose `provider`/`model` is *P*/*M* → `{ run_target, provider, model }`.
+3. Stamp that triple on the work bead's metadata — the per-dispatch routing model-advisor is
+   wiring to gc-core's spawn seam (the launcher binding a routed bead's `gc.model` →
+   `GC_AGENT_MODEL` at spawn; the same seam family as §4's effort wire).
+
+provider-forge does not perform the apply (it mutates nothing). It guarantees the triple
+model-advisor stamps is *valid and live* — that is its contribution to the dispatch path.
+
+---
+
+## 7. Live vs scaffold, and the honest edges
+
+- **Live:** `claude` (native; model via `GC_AGENT_MODEL`) and `codex` (CLI + auth present). These
+  are dispatchable now and populate the roster.
+- **Scaffold:** `gemini, copilot, cursor, kiro, omp, opencode, pi`. gc ships their overlays
+  (§2.1), so the *routing* half is ready, but each needs its CLI installed, its models filled into
+  the catalog, and `status` flipped to `live`. Their model arrays are intentionally empty; fill
+  them from each provider's docs on enablement. `forge list --all` surfaces which providers are
+  still scaffold; once one is set `live`, `forge doctor` then checks whether its CLI + auth are
+  actually present.
+- **Codex costs are estimates.** Codex `in_cost`/`out_cost` are placeholders — ordinally fine for
+  ranking, not invoice-accurate. Replace with a real rate sheet.
+- **The catalog is curated, not scraped.** provider-forge does not poll provider APIs for new
+  models or live prices. `doctor` checks *enablement* (CLI + auth), not upstream model existence
+  or price currency.
+
+---
+
+## 8. Surfaces (CLI) — contract
+
+`bin/forge` (built by the sibling builder). All reads; `roster` writes only with `--out`. Every
+command supports `--json`.
+
+| Command | Reads | Emits |
+|---------|-------|-------|
+| `forge list [--all] [--json]` | catalog | table: provider, model, run_target, costs, context, effort, status (**live by default**; `--all` adds scaffolds) |
+| `forge doctor [--json]` | catalog + filesystem (`cli` on `PATH`, `auth` exists) | per live provider: `ready` / `missing-cli` / `missing-auth` (no-`auth` ⇒ authed-by-other-means) |
+| `forge roster [--out FILE] [--provider P…]` | catalog (live, non-excluded) | model-advisor `[[tier]]` block, cost-ordered (§5) |
+| `forge targets [--json]` | catalog (live) | the `{ run_target, provider, model }` rows to stamp (§3, §6.2) |
+
+Degradation: `list`/`targets` are pure reads of the catalog; `doctor` is the only one that touches
+the filesystem and degrades to a `missing-cli` / `missing-auth` status (and a non-zero exit) rather
+than erroring when a CLI or auth file is absent; `roster` is a pure generator and never reads
+outside the catalog.
+
+---
+
+## 9. Acceptance (what "implements this doc" means)
+
+- `catalog.toml` validates against §1 (schema_version, provider tables, model arrays, invariants).
+- `forge list` shows live catalog entries with costs/context/effort; `--all` adds scaffolds.
+- `forge doctor` classifies each **live** provider as `ready` / `missing-cli` / `missing-auth` by
+  probing `cli` on `PATH` and `auth` existence (a provider with no `auth` is authed-by-other-means,
+  e.g. Claude's native session).
+- `forge targets` lists the exact `{ run_target, provider, model }` rows §2.3 stamps, for every
+  live model.
+- `forge roster` emits a cost-ordered `[[tier]]` block from live, non-`exclude_from_roster` models
+  that model-advisor consumes unchanged; `--out` writes advisor config only.
+- No surface dispatches, spawns a session, mutates a bead, or edits agent config. Routing remains
+  gc-core's (§2); choice remains model-advisor's (§5–§6).

--- a/provider-forge/forge/__init__.py
+++ b/provider-forge/forge/__init__.py
@@ -1,0 +1,46 @@
+"""provider-forge — the canonical provider × model catalog for Gas City.
+
+A pure-stdlib reader over ``catalog.toml`` (the source of truth: providers ×
+models, ``status`` live|scaffold, ``run_target``, costs, ``reasoning_levels``,
+``exclude_from_roster``). It powers four read-mostly surfaces:
+
+- ``forge list``    — providers + models (live by default; ``--all`` adds scaffolds).
+- ``forge doctor``  — per-live-provider CLI-on-PATH + auth-file readiness.
+- ``forge roster``  — generate model-advisor's cost-ordered ``[[tier]]`` roster
+  (the integration: maintain the model list once, here).
+- ``forge targets`` — the ``run_target`` gc session configs the catalog expects.
+
+Public surface (what the CLI and other tools build on):
+
+- :mod:`forge.catalog` — :func:`~forge.catalog.load_catalog` into a
+  :class:`~forge.catalog.Catalog` of :class:`~forge.catalog.Provider` /
+  :class:`~forge.catalog.Model` records, plus the cost-ordered
+  :meth:`~forge.catalog.Catalog.roster_tiers` view.
+- :mod:`forge.cli`     — the ``list`` / ``doctor`` / ``roster`` / ``targets``
+  command implementations and :func:`~forge.cli.render_roster_toml`.
+"""
+
+from __future__ import annotations
+
+SCHEMA_VERSION = "provider-forge.v1"
+
+from forge.catalog import (  # noqa: E402  (re-export after module docstring)
+    Catalog,
+    CatalogError,
+    Model,
+    Provider,
+    load_catalog,
+    parse_catalog,
+    default_catalog_path,
+)
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "Catalog",
+    "CatalogError",
+    "Model",
+    "Provider",
+    "load_catalog",
+    "parse_catalog",
+    "default_catalog_path",
+]

--- a/provider-forge/forge/catalog.py
+++ b/provider-forge/forge/catalog.py
@@ -1,0 +1,279 @@
+"""provider-forge — the catalog reader.
+
+Loads ``catalog.toml`` (the source of truth) into typed, immutable records and
+provides the derived views the CLI renders:
+
+- :func:`load_catalog`     parse + validate ``catalog.toml`` into a :class:`Catalog`.
+- :class:`Provider`        one provider (claude, codex, gemini, …): cli/auth/status/overlay.
+- :class:`Model`           one (provider, model) row: id/model/run_target/costs/reasoning.
+- :meth:`Catalog.live`     the live providers (CLI installed + authed, runnable now).
+- :meth:`Catalog.models`   flat (provider, model) rows, optionally live-only.
+- :meth:`Catalog.roster_tiers`  the cost-ordered tier list model-advisor consumes.
+
+Pure stdlib: TOML via :mod:`tomllib` (Python >= 3.11) with a :mod:`tomli`
+fallback below it, exactly mirroring model-advisor's loader shim. No I/O beyond
+reading the catalog file; no third-party deps.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Iterator, Optional
+
+try:  # Python >= 3.11 ships tomllib; older interpreters fall back to tomli.
+    import tomllib  # type: ignore[import-not-found]
+except ModuleNotFoundError:  # pragma: no cover - exercised only on < 3.11
+    import tomli as tomllib  # type: ignore[no-redef]
+
+SCHEMA_VERSION = "provider-forge.v1"
+
+# The catalog file ships at the pack root, next to pack.toml.
+_DEFAULT_CATALOG = Path(__file__).resolve().parents[1] / "catalog.toml"
+
+# Provider status values the catalog may declare.
+STATUS_LIVE = "live"
+STATUS_SCAFFOLD = "scaffold"
+
+
+class CatalogError(Exception):
+    """Raised when catalog.toml is missing, unparseable, or malformed."""
+
+
+@dataclass(frozen=True)
+class Model:
+    """One (provider, model) row from the catalog.
+
+    ``provider`` is the binding key (claude/codex/…); ``id`` is the short tier
+    handle (haiku/spark/…); ``model`` is the wire model name. ``run_target`` is
+    the gc session config this pair dispatches through. Costs are $/MTok.
+    """
+
+    provider: str
+    id: str
+    model: str
+    run_target: str
+    in_cost: float
+    out_cost: float
+    context: Optional[int] = None
+    default_reasoning: Optional[str] = None
+    note: Optional[str] = None
+    exclude_from_roster: bool = False
+
+    @property
+    def cost_key(self) -> float:
+        """Cost-ordering key: sum of input + output $/MTok (rank 1 = cheapest)."""
+        return self.in_cost + self.out_cost
+
+
+@dataclass(frozen=True)
+class Provider:
+    """One provider entry: its CLI, auth file, overlay, status, and models."""
+
+    name: str
+    cli: str
+    overlay: str
+    status: str
+    native: bool = False
+    auth: Optional[str] = None
+    models_cache: Optional[str] = None
+    reasoning_levels: tuple[str, ...] = ()
+    default_reasoning: Optional[str] = None
+    models: tuple[Model, ...] = ()
+
+    @property
+    def is_live(self) -> bool:
+        return self.status == STATUS_LIVE
+
+    def auth_path(self) -> Optional[Path]:
+        """The provider's auth file as an absolute path (``~`` expanded), or None."""
+        if not self.auth:
+            return None
+        return Path(os.path.expanduser(self.auth))
+
+
+@dataclass(frozen=True)
+class Catalog:
+    """The parsed catalog: schema metadata + all providers."""
+
+    schema_version: str
+    default_provider: str
+    providers: tuple[Provider, ...] = field(default_factory=tuple)
+
+    # -- provider views ------------------------------------------------------
+    def live(self) -> list[Provider]:
+        """Live providers, in catalog declaration order."""
+        return [p for p in self.providers if p.is_live]
+
+    def scaffold(self) -> list[Provider]:
+        """Scaffold providers (overlay present, CLI not yet installed)."""
+        return [p for p in self.providers if not p.is_live]
+
+    def provider(self, name: str) -> Provider:
+        for p in self.providers:
+            if p.name == name:
+                return p
+        raise KeyError(name)
+
+    # -- model views ---------------------------------------------------------
+    def models(self, *, live_only: bool = True) -> list[Model]:
+        """All (provider, model) rows; live providers only unless ``live_only=False``.
+
+        Preserves catalog order: providers in declaration order, models in the
+        order they appear under each provider.
+        """
+        out: list[Model] = []
+        for p in self.providers:
+            if live_only and not p.is_live:
+                continue
+            out.extend(p.models)
+        return out
+
+    def roster_models(self, providers: Optional[Iterable[str]] = None) -> list[Model]:
+        """Cost-ordered models for the advisor roster.
+
+        Every LIVE provider's models except those flagged
+        ``exclude_from_roster = true``, sorted ascending by combined $/MTok cost.
+        Ties break by (provider, id) for a deterministic order. Optionally
+        restrict to ``providers`` (an allow-list of provider names).
+        """
+        allow = set(providers) if providers is not None else None
+        rows = [
+            m
+            for m in self.models(live_only=True)
+            if not m.exclude_from_roster
+            and (allow is None or m.provider in allow)
+        ]
+        rows.sort(key=lambda m: (m.cost_key, m.provider, m.id))
+        return rows
+
+    def roster_tiers(
+        self, providers: Optional[Iterable[str]] = None
+    ) -> list[dict[str, Any]]:
+        """The advisor ``[[tier]]`` payloads, rank-assigned (rank 1 = cheapest).
+
+        Each dict carries exactly the fields a model-advisor tier emits:
+        ``id, provider, model, run_target, rank, in_cost, out_cost``.
+        """
+        tiers: list[dict[str, Any]] = []
+        for rank, m in enumerate(self.roster_models(providers), start=1):
+            tiers.append(
+                {
+                    "id": m.id,
+                    "provider": m.provider,
+                    "model": m.model,
+                    "run_target": m.run_target,
+                    "rank": rank,
+                    "in_cost": m.in_cost,
+                    "out_cost": m.out_cost,
+                }
+            )
+        return tiers
+
+    def __iter__(self) -> Iterator[Provider]:
+        return iter(self.providers)
+
+
+# --------------------------------------------------------------------------- #
+# Parsing                                                                       #
+# --------------------------------------------------------------------------- #
+
+def _require(d: dict, key: str, where: str) -> Any:
+    if key not in d:
+        raise CatalogError(f"missing required key {key!r} in {where}")
+    return d[key]
+
+
+def _parse_model(provider: str, raw: dict, idx: int) -> Model:
+    where = f"providers.{provider}.models[{idx}]"
+    if not isinstance(raw, dict):
+        raise CatalogError(f"{where} is not a table")
+    return Model(
+        provider=provider,
+        id=str(_require(raw, "id", where)),
+        model=str(_require(raw, "model", where)),
+        run_target=str(_require(raw, "run_target", where)),
+        in_cost=float(_require(raw, "in_cost", where)),
+        out_cost=float(_require(raw, "out_cost", where)),
+        context=int(raw["context"]) if raw.get("context") is not None else None,
+        default_reasoning=raw.get("default_reasoning"),
+        note=raw.get("note"),
+        exclude_from_roster=bool(raw.get("exclude_from_roster", False)),
+    )
+
+
+def _parse_provider(name: str, raw: dict) -> Provider:
+    where = f"providers.{name}"
+    if not isinstance(raw, dict):
+        raise CatalogError(f"{where} is not a table")
+    status = str(raw.get("status", STATUS_SCAFFOLD))
+    if status not in (STATUS_LIVE, STATUS_SCAFFOLD):
+        raise CatalogError(
+            f"{where}: status must be {STATUS_LIVE!r} or {STATUS_SCAFFOLD!r}, got {status!r}"
+        )
+    raw_models = raw.get("models", []) or []
+    if not isinstance(raw_models, list):
+        raise CatalogError(f"{where}.models must be an array of tables")
+    models = tuple(
+        _parse_model(name, m, i) for i, m in enumerate(raw_models)
+    )
+    levels = raw.get("reasoning_levels", []) or []
+    if not isinstance(levels, list):
+        raise CatalogError(f"{where}.reasoning_levels must be an array")
+    return Provider(
+        name=name,
+        cli=str(_require(raw, "cli", where)),
+        overlay=str(raw.get("overlay", name)),
+        status=status,
+        native=bool(raw.get("native", False)),
+        auth=raw.get("auth"),
+        models_cache=raw.get("models_cache"),
+        reasoning_levels=tuple(str(x) for x in levels),
+        default_reasoning=raw.get("default_reasoning"),
+        models=models,
+    )
+
+
+def parse_catalog(data: dict) -> Catalog:
+    """Build a :class:`Catalog` from an already-decoded TOML mapping."""
+    if not isinstance(data, dict):
+        raise CatalogError("catalog root is not a table")
+
+    schema = str(data.get("schema_version", SCHEMA_VERSION))
+    default_provider = str(data.get("default_provider", "claude"))
+
+    raw_providers = data.get("providers", {})
+    if not isinstance(raw_providers, dict):
+        raise CatalogError("[providers] must be a table of provider entries")
+
+    providers = tuple(
+        _parse_provider(name, raw)
+        for name, raw in raw_providers.items()
+    )
+    if not providers:
+        raise CatalogError("catalog declares no [providers.*] entries")
+
+    return Catalog(
+        schema_version=schema,
+        default_provider=default_provider,
+        providers=providers,
+    )
+
+
+def load_catalog(path: str | os.PathLike[str] | None = None) -> Catalog:
+    """Load and validate ``catalog.toml`` from ``path`` (default: the pack root)."""
+    p = Path(path) if path is not None else _DEFAULT_CATALOG
+    if not p.is_file():
+        raise CatalogError(f"catalog not found: {p}")
+    try:
+        with open(p, "rb") as fh:
+            data = tomllib.load(fh)
+    except tomllib.TOMLDecodeError as e:  # pragma: no cover - defensive
+        raise CatalogError(f"{p}: invalid TOML: {e}") from e
+    return parse_catalog(data)
+
+
+def default_catalog_path() -> Path:
+    """The catalog file location this pack ships (pack root / catalog.toml)."""
+    return _DEFAULT_CATALOG

--- a/provider-forge/forge/cli.py
+++ b/provider-forge/forge/cli.py
@@ -1,0 +1,385 @@
+"""provider-forge CLI — list / doctor / roster / targets over the catalog.
+
+    forge list   [--all] [--json]            providers + models table (live by default)
+    forge doctor [--json]                    per-live-provider CLI + auth readiness
+    forge roster [--out FILE] [--provider P...]  generate model-advisor's [[tier]] roster
+    forge targets [--json]                   run_target names the catalog declares (live)
+
+Every surface reads ``catalog.toml`` (the source of truth). ``list``, ``doctor``,
+``targets`` and ``roster``-to-stdout are read-only; only ``roster --out FILE``
+writes, and only where you point it. ``doctor`` exits non-zero if any live
+provider is broken (missing CLI or missing auth) so it is CI-usable.
+
+Pure stdlib; invoked as ``python -m forge.cli`` by the bin/forge wrapper.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from typing import Any, Optional, Sequence
+
+from forge.catalog import (
+    Catalog,
+    CatalogError,
+    Model,
+    Provider,
+    load_catalog,
+)
+
+# doctor readiness states
+READY = "ready"
+MISSING_CLI = "missing-cli"
+MISSING_AUTH = "missing-auth"
+
+
+# --------------------------------------------------------------------------- #
+# small table renderer (stdlib-only; no third-party tabulate)                   #
+# --------------------------------------------------------------------------- #
+
+def _render_table(headers: Sequence[str], rows: Sequence[Sequence[Any]]) -> str:
+    """A minimal fixed-width table: header row, rule, then rows. Left-aligned."""
+    cols = len(headers)
+    cells = [[("" if c is None else str(c)) for c in row] for row in rows]
+    widths = [len(str(h)) for h in headers]
+    for row in cells:
+        for i in range(cols):
+            widths[i] = max(widths[i], len(row[i]))
+
+    def fmt(values: Sequence[str]) -> str:
+        return "  ".join(str(v).ljust(widths[i]) for i, v in enumerate(values)).rstrip()
+
+    out = [fmt([str(h) for h in headers]), "  ".join("-" * w for w in widths)]
+    out.extend(fmt(row) for row in cells)
+    return "\n".join(out)
+
+
+def _money(x: float) -> str:
+    """Render a $/MTok cost compactly (two decimals)."""
+    return f"{x:.2f}"
+
+
+# --------------------------------------------------------------------------- #
+# list                                                                          #
+# --------------------------------------------------------------------------- #
+
+def _model_record(p: Provider, m: Model) -> dict[str, Any]:
+    return {
+        "provider": p.name,
+        "status": p.status,
+        "id": m.id,
+        "model": m.model,
+        "run_target": m.run_target,
+        "in_cost": m.in_cost,
+        "out_cost": m.out_cost,
+        "context": m.context,
+        "reasoning": m.default_reasoning or p.default_reasoning,
+        "exclude_from_roster": m.exclude_from_roster,
+        "note": m.note,
+    }
+
+
+def cmd_list(cat: Catalog, args: argparse.Namespace, out) -> int:
+    include_scaffold = bool(args.all)
+    providers = cat.providers if include_scaffold else cat.live()
+
+    records: list[dict[str, Any]] = []
+    for p in providers:
+        for m in p.models:
+            records.append(_model_record(p, m))
+
+    if args.json:
+        out.write(json.dumps(records, indent=2) + "\n")
+        return 0
+
+    if not records:
+        scope = "any provider" if include_scaffold else "any LIVE provider"
+        out.write(f"(no models declared under {scope})\n")
+        return 0
+
+    headers = ["PROVIDER", "MODEL", "STATUS", "RUN TARGET", "IN $/M", "OUT $/M", "REASONING"]
+    rows = [
+        [
+            r["provider"],
+            r["model"],
+            r["status"],
+            r["run_target"],
+            _money(r["in_cost"]),
+            _money(r["out_cost"]),
+            r["reasoning"] or "-",
+        ]
+        for r in records
+    ]
+    out.write(_render_table(headers, rows) + "\n")
+
+    # Note any live providers that declare no models, and (with --all) scaffolds.
+    bare_live = [p.name for p in cat.live() if not p.models]
+    if bare_live:
+        out.write(f"\nlive providers with no models declared: {', '.join(bare_live)}\n")
+    if include_scaffold:
+        scaffolds = [p.name for p in cat.scaffold()]
+        if scaffolds:
+            out.write(
+                f"scaffold providers (CLI not installed; no models yet): "
+                f"{', '.join(scaffolds)}\n"
+            )
+    return 0
+
+
+# --------------------------------------------------------------------------- #
+# doctor                                                                        #
+# --------------------------------------------------------------------------- #
+
+def _which(cli: str) -> Optional[str]:
+    """Resolve a CLI on PATH (indirection point for tests)."""
+    return shutil.which(cli)
+
+
+def diagnose_provider(p: Provider) -> dict[str, Any]:
+    """Readiness of one live provider: CLI on PATH and auth file present.
+
+    Order of failure reporting: a missing CLI dominates (you can't auth a CLI
+    you don't have), then a missing auth file. A provider that declares no
+    ``auth`` is considered authed-by-other-means (e.g. claude's native session).
+    """
+    cli_path = _which(p.cli)
+    auth_path = p.auth_path()
+    auth_ok = auth_path is None or auth_path.exists()
+
+    if cli_path is None:
+        status = MISSING_CLI
+    elif not auth_ok:
+        status = MISSING_AUTH
+    else:
+        status = READY
+
+    return {
+        "provider": p.name,
+        "cli": p.cli,
+        "cli_path": cli_path,
+        "auth": str(auth_path) if auth_path is not None else None,
+        "auth_ok": auth_ok,
+        "status": status,
+        "ready": status == READY,
+    }
+
+
+def cmd_doctor(cat: Catalog, args: argparse.Namespace, out) -> int:
+    live = cat.live()
+    results = [diagnose_provider(p) for p in live]
+    broken = [r for r in results if not r["ready"]]
+
+    if args.json:
+        out.write(
+            json.dumps(
+                {"ok": not broken, "providers": results},
+                indent=2,
+            )
+            + "\n"
+        )
+        return 1 if broken else 0
+
+    if not results:
+        out.write("(catalog declares no LIVE providers)\n")
+        return 0
+
+    headers = ["PROVIDER", "CLI", "STATUS", "CLI PATH", "AUTH"]
+    rows = []
+    for r in results:
+        rows.append(
+            [
+                r["provider"],
+                r["cli"],
+                r["status"],
+                r["cli_path"] or "(not on PATH)",
+                _auth_cell(r),
+            ]
+        )
+    out.write(_render_table(headers, rows) + "\n")
+
+    if broken:
+        names = ", ".join(r["provider"] for r in broken)
+        out.write(f"\nNOT READY: {names}\n")
+        return 1
+    out.write(f"\nall {len(results)} live provider(s) ready\n")
+    return 0
+
+
+def _auth_cell(r: dict[str, Any]) -> str:
+    if r["auth"] is None:
+        return "(none required)"
+    return r["auth"] if r["auth_ok"] else f"MISSING: {r['auth']}"
+
+
+# --------------------------------------------------------------------------- #
+# roster — generate model-advisor's [[tier]] roster from the catalog            #
+# --------------------------------------------------------------------------- #
+
+def render_roster_toml(cat: Catalog, providers: Optional[Sequence[str]] = None) -> str:
+    """Emit a model-advisor-compatible ``[[tier]]`` roster as TOML text.
+
+    Every LIVE provider's models except ``exclude_from_roster = true``,
+    cost-ordered (rank 1 = cheapest by ``in_cost + out_cost``). Each tier emits
+    exactly ``id, provider, model, run_target, rank, in_cost, out_cost``. A
+    header comment records provenance and the cost caveat.
+    """
+    tiers = cat.roster_tiers(providers)
+
+    live_names = [p.name for p in cat.live()]
+    scope = (
+        ", ".join(providers) if providers else ", ".join(live_names) or "(none)"
+    )
+
+    lines: list[str] = []
+    lines.append("# advisor.toml roster — GENERATED by provider-forge from catalog.toml.")
+    lines.append("#")
+    lines.append("# Do not hand-edit the [[tier]] blocks below: regenerate with")
+    lines.append("#   forge roster --out advisor.toml")
+    lines.append("# so the model list is maintained in ONE place (the catalog). Paste these")
+    lines.append("# tiers into model-advisor's advisor.toml (replacing its [[tier]] block);")
+    lines.append("# the shapes / tolerance / agents / hyperparams sections are hand-owned.")
+    lines.append("#")
+    lines.append(f"# providers: {scope}")
+    lines.append("# rank 1 = cheapest by (in_cost + out_cost); in_cost/out_cost are $/MTok.")
+    lines.append("# COSTS ARE ESTIMATES (esp. Codex) — replace with your real rate sheet.")
+    lines.append("# exclude_from_roster models are omitted; reasoning effort is advisory.")
+    lines.append("")
+
+    if not tiers:
+        lines.append("# (no roster-eligible models — no LIVE providers declare models)")
+        return "\n".join(lines) + "\n"
+
+    for t in tiers:
+        lines.append("[[tier]]")
+        lines.append(f'id         = "{t["id"]}"')
+        lines.append(f'provider   = "{t["provider"]}"')
+        lines.append(f'model      = "{t["model"]}"')
+        lines.append(f'run_target = "{t["run_target"]}"')
+        lines.append(f'rank       = {t["rank"]}')
+        lines.append(f"in_cost    = {_money(t['in_cost'])}")
+        lines.append(f"out_cost   = {_money(t['out_cost'])}")
+        lines.append("")
+
+    return "\n".join(lines).rstrip("\n") + "\n"
+
+
+def cmd_roster(cat: Catalog, args: argparse.Namespace, out) -> int:
+    providers = list(args.provider) if args.provider else None
+    if providers:
+        # Fail loudly on a typo'd / non-live provider rather than silently empty.
+        live = {p.name for p in cat.live()}
+        unknown = [p for p in providers if p not in live]
+        if unknown:
+            sys.stderr.write(
+                "forge roster: not a LIVE provider: "
+                + ", ".join(unknown)
+                + f" (live: {', '.join(sorted(live)) or 'none'})\n"
+            )
+            return 2
+
+    text = render_roster_toml(cat, providers)
+
+    if args.out:
+        with open(args.out, "w") as fh:
+            fh.write(text)
+        n = len(cat.roster_tiers(providers))
+        sys.stderr.write(f"forge roster: wrote {n} tier(s) to {args.out}\n")
+        return 0
+
+    out.write(text)
+    return 0
+
+
+# --------------------------------------------------------------------------- #
+# targets — run_target names the catalog declares (the gc session configs)      #
+# --------------------------------------------------------------------------- #
+
+def cmd_targets(cat: Catalog, args: argparse.Namespace, out) -> int:
+    records: list[dict[str, Any]] = []
+    for p in cat.live():
+        for m in p.models:
+            records.append(
+                {
+                    "run_target": m.run_target,
+                    "provider": p.name,
+                    "model": m.model,
+                    "id": m.id,
+                    "exclude_from_roster": m.exclude_from_roster,
+                }
+            )
+
+    if args.json:
+        out.write(json.dumps(records, indent=2) + "\n")
+        return 0
+
+    if not records:
+        out.write("(no run targets — no LIVE provider declares models)\n")
+        return 0
+
+    headers = ["RUN TARGET", "PROVIDER", "MODEL"]
+    rows = [[r["run_target"], r["provider"], r["model"]] for r in records]
+    out.write(_render_table(headers, rows) + "\n")
+    out.write(
+        f"\n{len(records)} run target(s) the catalog expects to exist as gc session configs\n"
+    )
+    return 0
+
+
+# --------------------------------------------------------------------------- #
+# argparse plumbing                                                             #
+# --------------------------------------------------------------------------- #
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="forge",
+        description="Catalog + enablement for multi-provider model run targets in gc.",
+    )
+    p.add_argument(
+        "--catalog",
+        default=None,
+        help="path to catalog.toml (default: the pack's catalog.toml)",
+    )
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    pl = sub.add_parser("list", help="list providers + models from the catalog")
+    pl.add_argument("--all", action="store_true", help="include scaffold providers")
+    pl.add_argument("--json", action="store_true", help="emit JSON")
+    pl.set_defaults(func=cmd_list)
+
+    pd = sub.add_parser("doctor", help="check live providers' CLI + auth readiness")
+    pd.add_argument("--json", action="store_true", help="emit JSON")
+    pd.set_defaults(func=cmd_doctor)
+
+    pr = sub.add_parser("roster", help="generate model-advisor [[tier]] roster")
+    pr.add_argument("--out", default=None, help="write to FILE instead of stdout")
+    pr.add_argument(
+        "--provider",
+        action="append",
+        metavar="P",
+        help="restrict to this live provider (repeatable)",
+    )
+    pr.set_defaults(func=cmd_roster)
+
+    pt = sub.add_parser("targets", help="list run_target names per live model")
+    pt.add_argument("--json", action="store_true", help="emit JSON")
+    pt.set_defaults(func=cmd_targets)
+
+    return p
+
+
+def main(argv: Optional[Sequence[str]] = None, out=None) -> int:
+    out = out if out is not None else sys.stdout
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        cat = load_catalog(args.catalog)
+    except CatalogError as e:
+        sys.stderr.write(f"forge: {e}\n")
+        return 2
+    return int(args.func(cat, args, out))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/provider-forge/install.sh
+++ b/provider-forge/install.sh
@@ -1,0 +1,330 @@
+#!/usr/bin/env bash
+# provider-forge — install lifecycle (reversible, idempotent).
+#
+#   install.sh (--town | --rig <name>) [--dry-run] [--city <path>] [--no-reload]
+#
+# Turns the provider-forge pack ON at one of two scopes:
+#   --town        city-wide: the pack's catalog + bin/forge become available to
+#                 the whole city (the catalog is a shared, city-level resource).
+#   --rig <name>  one rig only: scoped to that rig's [[rigs]] entry.
+#
+# What it does (in order):
+#   1. Build the engine venv via setup.sh (skipped if .venv already present).
+#   2. Add the pack import to the correct config scope. A LOCAL in-tree pack is
+#      imported via a DIRECT config entry (the gastown pattern) — NOT via
+#      `gc import add`, which targets remote/git-backed packs and mis-resolves a
+#      local file:// source. So a surgical, backed-up edit writes:
+#        --town       ->  <city>/pack.toml   [imports.provider-forge]
+#        --rig <name> ->  <city>/city.toml   [rigs.imports.provider-forge] (under
+#                         the [[rigs]] entry whose name matches <name>)
+#      source is recorded relative to the city root (e.g. "packs/provider-forge").
+#   3. Trigger re-projection with `gc reload` so the pack's bin/skills surface.
+#   4. Verify: `gc lint`, the import is registered.
+#
+# Unlike model-advisor, provider-forge ships NO prompt fragment and NO overlay
+# hook — it is a read-only catalog + CLI — so there is no global_fragments edit
+# and no projected-settings hook to materialize. The install is just: venv +
+# import + reload + verify.
+#
+# Idempotent: re-running is a no-op (each mutating step is guarded by a presence
+# check). Any config file it edits is backed up first. --dry-run prints the plan
+# and changes nothing. Fails loudly on unexpected state.
+#
+# Reverse with uninstall.sh (same scope flags).
+
+set -euo pipefail
+
+# Stripped-PATH guard (this environment sometimes ships a minimal PATH).
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${HOME}/go/bin:${HOME}/.local/bin:${PATH}"
+
+PACK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PACK_NAME="provider-forge"     # import binding name
+IMPORT_NAME="provider-forge"
+
+# ---- arg parsing -----------------------------------------------------------
+SCOPE=""          # "town" | "rig"
+RIG=""
+DRY_RUN=0
+NO_RELOAD=0
+CITY=""
+
+die()  { printf 'install.sh: error: %s\n' "$*" >&2; exit 1; }
+info() { printf '  %s\n' "$*"; }
+step() { printf '\n==> %s\n' "$*"; }
+run()  { # echo + execute, or just echo under --dry-run
+  if [ "$DRY_RUN" -eq 1 ]; then printf '    [dry-run] %s\n' "$*"; else printf '    + %s\n' "$*"; eval "$@"; fi
+}
+
+usage() {
+  sed -n '2,30p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+  exit "${1:-0}"
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --town)      SCOPE="town"; shift ;;
+    --rig)       SCOPE="rig"; RIG="${2:-}"; [ -n "$RIG" ] || die "--rig requires a rig name"; shift 2 ;;
+    --rig=*)     SCOPE="rig"; RIG="${1#*=}"; shift ;;
+    --dry-run)   DRY_RUN=1; shift ;;
+    --no-reload) NO_RELOAD=1; shift ;;
+    --city)      CITY="${2:-}"; [ -n "$CITY" ] || die "--city requires a path"; shift 2 ;;
+    --city=*)    CITY="${1#*=}"; shift ;;
+    -h|--help)   usage 0 ;;
+    *)           die "unknown argument: $1 (try --help)" ;;
+  esac
+done
+
+[ -n "$SCOPE" ] || die "choose a scope: --town or --rig <name>"
+
+# ---- locate the city -------------------------------------------------------
+# Default: the city that physically contains this pack (…/<city>/packs/provider-forge).
+if [ -z "$CITY" ]; then
+  CITY="$(cd "$PACK_DIR/../.." && pwd)"
+fi
+[ -f "$CITY/city.toml" ] || die "no city.toml at city root: $CITY (pass --city <path>)"
+CITY="$(cd "$CITY" && pwd)"
+
+# Source path recorded in the import: relative to the city root if the pack
+# lives under it (matches how gastown is referenced — a bare relative path with
+# no "./" prefix, e.g. "packs/provider-forge"), else absolute.
+if [ "${PACK_DIR#"$CITY"/}" != "$PACK_DIR" ]; then
+  PACK_SRC="${PACK_DIR#"$CITY"/}"
+else
+  PACK_SRC="$PACK_DIR"
+fi
+
+GC=(gc --city "$CITY")
+
+step "provider-forge install"
+info "scope:     $SCOPE${RIG:+ ($RIG)}"
+info "pack:      $PACK_DIR"
+info "city:      $CITY"
+info "import as: $IMPORT_NAME  (source: $PACK_SRC)"
+[ "$DRY_RUN" -eq 1 ] && info "MODE:      DRY RUN (no changes will be made)"
+
+command -v gc >/dev/null 2>&1 || die "gc not found on PATH"
+
+# For --rig, fail loudly now if the rig isn't configured, before any other step
+# runs. `gc import list --rig <name>` exits non-zero for an unknown rig.
+if [ "$SCOPE" = "rig" ]; then
+  if ! "${GC[@]}" import list --rig "$RIG" >/dev/null 2>&1; then
+    die "rig \"$RIG\" not found in $CITY/city.toml (configure the rig first)"
+  fi
+fi
+
+# ---- helpers ---------------------------------------------------------------
+backup_file() { # back up $1 once per run to <file>.provider-forge.bak.<ts>
+  local f="$1"
+  [ -f "$f" ] || return 0
+  local b="${f}.provider-forge.bak.$(date +%Y%m%d%H%M%S)"
+  if [ "$DRY_RUN" -eq 1 ]; then printf '    [dry-run] backup %s -> %s\n' "$f" "$b"; return 0; fi
+  cp -p "$f" "$b"; printf '    backup: %s\n' "$b"
+}
+
+import_present() { # 0 if IMPORT_NAME is registered at the active scope.
+  # gc import list reports direct-config imports (the gastown style) too, so it
+  # is the primary signal. Fall back to a config grep for the [..imports.NAME]
+  # table in case the catalog is unbuilt (stopped/fresh city).
+  if [ "$SCOPE" = "rig" ]; then
+    if "${GC[@]}" import list --rig "$RIG" 2>/dev/null | awk '{print $1}' | grep -qx "$IMPORT_NAME"; then
+      return 0
+    fi
+    rig_import_in_config "$RIG"
+  else
+    if "${GC[@]}" import list 2>/dev/null | awk '{print $1}' | grep -qx "$IMPORT_NAME"; then
+      return 0
+    fi
+    grep -Eq "^\[imports\.${IMPORT_NAME}\][[:space:]]*$" "$CITY/pack.toml" 2>/dev/null
+  fi
+}
+
+rig_import_in_config() { # 0 if [rigs.imports.IMPORT_NAME] exists under rig $1
+  python3 - "$CITY/city.toml" "$1" "$IMPORT_NAME" <<'PY'
+import sys, re
+path, rig, name = sys.argv[1], sys.argv[2], sys.argv[3]
+lines = open(path).read().splitlines(keepends=True)
+starts = [i for i, l in enumerate(lines) if re.match(r'^\[\[rigs\]\]\s*$', l)]
+for k, s in enumerate(starts):
+    end = starts[k + 1] if k + 1 < len(starts) else len(lines)
+    for j in range(s + 1, end):
+        if re.match(r'^\[', lines[j]) and not re.match(r'^\[(\[rigs\]\]|rigs(\.|\]))', lines[j]):
+            end = j; break
+    named = None
+    for j in range(s + 1, end):
+        m = re.match(r'^\s*name\s*=\s*["\'](.+?)["\']\s*$', lines[j])
+        if m:
+            named = m.group(1); break
+    if named != rig:
+        continue
+    hdr = re.compile(r'^\[rigs\.imports\.%s\]\s*$' % re.escape(name))
+    if any(hdr.match(lines[j]) for j in range(s + 1, end)):
+        sys.exit(0)
+    sys.exit(1)
+sys.exit(1)
+PY
+}
+
+edit_import() { # add|remove a DIRECT-config import (gastown style); idempotent.
+  # Local in-tree packs are imported by a direct config entry, NOT `gc import
+  # add` (which is for remote/git-backed packs and would mis-resolve a file://
+  # source). Surgical text edit; rest of file byte-exact, so add<->remove
+  # round-trips perfectly.
+  #   town: file=pack.toml, target [imports] -> [imports.IMPORT_NAME]
+  #   rig : file=city.toml, target the [rigs.imports] of the [[rigs]] named $5,
+  #         -> [rigs.imports.IMPORT_NAME]
+  # args: <action> <file> <import_name> <source> [<rig_name>]
+  python3 - "$2" "$1" "$3" "$4" "${5:-}" <<'PY'
+import sys, re
+path, action, name, source, rig = sys.argv[1:6]
+rig = rig or None
+
+def fail(msg):
+    sys.stderr.write("edit_import: %s\n" % msg); sys.exit(3)
+
+lines = open(path).read().splitlines(keepends=True)
+
+if rig is None:
+    table = "imports"
+    anchor = next((i for i, l in enumerate(lines) if re.match(r'^\[imports\]\s*$', l)), None)
+    if anchor is None: fail("[imports] table not found in %s" % path)
+    hi = len(lines)
+else:
+    table = "rigs.imports"
+    starts = [i for i, l in enumerate(lines) if re.match(r'^\[\[rigs\]\]\s*$', l)]
+    if not starts: fail("no [[rigs]] blocks in %s" % path)
+    target_start = None; hi = len(lines)
+    for k, s in enumerate(starts):
+        end = starts[k + 1] if k + 1 < len(starts) else len(lines)
+        for j in range(s + 1, end):
+            if re.match(r'^\[', lines[j]) and not re.match(r'^\[(\[rigs\]\]|rigs(\.|\]))', lines[j]):
+                end = j; break
+        named = None
+        for j in range(s + 1, end):
+            m = re.match(r'^\s*name\s*=\s*["\'](.+?)["\']\s*$', lines[j])
+            if m: named = m.group(1); break
+        if named == rig:
+            target_start, hi = s, end; break
+    if target_start is None: fail('no [[rigs]] block with name = "%s" in %s' % (rig, path))
+    anchor = next((i for i in range(target_start, hi) if re.match(r'^\[rigs\.imports\]\s*$', lines[i])), None)
+    if anchor is None: fail('[rigs.imports] not found under rig "%s" in %s' % (rig, path))
+
+header = "[%s.%s]" % (table, name)
+sub = re.compile(r'^\[%s\.%s\]\s*$' % (re.escape(table), re.escape(name)))
+existing = next((i for i in range(anchor, hi) if sub.match(lines[i])), None)
+
+if action == "add":
+    if existing is not None: sys.exit(0)
+    lines.insert(anchor + 1, "%s\nsource = \"%s\"\n" % (header, source))
+    open(path, "w").write("".join(lines))
+elif action == "remove":
+    if existing is None: sys.exit(0)
+    end = existing + 1
+    if end < len(lines) and re.match(r'^\s*source\s*=', lines[end]): end += 1
+    del lines[existing:end]
+    open(path, "w").write("".join(lines))
+else:
+    fail("unknown action: %s" % action)
+PY
+}
+
+# ---- step 1: venv ----------------------------------------------------------
+step "1/4  engine venv"
+if [ -x "$PACK_DIR/.venv/bin/python" ]; then
+  info "already present: $PACK_DIR/.venv (skipping setup.sh)"
+else
+  run "bash \"$PACK_DIR/setup.sh\""
+  [ "$DRY_RUN" -eq 1 ] && info "(dry-run) would build venv via setup.sh"
+fi
+
+# ---- step 2: import --------------------------------------------------------
+# Local in-tree packs are imported via a DIRECT config entry (the gastown
+# pattern), NOT `gc import add` — that command is for remote/git-backed packs
+# and mis-resolves a local file:// source. So we hand-edit the right config,
+# surgically and backed-up (see edit_import).
+#   rig : <city>/city.toml -> [rigs.imports.provider-forge] under the [[rigs]] named $RIG
+#   town: <city>/pack.toml -> [imports.provider-forge]
+step "2/4  register pack import ($SCOPE scope)"
+if import_present; then
+  info "import \"$IMPORT_NAME\" already registered — no-op"
+else
+  if [ "$SCOPE" = "rig" ]; then
+    IMPORT_CFG="$CITY/city.toml"
+    backup_file "$IMPORT_CFG"
+    if [ "$DRY_RUN" -eq 1 ]; then
+      info "[dry-run] add [rigs.imports.$IMPORT_NAME] (source = \"$PACK_SRC\") under rig \"$RIG\" in $IMPORT_CFG"
+    else
+      edit_import add "$IMPORT_CFG" "$IMPORT_NAME" "$PACK_SRC" "$RIG" \
+        || die "failed to add [rigs.imports.$IMPORT_NAME] under rig \"$RIG\" in $IMPORT_CFG"
+      info "added [rigs.imports.$IMPORT_NAME] (source = \"$PACK_SRC\") under rig \"$RIG\""
+    fi
+  else
+    IMPORT_CFG="$CITY/pack.toml"
+    backup_file "$IMPORT_CFG"
+    if [ "$DRY_RUN" -eq 1 ]; then
+      info "[dry-run] add [imports.$IMPORT_NAME] (source = \"$PACK_SRC\") to $IMPORT_CFG"
+    else
+      edit_import add "$IMPORT_CFG" "$IMPORT_NAME" "$PACK_SRC" \
+        || die "failed to add [imports.$IMPORT_NAME] to $IMPORT_CFG"
+      info "added [imports.$IMPORT_NAME] (source = \"$PACK_SRC\")"
+    fi
+  fi
+fi
+
+# ---- step 3: re-project ----------------------------------------------------
+step "3/4  re-project (gc reload)"
+if [ "$NO_RELOAD" -eq 1 ]; then
+  info "--no-reload: skipping. Run 'gc reload' (or restart the city) to apply."
+elif [ "$DRY_RUN" -eq 1 ]; then
+  info "[dry-run] gc reload  (surfaces the pack's bin/forge + catalog)"
+else
+  if "${GC[@]}" reload >/dev/null 2>&1; then
+    info "gc reload: ok"
+  else
+    info "gc reload returned non-zero (city may be stopped). Projection will"
+    info "happen on the next 'gc start' / 'gc rig boot'. Continuing."
+  fi
+fi
+
+# ---- step 4: verify --------------------------------------------------------
+step "4/4  verify"
+if [ "$DRY_RUN" -eq 1 ]; then
+  info "[dry-run] would verify: gc lint, import registered"
+  step "provider-forge install — DRY RUN complete (no changes made)"
+  exit 0
+fi
+
+fail=0
+
+# 4a. lint
+if "${GC[@]}" lint "$PACK_DIR" >/dev/null 2>&1; then
+  info "lint: ok"
+else
+  info "lint: FAILED"; "${GC[@]}" lint "$PACK_DIR" || true; fail=1
+fi
+
+# 4b. import registered
+if import_present; then info "import: registered ($IMPORT_NAME)"; else info "import: MISSING"; fail=1; fi
+
+# 4c. CLI smoke (best-effort): forge doctor exits non-zero if a live provider is
+#     broken on THIS machine — surface that as advice, not an install failure.
+if [ -x "$PACK_DIR/bin/forge" ]; then
+  if "$PACK_DIR/bin/forge" doctor >/dev/null 2>&1; then
+    info "doctor: all live providers ready"
+  else
+    info "doctor: one or more LIVE providers not ready (run 'bin/forge doctor')"
+  fi
+fi
+
+if [ "$SCOPE" = "rig" ]; then REVERSE_FLAGS="--rig $RIG"; else REVERSE_FLAGS="--town"; fi
+echo
+if [ "$fail" -eq 0 ]; then
+  step "provider-forge install complete ($SCOPE${RIG:+ $RIG})"
+  info "Use 'bin/forge doctor' to verify provider readiness, 'bin/forge roster"
+  info "--out packs/model-advisor/advisor.toml' to regenerate the advisor roster."
+  info "Reverse with: $PACK_DIR/uninstall.sh $REVERSE_FLAGS"
+  exit 0
+else
+  step "provider-forge install finished WITH WARNINGS ($SCOPE${RIG:+ $RIG})"
+  info "Review the lines marked FAILED/MISSING above."
+  exit 1
+fi

--- a/provider-forge/pack.toml
+++ b/provider-forge/pack.toml
@@ -1,0 +1,38 @@
+# provider-forge — the canonical provider × model catalog for Gas City.
+#
+# gc already ships the routing primitives: per-provider overlays
+# (.gc/system/packs/core/overlay/per-provider/<provider>/) and per-dispatch
+# metadata `gc.run_target` / `gc.provider` / `gc.model`. What gc lacks is a
+# single, machine-readable list of WHICH (provider, model) pairs exist, their
+# costs/limits, and the run_target each maps to. catalog.toml is that list — the
+# source of truth that this pack reads to:
+#   • verify each live provider's CLI + auth     (`forge doctor`),
+#   • enumerate the run targets a city should define (`forge targets`), and
+#   • GENERATE model-advisor's [[tier]] roster from one place (`forge roster`),
+#     so the model list is maintained once and the advisor consumes it.
+#
+# What this pack provides (all convention-discovered once the pack is imported):
+#   bin/forge        the list / doctor / roster / targets CLI
+#   forge/           the engine (pure-stdlib catalog reader + roster emitter)
+#   catalog.toml     the provider × model catalog (the source of truth)
+#
+# Stdlib-only (tomllib on Python >= 3.11; tomli fallback below it). No runtime
+# third-party dependencies — it mirrors model-advisor's minimal footprint.
+#
+# Wiring (after importing this pack into a city, e.g. `source = "packs/provider-forge"`):
+#   1. Run `packs/provider-forge/setup.sh` once to build the engine's venv.
+#   2. `bin/forge doctor` — confirm every live provider's CLI is on PATH + authed.
+#   3. `bin/forge roster --out packs/model-advisor/advisor.toml` regenerates the
+#      advisor's cost-ordered [[tier]] roster from the catalog (the integration:
+#      maintain the model list once, here, and the advisor consumes it).
+#   4. `bin/forge targets` lists the gc session configs (run targets) the catalog
+#      expects to exist for dispatch.
+#
+# The pack is read-only and side-effect-free at the catalog layer: `list`,
+# `doctor`, `targets`, and `roster`-to-stdout never mutate anything; only
+# `roster --out FILE` writes, and only where you point it.
+
+[pack]
+name = "provider-forge"
+schema = 2
+version = "0.1.0"

--- a/provider-forge/requirements-dev.txt
+++ b/provider-forge/requirements-dev.txt
@@ -1,0 +1,6 @@
+# provider-forge development/test dependencies (runtime deps live in
+# requirements.txt). The behavioural suite under tests/ uses pytest; ruff
+# provides linting. These mirror model-advisor's dev pipeline so both packs
+# test the same way.
+pytest
+ruff

--- a/provider-forge/requirements.txt
+++ b/provider-forge/requirements.txt
@@ -1,0 +1,10 @@
+# provider-forge runtime deps — deliberately MINIMAL (mirrors model-advisor).
+#
+# The engine is pure-stdlib: the catalog is parsed with the stdlib `tomllib`
+# (Python >= 3.11), roster emission is plain string formatting, and `doctor`
+# uses `shutil.which` + `os.path.expanduser` — no third-party runtime deps.
+#
+# The single guarded fallback below pulls `tomli` *only* on an older interpreter,
+# so the catalog loader's `import tomllib` / `import tomli as tomllib` shim has a
+# backend everywhere without adding a dependency on a modern Python.
+tomli>=2.0 ; python_version < "3.11"

--- a/provider-forge/setup.sh
+++ b/provider-forge/setup.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Bootstrap the provider-forge pack's self-contained venv (idempotent).
+set -euo pipefail
+PACK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PY="${PYTHON:-python3}"
+"$PY" -m venv "$PACK_DIR/.venv"
+"$PACK_DIR/.venv/bin/pip" install --quiet --upgrade pip
+"$PACK_DIR/.venv/bin/pip" install --quiet -r "$PACK_DIR/requirements.txt"
+echo "provider-forge venv ready: $PACK_DIR/.venv"

--- a/provider-forge/skills/use-provider-forge/SKILL.md
+++ b/provider-forge/skills/use-provider-forge/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: use-provider-forge
+description: Dispatch work to a specific provider and model, and know which (provider, model) pairs are real and runnable. Before routing a step to a non-default provider/model, look it up with `forge targets` to get the exact `gc.run_target` / `gc.provider` / `gc.model` triple to stamp on the bead (the mol-review-quorum pattern), and use `forge list` / `forge doctor` to see what exists and what's actually wired. Use whenever you fan work across providers, pick a non-native model, or need to refresh model-advisor's tier roster.
+---
+
+# Use Provider Forge
+
+## Overview
+
+gc can already route a dispatch to a *different* provider and model — that capability is
+in core. The thing you usually lack is the **list**: which `(provider, model)` pairs exist,
+what each costs, which `run_target` it maps to, and whether its CLI is actually installed
+and authed. **provider-forge** is that catalog, and `bin/forge` is the read CLI over it.
+
+The discipline this skill teaches has two halves:
+
+1. **Route by the triple.** To send a unit of work to a specific provider+model, stamp three
+   metadata keys on the dispatch — `gc.run_target`, `gc.provider`, `gc.model`. This is the
+   exact mechanism core's `mol-review-quorum` formula uses to fan review lanes across
+   providers. You do not invent a new dispatch path; you set the triple.
+2. **Look the triple up; don't guess it.** The valid values for that triple come from the
+   catalog. `forge targets` hands you a correct, *live* triple; `forge list` / `forge doctor`
+   tell you what exists and what is runnable. Never hand-type a model ID or run target you
+   have not confirmed against the catalog.
+
+provider-forge is **read-only**: it tells you the facts and gives you the triple. It never
+dispatches, spawns a session, or mutates a bead — *you* (or a formula) do the routing.
+
+## When to Use
+
+- You are about to dispatch a step to a **non-default** provider or model (anything other
+  than the agent's native Claude tier) and need the right `run_target` / `provider` / `model`
+  to put on it.
+- You are authoring or filling in a **graph/quorum formula** that fans lanes across providers
+  (like `mol-review-quorum`) and need valid lane `(provider, model, target)` values.
+- You want to know **what's runnable right now** — which providers are live versus scaffold,
+  and *why* a scaffold one isn't live yet (CLI missing? auth missing?).
+- You need to **refresh model-advisor's roster** after editing the catalog (added a model,
+  fixed a price, enabled a provider).
+
+**When NOT to use:**
+
+- The work should run on the agent's default provider/model — then just dispatch normally; you
+  do not need a routing triple at all.
+- You want to *choose* which tier is cost-optimal — that is `model-advisor`'s job
+  (`advisor advise`). provider-forge tells you which models *exist*; model-advisor tells you
+  which to *use*. Use them together: advise → look up the triple → stamp it.
+- You expect provider-forge to *enforce reasoning effort*. It records effort per model, but gc
+  has no effort path yet, so effort is advisory (see [Effort caveat](#effort-is-advisory)).
+
+## The routing triple
+
+Three metadata keys name where a dispatch runs. Set all three together:
+
+| Key | Value | Where it comes from |
+|-----|-------|---------------------|
+| `gc.run_target` | the configured gc target that executes the step | catalog `run_target` |
+| `gc.provider` | the provider identifier (native, or has a gc overlay) | catalog provider name |
+| `gc.model` | the concrete model string the provider uses | catalog `model` |
+
+These are exactly the keys `mol-review-quorum` stamps on each reviewer lane. Get their values
+from `forge targets` — never improvise them.
+
+## Process
+
+### Step 1 — See what exists / what's runnable
+
+```bash
+forge list                 # the catalog — live providers by default
+forge list --all           # everything, including scaffolds (overlay-only)
+forge doctor               # per live provider: ready / missing-cli / missing-auth
+```
+
+`bin/forge` ships with this pack. If it is not on `PATH`, invoke it by its pack-relative path
+(e.g. `.../packs/provider-forge/bin/forge list`). All three are **pure reads**.
+
+- `list` shows each `(provider, model)` with its `run_target`, costs (`$/MTok`), context, and
+  effort; **live-only by default**, `--all` adds the scaffolds so you can see which providers
+  aren't enabled yet.
+- `doctor` is the enablement check for the **live** providers: it probes whether each one's `cli`
+  is on `PATH` and whether its `auth` file exists, reporting `ready` / `missing-cli` /
+  `missing-auth`. Only **codex** and **claude** are live today; the other seven providers are
+  scaffolds (gc has their overlays, but they need the CLI installed + models filled in, then
+  `status = "live"` — at which point `doctor` starts checking them).
+
+Add `--json` to any of these for structured output.
+
+### Step 2 — Look up the dispatch triple
+
+```bash
+forge targets               # every live run_target / provider / model row
+#   RUN TARGET     PROVIDER   MODEL
+#   codex-gpt54    codex      gpt-5.4
+#   codex-spark    codex      gpt-5.3-codex-spark
+#   …
+```
+
+`targets` lists the `{ run_target, provider, model }` row for every *live* model. Pick the row for
+the model you want — those three values are precisely what you stamp on a step. (Use `--json` to
+select a row programmatically.) Everything `targets` lists is already live, so no separate
+runnability check is needed; use `doctor` if you want to confirm *why* a model is or isn't there.
+
+### Step 3 — Stamp the triple on the dispatch
+
+Set the three keys on the step's `metadata` (in a formula) or on the work bead. The
+`mol-review-quorum` pattern, verbatim:
+
+```toml
+# a reviewer lane, routed to a specific provider+model via the triple
+metadata = { "gc.run_target" = "codex-gpt54",
+             "gc.provider"   = "codex",
+             "gc.model"      = "gpt-5.4" }
+```
+
+For a fan-out (quorum) formula, give each lane a *different* triple — lane one to one
+provider/model, lane two to another, a synthesis step to a third target — exactly as
+`mol-review-quorum` does with its `lane_one_*` / `lane_two_*` / `synthesis_target` variables.
+gc routes each step to its `run_target`; the provider/model travel with it.
+
+### Step 4 — (when you edited the catalog) refresh the advisor roster
+
+```bash
+forge roster                                       # print the [[tier]] block
+forge roster --out ../model-advisor/advisor.tiers.toml   # write it
+```
+
+model-advisor's cost-ordered `[[tier]]` roster is **generated from the catalog** — maintain the
+model list in one place. After any catalog edit (new model, price fix, a provider flipped to
+`live`), re-run `forge roster` so the advisor's roster stays in sync. It emits only live,
+non-`exclude_from_roster` models, cost-ordered; it never writes the catalog.
+
+## Worked Example
+
+You are setting up a two-provider review quorum on a PR and want lane two to run on a fast Codex
+model.
+
+1. **Confirm it's runnable.** `forge doctor` → `codex: ready (cli ok, auth ok)`. Good — Codex is
+   dispatchable. (Had it said `missing-auth`, you would authenticate the Codex CLI first, or pick
+   a live provider.)
+2. **Get the triple.** `forge targets` → find the Codex spark row:
+   `codex-spark   codex   gpt-5.3-codex-spark`.
+3. **Stamp it.** In the quorum formula, lane two's `metadata` gets
+   `gc.run_target = "codex-spark"`, `gc.provider = "codex"`, `gc.model = "gpt-5.3-codex-spark"`;
+   lane one keeps a Claude triple. The synthesis step routes to its own target. gc fans the two
+   lanes across the two providers and synthesizes the quorum — using nothing but the triples.
+
+Note you did **not** type `gpt-5.3-codex-spark` from memory or guess `codex-spark`; both came
+from the catalog via `forge targets`, so the dispatch is guaranteed valid and live.
+
+## Why This Matters
+
+- **Valid, live triples — not guesses.** Routing across providers fails silently if you stamp a
+  model ID that doesn't exist or a provider that isn't installed. `forge targets` + `forge doctor`
+  give you a triple you have confirmed is real and runnable.
+- **One source of truth.** The same catalog that answers "what can I route to?" also generates
+  model-advisor's roster. Edit a model once; `forge roster` keeps the advisor current. No drift
+  between "what exists" and "what the advisor ranks."
+- **It rides gc's mechanism, adds no risk.** provider-forge never dispatches or mutates anything.
+  The actual routing is gc's own — the overlays and the `gc.run_target`/`gc.provider`/`gc.model`
+  triple that `mol-review-quorum` already proves out. This skill just teaches you to use them
+  with confirmed data.
+
+<a id="effort-is-advisory"></a>
+> **Effort is advisory.** The catalog records reasoning effort
+> (Codex's `low`/`medium`/`high`/`xhigh`) per model, but gc has **no effort path today** — the
+> launcher forwards the model, not a non-default effort. So a model runs at the provider's
+> default effort regardless of the catalog's `default_reasoning`, until a small gc-core seam to
+> forward effort lands (same shape as model-advisor's per-dispatch ask). Treat the effort field
+> as documentation, not enforcement.
+
+## Verification Gate
+
+Before routing a step to a non-default provider/model:
+
+- [ ] The destination provider is **live** (`forge doctor` / it appears in `forge list` /
+      `forge targets`) — not a scaffold that lacks a CLI or auth.
+- [ ] The `gc.run_target` / `gc.provider` / `gc.model` triple came from `forge targets`, not from
+      memory or a hand-typed model ID.
+- [ ] All **three** keys are set together on the step's `metadata` (a `run_target` without its
+      `provider`/`model`, or vice-versa, is incomplete).
+- [ ] For a fan-out formula, each lane carries its **own** complete triple (lanes are not meant to
+      share one).
+- [ ] If you edited `catalog.toml`, `forge roster` was re-run so model-advisor's roster matches.
+
+<!-- registration -->
+**Registration.** gc discovers pack skills by directory convention: a pack contributes a skill by
+placing `skills/<name>/SKILL.md` under the pack root, with YAML frontmatter carrying at minimum
+`name` and `description` (the body is free-form Markdown, by convention including a "When to Use"
+trigger section). This file lives at `provider-forge/skills/use-provider-forge/SKILL.md`, so it is
+picked up automatically — `pack.toml` does not enumerate skills. Once the `provider-forge` pack is
+imported into a city (vendored under the city's `packs/` and registered via a direct
+`source = "packs/provider-forge"` import), the skill surfaces in `gc skill list` binding-qualified
+as `<binding>.use-provider-forge` (e.g. `provider-forge.use-provider-forge`), and the materializer
+projects it into the per-agent skills sink at `gc start`. Verify with `gc skill list` (and
+`gc lint .` / `gc doctor` to surface name collisions). This mirrors how the bundled `core` pack
+ships its `core.gc-*` skills and how the sibling `model-advisor` pack ships `use-model-advisor`.

--- a/provider-forge/tests/test_catalog.py
+++ b/provider-forge/tests/test_catalog.py
@@ -1,0 +1,329 @@
+"""provider-forge — catalog reader + roster-generation tests.
+
+Covers the engine contract (the source-of-truth layer):
+
+  * the SHIPPED catalog.toml parses, and its live/scaffold split is what we expect;
+  * a synthetic catalog exercises cost-ordering, rank-from-1, exclude_from_roster,
+    and the (provider, model) row views deterministically;
+  * the generated roster round-trips back through tomllib into the same tiers;
+  * the roster matches the LIVE codex+claude set: exactly 7 tiers, cost-ordered,
+    with codex-auto-review (exclude_from_roster) omitted;
+  * generation is deterministic (byte-identical across repeated calls).
+
+Pure stdlib + pytest; no third-party deps. The pack root is made importable so
+``import forge...`` works regardless of where pytest is launched from.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+# Make the pack root importable when pytest is run from anywhere.
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+
+try:  # mirror the loader shim so the round-trip assertions use the same backend
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover
+    import tomli as tomllib  # type: ignore[no-redef]
+
+import pytest  # noqa: E402
+
+from forge import catalog as C  # noqa: E402
+from forge.cli import render_roster_toml  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures                                                                      #
+# --------------------------------------------------------------------------- #
+
+# A small, self-contained catalog with a known cost ordering and one excluded
+# model, plus a scaffold provider — independent of the shipped catalog so the
+# ordering/exclusion assertions can't drift when real costs change.
+SYNTH_TOML = """
+schema_version = "provider-forge.v1"
+default_provider = "claude"
+
+[providers.alpha]
+cli = "alpha-cli"
+overlay = "alpha"
+status = "live"
+auth = "~/.alpha/auth.json"
+reasoning_levels = ["low", "high"]
+default_reasoning = "low"
+
+[[providers.alpha.models]]
+id = "a-big"
+model = "alpha-big"
+context = 100000
+in_cost = 9.00
+out_cost = 30.00
+run_target = "alpha-big"
+
+[[providers.alpha.models]]
+id = "a-small"
+model = "alpha-small"
+context = 100000
+in_cost = 0.50
+out_cost = 1.50
+run_target = "alpha-small"
+
+[[providers.alpha.models]]
+id = "a-special"
+model = "alpha-special"
+in_cost = 1.00
+out_cost = 1.00
+run_target = "alpha-special"
+exclude_from_roster = true
+
+[providers.bravo]
+cli = "bravo-cli"
+overlay = "bravo"
+status = "live"
+native = true
+reasoning_levels = []
+
+[[providers.bravo.models]]
+id = "b-mid"
+model = "bravo-mid"
+in_cost = 2.00
+out_cost = 6.00
+run_target = "bravo-mid"
+
+[providers.charlie]
+cli = "charlie-cli"
+overlay = "charlie"
+status = "scaffold"
+reasoning_levels = []
+"""
+
+
+@pytest.fixture()
+def synth() -> C.Catalog:
+    return C.parse_catalog(tomllib.loads(SYNTH_TOML))
+
+
+@pytest.fixture()
+def shipped() -> C.Catalog:
+    return C.load_catalog()  # the pack's own catalog.toml
+
+
+# --------------------------------------------------------------------------- #
+# 1. shipped catalog parses + live/scaffold split                              #
+# --------------------------------------------------------------------------- #
+
+def test_shipped_catalog_parses(shipped: C.Catalog):
+    assert shipped.schema_version == "provider-forge.v1"
+    assert shipped.default_provider == "claude"
+    names = {p.name for p in shipped.providers}
+    # the two live providers must be present
+    assert {"claude", "codex"} <= names
+
+
+def test_shipped_live_vs_scaffold(shipped: C.Catalog):
+    live = {p.name for p in shipped.live()}
+    scaffold = {p.name for p in shipped.scaffold()}
+    assert live == {"claude", "codex"}
+    # the scaffolds declared in the catalog header
+    assert {"gemini", "copilot", "cursor", "kiro", "omp", "opencode", "pi"} <= scaffold
+    assert live.isdisjoint(scaffold)
+
+
+def test_codex_provider_fields(shipped: C.Catalog):
+    codex = shipped.provider("codex")
+    assert codex.is_live
+    assert codex.cli == "codex"
+    assert codex.auth_path() == C.Path(os.path.expanduser("~/.codex/auth.json"))
+    assert codex.default_reasoning == "medium"
+    assert "xhigh" in codex.reasoning_levels
+
+
+# --------------------------------------------------------------------------- #
+# 2. model views: live-only vs all                                             #
+# --------------------------------------------------------------------------- #
+
+def test_models_live_only_excludes_scaffold(synth: C.Catalog):
+    live_models = synth.models(live_only=True)
+    providers = {m.provider for m in live_models}
+    assert providers == {"alpha", "bravo"}  # charlie is scaffold -> excluded
+    # all three alpha models present (exclusion only applies to the roster)
+    assert {m.id for m in live_models} == {"a-big", "a-small", "a-special", "b-mid"}
+
+
+def test_models_all_includes_scaffold_providers(synth: C.Catalog):
+    # charlie declares no models, so the row count is unchanged, but live()==2
+    # and providers list includes the scaffold.
+    assert len(synth.scaffold()) == 1
+    assert synth.scaffold()[0].name == "charlie"
+    # live_only=False would include scaffold providers' models if they had any.
+    assert synth.models(live_only=False) == synth.models(live_only=True)
+
+
+# --------------------------------------------------------------------------- #
+# 3. roster: cost-order, rank-from-1, exclusion                                #
+# --------------------------------------------------------------------------- #
+
+def test_roster_cost_ordered_rank_from_one(synth: C.Catalog):
+    tiers = synth.roster_tiers()
+    # a-special is excluded; remaining 3 cost-ordered ascending:
+    #   a-small 0.5+1.5=2.0 ; bravo-mid 2.0+6.0=8.0 ; a-big 9.0+30.0=39.0
+    assert [t["id"] for t in tiers] == ["a-small", "b-mid", "a-big"]
+    assert [t["rank"] for t in tiers] == [1, 2, 3]
+
+
+def test_roster_excludes_exclude_from_roster(synth: C.Catalog):
+    ids = {t["id"] for t in synth.roster_tiers()}
+    assert "a-special" not in ids
+
+
+def test_roster_tier_fields_exact(synth: C.Catalog):
+    t = synth.roster_tiers()[0]
+    assert set(t.keys()) == {
+        "id", "provider", "model", "run_target", "rank", "in_cost", "out_cost",
+    }
+    assert t == {
+        "id": "a-small",
+        "provider": "alpha",
+        "model": "alpha-small",
+        "run_target": "alpha-small",
+        "rank": 1,
+        "in_cost": 0.50,
+        "out_cost": 1.50,
+    }
+
+
+def test_roster_provider_filter(synth: C.Catalog):
+    tiers = synth.roster_tiers(providers=["bravo"])
+    assert [t["id"] for t in tiers] == ["b-mid"]
+    assert tiers[0]["rank"] == 1  # rank re-based within the filtered set
+
+
+def test_roster_tie_break_is_deterministic():
+    # two models with identical cost -> stable (provider, id) tie-break.
+    toml = """
+schema_version = "provider-forge.v1"
+default_provider = "x"
+[providers.zeta]
+cli = "z"
+status = "live"
+[[providers.zeta.models]]
+id = "z1"
+model = "zeta-1"
+in_cost = 1.0
+out_cost = 1.0
+run_target = "zeta-1"
+[providers.alpha]
+cli = "a"
+status = "live"
+[[providers.alpha.models]]
+id = "a1"
+model = "alpha-1"
+in_cost = 1.0
+out_cost = 1.0
+run_target = "alpha-1"
+"""
+    cat = C.parse_catalog(tomllib.loads(toml))
+    tiers = cat.roster_tiers()
+    # equal cost -> ordered by provider name then id: alpha before zeta
+    assert [t["provider"] for t in tiers] == ["alpha", "zeta"]
+    assert [t["rank"] for t in tiers] == [1, 2]
+
+
+# --------------------------------------------------------------------------- #
+# 4. roster TOML round-trips + determinism                                     #
+# --------------------------------------------------------------------------- #
+
+def test_roster_toml_round_trips(synth: C.Catalog):
+    text = render_roster_toml(synth)
+    reparsed = tomllib.loads(text)
+    assert "tier" in reparsed
+    got = [
+        {k: t[k] for k in ("id", "provider", "model", "run_target", "rank", "in_cost", "out_cost")}
+        for t in reparsed["tier"]
+    ]
+    assert got == synth.roster_tiers()
+
+
+def test_roster_render_is_deterministic(synth: C.Catalog):
+    a = render_roster_toml(synth)
+    b = render_roster_toml(synth)
+    assert a == b  # byte-identical
+
+
+def test_roster_header_documents_cost_caveat(synth: C.Catalog):
+    text = render_roster_toml(synth)
+    head = text.splitlines()[0]
+    assert head.startswith("#")
+    low = text.lower()
+    assert "estimate" in low  # cost/estimate caveat present
+    assert "$/mtok" in low
+
+
+# --------------------------------------------------------------------------- #
+# 5. roster matches the LIVE codex+claude set (the integration contract)       #
+# --------------------------------------------------------------------------- #
+
+def test_shipped_roster_is_seven_tiers_no_auto_review(shipped: C.Catalog):
+    tiers = shipped.roster_tiers()
+    assert len(tiers) == 7
+    ids = [t["id"] for t in tiers]
+    # cost-ordered live set from catalog.toml (auto-review excluded)
+    assert ids == ["spark", "mini", "haiku", "gpt54", "sonnet", "gpt55", "opus"]
+    assert "auto-review" not in ids
+    assert [t["rank"] for t in tiers] == [1, 2, 3, 4, 5, 6, 7]
+
+
+def test_shipped_roster_round_trips_to_same_tiers(shipped: C.Catalog):
+    text = render_roster_toml(shipped)
+    reparsed = tomllib.loads(text)["tier"]
+    assert len(reparsed) == 7
+    # ranks strictly ascending and costs non-decreasing (cost-ordered)
+    ranks = [t["rank"] for t in reparsed]
+    costs = [t["in_cost"] + t["out_cost"] for t in reparsed]
+    assert ranks == sorted(ranks)
+    assert costs == sorted(costs)
+
+
+def test_shipped_auto_review_excluded_but_listed_as_model(shipped: C.Catalog):
+    # auto-review is still a real model row (shows in `list`/`targets`), it is
+    # only omitted from the ROSTER.
+    codex_model_ids = {m.id for m in shipped.provider("codex").models}
+    assert "auto-review" in codex_model_ids
+    roster_ids = {t["id"] for t in shipped.roster_tiers()}
+    assert "auto-review" not in roster_ids
+
+
+# --------------------------------------------------------------------------- #
+# 6. error handling                                                            #
+# --------------------------------------------------------------------------- #
+
+def test_missing_required_key_raises():
+    bad = """
+[providers.x]
+cli = "x"
+status = "live"
+[[providers.x.models]]
+id = "m"
+model = "x-m"
+in_cost = 1.0
+out_cost = 1.0
+"""  # run_target missing
+    with pytest.raises(C.CatalogError):
+        C.parse_catalog(tomllib.loads(bad))
+
+
+def test_bad_status_raises():
+    bad = """
+[providers.x]
+cli = "x"
+status = "experimental"
+"""
+    with pytest.raises(C.CatalogError):
+        C.parse_catalog(tomllib.loads(bad))
+
+
+def test_load_missing_file_raises(tmp_path):
+    with pytest.raises(C.CatalogError):
+        C.load_catalog(tmp_path / "does-not-exist.toml")

--- a/provider-forge/tests/test_cli.py
+++ b/provider-forge/tests/test_cli.py
@@ -1,0 +1,282 @@
+"""provider-forge — CLI surface tests (list / doctor / roster / targets).
+
+These own the CLI contract: filtering, the doctor readiness state machine (with
+a monkeypatched PATH + auth so the three outcomes — ready / missing-cli /
+missing-auth — and the non-zero exit on breakage are all exercised hermetically),
+roster-to-file, and targets. They drive a synthetic catalog written under
+``tmp_path`` (via ``--catalog``) so nothing depends on the host's installed CLIs
+except the explicit doctor-on-shipped smoke test.
+
+Pure stdlib + pytest. The pack root is importable so ``forge.cli.main`` resolves.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import sys
+
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+
+import pytest  # noqa: E402
+
+from forge import catalog as C  # noqa: E402
+from forge import cli  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+# A synthetic catalog on disk: two live providers (one with auth, one without)  #
+# plus a scaffold provider, and one excluded model.                            #
+# --------------------------------------------------------------------------- #
+
+SYNTH_TOML = """
+schema_version = "provider-forge.v1"
+default_provider = "bravo"
+
+[providers.alpha]
+cli = "alpha-cli"
+overlay = "alpha"
+status = "live"
+auth = "~/.alpha/auth.json"
+
+[[providers.alpha.models]]
+id = "a-small"
+model = "alpha-small"
+in_cost = 0.50
+out_cost = 1.50
+run_target = "alpha-small"
+
+[[providers.alpha.models]]
+id = "a-special"
+model = "alpha-special"
+in_cost = 1.00
+out_cost = 1.00
+run_target = "alpha-special"
+exclude_from_roster = true
+
+[providers.bravo]
+cli = "bravo-cli"
+overlay = "bravo"
+status = "live"
+native = true
+
+[[providers.bravo.models]]
+id = "b-mid"
+model = "bravo-mid"
+in_cost = 2.00
+out_cost = 6.00
+run_target = "bravo-mid"
+
+[providers.charlie]
+cli = "charlie-cli"
+overlay = "charlie"
+status = "scaffold"
+
+[[providers.charlie.models]]
+id = "c-future"
+model = "charlie-future"
+in_cost = 4.00
+out_cost = 8.00
+run_target = "charlie-future"
+"""
+
+
+@pytest.fixture()
+def cat_path(tmp_path):
+    p = tmp_path / "catalog.toml"
+    p.write_text(SYNTH_TOML)
+    return str(p)
+
+
+def _run(argv, cat_path=None):
+    """Invoke the CLI, capturing stdout; return (rc, stdout)."""
+    buf = io.StringIO()
+    full = list(argv)
+    if cat_path is not None:
+        full = ["--catalog", cat_path, *full]
+    rc = cli.main(full, out=buf)
+    return rc, buf.getvalue()
+
+
+# --------------------------------------------------------------------------- #
+# list — live default vs --all                                                 #
+# --------------------------------------------------------------------------- #
+
+def test_list_default_live_only(cat_path):
+    rc, out = _run(["list", "--json"], cat_path)
+    assert rc == 0
+    records = json.loads(out)
+    providers = {r["provider"] for r in records}
+    assert providers == {"alpha", "bravo"}  # charlie (scaffold) excluded
+    # exclude_from_roster model still appears in `list` (it's a real model)
+    assert any(r["id"] == "a-special" for r in records)
+
+
+def test_list_all_includes_scaffold(cat_path):
+    rc, out = _run(["list", "--all", "--json"], cat_path)
+    assert rc == 0
+    providers = {r["provider"] for r in json.loads(out)}
+    assert providers == {"alpha", "bravo", "charlie"}
+
+
+def test_list_table_default_omits_scaffold_model(cat_path):
+    rc, out = _run(["list"], cat_path)
+    assert rc == 0
+    assert "charlie-future" not in out  # scaffold model hidden without --all
+    assert "alpha-small" in out
+    rc2, out2 = _run(["list", "--all"], cat_path)
+    assert "charlie-future" in out2  # shown with --all
+
+
+# --------------------------------------------------------------------------- #
+# doctor — readiness state machine (monkeypatched PATH + auth)                  #
+# --------------------------------------------------------------------------- #
+
+def test_doctor_all_ready(cat_path, monkeypatch):
+    # both CLIs "on PATH"; alpha's auth file "exists"; bravo needs no auth.
+    monkeypatch.setattr(cli, "_which", lambda c: "/fake/bin/" + c)
+    monkeypatch.setattr(C.Path, "exists", lambda self: True)
+    rc, out = _run(["doctor", "--json"], cat_path)
+    assert rc == 0
+    payload = json.loads(out)
+    assert payload["ok"] is True
+    by = {p["provider"]: p for p in payload["providers"]}
+    assert by["alpha"]["status"] == cli.READY
+    assert by["bravo"]["status"] == cli.READY
+    assert by["bravo"]["auth"] is None  # no auth required
+
+
+def test_doctor_missing_cli(cat_path, monkeypatch):
+    # alpha CLI missing -> missing-cli and non-zero exit; bravo fine.
+    def which(c):
+        return None if c == "alpha-cli" else "/fake/bin/" + c
+    monkeypatch.setattr(cli, "_which", which)
+    monkeypatch.setattr(C.Path, "exists", lambda self: True)
+    rc, out = _run(["doctor", "--json"], cat_path)
+    assert rc == 1  # broken live provider -> non-zero
+    by = {p["provider"]: p for p in json.loads(out)["providers"]}
+    assert by["alpha"]["status"] == cli.MISSING_CLI
+    assert by["alpha"]["ready"] is False
+    assert by["bravo"]["status"] == cli.READY
+
+
+def test_doctor_missing_auth(cat_path, monkeypatch):
+    # CLI present, but alpha's auth file does NOT exist -> missing-auth.
+    monkeypatch.setattr(cli, "_which", lambda c: "/fake/bin/" + c)
+    monkeypatch.setattr(C.Path, "exists", lambda self: False)
+    rc, out = _run(["doctor", "--json"], cat_path)
+    assert rc == 1
+    by = {p["provider"]: p for p in json.loads(out)["providers"]}
+    assert by["alpha"]["status"] == cli.MISSING_AUTH
+    assert by["alpha"]["ready"] is False
+    # bravo declares no auth -> still ready even though exists()==False
+    assert by["bravo"]["status"] == cli.READY
+
+
+def test_doctor_missing_cli_dominates_missing_auth(cat_path, monkeypatch):
+    # both CLI missing AND auth missing -> report missing-cli (the dominant fault).
+    monkeypatch.setattr(cli, "_which", lambda c: None)
+    monkeypatch.setattr(C.Path, "exists", lambda self: False)
+    rc, out = _run(["doctor", "--json"], cat_path)
+    assert rc == 1
+    by = {p["provider"]: p for p in json.loads(out)["providers"]}
+    assert by["alpha"]["status"] == cli.MISSING_CLI
+
+
+def test_doctor_table_reports_not_ready(cat_path, monkeypatch):
+    monkeypatch.setattr(cli, "_which", lambda c: None)
+    rc, out = _run(["doctor"], cat_path)
+    assert rc == 1
+    assert "NOT READY" in out
+
+
+def test_doctor_on_shipped_catalog_smoke():
+    # On THIS machine claude+codex are installed/authed; assert the surface runs
+    # and returns a well-formed payload (rc reflects real readiness).
+    buf = io.StringIO()
+    rc = cli.main(["doctor", "--json"], out=buf)
+    payload = json.loads(buf.getvalue())
+    assert set(payload.keys()) == {"ok", "providers"}
+    assert {p["provider"] for p in payload["providers"]} == {"claude", "codex"}
+    assert rc in (0, 1)
+
+
+# --------------------------------------------------------------------------- #
+# roster — stdout + --out file                                                 #
+# --------------------------------------------------------------------------- #
+
+def test_roster_stdout(cat_path):
+    rc, out = _run(["roster"], cat_path)
+    assert rc == 0
+    assert out.startswith("#")
+    assert "[[tier]]" in out
+    # a-special excluded; cost order a-small(2.0) < b-mid(8.0)
+    i_small = out.index('"a-small"')
+    i_mid = out.index('"b-mid"')
+    assert i_small < i_mid
+    assert "a-special" not in out
+
+
+def test_roster_out_file_round_trips(cat_path, tmp_path):
+    out_file = tmp_path / "advisor.toml"
+    rc, _ = _run(["roster", "--out", str(out_file)], cat_path)
+    assert rc == 0
+    assert out_file.is_file()
+    # reload the catalog independently and compare tiers
+    try:
+        import tomllib
+    except ModuleNotFoundError:  # pragma: no cover
+        import tomli as tomllib  # type: ignore
+    parsed = tomllib.loads(out_file.read_text())["tier"]
+    expected = C.load_catalog(cat_path).roster_tiers()
+    got = [
+        {k: t[k] for k in ("id", "provider", "model", "run_target", "rank", "in_cost", "out_cost")}
+        for t in parsed
+    ]
+    assert got == expected
+
+
+def test_roster_provider_filter_cli(cat_path):
+    rc, out = _run(["roster", "--provider", "bravo"], cat_path)
+    assert rc == 0
+    assert '"b-mid"' in out
+    assert '"a-small"' not in out
+
+
+def test_roster_unknown_provider_errors(cat_path):
+    rc, out = _run(["roster", "--provider", "nope"], cat_path)
+    assert rc == 2  # fails loudly, does not emit an empty roster
+
+
+# --------------------------------------------------------------------------- #
+# targets                                                                       #
+# --------------------------------------------------------------------------- #
+
+def test_targets_lists_live_run_targets(cat_path):
+    rc, out = _run(["targets", "--json"], cat_path)
+    assert rc == 0
+    records = json.loads(out)
+    rts = {r["run_target"]: r for r in records}
+    # live providers only (charlie scaffold excluded), incl. the excluded model's
+    # target (run targets are about gc session configs, independent of roster).
+    assert set(rts) == {"alpha-small", "alpha-special", "bravo-mid"}
+    assert rts["bravo-mid"]["provider"] == "bravo"
+    assert rts["bravo-mid"]["model"] == "bravo-mid"
+
+
+def test_targets_maps_provider_and_model(cat_path):
+    rc, out = _run(["targets"], cat_path)
+    assert rc == 0
+    assert "alpha-small" in out and "alpha" in out
+
+
+# --------------------------------------------------------------------------- #
+# bad catalog path via CLI                                                      #
+# --------------------------------------------------------------------------- #
+
+def test_cli_bad_catalog_exits_2(tmp_path):
+    rc, _ = _run(["list"], str(tmp_path / "missing.toml"))
+    assert rc == 2

--- a/provider-forge/uninstall.sh
+++ b/provider-forge/uninstall.sh
@@ -1,0 +1,258 @@
+#!/usr/bin/env bash
+# provider-forge — uninstall lifecycle (reverses everything install.sh did).
+#
+#   uninstall.sh (--town | --rig <name>) [--dry-run] [--city <path>]
+#                [--purge] [--no-reload]
+#
+# Reverses, in order:
+#   1. Remove the pack import. It is a DIRECT config entry (the gastown pattern,
+#      not `gc import add`/`remove`), so a surgical, backed-up edit drops it:
+#        --town       -> drops  <city>/pack.toml   [imports.provider-forge]
+#        --rig <name> -> drops  <city>/city.toml   [rigs.imports.provider-forge]
+#                        (from under the [[rigs]] entry whose name matches <name>)
+#   2. Re-project with `gc reload` so the pack's surfaces drop out of projection.
+#   3. --purge: delete the engine .venv.
+#
+# Unlike model-advisor, provider-forge ships NO prompt fragment and NO overlay
+# hook, so there is nothing to remove from global_fragments and no projected
+# .claude/settings.json hook to strip — the uninstall is just: import + reload
+# (+ optional purge).
+#
+# Idempotent (re-running after a clean uninstall is a no-op). Any file it edits
+# is backed up first. --dry-run prints the plan and changes nothing.
+
+set -euo pipefail
+
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${HOME}/go/bin:${HOME}/.local/bin:${PATH}"
+
+PACK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PACK_NAME="provider-forge"
+IMPORT_NAME="provider-forge"
+
+SCOPE=""; RIG=""; DRY_RUN=0; NO_RELOAD=0; PURGE=0; CITY=""
+
+die()  { printf 'uninstall.sh: error: %s\n' "$*" >&2; exit 1; }
+info() { printf '  %s\n' "$*"; }
+step() { printf '\n==> %s\n' "$*"; }
+run()  { if [ "$DRY_RUN" -eq 1 ]; then printf '    [dry-run] %s\n' "$*"; else printf '    + %s\n' "$*"; eval "$@"; fi; }
+
+usage() { sed -n '2,25p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit "${1:-0}"; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --town)      SCOPE="town"; shift ;;
+    --rig)       SCOPE="rig"; RIG="${2:-}"; [ -n "$RIG" ] || die "--rig requires a rig name"; shift 2 ;;
+    --rig=*)     SCOPE="rig"; RIG="${1#*=}"; shift ;;
+    --dry-run)   DRY_RUN=1; shift ;;
+    --purge)     PURGE=1; shift ;;
+    --no-reload) NO_RELOAD=1; shift ;;
+    --city)      CITY="${2:-}"; [ -n "$CITY" ] || die "--city requires a path"; shift 2 ;;
+    --city=*)    CITY="${1#*=}"; shift ;;
+    -h|--help)   usage 0 ;;
+    *)           die "unknown argument: $1 (try --help)" ;;
+  esac
+done
+
+[ -n "$SCOPE" ] || die "choose a scope: --town or --rig <name>"
+
+if [ -z "$CITY" ]; then CITY="$(cd "$PACK_DIR/../.." && pwd)"; fi
+[ -f "$CITY/city.toml" ] || die "no city.toml at city root: $CITY (pass --city <path>)"
+CITY="$(cd "$CITY" && pwd)"
+
+GC=(gc --city "$CITY")
+
+step "provider-forge uninstall"
+info "scope:  $SCOPE${RIG:+ ($RIG)}"
+info "city:   $CITY"
+[ "$PURGE" -eq 1 ]   && info "purge:  yes (will delete .venv)"
+[ "$DRY_RUN" -eq 1 ] && info "MODE:   DRY RUN (no changes will be made)"
+
+command -v gc >/dev/null 2>&1 || die "gc not found on PATH"
+
+backup_file() {
+  local f="$1"; [ -f "$f" ] || return 0
+  local b="${f}.provider-forge.bak.$(date +%Y%m%d%H%M%S)"
+  if [ "$DRY_RUN" -eq 1 ]; then printf '    [dry-run] backup %s -> %s\n' "$f" "$b"; return 0; fi
+  cp -p "$f" "$b"; printf '    backup: %s\n' "$b"
+}
+
+import_present() { # 0 if IMPORT_NAME is registered at the active scope.
+  # gc import list reports direct-config imports (the gastown style); fall back
+  # to a config grep for the [..imports.NAME] table if the catalog is unbuilt.
+  if [ "$SCOPE" = "rig" ]; then
+    if "${GC[@]}" import list --rig "$RIG" 2>/dev/null | awk '{print $1}' | grep -qx "$IMPORT_NAME"; then
+      return 0
+    fi
+    rig_import_in_config "$RIG"
+  else
+    if "${GC[@]}" import list 2>/dev/null | awk '{print $1}' | grep -qx "$IMPORT_NAME"; then
+      return 0
+    fi
+    grep -Eq "^\[imports\.${IMPORT_NAME}\][[:space:]]*$" "$CITY/pack.toml" 2>/dev/null
+  fi
+}
+
+rig_import_in_config() { # 0 if [rigs.imports.IMPORT_NAME] exists under rig $1
+  python3 - "$CITY/city.toml" "$1" "$IMPORT_NAME" <<'PY'
+import sys, re
+path, rig, name = sys.argv[1], sys.argv[2], sys.argv[3]
+lines = open(path).read().splitlines(keepends=True)
+starts = [i for i, l in enumerate(lines) if re.match(r'^\[\[rigs\]\]\s*$', l)]
+for k, s in enumerate(starts):
+    end = starts[k + 1] if k + 1 < len(starts) else len(lines)
+    for j in range(s + 1, end):
+        if re.match(r'^\[', lines[j]) and not re.match(r'^\[(\[rigs\]\]|rigs(\.|\]))', lines[j]):
+            end = j; break
+    named = None
+    for j in range(s + 1, end):
+        m = re.match(r'^\s*name\s*=\s*["\'](.+?)["\']\s*$', lines[j])
+        if m:
+            named = m.group(1); break
+    if named != rig:
+        continue
+    hdr = re.compile(r'^\[rigs\.imports\.%s\]\s*$' % re.escape(name))
+    if any(hdr.match(lines[j]) for j in range(s + 1, end)):
+        sys.exit(0)
+    sys.exit(1)
+sys.exit(1)
+PY
+}
+
+edit_import() { # add|remove a DIRECT-config import (gastown style); idempotent.
+  # The mirror of install.sh's helper — a local in-tree pack is a direct config
+  # entry, not `gc import add`. Surgical text edit; rest of file byte-exact, so
+  # removal exactly reverses the add install.sh made.
+  #   town: file=pack.toml, [imports] -> [imports.IMPORT_NAME]
+  #   rig : file=city.toml, the [rigs.imports] of the [[rigs]] named $5
+  #         -> [rigs.imports.IMPORT_NAME]
+  # args: <action> <file> <import_name> <source> [<rig_name>]   (source ignored
+  #       on remove; pass "" for clarity)
+  python3 - "$2" "$1" "$3" "$4" "${5:-}" <<'PY'
+import sys, re
+path, action, name, source, rig = sys.argv[1:6]
+rig = rig or None
+
+def fail(msg):
+    sys.stderr.write("edit_import: %s\n" % msg); sys.exit(3)
+
+lines = open(path).read().splitlines(keepends=True)
+
+if rig is None:
+    table = "imports"
+    anchor = next((i for i, l in enumerate(lines) if re.match(r'^\[imports\]\s*$', l)), None)
+    if anchor is None: fail("[imports] table not found in %s" % path)
+    hi = len(lines)
+else:
+    table = "rigs.imports"
+    starts = [i for i, l in enumerate(lines) if re.match(r'^\[\[rigs\]\]\s*$', l)]
+    if not starts: fail("no [[rigs]] blocks in %s" % path)
+    target_start = None; hi = len(lines)
+    for k, s in enumerate(starts):
+        end = starts[k + 1] if k + 1 < len(starts) else len(lines)
+        for j in range(s + 1, end):
+            if re.match(r'^\[', lines[j]) and not re.match(r'^\[(\[rigs\]\]|rigs(\.|\]))', lines[j]):
+                end = j; break
+        named = None
+        for j in range(s + 1, end):
+            m = re.match(r'^\s*name\s*=\s*["\'](.+?)["\']\s*$', lines[j])
+            if m: named = m.group(1); break
+        if named == rig:
+            target_start, hi = s, end; break
+    if target_start is None: fail('no [[rigs]] block with name = "%s" in %s' % (rig, path))
+    anchor = next((i for i in range(target_start, hi) if re.match(r'^\[rigs\.imports\]\s*$', lines[i])), None)
+    if anchor is None: fail('[rigs.imports] not found under rig "%s" in %s' % (rig, path))
+
+header = "[%s.%s]" % (table, name)
+sub = re.compile(r'^\[%s\.%s\]\s*$' % (re.escape(table), re.escape(name)))
+existing = next((i for i in range(anchor, hi) if sub.match(lines[i])), None)
+
+if action == "add":
+    if existing is not None: sys.exit(0)
+    lines.insert(anchor + 1, "%s\nsource = \"%s\"\n" % (header, source))
+    open(path, "w").write("".join(lines))
+elif action == "remove":
+    if existing is None: sys.exit(0)
+    end = existing + 1
+    if end < len(lines) and re.match(r'^\s*source\s*=', lines[end]): end += 1
+    del lines[existing:end]
+    open(path, "w").write("".join(lines))
+else:
+    fail("unknown action: %s" % action)
+PY
+}
+
+# ---- step 1: import --------------------------------------------------------
+# The import is a DIRECT config entry (the gastown pattern), so remove it with a
+# surgical, backed-up edit — NOT `gc import remove` (paired with install's
+# edit_import; the removal exactly reverses the added table).
+#   rig : <city>/city.toml -> drop [rigs.imports.provider-forge] under [[rigs]] named $RIG
+#   town: <city>/pack.toml -> drop [imports.provider-forge]
+step "1/3  remove pack import ($SCOPE scope)"
+if import_present; then
+  if [ "$SCOPE" = "rig" ]; then
+    IMPORT_CFG="$CITY/city.toml"
+    backup_file "$IMPORT_CFG"
+    if [ "$DRY_RUN" -eq 1 ]; then
+      info "[dry-run] remove [rigs.imports.$IMPORT_NAME] from under rig \"$RIG\" in $IMPORT_CFG"
+    else
+      edit_import remove "$IMPORT_CFG" "$IMPORT_NAME" "" "$RIG" \
+        || die "failed to remove [rigs.imports.$IMPORT_NAME] from $IMPORT_CFG"
+      info "removed [rigs.imports.$IMPORT_NAME] from under rig \"$RIG\""
+    fi
+  else
+    IMPORT_CFG="$CITY/pack.toml"
+    backup_file "$IMPORT_CFG"
+    if [ "$DRY_RUN" -eq 1 ]; then
+      info "[dry-run] remove [imports.$IMPORT_NAME] from $IMPORT_CFG"
+    else
+      edit_import remove "$IMPORT_CFG" "$IMPORT_NAME" "" \
+        || die "failed to remove [imports.$IMPORT_NAME] from $IMPORT_CFG"
+      info "removed [imports.$IMPORT_NAME]"
+    fi
+  fi
+else
+  info "import \"$IMPORT_NAME\" not registered at this scope — no-op"
+fi
+
+# ---- step 2: re-project ----------------------------------------------------
+step "2/3  re-project (gc reload)"
+if [ "$NO_RELOAD" -eq 1 ]; then
+  info "--no-reload: skipping. Run 'gc reload' to drop the pack from projection."
+elif [ "$DRY_RUN" -eq 1 ]; then
+  info "[dry-run] gc reload  (drops the pack's surfaces from projection)"
+else
+  if "${GC[@]}" reload >/dev/null 2>&1; then info "gc reload: ok"
+  else info "gc reload non-zero (city may be stopped); clean state applies on next start"; fi
+fi
+
+# ---- step 3: purge venv ----------------------------------------------------
+step "3/3  engine venv"
+if [ "$PURGE" -eq 1 ]; then
+  if [ -d "$PACK_DIR/.venv" ]; then
+    run "rm -rf \"$PACK_DIR/.venv\""
+    info "purged $PACK_DIR/.venv"
+  else
+    info "no .venv to purge"
+  fi
+else
+  info "kept $PACK_DIR/.venv (pass --purge to delete it)"
+fi
+
+# ---- verify ----------------------------------------------------------------
+step "verify"
+if [ "$DRY_RUN" -eq 1 ]; then
+  step "provider-forge uninstall — DRY RUN complete (no changes made)"; exit 0
+fi
+fail=0
+if import_present; then info "import: STILL REGISTERED ($IMPORT_NAME)"; fail=1; else info "import: removed"; fi
+
+echo
+if [ "$fail" -eq 0 ]; then
+  step "provider-forge uninstall complete ($SCOPE${RIG:+ $RIG})"
+  info "Backups (*.provider-forge.bak.*) were left in place; remove them when satisfied."
+  exit 0
+else
+  step "provider-forge uninstall finished WITH WARNINGS"
+  info "Review the STILL-* lines above."
+  exit 1
+fi

--- a/registry.toml
+++ b/registry.toml
@@ -77,3 +77,17 @@ source_kind = "git"
   commit = "d3617d1319a1206ac85f69ba024ec395c49c6f4b"
   hash = "sha256:0d32d8da6ad57c632d4f54008bdd1bb8b822c493a709676b3d1761a5ef389387"
   description = "Initial Slack pack release."
+
+[[pack]]
+name = "provider-forge"
+description = "Multi-provider model catalog + enablement for Gas City — detect/verify provider CLIs, declare run targets, and generate model-advisor's tier roster from one source of truth."
+source = "https://github.com/gastownhall/gascity-packs/tree/main/provider-forge"
+source_kind = "git"
+
+  # commit/hash are placeholders for maintainers to finalize via release tooling on merge.
+  [[pack.release]]
+  version = "0.1.0"
+  ref = "main"
+  commit = "e5a9d3ed7bff40c4d3a671c1c63191915242135a"
+  hash = "sha256:d11f740607eb6a69aebc81f5abe2ed1f35e15eca880f376fd2fe6a0714c3dcc4"
+  description = "Initial provider-forge pack release."


### PR DESCRIPTION
Multi-provider model catalog + enablement: detect/verify provider CLIs, declare run targets, and generate model-advisor's tier roster from one source of truth. Codex + Claude live; gemini/copilot/cursor/kiro/omp/opencode/pi scaffolded.