### PR TITLE
feat(contributing): mol-contributing-* gc-orchestrated formula set

### DIFF
--- a/contributing/README.md
+++ b/contributing/README.md
@@ -42,6 +42,36 @@ Two entry points join the same loop:
 The [`contributing`](skills/contributing/SKILL.md) skill is the operational map;
 it explains both entry points and links each step to its skill.
 
+## Two ways to run it
+
+The same lifecycle, the same standards, two delivery modes:
+
+- **Skills (agent-read)** — your coding agent applies a step by *reading* the
+  skill text. This is the default for a contributor working with a coding agent:
+  no orchestration, no city required.
+- **Formulas (gc-orchestrated)** — thin `mol-contributing-*` wrappers let a city
+  *dispatch* a step to a polecat session as a gc formula. Each wrapper is
+  orchestration only: it resolves the run's root bead, records state, writes the
+  output artifact, and enforces blocking early-exits — then **delegates every
+  standard to its sibling skill**. The skill stays the single source of truth; the
+  formula never restates the audit, the gates, or the dimensions.
+
+| Formula | Applies skill | Models on (pr-pipeline) |
+|---------|---------------|-------------------------|
+| `mol-contributing-triage` | [`find-work`](skills/find-work/SKILL.md) | `mol-pr-triage` |
+| `mol-contributing-start` | [`plan-pr`](skills/plan-pr/SKILL.md) | `mol-pr-start` |
+| `mol-contributing-blast-radius` | [`blast-radius`](skills/blast-radius/SKILL.md) | `mol-pr-blast-radius` |
+| `mol-contributing-review` | [`check`](skills/check/SKILL.md) | `mol-pr-review` |
+| `mol-contributing-ship` | [`ship`](skills/ship/SKILL.md) | `mol-pr-ship` |
+
+There is no formula for `write-issue`: issue authoring sits upstream of the PR
+flow (you have nothing to orchestrate against yet), so use that skill directly.
+
+Formula outputs land under `.gc/contributing/` (work-queue, plan, blast-radius,
+review, and ship reports), and run state is recorded in the molecule's root-bead
+notes. Like the skills, the formulas stop before pushing — `mol-contributing-ship`
+ends at the readiness report and never runs `git push` or `gh pr create`.
+
 ## Nothing here pushes for you
 
 Each step produces an artifact you act on — an issue body, a plan, a blast-radius
@@ -66,7 +96,7 @@ this directory — they're self-contained Markdown.
 contributing/
 ├── pack.toml                       schema=2; no imports (self-contained)
 ├── README.md
-├── skills/
+├── skills/                         agent-read mode
 │   ├── contributing/SKILL.md       the lifecycle map (both entry points)
 │   ├── write-issue/SKILL.md        file a maintainer-grade issue
 │   ├── find-work/SKILL.md          triage open issues into a work-queue
@@ -74,13 +104,20 @@ contributing/
 │   ├── blast-radius/SKILL.md       map the impact surface of a change
 │   ├── check/SKILL.md              mechanical gates + the B1–B36 audit
 │   └── ship/SKILL.md               pre-push self-review gate
+├── formulas/                       gc-orchestrated mode (thin wrappers over the skills)
+│   ├── mol-contributing-triage.formula.toml        -> find-work
+│   ├── mol-contributing-start.formula.toml         -> plan-pr
+│   ├── mol-contributing-blast-radius.formula.toml  -> blast-radius
+│   ├── mol-contributing-review.formula.toml        -> check
+│   └── mol-contributing-ship.formula.toml          -> ship
 ├── doctor/                         preflight checks (gc, gh, git present)
 │   ├── check-gc.sh   + gc/doctor.toml
 │   ├── check-gh.sh   + gh/doctor.toml
 │   └── check-git.sh  + git/doctor.toml
 └── tests/
     ├── test_contributing_skill_frontmatter.py   skills have name + description
