### PR TITLE
fix(slack-full): escalating inbound-scan window ladder + truncation warning (gpk-hdnr)

### DIFF
--- a/slack-full/scripts/slack_intake_common.py
+++ b/slack-full/scripts/slack_intake_common.py
@@ -352,27 +352,51 @@ def current_session_id() -> str:
 
 # --- inbound-event lookup -------------------------------------------------
 
+# Windows tried in order when scanning for a session's latest inbound.
+# The events endpoint returns oldest-first with no descending order, and
+# `limit` keeps the OLDEST slice of the window — so a wide window on a
+# busy city truncates away exactly the newest events we want. Starting
+# narrow makes each scan a newest-slice view: the common case (reply
+# soon after an inbound) resolves in the first cheap query, and the
+# wider fallbacks cover sessions whose latest inbound predates the
+# narrow window (e.g. an agent idle overnight) without paying the
+# truncation risk up front.
+_INBOUND_SCAN_WINDOWS = ("10m", "2h", "48h")
+
+
 def find_latest_inbound_for_session(session_id: str) -> dict[str, Any] | None:
     """Find the most recent extmsg.inbound event targeting session_id.
 
-    Queries the gc events stream (HTTP, not SSE — single shot snapshot).
-    Returns the parsed event dict, or None if no match found.
+    Queries the gc events stream (HTTP, not SSE — single shot snapshot)
+    over escalating `since` windows (see _INBOUND_SCAN_WINDOWS).
+    Returns the parsed event dict, or None if no window matched.
 
-    Uses `since=2h` to bound the query window: the endpoint returns
-    events oldest-first by default, so on busy cities (event log >700k
-    seqs) `limit=50` would return only ancient history and a recent
-    extmsg.inbound at the tail would never appear in the response.
-    The time bound is the primary filter; limit=500 is a defensive cap.
-    Without this, `gc slack reply-current --thread-current` bails with
-    'no inbound event...' and the agent falls back to a non-threaded
-    publish-to-channel.
+    Without the time bound, `gc slack reply-current --thread-current`
+    bails with 'no inbound event...' on busy cities (oldest-first +
+    limit returns only ancient history) and the agent falls back to a
+    non-threaded publish-to-channel. limit=500 is a defensive cap; when
+    the server reports more matching events than it returned
+    (total > items), the scan was incomplete and a warning is emitted
+    so truncation is never silent.
     """
-    url = f"{gc_api_base()}/v0/city/{gc_city_name()}/events?type=extmsg.inbound&since=2h&limit=500"
-    raw = _request("GET", url, csrf=False).get("items", [])
-    matches = [e for e in raw if (e.get("payload") or {}).get("target_session") == session_id]
-    if not matches:
-        return None
-    return matches[-1]  # events are in chronological order
+    for window in _INBOUND_SCAN_WINDOWS:
+        url = (
+            f"{gc_api_base()}/v0/city/{gc_city_name()}/events"
+            f"?type=extmsg.inbound&since={window}&limit=500"
+        )
+        res = _request("GET", url, csrf=False)
+        raw = res.get("items", [])
+        total = res.get("total", len(raw))
+        if total > len(raw):
+            print(
+                f"warning: inbound event scan ({window} window) truncated to "
+                f"{len(raw)}/{total} oldest events; the latest inbound may be missed",
+                file=sys.stderr,
+            )
+        matches = [e for e in raw if (e.get("payload") or {}).get("target_session") == session_id]
+        if matches:
+            return matches[-1]  # events are in chronological order
+    return None
 
 
 def find_latest_inbound_message_id_for_session(

--- a/slack-full/tests/gc_mock.py
+++ b/slack-full/tests/gc_mock.py
@@ -29,6 +29,29 @@ from dataclasses import dataclass, field
 from typing import Any
 
 
+_GO_DURATION_UNIT_SECONDS = {"s": 1.0, "m": 60.0, "h": 3600.0}
+
+
+def _parse_go_duration_seconds(value: str) -> float | None:
+    """Parse the single-unit Go duration forms the pack emits (10m, 2h, 30s).
+
+    Returns seconds, or None for empty/unparseable input (the real
+    endpoint 400s on garbage; the mock treats it as 'no since filter'
+    since the pack only ever sends well-formed values).
+    """
+    value = value.strip()
+    if not value:
+        return None
+    unit = value[-1]
+    if unit not in _GO_DURATION_UNIT_SECONDS:
+        return None
+    try:
+        magnitude = float(value[:-1])
+    except ValueError:
+        return None
+    return magnitude * _GO_DURATION_UNIT_SECONDS[unit]
+
+
 @dataclass
 class GcCall:
     """A single gc API call captured at the mock."""
@@ -140,11 +163,16 @@ class GcMock:
         provider: str = "slack",
         kind: str = "dm",
         message_id: str = "",
+        age_seconds: float = 0.0,
     ) -> None:
         """Seed an extmsg.inbound event so reply-current's lookup path resolves.
 
         Mirrors the payload shape produced by gc when a real Slack event_callback
         arrives at the slack-pack adapter and gets forwarded to /extmsg/inbound.
+
+        ``age_seconds`` backdates the event so tests can exercise the
+        client's escalating ``since`` windows; it is mock-internal and
+        never serialized into the response.
         """
         event = {
             "type": "extmsg.inbound",
@@ -155,6 +183,7 @@ class GcMock:
                 "kind": kind,
                 "message_id": message_id,
             },
