### PR TITLE
docs: quick starts use brew install gascity and gc import add

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ this is the shortest path. Each step is copy-pasteable; swap names to taste.
 1. **Install Gas City and start a city** (skip steps you have already done):
 
    ```sh
-   brew install gastownhall/gascity/gascity
+   brew install gascity
    gc init ~/my-city
    cd ~/my-city
    gc start
@@ -33,30 +33,33 @@ this is the shortest path. Each step is copy-pasteable; swap names to taste.
    gc rig add .
    ```
 
-3. **Get the packs.** Clone this repo next to your city, or import straight
-   from git:
+3. **Import the base pack.** From the city directory:
 
    ```sh
-   git clone https://github.com/gastownhall/gascity-packs ~/gascity-packs
+   gc import add --name gc https://github.com/gastownhall/gascity-packs.git//gascity
    ```
 
-4. **Import the base pack and rig roles** in your city's `city.toml`:
+   This writes the import, fetches the latest release, and pins it in
+   `packs.lock` — no clone needed. (`gc import upgrade gc` moves the pin
+   later; contributors hacking on the packs themselves can point `source`
+   at a local clone instead.)
+
+4. **Import the rig roles** in your city's `city.toml`. Rig-scoped imports
+   are declared on the rig entry:
 
    ```toml
-   [imports.gc]
-   source = "/home/you/gascity-packs/gascity"
-
    [[rigs]]
    name = "your-project"
 
    [rigs.imports.gc]
-   source = "/home/you/gascity-packs/gascity/roles"
+   source = "https://github.com/gastownhall/gascity-packs.git//gascity/roles"
    ```
 
    The city-level import provides the workflow formulas and the `gc.mayor`
    coordinator skill; the rig-level `roles` import provides the worker agents
    (`gc.implementation-worker`, `gc.requirements-planner`, and friends) that
-   the formulas route work to.
+   the formulas route work to. Run `gc import install` after editing to
+   fetch anything newly referenced.
 
 5. **Run your first build.** Create a bead describing the goal, then launch
    the starter factory against it:
@@ -75,8 +78,13 @@ this is the shortest path. Each step is copy-pasteable; swap names to taste.
 6. **Pick a methodology when you want more opinion.** The four methodology
    packs below replace `build-basic`'s stages with vendored, battle-tested
    processes while keeping the same launch shape — import one at city scope
-   and sling its build formula instead (for example `--on bmad-build`). Each
-   pack's README has its own quick start.
+   and sling its build formula instead (for example `--on bmad-build`):
+
+   ```sh
+   gc import add https://github.com/gastownhall/gascity-packs.git//bmad
+   ```
+
+   Each pack's README has its own quick start.
 
 ## Which build pack should I use?
 
@@ -94,29 +102,27 @@ change to the formula name.
 
 ## Using a pack
 
-Packs live next to the consuming workspace. A typical layout:
+The canonical path is the import CLI — it writes the import, fetches the
+latest release, and pins the commit in `packs.lock`:
 
-```text
-your-city/
-  city.toml
-gascity-packs/
-  gascity/
-  bmad/
-  ...
+```sh
+gc import add https://github.com/gastownhall/gascity-packs.git//bmad
 ```
 
-Inside `city.toml` (or any pack's `pack.toml`):
-
-```toml
-[imports.bmad]
-source = "../gascity-packs/bmad"
-```
-
-Imports also accept git sources, fetched and pinned by `gc import install`:
+Which is equivalent to this in `city.toml` (or any pack's `pack.toml`),
+followed by `gc import install`:
 
 ```toml
 [imports.bmad]
 source = "https://github.com/gastownhall/gascity-packs.git//bmad"
+```
+
+Contributors working on the packs themselves can clone this repo and point
+`source` at a local path instead:
+
+```toml
+[imports.bmad]
+source = "../gascity-packs/bmad"
 ```
 
 Each pack documents its own prerequisites, import snippet, and usage.

--- a/bmad/README.md
+++ b/bmad/README.md
@@ -28,7 +28,7 @@ Prerequisites: Gas City installed and a city running, plus a git repository
 registered as a rig. If you have not done that yet:
 
 ```sh
