### PR TITLE
feat: add the personas pack (dynamic principal-engineer personas)

### DIFF
--- a/personas/.gitignore
+++ b/personas/.gitignore
@@ -1,0 +1,17 @@
+.venv/
+__pycache__/
+*.pyc
+.pytest_cache/
+.ruff_cache/
+.coverage
+.coverage.*
+coverage.json
+coverage.xml
+htmlcov/
+
+# the local warm cache, if a dev points it at the pack dir
+warm-cache.json
+
+# install.sh / uninstall.sh leave timestamped config backups next to the files they
+# edit; never commit those.
+*.personas.bak.*

--- a/personas/LICENSE
+++ b/personas/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Blackrim.dev
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/personas/README.md
+++ b/personas/README.md
@@ -1,0 +1,111 @@
+# personas — dynamic principal-engineer persona equip
+
+When a polecat picks up a task, it equips a principal-engineer persona matched to that
+task, performs the work at that level, then dematerializes. Recently-used personas stay
+warm in a shared cache so other agents reuse them without paying the materialize cost,
+and they age out after a period of disuse.
+
+This is the gas-city pack for [blackrim-personas](../README.md). It composes with the
+rest of the toolchain: **model-advisor** picks the model *tier*, **provider-forge** picks
+the *provider/model*, and **personas** picks the *role*.
+
+> Status: v0 scaffold. Read [`docs/DESIGN.md`](docs/DESIGN.md) for the registry shape,
+> the match rule, the TTL reasoning, and the open scope.
+
+## What it provides
+
+| Path | Role |
+|------|------|
+| `bin/personas` | the `list` / `show` / `lint` / `match` / `equip` / `cache` / `evict` / `sweep` CLI |
+| `personas/` | the engine (registry loader + match rule + warm-cache lifecycle) |
+| `personas.toml` | the roster (10 principal-engineer personas) + warm-cache TTL policy |
+| `hooks/equip-on-task-pickup.sh` | the gas-town SessionStart equip hook |
+| `overlay/per-provider/claude/` | wires the equip hook into projected agent settings |
+| `template-fragments/use-personas.template.md` | the equip-a-persona discipline fragment |
+| `skills/equip-persona/` | agent/operator skill: equip + inspect |
+| `docs/DESIGN.md` | registry shape, match rule, TTL reasoning, scope notes |
+
+Stdlib-only (`tomllib` ≥3.11 / `tomli` fallback). No runtime third-party deps — mirrors
+`model-advisor` / `provider-forge`'s minimal footprint.
+
+## Quickstart
+
+```bash
+# (optional) build the engine venv; bin/personas also runs under any system python3
+./setup.sh
+
+# 1. The roster — and check it's complete after an edit
+./bin/personas list
+./bin/personas lint             # registry integrity check (exit 1 if issues)
+
+# 2. The equip decision for a task (read-only; shows score + why)
+./bin/personas match "implement a paginated REST endpoint backed by Postgres"
+./bin/personas match --from-bead pers-0fs   # preview a bead's decision (read-only)
+
+# 3. Equip it — materializes the persona into the shared warm cache
+./bin/personas equip "audit the upload handler for SSRF"
+
+# 4. A persona's full playbook + verification bar
+./bin/personas show principal-security-engineer
+
+# 5. The warm cache (what's materialized + TTL remaining) / age it out
+./bin/personas cache
+./bin/personas evict principal-backend-engineer   # drop one persona now
+./bin/personas sweep            # evict expired   (--all clears everything)
+```
+
+`list` / `show` / `lint` / `match` / `cache` are pure reads; `equip` / `evict` / `sweep`
+mutate the shared warm cache. `match` and `equip` take `--from-bead <id>` to pull the task
+text from a work bead (`match` previews the decision, `equip` materializes it); `equip
+--emit-context` prints a Claude Code SessionStart hook payload (used by the equip hook).
+
+## The roster
+
+Ten principal-engineer specialists, each with a domain, a playbook, when-to-equip
+conditions, the skills/tools it brings, and a verification bar:
+
+`principal-backend-engineer` · `principal-frontend-engineer` · `principal-systems-engineer` ·
+`principal-security-engineer` · `principal-data-engineer` · `principal-platform-engineer` ·
+`principal-api-designer` · `principal-test-engineer` · `principal-refactoring-engineer` ·
+`principal-docs-engineer`
+
+Extending the suite is adding a `[[persona]]` block to [`personas.toml`](personas.toml).
+
+## Warm cache + TTL
+
+Equipped personas linger in a shared cache (under a rig's `.beads/personas/` by default)
+so the next agent reuses them. The aging policy (configurable in `personas.toml`
+`[cache]`):
+
+- **Sliding idle TTL: 30 min**, refreshed on every reuse.
+- **Absolute ceiling: 2 h**, so even a continuously-reused persona re-reads the registry.
+
+Eviction is lazy (every `equip` / `cache` sweeps expired entries) plus the explicit
+`sweep` (expired, by policy) and `evict <id>` (one persona, on demand). See
+[`docs/DESIGN.md`](docs/DESIGN.md) §3 for the TTL reasoning and §6 for the CLI.
+
+## Install into a city
+
+Vendor `pack/` into the target city as `packs/personas/`, then:
+
+```bash
+packs/personas/install.sh --town            # city-wide
+packs/personas/install.sh --rig <name>      # one rig
+packs/personas/install.sh --town --dry-run  # preview
+```
+
+This registers a direct `source = "packs/personas"` import (the gastown pattern), adds the
+`use-personas` discipline fragment (town scope), `gc reload`s so the SessionStart equip
+hook is merged into projected settings, and verifies (`gc lint`, skill listed, import
+registered, hook projected). Reverse with `uninstall.sh` (same scope flags; `--purge`
+drops the venv).
+
+## Tests
+
+```bash
+python3 -m pytest -q        # 171 tests, pure stdlib + pytest, no network
+```
+
+## License
+
+MIT — see [LICENSE](LICENSE).

--- a/personas/bin/personas
+++ b/personas/bin/personas
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# personas CLI: list / show / match / equip / cache / sweep over the persona registry.
+#
+#   bin/personas list                       the roster
+#   bin/personas show <id>                   one persona's definition + playbook
+#   bin/personas lint                        registry integrity check (exit 1 if issues)
+#   bin/personas match <task...>             the equip decision for a task (read-only)
+#       [--from-bead ID]
+#   bin/personas equip <task...>             match + materialize into the warm cache
+#       [--from-bead ID] [--emit-context]
+#   bin/personas cache                       the warm cache: what's materialized + TTL
+#   bin/personas evict <id>                  dematerialize one persona from the warm cache
+#   bin/personas sweep [--all]               evict expired (or all) warm personas
+#
+# This wrapper resolves the pack's own venv python (so personas runs under the
+# interpreter its deps are installed in), falling back to system python3, then hands
+# off to `python -m personas.cli`. It mirrors model-advisor/bin/advisor and
+# cockpit/bin/cockpit.
+#
+# Degrades gracefully: the engine is pure-stdlib (tomllib on Python >= 3.11), so it
+# runs fine with no .venv as long as some python3 is present. If NO interpreter is
+# found it prints a clear error to stderr and exits 2 — it never silently no-ops.
+set -euo pipefail
+PACK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PY="$PACK_DIR/.venv/bin/python"
+[ -x "$PY" ] || PY="$(command -v python3 || true)"
+[ -n "$PY" ] || { echo "personas: no python interpreter found (no .venv, no python3)" >&2; exit 2; }
+exec env PYTHONPATH="$PACK_DIR${PYTHONPATH:+:$PYTHONPATH}" "$PY" -m personas.cli "$@"

--- a/personas/docs/DESIGN.md
+++ b/personas/docs/DESIGN.md
@@ -1,0 +1,198 @@
+# personas — design
+
+This is the v0 scaffold of the dynamic persona system described in the repository
+[`README.md`](../../README.md). It implements the deliverables that README calls for — a
+persona **registry**, an **equip/match** engine, a **warm-cache + TTL** lifecycle, a
+gas-town **equip-on-task-pickup hook**, a **CLI** for inspecting all three, and the
+**pack skeleton** that carries them — as a pure-stdlib gas-city pack mirroring the
+`gascity-cockpit` / `model-advisor` conventions.
+
+It composes with the rest of the blackrim toolchain rather than competing with it:
+`model-advisor` picks the model **tier**, `provider-forge` picks the **provider/model**,
+and `personas` picks the **role**. A dispatch is a tier, a provider/model, and a persona.
+
+## 1. Registry (`personas.toml` + `personas/registry.py`)
+
+The registry is the library of persona *definitions*. It is config-driven: nothing in
+the decision path is hard-coded. Each `[[persona]]` is a role with:
+
+| field | meaning |
+|-------|---------|
+| `id` | stable kebab-case identifier (`principal-backend-engineer`) |
+| `domain` | one line: the territory the persona owns |
+| `when_to_equip` | the conditions under which an agent should equip it |
+| `match_keywords` | curated terms the equip engine scores a task against (lowercased on load) |
+| `skills` / `tools` | the gas-city skills and tools the persona brings |
+| `verification_bar` | the standard it holds its own work to before handing off |
+| `playbook` | the principal-engineer mindset + method for the domain |
+| `weight` | optional priority, used only as a deterministic tie-break |
+
+The shipped roster is the README's initial suite of ten principal-engineer specialists
+(backend, frontend, systems, security, data, platform, api-design, test, refactoring,
+docs). The suite is extensible — adding a persona is adding a `[[persona]]` block.
+
+`[cache]` carries the warm-cache TTL policy (see §3). A small built-in fallback roster
+(`registry.DEFAULT_PERSONAS`) keeps the engine working if `personas.toml` is deleted,
+exactly as `model-advisor` falls back to a built-in tier roster.
+
+## 2. Equip / match (`personas/match.py`)
+
+The README's equip step: "an agent matches the task to the best-fit persona (description
+match, the same way skills auto-fire)." The match rule is deliberately transparent and
+deterministic — no model call, no network — so every decision is explainable.
+
+Scoring channels:
+
+1. **Curated keywords (primary).** Each persona's `match_keywords` are matched against
+   the task as whole-word phrases. A multi-word keyword (`"threat model"`) is a stronger
+   signal than a single word, so it scores higher (`2.0` vs `1.0`).
+2. **Domain vocabulary (secondary).** Salient (non-stopword) words from `domain` and
+   `when_to_equip` that also appear in the task add a small bonus (`0.25`), so a task that
+   uses a persona's vocabulary without hitting an explicit keyword still matches.
+
+Both channels are **plural/singular aware** via a naive singularizer (`tests` → `test`,
+`queries` → `query`), with conservative length guards and a `ss` exclusion so `class` /
+`loss` survive. Near-duplicate keywords that singularize to the same phrase are counted
+once, so `"test"` + `"tests"` is one hit, not two.
+
+`MatchResult` carries the chosen persona, its score, the exact terms that fired, and the
+ranked runners-up, so `personas match` shows *why*. Ties break by `score`, then
+`weight`, then `id` — fully deterministic, never order-dependent. With no signal at all
+the engine returns the registry's default (generalist) persona, flagged
+`is_fallback=True`, so the caller always gets a usable answer.
+
+## 3. Warm cache + TTL (`personas/cache.py`)
+
+The README lifecycle is materialize → execute → dematerialize → **warm** → **age out**.
+This module owns *warm* and *age out*: a JSON-backed cache of materialized personas,
+shared so the next agent reuses a warm persona without paying the materialize cost again.
+
+What is cached is the **materialized payload**, not merely a last-used timestamp. Each
+`WarmEntry` stores the persona's rendered `overlay` — the task-independent working
+context `match.render_overlay(persona)` assembles — plus a `fingerprint` of the persona
+definition it was rendered from. That is what makes the amortization real: `equip` takes
+a `materialize` thunk and calls it **only** on a cold/stale equip; a warm reuse returns
+the stored overlay untouched. (Provenance — the per-task "why this persona" note — is
+*not* cached: it is task-specific, so `match.render_provenance` composes it onto the
+cached overlay at presentation time, which is what lets one overlay be reused across
+different tasks.)
+
+### The aging policy and its reasoning (README "Lifecycle TTL")
+
+- **Sliding idle TTL — 30 minutes (default).** A persona stays warm for 30 minutes since
+  it was last equipped, refreshed on every reuse. Thirty minutes comfortably covers a
+  clustered work session and its follow-ups, and evicts a persona no agent has wanted for
+  half an hour. Shorter re-materializes too often for back-to-back work; longer lets
+  unused personas accumulate.
+- **Absolute ceiling — 2 hours (default).** Even a continuously-reused persona is
+  force-refreshed after 2 hours so it picks up registry updates and the cache footprint
+  stays bounded. Two hours aligns with the polecat idle timeout.
+- **Both are configurable** via `[cache]` (`idle_ttl_minutes` / `ceiling_ttl_hours`, or
+  explicit `*_seconds` overrides). The defaults are the starting point, not a law.
+
+`equip(persona_id, now, *, materialize=None, fingerprint="")` is the write path: it
+sweeps expired entries first (lazy eviction), then either *touches* a still-warm persona
+(slide `last_used_at`, bump `use_count`, return the stored overlay, `was_warm=True`) or
+materializes a fresh one (call `materialize`, store overlay + `fingerprint`, reset
+`materialized_at`, `was_warm=False`). A persona is re-materialized when it is cold,
+idle/ceiling-expired, **or** its `fingerprint` no longer matches the current definition —
+so a registry edit is picked up *immediately*, not only at the 2-hour ceiling, and a warm
+reuse never serves a stale overlay. The fingerprint (`match.persona_fingerprint`) is a
+cheap digest of exactly the definition fields the overlay renders, so checking it never
+costs a re-render. `materialize` is optional: omit it for a metadata-only entry (the
+pre-payload behavior). `now` is injected into every time-dependent method, so the policy
+is deterministically testable (the suite drives the full idle/ceiling/drift state machine
+with fixed clocks and a counting materializer that asserts exactly when the cost is paid).
+
+### Concurrency and location
+
+Writes are atomic (temp file + `os.replace` + `fsync`) so a concurrent reader never sees
+a half-written cache; a corrupt or missing file is treated as empty and self-heals on the
+next write. Concurrent *writers* are last-writer-wins — acceptable because every entry is
+re-derivable from the registry; the cache is an optimization, not a source of truth.
+
+The cache path resolves (first hit wins): `PERSONAS_CACHE_FILE` → `PERSONAS_CACHE_DIR` →
+`$GC_RIG_ROOT/.beads/personas/` → the nearest ancestor `.beads/personas/` → `~/.gc/runtime/personas/`.
+A location under a rig's `.beads` is shared by all of that rig's agents, which is what
+makes "kept around for other agents to pick up" real.
+
+## 4. Equip-on-task-pickup hook (`hooks/` + `overlay/`)
+
+The gas-town integration. `hooks/equip-on-task-pickup.sh` is a Claude Code
+**SessionStart** hook: for a gas-town worker, session start *is* task pickup — the
+polecat is spawned with work already on its hook. The hook resolves the agent's current
+in-progress work bead (by session name / id / alias), runs
+`personas equip --from-bead <id> --emit-context`, and emits the engine's
+`hookSpecificOutput.additionalContext` so the persona's playbook + verification bar
+overlay the session. It is strictly best-effort and always exits 0 — equip must never
+block or fail a session start. `PERSONAS_DISABLE_EQUIP=1` makes it a no-op.
+
+`overlay/per-provider/claude/.claude/settings.json` wires the hook into projected agent
+settings; `gc reload` deep-merges it (the same mechanism `model-advisor` uses for its
+`Stop`/`SubagentStop` telemetry hook). The hook command walks up from
+`$CLAUDE_PROJECT_DIR` to find `packs/personas/hooks/equip-on-task-pickup.sh`, so it works
+from any agent worktree.
+
+> **Scope note.** SessionStart is the equip seam this scaffold ships because it is the
+> reliable "pickup" moment for a worker that is born with its task. A mid-session pickup
+> (an agent that claims a *second* bead via `gc bd update --claim` without restarting)
+> would want a `PostToolUse` hook keyed on the claim command; that is a deliberate
+> follow-up, not built here.
+
+## 5. Pack skeleton
+
+Standard gas-city pack layout (mirrors `gascity-cockpit/pack` + `model-advisor`):
+`pack.toml`, `bin/personas` (venv-or-system-python3 wrapper), the `personas/` engine,
+`personas.toml`, `skills/equip-persona/`, `template-fragments/use-personas.template.md`,
+the overlay + hook, `setup.sh` / `install.sh` / `uninstall.sh` (idempotent, backed-up,
+`--dry-run`), `requirements.txt`, `tests/`, and this doc. Stdlib-only; no runtime
+third-party deps.
+
+## 6. CLI (`bin/personas` + `personas/cli.py`)
+
+The README's sixth pack component: "a CLI for inspecting the registry, the warm cache, and
+the equip decisions." It is the operator surface over the three engine layers — one
+command group per layer — and adds no logic of its own: every command is a thin render over
+`registry` / `match` / `cache`, so the CLI and the equip hook always make the same decision.
+
+| Layer | Commands | What they show / do |
+|-------|----------|---------------------|
+| registry | `list`, `show <id>`, `lint` | the roster; one persona's full playbook + bar; an integrity check |
+| equip decision | `match <task…>`, `equip <task…>` | preview the decision (read-only) vs. materialize it |
+| warm cache | `cache`, `evict <id>`, `sweep [--all]` | what's warm + TTL remaining; drop one; age out expired / all |
+
+**Reads vs. writes.** `list` / `show` / `lint` / `match` / `cache` are pure reads; `equip`
+/ `evict` / `sweep` mutate the shared warm cache. `cache` lazily prunes expired entries as
+it reports (the same lazy eviction the engine does on every `equip`), so even a read
+self-heals an aged cache — but it never materializes a persona.
+
+**One way to name a task.** `match` and `equip` share a task resolver: positional words, or
+`--from-bead ID` (the bead's title + description, read via `bd show`). `match --from-bead`
+is the read-only preview — "what would this bead equip, and why?" — with no cache write;
+`equip --from-bead` is what the equip-on-task-pickup hook (§4) runs. The `bd` subprocess is
+isolated in one helper so the engine stays subprocess-free and tests monkeypatch it.
+
+**`lint` closes the registry-edit loop.** Loading rejects *structural* errors (a bad or
+duplicate `id`, an unknown default, a broken cache policy) outright; `lint` adds the
+*completeness* pass `registry.validate` exposes — a persona missing a domain, playbook,
+verification bar, match keywords, or skills/tools loads but routes and overlays less well.
+So editing `personas.toml` has a check a CI step or pre-commit hook can gate on.
+
+**`evict` vs. `sweep`.** `sweep` ages the cache by policy (expired entries) and `sweep
+--all` clears it; `evict <id>` is the targeted drop — force one persona to re-materialize
+(e.g. after editing its definition) without disturbing the rest. It is idempotent: evicting
+a cold persona is a no-op, not an error.
+
+**Exit codes.** `0` ok; `1` `lint` found integrity issues (so it gates); `2` a usage or
+resolution error (unknown persona id, an invalid registry, a `--from-bead` that won't
+resolve). Every command also takes `--json` for scripting. The engine is pure stdlib;
+`bin/personas` runs it under the pack venv or any system `python3` (§5).
+
+## Open scope (not built in v0)
+
+- **Mid-session re-equip** on a `--claim` `PostToolUse` hook (see the scope note in §4).
+- **Richer match** (embedding/semantic similarity) if curated-keyword + domain-vocab
+  matching proves too blunt. The current rule is intentionally simple and auditable.
+- **Cross-rig shared cache** beyond a single rig's `.beads`. The path resolver already
+  supports an explicit `PERSONAS_CACHE_DIR` for that.
+- **Per-persona metrics** (equip counts, reuse-hit rate) for tuning the roster and TTLs.

--- a/personas/hooks/equip-on-task-pickup.sh
+++ b/personas/hooks/equip-on-task-pickup.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+#
+# equip-on-task-pickup.sh — Claude Code SessionStart hook for the personas pack.
+#
+# This is the gas-town integration (README "How it works" §2 / "The pack"): when a
+# polecat picks up its work, equip the best-fit principal-engineer persona so the agent
+# performs the task at that level. For a gas-town worker, session start *is* task
+# pickup — the polecat is spawned with work already on its hook — so SessionStart is
+# the equip moment.
+#
+# What it does:
+#   1. Resolve the agent's current in-progress work bead (by session name / id / alias).
+#   2. Ask the personas engine to match + equip a persona from that bead's title +
+#      description: `bin/personas equip --from-bead <id> --emit-context`. That also
+#      materializes the persona into the shared warm cache (so the next agent reuses it).
+#   3. Emit the engine's SessionStart payload (hookSpecificOutput.additionalContext) so
+#      the persona's playbook + verification bar overlay this session.
+#
+# CONTRACT (Claude Code SessionStart):
+#   - stdin : JSON describing the session start (we don't require any field from it;
+#             the work bead is resolved from the gc launcher env).
+#   - stdout: either nothing, or a single JSON object:
+#               {"hookSpecificOutput":{"hookEventName":"SessionStart",
+#                                      "additionalContext":"<persona context>"}}
+#   - exit  : ALWAYS 0. Equip is strictly best-effort; it must never block or fail a
+#             session start. Every step is guarded and falls through to `exit 0`.
+#
+# Escape hatch: PERSONAS_DISABLE_EQUIP=1 makes this hook a no-op without touching
+# settings.json.
+#
+# Self-contained: locates the pack's bin/personas relative to its own path and shells
+# out to `bd` + `jq` (both guarded). No pack Python is invoked unless a bead is found.
+
+# Deliberately NOT using `set -e`/`set -u`/pipefail: every step is guarded and we must
+# always reach `exit 0`, even on an unbound var or a broken pipe.
+
+# ---- 0. Escape hatch -------------------------------------------------------
+if [ "${PERSONAS_DISABLE_EQUIP:-}" = "1" ]; then
+  exit 0
+fi
+
+# ---- 1. Drain stdin (we don't need a field from it, but must not leave it) --
+_payload="$(cat 2>/dev/null)" || true
+: "${_payload:=}"
+
+# ---- 2. Locate the pack's CLI ----------------------------------------------
+PACK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." 2>/dev/null && pwd)" || exit 0
+PERSONAS_BIN="$PACK_DIR/bin/personas"
+[ -x "$PERSONAS_BIN" ] || exit 0
+
+# ---- 3. Resolve the current in-progress work bead --------------------------
+# Prefer the runtime session name, then the session id, then the alias — the same
+# identity precedence the polecat startup hook check uses. Needs `bd` + `jq`.
+command -v bd >/dev/null 2>&1 || exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+
+bead=""
+for id in "${GC_SESSION_NAME:-}" "${GC_SESSION_ID:-}" "${GC_ALIAS:-}"; do
+  [ -z "$id" ] && continue
+  r="$(bd list --status in_progress --assignee="$id" --json --limit=1 2>/dev/null)" || continue
+  bead="$(printf '%s' "$r" | jq -r '.[0].id // empty' 2>/dev/null)"
+  [ -n "$bead" ] && break
+done
+
+# No assigned in-progress work -> nothing to equip. Stay silent, exit clean.
+[ -n "$bead" ] || exit 0
+
+# ---- 4. Equip + emit the SessionStart context payload ----------------------
+# `equip --emit-context` prints the hook JSON on success and matches even a
+# weakly-described bead (falling back to the default persona). Any failure (engine
+# error, bd hiccup) prints nothing and we still exit 0 — never block the session.
+"$PERSONAS_BIN" equip --from-bead "$bead" --emit-context 2>/dev/null || true
+
+exit 0

--- a/personas/install.sh
+++ b/personas/install.sh
@@ -1,0 +1,458 @@
+#!/usr/bin/env bash
+# personas — install lifecycle (reversible, idempotent).
+#
+#   install.sh (--town | --rig <name>) [--dry-run] [--city <path>] [--no-reload]
+#
+# Turns the personas pack ON at one of two scopes:
+#   --town        city-wide: every agent gets the equip-persona skill + (opt-in) the
+#                 use-personas discipline fragment + the claude SessionStart
+#                 equip-on-task-pickup hook (equips a persona as a session picks up work).
+#   --rig <name>  one rig only: that rig's agents get the skill + the equip hook.
+#
+# What it does (in order):
+#   1. Build the engine venv via setup.sh (skipped if .venv already present; optional —
+#      bin/personas also runs under any system python3).
+#   2. Add the pack import to the correct config scope. A LOCAL in-tree pack is imported
+#      via a DIRECT config entry (the gastown pattern) — NOT via `gc import add`, which
+#      targets remote/git-backed packs and mis-resolves a local file:// source. So a
+#      surgical, backed-up edit writes:
+#        --town       ->  <city>/pack.toml   [imports.personas]
+#        --rig <name> ->  <city>/city.toml   [rigs.imports.personas] (under the [[rigs]]
+#                         entry whose name matches <name>)
+#      source is recorded relative to the city root (e.g. "packs/personas").
+#   3. --town only: add the "use-personas" discipline fragment to city.toml
+#      [agent_defaults] append_fragments (idempotent; the table/array are created if
+#      absent). This is the non-deprecated home; the old top-level global_fragments key
+#      is deprecated.
+#   4. Trigger re-projection with `gc reload` so the claude overlay's SessionStart hook
+#      is materialized + merged into projected settings.
+#   5. Verify: `gc lint`, the skill shows in `gc skill list`, the import is registered,
+#      and (best-effort) the projected .claude settings carry the equip hook.
+#
+# Idempotent: re-running is a no-op (each mutating step is guarded by a presence check).
+# Any config file it edits is backed up first. --dry-run prints the plan and changes
+# nothing. Fails loudly on unexpected state.
+#
+# Reverse with uninstall.sh (same scope flags).
+
+set -euo pipefail
+
+# Stripped-PATH guard (this environment sometimes ships a minimal PATH).
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${HOME}/go/bin:${HOME}/.local/bin:${PATH}"
+
+PACK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PACK_NAME="personas"     # import binding name + skill prefix
+IMPORT_NAME="personas"
+# The single discipline prompt-fragment this pack ships. It has a file at
+# template-fragments/<name>.template.md and is wired into city.toml [agent_defaults]
+# append_fragments on --town scope.
+FRAGMENTS=("use-personas")
+SKILL_QUALIFIED="${PACK_NAME}.equip-persona"
+HOOK_MARKER="personas/hooks/equip-on-task-pickup.sh"   # unique substring of our hook command
+
+# ---- arg parsing -----------------------------------------------------------
+SCOPE=""          # "town" | "rig"
+RIG=""
+DRY_RUN=0
+NO_RELOAD=0
+CITY=""
+
+die()  { printf 'install.sh: error: %s\n' "$*" >&2; exit 1; }
+info() { printf '  %s\n' "$*"; }
+step() { printf '\n==> %s\n' "$*"; }
+run()  { # echo + execute, or just echo under --dry-run
+  if [ "$DRY_RUN" -eq 1 ]; then printf '    [dry-run] %s\n' "$*"; else printf '    + %s\n' "$*"; eval "$@"; fi
+}
+
+usage() {
+  sed -n '2,40p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+  exit "${1:-0}"
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --town)      SCOPE="town"; shift ;;
+    --rig)       SCOPE="rig"; RIG="${2:-}"; [ -n "$RIG" ] || die "--rig requires a rig name"; shift 2 ;;
+    --rig=*)     SCOPE="rig"; RIG="${1#*=}"; shift ;;
+    --dry-run)   DRY_RUN=1; shift ;;
+    --no-reload) NO_RELOAD=1; shift ;;
+    --city)      CITY="${2:-}"; [ -n "$CITY" ] || die "--city requires a path"; shift 2 ;;
+    --city=*)    CITY="${1#*=}"; shift ;;
+    -h|--help)   usage 0 ;;
+    *)           die "unknown argument: $1 (try --help)" ;;
+  esac
+done
+
+[ -n "$SCOPE" ] || die "choose a scope: --town or --rig <name>"
+
+# ---- locate the city -------------------------------------------------------
+# Default: the city that physically contains this pack (…/<city>/packs/personas).
+# When the pack is still in its source rig (blackrim-personas/pack), pass --city.
+if [ -z "$CITY" ]; then
+  CITY="$(cd "$PACK_DIR/../.." && pwd)"
+fi
+[ -f "$CITY/city.toml" ] || die "no city.toml at city root: $CITY (pass --city <path>; if the pack is in its source rig, vendor it into <city>/packs/personas first)"
+CITY="$(cd "$CITY" && pwd)"
+
+# Source path recorded in the import: relative to the city root if the pack lives under
+# it (a bare relative path with no "./" prefix, e.g. "packs/personas"), else absolute.
+if [ "${PACK_DIR#"$CITY"/}" != "$PACK_DIR" ]; then
+  PACK_SRC="${PACK_DIR#"$CITY"/}"
+else
+  PACK_SRC="$PACK_DIR"
+fi
+
+GC=(gc --city "$CITY")
+
+step "personas install"
+info "scope:     $SCOPE${RIG:+ ($RIG)}"
+info "pack:      $PACK_DIR"
+info "city:      $CITY"
+info "import as: $IMPORT_NAME  (source: $PACK_SRC)"
+[ "$DRY_RUN" -eq 1 ] && info "MODE:      DRY RUN (no changes will be made)"
+
+command -v gc >/dev/null 2>&1 || die "gc not found on PATH"
+
+# For --rig, fail loudly now if the rig isn't configured, before any other step runs.
+if [ "$SCOPE" = "rig" ]; then
+  if ! "${GC[@]}" import list --rig "$RIG" >/dev/null 2>&1; then
+    die "rig \"$RIG\" not found in $CITY/city.toml (configure the rig first)"
+  fi
+fi
+
+# ---- helpers ---------------------------------------------------------------
+backup_file() { # back up $1 once per run to <file>.personas.bak.<ts>
+  local f="$1"
+  [ -f "$f" ] || return 0
+  local b="${f}.personas.bak.$(date +%Y%m%d%H%M%S)"
+  if [ "$DRY_RUN" -eq 1 ]; then printf '    [dry-run] backup %s -> %s\n' "$f" "$b"; return 0; fi
+  cp -p "$f" "$b"; printf '    backup: %s\n' "$b"
+}
+
+import_present() { # 0 if IMPORT_NAME is registered at the active scope.
+  if [ "$SCOPE" = "rig" ]; then
+    if "${GC[@]}" import list --rig "$RIG" 2>/dev/null | awk '{print $1}' | grep -qx "$IMPORT_NAME"; then
+      return 0
+    fi
+    rig_import_in_config "$RIG"
+  else
+    if "${GC[@]}" import list 2>/dev/null | awk '{print $1}' | grep -qx "$IMPORT_NAME"; then
+      return 0
+    fi
+    grep -Eq "^\[imports\.${IMPORT_NAME}\][[:space:]]*$" "$CITY/pack.toml" 2>/dev/null
+  fi
+}
+
+rig_import_in_config() { # 0 if [rigs.imports.IMPORT_NAME] exists under rig $1
+  python3 - "$CITY/city.toml" "$1" "$IMPORT_NAME" <<'PY'
+import sys, re
+path, rig, name = sys.argv[1], sys.argv[2], sys.argv[3]
+lines = open(path).read().splitlines(keepends=True)
+starts = [i for i, l in enumerate(lines) if re.match(r'^\[\[rigs\]\]\s*$', l)]
+for k, s in enumerate(starts):
+    end = starts[k + 1] if k + 1 < len(starts) else len(lines)
+    for j in range(s + 1, end):
+        if re.match(r'^\[', lines[j]) and not re.match(r'^\[(\[rigs\]\]|rigs(\.|\]))', lines[j]):
+            end = j; break
+    named = None
+    for j in range(s + 1, end):
+        m = re.match(r'^\s*name\s*=\s*["\'](.+?)["\']\s*$', lines[j])
+        if m:
+            named = m.group(1); break
+    if named != rig:
+        continue
+    hdr = re.compile(r'^\[rigs\.imports\.%s\]\s*$' % re.escape(name))
+    if any(hdr.match(lines[j]) for j in range(s + 1, end)):
+        sys.exit(0)
+    sys.exit(1)
+sys.exit(1)
+PY
+}
+
+fragment_present() { # 0 if fragment $1 is already in [agent_defaults] append_fragments
+  python3 - "$CITY/city.toml" "$1" <<'PY'
+import sys, re
+path, frag = sys.argv[1], sys.argv[2]
+try:
+    src = open(path).read()
+except OSError:
+    sys.exit(1)
+lines = src.splitlines(keepends=True)
+hdr = re.compile(r'^\[agent_defaults\]\s*$')
+start = next((i for i, l in enumerate(lines) if hdr.match(l)), None)
+if start is None:
+    sys.exit(1)
+end = len(lines)
+for j in range(start + 1, len(lines)):
+    if re.match(r'^\[', lines[j]):
+        end = j; break
+body = "".join(lines[start + 1:end])
+m = re.search(r'(?m)^\s*append_fragments\s*=\s*(\[[^\]]*\])', body)
+if not m:
+    sys.exit(1)
+items = [x.strip().strip('"').strip("'") for x in m.group(1)[1:-1].split(',') if x.strip()]
+sys.exit(0 if frag in items else 1)
+PY
+}
+
+edit_fragment() { # add|remove fragment $2 in [agent_defaults] append_fragments (idempotent)
+  python3 - "$CITY/city.toml" "$1" "$2" <<'PY'
+import sys, re
+path, action, frag = sys.argv[1], sys.argv[2], sys.argv[3]
+src = open(path).read()
+lines = src.splitlines(keepends=True)
+
+def find_table(name):
+    hdr = re.compile(r'^\[%s\]\s*$' % re.escape(name))
+    s = next((i for i, l in enumerate(lines) if hdr.match(l)), None)
+    if s is None:
+        return None, None
+    e = len(lines)
+    for j in range(s + 1, len(lines)):
+        if re.match(r'^\[', lines[j]):
+            e = j; break
+    return s, e
+
+start, end = find_table("agent_defaults")
+
+if action == "add":
+    if start is None:
+        sep = "" if (src == "" or src.endswith("\n")) else "\n"
+        block = '%s\n[agent_defaults]\nappend_fragments = ["%s"]\n' % (sep, frag)
+        open(path, "w").write(src + block)
+        sys.exit(0)
+    body_lines = lines[start + 1:end]
+    body = "".join(body_lines)
+    m = re.search(r'(?m)^(\s*append_fragments\s*=\s*)(\[[^\]]*\])', body)
+    if m:
+        items = [x.strip().strip('"').strip("'")
+                 for x in m.group(2)[1:-1].split(',') if x.strip()]
+        if frag in items:
+            sys.exit(0)
+        items.append(frag)
+        new_arr = "[" + ", ".join('"%s"' % x for x in items) + "]"
+        new_body = body[:m.start(2)] + new_arr + body[m.end(2):]
+        open(path, "w").write("".join(lines[:start + 1]) + new_body + "".join(lines[end:]))
+        sys.exit(0)
+    insert = 'append_fragments = ["%s"]\n' % frag
+    out = lines[:start + 1] + [insert] + lines[start + 1:]
+    open(path, "w").write("".join(out))
+    sys.exit(0)
+
+# action == remove
+if start is None:
+    sys.exit(0)
+body_lines = lines[start + 1:end]
+body = "".join(body_lines)
+m = re.search(r'(?m)^(\s*append_fragments\s*=\s*)(\[[^\]]*\])', body)
+if not m:
+    sys.exit(0)
+items = [x.strip().strip('"').strip("'")
+         for x in m.group(2)[1:-1].split(',') if x.strip()]
+if frag not in items:
+    sys.exit(0)
+items = [x for x in items if x != frag]
+new_arr = "[" + ", ".join('"%s"' % x for x in items) + "]"
+new_body = body[:m.start(2)] + new_arr + body[m.end(2):]
+open(path, "w").write("".join(lines[:start + 1]) + new_body + "".join(lines[end:]))
+PY
+}
+
+edit_import() { # add|remove a DIRECT-config import (gastown style); idempotent.
+  # args: <action> <file> <import_name> <source> [<rig_name>]
+  python3 - "$2" "$1" "$3" "$4" "${5:-}" <<'PY'
+import sys, re
+path, action, name, source, rig = sys.argv[1:6]
+rig = rig or None
+
+def fail(msg):
+    sys.stderr.write("edit_import: %s\n" % msg); sys.exit(3)
+
+lines = open(path).read().splitlines(keepends=True)
+
+if rig is None:
+    table = "imports"
+    anchor = next((i for i, l in enumerate(lines) if re.match(r'^\[imports\]\s*$', l)), None)
+    if anchor is None: fail("[imports] table not found in %s" % path)
+    hi = len(lines)
+else:
+    table = "rigs.imports"
+    starts = [i for i, l in enumerate(lines) if re.match(r'^\[\[rigs\]\]\s*$', l)]
+    if not starts: fail("no [[rigs]] blocks in %s" % path)
+    target_start = None; hi = len(lines)
+    for k, s in enumerate(starts):
+        end = starts[k + 1] if k + 1 < len(starts) else len(lines)
+        for j in range(s + 1, end):
+            if re.match(r'^\[', lines[j]) and not re.match(r'^\[(\[rigs\]\]|rigs(\.|\]))', lines[j]):
+                end = j; break
+        named = None
+        for j in range(s + 1, end):
+            m = re.match(r'^\s*name\s*=\s*["\'](.+?)["\']\s*$', lines[j])
+            if m: named = m.group(1); break
+        if named == rig:
+            target_start, hi = s, end; break
+    if target_start is None: fail('no [[rigs]] block with name = "%s" in %s' % (rig, path))
+    anchor = next((i for i in range(target_start, hi) if re.match(r'^\[rigs\.imports\]\s*$', lines[i])), None)
+    if anchor is None: fail('[rigs.imports] not found under rig "%s" in %s' % (rig, path))
+
+header = "[%s.%s]" % (table, name)
+sub = re.compile(r'^\[%s\.%s\]\s*$' % (re.escape(table), re.escape(name)))
+existing = next((i for i in range(anchor, hi) if sub.match(lines[i])), None)
+
+if action == "add":
+    if existing is not None: sys.exit(0)
+    lines.insert(anchor + 1, "%s\nsource = \"%s\"\n" % (header, source))
+    open(path, "w").write("".join(lines))
+elif action == "remove":
+    if existing is None: sys.exit(0)
+    end = existing + 1
+    if end < len(lines) and re.match(r'^\s*source\s*=', lines[end]): end += 1
+    del lines[existing:end]
+    open(path, "w").write("".join(lines))
+else:
+    fail("unknown action: %s" % action)
+PY
+}
+
+# ---- step 1: venv ----------------------------------------------------------
+step "1/5  engine venv"
+if [ -x "$PACK_DIR/.venv/bin/python" ]; then
+  info "already present: $PACK_DIR/.venv (skipping setup.sh)"
+else
+  run "bash \"$PACK_DIR/setup.sh\""
+  [ "$DRY_RUN" -eq 1 ] && info "(dry-run) would build venv via setup.sh"
+fi
+
+# ---- step 2: import --------------------------------------------------------
+step "2/5  register pack import ($SCOPE scope)"
+if import_present; then
+  info "import \"$IMPORT_NAME\" already registered — no-op"
+else
+  if [ "$SCOPE" = "rig" ]; then
+    IMPORT_CFG="$CITY/city.toml"
+    backup_file "$IMPORT_CFG"
+    if [ "$DRY_RUN" -eq 1 ]; then
+      info "[dry-run] add [rigs.imports.$IMPORT_NAME] (source = \"$PACK_SRC\") under rig \"$RIG\" in $IMPORT_CFG"
+    else
+      edit_import add "$IMPORT_CFG" "$IMPORT_NAME" "$PACK_SRC" "$RIG" \
+        || die "failed to add [rigs.imports.$IMPORT_NAME] under rig \"$RIG\" in $IMPORT_CFG"
+      info "added [rigs.imports.$IMPORT_NAME] (source = \"$PACK_SRC\") under rig \"$RIG\""
+    fi
+  else
+    IMPORT_CFG="$CITY/pack.toml"
+    backup_file "$IMPORT_CFG"
+    if [ "$DRY_RUN" -eq 1 ]; then
+      info "[dry-run] add [imports.$IMPORT_NAME] (source = \"$PACK_SRC\") to $IMPORT_CFG"
+    else
+      edit_import add "$IMPORT_CFG" "$IMPORT_NAME" "$PACK_SRC" \
+        || die "failed to add [imports.$IMPORT_NAME] to $IMPORT_CFG"
+      info "added [imports.$IMPORT_NAME] (source = \"$PACK_SRC\")"
+    fi
+  fi
+fi
+
+# ---- step 3: agent_defaults append_fragments (town only) -------------------
+step "3/5  prompt fragment ([agent_defaults] append_fragments)"
+if [ "$SCOPE" = "town" ]; then
+  backed_up=0
+  for frag in "${FRAGMENTS[@]}"; do
+    if fragment_present "$frag"; then
+      info "\"$frag\" already in [agent_defaults] append_fragments — no-op"
+    elif [ "$DRY_RUN" -eq 1 ]; then
+      info "[dry-run] add \"$frag\" to [agent_defaults] append_fragments in $CITY/city.toml"
+    else
+      if [ "$backed_up" -eq 0 ]; then backup_file "$CITY/city.toml"; backed_up=1; fi
+      edit_fragment add "$frag"
+      info "added \"$frag\" to [agent_defaults] append_fragments"
+    fi
+  done
+else
+  info "rig scope: append_fragments is city-wide and not touched"
+  info "(the rig's agents still get the skill + equip hook from the import)"
+fi
+
+# ---- step 4: re-project ----------------------------------------------------
+step "4/5  re-project (gc reload)"
+if [ "$NO_RELOAD" -eq 1 ]; then
+  info "--no-reload: skipping. Run 'gc reload' (or restart the city) to apply."
+elif [ "$DRY_RUN" -eq 1 ]; then
+  info "[dry-run] gc reload  (materializes the claude overlay + merges SessionStart)"
+else
+  if "${GC[@]}" reload >/dev/null 2>&1; then
+    info "gc reload: ok"
+  else
+    info "gc reload returned non-zero (city may be stopped). Projection will"
+    info "happen on the next 'gc start' / 'gc rig boot'. Continuing."
+  fi
+fi
+
+# ---- step 5: verify --------------------------------------------------------
+step "5/5  verify"
+if [ "$DRY_RUN" -eq 1 ]; then
+  info "[dry-run] would verify: gc lint, gc skill list, import registered, hook projected"
+  step "personas install — DRY RUN complete (no changes made)"
+  exit 0
+fi
+
+fail=0
+
+# 5a. lint
+if "${GC[@]}" lint "$PACK_DIR" >/dev/null 2>&1; then
+  info "lint: ok"
+else
+  info "lint: FAILED"; "${GC[@]}" lint "$PACK_DIR" || true; fail=1
+fi
+
+# 5b. import registered
+if import_present; then info "import: registered ($IMPORT_NAME)"; else info "import: MISSING"; fail=1; fi
+
+# 5c. skill visible (binding-qualified).
+if [ "$SCOPE" = "rig" ]; then
+  if "${GC[@]}" skill list --rig "$RIG" 2>/dev/null | grep -q "$SKILL_QUALIFIED"; then
+    info "skill: visible ($SKILL_QUALIFIED, rig $RIG)"
+  else
+    info "skill: not yet visible at rig scope (it lands when the rig's agents project)"
+  fi
+else
+  if "${GC[@]}" skill list 2>/dev/null | grep -q "$SKILL_QUALIFIED" \
+     || "${GC[@]}" skill list 2>/dev/null | grep -q "$SKILL_QUALIFIED"; then
+    info "skill: visible ($SKILL_QUALIFIED)"
+  else
+    info "skill: not yet listed (catalog builds on next gc start; import is registered)"
+  fi
+fi
+
+# 5d. fragment (town only) — must be present
+if [ "$SCOPE" = "town" ]; then
+  for frag in "${FRAGMENTS[@]}"; do
+    if fragment_present "$frag"; then info "fragment: \"$frag\" in [agent_defaults] append_fragments"; else info "fragment: \"$frag\" MISSING"; fail=1; fi
+  done
+fi
+
+# 5e. equip hook projected (best-effort — only present once a claude agent has
+#     projected; absence is not fatal if the city is stopped).
+hook_hits=0
+while IFS= read -r f; do
+  if grep -q "$HOOK_MARKER" "$f" 2>/dev/null; then hook_hits=$((hook_hits+1)); fi
+done < <(find "$CITY/.gc/agents" "$CITY/.claude" "$CITY/.gc/settings.json" \
+              -name 'settings.json' 2>/dev/null)
+if [ "$hook_hits" -gt 0 ]; then
+  info "hook: SessionStart equip hook projected in $hook_hits settings file(s)"
+else
+  info "hook: not yet in any projected settings (expected if the city is stopped;"
+  info "      it materializes on the next agent session start / gc start)"
+fi
+
+if [ "$SCOPE" = "rig" ]; then REVERSE_FLAGS="--rig $RIG"; else REVERSE_FLAGS="--town"; fi
+echo
+if [ "$fail" -eq 0 ]; then
+  step "personas install complete ($SCOPE${RIG:+ $RIG})"
+  info "Agents will equip a best-fit persona on task pickup; inspect with"
+  info "'personas list' / 'personas match \"<task>\"' / 'personas cache'."
+  info "Reverse with: $PACK_DIR/uninstall.sh $REVERSE_FLAGS"
+  exit 0
+else
+  step "personas install finished WITH WARNINGS ($SCOPE${RIG:+ $RIG})"
+  info "Review the lines marked FAILED/MISSING above."
+  exit 1
+fi

