### PR TITLE
fix(discord): site binding must win workspace-name resolution, matching gc

### DIFF
--- a/discord/scripts/discord_intake_common.py
+++ b/discord/scripts/discord_intake_common.py
@@ -1988,29 +1988,32 @@ _SCOPE_CACHE_TTL = 60.0  # seconds
 def resolved_workspace_name(city_cfg: dict[str, Any]) -> str:
     """Resolve the city's runtime workspace name.
 
-    Precedence mirrors gc itself: declared city.toml workspace.name, then the
-    machine-local site binding (.gc/site.toml workspace_name), then the city
-    directory basename. gc init no longer writes workspace.name to city.toml,
-    so deployments commonly only carry the site binding.
+    Precedence mirrors gc itself (applyWorkspaceIdentityBinding): the
+    machine-local site binding (.gc/site.toml workspace_name) wins, then the
+    declared city.toml workspace.name, then the city directory basename. gc
+    registers the city with the supervisor under this resolved name, so scope
+    discovery must resolve it identically or a divergent site binding sends
+    delivery to the dead default API port.
     """
+    root = city_root()
+    if root:
+        site_path = os.path.join(root, ".gc", "site.toml")
+        try:
+            with open(site_path, "rb") as handle:
+                site_cfg = tomllib.load(handle)
+        except (OSError, tomllib.TOMLDecodeError):
+            site_cfg = {}
+        if isinstance(site_cfg, dict):
+            name = str(site_cfg.get("workspace_name", "")).strip()
+            if name:
+                return name
     workspace_cfg = city_cfg.get("workspace") or {}
     if isinstance(workspace_cfg, dict):
         name = str(workspace_cfg.get("name", "")).strip()
         if name:
             return name
-    root = city_root()
     if not root:
         return ""
-    site_path = os.path.join(root, ".gc", "site.toml")
-    try:
-        with open(site_path, "rb") as handle:
-            site_cfg = tomllib.load(handle)
-    except (OSError, tomllib.TOMLDecodeError):
-        site_cfg = {}
-    if isinstance(site_cfg, dict):
-        name = str(site_cfg.get("workspace_name", "")).strip()
-        if name:
-            return name
     return pathlib.Path(root).name
 
 

--- a/discord/tests/test_discord_intake_common.py
+++ b/discord/tests/test_discord_intake_common.py
@@ -524,6 +524,44 @@ class DiscordIntakeCommonTests(unittest.TestCase):
         with mock.patch.object(common.urllib.request, "urlopen", return_value=response):
             self.assertEqual(common.gc_api_base_url(), "http://127.0.0.1:8372")
 
+    def test_gc_api_base_url_prefers_site_binding_name_over_city_toml_name(self) -> None:
+        # gc registers the city under the resolved name, where the machine-local
+        # site binding overrides the declared city.toml name. If the pack checks
+        # city.toml first, a divergent site binding makes scope discovery miss
+        # and delivery falls back to the wrong API endpoint.
+        pathlib.Path(self.tempdir.name, "city.toml").write_text(
+            '[workspace]\nname = "legacy"\n[api]\nbind = "0.0.0.0"\nport = 9555\n',
+            encoding="utf-8",
+        )
+        site_dir = pathlib.Path(self.tempdir.name, ".gc")
+        site_dir.mkdir()
+        (site_dir / "site.toml").write_text('workspace_name = "site-wins"\n', encoding="utf-8")
+        common._supervisor_scope_cache.clear()
+        self.addCleanup(common._supervisor_scope_cache.clear)
+        response = mock.Mock()
+        response.__enter__ = mock.Mock(
+            return_value=mock.Mock(read=mock.Mock(return_value=b'{"items":[{"name":"site-wins","running":true}]}'))
+        )
+        response.__exit__ = mock.Mock(return_value=False)
+
+        with mock.patch.object(common.urllib.request, "urlopen", return_value=response):
+            self.assertEqual(common.gc_api_base_url(), "http://127.0.0.1:8372")
+
+    def test_resolved_workspace_name_prefers_site_binding_over_city_toml(self) -> None:
+        site_dir = pathlib.Path(self.tempdir.name, ".gc")
+        site_dir.mkdir()
+        (site_dir / "site.toml").write_text('workspace_name = "site-name"\n', encoding="utf-8")
+
+        self.assertEqual(common.resolved_workspace_name({"workspace": {"name": "declared-name"}}), "site-name")
+
+    def test_resolved_workspace_name_ignores_unreadable_site_binding(self) -> None:
+        site_dir = pathlib.Path(self.tempdir.name, ".gc")
+        site_dir.mkdir()
+        (site_dir / "site.toml").write_text("not [valid toml", encoding="utf-8")
+
+        self.assertEqual(common.resolved_workspace_name({"workspace": {"name": "declared-name"}}), "declared-name")
+        self.assertEqual(common.resolved_workspace_name({}), pathlib.Path(self.tempdir.name).name)
+
     def test_gc_api_base_url_falls_back_to_city_dir_basename_when_no_declared_name(self) -> None:
         pathlib.Path(self.tempdir.name, "city.toml").write_text("", encoding="utf-8")
         common._supervisor_scope_cache.clear()


