### PR TITLE
fix(discord): opt-in wake on @everyone / @here / @role for bound rooms

### DIFF
--- a/discord/commands/bind-room/help.md
+++ b/discord/commands/bind-room/help.md
@@ -5,6 +5,7 @@ Examples:
   gc discord bind-room --guild-id 223456789012345678 123456789012345678 sky lawrence
   gc discord bind-room --guild-id 223456789012345678 --enable-ambient-read 123456789012345678 sky lawrence
   gc discord bind-room --guild-id 223456789012345678 --enable-ambient-read --allow-untargeted-ambient-delivery 123456789012345678 randy
+  gc discord bind-room --guild-id 223456789012345678 --enable-broadcast-mentions 123456789012345678 sky lawrence
   gc discord bind-room --guild-id 223456789012345678 --enable-peer-fanout 123456789012345678 corp--sky corp--priya
   gc discord bind-room --guild-id 223456789012345678 --enable-peer-fanout --allow-untargeted-peer-fanout 123456789012345678 corp--sky corp--priya
 
@@ -27,6 +28,16 @@ Ambient read consumes unmentioned guild messages. Discord therefore requires
 the app's `Message Content Intent` to be enabled in the Developer Portal
 before ambient-read routing will work reliably.
 
+Broadcast mentions are disabled by default. Discord does not list `@everyone`,
+`@here`, or `@role` mentions in a message's `mentions[]`, and they are
+deliberately excluded from default routing, so a bound room ignores them. When
+`--enable-broadcast-mentions` is set, an `@everyone`/`@here` ping wakes the
+bound session(s), and an `@role` ping wakes them when the bot actually holds the
+mentioned role (its auto-created managed role, or a shared role assigned to it).
+This is opt-in per binding because `@everyone` is usually meant for humans and
+is noisy in busy servers. `@everyone` still only fires when the author has
+permission to mention everyone.
+
 Peer fanout is disabled by default. When enabled, the bridge can reinject one
 session's room publish to other bound sessions as `discord_peer_publication`
 events without re-reading bot messages from Discord.
@@ -36,6 +47,7 @@ Useful flags:
 
 - `--enable-ambient-read` / `--disable-ambient-read`
 - `--allow-untargeted-ambient-delivery` / `--disallow-untargeted-ambient-delivery`
+- `--enable-broadcast-mentions` / `--disable-broadcast-mentions`
 - `--enable-peer-fanout` / `--disable-peer-fanout`
 - `--allow-untargeted-peer-fanout` / `--disallow-untargeted-peer-fanout`
 - `--max-peer-triggered-publishes-per-root N`

--- a/discord/scripts/discord_chat_bind.py
+++ b/discord/scripts/discord_chat_bind.py
@@ -36,6 +36,16 @@ def main(argv: list[str]) -> int:
         action="store_true",
         help="Require explicit @session_name targeting for ambient room messages",
     )
+    parser.add_argument(
+        "--enable-broadcast-mentions",
+        action="store_true",
+        help="Wake the bound session(s) on @everyone/@here and @role mentions (role pings are scoped to roles the bot holds)",
+    )
+    parser.add_argument(
+        "--disable-broadcast-mentions",
+        action="store_true",
+        help="Ignore @everyone/@here and @role mentions (default)",
+    )
     parser.add_argument("--enable-peer-fanout", action="store_true", help="Enable peer fanout for bound room publishes")
     parser.add_argument("--disable-peer-fanout", action="store_true", help="Disable peer fanout for bound room publishes")
     parser.add_argument(
@@ -67,6 +77,12 @@ def main(argv: list[str]) -> int:
         enable_flag="--allow-untargeted-ambient-delivery",
         disable_flag="--disallow-untargeted-ambient-delivery",
     )
