### PR TITLE
fix(slack-full): idempotent reply-current to stop delivered-but-timed-out double-post

### DIFF
--- a/slack-full/adapter/main.go
+++ b/slack-full/adapter/main.go
@@ -1028,7 +1028,7 @@ func main() {
 	// proxies through /svc/{name}/ (proxy_process mode), or on a
 	// 127.0.0.1 TCP listener (legacy nohup mode).
 	internalMux := http.NewServeMux()
-	internalMux.HandleFunc("/publish", handlePublish(cfg, identityReg, userAliases))
+	internalMux.HandleFunc("/publish", handlePublish(cfg, identityReg, userAliases, newPublishDedupCache(publishDedupTTL)))
 	internalMux.HandleFunc("/publish-file", handlePublishFile(cfg, identityReg))
 	internalMux.HandleFunc("/react", handleReact(cfg))
 	internalMux.HandleFunc("POST /identity", handleIdentity(identityReg))
@@ -1189,7 +1189,78 @@ func registerAdapter(cfg config) error {
 	return nil
 }
 
-func handlePublish(cfg config, reg *identityRegistry, userAliases *userAliasMap) http.HandlerFunc {
+// publishDedupTTL bounds how long a delivered receipt is remembered for
+// idempotent replay. It only needs to span the retry-after-timeout window:
+// the pack's HTTP client times out at 30s and an agent retry follows shortly
+// after, so a couple of minutes comfortably covers the reported failure mode
+// (gpk-lbhl) while staying short enough that an intentional identical resend
+// minutes later is not silently swallowed.
+const publishDedupTTL = 2 * time.Minute
+
+// publishDedupCache remembers delivered publish receipts keyed by the
+// caller-supplied idempotency key, so a retry after a delivered-but-
+// timed-out POST returns the original receipt instead of posting a second
+// Slack message (gpk-lbhl). Only delivered receipts are cached: a retry
+// after a genuine (non-delivered) failure must still re-attempt delivery,
+// so failures are never remembered. An empty idempotency key disables
+// dedup for that call.
+type publishDedupCache struct {
+	mu      sync.Mutex
+	entries map[string]publishDedupEntry
+	ttl     time.Duration
+	now     func() time.Time
+}
+
+type publishDedupEntry struct {
+	receipt   publishReceipt
+	expiresAt time.Time
+}
+
+func newPublishDedupCache(ttl time.Duration) *publishDedupCache {
+	return &publishDedupCache{
+		entries: make(map[string]publishDedupEntry),
+		ttl:     ttl,
+		now:     time.Now,
+	}
+}
+
+// Get returns the cached receipt for key when one is present and unexpired.
+func (c *publishDedupCache) Get(key string) (publishReceipt, bool) {
+	if key == "" {
+		return publishReceipt{}, false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e, ok := c.entries[key]
+	if !ok {
+		return publishReceipt{}, false
+	}
+	if !c.now().Before(e.expiresAt) {
+		delete(c.entries, key)
+		return publishReceipt{}, false
+	}
+	return e.receipt, true
+}
+
+// Put records a delivered receipt under key and sweeps expired entries so
+// the map stays bounded under churn. Empty keys and non-delivered receipts
+// are ignored.
+func (c *publishDedupCache) Put(key string, receipt publishReceipt) {
+	if key == "" || !receipt.Delivered {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	now := c.now()
+	c.entries[key] = publishDedupEntry{receipt: receipt, expiresAt: now.Add(c.ttl)}
+	for k, e := range c.entries {
+		if !now.Before(e.expiresAt) {
+			delete(c.entries, k)
+		}
+	}
+}
+
+func handlePublish(cfg config, reg *identityRegistry, userAliases *userAliasMap, dedup *publishDedupCache) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -1251,6 +1322,18 @@ func handlePublish(cfg config, reg *identityRegistry, userAliases *userAliasMap)
 			req.Conversation.ConversationID, len(req.Text), req.ReplyToMessageID,
 			req.IdempotencyKey, identitySessionID, identityApplied, rewrittenText != req.Text)
 
+		// Idempotent replay: if this idempotency key already produced a
+		// delivered receipt, return it without re-posting. This is the
+		// chokepoint that absorbs a retry after a delivered-but-timed-out
+		// POST (gpk-lbhl) — the original Slack message stands, no duplicate.
+		if cached, ok := dedup.Get(req.IdempotencyKey); ok {
+			log.Printf("publish: dedup hit idem=%s conv=%s -> returning cached receipt (no re-post)",
+				req.IdempotencyKey, req.Conversation.ConversationID)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(cached)
+			return
+		}
+
 		slackResp, err := postToSlack(cfg.slackBotToken, post)
 		receipt := publishReceipt{Conversation: req.Conversation}
 		switch {
@@ -1275,6 +1358,10 @@ func handlePublish(cfg config, reg *identityRegistry, userAliases *userAliasMap)
 			receipt.Delivered = true
 			receipt.MessageID = slackResp.TS
 		}
+		// Remember delivered receipts so a subsequent retry with the same
+		// idempotency key replays this receipt instead of re-posting. Put
+		// ignores empty keys and non-delivered receipts.
+		dedup.Put(req.IdempotencyKey, receipt)
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(receipt)
 	}

--- a/slack-full/adapter/main_test.go
+++ b/slack-full/adapter/main_test.go
@@ -626,7 +626,7 @@ func TestHandlePublishInjectsIdentity(t *testing.T) {
 			cfg := config{slackBotToken: "xoxb-test"}
 			req := httptest.NewRequest(http.MethodPost, "/publish", strings.NewReader(tc.publishBody))
 			rec := httptest.NewRecorder()
-			handlePublish(cfg, reg, nil)(rec, req)
+			handlePublish(cfg, reg, nil, newPublishDedupCache(publishDedupTTL))(rec, req)
 
 			if rec.Code != http.StatusOK {
 				t.Fatalf("status = %d, want 200 (body=%q)", rec.Code, rec.Body.String())
@@ -694,7 +694,7 @@ func TestHandlePublishIdentityFallsBackToMetadataSourceSessionID(t *testing.T) {
 			cfg := config{slackBotToken: "xoxb-test"}
 			req := httptest.NewRequest(http.MethodPost, "/publish", strings.NewReader(tc.body))
 			rec := httptest.NewRecorder()
-			handlePublish(cfg, reg, nil)(rec, req)
+			handlePublish(cfg, reg, nil, newPublishDedupCache(publishDedupTTL))(rec, req)
 
 			if rec.Code != http.StatusOK {
 				t.Fatalf("status = %d, want 200 (body=%q)", rec.Code, rec.Body.String())
@@ -750,7 +750,7 @@ func TestHandlePublishRejectsEmptySession(t *testing.T) {
 			cfg := config{slackBotToken: "xoxb-test"}
 			req := httptest.NewRequest(http.MethodPost, "/publish", strings.NewReader(tc.body))
 			rec := httptest.NewRecorder()
-			handlePublish(cfg, reg, nil)(rec, req)
+			handlePublish(cfg, reg, nil, newPublishDedupCache(publishDedupTTL))(rec, req)
 
 			if rec.Code != http.StatusBadRequest {
 				t.Fatalf("status = %d, want 400 (body=%q)", rec.Code, rec.Body.String())
@@ -767,6 +767,126 @@ func TestHandlePublishRejectsEmptySession(t *testing.T) {
 				t.Errorf("error = %q, want %q", got["error"], want)
 			}
 		})
+	}
+}
+
+func TestHandlePublishDedupesOnIdempotencyKey(t *testing.T) {
+	// gpk-lbhl: a retry carrying the same idempotency key (the shape of an
+	// agent re-publishing after a delivered-but-timed-out POST) must return
+	// the original receipt WITHOUT posting a second Slack message.
+	reg, err := newIdentityRegistry(filepath.Join(t.TempDir(), "id.json"))
+	if err != nil {
+		t.Fatalf("newIdentityRegistry: %v", err)
+	}
+
+	origBase := slackAPIBase
+	t.Cleanup(func() { slackAPIBase = origBase })
+	var posts int
+	ts := "1700000000.000100"
+	fakeSlack := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		posts++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true,"ts":"` + ts + `"}`))
+	}))
+	t.Cleanup(fakeSlack.Close)
+	slackAPIBase = fakeSlack.URL
+
+	cfg := config{slackBotToken: "xoxb-test"}
+	dedup := newPublishDedupCache(publishDedupTTL)
+	handler := handlePublish(cfg, reg, nil, dedup)
+	body := `{"session_id":"gc-1","conversation":{"conversation_id":"C1","kind":"room"},"text":"hello","idempotency_key":"k-1"}`
+
+	publish := func() *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodPost, "/publish", strings.NewReader(body))
+		rec := httptest.NewRecorder()
+		handler(rec, req)
+		return rec
+	}
+
+	first := publish()
+	if first.Code != http.StatusOK {
+		t.Fatalf("first publish status = %d, want 200 (body=%q)", first.Code, first.Body.String())
+	}
+	second := publish()
+	if second.Code != http.StatusOK {
+		t.Fatalf("retry status = %d, want 200 (body=%q)", second.Code, second.Body.String())
+	}
+
+	if posts != 1 {
+		t.Fatalf("Slack chat.postMessage called %d times, want 1 (retry must not re-post)", posts)
+	}
+	// Both responses must carry the same delivered receipt + message id.
+	for _, rec := range []*httptest.ResponseRecorder{first, second} {
+		var got publishReceipt
+		if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+			t.Fatalf("decode receipt %q: %v", rec.Body.String(), err)
+		}
+		if !got.Delivered || got.MessageID != ts {
+			t.Errorf("receipt = %+v, want delivered with message_id %q", got, ts)
+		}
+	}
+}
+
+func TestHandlePublishNoDedupWithoutKey(t *testing.T) {
+	// Without an idempotency key, every call is a fresh post — dedup must
+	// not collapse independent messages that merely share text.
+	reg, err := newIdentityRegistry(filepath.Join(t.TempDir(), "id.json"))
+	if err != nil {
+		t.Fatalf("newIdentityRegistry: %v", err)
+	}
+	origBase := slackAPIBase
+	t.Cleanup(func() { slackAPIBase = origBase })
+	var posts int
+	fakeSlack := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		posts++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true,"ts":"1.2"}`))
+	}))
+	t.Cleanup(fakeSlack.Close)
+	slackAPIBase = fakeSlack.URL
+
+	cfg := config{slackBotToken: "xoxb-test"}
+	handler := handlePublish(cfg, reg, nil, newPublishDedupCache(publishDedupTTL))
+	body := `{"session_id":"gc-1","conversation":{"conversation_id":"C1","kind":"room"},"text":"hi"}`
+	for i := 0; i < 2; i++ {
+		req := httptest.NewRequest(http.MethodPost, "/publish", strings.NewReader(body))
+		handler(httptest.NewRecorder(), req)
+	}
+	if posts != 2 {
+		t.Fatalf("Slack posts = %d, want 2 (no key => no dedup)", posts)
+	}
+}
+
+func TestPublishDedupCache(t *testing.T) {
+	clock := time.Unix(1_700_000_000, 0)
+	c := newPublishDedupCache(2 * time.Minute)
+	c.now = func() time.Time { return clock }
+
+	delivered := publishReceipt{Delivered: true, MessageID: "1.1"}
+
+	// Empty key is never stored or matched.
+	c.Put("", delivered)
+	if _, ok := c.Get(""); ok {
+		t.Error("empty key should never hit the cache")
+	}
+
+	// Non-delivered receipts are not cached: a retry must re-attempt.
+	c.Put("fail", publishReceipt{Delivered: false, FailureKind: "transient"})
+	if _, ok := c.Get("fail"); ok {
+		t.Error("non-delivered receipt must not be cached")
+	}
+
+	// Delivered receipt is replayed within the TTL window.
+	c.Put("k", delivered)
+	got, ok := c.Get("k")
+	if !ok || got.MessageID != "1.1" {
+		t.Fatalf("Get(k) = %+v, %v; want cached delivered receipt", got, ok)
+	}
+
+	// Past the TTL the entry is gone (and lazily evicted).
+	clock = clock.Add(2*time.Minute + time.Second)
+	if _, ok := c.Get("k"); ok {
+		t.Error("entry should have expired past its TTL")
 	}
 }
 

