### PR TITLE
release(contributing): self-contained gas-city pack 0.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         run: python3 validate_registry.py
 
       - name: Run Python pack tests
-        run: python3 -m pytest tests gascity/tests discord/tests github/tests slack-full/tests slack-channel/tests pr-pipeline/tests -q
+        run: python3 -m pytest tests contributing/tests gascity/tests discord/tests github/tests slack-full/tests slack-channel/tests pr-pipeline/tests -q
 
       - name: Run Gastown shell tests
         run: |

--- a/contributing/README.md
+++ b/contributing/README.md
@@ -5,50 +5,48 @@ The external-contributor lifecycle for
 Gas City pack.
 
 It gives an outside contributor the full journey of landing work upstream — and
-routes each step to the command that runs it.
+carries Gas City's **actual** standards at every step. This is not generic PR
+discipline: the adoption-review audit (B1–B36), the blast-radius dimensions, the
+design-capture rule, the five test tiers, and the code conventions a Gas City
+maintainer reviews against are all **baked into the skill text**, so your own
+coding agent applies them by reading the skill.
+
+## Self-contained by design
+
+This pack has **no imports** and depends on nothing you might not have — no
+internal agents, no sibling pack, no maintainer-only tooling. Every skill is a
+self-applicable checklist. You run the workflow with `git`, `gh`, and your
+coding agent reading the skills; that's it.
+
+> The generic [pr-pipeline] pack is still the right choice for a city that wants
+> contributor discipline without Gas City's particular standards. This pack is
+> the gas-city-specific instantiation — it trades portability for baked-in
+> standards.
 
 ## The lifecycle
 
-| Step | What you do | Command | Owned by |
-|------|-------------|---------|----------|
-| 1 | Write a high-quality issue | `write-issue` skill (this pack) | **contributing** |
-| 2 | Find a priority issue to work on | `gc sling <rig>/<agent> mol-pr-triage --formula` | pr-pipeline |
-| 3 | Plan & build the PR | `gc pr-pipeline pr plan <issue>` + `pr blast-radius` | pr-pipeline |
-| 4 | Self-review before pushing | `gc pr-pipeline pr review <pr>` + `pr ship` | pr-pipeline |
+| Step | What you do | Skill |
+|------|-------------|-------|
+| 1 | Write a high-quality issue | [`write-issue`](skills/write-issue/SKILL.md) |
+| 2 | Find a priority issue to work on | [`find-work`](skills/find-work/SKILL.md) |
+| 3 | Plan the PR (adoption-review-aware) | [`plan-pr`](skills/plan-pr/SKILL.md) |
+| 4 | Map the impact surface | [`blast-radius`](skills/blast-radius/SKILL.md) |
+| 5 | Run the codebase audit + gates | [`check`](skills/check/SKILL.md) |
+| 6 | Self-review before pushing | [`ship`](skills/ship/SKILL.md) |
 
 Two entry points join the same loop:
 
-- **PR a priority issue** — start at step 2 (triage to find work), then plan it.
-- **PR your own issue** — start at step 1 (file the issue), then plan it.
+- **PR a priority issue** — start at step 2 (`find-work` to triage), then plan it.
+- **PR your own issue** — start at step 1 (`write-issue`), then plan it.
 
-The `contributing` skill is the operational map; it explains both entry points
-and links each step to its command.
+The [`contributing`](skills/contributing/SKILL.md) skill is the operational map;
+it explains both entry points and links each step to its skill.
 
-## Why it composes pr-pipeline
+## Nothing here pushes for you
 
-Steps 2-4 are already delivered by the
-[pr-pipeline](../pr-pipeline) pack — its `mol-pr-triage`, `mol-pr-start`
-(`pr plan`), `mol-pr-blast-radius` (`pr blast-radius`), `mol-pr-review`
-(`pr review`), and `mol-pr-ship` (`pr ship`) formulas. This pack does **not**
-re-implement them; it imports pr-pipeline and references those commands.
-
-The one net-new piece is **step 1** — the `write-issue` skill, the
-issue-authoring discipline that the pr-pipeline workflows assume has already
-happened.
-
-## Pairing
-
-This pack pairs with `pr-pipeline`. The pairing is declared in `pack.toml`:
-
-```toml
-[imports.pr-pipeline]
-source = "../pr-pipeline"   # path; or git URL when published
-```
-
-Repoint `source` to wherever your city vendors pr-pipeline. The `write-issue`
-skill is fully self-contained and works on its own; the `contributing` lifecycle
-skill is where the pr-pipeline commands come into play, so the full step 2-4
-experience needs pr-pipeline available.
+Each step produces an artifact you act on — an issue body, a plan, a blast-radius
+report, an audit verdict, a readiness report. The `ship` skill stops at the
+readiness report. **Pushing the branch and opening the PR are your call.**
 
 ## Usage
 
@@ -59,25 +57,30 @@ In your city's `pack.toml`:
 source = "../packs/contributing"   # path; or git URL when published
 ```
 
-Then the skills load for your coding agent, and the paired pr-pipeline commands
-are available as `gc pr-pipeline pr ...`.
+Then the skills load for your coding agent. You can also read them directly from
+this directory — they're self-contained Markdown.
 
 ## Pack contents
 
 ```
 contributing/
-├── pack.toml                       schema=2; imports pr-pipeline
+├── pack.toml                       schema=2; no imports (self-contained)
 ├── README.md
 ├── skills/
 │   ├── contributing/SKILL.md       the lifecycle map (both entry points)
-│   └── write-issue/SKILL.md        net-new: contributor issue-writing discipline
+│   ├── write-issue/SKILL.md        file a maintainer-grade issue
+│   ├── find-work/SKILL.md          triage open issues into a work-queue
+│   ├── plan-pr/SKILL.md            adoption-review-aware PR planning
+│   ├── blast-radius/SKILL.md       map the impact surface of a change
+│   ├── check/SKILL.md              mechanical gates + the B1–B36 audit
+│   └── ship/SKILL.md               pre-push self-review gate
 ├── doctor/                         preflight checks (gc, gh, git present)
 │   ├── check-gc.sh   + gc/doctor.toml
 │   ├── check-gh.sh   + gh/doctor.toml
 │   └── check-git.sh  + git/doctor.toml
 └── tests/
