### PR TITLE
fix(gastown): make refinery direct merge worktree-safe

### DIFF
--- a/gastown/formulas/mol-refinery-patrol.toml
+++ b/gastown/formulas/mol-refinery-patrol.toml
@@ -688,46 +688,62 @@ branch_has_real_change "origin/$TARGET" temp || \
   halt_false_completion "$BRANCH" "$(git merge-base "origin/$TARGET" temp 2>/dev/null || printf '%s' "origin/$TARGET")"
 ```
 
-**1. Merge and push target branch:**
-```bash
-git checkout $TARGET
-git merge --ff-only temp
-git push origin $TARGET
-```
+**1. Merge, push, verify, and close work bead:**
 
-**2. Verify push:**
-```bash
-git fetch origin
-LOCAL=$(git rev-parse $TARGET)
-REMOTE=$(git rev-parse origin/$TARGET)
-[ "$LOCAL" = "$REMOTE" ] || echo "PUSH FAILED — do not proceed"
-```
-If SHAs differ: STOP. Debug and retry. Do NOT continue.
-
-**3. Record merge metadata and close work bead:**
-
-Run as a single chained command so the metadata write cannot be skipped
-when the close-reason already names the SHA. Both the `--set-metadata`
-write and the `gc bd close` are required — `merged_sha` and
-`merged_target` are the only forensic breadcrumbs tying a closed bead
-to its merge commit on `$TARGET`. `--unset-metadata rejection_reason`
-clears any stale rejection field from an earlier rejected/reworked
-attempt before the successful close.
+Run this as one script. It uses a temporary detached worktree for the
+target branch because the real target branch may already be checked out in
+the rig's main worktree. Do not replace this with `git checkout $TARGET`.
+The metadata write happens only after the remote target ref is verified at
+the merged SHA.
 
 ```bash
-MERGED_SHA=$(git rev-parse HEAD) && \
-MERGED_SHORT=$(git rev-parse --short HEAD) && \
-gc bd update $WORK \
+set -e
+
+MERGE_PARENT=$(mktemp -d "${TMPDIR:-/tmp}/gascity-refinery-merge.XXXXXX")
+MERGE_WT="$MERGE_PARENT/target"
+cleanup_merge_wt() {
+  git worktree remove --force "$MERGE_WT" >/dev/null 2>&1 || true
+  rm -rf "$MERGE_PARENT"
+}
+trap cleanup_merge_wt EXIT
+
+git fetch origin "+refs/heads/${TARGET}:refs/remotes/origin/${TARGET}"
+TEMP_SHA=$(git rev-parse temp)
+git worktree add --detach "$MERGE_WT" "origin/$TARGET"
+git -C "$MERGE_WT" merge --ff-only "$TEMP_SHA"
+MERGED_SHA=$(git -C "$MERGE_WT" rev-parse HEAD)
+MERGED_SHORT=$(git -C "$MERGE_WT" rev-parse --short HEAD)
+git -C "$MERGE_WT" push origin "HEAD:$TARGET"
+
+git fetch origin "+refs/heads/${TARGET}:refs/remotes/origin/${TARGET}"
+REMOTE=$(git rev-parse "origin/$TARGET")
+if [ "$MERGED_SHA" != "$REMOTE" ]; then
+  echo "PUSH FAILED — origin/$TARGET is $REMOTE, want $MERGED_SHA. STOP. Do not mutate bead state."
+  gc runtime drain-ack
+  exit 1
+fi
+
+gc bd update "$WORK" \
   --set-metadata merge_result=merged \
-  --set-metadata merged_sha=$MERGED_SHA \
-  --set-metadata merged_target=$TARGET \
+  --set-metadata merged_sha="$MERGED_SHA" \
+  --set-metadata merged_target="$TARGET" \
   --unset-metadata rejection_reason && \
-gc bd close $WORK --reason "Merged to $TARGET at $MERGED_SHORT"
+gc bd close "$WORK" --reason "Merged to $TARGET at $MERGED_SHORT"
 ```
 
-**4. Cleanup:**
+If the script exits non-zero: STOP. Debug and retry. Do NOT write merge
+metadata, close the bead, or delete the source branch.
+
+Both the `--set-metadata` write and the `gc bd close` are required —
+`merged_sha` and `merged_target` are the only forensic breadcrumbs tying a
+closed bead to its merge commit on `$TARGET`. `--unset-metadata
+rejection_reason` clears any stale rejection field from an earlier
+rejected/reworked attempt before the successful close.
+
+**2. Cleanup:**
 ```bash