+    broadcast_mentions = _optional_bool(
+        args.enable_broadcast_mentions,
+        args.disable_broadcast_mentions,
+        enable_flag="--enable-broadcast-mentions",
+        disable_flag="--disable-broadcast-mentions",
+    )
     peer_fanout = _optional_bool(
         args.enable_peer_fanout,
         args.disable_peer_fanout,
@@ -85,6 +101,8 @@ def main(argv: list[str]) -> int:
         room_policy["ambient_read_enabled"] = ambient_read
     if untargeted_ambient_delivery is not None:
         room_policy["allow_untargeted_ambient_delivery"] = untargeted_ambient_delivery
+    if broadcast_mentions is not None:
+        room_policy["broadcast_mentions_enabled"] = broadcast_mentions
     if peer_fanout is not None:
         room_policy["peer_fanout_enabled"] = peer_fanout
     if untargeted_peer_fanout is not None:

--- a/discord/scripts/discord_gateway_service.py
+++ b/discord/scripts/discord_gateway_service.py
@@ -38,6 +38,7 @@ HEALTH_RECONNECT_GRACE_SECONDS = 90
 GC_API_HEALTH_TTL_SECONDS = 30
 GC_API_HEALTH_PROBE_TIMEOUT_SECONDS = 3.0
 CHANNEL_INFO_TTL_SECONDS = 5 * 60
+BOT_GUILD_ROLES_TTL_SECONDS = 5 * 60
 MAX_FRAME_BYTES = 16 * 1024 * 1024
 STALE_PROCESSING_RECEIPT_SECONDS = 2 * 60
 FAILED_RECEIPT_RETRY_SECONDS = 60
@@ -60,6 +61,10 @@ CHANNEL_INFO_CACHE_LOCK = threading.Lock()
 CHANNEL_INFO_FETCH_LOCKS_LOCK = threading.Lock()
 CHANNEL_INFO_FETCH_LOCKS: dict[str, threading.Lock] = {}
 CHANNEL_INFO_CACHE: dict[str, tuple[float, dict[str, Any]]] = {}
+BOT_GUILD_ROLES_CACHE_LOCK = threading.Lock()
+BOT_GUILD_ROLES_FETCH_LOCKS_LOCK = threading.Lock()
+BOT_GUILD_ROLES_FETCH_LOCKS: dict[str, threading.Lock] = {}
+BOT_GUILD_ROLES_CACHE: dict[str, tuple[float, frozenset[str]]] = {}
 AMBIENT_ROOM_BINDINGS_CACHE_LOCK = threading.Lock()
 AMBIENT_ROOM_BINDINGS_FETCH_LOCK = threading.Lock()
 AMBIENT_ROOM_BINDINGS_CACHE: dict[str, Any] = {"config_signature": None, "bindings": {}}
@@ -144,6 +149,26 @@ def bot_was_mentioned(message: dict[str, Any], bot_user_id: str) -> bool:
     if not isinstance(mentions, list):
         return False
     return any(str(item.get("id", "")).strip() == bot_user_id for item in mentions if isinstance(item, dict))
+
+
+def message_mentions_everyone(message: dict[str, Any]) -> bool:
+    # Discord does not list @everyone/@here in mentions[]; it reports them via
+    # the dedicated mention_everyone boolean, which the API sets only when the
+    # author actually has permission to mention everyone. Both @everyone and
+    # @here share this one flag, so honoring it covers both. A bound session
+    # treats an everyone/here ping as addressed to it, just like a direct
+    # @mention -- bot_was_mentioned() alone never catches these.
+    return bool(message.get("mention_everyone"))
+
+
+def message_role_mention_ids(message: dict[str, Any]) -> frozenset[str]:
+    # Role @mentions land in mention_roles[], never in mentions[]. This is the
+    # set of role ids a message pinged (the bot's managed role, a shared
+    # "Mayor" role, etc.).
+    raw = message.get("mention_roles") or []
+    if not isinstance(raw, list):
+        return frozenset()
+    return frozenset(str(role_id).strip() for role_id in raw if str(role_id).strip())
 
 
 def websocket_accept_value(key: str) -> str:
@@ -435,6 +460,59 @@ def channel_info_fetch_lock(channel_id: str) -> threading.Lock:
         return lock
 
 
+def bot_guild_roles_fetch_lock(cache_key: str) -> threading.Lock:
+    with BOT_GUILD_ROLES_FETCH_LOCKS_LOCK:
+        lock = BOT_GUILD_ROLES_FETCH_LOCKS.get(cache_key)
+        if lock is None:
+            lock = threading.Lock()
+            BOT_GUILD_ROLES_FETCH_LOCKS[cache_key] = lock
+        return lock
+
+
+def load_bot_guild_role_ids(guild_id: str, bot_user_id: str, bot_token: str) -> frozenset[str]:
+    # Role ids assigned to the bot's own member in this guild (cached, TTL).
+    # A message that mentions one of these roles (mention_roles[]) is addressed
+    # to the bot: this catches the bot's auto-created managed role as well as a
+    # shared role (e.g. a "Mayor" role) assigned to every mayor bot. Discord
+    # never lists role mentions in mentions[], so bot_was_mentioned() misses
+    # them. API failures are swallowed (treated as "no roles") so a transient
+    # error never blocks message processing.
+    guild_id = str(guild_id).strip()
+    bot_user_id = str(bot_user_id).strip()
+    if not guild_id or not bot_user_id:
+        return frozenset()
+    cache_key = f"{guild_id}:{bot_user_id}"
+    now = time.monotonic()
+    with BOT_GUILD_ROLES_CACHE_LOCK:
+        cached = BOT_GUILD_ROLES_CACHE.get(cache_key)
+        if cached and cached[0] > now:
+            return cached[1]
+    # Serialize cache fills so a burst of uncached role mentions does not fan
+    # out into concurrent Discord API reads for the same bot member.
+    with bot_guild_roles_fetch_lock(cache_key):
+        now = time.monotonic()
+        with BOT_GUILD_ROLES_CACHE_LOCK:
+            cached = BOT_GUILD_ROLES_CACHE.get(cache_key)
+            if cached and cached[0] > now:
+                return cached[1]
+        try:
+            member = common.discord_api_request(
+                "GET",
+                f"/guilds/{urllib.parse.quote(guild_id)}/members/{urllib.parse.quote(bot_user_id)}",
+                bot_token=bot_token,
+            )
+        except common.DiscordAPIError:
+            return frozenset()
+        if not isinstance(member, dict):
+            return frozenset()
+        role_ids = frozenset(
+            str(role_id).strip() for role_id in (member.get("roles") or []) if str(role_id).strip()
+        )
+        with BOT_GUILD_ROLES_CACHE_LOCK:
+            BOT_GUILD_ROLES_CACHE[cache_key] = (now + BOT_GUILD_ROLES_TTL_SECONDS, role_ids)
+        return role_ids
+
+
 def ingress_process_lock(ingress_id: str) -> threading.Lock:
     with INGRESS_PROCESS_LOCKS_LOCK:
         lock = INGRESS_PROCESS_LOCKS.get(ingress_id)
@@ -459,6 +537,23 @@ def prune_channel_info_fetch_locks() -> None:
         expired = [key for key, lock in CHANNEL_INFO_FETCH_LOCKS.items() if not lock.locked() and key not in cached_keys]
         for key in expired:
             del CHANNEL_INFO_FETCH_LOCKS[key]
+
+
+def prune_bot_guild_roles_cache() -> None:
+    now = time.monotonic()
+    with BOT_GUILD_ROLES_CACHE_LOCK:
+        expired = [key for key, (expires_at, _) in BOT_GUILD_ROLES_CACHE.items() if expires_at <= now]
+        for key in expired:
+            del BOT_GUILD_ROLES_CACHE[key]
+
+
+def prune_bot_guild_roles_fetch_locks() -> None:
+    with BOT_GUILD_ROLES_CACHE_LOCK:
+        cached_keys = set(BOT_GUILD_ROLES_CACHE.keys())
+    with BOT_GUILD_ROLES_FETCH_LOCKS_LOCK:
+        expired = [key for key, lock in BOT_GUILD_ROLES_FETCH_LOCKS.items() if not lock.locked() and key not in cached_keys]
+        for key in expired:
+            del BOT_GUILD_ROLES_FETCH_LOCKS[key]
 
 
 def prune_stale_reclaim_locks() -> None:
@@ -632,6 +727,35 @@ def bound_room_claims_message(config: dict[str, Any], channel_id: str, parent_id
     if parent and explicit_room_binding(config, parent):
         return True
     return False
+
+
+def bound_room_wakes_on_broadcast_mention(
+    config: dict[str, Any],
+    message: dict[str, Any],
+    guild_id: str,
+    channel_id: str,
+    bot_user_id: str,
+) -> bool:
+    # OPT-IN, default off. @everyone/@here (the mention_everyone boolean) and
+    # @role pings (mention_roles[], incl. the bot's auto-created managed role or
+    # a shared role assigned to it) are never in mentions[] and Discord
+    # deliberately excludes them from default addressing. They wake a bound room
+    # only when that binding sets broadcast_mentions_enabled, preserving the
+    # default for every room that has not opted in. @role is additionally scoped
+    # to roles the bot actually holds.
+    wants_everyone = message_mentions_everyone(message)
+    role_mention_ids = message_role_mention_ids(message)
+    if not wants_everyone and not role_mention_ids:
+        return False
+    binding = explicit_room_binding(config, channel_id)
+    if not binding or not common.binding_peer_policy(binding).get("broadcast_mentions_enabled"):
+        return False
+    if wants_everyone:
+        return True
+    bot_token = common.load_bot_token()
+    if not bot_token:
+        return False
+    return bool(load_bot_guild_role_ids(guild_id, bot_user_id, bot_token) & role_mention_ids)
 
 
 def ambient_bindings_config_signature() -> tuple[int, int, int] | None:
@@ -1257,6 +1381,11 @@ def process_inbound_message(message: dict[str, Any], bot_user_id: str) -> dict[s
     config = common.load_config()
     room_launchers_configured = bool(common.list_room_launchers(config)) if guild_id else False
     mentioned_bot = bot_was_mentioned(message, bot_user_id) if guild_id else False
+    if guild_id and not mentioned_bot:
+        # @everyone/@here and @role pings are NOT in mentions[], and Discord
+        # deliberately excludes them from default addressing. They wake a bound
+        # room only when that binding opts in (broadcast_mentions_enabled).
+        mentioned_bot = bound_room_wakes_on_broadcast_mention(config, message, guild_id, channel_id, bot_user_id)
     preloaded_launcher: dict[str, Any] | None = None
     preloaded_launch: dict[str, Any] | None = None
     preloaded_binding: dict[str, Any] | None = None
@@ -2089,6 +2218,8 @@ class GatewayWorker:
         common.prune_room_launches()
         prune_channel_info_cache()
         prune_channel_info_fetch_locks()
+        prune_bot_guild_roles_cache()
+        prune_bot_guild_roles_fetch_locks()
         prune_stale_reclaim_locks()
         prune_ingress_process_locks()
         self.runtime_state.patch(last_prune_at=common.utcnow())

--- a/discord/scripts/discord_intake_common.py
+++ b/discord/scripts/discord_intake_common.py
@@ -483,6 +483,7 @@ def default_room_peer_policy() -> dict[str, Any]:
     return {
         "ambient_read_enabled": False,
         "allow_untargeted_ambient_delivery": False,
+        "broadcast_mentions_enabled": False,
         "peer_fanout_enabled": False,
         "allow_untargeted_peer_fanout": False,
         "max_peer_triggered_publishes_per_root": 1,
@@ -504,6 +505,9 @@ def _normalize_peer_policy(policy: dict[str, Any] | None, defaults: dict[str, An
         "ambient_read_enabled": _coerce_bool(raw.get("ambient_read_enabled"), defaults["ambient_read_enabled"]),
         "allow_untargeted_ambient_delivery": _coerce_bool(
             raw.get("allow_untargeted_ambient_delivery"), defaults["allow_untargeted_ambient_delivery"]
+        ),
+        "broadcast_mentions_enabled": _coerce_bool(
+            raw.get("broadcast_mentions_enabled"), defaults["broadcast_mentions_enabled"]
         ),
         "peer_fanout_enabled": _coerce_bool(raw.get("peer_fanout_enabled"), defaults["peer_fanout_enabled"]),
         "allow_untargeted_peer_fanout": _coerce_bool(

--- a/discord/tests/test_discord_chat_scripts.py
+++ b/discord/tests/test_discord_chat_scripts.py
@@ -54,6 +54,20 @@ class DiscordChatScriptTests(unittest.TestCase):
             self.assertTrue(script_path.is_file(), f"missing command script for {command.get('name')}: {script_path}")
             self.assertTrue(help_path.is_file(), f"missing help text for {command.get('name')}: {help_path}")
 
+    def test_bind_room_enable_broadcast_mentions_sets_policy(self) -> None:
+        with redirect_stdout(io.StringIO()):
+            rc = bind_script.main(["--kind", "room", "--guild-id", "1", "--enable-broadcast-mentions", "22", "sky"])
+        self.assertEqual(rc, 0)
+        binding = common.resolve_chat_binding(common.load_config(), common.chat_binding_id("room", "22"))
+        self.assertTrue(common.binding_peer_policy(binding)["broadcast_mentions_enabled"])
+
+    def test_bind_room_broadcast_mentions_default_off(self) -> None:
+        with redirect_stdout(io.StringIO()):
+            rc = bind_script.main(["--kind", "room", "--guild-id", "1", "22", "sky"])
+        self.assertEqual(rc, 0)
+        binding = common.resolve_chat_binding(common.load_config(), common.chat_binding_id("room", "22"))
+        self.assertFalse(common.binding_peer_policy(binding)["broadcast_mentions_enabled"])
+
     def test_enable_room_launch_preserves_legacy_launcher_without_policy_flags(self) -> None:
         common.save_config(
             common.normalize_config(

--- a/discord/tests/test_discord_gateway_service.py
+++ b/discord/tests/test_discord_gateway_service.py
@@ -25,6 +25,8 @@ class DiscordGatewayServiceTests(unittest.TestCase):
         os.environ["GC_CITY_ROOT"] = self.tempdir.name
         gateway_service.CHANNEL_INFO_CACHE.clear()
         gateway_service.CHANNEL_INFO_FETCH_LOCKS.clear()
+        gateway_service.BOT_GUILD_ROLES_CACHE.clear()
+        gateway_service.BOT_GUILD_ROLES_FETCH_LOCKS.clear()
         gateway_service.STALE_RECLAIM_LOCKS.clear()
         gateway_service.INGRESS_PROCESS_LOCKS.clear()
         gateway_service.GC_API_HEALTH_CACHE["checked_at"] = 0.0
@@ -820,6 +822,257 @@ class DiscordGatewayServiceTests(unittest.TestCase):
         self.assertEqual(outcome["status"], "ignored")
         self.assertEqual(outcome["reason"], "not_mentioned")
         deliver_session_message.assert_not_called()
+
+    def test_process_inbound_room_message_broadcasts_on_mention_everyone(self) -> None:
+        # Discord does NOT add @everyone/@here to mentions[]; it sets the
+        # separate mention_everyone boolean (only when the author has the
+        # "Mention @everyone" permission). A bound room must treat that as
+        # addressed to it and wake every bound selector, with no @bot mention
+        # and no @@alias present.
+        common.set_chat_binding(
+            common.load_config(), "room", "22", ["sky", "lawrence"], guild_id="1",
+            policy={"broadcast_mentions_enabled": True},
+        )
+        message = {
+            "id": "990",
+            "guild_id": "1",
+            "channel_id": "22",
+            "content": "@everyone please surface for a quick sync",
+            "mentions": [],
+            "mention_everyone": True,
+            "author": {"id": "u-90", "username": "alice"},
+        }
+
+        with mock.patch.object(common, "deliver_session_message", return_value={"status": "accepted"}) as deliver_session_message:
+            outcome = gateway_service.process_inbound_message(message, bot_user_id="999")
+
+        self.assertEqual(outcome["status"], "delivered")
+        self.assertEqual(deliver_session_message.call_count, 2)
+        self.assertEqual(deliver_session_message.call_args_list[0].args[0], "sky")
+        self.assertEqual(deliver_session_message.call_args_list[1].args[0], "lawrence")
+        receipt = common.load_chat_ingress("in-990")
+        self.assertEqual(receipt["delivery"], "broadcast")
+
+    def test_process_inbound_room_message_broadcasts_on_mention_here(self) -> None:
+        # @here shares the same mention_everyone boolean as @everyone, so it
+        # must wake the bound mayor identically.
+        common.set_chat_binding(
+            common.load_config(), "room", "22", ["sky"], guild_id="1",
+            policy={"broadcast_mentions_enabled": True},
+        )
+        message = {
+            "id": "991",
+            "guild_id": "1",
+            "channel_id": "22",
+            "content": "@here anyone around?",
+            "mentions": [],
+            "mention_everyone": True,
+            "author": {"id": "u-91", "username": "alice"},
+        }
+
+        with mock.patch.object(common, "deliver_session_message", return_value={"status": "accepted"}) as deliver_session_message:
+            outcome = gateway_service.process_inbound_message(message, bot_user_id="999")
+
+        self.assertEqual(outcome["status"], "delivered")
+        deliver_session_message.assert_called_once()
+        self.assertEqual(deliver_session_message.call_args.args[0], "sky")
+
+    def test_process_inbound_room_message_ignores_when_mention_everyone_false(self) -> None:
+        # A plain message that does not mention the bot and is not an
+        # everyone/here ping (e.g. an unprivileged user typing the literal
+        # text, where Discord leaves mention_everyone False) stays ignored.
+        common.set_chat_binding(
+            common.load_config(), "room", "22", ["sky", "lawrence"], guild_id="1",
+            policy={"broadcast_mentions_enabled": True},
+        )
+        message = {
+            "id": "992",
+            "guild_id": "1",
+            "channel_id": "22",
+            "content": "@everyone (just typing this, no permission to ping)",
+            "mentions": [],
+            "mention_everyone": False,
+            "author": {"id": "u-92", "username": "alice"},
+        }
+
+        with mock.patch.object(common, "deliver_session_message") as deliver_session_message:
+            outcome = gateway_service.process_inbound_message(message, bot_user_id="999")
+
+        self.assertEqual(outcome["status"], "ignored")
+        self.assertEqual(outcome["reason"], "not_mentioned")
+        deliver_session_message.assert_not_called()
+
+    def test_process_inbound_unbound_room_mention_everyone_does_not_deliver(self) -> None:
+        # @everyone in a channel with no bound session must not deliver
+        # anywhere (no fan-out to unbound rooms).
+        message = {
+            "id": "993",
+            "guild_id": "1",
+            "channel_id": "22",
+            "content": "@everyone hello",
+            "mentions": [],
+            "mention_everyone": True,
+            "author": {"id": "u-93", "username": "alice"},
+        }
+
+        with mock.patch.object(gateway_service, "resolve_binding", return_value=(None, {})), mock.patch.object(
+            common, "deliver_session_message"
+        ) as deliver_session_message:
+            outcome = gateway_service.process_inbound_message(message, bot_user_id="999")
+
+        self.assertNotEqual(outcome["status"], "delivered")
+        deliver_session_message.assert_not_called()
+
+    @staticmethod
+    def _member_roles_api(role_ids: list[str]):
+        # discord_api_request side effect: return the bot's member (with roles)
+        # for the GET /guilds/.../members/<bot> call; empty dict otherwise.
+        def _fake(method: str, path: str, *args, **kwargs):
+            if "/members/" in path:
+                return {"roles": list(role_ids)}
+            return {}
+        return _fake
+
+    def test_process_inbound_room_message_wakes_on_bot_managed_role_mention(self) -> None:
+        # The exact footgun: tagging the bot's auto-created managed role lands in
+        # mention_roles[] (not mentions[]); the bound session must still wake.
+        common.set_chat_binding(
+            common.load_config(), "room", "22", ["jeeves"], guild_id="1",
+            policy={"broadcast_mentions_enabled": True},
+        )
+        message = {
+            "id": "994",
+            "guild_id": "1",
+            "channel_id": "22",
+            "content": "<@&777> all mayors please surface",
+            "mentions": [],
+            "mention_everyone": False,
+            "mention_roles": ["777"],
+            "author": {"id": "u-94", "username": "charlie"},
+        }
+
+        with mock.patch.object(common, "load_bot_token", return_value="tok"), mock.patch.object(
+            common, "discord_api_request", side_effect=self._member_roles_api(["777", "555"])
+        ), mock.patch.object(common, "deliver_session_message", return_value={"status": "accepted"}) as deliver_session_message:
+            outcome = gateway_service.process_inbound_message(message, bot_user_id="999")
+
+        self.assertEqual(outcome["status"], "delivered")
+        deliver_session_message.assert_called_once()
+        self.assertEqual(deliver_session_message.call_args.args[0], "jeeves")
+
+    def test_process_inbound_room_message_shared_role_broadcasts_to_all_bound(self) -> None:
+        # A shared "Mayor" role assigned to the bot broadcasts to every bound
+        # selector (the deliberate fan-out-to-all-mayors case).
+        common.set_chat_binding(
+            common.load_config(), "room", "22", ["jeeves", "sky"], guild_id="1",
+            policy={"broadcast_mentions_enabled": True},
+        )
+        message = {
+            "id": "995",
+            "guild_id": "1",
+            "channel_id": "22",
+            "content": "<@&mayor> standup in 5",
+            "mentions": [],
+            "mention_everyone": False,
+            "mention_roles": ["mayor"],
+            "author": {"id": "u-95", "username": "charlie"},
+        }
+
+        with mock.patch.object(common, "load_bot_token", return_value="tok"), mock.patch.object(
+            common, "discord_api_request", side_effect=self._member_roles_api(["mayor"])
+        ), mock.patch.object(common, "deliver_session_message", return_value={"status": "accepted"}) as deliver_session_message:
+            outcome = gateway_service.process_inbound_message(message, bot_user_id="999")
+
+        self.assertEqual(outcome["status"], "delivered")
+        self.assertEqual(deliver_session_message.call_count, 2)
+        self.assertEqual(
+            {c.args[0] for c in deliver_session_message.call_args_list}, {"jeeves", "sky"}
+        )
+
+    def test_process_inbound_room_message_ignores_role_the_bot_lacks(self) -> None:
+        # A role the bot does not have must not wake it.
+        common.set_chat_binding(
+            common.load_config(), "room", "22", ["jeeves"], guild_id="1",
+            policy={"broadcast_mentions_enabled": True},
+        )
+        message = {
+            "id": "996",
+            "guild_id": "1",
+            "channel_id": "22",
+            "content": "<@&other> not for the bots",
+            "mentions": [],
+            "mention_everyone": False,
+            "mention_roles": ["other"],
+            "author": {"id": "u-96", "username": "charlie"},
+        }
+
+        with mock.patch.object(common, "load_bot_token", return_value="tok"), mock.patch.object(
+            common, "discord_api_request", side_effect=self._member_roles_api(["role-the-bot-has"])
+        ), mock.patch.object(common, "deliver_session_message") as deliver_session_message:
+            outcome = gateway_service.process_inbound_message(message, bot_user_id="999")
+
+        self.assertEqual(outcome["status"], "ignored")
+        self.assertEqual(outcome["reason"], "not_mentioned")
+        deliver_session_message.assert_not_called()
+
+    def test_load_bot_guild_role_ids_caches_member_roles(self) -> None:
+        with mock.patch.object(common, "discord_api_request", return_value={"roles": ["a", "b"]}) as api:
+            first = gateway_service.load_bot_guild_role_ids("1", "999", "tok")
+            second = gateway_service.load_bot_guild_role_ids("1", "999", "tok")
+        self.assertEqual(first, frozenset({"a", "b"}))
+        self.assertEqual(second, frozenset({"a", "b"}))
+        api.assert_called_once()  # second call served from the TTL cache
+
+    def test_load_bot_guild_role_ids_swallows_api_error(self) -> None:
+        with mock.patch.object(common, "discord_api_request", side_effect=common.DiscordAPIError("boom")):
+            result = gateway_service.load_bot_guild_role_ids("1", "999", "tok")
+        self.assertEqual(result, frozenset())
+
+    def test_process_inbound_room_message_ignores_mention_everyone_without_optin(self) -> None:
+        # DEFAULT-OFF: a bound room that has not opted in still ignores @everyone,
+        # preserving Discord's deliberate reserved-mention exclusion.
+        common.set_chat_binding(common.load_config(), "room", "22", ["jeeves"], guild_id="1")
+        message = {
+            "id": "997",
+            "guild_id": "1",
+            "channel_id": "22",
+            "content": "@everyone please surface",
+            "mentions": [],
+            "mention_everyone": True,
+            "author": {"id": "u-97", "username": "charlie"},
+        }
+
+        with mock.patch.object(common, "deliver_session_message") as deliver_session_message:
+            outcome = gateway_service.process_inbound_message(message, bot_user_id="999")
+
+        self.assertEqual(outcome["status"], "ignored")
+        self.assertEqual(outcome["reason"], "not_mentioned")
+        deliver_session_message.assert_not_called()
+
+    def test_process_inbound_room_message_ignores_role_mention_without_optin(self) -> None:
+        # DEFAULT-OFF: without opt-in, a role mention is ignored AND the bot's
+        # guild member is never fetched (no API call for the role lookup).
+        common.set_chat_binding(common.load_config(), "room", "22", ["jeeves"], guild_id="1")
+        message = {
+            "id": "998",
+            "guild_id": "1",
+            "channel_id": "22",
+            "content": "<@&777> all mayors",
+            "mentions": [],
+            "mention_everyone": False,
+            "mention_roles": ["777"],
+            "author": {"id": "u-98", "username": "charlie"},
+        }
+
+        with mock.patch.object(common, "load_bot_token", return_value="tok"), mock.patch.object(
+            common, "discord_api_request"
+        ) as api, mock.patch.object(common, "deliver_session_message") as deliver_session_message:
+            outcome = gateway_service.process_inbound_message(message, bot_user_id="999")
+
+        self.assertEqual(outcome["status"], "ignored")
+        self.assertEqual(outcome["reason"], "not_mentioned")
+        deliver_session_message.assert_not_called()
+        api.assert_not_called()
 
     def test_process_inbound_ambient_room_message_routes_targeted_alias_without_bot_mention(self) -> None:
         common.set_chat_binding(


### PR DESCRIPTION
## TL;DR

**Default behavior is unchanged.** This adds an *opt-in, default-off* per-binding
flag so a `bind-room` session can choose to wake on `@everyone` / `@here` and
`@role` mentions. Rooms that don't opt in keep ignoring them exactly as today.

## Problem

A channel bound with `gc discord bind-room` responds to a direct `@Bot` mention
but never to `@everyone` / `@here` or to `@role` — including the bot's own
auto-created **managed role** (Discord makes a same-named integration role per
bot). Discord reports these outside `mentions[]`:

- `@everyone` / `@here` → the top-level boolean `mention_everyone`,
- `@role` → `mention_roles[]` (role ids),

and the gateway only checks `mentions[]` (the `@@alias` gate also excludes the
reserved `{everyone, here}`). These exclusions are deliberate — `@everyone` is
usually meant for humans and is noisy in busy servers — so the fix must be
**opt-in**, not a default change.

## Design (opt-in, default-off)

New per-binding room policy flag **`broadcast_mentions_enabled`** (default
`false`), set via a new bind-room flag:

```
gc discord bind-room --enable-broadcast-mentions <channel> <session...>
```

When enabled on a binding:

- `@everyone` / `@here` wake the bound session(s);
- `@role` wakes them **only when the bot actually holds the mentioned role** —
  its managed role, or a shared role (e.g. a `Mayor` role) assigned to it.

All three are gated behind the same flag for consistency (even though `@role` is
already membership-scoped).

## Changes

- `discord_intake_common.py` — `broadcast_mentions_enabled` added to the room
  peer policy default (`false`) and normalization.
- `discord_chat_bind.py` + `commands/bind-room/help.md` —
  `--enable-broadcast-mentions` / `--disable-broadcast-mentions`.
- `discord_gateway_service.py` — `bound_room_wakes_on_broadcast_mention()` runs
  only when the message has a broadcast/role mention, the channel has an
  explicit room binding, and that binding opted in. The bot's own roles are
  fetched once via `GET /guilds/{guild}/members/{bot}` and cached (TTL +
  per-key fetch lock + prune, mirroring `load_channel_info`); the member lookup
  happens only for an opted-in room receiving a role mention. API errors are
  swallowed (treated as "no roles").

## Why it's safe

- **Default off** — preserves Discord's deliberate exclusion for every room that
  doesn't opt in; existing installs are unaffected.
- `@everyone` is **permission-aware** (Discord only sets `mention_everyone` when
  the author may mention everyone).
- `@role` is **scoped by membership** — a role ping only reaches bots that hold
  the role.
- Single-member GET needs no privileged `GUILD_MEMBERS` intent.
- Bot-authored messages are still dropped at intake; unbound channels still
  resolve to `rejected_unbound`.

## Out of scope

- Launcher rooms (`enable-room-launch`) still require an explicit `@@handle`;
  this targets the `bind-room` model.

## Tests

`python3 -m pytest discord/tests -q` — all pass (verified locally with unittest:
**272 tests**, OK). New coverage:

- opt-in on: `@everyone`, `@here`, `@role` (managed + shared) wake / broadcast;
- **default off: `@everyone` and `@role` are ignored without the flag** (and the
  member lookup is not even performed);
- role the bot lacks is ignored; loader caches + swallows API errors;
- the `--enable-broadcast-mentions` bind flag sets the policy (and is off by
  default).