-brew install gastownhall/gascity/gascity
+brew install gascity
 gc init ~/my-city
 cd ~/my-city
 gc start
@@ -39,35 +39,32 @@ mkdir proj && cd proj && git init
 gc rig add .
 ```
 
-1. **Get the packs.** Clone this repository next to your city:
+1. **Import the pack.** From the city directory, add bmad at city scope. This
+   writes the import, fetches the latest release, and pins it in `packs.lock`
+   — no clone needed. The pack imports the Gas City base pack internally as
+   `gc`, so `build-base` and the `gc.*` formula surface are available
+   transitively:
 
    ```sh
-   git clone https://github.com/gastownhall/gascity-packs ~/gascity-packs
+   gc import add https://github.com/gastownhall/gascity-packs.git//bmad
    ```
 
-2. **Import the pack in `city.toml`.** Import bmad at city scope. The pack
-   imports the Gas City base pack internally as `gc`, so `build-base` and the
-   `gc.*` formula surface are available transitively. The rig additionally
-   needs the `gascity/roles` import so the `gc.*` role agents (operator,
-   publisher, and friends) can run work inside the target repository:
+2. **Import the rig roles in `city.toml`.** The rig additionally needs the
+   `gascity/roles` import so the `gc.*` role agents (operator, publisher,
+   and friends) can run work inside the target repository; run
+   `gc import install` after editing:
 
    ```toml
-   [imports.bmad]
-   source = "../gascity-packs/bmad"
-
    [[rigs]]
    name = "proj"
 
    [rigs.imports.gc]
-   source = "../gascity-packs/gascity/roles"
+   source = "https://github.com/gastownhall/gascity-packs.git//gascity/roles"
    ```
 
-   Imports also accept git sources, fetched and pinned by `gc import install`:
-
-   ```toml
-   [imports.bmad]
-   source = "https://github.com/gastownhall/gascity-packs.git//bmad"
-   ```
+   Contributors working on the packs themselves can clone
+   `https://github.com/gastownhall/gascity-packs` and point either `source`
+   at the local path (for example `../gascity-packs/bmad`) instead.
 
 3. **Launch your first build.** `bmad-build` is targeted
    (`target_required = true`), so create a bead describing the goal first,

--- a/compound-engineering/README.md
+++ b/compound-engineering/README.md
@@ -33,7 +33,7 @@ Prerequisites: git, and a repository you want agents to work on.
    done):
 
    ```sh
-   brew install gastownhall/gascity/gascity
+   brew install gascity
    gc init ~/my-city
    cd ~/my-city
    gc start
@@ -47,42 +47,33 @@ Prerequisites: git, and a repository you want agents to work on.
    gc rig add .
    ```
 
-3. **Get the packs.** Clone this repository next to your city:
+3. **Import the pack.** From the city directory, add `compound-engineering`
+   at city scope. This writes the import, fetches the latest release, and
+   pins it in `packs.lock` — no clone needed. The pack imports the Gas City
+   base pack internally as `gc`, so the `build-base` contract and `gc.*`
+   formulas come along transitively:
 
    ```sh
-   git clone https://github.com/gastownhall/gascity-packs ~/gascity-packs
+   gc import add https://github.com/gastownhall/gascity-packs.git//compound-engineering
    ```
 
-4. **Import the pack in your city's `city.toml`.** Import
-   `compound-engineering` at city scope; it imports the Gas City base pack
-   internally as `gc`, so the `build-base` contract and `gc.*` formulas come
-   along transitively. Each rig that should run work also needs the
-   `gascity/roles` import, which provides the worker role agents
-   (`gc.run-operator`, `gc.implementation-worker`, and friends) that formulas
-   route to:
+4. **Import the rig roles in `city.toml`.** Each rig that should run work
+   also needs the `gascity/roles` import, which provides the worker role
+   agents (`gc.run-operator`, `gc.implementation-worker`, and friends) that
+   formulas route to; run `gc import install` after editing:
 
    ```toml
-   [imports.compound-engineering]
-   source = "../gascity-packs/compound-engineering"
-
    [[rigs]]
    name = "your-project"
 
    [rigs.imports.gc]
-   source = "../gascity-packs/gascity/roles"
+   source = "https://github.com/gastownhall/gascity-packs.git//gascity/roles"
    ```
 
