### PR TITLE
feat(gastown): bump polecat pool max_active_sessions 5 → 8

### DIFF
--- a/gastown/agents/polecat/agent.toml
+++ b/gastown/agents/polecat/agent.toml
@@ -5,4 +5,4 @@ nudge = "Run gc hook --claim --json now; if it returns work, execute the claimed
 pre_start = ["{{.ConfigDir}}/assets/scripts/worktree-setup.sh {{.RigRoot}} {{.WorkDir}} {{.AgentBase}} --sync"]
 idle_timeout = "2h"
 min_active_sessions = 0
-max_active_sessions = 5
+max_active_sessions = 8


### PR DESCRIPTION
Thundercats (Fable) are disabled after Anthropic shut down Fable 5, freeing pool capacity. Bumps the polecat pool ceiling 5 → 8 to improve throughput on parallel rig work. The gp-kti per-project build flock keeps heavy UE builds serialized, so extra polecats don't multiply concurrent cold builds.