### PR TITLE
fix(gastown): change polecat→refinery nudge to actionable message for running session

### DIFF
--- a/gastown/agents/polecat/prompt.template.md
+++ b/gastown/agents/polecat/prompt.template.md
@@ -286,7 +286,7 @@ gc bd update <work-bead> \
 REFINERY_TARGET="${GC_RIG:+$GC_RIG/}{{ .BindingPrefix }}refinery"
 gc bd update <work-bead> --status=open --assignee="$REFINERY_TARGET" --set-metadata gc.routed_to=""
 gc session wake "$REFINERY_TARGET" || true
-gc session nudge "$REFINERY_TARGET" "Run 'gc prime' to check merge queue and begin processing." || true
+gc session nudge "$REFINERY_TARGET" "New bead submitted to merge queue — scan for assigned work and process it now." || true
 gc runtime drain-ack
 exit
 ```

--- a/gastown/formulas/mol-polecat-work.toml
+++ b/gastown/formulas/mol-polecat-work.toml
@@ -441,7 +441,7 @@ picks it up and resumes from the existing branch.
 ```bash
 REFINERY_TARGET="${GC_RIG:+$GC_RIG/}{{binding_prefix}}refinery"
 gc session wake "$REFINERY_TARGET" || true
-gc session nudge "$REFINERY_TARGET" "Run 'gc prime' to check merge queue and begin processing." || true
+gc session nudge "$REFINERY_TARGET" "New bead submitted to merge queue — scan for assigned work and process it now." || true
 ```
 
 The `gc bd update` in step 6 generates a `bead.updated` event the refinery's


### PR DESCRIPTION
## Problem

When a polecat finishes work (step 7 of `mol-polecat-work`), it sends two signals to the refinery:

```bash
gc session wake "$REFINERY_TARGET" || true   # restarts a stopped session
gc session nudge "$REFINERY_TARGET" "..."    # prompts an already-running session
```

These serve different purposes. `wake` is for cold starts; `nudge` is for a session that is already live and waiting for input. The old nudge message was:

> `"Run 'gc prime' to check merge queue and begin processing."`

This is the right instruction for a **new session** (the `agent.toml` cold-start nudge, unchanged). For a **running** refinery that has already primed itself, it's misdirection — the refinery interprets it as "re-orient yourself," finds nothing to do differently, and responds "Standing by." Work submitted to the queue waits for the next poll cycle instead of being picked up immediately.

## Fix

Change the `gc session nudge` message in both the formula and the polecat prompt to something actionable for a live session:

> `"New bead submitted to merge queue — scan for assigned work and process it now."`

This tells the running refinery exactly what happened and what to do next.

The `agent.toml` `nudge` field (controller cold-start path, where `gc prime` is correct) is intentionally unchanged.

## Verification

```
git grep -n "check merge queue and begin processing"
```

One remaining hit: `gastown/agents/refinery/agent.toml:4` — the cold-start nudge, intentionally preserved.