### PR TITLE
Synthesize Gastown statusline fixes from PRs 16 and 70

### DIFF
--- a/gastown/assets/scripts/status-line.sh
+++ b/gastown/assets/scripts/status-line.sh
@@ -31,7 +31,15 @@ json_array_count() {
         return 0
     fi
 
-    n=$(run_bounded "$@" 2>/dev/null | jq 'length' 2>/dev/null || true)
+    n=$(run_bounded "$@" 2>/dev/null | jq 'if type == "array" then length else 0 end' 2>/dev/null || true)
+    case "$n" in
+        ''|*[!0-9]*) printf '0' ;;
+        *) printf '%s' "$n" ;;
+    esac
+}
+
+first_number() {
+    n=$(run_bounded "$@" 2>/dev/null | awk '{print $1+0; exit}' || true)
     case "$n" in
         ''|*[!0-9]*) printf '0' ;;
         *) printf '%s' "$n" ;;
@@ -51,7 +59,15 @@ is_number() {
 
 cache_ttl="${GC_STATUSLINE_TTL:-30}"
 is_number "$cache_ttl" || cache_ttl=30
-cache_dir="${GC_STATUSLINE_CACHE_DIR:-${TMPDIR:-/tmp}}"
+if [ -n "${GC_STATUSLINE_CACHE_DIR:-}" ]; then
+    cache_dir="$GC_STATUSLINE_CACHE_DIR"
+    cache_private=0
+else
+    cache_base="${XDG_RUNTIME_DIR:-${TMPDIR:-/tmp}}"
+    uid=$(id -u 2>/dev/null || printf 'unknown')
+    cache_dir="$cache_base/gc-statusline-$uid"
+    cache_private=1
+fi
 cache_city=$(pwd -P 2>/dev/null || pwd)
 safe_agent=$(printf '%s' "$agent" | tr -c 'A-Za-z0-9._-' '_')
 cache_key=$(printf '%s\n%s\n' "$cache_city" "$agent" | cksum | awk '{print $1}')
@@ -64,15 +80,16 @@ if is_number "$now" && is_number "$mtime" && [ "$mtime" -gt 0 ] && [ "$((now - m
     is_number "${w:-}" || w=0
     is_number "${m:-}" || m=0
 else
-    # Count pending hook nudges with a bounded read-only Beads query. `gc hook`
-    # can block long enough for tmux to suppress status output.
-    w=$(json_array_count bd list --include-infra --label gc:nudge --status open --metadata-field "agent=$agent" --json --limit 0)
+    # Preserve gc hook ready-work semantics while bounding tmux refreshes.
+    w=$(json_array_count gc hook "$agent")
 
-    # Count unread/open message beads with a bounded read-only Beads query.
-    # `gc mail check` can be too slow for tmux status-right refreshes.
-    m=$(json_array_count bd list --include-infra --type message --status open --assignee "$agent" --json --limit 0)
+    # Preserve gc mail check unread/recipient-route semantics while caching.
+    m=$(first_number gc mail check "$agent")
 
     mkdir -p "$cache_dir" 2>/dev/null || true
+    if [ "$cache_private" = 1 ]; then
+        chmod 700 "$cache_dir" 2>/dev/null || true
+    fi
     printf '%s %s\n' "${w:-0}" "${m:-0}" > "$cache" 2>/dev/null || true
 fi
 

--- a/gastown/assets/scripts/status-line.sh
+++ b/gastown/assets/scripts/status-line.sh
@@ -1,19 +1,83 @@
 #!/bin/sh
-# status-line.sh — tmux status-right helper for Gas City agents.
-# Usage: status-line.sh <agent-name>
+# status-line.sh — tmux status-right helper for Gas Town agents.
+# Usage: status-line.sh <agent-name> [city-path]
 # Called by tmux every status-interval seconds via #(command).
 # Always exits 0 — tmux must never see errors.
+#
+# Counts are cached with a short TTL so tmux's frequent refresh does not query
+# Beads on every render across every agent. TTL override:
+# GC_STATUSLINE_TTL (seconds). Cache directory override:
+# GC_STATUSLINE_CACHE_DIR.
 
 agent="$1"
+city="${2:-${GC_CITY:-${GT_ROOT:-${GC_DIR:-}}}}"
 [ -z "$agent" ] && exit 0
 
-# Count pending work items (non-empty lines from gc hook).
-w=$(gc hook "$agent" 2>/dev/null | grep -c . || true)
+if [ -n "$city" ] && [ -d "$city" ]; then
+    cd "$city" 2>/dev/null || true
+fi
 
-# Count unread mail (first word of gc mail check output is the count).
-m=$(gc mail check "$agent" 2>/dev/null | awk '{print $1+0}' || true)
+run_bounded() {
+    if command -v timeout >/dev/null 2>&1; then
+        timeout 2s "$@"
+    else
+        "$@"
+    fi
+}
+
+json_array_count() {
+    if ! command -v jq >/dev/null 2>&1; then
+        printf '0'
+        return 0
+    fi
+
+    n=$(run_bounded "$@" 2>/dev/null | jq 'length' 2>/dev/null || true)
+    case "$n" in
+        ''|*[!0-9]*) printf '0' ;;
+        *) printf '%s' "$n" ;;
+    esac
+}
+
+cache_mtime() {
+    stat -c %Y "$1" 2>/dev/null || stat -f %m "$1" 2>/dev/null || printf '0'
+}
+
+is_number() {
+    case "$1" in
+        ''|*[!0-9]*) return 1 ;;
+        *) return 0 ;;
+    esac
+}
+
+cache_ttl="${GC_STATUSLINE_TTL:-30}"
+is_number "$cache_ttl" || cache_ttl=30
+cache_dir="${GC_STATUSLINE_CACHE_DIR:-${TMPDIR:-/tmp}}"
+cache_city=$(pwd -P 2>/dev/null || pwd)
+safe_agent=$(printf '%s' "$agent" | tr -c 'A-Za-z0-9._-' '_')
+cache_key=$(printf '%s\n%s\n' "$cache_city" "$agent" | cksum | awk '{print $1}')
+cache="$cache_dir/gc-statusline-${safe_agent}-${cache_key}.cache"
+
+now=$(date +%s 2>/dev/null || printf '0')
+mtime=$(cache_mtime "$cache")
+if is_number "$now" && is_number "$mtime" && [ "$mtime" -gt 0 ] && [ "$((now - mtime))" -lt "$cache_ttl" ]; then
+    read -r w m < "$cache" 2>/dev/null || true
+    is_number "${w:-}" || w=0
+    is_number "${m:-}" || m=0
+else
+    # Count pending hook nudges with a bounded read-only Beads query. `gc hook`
+    # can block long enough for tmux to suppress status output.
+    w=$(json_array_count bd list --include-infra --label gc:nudge --status open --metadata-field "agent=$agent" --json --limit 0)
+
+    # Count unread/open message beads with a bounded read-only Beads query.
+    # `gc mail check` can be too slow for tmux status-right refreshes.
+    m=$(json_array_count bd list --include-infra --type message --status open --assignee "$agent" --json --limit 0)
+
+    mkdir -p "$cache_dir" 2>/dev/null || true
+    printf '%s %s\n' "${w:-0}" "${m:-0}" > "$cache" 2>/dev/null || true
+fi
 
 # Format: agent | hook-icon N | mail-icon N  (omit segments that are 0)
 printf '%s' "$agent"
 [ "${w:-0}" -gt 0 ] && printf ' | 🪝 %d' "$w"
 [ "${m:-0}" -gt 0 ] && printf ' | 📬 %d' "$m"
