### PR TITLE
Release gastown 0.1.2: pack-owned dog + explicit-includes runtime docs

### DIFF
--- a/gastown/README.md
+++ b/gastown/README.md
@@ -14,66 +14,34 @@ source = "../packs/gastown"
 Use the pack as the workspace pack for city-scoped agents and as a rig pack for
 rig-scoped agents.
 
-## Composition Ordering (when maintenance is present)
+## Composition
 
-The Gas City maintenance pack still ships a legacy `mol-shutdown-dance`
-(required `warrant_id` var, raw `{{target}}` placeholders, PARDON mail to the
-requester). Formula names resolve last-wins across pack formula layers, so
-whichever pack's formula layer loads last decides which recipe dogs run. The
-dog agent resolves to gastown's wherever the dog names collide (legacy
-includes composition: non-fallback wins over the maintenance fallback dog);
-in import composition gastown's dog is a distinct `gastown.dog` agent and the
-implicit maintenance dog remains a dormant, unused fallback pool. Until the
-legacy maintenance copy is retired or renamed upstream, the formula the dog
-reads back depends on composition style:
+Gas City composes the builtin core pack (mechanical housekeeping orders)
+through the explicit `includes` entries that `gc init` writes into
+city.toml; this pack composes alongside it via `[imports.gastown]`. The
+retired maintenance pack no longer exists: gastown's `mol-shutdown-dance`
+and dog prompt fragments (`propulsion-dog`, `architecture`,
+`following-mol`) are the only copies in play, and cross-pack agent name
+collisions are hard errors rather than fallback resolutions.
 
-- **Schema-2 cities composing gastown via `[imports.gastown]`** (the style
-  shown in Import above) are safe by default: the runtime expands the
-  implicit maintenance system pack with the legacy includes pass, before any
-  `[imports.X]` layers, so gastown's formula layer loads after maintenance's
-  and wins. Do **not** add an explicit `[imports.maintenance]` alongside
-  `[imports.gastown]`: an explicit import suppresses the implicit injection
-  and moves maintenance into the import expansion, where binding names expand
-  in sorted order (`"gastown"` < `"maintenance"`), so the legacy maintenance
-  recipe would load last and win no matter where it is written in the file.
-  If maintenance must be pinned explicitly anyway, only the import binding
-  name's sort position relative to `gastown` controls layer order — too
-  fragile to rely on; prefer the implicit injection.
-- **Legacy schema-1 cities composing through `workspace.includes`** are
-  exposed by default: the implicit maintenance injection lands after the
-  user includes, so the legacy recipe wins. Compose maintenance explicitly
-  (an explicit entry suppresses the implicit system injection of the same
-  pack name) and list it before gastown in the same includes list, so
-  gastown's formula layer loads after maintenance's.
-
-Whichever style applies, verify which recipe wins after composing:
+Verify the composed recipe after changing imports:
 
 ```bash
 gc formula show mol-shutdown-dance
 ```
 
-The effective recipe must read warrant metadata from the claimed bead via
-`$GC_BEAD_ID` and must not declare a required `warrant_id` var. If it
-demands `warrant_id`, the legacy maintenance copy won — remove the explicit
-maintenance import (schema-2) or fix the include ordering (legacy includes)
-before running dogs.
-
-The same last-wins ordering governs template fragments: maintenance ships
-diverging copies of the `propulsion-dog`, `architecture`, and `following-mol`
-fragments used by the dog prompt, so the per-style guidance above also keeps
-gastown's fragment text authoritative.
+The recipe must read warrant metadata from the claimed bead via
+`$GC_BEAD_ID` and must not declare a required `warrant_id` var.
 
 ## Dog Pool
 
 Gastown owns `mol-shutdown-dance` and the dog agent that runs stuck-agent
-warrants, including the dog's `wake_mode` and `work_dir` settings. Where dog
-names collide (legacy includes composition), gastown's non-fallback dog wins
-over fallback dog providers; in import composition gastown's dog expands as
-the distinct `gastown.dog` agent and the implicit maintenance dog remains a
-dormant fallback pool that this pack's binding-prefixed producers never route
-to.
+warrants, including the dog's `wake_mode` and `work_dir` settings. In import
+composition gastown's dog expands as the distinct `gastown.dog` agent; the
+dolt pack ships its own separate dog for Dolt maintenance formulas, and the
+two coexist under their binding-qualified names.
 
 Gastown deliberately does not ship retired dog formulas for JSONL export or
-stale-session reaping. Compose the Gas City maintenance pack or an equivalent
-exec-order provider when a city needs JSONL export, stale-session or stale-data
-cleanup, and Dolt housekeeping.
+stale-session reaping. The Gas City builtin core pack provides JSONL export,
+stale-session and stale-data cleanup, and Dolt housekeeping as deterministic
+exec orders.

--- a/gastown/pack.toml
+++ b/gastown/pack.toml
@@ -2,15 +2,13 @@
 #
 # Gastown roles: mayor (coordinator), deacon (patrol), boot (watchdog),
 # dog (utility recovery), plus rig-scoped agents (witness, refinery, polecat).