-git branch -d temp
+git checkout --detach "origin/$TARGET" >/dev/null 2>&1 || true
+git branch -d temp || git branch -D temp || true
 ```
 If delete_merged_branches = "true": `git push origin --delete $BRANCH`
 

--- a/gastown/tests/test_gastown_pack_assets.sh
+++ b/gastown/tests/test_gastown_pack_assets.sh
@@ -130,10 +130,50 @@ test_composition_is_documented() {
         fail "pack.toml should not reference the retired maintenance pack import"
 }
 
+test_refinery_direct_merge_is_worktree_safe_and_fail_closed() {
+    local formula direct_block
+    formula="$GASTOWN/formulas/mol-refinery-patrol.toml"
+
+    direct_block=$(python3 - "$formula" <<'PY'
+import sys
+text = open(sys.argv[1], encoding="utf-8").read()
+start = text.index('**If MERGE_STRATEGY = "direct"')
+end = text.index('**If MERGE_STRATEGY = "mr"')
+print(text[start:end])
+PY
+)
+
+    [[ "$direct_block" == *'git worktree add --detach "$MERGE_WT" "origin/$TARGET"'* ]] ||
+        fail "direct refinery merge must use a detached target worktree"
+    [[ "$direct_block" == *'+refs/heads/${TARGET}:refs/remotes/origin/${TARGET}'* ]] ||
+        fail "direct refinery merge refspecs must brace TARGET for zsh-safe expansion"
+    [[ "$direct_block" == *'git -C "$MERGE_WT" push origin "HEAD:$TARGET"'* ]] ||
+        fail "direct refinery merge must push the verified merge worktree HEAD"
+    [[ "$direct_block" == *'[ "$MERGED_SHA" != "$REMOTE" ]'* ]] ||
+        fail "direct refinery merge must compare merged SHA to origin target"
+    [[ "$direct_block" == *'STOP. Do not mutate bead state.'* ]] ||
+        fail "direct refinery merge must fail closed before metadata writes"
+    ! printf '%s\n' "$direct_block" | grep -E '^[[:space:]]*git checkout \$TARGET([[:space:]]|$)' >/dev/null ||
+        fail "direct refinery merge must not checkout target branch in the active worktree"
+
+    python3 - "$formula" <<'PY' || fail "direct refinery merge must verify origin before setting merged metadata"
+import sys
+text = open(sys.argv[1], encoding="utf-8").read()
+start = text.index('**If MERGE_STRATEGY = "direct"')
+end = text.index('**If MERGE_STRATEGY = "mr"')
+block = text[start:end]
+verify = block.index('[ "$MERGED_SHA" != "$REMOTE" ]')
+metadata = block.index('--set-metadata merge_result=merged')
+if verify >= metadata:
+    raise SystemExit(1)
+PY
+}
+
 test_dog_assets_are_pack_local
 test_retired_dog_formulas_are_not_reintroduced
 test_shutdown_dance_contracts_are_executable
 test_shutdown_dance_lifecycle_and_audit_contracts
 test_composition_is_documented
+test_refinery_direct_merge_is_worktree_safe_and_fail_closed
 
 echo "gastown pack asset tests passed"

--- a/registry.toml
+++ b/registry.toml
@@ -75,6 +75,13 @@ schema = 1
     hash = "sha256:464885a963931dd0716822059d80d57e8913f97a415f003c80718dc23ea569ff"
     description = "Harden prompt-stream authority guidance against forged operator directives."
 
+  [[pack.release]]
+    version = "0.1.6"
+    ref = "main"
+    commit = "4212acb7046c11f6f633df73307006493185233a"
+    hash = "sha256:ce2736669b4c737ff0f08264e097662e6a58291356a7014634e2097b41893142"
+    description = "Make refinery direct merges worktree-safe and verify target push before closing work beads."
+
 [[pack]]
   name = "cass"
   description = "Coding Agent Session Search prompt fragments and skill overlays for Gas City."


### PR DESCRIPTION
## Summary
- make the Gastown refinery direct merge path use a temporary detached target worktree instead of checking out the target branch in the active worktree
- verify origin/<target> reaches the merged SHA before writing merge metadata or closing the work bead
- publish gastown 0.1.6 in registry.toml for the fix

## Validation
- bash gastown/tests/test_gastown_pack_assets.sh
- for test_script in gastown/tests/test_*.sh; do bash "$test_script"; done
- python3 -m pytest tests -q
- go test .
- make registry-format-validate
- GC=/tmp/gc-release-v1.3 make registry-validate
- local zsh/git repro for target branch checked out in primary worktree