+exit 0

--- a/gastown/assets/scripts/tmux-theme.sh
+++ b/gastown/assets/scripts/tmux-theme.sh
@@ -20,6 +20,12 @@ city="${GC_CITY:-${GT_ROOT:-${GC_DIR:-}}}"
 # Socket-aware tmux command (uses GC_TMUX_SOCKET when set).
 gcmux() { tmux ${GC_TMUX_SOCKET:+-L "$GC_TMUX_SOCKET"} "$@"; }
 
+shell_quote() {
+    printf "'"
+    printf '%s' "$1" | sed "s/'/'\\\\''/g"
+    printf "'"
+}
+
 # Determine theme tier by session-name shape.
 case "$SESSION" in
     *--*)       tier="rig" ;;
@@ -51,11 +57,11 @@ gcmux set-option -t "$SESSION" status-left-length 25
 gcmux set-option -t "$SESSION" status-left "$icon $AGENT "
 gcmux set-option -t "$SESSION" status-right-length 80
 gcmux set-option -t "$SESSION" status-interval 5
+status_cmd="$(shell_quote "$CONFIGDIR/assets/scripts/status-line.sh") $(shell_quote "$AGENT")"
 if [ -n "$city" ]; then
-    gcmux set-option -t "$SESSION" status-right "#($CONFIGDIR/assets/scripts/status-line.sh $AGENT $city) %H:%M"
-else
-    gcmux set-option -t "$SESSION" status-right "#($CONFIGDIR/assets/scripts/status-line.sh $AGENT) %H:%M"
+    status_cmd="$status_cmd $(shell_quote "$city")"
 fi
