### PR TITLE
fix(deacon): skip duplicate patrol-wisp pour on restart via startup open-check + loop-scoped queries

### DIFF
--- a/gastown/agents/deacon/prompt.template.md
+++ b/gastown/agents/deacon/prompt.template.md
@@ -54,22 +54,39 @@ Your formula: `mol-deacon-patrol`
 > **The Universal Propulsion Principle: If you find something on your hook, YOU RUN IT.**
 
 ```bash
-# Step 1: Check for assigned work
+# Resolve your assignee identity once. GC_ALIAS and GC_AGENT are equivalent for
+# a singleton patrol session; resolve a single ASSIGNEE so every wisp lookup
+# and assignment below uses the same value (no GC_ALIAS/GC_AGENT skew).
+ASSIGNEE=${GC_ALIAS:-$GC_AGENT}
+
+# Step 1: Check for assigned in-progress work
 {{ .AssignedInProgressQuery }}
 
-# Step 2: Nothing? Check mail for attached work
+# Step 2: Already have a patrol wisp queued? A prior cycle's next-iteration
+# pours the successor as an OPEN wisp. The in-progress check above does not
+# see an open wisp, so on a fresh restart — without this guard — you would
+# pour a DUPLICATE and the open successor would leak (gc-fph55). Patrol wisps
+# are issue_type=molecule; narrow by title (server prefilter + exact jq match)
+# so this matches only THIS patrol loop, never other molecule work assigned
+# to you.
+EXISTING_WISP=$(gc bd list --assignee="$ASSIGNEE" --status=open,in_progress --type=molecule --title="mol-deacon-patrol" --json | jq -r 'map(select(.title=="mol-deacon-patrol"))[0].id // empty')
+
+# Step 3: Nothing in progress? Check mail for attached work
 gc mail inbox
 
-# Step 3: Still nothing? Create patrol wisp (root-only — no child step beads)
-NEW_WISP=$(gc bd mol wisp mol-deacon-patrol --root-only --var binding_prefix={{ .BindingPrefix }} --json | jq -r '.new_epic_id')
-gc bd update "$NEW_WISP" --assignee="$GC_ALIAS"
+# Step 4: No assigned work AND no queued patrol wisp? Create one (root-only —
+# no child step beads). Skip the pour when a wisp already exists (idempotent).
+if [ -z "$EXISTING_WISP" ]; then
+  NEW_WISP=$(gc bd mol wisp mol-deacon-patrol --root-only --var binding_prefix={{ .BindingPrefix }} --json | jq -r '.new_epic_id')
+  gc bd update "$NEW_WISP" --assignee="$ASSIGNEE"
+fi
 
-# Step 4: Read the formula recipe — these are the steps to execute
+# Step 5: Read the formula recipe — these are the steps to execute
 # (Use 'gc bd formula show' for the recipe on disk; 'gc bd mol show' is
 #  for poured molecule instances, not formulas, and will say 'not found'.)
 gc bd formula show mol-deacon-patrol
 
-# Step 5: Execute — work through the steps in order
+# Step 6: Execute — work through the steps in order
 ```
 
 **Hook -> Read formula steps (`gc bd formula show <name>`) -> Follow in order -> pour next iteration -> run `gc hook`.**
