### PR TITLE
Expose pack content as a Go module embed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,9 @@ jobs:
             bash "$test_script"
           done
 
+      - name: Run root module embed tests
+        run: go test .
+
       - name: Run Slack full adapter tests
         working-directory: slack-full/adapter
         run: go test ./...

--- a/embed.go
+++ b/embed.go
@@ -1,0 +1,29 @@
+// Package gascitypacks exposes the registry pack content as embedded
+// filesystems so consumers (the gc binary) can depend on released pack
+// bytes through the Go module system instead of vendoring checked-in
+// copies. The embedded trees are the same content the registry releases
+// hash; nested adapter modules (slack-*) are not embedded.
+package gascitypacks
+
+import (
+	"embed"
+	"io/fs"
+)
+
+// packsFS embeds the gastown pack tree. Additional packs join this
+// pattern list as consumers need them.
+//
+//go:embed all:gastown
+var packsFS embed.FS
+
+// Gastown returns the gastown pack content rooted at the pack directory
+// (pack.toml at the top level), matching the layout consumers compose.
+func Gastown() fs.FS {
+	sub, err := fs.Sub(packsFS, "gastown")
+	if err != nil {
+		// fs.Sub only fails on an invalid path literal; "gastown" is
+		// embedded above, so this is unreachable at runtime.
+		panic(err)
+	}
+	return sub
+}

--- a/embed_test.go
+++ b/embed_test.go
@@ -1,0 +1,36 @@
+package gascitypacks
+
+import (
+	"io/fs"
+	"testing"
+)
+
+func TestGastownEmbedsPackContent(t *testing.T) {
+	pack := Gastown()
+	for _, rel := range []string{
+		"pack.toml",
+		"agents/dog/agent.toml",
+		"agents/dog/prompt.template.md",
+		"formulas/mol-shutdown-dance.toml",
+		"template-fragments/propulsion.template.md",
+		"overlay/per-provider/codex/.codex/hooks.json",
+	} {
+		if _, err := fs.Stat(pack, rel); err != nil {
+			t.Errorf("gastown pack missing %s: %v", rel, err)
+		}
+	}
+}
+
+func TestGastownEmbedHasNoUnexpectedRoots(t *testing.T) {
+	entries, err := fs.ReadDir(packsFS, ".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "gastown" {
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Fatalf("embedded roots = %v, want [gastown]", names)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/gastownhall/gascity-packs
+
+go 1.22


### PR DESCRIPTION
## Summary
- Add a root `go.mod` (`module github.com/gastownhall/gascity-packs`) and `embed.go` embedding the gastown pack tree (`all:gastown`, so dot-file overlays are included), with a `Gastown() fs.FS` accessor rooted at the pack directory.
- Root-level placement keeps the embed outside the pack directories, so registry release content hashes are unchanged and the sync/consumer tooling is unaffected; the nested `slack-*` adapter modules remain independent (dirs with their own go.mod are excluded from the parent module).
- CI gains a `go test .` step covering the embed (content presence + no unexpected embedded roots).

First step toward gastownhall/gascity consuming the gastown pack as a module dependency instead of a vendored, sync-tool-managed checked-in copy (and toward retiring per-city `.gc/system/packs` materialization). After merge this should be tagged (e.g. `v0.2.0`) so consumers can pin it.

## Validation
- `go vet . && go test .`
- `python3 validate_registry.py` unaffected (no pack content changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)