--- a/personas/overlay/per-provider/claude/.claude/settings.json
+++ b/personas/overlay/per-provider/claude/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "export PATH=\"/opt/homebrew/bin:/usr/local/bin:$HOME/go/bin:$HOME/.local/bin:$PATH\" && d=\"$CLAUDE_PROJECT_DIR\"; while [ -n \"$d\" ] && [ \"$d\" != \"/\" ]; do h=\"$d/packs/personas/hooks/equip-on-task-pickup.sh\"; [ -f \"$h\" ] && { bash \"$h\"; break; }; d=\"$(dirname \"$d\")\"; done; true"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/personas/pack.toml
+++ b/personas/pack.toml
@@ -1,0 +1,36 @@
+# personas — dynamic principal-engineer persona equip for Gas City agents.
+#
+# When a polecat picks up a task, it equips a principal-engineer persona matched to
+# that task, performs the work at that level, then dematerializes. Recently-used
+# personas stay warm in a shared cache so other agents reuse them without paying the
+# materialize cost, and they age out of the cache after a period of disuse. This
+# composes with the rest of the blackrim toolchain — model-advisor picks the model
+# tier, provider-forge picks the provider/model, and personas picks the role.
+#
+# What this pack provides (all convention-discovered once the pack is imported):
+#   bin/personas                            list / show / lint / match / equip / cache / evict / sweep CLI
+#   personas/                               the engine (registry + match + warm-cache)
+#   personas.toml                           the roster + warm-cache TTL policy (edit me)
+#   hooks/equip-on-task-pickup.sh           the gas-town equip-on-task-pickup hook
+#   overlay/per-provider/claude/            SessionStart hook that equips on pickup
+#   template-fragments/use-personas.*       the equip-a-persona discipline fragment
+#   skills/equip-persona/SKILL.md           agent/operator skill: equip + inspect
+#   docs/DESIGN.md                          registry shape, match rule, TTL reasoning
+#
+# Stdlib-only (tomllib on Python >= 3.11; tomli fallback below it). No runtime
+# third-party dependencies — it mirrors model-advisor / provider-forge's minimal
+# footprint.
+#
+# Wiring (after vendoring this pack into a city at packs/personas and importing it,
+# e.g. `source = "packs/personas"`):
+#   1. Run packs/personas/setup.sh once to build the engine's venv (optional —
+#      bin/personas also runs under any system python3).
+#   2. `bin/personas list` — inspect the roster.
+#   3. `bin/personas match "<task description>"` — see the equip decision.
+#   4. The SessionStart equip hook is materialized + merged into projected settings
+#      by `gc reload`, so a polecat equips a persona as it picks up its work.
+
+[pack]
+name = "personas"
+schema = 2
+version = "0.1.0"

