### PR TITLE
Embed the gascity pack alongside gastown

### DIFF
--- a/embed.go
+++ b/embed.go
@@ -10,19 +10,29 @@ import (
 	"io/fs"
 )
 
-// packsFS embeds the gastown pack tree. Additional packs join this
-// pattern list as consumers need them.
+// packsFS embeds the pack trees consumers depend on. Additional packs
+// join this pattern list as consumers need them.
 //
-//go:embed all:gastown
+//go:embed all:gastown all:gascity
 var packsFS embed.FS
 
 // Gastown returns the gastown pack content rooted at the pack directory
 // (pack.toml at the top level), matching the layout consumers compose.
 func Gastown() fs.FS {
-	sub, err := fs.Sub(packsFS, "gastown")
+	return packSub("gastown")
+}
+
+// Gascity returns the gascity planning/implementation pack content rooted
+// at the pack directory (pack.toml at the top level).
+func Gascity() fs.FS {
+	return packSub("gascity")
+}
+
+func packSub(name string) fs.FS {
+	sub, err := fs.Sub(packsFS, name)
 	if err != nil {
-		// fs.Sub only fails on an invalid path literal; "gastown" is
-		// embedded above, so this is unreachable at runtime.
+		// fs.Sub only fails on an invalid path literal; every name passed
+		// here is embedded above, so this is unreachable at runtime.
 		panic(err)
 	}
 	return sub

--- a/embed_test.go
+++ b/embed_test.go
@@ -21,16 +21,36 @@ func TestGastownEmbedsPackContent(t *testing.T) {
 	}
 }
 
-func TestGastownEmbedHasNoUnexpectedRoots(t *testing.T) {
+func TestGascityEmbedsPackContent(t *testing.T) {
+	pack := Gascity()
+	for _, rel := range []string{
+		"pack.toml",
+		"formulas/implement.formula.toml",
+		"skills/plan/SKILL.md",
+		"scripts/checks/gap-analysis-approved.sh",
+	} {
+		if _, err := fs.Stat(pack, rel); err != nil {
+			t.Errorf("gascity pack missing %s: %v", rel, err)
+		}
+	}
+}
+
+func TestEmbedHasNoUnexpectedRoots(t *testing.T) {
 	entries, err := fs.ReadDir(packsFS, ".")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(entries) != 1 || entries[0].Name() != "gastown" {
+	want := map[string]bool{"gastown": true, "gascity": true}
+	if len(entries) != len(want) {
 		names := make([]string, 0, len(entries))
 		for _, e := range entries {
 			names = append(names, e.Name())
 		}
-		t.Fatalf("embedded roots = %v, want [gastown]", names)
+		t.Fatalf("embedded roots = %v, want gastown + gascity", names)
+	}
+	for _, e := range entries {
+		if !want[e.Name()] {
+			t.Fatalf("unexpected embedded root %q", e.Name())
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- Add `all:gascity` to the root module embed with a `Gascity() fs.FS` accessor (shared `packSub` helper), plus embed tests.
- The `gascity/` tree is byte-identical between registry release 0.1.1 (commit 788b6e8) and main, so the existing release pin serves the embedded content — no new registry release needed.

Consumed by gastownhall/gascity to offer the gascity pack as an init wizard option served offline from the bundled cache. Tag `v0.3.0` after merge.

## Validation
- `go vet . && go test .`

🤖 Generated with [Claude Code](https://claude.com/claude-code)