### PR TITLE
Fix gascity 0.1.6 registry commit SHA

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -37,7 +37,7 @@ schema = 1
   [[pack.release]]
     version = "0.1.6"
     ref = "main"
-    commit = "d8b9e3388a49d11713a0621401f7b5c487bfbf78"
+    commit = "3b3b89f2011e06d84459aa7bea1552382f13930a"
     hash = "sha256:149772065f9f2862965146e74d853d17e432628f57d25a4386bbef0fb6744e33"
     description = "Release graph.v2 review/build prompt fixes validated by gascity RC gates."
 


### PR DESCRIPTION
## Summary
- Points gascity 0.1.6 at the squash-merged main commit 3b3b89f2011e06d84459aa7bea1552382f13930a instead of the pre-squash branch-only content commit.
- Keeps the validated pack content hash unchanged.

## Validation
- python3 validate_registry.py registry.toml -> ok
- PYTHONPATH=. pytest -q tests/test_validate_registry.py tests/test_registry_release.py tests/test_pack_release_compat.py -> 9 passed
- python scripts/pack_release_compat.py --gc-bin /data/tmp/gc-release-v1.3.0-e0d73e59f-20260616T2159Z/gc --pack gascity --pack gastown --exercise both -> compatibility smoke passed for 2 latest releases