@@ -87,18 +104,19 @@ without running `next-iteration` (crash recovery or formula misread).
 If `next-iteration` already ran, do not pour again; run `gc hook`.
 
 ```bash
+ASSIGNEE=${GC_ALIAS:-$GC_AGENT}
 CURRENT_WISP=${GC_BEAD_ID:-}
 if [ -z "$CURRENT_WISP" ]; then
-  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
+  CURRENT_WISP=$(gc bd list --assignee="$ASSIGNEE" --status=in_progress --type=molecule --title="mol-deacon-patrol" --json | jq -r 'map(select(.title=="mol-deacon-patrol"))[0].id // empty')
 fi
-ASSIGNED_WISP=$(gc bd list --assignee="$GC_AGENT" --status=open --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
+ASSIGNED_WISP=$(gc bd list --assignee="$ASSIGNEE" --status=open --type=molecule --title="mol-deacon-patrol" --json | jq -r 'map(select(.title=="mol-deacon-patrol"))[0].id // empty')
 if [ -n "$CURRENT_WISP" ] && [ -z "$ASSIGNED_WISP" ]; then
   NEXT=$(gc bd mol wisp mol-deacon-patrol --root-only --var binding_prefix={{ .BindingPrefix }} --json | jq -r '.new_epic_id // empty')
   if [ -z "$NEXT" ]; then
     echo "Could not pour next deacon wisp; not burning."
     exit 1
   fi
-  if ! gc bd update "$NEXT" --assignee="$GC_AGENT"; then
+  if ! gc bd update "$NEXT" --assignee="$ASSIGNEE"; then
     echo "Could not assign next deacon wisp; not burning."
     exit 1
   fi
@@ -111,7 +129,7 @@ elif [ -z "$ASSIGNED_WISP" ]; then
     echo "Could not bootstrap next deacon wisp."
     exit 1
   fi
-  if ! gc bd update "$NEXT" --assignee="$GC_AGENT"; then
+  if ! gc bd update "$NEXT" --assignee="$ASSIGNEE"; then
     echo "Could not assign bootstrap deacon wisp."
     exit 1
   fi

--- a/gastown/formulas/mol-deacon-patrol.toml
+++ b/gastown/formulas/mol-deacon-patrol.toml
@@ -427,7 +427,7 @@ Handle any urgent messages that arrived during patrol. Archive the rest.
 ```bash
 CURRENT_WISP=${GC_BEAD_ID:-}
 if [ -z "$CURRENT_WISP" ]; then
-  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
+  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --title="mol-deacon-patrol" --json | jq -r 'map(select(.title=="mol-deacon-patrol"))[0].id // empty')
 fi
 
 NEXT=$(gc bd mol wisp mol-deacon-patrol --root-only --var binding_prefix='{{binding_prefix}}' --json | jq -r '.new_epic_id // empty')

