### PR TITLE
chore(gastown): move dog shutdown behavior into pack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,12 @@ jobs:
       - name: Run Python pack tests
         run: python3 -m pytest tests gascity/tests discord/tests github/tests slack-full/tests slack-channel/tests -q
 
+      - name: Run Gastown shell tests
+        run: |
+          for test_script in gastown/tests/test_*.sh; do
+            bash "$test_script"
+          done
+
       - name: Run Slack full adapter tests
         working-directory: slack-full/adapter
         run: go test ./...

--- a/gastown/README.md
+++ b/gastown/README.md
@@ -1,0 +1,79 @@
+# Gastown Pack
+
+Gastown is the domain-specific coding workflow pack. It provides the city
+coordinator roles, rig worker roles, patrol formulas, and the pack-local dog
+pool used for stuck-agent shutdown warrants.
+
+## Import
+
+```toml
+[imports.gastown]
+source = "../packs/gastown"
+```
+
+Use the pack as the workspace pack for city-scoped agents and as a rig pack for
+rig-scoped agents.
+
+## Composition Ordering (when maintenance is present)
+
+The Gas City maintenance pack still ships a legacy `mol-shutdown-dance`
+(required `warrant_id` var, raw `{{target}}` placeholders, PARDON mail to the
+requester). Formula names resolve last-wins across pack formula layers, so
+whichever pack's formula layer loads last decides which recipe dogs run. The
+dog agent resolves to gastown's wherever the dog names collide (legacy
+includes composition: non-fallback wins over the maintenance fallback dog);
+in import composition gastown's dog is a distinct `gastown.dog` agent and the
+implicit maintenance dog remains a dormant, unused fallback pool. Until the
+legacy maintenance copy is retired or renamed upstream, the formula the dog
+reads back depends on composition style:
+
+- **Schema-2 cities composing gastown via `[imports.gastown]`** (the style
+  shown in Import above) are safe by default: the runtime expands the
+  implicit maintenance system pack with the legacy includes pass, before any
+  `[imports.X]` layers, so gastown's formula layer loads after maintenance's
+  and wins. Do **not** add an explicit `[imports.maintenance]` alongside
+  `[imports.gastown]`: an explicit import suppresses the implicit injection
+  and moves maintenance into the import expansion, where binding names expand
+  in sorted order (`"gastown"` < `"maintenance"`), so the legacy maintenance
+  recipe would load last and win no matter where it is written in the file.
+  If maintenance must be pinned explicitly anyway, only the import binding
+  name's sort position relative to `gastown` controls layer order — too
+  fragile to rely on; prefer the implicit injection.
+- **Legacy schema-1 cities composing through `workspace.includes`** are
+  exposed by default: the implicit maintenance injection lands after the
+  user includes, so the legacy recipe wins. Compose maintenance explicitly
+  (an explicit entry suppresses the implicit system injection of the same
+  pack name) and list it before gastown in the same includes list, so
+  gastown's formula layer loads after maintenance's.
+
+Whichever style applies, verify which recipe wins after composing:
+
+```bash
+gc formula show mol-shutdown-dance
+```
+
+The effective recipe must read warrant metadata from the claimed bead via
+`$GC_BEAD_ID` and must not declare a required `warrant_id` var. If it
+demands `warrant_id`, the legacy maintenance copy won — remove the explicit
+maintenance import (schema-2) or fix the include ordering (legacy includes)
+before running dogs.
+
+The same last-wins ordering governs template fragments: maintenance ships
+diverging copies of the `propulsion-dog`, `architecture`, and `following-mol`
+fragments used by the dog prompt, so the per-style guidance above also keeps
+gastown's fragment text authoritative.
+
+## Dog Pool
+
+Gastown owns `mol-shutdown-dance` and the dog agent that runs stuck-agent
+warrants, including the dog's `wake_mode` and `work_dir` settings. Where dog
+names collide (legacy includes composition), gastown's non-fallback dog wins
+over fallback dog providers; in import composition gastown's dog expands as
+the distinct `gastown.dog` agent and the implicit maintenance dog remains a
+dormant fallback pool that this pack's binding-prefixed producers never route
+to.
+
+Gastown deliberately does not ship retired dog formulas for JSONL export or
+stale-session reaping. Compose the Gas City maintenance pack or an equivalent
+exec-order provider when a city needs JSONL export, stale-session or stale-data
+cleanup, and Dolt housekeeping.

--- a/gastown/agents/dog/agent.toml
+++ b/gastown/agents/dog/agent.toml
@@ -1,0 +1,6 @@
+scope = "city"
+fallback = true
+nudge = "Check your hook for work assignments."
+idle_timeout = "2h"
+min_active_sessions = 0
+max_active_sessions = 3

--- a/gastown/agents/dog/agent.toml
+++ b/gastown/agents/dog/agent.toml
@@ -1,5 +1,6 @@
 scope = "city"
-fallback = true
+wake_mode = "fresh"
+work_dir = ".gc/agents/dogs/{{.AgentBase}}"
 nudge = "Check your hook for work assignments."
 idle_timeout = "2h"
 min_active_sessions = 0

