### PR TITLE
fix(slack-pack): newest-first transcript lookup in find_latest_inbound_message_id_for_session (redo of #64)

### DIFF
--- a/slack-full/scripts/slack_intake_common.py
+++ b/slack-full/scripts/slack_intake_common.py
@@ -410,13 +410,18 @@ def find_latest_inbound_message_id_for_session(
     The lookup chain:
       1. Find the latest extmsg.inbound event targeting this session.
       2. Read its conversation_id from the event payload.
-      3. Query the transcript for that conversation, find the latest entry
-         whose Kind=="inbound", and return its ProviderMessageID.
+      3. Query the transcript for that conversation newest-first
+         (order=desc, gascity#3128), take the first entry whose
+         Kind=="inbound", and return its ProviderMessageID.
 
     Two queries (event + transcript) because the inbound event payload
     intentionally does NOT carry message_id — that field lives in the
     transcript and is the canonical source. See engdocs/architecture/
     api-control-plane.md for the typed-wire rationale.
+
+    The transcript query MUST be newest-first: the endpoint's oldest-first
+    default with a bounded limit hides the most recent inbound on busy
+    conversations, threading the reply under a stale message.
     """
     event = find_latest_inbound_for_session(session_id)
     if event is None:
@@ -432,7 +437,10 @@ def find_latest_inbound_message_id_for_session(
     # primary use case; fall through to dm if no rows come back.
     items: list[dict[str, Any]] = []
     for kind in ("room", "dm"):
-        qs = f"scope_id={gc_city_name()}&provider={provider}&conversation_id={conv_id}&kind={kind}"
+        qs = (
+            f"scope_id={gc_city_name()}&provider={provider}"
+            f"&conversation_id={conv_id}&kind={kind}&order=desc&limit=500"
+        )
         if workspace:
             qs += f"&account_id={workspace}"
         try:
@@ -442,7 +450,8 @@ def find_latest_inbound_message_id_for_session(
         items = res.get("items") or []
         if items:
             break
-    for entry in reversed(items):
+    # items are newest-first (order=desc): the first inbound is the latest.
+    for entry in items:
         if (entry.get("Kind") or entry.get("kind")) == "inbound":
             mid = (entry.get("ProviderMessageID") or entry.get("provider_message_id") or "").strip()
             if mid:

--- a/slack-full/tests/gc_mock.py
+++ b/slack-full/tests/gc_mock.py
@@ -359,13 +359,26 @@ class GcMock:
         req: http.server.BaseHTTPRequestHandler,
         query: dict[str, str],
     ) -> None:
-        """GET /extmsg/transcript?scope_id=&provider=&conversation_id=&kind=[&account_id=]"""
+        """GET /extmsg/transcript?scope_id=&provider=&conversation_id=&kind=[&account_id=][&order=][&limit=]
+
+        Mirrors the real endpoint's pagination contract (gascity#3128):
+        oldest-first default, ``order=desc``, ``limit`` default 100 /
+        max 500. Faithful truncation is what makes the stale-thread-root
+        regression reproducible in tests.
+        """
         provider = query.get("provider", "")
         conversation_id = query.get("conversation_id", "")
         kind = query.get("kind", "")
         key = (provider, conversation_id, kind)
         with self._lock:
             items = list(self._transcripts.get(key, []))
+        if query.get("order", "asc") == "desc":
+            items.reverse()
+        try:
+            limit = int(query.get("limit", "100"))
+        except ValueError:
+            limit = 100
+        items = items[: min(limit, 500)]
         resp = json.dumps({"items": items}).encode()
         req.send_response(200)
         req.send_header("Content-Type", "application/json")

--- a/slack-full/tests/test_slack_pack_e2e.py
+++ b/slack-full/tests/test_slack_pack_e2e.py
@@ -356,8 +356,8 @@ def test_reply_current_thread_current_pulls_thread_ts_from_transcript(
         kind="room",
     )
     # Seed two transcript entries: an outbound followed by the inbound we
-    # want resolved. --thread-current should walk in reverse and pick
-    # the inbound one.
+    # want resolved. --thread-current receives entries newest-first
+    # (order=desc) and picks the first inbound.
     gc_mock.register_transcript_entry(
         conversation_id="C0THREADCHAN",
         kind="room",
@@ -409,6 +409,73 @@ def test_reply_current_thread_current_pulls_thread_ts_from_transcript(
         f"first transcript lookup must use kind=room; got query={first_transcript.query!r}"
     )
     assert first_transcript.query.get("conversation_id") == "C0THREADCHAN"
+
+
+def test_reply_current_thread_current_finds_newest_inbound_in_large_transcript(
+    gc_mock: GcMock,
+    slack_mock: SlackMock,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--thread-current must resolve the newest inbound on a busy transcript.
+
+    Regression pin for the oldest-first truncation bug (gpk-r89): with the
+    endpoint's oldest-first default and bounded limit, the most recent
+    inbound never appeared in the response on busy conversations and the
+    reply threaded under a stale root. The fix queries ``order=desc``
+    (gascity#3128). 130 entries puts the newest inbound past the
+    endpoint's default limit of 100, which GcMock truncates faithfully.
+    """
+    gc_mock.register_inbound_event(
+        target_session="gc-test-session",
+        conversation_id="C0BUSYCHAN",
+        provider="slack",
+        kind="room",
+    )
+    # 130 entries, oldest..newest. Odd indices inbound, even outbound:
+    # entry 130 (newest) is outbound, entry 129 is the newest inbound.
+    total = 130
+    for i in range(1, total + 1):
+        gc_mock.register_transcript_entry(
+            conversation_id="C0BUSYCHAN",
+            kind="room",
+            provider_message_id=f"1700000000.{i:06d}",
+            message_kind="inbound" if i % 2 else "outbound",
+        )
+    newest_inbound_ts = f"1700000000.{total - 1:06d}"
+
+    rc = _import_reply_current_module()
+    exit_code = rc.main([
+        "--session", "gc-test-session",
+        "--thread-current",
+        "--body", "threading under the newest inbound",
+    ])
+    assert exit_code is None or exit_code == 0
+    capsys.readouterr()  # drain stdout
+
+    slack_calls = slack_mock.calls()
+    assert len(slack_calls) == 1, (
+        f"expected 1 publish, got {len(slack_calls)}: {slack_calls!r}"
+    )
+    assert slack_calls[0].thread_ts == newest_inbound_ts, (
+        f"--thread-current must thread under the newest inbound "
+        f"({newest_inbound_ts}) even when the transcript exceeds the "
+        f"endpoint's default window; got {slack_calls[0].thread_ts!r}"
+    )
+
+    # The lookup must request newest-first explicitly — relying on the
+    # oldest-first default is exactly the regression this test pins.
+    transcript_calls = [
+        c for c in gc_mock.calls() if c.path.endswith("/extmsg/transcript")
+    ]
+    assert transcript_calls, "expected at least one /extmsg/transcript GET"
+    assert transcript_calls[0].query.get("order") == "desc", (
+        f"transcript lookup must use order=desc; got query="
+        f"{transcript_calls[0].query!r}"
+    )
+    assert transcript_calls[0].query.get("limit") == "500", (
+        f"transcript lookup must carry the limit=500 defensive cap; "
+        f"got query={transcript_calls[0].query!r}"
+    )
 
 
 def test_reply_current_resolves_conversation_from_inbound_event(


### PR DESCRIPTION
## Summary
Redo of #64 on a clean base. Fixes newest-first transcript lookup in `find_latest_inbound_message_id_for_session` (consumes gastownhall/gascity#3128) and reconciles slack-pack ↔ slack-full.

## Validation
- 86 slack-full pytests pass (incl. a new 130-entry e2e); review gate re-verified PASS.

Supersedes #64 (stale/conflicting base; this branch is rebased clean on main).