+gcmux set-option -t "$SESSION" status-right "#($status_cmd) %H:%M"
 
 # Mouse + clipboard.
 gcmux set-option -t "$SESSION" mouse on

--- a/gastown/assets/scripts/tmux-theme.sh
+++ b/gastown/assets/scripts/tmux-theme.sh
@@ -15,6 +15,7 @@
 # including custom packs whose role taxonomy differs from gastown's. Same
 # pattern as cycle.sh (#1571) and bind-key.sh (#1573).
 SESSION="$1" AGENT="$2" CONFIGDIR="$3"
+city="${GC_CITY:-${GT_ROOT:-${GC_DIR:-}}}"
 
 # Socket-aware tmux command (uses GC_TMUX_SOCKET when set).
 gcmux() { tmux ${GC_TMUX_SOCKET:+-L "$GC_TMUX_SOCKET"} "$@"; }
@@ -50,7 +51,11 @@ gcmux set-option -t "$SESSION" status-left-length 25
 gcmux set-option -t "$SESSION" status-left "$icon $AGENT "
 gcmux set-option -t "$SESSION" status-right-length 80
 gcmux set-option -t "$SESSION" status-interval 5
-gcmux set-option -t "$SESSION" status-right "#($CONFIGDIR/assets/scripts/status-line.sh $AGENT) %H:%M"
+if [ -n "$city" ]; then
+    gcmux set-option -t "$SESSION" status-right "#($CONFIGDIR/assets/scripts/status-line.sh $AGENT $city) %H:%M"
+else
+    gcmux set-option -t "$SESSION" status-right "#($CONFIGDIR/assets/scripts/status-line.sh $AGENT) %H:%M"
+fi
 
 # Mouse + clipboard.
 gcmux set-option -t "$SESSION" mouse on

