### PR TITLE
Release gastown 0.1.9 review-only contract fix

### DIFF
--- a/gastown/formulas/mol-review-leg.toml
+++ b/gastown/formulas/mol-review-leg.toml
@@ -15,6 +15,9 @@ Review legs are analysis-only. Do not create synthetic/test beads, route new
 work, assign or reassign unrelated beads, or run live mutation experiments to
 "observe" behavior. The only allowed bead mutations are the formula-prescribed
 updates to the review bead itself, the completion mail, and the final drain ack.
+When the assignment contains a plan, checklist, or procedure, treat that text as
+the subject being reviewed. Do not execute those listed steps unless the
+assignment explicitly says this review leg must execute them.
 
 This keeps review findings durable in beads instead of transient pane output
 or per-worktree scratch files.
@@ -62,6 +65,10 @@ Do not invent a different scope, format, or deliverable.
 reassign unrelated beads, or mutate live state just to observe behavior. If a
 piece of evidence would require changing unrelated state, document that it was
 not performed and continue with the existing assignment data.
+
+If the assignment describes a plan or checklist, review the text and report on
+it. Do not start cities, spawn sessions, route extra work, or perform checklist
+items just because they appear in the material being reviewed.
 """
 
 [[steps]]

--- a/gastown/tests/test_gastown_pack_assets.sh
+++ b/gastown/tests/test_gastown_pack_assets.sh
@@ -159,6 +159,10 @@ test_review_leg_contract_forbids_synthetic_mutation() {
         fail "review-leg load-assignment must forbid test bead creation"
     grep -F 'The only allowed bead mutations are the formula-prescribed' "$formula" >/dev/null ||
         fail "review-leg formula must define allowed mutation boundary"
+    grep -F 'treat that text as' "$formula" >/dev/null ||
+        fail "review-leg formula must treat plans/checklists as review subject matter"
+    grep -F 'Do not start cities, spawn sessions, route extra work' "$formula" >/dev/null ||
+        fail "review-leg formula must forbid executing reviewed checklist items"
     grep -F 'Formula-specific non-implementation assignments may explicitly tell you' "$prompt" >/dev/null ||
         fail "polecat prompt must allow formula-specific review/control close steps"
     grep -F 'Default implementation formula: `mol-polecat-work`' "$prompt" >/dev/null ||

--- a/registry.toml
+++ b/registry.toml
@@ -103,6 +103,13 @@ schema = 1
     hash = "sha256:b43ea3c4ad1c7075fdcc4a3a4a8d96bcf6fcf9155ead288bd50afc4c31d81561"
     description = "Constrain review-leg assignments to analysis-only mutations and allow formula-specific review bead closeout."
 
+  [[pack.release]]
+    version = "0.1.9"
+    ref = "main"
+    commit = "92a9e8558b86854264ccc082fe9f27d48db3c749"
+    hash = "sha256:610d39141c58201147a39649e68a772001ed57d6f97ea7856fd10f469afcacda"
+    description = "Clarify review-leg plans are review subject matter, not executable instructions."
+
 [[pack]]
   name = "cass"
   description = "Coding Agent Session Search prompt fragments and skill overlays for Gas City."

--- a/scripts/gascity_pack_inference_gate.py
+++ b/scripts/gascity_pack_inference_gate.py
@@ -2122,7 +2122,9 @@ def gastown_review_assignment_description() -> str:
     return """\
 Run a bounded Gastown orchestration review-leg gate.
 
-Review the following tiny release-gate plan:
+Review the following tiny release-gate plan as written. Do not execute the
+plan, start another city, spawn sessions, or route extra work; the numbered
+steps are the subject of the review.
 
 1. Start a disposable Gastown city.
 2. Require mayor, deacon, boot, and witness sessions to exist after startup.

--- a/tests/test_gascity_pack_inference_gate.py
+++ b/tests/test_gascity_pack_inference_gate.py
@@ -762,6 +762,13 @@ def test_gastown_session_matching_accepts_bound_and_unbound_identities() -> None
     assert gascity_pack_inference_gate.missing_session_agents(sessions, ["refinery"]) == ["refinery"]
 
 
+def test_gastown_review_assignment_is_review_only() -> None:
+    description = gascity_pack_inference_gate.gastown_review_assignment_description()
+
+    assert "Do not execute the" in description
+    assert "the subject of the review" in description
+
+
 def test_require_gastown_review_report_checks_structured_notes() -> None:
     gascity_pack_inference_gate.require_gastown_review_report(
         {


### PR DESCRIPTION
## Summary
- clarify mol-review-leg treats plans/checklists as review subject matter, not executable steps
- make the Gastown orchestration gate assignment explicitly review-only
- release gastown 0.1.9 in registry.toml

## Validation
- bash gastown/tests/test_gastown_pack_assets.sh
- python3 -m pytest tests/test_gascity_pack_inference_gate.py -q
- python3 -m pytest -q
- make registry-format-validate
- GC=/data/tmp/gc-release-v1.3.0-2fe28ea32-20260617T0049Z/gc make registry-validate
- python3 scripts/pack_release_compat.py --gc-bin /data/tmp/gc-release-v1.3.0-2fe28ea32-20260617T0049Z/gc --registry registry.toml --pack gastown --workdir /data/tmp/pack-compat-gastown-0.1.9-20260617T010446Z --exercise each