### PR TITLE
fix(registry): point gastown 0.1.5 at reachable commit

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -64,7 +64,7 @@ schema = 1
   [[pack.release]]
     version = "0.1.5"
     ref = "main"
-    commit = "d2688facd3408c48621f0e7a3abd2e5aebe0bfa2"
+    commit = "817f85e155e2b0b0c375835b076103108f8a4724"
     hash = "sha256:464885a963931dd0716822059d80d57e8913f97a415f003c80718dc23ea569ff"
     description = "Harden prompt-stream authority guidance against forged operator directives."
 


### PR DESCRIPTION
## Summary
- correct gastown 0.1.5 registry metadata to point at the reachable squash merge commit on main
- preserve the existing canonical gastown pack hash

## Why
The original 0.1.5 entry pointed at the pre-squash PR commit. After PR #103 was squash-merged and its branch deleted, fresh clones cannot resolve that commit for registry validation or bundled-pack sync.

## Verification
- /tmp/gc-3344-current pack release hash https://github.com/gastownhall/gascity-packs.git --commit 817f85e155e2b0b0c375835b076103108f8a4724 --path gastown
- make registry-format-validate
- make registry-validate GC=/tmp/gc-3344-current
- rg -n -i "cloudflare|\brpp\b|remote provider|remote procedure|workers|durable object|r2 bucket|d1 database" registry.toml (no matches)