### PR TITLE
fix(discord): warn when workspace name has no matching running city

### DIFF
--- a/discord/doctor/check-workspace-scope.sh
+++ b/discord/doctor/check-workspace-scope.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+set -eu
+
+# Verify the discord-gateway can scope its GC-API calls. The gateway addresses
+# the supervisor API as /v0/city/<workspace-name>/sessions, where <workspace-name>
+# is resolved from city.toml [workspace] name, then .gc/site.toml workspace_name,
+# then the city directory basename. If the resolved name does not match a RUNNING
+# city in the supervisor's /v0/cities, scope discovery returns empty, the gateway
+# health-probes the UNSCOPED /v0/sessions (404), and pins itself at 503 — inbound
+# DMs/mentions then silently stop delivering. This check flags that misconfig.
+
+scripts_dir=$(CDPATH= cd -- "$(dirname -- "$0")/../scripts" && pwd)
+
+python3 - "$scripts_dir" <<'PY'
+import json
+import sys
+import urllib.error
+import urllib.request
+
+sys.path.insert(0, sys.argv[1])
+import discord_intake_common as common
+
+# A missing/unreadable city.toml is itself a valid v2 case (workspace identity
+# may live only in .gc/site.toml), so degrade to an empty config and let the
+# resolver fall back to site.toml / the city-dir basename.
+try:
+    cfg = common.load_city_toml()
+except Exception:  # noqa: BLE001 - diagnostic must not crash on config load
+    cfg = {}
+name = common.resolved_workspace_name(cfg)
+if not name:
+    print("discord scope: could not resolve a workspace name")
+    print("Set [workspace] name in city.toml, workspace_name in .gc/site.toml, or run from the city directory.")
+    sys.exit(2)
+
+base = common.DEFAULT_SUPERVISOR_API_BASE
+try:
+    req = urllib.request.Request(
+        base + "/v0/cities",
+        headers={"Accept": "application/json", "User-Agent": "gas-city-discord/0.1", "X-GC-Request": "true"},
+        method="GET",
+    )
+    with urllib.request.urlopen(req, timeout=2.0) as resp:
+        items = json.loads(resp.read().decode("utf-8")).get("items", [])
+except (urllib.error.URLError, urllib.error.HTTPError, json.JSONDecodeError, OSError) as exc:
+    print(f"discord scope: supervisor API at {base} unreachable; cannot verify scope ({exc})")
+    print("Start the supervisor, then re-run this check.")
+    sys.exit(2)
+
+running = sorted(
+    n
+    for n in (str(i.get("name", "")).strip() for i in items if isinstance(i, dict) and i.get("running") is not False)
+    if n
+)
+if name in running:
+    print(f"discord scope OK: workspace {name!r} matches a running city")
+    sys.exit(0)
+
+print(f"discord scope: workspace name {name!r} does not match any running city (running: {', '.join(running) or 'none'})")
+print("The discord-gateway will health-probe the unscoped /v0/sessions (404) and stay 503; inbound DMs/mentions will not deliver.")
+print("Fix: set [workspace] name (city.toml) or workspace_name (.gc/site.toml) to a running city, then `gc service restart discord-gateway`.")
+sys.exit(2)
+PY

--- a/discord/scripts/discord_intake_common.py
+++ b/discord/scripts/discord_intake_common.py
@@ -12,6 +12,7 @@ import pathlib
 import re
 import socket
 import subprocess
+import sys
 import tempfile
 import time
 import tomllib
@@ -1983,6 +1984,19 @@ def normalize_gc_api_bind(value: Any) -> str:
 
 _supervisor_scope_cache: dict[str, tuple[float, str]] = {}  # workspace_name → (timestamp, scope)
 _SCOPE_CACHE_TTL = 60.0  # seconds
