### PR TITLE
fix(refinery): clarify mechanical conflict handling

### DIFF
--- a/gastown/agents/refinery/prompt.template.md
+++ b/gastown/agents/refinery/prompt.template.md
@@ -13,10 +13,11 @@
 ## Your Role: REFINERY (Merge Queue Processor for {{ .RigName }})
 
 **CARDINAL RULE: You are a merge processor, NOT a developer.**
-- You NEVER write application code. You merge branches mechanically.
+- You may make mechanical integration edits when the correct result is obvious.
 - If tests fail due to the branch: REJECT it back to the pool.
 - If tests fail due to pre-existing issues: file a bead. Do NOT fix it yourself.
-- FORBIDDEN: Reading polecat code to "understand what they were trying to do."
+- FORBIDDEN: Reading broad polecat code to infer intent. Inspect only conflicted
+  files and immediate context needed for mechanical conflict resolution.
 - FORBIDDEN: Landing integration branches to {{ .DefaultBranch }} via raw git commands
   (`git merge`, `git push`). Integration branches are landed by assigning the
   convoy bead to you with the correct metadata — you merge it like any other work bead.
@@ -34,7 +35,7 @@ the bead. No separate MR beads.
 
 | Situation | Your Decision |
 |-----------|---------------|
-| Merge conflict detected | Abort and reject to pool, or attempt trivial resolution |
+| Merge conflict detected | Resolve mechanical conflicts yourself; reject only when resolution requires product/feature judgment |
 | Tests fail after merge | Diagnose: branch regression or pre-existing? Reject or file bug. |
 | Push fails | Retry with backoff, or abort and investigate |
 | Pre-existing test failure | File bead for tracking (NEVER fix it yourself) — check for duplicates first |
@@ -228,7 +229,7 @@ Never infer a branch name. If `metadata.branch` is missing, reject the bead.
 
 ## Rejection Flow
 
-On rebase conflict or test failure:
+On unresolved rebase conflict or test failure:
 1. Put work bead back in pool:
    `gc bd update $WORK --status=open --assignee="" --set-metadata rejection_reason="..."`
 2. Branch handling depends on failure type:

--- a/gastown/formulas/mol-refinery-patrol.toml
+++ b/gastown/formulas/mol-refinery-patrol.toml
@@ -223,6 +223,15 @@ If rebase SUCCEEDED (exit 0): close this step, proceed to run-tests.
 
 If rebase FAILED (conflicts):
 
+Resolve the conflict yourself when the result is mechanical: combine
+non-overlapping changes, preserve ordering/formatting in generated or
+manifest-like files, update imports/lists/changelogs/snapshots, then continue
+to quality gates and note the resolved paths on the bead.
+
+Do NOT resolve conflicts that require developer judgment: choosing
+behavior/API/schema/migration/UX, rewriting feature logic, or inferring intent
+from broad branch archaeology. In that case, reject to the polecat pool:
+
 1. Abort: `git rebase --abort`
 2. Clean up the existing workflow and reopen the source bead:
 ```bash
@@ -233,7 +242,7 @@ gc workflow delete-source $WORK --apply && gc workflow reopen-source $WORK
 gc bd update $WORK \
   --status=open \
   --assignee="" \
-  --set-metadata rejection_reason="Conflicts with $TARGET at $(git rev-parse origin/$TARGET)" \
+  --set-metadata rejection_reason="Conflicts with $TARGET at $(git rev-parse origin/$TARGET): <conflicted paths and unresolved decision>" \
   --set-metadata gc.routed_to="${GC_RIG:+$GC_RIG/}{{binding_prefix}}polecat"
 ```
 4. Do NOT delete the branch (new polecat needs it for conflict resolution).


### PR DESCRIPTION
## Summary
- clarify that refinery should resolve obvious mechanical rebase conflicts itself
- keep semantic/product decisions routed back to the polecat pool
- include conflicted paths and unresolved decisions in rejection metadata

## Rationale
Refinery agents have been overly cautious around trivial conflicts and often push work back to the polecat pool by default. That creates unnecessary churn: pool resets, repeated pickup/rebase cycles, and stale branches for conflicts the refinery can safely resolve as part of normal merge processing. This keeps the boundary explicit: mechanical integration is refinery-owned; developer judgment still goes back to polecat.

## Validation
- go test ./...