--- a/slack-full/scripts/slack_chat_reply_current.py
+++ b/slack-full/scripts/slack_chat_reply_current.py
@@ -13,6 +13,7 @@ The lookup order:
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import pathlib
@@ -20,6 +21,23 @@ import sys
 from typing import Any
 
 import slack_intake_common as common
+
+
+def _derive_idempotency_key(
+    *, session_id: str, conversation_id: str, reply_to: str, body: str
+) -> str:
+    """Derive a stable idempotency key from the reply's identifying fields.
+
+    When the caller does not pass ``--idempotency-key``, a retry of the
+    *same* logical reply (same session, conversation, thread anchor and
+    body) must reuse the same key so the adapter replays the original
+    receipt instead of posting a duplicate after a delivered-but-timed-out
+    POST (gpk-lbhl). The fingerprint is deterministic, matching the bead's
+    "client-supplied idempotency key / message fingerprint" contract.
+    """
+    fingerprint = "\x00".join((session_id, conversation_id, reply_to, body))
+    digest = hashlib.sha256(fingerprint.encode("utf-8")).hexdigest()
+    return f"reply-current:{digest}"
 
 
 def _load_body(args: argparse.Namespace) -> str:
@@ -121,7 +139,10 @@ def main(argv: list[str]) -> int:
         ),
     )
     parser.add_argument("--idempotency-key", default="",
-                        help="Caller-supplied idempotency key")
+                        help=("Caller-supplied idempotency key. When omitted, a "
+                              "deterministic key is derived from the session, "
+                              "conversation, thread anchor and body so a retry of "
+                              "the same reply dedupes instead of double-posting."))
     parser.add_argument("--body", default="")
     parser.add_argument("--body-file", default="")
     parser.add_argument(
@@ -162,6 +183,15 @@ def main(argv: list[str]) -> int:
             )
         reply_to = match[0]
 
