### PR TITLE
fix(slack-channel): retry adapter registration on city-startup race

### DIFF
--- a/slack-channel/adapter/config.go
+++ b/slack-channel/adapter/config.go
@@ -33,6 +33,16 @@ const (
 	// cannot pin an inbound-bridge goroutine (or block startup
 	// registration) forever.
 	gcCallTimeout = 15 * time.Second
+
+	// Startup registration retry: on a supervisor/city restart the adapter
+	// can come up before the city has finished adopting sessions, so the
+	// first registration gets a 404 "city not found or not running". The
+	// adapter retries with exponential backoff (initial→max) until
+	// registerDeadline rather than exiting on the first 404 and killing all
+	// Slack comms until a manual restart; past the deadline it fails loudly.
+	registerInitialBackoff = 1 * time.Second
+	registerMaxBackoff     = 30 * time.Second
+	registerDeadline       = 5 * time.Minute
 )
 
 // config holds the adapter's resolved runtime configuration. It extends

--- a/slack-channel/adapter/gcclient.go
+++ b/slack-channel/adapter/gcclient.go
@@ -4,11 +4,14 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 )
 
 // postInbound bridges a verified Slack message into gc's extmsg inbound.
@@ -45,6 +48,62 @@ func (s *server) registerAdapter(ctx context.Context) error {
 	return s.postJSON(ctx, target, body)
 }
 
+// retryPolicy bounds the startup registration backoff. The overall deadline
+// is carried by the ctx passed to registerAdapterWithRetry.
+type retryPolicy struct {
+	initialBackoff time.Duration
+	maxBackoff     time.Duration
+}
+
+// registerAdapterWithRetry registers the adapter, retrying with exponential
+// backoff while the failure is transient. On a supervisor/city restart the
+// adapter can come up before the city has finished adopting sessions, so the
+// first /extmsg/adapters call returns 404 "city not found or not running":
+// exiting on that (the previous behaviour) silently killed all Slack comms
+// until a manual restart. Each attempt is bounded by gcCallTimeout; the loop
+// gives up only when ctx is cancelled (the overall deadline), returning the
+// last error so the caller can fail loudly once the city is genuinely
+// unreachable. A non-transient error (malformed request, auth) returns
+// immediately — backoff cannot fix a misconfiguration.
+func (s *server) registerAdapterWithRetry(ctx context.Context, p retryPolicy) error {
+	backoff := p.initialBackoff
+	for attempt := 1; ; attempt++ {
+		callCtx, cancel := context.WithTimeout(ctx, gcCallTimeout)
+		err := s.registerAdapter(callCtx)
+		cancel()
+		if err == nil {
+			if attempt > 1 {
+				log.Printf("register adapter: succeeded on attempt %d", attempt)
+			}
+			return nil
+		}
+		if !registrationRetryable(err) {
+			return err
+		}
+		log.Printf("register adapter: attempt %d failed (city not ready?), retrying in %s: %v", attempt, backoff, err)
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("city unreachable after %d attempts: %w", attempt, err)
+		case <-time.After(backoff):
+		}
+		backoff = min(backoff*2, p.maxBackoff)
+	}
+}
+
+// registrationRetryable reports whether a failed registration should be
+// retried. A 404 means the city has not finished starting and a 5xx means gc
+// itself is restarting — both clear once startup completes. A transport
+// error (no HTTP response: the gc API socket is not up yet) is likewise
+// transient during a restart. Any other 4xx (malformed request, auth) is a
+// real misconfiguration that backoff cannot fix, so it fails fast.
+func registrationRetryable(err error) bool {
+	var se *statusError
+	if errors.As(err, &se) {
+		return se.StatusCode == http.StatusNotFound || se.StatusCode >= 500
+	}
+	return true
+}
+
 // postJSON POSTs a JSON body to a gc API endpoint and treats any >=400
 // status as an error, surfacing the response body for diagnostics. ctx
 // bounds the call so callers can enforce a timeout.
@@ -62,7 +121,28 @@ func (s *server) postJSON(ctx context.Context, target string, body []byte) error
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode >= 400 {
 		respBody, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("%s: %s", resp.Status, strings.TrimSpace(string(respBody)))
+		return &statusError{
+			StatusCode: resp.StatusCode,
+			Status:     resp.Status,
+			Body:       strings.TrimSpace(string(respBody)),
+		}
 	}
 	return nil
+}
+
+// statusError is returned by postJSON when the gc API responds with a >=400
+// status. It carries the status code so callers (startup registration) can
+// distinguish a transient "city not ready" 404 from a permanent failure,
+// while its message preserves the status line + body for diagnostics.
+type statusError struct {
+	StatusCode int
+	Status     string // HTTP status line, e.g. "404 Not Found"
+	Body       string
+}
+
+func (e *statusError) Error() string {
+	if e.Body == "" {
+		return e.Status
+	}
+	return e.Status + ": " + e.Body
 }