-    ├── test_skill_frontmatter.py   skills have name + description
-    └── test_pack_structure.py      pairing declared; doctor scripts executable
+    ├── test_contributing_skill_frontmatter.py   skills have name + description
+    └── test_contributing_pack_structure.py      self-contained; doctor scripts executable
 ```
 
 ## Tests
@@ -85,3 +88,5 @@ contributing/
 ```sh
 python3 -m pytest contributing/tests/
 ```
+
+[pr-pipeline]: https://github.com/gastownhall/gascity-packs/tree/main/pr-pipeline

--- a/contributing/doctor/check-gc.sh
+++ b/contributing/doctor/check-gc.sh
@@ -3,7 +3,7 @@ set -eu
 
 if ! command -v gc >/dev/null 2>&1; then
   echo "gc CLI not found"
-  echo "Install or expose the gc binary so the pr-pipeline pr commands can dispatch formulas."
+  echo "Install or build the gas-city CLI (\`make build\`) so you can run the city and reproduce behavior while contributing to gastownhall/gascity."
   exit 2
 fi
 

--- a/contributing/doctor/gc/doctor.toml
+++ b/contributing/doctor/gc/doctor.toml
@@ -1,2 +1,2 @@
-description = 'gc CLI is available for pr-pipeline formula dispatch'
+description = 'gc CLI is available to run the city and reproduce behavior while contributing'
 run = '../check-gc.sh'

--- a/contributing/pack.toml
+++ b/contributing/pack.toml
@@ -4,29 +4,35 @@
 # Gives an outside contributor the full journey of landing work in
 # https://github.com/gastownhall/gascity:
 #
-#   1. write a best-practice issue        (this pack's write-issue skill)
-#   2. find priority work                  (pr-pipeline: mol-pr-triage)
-#   3. plan & open a PR for an issue        (pr-pipeline: pr plan + pr blast-radius)
-#   4. self-review before pushing           (pr-pipeline: pr review + pr ship)
+#   1. write a best-practice issue        (write-issue skill)
+#   2. find priority work                  (find-work skill)
+#   3. plan a PR for an issue              (plan-pr skill)
+#   4. map the impact surface             (blast-radius skill)
+#   5. verify against the codebase audit  (check skill)
+#   6. self-review before pushing          (ship skill)
 #
-# Only step 1 is net-new here. Steps 2-4 are ALREADY delivered by the
-# pr-pipeline pack, so this pack composes pr-pipeline rather than
-# re-implementing it. The contributing skill stitches the four steps into a
-# single lifecycle and routes each one to the right command.
+# SELF-CONTAINED by design. Every step carries Gas City's ACTUAL standards
+# baked into the skill text — the full adoption-review audit (B1-B36), the
+# blast-radius dimensions, the design-capture discipline, the five test
+# tiers, the code conventions — so a contributor's own coding agent applies
+# them by READING the skill. There is NO [imports.*]: the pack stands alone
+# and depends on nothing a contributor lacks (no internal agents, no sibling
+# pack, no maintainer infrastructure).
+#
+# This is the gas-city-specific instantiation of the contributor lifecycle.
+# The generic pr-pipeline pack remains the right choice for cities that want
+# discipline without gas-city's particular standards; this pack bakes those
+# standards in.
 #
 # Usage in your city's pack.toml:
 #   [imports.contributing]
 #   source = "../packs/contributing"   # path; or git URL when published
 #
-# This pack pairs with pr-pipeline. The import below resolves the sibling
-# pack so `gc pr-pipeline pr ...` commands are available alongside the
-# contributing skills. Repoint `source` to wherever your city vendors
-# pr-pipeline (a git URL once both packs are published).
+# The skills then load for your coding agent. Nothing here pushes a branch or
+# opens a PR — each step produces an artifact (an issue, a plan, a report) you
+# act on. Pushing is always your call.
 
 [pack]
 name = "contributing"
-version = "0.1.0"
+version = "0.2.0"
 schema = 2
-
-[imports.pr-pipeline]
-source = "../pr-pipeline"

--- a/contributing/skills/blast-radius/SKILL.md
+++ b/contributing/skills/blast-radius/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: blast-radius
+description: Map the full impact surface of a change to gastownhall/gascity before you commit — callers and their execution contexts (startup/tick/reload/CLI/API/shutdown), downward callees and their risky patterns (stale config, swallowed store errors, leaked goroutines), config-field sync chains, the six domain-boundary crossings, concurrency, and cross-repo contracts (gastown/beads). Self-contained — runs on plain git + grep + gh, no internal tooling. Use before committing anything that touches the reconciler, controller, lifecycle, dispatch, config, or any cross-subsystem code, and as Phase 2 of the plan-pr skill.
+---
+
+# Map the Blast Radius
+
+You are working on a change to
+[gastownhall/gascity](https://github.com/gastownhall/gascity) and need to know
+what it ripples to before you commit. A narrow-looking change can run on a config
+reload, leak a goroutine in a CLI path, or read stale config — the failures a
+maintainer's adoption review catches. This skill maps the surface so you catch
+them first.
+
+Run it from your local checkout. It uses only `git`, `grep`, and `gh` — no
+special index required. (If you've run `codegraph init` in the repo, its
+`codegraph_callers` / `codegraph_impact` are faster than grep for caller traces;
+fall back to grep when it returns nothing or the call is dynamic.)
+
+> `main` below means the upstream main you're targeting — `origin/main` if origin
+> is `gastownhall/gascity`, else `upstream/main`.
+
+## Step 1 — Enumerate touched functions
+
+```bash
+git diff main...HEAD --stat
+git diff main...HEAD -- '*.go' | grep '^[+-]func ' | grep -v _test.go
+```
+
+Record each new/modified function: package, name, exported/unexported.
+
+## Step 2 — Map callers (upward)
+
+For each touched function, find who calls it:
+
+```bash
+grep -rn 'FunctionName(' cmd/gc/ internal/ --include='*.go' | grep -v _test.go
+```
+
+Classify every caller into an execution context — the context determines the risk:
+
+| Context | Characteristics | Key concern |
+|---|---|---|
+| `newCityRuntime` | Runs once at startup | Safe for one-time sweeps |
+| `controller tick` | Runs every ~30s in the reconcile loop | Must be fast and idempotent |
+| `tryReloadConfig` / `update()` | Runs on config-file change | Reading `cs.cfg` directly sees the PREVIOUS config |
+| `buildStores(cfg)` | Called from `update()` before the `cs.cfg` swap | Must use the passed `cfg`, not `cs.cfg` |
+| `cobra RunE` | CLI one-shot | Process exits after return — goroutines die |
+| `API handler` | Long-lived HTTP server | Fire-and-forget goroutines OK |
+| `buildOrderDispatcher` | Startup AND reload | No one-time operations here |
+| `gracefulStopAll` | Shutdown path | Two-pass: interrupt then force-kill |
+
+## Step 3 — Map callees (downward)
+
+Read each modified function body and trace what it calls. Flag:
+
+- **`cs.cfg` reads** inside anything called from `update()` → stale-config risk (B21)
+- **`store.SetMetadata*` / `store.Close` / `store.Create`** → errors must propagate (B12)
+- **`shellCommand` / `exec.Command`** → is the timeout shared with another subsystem? (B13)
+- **`go func()`** → is the caller a CLI path? Then it needs a completion signal (B17)
+
+## Step 4 — Config-field impact
+
+If the change adds or modifies a config field, verify it appears in **all** of
+these — a missing one is a silent drop:
+
+```bash
+grep -rn 'FieldName' internal/config/ cmd/gc/ --include='*.go' | grep -v _test.go
+```
+
+- `config.Agent` struct
+- `config.AgentPatch` struct
+- `config.AgentOverride` struct
+- `applyAgentPatch()`
+- `applyAgentOverride()`
+- `poolAgents()` deep-copy in `cmd/gc/pool.go`
+- `ApplyAgentDefaults()` if there's a city-wide default
+- `Effective*()` accessor if the nil/empty distinction matters (B11)
+
+`TestAgentFieldSync` catches the struct definitions only — the apply functions
+and the pool deep-copy must be checked by hand.
+
+## Step 5 — Domain-boundary crossings
+
+Check whether the change crosses any of these six boundaries:
+
+| Boundary | Risk |
+|---|---|
+| Pool agents ↔ named-session agents | Map keys leak; scale checks count both? (B18) |
+| User agents ↔ infrastructure agents | Loops applying work config to `control_dispatcher` (B15) |
+| Startup path ↔ reload path | One-time ops in the reload path corrupt in-flight goroutines (B16) |
+| CLI path ↔ server path | Goroutine lifecycle differs (B17) |
+| Config snapshot ↔ live config | `update()`-chain functions read stale `cs.cfg` (B21) |
+| Reconciler tick ↔ background goroutines | Shared semaphores/timeouts with unintended scope (B13) |
+
+## Step 6 — Concurrency
+
+If the change involves goroutines, semaphores, or shared state:
+
+```bash
+git diff main...HEAD -- '*.go' | grep -E 'go func|\.Lock\(|\.RLock\(|<-|chan '
+```
+
+- New goroutine in a CLI path → does it return a completion signal? (B17)
+- New semaphore → does it bound exactly the right set of operations? (B13)
+- Package-level mutable state written by reload → `atomic.*` / mutex? (B30)
+- Shared state guarded by the right mutex (e.g. `serviceStateMu`)?
+
+## Step 7 — Cross-repo impact
+
+Gas City extracts subsystems from `gastownhall/gastown`, depends on
+`gastownhall/beads`, and uses `dolthub/dolt` as its storage engine. If your
+change touches a contract that spans repos, check it:
+
+- **Beads interface** — if you touch bead-store operations (`Create`,
+  `SetMetadata`, `Query`, `Close`), confirm against `gastownhall/beads` that the
+  interface contract still holds. Browse the repo on GitHub or
+  `gh search code --repo gastownhall/beads '<symbol>'`.
+- **Gastown original behavior** — for extracted code, check how `gastownhall/gastown`
+  handled the same path. Classify a divergence as `[extraction bug]` (gascity
+  broke something gastown gets right), `[inherited]` (gastown has the same
+  limitation), or `[intentional divergence]` (document why).
+- **Upstream drift** — has gastown/beads/dolt changed recently in this area?
+  `gh search commits --repo gastownhall/gastown '<area-keyword>'`. Flag if gascity
+  may need to pull in an upstream fix.
+
+## Step 8 — Report
+
+```
+Blast Radius — <branch>
+
+Changed functions:
+  <pkg>.<Func> — <one-line summary>
+
+Execution contexts:
+  <Func> called from: startup / tick / reload / CLI / API / shutdown
+
+Upward callers:
+  <Func> ← <caller1> ← <caller2> (context: reload path)
+
+Downward callees:
+  <Func> → store.SetMetadata (must propagate error)
+  <Func> → go func() (CLI path — needs completion gate)
+
+Config field chain: complete / MISSING <which step>
+
+Domain boundary crossings:
+  Pool ↔ named-session    : safe / RISK: <detail>
+  User ↔ infra agents     : safe / RISK: <detail>
+  Startup ↔ reload        : safe / RISK: <detail>
+  CLI ↔ server            : safe / RISK: <detail>
+  Snapshot ↔ live config  : safe / RISK: <detail>
+  Tick ↔ background        : safe / RISK: <detail>
+
+Concurrency:
+  Goroutines: none / N spawned, completion signals: yes/no
+  Semaphores: none / scoped to: X subsystem only
+  Shared state: none / protected by: <mutex>
+
+Cross-repo:
+  Beads interface : compatible / DIVERGES: <detail>
+  Gastown original: matches / [extraction bug] / [inherited] / [intentional divergence]
+  Upstream drift  : none recent / NEEDS SYNC: <detail>
+
+Risk summary:
+  HIGH: <anything a maintainer would call a "major">
+  MED:  <anything a maintainer would call a "minor">
+  LOW:  <nits, style>
+
+Recommendation: PROCEED / FIX BEFORE COMMIT
+```
+
+Keep findings to one line each, with a `file:line` ref. The HIGH/MED items feed
+the `Risks` section of your [`plan-pr`](../plan-pr/SKILL.md) plan and the audit in
+[`check`](../check/SKILL.md).
+
+## When to use
+
+- Before committing a change that touches the reconciler, controller, or
+  lifecycle code.
+- When a change spans multiple subsystems (config + runtime, beads + dispatch).
+- When you're unsure whether a function runs on startup only or also on reload.
+- As **Phase 2** of [`plan-pr`](../plan-pr/SKILL.md), before you write code.

--- a/contributing/skills/check/SKILL.md
+++ b/contributing/skills/check/SKILL.md
@@ -1,0 +1,384 @@
+---
+name: check
+description: Verify a change against gastownhall/gascity's actual quality bar before you push a PR. Runs the mechanical gates (make build + make check + make check-docs if docs touched), classifies test failures as pre-existing noise vs new regressions, and audits the diff against the full Gas City adoption-review checklist (B1-B36) — zero hardcoded roles, ZFC, the Bitter Lesson, the five test tiers, the code conventions, config-nil semantics, store-write errors, timeout isolation, startup-vs-reload safety, goroutine lifecycle, do*/cmd* split, env hermeticity, and more. Self-contained — you (or your coding agent) run every check by reading this skill; no internal tools required. Use before opening any PR to gastownhall/gascity.
+---
+
+# Run the Gas City Codebase Check
+
+You are an external contributor about to open a PR to
+[gastownhall/gascity](https://github.com/gastownhall/gascity). This skill is the
+audit a Gas City maintainer's adoption review will run on your diff — front-loaded
+so you fix the findings before they cost you a review round-trip.
+
+Run it on your branch from inside your local checkout of `gastownhall/gascity`.
+Two parts: **Part A** is the mechanical gates (build/lint/vet/test/docs); **Part
+B** is the codebase audit (the B-rules). Do both. Produce the Part C report.
+
+This is self-applicable: read each rule and check it against your diff with
+`grep`/`git`/`go`. There is no agent to dispatch — the checklist *is* the
+knowledge.
+
+> **Baseline for the diff:** these commands compare your work against the main
+> you branched from. If `origin` is `gastownhall/gascity`, use `origin/main`. If
+> you're working from a fork, fetch upstream first
+> (`git fetch upstream && git merge-base HEAD upstream/main`) and substitute
+> `upstream/main`. Below, `main` means "the upstream main you're targeting."
+
+## Part A — Mechanical gates
+
+### A1. Determine scope
+
+```bash
+git diff main...HEAD --name-only
+```
+
+Set scope flags:
+
+- `docs/**`, `*.mdx`, `docs/docs.json`, README, `engdocs/**` → also run `make check-docs`
+- `Makefile`, `go.mod`, CI files → flag for careful review
+- `cmd/gc/*.go` or `internal/**/*.go` only → `make build && make check` is sufficient
+
+### A2. Run the gates in order
+
+Each depends on the previous being green.
+
+```bash
+make build        # ~300s timeout
+make check        # ~600s timeout — runs fmt-check, lint, vet, test
+make check-docs   # only if docs/engdocs touched
+```
+
+Report status per sub-target. `make check` runs `fmt-check lint vet test`.
+
+### A3. Classify test failures
+
+`fmt-check`, `lint`, and `vet` failures are **always real blockers** — fix them.
+
+For **test** failures, separate pre-existing flakes from regressions you
+introduced. You don't have the maintainers' baseline table, so establish it
+yourself: run the failing test on a clean `main` checkout.
+
+```bash
+git worktree add /tmp/gascity-baseline main
+cd /tmp/gascity-baseline && go test -race -run 'TestNameThatFailed' ./path/to/package/... 2>&1 | tail -20
+git worktree remove /tmp/gascity-baseline
+```
+
+| Result on clean `main` | Meaning |
+|---|---|
+| Test also fails on `main` | Pre-existing flake/baseline — not yours, note it and move on |
+| Test passes on `main` | **Regression you introduced** — blocker, fix before push |
+
+Environment-dependent and race-detector-flaky tests exist; verifying against
+`main` is how you tell them apart from a real break.
+
+## Part B — Codebase audit (the B-rules)
+
+> The B-rule set is non-contiguous: **B32 is reserved and currently unused**, so
+> the active audit is B1–B31 and B33–B36. A complete pass covers every numbered
+> rule below — the absence of a B32 entry is intentional, not a missing check.
+
+Read the diff and check each rule. The rules are grouped into **five review
+lenses** — cover all five, not just the ones that feel obvious for your change.
+Each rule names the failure mode and, where useful, the public PR that taught it
+(real precedent you can read).
+
+### Design invariants (B1–B6)
+
+**B1. Zero hardcoded roles (HARD RULE).**
+```bash
+git diff main...HEAD -- '*.go' | grep -iE 'mayor|deacon|polecat|sheriff|rider|marshal' | grep -v _test.go
+```
+Any hit outside test fixtures is a blocker. Gas City has zero hardcoded role
+names in product code — roles are config-driven.
+
+**B2. Zero Framework Cognition (ZFC).** No `if stuck then restart` logic, no
+keyword/regex meaning-detection, no hardcoded semantic thresholds, no quality
+judgments in Go code. Reasoning belongs to the model, not the framework.
+
+**B3. Bitter Lesson alignment.** Flag heuristics/decision trees a smarter model
+would sidestep. Test: imagine a 10× more capable model — does this code become
+unnecessary? If yes, it's the wrong shape.
+
+**B4. SDK self-sufficiency.** No SDK operation may depend on a specific
+`[[agent]]` entry existing.
+
+**B5. No status files.** Grep for PID/lock/state-file writes in `.gc/runtime/`
+or `/tmp/`. State lives in the store, not on disk.
+
+**B6. Layering invariants.** Layer N never imports Layer N+1. `internal/`
+packages are peers — no cross-primitive imports. `internal/beads` must not import
+`cmd/gc/`.
+
+### Change impact / blast radius (B7, B9–B13, B15–B16, B18, B21, B23, B25–B26, B31, B35–B36)
+
+**B7. Code conventions (11 sub-checks).** Unit tests next to code; `t.TempDir()`;
+`//go:build integration` tag on integration tests; cobra/toml usage; atomic file
+writes; no `panic` in library code; error wrapping with `%w`; no role names;
+tmux invoked with `-L <socket>`; agent config field sync; raw string constants
+extracted (not duplicated literals).
+
+**B9. Code quality checklist.** Tests pass, vet clean, exported functions
+documented, no premature abstractions, happy path + edge cases covered, errors
+carry context, no hardcoded values.
+
+**B10. Scope discipline.** Fix what the issue asks. Don't fold in adjacent
+features or refactoring — note them as out-of-scope instead.
+
+**B11. Config nil semantics.** A new config field where the consumer needs to
+distinguish "not set" from "explicitly empty" must use `*string` (pointer), an
+`Effective*()` accessor, and patch/override updates. (PR #386.)
+
+**B12. Store-write error propagation — retain and retry, never delete and
+succeed.**
+```bash
+git diff main...HEAD | grep -E '_ = .*store\.|_ = .*SetMetadata'
+```
+A function returning `bool` after a store write must return `false` on write
+error. In an error handler for a failed store write, never call `store.Delete`,
+`store.CloseAll`, or a successor-state write as "recovery" — return the error or
+set a failure state so callers can retry. Never paper over a store error by
+deleting the source-of-truth record. (PR #480: `SetMetadataBatch` silently
+returned `true` on failure; PR #543: prune-on-error removed records whose
+terminal write had failed.)
+
+**B13. Timeout / concurrency isolation.** New timeouts/semaphores must affect
+only the intended subsystem. A shared `shellCommand` path needs splitting. Use
+config constants, not magic numbers. (PR #480.)
+
+**B15. Infrastructure-agent guards.** Loops iterating agents must exclude
+`control_dispatcher` / infrastructure agents from work-related config. (PR #386.)
+
+**B16. Startup vs reload safety.** `newCityRuntime` runs at startup only.
+`buildOrderDispatcher` / `update()` run on config reload too. One-time sweeps
+must be startup-only — putting them in a reload path corrupts in-flight state.
+(PR #526.)
+
+**B18. Map-key domain separation.** A map serving multiple consumers (pool +
+named-session) must be filtered before it's passed to each consumer, or keys
+leak across domains. (PR #535.)
+
+**B21. Config hot-reload snapshot safety.** Code in the `update()` / `buildStores()`
+chain must use the passed `cfg` parameter, not `cs.cfg` (which is stale during
+reload). (PRs #540, #526.)
+
+**B23. Fix-scope completeness + parallel code paths (the #1 adoption-review
+finding).** For an entity with multiple states
+(pending/in-flight/dead/active/creating), verify the fix handles **all** states,
+not just the one in your repro. Then: for every function you modified, grep all
+its callers; for every pattern you fixed (a missing nil-guard, a hardcoded
+string, a wrong env lookup), grep the **entire** codebase for sibling instances
+of the same pattern and fix them too. Fixing one call site while identical
+siblings stay broken is the most common reason a PR bounces. (PRs #543, #653,
+#656, #650.)
+
+**B25. Constant grep radius.** When you introduce or use a named constant, grep
+the entire codebase for the raw string value to find other occurrences that
+should use the constant too — don't limit the search to your diff. (PR #526: a
+raw `"order-tracking"` string diverged from the `labelOrderTracking` constant.)
+
+**B26. Golden-snapshot / doc-output drift.** When a change alters user-visible
+output (CLI output, log lines, error messages, `fmt.Fprintf` strings), grep
+`docs/` and `testdata/` for the old strings. Tutorial golden files
+(`docs/tutorials/*.md`) and `.txtar` fixtures hardcode command output that goes
+stale. **Extension:** the same applies to Go struct field doc comments and
+generated reference docs — when a struct field or exported function changes
+behavior, re-read its doc comment against the implementation; if it feeds
+`cmd/genschema`, run `go run ./cmd/genschema` + `make check-docs` and re-grep
+`docs/reference/` for the stale phrase. (PRs #658, #637, #1482, #1299.)
+
+**B31. Hard-fail conversion → examples audit + release note.** When a fix turns
+silent degradation (default fallback, version downgrade, skipped validation,
+silent success on missing data) into a hard error, anyone relying on the old
+silent behavior will see new failures. (1) Grep `examples/` (especially
+`examples/gastown/city.toml`) for configs that would newly hard-fail and update
+them in the same PR. (2) Flag the behavior change under a `Release note:` heading
+in the PR body. (PR #734.)
+
+**B35. Pack-binding qualification on routing/pool stamping.** Anything that
+stamps `gc.routed_to`, names a pool, or routes work by pack binding must use the
+binding-qualified name (`<binding>/<pool>`), not the bare pool name. Qualifying
+when the binding is empty is also a bug.
+```bash
+git diff main...HEAD | grep -E 'gc\.routed_to|pool\.Name|PoolName|qualifyPool'
+```
+(PRs #919, #1010, #1299.)
+
+**B36. Sweeps walk every rig.** Maintenance sweeps, orphan reapers, and
+lifecycle reconcilers must walk every rig in the city, not just HQ. The bug:
+accepting a `cityStore` and only iterating that store, silently skipping
+rig-scoped beads. Verify the loop covers `cfg.Rigs` and that progress counters
+are preserved across the loop, not reset per rig. (PRs #1448, #1010.)
+
+### Debuggability & operability (B12, B17, B22, B24, B28, B30, B34)
+
+**B17. Goroutine lifecycle (CLI vs server).** CLI commands exit immediately —
+fire-and-forget goroutines die. Return a `<-chan struct{}` completion signal, and
+callers must `defer`-block on the done channel on **all** return paths, not just
+the happy path. (PR #524: both `waitForSession` failure and an early `Attach`
+return leaked a background goroutine.)
+
+**B22. Dead-code audit.** Grep for functions/methods your PR introduces that have
+zero callers — including helpers added "for completeness" (e.g. a `Len()` on a
+wrapper). Diff new `func ` lines, then grep each name across the codebase.
+(PRs #584, #471.)
+
+**B24. Verify-before-delete.** Before pruning/closing/removing a record, verify
+its expected successor/terminal state actually exists in the store
+(`store.Get(id)` → exists check → prune). Fail open: a store-lookup error
+**retains** the record rather than deleting it. (PR #543.)
+
+**B28. Error-context wrapping.** Every new `return err` / `return fmt.Errorf(...)`
+must name the operation and entity that failed (bead ID, agent name, rig name,
+file path). Bare `return err` that drops context is a finding. The convention is
+`fmt.Errorf("adding rig %q: %w", name, err)`. A production error without context
+is invisible in logs.
+
+**B30. Package-level mutable state must be race-safe.** Any `var Foo bool/int/map`
+at package scope that's written by config reload (or any non-`init` path) and
+read by request/compile/instantiate paths must use `sync/atomic` or a mutex. The
+idiom is `atomic.Bool` with exported `SetFoo`/`IsFoo` accessors; snapshot once at
+the top of the read path.
+```bash
+git diff main...HEAD | grep -E '^\+var [A-Z][a-zA-Z]+ +(bool|int|int64|map)'
+```
+(Canonical: `internal/formula/compile.go` `formulaV2Enabled atomic.Bool`. PR #734.)
+
+**B34. Safety-predicate fail-closed.** A boolean predicate used as a safety gate
+(`HasUnpushedCommits`, `HasStashes`, `IsRepo`, `Exists`, `IsClean`, `IsHealthy`)
+must fail **closed** — returning `false` on internal error means "can't
+determine" gets treated as "safe to proceed", which is dangerous for destructive
+ops (prune/remove/reap/delete). Either return `(bool, error)` and propagate, or
+add an explicit precondition probe that fails-closed first. (PR #1482.)
+
+### Test evidence quality (B8, B14, B19–B20, B27, B33)
+
+**B8. Test-tier boundaries.** Five tiers: unit, testscript (`.txtar`),
+integration (`//go:build integration`), docsync, coordination. Put a new test in
+the right tier. A test needing more than 2 env vars belongs in a unit test, not a
+testscript.
+
+**B14. Regression-test depth.** A bug fix tests through the full write path and
+reads the state back from the store. Assertions must discriminate the exact bug
+path, and you must test **every** branch the fix introduces (early-exit, timeout,
+error, success), not just the happy path. (PRs #584, #510.)
+
+**B19. do*()/cmd*() split.** CLI commands split into `cmdFoo()` (wiring) +
+`doFoo()` (pure logic with injected deps), so the logic is unit-testable.
+
+**B20. Test-double conventions + env hermeticity.** No mock libraries — use
+hand-written fakes next to the interface, with a compile-time
+`var _ Interface = (*Fake)(nil)`. Tests that set environment variables must use
+`t.Setenv()` (auto-restores), never raw `os.Setenv` + manual defer.
+```bash
+git diff main...HEAD -- '*_test.go' | grep -nE '\bos\.Setenv\b'
+```
+Each hit is a finding. (PR #687: a test that didn't clear `GC_BEADS` failed for
+devs with it exported.)
+
+**B27. Polling over fixed sleeps in tests.** New test code uses `waitFor*` /
+`pollFor*` helpers (timeout + interval) instead of bare `time.Sleep` for state
+sync. The codebase has `waitForCondition`, `waitForFile`, `waitForBeadStatus`,
+`waitForSession`, `pollForCondition`, etc.
+```bash
+git diff main...HEAD -- '*_test.go' | grep -n 'time\.Sleep'
+```
+Each hit should justify why a polling helper won't work. (PRs #674, #621, #669.)
+
+**B33. Test save/restore for package-level state.** A test that reads/writes
+package-level mutable state (feature flags, global counters, mode switches) must
+save the prior value and restore it on cleanup — even when the variable defaults
+to `false`:
+```go
+prev := IsFooEnabled()
+SetFooEnabled(true)
+t.Cleanup(func() { SetFooEnabled(prev) })
+```
+Hardcoded-`false` cleanup corrupts later tests that run with the flag on. (PR #734.)
+
+### Portability (B29)
+
+**B29. Ambient env-var contamination — use the canonical projection layer.**
+When code reads an env var (`os.Getenv("GC_BEADS")`), verify a parent `gc`
+process in a nested launch can't pollute it. Gas City launches child `gc`
+processes and env vars leak downward. Subprocess env construction belongs in
+`cmd/gc/bd_env.go` (the model is `applyCanonicalDoltTargetEnv`, which explicitly
+overwrites stale ambient `GC_DOLT_HOST/PORT`), not inlined into command handlers.
+```bash
+git diff main...HEAD | grep -E 'os\.Getenv|os\.LookupEnv'
+```
+Trace each new read: could it be inherited from a parent `gc` with a conflicting
+value? (PR #687, env-projection extraction PR #790.)
+
+## Part C — Report
+
+Output exactly this format. Keep each B-line to one concern with a `file:line`
+ref.
+
+```
+Gas City check — <branch>
+
+Part A — Mechanical gates:
+  make build       : ✅ / ❌
+  fmt-check        : ✅ / ❌
+  lint             : ✅ / ❌
+  vet              : ✅ / ❌
+  test             : ✅ clean / ⚠️ baseline-only / ❌ NEW: <test names>
+  make check-docs  : ✅ / ❌ / n/a
+
+Part B — Codebase audit:
+  Design invariants:
+    B1  Zero hardcoded roles   : ✅ / ❌ <file:line>
+    B2  ZFC                    : ✅ / ⚠️ <concern>
+    B3  Bitter Lesson          : ✅ / ⚠️ <concern>
+    B4  SDK self-sufficiency   : ✅ / ❌
+    B5  No status files        : ✅ / ❌
+    B6  Layering               : ✅ / ❌ <import>
+  Change impact / blast radius:
+    B7  Code conventions       : ✅ / ⚠️ <which box>
+    B9  Quality checklist      : ✅ / ⚠️ <which box>
+    B10 Scope discipline       : ✅ / ⚠️
+    B11 Config nil semantics   : ✅ / ⚠️ / n/a
+    B12 Store write errors     : ✅ / ⚠️
+    B13 Timeout isolation      : ✅ / ⚠️ / n/a
+    B15 Infra agent guards     : ✅ / ⚠️ / n/a
+    B16 Startup vs reload      : ✅ / ⚠️ / n/a
+    B18 Map key separation     : ✅ / ⚠️ / n/a
+    B21 Config snapshot safety : ✅ / ⚠️ / n/a
+    B23 Fix scope completeness : ✅ / ⚠️ <missed sibling/state>
+    B25 Constant grep radius   : ✅ / ⚠️ <raw string>
+    B26 Doc/code drift         : ✅ / ⚠️ <stale doc/struct/ref> / n/a
+    B31 Hard-fail examples     : ✅ / ⚠️ <example needing update> / n/a
+    B35 Pack-binding qualify   : ✅ / ⚠️ <bare pool name> / n/a
+    B36 Sweep walks every rig  : ✅ / ⚠️ <HQ-only sweep> / n/a
+  Debuggability & operability:
+    B17 Goroutine lifecycle    : ✅ / ⚠️ / n/a
+    B22 Dead code audit        : ✅ / ⚠️ <dead func>
+    B24 Verify-before-delete   : ✅ / ⚠️ / n/a
+    B28 Error context wrapping : ✅ / ⚠️ <bare return err> / n/a
+    B30 Package race-safety    : ✅ / ⚠️ <var> / n/a
+    B34 Safety-predicate close : ✅ / ⚠️ <fail-open predicate> / n/a
+  Test evidence quality:
+    B8  Test tier              : ✅ / ⚠️
+    B14 Regression depth       : ✅ / ⚠️
+    B19 do*()/cmd*() split     : ✅ / ⚠️ / n/a
+    B20 Test doubles + env     : ✅ / ⚠️ <os.Setenv> / n/a
+    B27 Polling over sleeps    : ✅ / ⚠️ <time.Sleep> / n/a
+    B33 Save/restore pkg state : ✅ / ⚠️ <hardcoded cleanup> / n/a
+  Portability:
+    B29 Ambient env contamination: ✅ / ⚠️ <var name> / n/a
+
+Verdict: READY TO PUSH / NEEDS FIXES
+```
+
+## When to use
+
+- Before opening any PR to `gastownhall/gascity`.
+- After fixing issues a previous run of this check flagged.
+- Whenever you're unsure a change meets the codebase bar.
+
+Mechanical-gate failures and B-rule findings are not equal: `fmt-check`/`lint`/`vet`
+and a real test regression are hard blockers; B-rule `⚠️` findings are things a
+maintainer will flag — fix them, or consciously decide to leave one and say why
+in the PR body. The [`ship`](../ship/SKILL.md) skill runs this check as its final
+gate.

--- a/contributing/skills/contributing/SKILL.md
+++ b/contributing/skills/contributing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: contributing
-description: The full external-contributor lifecycle for gastownhall/gascity — write a good issue, find priority work, open a PR, and self-review before pushing. Use when someone wants to contribute to Gas City and needs to know which step they're on and which command runs it. Routes each step to the right tool (this pack's write-issue skill for filing; the pr-pipeline pack's pr commands for triage, planning, review, and the pre-push gate).
+description: The full external-contributor lifecycle for gastownhall/gascity — write a good issue, find priority work, plan a PR, map its blast radius, run the codebase audit, and self-review before pushing. Use when someone wants to contribute to Gas City and needs to know which step they're on and which skill runs it. Self-contained: every step is a skill in this pack with Gas City's actual standards baked in — no internal tooling, no sibling pack.
 ---
 
 # Contributing to Gas City
@@ -8,143 +8,107 @@ description: The full external-contributor lifecycle for gastownhall/gascity —
 You are an external contributor to
 [gastownhall/gascity](https://github.com/gastownhall/gascity). This skill is the
 map of the whole journey — from "I noticed something" to "my PR is ready to
-push" — and which command runs each step.
+push" — and which skill runs each step.
 
-It stitches together two packs:
+Everything lives in this one pack. Each step carries Gas City's **actual**
+standards (the adoption-review audit, the blast-radius dimensions, the
+design-capture rule, the test tiers) baked into the skill text, so your coding
+agent applies them by reading. There's nothing to install beyond `git`, `gh`, and
+a local checkout.
 
-- **this pack (`contributing`)** owns step 1: writing a high-quality issue.
-- **the `pr-pipeline` pack** owns steps 2-4: finding work, planning and building
-  the PR, and the pre-push self-review gate. This pack imports it, so its
-  `gc pr-pipeline pr ...` commands are available alongside the skills here.
-
-Nothing here pushes a branch or opens a PR for you — those stay explicit human
-actions. Each step produces an artifact (an issue, a plan, a report) you act on.
+Nothing here pushes a branch or opens a PR for you — those stay your explicit
+call. Each step produces an artifact (an issue, a plan, a report) you act on.
 
 ## The lifecycle
 
 ```
-   ┌─ 1. write a good issue ────────────────┐   (this pack: write-issue)
-   │                                         │
-   │   ┌─ 2. find priority work ─────────┐   │   (pr-pipeline: mol-pr-triage)
-   │   │                                 │   │
-   ▼   ▼                                 │   │
-   3. plan & build the PR ───────────────┘   │   (pr-pipeline: pr plan + pr blast-radius)
-   │                                         │
-   ▼                                         │
-   4. self-review before pushing ◀───────────┘   (pr-pipeline: pr review + pr ship)
+   ┌─ 1. write a good issue ───────────────┐   (write-issue)
+   │                                        │
+   │   ┌─ 2. find priority work ────────┐   │   (find-work)
+   │   │                                │   │
+   ▼   ▼                                │   │
+   3. plan the PR ──────────────────────┘   │   (plan-pr)
+   │                                        │
+   ▼                                        │
+   4. map blast radius                      │   (blast-radius)
+   │                                        │
+   ▼                                        │
+   5. run the codebase check                │   (check)
+   │                                        │
+   ▼                                        │
+   6. self-review before pushing ◀──────────┘   (ship)
 ```
 
-| Step | What you do | Command | Owned by |
-|------|-------------|---------|----------|
-| 1 | Write a high-quality issue | follow the [write-issue](../write-issue/SKILL.md) skill | this pack |
-| 2 | Find a priority issue to work on | `gc sling <rig>/<agent> mol-pr-triage --formula` | pr-pipeline |
-| 3a | Plan a PR from an issue | `gc pr-pipeline pr plan <issue> --rig <rig>` | pr-pipeline |
-| 3b | Map the impact surface | `gc pr-pipeline pr blast-radius "<scope>" --rig <rig>` | pr-pipeline |
-| 4a | Self-review the outgoing PR | `gc pr-pipeline pr review <pr-number> --rig <rig>` | pr-pipeline |
-| 4b | Run the pre-push gate | `gc pr-pipeline pr ship --rig <rig>` | pr-pipeline |
+| Step | What you do | Skill |
+|------|-------------|-------|
+| 1 | Write a high-quality issue | [write-issue](../write-issue/SKILL.md) |
+| 2 | Find a priority issue to work on | [find-work](../find-work/SKILL.md) |
+| 3 | Plan the PR (adoption-review-aware) | [plan-pr](../plan-pr/SKILL.md) |
+| 4 | Map the impact surface | [blast-radius](../blast-radius/SKILL.md) |
+| 5 | Run mechanical gates + the B1–B36 audit | [check](../check/SKILL.md) |
+| 6 | Self-review and produce a readiness report | [ship](../ship/SKILL.md) |
 
 ## Two entry points
 
-The lifecycle is one loop, but you join it at different places depending on what
+The lifecycle is one loop; you join it at different places depending on what
 you're starting from.
 
 ### A. PR a priority issue (someone else's issue, or a triage pick)
 
-You want to help, but you don't have a specific bug in mind yet. Start at
-**step 2**.
+You want to help but don't have a specific bug in mind. Start at **step 2**.
 
-1. **Find work** — run triage to scan open issues and rank them into a
-   contributor work-queue:
-
-   ```bash
-   gc sling <rig>/<agent> mol-pr-triage --formula
-   ```
-
-   `mol-pr-triage` has no wrapper command; it's dispatched as a formula and
-   writes a ranked queue. Pick an issue that's unassigned and in scope for you.
-
+1. **Find work** — run [find-work](../find-work/SKILL.md) to scan open issues,
+   rank them into a contributor work-queue, and filter out anything already
+   covered by an open PR or blocked on a maintainer decision. Pick an unassigned,
+   in-scope issue that passes the decision gates.
 2. **Plan the PR** for the issue you picked — go to **step 3**.
 
 ### B. PR your own issue (something you found)
 
 You hit a bug or have a change in mind. Start at **step 1**.
 
-1. **Write the issue** first, with the [write-issue](../write-issue/SKILL.md)
-   skill. Filing it before you code gives a maintainer a chance to redirect the
-   approach, flag a duplicate, or point at a design constraint — cheaper than
-   finding that out on the PR.
-
+1. **Write the issue** first with [write-issue](../write-issue/SKILL.md). Filing
+   it before you code gives a maintainer a chance to redirect the approach, flag a
+   duplicate, or point at a design constraint — far cheaper than finding that out
+   on the PR.
 2. **Plan the PR** on the issue you just filed — go to **step 3**.
 
-## Step 3 — plan & build the PR
+## Step 3 — plan the PR
 
-Both entry points converge here. You have an issue number.
+Both entry points converge here; you have an issue number. Run
+[plan-pr](../plan-pr/SKILL.md). It front-loads the analysis the maintainer's
+review will check — the competing-PR and architectural-refactor gates, blast
+radius, convention alignment, the design-capture decision, and a plan audited
+against the recurring review findings. **No code is written until the plan is
+confirmed.**
 
-1. **Plan it.** This front-loads the analysis a maintainer's review will check,
-   before any code is written — competing-PR and architectural-refactor gates,
-   blast radius, repo conventions, and a plan audited against recurring review
-   findings:
+## Step 4 — map blast radius
 
-   ```bash
-   gc pr-pipeline pr plan <issue> --rig <rig>
-   ```
+For any change that isn't trivially local — refactors, anything touching shared
+state, lifecycle, config, or dispatch — run [blast-radius](../blast-radius/SKILL.md)
+to map callers, execution contexts, config-field sync chains, domain boundaries,
+and concurrency before you write the code. (plan-pr calls this in as its Phase 2.)
 
-   The plan lands in `.gc/pr-pipeline/plans/issue-<issue>.md`. No code is
-   written. Read it before you start.
+## Step 5 — implement, then check
 
-2. **Map blast radius** for any change that isn't trivially local — refactors,
-   anything touching shared state, lifecycle, or dispatch:
+Implement against the plan, keeping the change scoped to what the issue asks
+(note anything adjacent as out-of-scope). Then run [check](../check/SKILL.md): the
+mechanical gates (`make build` / `make check` / `make check-docs`) with
+baseline-vs-regression classification, plus the full B1–B36 codebase audit.
 
-   ```bash
-   gc pr-pipeline pr blast-radius "<scope>" --rig <rig>
-   ```
+## Step 6 — self-review before pushing
 
-3. **Implement** against the plan. Keep the change scoped to what the issue
-   asks; note anything adjacent as out-of-scope rather than folding it in.
-
-> Shortcut: `mol-pr-from-issue` chains issue → plan → implement → ship-gate in
-> one routed run. It halts at branch-ready by default (no push, no PR):
->
-> ```bash
-> gc sling <rig>/<agent> mol-pr-from-issue --formula --var issue_number=<N>
-> ```
-
-## Step 4 — self-review before pushing
-
-Catch the structural and correctness defects a careful maintainer review would
-flag, so your PR lands with few or no review comments.
-
-1. **Score the change** against the 11-category scorecard (correctness, contract
-   fidelity, blast radius, concurrency, error handling, security, resource
-   lifecycle, release safety, test evidence, architectural consistency,
-   debuggability):
-
-   ```bash
-   gc pr-pipeline pr review <pr-number> --rig <rig>
-   ```
-
-   It writes a scorecard to `.gc/pr-pipeline/reviews/pr-<pr-number>.md` and gives
-   a verdict (`block` / `request_changes` / `approve`). Apply the fixes it
-   surfaces.
-
-2. **Run the pre-push gate** — simplify, iterate the self-review until clean, run
-   the mechanical checks (build / vet / test / docs), and produce a readiness
-   report:
-
-   ```bash
-   gc pr-pipeline pr ship --rig <rig>
-   ```
-
-   It **stops at the report.** Pushing the branch and opening the PR are your
-   call — make them once the report is clean.
+Run [ship](../ship/SKILL.md): the design-capture gate, a simplify pass, a
+self-review loop against the recurring adoption-review findings, optional
+performance measurement, and the check skill — combined into one readiness
+report. **It stops at the report. Pushing the branch and opening the PR are your
+call.**
 
 ## Notes
 
-- Replace `<rig>` with your rig name and `<agent>` with your city's coding worker.
-  The pr-pipeline wrapper commands dispatch to a default coding-worker agent;
-  pass `--agent <name>` if your city's worker is named differently.
-- The pr-pipeline commands are read-only outside their own `.gc/pr-pipeline/`
-  output paths, except `pr ship`, which may modify the diff during its simplify
-  and review-iteration stages.
-- For the deeper mechanics of each pr-pipeline formula, see the
-  [pr-pipeline README](../../../pr-pipeline/README.md).
+- The whole pack is self-contained — no `[imports.*]`, no internal agents, no
+  maintainer-only tooling. If you can read these skills and run `git`/`gh`, you
+  have everything.
+- This is the gas-city-specific lifecycle. A city wanting generic contributor
+  discipline without Gas City's particular standards can use the `pr-pipeline`
+  pack instead; this pack bakes those standards in.

--- a/contributing/skills/find-work/SKILL.md
+++ b/contributing/skills/find-work/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: find-work
+description: Find a good gastownhall/gascity issue to work on as an external contributor. Scans open issues, classifies them into actionability tiers (grab now / good candidate / investigate / skip), and — critically — detects competing PRs and maintainer-decision gates so you don't pick an issue that's already in flight or that needs a maintainer's product/design call before any PR is realistic. Self-contained: plain gh queries you run yourself, no internal tooling. Use when you want to contribute but don't have a specific bug in mind yet.
+---
+
+# Find Work
+
+You want to contribute to
+[gastownhall/gascity](https://github.com/gastownhall/gascity) but don't have a
+specific bug in mind. This skill scans the open issues and ranks them into a
+contributor work-queue — and, most importantly, filters out the issues that look
+grabbable but aren't: ones already covered by an open PR, or ones that need a
+maintainer decision before any PR makes sense.
+
+Run the `gh` queries yourself (or have your coding agent run them). The output is
+a ranked list and a single recommended pick.
+
+## 1. Pull the landscape
+
+```bash
+# Open issues, richest fields first
+gh issue list --repo gastownhall/gascity --state open --limit 100 \
+  --json number,title,labels,assignees,milestone,createdAt,updatedAt,comments
+
+# Open PRs (to cross-reference against issues)
+gh pr list --repo gastownhall/gascity --state open --limit 100 \
+  --json number,title,body,author,createdAt
+```
+
+Bias toward unassigned bugs at `priority/p0`–`p1` on the current milestone — those
+are the highest-value, lowest-ambiguity picks for an outside contributor.
+
+## 2. Competing-work detection (CRITICAL — get this right)
+
+For **every** candidate you'd consider grabbing, check for a competing PR using
+**all three** methods. A single search misses PRs that reference the issue by
+number in the body, by title keywords, or only via GitHub's cross-reference
+linkage.
+
+```bash
+# a) by issue number
+gh pr list --repo gastownhall/gascity --state open --search "<issue-number>"
+# b) by issue title keywords
+gh pr list --repo gastownhall/gascity --state open --search "<key phrases from the title>"
+# c) by the issue's cross-reference timeline
+gh api repos/gastownhall/gascity/issues/<number>/timeline --paginate \
+  --jq '.[] | select(.source.issue.pull_request) | .source.issue.html_url'
+```
+
+If **any** method finds an open PR targeting the issue → **Tier 4 (skip)**.
+Picking a contested issue wastes your time and creates merge conflicts.
+
+## 3. Maintainer-decision gates (run on every Tier 1/2 candidate)
+
+Competing-work checks catch duplicate PRs but miss issues where the fix needs a
+maintainer **product or design decision** before any PR is realistic. Apply these
+four blocking gates — if one fires, demote to Tier 3 (investigate, don't grab):
+
+- **DD — Design-doc conflict.** Grep `engdocs/design/*.md` for the issue's symbols;
+  if an `Accepted`/`Implementing` doc contradicts the issue's proposed direction,
+  the fix needs a maintainer's call. Demote.
+- **AU — Author uncertainty.** The issue body ends with "?" or contains phrasing
+  like "is this a bug or", "intended behavior", "Or at least", "Is X supposed
+  to", or proposes 2+ alternatives without committing. Demote.
+- **MA — Maintainer-ambivalent comment.** A maintainer comment says "good point"
+  / "we should" but gives no directive and links no PR. The direction isn't
+  settled. Demote.
+- **PD — Product decision disguised as a bug.** The "Expected/Actual" sections
+  argue a product opinion ("should be lighter", "feels counter-intuitive") rather
+  than pointing at a concrete defect. Demote.
+
+Emit a `Gates: [DD AU MA PD]` line on every Tier 1/2 entry, marking which fired.
+**The recommended pick must pass all four.**
+
+Also flag (don't demote): comment-thread scope drift — retracted repros, adjacent
+follow-ups, or 3+ clarifying exchanges with no maintainer commitment.
+
+## 4. Classify into tiers
+
+| Tier | Meaning | Criteria |
+|---|---|---|
+| **1 — GRAB NOW** | Clear, unblocked, high-value | Unassigned, clear bug, current milestone, p0/p1, no competing PR, all decision gates pass |
+| **2 — GOOD CANDIDATE** | Solid but needs some investigation | p1/p2 bug, fixable, no competing PR, gates pass |
+| **3 — INVESTIGATE FIRST** | Unclear scope or needs a maintainer call | A decision gate fired, or scope is ambiguous |
+| **4 — SKIP** | Don't grab | Assigned, covered by an open PR, post-release, or a pure design discussion |
+
+## 5. Output
+
+```
+Gas City work-queue — <date>
+
+Open issues: <count> (by milestone / priority)
+
+Tier 1 — GRAB NOW
+  #<n> <title>  [p<x>, milestone]  Gates: [....]  — <one-line why it's a clean pick>
+Tier 2 — GOOD CANDIDATE
+  #<n> <title>  [p<x>]  Gates: [....]  — <what to investigate first>
+Tier 3 — INVESTIGATE FIRST
+  #<n> <title>  — gate fired: <DD/AU/MA/PD + why>
+Tier 4 — SKIP
+  #<n> <title>  — <covered by PR #m / assigned / design discussion>
+
+Recommended next pick: #<n> — <rationale; confirm it passes all four gates>
+```
+
+## 6. Hand off to planning
+
+Once you've picked an issue, plan the PR with
+[`plan-pr`](../plan-pr/SKILL.md) — it runs the competing-PR and
+architectural-refactor gates again at code-time (the landscape may have changed),
+maps blast radius, and aligns the plan to repo conventions before you write code.
+
+## When to re-run
+
+- After main gets new merges (the landscape shifts).
+- After you ship a PR and want the next pick.
+- Periodically, to catch newly filed issues.

--- a/contributing/skills/plan-pr/SKILL.md
+++ b/contributing/skills/plan-pr/SKILL.md
@@ -1,0 +1,285 @@
+---
+name: plan-pr
+description: Plan a PR for a gastownhall/gascity issue before writing code — front-loading the analysis a maintainer's adoption review will check. Runs the competing-PR and architectural-refactor gates (don't start work that's already in flight or about to be superseded), maps blast radius, aligns the plan to repo conventions and the right test tier, and applies the design-capture discipline (land architectural work with an engdocs/design artifact). Produces a structured plan and the B-rule convention-trigger checklist. Self-contained — git + gh + the sibling skills, no internal tooling. Use when starting a new fix/feature branch.
+---
+
+# Plan a PR
+
+You have an issue number (from [`find-work`](../find-work/SKILL.md), or one you
+filed with [`write-issue`](../write-issue/SKILL.md)) and you're about to build a
+PR for [gastownhall/gascity](https://github.com/gastownhall/gascity). This skill
+front-loads the analysis the maintainer's adoption review will run — so you
+address the concerns *before* writing code, when they're cheap.
+
+The output is a written plan. **No code is written until the plan is done and you
+confirm it.**
+
+> `main` below means the upstream main you're targeting — `origin/main` if origin
+> is `gastownhall/gascity`, else `upstream/main`.
+
+## Phase 1 — Issue analysis
+
+Read the issue; extract what's broken, where it lives, why it matters.
+
+```bash
+gh issue view <number> --repo gastownhall/gascity --json title,body,labels,comments
+gh issue list --repo gastownhall/gascity --search "<keywords>" --state all --limit 10
+gh pr list   --repo gastownhall/gascity --search "<keywords>" --state all --limit 10
+```
+
+### Competing-PR gate (BLOCKING)
+
+Before anything else, check whether an open PR already targets this issue, or
+whether it's already fixed:
+
+```bash
+gh pr list   --repo gastownhall/gascity --state open --search "<issue number>" --json number,title,author,createdAt
+gh issue view <number> --repo gastownhall/gascity --json state
+```
+
+**If a competing PR exists or the issue is closed, STOP.** Pick a different issue
+or, if you still think yours adds value, say so explicitly in the plan and decide
+consciously. Don't silently start work someone else is already doing — it wastes
+effort and creates merge conflicts.
+
+### Architectural-refactor gate (BLOCKING)
+
+The competing-PR check catches *issue-level* duplicates; it misses *area-level*
+ones. Before scoping a fix, check whether the file/package you'll touch sits
+inside an active architectural refactor. If it does, a narrow fix gets superseded
+and your time is wasted.
+
+```bash
+# Accepted / Implementing design docs:
+grep -lE "^\| Status \|.*\b(Accepted|Implementing|Implemented)\b" engdocs/design/*.md
+
+# Open maintainer PRs consolidating the area:
+gh pr list --repo gastownhall/gascity --state open --search "unification refactor phase boundary" --json number,title
+
+# Recently-merged PRs that used "Supersedes" (the area is being consolidated):
+gh pr list --repo gastownhall/gascity --state merged --search "supersedes in:body" --limit 5 --json number,title
+```
+
+**If your area has an Accepted/Implementing design doc OR an open consolidation
+PR touching it, STOP** and choose one of:
+
+- **Point-fix** — a single-line change the refactor can absorb. Ask in the issue
+  whether that's wanted.
+- **Wait** for the refactor to land, then rebase.
+- **Pivot** to an issue outside the refactor area.
+
+Read the relevant design doc before writing any code. Its `Status` field and
+`## Phase N` headings tell you which parts are live and which are queued; a fix
+landing in a queued phase won't survive rebase. (Gas City precedent: PR #666
+superseded eight narrow session-model PRs; PR #790 superseded two env-projection
+PRs.)
+
+## Phase 2 — Blast radius
+
+Map the impact surface with the [`blast-radius`](../blast-radius/SKILL.md) skill:
+enumerate the functions you'll touch, their callers and execution contexts, the
+config-field sync chain, domain-boundary crossings, and concurrency. Carry its
+`HIGH`/`MED` findings into the plan's `Risks` and `Blast radius` sections.
+
+## Phase 3 — Convention alignment
+
+Verify the plan follows these patterns before writing code:
+
+### Architecture patterns
+
+- **do*()/cmd*() split** — `cmdFoo()` (wiring) + `doFoo()` (pure logic, injected deps)
+- **Provider interfaces** — new implementations pass the conformance suite in `*test/conformance.go`
+- **Nil-guard tracker** — optional subsystems use `if tracker != nil`; nil means disabled
+- **Config override chain** — `city.toml` → `[agent_defaults]` → `[[agent]]` → `AgentPatch` → `AgentOverride`
+
+### Test strategy (decide BEFORE writing code)
+
+1. **Which tier?**
+   - "Does the store handle corrupt X?" → unit test
+   - "Does `gc foo` print the right output?" → testscript (`.txtar`)
+   - "Does this work with real tmux?" → integration test (`//go:build integration`)
+   - "Does the provider shim handle this?" → acceptance test (`test/acceptance/`)
+   - "Are components called in the right order?" → coordination test
+2. **Fakes, not mocks** — `runtime.NewFake()`, `beads.MemStore`, `fsys.NewFake()`. No gomock. New fakes next to the interface with `var _ Interface = (*Fake)(nil)`.
+3. **Error injection** — per-path (`f.Errors["/path"] = err`) or modal (`f.Broken = true`).
+4. **Testscript env vars** — only `GC_SESSION`, `GC_BEADS`, `GC_DOLT`. More than 2 → unit test.
+5. **Regression depth** — bug fixes test through the full write path; assertions discriminate the exact bug path (B14).
+
+### Branch setup
+
+```bash
+git fetch origin
+git checkout -b <prefix>/<issue-number>-<short-desc> origin/main
+# prefix: fix/ feat/ refactor/ docs/
+```
+
+Branch from the upstream main you're targeting; don't `git checkout main` first.
+
+## Phase 3.5 — Design-capture decision
+
+Gas City's strongest contributions land architectural work **with a design
+artifact attached** — maintainers author the `engdocs/design/` canon, and a PR
+that implements against (or proposes) a design doc clears review in one pass
+instead of costing a "what's the intent here?" round-trip. This is the single
+highest-leverage thing you can do to make an architectural PR land cleanly.
+
+### Does this change need a design doc?
+
+Write (or update) an `engdocs/design/<name>.md` when **any** of these is true:
+
+- It introduces or changes a **subsystem boundary or cross-cutting mechanism** —
+  read-path/routing, store topology, supervisor or session lifecycle, a
+  provider/worker interface, the config override chain, an event/wire format, the
+  endpoint model.
+- It adds a **new package** or a **new public contract/schema** other components
+  or packs consume.
+- It changes **behavior other components depend on** — `events.jsonl` shape, a
+  CLI contract a pack reads, the bd+Dolt contract.
+- The work is **cohesive feature-scale**, not a point fix.
+
+Skip the doc (a code-only PR is correct) when the change is a single-function bug
+fix, test-only, docs-only, or a behavior-preserving mechanical refactor. Respect
+KISS/YAGNI — never write a design doc for a one-liner.
+
+### Two capture mechanisms — know which is which
+
+- `engdocs/design/*.md` — forward-looking **design proposal**. This is the one a
+  contributor authors.
+- `release-gates/*.md` — per-change acceptance contract tied to a builder-fleet
+  deploy. You won't author these, but if your area already has one, cite it the
+  same way you'd cite a design doc.
+
+### If the area ALREADY has a design doc or release-gate
+
+You found it in the Phase 1 architectural-refactor gate. Don't start a competing
+doc — **implement against it and cite it** by path in the PR body and in the
+commit that lands the core change (`implements engdocs/design/<name>.md`).
+
+### If it needs a NEW doc, draft the stub now — before code
+
+Author it in the branch so it's reviewed *with* the diff, not bolted on after.
+Confirm the live shape against any existing file in `engdocs/design/` first, then:
+
+```bash
+cat > engdocs/design/<short-kebab-name>.md <<'MD'
+---
+title: "<Title Case Name>"
+---
+
+| Field | Value |
+|---|---|
+| Status | Proposed |
+| Date | <YYYY-MM-DD> |
+| Author(s) | <your handle> |
+| Issue | #<number> |
+| Supersedes | N/A |
+
+## Summary
+
+<2-4 sentences: what this changes and the one-line reason it's worth doing.>
+
+## Problem
+
+<What's broken or missing today, for a future maintainer with no context.>
+
+## Design
+
+<The approach. Name the subsystem boundaries it touches and the contract it
+establishes — the "why this shape" the review otherwise reverse-engineers.>
+
+## Alternatives considered
+
+<At least one rejected option and why. Pre-empts "did you consider X?".>
+MD
+```
+
+Register it — add one row to the **Current Design Set** table in
+`engdocs/design/index.md`:
+
+```
+| `<short-kebab-name>` | Proposed | <one-line note> |
+```
+
+Open at `Status: Proposed`; let review move it to `Accepted` and the landing PR
+move it to `Implemented`.
+
+## Phase 4 — Plan output
+
+Produce this and confirm it before writing code:
+
+```
+Issue: #<number> — <title>
+
+Root cause: <one sentence>
+
+Files to change:
+  <file>:<function> — <what changes>
+
+Blast radius: <summary from the blast-radius skill>
+
+Design capture:
+  Change class: <point-fix | test/docs-only | refactor | architectural>
+  [ ] Trigger fired? (subsystem boundary / new package / new contract / feature-scale)
+  [ ] Existing engdocs/design doc to cite, OR new stub drafted (Proposed)
+  [ ] Registered in engdocs/design/index.md
+  (point-fix / test-only / docs-only / refactor → "N/A, code-only PR" + one-line why)
+
+Convention triggers (the B-rules this change must satisfy):
+  [ ] Config field sync (B11, B15)
+  [ ] Store write error propagation / retain-and-retry (B12)
+  [ ] Timeout isolation (B13)
+  [ ] do*()/cmd*() split (B19)
+  [ ] Test doubles + env hermeticity (B20)
+  [ ] Map key separation (B18)
+  [ ] Startup vs reload (B16)
+  [ ] Goroutine lifecycle (B17)
+  [ ] Config snapshot safety (B21)
+  [ ] Dead code audit (B22)
+  [ ] Fix scope completeness + parallel siblings (B23)
+  [ ] Verify-before-delete (B24)
+  [ ] Constant grep radius (B25)
+  [ ] Golden snapshot / doc drift (B26)
+  [ ] Env projection layer (B29)
+  [ ] Package-level race-safety (B30)
+  [ ] Hard-fail examples audit (B31)
+  [ ] Test save/restore of pkg state (B33)
+
+Test plan:
+  Unit: <what to test, which fakes>
+  Testscript: <which .txtar to add/modify>
+  Integration: <if needed>
+
+Risks:
+  <what could go wrong, what the maintainer will scrutinize>
+```
+
+**Confirm the plan before writing any code.**
+
+## Phase 5 — What the maintainer will check
+
+Gas City adoption reviews run a multi-model pass (Claude + Codex, sometimes
+Gemini) and consistently flag these. Address them proactively — each maps to a
+B-rule in [`check`](../check/SKILL.md):
+
+1. **Silent error handling** — `_ = store.Write()` or a `bool` return that doesn't fire `false` on write error (B12)
+2. **Shared code paths** — timeouts/semaphores bleeding into unintended subsystems (B13)
+3. **Nil/empty distinction** — config fields where "not set" vs "explicitly empty" matters (B11)
+4. **Infrastructure-agent contamination** — loops applying work config to `control_dispatcher` (B15)
+5. **Goroutine lifecycle** — fire-and-forget goroutines in CLI paths; defer-block done channels on ALL return paths (B17)
+6. **Startup vs reload safety** — one-time operations wired into reload paths (B16)
+7. **Test specificity** — assertions that could pass for the wrong reason (B14)
+8. **Raw string literals** — a constant defined but not used everywhere; grep the ENTIRE codebase (B25)
+9. **Dead code introduced by the PR** — helpers added "for completeness", never called (B22)
+10. **Incomplete state coverage** — a fix handling one state but not the others the bug also hits (B23)
+11. **Verify-before-delete** — pruning without confirming the successor state exists; fail-open (B24)
+12. **Missing regression branches** — multiple code paths (early-exit/timeout/error/success), only the happy path tested (B14)
+13. **Parallel code-path siblings (the #1 finding)** — fixing one call site while identical siblings stay broken (B23)
+14. **Env-var hermeticity** — `os.Setenv` instead of `t.Setenv()` in tests (B20)
+15. **Golden-snapshot / doc drift** — changed output without updating tutorial golden files / `.txtar` fixtures (B26)
+16. **Package-level mutable-state races** — `var Foo bool` written by reload, read by request paths; must be `atomic.*` (B30)
+17. **Hard-fail conversions** — turning silent degradation into a hard error without auditing `examples/` + adding a release note (B31)
+18. **Test cleanup that hardcodes state** instead of restoring it (B33)
+19. **Env projection inlined** into command handlers instead of `cmd/gc/bd_env.go` (B29)
+
+After the code is written, run [`check`](../check/SKILL.md) and
+[`ship`](../ship/SKILL.md) to verify against the full list before you push.

--- a/contributing/skills/ship/SKILL.md
+++ b/contributing/skills/ship/SKILL.md
@@ -1,0 +1,227 @@
+---
+name: ship
+description: The pre-push self-review gate for a gastownhall/gascity PR. Runs in sequence — design-capture gate, a simplify pass, a self-review against the recurring adoption-review findings (iterate until clean), optional performance measurement, then the full check skill (mechanical gates + B1-B36 audit) — and produces a readiness report. It STOPS at the report; pushing the branch and opening the PR are your call. Self-contained: no internal hooks or tooling required. Use right before you open a PR to gastownhall/gascity.
+---
+
+# Ship — Pre-Push Self-Review
+
+Your code is written and you're about to open a PR to
+[gastownhall/gascity](https://github.com/gastownhall/gascity). This skill runs the
+final review stages in sequence, produces one readiness report, and **stops**. It
+does not push and does not open a PR — those are your call, made once the report
+is clean.
+
+Goal: land the PR with few or no review comments by catching the structural and
+correctness defects a careful maintainer review would flag.
+
+> `main` below means the upstream main you're targeting — `origin/main` if origin
+> is `gastownhall/gascity`, else `upstream/main`.
+
+## Stage 0 — Design-capture gate (read-only)
+
+The cheapest finding to fix is the one captured before review. Architectural work
+on Gas City lands *with* a design artifact under `engdocs/design/`; a missing one
+is the most common reason an architectural PR costs an extra "what's the intent?"
+round-trip. This gate catches it before push — it's read-only and never authors
+the doc (authoring belongs in [`plan-pr`](../plan-pr/SKILL.md) Phase 3.5, before
+the code).
+
+```bash
+git diff --stat main...HEAD
+# Was a design artifact added/modified in this branch?
+git diff --name-only main...HEAD -- 'engdocs/design/**' 'release-gates/**'
+# Or is an existing one cited in a commit body?
+git log main..HEAD --format='%B' | grep -iE 'engdocs/design|release-gates'
+```
+
+Apply the same trigger test as `plan-pr` Phase 3.5:
+
+- **Point fix / test-only / docs-only / behavior-preserving refactor** → design
+  capture **N/A**. Pass.
+- **Architectural** (subsystem boundary, new package, new public contract/schema,
+  feature-scale) → the branch must add/modify an `engdocs/design/*.md` (or
+  `release-gates/*.md`), **or** cite an existing one in a commit/PR body.
+
+If architectural and no capture is present, check one thing before flagging — does
+the touched area already have a contract on `main` this PR implements against?
+
+```bash
+git ls-files 'engdocs/design/**' 'release-gates/**' | grep -iE '<pkg-or-feature-keyword>'
+```
+
+- **An existing contract covers it** → remedy is **cite it** (`implements engdocs/design/<name>.md`
+  in a commit/PR body). Cheap; do it and pass.
+- **None exists, none added** → report `Design capture: ⚠️ MISSING`. Don't silently
+  block, but the default recommendation is **stop and add the doc** via
+  [`plan-pr`](../plan-pr/SKILL.md) Phase 3.5 — adding it after review fragments the
+  PR.
+
+## Stage 1 — Simplify
+
+Clean up the diff before anyone reviews it: remove dead code, consolidate
+duplicates, tighten naming and structure. This stage **can** modify files. If you
+have a dedicated simplify tool, run it; otherwise do the pass by hand.
+
+After any change, confirm it still builds:
+
+```bash
+go build ./...
+```
+
+If the build breaks after simplifying, revert the simplify changes and note it —
+don't iterate here.
+
+## Stage 2 — Self-review (iterate until clean)
+
+Converge to **no blocker or major findings** before Stage 3. A single review pass
+leaves comments a maintainer (or the repo's automated reviewer) will catch
+post-push; iterating a review loop before push is what lands PRs with zero inline
+comments.
+
+### Stage 2a — Scan the recurring-finding patterns
+
+Before any deeper review, scan your diff against these patterns — each is a
+real, repeatedly-caught adoption-review finding. Fix hits in place; they're cheap
+now and noisy after push.
+
+1. **Safety-predicate fail-open** — a `bool`-returning predicate used as a safety
+   gate (`HasUnpushedCommits`, `HasStashes`, `IsRepo`, `Exists`) returning `false`
+   (= "safe") on internal error. Fail closed: add an error-return path or a
+   precondition probe (B34).
+2. **Helper error context across reuse contexts** — calling a shared helper from a
+   new caller where its existing error message no longer describes the new
+   context. Wrap: `fmt.Errorf("<new-context> %q: %w", id, err)` (B28).
+3. **Dedup-vs-filter mismatch** — one stage dedups inputs while a downstream stage
+   filters per-original-key, silently dropping the deduped-away keys. Dedup
+   one-to-many, or filter against every original key (B23).
+4. **Wrong working directory for destructive ops** — `git worktree remove`,
+   `git clean -fd`, `dolt prune` etc. invoked from *inside* the target. Use the
+   parent path as the workdir.
+5. **Pipeline output dropped across stages** — a later assignment to an output
+   slice/map overwriting entries an earlier stage wrote (listing errors,
+   partial-failure markers). Merge/prepend instead of overwriting.
+6. **Counter conflation** — a `len(slice)` in a user-facing message mixing
+   categories (threshold violations + measurement errors). Track distinct counters.
+7. **Struct doc / generated reference drift** — a struct field's doc comment
+   describing behavior the code doesn't perform. Fix the doc, then regenerate
+   downstream reference docs (`go run ./cmd/genschema`, `make check-docs`) and
+   re-grep `docs/reference/` for the stale phrase (B26).
+
+(These are the eight-finding sweep from PR #1482 + PR #1299 — read those PRs for
+the full pattern.)
+
+### Stage 2b — Review loop
+
+Run your code-review tool of choice over the diff (if you have a multi-model
+reviewer, use it — different models catch different defects). Classify every
+finding:
+
+- **blocker** — a correctness/safety defect that must be fixed before merge
+- **major** — a design or precision defect a reviewer will flag (includes any
+  Stage 2a pattern)
+- **minor** — style or nice-to-have; does not block
+
+Loop (max ~3 iterations): review → fix every blocker and major in place, commit →
+review again. Exit when the result is "approve" / "approve with minors only". If
+you can't converge in 3 iterations, stop and report **BLOCKED — review not
+converging**; decide consciously whether to keep iterating or accept the
+remaining majors.
+
+## Stage 2.5 — Performance (perf-touching changes only)
+
+Applies only when the change touches a hot path, claims a speedup, or closes a
+perf issue. All other changes: skip, note `Performance: N/A`.
+
+A perf-touching PR is **not ready** until it captures:
+
+1. **Bottleneck attributed from a measurement, not a guess** — name the dominant
+   cost with evidence (profile/bench/traced cost). No identified bottleneck →
+   `⚠️ UNMEASURED`.
+2. **Before/after numbers** — a real bench (`ns/op`, p95, wall-clock under load);
+   state the machine.
+3. **Honest speedup** — report the *measured* multiplier; if the issue/PR claims a
+   number, verify it and flag inflation.
+4. **Amdahl residual** — the fraction still un-optimized, listed explicitly.
+5. **Correctness guard** — when a fast path replaces a slow-but-correct one,
+   confirm it returns the same answer. A fast-but-wrong path is a **blocker**.
+
+If perf-touching and any of 1–4 is missing → report `Performance: ⚠️ UNMEASURED`
+(a conscious waive, never a silent pass).
+
+## Stage 3 — Run the check
+
+Run the full [`check`](../check/SKILL.md) skill: mechanical gates (`make build` /
+`make check` / `make check-docs`) with baseline-vs-regression classification, plus
+the B1–B36 codebase audit. This stage is read-only.
+
+## Stage 4 — Readiness report
+
+Combine the stages into one report:
+
+```
+Gas City ship readiness — <branch>
+
+Stage 0 — Design capture:
+  Change class: <point-fix | test/docs-only | refactor | architectural>
+  Design capture: <N/A, code-only | added/cited engdocs/design/<name>.md | ⚠️ MISSING — waive or add>
+
+Stage 1 — Simplify:
+  Changes made: <yes: N files / none needed>
+  Build after simplify: ✅ / ❌ (reverted)
+
+Stage 2 — Self-review:
+  Iterations: <N>
+  blocker: <count — must be 0 to be READY>
+  major:   <count — must be 0 to be READY>
+  minor:   <count — optional>
+  Fix commits: <sha1>, <sha2>, ...
+  Remaining minors (if any): <1-line summaries>
+
+Stage 2.5 — Performance (perf-touching only):
+  Bottleneck (measured): <attributed cost | N/A>
+  Before → after:        <bench numbers + machine>
+  Honest speedup:        <measured Nx — flag if inflated>
+  Residual / deferred:   <un-optimized fraction>
+  Correctness guard:     ✅ same-answer / ⚠️ <risk> / N/A
+
+Stage 3 — Check:
+  Part A (mechanical gates): ✅ / ❌
+  Part B (codebase audit):   ✅ / ⚠️ <count> findings
+
+  <paste the check skill's report>
+
+Overall: READY / BLOCKED (<what needs fixing>)
+```
+
+## Stage 5 — Stop
+
+**This skill stops here.** It does not run `git push`, does not run
+`gh pr create`, and does not send anything to a remote. Pushing the branch and
+opening the PR are your call — make them once the report says READY.
+
+When you do open the PR, include the Stage 2 + Stage 3 findings summary in the PR
+body — it shows the reviewer you did the work.
+
+## After you open the PR — automated review
+
+`gastownhall/gascity` runs an automated reviewer (GitHub Copilot) on new PRs; it
+typically posts within a few minutes. When its comments arrive:
+
+1. Evaluate each like any reviewer — verify against the code before fixing; skip
+   false positives with a one-line reason.
+2. Fix the valid ones, commit, push.
+3. Reply to each comment: "Fixed in `<sha>` — <what>" or "Won't fix — <reason with
+   file:line>".
+
+Every comment you could have caught with one more Stage 2 pass is one you can
+catch before push next time.
+
+## Handling failures
+
+- **Stage 0 design capture MISSING (architectural)** → warning. Default: stop and
+  add the doc via `plan-pr` Phase 3.5. Never auto-author it here.
+- **Stage 1 breaks the build** → revert the simplify changes, note it, continue.
+- **Stage 2 won't converge in ~3 iterations** → report BLOCKED; decide consciously.
+- **Stage 3 fails mechanical gates** → BLOCKED; fix before push.
+- **Stage 3 finds B-rule violations** → warnings; fix them or note why you're
+  leaving one in the PR body.

--- a/contributing/skills/write-issue/SKILL.md
+++ b/contributing/skills/write-issue/SKILL.md
@@ -71,11 +71,17 @@ If you find a match:
 
 The most common failure mode: a bug seen on an old version or a feature branch
 is reported as if it's on `main`, but `main` already fixed it (or never had the
-buggy code). Always verify against an up-to-date checkout of
-`gastownhall/gascity` at `origin/main`.
+buggy code). Always verify against an up-to-date checkout of the
+`gastownhall/gascity` main you're targeting.
+
+> **Which remote?** If you cloned `gastownhall/gascity` directly, its main is
+> `origin/main`. If you forked first and cloned your fork, your `origin` is the
+> fork — add the upstream once (`git remote add upstream
+> https://github.com/gastownhall/gascity && git fetch upstream`) and use
+> `upstream/main` everywhere `origin/main` appears below.
 
 ```bash
-# from your local clone of gastownhall/gascity
+# from your local clone (use upstream/main instead if origin is your fork)
 git fetch origin && git log -1 origin/main --oneline   # confirm the tree is current
 git checkout origin/main
 
@@ -233,9 +239,12 @@ directly.
 
 ## After filing
 
-Once the issue exists, you can pick it up yourself: see the [contributing
-lifecycle](../contributing/SKILL.md), which routes a filed issue straight into
-`gc pr-pipeline pr plan <issue>` to plan the PR.
+Once the issue exists, you can pick it up yourself: run
+[plan-pr](../plan-pr/SKILL.md) on the issue number to plan the PR (it re-runs the
+competing-PR and architectural-refactor gates at code-time, maps blast radius, and
+aligns the plan to repo conventions before you write code). The
+[contributing](../contributing/SKILL.md) skill is the full lifecycle map if you
+want the whole journey from here to a ready-to-push PR.
 
 ## Anti-patterns
 
@@ -258,7 +267,7 @@ lifecycle](../contributing/SKILL.md), which routes a filed issue straight into
 ## Quick checklist before `gh issue create`
 
 - [ ] Searched duplicates (3+ searches) — none open
-- [ ] Confirmed the bug exists on `origin/main` today (`git rev-parse origin/main`)
+- [ ] Confirmed the bug exists on the upstream main today (`git rev-parse origin/main`, or `upstream/main` if origin is your fork)
 - [ ] Checked `engdocs/design/*.md` for accepted docs covering this area; cited
       the relevant section OR confirmed none applies
 - [ ] Have `file:line` refs for the root cause

--- a/contributing/tests/test_contributing_pack_structure.py
+++ b/contributing/tests/test_contributing_pack_structure.py
@@ -8,12 +8,36 @@ import unittest
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 
 
+EXPECTED_SKILLS = {
+    "blast-radius",
+    "check",
+    "contributing",
+    "find-work",
+    "plan-pr",
+    "ship",
+    "write-issue",
+}
+
+
 class PackStructureTests(unittest.TestCase):
-    def test_pack_declares_pr_pipeline_import(self) -> None:
-        """The contributing pack composes pr-pipeline; the pairing must be declared."""
+    def test_pack_is_self_contained(self) -> None:
+        """0.2.0 is END-TO-END self-contained: it must declare no imports."""
         text = (ROOT / "pack.toml").read_text(encoding="utf-8")
-        self.assertRegex(text, r"(?m)^\[imports\.pr-pipeline\]")
-        self.assertRegex(text, r"(?m)^\s*source\s*=")
+        # Only `[pack]` tables are allowed; any `[imports.*]` table breaks the
+        # self-contained contract the 0.2.0 directive requires.
+        self.assertNotRegex(
+            text,
+            r"(?m)^\[imports\.",
+            "contributing 0.2.0 must not import any pack — it bakes the standards in",
+        )
+
+    def test_expected_skills_present(self) -> None:
+        skills = {p.parent.name for p in ROOT.glob("skills/*/SKILL.md")}
+        self.assertEqual(
+            skills,
+            EXPECTED_SKILLS,
+            "the self-contained lifecycle requires exactly these seven skills",
+        )
 
     def test_skill_name_matches_directory(self) -> None:
         for skill in sorted(ROOT.glob("skills/*/SKILL.md")):

--- a/contributing/tests/test_contributing_skill_frontmatter.py
+++ b/contributing/tests/test_contributing_skill_frontmatter.py
@@ -13,7 +13,12 @@ class SkillFrontmatterTests(unittest.TestCase):
         self.assertEqual(
             [path.parent.name for path in skill_files],
             [
+                "blast-radius",
+                "check",
                 "contributing",
+                "find-work",
+                "plan-pr",
+                "ship",
                 "write-issue",
             ],
         )

--- a/registry.toml
+++ b/registry.toml
@@ -210,7 +210,7 @@ schema = 1
 
 [[pack]]
   name = "contributing"
-  description = "The external-contributor lifecycle for gastownhall/gascity — write a good issue, find priority work, open a PR, and self-review before pushing. Composes pr-pipeline."
+  description = "The external-contributor lifecycle for gastownhall/gascity — write a good issue, find priority work, plan a PR, map its blast radius, and self-review against the codebase audit. Each step produces an artifact you act on; the pack stops before pushing — opening the PR is your call. Self-contained: gas-city's actual standards (the B-rule adoption-review audit, blast-radius dimensions, test tiers) are baked into the skills; no imports."
   source = "https://github.com/gastownhall/gascity-packs//contributing"
   source_kind = "git"
 
@@ -220,3 +220,10 @@ schema = 1
     commit = "16f8297d4e62e143456bfbe4a00e0980a7d9400e"
     hash = "sha256:8ee58fba7a87a2390fe707ccb593eec3f25b303782696d836d800e68992beeef"
     description = "Initial contributing pack release."
+
+  [[pack.release]]
+    version = "0.2.0"
+    ref = "main"
+    commit = "7dd57dd9be7d286f19f74c27a00a4359392734a4"
+    hash = "sha256:3ba4ad08c81ab8d2cb9bd591a0f546435e14a9132b1d4d4745bde03d0feb94ad"
+    description = "Self-contained gas-city contributor lifecycle: drops the pr-pipeline import, bakes in the B-rule adoption-review audit, blast-radius dimensions, and test-tier strategy (7 skills, zero imports)."


### PR DESCRIPTION
## Summary

Releases **contributing 0.2.0** — a self-contained, gas-city-specific rework of the external-contributor lifecycle pack. The published 0.1.0 composed the generic `pr-pipeline` pack (generic discipline, not gas-city's actual standards); 0.2.0 **drops the `pr-pipeline` import entirely** and bakes gas-city's real standards into the pack's own skills.

- `pack.toml` → `0.2.0`, `schema = 2`, **zero `[imports.*]`** — the pack stands alone, depends on nothing a contributor lacks.
- Seven self-applicable skills (`write-issue`, `find-work`, `plan-pr`, `blast-radius`, `check`, `ship`) a contributor's own coding agent runs by reading the skill.
- `check` bakes in the full B-rule adoption-review audit (B32 reserved/unused; active set B1–B31, B33–B36) + mechanical gates + baseline-vs-regression classification.
- `blast-radius` carries the gas-city impact dimensions; `plan-pr` is adoption-review-aware; `find-work` adds actionability tiers + competing-PR detection; `ship` is the pre-push self-review gate that STOPS before push.
- All base-ref commands are fork-aware (`origin/main` when origin is `gastownhall/gascity`, else `upstream/main`) so they work from a fork clone.

## Registry

`registry.toml` gains the `0.2.0` `[[pack.release]]` entry (commit `7dd57dd`, content hash via `gc pack release hash`) and the pack description is updated to reflect the self-contained design and that the pack stops before opening the PR.

## Review record

Three independent reviewers (Claude code-review, Claude security/publication, Codex grounded meta-review). Findings addressed before this PR:
- Security: removed an internal bead ID from the commit subject; confirmed no secrets / fork-local paths / private infra leak in file content.
- Quality: documented the B32 gap as intentional/reserved.
- Codex (HIGH): made `write-issue` fork-aware (it had hardcoded `origin/main` assuming origin = gastownhall); (LOW) corrected the registry description's "open a PR" overstatement.

## Verification

- `pytest contributing/tests` → 5 passed
- `validate_registry.py` → ok
- `gc pack release verify` (content hash) → ok