### PR TITLE
feat(maintenance): rig-agent liveness + merge-freshness watchdog order

### DIFF
--- a/maintenance/assets/scripts/rig-liveness-watchdog.sh
+++ b/maintenance/assets/scripts/rig-liveness-watchdog.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# rig-liveness-watchdog — deterministic per-rig agent + merge-freshness watchdog.
+#
+# Catches the failure where a critical rig agent (refinery / witness) silently
+# dies, or the refinery stalls with a non-empty merge queue, with NO alert.
+# This is a plain exec order (no LLM, no agent, no wisp) precisely BECAUSE the
+# Witness LLM patrol loop is the thing that silently dies — a deterministic
+# shell tick survives where an agent loop does not.
+#
+# For every non-suspended, running rig in the city it checks:
+#
+#   1. The rig's `refinery` and `witness` sessions are alive. A session is
+#      DEAD when it is missing entirely or its state is one of the hard-dead
+#      states (crashed / creating / failed-create / closed). `asleep`,
+#      `active`, `awake`, `running` are all ALIVE (an idle refinery sleeps).
+#
+#   2. Merge freshness: the refinery has merged to the rig's default branch
+#      within $WATCHDOG_FRESH_MIN minutes (last commit time on the default
+#      branch), OR its merge queue is genuinely empty (no open/in_progress
+#      beads assigned to the refinery and no ready in_progress work). If the
+#      queue is NON-empty AND there has been no merge inside the window, that
+#      is a STALL.
+#
+# On any detected dead-agent or stall it mails a LOUD [INCIDENT] escalation to
+# $WATCHDOG_ESCALATE_TO (default: mayor) with concrete evidence. A JSON ledger
+# de-dups: the same incident only re-alerts every $WATCHDOG_REALERT_TICKS ticks
+# or when its symptom changes, so a persistent stall does not spam every tick.
+#
+# Config (all env-overridable, upstream-friendly defaults):
+#   WATCHDOG_ESCALATE_TO   recipient for incident mail        (default: mayor)
+#   WATCHDOG_FRESH_MIN     merge-freshness window, minutes    (default: 60)
+#   WATCHDOG_REALERT_TICKS re-alert cadence for a live incident (default: 5)
+set -euo pipefail
+
+# Trace bd/gc invocations to $GC_BD_TRACE_JSON when set (no-op otherwise).
+__SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+. "$__SCRIPT_DIR/_bd_trace.sh" "rig-liveness-watchdog"
+
+ESCALATE_TO="${WATCHDOG_ESCALATE_TO:-mayor}"
+FRESH_MIN="${WATCHDOG_FRESH_MIN:-60}"
+REALERT_TICKS="${WATCHDOG_REALERT_TICKS:-5}"
+
+CITY="${GC_CITY:-.}"
+PACK_STATE_DIR="${GC_PACK_STATE_DIR:-${GC_CITY_RUNTIME_DIR:-$CITY/.gc/runtime}/packs/maintenance}"
+LEDGER="$PACK_STATE_DIR/rig-liveness-incidents.json"
+mkdir -p "$PACK_STATE_DIR"
+[ -f "$LEDGER" ] || echo '{}' > "$LEDGER"
+
+NOW=$(date +%s)
+FRESH_SECS=$((FRESH_MIN * 60))
+
+# normalize_sessions — tolerate both the v1.1.1 object shape
+# ({filters,ok,schema_version,sessions,summary}) and the OLD flat top-level
+# array. `(.sessions? // .)` yields the array in both cases; `arrays` then
+# only passes through when the result really is an array, so a scalar/object
+# never errors or leaks a non-session row.
+SESSIONS_JQ='(.sessions? // .) | if type == "array" then . else [] end'
+
+# Hard-dead session states: missing maps to "absent" below; these are the
+# states that mean a present session is not doing useful work and will not
+# recover on its own.
+is_dead_state() {
+    case "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" in
+        crashed|creating|failed-create|failed_create|closed|"") return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+COUNTS=$(cat "$LEDGER")
+INCIDENTS=0
+declare -A SEEN_KEYS=()
+
+# escalate — emit a de-duped [INCIDENT] mail. Args:
+#   $1 incident key (rig:agent:symptom-class), $2 subject, $3 body
+escalate() {
+    local key="$1" subject="$2" body="$3"
+    local prev
+    SEEN_KEYS["$key"]=1
+    prev=$(printf '%s' "$COUNTS" | jq -r --arg k "$key" '.[$k] // 0' 2>/dev/null) || prev=0
+    # Re-alert only every REALERT_TICKS ticks while an incident persists.
+    if [ "$prev" -gt 0 ] && [ $((prev % REALERT_TICKS)) -ne 0 ]; then
+        COUNTS=$(printf '%s' "$COUNTS" | jq --arg k "$key" '.[$k] = ((.[$k] // 0) + 1)' 2>/dev/null) || true
+        return 0
+    fi
+    gc mail send "$ESCALATE_TO" -s "$subject" -m "$body" 2>/dev/null || true
+    COUNTS=$(printf '%s' "$COUNTS" | jq --arg k "$key" '.[$k] = ((.[$k] // 0) + 1)' 2>/dev/null) || true
+    INCIDENTS=$((INCIDENTS + 1))
+}
+
+# Discover rigs the same way sibling maintenance scripts do.
+RIG_JSON=$(gc rig list --json 2>/dev/null) || exit 0
+[ -n "$RIG_JSON" ] || exit 0
+
+while IFS=$'\t' read -r rig rig_path default_branch; do
+    [ -z "$rig" ] && continue
+
+    # Pull this rig's sessions once; tolerate both JSON shapes.
+    sess=$(gc --rig "$rig" session list --json 2>/dev/null) || sess=""
+    [ -n "$sess" ] || sess='[]'
+
+    # State of the named role's session, or "absent" if no such session.
+    role_state() {
+        local role="$1"
+        printf '%s' "$sess" | jq -r --arg role "$role" "
+            [ $SESSIONS_JQ
+              | .[]
+              | select(((.name // \"\") | test(\"\\\\.\" + \$role + \"\$\"))
+                       or ((.agent_name // \"\") | test(\"\\\\.\" + \$role + \"\$\"))
+                       or ((.role // \"\") | test(\"\\\\.\" + \$role + \"\$\"))) ]
+            | (.[0].state // \"absent\")
+        " 2>/dev/null || printf 'absent'
+    }
+
+    witness_state=$(role_state witness)
+    refinery_state=$(role_state refinery)
+    [ -n "$witness_state" ] || witness_state="absent"
+    [ -n "$refinery_state" ] || refinery_state="absent"
+
+    # --- Check 1: witness must be alive (it never legitimately sleeps off). ---
+    if is_dead_state "$witness_state"; then
+        symptom="$witness_state"
+        [ "$symptom" = "" ] && symptom="missing"
+        escalate "$rig:witness:dead" \
+            "[INCIDENT] rig $rig: witness $symptom" \
+            "Watchdog tick $(date -u +%Y-%m-%dT%H:%M:%SZ): the witness session for rig '$rig' is $symptom.
+The witness LLM patrol loop is not alive and will not self-recover.
+
+Evidence:
+  rig            = $rig
+  witness state  = $witness_state
+  refinery state = $refinery_state
+  default branch = $default_branch
+
+Action: gc session reset $rig/<witness-alias>  (or respawn the rig witness)."
+    fi
+
+    # --- Check 2: refinery dead-state OR merge-freshness stall. ---
+    # Merge queue depth: open/in_progress beads assigned to the refinery, plus
+    # ready in_progress work that still needs to merge.
+    queue=$(gc bd list --rig "$rig" --json --limit=0 2>/dev/null \
+        | jq '[ .[]
+                | select((.assignee // "") | test("refinery"))
+                | select(.status == "open" or .status == "in_progress")
+                | select((.ephemeral // false) != true) ] | length' 2>/dev/null) || queue=0
+    [ -n "$queue" ] || queue=0
+
+    # Last merge: last commit time on the rig's default branch. Missing repo /
+    # branch yields 0 (unknown) and is treated as "no recent merge".
+    last_merge=0
+    if [ -n "$rig_path" ] && [ -n "$default_branch" ] && [ -d "$rig_path/.git" ]; then
+        last_merge=$(git -C "$rig_path" log -1 --format='%ct' "$default_branch" 2>/dev/null) || last_merge=0
+    fi
+    [ -n "$last_merge" ] || last_merge=0
+    age=$((NOW - last_merge))
+    [ "$last_merge" -eq 0 ] && age=-1
+
+    if is_dead_state "$refinery_state"; then
+        symptom="$refinery_state"
+        [ "$symptom" = "" ] && symptom="missing"
+        escalate "$rig:refinery:dead" \
+            "[INCIDENT] rig $rig: refinery $symptom" \
+            "Watchdog tick $(date -u +%Y-%m-%dT%H:%M:%SZ): the refinery session for rig '$rig' is $symptom.
+
+Evidence:
+  rig             = $rig
+  refinery state  = $refinery_state
+  merge queue     = $queue bead(s)
+  last merge (s)  = $age ago on '$default_branch'
+  default branch  = $default_branch
+
+Action: investigate / gc session reset $rig/<refinery-alias>."
+    elif [ "$queue" -gt 0 ] && { [ "$last_merge" -eq 0 ] || [ "$age" -ge "$FRESH_SECS" ]; }; then
+        if [ "$last_merge" -eq 0 ]; then
+            mergeline="unknown (no commit found on '$default_branch')"
+        else
+            mergeline="$((age / 60)) min ago (window: $FRESH_MIN min)"
+        fi
+        escalate "$rig:refinery:stall" \
+            "[INCIDENT] rig $rig: refinery merge-stall" \
+            "Watchdog tick $(date -u +%Y-%m-%dT%H:%M:%SZ): rig '$rig' has a non-empty merge queue but no merge inside the freshness window.
+
+Evidence:
+  rig             = $rig
+  refinery state  = $refinery_state
+  merge queue     = $queue bead(s) routed to refinery / ready
+  last merge      = $mergeline
+  default branch  = $default_branch
+
+The refinery is not draining the queue. Action: check the refinery session,
+its current verification, and the default-branch gate state."
+    fi
+done < <(printf '%s' "$RIG_JSON" | jq -r '.rigs[]
+    | select(.hq == false)
+    | select(.suspended == false)
+    | select(.running == true)
+    | "\(.name)\t\(.path // "")\t\(.default_branch // "")"' 2>/dev/null)
+
+# Prune ledger keys for incidents that did NOT recur this tick (state cleared).
+PRUNED='{}'
+while IFS= read -r k; do
+    [ -z "$k" ] && continue
+    if [ -n "${SEEN_KEYS[$k]:-}" ]; then
+        v=$(printf '%s' "$COUNTS" | jq -r --arg k "$k" '.[$k] // 0' 2>/dev/null)
+        PRUNED=$(printf '%s' "$PRUNED" | jq --arg k "$k" --argjson v "${v:-0}" '.[$k] = $v' 2>/dev/null) || true
+    fi
+done < <(printf '%s' "$COUNTS" | jq -r 'keys[]' 2>/dev/null)
+COUNTS="$PRUNED"
+
+printf '%s' "$COUNTS" > "$LEDGER"
+
+if [ "$INCIDENTS" -gt 0 ]; then
+    echo "rig-liveness-watchdog: escalated $INCIDENTS incident(s)"
+fi

--- a/maintenance/assets/scripts/rig-liveness-watchdog.sh
+++ b/maintenance/assets/scripts/rig-liveness-watchdog.sh
@@ -32,6 +32,12 @@
 #   WATCHDOG_REALERT_TICKS re-alert cadence for a live incident (default: 5)
 set -euo pipefail
 
+# Requires bash 4+ for associative arrays (declare -A).
+if [ "${BASH_VERSINFO[0]:-0}" -lt 4 ]; then
+    echo "rig-liveness-watchdog: requires bash 4 or later (found ${BASH_VERSION:-unknown})" >&2
+    exit 1
+fi
+
 # Trace bd/gc invocations to $GC_BD_TRACE_JSON when set (no-op otherwise).
 __SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck disable=SC1091
@@ -62,7 +68,7 @@ SESSIONS_JQ='(.sessions? // .) | if type == "array" then . else [] end'
 # recover on its own.
 is_dead_state() {
     case "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" in
-        crashed|creating|failed-create|failed_create|closed|"") return 0 ;;
+        absent|crashed|creating|failed-create|failed_create|closed|"") return 0 ;;
         *) return 1 ;;
     esac
 }
@@ -119,8 +125,7 @@ while IFS=$'\t' read -r rig rig_path default_branch; do
 
     # --- Check 1: witness must be alive (it never legitimately sleeps off). ---
     if is_dead_state "$witness_state"; then
-        symptom="$witness_state"
-        [ "$symptom" = "" ] && symptom="missing"
+        symptom="${witness_state:-missing}"
         escalate "$rig:witness:dead" \
             "[INCIDENT] rig $rig: witness $symptom" \
             "Watchdog tick $(date -u +%Y-%m-%dT%H:%M:%SZ): the witness session for rig '$rig' is $symptom.
@@ -156,8 +161,7 @@ Action: gc session reset $rig/<witness-alias>  (or respawn the rig witness)."
     [ "$last_merge" -eq 0 ] && age=-1
 
     if is_dead_state "$refinery_state"; then
-        symptom="$refinery_state"
-        [ "$symptom" = "" ] && symptom="missing"
+        symptom="${refinery_state:-missing}"
         escalate "$rig:refinery:dead" \
             "[INCIDENT] rig $rig: refinery $symptom" \
             "Watchdog tick $(date -u +%Y-%m-%dT%H:%M:%SZ): the refinery session for rig '$rig' is $symptom.
@@ -201,8 +205,11 @@ PRUNED='{}'
 while IFS= read -r k; do
     [ -z "$k" ] && continue
     if [ -n "${SEEN_KEYS[$k]:-}" ]; then
-        v=$(printf '%s' "$COUNTS" | jq -r --arg k "$k" '.[$k] // 0' 2>/dev/null)
-        PRUNED=$(printf '%s' "$PRUNED" | jq --arg k "$k" --argjson v "${v:-0}" '.[$k] = $v' 2>/dev/null) || true
+        v=$(printf '%s' "$COUNTS" | jq -r --arg k "$k" '.[$k] // 0' 2>/dev/null) || v=0
+        PRUNED=$(printf '%s' "$PRUNED" | jq --arg k "$k" --argjson v "${v:-0}" '.[$k] = $v' 2>/dev/null) || {
+            echo "rig-liveness-watchdog: ledger prune failed for key '$k'; skipping ledger write" >&2
+            exit 1
+        }
     fi
 done < <(printf '%s' "$COUNTS" | jq -r 'keys[]' 2>/dev/null)
 COUNTS="$PRUNED"

--- a/maintenance/orders/rig-liveness-watchdog.toml
+++ b/maintenance/orders/rig-liveness-watchdog.toml
@@ -1,0 +1,20 @@
+# Deterministic per-rig agent + merge-freshness watchdog.
+#
+# Catches the failure where a critical rig agent (refinery / witness) silently
+# dies, or the refinery stalls with a non-empty merge queue, with no alert.
+# Implemented as a plain exec order (no LLM, no agent, no wisp) BECAUSE the
+# Witness LLM patrol loop is itself the thing that silently dies — a
+# deterministic shell tick survives where the agent loop does not.
+#
+# For every running, non-suspended rig it verifies the refinery + witness
+# sessions are alive and that the refinery is either merging within the
+# freshness window or has a genuinely empty queue. On a dead agent or stall it
+# mails a [INCIDENT] escalation (de-duped via a ledger) to WATCHDOG_ESCALATE_TO.
+#
+# Tunable via env (set on the controller): WATCHDOG_ESCALATE_TO (default mayor),
+# WATCHDOG_FRESH_MIN (default 60), WATCHDOG_REALERT_TICKS (default 5).
+[order]
+description = "Watchdog: rig refinery/witness liveness + refinery merge freshness"
+trigger = "cooldown"
+interval = "3m"
+exec = "$PACK_DIR/assets/scripts/rig-liveness-watchdog.sh"


### PR DESCRIPTION
# feat(maintenance): rig-agent liveness + merge-freshness watchdog order

## Problem

Witness patrol loops die silently. When a `witness` or `refinery` session
crashes, enters a `failed-create` state, or simply stops responding, nothing
fires an alert. The Witness LLM loop is responsible for detecting stalls — but
when the loop itself is the thing that died, there is no observer left to notice.
Operators find out hours later when they inspect a rig manually or notice no
commits have landed on the default branch.

Two failure classes go undetected today:

1. **Dead agent**: a `refinery` or `witness` session enters a hard-dead state
   (`crashed`, `failed-create`, `closed`, absent) and does not self-recover.
2. **Merge stall**: the `refinery` session is technically alive but is not
   draining its merge queue — the default branch has received no commit within
   the configured freshness window and there is work outstanding.

## Why a shell-based watchdog

The Witness LLM patrol loop is exactly the component that silently fails. Using
another agent or wisp to watch it introduces the same single point of failure in
a different costume. A deterministic shell exec order — one with no LLM, no
agent, no wisp — survives where an agent loop does not. It runs on a fixed
`cooldown` interval driven by the controller, which continues ticking regardless
of whether any user-configured agent role is alive.

This design follows the SDK's self-sufficiency invariant: the watchdog is a
plain exec order and makes no assumption about which role names exist in the
deploying city.

## What the watchdog checks

Every 3 minutes the order calls `maintenance/assets/scripts/rig-liveness-watchdog.sh`,
which:

1. Enumerates every running, non-suspended, non-HQ rig via `gc rig list --json`.
2. For each rig pulls session state via `gc --rig <name> session list --json`,
   normalizing across the current v1.1.1 `{sessions:[...]}` object shape and the
   legacy flat-array format.
3. **Liveness check**: a session is DEAD if its state is `absent` (no session
   record at all), `crashed`, `creating`, `failed-create`, `closed`, or empty.
   States `asleep`, `active`, `awake`, and `running` are all ALIVE (an idle
   refinery legitimately sleeps).
4. **Merge-freshness check**: if the refinery is alive but the queue is non-empty
   AND the last commit on the rig's default branch is older than
   `WATCHDOG_FRESH_MIN` minutes (default 60), that is a STALL.
5. On any dead agent or stall, mails a loud `[INCIDENT]` escalation with
   concrete evidence (state, queue depth, last-merge age, default branch) to the
   configured recipient.

## Key design choices

**JSON ledger de-duplication.** A JSON file at
`$GC_PACK_STATE_DIR/rig-liveness-incidents.json` tracks a tick count per
`rig:agent:symptom-class` key. An active incident only re-alerts every
`WATCHDOG_REALERT_TICKS` ticks (default 5, i.e. every 15 minutes). When an
incident clears — the symptom is no longer detected — its key is pruned from the
ledger, so it will alert immediately if it recurs. This eliminates per-tick spam
without silencing newly triggered or newly changed incidents.

**Symptom-keyed, not time-keyed.** The ledger key includes the symptom class
(`dead` vs `stall`), so if a refinery recovers from dead but then enters a
merge stall, that is treated as a new incident and alerts immediately regardless
of the tick count.

**Session-API shape normalization.** The `(.sessions? // .) | if type == "array" then . else [] end`
jq expression handles both the current object-wrapped shape and the older
top-level array in one line, with no branching in the shell layer. This means
the watchdog works across city deployments that have not yet upgraded.

**Configurable via environment variables** set on the controller — no
city-specific file edits required:

| Variable | Default | Meaning |
|---|---|---|
| `WATCHDOG_ESCALATE_TO` | `mayor` | Recipient for incident mail |
| `WATCHDOG_FRESH_MIN` | `60` | Merge freshness window (minutes) |
| `WATCHDOG_REALERT_TICKS` | `5` | Re-alert cadence for a live incident |

## What incidents this would have caught

- **Silent witness crash**: witness enters `crashed` state after a tmux
  reconnect; LLM patrol loop is gone; no bead is ever filed; no human notices
  until a PR review goes stale for a day.
- **Refinery merge stall with alive session**: refinery session is `asleep`
  (healthy-looking) but is blocked on a failing gate check with 8 beads in
  queue; default branch receives no commits for 4 hours; no alert fires.
- **Failed-create on rig restart**: operator restarts a rig; the refinery
  session hits a `failed-create` and the rig is left with no merge capacity;
  the witness is alive but cannot itself restart the refinery.

## Prerequisites

The watchdog uses `declare -A` (bash associative arrays), which requires bash 4
or later. Stock macOS ships bash 3.2; the script guards this at startup and
exits with a clear error if the version is too old. Deployers on macOS need
Homebrew bash (`brew install bash`) or any Linux distribution (bash 4+ ships
everywhere by default).

## Files changed

- `maintenance/assets/scripts/rig-liveness-watchdog.sh` — 214-line shell
  watchdog (new file, executable)
- `maintenance/orders/rig-liveness-watchdog.toml` — exec order wiring
  (new file, 3-minute cooldown interval)
