### PR TITLE
feat(slack-full): transport-level reaction protocol — salvage of #88 onto clean main

### DIFF
--- a/slack-full/README.md
+++ b/slack-full/README.md
@@ -430,10 +430,21 @@ pkill -HUP gc-slack-adapter
 ```
 
 The other three registries — `IDENTITY_STORE_PATH`,
-`HANDLE_ALIAS_STORE_PATH`, and the thread-session store — are written
-in-process by the adapter itself (via `/identity`, `/handle-alias`,
-and the launcher), not by the CLI, so they do not participate in
-SIGHUP reload.
+`HANDLE_ALIAS_STORE_PATH`, and the thread-session store — are
+**adapter-owned**: written in-process by the adapter itself (via
+`/identity`, `/handle-alias`, and the launcher), not by the CLI, so
+they do not participate in SIGHUP reload. Do not hand-edit them while
+the adapter is running — it rewrites them from its in-memory state at
+will, so manual edits are silently overwritten. The five files in the
+table above are the operator-editable surface; everything else under
+the store paths belongs to the adapter.
+
+`apps.json` is the one file written from **both** sides (the CLI's
+`import-app` and the adapter's OAuth callback). The adapter
+generation-stamps its reload snapshots so a SIGHUP racing an OAuth
+callback re-stages instead of rolling the in-memory view back to the
+pre-callback state; if the log shows `apps registry commit skipped`,
+re-send the SIGHUP.
 
 **Consumer-specific** (referenced by deployment scripts and prompts in
 sibling tooling, not by the adapter binary): variables consumed by

--- a/slack-full/README.md
+++ b/slack-full/README.md
@@ -478,7 +478,12 @@ gc reload   # or: gc supervisor reload
 # 5. Verify the service is ready
 gc service list                            # expect: slack proxy_process ready
 curl --unix-socket "$(gc service show slack --json | jq -r .socket)" \
-     http://x/healthz                      # expect: 200 ok
+     http://x/healthz                      # expect: 200, first line "ok",
+                                           # then dispatch_dropped_total=N
+                                           # (inbound events dropped because
+                                           # the dispatch pool was saturated;
+                                           # a growing N means raise
+                                           # SLACK_DISPATCH_CONCURRENCY)
 
 # 6. Verify outbound publish through gc (replace the placeholders).
 #    GC_API_BASE_URL defaults to http://127.0.0.1:8372 on a single-host

--- a/slack-full/adapter/apps_registry.go
+++ b/slack-full/adapter/apps_registry.go
@@ -52,6 +52,14 @@ type appsRegistry struct {
 	mu       sync.RWMutex
 	byKey    map[string]appRecord
 	diskPath string
+	// gen counts in-process writes (Set). Stage stamps snapshots with
+	// the gen observed before the file read; Commit refuses snapshots
+	// staged before a later Set. This turns the gc-cby.9 constraint —
+	// a SIGHUP reload racing an OAuth-callback Set could briefly roll
+	// the in-memory view back to pre-Set state — from a documented
+	// hazard into a detected one (the reload re-stages; see
+	// commitAppsWithRetry in registry_reload.go).
+	gen uint64
 }
 
 // appsSnapshot is a parsed-but-not-yet-committed view of apps.json. A
@@ -60,6 +68,10 @@ type appsRegistry struct {
 // in-memory state. To clear, write an empty `{}` JSON document.
 type appsSnapshot struct {
 	byKey map[string]appRecord
+	// stagedAtGen is the registry generation observed before the file
+	// read backing this snapshot. Commit rejects the snapshot if the
+	// registry has advanced past it.
+	stagedAtGen uint64
 }
 
 func appsRegistryKey(workspaceID, appID string) string {
@@ -179,29 +191,51 @@ func (r *appsRegistry) load() error {
 // Stage parses the on-disk file into a snapshot ready for atomic Commit.
 // nil snapshot + nil error = file absent, preserve live state.
 func (r *appsRegistry) Stage() (*appsSnapshot, error) {
-	return parseAppsRegistry(r.diskPath)
+	// Capture gen BEFORE the file read: a Set landing between the two
+	// makes Commit report a false stale (the file read already saw the
+	// Set's write) — a harmless re-stage. The opposite order would
+	// miss real staleness.
+	r.mu.RLock()
+	gen := r.gen
+	r.mu.RUnlock()
+	snap, err := parseAppsRegistry(r.diskPath)
+	if snap != nil {
+		snap.stagedAtGen = gen
+	}
+	return snap, err
 }
 
 // Commit atomically swaps the in-memory snapshot under the write lock.
-// nil snapshot is a no-op so missing-file Stages preserve live state.
-func (r *appsRegistry) Commit(snap *appsSnapshot) {
+// nil snapshot is a no-op (missing-file Stages preserve live state) and
+// reports true. Returns false — without installing — when an in-process
+// Set advanced the registry past the snapshot's staging point; the
+// caller should re-Stage.
+func (r *appsRegistry) Commit(snap *appsSnapshot) bool {
 	if snap == nil {
-		return
+		return true
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	if r.gen != snap.stagedAtGen {
+		return false
+	}
 	r.byKey = snap.byKey
+	return true
 }
 
 // Reload combines Stage and Commit; per-registry test convenience.
 // Production reload uses reloadAllRegistries for all-or-nothing semantics.
 func (r *appsRegistry) Reload() error {
-	snap, err := r.Stage()
-	if err != nil {
-		return err
+	for attempt := 0; attempt < 3; attempt++ {
+		snap, err := r.Stage()
+		if err != nil {
+			return err
+		}
+		if r.Commit(snap) {
+			return nil
+		}
 	}
-	r.Commit(snap)
-	return nil
+	return fmt.Errorf("apps registry: reload kept racing in-process updates; retry")
 }
 
 // Len returns the number of records currently loaded. Used by the
@@ -225,6 +259,10 @@ func (r *appsRegistry) Set(rec appRecord) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.byKey[appsRegistryKey(rec.WorkspaceID, rec.AppID)] = rec
+	// Bump gen before the save: the in-memory view changed either way,
+	// so any snapshot staged before this point is stale even if the
+	// file write below fails.
+	r.gen++
 	return r.saveLocked()
 }
 

--- a/slack-full/adapter/apps_registry_test.go
+++ b/slack-full/adapter/apps_registry_test.go
@@ -479,3 +479,85 @@ func TestAppsRegistryLen(t *testing.T) {
 		t.Errorf("Len = %d, want 3", got)
 	}
 }
+
+// TestAppsRegistryCommitRefusesStaleSnapshot — a snapshot staged before
+// an in-process Set must not install: doing so would roll the in-memory
+// view back to pre-Set state (the gc-cby.9 OAuth-vs-SIGHUP race).
+func TestAppsRegistryCommitRefusesStaleSnapshot(t *testing.T) {
+	dir := t.TempDir()
+	path := writeAppsRegistryFile(t, dir, map[string]appRecord{
+		"T1:A1": {WorkspaceID: "T1", AppID: "A1", SigningSecret: "s1"},
+	})
+	reg, err := newAppsRegistry(path)
+	if err != nil {
+		t.Fatalf("newAppsRegistry: %v", err)
+	}
+
+	snap, err := reg.Stage()
+	if err != nil {
+		t.Fatalf("Stage: %v", err)
+	}
+	// OAuth callback lands between Stage and Commit.
+	if err := reg.Set(appRecord{WorkspaceID: "T1", AppID: "A2", SigningSecret: "oauth-secret"}); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	if reg.Commit(snap) {
+		t.Fatal("Commit installed a snapshot staged before Set, want refusal")
+	}
+	// The Set's record survived the refused commit.
+	if got := reg.Len(); got != 2 {
+		t.Errorf("Len after refused commit = %d, want 2 (Set preserved)", got)
+	}
+
+	// A fresh Stage sees the Set's file write and commits cleanly.
+	snap, err = reg.Stage()
+	if err != nil {
+		t.Fatalf("re-Stage: %v", err)
+	}
+	if !reg.Commit(snap) {
+		t.Fatal("fresh Commit refused, want install")
+	}
+	if got := reg.Len(); got != 2 {
+		t.Errorf("Len after fresh commit = %d, want 2", got)
+	}
+}
+
+// TestCommitAppsWithRetryConvergesAfterRace — the reload orchestrator's
+// retry path re-stages a stale snapshot and lands the post-Set state.
+func TestCommitAppsWithRetryConvergesAfterRace(t *testing.T) {
+	dir := t.TempDir()
+	path := writeAppsRegistryFile(t, dir, map[string]appRecord{
+		"T1:A1": {WorkspaceID: "T1", AppID: "A1", SigningSecret: "s1"},
+	})
+	reg, err := newAppsRegistry(path)
+	if err != nil {
+		t.Fatalf("newAppsRegistry: %v", err)
+	}
+
+	snap, err := reg.Stage()
+	if err != nil {
+		t.Fatalf("Stage: %v", err)
+	}
+	if err := reg.Set(appRecord{WorkspaceID: "T1", AppID: "A2", SigningSecret: "oauth-secret"}); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	commitAppsWithRetry(reg, snap)
+
+	// The retry re-staged from the file (which Set persisted), so both
+	// the original and the OAuth record are live.
+	if got := reg.Len(); got != 2 {
+		t.Errorf("Len after commitAppsWithRetry = %d, want 2", got)
+	}
+	recs := reg.GetByTeamID("T1")
+	var sawOAuth bool
+	for _, rec := range recs {
+		if rec.AppID == "A2" && rec.SigningSecret == "oauth-secret" {
+			sawOAuth = true
+		}
+	}
+	if !sawOAuth {
+		t.Errorf("OAuth record missing after retry converge: %+v", recs)
+	}
+}

--- a/slack-full/adapter/confined_open.go
+++ b/slack-full/adapter/confined_open.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+)
+
+// openBeneath opens rel (a Clean, root-relative path containing no
+// "..") beneath rootAbs by walking one path component at a time: each
+// step is an openat(2) relative to the fd of the already-opened parent,
+// with O_NOFOLLOW set. The parent fd pins the verified directory inode,
+// so a directory swapped for a symlink mid-walk cannot redirect the
+// traversal — the userspace equivalent of openat2(RESOLVE_BENEATH),
+// which stdlib syscall does not expose (and the adapter's
+// zero-dependency go.mod keeps us from importing x/sys for).
+//
+// O_NOFOLLOW applies to every component, not just the leaf, so any
+// symlink anywhere beneath root is a hard failure (ELOOP / ENOTDIR).
+// That matches the caller's contract: realPath is EvalSymlinks-resolved
+// before it gets here, so every component of a legitimate path is a
+// real directory or file and the walk succeeds; only a mid-flight swap
+// trips it.
+func openBeneath(rootAbs, rel string) (*os.File, error) {
+	if rel == "" || rel == "." || filepath.IsAbs(rel) {
+		return nil, fmt.Errorf("openBeneath: invalid relative path %q", rel)
+	}
+	comps := strings.Split(filepath.Clean(rel), string(filepath.Separator))
+	for _, c := range comps {
+		if c == "" || c == "." || c == ".." {
+			return nil, fmt.Errorf("openBeneath: invalid path component %q in %q", c, rel)
+		}
+	}
+	dirFlags := syscall.O_RDONLY | syscall.O_DIRECTORY | syscall.O_NOFOLLOW | syscall.O_CLOEXEC
+	fd, err := syscall.Open(rootAbs, dirFlags, 0)
+	if err != nil {
+		return nil, fmt.Errorf("openBeneath: open root %q: %w", rootAbs, err)
+	}
+	for i, c := range comps {
+		flags := syscall.O_RDONLY | syscall.O_NOFOLLOW | syscall.O_CLOEXEC
+		if i < len(comps)-1 {
+			flags |= syscall.O_DIRECTORY
+		}
+		next, err := syscall.Openat(fd, c, flags, 0)
+		syscall.Close(fd)
+		if err != nil {
+			return nil, fmt.Errorf("openBeneath: open component %q of %q: %w", c, rel, err)
+		}
+		fd = next
+	}
+	return os.NewFile(uintptr(fd), filepath.Join(rootAbs, rel)), nil
+}

--- a/slack-full/adapter/confined_open_test.go
+++ b/slack-full/adapter/confined_open_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// openBeneath is the userspace RESOLVE_BENEATH walk backing
+// readConfinedFile. These tests pin the mechanism: legitimate nested
+// paths open, and a symlink at ANY component — the stand-in for a
+// parent directory swapped mid-flight — is a hard failure.
+
+func TestOpenBeneathReadsNestedFile(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "a", "b"), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "a", "b", "f.txt"), []byte("payload"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	f, err := openBeneath(root, filepath.Join("a", "b", "f.txt"))
+	if err != nil {
+		t.Fatalf("openBeneath: %v", err)
+	}
+	defer f.Close()
+	buf := make([]byte, 16)
+	n, _ := f.Read(buf)
+	if got := string(buf[:n]); got != "payload" {
+		t.Errorf("read %q, want %q", got, "payload")
+	}
+}
+
+func TestOpenBeneathRefusesSymlinkComponents(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	if err := os.WriteFile(filepath.Join(outside, "secret"), []byte("loot"), 0o600); err != nil {
+		t.Fatalf("write outside: %v", err)
+	}
+
+	// Intermediate component is a symlink to a directory outside root —
+	// the post-swap shape of the parent-directory race.
+	if err := os.Symlink(outside, filepath.Join(root, "swapped")); err != nil {
+		t.Fatalf("symlink dir: %v", err)
+	}
+	if _, err := openBeneath(root, filepath.Join("swapped", "secret")); err == nil {
+		t.Fatal("openBeneath followed a symlinked intermediate directory, want failure")
+	}
+
+	// Leaf component is a symlink — O_NOFOLLOW parity with the old code.
+	if err := os.Symlink(filepath.Join(outside, "secret"), filepath.Join(root, "leaf")); err != nil {
+		t.Fatalf("symlink leaf: %v", err)
+	}
+	if _, err := openBeneath(root, "leaf"); err == nil {
+		t.Fatal("openBeneath followed a leaf symlink, want failure")
+	}
+}
+
+func TestOpenBeneathRejectsInvalidRel(t *testing.T) {
+	root := t.TempDir()
+	// "a/../b" is absent: filepath.Clean collapses it to "b" before the
+	// component check, which is correct — the cleaned form is beneath root.
+	for _, rel := range []string{"", ".", "/etc/passwd", "..", filepath.Join("..", "x")} {
+		if _, err := openBeneath(root, rel); err == nil {
+			t.Errorf("openBeneath(%q) succeeded, want rejection", rel)
+		}
+	}
+}
+
+func TestReadConfinedFileStillReadsAndStillConfines(t *testing.T) {
+	root := t.TempDir()
+	sub := filepath.Join(root, "files")
+	if err := os.MkdirAll(sub, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	path := filepath.Join(sub, "report.txt")
+	if err := os.WriteFile(path, []byte("contents"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	got, err := readConfinedFile(root, path)
+	if err != nil {
+		t.Fatalf("readConfinedFile: %v", err)
+	}
+	if string(got) != "contents" {
+		t.Errorf("read %q, want %q", got, "contents")
+	}
+
+	if _, err := readConfinedFile(root, "/etc/passwd"); err == nil ||
+		!strings.Contains(err.Error(), "outside root") {
+		t.Errorf("escape attempt error = %v, want outside-root rejection", err)
+	}
+}

--- a/slack-full/adapter/dispatch_drops.go
+++ b/slack-full/adapter/dispatch_drops.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"sync/atomic"
+	"time"
+)
+
+// dispatchDroppedTotal counts inbound Slack deliveries dropped because
+// the dispatch semaphore was saturated (acquireDispatchSlot returned
+// not-ok). Package-level like dispatchInflightWG: saturation is a
+// process-wide signal no matter which cfg value observed it. Exposed
+// on /healthz and rolled up by runDispatchDropSummary so operators
+// can see loss without scraping per-event "dispatch queue full" lines.
+var dispatchDroppedTotal atomic.Uint64
+
+// handleHealthz reports liveness plus the cumulative dropped-dispatch
+// count. The first line stays exactly "ok" so status-code and
+// grep-based checks keep working; the counter rides on a second line.
+func handleHealthz(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_, _ = fmt.Fprintf(w, "ok\ndispatch_dropped_total=%d\n", dispatchDroppedTotal.Load())
+}
+
+// dispatchDropSummaryInterval paces the saturation roll-up log. One
+// minute keeps the signal near-real-time; ticks with no new drops log
+// nothing, so a healthy adapter stays silent.
+const dispatchDropSummaryInterval = time.Minute
+
+// runDispatchDropSummary logs a periodic roll-up of dropped
+// dispatches so sustained saturation shows up as a low-noise
+// heartbeat even when per-event drop lines are flooding. Only ticks
+// where new drops occurred produce a line.
+func runDispatchDropSummary(ctx context.Context, interval time.Duration, capacity int) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	var lastReported uint64
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			total := dispatchDroppedTotal.Load()
+			if delta := total - lastReported; delta > 0 {
+				log.Printf("slack adapter: dispatch saturation summary: dropped=%d in last %s (total=%d cap=%d)",
+					delta, interval, total, capacity)
+				lastReported = total
+			}
+		}
+	}
+}

--- a/slack-full/adapter/dispatch_drops_test.go
+++ b/slack-full/adapter/dispatch_drops_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestHandleHealthzReportsDroppedCounter pins the /healthz body shape:
+// the first line stays exactly "ok" (status-code and grep checks keep
+// working), the second line carries the cumulative dropped-dispatch
+// counter, and a saturated acquire is reflected on the next probe.
+func TestHandleHealthzReportsDroppedCounter(t *testing.T) {
+	before := dispatchDroppedTotal.Load()
+
+	w := httptest.NewRecorder()
+	handleHealthz(w, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	lines := strings.Split(strings.TrimRight(w.Body.String(), "\n"), "\n")
+	if len(lines) != 2 || lines[0] != "ok" {
+		t.Fatalf("body = %q, want first line exactly \"ok\" plus counter line", w.Body.String())
+	}
+	if want := fmt.Sprintf("dispatch_dropped_total=%d", before); lines[1] != want {
+		t.Errorf("counter line = %q, want %q", lines[1], want)
+	}
+
+	// Saturate a cap-1 sem: the failed acquire must bump the counter.
+	cfg := config{dispatchSem: make(chan struct{}, 1)}
+	release, _, ok := cfg.acquireDispatchSlot()
+	if !ok {
+		t.Fatal("acquireDispatchSlot: failed to take initial slot in fresh sem")
+	}
+	defer release()
+	if _, _, ok := cfg.acquireDispatchSlot(); ok {
+		t.Fatal("second acquire on cap-1 sem succeeded, want saturation")
+	}
+
+	w2 := httptest.NewRecorder()
+	handleHealthz(w2, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+	if want := fmt.Sprintf("dispatch_dropped_total=%d", before+1); !strings.Contains(w2.Body.String(), want) {
+		t.Errorf("healthz after drop = %q, want it to contain %q", w2.Body.String(), want)
+	}
+}
+
+// TestRunDispatchDropSummaryLogsOnNewDrops verifies the periodic
+// roll-up fires once new drops accumulate and includes the configured
+// capacity, then stops cleanly on ctx cancel.
+func TestRunDispatchDropSummaryLogsOnNewDrops(t *testing.T) {
+	read, cleanup := captureLog(t)
+	t.Cleanup(cleanup)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		runDispatchDropSummary(ctx, 5*time.Millisecond, 7)
+		close(done)
+	}()
+	// Drain the goroutine before captureLog's cleanup swaps the log
+	// writer back, whatever path the test exits through.
+	t.Cleanup(func() { cancel(); <-done })
+
+	dispatchDroppedTotal.Add(3)
+
+	// captureLog's buffer is unsynchronized, so don't read while the
+	// goroutine may still write: give it a few ticks, then stop and
+	// drain before the single read below.
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+	<-done
+
+	logs := read()
+	if !strings.Contains(logs, "dispatch saturation summary") {
+		t.Fatalf("log missing saturation summary line:\n%s", logs)
+	}
+	if !strings.Contains(logs, "cap=7") {
+		t.Errorf("summary line missing cap=7:\n%s", logs)
+	}
+	if !strings.Contains(logs, "dropped=") {
+		t.Errorf("summary line missing dropped= delta:\n%s", logs)
+	}
+}

--- a/slack-full/adapter/double_handle_dispatch_test.go
+++ b/slack-full/adapter/double_handle_dispatch_test.go
@@ -85,7 +85,7 @@ func TestProcessSlackEventDoubleHandleUnclaimedEmitsLauncherEphemeral(t *testing
 		accountID:     "T1",
 		handlePrefix:  "@",
 		slackBotToken: "xoxb-test",
-		dispatchSem: defaultTestDispatchSem,
+		dispatchSem:   defaultTestDispatchSem,
 	}
 	aliasReg := newTestHandleAliasRegistry(t)
 	threadReg := newTestThreadSessionRegistry(t)
@@ -168,7 +168,7 @@ func TestProcessSlackEventDoubleHandlePreClaimedEmitsBoundEphemeral(t *testing.T
 		accountID:     "T1",
 		handlePrefix:  "@",
 		slackBotToken: "xoxb-test",
-		dispatchSem: defaultTestDispatchSem,
+		dispatchSem:   defaultTestDispatchSem,
 	}
 	aliasReg := newTestHandleAliasRegistry(t)
 	if err := aliasReg.Set("ops", "gc-existing-7"); err != nil {
@@ -242,7 +242,7 @@ func TestProcessSlackEventSingleHandleStillReachesAliasDispatch(t *testing.T) {
 		provider:     "slack",
 		accountID:    "T1",
 		handlePrefix: "@",
-		dispatchSem: defaultTestDispatchSem,
+		dispatchSem:  defaultTestDispatchSem,
 	}
 	aliasReg := newTestHandleAliasRegistry(t)
 	if err := aliasReg.Set("mayor", "gc-2568"); err != nil {
@@ -292,7 +292,7 @@ func TestProcessSlackEventPlainTextUnaffected(t *testing.T) {
 		provider:     "slack",
 		accountID:    "T1",
 		handlePrefix: "@",
-		dispatchSem: defaultTestDispatchSem,
+		dispatchSem:  defaultTestDispatchSem,
 	}
 	aliasReg := newTestHandleAliasRegistry(t)
 	threadReg := newTestThreadSessionRegistry(t)
@@ -337,7 +337,7 @@ func TestProcessSlackEventDoubleHandleNilThreadRegistry(t *testing.T) {
 		provider:     "slack",
 		accountID:    "T1",
 		handlePrefix: "@",
-		dispatchSem: defaultTestDispatchSem,
+		dispatchSem:  defaultTestDispatchSem,
 	}
 	aliasReg := newTestHandleAliasRegistry(t)
 
@@ -414,7 +414,7 @@ func TestHandleSlackEventsAcceptsThreadRegistry(t *testing.T) {
 		provider:        "slack",
 		accountID:       "T1",
 		slackSigningKey: "secret",
-		dispatchSem: defaultTestDispatchSem,
+		dispatchSem:     defaultTestDispatchSem,
 	}
 	aliasReg := newTestHandleAliasRegistry(t)
 	threadReg := newTestThreadSessionRegistry(t)

--- a/slack-full/adapter/interactions_test.go
+++ b/slack-full/adapter/interactions_test.go
@@ -195,7 +195,7 @@ func TestSlackInteractionsSessionMappingHitDispatches(t *testing.T) {
 		accountID:       "T1",
 		cityName:        "test-city",
 		gcAPIBase:       gcStub.URL,
-		dispatchSem: defaultTestDispatchSem,
+		dispatchSem:     defaultTestDispatchSem,
 	}
 	mapReg := newTestChannelMappingRegistry(t)
 	now := time.Now().UTC()
@@ -464,7 +464,7 @@ func TestSlackInteractionsResolverChannelOverride(t *testing.T) {
 		accountID:       "T1",
 		cityName:        "test-city",
 		gcAPIBase:       gcStub.URL,
-		dispatchSem: defaultTestDispatchSem,
+		dispatchSem:     defaultTestDispatchSem,
 	}
 	chanReg := newTestChannelMappingRegistry(t)
 	rigReg := newTestRigMappingRegistry(t)
@@ -770,7 +770,7 @@ func TestSessionDispatchGoroutineDrainedBeforeNextTest(t *testing.T) {
 		accountID:       "T1",
 		cityName:        "test-city",
 		gcAPIBase:       stub.URL,
-		dispatchSem: defaultTestDispatchSem,
+		dispatchSem:     defaultTestDispatchSem,
 	}
 	chanReg := newTestChannelMappingRegistry(t)
 	now := time.Now().UTC()
@@ -1138,7 +1138,7 @@ func TestSlackInteractionsPerAppSignatureLookup(t *testing.T) {
 		accountID:    "T1",
 		cityName:     "test-city",
 		appsRegistry: appsReg,
-		dispatchSem: defaultTestDispatchSem,
+		dispatchSem:  defaultTestDispatchSem,
 	}
 	mapReg := newTestChannelMappingRegistry(t)
 
@@ -1184,7 +1184,7 @@ func TestSlackInteractionsRegistryMissUsesEnvFallback(t *testing.T) {
 		accountID:       "T1",
 		cityName:        "test-city",
 		appsRegistry:    appsReg,
-		dispatchSem: defaultTestDispatchSem,
+		dispatchSem:     defaultTestDispatchSem,
 	}
 	mapReg := newTestChannelMappingRegistry(t)
 
@@ -1323,7 +1323,7 @@ func TestSlackInteractionsBlockActionsSessionDispatch(t *testing.T) {
 		accountID:       "T1",
 		cityName:        "test-city",
 		gcAPIBase:       gcStub.URL,
-		dispatchSem: defaultTestDispatchSem,
+		dispatchSem:     defaultTestDispatchSem,
 	}
 	mapReg := newTestChannelMappingRegistry(t)
 	now := time.Now().UTC()
@@ -1393,7 +1393,7 @@ func TestSlackInteractionsBlockActionsContainerChannelFallback(t *testing.T) {
 		accountID:       "T1",
 		cityName:        "test-city",
 		gcAPIBase:       gcStub.URL,
-		dispatchSem: defaultTestDispatchSem,
+		dispatchSem:     defaultTestDispatchSem,
 	}
 	mapReg := newTestChannelMappingRegistry(t)
 	now := time.Now().UTC()
@@ -1562,7 +1562,7 @@ func TestSlackInteractionsBlockActionsEmptyActionsArray(t *testing.T) {
 		accountID:       "T1",
 		cityName:        "test-city",
 		gcAPIBase:       gcStub.URL,
-		dispatchSem: defaultTestDispatchSem,
+		dispatchSem:     defaultTestDispatchSem,
 	}
 	mapReg := newTestChannelMappingRegistry(t)
 	now := time.Now().UTC()
@@ -1618,7 +1618,7 @@ func TestSlackInteractionsBlockActionsMultipleActions(t *testing.T) {
 		accountID:       "T1",
 		cityName:        "test-city",
 		gcAPIBase:       gcStub.URL,
-		dispatchSem: defaultTestDispatchSem,
+		dispatchSem:     defaultTestDispatchSem,
 	}
 	mapReg := newTestChannelMappingRegistry(t)
 	now := time.Now().UTC()
@@ -1737,7 +1737,7 @@ func TestSlackInteractionsBlockActionsPerAppSecret(t *testing.T) {
 		accountID:    "T1",
 		cityName:     "test-city",
 		appsRegistry: appsReg,
-		dispatchSem: defaultTestDispatchSem,
+		dispatchSem:  defaultTestDispatchSem,
 	}
 	mapReg := newTestChannelMappingRegistry(t)
 
@@ -1782,7 +1782,7 @@ func TestSlackInteractionsViewSubmissionDispatch(t *testing.T) {
 		accountID:       "T1",
 		cityName:        "test-city",
 		gcAPIBase:       gcStub.URL,
-		dispatchSem: defaultTestDispatchSem,
+		dispatchSem:     defaultTestDispatchSem,
 	}
 	mapReg := newTestChannelMappingRegistry(t)
 
@@ -1979,7 +1979,7 @@ func TestSlackInteractionsBlockActionsNeutralizesSystemReminderInjection(t *test
 		accountID:       "T1",
 		cityName:        "test-city",
 		gcAPIBase:       gcStub.URL,
-		dispatchSem: defaultTestDispatchSem,
+		dispatchSem:     defaultTestDispatchSem,
 	}
 	mapReg := newTestChannelMappingRegistry(t)
 	now := time.Now().UTC()
@@ -2049,7 +2049,7 @@ func TestSlackInteractionsSlashCommandNeutralizesSystemReminderInjection(t *test
 		accountID:       "T1",
 		cityName:        "test-city",
 		gcAPIBase:       gcStub.URL,
-		dispatchSem: defaultTestDispatchSem,
+		dispatchSem:     defaultTestDispatchSem,
 	}
 	mapReg := newTestChannelMappingRegistry(t)
 	now := time.Now().UTC()

--- a/slack-full/adapter/main.go
+++ b/slack-full/adapter/main.go
@@ -2205,8 +2205,10 @@ func processSlackEvent(cfg config, aliasReg *handleAliasRegistry, threadReg *thr
 	// the eye, because most channel messages aren't intentionally
 	// directed at an agent. Fires once per inbound (the alias-dispatch
 	// fanout below targets the same Slack TS, so a duplicate react would
-	// be a Slack no-op). Best-effort: errors are logged and don't block
-	// the dispatch path.
+	// be a Slack no-op). If alias dispatch later fails, reactAliasDispatchFailure
+	// posts ⚠️ on the same TS — that is semantically distinct (transport-layer
+	// ack vs. delivery failure) and not a duplicate. Best-effort: errors are
+	// logged and don't block the dispatch path.
 	if target != "" && cfg.slackBotToken != "" {
 		go func(channel, ts string) {
 			_, err := postReactionToSlack(cfg.slackBotToken, slackReactionsAddReq{
@@ -2246,7 +2248,10 @@ func processSlackEvent(cfg config, aliasReg *handleAliasRegistry, threadReg *thr
 			go func() {
 				defer dispatchInflightWG.Done()
 				defer release()
-				dispatchToAliasedSession(cfg, aliasedSessionID, inbound, target)
+				if !dispatchToAliasedSession(cfg, aliasedSessionID, inbound, target) {
+					reactAliasDispatchFailure(cfg.slackBotToken,
+						inbound.Conversation.ConversationID, inbound.ProviderMessageID)
+				}
 			}()
 		}
 	}
@@ -3311,9 +3316,9 @@ func handleHandleAliasDelete(reg *handleAliasRegistry) http.HandlerFunc {
 // receiving session needs to compose a reply: originating channel id (for
 // routing the reply back), message ts (for threading), and the inbound text.
 //
-// On error we log and continue — best-effort delivery; the originating
-// channel's transcript still records the inbound regardless.
-func dispatchToAliasedSession(cfg config, sessionID string, msg externalInboundMessage, handle string) {
+// Returns true on successful delivery, false on any error. The caller is
+// responsible for surface-visible failure signaling (e.g. a ⚠️ reaction).
+func dispatchToAliasedSession(cfg config, sessionID string, msg externalInboundMessage, handle string) bool {
 	// Every interpolated string is run through neutralizeMarkupBoundaries
 	// to prevent a Slack workspace member from forging </system-reminder>
 	// boundaries inside the dispatched body and injecting arbitrary
@@ -3350,6 +3355,9 @@ func dispatchToAliasedSession(cfg config, sessionID string, msg externalInboundM
 			"%s\n"+
 			"%s"+
 			"\n"+
+			"React to this message with writing_hand to signal you are actively working on it:\n"+
+			"  gc slack react --emoji writing_hand\n"+
+			"\n"+
 			"To reply in that channel (threaded under their message), write your reply to a tmpfile and run:\n"+
 			"  gc slack publish-to-channel \\\n"+
 			"    --conversation-id %s \\\n"+
@@ -3378,22 +3386,44 @@ func dispatchToAliasedSession(cfg config, sessionID string, msg externalInboundM
 	req, err := http.NewRequest(http.MethodPost, target, bytes.NewReader(payload))
 	if err != nil {
 		log.Printf("alias dispatch: build request: %v", err)
-		return
+		return false
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-GC-Request", "gc-slack-adapter-alias")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		log.Printf("alias dispatch: POST %s: %v", target, err)
-		return
+		return false
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode >= 400 {
 		respBody, _ := io.ReadAll(resp.Body)
 		log.Printf("alias dispatch: %s -> %s: %s", target, resp.Status, string(respBody))
-		return
+		return false
 	}
 	log.Printf("alias dispatch: handle=%s -> session=%s OK", handle, sessionID)
+	return true
+}
+
+// reactAliasDispatchFailure fires a best-effort ⚠️ reaction on the original
+// Slack message so a failed alias dispatch is visible in-channel rather than
+// silently dropped. Runs inside the dispatch goroutine (already async).
+func reactAliasDispatchFailure(token, channelID, ts string) {
+	if token == "" {
+		return
+	}
+	resp, err := postReactionToSlack(token, slackReactionsAddReq{
+		Channel:   channelID,
+		Name:      "warning",
+		Timestamp: ts,
+	})
+	if err != nil {
+		log.Printf("react warning (alias dispatch failure): chan=%s ts=%s: %v", channelID, ts, err)
+		return
+	}
+	if !resp.OK {
+		log.Printf("react warning (alias dispatch failure): chan=%s ts=%s: slack error=%s", channelID, ts, resp.Error)
+	}
 }
 
 // handleIdentity serves POST /identity. The caller (gc slack identity)

--- a/slack-full/adapter/main.go
+++ b/slack-full/adapter/main.go
@@ -244,6 +244,7 @@ func (c config) acquireDispatchSlot() (release func(), capacity int, ok bool) {
 	case sem <- struct{}{}:
 		return func() { <-sem }, semCap, true
 	default:
+		dispatchDroppedTotal.Add(1)
 		return nil, semCap, false
 	}
 }
@@ -1016,10 +1017,7 @@ func main() {
 	publicMux.HandleFunc("/slack/events", handleSlackEvents(cfg, aliasReg, threadReg, roomLaunchReg, subteamAliases, threadHandleSticky))
 	publicMux.HandleFunc("/slack/interactions", handleSlackInteractions(cfg, channelMapReg, rigMapReg))
 	registerOAuthHandlers(publicMux, cfg, appsReg)
-	publicMux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte("ok\n"))
-	})
+	publicMux.HandleFunc("/healthz", handleHealthz)
 	publicMux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 	})
@@ -1035,10 +1033,7 @@ func main() {
 	internalMux.HandleFunc("DELETE /identity", handleIdentityDelete(identityReg))
 	internalMux.HandleFunc("POST /handle-alias", handleHandleAlias(aliasReg))
 	internalMux.HandleFunc("DELETE /handle-alias", handleHandleAliasDelete(aliasReg))
-	internalMux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte("ok\n"))
-	})
+	internalMux.HandleFunc("/healthz", handleHealthz)
 
 	publicSrv := &http.Server{
 		Addr:              cfg.publicListen,
@@ -1065,6 +1060,7 @@ func main() {
 	janitorCtx, janitorCancel := context.WithCancel(context.Background())
 	defer janitorCancel()
 	go runInboundFileJanitor(janitorCtx, cfg)
+	go runDispatchDropSummary(janitorCtx, dispatchDropSummaryInterval, cfg.dispatchConcurrency)
 
 	// Thread-binding teardown subscriber (cby.5.4): listens to gc's
 	// city-scoped event stream for terminal session lifecycle events

--- a/slack-full/adapter/main.go
+++ b/slack-full/adapter/main.go
@@ -1546,18 +1546,26 @@ func handlePublishFile(cfg config, reg *identityRegistry) http.HandlerFunc {
 // The returned path is the cleaned absolute form, suitable for passing
 // to os.Stat / os.ReadFile.
 func confineFileUploadPath(root, path string) (string, error) {
+	_, pathAbs, _, err := confinedUploadPath(root, path)
+	return pathAbs, err
+}
+
+// confinedUploadPath is confineFileUploadPath's full-detail form: it
+// additionally returns the canonical root and the root-relative path,
+// which openBeneath needs for its component walk.
+func confinedUploadPath(root, path string) (rootAbs, pathAbs, rel string, err error) {
 	if root == "" {
-		return "", errors.New("FILE_UPLOAD_ROOT is empty")
+		return "", "", "", errors.New("FILE_UPLOAD_ROOT is empty")
 	}
 	if !filepath.IsAbs(root) {
-		return "", fmt.Errorf("FILE_UPLOAD_ROOT %q is not absolute", root)
+		return "", "", "", fmt.Errorf("FILE_UPLOAD_ROOT %q is not absolute", root)
 	}
 	if strings.TrimSpace(path) == "" {
-		return "", errors.New("path is empty")
+		return "", "", "", errors.New("path is empty")
 	}
-	rootAbs, err := filepath.Abs(root)
+	rootAbs, err = filepath.Abs(root)
 	if err != nil {
-		return "", fmt.Errorf("resolving root: %w", err)
+		return "", "", "", fmt.Errorf("resolving root: %w", err)
 	}
 	rootAbs = filepath.Clean(rootAbs)
 	// Best-effort symlink resolution on the root: if the operator
@@ -1566,14 +1574,14 @@ func confineFileUploadPath(root, path string) (string, error) {
 	if resolved, err := filepath.EvalSymlinks(rootAbs); err == nil {
 		rootAbs = resolved
 	}
-	pathAbs, err := filepath.Abs(path)
+	pathAbs, err = filepath.Abs(path)
 	if err != nil {
-		return "", fmt.Errorf("resolving path: %w", err)
+		return "", "", "", fmt.Errorf("resolving path: %w", err)
 	}
 	pathAbs = filepath.Clean(pathAbs)
-	rel, err := filepath.Rel(rootAbs, pathAbs)
+	rel, err = filepath.Rel(rootAbs, pathAbs)
 	if err != nil {
-		return "", fmt.Errorf("computing relative path: %w", err)
+		return "", "", "", fmt.Errorf("computing relative path: %w", err)
 	}
 	// Reject the root itself: the helper's contract is "file inside
 	// root", and any caller that later treats the returned path as a
@@ -1581,31 +1589,28 @@ func confineFileUploadPath(root, path string) (string, error) {
 	// directory-typed paths. Anything starting with ".." has escaped.
 	// An absolute rel (Windows volume crossing) is also out of bounds.
 	if rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
-		return "", fmt.Errorf("path %q is outside root %q", pathAbs, rootAbs)
+		return "", "", "", fmt.Errorf("path %q is outside root %q", pathAbs, rootAbs)
 	}
-	return pathAbs, nil
+	return rootAbs, pathAbs, rel, nil
 }
 
 // readConfinedFile reads realPath after re-asserting that it lies under
-// root, then opens with O_NOFOLLOW so a symlink that appears at the
-// leaf inode in the TOCTOU window between the caller's EvalSymlinks
-// resolution and the read causes the open to fail with ELOOP rather
-// than silently disclosing an arbitrary host file (gc-cby.10).
+// root, then opens it with openBeneath's component-wise walk so neither
+// a leaf symlink nor a parent directory swapped for a symlink in the
+// TOCTOU window between the caller's EvalSymlinks resolution and the
+// read can redirect the open outside root (gc-cby.10; the parent-swap
+// residual race was gpk-1ta4).
 //
 // realPath should be the filepath.EvalSymlinks-resolved canonical path
 // the caller has already verified with confineFileUploadPath; the
 // internal re-check makes the safe path the only path so a future call
 // site cannot regress arbitrary-read safety by skipping confinement.
-//
-// O_NOFOLLOW is leaf-only — a parent-directory component being swapped
-// to a symlink mid-flight is still followed by the kernel. Closing
-// that residual race requires openat2(2) with RESOLVE_BENEATH
-// (Linux ≥5.6) and is tracked separately.
 func readConfinedFile(root, realPath string) ([]byte, error) {
-	if _, err := confineFileUploadPath(root, realPath); err != nil {
+	rootAbs, _, rel, err := confinedUploadPath(root, realPath)
+	if err != nil {
 		return nil, err
 	}
-	f, err := os.OpenFile(realPath, os.O_RDONLY|syscall.O_NOFOLLOW, 0)
+	f, err := openBeneath(rootAbs, rel)
 	if err != nil {
 		return nil, err
 	}

--- a/slack-full/adapter/main_test.go
+++ b/slack-full/adapter/main_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"log"
 	"net"
@@ -1128,10 +1129,129 @@ func TestDispatchToAliasedSession(t *testing.T) {
 		"--conversation-id C0B1NSK4N3T",
 		"--thread-ts 1234.5678",
 		"gc slack publish-to-channel",
+		"writing_hand",
 	} {
 		if !strings.Contains(gotBody.Message, want) {
 			t.Errorf("body missing %q\n--- body ---\n%s", want, gotBody.Message)
 		}
+	}
+}
+
+// TestDispatchToAliasedSessionPostsWarningReactOnFailure verifies that when
+// the gc session-messages endpoint returns a 4xx error, the adapter fires a
+// ⚠️ (warning) reaction on the originating Slack message so the drop is
+// visible in-channel rather than silently lost.
+func TestDispatchToAliasedSessionPostsWarningReactOnFailure(t *testing.T) {
+	// gc stub returns 404 (session closed / unknown).
+	gcStub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(gcStub.Close)
+
+	// Slack stub captures the reactions.add call.
+	var gotChannel, gotName, gotTimestamp string
+	reactCh := make(chan struct{}, 1)
+	fakeSlack := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/reactions.add" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		var body struct {
+			Channel   string `json:"channel"`
+			Name      string `json:"name"`
+			Timestamp string `json:"timestamp"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		gotChannel, gotName, gotTimestamp = body.Channel, body.Name, body.Timestamp
+		select {
+		case reactCh <- struct{}{}:
+		default:
+		}
+		_, _ = fmt.Fprint(w, `{"ok":true}`)
+	}))
+	t.Cleanup(fakeSlack.Close)
+
+	origBase := slackAPIBase
+	t.Cleanup(func() { slackAPIBase = origBase })
+	slackAPIBase = fakeSlack.URL
+
+	cfg := config{
+		gcAPIBase:     gcStub.URL,
+		cityName:      "ds-research",
+		slackBotToken: "xoxb-test",
+	}
+	inbound := externalInboundMessage{
+		ProviderMessageID: "9999.0001",
+		Conversation: conversationRef{
+			ConversationID: "C0B25SS12CD",
+		},
+		Actor: externalActor{ID: "U0B1N5KD6HF"},
+		Text:  "hello, are you there?",
+	}
+	if !dispatchToAliasedSession(cfg, "gc-dead-session", inbound, "dashboard") {
+		reactAliasDispatchFailure(cfg.slackBotToken,
+			inbound.Conversation.ConversationID, inbound.ProviderMessageID)
+	}
+
+	select {
+	case <-reactCh:
+		if gotName != "warning" {
+			t.Errorf("reaction name = %q, want %q", gotName, "warning")
+		}
+		if gotChannel != "C0B25SS12CD" {
+			t.Errorf("reaction channel = %q, want %q", gotChannel, "C0B25SS12CD")
+		}
+		if gotTimestamp != "9999.0001" {
+			t.Errorf("reaction timestamp = %q, want %q", gotTimestamp, "9999.0001")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("warning reaction was not posted to Slack within 2s")
+	}
+}
+
+// TestDispatchToAliasedSessionNoReactWithoutToken verifies that when
+// slackBotToken is empty the failure reaction is skipped (no token → no
+// Slack API call possible).
+func TestDispatchToAliasedSessionNoReactWithoutToken(t *testing.T) {
+	gcStub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(gcStub.Close)
+
+	reactCh := make(chan struct{}, 1)
+	fakeSlack := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		select {
+		case reactCh <- struct{}{}:
+		default:
+		}
+		_, _ = fmt.Fprint(w, `{"ok":true}`)
+	}))
+	t.Cleanup(fakeSlack.Close)
+
+	origBase := slackAPIBase
+	t.Cleanup(func() { slackAPIBase = origBase })
+	slackAPIBase = fakeSlack.URL
+
+	// slackBotToken intentionally empty.
+	cfg := config{gcAPIBase: gcStub.URL, cityName: "ds-research"}
+	inbound := externalInboundMessage{
+		ProviderMessageID: "1.0",
+		Conversation:      conversationRef{ConversationID: "C1"},
+		Actor:             externalActor{ID: "U1"},
+		Text:              "ping",
+	}
+	if !dispatchToAliasedSession(cfg, "gc-dead", inbound, "bot") {
+		reactAliasDispatchFailure(cfg.slackBotToken,
+			inbound.Conversation.ConversationID, inbound.ProviderMessageID)
+	}
+
+	select {
+	case <-reactCh:
+		t.Fatal("Slack API was called despite empty slackBotToken")
+	case <-time.After(200 * time.Millisecond):
+		// expected: no call
 	}
 }
 
