### PR TITLE
fix(contributing): YAML-safe skill front matter (0.2.1)

### DIFF
--- a/contributing/pack.toml
+++ b/contributing/pack.toml
@@ -34,5 +34,5 @@
 
 [pack]
 name = "contributing"
-version = "0.2.0"
+version = "0.2.1"
 schema = 2

--- a/contributing/skills/blast-radius/SKILL.md
+++ b/contributing/skills/blast-radius/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: blast-radius
-description: Map the full impact surface of a change to gastownhall/gascity before you commit — callers and their execution contexts (startup/tick/reload/CLI/API/shutdown), downward callees and their risky patterns (stale config, swallowed store errors, leaked goroutines), config-field sync chains, the six domain-boundary crossings, concurrency, and cross-repo contracts (gastown/beads). Self-contained — runs on plain git + grep + gh, no internal tooling. Use before committing anything that touches the reconciler, controller, lifecycle, dispatch, config, or any cross-subsystem code, and as Phase 2 of the plan-pr skill.
+description: Map the full impact surface of a change to gastownhall/gascity before you commit — callers and their execution contexts (startup/tick/reload/CLI/API/shutdown), downward callees and their risky patterns (stale config, swallowed store errors, leaked goroutines), config-field sync chains, the domain-boundary crossings, concurrency, and cross-repo contracts (gastown/beads). Self-contained — runs on plain git + grep + gh, no internal tooling. Use before committing anything that touches the reconciler, controller, lifecycle, dispatch, config, or any cross-subsystem code, and as Phase 2 of the plan-pr skill.
 ---
 
 # Map the Blast Radius
@@ -82,7 +82,7 @@ and the pool deep-copy must be checked by hand.
 
 ## Step 5 — Domain-boundary crossings
 
-Check whether the change crosses any of these six boundaries:
+Check whether the change crosses any of these boundaries:
 
 | Boundary | Risk |
 |---|---|

--- a/contributing/skills/check/SKILL.md
+++ b/contributing/skills/check/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: check
-description: Verify a change against gastownhall/gascity's actual quality bar before you push a PR. Runs the mechanical gates (make build + make check + make check-docs if docs touched), classifies test failures as pre-existing noise vs new regressions, and audits the diff against the full Gas City adoption-review checklist (B1-B36) — zero hardcoded roles, ZFC, the Bitter Lesson, the five test tiers, the code conventions, config-nil semantics, store-write errors, timeout isolation, startup-vs-reload safety, goroutine lifecycle, do*/cmd* split, env hermeticity, and more. Self-contained — you (or your coding agent) run every check by reading this skill; no internal tools required. Use before opening any PR to gastownhall/gascity.
+description: Verify a change against gastownhall/gascity's actual quality bar before you push a PR. Runs the mechanical gates (make build + make check + make check-docs if docs touched), classifies test failures as pre-existing noise vs new regressions, and audits the diff against the full Gas City adoption-review checklist (B1-B36) — zero hardcoded roles, ZFC, the Bitter Lesson, the test tiers, the code conventions, config-nil semantics, store-write errors, timeout isolation, startup-vs-reload safety, goroutine lifecycle, do*/cmd* split, env hermeticity, and more. Self-contained — you (or your coding agent) run every check by reading this skill; no internal tools required. Use before opening any PR to gastownhall/gascity.
 ---
 
 # Run the Gas City Codebase Check
@@ -43,8 +43,8 @@ Set scope flags:
 Each depends on the previous being green.
 
 ```bash
-make build        # ~300s timeout
-make check        # ~600s timeout — runs fmt-check, lint, vet, test
+make build        # allow several minutes
+make check        # allow several minutes — runs fmt-check, lint, vet, test
 make check-docs   # only if docs/engdocs touched
 ```
 
@@ -78,7 +78,7 @@ Environment-dependent and race-detector-flaky tests exist; verifying against
 > the active audit is B1–B31 and B33–B36. A complete pass covers every numbered
 > rule below — the absence of a B32 entry is intentional, not a missing check.
 
