### PR TITLE
feat(contributing): external-contributor lifecycle pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,20 @@ your use case:
 See the [tiering design memo](./docs/design/slack-pack-tiering.md) for the
 rationale.
 
+### Contributor workflow packs
+
+Discipline for sending good work *to* another repo — planning, building,
+reviewing, and shipping the PRs your city authors.
+
+- [pr-pipeline](./pr-pipeline) ships the author-side PR workflows as formulas
+  (and four wrapper `pr` commands): plan an issue into a structured plan, map a
+  change's blast radius, self-review an outgoing PR against an 11-category
+  scorecard, and run a pre-push gate. None of them push or open PRs.
+- [contributing](./contributing) stitches the full external-contributor
+  lifecycle for `gastownhall/gascity` — write a good issue, find priority work,
+  open a PR, self-review — into one map. It imports `pr-pipeline` for steps 2-4
+  and adds the net-new `write-issue` issue-authoring discipline for step 1.
+
 ## Contributing
 
 Issues and pull requests are welcome. When a pack's surface changes, update

--- a/contributing/README.md
+++ b/contributing/README.md
@@ -1,0 +1,87 @@
+# Contributing
+
+The external-contributor lifecycle for
+[gastownhall/gascity](https://github.com/gastownhall/gascity), distributed as a
+Gas City pack.
+
+It gives an outside contributor the full journey of landing work upstream — and
+routes each step to the command that runs it.
+
+## The lifecycle
+
+| Step | What you do | Command | Owned by |
+|------|-------------|---------|----------|
+| 1 | Write a high-quality issue | `write-issue` skill (this pack) | **contributing** |
+| 2 | Find a priority issue to work on | `gc sling <rig>/<agent> mol-pr-triage --formula` | pr-pipeline |
+| 3 | Plan & build the PR | `gc pr-pipeline pr plan <issue>` + `pr blast-radius` | pr-pipeline |
+| 4 | Self-review before pushing | `gc pr-pipeline pr review <pr>` + `pr ship` | pr-pipeline |
+
+Two entry points join the same loop:
+
+- **PR a priority issue** — start at step 2 (triage to find work), then plan it.
+- **PR your own issue** — start at step 1 (file the issue), then plan it.
+
+The `contributing` skill is the operational map; it explains both entry points
+and links each step to its command.
+
+## Why it composes pr-pipeline
+
+Steps 2-4 are already delivered by the
+[pr-pipeline](../pr-pipeline) pack — its `mol-pr-triage`, `mol-pr-start`
+(`pr plan`), `mol-pr-blast-radius` (`pr blast-radius`), `mol-pr-review`
+(`pr review`), and `mol-pr-ship` (`pr ship`) formulas. This pack does **not**
+re-implement them; it imports pr-pipeline and references those commands.
+
+The one net-new piece is **step 1** — the `write-issue` skill, the
+issue-authoring discipline that the pr-pipeline workflows assume has already
+happened.
+
+## Pairing
+
+This pack pairs with `pr-pipeline`. The pairing is declared in `pack.toml`:
+
+```toml
+[imports.pr-pipeline]
+source = "../pr-pipeline"   # path; or git URL when published
+```
+
+Repoint `source` to wherever your city vendors pr-pipeline. The `write-issue`
+skill is fully self-contained and works on its own; the `contributing` lifecycle
+skill is where the pr-pipeline commands come into play, so the full step 2-4
+experience needs pr-pipeline available.
+
+## Usage
+
+In your city's `pack.toml`:
+
+```toml
+[imports.contributing]
+source = "../packs/contributing"   # path; or git URL when published
+```
+
+Then the skills load for your coding agent, and the paired pr-pipeline commands
+are available as `gc pr-pipeline pr ...`.
+
+## Pack contents
+
+```
+contributing/
+├── pack.toml                       schema=2; imports pr-pipeline
+├── README.md
+├── skills/
+│   ├── contributing/SKILL.md       the lifecycle map (both entry points)
+│   └── write-issue/SKILL.md        net-new: contributor issue-writing discipline
+├── doctor/                         preflight checks (gc, gh, git present)
+│   ├── check-gc.sh   + gc/doctor.toml
+│   ├── check-gh.sh   + gh/doctor.toml
+│   └── check-git.sh  + git/doctor.toml
+└── tests/
+    ├── test_skill_frontmatter.py   skills have name + description
+    └── test_pack_structure.py      pairing declared; doctor scripts executable
+```
+
+## Tests
+
+```sh
+python3 -m pytest contributing/tests/
+```

--- a/contributing/doctor/check-gc.sh
+++ b/contributing/doctor/check-gc.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if ! command -v gc >/dev/null 2>&1; then
+  echo "gc CLI not found"
+  echo "Install or expose the gc binary so the pr-pipeline pr commands can dispatch formulas."
+  exit 2
+fi
+
+echo "gc CLI available"

--- a/contributing/doctor/check-gh.sh
+++ b/contributing/doctor/check-gh.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "gh CLI not found"
+  echo "Install the GitHub CLI so you can search duplicates and file issues/PRs against gastownhall/gascity."
+  exit 2
+fi
+
+echo "gh CLI available"

--- a/contributing/doctor/check-git.sh
+++ b/contributing/doctor/check-git.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if ! command -v git >/dev/null 2>&1; then
+  echo "git not found"
+  echo "Install git so you can verify the bug against origin/main before filing."
+  exit 2
+fi
+
+echo "git available"

--- a/contributing/doctor/gc/doctor.toml
+++ b/contributing/doctor/gc/doctor.toml
@@ -1,0 +1,2 @@
+description = 'gc CLI is available for pr-pipeline formula dispatch'
+run = '../check-gc.sh'

--- a/contributing/doctor/gh/doctor.toml
+++ b/contributing/doctor/gh/doctor.toml
@@ -1,0 +1,2 @@
+description = 'GitHub CLI is available for duplicate search and issue/PR filing'
+run = '../check-gh.sh'

--- a/contributing/doctor/git/doctor.toml
+++ b/contributing/doctor/git/doctor.toml
@@ -1,0 +1,2 @@
+description = 'git is available for verifying bugs against origin/main'
+run = '../check-git.sh'

--- a/contributing/pack.toml
+++ b/contributing/pack.toml
@@ -1,0 +1,32 @@
+# Contributing — the external-contributor lifecycle for gastownhall/gascity,
+# distributed as a Gas City pack.
+#
+# Gives an outside contributor the full journey of landing work in
+# https://github.com/gastownhall/gascity:
+#
+#   1. write a best-practice issue        (this pack's write-issue skill)
+#   2. find priority work                  (pr-pipeline: mol-pr-triage)
+#   3. plan & open a PR for an issue        (pr-pipeline: pr plan + pr blast-radius)
+#   4. self-review before pushing           (pr-pipeline: pr review + pr ship)
+#
+# Only step 1 is net-new here. Steps 2-4 are ALREADY delivered by the
+# pr-pipeline pack, so this pack composes pr-pipeline rather than
+# re-implementing it. The contributing skill stitches the four steps into a
+# single lifecycle and routes each one to the right command.
+#
+# Usage in your city's pack.toml:
+#   [imports.contributing]
+#   source = "../packs/contributing"   # path; or git URL when published
+#
+# This pack pairs with pr-pipeline. The import below resolves the sibling
+# pack so `gc pr-pipeline pr ...` commands are available alongside the
+# contributing skills. Repoint `source` to wherever your city vendors
+# pr-pipeline (a git URL once both packs are published).
+
+[pack]
+name = "contributing"
+version = "0.1.0"
+schema = 2
+
+[imports.pr-pipeline]
+source = "../pr-pipeline"

--- a/contributing/skills/contributing/SKILL.md
+++ b/contributing/skills/contributing/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: contributing
+description: The full external-contributor lifecycle for gastownhall/gascity — write a good issue, find priority work, open a PR, and self-review before pushing. Use when someone wants to contribute to Gas City and needs to know which step they're on and which command runs it. Routes each step to the right tool (this pack's write-issue skill for filing; the pr-pipeline pack's pr commands for triage, planning, review, and the pre-push gate).
+---
+
+# Contributing to Gas City
+
+You are an external contributor to
+[gastownhall/gascity](https://github.com/gastownhall/gascity). This skill is the
+map of the whole journey — from "I noticed something" to "my PR is ready to
+push" — and which command runs each step.
+
+It stitches together two packs:
+
+- **this pack (`contributing`)** owns step 1: writing a high-quality issue.
+- **the `pr-pipeline` pack** owns steps 2-4: finding work, planning and building
+  the PR, and the pre-push self-review gate. This pack imports it, so its
+  `gc pr-pipeline pr ...` commands are available alongside the skills here.
+
+Nothing here pushes a branch or opens a PR for you — those stay explicit human
+actions. Each step produces an artifact (an issue, a plan, a report) you act on.
+
+## The lifecycle
+
+```
+   ┌─ 1. write a good issue ────────────────┐   (this pack: write-issue)
+   │                                         │
+   │   ┌─ 2. find priority work ─────────┐   │   (pr-pipeline: mol-pr-triage)
+   │   │                                 │   │
+   ▼   ▼                                 │   │
+   3. plan & build the PR ───────────────┘   │   (pr-pipeline: pr plan + pr blast-radius)
+   │                                         │
+   ▼                                         │
+   4. self-review before pushing ◀───────────┘   (pr-pipeline: pr review + pr ship)
+```
+
+| Step | What you do | Command | Owned by |
+|------|-------------|---------|----------|
+| 1 | Write a high-quality issue | follow the [write-issue](../write-issue/SKILL.md) skill | this pack |
+| 2 | Find a priority issue to work on | `gc sling <rig>/<agent> mol-pr-triage --formula` | pr-pipeline |
+| 3a | Plan a PR from an issue | `gc pr-pipeline pr plan <issue> --rig <rig>` | pr-pipeline |
+| 3b | Map the impact surface | `gc pr-pipeline pr blast-radius "<scope>" --rig <rig>` | pr-pipeline |
+| 4a | Self-review the outgoing PR | `gc pr-pipeline pr review <pr-number> --rig <rig>` | pr-pipeline |
+| 4b | Run the pre-push gate | `gc pr-pipeline pr ship --rig <rig>` | pr-pipeline |
+
+## Two entry points
+
+The lifecycle is one loop, but you join it at different places depending on what
+you're starting from.
+
+### A. PR a priority issue (someone else's issue, or a triage pick)
+
+You want to help, but you don't have a specific bug in mind yet. Start at
+**step 2**.
+
+1. **Find work** — run triage to scan open issues and rank them into a
+   contributor work-queue:
+
+   ```bash
+   gc sling <rig>/<agent> mol-pr-triage --formula
+   ```
+
+   `mol-pr-triage` has no wrapper command; it's dispatched as a formula and
+   writes a ranked queue. Pick an issue that's unassigned and in scope for you.
+
+2. **Plan the PR** for the issue you picked — go to **step 3**.
+
+### B. PR your own issue (something you found)
+
+You hit a bug or have a change in mind. Start at **step 1**.
+
+1. **Write the issue** first, with the [write-issue](../write-issue/SKILL.md)
+   skill. Filing it before you code gives a maintainer a chance to redirect the
+   approach, flag a duplicate, or point at a design constraint — cheaper than
+   finding that out on the PR.
+
+2. **Plan the PR** on the issue you just filed — go to **step 3**.
+
+## Step 3 — plan & build the PR
+
+Both entry points converge here. You have an issue number.
+
+1. **Plan it.** This front-loads the analysis a maintainer's review will check,
+   before any code is written — competing-PR and architectural-refactor gates,
+   blast radius, repo conventions, and a plan audited against recurring review
+   findings:
+
+   ```bash
+   gc pr-pipeline pr plan <issue> --rig <rig>
+   ```
+
+   The plan lands in `.gc/pr-pipeline/plans/issue-<issue>.md`. No code is
+   written. Read it before you start.
+
+2. **Map blast radius** for any change that isn't trivially local — refactors,
+   anything touching shared state, lifecycle, or dispatch:
+
+   ```bash
+   gc pr-pipeline pr blast-radius "<scope>" --rig <rig>
+   ```
+
+3. **Implement** against the plan. Keep the change scoped to what the issue
+   asks; note anything adjacent as out-of-scope rather than folding it in.
+
+> Shortcut: `mol-pr-from-issue` chains issue → plan → implement → ship-gate in
+> one routed run. It halts at branch-ready by default (no push, no PR):
+>
+> ```bash
+> gc sling <rig>/<agent> mol-pr-from-issue --formula --var issue_number=<N>
+> ```
+
+## Step 4 — self-review before pushing
+
+Catch the structural and correctness defects a careful maintainer review would
+flag, so your PR lands with few or no review comments.
+
+1. **Score the change** against the 11-category scorecard (correctness, contract
+   fidelity, blast radius, concurrency, error handling, security, resource
+   lifecycle, release safety, test evidence, architectural consistency,
+   debuggability):
+
+   ```bash
+   gc pr-pipeline pr review <pr-number> --rig <rig>
+   ```
+
+   It writes a scorecard to `.gc/pr-pipeline/reviews/pr-<pr-number>.md` and gives
+   a verdict (`block` / `request_changes` / `approve`). Apply the fixes it
+   surfaces.
+
+2. **Run the pre-push gate** — simplify, iterate the self-review until clean, run
+   the mechanical checks (build / vet / test / docs), and produce a readiness
+   report:
+
+   ```bash
+   gc pr-pipeline pr ship --rig <rig>
+   ```
+
+   It **stops at the report.** Pushing the branch and opening the PR are your
+   call — make them once the report is clean.
+
+## Notes
+
+- Replace `<rig>` with your rig name and `<agent>` with your city's coding worker.
+  The pr-pipeline wrapper commands dispatch to a default coding-worker agent;
+  pass `--agent <name>` if your city's worker is named differently.
+- The pr-pipeline commands are read-only outside their own `.gc/pr-pipeline/`
+  output paths, except `pr ship`, which may modify the diff during its simplify
+  and review-iteration stages.
+- For the deeper mechanics of each pr-pipeline formula, see the
+  [pr-pipeline README](../../../pr-pipeline/README.md).

--- a/contributing/skills/write-issue/SKILL.md
+++ b/contributing/skills/write-issue/SKILL.md
@@ -1,0 +1,269 @@
+---
+name: write-issue
+description: Write a high-quality issue for gastownhall/gascity as an external contributor. Enforces the investigation a maintainer would otherwise have to redo — confirm the bug actually exists on the current main (not just your branch or version), search for duplicates first, map blast radius, and produce a body with file:line root-cause refs and at least two fix candidates. Prevents the common "filed from memory, never verified against main" failure mode that gets issues bounced back.
+---
+
+# Write an Issue
+
+You are an external contributor filing an issue to
+[gastownhall/gascity](https://github.com/gastownhall/gascity). A good issue does
+the investigation up front so a maintainer can act on it without redoing your
+work. A vague issue — wrong file paths, missed duplicate, no root cause — costs
+the maintainer the whole investigation before they can even triage it, so it
+sits.
+
+This skill makes you do that investigation in the right order.
+
+## When to use
+
+- You hit a bug, footgun, or surprising behavior while using `gc` and want it
+  fixed upstream.
+- You have a feature request or architectural concern worth surfacing — the
+  investigation discipline below applies to non-bug issues too.
+
+**Do NOT skip this skill and call `gh issue create` directly.** Issues filed
+from raw notes or memory routinely cite paths from an old version or a local
+branch, miss an existing duplicate, and lack the `file:line` root-cause refs a
+maintainer needs to act. A misfiled issue is worse than no issue: someone has to
+redo the investigation before they can respond.
+
+## Workflow
+
+Run these **in order**. Don't skip ahead.
+
+### 1. Triage the observation
+
+Decide three things:
+
+- **Upstream-relevant?** Does this affect code in `gastownhall/gascity`, or is
+  it specific to your own deployment / config? If it's local-only, stop — don't
+  file it upstream.
+- **Scope:** bug / feature / docs?
+- **Rough priority:** P1 (breaks many users / data loss / unrecoverable) / P2
+  (significant friction, workaround exists) / P3 (polish, nice-to-have).
+  Priority is about how many users hit it and how recoverable it is — not how
+  loud it was for you. Most ergonomics issues are P3.
+
+### 2. Search for duplicates (REQUIRED — do not skip)
+
+Before any investigation:
+
+```bash
+# 2-3 searches with different keyword combinations
+gh issue list --repo gastownhall/gascity --state all --search "<core-symptom-keywords>" --limit 20
+gh issue list --repo gastownhall/gascity --state all --search "<file-or-component-name>" --limit 20
+gh pr list   --repo gastownhall/gascity --state all --search "<core-symptom-keywords>" --limit 20
+```
+
+If you find a match:
+
+- **Open issue, no resolution:** add your repro / extra context as a comment.
+  Done — don't open a second issue.
+- **Open issue, already in flight (assignee or recent activity):** same — comment
+  and link, done.
+- **Closed-fixed:** check whether the fix is in the version of `gc` you observed
+  the bug on. If the fix shipped and you still hit it, that's a *regression* —
+  file a NEW issue and reference the original.
+- **Closed-wontfix / not-planned:** read the discussion first. There may be a
+  deliberate decision you're missing. Don't silently refile.
+
+### 3. Verify the bug exists on current main (REQUIRED)
+
+The most common failure mode: a bug seen on an old version or a feature branch
+is reported as if it's on `main`, but `main` already fixed it (or never had the
+buggy code). Always verify against an up-to-date checkout of
+`gastownhall/gascity` at `origin/main`.
+
+```bash
+# from your local clone of gastownhall/gascity
+git fetch origin && git log -1 origin/main --oneline   # confirm the tree is current
+git checkout origin/main
+
+# locate the symptom in code
+grep -rn "<error-string-or-symbol>" --include="*.go" --include="*.py" --include="*.toml"
+
+# read the relevant function(s) and confirm the buggy path is on main
+sed -n '<line-range>p' <file>
+
+# look for recent fixes that might already be in flight
+git log --oneline -20 -- <affected-files>
+git log --oneline -S "<key-symbol-or-comment>" -20
+```
+
+| Finding | Action |
+|---|---|
+| Buggy code path present on main | Continue to step 4 |
+| Buggy code path absent on main (already refactored) | Find the commit that fixed it (`git log`). Don't file — the fix is already in. If it hasn't been released yet, that's worth noting on the relevant PR instead |
+| Buggy code path present, but a recent commit/PR already addresses it | Reference that PR in your issue, or comment on it — don't duplicate |
+
+### 4. Check architectural alignment (REQUIRED — do not skip)
+
+The area you're touching may already be governed by an accepted design doc in
+`engdocs/design/`. If it is, your fix candidates need to align with the design's
+prescribed behavior, not work around it. Filing candidates that contradict an
+accepted design wastes a maintainer's review and risks a "this conflicts with §X
+of doc Y" reply.
+
+```bash
+# from your origin/main checkout
+
+# 1. list accepted / implementing design docs
+grep -lE "^\| Status \|.*\b(Accepted|Implementing|Implemented)\b" engdocs/design/*.md
+
+# 2. for each candidate, grep for your symptom's keywords
+grep -nE '<symptom-keyword>' engdocs/design/<candidate>.md
+
+# 3. if a doc covers the area, read its relevant section in full —
+#    especially any "Rules:" or invariant lists. The design's contract is
+#    what a maintainer will hold your fix candidates against.
+
+# 4. check whether an open PR is already continuing the refactor in this area
+gh pr list --repo gastownhall/gascity --state open --search "<area-keyword>" --limit 20
+```
+
+| Finding | Action |
+|---|---|
+| No design doc covers the area | Continue to step 5 |
+| Design doc covers the area, describes a DIFFERENT paradigm than your fix implies | Don't draft fix candidates from scratch. Read the section. Either revise your candidates to align with the design, or note in the body that the symptom contradicts the design's invariant `<X>` (with file/line ref) and ask which way to fix |
+| Design doc covers the area, your fix lands in the SAME paradigm | Cite the doc section in your "Root cause" — frame the bug as "violates §X of doc Y". Signals you did the homework |
+| Design doc covers the area and the relevant phase is queued | Your candidates may be superseded. Propose a narrow point-fix the upcoming work can absorb, or open a comment on the design discussion instead of a fresh issue |
+
+### 5. Reduce to a minimum reproduction
+
+Distill the observation to the smallest reproduction someone else can run:
+
+- The exact `gc` subcommand or API call that triggers it
+- The city/rig state required (running, supervisor mode, …)
+- Expected vs. actual behavior
+- If timing-sensitive: the race window
+
+If you can't write a clean repro, that's a signal you don't understand the bug
+well enough yet. Investigate more, or file with an explicit "repro is
+best-effort" caveat — and tag it P3, because triage will have to figure it out.
+
+### 6. Map blast radius (for non-trivial bugs)
+
+For anything touching reconciler, controller, lifecycle, dispatch, or any
+subsystem with cross-cutting effects, do a blast-radius pass:
+
+- Who calls the affected function? Are any on hot paths (tick loops, reconciler
+  loops, hot HTTP routes)?
+- Does it interact with config reload? Goroutine lifecycle? Shared state?
+- What test layer would catch it (unit, acceptance, integration)? Does any
+  existing test cover the path?
+
+This feeds the "Root cause" and "Fix candidates" sections.
+
+### 7. Draft fix candidates (≥ 2)
+
+Force yourself to name **at least two** fix candidates before writing the body. A
+single-candidate issue forecloses the discussion. Two candidates expose the
+trade-offs (correctness vs. backwards-compat, complexity vs. blast radius,
+point-fix vs. structural).
+
+Each candidate gets:
+
+- A one-line description
+- A rough scope (LOC, files touched)
+- The trade-off it represents
+
+Mark which one you'd recommend and why — but leave the decision to the
+maintainer.
+
+### 8. Write the body using this template
+
+```markdown
+## Summary
+
+<1-2 sentences. The maintainer should know whether to read further.>
+
+## Symptom
+
+<What you observe. Literal log lines, error strings, UI behavior. Not root
+cause yet.>
+
+## Reproduction
+
+<Concrete, copy-pasteable steps. If timing-sensitive, note the race window.>
+
+Result: `<expected>` → got: `<actual>`.
+
+## Root cause
+
+<Tie the symptom to specific code with `path/to/file.go:LINE` references.>
+
+The buggy invariant is `<X>` (`<path>:<line>`). It's violated when `<Y>`
+because `<Z>` (`<path>:<line>`).
+
+## Fix candidates
+
+**A. <name>** — <one-line description>.
+- Scope: <LOC / files>
+- Trade-off: <what gets better / what gets worse>
+
+**B. <name>** — <one-line description>.
+- Scope: <LOC / files>
+- Trade-off: <what gets better / what gets worse>
+
+**Recommendation:** <A or B> because <reason>. Maintainer's call.
+
+## Adjacent / out of scope
+
+<Anything you noticed that's related but shouldn't be part of this fix. Helps
+the maintainer scope the work.>
+```
+
+### 9. File with labels
+
+```bash
+gh issue create --repo gastownhall/gascity \
+  --title "<kind: short imperative title>" \
+  --body-file /tmp/issue-body.md \
+  --label "kind/<bug|feature|docs>,priority/p<1|2|3>,status/needs-triage"
+```
+
+**Title conventions** (match the existing issue list):
+
+- `bug: <component>: <symptom>` — e.g. `bug: city stuck in adopting_sessions on supervisor restart`
+- `feat: <component>: <capability>` — e.g. `feat: per-agent watchdog gating`
+- `docs: <area>: <correction>` — e.g. `docs: deacon: point at "gc bd formula show"`
+
+Include `status/needs-triage` unless a maintainer has already agreed to take it
+directly.
+
+## After filing
+
+Once the issue exists, you can pick it up yourself: see the [contributing
+lifecycle](../contributing/SKILL.md), which routes a filed issue straight into
+`gc pr-pipeline pr plan <issue>` to plan the PR.
+
+## Anti-patterns
+
+- ❌ **Filing without verifying the bug still exists on main.** The failure mode
+  this skill exists to prevent. Always do step 3.
+- ❌ **Filing without a duplicate search.** Wastes everyone's time when it's
+  already tracked.
+- ❌ **Filing without checking active design docs.** Fix candidates that
+  contradict an accepted `engdocs/design/*.md` invariant get retracted on the
+  first maintainer pass. Run step 4 before drafting — even when you "already know
+  the fix".
+- ❌ **Symptoms-only body, no root-cause file:line refs.** The maintainer has to
+  redo your investigation. P3 at minimum, or write the refs.
+- ❌ **Single fix candidate.** Forecloses the design space.
+- ❌ **Skipping "out of scope".** Adjacent-looking issues that aren't part of the
+  fix cause scope creep; naming them upfront prevents it.
+- ❌ **Filing as P1 because it felt big.** Priority is reach and recoverability,
+  not how loud it was for you.
+
+## Quick checklist before `gh issue create`
+
+- [ ] Searched duplicates (3+ searches) — none open
+- [ ] Confirmed the bug exists on `origin/main` today (`git rev-parse origin/main`)
+- [ ] Checked `engdocs/design/*.md` for accepted docs covering this area; cited
+      the relevant section OR confirmed none applies
+- [ ] Have `file:line` refs for the root cause
+- [ ] Have ≥ 2 fix candidates with trade-offs named (and they don't contradict an
+      active design invariant)
+- [ ] Reduced to a minimum reproduction OR caveated explicitly
+- [ ] Body has all required sections
+- [ ] Labels include kind, priority, and `status/needs-triage`

--- a/contributing/tests/test_pack_structure.py
+++ b/contributing/tests/test_pack_structure.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import os
+import pathlib
+import re
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+class PackStructureTests(unittest.TestCase):
+    def test_pack_declares_pr_pipeline_import(self) -> None:
+        """The contributing pack composes pr-pipeline; the pairing must be declared."""
+        text = (ROOT / "pack.toml").read_text(encoding="utf-8")
+        self.assertRegex(text, r"(?m)^\[imports\.pr-pipeline\]")
+        self.assertRegex(text, r"(?m)^\s*source\s*=")
+
+    def test_skill_name_matches_directory(self) -> None:
+        for skill in sorted(ROOT.glob("skills/*/SKILL.md")):
+            text = skill.read_text(encoding="utf-8")
+            match = re.search(r"(?m)^name:\s*(\S+)", text)
+            self.assertIsNotNone(match, f"{skill} missing name")
+            self.assertEqual(
+                match.group(1),
+                skill.parent.name,
+                f"{skill} frontmatter name must match its directory",
+            )
+
+    def test_doctor_check_scripts_are_executable(self) -> None:
+        scripts = sorted(ROOT.glob("doctor/check-*.sh"))
+        self.assertTrue(scripts, "expected at least one doctor check script")
+        for script in scripts:
+            self.assertTrue(
+                os.access(script, os.X_OK),
+                f"{script} must be executable (release hashes depend on the +x bit)",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/contributing/tests/test_skill_frontmatter.py
+++ b/contributing/tests/test_skill_frontmatter.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import pathlib
+import re
+import unittest
+
+
+class SkillFrontmatterTests(unittest.TestCase):
+    def test_all_skills_have_name_and_description(self) -> None:
+        root = pathlib.Path(__file__).resolve().parents[1]
+        skill_files = sorted(root.glob("skills/*/SKILL.md"))
+
+        self.assertEqual(
+            [path.parent.name for path in skill_files],
+            [
+                "contributing",
+                "write-issue",
+            ],
+        )
+        for path in skill_files:
+            text = path.read_text(encoding="utf-8")
+            match = re.match(r"\A---\n(?P<body>.*?)\n---\n", text, re.DOTALL)
+            self.assertIsNotNone(match, f"{path} missing YAML front matter")
+            body = match.group("body") if match else ""
+            self.assertRegex(body, r"(?m)^name:\s*\S+", f"{path} missing name")
+            self.assertRegex(body, r"(?m)^description:\s*\S+", f"{path} missing description")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds the **`contributing`** pack — the external-contributor lifecycle for
`gastownhall/gascity`, distributed as a Gas City pack. It gives an outside
contributor the full journey of landing work upstream and routes each step to
the command that runs it:

1. **write a best-practice issue** — this pack's `write-issue` skill (net-new)
2. **find priority work** — `pr-pipeline: mol-pr-triage`
3. **plan & open a PR** — `pr-pipeline: pr plan` + `pr blast-radius`
4. **self-review before pushing** — `pr-pipeline: pr review` + `pr ship`

Only **step 1 is net-new.** Steps 2–4 are already delivered by `pr-pipeline`, so
this pack **composes** it via `[imports.pr-pipeline]` rather than re-implementing
— the `contributing` skill stitches the four steps into one lifecycle with two
entry points (PR a priority issue / PR your own issue).

## Contents

- `skills/write-issue/SKILL.md` — contributor issue-writing discipline: verify
  the bug on current `main` first, required duplicate search, `engdocs/design`
  invariant alignment, reconciler/dispatch blast-radius, file:line root cause,
  ≥2 fix candidates, body template, anti-patterns, pre-flight checklist.
- `skills/contributing/SKILL.md` — the lifecycle map (both entry points).
- `pack.toml` (schema 2, `[imports.pr-pipeline]`), README, doctor set (gc/gh/git),
  tests.

## Verification

- **Gates:** `contributing/tests` 4/4, repo-wide `tests/` 52/52, `pr-pipeline/tests`
  10/10, `validate_registry.py` ok.
- **Cross-pack refs checked against pr-pipeline:** `mol-pr-from-issue` exists;
  `gc sling … --formula` matches pr-pipeline's own documented syntax; the
  `pr plan/blast-radius/review/ship` commands all exist.
- **Repo refs checked against `gastownhall/gascity`:** the prescribed labels
  (`kind/bug|feature|docs`, `priority/p1–p3`, `status/needs-triage`) all exist,
  and `engdocs/design/` is real — so `gh issue create --label` and the
  design-alignment step won't dead-end a contributor.
- **Config-pure / no role assumptions / no private SDK** per the pack invariants;
  composes (does not duplicate) pr-pipeline.

A `0.1.0` registry release will be stamped as a follow-up once this merges
(matching the pr-pipeline release flow).