### PR DESCRIPTION

## What

`resolved_workspace_name()` (added in 26cfc61) resolves the workspace name for supervisor scope discovery, but checks the sources in the wrong order: declared `city.toml` `workspace.name` first, then the machine-local site binding (`.gc/site.toml` `workspace_name`), then the city directory basename.

gc resolves the other way around. `applyWorkspaceIdentityBinding()` (internal/config/site_binding.go) starts from the directory basename, lets `city.toml` `workspace.name` override it, and lets the **site binding override both** — and the supervisor registers the city under that resolved name (`supervisor.CityEntry{Name: cfg.ResolvedWorkspaceName}`, cmd/gc/main.go). The resolver's docstring says "Precedence mirrors gc itself", but it inverts gc's precedence.

## Why it matters

When the two files disagree, the pack resolves a name the supervisor doesn't know. Scope discovery misses, `gc_api_base_url()` falls back to the legacy default port (9443), and **every inbound Discord message dies with connection refused — silently** (the gateway keeps running; only the per-message ingress receipts show the failures).

Divergence is not exotic: `city.toml` is commonly shared/committed while `.gc/site.toml` is the per-machine binding, so a machine-local rename is exactly the case the site binding exists for. This is the same failure mode 26cfc61 fixed for the missing-name case, surviving in a narrower window.

Reproduced against a live supervisor (city.toml `name = "house-staff-legacy"`, site.toml `workspace_name = "house-staff"`, supervisor knows `house-staff`):

- before: resolves `house-staff-legacy` → no scope match → `http://127.0.0.1:9443` → `GET /v0/sessions` → `[Errno 111] Connection refused`
- after: resolves `house-staff` → `/v0/city/house-staff` on the supervisor API → sessions round-trip OK

## Changes

- Reorder `resolved_workspace_name()`: site binding → declared `city.toml` name → basename. Behavior with only one source configured is unchanged; `GC_CITY_ROOT`-unset behavior is unchanged (site binding and basename are skipped, declared name still honored).
- Correct the docstring to describe the actual (now gc-matching) precedence.
- Regression tests: the divergent both-set case had no coverage, which is how the inversion slipped in.
  - `test_gc_api_base_url_prefers_site_binding_name_over_city_toml_name` (end-to-end through scope discovery; fails before this fix)
  - `test_resolved_workspace_name_prefers_site_binding_over_city_toml` (fails before this fix)
  - `test_resolved_workspace_name_ignores_unreadable_site_binding` (pins the existing graceful fallback on a corrupt site.toml)

## Testing

- Full discord suite: 262 tests OK (259 at main + 3 new).
- Red check: both precedence tests fail against the unpatched resolver.
- Live-path check on a real deployment (gc supervisor on :8372): all three config shapes (identical names, site-only post-migration, divergent) resolve and round-trip `/v0/sessions` through the scoped supervisor API.