--- a/personas/personas.toml
+++ b/personas/personas.toml
@@ -1,0 +1,321 @@
+# personas.toml — the persona registry (edit me).
+#
+# This file is the library of principal-engineer persona definitions plus the
+# warm-cache TTL policy. Everything the equip/match engine and the warm cache need
+# lives here; nothing is hard-coded in the decision path. Deleting this file falls
+# back to a small built-in roster (see personas/registry.py DEFAULT_PERSONAS).
+#
+# Each [[persona]] is a role:
+#   id               stable kebab-case identifier
+#   domain           one line: the territory this persona owns
+#   when_to_equip    the conditions under which an agent should equip it
+#   match_keywords   curated terms the equip engine scores a task description against
+#                    (whole-word; multi-word phrases score higher). Lowercased on load.
+#   skills           gas-city skills this persona leans on
+#   tools            tools it expects to use
+#   verification_bar the bar it holds its own work to before handing off
+#   playbook         the principal-engineer mindset + method for this domain
+#   weight           optional priority (a finite number > 0) used ONLY as a
+#                    deterministic tie-break between personas with equal match scores
+
+[registry]
+# Equipped when a task matches nothing (the generalist fallback).
+default_persona = "principal-backend-engineer"
+
+# --------------------------------------------------------------------------- #
+# Warm-cache TTL policy (README "Lifecycle TTL").                              #
+#   idle    — sliding window since a persona was last equipped; refreshed on     #
+#             reuse. Covers a clustered work session; evicts the half-hour-cold. #
+#   ceiling — absolute cap since first materialize; force-refreshes even a       #
+#             continuously-reused persona so it picks up registry updates.       #
+# Convenience keys (minutes/hours) shown; *_seconds keys override them.          #
+# --------------------------------------------------------------------------- #
+[cache]
+idle_ttl_minutes = 30
+ceiling_ttl_hours = 2
+
+# =========================================================================== #
+# The roster                                                                    #
+# =========================================================================== #
+
+[[persona]]
+id = "principal-backend-engineer"
+domain = "Server-side services, APIs, data access, business logic, and server correctness."
+when_to_equip = "Implementing or changing server-side logic, endpoints, queues, jobs, auth flows, or data access."
+match_keywords = [
+  "backend", "server", "service", "microservice", "api", "endpoint", "handler",
+  "route", "rest", "rpc", "grpc", "database", "sql", "query", "orm", "migration",
+  "transaction", "queue", "worker", "background job", "cron", "auth", "authentication",
+  "authorization", "session", "cache", "idempotent", "webhook",
+]
+skills = ["tdd", "diagnose", "code-review"]
+tools = ["Read", "Edit", "Bash", "Grep", "Glob"]
+verification_bar = "Inputs validated at the boundary; errors are explicit and handled; state changes are idempotent or transactional; the change ships with a test that fails without it."
+playbook = """
+Think in contracts and failure modes before code. A backend change is a promise about
+inputs, outputs, and what happens when each step fails.
+
+- Validate and normalize at the boundary; keep the core logic pure and total.
+- Make writes idempotent or transactional — assume retries, partial failures, and
+  concurrent callers. Never leave a half-applied state.
+- Treat the database as the source of truth: model invariants as constraints, not as
+  application-layer hope. Watch N+1 queries, unbounded result sets, and missing indexes.
+- Errors are part of the API. Return precise, typed failures; log with enough context
+  to debug at 3am; never swallow exceptions.
+- Prove it with a test that exercises the real failure path, not just the happy case.
+"""
+
+[[persona]]
+id = "principal-frontend-engineer"
+domain = "User interfaces, components, client state, accessibility, and perceived performance."
+when_to_equip = "Building or changing UI components, client-side state, styling, forms, or browser behavior."
+match_keywords = [
+  "frontend", "ui", "ux", "component", "react", "vue", "svelte", "css", "html",
+  "tailwind", "styling", "layout", "responsive", "accessibility", "a11y", "aria",
+  "browser", "dom", "client state", "form", "render", "animation", "design system",
+  "button", "modal", "page",
+]
+skills = ["impeccable:impeccable", "verify", "code-review"]
+tools = ["Read", "Edit", "Write", "Bash", "Grep"]
+verification_bar = "Keyboard-navigable and screen-reader-labeled; handles loading, empty, and error states; no layout shift; works at mobile and desktop widths."
+playbook = """
+The interface is a state machine the user can see. Design every state, not just the
+populated happy path.
+
+- Enumerate states up front: loading, empty, error, partial, success. A component that
+  only renders success is unfinished.
+- Accessibility is correctness, not polish: semantic elements, focus order, labels,
+  contrast, and keyboard paths are non-negotiable.
+- Keep state minimal and derived where possible; lift it only as far as it must go.
+  Most "state bugs" are duplicated or stale derived state.
+- Guard perceived performance: avoid layout shift, render lists incrementally, and
+  never block paint on a slow request.
+- Verify in the real browser, not just in your head — see it work at narrow and wide.
+"""
+
+[[persona]]
+id = "principal-systems-engineer"
+domain = "Distributed systems, concurrency, performance, and resource correctness under load."
+when_to_equip = "Working on concurrency, distributed coordination, performance regressions, memory/CPU profiling, or throughput."
+match_keywords = [
+  "concurrency", "concurrent", "parallel", "race condition", "deadlock", "mutex",
+  "lock", "atomic", "goroutine", "thread", "async", "distributed", "consensus",
+  "replication", "sharding", "throughput", "latency", "performance", "profiling",
+  "profile", "benchmark", "memory leak", "backpressure", "queueing", "scalability",
+  "load",
+]
+skills = ["diagnose", "tdd", "code-review"]
+tools = ["Read", "Edit", "Bash", "Grep"]
+verification_bar = "Shared state is provably synchronized or eliminated; the hot path is measured before and after; failure and partial-failure modes are reasoned through, not assumed away."
+playbook = """
+Reason about time, ordering, and failure — the things that only break under load and
+concurrency. Intuition is unreliable here; measure and prove.
+
+- Find every piece of shared mutable state and either remove it or guard it. Name the
+  invariant the lock protects; an unnamed lock is a future deadlock.
+- Assume the network partitions, messages arrive twice, and nodes die mid-operation.
+  Design for at-least-once delivery and idempotent handling.
+- Never optimize on a hunch: profile first, change the one thing the profile indicts,
+  measure again. A benchmark with no baseline is theater.
+- Bound everything — queues, retries, fan-out, memory. Unbounded growth is the default
+  failure mode of a system under stress; add backpressure deliberately.
+"""
+
+[[persona]]
+id = "principal-security-engineer"
+domain = "Threat modeling, vulnerability analysis, secure defaults, and authorization."
+when_to_equip = "Security reviews, auth/crypto changes, handling untrusted input or secrets, or any threat-modeling task."
+match_keywords = [
+  "security", "secure", "vulnerability", "vuln", "threat model", "threat", "exploit",
+  "injection", "sql injection", "xss", "csrf", "ssrf", "authentication", "authorization",
+  "crypto", "encryption", "secret", "credential", "token", "sanitize", "audit",
+  "permission", "privilege", "owasp", "attack", "untrusted input",
+]
+skills = ["security-review", "diagnose", "code-review"]
+tools = ["Read", "Bash", "Grep", "Glob"]
+verification_bar = "Trust boundaries are explicit; all untrusted input is validated/encoded for its sink; secrets never logged or hard-coded; the change fails closed, and the finding is demonstrated, not asserted."
+playbook = """
+Assume the input is hostile and the caller is an attacker. Your job is to find the way
+in before someone else does.
+
+- Map trust boundaries first: where does untrusted data enter, and what sink does it
+  reach? Validate on input, encode on output for the specific sink (SQL, HTML, shell).
+- Prefer secure defaults and fail-closed: deny by default, least privilege, short-lived
+  credentials, no secrets in code or logs.
+- Don't roll your own crypto or auth; use vetted primitives correctly. Most breaks are
+  misuse, not broken algorithms.
+- A vulnerability claim needs a demonstration — the concrete input and the path it
+  takes — not a vibe. And distinguish exploitable from theoretical so fixes are ranked
+  by real risk.
+- Stay within authorized scope: this is defensive analysis, not live attack.
+"""
+
+[[persona]]
+id = "principal-data-engineer"
+domain = "Data and ML pipelines, ETL, schemas, data quality, and analytical correctness."
+when_to_equip = "Building or changing data pipelines, ETL/ELT, warehouse schemas, batch/stream jobs, or ML feature/data flows."
+match_keywords = [
+  "data pipeline", "pipeline", "etl", "elt", "warehouse", "data lake", "schema",
+  "ingestion", "batch", "streaming", "stream", "kafka", "spark", "airflow", "dbt",
+  "parquet", "dataset", "feature", "ml pipeline", "data quality", "dedup",
+  "backfill", "partition", "analytics",
+]
+skills = ["diagnose", "tdd"]
+tools = ["Read", "Edit", "Bash", "Grep"]
+verification_bar = "Transformations are idempotent and re-runnable; schema and types are enforced; row counts and key uniqueness are checked; a backfill cannot double-count."
+playbook = """
+Data pipelines fail silently — a wrong number looks exactly like a right one. Build for
+correctness you can verify and reruns you can trust.
+
+- Make every stage idempotent and re-runnable. A pipeline you cannot safely re-run is a
+  pipeline you cannot operate. Design backfills so they never double-count.
+- Enforce schema and types at boundaries; reject or quarantine bad rows loudly rather
+  than letting them poison downstream aggregates.
+- Add data-quality assertions as first-class steps: row counts, null rates, key
+  uniqueness, referential integrity. Alert on drift, not just on crashes.
+- Partition and incrementalize so cost scales with new data, not total data.
+- Treat schema changes as contracts with every downstream consumer; version and migrate
+  deliberately.
+"""
+
+[[persona]]
+id = "principal-platform-engineer"
+domain = "Infrastructure, SRE, CI/CD, observability, and operational reliability."
+when_to_equip = "Working on infra-as-code, deployment, CI/CD pipelines, containers, observability, or reliability/operability."
+match_keywords = [
+  "infrastructure", "infra", "sre", "devops", "ci", "cd", "ci/cd", "pipeline",
+  "deploy", "deployment", "kubernetes", "k8s", "docker", "container", "terraform",
+  "ansible", "helm", "observability", "monitoring", "metrics", "logging", "tracing",
+  "alerting", "reliability", "rollback", "provisioning", "cloud",
+]
+skills = ["diagnose", "verify"]
+tools = ["Read", "Edit", "Bash", "Grep"]
+verification_bar = "Changes are declarative and reproducible; rollout is reversible (rollback path tested); the change is observable (metrics/logs/alerts) before it is relied on."
+playbook = """
+You operate what you ship. Optimize for reproducibility, reversibility, and the 3am
+on-call who has to understand it.
+
+- Everything as code: declarative, version-controlled, reproducible from scratch. No
+  snowflake state, no manual console clicks that aren't captured.
+- Every change needs a rollback path you have actually exercised. "Roll forward only" is
+  not a plan.
+- If you can't observe it, you can't operate it: ship metrics, structured logs, and
+  alerts with the change, tied to user-visible SLOs, not vanity counters.
+- Make the safe path the easy path — guardrails, sane defaults, least-privilege access.
+- Automate toil, but keep the automation legible; a clever pipeline no one can debug is
+  a liability.
+"""
+
+[[persona]]
+id = "principal-api-designer"
+domain = "API contracts, interface design, versioning, and developer experience."
+when_to_equip = "Designing or changing a public/internal API surface, library interface, schema contract, or SDK ergonomics."
+match_keywords = [
+  "api design", "interface", "contract", "openapi", "swagger", "schema design",
+  "versioning", "backward compatible", "backwards compatibility", "deprecation",
+  "sdk", "client library", "public api", "endpoint design", "rest design",
+  "graphql", "protobuf", "developer experience", "ergonomics", "naming",
+]
+skills = ["code-review", "to-prd"]
+tools = ["Read", "Edit", "Grep"]
+verification_bar = "The contract is explicit and documented; changes are backward-compatible or versioned with a deprecation path; names are consistent; the easy thing is the correct thing."
+playbook = """
+An API is a promise you will have to keep for years. Design the contract first, from the
+caller's point of view, and make the common case effortless.
+
+- Start from the caller: write the usage you wish existed, then build the surface that
+  makes it real. The right design reads obviously.
+- Be ruthless about consistency — naming, pluralization, error shape, pagination. A
+  predictable API needs no documentation for the next endpoint.
+- Backward compatibility is sacred once published. Additive change is free; breaking
+  change requires a version and a deprecation path with a real timeline.
+- Make illegal states unrepresentable and the correct usage the path of least
+  resistance. Defaults should be safe; footguns should require effort.
+- Document the contract — types, errors, idempotency, limits — as part of the change,
+  not after.
+"""
+
+[[persona]]
+id = "principal-test-engineer"
+domain = "Test strategy, coverage, regression safety, and fast deterministic suites."
+when_to_equip = "Writing or strengthening tests, raising coverage, reproducing a bug as a test, or designing test strategy."
+match_keywords = [
+  "test", "tests", "testing", "unit test", "integration test", "e2e", "end to end",
+  "coverage", "regression", "tdd", "red green", "fixture", "mock", "stub", "assertion",
+  "flaky", "test suite", "property test", "snapshot test", "test strategy",
+]
+skills = ["tdd", "verify", "diagnose"]
+tools = ["Read", "Edit", "Bash", "Grep"]
+verification_bar = "Each test fails before the fix and passes after; tests assert behavior at the seam, not internals; the suite is deterministic and fast; no flakiness introduced."
+playbook = """
+A test exists to catch a regression you can name. Write the failing test first, make it
+pass, and keep the suite fast enough that people actually run it.
+
+- Red-green: see the test fail for the right reason before you make it pass. A test that
+  has never failed proves nothing.
+- Test behavior at the public seam, not private implementation. Tests coupled to
+  internals break on every refactor and teach people to delete tests.
+- Determinism is non-negotiable: control time, randomness, ordering, and I/O. A flaky
+  test is worse than no test — it trains people to ignore red.
+- Push logic down to fast unit tests; reserve slow integration/e2e for the wiring only.
+  Invert the pyramid and the suite rots.
+- Reproduce every bug as a failing test before fixing it; that test is the regression
+  guard.
+"""
+
+[[persona]]
+id = "principal-refactoring-engineer"
+domain = "Simplification, code health, and reducing complexity without changing behavior."
+when_to_equip = "Refactoring, simplifying, deduplicating, untangling, or improving readability and structure with behavior held constant."
+match_keywords = [
+  "refactor", "refactoring", "simplify", "simplification", "cleanup", "clean up",
+  "tech debt", "technical debt", "dedup", "deduplicate", "readability", "code health",
+  "untangle", "rename", "extract", "decouple", "consolidate", "code smell",
+  "complexity", "restructure",
+]
+skills = ["simplify", "improve-codebase-architecture", "code-review", "tdd"]
+tools = ["Read", "Edit", "Bash", "Grep", "Glob"]
+verification_bar = "Behavior is provably unchanged (tests green before and after, ideally identical); each step is small and reversible; the result is simpler by a real measure, not just moved around."
+playbook = """
+Refactoring changes structure while holding behavior exactly constant. The safety net is
+the whole game: never refactor without green tests.
+
+- Pin behavior first. If tests are thin, add characterization tests before touching the
+  structure — you cannot refactor what you cannot verify.
+- Work in small, reversible steps, each leaving the suite green. A giant "cleanup" commit
+  is a rewrite in disguise and a review nightmare.
+- Delete before you add. The simplest change is removing code; dead code, needless
+  abstraction, and duplication are the usual wins.
+- Make the change easy, then make the easy change. Reshape toward the upcoming need;
+  don't gold-plate generality no one asked for.
+- Measure simpler honestly: less duplication, fewer branches, clearer names — not the
+  same complexity relocated.
+"""
+
+[[persona]]
+id = "principal-docs-engineer"
+domain = "Technical writing, READMEs, API docs, and developer-facing explanation."
+when_to_equip = "Writing or revising documentation, READMEs, guides, design docs, changelogs, or explanatory comments."
+match_keywords = [
+  "docs", "documentation", "readme", "guide", "tutorial", "how-to", "reference docs",
+  "api docs", "changelog", "release notes", "design doc", "adr", "explainer",
+  "onboarding docs", "comment", "docstring", "manual", "wiki", "writeup",
+]
+skills = ["init", "to-prd"]
+tools = ["Read", "Edit", "Write", "Grep"]
+verification_bar = "A new reader can complete the task from the doc; every example runs as written; nothing contradicts the current code; structure leads with the reader's goal."
+playbook = """
+Write for the reader's next action, not to record what you did. Good docs are the
+shortest path from a goal to a working result.
+
+- Lead with the why and the outcome, then the steps. A reader scanning for their task
+  should find it in seconds.
+- Every example must run exactly as written — copy-paste-execute. A broken example
+  destroys trust in the whole document.
+- Keep claims verifiable against the code; docs that drift from reality are worse than
+  none. Prefer linking to the source of truth over duplicating it.
+- Match the reader's level: name prerequisites, define the one term they won't know,
+  skip the three they already do.
+- Ruthlessly cut. The best documentation is brief, accurate, and current — length is
+  not thoroughness.
+"""

--- a/personas/personas/__init__.py
+++ b/personas/personas/__init__.py
@@ -1,0 +1,28 @@
+"""personas — dynamic principal-engineer persona equip for Gas City agents.
+
+A pure-stdlib toolkit that picks the best-fit principal-engineer persona for a task,
+equips it (materializing it into a shared warm cache so other agents reuse it), and
+ages it out after a period of disuse. It does NOT run a backend; it is a registry, a
+match rule, and a warm-cache lifecycle, surfaced as a CLI and a gas-town hook.
+
+Public surface (what the CLI and the equip hook build on):
+
+- :mod:`personas.registry`  — load + validate the roster and the warm-cache TTL
+  policy from ``personas.toml`` (:class:`~personas.registry.Persona`,
+  :class:`~personas.registry.PersonasConfig`).
+- :mod:`personas.match`     — the equip/match engine: score every persona against a
+  task description and return the best fit, explainably
+  (:func:`~personas.match.match_persona`).
+- :mod:`personas.cache`     — the warm-cache + TTL lifecycle: materialize, reuse
+  (sliding-idle refresh), and evict on the configured policy
+  (:class:`~personas.cache.WarmCache`).
+- :mod:`personas.cli`       — the ``list`` / ``show`` / ``match`` / ``equip`` /
+  ``cache`` / ``sweep`` command implementations.
+"""
+
+from __future__ import annotations
+
+SCHEMA = "personas.v0"
+__version__ = "0.1.0"
+
+__all__ = ["SCHEMA", "__version__"]

