### PR TITLE
fix(maintenance): per-session cooldown for nudge-on-mail to stop spam

### DIFF
--- a/maintenance/assets/scripts/nudge-on-mail.sh
+++ b/maintenance/assets/scripts/nudge-on-mail.sh
@@ -7,14 +7,21 @@
 #
 # Subscribes to bead.created events; whenever a bead with issue_type=message
 # arrives it nudges the assignee session. Idempotent: a given bead_id is nudged
-# at most once. Dedup state lives in $GC_PACK_STATE_DIR/nudge-on-mail-state.json.
+# at most once per run; an assignee is nudged at most once per COOLDOWN window
+# across runs. Dedup state lives in $GC_PACK_STATE_DIR/nudge-on-mail-state.json.
+#
+# Note: concurrent runs are not serialised. Under parallel execution two
+# instances may both read state before either writes, causing a duplicate nudge
+# for the first bead a given assignee receives in that window. The controller's
+# exec-order serialisation should prevent this in normal operation.
 #
 # Runs as an exec order (no LLM, no agent, no wisp).
 set -euo pipefail
 
 __SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# _bd_trace.sh is optional instrumentation; source it only if present.
 # shellcheck disable=SC1091
-. "$__SCRIPT_DIR/_bd_trace.sh" "nudge-on-mail"
+[ -f "$__SCRIPT_DIR/_bd_trace.sh" ] && . "$__SCRIPT_DIR/_bd_trace.sh" "nudge-on-mail"
 
 if ! command -v jq >/dev/null 2>&1; then
     echo "nudge-on-mail: jq is required but not found in PATH" >&2
@@ -28,6 +35,8 @@ NUDGE_MESSAGE="${GC_NUDGE_ON_MAIL_MESSAGE:-You have new mail — run gc hook to 
 # Per-session rate limit: a given recipient is nudged at most once per
 # COOLDOWN, so a burst of mail (watchdog incidents, advisories, digests)
 # collapses into a single wake instead of one interruption per bead.
+# RETENTION must be >= COOLDOWN or session cooldown entries may be pruned
+# before the window expires, silently disabling the rate limit.
 COOLDOWN="${GC_NUDGE_ON_MAIL_COOLDOWN:-10m}"
 
 PACK_STATE_DIR="${GC_PACK_STATE_DIR:-${GC_CITY_RUNTIME_DIR:-$CITY/.gc/runtime}/packs/maintenance}"
@@ -61,16 +70,22 @@ PAIRS="$(printf '%s\n' "$EVENTS" \
 STATE="$(cat "$STATE_FILE" 2>/dev/null || true)"
 echo "$STATE" | jq -e 'type == "object"' >/dev/null 2>&1 || STATE='{}'
 
-NOW="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+RETENTION_S="$(duration_to_seconds "$RETENTION")"
 COOLDOWN_S="$(duration_to_seconds "$COOLDOWN")"
+if [ "$RETENTION_S" -lt "$COOLDOWN_S" ]; then
+    echo "nudge-on-mail: RETENTION ($RETENTION) is shorter than COOLDOWN ($COOLDOWN); session cooldowns will not be honoured" >&2
+fi
+
+NOW="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 NUDGED=0
 while IFS="$(printf '\t')" read -r bead_id assignee; do
     [ -n "$bead_id" ] || continue
     [ -n "$assignee" ] || continue
     key="$bead_id"
-    # Already processed this mail bead — refresh its timestamp and skip.
+    # Already processed this mail bead — skip. Do not refresh the timestamp;
+    # the entry should age from when it was first seen so retention prunes it
+    # correctly after RETENTION elapses.
     if echo "$STATE" | jq -e --arg k "$key" 'has($k)' >/dev/null 2>&1; then
-        STATE="$(echo "$STATE" | jq --arg k "$key" --arg now "$NOW" '.[$k] = $now')"
         continue
     fi
     # Record the bead as seen up front so a rate-limited burst is not
@@ -93,7 +108,6 @@ $PAIRS
 EOF
 
 # Prune entries older than RETENTION so the state file stays bounded.
-RETENTION_S="$(duration_to_seconds "$RETENTION")"
 STATE="$(echo "$STATE" | jq --argjson keep "$RETENTION_S" \
     'with_entries(select((now - (.value | fromdateiso8601)) <= $keep))')" || true
 

