### PR TITLE
feat(oversight-rig): new pack — rig-scoped project-lead + deterministic escalation (0.1.0)

### DIFF
--- a/oversight-rig/.gitignore
+++ b/oversight-rig/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+.pytest_cache/
+.gc/

--- a/oversight-rig/README.md
+++ b/oversight-rig/README.md
@@ -1,0 +1,53 @@
+# oversight-rig
+
+A drop-in Gas City pack that **disaggregates project-level work scoping out of the mayor**. It adds one always-on, rig-scoped `project-lead` role per rig, so the mayor stops being the bottleneck for every project's day-to-day triage and dispatch.
+
+## The problem it solves
+
+In a single-mayor city, the mayor ends up in the minutiae of every project's work scoping — what to dispatch, what's blocked, what to escalate — across every rig at once. That doesn't scale.
+
+## The model
+
+```
+mayor (city, unchanged) ──── plans cross-cutting work, handles escalations
+
+  rig: foo                      rig: bar                  …
+  project-lead-foo              project-lead-bar
+  • bounded to foo's beads      • bounded to bar's beads
+  • reads foo/.gc/              • reads bar/.gc/
+    project-brief.md              project-brief.md
+  • dispatches its own          • dispatches its own
+    ready work directly           ready work directly
+```
+
+- **`project-lead`** (rig scope, always-on, one per rig)
+  - Bounded to a single rig's beads. Reads its persona, current focus, and escalation triggers from `<rig>/.gc/project-brief.md` — each project owns its own scoping context, so it never piles onto the mayor.
+  - Triages its rig every tick and **dispatches ready, in-scope work in its own rig directly** — it does not route every dispatch through the mayor.
+  - Judges severity (info vs escalate) and writes structured rollup beads.
+- **The mayor stays unchanged** and shrinks to what is genuinely cross-cutting: planning work that spans rigs, and reacting to escalations.
+
+## Deterministic escalation (no relay agent)
+
+The project-lead writes a rollup bead labeled `severity:escalate`. A scheduled order (`escalate-rollups`) uses a mechanical condition trigger that checks for undelivered escalate-severity rollups and delivers them via extmsg — **no second agent decides "is this escalation-worthy."** The judgment is made once, by the agent with the right context, and the rollup bead is the audit trail. Human replies route straight back to the bound project-lead.
+
+## What's in the pack
+
+- `agents/project-lead/` — the role (agent config, prompt template, and a `project-brief.template.md` to copy per rig)
+- `orders/` — `patrol-project-leads` (triage cadence) and `escalate-rollups` (deterministic delivery)
+- `assets/scripts/` — the delivery script and a rig→channel resolver
+
+## Requirements
+
+- An extmsg/slack adapter in the city for outbound delivery and inbound replies — **compose this pack with your slack pack** (e.g. `slack-full`, `slack-channel`, or `slack-mini`). This pack ships only the oversight role and its escalation machinery, not a slack bridge.
+- Optional: the project-lead's rig-scoped dispatch examples use convoy formulas (`mol-decompose`, `mol-pr-from-issue`) supplied by a workflow pack (e.g. `gastown`). The role works without them.
+
+## Install
+
+1. Add the pack to your `city.toml` and stamp a `project-lead` per rig.
+2. For each rig under oversight, author its brief:
+   ```bash
+   cp agents/project-lead/project-brief.template.md <rig-root>/.gc/project-brief.md
+   # then edit the brief to fit the project
+   ```
+3. Bind each rig's `project-lead` session to that rig's channel via your slack pack so escalations deliver and replies route back.
+4. `gc supervisor reload` — picks up the new agents and orders.

--- a/oversight-rig/agents/project-lead/agent.toml
+++ b/oversight-rig/agents/project-lead/agent.toml
@@ -1,0 +1,4 @@
+scope = "rig"
+work_dir = "{{.RigRoot}}"
+nudge = "Read your brief. Triage your rig. Write a rollup bead if anything is off-baseline."
+idle_timeout = "1h"

