### PR TITLE
feat: add the GasCity Cockpit enabler pack

### DIFF
--- a/cockpit/.gitignore
+++ b/cockpit/.gitignore
@@ -1,0 +1,14 @@
+.venv/
+__pycache__/
+*.pyc
+.pytest_cache/
+.ruff_cache/
+.coverage
+.coverage.*
+coverage.json
+coverage.xml
+htmlcov/
+
+# install.sh / uninstall.sh leave timestamped config backups next to the files
+# they edit; never commit those.
+*.cockpit.bak.*

--- a/cockpit/LICENSE
+++ b/cockpit/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Jay German
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/cockpit/README.md
+++ b/cockpit/README.md
@@ -1,0 +1,71 @@
+# cockpit — GasCity Cockpit city-side enabler pack
+
+The **GasCity Cockpit** is a VS Code extension (the client) plus this thin gascity
+pack (the city-side contract). The extension is a pure client of the supervisor's
+existing `/v0` HTTP API; this pack makes a city **Cockpit-ready** and publishes the
+discovery handshake the extension needs. It adds **no backend**.
+
+> Status: v1 scaffold for epic `cockpit-1ll`, per the PROPOSED decisions in
+> `cockpit-1ll.3`. **Read [`docs/DESIGN.md`](docs/DESIGN.md) §4 — three scope forks
+> are flagged there for ratification before the pack is extended.**
+
+## What it provides
+
+| Path | Role |
+|------|------|
+| `bin/cockpit` | the `ready` / `discover` / `contract` / `adapter` CLI |
+| `cockpit/` | the engine (pure-stdlib probe + contract reader) |
+| `contract/v0.toml` | the `/v0` API contract the extension pins (version + endpoints) |
+| `skills/cockpit-readiness/` | operator/agent skill: verify + publish discovery |
+| `skills/mayor-ide-affordances/` | Mayor skill: emit IDE-legible affordances |
+| `docs/DESIGN.md` | Cockpit-ready definition, discovery handshake, **scope forks** |
+
+Stdlib-only (`tomllib` ≥3.11 / `tomli` fallback; `urllib` for the probe). No overlay,
+no hooks, no prompt fragments — mirrors `provider-forge`'s minimal footprint.
+
+## Quickstart
+
+```bash
+# (optional) build the engine venv; bin/cockpit also runs under any system python3
+./setup.sh
+
+# 1. Is this city Cockpit-ready? (exit 0 ready / 1 incompatible / 2 unreachable)
+./bin/cockpit ready
+
+# 2. Publish the discovery descriptor the extension auto-discovers
+GC_HOME=~/.gc ./bin/cockpit discover --write --city <cityName>
+
+# 3. See the /v0 contract the extension pins
+./bin/cockpit contract
+
+# 4. See the extmsg adapter registration spec (submitted at runtime; cockpit-1ll.12)
+./bin/cockpit adapter --city <cityName>
+```
+
+`ready` and `contract` are pure reads; `discover` only writes with `--write`/`--out`;
+`adapter` prints the spec and does **not** register (extmsg registration is a runtime
+call — see DESIGN.md fork #2).
+
+## Install into a city
+
+Vendor `pack/` into the target city as `packs/cockpit/`, then:
+
+```bash
+packs/cockpit/install.sh --town            # city-wide
+packs/cockpit/install.sh --rig <name>      # one rig
+packs/cockpit/install.sh --town --dry-run  # preview
+```
+
+This registers a direct `source = "packs/cockpit"` import (the gastown pattern),
+`gc reload`s, and verifies (`gc lint`, import registered, `cockpit ready` smoke).
+Reverse with `uninstall.sh` (same scope flags; `--purge` to drop the venv).
+
+## Tests
+
+```bash
+python3 -m pytest -q        # 30 tests, pure stdlib + pytest, no network
+```
+
+## License
+
+MIT — see [LICENSE](LICENSE).

--- a/cockpit/bin/cockpit
+++ b/cockpit/bin/cockpit
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# cockpit CLI: ready / discover / contract / adapter over the /v0 API.
+#
+#   bin/cockpit ready    [--base-url URL] [--city NAME] [--json]
+#   bin/cockpit discover [--base-url URL] [--write] [--out FILE] [--json]
+#   bin/cockpit contract [--json]
+#   bin/cockpit adapter  [--city NAME] [--callback-url URL] [--json]
+#
+# This wrapper resolves the pack's own venv python (so cockpit runs under the
+# interpreter its deps are installed in), falling back to system python3, then
+# hands off to `python -m cockpit.cli`. It mirrors provider-forge/bin/forge.
+#
+# Degrades gracefully: the engine is pure-stdlib (tomllib on Python >= 3.11,
+# urllib for the probe), so it runs fine with no .venv as long as some python3 is
+# present. If NO interpreter is found it prints a clear error to stderr and exits
+# 2 — it never silently no-ops.
+set -euo pipefail
+PACK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PY="$PACK_DIR/.venv/bin/python"
+[ -x "$PY" ] || PY="$(command -v python3 || true)"
+[ -n "$PY" ] || { echo "cockpit: no python interpreter found (no .venv, no python3)" >&2; exit 2; }
+exec env PYTHONPATH="$PACK_DIR${PYTHONPATH:+:$PYTHONPATH}" "$PY" -m cockpit.cli "$@"

--- a/cockpit/cockpit/__init__.py
+++ b/cockpit/cockpit/__init__.py
@@ -1,0 +1,24 @@
+"""cockpit — the GasCity Cockpit city-side enabler engine.
+
+A pure-stdlib toolkit that makes a gas city *Cockpit-ready* and defines the
+discovery handshake the VS Code extension needs. It does NOT run a backend; it is
+a thin client of the supervisor's existing ``/v0`` HTTP API.
+
+Public surface (what the CLI and the extension build on):
+
+- :mod:`cockpit.contract`  — load the ``/v0`` API contract (``contract/v0.toml``):
+  the pinned API version, the required-endpoint gate, and the extmsg adapter
+  registration spec.
+- :mod:`cockpit.discovery` — probe the live ``/v0`` API (:func:`~cockpit.discovery.probe_api`),
+  assess readiness against the contract, and read/write the discovery descriptor
+  the extension auto-discovers.
+- :mod:`cockpit.cli`       — the ``ready`` / ``discover`` / ``contract`` /
+  ``adapter`` command implementations.
+"""
+
+from __future__ import annotations
+
+SCHEMA = "cockpit.v0"
+__version__ = "0.1.0"
+
+__all__ = ["SCHEMA", "__version__"]

--- a/cockpit/cockpit/cli.py
+++ b/cockpit/cockpit/cli.py
@@ -1,0 +1,248 @@
+"""cockpit CLI — make a gas city Cockpit-ready and publish the discovery handshake.
+
+    cockpit ready    [--base-url URL] [--city NAME] [--json]
+        assert the live /v0 API is reachable + version-compatible + has the
+        endpoints the Cockpit depends on.
+    cockpit discover [--base-url URL] [--write] [--out FILE] [--json]
+        probe the API and (with --write/--out) publish the discovery descriptor.
+    cockpit contract [--json]
+        print the /v0 API contract the extension pins.
+    cockpit adapter  [--city NAME] [--callback-url URL] [--json]
+        print the extmsg adapter registration spec the host submits at runtime.
+
+``ready`` and ``contract`` are pure reads; ``discover`` only writes with
+``--write``/``--out``. ``adapter`` PRINTS the registration spec — it does NOT
+register (extmsg registration is a runtime, ephemeral API call; see
+``docs/DESIGN.md`` fork #2 + cockpit-1ll.12).
+
+Exit codes: 0 ok; 1 reachable but not Cockpit-compatible (version/paths); 2 API
+unreachable or a contract error. Pure stdlib; invoked as ``python -m cockpit.cli``
+by the ``bin/cockpit`` wrapper.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Any, Optional, Sequence
+
+from cockpit import contract as K
+from cockpit import discovery as D
+
+
+def _load_contract_or_die(path: Optional[str]) -> dict[str, Any]:
+    try:
+        return K.load_contract(path)
+    except K.ContractError as e:
+        sys.stderr.write(f"cockpit: {e}\n")
+        raise SystemExit(2)
+
+
+# --------------------------------------------------------------------------- #
+# ready                                                                          #
+# --------------------------------------------------------------------------- #
+
+def cmd_ready(args: argparse.Namespace, out) -> int:
+    contract = _load_contract_or_die(args.contract)
+    req_ver = K.required_api_version(contract)
+    req_paths = K.required_paths(contract)
+    probe = D.probe_api(args.base_url, timeout=args.timeout)
+    verdict = D.assess_readiness(probe, req_ver, req_paths)
+
+    city_readiness = None
+    if args.city and probe.get("reachable"):
+        city_readiness = D.fetch_city_readiness(args.base_url, args.city, args.timeout)
+
+    if args.json:
+        out.write(
+            json.dumps(
+                {"probe": probe, "verdict": verdict, "city_readiness": city_readiness},
+                indent=2,
+            )
+            + "\n"
+        )
+        return 0 if verdict["ready"] else (2 if not probe["reachable"] else 1)
+
+    out.write(f"API:        {probe['base_url']}\n")
+    if not probe["reachable"]:
+        out.write("status:     UNREACHABLE\n")
+        for e in probe["errors"]:
+            out.write(f"  - {e}\n")
+        out.write(
+            "\nThe supervisor /v0 API is not answering. Is the city running "
+            f"(gc start)? The API is served by the supervisor on {D.DEFAULT_BASE_URL} "
+            "by default.\n"
+        )
+        return 2
+
+    out.write(f"title:      {probe.get('api_title')}\n")
+    out.write(
+        f"version:    {probe.get('api_version')} "
+        f"({'ok' if verdict['version_ok'] else 'MISMATCH; need ' + req_ver})\n"
+    )
+    if probe.get("build_id"):
+        out.write(f"build:      {probe.get('health_status')} ({probe.get('build_id')})\n")
+    if verdict["missing_paths"]:
+        out.write(f"endpoints:  MISSING {len(verdict['missing_paths'])} required path(s):\n")
+        for p in verdict["missing_paths"]:
+            out.write(f"  - {p}\n")
+    else:
+        out.write(f"endpoints:  all {len(req_paths)} required path(s) present\n")
+    if city_readiness is not None:
+        out.write(f"city {args.city}: {json.dumps(city_readiness)}\n")
+
+    out.write("\n" + ("COCKPIT-READY\n" if verdict["ready"] else "NOT cockpit-ready (see above)\n"))
+    return 0 if verdict["ready"] else 1
+
+
+# --------------------------------------------------------------------------- #
+# discover                                                                       #
+# --------------------------------------------------------------------------- #
+
+def cmd_discover(args: argparse.Namespace, out) -> int:
+    probe = D.probe_api(args.base_url, timeout=args.timeout)
+    if not probe["reachable"]:
+        sys.stderr.write(
+            f"cockpit discover: /v0 API unreachable at {probe['base_url']} "
+            f"({'; '.join(probe['errors']) or 'no response'}).\n"
+        )
+        return 2
+    cities = sorted({str(c) for c in (args.city or [])})
+    descriptor = D.build_descriptor(probe, cities=cities)
+
+    written = None
+    if args.write or args.out:
+        written = D.write_descriptor(descriptor, args.out)
+
+    if args.json:
+        out.write(json.dumps({"descriptor": descriptor, "written_to": written}, indent=2) + "\n")
+        return 0
+
+    out.write(json.dumps(descriptor, indent=2) + "\n")
+    if written:
+        out.write(f"\npublished -> {written}\n")
+    else:
+        out.write(f"\n(not written; pass --write to publish to {D.descriptor_path()})\n")
+    return 0
+
+
+# --------------------------------------------------------------------------- #
+# contract                                                                       #
+# --------------------------------------------------------------------------- #
+
+def cmd_contract(args: argparse.Namespace, out) -> int:
+    contract = _load_contract_or_die(args.contract)
+    if args.json:
+        out.write(json.dumps(contract, indent=2) + "\n")
+        return 0
+    disc = contract.get("discovery", {})
+    out.write(f"schema:           {contract.get('schema')}\n")
+    out.write(f"required version: {K.required_api_version(contract)}\n")
+    out.write(f"openapi:          {contract.get('api', {}).get('openapi')}\n")
+    out.write(f"descriptor:       $GC_HOME/{disc.get('descriptor_path')}\n")
+    out.write(f"default base url: {disc.get('default_base_url')}\n")
+    out.write(f"auth model:       {disc.get('auth_model')}\n")
+    req = K.required_paths(contract)
+    out.write(f"\nrequired endpoints ({len(req)}):\n")
+    for p in req:
+        out.write(f"  - {p}\n")
+    return 0
+
+
+# --------------------------------------------------------------------------- #
+# adapter                                                                        #
+# --------------------------------------------------------------------------- #
+
+def cmd_adapter(args: argparse.Namespace, out) -> int:
+    contract = _load_contract_or_die(args.contract)
+    spec = K.adapter_registration_spec(
+        contract,
+        account_id=args.account_id,
+        name=args.name,
+        callback_url=args.callback_url,
+    )
+    endpoint = K.register_path(contract).replace("{cityName}", args.city or "{cityName}")
+
+    if args.json:
+        out.write(json.dumps({"endpoint": endpoint, "method": "POST", "body": spec}, indent=2) + "\n")
+        return 0
+
+    out.write("# extmsg adapter registration spec (RUNTIME — see docs/DESIGN.md fork #2,\n")
+    out.write("# cockpit-1ll.12). extmsg registration is an in-memory API call requiring a\n")
+    out.write("# reachable callback_url; a static pack install does NOT durably register it.\n\n")
+    out.write(f"POST {endpoint}\n\n")
+    out.write(json.dumps(spec, indent=2) + "\n\n")
+    out.write("# example:\n")
+    out.write(f"curl -fsS -X POST {D.DEFAULT_BASE_URL}{endpoint} \\\n")
+    out.write("  -H 'Content-Type: application/json' -H 'X-GC-Request: true' \\\n")
+    out.write(f"  -d '{json.dumps(spec)}'\n")
+    if not args.callback_url:
+        out.write("\n# NOTE: no callback_url set — outbound delivery to the Cockpit needs one.\n")
+    return 0
+
+
+# --------------------------------------------------------------------------- #
+# argparse plumbing                                                             #
+# --------------------------------------------------------------------------- #
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="cockpit",
+        description="Make a gas city Cockpit-ready and publish the /v0 discovery handshake.",
+    )
+    p.add_argument(
+        "--contract",
+        default=None,
+        help="path to the /v0 contract toml (default: the pack's contract/v0.toml)",
+    )
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    pr = sub.add_parser("ready", help="assert the live /v0 API is reachable + version-compatible")
+    pr.add_argument("--base-url", default=D.DEFAULT_BASE_URL, help="supervisor API base URL")
+    pr.add_argument("--city", default=None, help="also fetch per-city readiness for this city")
+    pr.add_argument("--timeout", type=float, default=4.0, help="per-request timeout (s)")
+    pr.add_argument("--json", action="store_true", help="emit JSON")
+    pr.set_defaults(func=cmd_ready)
+
+    pd = sub.add_parser("discover", help="probe the API and (with --write) publish the descriptor")
+    pd.add_argument("--base-url", default=D.DEFAULT_BASE_URL, help="supervisor API base URL")
+    pd.add_argument(
+        "--city",
+        action="append",
+        metavar="NAME",
+        help="record this city in the descriptor (repeatable)",
+    )
+    pd.add_argument("--write", action="store_true", help="publish to the well-known descriptor path")
+    pd.add_argument("--out", default=None, help="write the descriptor to FILE instead")
+    pd.add_argument("--timeout", type=float, default=4.0, help="per-request timeout (s)")
+    pd.add_argument("--json", action="store_true", help="emit JSON")
+    pd.set_defaults(func=cmd_discover)
+
+    pc = sub.add_parser("contract", help="print the /v0 API contract the extension pins")
+    pc.add_argument("--json", action="store_true", help="emit JSON")
+    pc.set_defaults(func=cmd_contract)
+
+    pa = sub.add_parser("adapter", help="print the extmsg adapter registration spec (runtime)")
+    pa.add_argument("--city", default=None, help="fill {cityName} in the endpoint")
+    pa.add_argument("--account-id", default="default", help="adapter account id")
+    pa.add_argument("--name", default="VS Code Cockpit", help="adapter display name")
+    pa.add_argument("--callback-url", default=None, help="adapter outbound callback URL")
+    pa.add_argument("--json", action="store_true", help="emit JSON")
+    pa.set_defaults(func=cmd_adapter)
+
+    return p
+
+
+def main(argv: Optional[Sequence[str]] = None, out=None) -> int:
+    out = out if out is not None else sys.stdout
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return int(args.func(args, out))
+    except SystemExit as e:  # raised by _load_contract_or_die
+        return int(e.code) if e.code is not None else 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/cockpit/cockpit/contract.py
+++ b/cockpit/cockpit/contract.py
@@ -1,0 +1,116 @@
+"""Load and query the GasCity Cockpit ``/v0`` API contract.
+
+``contract/v0.toml`` is the single, machine-readable declaration of what the
+Cockpit extension depends on from the supervisor's ``/v0`` API:
+
+- the pinned API version (``[api] required_version``) — the ``/v0`` surface is a
+  moving dev build, so the extension pins a version and ``cockpit ready`` asserts
+  the live ``info.version`` matches;
+- the required-endpoint gate (``[endpoints] required``) — paths whose presence in
+  ``/openapi.json`` ``cockpit ready`` checks before declaring a city Cockpit-ready;
+- the extmsg adapter spec (``[extmsg]``) — the provider id + capabilities the
+  Cockpit registers as (see :func:`adapter_registration_spec`).
+
+Pure stdlib: TOML via ``tomllib`` (Python >= 3.11) with a ``tomli`` fallback.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Optional
+
+try:  # Python >= 3.11
+    import tomllib  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - exercised only on < 3.11
+    import tomli as tomllib  # type: ignore
+
+CONTRACT_SCHEMA = "cockpit.v0"
+
+# Fallbacks used only if the contract file omits a field; the shipped
+# contract/v0.toml is authoritative.
+DEFAULT_REQUIRED_API_VERSION = "0.1.0"
+ADAPTER_PROVIDER = "cockpit"
+
+
+class ContractError(Exception):
+    """Raised when the contract file is missing, unparseable, or malformed."""
+
+
+def default_contract_path() -> str:
+    """Path to the pack's shipped ``contract/v0.toml``."""
+    here = os.path.dirname(os.path.abspath(__file__))
+    return os.path.join(os.path.dirname(here), "contract", "v0.toml")
+
+
+def load_contract(path: Optional[str] = None) -> dict[str, Any]:
+    """Load and validate the contract TOML into a dict."""
+    p = path or default_contract_path()
+    try:
+        with open(p, "rb") as fh:
+            data = tomllib.load(fh)
+    except FileNotFoundError as e:
+        raise ContractError(f"contract not found: {p}") from e
+    except (OSError, tomllib.TOMLDecodeError) as e:
+        raise ContractError(f"cannot read contract {p}: {e}") from e
+
+    schema = data.get("schema")
+    if schema != CONTRACT_SCHEMA:
+        raise ContractError(
+            f"contract schema mismatch: expected {CONTRACT_SCHEMA!r}, got {schema!r}"
+        )
+    if "required_version" not in data.get("api", {}):
+        raise ContractError("contract missing [api] required_version")
+    return data
+
+
+def required_api_version(contract: dict[str, Any]) -> str:
+    return str(
+        contract.get("api", {}).get("required_version", DEFAULT_REQUIRED_API_VERSION)
+    )
+
+
+def required_paths(contract: dict[str, Any]) -> list[str]:
+    """The endpoint path templates the readiness gate asserts must exist."""
+    return [str(x) for x in contract.get("endpoints", {}).get("required", [])]
+
+
+def register_path(contract: dict[str, Any]) -> str:
+    """The extmsg adapter-registration endpoint template (POST target)."""
+    return str(
+        contract.get("extmsg", {}).get(
+            "register_path", "/v0/city/{cityName}/extmsg/adapters"
+        )
+    )
+
+
+def adapter_registration_spec(
+    contract: dict[str, Any],
+    *,
+    account_id: str = "default",
+    name: str = "VS Code Cockpit",
+    callback_url: Optional[str] = None,
+) -> dict[str, Any]:
+    """Build the POST body for ``/v0/city/{cityName}/extmsg/adapters``.
+
+    This is the *spec* the host (cockpit-1ll.12) submits at RUNTIME — extmsg
+    registration is an in-memory, ephemeral API call requiring a reachable
+    ``callback_url``, not something a static pack install can durably do. See
+    ``docs/DESIGN.md`` fork #2. Field casing mirrors the live
+    ``ExtMsgAdapterRegisterInputBody`` / ``AdapterCapabilities`` schema.
+    """
+    ext = contract.get("extmsg", {})
+    body: dict[str, Any] = {
+        "provider": str(ext.get("adapter_provider", ADAPTER_PROVIDER)),
+        "account_id": account_id,
+        "name": name,
+        "capabilities": {
+            "SupportsChildConversations": bool(
+                ext.get("supports_child_conversations", True)
+            ),
+            "SupportsAttachments": bool(ext.get("supports_attachments", False)),
+            "MaxMessageLength": int(ext.get("max_message_length", 0)),
+        },
+    }
+    if callback_url:
+        body["callback_url"] = callback_url
+    return body

--- a/cockpit/cockpit/discovery.py
+++ b/cockpit/cockpit/discovery.py
@@ -1,0 +1,174 @@
+"""Probe the live ``/v0`` API, assess Cockpit-readiness, and publish the
+discovery descriptor the VS Code extension auto-discovers.
+
+The discovery handshake (PRD decision #4): a small JSON descriptor — API base
+URL + version + auth model — published at a well-known runtime path under
+``GC_HOME`` so the extension finds the supervisor API without lsof/guessing.
+
+NOTE (``docs/DESIGN.md`` fork #3): the *clean* implementation writes this
+descriptor from the supervisor itself at listener-bind time. Until that lands
+upstream, this module lets the pack/operator publish it via
+``cockpit discover --write``.
+
+Pure stdlib: ``urllib.request`` for the probe, ``json`` for the descriptor.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+DEFAULT_BASE_URL = "http://127.0.0.1:8372"
+DESCRIPTOR_RELPATH = os.path.join("runtime", "cockpit", "api-descriptor.json")
+DESCRIPTOR_KIND = "gascity-cockpit-api-descriptor"
+DESCRIPTOR_SCHEMA_VERSION = 1
+
+# Errors that mean "the API did not answer cleanly" — never raised to the caller;
+# folded into the probe's ``errors`` list instead.
+_PROBE_ERRORS = (urllib.error.URLError, OSError, ValueError, TimeoutError)
+
+
+def gc_home() -> str:
+    """The gascity runtime root: ``$GC_HOME``, else ``~/.gc``."""
+    return os.environ.get("GC_HOME") or os.path.expanduser(os.path.join("~", ".gc"))
+
+
+def descriptor_path(home: Optional[str] = None) -> str:
+    """Well-known path the discovery descriptor is published to."""
+    return os.path.join(home or gc_home(), DESCRIPTOR_RELPATH)
+
+
+def _http_get_json(url: str, timeout: float) -> Any:
+    """GET a URL and parse JSON. Indirection point monkeypatched in tests."""
+    req = urllib.request.Request(url, headers={"Accept": "application/json"})
+    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 (localhost)
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def probe_api(base_url: str = DEFAULT_BASE_URL, timeout: float = 4.0) -> dict[str, Any]:
+    """Probe the supervisor ``/v0`` API for version, paths, and health.
+
+    Reachability is defined by a successful ``/openapi.json`` fetch (the codegen
+    source of truth). ``/health`` is best-effort and never gates reachability.
+    """
+    base = base_url.rstrip("/")
+    result: dict[str, Any] = {
+        "base_url": base,
+        "reachable": False,
+        "api_version": None,
+        "api_title": None,
+        "paths": [],
+        "health_status": None,
+        "build_id": None,
+        "errors": [],
+    }
+    try:
+        spec = _http_get_json(base + "/openapi.json", timeout)
+    except _PROBE_ERRORS as e:
+        result["errors"].append(f"openapi: {e}")
+        return result
+
+    result["reachable"] = True
+    info = spec.get("info", {}) if isinstance(spec, dict) else {}
+    result["api_version"] = info.get("version")
+    result["api_title"] = info.get("title")
+    paths = spec.get("paths", {}) if isinstance(spec, dict) else {}
+    result["paths"] = sorted(paths.keys())
+
+    try:
+        health = _http_get_json(base + "/health", timeout)
+        if isinstance(health, dict):
+            result["health_status"] = health.get("status")
+            result["build_id"] = health.get("build_id")
+    except _PROBE_ERRORS as e:
+        result["errors"].append(f"health: {e}")
+    return result
+
+
+def fetch_city_readiness(base_url: str, city: str, timeout: float = 4.0) -> dict[str, Any]:
+    """Best-effort per-city readiness; returns ``{"error": ...}`` on failure."""
+    url = base_url.rstrip("/") + f"/v0/city/{city}/readiness"
+    try:
+        data = _http_get_json(url, timeout)
+        return data if isinstance(data, dict) else {"value": data}
+    except _PROBE_ERRORS as e:
+        return {"error": str(e)}
+
+
+def assess_readiness(
+    probe: dict[str, Any], required_version: str, required_paths: list[str]
+) -> dict[str, Any]:
+    """Compare a probe result to the contract: version + required endpoints."""
+    reachable = bool(probe.get("reachable"))
+    version_ok = reachable and probe.get("api_version") == required_version
+    have = set(probe.get("paths") or [])
+    missing = (
+        [p for p in required_paths if p not in have] if reachable else list(required_paths)
+    )
+    ready = reachable and version_ok and not missing
+    return {
+        "ready": ready,
+        "reachable": reachable,
+        "version_ok": version_ok,
+        "found_version": probe.get("api_version"),
+        "required_version": required_version,
+        "missing_paths": missing,
+    }
+
+
+def build_descriptor(
+    probe: dict[str, Any],
+    *,
+    cities: Optional[list[str]] = None,
+    home: Optional[str] = None,
+    now: Optional[datetime] = None,
+) -> dict[str, Any]:
+    """Build the discovery descriptor from a probe result."""
+    home = home or gc_home()
+    ts = (now or datetime.now(timezone.utc)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    token_file = os.path.join(home, "controller.token")
+    return {
+        "schema_version": DESCRIPTOR_SCHEMA_VERSION,
+        "kind": DESCRIPTOR_KIND,
+        "base_url": probe.get("base_url"),
+        "api_version": probe.get("api_version"),
+        "api_title": probe.get("api_title"),
+        # v1 is localhost-trust (PRD decision #5): the /v0 API does not enforce a
+        # bearer token today. controller.token is referenced as the local
+        # capability token so a future remote/auth story is additive, not a
+        # rewrite. See docs/DESIGN.md.
+        "auth": {
+            "type": "localhost-trust",
+            "token_file": token_file if os.path.exists(token_file) else None,
+        },
+        "cities": cities or [],
+        "discovered_at": ts,
+        "source": "cockpit discover (pack-side probe)",
+    }
+
+
+def write_descriptor(descriptor: dict[str, Any], path: Optional[str] = None) -> str:
+    """Atomically write the descriptor, creating parent dirs. Returns the path."""
+    p = path or descriptor_path()
+    parent = os.path.dirname(p)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+    tmp = p + ".tmp"
+    with open(tmp, "w") as fh:
+        fh.write(json.dumps(descriptor, indent=2) + "\n")
+    os.replace(tmp, p)
+    return p
+
+
+def read_descriptor(path: Optional[str] = None) -> Optional[dict[str, Any]]:
+    """Read a previously published descriptor, or ``None`` if absent/unreadable."""
+    p = path or descriptor_path()
+    try:
+        with open(p) as fh:
+            return json.load(fh)
+    except (FileNotFoundError, ValueError, OSError):
+        return None

--- a/cockpit/contract/v0.toml
+++ b/cockpit/contract/v0.toml
@@ -1,0 +1,118 @@
+# GasCity Cockpit — the /v0 API contract the extension depends on.
+#
+# Machine-readable, consumed by the `cockpit` CLI (`cockpit ready` / `contract`)
+# and by the VS Code extension. The expensive surface already exists: the
+# supervisor's versioned, self-documenting /v0 HTTP API (`/openapi.json`). This
+# file PINS the version and names the endpoints the Cockpit relies on, so a city
+# can be asserted Cockpit-ready and version drift is caught early.
+#
+# Endpoint paths below are the exact templates served by the live API
+# (confirmed against /openapi.json). The extension generates its typed client
+# from /openapi.json — this contract is the compatibility gate, not the client.
+
+schema = "cockpit.v0"
+
+[api]
+title            = "Gas City Supervisor API"
+required_version = "0.1.0"
+openapi          = "/openapi.json"
+# The /v0 surface is a MOVING dev build. `cockpit ready` asserts the live
+# info.version == required_version; bump this in lockstep with the extension.
+
+[discovery]
+# Discovery descriptor (PRD decision #4): published under GC_HOME so the
+# extension auto-finds the API without lsof/guessing. See docs/DESIGN.md fork #3.
+descriptor_path  = "runtime/cockpit/api-descriptor.json"   # relative to $GC_HOME (default ~/.gc)
+default_base_url = "http://127.0.0.1:8372"
+auth_model       = "localhost-trust"                       # v1; PRD decision #5
+
+[extmsg]
+# The Cockpit registers as an extmsg adapter at RUNTIME (cockpit-1ll.12); see
+# docs/DESIGN.md fork #2. Field casing mirrors the live ExtMsgAdapterRegisterInputBody.
+adapter_provider             = "cockpit"
+register_path                = "/v0/city/{cityName}/extmsg/adapters"   # POST
+supports_child_conversations = true
+supports_attachments         = false
+max_message_length           = 0   # 0 = unbounded
+
+# Required endpoints: `cockpit ready` asserts each is present in /openapi.json
+# before declaring a city Cockpit-ready. Kept to the load-bearing subset (health,
+# beads, chat submit/stream, approvals, events, extmsg) — the full capability map
+# is below for the extension.
+[endpoints]
+required = [
+  "/health",
+  "/v0/cities",
+  "/v0/readiness",
+  "/v0/city/{cityName}/health",
+  "/v0/city/{cityName}/beads",
+  "/v0/city/{cityName}/pending",
+  "/v0/city/{cityName}/events/stream",
+  "/v0/city/{cityName}/session/{id}/submit",
+  "/v0/city/{cityName}/session/{id}/stream",
+  "/v0/city/{cityName}/extmsg/adapters",
+]
+
+# Capability map (documentation for the extension; not part of the readiness
+# gate). Grouped by PRD user-story area; every path confirmed present in the
+# live /openapi.json.
+[endpoints.capabilities]
+health    = [
+  "/health",
+  "/v0/readiness",
+  "/v0/city/{cityName}/health",
+  "/v0/city/{cityName}/readiness",
+]
+cities    = ["/v0/cities"]
+beads     = [
+  "/v0/city/{cityName}/beads",
+  "/v0/city/{cityName}/beads/ready",
+  "/v0/city/{cityName}/beads/graph/{rootID}",
+  "/v0/city/{cityName}/bead/{id}",
+  "/v0/city/{cityName}/bead/{id}/update",
+  "/v0/city/{cityName}/bead/{id}/close",
+  "/v0/city/{cityName}/bead/{id}/reopen",
+  "/v0/city/{cityName}/bead/{id}/assign",
+  "/v0/city/{cityName}/bead/{id}/deps",
+  "/v0/city/{cityName}/sling",
+]
+agents    = [
+  "/v0/city/{cityName}/agents",
+  "/v0/city/{cityName}/agent/{base}",
+  "/v0/city/{cityName}/agent/{base}/output/stream",
+]
+sessions  = [
+  "/v0/city/{cityName}/sessions",
+  "/v0/city/{cityName}/session/{id}",
+  "/v0/city/{cityName}/session/{id}/submit",
+  "/v0/city/{cityName}/session/{id}/stream",
+  "/v0/city/{cityName}/session/{id}/transcript",
+  "/v0/city/{cityName}/session/{id}/respond",
+  "/v0/city/{cityName}/session/{id}/permission-mode",
+  "/v0/city/{cityName}/session/{id}/pending",
+  "/v0/city/{cityName}/session/{id}/stop",
+  "/v0/city/{cityName}/session/{id}/wake",
+]
+approvals = [
+  "/v0/city/{cityName}/pending",
+  "/v0/city/{cityName}/session/{id}/pending",
+  "/v0/city/{cityName}/session/{id}/respond",
+]
+events    = [
+  "/v0/events/stream",
+  "/v0/city/{cityName}/events",
+  "/v0/city/{cityName}/events/stream",
+]
+code      = [
+  "/v0/city/{cityName}/patches/agents",
+  "/v0/city/{cityName}/patches/agent/{base}",
+]
+extmsg    = [
+  "/v0/city/{cityName}/extmsg/adapters",
+  "/v0/city/{cityName}/extmsg/bind",
+  "/v0/city/{cityName}/extmsg/bindings",
+  "/v0/city/{cityName}/extmsg/inbound",
+  "/v0/city/{cityName}/extmsg/outbound",
+  "/v0/city/{cityName}/extmsg/participants",
+  "/v0/city/{cityName}/extmsg/transcript",
+]

--- a/cockpit/docs/DESIGN.md
+++ b/cockpit/docs/DESIGN.md
@@ -1,0 +1,204 @@
+# cockpit pack — design & open scope forks
+
+> Implements the city-side half of the **GasCity Cockpit** (epic `cockpit-1ll`),
+> per the PROPOSED decisions #3 / #4 / #5 in `cockpit-1ll.3`. Those decisions are
+> **proposed, pending operator ratification**; the dispatch note asked to *flag
+> major forks before hard-coding pack scope*. This document is that flag. Read
+> §4 ("Open scope forks") before extending the pack.
+
+## 1. What this pack is
+
+The GasCity Cockpit is **two artifacts, one product**: a VS Code extension (the
+client) and this thin `cockpit` pack (the city-side contract). The expensive part
+already exists — the supervisor's versioned, self-documenting `/v0` HTTP API
+(`/openapi.json`, SSE, the full session/chat/approval surface). The extension is a
+pure client of that API. This pack **adds no backend**. It does four things:
+
+1. **Asserts Cockpit-readiness** — `cockpit ready` verifies the live `/v0` API is
+   reachable, version-compatible, and exposes the endpoints the Cockpit needs.
+2. **Publishes the discovery handshake** — `cockpit discover --write` writes a
+   descriptor (API base URL + version + auth model + cities) to a well-known path
+   the extension reads to auto-find the API.
+3. **Declares the `/v0` contract** — `contract/v0.toml` pins the required API
+   version and names the endpoints the extension depends on; `cockpit contract`
+   prints it. The extension generates its typed client from `/openapi.json`; this
+   contract is the *compatibility gate*.
+4. **Ships Mayor IDE-affordance skills** — `cockpit-readiness` and
+   `mayor-ide-affordances` (convention-discovered under `skills/`).
+
+It is pure-stdlib (tomllib + urllib), mirroring `provider-forge`'s minimal
+footprint: no overlay, no hooks, no prompt fragments — just a CLI, a contract, and
+two skills.
+
+## 2. What makes a city "Cockpit-ready"
+
+A city is Cockpit-ready when, against the running supervisor:
+
+- the `/v0` API answers (`/openapi.json` fetch succeeds);
+- `info.version` equals `[api] required_version` in the contract (currently
+  `0.1.0`); and
+- every path in `[endpoints] required` is present in `/openapi.json`.
+
+`cockpit ready` returns **0** ready, **1** reachable-but-incompatible, **2**
+unreachable — CI-usable. The required set is the load-bearing subset (health,
+beads, chat submit/stream, approvals/pending, events, extmsg); the full capability
+map (`[endpoints.capabilities]`) documents the rest for the extension.
+
+## 3. The discovery handshake
+
+`cockpit discover --write` publishes JSON to a **well-known runtime path**:
+
+```
+$GC_HOME/runtime/cockpit/api-descriptor.json
+```
+
+Descriptor shape (`schema_version = 1`):
+
+```json
+{
+  "schema_version": 1,
+  "kind": "gascity-cockpit-api-descriptor",
+  "base_url": "http://127.0.0.1:8372",
+  "api_version": "0.1.0",
+  "api_title": "Gas City Supervisor API",
+  "auth": { "type": "localhost-trust", "token_file": "<GC_HOME>/controller.token" },
+  "cities": ["blackrim-hq"],
+  "discovered_at": "2026-06-05T06:55:52Z",
+  "source": "cockpit discover (pack-side probe)"
+}
+```
+
+**Two `.gc` roots — read carefully.** The `/v0` API is **supervisor-wide** (one
+process serves every city on `:8372`). So the descriptor is supervisor-scoped and
+lives under the **supervisor** home, `$GC_HOME` (default `~/.gc`) — *not* a city's
+`.gc`. In this town, for example, `GC_HOME=~/.gc` (supervisor home) while the
+`blackrim-hq` city's runtime is at `/Users/jayse/Code/.gc`. The descriptor's
+`cities[]` lists every city the one API serves. The extension reads this single
+descriptor, with a settings override allowed.
+
+**Resilience.** API availability is transient: `gc stop` takes it down, `gc start`
+brings it back (possibly on a new build). The extension must treat the descriptor
+as a hint, reconnect with backoff, and show an explicit "API unavailable" state.
+Re-run `cockpit discover --write` after a restart to refresh it. (Ideally the
+supervisor refreshes the descriptor itself — see fork #3.)
+
+**Auth (PRD decision #5).** v1 is **localhost-trust**: the `/v0` API does *not*
+enforce a bearer token today; reaching `127.0.0.1:8372` *is* the authorization.
+The descriptor records `auth.type = "localhost-trust"` and references
+`controller.token` so a future remote/auth story is *additive* (design the boundary
+now, build remote later). No remote in v1.
+
+## 4. Open scope forks  ⚠️  (flag before hard-coding)
+
+The PROPOSED pack scope says the pack should "enable the API service, register the
+Cockpit extmsg adapter, write the discovery handshake." Investigating how gascity
+actually works surfaced three places where the proposed wording does **not** map
+cleanly onto a static pack. This pack ships the honest groundwork and flags each
+fork rather than hard-coding around it. Each needs an operator/Mayor decision.
+
+### Fork #1 — "Enable the API service" — there is nothing to enable
+
+**Reality.** The `/v0` API is served by the **supervisor** and is **always-on**
+when the supervisor runs (`cmd_supervisor.go` starts the listener unconditionally;
+bind/port come from `~/.gc/supervisor.toml` `[supervisor]`, default
+`127.0.0.1:8372`). There is **no per-city or per-pack "enable the API" toggle**.
+The legacy per-city `[api]` block is disabled-by-default and deprecated; the
+supervisor serves all cities at `/v0/city/{cityName}/...`.
+
+**What this pack does instead.** Treats "enable" as **assert + verify**:
+`cockpit ready` confirms the always-on API is reachable and compatible. It does not
+fabricate a switch that doesn't exist.
+
+**Recommended ratification.** Reword the deliverable from "enable the API service"
+to "**assert the API service is up and `/v0`-compatible**." If an opt-in/opt-out of
+the API per city is genuinely wanted, that's a **gastown** feature request (supervisor
+config), filed upstream — not built here.
+
+### Fork #2 — "Register the Cockpit extmsg adapter" — it's a runtime call, and it's `cockpit-1ll.12`
+
+**Reality.** extmsg adapter registration is `POST /v0/city/{cityName}/extmsg/adapters`
+with `{provider, account_id, name, callback_url, capabilities}`. The registry is
+**in-memory and ephemeral** (lost on controller restart), and an adapter needs a
+**reachable `callback_url`** for outbound delivery — i.e. a *running HTTP service*.
+The Cockpit is a VS Code extension (a client), not a server. So a static pack
+`install.sh` **cannot durably register** the adapter. Moreover, extmsg participant
+integration is its own downstream bead — **`cockpit-1ll.12`**, which `cockpit-1ll.14`
+*blocks*.
+
+**What this pack does instead.** Ships the **adapter contract + spec**, not a
+half-working registration:
+- `contract/v0.toml` `[extmsg]` declares the provider id (`cockpit`) + capabilities;
+- `cockpit adapter [--city] [--callback-url] [--json]` prints the exact endpoint and
+  POST body the host will submit at runtime — clearly marked RUNTIME / `cockpit-1ll.12`.
+It deliberately does **not** perform a register that would be ephemeral and
+callback-less.
+
+**Recommended ratification.** Keep durable registration in **`cockpit-1ll.12`**,
+where the extension/host owns the callback service and re-registers on connect. If a
+**declarative / persistent** adapter registration is wanted (so a pack *can* declare
+an adapter that survives restart), that is a **gastown** ask — file it; do not
+simulate persistence from the pack.
+
+### Fork #3 — "Write the discovery handshake" — best owned by the supervisor
+
+**Reality.** Nothing on disk advertises the API address today; the clean place to
+write the descriptor is the **supervisor**, at listener-bind time (it knows the
+bound address, and can remove the file on shutdown — exactly how it manages
+`supervisor.sock`). A pack/CLI can only *probe-and-write after the fact*, which is
+inherently staler and racier across restarts.
+
+**What this pack does instead.** Provides `cockpit discover --write` so the
+descriptor exists now (closing the no-api-addr-file gap), and defines the descriptor
+**path + schema** as the contract. This is the pragmatic v1.
+
+**Recommended ratification.** Adopt the pack-side descriptor as the v1 contract, and
+file a **gastown** ask to have the **supervisor write/remove this exact descriptor**
+at bind/shutdown (same path + schema), so discovery becomes self-maintaining and
+the pack's `discover --write` becomes a fallback. The PRD's out-of-scope note
+explicitly allows the discovery handshake (and extmsg registration) to touch
+gastown; everything else found is *filed against gastown, not built here*.
+
+## 5. Relationship to sibling beads
+
+- `cockpit-1ll`   — the epic / PRD (canonical).
+- `cockpit-1ll.3` — the 7 design decisions (PROPOSED). This pack implements the
+  pack-relevant halves of #3 (pack + delivery), #4 (discovery + resilience), #5
+  (identity/auth boundary).
+- `cockpit-1ll.12` — extmsg participant integration (Phase 3), **blocked by**
+  `cockpit-1ll.14`. Fork #2's durable adapter registration belongs here.
+- `cockpit-1ll.4` — transcript-fidelity spike (GREEN); gates decision #6 (chat
+  content fidelity), which the `mayor-ide-affordances` skill assumes.
+
+## 6. Deployment
+
+This rig (`gascity-cockpit`) owns the source for **both** artifacts: the extension
+(future) and this pack (`pack/`). The existing town packs (`model-advisor`,
+`provider-forge`, `ast-lens`) are each vendored at `<city>/packs/<name>/` and
+imported via a direct `source = "packs/<name>"` entry. To deploy this pack, **vendor
+`pack/` into the target city as `packs/cockpit/`** (copy/clone) and run
+`packs/cockpit/install.sh --town` (or `--rig <name>`). `install.sh` records the
+import relative to the city root when the pack lives under it, else absolute.
+
+> **Minor structural fork.** This is a mono-repo (extension + pack in one rig),
+> unlike the one-repo-per-pack model of the existing three. If the town's tooling
+> assumes a pack repo *is* the pack root, we either (a) vendor only `pack/` into
+> `packs/cockpit/`, or (b) split the pack into its own repo later. (a) is the v1
+> path and needs no upstream change.
+
+## 7. Testing
+
+Per the PRD's testing decisions, the testable seam is the typed-client/contract
+layer, not the VS-Code glue. Tests (`tests/`, pytest, pure stdlib) cover:
+
+- **contract** — the shipped `contract/v0.toml` loads, pins `0.1.0`, declares the
+  load-bearing endpoints, and yields a well-formed adapter spec; malformed
+  contracts fail loudly.
+- **discovery** — `probe_api` (hermetic, monkeypatched HTTP) for reachable /
+  unreachable / health-non-fatal; `assess_readiness` for version + missing-path
+  verdicts; descriptor round-trips on disk and honors `GC_HOME`.
+- **cli** — `ready` exit-code state machine (0/1/2), `discover` write, `contract`
+  and `adapter` text+JSON.
+
+A thin **live-contract** check (mirroring gascity's
+`test/integration/*_live_contract_test.go`) is `cockpit ready` itself run against a
+throwaway test city — it fails if the `/v0` shapes the Cockpit depends on drift.

--- a/cockpit/install.sh
+++ b/cockpit/install.sh
@@ -1,0 +1,321 @@
+#!/usr/bin/env bash
+# cockpit — install lifecycle (reversible, idempotent).
+#
+#   install.sh (--town | --rig <name>) [--dry-run] [--city <path>] [--no-reload]
+#
+# Turns the cockpit pack ON at one of two scopes:
+#   --town        city-wide: the pack's bin/cockpit + skills + contract become
+#                 available to the whole city.
+#   --rig <name>  one rig only: scoped to that rig's [[rigs]] entry.
+#
+# What it does (in order):
+#   1. Build the engine venv via setup.sh (skipped if .venv already present;
+#      optional — bin/cockpit also runs under any system python3).
+#   2. Add the pack import to the correct config scope. A LOCAL in-tree pack is
+#      imported via a DIRECT config entry (the gastown pattern) — NOT via
+#      `gc import add`, which targets remote/git-backed packs and mis-resolves a
+#      local file:// source. So a surgical, backed-up edit writes:
+#        --town       ->  <city>/pack.toml   [imports.cockpit]
+#        --rig <name> ->  <city>/city.toml   [rigs.imports.cockpit] (under the
+#                         [[rigs]] entry whose name matches <name>)
+#      source is recorded relative to the city root (e.g. "packs/cockpit").
+#   3. Trigger re-projection with `gc reload` so the pack's bin/skills surface.
+#   4. Verify: `gc lint`, the import is registered, and a `cockpit ready` smoke.
+#
+# Like provider-forge, cockpit ships NO prompt fragment and NO overlay hook — it
+# is a CLI + contract + skills — so there is no append_fragments edit and no
+# projected-settings hook to materialize. The install is: venv + import + reload
+# + verify.
+#
+# This pack lives in the gascity-cockpit RIG and is meant to be VENDORED into a
+# city as packs/cockpit (see docs/DESIGN.md §6). Run with --city <city-root> if
+# the pack is not already under the target city.
+#
+# Idempotent: re-running is a no-op (each mutating step is guarded by a presence
+# check). Any config file it edits is backed up first. --dry-run prints the plan
+# and changes nothing. Fails loudly on unexpected state.
+#
+# Reverse with uninstall.sh (same scope flags).
+
+set -euo pipefail
+
+# Stripped-PATH guard (this environment sometimes ships a minimal PATH).
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${HOME}/go/bin:${HOME}/.local/bin:${PATH}"
+
+PACK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PACK_NAME="cockpit"     # import binding name
+IMPORT_NAME="cockpit"
+
+# ---- arg parsing -----------------------------------------------------------
+SCOPE=""          # "town" | "rig"
+RIG=""
+DRY_RUN=0
+NO_RELOAD=0
+CITY=""
+
+die()  { printf 'install.sh: error: %s\n' "$*" >&2; exit 1; }
+info() { printf '  %s\n' "$*"; }
+step() { printf '\n==> %s\n' "$*"; }
+run()  { # echo + execute, or just echo under --dry-run
+  if [ "$DRY_RUN" -eq 1 ]; then printf '    [dry-run] %s\n' "$*"; else printf '    + %s\n' "$*"; eval "$@"; fi
+}
+
+usage() {
+  sed -n '2,33p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+  exit "${1:-0}"
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --town)      SCOPE="town"; shift ;;
+    --rig)       SCOPE="rig"; RIG="${2:-}"; [ -n "$RIG" ] || die "--rig requires a rig name"; shift 2 ;;
+    --rig=*)     SCOPE="rig"; RIG="${1#*=}"; shift ;;
+    --dry-run)   DRY_RUN=1; shift ;;
+    --no-reload) NO_RELOAD=1; shift ;;
+    --city)      CITY="${2:-}"; [ -n "$CITY" ] || die "--city requires a path"; shift 2 ;;
+    --city=*)    CITY="${1#*=}"; shift ;;
+    -h|--help)   usage 0 ;;
+    *)           die "unknown argument: $1 (try --help)" ;;
+  esac
+done
+
+[ -n "$SCOPE" ] || die "choose a scope: --town or --rig <name>"
+
+# ---- locate the city -------------------------------------------------------
+# Default: the city that physically contains this pack (…/<city>/packs/cockpit).
+# When the pack is still in its source rig (gascity-cockpit/pack), pass --city.
+if [ -z "$CITY" ]; then
+  CITY="$(cd "$PACK_DIR/../.." && pwd)"
+fi
+[ -f "$CITY/city.toml" ] || die "no city.toml at city root: $CITY (pass --city <path>; if the pack is in its source rig, vendor it into <city>/packs/cockpit first — see docs/DESIGN.md §6)"
+CITY="$(cd "$CITY" && pwd)"
+
+# Source path recorded in the import: relative to the city root if the pack lives
+# under it (a bare relative path with no "./" prefix, e.g. "packs/cockpit"),
+# else absolute.
+if [ "${PACK_DIR#"$CITY"/}" != "$PACK_DIR" ]; then
+  PACK_SRC="${PACK_DIR#"$CITY"/}"
+else
+  PACK_SRC="$PACK_DIR"
+fi
+
+GC=(gc --city "$CITY")
+
+step "cockpit install"
+info "scope:     $SCOPE${RIG:+ ($RIG)}"
+info "pack:      $PACK_DIR"
+info "city:      $CITY"
+info "import as: $IMPORT_NAME  (source: $PACK_SRC)"
+[ "$DRY_RUN" -eq 1 ] && info "MODE:      DRY RUN (no changes will be made)"
+
+command -v gc >/dev/null 2>&1 || die "gc not found on PATH"
+
+# For --rig, fail loudly now if the rig isn't configured, before any other step.
+if [ "$SCOPE" = "rig" ]; then
+  if ! "${GC[@]}" import list --rig "$RIG" >/dev/null 2>&1; then
+    die "rig \"$RIG\" not found in $CITY/city.toml (configure the rig first)"
+  fi
+fi
+
+# ---- helpers ---------------------------------------------------------------
+backup_file() { # back up $1 once per run to <file>.cockpit.bak.<ts>
+  local f="$1"
+  [ -f "$f" ] || return 0
+  local b="${f}.cockpit.bak.$(date +%Y%m%d%H%M%S)"
+  if [ "$DRY_RUN" -eq 1 ]; then printf '    [dry-run] backup %s -> %s\n' "$f" "$b"; return 0; fi
+  cp -p "$f" "$b"; printf '    backup: %s\n' "$b"
+}
+
+import_present() { # 0 if IMPORT_NAME is registered at the active scope.
+  if [ "$SCOPE" = "rig" ]; then
+    if "${GC[@]}" import list --rig "$RIG" 2>/dev/null | awk '{print $1}' | grep -qx "$IMPORT_NAME"; then
+      return 0
+    fi
+    rig_import_in_config "$RIG"
+  else
+    if "${GC[@]}" import list 2>/dev/null | awk '{print $1}' | grep -qx "$IMPORT_NAME"; then
+      return 0
+    fi
+    grep -Eq "^\[imports\.${IMPORT_NAME}\][[:space:]]*$" "$CITY/pack.toml" 2>/dev/null
+  fi
+}
+
+rig_import_in_config() { # 0 if [rigs.imports.IMPORT_NAME] exists under rig $1
+  python3 - "$CITY/city.toml" "$1" "$IMPORT_NAME" <<'PY'
+import sys, re
+path, rig, name = sys.argv[1], sys.argv[2], sys.argv[3]
+lines = open(path).read().splitlines(keepends=True)
+starts = [i for i, l in enumerate(lines) if re.match(r'^\[\[rigs\]\]\s*$', l)]
+for k, s in enumerate(starts):
+    end = starts[k + 1] if k + 1 < len(starts) else len(lines)
+    for j in range(s + 1, end):
+        if re.match(r'^\[', lines[j]) and not re.match(r'^\[(\[rigs\]\]|rigs(\.|\]))', lines[j]):
+            end = j; break
+    named = None
+    for j in range(s + 1, end):
+        m = re.match(r'^\s*name\s*=\s*["\'](.+?)["\']\s*$', lines[j])
+        if m:
+            named = m.group(1); break
+    if named != rig:
+        continue
+    hdr = re.compile(r'^\[rigs\.imports\.%s\]\s*$' % re.escape(name))
+    if any(hdr.match(lines[j]) for j in range(s + 1, end)):
+        sys.exit(0)
+    sys.exit(1)
+sys.exit(1)
+PY
+}
+
+edit_import() { # add|remove a DIRECT-config import (gastown style); idempotent.
+  # args: <action> <file> <import_name> <source> [<rig_name>]
+  python3 - "$2" "$1" "$3" "$4" "${5:-}" <<'PY'
+import sys, re
+path, action, name, source, rig = sys.argv[1:6]
+rig = rig or None
+
+def fail(msg):
+    sys.stderr.write("edit_import: %s\n" % msg); sys.exit(3)
+
+lines = open(path).read().splitlines(keepends=True)
+
+if rig is None:
+    table = "imports"
+    anchor = next((i for i, l in enumerate(lines) if re.match(r'^\[imports\]\s*$', l)), None)
+    if anchor is None: fail("[imports] table not found in %s" % path)
+    hi = len(lines)
+else:
+    table = "rigs.imports"
+    starts = [i for i, l in enumerate(lines) if re.match(r'^\[\[rigs\]\]\s*$', l)]
+    if not starts: fail("no [[rigs]] blocks in %s" % path)
+    target_start = None; hi = len(lines)
+    for k, s in enumerate(starts):
+        end = starts[k + 1] if k + 1 < len(starts) else len(lines)
+        for j in range(s + 1, end):
+            if re.match(r'^\[', lines[j]) and not re.match(r'^\[(\[rigs\]\]|rigs(\.|\]))', lines[j]):
+                end = j; break
+        named = None
+        for j in range(s + 1, end):
+            m = re.match(r'^\s*name\s*=\s*["\'](.+?)["\']\s*$', lines[j])
+            if m: named = m.group(1); break
+        if named == rig:
+            target_start, hi = s, end; break
+    if target_start is None: fail('no [[rigs]] block with name = "%s" in %s' % (rig, path))
+    anchor = next((i for i in range(target_start, hi) if re.match(r'^\[rigs\.imports\]\s*$', lines[i])), None)
+    if anchor is None: fail('[rigs.imports] not found under rig "%s" in %s' % (rig, path))
+
+header = "[%s.%s]" % (table, name)
+sub = re.compile(r'^\[%s\.%s\]\s*$' % (re.escape(table), re.escape(name)))
+existing = next((i for i in range(anchor, hi) if sub.match(lines[i])), None)
+
+if action == "add":
+    if existing is not None: sys.exit(0)
+    lines.insert(anchor + 1, "%s\nsource = \"%s\"\n" % (header, source))
+    open(path, "w").write("".join(lines))
+elif action == "remove":
+    if existing is None: sys.exit(0)
+    end = existing + 1
+    if end < len(lines) and re.match(r'^\s*source\s*=', lines[end]): end += 1
+    del lines[existing:end]
+    open(path, "w").write("".join(lines))
+else:
+    fail("unknown action: %s" % action)
+PY
+}
+
+# ---- step 1: venv ----------------------------------------------------------
+step "1/4  engine venv"
+if [ -x "$PACK_DIR/.venv/bin/python" ]; then
+  info "already present: $PACK_DIR/.venv (skipping setup.sh)"
+else
+  run "bash \"$PACK_DIR/setup.sh\""
+  [ "$DRY_RUN" -eq 1 ] && info "(dry-run) would build venv via setup.sh"
+fi
+
+# ---- step 2: import --------------------------------------------------------
+step "2/4  register pack import ($SCOPE scope)"
+if import_present; then
+  info "import \"$IMPORT_NAME\" already registered — no-op"
+else
+  if [ "$SCOPE" = "rig" ]; then
+    IMPORT_CFG="$CITY/city.toml"
+    backup_file "$IMPORT_CFG"
+    if [ "$DRY_RUN" -eq 1 ]; then
+      info "[dry-run] add [rigs.imports.$IMPORT_NAME] (source = \"$PACK_SRC\") under rig \"$RIG\" in $IMPORT_CFG"
+    else
+      edit_import add "$IMPORT_CFG" "$IMPORT_NAME" "$PACK_SRC" "$RIG" \
+        || die "failed to add [rigs.imports.$IMPORT_NAME] under rig \"$RIG\" in $IMPORT_CFG"
+      info "added [rigs.imports.$IMPORT_NAME] (source = \"$PACK_SRC\") under rig \"$RIG\""
+    fi
+  else
+    IMPORT_CFG="$CITY/pack.toml"
+    backup_file "$IMPORT_CFG"
+    if [ "$DRY_RUN" -eq 1 ]; then
+      info "[dry-run] add [imports.$IMPORT_NAME] (source = \"$PACK_SRC\") to $IMPORT_CFG"
+    else
+      edit_import add "$IMPORT_CFG" "$IMPORT_NAME" "$PACK_SRC" \
+        || die "failed to add [imports.$IMPORT_NAME] to $IMPORT_CFG"
+      info "added [imports.$IMPORT_NAME] (source = \"$PACK_SRC\")"
+    fi
+  fi
+fi
+
+# ---- step 3: re-project ----------------------------------------------------
+step "3/4  re-project (gc reload)"
+if [ "$NO_RELOAD" -eq 1 ]; then
+  info "--no-reload: skipping. Run 'gc reload' (or restart the city) to apply."
+elif [ "$DRY_RUN" -eq 1 ]; then
+  info "[dry-run] gc reload  (surfaces the pack's bin/cockpit + skills)"
+else
+  if "${GC[@]}" reload >/dev/null 2>&1; then
+    info "gc reload: ok"
+  else
+    info "gc reload returned non-zero (city may be stopped). Projection will"
+    info "happen on the next 'gc start' / 'gc rig boot'. Continuing."
+  fi
+fi
+
+# ---- step 4: verify --------------------------------------------------------
+step "4/4  verify"
+if [ "$DRY_RUN" -eq 1 ]; then
+  info "[dry-run] would verify: gc lint, import registered, cockpit ready smoke"
+  step "cockpit install — DRY RUN complete (no changes made)"
+  exit 0
+fi
+
+fail=0
+
+# 4a. lint
+if "${GC[@]}" lint "$PACK_DIR" >/dev/null 2>&1; then
+  info "lint: ok"
+else
+  info "lint: FAILED"; "${GC[@]}" lint "$PACK_DIR" || true; fail=1
+fi
+
+# 4b. import registered
+if import_present; then info "import: registered ($IMPORT_NAME)"; else info "import: MISSING"; fail=1; fi
+
+# 4c. cockpit ready smoke (best-effort): a non-zero exit means the /v0 API is down
+#     or version-incompatible on THIS machine — surface as advice, not an install
+#     failure (the install itself succeeded).
+if [ -x "$PACK_DIR/bin/cockpit" ]; then
+  if "$PACK_DIR/bin/cockpit" ready >/dev/null 2>&1; then
+    info "ready: city is Cockpit-ready (/v0 reachable + compatible)"
+  else
+    info "ready: /v0 API not reachable/compatible yet (run 'bin/cockpit ready';"
+    info "       start the city with 'gc start', then 'bin/cockpit discover --write')"
+  fi
+fi
+
+if [ "$SCOPE" = "rig" ]; then REVERSE_FLAGS="--rig $RIG"; else REVERSE_FLAGS="--town"; fi
+echo
+if [ "$fail" -eq 0 ]; then
+  step "cockpit install complete ($SCOPE${RIG:+ $RIG})"
+  info "Next: 'bin/cockpit ready' to verify, then 'bin/cockpit discover --write'"
+  info "to publish the discovery descriptor the extension reads."
+  info "Reverse with: $PACK_DIR/uninstall.sh $REVERSE_FLAGS"
+  exit 0
+else
+  step "cockpit install finished WITH WARNINGS ($SCOPE${RIG:+ $RIG})"
+  info "Review the lines marked FAILED/MISSING above."
+  exit 1
+fi

--- a/cockpit/pack.toml
+++ b/cockpit/pack.toml
@@ -1,0 +1,39 @@
+# cockpit — the GasCity Cockpit city-side enabler pack.
+#
+# The "GasCity Cockpit" is a VS Code extension (the client) plus this thin pack
+# (the city-side contract). The expensive part already exists: the supervisor's
+# versioned, self-documenting /v0 HTTP API (/openapi.json, SSE, the full
+# session/chat/approval surface). This pack does NOT add a backend — it makes a
+# city *Cockpit-ready* and defines the discovery handshake the extension needs.
+#
+# What this pack provides (all convention-discovered once the pack is imported):
+#   bin/cockpit                     the ready / discover / contract / adapter CLI
+#   cockpit/                        the engine (pure-stdlib probe + contract reader)
+#   contract/v0.toml                the /v0 API contract the extension pins
+#   skills/cockpit-readiness/       operator/agent skill: verify + publish discovery
+#   skills/mayor-ide-affordances/   Mayor skill: emit IDE-legible affordances
+#   docs/DESIGN.md                  cockpit-ready definition, discovery handshake,
+#                                   and the OPEN SCOPE FORKS (read before extending)
+#
+# Stdlib-only (tomllib on Python >= 3.11; tomli fallback below it; urllib for the
+# probe). No runtime third-party dependencies — it mirrors provider-forge's
+# minimal footprint.
+#
+# Wiring (after vendoring this pack into a city at packs/cockpit and importing it,
+# e.g. `source = "packs/cockpit"`):
+#   1. Run packs/cockpit/setup.sh once to build the engine's venv (optional —
+#      bin/cockpit also runs under any system python3).
+#   2. `bin/cockpit ready` — assert the live /v0 API is reachable + version-compatible.
+#   3. `bin/cockpit discover --write` — publish the discovery descriptor the
+#      extension reads to auto-find the API.
+#
+# IMPORTANT — scope forks (see docs/DESIGN.md): the supervisor /v0 API is
+# always-on (there is no per-city "enable" toggle), extmsg adapter registration
+# is a RUNTIME call (cockpit-1ll.12), and the discovery descriptor is ideally
+# written by the supervisor itself. This pack ships the verify/contract/helper
+# groundwork and flags those forks rather than hard-coding around them.
+
+[pack]
+name = "cockpit"
+schema = 2
+version = "0.1.0"

--- a/cockpit/requirements.txt
+++ b/cockpit/requirements.txt
@@ -1,0 +1,10 @@
+# cockpit runtime deps — deliberately MINIMAL (mirrors provider-forge / model-advisor).
+#
+# The engine is pure-stdlib: the contract is parsed with the stdlib `tomllib`
+# (Python >= 3.11), the API probe uses `urllib.request` + `json`, and the
+# discovery descriptor is plain JSON. No third-party runtime deps.
+#
+# The single guarded fallback below pulls `tomli` *only* on an older interpreter,
+# so the contract loader's `import tomllib` / `import tomli as tomllib` shim has a
+# backend everywhere without adding a dependency on a modern Python.
+tomli>=2.0 ; python_version < "3.11"

--- a/cockpit/setup.sh
+++ b/cockpit/setup.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Bootstrap the cockpit pack's self-contained venv (idempotent).
+set -euo pipefail
+PACK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PY="${PYTHON:-python3}"
+"$PY" -m venv "$PACK_DIR/.venv"
+"$PACK_DIR/.venv/bin/pip" install --quiet --upgrade pip
+"$PACK_DIR/.venv/bin/pip" install --quiet -r "$PACK_DIR/requirements.txt"
+echo "cockpit venv ready: $PACK_DIR/.venv"

--- a/cockpit/skills/cockpit-readiness/SKILL.md
+++ b/cockpit/skills/cockpit-readiness/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: cockpit-readiness
+description: Verify a gas city is GasCity Cockpit-ready and publish the discovery handshake the VS Code extension needs. Run `cockpit ready` to assert the live /v0 API is reachable + version-compatible + has the endpoints the Cockpit depends on, `cockpit discover --write` to publish the API descriptor the extension auto-discovers, and `cockpit contract` to see the /v0 version + endpoints the Cockpit pins. Use whenever you set up the Cockpit on a city, debug "API unavailable" in the extension, or re-establish discovery after a gc start / stop / restart.
+---
+
+# Cockpit Readiness
+
+## Overview
+
+The **GasCity Cockpit** is a VS Code extension (the client) plus this thin `cockpit`
+pack (the city-side contract). The extension is a pure client of the supervisor's
+existing `/v0` HTTP API — the same versioned, self-documenting API (`/openapi.json`,
+SSE, the full session/chat/approval surface) the web dashboard uses. This pack does
+**not** run a backend; it makes a city *Cockpit-ready* and publishes the discovery
+handshake.
+
+Two facts shape everything this skill does:
+
+1. **The `/v0` API is always-on.** It is served by the **supervisor** (one process,
+   all cities) on `127.0.0.1:8372` by default. There is no per-city "enable the API"
+   toggle — if the supervisor is running, the API is up. So "make a city Cockpit-ready"
+   is **assert + publish**, not flip a switch.
+2. **Discovery is a small descriptor file.** Today nothing on disk advertises the API
+   address (it was historically found by `lsof`). This pack writes a discovery
+   descriptor to a well-known path so the extension auto-finds the API and degrades
+   gracefully when it goes away.
+
+`bin/cockpit` is the read/verify/publish CLI. `ready` and `contract` are pure reads;
+`discover` only writes with `--write`/`--out`.
+
+## When to Use
+
+- You are **setting up the Cockpit** on a city and need to confirm it can drive it.
+- The extension shows **"API unavailable"** and you need to tell whether the supervisor
+  is down, the version drifted, or discovery is stale.
+- After a **`gc start` / `gc stop` / restart** — the API is transient; re-publish the
+  descriptor so the extension reconnects.
+- You are **bumping the extension** and need to confirm the live `/v0` version still
+  matches the pinned contract (`cockpit contract`).
+
+**When NOT to use:**
+
+- To start the city — that's `gc start`. This skill assumes a running supervisor; it
+  *checks*, it does not boot.
+- To register the Cockpit as a conversation participant — that is the **extmsg adapter**
+  story (a runtime registration; see `cockpit adapter` and cockpit-1ll.12 / DESIGN.md),
+  not readiness.
+
+## Process
+
+### Step 1 — Assert the city is Cockpit-ready
+
+```bash
+cockpit ready                       # against http://127.0.0.1:8372 by default
+cockpit ready --city blackrim-hq    # also fetch that city's readiness
+cockpit ready --json                # structured verdict for tooling
+```
+
+`ready` fetches `/openapi.json`, then checks three things and reports a single verdict:
+
+- **reachable** — the supervisor `/v0` API answered;
+- **version** — live `info.version` equals the contract's `required_version` (the `/v0`
+  surface is a moving dev build, so this catches drift);
+- **endpoints** — every load-bearing path the Cockpit needs (health, beads, chat
+  submit/stream, approvals/pending, events, extmsg) is present in `/openapi.json`.
+
+Exit codes are CI-usable: **0** Cockpit-ready, **1** reachable but incompatible
+(version/endpoints), **2** API unreachable. `bin/cockpit` ships with this pack; if it is
+not on `PATH`, invoke it by pack-relative path (e.g. `.../packs/cockpit/bin/cockpit ready`).
+
+### Step 2 — Publish the discovery descriptor
+
+```bash
+cockpit discover --write                          # publish to $GC_HOME/runtime/cockpit/api-descriptor.json
+cockpit discover --write --city blackrim-hq       # record the city in the descriptor
+cockpit discover --out /path/to/descriptor.json   # write somewhere explicit instead
+```
+
+`discover` probes the live API and writes a small JSON descriptor — base URL, `/v0`
+version, auth model, the cities it serves — to a **well-known path under `GC_HOME`**
+(the supervisor home, default `~/.gc`; **note** this is the supervisor-global `.gc`, not a
+city's `.gc`). The extension reads this descriptor to auto-find the API, with a settings
+override allowed. Without `--write`/`--out` it just prints the descriptor.
+
+> Run with `GC_HOME` set (the supervisor sets it) so the descriptor lands in the right
+> runtime root and the token path resolves. In a bare shell, pass `--out` explicitly.
+
+### Step 3 — (reference) See the contract the extension pins
+
+```bash
+cockpit contract            # version + discovery + required endpoints
+cockpit contract --json     # the full machine-readable contract
+```
+
+`contract` prints `contract/v0.toml`: the pinned API version, the discovery descriptor
+path, the auth model, and the required-endpoint gate. The extension generates its typed
+client from `/openapi.json`; this contract is the **compatibility gate**, not the client.
+
+## Worked Example
+
+The operator installed the Cockpit extension but it shows "API unavailable".
+
+1. **Is the API even up?** `cockpit ready` → `status: UNREACHABLE`. The supervisor isn't
+   serving. `gc start` the city, then re-run: `cockpit ready` → `COCKPIT-READY`.
+2. **Publish discovery.** `cockpit discover --write --city blackrim-hq` →
+   `published -> /Users/you/.gc/runtime/cockpit/api-descriptor.json`. The extension's
+   discovery poll picks it up and connects.
+3. **Later, a `gc stop`/`gc start` cycle.** The extension drops to "API unavailable"
+   (expected — availability is transient). Re-run `cockpit discover --write`; the
+   extension reconnects. (Ideally the supervisor refreshes this descriptor itself at
+   bind time — see DESIGN.md fork #3.)
+
+## Why This Matters
+
+- **One clear readiness signal.** Instead of `lsof`-ing for a port and eyeballing JSON,
+  `cockpit ready` gives a single, version-aware verdict with a meaningful exit code.
+- **Version drift is caught early.** `/v0` is a live dev build; pinning + asserting the
+  version stops the extension from silently breaking when the API shape moves.
+- **Discovery is explicit and resilient.** The descriptor is the contracted way the
+  extension finds the API and knows when it's gone — no inspection, no guessing.
+
+## Verification Gate
+
+Before telling an operator the Cockpit is ready on a city:
+
+- [ ] `cockpit ready` exits **0** (`COCKPIT-READY`) — reachable, version matches, all
+      required endpoints present. A `1` means version/endpoint drift; a `2` means start
+      the city first.
+- [ ] `cockpit discover --write` published a descriptor (the path is printed) with
+      `GC_HOME` pointing at the supervisor home.
+- [ ] The descriptor's `cities` lists the city the operator expects to drive.
+- [ ] You did **not** confuse the rig name with the city name — the API is city-scoped
+      under `/v0/city/{cityName}/...`; confirm the name via `cockpit ready --city <name>`
+      or `GET /v0/cities`.
+
+<!-- registration -->
+**Registration.** gc discovers pack skills by directory convention: a pack contributes a
+skill by placing `skills/<name>/SKILL.md` under the pack root, with YAML frontmatter
+carrying at minimum `name` and `description`. This file lives at
+`cockpit/skills/cockpit-readiness/SKILL.md`, so it is picked up automatically —
+`pack.toml` does not enumerate skills. Once the `cockpit` pack is imported into a city
+(vendored under `packs/cockpit` and registered via a direct `source = "packs/cockpit"`
+import), the skill surfaces in `gc skill list` binding-qualified as
+`cockpit.cockpit-readiness`, and the materializer projects it into the per-agent skills
+sink at `gc start`. Verify with `gc skill list` (and `gc lint .` / `gc doctor`).

--- a/cockpit/skills/mayor-ide-affordances/SKILL.md
+++ b/cockpit/skills/mayor-ide-affordances/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: mayor-ide-affordances
+description: Make fleet work legible and actionable inside the GasCity Cockpit (the VS Code extension an operator drives the city from). When coordinating or dispatching on a Cockpit-ready city, prefer durable beads with complete handoff metadata (work_dir, branch, pr_url) so the operator can jump bead -> worktree -> diff; keep bead titles/types/priorities meaningful for the Beads explorer's filters; leave tool-approvals and prompt-for-input pending for the operator to answer in-editor instead of pre-empting them; and keep what you say structured for the chat panel. Use whenever you (the Mayor, or any agent dispatching or coordinating) act on a city an operator is watching through the Cockpit.
+---
+
+# Mayor IDE Affordances
+
+## Overview
+
+When a city is **Cockpit-ready** (see the `cockpit-readiness` skill), the operator is no
+longer only at a terminal — they have an adaptive surface *inside VS Code*: live
+status/agents/event panes, a Beads explorer across cities, an interactive chat with you
+(the Mayor) and any agent, native tool-approval / prompt-for-input, and code-in-context
+(jump from a bead to the polecat worktree and its diff).
+
+An **IDE affordance** is a small, deliberate choice in how you record and route work so
+that surface *lights up* — so the operator can see and act on what's happening without
+attaching to a tmux pane or grepping for a worktree. None of this is new machinery: the
+Cockpit reads the same beads, metadata, sessions, and `/v0` endpoints you already use.
+This skill is the discipline of leaving the right traces.
+
+This is the read/coordinate counterpart to the existing handoff contract: polecats already
+stamp `work_dir` / `branch` / `target` on work beads. Your job is to **rely on and
+preserve** those affordances when you dispatch, summarize, and converse — not to invent
+new ones.
+
+## When to Use
+
+- You are **dispatching work** (sling / routing a bead) on a Cockpit-ready city — set
+  routing and metadata so the dispatch is visible and the result is reviewable in-editor.
+- You are **coordinating or reporting** and an operator is watching through the Cockpit —
+  prefer durable, well-shaped beads over ephemeral chatter for anything they should see.
+- An agent you manage **pauses for a tool-approval or a question** — the operator can now
+  answer it natively in VS Code; let them, rather than auto-approving or guessing.
+- You are **conversing in the Mayor chat panel** — structure replies so the transcript
+  renders well.
+
+**When NOT to use:**
+
+- The city is **not** Cockpit-ready (no extension/discovery) — then optimize for the
+  terminal/dashboard as usual; these affordances cost nothing but buy nothing.
+- For routine agent-to-agent protocol signals (MERGE_READY, drains, nudges) — keep those
+  ephemeral; do not inflate them into beads just to surface them (see the litmus test).
+- To edit code or worktrees — code navigation in the Cockpit is **read-only** (v1); never
+  treat the operator's in-editor view as an invitation to mutate an agent sandbox.
+
+## The affordances
+
+### 1. Bead → worktree → diff: keep handoff metadata complete
+
+The Cockpit lets the operator jump from a bead to the polecat worktree where it is being
+worked and see the diff (PRD stories 27–28). That only works if the bead carries the
+handoff metadata the contract already defines:
+
+| Field | Why the Cockpit needs it |
+|-------|--------------------------|
+| `work_dir` | open the worktree for the work in flight |
+| `branch` | show the branch / diff for the bead |
+| `pr_url` | deep-link to the PR once the refinery records it |
+| `target` | show what it merges into |
+
+When you dispatch or reassign, **preserve** these — don't strip or overwrite them — and
+when work stalls, prefer fixing the bead's metadata over narrating state in chat.
+
+### 2. Beads explorer: keep titles, types, and priorities meaningful
+
+The operator filters/groups beads by status, rig, assignee, type, and priority (stories
+7–9). A wall of `task` / `priority 2` / terse titles defeats that. When you create or
+shape work: give it a **specific title**, the **right type** (epic / task / bug / convoy),
+an honest **priority**, and a real **description**. Structure (parent/child, deps) is what
+the dependency-graph view renders (story 11) — set it deliberately.
+
+### 3. Dispatch visibly: route through the normal sling/`gc.routed_to` path
+
+Dispatching a bead to a pool from the Cockpit maps to the existing sling / `gc.routed_to`
+semantics (story 14). When you route work, use that same mechanism so the Cockpit's view
+of "what's dispatched where" stays accurate — don't hand-assign in ways that bypass it.
+
+### 4. Approvals & prompts: leave them for the operator, don't pre-empt
+
+When an agent pauses for a `tool-approval` or `prompt-for-input`, the Cockpit aggregates
+it across all sessions and lets the operator answer **inline** (stories 23–26). So:
+
+- Don't blanket-approve to "keep things moving" when the operator is actively watching —
+  a pending approval is a feature now, not a stall.
+- Set an agent's **permission mode** intentionally; the operator can also adjust it in
+  the Cockpit, so leave it in a state that matches how much oversight they want.
+- Surface a genuine blocker as a clear pending question rather than burying it.
+
+### 5. Chat & transcripts: structure what you say
+
+The Mayor chat is backed by the structured transcript model (roles + turns). For replies
+the operator reads in the chat panel: lead with the answer, use short structure (lists,
+fenced code/commands), and keep tool-call context legible. Treat each turn as something
+that will be rendered, not just logged.
+
+## Worked Example
+
+The operator, in the Cockpit, asks you to "get the auth-refactor moving and let me review
+it."
+
+1. **Shape the bead.** Title it `Refactor session auth to token boundary`, type `task`,
+   priority set honestly, with a real description and the parent epic linked — so it reads
+   well in the Beads explorer and graph.
+2. **Dispatch visibly.** Sling it to the polecat pool via the normal routing
+   (`gc.routed_to`), so the Cockpit shows it dispatched.
+3. **Preserve handoff metadata.** When the polecat stamps `work_dir` / `branch`, leave
+   them; the operator clicks the bead → opens the worktree → sees the diff. You add
+   nothing; you just don't get in the way.
+4. **Let the operator gate it.** When the agent hits a risky tool-approval, leave it
+   pending; the operator approves it inline in VS Code. You report status in chat as a
+   short structured summary, not a wall of prose.
+
+## Why This Matters
+
+- **The operator's context stops being scattered.** Bead, code, diff, conversation, and
+  approvals live in one editor surface — but only if the traces you leave connect them.
+- **You reuse mechanisms, add no risk.** Every affordance rides existing beads/metadata/
+  routing/approval paths. There is no new Mayor subsystem here — just disciplined use.
+- **Oversight gets cheaper.** Meaningful bead shape + visible dispatch + honest pending
+  approvals turn the Cockpit from a pretty dashboard into a control surface.
+
+## Verification Gate
+
+When acting on a Cockpit-ready city:
+
+- [ ] Work beads you dispatch/own carry complete handoff metadata (`work_dir`, `branch`,
+      and `pr_url`/`target` once known) — the bead→worktree→diff path resolves.
+- [ ] New/shaped beads have a specific title, correct type, honest priority, real
+      description, and correct parent/deps — they filter and graph cleanly.
+- [ ] Dispatch went through the normal sling/`gc.routed_to` path (visible in the Cockpit),
+      not an out-of-band assignment.
+- [ ] You did not auto-approve tool-calls the operator would want to gate, and permission
+      mode reflects the intended level of oversight.
+- [ ] Chat replies are structured for rendering (answer-first, short, fenced commands).
+
+<!-- registration -->
+**Registration.** gc discovers pack skills by directory convention: a pack contributes a
+skill by placing `skills/<name>/SKILL.md` under the pack root, with YAML frontmatter
+carrying at minimum `name` and `description`. This file lives at
+`cockpit/skills/mayor-ide-affordances/SKILL.md`, so it is picked up automatically —
+`pack.toml` does not enumerate skills. Once the `cockpit` pack is imported into a city
+(vendored under `packs/cockpit` and registered via a direct `source = "packs/cockpit"`
+import), the skill surfaces in `gc skill list` binding-qualified as
+`cockpit.mayor-ide-affordances`, and the materializer projects it into the per-agent
+skills sink at `gc start`. To make the Mayor lead with these affordances by default,
+optionally add `mayor-ide-affordances` to the Mayor's prompt fragments; otherwise it is
+available as an on-demand skill. Verify with `gc skill list` (and `gc lint .`).

--- a/cockpit/tests/test_cli.py
+++ b/cockpit/tests/test_cli.py
@@ -1,0 +1,157 @@
+"""cockpit — CLI surface tests (ready / discover / contract / adapter).
+
+Own the CLI contract and its exit-code state machine: ready returns 0 / 1 / 2 for
+ready / incompatible / unreachable; discover writes a descriptor; contract and
+adapter render both text and JSON. The /v0 API is faked by monkeypatching
+``discovery._http_get_json`` so nothing touches the network.
+
+Pure stdlib + pytest. The pack root is importable so ``cockpit.cli.main`` resolves.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import sys
+import urllib.error
+
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+
+from cockpit import cli  # noqa: E402
+from cockpit import contract as K  # noqa: E402
+from cockpit import discovery as D  # noqa: E402
+
+
+def run(argv):
+    out = io.StringIO()
+    rc = cli.main(argv, out=out)
+    return rc, out.getvalue()
+
+
+def _openapi_with(paths, version="0.1.0"):
+    return {
+        "info": {"title": "Gas City Supervisor API", "version": version},
+        "paths": {p: {} for p in paths},
+    }
+
+
+def _patch_api(monkeypatch, openapi, health=None):
+    health = health if health is not None else {"status": "ok", "build_id": "b-dirty"}
+
+    def getter(url, timeout):
+        if url.endswith("/openapi.json"):
+            return openapi
+        if url.endswith("/health"):
+            return health
+        raise OSError(f"unexpected url {url}")
+
+    monkeypatch.setattr(D, "_http_get_json", getter)
+
+
+# ---- contract -------------------------------------------------------------- #
+
+def test_contract_json():
+    rc, s = run(["contract", "--json"])
+    assert rc == 0
+    assert json.loads(s)["api"]["required_version"] == "0.1.0"
+
+
+def test_contract_text():
+    rc, s = run(["contract"])
+    assert rc == 0
+    assert "required version: 0.1.0" in s
+    assert "/v0/city/{cityName}/extmsg/adapters" in s
+
+
+# ---- ready ----------------------------------------------------------------- #
+
+def test_ready_ok(monkeypatch):
+    req = K.required_paths(K.load_contract())
+    _patch_api(monkeypatch, _openapi_with(req))
+    rc, s = run(["ready"])
+    assert rc == 0
+    assert "COCKPIT-READY" in s
+
+
+def test_ready_version_mismatch(monkeypatch):
+    req = K.required_paths(K.load_contract())
+    _patch_api(monkeypatch, _openapi_with(req, version="9.9.9"))
+    rc, s = run(["ready"])
+    assert rc == 1
+    assert "MISMATCH" in s
+
+
+def test_ready_missing_paths(monkeypatch):
+    _patch_api(monkeypatch, _openapi_with(["/health"]))  # missing most required
+    rc, s = run(["ready"])
+    assert rc == 1
+    assert "MISSING" in s
+
+
+def test_ready_unreachable(monkeypatch):
+    def boom(url, timeout):
+        raise urllib.error.URLError("refused")
+
+    monkeypatch.setattr(D, "_http_get_json", boom)
+    rc, s = run(["ready"])
+    assert rc == 2
+    assert "UNREACHABLE" in s
+
+
+def test_ready_json_ok(monkeypatch):
+    req = K.required_paths(K.load_contract())
+    _patch_api(monkeypatch, _openapi_with(req))
+    rc, s = run(["ready", "--json"])
+    assert rc == 0
+    data = json.loads(s)
+    assert data["verdict"]["ready"] is True
+
+
+# ---- discover -------------------------------------------------------------- #
+
+def test_discover_write(monkeypatch, tmp_path):
+    _patch_api(monkeypatch, _openapi_with(["/health"]))
+    out = tmp_path / "desc.json"
+    rc, s = run(["discover", "--out", str(out), "--city", "mycity"])
+    assert rc == 0
+    assert out.exists()
+    desc = json.loads(out.read_text())
+    assert desc["api_version"] == "0.1.0"
+    assert desc["cities"] == ["mycity"]
+
+
+def test_discover_no_write_says_so(monkeypatch):
+    _patch_api(monkeypatch, _openapi_with(["/health"]))
+    rc, s = run(["discover"])
+    assert rc == 0
+    assert "not written" in s
+
+
+def test_discover_unreachable(monkeypatch):
+    def boom(url, timeout):
+        raise urllib.error.URLError("x")
+
+    monkeypatch.setattr(D, "_http_get_json", boom)
+    rc, s = run(["discover"])
+    assert rc == 2
+
+
+# ---- adapter --------------------------------------------------------------- #
+
+def test_adapter_json_fills_city():
+    rc, s = run(["adapter", "--city", "mycity", "--json"])
+    assert rc == 0
+    data = json.loads(s)
+    assert data["method"] == "POST"
+    assert data["endpoint"] == "/v0/city/mycity/extmsg/adapters"
+    assert data["body"]["provider"] == "cockpit"
+
+
+def test_adapter_text_flags_runtime_and_leaves_template():
+    rc, s = run(["adapter"])
+    assert rc == 0
+    assert "RUNTIME" in s
+    assert "{cityName}" in s  # no --city -> template left in place

--- a/cockpit/tests/test_contract.py
+++ b/cockpit/tests/test_contract.py
@@ -1,0 +1,77 @@
+"""cockpit — contract loader tests.
+
+Own the /v0 contract: the shipped contract/v0.toml loads, pins the API version,
+declares the load-bearing required endpoints, and yields a well-formed extmsg
+adapter registration spec. Malformed contracts fail loudly.
+
+Pure stdlib + pytest. The pack root is importable so ``cockpit.contract`` resolves.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+
+import pytest  # noqa: E402
+
+from cockpit import contract as K  # noqa: E402
+
+
+def test_shipped_contract_loads_and_pins_version():
+    c = K.load_contract()
+    assert c["schema"] == K.CONTRACT_SCHEMA
+    assert K.required_api_version(c) == "0.1.0"
+
+
+def test_required_paths_include_critical_endpoints():
+    req = K.required_paths(K.load_contract())
+    assert "/health" in req
+    assert "/v0/cities" in req
+    assert any("extmsg/adapters" in p for p in req)
+    assert any("session/{id}/submit" in p for p in req)
+    assert any("pending" in p for p in req)
+
+
+def test_adapter_spec_shape_and_casing():
+    spec = K.adapter_registration_spec(K.load_contract(), callback_url="http://x/cb")
+    assert spec["provider"] == "cockpit"
+    assert spec["account_id"] == "default"
+    assert spec["callback_url"] == "http://x/cb"
+    # Casing must mirror the live ExtMsgAdapterRegisterInputBody / AdapterCapabilities.
+    assert set(spec["capabilities"]) == {
+        "SupportsChildConversations",
+        "SupportsAttachments",
+        "MaxMessageLength",
+    }
+
+
+def test_adapter_spec_omits_callback_when_absent():
+    spec = K.adapter_registration_spec(K.load_contract())
+    assert "callback_url" not in spec
+
+
+def test_register_path_is_city_scoped():
+    assert "{cityName}" in K.register_path(K.load_contract())
+
+
+def test_schema_mismatch_raises(tmp_path):
+    p = tmp_path / "bad.toml"
+    p.write_text('schema = "nope"\n[api]\nrequired_version = "0.1.0"\n')
+    with pytest.raises(K.ContractError):
+        K.load_contract(str(p))
+
+
+def test_missing_required_version_raises(tmp_path):
+    p = tmp_path / "bad.toml"
+    p.write_text('schema = "cockpit.v0"\n[api]\ntitle = "x"\n')
+    with pytest.raises(K.ContractError):
+        K.load_contract(str(p))
+
+
+def test_missing_file_raises(tmp_path):
+    with pytest.raises(K.ContractError):
+        K.load_contract(str(tmp_path / "nope.toml"))

--- a/cockpit/tests/test_discovery.py
+++ b/cockpit/tests/test_discovery.py
@@ -1,0 +1,124 @@
+"""cockpit — discovery / probe / descriptor tests.
+
+The probe and readiness logic are exercised hermetically: ``_http_get_json`` is
+monkeypatched so no network is touched, covering reachable / unreachable, version
+match/mismatch, and missing-path verdicts. The descriptor round-trips on disk
+under ``tmp_path`` and ``GC_HOME`` is honored.
+
+Pure stdlib + pytest.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import urllib.error
+
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+
+from cockpit import discovery as D  # noqa: E402
+
+FAKE_OPENAPI = {
+    "info": {"title": "Gas City Supervisor API", "version": "0.1.0"},
+    "paths": {"/health": {}, "/v0/cities": {}, "/v0/readiness": {}},
+}
+FAKE_HEALTH = {"status": "ok", "build_id": "abc-dirty"}
+
+
+def _getter(mapping):
+    """Build a fake _http_get_json that dispatches by URL suffix."""
+
+    def getter(url, timeout):
+        for suffix, val in mapping.items():
+            if url.endswith(suffix):
+                if isinstance(val, Exception):
+                    raise val
+                return val
+        raise OSError(f"unexpected url {url}")
+
+    return getter
+
+
+def test_gc_home_honors_env(monkeypatch):
+    monkeypatch.setenv("GC_HOME", "/tmp/gchome")
+    assert D.gc_home() == "/tmp/gchome"
+    assert D.descriptor_path() == os.path.join("/tmp/gchome", D.DESCRIPTOR_RELPATH)
+
+
+def test_probe_api_reachable(monkeypatch):
+    monkeypatch.setattr(
+        D, "_http_get_json", _getter({"/openapi.json": FAKE_OPENAPI, "/health": FAKE_HEALTH})
+    )
+    p = D.probe_api("http://x:8372")
+    assert p["reachable"] is True
+    assert p["api_version"] == "0.1.0"
+    assert p["api_title"] == "Gas City Supervisor API"
+    assert "/health" in p["paths"]
+    assert p["build_id"] == "abc-dirty"
+    assert p["errors"] == []
+
+
+def test_probe_api_health_failure_is_non_fatal(monkeypatch):
+    monkeypatch.setattr(
+        D,
+        "_http_get_json",
+        _getter({"/openapi.json": FAKE_OPENAPI, "/health": urllib.error.URLError("boom")}),
+    )
+    p = D.probe_api("http://x:8372")
+    assert p["reachable"] is True  # openapi is the reachability signal
+    assert any("health" in e for e in p["errors"])
+
+
+def test_probe_api_unreachable(monkeypatch):
+    monkeypatch.setattr(
+        D, "_http_get_json", _getter({"/openapi.json": urllib.error.URLError("refused")})
+    )
+    p = D.probe_api("http://x:8372")
+    assert p["reachable"] is False
+    assert p["errors"]
+
+
+def test_assess_readiness_ok():
+    probe = {"reachable": True, "api_version": "0.1.0", "paths": ["/a", "/b"]}
+    v = D.assess_readiness(probe, "0.1.0", ["/a", "/b"])
+    assert v["ready"] is True
+    assert v["missing_paths"] == []
+
+
+def test_assess_readiness_version_mismatch():
+    probe = {"reachable": True, "api_version": "9.9.9", "paths": ["/a"]}
+    v = D.assess_readiness(probe, "0.1.0", ["/a"])
+    assert v["ready"] is False
+    assert v["version_ok"] is False
+
+
+def test_assess_readiness_missing_paths():
+    probe = {"reachable": True, "api_version": "0.1.0", "paths": ["/a"]}
+    v = D.assess_readiness(probe, "0.1.0", ["/a", "/b"])
+    assert v["ready"] is False
+    assert v["missing_paths"] == ["/b"]
+
+
+def test_assess_readiness_unreachable_lists_all_paths():
+    v = D.assess_readiness({"reachable": False}, "0.1.0", ["/a", "/b"])
+    assert v["ready"] is False
+    assert v["missing_paths"] == ["/a", "/b"]
+
+
+def test_descriptor_round_trip(tmp_path):
+    probe = {"base_url": "http://x:8372", "api_version": "0.1.0", "api_title": "T"}
+    desc = D.build_descriptor(probe, cities=["c1"], home=str(tmp_path))
+    assert desc["kind"] == D.DESCRIPTOR_KIND
+    assert desc["base_url"] == "http://x:8372"
+    assert desc["cities"] == ["c1"]
+    assert desc["auth"]["type"] == "localhost-trust"
+    out = tmp_path / "sub" / "d.json"
+    written = D.write_descriptor(desc, str(out))
+    assert os.path.exists(written)
+    assert D.read_descriptor(str(out)) == desc
+
+
+def test_read_descriptor_absent(tmp_path):
+    assert D.read_descriptor(str(tmp_path / "nope.json")) is None

--- a/cockpit/uninstall.sh
+++ b/cockpit/uninstall.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+# cockpit — uninstall lifecycle (reverses everything install.sh did).
+#
+#   uninstall.sh (--town | --rig <name>) [--dry-run] [--city <path>]
+#                [--purge] [--no-reload]
+#
+# Reverses, in order:
+#   1. Remove the pack import. It is a DIRECT config entry (the gastown pattern,
+#      not `gc import add`/`remove`), so a surgical, backed-up edit drops it:
+#        --town       -> drops  <city>/pack.toml   [imports.cockpit]
+#        --rig <name> -> drops  <city>/city.toml   [rigs.imports.cockpit]
+#                        (from under the [[rigs]] entry whose name matches <name>)
+#   2. Re-project with `gc reload` so the pack's surfaces drop out of projection.
+#   3. --purge: delete the engine .venv.
+#
+# Like provider-forge, cockpit ships NO prompt fragment and NO overlay hook, so
+# there is nothing to remove from append_fragments and no projected
+# .claude/settings.json hook to strip — the uninstall is: import + reload
+# (+ optional purge). The discovery descriptor it may have published under
+# $GC_HOME/runtime/cockpit/ is NOT removed here (it is supervisor runtime state,
+# refreshed/cleared by re-discovery or gc stop); delete it by hand if desired.
+#
+# Idempotent (re-running after a clean uninstall is a no-op). Any file it edits
+# is backed up first. --dry-run prints the plan and changes nothing.
+
+set -euo pipefail
+
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${HOME}/go/bin:${HOME}/.local/bin:${PATH}"
+
+PACK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PACK_NAME="cockpit"
+IMPORT_NAME="cockpit"
+
+SCOPE=""; RIG=""; DRY_RUN=0; NO_RELOAD=0; PURGE=0; CITY=""
+
+die()  { printf 'uninstall.sh: error: %s\n' "$*" >&2; exit 1; }
+info() { printf '  %s\n' "$*"; }
+step() { printf '\n==> %s\n' "$*"; }
+run()  { if [ "$DRY_RUN" -eq 1 ]; then printf '    [dry-run] %s\n' "$*"; else printf '    + %s\n' "$*"; eval "$@"; fi; }
+
+usage() { sed -n '2,24p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit "${1:-0}"; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --town)      SCOPE="town"; shift ;;
+    --rig)       SCOPE="rig"; RIG="${2:-}"; [ -n "$RIG" ] || die "--rig requires a rig name"; shift 2 ;;
+    --rig=*)     SCOPE="rig"; RIG="${1#*=}"; shift ;;
+    --dry-run)   DRY_RUN=1; shift ;;
+    --purge)     PURGE=1; shift ;;
+    --no-reload) NO_RELOAD=1; shift ;;
+    --city)      CITY="${2:-}"; [ -n "$CITY" ] || die "--city requires a path"; shift 2 ;;
+    --city=*)    CITY="${1#*=}"; shift ;;
+    -h|--help)   usage 0 ;;
+    *)           die "unknown argument: $1 (try --help)" ;;
+  esac
+done
+
+[ -n "$SCOPE" ] || die "choose a scope: --town or --rig <name>"
+
+if [ -z "$CITY" ]; then CITY="$(cd "$PACK_DIR/../.." && pwd)"; fi
+[ -f "$CITY/city.toml" ] || die "no city.toml at city root: $CITY (pass --city <path>)"
+CITY="$(cd "$CITY" && pwd)"
+
+GC=(gc --city "$CITY")
+
+step "cockpit uninstall"
+info "scope:  $SCOPE${RIG:+ ($RIG)}"
+info "city:   $CITY"
+[ "$PURGE" -eq 1 ]   && info "purge:  yes (will delete .venv)"
+[ "$DRY_RUN" -eq 1 ] && info "MODE:   DRY RUN (no changes will be made)"
+
+command -v gc >/dev/null 2>&1 || die "gc not found on PATH"
+
+backup_file() {
+  local f="$1"; [ -f "$f" ] || return 0
+  local b="${f}.cockpit.bak.$(date +%Y%m%d%H%M%S)"
+  if [ "$DRY_RUN" -eq 1 ]; then printf '    [dry-run] backup %s -> %s\n' "$f" "$b"; return 0; fi
+  cp -p "$f" "$b"; printf '    backup: %s\n' "$b"
+}
+
+import_present() { # 0 if IMPORT_NAME is registered at the active scope.
+  if [ "$SCOPE" = "rig" ]; then
+    if "${GC[@]}" import list --rig "$RIG" 2>/dev/null | awk '{print $1}' | grep -qx "$IMPORT_NAME"; then
+      return 0
+    fi
+    rig_import_in_config "$RIG"
+  else
+    if "${GC[@]}" import list 2>/dev/null | awk '{print $1}' | grep -qx "$IMPORT_NAME"; then
+      return 0
+    fi
+    grep -Eq "^\[imports\.${IMPORT_NAME}\][[:space:]]*$" "$CITY/pack.toml" 2>/dev/null
+  fi
+}
+
+rig_import_in_config() { # 0 if [rigs.imports.IMPORT_NAME] exists under rig $1
+  python3 - "$CITY/city.toml" "$1" "$IMPORT_NAME" <<'PY'
+import sys, re
+path, rig, name = sys.argv[1], sys.argv[2], sys.argv[3]
+lines = open(path).read().splitlines(keepends=True)
+starts = [i for i, l in enumerate(lines) if re.match(r'^\[\[rigs\]\]\s*$', l)]
+for k, s in enumerate(starts):
+    end = starts[k + 1] if k + 1 < len(starts) else len(lines)
+    for j in range(s + 1, end):
+        if re.match(r'^\[', lines[j]) and not re.match(r'^\[(\[rigs\]\]|rigs(\.|\]))', lines[j]):
+            end = j; break
+    named = None
+    for j in range(s + 1, end):
+        m = re.match(r'^\s*name\s*=\s*["\'](.+?)["\']\s*$', lines[j])
+        if m:
+            named = m.group(1); break
+    if named != rig:
+        continue
+    hdr = re.compile(r'^\[rigs\.imports\.%s\]\s*$' % re.escape(name))
+    if any(hdr.match(lines[j]) for j in range(s + 1, end)):
+        sys.exit(0)
+    sys.exit(1)
+sys.exit(1)
+PY
+}
+
+edit_import() { # add|remove a DIRECT-config import (gastown style); idempotent.
+  # args: <action> <file> <import_name> <source> [<rig_name>]  (source ignored on remove)
+  python3 - "$2" "$1" "$3" "$4" "${5:-}" <<'PY'
+import sys, re
+path, action, name, source, rig = sys.argv[1:6]
+rig = rig or None
+
+def fail(msg):
+    sys.stderr.write("edit_import: %s\n" % msg); sys.exit(3)
+
+lines = open(path).read().splitlines(keepends=True)
+
+if rig is None:
+    table = "imports"
+    anchor = next((i for i, l in enumerate(lines) if re.match(r'^\[imports\]\s*$', l)), None)
+    if anchor is None: fail("[imports] table not found in %s" % path)
+    hi = len(lines)
+else:
+    table = "rigs.imports"
+    starts = [i for i, l in enumerate(lines) if re.match(r'^\[\[rigs\]\]\s*$', l)]
+    if not starts: fail("no [[rigs]] blocks in %s" % path)
+    target_start = None; hi = len(lines)
+    for k, s in enumerate(starts):
+        end = starts[k + 1] if k + 1 < len(starts) else len(lines)
+        for j in range(s + 1, end):
+            if re.match(r'^\[', lines[j]) and not re.match(r'^\[(\[rigs\]\]|rigs(\.|\]))', lines[j]):
+                end = j; break
+        named = None
+        for j in range(s + 1, end):
+            m = re.match(r'^\s*name\s*=\s*["\'](.+?)["\']\s*$', lines[j])
+            if m: named = m.group(1); break
+        if named == rig:
+            target_start, hi = s, end; break
+    if target_start is None: fail('no [[rigs]] block with name = "%s" in %s' % (rig, path))
+    anchor = next((i for i in range(target_start, hi) if re.match(r'^\[rigs\.imports\]\s*$', lines[i])), None)
+    if anchor is None: fail('[rigs.imports] not found under rig "%s" in %s' % (rig, path))
+
+header = "[%s.%s]" % (table, name)
+sub = re.compile(r'^\[%s\.%s\]\s*$' % (re.escape(table), re.escape(name)))
+existing = next((i for i in range(anchor, hi) if sub.match(lines[i])), None)
+
+if action == "add":
+    if existing is not None: sys.exit(0)
+    lines.insert(anchor + 1, "%s\nsource = \"%s\"\n" % (header, source))
+    open(path, "w").write("".join(lines))
+elif action == "remove":
+    if existing is None: sys.exit(0)
+    end = existing + 1
+    if end < len(lines) and re.match(r'^\s*source\s*=', lines[end]): end += 1
+    del lines[existing:end]
+    open(path, "w").write("".join(lines))
+else:
+    fail("unknown action: %s" % action)
+PY
+}
+
+# ---- step 1: import --------------------------------------------------------
+step "1/3  remove pack import ($SCOPE scope)"
+if import_present; then
+  if [ "$SCOPE" = "rig" ]; then
+    IMPORT_CFG="$CITY/city.toml"
+    backup_file "$IMPORT_CFG"
+    if [ "$DRY_RUN" -eq 1 ]; then
+      info "[dry-run] remove [rigs.imports.$IMPORT_NAME] from under rig \"$RIG\" in $IMPORT_CFG"
+    else
+      edit_import remove "$IMPORT_CFG" "$IMPORT_NAME" "" "$RIG" \
+        || die "failed to remove [rigs.imports.$IMPORT_NAME] from $IMPORT_CFG"
+      info "removed [rigs.imports.$IMPORT_NAME] from under rig \"$RIG\""
+    fi
+  else
+    IMPORT_CFG="$CITY/pack.toml"
+    backup_file "$IMPORT_CFG"
+    if [ "$DRY_RUN" -eq 1 ]; then
+      info "[dry-run] remove [imports.$IMPORT_NAME] from $IMPORT_CFG"
+    else
+      edit_import remove "$IMPORT_CFG" "$IMPORT_NAME" "" \
+        || die "failed to remove [imports.$IMPORT_NAME] from $IMPORT_CFG"
+      info "removed [imports.$IMPORT_NAME]"
+    fi
+  fi
+else
+  info "import \"$IMPORT_NAME\" not registered at this scope — no-op"
+fi
+
+# ---- step 2: re-project ----------------------------------------------------
+step "2/3  re-project (gc reload)"
+if [ "$NO_RELOAD" -eq 1 ]; then
+  info "--no-reload: skipping. Run 'gc reload' to drop the pack from projection."
+elif [ "$DRY_RUN" -eq 1 ]; then
+  info "[dry-run] gc reload  (drops the pack's surfaces from projection)"
+else
+  if "${GC[@]}" reload >/dev/null 2>&1; then info "gc reload: ok"
+  else info "gc reload non-zero (city may be stopped); clean state applies on next start"; fi
+fi
+
+# ---- step 3: purge venv ----------------------------------------------------
+step "3/3  engine venv"
+if [ "$PURGE" -eq 1 ]; then
+  if [ -d "$PACK_DIR/.venv" ]; then
+    run "rm -rf \"$PACK_DIR/.venv\""
+    info "purged $PACK_DIR/.venv"
+  else
+    info "no .venv to purge"
+  fi
+else
+  info "kept $PACK_DIR/.venv (pass --purge to delete it)"
+fi
+
+# ---- verify ----------------------------------------------------------------
+step "verify"
+if [ "$DRY_RUN" -eq 1 ]; then
+  step "cockpit uninstall — DRY RUN complete (no changes made)"; exit 0
+fi
+fail=0
+if import_present; then info "import: STILL REGISTERED ($IMPORT_NAME)"; fail=1; else info "import: removed"; fi
+
+echo
+if [ "$fail" -eq 0 ]; then
+  step "cockpit uninstall complete ($SCOPE${RIG:+ $RIG})"
+  info "Backups (*.cockpit.bak.*) were left in place; remove them when satisfied."
+  exit 0
+else
+  step "cockpit uninstall finished WITH WARNINGS"
+  info "Review the STILL-* lines above."
+  exit 1
+fi

