### PR TITLE
fix(deacon): add bug-filing routing rules and no-idle-cycle enforcement

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,48 @@
+# fix(deacon): add bug-filing routing rules and no-idle-cycle enforcement
+
+## Summary
+
+This PR fixes two independent behavioral bugs in the deacon prompt that surface in production Gas Town deployments.
+
+---
+
+## Problem 1: Bugs filed to the wrong polecat pool
+
+The deacon's patrol cycle discovers bugs and infrastructure issues. Without explicit routing guidance, deacon agents were routing all bugs to whatever polecat pool was available — including rig-scoped polecats (e.g. `my-rig/gastown.polecat`) for gastown infrastructure bugs. A rig-scoped polecat operates inside a single git worktree and has no access to the gastown/gc source tree. It claims the bead, spins its wheels, and either stalls or produces incorrect output.
+
+**Fix:** Added an explicit routing table and decision rule to the prompt:
+
+- Rig-specific bugs → `gc bd create --rig <rig>` + sling to that rig's polecat
+- Gastown infrastructure bugs → `gc bd create --rig gastown` + mail mayor for triage
+- Cross-rig / unclear → HQ bead + mail mayor
+
+The guiding heuristic is "which git repo would the fix land in?" — file there. The prompt also now explicitly prohibits setting `gc.routed_to` for anything that needs mayor triage, because a wrong pool assignment is worse than an empty one.
+
+---
+
+## Problem 2: Deacon enters idle state between patrol cycles
+
+After completing a patrol cycle, the `next-iteration` formula step pours the next `mol-deacon-patrol` wisp and assigns it to the deacon before burning the current one. However, without explicit instruction to run `gc hook` immediately, deacon agents would emit the phrase "Standing by for the next hook" and wait passively — effectively halting the patrol loop until manually nudged.
+
+**Fix:** Added a "No Idle State Between Cycles" section that:
+
+1. Instructs the deacon to run `gc hook` immediately after `next-iteration` completes
+2. Flags "Standing by for the next hook" as a bug indicator
+3. Provides a crash-recovery bash snippet for the edge case where the deacon exited a cycle without running `next-iteration` (e.g. context exhaustion mid-formula) — it pours a fresh wisp, assigns it, and burns the stale one before calling `gc hook`
+
+---
+
+## Why upstream users hit this
+
+Any Gas Town deployment running a deacon patrol loop will encounter both issues:
+
+- **Routing bug:** surfaces as soon as the deacon files its first infrastructure or ambiguous bug — easy to miss initially because the bead appears to be handled, but the assigned polecat makes no progress.
+- **Idle cycle bug:** surfaces on every patrol cycle completion — the deacon goes passive and requires an operator or mayor to nudge it back into the loop. High-frequency patrols (every few minutes) make this extremely disruptive.
+
+Neither fix introduces new primitives or changes any Go code. Both are purely prompt-level behavioral corrections in `gastown/agents/deacon/prompt.template.md`.
+
+---
+
+## Files changed
+
+- `gastown/agents/deacon/prompt.template.md` — 80 lines added, 1 line changed

--- a/gastown/agents/deacon/prompt.template.md
+++ b/gastown/agents/deacon/prompt.template.md
@@ -33,6 +33,7 @@ Your job:
 - Kill agents directly (file warrants, dog pool runs shutdown dance)
 - Pool sizing (controller pool reconciliation)
 - Per-rig polecat health monitoring (witness handles this)
+- Route bugs to a polecat pool without verifying rig scope (file in the right rig; mail mayor if unsure)
 
 {{ template "architecture" . }}
 
@@ -59,14 +60,14 @@ Your formula: `mol-deacon-patrol`
 
 ```bash
 # Step 1: Check for assigned work
-gc bd list --assignee="$GC_ALIAS" --status=in_progress
+gc bd list --assignee="$GC_AGENT" --status=in_progress
 
 # Step 2: Nothing? Check mail for attached work
 gc mail inbox
 
 # Step 3: Still nothing? Create patrol wisp (root-only — no child step beads)
 NEW_WISP=$(gc bd mol wisp mol-deacon-patrol --root-only --var binding_prefix={{ .BindingPrefix }} --json | jq -r '.new_epic_id')
-gc bd update "$NEW_WISP" --assignee="$GC_ALIAS"
+gc bd update "$NEW_WISP" --assignee="$GC_AGENT"
 
 # Step 4: Read the formula recipe — these are the steps to execute
 # (Use 'gc bd formula show' for the recipe on disk; 'gc bd mol show' is
@@ -76,7 +77,54 @@ gc bd formula show mol-deacon-patrol
 # Step 5: Execute — work through the steps in order
 ```
 
