### PR TITLE
Release gastown 0.1.7 polecat claim fix

### DIFF
--- a/gastown/agents/polecat/agent.toml
+++ b/gastown/agents/polecat/agent.toml
@@ -1,7 +1,7 @@
 scope = "rig"
 wake_mode = "fresh"
 work_dir = ".gc/worktrees/{{.Rig}}/polecats/{{.AgentBase}}"
-nudge = "Run gc hook; it checks assigned work first, then routed pool work."
+nudge = "Run gc hook --claim --json now; if it returns work, execute the claimed formula immediately."
 pre_start = ["{{.ConfigDir}}/assets/scripts/worktree-setup.sh {{.RigRoot}} {{.WorkDir}} {{.AgentBase}} --sync"]
 idle_timeout = "2h"
 min_active_sessions = 0

--- a/gastown/agents/polecat/prompt.template.md
+++ b/gastown/agents/polecat/prompt.template.md
@@ -134,14 +134,8 @@ Your formula: `mol-polecat-work`
 > Polecat-vs-polecat races are the #1 source of churn — close the window.
 
 ```bash
-# Step 1a: Check for assigned in-progress work (already claimed — no race)
-{{ .AssignedInProgressQuery }}
-
-# Step 1b: If none, find pool work
-{{ .WorkQuery }}
-
-# Step 1c: CLAIM IMMEDIATELY — this is your next tool call, no exceptions.
-gc bd update <id> --claim                                       # Atomic CAS
+# Step 1: Claim exactly one work item through the standard hook protocol.
+gc hook --claim --json
 
 # Step 2: AFTER successful claim, only then read code, formula steps, etc.
 gc bd show <id> --json | jq '.[0].metadata'
@@ -152,12 +146,13 @@ gc mail inbox
 # Step 4: Execute — read formula steps and work through them in order
 ```
 
-When nudged after dispatch, run `gc hook` or `{{ .WorkQuery }}`. That lookup
-checks assigned work first (session bead ID, runtime session name, then
-alias) and only falls through to unassigned pool work routed to
-`${GC_RIG:+$GC_RIG/}{{ .BindingPrefix }}polecat`.
+When nudged after dispatch, run `gc hook --claim --json`. That single command
+checks assigned work first (session bead ID, runtime session name, then alias)
+and only falls through to unassigned pool work routed to
+`${GC_RIG:+$GC_RIG/}{{ .BindingPrefix }}polecat`; it also performs the atomic
+claim before you inspect the bead.
 
-**Hook/work query -> Read formula steps -> Follow in order -> done sequence.**
+**Hook claim -> Read formula steps -> Follow in order -> done sequence.**
 
 ## Context Exhaustion
 

--- a/gastown/template-fragments/propulsion.template.md
+++ b/gastown/template-fragments/propulsion.template.md
@@ -142,9 +142,10 @@ agent. The pool thinks it's full. New work can't be dispatched.
 2. Work MUST be assigned (polecats always have work) → EXECUTE immediately
 3. If nothing assigned → ERROR: escalate to Witness
 
-If you were nudged rather than freshly spawned, run `gc hook` or
-`{{ .WorkQuery }}`. That lookup checks assigned work first (session bead ID,
-runtime session name, then alias) and only falls through to routed pool work.
+If you were nudged rather than freshly spawned, run `gc hook --claim --json`.
+That single command checks assigned work first (session bead ID, runtime
+session name, then alias), falls through to routed pool work, and performs the
+atomic claim before you inspect the bead.
 
 You were spawned with work. There is no extra decision to make. Run it.
 

--- a/gastown/tests/test_gastown_pack_assets.sh
+++ b/gastown/tests/test_gastown_pack_assets.sh
@@ -130,6 +130,24 @@ test_composition_is_documented() {
         fail "pack.toml should not reference the retired maintenance pack import"
 }
 
+test_polecat_startup_uses_standard_hook_claim() {
+    local agent prompt propulsion
+    agent="$GASTOWN/agents/polecat/agent.toml"
+    prompt="$GASTOWN/agents/polecat/prompt.template.md"
+    propulsion="$GASTOWN/template-fragments/propulsion.template.md"
+
+    grep -F 'gc hook --claim --json' "$agent" >/dev/null ||
+        fail "polecat nudge should call the standard hook claim path"
+    grep -F 'gc hook --claim --json' "$prompt" >/dev/null ||
+        fail "polecat prompt should call the standard hook claim path"
+    grep -F 'gc hook --claim --json' "$propulsion" >/dev/null ||
+        fail "polecat propulsion fragment should call the standard hook claim path"
+    ! grep -F 'run `gc hook` or' "$prompt" >/dev/null ||
+        fail "polecat prompt must not regress to an unclaimed hook/work-query choice"
+    ! grep -F 'run `gc hook` or' "$propulsion" >/dev/null ||
+        fail "polecat propulsion fragment must not regress to an unclaimed hook/work-query choice"
+}
+
 test_refinery_direct_merge_is_worktree_safe_and_fail_closed() {
     local formula direct_block
     formula="$GASTOWN/formulas/mol-refinery-patrol.toml"
@@ -174,6 +192,7 @@ test_retired_dog_formulas_are_not_reintroduced
 test_shutdown_dance_contracts_are_executable
 test_shutdown_dance_lifecycle_and_audit_contracts
 test_composition_is_documented
+test_polecat_startup_uses_standard_hook_claim
 test_refinery_direct_merge_is_worktree_safe_and_fail_closed
 
 echo "gastown pack asset tests passed"

--- a/registry.toml
+++ b/registry.toml
@@ -89,6 +89,13 @@ schema = 1
     hash = "sha256:ce2736669b4c737ff0f08264e097662e6a58291356a7014634e2097b41893142"
     description = "Make refinery direct merges worktree-safe and verify target push before closing work beads."
 
+  [[pack.release]]
+    version = "0.1.7"
+    ref = "main"
+    commit = "342bcfb0775ad79d2c67df3b235edf70a0a7e372"
+    hash = "sha256:4ee6d7c501d9a4a1617953c8d775523c421246b46e3eb9b653618b7900df123b"
+    description = "Claim routed polecat work through gc hook on nudge."
+
 [[pack]]
   name = "cass"
   description = "Coding Agent Session Search prompt fragments and skill overlays for Gas City."


### PR DESCRIPTION
## Summary
- Fixes Gastown polecat prompt/nudge guidance to use the standard gc hook claim path.
- Releases gastown 0.1.7 at content commit 342bcfb0775ad79d2c67df3b235edf70a0a7e372.

## RCA
The release RC gate routed mol-review-leg to fixture/gastown.polecat. The work was visible through gc hook, but the polecat prompt/nudge told the model to run an unclaimed hook/work-query flow. The live polecat skipped claim and idled, leaving the workflow root in progress and child beads open. The fix makes the first action gc hook --claim --json.

## Validation
- bash gastown/tests/test_gastown_pack_assets.sh -> passed
- PYTHONPATH=. pytest -q -> 683 passed, 11057 subtests passed
- python3 validate_registry.py registry.toml -> ok
- PYTHONPATH=. pytest -q tests/test_validate_registry.py tests/test_registry_release.py tests/test_pack_release_compat.py -> 9 passed
- python scripts/pack_release_compat.py --gc-bin /data/tmp/gc-release-v1.3.0-1c9838717-20260616T2351Z/gc --pack gascity --pack gastown --exercise both -> compatibility smoke passed for 2 latest releases