### PR TITLE
feat(gastown): mol-pr-ship review gate between polecat and refinery

### DIFF
--- a/gastown/agents/polecat/prompt.template.md
+++ b/gastown/agents/polecat/prompt.template.md
@@ -278,6 +278,28 @@ if [ "$AUTO_PUSH" = "false" ]; then
   gc runtime drain-ack
   exit 0
 fi
+# PR review gate: pour and execute mol-pr-ship before pushing.
+# Runs simplify → adversarial multi-reviewer panel → mechanical gates.
+# Verdict is written to ship bead notes as `readiness: READY | BLOCKED`.
+# Polecat executes all mol-pr-ship steps inline; read steps with:
+#   gc bd formula show mol-pr-ship
+BRANCH=$(git branch --show-current)
+SHIP_BEAD=$(gc bd mol wisp mol-pr-ship --root-only --var branch="$BRANCH" --json | jq -r '.new_epic_id')
+gc bd update "$SHIP_BEAD" --assignee="$GC_AGENT"
+# --- execute mol-pr-ship steps in full here ---
+# After completing all mol-pr-ship steps, read the verdict:
+SHIP_VERDICT=$(gc bd show "$SHIP_BEAD" --json | jq -r '.[0].notes' | grep '^readiness:' | awk '{print $2}')
+SHIP_BLOCKERS=$(gc bd show "$SHIP_BEAD" --json | jq -r '.[0].notes' | grep '^blockers:' | cut -d' ' -f2-)
+gc bd mol burn "$SHIP_BEAD" --force
+gc bd update <work-bead> --set-metadata pr_review_verdict="$(echo "$SHIP_VERDICT" | tr '[:upper:]' '[:lower:]')"
+if [ "$SHIP_VERDICT" != "READY" ]; then
+  gc bd update <work-bead> \
+    --status=open --assignee="" \
+    --set-metadata halt_reason="pr_ship: $SHIP_BLOCKERS" \
+    --notes "PR ship gate blocked: $SHIP_BLOCKERS"
+  gc runtime drain-ack
+  exit 0
+fi
 git push origin HEAD && {
   BRANCH=$(git branch --show-current)
   REMOTE_REF=$(git ls-remote origin "refs/heads/$BRANCH" 2>/dev/null | awk '{print $1}')

--- a/gastown/agents/refinery/prompt.template.md
+++ b/gastown/agents/refinery/prompt.template.md
@@ -215,6 +215,7 @@ Polecats set these metadata fields before assigning a work bead to you:
 - `target` — target branch (optional, defaults to {{ .DefaultBranch }})
 - `merge_strategy` — handoff mode (optional, defaults to `direct`)
 - `existing_pr` — existing PR URL to reuse in `mr` / `pr` mode
+- `pr_review_verdict` — result of the polecat's mol-pr-ship gate (`ready` or `blocked`)
 
 Read them mechanically:
 ```bash
@@ -222,9 +223,26 @@ gc bd show $WORK --json | jq -r '.[0].metadata.branch'
 gc bd show $WORK --json | jq -r '.[0].metadata.target // "{{ .DefaultBranch }}"'
 gc bd show $WORK --json | jq -r '.[0].metadata.merge_strategy // "direct"'
 gc bd show $WORK --json | jq -r '.[0].metadata.existing_pr // empty'
+gc bd show $WORK --json | jq -r '.[0].metadata.pr_review_verdict // empty'
 ```
 
 Never infer a branch name. If `metadata.branch` is missing, reject the bead.
+
+### Pre-merge PR review gate
+
+Before starting rebase/merge, check `metadata.pr_review_verdict`. A bead
+with `blocked` was halted by mol-pr-ship and should not be merged — it
+must go back to a polecat for fixes first. Absence means the bead predates
+the gate; proceed normally.
+
+```bash
+PR_VERDICT=$(gc bd show $WORK --json | jq -r '.[0].metadata.pr_review_verdict // empty')
+if [ "$PR_VERDICT" = "blocked" ]; then
+  gc bd update $WORK --status=open --assignee="" \
+    --set-metadata rejection_reason="pr_ship: blocked — polecat must re-run mol-pr-ship and fix blockers"
+  # Pour next wisp, burn current, continue patrol
+fi
+```
 
 ## Rejection Flow
 


### PR DESCRIPTION
## Summary

- **Polecat**: before pushing a branch, pours and executes `mol-pr-ship` (simplify → adversarial multi-reviewer panel → mechanical gates). Verdict (`READY`/`BLOCKED`) is written to the work bead as `metadata.pr_review_verdict`. If blocked, bead is returned to the pool — no push, no refinery handoff.
- **Refinery**: added pre-merge check for `pr_review_verdict`. Beads arriving with `blocked` are rejected back to the pool rather than merged. Absent field is backwards-compatible (pre-gate beads flow through unchanged).

## New metadata field

`pr_review_verdict` on work beads:
- `ready` — mol-pr-ship passed; polecat proceeds to push + refinery handoff
- `blocked` — mol-pr-ship found unresolved blockers; bead needs another polecat pass before merge

## Test plan

- [ ] Dispatch a work bead to a polecat; confirm polecat pours `mol-pr-ship`, executes steps, sets `pr_review_verdict` on work bead
- [ ] Simulate a BLOCKED verdict: confirm bead returns to pool with `halt_reason` set, no push
- [ ] Simulate a READY verdict: confirm bead proceeds to push + refinery handoff
- [ ] Assign a BLOCKED bead to refinery: confirm refinery rejects it back to pool

Closes: ci-rrz

🤖 Generated with [Claude Code](https://claude.com/claude-code)