--- a/gastown/tests/test_gastown_theme_scripts.sh
+++ b/gastown/tests/test_gastown_theme_scripts.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+SCRIPTS="$ROOT/gastown/assets/scripts"
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+write_count_stubs() {
+    local bin="$1"
+    mkdir -p "$bin"
+
+    cat >"$bin/timeout" <<'SH'
+#!/usr/bin/env sh
+shift
+exec "$@"
+SH
+    chmod +x "$bin/timeout"
+
+    cat >"$bin/jq" <<'SH'
+#!/usr/bin/env sh
+input=$(cat)
+case "$input" in
+    "[{},{}]") printf '2\n' ;;
+    "[{}]") printf '1\n' ;;
+    "[]") printf '0\n' ;;
+    *) printf '0\n' ;;
+esac
+SH
+    chmod +x "$bin/jq"
+
+    cat >"$bin/bd" <<'SH'
+#!/usr/bin/env sh
+printf '%s\t%s\n' "$PWD" "$*" >>"$BD_LOG"
+case "$PWD $*" in
+    *city-a*" --label gc:nudge "*) printf '[{},{}]\n' ;;
+    *city-a*" --type message "*) printf '[{}]\n' ;;
+    *city-b*" --label gc:nudge "*) printf '[{}]\n' ;;
+    *city-b*" --type message "*) printf '[]\n' ;;
+    *) printf '[]\n' ;;
+esac
+SH
+    chmod +x "$bin/bd"
+}
+
+test_status_line_counts_with_bounded_bd_queries_and_cache() {
+    local tmp city bin cache log output
+    tmp=$(mktemp -d)
+    city="$tmp/city-a"
+    bin="$tmp/bin"
+    cache="$tmp/cache"
+    log="$tmp/bd.log"
+    mkdir -p "$city" "$cache"
+    write_count_stubs "$bin"
+
+    if ! output=$(BD_LOG="$log" GC_STATUSLINE_CACHE_DIR="$cache" PATH="$bin:$PATH" "$SCRIPTS/status-line.sh" alpha "$city"); then
+        fail "status-line exited non-zero"
+    fi
+
+    [[ "$output" == "alpha | 🪝 2 | 📬 1" ]] || fail "unexpected status output: $output"
+    grep -F "$city" "$log" >/dev/null || fail "bd was not run from city path"
+    grep -F -- "list --include-infra --label gc:nudge --status open --metadata-field agent=alpha --json --limit 0" "$log" >/dev/null ||
+        fail "missing bounded nudge query"
+    grep -F -- "list --include-infra --type message --status open --assignee alpha --json --limit 0" "$log" >/dev/null ||
+        fail "missing bounded message query"
+
+    : >"$log"
+    if ! output=$(BD_LOG="$log" GC_STATUSLINE_CACHE_DIR="$cache" PATH="$bin:$PATH" "$SCRIPTS/status-line.sh" alpha "$city"); then
+        fail "status-line exited non-zero on cache hit"
+    fi
+
+    [[ "$output" == "alpha | 🪝 2 | 📬 1" ]] || fail "unexpected cached status output: $output"
+    [[ ! -s "$log" ]] || fail "cache hit still called bd"
+}
+
+test_status_line_cache_is_city_scoped() {
+    local tmp city_a city_b bin cache log output
+    tmp=$(mktemp -d)
+    city_a="$tmp/city-a"
+    city_b="$tmp/city-b"
+    bin="$tmp/bin"
+    cache="$tmp/cache"
+    log="$tmp/bd.log"
+    mkdir -p "$city_a" "$city_b" "$cache"
+    write_count_stubs "$bin"
+
+    BD_LOG="$log" GC_STATUSLINE_CACHE_DIR="$cache" PATH="$bin:$PATH" "$SCRIPTS/status-line.sh" alpha "$city_a" >/dev/null
+
+    if ! output=$(BD_LOG="$log" GC_STATUSLINE_CACHE_DIR="$cache" PATH="$bin:$PATH" "$SCRIPTS/status-line.sh" alpha "$city_b"); then
+        fail "status-line exited non-zero for second city"
+    fi
+
+    [[ "$output" == "alpha | 🪝 1" ]] || fail "cache was not city scoped, got: $output"
+    grep -F "$city_b" "$log" >/dev/null || fail "second city did not run its own query"
+}
+
+test_status_line_falls_back_to_agent_only_on_query_failure() {
+    local tmp bin cache output
+    tmp=$(mktemp -d)
+    bin="$tmp/bin"
+    cache="$tmp/cache"
+    mkdir -p "$bin" "$cache"
+
+    cat >"$bin/bd" <<'SH'
+#!/usr/bin/env sh
+exit 2
+SH
+    chmod +x "$bin/bd"
+    cat >"$bin/jq" <<'SH'
+#!/usr/bin/env sh
+exit 2
+SH
+    chmod +x "$bin/jq"
+
+    if ! output=$(GC_STATUSLINE_CACHE_DIR="$cache" PATH="$bin:$PATH" "$SCRIPTS/status-line.sh" alpha "$tmp"); then
+        fail "status-line exited non-zero on query failure"
+    fi
+
+    [[ "$output" == "alpha" ]] || fail "expected fallback status output, got: $output"
+}
+
+test_tmux_theme_passes_city_path_to_status_helper() {
+    local tmp bin log city
+    tmp=$(mktemp -d)
+    bin="$tmp/bin"
+    log="$tmp/tmux.log"
+    city="$tmp/city"
+    mkdir -p "$bin" "$city"
+
+    cat >"$bin/tmux" <<'SH'
+#!/usr/bin/env sh
+printf '%s\n' "$*" >>"$TMUX_LOG"
+SH
+    chmod +x "$bin/tmux"
+
+    GC_CITY="$city" TMUX_LOG="$log" PATH="$bin:$PATH" "$SCRIPTS/tmux-theme.sh" session-alpha alpha "$ROOT/gastown"
+
+    grep -F -- "status-right #($ROOT/gastown/assets/scripts/status-line.sh alpha $city) %H:%M" "$log" >/dev/null ||
+        fail "tmux-theme did not pass city path to status-line"
+}
+
+test_status_line_counts_with_bounded_bd_queries_and_cache
+test_status_line_cache_is_city_scoped
+test_status_line_falls_back_to_agent_only_on_query_failure
+test_tmux_theme_passes_city_path_to_status_helper
+
+echo "gastown theme script tests passed"