--- a/gastown/agents/dog/prompt.template.md
+++ b/gastown/agents/dog/prompt.template.md
@@ -1,0 +1,135 @@
+# Dog Context
+
+> **Recovery**: Run `{{ cmd }} prime` after compaction, clear, or new session
+
+{{ template "propulsion-dog" . }}
+
+---
+
+## Your Role: DOG (Utility Agent)
+
+You are a **Dog** — a utility agent in the dog pool. You pick up work
+beads and execute infrastructure maintenance formulas.
+
+Your lifecycle: find work -> execute formula -> close bead -> exit.
+The controller recycles your pool slot when you exit.
+
+**Auto-termination**: When your formula completes, close the bead and
+`exit`. Your session ends. The controller assigns your slot to the next
+queued formula.
+
+{{ template "architecture" . }}
+
+{{ template "following-mol" . }}
+
+### Available Formulas
+
+| Formula | Purpose |
+|---------|---------|
+| `mol-shutdown-dance` | Interrogation protocol for stuck agents |
+
+Core and provider packs may define deterministic exec orders for housekeeping
+such as JSONL export, stale-data cleanup, and Dolt checks. Do not look for
+retired `mol-dog-*` formulas unless a wisp explicitly names one.
+
+If your wisp names a formula not listed above (one that an included
+pack provides, or one the daemon assigned), read its recipe with
+`gc bd formula show <formula-name>`. **Never** locate formula files
+with whole-filesystem searches (`find /`, `find ~`) — they trigger
+macOS TCC permission prompts on protected directories (Documents,
+Desktop, Downloads, removable volumes, network mounts) and produce
+no useful signal a `gc` introspection command can't already provide.
+If `gc bd formula show` returns "formula not found", the wisp is
+mis-routed — close the bead with that reason and exit; do not hunt.
+
+---
+
+## The Shutdown Dance
+
+Your primary formula is `mol-shutdown-dance` — a 3-attempt interrogation
+protocol that gives stuck agents multiple chances to prove they're alive
+before killing the session.
+
+| Attempt | Timeout | Message |
+|---------|---------|---------|
+| 1 | 60s | Health check via `gc session nudge` |
+| 2 | 120s | Second health check |
+| 3 | 240s | Final warning |
+
+**If the agent responds ALIVE (or shows active output):** Pardon —
+close the warrant, notify the requester, exit.
+
+**If no response after 3 attempts (420s total):** Execute — send
+`gc session kill <target>`, close the warrant, notify, exit.
+
+This is due process, not summary execution. The timeouts give agents
+ample opportunity to respond even if they're in long-running operations.
+
+---
+
+## Completing Work
+
+**CRITICAL**: When you finish, you MUST close your work and exit:
+
+```bash
+gc bd close <work-bead>    # Close your assigned work
+gc runtime drain-ack    # Signal reconciler you're done
+exit                     # Return to pool (controller recycles you)
+```
+
+Without closing and exiting, you'll be stuck in "working" state forever
+and the pool can't recycle your slot.
+
+---
+
+## Communication
+
+```bash
+gc session nudge <target> "message"                # Nudge an agent
+gc session peek <target> --lines 50                # View agent output
+gc session list                                    # Check agent status
+```
+
+### Communication: Nudge Only, Zero Mail
+
+**Dogs NEVER send mail.** Your results go to:
+1. Event beads (for audit trail)
+2. `gc session nudge deacon/ "DOG_DONE: <warrant> <result>"` (for immediate notification)
+3. Escalation via `gc mail send mayor/` ONLY for unresolvable problems
+
+**Never use `gc mail send` for routine reporting.** Every mail creates a permanent
+Dolt commit. Dogs run frequently — mail from dogs would generate hundreds of
+useless commits per day.
+
+### DOG_DONE Notification
+
+When you complete a warrant (pardon or execute), notify the requester
+via nudge:
+
+```bash
+gc session nudge {{"{{requester}}"}}/ "DOG_DONE: <target> — <outcome>"
+```
+
+---
+
+## Command Quick-Reference
+
+### Dog-Specific Commands
+
+| Want to... | Correct command |
+|------------|----------------|
+| Read formula steps | `gc bd show <wisp-id>` (shows formula ref) |
+| Read formula recipe | `gc bd formula show <formula-name>` (NOT `find /`) |
+| Find pool work | `{{ .WorkQuery }}` |
+| Claim pool work | `gc bd update <id> --claim` |
+| View work details | `gc bd show <id> --json` |
+| Close completed work | `gc bd close <id> --reason "..."` |
+| Request target restart | `gc session kill <target>` |
+| List orphan databases | `gc dolt cleanup` |
+| Remove orphan databases | `gc dolt cleanup --force` (safe via SQL DROP when dolt is up) |
+| Remove orphan databases (dolt stopped) | `gc dolt cleanup --force --server-down-ok` (**operator/TTY-only**; do **not** use from autonomous/agent contexts — the rm fallback corrupts NBS state if dolt is actually running, #1549) |
+| Exit (return to pool) | `gc runtime drain-ack && exit` |
+
+Working directory: {{ .WorkDir }}
+Mail identity: dog/{{ basename .AgentName }}
+Formulas: mol-shutdown-dance

--- a/gastown/agents/dog/prompt.template.md
+++ b/gastown/agents/dog/prompt.template.md
@@ -50,6 +50,11 @@ Your primary formula is `mol-shutdown-dance` — a 3-attempt interrogation
 protocol that gives stuck agents multiple chances to prove they're alive
 before killing the session.
 
+When your claimed work bead is a warrant, that bead is the shutdown-dance
+warrant. Use `$GC_BEAD_ID` as the warrant id, and read `target`, `reason`,
+and `requester` from the claimed bead metadata. Existing warrant producers do
+not provide a separate `warrant_id`.
+
 | Attempt | Timeout | Message |
 |---------|---------|---------|
 | 1 | 60s | Health check via `gc session nudge` |
@@ -94,7 +99,8 @@ gc session list                                    # Check agent status
 
 **Dogs NEVER send mail.** Your results go to:
 1. Event beads (for audit trail)
-2. `gc session nudge deacon/ "DOG_DONE: <warrant> <result>"` (for immediate notification)
+2. `gc session nudge "$requester_endpoint" "DOG_DONE: <warrant> <result>"` — the
+   warrant's requester (deacon, witness, or boot), never a hardcoded recipient
 3. Escalation via `gc mail send mayor/` ONLY for unresolvable problems
 
 **Never use `gc mail send` for routine reporting.** Every mail creates a permanent
@@ -104,10 +110,12 @@ useless commits per day.
 ### DOG_DONE Notification
 
 When you complete a warrant (pardon or execute), notify the requester
-via nudge:
+via nudge, using the normalized endpoint from the formula preamble
+(the warrant's `requester` metadata with exactly one trailing slash,
+`requester_endpoint="${requester%/}/"`):
 
 ```bash
-gc session nudge {{"{{requester}}"}}/ "DOG_DONE: <target> — <outcome>"
+gc session nudge "$requester_endpoint" "DOG_DONE: <target> — <outcome>"
 ```
 
 ---

--- a/gastown/formulas/mol-shutdown-dance.toml
+++ b/gastown/formulas/mol-shutdown-dance.toml
@@ -1,0 +1,274 @@
+description = """
+Shutdown dance — due process for stuck agents.
+
+Dispatched by filing a warrant bead routed to the dog pool:
+
+```bash
+gc bd create --type=task \
+  --title="Stuck: <agent>" \
+  --metadata '{"target":"<session>","reason":"<reason>","requester":"<who>","gc.routed_to":"<binding-prefix>dog"}' \
+  --label=warrant
+```
+
+The dog pool picks up the warrant and pours this formula. Each wisp is
+one shutdown dance for one target. On crash, re-read formula steps and
+resume from context (check target state, attempt history).
+
+## State Machine
+
+```
+RECEIVE → INTERROGATE (1) → INTERROGATE (2) → INTERROGATE (3) → EXECUTE → EPITAPH
+              ↓                   ↓                   ↓
+           ALIVE?             ALIVE?              ALIVE?
+              ↓                   ↓                   ↓
+           [yes → EPITAPH with PARDONED]          [no → EXECUTE]
+```
+
+## Timeouts
+
+| Attempt | Timeout | Cumulative |
+|---------|---------|------------|
+| 1       | 60s     | 60s        |
+| 2       | 120s    | 180s (3m)  |
+| 3       | 240s    | 420s (7m)  |
+
+## Who files warrants
+
+| Detector | Stuck agent | Detection method |
+|----------|-------------|-----------------|
+| Deacon health-scan | Witness | Stale patrol wisp |
+| Deacon health-scan | Refinery | Stale wisp + queue has work |
+| Deacon utility-agent-health | Dog | Stale wisp/bead |
+| Witness check-polecat-health | Polecat | Stale work bead, no progress |
+
+No agent kills anything directly. The shutdown dance is the single
+recovery mechanism for all stuck agents.
+
+Read each step's description before acting — Config values override defaults."""
+formula = "mol-shutdown-dance"
+version = 1
+
+[vars]
+[vars.warrant_id]
+description = "Bead ID of the warrant being processed (from metadata on the wisp)"
+required = true
+
+[vars.target]
+description = "Session name of the agent to interrogate"
+required = true
+
+[vars.reason]
+description = "Why the warrant was filed"
+required = true
+
+[vars.requester]
+description = "Who filed the warrant (deacon, witness, etc.)"
+default = "deacon"
+
+[[steps]]
+id = "receive-warrant"
+title = "Validate warrant and confirm target alive"
+description = """
+Entry point. Read the warrant metadata from your wisp.
+
+**1. Read warrant details:**
+```bash
+gc bd show <wisp-id> --json | jq '.[0].metadata'
+```
+Extract: `target`, `reason`, `requester`, `warrant_id`.
+
+**2. Verify the warrant bead exists and is open:**
+```bash
+gc bd show {{warrant_id}} --json | jq '.[0].status'
+```
+If warrant is already closed (another dog handled it, or requester
+cancelled): close this step, burn the wisp, exit.
+
+**3. Check if target session is alive:**
+```bash
+gc session peek {{target}} --lines 1
+```
+If target session doesn't exist (already dead):
+- Close warrant: `gc bd close {{warrant_id}} --reason "Target already dead"`
+- Send DOG_DONE mail to requester
+- Burn this wisp, exit
+
+**4. If target is alive:** close this step and proceed to interrogation."""
+
+[[steps]]
+id = "interrogate-1"
+title = "First health check (60s timeout)"
+needs = ["receive-warrant"]
+description = """
+First attempt to contact the stuck agent. Give it 60 seconds.
+
+**1. Send health check via nudge:**
+```bash
+gc session nudge {{target}} "[DOG] HEALTH CHECK: Respond ALIVE within 60s or face termination.
+Warrant: {{warrant_id}}
+Reason: {{reason}}
+Filed by: {{requester}}
+Attempt: 1/3"
+```
+
+**2. Wait 60 seconds:**
+```bash
+sleep 60
+```
+
+**3. Check for response:**
+```bash
+gc session peek {{target}} --lines 50
+```
+
+Look for the ALIVE keyword in the output after your health check message.
+Also check for any sign of active work (new tool calls, output being
+generated). Use judgment — explicit "ALIVE" is definitive, but active
+output also indicates the agent is functioning.
+
+**4. If ALIVE or active:**
+- Close warrant: `gc bd close {{warrant_id}} --reason "Session responded at attempt 1"`
+- Send mail: `gc mail send {{requester}}/ -s "PARDON: {{target}}" -m "Responded after attempt 1"`
+- Burn wisp, exit
+
+**5. If no response:** close this step, proceed to interrogation-2."""
+
+[[steps]]
+id = "interrogate-2"
+title = "Second health check (120s timeout)"
+needs = ["interrogate-1"]
+description = """
+Second attempt with longer timeout. Only reached if first attempt
+got no response.
+
+**1. Send health check:**
+```bash
+gc session nudge {{target}} "[DOG] HEALTH CHECK: Respond ALIVE within 120s or face termination.
+Warrant: {{warrant_id}}
+Reason: {{reason}}
+Filed by: {{requester}}
+Attempt: 2/3"
+```
+
+**2. Wait 120 seconds:**
+```bash
+sleep 120
+```
+
+**3. Check for response:**
+```bash
+gc session peek {{target}} --lines 50
+```
+
+Same evaluation as attempt 1: ALIVE keyword or active output.
+
+**4. If ALIVE or active:**
+- Close warrant: `gc bd close {{warrant_id}} --reason "Session responded at attempt 2"`
+- Send mail: `gc mail send {{requester}}/ -s "PARDON: {{target}}" -m "Responded after attempt 2"`
+- Burn wisp, exit
+
+**5. If no response:** close this step, proceed to final interrogation."""
+
+[[steps]]
+id = "interrogate-3"
+title = "Final health check (240s timeout)"
+needs = ["interrogate-2"]
+description = """
+Final attempt before execution. 240 seconds — if the agent can't
+respond in 4 minutes after 3 attempts, it's genuinely stuck.
+
+**1. Send health check:**
+```bash
+gc session nudge {{target}} "[DOG] HEALTH CHECK: FINAL WARNING. Respond ALIVE within 240s.
+Warrant: {{warrant_id}}
+Reason: {{reason}}
+Filed by: {{requester}}
+Attempt: 3/3 — session will be terminated if no response"
+```
+
+**2. Wait 240 seconds:**
+```bash
+sleep 240
+```
+
+**3. Check for response:**
+```bash
+gc session peek {{target}} --lines 50
+```
+
+**4. If ALIVE or active:**
+- Close warrant: `gc bd close {{warrant_id}} --reason "Session responded at attempt 3"`
+- Send mail: `gc mail send {{requester}}/ -s "PARDON: {{target}}" -m "Responded after attempt 3 (close call)"`
+- Burn wisp, exit
+
+**5. If no response:** close this step, proceed to execute."""
+
+[[steps]]
+id = "execute"
+title = "Execute warrant — kill session"
+needs = ["interrogate-3"]
+description = """
+Three attempts, no response. Execute the warrant.
+
+**1. Capture final pane output for forensics:**
+```bash
+gc session peek {{target}} --lines 100
+```
+Save this output — it's the last evidence of what the agent was doing.
+
+**2. Kill the session:**
+```bash
+gc session kill {{target}}
+```
+This kills the session directly. The reconciler will see the agent
+has no running session and restart it on the next reconcile tick.
+
+If the kill doesn't take effect (session already dead or provider
+error), escalate:
+```bash
+gc mail send {{requester}}/ -s "EXECUTE_FAILED: {{target}}" \
+  -m "session kill didn't take effect. Agent may need manual intervention."
+```
+
+**3. Record execution on the warrant:**
+```bash
+gc bd close {{warrant_id}} --reason "Executed after 3 failed attempts (420s total)"
+```
+
+Close this step, proceed to epitaph."""
+
+[[steps]]
+id = "epitaph"
+title = "Log outcome, notify, and exit"
+needs = ["execute"]
+description = """
+Final step. Create audit record and exit.
+
+**1. Send DOG_DONE notification to requester:**
+```bash
+gc mail send {{requester}}/ -s "DOG_DONE: {{target}} warrant executed" \
+  -m "Warrant: {{warrant_id}}
+Target: {{target}}
+Reason: {{reason}}
+Outcome: EXECUTED after 3 attempts (60s + 120s + 240s = 420s)
+Action: session killed, reconciler will restart"
+```
+
+**2. Close work bead (if separate from warrant):**
+If your assigned work bead is different from the warrant bead, close it:
+```bash
+gc bd close <work-bead> --reason "Shutdown dance complete: {{target}} executed"
+```
+
+**3. Exit:**
+```bash
+gc runtime drain-ack
+exit
+```
+
+The controller sees you as idle and can assign new work or recycle
+your pool slot.
+
+**Note:** The pardon path (ALIVE detected) exits early from the
+interrogation steps and never reaches this step. This step only
+handles the execution path."""

--- a/gastown/formulas/mol-shutdown-dance.toml
+++ b/gastown/formulas/mol-shutdown-dance.toml
@@ -10,9 +10,31 @@ gc bd create --type=task \
   --label=warrant
 ```
 
-The dog pool picks up the warrant and pours this formula. Each wisp is
-one shutdown dance for one target. On crash, re-read formula steps and
-resume from context (check target state, attempt history).
+The dog pool picks up the warrant and runs this formula against the
+claimed warrant bead. The claimed bead is the warrant id; use
+`$GC_BEAD_ID` for warrant verification, closure, and audit output.
+Existing warrant producers provide `target`, `reason`, and `requester`
+metadata, not a separate `warrant_id`. Each warrant is one shutdown dance
+for one target. On crash, re-read formula steps and resume from context
+(check target state, attempt history).
+
+Before running command snippets in any step, load warrant metadata into quoted
+shell variables:
+
+```bash
+warrant_json="$(gc bd show "$GC_BEAD_ID" --json)"
+target="$(printf '%s' "$warrant_json" | jq -r '.[0].metadata.target // empty')"
+reason="$(printf '%s' "$warrant_json" | jq -r '.[0].metadata.reason // empty')"
+requester="$(printf '%s' "$warrant_json" | jq -r '.[0].metadata.requester // "deacon"')"
+requester_endpoint="${requester%/}/"
+if [ -z "$target" ] || [ -z "$reason" ]; then
+  echo "warrant $GC_BEAD_ID is missing target or reason" >&2
+  gc bd close "$GC_BEAD_ID" --reason "MALFORMED_WARRANT: missing target or reason metadata"
+  gc session nudge "$requester_endpoint" "DOG_DONE: warrant $GC_BEAD_ID - MALFORMED_WARRANT (missing target or reason)" || true
+  gc runtime drain-ack
+  exit 1
+fi
+```
 
 ## State Machine
 
@@ -48,50 +70,59 @@ Read each step's description before acting — Config values override defaults."
 formula = "mol-shutdown-dance"
 version = 1
 
-[vars]
-[vars.warrant_id]
-description = "Bead ID of the warrant being processed (from metadata on the wisp)"
-required = true
-
-[vars.target]
-description = "Session name of the agent to interrogate"
-required = true
-
-[vars.reason]
-description = "Why the warrant was filed"
-required = true
-
-[vars.requester]
-description = "Who filed the warrant (deacon, witness, etc.)"
-default = "deacon"
+# No [vars] block: this formula is not poured with template vars. Dispatch is
+# a claimed task bead, and `target`/`reason`/`requester` are read from the
+# warrant bead's metadata at run time (see the preamble above).
 
 [[steps]]
 id = "receive-warrant"
 title = "Validate warrant and confirm target alive"
 description = """
-Entry point. Read the warrant metadata from your wisp.
+Entry point. Read the warrant metadata from the claimed warrant bead.
 
 **1. Read warrant details:**
 ```bash
-gc bd show <wisp-id> --json | jq '.[0].metadata'
+warrant_json="$(gc bd show "$GC_BEAD_ID" --json)"
+target="$(printf '%s' "$warrant_json" | jq -r '.[0].metadata.target // empty')"
+reason="$(printf '%s' "$warrant_json" | jq -r '.[0].metadata.reason // empty')"
+requester="$(printf '%s' "$warrant_json" | jq -r '.[0].metadata.requester // "deacon"')"
+requester_endpoint="${requester%/}/"
+if [ -z "$target" ] || [ -z "$reason" ]; then
+  echo "warrant $GC_BEAD_ID is missing target or reason" >&2
+  gc bd close "$GC_BEAD_ID" --reason "MALFORMED_WARRANT: missing target or reason metadata"
+  gc session nudge "$requester_endpoint" "DOG_DONE: warrant $GC_BEAD_ID - MALFORMED_WARRANT (missing target or reason)" || true
+  gc runtime drain-ack
+  exit 1
+fi
 ```
-Extract: `target`, `reason`, `requester`, `warrant_id`.
+Extract: `target`, `reason`, and `requester`. The warrant id is the
+claimed work bead, `$GC_BEAD_ID`.
 
-**2. Verify the warrant bead exists and is open:**
+A warrant missing `target` or `reason` is malformed and cannot be danced.
+The branch above is a terminal cleanup path: it closes the claimed warrant
+with a malformed-warrant reason, notifies the requester best-effort, runs
+`gc runtime drain-ack`, and exits. Never bare-exit with the claimed warrant
+still `in_progress` — that leaks the warrant and wedges this pool slot.
+
+**2. Verify the warrant bead exists and is not closed:**
 ```bash
-gc bd show {{warrant_id}} --json | jq '.[0].status'
+gc bd show "$GC_BEAD_ID" --json | jq '.[0].status'
 ```
-If warrant is already closed (another dog handled it, or requester
-cancelled): close this step, burn the wisp, exit.
+Both `open` and `in_progress` are valid warrant states — a claimed
+warrant is normally already `in_progress`. Only `closed` stops the
+dance. If the warrant is already closed (another dog handled it, or
+the requester cancelled), there is nothing to transition: do not
+attempt any step or bead updates against the closed warrant. Run
+`gc runtime drain-ack`, then exit.
 
 **3. Check if target session is alive:**
 ```bash
-gc session peek {{target}} --lines 1
+gc session peek "$target" --lines 1
 ```
 If target session doesn't exist (already dead):
-- Close warrant: `gc bd close {{warrant_id}} --reason "Target already dead"`
-- Send DOG_DONE mail to requester
-- Burn this wisp, exit
+- Close warrant: `gc bd close "$GC_BEAD_ID" --reason "Target already dead"`
+- Nudge requester: `gc session nudge "$requester_endpoint" "DOG_DONE: $target - already dead"`
+- Run `gc runtime drain-ack`, then exit
 
 **4. If target is alive:** close this step and proceed to interrogation."""
 
@@ -104,10 +135,10 @@ First attempt to contact the stuck agent. Give it 60 seconds.
 
 **1. Send health check via nudge:**
 ```bash
-gc session nudge {{target}} "[DOG] HEALTH CHECK: Respond ALIVE within 60s or face termination.
-Warrant: {{warrant_id}}
-Reason: {{reason}}
-Filed by: {{requester}}
+gc session nudge "$target" "[DOG] HEALTH CHECK: Respond ALIVE within 60s or face termination.
+Warrant: $GC_BEAD_ID
+Reason: $reason
+Filed by: $requester
 Attempt: 1/3"
 ```
 
@@ -118,7 +149,7 @@ sleep 60
 
 **3. Check for response:**
 ```bash
-gc session peek {{target}} --lines 50
+gc session peek "$target" --lines 50
 ```
 
 Look for the ALIVE keyword in the output after your health check message.
@@ -127,9 +158,9 @@ generated). Use judgment — explicit "ALIVE" is definitive, but active
 output also indicates the agent is functioning.
 
 **4. If ALIVE or active:**
-- Close warrant: `gc bd close {{warrant_id}} --reason "Session responded at attempt 1"`
-- Send mail: `gc mail send {{requester}}/ -s "PARDON: {{target}}" -m "Responded after attempt 1"`
-- Burn wisp, exit
+- Close warrant: `gc bd close "$GC_BEAD_ID" --reason "Session responded at attempt 1"`
+- Nudge requester: `gc session nudge "$requester_endpoint" "DOG_DONE: $target - PARDONED after attempt 1"`
+- Run `gc runtime drain-ack`, then exit
 
 **5. If no response:** close this step, proceed to interrogation-2."""
 
@@ -143,10 +174,10 @@ got no response.
 
 **1. Send health check:**
 ```bash
-gc session nudge {{target}} "[DOG] HEALTH CHECK: Respond ALIVE within 120s or face termination.
-Warrant: {{warrant_id}}
-Reason: {{reason}}
-Filed by: {{requester}}
+gc session nudge "$target" "[DOG] HEALTH CHECK: Respond ALIVE within 120s or face termination.
+Warrant: $GC_BEAD_ID
+Reason: $reason
+Filed by: $requester
 Attempt: 2/3"
 ```
 
@@ -157,15 +188,15 @@ sleep 120
 
 **3. Check for response:**
 ```bash
-gc session peek {{target}} --lines 50
+gc session peek "$target" --lines 50
 ```
 
 Same evaluation as attempt 1: ALIVE keyword or active output.
 
 **4. If ALIVE or active:**
-- Close warrant: `gc bd close {{warrant_id}} --reason "Session responded at attempt 2"`
-- Send mail: `gc mail send {{requester}}/ -s "PARDON: {{target}}" -m "Responded after attempt 2"`
-- Burn wisp, exit
+- Close warrant: `gc bd close "$GC_BEAD_ID" --reason "Session responded at attempt 2"`
+- Nudge requester: `gc session nudge "$requester_endpoint" "DOG_DONE: $target - PARDONED after attempt 2"`
+- Run `gc runtime drain-ack`, then exit
 
 **5. If no response:** close this step, proceed to final interrogation."""
 
@@ -179,10 +210,10 @@ respond in 4 minutes after 3 attempts, it's genuinely stuck.
 
 **1. Send health check:**
 ```bash
-gc session nudge {{target}} "[DOG] HEALTH CHECK: FINAL WARNING. Respond ALIVE within 240s.
-Warrant: {{warrant_id}}
-Reason: {{reason}}
-Filed by: {{requester}}
+gc session nudge "$target" "[DOG] HEALTH CHECK: FINAL WARNING. Respond ALIVE within 240s.
+Warrant: $GC_BEAD_ID
+Reason: $reason
+Filed by: $requester
 Attempt: 3/3 — session will be terminated if no response"
 ```
 
@@ -193,13 +224,13 @@ sleep 240
 
 **3. Check for response:**
 ```bash
-gc session peek {{target}} --lines 50
+gc session peek "$target" --lines 50
 ```
 
 **4. If ALIVE or active:**
-- Close warrant: `gc bd close {{warrant_id}} --reason "Session responded at attempt 3"`
-- Send mail: `gc mail send {{requester}}/ -s "PARDON: {{target}}" -m "Responded after attempt 3 (close call)"`
-- Burn wisp, exit
+- Close warrant: `gc bd close "$GC_BEAD_ID" --reason "Session responded at attempt 3"`
+- Nudge requester: `gc session nudge "$requester_endpoint" "DOG_DONE: $target - PARDONED after attempt 3"`
+- Run `gc runtime drain-ack`, then exit
 
 **5. If no response:** close this step, proceed to execute."""
 
@@ -212,30 +243,47 @@ Three attempts, no response. Execute the warrant.
 
 **1. Capture final pane output for forensics:**
 ```bash
-gc session peek {{target}} --lines 100
+gc session peek "$target" --lines 100
 ```
 Save this output — it's the last evidence of what the agent was doing.
 
 **2. Kill the session:**
 ```bash
-gc session kill {{target}}
+gc session kill "$target"
 ```
 This kills the session directly. The reconciler will see the agent
 has no running session and restart it on the next reconcile tick.
 
-If the kill doesn't take effect (session already dead or provider
-error), escalate:
+**3. Verify the kill took effect — peek immediately after the kill:**
 ```bash
-gc mail send {{requester}}/ -s "EXECUTE_FAILED: {{target}}" \
-  -m "session kill didn't take effect. Agent may need manual intervention."
+gc session peek "$target" --lines 1
+```
+Compare the output against the step-1 forensic capture. The kill
+succeeded when the session is gone or shows fresh startup output: the
+reconciler may restart a replacement between the kill and this peek,
+and a fresh replacement still means the stuck session died. The kill
+failed only when the session still shows the same pre-kill stuck
+state captured in step 1.
+
+**4. If the kill succeeded, record the execution on the warrant:**
+```bash
+gc bd close "$GC_BEAD_ID" --reason "Executed after 3 failed attempts (420s total)"
 ```
 
-**3. Record execution on the warrant:**
+**5. If the kill did not take effect** (the session still shows the
+pre-kill stuck state, or the kill returned a provider error), do not
+record an execution that did not happen. Escalate to the
+mayor and close the warrant with the failure on the audit record:
 ```bash
-gc bd close {{warrant_id}} --reason "Executed after 3 failed attempts (420s total)"
+gc mail send mayor/ -s "EXECUTE_FAILED: $target" \
+  -m "session kill didn't take effect. Agent may need manual intervention.
+Requester: $requester
+Warrant: $GC_BEAD_ID"
+gc bd close "$GC_BEAD_ID" --reason "EXECUTE_FAILED: kill did not take effect, escalated to mayor"
 ```
 
-Close this step, proceed to epitaph."""
+Close this step, proceed to epitaph. Carry the outcome (EXECUTED or
+EXECUTE_FAILED) into the epitaph notification."""
 
 [[steps]]
 id = "epitaph"
@@ -245,20 +293,31 @@ description = """
 Final step. Create audit record and exit.
 
 **1. Send DOG_DONE notification to requester:**
+
+If the kill took effect (warrant closed as Executed):
 ```bash
-gc mail send {{requester}}/ -s "DOG_DONE: {{target}} warrant executed" \
-  -m "Warrant: {{warrant_id}}
-Target: {{target}}
-Reason: {{reason}}
+gc session nudge "$requester_endpoint" "DOG_DONE: $target - EXECUTED after 3 failed attempts.
+Warrant: $GC_BEAD_ID
+Target: $target
+Reason: $reason
 Outcome: EXECUTED after 3 attempts (60s + 120s + 240s = 420s)
 Action: session killed, reconciler will restart"
 ```
 
-**2. Close work bead (if separate from warrant):**
-If your assigned work bead is different from the warrant bead, close it:
+If the kill did not take effect (warrant closed as EXECUTE_FAILED):
 ```bash
-gc bd close <work-bead> --reason "Shutdown dance complete: {{target}} executed"
+gc session nudge "$requester_endpoint" "DOG_DONE: $target - EXECUTE_FAILED (escalated).
+Warrant: $GC_BEAD_ID
+Target: $target
+Reason: $reason
+Outcome: EXECUTE_FAILED after 3 attempts (60s + 120s + 240s = 420s)
+Action: kill did not take effect; escalated to mayor for manual intervention"
 ```
+The requester signal must match the warrant close reason — never report
+EXECUTED for a target that survived the kill.
+
+**2. Confirm work is closed:**
+The claimed warrant bead is the work bead and was closed in `execute`.
 
 **3. Exit:**
 ```bash

--- a/gastown/pack.toml
+++ b/gastown/pack.toml
@@ -1,12 +1,19 @@
 # Gas Town — domain-specific coding workflow pack.
 #
 # Gastown roles: mayor (coordinator), deacon (patrol), boot (watchdog),
-# plus rig-scoped agents (witness, refinery, polecat).
+# dog (utility recovery), plus rig-scoped agents (witness, refinery, polecat).
 # The host Gas City runtime supplies the implicit maintenance/core utility
-# layer that provides dog workers and mechanical housekeeping.
+# layer for mechanical housekeeping outside the pack-local dog pool. Compose
+# maintenance or an equivalent exec-order provider for JSONL export, stale
+# cleanup, and Dolt housekeeping. Schema-2 import cities must rely on the
+# implicit maintenance injection: adding [imports.maintenance] alongside
+# [imports.gastown] makes the legacy maintenance mol-shutdown-dance win
+# last-wins resolution. Legacy workspace.includes cities composing
+# maintenance explicitly must list it before gastown (see README
+# "Composition Ordering").
 #
 # Referenced by both workspace.pack and rigs[].pack:
-#   workspace.pack → expands city-scoped agents only (mayor, deacon, boot)
+#   workspace.pack → expands city-scoped agents only (mayor, deacon, boot, dog)
 #   rigs[].pack    → expands rig agents only (witness, refinery, polecat)
 #
 # Crew members are individually named and declared inline in city.toml.
@@ -20,11 +27,6 @@ session_live = [
     "{{.ConfigDir}}/assets/scripts/tmux-theme.sh {{.Session}} {{.Agent}} {{.ConfigDir}}",
     "{{.ConfigDir}}/assets/scripts/tmux-keybindings.sh {{.ConfigDir}}",
 ]
-
-[[patches.agent]]
-name = "dog"
-wake_mode = "fresh"
-work_dir = ".gc/agents/dogs/{{.AgentBase}}"
 
 [[named_session]]
 template = "mayor"

--- a/gastown/tests/test_gastown_pack_assets.sh
+++ b/gastown/tests/test_gastown_pack_assets.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+GASTOWN="$ROOT/gastown"
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+test_dog_assets_are_pack_local() {
+    [[ -f "$GASTOWN/agents/dog/agent.toml" ]] || fail "missing dog agent config"
+    [[ -f "$GASTOWN/agents/dog/prompt.template.md" ]] || fail "missing dog prompt"
+    [[ -f "$GASTOWN/formulas/mol-shutdown-dance.toml" ]] || fail "missing shutdown dance formula"
+}
+
+test_retired_dog_formulas_are_not_reintroduced() {
+    [[ ! -e "$GASTOWN/formulas/mol-dog-jsonl.toml" ]] || fail "mol-dog-jsonl formula should remain retired"
+    [[ ! -e "$GASTOWN/formulas/mol-dog-reaper.toml" ]] || fail "mol-dog-reaper formula should remain retired"
+    ! grep -R "mol-dog-jsonl\\|mol-dog-reaper" "$GASTOWN/agents/dog" >/dev/null ||
+        fail "dog prompt should not advertise retired dog formulas"
+}
+
+test_dog_assets_are_pack_local
+test_retired_dog_formulas_are_not_reintroduced
+
+echo "gastown pack asset tests passed"

--- a/gastown/tests/test_gastown_pack_assets.sh
+++ b/gastown/tests/test_gastown_pack_assets.sh
@@ -9,20 +9,129 @@ fail() {
     exit 1
 }
 
+parse_toml() {
+    python3 - "$@" <<'PY'
+import sys
+import tomllib
+
+for path in sys.argv[1:]:
+    with open(path, "rb") as handle:
+        tomllib.load(handle)
+PY
+}
+
 test_dog_assets_are_pack_local() {
     [[ -f "$GASTOWN/agents/dog/agent.toml" ]] || fail "missing dog agent config"
     [[ -f "$GASTOWN/agents/dog/prompt.template.md" ]] || fail "missing dog prompt"
     [[ -f "$GASTOWN/formulas/mol-shutdown-dance.toml" ]] || fail "missing shutdown dance formula"
+    parse_toml "$GASTOWN/agents/dog/agent.toml" "$GASTOWN/formulas/mol-shutdown-dance.toml"
+    grep -F 'wake_mode = "fresh"' "$GASTOWN/agents/dog/agent.toml" >/dev/null ||
+        fail "dog agent should own wake_mode"
+    grep -F 'work_dir = ".gc/agents/dogs/{{.AgentBase}}"' "$GASTOWN/agents/dog/agent.toml" >/dev/null ||
+        fail "dog agent should own work_dir"
+    ! grep -F 'fallback = true' "$GASTOWN/agents/dog/agent.toml" >/dev/null ||
+        fail "gastown dog should be authoritative over fallback dog providers"
+    ! grep -A3 -F '[[patches.agent]]' "$GASTOWN/pack.toml" | grep -F 'name = "dog"' >/dev/null ||
+        fail "dog should not be split between pack-local agent and same-name patch"
+    [[ ! -e "$GASTOWN/agents/dog/overlay/.gitkeep" ]] ||
+        fail "dog overlay placeholder should not be present without an overlay contract"
 }
 
 test_retired_dog_formulas_are_not_reintroduced() {
     [[ ! -e "$GASTOWN/formulas/mol-dog-jsonl.toml" ]] || fail "mol-dog-jsonl formula should remain retired"
     [[ ! -e "$GASTOWN/formulas/mol-dog-reaper.toml" ]] || fail "mol-dog-reaper formula should remain retired"
-    ! grep -R "mol-dog-jsonl\\|mol-dog-reaper" "$GASTOWN/agents/dog" >/dev/null ||
-        fail "dog prompt should not advertise retired dog formulas"
+    ! grep -R --exclude='test_gastown_pack_assets.sh' "mol-dog-jsonl\\|mol-dog-reaper" "$GASTOWN" >/dev/null ||
+        fail "gastown pack should not advertise retired dog formulas"
+}
+
+test_shutdown_dance_contracts_are_executable() {
+    local formula="$GASTOWN/formulas/mol-shutdown-dance.toml"
+
+    ! grep -F '[vars.warrant_id]' "$formula" >/dev/null ||
+        fail "warrant_id should be the claimed work bead, not a required formula var"
+    grep -F 'gc bd show "$GC_BEAD_ID"' "$formula" >/dev/null ||
+        fail "shutdown dance should inspect the claimed warrant bead"
+    grep -F 'gc bd close "$GC_BEAD_ID"' "$formula" >/dev/null ||
+        fail "shutdown dance should close the claimed warrant bead"
+    ! grep -F '<wisp-id>' "$formula" >/dev/null ||
+        fail "shutdown dance should not contain raw wisp placeholders"
+    ! grep -F '<work-bead>' "$formula" >/dev/null ||
+        fail "shutdown dance should not contain raw work bead placeholders"
+    ! grep -F 'gc mail send {{requester}}/' "$formula" >/dev/null ||
+        fail "routine dog requester reporting must use nudge, not mail"
+    grep -F 'requester_endpoint="${requester%/}/"' "$formula" >/dev/null ||
+        fail "shutdown dance should normalize requester endpoints"
+    grep -F 'gc session nudge "$requester_endpoint" "DOG_DONE:' "$formula" >/dev/null ||
+        fail "shutdown dance should notify requester with DOG_DONE nudges"
+    ! grep -F 'gc session peek "{{target}}"' "$formula" >/dev/null ||
+        fail "shutdown dance should use quoted target shell variables for peeks"
+    ! grep -F 'gc session kill "{{target}}"' "$formula" >/dev/null ||
+        fail "shutdown dance should use quoted target shell variables for kills"
+    grep -F 'Verify the warrant bead exists and is not closed' "$formula" >/dev/null ||
+        fail "receive step should verify the warrant is not closed rather than demanding open"
+    grep -F 'Both `open` and `in_progress` are valid warrant states' "$formula" >/dev/null ||
+        fail "receive step should explicitly accept open and in_progress warrant states"
+    ! grep -F 'exists and is open' "$formula" >/dev/null ||
+        fail "receive step must not regress to an open-only warrant instruction; claimed warrants are in_progress"
+}
+
+test_shutdown_dance_lifecycle_and_audit_contracts() {
+    local formula="$GASTOWN/formulas/mol-shutdown-dance.toml"
+    local prompt="$GASTOWN/agents/dog/prompt.template.md"
+
+    ! grep -Fi 'burn' "$formula" >/dev/null ||
+        fail "early-exit paths should drain-ack and exit, not burn a wisp that was never poured"
+    [[ "$(grep -c 'gc runtime drain-ack' "$formula")" -ge 8 ]] ||
+        fail "every early-exit path and the epitaph should end with gc runtime drain-ack"
+    local malformed_branches malformed_closes malformed_drains
+    malformed_branches="$(grep -c 'is missing target or reason' "$formula" || true)"
+    malformed_closes="$(grep -A4 'is missing target or reason' "$formula" | grep -cF 'gc bd close "$GC_BEAD_ID"' || true)"
+    malformed_drains="$(grep -A4 'is missing target or reason' "$formula" | grep -cF 'gc runtime drain-ack' || true)"
+    [[ "$malformed_branches" -ge 1 ]] ||
+        fail "shutdown dance should validate warrant target/reason metadata"
+    [[ "$malformed_closes" -eq "$malformed_branches" ]] ||
+        fail "every malformed-warrant branch must close the claimed warrant before exiting"
+    [[ "$malformed_drains" -eq "$malformed_branches" ]] ||
+        fail "every malformed-warrant branch must drain-ack before exiting, not leak the claimed warrant"
+    grep -F 'MALFORMED_WARRANT' "$formula" >/dev/null ||
+        fail "malformed warrants should close with a malformed-warrant audit reason"
+    ! grep -E '^\[vars' "$formula" >/dev/null ||
+        fail "warrant values come from bead metadata; the formula should not declare pour vars"
+    grep -F 'EXECUTE_FAILED: kill did not take effect' "$formula" >/dev/null ||
+        fail "kill failures should close the warrant as EXECUTE_FAILED, not Executed"
+    grep -F 'DOG_DONE: $target - EXECUTE_FAILED (escalated)' "$formula" >/dev/null ||
+        fail "kill failures should notify the requester with EXECUTE_FAILED, not EXECUTED"
+    grep -F 'gone or shows fresh startup output' "$formula" >/dev/null ||
+        fail "execute verification should treat gone-or-freshly-restarted as kill success"
+    ! grep -F '{{requester}}' "$prompt" >/dev/null ||
+        fail "dog prompt should use the normalized requester endpoint, not raw requester templates"
+    ! grep -F 'nudge deacon/' "$prompt" >/dev/null ||
+        fail "dog prompt should notify the warrant's requester, not a hardcoded deacon endpoint"
+    grep -F 'gc session nudge "$requester_endpoint"' "$prompt" >/dev/null ||
+        fail "dog prompt DOG_DONE guidance should use the normalized requester endpoint"
+}
+
+test_composition_ordering_is_documented() {
+    grep -F 'safe by default' "$GASTOWN/README.md" >/dev/null ||
+        fail "README should document that schema-2 import cities are safe by default"
+    grep -F 'Do **not** add an explicit `[imports.maintenance]`' "$GASTOWN/README.md" >/dev/null ||
+        fail "README should warn schema-2 import cities away from an explicit maintenance import"
+    grep -F 'workspace.includes' "$GASTOWN/README.md" >/dev/null ||
+        fail "README should scope the before-gastown ordering advice to legacy workspace.includes cities"
+    grep -F 'list it before gastown' "$GASTOWN/README.md" >/dev/null ||
+        fail "README should keep the legacy includes advice to list maintenance before gastown"
+    grep -F 'gc formula show mol-shutdown-dance' "$GASTOWN/README.md" >/dev/null ||
+        fail "README should document how to verify the effective shutdown-dance formula"
+    grep -F '[imports.maintenance]' "$GASTOWN/pack.toml" >/dev/null ||
+        fail "pack.toml should warn schema-2 import cities away from an explicit maintenance import"
+    grep -F 'workspace.includes' "$GASTOWN/pack.toml" >/dev/null ||
+        fail "pack.toml should scope before-gastown ordering advice to legacy workspace.includes cities"
 }
 
 test_dog_assets_are_pack_local
 test_retired_dog_formulas_are_not_reintroduced
+test_shutdown_dance_contracts_are_executable
+test_shutdown_dance_lifecycle_and_audit_contracts
+test_composition_ordering_is_documented
 
 echo "gastown pack asset tests passed"


### PR DESCRIPTION
## Summary\n- move Gastown Dog agent assets into the canonical public gastown pack\n- move the Gastown-specific shutdown dance formula into the public pack\n- add a focused pack asset regression test that keeps retired mol-dog JSONL/reaper formulas out\n\n## Validation\n- bash gastown/tests/test_gastown_pack_assets.sh\n- bash gastown/tests/test_gastown_theme_scripts.sh\n- python3 validate_registry.py\n- find gastown -type f -name '*.sh' -print0 | xargs -0 -n1 bash -n\n- git diff --check origin/main...HEAD