--- a/personas/personas/cache.py
+++ b/personas/personas/cache.py
@@ -1,0 +1,344 @@
+"""Warm-cache + TTL lifecycle — materialized personas kept warm for reuse.
+
+The README lifecycle: materialize -> execute -> dematerialize -> *warm* -> age out.
+This module owns the **warm** and **age-out** phases. A materialized persona — its
+assembled, ready-to-overlay working context — lingers in a shared, JSON-backed cache
+so the next agent that needs it reuses it **without paying the materialize cost
+again**, and it is evicted once it goes cold per the configured
+:class:`~personas.registry.CachePolicy`:
+
+- **Sliding idle TTL** (default 30 min): refreshed on every reuse. Evicts a persona
+  no agent has equipped within the window.
+- **Absolute ceiling** (default 2 h): from first materialize. Force-refreshes even a
+  continuously-reused persona so it picks up registry updates and the cache stays
+  bounded.
+
+What is cached is the **materialized payload**, not just a last-used timestamp: each
+:class:`WarmEntry` carries the persona's rendered ``overlay`` (the working context the
+equip step assembles) plus a ``fingerprint`` of the persona definition it was rendered
+from. :meth:`WarmCache.equip` takes a ``materialize`` thunk and calls it **only** on a
+cold or stale equip — a warm reuse returns the stored overlay untouched, which is the
+cost the cache exists to amortize. The fingerprint makes that amortization safe: if the
+registry definition drifts, the stored overlay is re-materialized immediately rather
+than waiting for the ceiling, so a warm reuse never serves a stale persona.
+
+Eviction is lazy: every :meth:`WarmCache.equip` / :meth:`WarmCache.status` sweeps
+expired entries first, and :meth:`WarmCache.sweep` can be called explicitly. ``now``
+is injected into every time-dependent method so the policy is deterministically
+testable; callers pass :func:`time.time`.
+
+Writes are atomic (temp file + ``os.replace``) so a concurrent reader never sees a
+half-written cache. Concurrent writers are last-writer-wins — acceptable for a warm
+cache whose entries are always re-derivable from the registry.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from dataclasses import asdict, dataclass, replace
+from typing import Callable, Optional
+
+from personas.registry import CachePolicy
+
+#: Bumped from v0 when entries gained the materialized ``overlay`` + ``fingerprint``.
+#: The reader tolerates rows missing those fields, so a v0 file still loads (its entries
+#: simply re-materialize on next equip), and the cache is always re-derivable anyway.
+SCHEMA = "personas.warm-cache.v1"
+
+
+@dataclass(frozen=True)
+class WarmEntry:
+    """One materialized persona in the warm cache.
+
+    ``overlay`` is the materialized payload — the rendered working context a warm reuse
+    returns instead of re-assembling. ``fingerprint`` is a digest of the persona
+    definition it was rendered from, so :meth:`WarmCache.equip` can detect a registry
+    edit and re-materialize before the ceiling. Both default to empty for a
+    metadata-only entry (no materializer supplied) and for forward-compatible reads of a
+    pre-payload cache file.
+    """
+
+    persona_id: str
+    materialized_at: float  # epoch seconds of first materialize (drives the ceiling)
+    last_used_at: float     # epoch seconds of most recent equip (drives the idle TTL)
+    use_count: int          # how many times it has been equipped while warm
+    overlay: str = ""       # the materialized working context (what the cache amortizes)
+    fingerprint: str = ""   # digest of the persona definition this overlay was made from
+
+    def idle_age(self, now: float) -> float:
+        return max(0.0, now - self.last_used_at)
+
+    def total_age(self, now: float) -> float:
+        return max(0.0, now - self.materialized_at)
+
+    def expiry_reason(self, policy: CachePolicy, now: float) -> Optional[str]:
+        """``None`` if live; else ``"ceiling"`` or ``"idle"`` (ceiling checked first)."""
+        if self.total_age(now) > policy.ceiling_ttl_seconds:
+            return "ceiling"
+        if self.idle_age(now) > policy.idle_ttl_seconds:
+            return "idle"
+        return None
+
+    def is_live(self, policy: CachePolicy, now: float) -> bool:
+        return self.expiry_reason(policy, now) is None
+
+    def remaining_idle(self, policy: CachePolicy, now: float) -> float:
+        return policy.idle_ttl_seconds - self.idle_age(now)
+
+    def remaining_ceiling(self, policy: CachePolicy, now: float) -> float:
+        return policy.ceiling_ttl_seconds - self.total_age(now)
+
+
+@dataclass(frozen=True)
+class EquipOutcome:
+    """Result of :meth:`WarmCache.equip` — the warm entry and whether it was a reuse."""
+
+    entry: WarmEntry
+    was_warm: bool                # True = reused an already-warm persona (no materialize)
+    evicted: tuple[WarmEntry, ...]  # entries swept on this equip (cold/expired)
+
+    @property
+    def overlay(self) -> str:
+        """The materialized working context for this equip (served warm or freshly made)."""
+        return self.entry.overlay
+
+
+@dataclass(frozen=True)
+class EntryStatus:
+    """A warm entry decorated with its live/expired verdict for inspection."""
+
+    entry: WarmEntry
+    live: bool
+    expiry_reason: Optional[str]
+    remaining_idle: float
+    remaining_ceiling: float
+
+
+class WarmCache:
+    """A JSON-backed warm cache of materialized personas under a single policy."""
+
+    def __init__(self, path: str | os.PathLike[str], policy: CachePolicy) -> None:
+        self.path = os.fspath(path)
+        self.policy = policy
+
+    # ---- persistence ------------------------------------------------------- #
+
+    def _read(self) -> dict[str, WarmEntry]:
+        try:
+            with open(self.path, "r", encoding="utf-8") as fh:
+                raw = json.load(fh)
+        except (FileNotFoundError, ValueError, OSError):
+            # Missing or corrupt cache is not an error: a warm cache is always
+            # re-derivable, so we start empty rather than fail the equip path.
+            return {}
+        entries: dict[str, WarmEntry] = {}
+        for rec in raw.get("entries", []):
+            try:
+                entries[str(rec["persona_id"])] = WarmEntry(
+                    persona_id=str(rec["persona_id"]),
+                    materialized_at=float(rec["materialized_at"]),
+                    last_used_at=float(rec["last_used_at"]),
+                    use_count=int(rec.get("use_count", 1)),
+                    # Absent on a v0 (pre-payload) file: degrade to a metadata-only entry
+                    # that re-materializes on its next equip rather than failing the read.
+                    overlay=str(rec.get("overlay", "")),
+                    fingerprint=str(rec.get("fingerprint", "")),
+                )
+            except (KeyError, TypeError, ValueError):
+                continue  # skip malformed rows, keep the rest
+        return entries
+
+    def _write(self, entries: dict[str, WarmEntry]) -> None:
+        ordered = sorted(entries.values(), key=lambda e: e.persona_id)
+        doc = {"schema": SCHEMA, "entries": [asdict(e) for e in ordered]}
+        directory = os.path.dirname(self.path) or "."
+        os.makedirs(directory, exist_ok=True)
+        # Atomic replace: write a sibling temp file, fsync, then rename over the target.
+        fd, tmp = tempfile.mkstemp(dir=directory, prefix=".warm-cache.", suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                json.dump(doc, fh, indent=2, sort_keys=True)
+                fh.write("\n")
+                fh.flush()
+                os.fsync(fh.fileno())
+            os.replace(tmp, self.path)
+        finally:
+            if os.path.exists(tmp):
+                os.unlink(tmp)
+
+    # ---- introspection ----------------------------------------------------- #
+
+    def entries(self) -> dict[str, WarmEntry]:
+        """All persisted entries (including any that are now expired)."""
+        return self._read()
+
+    def get(self, persona_id: str, now: float) -> Optional[WarmEntry]:
+        """Return the entry for ``persona_id`` only if it is still live, else ``None``."""
+        entry = self._read().get(persona_id)
+        if entry is not None and entry.is_live(self.policy, now):
+            return entry
+        return None
+
+    def status(self, now: float, *, prune: bool = True) -> list[EntryStatus]:
+        """Live + expired verdict for every entry, newest-used first.
+
+        With ``prune`` (default) expired entries are swept from disk as a side effect,
+        matching the lazy-eviction contract; the returned list still describes them.
+        """
+        entries = self._read()
+        out = [
+            EntryStatus(
+                entry=e,
+                live=e.is_live(self.policy, now),
+                expiry_reason=e.expiry_reason(self.policy, now),
+                remaining_idle=e.remaining_idle(self.policy, now),
+                remaining_ceiling=e.remaining_ceiling(self.policy, now),
+            )
+            for e in entries.values()
+        ]
+        out.sort(key=lambda s: s.entry.last_used_at, reverse=True)
+        if prune:
+            live = {pid: e for pid, e in entries.items() if e.is_live(self.policy, now)}
+            if len(live) != len(entries):
+                self._write(live)
+        return out
+
+    # ---- mutation ---------------------------------------------------------- #
+
+    def equip(
+        self,
+        persona_id: str,
+        now: float,
+        *,
+        materialize: Optional[Callable[[], str]] = None,
+        fingerprint: str = "",
+    ) -> EquipOutcome:
+        """Materialize ``persona_id`` (or reuse it if already warm), then persist.
+
+        Sweeps expired entries first (lazy eviction), then either reuses a still-warm
+        persona or materializes a fresh one:
+
+        - **Warm reuse** (``was_warm`` True). A live entry whose payload is still valid is
+          *touched* — ``last_used_at`` slides to ``now`` and ``use_count`` increments —
+          and its stored ``overlay`` is returned **without calling** ``materialize``.
+          This is the cost the warm cache exists to amortize.
+        - **Materialize** (``was_warm`` False). On a cold, ceiling/idle-expired, or
+          definition-drifted persona, ``materialize`` (if given) is invoked once to
+          assemble the overlay, and the entry is stored fresh with ``materialized_at``
+          reset to ``now`` — so a ceiling refresh and a registry edit both genuinely
+          re-read the registry.
+
+        ``materialize`` is the (potentially expensive) thunk that assembles the persona's
+        working context; omit it for a metadata-only entry (overlay stays empty), which
+        preserves the pre-payload behavior. ``fingerprint`` is the current persona
+        definition's digest: a live entry whose stored fingerprint differs is treated as
+        stale and re-materialized, so an edited persona is picked up immediately rather
+        than only at the ceiling. When ``fingerprint`` is empty no drift check is done.
+        """
+        entries = self._read()
+        evicted = tuple(
+            e for e in entries.values() if not e.is_live(self.policy, now)
+        )
+        live = {pid: e for pid, e in entries.items() if e.is_live(self.policy, now)}
+
+        existing = live.get(persona_id)
+        # A warm reuse needs a live entry that (a) was rendered from the current
+        # definition — or no fingerprint was supplied to check against — and (b) actually
+        # carries a payload to return when a materializer is in play. Otherwise we
+        # re-materialize, paying the cost the cache could not amortize this time.
+        fingerprint_ok = not fingerprint or (
+            existing is not None and existing.fingerprint == fingerprint
+        )
+        has_payload = materialize is None or (existing is not None and existing.overlay != "")
+        if existing is not None and fingerprint_ok and has_payload:
+            entry = replace(existing, last_used_at=now, use_count=existing.use_count + 1)
+            was_warm = True
+        else:
+            overlay = materialize() if materialize is not None else ""
+            entry = WarmEntry(
+                persona_id=persona_id,
+                materialized_at=now,
+                last_used_at=now,
+                use_count=1,
+                overlay=overlay,
+                fingerprint=fingerprint,
+            )
+            was_warm = False
+
+        live[persona_id] = entry
+        self._write(live)
+        return EquipOutcome(entry=entry, was_warm=was_warm, evicted=evicted)
+
+    def sweep(self, now: float) -> list[WarmEntry]:
+        """Evict every expired entry and return what was removed."""
+        entries = self._read()
+        evicted = [e for e in entries.values() if not e.is_live(self.policy, now)]
+        if evicted:
+            live = {pid: e for pid, e in entries.items() if e.is_live(self.policy, now)}
+            self._write(live)
+        return evicted
+
+    def evict(self, persona_id: str) -> bool:
+        """Dematerialize a specific persona now (regardless of TTL). True if removed."""
+        entries = self._read()
+        if persona_id not in entries:
+            return False
+        del entries[persona_id]
+        self._write(entries)
+        return True
+
+    def clear(self) -> int:
+        """Drop the whole warm cache. Returns the number of entries removed."""
+        n = len(self._read())
+        self._write({})
+        return n
+
+
+# --------------------------------------------------------------------------- #
+# Cache-path resolution                                                          #
+# --------------------------------------------------------------------------- #
+
+_CACHE_BASENAME = "warm-cache.json"
+
+
+def default_cache_path(start_dir: str | None = None, env: Optional[dict] = None) -> str:
+    """Resolve where the shared warm cache lives.
+
+    Precedence (first hit wins):
+
+    1. ``PERSONAS_CACHE_FILE`` — an explicit file path.
+    2. ``PERSONAS_CACHE_DIR`` — a directory; the cache is ``<dir>/warm-cache.json``.
+    3. ``GC_RIG_ROOT`` — the rig repo (shared by all of a rig's agents);
+       ``<rig>/.beads/personas/warm-cache.json``. This is the intended home: a cache
+       under ``.beads`` is shared, so the next agent reuses a warm persona.
+    4. Walk up from ``start_dir`` (or cwd) for a ``.beads`` directory; use
+       ``<that>/.beads/personas/warm-cache.json``.
+    5. Fall back to ``~/.gc/runtime/personas/warm-cache.json``.
+    """
+    env = os.environ if env is None else env
+
+    explicit = env.get("PERSONAS_CACHE_FILE")
+    if explicit:
+        return os.path.abspath(explicit)
+
+    cache_dir = env.get("PERSONAS_CACHE_DIR")
+    if cache_dir:
+        return os.path.abspath(os.path.join(cache_dir, _CACHE_BASENAME))
+
+    rig_root = env.get("GC_RIG_ROOT")
+    if rig_root and os.path.isdir(rig_root):
+        return os.path.join(rig_root, ".beads", "personas", _CACHE_BASENAME)
+
+    d = os.path.abspath(start_dir or os.getcwd())
+    for _ in range(24):
+        if os.path.isdir(os.path.join(d, ".beads")):
+            return os.path.join(d, ".beads", "personas", _CACHE_BASENAME)
+        parent = os.path.dirname(d)
+        if parent == d:
+            break
+        d = parent
+
+    home = env.get("GC_HOME") or os.path.expanduser("~/.gc")
+    return os.path.join(home, "runtime", "personas", _CACHE_BASENAME)

--- a/personas/personas/cli.py
+++ b/personas/personas/cli.py
@@ -1,0 +1,520 @@
+"""personas CLI — inspect the roster, see equip decisions, and drive the warm cache.
+
+    personas list                       the roster (id, domain, when to equip)
+    personas show <id>                  one persona's full definition + playbook
+    personas lint                       registry integrity check (exit 1 if issues)
+    personas match <task...>            the equip decision for a task (read-only)
+        [--from-bead ID]
+    personas equip <task...>            match + materialize into the warm cache
+        [--from-bead ID] [--emit-context]
+    personas cache                      the warm cache: what's materialized + TTL
+    personas evict <id>                 dematerialize one persona from the warm cache
+    personas sweep [--all]              evict expired (or all) warm personas
+
+The CLI is the inspection surface over the three engine layers: the **registry**
+(``list`` / ``show`` / ``lint``), the **equip decision** (``match`` / ``equip``), and the
+**warm cache** (``cache`` / ``evict`` / ``sweep``). ``list`` / ``show`` / ``lint`` /
+``match`` / ``cache`` are pure reads (``cache`` lazily prunes expired entries — a no-op on
+a fresh cache); ``equip`` / ``evict`` / ``sweep`` mutate the warm cache. ``match`` and
+``equip`` take the task as positional words or ``--from-bead ID`` (resolved from a work
+bead's title + description) — ``match`` previews the decision without materializing,
+``equip`` materializes it into the cache. ``equip --emit-context`` prints a Claude Code
+SessionStart hook payload so the equip-on-task-pickup hook can overlay the persona.
+
+Exit codes: 0 ok; 1 ``lint`` found registry integrity issues; 2 a usage / resolution
+error (unknown persona id, invalid registry, ``--from-bead`` could not resolve a task).
+Pure stdlib; invoked as ``python -m personas.cli`` by the ``bin/personas`` wrapper.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from typing import Any, Optional, Sequence
+
+from personas import cache as C
+from personas import match as M
+from personas import registry as R
+
+#: The roster shipped with the pack (pack root / personas.toml), used unless --registry.
+_DEFAULT_REGISTRY = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "personas.toml"
+)
+
+
+def _load(args: argparse.Namespace) -> R.PersonasConfig:
+    try:
+        return R.load_config(args.registry)
+    except R.RegistryError as e:
+        sys.stderr.write(f"personas: invalid registry: {e}\n")
+        raise SystemExit(2)
+
+
+def _cache(args: argparse.Namespace, config: R.PersonasConfig) -> C.WarmCache:
+    path = args.cache_file or C.default_cache_path()
+    return C.WarmCache(path, config.cache)
+
+
+# --------------------------------------------------------------------------- #
+# Serialization / rendering helpers                                             #
+# --------------------------------------------------------------------------- #
+
+
+def _persona_dict(p: R.Persona) -> dict[str, Any]:
+    return {
+        "id": p.id,
+        "title": p.title,
+        "domain": p.domain,
+        "when_to_equip": p.when_to_equip,
+        "match_keywords": list(p.match_keywords),
+        "skills": list(p.skills),
+        "tools": list(p.tools),
+        "verification_bar": p.verification_bar,
+        "weight": p.weight,
+        "playbook": p.playbook,
+    }
+
+
+def _compose_context(persona_overlay: str, result: M.MatchResult) -> str:
+    """Compose the equip overlay shown/emitted for a task: provenance note + the overlay.
+
+    ``persona_overlay`` is the materialized, task-independent context the warm cache
+    serves (``EquipOutcome.overlay``); :func:`personas.match.render_provenance` adds the
+    cheap, per-task "why this persona" note on top. Composing here (rather than baking
+    provenance into the cached overlay) is what lets the cache reuse one overlay across
+    different tasks — the amortization the warm cache exists for.
+    """
+    provenance = M.render_provenance(result)
+    return f"{provenance}\n\n{persona_overlay}" if provenance else persona_overlay
+
+
+def _fmt_secs(s: float) -> str:
+    """Compact human duration for TTL remaining (e.g. ``28m12s``, ``-3m`` if expired)."""
+    sign = "-" if s < 0 else ""
+    s = abs(int(s))
+    h, rem = divmod(s, 3600)
+    m, sec = divmod(rem, 60)
+    if h:
+        return f"{sign}{h}h{m:02d}m"
+    if m:
+        return f"{sign}{m}m{sec:02d}s"
+    return f"{sign}{sec}s"
+
+
+# --------------------------------------------------------------------------- #
+# bead resolution (for `equip --from-bead`)                                     #
+# --------------------------------------------------------------------------- #
+
+
+def _task_from_bead(bead_id: str) -> str:
+    """Resolve a task description (title + description) from a bead via ``bd show``.
+
+    Best-effort and isolated here so the engine stays subprocess-free and tests can
+    monkeypatch it. Raises ``ValueError`` with a clear message on any failure.
+    """
+    try:
+        proc = subprocess.run(
+            ["bd", "show", bead_id, "--json"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except (OSError, subprocess.SubprocessError) as e:
+        raise ValueError(f"could not run 'bd show {bead_id}': {e}")
+    if proc.returncode != 0:
+        raise ValueError(
+            f"'bd show {bead_id}' failed ({proc.returncode}): {proc.stderr.strip()}"
+        )
+    try:
+        data = json.loads(proc.stdout)
+    except ValueError as e:
+        raise ValueError(f"'bd show {bead_id}' did not return JSON: {e}")
+    rec = data[0] if isinstance(data, list) and data else data
+    if not isinstance(rec, dict):
+        raise ValueError(f"unexpected 'bd show {bead_id}' shape")
+    title = str(rec.get("title", "")).strip()
+    desc = str(rec.get("description", "")).strip()
+    text = ". ".join(t for t in (title, desc) if t)
+    if not text:
+        raise ValueError(f"bead {bead_id} has no title/description to match on")
+    return text
+
+
+def _resolve_task(args: argparse.Namespace, label: str) -> Optional[str]:
+    """Resolve the task text for a match/equip command, or ``None`` on a usage error.
+
+    Shared by :func:`cmd_match` and :func:`cmd_equip` so the two commands accept a task
+    the same way: ``--from-bead ID`` (pulled from the bead's title + description) takes
+    precedence over the positional words. On any failure — an unresolvable bead or an
+    empty task — it writes a ``personas <label>: …`` message to stderr and returns
+    ``None``, so the caller returns exit code 2 without duplicating the error handling.
+    """
+    if getattr(args, "from_bead", None):
+        try:
+            task = _task_from_bead(args.from_bead)
+        except ValueError as e:
+            sys.stderr.write(f"personas {label}: {e}\n")
+            return None
+    else:
+        task = " ".join(args.task)
+    if not task.strip():
+        sys.stderr.write(
+            f"personas {label}: empty task (give a description or --from-bead ID)\n"
+        )
+        return None
+    return task
+
+
+# --------------------------------------------------------------------------- #
+# commands                                                                       #
+# --------------------------------------------------------------------------- #
+
+
+def cmd_list(args: argparse.Namespace, out) -> int:
+    config = _load(args)
+    if args.json:
+        out.write(json.dumps([_persona_dict(p) for p in config.personas], indent=2) + "\n")
+        return 0
+    out.write(f"persona roster ({len(config.personas)}):\n\n")
+    width = max((len(p.id) for p in config.personas), default=0)
+    for p in config.personas:
+        marker = " *" if p.id == config.default_persona_id else "  "
+        out.write(f"{marker}{p.id.ljust(width)}  {p.domain}\n")
+    if config.default_persona_id:
+        out.write("\n* = default (equipped when a task matches nothing)\n")
+    return 0
+
+
+def cmd_show(args: argparse.Namespace, out) -> int:
+    config = _load(args)
+    if not config.has(args.id):
+        sys.stderr.write(
+            f"personas: unknown persona {args.id!r}. Known: {', '.join(config.ids)}\n"
+        )
+        return 2
+    p = config.get(args.id)
+    if args.json:
+        out.write(json.dumps(_persona_dict(p), indent=2) + "\n")
+        return 0
+    out.write(M.render_overlay(p))
+    if p.when_to_equip:
+        out.write(f"\n**When to equip:** {p.when_to_equip}\n")
+    if p.match_keywords:
+        out.write(f"**Match keywords:** {', '.join(p.match_keywords)}\n")
+    return 0
+
+
+def cmd_lint(args: argparse.Namespace, out) -> int:
+    """Integrity-check the registry: every persona is *semantically* complete.
+
+    Loading the registry already rejects anything structurally invalid (a bad/duplicate
+    id, an unknown default, a broken cache policy) with exit 2. This is the complementary
+    completeness pass over a roster that loaded: :func:`personas.registry.validate` flags a
+    persona missing the fields that make it usable — a domain, playbook, verification bar,
+    keywords to match on, and the skills/tools it brings. It is the seam the registry
+    foundation exposed for exactly this command, so editing ``personas.toml`` has a check.
+
+    Exit 0 when the roster is clean, 1 when integrity issues are found (so a CI step or a
+    pre-commit hook can gate on a roster edit), 2 if the registry itself won't load.
+    """
+    config = _load(args)
+    issues = R.validate(config)
+    rc = 0 if not issues else 1
+    if args.json:
+        out.write(
+            json.dumps(
+                {
+                    "ok": not issues,
+                    "persona_count": len(config.personas),
+                    "issue_count": len(issues),
+                    "issues": issues,
+                },
+                indent=2,
+            )
+            + "\n"
+        )
+        return rc
+    n = len(config.personas)
+    if not issues:
+        out.write(f"registry ok: {n} persona{'' if n == 1 else 's'}, no integrity issues\n")
+        return rc
+    out.write(f"registry has {len(issues)} integrity issue{'' if len(issues) == 1 else 's'} "
+              f"across {n} persona{'' if n == 1 else 's'}:\n\n")
+    for issue in issues:
+        out.write(f"  - {issue}\n")
+    out.write(
+        "\n(structural errors are rejected at load with exit 2; these are completeness "
+        "gaps — a persona that loads but routes/overlays less well)\n"
+    )
+    return rc
+
+
+def cmd_match(args: argparse.Namespace, out) -> int:
+    config = _load(args)
+    task = _resolve_task(args, "match")
+    if task is None:
+        return 2
+    result = M.match_persona(config, task)
+    if args.json:
+        out.write(json.dumps(_match_dict(result), indent=2) + "\n")
+        return 0
+    if result.is_fallback:
+        out.write(
+            f"no strong match for {task!r}\n"
+            f"-> default persona: {result.best.id} ({result.best.title})\n"
+        )
+        return 0
+    out.write(f"task: {task}\n\n")
+    out.write(f"-> {result.best.id}  (score {result.score:g}; matched: {', '.join(result.matched)})\n")
+    if result.runners_up:
+        out.write("\nrunners-up:\n")
+        for s in result.runners_up:
+            out.write(f"   {s.persona.id}  (score {s.score:g}; {', '.join(s.matched)})\n")
+    return 0
+
+
+def cmd_equip(args: argparse.Namespace, out) -> int:
+    config = _load(args)
+    task = _resolve_task(args, "equip")
+    if task is None:
+        return 2
+
+    result = M.match_persona(config, task)
+    cache = _cache(args, config)
+    # Materialize through the warm cache: the overlay is rendered (the cost) only on a
+    # cold/stale equip; a warm reuse returns the stored overlay untouched. The fingerprint
+    # invalidates a warm entry whose persona definition has since changed.
+    outcome = cache.equip(
+        result.best.id,
+        now=time.time(),
+        materialize=lambda: M.render_overlay(result.best),
+        fingerprint=M.persona_fingerprint(result.best),
+    )
+    context = _compose_context(outcome.overlay, result)
+
+    if args.emit_context:
+        # Claude Code SessionStart hook payload: inject the persona as added context.
+        payload = {
+            "hookSpecificOutput": {
+                "hookEventName": "SessionStart",
+                "additionalContext": context,
+            }
+        }
+        out.write(json.dumps(payload) + "\n")
+        return 0
+
+    if args.json:
+        doc = _match_dict(result)
+        doc["equipped"] = {
+            "persona_id": outcome.entry.persona_id,
+            "was_warm": outcome.was_warm,
+            "use_count": outcome.entry.use_count,
+            "evicted": [e.persona_id for e in outcome.evicted],
+        }
+        out.write(json.dumps(doc, indent=2) + "\n")
+        return 0
+
+    state = "reused warm" if outcome.was_warm else "materialized"
+    out.write(context)
+    out.write(f"\n[{state}; use_count={outcome.entry.use_count}]\n")
+    if outcome.evicted:
+        out.write(f"[evicted (cold): {', '.join(e.persona_id for e in outcome.evicted)}]\n")
+    return 0
+
+
+def cmd_cache(args: argparse.Namespace, out) -> int:
+    config = _load(args)
+    cache = _cache(args, config)
+    now = time.time()
+    statuses = cache.status(now)
+    pol = config.cache
+    if args.json:
+        out.write(
+            json.dumps(
+                {
+                    "policy": {
+                        "idle_ttl_seconds": pol.idle_ttl_seconds,
+                        "ceiling_ttl_seconds": pol.ceiling_ttl_seconds,
+                    },
+                    "path": cache.path,
+                    "entries": [
+                        {
+                            "persona_id": s.entry.persona_id,
+                            "use_count": s.entry.use_count,
+                            "live": s.live,
+                            "expiry_reason": s.expiry_reason,
+                            "remaining_idle_seconds": round(s.remaining_idle, 3),
+                            "remaining_ceiling_seconds": round(s.remaining_ceiling, 3),
+                            # Whether this entry carries a materialized overlay (the cached
+                            # payload a warm reuse serves) vs. a metadata-only row.
+                            "materialized": bool(s.entry.overlay),
+                            "overlay_bytes": len(s.entry.overlay),
+                        }
+                        for s in statuses
+                    ],
+                },
+                indent=2,
+            )
+            + "\n"
+        )
+        return 0
+    out.write(
+        f"warm cache: {cache.path}\n"
+        f"policy: idle {_fmt_secs(pol.idle_ttl_seconds)} (sliding), "
+        f"ceiling {_fmt_secs(pol.ceiling_ttl_seconds)}\n\n"
+    )
+    live = [s for s in statuses if s.live]
+    if not live:
+        out.write("(no warm personas)\n")
+        return 0
+    for s in live:
+        out.write(
+            f"  {s.entry.persona_id}  used x{s.entry.use_count}  "
+            f"idle-left {_fmt_secs(s.remaining_idle)}  "
+            f"ceiling-left {_fmt_secs(s.remaining_ceiling)}\n"
+        )
+    return 0
+
+
+def cmd_evict(args: argparse.Namespace, out) -> int:
+    """Dematerialize one persona from the warm cache now, regardless of its TTL.
+
+    Targeted counterpart to ``sweep`` (evict expired) and ``sweep --all`` (clear
+    everything): drops a single ``persona_id`` so an operator can force a re-materialize
+    of one persona — e.g. after editing its definition — without disturbing the rest of
+    the warm cache. Idempotent: evicting a persona that is not warm is a no-op, not an
+    error, so it always exits 0 (mirroring ``sweep`` with nothing to evict).
+    """
+    config = _load(args)
+    cache = _cache(args, config)
+    removed = cache.evict(args.id)
+    if args.json:
+        out.write(json.dumps({"persona_id": args.id, "evicted": removed}, indent=2) + "\n")
+        return 0
+    if removed:
+        out.write(f"dematerialized {args.id} (evicted from the warm cache)\n")
+    else:
+        out.write(f"{args.id} is not warm (nothing to evict)\n")
+    return 0
+
+
+def cmd_sweep(args: argparse.Namespace, out) -> int:
+    config = _load(args)
+    cache = _cache(args, config)
+    if args.all:
+        n = cache.clear()
+        out.write(f"cleared warm cache ({n} entr{'y' if n == 1 else 'ies'})\n")
+        return 0
+    evicted = cache.sweep(now=time.time())
+    if args.json:
+        out.write(json.dumps({"evicted": [e.persona_id for e in evicted]}, indent=2) + "\n")
+        return 0
+    if not evicted:
+        out.write("nothing to evict (no expired personas)\n")
+        return 0
+    out.write(f"evicted {len(evicted)}: {', '.join(e.persona_id for e in evicted)}\n")
+    return 0
+
+
+def _match_dict(result: M.MatchResult) -> dict[str, Any]:
+    return {
+        "task": result.task,
+        "best": result.best.id,
+        "score": result.score,
+        "matched": list(result.matched),
+        "is_fallback": result.is_fallback,
+        "ranked": [
+            {"persona_id": s.persona.id, "score": s.score, "matched": list(s.matched)}
+            for s in result.ranked
+        ],
+    }
+
+
+# --------------------------------------------------------------------------- #
+# argparse plumbing                                                             #
+# --------------------------------------------------------------------------- #
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="personas",
+        description="Equip a best-fit principal-engineer persona for a task; keep recent ones warm.",
+    )
+    p.add_argument(
+        "--registry",
+        default=_DEFAULT_REGISTRY,
+        help="path to the persona roster toml (default: the pack's personas.toml)",
+    )
+    p.add_argument(
+        "--cache-file",
+        default=None,
+        help="warm-cache file (default: resolved from PERSONAS_CACHE_*/GC_RIG_ROOT/.beads)",
+    )
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    pl = sub.add_parser("list", help="list the persona roster")
+    pl.add_argument("--json", action="store_true", help="emit JSON")
+    pl.set_defaults(func=cmd_list)
+
+    ps = sub.add_parser("show", help="show one persona's full definition + playbook")
+    ps.add_argument("id", help="persona id (e.g. principal-backend-engineer)")
+    ps.add_argument("--json", action="store_true", help="emit JSON")
+    ps.set_defaults(func=cmd_show)
+
+    pli = sub.add_parser("lint", help="check registry integrity (exit 1 if issues found)")
+    pli.add_argument("--json", action="store_true", help="emit JSON")
+    pli.set_defaults(func=cmd_lint)
+
+    pm = sub.add_parser("match", help="show the equip decision for a task (read-only)")
+    pm.add_argument("task", nargs="*", help="the task description to match")
+    pm.add_argument(
+        "--from-bead", default=None, metavar="ID",
+        help="pull the task text from a bead (preview its equip decision; read-only)",
+    )
+    pm.add_argument("--json", action="store_true", help="emit JSON")
+    pm.set_defaults(func=cmd_match)
+
+    pe = sub.add_parser("equip", help="match + materialize a persona into the warm cache")
+    pe.add_argument("task", nargs="*", help="the task description to match")
+    pe.add_argument("--from-bead", default=None, metavar="ID", help="pull the task text from a bead")
+    pe.add_argument(
+        "--emit-context",
+        action="store_true",
+        help="print a SessionStart hook payload (additionalContext) instead of text",
+    )
+    pe.add_argument("--json", action="store_true", help="emit JSON")
+    pe.set_defaults(func=cmd_equip)
+
+    pc = sub.add_parser("cache", help="show the warm cache (materialized personas + TTL)")
+    pc.add_argument("--json", action="store_true", help="emit JSON")
+    pc.set_defaults(func=cmd_cache)
+
+    pv = sub.add_parser("evict", help="dematerialize one persona from the warm cache")
+    pv.add_argument("id", help="persona id to evict (no-op if not warm)")
+    pv.add_argument("--json", action="store_true", help="emit JSON")
+    pv.set_defaults(func=cmd_evict)
+
+    pw = sub.add_parser("sweep", help="evict expired warm personas")
+    pw.add_argument("--all", action="store_true", help="clear the whole warm cache")
+    pw.add_argument("--json", action="store_true", help="emit JSON")
+    pw.set_defaults(func=cmd_sweep)
+
+    return p
+
+
+def main(argv: Optional[Sequence[str]] = None, out=None) -> int:
+    out = out if out is not None else sys.stdout
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return int(args.func(args, out))
+    except SystemExit as e:  # raised by _load on an invalid registry
+        return int(e.code) if e.code is not None else 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/personas/personas/match.py
+++ b/personas/personas/match.py
@@ -1,0 +1,345 @@
+"""Equip / match engine — pick the best-fit persona for a task by description match.
+
+The README's equip step: "an agent matches the task to the best-fit persona
+(description match, the same way skills auto-fire)." This module is that match rule.
+
+It is deliberately transparent and deterministic — no model call, no network. Every
+decision is explainable: :class:`MatchResult` carries the score and the exact terms
+that fired, so ``personas match`` can show *why* a persona was chosen. Scoring:
+
+- **Curated keywords (primary).** Each persona's ``match_keywords`` are matched against
+  the task as whole-word phrases. A multi-word keyword (e.g. ``"threat model"``) is a
+  stronger signal than a single word, so it scores higher.
+- **Domain vocabulary (secondary).** Salient words from the persona's ``domain`` and
+  ``when_to_equip`` that also appear in the task add a small bonus, so a task that uses
+  a persona's vocabulary without hitting an explicit keyword still matches.
+- **Tie-break.** Equal scores break by ``persona.weight`` then ``id`` — fully
+  deterministic, never order-dependent.
+
+With no signal at all the engine returns the registry's default (generalist) persona,
+flagged ``is_fallback=True``, so the caller always gets a usable answer.
+
+This module owns both halves of the README's *equip* step:
+
+- **select** — :func:`match_persona` returns the equip decision (which persona won, the
+  score, the terms that fired, and the ranked runners-up).
+- **overlay / materialize** — :func:`render_overlay` assembles a chosen persona's full
+  working context (playbook, domain, skills, tools, verification bar) into the markdown
+  that overlays the agent for one task — the README's *materialize* step. :func:`equip`
+  composes select + overlay into one ready, equipped state, so every consumer (the CLI,
+  the equip-on-task-pickup hook, tests) equips one canonical way. The warm cache
+  (:mod:`personas.cache`) is the complementary layer that keeps a materialized persona
+  warm for the next agent to reuse.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+
+from personas.registry import Persona, PersonasConfig
+
+_WORD = re.compile(r"[a-z0-9]+")
+
+# Weights for the scoring channels. Kept here (not magic numbers inline) so the rule
+# is auditable and tunable in one place.
+_W_KEYWORD = 1.0          # single-word curated keyword hit
+_W_KEYWORD_PHRASE = 2.0   # multi-word curated keyword hit (stronger signal)
+_W_DOMAIN_TERM = 0.25     # salient domain/when-to-equip word that also appears in task
+
+# Common words that carry no routing signal — excluded from the secondary channel so
+# "the", "and", "code" etc. don't make every persona match everything.
+_STOPWORDS = frozenset(
+    """
+    a an and are as at be by for from has have in into is it its of on or over so that
+    the their then there these this to up via was were will with your you can change
+    changes code codebase work task make new use using add adds added implement update
+    fix fixing build run review small large file files line lines write writing
+    """.split()
+)
+
+
+def normalize(text: str) -> list[str]:
+    """Lowercase the text and split it into alphanumeric word tokens."""
+    return _WORD.findall(text.lower())
+
+
+def _singular(w: str) -> str:
+    """Naive singularization so plural/singular forms match (``tests`` -> ``test``).
+
+    A heuristic, not a lemmatizer — good enough to keep keyword matching from missing
+    on a trailing ``s``. Conservative length guards avoid mangling short words, and the
+    ``ss`` exclusion keeps ``class``/``loss`` intact.
+    """
+    if len(w) > 4 and w.endswith("ies"):
+        return w[:-3] + "y"
+    if len(w) > 4 and (w[-4:] in ("ches", "shes") or w[-3:] in ("ses", "xes", "zes")):
+        return w[:-2]
+    if len(w) > 3 and w.endswith("s") and not w.endswith("ss"):
+        return w[:-1]
+    return w
+
+
+def _singularize(tokens: list[str]) -> list[str]:
+    return [_singular(t) for t in tokens]
+
+
+def _phrase_in(phrase_tokens: list[str], haystack_padded: str) -> bool:
+    """True if ``phrase_tokens`` occurs as a whole-word run inside the task text.
+
+    ``haystack_padded`` is the task's normalized tokens space-joined and space-padded,
+    so a simple substring check honors word boundaries (``" api "`` never matches
+    ``"rapid"``).
+    """
+    if not phrase_tokens:
+        return False
+    needle = " " + " ".join(phrase_tokens) + " "
+    return needle in haystack_padded
+
+
+@dataclass(frozen=True)
+class Scored:
+    """One persona's score against a task, with the terms that fired."""
+
+    persona: Persona
+    score: float
+    matched: tuple[str, ...]  # the keywords / domain terms that contributed
+
+
+@dataclass(frozen=True)
+class MatchResult:
+    """The equip decision for a task.
+
+    ``best`` is the chosen persona; ``ranked`` is every persona with a positive score,
+    best first; ``is_fallback`` is True when nothing scored and the default was used.
+    """
+
+    best: Persona
+    score: float
+    matched: tuple[str, ...]
+    ranked: tuple[Scored, ...]
+    is_fallback: bool = False
+    task: str = ""
+
+    @property
+    def runners_up(self) -> tuple[Scored, ...]:
+        return tuple(s for s in self.ranked if s.persona.id != self.best.id)
+
+
+def _domain_terms(persona: Persona) -> set[str]:
+    """Salient (non-stopword) singularized vocab from a persona's domain + when_to_equip."""
+    words = normalize(persona.domain) + normalize(persona.when_to_equip)
+    return {_singular(w) for w in words if w not in _STOPWORDS and len(w) > 2}
+
+
+def score_persona(persona: Persona, task_sing: set[str], task_padded_sing: str) -> Scored:
+    """Score a single persona against the (singularized) task.
+
+    ``task_padded_sing`` is the task's singularized tokens, space-joined and padded for
+    whole-word phrase matching; ``task_sing`` is the same tokens as a set for the
+    secondary domain-vocabulary channel.
+    """
+    score = 0.0
+    matched: list[str] = []
+
+    # Primary channel: curated keywords as whole-word phrases (singularized). Dedup by
+    # the singularized phrase so near-duplicate keywords (e.g. "test"/"tests") count once.
+    keyword_hits: set[str] = set()
+    seen_phrases: set[str] = set()
+    for kw in persona.match_keywords:
+        kw_sing = _singularize(normalize(kw))
+        if not kw_sing:
+            continue
+        phrase = " ".join(kw_sing)
+        if phrase in seen_phrases:
+            continue
+        if _phrase_in(kw_sing, task_padded_sing):
+            seen_phrases.add(phrase)
+            score += _W_KEYWORD_PHRASE if len(kw_sing) > 1 else _W_KEYWORD
+            matched.append(kw)
+            keyword_hits.update(kw_sing)
+
+    # Secondary channel: salient domain vocabulary that also appears in the task, not
+    # already credited via a keyword hit. Bounded and low-weight by construction.
+    for term in sorted(_domain_terms(persona)):
+        if term in task_sing and term not in keyword_hits:
+            score += _W_DOMAIN_TERM
+            matched.append(term)
+
+    return Scored(persona=persona, score=round(score, 4), matched=tuple(matched))
+
+
+def match_persona(config: PersonasConfig, task: str) -> MatchResult:
+    """Return the best-fit persona for ``task`` (the equip decision).
+
+    Raises :class:`ValueError` if the roster is empty — there is no persona to equip
+    or to fall back to. The registry loader guarantees a non-empty roster, so this only
+    guards a directly-constructed config; it turns an opaque ``IndexError`` deep in the
+    fallback path into a clear error at the boundary.
+    """
+    if not config.personas:
+        raise ValueError("cannot match a task against an empty persona roster")
+    task_sing_tokens = _singularize(normalize(task))
+    task_sing = set(task_sing_tokens)
+    task_padded_sing = " " + " ".join(task_sing_tokens) + " "
+
+    scored = [score_persona(p, task_sing, task_padded_sing) for p in config.personas]
+    # Deterministic order: score desc, then weight desc, then id asc.
+    scored.sort(key=lambda s: (-s.score, -s.persona.weight, s.persona.id))
+
+    positive = tuple(s for s in scored if s.score > 0)
+
+    if not positive:
+        fallback = config.default_persona
+        return MatchResult(
+            best=fallback,
+            score=0.0,
+            matched=(),
+            ranked=(),
+            is_fallback=True,
+            task=task,
+        )
+
+    top = positive[0]
+    return MatchResult(
+        best=top.persona,
+        score=top.score,
+        matched=top.matched,
+        ranked=positive,
+        is_fallback=False,
+        task=task,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Overlay / materialize — assemble a persona into the context it overlays with  #
+# --------------------------------------------------------------------------- #
+
+
+def render_provenance(result: MatchResult | None) -> str:
+    """One-line note on *why* a persona was equipped for a task (``""`` if none).
+
+    Separated from :func:`render_overlay` because provenance is *task-specific* — it
+    names the terms this task matched — whereas the rest of the overlay is a pure
+    function of the persona. The warm cache (:mod:`personas.cache`) therefore caches the
+    persona overlay (task-independent, reusable across tasks) and a caller composes this
+    cheap per-task note with it at presentation time. :func:`render_overlay` folds it in
+    when handed a result, so a single-shot caller still gets a self-documenting overlay.
+    """
+    if result is None:
+        return ""
+    if result.is_fallback:
+        return "_No strong task match — equipped the default (generalist) persona._"
+    if result.matched:
+        return f"_Matched on: {', '.join(result.matched)} (score {result.score:g})._"
+    return ""
+
+
+def render_overlay(persona: Persona, result: MatchResult | None = None) -> str:
+    """Materialize ``persona`` into the markdown overlay injected onto an agent.
+
+    This is the README's *materialize* step — "assemble the persona's full working
+    context (playbook, domain knowledge, relevant skills) into a ready, equipped
+    state." The returned markdown is what the equip-on-task-pickup hook feeds to a
+    Claude Code ``SessionStart`` hook as ``additionalContext``, overlaying the
+    persona's role onto the agent for the duration of one task.
+
+    Called *without* ``result`` it renders the persona's task-independent working
+    context — exactly the form the warm cache materializes and reuses across tasks (see
+    :func:`personas.cache.WarmCache.equip`). Called *with* ``result`` it also folds in a
+    one-line :func:`render_provenance` note explaining *why* this persona was equipped,
+    so a single-shot overlay is self-documenting. Persona fields that are empty are
+    omitted rather than rendered as bare headings, so a lean persona still produces clean
+    output. The result always ends in exactly one trailing newline.
+    """
+    lines = [f"# Equipped persona: {persona.title}", ""]
+    if result is not None:
+        provenance = render_provenance(result)
+        if provenance:
+            lines.append(provenance)
+        lines.append("")
+    if persona.domain:
+        lines += [f"**Domain.** {persona.domain}", ""]
+    if persona.playbook:
+        lines += ["**Playbook.**", persona.playbook, ""]
+    if persona.skills:
+        lines.append(f"**Skills to lean on:** {', '.join(persona.skills)}")
+    if persona.tools:
+        lines.append(f"**Tools:** {', '.join(persona.tools)}")
+    if persona.verification_bar:
+        lines += [
+            "",
+            f"**Verification bar (do not hand off below this):** {persona.verification_bar}",
+        ]
+    return "\n".join(lines).strip() + "\n"
+
+
+@dataclass(frozen=True)
+class Equip:
+    """A persona equipped for one task: the match decision plus the materialized overlay.
+
+    The README's "ready, equipped state" — *select* (which persona and why) and
+    *overlay* (the working context to inject) composed into one value, so every
+    consumer equips one canonical way instead of re-deriving the overlay. The warm
+    cache (:mod:`personas.cache`) is the complementary layer: it records the equipped
+    persona so the next agent reuses it warm; this object is the pure select-and-render
+    that the cache amortizes.
+    """
+
+    result: MatchResult
+    overlay: str
+
+    @property
+    def persona(self) -> Persona:
+        """The equipped persona (the match's best-fit, or the default fallback)."""
+        return self.result.best
+
+    @property
+    def is_fallback(self) -> bool:
+        """True when no task signal matched and the default persona was equipped."""
+        return self.result.is_fallback
+
+
+def equip(config: PersonasConfig, task: str) -> Equip:
+    """Select the best-fit persona for ``task`` and materialize its overlay.
+
+    The README's *equip* step end to end: composes :func:`match_persona` (select) with
+    :func:`render_overlay` (materialize) into the ready, equipped state. The caller gets
+    the chosen persona, the provenance, and the markdown overlay to inject — in one call.
+    Raises :class:`ValueError` on an empty roster (via :func:`match_persona`).
+    """
+    result = match_persona(config, task)
+    return Equip(result=result, overlay=render_overlay(result.best, result))
+
+
+def persona_fingerprint(persona: Persona) -> str:
+    """A stable digest of the persona-definition fields :func:`render_overlay` reads.
+
+    The warm cache stores this alongside a materialized overlay so it can tell, cheaply,
+    whether the registry definition has drifted since — and re-materialize if so, instead
+    of serving a stale overlay (see :func:`personas.cache.WarmCache.equip`). It is a pure
+    function of the definition: no markdown is assembled and no files are read, so it is
+    cheap enough to compute on every equip without defeating the amortization it guards.
+
+    It covers exactly the fields the (task-independent) overlay renders — ``title`` derives
+    from ``id`` — and deliberately *excludes* ``when_to_equip``, ``match_keywords``, and
+    ``weight``, which steer routing but never appear in the overlay, so editing them does
+    not needlessly invalidate warm entries. **Invariant:** keep this in lockstep with
+    :func:`render_overlay` — a field that starts appearing in the overlay must be added
+    here, or a definition change could be silently served stale until the ceiling.
+    """
+    payload = json.dumps(
+        {
+            "id": persona.id,
+            "domain": persona.domain,
+            "playbook": persona.playbook,
+            "skills": list(persona.skills),
+            "tools": list(persona.tools),
+            "verification_bar": persona.verification_bar,
+        },
+        sort_keys=True,
+        ensure_ascii=False,
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()

--- a/personas/personas/registry.py
+++ b/personas/personas/registry.py
@@ -1,0 +1,417 @@
+"""Persona registry — load + validate the principal-engineer roster (``personas.toml``).
+
+Stdlib-only (TOML via :mod:`tomllib` on Python 3.11+; :mod:`tomli` fallback below).
+The registry is the library of persona *definitions* (README "How it works" §1): each
+persona is a role — its domain, the principal-engineer playbook for that domain, when
+to equip it, the skills/tools it brings, and the verification bar it holds work to.
+
+Nothing in the decision path is hard-coded: the roster, the match keywords, and the
+warm-cache TTL policy all come from ``personas.toml``. A small built-in
+:func:`default_config` keeps the engine working if that file is missing or deleted,
+mirroring how ``model-advisor`` degrades to a built-in roster.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import re
+from dataclasses import dataclass
+from typing import Mapping, Sequence
+
+try:  # Python >= 3.11 has tomllib in the stdlib.
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - only on < 3.11 via the tomli backport
+    import tomli as tomllib  # type: ignore[no-redef]
+
+
+class RegistryError(ValueError):
+    """Raised when ``personas.toml`` is missing required structure or is invalid."""
+
+
+#: A persona ``id`` is a stable, kebab-case handle: the warm cache keys on it, the CLI
+#: shows/looks-up by it, and the equip hook overlays by it. Lowercase alphanumerics in
+#: hyphen-separated groups — no leading/trailing/doubled hyphens, no spaces or uppercase.
+_VALID_ID = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+
+
+# --------------------------------------------------------------------------- #
+# Dataclasses                                                                   #
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class Persona:
+    """One principal-engineer persona — a role an agent equips for one task.
+
+    ``match_keywords`` is the curated signal the equip/match engine scores a task
+    description against (the same "description match" skills auto-fire on). ``weight``
+    is an optional priority used only as a deterministic tie-break between equal scores.
+    """
+
+    id: str
+    domain: str
+    when_to_equip: str
+    verification_bar: str
+    playbook: str
+    match_keywords: tuple[str, ...] = ()
+    skills: tuple[str, ...] = ()
+    tools: tuple[str, ...] = ()
+    weight: float = 1.0
+
+    @property
+    def title(self) -> str:
+        """Human title: ``principal-backend-engineer`` -> ``Principal Backend Engineer``."""
+        return " ".join(w.capitalize() for w in self.id.replace("_", "-").split("-") if w)
+
+
+@dataclass(frozen=True)
+class CachePolicy:
+    """Warm-cache TTL policy (README "Lifecycle TTL (the reasoning)").
+
+    - ``idle_ttl_seconds`` — sliding idle window, refreshed on every reuse. A persona
+      that no agent has equipped within this window is evicted (default 30 min).
+    - ``ceiling_ttl_seconds`` — absolute cap since first materialize. Even a
+      continuously-reused persona is force-refreshed past this so it picks up registry
+      updates and the cache footprint stays bounded (default 2 h).
+
+    Both are configurable via the ``[cache]`` table; the defaults are the starting
+    point, not a law.
+    """
+
+    idle_ttl_seconds: float = 1800.0
+    ceiling_ttl_seconds: float = 7200.0
+
+    def __post_init__(self) -> None:
+        if self.idle_ttl_seconds <= 0:
+            raise RegistryError("[cache] idle TTL must be > 0")
+        if self.ceiling_ttl_seconds <= 0:
+            raise RegistryError("[cache] ceiling TTL must be > 0")
+        if self.ceiling_ttl_seconds < self.idle_ttl_seconds:
+            raise RegistryError(
+                "[cache] ceiling TTL must be >= idle TTL "
+                f"(got ceiling={self.ceiling_ttl_seconds}s < idle={self.idle_ttl_seconds}s)"
+            )
+
+
+@dataclass(frozen=True)
+class PersonasConfig:
+    """The fully-resolved persona configuration (roster + warm-cache policy)."""
+
+    personas: tuple[Persona, ...]
+    cache: CachePolicy
+    #: Persona equipped when a task matches nothing (the generalist fallback). May be
+    #: ``None``, in which case the match engine falls back to the first persona.
+    default_persona_id: str | None = None
+
+    def get(self, persona_id: str) -> Persona:
+        for p in self.personas:
+            if p.id == persona_id:
+                return p
+        raise KeyError(f"persona {persona_id!r} not in registry")
+
+    def has(self, persona_id: str) -> bool:
+        return any(p.id == persona_id for p in self.personas)
+
+    @property
+    def ids(self) -> tuple[str, ...]:
+        return tuple(p.id for p in self.personas)
+
+    @property
+    def default_persona(self) -> Persona:
+        """The fallback persona: the configured default, else the first in the roster."""
+        if self.default_persona_id is not None:
+            return self.get(self.default_persona_id)
+        return self.personas[0]
+
+
+# --------------------------------------------------------------------------- #
+# Built-in default (safety net when personas.toml is absent)                    #
+# --------------------------------------------------------------------------- #
+
+#: A lean three-persona fallback so the engine never has an empty roster. Normal use
+#: loads the shipped ``personas.toml`` (the full 10-persona roster); this only kicks
+#: in if that file is missing or deleted (mirrors ``model-advisor``'s default roster).
+DEFAULT_PERSONAS: tuple[Persona, ...] = (
+    Persona(
+        id="principal-backend-engineer",
+        domain="Server-side services, APIs, data access, and business logic.",
+        when_to_equip="Implementing or changing server-side logic, endpoints, or data access.",
+        verification_bar="Inputs validated, errors handled, the change is covered by a test.",
+        playbook="Think in contracts and failure modes. Validate at the boundary, keep "
+        "the core pure, make state changes idempotent, and prove it with a test.",
+        match_keywords=("backend", "api", "endpoint", "server", "database", "service"),
+        skills=("tdd", "diagnose"),
+        tools=("Read", "Edit", "Bash", "Grep"),
+    ),
+    Persona(
+        id="principal-test-engineer",
+        domain="Test strategy, coverage, and regression safety.",
+        when_to_equip="Writing tests, raising coverage, or reproducing a bug as a test.",
+        verification_bar="Tests fail before the fix and pass after; they assert behavior, not internals.",
+        playbook="Test behavior at the seam, not implementation detail. Make the failing "
+        "case first, keep tests fast and deterministic, and name them for the behavior.",
+        match_keywords=("test", "tests", "coverage", "regression", "tdd", "fixture"),
+        skills=("tdd", "verify"),
+        tools=("Read", "Edit", "Bash"),
+    ),
+    Persona(
+        id="principal-docs-engineer",
+        domain="Technical writing, READMEs, and developer-facing documentation.",
+        when_to_equip="Writing or revising docs, READMEs, or explanatory comments.",
+        verification_bar="A new reader can act on it; examples run; nothing contradicts the code.",
+        playbook="Write for the reader's next action. Lead with the why, show a runnable "
+        "example, and keep claims verifiable against the code.",
+        match_keywords=("docs", "documentation", "readme", "guide", "tutorial", "changelog"),
+        skills=("init",),
+        tools=("Read", "Edit", "Write"),
+    ),
+)
+
+
+def default_config() -> PersonasConfig:
+    """A complete, sensible fallback config used when no ``personas.toml`` is present."""
+    return PersonasConfig(
+        personas=DEFAULT_PERSONAS,
+        cache=CachePolicy(),
+        default_persona_id="principal-backend-engineer",
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Loading / validation                                                          #
+# --------------------------------------------------------------------------- #
+
+
+def load_config(path: str | os.PathLike[str] | None = None) -> PersonasConfig:
+    """Load ``personas.toml`` from ``path`` (or return :func:`default_config`).
+
+    If ``path`` is ``None`` or does not exist, the default config is returned so the
+    engine always has a roster. A *malformed* config (no personas, duplicate ids, an
+    unknown ``default_persona``) raises :class:`RegistryError`.
+    """
+    if path is None:
+        return default_config()
+    p = os.fspath(path)
+    if not os.path.exists(p):
+        return default_config()
+    with open(p, "rb") as fh:
+        raw = tomllib.load(fh)
+    return from_mapping(raw)
+
+
+def default_registry_path() -> str:
+    """Absolute path to the roster shipped with the pack (``<pack>/personas.toml``).
+
+    The one canonical answer to "where is the registry": the equip/match engine, the
+    warm cache, the CLI, and the equip-on-task-pickup hook all resolve the shipped
+    roster through here (or :func:`load_default`) instead of each re-deriving the path.
+    """
+    pack_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    return os.path.join(pack_root, "personas.toml")
+
+
+def load_default() -> PersonasConfig:
+    """Load the roster shipped with the pack — the registry every consumer starts from.
+
+    Equivalent to ``load_config(default_registry_path())``; degrades to
+    :func:`default_config` (the built-in roster) if the shipped file is missing, so a
+    caller always gets a usable registry.
+    """
+    return load_config(default_registry_path())
+
+
+#: Text fields whose absence makes a persona *semantically* incomplete (as opposed to
+#: structurally invalid, which loading rejects outright). Kept as data so the integrity
+#: lint below reads as one obvious rule.
+_REQUIRED_TEXT = ("domain", "when_to_equip", "verification_bar", "playbook")
+
+
+def validate(config: PersonasConfig) -> list[str]:
+    """Return registry *integrity* issues (empty list == healthy).
+
+    Loading already rejects anything structurally invalid — a missing/duplicate/
+    malformed ``id``, an unknown ``default_persona``, a bad ``weight``, a broken cache
+    policy. This is the complementary *semantic-completeness* check the foundation
+    exposes so the CLI (e.g. a ``personas lint``), the equip hook, and tests can assert
+    every persona is actually usable: it has a domain, a playbook, a verification bar,
+    signal to match on, and the skills/tools it brings.
+
+    It returns human-readable strings rather than raising, so a caller can warn and keep
+    going — the engine still runs on an incomplete persona, it just routes and overlays
+    less well.
+    """
+    issues: list[str] = []
+    for p in config.personas:
+        for field in _REQUIRED_TEXT:
+            if not getattr(p, field):
+                issues.append(f"{p.id}: missing {field}")
+        if not p.match_keywords:
+            issues.append(f"{p.id}: no match_keywords (cannot be matched by keyword)")
+        if not p.skills:
+            issues.append(f"{p.id}: brings no skills")
+        if not p.tools:
+            issues.append(f"{p.id}: brings no tools")
+    return issues
+
+
+def from_mapping(raw: Mapping[str, object]) -> PersonasConfig:
+    """Build a :class:`PersonasConfig` from a parsed-TOML mapping.
+
+    Kept separate from :func:`load_config` so tests can drive it from a dict and the
+    CLI can reuse the same validation on an already-parsed document.
+    """
+    personas = _parse_personas(raw.get("persona"))
+    cache = _parse_cache(raw.get("cache"))
+
+    reg = raw.get("registry") or {}
+    if not isinstance(reg, Mapping):
+        raise RegistryError("[registry] must be a table")
+    default_id = reg.get("default_persona")
+    default_id = str(default_id) if default_id is not None else None
+
+    return _finalise(personas=personas, cache=cache, default_persona_id=default_id)
+
+
+def _finalise(
+    *,
+    personas: list[Persona],
+    cache: CachePolicy,
+    default_persona_id: str | None,
+) -> PersonasConfig:
+    if not personas:
+        raise RegistryError("roster is empty: at least one [[persona]] is required")
+    ids = [p.id for p in personas]
+    dupes = sorted({i for i in ids if ids.count(i) > 1})
+    if dupes:
+        raise RegistryError(f"duplicate persona id(s): {dupes}")
+    if default_persona_id is not None and default_persona_id not in ids:
+        raise RegistryError(
+            f"default_persona {default_persona_id!r} is not in the roster {sorted(ids)}"
+        )
+    return PersonasConfig(
+        personas=tuple(personas),
+        cache=cache,
+        default_persona_id=default_persona_id,
+    )
+
+
+# ---- section parsers ------------------------------------------------------- #
+
+
+def _as_list_of_tables(value: object, section: str) -> list[Mapping[str, object]]:
+    if value is None:
+        return []
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        raise RegistryError(f"[[{section}]] must be an array of tables")
+    out: list[Mapping[str, object]] = []
+    for item in value:
+        if not isinstance(item, Mapping):
+            raise RegistryError(f"each [[{section}]] entry must be a table")
+        out.append(item)
+    return out
+
+
+def _str_list(value: object, what: str) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        raise RegistryError(f"{what} must be an array of strings")
+    return tuple(str(v) for v in value)
+
+
+def _clean_terms(values: tuple[str, ...], *, lower: bool) -> tuple[str, ...]:
+    """Trim, drop blanks, and de-duplicate a term list, preserving first-seen order.
+
+    Hands the match engine clean signal: keywords are lowercased (and compared
+    lowercased for dedup) so ``"API"``/``"api"`` collapse to one; skills/tools keep
+    their case (``"Read"``) but still trim and dedup. A term that is empty or all
+    whitespace is dropped rather than smuggled through as a phantom keyword.
+    """
+    out: list[str] = []
+    seen: set[str] = set()
+    for v in values:
+        term = v.strip().lower() if lower else v.strip()
+        if not term or term in seen:
+            continue
+        seen.add(term)
+        out.append(term)
+    return tuple(out)
+
+
+def _parse_weight(pid: str, raw: object) -> float:
+    """Parse a persona ``weight``: a finite number > 0 (it feeds the match tie-break).
+
+    The equip engine orders ties by ``(score, weight, id)``. A NaN weight makes that
+    sort order undefined, and a non-positive weight inverts the intended priority — so
+    both are rejected here, at the boundary, rather than corrupting routing later.
+    """
+    try:
+        weight = float(raw)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        raise RegistryError(f"persona {pid!r} weight must be a number, got {raw!r}")
+    if not math.isfinite(weight) or weight <= 0:
+        raise RegistryError(
+            f"persona {pid!r} weight must be a finite number > 0, got {weight!r}"
+        )
+    return weight
+
+
+def _parse_personas(value: object) -> list[Persona]:
+    rows = _as_list_of_tables(value, "persona")
+    if not rows:
+        return list(DEFAULT_PERSONAS)
+    personas: list[Persona] = []
+    for i, r in enumerate(rows):
+        if "id" not in r:
+            raise RegistryError(f"[[persona]] #{i} missing 'id'")
+        pid = str(r["id"]).strip()
+        if not _VALID_ID.match(pid):
+            raise RegistryError(
+                f"[[persona]] #{i} id {str(r['id'])!r} is not a valid kebab-case id "
+                "(lowercase alphanumerics in hyphen-separated groups, e.g. "
+                "'principal-backend-engineer')"
+            )
+        personas.append(
+            Persona(
+                id=pid,
+                domain=str(r.get("domain", "")),
+                when_to_equip=str(r.get("when_to_equip", "")),
+                verification_bar=str(r.get("verification_bar", "")),
+                playbook=str(r.get("playbook", "")).strip(),
+                match_keywords=_clean_terms(
+                    _str_list(r.get("match_keywords"), f"persona {pid!r} match_keywords"),
+                    lower=True,
+                ),
+                skills=_clean_terms(_str_list(r.get("skills"), f"persona {pid!r} skills"), lower=False),
+                tools=_clean_terms(_str_list(r.get("tools"), f"persona {pid!r} tools"), lower=False),
+                weight=_parse_weight(pid, r.get("weight", 1.0)),
+            )
+        )
+    return personas
+
+
+def _parse_cache(value: object) -> CachePolicy:
+    """Parse ``[cache]``. Accepts minute/hour convenience keys or explicit seconds.
+
+    Precedence per dimension: an explicit ``*_seconds`` key wins over the
+    minute/hour convenience key, which wins over the default.
+    """
+    if value is None:
+        return CachePolicy()
+    if not isinstance(value, Mapping):
+        raise RegistryError("[cache] must be a table")
+
+    idle = CachePolicy().idle_ttl_seconds
+    if "idle_ttl_minutes" in value:
+        idle = float(value["idle_ttl_minutes"]) * 60.0
+    if "idle_ttl_seconds" in value:
+        idle = float(value["idle_ttl_seconds"])
+
+    ceiling = CachePolicy().ceiling_ttl_seconds
+    if "ceiling_ttl_hours" in value:
+        ceiling = float(value["ceiling_ttl_hours"]) * 3600.0
+    if "ceiling_ttl_seconds" in value:
+        ceiling = float(value["ceiling_ttl_seconds"])
+
+    return CachePolicy(idle_ttl_seconds=idle, ceiling_ttl_seconds=ceiling)

--- a/personas/requirements.txt
+++ b/personas/requirements.txt
@@ -1,0 +1,10 @@
+# personas runtime deps — deliberately MINIMAL (mirrors model-advisor / provider-forge).
+#
+# The engine is pure-stdlib: the registry is parsed with the stdlib `tomllib`
+# (Python >= 3.11), the warm cache is plain JSON, and matching is `re` only. No
+# third-party runtime deps.
+#
+# The single guarded fallback below pulls `tomli` *only* on an older interpreter, so the
+# registry loader's `import tomllib` / `import tomli as tomllib` shim has a backend
+# everywhere without adding a dependency on a modern Python.
+tomli>=2.0 ; python_version < "3.11"

--- a/personas/setup.sh
+++ b/personas/setup.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Bootstrap the personas pack's self-contained venv (idempotent).
+#
+# Optional: the engine is pure-stdlib, so bin/personas also runs under any system
+# python3. The venv just pins the tomli fallback for interpreters older than 3.11.
+set -euo pipefail
+PACK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PY="${PYTHON:-python3}"
+"$PY" -m venv "$PACK_DIR/.venv"
+"$PACK_DIR/.venv/bin/pip" install --quiet --upgrade pip
+"$PACK_DIR/.venv/bin/pip" install --quiet -r "$PACK_DIR/requirements.txt"
+echo "personas venv ready: $PACK_DIR/.venv"

--- a/personas/skills/equip-persona/SKILL.md
+++ b/personas/skills/equip-persona/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: equip-persona
+description: Equip a best-fit principal-engineer persona for a task, and inspect the persona registry and warm cache. Run `personas match "<task>"` to see which persona fits a task (and why), `personas equip "<task>"` to equip it and keep it warm for other agents, `personas show <id>` to read a persona's full playbook + verification bar, `personas lint` to check the registry is complete after an edit, and `personas cache` / `personas evict <id>` / `personas sweep` to inspect or age out the warm cache. Use when picking up a task and you want to work at principal-engineer level in that task's domain (backend, frontend, systems, security, data, platform, api-design, test, refactoring, docs), when debugging which persona an agent equipped, or when tuning the registry or warm-cache TTL.
+---
+
+# Equip Persona
+
+## Overview
+
+**blackrim-personas** is a dynamic persona system. A generalist agent is competent at
+everything and excellent at nothing; a persona makes an agent excellent at one thing for
+the duration of one task. The pack is a curated suite of principal-engineer personas —
+each a specialist with a domain, a playbook, the conditions under which to equip it, the
+skills/tools it brings, and a verification bar — that an agent equips dynamically based
+on the task in front of it.
+
+It composes with the rest of the toolchain rather than competing with it: **model-advisor**
+picks the model *tier*, **provider-forge** picks the *provider/model*, and **personas**
+picks the *role*. A dispatch is a tier, a provider/model, and a persona.
+
+`bin/personas` is the read/equip/inspect CLI. `list`, `show`, `lint`, `match`, and `cache`
+are pure reads; `equip`, `evict`, and `sweep` mutate the shared warm cache.
+
+## When to Use
+
+- You are **picking up a task** and want to work at principal-engineer level in its
+  domain. Match it, equip the persona, and hold your work to that persona's bar.
+- You need to **see why a persona was chosen** — `personas match` shows the score and the
+  exact terms that fired.
+- You are **debugging the equip-on-task-pickup hook** (it equips a persona at session
+  start) and want to see the warm cache state.
+- You are **tuning the registry** (adding a persona, adjusting match keywords) or the
+  **warm-cache TTL policy**.
+
+**When NOT to use:**
+
+- For trivial or throwaway work — the role does not matter; skip it.
+- To pick a model tier (that's `advisor advise`) or a provider/model (that's
+  `forge targets`). Personas picks the role only.
+
+## Process
+
+### Step 1 — See the equip decision
+
+```bash
+personas match "implement a paginated REST endpoint backed by Postgres"
+personas match "audit the upload handler for SSRF" --json
+```
+
+`match` scores every persona against the task (whole-word keyword + domain-vocabulary
+match, plural/singular aware) and prints the best fit, its score, the terms that fired,
+and the runners-up. It is read-only — it does not touch the warm cache. With no signal it
+returns the registry's default (generalist) persona, flagged as a fallback.
+
+### Step 2 — Equip the persona
+
+```bash
+personas equip "implement a paginated REST endpoint backed by Postgres"
+personas equip --from-bead pers-0fs        # pull the task text from a work bead
+```
+
+`equip` matches, then **materializes** the persona into the shared warm cache (recording
+a last-used timestamp). Its text output is the persona's playbook + verification bar — the
+context you adopt for the task. If the persona is already warm, equip *reuses* it
+(`was_warm=true`) and refreshes its idle TTL instead of paying the materialize cost again.
+
+In a gas-town session you usually don't run this by hand: the `equip-on-task-pickup` hook
+runs `personas equip --from-bead <current bead> --emit-context` at session start and
+overlays the persona automatically.
+
+### Step 3 — Read a persona's full definition
+
+```bash
+personas show principal-security-engineer
+personas list                              # the whole roster
+```
+
+### Step 4 — Inspect / age out the warm cache
+
+```bash
+personas cache                             # materialized personas + TTL remaining
+personas evict principal-backend-engineer  # dematerialize one persona now (e.g. after editing it)
+personas sweep                             # evict expired personas now
+personas sweep --all                       # clear the whole warm cache
+```
+
+The warm cache ages personas out on a **sliding 30-minute idle TTL** (refreshed on every
+reuse) with a **2-hour absolute ceiling** (force-refresh so the persona picks up registry
+edits). Both are configurable in `personas.toml` `[cache]`. Eviction is lazy — `equip` and
+`cache` sweep expired entries as a side effect — so `sweep` is for housekeeping.
+
+## Worked Example
+
+A polecat claims a bead titled "Fix N+1 query in the orders service".
+
+1. **Match.** `personas match "Fix N+1 query in the orders service"` →
+   `principal-backend-engineer` (matched: `query`, `service`). The choice is explainable.
+2. **Equip.** The session-start hook already ran `personas equip --from-bead <bead>
+   --emit-context`, so the backend persona's playbook ("watch N+1 queries, unbounded
+   result sets, missing indexes…") is overlaid on the agent.
+3. **Hold the bar.** The agent meets the backend verification bar — inputs validated,
+   change covered by a test — before handing off to the refinery.
+4. **Reuse.** Ten minutes later another polecat picks up a sibling backend bead. The
+   backend persona is still warm (`personas cache` shows it), so it is reused, not
+   re-materialized.
+
+## Why This Matters
+
+- **Excellence on demand.** The agent becomes a domain specialist for the one task,
+  then releases the role — no permanent, bloated mega-prompt.
+- **Explainable routing.** Every equip decision shows the score and the matched terms,
+  so a wrong match is debuggable and the keywords are tunable.
+- **Amortized cost.** The warm cache means a busy fleet pays the materialize cost once
+  per clustered work session, not once per task.
+
+## Verification Gate
+
+Before relying on an equipped persona:
+
+- [ ] `personas match "<task>"` chose a persona whose domain actually fits — if it fell
+      back to the default, the task description was too thin or a keyword is missing.
+- [ ] You read the persona's **verification bar** (`personas show <id>`) and will hold
+      your work to it before handing off.
+- [ ] If you tuned the registry, `personas lint` is clean (exit 0), `python3 -m pytest`
+      passes, and `personas list` shows the roster you expect.
+
+<!-- registration -->
+**Registration.** gc discovers pack skills by directory convention: a pack contributes a
+skill by placing `skills/<name>/SKILL.md` under the pack root, with YAML frontmatter
+carrying at minimum `name` and `description`. This file lives at
+`personas/skills/equip-persona/SKILL.md`, so it is picked up automatically — `pack.toml`
+does not enumerate skills. Once the `personas` pack is imported into a city (vendored
+under `packs/personas` and registered via a direct `source = "packs/personas"` import),
+the skill surfaces in `gc skill list` binding-qualified as `personas.equip-persona`, and
+the materializer projects it into the per-agent skills sink at `gc start`. Verify with
+`gc skill list` (and `gc lint .` / `gc doctor`).

--- a/personas/template-fragments/use-personas.template.md
+++ b/personas/template-fragments/use-personas.template.md
@@ -1,0 +1,36 @@
+{{ define "use-personas" }}
+## Equip a Persona Before You Build
+
+A generalist agent is competent at everything and excellent at nothing. Before you
+start meaningful work, equip the principal-engineer persona that fits the task — become
+a principal backend engineer for a backend change, a principal security engineer for an
+audit — do the work at that level, then release it when the task is done.
+
+This composes with the rest of the toolchain: model-advisor picks the model *tier*,
+provider-forge picks the *provider/model*, and personas picks the *role*.
+
+**The rule:** on task pickup, equip the best-fit persona, then hold your work to that
+persona's verification bar.
+
+```bash
+personas match "<task description>"   # see the equip decision (read-only)
+personas equip "<task description>"    # equip it + keep it warm for the next agent
+personas show <persona-id>             # the full playbook + verification bar
+```
+
+`personas` is pure-stdlib and read-only on `list`/`show`/`lint`/`match`/`cache`; `equip`
+materializes the persona into a shared warm cache so the next agent that needs the same
+role reuses it without paying the materialize cost. Equipped personas age out on a
+sliding 30-minute idle TTL (2-hour absolute ceiling), both configurable.
+
+**The loop:**
+1. **Match.** `personas match "<task>"` returns the best-fit persona, the score, and the
+   exact terms that fired — so the choice is explainable, not a black box.
+2. **Equip.** Adopt that persona's playbook and mindset for the task. In a gas-town
+   session the equip-on-task-pickup hook does this for you at session start.
+3. **Hold the bar.** Each persona carries a verification bar — the standard it does not
+   hand off work below. Meet it before you submit.
+
+For trivial or throwaway work, skip it — the role does not matter. When the work is
+consequential and squarely in one discipline, equip first.
+{{ end }}

--- a/personas/tests/test_cache.py
+++ b/personas/tests/test_cache.py
@@ -1,0 +1,349 @@
+"""personas — warm-cache + TTL lifecycle tests.
+
+Owns the lifecycle math (README "Lifecycle TTL"): materialize vs warm reuse, the sliding
+idle TTL, the absolute ceiling, lazy + explicit eviction, and a durable round-trip.
+``now`` is injected throughout so the policy is deterministic. Pure stdlib + pytest.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+
+from personas import cache as C  # noqa: E402
+from personas.registry import CachePolicy  # noqa: E402
+
+# Small, exact TTLs so the arithmetic in assertions is obvious.
+POLICY = CachePolicy(idle_ttl_seconds=100.0, ceiling_ttl_seconds=1000.0)
+
+
+@pytest.fixture
+def warm(tmp_path):
+    return C.WarmCache(tmp_path / "warm-cache.json", POLICY)
+
+
+# ---- materialize vs warm reuse --------------------------------------------- #
+
+
+def test_cold_equip_materializes(warm):
+    out = warm.equip("p", now=0.0)
+    assert out.was_warm is False
+    assert out.entry.use_count == 1
+    assert out.entry.materialized_at == 0.0
+    assert out.entry.last_used_at == 0.0
+
+
+def test_warm_equip_reuses_and_touches(warm):
+    warm.equip("p", now=0.0)
+    out = warm.equip("p", now=50.0)  # within idle TTL
+    assert out.was_warm is True
+    assert out.entry.use_count == 2
+    assert out.entry.materialized_at == 0.0     # unchanged
+    assert out.entry.last_used_at == 50.0       # slid forward
+
+
+def test_get_returns_live_entry_only(warm):
+    warm.equip("p", now=0.0)
+    assert warm.get("p", now=50.0) is not None
+    assert warm.get("p", now=200.0) is None     # idle-expired
+    assert warm.get("absent", now=0.0) is None
+
+
+# ---- sliding idle TTL ------------------------------------------------------ #
+
+
+def test_idle_expiry(warm):
+    warm.equip("p", now=0.0)
+    # 101s of idle (> 100s) -> expired and re-materialized fresh on next equip.
+    out = warm.equip("p", now=101.0)
+    assert out.was_warm is False
+    assert out.entry.materialized_at == 101.0
+    assert out.entry.use_count == 1
+    assert any(e.persona_id == "p" for e in out.evicted)
+
+
+def test_idle_slides_on_reuse(warm):
+    warm.equip("p", now=0.0)
+    warm.equip("p", now=80.0)   # refresh idle clock
+    warm.equip("p", now=160.0)  # 80s since last use -> still live
+    assert warm.get("p", now=160.0) is not None
+
+
+# ---- absolute ceiling ------------------------------------------------------ #
+
+
+def test_ceiling_forces_refresh_even_when_reused(warm):
+    warm.equip("p", now=0.0)
+    # Keep it warm via reuse right up to the ceiling...
+    for t in (90.0, 180.0, 270.0, 360.0, 450.0, 540.0, 630.0, 720.0, 810.0, 900.0, 990.0):
+        out = warm.equip("p", now=t)
+        assert out.was_warm is True
+    # ...but past the 1000s ceiling it is force-refreshed (materialized anew).
+    out = warm.equip("p", now=1001.0)
+    assert out.was_warm is False
+    assert out.entry.materialized_at == 1001.0
+    assert out.entry.use_count == 1
+
+
+def test_expiry_reason_prefers_ceiling(warm):
+    e = C.WarmEntry("p", materialized_at=0.0, last_used_at=0.0, use_count=1)
+    # Past both windows; ceiling is the reported reason.
+    assert e.expiry_reason(POLICY, now=2000.0) == "ceiling"
+    # Past idle only.
+    assert e.expiry_reason(POLICY, now=150.0) == "idle"
+    # Within both.
+    assert e.expiry_reason(POLICY, now=50.0) is None
+
+
+# ---- eviction: lazy, sweep, evict, clear ----------------------------------- #
+
+
+def test_equip_sweeps_other_expired_entries(warm):
+    warm.equip("stale", now=0.0)
+    out = warm.equip("fresh", now=500.0)   # 'stale' is now idle-expired (>100s)
+    assert "stale" in [e.persona_id for e in out.evicted]
+    assert warm.get("stale", now=500.0) is None
+    assert warm.get("fresh", now=500.0) is not None
+
+
+def test_sweep_returns_evicted(warm):
+    warm.equip("a", now=0.0)
+    warm.equip("b", now=50.0)               # both live; no eviction yet
+    evicted = warm.sweep(now=120.0)         # 'a' idle-expired (120>100); 'b' live (70<100)
+    assert [e.persona_id for e in evicted] == ["a"]
+    assert warm.get("b", now=120.0) is not None
+
+
+def test_evict_specific(warm):
+    warm.equip("p", now=0.0)
+    assert warm.evict("p") is True
+    assert warm.evict("p") is False         # already gone
+    assert warm.get("p", now=0.0) is None
+
+
+def test_clear_drops_all(warm):
+    warm.equip("a", now=0.0)
+    warm.equip("b", now=0.0)
+    assert warm.clear() == 2
+    assert warm.entries() == {}
+
+
+# ---- status ---------------------------------------------------------------- #
+
+
+def test_status_reports_live_and_remaining(warm):
+    warm.equip("p", now=0.0)
+    [s] = warm.status(now=40.0)
+    assert s.live is True
+    assert s.expiry_reason is None
+    assert s.remaining_idle == pytest.approx(60.0)      # 100 - 40
+    assert s.remaining_ceiling == pytest.approx(960.0)  # 1000 - 40
+
+
+def test_status_prunes_expired_by_default(warm):
+    warm.equip("p", now=0.0)
+    warm.status(now=200.0)                  # idle-expired -> pruned as a side effect
+    assert warm.entries() == {}
+
+
+def test_status_can_skip_prune(warm):
+    warm.equip("p", now=0.0)
+    statuses = warm.status(now=200.0, prune=False)
+    assert statuses and statuses[0].live is False
+    assert "p" in warm.entries()            # still on disk
+
+
+# ---- persistence ----------------------------------------------------------- #
+
+
+def test_round_trips_through_disk(warm):
+    warm.equip("p", now=0.0)
+    warm.equip("p", now=10.0)
+    reopened = C.WarmCache(warm.path, POLICY)
+    e = reopened.entries()["p"]
+    assert e.use_count == 2
+    assert e.last_used_at == 10.0
+
+
+def test_corrupt_cache_is_treated_as_empty(tmp_path):
+    path = tmp_path / "warm-cache.json"
+    path.write_text("{ not json")
+    wc = C.WarmCache(path, POLICY)
+    assert wc.entries() == {}
+    # And it recovers — a subsequent equip writes a clean file.
+    wc.equip("p", now=0.0)
+    assert "p" in wc.entries()
+
+
+def test_missing_cache_file_is_empty(warm):
+    assert warm.entries() == {}
+    assert warm.sweep(now=0.0) == []
+
+
+# ---- path resolution ------------------------------------------------------- #
+
+
+def test_cache_path_prefers_explicit_file(tmp_path):
+    env = {"PERSONAS_CACHE_FILE": str(tmp_path / "x.json")}
+    assert C.default_cache_path(env=env) == os.path.abspath(str(tmp_path / "x.json"))
+
+
+def test_cache_path_uses_cache_dir(tmp_path):
+    env = {"PERSONAS_CACHE_DIR": str(tmp_path)}
+    assert C.default_cache_path(env=env) == os.path.abspath(str(tmp_path / "warm-cache.json"))
+
+
+def test_cache_path_uses_rig_root(tmp_path):
+    env = {"GC_RIG_ROOT": str(tmp_path)}
+    got = C.default_cache_path(env=env)
+    assert got == os.path.join(str(tmp_path), ".beads", "personas", "warm-cache.json")
+
+
+def test_cache_path_walks_up_for_beads(tmp_path):
+    beads = tmp_path / ".beads"
+    beads.mkdir()
+    start = tmp_path / "a" / "b"
+    start.mkdir(parents=True)
+    got = C.default_cache_path(start_dir=str(start), env={})
+    assert got == os.path.join(str(tmp_path), ".beads", "personas", "warm-cache.json")
+
+
+# ---- materialized payload: the cost the warm cache amortizes ---------------- #
+
+
+class _Materializer:
+    """A counting overlay thunk so a test can assert exactly when materialize ran."""
+
+    def __init__(self, text: str = "OVERLAY") -> None:
+        self.text = text
+        self.calls = 0
+
+    def __call__(self) -> str:
+        self.calls += 1
+        return self.text
+
+
+def test_cold_equip_runs_materialize_and_stores_overlay(warm):
+    mk = _Materializer("MATERIALIZED")
+    out = warm.equip("p", now=0.0, materialize=mk, fingerprint="fp1")
+    assert out.was_warm is False
+    assert mk.calls == 1
+    assert out.overlay == "MATERIALIZED"          # EquipOutcome.overlay convenience
+    assert out.entry.overlay == "MATERIALIZED"
+    assert out.entry.fingerprint == "fp1"
+
+
+def test_warm_reuse_serves_cached_overlay_without_rematerializing(warm):
+    mk = _Materializer("MATERIALIZED")
+    warm.equip("p", now=0.0, materialize=mk, fingerprint="fp1")
+    out = warm.equip("p", now=50.0, materialize=mk, fingerprint="fp1")  # within idle TTL
+    assert out.was_warm is True
+    assert out.overlay == "MATERIALIZED"          # same payload, served warm
+    assert mk.calls == 1                           # materialize was NOT called again
+    assert out.entry.use_count == 2
+
+
+def test_idle_expiry_rematerializes(warm):
+    mk = _Materializer()
+    warm.equip("p", now=0.0, materialize=mk, fingerprint="fp")
+    out = warm.equip("p", now=101.0, materialize=mk, fingerprint="fp")  # idle-expired
+    assert out.was_warm is False
+    assert mk.calls == 2                           # paid the materialize cost again
+
+
+def test_ceiling_refresh_rematerializes(warm):
+    mk = _Materializer()
+    warm.equip("p", now=0.0, materialize=mk, fingerprint="fp")
+    # Kept warm by steady reuse (each within the 100s idle window) right up to the
+    # ceiling — no re-materialize...
+    for t in (90.0, 180.0, 270.0, 360.0, 450.0, 540.0, 630.0, 720.0, 810.0, 900.0, 990.0):
+        warm.equip("p", now=t, materialize=mk, fingerprint="fp")
+    assert mk.calls == 1
+    # ...then past the 1000s ceiling it is force-refreshed.
+    out = warm.equip("p", now=1001.0, materialize=mk, fingerprint="fp")
+    assert out.was_warm is False
+    assert mk.calls == 2
+    assert out.entry.materialized_at == 1001.0
+
+
+# ---- fingerprint: pick up registry edits before the ceiling ----------------- #
+
+
+def test_fingerprint_drift_rematerializes_within_ttl(warm):
+    v1, v2 = _Materializer("OVERLAY-v1"), _Materializer("OVERLAY-v2")
+    warm.equip("p", now=0.0, materialize=v1, fingerprint="fp-v1")
+    # Same persona, still well within the idle TTL, but its definition changed:
+    out = warm.equip("p", now=10.0, materialize=v2, fingerprint="fp-v2")
+    assert out.was_warm is False                   # re-materialized despite being time-live
+    assert out.overlay == "OVERLAY-v2"
+    assert out.entry.fingerprint == "fp-v2"
+    assert out.entry.materialized_at == 10.0       # ceiling clock reset on refresh
+    assert v1.calls == 1 and v2.calls == 1
+
+
+def test_matching_fingerprint_reuses_within_ttl(warm):
+    mk = _Materializer()
+    warm.equip("p", now=0.0, materialize=mk, fingerprint="fp")
+    out = warm.equip("p", now=10.0, materialize=mk, fingerprint="fp")
+    assert out.was_warm is True
+    assert mk.calls == 1
+
+
+def test_no_fingerprint_skips_the_drift_check(warm):
+    # Omitting the fingerprint disables drift detection: a live entry is reused on TTL
+    # alone (the pre-payload behavior), even though the materializer text differs.
+    a, b = _Materializer("A"), _Materializer("B")
+    warm.equip("p", now=0.0, materialize=a)        # no fingerprint
+    out = warm.equip("p", now=10.0, materialize=b)  # no fingerprint
+    assert out.was_warm is True
+    assert out.overlay == "A"                       # still serving the first payload
+    assert b.calls == 0
+
+
+# ---- payload persistence + the v0 -> v1 upgrade path ------------------------ #
+
+
+def test_overlay_round_trips_through_disk_and_serves_warm(warm):
+    mk = _Materializer("PERSISTED")
+    warm.equip("p", now=0.0, materialize=mk, fingerprint="fp")
+    # A fresh cache object over the same file == another agent/process on the shared cache.
+    reopened = C.WarmCache(warm.path, POLICY)
+    e = reopened.entries()["p"]
+    assert e.overlay == "PERSISTED"
+    assert e.fingerprint == "fp"
+    out = reopened.equip("p", now=20.0, materialize=mk, fingerprint="fp")
+    assert out.was_warm is True                     # reused across the process boundary
+    assert out.overlay == "PERSISTED"
+    assert mk.calls == 1                            # the other process did not re-materialize
+
+
+def test_get_returns_entry_with_overlay(warm):
+    warm.equip("p", now=0.0, materialize=_Materializer("OV"), fingerprint="fp")
+    e = warm.get("p", now=10.0)
+    assert e is not None
+    assert e.overlay == "OV"
+    assert e.fingerprint == "fp"
+
+
+def test_metadata_only_entry_rematerializes_when_payload_needed(warm):
+    # A pre-payload (v0) entry, or any equip that stored no overlay, has nothing to serve
+    # warm: a later equip that DOES supply a materializer must re-materialize.
+    warm.equip("p", now=0.0)                        # metadata-only: overlay == ""
+    assert warm.entries()["p"].overlay == ""
+    mk = _Materializer("FRESH")
+    out = warm.equip("p", now=10.0, materialize=mk)
+    assert out.was_warm is False                    # had no payload to reuse
+    assert out.overlay == "FRESH"
+    assert mk.calls == 1
+
+
+def test_equip_without_materializer_stays_metadata_only(warm):
+    out = warm.equip("p", now=0.0)
+    assert out.overlay == ""
+    assert out.entry.fingerprint == ""

--- a/personas/tests/test_cli.py
+++ b/personas/tests/test_cli.py
@@ -1,0 +1,368 @@
+"""personas — CLI surface tests (list / show / lint / match / equip / cache / evict / sweep).
+
+Owns the CLI contract and its exit codes: reads render text + JSON; lint integrity-checks
+the registry (exit 1 on completeness gaps, 2 on a structural load error); match/equip take
+the task as words or --from-bead (the subprocess is monkeypatched so nothing shells out)
+with match staying read-only; equip materializes into the warm cache and can emit a
+SessionStart hook payload; evict dematerializes one persona. The warm cache is pointed at a
+tmp file via --cache-file. Pure stdlib + pytest.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import sys
+
+import pytest
+
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+
+from personas import cli  # noqa: E402
+
+
+@pytest.fixture
+def cache_file(tmp_path):
+    return str(tmp_path / "warm-cache.json")
+
+
+def run(argv, cache_file=None):
+    if cache_file is not None:
+        argv = ["--cache-file", cache_file] + argv
+    out = io.StringIO()
+    rc = cli.main(argv, out=out)
+    return rc, out.getvalue()
+
+
+# ---- list ------------------------------------------------------------------ #
+
+
+def test_list_text():
+    rc, s = run(["list"])
+    assert rc == 0
+    assert "principal-backend-engineer" in s
+    assert "principal-docs-engineer" in s
+
+
+def test_list_json_has_full_roster():
+    rc, s = run(["list", "--json"])
+    assert rc == 0
+    data = json.loads(s)
+    assert len(data) == 10
+    assert {p["id"] for p in data} >= {"principal-security-engineer", "principal-test-engineer"}
+    # JSON carries the full definition, including the playbook.
+    assert all(p["playbook"] for p in data)
+
+
+# ---- show ------------------------------------------------------------------ #
+
+
+def test_show_text_includes_playbook_and_bar():
+    rc, s = run(["show", "principal-security-engineer"])
+    assert rc == 0
+    assert "Principal Security Engineer" in s
+    assert "Verification bar" in s
+    assert "When to equip" in s
+
+
+def test_show_json():
+    rc, s = run(["show", "principal-backend-engineer", "--json"])
+    assert rc == 0
+    assert json.loads(s)["id"] == "principal-backend-engineer"
+
+
+def test_show_unknown_persona_exits_2():
+    rc, s = run(["show", "principal-nope"])
+    assert rc == 2
+
+
+# ---- lint ------------------------------------------------------------------ #
+
+
+def test_lint_shipped_roster_is_clean():
+    rc, s = run(["lint"])
+    assert rc == 0
+    assert "no integrity issues" in s
+
+
+def test_lint_json_reports_ok():
+    rc, s = run(["lint", "--json"])
+    assert rc == 0
+    data = json.loads(s)
+    assert data["ok"] is True
+    assert data["persona_count"] == 10
+    assert data["issue_count"] == 0
+    assert data["issues"] == []
+
+
+def test_lint_flags_incomplete_roster_exits_1(tmp_path):
+    bad = tmp_path / "bare.toml"
+    bad.write_text('[[persona]]\nid = "bare"\n')
+    rc, s = run(["--registry", str(bad), "lint"])
+    assert rc == 1  # completeness gaps are exit 1, distinct from a load error (2)
+    assert "bare: missing domain" in s
+
+
+def test_lint_json_flags_issues_exits_1(tmp_path):
+    bad = tmp_path / "bare.toml"
+    bad.write_text('[[persona]]\nid = "bare"\n')
+    rc, s = run(["--registry", str(bad), "lint", "--json"])
+    assert rc == 1
+    data = json.loads(s)
+    assert data["ok"] is False
+    assert data["issue_count"] > 0
+    assert any("bare" in issue for issue in data["issues"])
+
+
+def test_lint_structural_error_exits_2(tmp_path):
+    # A duplicate id is rejected at *load* (structural), so lint surfaces it as a usage
+    # error (exit 2) — not as a completeness finding (exit 1).
+    bad = tmp_path / "dup.toml"
+    bad.write_text('[[persona]]\nid = "dup"\n[[persona]]\nid = "dup"\n')
+    rc, s = run(["--registry", str(bad), "lint"])
+    assert rc == 2
+
+
+# ---- match ----------------------------------------------------------------- #
+
+
+def test_match_text_picks_persona():
+    rc, s = run(["match", "audit", "for", "sql", "injection"])
+    assert rc == 0
+    assert "principal-security-engineer" in s
+
+
+def test_match_json_structure():
+    rc, s = run(["match", "build", "an", "accessible", "react", "component", "--json"])
+    assert rc == 0
+    data = json.loads(s)
+    assert data["best"] == "principal-frontend-engineer"
+    assert data["is_fallback"] is False
+    assert data["matched"]
+
+
+def test_match_fallback_text():
+    rc, s = run(["match", "do", "the", "thing"])
+    assert rc == 0
+    assert "no strong match" in s
+
+
+def test_match_does_not_touch_cache(cache_file):
+    run(["match", "audit for sql injection"], cache_file=cache_file)
+    # match is read-only: no cache file should have been written.
+    rc, s = run(["cache", "--json"], cache_file=cache_file)
+    assert json.loads(s)["entries"] == []
+
+
+def test_match_from_bead(monkeypatch, cache_file):
+    monkeypatch.setattr(
+        cli, "_task_from_bead", lambda bid: "build an accessible react component"
+    )
+    rc, s = run(["match", "--from-bead", "pers-1", "--json"], cache_file=cache_file)
+    assert rc == 0
+    assert json.loads(s)["best"] == "principal-frontend-engineer"
+
+
+def test_match_from_bead_is_read_only(monkeypatch, cache_file):
+    monkeypatch.setattr(cli, "_task_from_bead", lambda bid: "audit for sql injection")
+    run(["match", "--from-bead", "pers-1"], cache_file=cache_file)
+    # match never materializes — previewing a bead's decision leaves the cache empty.
+    rc, s = run(["cache", "--json"], cache_file=cache_file)
+    assert json.loads(s)["entries"] == []
+
+
+def test_match_from_bead_failure_exits_2(monkeypatch, cache_file):
+    def boom(bid):
+        raise ValueError("no such bead")
+
+    monkeypatch.setattr(cli, "_task_from_bead", boom)
+    rc, s = run(["match", "--from-bead", "nope"], cache_file=cache_file)
+    assert rc == 2
+
+
+def test_match_empty_task_exits_2():
+    rc, s = run(["match"])
+    assert rc == 2
+
+
+# ---- equip ----------------------------------------------------------------- #
+
+
+def test_equip_materializes_into_cache(cache_file):
+    rc, s = run(["equip", "refactor and simplify this module", "--json"], cache_file=cache_file)
+    assert rc == 0
+    data = json.loads(s)
+    assert data["best"] == "principal-refactoring-engineer"
+    assert data["equipped"]["was_warm"] is False
+    assert data["equipped"]["use_count"] == 1
+
+
+def test_equip_twice_reuses_warm(cache_file):
+    run(["equip", "simplify duplication", "--json"], cache_file=cache_file)
+    rc, s = run(["equip", "simplify duplication", "--json"], cache_file=cache_file)
+    data = json.loads(s)
+    assert data["equipped"]["was_warm"] is True
+    assert data["equipped"]["use_count"] == 2
+
+
+def test_equip_text_shows_state(cache_file):
+    rc, s = run(["equip", "implement a backend endpoint"], cache_file=cache_file)
+    assert rc == 0
+    assert "Equipped persona" in s
+    assert "materialized" in s
+
+
+def test_equip_emit_context_is_sessionstart_payload(cache_file):
+    rc, s = run(
+        ["equip", "design a backward-compatible openapi contract", "--emit-context"],
+        cache_file=cache_file,
+    )
+    assert rc == 0
+    payload = json.loads(s)
+    hso = payload["hookSpecificOutput"]
+    assert hso["hookEventName"] == "SessionStart"
+    assert "Principal Api Designer" in hso["additionalContext"]
+    assert "Verification bar" in hso["additionalContext"]
+
+
+def test_equip_warm_reuse_serves_identical_cached_context(cache_file):
+    # First equip materializes; the second reuses warm. The emitted SessionStart context
+    # must be byte-identical — a warm reuse serves the cached overlay, it does not re-render.
+    _, first = run(
+        ["equip", "implement a backend endpoint", "--emit-context"], cache_file=cache_file
+    )
+    _, second = run(
+        ["equip", "implement a backend endpoint", "--emit-context"], cache_file=cache_file
+    )
+    assert first == second
+    # ...and the cache reports the reuse.
+    _, j = run(["equip", "implement a backend endpoint", "--json"], cache_file=cache_file)
+    assert json.loads(j)["equipped"]["was_warm"] is True
+
+
+def test_equip_emit_context_includes_provenance(cache_file):
+    rc, s = run(
+        ["equip", "audit for sql injection", "--emit-context"], cache_file=cache_file
+    )
+    assert rc == 0
+    ctx = json.loads(s)["hookSpecificOutput"]["additionalContext"]
+    assert "Matched on:" in ctx  # the per-task provenance note
+    assert "# Equipped persona: Principal Security Engineer" in ctx  # the cached overlay
+
+
+def test_equip_empty_task_exits_2(cache_file):
+    rc, s = run(["equip"], cache_file=cache_file)
+    assert rc == 2
+
+
+def test_equip_from_bead(monkeypatch, cache_file):
+    monkeypatch.setattr(
+        cli, "_task_from_bead", lambda bid: "fix a race condition in the concurrent worker"
+    )
+    rc, s = run(["equip", "--from-bead", "pers-1", "--json"], cache_file=cache_file)
+    assert rc == 0
+    assert json.loads(s)["best"] == "principal-systems-engineer"
+
+
+def test_equip_from_bead_failure_exits_2(monkeypatch, cache_file):
+    def boom(bid):
+        raise ValueError("no such bead")
+
+    monkeypatch.setattr(cli, "_task_from_bead", boom)
+    rc, s = run(["equip", "--from-bead", "nope"], cache_file=cache_file)
+    assert rc == 2
+
+
+# ---- cache + evict + sweep ------------------------------------------------- #
+
+
+def test_cache_lists_warm_personas(cache_file):
+    run(["equip", "implement a backend endpoint"], cache_file=cache_file)
+    rc, s = run(["cache"], cache_file=cache_file)
+    assert rc == 0
+    assert "principal-backend-engineer" in s
+    assert "idle 30m" in s  # policy line
+
+
+def test_cache_json_reports_policy(cache_file):
+    rc, s = run(["cache", "--json"], cache_file=cache_file)
+    assert rc == 0
+    data = json.loads(s)
+    assert data["policy"]["idle_ttl_seconds"] == 1800.0
+    assert data["policy"]["ceiling_ttl_seconds"] == 7200.0
+
+
+def test_cache_json_reports_materialized_payload(cache_file):
+    run(["equip", "implement a backend endpoint"], cache_file=cache_file)
+    rc, s = run(["cache", "--json"], cache_file=cache_file)
+    assert rc == 0
+    entry = json.loads(s)["entries"][0]
+    assert entry["persona_id"] == "principal-backend-engineer"
+    assert entry["materialized"] is True
+    assert entry["overlay_bytes"] > 0
+
+
+def test_evict_removes_a_warm_persona(cache_file):
+    run(["equip", "implement a backend endpoint"], cache_file=cache_file)
+    rc, s = run(["evict", "principal-backend-engineer"], cache_file=cache_file)
+    assert rc == 0
+    assert "dematerialized principal-backend-engineer" in s
+    # ...and it is gone from the cache afterward.
+    rc, s = run(["cache", "--json"], cache_file=cache_file)
+    assert json.loads(s)["entries"] == []
+
+
+def test_evict_not_warm_is_noop_exit_0(cache_file):
+    rc, s = run(["evict", "principal-backend-engineer"], cache_file=cache_file)
+    assert rc == 0  # idempotent: evicting a cold persona is not an error
+    assert "not warm" in s
+
+
+def test_evict_json_is_idempotent(cache_file):
+    run(["equip", "implement a backend endpoint"], cache_file=cache_file)
+    rc, s = run(["evict", "principal-backend-engineer", "--json"], cache_file=cache_file)
+    assert rc == 0
+    assert json.loads(s) == {"persona_id": "principal-backend-engineer", "evicted": True}
+    # A second evict reports evicted=False — the row is already gone.
+    rc, s = run(["evict", "principal-backend-engineer", "--json"], cache_file=cache_file)
+    assert json.loads(s)["evicted"] is False
+
+
+def test_evict_leaves_other_warm_personas(cache_file):
+    # Targeted eviction drops only the named persona, unlike sweep --all.
+    run(["equip", "implement a backend endpoint"], cache_file=cache_file)
+    run(["equip", "write some tests"], cache_file=cache_file)
+    run(["evict", "principal-backend-engineer"], cache_file=cache_file)
+    rc, s = run(["cache", "--json"], cache_file=cache_file)
+    ids = [e["persona_id"] for e in json.loads(s)["entries"]]
+    assert ids == ["principal-test-engineer"]
+
+
+def test_sweep_all_clears(cache_file):
+    run(["equip", "implement a backend endpoint"], cache_file=cache_file)
+    run(["equip", "write some tests"], cache_file=cache_file)
+    rc, s = run(["sweep", "--all"], cache_file=cache_file)
+    assert rc == 0
+    assert "cleared" in s
+    rc, s = run(["cache", "--json"], cache_file=cache_file)
+    assert json.loads(s)["entries"] == []
+
+
+def test_sweep_nothing_to_evict(cache_file):
+    run(["equip", "implement a backend endpoint"], cache_file=cache_file)
+    rc, s = run(["sweep"], cache_file=cache_file)
+    assert rc == 0
+    assert "nothing to evict" in s
+
+
+# ---- invalid registry ------------------------------------------------------ #
+
+
+def test_invalid_registry_exits_2(tmp_path):
+    bad = tmp_path / "bad.toml"
+    bad.write_text('[[persona]]\nid = "dup"\n[[persona]]\nid = "dup"\n')
+    rc, s = run(["--registry", str(bad), "list"])
+    assert rc == 2

--- a/personas/tests/test_hook.py
+++ b/personas/tests/test_hook.py
@@ -1,0 +1,299 @@
+"""personas — equip-on-task-pickup integration tests (the gas-town seam).
+
+Owns the integration contract for pers-o27 (epic pers-0c9): a polecat equips a
+best-fit principal-engineer persona as it picks up its work. Two surfaces:
+
+  * ``overlay/per-provider/claude/.claude/settings.json`` — the SessionStart hook
+    ``gc reload`` deep-merges into projected agent settings. It is
+    convention-discovered (mirrors model-advisor's Stop/SubagentStop overlay), so
+    nothing registers it but its own existence; these tests validate it as data:
+    a well-formed SessionStart *command* hook whose command walks
+    ``$CLAUDE_PROJECT_DIR`` up to ``packs/personas/hooks/equip-on-task-pickup.sh``
+    (the exact marker ``install.sh`` greps projected settings for) and always
+    exits clean. One test runs the command against a stub hook in a fake city tree
+    to prove the walk-up + stdout pass-through end to end.
+
+  * ``hooks/equip-on-task-pickup.sh`` — run as a real subprocess against a *fake*
+    ``bd`` (so nothing touches the live ledger) and a tmp warm cache. Asserts the
+    always-exit-0, strictly-best-effort contract: the escape hatch, silence when
+    there is no work, a well-formed SessionStart payload for a resolvable bead, and
+    graceful no-op when bead resolution fails or ``bd`` is absent.
+
+Hermetic: no live ``bd`` / ``.beads`` / warm cache is touched — every external
+dependency is a fake on PATH or a tmp file.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+PACK_DIR = Path(__file__).resolve().parents[1]
+HOOK_PATH = PACK_DIR / "hooks" / "equip-on-task-pickup.sh"
+OVERLAY_PATH = (
+    PACK_DIR / "overlay" / "per-provider" / "claude" / ".claude" / "settings.json"
+)
+
+#: The exact substring install.sh's HOOK_MARKER greps projected settings for.
+HOOK_MARKER = "personas/hooks/equip-on-task-pickup.sh"
+
+#: A PATH carrying the real coreutils / jq / python3 the hook + engine need.
+STD_PATH = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+
+#: Resolve bash once so the executable lookup never depends on the (deliberately
+#: minimal) PATH we hand the hook under test.
+BASH = shutil.which("bash") or "bash"
+
+
+# --------------------------------------------------------------------------- #
+# helpers                                                                       #
+# --------------------------------------------------------------------------- #
+
+
+def _overlay_command() -> str:
+    doc = json.loads(OVERLAY_PATH.read_text())
+    return doc["hooks"]["SessionStart"][0]["hooks"][0]["command"]
+
+
+def _write_fake_bd(bin_dir: Path) -> None:
+    """Drop an executable fake ``bd`` that answers ``list`` / ``show`` from env.
+
+    ``bd list ... --json``  -> ``$FAKE_BD_LIST`` (the in-progress lookup the hook does).
+    ``bd show <id> --json`` -> ``$FAKE_BD_SHOW`` (what bin/personas builds the task from);
+    an unset ``$FAKE_BD_SHOW`` makes ``bd show`` exit 1, simulating a resolution failure.
+
+    Outputs travel as env values, never embedded in the script, so no shell quoting
+    of JSON is involved.
+    """
+    bd = bin_dir / "bd"
+    bd.write_text(
+        "#!/usr/bin/env bash\n"
+        'case "$1" in\n'
+        '  list) printf "%s" "${FAKE_BD_LIST:-[]}" ;;\n'
+        '  show) [ -n "${FAKE_BD_SHOW:-}" ] && printf "%s" "$FAKE_BD_SHOW" || exit 1 ;;\n'
+        '  *) printf "%s" "[]" ;;\n'
+        "esac\n"
+    )
+    bd.chmod(0o755)
+
+
+def _run_hook(payload: str, env_extra: dict, path: str) -> subprocess.CompletedProcess:
+    """Run the real hook script as Claude Code would, with a controlled environment."""
+    env = dict(os.environ)
+    # Drop any inherited polecat identity / cache so each test controls resolution.
+    for k in ("GC_SESSION_NAME", "GC_SESSION_ID", "GC_ALIAS", "PERSONAS_CACHE_FILE",
+              "PERSONAS_CACHE_DIR", "PERSONAS_DISABLE_EQUIP"):
+        env.pop(k, None)
+    env.update(env_extra)
+    env["PATH"] = path
+    return subprocess.run(
+        [BASH, str(HOOK_PATH)],
+        input=payload,
+        text=True,
+        capture_output=True,
+        env=env,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# the overlay: well-formed, correctly targeted, deep-merge-friendly             #
+# --------------------------------------------------------------------------- #
+
+
+def test_overlay_is_wellformed_sessionstart_command_hook():
+    doc = json.loads(OVERLAY_PATH.read_text())  # must be valid JSON for gc reload
+    sessionstart = doc["hooks"]["SessionStart"]
+    assert isinstance(sessionstart, list) and sessionstart
+    inner = sessionstart[0]["hooks"]
+    assert isinstance(inner, list) and inner
+    entry = inner[0]
+    assert entry["type"] == "command"
+    assert isinstance(entry["command"], str) and entry["command"].strip()
+
+
+def test_overlay_only_registers_sessionstart():
+    # Equip is a SessionStart concern; keeping the overlay to that single event is
+    # what lets it deep-merge cleanly alongside e.g. model-advisor's Stop hooks.
+    doc = json.loads(OVERLAY_PATH.read_text())
+    assert list(doc["hooks"].keys()) == ["SessionStart"]
+
+
+def test_overlay_command_targets_pack_hook_and_is_best_effort():
+    cmd = _overlay_command()
+    assert HOOK_MARKER in cmd  # exactly what install.sh verifies got projected
+    assert "packs/personas/hooks/equip-on-task-pickup.sh" in cmd
+    assert "$CLAUDE_PROJECT_DIR" in cmd  # resolves from the agent's project dir
+    # The trailing `; true` guarantees the command never fails a session start even
+    # if the walk-up finds nothing — equip is strictly best-effort.
+    assert cmd.rstrip().endswith("true")
+
+
+def test_overlay_command_walks_up_to_hook_and_passes_stdout_through(tmp_path):
+    """Lay out <root>/packs/personas/hooks/<hook> and a deeply nested project dir;
+    the overlay command must walk up, run the hook, and surface its stdout."""
+    hook = tmp_path / "packs" / "personas" / "hooks" / "equip-on-task-pickup.sh"
+    hook.parent.mkdir(parents=True)
+    hook.write_text(
+        "#!/usr/bin/env bash\n"
+        "cat >/dev/null\n"  # drain stdin, like the real hook
+        'printf "%s\\n" '
+        "'{\"hookSpecificOutput\":{\"hookEventName\":\"SessionStart\","
+        '"additionalContext":"STUB"}}\'\n'
+    )
+    hook.chmod(0o755)
+    deep = tmp_path / "rig" / "wt" / "a" / "b"
+    deep.mkdir(parents=True)
+
+    env = dict(os.environ)
+    env["CLAUDE_PROJECT_DIR"] = str(deep)
+    env["PATH"] = STD_PATH
+    proc = subprocess.run(
+        [BASH, "-c", _overlay_command()],
+        input="{}",
+        text=True,
+        capture_output=True,
+        env=env,
+    )
+    assert proc.returncode == 0
+    payload = json.loads(proc.stdout)
+    assert payload["hookSpecificOutput"]["hookEventName"] == "SessionStart"
+    assert payload["hookSpecificOutput"]["additionalContext"] == "STUB"
+
+
+def test_overlay_command_is_silent_noop_without_project_dir():
+    env = {k: v for k, v in os.environ.items() if k != "CLAUDE_PROJECT_DIR"}
+    env["PATH"] = STD_PATH
+    proc = subprocess.run(
+        [BASH, "-c", _overlay_command()],
+        input="{}",
+        text=True,
+        capture_output=True,
+        env=env,
+    )
+    assert proc.returncode == 0
+    assert proc.stdout == ""
+
+
+# --------------------------------------------------------------------------- #
+# the hook: best-effort, always exit 0, emits a SessionStart payload on a hit   #
+# --------------------------------------------------------------------------- #
+
+
+def test_hook_escape_hatch_writes_nothing():
+    proc = _run_hook("{}", {"PERSONAS_DISABLE_EQUIP": "1"}, STD_PATH)
+    assert proc.returncode == 0
+    assert proc.stdout == ""
+
+
+def test_hook_no_in_progress_bead_is_silent(tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_fake_bd(bin_dir)
+    proc = _run_hook(
+        "{}",
+        {"GC_SESSION_NAME": "agent-x", "FAKE_BD_LIST": "[]"},
+        f"{bin_dir}:{STD_PATH}",
+    )
+    assert proc.returncode == 0
+    assert proc.stdout == ""
+
+
+def test_hook_emits_sessionstart_payload_for_resolved_bead(tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_fake_bd(bin_dir)
+    cache = tmp_path / "warm-cache.json"
+    proc = _run_hook(
+        "{}",
+        {
+            "GC_SESSION_NAME": "agent-x",
+            "FAKE_BD_LIST": '[{"id":"hooktest-1"}]',
+            "FAKE_BD_SHOW": (
+                '[{"id":"hooktest-1",'
+                '"title":"Refactor the database query layer for performance",'
+                '"description":"backend service hot path"}]'
+            ),
+            "PERSONAS_CACHE_FILE": str(cache),
+        },
+        f"{bin_dir}:{STD_PATH}",
+    )
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(proc.stdout)
+    hso = payload["hookSpecificOutput"]
+    assert hso["hookEventName"] == "SessionStart"
+    assert "Equipped persona" in hso["additionalContext"]
+    # Equip materialized into the *tmp* warm cache, never the live one.
+    assert cache.exists()
+
+
+def test_hook_resolves_bead_via_session_id_when_name_unset(tmp_path):
+    """The identity loop falls through name -> id -> alias; with only GC_SESSION_ID
+    set it must still resolve and emit."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_fake_bd(bin_dir)
+    cache = tmp_path / "warm-cache.json"
+    proc = _run_hook(
+        "{}",
+        {
+            "GC_SESSION_ID": "bh-wisp-x",
+            "FAKE_BD_LIST": '[{"id":"hooktest-2"}]',
+            "FAKE_BD_SHOW": (
+                '[{"id":"hooktest-2","title":"Write API reference docs",'
+                '"description":"documentation for the public endpoints"}]'
+            ),
+            "PERSONAS_CACHE_FILE": str(cache),
+        },
+        f"{bin_dir}:{STD_PATH}",
+    )
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(proc.stdout)
+    assert payload["hookSpecificOutput"]["hookEventName"] == "SessionStart"
+
+
+def test_hook_exits_zero_when_bead_show_fails(tmp_path):
+    """A resolvable in-progress bead whose `bd show` fails: equip --from-bead can't
+    build a task, prints nothing, and the hook still exits 0 (never blocks)."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_fake_bd(bin_dir)  # FAKE_BD_SHOW unset -> `bd show` exits 1
+    cache = tmp_path / "warm-cache.json"
+    proc = _run_hook(
+        "{}",
+        {
+            "GC_SESSION_NAME": "agent-x",
+            "FAKE_BD_LIST": '[{"id":"hooktest-1"}]',
+            "PERSONAS_CACHE_FILE": str(cache),
+        },
+        f"{bin_dir}:{STD_PATH}",
+    )
+    assert proc.returncode == 0
+    assert proc.stdout == ""
+
+
+def test_hook_exits_zero_when_bd_unavailable(tmp_path):
+    """No `bd` on PATH at all: the hook's `command -v bd` guard short-circuits to a
+    clean exit 0 with no output."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    # A PATH with just enough coreutils for the hook to run up to the bd guard.
+    for tool in ("cat", "dirname"):
+        src = shutil.which(tool)
+        if src:
+            os.symlink(src, bin_dir / tool)
+    proc = _run_hook("{}", {"GC_SESSION_NAME": "agent-x"}, str(bin_dir))
+    assert proc.returncode == 0
+    assert proc.stdout == ""
+
+
+def test_hook_script_is_executable_and_documents_the_contract():
+    assert HOOK_PATH.exists()
+    assert os.access(HOOK_PATH, os.X_OK), "hook must be executable for the overlay to run it"
+    text = HOOK_PATH.read_text()
+    # The contract the overlay and tests depend on.
+    assert "PERSONAS_DISABLE_EQUIP" in text
+    assert "--emit-context" in text
+    assert "exit 0" in text

--- a/personas/tests/test_match.py
+++ b/personas/tests/test_match.py
@@ -1,0 +1,425 @@
+"""personas — equip/match engine tests.
+
+Owns the equip decision: the right persona wins for a clearly-domain task, the choice
+is explainable (the matched terms are reported), plural/singular forms match, ties break
+deterministically, and a no-signal task falls back to the default. Pure stdlib + pytest.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import os
+import sys
+
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+
+from personas import match as M  # noqa: E402
+from personas import registry as R  # noqa: E402
+
+_SHIPPED = os.path.join(_ROOT, "personas.toml")
+
+
+def cfg() -> R.PersonasConfig:
+    return R.load_config(_SHIPPED)
+
+
+# ---- singularization helper ------------------------------------------------ #
+
+
+def test_singular_handles_common_plurals():
+    assert M._singular("tests") == "test"
+    assert M._singular("apis") == "api"
+    assert M._singular("queries") == "query"
+    assert M._singular("vulnerabilities") == "vulnerability"
+    assert M._singular("batches") == "batch"
+
+
+def test_singular_preserves_double_s_and_short_words():
+    assert M._singular("class") == "class"
+    assert M._singular("loss") == "loss"
+    assert M._singular("is") == "is"
+    assert M._singular("as") == "as"
+
+
+# ---- routing to the right persona ------------------------------------------ #
+
+
+def test_backend_task_routes_to_backend():
+    r = M.match_persona(cfg(), "implement a REST endpoint backed by Postgres with idempotent writes")
+    assert r.best.id == "principal-backend-engineer"
+    assert not r.is_fallback
+
+
+def test_security_task_routes_to_security():
+    r = M.match_persona(cfg(), "audit the upload handler for SSRF and sql injection")
+    assert r.best.id == "principal-security-engineer"
+
+
+def test_frontend_task_routes_to_frontend():
+    r = M.match_persona(cfg(), "build an accessible React modal component with keyboard focus")
+    assert r.best.id == "principal-frontend-engineer"
+
+
+def test_systems_task_routes_to_systems():
+    r = M.match_persona(cfg(), "fix the race condition and deadlock in the concurrent worker pool")
+    assert r.best.id == "principal-systems-engineer"
+
+
+def test_platform_task_routes_to_platform():
+    r = M.match_persona(cfg(), "set up the kubernetes deployment and ci/cd pipeline with a rollback")
+    assert r.best.id == "principal-platform-engineer"
+
+
+def test_data_task_routes_to_data():
+    r = M.match_persona(cfg(), "build an idempotent ETL pipeline that backfills the warehouse")
+    assert r.best.id == "principal-data-engineer"
+
+
+def test_test_task_routes_to_test_engineer():
+    r = M.match_persona(cfg(), "write integration tests and raise coverage for the module")
+    assert r.best.id == "principal-test-engineer"
+
+
+def test_refactor_task_routes_to_refactoring():
+    r = M.match_persona(cfg(), "refactor and simplify this tangled module to cut duplication")
+    assert r.best.id == "principal-refactoring-engineer"
+
+
+def test_docs_task_routes_to_docs():
+    r = M.match_persona(cfg(), "rewrite the README and write a getting-started tutorial")
+    assert r.best.id == "principal-docs-engineer"
+
+
+def test_api_design_task_routes_to_api_designer():
+    r = M.match_persona(cfg(), "design a backward-compatible openapi contract and deprecation path")
+    assert r.best.id == "principal-api-designer"
+
+
+# ---- explainability + structure -------------------------------------------- #
+
+
+def test_result_reports_matched_terms():
+    r = M.match_persona(cfg(), "audit for sql injection")
+    assert r.matched  # non-empty
+    assert any("injection" in m for m in r.matched)
+    assert r.score > 0
+
+
+def test_phrase_keyword_scores_more_than_single_word():
+    # "sql injection" (phrase) should outscore a lone single-word hit.
+    single = M.score_persona(
+        cfg().get("principal-security-engineer"),
+        {"audit"},
+        " audit ",
+    )
+    phrase = M.score_persona(
+        cfg().get("principal-security-engineer"),
+        set("sql injection".split()),
+        " sql injection ",
+    )
+    assert phrase.score > single.score
+
+
+def test_runners_up_excludes_best():
+    r = M.match_persona(cfg(), "audit the auth flow for sql injection vulnerabilities")
+    assert r.best.id not in {s.persona.id for s in r.runners_up}
+
+
+# ---- fallback + determinism ------------------------------------------------ #
+
+
+def test_no_signal_falls_back_to_default():
+    r = M.match_persona(cfg(), "do the thing with the stuff")
+    assert r.is_fallback
+    assert r.best.id == cfg().default_persona_id
+    assert r.score == 0.0
+    assert r.ranked == ()
+
+
+def test_empty_task_is_fallback():
+    r = M.match_persona(cfg(), "")
+    assert r.is_fallback
+
+
+def test_match_is_deterministic():
+    task = "audit the auth flow for sql injection vulnerabilities in the api"
+    first = M.match_persona(cfg(), task)
+    again = M.match_persona(cfg(), task)
+    assert first.best.id == again.best.id
+    assert first.score == again.score
+    assert [s.persona.id for s in first.ranked] == [s.persona.id for s in again.ranked]
+
+
+def test_ranked_is_sorted_by_score_desc():
+    r = M.match_persona(cfg(), "audit the auth flow for sql injection in the api endpoint")
+    scores = [s.score for s in r.ranked]
+    assert scores == sorted(scores, reverse=True)
+
+
+def test_tie_breaks_by_id_when_scores_equal():
+    # Two single-keyword personas; an ambiguous task that hits exactly one keyword each.
+    config = R.from_mapping(
+        {
+            "persona": [
+                {"id": "bbb", "domain": "d", "match_keywords": ["widget"]},
+                {"id": "aaa", "domain": "d", "match_keywords": ["widget"]},
+            ]
+        }
+    )
+    r = M.match_persona(config, "build a widget")
+    assert r.best.id == "aaa"  # equal score + weight -> id ascending
+
+
+# ---- matching boundaries (whole-word, adjacency, case) --------------------- #
+
+
+def _one(pid: str, keywords: list[str], domain: str = "isolated-domain-vocab") -> R.PersonasConfig:
+    """A single-persona config for asserting one matching rule in isolation."""
+    return R.from_mapping({"persona": [{"id": pid, "domain": domain, "match_keywords": keywords}]})
+
+
+def test_keyword_matches_whole_word_only():
+    # "api" must not fire inside "therapist" or "rapidly" — substring matching would.
+    config = _one("api-persona", ["api"])
+    r = M.match_persona(config, "the therapist rapidly reviewed the design")
+    assert r.is_fallback
+
+
+def test_keyword_fires_on_a_standalone_word():
+    config = _one("api-persona", ["api"])
+    r = M.match_persona(config, "design the public api surface")
+    assert r.best.id == "api-persona"
+    assert not r.is_fallback
+
+
+def test_multi_word_keyword_requires_adjacency():
+    # The phrase keyword "load balancer" fires only when the words are adjacent, in order.
+    config = _one("infra", ["load balancer"])
+    assert M.match_persona(config, "configure the load balancer").best.id == "infra"
+    # Words present but neither adjacent nor forming the phrase -> no match.
+    assert M.match_persona(config, "balance the heavy server load").is_fallback
+
+
+def test_keyword_match_is_case_insensitive():
+    # The registry lowercases keywords on load; normalize() lowercases the task.
+    config = _one("p", ["API"])
+    assert config.get("p").match_keywords == ("api",)
+    r = M.match_persona(config, "Design the public API Surface")
+    assert r.best.id == "p"
+
+
+def test_whitespace_only_task_is_fallback():
+    r = M.match_persona(cfg(), "   \t  \n ")
+    assert r.is_fallback
+
+
+# ---- empty-roster boundary ------------------------------------------------- #
+
+
+def test_match_empty_roster_raises_clear_error():
+    empty = R.PersonasConfig(personas=(), cache=R.CachePolicy())
+    try:
+        M.match_persona(empty, "anything")
+    except ValueError as e:
+        assert "empty persona roster" in str(e)
+    else:
+        raise AssertionError("expected ValueError on an empty roster")
+
+
+def test_equip_empty_roster_raises_clear_error():
+    empty = R.PersonasConfig(personas=(), cache=R.CachePolicy())
+    try:
+        M.equip(empty, "anything")
+    except ValueError as e:
+        assert "empty persona roster" in str(e)
+    else:
+        raise AssertionError("expected ValueError on an empty roster")
+
+
+# ---- overlay / materialize ------------------------------------------------- #
+
+
+def _backend(config: R.PersonasConfig) -> R.Persona:
+    return config.get("principal-backend-engineer")
+
+
+def test_render_overlay_includes_persona_essentials():
+    p = _backend(cfg())
+    md = M.render_overlay(p)
+    assert f"# Equipped persona: {p.title}" in md
+    assert p.domain in md
+    assert p.playbook in md
+    assert "**Verification bar" in md and p.verification_bar in md
+    assert "**Skills to lean on:**" in md
+    assert "**Tools:**" in md
+
+
+def test_render_overlay_reports_matched_terms():
+    config = cfg()
+    result = M.match_persona(config, "audit the upload handler for sql injection")
+    md = M.render_overlay(result.best, result)
+    assert "Matched on:" in md
+    assert "score" in md
+    # Every reported term should be named in the provenance line.
+    for term in result.matched:
+        assert term in md
+
+
+def test_render_overlay_marks_fallback():
+    config = cfg()
+    result = M.match_persona(config, "do the thing with the stuff")
+    assert result.is_fallback
+    md = M.render_overlay(result.best, result)
+    assert "No strong task match" in md
+    assert "default" in md
+
+
+def test_render_overlay_without_result_has_no_provenance():
+    md = M.render_overlay(_backend(cfg()))
+    assert "Matched on:" not in md
+    assert "No strong task match" not in md
+
+
+def test_render_overlay_omits_empty_sections_for_lean_persona():
+    lean = R.Persona(
+        id="lean-persona",
+        domain="",
+        when_to_equip="",
+        verification_bar="",
+        playbook="",
+        match_keywords=(),
+        skills=(),
+        tools=(),
+    )
+    md = M.render_overlay(lean)
+    assert md.startswith("# Equipped persona: Lean Persona")
+    # Nothing to say beyond the heading — no empty section labels.
+    assert "**Domain.**" not in md
+    assert "**Playbook.**" not in md
+    assert "**Skills to lean on:**" not in md
+    assert "**Tools:**" not in md
+    assert "**Verification bar" not in md
+
+
+def test_render_overlay_ends_with_single_newline():
+    md = M.render_overlay(_backend(cfg()))
+    assert md.endswith("\n")
+    assert not md.endswith("\n\n")
+
+
+def test_render_overlay_is_deterministic():
+    p = _backend(cfg())
+    assert M.render_overlay(p) == M.render_overlay(p)
+
+
+# ---- equip (select + overlay) ---------------------------------------------- #
+
+
+def test_equip_selects_persona_and_materializes_overlay():
+    e = M.equip(cfg(), "implement a REST endpoint backed by Postgres with idempotent writes")
+    assert e.persona.id == "principal-backend-engineer"
+    assert not e.is_fallback
+    assert e.overlay.strip()  # non-empty overlay
+    assert f"# Equipped persona: {e.persona.title}" in e.overlay
+
+
+def test_equip_overlay_matches_render_overlay():
+    e = M.equip(cfg(), "audit the auth flow for sql injection vulnerabilities")
+    assert e.overlay == M.render_overlay(e.result.best, e.result)
+
+
+def test_equip_result_agrees_with_match_persona():
+    config = cfg()
+    task = "build an accessible React modal component with keyboard focus"
+    e = M.equip(config, task)
+    direct = M.match_persona(config, task)
+    assert e.result.best.id == direct.best.id
+    assert e.result.score == direct.score
+
+
+def test_equip_falls_back_when_no_signal():
+    e = M.equip(cfg(), "do the thing with the stuff")
+    assert e.is_fallback
+    assert e.persona.id == cfg().default_persona_id
+    assert "No strong task match" in e.overlay
+
+
+# ---- provenance (factored out of render_overlay) --------------------------- #
+
+
+def test_render_provenance_none_is_empty():
+    assert M.render_provenance(None) == ""
+
+
+def test_render_provenance_matches_the_overlay_line():
+    result = M.match_persona(cfg(), "audit the upload handler for sql injection")
+    prov = M.render_provenance(result)
+    assert prov.startswith("_Matched on:")
+    # render_overlay folds in exactly this line when given a result.
+    assert prov in M.render_overlay(result.best, result)
+
+
+def test_render_provenance_marks_fallback():
+    result = M.match_persona(cfg(), "do the thing with the stuff")
+    assert result.is_fallback
+    prov = M.render_provenance(result)
+    assert "No strong task match" in prov
+    assert prov in M.render_overlay(result.best, result)
+
+
+# ---- persona_fingerprint (what the warm cache keys staleness on) ------------ #
+
+
+def _lean(**over) -> R.Persona:
+    base = dict(
+        id="p",
+        domain="d",
+        when_to_equip="w",
+        verification_bar="v",
+        playbook="pb",
+        match_keywords=("k",),
+        skills=("s",),
+        tools=("t",),
+        weight=1.0,
+    )
+    base.update(over)
+    return R.Persona(**base)
+
+
+def test_persona_fingerprint_is_stable_and_sha256_hex():
+    p = _backend(cfg())
+    fp = M.persona_fingerprint(p)
+    assert fp == M.persona_fingerprint(p)
+    assert len(fp) == 64
+    assert all(c in "0123456789abcdef" for c in fp)
+
+
+def test_persona_fingerprint_changes_on_every_overlay_field():
+    fp0 = M.persona_fingerprint(_lean())
+    # Each of these is rendered by render_overlay, so a change must be detected.
+    assert M.persona_fingerprint(_lean(id="q")) != fp0          # id drives the title
+    assert M.persona_fingerprint(_lean(domain="d2")) != fp0
+    assert M.persona_fingerprint(_lean(playbook="pb2")) != fp0
+    assert M.persona_fingerprint(_lean(skills=("s", "s2"))) != fp0
+    assert M.persona_fingerprint(_lean(tools=("t2",))) != fp0
+    assert M.persona_fingerprint(_lean(verification_bar="v2")) != fp0
+
+
+def test_persona_fingerprint_ignores_non_overlay_fields():
+    fp0 = M.persona_fingerprint(_lean())
+    # These steer routing but never appear in the overlay — editing them must NOT
+    # invalidate a warm entry (it would re-materialize an identical overlay for nothing).
+    assert M.persona_fingerprint(_lean(when_to_equip="totally different")) == fp0
+    assert M.persona_fingerprint(_lean(match_keywords=("x", "y", "z"))) == fp0
+    assert M.persona_fingerprint(_lean(weight=9.0)) == fp0
+
+
+def test_persona_fingerprint_tracks_render_overlay():
+    # The invariant the warm cache relies on: when the rendered overlay changes, so does
+    # the fingerprint, so a definition edit is never served stale.
+    base = _backend(cfg())
+    edited = dataclasses.replace(base, playbook=base.playbook + " And one more rule.")
+    assert M.render_overlay(edited) != M.render_overlay(base)
+    assert M.persona_fingerprint(edited) != M.persona_fingerprint(base)

--- a/personas/tests/test_registry.py
+++ b/personas/tests/test_registry.py
@@ -1,0 +1,265 @@
+"""personas — registry load + validation tests.
+
+Owns the contract of ``personas.toml``: the shipped roster parses and carries the full
+10-persona suite the README specifies; the cache TTL policy resolves from minute/hour
+convenience keys; and malformed config is rejected loudly. Pure stdlib + pytest.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+
+from personas import registry as R  # noqa: E402
+
+_SHIPPED = os.path.join(_ROOT, "personas.toml")
+
+# The roster the README "initial roster" promises.
+EXPECTED_IDS = {
+    "principal-backend-engineer",
+    "principal-frontend-engineer",
+    "principal-systems-engineer",
+    "principal-security-engineer",
+    "principal-data-engineer",
+    "principal-platform-engineer",
+    "principal-api-designer",
+    "principal-test-engineer",
+    "principal-refactoring-engineer",
+    "principal-docs-engineer",
+}
+
+
+# ---- shipped roster -------------------------------------------------------- #
+
+
+def test_shipped_roster_has_full_suite():
+    config = R.load_config(_SHIPPED)
+    assert set(config.ids) == EXPECTED_IDS
+    assert len(config.personas) == 10
+
+
+def test_every_persona_is_complete():
+    config = R.load_config(_SHIPPED)
+    for p in config.personas:
+        assert p.domain, f"{p.id} missing domain"
+        assert p.when_to_equip, f"{p.id} missing when_to_equip"
+        assert p.verification_bar, f"{p.id} missing verification_bar"
+        assert p.playbook, f"{p.id} missing playbook"
+        assert p.match_keywords, f"{p.id} has no match_keywords"
+        assert p.skills, f"{p.id} brings no skills"
+        assert p.tools, f"{p.id} brings no tools"
+
+
+def test_keywords_are_lowercased_on_load():
+    config = R.load_config(_SHIPPED)
+    for p in config.personas:
+        for kw in p.match_keywords:
+            assert kw == kw.lower()
+
+
+def test_shipped_cache_policy_is_the_documented_default():
+    config = R.load_config(_SHIPPED)
+    assert config.cache.idle_ttl_seconds == 30 * 60
+    assert config.cache.ceiling_ttl_seconds == 2 * 3600
+
+
+def test_default_persona_resolves():
+    config = R.load_config(_SHIPPED)
+    assert config.default_persona_id == "principal-backend-engineer"
+    assert config.default_persona.id == "principal-backend-engineer"
+
+
+def test_title_is_humanized():
+    p = R.load_config(_SHIPPED).get("principal-backend-engineer")
+    assert p.title == "Principal Backend Engineer"
+
+
+# ---- defaults / missing file ----------------------------------------------- #
+
+
+def test_missing_file_falls_back_to_builtin():
+    config = R.load_config("/nonexistent/personas.toml")
+    assert len(config.personas) >= 1
+    assert config.has(config.default_persona_id)
+
+
+def test_none_path_is_builtin_default():
+    config = R.load_config(None)
+    assert config is not None
+    assert len(config.personas) >= 1
+
+
+# ---- cache policy parsing -------------------------------------------------- #
+
+
+def test_cache_seconds_override_convenience_keys():
+    cfg = R.from_mapping(
+        {
+            "persona": [{"id": "p", "domain": "d"}],
+            "cache": {"idle_ttl_minutes": 30, "idle_ttl_seconds": 5, "ceiling_ttl_seconds": 10},
+        }
+    )
+    assert cfg.cache.idle_ttl_seconds == 5
+    assert cfg.cache.ceiling_ttl_seconds == 10
+
+
+def test_cache_ceiling_below_idle_is_rejected():
+    with pytest.raises(R.RegistryError):
+        R.from_mapping(
+            {
+                "persona": [{"id": "p", "domain": "d"}],
+                "cache": {"idle_ttl_seconds": 100, "ceiling_ttl_seconds": 10},
+            }
+        )
+
+
+# ---- malformed config ------------------------------------------------------ #
+
+
+def test_empty_roster_rejected():
+    with pytest.raises(R.RegistryError):
+        R._finalise(personas=[], cache=R.CachePolicy(), default_persona_id=None)
+
+
+def test_duplicate_ids_rejected():
+    with pytest.raises(R.RegistryError):
+        R.from_mapping({"persona": [{"id": "dup"}, {"id": "dup"}]})
+
+
+def test_unknown_default_persona_rejected():
+    with pytest.raises(R.RegistryError):
+        R.from_mapping(
+            {"persona": [{"id": "a"}], "registry": {"default_persona": "nope"}}
+        )
+
+
+def test_persona_missing_id_rejected():
+    with pytest.raises(R.RegistryError):
+        R.from_mapping({"persona": [{"domain": "no id here"}]})
+
+
+def test_match_keywords_must_be_array():
+    with pytest.raises(R.RegistryError):
+        R.from_mapping({"persona": [{"id": "a", "match_keywords": "backend"}]})
+
+
+# ---- id validation --------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("bad", ["", "   ", "Has Space", "UPPER", "trailing-", "-leading", "a--b", "a_b"])
+def test_invalid_id_rejected(bad):
+    with pytest.raises(R.RegistryError):
+        R.from_mapping({"persona": [{"id": bad}]})
+
+
+def test_id_is_stripped_of_surrounding_whitespace():
+    cfg = R.from_mapping({"persona": [{"id": "  principal-x  ", "domain": "d"}]})
+    assert cfg.ids == ("principal-x",)
+
+
+@pytest.mark.parametrize("ok", ["a", "p", "dup", "v2", "principal-backend-engineer"])
+def test_valid_ids_accepted(ok):
+    cfg = R.from_mapping({"persona": [{"id": ok}]})
+    assert cfg.ids == (ok,)
+
+
+# ---- weight validation ----------------------------------------------------- #
+
+
+@pytest.mark.parametrize("bad", [0, -1, float("nan"), float("inf"), float("-inf"), "abc"])
+def test_bad_weight_rejected(bad):
+    with pytest.raises(R.RegistryError):
+        R.from_mapping({"persona": [{"id": "p", "weight": bad}]})
+
+
+def test_weight_defaults_to_one():
+    cfg = R.from_mapping({"persona": [{"id": "p"}]})
+    assert cfg.get("p").weight == 1.0
+
+
+def test_valid_weight_parsed():
+    cfg = R.from_mapping({"persona": [{"id": "p", "weight": 2.5}]})
+    assert cfg.get("p").weight == 2.5
+
+
+# ---- term hygiene (keywords / skills / tools) ------------------------------ #
+
+
+def test_keywords_trimmed_deduped_and_lowercased():
+    cfg = R.from_mapping(
+        {"persona": [{"id": "p", "match_keywords": [" API ", "api", "Api", "", "  ", "rest"]}]}
+    )
+    # "API"/"api"/"Api" collapse to one; blanks dropped; first-seen order kept.
+    assert cfg.get("p").match_keywords == ("api", "rest")
+
+
+def test_skills_and_tools_trimmed_and_deduped_case_sensitively():
+    cfg = R.from_mapping(
+        {"persona": [{"id": "p", "skills": [" tdd ", "tdd", ""], "tools": ["Read", "Read", " Edit "]}]}
+    )
+    assert cfg.get("p").skills == ("tdd",)
+    assert cfg.get("p").tools == ("Read", "Edit")
+
+
+# ---- canonical loader (default_registry_path / load_default) ---------------- #
+
+
+def test_default_registry_path_points_at_shipped_file():
+    path = R.default_registry_path()
+    assert path == _SHIPPED
+    assert os.path.exists(path)
+
+
+def test_load_default_loads_the_shipped_roster():
+    config = R.load_default()
+    assert set(config.ids) == EXPECTED_IDS
+    assert config.default_persona.id == "principal-backend-engineer"
+
+
+# ---- integrity lint (validate) --------------------------------------------- #
+
+
+def test_shipped_registry_passes_validate():
+    assert R.validate(R.load_default()) == []
+
+
+def test_builtin_default_config_passes_validate():
+    # The fallback roster must itself be complete — it ships when personas.toml is gone.
+    assert R.validate(R.default_config()) == []
+
+
+def test_validate_flags_an_incomplete_persona():
+    cfg = R.from_mapping({"persona": [{"id": "bare"}]})
+    issues = R.validate(cfg)
+    joined = "\n".join(issues)
+    for field in ("domain", "when_to_equip", "verification_bar", "playbook"):
+        assert f"bare: missing {field}" in joined
+    assert any("match_keywords" in i for i in issues)
+    assert any("skills" in i for i in issues)
+    assert any("tools" in i for i in issues)
+
+
+def test_validate_clean_persona_has_no_issues():
+    cfg = R.from_mapping(
+        {
+            "persona": [
+                {
+                    "id": "complete-one",
+                    "domain": "d",
+                    "when_to_equip": "w",
+                    "verification_bar": "v",
+                    "playbook": "p",
+                    "match_keywords": ["k"],
+                    "skills": ["tdd"],
+                    "tools": ["Read"],
+                }
+            ]
+        }
+    )
+    assert R.validate(cfg) == []

--- a/personas/uninstall.sh
+++ b/personas/uninstall.sh
@@ -1,0 +1,329 @@
+#!/usr/bin/env bash
+# personas — uninstall lifecycle (reverses everything install.sh did).
+#
+#   uninstall.sh (--town | --rig <name>) [--dry-run] [--city <path>]
+#                [--purge] [--no-reload]
+#
+# Reverses, in order:
+#   1. --town only: remove the "use-personas" fragment from city.toml [agent_defaults]
+#      append_fragments (surgical, backed-up; rest of the file byte-exact).
+#   2. Remove the pack import. It is a DIRECT config entry (the gastown pattern), so a
+#      surgical, backed-up edit drops it:
+#        --town       -> drops  <city>/pack.toml   [imports.personas]
+#        --rig <name> -> drops  <city>/city.toml   [rigs.imports.personas]
+#                        (from under the [[rigs]] entry whose name matches <name>)
+#   3. Re-project with `gc reload` so the pack's surfaces (skill + SessionStart equip
+#      hook) drop out of projection.
+#   4. --purge: delete the engine .venv.
+#
+# The shared warm cache (under .beads/personas/ or $GC_RIG_ROOT) is NOT removed here —
+# it is rebuildable runtime state. Clear it with `personas sweep --all` or delete the
+# file by hand if desired.
+#
+# Idempotent (re-running after a clean uninstall is a no-op). Any file it edits is
+# backed up first. --dry-run prints the plan and changes nothing.
+
+set -euo pipefail
+
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${HOME}/go/bin:${HOME}/.local/bin:${PATH}"
+
+PACK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PACK_NAME="personas"
+IMPORT_NAME="personas"
+FRAGMENTS=("use-personas")
+
+SCOPE=""; RIG=""; DRY_RUN=0; NO_RELOAD=0; PURGE=0; CITY=""
+
+die()  { printf 'uninstall.sh: error: %s\n' "$*" >&2; exit 1; }
+info() { printf '  %s\n' "$*"; }
+step() { printf '\n==> %s\n' "$*"; }
+run()  { if [ "$DRY_RUN" -eq 1 ]; then printf '    [dry-run] %s\n' "$*"; else printf '    + %s\n' "$*"; eval "$@"; fi; }
+
+usage() { sed -n '2,26p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit "${1:-0}"; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --town)      SCOPE="town"; shift ;;
+    --rig)       SCOPE="rig"; RIG="${2:-}"; [ -n "$RIG" ] || die "--rig requires a rig name"; shift 2 ;;
+    --rig=*)     SCOPE="rig"; RIG="${1#*=}"; shift ;;
+    --dry-run)   DRY_RUN=1; shift ;;
+    --purge)     PURGE=1; shift ;;
+    --no-reload) NO_RELOAD=1; shift ;;
+    --city)      CITY="${2:-}"; [ -n "$CITY" ] || die "--city requires a path"; shift 2 ;;
+    --city=*)    CITY="${1#*=}"; shift ;;
+    -h|--help)   usage 0 ;;
+    *)           die "unknown argument: $1 (try --help)" ;;
+  esac
+done
+
+[ -n "$SCOPE" ] || die "choose a scope: --town or --rig <name>"
+
+if [ -z "$CITY" ]; then CITY="$(cd "$PACK_DIR/../.." && pwd)"; fi
+[ -f "$CITY/city.toml" ] || die "no city.toml at city root: $CITY (pass --city <path>)"
+CITY="$(cd "$CITY" && pwd)"
+
+GC=(gc --city "$CITY")
+
+step "personas uninstall"
+info "scope:  $SCOPE${RIG:+ ($RIG)}"
+info "city:   $CITY"
+[ "$PURGE" -eq 1 ]   && info "purge:  yes (will delete .venv)"
+[ "$DRY_RUN" -eq 1 ] && info "MODE:   DRY RUN (no changes will be made)"
+
+command -v gc >/dev/null 2>&1 || die "gc not found on PATH"
+
+backup_file() {
+  local f="$1"; [ -f "$f" ] || return 0
+  local b="${f}.personas.bak.$(date +%Y%m%d%H%M%S)"
+  if [ "$DRY_RUN" -eq 1 ]; then printf '    [dry-run] backup %s -> %s\n' "$f" "$b"; return 0; fi
+  cp -p "$f" "$b"; printf '    backup: %s\n' "$b"
+}
+
+import_present() { # 0 if IMPORT_NAME is registered at the active scope.
+  if [ "$SCOPE" = "rig" ]; then
+    if "${GC[@]}" import list --rig "$RIG" 2>/dev/null | awk '{print $1}' | grep -qx "$IMPORT_NAME"; then
+      return 0
+    fi
+    rig_import_in_config "$RIG"
+  else
+    if "${GC[@]}" import list 2>/dev/null | awk '{print $1}' | grep -qx "$IMPORT_NAME"; then
+      return 0
+    fi
+    grep -Eq "^\[imports\.${IMPORT_NAME}\][[:space:]]*$" "$CITY/pack.toml" 2>/dev/null
+  fi
+}
+
+rig_import_in_config() { # 0 if [rigs.imports.IMPORT_NAME] exists under rig $1
+  python3 - "$CITY/city.toml" "$1" "$IMPORT_NAME" <<'PY'
+import sys, re
+path, rig, name = sys.argv[1], sys.argv[2], sys.argv[3]
+lines = open(path).read().splitlines(keepends=True)
+starts = [i for i, l in enumerate(lines) if re.match(r'^\[\[rigs\]\]\s*$', l)]
+for k, s in enumerate(starts):
+    end = starts[k + 1] if k + 1 < len(starts) else len(lines)
+    for j in range(s + 1, end):
+        if re.match(r'^\[', lines[j]) and not re.match(r'^\[(\[rigs\]\]|rigs(\.|\]))', lines[j]):
+            end = j; break
+    named = None
+    for j in range(s + 1, end):
+        m = re.match(r'^\s*name\s*=\s*["\'](.+?)["\']\s*$', lines[j])
+        if m:
+            named = m.group(1); break
+    if named != rig:
+        continue
+    hdr = re.compile(r'^\[rigs\.imports\.%s\]\s*$' % re.escape(name))
+    if any(hdr.match(lines[j]) for j in range(s + 1, end)):
+        sys.exit(0)
+    sys.exit(1)
+sys.exit(1)
+PY
+}
+
+fragment_present() { # 0 if fragment $1 is already in [agent_defaults] append_fragments
+  python3 - "$CITY/city.toml" "$1" <<'PY'
+import sys, re
+path, frag = sys.argv[1], sys.argv[2]
+try:
+    src = open(path).read()
+except OSError:
+    sys.exit(1)
+lines = src.splitlines(keepends=True)
+hdr = re.compile(r'^\[agent_defaults\]\s*$')
+start = next((i for i, l in enumerate(lines) if hdr.match(l)), None)
+if start is None:
+    sys.exit(1)
+end = len(lines)
+for j in range(start + 1, len(lines)):
+    if re.match(r'^\[', lines[j]):
+        end = j; break
+body = "".join(lines[start + 1:end])
+m = re.search(r'(?m)^\s*append_fragments\s*=\s*(\[[^\]]*\])', body)
+if not m:
+    sys.exit(1)
+items = [x.strip().strip('"').strip("'") for x in m.group(1)[1:-1].split(',') if x.strip()]
+sys.exit(0 if frag in items else 1)
+PY
+}
+
+edit_fragment() { # add|remove fragment $2 in [agent_defaults] append_fragments (idempotent)
+  python3 - "$CITY/city.toml" "$1" "$2" <<'PY'
+import sys, re
+path, action, frag = sys.argv[1], sys.argv[2], sys.argv[3]
+src = open(path).read()
+lines = src.splitlines(keepends=True)
+
+def find_table(name):
+    hdr = re.compile(r'^\[%s\]\s*$' % re.escape(name))
+    s = next((i for i, l in enumerate(lines) if hdr.match(l)), None)
+    if s is None:
+        return None, None
+    e = len(lines)
+    for j in range(s + 1, len(lines)):
+        if re.match(r'^\[', lines[j]):
+            e = j; break
+    return s, e
+
+start, end = find_table("agent_defaults")
+if action == "remove":
+    if start is None:
+        sys.exit(0)
+    body = "".join(lines[start + 1:end])
+    m = re.search(r'(?m)^(\s*append_fragments\s*=\s*)(\[[^\]]*\])', body)
+    if not m:
+        sys.exit(0)
+    items = [x.strip().strip('"').strip("'") for x in m.group(2)[1:-1].split(',') if x.strip()]
+    if frag not in items:
+        sys.exit(0)
+    items = [x for x in items if x != frag]
+    new_arr = "[" + ", ".join('"%s"' % x for x in items) + "]"
+    new_body = body[:m.start(2)] + new_arr + body[m.end(2):]
+    open(path, "w").write("".join(lines[:start + 1]) + new_body + "".join(lines[end:]))
+    sys.exit(0)
+sys.exit(0)
+PY
+}
+
+edit_import() { # remove a DIRECT-config import (gastown style); idempotent.
+  python3 - "$2" "$1" "$3" "$4" "${5:-}" <<'PY'
+import sys, re
+path, action, name, source, rig = sys.argv[1:6]
+rig = rig or None
+
+def fail(msg):
+    sys.stderr.write("edit_import: %s\n" % msg); sys.exit(3)
+
+lines = open(path).read().splitlines(keepends=True)
+
+if rig is None:
+    table = "imports"
+    anchor = next((i for i, l in enumerate(lines) if re.match(r'^\[imports\]\s*$', l)), None)
+    if anchor is None: fail("[imports] table not found in %s" % path)
+    hi = len(lines)
+else:
+    table = "rigs.imports"
+    starts = [i for i, l in enumerate(lines) if re.match(r'^\[\[rigs\]\]\s*$', l)]
+    if not starts: fail("no [[rigs]] blocks in %s" % path)
+    target_start = None; hi = len(lines)
+    for k, s in enumerate(starts):
+        end = starts[k + 1] if k + 1 < len(starts) else len(lines)
+        for j in range(s + 1, end):
+            if re.match(r'^\[', lines[j]) and not re.match(r'^\[(\[rigs\]\]|rigs(\.|\]))', lines[j]):
+                end = j; break
+        named = None
+        for j in range(s + 1, end):
+            m = re.match(r'^\s*name\s*=\s*["\'](.+?)["\']\s*$', lines[j])
+            if m: named = m.group(1); break
+        if named == rig:
+            target_start, hi = s, end; break
+    if target_start is None: fail('no [[rigs]] block with name = "%s" in %s' % (rig, path))
+    anchor = next((i for i in range(target_start, hi) if re.match(r'^\[rigs\.imports\]\s*$', lines[i])), None)
+    if anchor is None: fail('[rigs.imports] not found under rig "%s" in %s' % (rig, path))
+
+sub = re.compile(r'^\[%s\.%s\]\s*$' % (re.escape(table), re.escape(name)))
+existing = next((i for i in range(anchor, hi) if sub.match(lines[i])), None)
+if existing is None:
+    sys.exit(0)
+end = existing + 1
+if end < len(lines) and re.match(r'^\s*source\s*=', lines[end]): end += 1
+del lines[existing:end]
+open(path, "w").write("".join(lines))
+PY
+}
+
+# ---- step 1: fragment (town only) ------------------------------------------
+step "1/4  remove prompt fragment ([agent_defaults] append_fragments)"
+if [ "$SCOPE" = "town" ]; then
+  backed_up=0
+  for frag in "${FRAGMENTS[@]}"; do
+    if fragment_present "$frag"; then
+      if [ "$DRY_RUN" -eq 1 ]; then
+        info "[dry-run] remove \"$frag\" from [agent_defaults] append_fragments"
+      else
+        if [ "$backed_up" -eq 0 ]; then backup_file "$CITY/city.toml"; backed_up=1; fi
+        edit_fragment remove "$frag"
+        info "removed \"$frag\" from [agent_defaults] append_fragments"
+      fi
+    else
+      info "\"$frag\" not in append_fragments — no-op"
+    fi
+  done
+else
+  info "rig scope: append_fragments is city-wide and not touched"
+fi
+
+# ---- step 2: import --------------------------------------------------------
+step "2/4  remove pack import ($SCOPE scope)"
+if import_present; then
+  if [ "$SCOPE" = "rig" ]; then
+    IMPORT_CFG="$CITY/city.toml"
+    backup_file "$IMPORT_CFG"
+    if [ "$DRY_RUN" -eq 1 ]; then
+      info "[dry-run] remove [rigs.imports.$IMPORT_NAME] from under rig \"$RIG\" in $IMPORT_CFG"
+    else
+      edit_import remove "$IMPORT_CFG" "$IMPORT_NAME" "" "$RIG" \
+        || die "failed to remove [rigs.imports.$IMPORT_NAME] from $IMPORT_CFG"
+      info "removed [rigs.imports.$IMPORT_NAME] from under rig \"$RIG\""
+    fi
+  else
+    IMPORT_CFG="$CITY/pack.toml"
+    backup_file "$IMPORT_CFG"
+    if [ "$DRY_RUN" -eq 1 ]; then
+      info "[dry-run] remove [imports.$IMPORT_NAME] from $IMPORT_CFG"
+    else
+      edit_import remove "$IMPORT_CFG" "$IMPORT_NAME" "" \
+        || die "failed to remove [imports.$IMPORT_NAME] from $IMPORT_CFG"
+      info "removed [imports.$IMPORT_NAME]"
+    fi
+  fi
+else
+  info "import \"$IMPORT_NAME\" not registered at this scope — no-op"
+fi
+
+# ---- step 3: re-project ----------------------------------------------------
+step "3/4  re-project (gc reload)"
+if [ "$NO_RELOAD" -eq 1 ]; then
+  info "--no-reload: skipping. Run 'gc reload' to drop the pack from projection."
+elif [ "$DRY_RUN" -eq 1 ]; then
+  info "[dry-run] gc reload  (drops the pack's surfaces from projection)"
+else
+  if "${GC[@]}" reload >/dev/null 2>&1; then info "gc reload: ok"
+  else info "gc reload non-zero (city may be stopped); clean state applies on next start"; fi
+fi
+
+# ---- step 4: purge venv ----------------------------------------------------
+step "4/4  engine venv"
+if [ "$PURGE" -eq 1 ]; then
+  if [ -d "$PACK_DIR/.venv" ]; then
+    run "rm -rf \"$PACK_DIR/.venv\""
+    info "purged $PACK_DIR/.venv"
+  else
+    info "no .venv to purge"
+  fi
+else
+  info "kept $PACK_DIR/.venv (pass --purge to delete it)"
+fi
+
+# ---- verify ----------------------------------------------------------------
+step "verify"
+if [ "$DRY_RUN" -eq 1 ]; then
+  step "personas uninstall — DRY RUN complete (no changes made)"; exit 0
+fi
+fail=0
+if import_present; then info "import: STILL REGISTERED ($IMPORT_NAME)"; fail=1; else info "import: removed"; fi
+if [ "$SCOPE" = "town" ]; then
+  for frag in "${FRAGMENTS[@]}"; do
+    if fragment_present "$frag"; then info "fragment: \"$frag\" STILL PRESENT"; fail=1; else info "fragment: \"$frag\" removed"; fi
+  done
+fi
+
+echo
+if [ "$fail" -eq 0 ]; then
+  step "personas uninstall complete ($SCOPE${RIG:+ $RIG})"
+  info "Backups (*.personas.bak.*) were left in place; remove them when satisfied."
+  info "The shared warm cache was left intact (clear with 'personas sweep --all')."
+  exit 0
+else
+  step "personas uninstall finished WITH WARNINGS"
+  info "Review the STILL-* lines above."
+  exit 1
+fi

--- a/registry.toml
+++ b/registry.toml
@@ -77,3 +77,17 @@ source_kind = "git"
   commit = "d3617d1319a1206ac85f69ba024ec395c49c6f4b"
   hash = "sha256:0d32d8da6ad57c632d4f54008bdd1bb8b822c493a709676b3d1761a5ef389387"
   description = "Initial Slack pack release."
+
+[[pack]]
+name = "personas"
+description = "Dynamic principal-engineer personas for agent fleets: an agent equips a best-fit persona on task pickup, works at that level, then dematerializes; a warm cache keeps recent personas hot (sliding 30-minute idle TTL, 2-hour ceiling). Composes with model-advisor (tier) and provider-forge (provider) as the role dimension."
+source = "https://github.com/gastownhall/gascity-packs/tree/main/personas"
+source_kind = "git"
+
+  # commit/hash are placeholders for maintainers to finalize via release tooling on merge.
+  [[pack.release]]
+  version = "0.1.0"
+  ref = "main"
+  commit = "885bb7c0616f5ddb70cb1c673f73b86332abe684"
+  hash = "sha256:d2d37f0665edb783b92e585a2b560c06ff46b90a97b76c50c88916183a9ca289"
+  description = "Initial personas pack release."


### PR DESCRIPTION
## Summary

Adds `personas` as a top-level pack plus its `registry.toml` entry, pinned to the blackrim-personas source. Siblings to model-advisor (#58) and provider-forge (#59); together they form the dispatch dimensions of tier, provider, and role.

## What the pack provides

A dynamic persona system. When an agent picks up a task it equips a best-fit principal-engineer persona (description-match, the way skills auto-fire), performs the work at that level, then dematerializes. Recently-used personas stay warm in a shared cache (sliding 30-minute idle TTL refreshed on reuse, 2-hour ceiling) so other agents reuse them without paying the materialize cost again, then age out.

Roster: principal backend, frontend, systems, security, data, platform, api-design, test, refactoring, and docs engineers.

It composes with model-advisor (model tier) and provider-forge (provider and model) as the role dimension: a dispatch is a tier, a provider/model, and a persona.

```
personas/
  pack.toml              gas-city pack manifest
  personas.toml          the persona registry (the 10 role definitions)
  personas/              registry + equip/match engine + warm-cache/TTL + CLI (Python)
  hooks/                 equip-on-task-pickup hook
  skills/equip-persona/  equip skill overlay
  bin/personas           CLI entry
  template-fragments/    use-personas prompt fragment
  tests/                 pytest coverage (registry, match, cache, cli, hook)
  install.sh setup.sh uninstall.sh README LICENSE
```

Source of truth: jsgerman-oss/blackrim-personas (clean-room, MIT), site at https://jsgerman-oss.github.io/blackrim-personas/. The release pin's commit and hash are placeholders for maintainers to finalize via the registry release tooling on merge.