-    └── test_contributing_pack_structure.py      self-contained; doctor scripts executable
+    ├── test_contributing_pack_structure.py      self-contained; doctor scripts executable
+    └── test_contributing_formulas.py            formulas parse; each references a real skill
 ```
 
 ## Tests

--- a/contributing/formulas/mol-contributing-blast-radius.formula.toml
+++ b/contributing/formulas/mol-contributing-blast-radius.formula.toml
@@ -1,0 +1,98 @@
+description = """
+Blast-radius mapping — describe the full impact surface of a proposed
+gastownhall/gascity change without making any modifications. The
+gc-orchestrated mode of the `blast-radius` skill: produces the same
+impact-surface map a contributor's coding agent makes by reading the skill,
+run inside a polecat session so a city operator can dispatch it on a
+free-text scope. **No code is written.**
+
+THIN WRAPPER. This formula is orchestration only — it resolves the root
+bead, decomposes the scope, and records the output path. ALL analysis
+dimensions (callers and their execution contexts, downward callees, config
+sync chains, domain boundaries, concurrency, cross-repo contracts) live in
+the `blast-radius` skill, which is the single source of truth. The steps
+below say *apply the skill*; they do not restate it.
+
+The molecule root bead IS the control bead — run state is recorded in its
+notes via `bd update <root-id> --notes "<key>: <value>"`.
+
+## Contract
+
+1. Caller slings with `--var scope=<free-text>` (and optional `--var key=<id>`)
+2. Agent applies the `blast-radius` skill across two sequential steps
+3. Report written to `.gc/contributing/blast-radius/<key>.md`
+4. Root-bead notes record `report_path:`
+5. Agent exits — no implementation work happens here
+
+## Failure Modes
+
+| Situation | Action |
+|-----------|--------|
+| Repo is not a git checkout | Record cwd, close bead |
+| `scope` is empty or unparseable | Record error, close bead |
+| No callers found for any symbol | Note in report; not a failure |"""
+formula = "mol-contributing-blast-radius"
+version = 1
+
+[vars]
+[vars.scope]
+description = "Free-text scope description: symbols, files, or packages the change will touch (e.g. \\\"FuncXYZ in pkg/foo and the FieldBar struct field\\\")"
+required = true
+
+[vars.key]
+description = "Stable identifier used as the output filename (e.g. \\\"issue-1234\\\" or \\\"refactor-foo\\\"). Defaults to a slug derived from scope."
+default = ""
+
+[[steps]]
+id = "intake"
+title = "Resolve scope and the output path"
+description = """
+Confirm we are in a git repo and resolve the output key. Pure mechanism —
+the decomposition into analyzable targets is the skill's job; here we only
+establish where the report lands.
+
+```bash
+ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
+    echo "Not in a git repository — cannot map blast radius."
+    bd close "$ROOT_ID" --reason "not a git checkout"
+    exit 1
+}
+cd "$REPO_ROOT"
+KEY="{{key}}"
+if [ -z "$KEY" ]; then
+    KEY=$(echo "{{scope}}" | tr 'A-Z' 'a-z' | tr -cs 'a-z0-9' '-' | sed 's/^-//;s/-$//' | cut -c1-40)
+fi
+mkdir -p .gc/contributing/blast-radius
+REPORT_PATH=".gc/contributing/blast-radius/${KEY}.md"
+bd update "$ROOT_ID" --notes "scope: {{scope}}
+key: $KEY
+report_path: $REPORT_PATH
+status: in_progress"
+```
+
+**Exit criteria:** In repo root, scope recorded, report path determined.
+"""
+
+[[steps]]
+id = "map"
+title = "Apply the blast-radius skill and write the report"
+needs = ["intake"]
+description = """
+Apply the pack's own `blast-radius` skill — read
+`${GC_PACK_DIR}/skills/blast-radius/SKILL.md` and follow it end to end
+against `{{scope}}`. The skill is the single source of truth for every
+analysis dimension. Do not restate them here; run them from the skill, and
+write the skill's structured impact-surface report to `$REPORT_PATH`.
+
+After writing the report, finalize:
+
+```bash
+ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+bd update "$ROOT_ID" --notes "status: complete"
+echo "[contributing-blast-radius] Complete for: {{scope}}"
+echo "[contributing-blast-radius]   Path: $REPORT_PATH"
+```
+
+**Exit criteria:** Report written per the blast-radius skill, root-bead notes finalized.
+"""

--- a/contributing/formulas/mol-contributing-review.formula.toml
+++ b/contributing/formulas/mol-contributing-review.formula.toml
@@ -1,0 +1,135 @@
+description = """
+Pre-push codebase audit — verify a local gastownhall/gascity change against
+the project's actual quality bar before pushing. The gc-orchestrated mode of
+the `check` skill: produces the same audit a contributor's coding agent runs
+by reading the skill, inside a polecat session so a city operator can
+dispatch it on a branch.
+
+Scope note: unlike the maintainer-side review of an incoming GitHub PR, this
+audits *your own local branch's diff* against the upstream main you're
+targeting — the mechanical gates (`make build` / `make check` /
+`make check-docs`) plus the B1-B36 codebase audit. It is read-only.
+
+THIN WRAPPER. This formula is orchestration only. ALL audit standards — the
+mechanical gate set, the baseline-vs-regression classification, and the full
+B1-B36 checklist — live in the `check` skill, which is the single source of
+truth. The steps below say *apply the skill*; they do not restate it.
+
+The molecule root bead IS the control bead — run state is recorded in its
+notes via `bd update <root-id> --notes "<key>: <value>"`.
+
+## Contract
+
+1. Caller slings with optional `--var base=<ref>` (the baseline to diff
+   against; default: the upstream main the check skill resolves) and
+   `--var key=<id>` (output filename; default: the current branch name)
+2. Agent applies the `check` skill across three sequential steps
+3. Audit report written to `.gc/contributing/reviews/<key>.md`
+4. Root-bead notes record `verdict:` (block | request_changes | approve)
+5. Agent exits — no fixes are applied
+
+Apply fixes by re-iterating the development loop (or `mol-contributing-ship`),
+not by extending this formula.
+
+## Failure Modes
+
+| Situation | Action |
+|-----------|--------|
+| Repo is not a git checkout | Record cwd, close bead |
+| On the default branch (no diff) | Note in report; verdict approve |
+| Diff is too large to fully audit | Note coverage, finish what fits |"""
+formula = "mol-contributing-review"
+version = 1
+
+[vars]
+[vars.base]
+description = "Baseline ref to diff against (e.g. origin/main or upstream/main). Default empty — the check skill resolves the upstream main it's targeting."
+default = ""
+
+[vars.key]
+description = "Stable identifier used as the output filename (e.g. \\\"issue-1234\\\"). Defaults to the current branch name."
+default = ""
+
+[[steps]]
+id = "intake"
+title = "Resolve the diff baseline and output path"
+description = """
+Confirm we are in a git repo and resolve where the report lands. Pure
+mechanism — the audit is the skill's job.
+
+```bash
+ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
+    echo "Not in a git repository — cannot run the codebase check."
+    bd close "$ROOT_ID" --reason "not a git checkout"
+    exit 1
+}
+cd "$REPO_ROOT"
+BASE="{{base}}"
+KEY="{{key}}"
+if [ -z "$KEY" ]; then
+    KEY=$(git branch --show-current | tr '/' '_')
+    [ -z "$KEY" ] && KEY="HEAD"
+fi
+mkdir -p .gc/contributing/reviews
+REPORT_PATH=".gc/contributing/reviews/${KEY}.md"
+bd update "$ROOT_ID" --notes "base: ${BASE:-<skill-resolved upstream main>}
+key: $KEY
+report_path: $REPORT_PATH
+status: in_progress"
+```
+
+**Exit criteria:** In repo root, baseline + report path recorded.
+"""
+
+[[steps]]
+id = "check"
+title = "Apply the check skill and write the audit report"
+needs = ["intake"]
+description = """
+Apply the pack's own `check` skill — read
+`${GC_PACK_DIR}/skills/check/SKILL.md` and follow it end to end against this
+branch's diff (use `BASE` as the baseline if set; otherwise let the skill
+resolve the upstream main it targets). The skill is the single source of
+truth for Part A (mechanical gates + baseline-vs-regression classification)
+and Part B (the B1-B36 audit). Do not restate any rule here; run them from
+the skill, and write the skill's Part C report to `$REPORT_PATH`.
+
+Derive the verdict mechanically from the skill's findings — a real
+regression or an unwaived B-rule blocker is `block`/`request_changes`; an
+all-green or minors-only result is `approve`. Record it:
+
+```bash
+ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+VERDICT="<block | request_changes | approve>"
+bd update "$ROOT_ID" --notes "verdict: $VERDICT
+status: report_written"
+```
+
+**Exit criteria:** Report written per the check skill, verdict recorded in bead notes.
+"""
+
+[[steps]]
+id = "finalize"
+title = "Surface the verdict and exit"
+needs = ["check"]
+description = """
+Display the report path and verdict on stdout for the caller, then close the
+root bead. No fixes are applied here.
+
+```bash
+ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+NOTES=$(bd show "$ROOT_ID" --json | jq -r '.[0].notes // ""')
+REPORT_PATH=$(echo "$NOTES" | grep -m1 '^report_path:' | sed 's/^report_path: //')
+VERDICT=$(echo "$NOTES" | grep -m1 '^verdict:' | sed 's/^verdict: //')
+cat <<EOF
+[contributing-review] Codebase check complete
+[contributing-review]   Verdict: $VERDICT
+[contributing-review]   Path: $REPORT_PATH
+EOF
+bd update "$ROOT_ID" --notes "status: complete"
+bd close "$ROOT_ID" --reason "contributor codebase check written: $REPORT_PATH"
+```
+
+**Exit criteria:** Report path + verdict printed, root bead closed with status:complete.
+"""

--- a/contributing/formulas/mol-contributing-ship.formula.toml
+++ b/contributing/formulas/mol-contributing-ship.formula.toml
@@ -1,0 +1,142 @@
+description = """
+Pre-push ship gate for a gastownhall/gascity contributor PR. The
+gc-orchestrated mode of the `ship` skill: runs the skill's staged self-review
+pipeline (design-capture gate, simplify, self-review until clean, optional
+performance, then the full check) and produces one readiness report.
+**STOPS at the report.** Does NOT push, does NOT open a PR.
+
+THIN WRAPPER. This formula is orchestration only. ALL ship standards — the
+stage sequence, the recurring-finding patterns, the convergence rule, the
+performance gate, and the embedded check — live in the `ship` skill, which is
+the single source of truth. The steps below say *apply the skill*; they do
+not restate it. The one thing the formula enforces is the hard STOP: push
+and PR open are caller actions gated on human review of the report.
+
+The molecule root bead IS the control bead — run state is recorded in its
+notes via `bd update <root-id> --notes "<key>: <value>"`. The skill's
+simplify and self-review stages CAN modify files; every other stage is
+read-only.
+
+## Contract
+
+1. Caller slings with `--var branch=<name>` (or omits to use current branch)
+2. Agent applies the `ship` skill across three sequential steps
+3. Readiness report written to `.gc/contributing/ship/<branch>.md`
+4. Root-bead notes record `readiness:` (ready | blocked) + `blockers:`
+5. Agent exits — no push, no PR open
+
+## Failure Modes
+
+| Situation | Action |
+|-----------|--------|
+| ship skill reports the review won't converge | readiness: blocked, list remaining findings |
+| ship skill's check fails a mechanical gate | readiness: blocked, list which gate |
+| On the default branch | Refuse — create a feature branch first |"""
+formula = "mol-contributing-ship"
+version = 1
+
+[vars]
+[vars.branch]
+description = "Branch to gate (defaults to current branch)"
+default = ""
+
+[vars.skip_simplify]
+description = "Set to 'true' to skip the ship skill's Stage 1 simplify pass"
+default = "false"
+
+[[steps]]
+id = "intake"
+title = "Resolve the branch and report path"
+description = """
+Confirm we are in a git repo, resolve the branch, refuse the default branch,
+and prepare the report path. Pure mechanism — the staged review is the
+skill's job.
+
+```bash
+ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
+    echo "Not in a git repository — cannot ship."
+    bd close "$ROOT_ID" --reason "not a git checkout"
+    exit 1
+}
+cd "$REPO_ROOT"
+BRANCH="{{branch}}"
+[ -z "$BRANCH" ] && BRANCH=$(git branch --show-current)
+if [ -z "$BRANCH" ] || [ "$BRANCH" = "HEAD" ]; then
+    bd close "$ROOT_ID" --reason "no branch resolved"
+    exit 1
+fi
+DEFAULT=$(git remote show origin 2>/dev/null | sed -n 's/.*HEAD branch: //p' || echo "main")
+if [ "$BRANCH" = "$DEFAULT" ] || [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then
+    echo "Cannot ship from default branch ($BRANCH). Create a feature branch first."
+    bd close "$ROOT_ID" --reason "on default branch"
+    exit 1
+fi
+mkdir -p .gc/contributing/ship
+SAFE=$(echo "$BRANCH" | tr '/' '_')
+REPORT_PATH=".gc/contributing/ship/${SAFE}.md"
+bd update "$ROOT_ID" --notes "branch: $BRANCH
+report_path: $REPORT_PATH
+status: in_progress"
+```
+
+**Exit criteria:** Branch resolved, report path set, not on default branch.
+"""
+
+[[steps]]
+id = "ship"
+title = "Apply the ship skill and write the readiness report"
+needs = ["intake"]
+description = """
+Apply the pack's own `ship` skill — read
+`${GC_PACK_DIR}/skills/ship/SKILL.md` and follow it end to end against
+`$BRANCH`. The skill is the single source of truth for every stage:
+Stage 0 design-capture gate, Stage 1 simplify (skip it if
+`{{skip_simplify}}` is `true`), Stage 2 self-review iterated to convergence,
+Stage 2.5 performance (perf-touching changes only), and Stage 3 the embedded
+`check`. Do not restate any of that here; run it from the skill, and write
+the skill's Stage 4 readiness report to `$REPORT_PATH`.
+
+Record the readiness verdict the skill produces:
+
+```bash
+ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+READINESS="<ready | blocked>"
+BLOCKERS="<one-line summary of what blocks, or 'none'>"
+bd update "$ROOT_ID" --notes "readiness: $READINESS
+blockers: $BLOCKERS
+status: report_written"
+```
+
+**Exit criteria:** Readiness report written per the ship skill, verdict recorded.
+"""
+
+[[steps]]
+id = "stop"
+title = "Surface readiness and STOP"
+needs = ["ship"]
+description = """
+Display the report path and readiness verdict, then close the bead. The
+caller decides whether to push based on the report.
+
+```bash
+ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+NOTES=$(bd show "$ROOT_ID" --json | jq -r '.[0].notes // ""')
+REPORT_PATH=$(echo "$NOTES" | grep -m1 '^report_path:' | sed 's/^report_path: //')
+READINESS=$(echo "$NOTES" | grep -m1 '^readiness:' | sed 's/^readiness: //')
+cat <<EOF
+[contributing-ship] Ship pipeline complete for branch $BRANCH
+[contributing-ship]   Readiness: $READINESS
+[contributing-ship]   Path: $REPORT_PATH
+[contributing-ship] STOP — push and PR open are the caller's call, not this formula's.
+EOF
+bd update "$ROOT_ID" --notes "status: complete"
+bd close "$ROOT_ID" --reason "contributor ship report written: $REPORT_PATH"
+```
+
+**Critical:** This formula MUST NOT run `git push` or `gh pr create` under
+any circumstances — exactly as the ship skill's Stage 5 requires. Push and
+PR open are explicit caller actions gated on human review of this report.
+
+**Exit criteria:** Report written, readiness recorded, formula stops without pushing.
+"""

--- a/contributing/formulas/mol-contributing-start.formula.toml
+++ b/contributing/formulas/mol-contributing-start.formula.toml
@@ -1,0 +1,134 @@
+description = """
+Contributor PR-start workflow — front-load the analysis a maintainer's
+adoption review will check, before any code is written. The gc-orchestrated
+mode of the `plan-pr` skill: produces the same structured plan a
+contributor's coding agent makes by reading the skill, run inside a polecat
+session so a city operator can dispatch it on an issue.
+
+THIN WRAPPER. This formula is orchestration only. ALL planning standards —
+the competing-PR and architectural-refactor gates, the blast-radius
+dimensions, the convention triggers, the test-tier strategy, the
+design-capture discipline, the B-rule checklist — live in the `plan-pr`
+skill, which is the single source of truth. The steps below say *apply the
+skill*; they do not restate it. The one thing the formula owns is the
+BLOCKING early-exit: when a gate the skill defines fires, the orchestration
+records the reason and closes the bead instead of producing a plan.
+
+The molecule root bead IS the control bead — run state is recorded in its
+notes via `bd update <root-id> --notes "<key>: <value>"`.
+
+## Contract
+
+1. Caller slings with `--var issue=<number>`
+2. Agent applies the `plan-pr` skill across three sequential steps; the
+   BLOCKING gates step can early-exit
+3. Plan written to `.gc/contributing/plans/issue-<N>.md`
+4. Root-bead notes record `plan_path:` (or the block reason)
+5. Agent exits — no implementation work happens here
+
+## Failure Modes
+
+| Situation | Action |
+|-----------|--------|
+| A plan-pr gate fires (competing PR / active refactor) | Record reason in root-bead notes, close bead, exit |
+| Issue does not exist | gh fails; record error, close bead |
+| Repo is not a git checkout | Record cwd, close bead |"""
+formula = "mol-contributing-start"
+version = 1
+
+[vars]
+[vars.issue]
+description = "gastownhall/gascity issue number to plan a PR for"
+required = true
+
+[[steps]]
+id = "intake"
+title = "Read the issue and record initial state"
+description = """
+Resolve the root bead, confirm we are in a git repo, read the issue, and
+record initial state. Pure mechanism — the planning judgment is the skill's.
+
+```bash
+ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
+    echo "Not in a git repository — cannot plan."
+    bd close "$ROOT_ID" --reason "not a git checkout"
+    exit 1
+}
+cd "$REPO_ROOT"
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+gh issue view {{issue}} --repo "$REPO" --json title,body,labels,comments,state
+bd update "$ROOT_ID" --notes "issue: {{issue}}
+repo: $REPO
+repo_root: $REPO_ROOT
+status: in_progress"
+```
+
+**Exit criteria:** In repo root, issue read, root-bead notes initialized.
+"""
+
+[[steps]]
+id = "gates"
+title = "Run the BLOCKING gates the plan-pr skill defines"
+needs = ["intake"]
+description = """
+The `plan-pr` skill defines two gates that should stop the work before any
+plan is written — a competing open/merged PR for the issue, and an active
+architectural refactor consolidating the issue's area. Apply those gates as
+the skill specifies them (read
+`${GC_PACK_DIR}/skills/plan-pr/SKILL.md` — do not restate the criteria
+here). Use the skill's own `gh`/`git` checks to decide whether either fires.
+
+The formula owns only the early-exit mechanic. If a gate fires, record the
+reason and close the bead — do not proceed to planning:
+
+```bash
+ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+bd update "$ROOT_ID" --notes "status: blocked
+gate: <competing_pr | architectural_refactor>
+detail: <one-line: which PR / which refactor and why>"
+echo "[contributing-start] BLOCKED — <gate>: <detail>"
+bd close "$ROOT_ID" --reason "<gate> for issue #{{issue}}"
+exit 0
+```
+
+If neither gate fires, record clearance and proceed:
+
+```bash
+bd update "$ROOT_ID" --notes "gates: cleared"
+```
+
+**Exit criteria:** Both gates cleared (or the formula exited via a gate). Root-bead notes record gates: cleared.
+"""
+
+[[steps]]
+id = "plan"
+title = "Apply the plan-pr skill and write the structured plan"
+needs = ["gates"]
+description = """
+Apply the pack's own `plan-pr` skill — read
+`${GC_PACK_DIR}/skills/plan-pr/SKILL.md` and follow it end to end against
+issue #{{issue}}. The skill is the single source of truth for the
+blast-radius mapping, the repo conventions, the test-tier strategy, the
+design-capture discipline (Phase 3.5), and the B-rule convention-trigger
+checklist. Do not restate any of that here; run it from the skill.
+
+Write the skill's structured plan output to the plan path:
+
+```bash
+ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+mkdir -p .gc/contributing/plans
+PLAN_PATH=".gc/contributing/plans/issue-{{issue}}.md"
+# (write the plan-pr skill's plan into $PLAN_PATH)
+bd update "$ROOT_ID" --notes "plan_path: $PLAN_PATH
+plan_status: finalized
+status: complete"
+cat <<EOF
+[contributing-start] Plan finalized for issue #{{issue}}
+[contributing-start]   Path: $PLAN_PATH
+[contributing-start] Next: hand off to an implementing agent or human. No code was written here.
+EOF
+```
+
+**Exit criteria:** Plan file written per the plan-pr skill, root-bead notes updated, agent exits.
+"""

--- a/contributing/formulas/mol-contributing-triage.formula.toml
+++ b/contributing/formulas/mol-contributing-triage.formula.toml
@@ -1,0 +1,165 @@
+description = """
+Contributor triage workflow — scan open issues on gastownhall/gascity,
+classify them into the contributor-actionability tiers, and produce a
+ranked work-queue report. The gc-orchestrated mode of the `find-work`
+skill: same output a contributor's coding agent produces by reading the
+skill, but run inside a polecat session so a city operator can dispatch it
+on demand.
+
+THIN WRAPPER. This formula is orchestration only — it resolves the root
+bead, verifies the repo, and records run state. ALL triage standards (the
+tier definitions, competing-PR detection, the maintainer-decision gates)
+live in the `find-work` skill, which is the single source of truth. The
+steps below say *apply the skill*; they do not restate it.
+
+The molecule root bead IS the control bead — run state is recorded in its
+notes via `bd update <root-id> --notes "<key>: <value>"`.
+
+## Contract
+
+1. Caller slings with optional `--var limit=<N>` (default 10) and
+   `--var category=<filter>` (default "all")
+2. Agent applies the `find-work` skill across three sequential steps
+3. Work-queue report written to `.gc/contributing/find-work/<timestamp>.md`
+4. Root-bead notes record `report_path:` + tier counts + recommended pick
+5. Agent exits — no implementation, labeling, or PR creation happens here
+
+## Failure Modes
+
+| Situation | Action |
+|-----------|--------|
+| Repo is not a git checkout | Record cwd, close bead |
+| Repo is not gastownhall/gascity | Record error, close bead |
+| `gh` not authenticated | Record error, close bead |
+| No open issues match category | Write empty-queue report, close bead with note |"""
+formula = "mol-contributing-triage"
+version = 1
+
+[vars]
+[vars.limit]
+description = "Maximum number of candidate issues to evaluate per tier (default 10)"
+required = false
+
+[vars.category]
+description = "Issue category filter — 'p0', 'p1', 'p2', 'good-first-issue', 'all', or any kind/priority label name (default 'all')"
+required = false
+
+[[steps]]
+id = "setup"
+title = "Establish working state and verify the repo"
+description = """
+Resolve the root bead, confirm we are in a gastownhall/gascity checkout,
+verify gh auth, and record the run vars + output path. This is pure
+mechanism — no triage judgment happens here.
+
+```bash
+ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
+    echo "Not in a git repository — cannot triage."
+    bd close "$ROOT_ID" --reason "not a git checkout"
+    exit 1
+}
+cd "$REPO_ROOT"
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+if [ "$REPO" != "gastownhall/gascity" ]; then
+    bd update "$ROOT_ID" --notes "status: blocked
+gate: wrong_repo
+detail: $REPO"
+    bd close "$ROOT_ID" --reason "wrong repo for contributor triage"
+    exit 0
+fi
+gh auth status >/dev/null 2>&1 || {
+    bd update "$ROOT_ID" --notes "status: blocked
+gate: gh_not_authed"
+    bd close "$ROOT_ID" --reason "gh not authenticated"
+    exit 1
+}
+```
+
+Resolve vars and the report path. The report is written to a city-scope
+path (via `$GC_CITY_PATH`) when available, so the caller can read it after
+the transient polecat worktree is cleaned up; otherwise fall back to the
+polecat-local relative path.
+
+```bash
+LIMIT="{{limit}}"
+[ -z "$LIMIT" ] && LIMIT=10
+CATEGORY="{{category}}"
+[ -z "$CATEGORY" ] && CATEGORY="all"
+TS=$(date +%Y%m%d-%H%M%S)
+if [ -n "${GC_CITY_PATH:-}" ]; then
+    REPORT_DIR="${GC_CITY_PATH}/.gc/contributing/find-work"
+else
+    REPORT_DIR=".gc/contributing/find-work"
+fi
+mkdir -p "$REPORT_DIR"
+REPORT_PATH="$REPORT_DIR/$TS.md"
+bd update "$ROOT_ID" --notes "category: $CATEGORY
+limit: $LIMIT
+repo: $REPO
+report_path: $REPORT_PATH
+status: in_progress"
+```
+
+**Exit criteria:** In gastownhall/gascity repo root, gh auth ok, vars + report path recorded.
+"""
+
+[[steps]]
+id = "find-work"
+title = "Apply the find-work skill and write the work-queue report"
+needs = ["setup"]
+description = """
+Apply the pack's own `find-work` skill — read
+`${GC_PACK_DIR}/skills/find-work/SKILL.md` and follow it end to end. The
+skill is the single source of truth for the tier classification, the
+competing-PR detection, and the maintainer-decision gates. Do not restate
+those rules here; run them from the skill.
+
+Scope the run to this formula's vars: evaluate at most `LIMIT` candidates
+per tier, and filter the open-issue scan to `CATEGORY` (the skill's plain
+`gh` queries take a label/priority filter). Write the skill's ranked
+work-queue output to `$REPORT_PATH`.
+
+After writing the report, record the tier counts and the single
+recommended next pick in the root-bead notes so the caller can act without
+re-reading the file:
+
+```bash
+ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+bd update "$ROOT_ID" --notes "tier1: <n>
+tier2: <n>
+tier3: <n>
+tier4: <n>
+recommended: <issue number or none>
+status: report_written"
+```
+
+**Exit criteria:** Report written per the find-work skill; bead notes record tier counts + recommended pick.
+"""
+
+[[steps]]
+id = "finalize"
+title = "Surface the report path and exit"
+needs = ["find-work"]
+description = """
+Display the report path and recommended pick on stdout for the caller, then
+close the root bead. No further work happens — the caller reviews the
+report and decides which issue to dispatch via `mol-contributing-start`.
+
+```bash
+ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+NOTES=$(bd show "$ROOT_ID" --json | jq -r '.[0].notes // ""')
+REPORT_PATH=$(echo "$NOTES" | grep -m1 '^report_path:' | sed 's/^report_path: //')
+RECOMMENDED=$(echo "$NOTES" | grep -m1 '^recommended:' | sed 's/^recommended: //')
+cat <<EOF
+[contributing-triage] Work-queue report ready
+[contributing-triage]   Path: $REPORT_PATH
+[contributing-triage]   Recommended next pick: #$RECOMMENDED
+[contributing-triage] Next: review the report, then dispatch mol-contributing-start --var issue=<N>.
+EOF
+bd update "$ROOT_ID" --notes "status: complete"
+bd close "$ROOT_ID" --reason "contributor triage report written: $REPORT_PATH"
+```
+
+**Exit criteria:** Report path printed, root bead closed with status:complete.
+"""

--- a/contributing/pack.toml
+++ b/contributing/pack.toml
@@ -24,15 +24,34 @@
 # discipline without gas-city's particular standards; this pack bakes those
 # standards in.
 #
+# TWO MODES, ONE SET OF STANDARDS:
+#   - skills/   — agent-read: your coding agent applies the standards by
+#                 READING the skill text. The default for a contributor with a
+#                 coding agent. (write-issue, find-work, plan-pr, blast-radius,
+#                 check, ship)
+#   - formulas/ — gc-orchestrated: thin `mol-contributing-*` wrappers that drive
+#                 the same lifecycle as gc formulas, for a city that wants to
+#                 dispatch the steps to a polecat session. Each wrapper DELEGATES
+#                 all standards to its sibling skill — the skill stays the single
+#                 source of truth; the formula adds only the gc orchestration
+#                 (root-bead run state, output paths, blocking early-exit).
+#       mol-contributing-triage       -> find-work skill
+#       mol-contributing-start        -> plan-pr skill
+#       mol-contributing-blast-radius -> blast-radius skill
+#       mol-contributing-review       -> check skill
+#       mol-contributing-ship         -> ship skill
+#     (write-issue has no formula peer — issue authoring sits upstream of the
+#     PR flow; use the skill directly.)
+#
 # Usage in your city's pack.toml:
 #   [imports.contributing]
 #   source = "../packs/contributing"   # path; or git URL when published
 #
-# The skills then load for your coding agent. Nothing here pushes a branch or
-# opens a PR — each step produces an artifact (an issue, a plan, a report) you
-# act on. Pushing is always your call.
+# The skills then load for your coding agent; the formulas register as gc
+# methods. Nothing here pushes a branch or opens a PR — each step produces an
+# artifact (an issue, a plan, a report) you act on. Pushing is always your call.
 
 [pack]
 name = "contributing"
-version = "0.2.1"
+version = "0.3.0"
 schema = 2

--- a/contributing/tests/test_contributing_formulas.py
+++ b/contributing/tests/test_contributing_formulas.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import pathlib
+import tomllib
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+FORMULAS = ROOT / "formulas"
+SKILLS = ROOT / "skills"
+
+# Each thin wrapper formula delegates ALL standards to exactly one sibling
+# skill, which stays the single source of truth. The formula adds only gc
+# orchestration. write-issue is intentionally absent: issue authoring sits
+# upstream of the PR flow, so it has no formula peer (use the skill directly).
+FORMULA_TO_SKILL = {
+    "mol-contributing-triage": "find-work",
+    "mol-contributing-start": "plan-pr",
+    "mol-contributing-blast-radius": "blast-radius",
+    "mol-contributing-review": "check",
+    "mol-contributing-ship": "ship",
+}
+
+
+def _formula_files() -> list[pathlib.Path]:
+    return sorted(FORMULAS.glob("*.formula.toml"))
+
+
+class FormulaSetTests(unittest.TestCase):
+    """The pack ships exactly the five thin wrappers — no more, no fewer."""
+
+    def test_formulas_directory_exists(self) -> None:
+        self.assertTrue(FORMULAS.is_dir(), "contributing/formulas/ must exist")
+
+    def test_exactly_the_expected_formulas_are_present(self) -> None:
+        names = {p.name[: -len(".formula.toml")] for p in _formula_files()}
+        self.assertEqual(
+            names,
+            set(FORMULA_TO_SKILL),
+            "formulas/ must contain exactly the five mol-contributing-* wrappers",
+        )
+
+    def test_write_issue_has_no_formula_peer(self) -> None:
+        # Out of scope by design — guard against a future drive-by addition.
+        self.assertFalse(
+            (FORMULAS / "mol-contributing-write-issue.formula.toml").exists(),
+            "write-issue authoring is upstream of the PR flow; it must have no formula",
+        )
+
+
+class FormulaWellFormednessTests(unittest.TestCase):
+    """Every formula parses and has the plain step-formula shape its peers use."""
+
+    def test_each_formula_parses_and_is_well_formed(self) -> None:
+        for path in _formula_files():
+            with self.subTest(formula=path.name):
+                data = tomllib.loads(path.read_text(encoding="utf-8"))
+                stem = path.name[: -len(".formula.toml")]
+                self.assertEqual(
+                    data.get("formula"),
+                    stem,
+                    "formula name must match the filename",
+                )
+                self.assertIn(stem, FORMULA_TO_SKILL, "unexpected formula")
+                self.assertEqual(data.get("version"), 1)
+                self.assertTrue(data.get("description"), "formula needs a description")
+                steps = data.get("steps", [])
+                self.assertTrue(steps, "formula must declare at least one step")
+
+    def test_step_needs_reference_real_step_ids(self) -> None:
+        for path in _formula_files():
+            with self.subTest(formula=path.name):
+                data = tomllib.loads(path.read_text(encoding="utf-8"))
+                ids = {step["id"] for step in data["steps"]}
+                for step in data["steps"]:
+                    for need in step.get("needs", []):
+                        self.assertIn(
+                            need,
+                            ids,
+                            f"{path.name}: step {step['id']!r} needs unknown step {need!r}",
+                        )
+
+
+class FormulaSkillDelegationTests(unittest.TestCase):
+    """The whole point: each wrapper references a REAL sibling skill, and the
+    skill — not the formula — carries the standards."""
+
+    def test_each_formula_references_its_real_sibling_skill(self) -> None:
+        for stem, skill in FORMULA_TO_SKILL.items():
+            with self.subTest(formula=stem):
+                self.assertTrue(
+                    (SKILLS / skill / "SKILL.md").exists(),
+                    f"{stem} delegates to skills/{skill}, which must exist",
+                )
+                text = (FORMULAS / f"{stem}.formula.toml").read_text(encoding="utf-8")
+                self.assertIn(
+                    f"${{GC_PACK_DIR}}/skills/{skill}/SKILL.md",
+                    text,
+                    f"{stem} must reference its skill pack-relative via GC_PACK_DIR",
+                )
+
+
+class FormulaSelfContainmentTests(unittest.TestCase):
+    """Formulas keep the pack standalone: no sibling-pack imports, no author
+    host paths. Mirrors the pr-pipeline config-purity guard."""
+
+    def test_no_sibling_pack_imports(self) -> None:
+        for path in _formula_files():
+            with self.subTest(formula=path.name):
+                text = path.read_text(encoding="utf-8")
+                self.assertNotIn("[imports.", text)
+                self.assertNotIn(
+                    "pr-pipeline",
+                    text,
+                    "formulas must reference the pack's own skills, not pr-pipeline",
+                )
+
+    def test_no_author_absolute_paths(self) -> None:
+        for path in _formula_files():
+            with self.subTest(formula=path.name):
+                self.assertNotIn("/home/", path.read_text(encoding="utf-8"))
+
+
+class ShipStopGuardTests(unittest.TestCase):
+    """mol-contributing-ship must carry the explicit STOP guard — its load-bearing
+    safety contract is that it ends at the readiness report and never pushes."""
+
+    def test_ship_formula_declares_the_stop_guard(self) -> None:
+        text = (FORMULAS / "mol-contributing-ship.formula.toml").read_text(encoding="utf-8")
+        self.assertIn(
+            "MUST NOT run `git push` or `gh pr create`",
+            text,
+            "the ship wrapper must state the no-push / no-PR guard verbatim",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add a `contributing/formulas/` directory with five **thin** wrapper formulas so a
gas-city operator can drive the contributor lifecycle as gc-orchestrated methods,
not just agent-read skills — fulfilling an external contributor's request for gc
orchestration over the contributing pack.

### What's new
Five `mol-contributing-*` formulas, each modeled on its pr-pipeline peer but kept
thin — orchestration only (root-bead run state, `.gc/contributing/` output paths,
blocking early-exit gates), delegating **every** standard to the sibling skill
that is the single source of truth:

| formula                          | applies skill              | modeled on          |
|----------------------------------|----------------------------|---------------------|
| `mol-contributing-triage`        | `contributing/find-work`   | `mol-pr-triage`     |
| `mol-contributing-start`         | `contributing/plan-pr`     | `mol-pr-start`      |
| `mol-contributing-blast-radius`  | `contributing/blast-radius`| `mol-pr-blast-radius`|
| `mol-contributing-review`        | `contributing/check`       | `mol-pr-review`     |
| `mol-contributing-ship`          | `contributing/ship`        | `mol-pr-ship`       |

`write-issue` has no formula peer — issue authoring sits upstream of the PR flow
(noted in the README).

### Design constraints honored
- **Thin** — 674 formula lines vs the pr-pipeline peers' 1798; no restated B1–B36
  audit / blast-radius dimensions / scorecard text. The skill stays SSOT.
- **Self-contained** — formulas reference the pack's own skills via
  `${GC_PACK_DIR}/skills/<skill>/SKILL.md`. No `[imports.pr-pipeline]`; pack.toml
  stays import-free so external contributors still get a standalone pack.
- **Reuses pr-pipeline mechanics** — `--var` sling contract, sequential steps,
  blocking gates where the peer has them, root-bead-notes run state, ship stops
  at readiness and never pushes.

### Also
- `pack.toml`: version `0.2.1` → `0.3.0`; header documents the two modes.
- `README.md`: "Two ways to run it" section (skills for agent-read / formulas for
  gc-orchestrated) + formula map + updated contents tree.
- `tests/test_contributing_formulas.py`: each formula parses, references a real
  sibling skill, stays import-free, and the ship STOP guard is asserted present.

The `registry.toml` 0.3.0 stamp is a follow-up chore after merge (it pins the
merged main commit + content hash, like the pr-pipeline #122 and oversight-rig
release commits).
