### PR TITLE
fix(slack-pack): newest-first transcript lookup in find_latest_inbound_message_id_for_session

### DIFF
--- a/docs/design/slack-pack-tiering.md
+++ b/docs/design/slack-pack-tiering.md
@@ -1,0 +1,343 @@
+# slack-pack tiering: tier contracts, migration paths, and import compatibility
+
+Design memo for `gc-yrw` (slack-pack tiering). Tracking bead: `gc-yrw.1`.
+
+Status: design. Defines the contract that drives the extraction work in
+`gc-yrw.2` (slack-mini), `gc-yrw.3` (slack-mini docs), `gc-yrw.4`
+(slack-channel), and `gc-yrw.5` (retitle current pack → slack-full).
+
+## Motivation
+
+A reviewer on gastownhall/gascity-packs PR #8 asked: *"why does plugging in
+Slack take 156 files?"* The honest answer is that the current pack is
+**Tier 3** — a workspace-grade orchestration surface (webhooks, modals, file
+uploads, peer fanout, multi-rig, room launcher) where roughly half the file
+count is tests plus the gc convention of three command-wrapper files per verb.
+
+But the question exposes a real adoption-friction problem: nobody wiring up
+"`@mayor` in Slack" for the first time wants to opt into all 156 files. Tiering
+lets a consumer adopt the smallest surface that fits their use case instead of
+taking the whole integration or none of it.
+
+This memo is **docs-only**. It defines what is IN and OUT of each tier, how a
+city migrates between tiers, and whether tiers can coexist. It does not extract
+any code — that is the job of the sibling beads.
+
+---
+
+## 1. Tier contracts
+
+Three tiers. Each **strictly subsumes** the prior: every capability in Tier N
+is present in Tier N+1. Migration up is additive (drop in the larger pack);
+migration down requires re-deriving state and is not officially supported (see
+§2).
+
+```
+Tier 1 — slack-mini       ~12-18 files     "Talk to mayor from Slack"
+Tier 2 — slack-channel    ~50-60 files     "Bind your team channel to your session graph"
+Tier 3 — slack-full       ~156+ files      "Workspace-grade multi-rig orchestration surface" (current pack)
+```
+
+### Tier 1 — slack-mini
+
+**Use case:** add a bot to your company Slack, `@mayor` it from any channel, get
+threaded replies.
+
+**In:**
+- Slack Events API receiver, only `app_mention`.
+- Inbound bridge-mail path: mention → `gc mail send mayor`.
+- One outbound verb: `gc slack post-message` (workspace-token-authed).
+- 4 env vars (bot token, signing secret, workspace_id, city_name).
+
+**Out:** bindings, registries, per-session identity, non-mention channels,
+modals, files, fanout, multi-rig.
+
+**Files:** ~12–18.
+
+### Tier 2 — slack-channel
+
+**Use case:** a team has a `#ops` channel; bind it to mayor (and optionally PL).
+Team conversations route to the bound sessions, and sessions post back.
+Per-session identity overrides let different agents post as different bot
+personas.
+
+**Tier 1 + adds:**
+- Channel binding registry (channel ↔ N sessions, on-disk JSON).
+- Verbs: `bind-dm`, `bind-room`, `publish`, `publish-to-channel`,
+  `reply-current`, `identity`, `react`, `handle-alias` (cross-channel
+  address-by-handle).
+- Identity registry (display name + avatar overrides).
+- Non-mention channel message routing to bound sessions.
+- Basic inbound modal-button ack.
+
+**Out:** multi-rig, peer fanout, room launcher, channel-name patterns, file
+uploads, double-handle dispatch.
+
+**Files:** ~50–60.
+
+### Tier 3 — slack-full (current pack)
+
+**Use case:** a workspace orchestrates a multi-rig session graph; channels map
+to rigs map to session pools; peers fan out replies; cross-channel handles;
+file uploads; room launcher (`@@<handle>` spawns a session); slash-command verb
+intake.
+
+**Tier 2 + adds:** rig binding, channel-name pattern resolver, room launcher
+mode, handle aliases (double-handle dispatch), peer fanout, file upload,
+`import-app` + `sync-commands`, and `status` / `retry-peer-fanout` / `map-rig`
+diagnostics.
+
+**Files:** ~156 (159 in the current snapshot on `main`). This is the pack that
+lands at gastownhall/gascity-packs PR #8; `gc-yrw.5` retitles it to
+`slack-full`.
+
+---
+
+## 2. Migration paths
+
+### Up — additive, no state loss
+
+Up-migration is a pack swap. Because each tier strictly subsumes the prior, the
+larger pack reads the same on-disk registries the smaller pack wrote; existing
+state is preserved and new capabilities light up.
+
+**`slack-mini` → `slack-channel`:**
+1. Replace the pack (`slack-mini` → `slack-channel`) in the city. Both register
+   `name = "slack"`, so this is a swap, not a coexistence (see §3).
+2. The bot token, signing secret, and workspace_id env vars carry over
+   unchanged.
+3. New on-disk registries (channel mappings, identities, handle aliases) start
+   empty; `bind-dm` / `bind-room` / `identity` populate them. No mini state is
+   invalidated — mini wrote none.
+
+**`slack-channel` → `slack-full`:**
+1. Replace the pack (`slack-channel` → `slack-full`).
+2. Carries over: the channel-mappings, identity, and handle-alias registries
+   written under Tier 2 are read unchanged by Tier 3.
+3. New, initially-empty registries: apps (`import-app`), rig mappings
+   (`map-rig`), room-launch mappings (`enable-room-launch`).
+4. The adapter picks up the new registries on next start (or `SIGHUP`); Tier-2
+   bindings keep working throughout.
+
+In both directions up, the only required action is the pack swap plus
+populating the newly available registries. No migration script is needed.
+
+### Down — not officially supported; orphaned state documented
+
+Down-migration is **not officially supported**. The smaller pack does not read
+the larger pack's extra registries, so that state becomes orphaned (it persists
+on disk but is ignored, and the verbs that wrote it no longer exist). Document,
+don't auto-delete — silently deleting a consumer's registry data on downgrade
+would be a destructive surprise.
+
+**`slack-full` → `slack-channel`** orphans:
+- `apps.json` — the apps registry (`import-app` records: OAuth client id,
+  signing secret, bot-token linkage). Slack app remains installed
+  workspace-side; only the local record is orphaned.
+- `rig_mappings.json` — rig bindings (`map-rig`).
+- `room_launch_mappings.json` — room-launch mappings (`enable-room-launch`).
+- Peer-fanout queue / retry state, if any is persisted.
+
+**`slack-channel` → `slack-mini`** orphans:
+- `channel_mappings.json` — channel bindings (`bind-dm` / `bind-room` /
+  `map-channel`).
+- `identities.json` — per-session identity overrides (`identity`).
+- `handle-aliases.json` — cross-channel handle → session-id aliases
+  (`handle-alias`).
+
+Recommended downgrade procedure (manual, by the operator): stop the adapter,
+archive the orphaned `*.json` files out of the adapter state directory, swap the
+pack, restart. Re-upgrading later requires re-deriving the archived state (the
+files can be restored if their schema has not changed across versions, but this
+is best-effort, not a supported contract).
+
+---
+
+## 3. Import compatibility
+
+### Can a city import both `slack-mini` and `slack-channel` (or any two tiers)?
+
+**No.** All three tiers register the same pack name in `pack.toml`:
+
+```toml
+[pack]
+name = "slack"
+```
+
+Pack names must be unique within a city. If a city installs two packs that both
+declare `name = "slack"`, only one wins — gc does not merge them and does not
+namespace them apart. The `gc slack <verb>` surface, the `[[service]]` named
+`slack`, and the `/svc/slack/*` reverse-proxy route all key off that single
+name. Two packs claiming it is a collision, not a composition.
+
+This is intentional: the tiers are **alternatives**, not **layers you stack at
+install time**. The subsumption relationship (§1) is a *design-time* guarantee
+that up-migration is additive — it is not an invitation to install more than
+one tier simultaneously.
+
+### Recommended pattern: one slack pack per city
+
+Exactly **one**. A city picks the tier that matches its use case and installs
+only that pack. To change tiers, swap the pack (§2) — never run two side by
+side. The single `name = "slack"` namespace is the mechanism that enforces this:
+the verb surface, the service, and the proxy route are all singular by
+construction.
+
+(If a future use case genuinely needs two independent Slack surfaces in one
+city — e.g. two workspaces — that would require per-pack name parameterization,
+which is out of scope for this tiering and tracked separately if it ever
+arises.)
+
+---
+
+## 4. Verb surface per tier
+
+Each `gc slack <verb>` is introduced by exactly one tier and inherited by all
+higher tiers. The table maps every one of the **17 current Tier-3 verbs** to the
+tier that introduces it.
+
+| `gc slack <verb>`     | Introduced at | Purpose                                                        |
+| --------------------- | ------------- | -------------------------------------------------------------- |
+| `post-message`        | Tier 1        | Outbound workspace-token-authed message (the only mini verb).  |
+| `bind-dm`             | Tier 2        | Bind a DM channel to one or more sessions.                     |
+| `bind-room`           | Tier 2        | Bind a channel/room to one or more sessions.                   |
+| `publish`             | Tier 2        | Publish a message from the current session to its bound target.|
+| `publish-to-channel`  | Tier 2        | Publish to a specific channel.                                 |
+| `reply-current`       | Tier 2        | Reply in the current inbound thread context.                   |
+| `identity`            | Tier 2        | Set per-session display-name / avatar identity override.       |
+| `react`               | Tier 2        | Add an emoji reaction to a message.                            |
+| `handle-alias`        | Tier 2        | Register cross-channel handle → session alias.¹                |
+| `map-channel`         | Tier 3        | Channel-name pattern → binding resolver.                       |
+| `map-rig`             | Tier 3        | Bind a channel/pattern to a rig (multi-rig).                   |
+| `enable-room-launch`  | Tier 3        | Enable `@@<handle>` room launcher mode.                        |
+| `import-app`          | Tier 3        | OAuth app intake; populates the apps registry.                 |
+| `sync-commands`       | Tier 3        | Push slash-command definitions to Slack.                       |
+| `upload`              | Tier 3        | File upload to a channel/thread.                               |
+| `retry-peer-fanout`   | Tier 3        | Re-drive a failed peer-fanout dispatch (diagnostic).           |
+| `status`              | Tier 3        | Cross-registry status report (apps, channels, rigs).           |
+
+Tier 1: 1 verb. Tier 2: +8 verbs (9 total). Tier 3: +8 verbs (**17 total**).
+
+> ¹ **`handle-alias` tier boundary.** The `gc-yrw` contract lists `handle-alias`
+> under Tier 2's verbs ("cross-channel address-by-handle") while also listing
+> "handle aliases / double-handle dispatch" under Tier 3's additions. The
+> resolution adopted here: the **`handle-alias` verb and single cross-channel
+> handle resolution are Tier 2**; **double-handle dispatch** (addressing via two
+> chained handles) is the **Tier 3** behavior layered on the same registry.
+> Tier 2's explicit "Out" list excludes "double-handle dispatch," which confirms
+> this split. See Open Questions (§7).
+
+---
+
+## 5. Service shape per tier
+
+All tiers run the adapter as a gc `proxy_process` service named `slack` (UDS for
+`/publish` + `/healthz`, public TCP for `/slack/events`). What differs is the
+on-disk registry state the adapter and CLI maintain.
+
+The current pack has **6 registries** (4 written by `gc slack` CLI commands and
+read by the adapter on start / `SIGHUP`, plus identity and handle-alias):
+
+| # | Registry             | File                        | CLI writer                    |
+| - | -------------------- | --------------------------- | ----------------------------- |
+| 1 | Apps                 | `apps.json`                 | `gc slack import-app`         |
+| 2 | Channel mappings     | `channel_mappings.json`     | `gc slack map-channel` / `bind-*` |
+| 3 | Rig mappings         | `rig_mappings.json`         | `gc slack map-rig`            |
+| 4 | Room launch mappings | `room_launch_mappings.json` | `gc slack enable-room-launch` |
+| 5 | Identity             | `identities.json`           | `gc slack identity`           |
+| 6 | Handle aliases       | `handle-aliases.json`       | `gc slack handle-alias`       |
+
+(The adapter also maintains a `thread_sessions.json` runtime map of inbound
+threads → sessions. That is auto-managed adapter state, not an operator-
+configured registry, so it is excluded from the "6 registries" count and is
+present wherever inbound routing is — i.e. Tier 2+.)
+
+**Tier 1 — slack-mini:** minimal `proxy_process`, bot-token-only, **no UDS state
+registries**. The adapter receives `app_mention`, bridges to `gc mail send
+mayor`, and the single outbound verb posts via workspace token. No on-disk
+registry files.
+
+**Tier 2 — slack-channel:** `proxy_process` + on-disk **channel/identity**
+registries. Concretely, the three Tier-2 registries are **channel mappings (2),
+identity (5), and handle aliases (6)** — channel binding, per-session identity
+override, and cross-channel handle resolution. Inbound non-mention routing and
+the `thread_sessions` runtime map appear here.
+
+**Tier 3 — slack-full:** full `proxy_process` + **all 6 registries** + room
+launcher + peer fanout. Tier 3 adds the **apps (1), rig mappings (3), and
+room-launch mappings (4)** registries on top of Tier 2's three, plus peer-fanout
+dispatch and the `@@<handle>` room launcher.
+
+| Registry             | Tier 1 | Tier 2 | Tier 3 |
+| -------------------- | :----: | :----: | :----: |
+| (none)               |   ✓    |        |        |
+| Channel mappings     |        |   ✓    |   ✓    |
+| Identity             |        |   ✓    |   ✓    |
+| Handle aliases       |        |   ✓    |   ✓    |
+| Apps                 |        |        |   ✓    |
+| Rig mappings         |        |        |   ✓    |
+| Room launch mappings |        |        |   ✓    |
+
+---
+
+## 6. Test surface per tier
+
+The current Tier-3 pack snapshot on `main` carries **~43 test files** (32 Go
+`*_test.go` + 11 Python) against 33 Go source files, plus 51 command-wrapper
+files (17 verbs × the 3-file gc convention: `<verb>.sh` + `command.toml` +
+`help.md`). Roughly half the pack's 159 files are test or boilerplate — which is
+the grounded answer to "why 156 files."
+
+Test-count expectations below are budgets for the extraction beads, not hard
+counts; the principle is **each tier ships the tests for its own surface and
+inherits the lower tiers' tests unchanged**.
+
+| Tier | Test budget (approx.) | What is covered |
+| ---- | --------------------- | --------------- |
+| Tier 1 — slack-mini | ~6–10 test files | Events-API signature verification; `app_mention` parse; mention → `gc mail send mayor` bridge; `post-message` outbound; env-var validation / startup config. |
+| Tier 2 — slack-channel | Tier 1 + ~12–18 | Channel-mapping registry read/write + SIGHUP reload; identity registry; handle-alias resolution (single handle); non-mention inbound routing to bound sessions; modal-button ack; the 8 Tier-2 verbs' CLI surface. |
+| Tier 3 — slack-full | Tier 2 + remainder (~43 total today) | Apps registry + OAuth callback; rig dispatch + rig mapping + rig workdir; room-launch mapping + launcher; peer fanout + `retry-peer-fanout`; channel-name pattern resolver; file upload; double-handle dispatch; `import-app` / `sync-commands`; `status` cross-registry view. Includes the Python adapter integration tests. |
+
+**Layer coverage:** unit tests live beside each registry and resolver
+(`*_test.go` next to the source); the Python `tests/` directory holds adapter
+integration tests (webhook → bridge → outbound round-trips). Tier 1 and Tier 2
+extractions must carry the subset of each that exercises only their surface;
+Tier 3 keeps the full set.
+
+---
+
+## 7. Open questions
+
+1. **`slack-channel`: derived-from-Tier-3 or designed-fresh?**
+   **Recommendation: designed-fresh** (build Tier 2 on top of the Tier-1
+   kernel, per `gc-yrw.4`), *not* carved down from Tier 3. Rationale: Tier 3's
+   code assumes multi-rig dispatch, peer fanout, and the apps registry
+   throughout its routing and state paths; carving those out leaves dead
+   branches and defensive `if registry == nil` guards that erode the module.
+   Designing Tier 2 fresh against the Tier-1 kernel yields a clean ~50–60 file
+   pack whose every branch is exercised. The cost is some re-implementation of
+   channel routing, but that routing is simpler without the Tier-3 assumptions.
+   This decision is **deferred to `gc-yrw.4`** for final confirmation but the
+   memo recommends designed-fresh.
+
+2. **`handle-alias` tier boundary** (see §4 footnote). The source contract is
+   ambiguous: `handle-alias` is listed under both Tier 2 verbs and Tier 3
+   additions. Adopted resolution: **verb + single-handle resolution = Tier 2;
+   double-handle dispatch = Tier 3.** Confirm against the Tier-2 extraction
+   whether single-handle resolution can stand alone without pulling in fanout.
+
+3. **Thread-session runtime state.** `thread_sessions.json` is adapter-managed
+   runtime state, not an operator registry. It appears wherever inbound routing
+   exists (Tier 2+). Confirm Tier 2 needs it (it does, for `reply-current`
+   thread context) and that Tier 1 can omit it entirely (mini replies in-thread
+   directly from the inbound event without persisting a map).
+
+4. **Down-migration support.** This memo documents down-migration as
+   unsupported with orphaned-state archival (§2). Open: whether to ship a
+   best-effort `gc slack migrate-down` helper that archives orphaned registries
+   automatically, or leave it fully manual. Current recommendation: manual,
+   documented — a helper risks the silent-deletion failure mode.
+
+5. **Two Slack surfaces in one city.** Out of scope for tiering (§3). If a
+   genuine multi-workspace use case arises, it needs per-pack name
+   parameterization, tracked separately.

--- a/pr-pipeline/README.md
+++ b/pr-pipeline/README.md
@@ -28,9 +28,9 @@ stay with the caller.
 ## Sibling pack
 
 `pr-review` (in this same repo) covers the **maintainer-side incoming-PR
-review/merge workflow** with `mol-adopt-pr` — a 6-step formula for
+review/merge workflow** with `mol-adopt-pr` — a 5-step formula for
 adopting contributor PRs (intake → rebase → review → human-gate →
-finalize → merge). The two packs are complementary:
+finalize). The two packs are complementary:
 
 - `pr-review` → reviewing PRs that arrive at your repo
 - `pr-pipeline` → planning, building, and shipping PRs your city sends out

--- a/pr-pipeline/formulas/mol-pr-triage.formula.toml
+++ b/pr-pipeline/formulas/mol-pr-triage.formula.toml
@@ -297,7 +297,9 @@ If no Tier 1 OR Tier 2 candidates exist, recommend a Tier 3 to investigate
 or note that the queue is empty and triage should wait for new issues.
 ```
 
-After writing the file:
+After writing the file, record final state, surface the summary on stdout
+(the maintenance PL relays it back to Slack), and close the molecule. All
+values are still in scope from the classification above — no re-read needed:
 
 ```bash
 TIER1=$(jq '[.[] | select(.tier==1)] | length' /tmp/triage-classified.json)
@@ -312,29 +314,7 @@ tier2: $TIER2
 tier3: $TIER3
 tier4: $TIER4
 recommended: $RECOMMENDED
-status: report_written"
-```
-
-**Exit criteria:** Markdown report written; bead notes record path + tier counts + recommended pick.
-"""
-
-[[steps]]
-id = "finalize"
-title = "Surface report path and exit"
-needs = ["report"]
-description = """
-Display the report path and recommended pick on stdout for the maintenance
-PL to relay back to Slack:
-
-```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
-NOTES=$(bd show "$ROOT_ID" --json | jq -r '.notes // ""')
-TRIAGE_PATH=$(echo "$NOTES" | grep -m1 '^triage_path:' | sed 's/^triage_path: //')
-TIER1=$(echo "$NOTES" | grep -m1 '^tier1:' | sed 's/^tier1: //')
-TIER2=$(echo "$NOTES" | grep -m1 '^tier2:' | sed 's/^tier2: //')
-TIER3=$(echo "$NOTES" | grep -m1 '^tier3:' | sed 's/^tier3: //')
-TIER4=$(echo "$NOTES" | grep -m1 '^tier4:' | sed 's/^tier4: //')
-RECOMMENDED=$(echo "$NOTES" | grep -m1 '^recommended:' | sed 's/^recommended: //')
+status: complete"
 
 cat <<EOF
 [pr-triage] Triage report ready
@@ -344,9 +324,10 @@ cat <<EOF
 [pr-triage] Next: human reviews report, picks an issue, dispatches mol-pr-start.
 EOF
 