-# The host Gas City runtime supplies the implicit maintenance/core utility
-# layer for mechanical housekeeping outside the pack-local dog pool. Compose
-# maintenance or an equivalent exec-order provider for JSONL export, stale
-# cleanup, and Dolt housekeeping. Schema-2 import cities must rely on the
-# implicit maintenance injection: adding [imports.maintenance] alongside
-# [imports.gastown] makes the legacy maintenance mol-shutdown-dance win
-# last-wins resolution. Legacy workspace.includes cities composing
-# maintenance explicitly must list it before gastown (see README
-# "Composition Ordering").
+# This pack owns its dog pool and the mol-shutdown-dance formula outright.
+# Mechanical housekeeping (gate/orphan/wisp sweeps, branch pruning, nudge
+# relays, JSONL export, Dolt checks) ships with the Gas City builtin core
+# pack, which cities include explicitly in city.toml (gc init writes the
+# include; gc doctor --fix repairs it). The retired maintenance pack no
+# longer exists, and cross-pack agent name collisions are hard errors, so
+# no fallback or composition-ordering dance is needed.
 #
 # Referenced by both workspace.pack and rigs[].pack:
 #   workspace.pack → expands city-scoped agents only (mayor, deacon, boot, dog)

--- a/gastown/tests/test_gastown_pack_assets.sh
+++ b/gastown/tests/test_gastown_pack_assets.sh
@@ -111,27 +111,29 @@ test_shutdown_dance_lifecycle_and_audit_contracts() {
         fail "dog prompt DOG_DONE guidance should use the normalized requester endpoint"
 }
 
-test_composition_ordering_is_documented() {
-    grep -F 'safe by default' "$GASTOWN/README.md" >/dev/null ||
-        fail "README should document that schema-2 import cities are safe by default"
-    grep -F 'Do **not** add an explicit `[imports.maintenance]`' "$GASTOWN/README.md" >/dev/null ||
-        fail "README should warn schema-2 import cities away from an explicit maintenance import"
-    grep -F 'workspace.includes' "$GASTOWN/README.md" >/dev/null ||
-        fail "README should scope the before-gastown ordering advice to legacy workspace.includes cities"
-    grep -F 'list it before gastown' "$GASTOWN/README.md" >/dev/null ||
-        fail "README should keep the legacy includes advice to list maintenance before gastown"
+test_composition_is_documented() {
+    # The retired maintenance pack is gone: the runtime composes the builtin
+    # core pack via explicit city.toml includes, and gastown owns the only
+    # mol-shutdown-dance. The docs must describe that model, not the old
+    # fallback/ordering workarounds.
+    grep -F 'builtin core pack' "$GASTOWN/README.md" >/dev/null ||
+        fail "README should attribute mechanical housekeeping to the builtin core pack"
+    ! grep -F '[imports.maintenance]' "$GASTOWN/README.md" >/dev/null ||
+        fail "README should not reference the retired maintenance pack import"
+    ! grep -Fi 'implicit maintenance' "$GASTOWN/README.md" >/dev/null ||
+        fail "README should not describe implicit maintenance injection"
     grep -F 'gc formula show mol-shutdown-dance' "$GASTOWN/README.md" >/dev/null ||
         fail "README should document how to verify the effective shutdown-dance formula"
-    grep -F '[imports.maintenance]' "$GASTOWN/pack.toml" >/dev/null ||
-        fail "pack.toml should warn schema-2 import cities away from an explicit maintenance import"
-    grep -F 'workspace.includes' "$GASTOWN/pack.toml" >/dev/null ||
-        fail "pack.toml should scope before-gastown ordering advice to legacy workspace.includes cities"
+    grep -F 'builtin core' "$GASTOWN/pack.toml" >/dev/null ||
+        fail "pack.toml should attribute mechanical housekeeping to the builtin core pack"
+    ! grep -F '[imports.maintenance]' "$GASTOWN/pack.toml" >/dev/null ||
+        fail "pack.toml should not reference the retired maintenance pack import"
 }
 
 test_dog_assets_are_pack_local
 test_retired_dog_formulas_are_not_reintroduced
 test_shutdown_dance_contracts_are_executable
 test_shutdown_dance_lifecycle_and_audit_contracts
-test_composition_ordering_is_documented
+test_composition_is_documented
 
 echo "gastown pack asset tests passed"

--- a/registry.toml
+++ b/registry.toml
@@ -26,6 +26,13 @@ source_kind = "git"
   hash = "sha256:275565384903ae22bf9187aa821df135724bd4a639be18e4b4e76f739a555cc4"
   description = "Refresh Gas Town workflow pack release pin."
 
+  [[pack.release]]
+  version = "0.1.2"
+  ref = "main"
+  commit = "1f45471e8bdc5dece030dfc99406ca7d3d45f9c0"
+  hash = "sha256:5d68300d4fdf04b705cb0b4e09ceb55406e42e7ab0d0a12ddba3b1e4d8628b92"
+  description = "Gastown owns its dog pool and shutdown dance; docs reflect the explicit-includes runtime (maintenance pack retired)."
+
 [[pack]]
 name = "cass"
 description = "Coding Agent Session Search prompt fragments and skill overlays for Gas City."


### PR DESCRIPTION
## Summary
- Update the gastown pack docs (pack.toml header, README, pack asset test) to the new Gas City runtime model: the maintenance pack was folded into the builtin core pack, builtin packs compose via explicit city.toml includes (written by `gc init`, repaired by `gc doctor --fix`), implicit pack injection is gone, and cross-pack agent name collisions are hard errors — so the old composition-ordering / fallback-dog workaround guidance is obsolete.
- Register gastown release **0.1.2** pointing at that content (the pack-owned dog pool + reworked `mol-shutdown-dance` merged in #74, plus these doc updates).

Companion to gastownhall/gascity `feat/fold-maintenance-into-core`, which consumes this release via `make update-bundled-gastown-pack`.

## Validation
- `python3 validate_registry.py` (commit + content-hash verification)
- `bash gastown/tests/test_gastown_pack_assets.sh`
- `bash gastown/tests/test_gastown_theme_scripts.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)