+            "_age_seconds": age_seconds,
         }
         with self._lock:
             self._inbound_events.append(event)
@@ -294,20 +323,31 @@ class GcMock:
         req: http.server.BaseHTTPRequestHandler,
         query: dict[str, str],
     ) -> None:
-        """GET /events — scoped event-stream snapshot. Used for inbound-event lookup."""
+        """GET /events — scoped event-stream snapshot. Used for inbound-event lookup.
+
+        Mirrors the real endpoint's contract (huma_handlers_events.go):
+        events are returned OLDEST-first, ``since`` (Go duration string)
+        filters by age, ``limit`` keeps the oldest slice (the newest
+        events are what truncation drops), and ``total`` reports the
+        pre-truncation match count so clients can detect incompleteness.
+        """
         wanted_type = query.get("type", "")
         with self._lock:
             if wanted_type == "extmsg.inbound":
                 items = list(self._inbound_events)
             else:
                 items = []
-        # Apply limit if supplied (default behavior in the real API).
+        since = _parse_go_duration_seconds(query.get("since", ""))
+        if since is not None:
+            items = [e for e in items if float(e.get("_age_seconds", 0.0)) <= since]
+        items = [{k: v for k, v in e.items() if k != "_age_seconds"} for e in items]
         try:
-            limit = int(query.get("limit", "50"))
+            limit = int(query.get("limit", "100"))
         except ValueError:
-            limit = 50
-        items = items[-limit:]
-        resp = json.dumps({"items": items}).encode()
+            limit = 100
+        total = len(items)
+        items = items[:limit]
+        resp = json.dumps({"items": items, "total": total}).encode()
         req.send_response(200)
         req.send_header("Content-Type", "application/json")
         req.send_header("Content-Length", str(len(resp)))

