### PR TITLE
fix(gastown/statusline): cache work/mail counts to stop per-render fork storm

### DIFF
--- a/gastown/assets/scripts/status-line.sh
+++ b/gastown/assets/scripts/status-line.sh
@@ -3,17 +3,33 @@
 # Usage: status-line.sh <agent-name>
 # Called by tmux every status-interval seconds via #(command).
 # Always exits 0 — tmux must never see errors.
+#
+# Counts are cached with a short TTL so tmux's frequent refresh does not fork
+# `gc hook` + `gc mail check` (each a gc->bd.real->dolt cascade) on EVERY render
+# across EVERY agent — a significant, avoidable share of city fork/CPU load.
+# Within the TTL the cached value is reused; the gc calls run at most once per
+# TTL per agent. TTL override: GC_STATUSLINE_TTL (seconds).
 
 agent="$1"
 [ -z "$agent" ] && exit 0
 
-# Count pending work items (non-empty lines from gc hook).
-w=$(gc hook "$agent" 2>/dev/null | grep -c . || true)
+cache_ttl="${GC_STATUSLINE_TTL:-30}"
+safe=$(printf '%s' "$agent" | tr -c 'A-Za-z0-9._-' '_')
+cache="${TMPDIR:-/tmp}/gc-statusline-${safe}.cache"
 
-# Count unread mail (first word of gc mail check output is the count).
-m=$(gc mail check "$agent" 2>/dev/null | awk '{print $1+0}' || true)
+# Reuse the cache if it was written within the TTL window. Uses date+stat
+# (portable) rather than find -newermt/-mmin, which some find variants (e.g.
+# bfs) reject.
+now=$(date +%s 2>/dev/null || echo 0)
+mtime=$(stat -c %Y "$cache" 2>/dev/null || echo 0)
+if [ "$mtime" -gt 0 ] && [ "$((now - mtime))" -lt "$cache_ttl" ]; then
+	read -r w m < "$cache" 2>/dev/null
+else
+	w=$(gc hook "$agent" 2>/dev/null | grep -c . || true)
+	m=$(gc mail check "$agent" 2>/dev/null | awk '{print $1+0}' || true)
+	printf '%s %s\n' "${w:-0}" "${m:-0}" > "$cache" 2>/dev/null || true
+fi
 
-# Format: agent | hook-icon N | mail-icon N  (omit segments that are 0)
 printf '%s' "$agent"
 [ "${w:-0}" -gt 0 ] && printf ' | 🪝 %d' "$w"
 [ "${m:-0}" -gt 0 ] && printf ' | 📬 %d' "$m"


### PR DESCRIPTION
## What

Cache the gastown tmux statusline's work/mail counts with a short TTL so it stops forking `gc hook` + `gc mail check` on **every** render.

## Why

`status-line.sh` (tmux `status-right`, run every `status-interval` for each agent) calls `gc hook` and `gc mail check` per render. Each is a `gc → bd.real → dolt` cascade. Measured with `strace -f -e execve`, **one render = 888 process execs** (gc=2 → bd.real=43, dolt=34, + the rest of the cascade). Across agents rendering continuously, this is a large, avoidable share of city fork/CPU load — and high fork load is exactly what operators misread as CPU saturation (load ≠ CPU).

Field context: on a busy city this statusline path was a double-digit % of total forks/s (bpftrace `sched_process_fork` ancestry: `gc ← status-line.sh` ≈ 271–316 forks/10s).

## Change

Cache the two counts with a TTL (default 30s, override `GC_STATUSLINE_TTL`). Within the TTL, renders reuse the cached value via a `date`+`stat` freshness check (no gc); the gc calls run at most once per TTL per agent. Output is byte-identical.

Freshness uses `date`+`stat`, **not** `find -newermt`/`-mmin` — some `find` variants (e.g. **bfs**) reject those, which silently defeats the cache (every render misses). Found via dogfooding.

## Proof (strace -f -e execve, one render)

| render | total execs | gc | bd.real | dolt |
|---|---|---|---|---|
| before (current) | 888 | 2 | 43 | 34 |
| cached — miss | 891 | 2 | 43 | 34 |
| **cached — hit** | **4** | **0** | **0** | **0** |

**99.5% fewer execs per cached render**, validated in an environment where `find` is `bfs`. Counts are at most `GC_STATUSLINE_TTL` seconds stale — fine for a status indicator.

## Scope

Display-script only; no data/control-plane change. Complements the `gc doctor` fork-rate watch (gascity#3252), which can confirm the city-wide drop once this is imported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