--- a/slack-channel/adapter/gcclient_test.go
+++ b/slack-channel/adapter/gcclient_test.go
@@ -7,8 +7,14 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 )
+
+// fastRetry is a retryPolicy with sub-millisecond backoff so registration
+// retry tests exercise the loop without real waits.
+var fastRetry = retryPolicy{initialBackoff: time.Millisecond, maxBackoff: 5 * time.Millisecond}
 
 func TestRegisterAdapter(t *testing.T) {
 	srv := newTestServer(t)
@@ -31,6 +37,88 @@ func TestRegisterAdapter(t *testing.T) {
 	}
 	if got.Capabilities.SupportsChildConversations {
 		t.Error("Tier 2 must not advertise child conversations")
+	}
+}
+
+// TestRegisterAdapterWithRetry404ThenSuccess is the registration-race
+// regression: the city returns 404 "city not found" while it is still
+// starting, then 200 once adoption completes. The adapter must retry through
+// the 404s and succeed instead of exiting on the first one (ref gc-c69aq).
+func TestRegisterAdapterWithRetry404ThenSuccess(t *testing.T) {
+	srv := newTestServer(t)
+	const failFirst = 3
+	var calls atomic.Int32
+	gc := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if calls.Add(1) <= failFirst {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = io.WriteString(w, "city not found or not running: ds-research")
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer gc.Close()
+	srv.cfg.gcAPIBase = gc.URL
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := srv.registerAdapterWithRetry(ctx, fastRetry); err != nil {
+		t.Fatalf("registerAdapterWithRetry: %v", err)
+	}
+	if got := calls.Load(); got != failFirst+1 {
+		t.Errorf("expected %d attempts (%d×404 then success), got %d", failFirst+1, failFirst, got)
+	}
+}
+
+// TestRegisterAdapterWithRetryDeadline asserts the loop gives up once the
+// ctx deadline passes when the city never comes up, surfacing the last error
+// rather than spinning forever.
+func TestRegisterAdapterWithRetryDeadline(t *testing.T) {
+	srv := newTestServer(t)
+	var calls atomic.Int32
+	gc := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = io.WriteString(w, "city not found")
+	}))
+	defer gc.Close()
+	srv.cfg.gcAPIBase = gc.URL
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+	err := srv.registerAdapterWithRetry(ctx, fastRetry)
+	if err == nil {
+		t.Fatal("expected deadline error, got nil")
+	}
+	if !strings.Contains(err.Error(), "city unreachable") {
+		t.Errorf("expected give-up error, got %v", err)
+	}
+	if calls.Load() == 0 {
+		t.Error("expected at least one registration attempt before giving up")
+	}
+}
+
+// TestRegisterAdapterWithRetryNonRetryable asserts a permanent failure (a
+// 4xx that is not 404, e.g. a malformed request) returns immediately without
+// burning the backoff loop — backoff cannot fix a misconfiguration.
+func TestRegisterAdapterWithRetryNonRetryable(t *testing.T) {
+	srv := newTestServer(t)
+	var calls atomic.Int32
+	gc := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = io.WriteString(w, "bad provider")
+	}))
+	defer gc.Close()
+	srv.cfg.gcAPIBase = gc.URL
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err := srv.registerAdapterWithRetry(ctx, fastRetry)
+	if err == nil || !strings.Contains(err.Error(), "bad provider") {
+		t.Fatalf("expected immediate non-retryable error surfacing body, got %v", err)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Errorf("expected exactly 1 attempt for a non-retryable error, got %d", got)
 	}
 }
 

--- a/slack-channel/adapter/main.go
+++ b/slack-channel/adapter/main.go
@@ -136,8 +136,11 @@ func main() {
 	}
 
 	if cfg.registerOnStart {
-		regCtx, cancel := context.WithTimeout(context.Background(), gcCallTimeout)
-		err := srv.registerAdapter(regCtx)
+		regCtx, cancel := context.WithTimeout(context.Background(), registerDeadline)
+		err := srv.registerAdapterWithRetry(regCtx, retryPolicy{
+			initialBackoff: registerInitialBackoff,
+			maxBackoff:     registerMaxBackoff,
+		})
 		cancel()
 		if err != nil {
 			log.Fatalf("register adapter: %v", err)


### PR DESCRIPTION
## Problem

The `slack-channel` adapter calls `log.Fatalf` and exits permanently if its registration POST to the gc API fails — including during city startup, when the gc server may not yet be accepting adapter registrations. The result is a registration *race*: a transient `404`/`5xx`/transport error at boot kills the adapter for good instead of waiting for the server to come up.

## Fix

- `postJSON` now returns a typed `*statusError{StatusCode, Status, Body}` so callers can classify failures by HTTP status (was an opaque `fmt.Errorf`).
- New `registerAdapterWithRetry`: bounded exponential backoff (1s → cap 30s) on **transient** failures — `404`, any `5xx`, and transport errors — until a **5-minute deadline** (`context.WithTimeout`), then `log.Fatalf`. Permanent failures (`400`/`401`/`403`, other non-404 `4xx`) **fail fast** on the first attempt, so a real misconfiguration surfaces immediately instead of hanging.
- The deadline context is propagated into each attempt and checked in the backoff `select`, so the loop can't spin hot and is bounded by the deadline.

## Tests

3 new tests in `gcclient_test.go` against a real `httptest.Server` with atomic call counts:
- `404 ×3 then 200` → exactly N+1 calls (retry-then-success)
- deadline expiry → fails with the expected message after ≥1 attempt
- `400` → exactly 1 call (fail-fast, non-retryable)

`go test ./slack-channel/adapter/...` and `go test -race ./...` both clean (65 tests).

4 files, +184/-3.
