### PR TITLE
GitHub pack: addressed-message intake, sync-app, and identity publish/resolve tooling

### DIFF
--- a/cass/template-fragments/cass-search.template.md
+++ b/cass/template-fragments/cass-search.template.md
@@ -7,11 +7,16 @@ subsystem, check past agent sessions before starting from scratch.
 Use non-interactive `cass` commands only:
 
 ```bash
-cass health --json || cass index --full
+cass health --json || cass diag --json
 cass sessions --current --json
 cass sessions --workspace "$(pwd)" --json --limit 5
 cass search "<query>" --json --limit 5 --fields minimal
 ```
+
+Do not run `cass index`, `cass index --full`, or `cass doctor --fix` from an
+agent session unless the human explicitly asks you to repair the shared CASS
+store. Failed health means search may be unavailable; it is not permission to
+start a rebuild.
 
 If a hit looks relevant, inspect it with:
 

--- a/discord/README.md
+++ b/discord/README.md
@@ -167,14 +167,14 @@ Inbound behavior in v0:
 - unmentioned follow-ups inside a managed launcher thread continue to the last agent the human addressed in that thread
 - guild and thread messages route only when the bot is explicitly mentioned
 - ambient-read room bindings are the exception: the bound room or bound thread accepts unmentioned messages, but only when one or more exact `@session_name` targets are present
-- single-session ambient-read bindings may opt into untargeted delivery with `--allow-untargeted-ambient-delivery`; that is the sticky room mode for long-lived agents like Randy
+- single-session ambient-read bindings may opt into untargeted delivery with `--allow-untargeted-ambient-delivery`; that sticky room mode delivers all visible messages to the one bound agent, even when the body includes a non-exact shorthand such as `@randy`
 - thread messages inherit the parent room binding when the thread itself is not bound
 - inherited thread routing still requires a bot mention unless the thread itself is bound with ambient read
 - ambient-read rooms stay targeted-only even when the bot is mentioned, unless the binding explicitly allows untargeted ambient delivery for its one bound session
 - launcher rooms and ambient-read rooms depend on Discord `Message Content Intent` because they consume unmentioned guild text
 - `@sky` inside the message targets that session name exactly
 - untargeted room messages fan out to every bound participant session
-- untargeted ambient-read room messages are ignored instead of broadcasting
+- untargeted multi-session ambient-read room messages are ignored instead of broadcasting
 - agent normal output remains private; only explicit publish commands speak back to humans
 - agents should prefer `gc discord reply-current --body-file ...` when answering the latest Discord turn
 - direct `gc discord publish` only participates in peer fanout when explicit source metadata is supplied

--- a/discord/commands/bind-room/help.md
+++ b/discord/commands/bind-room/help.md
@@ -19,7 +19,9 @@ explicitly target one or more `@session_name` values to route. Parent-room
 thread inheritance still requires a bot mention unless the thread itself is
 also bound. Ambient-read bindings remain targeted-only even when the bot is
 mentioned directly, unless `--allow-untargeted-ambient-delivery` is enabled on
-an ambient-read room with exactly one bound session.
+an ambient-read room with exactly one bound session. In that sticky single-agent
+mode, every visible message routes to the one bound session, including messages
+that contain a non-exact shorthand mention.
 
 Ambient read consumes unmentioned guild messages. Discord therefore requires
 the app's `Message Content Intent` to be enabled in the Developer Portal

--- a/discord/formulas/mol-discord-fix-issue.formula.toml
+++ b/discord/formulas/mol-discord-fix-issue.formula.toml
@@ -136,7 +136,9 @@ WORKTREE=$(bd show {{issue}} --json | jq -r '.metadata.work_dir // empty')
 if [ -n "$WORKTREE" ] && [ -d "$WORKTREE" ]; then
   cd "$WORKTREE"
 else
-  WORKTREE_PATH=$(pwd)/worktrees/{{issue}}
+  WORKTREE_ROOT="$(pwd)/.gc/worktrees"
+  mkdir -p "$WORKTREE_ROOT"
+  WORKTREE_PATH="$WORKTREE_ROOT/{{issue}}"
   git worktree add "$WORKTREE_PATH" --detach origin/$(git remote show origin | sed -n '/HEAD branch/s/.*: //p')
   cd "$WORKTREE_PATH"
   bd update {{issue}} --set-metadata work_dir="$WORKTREE_PATH"
@@ -293,17 +295,18 @@ if command -v gt >/dev/null 2>&1; then
   fi
 else
   if [ -n "$WORKTREE" ] && [ -d "$WORKTREE" ]; then