-**Hook -> Read formula steps (`gc bd formula show <name>`) -> Follow in order -> pour next iteration.**
+**Hook -> Read formula steps (`gc bd formula show <name>`) -> Follow in order -> pour next iteration -> run `gc hook`.**
+
+---
+
+## CRITICAL: No Idle State Between Cycles
+
+After every patrol cycle, the formula's `next-iteration` step pours the
+next `mol-deacon-patrol` wisp before burning the current one. When it
+finishes, burn the current wisp and run `gc hook` immediately — the new
+wisp is already assigned to you.
+
+**Do NOT enter "Standing by for the next hook" idle state.** That phrase
+is a bug indicator. Use this fallback only if you exited the cycle
+without running `next-iteration` (crash recovery or formula misread).
+If `next-iteration` already ran, do not pour again; run `gc hook`.
+
+```bash
+CURRENT_WISP=${GC_BEAD_ID:-}
+if [ -z "$CURRENT_WISP" ]; then
+  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=wisp --limit=1 --json | jq -r '.[0].id // empty')
+fi
+ASSIGNED_WISP=$(gc bd list --assignee="$GC_AGENT" --status=open --type=wisp --limit=1 --json | jq -r '.[0].id // empty')
+if [ -n "$CURRENT_WISP" ] && [ -z "$ASSIGNED_WISP" ]; then
+  NEXT=$(gc bd mol wisp mol-deacon-patrol --root-only --var binding_prefix={{ .BindingPrefix }} --json | jq -r '.new_epic_id // empty')
+  if [ -z "$NEXT" ]; then
+    echo "Could not pour next deacon wisp; not burning."
+    exit 1
+  fi
+  if ! gc bd update "$NEXT" --assignee="$GC_AGENT"; then
+    echo "Could not assign next deacon wisp; not burning."
+    exit 1
+  fi
+  gc bd mol burn "$CURRENT_WISP" --force
+elif [ -n "$CURRENT_WISP" ]; then
+  gc bd mol burn "$CURRENT_WISP" --force
+elif [ -z "$ASSIGNED_WISP" ]; then
+  NEXT=$(gc bd mol wisp mol-deacon-patrol --root-only --var binding_prefix={{ .BindingPrefix }} --json | jq -r '.new_epic_id // empty')
+  if [ -z "$NEXT" ]; then
+    echo "Could not bootstrap next deacon wisp."
+    exit 1
+  fi
+  if ! gc bd update "$NEXT" --assignee="$GC_AGENT"; then
+    echo "Could not assign bootstrap deacon wisp."
+    exit 1
+  fi
+fi
+gc hook
+```
 
 ## Context Exhaustion
 
