### PR TITLE
fix(deacon): drop --type=wisp from mol-wisp scan queries

### DIFF
--- a/gastown/agents/deacon/prompt.template.md
+++ b/gastown/agents/deacon/prompt.template.md
@@ -89,9 +89,9 @@ If `next-iteration` already ran, do not pour again; run `gc hook`.
 ```bash
 CURRENT_WISP=${GC_BEAD_ID:-}
 if [ -z "$CURRENT_WISP" ]; then
-  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=wisp --limit=1 --json | jq -r '.[0].id // empty')
+  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --limit=1 --json | jq -r '.[0].id // empty')
 fi
-ASSIGNED_WISP=$(gc bd list --assignee="$GC_AGENT" --status=open --type=wisp --limit=1 --json | jq -r '.[0].id // empty')
+ASSIGNED_WISP=$(gc bd list --assignee="$GC_AGENT" --status=open --limit=1 --json | jq -r '.[0].id // empty')
 if [ -n "$CURRENT_WISP" ] && [ -z "$ASSIGNED_WISP" ]; then
   NEXT=$(gc bd mol wisp mol-deacon-patrol --root-only --var binding_prefix={{ .BindingPrefix }} --json | jq -r '.new_epic_id // empty')
   if [ -z "$NEXT" ]; then


### PR DESCRIPTION
## Problem

`mol-deacon-patrol` beads have `issue_type=molecule`, **not** `wisp`. The `--type=wisp` filter in the deacon's startup protocol and "No Idle State" fallback was silently returning 0 results.

**Consequence**: The fallback scan missed stale wisps from prior iterations, and on any crash-recovery restart that lands in the fallback path, it would find no `ASSIGNED_WISP` and pour a **duplicate successor wisp** each cycle.

**Evidence**: Reported by `gastown.deacon` on first patrol (city DB, bd 1.0.4). Stale wisp `ci-wisp-s9iq` was missed and had to be caught via an unfiltered assignee query.

## Fix

Drop `--type=wisp` from both queries on lines 92 and 94. Assignee + status filtering alone is sufficient and correct — the deacon is only ever assigned mol-deacon-patrol beads.

## Test

Deacon startup with an existing assigned mol-wisp bead correctly resolves `ASSIGNED_WISP` without the type filter.