-   To pull the pack straight from git instead of a local clone, use a git
-   source and install it:
-
-   ```toml
-   [imports.compound-engineering]
-   source = "https://github.com/gastownhall/gascity-packs.git//compound-engineering"
-   ```
-
-   ```sh
-   gc import install
-   ```
+   Contributors working on the packs themselves can clone
+   `https://github.com/gastownhall/gascity-packs` and point either `source`
+   at the local path (for example `../gascity-packs/compound-engineering`)
+   instead.
 
 5. **Verify the formula is visible** from the rig context:
 

--- a/gascity/README.md
+++ b/gascity/README.md
@@ -21,19 +21,26 @@ Prerequisites: Gas City installed and a city running (`gc init`, `gc start`),
 and your project added as a rig (`gc rig add .` inside the repo). See the
 [repository README](../README.md) for the from-scratch path.
 
-1. Import the pack twice in `city.toml` — once at city scope for formulas and
-   the mayor skill, once per rig for the worker role agents:
+1. Import the pack twice — once at city scope for formulas and the mayor
+   skill, once per rig for the worker role agents. From the city directory:
+
+   ```sh
+   gc import add --name gc https://github.com/gastownhall/gascity-packs.git//gascity
+   ```
+
+   Then add the rig-scoped roles import in `city.toml` and run
+   `gc import install`:
 
    ```toml
-   [imports.gc]
-   source = "../gascity-packs/gascity"
-
    [[rigs]]
    name = "your-project"
 
    [rigs.imports.gc]
-   source = "../gascity-packs/gascity/roles"
+   source = "https://github.com/gastownhall/gascity-packs.git//gascity/roles"
    ```
+
+   (Contributors hacking on the pack itself can point either `source` at a
+   local clone, for example `../gascity-packs/gascity`.)
 
 2. Create a bead describing what you want built, and sling the starter
    factory at it:

--- a/gstack/README.md
+++ b/gstack/README.md
@@ -41,7 +41,7 @@ These steps go from a fresh machine to a completed gstack sprint.
 1. Install Gas City and create a city:
 
    ```sh
-   brew install gastownhall/gascity/gascity
+   brew install gascity
    gc init ~/my-city && cd ~/my-city && gc start
    ```
 
@@ -51,33 +51,31 @@ These steps go from a fresh machine to a completed gstack sprint.
    mkdir proj && cd proj && git init && gc rig add .
    ```
 
-3. Import this pack at city scope, and import the Gas City roles pack on the
-   rig. Two imports are required: the methodology pack supplies the formulas
-   and `gstack.*` agents, and the rig-level `gascity/roles` import supplies the
-   `gc.*` role agents (run operator, publisher, implementation workers) that
-   the formulas route to. In your `city.toml`:
+3. Import this pack at city scope. From the city directory — this writes the
+   import, fetches the latest release, and pins it in `packs.lock`, no clone
+   needed:
+
+   ```sh
+   gc import add https://github.com/gastownhall/gascity-packs.git//gstack
+   ```
+
+   Then import the Gas City roles pack on the rig: the methodology pack
+   supplies the formulas and `gstack.*` agents, and the rig-level
+   `gascity/roles` import supplies the `gc.*` role agents (run operator,
+   publisher, implementation workers) that the formulas route to. In your
+   `city.toml`, then `gc import install`:
 
    ```toml
-   [imports.gstack]
-   source = "../gascity-packs/gstack"
-
    [[rigs]]
    name = "proj"
 
    [rigs.imports.gc]