--- a/oversight-rig/agents/project-lead/project-brief.template.md
+++ b/oversight-rig/agents/project-lead/project-brief.template.md
@@ -1,0 +1,58 @@
+# Project Brief — `<RIG-NAME>`
+
+> Copy to `<rig-root>/.gc/project-brief.md` and customize. The
+> project-lead reads this every tick. Write it like a memo to a smart
+> colleague who's never worked on this project — plain language,
+> directional, no codebase jargon. The project-lead translates your
+> intent into the operational checks (bead queries, label filters,
+> etc.) — you don't have to.
+
+## What this project is
+
+One short paragraph. What problem are we solving, who is it for, and
+what does success look like this quarter? Plain language — no internal
+acronyms, no bead IDs, no file paths. If a new exec joined the team
+tomorrow, this paragraph is what you'd want them to read first.
+
+## How I want to hear about it
+
+Two or three sentences on tone and depth. Examples:
+
+- "Quick research notes, not bug reports. Tell me what shifted, why
+  it matters, and what decision you need."
+- "Plain English. I want to be able to read a rollup at the airport
+  and reply with one sentence."
+- "Lead with the business impact, then the technical context if
+  needed. Skip implementation detail unless I ask."
+
+## When to wake me up
+
+List 3–5 directional statements. Plain language, not bead syntax.
+Examples (replace with what's true for THIS project):
+
+- Anything that's threatening to slow the headline goal for this quarter
+- Decisions that need my judgment about scope, prioritization, or risk tolerance
+- Spend or commitments that exceed what I've already approved
+- An external dependency falling through (vendor, partner, tool)
+- A repeated failure pattern that suggests something deeper is broken
+- Anything where the team is stuck waiting for me specifically
+
+The project-lead will turn each of these into the operational signal
+to watch for. Your job is to tell it what counts as worth your time.
+
+## When NOT to wake me up
+
+List 2–4 directional statements. These matter as much as the wake-me
+list — they're how you tune out noise.
+
+- Routine work in progress, even if it's slow
+- Known dependencies on other projects that are already on someone's plate
+- Cleanup, refactoring, or anything explicitly de-prioritized
+- Any specific scenario you've already decided about (just note the decision)
+
+## What "going well" looks like
+
+One short paragraph. Forward-looking — what does this project look
+like in 4 weeks if it's on track? The project-lead uses this to
+distinguish "boringly on track" (don't escalate) from "drifting from
+the plan" (mention in a weekly digest).

--- a/oversight-rig/agents/project-lead/prompt.template.md
+++ b/oversight-rig/agents/project-lead/prompt.template.md
@@ -1,0 +1,215 @@
+# Project Lead — Single-Rig Coordinator
+
+> **Recovery**: Run `gc prime` after compaction, clear, or new session.
+
+## Your Role
+
+You are the **project-lead** for **one rig** (`{{ .Rig }}`). You hold
+context for THIS rig only — never another rig, never the whole city.
+You judge whether anything in your rig warrants the human's attention,
+and you write structured rollup beads when it does.
+
+You do not write code. You do not contact the human directly. You do
+not deliver to Slack/email. The downstream pipeline turns your rollup
+beads into messages mechanically — your job is to make the right
+judgment, in your project's voice, and write the bead.
+
+You also **dispatch ready, in-scope work in your own rig directly** —
+you no longer route every dispatch through the mayor. See
+_Rig-Scoped Dispatch_ below for the boundary.
+
+## Required First Step Each Tick
+
+Read your project brief at `{{ .RigRoot }}/.gc/project-brief.md`. The
+brief defines:
+
+- The project's name and current focus
+- Your persona — how you communicate, what you care about, your voice
+- Project-specific escalation triggers (e.g. "any blocked bead on the
+  migration epic", "any test failure on auth/* paths", "any coder
+  retry count over 3 on the same step")
+- Anything you should specifically NOT escalate (e.g. work that's
+  correctly waiting on a known external gate)
+
+If the brief is missing, mail the mayor that this rig needs onboarding
+and exit. Do not improvise a persona.
+
+## Your Inputs (rig-bounded)
+
+You read these and nothing else:
+
+- `gc bd list --rig {{ .Rig }} --status blocked --json`
+- `gc bd list --rig {{ .Rig }} --status in_progress --json`
+- `gc bd list --rig {{ .Rig }} --label rollup --status open --json` (dedup)
+- `gc mail inbox` (human replies routed back to you, plus crew
+  questions specific to your rig)
+- `{{ .RigRoot }}/.gc/project-brief.md` (your operating manual)
+
+You do **not** read source files, test logs, or raw agent transcripts.
+If your brief's triggers reference test/log content, the trigger has
+to come from a separate watcher writing a bead — don't go fetch it
+yourself.
+
+## Your Outputs (one bead shape, two severities)
+
+Every tick produces zero or more **rollup beads** with this exact
+label set:
+
+- `rollup` (always)
+- `rig:{{ .Rig }}` (always)
+- `severity:escalate` OR `severity:info` (always exactly one)
+- `ref:<source-bead-id>` (for each source bead the rollup is about)
+
+`severity:escalate` means: this needs the human now. The downstream
+order will deliver it. Use sparingly — once delivered, the human is
+paged.
+
+`severity:info` means: this is for the audit trail / weekly digest.
+Not delivered. Use freely.
+
+Bead title format:
+
+```
+Rollup({{ .Rig }}): <one-line summary in your project's voice>
+```
+
+Bead description must be exactly this template, filled in:
+
+```
+Rig: {{ .Rig }}
+Project: <name from brief>
+State: <one line — "healthy", "blocked on X", "needs decision on Y">
+Source bead(s): <comma-separated ids>
+Stuck since: <ISO 8601 timestamp of earliest source bead's relevant transition>
+Why: <one paragraph in your persona's voice — what is happening, why it matters>
+Smallest ask: <single concrete decision or question the human can answer in under a minute, or "none — informational">
+```
+
+The downstream delivery pipeline parses this format. Drift from the
+template and your rollup will not be deliverable.
+
+### Slack-mrkdwn for any prose you write into the bead body
+
+Rollup-bead bodies are posted to Slack verbatim by the downstream
+delivery pipeline. Slack uses **single-asterisk bold** (`*bold*`),
+NOT GitHub-markdown double-asterisk (`**bold**`). Same for italics:
+underscores (`_italic_`), not double-asterisks. Tables go in code
+fences. Links are `<url|label>` form, not `[label](url)`.
+
+Use an executive-skimmable shape inside the `Why:`
+field when applicable:
+
+```
+*TL;DR:* 1-2 sentences.
+
+*Context (≤3 bullets, OPTIONAL):* only if TL;DR isn't enough.
+
+*Asks:* "none — informational" OR a numbered list, each with: what to
+decide / paths available / recommended path + why / why YOUR call.
+```
+
+The `Smallest ask:` field of the template still gates whether
+`severity:escalate` is appropriate; the format above structures the
+`Why:` paragraph so the human can act on it in seconds rather than
+reading prose.
+
+## Dedup (mandatory)
+
+Before writing a `severity:escalate` rollup, list existing open
+`severity:escalate` rollup beads for your rig:
+
+```bash
+gc bd list --rig {{ .Rig }} --label rollup --label severity:escalate --status open --json
+```
+
+If any of them have a `ref:<id>` matching one of your source beads,
+do NOT write a new one. Either update the existing bead's
+description (if the situation has materially changed) or skip.
+
+## Replies From the Human
+
+The human replies in the external channel your rig is bound to. The reply
+reaches you directly — as an inbound channel notification if your session is
+bound to the channel, or as mail (`gc mail send {{ .Rig }}/project-lead`)
+otherwise. When you receive one:
+
+1. Read the reply.
+2. Act on it (file beads, unblock coders, update priorities in your rig).
+3. Write a `severity:info` rollup with `state: "<original ask> resolved: <what the human decided>"` and the same `ref:` labels.
+4. Close the original `severity:escalate` rollup with status `closed`
+   and outcome in the closing comment.
+
+## Rig-Scoped Dispatch (your rig only)
+
+You may dispatch **ready** work in your own rig directly, including
+convoy-creating formulas (`mol-decompose`, `mol-pr-from-issue`) that
+expand a single root bead into a multi-bead graph workflow. A bead is
+*ready* to sling when ALL of these hold:
+
+- status `open`, not `blocked`, and every `depends-on` bead is closed
+- not gated on a human decision (no open `severity:escalate` rollup
+  about it, no "needs decision" / "needs-api" gate in its notes or
+  `gc.tier` metadata)
+- your rig has a worker pool (`{{ .Rig }}`-worker or equivalent)
+
+To dispatch:
+
+```bash
+# Atomic in-rig work (single bead → single worker):
+gc-sling <rig-worker-agent> <bead-id>
+
+# Convoy-creating formulas (epic → multi-bead graph; in-rig only):
+gc-sling <rig-worker-agent> --on mol-decompose --var issue=<epic> --var rig={{ .Rig }} --stdin
+gc-sling <rig-worker-agent> --on mol-pr-from-issue --var issue=<N> --stdin
+```
+
+Use the `gc-sling` wrapper — it auto-injects `--nudge`. Then **verify
+the worker actually picked it up** — a bead can be routed but sit
+unclaimed if no worker session is awake:
+
+```bash
+gc bd --rig {{ .Rig }} show <bead-id>   # expect IN_PROGRESS within a few minutes
+```
+
+If it stays `open` with `gc.routed_to` already set, the pool is asleep.
+`gc sling` treats an already-routed bead as an idempotent skip and will
+NOT re-nudge — re-slinging a stuck bead is a silent no-op. Unstick it by
+waking a worker and nudging it onto the bead:
+
+```bash
+gc session wake <rig-worker-agent>-1
+gc session nudge <rig-worker-agent>-1 "Claim and work routed bead <bead-id>." --delivery immediate
+```
+
+**Still mayor-owned — surface as a rollup, do not sling yourself:**
+
+- **Cross-rig routing remains mayor-owned** — any work that touches another
+  rig's worktree, beads, or worker pool. In-rig convoys are yours; cross-rig
+  convoys are mayor's.
+- Worker-pool allocation — if your rig has no pool, mail the mayor
+- City-level orders (`gc order run …`) — mayor-only
+- Anything gated on a human decision — surface it `severity:escalate`
+  first; sling only after the human answers
+
+You may NOT push, open, edit, or merge PRs — even for work you dispatch.
+Polecats write code on branches and HALT at branch-ready; mayor publishes
+externally. This preserves the polecat-publish-authority rule end-to-end.
+
+## What You Never Do
+
+- Read or write code.
+- Look at beads from other rigs (cross-rig work is mayor-owned).
+- Sling cross-rig or human-gated work — surface those, don't dispatch them.
+  In-rig convoys ARE yours; cross-rig convoys are NOT.
+- Push, open, edit, or merge PRs — even for work you sling. Mayor publishes
+  per-action after human approval.
+- Decide for the human (you surface decisions, you don't make them).
+- Skip the brief. If it's missing, you don't have the context to do
+  this job — escalate the missing-brief itself.
+- Drift from the rollup description template. Downstream is mechanical.
+- Hold context across ticks. Re-derive everything from beads + brief.
+
+---
+
+Agent: {{ .AgentName }}
+Rig:   {{ .Rig }}

--- a/oversight-rig/assets/scripts/deliver-rollup.sh
+++ b/oversight-rig/assets/scripts/deliver-rollup.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+#
+# deliver-rollup.sh — POST severity:escalate rollup beads to extmsg
+# and mark them delivered. Idempotent.
+#
+# Routing model
+# -------------
+#
+# Each rollup bead carries a ``rig:<name>`` label. The script tries to
+# deliver to that rig's own bound conversation first, falling back to a
+# city-wide oversight DM if the rig has no per-rig binding yet.
+#
+# Resolution order (per bead, in priority order):
+#
+#   1. Rig-specific channel: locate the project-lead session for the
+#      bead's ``rig:`` label, then read its most recent active extmsg
+#      binding (created by ``gc slack bind-room`` or equivalent).
+#      Publish through gc's ``/extmsg/outbound`` using that session +
+#      conversation, so peer fanout fires for the other bound peers.
+#
+#   2. City-wide fallback: if the rig has no project-lead session, no
+#      active binding, or no rig label, fall back to the legacy
+#      ``GC_OVERSIGHT_*`` env vars (single DM for all rigs).
+#
+# Required environment
+# --------------------
+#
+#   GC_API_BASE_URL              e.g. http://127.0.0.1:8372
+#   GC_CITY_NAME                 the city name (matches [workspace].name)
+#
+# Required for the city-wide fallback only (no per-rig binding):
+#
+#   GC_OVERSIGHT_SESSION_ID      session id pre-bound to a conversation
+#                                via POST /v0/city/{city}/extmsg/bind
+#   GC_OVERSIGHT_PROVIDER        e.g. "slack"
+#   GC_OVERSIGHT_ACCOUNT_ID      e.g. workspace id "TXXXXXXXXXX"
+#   GC_OVERSIGHT_CONVERSATION_ID e.g. DM channel "DXXXXXXXXXX"
+#   GC_OVERSIGHT_KIND            "dm" | "room" | "thread"
+#
+# Why this script (not a CLI): the v0 SDK has no `gc extmsg send`
+# command. Outbound is HTTP-only. This script encapsulates the curl so
+# the rest of the pack stays declarative.
+#
+# The mapping from rollup bead → extmsg payload preserves enough
+# context that the inbound reply path can find the right bead:
+#   - Title becomes the message header
+#   - Description's "Smallest ask" line becomes the call-to-action
+#   - Bead id is included as `in_reply_to_bead` metadata in the
+#     idempotency_key so the inbound reply path can attribute a human
+#     reply back to the right escalation bead.
+
+set -euo pipefail
+
+: "${GC_API_BASE_URL:?GC_API_BASE_URL must be set}"
+: "${GC_CITY_NAME:?GC_CITY_NAME must be set}"
+
+api="${GC_API_BASE_URL%/}/v0/city/${GC_CITY_NAME}/extmsg/outbound"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+resolver="${script_dir}/resolve_rig_channel.py"
+
+# resolve_target <rig>
+#
+# Stdout: JSON {session_id, conversation: {...}} on success.
+# Returns the resolver's exit code:
+#   0 — resolved per-rig channel (caller uses stdout)
+#   2 — no project-lead session for this rig (caller falls back)
+#   3 — project-lead exists but no active binding (caller falls back)
+#   1 — resolver hit an error (caller logs and skips this bead)
+resolve_target() {
+  local rig="$1"
+  if [[ -z "$rig" ]]; then
+    return 2
+  fi
+  if ! command -v python3 >/dev/null 2>&1; then
+    echo "deliver-rollup: python3 not on PATH; cannot resolve per-rig channel" >&2
+    return 1
+  fi
+  python3 "$resolver" "$rig"
+}
+
+mapfile -t bead_ids < <(
+  gc bd list --label rollup --label severity:escalate --status open --json \
+    | jq -r '.[] | select((.labels // []) | index("delivered") | not) | .id'
+)
+
+if [[ ${#bead_ids[@]} -eq 0 ]]; then
+  exit 0
+fi
+
+# Whether the legacy city-wide fallback is configured. If not, beads
+# whose rig has no binding will be left undelivered (and retried next
+# tick) instead of silently disappearing.
+fallback_configured=true
+for var in GC_OVERSIGHT_SESSION_ID GC_OVERSIGHT_PROVIDER \
+           GC_OVERSIGHT_ACCOUNT_ID GC_OVERSIGHT_CONVERSATION_ID \
+           GC_OVERSIGHT_KIND; do
+  if [[ -z "${!var:-}" ]]; then
+    fallback_configured=false
+    break
+  fi
+done
+
+for id in "${bead_ids[@]}"; do
+  bead_json=$(gc bd show "$id" --json)
+  title=$(jq -r '.[0].title' <<<"$bead_json")
+  body=$(jq -r '.[0].description // ""' <<<"$bead_json")
+  rig=$(jq -r '.[0].labels[] | select(startswith("rig:")) | sub("^rig:"; "")' <<<"$bead_json" | head -1)
+
+  text=$(printf '*%s*\n\n%s\n\n_(rollup bead %s · rig: %s)_\n_Reply to this message to respond to %s._' \
+    "$title" "$body" "$id" "$rig" "$id")
+
+  resolved_json=""
+  rerr=$(mktemp)
+  if resolved_json=$(resolve_target "$rig" 2>"$rerr"); then
+    rm -f "$rerr"  # per-rig binding found; resolved_json populated
+  else
+    rc=$?
+    case "$rc" in
+      2|3)
+        rm -f "$rerr"
+        if ! $fallback_configured; then
+          echo "deliver-rollup: rig=${rig:-<none>} has no per-rig binding and city-wide fallback is not configured; skipping bead $id" >&2
+          continue
+        fi
+        resolved_json=""  # signal: use legacy env-var fallback
+        ;;
+      *)
+        echo "deliver-rollup: resolver failed for rig=${rig:-<none>} (rc=$rc): $(cat "$rerr" 2>/dev/null); skipping bead $id" >&2
+        rm -f "$rerr"; continue
+        ;;
+    esac
+  fi
+
+  if [[ -n "$resolved_json" ]]; then
+    sid=$(jq -r '.session_id' <<<"$resolved_json")
+    scope=$(jq -r '.conversation.scope_id' <<<"$resolved_json")
+    prov=$(jq -r '.conversation.provider' <<<"$resolved_json")
+    acct=$(jq -r '.conversation.account_id' <<<"$resolved_json")
+    conv=$(jq -r '.conversation.conversation_id' <<<"$resolved_json")
+    kind=$(jq -r '.conversation.kind' <<<"$resolved_json")
+    target_label="rig:$rig"
+  else
+    sid="$GC_OVERSIGHT_SESSION_ID"
+    scope="$GC_CITY_NAME"
+    prov="$GC_OVERSIGHT_PROVIDER"
+    acct="$GC_OVERSIGHT_ACCOUNT_ID"
+    conv="$GC_OVERSIGHT_CONVERSATION_ID"
+    kind="$GC_OVERSIGHT_KIND"
+    target_label="city-wide"
+  fi
+
+  payload=$(jq -n \
+    --arg sid "$sid" \
+    --arg text "$text" \
+    --arg key "rollup-$id" \
+    --arg scope "$scope" \
+    --arg prov "$prov" \
+    --arg acct "$acct" \
+    --arg conv "$conv" \
+    --arg kind "$kind" \
+    '{
+       session_id: $sid,
+       conversation: {
+         scope_id: $scope,
+         provider: $prov,
+         account_id: $acct,
+         conversation_id: $conv,
+         kind: $kind
+       },
+       text: $text,
+       idempotency_key: $key
+     }')
+
+  if curl --silent --show-error --fail \
+       --max-time 30 \
+       --header "Content-Type: application/json" \
+       --header "X-GC-Request: deliver-rollup" \
+       --data "$payload" \
+       "$api" >/dev/null; then
+    gc bd update "$id" --add-label delivered
+    echo "delivered $id ($target_label, conv=$conv)"
+  else
+    echo "delivery failed for $id; will retry next tick" >&2
+  fi
+done

--- a/oversight-rig/assets/scripts/has-undelivered-escalates.sh
+++ b/oversight-rig/assets/scripts/has-undelivered-escalates.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+#
+# has-undelivered-escalates.sh — condition check for escalate-rollups order.
+#
+# Exits 0 (fire the order) when there is at least one open rollup bead
+# with severity:escalate that has not yet been labeled delivered.
+# Exits non-zero otherwise.
+
+set -euo pipefail
+
+count=$(
+  gc bd list --label rollup --label severity:escalate --status open --json \
+    | jq '[.[] | select((.labels // []) | index("delivered") | not)] | length'
+)
+
+[[ "$count" -gt 0 ]]

--- a/oversight-rig/assets/scripts/nudge-project-leads.sh
+++ b/oversight-rig/assets/scripts/nudge-project-leads.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# nudge-project-leads.sh — wake every project-lead session for a triage tick.
+#
+# Pure plumbing: enumerate active project-lead sessions, send each one
+# the standard triage nudge. The decision of "what to escalate" stays
+# entirely with the project-lead (informed by its rig's project-brief.md).
+# This script never reads beads, never decides escalations.
+
+set -euo pipefail
+
+# Session template for this pack's project-lead.
+template="oversight-rig.project-lead"
+
+mapfile -t session_ids < <(
+  gc session list --json \
+    | jq -r --arg t "$template" '.[] | select(.template == $t and .state == "active") | .id'
+)
+
+if [[ ${#session_ids[@]} -eq 0 ]]; then
+  echo "no active project-lead sessions"
+  exit 0
+fi
+
+nudged=0
+for sid in "${session_ids[@]}"; do
+  if gc session nudge "$sid" --message "Triage tick: read your brief, survey your rig, write rollups." >/dev/null 2>&1; then
+    nudged=$((nudged + 1))
+  else
+    echo "nudge failed for $sid" >&2
+  fi
+done
+
+echo "nudged $nudged project-lead session(s)"

--- a/oversight-rig/assets/scripts/resolve_rig_channel.py
+++ b/oversight-rig/assets/scripts/resolve_rig_channel.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Resolve the publishing target for a rig's rollup delivery.
+
+Given a ``rig`` label (e.g. ``my-rig``), find the project-lead session that
+owns the rig's bound conversation and emit the publish parameters needed
+by ``POST /v0/city/{city}/extmsg/outbound``.
+
+Resolution order:
+
+1. ``GET /v0/city/{city}/sessions`` — find the session whose
+   ``rig`` matches and whose ``alias`` (or ``session_name``) ends in
+   ``oversight-rig.project-lead``.
+2. ``GET /v0/city/{city}/extmsg/bindings?session_id=<id>`` — pick the
+   most recent active binding (the bind-room participant binding).
+3. Print JSON ``{session_id, conversation: {...}}`` to stdout.
+
+Exit codes:
+
+* ``0`` — resolution succeeded; JSON written to stdout.
+* ``1`` — usage / required env missing.
+* ``2`` — no project-lead session exists for ``rig``.
+* ``3`` — project-lead exists but has no active extmsg binding.
+
+The bash caller treats exit codes 2 and 3 as "fall back to the legacy
+city-wide ``GC_OVERSIGHT_*`` env vars", and any other non-zero as a
+hard failure.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from typing import Any
+
+DEFAULT_GC_API = "http://127.0.0.1:8372"
+PROJECT_LEAD_SUFFIX = "oversight-rig.project-lead"
+
+EXIT_OK = 0
+EXIT_USAGE = 1
+EXIT_NO_SESSION = 2
+EXIT_NO_BINDING = 3
+
+
+class ResolveError(RuntimeError):
+    """Raised when the resolver hits an unrecoverable error."""
+
+
+def _api_base() -> str:
+    return os.environ.get("GC_API_BASE_URL", DEFAULT_GC_API).rstrip("/")
+
+
+def _city_name() -> str:
+    name = os.environ.get("GC_CITY_NAME", "").strip()
+    if not name:
+        raise ResolveError("GC_CITY_NAME is not set")
+    return name
+
+
+def _http_get(url: str, *, timeout: float = 10.0) -> dict[str, Any]:
+    """GET ``url`` and return the decoded JSON body."""
+    req = urllib.request.Request(url, headers={"Accept": "application/json"}, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read()
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise ResolveError(f"GET {url} -> {exc.code}: {detail}") from exc
+    except urllib.error.URLError as exc:
+        raise ResolveError(f"GET {url} failed: {exc}") from exc
+    if not raw:
+        return {}
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ResolveError(f"GET {url}: response is not JSON: {raw!r}") from exc
+
+
+def find_project_lead_session(sessions: list[dict[str, Any]], rig: str) -> dict[str, Any] | None:
+    """Pick the project-lead session for ``rig`` from a sessions list.
+
+    Two matching strategies are accepted because both forms appear in
+    the wild and either alone could break under naming drift:
+
+    * ``rig == <rig>`` AND template/alias/session_name ending in
+      ``oversight-rig.project-lead``.
+    * fallback: alias or session_name equal to
+      ``<rig>/oversight-rig.project-lead`` exactly.
+
+    Active sessions are preferred over closed ones; among ties the
+    first match wins (sessions list is ordered by the supervisor).
+    """
+    rig = rig.strip()
+    if not rig:
+        return None
+
+    candidates: list[tuple[int, dict[str, Any]]] = []
+    exact_alias = f"{rig}/{PROJECT_LEAD_SUFFIX}"
+    for entry in sessions:
+        if not isinstance(entry, dict):
+            continue
+        entry_rig = (entry.get("rig") or "").strip()
+        alias = (entry.get("alias") or "").strip()
+        session_name = (entry.get("session_name") or "").strip()
+        template = (entry.get("template") or "").strip()
+        ends_with_pl = (
+            alias.endswith(PROJECT_LEAD_SUFFIX)
+            or session_name.endswith(PROJECT_LEAD_SUFFIX)
+            or template.endswith(PROJECT_LEAD_SUFFIX)
+        )
+        if entry_rig == rig and ends_with_pl:
+            score = 0  # strongest match
+        elif alias == exact_alias or session_name == exact_alias:
+            score = 1  # exact alias fallback
+        else:
+            continue
+        # Prefer non-closed states.
+        state = (entry.get("state") or "").strip().lower()
+        if state == "closed":
+            score += 10
+        candidates.append((score, entry))
+
+    if not candidates:
+        return None
+    candidates.sort(key=lambda item: item[0])
+    return candidates[0][1]
+
+
+def pick_active_binding(bindings: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """Return the most recent active binding from a bindings list.
+
+    Mirrors the discord/slack pack convention: scan from newest to
+    oldest, return the first one whose ``Status`` is ``active``.
+    """
+    for entry in reversed(bindings):
+        if not isinstance(entry, dict):
+            continue
+        if (entry.get("Status") or "").strip().lower() == "active":
+            return entry
+    return None
+
+
+def resolve(
+    rig: str,
+    *,
+    fetch_sessions: Any = None,
+    fetch_bindings: Any = None,
+) -> dict[str, Any]:
+    """Resolve ``rig`` to a publish target.
+
+    ``fetch_sessions`` and ``fetch_bindings`` are injected for tests;
+    in production they default to live HTTP calls.
+    """
+    rig = rig.strip()
+    if not rig:
+        raise ResolveError("rig is empty")
+
+    if fetch_sessions is None:
+        def fetch_sessions() -> list[dict[str, Any]]:
+            base = _api_base()
+            city = _city_name()
+            return list(_http_get(f"{base}/v0/city/{city}/sessions").get("items", []))
+
+    if fetch_bindings is None:
+        def fetch_bindings(session_id: str) -> list[dict[str, Any]]:
+            base = _api_base()
+            city = _city_name()
+            return list(_http_get(
+                f"{base}/v0/city/{city}/extmsg/bindings?session_id={session_id}"
+            ).get("items", []))
+
+    sessions = fetch_sessions()
+    session = find_project_lead_session(sessions, rig)
+    if session is None:
+        raise ResolveError(f"no project-lead session for rig {rig!r}")
+
+    session_id = (session.get("id") or "").strip()
+    if not session_id:
+        raise ResolveError(f"project-lead session for rig {rig!r} has no id")
+
+    bindings = fetch_bindings(session_id)
+    binding = pick_active_binding(bindings)
+    if binding is None:
+        raise ResolveError(
+            f"project-lead session {session_id} for rig {rig!r} has no active binding")
+
+    conversation = binding.get("Conversation") or {}
+    return {
+        "session_id": session_id,
+        "conversation": {
+            "scope_id": conversation.get("scope_id", ""),
+            "provider": conversation.get("provider", ""),
+            "account_id": conversation.get("account_id", ""),
+            "conversation_id": conversation.get("conversation_id", ""),
+            "kind": conversation.get("kind", ""),
+        },
+    }
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("rig", help="rig label (e.g. 'my-rig')")
+    args = parser.parse_args(argv)
+
+    try:
+        result = resolve(args.rig)
+    except ResolveError as exc:
+        msg = str(exc)
+        sys.stderr.write(msg + "\n")
+        if msg.startswith("no project-lead session"):
+            return EXIT_NO_SESSION
+        if "no active binding" in msg:
+            return EXIT_NO_BINDING
+        return EXIT_USAGE
+    json.dump(result, sys.stdout)
+    sys.stdout.write("\n")
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/oversight-rig/assets/scripts/test_resolve_rig_channel.py
+++ b/oversight-rig/assets/scripts/test_resolve_rig_channel.py
@@ -1,0 +1,207 @@
+"""Tests for resolve_rig_channel — pure resolver logic, no live HTTP.
+
+The module is meant to be runnable as both a CLI and a library; the
+tests target the library surface (``resolve``, ``find_project_lead_session``,
+``pick_active_binding``) and the CLI exit-code mapping.
+"""
+
+from __future__ import annotations
+
+import io
+import pathlib
+import sys
+from typing import Any
+
+import pytest
+
+SCRIPTS_DIR = pathlib.Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GC_API_BASE_URL", "http://127.0.0.1:8372")
+    monkeypatch.setenv("GC_CITY_NAME", "test-city")
+
+
+def _import():
+    sys.modules.pop("resolve_rig_channel", None)
+    import resolve_rig_channel  # type: ignore
+    return resolve_rig_channel
+
+
+def _session(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "id": "gc-77139",
+        "alias": "geo/oversight-rig.project-lead",
+        "session_name": "geo/oversight-rig.project-lead",
+        "template": "geo/oversight-rig.project-lead",
+        "rig": "geo",
+        "state": "active",
+    }
+    base.update(overrides)
+    return base
+
+
+def _binding(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "ID": "gc-83357",
+        "SessionID": "gc-77139",
+        "Status": "active",
+        "Conversation": {
+            "scope_id": "test-city",
+            "provider": "slack",
+            "account_id": "T0TESTWS",
+            "conversation_id": "C0123ROOM",
+            "kind": "room",
+        },
+    }
+    base.update(overrides)
+    return base
+
+
+def test_resolve_success_returns_session_and_conversation():
+    mod = _import()
+    out = mod.resolve(
+        "geo",
+        fetch_sessions=lambda: [_session()],
+        fetch_bindings=lambda _sid: [_binding()],
+    )
+    assert out == {
+        "session_id": "gc-77139",
+        "conversation": {
+            "scope_id": "test-city",
+            "provider": "slack",
+            "account_id": "T0TESTWS",
+            "conversation_id": "C0123ROOM",
+            "kind": "room",
+        },
+    }
+
+
+def test_find_project_lead_prefers_rig_match_over_alias_fallback():
+    mod = _import()
+    sessions = [
+        # Pure alias-based fallback match — score 1.
+        _session(id="gc-old", rig="", alias="geo/oversight-rig.project-lead",
+                 session_name="", template="", state="active"),
+        # Strong rig-based match — score 0.
+        _session(id="gc-new", rig="geo", alias="geo/oversight-rig.project-lead",
+                 state="active"),
+    ]
+    out = mod.find_project_lead_session(sessions, "geo")
+    assert out is not None and out["id"] == "gc-new"
+
+
+def test_find_project_lead_prefers_active_over_closed():
+    mod = _import()
+    sessions = [
+        _session(id="gc-closed", state="closed"),
+        _session(id="gc-active", state="active"),
+    ]
+    out = mod.find_project_lead_session(sessions, "geo")
+    assert out is not None and out["id"] == "gc-active"
+
+
+def test_find_project_lead_returns_none_for_unknown_rig():
+    mod = _import()
+    sessions = [_session(id="gc-77139", rig="geo")]
+    assert mod.find_project_lead_session(sessions, "unknown-rig") is None
+
+
+def test_find_project_lead_skips_unrelated_sessions():
+    mod = _import()
+    sessions = [
+        # mayor session under "oversight-rig" rig — not a project-lead.
+        {
+            "id": "gc-mayor",
+            "rig": "oversight-rig",
+            "alias": "oversight-rig.mayor",
+            "session_name": "oversight-rig.mayor",
+            "template": "oversight-rig.mayor",
+            "state": "active",
+        },
+    ]
+    assert mod.find_project_lead_session(sessions, "oversight-rig") is None
+
+
+def test_pick_active_binding_returns_most_recent_active():
+    mod = _import()
+    bindings = [
+        _binding(ID="b1", Status="active", Conversation={
+            "scope_id": "x", "provider": "slack", "account_id": "a",
+            "conversation_id": "C-OLD", "kind": "room",
+        }),
+        _binding(ID="b2", Status="inactive"),
+        _binding(ID="b3", Status="active", Conversation={
+            "scope_id": "x", "provider": "slack", "account_id": "a",
+            "conversation_id": "C-NEW", "kind": "room",
+        }),
+    ]
+    out = mod.pick_active_binding(bindings)
+    assert out is not None and out["Conversation"]["conversation_id"] == "C-NEW"
+
+
+def test_pick_active_binding_returns_none_when_all_inactive():
+    mod = _import()
+    bindings = [_binding(Status="inactive"), _binding(Status="closed")]
+    assert mod.pick_active_binding(bindings) is None
+
+
+def test_resolve_raises_when_no_session():
+    mod = _import()
+    with pytest.raises(mod.ResolveError, match="no project-lead session"):
+        mod.resolve(
+            "missing-rig",
+            fetch_sessions=lambda: [_session()],
+            fetch_bindings=lambda _sid: [],
+        )
+
+
+def test_resolve_raises_when_no_active_binding():
+    mod = _import()
+    with pytest.raises(mod.ResolveError, match="no active binding"):
+        mod.resolve(
+            "geo",
+            fetch_sessions=lambda: [_session()],
+            fetch_bindings=lambda _sid: [_binding(Status="inactive")],
+        )
+
+
+def test_main_exit_code_maps_no_session_to_2(monkeypatch: pytest.MonkeyPatch,
+                                             capsys: pytest.CaptureFixture[str]):
+    mod = _import()
+    monkeypatch.setattr(mod, "resolve", lambda _rig: (_ for _ in ()).throw(
+        mod.ResolveError("no project-lead session for rig 'unknown'")))
+    rc = mod.main(["unknown"])
+    assert rc == mod.EXIT_NO_SESSION
+
+
+def test_main_exit_code_maps_no_binding_to_3(monkeypatch: pytest.MonkeyPatch):
+    mod = _import()
+    monkeypatch.setattr(mod, "resolve", lambda _rig: (_ for _ in ()).throw(
+        mod.ResolveError("project-lead session gc-1 for rig 'geo' has no active binding")))
+    rc = mod.main(["geo"])
+    assert rc == mod.EXIT_NO_BINDING
+
+
+def test_main_emits_json_on_success(monkeypatch: pytest.MonkeyPatch,
+                                    capsys: pytest.CaptureFixture[str]):
+    mod = _import()
+    monkeypatch.setattr(mod, "resolve", lambda rig: {
+        "session_id": "gc-77139",
+        "conversation": {
+            "scope_id": "test-city",
+            "provider": "slack",
+            "account_id": "T0TESTWS",
+            "conversation_id": "C0123ROOM",
+            "kind": "room",
+        },
+    })
+    rc = mod.main(["geo"])
+    assert rc == mod.EXIT_OK
+    captured = capsys.readouterr()
+    import json
+    parsed = json.loads(captured.out)
+    assert parsed["session_id"] == "gc-77139"
+    assert parsed["conversation"]["conversation_id"] == "C0123ROOM"

--- a/oversight-rig/orders/escalate-rollups.toml
+++ b/oversight-rig/orders/escalate-rollups.toml
@@ -1,0 +1,6 @@
+[order]
+description = "Watch for severity:escalate rollup beads and deliver them. Pure mechanical — no agent decision."
+trigger = "condition"
+check = "bash $GC_PACK_DIR/assets/scripts/has-undelivered-escalates.sh"
+exec = "bash $GC_PACK_DIR/assets/scripts/deliver-rollup.sh"
+timeout = "2m"

--- a/oversight-rig/orders/patrol-project-leads.toml
+++ b/oversight-rig/orders/patrol-project-leads.toml
@@ -1,0 +1,6 @@
+[order]
+description = "Nudge every project-lead to run a triage tick. Cooldown sets the cadence."
+trigger = "cooldown"
+interval = "15m"
+exec = "bash $GC_PACK_DIR/assets/scripts/nudge-project-leads.sh"
+timeout = "30s"

--- a/oversight-rig/pack.toml
+++ b/oversight-rig/pack.toml
@@ -1,0 +1,87 @@
+# Oversight (rig variant) — drop-in pack for existing gastown-style cities.
+#
+# Disaggregates project-level work scoping out of the mayor. Adds one role
+# alongside your existing mayor, without touching it:
+#
+#   project-lead (rig scope, always-on, stamped per rig)
+#     • Bounded to ONE rig's beads. Reads its persona/focus/escalation
+#       triggers from <rig>/.gc/project-brief.md (each project owns its
+#       own brief, so scoping context stays local instead of piling onto
+#       the mayor).
+#     • Triages its rig every tick and dispatches ready, in-scope work in
+#       its own rig directly — it does not route every dispatch through
+#       the mayor.
+#     • Judges severity (info vs escalate) and writes structured rollup
+#       beads with explicit labels.
+#
+# The mayor stays unchanged and shrinks to what is genuinely cross-cutting:
+# planning work that spans rigs, and reacting to escalations.
+#
+# Why the outbound path has zero agent gates beyond project-lead:
+#   project-lead writes a rollup bead with label:severity:escalate.
+#   The escalate-rollups order uses a `condition` trigger that mechanically
+#   checks for undelivered escalate-severity rollup beads. When any exist,
+#   it runs deliver-rollup.sh which POSTs to extmsg and marks the bead
+#   delivered. No second agent decides "is this escalation-worthy" — that
+#   judgment was made once, by the agent with the right context, and the
+#   rollup bead IS the audit trail of that decision.
+#
+# Human replies route straight back to the bound project-lead: bind each
+# rig's project-lead session to that rig's channel with your slack pack, and
+# the human's reply arrives as an inbound notification on that session. (No
+# relay agent — the role that wrote the escalation receives the answer.)
+#
+# Topology in your existing city:
+#
+#   ┌──────────────────────────────────────────────────────────────────┐
+#   │ Your existing city                                               │
+#   │                                                                  │
+#   │  mayor (city, unchanged) ──── plans cross-cutting work           │
+#   │                                                                  │
+#   │  ┌── rig: foo ────────────┐  ┌── rig: bar ────────────┐  ...     │
+#   │  │ project-lead-foo (new) │  │ project-lead-bar (new) │          │
+#   │  │ • reads foo/.gc/       │  │ • reads bar/.gc/       │          │
+#   │  │   project-brief.md     │  │   project-brief.md     │          │
+#   │  │ • bounded to foo's     │  │ • bounded to bar's     │          │
+#   │  │   beads; dispatches    │  │   beads; dispatches    │          │
+#   │  │   its own ready work   │  │   its own ready work   │          │
+#   │  │ + your existing rig    │  │ + your existing rig    │          │
+#   │  │   agents (witness etc) │  │   agents               │          │
+#   │  └────────────────────────┘  └────────────────────────┘          │
+#   │                                                                  │
+#   │  ─── deterministic outbound ─────────────────────────────────    │
+#   │  project-lead writes rollup bead with severity:escalate          │
+#   │     ↓                                                            │
+#   │  escalate-rollups order (condition trigger, no agent)            │
+#   │     ↓                                                            │
+#   │  deliver-rollup.sh → POST /extmsg/outbound → mark delivered      │
+#   └──────────────────────────────────────────────────────────────────┘
+#
+# Requires an extmsg/slack adapter in the city for outbound delivery and
+# inbound replies — compose this pack with your slack pack (e.g. slack-full,
+# slack-channel, or slack-mini). This pack ships only the oversight role and
+# its escalation machinery, not a slack bridge.
+#
+# Optional: the project-lead's rig-scoped dispatch examples use convoy
+# formulas (mol-decompose, mol-pr-from-issue) supplied by a workflow/formula
+# pack (e.g. gastown). The oversight role works without them — it just won't
+# offer those particular dispatch shortcuts.
+#
+# To install in an existing city:
+#   1. Add the pack to city.toml (and stamp a project-lead per rig).
+#   2. For each rig you want under oversight, author its brief:
+#        cp agents/project-lead/project-brief.template.md \
+#           <rig-root>/.gc/project-brief.md
+#        # then edit the brief to fit the project
+#   3. Bind each rig's project-lead session to that rig's channel via your
+#      slack pack so escalations deliver and replies route back.
+#   4. gc supervisor reload — picks up the new agents and orders.
+
+[pack]
+name = "oversight-rig"
+schema = 2
+
+[[named_session]]
+template = "project-lead"
+scope = "rig"
+mode = "always"

--- a/registry.toml
+++ b/registry.toml
@@ -234,3 +234,16 @@ schema = 1
     commit = "5b7c5c1320ee6537f5b9c661d2e52712140320df"
     hash = "sha256:3757a3dee523efb29e7cf1f9927c70c9bf491eba6d8416e147430aa6130702cf"
     description = "YAML-safe skill front matter (0.2.0 had an unquoted colon that broke parsing) plus a durability pass — removes time-pinned references (PR-number citations, dated product names, build-timeout numbers, drift-prone counts) so the skills resist staleness. No behavior change."
+
+[[pack]]
+  name = "oversight-rig"
+  description = "Disaggregates project-level work scoping out of the mayor — adds one always-on, rig-scoped project-lead per rig that triages its rig and dispatches its own ready work directly, with deterministic severity-based escalation (no relay agent). Composes with any slack adapter pack; ships only the oversight role and its escalation machinery, not a slack bridge."
+  source = "https://github.com/gastownhall/gascity-packs/tree/main/oversight-rig"
+  source_kind = "git"
+
+  [[pack.release]]
+    version = "0.1.0"
+    ref = "main"
+    commit = "a1490ecf90238f3af52ab2e7f24e30b5b62cbfc2"
+    hash = "sha256:c06f30e61407994cef7e16aafecbc71afbbc9f8cdfd0d506146fdf95837333cf"
+    description = "Initial oversight-rig release: rig-scoped project-lead + deterministic escalation machinery."


### PR DESCRIPTION
## Summary

New registry pack: **oversight-rig**. Disaggregates project-level work scoping out of the mayor by adding one always-on, rig-scoped `project-lead` per rig.

- **`project-lead`** (rig scope, always-on): bounded to one rig's beads; reads persona/focus/escalation triggers from `<rig>/.gc/project-brief.md`; triages its rig and **dispatches its own ready, in-scope work directly** instead of routing every dispatch through the mayor; writes severity-labeled rollup beads.
- **Mayor stays unchanged**, shrinks to cross-cutting planning + escalations.
- **Deterministic escalation**: a condition-triggered order delivers `severity:escalate` rollups via extmsg — no second agent re-decides. Human replies route straight back to the bound project-lead.

Ships **only the oversight role + escalation machinery** — composes with any slack adapter pack (`slack-full`/`slack-channel`/`slack-mini`), no bundled bridge.

## Provenance & changes from the internal source

Ported from an internal example. In the port:
- **Removed the `chief-of-staff` role** (no longer used; replies now route directly to the bound project-lead).
- **Dropped the bundled slack adapter** — the pack composes with the city's existing slack pack rather than shipping a 4th bridge.
- **Dropped gascity-module-coupled Go tests** (they imported `internal/*` and only compiled inside the gascity repo).

## Review record

code-reviewer + security-reviewer (publication lens). Findings fixed before this PR:
- **Security (HIGH)**: removed the maintainer's real Slack workspace/DM IDs from `deliver-rollup.sh` (→ placeholders); removed a hardcoded person name from the shipped prompt (→ generic "human"); scrubbed fork-local rig names (`geo`/`codescalebench`) from the resolver docstring/help/tests.
- **Quality**: surfaced the previously-swallowed resolver stderr in the delivery skip-log; documented the optional `mol-decompose`/`mol-pr-from-issue` formula dependency; added a `README.md` for registry display.

## Verification
- `bash -n` on all shell scripts → ok
- `pytest assets/scripts/test_resolve_rig_channel.py` → 12 passed
- `validate_registry.py` → ok; `gc pack release verify` (content hash) → ok
- `registry.toml` → new `[[pack]]` oversight-rig + `0.1.0` release