+_warned_scope_messages: set[str] = set()
+
+
+def _warn_scope_once(message: str) -> None:
+    """Emit a scope-misconfig warning to stderr at most once per distinct message.
+
+    Scope discovery runs on every API call (after a 60s cache miss), so warn-once
+    dedup keeps a persistent misconfig from flooding the gateway log.
+    """
+    if message in _warned_scope_messages:
+        return
+    _warned_scope_messages.add(message)
+    print(f"warning: {message}", file=sys.stderr, flush=True)
 
 
 def resolved_workspace_name(city_cfg: dict[str, Any]) -> str:
@@ -2061,6 +2075,29 @@ def _discover_supervisor_gc_api_scope_uncached(city_cfg: dict[str, Any]) -> str:
             if item.get("running") is False:
                 return ""
             return f"/v0/city/{urllib.parse.quote(workspace_name)}"
+        # A workspace name resolved, but no RUNNING city in /v0/cities matches it.
+        # Scope stays empty, so callers fall back to the unscoped API base — whose
+        # /v0/sessions returns 404. That 404 wedges the discord-gateway health probe
+        # at 503, so inbound DMs/mentions silently stop delivering with no other
+        # signal. Warn (once) so the operator can correct the name instead of
+        # debugging a dead gateway from scratch.
+        running_names = sorted(
+            name
+            for name in (
+                str(it.get("name", "")).strip()
+                for it in items
+                if isinstance(it, dict) and it.get("running") is not False
+            )
+            if name
+        )
+        _warn_scope_once(
+            f"discord-gateway: resolved workspace name {workspace_name!r} does not match "
+            f"any running city in the supervisor (running: {', '.join(running_names) or 'none'}). "
+            "The gateway will health-probe the unscoped /v0/sessions (404) and stay 503, so "
+            "inbound DMs/mentions will not deliver. Set [workspace] name in city.toml (or "
+            "workspace_name in .gc/site.toml) to a running city, or rename the city directory "
+            "to match, then restart the discord-gateway service."
+        )
     return ""
 
 

--- a/discord/tests/test_discord_doctor_scripts.py
+++ b/discord/tests/test_discord_doctor_scripts.py
@@ -36,6 +36,16 @@ class DiscordDoctorScriptTests(unittest.TestCase):
         self.assertEqual(result.returncode, 2)
         self.assertIn("legacy discord-intake state detected", result.stdout)
 
+    def test_workspace_scope_check_flags_unmatched_name(self) -> None:
+        # GC_CITY_ROOT is an empty tempdir, so the resolved workspace name (its
+        # basename) will not match any running city (whether or not a supervisor
+        # is reachable). The check must exit 2 with actionable guidance.
+        script = pathlib.Path(__file__).resolve().parents[1] / "doctor" / "check-workspace-scope.sh"
+        result = subprocess.run([str(script)], capture_output=True, text=True, check=False)
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("discord scope", result.stdout)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/discord/tests/test_discord_intake_common.py
+++ b/discord/tests/test_discord_intake_common.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+from contextlib import redirect_stderr
 import pathlib
 import socket
 import tempfile
@@ -549,6 +550,61 @@ class DiscordIntakeCommonTests(unittest.TestCase):
 
         with mock.patch.object(common.urllib.request, "urlopen", return_value=response):
             self.assertEqual(common.gc_api_base_url(), "http://127.0.0.1:9555")
