### PR TITLE
feat(discord): force-wake target session on inbound human DM

### DIFF
--- a/discord/scripts/discord_gateway_service.py
+++ b/discord/scripts/discord_gateway_service.py
@@ -1577,6 +1577,18 @@ def process_inbound_message(message: dict[str, Any], bot_user_id: str) -> dict[s
                         "response": response,
                     }
                 )
+                # Force-wake on an inbound HUMAN DM so it pushes in live rather
+                # than riding the target's next scheduled wake (the deferred-
+                # reminder latency a DM hits when the target is idle between
+                # turns). DM-scoped (binding kind == "dm") so we never wake the
+                # fleet on room/channel traffic. Best-effort + double-guarded:
+                # a wake miss (or a wake-resistant session) never affects the
+                # delivery that already succeeded above.
+                if str(binding.get("kind", "")).strip().lower() == "dm":
+                    try:
+                        updated_targets[-1]["wake"] = common.wake_session(target)
+                    except Exception as wake_exc:  # delivery already succeeded; wake is advisory
+                        updated_targets[-1]["wake"] = {"status": "wake_error", "error": str(wake_exc)}
             except common.GCAPIError as exc:
                 failures += 1
                 updated_targets.append(

--- a/discord/scripts/discord_intake_common.py
+++ b/discord/scripts/discord_intake_common.py
@@ -4834,6 +4834,34 @@ def deliver_session_message(
     return payload
 
 
+def wake_session(
+    session_name: str,
+    timeout: float = GC_API_REQUEST_TIMEOUT_SECONDS,
+) -> dict[str, Any]:
+    """Best-effort force-wake of a session via the gc API.
+
+    POSTs to /v0/session/<name>/wake (no body; 200 on success) to push an
+    inbound HUMAN DM into a sleeping target immediately, rather than letting
+    it wait for the target's next scheduled wake (the deferred-reminder
+    latency a human DM hits when the target is idle between turns).
+
+    Wake is ADVISORY: an API error — or a wake-resistant deep-idle /
+    stale-'active' session — returns a status dict and never raises, so a
+    wake miss can never fail the delivery that preceded it.
+    """
+    name = str(session_name).strip()
+    if not name:
+        return {}
+    path = f"/v0/session/{urllib.parse.quote(name, safe='')}/wake"
+    try:
+        payload = gc_api_request("POST", path, timeout=timeout)
+    except GCAPIError as exc:
+        return {"status": "wake_failed", "error": str(exc)}
+    if not isinstance(payload, dict):
+        return {"status": "woken"}
+    return payload
+
+
 def command_name(config: dict[str, Any]) -> str:
     return str(normalize_config(config).get("app", {}).get("command_name", COMMAND_NAME_DEFAULT)).strip() or COMMAND_NAME_DEFAULT
 

--- a/discord/tests/test_discord_intake_common.py
+++ b/discord/tests/test_discord_intake_common.py
@@ -1932,5 +1932,33 @@ class DiscordIntakeCommonTests(unittest.TestCase):
         sleep.assert_called_once_with(0.0)
 
 
+class WakeSessionTests(unittest.TestCase):
+    def test_wake_session_posts_to_wake_endpoint(self) -> None:
+        with mock.patch.object(common, "gc_api_request", return_value={"status": "ok"}) as api:
+            result = common.wake_session("gastown.mayor")
+        api.assert_called_once()
+        args, _kwargs = api.call_args
+        self.assertEqual(args[0], "POST")
+        self.assertEqual(args[1], "/v0/session/gastown.mayor/wake")
+        self.assertEqual(result, {"status": "ok"})
+
+    def test_wake_session_url_quotes_name(self) -> None:
+        with mock.patch.object(common, "gc_api_request", return_value={}) as api:
+            common.wake_session("thriva/devpipeline.backend_dev")
+        args, _kwargs = api.call_args
+        self.assertEqual(args[1], "/v0/session/thriva%2Fdevpipeline.backend_dev/wake")
+
+    def test_wake_session_best_effort_on_api_error(self) -> None:
+        with mock.patch.object(common, "gc_api_request", side_effect=common.GCAPIError("boom")):
+            result = common.wake_session("gastown.mayor")
+        self.assertEqual(result.get("status"), "wake_failed")
+
+    def test_wake_session_empty_name_is_noop(self) -> None:
+        with mock.patch.object(common, "gc_api_request") as api:
+            result = common.wake_session("   ")
+        api.assert_not_called()
+        self.assertEqual(result, {})
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem
A human DM delivered to a sleeping/idle session via the gc `/submit` API is enqueued and surfaces at the target's **next scheduled wake** — a deferred-reminder latency of up to a full sweep interval. On a human's primary channel this reads as "my message didn't go through live."

## Change
- **`common.wake_session(name)`**: best-effort `POST /v0/session/<name>/wake` (nil body → 200; the gc force-wake endpoint). *Advisory* — an API error or a wake-resistant deep-idle session returns a status dict and never raises, so a wake miss can never fail the delivery that preceded it.
- **Gateway**: after a successful human-message delivery, if the binding is a DM (`kind == "dm"`), call `wake_session(target)` to force-wake the target so the DM is processed immediately. **DM-scoped** so agent/room/channel traffic never wakes the fleet; **double-guarded** (the helper is best-effort *and* the call site is wrapped) so it can never break delivery. The wake result is recorded in the ingress receipt for observability.

## Tests
- +4 `wake_session` unit tests (endpoint path, URL-quoting, best-effort-on-error, empty-name no-op).
- Full discord suite green: **181 tests**.

## Notes
Verified live on a Gas City deployment: the `/wake` endpoint wakes a sleeping session (asleep → active), and the gateway invokes it only on DM-kind bindings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)