### PR TITLE
Release gastown 0.1.8 review-leg contract fix

### DIFF
--- a/gastown/agents/polecat/prompt.template.md
+++ b/gastown/agents/polecat/prompt.template.md
@@ -6,13 +6,19 @@
 
 ---
 
-## CRITICAL: Never Close Beads
+## CRITICAL: Do Not Close Implementation Work Beads
 
-**You MUST NOT close beads. EVER. No exceptions.**
+For `mol-polecat-work` implementation assignments, **you MUST NOT close the
+implementation bead.** The Refinery closes it after verifying the merge.
 
-Do not run `bd close`, `gc bd close`, or set `--status=closed`. Only the
-Refinery closes beads after verifying the merge. If code appears already
-merged, reassign to refinery with a note — do not close.
+Do not run `bd close`, `gc bd close`, or set `--status=closed` on an
+implementation bead. If code appears already merged, reassign to refinery with
+a note.
+
+Formula-specific non-implementation assignments may explicitly tell you to
+close their own review/control bead after writing the required deliverable. In
+that case, follow the current formula exactly. Never close unrelated source
+beads or unrelated workflow beads.
 
 ## CRITICAL: Directory Discipline
 
@@ -104,13 +110,15 @@ gc bd show <issue> --json | jq '.[0].metadata'
 
 ## Work Protocol
 
-Your work follows the **mol-polecat-work** formula.
+Implementation work follows the **mol-polecat-work** formula. If your hook
+claim or current molecule identifies a different formula, such as
+`mol-review-leg`, that formula's step descriptions are your instructions.
 
 **FIRST: Read your formula steps.** Do NOT use Claude's internal task tools.
 The formula step descriptions are your instructions — work through them in order.
 
-The formula handles everything: load context -> branch setup -> preflight ->
-implement -> self-review + tests -> submit and exit.
+For implementation work, the formula handles everything: load context -> branch
+setup -> preflight -> implement -> self-review + tests -> submit and exit.
 
 **Affected-test gate before push.** The self-review step runs only the tests
 your diff touches when the rig configures `affected_tests_command` (mirrors
@@ -120,7 +128,7 @@ on local pass — don't ship a PR with locally-failing tests.
 
 {{ template "following-mol" . }}
 
-Your formula: `mol-polecat-work`
+Default implementation formula: `mol-polecat-work`
 
 ## Startup Protocol
 

--- a/gastown/formulas/mol-review-leg.toml
+++ b/gastown/formulas/mol-review-leg.toml
@@ -11,6 +11,11 @@ actual review prompt; this formula standardizes how the worker returns results:
 4. Mail the coordinator recorded on the bead metadata
 5. Close the bead and drain the session
 
+Review legs are analysis-only. Do not create synthetic/test beads, route new
+work, assign or reassign unrelated beads, or run live mutation experiments to
+"observe" behavior. The only allowed bead mutations are the formula-prescribed
+updates to the review bead itself, the completion mail, and the final drain ack.
+
 This keeps review findings durable in beads instead of transient pane output
 or per-worktree scratch files.
 """
@@ -52,6 +57,11 @@ gc bd show "$WORK_BEAD_ID" --json | jq '.[0].metadata'
 
 The bead description is the source of truth. Follow it exactly.
 Do not invent a different scope, format, or deliverable.
+
+**Mutation boundary:** Do not create test beads, dispatch new work, assign or
+reassign unrelated beads, or mutate live state just to observe behavior. If a
+piece of evidence would require changing unrelated state, document that it was
+not performed and continue with the existing assignment data.
 """
 
 [[steps]]

--- a/gastown/tests/test_gastown_pack_assets.sh
+++ b/gastown/tests/test_gastown_pack_assets.sh
@@ -148,6 +148,25 @@ test_polecat_startup_uses_standard_hook_claim() {
         fail "polecat propulsion fragment must not regress to an unclaimed hook/work-query choice"
 }
 
+test_review_leg_contract_forbids_synthetic_mutation() {
+    local formula prompt
+    formula="$GASTOWN/formulas/mol-review-leg.toml"
+    prompt="$GASTOWN/agents/polecat/prompt.template.md"
+
+    grep -F 'Do not create synthetic/test beads' "$formula" >/dev/null ||
+        fail "review-leg formula must forbid synthetic test beads"
+    grep -F 'Do not create test beads' "$formula" >/dev/null ||
+        fail "review-leg load-assignment must forbid test bead creation"
+    grep -F 'The only allowed bead mutations are the formula-prescribed' "$formula" >/dev/null ||
+        fail "review-leg formula must define allowed mutation boundary"
+    grep -F 'Formula-specific non-implementation assignments may explicitly tell you' "$prompt" >/dev/null ||
+        fail "polecat prompt must allow formula-specific review/control close steps"
+    grep -F 'Default implementation formula: `mol-polecat-work`' "$prompt" >/dev/null ||
+        fail "polecat prompt must describe mol-polecat-work as the default implementation formula"
+    ! grep -F '**You MUST NOT close beads. EVER. No exceptions.**' "$prompt" >/dev/null ||
+        fail "polecat prompt must not globally forbid review-leg close steps"
+}
+
 test_refinery_direct_merge_is_worktree_safe_and_fail_closed() {
     local formula direct_block
     formula="$GASTOWN/formulas/mol-refinery-patrol.toml"
@@ -193,6 +212,7 @@ test_shutdown_dance_contracts_are_executable
 test_shutdown_dance_lifecycle_and_audit_contracts
 test_composition_is_documented
 test_polecat_startup_uses_standard_hook_claim
+test_review_leg_contract_forbids_synthetic_mutation
 test_refinery_direct_merge_is_worktree_safe_and_fail_closed
 
 echo "gastown pack asset tests passed"

--- a/registry.toml
+++ b/registry.toml
@@ -96,6 +96,13 @@ schema = 1
     hash = "sha256:4ee6d7c501d9a4a1617953c8d775523c421246b46e3eb9b653618b7900df123b"
     description = "Claim routed polecat work through gc hook on nudge."
 
+  [[pack.release]]
+    version = "0.1.8"
+    ref = "main"
+    commit = "2cd3360f36b2ff55f6c306546841963cbca1ed69"
+    hash = "sha256:b43ea3c4ad1c7075fdcc4a3a4a8d96bcf6fcf9155ead288bd50afc4c31d81561"
+    description = "Constrain review-leg assignments to analysis-only mutations and allow formula-specific review bead closeout."
+
 [[pack]]
   name = "cass"
   description = "Coding Agent Session Search prompt fragments and skill overlays for Gas City."


### PR DESCRIPTION
## Summary
- forbid synthetic/test bead creation and unrelated live-state mutation in mol-review-leg
- narrow polecat close guidance so formula-specific review/control closeout can complete
- release gastown 0.1.8 in registry.toml

## Validation
- bash gastown/tests/test_gastown_pack_assets.sh
- python3 -m pytest -q
- make registry-format-validate
- GC=/data/tmp/gc-release-v1.3.0-8d32a07a0-20260617T0017Z/gc make registry-validate
- python3 scripts/pack_release_compat.py --gc-bin /data/tmp/gc-release-v1.3.0-8d32a07a0-20260617T0017Z/gc --registry registry.toml --pack gastown --workdir /data/tmp/pack-compat-gastown-0.1.8-20260617T003556Z --exercise each