--- a/slack-full/tests/test_inbound_event_scan.py
+++ b/slack-full/tests/test_inbound_event_scan.py
@@ -1,0 +1,139 @@
+"""Tests for find_latest_inbound_for_session's escalating scan windows.
+
+The gc events endpoint returns events oldest-first with no descending
+order, and ``limit`` keeps the OLDEST slice of the window — so the scan
+starts narrow (a newest-slice view) and widens only when nothing
+matched. These tests pin the window ladder, the wide-window fallback
+for long-idle sessions, and the never-silent truncation warning.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+from typing import Any
+
+import pytest
+
+TESTS_DIR = pathlib.Path(__file__).resolve().parent
+sys.path.insert(0, str(TESTS_DIR))
+
+from gc_mock import GcMock  # type: ignore  # noqa: E402
+
+PACK_DIR = TESTS_DIR.parent
+SCRIPTS_DIR = PACK_DIR / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+
+@pytest.fixture
+def gc_mock() -> "GcMock":
+    g = GcMock(city_name="test-city")
+    yield g
+    g.close()
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+    gc_mock: "GcMock",
+) -> None:
+    monkeypatch.setenv("GC_API_BASE_URL", gc_mock.url)
+    monkeypatch.setenv("GC_CITY_NAME", "test-city")
+    monkeypatch.setenv("GC_CITY_PATH", str(tmp_path))
+    monkeypatch.setenv("SLACK_WORKSPACE_ID", "T0TESTWS")
+    monkeypatch.setenv("GC_SESSION_ID", "gc-test-session")
+    monkeypatch.delenv("GC_SLACK_ADAPTER_ENV", raising=False)
+
+
+def _import_common():
+    sys.modules.pop("slack_intake_common", None)
+    import slack_intake_common  # type: ignore
+
+    return slack_intake_common
+
+
+def _events_calls(gc_mock: "GcMock") -> list[dict[str, str]]:
+    return [c.query for c in gc_mock.calls() if c.path.endswith("/events")]
+
+
+def test_recent_inbound_resolves_in_first_window(gc_mock: "GcMock") -> None:
+    common = _import_common()
+    gc_mock.register_inbound_event(
+        target_session="gc-test-session", conversation_id="D0RECENT",
+    )
+
+    event = common.find_latest_inbound_for_session("gc-test-session")
+
+    assert event is not None
+    assert event["payload"]["conversation_id"] == "D0RECENT"
+    calls = _events_calls(gc_mock)
+    assert len(calls) == 1, f"expected single narrow-window query, got {calls}"
+    assert calls[0].get("since") == common._INBOUND_SCAN_WINDOWS[0]
+
+
+def test_old_inbound_found_via_widened_window(gc_mock: "GcMock") -> None:
+    # Latest inbound is 3h old: outside 10m and 2h, inside 48h. The old
+    # single-shot 2h scan returned None here and reply-current fell back
+    # to a non-threaded channel publish.
+    common = _import_common()
+    gc_mock.register_inbound_event(
+        target_session="gc-test-session",
+        conversation_id="D0OVERNIGHT",
+        age_seconds=3 * 3600,
+    )
+
+    event = common.find_latest_inbound_for_session("gc-test-session")
+
+    assert event is not None
+    assert event["payload"]["conversation_id"] == "D0OVERNIGHT"
+    sinces = [c.get("since") for c in _events_calls(gc_mock)]
+    assert sinces == list(common._INBOUND_SCAN_WINDOWS), (
+        f"expected full ladder before the wide-window hit, got {sinces}"
+    )
+
+
+def test_no_inbound_returns_none_after_all_windows(gc_mock: "GcMock") -> None:
+    common = _import_common()
+
+    assert common.find_latest_inbound_for_session("gc-test-session") is None
+    sinces = [c.get("since") for c in _events_calls(gc_mock)]
+    assert sinces == list(common._INBOUND_SCAN_WINDOWS)
+
+
+def test_latest_match_wins_within_a_window(gc_mock: "GcMock") -> None:
+    common = _import_common()
+    gc_mock.register_inbound_event(
+        target_session="gc-test-session", conversation_id="D0OLDER", age_seconds=120,
+    )
+    gc_mock.register_inbound_event(
+        target_session="other-session", conversation_id="D0NOISE", age_seconds=60,
+    )
+    gc_mock.register_inbound_event(
+        target_session="gc-test-session", conversation_id="D0NEWEST", age_seconds=5,
+    )
+
+    event = common.find_latest_inbound_for_session("gc-test-session")
+
+    assert event is not None
+    assert event["payload"]["conversation_id"] == "D0NEWEST"
+
+
+def test_truncated_scan_warns_on_stderr(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # The server reporting total > len(items) means the oldest-first
+    # limit cut off the newest events — exactly the ones the scan is
+    # after. That must never pass silently.
+    common = _import_common()
+
+    def fake_request(method: str, url: str, body: Any = None, **kwargs: Any) -> dict[str, Any]:
+        return {"items": [], "total": 750}
+
+    monkeypatch.setattr(common, "_request", fake_request)
+
+    assert common.find_latest_inbound_for_session("gc-test-session") is None
+    err = capsys.readouterr().err
+    assert "truncated to 0/750" in err
+    assert err.count("warning: inbound event scan") == len(common._INBOUND_SCAN_WINDOWS)


### PR DESCRIPTION
Salvages the escalating inbound-scan window ladder + truncation warning into `slack-full` (3 files), split from the closed reconcile PR #90 (`bd-gpk-yipm`).

- `slack-full/scripts/slack_intake_common.py` — replaces the single 2h inbound-scan shot with an escalating window ladder + a truncation warning when results are clipped.
- `slack-full/tests/test_inbound_event_scan.py` — new coverage for the ladder + truncation.
- `slack-full/tests/gc_mock.py` — mock support.

Cherry-picked onto current `gastownhall/gascity-packs` main (clean base). Full slack-full suite: 85/85 pass.
