### PR TITLE
release(gascity): 0.1.4 work-option metadata normalization

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -27,6 +27,13 @@ schema = 1
     hash = "sha256:505f414c4ac6909a07dde95237a84995a7d99a280141d0abb3b4d5f43712c59f"
     description = "Align build-basic review expansion and artifact guidance with graph.v2 validation."
 
+  [[pack.release]]
+    version = "0.1.4"
+    ref = "main"
+    commit = "99464ed9240b1f6e6b7ab1d351f67016e1a973ff"
+    hash = "sha256:12cd31ffae96b1dbef8e7e16a84903b47fc49098abb2fe8a1a7df62d6e042b6e"
+    description = "Normalize legacy work option metadata in task creation."
+
 [[pack]]
   name = "gastown"
   description = "Default Gas Town coding workflow pack."


### PR DESCRIPTION
## Summary
- add gascity pack release 0.1.4 for the PR #68 work-option metadata normalization change
- point the release at the reachable content commit `99464ed9240b1f6e6b7ab1d351f67016e1a973ff`

## Why
The Gas City 1.3 branch needs to pin the module at gastown 0.1.5. That module commit also contains the gascity pack changes from PR #68, so the gascity pack needs a matching registry release hash for the bundled-pack sync guard to pass honestly.

## Verification
- make registry-format-validate
- make registry-validate GC=/tmp/gc-3344-current
- python3 gascity/tests/test_create_beads_from_tasks.py
- rg -n -i "cloudflare|\brpp\b|remote provider|remote procedure|workers|durable object|r2 bucket|d1 database" registry.toml (no matches)