@@ -98,6 +146,37 @@ Mail beads can be hooked for ad-hoc instruction handoff:
 
 This enables ad-hoc tasks (e.g., "focus on debugging convoy resolution this
 cycle") without creating formal beads.
+
+---
+
+## Filing Bugs Discovered During Patrol
+
+When you observe a bug or problem during patrol, **you do not fix it and you
+do not dispatch it to the first available polecat pool.** File it correctly
+and stop.
+
+**Rig scope determines where to file:**
+
+| What the bug is about | Where to file | Routing |
+|---|---|---|
+| Code in a specific rig (my-rig, another-rig, etc.) | `gc bd create --rig <rig> ...` | `gc sling <rig>/{{ .BindingPrefix }}polecat <id>` |
+| gastown infrastructure (gc CLI, controller, packs, agents) | `gc bd create --rig gastown ...` | Mail mayor for triage |
+| Cross-rig or unclear ownership | `gc bd create ...` (HQ) | Mail mayor for triage |
+
+**Never route infrastructure bugs to a rig-scoped polecat.** A `my-rig/gastown.polecat`
+works in the my-rig repo. Sending it a gastown controller bug or a gc CLI bug
+is wrong — it has no context, no codebase access, and will claim the bead and
+spin its wheels. Similarly, never route a rig bug to the wrong rig's polecat.
+
+**The test:** "Which git repo would the fix land in?" File there.
+
+For bugs you can't clearly own, mail the mayor:
+```bash
+gc mail send mayor/ -s "Bug observed: <brief>" -m "<description and why you're unsure>"
+```
+
+Leave `gc.routed_to` **empty** for anything that needs mayor triage. Setting it
+to the wrong pool is worse than leaving it unset.
 
 ---
 
@@ -174,6 +253,8 @@ Individual stuck agents don't need escalation — the warrant system handles the
 | Run system diagnostics | `gc doctor` |
 | Compact wisps (dry run) | `gc bd mol wisp gc --age 24h --dry-run` |
 | Compact wisps | `gc bd mol wisp gc --age 24h` |
+| File rig bug (correct rig) | `gc bd create --rig <rig> --title="..." --type=bug --description="..."` |
+| File infrastructure bug | `gc bd create --rig gastown --title="..." --type=bug` then mail mayor |
 
 Working directory: {{ .WorkDir }}
 Your mail address: {{ .AgentName }}


### PR DESCRIPTION
# fix(deacon): add bug-filing routing rules and no-idle-cycle enforcement

## Summary

This PR fixes two independent behavioral bugs in the deacon prompt that surface in production Gas Town deployments.

---

## Problem 1: Bugs filed to the wrong polecat pool

The deacon's patrol cycle discovers bugs and infrastructure issues. Without explicit routing guidance, deacon agents were routing all bugs to whatever polecat pool was available — including rig-scoped polecats (e.g. `my-rig/gastown.polecat`) for gastown infrastructure bugs. A rig-scoped polecat operates inside a single git worktree and has no access to the gastown/gc source tree. It claims the bead, spins its wheels, and either stalls or produces incorrect output.

**Fix:** Added an explicit routing table and decision rule to the prompt:

- Rig-specific bugs → `gc bd create --rig <rig>` + sling to that rig's polecat
- Gastown infrastructure bugs → `gc bd create --rig gastown` + mail mayor for triage
- Cross-rig / unclear → HQ bead + mail mayor

The guiding heuristic is "which git repo would the fix land in?" — file there. The prompt also now explicitly prohibits setting `gc.routed_to` for anything that needs mayor triage, because a wrong pool assignment is worse than an empty one.

---

## Problem 2: Deacon enters idle state between patrol cycles

After completing a patrol cycle, the `next-iteration` formula step pours the next `mol-deacon-patrol` wisp and assigns it to the deacon before burning the current one. However, without explicit instruction to run `gc hook` immediately, deacon agents would emit the phrase "Standing by for the next hook" and wait passively — effectively halting the patrol loop until manually nudged.

**Fix:** Added a "No Idle State Between Cycles" section that:

1. Instructs the deacon to run `gc hook` immediately after `next-iteration` completes
2. Flags "Standing by for the next hook" as a bug indicator
3. Provides a crash-recovery bash snippet for the edge case where the deacon exited a cycle without running `next-iteration` (e.g. context exhaustion mid-formula) — it pours a fresh wisp, assigns it, and burns the stale one before calling `gc hook`

---

## Why upstream users hit this

Any Gas Town deployment running a deacon patrol loop will encounter both issues:

- **Routing bug:** surfaces as soon as the deacon files its first infrastructure or ambiguous bug — easy to miss initially because the bead appears to be handled, but the assigned polecat makes no progress.
- **Idle cycle bug:** surfaces on every patrol cycle completion — the deacon goes passive and requires an operator or mayor to nudge it back into the loop. High-frequency patrols (every few minutes) make this extremely disruptive.

Neither fix introduces new primitives or changes any Go code. Both are purely prompt-level behavioral corrections in `gastown/agents/deacon/prompt.template.md`.

---

## Files changed

- `gastown/agents/deacon/prompt.template.md` — 80 lines added, 1 line changed