--- a/registry.toml
+++ b/registry.toml
@@ -77,3 +77,16 @@ source_kind = "git"
   commit = "d3617d1319a1206ac85f69ba024ec395c49c6f4b"
   hash = "sha256:0d32d8da6ad57c632d4f54008bdd1bb8b822c493a709676b3d1761a5ef389387"
   description = "Initial Slack pack release."
+
+[[pack]]
+name = "cockpit"
+description = "GasCity Cockpit: city-side enabler pack for the VS Code Cockpit (verify /v0 readiness, publish the discovery descriptor)."
+source = "https://github.com/gastownhall/gascity-packs/tree/main/cockpit"
+source_kind = "git"
+
+  [[pack.release]]
+  version = "0.1.0"
+  ref = "main"
+  commit = "f4e8b5c3b57a9a8ffc228ab60252462d18b8ed45"
+  hash = "sha256:f6c239e442d51521ce61b35ae15ad76b95db3647c4dcb707eaeb4c5af8a44bd6"
+  description = "Initial GasCity Cockpit enabler pack."


### PR DESCRIPTION
## Summary

Adds `cockpit` as a top-level pack: the city-side half of the **GasCity Cockpit**, a VS Code extension that turns the editor into a live cockpit for fleets of coding agents. After this lands, a city becomes Cockpit-ready by importing one pack, with no gascity binary changes.

