### PR TITLE
feat(registry): add hash compute/emit tooling to validate_registry.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,31 @@ make registry-format-validate
 GC=/path/to/gc make registry-validate
 ```
 
+### Publishing a pack to the registry
+
+`registry.toml` is the public catalog. Each `[[pack.release]]` carries a
+content hash that `validate_registry.py` enforces against the pack tree at the
+pinned `commit`. To register a new pack, commit it on your branch, then mint a
+ready-to-paste entry with the canonical hash:
+
+```bash
+# Print just the content hash for a pack at a given commit (default: HEAD)
+python3 validate_registry.py --compute <pack> --commit <ref>
+
+# Print a full [[pack]] block to paste into registry.toml
+python3 validate_registry.py --emit-entry <pack> \
+  --version 0.1.0 \
+  --pack-description "One-line catalog description." \
+  --release-description "Initial <pack> pack release."
+
+# Validate the catalog (default, no-arg invocation — same as CI)
+python3 validate_registry.py
+```
+
+The hash is derived from a sorted manifest of each tracked file's relative
+path, mode, and blob SHA-256 — so it is deterministic and reproducible. A
+maintainer re-pins releases to a single published commit at release time.
+
 ### Release compatibility and inference gates
 
 Supported pack releases are also gated by the registry-driven compatibility

--- a/tests/test_validate_registry.py
+++ b/tests/test_validate_registry.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import subprocess
+import sys
 import textwrap
 import tomllib
 
@@ -9,9 +10,25 @@ import pytest
 
 import validate_registry
 
+_PACK_TOML_BYTES = b'[pack]\nname = "cass"\nschema = 2\n'
+_README_BYTES = b"CASS docs\n"
+
 
 def run_git(root, *args: str) -> str:
     return subprocess.check_output(["git", "-C", str(root), *args], text=True).strip()
+
+
+def _init_pack_repo(root) -> str:
+    run_git(root, "init")
+    run_git(root, "config", "user.email", "test@example.com")
+    run_git(root, "config", "user.name", "Test User")
+    pack_dir = root / "cass"
+    pack_dir.mkdir()
+    (pack_dir / "pack.toml").write_bytes(_PACK_TOML_BYTES)
+    (pack_dir / "README.md").write_bytes(_README_BYTES)
+    run_git(root, "add", "cass")
+    run_git(root, "commit", "-m", "add cass")
+    return run_git(root, "rev-parse", "HEAD")
 
 
 def test_source_pack_path_accepts_tree_urls() -> None:
@@ -62,44 +79,19 @@ def test_validate_tree_url_source_checks_pack_toml_name(tmp_path) -> None:
 
 
 def test_pack_content_hash_uses_relative_paths_modes_and_blob_hashes(tmp_path) -> None:
-    run_git(tmp_path, "init")
-    run_git(tmp_path, "config", "user.email", "test@example.com")
-    run_git(tmp_path, "config", "user.name", "Test User")
-    pack_dir = tmp_path / "cass"
-    pack_dir.mkdir()
-    pack_toml = b'[pack]\nname = "cass"\nschema = 2\n'
-    readme = b"CASS docs\n"
-    (pack_dir / "pack.toml").write_bytes(pack_toml)
-    (pack_dir / "README.md").write_bytes(readme)
-    run_git(tmp_path, "add", "cass")
-    run_git(tmp_path, "commit", "-m", "add cass")
-    commit = run_git(tmp_path, "rev-parse", "HEAD")
+    commit = _init_pack_repo(tmp_path)
 
     manifest = "\n".join(
         sorted(
             [
-                f"README.md 0644 {hashlib.sha256(readme).hexdigest()}",
-                f"pack.toml 0644 {hashlib.sha256(pack_toml).hexdigest()}",
+                f"README.md 0644 {hashlib.sha256(_README_BYTES).hexdigest()}",
+                f"pack.toml 0644 {hashlib.sha256(_PACK_TOML_BYTES).hexdigest()}",
             ]
         )
     ).encode("utf-8")
-
     expected = "sha256:" + hashlib.sha256(manifest).hexdigest()
 
     assert validate_registry.git_pack_content_hash(tmp_path, commit, "cass") == expected
-
-
-def _init_pack_repo(root) -> str:
-    run_git(root, "init")
-    run_git(root, "config", "user.email", "test@example.com")
-    run_git(root, "config", "user.name", "Test User")
-    pack_dir = root / "cass"
-    pack_dir.mkdir()
-    (pack_dir / "pack.toml").write_bytes(b'[pack]\nname = "cass"\nschema = 2\n')
-    (pack_dir / "README.md").write_bytes(b"CASS docs\n")
-    run_git(root, "add", "cass")
-    run_git(root, "commit", "-m", "add cass")
-    return run_git(root, "rev-parse", "HEAD")
 
 
 def test_resolve_commit_returns_full_lowercase_sha(tmp_path) -> None:
@@ -165,3 +157,61 @@ def test_render_pack_entry_escapes_quotes_in_descriptions(tmp_path) -> None:
 
     parsed = tomllib.loads(block)
     assert parsed["pack"][0]["description"] == description
+
+
+def test_cli_compute_happy_path(tmp_path, monkeypatch, capsys) -> None:
+    commit = _init_pack_repo(tmp_path)
+    registry = tmp_path / "registry.toml"
+    registry.write_bytes(b"schema = 1\n")
+    monkeypatch.setattr(sys, "argv", [
+        "validate_registry", str(registry), "--compute", "cass", "--commit", commit,
+    ])
+
+    result = validate_registry.main()
+
+    assert result == 0
+    out, _ = capsys.readouterr()
+    expected = validate_registry.git_pack_content_hash(tmp_path, commit, "cass")
+    assert out.strip() == expected
+
+
+def test_cli_emit_entry_missing_required_args_exit_2(tmp_path, monkeypatch, capsys) -> None:
+    registry = tmp_path / "registry.toml"
+    registry.write_bytes(b"schema = 1\n")
+    monkeypatch.setattr(sys, "argv", [
+        "validate_registry", str(registry), "--emit-entry", "cass",
+    ])
+
+    result = validate_registry.main()
+
+    assert result == 2
+    _, err = capsys.readouterr()
+    assert "emit-entry failed" in err
+
+
+def test_cli_mutual_exclusion_guard(tmp_path, monkeypatch, capsys) -> None:
+    registry = tmp_path / "registry.toml"
+    registry.write_bytes(b"schema = 1\n")
+    monkeypatch.setattr(sys, "argv", [
+        "validate_registry", str(registry), "--compute", "cass", "--emit-entry", "cass",
+    ])
+
+    result = validate_registry.main()
+
+    assert result == 2
+    _, err = capsys.readouterr()
+    assert "mutually exclusive" in err
+
+
+def test_cli_pack_name_traversal_rejected(tmp_path, monkeypatch, capsys) -> None:
+    registry = tmp_path / "registry.toml"
+    registry.write_bytes(b"schema = 1\n")
+    monkeypatch.setattr(sys, "argv", [
+        "validate_registry", str(registry), "--compute", "../../x",
+    ])
+
+    result = validate_registry.main()
+
+    assert result == 1
+    _, err = capsys.readouterr()
+    assert "invalid pack name" in err

--- a/tests/test_validate_registry.py
+++ b/tests/test_validate_registry.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 import hashlib
 import subprocess
 import textwrap
+import tomllib
+
+import pytest
 
 import validate_registry
 
@@ -84,3 +87,81 @@ def test_pack_content_hash_uses_relative_paths_modes_and_blob_hashes(tmp_path) -
     expected = "sha256:" + hashlib.sha256(manifest).hexdigest()
 
     assert validate_registry.git_pack_content_hash(tmp_path, commit, "cass") == expected
+
+
+def _init_pack_repo(root) -> str:
+    run_git(root, "init")
+    run_git(root, "config", "user.email", "test@example.com")
+    run_git(root, "config", "user.name", "Test User")
+    pack_dir = root / "cass"
+    pack_dir.mkdir()
+    (pack_dir / "pack.toml").write_bytes(b'[pack]\nname = "cass"\nschema = 2\n')
+    (pack_dir / "README.md").write_bytes(b"CASS docs\n")
+    run_git(root, "add", "cass")
+    run_git(root, "commit", "-m", "add cass")
+    return run_git(root, "rev-parse", "HEAD")
+
+
+def test_resolve_commit_returns_full_lowercase_sha(tmp_path) -> None:
+    head = _init_pack_repo(tmp_path)
+
+    resolved = validate_registry.resolve_commit(tmp_path, "HEAD")
+
+    assert validate_registry.COMMIT_RE.fullmatch(resolved)
+    assert resolved == head
+
+
+def test_compute_pack_hash_matches_validator_and_raises_when_absent(tmp_path) -> None:
+    commit = _init_pack_repo(tmp_path)
+
+    computed = validate_registry.compute_pack_hash(tmp_path, "cass", commit)
+
+    assert computed == validate_registry.git_pack_content_hash(tmp_path, commit, "cass")
+    assert validate_registry.HASH_RE.fullmatch(computed)
+    with pytest.raises(ValueError):
+        validate_registry.compute_pack_hash(tmp_path, "missing", commit)
+
+
+def test_render_pack_entry_parses_and_carries_computed_hash(tmp_path) -> None:
+    commit = _init_pack_repo(tmp_path)
+    content_hash = validate_registry.compute_pack_hash(tmp_path, "cass", commit)
+
+    block = validate_registry.render_pack_entry(
+        name="cass",
+        description="CASS session search pack.",
+        source="https://github.com/gastownhall/gascity-packs/tree/main/cass",
+        version="0.1.0",
+        ref="main",
+        commit=commit,
+        content_hash=content_hash,
+        release_description="Initial CASS session-search pack release.",
+    )
+
+    parsed = tomllib.loads(block)
+    entry = parsed["pack"][0]
+    release = entry["release"][0]
+    assert entry["name"] == "cass"
+    assert entry["source_kind"] == "git"
+    assert release["commit"] == commit
+    assert release["hash"] == content_hash
+    assert validate_registry.HASH_RE.fullmatch(release["hash"])
+
+
+def test_render_pack_entry_escapes_quotes_in_descriptions(tmp_path) -> None:
+    commit = _init_pack_repo(tmp_path)
+    content_hash = validate_registry.compute_pack_hash(tmp_path, "cass", commit)
+
+    description = 'Has a "quote" and a \\ backslash'
+    block = validate_registry.render_pack_entry(
+        name="cass",
+        description=description,
+        source="https://github.com/gastownhall/gascity-packs/tree/main/cass",
+        version="0.1.0",
+        ref="main",
+        commit=commit,
+        content_hash=content_hash,
+        release_description="Initial release.",
+    )
+
+    parsed = tomllib.loads(block)
+    assert parsed["pack"][0]["description"] == description

--- a/validate_registry.py
+++ b/validate_registry.py
@@ -247,7 +247,23 @@ def resolve_commit(root: Path, ref: str) -> str:
 
 def _toml_escape(value: str) -> str:
     """Escape a string for embedding in a TOML basic (double-quoted) string."""
-    return value.replace("\\", "\\\\").replace('"', '\\"')
+    result = []
+    for ch in value:
+        if ch == "\\":
+            result.append("\\\\")
+        elif ch == '"':
+            result.append('\\"')
+        elif ch == "\n":
+            result.append("\\n")
+        elif ch == "\r":
+            result.append("\\r")
+        elif ch == "\t":
+            result.append("\\t")
+        elif ord(ch) < 0x20 or ord(ch) == 0x7F:
+            raise ValueError(f"control character U+{ord(ch):04X} in field value")
+        else:
+            result.append(ch)
+    return "".join(result)
 
 
 def compute_pack_hash(root: Path, pack_path: str, commit: str) -> str:
@@ -292,6 +308,8 @@ def render_pack_entry(
 
 
 def _pack_toml_name(root: Path, pack: str) -> str:
+    if not PACK_NAME_RE.fullmatch(pack):
+        raise ValueError(f"invalid pack name {pack!r}")
     pack_toml = root / pack / "pack.toml"
     if not pack_toml.exists():
         raise ValueError(f"{pack}/pack.toml not found in working tree")
@@ -322,6 +340,12 @@ def main() -> int:
         help="commit-ish whose pack content is hashed/pinned (default: HEAD)",
     )
     parser.add_argument(
+        "--ref",
+        default="main",
+        metavar="REF",
+        help="git ref label for the source URL and release ref field (default: main)",
+    )
+    parser.add_argument(
         "--repo-url",
         default="https://github.com/gastownhall/gascity-packs",
         help="repository base URL for the source field of --emit-entry",
@@ -342,6 +366,9 @@ def main() -> int:
         return 2
 
     if args.compute:
+        if not PACK_NAME_RE.fullmatch(args.compute):
+            print(f"compute failed: invalid pack name {args.compute!r}", file=sys.stderr)
+            return 1
         try:
             commit = resolve_commit(root, args.commit)
             print(compute_pack_hash(root, args.compute, commit))
@@ -371,22 +398,20 @@ def main() -> int:
                 )
             commit = resolve_commit(root, args.commit)
             content_hash = compute_pack_hash(root, pack, commit)
-        except (ValueError, subprocess.CalledProcessError) as exc:
-            print(f"emit-entry failed: {exc}", file=sys.stderr)
-            return 1
-        print(
-            render_pack_entry(
+            entry = render_pack_entry(
                 name=pack,
                 description=args.pack_description,
-                source=f"{args.repo_url.rstrip('/')}/tree/main/{pack}",
+                source=f"{args.repo_url.rstrip('/')}/tree/{args.ref}/{pack}",
                 version=args.version,
-                ref="main",
+                ref=args.ref,
                 commit=commit,
                 content_hash=content_hash,
                 release_description=args.release_description,
-            ),
-            end="",
-        )
+            )
+        except (ValueError, subprocess.CalledProcessError) as exc:
+            print(f"emit-entry failed: {exc}", file=sys.stderr)
+            return 1
+        print(entry, end="")
         return 0
 
     errors = validate(Path(args.registry))

--- a/validate_registry.py
+++ b/validate_registry.py
@@ -240,10 +240,154 @@ def validate(path: Path) -> list[str]:
     return errors
 
 
+def resolve_commit(root: Path, ref: str) -> str:
+    """Resolve a git ref to its full 40-char lowercase commit SHA."""
+    return git_bytes(root, "rev-parse", "--verify", f"{ref}^{{commit}}").decode("utf-8").strip()
+
+
+def _toml_escape(value: str) -> str:
+    """Escape a string for embedding in a TOML basic (double-quoted) string."""
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def compute_pack_hash(root: Path, pack_path: str, commit: str) -> str:
+    """Compute the canonical content hash for a pack at a commit.
+
+    Wraps git_pack_content_hash with a clear error when the pack is absent at
+    that commit, so callers minting a registry entry fail loudly instead of
+    emitting a null hash.
+    """
+    digest = git_pack_content_hash(root, commit, pack_path)
+    if digest is None:
+        raise ValueError(f"pack {pack_path!r} not found at commit {commit}")
+    return digest
+
+
+def render_pack_entry(
+    *,
+    name: str,
+    description: str,
+    source: str,
+    version: str,
+    ref: str,
+    commit: str,
+    content_hash: str,
+    release_description: str,
+) -> str:
+    """Render a ready-to-paste [[pack]] block matching registry.toml style."""
+    return (
+        "[[pack]]\n"
+        f'name = "{_toml_escape(name)}"\n'
+        f'description = "{_toml_escape(description)}"\n'
+        f'source = "{_toml_escape(source)}"\n'
+        'source_kind = "git"\n'
+        "\n"
+        "  [[pack.release]]\n"
+        f'  version = "{_toml_escape(version)}"\n'
+        f'  ref = "{_toml_escape(ref)}"\n'
+        f'  commit = "{commit}"\n'
+        f'  hash = "{content_hash}"\n'
+        f'  description = "{_toml_escape(release_description)}"\n'
+    )
+
+
+def _pack_toml_name(root: Path, pack: str) -> str:
+    pack_toml = root / pack / "pack.toml"
+    if not pack_toml.exists():
+        raise ValueError(f"{pack}/pack.toml not found in working tree")
+    with pack_toml.open("rb") as handle:
+        name = tomllib.load(handle).get("pack", {}).get("name")
+    if not name:
+        raise ValueError(f"{pack}/pack.toml has no [pack].name key")
+    return name
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("registry", nargs="?", default="registry.toml")
+    parser.add_argument(
+        "--compute",
+        metavar="PACK",
+        help="compute and print the content hash for PACK at --commit, then exit",
+    )
+    parser.add_argument(
+        "--emit-entry",
+        metavar="PACK",
+        help="print a ready-to-paste [[pack]] registry block for PACK, then exit",
+    )
+    parser.add_argument(
+        "--commit",
+        default="HEAD",
+        metavar="REF",
+        help="commit-ish whose pack content is hashed/pinned (default: HEAD)",
+    )
+    parser.add_argument(
+        "--repo-url",
+        default="https://github.com/gastownhall/gascity-packs",
+        help="repository base URL for the source field of --emit-entry",
+    )
+    parser.add_argument("--version", help="release version for --emit-entry (semver)")
+    parser.add_argument(
+        "--pack-description", help="catalog description for --emit-entry"
+    )
+    parser.add_argument(
+        "--release-description", help="release description for --emit-entry"
+    )
     args = parser.parse_args()
+
+    root = Path(args.registry).resolve().parent
+
+    if args.compute and args.emit_entry:
+        print("--compute and --emit-entry are mutually exclusive", file=sys.stderr)
+        return 2
+
+    if args.compute:
+        try:
+            commit = resolve_commit(root, args.commit)
+            print(compute_pack_hash(root, args.compute, commit))
+        except (ValueError, subprocess.CalledProcessError) as exc:
+            print(f"compute failed: {exc}", file=sys.stderr)
+            return 1
+        return 0
+
+    if args.emit_entry:
+        pack = args.emit_entry
+        problems = []
+        if not args.version or not RELEASE_VERSION_RE.fullmatch(args.version):
+            problems.append("--version must be semver major.minor[.patch]")
+        if not args.pack_description:
+            problems.append("--pack-description is required")
+        if not args.release_description:
+            problems.append("--release-description is required")
+        if problems:
+            for problem in problems:
+                print(f"emit-entry failed: {problem}", file=sys.stderr)
+            return 2
+        try:
+            actual_name = _pack_toml_name(root, pack)
+            if actual_name != pack:
+                raise ValueError(
+                    f"{pack}/pack.toml name {actual_name!r} does not match {pack!r}"
+                )
+            commit = resolve_commit(root, args.commit)
+            content_hash = compute_pack_hash(root, pack, commit)
+        except (ValueError, subprocess.CalledProcessError) as exc:
+            print(f"emit-entry failed: {exc}", file=sys.stderr)
+            return 1
+        print(
+            render_pack_entry(
+                name=pack,
+                description=args.pack_description,
+                source=f"{args.repo_url.rstrip('/')}/tree/main/{pack}",
+                version=args.version,
+                ref="main",
+                commit=commit,
+                content_hash=content_hash,
+                release_description=args.release_description,
+            ),
+            end="",
+        )
+        return 0
 
     errors = validate(Path(args.registry))
     if errors:


### PR DESCRIPTION
## What

Adds a way to **compute** the `registry.toml` content hash so new packs can be
registered. Closes the mechanism gap in #53.

`[[pack.release]]` entries carry a `hash = "sha256:…"` that `validate_registry.py`
enforces against the pack tree at the pinned `commit` (via the existing
`git_pack_content_hash`). Until now there was no way to *produce* that value, so
packs already on `main` but absent from the catalog (`slack-channel`,
`slack-mini`, and the wave-1 builtins) couldn't be added.

This exposes the **already-canonical** algorithm — the computed hashes reproduce
the live `cass` and `slack-full` pins exactly — rather than inventing a new one.

## Usage

```bash
# Print the content hash for a pack at a commit (default: HEAD)
python3 validate_registry.py --compute <pack> --commit <ref>