-   source = "../gascity-packs/gascity/roles"
+   source = "https://github.com/gastownhall/gascity-packs.git//gascity/roles"
    ```
 
-   Imports also accept git sources, fetched and pinned by `gc import install`:
-
-   ```toml
-   [imports.gstack]
-   source = "https://github.com/gastownhall/gascity-packs.git//gstack"
-   ```
-
-   ```sh
-   gc import install
-   ```
+   Contributors working on the packs themselves can clone
+   `https://github.com/gastownhall/gascity-packs` and point either `source`
+   at the local path (for example `../gascity-packs/gstack`) instead.
 
 4. Create a bead for the goal and sling it onto `gstack-build`. The formula
    declares `target_required = true`, so it is launched against a bead (or

--- a/superpowers/README.md
+++ b/superpowers/README.md
@@ -37,7 +37,7 @@ run.
 1. **Install Gas City and start a city** (skip what you already have):
 
    ```sh
-   brew install gastownhall/gascity/gascity
+   brew install gascity
    gc init ~/my-city
    cd ~/my-city
    gc start
@@ -51,36 +51,32 @@ run.
    gc rig add .
    ```
 
-3. **Get the packs.** Clone this repo next to your city:
+3. **Import the pack.** From the city directory, add `superpowers` at city
+   scope. This writes the import, fetches the latest release, and pins it in
+   `packs.lock` — no clone needed. The pack imports the Gas City pack
+   internally as `gc`, so `build-base` and the shared `gc.*` formula surface
+   come along transitively:
 
    ```sh
-   git clone https://github.com/gastownhall/gascity-packs ~/gascity-packs
+   gc import add https://github.com/gastownhall/gascity-packs.git//superpowers
    ```
 
-4. **Import the pack and the rig roles** in your city's `city.toml`. Import
-   `superpowers` at city scope — it imports the Gas City pack internally as
-   `gc`, so `build-base` and the shared `gc.*` formula surface come along
-   transitively. Each rig that should run work also needs the `gascity/roles`
-   import, which provides the worker agents (`gc.run-operator`,
-   `gc.task-decomposer`, and friends) that formula steps route to:
+4. **Import the rig roles** in your city's `city.toml`. Each rig that should
+   run work also needs the `gascity/roles` import, which provides the worker
+   agents (`gc.run-operator`, `gc.task-decomposer`, and friends) that formula
+   steps route to; run `gc import install` after editing:
 
    ```toml
-   [imports.superpowers]
-   source = "../gascity-packs/superpowers"
-
    [[rigs]]
    name = "your-project"
 
    [rigs.imports.gc]
-   source = "../gascity-packs/gascity/roles"
+   source = "https://github.com/gastownhall/gascity-packs.git//gascity/roles"
    ```
 
-   Imports also accept git sources, fetched and pinned by `gc import install`:
-
-   ```toml
-   [imports.superpowers]
-   source = "https://github.com/gastownhall/gascity-packs.git//superpowers"
-   ```
+   Contributors working on the packs themselves can clone
+   `https://github.com/gastownhall/gascity-packs` and point either `source`
+   at the local path (for example `../gascity-packs/superpowers`) instead.
 
 5. **Run your first build.** `superpowers-build` is a targeted formula
    (`target_required = true`): create a bead describing the goal, then sling


### PR DESCRIPTION
Follow-up to #67. The build pack quick starts (root README, gascity, bmad, compound-engineering, superpowers, gstack) now:

- install Gas City with plain `brew install gascity` (homebrew-core) instead of the tap-qualified formula
- import packs with `gc import add https://github.com/gastownhall/gascity-packs.git//<pack>` instead of cloning the repo and path-importing — one command that writes the import, fetches the latest release, and pins it in `packs.lock`
- declare rig-scoped `gascity/roles` imports with the git source URL plus `gc import install`
- keep the local-clone path import documented as the contributor workflow

The flow was verified end-to-end against a scratch city, including rig-scoped remote import resolution. Note `gc import add` resolves the latest release tag, so the new packs become importable when the next release is cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)