### PR TITLE
fix(gastown): port polecat push verification and digest city scoping; release 0.1.4

### DIFF
--- a/gastown/agents/polecat/prompt.template.md
+++ b/gastown/agents/polecat/prompt.template.md
@@ -269,7 +269,16 @@ if [ "$AUTO_PUSH" = "false" ]; then
   gc runtime drain-ack
   exit 0
 fi
-git push origin HEAD
+git push origin HEAD && {
+  BRANCH=$(git branch --show-current)
+  REMOTE_REF=$(git ls-remote origin "refs/heads/$BRANCH" 2>/dev/null | awk '{print $1}')
+  LOCAL_HEAD=$(git rev-parse HEAD)
+  if [ -z "$REMOTE_REF" ] || [ "$REMOTE_REF" != "$LOCAL_HEAD" ]; then
+    echo "PUSH VERIFICATION FAILED: origin/$BRANCH does not match local HEAD. Aborting handoff."
+    gc runtime drain-ack
+    exit 1
+  fi
+} || { echo "PUSH FAILED. Aborting handoff — bead stays with polecat."; gc runtime drain-ack; exit 1; }
 gc bd update <work-bead> \
   --set-metadata branch=$(git branch --show-current) \
   --set-metadata target={{ .DefaultBranch }} \

--- a/gastown/formulas/mol-polecat-work.toml
+++ b/gastown/formulas/mol-polecat-work.toml
@@ -366,6 +366,34 @@ if [ "$AUTO_PUSH" = "false" ]; then
   exit 0
 fi
 git push origin HEAD
+PUSH_EXIT=$?
+if [ $PUSH_EXIT -ne 0 ]; then
+    echo "PUSH FAILED (exit $PUSH_EXIT)"
+    echo "Branch '$CURRENT_BRANCH' was NOT pushed to origin."
+    echo "Aborting handoff — bead stays with polecat."
+    echo ""
+    echo "Diagnose the push failure (network, auth, force-needed?) and re-run submit-and-exit."
+    gc runtime drain-ack
+    exit 1
+fi
+# Verify the ref is reachable on origin before trusting the push succeeded.
+REMOTE_REF=$(git ls-remote origin "refs/heads/$CURRENT_BRANCH" 2>/dev/null | awk '{print $1}')
+LOCAL_HEAD=$(git rev-parse HEAD)
+if [ -z "$REMOTE_REF" ]; then
+    echo "PUSH VERIFICATION FAILED"
+    echo "  git push exited 0 but 'git ls-remote' returned no ref for '$CURRENT_BRANCH' on origin."
+    echo "  Branch is local-only. Aborting handoff."
+    gc runtime drain-ack
+    exit 1
+fi
+if [ "$REMOTE_REF" != "$LOCAL_HEAD" ]; then
+    echo "PUSH VERIFICATION FAILED"
+    echo "  origin/$CURRENT_BRANCH = $REMOTE_REF"
+    echo "  local HEAD             = $LOCAL_HEAD"
+    echo "  Branch tip on origin does not match local HEAD. Aborting handoff."
+    gc runtime drain-ack
+    exit 1
+fi
 ```
 
 **4. Clean up local branch (prevent stale branch accumulation):**

--- a/gastown/orders/digest-generate.toml
+++ b/gastown/orders/digest-generate.toml
@@ -1,5 +1,12 @@
 [order]
 description = "Generate daily code digest across all rigs"
+# City-scoped: one digest already covers every rig, so register a single
+# city-level instance instead of one per importing rig. Without this, the
+# gastown pack's per-rig import projects a digest-generate order onto every
+# rig; those per-rig instances never fire (only the city instance reaches the
+# city-level `dog` pool), so they sit perpetually overdue and trip the
+# order-firing-current doctor check.
+scope = "city"
 formula = "mol-digest-generate"
 trigger = "cooldown"
 interval = "24h"

--- a/gastown/template-fragments/approval-fallacy.template.md
+++ b/gastown/template-fragments/approval-fallacy.template.md
@@ -36,7 +36,16 @@ if [ "$AUTO_PUSH" = "false" ]; then
   gc runtime drain-ack
   exit 0
 fi
-git push origin HEAD
+git push origin HEAD && {
+  BRANCH=$(git branch --show-current)
+  REMOTE_REF=$(git ls-remote origin "refs/heads/$BRANCH" 2>/dev/null | awk '{print $1}')
+  LOCAL_HEAD=$(git rev-parse HEAD)
+  if [ -z "$REMOTE_REF" ] || [ "$REMOTE_REF" != "$LOCAL_HEAD" ]; then
+    echo "PUSH VERIFICATION FAILED: origin/$BRANCH does not match local HEAD. Aborting handoff."
+    gc runtime drain-ack
+    exit 1
+  fi
+} || { echo "PUSH FAILED. Aborting handoff — bead stays with polecat."; gc runtime drain-ack; exit 1; }
 gc bd update <work-bead> \
   --set-metadata branch=$(git branch --show-current) \
   --set-metadata target={{ .DefaultBranch }} \

--- a/registry.toml
+++ b/registry.toml
@@ -47,6 +47,13 @@ source_kind = "git"
   hash = "sha256:d1be2da74dfbeee2ae15f093c542de68becdb7d86dab06351313f2faf9b482b3"
   description = "Mark pack test scripts executable (consumer smoke tests require +x on pack scripts)."
 
+  [[pack.release]]
+  version = "0.1.4"
+  ref = "main"
+  commit = "fa91a3b4f1fe5cc9d1ba9ffbdd2d26274680adf9"
+  hash = "sha256:4b7e1331d2cac43334c32a2cbb1d267868c6ec1fb36b2e1beba59568383fe802"
+  description = "Polecat verifies the pushed remote ref before refinery handoff; digest-generate order is city-scoped (ports gascity #3339 and #3320)."
+
 [[pack]]
 name = "cass"
 description = "Coding Agent Session Search prompt fragments and skill overlays for Gas City."


### PR DESCRIPTION
Ports two pack-content fixes that landed on gastownhall/gascity main against the (since removed) vendored pack copy, so the registry pack carries the canonical behavior:

- **verify polecat push before refinery handoff** (gascity `fa38387dc`, gastownhall/gascity#3339): polecat prompt, mol-polecat-work formula, and approval-fallacy fragment verify the pushed remote ref matches local HEAD before refinery handoff, and abort the handoff on push failure.
- **scope digest-generate order to city** (gascity `f98cd4ae5`, gastownhall/gascity#3320): stops non-firing per-rig copies of the digest-generate order.

Adds registry release `gastown 0.1.4` pinning the port commit (`fa91a3b`, hash computed with the consumer pin-script algorithm).

Needed by gastownhall/gascity#3335, which replaces the vendored pack with this module: gascity main's tests assert the push-verification contract, so the registry pack must contain it before that PR can go green.

**Merge note: use a merge commit (not squash/rebase)** — the registry entry pins commit `fa91a3b4f1fe` by SHA, which must stay reachable from main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)