### PR TITLE
feat(slack-full): doctor preflight checks (salvage from #90, split 1/2)

### DIFF
--- a/slack-full/doctor/binaries/doctor.toml
+++ b/slack-full/doctor/binaries/doctor.toml
@@ -1,0 +1,2 @@
+description = 'adapter and operator CLI Go binaries are built in place'
+run = '../check-binaries.sh'

--- a/slack-full/doctor/check-binaries.sh
+++ b/slack-full/doctor/check-binaries.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -eu
+
+pack_dir="${GC_PACK_DIR:-$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)}"
+
+missing=""
+for bin in adapter/gc-slack-adapter cli/gc-slack-cli; do
+  if [ ! -x "$pack_dir/$bin" ]; then
+    missing="$missing $bin"
+  fi
+done
+
+if [ -n "$missing" ]; then
+  echo "pack binaries not built:$missing"
+  echo "Build them in place: (cd adapter && go build -o gc-slack-adapter) and (cd cli && go build -o gc-slack-cli .) — see CONTRIBUTING.md."
+  exit 2
+fi
+
+echo "adapter and CLI binaries built"

--- a/slack-full/doctor/check-env.sh
+++ b/slack-full/doctor/check-env.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -eu
+
+env_file="${XDG_CONFIG_HOME:-$HOME/.config}/gc-slack-adapter/env"
+
+missing=""
+for var in SLACK_WORKSPACE_ID SLACK_BOT_TOKEN SLACK_SIGNING_SECRET GC_CITY_NAME; do
+  if eval "[ -n \"\${$var:-}\" ]"; then
+    continue
+  fi
+  if [ -f "$env_file" ] && grep -q "^\(export \)\{0,1\}${var}=." "$env_file"; then
+    continue
+  fi
+  missing="$missing $var"
+done
+
+if [ -n "$missing" ]; then
+  echo "missing adapter env vars:$missing"
+  echo "Export them or add them to $env_file (mode 0600) so the adapter's supervisor inherits them — the adapter Fatals at start without them."
+  exit 2
+fi
+
+echo "adapter env vars present"

--- a/slack-full/doctor/check-funnel.sh
+++ b/slack-full/doctor/check-funnel.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -eu
+
+env_file="${XDG_CONFIG_HOME:-$HOME/.config}/gc-slack-adapter/env"
+listen="${LISTEN_PUBLIC:-}"
+if [ -z "$listen" ] && [ -f "$env_file" ]; then
+  listen="$(sed -n 's/^\(export \)\{0,1\}LISTEN_PUBLIC=//p' "$env_file" | tail -n 1 | tr -d '"'"'"'')"
+fi
+port="${listen:-:8765}"
+port="${port##*:}"
+
+if ! command -v tailscale >/dev/null 2>&1; then
+  echo "tailscale not found; skipping Funnel check — public ingress to the adapter's /slack/events listener (:${port}) must be provided another way"
+  exit 0
+fi
+
+if ! tailscale funnel status 2>/dev/null | grep -q ":${port}\b"; then
+  echo "no Tailscale Funnel rule forwarding to adapter port ${port}"
+  echo "Re-add it (e.g. tailscale funnel --bg ${port}) — the rule is not declared in the city, so a host reboot or 'tailscale funnel reset' silently stops Slack traffic."
+  exit 2
+fi
+
+echo "Tailscale Funnel rule to adapter port ${port} present"

--- a/slack-full/doctor/check-gc.sh
+++ b/slack-full/doctor/check-gc.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if ! command -v gc >/dev/null 2>&1; then
+  echo "gc CLI not found"
+  echo "Install or expose the gc binary so slack-full commands can resolve the city and deliver protocol nudges."
+  exit 2
+fi
+
+echo "gc CLI available"

--- a/slack-full/doctor/check-python.sh
+++ b/slack-full/doctor/check-python.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -eu
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "python3 not found"
+  echo "Install Python 3.11 or newer to run the gc slack helper commands."
+  exit 2
+fi
+
+python3 - <<'PY'
+import sys
+if sys.version_info < (3, 11):
+    print(f"python3 is {sys.version.split()[0]}; need 3.11+")
+    print("Install Python 3.11 or newer to run the gc slack helper commands.")
+    raise SystemExit(2)
+print(f"python3 {sys.version.split()[0]} available")
+PY

--- a/slack-full/doctor/env/doctor.toml
+++ b/slack-full/doctor/env/doctor.toml
@@ -1,0 +1,2 @@
+description = 'required Slack adapter env vars are set or present in the adapter env file'
+run = '../check-env.sh'

--- a/slack-full/doctor/funnel/doctor.toml
+++ b/slack-full/doctor/funnel/doctor.toml
@@ -1,0 +1,2 @@
+description = 'public ingress (Tailscale Funnel) reaches the adapter /slack/events listener'
+run = '../check-funnel.sh'

--- a/slack-full/doctor/gc/doctor.toml
+++ b/slack-full/doctor/gc/doctor.toml
@@ -1,0 +1,2 @@
+description = 'gc CLI is available for city resolution and protocol nudges'
+run = '../check-gc.sh'

--- a/slack-full/doctor/python/doctor.toml
+++ b/slack-full/doctor/python/doctor.toml
@@ -1,0 +1,2 @@
+description = 'python3 3.11+ is available for the gc slack helper commands'
+run = '../check-python.sh'


### PR DESCRIPTION
Salvages the net-new `slack-full/doctor` preflight from #90, which is being superseded.

Per the agreed 2-PR split, this is the **doctor-preflight half** — 10 net-new files (4 `check-*.sh` scripts + their `doctor.toml` manifests), additive only, no edits to existing files. The inbound-scan-test half is split into a separate follow-up PR (it needs the escalating-window port first).

**Scope (additive, 10 files, +102):**
- `slack-full/doctor/check-{binaries,env,funnel,gc,python}.sh` + `binaries/env/funnel/gc/python/doctor.toml`

**Checks:** executable modes preserved; `sh -n` clean on all scripts; `tomllib` parses all manifests. File-disjoint from the in-flight registry overhaul (#106) — touches neither `registry.toml` nor existing `slack-full` files.

Supersedes #90.
