### PR TITLE
fix(refinery): make gc.routed_to=polecat un-droppable on reject paths

### DIFF
--- a/gastown/formulas/mol-refinery-patrol.toml
+++ b/gastown/formulas/mol-refinery-patrol.toml
@@ -196,7 +196,18 @@ If rebase FAILED (conflicts):
 ```bash
 gc workflow delete-source $WORK --apply && gc workflow reopen-source $WORK
 ```
-3. Put the work bead back in the pool with rejection metadata:
+3. Put the work bead back in the POLECAT POOL with rejection metadata.
+
+   Setting `status=open` + `assignee=""` is NOT sufficient on its own. An
+   open, unassigned bead that is still routed to the refinery sits in nobody's
+   queue — the refinery will not re-fix it and no polecat will ever see it, so
+   it is stranded forever. The `--set-metadata gc.routed_to=...polecat` line is
+   THE ONLY thing that hands the bead to a polecat to fix the conflict. Without
+   it, the reject silently strands the bead.
+
+   Run this as a SINGLE atomic `gc bd update` EXACTLY as written — do not
+   paraphrase, shorten, split, or drop any line (the routing must stay welded
+   to the reject so it cannot be separated):
 ```bash
 gc bd update $WORK \
   --status=open \
@@ -204,6 +215,14 @@ gc bd update $WORK \
   --set-metadata rejection_reason="Conflicts with $TARGET at $(git rev-parse origin/$TARGET)" \
   --set-metadata gc.routed_to="${GC_RIG:+$GC_RIG/}{{binding_prefix}}polecat"
 ```
+
+   Then VERIFY the routing landed on the polecat pool, not the refinery:
+```bash
+gc bd show $WORK --json | jq -r '.[0].metadata."gc.routed_to"'
+```
+   This MUST print the polecat pool target (e.g. `<rig>/{{binding_prefix}}polecat`),
+   NOT the refinery. If it shows the refinery (or empty), the routing was
+   dropped — re-run the `gc bd update` above before continuing.
 4. Do NOT delete the branch (new polecat needs it for conflict resolution).
 5. Clean up temp branch: `git checkout {{target_branch}} && git branch -D temp`
 6. Pour next patrol iteration before burning:
@@ -268,7 +287,18 @@ TARGET=$(gc bd show $WORK --json | jq -r '.[0].metadata.target // "{{target_bran
      ```bash
      gc workflow delete-source $WORK --apply && gc workflow reopen-source $WORK
      ```
-   - Put the work bead back in the pool with rejection metadata:
+   - Put the work bead back in the POLECAT POOL with rejection metadata.
+
+     Setting `status=open` + `assignee=""` is NOT sufficient on its own. An
+     open, unassigned bead that is still routed to the refinery sits in
+     nobody's queue — the refinery will not re-fix it and no polecat will ever
+     see it, so it is stranded forever. The `--set-metadata gc.routed_to=...polecat`
+     line is THE ONLY thing that hands the bead to a polecat to fix the
+     failure. Without it, the reject silently strands the bead.
+
+     Run this as a SINGLE atomic `gc bd update` EXACTLY as written — do not
+     paraphrase, shorten, split, or drop any line (the routing must stay welded
+     to the reject so it cannot be separated):
      ```bash
      gc bd update $WORK \
        --status=open \
@@ -276,6 +306,14 @@ TARGET=$(gc bd show $WORK --json | jq -r '.[0].metadata.target // "{{target_bran
        --set-metadata rejection_reason="<failure summary>" \
        --set-metadata gc.routed_to="${GC_RIG:+$GC_RIG/}{{binding_prefix}}polecat"
      ```
+   - VERIFY the routing landed on the polecat pool, not the refinery:
+     ```bash
+     gc bd show $WORK --json | jq -r '.[0].metadata."gc.routed_to"'
+     ```
+     This MUST print the polecat pool target (e.g.
+     `<rig>/{{binding_prefix}}polecat`), NOT the refinery. If it shows the
+     refinery (or empty), the routing was dropped — re-run the `gc bd update`
+     above before continuing.
    - Delete branch: `git push origin --delete $BRANCH`
    - Clean up: `git checkout "$TARGET" && git branch -D temp`
    - Pour next patrol iteration before burning:


### PR DESCRIPTION
# fix(refinery): make gc.routed_to=polecat un-droppable on reject paths

## Problem

Both refinery reject paths — rebase-conflict and test/gate-failure — contain a
multi-line `gc bd update` block that is supposed to hand rejected work beads back
to the polecat pool. In practice, agents paraphrase the block. The heading "Put the
work bead back in the pool with rejection metadata" reads like "set open + unassign",
and `gc.routed_to=...polecat` is the fifth line of that block. Agents compose a
shorter command and drop the routing line entirely.

The consequence is silent data loss in the work queue:

- The bead ends up `status=open`, `assignee=""`, `gc.routed_to=<rig>/refinery`.
- The refinery's find-work query filters on `assignee=$GC_AGENT` — skips it.
- The polecat pool's scale-check queries `gc.routed_to=<polecat>` — never sees it.
- The orphan-sweep checks for beads assigned to dead agents — misses it (unassigned).

The bead is in nobody's queue. No polecat ever picks it up to fix the failure
described in `rejection_reason`. In production we observed ~24 merge beads stranded
12h+ after rejection, and the issue caused the rig to go fully idle twice in one
session: 18 ready beads, 0 polecats, 0 demand signal, dispatcher asleep.

## Root cause

The `gc.routed_to` line is the **only** thing that routes the bead to a polecat. The
surrounding text did not make this clear, so agents treated it as optional metadata.
Nothing in the command block signalled that omitting it silently strands the bead.

## Fix

Reword both reject paths (rebase-conflict path around line 196; test/gate-failure
path around line 287) so the routing is un-droppable:

1. **Rename the step heading** from "pool" (vague) to "POLECAT POOL" (explicit about
   the destination).
2. **Add a plain-language warning** immediately before the command block: setting
   `status=open` + `assignee=""` is NOT sufficient; an open, unassigned bead still
   routed to the refinery sits in nobody's queue. The `gc.routed_to` line is the ONLY
   thing that hands the bead to a polecat.
3. **Require atomic execution**: instruct the agent to run the entire `gc bd update`
   as a single command exactly as written — no paraphrasing, no splitting, no dropping
   lines. The routing must stay welded to the reject.
4. **Add a post-update verify step**: `gc bd show $WORK --json | jq -r '.[0].metadata."gc.routed_to"'` 
   must print the polecat pool target, not the refinery. If it shows the refinery (or
   is empty), the routing was dropped and the agent must re-run the update before
   continuing.

The command blocks themselves are unchanged — only the surrounding instruction text is
updated. This is a prompt-layer fix: the model needs to understand the consequence of
omitting the routing line, not a different command structure.

## Files changed

- `gastown/formulas/mol-refinery-patrol.toml`: +40 lines of instructional text
  around the two reject-path `gc bd update` blocks. No command syntax changed.

## Impact

Without this fix, every refinery rejection that an agent paraphrases results in a
bead permanently stranded unless manually rescued. With it, the verify step catches
any dropped routing before the agent moves on, and the explicit warning makes the
consequence of paraphrasing legible to the model.
