### PR TITLE
Normalize legacy work option metadata in task creation

### DIFF
--- a/gascity/assets/scripts/create_beads_from_tasks.py
+++ b/gascity/assets/scripts/create_beads_from_tasks.py
@@ -25,6 +25,11 @@ CREATED_RE = re.compile(r"^## Created Beads\s*?\n.*?(?=^## |\Z)", re.MULTILINE |
 FRONT_MATTER_RE = re.compile(r"\A---\n(?P<body>.*?)\n---\n", re.DOTALL)
 VALID_TYPES = {"feature", "bug", "task", "chore", "docs"}
 VALID_PRIORITIES = {"0", "1", "2", "3", "4", "P0", "P1", "P2", "P3", "P4"}
+LEGACY_WORK_OPTION_METADATA = {
+    "gc.model": "opt_model",
+    "gc.reasoning": "opt_effort",
+    "gc.effort": "opt_effort",
+}
 
 
 class PlanError(Exception):
@@ -158,7 +163,11 @@ def metadata_map(value: Any, field_name: str) -> dict[str, str]:
     for key, val in value.items():
         if not isinstance(key, str) or not key.strip():
             raise PlanError(f"{field_name} keys must be non-empty strings")
-        out[key.strip()] = str(val)
+        raw_key = key.strip()
+        normalized_key = LEGACY_WORK_OPTION_METADATA.get(raw_key, raw_key)
+        if raw_key in LEGACY_WORK_OPTION_METADATA and normalized_key in out:
+            continue
+        out[normalized_key] = str(val)
     return out
 
 

--- a/gascity/tests/test_create_beads_from_tasks.py
+++ b/gascity/tests/test_create_beads_from_tasks.py
@@ -189,6 +189,31 @@ class CreateBeadsFromTasksTests(unittest.TestCase):
         self.assertEqual(convoys["implementation"].convoy_keys, ["nested"])
         self.assertEqual(convoys["nested"].convoy_keys, ["deeper"])
 
+    def test_metadata_normalizes_legacy_work_option_keys(self) -> None:
+        text = sample_tasks().replace(
+            "        priority: 2\n"
+            "        description: |\n",
+            """        priority: 2
+        metadata:
+          gc.model: opus
+          gc.reasoning: high
+          gc.effort: medium
+          opt_model: sonnet
+          opt_effort: low
+        description: |
+""",
+            1,
+        )
+
+        plan = script.parse_plan(script.extract_payload(text))
+        schema = next(item for item in plan.runnables if item.key == "schema")
+
+        self.assertEqual(schema.metadata["opt_model"], "sonnet")
+        self.assertEqual(schema.metadata["opt_effort"], "low")
+        self.assertNotIn("gc.model", schema.metadata)
+        self.assertNotIn("gc.reasoning", schema.metadata)
+        self.assertNotIn("gc.effort", schema.metadata)
+
     def test_dry_run_prints_gc_commands_and_does_not_modify_file(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             path = pathlib.Path(tmp) / "tasks.md"


### PR DESCRIPTION
## Summary
- normalize task payload metadata keys gc.model -> opt_model and gc.reasoning/gc.effort -> opt_effort in the Gas City task bead creation helper
- keep explicit canonical opt_model/opt_effort values authoritative when both legacy and canonical keys are present
- add regression coverage for the migration behavior

Note: I checked current origin/main and repo history for literal gc.model/gc.reasoning/gc.effort pack metadata and found no formula/pack asset occurrences to rewrite. This covers the current packs-side path that accepts and emits task bead metadata.

## Tests
- python -m unittest gascity.tests.test_create_beads_from_tasks.CreateBeadsFromTasksTests.test_metadata_normalizes_legacy_work_option_keys
- python -m unittest discover -s gascity/tests
- python validate_registry.py
- python -m pytest tests gascity/tests
