### PR TITLE
fix(gastown): pass wheel through to alternate-screen apps in WheelUpPane

### DIFF
--- a/gastown/assets/scripts/tmux-keybindings.sh
+++ b/gastown/assets/scripts/tmux-keybindings.sh
@@ -22,12 +22,18 @@ if ! printf '%s' "$existing" | grep -qF "$mail_popup"; then
 fi
 
 # ── Mouse-wheel scrollback (root table) ───────────────────────────────
-# Make the wheel drive tmux copy-mode scrollback instead of leaking to the
-# focused app. Without this, "mouse on" (set in tmux-theme.sh) hands the wheel
-# to mouse-reporting TUIs — Claude Code scrolls its own history, a pager/shell
-# gets Up-arrows — and only a bare prompt reaches copy-mode. Force copy-mode
-# even over mouse-reporting apps (no mouse_any_flag check) so scrollback wins;
-# once in copy-mode the wheel passes through (-M) for normal scrolling, and -e
-# exits at the bottom. Shift+wheel still does native terminal selection.
-gcmux bind-key -T root WheelUpPane   if-shell -F -t= "#{pane_in_mode}" "send-keys -M" "copy-mode -e"
+# WheelUp drives tmux copy-mode scrollback when a plain shell (or any pane
+# not using the terminal alternate screen) is focused. When the focused pane
+# IS in alternate-screen mode — Claude Code's TUI, a pager, or any other
+# full-screen app — the wheel is passed through to the application so its own
+# history/scroll works as expected. Rationale: the tmux scrollback buffer
+# contains no content from alternate-screen apps (their output never lands
+# there), so entering copy-mode while Claude Code is focused gives an empty
+# scrollback, silently discarding the intended scroll.
+#   #{alternate_on}   — pane is currently in the terminal alternate screen
+#   #{pane_in_mode}   — already in tmux copy-mode (wheel continues scrolling)
+#   #{mouse_any_flag} — app has requested mouse tracking (belt-and-suspenders)
+# WheelDown always passes through; -e in copy-mode exits at the bottom.
+# Shift+wheel still does native terminal selection.
+gcmux bind-key -T root WheelUpPane   if-shell -F -t= "#{||:#{alternate_on},#{pane_in_mode},#{mouse_any_flag}}" "send-keys -M" "copy-mode -e"
 gcmux bind-key -T root WheelDownPane send-keys -M


### PR DESCRIPTION
## Problem

The ga-c4w fix (PR #3103 in gascity) set `WheelUpPane` to force tmux copy-mode on every upward mouse scroll, regardless of what is running in the pane. The intent was good: drive tmux scrollback instead of leaking the wheel into the focused application.

However, it did not account for panes running in the **terminal alternate screen** (Claude Code, pagers, etc.). The tmux scrollback buffer never receives content from alternate-screen apps — their output lives only in the alternate screen. So when a user scrolls up while Claude Code is focused, they enter copy-mode and see an empty buffer, silently losing access to the conversation history they were trying to read.

## Fix

Add `#{alternate_on}` and `#{mouse_any_flag}` back to the `WheelUpPane` condition (matching tmux's own default for `mouse on`):

```sh
# Before
gcmux bind-key -T root WheelUpPane   if-shell -F -t= "#{pane_in_mode}" "send-keys -M" "copy-mode -e"

# After
gcmux bind-key -T root WheelUpPane   if-shell -F -t= "#{||:#{alternate_on},#{pane_in_mode},#{mouse_any_flag}}" "send-keys -M" "copy-mode -e"
```

Behaviour after this change:

| Pane state | WheelUp action |
|---|---|
| Plain shell / bare prompt | enters copy-mode (scrollback) — unchanged |
| Already in copy-mode | passes through within copy-mode — unchanged |
| Alternate-screen app (Claude Code, less, etc.) | passes through to app |
| App with mouse tracking requested | passes through to app |

## Safety

The ga-c4w ESC-injection fix lives in the gc runtime (`internal/runtime/tmux/adapter.go` `disableMouseAndActivity`) and is entirely unaffected by this change. `MouseOn` is still set to `true` only for human-interactive session paths; headless controller-polled sessions continue to run with mouse off and never reach this binding.

The `cancelCopyModeIfParked` guard added as a ga-c4w side-fix (which cancels copy-mode before sending nudge/response keystrokes) is also unaffected: copy-mode and alternate-screen mode are mutually exclusive in tmux, so `pane_in_mode` cannot be 1 when `alternate_on` is 1.

## References

- Original ga-c4w fix: gastownhall/gascity#3103
- Regression reported by @lvanderbijl-kry (edna city, `gc attach session` workflow)

A companion PR to gastownhall/gascity will follow to bump the module version and update `TestTmuxKeybindingsScrollWheel`.