--- a/gastown/tests/test_deacon_patrol_wisp.sh
+++ b/gastown/tests/test_deacon_patrol_wisp.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# Regression test for gc-fph55: deacon patrol wisps accumulating as duplicate
+# OPEN molecules on fresh restart.
+#
+# Two layers:
+#   1. Static guards on the real formula + prompt — assert the patrol-wisp
+#      queries never use the invalid `--type=wisp` (matches nothing) and are
+#      title-narrowed to this patrol loop, and that the Startup Protocol gates
+#      its pour on an existing-wisp check (the gc-fph55 bootstrap fix).
+#   2. Behavioural idempotency — drive a mirror of the Startup Protocol pour
+#      decision against a stubbed `gc` ledger and assert it never pours a
+#      duplicate when a patrol wisp already exists (and is a no-op on re-run).
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+FORMULA="$ROOT/gastown/formulas/mol-deacon-patrol.toml"
+PROMPT="$ROOT/gastown/agents/deacon/prompt.template.md"
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+# ---------------------------------------------------------------------------
+# Layer 1: static guards on the real artifacts
+# ---------------------------------------------------------------------------
+test_no_invalid_wisp_type_filter() {
+    # `--type=wisp` is not a valid bd issue type; the query errors and matches
+    # nothing, so the open-successor / current-wisp lookups silently return
+    # empty and a duplicate is poured. Patrol wisp roots are issue_type=molecule.
+    if grep -n -- '--type=wisp' "$FORMULA" "$PROMPT"; then
+        fail "found invalid --type=wisp filter (patrol wisps are issue_type=molecule)"
+    fi
+}
+
+test_patrol_wisp_queries_are_title_narrowed() {
+    # Every molecule lookup that resolves a patrol wisp must narrow by title to
+    # this patrol loop, so reconcile/idempotency logic never matches unrelated
+    # molecule work that may be assigned to the deacon (gc-fph55 caveat).
+    local untargeted
+    untargeted=$(grep -hn -- '--type=molecule' "$FORMULA" "$PROMPT" \
+        | grep -- 'gc bd list' \
+        | grep -v -- '--title="mol-deacon-patrol"' || true)
+    if [ -n "$untargeted" ]; then
+        fail "molecule wisp query missing --title=\"mol-deacon-patrol\" narrow:
+$untargeted"
+    fi
+}
+
+test_startup_pour_is_guarded() {
+    # The Startup Protocol must look for an already-queued OPEN patrol wisp and
+    # skip the pour when one exists — otherwise a fresh restart re-pours a
+    # duplicate (the core gc-fph55 bootstrap bug).
+    grep -q 'EXISTING_WISP=' "$PROMPT" \
+        || fail "Startup Protocol missing EXISTING_WISP open-successor check"
+    grep -q 'status=open,in_progress' "$PROMPT" \
+        || fail "EXISTING_WISP check must include open status (not in_progress only)"
+    grep -q 'if \[ -z "\$EXISTING_WISP" \]; then' "$PROMPT" \
+        || fail "Startup pour must be gated on an empty EXISTING_WISP"
+}
+
+test_assignee_is_unified() {
+    # GC_ALIAS and GC_AGENT must not be mixed in the prompt's wisp lookups —
+    # resolve one ASSIGNEE and use it everywhere (avoids GC_ALIAS/GC_AGENT skew).
+    grep -q 'ASSIGNEE=${GC_ALIAS:-$GC_AGENT}' "$PROMPT" \
+        || fail "prompt must resolve a single ASSIGNEE=\${GC_ALIAS:-\$GC_AGENT}"
+    if grep -- 'gc bd list' "$PROMPT" | grep -- '--type=molecule' | grep -qE -- '--assignee="\$GC_(ALIAS|AGENT)"'; then
+        fail "prompt molecule wisp queries must use --assignee=\"\$ASSIGNEE\", not raw GC_ALIAS/GC_AGENT"
+    fi
+}
+
+test_title_match_is_exact() {
+    # Belt-and-suspenders: --title= is a case-insensitive substring prefilter;
+    # an exact jq select guards against substring false-matches.
+    local q
+    for q in "$FORMULA" "$PROMPT"; do
+        if grep -- 'gc bd list' "$q" | grep -- '--title="mol-deacon-patrol"' \
+            | grep -v -- 'select(.title=="mol-deacon-patrol")' | grep -q .; then
+            fail "title-narrowed query in $q missing exact jq select(.title==...)"
+        fi
+    done
+}
+
+# ---------------------------------------------------------------------------
+# Layer 2: behavioural idempotency of the Startup pour decision
+# ---------------------------------------------------------------------------
+# Stubs `gc` with a file-backed ledger of patrol wisps and runs a mirror of the
+# Startup Protocol decision (Step 2 + Step 4 in the prompt — kept in sync by the
+# static guards above). Asserts the decision converges to exactly one wisp and
+# never pours a duplicate.
+write_gc_stub() {
+    local bin="$1"
+    mkdir -p "$bin"
+    cat >"$bin/gc" <<'SH'
+#!/usr/bin/env sh
+# Minimal gc-bd ledger stub. Ledger file = one wisp id per line (all "open").
+LEDGER="$GC_TEST_LEDGER"
+case "$1 $2 ${3:-}" in
+  "bd list "*)
+    # Emit the ledger as a JSON array of {"id": "..."} objects.
+    if [ ! -s "$LEDGER" ]; then printf '[]'; exit 0; fi
+    out=""
+    while IFS= read -r id; do
+      [ -n "$id" ] || continue
+      out="$out{\"id\":\"$id\",\"title\":\"mol-deacon-patrol\"},"
+    done < "$LEDGER"
+    printf '[%s]' "${out%,}"
+    ;;
+  "bd mol wisp")
+    n=$(( $(wc -l < "$LEDGER" 2>/dev/null || echo 0) + 1 ))
+    id="gc-wisp-stub$n"
+    printf '%s\n' "$id" >> "$LEDGER"
+    printf '{"new_epic_id":"%s"}' "$id"
+    ;;
+  "bd mol burn")
+    id="$4"
+    grep -v -x "$id" "$LEDGER" > "$LEDGER.tmp" 2>/dev/null || :
+    mv "$LEDGER.tmp" "$LEDGER" 2>/dev/null || :
+    ;;
+  "bd update "*) : ;;
+  "mail inbox"*) : ;;
+  *) printf '[]' ;;
+esac
+SH
+    chmod +x "$bin/gc"
+}
+
+# Mirror of the prompt Startup Protocol pour decision (Step 2 + Step 4).
+# The static guards (Layer 1) assert the real prompt keeps this shape.
+startup_pour_decision() {
+    ASSIGNEE=${GC_ALIAS:-$GC_AGENT}
+    EXISTING_WISP=$(gc bd list --assignee="$ASSIGNEE" --status=open,in_progress --type=molecule --title="mol-deacon-patrol" --json | jq -r 'map(select(.title=="mol-deacon-patrol"))[0].id // empty')
+    gc mail inbox
+    if [ -z "$EXISTING_WISP" ]; then
+        NEW_WISP=$(gc bd mol wisp mol-deacon-patrol --root-only --var binding_prefix=test. --json | jq -r '.new_epic_id')
+        gc bd update "$NEW_WISP" --assignee="$ASSIGNEE"
+    fi
+}
+
+ledger_count() { awk 'NF{c++} END{print c+0}' "$1" 2>/dev/null; }
+
+test_startup_is_idempotent() {
+    command -v jq >/dev/null 2>&1 || { echo "SKIP: jq not installed"; return 0; }
+    local tmp bin ledger
+    tmp=$(mktemp -d)
+    bin="$tmp/bin"
+    ledger="$tmp/ledger"
+    : > "$ledger"
+    write_gc_stub "$bin"
+
+    # Empty ledger -> pours exactly one.
+    ( export PATH="$bin:$PATH" GC_TEST_LEDGER="$ledger" GC_ALIAS=deacon; startup_pour_decision )
+    [ "$(ledger_count "$ledger")" -eq 1 ] || fail "empty start should pour exactly 1, got $(ledger_count "$ledger")"
+
+    # An open wisp already exists -> must NOT pour a duplicate.
+    ( export PATH="$bin:$PATH" GC_TEST_LEDGER="$ledger" GC_ALIAS=deacon; startup_pour_decision )
+    [ "$(ledger_count "$ledger")" -eq 1 ] || fail "existing wisp: must not pour duplicate, got $(ledger_count "$ledger")"
+
+    # Idempotency-twice: a third run is still a no-op.
+    ( export PATH="$bin:$PATH" GC_TEST_LEDGER="$ledger" GC_ALIAS=deacon; startup_pour_decision )
+    [ "$(ledger_count "$ledger")" -eq 1 ] || fail "idempotency: third run should stay at 1, got $(ledger_count "$ledger")"
+}
+
+test_no_invalid_wisp_type_filter
+test_patrol_wisp_queries_are_title_narrowed
+test_startup_pour_is_guarded
+test_assignee_is_unified
+test_title_match_is_exact
+test_startup_is_idempotent
+
+echo "PASS: $(basename "${BASH_SOURCE[0]}")"