--- a/gastown/tests/test_gastown_theme_scripts.sh
+++ b/gastown/tests/test_gastown_theme_scripts.sh
@@ -20,33 +20,21 @@ exec "$@"
 SH
     chmod +x "$bin/timeout"
 
-    cat >"$bin/jq" <<'SH'
+    cat >"$bin/gc" <<'SH'
 #!/usr/bin/env sh
-input=$(cat)
-case "$input" in
-    "[{},{}]") printf '2\n' ;;
-    "[{}]") printf '1\n' ;;
-    "[]") printf '0\n' ;;
-    *) printf '0\n' ;;
-esac
-SH
-    chmod +x "$bin/jq"
-
-    cat >"$bin/bd" <<'SH'
-#!/usr/bin/env sh
-printf '%s\t%s\n' "$PWD" "$*" >>"$BD_LOG"
+printf '%s\t%s\n' "$PWD" "$*" >>"$GC_LOG"
 case "$PWD $*" in
-    *city-a*" --label gc:nudge "*) printf '[{},{}]\n' ;;
-    *city-a*" --type message "*) printf '[{}]\n' ;;
-    *city-b*" --label gc:nudge "*) printf '[{}]\n' ;;
-    *city-b*" --type message "*) printf '[]\n' ;;
-    *) printf '[]\n' ;;
+    *city-a*" hook alpha") printf '[{"id":"work-a"},{"id":"work-b"}]' ;;
+    *city-a*" mail check alpha") printf '1 unread message\n' ;;
+    *city-b*" hook alpha") printf '[{"id":"work-a"}]' ;;
+    *city-b*" mail check alpha") printf '0 unread messages\n' ;;
+    *) printf '[]' ;;
 esac
 SH
-    chmod +x "$bin/bd"
+    chmod +x "$bin/gc"
 }
 