# Print a ready-to-paste [[pack]] block with the correct hash + pin
python3 validate_registry.py --emit-entry <pack> \
  --version 0.1.0 \
  --pack-description "One-line catalog description." \
  --release-description "Initial <pack> pack release."
```

## Notes

- **Backward compatible**: no-arg `python3 validate_registry.py` validates exactly
  as before — CI step unchanged.
- TOML basic-string escaping on emitted free-text fields; reuses the hardened
  `git_bytes` helper for ref resolution.
- README documents the publish-a-pack-to-the-registry flow (answering #53 Ask 1).
- A maintainer still re-pins releases to a single published commit at release
  time; this just removes the "we can't generate the hash" blocker.

@julianknutsen — this is the packs-side compute/stamp helper from #53. Happy to
align it with the `gc` commands you mentioned (or fold it in) if you'd rather the
canonical tool live there; opening this so the wave-1 + slack-channel/slack-mini
registrations aren't blocked in the meantime.

## Test plan

- [x] `python3 -m pytest tests -q` → 7 passing (incl. round-trip + quote-escaping regression)
- [x] `python3 validate_registry.py` → `registry.toml: ok`
- [x] `--compute cass --commit 788b6e8…` reproduces the live pinned hash
- [x] `--emit-entry slack-mini` block splices into registry.toml and validates