-    WORKTREE_PARENT=$(dirname "$WORKTREE")
-    CLEANUP_CWD=$(dirname "$WORKTREE_PARENT")
-    if [ ! -d "$CLEANUP_CWD/.git" ]; then
-      CLEANUP_CWD="$WORKTREE_PARENT"
-    fi
+    GIT_COMMON_DIR=$(git -C "$WORKTREE" rev-parse --git-common-dir)
+    case "$GIT_COMMON_DIR" in
+      /*) ;;
+      *) GIT_COMMON_DIR="$WORKTREE/$GIT_COMMON_DIR" ;;
+    esac
+    CLEANUP_CWD=$(dirname "$GIT_COMMON_DIR")
     if ! cd "$CLEANUP_CWD"; then
       echo "error: failed to enter cleanup directory $CLEANUP_CWD" >&2
       RELEASE_WORKFLOW=0
       exit 1
     fi
-    if ! git worktree remove "$WORKTREE" --force; then
+    if ! git --git-dir="$GIT_COMMON_DIR" worktree remove "$WORKTREE" --force; then
       echo "error: failed to remove worktree $WORKTREE" >&2
       RELEASE_WORKFLOW=0
       exit 1

--- a/discord/scripts/discord_gateway_service.py
+++ b/discord/scripts/discord_gateway_service.py
@@ -1284,7 +1284,8 @@ def process_inbound_message(message: dict[str, Any], bot_user_id: str) -> dict[s
             preloaded_channel_info = binding_channel_info(preloaded_binding)
             preloaded_body = strip_bot_mentions(str(message.get("content", "")), bot_user_id)
             preloaded_aliases = extract_alias_mentions(preloaded_body)
-            if not preloaded_aliases and not binding_allows_untargeted_ambient_delivery(preloaded_binding):
+            sticky_single_session_delivery = binding_allows_untargeted_ambient_delivery(preloaded_binding)
+            if not preloaded_aliases and not sticky_single_session_delivery:
                 return reject_ingress_before_processing(
                     message,
                     bot_user_id,
@@ -1302,7 +1303,7 @@ def process_inbound_message(message: dict[str, Any], bot_user_id: str) -> dict[s
                 if participant_lookup.get(key):
                     has_valid_preloaded_alias = True
                     break
-            if preloaded_aliases and not has_valid_preloaded_alias:
+            if preloaded_aliases and not has_valid_preloaded_alias and not sticky_single_session_delivery:
                 return reject_ingress_before_processing(
                     message,
                     bot_user_id,
@@ -1493,9 +1494,10 @@ def process_inbound_message(message: dict[str, Any], bot_user_id: str) -> dict[s
             return {"status": "ignored_empty", "ingress_id": ingress_id, "receipt": receipt}
 
         mentioned_aliases = preloaded_aliases if preloaded_aliases is not None else extract_alias_mentions(body)
+        target_aliases = [] if binding_allows_untargeted_ambient_delivery(binding) else mentioned_aliases
         targets, delivery, resolve_error = resolve_targets(
             binding,
-            mentioned_aliases,
+            target_aliases,
             require_targeted_aliases=bool(
                 binding_allows_ambient_read(binding) and guild_id and not binding_allows_untargeted_ambient_delivery(binding)
             ),

--- a/discord/scripts/discord_intake_common.py
+++ b/discord/scripts/discord_intake_common.py
@@ -1985,14 +1985,42 @@ _supervisor_scope_cache: dict[str, tuple[float, str]] = {}  # workspace_name →
 _SCOPE_CACHE_TTL = 60.0  # seconds
 
 
+def resolved_workspace_name(city_cfg: dict[str, Any]) -> str:
+    """Resolve the city's runtime workspace name.
+
+    Precedence mirrors gc itself: declared city.toml workspace.name, then the
+    machine-local site binding (.gc/site.toml workspace_name), then the city
+    directory basename. gc init no longer writes workspace.name to city.toml,
+    so deployments commonly only carry the site binding.
+    """
+    workspace_cfg = city_cfg.get("workspace") or {}
+    if isinstance(workspace_cfg, dict):
+        name = str(workspace_cfg.get("name", "")).strip()
+        if name:
+            return name
+    root = city_root()
+    if not root:
+        return ""
+    site_path = os.path.join(root, ".gc", "site.toml")
+    try:
+        with open(site_path, "rb") as handle:
+            site_cfg = tomllib.load(handle)
+    except (OSError, tomllib.TOMLDecodeError):
+        site_cfg = {}
+    if isinstance(site_cfg, dict):
+        name = str(site_cfg.get("workspace_name", "")).strip()
+        if name:
+            return name
+    return pathlib.Path(root).name
+
+
 def discover_supervisor_gc_api_scope(city_cfg: dict[str, Any]) -> str:
     """Discover the supervisor API scope prefix for the city.
 
     Caches the result for 60 seconds to avoid hitting the supervisor
     on every API call.
     """
-    workspace_cfg = city_cfg.get("workspace") or {}
-    workspace_name = str(workspace_cfg.get("name", "")).strip() if isinstance(workspace_cfg, dict) else ""
+    workspace_name = resolved_workspace_name(city_cfg)
     cache_key = workspace_name or "__default__"
     now = time.monotonic()
     if cache_key in _supervisor_scope_cache:
@@ -2006,10 +2034,7 @@ def discover_supervisor_gc_api_scope(city_cfg: dict[str, Any]) -> str:
 
 
 def _discover_supervisor_gc_api_scope_uncached(city_cfg: dict[str, Any]) -> str:
-    workspace_cfg = city_cfg.get("workspace") or {}
-    workspace_name = ""
-    if isinstance(workspace_cfg, dict):
-        workspace_name = str(workspace_cfg.get("name", "")).strip()
+    workspace_name = resolved_workspace_name(city_cfg)
     request = urllib.request.Request(
         DEFAULT_SUPERVISOR_API_BASE + "/v0/cities",
         headers={

--- a/discord/tests/test_discord_gateway_service.py
+++ b/discord/tests/test_discord_gateway_service.py
@@ -1046,6 +1046,36 @@ class DiscordGatewayServiceTests(unittest.TestCase):
         self.assertEqual(receipt["status"], "delivered")
         self.assertEqual(receipt["delivery"], "broadcast")
 
+    def test_process_inbound_ambient_room_message_routes_unknown_alias_to_sticky_single_session(self) -> None:
+        common.set_chat_binding(
+            common.load_config(),
+            "room",
+            "22",
+            ["deacon__deacon"],
+            guild_id="1",
+            policy={"ambient_read_enabled": True, "allow_untargeted_ambient_delivery": True},
+        )
+        message = {
+            "id": "507-sticky-alias",
+            "guild_id": "1",
+            "channel_id": "22",
+            "content": "@deacon: can you check the dashboard deploy?",
+            "mentions": [],
+            "author": {"id": "u-5b2", "username": "alice"},
+        }
+
+        with mock.patch.object(common, "deliver_session_message", return_value={"status": "accepted"}) as deliver_session_message:
+            outcome = gateway_service.process_inbound_message(message, bot_user_id="999")
+
+        self.assertEqual(outcome["status"], "delivered")
+        deliver_session_message.assert_called_once()
+        self.assertEqual(deliver_session_message.call_args.args[0], "deacon__deacon")
+        receipt = common.load_chat_ingress("in-507-sticky-alias")
+        assert receipt is not None
+        self.assertEqual(receipt["status"], "delivered")
+        self.assertEqual(receipt["delivery"], "broadcast")
+        self.assertEqual(receipt["mentioned_aliases"], ["deacon"])
+
     def test_process_inbound_ambient_room_message_ignores_unknown_alias_with_receipt(self) -> None:
         common.set_chat_binding(
             common.load_config(),

--- a/discord/tests/test_discord_intake_common.py
+++ b/discord/tests/test_discord_intake_common.py
@@ -506,6 +506,36 @@ class DiscordIntakeCommonTests(unittest.TestCase):
 
         self.assertEqual(urlopen.call_count, 1)
 
+    def test_gc_api_base_url_uses_site_workspace_name_when_city_toml_omits_name(self) -> None:
+        pathlib.Path(self.tempdir.name, "city.toml").write_text(
+            "[workspace]\nmax_active_sessions = 5\n",
+            encoding="utf-8",
+        )
+        site_dir = pathlib.Path(self.tempdir.name, ".gc")
+        site_dir.mkdir()
+        (site_dir / "site.toml").write_text('workspace_name = "gc"\n', encoding="utf-8")
+        common._supervisor_scope_cache.clear()
+        response = mock.Mock()
+        response.__enter__ = mock.Mock(
+            return_value=mock.Mock(read=mock.Mock(return_value=b'{"items":[{"name":"gc","running":true}]}'))
+        )
+        response.__exit__ = mock.Mock(return_value=False)
+
+        with mock.patch.object(common.urllib.request, "urlopen", return_value=response):
+            self.assertEqual(common.gc_api_base_url(), "http://127.0.0.1:8372")
+
+    def test_gc_api_base_url_falls_back_to_city_dir_basename_when_no_declared_name(self) -> None:
+        pathlib.Path(self.tempdir.name, "city.toml").write_text("", encoding="utf-8")
+        common._supervisor_scope_cache.clear()
+        basename = pathlib.Path(self.tempdir.name).name
+        body = ('{"items":[{"name":"%s","running":true}]}' % basename).encode("utf-8")
+        response = mock.Mock()
+        response.__enter__ = mock.Mock(return_value=mock.Mock(read=mock.Mock(return_value=body)))
+        response.__exit__ = mock.Mock(return_value=False)
+
+        with mock.patch.object(common.urllib.request, "urlopen", return_value=response):
+            self.assertEqual(common.gc_api_base_url(), "http://127.0.0.1:8372")
+
     def test_gc_api_base_url_falls_back_when_supervisor_city_missing(self) -> None:
         pathlib.Path(self.tempdir.name, "city.toml").write_text(
             '[workspace]\nname = "gc"\n[api]\nbind = "0.0.0.0"\nport = 9555\n',

--- a/github/README.md
+++ b/github/README.md
@@ -1,6 +1,6 @@
 # GitHub Intake Pack
 
-Workspace-hosted GitHub slash-command intake for Gas City.
+Workspace-hosted GitHub comment and event intake for Gas City.
 
 This pack keeps `gastown-hosted` generic. It runs the GitHub-facing service
 inside the workspace and exports it through the normal published-service path:
@@ -12,18 +12,23 @@ inside the workspace and exports it through the normal published-service path:
 The current slice ships:
 
 - GitHub App manifest/bootstrap hosted by the workspace service
+- env-backed or identity-resolved GitHub App secrets for service runtimes
 - webhook signature validation
 - durable receipt and request persistence
+- checked-in event rules loaded from `config/github-intake/rules.toml`
+- repo-scoped addressed-message intake such as `@mayor <request>`
 - issue-only `/gc fix ...` command parsing with multiline context support
 - per-issue idempotency for `/gc fix`
 - write/admin permission verification through the imported GitHub App
-- rig bead creation plus `gc sling <target> <bead> --on <formula>` dispatch
+- bugflow source-bead creation plus immediate bugflow router scan
 - pack commands for issue comments, authenticated branch push, and PR creation
-- `mol-github-fix-issue` workflow for TDD bugfixes
+- `/gc fix` routing into the workflows-pack `mol-bug-report-flow-v2` pipeline
 - issue-only `/gc fix` routing for this phase; other `/gc` commands are intentionally ignored
 
-The new `/gc fix` path does not post an immediate ack comment. The workflow
-itself comments when work starts and when the PR is ready for review.
+The `/gc fix` path posts a queued-in-bugflow acknowledgement after the bugflow
+source bead and router scan succeed. Bugflow snapshots the issue and comments,
+then owns investigation, classification, implementation gates, PR review, CI,
+and final issue updates.
 
 If a dispatched workflow gets wedged and you need to retry the same issue
 before cancel/retry automation exists, release the intake lock manually:
@@ -51,16 +56,169 @@ This pack expects helper-backed published services. After the workspace starts,
 Open the tenant-visible `github-admin` URL to register the GitHub App from the
 hosted manifest helper.
 
-## Repository Mapping
+## Bugflow Routing
 
-After app bootstrap, map repositories to slash-command targets:
+`/gc fix` now uses the workflows-pack bugflow router. Configure repository
+routing with the shared workflows routing config:
 
 ```bash
-gc github map-repo owner/repo rig/polecat \
-  --fix-formula mol-github-fix-issue
+gc workflows pr-review config set-repo owner/repo \
+  --city /abs/path/to/city \
+  --rig <rig> \
+  --base-branch main
 ```
 
-That stores dispatch config locally under `.gc/services/github/data/`.
+The legacy `gc github map-repo ... --fix-formula mol-github-fix-issue`
+command still records old direct-fix mappings in
+`.gc/services/github/data/`, but `/gc fix` no longer requires those
+mappings.
+
+## Event Rules
+
+City-owned event rules live at `config/github-intake/rules.toml` by default
+or at `$GC_GITHUB_INTAKE_RULES_FILE` when set. Rules match exact dotted
+GitHub payload fields and run ordered actions synchronously. The first action
+type is `order`, which runs a checked-in Gas City order with GitHub event
+context in environment variables:
+
+```toml
+version = 1
+
+[[rule]]
+id = "pr-review-on-needs-review-label"
+event = "pull_request"
+
+[rule.match]
+action = "labeled"
+label.name = "status/needs-review"
+pull_request.state = "open"
+
+[[rule.action]]
+type = "order"
+name = "pr-review-request"
+github_app_token_env = "GH_TOKEN"
+```
+
+Rules ignore events sent by the configured GitHub App bot by default. Set
+`allow_self = true` on a rule when bot-authored label changes are intentional
+triggers, such as a GitHub Action adding `status/needs-triage`.
+
+The order receives fields such as `GC_GITHUB_PR_URL`, `GC_GITHUB_ISSUE_URL`,
+`GC_GITHUB_REPO`, `GC_GITHUB_ITEM_NUMBER`, and
+`GC_GITHUB_EVENT_PAYLOAD_FILE`. When
+`github_app_token_env` is set, the service mints a short-lived installation
+token for the webhook installation and injects it only into that order run.
+
+## Addressed Messages
+
+The same rules file can define repo-scoped comment addresses. Addressed
+messages use the webhook edge for `issue_comment.created`: the webhook creates
+or reuses the source bead and kicks the addressed router in the background. The
+handling session posts the acknowledgement as the addressed profile before
+acting. The `github-addressed-message-router` cooldown order keeps running as
+the reconciliation path for missed comments or interrupted dispatch.
+
+```toml
+version = 1
+
+[[repo]]
+full_name = "owner/repo"
+rig = "product"
+authorized_users = ["alice", "bob"]
+installation_id = "123456"
+
+[[repo.address]]
+address = "@mayor"
+pool = "mayor"
+profile = "mayor"
+github_app_identity = "mayor"
+installation_id = "234567"
+formula = "github-addressed-message"
+ack = true
+```
+
+Only configured addresses are considered. The sender login must appear in the
+repo-level `authorized_users` snapshot. Bot comments are ignored. Empty
+mentions such as `@mayor` create no work and receive an error reply when the
+profile GitHub App can comment. When a comment contains a configured address,
+addressed message intake owns that comment; the legacy `/gc` parser is not also
+run for the same webhook delivery.
+
+Valid addressed comments create or reuse a source bead keyed by
+`github-comment:<repo-id>:<comment-id>:<address>`. The webhook does not post
+the accepted-request ack. Instead, it stores the addressed profile's
+`github_app_identity`, profile `installation_id`, and `ack` setting on the
+source bead. The addressed router then slings the configured formula to
+`<rig>/<pool>`; that formula tells the handling session to post the ack exactly
+once with `gc github comment-issue --github-app-identity ...` before
+doing request side effects. The address-level `installation_id` is the profile
+App installation for that repository owner; it may differ from the repo-level
+intake App installation used for webhook scans. The addressed router records
+`addressed.workflow_root`, and closes the source bead. The repo-level `rig`
+setting maps a GitHub path to a local Gas City rig name. If omitted,
+`owner/repo` falls back to the derived rig `github-owner-repo`; with
+`rig = "product"`, the example dispatch target is `product/mayor`. Duplicate
+webhook deliveries and backup scans converge on the same source key.
+
+The backup scan uses `gh` to inspect issues and PRs updated in the last seven
+days, including closed items. It mints a GitHub App installation token from the repo
+`installation_id` before calling `gh`; repos without an installation id are
+skipped by the backup scan until the app is installed/configured. Edited
+comments are skipped by the scan so comment edits do not create new concierge
+work.
+
+## Runtime Secrets
+
+The service supports manual App import into state, environment-backed
+credentials, and identity-resolved credentials. Production deployments should
+prefer an identity resolver so restarts and secret rotation converge without
+manual import. Set `GITHUB_INTAKE_APP_IDENTITY` to the intake App identity and
+`GITHUB_INTAKE_IDENTITY_RESOLVER` to a command that returns the v1 resolver JSON
+document. The service syncs that identity on startup, the webhook path retries
+the sync before returning a missing-secret error, and the
+`github-intake-sync-app` cooldown order refreshes the persisted config every
+five minutes.
+
+Manual environment keys are still supported:
+
+```text
+GITHUB_APP_ID
+GITHUB_INSTALLATION_ID
+GITHUB_APP_PRIVATE_KEY_PEM
+GITHUB_WEBHOOK_SECRET
+GITHUB_APP_SLUG
+GITHUB_APP_NAME
+GITHUB_APP_HTML_URL
+GITHUB_APP_CLIENT_ID
+GITHUB_APP_CLIENT_SECRET
+```
+
+Addressed profile replies load their own GitHub App bundle from
+`repo.address.github_app_identity`. The identity is a deployment-local key,
+not a secret-store path; it must match
+`[A-Za-z0-9][A-Za-z0-9._:-]{0,127}`. When an address sets that field,
+configure `GITHUB_INTAKE_IDENTITY_RESOLVER` to a command that accepts the
+identity as its only argument and writes a v1 resolver JSON object to stdout.
+The full contract and local-file quick start live in
+[`docs/github-app-identity.md`](docs/github-app-identity.md).
+
+The write side is symmetric: set `GITHUB_INTAKE_IDENTITY_PUBLISHER` to a
+command that accepts the identity as its only argument and reads the v1
+identity JSON from stdin. After the manifest onboarding callback or a manual
+`/v0/github/app/import`, the service runs the publisher so new credentials
+land in your secret store instead of staying only in the local service
+config. With no publisher configured the hook is a no-op, and publish
+failures are logged without breaking credential capture. A portable
+file-backed pair ships in `examples/`: `file_identity_publisher.py` writes
+`$GITHUB_INTAKE_IDENTITY_DIR/<identity>.json` (0600, merge-on-republish) and
+`file_identity_resolver.py` reads it back — a full onboarding round-trip with
+no secret store required.
+
+To sync the intake App from the configured resolver immediately:
+
+```bash
+gc github sync-app
+```
 
 ## Manual App Import
 
@@ -87,6 +245,10 @@ The pack also exposes helper commands the workflow can call directly:
 
 ```bash
 gc github comment-issue owner/repo 42 --installation-id 123 --body "hello"
+gc github comment-issue owner/repo 42 \
+  --installation-id 234 \
+  --github-app-identity mayor \
+  --body "hello from the addressed profile"
 gc github push-branch owner/repo --installation-id 123 --branch fix-42
 gc github create-pr owner/repo --installation-id 123 --base main --head fix-42 --title "fix: widget"
 ```

--- a/github/commands/comment-issue/help.md
+++ b/github/commands/comment-issue/help.md
@@ -3,6 +3,7 @@ Post an issue comment using the workspace-owned GitHub App installation.
 Example:
   gc github comment-issue owner/repo 42 \
     --installation-id 123456 \
+    --github-app-identity mayor \
     --body "Started work on this issue"
 
 Arguments:
@@ -10,6 +11,7 @@ Arguments:
   <issue-number> GitHub issue number
 
 Flags:
-  --installation-id <id>    GitHub App installation id
-  --body <text>             inline markdown body
-  --body-file <path>        read markdown body from file
+  --installation-id <id>          GitHub App installation id, unless identity resolves one
+  --github-app-identity <identity>     GitHub App identity for the comment author; see docs/github-app-identity.md
+  --body <text>                   inline markdown body
+  --body-file <path>              read markdown body from file

--- a/github/commands/sync-app.sh
+++ b/github/commands/sync-app.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -eu
+
+if [ -z "${GC_CITY_PATH:-}" ] || [ -z "${GC_PACK_DIR:-}" ]; then
+  echo "gc github sync-app: missing Gas City pack context" >&2
+  exit 1
+fi
+
+exec python3 "$GC_PACK_DIR/scripts/github_intake_sync_app.py" "$@"

--- a/github/commands/sync-app/command.toml
+++ b/github/commands/sync-app/command.toml
@@ -1,0 +1,2 @@
+description = 'Sync GitHub App configuration from the configured identity resolver'
+run = '../sync-app.sh'

--- a/github/commands/sync-app/help.md
+++ b/github/commands/sync-app/help.md
@@ -1,0 +1,11 @@
+Sync the GitHub intake App configuration from the configured identity resolver.
+
+Examples:
+  gc github sync-app
+  gc github sync-app --identity mayor
+  gc github sync-app --json
+
+By default the command reads `GITHUB_INTAKE_APP_IDENTITY` from the city
+workspace environment, resolves it through `GITHUB_INTAKE_IDENTITY_RESOLVER`,
+and writes the redacted App metadata plus secret material into the pack state.
+Secret values are not printed.

--- a/github/docs/github-app-identity.md
+++ b/github/docs/github-app-identity.md
@@ -1,0 +1,146 @@
+# GitHub App Identity Resolver Contract
+
+`github_app_identity` lets an addressed GitHub request reply as the profile
+that handled the request. The public pack treats the identity as an opaque
+deployment-local key. Secret stores, file paths, and organization policy belong
+behind the resolver command, not in `rules.toml`.
+
+## Identity String
+
+An identity must match:
+
+```text
+[A-Za-z0-9][A-Za-z0-9._:-]{0,127}
+```
+
+Examples: `mayor`, `review-bot`, `prod:mayor`, `team_a.mayor`.
+
+Do not put secret-store paths, file paths, GitHub private keys, tokens, or
+installation tokens in `github_app_identity`.
+
+## Resolver Command
+
+Set `GITHUB_INTAKE_IDENTITY_RESOLVER` to an executable command. github-intake
+calls it as:
+
+```bash
+$GITHUB_INTAKE_IDENTITY_RESOLVER <identity>
+```
+
+The command must:
+
+- accept exactly one identity argument
+- write exactly one JSON object to stdout
+- write diagnostics to stderr
+- exit nonzero when the identity cannot be resolved
+- never log private key material, tokens, or webhook secrets to stderr
+
+## Schema V1
+
+The resolver JSON object must include:
+
+```json
+{
+  "schema_version": "github-intake.github-app-identity.v1",
+  "app_id": "123456",
+  "private_key_pem": "-----BEGIN PRIVATE KEY-----\\n...\\n-----END PRIVATE KEY-----\\n"
+}
+```
+
+Optional fields:
+
+```json
+{
+  "installation_id": "987654",
+  "webhook_secret": "...",
+  "client_id": "Iv1.example",
+  "client_secret": "...",
+  "slug": "my-app",
+  "html_url": "https://github.com/apps/my-app",
+  "name": "My App",
+  "owner": "my-org",
+  "ready": true
+}
+```
+
+If `ready` is present, it must be `1`, `true`, or `yes`. For
+`gc github comment-issue`, `installation_id` may come from either the
+resolver JSON or the command's `--installation-id` flag.
+
+## Quick Start: Local File Resolver
+
+For a small city or local test, store identity JSON outside committed source and
+use the example resolver:
+
+```bash
+mkdir -p config/github-intake/identities
+chmod 700 config/github-intake/identities
+cat >config/github-intake/identities/mayor.json <<'JSON'
+{
+  "schema_version": "github-intake.github-app-identity.v1",
+  "app_id": "123456",
+  "installation_id": "987654",
+  "private_key_pem": "-----BEGIN PRIVATE KEY-----\\nreplace me\\n-----END PRIVATE KEY-----\\n",
+  "ready": true
+}
+JSON
+chmod 600 config/github-intake/identities/mayor.json
+export GITHUB_INTAKE_IDENTITY_RESOLVER="/abs/path/to/github-intake/examples/file_identity_resolver.py"
+```
+
+Then configure an address:
+
+```toml
+[[repo.address]]
+address = "@mayor"
+pool = "mayor"
+profile = "mayor"
+github_app_identity = "mayor"
+formula = "github-addressed-message"
+ack = true
+```
+
+For production, replace the file resolver with a resolver backed by your secret
+store. Keep the public identity stable and move all store-specific naming and
+credential rotation policy into the resolver.
+
+## Publisher Command
+
+The publisher is the write-side mirror of the resolver. When
+`GITHUB_INTAKE_IDENTITY_PUBLISHER` is set (process environment or city
+`[workspace.env]`), the service runs it after credentials are captured — the
+manifest onboarding callback and the admin `/v0/github/app/import` endpoint —
+so freshly created App credentials land in your secret store instead of being
+stranded in the service's local `config.json`.
+
+Invocation contract:
+
+- The command is invoked with the identity string as its only argument, the
+  same shape as the resolver.
+- The identity JSON document (schema v1, see above) arrives on stdin with
+  `schema_version` stamped; empty fields are omitted.
+- Exit 0 means published. Any other exit reports a publish failure, which the
+  service logs and surfaces but never treats as fatal — credential capture
+  must not be broken by a misbehaving store. With no publisher configured the
+  hook is a clean no-op.
+
+## Quick Start: Local File Publisher
+
+`examples/file_identity_publisher.py` is the write-side pair of the file
+resolver: it persists the incoming identity to
+`$GITHUB_INTAKE_IDENTITY_DIR/<identity>.json` (0600, atomic, merge-on-update
+so operator-set fields like `permissions` survive a partial republish), which
+is exactly the file the example resolver reads back:
+
+```bash
+export GITHUB_INTAKE_APP_IDENTITY="mayor"
+export GITHUB_INTAKE_IDENTITY_PUBLISHER="/abs/path/to/github/examples/file_identity_publisher.py"
+export GITHUB_INTAKE_IDENTITY_RESOLVER="/abs/path/to/github/examples/file_identity_resolver.py"
+```
+
+With both set, the manifest onboarding flow round-trips with no secret store
+at all: create the App in the browser, the callback publishes the credentials
+to the identity file, and the resolver (service startup, sync-app order)
+reads them back. The `ready` flag in the file is derived from field
+completeness, never trusted from the caller. For production, swap the
+publisher for one backed by your secret store and keep the same contract.

--- a/github/examples/file_identity_publisher.py
+++ b/github/examples/file_identity_publisher.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Publish github-intake GitHub App identities to local JSON files.
+
+Write-side mirror of ``file_identity_resolver.py``: the pack's identity
+publish hook pipes the freshly captured app identity to this script on STDIN,
+and it persists it to ``$GITHUB_INTAKE_IDENTITY_DIR/<identity>.json`` (0600) —
+the exact file the resolver reads back. Together they give a portable,
+dependency-free round-trip (create → publish to file → resolve from file);
+a secret-store-backed publisher (Vault, a cloud secret manager, ...) is the
+production variant of the same contract.
+
+The identity name arrives as the only positional argument (symmetric with the
+resolver invocation); ``GITHUB_INTAKE_APP_IDENTITY`` is the fallback for
+manual use. The directory comes from ``GITHUB_INTAKE_IDENTITY_DIR`` (default
+``config/github-intake/identities``), matching the resolver so both ends
+agree.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import re
+import sys
+import tempfile
+from typing import Any
+
+SCHEMA_VERSION = "github-intake.github-app-identity.v1"
+IDENTITY_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+
+# Fields the resolver expects; we persist whichever are present and merge over
+# an existing file so operator-set values (permissions, repos, ...) survive a
+# republish that only carries a subset (e.g. a later installation_id capture).
+IDENTITY_FIELDS = (
+    "app_id",
+    "client_id",
+    "client_secret",
+    "webhook_secret",
+    "slug",
+    "html_url",
+    "name",
+    "installation_id",
+    "owner",
+    "private_key_pem",
+    "permissions",
+    "repos",
+    "token_ttl_seconds",
+    "ready",
+)
+
+
+def identity_dir() -> pathlib.Path:
+    return pathlib.Path(
+        os.environ.get("GITHUB_INTAKE_IDENTITY_DIR", "config/github-intake/identities")
+    ).expanduser()
+
+
+def validate_identity(identity: str) -> str:
+    identity = identity.strip()
+    if not IDENTITY_PATTERN.fullmatch(identity):
+        raise ValueError("identity must match [A-Za-z0-9][A-Za-z0-9._:-]{0,127}")
+    return identity
+
+
+def read_existing(path: pathlib.Path) -> dict[str, Any]:
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def is_ready(payload: dict[str, Any]) -> bool:
+    return all(str(payload.get(key, "")).strip() for key in ("app_id", "private_key_pem", "webhook_secret"))
+
+
+def atomic_write(path: pathlib.Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=f".{path.name}.")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+        os.chmod(tmp, 0o600)
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def publish(identity: str, incoming: dict[str, Any]) -> pathlib.Path:
+    identity = validate_identity(identity)
+    path = identity_dir() / f"{identity}.json"
+    merged = read_existing(path)
+    for key in IDENTITY_FIELDS:
+        value = incoming.get(key)
+        if value not in (None, ""):
+            merged[key] = value
+    merged["schema_version"] = SCHEMA_VERSION
+    # ``ready`` is derived, not trusted from the caller, so a partial republish
+    # can't falsely mark an incomplete identity ready.
+    merged["ready"] = "true" if is_ready(merged) else "false"
+    atomic_write(path, merged)
+    return path
+
+
+def main(argv: list[str]) -> int:
+    identity = argv[0] if argv else os.environ.get("GITHUB_INTAKE_APP_IDENTITY", "").strip()
+    if not identity:
+        print(
+            "github-intake identity publish failed: pass the identity as the only "
+            "argument or set GITHUB_INTAKE_APP_IDENTITY",
+            file=sys.stderr,
+        )
+        return 2
+    try:
+        incoming = json.load(sys.stdin)
+    except json.JSONDecodeError as exc:
+        print(f"github-intake identity publish failed: invalid identity JSON on stdin: {exc}", file=sys.stderr)
+        return 1
+    if not isinstance(incoming, dict):
+        print("github-intake identity publish failed: identity payload must be a JSON object", file=sys.stderr)
+        return 1
+    try:
+        path = publish(identity, incoming)
+    except (OSError, ValueError) as exc:
+        print(f"github-intake identity publish failed: {exc}", file=sys.stderr)
+        return 1
+    published = json.loads(path.read_text(encoding="utf-8"))
+    print(json.dumps({"published": True, "path": str(path), "ready": published.get("ready") == "true"}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/github/examples/file_identity_resolver.py
+++ b/github/examples/file_identity_resolver.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Resolve github-intake GitHub App identities from local JSON files."""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import re
+import sys
+from typing import Any
+
+SCHEMA_VERSION = "github-intake.github-app-identity.v1"
+IDENTITY_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+
+
+def identity_dir() -> pathlib.Path:
+    return pathlib.Path(os.environ.get("GITHUB_INTAKE_IDENTITY_DIR", "config/github-intake/identities")).expanduser()
+
+
+def validate_identity(identity: str) -> str:
+    identity = identity.strip()
+    if not IDENTITY_PATTERN.fullmatch(identity):
+        raise ValueError("identity must match [A-Za-z0-9][A-Za-z0-9._:-]{0,127}")
+    return identity
+
+
+def load_identity(identity: str) -> dict[str, Any]:
+    identity = validate_identity(identity)
+    path = identity_dir() / f"{identity}.json"
+    with open(path, "r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain one JSON object")
+    if payload.get("schema_version") != SCHEMA_VERSION:
+        raise ValueError(f"{path} must set schema_version to {SCHEMA_VERSION!r}")
+    for key in ("app_id", "private_key_pem"):
+        if not str(payload.get(key, "")).strip():
+            raise ValueError(f"{path} is missing required field {key!r}")
+    return payload
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 1:
+        print("usage: file_identity_resolver.py <identity>", file=sys.stderr)
+        return 2
+    try:
+        payload = load_identity(argv[0])
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"github-intake identity resolution failed: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/github/formulas/github-addressed-message.formula.toml
+++ b/github/formulas/github-addressed-message.formula.toml
@@ -1,0 +1,189 @@
+description = """
+Generic GitHub addressed-message workflow.
+
+This formula is attached by github-intake when a configured repository address
+such as `@mayor` is mentioned in an issue or PR comment. The address maps to a
+configured pool; this formula gives the request-scoped worker normalized
+GitHub context without requiring it to parse webhook JSON.
+"""
+formula = "github-addressed-message"
+version = 1
+
+[vars]
+[vars.source_bead_id]
+description = "Addressed-message source bead id"
+required = true
+
+[vars.city_root]
+description = "City root that owns the addressed-message source bead and GitHub intake state"
+default = ""
+
+[vars.address]
+description = "Configured address token that matched the GitHub comment"
+required = true
+
+[vars.request_text]
+description = "Comment body after configured address tokens were removed"
+required = true
+
+[vars.github_repo]
+description = "Repository in owner/repo format"
+required = true
+
+[vars.github_issue_number]
+description = "GitHub issue or PR number for commenting back"
+required = true
+
+[vars.github_item_url]
+description = "GitHub issue or PR URL"
+required = true
+
+[vars.github_comment_url]
+description = "Triggering GitHub comment URL"
+required = true
+
+[vars.github_app_installation_id]
+description = "GitHub App installation id for the addressed profile comment identity"
+default = ""
+
+[vars.github_app_identity]
+description = "Credential identity for the addressed profile GitHub App"
+default = ""
+
+[vars.acknowledgement_requested]
+description = "Whether the handling session should post the acknowledgement comment"
+default = "true"
+
+[vars.github_sender]
+description = "GitHub username that posted the triggering comment"
+required = true
+
+[vars.external_source_key]
+description = "Canonical dedupe key for this addressed-message source"
+required = true
+
+[vars.raw_payload_path]
+description = "Path to the raw persisted GitHub payload when available"
+default = ""
+
+[[steps]]
+id = "handle-request"
+title = "Handle GitHub addressed request"
+description = """
+Handle the GitHub addressed-message request.
+
+## Source
+
+- Source bead: `{{source_bead_id}}`
+- Address: `{{address}}`
+- Requested by: `{{github_sender}}`
+- Repository: `{{github_repo}}`
+- Thread: {{github_item_url}}
+- Comment: {{github_comment_url}}
+- GitHub issue/PR number: `{{github_issue_number}}`
+- GitHub App installation: `{{github_app_installation_id}}`
+- GitHub App identity: `{{github_app_identity}}`
+- Acknowledgement requested: `{{acknowledgement_requested}}`
+- Source key: `{{external_source_key}}`
+- Raw payload: `{{raw_payload_path}}`
+
+## Request
+
+{{request_text}}
+
+## Working Rules
+
+Read the source bead before acting:
+
+```bash
+gc bd show {{source_bead_id}}
+```
+
+If `{{acknowledgement_requested}}` is not `false`, post the acknowledgement
+comment before other side effects. The webhook intentionally did not post this
+acknowledgement; the addressed handling session owns it so the comment is made
+by the same GitHub App profile handling the request.
+
+Post the acknowledgement exactly once:
+
+```bash
+if [ -n "{{city_root}}" ]; then
+  export GC_CITY_ROOT="{{city_root}}"
+fi
+SOURCE_JSON=$(gc bd show {{source_bead_id}} --json)
+ACKED=$(printf '%s' "$SOURCE_JSON" | jq -r '((if type == "array" then .[0] else . end).metadata // {})["addressed.ack_comment_id"] // empty')
+if [ "{{acknowledgement_requested}}" != "false" ] && [ -z "$ACKED" ]; then
+  BODY=$(mktemp)
+  cat >"$BODY" <<'EOF'
+Received `{{address}}` request as `{{source_bead_id}}`.
+
+I am handling it now and will follow up here with the result or blocker.
+
+Source request: {{github_comment_url}}
+EOF
+  COMMENT_ARGS=(github comment-issue "{{github_repo}}" "{{github_issue_number}}" --installation-id "{{github_app_installation_id}}" --body-file "$BODY")
+  if [ -n "{{github_app_identity}}" ]; then
+    COMMENT_ARGS+=(--github-app-identity "{{github_app_identity}}")
+  fi
+  COMMENT_JSON=$(gc "${COMMENT_ARGS[@]}")
+  COMMENT_ID=$(printf '%s' "$COMMENT_JSON" | jq -r '.id // empty')
+  COMMENT_URL=$(printf '%s' "$COMMENT_JSON" | jq -r '.html_url // empty')
+  if [ -n "$COMMENT_ID" ]; then
+    gc bd update {{source_bead_id}} \
+      --set-metadata addressed.ack_comment_id="$COMMENT_ID" \
+      --set-metadata addressed.ack_comment_url="$COMMENT_URL" \
+      --set-metadata addressed.acknowledged_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  fi
+  rm -f "$BODY"
+fi
+```
+
+Use the configured city tools and prompts to decide the next concrete action.
+If this request should start a workflow, create the appropriate durable work
+and record the result on `{{source_bead_id}}` or the current workflow bead.
+If the request is a codebase question, answer from repository evidence and cite
+the files or commands you inspected.
+
+## GitHub Response Contract
+
+The GitHub thread is the user-visible response channel. Before closing this
+workflow step, post one final response comment to {{github_item_url}} with the
+result, blocker, durable work IDs created, or dry-run plan. Dry-run requests still require a GitHub comment; do not treat in-session output as enough.
+
+Local session output, bead metadata, and in-session summaries are not completion.
+They are useful working notes, but the requester is waiting on the GitHub
+thread.
+
+Use the addressed profile identity for the final response:
+
+```bash
+if [ -n "{{city_root}}" ]; then
+  export GC_CITY_ROOT="{{city_root}}"
+fi
+RESPONSE_BODY=$(mktemp)
+cat >"$RESPONSE_BODY" <<'EOF'
+<write the final result, blocker, durable work IDs, or dry-run plan here>
+EOF
+RESPONSE_ARGS=(github comment-issue "{{github_repo}}" "{{github_issue_number}}" --installation-id "{{github_app_installation_id}}" --body-file "$RESPONSE_BODY")
+if [ -n "{{github_app_identity}}" ]; then
+  RESPONSE_ARGS+=(--github-app-identity "{{github_app_identity}}")
+fi
+RESPONSE_JSON=$(gc "${RESPONSE_ARGS[@]}")
+RESPONSE_ID=$(printf '%s' "$RESPONSE_JSON" | jq -r '.id // empty')
+RESPONSE_URL=$(printf '%s' "$RESPONSE_JSON" | jq -r '.html_url // empty')
+if [ -n "$RESPONSE_ID" ]; then
+  gc bd update {{source_bead_id}} \
+    --set-metadata addressed.response_comment_id="$RESPONSE_ID" \
+    --set-metadata addressed.response_comment_url="$RESPONSE_URL" \
+    --set-metadata addressed.responded_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+fi
+rm -f "$RESPONSE_BODY"
+```
+
+If posting the final GitHub comment fails, record the error on
+`{{source_bead_id}}` or the current workflow bead so operators can see that no
+GitHub response was delivered.
+
+Close this workflow step only after the GitHub final response comment succeeds,
+or after you have recorded the final-comment failure with the concrete error.
+"""

--- a/github/formulas/mol-github-fix-issue.formula.toml
+++ b/github/formulas/mol-github-fix-issue.formula.toml
@@ -128,7 +128,9 @@ WORKTREE=$(bd show {{issue}} --json | jq -r '.metadata.work_dir // empty')
 if [ -n "$WORKTREE" ] && [ -d "$WORKTREE" ]; then
   cd "$WORKTREE"
 else
-  WORKTREE_PATH=$(pwd)/worktrees/{{issue}}
+  WORKTREE_ROOT="$(pwd)/.gc/worktrees"
+  mkdir -p "$WORKTREE_ROOT"
+  WORKTREE_PATH="$WORKTREE_ROOT/{{issue}}"
   git worktree add "$WORKTREE_PATH" --detach origin/{{github_default_branch}}
   cd "$WORKTREE_PATH"
   bd update {{issue}} --set-metadata work_dir="$WORKTREE_PATH"
@@ -364,8 +366,14 @@ fi
 PR_URL=$(bd show {{issue}} --json | jq -r '.metadata.github_fix_pr_url // empty')
 WORKTREE=$(bd show {{issue}} --json | jq -r '.metadata.work_dir // empty')
 if [ -n "$WORKTREE" ] && [ -d "$WORKTREE" ]; then
-  cd "$(dirname "$WORKTREE")"
-  git worktree remove "$WORKTREE" --force
+  GIT_COMMON_DIR=$(git -C "$WORKTREE" rev-parse --git-common-dir)
+  case "$GIT_COMMON_DIR" in
+    /*) ;;
+    *) GIT_COMMON_DIR="$WORKTREE/$GIT_COMMON_DIR" ;;
+  esac
+  CLEANUP_CWD=$(dirname "$GIT_COMMON_DIR")
+  cd "$CLEANUP_CWD" || exit 1
+  git --git-dir="$GIT_COMMON_DIR" worktree remove "$WORKTREE" --force
   bd update {{issue}} --unset-metadata work_dir
 fi
 CURRENT_NOTES=$(bd show {{issue}} --json | jq -r '.notes // empty')

--- a/github/orders/github-addressed-message-router.toml
+++ b/github/orders/github-addressed-message-router.toml
@@ -1,0 +1,6 @@
+[order]
+description = "Reconcile GitHub addressed comments and dispatch addressed-message source beads"
+trigger = "cooldown"
+interval = "5m"
+exec = "$ORDER_DIR/scripts/github-addressed-message-router.sh"
+timeout = "10m"

--- a/github/orders/github-intake-sync-app.toml
+++ b/github/orders/github-intake-sync-app.toml
@@ -1,0 +1,6 @@
+[order]
+description = "Refresh GitHub intake App configuration from the configured identity resolver"
+trigger = "cooldown"
+interval = "5m"
+exec = "$ORDER_DIR/scripts/github-intake-sync-app.sh"
+timeout = "2m"

--- a/github/orders/scripts/github-addressed-message-router.sh
+++ b/github/orders/scripts/github-addressed-message-router.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+order_dir="${ORDER_DIR:-$(cd "$script_dir/.." && pwd -P)}"
+pack_root="${PACK_DIR:-$(cd "$order_dir/.." && pwd -P)}"
+sweep_limit="${GITHUB_INTAKE_ADDRESS_SWEEP_LIMIT:-50}"
+sweep_days="${GITHUB_INTAKE_ADDRESS_SWEEP_DAYS:-7}"
+
+rc=0
+python3 "$pack_root/scripts/github_intake_addressed.py" sweep-comments --limit "$sweep_limit" --days "$sweep_days" --fail-on-error || rc=$?
+python3 "$pack_root/scripts/github_intake_addressed.py" router-scan --fail-on-error || rc=$?
+exit "$rc"

--- a/github/orders/scripts/github-intake-sync-app.sh
+++ b/github/orders/scripts/github-intake-sync-app.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+order_dir="${ORDER_DIR:-$(cd "$script_dir/.." && pwd -P)}"
+pack_root="${PACK_DIR:-$(cd "$order_dir/.." && pwd -P)}"
+
+python3 "$pack_root/scripts/github_intake_sync_app.py" --quiet

--- a/github/scripts/github_intake_addressed.py
+++ b/github/scripts/github_intake_addressed.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import urllib.parse
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import github_intake_common as common
+import github_intake_service as service
+
+
+class AddressedError(RuntimeError):
+    pass
+
+
+def gh_timeout_seconds() -> int:
+    raw = os.environ.get("GITHUB_INTAKE_GH_TIMEOUT_SECONDS", "30").strip()
+    try:
+        timeout = int(raw)
+    except ValueError:
+        timeout = 30
+    return max(timeout, 1)
+
+
+def json_out(payload: dict[str, Any]) -> None:
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+def load_json_command(command: list[str], env: dict[str, str] | None = None) -> Any:
+    timeout = gh_timeout_seconds()
+    try:
+        result = subprocess.run(command, capture_output=True, text=True, check=False, env=env, timeout=timeout)
+    except subprocess.TimeoutExpired as exc:
+        detail = service.trim_output(str(exc.stderr or exc.stdout or ""))
+        suffix = f": {detail}" if detail else ""
+        raise AddressedError(f"{' '.join(command)} timed out after {timeout}s{suffix}") from exc
+    if result.returncode != 0:
+        raise AddressedError(f"{' '.join(command)} failed: {service.trim_output(result.stderr or result.stdout)}")
+    try:
+        return json.loads(result.stdout or "null")
+    except json.JSONDecodeError as exc:
+        raise AddressedError(f"{' '.join(command)} returned invalid JSON: {exc}") from exc
+
+
+def decode_json_stream(raw: str) -> list[Any]:
+    values: list[Any] = []
+    decoder = json.JSONDecoder()
+    index = 0
+    raw = raw.strip()
+    while index < len(raw):
+        while index < len(raw) and raw[index].isspace():
+            index += 1
+        if index >= len(raw):
+            break
+        value, index = decoder.raw_decode(raw, index)
+        values.append(value)
+    return values
+
+
+def load_json_pages_command(command: list[str], env: dict[str, str] | None = None) -> list[Any]:
+    timeout = gh_timeout_seconds()
+    try:
+        result = subprocess.run(command, capture_output=True, text=True, check=False, env=env, timeout=timeout)
+    except subprocess.TimeoutExpired as exc:
+        detail = service.trim_output(str(exc.stderr or exc.stdout or ""))
+        suffix = f": {detail}" if detail else ""
+        raise AddressedError(f"{' '.join(command)} timed out after {timeout}s{suffix}") from exc
+    if result.returncode != 0:
+        raise AddressedError(f"{' '.join(command)} failed: {service.trim_output(result.stderr or result.stdout)}")
+    try:
+        return decode_json_stream(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise AddressedError(f"{' '.join(command)} returned invalid JSON: {exc}") from exc
+
+
+def parse_github_time(value: str) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def split_repo(full_name: str) -> tuple[str, str]:
+    owner, sep, name = full_name.partition("/")
+    if not sep or not owner or not name:
+        raise AddressedError(f"invalid repo full_name {full_name!r}")
+    return owner, name
+
+
+def gh_repo(repo: str, env: dict[str, str] | None) -> dict[str, Any]:
+    data = load_json_command(["gh", "api", f"repos/{repo}"], env=env)
+    if not isinstance(data, dict):
+        raise AddressedError(f"gh api repos/{repo} returned non-object JSON")
+    return data
+
+
+def gh_recent_items(repo: str, cutoff: datetime, limit: int, env: dict[str, str] | None) -> list[dict[str, Any]]:
+    query = f"repo:{repo} updated:>={cutoff.date().isoformat()}"
+    data = load_json_pages_command(["gh", "api", "--paginate", "-X", "GET", "search/issues", "-f", f"q={query}"], env=env)
+    if not isinstance(data, list):
+        raise AddressedError(f"search/issues for {repo} returned non-list JSON")
+    items: list[dict[str, Any]] = []
+    for page in data:
+        if not isinstance(page, dict):
+            continue
+        raw_items = page.get("items") or []
+        if not isinstance(raw_items, list):
+            continue
+        for item in raw_items:
+            if not isinstance(item, dict):
+                continue
+            items.append(
+                {
+                    "number": item.get("number", ""),
+                    "url": item.get("html_url", ""),
+                    "updatedAt": item.get("updated_at", ""),
+                    "title": item.get("title", ""),
+                    "kind": "pr" if item.get("pull_request") else "issue",
+                }
+            )
+            if limit > 0 and len(items) >= limit:
+                return items
+    return items
+
+
+def gh_issue_comments(repo: str, number: str, env: dict[str, str] | None) -> list[dict[str, Any]]:
+    data = load_json_pages_command(["gh", "api", "--paginate", f"repos/{repo}/issues/{number}/comments"], env=env)
+    if not isinstance(data, list):
+        raise AddressedError(f"comment list for {repo}#{number} returned non-list JSON")
+    comments: list[dict[str, Any]] = []
+    for page in data:
+        if isinstance(page, list):
+            comments.extend(item for item in page if isinstance(item, dict))
+        elif isinstance(page, dict):
+            comments.append(page)
+    return comments
+
+
+def repo_installation_id(repo_cfg: dict[str, Any], app_cfg: dict[str, Any]) -> str:
+    return str(
+        repo_cfg.get("installation_id")
+        or app_cfg.get("installation_id")
+        or os.environ.get("GC_GITHUB_INSTALLATION_ID", "")
+    ).strip()
+
+
+def gh_env_for_repo(repo_cfg: dict[str, Any], app_cfg: dict[str, Any]) -> dict[str, str]:
+    installation_id = repo_installation_id(repo_cfg, app_cfg)
+    if not installation_id:
+        raise AddressedError("repo address sweep requires repo.installation_id or GC_GITHUB_INSTALLATION_ID")
+    token = common.create_installation_token(app_cfg, installation_id)
+    env = os.environ.copy()
+    env["GH_TOKEN"] = token
+    parsed = urllib.parse.urlparse(common.github_web_base())
+    host = parsed.netloc
+    if host and host != "github.com":
+        env["GH_HOST"] = host
+        env["GH_ENTERPRISE_TOKEN"] = token
+    return env
+
+
+def build_sweep_payload(
+    repo_cfg: dict[str, Any],
+    repo_info: dict[str, Any],
+    item: dict[str, Any],
+    comment: dict[str, Any],
+    kind: str,
+    installation_id: str,
+) -> dict[str, Any]:
+    repo = str(repo_cfg.get("full_name", ""))
+    owner, name = split_repo(repo)
+    issue: dict[str, Any] = {
+        "number": item.get("number", ""),
+        "title": item.get("title", ""),
+        "html_url": item.get("url", ""),
+    }
+    if kind == "pr":
+        issue["pull_request"] = {"url": f"https://api.github.com/repos/{repo}/pulls/{item.get('number', '')}"}
+    payload = {
+        "action": "created",
+        "issue": issue,
+        "comment": {
+            "id": comment.get("id", ""),
+            "body": comment.get("body", ""),
+            "html_url": comment.get("html_url", ""),
+            "created_at": comment.get("created_at", ""),
+            "updated_at": comment.get("updated_at", ""),
+            "user": comment.get("user") or {},
+        },
+        "repository": {
+            "id": repo_info.get("id", ""),
+            "name": name,
+            "full_name": repo,
+            "default_branch": repo_info.get("default_branch", ""),
+            "owner": {"login": owner},
+        },
+    }
+    if installation_id:
+        payload["installation"] = {"id": installation_id}
+    return payload
+
+
+def sweep_comments(limit: int, days: int) -> dict[str, Any]:
+    rules = common.load_rules()
+    app_cfg = common.load_effective_config().get("app", {})
+    if not isinstance(app_cfg, dict):
+        app_cfg = {}
+    cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+    processed: list[dict[str, Any]] = []
+    skipped: list[dict[str, Any]] = []
+    failures: list[dict[str, Any]] = []
+    for repo_cfg in rules.get("repos") or []:
+        if not isinstance(repo_cfg, dict) or not repo_cfg.get("addresses"):
+            continue
+        repo = str(repo_cfg.get("full_name", ""))
+        try:
+            installation_id = repo_installation_id(repo_cfg, app_cfg)
+            if not installation_id:
+                skipped.append({"repo": repo, "reason": "installation_missing"})
+                continue
+            repo_env = gh_env_for_repo(repo_cfg, app_cfg)
+            repo_info = gh_repo(repo, repo_env)
+            items = gh_recent_items(repo, cutoff, limit, repo_env)
+        except Exception as exc:  # noqa: BLE001
+            failures.append({"repo": repo, "reason": "item_scan_failed", "detail": service.trim_output(str(exc))})
+            continue
+        seen_numbers: set[tuple[str, str]] = set()
+        for item in items:
+            number = str(item.get("number", ""))
+            kind = str(item.get("kind", "issue"))
+            if not number or (kind, number) in seen_numbers:
+                continue
+            seen_numbers.add((kind, number))
+            updated_at = parse_github_time(str(item.get("updatedAt", "")))
+            if updated_at and updated_at < cutoff:
+                skipped.append({"repo": repo, "number": number, "kind": kind, "reason": "outside_window"})
+                continue
+            try:
+                comments = gh_issue_comments(repo, number, repo_env)
+            except Exception as exc:  # noqa: BLE001
+                failures.append({"repo": repo, "number": number, "kind": kind, "reason": "comment_scan_failed", "detail": service.trim_output(str(exc))})
+                continue
+            for comment in comments:
+                created_at = str(comment.get("created_at", ""))
+                updated_comment_at = str(comment.get("updated_at", ""))
+                if created_at and updated_comment_at and created_at != updated_comment_at:
+                    skipped.append({"repo": repo, "number": number, "kind": kind, "comment_id": str(comment.get("id", "")), "reason": "edited_comment"})
+                    continue
+                payload = build_sweep_payload(repo_cfg, repo_info, item, comment, kind, installation_id)
+                extracted = common.extract_addressed_comment_requests(payload, rules)
+                if not extracted:
+                    continue
+                delivery_id = f"sweep-{repo_info.get('id', '')}-{comment.get('id', '')}"
+                common.save_delivery(
+                    {
+                        "delivery_id": delivery_id,
+                        "received_at": common.utcnow(),
+                        "event": "issue_comment",
+                        "source": "addressed-comment-sweep",
+                        "payload": payload,
+                    }
+                )
+                outcome = service.process_addressed_comment("issue_comment", delivery_id, payload, app_cfg)
+                processed.append({"repo": repo, "number": number, "kind": kind, "comment_id": str(comment.get("id", "")), "outcome": outcome})
+    return {
+        "status": "failed" if failures else "ok",
+        "processed_count": len(processed),
+        "skipped_count": len(skipped),
+        "failure_count": len(failures),
+        "processed": processed,
+        "skipped": skipped,
+        "failures": failures,
+    }
+
+
+def cmd_router_scan(args: argparse.Namespace) -> int:
+    result = service.run_addressed_router(limit=args.limit)
+    json_out(result)
+    return 1 if args.fail_on_error and result.get("status") != "ok" else 0
+
+
+def cmd_sweep_comments(args: argparse.Namespace) -> int:
+    try:
+        result = sweep_comments(limit=args.limit, days=args.days)
+    except Exception as exc:  # noqa: BLE001
+        result = {"status": "failed", "reason": str(exc), "processed": [], "skipped": [], "failures": []}
+    json_out(result)
+    return 1 if args.fail_on_error and result.get("status") != "ok" else 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="GitHub addressed-message intake helpers")
+    sub = parser.add_subparsers(dest="command", required=True)
+    router = sub.add_parser("router-scan", help="dispatch open addressed-message source beads")
+    router.add_argument("--limit", type=int, default=50)
+    router.add_argument("--fail-on-error", action="store_true")
+    router.set_defaults(func=cmd_router_scan)
+    sweep = sub.add_parser("sweep-comments", help="reconcile recent GitHub comments with configured addresses")
+    sweep.add_argument("--limit", type=int, default=0, help="maximum updated issues/PRs to scan per repo; 0 means all")
+    sweep.add_argument("--days", type=int, default=7)
+    sweep.add_argument("--fail-on-error", action="store_true")
+    sweep.set_defaults(func=cmd_sweep_comments)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/github/scripts/github_intake_comment_issue.py
+++ b/github/scripts/github_intake_comment_issue.py
@@ -8,6 +8,23 @@ import json
 import github_intake_common as common
 
 
+def load_profile_github_app(identity: str) -> dict[str, str]:
+    import github_intake_service as service
+
+    return service.load_profile_github_app(identity)
+
+
+def app_config(identity: str) -> dict[str, object]:
+    identity = common.validate_github_app_identity(identity)
+    if identity:
+        return load_profile_github_app(identity)
+    config = common.load_effective_config()
+    app_cfg = config.get("app", {})
+    if isinstance(app_cfg, dict):
+        return app_cfg
+    return {}
+
+
 def split_repository(value: str) -> tuple[str, str]:
     owner, sep, repo = value.strip().partition("/")
     if not owner or not sep or not repo:
@@ -26,20 +43,30 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="Post an issue comment via the workspace GitHub App")
     parser.add_argument("repository", help="owner/repo")
     parser.add_argument("issue_number", help="GitHub issue number")
-    parser.add_argument("--installation-id", required=True, help="GitHub App installation id")
+    parser.add_argument("--installation-id", default="", help="GitHub App installation id")
+    parser.add_argument(
+        "--github-app-identity",
+        default="",
+        help="GitHub App identity that should post the comment",
+    )
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument("--body", default="", help="comment markdown")
     group.add_argument("--body-file", default="", help="path to a markdown file")
     args = parser.parse_args()
 
-    config = common.load_config()
-    app_cfg = config.get("app", {})
+    try:
+        app_cfg = app_config(args.github_app_identity)
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
     if not isinstance(app_cfg, dict) or not app_cfg.get("app_id") or not app_cfg.get("private_key_pem"):
         raise SystemExit("GitHub App configuration is incomplete")
+    installation_id = str(args.installation_id or app_cfg.get("installation_id", "")).strip()
+    if not installation_id:
+        raise SystemExit("GitHub App installation id is required")
     owner, repo = split_repository(args.repository)
     comment = common.post_issue_comment(
         app_cfg,
-        args.installation_id,
+        installation_id,
         owner,
         repo,
         args.issue_number,

--- a/github/scripts/github_intake_common.py
+++ b/github/scripts/github_intake_common.py
@@ -7,9 +7,12 @@ import hmac
 import json
 import os
 import pathlib
+import re
+import shlex
 import subprocess
 import tempfile
 import time
+import tomllib
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -20,6 +23,8 @@ ADMIN_SERVICE_NAME = "github-admin"
 SCHEMA_VERSION = 1
 GITHUB_API_BASE = os.environ.get("GC_GITHUB_API_BASE", "https://api.github.com")
 GITHUB_API_VERSION = os.environ.get("GC_GITHUB_API_VERSION", "2026-03-10")
+GITHUB_APP_IDENTITY_SCHEMA_VERSION = "github-intake.github-app-identity.v1"
+GITHUB_APP_IDENTITY_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
 
 
 class GitHubAPIError(RuntimeError):
@@ -71,8 +76,26 @@ def workflows_dir() -> str:
     return os.path.join(data_dir(), "workflows")
 
 
+def rule_results_dir() -> str:
+    return os.path.join(data_dir(), "rule-results")
+
+
+def address_results_dir() -> str:
+    return os.path.join(data_dir(), "address-results")
+
+
 def config_path() -> str:
     return os.path.join(data_dir(), "config.json")
+
+
+def rules_path() -> str:
+    override = os.environ.get("GC_GITHUB_INTAKE_RULES_FILE")
+    if override:
+        return os.path.expanduser(override)
+    root = city_root()
+    if not root:
+        return "config/github-intake/rules.toml"
+    return os.path.join(root, "config", "github-intake", "rules.toml")
 
 
 def published_services_dir() -> str:
@@ -86,7 +109,7 @@ def published_services_dir() -> str:
 
 
 def ensure_layout() -> None:
-    for path in (data_dir(), requests_dir(), deliveries_dir(), workflows_dir()):
+    for path in (data_dir(), requests_dir(), deliveries_dir(), workflows_dir(), rule_results_dir(), address_results_dir()):
         os.makedirs(path, exist_ok=True)
 
 
@@ -131,9 +154,47 @@ def normalize_config(raw: dict[str, Any] | None) -> dict[str, Any]:
     return cfg
 
 
+ENV_APP_FIELDS = {
+    "GITHUB_APP_ID": "app_id",
+    "GITHUB_APP_CLIENT_ID": "client_id",
+    "GITHUB_APP_CLIENT_SECRET": "client_secret",
+    "GITHUB_APP_WEBHOOK_SECRET": "webhook_secret",
+    "GITHUB_WEBHOOK_SECRET": "webhook_secret",
+    "GITHUB_APP_PRIVATE_KEY_PEM": "private_key_pem",
+    "GITHUB_APP_PRIVATE_KEY": "private_key_pem",
+    "GITHUB_APP_SLUG": "slug",
+    "GITHUB_APP_HTML_URL": "html_url",
+    "GITHUB_APP_NAME": "name",
+    "GITHUB_INSTALLATION_ID": "installation_id",
+}
+
+
+def app_config_from_env() -> dict[str, str]:
+    app: dict[str, str] = {}
+    for env_key, app_key in ENV_APP_FIELDS.items():
+        value = os.environ.get(env_key)
+        if value:
+            app[app_key] = value
+    return app
+
+
+def effective_config(config: dict[str, Any] | None) -> dict[str, Any]:
+    cfg = normalize_config(config)
+    env_app = app_config_from_env()
+    if env_app:
+        app = cfg.setdefault("app", {})
+        if isinstance(app, dict):
+            app.update(env_app)
+    return cfg
+
+
 def load_config() -> dict[str, Any]:
     ensure_layout()
     return normalize_config(read_json(config_path(), {}))
+
+
+def load_effective_config() -> dict[str, Any]:
+    return effective_config(load_config())
 
 
 def save_config(config: dict[str, Any]) -> dict[str, Any]:
@@ -162,7 +223,15 @@ def import_app_config(config: dict[str, Any], app_fields: dict[str, Any]) -> dic
     raw_id = app_fields.get("app_id", app_fields.get("id"))
     if raw_id is not None and raw_id != "":
         app["app_id"] = str(raw_id)
-    for key in ("client_id", "client_secret", "webhook_secret", "slug", "html_url", "name"):
+    for key in (
+        "client_id",
+        "client_secret",
+        "webhook_secret",
+        "slug",
+        "html_url",
+        "name",
+        "installation_id",
+    ):
         value = app_fields.get(key)
         if value:
             app[key] = value
@@ -177,6 +246,96 @@ def import_app_config(config: dict[str, Any], app_fields: dict[str, Any]) -> dic
 
 def normalize_repo_key(value: str) -> str:
     return value.strip().lower()
+
+
+def validate_github_app_identity(value: str, field: str = "github_app_identity") -> str:
+    identity = str(value).strip()
+    if not identity:
+        return ""
+    if not GITHUB_APP_IDENTITY_PATTERN.fullmatch(identity):
+        raise ValueError(
+            f"{field} must match [A-Za-z0-9][A-Za-z0-9._:-]{{0,127}}; got {identity!r}"
+        )
+    return identity
+
+
+def publish_identity(
+    app_fields: dict[str, Any],
+    identity: str = "",
+    publisher: str = "",
+    cwd: str = "",
+) -> dict[str, Any]:
+    """Push a GitHub App identity to the deployment secret store.
+
+    Write-side mirror of the identity resolver: runs the command configured
+    via GITHUB_INTAKE_IDENTITY_PUBLISHER with the identity name as its only
+    argument and the identity JSON document on stdin. The publisher is a
+    deployment plug — a no-op when unset — and failures are reported in the
+    returned status, never raised, so credential capture (manifest callback,
+    manual import) cannot be broken by a misbehaving store.
+    """
+    publisher = publisher.strip() or os.environ.get("GITHUB_INTAKE_IDENTITY_PUBLISHER", "").strip()
+    if not publisher:
+        return {"status": "skipped", "reason": "no publisher configured"}
+    identity = identity.strip() or os.environ.get("GITHUB_INTAKE_APP_IDENTITY", "").strip()
+    if not identity:
+        return {"status": "skipped", "reason": "GITHUB_INTAKE_APP_IDENTITY is not configured"}
+    try:
+        identity = validate_github_app_identity(identity, "GITHUB_INTAKE_APP_IDENTITY")
+    except ValueError as exc:
+        return {"status": "error", "detail": str(exc)}
+    command = shlex.split(publisher)
+    if not command:
+        return {"status": "error", "detail": "GITHUB_INTAKE_IDENTITY_PUBLISHER did not contain a command"}
+    payload = {
+        str(key): str(value)
+        for key, value in app_fields.items()
+        if value is not None and str(value) != ""
+    }
+    payload["schema_version"] = GITHUB_APP_IDENTITY_SCHEMA_VERSION
+    try:
+        result = subprocess.run(
+            [*command, identity],
+            input=json.dumps(payload, sort_keys=True),
+            capture_output=True,
+            text=True,
+            check=False,
+            cwd=cwd or city_root() or ".",
+            timeout=60,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return {"status": "error", "detail": str(exc)}
+    detail = (result.stderr or result.stdout or "").strip()[:1200]
+    if result.returncode != 0:
+        return {"status": "error", "detail": detail or f"exit {result.returncode}"}
+    return {"status": "published", "detail": detail}
+
+
+def github_repo_rig_name(repository_full_name: str) -> str:
+    repo_key = normalize_repo_key(repository_full_name)
+    owner, sep, repo = repo_key.partition("/")
+    if not sep or not owner or not repo:
+        return ""
+    slug = re.sub(r"[^a-z0-9_-]+", "-", f"github-{owner}-{repo}")
+    slug = re.sub(r"-+", "-", slug).strip("-")
+    return slug
+
+
+def github_repo_dispatch_rig(repository_full_name: str, rules_config: dict[str, Any] | None = None) -> str:
+    repo_key = normalize_repo_key(repository_full_name)
+    fallback = github_repo_rig_name(repo_key)
+    if not fallback:
+        return ""
+    repos = (rules_config if rules_config is not None else load_rules()).get("repos") or []
+    for repo in repos:
+        if not isinstance(repo, dict):
+            continue
+        if normalize_repo_key(str(repo.get("full_name", ""))) != repo_key:
+            continue
+        rig = str(repo.get("rig", "")).strip()
+        if rig:
+            return rig
+    return fallback
 
 
 def _set_command_formula(commands: dict[str, Any], name: str, formula: str | None) -> dict[str, Any]:
@@ -257,7 +416,7 @@ def build_manifest() -> dict[str, Any]:
         "redirect_url": admin.rstrip("/") + "/v0/github/app/manifest/callback",
         "callback_urls": [admin.rstrip("/") + "/v0/github/app/manifest/callback"],
         "setup_url": admin,
-        "description": "Workspace-hosted GitHub slash-command intake for Gas City",
+        "description": "Workspace-hosted GitHub comment and event intake for Gas City",
         "public": False,
         "default_permissions": {
             "contents": "write",
@@ -266,8 +425,237 @@ def build_manifest() -> dict[str, Any]:
         },
         "default_events": [
             "issue_comment",
+            "issues",
+            "pull_request",
         ],
     }
+
+
+def _flatten_match(prefix: str, value: Any, out: dict[str, str]) -> None:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            dotted = f"{prefix}.{key}" if prefix else str(key)
+            _flatten_match(dotted, child, out)
+        return
+    out[prefix] = str(value)
+
+
+def normalize_rule(raw_rule: dict[str, Any], index: int) -> dict[str, Any]:
+    rule_id = str(raw_rule.get("id", "")).strip()
+    if not rule_id:
+        raise ValueError(f"rule[{index}]: id is required")
+    event = str(raw_rule.get("event", "")).strip()
+    if not event:
+        raise ValueError(f"rule {rule_id!r}: event is required")
+    raw_match = raw_rule.get("match") or {}
+    if not isinstance(raw_match, dict):
+        raise ValueError(f"rule {rule_id!r}: match must be a table")
+    match: dict[str, str] = {}
+    _flatten_match("", raw_match, match)
+    raw_actions = raw_rule.get("action") or []
+    if not isinstance(raw_actions, list) or not raw_actions:
+        raise ValueError(f"rule {rule_id!r}: at least one action is required")
+    actions: list[dict[str, Any]] = []
+    for action_index, raw_action in enumerate(raw_actions):
+        if not isinstance(raw_action, dict):
+            raise ValueError(f"rule {rule_id!r}: action[{action_index}] must be a table")
+        action_type = str(raw_action.get("type", "")).strip()
+        if not action_type:
+            raise ValueError(f"rule {rule_id!r}: action[{action_index}].type is required")
+        if action_type == "order" and not str(raw_action.get("name", "")).strip():
+            raise ValueError(f"rule {rule_id!r}: order action requires name")
+        actions.append(dict(raw_action))
+    return {
+        "id": rule_id,
+        "event": event,
+        "match": match,
+        "allow_self": bool(raw_rule.get("allow_self", False)),
+        "action": actions,
+    }
+
+
+def _normalized_unique_strings(values: Any) -> list[str]:
+    if not isinstance(values, list):
+        return []
+    out: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        normalized = str(value).strip().lower()
+        if normalized and normalized not in seen:
+            out.append(normalized)
+            seen.add(normalized)
+    return out
+
+
+def normalize_address(raw_address: dict[str, Any], repo_name: str, repo_rig: str, index: int) -> dict[str, Any]:
+    address = str(raw_address.get("address", "")).strip().lower()
+    if not address:
+        raise ValueError(f"repo {repo_name!r}: address[{index}].address is required")
+    pool = str(raw_address.get("pool", "")).strip()
+    if not pool:
+        raise ValueError(f"repo {repo_name!r}: address {address!r}: pool is required")
+    if "/" in pool:
+        raise ValueError(f"repo {repo_name!r}: address {address!r}: pool must not include a rig")
+    formula = str(raw_address.get("formula", "")).strip()
+    if not formula:
+        raise ValueError(f"repo {repo_name!r}: address {address!r}: formula is required")
+    profile = str(raw_address.get("profile", "")).strip() or address.lstrip("@")
+    identity = validate_github_app_identity(
+        str(raw_address.get("github_app_identity", "")),
+        f"repo {repo_name!r}: address {address!r}: github_app_identity",
+    )
+    return {
+        "address": address,
+        "pool": pool,
+        "target": f"{repo_rig}/{pool}",
+        "formula": formula,
+        "ack": bool(raw_address.get("ack", True)),
+        "profile": profile,
+        "github_app_identity": identity,
+        "installation_id": str(raw_address.get("installation_id", "")).strip(),
+    }
+
+
+def normalize_repo_addresses(raw_repo: dict[str, Any], index: int) -> dict[str, Any]:
+    full_name = normalize_repo_key(str(raw_repo.get("full_name", "")))
+    if not full_name:
+        raise ValueError(f"repo[{index}]: full_name is required")
+    github_rig = github_repo_rig_name(full_name)
+    if not github_rig:
+        raise ValueError(f"repo[{index}]: full_name must be owner/repo")
+    configured_rig = str(raw_repo.get("rig", "")).strip()
+    if configured_rig and "/" in configured_rig:
+        raise ValueError(f"repo {full_name!r}: rig must be a local rig name, not a target")
+    rig = configured_rig or github_rig
+    raw_addresses = raw_repo.get("address") or []
+    if not isinstance(raw_addresses, list):
+        raise ValueError(f"repo {full_name!r}: address must be an array of tables")
+    return {
+        "full_name": full_name,
+        "github_rig": github_rig,
+        "rig": rig,
+        "authorized_users": _normalized_unique_strings(raw_repo.get("authorized_users")),
+        "installation_id": str(raw_repo.get("installation_id", "")).strip(),
+        "addresses": [
+            normalize_address(raw_address, full_name, rig, address_index)
+            for address_index, raw_address in enumerate(raw_addresses)
+            if isinstance(raw_address, dict)
+        ],
+    }
+
+
+def load_rules() -> dict[str, Any]:
+    path = rules_path()
+    if not os.path.exists(path):
+        return {"version": 1, "path": path, "rules": [], "repos": []}
+    with open(path, "rb") as handle:
+        data = tomllib.load(handle)
+    if not isinstance(data, dict):
+        raise ValueError("rules root must be a TOML table")
+    if int(data.get("version", 0)) != 1:
+        raise ValueError("rules version must be 1")
+    raw_rules = data.get("rule") or []
+    if not isinstance(raw_rules, list):
+        raise ValueError("rule must be an array of tables")
+    raw_repos = data.get("repo") or []
+    if not isinstance(raw_repos, list):
+        raise ValueError("repo must be an array of tables")
+    return {
+        "version": 1,
+        "path": path,
+        "rules": [normalize_rule(raw_rule, index) for index, raw_rule in enumerate(raw_rules)],
+        "repos": [normalize_repo_addresses(raw_repo, index) for index, raw_repo in enumerate(raw_repos)],
+    }
+
+
+def payload_value(payload: dict[str, Any], dotted_path: str) -> Any:
+    current: Any = payload
+    for part in dotted_path.split("."):
+        if not isinstance(current, dict):
+            return None
+        current = current.get(part)
+    return current
+
+
+def rule_matches(rule: dict[str, Any], event: str, payload: dict[str, Any]) -> bool:
+    if str(rule.get("event", "")) != event:
+        return False
+    match = rule.get("match") or {}
+    if not isinstance(match, dict):
+        return False
+    for dotted_path, expected in match.items():
+        actual = payload_value(payload, str(dotted_path))
+        if str(actual) != str(expected):
+            return False
+    return True
+
+
+def matching_rules(event: str, payload: dict[str, Any], rules_config: dict[str, Any] | None = None) -> list[dict[str, Any]]:
+    rules = (rules_config or load_rules()).get("rules") or []
+    return [rule for rule in rules if isinstance(rule, dict) and rule_matches(rule, event, payload)]
+
+
+def rule_result_path(result_id: str) -> str:
+    return os.path.join(rule_results_dir(), f"{safe_storage_id(result_id, 'rule-result')}.json")
+
+
+def save_rule_result(payload: dict[str, Any]) -> dict[str, Any]:
+    ensure_layout()
+    result = copy.deepcopy(payload)
+    result["updated_at"] = utcnow()
+    atomic_write_json(rule_result_path(str(result["result_id"])), result)
+    return result
+
+
+def address_result_path(result_id: str) -> str:
+    return os.path.join(address_results_dir(), f"{safe_storage_id(result_id, 'address-result')}.json")
+
+
+def save_address_result(payload: dict[str, Any]) -> dict[str, Any]:
+    ensure_layout()
+    result = copy.deepcopy(payload)
+    result["updated_at"] = utcnow()
+    atomic_write_json(address_result_path(str(result["result_id"])), result)
+    return result
+
+
+def load_address_result(result_id: str) -> dict[str, Any] | None:
+    data = read_json(address_result_path(result_id))
+    if isinstance(data, dict):
+        return data
+    return None
+
+
+def list_recent_rule_results(limit: int = 20) -> list[dict[str, Any]]:
+    ensure_layout()
+    entries: list[dict[str, Any]] = []
+    paths = sorted(
+        pathlib.Path(rule_results_dir()).glob("*.json"),
+        key=lambda path: path.stat().st_mtime,
+        reverse=True,
+    )[:limit]
+    for path in paths:
+        data = read_json(str(path))
+        if isinstance(data, dict):
+            entries.append(data)
+    entries.sort(key=lambda item: item.get("created_at", ""), reverse=True)
+    return entries[:limit]
+
+
+def list_recent_address_results(limit: int = 20) -> list[dict[str, Any]]:
+    ensure_layout()
+    entries: list[dict[str, Any]] = []
+    paths = sorted(
+        pathlib.Path(address_results_dir()).glob("*.json"),
+        key=lambda path: path.stat().st_mtime,
+        reverse=True,
+    )[:limit]
+    for path in paths:
+        data = read_json(str(path))
+        if isinstance(data, dict):
+            entries.append(data)
+    entries.sort(key=lambda item: item.get("created_at", ""), reverse=True)
+    return entries[:limit]
 
 
 def parse_gc_command(body: str) -> dict[str, Any] | None:
@@ -319,6 +707,127 @@ def workflow_storage_id(value: str) -> str:
         return value
     digest = hashlib.sha256(value.encode("utf-8")).hexdigest()[:24]
     return f"workflow-{digest}"
+
+
+def address_token_pattern(address: str) -> re.Pattern[str]:
+    return re.compile(r"(?<![\w@])" + re.escape(address) + r"(?![\w-])", re.IGNORECASE)
+
+
+def clean_addressed_body(body: str, addresses: list[str]) -> str:
+    cleaned = body
+    for address in addresses:
+        cleaned = address_token_pattern(address).sub("", cleaned)
+    lines = [re.sub(r"[ \t]{2,}", " ", line).strip() for line in cleaned.splitlines()]
+    return "\n".join(lines).strip()
+
+
+def addressed_source_key(repository_id: str, comment_id: str, address: str) -> str:
+    return f"github-comment:{repository_id}:{comment_id}:{address.strip().lower()}"
+
+
+def extract_addressed_comment_requests(
+    payload: dict[str, Any], rules_config: dict[str, Any] | None = None
+) -> dict[str, Any] | None:
+    if payload.get("action") != "created":
+        return None
+    issue = payload.get("issue") or {}
+    comment = payload.get("comment") or {}
+    repository = payload.get("repository") or {}
+    if not isinstance(issue, dict) or not isinstance(comment, dict) or not isinstance(repository, dict):
+        return None
+    repo_name = normalize_repo_key(str(repository.get("full_name", "")))
+    repository_id = str(repository.get("id", "")).strip()
+    comment_id = str(comment.get("id", "")).strip()
+    issue_number = str(issue.get("number", "")).strip()
+    if not repo_name or not repository_id or not comment_id or not issue_number:
+        return None
+    repos = (rules_config or load_rules()).get("repos") or []
+    repo_cfg = next(
+        (
+            repo
+            for repo in repos
+            if isinstance(repo, dict) and normalize_repo_key(str(repo.get("full_name", ""))) == repo_name
+        ),
+        None,
+    )
+    if not repo_cfg:
+        return None
+    body = str(comment.get("body", ""))
+    addresses = [address for address in repo_cfg.get("addresses") or [] if isinstance(address, dict)]
+    matched: list[dict[str, Any]] = []
+    seen_addresses: set[str] = set()
+    for address_cfg in addresses:
+        address = str(address_cfg.get("address", "")).strip().lower()
+        if not address or address in seen_addresses:
+            continue
+        if address_token_pattern(address).search(body):
+            matched.append(address_cfg)
+            seen_addresses.add(address)
+    if not matched:
+        return None
+
+    matched_tokens = [str(address.get("address", "")).strip().lower() for address in matched]
+    cleaned_body = clean_addressed_body(body, matched_tokens)
+    sender = str((comment.get("user") or {}).get("login", "")).strip()
+    sender_key = sender.lower()
+    authorized_users = _normalized_unique_strings(repo_cfg.get("authorized_users"))
+    owner = repository.get("owner") or {}
+    item_kind = "pr" if issue.get("pull_request") else "issue"
+    rig = str(repo_cfg.get("rig") or github_repo_rig_name(repo_name))
+    base = {
+        "repository_id": repository_id,
+        "repository_full_name": repo_name,
+        "repository_owner": str(owner.get("login", "")),
+        "repository_name": str(repository.get("name", "")),
+        "repository_default_branch": str(repository.get("default_branch", "")),
+        "item_kind": item_kind,
+        "item_number": issue_number,
+        "item_url": str(issue.get("html_url", "")),
+        "issue_id": str(issue.get("id", "")),
+        "issue_number": issue_number,
+        "issue_title": str(issue.get("title", "")),
+        "issue_url": str(issue.get("html_url", "")),
+        "comment_id": comment_id,
+        "comment_body": body,
+        "comment_url": str(comment.get("html_url", "")),
+        "comment_author": sender,
+        "comment_author_type": str((comment.get("user") or {}).get("type", "")),
+        "comment_created_at": str(comment.get("created_at", "")),
+        "comment_updated_at": str(comment.get("updated_at", "")),
+        "installation_id": str((payload.get("installation") or {}).get("id", "")),
+        "cleaned_body": cleaned_body,
+    }
+    requests: list[dict[str, Any]] = []
+    for address_cfg in matched:
+        address = str(address_cfg.get("address", "")).strip().lower()
+        pool = str(address_cfg.get("pool", "")).strip()
+        target = str(address_cfg.get("target") or (f"{rig}/{pool}" if rig and pool else "")).strip()
+        profile = str(address_cfg.get("profile", "")).strip() or address.lstrip("@")
+        request = dict(base)
+        request.update(
+            {
+                "address": address,
+                "rig": rig,
+                "pool": pool,
+                "target": target,
+                "formula": str(address_cfg.get("formula", "")),
+                "ack": bool(address_cfg.get("ack", True)),
+                "profile": profile,
+                "profile_github_app_identity": str(address_cfg.get("github_app_identity", "")),
+                "profile_installation_id": str(address_cfg.get("installation_id", "")),
+                "source_key": addressed_source_key(repository_id, comment_id, address),
+            }
+        )
+        requests.append(request)
+    return {
+        "repository": repo_cfg,
+        "authorized": bool(sender_key and sender_key in authorized_users),
+        "authorized_users": authorized_users,
+        "sender": sender,
+        "addresses": matched_tokens,
+        "cleaned_body": cleaned_body,
+        "requests": requests,
+    }
 
 
 def extract_issue_comment_request(payload: dict[str, Any]) -> dict[str, Any] | None:
@@ -474,7 +983,13 @@ def find_request(repository_full_name: str, issue_number: str, command: str) -> 
 
 
 def build_status_snapshot(limit: int = 20) -> dict[str, Any]:
-    cfg = load_config()
+    cfg = load_effective_config()
+    rules_error = ""
+    try:
+        rules = load_rules()
+    except Exception as exc:  # noqa: BLE001
+        rules = {"version": 1, "path": rules_path(), "rules": []}
+        rules_error = str(exc)
     return {
         "service_name": current_service_name(),
         "city_root": city_root(),
@@ -483,7 +998,19 @@ def build_status_snapshot(limit: int = 20) -> dict[str, Any]:
         "webhook_url": webhook_url(),
         "published_services_dir": published_services_dir(),
         "config": redact_config(cfg),
+        "rules": {
+            "path": rules.get("path", rules_path()),
+            "count": len(rules.get("rules") or []),
+            "ids": [str(rule.get("id", "")) for rule in (rules.get("rules") or []) if isinstance(rule, dict)],
+            "address_repo_count": len(rules.get("repos") or []),
+            "address_count": sum(
+                len(repo.get("addresses") or []) for repo in (rules.get("repos") or []) if isinstance(repo, dict)
+            ),
+            "error": rules_error,
+        },
         "recent_requests": list_recent_requests(limit=limit),
+        "recent_rule_results": list_recent_rule_results(limit=limit),
+        "recent_address_results": list_recent_address_results(limit=limit),
     }
 
 

--- a/github/scripts/github_intake_service.py
+++ b/github/scripts/github_intake_service.py
@@ -5,11 +5,14 @@ from __future__ import annotations
 import html
 import json
 import os
+import shlex
 import socketserver
 import subprocess
 import threading
+import tomllib
 import traceback
 import urllib.parse
+from datetime import datetime, timedelta, timezone
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler
 from typing import Any
@@ -18,8 +21,25 @@ import github_intake_common as common
 
 PROCESSING_LOCK = threading.Lock()
 ACCEPTANCE_LOCK = threading.Lock()
+RULE_PROCESSING_LOCK = threading.Lock()
+ADDRESSED_ROUTER_KICK_LOCK = threading.Lock()
 PROCESSING_REQUESTS: set[str] = set()
+RULE_PROCESSING_DELIVERIES: set[str] = set()
+ADDRESSED_ROUTER_KICK_DELIVERIES: set[str] = set()
 WRITE_PERMISSION_LEVELS = {"write", "maintain", "admin"}
+BUGFLOW_WORKFLOW_FORMULA = "mol-bug-report-flow-v2"
+ADDRESSED_MESSAGE_FORMULA = "github-addressed-message"
+BUGFLOW_DUPLICATE_MARKERS = (
+    "duplicate_open_bead",
+    "open bugflow source bead already exists",
+)
+ADDRESSED_ROUTER_IN_PROGRESS_STATUSES = {"starting", "dispatching"}
+ADDRESSED_ROUTER_STALE_AFTER = timedelta(minutes=10)
+# Workspace-env keys forwarded to identity resolver/publisher subprocesses.
+# Any GITHUB_INTAKE_* key passes through so store-specific resolvers can
+# define their own configuration knobs without this pack knowing the store.
+PROFILE_IDENTITY_ENV_PREFIX = "GITHUB_INTAKE_"
+INTAKE_APP_CONFIG_REQUIRED_FIELDS = ("app_id", "webhook_secret", "private_key_pem")
 
 
 class ThreadingUnixHTTPServer(socketserver.ThreadingMixIn, socketserver.UnixStreamServer):
@@ -59,6 +79,9 @@ def request_summary(request: dict[str, Any]) -> dict[str, Any]:
         "repository_full_name": request.get("repository_full_name"),
         "issue_number": request.get("issue_number"),
         "bead_id": request.get("bead_id", ""),
+        "bugflow_source_bead_id": request.get("bugflow_source_bead_id", ""),
+        "workflow_root_id": request.get("workflow_root_id", ""),
+        "acknowledgement_comment_url": request.get("acknowledgement_comment_url", ""),
         "dispatch_target": request.get("dispatch_target", ""),
         "dispatch_formula": request.get("dispatch_formula", ""),
         "reason": request.get("reason", ""),
@@ -83,6 +106,9 @@ def human_reason(code: str) -> str:
         "invalid_dispatch_target": "the repository mapping target is not a rig-scoped sling target",
         "bead_create_failed": "the workflow bead could not be created",
         "bead_update_failed": "the workflow bead could not be initialized",
+        "bugflow_router_failed": "the bugflow source bead was created but the router did not start the workflow",
+        "github_app_token_failed": "the GitHub App installation token could not be created",
+        "issue_url_missing": "the issue URL was missing from the GitHub webhook payload",
         "permission_lookup_failed": "the GitHub App could not verify the commenter's repository permission",
         "pr_comments_not_supported": "this slice only accepts /gc fix commands on GitHub issues, not pull requests",
     }
@@ -119,10 +145,14 @@ def rig_workdir(rig: str) -> str:
     return ""
 
 
-def extract_json_output(raw: str) -> dict[str, Any]:
+def extract_json_value(raw: str) -> Any:
     raw = raw.strip()
     if not raw:
         return {}
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        pass
     for left, right in (("{", "}"), ("[", "]")):
         start = raw.find(left)
         end = raw.rfind(right)
@@ -132,10 +162,16 @@ def extract_json_output(raw: str) -> dict[str, Any]:
             payload = json.loads(raw[start : end + 1])
         except json.JSONDecodeError:
             continue
-        if isinstance(payload, dict):
-            return payload
-        if isinstance(payload, list) and payload and isinstance(payload[0], dict):
-            return payload[0]
+        return payload
+    return {}
+
+
+def extract_json_output(raw: str) -> dict[str, Any]:
+    payload = extract_json_value(raw)
+    if isinstance(payload, dict):
+        return payload
+    if isinstance(payload, list) and payload and isinstance(payload[0], dict):
+        return payload[0]
     return {}
 
 
@@ -182,14 +218,73 @@ def build_fix_bead_notes(request: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
-def run_subprocess(command: list[str], cwd: str) -> subprocess.CompletedProcess[str]:
+def run_subprocess(command: list[str], cwd: str, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         command,
         cwd=cwd,
         capture_output=True,
         text=True,
         check=False,
+        env=env,
     )
+
+
+def publish_imported_identity(config: dict[str, Any]) -> dict[str, Any]:
+    """Mirror freshly captured app credentials to the deployment secret store.
+
+    Resolves the publisher command and identity name from the process
+    environment with the city workspace env as fallback (matching the
+    identity-resolver lookup), then delegates to common.publish_identity.
+    Always returns a status dict; failures are logged, never raised.
+    """
+    workspace_env = city_workspace_env()
+    publisher = os.environ.get("GITHUB_INTAKE_IDENTITY_PUBLISHER", "").strip()
+    if not publisher:
+        publisher = workspace_env.get("GITHUB_INTAKE_IDENTITY_PUBLISHER", "").strip()
+    identity = os.environ.get("GITHUB_INTAKE_APP_IDENTITY", "").strip()
+    if not identity:
+        identity = workspace_env.get("GITHUB_INTAKE_APP_IDENTITY", "").strip()
+    app = config.get("app", {})
+    if not isinstance(app, dict):
+        app = {}
+    result = common.publish_identity(dict(app), identity=identity, publisher=publisher)
+    status = result.get("status", "")
+    if status == "error":
+        print(
+            f"[{common.current_service_name() or 'github-intake'}] "
+            f"identity publish failed: {result.get('detail', '')}",
+            file=sys.stderr,
+        )
+    elif status == "published":
+        print(f"[{common.current_service_name() or 'github-intake'}] identity published to secret store")
+    return result
+
+
+def city_workspace_env() -> dict[str, str]:
+    city_root = common.city_root()
+    if not city_root:
+        return {}
+    city_toml = os.path.join(city_root, "city.toml")
+    try:
+        with open(city_toml, "rb") as handle:
+            config = tomllib.load(handle)
+    except (OSError, tomllib.TOMLDecodeError):
+        return {}
+    workspace = config.get("workspace", {})
+    if not isinstance(workspace, dict):
+        return {}
+    raw_env = workspace.get("env", {})
+    if not isinstance(raw_env, dict):
+        return {}
+    env: dict[str, str] = {}
+    for key, value in raw_env.items():
+        name = str(key)
+        if not name.startswith(PROFILE_IDENTITY_ENV_PREFIX):
+            continue
+        text = str(value).strip()
+        if text:
+            env[name] = text
+    return env
 
 
 def create_fix_bead(request: dict[str, Any], target: str) -> dict[str, Any]:
@@ -290,6 +385,760 @@ def close_failed_bead(bead_id: str, reason: str, rig: str = "") -> bool:
     return result.returncode == 0
 
 
+def bugflow_duplicate_source(result: subprocess.CompletedProcess[str]) -> bool:
+    text = f"{result.stdout}\n{result.stderr}"
+    return any(marker in text for marker in BUGFLOW_DUPLICATE_MARKERS)
+
+
+def bugflow_env(app_cfg: dict[str, Any], installation_id: str) -> dict[str, str]:
+    env = os.environ.copy()
+    env["GH_TOKEN"] = common.create_installation_token(app_cfg, installation_id)
+    return env
+
+
+def add_router_result(outcome: dict[str, Any], result: subprocess.CompletedProcess[str]) -> None:
+    outcome["router_exit_code"] = result.returncode
+    outcome["router_stdout"] = trim_output(result.stdout)
+    outcome["router_stderr"] = trim_output(result.stderr)
+    router_payload = extract_json_output(result.stdout)
+    started = router_payload.get("started")
+    if isinstance(started, list) and started and isinstance(started[0], dict):
+        first = started[0]
+        workflow_root_id = str(first.get("workflow_root_id", "")).strip()
+        rig_launch_bead_id = str(first.get("rig_launch_bead_id", "")).strip()
+        if workflow_root_id:
+            outcome["workflow_root_id"] = workflow_root_id
+        if rig_launch_bead_id:
+            outcome["rig_launch_bead_id"] = rig_launch_bead_id
+
+
+def bugflow_acknowledgement_body(outcome: dict[str, Any]) -> str:
+    source_bead_id = str(outcome.get("bugflow_source_bead_id", "") or outcome.get("bead_id", "")).strip()
+    workflow_root_id = str(outcome.get("workflow_root_id", "")).strip()
+    rig_launch_bead_id = str(outcome.get("rig_launch_bead_id", "")).strip()
+    duplicate = outcome.get("reason") == "duplicate_open_bead"
+
+    lines = [
+        "GitHub intake received this `/gc fix` request. The `/gc fix` request is queued in bugflow.",
+        "",
+        f"- Workflow: `{BUGFLOW_WORKFLOW_FORMULA}`",
+    ]
+    if source_bead_id:
+        lines.append(f"- Source bead: `{source_bead_id}`")
+    if workflow_root_id:
+        lines.append(f"- Workflow root: `{workflow_root_id}`")
+    if rig_launch_bead_id:
+        lines.append(f"- Launch bead: `{rig_launch_bead_id}`")
+    lines.append("")
+    if duplicate:
+        lines.append("An open bugflow request already exists for this issue, so I refreshed the router scan instead of creating a duplicate.")
+    else:
+        lines.append("Bugflow will investigate and classify the report before any implementation path begins.")
+    return "\n".join(lines)
+
+
+def post_bugflow_acknowledgement(request: dict[str, Any], app_cfg: dict[str, Any], outcome: dict[str, Any]) -> None:
+    installation_id = str(request.get("installation_id", ""))
+    owner = str(request.get("repository_owner", ""))
+    repo = str(request.get("repository_name", ""))
+    issue_number = str(request.get("issue_number", ""))
+    if not installation_id or not owner or not repo or not issue_number:
+        outcome["acknowledgement_comment_skipped"] = "missing_issue_context"
+        return
+    try:
+        comment = common.post_issue_comment(
+            app_cfg,
+            installation_id,
+            owner,
+            repo,
+            issue_number,
+            bugflow_acknowledgement_body(outcome),
+        )
+    except Exception as exc:  # noqa: BLE001 - acknowledgement is best-effort after dispatch.
+        outcome["acknowledgement_comment_failed"] = trim_output(str(exc))
+        return
+    comment_id = str(comment.get("id", "")).strip()
+    comment_url = str(comment.get("html_url", "")).strip()
+    if comment_id:
+        outcome["acknowledgement_comment_id"] = comment_id
+    if comment_url:
+        outcome["acknowledgement_comment_url"] = comment_url
+
+
+def bead_id(bead: dict[str, Any]) -> str:
+    return str(bead.get("id") or bead.get("ID") or "").strip()
+
+
+def bead_metadata(bead: dict[str, Any]) -> dict[str, str]:
+    raw = bead.get("metadata") or {}
+    if not isinstance(raw, dict):
+        return {}
+    return {str(key): str(value) for key, value in raw.items()}
+
+
+def addressed_result_id(delivery_id: str, suffix: str) -> str:
+    return f"{delivery_id or 'unknown-delivery'}-addressed-{suffix or 'result'}"
+
+
+def addressed_source_result_id(source_key: str, suffix: str) -> str:
+    return f"{source_key}:{suffix}"
+
+
+def format_addresses(addresses: list[str]) -> str:
+    quoted = [f"`{address}`" for address in addresses if address]
+    if not quoted:
+        return "`configured address`"
+    if len(quoted) == 1:
+        return quoted[0]
+    return ", ".join(quoted[:-1]) + f" and {quoted[-1]}"
+
+
+PROFILE_APP_CACHE: dict[str, dict[str, str]] = {}
+
+
+def github_app_config_from_secret(secret: dict[str, str]) -> dict[str, str]:
+    app: dict[str, str] = {}
+    for key in (
+        "app_id",
+        "client_id",
+        "client_secret",
+        "webhook_secret",
+        "slug",
+        "html_url",
+        "name",
+        "installation_id",
+        "owner",
+    ):
+        value = str(secret.get(key, "")).strip()
+        if value:
+            app[key] = value
+    private_key = str(secret.get("private_key_pem", "")).strip()
+    if private_key:
+        if "\\n" in private_key and "-----BEGIN" in private_key:
+            private_key = private_key.replace("\\n", "\n")
+        app["private_key_pem"] = private_key
+    return app
+
+
+def load_profile_github_app(identity: str) -> dict[str, str]:
+    try:
+        identity = common.validate_github_app_identity(identity)
+    except ValueError as exc:
+        raise RuntimeError(str(exc)) from exc
+    if not identity:
+        return {}
+    cached = PROFILE_APP_CACHE.get(identity)
+    if cached is not None:
+        return dict(cached)
+
+    workspace_env = city_workspace_env()
+    resolver = os.environ.get("GITHUB_INTAKE_IDENTITY_RESOLVER", "").strip()
+    if not resolver:
+        resolver = workspace_env.get("GITHUB_INTAKE_IDENTITY_RESOLVER", "").strip()
+    if not resolver:
+        raise RuntimeError(
+            f"GitHub App identity {identity!r} requires GITHUB_INTAKE_IDENTITY_RESOLVER"
+        )
+    command = shlex.split(resolver)
+    if not command:
+        raise RuntimeError("GITHUB_INTAKE_IDENTITY_RESOLVER did not contain a command")
+    env = os.environ.copy()
+    for key, value in workspace_env.items():
+        env.setdefault(key, value)
+    env["GITHUB_INTAKE_IDENTITY_RESOLVER"] = resolver
+    city_root = common.city_root() or "."
+    if city_root != ".":
+        env.setdefault("GC_CITY_ROOT", city_root)
+    result = run_subprocess(
+        [*command, identity],
+        city_root,
+        env=env,
+    )
+    if result.returncode != 0:
+        detail = trim_output(result.stderr or result.stdout) or f"exit {result.returncode}"
+        raise RuntimeError(f"GitHub App identity resolver failed for {identity!r}: {detail}")
+    secret_payload = extract_json_value(result.stdout)
+    if not isinstance(secret_payload, dict):
+        raise RuntimeError(f"GitHub App identity resolver for {identity!r} did not return a JSON object")
+    schema_version = str(secret_payload.get("schema_version", "")).strip()
+    if schema_version != common.GITHUB_APP_IDENTITY_SCHEMA_VERSION:
+        raise RuntimeError(
+            f"GitHub App identity resolver for {identity!r} must return "
+            f"schema_version={common.GITHUB_APP_IDENTITY_SCHEMA_VERSION!r}"
+        )
+    secret = {str(key): str(value) for key, value in secret_payload.items() if value is not None}
+    ready = str(secret.get("ready", "")).strip().lower()
+    if ready and ready not in {"1", "true", "yes"}:
+        raise RuntimeError(f"GitHub App identity {identity!r} is not ready")
+    app = github_app_config_from_secret(secret)
+    PROFILE_APP_CACHE[identity] = dict(app)
+    return app
+
+
+def configured_github_app_identity() -> str:
+    identity = os.environ.get("GITHUB_INTAKE_APP_IDENTITY", "").strip()
+    if not identity:
+        identity = city_workspace_env().get("GITHUB_INTAKE_APP_IDENTITY", "").strip()
+    try:
+        return common.validate_github_app_identity(identity, "GITHUB_INTAKE_APP_IDENTITY")
+    except ValueError as exc:
+        raise RuntimeError(str(exc)) from exc
+
+
+def missing_intake_app_config_fields(app_cfg: dict[str, Any]) -> list[str]:
+    return [field for field in INTAKE_APP_CONFIG_REQUIRED_FIELDS if not str(app_cfg.get(field, "")).strip()]
+
+
+def sync_github_app_config_from_identity(identity: str = "") -> dict[str, Any]:
+    identity = identity.strip() or configured_github_app_identity()
+    if not identity:
+        return {"status": "skipped", "reason": "GITHUB_INTAKE_APP_IDENTITY is not configured"}
+    app = load_profile_github_app(identity)
+    missing = missing_intake_app_config_fields(app)
+    if missing:
+        raise RuntimeError(
+            f"GitHub App identity {identity!r} is missing required app field(s): {', '.join(missing)}"
+        )
+    config = common.load_config()
+    current_app = config.get("app", {}) if isinstance(config.get("app", {}), dict) else {}
+    changed = any(str(current_app.get(key, "")) != str(value) for key, value in app.items() if value)
+    config = common.import_app_config(config, app)
+    return {
+        "status": "updated" if changed else "unchanged",
+        "identity": identity,
+        "config": common.redact_config(config),
+    }
+
+
+def ensure_webhook_app_config(config: dict[str, Any]) -> dict[str, Any]:
+    app_cfg = config.get("app", {}) if isinstance(config.get("app", {}), dict) else {}
+    if str(app_cfg.get("webhook_secret", "")).strip():
+        return config
+    identity = configured_github_app_identity()
+    if not identity:
+        return config
+    sync_github_app_config_from_identity(identity)
+    return common.load_effective_config()
+
+
+def sync_configured_github_app_at_startup() -> None:
+    identity = configured_github_app_identity()
+    if not identity:
+        return
+    outcome = sync_github_app_config_from_identity(identity)
+    if outcome.get("status") != "skipped":
+        print(
+            f"[{common.current_service_name() or 'github-intake'}] "
+            f"GitHub App config {outcome.get('status')} from identity {identity!r}",
+            flush=True,
+        )
+
+
+def addressed_reply_app_config(request: dict[str, Any], app_cfg: dict[str, Any]) -> tuple[dict[str, Any], str]:
+    identity = str(request.get("profile_github_app_identity", "")).strip()
+    if not identity:
+        return app_cfg, str(request.get("installation_id", "")).strip()
+    profile_app = load_profile_github_app(identity)
+    installation_id = str(request.get("profile_installation_id", "") or profile_app.get("installation_id", "")).strip()
+    if not installation_id:
+        profile = str(request.get("profile", "")).strip() or str(request.get("address", "")).strip()
+        raise RuntimeError(f"GitHub App installation_id is missing for addressed profile {profile!r}")
+    return profile_app, installation_id
+
+
+def post_addressed_reply(
+    request: dict[str, Any],
+    app_cfg: dict[str, Any],
+    body: str,
+    outcome: dict[str, Any],
+) -> None:
+    owner = str(request.get("repository_owner", ""))
+    repo = str(request.get("repository_name", ""))
+    issue_number = str(request.get("issue_number", ""))
+    if not owner or not repo or not issue_number:
+        outcome["reply_skipped"] = "missing_issue_context"
+        return
+    try:
+        reply_app_cfg, installation_id = addressed_reply_app_config(request, app_cfg)
+        comment = common.post_issue_comment(reply_app_cfg, installation_id, owner, repo, issue_number, body)
+    except Exception as exc:  # noqa: BLE001 - reply failure must not drop durable work.
+        outcome["reply_failed"] = trim_output(str(exc))
+        return
+    comment_id = str(comment.get("id", "")).strip()
+    comment_url = str(comment.get("html_url", "")).strip()
+    if comment_id:
+        outcome["reply_comment_id"] = comment_id
+    if comment_url:
+        outcome["reply_comment_url"] = comment_url
+
+
+def addressed_router_kick_limit() -> int:
+    raw = os.environ.get("GITHUB_INTAKE_ADDRESS_ROUTER_KICK_LIMIT", "50").strip()
+    try:
+        limit = int(raw)
+    except ValueError:
+        return 50
+    return max(1, limit)
+
+
+def process_queued_addressed_router(delivery_id: str, source_keys: list[str], processing_key: str) -> None:
+    try:
+        router = run_addressed_router(limit=addressed_router_kick_limit())
+        status = str(router.get("status", "failed")) if isinstance(router, dict) else "failed"
+        common.save_address_result(
+            {
+                "result_id": addressed_result_id(delivery_id, "router-kick"),
+                "created_at": common.utcnow(),
+                "delivery_id": delivery_id,
+                "event": "addressed-router-kick",
+                "status": status,
+                "source_keys": source_keys,
+                "router": router,
+            }
+        )
+    except Exception as exc:  # noqa: BLE001 - persist unexpected router failures for operator inspection.
+        common.save_address_result(
+            {
+                "result_id": addressed_result_id(delivery_id, "router-kick"),
+                "created_at": common.utcnow(),
+                "delivery_id": delivery_id,
+                "event": "addressed-router-kick",
+                "status": "failed",
+                "reason": f"addressed_router_kick_failed: {exc}",
+                "source_keys": source_keys,
+                "traceback": trim_output(traceback.format_exc(), 4000),
+            }
+        )
+    finally:
+        if processing_key:
+            with ADDRESSED_ROUTER_KICK_LOCK:
+                ADDRESSED_ROUTER_KICK_DELIVERIES.discard(processing_key)
+
+
+def enqueue_addressed_router(delivery_id: str, source_keys: list[str]) -> str:
+    source_keys = [str(source_key).strip() for source_key in source_keys if str(source_key).strip()]
+    if not source_keys:
+        return "skipped_no_sources"
+    processing_key = delivery_id.strip() or ",".join(source_keys)
+    if processing_key:
+        with ADDRESSED_ROUTER_KICK_LOCK:
+            if processing_key in ADDRESSED_ROUTER_KICK_DELIVERIES:
+                return "already_processing"
+            ADDRESSED_ROUTER_KICK_DELIVERIES.add(processing_key)
+    thread = threading.Thread(
+        target=process_queued_addressed_router,
+        args=(delivery_id, source_keys, processing_key),
+        daemon=True,
+    )
+    thread.start()
+    return "queued"
+
+
+def addressed_bool_metadata(value: Any, default: bool = True) -> str:
+    if value is None:
+        return "true" if default else "false"
+    if isinstance(value, str):
+        return "false" if value.strip().lower() in {"0", "false", "no", "off"} else "true"
+    return "true" if bool(value) else "false"
+
+
+def addressed_source_title(request: dict[str, Any]) -> str:
+    repo = str(request.get("repository_full_name", ""))
+    number = str(request.get("item_number", ""))
+    address = str(request.get("address", ""))
+    location = f"{repo}#{number}" if repo and number else repo or "GitHub"
+    return f"GitHub addressed message {address} in {location}"[:180]
+
+
+def addressed_source_description(request: dict[str, Any]) -> str:
+    body = str(request.get("cleaned_body", "")).strip() or "(empty)"
+    lines = [
+        "## GitHub Addressed Message",
+        "",
+        f"- Address: {request.get('address', '')}",
+        f"- Repository: {request.get('repository_full_name', '')}",
+        f"- Source: {request.get('item_url', '')}",
+        f"- Comment: {request.get('comment_url', '')}",
+        f"- Requested By: {request.get('comment_author', '')}",
+        f"- Source Key: {request.get('source_key', '')}",
+        "",
+        "## Request",
+        "",
+        body,
+    ]
+    return "\n".join(lines)
+
+
+def addressed_source_metadata(request: dict[str, Any]) -> dict[str, str]:
+    rig = str(request.get("rig", ""))
+    pool = str(request.get("pool", ""))
+    target = str(request.get("target", ""))
+    if not target and rig and pool:
+        target = f"{rig}/{pool}"
+    values = {
+        "external.provider": "github",
+        "external.kind": "addressed-message",
+        "external.source_key": str(request.get("source_key", "")),
+        "github.repo": str(request.get("repository_full_name", "")),
+        "github.repo_id": str(request.get("repository_id", "")),
+        "github.item_kind": str(request.get("item_kind", "")),
+        "github.item_number": str(request.get("item_number", "")),
+        "github.item_url": str(request.get("item_url", "")),
+        "github.issue_number": str(request.get("issue_number", "")),
+        "github.comment_id": str(request.get("comment_id", "")),
+        "github.comment_url": str(request.get("comment_url", "")),
+        "github.sender": str(request.get("comment_author", "")),
+        "github.installation_id": str(request.get("installation_id", "")),
+        "addressed.address": str(request.get("address", "")),
+        "addressed.cleaned_body": str(request.get("cleaned_body", "")),
+        "addressed.rig": rig,
+        "addressed.pool": pool,
+        "addressed.target": target,
+        "addressed.profile": str(request.get("profile", "")),
+        "addressed.github_app_identity": str(request.get("profile_github_app_identity", "")),
+        "addressed.github_app_installation_id": str(request.get("profile_installation_id", "")),
+        "addressed.formula": str(request.get("formula", "")),
+        "addressed.ack_requested": addressed_bool_metadata(request.get("ack", True)),
+        "addressed.status": "source_created",
+        "addressed.created_at": common.utcnow(),
+        "intake.delivery_id": str(request.get("delivery_id", "")),
+        "raw_payload.path": str(request.get("raw_payload_path", "")),
+    }
+    return {key: value for key, value in values.items() if value}
+
+
+def addressed_sources_by_key(source_key: str) -> list[dict[str, Any]]:
+    city_root = common.city_root() or "."
+    bd_bin = os.environ.get("BD_BIN", "bd")
+    result = run_subprocess(
+        [
+            bd_bin,
+            "list",
+            "--json",
+            "--all",
+            "--metadata-field",
+            f"external.source_key={source_key}",
+            "--limit",
+            "0",
+        ],
+        city_root,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"bd list failed: {trim_output(result.stderr or result.stdout)}")
+    payload = extract_json_value(result.stdout)
+    if not isinstance(payload, list):
+        return []
+    return [item for item in payload if isinstance(item, dict)]
+
+
+def create_addressed_source(request: dict[str, Any]) -> dict[str, Any]:
+    source_key = str(request.get("source_key", "")).strip()
+    if not source_key:
+        return {"status": "failed", "reason": "source_key_missing"}
+    try:
+        existing = addressed_sources_by_key(source_key)
+    except FileNotFoundError:
+        return {"status": "failed", "reason": "bd_not_available"}
+    except Exception as exc:  # noqa: BLE001
+        return {"status": "failed", "reason": "source_lookup_failed", "detail": trim_output(str(exc))}
+    if existing:
+        existing_id = bead_id(existing[0])
+        return {
+            "status": "duplicate",
+            "reason": "source_key_exists",
+            "bead_id": existing_id,
+            "source_key": source_key,
+            "address": request.get("address", ""),
+        }
+
+    city_root = common.city_root() or "."
+    bd_bin = os.environ.get("BD_BIN", "bd")
+    metadata = addressed_source_metadata(request)
+    command = [
+        bd_bin,
+        "create",
+        "--json",
+        addressed_source_title(request),
+        "-t",
+        "task",
+        "--description",
+        addressed_source_description(request),
+        "--labels",
+        "github-intake,addressed-message",
+        "--external-ref",
+        source_key,
+        "--metadata",
+        json.dumps(metadata, sort_keys=True),
+    ]
+    try:
+        result = run_subprocess(command, city_root)
+    except FileNotFoundError:
+        return {"status": "failed", "reason": "bd_not_available"}
+    if result.returncode != 0:
+        return {
+            "status": "failed",
+            "reason": "source_create_failed",
+            "source_key": source_key,
+            "stdout": trim_output(result.stdout),
+            "stderr": trim_output(result.stderr),
+        }
+    created = extract_json_output(result.stdout)
+    created_id = str(created.get("id", "")).strip()
+    if not created_id:
+        return {
+            "status": "failed",
+            "reason": "source_create_invalid_json",
+            "source_key": source_key,
+            "stdout": trim_output(result.stdout),
+            "stderr": trim_output(result.stderr),
+        }
+    return {
+        "status": "created",
+        "bead_id": created_id,
+        "source_key": source_key,
+        "address": request.get("address", ""),
+    }
+
+
+def comment_from_bot(payload: dict[str, Any], app_cfg: dict[str, Any]) -> bool:
+    comment = payload.get("comment") or {}
+    user = comment.get("user") or {}
+    login = str(user.get("login", ""))
+    user_type = str(user.get("type", ""))
+    bot_login = common.app_bot_login(app_cfg)
+    if bot_login and login.lower() == bot_login.lower():
+        return True
+    return user_type.lower() == "bot" or login.lower().endswith("[bot]")
+
+
+def process_addressed_comment(
+    event: str,
+    delivery_id: str,
+    payload: dict[str, Any],
+    app_cfg: dict[str, Any],
+) -> dict[str, Any]:
+    if event != "issue_comment":
+        return {"status": "ignored", "reason": "not_issue_comment"}
+    try:
+        rules_config = common.load_rules()
+    except Exception as exc:  # noqa: BLE001
+        result = {
+            "result_id": addressed_result_id(delivery_id, "rules-load-failed"),
+            "created_at": common.utcnow(),
+            "delivery_id": delivery_id,
+            "event": event,
+            "status": "failed",
+            "reason": f"rules_load_failed: {exc}",
+        }
+        common.save_address_result(result)
+        return result
+    extracted = common.extract_addressed_comment_requests(payload, rules_config)
+    if not extracted:
+        return {"status": "ignored", "reason": "no_configured_address_match"}
+    if comment_from_bot(payload, app_cfg):
+        result = {
+            "result_id": addressed_result_id(delivery_id, "comment-from-bot"),
+            "created_at": common.utcnow(),
+            "delivery_id": delivery_id,
+            "event": event,
+            "status": "ignored",
+            "reason": "comment_from_bot",
+            "addresses": extracted.get("addresses", []),
+        }
+        common.save_address_result(result)
+        return result
+
+    first_request = dict((extracted.get("requests") or [{}])[0])
+    first_request["delivery_id"] = delivery_id
+    first_request["raw_payload_path"] = common.delivery_path(delivery_id or "unknown-delivery")
+    addresses = [str(address) for address in extracted.get("addresses", [])]
+    first_source_key = str(first_request.get("source_key", ""))
+    if not extracted.get("authorized"):
+        result_id = addressed_source_result_id(first_source_key, "sender-not-authorized")
+        existing = common.load_address_result(result_id) if first_source_key else None
+        if existing:
+            return {
+                "result_id": result_id,
+                "created_at": common.utcnow(),
+                "delivery_id": delivery_id,
+                "event": event,
+                "status": "duplicate",
+                "reason": "sender_not_authorized_already_reported",
+                "addresses": addresses,
+            }
+        result = {
+            "result_id": result_id or addressed_result_id(delivery_id, "unauthorized"),
+            "created_at": common.utcnow(),
+            "delivery_id": delivery_id,
+            "event": event,
+            "status": "rejected",
+            "reason": "sender_not_authorized",
+            "sender": extracted.get("sender", ""),
+            "addresses": addresses,
+        }
+        post_addressed_reply(
+            first_request,
+            app_cfg,
+            f"You are not authorized to use {format_addresses(addresses)} in this repository. No work was created.",
+            result,
+        )
+        common.save_address_result(result)
+        return result
+    if not str(extracted.get("cleaned_body", "")).strip():
+        result_id = addressed_source_result_id(first_source_key, "empty-request")
+        existing = common.load_address_result(result_id) if first_source_key else None
+        if existing:
+            return {
+                "result_id": result_id,
+                "created_at": common.utcnow(),
+                "delivery_id": delivery_id,
+                "event": event,
+                "status": "duplicate",
+                "reason": "empty_request_already_reported",
+                "addresses": addresses,
+            }
+        result = {
+            "result_id": result_id or addressed_result_id(delivery_id, "empty-request"),
+            "created_at": common.utcnow(),
+            "delivery_id": delivery_id,
+            "event": event,
+            "status": "rejected",
+            "reason": "empty_request",
+            "addresses": addresses,
+        }
+        post_addressed_reply(
+            first_request,
+            app_cfg,
+            f"{format_addresses(addresses)} needs a request after the mention. No work was created.",
+            result,
+        )
+        common.save_address_result(result)
+        return result
+
+    created: list[dict[str, Any]] = []
+    duplicates: list[dict[str, Any]] = []
+    failures: list[dict[str, Any]] = []
+    for raw_request in extracted.get("requests") or []:
+        request = dict(raw_request)
+        request["delivery_id"] = delivery_id
+        request["raw_payload_path"] = common.delivery_path(delivery_id or "unknown-delivery")
+        outcome = create_addressed_source(request)
+        outcome["address"] = request.get("address", "")
+        outcome["ack"] = addressed_bool_metadata(request.get("ack", True)) == "true"
+        if outcome.get("status") == "created":
+            created.append(outcome)
+        elif outcome.get("status") == "duplicate":
+            duplicates.append(outcome)
+        else:
+            failures.append(outcome)
+
+    result = {
+        "result_id": addressed_result_id(delivery_id, "processed"),
+        "created_at": common.utcnow(),
+        "delivery_id": delivery_id,
+        "event": event,
+        "status": "failed" if failures else "accepted",
+        "addresses": addresses,
+        "created_count": len(created),
+        "duplicate_count": len(duplicates),
+        "failure_count": len(failures),
+        "created": created,
+        "duplicates": duplicates,
+        "failures": failures,
+    }
+    source_keys = [str(item.get("source_key", "")).strip() for item in created + duplicates]
+    if source_keys:
+        result["router_kick"] = enqueue_addressed_router(delivery_id, source_keys)
+    if failures:
+        result["reason"] = "source_create_failed"
+    common.save_address_result(result)
+    return result
+
+
+def run_fix_bugflow_dispatch(request: dict[str, Any], app_cfg: dict[str, Any]) -> dict[str, Any]:
+    installation_id = str(request.get("installation_id", ""))
+    owner = str(request.get("repository_owner", ""))
+    repo = str(request.get("repository_name", ""))
+    commenter = str(request.get("comment_author", ""))
+    issue_url = str(request.get("issue_url", "")).strip()
+    if not app_cfg or not installation_id or not owner or not repo:
+        return {"status": "ignored", "reason": "github_app_not_configured"}
+    if not issue_url:
+        return {"status": "dispatch_failed", "reason": "issue_url_missing"}
+    try:
+        permission = common.repository_permission(app_cfg, installation_id, owner, repo, commenter)
+    except Exception:  # noqa: BLE001
+        return {"status": "dispatch_failed", "reason": "permission_lookup_failed"}
+    if permission not in WRITE_PERMISSION_LEVELS:
+        return {
+            "status": "ignored",
+            "reason": "comment_author_lacks_write",
+            "requester_permission": permission,
+        }
+    try:
+        env = bugflow_env(app_cfg, installation_id)
+    except Exception as exc:  # noqa: BLE001
+        return {
+            "status": "dispatch_failed",
+            "reason": "github_app_token_failed",
+            "dispatch_stderr": trim_output(str(exc)),
+            "requester_permission": permission,
+        }
+
+    gc_bin = os.environ.get("GC_BIN", "gc")
+    create_command = [gc_bin, "workflows", "bugflow", "create", issue_url]
+    try:
+        create_result = run_subprocess(create_command, common.city_root() or ".", env=env)
+    except FileNotFoundError:
+        return {
+            "status": "dispatch_failed",
+            "reason": "gc_not_available",
+            "dispatch_formula": BUGFLOW_WORKFLOW_FORMULA,
+            "dispatch_command": create_command,
+            "requester_permission": permission,
+        }
+
+    create_payload = extract_json_output(create_result.stdout)
+    source_bead_id = str(create_payload.get("bead_id", "") or create_payload.get("id", "")).strip()
+    outcome = {
+        "dispatch_target": "workflows.bugflow-router",
+        "dispatch_formula": BUGFLOW_WORKFLOW_FORMULA,
+        "dispatch_command": create_command,
+        "dispatch_exit_code": create_result.returncode,
+        "dispatch_stdout": trim_output(create_result.stdout),
+        "dispatch_stderr": trim_output(create_result.stderr),
+        "requester_permission": permission,
+    }
+    if source_bead_id:
+        outcome["bead_id"] = source_bead_id
+        outcome["bugflow_source_bead_id"] = source_bead_id
+
+    duplicate = bugflow_duplicate_source(create_result)
+    if create_result.returncode != 0 and not duplicate:
+        outcome["status"] = "dispatch_failed"
+        outcome["reason"] = "dispatch_failed"
+        return outcome
+    if duplicate:
+        outcome["reason"] = "duplicate_open_bead"
+
+    router_command = [gc_bin, "workflows", "bugflow", "router-scan"]
+    outcome["router_command"] = router_command
+    try:
+        router_result = run_subprocess(router_command, common.city_root() or ".", env=env)
+    except FileNotFoundError:
+        outcome["status"] = "dispatch_failed"
+        outcome["reason"] = "gc_not_available"
+        return outcome
+    add_router_result(outcome, router_result)
+    if router_result.returncode != 0:
+        outcome["status"] = "dispatch_failed"
+        outcome["reason"] = "bugflow_router_failed"
+        return outcome
+    outcome["status"] = "dispatched"
+    post_bugflow_acknowledgement(request, app_cfg, outcome)
+    return outcome
+
+
 def run_fix_issue_dispatch(
     request: dict[str, Any],
     mapping: dict[str, Any],
@@ -380,7 +1229,7 @@ def process_request(request_id: str) -> None:
         if not request:
             return
         workflow_key_hint = str(request.get("workflow_key", ""))
-        config = common.load_config()
+        config = common.load_effective_config()
         app_cfg = config.get("app", {})
         mapping = common.resolve_repo_mapping(
             config,
@@ -391,6 +1240,9 @@ def process_request(request_id: str) -> None:
         if not behavior:
             request["status"] = "ignored"
             request["reason"] = "command_not_supported"
+        elif str(request.get("command", "")) == "fix":
+            outcome = run_fix_bugflow_dispatch(request, app_cfg if isinstance(app_cfg, dict) else {})
+            request.update(outcome)
         elif not mapping:
             request["status"] = "ignored"
             request["reason"] = "repo_mapping_missing"
@@ -460,6 +1312,675 @@ def enqueue_request(request_id: str) -> None:
     thread.start()
 
 
+def process_queued_event_rules(
+    event: str,
+    delivery_id: str,
+    payload: dict[str, Any],
+    app_cfg: dict[str, Any],
+    processing_key: str,
+) -> None:
+    try:
+        process_event_rules(event, delivery_id, payload, app_cfg)
+    except Exception as exc:  # noqa: BLE001 - persist unexpected rule processor failures for operator inspection.
+        common.save_rule_result(
+            {
+                "result_id": f"{delivery_id or 'unknown-delivery'}-rules-processing-failed",
+                "created_at": common.utcnow(),
+                "delivery_id": delivery_id,
+                "event": event,
+                "status": "failed",
+                "reason": f"rules_processing_failed: {exc}",
+                "traceback": trim_output(traceback.format_exc(), 4000),
+                "actions": [],
+            }
+        )
+    finally:
+        if processing_key:
+            with RULE_PROCESSING_LOCK:
+                RULE_PROCESSING_DELIVERIES.discard(processing_key)
+
+
+def enqueue_event_rules(event: str, delivery_id: str, payload: dict[str, Any], app_cfg: dict[str, Any]) -> str:
+    processing_key = delivery_id.strip()
+    if processing_key:
+        with RULE_PROCESSING_LOCK:
+            if processing_key in RULE_PROCESSING_DELIVERIES:
+                return "already_processing"
+            RULE_PROCESSING_DELIVERIES.add(processing_key)
+    thread = threading.Thread(
+        target=process_queued_event_rules,
+        args=(event, delivery_id, payload, app_cfg, processing_key),
+        daemon=True,
+    )
+    thread.start()
+    return "queued"
+
+
+def render_template(value: str, payload: dict[str, Any]) -> str:
+    out = value
+    while "{{" in out and "}}" in out:
+        start = out.find("{{")
+        end = out.find("}}", start + 2)
+        if end == -1:
+            break
+        key = out[start + 2 : end].strip()
+        replacement = common.payload_value(payload, key)
+        out = out[:start] + ("" if replacement is None else str(replacement)) + out[end + 2 :]
+    return out
+
+
+def github_event_env(event: str, delivery_id: str, payload: dict[str, Any], payload_file: str) -> dict[str, str]:
+    repository = payload.get("repository") or {}
+    owner = repository.get("owner") or {}
+    pull_request = payload.get("pull_request") or {}
+    issue = payload.get("issue") or {}
+    item_kind = "pr" if pull_request else ("issue" if issue else "")
+    item = pull_request or issue
+    label = payload.get("label") or {}
+    sender = payload.get("sender") or {}
+    installation = payload.get("installation") or {}
+    values = {
+        "GC_GITHUB_EVENT": event,
+        "GC_GITHUB_DELIVERY_ID": delivery_id,
+        "GC_GITHUB_EVENT_PAYLOAD_FILE": payload_file,
+        "GC_GITHUB_ACTION": str(payload.get("action", "")),
+        "GC_GITHUB_REPO": str(repository.get("full_name", "")).lower(),
+        "GC_GITHUB_REPOSITORY_ID": str(repository.get("id", "")),
+        "GC_GITHUB_REPOSITORY_OWNER": str(owner.get("login", "")),
+        "GC_GITHUB_REPOSITORY_NAME": str(repository.get("name", "")),
+        "GC_GITHUB_PR_NUMBER": str(pull_request.get("number", "")),
+        "GC_GITHUB_PR_URL": str(pull_request.get("html_url", "")),
+        "GC_GITHUB_PR_STATE": str(pull_request.get("state", "")),
+        "GC_GITHUB_ISSUE_NUMBER": str(issue.get("number", "")),
+        "GC_GITHUB_ISSUE_URL": str(issue.get("html_url", "")),
+        "GC_GITHUB_ISSUE_STATE": str(issue.get("state", "")),
+        "GC_GITHUB_ITEM_KIND": item_kind,
+        "GC_GITHUB_ITEM_NUMBER": str(item.get("number", "")),
+        "GC_GITHUB_ITEM_URL": str(item.get("html_url", "")),
+        "GC_GITHUB_ITEM_STATE": str(item.get("state", "")),
+        "GC_GITHUB_LABEL_NAME": str(label.get("name", "")),
+        "GC_GITHUB_SENDER": str(sender.get("login", "")),
+        "GC_GITHUB_INSTALLATION_ID": str(installation.get("id", "")),
+    }
+    return {key: value for key, value in values.items() if value}
+
+
+def action_success(action: dict[str, Any], result: subprocess.CompletedProcess[str]) -> bool:
+    raw_codes = action.get("success_exit_codes", [0])
+    if not isinstance(raw_codes, list):
+        raw_codes = [raw_codes]
+    success_codes = {int(code) for code in raw_codes}
+    if result.returncode in success_codes:
+        return True
+    for value in action.get("success_stderr_contains") or []:
+        if str(value) and str(value) in result.stderr:
+            return True
+    return False
+
+
+def action_env(
+    action: dict[str, Any],
+    event: str,
+    delivery_id: str,
+    payload: dict[str, Any],
+    payload_file: str,
+    app_cfg: dict[str, Any],
+) -> tuple[dict[str, str], str]:
+    env = os.environ.copy()
+    env.update(github_event_env(event, delivery_id, payload, payload_file))
+    extra_env = action.get("env") or {}
+    if isinstance(extra_env, dict):
+        for key, value in extra_env.items():
+            env[str(key)] = render_template(str(value), payload)
+    token_env = str(action.get("github_app_token_env", "")).strip()
+    if token_env:
+        installation_id = str((payload.get("installation") or {}).get("id", ""))
+        if not installation_id:
+            raise RuntimeError("github_app_token_env requires payload.installation.id")
+        env[token_env] = common.create_installation_token(app_cfg, installation_id)
+    return env, token_env
+
+
+def execute_rule_action(
+    rule: dict[str, Any],
+    action: dict[str, Any],
+    event: str,
+    delivery_id: str,
+    payload: dict[str, Any],
+    payload_file: str,
+    app_cfg: dict[str, Any],
+) -> dict[str, Any]:
+    started = common.utcnow()
+    action_type = str(action.get("type", "")).strip()
+    if action_type == "order":
+        command = ["gc", "order", "run", render_template(str(action.get("name", "")), payload)]
+        rig = str(action.get("rig", "")).strip()
+        if rig:
+            command.extend(["--rig", render_template(rig, payload)])
+    elif action_type == "command":
+        raw_command = action.get("command") or []
+        if not isinstance(raw_command, list) or not raw_command:
+            return {
+                "type": action_type,
+                "status": "failed",
+                "reason": "command_action_requires_command_array",
+                "started_at": started,
+                "finished_at": common.utcnow(),
+            }
+        command = [render_template(str(part), payload) for part in raw_command]
+    else:
+        return {
+            "type": action_type,
+            "status": "failed",
+            "reason": "unsupported_action_type",
+            "started_at": started,
+            "finished_at": common.utcnow(),
+        }
+
+    try:
+        env, token_env = action_env(action, event, delivery_id, payload, payload_file, app_cfg)
+        result = run_subprocess(command, common.city_root() or ".", env=env)
+    except Exception as exc:  # noqa: BLE001
+        return {
+            "type": action_type,
+            "status": "failed",
+            "reason": str(exc),
+            "command": command,
+            "started_at": started,
+            "finished_at": common.utcnow(),
+        }
+    status = "success" if action_success(action, result) else "failed"
+    outcome = {
+        "type": action_type,
+        "status": status,
+        "command": command,
+        "exit_code": result.returncode,
+        "stdout": trim_output(result.stdout),
+        "stderr": trim_output(result.stderr),
+        "started_at": started,
+        "finished_at": common.utcnow(),
+    }
+    if token_env:
+        outcome["github_app_token_env"] = token_env
+        outcome["github_app_token_injected"] = True
+    if status != "success":
+        outcome["reason"] = "action_failed"
+    return outcome
+
+
+def process_event_rules(event: str, delivery_id: str, payload: dict[str, Any], app_cfg: dict[str, Any]) -> list[dict[str, Any]]:
+    try:
+        rules_config = common.load_rules()
+    except Exception as exc:  # noqa: BLE001
+        result = {
+            "result_id": f"{delivery_id or 'unknown-delivery'}-rules-load-failed",
+            "created_at": common.utcnow(),
+            "delivery_id": delivery_id,
+            "event": event,
+            "status": "failed",
+            "reason": f"rules_load_failed: {exc}",
+            "actions": [],
+        }
+        common.save_rule_result(result)
+        return [result]
+
+    payload_file = common.delivery_path(delivery_id or "unknown-delivery")
+    summaries: list[dict[str, Any]] = []
+    rules = common.matching_rules(event, payload, rules_config)
+    bot_login = common.app_bot_login(app_cfg)
+    sender = str((payload.get("sender") or {}).get("login", ""))
+    if bot_login and sender.lower() == bot_login.lower():
+        rules = [rule for rule in rules if bool(rule.get("allow_self"))]
+
+    for rule in rules:
+        result = {
+            "result_id": f"{delivery_id or 'unknown-delivery'}-{rule.get('id', 'rule')}",
+            "created_at": common.utcnow(),
+            "delivery_id": delivery_id,
+            "event": event,
+            "rule_id": rule.get("id", ""),
+            "status": "success",
+            "actions": [],
+        }
+        for index, action in enumerate(rule.get("action") or []):
+            outcome = execute_rule_action(rule, action, event, delivery_id, payload, payload_file, app_cfg)
+            outcome["index"] = index
+            result["actions"].append(outcome)
+            if outcome.get("status") != "success":
+                result["status"] = "failed"
+                result["reason"] = outcome.get("reason", "action_failed")
+                break
+        common.save_rule_result(result)
+        summaries.append(
+            {
+                "result_id": result["result_id"],
+                "rule_id": result.get("rule_id", ""),
+                "status": result.get("status", ""),
+                "reason": result.get("reason", ""),
+            }
+        )
+    return summaries
+
+
+def list_addressed_router_sources(limit: int) -> list[dict[str, Any]]:
+    bd_bin = os.environ.get("BD_BIN", "bd")
+    result = run_subprocess(
+        [
+            bd_bin,
+            "list",
+            "--json",
+            "--status",
+            "open",
+            "--metadata-field",
+            "external.kind=addressed-message",
+            "--limit",
+            str(limit),
+        ],
+        common.city_root() or ".",
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"bd list failed: {trim_output(result.stderr or result.stdout)}")
+    payload = extract_json_value(result.stdout)
+    if not isinstance(payload, list):
+        return []
+    return [item for item in payload if isinstance(item, dict)]
+
+
+def update_bead_metadata(bead: str, values: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    bd_bin = os.environ.get("BD_BIN", "bd")
+    command = [bd_bin, "update", bead]
+    for key, value in values.items():
+        if value:
+            command.extend(["--set-metadata", f"{key}={value}"])
+    return run_subprocess(command, common.city_root() or ".")
+
+
+def close_addressed_source(source_id: str) -> subprocess.CompletedProcess[str]:
+    bd_bin = os.environ.get("BD_BIN", "bd")
+    return run_subprocess(
+        [bd_bin, "close", source_id, "--reason", "github addressed message dispatched"],
+        common.city_root() or ".",
+    )
+
+
+def addressed_router_vars(source_id: str, metadata: dict[str, str]) -> dict[str, str]:
+    installation_id = metadata.get("addressed.github_app_installation_id", "") or metadata.get("github.installation_id", "")
+    return {
+        "source_bead_id": source_id,
+        "city_root": metadata.get("addressed.city_source_city", "") or common.city_root(),
+        "address": metadata.get("addressed.address", ""),
+        "request_text": metadata.get("addressed.cleaned_body", ""),
+        "github_repo": metadata.get("github.repo", ""),
+        "github_issue_number": metadata.get("github.issue_number", ""),
+        "github_item_url": metadata.get("github.item_url", ""),
+        "github_comment_url": metadata.get("github.comment_url", ""),
+        "github_sender": metadata.get("github.sender", ""),
+        "github_app_identity": metadata.get("addressed.github_app_identity", ""),
+        "github_app_installation_id": installation_id,
+        "acknowledgement_requested": metadata.get("addressed.ack_requested", "true") or "true",
+        "external_source_key": metadata.get("external.source_key", ""),
+        "raw_payload_path": metadata.get("raw_payload.path", ""),
+    }
+
+
+def addressed_route_target(metadata: dict[str, str]) -> str:
+    pool = metadata.get("addressed.pool", "").strip()
+    try:
+        rig = common.github_repo_dispatch_rig(metadata.get("github.repo", ""))
+    except Exception:  # noqa: BLE001
+        rig = common.github_repo_rig_name(metadata.get("github.repo", ""))
+    if rig and pool and "/" not in pool:
+        return f"{rig}/{pool}"
+    return ""
+
+
+def addressed_rig_launch_description(source_id: str, metadata: dict[str, str], formula: str) -> str:
+    repo = metadata.get("github.repo", "")
+    issue_number = metadata.get("github.issue_number", "")
+    return "\n".join(
+        [
+            "GitHub addressed-message rig launch bead.",
+            "",
+            f"Address: {metadata.get('addressed.address', '')}",
+            f"Repository: {metadata.get('github.repo', '')}",
+            f"Source: {metadata.get('github.item_url', '')}",
+            f"Comment: {metadata.get('github.comment_url', '')}",
+            f"Requested By: {metadata.get('github.sender', '')}",
+            f"City source bead: {source_id}",
+            "",
+            f"{formula} is attached to this rig-local bead so the request runs in the same bead database as the target agent.",
+            "",
+            "## GitHub Response Contract",
+            "",
+            "The GitHub thread is the user-visible response channel.",
+            "Post acknowledgements, dry-run plans, results, and blockers back to the GitHub thread using the addressed profile identity.",
+            f"Use: gc github comment-issue {repo} {issue_number} --installation-id <profile-installation-id> --github-app-identity <profile-identity> --body-file <file>",
+            "Local session output alone does not complete this request.",
+            f"Record response comment IDs or posting failures on the city source bead `{source_id}`.",
+        ]
+    )
+
+
+def addressed_rig_launch_metadata(source_id: str, metadata: dict[str, str], target: str, formula: str) -> dict[str, str]:
+    launch_metadata = {
+        key: value
+        for key, value in metadata.items()
+        if not key.startswith("addressed.router_")
+        and key
+        not in {
+            "addressed.dispatched_at",
+            "addressed.rig_launch_bead",
+            "addressed.workflow_root",
+            "addressed.workflow_store",
+        }
+    }
+    launch_metadata.update(
+        {
+            "gc.source_bead_id": source_id,
+            "gc.source_store_ref": f"city:{common.city_name()}",
+            "addressed.city_source_bead_id": source_id,
+            "addressed.city_source_city": common.city_root() or "",
+            "addressed.status": "rig_launch_created",
+            "addressed.workflow_formula": formula,
+            "addressed.workflow_role": "rig-launch",
+            "addressed.workflow_target": target,
+        }
+    )
+    return launch_metadata
+
+
+def create_addressed_rig_launch_bead(
+    source_id: str,
+    source: dict[str, Any],
+    metadata: dict[str, str],
+    target: str,
+    formula: str,
+) -> dict[str, Any]:
+    rig = rig_from_target(target)
+    if not rig:
+        return {"status": "failed", "reason": "missing_rig"}
+    gc_bin = os.environ.get("GC_BIN", "gc")
+    launch_metadata = addressed_rig_launch_metadata(source_id, metadata, target, formula)
+    command = [
+        gc_bin,
+        "--rig",
+        rig,
+        "bd",
+        "create",
+        str(source.get("title") or addressed_source_title(metadata)),
+        "--type",
+        "task",
+        "--description",
+        addressed_rig_launch_description(source_id, metadata, formula),
+        "--external-ref",
+        metadata.get("external.source_key", ""),
+        "--metadata",
+        json.dumps(launch_metadata, sort_keys=True),
+        "--json",
+    ]
+    try:
+        result = run_subprocess(command, common.city_root() or ".")
+    except FileNotFoundError:
+        return {"status": "failed", "reason": "gc_not_available"}
+    if result.returncode != 0:
+        return {
+            "status": "failed",
+            "reason": "rig_launch_failed",
+            "exit_code": result.returncode,
+            "stdout": trim_output(result.stdout),
+            "stderr": trim_output(result.stderr),
+        }
+    created = extract_json_output(result.stdout)
+    launch_id = str(created.get("id", "")).strip()
+    if not launch_id:
+        return {
+            "status": "failed",
+            "reason": "rig_launch_invalid_json",
+            "stdout": trim_output(result.stdout),
+            "stderr": trim_output(result.stderr),
+        }
+    return {"status": "created", "bead_id": launch_id, "rig": rig}
+
+
+def workflow_root_from_sling_output(output: str) -> str:
+    payload = extract_json_output(output)
+    for key in ("workflow_id", "molecule_id", "bead_id"):
+        value = str(payload.get(key, "")).strip()
+        if value:
+            return value
+    return ""
+
+
+def parse_utc(value: str) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def addressed_router_state_stale(metadata: dict[str, str]) -> bool:
+    started_at = parse_utc(metadata.get("addressed.router_started_at", ""))
+    if not started_at:
+        return True
+    return datetime.now(timezone.utc) - started_at > ADDRESSED_ROUTER_STALE_AFTER
+
+
+def route_addressed_source(source: dict[str, Any]) -> dict[str, Any]:
+    source_id = bead_id(source)
+    metadata = bead_metadata(source)
+    if not source_id:
+        return {"status": "skipped", "reason": "missing_source_id"}
+    if metadata.get("addressed.workflow_root"):
+        close = close_addressed_source(source_id)
+        if close.returncode != 0:
+            return {
+                "status": "failed",
+                "bead_id": source_id,
+                "workflow_root_id": metadata.get("addressed.workflow_root", ""),
+                "reason": "source_close_failed",
+                "stderr": trim_output(close.stderr),
+            }
+        return {
+            "status": "skipped",
+            "bead_id": source_id,
+            "workflow_root_id": metadata.get("addressed.workflow_root", ""),
+            "reason": "already_dispatched_closed",
+        }
+    if metadata.get("addressed.router_status") in ADDRESSED_ROUTER_IN_PROGRESS_STATUSES and not addressed_router_state_stale(metadata):
+        return {"status": "skipped", "bead_id": source_id, "reason": "router_already_started"}
+    pool = metadata.get("addressed.pool", "")
+    target = addressed_route_target(metadata)
+    formula = metadata.get("addressed.formula", "") or ADDRESSED_MESSAGE_FORMULA
+    rig = rig_from_target(target)
+    if not target or not formula or not rig:
+        outcome = {"status": "failed", "bead_id": source_id, "reason": "missing_route"}
+        update_bead_metadata(
+            source_id,
+            {
+                "addressed.router_status": "failed",
+                "addressed.router_reason": "missing_route",
+                "addressed.router_failed_at": common.utcnow(),
+            },
+        )
+        return outcome
+
+    starting = update_bead_metadata(
+        source_id,
+        {
+            "addressed.router_status": "starting",
+            "addressed.router_started_at": common.utcnow(),
+        },
+    )
+    if starting.returncode != 0:
+        return {
+            "status": "failed",
+            "bead_id": source_id,
+            "reason": "source_update_failed",
+            "stderr": trim_output(starting.stderr),
+        }
+
+    gc_bin = os.environ.get("GC_BIN", "gc")
+    launch = create_addressed_rig_launch_bead(source_id, source, metadata, target, formula)
+    launch_bead_id = str(launch.get("bead_id", ""))
+    if launch.get("status") != "created" or not launch_bead_id:
+        reason = str(launch.get("reason", "rig_launch_failed"))
+        update_bead_metadata(
+            source_id,
+            {
+                "addressed.router_status": "failed",
+                "addressed.router_reason": reason,
+                "addressed.router_failed_at": common.utcnow(),
+                "addressed.router_stderr": str(launch.get("stderr", "")),
+            },
+        )
+        outcome = {
+            "status": "failed",
+            "bead_id": source_id,
+            "reason": reason,
+        }
+        if launch.get("exit_code") is not None:
+            outcome["exit_code"] = launch.get("exit_code")
+        if launch.get("stdout"):
+            outcome["stdout"] = launch.get("stdout")
+        if launch.get("stderr"):
+            outcome["stderr"] = launch.get("stderr")
+        return outcome
+
+    command = [
+        gc_bin,
+        "--rig",
+        rig,
+        "sling",
+        "--json",
+        target,
+        launch_bead_id,
+        "--force",
+        "--on",
+        formula,
+        "--title",
+        str(source.get("title") or addressed_source_title(metadata)),
+    ]
+    for key, value in addressed_router_vars(source_id, metadata).items():
+        if value:
+            command.extend(["--var", f"{key}={value}"])
+    try:
+        result = run_subprocess(command, common.city_root() or ".")
+    except FileNotFoundError:
+        update_bead_metadata(
+            source_id,
+            {
+                "addressed.router_status": "failed",
+                "addressed.router_reason": "gc_not_available",
+                "addressed.router_failed_at": common.utcnow(),
+            },
+        )
+        return {"status": "failed", "bead_id": source_id, "reason": "gc_not_available"}
+    workflow_root = workflow_root_from_sling_output(result.stdout)
+    if result.returncode != 0 or not workflow_root:
+        reason = "sling_failed" if result.returncode != 0 else "missing_workflow_root"
+        update_bead_metadata(
+            source_id,
+            {
+                "addressed.router_status": "failed",
+                "addressed.router_reason": reason,
+                "addressed.router_failed_at": common.utcnow(),
+                "addressed.router_stderr": trim_output(result.stderr),
+            },
+        )
+        return {
+            "status": "failed",
+            "bead_id": source_id,
+            "reason": reason,
+            "exit_code": result.returncode,
+            "stdout": trim_output(result.stdout),
+            "stderr": trim_output(result.stderr),
+        }
+
+    update = update_bead_metadata(
+        source_id,
+        {
+            "addressed.router_status": "dispatched",
+            "addressed.rig_launch_bead": launch_bead_id,
+            "addressed.workflow_root": workflow_root,
+            "addressed.dispatched_at": common.utcnow(),
+            "addressed.workflow_formula": formula,
+            "addressed.workflow_pool": pool,
+            "addressed.workflow_target": target,
+            "addressed.workflow_store": f"rig:{rig}",
+        },
+    )
+    if update.returncode != 0:
+        update_bead_metadata(
+            source_id,
+            {
+                "addressed.router_status": "failed",
+                "addressed.router_reason": "source_update_failed",
+                "addressed.router_failed_at": common.utcnow(),
+                "addressed.rig_launch_bead": launch_bead_id,
+                "addressed.workflow_root": workflow_root,
+            },
+        )
+        return {
+            "status": "failed",
+            "bead_id": source_id,
+            "rig_launch_bead_id": launch_bead_id,
+            "workflow_root_id": workflow_root,
+            "reason": "source_update_failed",
+            "stderr": trim_output(update.stderr),
+        }
+    close = close_addressed_source(source_id)
+    if close.returncode != 0:
+        return {
+            "status": "failed",
+            "bead_id": source_id,
+            "workflow_root_id": workflow_root,
+            "reason": "source_close_failed",
+            "stderr": trim_output(close.stderr),
+        }
+    return {
+        "status": "started",
+        "bead_id": source_id,
+        "rig_launch_bead_id": launch_bead_id,
+        "workflow_root_id": workflow_root,
+        "pool": pool,
+        "target": target,
+        "formula": formula,
+    }
+
+
+def run_addressed_router(limit: int = 50) -> dict[str, Any]:
+    try:
+        sources = list_addressed_router_sources(limit)
+    except FileNotFoundError:
+        return {"status": "failed", "reason": "bd_not_available", "started": [], "skipped": [], "failures": []}
+    except Exception as exc:  # noqa: BLE001
+        return {"status": "failed", "reason": "source_list_failed", "detail": str(exc), "started": [], "skipped": [], "failures": []}
+
+    started: list[dict[str, Any]] = []
+    skipped: list[dict[str, Any]] = []
+    failures: list[dict[str, Any]] = []
+    for source in sources:
+        outcome = route_addressed_source(source)
+        status = outcome.get("status")
+        if status == "started":
+            started.append(outcome)
+        elif status == "skipped":
+            skipped.append(outcome)
+        else:
+            failures.append(outcome)
+    return {
+        "status": "failed" if failures else "ok",
+        "started_count": len(started),
+        "skipped_count": len(skipped),
+        "failure_count": len(failures),
+        "started": started,
+        "skipped": skipped,
+        "failures": failures,
+    }
+
+
 def render_admin_home() -> str:
     snapshot = common.build_status_snapshot(limit=20)
     config = snapshot["config"]
@@ -527,8 +2048,10 @@ def render_admin_home() -> str:
   <pre>{html.escape(json.dumps(config, indent=2, sort_keys=True))}</pre>
   <h2>Recent Requests</h2>
   <pre>{html.escape(json.dumps(snapshot['recent_requests'], indent=2, sort_keys=True))}</pre>
-  <h2>Repository Mapping</h2>
-  <p>Use <code>gc github map-repo owner/repo rig/polecat --fix-formula mol-github-fix-issue</code> to update repo routing.</p>
+  <h2>Recent Addressed Messages</h2>
+  <pre>{html.escape(json.dumps(snapshot['recent_address_results'], indent=2, sort_keys=True))}</pre>
+  <h2>Bugflow Routing</h2>
+  <p><code>/gc fix</code> uses the workflows bugflow router. Configure repositories with <code>gc workflows pr-review config set-repo owner/repo --city /abs/city --rig &lt;rig&gt; --base-branch main</code>.</p>
 </body>
 </html>
 """
@@ -608,12 +2131,22 @@ class IntakeHandler(BaseHTTPRequestHandler):
                     "text/plain; charset=utf-8",
                 )
                 return
+            publish_result = publish_imported_identity(config)
             app_cfg = config.get("app", {})
             body = [
                 "<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\"><title>GitHub Intake Ready</title></head><body>",
                 "<h1>GitHub App Imported</h1>",
                 f"<p>App id: <code>{html.escape(str(app_cfg.get('app_id', '')))}</code></p>",
             ]
+            publish_status = str(publish_result.get("status", ""))
+            if publish_status == "published":
+                body.append("<p>Credentials published to the configured secret store.</p>")
+            elif publish_status == "error":
+                body.append(
+                    f'<p class="warning">Secret-store publish failed: '
+                    f"<code>{html.escape(str(publish_result.get('detail', '')))}</code>. "
+                    "Credentials remain in the local service config.</p>"
+                )
             install_url = common.install_url(app_cfg)
             if install_url:
                 body.append(f'<p><a href="{html.escape(install_url)}">Install the GitHub App</a></p>')
@@ -632,7 +2165,8 @@ class IntakeHandler(BaseHTTPRequestHandler):
             json_response(self, HTTPStatus.BAD_REQUEST, {"error": str(exc)})
             return
         config = common.import_app_config(common.load_config(), body)
-        json_response(self, HTTPStatus.OK, {"config": common.redact_config(config)})
+        publish_result = publish_imported_identity(config)
+        json_response(self, HTTPStatus.OK, {"config": common.redact_config(config), "publish": publish_result})
 
     def _do_webhook_get(self, parsed: urllib.parse.ParseResult) -> None:
         if parsed.path == "/":
@@ -654,7 +2188,19 @@ class IntakeHandler(BaseHTTPRequestHandler):
             return
         length = int(self.headers.get("Content-Length", "0"))
         body = self.rfile.read(length) if length > 0 else b""
-        config = common.load_config()
+        config = common.load_effective_config()
+        try:
+            config = ensure_webhook_app_config(config)
+        except Exception as exc:  # noqa: BLE001 - report sync failure without dropping the service.
+            json_response(
+                self,
+                HTTPStatus.SERVICE_UNAVAILABLE,
+                {
+                    "error": "github app webhook secret is not configured",
+                    "sync_error": trim_output(str(exc)),
+                },
+            )
+            return
         app_cfg = config.get("app", {})
         secret = str(app_cfg.get("webhook_secret", ""))
         if not secret:
@@ -681,8 +2227,37 @@ class IntakeHandler(BaseHTTPRequestHandler):
             }
         )
 
+        rule_processing = enqueue_event_rules(event, delivery_id, payload, app_cfg if isinstance(app_cfg, dict) else {})
+
         if event != "issue_comment":
-            json_response(self, HTTPStatus.ACCEPTED, {"status": "ignored", "event": event})
+            json_response(
+                self,
+                HTTPStatus.ACCEPTED,
+                {
+                    "status": "accepted",
+                    "event": event,
+                    "delivery_id": delivery_id or "unknown-delivery",
+                    "rule_processing": rule_processing,
+                },
+            )
+            return
+        addressed = process_addressed_comment(event, delivery_id, payload, app_cfg if isinstance(app_cfg, dict) else {})
+        if addressed.get("status") != "ignored" or addressed.get("reason") == "comment_from_bot":
+            json_response(
+                self,
+                HTTPStatus.ACCEPTED,
+                {
+                    "status": addressed.get("status", "accepted"),
+                    "addressed_message": {
+                        "reason": addressed.get("reason", ""),
+                        "created_count": addressed.get("created_count", 0),
+                        "duplicate_count": addressed.get("duplicate_count", 0),
+                        "failure_count": addressed.get("failure_count", 0),
+                    },
+                    "command_processing": "skipped_addressed_message",
+                    "rule_processing": rule_processing,
+                },
+            )
             return
         parsed_command = common.parse_gc_command(str((payload.get("comment") or {}).get("body", "")))
         issue = payload.get("issue") or {}
@@ -733,6 +2308,14 @@ class IntakeHandler(BaseHTTPRequestHandler):
 
 def main() -> int:
     common.ensure_layout()
+    try:
+        sync_configured_github_app_at_startup()
+    except Exception as exc:  # noqa: BLE001 - the webhook path still reports config failures precisely.
+        print(
+            f"[{common.current_service_name() or 'github-intake'}] "
+            f"GitHub App config sync failed: {trim_output(str(exc))}",
+            flush=True,
+        )
     socket_path = os.environ.get("GC_SERVICE_SOCKET")
     if not socket_path:
         raise SystemExit("GC_SERVICE_SOCKET is required")

--- a/github/scripts/github_intake_status.py
+++ b/github/scripts/github_intake_status.py
@@ -48,6 +48,40 @@ def main() -> int:
     else:
         print("repository_mappings: (none)")
 
+    rules = snapshot.get("rules", {})
+    print("rules:")
+    print(f"  path: {rules.get('path', '(unknown)')}")
+    print(f"  count: {rules.get('count', 0)}")
+    print(f"  address_repo_count: {rules.get('address_repo_count', 0)}")
+    print(f"  address_count: {rules.get('address_count', 0)}")
+    if rules.get("error"):
+        print(f"  error: {rules.get('error')}")
+    ids = rules.get("ids") or []
+    if ids:
+        print("  ids:")
+        for rule_id in ids:
+            print(f"    - {rule_id}")
+
+    if snapshot.get("recent_rule_results"):
+        print("recent_rule_results:")
+        for item in snapshot["recent_rule_results"][:10]:
+            print(
+                f"  {item.get('result_id')} status={item.get('status')} "
+                f"rule={item.get('rule_id')} event={item.get('event')}"
+            )
+    else:
+        print("recent_rule_results: (none)")
+
+    if snapshot.get("recent_address_results"):
+        print("recent_address_results:")
+        for item in snapshot["recent_address_results"][:10]:
+            print(
+                f"  {item.get('result_id')} status={item.get('status')} "
+                f"reason={item.get('reason', '')} addresses={','.join(item.get('addresses') or [])}"
+            )
+    else:
+        print("recent_address_results: (none)")
+
     if snapshot["recent_requests"]:
         print("recent_requests:")
         for item in snapshot["recent_requests"][:10]:

--- a/github/scripts/github_intake_sync_app.py
+++ b/github/scripts/github_intake_sync_app.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+import github_intake_service as service
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Sync GitHub App configuration from the configured identity resolver")
+    parser.add_argument(
+        "--identity",
+        default="",
+        help="GitHub App identity to resolve; defaults to GITHUB_INTAKE_APP_IDENTITY",
+    )
+    parser.add_argument("--json", action="store_true", dest="json_output", help="emit raw JSON")
+    parser.add_argument("--quiet", action="store_true", help="print only errors")
+    args = parser.parse_args()
+
+    try:
+        outcome = service.sync_github_app_config_from_identity(args.identity)
+    except Exception as exc:  # noqa: BLE001 - command boundary reports resolver/config errors.
+        print(f"gc github sync-app: {exc}", file=sys.stderr)
+        return 1
+    if outcome.get("status") == "skipped":
+        print(f"gc github sync-app: {outcome.get('reason', 'sync skipped')}", file=sys.stderr)
+        return 1
+    if args.quiet:
+        return 0
+    if args.json_output:
+        print(json.dumps(outcome, indent=2, sort_keys=True))
+        return 0
+    print(f"status: {outcome.get('status')}")
+    print(f"identity: {outcome.get('identity')}")
+    app = (outcome.get("config") or {}).get("app") or {}
+    print(f"app_id: {app.get('app_id', '(unset)')}")
+    print(f"installation_id: {app.get('installation_id', '(unset)')}")
+    print(f"slug: {app.get('slug', '(unset)')}")
+    print(f"webhook_secret_present: {app.get('webhook_secret_present', False)}")
+    print(f"private_key_pem_present: {app.get('private_key_pem_present', False)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/github/scripts/github_intake_sync_app.py
+++ b/github/scripts/github_intake_sync_app.py
@@ -39,8 +39,8 @@ def main() -> int:
     print(f"app_id: {app.get('app_id', '(unset)')}")
     print(f"installation_id: {app.get('installation_id', '(unset)')}")
     print(f"slug: {app.get('slug', '(unset)')}")
-    print(f"webhook_secret_present: {app.get('webhook_secret_present', False)}")
-    print(f"private_key_pem_present: {app.get('private_key_pem_present', False)}")
+    print(f"webhook_secret_present: {app.get('webhook_secret_present') is True}")
+    print(f"private_key_pem_present: {app.get('private_key_pem_present') is True}")
     return 0
 
 

--- a/github/tests/test_file_identity_publisher.py
+++ b/github/tests/test_file_identity_publisher.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import io
+import json
+import os
+import pathlib
+import stat
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "examples"))
+
+import file_identity_publisher as publisher
+import file_identity_resolver as resolver
+
+
+class FileIdentityPublisherTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self._old_environ = os.environ.copy()
+        os.environ["GITHUB_INTAKE_IDENTITY_DIR"] = self.tempdir.name
+
+    def tearDown(self) -> None:
+        os.environ.clear()
+        os.environ.update(self._old_environ)
+
+    def test_writes_0600_file_with_schema_and_derived_ready(self) -> None:
+        path = publisher.publish(
+            "demo-city",
+            {"app_id": "123", "private_key_pem": "-----BEGIN-----\nline2\n-----END-----\n", "webhook_secret": "s3cr3t"},
+        )
+
+        self.assertTrue(path.exists())
+        self.assertEqual(stat.S_IMODE(path.stat().st_mode), 0o600)
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        self.assertEqual(payload["schema_version"], publisher.SCHEMA_VERSION)
+        self.assertEqual(payload["ready"], "true")
+        self.assertIn("line2", payload["private_key_pem"])
+
+    def test_partial_republish_merges_and_cannot_fake_ready(self) -> None:
+        publisher.publish("c", {"app_id": "1", "permissions": "metadata=read", "repos": "demo"})
+
+        path = publisher.publish("c", {"installation_id": "999", "ready": "true"})
+
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        self.assertEqual(payload["installation_id"], "999")
+        self.assertEqual(payload["permissions"], "metadata=read")
+        self.assertEqual(payload["repos"], "demo")
+        self.assertEqual(payload["ready"], "false")
+
+    def test_round_trips_through_the_shipped_resolver(self) -> None:
+        publisher.publish(
+            "round",
+            {"app_id": "42", "private_key_pem": "PEM", "webhook_secret": "w", "slug": "round-app"},
+        )
+
+        loaded = resolver.load_identity("round")
+
+        self.assertEqual(loaded["app_id"], "42")
+        self.assertEqual(loaded["slug"], "round-app")
+
+    def test_bad_identity_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            publisher.publish("../escape", {"app_id": "1"})
+
+    def test_main_takes_identity_argument_and_reports_derived_ready(self) -> None:
+        payload = json.dumps({"app_id": "5"})
+
+        with mock.patch.object(sys, "stdin", io.StringIO(payload)):
+            with mock.patch.object(sys, "stdout", io.StringIO()) as out:
+                code = publisher.main(["argv-identity"])
+
+        self.assertEqual(code, 0)
+        result = json.loads(out.getvalue())
+        self.assertTrue(result["published"])
+        self.assertFalse(result["ready"])
+        self.assertTrue(pathlib.Path(self.tempdir.name, "argv-identity.json").exists())
+
+    def test_main_without_identity_fails_with_usage_error(self) -> None:
+        os.environ.pop("GITHUB_INTAKE_APP_IDENTITY", None)
+
+        with mock.patch.object(sys, "stdin", io.StringIO("{}")):
+            with mock.patch.object(sys, "stderr", io.StringIO()):
+                code = publisher.main([])
+
+        self.assertEqual(code, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/github/tests/test_file_identity_resolver.py
+++ b/github/tests/test_file_identity_resolver.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "examples"))
+
+import file_identity_resolver as resolver
+
+
+class FileIdentityResolverTests(unittest.TestCase):
+    def test_load_identity_reads_schema_v1_json(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            identity_dir = pathlib.Path(tmpdir)
+            (identity_dir / "mayor.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": resolver.SCHEMA_VERSION,
+                        "app_id": "123",
+                        "installation_id": "456",
+                        "private_key_pem": "pem",
+                        "ready": True,
+                    }
+                ),
+                encoding="utf-8",
+            )
+            with mock.patch.dict(os.environ, {"GITHUB_INTAKE_IDENTITY_DIR": tmpdir}, clear=True):
+                payload = resolver.load_identity("mayor")
+
+        self.assertEqual(payload["app_id"], "123")
+        self.assertEqual(payload["schema_version"], resolver.SCHEMA_VERSION)
+
+    def test_load_identity_rejects_path_like_identity(self) -> None:
+        with self.assertRaisesRegex(ValueError, "identity must match"):
+            resolver.load_identity("../mayor")
+
+    def test_load_identity_rejects_missing_schema_version(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            (pathlib.Path(tmpdir) / "mayor.json").write_text(
+                json.dumps({"app_id": "123", "private_key_pem": "pem"}),
+                encoding="utf-8",
+            )
+            with mock.patch.dict(os.environ, {"GITHUB_INTAKE_IDENTITY_DIR": tmpdir}, clear=True):
+                with self.assertRaisesRegex(ValueError, "schema_version"):
+                    resolver.load_identity("mayor")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/github/tests/test_formula_worktree_paths.py
+++ b/github/tests/test_formula_worktree_paths.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import pathlib
+import unittest
+
+
+PACKS_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+class FormulaWorktreePathTests(unittest.TestCase):
+    def test_issue_fix_formulas_create_worktrees_under_gc_context(self) -> None:
+        formula_paths = [
+            (PACKS_ROOT / "github" / "formulas" / "mol-github-fix-issue.formula.toml", True),
+            (PACKS_ROOT / "discord" / "formulas" / "mol-discord-fix-issue.formula.toml", True),
+        ]
+
+        for formula_path, removes_worktree in formula_paths:
+            with self.subTest(formula=str(formula_path.relative_to(PACKS_ROOT))):
+                text = formula_path.read_text(encoding="utf-8")
+                self.assertIn('WORKTREE_ROOT="$(pwd)/.gc/worktrees"', text)
+                self.assertIn('mkdir -p "$WORKTREE_ROOT"', text)
+                self.assertIn('WORKTREE_PATH="$WORKTREE_ROOT/{{issue}}"', text)
+                if removes_worktree:
+                    self.assertIn('GIT_COMMON_DIR=$(git -C "$WORKTREE" rev-parse --git-common-dir)', text)
+                    self.assertIn('CLEANUP_CWD=$(dirname "$GIT_COMMON_DIR")', text)
+                    self.assertIn('git --git-dir="$GIT_COMMON_DIR" worktree remove "$WORKTREE" --force', text)
+                self.assertNotIn("$(pwd)/worktrees", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/github/tests/test_github_intake_addressed.py
+++ b/github/tests/test_github_intake_addressed.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import os
+import pathlib
+import tempfile
+import unittest
+from unittest import mock
+from datetime import datetime, timezone
+
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+
+import github_intake_addressed as addressed
+
+
+class GitHubIntakeAddressedTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self._old_environ = os.environ.copy()
+        os.environ["GC_CITY_ROOT"] = self.tempdir.name
+
+    def tearDown(self) -> None:
+        os.environ.clear()
+        os.environ.update(self._old_environ)
+
+    def test_sweep_comments_default_limit_scans_all(self) -> None:
+        parser = addressed.build_parser()
+
+        args = parser.parse_args(["sweep-comments"])
+
+        self.assertEqual(args.limit, 0)
+
+    def test_decode_json_stream_accepts_concatenated_paginated_json(self) -> None:
+        values = addressed.decode_json_stream('{"items":[{"number":1}]}\n{"items":[{"number":2}]}')
+
+        self.assertEqual(values[0]["items"][0]["number"], 1)
+        self.assertEqual(values[1]["items"][0]["number"], 2)
+
+    def test_gh_recent_items_uses_paginate_without_slurp(self) -> None:
+        completed = mock.Mock(
+            returncode=0,
+            stdout='{"items":[{"number":42,"html_url":"https://github.com/owner/repo/issues/42","updated_at":"2026-05-28T00:00:00Z","title":"Bug"}]}',
+            stderr="",
+        )
+
+        with mock.patch.object(addressed.subprocess, "run", return_value=completed) as run:
+            items = addressed.gh_recent_items("owner/repo", datetime(2026, 5, 21, tzinfo=timezone.utc), 10, {"GH_TOKEN": "token"})
+
+        command = run.call_args.args[0]
+        self.assertNotIn("--slurp", command)
+        self.assertEqual(command[:6], ["gh", "api", "--paginate", "-X", "GET", "search/issues"])
+        query = next(arg.removeprefix("q=") for arg in command if arg.startswith("q="))
+        self.assertIn("repo:owner/repo", query)
+        self.assertIn("updated:>=2026-05-21", query)
+        self.assertNotIn("is:open", query)
+        self.assertEqual(run.call_args.kwargs["timeout"], 30)
+        self.assertEqual(items[0]["number"], 42)
+
+    def test_load_json_pages_command_reports_timeout(self) -> None:
+        with mock.patch.object(
+            addressed.subprocess,
+            "run",
+            side_effect=addressed.subprocess.TimeoutExpired(["gh", "api", "endpoint"], 30),
+        ):
+            with self.assertRaisesRegex(addressed.AddressedError, "timed out after 30s"):
+                addressed.load_json_pages_command(["gh", "api", "endpoint"])
+
+    def test_gh_env_for_repo_sets_enterprise_host_token(self) -> None:
+        old_api_base = addressed.common.GITHUB_API_BASE
+        addressed.common.GITHUB_API_BASE = "https://github.enterprise.example/api/v3"
+        self.addCleanup(setattr, addressed.common, "GITHUB_API_BASE", old_api_base)
+
+        with mock.patch.object(addressed.common, "create_installation_token", return_value="token-123"):
+            env = addressed.gh_env_for_repo(
+                {"full_name": "owner/repo", "installation_id": "88"},
+                {"app_id": "1", "private_key_pem": "pem"},
+            )
+
+        self.assertEqual(env["GH_TOKEN"], "token-123")
+        self.assertEqual(env["GH_HOST"], "github.enterprise.example")
+        self.assertEqual(env["GH_ENTERPRISE_TOKEN"], "token-123")
+
+    def test_sweep_comments_skips_repos_without_installation_id(self) -> None:
+        rules = {
+            "repos": [
+                {
+                    "full_name": "owner/repo",
+                    "addresses": [{"address": "@mayor", "pool": "mayor", "formula": "github-addressed-message"}],
+                }
+            ]
+        }
+
+        with mock.patch.object(addressed.common, "load_rules", return_value=rules), mock.patch.object(
+            addressed.common,
+            "load_effective_config",
+            return_value={"app": {}},
+        ), mock.patch.object(addressed, "gh_env_for_repo") as gh_env_for_repo:
+            result = addressed.sweep_comments(limit=0, days=7)
+
+        self.assertEqual(result["status"], "ok")
+        self.assertEqual(result["processed_count"], 0)
+        self.assertEqual(result["failure_count"], 0)
+        self.assertEqual(result["skipped_count"], 1)
+        self.assertEqual(result["skipped"][0]["reason"], "installation_missing")
+        gh_env_for_repo.assert_not_called()
+
+    def test_order_script_runs_sweep_and_router(self) -> None:
+        pack_root = pathlib.Path(__file__).resolve().parents[1]
+        script = pack_root / "orders" / "scripts" / "github-addressed-message-router.sh"
+
+        contents = script.read_text(encoding="utf-8")
+
+        self.assertEqual(contents.count("github_intake_addressed.py"), 2)
+        self.assertIn("github_intake_addressed.py\" sweep-comments", contents)
+        self.assertIn("--limit \"$sweep_limit\" --days \"$sweep_days\"", contents)
+        self.assertIn("github_intake_addressed.py\" router-scan --fail-on-error", contents)
+
+    def test_addressed_formula_quotes_acknowledgement_heredoc(self) -> None:
+        pack_root = pathlib.Path(__file__).resolve().parents[1]
+        formula = pack_root / "formulas" / "github-addressed-message.formula.toml"
+
+        contents = formula.read_text(encoding="utf-8")
+
+        self.assertIn("cat >\"$BODY\" <<'EOF'", contents)
+        self.assertIn('export GC_CITY_ROOT="{{city_root}}"', contents)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/github/tests/test_github_intake_comment_issue.py
+++ b/github/tests/test_github_intake_comment_issue.py
@@ -1,0 +1,119 @@
+import pathlib
+import sys
+import unittest
+import io
+from unittest import mock
+
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+
+import github_intake_comment_issue as comment_issue
+
+
+class GitHubIntakeCommentIssueTests(unittest.TestCase):
+    def test_main_uses_profile_identity_when_provided(self) -> None:
+        with mock.patch.object(
+            sys,
+            "argv",
+            [
+                "github_intake_comment_issue.py",
+                "owner/repo",
+                "42",
+                "--installation-id",
+                "profile-installation",
+                "--github-app-identity",
+                "mayor",
+                "--body",
+                "ack",
+            ],
+        ), mock.patch.object(
+            comment_issue,
+            "load_profile_github_app",
+            return_value={"app_id": "mayor-app", "private_key_pem": "pem"},
+        ) as load_profile_github_app, mock.patch.object(
+            comment_issue.common,
+            "post_issue_comment",
+            return_value={"id": "100", "html_url": "https://github.com/owner/repo/issues/42#issuecomment-100"},
+        ) as post_issue_comment, mock.patch.object(sys, "stdout", io.StringIO()):
+            self.assertEqual(comment_issue.main(), 0)
+
+        load_profile_github_app.assert_called_once_with("mayor")
+        post_issue_comment.assert_called_once()
+        self.assertEqual(post_issue_comment.call_args.args[0]["app_id"], "mayor-app")
+        self.assertEqual(post_issue_comment.call_args.args[1:5], ("profile-installation", "owner", "repo", "42"))
+        self.assertEqual(post_issue_comment.call_args.args[5], "ack")
+
+    def test_main_uses_effective_config_by_default(self) -> None:
+        with mock.patch.object(
+            sys,
+            "argv",
+            [
+                "github_intake_comment_issue.py",
+                "owner/repo",
+                "42",
+                "--installation-id",
+                "repo-installation",
+                "--body",
+                "ack",
+            ],
+        ), mock.patch.object(
+            comment_issue.common,
+            "load_effective_config",
+            return_value={"app": {"app_id": "repo-app", "private_key_pem": "pem"}},
+        ) as load_effective_config, mock.patch.object(
+            comment_issue.common,
+            "post_issue_comment",
+            return_value={"id": "100"},
+        ) as post_issue_comment, mock.patch.object(sys, "stdout", io.StringIO()):
+            self.assertEqual(comment_issue.main(), 0)
+
+        load_effective_config.assert_called_once()
+        self.assertEqual(post_issue_comment.call_args.args[0]["app_id"], "repo-app")
+        self.assertEqual(post_issue_comment.call_args.args[1:5], ("repo-installation", "owner", "repo", "42"))
+
+    def test_main_uses_identity_installation_id_when_flag_omitted(self) -> None:
+        with mock.patch.object(
+            sys,
+            "argv",
+            [
+                "github_intake_comment_issue.py",
+                "owner/repo",
+                "42",
+                "--github-app-identity",
+                "mayor",
+                "--body",
+                "ack",
+            ],
+        ), mock.patch.object(
+            comment_issue,
+            "load_profile_github_app",
+            return_value={"app_id": "mayor-app", "private_key_pem": "pem", "installation_id": "profile-installation"},
+        ), mock.patch.object(
+            comment_issue.common,
+            "post_issue_comment",
+            return_value={"id": "100"},
+        ) as post_issue_comment, mock.patch.object(sys, "stdout", io.StringIO()):
+            self.assertEqual(comment_issue.main(), 0)
+
+        self.assertEqual(post_issue_comment.call_args.args[1], "profile-installation")
+
+    def test_main_rejects_invalid_identity(self) -> None:
+        with mock.patch.object(
+            sys,
+            "argv",
+            [
+                "github_intake_comment_issue.py",
+                "owner/repo",
+                "42",
+                "--github-app-identity",
+                "secret/store/path",
+                "--body",
+                "ack",
+            ],
+        ):
+            with self.assertRaisesRegex(SystemExit, "github_app_identity"):
+                comment_issue.main()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/github/tests/test_github_intake_common.py
+++ b/github/tests/test_github_intake_common.py
@@ -60,8 +60,358 @@ class GitHubIntakeCommonTests(unittest.TestCase):
             "https://admin.example.com/v0/github/app/manifest/callback",
         )
         self.assertIn("issue_comment", manifest["default_events"])
+        self.assertIn("issues", manifest["default_events"])
+        self.assertIn("pull_request", manifest["default_events"])
         self.assertEqual(manifest["default_permissions"]["contents"], "write")
         self.assertEqual(manifest["default_permissions"]["pull_requests"], "write")
+
+    def test_effective_config_merges_github_app_env_secrets(self) -> None:
+        os.environ["GITHUB_APP_ID"] = "123"
+        os.environ["GITHUB_WEBHOOK_SECRET"] = "env-secret"
+        os.environ["GITHUB_APP_PRIVATE_KEY_PEM"] = "pem"
+        config = {"schema_version": 1, "app": {"webhook_secret": "state-secret"}, "repositories": {}}
+
+        effective = common.effective_config(config)
+
+        self.assertEqual(effective["app"]["app_id"], "123")
+        self.assertEqual(effective["app"]["webhook_secret"], "env-secret")
+        self.assertEqual(effective["app"]["private_key_pem"], "pem")
+
+    def test_import_app_config_persists_installation_id(self) -> None:
+        config = common.import_app_config(
+            common.load_config(),
+            {
+                "app_id": "123",
+                "installation_id": "456",
+                "webhook_secret": "secret",
+                "private_key_pem": "pem",
+            },
+        )
+
+        self.assertEqual(config["app"]["app_id"], "123")
+        self.assertEqual(config["app"]["installation_id"], "456")
+
+    def test_load_rules_reads_city_owned_toml_and_flattens_match(self) -> None:
+        rules_dir = pathlib.Path(self.tempdir.name) / "config" / "github-intake"
+        rules_dir.mkdir(parents=True)
+        (rules_dir / "rules.toml").write_text(
+            """
+version = 1
+
+[[rule]]
+id = "pr-review-on-needs-review-label"
+event = "pull_request"
+
+[rule.match]
+action = "labeled"
+label.name = "status/needs-review"
+pull_request.state = "open"
+
+[[rule.action]]
+type = "order"
+name = "pr-review-request"
+github_app_token_env = "GH_TOKEN"
+""",
+            encoding="utf-8",
+        )
+
+        rules = common.load_rules()
+
+        self.assertEqual(rules["path"], str(rules_dir / "rules.toml"))
+        self.assertEqual(len(rules["rules"]), 1)
+        rule = rules["rules"][0]
+        self.assertEqual(rule["id"], "pr-review-on-needs-review-label")
+        self.assertEqual(rule["match"]["label.name"], "status/needs-review")
+        self.assertEqual(rule["match"]["pull_request.state"], "open")
+        self.assertFalse(rule["allow_self"])
+        self.assertEqual(rule["action"][0]["type"], "order")
+
+    def test_load_rules_reads_repo_scoped_address_config(self) -> None:
+        rules_dir = pathlib.Path(self.tempdir.name) / "config" / "github-intake"
+        rules_dir.mkdir(parents=True)
+        (rules_dir / "rules.toml").write_text(
+            """
+version = 1
+
+[[repo]]
+full_name = "Owner/Repo"
+authorized_users = ["Alice", "bob"]
+installation_id = "88"
+
+[[repo.address]]
+address = "@mayor"
+pool = "mayor"
+formula = "github-addressed-message"
+profile = "mayor"
+github_app_identity = "mayor"
+installation_id = "99"
+ack = true
+""",
+            encoding="utf-8",
+        )
+
+        rules = common.load_rules()
+
+        self.assertEqual(len(rules["repos"]), 1)
+        repo = rules["repos"][0]
+        self.assertEqual(repo["full_name"], "owner/repo")
+        self.assertEqual(repo["rig"], "github-owner-repo")
+        self.assertEqual(repo["authorized_users"], ["alice", "bob"])
+        self.assertEqual(repo["installation_id"], "88")
+        self.assertEqual(repo["addresses"][0]["address"], "@mayor")
+        self.assertEqual(repo["addresses"][0]["pool"], "mayor")
+        self.assertEqual(repo["addresses"][0]["target"], "github-owner-repo/mayor")
+        self.assertEqual(repo["addresses"][0]["formula"], "github-addressed-message")
+        self.assertEqual(repo["addresses"][0]["profile"], "mayor")
+        self.assertEqual(repo["addresses"][0]["github_app_identity"], "mayor")
+        self.assertEqual(repo["addresses"][0]["installation_id"], "99")
+        self.assertTrue(repo["addresses"][0]["ack"])
+
+    def test_load_rules_maps_github_repo_to_configured_local_rig(self) -> None:
+        rules_dir = pathlib.Path(self.tempdir.name) / "config" / "github-intake"
+        rules_dir.mkdir(parents=True)
+        (rules_dir / "rules.toml").write_text(
+            """
+version = 1
+
+[[repo]]
+full_name = "Owner/Repo"
+rig = "product"
+authorized_users = ["Alice"]
+
+[[repo.address]]
+address = "@mayor"
+pool = "mayor"
+formula = "github-addressed-message"
+""",
+            encoding="utf-8",
+        )
+
+        rules = common.load_rules()
+
+        repo = rules["repos"][0]
+        self.assertEqual(repo["full_name"], "owner/repo")
+        self.assertEqual(repo["github_rig"], "github-owner-repo")
+        self.assertEqual(repo["rig"], "product")
+        self.assertEqual(repo["addresses"][0]["target"], "product/mayor")
+        self.assertEqual(common.github_repo_dispatch_rig("Owner/Repo", rules), "product")
+
+    def test_load_rules_rejects_path_like_github_app_identity(self) -> None:
+        rules_dir = pathlib.Path(self.tempdir.name) / "config" / "github-intake"
+        rules_dir.mkdir(parents=True)
+        (rules_dir / "rules.toml").write_text(
+            """
+version = 1
+
+[[repo]]
+full_name = "owner/repo"
+
+[[repo.address]]
+address = "@mayor"
+pool = "mayor"
+formula = "github-addressed-message"
+github_app_identity = "secret/store/path"
+""",
+            encoding="utf-8",
+        )
+
+        with self.assertRaisesRegex(ValueError, "github_app_identity"):
+            common.load_rules()
+
+    def test_github_repo_rig_name_derives_stable_rig_from_org_repo(self) -> None:
+        self.assertEqual(common.github_repo_rig_name("Owner/Repo.Name"), "github-owner-repo-name")
+        self.assertEqual(common.github_repo_rig_name(" example-org/Gas_City "), "github-example-org-gas_city")
+
+    def test_github_repo_dispatch_rig_falls_back_to_slug_when_unconfigured(self) -> None:
+        self.assertEqual(common.github_repo_dispatch_rig("Owner/Repo", {"repos": []}), "github-owner-repo")
+
+    def test_load_rules_rejects_rig_scoped_address_pool(self) -> None:
+        rules_dir = pathlib.Path(self.tempdir.name) / "config" / "github-intake"
+        rules_dir.mkdir(parents=True)
+        (rules_dir / "rules.toml").write_text(
+            """
+version = 1
+
+[[repo]]
+full_name = "owner/repo"
+authorized_users = ["alice"]
+
+[[repo.address]]
+address = "@mayor"
+pool = "other-rig/mayor"
+formula = "github-addressed-message"
+""",
+            encoding="utf-8",
+        )
+
+        with self.assertRaisesRegex(ValueError, "pool must not include a rig"):
+            common.load_rules()
+
+    def test_load_rules_rejects_invalid_repo_rig_mapping(self) -> None:
+        rules_dir = pathlib.Path(self.tempdir.name) / "config" / "github-intake"
+        rules_dir.mkdir(parents=True)
+        (rules_dir / "rules.toml").write_text(
+            """
+version = 1
+
+[[repo]]
+full_name = "owner/repo"
+rig = "other-rig/mayor"
+authorized_users = ["alice"]
+
+[[repo.address]]
+address = "@mayor"
+pool = "mayor"
+formula = "github-addressed-message"
+""",
+            encoding="utf-8",
+        )
+
+        with self.assertRaisesRegex(ValueError, "rig must be a local rig name"):
+            common.load_rules()
+
+    def test_extract_addressed_comment_requests_repo_scoped_matches(self) -> None:
+        rules = {
+            "repos": [
+                {
+                    "full_name": "owner/repo",
+                    "rig": "product",
+                    "authorized_users": ["alice"],
+                    "addresses": [
+                        {
+                            "address": "@mayor",
+                            "pool": "mayor",
+                            "target": "product/mayor",
+                            "formula": "github-addressed-message",
+                            "ack": True,
+                        },
+                        {
+                            "address": "@deacon",
+                            "pool": "deacon",
+                            "target": "product/deacon",
+                            "formula": "github-addressed-message",
+                            "ack": True,
+                        },
+                    ],
+                }
+            ]
+        }
+        payload = {
+            "action": "created",
+            "installation": {"id": 77},
+            "issue": {
+                "id": 4242,
+                "number": 42,
+                "title": "Crash on startup",
+                "body": "The app crashes.",
+                "html_url": "https://github.com/owner/repo/issues/42",
+                "user": {"login": "reporter"},
+                "pull_request": {"url": "https://api.github.com/repos/owner/repo/pulls/42"},
+            },
+            "comment": {
+                "id": 99,
+                "body": "@mayor @deacon please triage this",
+                "html_url": "https://github.com/owner/repo/issues/42#issuecomment-99",
+                "user": {"login": "Alice", "type": "User"},
+                "created_at": "2026-05-28T12:00:00Z",
+                "updated_at": "2026-05-28T12:00:00Z",
+            },
+            "repository": {
+                "id": 123,
+                "name": "repo",
+                "full_name": "Owner/Repo",
+                "default_branch": "main",
+                "owner": {"login": "Owner"},
+            },
+        }
+
+        result = common.extract_addressed_comment_requests(payload, rules)
+
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertTrue(result["authorized"])
+        self.assertEqual(result["cleaned_body"], "please triage this")
+        self.assertEqual([request["address"] for request in result["requests"]], ["@mayor", "@deacon"])
+        self.assertEqual(result["requests"][0]["source_key"], "github-comment:123:99:@mayor")
+        self.assertEqual(result["requests"][0]["item_kind"], "pr")
+        self.assertEqual(result["requests"][0]["rig"], "product")
+        self.assertEqual(result["requests"][0]["pool"], "mayor")
+        self.assertEqual(result["requests"][0]["target"], "product/mayor")
+        self.assertEqual(result["requests"][0]["profile"], "mayor")
+
+    def test_extract_addressed_comment_requests_ignores_edits_and_unconfigured_mentions(self) -> None:
+        rules = {
+            "repos": [
+                {
+                    "full_name": "owner/repo",
+                    "authorized_users": ["alice"],
+                    "addresses": [{"address": "@mayor", "pool": "mayor", "formula": "github-addressed-message"}],
+                }
+            ]
+        }
+        payload = {
+            "action": "edited",
+            "issue": {"number": 42, "html_url": "https://github.com/owner/repo/issues/42"},
+            "comment": {"id": 99, "body": "@mayor edited request", "user": {"login": "alice"}},
+            "repository": {"id": 123, "full_name": "owner/repo"},
+        }
+
+        self.assertIsNone(common.extract_addressed_comment_requests(payload, rules))
+        payload["action"] = "created"
+        payload["comment"]["body"] = "@unknown do work"
+        self.assertIsNone(common.extract_addressed_comment_requests(payload, rules))
+
+    def test_rule_can_allow_self_events(self) -> None:
+        rules_dir = pathlib.Path(self.tempdir.name) / "config" / "github-intake"
+        rules_dir.mkdir(parents=True)
+        (rules_dir / "rules.toml").write_text(
+            """
+version = 1
+
+[[rule]]
+id = "triage-on-needs-triage-label"
+event = "pull_request"
+allow_self = true
+
+[rule.match]
+action = "labeled"
+label.name = "status/needs-triage"
+
+[[rule.action]]
+type = "order"
+name = "triage-patrol"
+""",
+            encoding="utf-8",
+        )
+
+        rules = common.load_rules()
+
+        self.assertTrue(rules["rules"][0]["allow_self"])
+
+    def test_matching_rules_uses_exact_dotted_payload_values(self) -> None:
+        rules = {
+            "rules": [
+                {
+                    "id": "pr-review",
+                    "event": "pull_request",
+                    "match": {
+                        "action": "labeled",
+                        "label.name": "status/needs-review",
+                        "pull_request.state": "open",
+                    },
+                    "action": [{"type": "order", "name": "pr-review-request"}],
+                }
+            ]
+        }
+        payload = {
+            "action": "labeled",
+            "label": {"name": "status/needs-review"},
+            "pull_request": {"state": "open"},
+        }
+
+        self.assertEqual([rule["id"] for rule in common.matching_rules("pull_request", payload, rules)], ["pr-review"])
+        payload["label"]["name"] = "status/reviewing"
+        self.assertEqual(common.matching_rules("pull_request", payload, rules), [])
 
     def test_parse_gc_command_extracts_multiline_context(self) -> None:
         parsed = common.parse_gc_command("please take a look\n/gc fix crash on startup\nstack trace line 1\nstack trace line 2")
@@ -209,6 +559,99 @@ class GitHubIntakeCommonTests(unittest.TestCase):
         self.assertEqual(common.app_identifier({"app_id": "123456"}), "123456")
         with self.assertRaises(common.GitHubAPIError):
             common.app_identifier({"client_id": "Iv1.only-client-id"})
+
+
+class GitHubIntakePublishIdentityTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self._old_environ = os.environ.copy()
+        os.environ["GC_CITY_ROOT"] = self.tempdir.name
+        os.environ.pop("GITHUB_INTAKE_IDENTITY_PUBLISHER", None)
+        os.environ.pop("GITHUB_INTAKE_APP_IDENTITY", None)
+
+    def tearDown(self) -> None:
+        os.environ.clear()
+        os.environ.update(self._old_environ)
+
+    def _capture_publisher(self) -> tuple[str, pathlib.Path]:
+        capture = pathlib.Path(self.tempdir.name) / "captured.json"
+        script = pathlib.Path(self.tempdir.name) / "capture_publisher.py"
+        script.write_text(
+            "import json, os, pathlib, sys\n"
+            "out = pathlib.Path(os.environ['PUBLISH_CAPTURE_PATH'])\n"
+            "out.write_text(json.dumps({'argv': sys.argv[1:], 'stdin': json.load(sys.stdin)}))\n"
+            "print('stored')\n",
+            encoding="utf-8",
+        )
+        os.environ["PUBLISH_CAPTURE_PATH"] = str(capture)
+        import sys as _sys
+
+        return f"{_sys.executable} {script}", capture
+
+    def test_publish_identity_skips_when_no_publisher_configured(self) -> None:
+        result = common.publish_identity({"app_id": "7"}, identity="mayor")
+
+        self.assertEqual(result["status"], "skipped")
+        self.assertIn("no publisher configured", result["reason"])
+
+    def test_publish_identity_skips_when_identity_is_not_configured(self) -> None:
+        result = common.publish_identity({"app_id": "7"}, publisher="true")
+
+        self.assertEqual(result["status"], "skipped")
+        self.assertIn("GITHUB_INTAKE_APP_IDENTITY", result["reason"])
+
+    def test_publish_identity_invokes_publisher_with_identity_arg_and_json_stdin(self) -> None:
+        publisher, capture = self._capture_publisher()
+
+        result = common.publish_identity(
+            {"app_id": "7", "private_key_pem": "PEM\nLINE2", "webhook_secret": "s", "empty": ""},
+            identity="mayor",
+            publisher=publisher,
+        )
+
+        self.assertEqual(result["status"], "published")
+        recorded = json.loads(capture.read_text(encoding="utf-8"))
+        self.assertEqual(recorded["argv"], ["mayor"])
+        self.assertEqual(recorded["stdin"]["app_id"], "7")
+        self.assertEqual(recorded["stdin"]["private_key_pem"], "PEM\nLINE2")
+        self.assertEqual(
+            recorded["stdin"]["schema_version"], common.GITHUB_APP_IDENTITY_SCHEMA_VERSION
+        )
+        self.assertNotIn("empty", recorded["stdin"])
+
+    def test_publish_identity_reads_identity_and_publisher_from_environment(self) -> None:
+        publisher, capture = self._capture_publisher()
+        os.environ["GITHUB_INTAKE_IDENTITY_PUBLISHER"] = publisher
+        os.environ["GITHUB_INTAKE_APP_IDENTITY"] = "mayor"
+
+        result = common.publish_identity({"app_id": "9"})
+
+        self.assertEqual(result["status"], "published")
+        recorded = json.loads(capture.read_text(encoding="utf-8"))
+        self.assertEqual(recorded["argv"], ["mayor"])
+
+    def test_publish_identity_reports_publisher_failure_without_raising(self) -> None:
+        script = pathlib.Path(self.tempdir.name) / "failing_publisher.py"
+        script.write_text(
+            "import sys\nprint('store unavailable', file=sys.stderr)\nsys.exit(3)\n",
+            encoding="utf-8",
+        )
+        import sys as _sys
+
+        result = common.publish_identity(
+            {"app_id": "7"}, identity="mayor", publisher=f"{_sys.executable} {script}"
+        )
+
+        self.assertEqual(result["status"], "error")
+        self.assertIn("store unavailable", result["detail"])
+
+    def test_publish_identity_rejects_invalid_identity_without_raising(self) -> None:
+        result = common.publish_identity({"app_id": "7"}, identity="../escape", publisher="true")
+
+        self.assertEqual(result["status"], "error")
+        self.assertIn("must match", result["detail"])
+
 
 
 if __name__ == "__main__":

--- a/github/tests/test_github_intake_service.py
+++ b/github/tests/test_github_intake_service.py
@@ -1,16 +1,39 @@
 from __future__ import annotations
 
+import io
+import json
+import urllib.parse
 import pathlib
 import tempfile
 import unittest
 
 import os
 import sys
+import subprocess
 from unittest import mock
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
 
 import github_intake_service as service
+
+
+class DummyWebhookHandler:
+    def __init__(self, body: bytes, headers: dict[str, str]) -> None:
+        self.headers = headers
+        self.rfile = io.BytesIO(body)
+        self.wfile = io.BytesIO()
+        self.status: int | None = None
+        self.response_headers: list[tuple[str, str]] = []
+        self._headers_buffer: list[bytes] = []
+
+    def send_response(self, status: int) -> None:
+        self.status = status
+
+    def send_header(self, key: str, value: str) -> None:
+        self.response_headers.append((key, value))
+
+    def end_headers(self) -> None:
+        pass
 
 
 class GitHubIntakeServiceTests(unittest.TestCase):
@@ -41,6 +64,1117 @@ class GitHubIntakeServiceTests(unittest.TestCase):
         self.assertEqual(service.extract_json_output('{"id":"bd-1"}')["id"], "bd-1")
         self.assertEqual(service.extract_json_output('[{"id":"bd-2"}]')["id"], "bd-2")
         self.assertEqual(service.extract_json_output("not json"), {})
+
+    def test_github_event_env_includes_pr_context_and_payload_file(self) -> None:
+        payload = {
+            "action": "labeled",
+            "installation": {"id": 88},
+            "label": {"name": "status/needs-review"},
+            "repository": {
+                "id": 123,
+                "name": "repo",
+                "full_name": "Owner/Repo",
+                "owner": {"login": "Owner"},
+            },
+            "pull_request": {
+                "number": 42,
+                "html_url": "https://github.com/owner/repo/pull/42",
+                "state": "open",
+            },
+            "sender": {"login": "alice"},
+        }
+
+        env = service.github_event_env("pull_request", "delivery-1", payload, "/tmp/payload.json")
+
+        self.assertEqual(env["GC_GITHUB_EVENT"], "pull_request")
+        self.assertEqual(env["GC_GITHUB_REPO"], "owner/repo")
+        self.assertEqual(env["GC_GITHUB_PR_NUMBER"], "42")
+        self.assertEqual(env["GC_GITHUB_PR_URL"], "https://github.com/owner/repo/pull/42")
+        self.assertEqual(env["GC_GITHUB_LABEL_NAME"], "status/needs-review")
+        self.assertEqual(env["GC_GITHUB_ITEM_KIND"], "pr")
+        self.assertEqual(env["GC_GITHUB_ITEM_NUMBER"], "42")
+        self.assertEqual(env["GC_GITHUB_EVENT_PAYLOAD_FILE"], "/tmp/payload.json")
+
+    def test_github_event_env_includes_issue_context(self) -> None:
+        payload = {
+            "action": "labeled",
+            "installation": {"id": 88},
+            "label": {"name": "status/needs-triage"},
+            "repository": {
+                "id": 123,
+                "name": "repo",
+                "full_name": "Owner/Repo",
+                "owner": {"login": "Owner"},
+            },
+            "issue": {
+                "number": 43,
+                "html_url": "https://github.com/owner/repo/issues/43",
+                "state": "open",
+            },
+            "sender": {"login": "alice"},
+        }
+
+        env = service.github_event_env("issues", "delivery-1", payload, "/tmp/payload.json")
+
+        self.assertEqual(env["GC_GITHUB_EVENT"], "issues")
+        self.assertEqual(env["GC_GITHUB_ISSUE_NUMBER"], "43")
+        self.assertEqual(env["GC_GITHUB_ISSUE_URL"], "https://github.com/owner/repo/issues/43")
+        self.assertEqual(env["GC_GITHUB_ITEM_KIND"], "issue")
+        self.assertEqual(env["GC_GITHUB_ITEM_NUMBER"], "43")
+
+    def test_order_action_runs_gc_order_with_event_env_and_installation_token(self) -> None:
+        payload = {
+            "action": "labeled",
+            "installation": {"id": 88},
+            "label": {"name": "status/needs-review"},
+            "repository": {
+                "id": 123,
+                "name": "repo",
+                "full_name": "Owner/Repo",
+                "owner": {"login": "Owner"},
+            },
+            "pull_request": {
+                "number": 42,
+                "html_url": "https://github.com/owner/repo/pull/42",
+                "state": "open",
+            },
+        }
+        action = {"type": "order", "name": "pr-review-request", "github_app_token_env": "GH_TOKEN"}
+        completed = mock.Mock(returncode=0, stdout="ok\n", stderr="")
+
+        with mock.patch.object(service.common, "create_installation_token", return_value="token-123"), mock.patch.object(
+            service,
+            "run_subprocess",
+            return_value=completed,
+        ) as run_subprocess:
+            outcome = service.execute_rule_action(
+                {"id": "rule"},
+                action,
+                "pull_request",
+                "delivery-1",
+                payload,
+                "/tmp/payload.json",
+                {"app_id": "1", "private_key_pem": "pem"},
+            )
+
+        self.assertEqual(outcome["status"], "success")
+        command, cwd = run_subprocess.call_args.args[:2]
+        env = run_subprocess.call_args.kwargs["env"]
+        self.assertEqual(command, ["gc", "order", "run", "pr-review-request"])
+        self.assertEqual(cwd, self.tempdir.name)
+        self.assertEqual(env["GC_GITHUB_PR_URL"], "https://github.com/owner/repo/pull/42")
+        self.assertEqual(env["GH_TOKEN"], "token-123")
+        self.assertTrue(outcome["github_app_token_injected"])
+
+    def test_process_event_rules_executes_matching_order_rule_and_persists_result(self) -> None:
+        rules_dir = pathlib.Path(self.tempdir.name) / "config" / "github-intake"
+        rules_dir.mkdir(parents=True)
+        (rules_dir / "rules.toml").write_text(
+            """
+version = 1
+
+[[rule]]
+id = "pr-review-on-needs-review-label"
+event = "pull_request"
+
+[rule.match]
+action = "labeled"
+label.name = "status/needs-review"
+pull_request.state = "open"
+
+[[rule.action]]
+type = "order"
+name = "pr-review-request"
+""",
+            encoding="utf-8",
+        )
+        payload = {
+            "action": "labeled",
+            "label": {"name": "status/needs-review"},
+            "repository": {"full_name": "owner/repo"},
+            "pull_request": {"number": 42, "state": "open"},
+        }
+        completed = mock.Mock(returncode=0, stdout="", stderr="")
+
+        with mock.patch.object(service, "run_subprocess", return_value=completed):
+            summaries = service.process_event_rules("pull_request", "delivery-1", payload, {})
+
+        self.assertEqual(summaries[0]["rule_id"], "pr-review-on-needs-review-label")
+        self.assertEqual(summaries[0]["status"], "success")
+        results = service.common.list_recent_rule_results()
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["rule_id"], "pr-review-on-needs-review-label")
+
+    def test_process_event_rules_allows_self_bot_only_for_opted_in_rules(self) -> None:
+        rules_dir = pathlib.Path(self.tempdir.name) / "config" / "github-intake"
+        rules_dir.mkdir(parents=True)
+        (rules_dir / "rules.toml").write_text(
+            """
+version = 1
+
+[[rule]]
+id = "self-allowed-needs-triage"
+event = "pull_request"
+allow_self = true
+
+[rule.match]
+action = "labeled"
+label.name = "status/needs-triage"
+
+[[rule.action]]
+type = "order"
+name = "triage-patrol"
+
+[[rule]]
+id = "self-blocked-needs-review"
+event = "pull_request"
+
+[rule.match]
+action = "labeled"
+label.name = "status/needs-triage"
+
+[[rule.action]]
+type = "order"
+name = "pr-review-request"
+""",
+            encoding="utf-8",
+        )
+        payload = {
+            "action": "labeled",
+            "label": {"name": "status/needs-triage"},
+            "repository": {"full_name": "owner/repo"},
+            "pull_request": {"number": 42, "state": "open"},
+            "sender": {"login": "mayor[bot]"},
+        }
+        completed = mock.Mock(returncode=0, stdout="", stderr="")
+
+        with mock.patch.object(service, "run_subprocess", return_value=completed) as run_subprocess:
+            summaries = service.process_event_rules("pull_request", "delivery-1", payload, {"slug": "mayor"})
+
+        self.assertEqual([summary["rule_id"] for summary in summaries], ["self-allowed-needs-triage"])
+        self.assertEqual(run_subprocess.call_args.args[0], ["gc", "order", "run", "triage-patrol"])
+
+    def test_process_addressed_comment_creates_source_and_defers_ack_to_handler(self) -> None:
+        rules = {
+            "repos": [
+                {
+                    "full_name": "owner/repo",
+                    "rig": "product",
+                    "authorized_users": ["alice"],
+                    "addresses": [
+                        {
+                            "address": "@mayor",
+                            "pool": "mayor",
+                            "target": "product/mayor",
+                            "formula": "github-addressed-message",
+                        }
+                    ],
+                }
+            ]
+        }
+        payload = {
+            "action": "created",
+            "installation": {"id": 88},
+            "issue": {"number": 42, "html_url": "https://github.com/owner/repo/issues/42"},
+            "comment": {
+                "id": 99,
+                "body": "@mayor please triage this",
+                "html_url": "https://github.com/owner/repo/issues/42#issuecomment-99",
+                "user": {"login": "alice", "type": "User"},
+            },
+            "repository": {
+                "id": 123,
+                "name": "repo",
+                "full_name": "owner/repo",
+                "owner": {"login": "owner"},
+            },
+        }
+
+        with mock.patch.object(service.common, "load_rules", return_value=rules), mock.patch.object(
+            service,
+            "create_addressed_source",
+            return_value={"status": "created", "bead_id": "ga-addr1", "source_key": "github-comment:123:99:@mayor"},
+        ) as create_addressed_source, mock.patch.object(
+            service.common,
+            "post_issue_comment",
+            return_value={"id": "ack-1", "html_url": "https://github.com/owner/repo/issues/42#issuecomment-100"},
+        ) as post_issue_comment, mock.patch.object(
+            service,
+            "enqueue_addressed_router",
+            return_value="queued",
+        ) as enqueue_addressed_router:
+            outcome = service.process_addressed_comment(
+                "issue_comment",
+                "delivery-1",
+                payload,
+                {"app_id": "1", "private_key_pem": "pem"},
+            )
+
+        self.assertEqual(outcome["status"], "accepted")
+        self.assertEqual(outcome["created_count"], 1)
+        self.assertEqual(outcome["router_kick"], "queued")
+        request = create_addressed_source.call_args.args[0]
+        self.assertEqual(request["cleaned_body"], "please triage this")
+        self.assertEqual(request["source_key"], "github-comment:123:99:@mayor")
+        self.assertEqual(request["target"], "product/mayor")
+        enqueue_addressed_router.assert_called_once_with("delivery-1", ["github-comment:123:99:@mayor"])
+        post_issue_comment.assert_not_called()
+        self.assertNotIn("reply_comment_id", outcome)
+
+    def test_process_addressed_comment_carries_profile_app_for_handler_ack(self) -> None:
+        rules = {
+            "repos": [
+                {
+                    "full_name": "owner/repo",
+                    "rig": "product",
+                    "authorized_users": ["alice"],
+                    "addresses": [
+                        {
+                            "address": "@mayor",
+                            "pool": "mayor",
+                            "target": "product/mayor",
+                            "formula": "github-addressed-message",
+                            "profile": "mayor",
+                            "github_app_identity": "mayor",
+                            "installation_id": "profile-installation",
+                        }
+                    ],
+                }
+            ]
+        }
+        payload = {
+            "action": "created",
+            "installation": {"id": 88},
+            "issue": {"number": 42, "html_url": "https://github.com/owner/repo/issues/42"},
+            "comment": {
+                "id": 99,
+                "body": "@mayor please triage this",
+                "html_url": "https://github.com/owner/repo/issues/42#issuecomment-99",
+                "user": {"login": "alice", "type": "User"},
+            },
+            "repository": {
+                "id": 123,
+                "name": "repo",
+                "full_name": "owner/repo",
+                "owner": {"login": "owner"},
+            },
+        }
+
+        with mock.patch.object(service.common, "load_rules", return_value=rules), mock.patch.object(
+            service,
+            "create_addressed_source",
+            return_value={"status": "created", "bead_id": "ga-addr1", "source_key": "github-comment:123:99:@mayor"},
+        ) as create_addressed_source, mock.patch.object(
+            service,
+            "load_profile_github_app",
+            return_value={"app_id": "mayor-app", "private_key_pem": "mayor-pem"},
+        ) as load_profile_github_app, mock.patch.object(
+            service.common,
+            "post_issue_comment",
+            return_value={"id": "ack-1", "html_url": "https://github.com/owner/repo/issues/42#issuecomment-100"},
+        ) as post_issue_comment, mock.patch.object(
+            service,
+            "enqueue_addressed_router",
+            return_value="queued",
+        ):
+            outcome = service.process_addressed_comment(
+                "issue_comment",
+                "delivery-1",
+                payload,
+                {"app_id": "mayor-app", "private_key_pem": "mayor-pem"},
+            )
+
+        self.assertEqual(outcome["status"], "accepted")
+        request = create_addressed_source.call_args.args[0]
+        self.assertEqual(request["profile"], "mayor")
+        self.assertEqual(request["profile_github_app_identity"], "mayor")
+        self.assertEqual(request["profile_installation_id"], "profile-installation")
+        load_profile_github_app.assert_not_called()
+        post_issue_comment.assert_not_called()
+
+    def test_load_profile_github_app_uses_identity_resolver(self) -> None:
+        service.PROFILE_APP_CACHE.clear()
+        result = subprocess.CompletedProcess(
+            ["resolve", "mayor"],
+            0,
+            stdout=json.dumps(
+                {
+                    "schema_version": service.common.GITHUB_APP_IDENTITY_SCHEMA_VERSION,
+                    "app_id": "mayor-app",
+                    "installation_id": "profile-installation",
+                    "private_key_pem": "pem",
+                    "ready": "true",
+                }
+            ),
+            stderr="",
+        )
+
+        with mock.patch.dict(
+            service.os.environ,
+            {"GITHUB_INTAKE_IDENTITY_RESOLVER": "resolve --json"},
+            clear=True,
+        ), mock.patch.object(service, "run_subprocess", return_value=result) as run_subprocess:
+            app = service.load_profile_github_app("mayor")
+
+        self.assertEqual(app["app_id"], "mayor-app")
+        self.assertEqual(app["installation_id"], "profile-installation")
+        self.assertEqual(app["private_key_pem"], "pem")
+        run_subprocess.assert_called_once()
+        self.assertEqual(run_subprocess.call_args.args[0], ["resolve", "--json", "mayor"])
+
+    def test_load_profile_github_app_uses_city_workspace_env_resolver(self) -> None:
+        service.PROFILE_APP_CACHE.clear()
+        pathlib.Path(self.tempdir.name, "city.toml").write_text(
+            """
+[workspace]
+[workspace.env]
+GITHUB_INTAKE_IDENTITY_RESOLVER = "resolve --json"
+GITHUB_INTAKE_APP_IDENTITY = "mayor"
+GITHUB_INTAKE_STORE_NAMESPACE = "internal"
+GITHUB_INTAKE_STORE_SECRET_PREFIX = "agents"
+GITHUB_INTAKE_STORE_SESSION_ENV = "/tmp/session.env"
+UNRELATED_KEY = "must-not-pass-through"
+""".strip(),
+            encoding="utf-8",
+        )
+        result = subprocess.CompletedProcess(
+            ["resolve", "mayor"],
+            0,
+            stdout=json.dumps(
+                {
+                    "schema_version": service.common.GITHUB_APP_IDENTITY_SCHEMA_VERSION,
+                    "app_id": "mayor-app",
+                    "installation_id": "profile-installation",
+                    "private_key_pem": "pem",
+                    "ready": "true",
+                }
+            ),
+            stderr="",
+        )
+
+        with mock.patch.dict(
+            service.os.environ,
+            {"GC_CITY_ROOT": self.tempdir.name},
+            clear=True,
+        ), mock.patch.object(service, "run_subprocess", return_value=result) as run_subprocess:
+            app = service.load_profile_github_app("mayor")
+
+        self.assertEqual(app["app_id"], "mayor-app")
+        self.assertEqual(run_subprocess.call_args.args[0], ["resolve", "--json", "mayor"])
+        env = run_subprocess.call_args.kwargs["env"]
+        self.assertEqual(env["GITHUB_INTAKE_IDENTITY_RESOLVER"], "resolve --json")
+        self.assertEqual(env["GITHUB_INTAKE_APP_IDENTITY"], "mayor")
+        self.assertEqual(env["GITHUB_INTAKE_STORE_NAMESPACE"], "internal")
+        self.assertEqual(env["GITHUB_INTAKE_STORE_SECRET_PREFIX"], "agents")
+        self.assertEqual(env["GITHUB_INTAKE_STORE_SESSION_ENV"], "/tmp/session.env")
+        self.assertNotIn("UNRELATED_KEY", env)
+
+    def test_configured_github_app_identity_uses_city_workspace_env(self) -> None:
+        pathlib.Path(self.tempdir.name, "city.toml").write_text(
+            """
+[workspace]
+[workspace.env]
+GITHUB_INTAKE_APP_IDENTITY = "mayor"
+""".strip(),
+            encoding="utf-8",
+        )
+
+        with mock.patch.dict(service.os.environ, {"GC_CITY_ROOT": self.tempdir.name}, clear=True):
+            identity = service.configured_github_app_identity()
+
+        self.assertEqual(identity, "mayor")
+
+    def test_sync_github_app_config_from_identity_persists_resolved_bundle(self) -> None:
+        service.PROFILE_APP_CACHE.clear()
+
+        with mock.patch.object(
+            service,
+            "load_profile_github_app",
+            return_value={
+                "app_id": "3506340",
+                "installation_id": "127147095",
+                "webhook_secret": "secret",
+                "private_key_pem": "pem",
+                "slug": "release-manager",
+            },
+        ) as load_profile_github_app:
+            outcome = service.sync_github_app_config_from_identity("mayor")
+
+        self.assertEqual(outcome["status"], "updated")
+        self.assertEqual(outcome["identity"], "mayor")
+        load_profile_github_app.assert_called_once_with("mayor")
+        config = service.common.load_config()
+        self.assertEqual(config["app"]["app_id"], "3506340")
+        self.assertEqual(config["app"]["installation_id"], "127147095")
+        self.assertEqual(config["app"]["webhook_secret"], "secret")
+        self.assertEqual(config["app"]["private_key_pem"], "pem")
+
+    def test_load_profile_github_app_requires_identity_schema_version(self) -> None:
+        service.PROFILE_APP_CACHE.clear()
+        result = subprocess.CompletedProcess(
+            ["resolve", "mayor"],
+            0,
+            stdout=json.dumps({"app_id": "mayor-app", "private_key_pem": "pem"}),
+            stderr="",
+        )
+
+        with mock.patch.dict(
+            service.os.environ,
+            {"GITHUB_INTAKE_IDENTITY_RESOLVER": "resolve"},
+            clear=True,
+        ), mock.patch.object(service, "run_subprocess", return_value=result):
+            with self.assertRaisesRegex(RuntimeError, "schema_version"):
+                service.load_profile_github_app("mayor")
+
+    def test_load_profile_github_app_requires_identity_resolver(self) -> None:
+        service.PROFILE_APP_CACHE.clear()
+        with mock.patch.dict(service.os.environ, {}, clear=True):
+            with self.assertRaisesRegex(RuntimeError, "GITHUB_INTAKE_IDENTITY_RESOLVER"):
+                service.load_profile_github_app("mayor")
+
+    def test_process_addressed_comment_honors_ack_false(self) -> None:
+        rules = {
+            "repos": [
+                {
+                    "full_name": "owner/repo",
+                    "authorized_users": ["alice"],
+                    "addresses": [
+                        {
+                            "address": "@mayor",
+                            "pool": "mayor",
+                            "formula": "github-addressed-message",
+                            "ack": False,
+                        }
+                    ],
+                }
+            ]
+        }
+        payload = {
+            "action": "created",
+            "installation": {"id": 88},
+            "issue": {"number": 42, "html_url": "https://github.com/owner/repo/issues/42"},
+            "comment": {"id": 99, "body": "@mayor please triage this", "user": {"login": "alice", "type": "User"}},
+            "repository": {"id": 123, "name": "repo", "full_name": "owner/repo", "owner": {"login": "owner"}},
+        }
+
+        with mock.patch.object(service.common, "load_rules", return_value=rules), mock.patch.object(
+            service,
+            "create_addressed_source",
+            return_value={"status": "created", "bead_id": "ga-addr1", "source_key": "github-comment:123:99:@mayor"},
+        ), mock.patch.object(
+            service.common,
+            "post_issue_comment",
+        ) as post_issue_comment, mock.patch.object(
+            service,
+            "enqueue_addressed_router",
+            return_value="queued",
+        ) as enqueue_addressed_router:
+            outcome = service.process_addressed_comment("issue_comment", "delivery-1", payload, {"app_id": "1"})
+
+        self.assertEqual(outcome["status"], "accepted")
+        self.assertEqual(outcome["created_count"], 1)
+        self.assertEqual(outcome["router_kick"], "queued")
+        enqueue_addressed_router.assert_called_once_with("delivery-1", ["github-comment:123:99:@mayor"])
+        post_issue_comment.assert_not_called()
+
+    def test_process_addressed_comment_kicks_router_for_duplicate_source(self) -> None:
+        rules = {
+            "repos": [
+                {
+                    "full_name": "owner/repo",
+                    "authorized_users": ["alice"],
+                    "addresses": [{"address": "@mayor", "pool": "mayor", "formula": "github-addressed-message"}],
+                }
+            ]
+        }
+        payload = {
+            "action": "created",
+            "installation": {"id": 88},
+            "issue": {"number": 42, "html_url": "https://github.com/owner/repo/issues/42"},
+            "comment": {"id": 99, "body": "@mayor please triage this", "user": {"login": "alice", "type": "User"}},
+            "repository": {"id": 123, "name": "repo", "full_name": "owner/repo", "owner": {"login": "owner"}},
+        }
+
+        with mock.patch.object(service.common, "load_rules", return_value=rules), mock.patch.object(
+            service,
+            "create_addressed_source",
+            return_value={
+                "status": "duplicate",
+                "bead_id": "ga-addr1",
+                "source_key": "github-comment:123:99:@mayor",
+            },
+        ), mock.patch.object(
+            service.common,
+            "post_issue_comment",
+        ) as post_issue_comment, mock.patch.object(
+            service,
+            "enqueue_addressed_router",
+            return_value="queued",
+        ) as enqueue_addressed_router:
+            outcome = service.process_addressed_comment("issue_comment", "delivery-1", payload, {"app_id": "1"})
+
+        self.assertEqual(outcome["status"], "accepted")
+        self.assertEqual(outcome["created_count"], 0)
+        self.assertEqual(outcome["duplicate_count"], 1)
+        self.assertEqual(outcome["router_kick"], "queued")
+        enqueue_addressed_router.assert_called_once_with("delivery-1", ["github-comment:123:99:@mayor"])
+        post_issue_comment.assert_not_called()
+
+    def test_enqueue_addressed_router_runs_scan_in_background(self) -> None:
+        class ImmediateThread:
+            def __init__(self, target, args=(), daemon=None) -> None:
+                self.target = target
+                self.args = args
+                self.daemon = daemon
+
+            def start(self) -> None:
+                self.target(*self.args)
+
+        with mock.patch.object(
+            service.threading,
+            "Thread",
+            ImmediateThread,
+        ), mock.patch.object(
+            service,
+            "run_addressed_router",
+            return_value={"status": "ok", "started_count": 1, "started": [{"bead_id": "ga-src1"}]},
+        ) as run_addressed_router, mock.patch.object(
+            service.common,
+            "save_address_result",
+        ) as save_address_result:
+            status = service.enqueue_addressed_router("delivery-1", ["github-comment:123:99:@mayor"])
+
+        self.assertEqual(status, "queued")
+        run_addressed_router.assert_called_once_with(limit=50)
+        result = save_address_result.call_args.args[0]
+        self.assertEqual(result["result_id"], "delivery-1-addressed-router-kick")
+        self.assertEqual(result["event"], "addressed-router-kick")
+        self.assertEqual(result["status"], "ok")
+        self.assertEqual(result["source_keys"], ["github-comment:123:99:@mayor"])
+        self.assertEqual(result["router"]["started_count"], 1)
+
+    def test_process_addressed_comment_rejects_unauthorized_sender_with_reply(self) -> None:
+        rules = {
+            "repos": [
+                {
+                    "full_name": "owner/repo",
+                    "authorized_users": ["alice"],
+                    "addresses": [{"address": "@mayor", "pool": "mayor", "formula": "github-addressed-message"}],
+                }
+            ]
+        }
+        payload = {
+            "action": "created",
+            "installation": {"id": 88},
+            "issue": {"number": 42, "html_url": "https://github.com/owner/repo/issues/42"},
+            "comment": {
+                "id": 99,
+                "body": "@mayor please triage this",
+                "user": {"login": "mallory", "type": "User"},
+            },
+            "repository": {"id": 123, "name": "repo", "full_name": "owner/repo", "owner": {"login": "owner"}},
+        }
+
+        with mock.patch.object(service.common, "load_rules", return_value=rules), mock.patch.object(
+            service,
+            "create_addressed_source",
+        ) as create_addressed_source, mock.patch.object(
+            service.common,
+            "post_issue_comment",
+            return_value={},
+        ) as post_issue_comment:
+            outcome = service.process_addressed_comment("issue_comment", "delivery-1", payload, {"app_id": "1"})
+
+        self.assertEqual(outcome["status"], "rejected")
+        self.assertEqual(outcome["reason"], "sender_not_authorized")
+        create_addressed_source.assert_not_called()
+        self.assertIn("not authorized to use `@mayor`", post_issue_comment.call_args.args[5])
+
+    def test_process_addressed_comment_does_not_repeat_rejection_reply(self) -> None:
+        rules = {
+            "repos": [
+                {
+                    "full_name": "owner/repo",
+                    "authorized_users": ["alice"],
+                    "addresses": [{"address": "@mayor", "pool": "mayor", "formula": "github-addressed-message"}],
+                }
+            ]
+        }
+        payload = {
+            "action": "created",
+            "installation": {"id": 88},
+            "issue": {"number": 42, "html_url": "https://github.com/owner/repo/issues/42"},
+            "comment": {"id": 99, "body": "@mayor please triage this", "user": {"login": "mallory", "type": "User"}},
+            "repository": {"id": 123, "name": "repo", "full_name": "owner/repo", "owner": {"login": "owner"}},
+        }
+        service.common.save_address_result(
+            {
+                "result_id": "github-comment:123:99:@mayor:sender-not-authorized",
+                "created_at": "2026-05-28T12:00:00Z",
+                "status": "rejected",
+            }
+        )
+
+        with mock.patch.object(service.common, "load_rules", return_value=rules), mock.patch.object(
+            service.common,
+            "post_issue_comment",
+        ) as post_issue_comment:
+            outcome = service.process_addressed_comment("issue_comment", "delivery-2", payload, {"app_id": "1"})
+
+        self.assertEqual(outcome["status"], "duplicate")
+        self.assertEqual(outcome["reason"], "sender_not_authorized_already_reported")
+        post_issue_comment.assert_not_called()
+
+    def test_create_addressed_source_dedupes_existing_closed_source(self) -> None:
+        existing = {"id": "ga-closed", "status": "closed", "metadata": {"external.source_key": "github-comment:123:99:@mayor"}}
+        list_result = mock.Mock(returncode=0, stdout=json.dumps([existing]), stderr="")
+
+        with mock.patch.object(service, "run_subprocess", return_value=list_result) as run_subprocess:
+            outcome = service.create_addressed_source(
+                {
+                    "source_key": "github-comment:123:99:@mayor",
+                    "address": "@mayor",
+                    "cleaned_body": "please triage",
+                    "pool": "mayor",
+                    "rig": "github-owner-repo",
+                    "target": "github-owner-repo/mayor",
+                    "formula": "github-addressed-message",
+                }
+            )
+
+        self.assertEqual(outcome["status"], "duplicate")
+        self.assertEqual(outcome["bead_id"], "ga-closed")
+        command = run_subprocess.call_args.args[0]
+        self.assertIn("--all", command)
+        self.assertNotIn("--status", command)
+
+    def test_create_addressed_source_stores_repo_derived_target_metadata(self) -> None:
+        list_result = mock.Mock(returncode=0, stdout="[]", stderr="")
+        create_result = mock.Mock(returncode=0, stdout='{"id":"ga-src1"}\n', stderr="")
+
+        with mock.patch.object(service, "run_subprocess", side_effect=[list_result, create_result]) as run_subprocess:
+            outcome = service.create_addressed_source(
+                {
+                    "source_key": "github-comment:123:99:@mayor",
+                    "address": "@mayor",
+                    "cleaned_body": "please triage",
+                    "repository_full_name": "owner/repo",
+                    "repository_id": "123",
+                    "item_number": "42",
+                    "pool": "mayor",
+                    "rig": "github-owner-repo",
+                    "target": "github-owner-repo/mayor",
+                    "formula": "github-addressed-message",
+                    "ack": False,
+                    "profile": "mayor",
+                    "profile_github_app_identity": "mayor",
+                    "profile_installation_id": "profile-installation",
+                }
+            )
+
+        self.assertEqual(outcome["status"], "created")
+        create_command = run_subprocess.call_args_list[1].args[0]
+        metadata = json.loads(create_command[create_command.index("--metadata") + 1])
+        self.assertEqual(metadata["addressed.rig"], "github-owner-repo")
+        self.assertEqual(metadata["addressed.pool"], "mayor")
+        self.assertEqual(metadata["addressed.target"], "github-owner-repo/mayor")
+        self.assertEqual(metadata["addressed.profile"], "mayor")
+        self.assertEqual(metadata["addressed.github_app_identity"], "mayor")
+        self.assertEqual(metadata["addressed.github_app_installation_id"], "profile-installation")
+        self.assertEqual(metadata["addressed.ack_requested"], "false")
+
+    def test_addressed_route_target_derives_from_github_repo_at_dispatch_time(self) -> None:
+        with mock.patch.object(
+            service.common,
+            "load_rules",
+            return_value={"repos": [{"full_name": "owner/repo", "rig": "product"}]},
+        ):
+            target = service.addressed_route_target(
+                {
+                    "github.repo": "owner/repo",
+                    "addressed.pool": "mayor",
+                    "addressed.target": "wrong-rig/mayor",
+                }
+            )
+
+        self.assertEqual(target, "product/mayor")
+
+    def test_addressed_route_target_falls_back_to_github_slug_without_mapping(self) -> None:
+        target = service.addressed_route_target(
+            {
+                "github.repo": "owner/repo",
+                "addressed.pool": "mayor",
+                "addressed.target": "wrong-rig/mayor",
+            }
+        )
+
+        self.assertEqual(target, "github-owner-repo/mayor")
+        self.assertEqual(service.addressed_route_target({"addressed.pool": "mayor"}), "")
+        self.assertEqual(service.addressed_route_target({"github.repo": "owner/repo", "addressed.pool": "wrong/mayor"}), "")
+
+    def test_addressed_rig_launch_description_includes_github_response_contract(self) -> None:
+        description = service.addressed_rig_launch_description(
+            "ga-src1",
+            {
+                "addressed.address": "@mayor",
+                "github.repo": "owner/repo",
+                "github.issue_number": "42",
+                "github.item_url": "https://github.com/owner/repo/issues/42",
+                "github.comment_url": "https://github.com/owner/repo/issues/42#issuecomment-99",
+                "github.sender": "octocat",
+            },
+            "github-addressed-message",
+        )
+
+        self.assertIn("## GitHub Response Contract", description)
+        self.assertIn("The GitHub thread is the user-visible response channel.", description)
+        self.assertIn("gc github comment-issue owner/repo 42", description)
+        self.assertIn("Local session output alone does not complete this request.", description)
+
+    def test_addressed_formula_requires_final_github_comment(self) -> None:
+        formula = (pathlib.Path(__file__).resolve().parents[1] / "formulas" / "github-addressed-message.formula.toml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("## GitHub Response Contract", formula)
+        self.assertIn("The GitHub thread is the user-visible response channel.", formula)
+        self.assertIn("Dry-run requests still require a GitHub comment", formula)
+        self.assertIn("Local session output, bead metadata, and in-session summaries are not completion.", formula)
+
+    def test_run_addressed_router_slings_open_sources_and_closes_them(self) -> None:
+        source = {
+            "id": "ga-src1",
+            "status": "open",
+            "title": "GitHub addressed message @mayor in owner/repo#42",
+            "metadata": {
+                "external.source_key": "github-comment:123:99:@mayor",
+                "external.kind": "addressed-message",
+                "addressed.address": "@mayor",
+                "addressed.cleaned_body": "please triage this",
+                "addressed.pool": "mayor",
+                "addressed.formula": "github-addressed-message",
+                "addressed.ack_requested": "true",
+                "addressed.router_status": "failed",
+                "addressed.router_reason": "sling_failed",
+                "addressed.workflow_store": "rig:old",
+                "github.repo": "owner/repo",
+                "github.issue_number": "42",
+                "github.item_url": "https://github.com/owner/repo/issues/42",
+                "github.comment_url": "https://github.com/owner/repo/issues/42#issuecomment-99",
+                "github.installation_id": "repo-installation",
+                "addressed.github_app_identity": "mayor",
+                "addressed.github_app_installation_id": "profile-installation",
+            },
+        }
+        list_result = mock.Mock(returncode=0, stdout=json.dumps([source]), stderr="")
+        starting_result = mock.Mock(returncode=0, stdout="", stderr="")
+        create_result = mock.Mock(returncode=0, stdout='{"id":"ga-launch"}\n', stderr="")
+        sling_result = mock.Mock(returncode=0, stdout='{"workflow_id":"ga-root","bead_id":"ga-root"}\n', stderr="")
+        update_result = mock.Mock(returncode=0, stdout="", stderr="")
+        close_result = mock.Mock(returncode=0, stdout="", stderr="")
+
+        with mock.patch.object(
+            service,
+            "run_subprocess",
+            side_effect=[list_result, starting_result, create_result, sling_result, update_result, close_result],
+        ) as run_subprocess:
+            outcome = service.run_addressed_router(limit=10)
+
+        self.assertEqual(outcome["status"], "ok")
+        self.assertEqual(outcome["started"][0]["rig_launch_bead_id"], "ga-launch")
+        self.assertEqual(outcome["started"][0]["workflow_root_id"], "ga-root")
+        commands = [call.args[0] for call in run_subprocess.call_args_list]
+        self.assertEqual(
+            commands[2][:6],
+            ["gc", "--rig", "github-owner-repo", "bd", "create", "GitHub addressed message @mayor in owner/repo#42"],
+        )
+        create_metadata = json.loads(commands[2][commands[2].index("--metadata") + 1])
+        self.assertEqual(create_metadata["addressed.city_source_bead_id"], "ga-src1")
+        self.assertEqual(create_metadata["addressed.status"], "rig_launch_created")
+        self.assertEqual(create_metadata["addressed.workflow_target"], "github-owner-repo/mayor")
+        self.assertNotIn("addressed.router_status", create_metadata)
+        self.assertNotIn("addressed.router_reason", create_metadata)
+        self.assertNotIn("addressed.workflow_store", create_metadata)
+        self.assertEqual(commands[2][-1], "--json")
+        self.assertEqual(
+            commands[3][:8],
+            ["gc", "--rig", "github-owner-repo", "sling", "--json", "github-owner-repo/mayor", "ga-launch", "--force"],
+        )
+        self.assertIn("--var", commands[3])
+        sling_vars = {
+            item.split("=", 1)[0]: item.split("=", 1)[1]
+            for index, item in enumerate(commands[3])
+            if commands[3][index - 1] == "--var" and "=" in item
+        }
+        self.assertEqual(sling_vars["github_issue_number"], "42")
+        self.assertEqual(sling_vars["city_root"], self.tempdir.name)
+        self.assertEqual(sling_vars["github_app_installation_id"], "profile-installation")
+        self.assertEqual(sling_vars["github_app_identity"], "mayor")
+        self.assertEqual(sling_vars["acknowledgement_requested"], "true")
+        self.assertEqual(commands[1][0:3], ["bd", "update", "ga-src1"])
+        self.assertEqual(commands[4][0:3], ["bd", "update", "ga-src1"])
+        self.assertEqual(commands[5], ["bd", "close", "ga-src1", "--reason", "github addressed message dispatched"])
+
+    def test_route_addressed_source_marks_failed_when_post_sling_update_fails(self) -> None:
+        source = {
+            "id": "ga-src1",
+            "status": "open",
+            "metadata": {
+                "external.source_key": "github-comment:123:99:@mayor",
+                "external.kind": "addressed-message",
+                "addressed.address": "@mayor",
+                "addressed.cleaned_body": "please triage this",
+                "addressed.pool": "mayor",
+                "addressed.formula": "github-addressed-message",
+                "github.repo": "owner/repo",
+            },
+        }
+        starting_result = mock.Mock(returncode=0, stdout="", stderr="")
+        create_result = mock.Mock(returncode=0, stdout='{"id":"ga-launch"}\n', stderr="")
+        sling_result = mock.Mock(returncode=0, stdout='{"workflow_id":"ga-root"}\n', stderr="")
+        update_failed = mock.Mock(returncode=1, stdout="", stderr="bd busy")
+        failure_mark = mock.Mock(returncode=0, stdout="", stderr="")
+
+        with mock.patch.object(
+            service,
+            "run_subprocess",
+            side_effect=[starting_result, create_result, sling_result, update_failed, failure_mark],
+        ) as run_subprocess:
+            outcome = service.route_addressed_source(source)
+
+        self.assertEqual(outcome["status"], "failed")
+        self.assertEqual(outcome["reason"], "source_update_failed")
+        self.assertEqual(outcome["rig_launch_bead_id"], "ga-launch")
+        self.assertEqual(outcome["workflow_root_id"], "ga-root")
+        commands = [call.args[0] for call in run_subprocess.call_args_list]
+        self.assertIn("addressed.router_status=failed", commands[4])
+        self.assertNotIn("close", [command[1] for command in commands])
+
+    def test_route_addressed_source_recloses_already_dispatched_open_source(self) -> None:
+        source = {
+            "id": "ga-src1",
+            "status": "open",
+            "metadata": {
+                "external.source_key": "github-comment:123:99:@mayor",
+                "external.kind": "addressed-message",
+                "addressed.workflow_root": "ga-root",
+            },
+        }
+        close_result = mock.Mock(returncode=0, stdout="", stderr="")
+
+        with mock.patch.object(service, "run_subprocess", return_value=close_result) as run_subprocess:
+            outcome = service.route_addressed_source(source)
+
+        self.assertEqual(outcome["status"], "skipped")
+        self.assertEqual(outcome["reason"], "already_dispatched_closed")
+        self.assertEqual(outcome["workflow_root_id"], "ga-root")
+        run_subprocess.assert_called_once_with(
+            ["bd", "close", "ga-src1", "--reason", "github addressed message dispatched"],
+            self.tempdir.name,
+        )
+
+    def test_non_comment_webhook_queues_rule_processing_before_responding(self) -> None:
+        payload = {
+            "action": "labeled",
+            "repository": {"full_name": "owner/repo"},
+            "pull_request": {"number": 42, "state": "open"},
+            "label": {"name": "status/needs-review"},
+        }
+        body = json.dumps(payload).encode("utf-8")
+        handler = DummyWebhookHandler(
+            body,
+            {
+                "Content-Length": str(len(body)),
+                "X-Hub-Signature-256": "sha256=test",
+                "X-GitHub-Delivery": "delivery-1",
+                "X-GitHub-Event": "pull_request",
+            },
+        )
+
+        with mock.patch.object(
+            service.common,
+            "load_effective_config",
+            return_value={"app": {"webhook_secret": "secret"}},
+        ), mock.patch.object(
+            service.common,
+            "verify_github_signature",
+            return_value=True,
+        ), mock.patch.object(
+            service.common,
+            "save_delivery",
+        ) as save_delivery, mock.patch.object(
+            service,
+            "enqueue_event_rules",
+            return_value="queued",
+        ) as enqueue_event_rules, mock.patch.object(
+            service,
+            "process_event_rules",
+            side_effect=AssertionError("rule processing must not run inline"),
+        ):
+            service.IntakeHandler._do_webhook_post(handler, urllib.parse.urlparse("/v0/github/webhook"))
+
+        self.assertEqual(handler.status, 202)
+        response = json.loads(handler.wfile.getvalue().decode("utf-8"))
+        self.assertEqual(response["status"], "accepted")
+        self.assertEqual(response["rule_processing"], "queued")
+        save_delivery.assert_called_once()
+        enqueue_event_rules.assert_called_once_with(
+            "pull_request",
+            "delivery-1",
+            payload,
+            {"webhook_secret": "secret"},
+        )
+
+    def test_webhook_post_syncs_app_config_when_webhook_secret_missing(self) -> None:
+        payload = {
+            "action": "labeled",
+            "repository": {"full_name": "owner/repo"},
+            "pull_request": {"number": 42, "state": "open"},
+            "label": {"name": "status/needs-review"},
+        }
+        body = json.dumps(payload).encode("utf-8")
+        handler = DummyWebhookHandler(
+            body,
+            {
+                "Content-Length": str(len(body)),
+                "X-Hub-Signature-256": "sha256=test",
+                "X-GitHub-Delivery": "delivery-1",
+                "X-GitHub-Event": "pull_request",
+            },
+        )
+
+        with mock.patch.object(
+            service,
+            "configured_github_app_identity",
+            return_value="mayor",
+        ), mock.patch.object(
+            service,
+            "load_profile_github_app",
+            return_value={
+                "app_id": "3506340",
+                "installation_id": "127147095",
+                "webhook_secret": "secret",
+                "private_key_pem": "pem",
+            },
+        ) as load_profile_github_app, mock.patch.object(
+            service.common,
+            "verify_github_signature",
+            return_value=True,
+        ) as verify_github_signature, mock.patch.object(
+            service.common,
+            "save_delivery",
+        ), mock.patch.object(
+            service,
+            "enqueue_event_rules",
+            return_value="queued",
+        ):
+            service.IntakeHandler._do_webhook_post(handler, urllib.parse.urlparse("/v0/github/webhook"))
+
+        self.assertEqual(handler.status, 202)
+        load_profile_github_app.assert_called_once_with("mayor")
+        verify_github_signature.assert_called_once_with("secret", body, "sha256=test")
+        config = service.common.load_config()
+        self.assertEqual(config["app"]["app_id"], "3506340")
+        self.assertEqual(config["app"]["installation_id"], "127147095")
+
+    def test_addressed_comment_response_marks_legacy_gc_parser_skipped(self) -> None:
+        payload = {
+            "action": "created",
+            "repository": {"full_name": "owner/repo"},
+            "issue": {"number": 42, "html_url": "https://github.com/owner/repo/issues/42"},
+            "comment": {"id": 99, "body": "@mayor /gc fix crash", "user": {"login": "alice"}},
+        }
+        body = json.dumps(payload).encode("utf-8")
+        handler = DummyWebhookHandler(
+            body,
+            {
+                "Content-Length": str(len(body)),
+                "X-Hub-Signature-256": "sha256=test",
+                "X-GitHub-Delivery": "delivery-1",
+                "X-GitHub-Event": "issue_comment",
+            },
+        )
+
+        with mock.patch.object(
+            service.common,
+            "load_effective_config",
+            return_value={"app": {"webhook_secret": "secret"}},
+        ), mock.patch.object(
+            service.common,
+            "verify_github_signature",
+            return_value=True,
+        ), mock.patch.object(
+            service.common,
+            "save_delivery",
+        ), mock.patch.object(
+            service,
+            "enqueue_event_rules",
+            return_value="queued",
+        ), mock.patch.object(
+            service,
+            "process_addressed_comment",
+            return_value={"status": "accepted", "created_count": 1, "duplicate_count": 0, "failure_count": 0},
+        ), mock.patch.object(
+            service.common,
+            "extract_issue_comment_request",
+        ) as extract_issue_comment_request:
+            service.IntakeHandler._do_webhook_post(handler, urllib.parse.urlparse("/v0/github/webhook"))
+
+        self.assertEqual(handler.status, 202)
+        response = json.loads(handler.wfile.getvalue().decode("utf-8"))
+        self.assertEqual(response["status"], "accepted")
+        self.assertEqual(response["command_processing"], "skipped_addressed_message")
+        extract_issue_comment_request.assert_not_called()
+
+    def test_bot_addressed_comment_does_not_fall_through_to_legacy_gc_parser(self) -> None:
+        payload = {
+            "action": "created",
+            "repository": {"full_name": "owner/repo"},
+            "issue": {"number": 42, "html_url": "https://github.com/owner/repo/issues/42"},
+            "comment": {"id": 99, "body": "@mayor please triage\n/gc fix crash", "user": {"login": "renovate[bot]"}},
+        }
+        body = json.dumps(payload).encode("utf-8")
+        handler = DummyWebhookHandler(
+            body,
+            {
+                "Content-Length": str(len(body)),
+                "X-Hub-Signature-256": "sha256=test",
+                "X-GitHub-Delivery": "delivery-1",
+                "X-GitHub-Event": "issue_comment",
+            },
+        )
+
+        with mock.patch.object(
+            service.common,
+            "load_effective_config",
+            return_value={"app": {"webhook_secret": "secret"}},
+        ), mock.patch.object(
+            service.common,
+            "verify_github_signature",
+            return_value=True,
+        ), mock.patch.object(
+            service.common,
+            "save_delivery",
+        ), mock.patch.object(
+            service,
+            "enqueue_event_rules",
+            return_value="queued",
+        ), mock.patch.object(
+            service,
+            "process_addressed_comment",
+            return_value={"status": "ignored", "reason": "comment_from_bot", "addresses": ["@mayor"]},
+        ), mock.patch.object(
+            service.common,
+            "extract_issue_comment_request",
+        ) as extract_issue_comment_request:
+            service.IntakeHandler._do_webhook_post(handler, urllib.parse.urlparse("/v0/github/webhook"))
+
+        self.assertEqual(handler.status, 202)
+        response = json.loads(handler.wfile.getvalue().decode("utf-8"))
+        self.assertEqual(response["status"], "ignored")
+        self.assertEqual(response["addressed_message"]["reason"], "comment_from_bot")
+        self.assertEqual(response["command_processing"], "skipped_addressed_message")
+        extract_issue_comment_request.assert_not_called()
 
     def test_build_fix_bead_notes_includes_issue_and_context(self) -> None:
         request = {
@@ -119,6 +1253,134 @@ class GitHubIntakeServiceTests(unittest.TestCase):
         self.assertEqual(commands[1], ["bd", "close", "bd-1"])
         self.assertNotIn("gc", [command[0] for command in commands])
 
+    def test_run_fix_bugflow_dispatch_creates_source_and_routes_with_app_token(self) -> None:
+        request = {
+            "installation_id": "88",
+            "repository_owner": "owner",
+            "repository_name": "repo",
+            "repository_full_name": "owner/repo",
+            "issue_number": "42",
+            "issue_url": "https://github.com/owner/repo/issues/42",
+            "comment_author": "alice",
+        }
+        create_result = mock.Mock(
+            returncode=0,
+            stdout='{"bead_id":"mc-source","status":"created"}\n',
+            stderr="",
+        )
+        router_result = mock.Mock(
+            returncode=0,
+            stdout='{"status":"ok","started":[{"bead_id":"mc-source","workflow_root_id":"ga-root","rig_launch_bead_id":"ga-launch"}]}\n',
+            stderr="",
+        )
+
+        with mock.patch.object(service.common, "repository_permission", return_value="write"), mock.patch.object(
+            service.common,
+            "create_installation_token",
+            return_value="token-123",
+        ), mock.patch.object(
+            service.common,
+            "post_issue_comment",
+            return_value={},
+        ), mock.patch.object(
+            service,
+            "run_subprocess",
+            side_effect=[create_result, router_result],
+        ) as run_subprocess:
+            outcome = service.run_fix_bugflow_dispatch(request, {"app_id": "1", "private_key_pem": "pem"})
+
+        self.assertEqual(outcome["status"], "dispatched")
+        self.assertEqual(outcome["dispatch_formula"], "mol-bug-report-flow-v2")
+        self.assertEqual(outcome["bead_id"], "mc-source")
+        self.assertEqual(outcome["workflow_root_id"], "ga-root")
+        commands = [call.args[0] for call in run_subprocess.call_args_list]
+        self.assertEqual(commands[0], ["gc", "workflows", "bugflow", "create", "https://github.com/owner/repo/issues/42"])
+        self.assertEqual(commands[1], ["gc", "workflows", "bugflow", "router-scan"])
+        self.assertEqual(run_subprocess.call_args_list[0].kwargs["env"]["GH_TOKEN"], "token-123")
+        self.assertEqual(run_subprocess.call_args_list[1].kwargs["env"]["GH_TOKEN"], "token-123")
+
+    def test_run_fix_bugflow_dispatch_posts_acknowledgement_comment(self) -> None:
+        request = {
+            "installation_id": "88",
+            "repository_owner": "owner",
+            "repository_name": "repo",
+            "repository_full_name": "owner/repo",
+            "issue_number": "42",
+            "issue_url": "https://github.com/owner/repo/issues/42",
+            "comment_author": "alice",
+        }
+        create_result = mock.Mock(
+            returncode=0,
+            stdout='{"bead_id":"mc-source","status":"created"}\n',
+            stderr="",
+        )
+        router_result = mock.Mock(
+            returncode=0,
+            stdout='{"status":"ok","started":[{"bead_id":"mc-source","workflow_root_id":"ga-root","rig_launch_bead_id":"ga-launch"}]}\n',
+            stderr="",
+        )
+
+        with mock.patch.object(service.common, "repository_permission", return_value="write"), mock.patch.object(
+            service.common,
+            "create_installation_token",
+            return_value="token-123",
+        ), mock.patch.object(
+            service.common,
+            "post_issue_comment",
+            return_value={"id": "comment-123", "html_url": "https://github.com/owner/repo/issues/42#issuecomment-123"},
+        ) as post_issue_comment, mock.patch.object(
+            service,
+            "run_subprocess",
+            side_effect=[create_result, router_result],
+        ):
+            outcome = service.run_fix_bugflow_dispatch(request, {"app_id": "1", "private_key_pem": "pem"})
+
+        self.assertEqual(outcome["status"], "dispatched")
+        self.assertEqual(outcome["acknowledgement_comment_id"], "comment-123")
+        self.assertEqual(outcome["acknowledgement_comment_url"], "https://github.com/owner/repo/issues/42#issuecomment-123")
+        comment_args = post_issue_comment.call_args.args
+        self.assertEqual(comment_args[1:5], ("88", "owner", "repo", "42"))
+        self.assertIn("`/gc fix` request is queued", comment_args[5])
+        self.assertNotIn("Mayor", comment_args[5])
+        self.assertIn("`mc-source`", comment_args[5])
+        self.assertIn("`ga-root`", comment_args[5])
+
+    def test_run_fix_bugflow_dispatch_treats_duplicate_source_as_dispatched(self) -> None:
+        request = {
+            "installation_id": "88",
+            "repository_owner": "owner",
+            "repository_name": "repo",
+            "repository_full_name": "owner/repo",
+            "issue_number": "42",
+            "issue_url": "https://github.com/owner/repo/issues/42",
+            "comment_author": "alice",
+        }
+        create_result = mock.Mock(
+            returncode=1,
+            stdout="",
+            stderr="bugflow-request: open bugflow source bead already exists for https://github.com/owner/repo/issues/42: mc-source\n",
+        )
+        router_result = mock.Mock(returncode=0, stdout='{"status":"ok","started":[]}\n', stderr="")
+
+        with mock.patch.object(service.common, "repository_permission", return_value="write"), mock.patch.object(
+            service.common,
+            "create_installation_token",
+            return_value="token-123",
+        ), mock.patch.object(
+            service.common,
+            "post_issue_comment",
+            return_value={},
+        ), mock.patch.object(
+            service,
+            "run_subprocess",
+            side_effect=[create_result, router_result],
+        ):
+            outcome = service.run_fix_bugflow_dispatch(request, {"app_id": "1", "private_key_pem": "pem"})
+
+        self.assertEqual(outcome["status"], "dispatched")
+        self.assertEqual(outcome["reason"], "duplicate_open_bead")
+        self.assertEqual(outcome["dispatch_formula"], "mol-bug-report-flow-v2")
+
     def test_close_failed_bead_updates_and_closes(self) -> None:
         result = mock.Mock(returncode=0)
         with mock.patch.object(service, "run_subprocess", return_value=result) as run_subprocess:
@@ -142,20 +1404,16 @@ class GitHubIntakeServiceTests(unittest.TestCase):
             "repository_name": "repo",
             "comment_author": "alice",
         }
-        mapping = {
-            "target": "product/polecat",
-            "commands": {"fix": {"formula": "mol-github-fix-issue"}},
-        }
         service.common.save_request(request)
         service.common.save_workflow_link(request["workflow_key"], request["request_id"])
 
         with mock.patch.object(service.common, "load_config", return_value={"app": {"app_id": "1"}}), mock.patch.object(
             service.common,
             "resolve_repo_mapping",
-            return_value=mapping,
+            return_value=None,
         ), mock.patch.object(
             service,
-            "run_fix_issue_dispatch",
+            "run_fix_bugflow_dispatch",
             return_value={"status": "dispatch_failed", "reason": "dispatch_failed", "bead_id": "bd-1"},
         ):
             service.process_request(request["request_id"])
@@ -175,20 +1433,16 @@ class GitHubIntakeServiceTests(unittest.TestCase):
             "repository_id": "123",
             "issue_number": "43",
         }
-        mapping = {
-            "target": "product/polecat",
-            "commands": {"fix": {"formula": "mol-github-fix-issue"}},
-        }
         service.common.save_request(request)
         service.common.save_workflow_link(request["workflow_key"], request["request_id"])
 
         with mock.patch.object(service.common, "load_config", return_value={"app": {"app_id": "1"}}), mock.patch.object(
             service.common,
             "resolve_repo_mapping",
-            return_value=mapping,
+            return_value=None,
         ), mock.patch.object(
             service,
-            "run_fix_issue_dispatch",
+            "run_fix_bugflow_dispatch",
             return_value={
                 "status": "dispatch_failed",
                 "reason": "dispatch_failed",
@@ -210,20 +1464,16 @@ class GitHubIntakeServiceTests(unittest.TestCase):
             "issue_number": "45",
             "bead_id": "bd-9",
         }
-        mapping = {
-            "target": "product/polecat",
-            "commands": {"fix": {"formula": "mol-github-fix-issue"}},
-        }
         service.common.save_request(request)
         service.common.save_workflow_link(request["workflow_key"], request["request_id"])
 
         with mock.patch.object(service.common, "load_config", return_value={"app": {"app_id": "1"}}), mock.patch.object(
             service.common,
             "resolve_repo_mapping",
-            return_value=mapping,
+            return_value=None,
         ), mock.patch.object(
             service,
-            "run_fix_issue_dispatch",
+            "run_fix_bugflow_dispatch",
             side_effect=RuntimeError("boom"),
         ), mock.patch.object(
             service,
@@ -245,10 +1495,6 @@ class GitHubIntakeServiceTests(unittest.TestCase):
             "issue_number": "46",
             "bead_id": "bd-10",
         }
-        mapping = {
-            "target": "product/polecat",
-            "commands": {"fix": {"formula": "mol-github-fix-issue"}},
-        }
         service.common.save_request(request)
         service.common.save_workflow_link(request["workflow_key"], request["request_id"])
 
@@ -259,10 +1505,10 @@ class GitHubIntakeServiceTests(unittest.TestCase):
         with mock.patch.object(service.common, "load_config", return_value={"app": {"app_id": "1"}}), mock.patch.object(
             service.common,
             "resolve_repo_mapping",
-            return_value=mapping,
+            return_value=None,
         ), mock.patch.object(
             service,
-            "run_fix_issue_dispatch",
+            "run_fix_bugflow_dispatch",
             side_effect=dispatch_then_blow_up,
         ), mock.patch.object(
             service,
@@ -290,10 +1536,6 @@ class GitHubIntakeServiceTests(unittest.TestCase):
             "repository_full_name": "owner/repo",
             "issue_number": "44",
         }
-        mapping = {
-            "target": "product/polecat",
-            "commands": {"fix": {"formula": "mol-github-fix-issue"}},
-        }
         service.common.save_request(request)
         service.common.save_request(newer)
         service.common.save_workflow_link(request["workflow_key"], newer["request_id"])
@@ -301,10 +1543,10 @@ class GitHubIntakeServiceTests(unittest.TestCase):
         with mock.patch.object(service.common, "load_config", return_value={"app": {"app_id": "1"}}), mock.patch.object(
             service.common,
             "resolve_repo_mapping",
-            return_value=mapping,
+            return_value=None,
         ), mock.patch.object(
             service,
-            "run_fix_issue_dispatch",
+            "run_fix_bugflow_dispatch",
             return_value={"status": "dispatch_failed", "reason": "dispatch_failed"},
         ):
             service.process_request(request["request_id"])
@@ -313,6 +1555,90 @@ class GitHubIntakeServiceTests(unittest.TestCase):
         self.assertIsNotNone(loaded)
         assert loaded is not None
         self.assertEqual(loaded["request_id"], newer["request_id"])
+
+
+class PublishImportedIdentityTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self._old_environ = os.environ.copy()
+        os.environ["GC_CITY_ROOT"] = self.tempdir.name
+        os.environ.pop("GITHUB_INTAKE_IDENTITY_PUBLISHER", None)
+        os.environ.pop("GITHUB_INTAKE_APP_IDENTITY", None)
+
+    def tearDown(self) -> None:
+        os.environ.clear()
+        os.environ.update(self._old_environ)
+
+    def test_publish_imported_identity_resolves_settings_from_workspace_env(self) -> None:
+        config = {"app": {"app_id": "7", "private_key_pem": "PEM"}}
+        with mock.patch.object(
+            service,
+            "city_workspace_env",
+            return_value={
+                "GITHUB_INTAKE_IDENTITY_PUBLISHER": "publish-cmd",
+                "GITHUB_INTAKE_APP_IDENTITY": "mayor",
+            },
+        ), mock.patch.object(
+            service.common, "publish_identity", return_value={"status": "published", "detail": ""}
+        ) as publish:
+            result = service.publish_imported_identity(config)
+
+        self.assertEqual(result["status"], "published")
+        publish.assert_called_once_with(
+            {"app_id": "7", "private_key_pem": "PEM"},
+            identity="mayor",
+            publisher="publish-cmd",
+        )
+
+    def test_publish_imported_identity_prefers_process_env(self) -> None:
+        os.environ["GITHUB_INTAKE_IDENTITY_PUBLISHER"] = "env-cmd"
+        os.environ["GITHUB_INTAKE_APP_IDENTITY"] = "mayor"
+        with mock.patch.object(service, "city_workspace_env", return_value={}), mock.patch.object(
+            service.common, "publish_identity", return_value={"status": "published", "detail": ""}
+        ) as publish:
+            service.publish_imported_identity({"app": {"app_id": "9"}})
+
+        publish.assert_called_once_with({"app_id": "9"}, identity="mayor", publisher="env-cmd")
+
+    def test_manifest_callback_publishes_identity_after_import(self) -> None:
+        handler = DummyWebhookHandler(b"", {})
+        config = {"app": {"app_id": "7", "slug": "demo-app"}}
+        with mock.patch.object(
+            service.common, "exchange_manifest_code", return_value={"app_id": "7"}
+        ), mock.patch.object(
+            service.common, "import_app_config", return_value=config
+        ), mock.patch.object(
+            service.common, "load_config", return_value={}
+        ), mock.patch.object(
+            service, "publish_imported_identity", return_value={"status": "published", "detail": ""}
+        ) as publish:
+            service.IntakeHandler._do_admin_get(
+                handler, urllib.parse.urlparse("/v0/github/app/manifest/callback?code=abc")
+            )
+
+        self.assertEqual(handler.status, 200)
+        publish.assert_called_once_with(config)
+
+    def test_admin_import_post_publishes_identity(self) -> None:
+        body = json.dumps({"app_id": "7"}).encode("utf-8")
+        handler = DummyWebhookHandler(body, {"Content-Length": str(len(body))})
+        handler._read_json_body = service.IntakeHandler._read_json_body.__get__(handler)
+        config = {"app": {"app_id": "7"}}
+        with mock.patch.object(
+            service.common, "import_app_config", return_value=config
+        ), mock.patch.object(
+            service.common, "load_config", return_value={}
+        ), mock.patch.object(
+            service, "publish_imported_identity", return_value={"status": "skipped", "reason": "no publisher configured"}
+        ) as publish:
+            service.IntakeHandler._do_admin_post(
+                handler, urllib.parse.urlparse("/v0/github/app/import")
+            )
+
+        self.assertEqual(handler.status, 200)
+        publish.assert_called_once_with(config)
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Three commits, exercised together in a production deployment:

### feat(github): addressed-message intake, sync-app, and identity publish/resolve tooling
- **Addressed messages** — repo-scoped comment addresses (e.g. `@mayor`) in the rules file route issue/PR comments to a configured pool via a formula, with sender authorization, bot filtering, dedupe by source key, a webhook fast path, and a `github-addressed-message-router` cooldown order as the reconciliation path for missed comments. Includes a 7-day backup scan via `gh` using an App installation token.
- **Identity sync** — a `sync-app` command plus cooldown order that refresh the persisted App config from the configured identity resolver, so restarts and secret rotation converge without manual import. The resolver env passthrough is store-agnostic: any `GITHUB_INTAKE_*` workspace-env key is forwarded, so store-specific resolvers can define their own knobs without this pack enumerating them.
- **Identity publish hook** — the write-side mirror of the resolver. `GITHUB_INTAKE_IDENTITY_PUBLISHER` runs with the identity as its only argument and the v1 identity JSON on stdin after the manifest onboarding callback or a manual import, so freshly created App credentials land in the deployment secret store instead of being stranded in the local service config. No-op when unset; failures are logged, never fatal. A portable file-backed publisher/resolver pair ships in `examples/`, giving a dependency-free onboarding round trip (create → publish to file → resolve from file).
- Docs: README event-rules/addressed/runtime-secrets sections and `docs/github-app-identity.md` (resolver + publisher contracts, file quick starts). All command examples use the pack-name namespace (`gc github ...`).

### fix(discord): gateway follow-up delivery and workspace-name resolution
- Deliver bound-room follow-up messages to the bound session reliably, with regression tests for targeted and untargeted ambient paths.
- Resolve the workspace name for supervisor scope discovery the way gc does (declared `workspace.name` → `.gc/site.toml` `workspace_name` → city dir basename). `gc init` no longer writes `workspace.name`, so deployments without the legacy field fell back to the dead default API port and the gateway healthz reported degraded while Discord routing was healthy.
- Sync the fix-issue formula vars with the b64-safe interpolation scheme.

### docs(cass): do not start index rebuilds from agent sessions

## Test plan
- `python3 -m pytest tests gascity/tests discord/tests github/tests slack-full/tests slack-channel/tests -q` — 620 passed, 10,709 subtests
- `python3 validate_registry.py` — ok
- `go test .` — ok (embed)
- New coverage: publish hook (skip/env/exec/error paths), service wiring (manifest callback + admin import), file publisher (0600 + schema + derived `ready`, merge republish, resolver round-trip, argv/main paths), gateway workspace-name fallbacks, prefix-based env passthrough including a negative case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)