-test_status_line_counts_with_bounded_bd_queries_and_cache() {
+test_status_line_counts_with_bounded_gc_commands_and_cache() {
     local tmp city bin cache log output
     tmp=$(mktemp -d)
     city="$tmp/city-a"
@@ -56,24 +44,22 @@ test_status_line_counts_with_bounded_bd_queries_and_cache() {
     mkdir -p "$city" "$cache"
     write_count_stubs "$bin"
 
-    if ! output=$(BD_LOG="$log" GC_STATUSLINE_CACHE_DIR="$cache" PATH="$bin:$PATH" "$SCRIPTS/status-line.sh" alpha "$city"); then
+    if ! output=$(GC_LOG="$log" GC_STATUSLINE_CACHE_DIR="$cache" PATH="$bin:$PATH" "$SCRIPTS/status-line.sh" alpha "$city"); then
         fail "status-line exited non-zero"
     fi
 
     [[ "$output" == "alpha | 🪝 2 | 📬 1" ]] || fail "unexpected status output: $output"
-    grep -F "$city" "$log" >/dev/null || fail "bd was not run from city path"
-    grep -F -- "list --include-infra --label gc:nudge --status open --metadata-field agent=alpha --json --limit 0" "$log" >/dev/null ||
-        fail "missing bounded nudge query"
-    grep -F -- "list --include-infra --type message --status open --assignee alpha --json --limit 0" "$log" >/dev/null ||
-        fail "missing bounded message query"
+    grep -F "$city" "$log" >/dev/null || fail "gc was not run from city path"
+    grep -F -- $'\thook alpha' "$log" >/dev/null || fail "missing bounded hook query"
+    grep -F -- $'\tmail check alpha' "$log" >/dev/null || fail "missing bounded mail check query"
 
     : >"$log"
-    if ! output=$(BD_LOG="$log" GC_STATUSLINE_CACHE_DIR="$cache" PATH="$bin:$PATH" "$SCRIPTS/status-line.sh" alpha "$city"); then
+    if ! output=$(GC_LOG="$log" GC_STATUSLINE_CACHE_DIR="$cache" PATH="$bin:$PATH" "$SCRIPTS/status-line.sh" alpha "$city"); then
         fail "status-line exited non-zero on cache hit"
     fi
 
     [[ "$output" == "alpha | 🪝 2 | 📬 1" ]] || fail "unexpected cached status output: $output"
-    [[ ! -s "$log" ]] || fail "cache hit still called bd"
+    [[ ! -s "$log" ]] || fail "cache hit still called gc"
 }
 
 test_status_line_cache_is_city_scoped() {
@@ -87,9 +73,9 @@ test_status_line_cache_is_city_scoped() {
     mkdir -p "$city_a" "$city_b" "$cache"
     write_count_stubs "$bin"
 
-    BD_LOG="$log" GC_STATUSLINE_CACHE_DIR="$cache" PATH="$bin:$PATH" "$SCRIPTS/status-line.sh" alpha "$city_a" >/dev/null
+    GC_LOG="$log" GC_STATUSLINE_CACHE_DIR="$cache" PATH="$bin:$PATH" "$SCRIPTS/status-line.sh" alpha "$city_a" >/dev/null
 
-    if ! output=$(BD_LOG="$log" GC_STATUSLINE_CACHE_DIR="$cache" PATH="$bin:$PATH" "$SCRIPTS/status-line.sh" alpha "$city_b"); then
+    if ! output=$(GC_LOG="$log" GC_STATUSLINE_CACHE_DIR="$cache" PATH="$bin:$PATH" "$SCRIPTS/status-line.sh" alpha "$city_b"); then
         fail "status-line exited non-zero for second city"
     fi
 
@@ -104,16 +90,11 @@ test_status_line_falls_back_to_agent_only_on_query_failure() {
     cache="$tmp/cache"
     mkdir -p "$bin" "$cache"
 
-    cat >"$bin/bd" <<'SH'
+    cat >"$bin/gc" <<'SH'
 #!/usr/bin/env sh
 exit 2
 SH
-    chmod +x "$bin/bd"
-    cat >"$bin/jq" <<'SH'
-#!/usr/bin/env sh
-exit 2
-SH
-    chmod +x "$bin/jq"
+    chmod +x "$bin/gc"
 
     if ! output=$(GC_STATUSLINE_CACHE_DIR="$cache" PATH="$bin:$PATH" "$SCRIPTS/status-line.sh" alpha "$tmp"); then
         fail "status-line exited non-zero on query failure"
@@ -122,12 +103,94 @@ SH
     [[ "$output" == "alpha" ]] || fail "expected fallback status output, got: $output"
 }
 
+test_status_line_counts_ready_work_not_queued_nudges() {
+    local tmp city bin cache output
+    tmp=$(mktemp -d)
+    city="$tmp/city"
+    bin="$tmp/bin"
+    cache="$tmp/cache"
+    mkdir -p "$city" "$bin" "$cache"
+
+    cat >"$bin/timeout" <<'SH'
+#!/usr/bin/env sh
+shift
+exec "$@"
+SH
+    chmod +x "$bin/timeout"
+
+    cat >"$bin/gc" <<'SH'
+#!/usr/bin/env sh
+case "$*" in
+    "hook alpha") printf '[{"id":"ready-work"}]' ;;
+    "mail check alpha") printf '0 unread messages\n' ;;
+    "hook beta") printf '[]' ;;
+    "mail check beta") printf '0 unread messages\n' ;;
+esac
+SH
+    chmod +x "$bin/gc"
+
+    cat >"$bin/bd" <<'SH'
+#!/usr/bin/env sh
+printf '[]\n'
+SH
+    chmod +x "$bin/bd"
+
+    if ! output=$(GC_STATUSLINE_CACHE_DIR="$cache" PATH="$bin:$PATH" "$SCRIPTS/status-line.sh" alpha "$city"); then
+        fail "status-line exited non-zero for ready-work semantics"
+    fi
+
+    [[ "$output" == "alpha | 🪝 1" ]] || fail "expected ready work count from gc hook, got: $output"
+
+    if ! output=$(GC_STATUSLINE_CACHE_DIR="$cache" PATH="$bin:$PATH" "$SCRIPTS/status-line.sh" beta "$city"); then
+        fail "status-line exited non-zero for idle ready-work semantics"
+    fi
+
+    [[ "$output" == "beta" ]] || fail "expected empty hook array to be omitted, got: $output"
+}
+
+test_status_line_uses_unread_mail_check_semantics() {
+    local tmp city bin cache output
+    tmp=$(mktemp -d)
+    city="$tmp/city"
+    bin="$tmp/bin"
+    cache="$tmp/cache"
+    mkdir -p "$city" "$bin" "$cache"
+
+    cat >"$bin/timeout" <<'SH'
+#!/usr/bin/env sh
+shift
+exec "$@"
+SH
+    chmod +x "$bin/timeout"
+
+    cat >"$bin/gc" <<'SH'
+#!/usr/bin/env sh
+case "$*" in
+    "hook alpha") printf '[]' ;;
+    "mail check alpha") printf '0 unread messages\n' ;;
+esac
+SH
+    chmod +x "$bin/gc"
+
+    cat >"$bin/bd" <<'SH'
+#!/usr/bin/env sh
+printf '[{"labels":["read"]}]\n'
+SH
+    chmod +x "$bin/bd"
+
+    if ! output=$(GC_STATUSLINE_CACHE_DIR="$cache" PATH="$bin:$PATH" "$SCRIPTS/status-line.sh" alpha "$city"); then
+        fail "status-line exited non-zero for unread mail semantics"
+    fi
+
+    [[ "$output" == "alpha" ]] || fail "expected read mail to be omitted, got: $output"
+}
+
 test_tmux_theme_passes_city_path_to_status_helper() {
     local tmp bin log city
     tmp=$(mktemp -d)
     bin="$tmp/bin"
     log="$tmp/tmux.log"
-    city="$tmp/city"
+    city="$tmp/city with spaces"
     mkdir -p "$bin" "$city"
 
     cat >"$bin/tmux" <<'SH'
@@ -138,13 +201,15 @@ SH
 
     GC_CITY="$city" TMUX_LOG="$log" PATH="$bin:$PATH" "$SCRIPTS/tmux-theme.sh" session-alpha alpha "$ROOT/gastown"
 
-    grep -F -- "status-right #($ROOT/gastown/assets/scripts/status-line.sh alpha $city) %H:%M" "$log" >/dev/null ||
-        fail "tmux-theme did not pass city path to status-line"
+    grep -F -- "status-right #('$ROOT/gastown/assets/scripts/status-line.sh' 'alpha' '$city') %H:%M" "$log" >/dev/null ||
+        fail "tmux-theme did not quote and pass city path to status-line"
 }
 