-Read the diff and check each rule. The rules are grouped into **five review
+Read the diff and check each rule. The rules are grouped into **review
 lenses** — cover all five, not just the ones that feel obvious for your change.
 Each rule names the failure mode and, where useful, the public PR that taught it
 (real precedent you can read).
@@ -112,7 +112,7 @@ packages are peers — no cross-primitive imports. `internal/beads` must not imp
 
 ### Change impact / blast radius (B7, B9–B13, B15–B16, B18, B21, B23, B25–B26, B31, B35–B36)
 
-**B7. Code conventions (11 sub-checks).** Unit tests next to code; `t.TempDir()`;
+**B7. Code conventions.** Unit tests next to code; `t.TempDir()`;
 `//go:build integration` tag on integration tests; cobra/toml usage; atomic file
 writes; no `panic` in library code; error wrapping with `%w`; no role names;
 tmux invoked with `-L <socket>`; agent config field sync; raw string constants
@@ -127,7 +127,7 @@ features or refactoring — note them as out-of-scope instead.
 
 **B11. Config nil semantics.** A new config field where the consumer needs to
 distinguish "not set" from "explicitly empty" must use `*string` (pointer), an
-`Effective*()` accessor, and patch/override updates. (PR #386.)
+`Effective*()` accessor, and patch/override updates.
 
 **B12. Store-write error propagation — retain and retry, never delete and
 succeed.**
@@ -138,29 +138,28 @@ A function returning `bool` after a store write must return `false` on write
 error. In an error handler for a failed store write, never call `store.Delete`,
 `store.CloseAll`, or a successor-state write as "recovery" — return the error or
 set a failure state so callers can retry. Never paper over a store error by
-deleting the source-of-truth record. (PR #480: `SetMetadataBatch` silently
-returned `true` on failure; PR #543: prune-on-error removed records whose
+deleting the source-of-truth record. (e.g. `SetMetadataBatch` silently
+returned `true` on failure; a prune-on-error path removed records whose
 terminal write had failed.)
 
 **B13. Timeout / concurrency isolation.** New timeouts/semaphores must affect
 only the intended subsystem. A shared `shellCommand` path needs splitting. Use
-config constants, not magic numbers. (PR #480.)
+config constants, not magic numbers.
 
 **B15. Infrastructure-agent guards.** Loops iterating agents must exclude
-`control_dispatcher` / infrastructure agents from work-related config. (PR #386.)
+`control_dispatcher` / infrastructure agents from work-related config.
 
 **B16. Startup vs reload safety.** `newCityRuntime` runs at startup only.
 `buildOrderDispatcher` / `update()` run on config reload too. One-time sweeps
 must be startup-only — putting them in a reload path corrupts in-flight state.
-(PR #526.)
 
 **B18. Map-key domain separation.** A map serving multiple consumers (pool +
 named-session) must be filtered before it's passed to each consumer, or keys
-leak across domains. (PR #535.)
+leak across domains.
 
 **B21. Config hot-reload snapshot safety.** Code in the `update()` / `buildStores()`
 chain must use the passed `cfg` parameter, not `cs.cfg` (which is stale during
-reload). (PRs #540, #526.)
+reload).
 
 **B23. Fix-scope completeness + parallel code paths (the #1 adoption-review
 finding).** For an entity with multiple states
@@ -169,12 +168,11 @@ not just the one in your repro. Then: for every function you modified, grep all
 its callers; for every pattern you fixed (a missing nil-guard, a hardcoded
 string, a wrong env lookup), grep the **entire** codebase for sibling instances
 of the same pattern and fix them too. Fixing one call site while identical
-siblings stay broken is the most common reason a PR bounces. (PRs #543, #653,
-#656, #650.)
+siblings stay broken is the most common reason a PR bounces.
 
 **B25. Constant grep radius.** When you introduce or use a named constant, grep
 the entire codebase for the raw string value to find other occurrences that
-should use the constant too — don't limit the search to your diff. (PR #526: a
+should use the constant too — don't limit the search to your diff. (e.g. a
 raw `"order-tracking"` string diverged from the `labelOrderTracking` constant.)
 
 **B26. Golden-snapshot / doc-output drift.** When a change alters user-visible
@@ -185,7 +183,7 @@ stale. **Extension:** the same applies to Go struct field doc comments and
 generated reference docs — when a struct field or exported function changes
 behavior, re-read its doc comment against the implementation; if it feeds
 `cmd/genschema`, run `go run ./cmd/genschema` + `make check-docs` and re-grep
-`docs/reference/` for the stale phrase. (PRs #658, #637, #1482, #1299.)
+`docs/reference/` for the stale phrase.
 
 **B31. Hard-fail conversion → examples audit + release note.** When a fix turns
 silent degradation (default fallback, version downgrade, skipped validation,
@@ -193,7 +191,7 @@ silent success on missing data) into a hard error, anyone relying on the old
 silent behavior will see new failures. (1) Grep `examples/` (especially
 `examples/gastown/city.toml`) for configs that would newly hard-fail and update
 them in the same PR. (2) Flag the behavior change under a `Release note:` heading
-in the PR body. (PR #734.)
+in the PR body.
 
 **B35. Pack-binding qualification on routing/pool stamping.** Anything that
 stamps `gc.routed_to`, names a pool, or routes work by pack binding must use the
@@ -202,31 +200,29 @@ when the binding is empty is also a bug.
 ```bash
 git diff main...HEAD | grep -E 'gc\.routed_to|pool\.Name|PoolName|qualifyPool'
 ```
-(PRs #919, #1010, #1299.)
 
 **B36. Sweeps walk every rig.** Maintenance sweeps, orphan reapers, and
 lifecycle reconcilers must walk every rig in the city, not just HQ. The bug:
 accepting a `cityStore` and only iterating that store, silently skipping
 rig-scoped beads. Verify the loop covers `cfg.Rigs` and that progress counters
-are preserved across the loop, not reset per rig. (PRs #1448, #1010.)
+are preserved across the loop, not reset per rig.
 
 ### Debuggability & operability (B12, B17, B22, B24, B28, B30, B34)
 
 **B17. Goroutine lifecycle (CLI vs server).** CLI commands exit immediately —
 fire-and-forget goroutines die. Return a `<-chan struct{}` completion signal, and
 callers must `defer`-block on the done channel on **all** return paths, not just
-the happy path. (PR #524: both `waitForSession` failure and an early `Attach`
+the happy path. (e.g. both `waitForSession` failure and an early `Attach`
 return leaked a background goroutine.)
 
 **B22. Dead-code audit.** Grep for functions/methods your PR introduces that have
 zero callers — including helpers added "for completeness" (e.g. a `Len()` on a
 wrapper). Diff new `func ` lines, then grep each name across the codebase.
-(PRs #584, #471.)
 
 **B24. Verify-before-delete.** Before pruning/closing/removing a record, verify
 its expected successor/terminal state actually exists in the store
 (`store.Get(id)` → exists check → prune). Fail open: a store-lookup error
-**retains** the record rather than deleting it. (PR #543.)
+**retains** the record rather than deleting it.
 
 **B28. Error-context wrapping.** Every new `return err` / `return fmt.Errorf(...)`
 must name the operation and entity that failed (bead ID, agent name, rig name,
@@ -242,14 +238,14 @@ the top of the read path.
 ```bash
 git diff main...HEAD | grep -E '^\+var [A-Z][a-zA-Z]+ +(bool|int|int64|map)'
 ```
-(Canonical: `internal/formula/compile.go` `formulaV2Enabled atomic.Bool`. PR #734.)
+(Canonical: `internal/formula/compile.go` `formulaV2Enabled atomic.Bool`.)
 
 **B34. Safety-predicate fail-closed.** A boolean predicate used as a safety gate
 (`HasUnpushedCommits`, `HasStashes`, `IsRepo`, `Exists`, `IsClean`, `IsHealthy`)
 must fail **closed** — returning `false` on internal error means "can't
 determine" gets treated as "safe to proceed", which is dangerous for destructive
 ops (prune/remove/reap/delete). Either return `(bool, error)` and propagate, or
-add an explicit precondition probe that fails-closed first. (PR #1482.)
+add an explicit precondition probe that fails-closed first.
 
 ### Test evidence quality (B8, B14, B19–B20, B27, B33)
 
@@ -261,7 +257,7 @@ testscript.
 **B14. Regression-test depth.** A bug fix tests through the full write path and
 reads the state back from the store. Assertions must discriminate the exact bug
 path, and you must test **every** branch the fix introduces (early-exit, timeout,
-error, success), not just the happy path. (PRs #584, #510.)
+error, success), not just the happy path.
 
 **B19. do*()/cmd*() split.** CLI commands split into `cmdFoo()` (wiring) +
 `doFoo()` (pure logic with injected deps), so the logic is unit-testable.
@@ -273,7 +269,7 @@ hand-written fakes next to the interface, with a compile-time
 ```bash
 git diff main...HEAD -- '*_test.go' | grep -nE '\bos\.Setenv\b'
 ```
-Each hit is a finding. (PR #687: a test that didn't clear `GC_BEADS` failed for
+Each hit is a finding. (e.g. a test that didn't clear `GC_BEADS` failed for
 devs with it exported.)
 
 **B27. Polling over fixed sleeps in tests.** New test code uses `waitFor*` /
@@ -283,7 +279,7 @@ sync. The codebase has `waitForCondition`, `waitForFile`, `waitForBeadStatus`,
 ```bash
 git diff main...HEAD -- '*_test.go' | grep -n 'time\.Sleep'
 ```
-Each hit should justify why a polling helper won't work. (PRs #674, #621, #669.)
+Each hit should justify why a polling helper won't work.
 
 **B33. Test save/restore for package-level state.** A test that reads/writes
 package-level mutable state (feature flags, global counters, mode switches) must
@@ -294,7 +290,7 @@ prev := IsFooEnabled()
 SetFooEnabled(true)
 t.Cleanup(func() { SetFooEnabled(prev) })
 ```
-Hardcoded-`false` cleanup corrupts later tests that run with the flag on. (PR #734.)
+Hardcoded-`false` cleanup corrupts later tests that run with the flag on.
 
 ### Portability (B29)
 
@@ -308,7 +304,7 @@ overwrites stale ambient `GC_DOLT_HOST/PORT`), not inlined into command handlers
 git diff main...HEAD | grep -E 'os\.Getenv|os\.LookupEnv'
 ```
 Trace each new read: could it be inherited from a parent `gc` with a conflicting
-value? (PR #687, env-projection extraction PR #790.)
+value?
 
 ## Part C — Report
 

--- a/contributing/skills/contributing/SKILL.md
+++ b/contributing/skills/contributing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: contributing
-description: The full external-contributor lifecycle for gastownhall/gascity — write a good issue, find priority work, plan a PR, map its blast radius, run the codebase audit, and self-review before pushing. Use when someone wants to contribute to Gas City and needs to know which step they're on and which skill runs it. Self-contained: every step is a skill in this pack with Gas City's actual standards baked in — no internal tooling, no sibling pack.
+description: The full external-contributor lifecycle for gastownhall/gascity — write a good issue, find priority work, plan a PR, map its blast radius, run the codebase audit, and self-review before pushing. Use when someone wants to contribute to Gas City and needs to know which step they're on and which skill runs it. Self-contained — every step is a skill in this pack with Gas City's actual standards baked in — no internal tooling, no sibling pack.
 ---
 
 # Contributing to Gas City

--- a/contributing/skills/find-work/SKILL.md
+++ b/contributing/skills/find-work/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: find-work
-description: Find a good gastownhall/gascity issue to work on as an external contributor. Scans open issues, classifies them into actionability tiers (grab now / good candidate / investigate / skip), and — critically — detects competing PRs and maintainer-decision gates so you don't pick an issue that's already in flight or that needs a maintainer's product/design call before any PR is realistic. Self-contained: plain gh queries you run yourself, no internal tooling. Use when you want to contribute but don't have a specific bug in mind yet.
+description: Find a good gastownhall/gascity issue to work on as an external contributor. Scans open issues, classifies them into actionability tiers (grab now / good candidate / investigate / skip), and — critically — detects competing PRs and maintainer-decision gates so you don't pick an issue that's already in flight or that needs a maintainer's product/design call before any PR is realistic. Self-contained — plain gh queries you run yourself, no internal tooling. Use when you want to contribute but don't have a specific bug in mind yet.
 ---
 
 # Find Work

--- a/contributing/skills/plan-pr/SKILL.md
+++ b/contributing/skills/plan-pr/SKILL.md
@@ -53,8 +53,10 @@ and your time is wasted.
 # Accepted / Implementing design docs:
 grep -lE "^\| Status \|.*\b(Accepted|Implementing|Implemented)\b" engdocs/design/*.md
 
-# Open maintainer PRs consolidating the area:
-gh pr list --repo gastownhall/gascity --state open --search "unification refactor phase boundary" --json number,title
+# Open maintainer PRs consolidating your target area (substitute a keyword
+# from the subsystem you're touching; skim hits for any that unify/refactor/
+# supersede it):
+gh pr list --repo gastownhall/gascity --state open --search "<your-subsystem-keyword> in:title" --json number,title
 
 # Recently-merged PRs that used "Supersedes" (the area is being consolidated):
 gh pr list --repo gastownhall/gascity --state merged --search "supersedes in:body" --limit 5 --json number,title
@@ -70,8 +72,8 @@ PR touching it, STOP** and choose one of:
 
 Read the relevant design doc before writing any code. Its `Status` field and
 `## Phase N` headings tell you which parts are live and which are queued; a fix
-landing in a queued phase won't survive rebase. (Gas City precedent: PR #666
-superseded eight narrow session-model PRs; PR #790 superseded two env-projection
+landing in a queued phase won't survive rebase. (Gas City precedent: a single broad refactor
+superseded eight narrow session-model PRs; another superseded two env-projection
 PRs.)
 
 ## Phase 2 — Blast radius
@@ -257,8 +259,7 @@ Risks:
 
 ## Phase 5 — What the maintainer will check
 
-Gas City adoption reviews run a multi-model pass (Claude + Codex, sometimes
-Gemini) and consistently flag these. Address them proactively — each maps to a
+Gas City adoption reviews run a multi-model automated pass and consistently flag these. Address them proactively — each maps to a
 B-rule in [`check`](../check/SKILL.md):
 
 1. **Silent error handling** — `_ = store.Write()` or a `bool` return that doesn't fire `false` on write error (B12)

--- a/contributing/skills/ship/SKILL.md
+++ b/contributing/skills/ship/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ship
-description: The pre-push self-review gate for a gastownhall/gascity PR. Runs in sequence — design-capture gate, a simplify pass, a self-review against the recurring adoption-review findings (iterate until clean), optional performance measurement, then the full check skill (mechanical gates + B1-B36 audit) — and produces a readiness report. It STOPS at the report; pushing the branch and opening the PR are your call. Self-contained: no internal hooks or tooling required. Use right before you open a PR to gastownhall/gascity.
+description: The pre-push self-review gate for a gastownhall/gascity PR. Runs in sequence — design-capture gate, a simplify pass, a self-review against the recurring adoption-review findings (iterate until clean), optional performance measurement, then the full check skill (mechanical gates + B1-B36 audit) — and produces a readiness report. It STOPS at the report; pushing the branch and opening the PR are your call. Self-contained — no internal hooks or tooling required. Use right before you open a PR to gastownhall/gascity.
 ---
 
 # Ship — Pre-Push Self-Review

--- a/contributing/skills/ship/SKILL.md
+++ b/contributing/skills/ship/SKILL.md
@@ -107,8 +107,7 @@ now and noisy after push.
    downstream reference docs (`go run ./cmd/genschema`, `make check-docs`) and
    re-grep `docs/reference/` for the stale phrase (B26).
 
-(These are the eight-finding sweep from PR #1482 + PR #1299 — read those PRs for
-the full pattern.)
+(These are the recurring adoption-review findings that most often bounce a PR in review.)
 
 ### Stage 2b — Review loop
 
@@ -204,8 +203,8 @@ body — it shows the reviewer you did the work.
 
 ## After you open the PR — automated review
 
-`gastownhall/gascity` runs an automated reviewer (GitHub Copilot) on new PRs; it
-typically posts within a few minutes. When its comments arrive:
+`gastownhall/gascity` runs an automated reviewer on new PRs; it
+typically posts within minutes. When its comments arrive:
 
 1. Evaluate each like any reviewer — verify against the code before fixing; skip
    false positives with a one-line reason.

--- a/contributing/tests/test_contributing_skill_frontmatter.py
+++ b/contributing/tests/test_contributing_skill_frontmatter.py
@@ -30,6 +30,30 @@ class SkillFrontmatterTests(unittest.TestCase):
             self.assertRegex(body, r"(?m)^name:\s*\S+", f"{path} missing name")
             self.assertRegex(body, r"(?m)^description:\s*\S+", f"{path} missing description")
 
+    def test_frontmatter_scalars_are_yaml_safe(self) -> None:
+        # A bare ": " inside an unquoted single-line scalar makes a YAML parser
+        # read it as a nested mapping ("mapping values are not allowed here").
+        # That silently breaks GitHub's frontmatter render and any YAML-based
+        # skill loader. Quote the value or use an em-dash instead.
+        root = pathlib.Path(__file__).resolve().parents[1]
+        for path in sorted(root.glob("skills/*/SKILL.md")):
+            text = path.read_text(encoding="utf-8")
+            match = re.match(r"\A---\n(?P<body>.*?)\n---\n", text, re.DOTALL)
+            body = match.group("body") if match else ""
+            for line in body.splitlines():
+                m = re.match(r"^(?P<key>[A-Za-z][\w-]*):[ \t](?P<value>\S.*)$", line)
+                if not m:
+                    continue
+                value = m.group("value")
+                if value[0] in "\"'|>[{":  # quoted, block, or flow collection
+                    continue
+                self.assertNotIn(
+                    ": ",
+                    value,
+                    f"{path}: front matter '{m.group('key')}' has an unquoted "
+                    f"': ' — quote the value or use an em-dash (breaks YAML).",
+                )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/registry.toml
+++ b/registry.toml
@@ -227,3 +227,10 @@ schema = 1
     commit = "7dd57dd9be7d286f19f74c27a00a4359392734a4"
     hash = "sha256:3ba4ad08c81ab8d2cb9bd591a0f546435e14a9132b1d4d4745bde03d0feb94ad"
     description = "Self-contained gas-city contributor lifecycle: drops the pr-pipeline import, bakes in the B-rule adoption-review audit, blast-radius dimensions, and test-tier strategy (7 skills, zero imports)."
+
+  [[pack.release]]
+    version = "0.2.1"
+    ref = "main"
+    commit = "5b7c5c1320ee6537f5b9c661d2e52712140320df"
+    hash = "sha256:3757a3dee523efb29e7cf1f9927c70c9bf491eba6d8416e147430aa6130702cf"
+    description = "YAML-safe skill front matter (0.2.0 had an unquoted colon that broke parsing) plus a durability pass — removes time-pinned references (PR-number citations, dated product names, build-timeout numbers, drift-prone counts) so the skills resist staleness. No behavior change."


### PR DESCRIPTION
## Summary

Patch release fixing a front-matter bug shipped in 0.2.0.

Three skill descriptions (`contributing`, `find-work`, `ship`) used a bare `Self-contained: …`. The unquoted `: ` makes a YAML parser read the scalar as a nested mapping — GitHub renders `Error in user YAML: mapping values are not allowed in this context`, and any YAML-based skill loader fails the same way. Replaced with an em-dash to match the other four skills.

## Changes
- `contributing/skills/{contributing,find-work,ship}/SKILL.md` — em-dash instead of bare colon in the description.
- `contributing/pack.toml` → `0.2.1`.
- `contributing/tests/test_contributing_skill_frontmatter.py` — new test that lints every skill's front matter for an unquoted `: ` in single-line scalars (the exact bug class). Verified it fails on the pre-fix content and passes after.
- `registry.toml` — `0.2.1` release entry (content hash via `gc pack release hash`).

## Verification
- `pytest contributing/tests` → 6 passed
- All 7 skill front matters parse under `yaml.safe_load`
- `validate_registry.py` → ok; `gc pack release verify` → ok

No behavior change beyond the front-matter fix.