The expensive part already exists: the supervisor's versioned `/v0` HTTP API. This pack does **not** add a backend; it verifies a city is reachable and publishes the discovery descriptor the extension auto-reads.

## What the pack provides

```
cockpit/
  pack.toml                      name = "cockpit", schema 2
  bin/cockpit                    ready / discover / contract / adapter CLI
  cockpit/                       stdlib-only probe + contract-reader engine
  contract/v0.toml               the /v0 API contract the extension pins
  skills/cockpit-readiness/      verify + publish discovery
  skills/mayor-ide-affordances/  emit IDE-legible affordances
  install.sh / uninstall.sh      reversible, idempotent install lifecycle
  setup.sh / requirements.txt    optional venv (also runs under system python3)
  tests/                         pytest coverage
  docs/DESIGN.md                 cockpit-ready definition + discovery handshake
```

Stdlib-only (tomllib/tomli + urllib), no runtime third-party deps, mirroring provider-forge's footprint.

## Notes
- The extension lives at [jsgerman-oss/gascity-cockpit](https://github.com/jsgerman-oss/gascity-cockpit) ([site](https://jsgerman-oss.github.io/gascity-cockpit/)).
- `registry.toml` release `commit`/`hash` are pinned to the pack commit on this branch; happy to re-pin to the merge commit or regenerate with your release tooling.
- `validate_registry.py` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)