-test_status_line_counts_with_bounded_bd_queries_and_cache
+test_status_line_counts_with_bounded_gc_commands_and_cache
 test_status_line_cache_is_city_scoped
 test_status_line_falls_back_to_agent_only_on_query_failure
+test_status_line_counts_ready_work_not_queued_nudges
+test_status_line_uses_unread_mail_check_semantics
 test_tmux_theme_passes_city_path_to_status_helper
 
 echo "gastown theme script tests passed"


### PR DESCRIPTION
## Summary

Supersedes #16 and #70 with a current-tree synthesis for the `gastown/` pack.

The standalone `tmux-theme/` pack no longer exists on `origin/main`, so this does not resurrect those deleted files. Instead, it carries the useful behavior into `gastown/assets/scripts`.

## What changed

- Replaces per-render `gc hook` / `gc mail check` calls with bounded read-only `bd list --json --limit 0` queries.
- Adds a short statusline TTL cache with `GC_STATUSLINE_TTL`, using `date`/`stat` freshness checks.
- Scopes cache entries by city path and agent so same-named agents in different cities do not share stale counts.
- Passes the active city path from `tmux-theme.sh` into `status-line.sh` so tmux refreshes do not depend on the tmux server cwd.
- Keeps the Gastown direct socket-scoped `bind-key.sh` behavior unchanged.
- Adds focused shell regression coverage for bounded queries, cache hits, city-scoped cache keys, failure fallback, and city-path wiring.

## Thanks

Thanks to @jerebrow-orcl for #16, which identified the safer bounded Beads query approach and the city-path/status-helper reliability issues.

Thanks to @Wldc4rd for #70, which measured the statusline fork storm and proposed the TTL cache that makes repeated tmux renders cheap.

## Validation

- `bash gastown/tests/test_gastown_theme_scripts.sh`
- `bash -n gastown/assets/scripts/status-line.sh gastown/assets/scripts/tmux-theme.sh gastown/assets/scripts/bind-key.sh gastown/tests/test_gastown_theme_scripts.sh`
- `GC_PACK_DIR=gastown bash gastown/doctor/check-scripts/run.sh`
- `git diff --check`