@@ -1475,6 +1595,9 @@ func TestDispatchToAliasedSessionZeroAttachmentsUnchanged(t *testing.T) {
 		"\n" +
 		"Message text:\n" +
 		"hi mayor please ack the deploy\n" +
+		"\n" +
+		"React to this message with writing_hand to signal you are actively working on it:\n" +
+		"  gc slack react --emoji writing_hand\n" +
 		"\n" +
 		"To reply in that channel (threaded under their message), write your reply to a tmpfile and run:\n" +
 		"  gc slack publish-to-channel \\\n" +

--- a/slack-full/adapter/main_test.go
+++ b/slack-full/adapter/main_test.go
@@ -3645,11 +3645,15 @@ func TestHandleSlackEventsDropsWhenSemaphoreFull(t *testing.T) {
 	req.Header.Set("X-Slack-Signature", sig)
 	w := httptest.NewRecorder()
 
+	droppedBefore := dispatchDroppedTotal.Load()
 	handleSlackEvents(cfg, aliasReg, nil, nil, nil, nil)(w, req)
 
 	// Slack always sees 200 (we ack quickly to suppress retries).
 	if w.Result().StatusCode != http.StatusOK {
 		t.Errorf("status = %d, want 200", w.Result().StatusCode)
+	}
+	if got := dispatchDroppedTotal.Load(); got != droppedBefore+1 {
+		t.Errorf("dispatchDroppedTotal = %d, want %d (one drop counted)", got, droppedBefore+1)
 	}
 	// Sem was full: processSlackEvent never ran → no inbound POST hit
 	// the gc stub.

--- a/slack-full/adapter/registry_reload.go
+++ b/slack-full/adapter/registry_reload.go
@@ -80,13 +80,12 @@ func scrubAppsRegistryError(err error) string {
 // If a future CLI command writes to any of those, extend this
 // orchestrator.
 //
-// gc-cby.9 follow-up: an in-process Set on appsRegistry (planned for the
-// OAuth callback path) racing a SIGHUP-driven Stage→Commit can briefly
-// roll the in-memory snapshot back to the pre-Set version (Set holds the
-// write lock, then Commit installs a snapshot taken before Set ran).
-// Stage's snapshot is whole-file, so the next reload converges. Document
-// the constraint where Set callers live, or sequence Set→file-write→
-// Set-mutex-hold-through-Commit if that's not acceptable.
+// gc-cby.9 race, defended: an in-process Set on appsRegistry (the OAuth
+// callback path) racing a SIGHUP-driven Stage→Commit would briefly roll
+// the in-memory snapshot back to the pre-Set version. The registry now
+// generation-stamps snapshots: Commit refuses one staged before a later
+// Set, and commitAppsWithRetry re-stages (bounded) so the reload picks
+// up the post-Set file instead of installing stale memory.
 func reloadAllRegistries(
 	apps *appsRegistry,
 	chans *channelMappingRegistry,
@@ -109,7 +108,7 @@ func reloadAllRegistries(
 
 	if apps != nil {
 		snap, err := apps.Stage()
-		stage(appsRegistryStageLabel, err, func() { apps.Commit(snap) })
+		stage(appsRegistryStageLabel, err, func() { commitAppsWithRetry(apps, snap) })
 	}
 	if chans != nil {
 		snap, err := chans.Stage()
@@ -139,6 +138,34 @@ func reloadAllRegistries(
 		c()
 	}
 	return nil
+}
+
+// commitAppsWithRetry installs the staged apps snapshot, re-staging when
+// an in-process Set (OAuth callback) landed after the Stage — installing
+// the stale snapshot would roll the in-memory view back to pre-Set
+// state. Bounded retries; the re-staged file already contains the Set's
+// write (Set persists before releasing the lock), so one retry normally
+// converges. On a re-stage parse error or retry exhaustion the live
+// state is preserved and the operator is told to re-send SIGHUP — the
+// other registries' commits have already run at this point, so failing
+// the whole reload would not restore atomicity.
+func commitAppsWithRetry(apps *appsRegistry, snap *appsSnapshot) {
+	for attempt := 0; ; attempt++ {
+		if apps.Commit(snap) {
+			return
+		}
+		if attempt >= 2 {
+			log.Printf("WARN: apps registry commit skipped after %d attempts: in-process updates kept racing the reload (live state preserved); re-send SIGHUP", attempt+1)
+			return
+		}
+		var err error
+		snap, err = apps.Stage()
+		if err != nil {
+			log.Printf("WARN: apps registry re-stage failed (live state preserved): %s",
+				scrubAppsRegistryError(fmt.Errorf("%s: %w", appsRegistryStageLabel, err)))
+			return
+		}
+	}
 }
 
 // runReloadLoop drains sigCh and invokes reload for each signal until

--- a/slack-full/adapter/rig_dispatch_test.go
+++ b/slack-full/adapter/rig_dispatch_test.go
@@ -200,7 +200,7 @@ func TestSlackInteractionsRigSlashOpensModal(t *testing.T) {
 		accountID:       "T1",
 		cityName:        "test-city",
 		cityPath:        cityPath,
-		dispatchSem: defaultTestDispatchSem,
+		dispatchSem:     defaultTestDispatchSem,
 	}
 	chanReg := newTestChannelMappingRegistry(t)
 	rigReg := newTestRigMappingRegistry(t)
@@ -286,7 +286,7 @@ func TestSlackInteractionsRigSlashMissingTriggerID(t *testing.T) {
 		accountID:       "T1",
 		cityName:        "test-city",
 		cityPath:        cityPath,
-		dispatchSem: defaultTestDispatchSem,
+		dispatchSem:     defaultTestDispatchSem,
 	}
 	chanReg := newTestChannelMappingRegistry(t)
 	rigReg := newTestRigMappingRegistry(t)
@@ -332,7 +332,7 @@ func TestSlackInteractionsRigSlashViewsOpenFailure(t *testing.T) {
 		accountID:       "T1",
 		cityName:        "test-city",
 		cityPath:        cityPath,
-		dispatchSem: defaultTestDispatchSem,
+		dispatchSem:     defaultTestDispatchSem,
 	}
 	chanReg := newTestChannelMappingRegistry(t)
 	rigReg := newTestRigMappingRegistry(t)
@@ -461,7 +461,7 @@ func TestSlackInteractionsRigViewSubmissionDispatchesHappyPath(t *testing.T) {
 		accountID:       "T1",
 		cityName:        "test-city",
 		cityPath:        cityPath,
-		dispatchSem: defaultTestDispatchSem,
+		dispatchSem:     defaultTestDispatchSem,
 	}
 	chanReg := newTestChannelMappingRegistry(t)
 	rigReg := newTestRigMappingRegistry(t)

--- a/slack-full/adapter/room_launch_dispatch_test.go
+++ b/slack-full/adapter/room_launch_dispatch_test.go
@@ -122,7 +122,7 @@ func TestRoomLaunchDispatchSpawnOnMissCreatesSessionAndPostsFirstMessage(t *test
 		handlePrefix:        "@",
 		slackBotToken:       "xoxb-test",
 		dispatchConcurrency: 8,
-		dispatchSem: defaultTestDispatchSem,
+		dispatchSem:         defaultTestDispatchSem,
 	}
 	aliasReg := newTestHandleAliasRegistry(t)
 	threadReg := newTestThreadSessionRegistry(t)
@@ -220,7 +220,7 @@ func TestRoomLaunchDispatchReuseOnHitSkipsCreateAndPostsToExistingSession(t *tes
 		handlePrefix:        "@",
 		slackBotToken:       "xoxb-test",
 		dispatchConcurrency: 8,
-		dispatchSem: defaultTestDispatchSem,
+		dispatchSem:         defaultTestDispatchSem,
 	}
 	aliasReg := newTestHandleAliasRegistry(t)
 	threadReg := newTestThreadSessionRegistry(t)
@@ -277,7 +277,7 @@ func TestRoomLaunchDispatchChannelNotEnabledEmitsActionableEphemeral(t *testing.
 		handlePrefix:        "@",
 		slackBotToken:       "xoxb-test",
 		dispatchConcurrency: 8,
-		dispatchSem: defaultTestDispatchSem,
+		dispatchSem:         defaultTestDispatchSem,
 	}
 	aliasReg := newTestHandleAliasRegistry(t)
 	threadReg := newTestThreadSessionRegistry(t)
@@ -329,7 +329,7 @@ func TestRoomLaunchDispatchSpawnFailureLeavesRegistryEmpty(t *testing.T) {
 		handlePrefix:        "@",
 		slackBotToken:       "xoxb-test",
 		dispatchConcurrency: 8,
-		dispatchSem: defaultTestDispatchSem,
+		dispatchSem:         defaultTestDispatchSem,
 	}
 	aliasReg := newTestHandleAliasRegistry(t)
 	threadReg := newTestThreadSessionRegistry(t)

--- a/slack-full/adapter/subteam_alias_map.go
+++ b/slack-full/adapter/subteam_alias_map.go
@@ -37,9 +37,9 @@ import (
 // fully supported: subteam-aliases.json is a static file the operator
 // populates manually. No usergroups.list fetch is performed by v1.
 type subteamAliasMap struct {
-	mu         sync.RWMutex
-	byID       map[string]string // subteam_id -> handle
-	diskPath   string
+	mu       sync.RWMutex
+	byID     map[string]string // subteam_id -> handle
+	diskPath string
 }
 
 // subteamAliasSnapshot is a parsed-but-not-yet-committed view of

--- a/slack-full/adapter/subteam_alias_map_test.go
+++ b/slack-full/adapter/subteam_alias_map_test.go
@@ -139,8 +139,8 @@ func TestSubteamAliasMapReloadOnUpdate(t *testing.T) {
 
 	// Operator edits the file: rename mayor → cos, add a new binding.
 	writeSubteamAliasFile(t, dir, map[string]string{
-		"S0123":  "cos",
-		"S_NEW":  "probe-pl",
+		"S0123": "cos",
+		"S_NEW": "probe-pl",
 	})
 	if err := m.Reload(); err != nil {
 		t.Fatalf("reload: %v", err)

--- a/slack-full/adapter/subteam_mention_prefix.go
+++ b/slack-full/adapter/subteam_mention_prefix.go
@@ -20,14 +20,14 @@ import "strings"
 // Return values:
 //
 //   - handle:     non-empty for the labeled form (the `@`-stripped
-//                 label); empty for the unlabeled form.
+//     label); empty for the unlabeled form.
 //   - subteamID:  the Slack User Group ID (e.g. "S0123ABCD") in both
-//                 shapes. Non-empty whenever ok=true.
+//     shapes. Non-empty whenever ok=true.
 //   - remainder:  the text after the closing `>`, with one optional
-//                 colon and one leading whitespace byte trimmed
-//                 (mirroring parseHandlePrefix's separator rules).
+//     colon and one leading whitespace byte trimmed
+//     (mirroring parseHandlePrefix's separator rules).
 //   - ok:         true on any well-formed subteam token at the head;
-//                 false otherwise.
+//     false otherwise.
 //
 // Caller responsibilities:
 //

--- a/slack-full/adapter/thread_context.go
+++ b/slack-full/adapter/thread_context.go
@@ -55,6 +55,22 @@ const defaultThreadContextLimit = 20
 // dispatchSem slot.
 const threadContextFetchTimeout = 5 * time.Second
 
+// threadContextCacheTTL bounds how long an idle (target, channel,
+// thread) entry survives. Slack threads rarely stay active for a
+// week; an evicted entry merely means the next mention on that
+// thread re-delivers the full prior window instead of the delta — a
+// one-time duplicate preamble, not context loss. Aligned with the
+// INBOUND_FILE_TTL default (7d) so both per-thread artifacts age out
+// on the same horizon.
+const threadContextCacheTTL = 7 * 24 * time.Hour
+
+// threadContextCacheMaxEntries hard-caps the cache so a pathological
+// workload (many distinct threads inside one TTL window) cannot grow
+// it without bound. When an insert pushes the map over the cap, the
+// oldest-touched entry is evicted; the same benign full-preamble
+// re-delivery applies.
+const threadContextCacheMaxEntries = 4096
+
 // threadContextCache tracks, per (target, channel, thread_ts) tuple,
 // the ts of the most recent thread-context preamble the adapter has
 // delivered for that target. The next inbound to the same target in
@@ -62,10 +78,11 @@ const threadContextFetchTimeout = 5 * time.Second
 // replies to include — peer activity newer than the last visit, not
 // the entire history again.
 //
-// Process-lifetime; no eviction. Workload is bounded by the count of
-// distinct (target, channel, thread) tuples observed, which is small
-// relative to per-message memory budgets. A target value of "" is a
-// valid key for channel-bound inbounds without an explicit @handle.
+// Entries are evicted after threadContextCacheTTL of inactivity
+// (both reads and writes refresh an entry's clock, so live threads
+// stay warm) and the map is capped at threadContextCacheMaxEntries
+// with oldest-touched eviction. A target value of "" is a valid key
+// for channel-bound inbounds without an explicit @handle.
 //
 // Errors during fetchThreadReplies do NOT advance the cached ts. A
 // transient Slack 5xx or missing-scope 401 leaves the lower bound
@@ -76,11 +93,28 @@ const threadContextFetchTimeout = 5 * time.Second
 // suppression of context loss is worse than a noisy log.
 type threadContextCache struct {
 	mu            sync.Mutex
-	lastDelivered map[string]string
+	lastDelivered map[string]threadContextEntry
+	// now is the clock; nil means time.Now. Injectable so tests can
+	// drive TTL expiry without sleeping.
+	now func() time.Time
+}
+
+// threadContextEntry pairs the delivered-up-to ts with the wall-clock
+// instant the entry was last read or written, which drives eviction.
+type threadContextEntry struct {
+	ts      string
+	touched time.Time
 }
 
 func newThreadContextCache() *threadContextCache {
-	return &threadContextCache{lastDelivered: make(map[string]string)}
+	return &threadContextCache{lastDelivered: make(map[string]threadContextEntry)}
+}
+
+func (c *threadContextCache) clock() time.Time {
+	if c.now != nil {
+		return c.now()
+	}
+	return time.Now()
 }
 
 // lastDeliveredFor returns the ts up-to-which the adapter has already
@@ -95,9 +129,23 @@ func (c *threadContextCache) lastDeliveredFor(target, channel, threadTS string) 
 	if channel == "" || threadTS == "" {
 		return ""
 	}
+	key := threadCacheKey(target, channel, threadTS)
+	now := c.clock()
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	return c.lastDelivered[threadCacheKey(target, channel, threadTS)]
+	entry, ok := c.lastDelivered[key]
+	if !ok {
+		return ""
+	}
+	if now.Sub(entry.touched) > threadContextCacheTTL {
+		delete(c.lastDelivered, key)
+		return ""
+	}
+	// Refresh the clock on read so a thread that is actively being
+	// followed never ages out mid-conversation.
+	entry.touched = now
+	c.lastDelivered[key] = entry
+	return entry.ts
 }
 
 // markDelivered records ts as the high-water mark for which preamble
@@ -112,16 +160,44 @@ func (c *threadContextCache) markDelivered(target, channel, threadTS, ts string)
 		return
 	}
 	key := threadCacheKey(target, channel, threadTS)
+	now := c.clock()
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if prev, ok := c.lastDelivered[key]; ok && prev >= ts {
+	if prev, ok := c.lastDelivered[key]; ok && prev.ts >= ts {
 		// Slack ts strings are lexically comparable in canonical
 		// 17-char "<seconds>.<microseconds>" form; a regression here
 		// would mean a stale handler raced ahead of a newer delivery,
-		// which is a no-op for cache semantics.
+		// which is a no-op for cache semantics — but the entry is
+		// still live, so refresh its clock.
+		prev.touched = now
+		c.lastDelivered[key] = prev
 		return
 	}
-	c.lastDelivered[key] = ts
+	c.lastDelivered[key] = threadContextEntry{ts: ts, touched: now}
+	if len(c.lastDelivered) > threadContextCacheMaxEntries {
+		c.evictLocked(now)
+	}
+}
+
+// evictLocked drops expired entries and, if the map is still over
+// cap, the single oldest-touched entry. Called with c.mu held, only
+// on the insert that pushed the map past the cap, so the O(n) scan
+// amortizes to once per overflow insert.
+func (c *threadContextCache) evictLocked(now time.Time) {
+	var oldestKey string
+	var oldestTouched time.Time
+	for key, entry := range c.lastDelivered {
+		if now.Sub(entry.touched) > threadContextCacheTTL {
+			delete(c.lastDelivered, key)
+			continue
+		}
+		if oldestKey == "" || entry.touched.Before(oldestTouched) {
+			oldestKey, oldestTouched = key, entry.touched
+		}
+	}
+	if len(c.lastDelivered) > threadContextCacheMaxEntries && oldestKey != "" {
+		delete(c.lastDelivered, oldestKey)
+	}
 }
 
 // threadCacheKey is the cache-map key shape for (target, channel,

--- a/slack-full/adapter/thread_context_test.go
+++ b/slack-full/adapter/thread_context_test.go
@@ -712,6 +712,79 @@ func TestThreadContextCache_LastDeliveredRoundTrip(t *testing.T) {
 	}
 }
 
+func TestThreadContextCache_TTLEviction(t *testing.T) {
+	t.Parallel()
+	c := newThreadContextCache()
+	clock := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	c.now = func() time.Time { return clock }
+
+	c.markDelivered("mayor", "C1", "T1", "100.000001")
+	c.markDelivered("PL", "C1", "T2", "100.000002")
+
+	// Within TTL: both entries live; the read refreshes mayor's clock.
+	clock = clock.Add(threadContextCacheTTL - time.Hour)
+	if got := c.lastDeliveredFor("mayor", "C1", "T1"); got != "100.000001" {
+		t.Errorf("within TTL = %q, want %q", got, "100.000001")
+	}
+
+	// Past PL's TTL but inside mayor's refreshed window: PL ages out,
+	// mayor survives because the read above re-touched it.
+	clock = clock.Add(2 * time.Hour)
+	if got := c.lastDeliveredFor("PL", "C1", "T2"); got != "" {
+		t.Errorf("expired entry = %q, want \"\" (TTL eviction)", got)
+	}
+	if got := c.lastDeliveredFor("mayor", "C1", "T1"); got != "100.000001" {
+		t.Errorf("read-refreshed entry = %q, want %q (touch on read keeps live threads warm)", got, "100.000001")
+	}
+
+	// The expired entry was deleted, not just hidden.
+	c.mu.Lock()
+	_, stillThere := c.lastDelivered[threadCacheKey("PL", "C1", "T2")]
+	c.mu.Unlock()
+	if stillThere {
+		t.Error("expired entry still present in map after read")
+	}
+
+	// A write to a fully-expired cache starts fresh.
+	clock = clock.Add(2 * threadContextCacheTTL)
+	c.markDelivered("mayor", "C1", "T1", "200.000001")
+	if got := c.lastDeliveredFor("mayor", "C1", "T1"); got != "200.000001" {
+		t.Errorf("after re-mark = %q, want %q", got, "200.000001")
+	}
+}
+
+func TestThreadContextCache_CapEvictsOldestTouched(t *testing.T) {
+	t.Parallel()
+	c := newThreadContextCache()
+	clock := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	c.now = func() time.Time { return clock }
+
+	// Fill to cap; entry i is touched at base+i seconds, so T0 is the
+	// oldest when the overflow insert arrives.
+	for i := 0; i < threadContextCacheMaxEntries; i++ {
+		clock = clock.Add(time.Second)
+		c.markDelivered("mayor", "C1", fmt.Sprintf("T%d", i), "100.000001")
+	}
+	clock = clock.Add(time.Second)
+	c.markDelivered("mayor", "C1", "T-overflow", "100.000001")
+
+	c.mu.Lock()
+	size := len(c.lastDelivered)
+	c.mu.Unlock()
+	if size != threadContextCacheMaxEntries {
+		t.Errorf("cache size after overflow = %d, want %d (cap enforced)", size, threadContextCacheMaxEntries)
+	}
+	if got := c.lastDeliveredFor("mayor", "C1", "T0"); got != "" {
+		t.Errorf("oldest entry = %q, want \"\" (evicted on overflow)", got)
+	}
+	if got := c.lastDeliveredFor("mayor", "C1", "T-overflow"); got != "100.000001" {
+		t.Errorf("overflow entry = %q, want %q (newest survives)", got, "100.000001")
+	}
+	if got := c.lastDeliveredFor("mayor", "C1", "T1"); got != "100.000001" {
+		t.Errorf("second-oldest entry = %q, want %q (only one eviction needed)", got, "100.000001")
+	}
+}
+
 func TestThreadContextCache_MarkDeliveredConcurrent(t *testing.T) {
 	t.Parallel()
 	c := newThreadContextCache()

--- a/slack-full/adapter/thread_context_test.go
+++ b/slack-full/adapter/thread_context_test.go
@@ -112,7 +112,7 @@ func TestThreadContext_FirstMentionPrependsPreamble(t *testing.T) {
 		slackBotToken:           "xoxb-fake",
 		slackThreadContextLimit: 20,
 		threadContextCache:      newThreadContextCache(),
-		dispatchSem: defaultTestDispatchSem,
+		dispatchSem:             defaultTestDispatchSem,
 	}
 	rawMsg, _ := json.Marshal(slackMessageEvent{
 		Type:     "message",
@@ -198,7 +198,7 @@ func TestThreadContext_SecondMentionWithoutNewActivityNoPreamble(t *testing.T) {
 		slackBotToken:           "xoxb-fake",
 		slackThreadContextLimit: 20,
 		threadContextCache:      newThreadContextCache(),
-		dispatchSem: defaultTestDispatchSem,
+		dispatchSem:             defaultTestDispatchSem,
 	}
 
 	first, _ := json.Marshal(slackMessageEvent{
@@ -258,7 +258,7 @@ func TestThreadContext_NonThreadInboundSkipsFetch(t *testing.T) {
 		slackBotToken:           "xoxb-fake",
 		slackThreadContextLimit: 20,
 		threadContextCache:      newThreadContextCache(),
-		dispatchSem: defaultTestDispatchSem,
+		dispatchSem:             defaultTestDispatchSem,
 	}
 	// thread_ts empty: not a reply; no preamble path.
 	rawMsg, _ := json.Marshal(slackMessageEvent{
@@ -301,7 +301,7 @@ func TestThreadContext_ThreadParentSkipsFetch(t *testing.T) {
 		slackBotToken:           "xoxb-fake",
 		slackThreadContextLimit: 20,
 		threadContextCache:      newThreadContextCache(),
-		dispatchSem: defaultTestDispatchSem,
+		dispatchSem:             defaultTestDispatchSem,
 	}
 	rawMsg, _ := json.Marshal(slackMessageEvent{
 		Type:     "message",
@@ -355,7 +355,7 @@ func TestThreadContext_NoPriorsAfterFilteringEmitsNoPreamble(t *testing.T) {
 		slackBotToken:           "xoxb-fake",
 		slackThreadContextLimit: 20,
 		threadContextCache:      newThreadContextCache(),
-		dispatchSem: defaultTestDispatchSem,
+		dispatchSem:             defaultTestDispatchSem,
 	}
 	rawMsg, _ := json.Marshal(slackMessageEvent{
 		Type:     "message",
@@ -412,7 +412,7 @@ func TestThreadContext_FetchFailureRetriesNextInbound(t *testing.T) {
 		slackBotToken:           "xoxb-fake",
 		slackThreadContextLimit: 20,
 		threadContextCache:      newThreadContextCache(),
-		dispatchSem: defaultTestDispatchSem,
+		dispatchSem:             defaultTestDispatchSem,
 	}
 	mk := func(ts string) []byte {
 		raw, _ := json.Marshal(slackMessageEvent{
@@ -493,7 +493,7 @@ func TestThreadContext_CrossAgentDeltaVisibility(t *testing.T) {
 		slackBotToken:           "xoxb-fake",
 		slackThreadContextLimit: 20,
 		threadContextCache:      newThreadContextCache(),
-		dispatchSem: defaultTestDispatchSem,
+		dispatchSem:             defaultTestDispatchSem,
 	}
 	aliasReg := newTestHandleAliasRegistry(t)
 
@@ -602,7 +602,7 @@ func TestThreadContext_IsolationAcrossThreads(t *testing.T) {
 		slackBotToken:           "xoxb-fake",
 		slackThreadContextLimit: 20,
 		threadContextCache:      newThreadContextCache(),
-		dispatchSem: defaultTestDispatchSem,
+		dispatchSem:             defaultTestDispatchSem,
 	}
 
 	// Mayor is mentioned in thread A → cache pulls the prior.
@@ -864,9 +864,9 @@ func TestFormatThreadContextPreamble_FiltersAndFormats(t *testing.T) {
 // it overwrites the package-level slackAPIBase var.
 func TestFetchThreadReplies_QueryAndAuth(t *testing.T) {
 	var (
-		mu             sync.Mutex
-		capturedAuth   string
-		capturedQuery  string
+		mu            sync.Mutex
+		capturedAuth  string
+		capturedQuery string
 	)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		mu.Lock()

--- a/slack-full/adapter/thread_handle_stickiness.go
+++ b/slack-full/adapter/thread_handle_stickiness.go
@@ -36,8 +36,8 @@ import "sync"
 // future need calls for persistence, mirror the threadSessionRegistry
 // disk pattern.
 type threadHandleStickiness struct {
-	mu      sync.RWMutex
-	byKey   map[threadKey]string // (channel, thread_ts) -> handle
+	mu    sync.RWMutex
+	byKey map[threadKey]string // (channel, thread_ts) -> handle
 }
 
 // newThreadHandleStickiness returns an empty registry.

--- a/slack-full/scripts/slack_chat_bind_room.py
+++ b/slack-full/scripts/slack_chat_bind_room.py
@@ -35,12 +35,14 @@ You are a slack-bound agent in this conversation.
 
 Reply protocol when you receive a `New message in shared conversation slack/...` reminder:
 
-  1. **FIRST**: react with eyes — BEFORE you compose anything, BEFORE you
+  1. **FIRST**: react with writing_hand — BEFORE you compose anything, BEFORE you
      read context, BEFORE you think about the reply.
-       gc slack react --emoji eyes
-     This is non-blocking and signals to the human that you've seen the
-     message. Replying first means the human waits in silence until your
-     full reply lands, even when you have an instant answer.
+       gc slack react --emoji writing_hand
+     This signals to the human that you are actively working on the message.
+     The adapter already placed 👀 on the message when it enqueued the inbound
+     (transport-level ack: "queued for the agent"). Your ✍️ is the agent-level
+     signal: "I am processing." Replying first means the human waits in silence
+     until your full reply lands, even when you have an instant answer.
 
   2. THEN compose your reply to a tmpfile.
 
@@ -56,9 +58,9 @@ when the inbound is a re-ping of an active thread. Even when it's a
 
 Use `gc slack publish-to-channel --conversation-id ... --no-thread` ONLY
 for explicit top-level status broadcasts initiated by you, never as a
-reply to an inbound. Eyes-react is for inbound-replies only — proactive
-posts (e.g. surfacing slung work completion) skip the react and just
-publish-to-thread.
+reply to an inbound. The writing_hand react is for inbound-replies only —
+proactive posts (e.g. surfacing slung work completion) skip the react and
+just publish-to-thread.
 </system-reminder>
 """
 


### PR DESCRIPTION
## Summary
Salvage of #88 onto fresh main. Six slack-pack hardening commits: dispatch-drops observability, thread-context TTL+cap, OAuth/SIGHUP generation-stamps, confined_open symlink race, writing_hand reaction; gofmt. Dropped superseded/stale-base commits (doctor, escalating-scan, 3 tiering commits).

## Validation
- adapter `go build`/`vet`/`test -race` + cli + gofmt + 85 pytests pass.
- Note: pre-existing `-race` flakiness on thread_context/thread_teardown reproduces on upstream/main too (candidate for a separate flaky-test bead).

Supersedes #88 (stale/conflicting base; salvaged clean on main).