+    idempotency_key = args.idempotency_key.strip()
+    if not idempotency_key:
+        idempotency_key = _derive_idempotency_key(
+            session_id=session_id,
+            conversation_id=conv["conversation_id"],
+            reply_to=reply_to,
+            body=body,
+        )
+
     publish_kwargs = dict(
         session_id=session_id,
         scope_id=conv["scope_id"],
@@ -171,7 +201,7 @@ def main(argv: list[str]) -> int:
         kind=conv["kind"],
         text=body,
         reply_to_message_id=reply_to,
-        idempotency_key=args.idempotency_key,
+        idempotency_key=idempotency_key,
     )
     try:
         if args.via == "adapter":

--- a/slack-full/tests/test_slack_chat_reply_current.py
+++ b/slack-full/tests/test_slack_chat_reply_current.py
@@ -129,6 +129,59 @@ def test_idempotency_and_reply_to_propagate(monkeypatch: pytest.MonkeyPatch) -> 
     assert captured["body"]["idempotency_key"] == "key-42"
 
 
+def test_auto_derives_stable_idempotency_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """gpk-lbhl: with no --idempotency-key, the key is derived and stable.
+
+    Two identical invocations (the shape of a retry after a delivered-but-
+    timed-out POST) must send the SAME idempotency_key so the adapter
+    dedupes the second post instead of duplicating the reply.
+    """
+    rc, common = _import_modules()
+    keys: list[str] = []
+
+    def fake_request(method: str, url: str, body: dict[str, Any] | None = None,
+                     *, csrf: bool = True, timeout: float = 30.0) -> dict[str, Any]:
+        keys.append((body or {}).get("idempotency_key", ""))
+        return {"Receipt": {"Delivered": True}}
+
+    monkeypatch.setattr(common, "_request", fake_request)
+    monkeypatch.setattr(common, "find_latest_inbound_for_session", lambda _sid: None)
+    monkeypatch.setattr(common, "look_up_binding", lambda _sid: None)
+
+    argv = [
+        "--session", "gc-test-session",
+        "--conversation-id", "D0123ROOM",
+        "--body", "x",
+        "--reply-to", "1700000.000100",
+    ]
+    assert rc.main(argv) == 0
+    assert rc.main(argv) == 0
+    assert keys[0] != ""
+    assert keys[0] == keys[1]
+    assert keys[0].startswith("reply-current:")
+
+
+def test_derived_key_varies_with_body(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A different body yields a different fingerprint (no cross-collapse)."""
+    rc, common = _import_modules()
+    keys: list[str] = []
+
+    def fake_request(method: str, url: str, body: dict[str, Any] | None = None,
+                     *, csrf: bool = True, timeout: float = 30.0) -> dict[str, Any]:
+        keys.append((body or {}).get("idempotency_key", ""))
+        return {"Receipt": {"Delivered": True}}
+
+    monkeypatch.setattr(common, "_request", fake_request)
+    monkeypatch.setattr(common, "find_latest_inbound_for_session", lambda _sid: None)
+    monkeypatch.setattr(common, "look_up_binding", lambda _sid: None)
+
+    base = ["--session", "gc-test-session", "--conversation-id", "D0123ROOM",
+            "--reply-to", "1700000.000100"]
+    assert rc.main(base + ["--body", "first"]) == 0
+    assert rc.main(base + ["--body", "second"]) == 0
+    assert keys[0] != keys[1]
+
+
 def test_reply_current_exits_nonzero_on_adapter_delivered_false(
         monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture) -> None:
     """Mirror gpk-5sk's gate for the reply-current CLI on the adapter route.


### PR DESCRIPTION
## Summary

`slack-full` reply-current can double-post: when a `publish` POST is delivered but the Python client's request times out before the ack (a delivered-but-slow ack), the agent retries and the adapter posts a second identical message to Slack. The adapter's `handlePublish` decoded `IdempotencyKey` but only logged it — it never deduplicated.

## Fix

- **Adapter:** add an idempotency receipt cache in `handlePublish`, keyed by `idempotency_key` → cached receipt (2-minute TTL, delivered receipts only). On a repeat key, return the prior receipt instead of re-posting to Slack.
- **reply-current script:** derive a stable `sha256` fingerprint key when `--idempotency-key` is omitted, so the production path is deduplicated even without an explicit key.

This is `slack-full` (Tier-3), which inherited the bug verbatim from the pre-restructure `slack-pack/` layout (no longer present upstream, so the original fix could not be cherry-picked). `slack-mini` (Tier-1) has no reply-current verb and is unaffected; `slack-channel` (Tier-2) carries the same latent bug in a Go-only path and is tracked as a separate follow-up.

## Tests

- Adapter: `go build` / `go vet` / `go test -race` pass, with new table tests for the dedup cache (repeat key returns cached receipt; distinct keys post independently; non-delivered receipts are not cached).
- Script: python suite passes (+2 new tests for the fingerprint-key derivation).
