### PR TITLE
fix(slack-full): redact pre-signed uploadURL token in slackPutFileBytes errors

### DIFF
--- a/slack-full/adapter/main.go
+++ b/slack-full/adapter/main.go
@@ -1714,7 +1714,16 @@ func slackPutFileBytes(uploadURL string, filename string, body []byte) error {
 	defer resp.Body.Close()
 	if resp.StatusCode >= 300 {
 		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return fmt.Errorf("upload POST %s: %s — %s", uploadURL, resp.Status, string(respBody))
+		// Redact the pre-signed upload URL — its query string carries a
+		// short-lived auth token; strip RawQuery so it does not reach adapter
+		// logs verbatim. url.Redacted() alone only handles userinfo passwords
+		// and would leave query-string tokens intact.
+		safeURL := uploadURL
+		if u, perr := url.Parse(uploadURL); perr == nil {
+			u.RawQuery = ""
+			safeURL = u.String()
+		}
+		return fmt.Errorf("upload POST %s: %s — %s", safeURL, resp.Status, string(respBody))
 	}
 	_, _ = io.Copy(io.Discard, resp.Body)
 	return nil

--- a/slack-full/adapter/main_test.go
+++ b/slack-full/adapter/main_test.go
@@ -2974,6 +2974,35 @@ func TestSlackDownloadToFileRedactsUserinfoInError(t *testing.T) {
 	}
 }
 
+func TestSlackPutFileBytesRedactsTokenInError(t *testing.T) {
+	// Pre-signed Slack upload URLs carry auth tokens in query parameters
+	// (e.g. ?token=xoxe-...). A non-2xx response must not echo the raw
+	// URL — and its embedded token — into the error string that reaches
+	// adapter logs. url.URL.Redacted() replaces query values with "xxxxx".
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte("forbidden"))
+	}))
+	defer srv.Close()
+
+	u, _ := url.Parse(srv.URL + "/upload")
+	q := u.Query()
+	q.Set("token", "xoxe-supersecret-upload-token")
+	u.RawQuery = q.Encode()
+	tokenURL := u.String()
+
+	err := slackPutFileBytes(tokenURL, "test.txt", []byte("hello"))
+	if err == nil {
+		t.Fatal("expected error from non-2xx upload server, got nil")
+	}
+	if strings.Contains(err.Error(), "xoxe-supersecret-upload-token") {
+		t.Errorf("pre-signed token leaked in error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "upload POST") {
+		t.Errorf("expected error to contain 'upload POST', got: %v", err)
+	}
+}
+
 func TestSlackDownloadToFileRejectsNonSlackHostHTTPS(t *testing.T) {
 	// Forged url_private pointing at a local TLS server. If the SSRF gate
 	// works, slackDownloadToFile must NOT make the HTTP request — verified


### PR DESCRIPTION
`slackPutFileBytes` error paths embedded the full pre-signed `getUploadURLExternal` URL — including its auth token — in error strings that propagate to logs and agent transcripts.

- redact via `url.Parse` + `RawQuery` strip before formatting the error (with test)
- audited `slack-channel` and `slack-mini`: neither has the `slackPutFileBytes` / `getUploadURLExternal` pattern, no port needed

Port of a fork-local fix originally authored against the pre-split `slack-pack/` layout, re-based fresh onto upstream `main` per the tiered restructure (same pattern as #69/#72). `go test -race` clean.