-bd update "$ROOT_ID" --notes "status: complete"
 bd close "$ROOT_ID" --reason "triage report written: $TRIAGE_PATH"
 ```
 
-**Exit criteria:** Report path printed, root bead closed with status:complete.
+**Exit criteria:** Markdown report written; bead notes record path + tier
+counts + recommended pick; summary printed to stdout; root bead closed with
+status:complete.
 """

--- a/pr-review/README.md
+++ b/pr-review/README.md
@@ -6,8 +6,8 @@ gate between review and merge.
 
 ## What's Included
 
-- **`mol-adopt-pr` formula** — 6-step molecule: intake, rebase-check, review,
-  human-gate, finalize, complete
+- **`mol-adopt-pr` formula** — 5-step molecule: intake, rebase-check, review,
+  human-gate, finalize
 - **`/review-pr` skill** — multi-model code review engine (overlay)
 
 ## Prerequisites
@@ -47,8 +47,7 @@ gc sling <rig>/polecat mol-adopt-pr --formula \
    ```bash
    bd close <human-gate-step-id>
    ```
-5. **Finalize** — Determine merge path, push, post synthesis comment, wait for CI, merge
-6. **Complete** — Clean up refs, update root bead
+5. **Finalize** — Resolve merge path, prepare local artifacts (squash/rebase/branch/synthesis), hand publish + merge to mayor, then clean up refs and update the root bead
 
 ## Merge Paths
 

--- a/pr-review/pack.toml
+++ b/pr-review/pack.toml
@@ -1,6 +1,6 @@
 # PR Review — formula-driven adopt-PR workflow.
 #
-# Provides a 6-step molecule formula for reviewing and merging contributor PRs.
+# Provides a 5-step molecule formula for reviewing and merging contributor PRs.
 # The polecat follows the formula steps; a human gate after review blocks until
 # the maintainer is ready to finalize.
 #

--- a/slack-channel/.gitignore
+++ b/slack-channel/.gitignore
@@ -1,0 +1,9 @@
+# Built adapter binary — produced by `go build` in adapter/ and read in
+# place by the [[service]] proxy_process command.
+adapter/gc-slack-channel-adapter
+
+# Python test artifacts (tests/test_schemas.py runs under pytest).
+__pycache__/
+.pytest_cache/
+*.pyc
+adapter/*.out

--- a/slack-channel/CHANGELOG.md
+++ b/slack-channel/CHANGELOG.md
@@ -1,0 +1,62 @@
+# Changelog
+
+All notable changes to slack-channel are documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] — Tier 2
+
+Initial release. slack-channel is Tier 2 of the Slack pack family — the
+"team channel ↔ session graph" middle tier, built fresh on slack-mini's
+single-file kernel rather than carved down from slack-full (`gc-yrw.4`).
+
+### Added
+
+- Multi-file Slack adapter (`adapter/*.go`, module
+  `github.com/sjarmak/gc-slack-channel-adapter`), built on the slack-mini
+  kernel:
+  - Public Slack Events API receiver at `/slack/events`, HMAC-verified with
+    `SLACK_SIGNING_SECRET` and a 5-minute replay window.
+  - **Widened inbound routing**: handles `message.*` events as well as
+    `app_mention`. A message in a bound channel is delivered to every bound
+    session; `@handle[:]` addresses route to the aliased session from any
+    channel; an unbound, unaliased `app_mention` falls back to the default
+    target (preserving Tier 1's "talk to mayor from any channel").
+  - Three adapter-owned on-disk registries under
+    `<GC_CITY_PATH>/.gc/slack-channel/`, written atomically and reloaded
+    into memory: `channel_mappings.json`, `identities.json`,
+    `handle_aliases.json`. JSON Schemas in `schema/`.
+  - Outbound verb endpoints: `/publish`, `/publish-to-channel`,
+    `/reply-current`, `/react`, all applying the session's identity override
+    (`chat:write.customize`) to `chat.postMessage`.
+  - `/slack/interactions` endpoint that verifies the signature and acks
+    interactive payloads (basic modal-button ack; no custom modal handling).
+  - Self-registers as an extmsg adapter on start (`REGISTER_ON_START`).
+- Eight verbs, each a bash wrapper (`commands/<verb>.sh`) relaying to the
+  adapter through gc's `/svc/slack-channel` reverse proxy — no operator CLI
+  binary at this tier:
+  - `bind-dm`, `bind-room` — bind a channel/DM to one or more sessions.
+  - `publish`, `publish-to-channel` — post into a session's bound channel,
+    or into any channel by id.
+  - `reply-current` — reply into the conversation of the session's latest
+    inbound message (optionally threaded).
+  - `react` — add an emoji reaction to the latest inbound (or an explicit
+    message).
+  - `identity` — register/remove a per-session username + avatar override.
+  - `handle-alias` — register/remove a `@handle → session` alias.
+- Slack app manifest (`manifest/app.json`): scopes `app_mentions:read`,
+  `channels:history`, `groups:history`, `im:history`, `mpim:history`,
+  `chat:write`, `chat:write.public`, `chat:write.customize`,
+  `reactions:write`; subscribes to `app_mention` and `message.*`.
+- `pack.toml` declaring the adapter as a `proxy_process` service named
+  `slack-channel`.
+
+### Notes
+
+- Independent of slack-mini and slack-full — no shared Go modules.
+- Tier 2 excludes (those are slack-full / Tier 3): multi-rig routing,
+  channel-name pattern resolvers, room-launch, the apps registry +
+  slash-command intake, peer fanout, file upload, and double-handle
+  dispatch.
+- Pick exactly one Slack tier per city.

--- a/slack-channel/LICENSE
+++ b/slack-channel/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Steve Yegge
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/slack-channel/README.md
+++ b/slack-channel/README.md
@@ -1,0 +1,197 @@
+# slack-channel
+
+**Bridge Slack channels and DMs to your Gas City sessions.** Bind a channel
+to one or more gc sessions and every message there is delivered to them;
+reply, publish, and react back; give each session its own Slack identity;
+address a session from any channel with `@handle`.
+
+slack-channel is **Tier 2** of the Slack pack family — the "team channel ↔
+session graph" middle tier. It is built on slack-mini's single-file kernel
+and adds the state Tier 1 deliberately omits. It does **not** include the
+multi-rig routing, slash-command intake, peer fanout, or file upload of
+`slack-full` (Tier 3).
+
+> Pick exactly one Slack tier per city. The tiers are alternatives, not
+> layers you stack.
+
+## What you get
+
+- **Bound channels:** `bind-room C0123 sess-a sess-b` — every human message
+  in `C0123` is delivered to both sessions (not just `@`-mentions).
+- **Address by handle:** `@mayor: status?` in any channel routes to the
+  session aliased to `mayor`.
+- **Reply / publish:** `reply-current` threads under the message that just
+  arrived; `publish` posts into a session's bound channel;
+  `publish-to-channel` posts anywhere by id.
+- **Per-session identity:** each session posts under its own username +
+  avatar (`chat:write.customize`).
+- **React:** `react --emoji eyes` drops a receipt on the latest inbound.
+
+## Verbs
+
+All verbs are `gc slack-channel <verb>`. Run any with `--help` for full
+flags.
+
+| Verb | Purpose |
+| --- | --- |
+| `bind-dm <channel> <session...>` | Bind a DM to one or more sessions. |
+| `bind-room <channel> <session...>` | Bind a channel to one or more sessions. |
+| `publish --body <text>` | Post into the current session's bound channel. |
+| `publish-to-channel --channel <id> --body <text>` | Post into any channel by id. |
+| `reply-current --body <text> [--thread-current]` | Reply into the session's latest inbound conversation. |
+| `react [--emoji <name>]` | React on the session's latest inbound message. |
+| `identity --as <name> [--avatar-emoji <e>]` | Set the session's Slack username + avatar. |
+| `handle-alias --handle <h> --session <id>` | Map `@<h>` to a session. |
+
+## Install
+
+### 1. Create the Slack app
+
+Create an app from the shipped manifest at
+[`manifest/app.json`](./manifest/app.json):
+
+1. <https://api.slack.com/apps> → **Create New App** → **From a manifest**.
+2. Pick your workspace, paste `manifest/app.json`, create.
+3. **Install to Workspace** and copy the **Bot User OAuth Token** (`xoxb-…`).
+4. From **Basic Information**, copy the **Signing Secret**.
+
+The manifest requests the scopes Tier 2 needs: `app_mentions:read`,
+`channels:history`, `groups:history`, `im:history`, `mpim:history`,
+`chat:write`, `chat:write.public`, `chat:write.customize`,
+`reactions:write`; and subscribes to `app_mention` plus `message.*`.
+
+> `chat:write.customize` is what makes per-session `identity` overrides
+> visible. Without it, Slack ignores the username/avatar and posts fall
+> through under the default bot identity.
+
+### 2. Configure the city
+
+Import the pack in your city's `pack.toml`:
+
+```toml
+[imports.slack-channel]
+source = "../packs/slack-channel"
+```
+
+Provide the adapter's environment:
+
+```sh
+SLACK_BOT_TOKEN=xoxb-...          # from step 1
+SLACK_SIGNING_SECRET=...          # from step 1
+SLACK_WORKSPACE_ID=T0123ABCD      # your Slack team id
+GC_CITY_NAME=<your-city-name>     # the gc city to bridge into
+GC_CITY_PATH=/path/to/your/city   # on-disk city root (for the registries)
+```
+
+`GC_CITY_PATH` is where the three registries live
+(`<GC_CITY_PATH>/.gc/slack-channel/`). Override the directory with
+`SLACK_CHANNEL_REGISTRY_DIR` if needed.
+
+### 3. Expose the events endpoint and start
+
+The adapter listens for Slack events on public TCP (`LISTEN_PUBLIC`,
+default `0.0.0.0:8775`). Terminate TLS in front of it and give Slack a
+public URL — [Tailscale Funnel](https://tailscale.com/kb/1223/funnel) is the
+easy path:
+
+```sh
+tailscale funnel 8775
+```
+
+Then in **Event Subscriptions**, set the Request URL to
+`https://<your-funnel-host>/slack/events`. Slack sends a one-time
+`url_verification` challenge, which the adapter answers automatically.
+
+gc supervises the adapter as a `proxy_process` service (named
+`slack-channel`); building the binary is a one-time `go build` in `adapter/`
+(see [Build](#build)). Start your city.
+
+## Usage walkthrough
+
+```sh
+# Bind a channel to the PL and reviewer sessions.
+gc slack-channel bind-room C0123 sess-pl sess-reviewer
+
+# Give the PL session its own identity (call once at session start).
+gc slack-channel identity --session sess-pl --as "Gas City PL" --avatar-emoji robot_face
+
+# Let humans address the mayor from any channel.
+gc slack-channel handle-alias --handle mayor --session sess-mayor
+
+# A human posts in C0123 → both bound sessions receive it. The PL replies
+# in-thread:
+gc slack-channel reply-current --body "on it — see PR #42" --thread-current
+
+# Drop a receipt on the message that just arrived.
+gc slack-channel react --emoji eyes
+
+# Unprompted status post into the bound channel.
+gc slack-channel publish --body "nightly build is green"
+```
+
+## Registries
+
+The adapter owns three on-disk registries under
+`<GC_CITY_PATH>/.gc/slack-channel/`. JSON Schemas live in [`schema/`](./schema):
+
+| File | Schema | Contents |
+| --- | --- | --- |
+| `channel_mappings.json` | [channel_mappings.schema.json](./schema/channel_mappings.schema.json) | channel → bound sessions |
+| `identities.json` | [identities.schema.json](./schema/identities.schema.json) | session → username/avatar |
+| `handle_aliases.json` | [handle_aliases.schema.json](./schema/handle_aliases.schema.json) | handle → session |
+
+The adapter is the only writer and reader; the verbs mutate them by POSTing
+to the adapter, never by touching the files directly.
+
+## Build
+
+The adapter is a small multi-file Go module with no external dependencies:
+
+```sh
+cd adapter
+go build -o gc-slack-channel-adapter ./...
+go test ./...
+```
+
+The built binary is git-ignored; the `[[service]]` block runs it in place.
+
+## Configuration reference
+
+| Variable | Required | Default | Purpose |
+| --- | :---: | --- | --- |
+| `SLACK_BOT_TOKEN` | ✓ | — | Bot token for `chat.postMessage` + `reactions.add`. |
+| `SLACK_SIGNING_SECRET` | ✓ | — | HMAC secret for verifying Slack requests. |
+| `SLACK_WORKSPACE_ID` | ✓ | — | Slack team id (extmsg account id + registry key). |
+| `GC_CITY_NAME` | ✓ | — | gc city to bridge into. |
+| `GC_CITY_PATH` | ✓* | — | City root; registry dir defaults under it. |
+| `SLACK_CHANNEL_REGISTRY_DIR` | | `<GC_CITY_PATH>/.gc/slack-channel` | Override the registry directory. |
+| `LISTEN_PUBLIC` | | `0.0.0.0:8775` | Public bind for `/slack/events` + `/slack/interactions`. |
+| `LISTEN_INTERNAL` | | `127.0.0.1:8776` | TCP bind for the verb endpoints when not a gc proxy_process. |
+| `REGISTER_ON_START` | | `true` | Self-register as an extmsg adapter on start. |
+| `SLACK_CHANNEL_INBOUND_TARGET` | | `mayor` | Fallback session for an unbound, unaliased `app_mention`. |
+| `SLACK_API_BASE` | | `https://slack.com/api` | Slack web API origin (override for relays/tests). |
+| `GC_API_BASE_URL` | | `http://127.0.0.1:9443` | gc API base. |
+
+\* Either `GC_CITY_PATH` or `SLACK_CHANNEL_REGISTRY_DIR` must be set so the
+registries have a home. `GC_SERVICE_SOCKET`, `GC_SERVICE_URL_PREFIX`, and
+`GC_API_BASE_URL` are injected by gc when the adapter runs as a
+`proxy_process` service.
+
+### Optional: interactive payloads
+
+To enable the basic modal-button ack, turn on **Interactivity** in the Slack
+app and point its Request URL at `https://<your-funnel-host>/slack/interactions`.
+The adapter verifies the signature and acks with `200` so Slack dismisses
+the interaction; it does no custom modal handling (that is Tier 3).
+
+## Choosing a tier
+
+- **slack-mini** (Tier 1) — one outbound verb, `app_mention` → mayor. No
+  registries.
+- **slack-channel** (Tier 2, this pack) — channel bindings, per-session
+  identity, handle aliases. Single workspace, single rig.
+- **slack-full** (Tier 3) — multi-rig routing, slash commands, peer fanout,
+  file upload, modal flows.
+
+The bot token, signing secret, and workspace id carry over unchanged when
+you move between tiers.

--- a/slack-channel/adapter/config.go
+++ b/slack-channel/adapter/config.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	defaultPublicListen   = "0.0.0.0:8775"
+	defaultInternalListen = "127.0.0.1:8776"
+	defaultGCAPIBase      = "http://127.0.0.1:9443"
+	defaultProvider       = "slack"
+	defaultInboundTarget  = "mayor"
+	defaultSlackAPIBase   = "https://slack.com/api"
+
+	// maxInboundBody caps the /slack/events body read. The body is
+	// unsigned until HMAC-verified, so bounding it pre-verify limits a
+	// memory-amplification vector. Slack event payloads are small.
+	maxInboundBody = 1 << 20 // 1 MiB
+
+	// slackReplayWindow rejects requests whose signed timestamp is older
+	// than this, mitigating replay of a captured signature.
+	slackReplayWindow = 5 * time.Minute
+
+	slackPostTimeout = 15 * time.Second
+
+	// gcCallTimeout bounds outbound calls to the gc API so a stalled gc
+	// cannot pin an inbound-bridge goroutine (or block startup
+	// registration) forever.
+	gcCallTimeout = 15 * time.Second
+)
+
+// config holds the adapter's resolved runtime configuration. It extends
+// slack-mini's Tier-1 config with the on-disk registry directory that
+// Tier 2 needs for channel bindings, per-session identities, and handle
+// aliases.
+type config struct {
+	publicListen        string
+	internalListen      string
+	serviceSocket       string
+	gcAPIBase           string
+	internalCallbackURL string
+	cityName            string
+	cityPath            string
+	registryDir         string
+	provider            string
+	workspaceID         string
+	botToken            string
+	signingSecret       string
+	inboundTarget       string
+	slackAPIBase        string
+	registerOnStart     bool
+}
+
+func (c config) channelMappingsPath() string {
+	return filepath.Join(c.registryDir, "channel_mappings.json")
+}
+
+func (c config) identitiesPath() string {
+	return filepath.Join(c.registryDir, "identities.json")
+}
+
+func (c config) handleAliasesPath() string {
+	return filepath.Join(c.registryDir, "handle_aliases.json")
+}
+
+// loadConfig reads the process environment.
+func loadConfig() (config, error) { return loadConfigFromEnv(os.Getenv) }
+
+// loadConfigFromEnv builds and validates a config from a getenv function.
+// Split out so tests can supply a fake environment.
+func loadConfigFromEnv(getenv func(string) string) (config, error) {
+	envOr := func(key, fallback string) string {
+		if v := getenv(key); v != "" {
+			return v
+		}
+		return fallback
+	}
+	cfg := config{
+		publicListen:    envOr("LISTEN_PUBLIC", defaultPublicListen),
+		internalListen:  envOr("LISTEN_INTERNAL", defaultInternalListen),
+		serviceSocket:   getenv("GC_SERVICE_SOCKET"),
+		gcAPIBase:       strings.TrimRight(envOr("GC_API_BASE_URL", defaultGCAPIBase), "/"),
+		cityName:        getenv("GC_CITY_NAME"),
+		cityPath:        getenv("GC_CITY_PATH"),
+		provider:        envOr("ADAPTER_PROVIDER", defaultProvider),
+		workspaceID:     getenv("SLACK_WORKSPACE_ID"),
+		botToken:        getenv("SLACK_BOT_TOKEN"),
+		signingSecret:   getenv("SLACK_SIGNING_SECRET"),
+		inboundTarget:   envOr("SLACK_CHANNEL_INBOUND_TARGET", defaultInboundTarget),
+		slackAPIBase:    strings.TrimRight(envOr("SLACK_API_BASE", defaultSlackAPIBase), "/"),
+		registerOnStart: envOr("REGISTER_ON_START", "true") == "true",
+	}
+
+	// The registry directory holds the three on-disk registries. It
+	// defaults to <GC_CITY_PATH>/.gc/slack-channel when GC_CITY_PATH is
+	// set; SLACK_CHANNEL_REGISTRY_DIR overrides it outright (tests, or a
+	// deployment that stores state elsewhere).
+	cfg.registryDir = getenv("SLACK_CHANNEL_REGISTRY_DIR")
+	if cfg.registryDir == "" && cfg.cityPath != "" {
+		cfg.registryDir = filepath.Join(cfg.cityPath, ".gc", "slack-channel")
+	}
+
+	// proxy_process mode: gc reaches the adapter via GC_API_BASE_URL +
+	// GC_SERVICE_URL_PREFIX. gc appends the endpoint path itself, so the
+	// registered callback base must not include it.
+	if cfg.serviceSocket != "" {
+		urlPrefix := strings.TrimRight(getenv("GC_SERVICE_URL_PREFIX"), "/")
+		if urlPrefix == "" {
+			return cfg, errors.New("GC_SERVICE_SOCKET is set but GC_SERVICE_URL_PREFIX is empty — controller-injected env is incomplete")
+		}
+		cfg.internalCallbackURL = cfg.gcAPIBase + urlPrefix
+	}
+
+	var missing []string
+	if cfg.workspaceID == "" {
+		missing = append(missing, "SLACK_WORKSPACE_ID")
+	}
+	if cfg.botToken == "" {
+		missing = append(missing, "SLACK_BOT_TOKEN")
+	}
+	if cfg.signingSecret == "" {
+		missing = append(missing, "SLACK_SIGNING_SECRET")
+	}
+	if cfg.cityName == "" {
+		missing = append(missing, "GC_CITY_NAME")
+	}
+	if len(missing) > 0 {
+		return cfg, fmt.Errorf("missing required env vars: %s", strings.Join(missing, ", "))
+	}
+	// Tier 2 keeps on-disk registries, so it needs a place to put them.
+	// Require either GC_CITY_PATH (the normal gc-supervised path) or an
+	// explicit override rather than silently writing to the CWD.
+	if cfg.registryDir == "" {
+		return cfg, errors.New("registry directory is unset: set GC_CITY_PATH (preferred) or SLACK_CHANNEL_REGISTRY_DIR")
+	}
+	// cityName is interpolated into every /v0/city/{city}/... URL. Reject
+	// URL-significant characters so a city name cannot alter routing.
+	if strings.ContainsAny(cfg.cityName, "/?#%") {
+		return cfg, fmt.Errorf("GC_CITY_NAME must not contain '/', '?', '#', or '%%': %q", cfg.cityName)
+	}
+	return cfg, nil
+}

--- a/slack-channel/adapter/config_test.go
+++ b/slack-channel/adapter/config_test.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadConfigFromEnv(t *testing.T) {
+	base := map[string]string{
+		"SLACK_BOT_TOKEN":      "xoxb-1",
+		"SLACK_SIGNING_SECRET": "secret",
+		"SLACK_WORKSPACE_ID":   "T123",
+		"GC_CITY_NAME":         "mycity",
+		"GC_CITY_PATH":         "/srv/mycity",
+	}
+	clone := func(extra map[string]string) func(string) string {
+		m := map[string]string{}
+		for k, v := range base {
+			m[k] = v
+		}
+		for k, v := range extra {
+			if v == "" {
+				delete(m, k)
+			} else {
+				m[k] = v
+			}
+		}
+		return func(k string) string { return m[k] }
+	}
+
+	t.Run("defaults", func(t *testing.T) {
+		cfg, err := loadConfigFromEnv(clone(nil))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.publicListen != defaultPublicListen {
+			t.Errorf("publicListen = %q, want default", cfg.publicListen)
+		}
+		if cfg.inboundTarget != defaultInboundTarget {
+			t.Errorf("inboundTarget = %q, want %q", cfg.inboundTarget, defaultInboundTarget)
+		}
+		if !cfg.registerOnStart {
+			t.Error("registerOnStart should default true")
+		}
+		want := filepath.Join("/srv/mycity", ".gc", "slack-channel")
+		if cfg.registryDir != want {
+			t.Errorf("registryDir = %q, want %q", cfg.registryDir, want)
+		}
+		if cfg.channelMappingsPath() != filepath.Join(want, "channel_mappings.json") {
+			t.Errorf("channelMappingsPath = %q", cfg.channelMappingsPath())
+		}
+		if cfg.identitiesPath() != filepath.Join(want, "identities.json") {
+			t.Errorf("identitiesPath = %q", cfg.identitiesPath())
+		}
+		if cfg.handleAliasesPath() != filepath.Join(want, "handle_aliases.json") {
+			t.Errorf("handleAliasesPath = %q", cfg.handleAliasesPath())
+		}
+	})
+
+	t.Run("registry dir override wins over city path", func(t *testing.T) {
+		cfg, err := loadConfigFromEnv(clone(map[string]string{"SLACK_CHANNEL_REGISTRY_DIR": "/var/state/sc"}))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.registryDir != "/var/state/sc" {
+			t.Errorf("registryDir = %q, want override", cfg.registryDir)
+		}
+	})
+
+	t.Run("registry dir from override without city path", func(t *testing.T) {
+		cfg, err := loadConfigFromEnv(clone(map[string]string{
+			"GC_CITY_PATH":               "",
+			"SLACK_CHANNEL_REGISTRY_DIR": "/var/state/sc",
+		}))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.registryDir != "/var/state/sc" {
+			t.Errorf("registryDir = %q", cfg.registryDir)
+		}
+	})
+
+	t.Run("missing registry dir errors", func(t *testing.T) {
+		_, err := loadConfigFromEnv(clone(map[string]string{"GC_CITY_PATH": ""}))
+		if err == nil || !strings.Contains(err.Error(), "registry directory") {
+			t.Fatalf("expected registry-dir error, got %v", err)
+		}
+	})
+
+	t.Run("missing required", func(t *testing.T) {
+		_, err := loadConfigFromEnv(clone(map[string]string{"GC_CITY_NAME": ""}))
+		if err == nil || !strings.Contains(err.Error(), "GC_CITY_NAME") {
+			t.Fatalf("expected missing GC_CITY_NAME error, got %v", err)
+		}
+	})
+
+	t.Run("city name with slash rejected", func(t *testing.T) {
+		_, err := loadConfigFromEnv(clone(map[string]string{"GC_CITY_NAME": "a/b"}))
+		if err == nil || !strings.Contains(err.Error(), "must not contain") {
+			t.Fatalf("expected city-name rejection, got %v", err)
+		}
+	})
+
+	t.Run("proxy_process requires url prefix", func(t *testing.T) {
+		_, err := loadConfigFromEnv(clone(map[string]string{"GC_SERVICE_SOCKET": "/tmp/s.sock"}))
+		if err == nil || !strings.Contains(err.Error(), "GC_SERVICE_URL_PREFIX") {
+			t.Fatalf("expected url-prefix error, got %v", err)
+		}
+	})
+
+	t.Run("proxy_process callback url", func(t *testing.T) {
+		cfg, err := loadConfigFromEnv(clone(map[string]string{
+			"GC_SERVICE_SOCKET":     "/tmp/s.sock",
+			"GC_SERVICE_URL_PREFIX": "/v0/city/mycity/svc/slack-channel/",
+			"GC_API_BASE_URL":       "http://127.0.0.1:8372",
+		}))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := "http://127.0.0.1:8372/v0/city/mycity/svc/slack-channel"
+		if cfg.internalCallbackURL != want {
+			t.Errorf("internalCallbackURL = %q, want %q", cfg.internalCallbackURL, want)
+		}
+	})
+
+	t.Run("slack api base trimmed", func(t *testing.T) {
+		cfg, err := loadConfigFromEnv(clone(map[string]string{"SLACK_API_BASE": "https://relay.example/api/"}))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.slackAPIBase != "https://relay.example/api" {
+			t.Errorf("slackAPIBase = %q, want trimmed", cfg.slackAPIBase)
+		}
+	})
+}

--- a/slack-channel/adapter/gcclient.go
+++ b/slack-channel/adapter/gcclient.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// postInbound bridges a verified Slack message into gc's extmsg inbound.
+func (s *server) postInbound(ctx context.Context, msg externalInboundMessage) error {
+	body, err := json.Marshal(map[string]any{"message": msg})
+	if err != nil {
+		return err
+	}
+	target := fmt.Sprintf("%s/v0/city/%s/extmsg/inbound", s.cfg.gcAPIBase, url.PathEscape(s.cfg.cityName))
+	if err := s.postJSON(ctx, target, body); err != nil {
+		return fmt.Errorf("post inbound: %w", err)
+	}
+	return nil
+}
+
+// registerAdapter self-registers as an extmsg adapter so gc accepts this
+// provider's inbound messages.
+func (s *server) registerAdapter(ctx context.Context) error {
+	body, err := json.Marshal(adapterRegisterRequest{
+		Provider:    s.cfg.provider,
+		AccountID:   s.cfg.workspaceID,
+		Name:        "slack-channel-adapter",
+		CallbackURL: s.cfg.internalCallbackURL,
+		Capabilities: adapterCapabilities{
+			SupportsChildConversations: false,
+			SupportsAttachments:        false,
+			MaxMessageLength:           40000, // Slack's chat.postMessage limit
+		},
+	})
+	if err != nil {
+		return err
+	}
+	target := fmt.Sprintf("%s/v0/city/%s/extmsg/adapters", s.cfg.gcAPIBase, url.PathEscape(s.cfg.cityName))
+	return s.postJSON(ctx, target, body)
+}
+
+// postJSON POSTs a JSON body to a gc API endpoint and treats any >=400
+// status as an error, surfacing the response body for diagnostics. ctx
+// bounds the call so callers can enforce a timeout.
+func (s *server) postJSON(ctx context.Context, target string, body []byte) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, target, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-GC-Request", "gc-slack-channel-adapter")
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 400 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("%s: %s", resp.Status, strings.TrimSpace(string(respBody)))
+	}
+	return nil
+}

--- a/slack-channel/adapter/gcclient_test.go
+++ b/slack-channel/adapter/gcclient_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestRegisterAdapter(t *testing.T) {
+	srv := newTestServer(t)
+	var got adapterRegisterRequest
+	gc := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/extmsg/adapters") {
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+		_ = json.NewDecoder(r.Body).Decode(&got)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer gc.Close()
+	srv.cfg.gcAPIBase = gc.URL
+
+	if err := srv.registerAdapter(context.Background()); err != nil {
+		t.Fatalf("registerAdapter: %v", err)
+	}
+	if got.Provider != "slack" || got.AccountID != "T123" {
+		t.Errorf("register payload = %+v", got)
+	}
+	if got.Capabilities.SupportsChildConversations {
+		t.Error("Tier 2 must not advertise child conversations")
+	}
+}
+
+func TestPostJSONSurfacesErrorStatus(t *testing.T) {
+	srv := newTestServer(t)
+	gc := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = io.WriteString(w, "nope")
+	}))
+	defer gc.Close()
+	if err := srv.postJSON(context.Background(), gc.URL, []byte(`{}`)); err == nil || !strings.Contains(err.Error(), "nope") {
+		t.Fatalf("expected error surfacing body, got %v", err)
+	}
+}

--- a/slack-channel/adapter/go.mod
+++ b/slack-channel/adapter/go.mod
@@ -1,0 +1,3 @@
+module github.com/sjarmak/gc-slack-channel-adapter
+
+go 1.25.9

--- a/slack-channel/adapter/httputil.go
+++ b/slack-channel/adapter/httputil.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+func handleHealthz(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("ok\n"))
+}
+
+func writeJSONError(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]any{"ok": false, "error": msg})
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}

--- a/slack-channel/adapter/inbound.go
+++ b/slack-channel/adapter/inbound.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"sync"
+)
+
+// handleSlackEvents verifies and acks Slack Events API deliveries, then
+// routes each verified message in its own goroutine. It answers the
+// one-time url_verification handshake inline.
+func (s *server) handleSlackEvents() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		body, err := io.ReadAll(io.LimitReader(r.Body, maxInboundBody))
+		if err != nil {
+			http.Error(w, "read body", http.StatusBadRequest)
+			return
+		}
+		ts := r.Header.Get("X-Slack-Request-Timestamp")
+		sig := r.Header.Get("X-Slack-Signature")
+		if !verifySlackSignature(s.cfg.signingSecret, ts, body, sig) {
+			log.Printf("slack signature verify FAILED")
+			http.Error(w, "invalid signature", http.StatusUnauthorized)
+			return
+		}
+
+		var env slackEventEnvelope
+		if err := json.Unmarshal(body, &env); err != nil {
+			http.Error(w, fmt.Sprintf("decode: %v", err), http.StatusBadRequest)
+			return
+		}
+
+		if env.Type == "url_verification" && env.Challenge != "" {
+			w.Header().Set("Content-Type", "text/plain")
+			_, _ = w.Write([]byte(env.Challenge))
+			return
+		}
+
+		// Ack immediately so Slack does not retry, then route.
+		w.WriteHeader(http.StatusOK)
+		go s.routeEvent(env)
+	}
+}
+
+// routeEvent decodes a Slack event and fans it out to the gc sessions that
+// should receive it. Tier 2 widens Tier 1's app_mention-only path to plain
+// message.* events delivered in bound channels:
+//
+//   - A message in a channel with a binding → every bound session.
+//   - A message whose body leads with "@handle[:]" matching a registered
+//     alias → the aliased session (with the handle token stripped),
+//     regardless of binding.
+//   - An app_mention in a channel with neither a binding nor a matching
+//     alias → the default inbound target (preserving Tier 1's "talk to
+//     mayor from any channel").
+//   - A plain message with no binding and no alias → dropped (Tier 2 does
+//     not firehose every channel message at the mayor).
+//
+// Bot, system, and edited messages are dropped to avoid echo loops.
+func (s *server) routeEvent(env slackEventEnvelope) {
+	if env.Type != "event_callback" || len(env.Event) == 0 {
+		return
+	}
+	var msg slackMessageEvent
+	if err := json.Unmarshal(env.Event, &msg); err != nil {
+		log.Printf("decode slack event: %v", err)
+		return
+	}
+	if msg.Type != "app_mention" && msg.Type != "message" {
+		return
+	}
+	if msg.BotID != "" || msg.Subtype != "" || msg.User == "" {
+		return
+	}
+
+	baseText := msg.Text
+	if msg.Type == "app_mention" {
+		baseText = stripLeadingMention(msg.Text)
+	}
+
+	// targets maps a destination session to the text it should receive.
+	// A later rule overwrites an earlier one for the same session, so an
+	// explicit alias address wins over a plain channel-binding delivery.
+	targets := map[string]string{}
+	if binding, ok := s.bindingForChannel(msg.Channel); ok {
+		for _, sid := range binding.SessionIDs {
+			targets[sid] = baseText
+		}
+	}
+	if handle, rest := parseLeadingHandle(baseText); handle != "" {
+		if alias, ok := s.aliasFor(handle); ok && alias.SessionID != "" {
+			targets[alias.SessionID] = rest
+		}
+	}
+	if len(targets) == 0 && msg.Type == "app_mention" {
+		targets[s.cfg.inboundTarget] = baseText
+	}
+	if len(targets) == 0 {
+		return
+	}
+
+	// Deliver to all targets concurrently: the gc POSTs are independent
+	// (distinct explicit_target + dedup_key) and each is bounded by
+	// gcCallTimeout, so a slow gc bounds total fan-out latency to ~one
+	// timeout rather than N×timeout for an N-session binding.
+	kind := slackKindFromChannelType(msg.ChannelType, msg.Channel)
+	var wg sync.WaitGroup
+	for sid, text := range targets {
+		if strings.TrimSpace(text) == "" {
+			continue
+		}
+		wg.Add(1)
+		go func(target, body string) {
+			defer wg.Done()
+			s.deliverInbound(msg, target, body, kind)
+		}(sid, text)
+	}
+	wg.Wait()
+}
+
+// deliverInbound POSTs one extmsg inbound addressed to target and records
+// it as the session's latest inbound for reply-current/react. The DedupKey
+// is per-target so the same Slack message fanned out to N sessions is not
+// collapsed into one by gc's dedup.
+func (s *server) deliverInbound(msg slackMessageEvent, target, text, kind string) {
+	threadTS := msg.ThreadTS
+	if threadTS == "" {
+		threadTS = msg.TS
+	}
+	inbound := externalInboundMessage{
+		ProviderMessageID: msg.TS,
+		Conversation: conversationRef{
+			ScopeID:        s.cfg.cityName,
+			Provider:       s.cfg.provider,
+			AccountID:      s.cfg.workspaceID,
+			ConversationID: msg.Channel,
+			Kind:           kind,
+		},
+		Actor: externalActor{
+			ID:          msg.User,
+			DisplayName: msg.User, // resolving a display name needs users.info — out of Tier 2 scope
+		},
+		Text:             text,
+		ExplicitTarget:   target,
+		ReplyToMessageID: msg.ThreadTS,
+		DedupKey:         "slack-" + msg.TS + "-" + target,
+		ReceivedAt:       s.now().UTC(),
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), gcCallTimeout)
+	defer cancel()
+	if err := s.postInbound(ctx, inbound); err != nil {
+		log.Printf("inbound POST failed (target=%s): %v", target, err)
+		return
+	}
+	s.recordInbound(target, inboundRef{
+		channelID: msg.Channel,
+		messageTS: msg.TS,
+		threadTS:  threadTS,
+	})
+	log.Printf("inbound: chan=%s user=%s ts=%s target=%s text=%dch",
+		msg.Channel, msg.User, msg.TS, target, len(text))
+}

--- a/slack-channel/adapter/inbound_test.go
+++ b/slack-channel/adapter/inbound_test.go
@@ -1,0 +1,208 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// inboundCollector stands in for gc's extmsg inbound endpoint, recording
+// every delivered message keyed by explicit_target.
+type inboundCollector struct {
+	srv *httptest.Server
+	mu  sync.Mutex
+	got map[string]externalInboundMessage
+	all []externalInboundMessage
+}
+
+func newInboundCollector(t *testing.T, s *server) *inboundCollector {
+	t.Helper()
+	c := &inboundCollector{got: map[string]externalInboundMessage{}}
+	c.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/extmsg/inbound") {
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+		var wrap struct {
+			Message externalInboundMessage `json:"message"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&wrap); err != nil {
+			t.Errorf("decode inbound: %v", err)
+		}
+		c.mu.Lock()
+		c.got[wrap.Message.ExplicitTarget] = wrap.Message
+		c.all = append(c.all, wrap.Message)
+		c.mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(c.srv.Close)
+	s.cfg.gcAPIBase = c.srv.URL
+	return c
+}
+
+func routeMessage(s *server, ev slackMessageEvent) {
+	raw, _ := json.Marshal(ev)
+	s.routeEvent(slackEventEnvelope{Type: "event_callback", Event: raw})
+}
+
+func TestRouteEventBoundFanOut(t *testing.T) {
+	srv := newTestServer(t)
+	c := newInboundCollector(t, srv)
+	mustBind(t, srv, "C1", "room", "s1", "s2")
+
+	routeMessage(srv, slackMessageEvent{Type: "message", User: "U9", Text: "deploy please", Channel: "C1", TS: "1700.1"})
+
+	if len(c.all) != 2 {
+		t.Fatalf("want 2 deliveries (one per bound session), got %d", len(c.all))
+	}
+	for _, sid := range []string{"s1", "s2"} {
+		msg, ok := c.got[sid]
+		if !ok {
+			t.Fatalf("no delivery to %s", sid)
+		}
+		if msg.Text != "deploy please" {
+			t.Errorf("%s text = %q, want full body", sid, msg.Text)
+		}
+		if msg.DedupKey != "slack-1700.1-"+sid {
+			t.Errorf("%s dedup_key = %q, want per-target", sid, msg.DedupKey)
+		}
+		if msg.Conversation.ConversationID != "C1" || msg.Conversation.Kind != "room" {
+			t.Errorf("%s conversation = %+v", sid, msg.Conversation)
+		}
+	}
+	// last-inbound recorded for reply-current/react.
+	if ref, ok := srv.latestInbound("s1"); !ok || ref.channelID != "C1" || ref.messageTS != "1700.1" {
+		t.Errorf("latestInbound(s1) = %+v ok=%v", ref, ok)
+	}
+}
+
+func TestRouteEventAppMentionStripsInBoundChannel(t *testing.T) {
+	srv := newTestServer(t)
+	c := newInboundCollector(t, srv)
+	mustBind(t, srv, "C1", "room", "s1")
+
+	routeMessage(srv, slackMessageEvent{Type: "app_mention", User: "U9", Text: "<@U0BOT> status?", Channel: "C1", TS: "1700.2"})
+
+	if msg, ok := c.got["s1"]; !ok || msg.Text != "status?" {
+		t.Errorf("app_mention to bound session = %q (ok=%v), want stripped 'status?'", msg.Text, ok)
+	}
+}
+
+func TestRouteEventAliasRouting(t *testing.T) {
+	srv := newTestServer(t)
+	c := newInboundCollector(t, srv)
+	if _, err := srv.upsertHandleAlias("mayor", "sess-m"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Unbound channel; alias address routes to the aliased session.
+	routeMessage(srv, slackMessageEvent{Type: "message", User: "U9", Text: "@mayor: ship it", Channel: "C9", TS: "1700.3"})
+
+	if len(c.all) != 1 {
+		t.Fatalf("want 1 delivery, got %d", len(c.all))
+	}
+	if msg, ok := c.got["sess-m"]; !ok || msg.Text != "ship it" {
+		t.Errorf("alias delivery = %q (ok=%v), want stripped 'ship it'", msg.Text, ok)
+	}
+}
+
+func TestRouteEventAliasOverridesBoundText(t *testing.T) {
+	srv := newTestServer(t)
+	c := newInboundCollector(t, srv)
+	mustBind(t, srv, "C1", "room", "s1")
+	if _, err := srv.upsertHandleAlias("mayor", "sess-m"); err != nil {
+		t.Fatal(err)
+	}
+
+	routeMessage(srv, slackMessageEvent{Type: "message", User: "U9", Text: "@mayor: hi team", Channel: "C1", TS: "1700.4"})
+
+	if len(c.all) != 2 {
+		t.Fatalf("want 2 deliveries (bound + alias), got %d", len(c.all))
+	}
+	if msg := c.got["s1"]; msg.Text != "@mayor: hi team" {
+		t.Errorf("bound session text = %q, want full body", msg.Text)
+	}
+	if msg := c.got["sess-m"]; msg.Text != "hi team" {
+		t.Errorf("alias session text = %q, want stripped", msg.Text)
+	}
+}
+
+func TestRouteEventAppMentionFallback(t *testing.T) {
+	srv := newTestServer(t)
+	c := newInboundCollector(t, srv)
+
+	// Unbound, unaliased app_mention falls back to the default target.
+	routeMessage(srv, slackMessageEvent{Type: "app_mention", User: "U9", Text: "<@U0BOT> hello", Channel: "C9", TS: "1700.5"})
+
+	if msg, ok := c.got["mayor"]; !ok || msg.Text != "hello" {
+		t.Errorf("fallback delivery = %q (ok=%v), want 'hello' to mayor", msg.Text, ok)
+	}
+}
+
+func TestRouteEventDrops(t *testing.T) {
+	srv := newTestServer(t)
+	c := newInboundCollector(t, srv)
+	mustBind(t, srv, "C1", "room", "s1")
+
+	drops := []struct {
+		name string
+		ev   slackMessageEvent
+	}{
+		{"plain message unbound channel", slackMessageEvent{Type: "message", User: "U9", Text: "hi", Channel: "C9", TS: "1"}},
+		{"bot message", slackMessageEvent{Type: "message", BotID: "B1", Text: "hi", Channel: "C1", TS: "1"}},
+		{"subtype edit", slackMessageEvent{Type: "message", Subtype: "message_changed", User: "U9", Text: "hi", Channel: "C1", TS: "1"}},
+		{"empty user", slackMessageEvent{Type: "message", Text: "hi", Channel: "C1", TS: "1"}},
+		{"unknown type", slackMessageEvent{Type: "reaction_added", User: "U9", Channel: "C1", TS: "1"}},
+		{"empty after strip", slackMessageEvent{Type: "app_mention", User: "U9", Text: "<@U0BOT>", Channel: "C1", TS: "1"}},
+	}
+	for _, tc := range drops {
+		t.Run(tc.name, func(t *testing.T) {
+			before := len(c.all)
+			routeMessage(srv, tc.ev)
+			if len(c.all) != before {
+				t.Errorf("%s: expected drop, but a delivery was made", tc.name)
+			}
+		})
+	}
+}
+
+func TestHandleSlackEventsURLVerification(t *testing.T) {
+	srv := newTestServer(t)
+	body := []byte(`{"type":"url_verification","challenge":"c4tt0ken"}`)
+	ts := strconv.FormatInt(time.Now().Unix(), 10)
+
+	req := httptest.NewRequest(http.MethodPost, "/slack/events", strings.NewReader(string(body)))
+	req.Header.Set("X-Slack-Request-Timestamp", ts)
+	req.Header.Set("X-Slack-Signature", signSlack(srv.cfg.signingSecret, ts, body))
+	rec := httptest.NewRecorder()
+
+	srv.handleSlackEvents()(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got := strings.TrimSpace(rec.Body.String()); got != "c4tt0ken" {
+		t.Fatalf("challenge echo = %q", got)
+	}
+}
+
+func TestHandleSlackEventsBadSignature(t *testing.T) {
+	srv := newTestServer(t)
+	body := []byte(`{"type":"event_callback"}`)
+	ts := strconv.FormatInt(time.Now().Unix(), 10)
+
+	req := httptest.NewRequest(http.MethodPost, "/slack/events", strings.NewReader(string(body)))
+	req.Header.Set("X-Slack-Request-Timestamp", ts)
+	req.Header.Set("X-Slack-Signature", "v0=deadbeef")
+	rec := httptest.NewRecorder()
+
+	srv.handleSlackEvents()(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+}

--- a/slack-channel/adapter/integration_test.go
+++ b/slack-channel/adapter/integration_test.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestSmokeVerbRoundTrip is the acceptance smoke test: it runs the real
+// bash verb wrappers against a live adapter (internal mux over TCP) with
+// fake Slack + gc backends, then drives an inbound event through the public
+// mux. It exercises the full Tier-2 loop:
+//
+//	bind-room  → channel bound to a session
+//	inbound    → bound session receives bridge-mail (via fake gc)
+//	publish    → message lands in the channel (via fake Slack)
+//	react      → reaction on the latest inbound message
+//
+// It needs sh/jq/curl on PATH; it skips cleanly when they are absent.
+func TestSmokeVerbRoundTrip(t *testing.T) {
+	for _, bin := range []string{"sh", "jq", "curl"} {
+		if _, err := exec.LookPath(bin); err != nil {
+			t.Skipf("%s not on PATH; skipping verb smoke test", bin)
+		}
+	}
+
+	// Fake Slack: records chat.postMessage + reactions.add, always OK.
+	var slackMu sync.Mutex
+	var posts []slackPostMessageReq
+	var reactions []slackReactionsAddReq
+	slack := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		slackMu.Lock()
+		defer slackMu.Unlock()
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/chat.postMessage"):
+			var req slackPostMessageReq
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			posts = append(posts, req)
+			_ = json.NewEncoder(w).Encode(slackPostMessageResp{OK: true, TS: "200.1", Channel: req.Channel})
+		case strings.HasSuffix(r.URL.Path, "/reactions.add"):
+			var req slackReactionsAddReq
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			reactions = append(reactions, req)
+			_ = json.NewEncoder(w).Encode(slackReactionsAddResp{OK: true})
+		default:
+			t.Errorf("unexpected slack path %s", r.URL.Path)
+		}
+	}))
+	defer slack.Close()
+
+	// Fake gc: records extmsg inbound deliveries.
+	var gcMu sync.Mutex
+	var inbound []externalInboundMessage
+	gc := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var wrap struct {
+			Message externalInboundMessage `json:"message"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&wrap)
+		gcMu.Lock()
+		inbound = append(inbound, wrap.Message)
+		gcMu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer gc.Close()
+
+	cfg := config{
+		cityName:      "smokecity",
+		provider:      "slack",
+		workspaceID:   "T123",
+		botToken:      "xoxb-smoke",
+		signingSecret: "smoke-secret",
+		inboundTarget: "mayor",
+		slackAPIBase:  slack.URL,
+		gcAPIBase:     gc.URL,
+		registryDir:   t.TempDir(),
+	}
+	srv, err := newServer(cfg)
+	if err != nil {
+		t.Fatalf("newServer: %v", err)
+	}
+
+	internalMux := http.NewServeMux()
+	internalMux.HandleFunc("POST /publish", srv.handlePublish())
+	internalMux.HandleFunc("POST /publish-to-channel", srv.handlePublishToChannel())
+	internalMux.HandleFunc("POST /reply-current", srv.handleReplyCurrent())
+	internalMux.HandleFunc("POST /react", srv.handleReact())
+	internalMux.HandleFunc("POST /bindings", srv.handleBind())
+	internal := httptest.NewServer(internalMux)
+	defer internal.Close()
+
+	publicMux := http.NewServeMux()
+	publicMux.HandleFunc("/slack/events", srv.handleSlackEvents())
+	public := httptest.NewServer(publicMux)
+	defer public.Close()
+
+	commandsDir, err := filepath.Abs("../commands")
+	if err != nil {
+		t.Fatal(err)
+	}
+	runVerb := func(verb string, args ...string) (string, error) {
+		cmd := exec.Command("sh", append([]string{filepath.Join(commandsDir, verb+".sh")}, args...)...)
+		cmd.Env = append(os.Environ(),
+			"GC_CITY_NAME=smokecity",
+			"GC_SESSION_ID=sess-pl",
+			"SLACK_CHANNEL_ADAPTER_URL="+internal.URL,
+		)
+		out, err := cmd.CombinedOutput()
+		return string(out), err
+	}
+
+	// 1. bind-room: bind C1 to sess-pl.
+	if out, err := runVerb("bind-room", "C1", "sess-pl"); err != nil {
+		t.Fatalf("bind-room failed: %v\n%s", err, out)
+	}
+	if _, ok := srv.bindingForChannel("C1"); !ok {
+		t.Fatal("binding not persisted by bind-room verb")
+	}
+
+	// 2. inbound: a human posts in C1 → sess-pl receives bridge-mail.
+	ev := slackMessageEvent{Type: "message", User: "U9", Text: "status?", Channel: "C1", TS: "100.1"}
+	raw, _ := json.Marshal(slackEventEnvelope{Type: "event_callback", Event: mustJSON(ev)})
+	ts := strconv.FormatInt(time.Now().Unix(), 10)
+	req, _ := http.NewRequest(http.MethodPost, public.URL+"/slack/events", strings.NewReader(string(raw)))
+	req.Header.Set("X-Slack-Request-Timestamp", ts)
+	req.Header.Set("X-Slack-Signature", signSlack(cfg.signingSecret, ts, raw))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("inbound POST: %v", err)
+	}
+	_ = resp.Body.Close()
+	waitFor(t, func() bool {
+		gcMu.Lock()
+		defer gcMu.Unlock()
+		return len(inbound) == 1 && inbound[0].ExplicitTarget == "sess-pl" && inbound[0].Text == "status?"
+	}, "bound session did not receive inbound bridge-mail")
+
+	// 3. publish: sess-pl publishes back into its bound channel.
+	if out, err := runVerb("publish", "--body", "build is green"); err != nil {
+		t.Fatalf("publish failed: %v\n%s", err, out)
+	}
+	slackMu.Lock()
+	if len(posts) != 1 || posts[0].Channel != "C1" || posts[0].Text != "build is green" {
+		t.Errorf("publish did not land in channel: %+v", posts)
+	}
+	slackMu.Unlock()
+
+	// 4. react: reaction on the latest inbound message ts.
+	if out, err := runVerb("react", "--emoji", "white_check_mark"); err != nil {
+		t.Fatalf("react failed: %v\n%s", err, out)
+	}
+	slackMu.Lock()
+	if len(reactions) != 1 || reactions[0].Timestamp != "100.1" || reactions[0].Name != "white_check_mark" {
+		t.Errorf("react did not target latest inbound: %+v", reactions)
+	}
+	slackMu.Unlock()
+}
+
+func mustJSON(v any) []byte {
+	b, _ := json.Marshal(v)
+	return b
+}
+
+func waitFor(t *testing.T, cond func() bool, msg string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal(msg)
+}

--- a/slack-channel/adapter/interactions.go
+++ b/slack-channel/adapter/interactions.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"io"
+	"log"
+	"net/http"
+)
+
+// handleInteractions acks Slack interactive payloads (block buttons, modal
+// submits). Tier 2 does no custom interaction handling — it verifies the
+// signature and returns 200 so Slack dismisses the interaction without
+// retrying. Custom modal flows are Tier 3.
+//
+// Interactive payloads arrive as application/x-www-form-urlencoded with a
+// `payload` field; the Slack signature is computed over the raw request
+// body, so we verify the bytes as-read before doing anything else.
+func (s *server) handleInteractions() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		body, err := io.ReadAll(io.LimitReader(r.Body, maxInboundBody))
+		if err != nil {
+			http.Error(w, "read body", http.StatusBadRequest)
+			return
+		}
+		ts := r.Header.Get("X-Slack-Request-Timestamp")
+		sig := r.Header.Get("X-Slack-Signature")
+		if !verifySlackSignature(s.cfg.signingSecret, ts, body, sig) {
+			log.Printf("slack interaction signature verify FAILED")
+			http.Error(w, "invalid signature", http.StatusUnauthorized)
+			return
+		}
+		log.Printf("interaction acked (%d bytes)", len(body))
+		w.WriteHeader(http.StatusOK)
+	}
+}

--- a/slack-channel/adapter/interactions_test.go
+++ b/slack-channel/adapter/interactions_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestHandleInteractionsAck(t *testing.T) {
+	srv := newTestServer(t)
+	body := []byte("payload=%7B%22type%22%3A%22block_actions%22%7D")
+	ts := strconv.FormatInt(time.Now().Unix(), 10)
+
+	req := httptest.NewRequest(http.MethodPost, "/slack/interactions", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("X-Slack-Request-Timestamp", ts)
+	req.Header.Set("X-Slack-Signature", signSlack(srv.cfg.signingSecret, ts, body))
+	rec := httptest.NewRecorder()
+
+	srv.handleInteractions()(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+}
+
+func TestHandleInteractionsBadSignature(t *testing.T) {
+	srv := newTestServer(t)
+	req := httptest.NewRequest(http.MethodPost, "/slack/interactions", strings.NewReader("payload=%7B%7D"))
+	req.Header.Set("X-Slack-Request-Timestamp", strconv.FormatInt(time.Now().Unix(), 10))
+	req.Header.Set("X-Slack-Signature", "v0=deadbeef")
+	rec := httptest.NewRecorder()
+
+	srv.handleInteractions()(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+}
+
+func TestHandleHealthz(t *testing.T) {
+	rec := httptest.NewRecorder()
+	handleHealthz(rec, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+	if rec.Code != http.StatusOK || strings.TrimSpace(rec.Body.String()) != "ok" {
+		t.Fatalf("healthz = %d %q", rec.Code, rec.Body.String())
+	}
+}
+
+func TestListenUDS(t *testing.T) {
+	path := t.TempDir() + "/adapter.sock"
+	lis, err := listenUDS(path)
+	if err != nil {
+		t.Fatalf("listenUDS: %v", err)
+	}
+	_ = lis.Close()
+	// A stale socket file must not block a restart.
+	lis2, err := listenUDS(path)
+	if err != nil {
+		t.Fatalf("listenUDS over stale: %v", err)
+	}
+	_ = lis2.Close()
+}

--- a/slack-channel/adapter/main.go
+++ b/slack-channel/adapter/main.go
@@ -1,0 +1,200 @@
+// gc-slack-channel-adapter — the Tier-2 ("slack-channel") Slack ↔ gc bridge.
+//
+// slack-channel is the "team channel ↔ session graph" middle tier. It is
+// built on slack-mini's single-file kernel (HMAC-verified Events API
+// receiver + chat.postMessage outbound) and adds the state slack-mini
+// deliberately omits:
+//
+//   - Channel binding registry (channel_mappings.json): a Slack channel or
+//     DM bound to one or more gc sessions. A non-mention message in a bound
+//     channel is delivered to every bound session — Tier 1 only handled
+//     app_mention.
+//   - Identity registry (identities.json): a per-session username/avatar
+//     override injected into chat.postMessage (chat:write.customize).
+//   - Handle aliases (handle_aliases.json): "@handle[:]" address-by-handle
+//     routing to a session from any channel.
+//
+// The adapter is the single owner of all three registries: verb wrappers
+// POST to it over gc's /svc/slack-channel reverse proxy (no operator CLI
+// binary, no direct file writes from bash), and the inbound path reads them
+// under a lock.
+//
+// Tier 2 explicitly EXCLUDES (those are slack-full / Tier 3): multi-rig
+// routing, channel-name pattern resolvers, room-launch, the apps registry +
+// slash-command intake, peer fanout, file upload, and double-handle
+// dispatch.
+//
+// Required env:
+//
+//	SLACK_BOT_TOKEN        Bot token (xoxb-...) for chat.postMessage +
+//	                       reactions.add.
+//	SLACK_SIGNING_SECRET   HMAC secret for verifying Slack request
+//	                       signatures on /slack/events and
+//	                       /slack/interactions.
+//	SLACK_WORKSPACE_ID     Slack workspace (team) id; the extmsg account id
+//	                       and the registries' workspace component.
+//	GC_CITY_NAME           gc city the adapter bridges into.
+//	GC_CITY_PATH           On-disk root of the gc city; the registry
+//	                       directory defaults to <GC_CITY_PATH>/.gc/
+//	                       slack-channel (override with
+//	                       SLACK_CHANNEL_REGISTRY_DIR).
+//
+// Controller-injected env (proxy_process mode):
+//
+//	GC_SERVICE_SOCKET      UDS path the internal listener binds.
+//	GC_SERVICE_URL_PREFIX  Reverse-proxy prefix gc routes to this service.
+//	GC_API_BASE_URL        gc API base (default http://127.0.0.1:9443).
+//
+// Optional env:
+//
+//	LISTEN_PUBLIC                 Public bind for /slack/events +
+//	                              /slack/interactions (default 0.0.0.0:8775).
+//	LISTEN_INTERNAL               TCP bind for the internal mux when
+//	                              GC_SERVICE_SOCKET is unset (default
+//	                              127.0.0.1:8776).
+//	REGISTER_ON_START             "true" (default) self-registers as an
+//	                              extmsg adapter.
+//	ADAPTER_PROVIDER              extmsg provider name (default "slack").
+//	SLACK_CHANNEL_INBOUND_TARGET  Fallback session for an unbound,
+//	                              unaliased app_mention (default "mayor").
+//	SLACK_CHANNEL_REGISTRY_DIR    Override for the registry directory.
+//	SLACK_API_BASE                Slack web API base (default
+//	                              https://slack.com/api).
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+)
+
+func main() {
+	cfg, err := loadConfig()
+	if err != nil {
+		log.Fatalf("config: %v", err)
+	}
+	srv, err := newServer(cfg)
+	if err != nil {
+		log.Fatalf("init: %v", err)
+	}
+
+	internalDescr := cfg.internalListen
+	if cfg.serviceSocket != "" {
+		internalDescr = "uds:" + cfg.serviceSocket
+	}
+	log.Printf("starting gc-slack-channel-adapter public=%s internal=%s gc=%s city=%s registry=%s target=%s",
+		cfg.publicListen, internalDescr, cfg.gcAPIBase, cfg.cityName, cfg.registryDir, cfg.inboundTarget)
+
+	publicMux := http.NewServeMux()
+	publicMux.HandleFunc("/slack/events", srv.handleSlackEvents())
+	publicMux.HandleFunc("/slack/interactions", srv.handleInteractions())
+	publicMux.HandleFunc("/healthz", handleHealthz)
+	publicMux.HandleFunc("/", http.NotFound)
+
+	internalMux := http.NewServeMux()
+	internalMux.HandleFunc("POST /publish", srv.handlePublish())
+	internalMux.HandleFunc("POST /publish-to-channel", srv.handlePublishToChannel())
+	internalMux.HandleFunc("POST /reply-current", srv.handleReplyCurrent())
+	internalMux.HandleFunc("POST /react", srv.handleReact())
+	internalMux.HandleFunc("POST /bindings", srv.handleBind())
+	internalMux.HandleFunc("POST /identity", srv.handleIdentitySet())
+	internalMux.HandleFunc("DELETE /identity", srv.handleIdentityRemove())
+	internalMux.HandleFunc("POST /handle-alias", srv.handleAliasSet())
+	internalMux.HandleFunc("DELETE /handle-alias", srv.handleAliasRemove())
+	internalMux.HandleFunc("/healthz", handleHealthz)
+
+	// ReadTimeout/WriteTimeout bound slow clients on the public,
+	// attacker-reachable listener (the body is unsigned until verified);
+	// ReadHeaderTimeout alone leaves a slow-body drip able to pin a
+	// connection up to the maxInboundBody size.
+	publicSrv := &http.Server{
+		Addr:              cfg.publicListen,
+		Handler:           publicMux,
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      30 * time.Second,
+		IdleTimeout:       120 * time.Second,
+	}
+	internalSrv := &http.Server{
+		Handler:           internalMux,
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      30 * time.Second,
+	}
+	// Set the internal TCP address before launching the serve goroutine so
+	// the field is not written concurrently with a shutdown read. Unused in
+	// UDS mode (Serve(lis) ignores Addr).
+	if cfg.serviceSocket == "" {
+		internalSrv.Addr = cfg.internalListen
+	}
+
+	if cfg.registerOnStart {
+		regCtx, cancel := context.WithTimeout(context.Background(), gcCallTimeout)
+		err := srv.registerAdapter(regCtx)
+		cancel()
+		if err != nil {
+			log.Fatalf("register adapter: %v", err)
+		}
+		log.Printf("registered with gc as provider=%s account=%s callback=%s",
+			cfg.provider, cfg.workspaceID, cfg.internalCallbackURL)
+	}
+
+	errCh := make(chan error, 2)
+	go func() {
+		log.Printf("public listener serving on %s (Slack events + interactions)", cfg.publicListen)
+		errCh <- publicSrv.ListenAndServe()
+	}()
+	go func() {
+		if cfg.serviceSocket != "" {
+			log.Printf("internal listener serving on UDS %s (gc proxy_process)", cfg.serviceSocket)
+			lis, err := listenUDS(cfg.serviceSocket)
+			if err != nil {
+				errCh <- err
+				return
+			}
+			errCh <- internalSrv.Serve(lis)
+			return
+		}
+		log.Printf("internal listener serving on %s (verb endpoints)", cfg.internalListen)
+		errCh <- internalSrv.ListenAndServe()
+	}()
+
+	stop := make(chan os.Signal, 1)
+	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
+	select {
+	case <-stop:
+		log.Println("shutting down (signal)")
+	case err := <-errCh:
+		if !errors.Is(err, http.ErrServerClosed) {
+			log.Printf("listener error: %v", err)
+		}
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_ = publicSrv.Shutdown(ctx)
+	_ = internalSrv.Shutdown(ctx)
+}
+
+// listenUDS binds a Unix domain socket, removing any stale entry first so
+// restarts succeed, and tightens it to owner-only.
+func listenUDS(path string) (net.Listener, error) {
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("remove stale socket: %w", err)
+	}
+	lis, err := net.Listen("unix", path)
+	if err != nil {
+		return nil, fmt.Errorf("listen unix %s: %w", path, err)
+	}
+	if err := os.Chmod(path, 0o600); err != nil {
+		_ = lis.Close()
+		return nil, fmt.Errorf("chmod uds: %w", err)
+	}
+	return lis, nil
+}

--- a/slack-channel/adapter/outbound.go
+++ b/slack-channel/adapter/outbound.go
@@ -1,0 +1,244 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+)
+
+// --- request bodies (one per outbound verb wrapper) -----------------------
+
+type publishRequest struct {
+	SessionID string `json:"session_id"`
+	Body      string `json:"body"`
+	ReplyTo   string `json:"reply_to,omitempty"`
+}
+
+type publishToChannelRequest struct {
+	SessionID string `json:"session_id,omitempty"`
+	ChannelID string `json:"channel_id"`
+	ThreadTS  string `json:"thread_ts,omitempty"`
+	Body      string `json:"body"`
+}
+
+type replyCurrentRequest struct {
+	SessionID     string `json:"session_id"`
+	Body          string `json:"body"`
+	ReplyTo       string `json:"reply_to,omitempty"`
+	ThreadCurrent bool   `json:"thread_current,omitempty"`
+}
+
+type reactRequest struct {
+	SessionID      string `json:"session_id,omitempty"`
+	ConversationID string `json:"conversation_id,omitempty"`
+	MessageID      string `json:"message_id,omitempty"`
+	Emoji          string `json:"emoji"`
+}
+
+// applyIdentity injects a session's registered username/avatar override
+// into a chat.postMessage request. It returns the applied username (for the
+// response/log), or "" when the session has no identity override.
+func (s *server) applyIdentity(req *slackPostMessageReq, sessionID string) string {
+	if sessionID == "" {
+		return ""
+	}
+	id, ok := s.identityFor(sessionID)
+	if !ok {
+		return ""
+	}
+	req.Username = id.Username
+	req.IconURL = id.IconURL
+	req.IconEmoji = id.IconEmoji
+	return id.Username
+}
+
+// post sends a chat.postMessage and writes a uniform receipt. channel and
+// text are required by the caller; identity is applied from sessionID.
+func (s *server) post(w http.ResponseWriter, r *http.Request, sessionID, channel, text, threadTS string) {
+	req := slackPostMessageReq{Channel: channel, Text: text, ThreadTS: threadTS}
+	identityApplied := s.applyIdentity(&req, sessionID)
+	resp, err := s.postToSlack(r.Context(), req)
+	if err != nil {
+		writeJSONError(w, http.StatusBadGateway, err.Error())
+		return
+	}
+	if !resp.OK {
+		writeJSONError(w, http.StatusBadGateway, "slack: "+resp.Error)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"ok":               true,
+		"ts":               resp.TS,
+		"channel":          resp.Channel,
+		"identity_applied": identityApplied,
+	})
+}
+
+// handlePublish posts into the single channel a session is bound to. A
+// session bound to zero channels (run bind-dm/bind-room first) or to more
+// than one (ambiguous — use publish-to-channel) is a fail-fast error.
+func (s *server) handlePublish() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req publishRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeJSONError(w, http.StatusBadRequest, fmt.Sprintf("decode: %v", err))
+			return
+		}
+		if strings.TrimSpace(req.SessionID) == "" {
+			writeJSONError(w, http.StatusBadRequest, "session_id is required")
+			return
+		}
+		if strings.TrimSpace(req.Body) == "" {
+			writeJSONError(w, http.StatusBadRequest, "body is required")
+			return
+		}
+		channels := s.channelsForSession(req.SessionID)
+		switch {
+		case len(channels) == 0:
+			writeJSONError(w, http.StatusBadRequest,
+				fmt.Sprintf("session %q has no channel binding; run bind-dm or bind-room first", req.SessionID))
+			return
+		case len(channels) > 1:
+			writeJSONError(w, http.StatusBadRequest,
+				fmt.Sprintf("session %q is bound to multiple channels (%s); use publish-to-channel --channel to disambiguate",
+					req.SessionID, strings.Join(channels, ", ")))
+			return
+		}
+		log.Printf("publish: session=%s channel=%s reply_to=%s", req.SessionID, channels[0], req.ReplyTo)
+		s.post(w, r, req.SessionID, channels[0], req.Body, req.ReplyTo)
+	}
+}
+
+// handlePublishToChannel posts directly to a channel by id, bypassing the
+// binding lookup. The session id (if supplied) still drives the identity
+// override.
+func (s *server) handlePublishToChannel() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req publishToChannelRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeJSONError(w, http.StatusBadRequest, fmt.Sprintf("decode: %v", err))
+			return
+		}
+		if strings.TrimSpace(req.ChannelID) == "" {
+			writeJSONError(w, http.StatusBadRequest, "channel_id is required")
+			return
+		}
+		if strings.TrimSpace(req.Body) == "" {
+			writeJSONError(w, http.StatusBadRequest, "body is required")
+			return
+		}
+		log.Printf("publish-to-channel: session=%s channel=%s thread_ts=%s", req.SessionID, req.ChannelID, req.ThreadTS)
+		s.post(w, r, req.SessionID, req.ChannelID, req.Body, req.ThreadTS)
+	}
+}
+
+// handleReplyCurrent replies into the conversation of the latest inbound
+// message delivered to the session. With --thread-current it threads under
+// that message; with an explicit reply-to it threads under that ts; with
+// neither it posts unthreaded into the same channel. Falls back to the
+// session's single binding when no inbound has been seen this process.
+func (s *server) handleReplyCurrent() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req replyCurrentRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeJSONError(w, http.StatusBadRequest, fmt.Sprintf("decode: %v", err))
+			return
+		}
+		if strings.TrimSpace(req.SessionID) == "" {
+			writeJSONError(w, http.StatusBadRequest, "session_id is required")
+			return
+		}
+		if strings.TrimSpace(req.Body) == "" {
+			writeJSONError(w, http.StatusBadRequest, "body is required")
+			return
+		}
+		if req.ReplyTo != "" && req.ThreadCurrent {
+			writeJSONError(w, http.StatusBadRequest, "reply_to and thread_current are mutually exclusive")
+			return
+		}
+
+		var channel, threadTS string
+		if ref, ok := s.latestInbound(req.SessionID); ok {
+			channel = ref.channelID
+			switch {
+			case req.ReplyTo != "":
+				threadTS = req.ReplyTo
+			case req.ThreadCurrent:
+				threadTS = ref.threadTS
+			}
+		} else {
+			// No inbound seen this process — fall back to the session's
+			// single channel binding so a fresh adapter can still reply.
+			channels := s.channelsForSession(req.SessionID)
+			if len(channels) != 1 {
+				writeJSONError(w, http.StatusBadRequest,
+					"no recent inbound for this session and no single channel binding; use publish-to-channel")
+				return
+			}
+			channel = channels[0]
+			threadTS = req.ReplyTo // thread_current has no message to thread under here
+		}
+		log.Printf("reply-current: session=%s channel=%s thread_ts=%s", req.SessionID, channel, threadTS)
+		s.post(w, r, req.SessionID, channel, req.Body, threadTS)
+	}
+}
+
+// handleReact adds an emoji reaction. Explicit mode names channel+ts
+// directly; otherwise it reacts on the latest inbound message delivered to
+// the session. already_reacted is treated as success (the emoji is on the
+// message either way).
+func (s *server) handleReact() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req reactRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeJSONError(w, http.StatusBadRequest, fmt.Sprintf("decode: %v", err))
+			return
+		}
+		emoji := strings.Trim(req.Emoji, ":")
+		if emoji == "" {
+			writeJSONError(w, http.StatusBadRequest, "emoji is required")
+			return
+		}
+
+		explicit := req.ConversationID != "" || req.MessageID != ""
+		var channel, ts string
+		if explicit {
+			if req.ConversationID == "" || req.MessageID == "" {
+				writeJSONError(w, http.StatusBadRequest, "conversation_id and message_id must be passed together")
+				return
+			}
+			channel, ts = req.ConversationID, req.MessageID
+		} else {
+			if strings.TrimSpace(req.SessionID) == "" {
+				writeJSONError(w, http.StatusBadRequest, "session_id is required when conversation_id/message_id are not given")
+				return
+			}
+			ref, ok := s.latestInbound(req.SessionID)
+			if !ok {
+				writeJSONError(w, http.StatusBadRequest,
+					"no recent inbound for this session; pass conversation_id and message_id explicitly")
+				return
+			}
+			channel, ts = ref.channelID, ref.messageTS
+		}
+
+		log.Printf("react: channel=%s ts=%s emoji=%s", channel, ts, emoji)
+		resp, err := s.addReaction(r.Context(), channel, ts, emoji)
+		if err != nil {
+			writeJSONError(w, http.StatusBadGateway, err.Error())
+			return
+		}
+		if !resp.OK && resp.Error != "already_reacted" {
+			writeJSONError(w, http.StatusBadGateway, "slack: "+resp.Error)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{
+			"ok":      true,
+			"channel": channel,
+			"ts":      ts,
+			"emoji":   emoji,
+		})
+	}
+}

--- a/slack-channel/adapter/outbound_test.go
+++ b/slack-channel/adapter/outbound_test.go
@@ -1,0 +1,290 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// slackCollector stands in for the Slack web API, recording chat.postMessage
+// and reactions.add calls and returning a configurable response.
+type slackCollector struct {
+	srv        *httptest.Server
+	mu         sync.Mutex
+	posts      []slackPostMessageReq
+	reactions  []slackReactionsAddReq
+	postError  string // when set, returned as {ok:false,error:...}
+	reactError string
+}
+
+func newSlackCollector(t *testing.T, s *server) *slackCollector {
+	t.Helper()
+	c := &slackCollector{}
+	c.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/chat.postMessage"):
+			var req slackPostMessageReq
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			c.posts = append(c.posts, req)
+			resp := slackPostMessageResp{OK: c.postError == "", TS: "99.9", Channel: req.Channel, Error: c.postError}
+			_ = json.NewEncoder(w).Encode(resp)
+		case strings.HasSuffix(r.URL.Path, "/reactions.add"):
+			var req slackReactionsAddReq
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			c.reactions = append(c.reactions, req)
+			_ = json.NewEncoder(w).Encode(slackReactionsAddResp{OK: c.reactError == "", Error: c.reactError})
+		default:
+			t.Errorf("unexpected slack path %s", r.URL.Path)
+		}
+	}))
+	t.Cleanup(c.srv.Close)
+	s.cfg.slackAPIBase = c.srv.URL
+	return c
+}
+
+func doJSON(h http.HandlerFunc, body string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, "/x", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	h(rec, req)
+	return rec
+}
+
+func TestHandlePublish(t *testing.T) {
+	srv := newTestServer(t)
+	slack := newSlackCollector(t, srv)
+	mustBind(t, srv, "C1", "room", "s1")
+	if _, err := srv.upsertIdentity("s1", "Gas City PL", "", "robot_face"); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := doJSON(srv.handlePublish(), `{"session_id":"s1","body":"build green","reply_to":"50.0"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	if len(slack.posts) != 1 {
+		t.Fatalf("want 1 slack post, got %d", len(slack.posts))
+	}
+	post := slack.posts[0]
+	if post.Channel != "C1" || post.Text != "build green" || post.ThreadTS != "50.0" {
+		t.Errorf("post = %+v", post)
+	}
+	if post.Username != "Gas City PL" || post.IconEmoji != "robot_face" {
+		t.Errorf("identity not injected: %+v", post)
+	}
+}
+
+func TestHandlePublishNoBinding(t *testing.T) {
+	srv := newTestServer(t)
+	newSlackCollector(t, srv)
+	rec := doJSON(srv.handlePublish(), `{"session_id":"s1","body":"hi"}`)
+	if rec.Code != http.StatusBadRequest || !strings.Contains(rec.Body.String(), "no channel binding") {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandlePublishAmbiguous(t *testing.T) {
+	srv := newTestServer(t)
+	newSlackCollector(t, srv)
+	mustBind(t, srv, "C1", "room", "s1")
+	mustBind(t, srv, "C2", "room", "s1")
+	rec := doJSON(srv.handlePublish(), `{"session_id":"s1","body":"hi"}`)
+	if rec.Code != http.StatusBadRequest || !strings.Contains(rec.Body.String(), "multiple channels") {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandlePublishValidation(t *testing.T) {
+	srv := newTestServer(t)
+	newSlackCollector(t, srv)
+	for name, body := range map[string]string{
+		"no session": `{"body":"hi"}`,
+		"no body":    `{"session_id":"s1"}`,
+		"bad json":   `{`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			if rec := doJSON(srv.handlePublish(), body); rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d", rec.Code)
+			}
+		})
+	}
+}
+
+func TestHandlePublishToChannel(t *testing.T) {
+	srv := newTestServer(t)
+	slack := newSlackCollector(t, srv)
+	rec := doJSON(srv.handlePublishToChannel(), `{"channel_id":"C9","body":"ping","thread_ts":"1.2"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if slack.posts[0].Channel != "C9" || slack.posts[0].ThreadTS != "1.2" {
+		t.Errorf("post = %+v", slack.posts[0])
+	}
+}
+
+func TestHandlePublishToChannelValidation(t *testing.T) {
+	srv := newTestServer(t)
+	newSlackCollector(t, srv)
+	if rec := doJSON(srv.handlePublishToChannel(), `{"body":"hi"}`); rec.Code != http.StatusBadRequest {
+		t.Fatalf("missing channel: status=%d", rec.Code)
+	}
+}
+
+func TestHandleReplyCurrent(t *testing.T) {
+	srv := newTestServer(t)
+	slack := newSlackCollector(t, srv)
+	srv.recordInbound("s1", inboundRef{channelID: "C1", messageTS: "70.1", threadTS: "70.0"})
+
+	t.Run("thread-current threads under root", func(t *testing.T) {
+		rec := doJSON(srv.handleReplyCurrent(), `{"session_id":"s1","body":"on it","thread_current":true}`)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+		}
+		last := slack.posts[len(slack.posts)-1]
+		if last.Channel != "C1" || last.ThreadTS != "70.0" {
+			t.Errorf("post = %+v", last)
+		}
+	})
+
+	t.Run("unthreaded by default", func(t *testing.T) {
+		rec := doJSON(srv.handleReplyCurrent(), `{"session_id":"s1","body":"fyi"}`)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status=%d", rec.Code)
+		}
+		if last := slack.posts[len(slack.posts)-1]; last.ThreadTS != "" {
+			t.Errorf("expected unthreaded, got thread_ts=%q", last.ThreadTS)
+		}
+	})
+
+	t.Run("reply_to and thread_current conflict", func(t *testing.T) {
+		rec := doJSON(srv.handleReplyCurrent(), `{"session_id":"s1","body":"x","reply_to":"1","thread_current":true}`)
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("status=%d", rec.Code)
+		}
+	})
+}
+
+func TestHandleReplyCurrentFallbackToBinding(t *testing.T) {
+	srv := newTestServer(t)
+	slack := newSlackCollector(t, srv)
+	mustBind(t, srv, "C7", "dm", "s1") // no recorded inbound
+
+	rec := doJSON(srv.handleReplyCurrent(), `{"session_id":"s1","body":"hello"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if slack.posts[0].Channel != "C7" {
+		t.Errorf("fallback channel = %q, want C7", slack.posts[0].Channel)
+	}
+}
+
+func TestHandleReplyCurrentNoTarget(t *testing.T) {
+	srv := newTestServer(t)
+	newSlackCollector(t, srv)
+	rec := doJSON(srv.handleReplyCurrent(), `{"session_id":"ghost","body":"hello"}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleReact(t *testing.T) {
+	srv := newTestServer(t)
+	slack := newSlackCollector(t, srv)
+	srv.recordInbound("s1", inboundRef{channelID: "C1", messageTS: "70.1", threadTS: "70.0"})
+
+	t.Run("current", func(t *testing.T) {
+		rec := doJSON(srv.handleReact(), `{"session_id":"s1","emoji":":eyes:"}`)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+		}
+		r := slack.reactions[len(slack.reactions)-1]
+		if r.Channel != "C1" || r.Timestamp != "70.1" || r.Name != "eyes" {
+			t.Errorf("reaction = %+v", r)
+		}
+	})
+
+	t.Run("explicit", func(t *testing.T) {
+		rec := doJSON(srv.handleReact(), `{"conversation_id":"C2","message_id":"5.5","emoji":"tada"}`)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status=%d", rec.Code)
+		}
+		r := slack.reactions[len(slack.reactions)-1]
+		if r.Channel != "C2" || r.Timestamp != "5.5" || r.Name != "tada" {
+			t.Errorf("reaction = %+v", r)
+		}
+	})
+}
+
+func TestHandleReactValidation(t *testing.T) {
+	srv := newTestServer(t)
+	newSlackCollector(t, srv)
+	cases := map[string]string{
+		"no emoji":             `{"session_id":"s1"}`,
+		"explicit half":        `{"conversation_id":"C1","emoji":"eyes"}`,
+		"no session no target": `{"emoji":"eyes"}`,
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			if rec := doJSON(srv.handleReact(), body); rec.Code != http.StatusBadRequest {
+				t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestHandleReactAlreadyReacted(t *testing.T) {
+	srv := newTestServer(t)
+	slack := newSlackCollector(t, srv)
+	slack.reactError = "already_reacted"
+	rec := doJSON(srv.handleReact(), `{"conversation_id":"C2","message_id":"5.5","emoji":"eyes"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("already_reacted should be success, got status=%d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestOutboundHandlersRejectBadJSON(t *testing.T) {
+	srv := newTestServer(t)
+	newSlackCollector(t, srv)
+	handlers := map[string]http.HandlerFunc{
+		"publish":            srv.handlePublish(),
+		"publish-to-channel": srv.handlePublishToChannel(),
+		"reply-current":      srv.handleReplyCurrent(),
+		"react":              srv.handleReact(),
+	}
+	for name, h := range handlers {
+		t.Run(name, func(t *testing.T) {
+			if rec := doJSON(h, `{bad`); rec.Code != http.StatusBadRequest {
+				t.Fatalf("%s: status=%d, want 400", name, rec.Code)
+			}
+		})
+	}
+}
+
+func TestOutboundSlackUnreachable(t *testing.T) {
+	srv := newTestServer(t)
+	srv.cfg.slackAPIBase = "http://127.0.0.1:1" // connection refused
+	mustBind(t, srv, "C1", "room", "s1")
+	srv.recordInbound("s1", inboundRef{channelID: "C1", messageTS: "70.1", threadTS: "70.0"})
+
+	if rec := doJSON(srv.handlePublish(), `{"session_id":"s1","body":"hi"}`); rec.Code != http.StatusBadGateway {
+		t.Errorf("publish unreachable status = %d, want 502", rec.Code)
+	}
+	if rec := doJSON(srv.handleReact(), `{"session_id":"s1","emoji":"eyes"}`); rec.Code != http.StatusBadGateway {
+		t.Errorf("react unreachable status = %d, want 502", rec.Code)
+	}
+}
+
+func TestHandlePublishSlackError(t *testing.T) {
+	srv := newTestServer(t)
+	slack := newSlackCollector(t, srv)
+	slack.postError = "channel_not_found"
+	mustBind(t, srv, "C1", "room", "s1")
+	rec := doJSON(srv.handlePublish(), `{"session_id":"s1","body":"hi"}`)
+	if rec.Code != http.StatusBadGateway || !strings.Contains(rec.Body.String(), "channel_not_found") {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+}

--- a/slack-channel/adapter/registries.go
+++ b/slack-channel/adapter/registries.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// --- channel bindings -----------------------------------------------------
+
+// channelBinding is one record in channel_mappings.json. It binds a Slack
+// channel (or DM) to one or more gc sessions. A non-mention message
+// arriving in a bound channel is delivered to every listed session. The
+// JSON object key is the composite "<workspace_id>:<channel_id>".
+type channelBinding struct {
+	WorkspaceID string   `json:"workspace_id"`
+	ChannelID   string   `json:"channel_id"`
+	Kind        string   `json:"kind"`
+	SessionIDs  []string `json:"session_ids"`
+	CreatedAt   string   `json:"created_at"`
+	UpdatedAt   string   `json:"updated_at"`
+}
+
+// identity is one record in identities.json. It overrides the visible
+// username/avatar a session posts under (Slack chat:write.customize). The
+// JSON object key is the session id.
+type identity struct {
+	SessionID string `json:"session_id"`
+	Username  string `json:"username,omitempty"`
+	IconURL   string `json:"icon_url,omitempty"`
+	IconEmoji string `json:"icon_emoji,omitempty"`
+	CreatedAt string `json:"created_at"`
+	UpdatedAt string `json:"updated_at"`
+}
+
+// handleAlias is one record in handle_aliases.json. It maps an
+// address-by-handle token ("@mayor:") to a session so a human can address
+// that session from any channel, regardless of channel binding. The JSON
+// object key is the handle. Single-workspace at Tier 2 — aliases are not
+// scoped per workspace.
+type handleAlias struct {
+	Handle    string `json:"handle"`
+	SessionID string `json:"session_id"`
+	CreatedAt string `json:"created_at"`
+	UpdatedAt string `json:"updated_at"`
+}
+
+// bindingKey builds the composite primary key for a channel binding.
+func bindingKey(workspaceID, channelID string) string {
+	return workspaceID + ":" + channelID
+}
+
+var (
+	validKinds  = map[string]bool{"dm": true, "room": true}
+	handleRE    = regexp.MustCompile(`^[a-z0-9_-]+$`)
+	sessionIDRE = regexp.MustCompile(`^[^\s]+$`) // any non-empty, whitespace-free token
+)
+
+// sortedDedupSessions returns the input session ids trimmed, with empties
+// and duplicates removed, in sorted order. Sorting makes the on-disk
+// representation stable so idempotent re-binds produce no diff.
+func sortedDedupSessions(in []string) []string {
+	seen := make(map[string]bool, len(in))
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		s = strings.TrimSpace(s)
+		if s == "" || seen[s] {
+			continue
+		}
+		seen[s] = true
+		out = append(out, s)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// validateBinding checks a channel binding request. It returns the
+// cleaned session-id slice on success.
+func validateBinding(workspaceID, channelID, kind string, sessionIDs []string) ([]string, error) {
+	if strings.TrimSpace(workspaceID) == "" {
+		return nil, fmt.Errorf("workspace_id is required")
+	}
+	if strings.TrimSpace(channelID) == "" {
+		return nil, fmt.Errorf("channel_id is required")
+	}
+	if !validKinds[kind] {
+		return nil, fmt.Errorf("kind must be one of dm, room (got %q)", kind)
+	}
+	cleaned := sortedDedupSessions(sessionIDs)
+	if len(cleaned) == 0 {
+		return nil, fmt.Errorf("at least one session_id is required")
+	}
+	for _, s := range cleaned {
+		if !sessionIDRE.MatchString(s) {
+			return nil, fmt.Errorf("session_id must not contain whitespace: %q", s)
+		}
+	}
+	return cleaned, nil
+}
+
+// validateIdentity checks an identity override request. icon_url and
+// icon_emoji are mutually exclusive, and at least one identity field must
+// be present (an all-empty identity is meaningless).
+func validateIdentity(sessionID, username, iconURL, iconEmoji string) error {
+	if strings.TrimSpace(sessionID) == "" {
+		return fmt.Errorf("session_id is required")
+	}
+	if iconURL != "" && iconEmoji != "" {
+		return fmt.Errorf("icon_url and icon_emoji are mutually exclusive")
+	}
+	if username == "" && iconURL == "" && iconEmoji == "" {
+		return fmt.Errorf("at least one of username, icon_url, icon_emoji is required")
+	}
+	return nil
+}
+
+// normalizeHandle lowercases and strips a leading '@' from a handle.
+func normalizeHandle(handle string) string {
+	return strings.ToLower(strings.TrimPrefix(strings.TrimSpace(handle), "@"))
+}
+
+// validateHandle checks a handle-alias request and returns the normalized
+// handle.
+func validateHandle(handle, sessionID string) (string, error) {
+	h := normalizeHandle(handle)
+	if h == "" {
+		return "", fmt.Errorf("handle is required")
+	}
+	if !handleRE.MatchString(h) {
+		return "", fmt.Errorf("handle must match [a-z0-9_-]+ (got %q)", h)
+	}
+	if !sessionIDRE.MatchString(strings.TrimSpace(sessionID)) {
+		return "", fmt.Errorf("session_id is required and must not contain whitespace")
+	}
+	return h, nil
+}

--- a/slack-channel/adapter/registries_http.go
+++ b/slack-channel/adapter/registries_http.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+)
+
+type bindRequest struct {
+	ChannelID  string   `json:"channel_id"`
+	Kind       string   `json:"kind"`
+	SessionIDs []string `json:"session_ids"`
+}
+
+type identityRequest struct {
+	SessionID string `json:"session_id"`
+	Username  string `json:"username,omitempty"`
+	IconURL   string `json:"icon_url,omitempty"`
+	IconEmoji string `json:"icon_emoji,omitempty"`
+}
+
+type handleAliasRequest struct {
+	Handle    string `json:"handle"`
+	SessionID string `json:"session_id,omitempty"`
+}
+
+// handleBind persists a channel→sessions binding (bind-dm / bind-room).
+func (s *server) handleBind() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req bindRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeJSONError(w, http.StatusBadRequest, fmt.Sprintf("decode: %v", err))
+			return
+		}
+		rec, err := s.upsertBinding(req.ChannelID, req.Kind, req.SessionIDs)
+		if err != nil {
+			writeJSONError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		log.Printf("bind: channel=%s kind=%s sessions=%s", rec.ChannelID, rec.Kind, strings.Join(rec.SessionIDs, ","))
+		writeJSON(w, http.StatusOK, map[string]any{"ok": true, "binding": rec})
+	}
+}
+
+// handleIdentitySet registers or updates a per-session identity override.
+func (s *server) handleIdentitySet() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req identityRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeJSONError(w, http.StatusBadRequest, fmt.Sprintf("decode: %v", err))
+			return
+		}
+		rec, err := s.upsertIdentity(req.SessionID, req.Username, req.IconURL, req.IconEmoji)
+		if err != nil {
+			writeJSONError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		log.Printf("identity set: session=%s username=%q", rec.SessionID, rec.Username)
+		writeJSON(w, http.StatusOK, map[string]any{"ok": true, "identity": rec})
+	}
+}
+
+// handleIdentityRemove deletes a session's identity override. Idempotent.
+func (s *server) handleIdentityRemove() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req identityRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeJSONError(w, http.StatusBadRequest, fmt.Sprintf("decode: %v", err))
+			return
+		}
+		if strings.TrimSpace(req.SessionID) == "" {
+			writeJSONError(w, http.StatusBadRequest, "session_id is required")
+			return
+		}
+		removed, err := s.removeIdentity(req.SessionID)
+		if err != nil {
+			writeJSONError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		log.Printf("identity remove: session=%s removed=%v", req.SessionID, removed)
+		writeJSON(w, http.StatusOK, map[string]any{"ok": true, "removed": removed})
+	}
+}
+
+// handleAliasSet registers or updates a handle→session alias.
+func (s *server) handleAliasSet() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req handleAliasRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeJSONError(w, http.StatusBadRequest, fmt.Sprintf("decode: %v", err))
+			return
+		}
+		rec, err := s.upsertHandleAlias(req.Handle, req.SessionID)
+		if err != nil {
+			writeJSONError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		log.Printf("handle-alias set: handle=%s session=%s", rec.Handle, rec.SessionID)
+		writeJSON(w, http.StatusOK, map[string]any{"ok": true, "alias": rec})
+	}
+}
+
+// handleAliasRemove deletes a handle alias. Idempotent.
+func (s *server) handleAliasRemove() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req handleAliasRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeJSONError(w, http.StatusBadRequest, fmt.Sprintf("decode: %v", err))
+			return
+		}
+		removed, err := s.removeHandleAlias(req.Handle)
+		if err != nil {
+			writeJSONError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		log.Printf("handle-alias remove: handle=%s removed=%v", normalizeHandle(req.Handle), removed)
+		writeJSON(w, http.StatusOK, map[string]any{"ok": true, "removed": removed})
+	}
+}

--- a/slack-channel/adapter/registries_http_test.go
+++ b/slack-channel/adapter/registries_http_test.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+func doMethod(method string, h http.HandlerFunc, body string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(method, "/x", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	h(rec, req)
+	return rec
+}
+
+func TestHandleBind(t *testing.T) {
+	srv := newTestServer(t)
+	rec := doMethod(http.MethodPost, srv.handleBind(), `{"channel_id":"C1","kind":"room","session_ids":["s2","s1"]}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	got, ok := srv.bindingForChannel("C1")
+	if !ok || got.Kind != "room" {
+		t.Fatalf("binding not stored: %+v ok=%v", got, ok)
+	}
+	var resp struct {
+		OK      bool           `json:"ok"`
+		Binding channelBinding `json:"binding"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if !resp.OK || len(resp.Binding.SessionIDs) != 2 {
+		t.Errorf("response = %+v", resp)
+	}
+}
+
+func TestHandleBindValidation(t *testing.T) {
+	srv := newTestServer(t)
+	rec := doMethod(http.MethodPost, srv.handleBind(), `{"channel_id":"C1","kind":"thread","session_ids":["s1"]}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("bad kind should 400, got %d", rec.Code)
+	}
+}
+
+func TestHandleIdentitySetAndRemove(t *testing.T) {
+	srv := newTestServer(t)
+	rec := doMethod(http.MethodPost, srv.handleIdentitySet(), `{"session_id":"s1","username":"PL","icon_emoji":"robot_face"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("set status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if id, ok := srv.identityFor("s1"); !ok || id.Username != "PL" {
+		t.Fatalf("identity not set: %+v", id)
+	}
+
+	rec = doMethod(http.MethodDelete, srv.handleIdentityRemove(), `{"session_id":"s1"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("remove status=%d", rec.Code)
+	}
+	if _, ok := srv.identityFor("s1"); ok {
+		t.Error("identity should be removed")
+	}
+}
+
+func TestHandleIdentitySetValidation(t *testing.T) {
+	srv := newTestServer(t)
+	// both icon fields set is invalid
+	rec := doMethod(http.MethodPost, srv.handleIdentitySet(), `{"session_id":"s1","icon_url":"u","icon_emoji":"e"}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d", rec.Code)
+	}
+}
+
+func TestHandleAliasSetAndRemove(t *testing.T) {
+	srv := newTestServer(t)
+	rec := doMethod(http.MethodPost, srv.handleAliasSet(), `{"handle":"@Mayor","session_id":"sess-1"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("set status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if a, ok := srv.aliasFor("mayor"); !ok || a.SessionID != "sess-1" {
+		t.Fatalf("alias not set: %+v", a)
+	}
+
+	rec = doMethod(http.MethodDelete, srv.handleAliasRemove(), `{"handle":"mayor"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("remove status=%d", rec.Code)
+	}
+	if _, ok := srv.aliasFor("mayor"); ok {
+		t.Error("alias should be removed")
+	}
+}
+
+func TestHandleAliasSetValidation(t *testing.T) {
+	srv := newTestServer(t)
+	rec := doMethod(http.MethodPost, srv.handleAliasSet(), `{"handle":"bad handle","session_id":"s1"}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d", rec.Code)
+	}
+}
+
+func TestRegistryHandlersRejectBadJSON(t *testing.T) {
+	srv := newTestServer(t)
+	handlers := map[string]http.HandlerFunc{
+		"bind":         srv.handleBind(),
+		"identity-set": srv.handleIdentitySet(),
+		"identity-rm":  srv.handleIdentityRemove(),
+		"alias-set":    srv.handleAliasSet(),
+		"alias-rm":     srv.handleAliasRemove(),
+	}
+	for name, h := range handlers {
+		t.Run(name, func(t *testing.T) {
+			if rec := doMethod(http.MethodPost, h, `{bad`); rec.Code != http.StatusBadRequest {
+				t.Fatalf("%s: status=%d, want 400", name, rec.Code)
+			}
+		})
+	}
+}
+
+func TestHandleIdentityRemoveRequiresSession(t *testing.T) {
+	srv := newTestServer(t)
+	if rec := doMethod(http.MethodDelete, srv.handleIdentityRemove(), `{}`); rec.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d, want 400", rec.Code)
+	}
+}
+
+func TestHandleAliasRemoveRejectsEmptyHandle(t *testing.T) {
+	srv := newTestServer(t)
+	if rec := doMethod(http.MethodDelete, srv.handleAliasRemove(), `{"handle":"@"}`); rec.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d, want 400", rec.Code)
+	}
+}
+
+func TestRemoveSaveErrors(t *testing.T) {
+	srv := newTestServer(t)
+	if _, err := srv.upsertIdentity("s1", "PL", "", ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := srv.upsertHandleAlias("mayor", "s1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(srv.cfg.registryDir, 0o500); err != nil {
+		t.Skip("chmod unsupported on this platform")
+	}
+	t.Cleanup(func() { _ = os.Chmod(srv.cfg.registryDir, 0o700) })
+
+	if rec := doMethod(http.MethodDelete, srv.handleIdentityRemove(), `{"session_id":"s1"}`); rec.Code != http.StatusInternalServerError {
+		t.Errorf("identity remove save error status=%d, want 500", rec.Code)
+	}
+	if rec := doMethod(http.MethodDelete, srv.handleAliasRemove(), `{"handle":"mayor"}`); rec.Code != http.StatusBadRequest {
+		t.Errorf("alias remove save error status=%d, want 400", rec.Code)
+	}
+}

--- a/slack-channel/adapter/registries_test.go
+++ b/slack-channel/adapter/registries_test.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestSortedDedupSessions(t *testing.T) {
+	got := sortedDedupSessions([]string{" s2 ", "s1", "s2", "", "  ", "s1"})
+	want := []string{"s1", "s2"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("sortedDedupSessions = %v, want %v", got, want)
+	}
+}
+
+func TestValidateBinding(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		got, err := validateBinding("T1", "C1", "room", []string{"b", "a", "a"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !reflect.DeepEqual(got, []string{"a", "b"}) {
+			t.Errorf("cleaned = %v", got)
+		}
+	})
+	bad := []struct {
+		name          string
+		ws, ch, kind  string
+		sessions      []string
+		wantErrSubstr string
+	}{
+		{"no workspace", "", "C1", "room", []string{"a"}, "workspace_id"},
+		{"no channel", "T1", "", "room", []string{"a"}, "channel_id"},
+		{"bad kind", "T1", "C1", "thread", []string{"a"}, "kind must be"},
+		{"no sessions", "T1", "C1", "room", []string{"", "  "}, "at least one session_id"},
+		{"whitespace session", "T1", "C1", "room", []string{"a b"}, "must not contain whitespace"},
+	}
+	for _, tc := range bad {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := validateBinding(tc.ws, tc.ch, tc.kind, tc.sessions)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErrSubstr) {
+				t.Fatalf("err = %v, want substring %q", err, tc.wantErrSubstr)
+			}
+		})
+	}
+}
+
+func TestValidateIdentity(t *testing.T) {
+	if err := validateIdentity("s1", "PL", "", ""); err != nil {
+		t.Errorf("username-only should be valid: %v", err)
+	}
+	if err := validateIdentity("s1", "", "https://x/y.png", ""); err != nil {
+		t.Errorf("icon_url-only should be valid: %v", err)
+	}
+	cases := []struct {
+		name                                  string
+		session, username, iconURL, iconEmoji string
+		want                                  string
+	}{
+		{"no session", "", "PL", "", "", "session_id"},
+		{"both icons", "s1", "", "u", "e", "mutually exclusive"},
+		{"all empty", "s1", "", "", "", "at least one"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateIdentity(tc.session, tc.username, tc.iconURL, tc.iconEmoji)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("err = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidateHandle(t *testing.T) {
+	h, err := validateHandle("@Mayor", "s1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if h != "mayor" {
+		t.Errorf("normalized handle = %q, want mayor", h)
+	}
+	if _, err := validateHandle("bad handle", "s1"); err == nil {
+		t.Error("expected error for handle with space")
+	}
+	if _, err := validateHandle("mayor", "  "); err == nil {
+		t.Error("expected error for empty session")
+	}
+	if _, err := validateHandle("@", "s1"); err == nil {
+		t.Error("expected error for bare @")
+	}
+}
+
+func TestNormalizeHandle(t *testing.T) {
+	tests := map[string]string{
+		"@Mayor": "mayor",
+		" COS ":  "cos",
+		"build":  "build",
+	}
+	for in, want := range tests {
+		if got := normalizeHandle(in); got != want {
+			t.Errorf("normalizeHandle(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestBindingKey(t *testing.T) {
+	if got := bindingKey("T1", "C9"); got != "T1:C9" {
+		t.Errorf("bindingKey = %q", got)
+	}
+}

--- a/slack-channel/adapter/server.go
+++ b/slack-channel/adapter/server.go
@@ -1,0 +1,284 @@
+package main
+
+import (
+	"fmt"
+	"maps"
+	"net/http"
+	"sort"
+	"sync"
+	"time"
+)
+
+// inboundRef remembers the last inbound message delivered to a session so
+// `reply-current` and `react` can act on "the message I just received"
+// without the caller having to thread channel/ts by hand. It is in-memory
+// and best-effort: an adapter restart clears it, after which reply-current
+// falls back to the session's channel binding.
+//
+// messageTS is the specific message (what `react` reacts on); threadTS is
+// the thread root to reply under (what `reply-current` threads against) —
+// the parent thread when the inbound was itself a threaded reply, else the
+// message's own ts.
+type inboundRef struct {
+	channelID string
+	messageTS string
+	threadTS  string
+}
+
+// server holds the adapter's configuration, the three on-disk registries
+// (mirrored in memory), and the per-session last-inbound map. It is the
+// single owner of registry state: verb endpoints mutate through it under a
+// write lock, and the inbound path reads through it under a read lock.
+//
+// Two locks guard the registries: regMu protects the in-memory maps
+// (readers on the inbound hot path take RLock), and writeMu serializes
+// mutators. A mutator holds writeMu for the whole operation but takes regMu
+// only to mutate the map and snapshot it — the disk flush happens under
+// writeMu alone, so a registry write never blocks an inbound read on file
+// I/O, while writeMu still guarantees on-disk order matches mutation order.
+type server struct {
+	cfg config
+
+	writeMu    sync.Mutex                // serializes registry mutators (held across disk flush)
+	regMu      sync.RWMutex              // protects the in-memory maps below
+	channels   map[string]channelBinding // key: "<workspace>:<channel>"
+	identities map[string]identity       // key: session id
+	aliases    map[string]handleAlias    // key: handle
+
+	lastMu      sync.RWMutex
+	lastInbound map[string]inboundRef // key: session id
+
+	httpClient *http.Client
+	now        func() time.Time
+}
+
+func newServer(cfg config) (*server, error) {
+	s := &server{
+		cfg:         cfg,
+		channels:    map[string]channelBinding{},
+		identities:  map[string]identity{},
+		aliases:     map[string]handleAlias{},
+		lastInbound: map[string]inboundRef{},
+		httpClient:  &http.Client{},
+		now:         func() time.Time { return time.Now() },
+	}
+	if err := s.loadRegistries(); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+func (s *server) nowStamp() string { return s.now().UTC().Format(time.RFC3339) }
+
+// loadRegistries reads all three registry files into memory. Missing files
+// are treated as empty registries (a fresh city), not an error.
+func (s *server) loadRegistries() error {
+	s.regMu.Lock()
+	defer s.regMu.Unlock()
+	if err := loadJSONMap(s.cfg.channelMappingsPath(), &s.channels); err != nil {
+		return err
+	}
+	if err := loadJSONMap(s.cfg.identitiesPath(), &s.identities); err != nil {
+		return err
+	}
+	if err := loadJSONMap(s.cfg.handleAliasesPath(), &s.aliases); err != nil {
+		return err
+	}
+	return nil
+}
+
+// --- channel bindings -----------------------------------------------------
+
+// upsertBinding validates and persists a channel→sessions binding. An
+// idempotent re-bind preserves the original created_at and only advances
+// updated_at.
+func (s *server) upsertBinding(channelID, kind string, sessionIDs []string) (channelBinding, error) {
+	cleaned, err := validateBinding(s.cfg.workspaceID, channelID, kind, sessionIDs)
+	if err != nil {
+		return channelBinding{}, err
+	}
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
+	now := s.nowStamp()
+	rec := channelBinding{
+		WorkspaceID: s.cfg.workspaceID,
+		ChannelID:   channelID,
+		Kind:        kind,
+		SessionIDs:  cleaned,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	s.regMu.Lock()
+	key := bindingKey(s.cfg.workspaceID, channelID)
+	if prev, ok := s.channels[key]; ok {
+		rec.CreatedAt = prev.CreatedAt
+	}
+	s.channels[key] = rec
+	snapshot := maps.Clone(s.channels)
+	s.regMu.Unlock()
+
+	if err := saveJSONAtomic(s.cfg.channelMappingsPath(), snapshot); err != nil {
+		return channelBinding{}, err
+	}
+	return rec, nil
+}
+
+// bindingForChannel returns the binding for a channel in the configured
+// workspace, if any.
+func (s *server) bindingForChannel(channelID string) (channelBinding, bool) {
+	s.regMu.RLock()
+	defer s.regMu.RUnlock()
+	rec, ok := s.channels[bindingKey(s.cfg.workspaceID, channelID)]
+	return rec, ok
+}
+
+// channelsForSession returns the sorted channel ids the session is bound
+// to within the configured workspace. Used by `publish` to resolve a
+// session's single bound conversation.
+func (s *server) channelsForSession(sessionID string) []string {
+	s.regMu.RLock()
+	defer s.regMu.RUnlock()
+	var out []string
+	for _, rec := range s.channels {
+		for _, sid := range rec.SessionIDs {
+			if sid == sessionID {
+				out = append(out, rec.ChannelID)
+				break
+			}
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// --- identities -----------------------------------------------------------
+
+func (s *server) upsertIdentity(sessionID, username, iconURL, iconEmoji string) (identity, error) {
+	if err := validateIdentity(sessionID, username, iconURL, iconEmoji); err != nil {
+		return identity{}, err
+	}
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
+	now := s.nowStamp()
+	rec := identity{
+		SessionID: sessionID,
+		Username:  username,
+		IconURL:   iconURL,
+		IconEmoji: iconEmoji,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	s.regMu.Lock()
+	if prev, ok := s.identities[sessionID]; ok {
+		rec.CreatedAt = prev.CreatedAt
+	}
+	s.identities[sessionID] = rec
+	snapshot := maps.Clone(s.identities)
+	s.regMu.Unlock()
+
+	if err := saveJSONAtomic(s.cfg.identitiesPath(), snapshot); err != nil {
+		return identity{}, err
+	}
+	return rec, nil
+}
+
+// removeIdentity deletes a session's identity override. It is idempotent:
+// removing a missing entry reports removed=false without erroring.
+func (s *server) removeIdentity(sessionID string) (bool, error) {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
+	s.regMu.Lock()
+	if _, ok := s.identities[sessionID]; !ok {
+		s.regMu.Unlock()
+		return false, nil
+	}
+	delete(s.identities, sessionID)
+	snapshot := maps.Clone(s.identities)
+	s.regMu.Unlock()
+
+	if err := saveJSONAtomic(s.cfg.identitiesPath(), snapshot); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (s *server) identityFor(sessionID string) (identity, bool) {
+	s.regMu.RLock()
+	defer s.regMu.RUnlock()
+	rec, ok := s.identities[sessionID]
+	return rec, ok
+}
+
+// --- handle aliases -------------------------------------------------------
+
+func (s *server) upsertHandleAlias(handle, sessionID string) (handleAlias, error) {
+	h, err := validateHandle(handle, sessionID)
+	if err != nil {
+		return handleAlias{}, err
+	}
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
+	now := s.nowStamp()
+	rec := handleAlias{Handle: h, SessionID: sessionID, CreatedAt: now, UpdatedAt: now}
+	s.regMu.Lock()
+	if prev, ok := s.aliases[h]; ok {
+		rec.CreatedAt = prev.CreatedAt
+	}
+	s.aliases[h] = rec
+	snapshot := maps.Clone(s.aliases)
+	s.regMu.Unlock()
+
+	if err := saveJSONAtomic(s.cfg.handleAliasesPath(), snapshot); err != nil {
+		return handleAlias{}, err
+	}
+	return rec, nil
+}
+
+func (s *server) removeHandleAlias(handle string) (bool, error) {
+	h := normalizeHandle(handle)
+	if h == "" {
+		return false, fmt.Errorf("handle is required")
+	}
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
+	s.regMu.Lock()
+	if _, ok := s.aliases[h]; !ok {
+		s.regMu.Unlock()
+		return false, nil
+	}
+	delete(s.aliases, h)
+	snapshot := maps.Clone(s.aliases)
+	s.regMu.Unlock()
+
+	if err := saveJSONAtomic(s.cfg.handleAliasesPath(), snapshot); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (s *server) aliasFor(handle string) (handleAlias, bool) {
+	s.regMu.RLock()
+	defer s.regMu.RUnlock()
+	rec, ok := s.aliases[normalizeHandle(handle)]
+	return rec, ok
+}
+
+// --- last-inbound tracking ------------------------------------------------
+
+func (s *server) recordInbound(sessionID string, ref inboundRef) {
+	s.lastMu.Lock()
+	defer s.lastMu.Unlock()
+	s.lastInbound[sessionID] = ref
+}
+
+func (s *server) latestInbound(sessionID string) (inboundRef, bool) {
+	s.lastMu.RLock()
+	defer s.lastMu.RUnlock()
+	ref, ok := s.lastInbound[sessionID]
+	return ref, ok
+}

--- a/slack-channel/adapter/server_test.go
+++ b/slack-channel/adapter/server_test.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestUpsertBindingPersistsAndReloads(t *testing.T) {
+	srv := newTestServer(t)
+	rec, err := srv.upsertBinding("C1", "room", []string{"s2", "s1"})
+	if err != nil {
+		t.Fatalf("upsertBinding: %v", err)
+	}
+	if !reflect.DeepEqual(rec.SessionIDs, []string{"s1", "s2"}) {
+		t.Errorf("session_ids = %v, want sorted", rec.SessionIDs)
+	}
+
+	// A fresh server over the same registry dir sees the persisted binding.
+	reloaded, err := newServer(srv.cfg)
+	if err != nil {
+		t.Fatalf("reload server: %v", err)
+	}
+	got, ok := reloaded.bindingForChannel("C1")
+	if !ok {
+		t.Fatal("binding not reloaded from disk")
+	}
+	if got.Kind != "room" || got.WorkspaceID != "T123" {
+		t.Errorf("reloaded binding = %+v", got)
+	}
+}
+
+func TestUpsertBindingIdempotentCreatedAt(t *testing.T) {
+	srv := newTestServer(t)
+	first, _ := srv.upsertBinding("C1", "dm", []string{"s1"})
+	second, _ := srv.upsertBinding("C1", "dm", []string{"s1", "s3"})
+	if second.CreatedAt != first.CreatedAt {
+		t.Errorf("created_at changed on rebind: %q -> %q", first.CreatedAt, second.CreatedAt)
+	}
+}
+
+func TestChannelsForSession(t *testing.T) {
+	srv := newTestServer(t)
+	mustBind(t, srv, "C1", "room", "s1", "s2")
+	mustBind(t, srv, "C2", "room", "s1")
+	mustBind(t, srv, "C3", "dm", "s9")
+
+	if got := srv.channelsForSession("s1"); !reflect.DeepEqual(got, []string{"C1", "C2"}) {
+		t.Errorf("channelsForSession(s1) = %v, want [C1 C2]", got)
+	}
+	if got := srv.channelsForSession("s2"); !reflect.DeepEqual(got, []string{"C1"}) {
+		t.Errorf("channelsForSession(s2) = %v", got)
+	}
+	if got := srv.channelsForSession("nobody"); got != nil {
+		t.Errorf("channelsForSession(nobody) = %v, want nil", got)
+	}
+}
+
+func TestIdentityLifecycle(t *testing.T) {
+	srv := newTestServer(t)
+	if _, ok := srv.identityFor("s1"); ok {
+		t.Fatal("identity should be absent initially")
+	}
+	if _, err := srv.upsertIdentity("s1", "PL", "https://x/a.png", ""); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	id, ok := srv.identityFor("s1")
+	if !ok || id.Username != "PL" || id.IconURL != "https://x/a.png" {
+		t.Errorf("identity = %+v ok=%v", id, ok)
+	}
+	removed, err := srv.removeIdentity("s1")
+	if err != nil || !removed {
+		t.Errorf("remove = %v, err=%v", removed, err)
+	}
+	// Idempotent: removing again reports false, no error.
+	removed, err = srv.removeIdentity("s1")
+	if err != nil || removed {
+		t.Errorf("second remove = %v, err=%v", removed, err)
+	}
+}
+
+func TestHandleAliasLifecycle(t *testing.T) {
+	srv := newTestServer(t)
+	if _, err := srv.upsertHandleAlias("@Mayor", "sess-1"); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	rec, ok := srv.aliasFor("mayor")
+	if !ok || rec.SessionID != "sess-1" {
+		t.Errorf("alias = %+v ok=%v", rec, ok)
+	}
+	// Lookup normalizes the queried handle too.
+	if _, ok := srv.aliasFor("@MAYOR"); !ok {
+		t.Error("alias lookup should normalize the query")
+	}
+	removed, err := srv.removeHandleAlias("MAYOR")
+	if err != nil || !removed {
+		t.Errorf("remove = %v err=%v", removed, err)
+	}
+	if _, ok := srv.aliasFor("mayor"); ok {
+		t.Error("alias should be gone after remove")
+	}
+}
+
+func TestLastInboundTracking(t *testing.T) {
+	srv := newTestServer(t)
+	if _, ok := srv.latestInbound("s1"); ok {
+		t.Fatal("no inbound expected initially")
+	}
+	srv.recordInbound("s1", inboundRef{channelID: "C1", messageTS: "1.1", threadTS: "1.0"})
+	ref, ok := srv.latestInbound("s1")
+	if !ok || ref.channelID != "C1" || ref.messageTS != "1.1" || ref.threadTS != "1.0" {
+		t.Errorf("latestInbound = %+v ok=%v", ref, ok)
+	}
+}
+
+func TestNewServerRejectsCorruptRegistry(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "channel_mappings.json"), []byte("{bad json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg := config{
+		cityName: "c", provider: "slack", workspaceID: "T1",
+		slackAPIBase: "x", gcAPIBase: "y", registryDir: dir,
+	}
+	if _, err := newServer(cfg); err == nil {
+		t.Fatal("expected newServer to fail loading a corrupt registry")
+	}
+}
+
+func TestUpsertBindingSaveError(t *testing.T) {
+	srv := newTestServer(t)
+	if err := os.Chmod(srv.cfg.registryDir, 0o500); err != nil {
+		t.Skip("chmod unsupported on this platform")
+	}
+	t.Cleanup(func() { _ = os.Chmod(srv.cfg.registryDir, 0o700) })
+	if _, err := srv.upsertBinding("C1", "room", []string{"s1"}); err == nil {
+		t.Fatal("expected a save error on a read-only registry directory")
+	}
+}
+
+func mustBind(t *testing.T, srv *server, channel, kind string, sessions ...string) {
+	t.Helper()
+	if _, err := srv.upsertBinding(channel, kind, sessions); err != nil {
+		t.Fatalf("bind %s: %v", channel, err)
+	}
+}

--- a/slack-channel/adapter/signature.go
+++ b/slack-channel/adapter/signature.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// verifySlackSignature validates Slack's v0 HMAC request signature and
+// rejects timestamps whose absolute age exceeds the replay window — both
+// stale (past) and far-future. Fails closed on any missing field or parse
+// error.
+func verifySlackSignature(secret, ts string, body []byte, sig string) bool {
+	if secret == "" || ts == "" || sig == "" {
+		return false
+	}
+	tsInt, err := strconv.ParseInt(ts, 10, 64)
+	if err != nil {
+		return false
+	}
+	// Reject when the absolute age exceeds the replay window — both stale
+	// (past) and far-future timestamps. time.Since yields a negative
+	// duration for future timestamps, so a one-sided ">" check would
+	// silently accept them.
+	age := time.Since(time.Unix(tsInt, 0))
+	if age < 0 {
+		age = -age
+	}
+	if age > slackReplayWindow {
+		return false
+	}
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write([]byte("v0:" + ts + ":"))
+	_, _ = mac.Write(body)
+	expected := "v0=" + hex.EncodeToString(mac.Sum(nil))
+	return hmac.Equal([]byte(expected), []byte(sig))
+}
+
+// leadingMentionRE matches one or more leading Slack user-mention tokens
+// (`<@U…>`) and surrounding whitespace. Slack delivers app_mention text
+// with the bot mention inline (e.g. "<@U0BOT> status?"); stripping it
+// yields the human-meant message body.
+var leadingMentionRE = regexp.MustCompile(`^\s*(?:<@[A-Z0-9]+>\s*)+`)
+
+func stripLeadingMention(text string) string {
+	return strings.TrimSpace(leadingMentionRE.ReplaceAllString(text, ""))
+}
+
+// slackKindFromChannelType maps a Slack channel_type onto a gc
+// ConversationKind, falling back to the channel-id prefix.
+func slackKindFromChannelType(channelType, channelID string) string {
+	switch channelType {
+	case "channel", "group", "mpim":
+		return "room"
+	case "im":
+		return "dm"
+	}
+	if len(channelID) > 0 {
+		switch channelID[0] {
+		case 'C', 'G':
+			return "room"
+		case 'D':
+			return "dm"
+		}
+	}
+	return "dm"
+}
+
+// handleAliasRE matches a leading address-by-handle token: "@<handle>"
+// optionally followed by a colon, then the rest of the message. Handles
+// are lowercase letters, digits, '_' and '-'. The capture groups are the
+// handle and the remaining text. Mirrors the alias syntax documented for
+// `gc slack-channel handle-alias`.
+var handleAliasRE = regexp.MustCompile(`^@([a-z0-9_-]+):?\s*(.*)$`)
+
+// parseLeadingHandle extracts a leading "@handle[:]" address token. It
+// returns the lowercased handle and the remaining message text, or
+// ("", text) when the text does not begin with a handle token.
+func parseLeadingHandle(text string) (handle, rest string) {
+	m := handleAliasRE.FindStringSubmatch(strings.TrimSpace(text))
+	if m == nil {
+		return "", text
+	}
+	return m[1], strings.TrimSpace(m[2])
+}

--- a/slack-channel/adapter/signature_test.go
+++ b/slack-channel/adapter/signature_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestVerifySlackSignature(t *testing.T) {
+	const secret = "shhh"
+	body := []byte(`{"type":"event_callback"}`)
+	now := strconv.FormatInt(time.Now().Unix(), 10)
+	stale := strconv.FormatInt(time.Now().Add(-10*time.Minute).Unix(), 10)
+	future := strconv.FormatInt(time.Now().Add(10*time.Minute).Unix(), 10)
+	valid := signSlack(secret, now, body)
+
+	tests := []struct {
+		name   string
+		secret string
+		ts     string
+		sig    string
+		want   bool
+	}{
+		{"valid", secret, now, valid, true},
+		{"wrong secret", "nope", now, valid, false},
+		{"tampered body sig", secret, now, signSlack(secret, now, []byte("other")), false},
+		{"stale timestamp", secret, stale, signSlack(secret, stale, body), false},
+		{"far-future timestamp", secret, future, signSlack(secret, future, body), false},
+		{"non-numeric timestamp", secret, "abc", valid, false},
+		{"empty secret", "", now, valid, false},
+		{"empty ts", secret, "", valid, false},
+		{"empty sig", secret, now, "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := verifySlackSignature(tc.secret, tc.ts, body, tc.sig); got != tc.want {
+				t.Fatalf("verifySlackSignature = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestStripLeadingMention(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{"<@U0BOT> status please", "status please"},
+		{"  <@U0BOT>   hello", "hello"},
+		{"<@U0BOT> <@U1OPS> deploy", "deploy"},
+		{"no mention here", "no mention here"},
+		{"<@U0BOT>", ""},
+		{"   ", ""},
+		{"text then <@U0BOT>", "text then <@U0BOT>"},
+	}
+	for _, tc := range tests {
+		if got := stripLeadingMention(tc.in); got != tc.want {
+			t.Errorf("stripLeadingMention(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestSlackKindFromChannelType(t *testing.T) {
+	tests := []struct{ ctype, cid, want string }{
+		{"channel", "C123", "room"},
+		{"group", "G123", "room"},
+		{"mpim", "C123", "room"},
+		{"im", "D123", "dm"},
+		{"", "C123", "room"},
+		{"", "G123", "room"},
+		{"", "D123", "dm"},
+		{"", "", "dm"},
+	}
+	for _, tc := range tests {
+		if got := slackKindFromChannelType(tc.ctype, tc.cid); got != tc.want {
+			t.Errorf("slackKindFromChannelType(%q,%q) = %q, want %q", tc.ctype, tc.cid, got, tc.want)
+		}
+	}
+}
+
+func TestParseLeadingHandle(t *testing.T) {
+	tests := []struct {
+		in         string
+		wantHandle string
+		wantRest   string
+	}{
+		{"@mayor: deploy now", "mayor", "deploy now"},
+		{"@cos ship it", "cos", "ship it"},
+		{"@build-bot:status", "build-bot", "status"},
+		{"no handle here", "", "no handle here"},
+		{"email me a@b.com", "", "email me a@b.com"},
+		{"@MixedCase: hi", "", "@MixedCase: hi"}, // uppercase not a valid handle char
+		{"@mayor:", "mayor", ""},
+	}
+	for _, tc := range tests {
+		h, rest := parseLeadingHandle(tc.in)
+		if h != tc.wantHandle || rest != tc.wantRest {
+			t.Errorf("parseLeadingHandle(%q) = (%q,%q), want (%q,%q)", tc.in, h, rest, tc.wantHandle, tc.wantRest)
+		}
+	}
+}

--- a/slack-channel/adapter/slackclient.go
+++ b/slack-channel/adapter/slackclient.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// slackCall POSTs req as JSON to a Slack web API method and decodes the
+// response into *Resp. It applies the bot token, a per-call timeout, and
+// surfaces any non-2xx HTTP status as an error. The two outbound Slack
+// calls (chat.postMessage, reactions.add) differ only in method, request,
+// and response type, so they share this body.
+func slackCall[Resp any](ctx context.Context, s *server, method string, req any) (*Resp, error) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithTimeout(ctx, slackPostTimeout)
+	defer cancel()
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, s.cfg.slackAPIBase+method, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+s.cfg.botToken)
+	httpReq.Header.Set("Content-Type", "application/json; charset=utf-8")
+	resp, err := s.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("post %s: %w", method, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read slack response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("slack http %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+	var out Resp
+	if err := json.Unmarshal(respBody, &out); err != nil {
+		return nil, fmt.Errorf("decode slack response: %w", err)
+	}
+	return &out, nil
+}
+
+// postToSlack posts a message via chat.postMessage. Identity fields
+// (username/icon_url/icon_emoji) on req are forwarded verbatim — the caller
+// injects them from the identity registry.
+func (s *server) postToSlack(ctx context.Context, req slackPostMessageReq) (*slackPostMessageResp, error) {
+	return slackCall[slackPostMessageResp](ctx, s, "/chat.postMessage", req)
+}
+
+// addReaction adds an emoji reaction via reactions.add. The emoji name is
+// forwarded verbatim minus surrounding colons (callers may send "eyes" or
+// ":eyes:").
+func (s *server) addReaction(ctx context.Context, channel, timestamp, emoji string) (*slackReactionsAddResp, error) {
+	return slackCall[slackReactionsAddResp](ctx, s, "/reactions.add", slackReactionsAddReq{
+		Channel:   channel,
+		Name:      strings.Trim(emoji, ":"),
+		Timestamp: timestamp,
+	})
+}

--- a/slack-channel/adapter/store.go
+++ b/slack-channel/adapter/store.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// loadJSONMap reads a JSON object file into dst. A missing file is not an
+// error — dst is left as the caller initialized it (an empty map), so a
+// fresh city with no registries yet starts clean.
+func loadJSONMap(path string, dst any) error {
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read %s: %w", path, err)
+	}
+	if len(data) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(data, dst); err != nil {
+		return fmt.Errorf("parse %s: %w", path, err)
+	}
+	return nil
+}
+
+// saveJSONAtomic writes v as indented JSON to path via a temp file +
+// rename so a concurrent reader never observes a half-written file. The
+// registry directory is created if missing and the file is tightened to
+// owner-only (it can hold session ids and identity overrides).
+func saveJSONAtomic(path string, v any) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create registry dir %s: %w", dir, err)
+	}
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal %s: %w", path, err)
+	}
+	data = append(data, '\n')
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create temp for %s: %w", path, err)
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }() // no-op once renamed
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temp for %s: %w", path, err)
+	}
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("chmod temp for %s: %w", path, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp for %s: %w", path, err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("rename temp into %s: %w", path, err)
+	}
+	return nil
+}

--- a/slack-channel/adapter/store_test.go
+++ b/slack-channel/adapter/store_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadJSONMapMissingFile(t *testing.T) {
+	m := map[string]string{}
+	if err := loadJSONMap(filepath.Join(t.TempDir(), "nope.json"), &m); err != nil {
+		t.Fatalf("missing file should not error: %v", err)
+	}
+	if len(m) != 0 {
+		t.Errorf("map should stay empty, got %v", m)
+	}
+}
+
+func TestLoadJSONMapEmptyFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "empty.json")
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	m := map[string]string{}
+	if err := loadJSONMap(path, &m); err != nil {
+		t.Fatalf("empty file should not error: %v", err)
+	}
+}
+
+func TestLoadJSONMapParseError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bad.json")
+	if err := os.WriteFile(path, []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	m := map[string]string{}
+	if err := loadJSONMap(path, &m); err == nil {
+		t.Fatal("expected parse error")
+	}
+}
+
+func TestSaveJSONAtomicMkdirError(t *testing.T) {
+	// A regular file where a directory component is expected makes MkdirAll
+	// fail, surfacing as an error rather than a silent miss.
+	f := filepath.Join(t.TempDir(), "afile")
+	if err := os.WriteFile(f, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(f, "sub", "out.json") // f is a file, not a dir
+	if err := saveJSONAtomic(path, map[string]string{"a": "1"}); err == nil {
+		t.Fatal("expected error when a parent path component is a file")
+	}
+}
+
+func TestSaveJSONAtomicRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "out.json")
+	in := map[string]string{"a": "1", "b": "2"}
+	if err := saveJSONAtomic(path, in); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("file perm = %o, want 600", perm)
+	}
+	out := map[string]string{}
+	if err := loadJSONMap(path, &out); err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if out["a"] != "1" || out["b"] != "2" {
+		t.Errorf("round-trip = %v", out)
+	}
+	// No leftover temp files in the directory.
+	entries, _ := os.ReadDir(filepath.Dir(path))
+	if len(entries) != 1 {
+		t.Errorf("expected only the final file, got %d entries", len(entries))
+	}
+}

--- a/slack-channel/adapter/testutil_test.go
+++ b/slack-channel/adapter/testutil_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"testing"
+	"time"
+)
+
+// signSlack produces a valid X-Slack-Signature header for the given body,
+// timestamp, and secret — the inverse of verifySlackSignature.
+func signSlack(secret, ts string, body []byte) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write([]byte("v0:" + ts + ":"))
+	_, _ = mac.Write(body)
+	return "v0=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+// fixedClock returns a deterministic time so on-disk created_at/updated_at
+// stamps are stable across a test run.
+func fixedClock() func() time.Time {
+	t := time.Date(2026, 5, 30, 12, 0, 0, 0, time.UTC)
+	return func() time.Time { return t }
+}
+
+// newTestServer builds a server backed by a fresh temp registry directory
+// and a fixed clock. Slack/gc API bases are left empty; tests that exercise
+// the network paths set them to httptest servers.
+func newTestServer(t *testing.T) *server {
+	t.Helper()
+	cfg := config{
+		cityName:      "mycity",
+		provider:      "slack",
+		workspaceID:   "T123",
+		botToken:      "xoxb-test",
+		signingSecret: "secret",
+		inboundTarget: "mayor",
+		slackAPIBase:  "https://slack.test/api",
+		gcAPIBase:     "http://gc.test",
+		registryDir:   t.TempDir(),
+	}
+	srv, err := newServer(cfg)
+	if err != nil {
+		t.Fatalf("newServer: %v", err)
+	}
+	srv.now = fixedClock()
+	return srv
+}

--- a/slack-channel/adapter/wire.go
+++ b/slack-channel/adapter/wire.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// --- Slack Events API wire types (subset Tier 2 reads) --------------------
+
+type slackEventEnvelope struct {
+	Type      string          `json:"type"`
+	Challenge string          `json:"challenge,omitempty"`
+	TeamID    string          `json:"team_id,omitempty"`
+	Event     json.RawMessage `json:"event,omitempty"`
+}
+
+// slackMessageEvent is the subset of an app_mention / message event Tier 2
+// reads. Tier 2 widens beyond Tier 1's app_mention-only path to plain
+// message.* events delivered in bound channels.
+type slackMessageEvent struct {
+	Type        string `json:"type"`
+	Subtype     string `json:"subtype,omitempty"`
+	User        string `json:"user,omitempty"`
+	BotID       string `json:"bot_id,omitempty"`
+	Text        string `json:"text,omitempty"`
+	Channel     string `json:"channel,omitempty"`
+	TS          string `json:"ts,omitempty"`
+	ThreadTS    string `json:"thread_ts,omitempty"`
+	ChannelType string `json:"channel_type,omitempty"`
+}
+
+// --- gc extmsg wire types (mirrored, wire-compatible only) ----------------
+
+type conversationRef struct {
+	ScopeID        string `json:"scope_id"`
+	Provider       string `json:"provider"`
+	AccountID      string `json:"account_id"`
+	ConversationID string `json:"conversation_id"`
+	Kind           string `json:"kind"`
+}
+
+type externalActor struct {
+	ID          string `json:"id"`
+	DisplayName string `json:"display_name"`
+	IsBot       bool   `json:"is_bot"`
+}
+
+type externalInboundMessage struct {
+	ProviderMessageID string          `json:"provider_message_id"`
+	Conversation      conversationRef `json:"conversation"`
+	Actor             externalActor   `json:"actor"`
+	Text              string          `json:"text"`
+	ExplicitTarget    string          `json:"explicit_target,omitempty"`
+	ReplyToMessageID  string          `json:"reply_to_message_id,omitempty"`
+	DedupKey          string          `json:"dedup_key,omitempty"`
+	ReceivedAt        time.Time       `json:"received_at"`
+}
+
+type adapterCapabilities struct {
+	SupportsChildConversations bool `json:"SupportsChildConversations"`
+	SupportsAttachments        bool `json:"SupportsAttachments"`
+	MaxMessageLength           int  `json:"MaxMessageLength"`
+}
+
+type adapterRegisterRequest struct {
+	Provider     string              `json:"provider"`
+	AccountID    string              `json:"account_id"`
+	Name         string              `json:"name,omitempty"`
+	CallbackURL  string              `json:"callback_url,omitempty"`
+	Capabilities adapterCapabilities `json:"capabilities,omitempty"`
+}
+
+// --- Slack web API wire types --------------------------------------------
+
+// slackPostMessageReq is the chat.postMessage payload. Username/IconURL/
+// IconEmoji carry a per-session identity override (chat:write.customize)
+// when one is registered; they are omitted otherwise.
+type slackPostMessageReq struct {
+	Channel   string `json:"channel"`
+	Text      string `json:"text"`
+	ThreadTS  string `json:"thread_ts,omitempty"`
+	Username  string `json:"username,omitempty"`
+	IconURL   string `json:"icon_url,omitempty"`
+	IconEmoji string `json:"icon_emoji,omitempty"`
+}
+
+type slackPostMessageResp struct {
+	OK      bool   `json:"ok"`
+	TS      string `json:"ts,omitempty"`
+	Channel string `json:"channel,omitempty"`
+	Error   string `json:"error,omitempty"`
+}
+
+type slackReactionsAddReq struct {
+	Channel   string `json:"channel"`
+	Name      string `json:"name"`
+	Timestamp string `json:"timestamp"`
+}
+
+type slackReactionsAddResp struct {
+	OK    bool   `json:"ok"`
+	Error string `json:"error,omitempty"`
+}

--- a/slack-channel/commands/_lib.sh
+++ b/slack-channel/commands/_lib.sh
@@ -1,0 +1,105 @@
+#!/bin/sh
+# Shared helpers for slack-channel verb wrappers. This file is SOURCED by
+# the verb scripts, never run as a command (it has no command.toml, so gc
+# does not expose it). slack-channel ships no operator CLI binary: each verb
+# resolves the adapter endpoint through gc's /svc/slack-channel reverse
+# proxy and relays a JSON request. The adapter holds SLACK_BOT_TOKEN and
+# owns the on-disk registries, so secrets never enter the command env.
+
+sc_die() {
+  echo "gc slack-channel: $1" >&2
+  exit "${2:-1}"
+}
+
+sc_require() {
+  command -v jq >/dev/null 2>&1 || sc_die "jq is required on PATH" 1
+  command -v curl >/dev/null 2>&1 || sc_die "curl is required on PATH" 1
+}
+
+sc_city() {
+  [ -n "${GC_CITY_NAME:-}" ] || sc_die "GC_CITY_NAME is not set" 1
+  printf '%s' "$GC_CITY_NAME"
+}
+
+# sc_adapter_base prints the adapter's base URL. SLACK_CHANNEL_ADAPTER_URL
+# overrides for local testing; otherwise it is gc's reverse-proxy path.
+sc_adapter_base() {
+  if [ -n "${SLACK_CHANNEL_ADAPTER_URL:-}" ]; then
+    printf '%s' "${SLACK_CHANNEL_ADAPTER_URL%/}"
+    return
+  fi
+  _base="${GC_API_BASE_URL:-http://127.0.0.1:9443}"
+  _base="${_base%/}"
+  printf '%s/v0/city/%s/svc/slack-channel' "$_base" "$(sc_city)"
+}
+
+# sc_call METHOD ENDPOINT JSON_BODY — relay to the adapter, print its JSON
+# payload on stdout, and exit non-zero on a non-2xx status (surfacing the
+# adapter's {"ok":false,"error":...} body rather than swallowing it).
+sc_call() {
+  _method="$1"
+  _endpoint="$2"
+  _body="$3"
+  _url="$(sc_adapter_base)/${_endpoint}"
+  _resp=$(curl -sS -X "$_method" "$_url" \
+    -H 'Content-Type: application/json' \
+    -H 'X-GC-Request: gc-slack-channel' \
+    -d "$_body" \
+    -w '\n%{http_code}') || sc_die "request to adapter failed: $_resp" 1
+  _code=$(printf '%s\n' "$_resp" | tail -n1)
+  _payload=$(printf '%s\n' "$_resp" | sed '$d')
+  printf '%s\n' "$_payload"
+  case "$_code" in
+    2*) return 0 ;;
+    *) sc_die "adapter returned HTTP $_code" 1 ;;
+  esac
+}
+
+# sc_session prints the explicit session id if non-empty, else the current
+# session ($GC_SESSION_ID), failing when neither is available.
+sc_session() {
+  if [ -n "$1" ]; then
+    printf '%s' "$1"
+    return
+  fi
+  [ -n "${GC_SESSION_ID:-}" ] || sc_die "no --session given and GC_SESSION_ID is not set" 1
+  printf '%s' "$GC_SESSION_ID"
+}
+
+# sc_help VERB — print the verb's help.md (relative to the verb script) and
+# exit 0.
+sc_help() {
+  cat "$(dirname "$0")/$1/help.md"
+  exit 0
+}
+
+# sc_load_body BODY BODY_FILE — resolve a message body from --body or
+# --body-file (mutually exclusive, exactly one required).
+sc_load_body() {
+  if [ -n "$1" ] && [ -n "$2" ]; then
+    sc_die "pass --body OR --body-file, not both" 2
+  fi
+  if [ -n "$1" ]; then
+    printf '%s' "$1"
+    return
+  fi
+  [ -n "$2" ] || sc_die "either --body or --body-file is required" 2
+  cat "$2"
+}
+
+# sc_bind KIND ARGS... — shared implementation for bind-dm / bind-room.
+# Positional args: <channel_id> <session_id> [session_id...].
+sc_bind() {
+  _kind="$1"
+  shift
+  [ $# -ge 2 ] || sc_die "usage: bind-${_kind} <channel_id> <session_id> [session_id...]" 2
+  _channel="$1"
+  shift
+  _sessions=$(printf '%s\n' "$@" | jq -R . | jq -s .)
+  _body=$(jq -n \
+    --arg ch "$_channel" \
+    --arg kind "$_kind" \
+    --argjson sessions "$_sessions" \
+    '{channel_id: $ch, kind: $kind, session_ids: $sessions}')
+  sc_call POST bindings "$_body"
+}

--- a/slack-channel/commands/bind-dm.sh
+++ b/slack-channel/commands/bind-dm.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# gc slack-channel bind-dm — bind a Slack DM to one or more gc sessions.
+#
+# A message arriving in the bound DM is delivered to every listed session.
+set -eu
+. "$(dirname "$0")/_lib.sh"
+
+case "${1:-}" in
+  -h|--help) sc_help bind-dm ;;
+esac
+
+sc_require
+sc_bind dm "$@"

--- a/slack-channel/commands/bind-dm/command.toml
+++ b/slack-channel/commands/bind-dm/command.toml
@@ -1,0 +1,2 @@
+description = "Bind a Slack DM to one or more gc sessions"
+run = "../bind-dm.sh"

--- a/slack-channel/commands/bind-dm/help.md
+++ b/slack-channel/commands/bind-dm/help.md
@@ -1,0 +1,25 @@
+Bind a Slack DM channel to one or more gc sessions.
+
+Once bound, any message a human sends in that DM is delivered to every
+listed session (not just `@`-mentions). Re-binding the same DM replaces the
+session list. Pass the session's own id (the value of `$GC_SESSION_ID` in
+that session) so `reply-current` and `react` can resolve "the message I
+just received".
+
+Usage:
+  gc slack-channel bind-dm <channel_id> <session_id> [session_id...]
+
+Arguments:
+  channel_id   Slack DM id (e.g. D0123ABCD).
+  session_id   One or more gc session ids to deliver inbound messages to.
+
+Examples:
+  gc slack-channel bind-dm D0123ABCD sess-mayor
+  gc slack-channel bind-dm D0123ABCD sess-pl sess-cos
+
+On success, prints the stored binding as JSON. The binding is persisted to
+<city>/.gc/slack-channel/channel_mappings.json.
+
+Requires: GC_CITY_NAME + GC_API_BASE_URL in the environment (gc sets these
+for command wrappers), plus `jq` and `curl` on PATH. The slack-channel
+service must be running.

--- a/slack-channel/commands/bind-room.sh
+++ b/slack-channel/commands/bind-room.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# gc slack-channel bind-room — bind a Slack channel to one or more sessions.
+#
+# A message arriving in the bound channel is delivered to every listed
+# session. Single-rig at Tier 2 (multi-rig routing is Tier 3).
+set -eu
+. "$(dirname "$0")/_lib.sh"
+
+case "${1:-}" in
+  -h|--help) sc_help bind-room ;;
+esac
+
+sc_require
+sc_bind room "$@"

--- a/slack-channel/commands/bind-room/command.toml
+++ b/slack-channel/commands/bind-room/command.toml
@@ -1,0 +1,2 @@
+description = "Bind a Slack channel to one or more gc sessions"
+run = "../bind-room.sh"

--- a/slack-channel/commands/bind-room/help.md
+++ b/slack-channel/commands/bind-room/help.md
@@ -1,0 +1,28 @@
+Bind a Slack room/channel to one or more gc sessions.
+
+Once bound, any human message in that channel is delivered to every listed
+session — this is the Tier 2 "team channel ↔ session graph": several gc
+sessions can listen to one channel at once. Re-binding the same channel
+replaces the session list. Pass each session's own id (the value of
+`$GC_SESSION_ID` in that session) so `reply-current` and `react` resolve
+correctly.
+
+Single-rig only at Tier 2 — binding a channel to a whole rig (and
+channel-name patterns) is Tier 3 (slack-full).
+
+Usage:
+  gc slack-channel bind-room <channel_id> <session_id> [session_id...]
+
+Arguments:
+  channel_id   Slack channel id (e.g. C0123ABCD or G0123ABCD).
+  session_id   One or more gc session ids to deliver inbound messages to.
+
+Examples:
+  gc slack-channel bind-room C0123ABCD sess-pl
+  gc slack-channel bind-room C0123ABCD sess-pl sess-cos sess-reviewer
+
+On success, prints the stored binding as JSON. The binding is persisted to
+<city>/.gc/slack-channel/channel_mappings.json.
+
+Requires: GC_CITY_NAME + GC_API_BASE_URL in the environment, plus `jq` and
+`curl` on PATH. The slack-channel service must be running.

--- a/slack-channel/commands/handle-alias.sh
+++ b/slack-channel/commands/handle-alias.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+# gc slack-channel handle-alias — register (or remove) a handle → session
+# alias for address-by-handle routing from any channel.
+set -eu
+. "$(dirname "$0")/_lib.sh"
+
+handle=""
+session=""
+remove="false"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --handle)    handle="$2"; shift 2 ;;
+    --handle=*)  handle="${1#*=}"; shift ;;
+    --session)   session="$2"; shift 2 ;;
+    --session=*) session="${1#*=}"; shift ;;
+    --remove)    remove="true"; shift ;;
+    -h|--help)   sc_help handle-alias ;;
+    *) sc_die "unknown argument: $1" 2 ;;
+  esac
+done
+
+[ -n "$handle" ] || sc_die "--handle is required" 2
+sc_require
+
+if [ "$remove" = "true" ]; then
+  req=$(jq -n --arg handle "$handle" '{handle: $handle}')
+  sc_call DELETE handle-alias "$req"
+  exit 0
+fi
+
+[ -n "$session" ] || sc_die "--session is required (or pass --remove)" 2
+req=$(jq -n --arg handle "$handle" --arg session "$session" '{handle: $handle, session_id: $session}')
+sc_call POST handle-alias "$req"

--- a/slack-channel/commands/handle-alias/command.toml
+++ b/slack-channel/commands/handle-alias/command.toml
@@ -1,0 +1,2 @@
+description = "Register a handle -> session alias for address-by-handle routing"
+run = "../handle-alias.sh"

--- a/slack-channel/commands/handle-alias/help.md
+++ b/slack-channel/commands/handle-alias/help.md
@@ -1,0 +1,34 @@
+Register a handle → session alias for address-by-handle routing.
+
+When an inbound Slack message leads with "@<handle>" (optionally followed by
+a colon) and the handle matches a registered alias, the adapter delivers
+that message to the aliased session — regardless of channel binding, from
+any channel. This lets humans address a session by name from anywhere
+(e.g. "@mayor: status?"). The aliased session receives the message with the
+"@handle" token stripped.
+
+Typical use: at startup register the well-known sessions —
+  gc slack-channel handle-alias --handle mayor --session <mayor session id>
+  gc slack-channel handle-alias --handle cos   --session <chief-of-staff id>
+
+Single-workspace at Tier 2 — aliases are not scoped per workspace. The
+adapter persists them to <city>/.gc/slack-channel/handle_aliases.json.
+
+Usage:
+  gc slack-channel handle-alias --handle <handle> --session <id>
+  gc slack-channel handle-alias --handle <handle> --remove
+
+Flags:
+  --handle    Handle to alias (e.g. "mayor"); a leading "@" is stripped and
+              the handle is lowercased. Must match [a-z0-9_-]+.
+  --session   Session id the handle routes to.
+  --remove    Remove the alias. Idempotent.
+
+Examples:
+  gc slack-channel handle-alias --handle mayor --session sess-mayor
+  gc slack-channel handle-alias --handle mayor --remove
+
+On success, prints the adapter's JSON receipt.
+
+Requires: GC_CITY_NAME + GC_API_BASE_URL, plus `jq` and `curl` on PATH. The
+slack-channel service must be running.

--- a/slack-channel/commands/identity.sh
+++ b/slack-channel/commands/identity.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+# gc slack-channel identity — register (or remove) a per-session Slack
+# identity override: the username + avatar a session posts under.
+set -eu
+. "$(dirname "$0")/_lib.sh"
+
+session=""
+display_name=""
+avatar_url=""
+avatar_emoji=""
+remove="false"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --session)        session="$2"; shift 2 ;;
+    --session=*)      session="${1#*=}"; shift ;;
+    --as)             display_name="$2"; shift 2 ;;
+    --as=*)           display_name="${1#*=}"; shift ;;
+    --avatar-url)     avatar_url="$2"; shift 2 ;;
+    --avatar-url=*)   avatar_url="${1#*=}"; shift ;;
+    --avatar-emoji)   avatar_emoji="$2"; shift 2 ;;
+    --avatar-emoji=*) avatar_emoji="${1#*=}"; shift ;;
+    --remove)         remove="true"; shift ;;
+    -h|--help)        sc_help identity ;;
+    *) sc_die "unknown argument: $1" 2 ;;
+  esac
+done
+
+sc_require
+sid=$(sc_session "$session")
+
+if [ "$remove" = "true" ]; then
+  req=$(jq -n --arg session "$sid" '{session_id: $session}')
+  sc_call DELETE identity "$req"
+  exit 0
+fi
+
+if [ -n "$avatar_url" ] && [ -n "$avatar_emoji" ]; then
+  sc_die "pass --avatar-url OR --avatar-emoji, not both" 2
+fi
+if [ -z "$display_name" ] && [ -z "$avatar_url" ] && [ -z "$avatar_emoji" ]; then
+  sc_die "supply at least one of --as, --avatar-url, --avatar-emoji" 2
+fi
+
+req=$(jq -n \
+  --arg session "$sid" \
+  --arg username "$display_name" \
+  --arg icon_url "$avatar_url" \
+  --arg icon_emoji "$avatar_emoji" \
+  '{session_id: $session}
+   + (if $username   == "" then {} else {username: $username}     end)
+   + (if $icon_url   == "" then {} else {icon_url: $icon_url}     end)
+   + (if $icon_emoji == "" then {} else {icon_emoji: $icon_emoji} end)')
+sc_call POST identity "$req"

--- a/slack-channel/commands/identity/command.toml
+++ b/slack-channel/commands/identity/command.toml
@@ -1,0 +1,2 @@
+description = "Register a per-session Slack identity override (username + avatar)"
+run = "../identity.sh"

--- a/slack-channel/commands/identity/help.md
+++ b/slack-channel/commands/identity/help.md
@@ -1,0 +1,37 @@
+Register a per-session Slack identity override.
+
+Each gc session can post under a distinct username + avatar (Slack's
+`chat:write.customize`). Call this once at session start; every subsequent
+`publish` / `publish-to-channel` / `reply-current` from that session posts
+under the chosen identity. The adapter persists the override to
+<city>/.gc/slack-channel/identities.json.
+
+The Slack app must have `chat:write.customize` granted (and be reinstalled)
+for the override to take effect — without it, Slack ignores the
+username/icon and the post falls through under the default bot identity.
+
+Usage:
+  gc slack-channel identity [--session <id>] --as <name>
+                            [--avatar-url <url> | --avatar-emoji <name>]
+  gc slack-channel identity [--session <id>] --remove
+
+Flags:
+  --session       Session to set identity for (default: $GC_SESSION_ID).
+  --as            Display name to post under (e.g. "Gas City PL").
+  --avatar-url    Avatar image URL. Mutually exclusive with --avatar-emoji.
+  --avatar-emoji  Avatar emoji name without colons (e.g. "robot_face").
+                  Mutually exclusive with --avatar-url.
+  --remove        Remove the session's identity override. Idempotent.
+
+At least one of --as / --avatar-url / --avatar-emoji is required unless
+--remove is given.
+
+Examples:
+  gc slack-channel identity --as "Gas City PL" --avatar-emoji robot_face
+  gc slack-channel identity --session sess-pl --as "Reviewer"
+  gc slack-channel identity --remove
+
+On success, prints the adapter's JSON receipt.
+
+Requires: GC_CITY_NAME + GC_API_BASE_URL, plus `jq` and `curl` on PATH. The
+slack-channel service must be running.

--- a/slack-channel/commands/publish-to-channel.sh
+++ b/slack-channel/commands/publish-to-channel.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+# gc slack-channel publish-to-channel — post to a channel by id, bypassing
+# the binding lookup. The session id (if any) still drives the identity
+# override.
+set -eu
+. "$(dirname "$0")/_lib.sh"
+
+channel=""
+session=""
+thread_ts=""
+body=""
+body_file=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --channel)     channel="$2"; shift 2 ;;
+    --channel=*)   channel="${1#*=}"; shift ;;
+    --session)     session="$2"; shift 2 ;;
+    --session=*)   session="${1#*=}"; shift ;;
+    --thread-ts)   thread_ts="$2"; shift 2 ;;
+    --thread-ts=*) thread_ts="${1#*=}"; shift ;;
+    --body)        body="$2"; shift 2 ;;
+    --body=*)      body="${1#*=}"; shift ;;
+    --body-file)   body_file="$2"; shift 2 ;;
+    --body-file=*) body_file="${1#*=}"; shift ;;
+    -h|--help)     sc_help publish-to-channel ;;
+    *) sc_die "unknown argument: $1" 2 ;;
+  esac
+done
+
+[ -n "$channel" ] || sc_die "--channel is required" 2
+sc_require
+text=$(sc_load_body "$body" "$body_file")
+# Default to the current session so its identity override applies, but do
+# not require one — publish-to-channel works with no session attribution.
+[ -n "$session" ] || session="${GC_SESSION_ID:-}"
+
+req=$(jq -n \
+  --arg channel "$channel" \
+  --arg session "$session" \
+  --arg body "$text" \
+  --arg thread_ts "$thread_ts" \
+  '{channel_id: $channel, body: $body}
+   + (if $session == "" then {} else {session_id: $session} end)
+   + (if $thread_ts == "" then {} else {thread_ts: $thread_ts} end)')
+sc_call POST publish-to-channel "$req"

--- a/slack-channel/commands/publish-to-channel/command.toml
+++ b/slack-channel/commands/publish-to-channel/command.toml
@@ -1,0 +1,2 @@
+description = "Publish into a Slack channel by id, bypassing binding lookup"
+run = "../publish-to-channel.sh"

--- a/slack-channel/commands/publish-to-channel/help.md
+++ b/slack-channel/commands/publish-to-channel/help.md
@@ -1,0 +1,29 @@
+Publish a message into a Slack channel by id, bypassing the binding lookup.
+
+Unlike `publish`, the channel is named explicitly, so a session can post
+into a channel it has no binding for — useful for a session bound to
+several channels, or for one-off posts. The session id (defaulting to the
+current session) still selects the identity override applied to the post.
+
+Usage:
+  gc slack-channel publish-to-channel --channel <id>
+                                      (--body <text> | --body-file <path>)
+                                      [--session <id>] [--thread-ts <ts>]
+
+Flags:
+  --channel    Slack channel id (C..., G..., or D...) — required.
+  --body       Message text. Mutually exclusive with --body-file.
+  --body-file  Read the message body from a file.
+  --session    Session to attribute the post to (identity override).
+               Defaults to the current session ($GC_SESSION_ID).
+  --thread-ts  Slack message ts to thread under (optional).
+
+Examples:
+  gc slack-channel publish-to-channel --channel C0123 --body "deploy started"
+  gc slack-channel publish-to-channel --channel C0123 \
+    --thread-ts 1700000000.0001 --body "done"
+
+On success, prints the adapter's JSON receipt {"ok":true,"ts":...}.
+
+Requires: GC_CITY_NAME + GC_API_BASE_URL, plus `jq` and `curl` on PATH. The
+slack-channel service must be running.

--- a/slack-channel/commands/publish.sh
+++ b/slack-channel/commands/publish.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+# gc slack-channel publish — post into the channel a session is bound to.
+#
+# Resolves the session's channel binding (run bind-dm/bind-room first) and
+# posts there, applying the session's identity override if one is set.
+set -eu
+. "$(dirname "$0")/_lib.sh"
+
+session=""
+reply_to=""
+body=""
+body_file=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --session)     session="$2"; shift 2 ;;
+    --session=*)   session="${1#*=}"; shift ;;
+    --reply-to)    reply_to="$2"; shift 2 ;;
+    --reply-to=*)  reply_to="${1#*=}"; shift ;;
+    --body)        body="$2"; shift 2 ;;
+    --body=*)      body="${1#*=}"; shift ;;
+    --body-file)   body_file="$2"; shift 2 ;;
+    --body-file=*) body_file="${1#*=}"; shift ;;
+    -h|--help)     sc_help publish ;;
+    *) sc_die "unknown argument: $1" 2 ;;
+  esac
+done
+
+sc_require
+text=$(sc_load_body "$body" "$body_file")
+sid=$(sc_session "$session")
+
+req=$(jq -n \
+  --arg session "$sid" \
+  --arg body "$text" \
+  --arg reply_to "$reply_to" \
+  '{session_id: $session, body: $body} + (if $reply_to == "" then {} else {reply_to: $reply_to} end)')
+sc_call POST publish "$req"

--- a/slack-channel/commands/publish/command.toml
+++ b/slack-channel/commands/publish/command.toml
@@ -1,0 +1,2 @@
+description = "Publish a message into the channel a session is bound to"
+run = "../publish.sh"

--- a/slack-channel/commands/publish/help.md
+++ b/slack-channel/commands/publish/help.md
@@ -1,0 +1,33 @@
+Publish a message into the Slack channel a session is bound to.
+
+`publish` resolves the channel from the session's binding — use it for
+unprompted posts (status pings, cron-driven updates) that don't depend on a
+prior inbound message. If the session has a registered identity override,
+the message posts under that username/avatar.
+
+The session must be bound to exactly one channel. If it is bound to none,
+run `bind-dm`/`bind-room` first; if it is bound to several, use
+`publish-to-channel --channel` to disambiguate.
+
+Use `reply-current` instead when you want to thread under a message that
+just arrived.
+
+Usage:
+  gc slack-channel publish [--session <id>] (--body <text> | --body-file <path>)
+                           [--reply-to <ts>]
+
+Flags:
+  --session    Session whose binding to publish into. Defaults to the
+               current session ($GC_SESSION_ID).
+  --body       Message text. Mutually exclusive with --body-file.
+  --body-file  Read the message body from a file.
+  --reply-to   Slack message ts to thread under (optional).
+
+Examples:
+  gc slack-channel publish --body "build is green"
+  gc slack-channel publish --session sess-pl --body-file /tmp/status.md
+
+On success, prints the adapter's JSON receipt {"ok":true,"ts":...}.
+
+Requires: GC_CITY_NAME + GC_API_BASE_URL, plus `jq` and `curl` on PATH. The
+slack-channel service must be running.

--- a/slack-channel/commands/react.sh
+++ b/slack-channel/commands/react.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+# gc slack-channel react — add an emoji reaction to the latest inbound Slack
+# message for this session, or to an explicit (channel, ts) pair.
+set -eu
+. "$(dirname "$0")/_lib.sh"
+
+session=""
+conversation_id=""
+message_id=""
+emoji="eyes"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --session)           session="$2"; shift 2 ;;
+    --session=*)         session="${1#*=}"; shift ;;
+    --conversation-id)   conversation_id="$2"; shift 2 ;;
+    --conversation-id=*) conversation_id="${1#*=}"; shift ;;
+    --message-id)        message_id="$2"; shift 2 ;;
+    --message-id=*)      message_id="${1#*=}"; shift ;;
+    --emoji)             emoji="$2"; shift 2 ;;
+    --emoji=*)           emoji="${1#*=}"; shift ;;
+    -h|--help)           sc_help react ;;
+    *) sc_die "unknown argument: $1" 2 ;;
+  esac
+done
+
+sc_require
+
+# Explicit mode names channel + ts directly; otherwise react on the
+# session's latest inbound, so the session id must be resolvable.
+if [ -n "$conversation_id" ] || [ -n "$message_id" ]; then
+  req=$(jq -n \
+    --arg conversation_id "$conversation_id" \
+    --arg message_id "$message_id" \
+    --arg emoji "$emoji" \
+    '{conversation_id: $conversation_id, message_id: $message_id, emoji: $emoji}')
+else
+  sid=$(sc_session "$session")
+  req=$(jq -n --arg session "$sid" --arg emoji "$emoji" '{session_id: $session, emoji: $emoji}')
+fi
+sc_call POST react "$req"

--- a/slack-channel/commands/react/command.toml
+++ b/slack-channel/commands/react/command.toml
@@ -1,0 +1,2 @@
+description = "Add an emoji reaction to this session's latest inbound message"
+run = "../react.sh"

--- a/slack-channel/commands/react/help.md
+++ b/slack-channel/commands/react/help.md
@@ -1,0 +1,29 @@
+Add an emoji reaction to a Slack message.
+
+Default mode reacts on the latest inbound message delivered to this session
+— the "got it, working on a reply" receipt. Explicit mode names the channel
+and message ts directly.
+
+Usage:
+  gc slack-channel react [--session <id>] [--emoji <name>]
+  gc slack-channel react --conversation-id <id> --message-id <ts> [--emoji <name>]
+
+Flags:
+  --session          Override the session id (default: $GC_SESSION_ID).
+  --emoji            Emoji name without colons (default: eyes). ":eyes:"
+                     and "eyes" both work.
+  --conversation-id  Slack channel id (explicit mode; requires --message-id).
+  --message-id       Slack message ts (explicit mode; requires
+                     --conversation-id).
+
+Examples:
+  gc slack-channel react
+  gc slack-channel react --emoji white_check_mark
+  gc slack-channel react --conversation-id C0123 --message-id 1700000000.0001 --emoji tada
+
+already_reacted is treated as success. On success, prints the adapter's
+JSON receipt.
+
+Requires: GC_CITY_NAME + GC_API_BASE_URL, plus `jq` and `curl` on PATH, and
+the `reactions:write` scope on the Slack app. The slack-channel service must
+be running.

--- a/slack-channel/commands/reply-current.sh
+++ b/slack-channel/commands/reply-current.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+# gc slack-channel reply-current — reply into the conversation of the latest
+# inbound message delivered to this session.
+set -eu
+. "$(dirname "$0")/_lib.sh"
+
+session=""
+reply_to=""
+thread_current="false"
+body=""
+body_file=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --session)        session="$2"; shift 2 ;;
+    --session=*)      session="${1#*=}"; shift ;;
+    --reply-to)       reply_to="$2"; shift 2 ;;
+    --reply-to=*)     reply_to="${1#*=}"; shift ;;
+    --thread-current) thread_current="true"; shift ;;
+    --body)           body="$2"; shift 2 ;;
+    --body=*)         body="${1#*=}"; shift ;;
+    --body-file)      body_file="$2"; shift 2 ;;
+    --body-file=*)    body_file="${1#*=}"; shift ;;
+    -h|--help)        sc_help reply-current ;;
+    *) sc_die "unknown argument: $1" 2 ;;
+  esac
+done
+
+sc_require
+text=$(sc_load_body "$body" "$body_file")
+sid=$(sc_session "$session")
+
+req=$(jq -n \
+  --arg session "$sid" \
+  --arg body "$text" \
+  --arg reply_to "$reply_to" \
+  --argjson thread_current "$thread_current" \
+  '{session_id: $session, body: $body, thread_current: $thread_current}
+   + (if $reply_to == "" then {} else {reply_to: $reply_to} end)')
+sc_call POST reply-current "$req"

--- a/slack-channel/commands/reply-current/command.toml
+++ b/slack-channel/commands/reply-current/command.toml
@@ -1,0 +1,2 @@
+description = "Reply into the conversation of this session's latest inbound"
+run = "../reply-current.sh"

--- a/slack-channel/commands/reply-current/help.md
+++ b/slack-channel/commands/reply-current/help.md
@@ -1,0 +1,34 @@
+Reply into the conversation of the latest inbound message delivered to this
+session.
+
+The adapter remembers, per session, the last Slack message it bridged in.
+`reply-current` posts back into that same channel — the natural "answer the
+thing that just pinged me" verb. With `--thread-current` it threads the
+reply under that message; with `--reply-to <ts>` it threads under a specific
+ts; with neither it posts unthreaded into the channel.
+
+If the adapter has seen no inbound for this session (e.g. just restarted),
+it falls back to the session's single channel binding. If there is neither a
+recent inbound nor a single binding, use `publish-to-channel`.
+
+Usage:
+  gc slack-channel reply-current [--session <id>]
+                                 (--body <text> | --body-file <path>)
+                                 [--thread-current | --reply-to <ts>]
+
+Flags:
+  --session         Override the session id (default: $GC_SESSION_ID).
+  --body            Message text. Mutually exclusive with --body-file.
+  --body-file       Read the message body from a file.
+  --thread-current  Thread under the latest inbound message. Mutually
+                    exclusive with --reply-to.
+  --reply-to        Slack message ts to thread under.
+
+Examples:
+  gc slack-channel reply-current --body "on it" --thread-current
+  gc slack-channel reply-current --body "see PR #42"
+
+On success, prints the adapter's JSON receipt {"ok":true,"ts":...}.
+
+Requires: GC_CITY_NAME + GC_API_BASE_URL, plus `jq` and `curl` on PATH. The
+slack-channel service must be running.

--- a/slack-channel/manifest/app.json
+++ b/slack-channel/manifest/app.json
@@ -1,0 +1,51 @@
+{
+  "display_information": {
+    "name": "gc-channel",
+    "description": "Bridge Slack channels and DMs to your Gas City sessions.",
+    "background_color": "#1f2933",
+    "long_description": "slack-channel (Tier 2) bridges human Slack conversations to Gas City sessions. Bind a channel or DM to one or more gc sessions and every message there is delivered to them; address a session from any channel with '@handle'. Per-session display-name and avatar overrides use chat:write.customize so each bound session appears under its own identity. See https://github.com/gastownhall/gascity-packs/tree/main/slack-channel for setup."
+  },
+  "features": {
+    "bot_user": {
+      "display_name": "gc-channel",
+      "always_online": true
+    },
+    "app_home": {
+      "home_tab_enabled": false,
+      "messages_tab_enabled": true,
+      "messages_tab_read_only_enabled": false
+    }
+  },
+  "oauth_config": {
+    "scopes": {
+      "bot": [
+        "app_mentions:read",
+        "channels:history",
+        "chat:write",
+        "chat:write.customize",
+        "chat:write.public",
+        "groups:history",
+        "im:history",
+        "mpim:history",
+        "reactions:write"
+      ]
+    }
+  },
+  "settings": {
+    "event_subscriptions": {
+      "bot_events": [
+        "app_mention",
+        "message.channels",
+        "message.groups",
+        "message.im",
+        "message.mpim"
+      ]
+    },
+    "interactivity": {
+      "is_enabled": false
+    },
+    "org_deploy_enabled": false,
+    "socket_mode_enabled": false,
+    "token_rotation_enabled": false
+  }
+}

--- a/slack-channel/pack.toml
+++ b/slack-channel/pack.toml
@@ -1,0 +1,58 @@
+# slack-channel — Tier 2 of the Slack pack family. "Team channel ↔ session
+# graph."
+#
+# The middle Slack tier: built on slack-mini's single-file kernel, it adds
+# the state Tier 1 omits — channel bindings (one channel → many sessions),
+# per-session identity overrides, and "@handle" address-by-handle routing.
+# A message in a bound channel is delivered to every bound session, not just
+# @-mentions.
+#
+# Pack-shipped binary:
+#
+#   - Adapter (./adapter/gc-slack-channel-adapter, built from
+#     adapter/*.go). A Slack Events API receiver + outbound publisher that
+#     also owns three on-disk registries under
+#     <GC_CITY_PATH>/.gc/slack-channel/. The [[service]] block below has gc
+#     supervise it as a proxy_process: it binds a Unix domain socket at
+#     $GC_SERVICE_SOCKET for the verb endpoints + /healthz, and a public TCP
+#     port for /slack/events + /slack/interactions (terminate TLS in front
+#     of it, e.g. Tailscale Funnel).
+#
+# This pack ships NO operator CLI binary: every verb is a bash wrapper
+# (commands/<verb>.sh) that POSTs to the adapter through gc's
+# /svc/slack-channel reverse proxy.
+#
+# Tiering: slack-channel sits between slack-mini (Tier 1) and slack-full
+# (Tier 3). Pick exactly one Slack tier per city — they all expose a Slack
+# runtime surface and cannot coexist.
+
+[pack]
+name = "slack-channel"
+version = "0.1.0"
+schema = 2
+
+# proxy_process service: gc supervises the adapter as part of the city's
+# service set. The adapter binds a UDS at $GC_SERVICE_SOCKET for the verb
+# endpoints + /healthz; gc reverse-proxies /svc/slack-channel/* to it. The
+# adapter also binds public TCP (LISTEN_PUBLIC, default 0.0.0.0:8775) for
+# /slack/events + /slack/interactions. proxy_process owns only the UDS
+# lifecycle.
+#
+# The service is named "slack-channel" (matching the pack) so it does not
+# collide with a slack-mini or slack-full install. Per the tiering design,
+# run exactly one Slack tier per city regardless.
+#
+# Secrets (SLACK_BOT_TOKEN, SLACK_SIGNING_SECRET, SLACK_WORKSPACE_ID),
+# GC_CITY_NAME, and GC_CITY_PATH are inherited from the service environment
+# at start. See README.md "Configure".
+
+[[service]]
+name = "slack-channel"
+kind = "proxy_process"
+
+[service.publication]
+visibility = "private"
+
+[service.process]
+command = ["./adapter/gc-slack-channel-adapter"]
+health_path = "/healthz"

--- a/slack-channel/schema/channel_mappings.schema.json
+++ b/slack-channel/schema/channel_mappings.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/gastownhall/gascity-packs/slack-channel/schema/channel_mappings.schema.json",
+  "title": "slack-channel channel_mappings.json",
+  "description": "Authoritative schema for the channel binding registry persisted at <GC_CITY_PATH>/.gc/slack-channel/channel_mappings.json. The slack-channel adapter is the sole writer (via the bind-dm / bind-room verb endpoints) and reader (on the inbound path). The JSON object key is the composite '<workspace_id>:<channel_id>'. A message arriving in a bound channel is delivered to every session in session_ids.",
+  "type": "object",
+  "additionalProperties": { "$ref": "#/$defs/channelBinding" },
+  "$defs": {
+    "channelBinding": {
+      "type": "object",
+      "required": ["workspace_id", "channel_id", "kind", "session_ids", "created_at", "updated_at"],
+      "additionalProperties": false,
+      "properties": {
+        "workspace_id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Slack workspace (team) id, e.g. T0123456. Required component of the composite key."
+        },
+        "channel_id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Slack channel or DM id, e.g. C0123456 or D0123456. Required component of the composite key."
+        },
+        "kind": {
+          "type": "string",
+          "enum": ["dm", "room"],
+          "description": "Conversation kind. 'dm' for direct-message bindings (bind-dm), 'room' for channel bindings (bind-room)."
+        },
+        "session_ids": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1, "pattern": "^[^\\s]+$" },
+          "minItems": 1,
+          "uniqueItems": true,
+          "description": "Sorted, deduplicated gc session ids that receive every message in the bound channel. Whitespace is not allowed in a session id. At least one is required."
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "RFC3339 timestamp of the first successful binding for this key. Idempotent re-binds preserve this value."
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "RFC3339 timestamp of the most recent successful binding for this key. Re-binds advance this in place."
+        }
+      }
+    }
+  }
+}

--- a/slack-channel/schema/handle_aliases.schema.json
+++ b/slack-channel/schema/handle_aliases.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/gastownhall/gascity-packs/slack-channel/schema/handle_aliases.schema.json",
+  "title": "slack-channel handle_aliases.json",
+  "description": "Authoritative schema for the handle-alias registry persisted at <GC_CITY_PATH>/.gc/slack-channel/handle_aliases.json. The slack-channel adapter is the sole writer (via the handle-alias verb endpoint) and reader (on the inbound path). The JSON object key is the normalized handle (lowercased, leading '@' stripped). When an inbound message leads with '@<handle>[:]', it is routed to the aliased session regardless of channel binding. Single-workspace at Tier 2 — aliases are not scoped per workspace.",
+  "type": "object",
+  "additionalProperties": { "$ref": "#/$defs/handleAlias" },
+  "$defs": {
+    "handleAlias": {
+      "type": "object",
+      "required": ["handle", "session_id", "created_at", "updated_at"],
+      "additionalProperties": false,
+      "properties": {
+        "handle": {
+          "type": "string",
+          "pattern": "^[a-z0-9_-]+$",
+          "description": "Normalized handle (lowercase, no leading '@'). Matches the JSON object key. Must match [a-z0-9_-]+."
+        },
+        "session_id": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^[^\\s]+$",
+          "description": "gc session id this handle routes to. Whitespace is not allowed."
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "RFC3339 timestamp of first registration. Idempotent updates preserve this value."
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "RFC3339 timestamp of the most recent update. Advances in place."
+        }
+      }
+    }
+  }
+}

--- a/slack-channel/schema/identities.schema.json
+++ b/slack-channel/schema/identities.schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/gastownhall/gascity-packs/slack-channel/schema/identities.schema.json",
+  "title": "slack-channel identities.json",
+  "description": "Authoritative schema for the per-session identity registry persisted at <GC_CITY_PATH>/.gc/slack-channel/identities.json. The slack-channel adapter is the sole writer (via the identity verb endpoint) and reader (injected into chat.postMessage on every outbound). The JSON object key is the gc session id. icon_url and icon_emoji are mutually exclusive; at least one of username / icon_url / icon_emoji is set.",
+  "type": "object",
+  "additionalProperties": { "$ref": "#/$defs/identity" },
+  "$defs": {
+    "identity": {
+      "type": "object",
+      "required": ["session_id", "created_at", "updated_at"],
+      "additionalProperties": false,
+      "anyOf": [
+        { "required": ["username"] },
+        { "required": ["icon_url"] },
+        { "required": ["icon_emoji"] }
+      ],
+      "not": { "required": ["icon_url", "icon_emoji"] },
+      "properties": {
+        "session_id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "gc session id this identity applies to. Matches the JSON object key."
+        },
+        "username": {
+          "type": "string",
+          "description": "Display name the session posts under (Slack chat:write.customize 'username')."
+        },
+        "icon_url": {
+          "type": "string",
+          "description": "Avatar image URL (Slack 'icon_url'). Mutually exclusive with icon_emoji."
+        },
+        "icon_emoji": {
+          "type": "string",
+          "description": "Avatar emoji name without colons, e.g. 'robot_face' (Slack 'icon_emoji'). Mutually exclusive with icon_url."
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "RFC3339 timestamp of first registration. Idempotent updates preserve this value."
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "RFC3339 timestamp of the most recent update. Advances in place."
+        }
+      }
+    }
+  }
+}

--- a/slack-channel/tests/test_schemas.py
+++ b/slack-channel/tests/test_schemas.py
@@ -1,0 +1,143 @@
+"""Validate slack-channel registry records against the shipped JSON Schemas.
+
+The schemas in ../schema are the documented contract for the three on-disk
+registries the adapter owns. This test asserts that records matching the
+adapter's serialized shape pass, and that the documented constraints
+(required keys, enums, mutual exclusions) actually reject bad records — so
+"schema documented" and "schema validated" stay in lockstep.
+
+Run: python3 -m pytest slack-channel/tests/
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+import pytest
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import ValidationError
+
+SCHEMA_DIR = pathlib.Path(__file__).resolve().parent.parent / "schema"
+
+
+def _validator(name: str) -> Draft202012Validator:
+    schema = json.loads((SCHEMA_DIR / name).read_text(encoding="utf-8"))
+    Draft202012Validator.check_schema(schema)
+    return Draft202012Validator(schema)
+
+
+# --- channel_mappings ------------------------------------------------------
+
+CHANNEL_V = "channel_mappings.schema.json"
+
+
+def test_channel_mappings_valid():
+    doc = {
+        "T123:C1": {
+            "workspace_id": "T123",
+            "channel_id": "C1",
+            "kind": "room",
+            "session_ids": ["s1", "s2"],
+            "created_at": "2026-05-30T12:00:00Z",
+            "updated_at": "2026-05-30T12:00:00Z",
+        }
+    }
+    _validator(CHANNEL_V).validate(doc)
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda r: r.pop("kind"),
+        lambda r: r.update(kind="thread"),
+        lambda r: r.update(session_ids=[]),
+        lambda r: r.update(extra="nope"),
+    ],
+)
+def test_channel_mappings_rejects(mutate):
+    rec = {
+        "workspace_id": "T123",
+        "channel_id": "C1",
+        "kind": "room",
+        "session_ids": ["s1"],
+        "created_at": "2026-05-30T12:00:00Z",
+        "updated_at": "2026-05-30T12:00:00Z",
+    }
+    mutate(rec)
+    with pytest.raises(ValidationError):
+        _validator(CHANNEL_V).validate({"T123:C1": rec})
+
+
+# --- identities ------------------------------------------------------------
+
+IDENTITY_V = "identities.schema.json"
+
+
+def test_identities_username_only_valid():
+    doc = {
+        "s1": {
+            "session_id": "s1",
+            "username": "Gas City PL",
+            "created_at": "2026-05-30T12:00:00Z",
+            "updated_at": "2026-05-30T12:00:00Z",
+        }
+    }
+    _validator(IDENTITY_V).validate(doc)
+
+
+def test_identities_rejects_both_icons():
+    doc = {
+        "s1": {
+            "session_id": "s1",
+            "icon_url": "https://x/a.png",
+            "icon_emoji": "robot_face",
+            "created_at": "2026-05-30T12:00:00Z",
+            "updated_at": "2026-05-30T12:00:00Z",
+        }
+    }
+    with pytest.raises(ValidationError):
+        _validator(IDENTITY_V).validate(doc)
+
+
+def test_identities_rejects_all_empty():
+    doc = {
+        "s1": {
+            "session_id": "s1",
+            "created_at": "2026-05-30T12:00:00Z",
+            "updated_at": "2026-05-30T12:00:00Z",
+        }
+    }
+    with pytest.raises(ValidationError):
+        _validator(IDENTITY_V).validate(doc)
+
+
+# --- handle_aliases --------------------------------------------------------
+
+ALIAS_V = "handle_aliases.schema.json"
+
+
+def test_handle_aliases_valid():
+    doc = {
+        "mayor": {
+            "handle": "mayor",
+            "session_id": "sess-m",
+            "created_at": "2026-05-30T12:00:00Z",
+            "updated_at": "2026-05-30T12:00:00Z",
+        }
+    }
+    _validator(ALIAS_V).validate(doc)
+
+
+@pytest.mark.parametrize("bad_handle", ["Mayor", "with space", "@mayor", ""])
+def test_handle_aliases_rejects_bad_handle(bad_handle):
+    doc = {
+        bad_handle: {
+            "handle": bad_handle,
+            "session_id": "sess-m",
+            "created_at": "2026-05-30T12:00:00Z",
+            "updated_at": "2026-05-30T12:00:00Z",
+        }
+    }
+    with pytest.raises(ValidationError):
+        _validator(ALIAS_V).validate(doc)

--- a/slack-mini/.gitignore
+++ b/slack-mini/.gitignore
@@ -1,0 +1,3 @@
+# Built adapter binary — produced by `go build` in adapter/ and read in
+# place by the [[service]] proxy_process command.
+adapter/gc-slack-mini-adapter

--- a/slack-mini/CHANGELOG.md
+++ b/slack-mini/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Changelog
+
+All notable changes to slack-mini are documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] — Tier 1 extraction
+
+Initial release. slack-mini is Tier 1 of the Slack pack family — the
+minimum viable Slack→gc surface, extracted from slack-pack per the
+slack-pack tiering design memo (`docs/design/slack-pack-tiering.md`,
+landing separately; `gc-yrw.1`).
+
+### Added
+
+- Single-file Slack adapter (`adapter/main.go`, module
+  `github.com/sjarmak/gc-slack-mini-adapter`):
+  - Public Slack Events API receiver at `/slack/events`, HMAC-verified
+    with `SLACK_SIGNING_SECRET` and a 5-minute replay window.
+  - Handles `app_mention` only; each verified mention is bridged to gc by
+    POSTing `/v0/city/{city}/extmsg/inbound`, addressed to the mayor
+    session (override with `SLACK_MINI_INBOUND_TARGET`).
+  - Outbound `/post-message` endpoint on the gc-proxied UDS, posting plain
+    text to Slack via `chat.postMessage` with the workspace bot token.
+  - Self-registers as an extmsg adapter on start (`REGISTER_ON_START`).
+- `gc slack-mini post-message` verb — a bash wrapper
+  (`commands/post-message.sh`) that relays to the adapter through gc's
+  `/svc/slack-mini` reverse proxy. No operator CLI binary at this tier.
+- Minimal Slack app manifest (`manifest/app.json`): scopes
+  `app_mentions:read`, `chat:write`, `chat:write.public`; subscribes only
+  to the `app_mention` bot event.
+- `pack.toml` declaring the adapter as a `proxy_process` service named
+  `slack-mini`.
+
+### Notes
+
+- No on-disk registries at Tier 1 (no channel bindings, per-session
+  identity, apps, rig, or room state). Those arrive in slack-channel
+  (Tier 2) and slack-full (Tier 3).
+- Pick exactly one Slack tier per city.

--- a/slack-mini/LICENSE
+++ b/slack-mini/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Steve Yegge
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/slack-mini/README.md
+++ b/slack-mini/README.md
@@ -1,0 +1,125 @@
+# slack-mini
+
+**Talk to your Gas City mayor from Slack.** Add a bot to your workspace,
+`@`-mention it from any channel, and the mention bridges to your gc mayor
+session. Reply back with one verb.
+
+slack-mini is **Tier 1** of the Slack pack family — the smallest surface
+that gets a human talking to gc over Slack. It ships a single-file adapter
+and one outbound verb. No channel bindings, no per-session identity, no
+multi-rig routing — those live in `slack-channel` (Tier 2) and `slack-full`
+(Tier 3). See the [slack-pack tiering design memo](../docs/design/slack-pack-tiering.md)
+(landing separately).
+
+> Pick exactly one Slack tier per city. The tiers are alternatives, not
+> layers you stack.
+
+## What you get
+
+- **Inbound:** `@gc-mayor what's the convoy status?` in any channel the bot
+  is in → delivered to your gc mayor session.
+- **Outbound:** `gc slack-mini post-message --channel C0123 --text "…"` →
+  posts to a channel, optionally in a thread.
+
+## Install in 3 minutes
+
+### 1. Create the Slack app (1 min)
+
+Create an app from the shipped manifest at
+[`manifest/app.json`](./manifest/app.json):
+
+1. <https://api.slack.com/apps> → **Create New App** → **From a manifest**.
+2. Pick your workspace, paste `manifest/app.json`, create.
+3. **Install to Workspace** and copy the **Bot User OAuth Token**
+   (`xoxb-…`).
+4. From **Basic Information**, copy the **Signing Secret**.
+
+The manifest requests only three scopes — `app_mentions:read`,
+`chat:write`, `chat:write.public` — and subscribes to the `app_mention`
+event.
+
+### 2. Configure the city (1 min)
+
+Import the pack in your city's `pack.toml`:
+
+```toml
+[imports.slack-mini]
+source = "../packs/slack-mini"
+```
+
+Provide the adapter's environment (e.g. in your city service env or
+`~/.config/gc-slack-mini-adapter/env`):
+
+```sh
+SLACK_BOT_TOKEN=xoxb-...          # from step 1
+SLACK_SIGNING_SECRET=...          # from step 1
+SLACK_WORKSPACE_ID=T0123ABCD      # your Slack team id
+GC_CITY_NAME=<your-city-name>     # the gc city to bridge into
+```
+
+That's the full required set — four variables.
+
+### 3. Expose the events endpoint and start (1 min)
+
+The adapter listens for Slack events on public TCP (`LISTEN_PUBLIC`,
+default `0.0.0.0:8775`). Terminate TLS in front of it and give Slack a
+public URL — [Tailscale Funnel](https://tailscale.com/kb/1223/funnel) is
+the easy path:
+
+```sh
+tailscale funnel 8775
+```
+
+Then in the Slack app's **Event Subscriptions**, set the Request URL to
+`https://<your-funnel-host>/slack/events`. Slack sends a one-time
+`url_verification` challenge, which the adapter answers automatically.
+
+gc supervises the adapter as a `proxy_process` service (named
+`slack-mini`); building the binary is a one-time `go build` in `adapter/`
+(see [Build](#build)). Start your city and `@`-mention the bot.
+
+## Replying in a thread
+
+When the mayor session handles an inbound mention, the conversation carries
+the Slack message `ts` as its reply-to id. Answer in the same thread with:
+
+```sh
+gc slack-mini post-message --channel C0123 \
+  --thread-ts 1700000000.0001 --text "on it — see PR #42"
+```
+
+## Build
+
+The adapter is a single Go file with no external dependencies:
+
+```sh
+cd adapter
+go build -o gc-slack-mini-adapter ./...
+```
+
+The built binary is git-ignored; the `[[service]]` block runs it in place.
+
+## Configuration reference
+
+| Variable | Required | Default | Purpose |
+| --- | :---: | --- | --- |
+| `SLACK_BOT_TOKEN` | ✓ | — | Bot token for `chat.postMessage` and the inbound POST. |
+| `SLACK_SIGNING_SECRET` | ✓ | — | HMAC secret for verifying Slack requests. |
+| `SLACK_WORKSPACE_ID` | ✓ | — | Slack team id (the extmsg account id). |
+| `GC_CITY_NAME` | ✓ | — | gc city to bridge into. |
+| `LISTEN_PUBLIC` | | `0.0.0.0:8775` | Public bind for `/slack/events`. |
+| `LISTEN_INTERNAL` | | `127.0.0.1:8776` | TCP bind for `/post-message` when not run as a gc proxy_process (no `GC_SERVICE_SOCKET`). |
+| `REGISTER_ON_START` | | `true` | Self-register as an extmsg adapter on start. |
+| `SLACK_MINI_INBOUND_TARGET` | | `mayor` | Session handle inbound mentions address. |
+| `SLACK_API_BASE` | | `https://slack.com/api` | Slack web API origin (override for relays/tests). |
+| `GC_API_BASE_URL` | | `http://127.0.0.1:9443` | gc API base. |
+
+`GC_SERVICE_SOCKET`, `GC_SERVICE_URL_PREFIX`, and `GC_API_BASE_URL` are
+injected by gc when the adapter runs as a `proxy_process` service.
+
+## Upgrading to a larger tier
+
+To gain channel bindings, per-session identity, or multi-rig routing, swap
+this pack for `slack-channel` or `slack-full`. The bot token, signing
+secret, and workspace id carry over unchanged. See the tiering memo's
+migration section.

--- a/slack-mini/adapter/go.mod
+++ b/slack-mini/adapter/go.mod
@@ -1,0 +1,3 @@
+module github.com/sjarmak/gc-slack-mini-adapter
+
+go 1.25.9

--- a/slack-mini/adapter/main.go
+++ b/slack-mini/adapter/main.go
@@ -1,0 +1,640 @@
+// gc-slack-mini-adapter — the Tier-1 ("slack-mini") Slack ↔ gc bridge.
+//
+// The minimal viable Slack→mayor surface, single-file by design:
+//
+//   - Inbound: a public HTTPS receiver for the Slack Events API. Only
+//     `app_mention` is handled. Each verified mention is bridged to gc by
+//     POSTing /v0/city/{city}/extmsg/inbound, addressed to the mayor
+//     session (override with SLACK_MINI_INBOUND_TARGET).
+//
+//   - Outbound: a UDS endpoint (/post-message) that posts plain text to a
+//     Slack channel via chat.postMessage using the workspace bot token.
+//     The pack's commands/post-message.sh wrapper reaches it through gc's
+//     /svc/slack-mini reverse proxy. This is the only outbound verb at Tier 1.
+//
+// Tier 1 keeps NO on-disk registries: no channel bindings, no per-session
+// identity, no apps registry, no rig/room state. Those belong to
+// slack-channel (Tier 2) and slack-full (Tier 3). See
+// docs/design/slack-pack-tiering.md.
+//
+// Required env:
+//
+//	SLACK_BOT_TOKEN        Bot token (xoxb-...) for outbound chat.postMessage.
+//	                       Not used on the inbound path (which only verifies
+//	                       the signing secret and POSTs to gc).
+//	SLACK_SIGNING_SECRET   HMAC secret for verifying Slack request signatures
+//	                       on the inbound bridge. Required at Tier 1 — there is
+//	                       no apps-registry fallback, so without it every
+//	                       inbound is rejected.
+//	SLACK_WORKSPACE_ID     Slack workspace (team) id; the extmsg account id.
+//	GC_CITY_NAME           gc city the adapter bridges into.
+//
+// Controller-injected env (proxy_process mode):
+//
+//	GC_SERVICE_SOCKET      UDS path the internal listener binds. When set, the
+//	                       adapter runs as a gc proxy_process service.
+//	GC_SERVICE_URL_PREFIX  Reverse-proxy prefix gc routes to this service;
+//	                       used to compute the self-registration callback URL.
+//	GC_API_BASE_URL        gc API base (default http://127.0.0.1:9443).
+//
+// Optional env:
+//
+//	LISTEN_PUBLIC              Public bind for /slack/events (default 0.0.0.0:8775).
+//	LISTEN_INTERNAL            TCP bind for the internal mux when GC_SERVICE_SOCKET
+//	                           is unset (default 127.0.0.1:8776).
+//	REGISTER_ON_START          "true" (default) self-registers as an extmsg adapter.
+//	ADAPTER_PROVIDER           extmsg provider name (default "slack").
+//	SLACK_MINI_INBOUND_TARGET  Session handle inbound mentions address (default "mayor").
+//	SLACK_API_BASE             Slack web API base (default https://slack.com/api).
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"os/signal"
+	"regexp"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+const (
+	defaultPublicListen   = "0.0.0.0:8775"
+	defaultInternalListen = "127.0.0.1:8776"
+	defaultGCAPIBase      = "http://127.0.0.1:9443"
+	defaultProvider       = "slack"
+	defaultInboundTarget  = "mayor"
+
+	// maxInboundBody caps the /slack/events body read. The body is
+	// unsigned until HMAC-verified, so bounding it pre-verify limits a
+	// memory-amplification vector. Slack event payloads are small.
+	maxInboundBody = 1 << 20 // 1 MiB
+
+	// slackReplayWindow rejects requests whose signed timestamp is older
+	// than this, mitigating replay of a captured signature.
+	slackReplayWindow = 5 * time.Minute
+
+	slackPostTimeout = 15 * time.Second
+)
+
+// defaultSlackAPIBase is the production Slack web API origin. Overridable
+// via SLACK_API_BASE (and via cfg.slackAPIBase in tests).
+const defaultSlackAPIBase = "https://slack.com/api"
+
+// gcCallTimeout bounds outbound calls to the gc API so a stalled gc cannot
+// pin an inbound-bridge goroutine (or block startup registration) forever.
+const gcCallTimeout = 15 * time.Second
+
+type config struct {
+	publicListen        string
+	internalListen      string
+	serviceSocket       string
+	gcAPIBase           string
+	internalCallbackURL string
+	cityName            string
+	provider            string
+	workspaceID         string
+	botToken            string
+	signingSecret       string
+	inboundTarget       string
+	slackAPIBase        string
+	registerOnStart     bool
+}
+
+func main() {
+	cfg, err := loadConfig()
+	if err != nil {
+		log.Fatalf("config: %v", err)
+	}
+	internalDescr := cfg.internalListen
+	if cfg.serviceSocket != "" {
+		internalDescr = "uds:" + cfg.serviceSocket
+	}
+	log.Printf("starting gc-slack-mini-adapter public=%s internal=%s gc=%s city=%s target=%s",
+		cfg.publicListen, internalDescr, cfg.gcAPIBase, cfg.cityName, cfg.inboundTarget)
+
+	publicMux := http.NewServeMux()
+	publicMux.HandleFunc("/slack/events", handleSlackEvents(cfg))
+	publicMux.HandleFunc("/healthz", handleHealthz)
+	publicMux.HandleFunc("/", http.NotFound)
+
+	internalMux := http.NewServeMux()
+	internalMux.HandleFunc("POST /post-message", handlePostMessage(cfg))
+	internalMux.HandleFunc("/healthz", handleHealthz)
+
+	publicSrv := &http.Server{
+		Addr:              cfg.publicListen,
+		Handler:           publicMux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	internalSrv := &http.Server{
+		Handler:           internalMux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	if cfg.registerOnStart {
+		regCtx, cancel := context.WithTimeout(context.Background(), gcCallTimeout)
+		err := registerAdapter(regCtx, cfg)
+		cancel()
+		if err != nil {
+			log.Fatalf("register adapter: %v", err)
+		}
+		log.Printf("registered with gc as provider=%s account=%s callback=%s/post-message",
+			cfg.provider, cfg.workspaceID, cfg.internalCallbackURL)
+	}
+
+	errCh := make(chan error, 2)
+	go func() {
+		log.Printf("public listener serving on %s (Slack events)", cfg.publicListen)
+		errCh <- publicSrv.ListenAndServe()
+	}()
+	go func() {
+		if cfg.serviceSocket != "" {
+			log.Printf("internal listener serving on UDS %s (gc proxy_process)", cfg.serviceSocket)
+			lis, err := listenUDS(cfg.serviceSocket)
+			if err != nil {
+				errCh <- err
+				return
+			}
+			errCh <- internalSrv.Serve(lis)
+			return
+		}
+		internalSrv.Addr = cfg.internalListen
+		log.Printf("internal listener serving on %s (post-message only)", cfg.internalListen)
+		errCh <- internalSrv.ListenAndServe()
+	}()
+
+	stop := make(chan os.Signal, 1)
+	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
+	select {
+	case <-stop:
+		log.Println("shutting down (signal)")
+	case err := <-errCh:
+		if !errors.Is(err, http.ErrServerClosed) {
+			log.Printf("listener error: %v", err)
+		}
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_ = publicSrv.Shutdown(ctx)
+	_ = internalSrv.Shutdown(ctx)
+}
+
+func handleHealthz(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("ok\n"))
+}
+
+// loadConfig reads the process environment.
+func loadConfig() (config, error) { return loadConfigFromEnv(os.Getenv) }
+
+// loadConfigFromEnv builds and validates a config from a getenv function.
+// Split out so tests can supply a fake environment.
+func loadConfigFromEnv(getenv func(string) string) (config, error) {
+	envOr := func(key, fallback string) string {
+		if v := getenv(key); v != "" {
+			return v
+		}
+		return fallback
+	}
+	cfg := config{
+		publicListen:    envOr("LISTEN_PUBLIC", defaultPublicListen),
+		internalListen:  envOr("LISTEN_INTERNAL", defaultInternalListen),
+		serviceSocket:   getenv("GC_SERVICE_SOCKET"),
+		gcAPIBase:       strings.TrimRight(envOr("GC_API_BASE_URL", defaultGCAPIBase), "/"),
+		cityName:        getenv("GC_CITY_NAME"),
+		provider:        envOr("ADAPTER_PROVIDER", defaultProvider),
+		workspaceID:     getenv("SLACK_WORKSPACE_ID"),
+		botToken:        getenv("SLACK_BOT_TOKEN"),
+		signingSecret:   getenv("SLACK_SIGNING_SECRET"),
+		inboundTarget:   envOr("SLACK_MINI_INBOUND_TARGET", defaultInboundTarget),
+		slackAPIBase:    strings.TrimRight(envOr("SLACK_API_BASE", defaultSlackAPIBase), "/"),
+		registerOnStart: envOr("REGISTER_ON_START", "true") == "true",
+	}
+
+	// proxy_process mode: gc reaches the adapter via GC_API_BASE_URL +
+	// GC_SERVICE_URL_PREFIX. gc appends the endpoint path itself, so the
+	// registered callback base must not include it.
+	if cfg.serviceSocket != "" {
+		urlPrefix := strings.TrimRight(getenv("GC_SERVICE_URL_PREFIX"), "/")
+		if urlPrefix == "" {
+			return cfg, errors.New("GC_SERVICE_SOCKET is set but GC_SERVICE_URL_PREFIX is empty — controller-injected env is incomplete")
+		}
+		cfg.internalCallbackURL = cfg.gcAPIBase + urlPrefix
+	}
+
+	var missing []string
+	if cfg.workspaceID == "" {
+		missing = append(missing, "SLACK_WORKSPACE_ID")
+	}
+	if cfg.botToken == "" {
+		missing = append(missing, "SLACK_BOT_TOKEN")
+	}
+	if cfg.signingSecret == "" {
+		missing = append(missing, "SLACK_SIGNING_SECRET")
+	}
+	if cfg.cityName == "" {
+		missing = append(missing, "GC_CITY_NAME")
+	}
+	if len(missing) > 0 {
+		return cfg, fmt.Errorf("missing required env vars: %s", strings.Join(missing, ", "))
+	}
+	// cityName is interpolated into every /v0/city/{city}/... URL. Reject
+	// URL-significant characters so a city name cannot alter routing.
+	if strings.ContainsAny(cfg.cityName, "/?#%") {
+		return cfg, fmt.Errorf("GC_CITY_NAME must not contain '/', '?', '#', or '%%': %q", cfg.cityName)
+	}
+	return cfg, nil
+}
+
+// --- inbound: Slack events → gc extmsg ------------------------------------
+
+type slackEventEnvelope struct {
+	Type      string          `json:"type"`
+	Challenge string          `json:"challenge,omitempty"`
+	TeamID    string          `json:"team_id,omitempty"`
+	Event     json.RawMessage `json:"event,omitempty"`
+}
+
+// slackMessageEvent is the subset of an app_mention event Tier 1 reads.
+type slackMessageEvent struct {
+	Type        string `json:"type"`
+	Subtype     string `json:"subtype,omitempty"`
+	User        string `json:"user,omitempty"`
+	BotID       string `json:"bot_id,omitempty"`
+	Text        string `json:"text,omitempty"`
+	Channel     string `json:"channel,omitempty"`
+	TS          string `json:"ts,omitempty"`
+	ThreadTS    string `json:"thread_ts,omitempty"`
+	ChannelType string `json:"channel_type,omitempty"`
+}
+
+func handleSlackEvents(cfg config) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		body, err := io.ReadAll(io.LimitReader(r.Body, maxInboundBody))
+		if err != nil {
+			http.Error(w, "read body", http.StatusBadRequest)
+			return
+		}
+		ts := r.Header.Get("X-Slack-Request-Timestamp")
+		sig := r.Header.Get("X-Slack-Signature")
+		if !verifySlackSignature(cfg.signingSecret, ts, body, sig) {
+			log.Printf("slack signature verify FAILED")
+			http.Error(w, "invalid signature", http.StatusUnauthorized)
+			return
+		}
+
+		var env slackEventEnvelope
+		if err := json.Unmarshal(body, &env); err != nil {
+			http.Error(w, fmt.Sprintf("decode: %v", err), http.StatusBadRequest)
+			return
+		}
+
+		// URL verification handshake (Slack sends this once when the
+		// Events API endpoint is registered).
+		if env.Type == "url_verification" && env.Challenge != "" {
+			w.Header().Set("Content-Type", "text/plain")
+			_, _ = w.Write([]byte(env.Challenge))
+			return
+		}
+
+		// Ack immediately so Slack does not retry, then bridge.
+		w.WriteHeader(http.StatusOK)
+		go bridgeEvent(cfg, env)
+	}
+}
+
+// bridgeEvent decodes an app_mention and POSTs it to gc's extmsg inbound.
+// Non-app_mention events, bot/system messages, and empty bodies are
+// dropped — Tier 1 handles only direct human mentions. It runs in its own
+// goroutine; the gc call is bounded by gcCallTimeout so a stalled gc
+// cannot leak goroutines under sustained traffic.
+func bridgeEvent(cfg config, env slackEventEnvelope) {
+	if env.Type != "event_callback" || len(env.Event) == 0 {
+		return
+	}
+	var msg slackMessageEvent
+	if err := json.Unmarshal(env.Event, &msg); err != nil {
+		log.Printf("decode slack event: %v", err)
+		return
+	}
+	if msg.Type != "app_mention" {
+		return
+	}
+	if msg.BotID != "" || msg.Subtype != "" || msg.User == "" {
+		return
+	}
+	text := stripLeadingMention(msg.Text)
+	if text == "" {
+		return
+	}
+
+	inbound := externalInboundMessage{
+		ProviderMessageID: msg.TS,
+		Conversation: conversationRef{
+			ScopeID:        cfg.cityName,
+			Provider:       cfg.provider,
+			AccountID:      cfg.workspaceID,
+			ConversationID: msg.Channel,
+			Kind:           slackKindFromChannelType(msg.ChannelType, msg.Channel),
+		},
+		Actor: externalActor{
+			ID:          msg.User,
+			DisplayName: msg.User, // resolving a display name needs users.info — defer to Tier 2
+		},
+		Text:             text,
+		ExplicitTarget:   cfg.inboundTarget,
+		ReplyToMessageID: msg.ThreadTS,
+		DedupKey:         "slack-" + msg.TS,
+		ReceivedAt:       time.Now().UTC(),
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), gcCallTimeout)
+	defer cancel()
+	if err := postInbound(ctx, cfg, inbound); err != nil {
+		log.Printf("inbound POST failed: %v", err)
+		return
+	}
+	log.Printf("inbound: chan=%s user=%s ts=%s thread=%s target=%s text=%dch",
+		msg.Channel, msg.User, msg.TS, msg.ThreadTS, cfg.inboundTarget, len(text))
+}
+
+// leadingMentionRE matches one or more leading Slack user-mention tokens
+// (`<@U…>`) and surrounding whitespace. Slack delivers app_mention text
+// with the bot mention inline (e.g. "<@U0BOT> status?"); stripping it
+// yields the human-meant message body.
+var leadingMentionRE = regexp.MustCompile(`^\s*(?:<@[A-Z0-9]+>\s*)+`)
+
+func stripLeadingMention(text string) string {
+	return strings.TrimSpace(leadingMentionRE.ReplaceAllString(text, ""))
+}
+
+// slackKindFromChannelType maps a Slack channel_type onto a gc
+// ConversationKind, falling back to the channel-id prefix.
+func slackKindFromChannelType(channelType, channelID string) string {
+	switch channelType {
+	case "channel", "group", "mpim":
+		return "room"
+	case "im":
+		return "dm"
+	}
+	if len(channelID) > 0 {
+		switch channelID[0] {
+		case 'C', 'G':
+			return "room"
+		case 'D':
+			return "dm"
+		}
+	}
+	return "dm"
+}
+
+// verifySlackSignature validates Slack's v0 HMAC request signature and
+// rejects timestamps whose absolute age exceeds the replay window — both
+// stale (past) and far-future. Fails closed on any missing field or parse
+// error.
+func verifySlackSignature(secret, ts string, body []byte, sig string) bool {
+	if secret == "" || ts == "" || sig == "" {
+		return false
+	}
+	tsInt, err := strconv.ParseInt(ts, 10, 64)
+	if err != nil {
+		return false
+	}
+	// Reject when the absolute age exceeds the replay window — both stale
+	// (past) and far-future timestamps. time.Since yields a negative
+	// duration for future timestamps, so a one-sided ">" check would
+	// silently accept them.
+	age := time.Since(time.Unix(tsInt, 0))
+	if age < 0 {
+		age = -age
+	}
+	if age > slackReplayWindow {
+		return false
+	}
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write([]byte("v0:" + ts + ":"))
+	_, _ = mac.Write(body)
+	expected := "v0=" + hex.EncodeToString(mac.Sum(nil))
+	return hmac.Equal([]byte(expected), []byte(sig))
+}
+
+// --- gc extmsg wire types (mirrored, wire-compatible only) ----------------
+
+type conversationRef struct {
+	ScopeID        string `json:"scope_id"`
+	Provider       string `json:"provider"`
+	AccountID      string `json:"account_id"`
+	ConversationID string `json:"conversation_id"`
+	Kind           string `json:"kind"`
+}
+
+type externalActor struct {
+	ID          string `json:"id"`
+	DisplayName string `json:"display_name"`
+	IsBot       bool   `json:"is_bot"`
+}
+
+type externalInboundMessage struct {
+	ProviderMessageID string          `json:"provider_message_id"`
+	Conversation      conversationRef `json:"conversation"`
+	Actor             externalActor   `json:"actor"`
+	Text              string          `json:"text"`
+	ExplicitTarget    string          `json:"explicit_target,omitempty"`
+	ReplyToMessageID  string          `json:"reply_to_message_id,omitempty"`
+	DedupKey          string          `json:"dedup_key,omitempty"`
+	ReceivedAt        time.Time       `json:"received_at"`
+}
+
+type adapterCapabilities struct {
+	SupportsChildConversations bool `json:"SupportsChildConversations"`
+	SupportsAttachments        bool `json:"SupportsAttachments"`
+	MaxMessageLength           int  `json:"MaxMessageLength"`
+}
+
+type adapterRegisterRequest struct {
+	Provider     string              `json:"provider"`
+	AccountID    string              `json:"account_id"`
+	Name         string              `json:"name,omitempty"`
+	CallbackURL  string              `json:"callback_url,omitempty"`
+	Capabilities adapterCapabilities `json:"capabilities,omitempty"`
+}
+
+// postInbound bridges a verified Slack mention into gc.
+func postInbound(ctx context.Context, cfg config, msg externalInboundMessage) error {
+	body, err := json.Marshal(map[string]any{"message": msg})
+	if err != nil {
+		return err
+	}
+	target := fmt.Sprintf("%s/v0/city/%s/extmsg/inbound", cfg.gcAPIBase, url.PathEscape(cfg.cityName))
+	if err := postJSON(ctx, target, body); err != nil {
+		return fmt.Errorf("post inbound: %w", err)
+	}
+	return nil
+}
+
+// registerAdapter self-registers as an extmsg adapter so gc accepts this
+// provider's inbound messages.
+func registerAdapter(ctx context.Context, cfg config) error {
+	body, err := json.Marshal(adapterRegisterRequest{
+		Provider:    cfg.provider,
+		AccountID:   cfg.workspaceID,
+		Name:        "slack-mini-adapter",
+		CallbackURL: cfg.internalCallbackURL,
+		Capabilities: adapterCapabilities{
+			SupportsChildConversations: false,
+			SupportsAttachments:        false,
+			MaxMessageLength:           40000, // Slack's chat.postMessage limit
+		},
+	})
+	if err != nil {
+		return err
+	}
+	target := fmt.Sprintf("%s/v0/city/%s/extmsg/adapters", cfg.gcAPIBase, url.PathEscape(cfg.cityName))
+	return postJSON(ctx, target, body)
+}
+
+// postJSON POSTs a JSON body to a gc API endpoint and treats any >=400
+// status as an error, surfacing the response body for diagnostics. ctx
+// bounds the call so callers can enforce a timeout.
+func postJSON(ctx context.Context, target string, body []byte) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, target, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-GC-Request", "gc-slack-mini-adapter")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 400 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("%s: %s", resp.Status, strings.TrimSpace(string(respBody)))
+	}
+	return nil
+}
+
+// --- outbound: post-message → Slack chat.postMessage ----------------------
+
+// slackPostMessageReq is both the JSON body the post-message.sh wrapper
+// POSTs to /post-message and the chat.postMessage payload — the wrapper
+// deliberately speaks Slack's own field names, so one type serves both.
+type slackPostMessageReq struct {
+	Channel  string `json:"channel"`
+	Text     string `json:"text"`
+	ThreadTS string `json:"thread_ts,omitempty"`
+}
+
+type slackPostMessageResp struct {
+	OK      bool   `json:"ok"`
+	TS      string `json:"ts,omitempty"`
+	Channel string `json:"channel,omitempty"`
+	Error   string `json:"error,omitempty"`
+}
+
+func handlePostMessage(cfg config) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req slackPostMessageReq
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeJSONError(w, http.StatusBadRequest, fmt.Sprintf("decode: %v", err))
+			return
+		}
+		if strings.TrimSpace(req.Channel) == "" {
+			writeJSONError(w, http.StatusBadRequest, "channel is required")
+			return
+		}
+		if strings.TrimSpace(req.Text) == "" {
+			writeJSONError(w, http.StatusBadRequest, "text is required")
+			return
+		}
+		resp, err := postToSlack(r.Context(), cfg.slackAPIBase, cfg.botToken, req)
+		if err != nil {
+			writeJSONError(w, http.StatusBadGateway, err.Error())
+			return
+		}
+		if !resp.OK {
+			writeJSONError(w, http.StatusBadGateway, "slack: "+resp.Error)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok":      true,
+			"ts":      resp.TS,
+			"channel": resp.Channel,
+		})
+	}
+}
+
+func writeJSONError(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]any{"ok": false, "error": msg})
+}
+
+// postToSlack posts a message via chat.postMessage using the bot token.
+func postToSlack(ctx context.Context, apiBase, token string, req slackPostMessageReq) (*slackPostMessageResp, error) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithTimeout(ctx, slackPostTimeout)
+	defer cancel()
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, apiBase+"/chat.postMessage", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+token)
+	httpReq.Header.Set("Content-Type", "application/json; charset=utf-8")
+	resp, err := http.DefaultClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("post chat.postMessage: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read slack response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("slack http %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+	var sr slackPostMessageResp
+	if err := json.Unmarshal(respBody, &sr); err != nil {
+		return nil, fmt.Errorf("decode slack response: %w", err)
+	}
+	return &sr, nil
+}
+
+// listenUDS binds a Unix domain socket, removing any stale entry first so
+// restarts succeed, and tightens it to owner-only.
+func listenUDS(path string) (net.Listener, error) {
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("remove stale socket: %w", err)
+	}
+	lis, err := net.Listen("unix", path)
+	if err != nil {
+		return nil, fmt.Errorf("listen unix %s: %w", path, err)
+	}
+	if err := os.Chmod(path, 0o600); err != nil {
+		_ = lis.Close()
+		return nil, fmt.Errorf("chmod uds: %w", err)
+	}
+	return lis, nil
+}

--- a/slack-mini/adapter/main_test.go
+++ b/slack-mini/adapter/main_test.go
@@ -1,0 +1,468 @@
+package main
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// signSlack produces a valid X-Slack-Signature header for the given body,
+// timestamp, and secret — the inverse of verifySlackSignature.
+func signSlack(secret, ts string, body []byte) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write([]byte("v0:" + ts + ":"))
+	_, _ = mac.Write(body)
+	return "v0=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+func TestVerifySlackSignature(t *testing.T) {
+	const secret = "shhh"
+	body := []byte(`{"type":"event_callback"}`)
+	now := strconv.FormatInt(time.Now().Unix(), 10)
+	stale := strconv.FormatInt(time.Now().Add(-10*time.Minute).Unix(), 10)
+	future := strconv.FormatInt(time.Now().Add(10*time.Minute).Unix(), 10)
+	valid := signSlack(secret, now, body)
+
+	tests := []struct {
+		name   string
+		secret string
+		ts     string
+		sig    string
+		want   bool
+	}{
+		{"valid", secret, now, valid, true},
+		{"wrong secret", "nope", now, valid, false},
+		{"tampered body sig", secret, now, signSlack(secret, now, []byte("other")), false},
+		{"stale timestamp", secret, stale, signSlack(secret, stale, body), false},
+		{"far-future timestamp", secret, future, signSlack(secret, future, body), false},
+		{"non-numeric timestamp", secret, "abc", valid, false},
+		{"empty secret", "", now, valid, false},
+		{"empty ts", secret, "", valid, false},
+		{"empty sig", secret, now, "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := verifySlackSignature(tc.secret, tc.ts, body, tc.sig); got != tc.want {
+				t.Fatalf("verifySlackSignature = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestStripLeadingMention(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"<@U0BOT> status please", "status please"},
+		{"  <@U0BOT>   hello", "hello"},
+		{"<@U0BOT> <@U1OPS> deploy", "deploy"},
+		{"no mention here", "no mention here"},
+		{"<@U0BOT>", ""},
+		{"   ", ""},
+		{"text then <@U0BOT>", "text then <@U0BOT>"}, // only leading mentions stripped
+	}
+	for _, tc := range tests {
+		if got := stripLeadingMention(tc.in); got != tc.want {
+			t.Errorf("stripLeadingMention(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestSlackKindFromChannelType(t *testing.T) {
+	tests := []struct {
+		ctype, cid, want string
+	}{
+		{"channel", "C123", "room"},
+		{"group", "G123", "room"},
+		{"mpim", "C123", "room"},
+		{"im", "D123", "dm"},
+		{"", "C123", "room"},
+		{"", "G123", "room"},
+		{"", "D123", "dm"},
+		{"", "", "dm"},
+	}
+	for _, tc := range tests {
+		if got := slackKindFromChannelType(tc.ctype, tc.cid); got != tc.want {
+			t.Errorf("slackKindFromChannelType(%q,%q) = %q, want %q", tc.ctype, tc.cid, got, tc.want)
+		}
+	}
+}
+
+func TestLoadConfigFromEnv(t *testing.T) {
+	base := map[string]string{
+		"SLACK_BOT_TOKEN":      "xoxb-1",
+		"SLACK_SIGNING_SECRET": "secret",
+		"SLACK_WORKSPACE_ID":   "T123",
+		"GC_CITY_NAME":         "mycity",
+	}
+	clone := func(extra map[string]string) func(string) string {
+		m := map[string]string{}
+		for k, v := range base {
+			m[k] = v
+		}
+		for k, v := range extra {
+			m[k] = v
+		}
+		return func(k string) string { return m[k] }
+	}
+
+	t.Run("defaults", func(t *testing.T) {
+		cfg, err := loadConfigFromEnv(clone(nil))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.publicListen != defaultPublicListen {
+			t.Errorf("publicListen = %q, want default", cfg.publicListen)
+		}
+		if cfg.inboundTarget != defaultInboundTarget {
+			t.Errorf("inboundTarget = %q, want %q", cfg.inboundTarget, defaultInboundTarget)
+		}
+		if !cfg.registerOnStart {
+			t.Error("registerOnStart should default true")
+		}
+		if cfg.slackAPIBase != defaultSlackAPIBase {
+			t.Errorf("slackAPIBase = %q, want default", cfg.slackAPIBase)
+		}
+	})
+
+	t.Run("slack api base override", func(t *testing.T) {
+		cfg, err := loadConfigFromEnv(clone(map[string]string{"SLACK_API_BASE": "https://relay.example/api/"}))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.slackAPIBase != "https://relay.example/api" {
+			t.Errorf("slackAPIBase = %q, want trimmed override", cfg.slackAPIBase)
+		}
+	})
+
+	t.Run("missing required", func(t *testing.T) {
+		getenv := func(k string) string {
+			if k == "GC_CITY_NAME" {
+				return ""
+			}
+			return base[k]
+		}
+		_, err := loadConfigFromEnv(getenv)
+		if err == nil || !strings.Contains(err.Error(), "GC_CITY_NAME") {
+			t.Fatalf("expected missing GC_CITY_NAME error, got %v", err)
+		}
+	})
+
+	t.Run("city name with slash rejected", func(t *testing.T) {
+		_, err := loadConfigFromEnv(clone(map[string]string{"GC_CITY_NAME": "a/b"}))
+		if err == nil || !strings.Contains(err.Error(), "must not contain") {
+			t.Fatalf("expected city-name rejection, got %v", err)
+		}
+	})
+
+	t.Run("proxy_process requires url prefix", func(t *testing.T) {
+		_, err := loadConfigFromEnv(clone(map[string]string{"GC_SERVICE_SOCKET": "/tmp/s.sock"}))
+		if err == nil || !strings.Contains(err.Error(), "GC_SERVICE_URL_PREFIX") {
+			t.Fatalf("expected url-prefix error, got %v", err)
+		}
+	})
+
+	t.Run("proxy_process callback url", func(t *testing.T) {
+		cfg, err := loadConfigFromEnv(clone(map[string]string{
+			"GC_SERVICE_SOCKET":     "/tmp/s.sock",
+			"GC_SERVICE_URL_PREFIX": "/v0/city/mycity/svc/slack-mini/",
+			"GC_API_BASE_URL":       "http://127.0.0.1:8372",
+		}))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := "http://127.0.0.1:8372/v0/city/mycity/svc/slack-mini"
+		if cfg.internalCallbackURL != want {
+			t.Errorf("internalCallbackURL = %q, want %q", cfg.internalCallbackURL, want)
+		}
+	})
+}
+
+func TestHandleSlackEventsURLVerification(t *testing.T) {
+	cfg := config{signingSecret: "secret"}
+	body := []byte(`{"type":"url_verification","challenge":"c4tt0ken"}`)
+	ts := strconv.FormatInt(time.Now().Unix(), 10)
+
+	req := httptest.NewRequest(http.MethodPost, "/slack/events", strings.NewReader(string(body)))
+	req.Header.Set("X-Slack-Request-Timestamp", ts)
+	req.Header.Set("X-Slack-Signature", signSlack(cfg.signingSecret, ts, body))
+	rec := httptest.NewRecorder()
+
+	handleSlackEvents(cfg)(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got := strings.TrimSpace(rec.Body.String()); got != "c4tt0ken" {
+		t.Fatalf("challenge echo = %q, want c4tt0ken", got)
+	}
+}
+
+func TestHandleSlackEventsBadSignature(t *testing.T) {
+	cfg := config{signingSecret: "secret"}
+	body := []byte(`{"type":"event_callback"}`)
+	ts := strconv.FormatInt(time.Now().Unix(), 10)
+
+	req := httptest.NewRequest(http.MethodPost, "/slack/events", strings.NewReader(string(body)))
+	req.Header.Set("X-Slack-Request-Timestamp", ts)
+	req.Header.Set("X-Slack-Signature", "v0=deadbeef")
+	rec := httptest.NewRecorder()
+
+	handleSlackEvents(cfg)(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+}
+
+// TestBridgeEventPostsInbound drives an app_mention through bridgeEvent and
+// asserts the extmsg inbound payload shape.
+func TestBridgeEventPostsInbound(t *testing.T) {
+	var got externalInboundMessage
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/extmsg/inbound") {
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+		var wrap struct {
+			Message externalInboundMessage `json:"message"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&wrap); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		got = wrap.Message
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := config{
+		gcAPIBase:     srv.URL,
+		cityName:      "mycity",
+		provider:      "slack",
+		workspaceID:   "T123",
+		inboundTarget: "mayor",
+	}
+	event := slackMessageEvent{
+		Type:        "app_mention",
+		User:        "U99",
+		Text:        "<@U0BOT> deploy please",
+		Channel:     "C42",
+		TS:          "1700000000.0001",
+		ThreadTS:    "1700000000.0000",
+		ChannelType: "channel",
+	}
+	raw, _ := json.Marshal(event)
+	bridgeEvent(cfg, slackEventEnvelope{Type: "event_callback", Event: raw})
+
+	if got.Text != "deploy please" {
+		t.Errorf("Text = %q, want stripped 'deploy please'", got.Text)
+	}
+	if got.ExplicitTarget != "mayor" {
+		t.Errorf("ExplicitTarget = %q, want mayor", got.ExplicitTarget)
+	}
+	if got.Conversation.ConversationID != "C42" || got.Conversation.Kind != "room" {
+		t.Errorf("conversation = %+v, want channel C42 room", got.Conversation)
+	}
+	if got.DedupKey != "slack-1700000000.0001" {
+		t.Errorf("DedupKey = %q", got.DedupKey)
+	}
+	if got.ReplyToMessageID != "1700000000.0000" {
+		t.Errorf("ReplyToMessageID = %q", got.ReplyToMessageID)
+	}
+}
+
+// TestBridgeEventIgnoresNonMentions confirms Tier 1 drops everything that
+// is not a clean human app_mention.
+func TestBridgeEventIgnoresNonMentions(t *testing.T) {
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	cfg := config{gcAPIBase: srv.URL, cityName: "c", inboundTarget: "mayor"}
+
+	drop := func(name string, ev slackMessageEvent) {
+		raw, _ := json.Marshal(ev)
+		bridgeEvent(cfg, slackEventEnvelope{Type: "event_callback", Event: raw})
+		if called {
+			t.Errorf("%s: expected event dropped, but inbound was posted", name)
+			called = false
+		}
+	}
+	drop("plain message", slackMessageEvent{Type: "message", User: "U1", Text: "hi", Channel: "C1", TS: "1"})
+	drop("bot message", slackMessageEvent{Type: "app_mention", BotID: "B1", Text: "hi", Channel: "C1", TS: "1"})
+	drop("subtype", slackMessageEvent{Type: "app_mention", Subtype: "message_changed", User: "U1", Text: "hi", TS: "1"})
+	drop("empty after strip", slackMessageEvent{Type: "app_mention", User: "U1", Text: "<@U0BOT>", Channel: "C1", TS: "1"})
+}
+
+func TestHandlePostMessage(t *testing.T) {
+	var gotBody slackPostMessageReq
+	var gotAuth string
+	slack := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		_ = json.NewEncoder(w).Encode(slackPostMessageResp{OK: true, TS: "1700000000.0002", Channel: "C42"})
+	}))
+	defer slack.Close()
+
+	cfg := config{botToken: "xoxb-tok", slackAPIBase: slack.URL}
+	reqBody := `{"channel":"C42","text":"build green","thread_ts":"1700000000.0000"}`
+	req := httptest.NewRequest(http.MethodPost, "/post-message", strings.NewReader(reqBody))
+	rec := httptest.NewRecorder()
+
+	handlePostMessage(cfg)(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if gotAuth != "Bearer xoxb-tok" {
+		t.Errorf("Authorization = %q", gotAuth)
+	}
+	if gotBody.Channel != "C42" || gotBody.Text != "build green" || gotBody.ThreadTS != "1700000000.0000" {
+		t.Errorf("forwarded body = %+v", gotBody)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if out["ok"] != true || out["ts"] != "1700000000.0002" {
+		t.Errorf("response = %v", out)
+	}
+}
+
+func TestHandlePostMessageValidation(t *testing.T) {
+	cfg := config{botToken: "xoxb"}
+	cases := map[string]string{
+		"missing channel": `{"text":"hi"}`,
+		"missing text":    `{"channel":"C1"}`,
+		"bad json":        `{`,
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/post-message", strings.NewReader(body))
+			rec := httptest.NewRecorder()
+			handlePostMessage(cfg)(rec, req)
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400", rec.Code)
+			}
+		})
+	}
+}
+
+func TestHandlePostMessageSlackError(t *testing.T) {
+	slack := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(slackPostMessageResp{OK: false, Error: "channel_not_found"})
+	}))
+	defer slack.Close()
+
+	cfg := config{botToken: "xoxb", slackAPIBase: slack.URL}
+	req := httptest.NewRequest(http.MethodPost, "/post-message", strings.NewReader(`{"channel":"C1","text":"hi"}`))
+	rec := httptest.NewRecorder()
+	handlePostMessage(cfg)(rec, req)
+
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "channel_not_found") {
+		t.Errorf("error not surfaced: %s", rec.Body.String())
+	}
+}
+
+// TestRegisterAdapter confirms the self-registration payload shape.
+func TestRegisterAdapter(t *testing.T) {
+	var got adapterRegisterRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/extmsg/adapters") {
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+		_ = json.NewDecoder(r.Body).Decode(&got)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := config{
+		gcAPIBase:           srv.URL,
+		cityName:            "mycity",
+		provider:            "slack",
+		workspaceID:         "T123",
+		internalCallbackURL: "http://127.0.0.1:8372/v0/city/mycity/svc/slack-mini",
+	}
+	if err := registerAdapter(context.Background(), cfg); err != nil {
+		t.Fatalf("registerAdapter: %v", err)
+	}
+	if got.Provider != "slack" || got.AccountID != "T123" {
+		t.Errorf("register payload = %+v", got)
+	}
+	if got.Capabilities.SupportsChildConversations {
+		t.Error("Tier 1 must not advertise child conversations")
+	}
+}
+
+func TestHandleHealthz(t *testing.T) {
+	rec := httptest.NewRecorder()
+	handleHealthz(rec, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if strings.TrimSpace(rec.Body.String()) != "ok" {
+		t.Fatalf("body = %q, want ok", rec.Body.String())
+	}
+}
+
+// TestListenUDS confirms the socket binds, is owner-only, and that a stale
+// socket file from a prior run is replaced rather than blocking startup.
+func TestListenUDS(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "adapter.sock")
+
+	lis, err := listenUDS(path)
+	if err != nil {
+		t.Fatalf("listenUDS: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat socket: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("socket perm = %o, want 600", perm)
+	}
+	_ = lis.Close()
+
+	// A leftover socket file at the path must not block a restart.
+	if err := os.WriteFile(path, []byte("stale"), 0o600); err != nil {
+		t.Fatalf("write stale: %v", err)
+	}
+	lis2, err := listenUDS(path)
+	if err != nil {
+		t.Fatalf("listenUDS over stale socket: %v", err)
+	}
+	defer func() { _ = lis2.Close() }()
+	if _, ok := lis2.(*net.UnixListener); !ok {
+		t.Errorf("listener type = %T, want *net.UnixListener", lis2)
+	}
+}
+
+// TestPostJSONSurfacesErrorStatus confirms a >=400 from gc is an error.
+func TestPostJSONSurfacesErrorStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = io.WriteString(w, "nope")
+	}))
+	defer srv.Close()
+	err := postJSON(context.Background(), srv.URL, []byte(`{}`))
+	if err == nil || !strings.Contains(err.Error(), "nope") {
+		t.Fatalf("expected error surfacing body, got %v", err)
+	}
+}

--- a/slack-mini/commands/post-message.sh
+++ b/slack-mini/commands/post-message.sh
@@ -1,0 +1,98 @@
+#!/bin/sh
+# gc slack-mini post-message — post plain text to a Slack channel/thread.
+#
+# Tier 1 has no operator CLI binary: this wrapper relays to the running
+# slack-mini adapter through gc's /svc/slack-mini reverse proxy. The
+# adapter holds SLACK_BOT_TOKEN and calls Slack chat.postMessage, so the
+# token never has to be present in the command environment.
+#
+# Usage:
+#   gc slack-mini post-message --channel C0123 --text "build is green"
+#   gc slack-mini post-message --channel C0123 --thread-ts 1700000000.0001 \
+#       --text "follow-up in thread"
+set -eu
+
+channel=""
+text=""
+thread_ts=""
+
+require_value() {
+  # $1 = flag name, $2 = arg count remaining (including the flag itself)
+  if [ "$2" -lt 2 ]; then
+    echo "gc slack-mini post-message: $1 requires a value" >&2
+    exit 2
+  fi
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --channel)    require_value "$1" "$#"; channel="$2"; shift 2 ;;
+    --text)       require_value "$1" "$#"; text="$2"; shift 2 ;;
+    --thread-ts)  require_value "$1" "$#"; thread_ts="$2"; shift 2 ;;
+    --channel=*)   channel="${1#*=}"; shift ;;
+    --text=*)      text="${1#*=}"; shift ;;
+    --thread-ts=*) thread_ts="${1#*=}"; shift ;;
+    -h|--help)
+      cat "$(dirname "$0")/post-message/help.md"
+      exit 0
+      ;;
+    *)
+      echo "gc slack-mini post-message: unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ -z "$channel" ]; then
+  echo "gc slack-mini post-message: --channel is required" >&2
+  exit 2
+fi
+if [ -z "$text" ]; then
+  echo "gc slack-mini post-message: --text is required" >&2
+  exit 2
+fi
+
+api_base="${GC_API_BASE_URL:-http://127.0.0.1:9443}"
+api_base="${api_base%/}"
+city="${GC_CITY_NAME:-}"
+if [ -z "$city" ]; then
+  echo "gc slack-mini post-message: GC_CITY_NAME is not set" >&2
+  exit 1
+fi
+
+# Resolve the adapter endpoint: gc proxies /svc/slack-mini/* to the
+# adapter's UDS. SLACK_MINI_ADAPTER_URL overrides for local testing.
+url="${SLACK_MINI_ADAPTER_URL:-${api_base}/v0/city/${city}/svc/slack-mini/post-message}"
+
+# Build the request body with jq so channel/text/thread_ts are correctly
+# JSON-escaped (text may contain quotes, newlines, etc.).
+body=$(jq -n \
+  --arg channel "$channel" \
+  --arg text "$text" \
+  --arg thread_ts "$thread_ts" \
+  '{channel: $channel, text: $text} + (if $thread_ts == "" then {} else {thread_ts: $thread_ts} end)')
+
+# Capture status and body separately so the adapter's JSON error payload
+# ({"ok":false,"error":...}) reaches the operator instead of being swallowed
+# by `curl -f`. -w writes the HTTP status on its own trailing line.
+response=$(curl -sS -X POST "$url" \
+  -H 'Content-Type: application/json' \
+  -H 'X-GC-Request: gc-slack-mini' \
+  -d "$body" \
+  -w '\n%{http_code}') || {
+  echo "gc slack-mini post-message: request to adapter failed" >&2
+  echo "$response" >&2
+  exit 1
+}
+
+http_code=$(printf '%s\n' "$response" | tail -n1)
+payload=$(printf '%s\n' "$response" | sed '$d')
+
+printf '%s\n' "$payload"
+case "$http_code" in
+  2*) exit 0 ;;
+  *)
+    echo "gc slack-mini post-message: adapter returned HTTP $http_code" >&2
+    exit 1
+    ;;
+esac

--- a/slack-mini/commands/post-message/command.toml
+++ b/slack-mini/commands/post-message/command.toml
@@ -1,0 +1,2 @@
+description = "Post plain text to a Slack channel (optionally in a thread)"
+run = "../post-message.sh"

--- a/slack-mini/commands/post-message/help.md
+++ b/slack-mini/commands/post-message/help.md
@@ -1,0 +1,26 @@
+Post plain text to a Slack channel using the workspace bot token.
+
+This is the only outbound verb at Tier 1 (slack-mini). It relays to the
+running slack-mini adapter through gc's /svc/slack-mini reverse proxy; the
+adapter calls Slack chat.postMessage. Use it to reply to an inbound mention
+in its thread, or to push a notification to a channel.
+
+Flags:
+  --channel    Slack channel id (e.g. C0123ABCD) — required.
+  --text       Message text — required.
+  --thread-ts  Reply inside an existing thread. Pass the inbound message's
+               ts (surfaced to your session as the conversation's
+               reply-to id) to answer in-thread.
+
+Examples:
+  gc slack-mini post-message --channel C0123 --text "build is green"
+
+  gc slack-mini post-message --channel C0123 \
+    --thread-ts 1700000000.0001 --text "done — see PR #42"
+
+On success, prints Slack's JSON response: {"ok":true,"ts":...,"channel":...}.
+The returned ts is the new message's timestamp.
+
+Requires: GC_CITY_NAME and GC_API_BASE_URL in the environment (gc sets
+these for command wrappers), plus `jq` and `curl` on PATH. The slack-mini
+service must be running (gc supervises it as a proxy_process).

--- a/slack-mini/manifest/app.json
+++ b/slack-mini/manifest/app.json
@@ -1,0 +1,40 @@
+{
+  "display_information": {
+    "name": "gc-mayor",
+    "description": "Talk to your Gas City mayor from Slack. @-mention the bot and it bridges to your gc session.",
+    "background_color": "#1f2933"
+  },
+  "features": {
+    "bot_user": {
+      "display_name": "gc-mayor",
+      "always_online": true
+    },
+    "app_home": {
+      "home_tab_enabled": false,
+      "messages_tab_enabled": true,
+      "messages_tab_read_only_enabled": false
+    }
+  },
+  "oauth_config": {
+    "scopes": {
+      "bot": [
+        "app_mentions:read",
+        "chat:write",
+        "chat:write.public"
+      ]
+    }
+  },
+  "settings": {
+    "event_subscriptions": {
+      "bot_events": [
+        "app_mention"
+      ]
+    },
+    "interactivity": {
+      "is_enabled": false
+    },
+    "org_deploy_enabled": false,
+    "socket_mode_enabled": false,
+    "token_rotation_enabled": false
+  }
+}

--- a/slack-mini/pack.toml
+++ b/slack-mini/pack.toml
@@ -1,0 +1,54 @@
+# slack-mini — Tier 1 of the Slack pack family. "Talk to mayor from Slack."
+#
+# The minimum viable Slack→gc surface: add a bot to your workspace,
+# @-mention it from any channel, and the mention bridges to your gc mayor
+# session. One outbound verb (`gc slack-mini post-message`) posts plain
+# text back to a channel/thread.
+#
+# Pack-shipped binary:
+#
+#   - Adapter (./adapter/gc-slack-mini-adapter, built from adapter/main.go).
+#     A single-file Slack webhook receiver + outbound publisher. The
+#     [[service]] block below has gc supervise it as a proxy_process. It
+#     binds a Unix domain socket at $GC_SERVICE_SOCKET for /post-message +
+#     /healthz, and a public TCP port for /slack/events (the Slack Events
+#     API receiver — terminate TLS in front of it, e.g. Tailscale Funnel).
+#
+# This pack ships NO operator CLI binary: the single outbound verb is a
+# bash wrapper (commands/post-message.sh) that POSTs to the adapter through
+# gc's /svc/slack-mini reverse proxy.
+#
+# Tiering: slack-mini strictly subsumed by slack-channel (Tier 2) and
+# slack-full (Tier 3). Pick exactly one Slack tier per city — they all
+# expose the same `gc slack` runtime surface and cannot coexist. See
+# docs/design/slack-pack-tiering.md.
+
+[pack]
+name = "slack-mini"
+version = "0.1.0"
+schema = 2
+
+# proxy_process service: gc supervises the adapter as part of the city's
+# service set. The adapter binds a UDS at $GC_SERVICE_SOCKET for
+# /post-message + /healthz; gc reverse-proxies /svc/slack-mini/* to it. The
+# adapter also binds public TCP (LISTEN_PUBLIC, default 0.0.0.0:8775) for
+# /slack/events. proxy_process owns only the UDS lifecycle.
+#
+# The service is named "slack-mini" (matching the pack) so it does not
+# collide with a slack-full install's "slack" service. Per the tiering
+# design, run exactly one Slack tier per city regardless.
+#
+# Secrets (SLACK_BOT_TOKEN, SLACK_SIGNING_SECRET, SLACK_WORKSPACE_ID) and
+# GC_CITY_NAME are inherited from the service environment at start. See
+# README.md "Configure".
+
+[[service]]
+name = "slack-mini"
+kind = "proxy_process"
+
+[service.publication]
+visibility = "private"
+
+[service.process]
+command = ["./adapter/gc-slack-mini-adapter"]
+health_path = "/healthz"

--- a/slack-pack/scripts/slack_intake_common.py
+++ b/slack-pack/scripts/slack_intake_common.py
@@ -386,13 +386,18 @@ def find_latest_inbound_message_id_for_session(
     The lookup chain:
       1. Find the latest extmsg.inbound event targeting this session.
       2. Read its conversation_id from the event payload.
-      3. Query the transcript for that conversation, find the latest entry
-         whose Kind=="inbound", and return its ProviderMessageID.
+      3. Query the transcript for that conversation newest-first
+         (order=desc, gascity#3128), take the first entry whose
+         Kind=="inbound", and return its ProviderMessageID.
 
     Two queries (event + transcript) because the inbound event payload
     intentionally does NOT carry message_id — that field lives in the
     transcript and is the canonical source. See engdocs/architecture/
     api-control-plane.md for the typed-wire rationale.
+
+    The transcript query MUST be newest-first: the endpoint's oldest-first
+    default with a bounded limit hides the most recent inbound on busy
+    conversations, threading the reply under a stale message.
     """
     event = find_latest_inbound_for_session(session_id)
     if event is None:
@@ -408,7 +413,10 @@ def find_latest_inbound_message_id_for_session(
     # primary use case; fall through to dm if no rows come back.
     items: list[dict[str, Any]] = []
     for kind in ("room", "dm"):
-        qs = f"scope_id={gc_city_name()}&provider={provider}&conversation_id={conv_id}&kind={kind}"
+        qs = (
+            f"scope_id={gc_city_name()}&provider={provider}"
+            f"&conversation_id={conv_id}&kind={kind}&order=desc&limit=500"
+        )
         if workspace:
             qs += f"&account_id={workspace}"
         try:
@@ -418,7 +426,8 @@ def find_latest_inbound_message_id_for_session(
         items = res.get("items") or []
         if items:
             break
-    for entry in reversed(items):
+    # items are newest-first (order=desc): the first inbound is the latest.
+    for entry in items:
         if (entry.get("Kind") or entry.get("kind")) == "inbound":
             mid = (entry.get("ProviderMessageID") or entry.get("provider_message_id") or "").strip()
             if mid:

--- a/slack-pack/tests/gc_mock.py
+++ b/slack-pack/tests/gc_mock.py
@@ -319,13 +319,26 @@ class GcMock:
         req: http.server.BaseHTTPRequestHandler,
         query: dict[str, str],
     ) -> None:
-        """GET /extmsg/transcript?scope_id=&provider=&conversation_id=&kind=[&account_id=]"""
+        """GET /extmsg/transcript?scope_id=&provider=&conversation_id=&kind=[&account_id=][&order=][&limit=]
+
+        Mirrors the real endpoint's pagination contract (gascity#3128):
+        oldest-first default, ``order=desc``, ``limit`` default 100 /
+        max 500. Faithful truncation is what makes the stale-thread-root
+        regression reproducible in tests.
+        """
         provider = query.get("provider", "")
         conversation_id = query.get("conversation_id", "")
         kind = query.get("kind", "")
         key = (provider, conversation_id, kind)
         with self._lock:
             items = list(self._transcripts.get(key, []))
+        if query.get("order", "asc") == "desc":
+            items.reverse()
+        try:
+            limit = int(query.get("limit", "100"))
+        except ValueError:
+            limit = 100
+        items = items[: min(limit, 500)]
         resp = json.dumps({"items": items}).encode()
         req.send_response(200)
         req.send_header("Content-Type", "application/json")

--- a/slack-pack/tests/test_slack_pack_e2e.py
+++ b/slack-pack/tests/test_slack_pack_e2e.py
@@ -356,8 +356,8 @@ def test_reply_current_thread_current_pulls_thread_ts_from_transcript(
         kind="room",
     )
     # Seed two transcript entries: an outbound followed by the inbound we
-    # want resolved. --thread-current should walk in reverse and pick
-    # the inbound one.
+    # want resolved. --thread-current receives entries newest-first
+    # (order=desc) and picks the first inbound.
     gc_mock.register_transcript_entry(
         conversation_id="C0THREADCHAN",
         kind="room",
@@ -409,6 +409,73 @@ def test_reply_current_thread_current_pulls_thread_ts_from_transcript(
         f"first transcript lookup must use kind=room; got query={first_transcript.query!r}"
     )
     assert first_transcript.query.get("conversation_id") == "C0THREADCHAN"
+
+
+def test_reply_current_thread_current_finds_newest_inbound_in_large_transcript(
+    gc_mock: GcMock,
+    slack_mock: SlackMock,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--thread-current must resolve the newest inbound on a busy transcript.
+
+    Regression pin for the oldest-first truncation bug (gpk-r89): with the
+    endpoint's oldest-first default and bounded limit, the most recent
+    inbound never appeared in the response on busy conversations and the
+    reply threaded under a stale root. The fix queries ``order=desc``
+    (gascity#3128). 130 entries puts the newest inbound past the
+    endpoint's default limit of 100, which GcMock truncates faithfully.
+    """
+    gc_mock.register_inbound_event(
+        target_session="gc-test-session",
+        conversation_id="C0BUSYCHAN",
+        provider="slack",
+        kind="room",
+    )
+    # 130 entries, oldest..newest. Odd indices inbound, even outbound:
+    # entry 130 (newest) is outbound, entry 129 is the newest inbound.
+    total = 130
+    for i in range(1, total + 1):
+        gc_mock.register_transcript_entry(
+            conversation_id="C0BUSYCHAN",
+            kind="room",
+            provider_message_id=f"1700000000.{i:06d}",
+            message_kind="inbound" if i % 2 else "outbound",
+        )
+    newest_inbound_ts = f"1700000000.{total - 1:06d}"
+
+    rc = _import_reply_current_module()
+    exit_code = rc.main([
+        "--session", "gc-test-session",
+        "--thread-current",
+        "--body", "threading under the newest inbound",
+    ])
+    assert exit_code is None or exit_code == 0
+    capsys.readouterr()  # drain stdout
+
+    slack_calls = slack_mock.calls()
+    assert len(slack_calls) == 1, (
+        f"expected 1 publish, got {len(slack_calls)}: {slack_calls!r}"
+    )
+    assert slack_calls[0].thread_ts == newest_inbound_ts, (
+        f"--thread-current must thread under the newest inbound "
+        f"({newest_inbound_ts}) even when the transcript exceeds the "
+        f"endpoint's default window; got {slack_calls[0].thread_ts!r}"
+    )
+
+    # The lookup must request newest-first explicitly — relying on the
+    # oldest-first default is exactly the regression this test pins.
+    transcript_calls = [
+        c for c in gc_mock.calls() if c.path.endswith("/extmsg/transcript")
+    ]
+    assert transcript_calls, "expected at least one /extmsg/transcript GET"
+    assert transcript_calls[0].query.get("order") == "desc", (
+        f"transcript lookup must use order=desc; got query="
+        f"{transcript_calls[0].query!r}"
+    )
+    assert transcript_calls[0].query.get("limit") == "500", (
+        f"transcript lookup must carry the limit=500 defensive cap; "
+        f"got query={transcript_calls[0].query!r}"
+    )
 
 
 def test_reply_current_resolves_conversation_from_inbound_event(


### PR DESCRIPTION
## Problem

`find_latest_inbound_message_id_for_session` walked the `extmsg.transcript_list`
stream **oldest-first** and returned the first inbound match, so once a session's
transcript grew past the page limit the "latest inbound" lookup silently returned
a stale (oldest) message id instead of the newest one.

## Fix

Query the transcript **newest-first**, consuming the new ordering/limit params
added upstream in gastownhall/gascity#3128 (`limit` default 100 / max 500). The
first inbound match on a newest-first stream is the genuine latest inbound message.

## Test

Regression test pins the truncation case (transcript longer than one page) so the
oldest-first regression cannot reappear.
