### PR TITLE
fix(deacon): add bug-filing routing rules and no-idle-cycle enforcement

### DIFF
--- a/gastown/agents/deacon/prompt.template.md
+++ b/gastown/agents/deacon/prompt.template.md
@@ -33,6 +33,7 @@ Your job:
 - Kill agents directly (file warrants, dog pool runs shutdown dance)
 - Pool sizing (controller pool reconciliation)
 - Per-rig polecat health monitoring (witness handles this)
+- Route bugs to a polecat pool without verifying rig scope (file in the right rig; mail mayor if unsure)
 
 {{ template "architecture" . }}
 
@@ -76,7 +77,52 @@ gc bd formula show mol-deacon-patrol
 # Step 5: Execute — work through the steps in order
 ```
 
-**Hook -> Read formula steps (`gc bd formula show <name>`) -> Follow in order -> pour next iteration.**
+**Hook -> Read formula steps (`gc bd formula show <name>`) -> Follow in order -> pour next iteration -> run `gc hook`.**
+
+## CRITICAL: No Idle State Between Cycles
+
+After every patrol cycle, the formula's `next-iteration` step pours the
+next `mol-deacon-patrol` wisp before burning the current one. When it
+finishes, run `gc hook` immediately — the new wisp is already assigned
+to you.
+
+**Do NOT enter "Standing by for the next hook" idle state.** That phrase
+is a bug indicator. Use this fallback only if you exited the cycle
+without running `next-iteration` (crash recovery or formula misread).
+If `next-iteration` already ran, do not pour again; run `gc hook`.
+
+```bash
+CURRENT_WISP=${GC_BEAD_ID:-}
+if [ -z "$CURRENT_WISP" ]; then
+  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=wisp --limit=1 --json | jq -r '.[0].id // empty')
+fi
+ASSIGNED_WISP=$(gc bd list --assignee="$GC_AGENT" --status=open --type=wisp --limit=1 --json | jq -r '.[0].id // empty')
+if [ -n "$CURRENT_WISP" ] && [ -z "$ASSIGNED_WISP" ]; then
+  NEXT=$(gc bd mol wisp mol-deacon-patrol --root-only --var binding_prefix={{ .BindingPrefix }} --json | jq -r '.new_epic_id // empty')
+  if [ -z "$NEXT" ]; then
+    echo "Could not pour next deacon wisp; not burning."
+    exit 1
+  fi
+  if ! gc bd update "$NEXT" --assignee="$GC_AGENT"; then
+    echo "Could not assign next deacon wisp; not burning."
+    exit 1
+  fi
+  gc bd mol burn "$CURRENT_WISP" --force
+elif [ -n "$CURRENT_WISP" ]; then
+  gc bd mol burn "$CURRENT_WISP" --force
+elif [ -z "$ASSIGNED_WISP" ]; then
+  NEXT=$(gc bd mol wisp mol-deacon-patrol --root-only --var binding_prefix={{ .BindingPrefix }} --json | jq -r '.new_epic_id // empty')
+  if [ -z "$NEXT" ]; then
+    echo "Could not bootstrap next deacon wisp."
+    exit 1
+  fi
+  if ! gc bd update "$NEXT" --assignee="$GC_AGENT"; then
+    echo "Could not assign bootstrap deacon wisp."
+    exit 1
+  fi
+fi
+gc hook
+```
 
 ## Context Exhaustion
 
@@ -98,6 +144,37 @@ Mail beads can be hooked for ad-hoc instruction handoff:
 
 This enables ad-hoc tasks (e.g., "focus on debugging convoy resolution this
 cycle") without creating formal beads.
+
+---
+
+## Filing Bugs Discovered During Patrol
+
+When you observe a bug or problem during patrol, **you do not fix it and you
+do not dispatch it to the first available polecat pool.** File it correctly
+and stop.
+
+**Rig scope determines where to file:**
+
+| What the bug is about | Where to file | Routing |
+|---|---|---|
+| Code in a specific rig (chatehr, wyvern, etc.) | `gc bd create --rig <rig> ...` | `gc sling <rig>/{{ .BindingPrefix }}polecat <id>` |
+| gastown infrastructure (gc CLI, controller, packs, agents) | `gc bd create --rig gastown ...` | Mail mayor for triage |
+| Cross-rig or unclear ownership | `gc bd create ...` (HQ) | Mail mayor for triage |
+
+**Never route infrastructure bugs to a rig-scoped polecat.** A `chatehr/gastown.polecat`
+works in the chatehr repo. Sending it a gastown controller bug or a gc CLI bug
+is wrong — it has no context, no codebase access, and will claim the bead and
+spin its wheels. Similarly, never route a rig bug to the wrong rig's polecat.
+
+**The test:** "Which git repo would the fix land in?" File there.
+
+For bugs you can't clearly own, mail the mayor:
+```bash
+gc mail send mayor/ -s "Bug observed: <brief>" -m "<description and why you're unsure>"
+```
+
+Leave `gc.routed_to` **empty** for anything that needs mayor triage. Setting it
+to the wrong pool is worse than leaving it unset.
 
 ---
 
@@ -174,6 +251,8 @@ Individual stuck agents don't need escalation — the warrant system handles the
 | Run system diagnostics | `gc doctor` |
 | Compact wisps (dry run) | `gc bd mol wisp gc --age 24h --dry-run` |
 | Compact wisps | `gc bd mol wisp gc --age 24h` |
+| File rig bug (correct rig) | `gc bd create --rig <rig> --title="..." --type=bug --description="..."` |
+| File infrastructure bug | `gc bd create --rig gastown --title="..." --type=bug` then mail mayor |
 
 Working directory: {{ .WorkDir }}
 Your mail address: {{ .AgentName }}


### PR DESCRIPTION
## Problem

Two gaps in the deacon prompt caused operational problems in production:

**1. Deacon routing bugs to wrong rig's polecat pool**

The deacon had no guidance on how to file bugs it discovers during patrol. In practice it was routing infrastructure bugs (e.g. controller/dog-pool scaling issues) to `proj/gastown.polecat` — a rig-scoped polecat with no access to the gastown codebase. This caused:
- Polecats claiming work completely unrelated to their rig
- Polecats getting overloaded with multiple unrelated beads
- Wasted cycles on bugs they have no context or access to fix

**2. Deacon entering idle state between patrol cycles**

After completing a patrol cycle the deacon would sometimes stall waiting for a human nudge instead of immediately running `gc hook`. The fallback shell snippet handling this case existed in deployed installs but was missing from the source prompt, causing drift on reinstall.

## Changes

**Bug-filing routing rules** (`Filing Bugs Discovered During Patrol` section):
- Explicit routing table: rig bug → that rig's polecat, infrastructure/gastown bug → gastown rig + mail mayor, unclear → HQ + mail mayor
- The test: "Which git repo would the fix land in?"
- Explicit rule: leave `gc.routed_to` empty for anything needing mayor triage — wrong pool is worse than unset
- Added to "what you never do" list
- Added bug-filing commands to quick-reference table

**No-idle-cycle enforcement** (`CRITICAL: No Idle State Between Cycles` section):
- Documents that `next-iteration` pours the next wisp before burning the current one
- Flags "Standing by for the next hook" as a bug indicator
- Adds the fallback shell snippet for crash recovery cases

## Observed failure

```
ga-ojk · Bug: dog pool not auto-scaled when parent molecule open but unworked
  created_by: gastown__deacon
  gc.routed_to: proj/gastown.polecat   ← wrong
  assignee: chatehr/gastown.capable       ← claimed alongside unrelated P0
```

The deacon filed a gastown controller bug and routed it to a project polecat. That polecat already had a P0 assigned; it claimed this P2 on its next nudge cycle, getting overloaded with two unrelated beads across two unrelated codebases.