### PR DESCRIPTION
## What & why

We run a local gastown city and observed the deacon's patrol wisps accumulating as duplicate **open** `mol-deacon-patrol` molecules — at one point the deacon held two open patrol wisps at once (both `issue_type=molecule`, neither ever `in_progress`). After investigating the gastown-pack deacon logic I traced the cause and a fix, so I'm submitting it here. (More detail in #145.)

Root cause:
- The Startup Protocol resolves assigned work with an **in-progress-only** query, but a patrol loop pours its successor as an **open** wisp. On a fresh restart the in-progress check doesn't see the open successor, so the deacon pours a *second* one and the original leaks.
- The patrol wisp queries match bare `--type=molecule` + assignee — i.e. *any* molecule assigned to the deacon, not just this patrol loop.

## What this PR does (deacon only, non-destructive)

- **Startup open-check**: before pouring, look for an existing `open,in_progress` patrol molecule (title-scoped) and skip the pour if one exists — so a restart adopts the open successor instead of pouring a duplicate.
- **Scope queries to the loop**: add `--title="mol-deacon-patrol"` (+ exact match in `jq`) to the patrol wisp queries.
- Resolve the assignee once (`ASSIGNEE=${GC_ALIAS:-$GC_AGENT}`) for consistent lookups.
- Add a shell test (`gastown/tests/test_deacon_patrol_wisp.sh`): static guards on the real files + a behavioural idempotency check; it fails against pre-fix `main`.

It is intentionally **non-destructive** (no burn): it stops *new* duplication but does not clean up already-leaked duplicates, and leaves refinery untouched — those are the guarded follow-up stages described in #145.

## Relationship to existing work — maintainers, please judge

This is based on #121 (`--type=molecule`). While preparing it I noticed the change area overlaps two open PRs:
- **#36** — marks the freshly-created wisp `in_progress` so the next cycle resumes it.
- **#134** — drops `--type=wisp` from the No-Idle scan queries.

This PR takes a different approach (an explicit open-successor check, on top of #121's `--type=molecule`), so it touches some of the same lines. I'm an external contributor tracking a behavior issue in my local city, and I don't yet know how PRs are being triaged in this repo (no CONTRIBUTING guide that I could find). I'm submitting this for your consideration only — please judge whether/how to adopt it given #121, #36 and #134. Happy to rework, split, or close as you see fit.

Part of #145.