--- a/maintenance/assets/scripts/nudge-on-mail.sh
+++ b/maintenance/assets/scripts/nudge-on-mail.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# nudge-on-mail — wake a session the moment a mail bead (type=message) is
+# delivered to it. Mail delivery does not set gc.routed_to, so nudge-on-route
+# never fires for mail. Without this, the recipient only sees new mail when
+# a human types or a scheduled turn cycle fires — too slow for semi-autonomous
+# agents like the mayor that should act on escalations promptly.
+#
+# Subscribes to bead.created events; whenever a bead with issue_type=message
+# arrives it nudges the assignee session. Idempotent: a given bead_id is nudged
+# at most once. Dedup state lives in $GC_PACK_STATE_DIR/nudge-on-mail-state.json.
+#
+# Runs as an exec order (no LLM, no agent, no wisp).
+set -euo pipefail
+
+__SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+. "$__SCRIPT_DIR/_bd_trace.sh" "nudge-on-mail"
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "nudge-on-mail: jq is required but not found in PATH" >&2
+    exit 1
+fi
+
+CITY="${GC_CITY:-.}"
+LOOKBACK="${GC_NUDGE_ON_MAIL_LOOKBACK:-2m}"
+RETENTION="${GC_NUDGE_ON_MAIL_RETENTION:-1h}"
+NUDGE_MESSAGE="${GC_NUDGE_ON_MAIL_MESSAGE:-You have new mail — run gc hook to process it}"
+# Per-session rate limit: a given recipient is nudged at most once per
+# COOLDOWN, so a burst of mail (watchdog incidents, advisories, digests)
+# collapses into a single wake instead of one interruption per bead.
+COOLDOWN="${GC_NUDGE_ON_MAIL_COOLDOWN:-10m}"
+
+PACK_STATE_DIR="${GC_PACK_STATE_DIR:-${GC_CITY_RUNTIME_DIR:-$CITY/.gc/runtime}/packs/maintenance}"
+STATE_FILE="$PACK_STATE_DIR/nudge-on-mail-state.json"
+mkdir -p "$PACK_STATE_DIR"
+
+duration_to_seconds() {
+    case "$1" in
+        *h) echo $(( ${1%h} * 3600 )) ;;
+        *m) echo $(( ${1%m} * 60 )) ;;
+        *s) echo "${1%s}" ;;
+        *)  echo "$1" ;;
+    esac
+}
+
+# Pull recent bead.created events. Best-effort: failure must not crash the
+# controller's order loop.
+EVENTS="$(gc events --type bead.created --since "$LOOKBACK" 2>/dev/null)" || exit 0
+[ -n "$EVENTS" ] || exit 0
+
+# Extract unique "<bead_id>\t<assignee>" pairs for mail beads only.
+# Skip beads whose assignee is "human" — no session to nudge.
+PAIRS="$(printf '%s\n' "$EVENTS" \
+    | jq -r 'select(.payload.bead.issue_type == "message"
+                    and (.payload.bead.assignee // "") != ""
+                    and (.payload.bead.assignee // "") != "human")
+             | [.payload.bead.id, .payload.bead.assignee] | @tsv' 2>/dev/null \
+    | sort -u)" || PAIRS=""
+[ -n "$PAIRS" ] || exit 0
+
+STATE="$(cat "$STATE_FILE" 2>/dev/null || true)"
+echo "$STATE" | jq -e 'type == "object"' >/dev/null 2>&1 || STATE='{}'
+
+NOW="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+COOLDOWN_S="$(duration_to_seconds "$COOLDOWN")"
+NUDGED=0
+while IFS="$(printf '\t')" read -r bead_id assignee; do
+    [ -n "$bead_id" ] || continue
+    [ -n "$assignee" ] || continue
+    key="$bead_id"
+    # Already processed this mail bead — refresh its timestamp and skip.
+    if echo "$STATE" | jq -e --arg k "$key" 'has($k)' >/dev/null 2>&1; then
+        STATE="$(echo "$STATE" | jq --arg k "$key" --arg now "$NOW" '.[$k] = $now')"
+        continue
+    fi
+    # Record the bead as seen up front so a rate-limited burst is not
+    # re-evaluated on every subsequent tick.
+    STATE="$(echo "$STATE" | jq --arg k "$key" --arg now "$NOW" '.[$k] = $now')"
+    # Per-session rate limit: skip the nudge if this assignee was already
+    # nudged within COOLDOWN. Uses the same jq epoch clock as the retention
+    # prune below. Session entries are namespaced "session:<assignee>".
+    skey="session:$assignee"
+    if echo "$STATE" | jq -e --arg k "$skey" --argjson cd "$COOLDOWN_S" \
+        'has($k) and ((now - (.[$k] | fromdateiso8601)) < $cd)' >/dev/null 2>&1; then
+        continue
+    fi
+    if gc session nudge "$assignee" "$NUDGE_MESSAGE" >/dev/null 2>&1; then
+        STATE="$(echo "$STATE" | jq --arg k "$skey" --arg now "$NOW" '.[$k] = $now')"
+        NUDGED=$((NUDGED + 1))
+    fi
+done <<EOF
+$PAIRS
+EOF
+
+# Prune entries older than RETENTION so the state file stays bounded.
+RETENTION_S="$(duration_to_seconds "$RETENTION")"
+STATE="$(echo "$STATE" | jq --argjson keep "$RETENTION_S" \
+    'with_entries(select((now - (.value | fromdateiso8601)) <= $keep))')" || true
+
+TMP="$(mktemp "$PACK_STATE_DIR/.nudge-on-mail-state.XXXXXX")"
+printf '%s\n' "$STATE" > "$TMP"
+mv -f "$TMP" "$STATE_FILE"
+
+if [ "$NUDGED" -gt 0 ]; then
+    echo "nudge-on-mail: nudged $NUDGED session(s) for new mail"
+fi


### PR DESCRIPTION
# fix(maintenance): per-session cooldown for nudge-on-mail to stop spam

## Problem

`nudge-on-mail` wakes a session the moment a `type=message` bead is delivered
to it. Each bead triggers one nudge. Under normal operation — one mail, one
nudge — that's the right behaviour.

Under a watchdog incident the system emits a burst: an incident bead, one or
more advisory digests, and any related agent notifications, all delivered in
the same polling window. Before this fix every bead in that burst fired an
independent nudge, causing the recipient session to receive several rapid-fire
interruptions for the same underlying event. On a busy city with multiple
watchdog checks this produced enough noise that agents began dropping or
mishandling the extra wakes.

## Fix

Add a **per-assignee cooldown** gated by `GC_NUDGE_ON_MAIL_COOLDOWN`
(default `10m`).

When a new (unseen) mail bead arrives for an assignee:

1. The bead is recorded in state immediately so it is not re-evaluated on
   the next tick regardless of what happens to the nudge.
2. A cooldown check tests whether a `session:<assignee>` entry exists in
   state and whether fewer than `COOLDOWN` seconds have elapsed since the
   last nudge to that assignee.
3. If the assignee is still inside the cooldown window, the nudge is
   skipped. All beads in the burst are still marked seen, so none of them
   will generate a nudge on future ticks either.
4. If the assignee is outside the cooldown window (or has never been
   nudged), the nudge fires and the `session:<assignee>` timestamp is
   updated.

The result: a burst of ten mail beads collapses into a single wake. The
agent is notified once and then processes its full inbox — the correct
behaviour given GUPP ("if you find work on your hook, you run it").

## Configuration

| Variable | Default | Meaning |
|---|---|---|
| `GC_NUDGE_ON_MAIL_COOLDOWN` | `10m` | Minimum gap between nudges to the same assignee |

The existing `GC_NUDGE_ON_MAIL_LOOKBACK` and `GC_NUDGE_ON_MAIL_RETENTION`
variables are unchanged. The cooldown state is namespaced `session:<assignee>`
in the same state file as bead-seen entries and is pruned by the same
retention sweep.

## Implementation notes

- `duration_to_seconds` already existed; `COOLDOWN_S` uses it the same way
  `RETENTION_S` does.
- The `fromdateiso8601` + `now` pattern is already used for the retention
  prune — cooldown reuses the same jq clock, so there is no new time-handling
  logic.
- The bead-seen entry is written **before** the nudge attempt so a transient
  nudge failure does not cause the same bead to re-evaluate the cooldown on
  the next tick. The `session:<assignee>` cooldown entry is written **only on
  a successful nudge**: a persistent nudge failure (session down) will not
  set a cooldown, so the next new bead for that assignee will retry — which
  is the correct behaviour for a downed session.
- `_bd_trace.sh` is sourced only if present (`[ -f ... ] && . ...`). It is
  optional instrumentation; the script functions fully without it.
- **Invariant:** `RETENTION` must be >= `COOLDOWN` or session cooldown entries
  may be pruned before the window expires. The script now emits a warning to
  stderr at startup if this is violated. With defaults (RETENTION=1h,
  COOLDOWN=10m) the invariant holds comfortably.
- `RETENTION_S` is now computed before the main loop (alongside `COOLDOWN_S`)
  so the invariant check fires before any state is mutated.

## Testing

Deploy against a city with a watchdog formula. Trigger a watchdog incident
(or manually create multiple mail beads for the same assignee within 10
minutes). Confirm the recipient session receives exactly one nudge per
`GC_NUDGE_ON_MAIL_COOLDOWN` window rather than one per bead.
