### PR TITLE
feat(github): deployment URL overrides for manifest onboarding

### DIFF
--- a/github/scripts/github_intake_common.py
+++ b/github/scripts/github_intake_common.py
@@ -396,23 +396,65 @@ def published_service_url(service_name: str) -> str:
     return ""
 
 
+def workspace_env_value(name: str) -> str:
+    """Resolve a config knob from the process env, then city workspace.env.
+
+    Service processes do not inherit [workspace.env], so deployment knobs
+    must also be readable straight from city.toml.
+    """
+    value = os.environ.get(name, "").strip()
+    if value:
+        return value
+    root = city_root()
+    if not root:
+        return ""
+    try:
+        with open(os.path.join(root, "city.toml"), "rb") as handle:
+            data = tomllib.load(handle)
+    except (OSError, tomllib.TOMLDecodeError):
+        return ""
+    workspace = data.get("workspace") if isinstance(data, dict) else None
+    env = workspace.get("env") if isinstance(workspace, dict) else None
+    if isinstance(env, dict):
+        return str(env.get(name, "")).strip()
+    return ""
+
+
 def admin_url() -> str:
+    """Public admin URL: deployment override first, then gc publication.
+
+    Self-hosted cities have no gc publication provider; the override lets
+    them run the manifest onboarding flow behind their own edge or tunnel.
+    """
+    override = workspace_env_value("GITHUB_INTAKE_ADMIN_PUBLIC_URL")
+    if override:
+        return override
     return published_service_url(ADMIN_SERVICE_NAME)
 
 
 def webhook_url() -> str:
+    """Public webhook base URL: deployment override first, then publication."""
+    override = workspace_env_value("GITHUB_INTAKE_WEBHOOK_PUBLIC_URL")
+    if override:
+        return override
     return published_service_url(WEBHOOK_SERVICE_NAME)
 
 
 def build_manifest() -> dict[str, Any]:
     admin = admin_url()
     webhook = webhook_url()
-    if not admin or not webhook:
+    # GITHUB_INTAKE_WEBHOOK_HOOK_URL is the exact delivery URL placed in the
+    # manifest, for deployments whose edge uses a different path shape than
+    # the service-native /v0/github/webhook suffix.
+    hook_url = workspace_env_value("GITHUB_INTAKE_WEBHOOK_HOOK_URL")
+    if not admin or not (webhook or hook_url):
         raise ValueError("published admin and webhook URLs are required before building the GitHub App manifest")
+    if not hook_url:
+        hook_url = webhook.rstrip("/") + "/v0/github/webhook"
     return {
         "name": f"Gas City {city_name()} GitHub Intake",
         "url": admin,
-        "hook_attributes": {"url": webhook.rstrip("/") + "/v0/github/webhook", "active": True},
+        "hook_attributes": {"url": hook_url, "active": True},
         "redirect_url": admin.rstrip("/") + "/v0/github/app/manifest/callback",
         "callback_urls": [admin.rstrip("/") + "/v0/github/app/manifest/callback"],
         "setup_url": admin,

--- a/github/tests/test_github_intake_common.py
+++ b/github/tests/test_github_intake_common.py
@@ -561,6 +561,60 @@ name = "triage-patrol"
             common.app_identifier({"client_id": "Iv1.only-client-id"})
 
 
+class GitHubIntakePublicUrlOverrideTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self._old_environ = os.environ.copy()
+        os.environ["GC_CITY_ROOT"] = self.tempdir.name
+        for key in (
+            "GITHUB_INTAKE_ADMIN_PUBLIC_URL",
+            "GITHUB_INTAKE_WEBHOOK_PUBLIC_URL",
+            "GITHUB_INTAKE_WEBHOOK_HOOK_URL",
+        ):
+            os.environ.pop(key, None)
+
+    def tearDown(self) -> None:
+        os.environ.clear()
+        os.environ.update(self._old_environ)
+
+    def test_admin_and_webhook_env_overrides_win_over_snapshots(self) -> None:
+        os.environ["GITHUB_INTAKE_ADMIN_PUBLIC_URL"] = "https://admin.example/svc"
+        os.environ["GITHUB_INTAKE_WEBHOOK_PUBLIC_URL"] = "https://hooks.example/base"
+
+        self.assertEqual(common.admin_url(), "https://admin.example/svc")
+        self.assertEqual(common.webhook_url(), "https://hooks.example/base")
+
+    def test_overrides_resolve_from_city_workspace_env(self) -> None:
+        pathlib.Path(self.tempdir.name, "city.toml").write_text(
+            '[workspace]\n[workspace.env]\n'
+            'GITHUB_INTAKE_ADMIN_PUBLIC_URL = "https://admin.city/svc"\n'
+            'GITHUB_INTAKE_WEBHOOK_HOOK_URL = "https://hooks.city/me/github/webhook"\n',
+            encoding="utf-8",
+        )
+
+        self.assertEqual(common.admin_url(), "https://admin.city/svc")
+        manifest = common.build_manifest()
+        self.assertEqual(manifest["hook_attributes"]["url"], "https://hooks.city/me/github/webhook")
+        self.assertEqual(
+            manifest["redirect_url"],
+            "https://admin.city/svc/v0/github/app/manifest/callback",
+        )
+
+    def test_hook_url_override_used_verbatim_over_derived_path(self) -> None:
+        os.environ["GITHUB_INTAKE_ADMIN_PUBLIC_URL"] = "https://admin.example"
+        os.environ["GITHUB_INTAKE_WEBHOOK_PUBLIC_URL"] = "https://hooks.example/base"
+        os.environ["GITHUB_INTAKE_WEBHOOK_HOOK_URL"] = "https://edge.example/paxel-city/github/webhook"
+
+        manifest = common.build_manifest()
+
+        self.assertEqual(manifest["hook_attributes"]["url"], "https://edge.example/paxel-city/github/webhook")
+
+    def test_build_manifest_still_requires_some_urls(self) -> None:
+        with self.assertRaisesRegex(ValueError, "published admin and webhook URLs"):
+            common.build_manifest()
+
+
 class GitHubIntakePublishIdentityTests(unittest.TestCase):
     def setUp(self) -> None:
         self.tempdir = tempfile.TemporaryDirectory()


### PR DESCRIPTION
Self-hosted cities have no gc publication provider, so `admin_url()`/`webhook_url()` always came back empty and the App Setup page could never render the manifest ("published admin and webhook URLs are required").

Adds three deployment knobs, resolved from process env then city.toml `[workspace.env]` (service processes do not inherit workspace env):

- `GITHUB_INTAKE_ADMIN_PUBLIC_URL` — admin page base + manifest redirect/callback
- `GITHUB_INTAKE_WEBHOOK_PUBLIC_URL` — webhook base
- `GITHUB_INTAKE_WEBHOOK_HOOK_URL` — exact delivery URL placed in the manifest, for edges whose path shape differs from the service-native `/v0/github/webhook` suffix

Publication snapshots remain the default when no override is set. Tests cover env-wins-over-snapshot, workspace-env resolution, verbatim hook override, and the still-required failure path. Full pack suite green (111 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)