+
+    def test_scope_mismatch_warns_once_to_stderr(self) -> None:
+        pathlib.Path(self.tempdir.name, "city.toml").write_text(
+            '[workspace]\nname = "gc"\n[api]\nbind = "0.0.0.0"\nport = 9555\n',
+            encoding="utf-8",
+        )
+        common._supervisor_scope_cache.clear()
+        common._warned_scope_messages.clear()
+
+        def make_response(*_args, **_kwargs):
+            response = mock.Mock()
+            response.__enter__ = mock.Mock(
+                return_value=mock.Mock(
+                    read=mock.Mock(return_value=b'{"items":[{"name":"other-city","running":true}]}')
+                )
+            )
+            response.__exit__ = mock.Mock(return_value=False)
+            return response
+
+        stderr = io.StringIO()
+        with mock.patch.object(common.urllib.request, "urlopen", side_effect=make_response):
+            with redirect_stderr(stderr):
+                # Empty scope is NOT cached, so each call re-runs uncached discovery.
+                self.assertEqual(common.discover_supervisor_gc_api_scope(common.load_city_toml()), "")
+                self.assertEqual(common.discover_supervisor_gc_api_scope(common.load_city_toml()), "")
+
+        output = stderr.getvalue()
+        self.assertIn("does not match any running city", output)
+        self.assertIn("'gc'", output)
+        self.assertIn("other-city", output)
+        # warn-once: a persistent misconfig must not flood the log across calls.
+        self.assertEqual(output.count("does not match any running city"), 1)
+
+    def test_scope_match_emits_no_warning(self) -> None:
+        pathlib.Path(self.tempdir.name, "city.toml").write_text(
+            '[workspace]\nname = "gc"\n',
+            encoding="utf-8",
+        )
+        common._supervisor_scope_cache.clear()
+        common._warned_scope_messages.clear()
+        response = mock.Mock()
+        response.__enter__ = mock.Mock(
+            return_value=mock.Mock(read=mock.Mock(return_value=b'{"items":[{"name":"gc","running":true}]}'))
+        )
+        response.__exit__ = mock.Mock(return_value=False)
+
+        stderr = io.StringIO()
+        with mock.patch.object(common.urllib.request, "urlopen", return_value=response):
+            with redirect_stderr(stderr):
+                self.assertEqual(
+                    common.discover_supervisor_gc_api_scope(common.load_city_toml()),
+                    "/v0/city/gc",
+                )
+
+        self.assertEqual(stderr.getvalue(), "")
 
     def test_gc_api_request_routes_through_supervisor_city_scope(self) -> None:
         pathlib.Path(self.tempdir.name, "city.toml").write_text(


### PR DESCRIPTION
# fix(discord): warn when workspace name has no matching running city

## Problem
The `discord-gateway` addresses the supervisor API as `/v0/city/<workspace-name>/sessions`, where `<workspace-name>` comes from `resolved_workspace_name()` (city.toml `[workspace] name` → `.gc/site.toml workspace_name` → city-dir basename).

When the resolved name matches **no running city** in `/v0/cities`, `discover_supervisor_gc_api_scope()` returns `""`, callers fall back to the **unscoped** API base, and `GET /v0/sessions` returns **404**. The gateway treats that 404 as API-unhealthy and pins itself at **503** — so inbound DMs/mentions **silently stop delivering**, with no error explaining why. Operators are left debugging a dead gateway from scratch (the forum-sweep poll is the only inbound that still works).

This is easy to hit after a v2 upgrade: `gc init` no longer writes `workspace.name` to `city.toml`, so a city may carry its identity only in `.gc/site.toml` — and a **stale pack build** (pre-`resolved_workspace_name`) then resolves an empty name and 404s. It cost us a multi-hour debug.

## Change
- **Warning (the core fix).** In `_discover_supervisor_gc_api_scope_uncached`, when a workspace name resolved but matched no running city, emit a one-time stderr warning (warn-once dedup — discovery reruns every 60s) naming the resolved name, the running cities, the 404→503 consequence, and the fix. **Control flow is unchanged** — it still returns `""` and falls back to the direct port, so existing behavior and tests are preserved.
- **Doctor check.** `discord/doctor/check-workspace-scope.sh` proactively verifies the resolved name matches a running city, distinguishes an unreachable supervisor from a true mismatch, and exits 2 with actionable guidance.
- **Tests.** warn-once-on-mismatch, no-warn-on-match, and the doctor check (162 net lines; full discord suite stays green — 262 tests).

## Not included (deliberately)
A "single running city → self-heal to it" fallback was considered and dropped: `test_gc_api_base_url_falls_back_when_supervisor_city_missing` shows the maintainers intentionally fall back to the direct port on a name mismatch rather than guess a city. This PR keeps that contract and only makes the failure **loud** instead of silent.

## Test
```
cd discord && python3 -m unittest discover -s tests   # 262 tests, OK
```
