### PR TITLE
Release gastown 0.1.10 formula continuation fix

### DIFF
--- a/gastown/agents/polecat/prompt.template.md
+++ b/gastown/agents/polecat/prompt.template.md
@@ -117,6 +117,12 @@ claim or current molecule identifies a different formula, such as
 **FIRST: Read your formula steps.** Do NOT use Claude's internal task tools.
 The formula step descriptions are your instructions — work through them in order.
 
+**Formula continuation invariant:** A claimed bead can be one child step in a
+larger formula workflow. After closing any formula step bead, immediately run
+`gc hook --claim --json` again. If it returns work, execute that next step.
+Do not declare the session done until a final formula step tells you to drain
+or `gc hook --claim --json` returns no work.
+
 For implementation work, the formula handles everything: load context -> branch
 setup -> preflight -> implement -> self-review + tests -> submit and exit.
 
@@ -160,7 +166,7 @@ and only falls through to unassigned pool work routed to
 `${GC_RIG:+$GC_RIG/}{{ .BindingPrefix }}polecat`; it also performs the atomic
 claim before you inspect the bead.
 
-**Hook claim -> Read formula steps -> Follow in order -> done sequence.**
+**Hook claim -> Read formula steps -> Follow in order -> claim next step or drain.**
 
 ## Context Exhaustion
 

--- a/gastown/template-fragments/propulsion.template.md
+++ b/gastown/template-fragments/propulsion.template.md
@@ -147,6 +147,10 @@ That single command checks assigned work first (session bead ID, runtime
 session name, then alias), falls through to routed pool work, and performs the
 atomic claim before you inspect the bead.
 
+Formula workflows are split into child step beads. After closing a step bead,
+immediately run `gc hook --claim --json` again. Keep claiming and executing
+ready steps until a final formula step drains you or the hook returns no work.
+
 You were spawned with work. There is no extra decision to make. Run it.
 
 **Who depends on you:** The witness monitors your health. The refinery waits

--- a/gastown/tests/test_gastown_pack_assets.sh
+++ b/gastown/tests/test_gastown_pack_assets.sh
@@ -142,6 +142,10 @@ test_polecat_startup_uses_standard_hook_claim() {
         fail "polecat prompt should call the standard hook claim path"
     grep -F 'gc hook --claim --json' "$propulsion" >/dev/null ||
         fail "polecat propulsion fragment should call the standard hook claim path"
+    grep -F 'After closing any formula step bead, immediately run' "$prompt" >/dev/null ||
+        fail "polecat prompt must require hook continuation after each formula step"
+    grep -F 'After closing a step bead,' "$propulsion" >/dev/null ||
+        fail "polecat propulsion fragment must require hook continuation after each formula step"
     ! grep -F 'run `gc hook` or' "$prompt" >/dev/null ||
         fail "polecat prompt must not regress to an unclaimed hook/work-query choice"
     ! grep -F 'run `gc hook` or' "$propulsion" >/dev/null ||

--- a/registry.toml
+++ b/registry.toml
@@ -110,6 +110,13 @@ schema = 1
     hash = "sha256:610d39141c58201147a39649e68a772001ed57d6f97ea7856fd10f469afcacda"
     description = "Clarify review-leg plans are review subject matter, not executable instructions."
 
+  [[pack.release]]
+    version = "0.1.10"
+    ref = "main"
+    commit = "33d3a430a67d1782ad364556cb566bdb01d0afe3"
+    hash = "sha256:5a83996226e3154f29fc1bca13ff0e8b37a1a02cee8f71fb70bddcdcea2e6895"
+    description = "Require Gastown polecats to continue claiming formula step beads until final drain."
+
 [[pack]]
   name = "cass"
   description = "Coding Agent Session Search prompt fragments and skill overlays for Gas City."


### PR DESCRIPTION
## Summary
- require Gastown polecats to run gc hook --claim --json after closing formula step beads
- update polecat prompt and propulsion fragment so formula workflows continue until final drain/no work
- release gastown 0.1.10 in registry.toml

## Validation
- bash gastown/tests/test_gastown_pack_assets.sh
- python3 -m pytest -q
- make registry-format-validate
- GC=/data/tmp/gc-release-v1.3.0-521b77b72-20260617T0118Z/gc make registry-validate
- python3 scripts/pack_release_compat.py --gc-bin /data/tmp/gc-release-v1.3.0-521b77b72-20260617T0118Z/gc --registry registry.toml --pack gastown --workdir /data/tmp/pack-compat-gastown-0.1.10-20260617T013339Z --exercise each