### PR TITLE
feat(discord): opt-in acceptance of bot-authored messages in bound rooms

### DIFF
--- a/discord/commands/bind-room/help.md
+++ b/discord/commands/bind-room/help.md
@@ -41,3 +41,21 @@ Useful flags:
 - `--max-peer-triggered-publishes-per-root N`
 - `--max-total-peer-deliveries-per-root N`
 - `--max-peer-triggered-publishes-per-session-per-minute N`
+
+Bot-authored inbound messages are ignored by default (`reason=bot_message`). A room
+binding can opt in so other operators' agents (e.g. a shared guild of mayor bots) can
+reach the bound session like a human author would — normal targeting rules still apply
+(mention-only rooms still require this bot's @mention):
+
+- `--allow-bot-author USER_ID` — accept this bot author (repeatable; additive)
+- `--remove-bot-author USER_ID` / `--clear-bot-authors`
+- `--enable-guild-bot-authors` / `--disable-guild-bot-authors` — wildcard: accept any
+  bot able to post in the bound channel. The trust boundary is guild membership: only
+  bots your guild admins admitted can post there, and a newly admitted bot needs no
+  per-binding config. Use only in private, membership-controlled guilds.
+- `--max-accepted-bot-author-messages-per-minute N` — anti-loop cap per (binding,
+  author); default 6, `0` disables acceptance. Over-limit messages are ignored with
+  `reason=bot_author_rate_limited`. The gateway's own messages are never accepted.
+
+Example — trust all mayor bots in a private ops guild:
+  gc discord bind-room --guild-id 2234... --enable-guild-bot-authors 1234... mayor

--- a/discord/scripts/discord_chat_bind.py
+++ b/discord/scripts/discord_chat_bind.py
@@ -51,6 +51,37 @@ def main(argv: list[str]) -> int:
     parser.add_argument("--max-peer-triggered-publishes-per-root", type=int, default=None)
     parser.add_argument("--max-total-peer-deliveries-per-root", type=int, default=None)
     parser.add_argument("--max-peer-triggered-publishes-per-session-per-minute", type=int, default=None)
+    parser.add_argument(
+        "--allow-bot-author",
+        action="append",
+        default=None,
+        metavar="USER_ID",
+        help="Accept inbound messages from this bot author in the bound room (repeatable; additive)",
+    )
+    parser.add_argument(
+        "--remove-bot-author",
+        action="append",
+        default=None,
+        metavar="USER_ID",
+        help="Remove a previously allowed bot author (repeatable)",
+    )
+    parser.add_argument("--clear-bot-authors", action="store_true", help="Clear the allowed bot author list")
+    parser.add_argument(
+        "--enable-guild-bot-authors",
+        action="store_true",
+        help="Accept messages from ANY bot able to post in this bound channel (trust boundary = guild membership)",
+    )
+    parser.add_argument(
+        "--disable-guild-bot-authors",
+        action="store_true",
+        help="Disable the guild-wide bot author wildcard",
+    )
+    parser.add_argument(
+        "--max-accepted-bot-author-messages-per-minute",
+        type=int,
+        default=None,
+        help="Anti-loop cap per (binding, bot author); 0 disables acceptance outright",
+    )
     parser.add_argument("conversation_id", help="Discord DM, channel, or thread id")
     parser.add_argument("session_name", nargs="+", help="Gas City session name(s)")
     args = parser.parse_args(argv)
@@ -79,6 +110,12 @@ def main(argv: list[str]) -> int:
         enable_flag="--allow-untargeted-peer-fanout",
         disable_flag="--disallow-untargeted-peer-fanout",
     )
+    guild_bot_authors = _optional_bool(
+        args.enable_guild_bot_authors,
+        args.disable_guild_bot_authors,
+        enable_flag="--enable-guild-bot-authors",
+        disable_flag="--disable-guild-bot-authors",
+    )
 
     room_policy: dict[str, Any] = {}
     if ambient_read is not None:
@@ -95,6 +132,30 @@ def main(argv: list[str]) -> int:
         room_policy["max_total_peer_deliveries_per_root"] = args.max_total_peer_deliveries_per_root
     if args.max_peer_triggered_publishes_per_session_per_minute is not None:
         room_policy["max_peer_triggered_publishes_per_session_per_minute"] = args.max_peer_triggered_publishes_per_session_per_minute
+    if guild_bot_authors is not None:
+        room_policy["allow_guild_bots"] = guild_bot_authors
+    if args.max_accepted_bot_author_messages_per_minute is not None:
+        room_policy["max_accepted_bot_author_messages_per_minute"] = args.max_accepted_bot_author_messages_per_minute
+    if args.clear_bot_authors or args.allow_bot_author or args.remove_bot_author:
+        # additive edit: start from the existing binding's list (set_chat_binding merges
+        # dict keys but replaces list values wholesale)
+        existing = common.resolve_chat_binding(
+            common.load_config(), common.chat_binding_id(args.kind, args.conversation_id)
+        )
+        existing_policy = existing.get("policy") if isinstance(existing, dict) else None
+        current: list[str] = []
+        if not args.clear_bot_authors and isinstance(existing_policy, dict):
+            current = [str(v).strip() for v in (existing_policy.get("allowed_bot_authors") or []) if str(v).strip()]
+        for value in args.allow_bot_author or []:
+            normalized = str(value).strip()
+            if not normalized.isdigit():
+                raise SystemExit(f"--allow-bot-author expects a Discord snowflake, got: {value!r}")
+            if normalized not in current:
+                current.append(normalized)
+        for value in args.remove_bot_author or []:
+            normalized = str(value).strip()
+            current = [v for v in current if v != normalized]
+        room_policy["allowed_bot_authors"] = current
 
     if args.kind != "room" and room_policy:
         raise SystemExit("room policy flags require --kind room")

--- a/discord/scripts/discord_gateway_service.py
+++ b/discord/scripts/discord_gateway_service.py
@@ -634,6 +634,65 @@ def bound_room_claims_message(config: dict[str, Any], channel_id: str, parent_id
     return False
 
 
+# --- opt-in acceptance of bot-authored messages (default: dropped) -----------------
+# Cross-gateway agent participation: another operator's bot posting in a room bound on
+# this gateway. Off unless the binding's policy opts in via explicit author ids or the
+# guild-scoped wildcard (any bot able to post in the bound channel — the trust boundary
+# is guild membership, which the guild's admins control). The gateway's own bot id is
+# never accepted (hard anti-echo). A per-(binding, author) sliding-window rate limit
+# bounds mention loops; state is in-process (resets on gateway restart by design).
+_BOT_AUTHOR_ACCEPT_WINDOW_SECONDS = 60.0
+_bot_author_accept_times: dict[tuple[str, str], list[tuple[float, str]]] = {}
+
+
+def _bot_author_rate_ok(binding_key: str, author_id: str, per_minute: int, message_id: str) -> bool:
+    # Idempotent per message id: the extmsg and legacy paths may both consult the gate
+    # for the same message — it must count once.
+    if per_minute <= 0:
+        return False
+    now = time.monotonic()
+    key = (binding_key, author_id)
+    window = [(t, mid) for (t, mid) in _bot_author_accept_times.get(key, []) if now - t < _BOT_AUTHOR_ACCEPT_WINDOW_SECONDS]
+    if message_id and any(mid == message_id for (_t, mid) in window):
+        _bot_author_accept_times[key] = window
+        return True
+    if len(window) >= per_minute:
+        _bot_author_accept_times[key] = window
+        return False
+    window.append((now, message_id))
+    _bot_author_accept_times[key] = window
+    return True
+
+
+def bot_author_acceptance(config: dict[str, Any], message: dict[str, Any], bot_user_id: str) -> tuple[bool, str]:
+    """Return (accepted, ignore_reason) for a bot-authored inbound message."""
+    author = message.get("author") or {}
+    author_id = str(author.get("id", "")).strip()
+    if not author_id or author_id == bot_user_id:
+        return False, "bot_message"
+    guild_id = str(message.get("guild_id", "")).strip()
+    channel_id = str(message.get("channel_id", "")).strip()
+    if not guild_id or not channel_id:
+        return False, "bot_message"  # DM-side stays closed (Discord bots cannot DM bots)
+    binding = explicit_room_binding(config, channel_id)
+    if binding is None:
+        parent_id = _resolve_thread_parent(channel_id)
+        if parent_id:
+            binding = explicit_room_binding(config, parent_id)
+    if binding is None:
+        return False, "bot_message"
+    policy = common.binding_peer_policy(binding)
+    allowed = bool(policy.get("allow_guild_bots")) or author_id in (policy.get("allowed_bot_authors") or [])
+    if not allowed:
+        return False, "bot_message"
+    binding_key = str(binding.get("id", "")).strip() or channel_id
+    per_minute = int(policy.get("max_accepted_bot_author_messages_per_minute", 0) or 0)
+    message_id = str(message.get("id", "")).strip()
+    if not _bot_author_rate_ok(binding_key, author_id, per_minute, message_id):
+        return False, "bot_author_rate_limited"
+    return True, ""
+
+
 def ambient_bindings_config_signature() -> tuple[int, int, int] | None:
     try:
         stat_result = os.stat(common.config_path())
@@ -1244,7 +1303,9 @@ def process_inbound_message(message: dict[str, Any], bot_user_id: str) -> dict[s
     ingress_id = message_ingress_id(message)
     author = message.get("author") or {}
     if bool(author.get("bot")) or str(author.get("id", "")).strip() == bot_user_id:
-        return {"status": "ignored", "reason": "bot_message", "ingress_id": ingress_id}
+        accepted, ignore_reason = bot_author_acceptance(common.load_config(), message, bot_user_id)
+        if not accepted:
+            return {"status": "ignored", "reason": ignore_reason, "ingress_id": ingress_id}
 
     guild_id = str(message.get("guild_id", "")).strip()
     channel_id = str(message.get("channel_id", "")).strip()
@@ -1928,7 +1989,9 @@ class GatewayWorker:
         try:
             author = message.get("author") or {}
             if bool(author.get("bot")) or str(author.get("id", "")).strip() == bot_user_id:
-                return False  # Skip bot messages.
+                accepted, _ignore_reason = bot_author_acceptance(common.load_config(), message, bot_user_id)
+                if not accepted:
+                    return False  # Skip bot messages (legacy path re-drops with a receipt).
             guild_id = str(message.get("guild_id", "")).strip()
             config = common.load_config()
             app_id = str(config.get("app", {}).get("application_id", "")).strip()

--- a/discord/scripts/discord_intake_common.py
+++ b/discord/scripts/discord_intake_common.py
@@ -488,6 +488,12 @@ def default_room_peer_policy() -> dict[str, Any]:
         "max_peer_triggered_publishes_per_root": 1,
         "max_total_peer_deliveries_per_root": 8,
         "max_peer_triggered_publishes_per_session_per_minute": 5,
+        # Bot-authored inbound messages (cross-gateway mayor bots etc.) are dropped by
+        # default. Opt in per binding: explicit author ids, or trust every bot able to
+        # post in this bound channel (i.e. members your guild admins admitted).
+        "allowed_bot_authors": [],
+        "allow_guild_bots": False,
+        "max_accepted_bot_author_messages_per_minute": 6,
     }
 
 
@@ -521,6 +527,18 @@ def _normalize_peer_policy(policy: dict[str, Any] | None, defaults: dict[str, An
                 raw.get(
                     "max_peer_triggered_publishes_per_session_per_minute",
                     defaults["max_peer_triggered_publishes_per_session_per_minute"],
+                )
+                or 0
+            ),
+        ),
+        "allowed_bot_authors": _normalize_allowlist(raw.get("allowed_bot_authors", defaults["allowed_bot_authors"])),
+        "allow_guild_bots": _coerce_bool(raw.get("allow_guild_bots"), defaults["allow_guild_bots"]),
+        "max_accepted_bot_author_messages_per_minute": max(
+            0,
+            int(
+                raw.get(
+                    "max_accepted_bot_author_messages_per_minute",
+                    defaults["max_accepted_bot_author_messages_per_minute"],
                 )
                 or 0
             ),

--- a/discord/tests/test_discord_gateway_service.py
+++ b/discord/tests/test_discord_gateway_service.py
@@ -2177,3 +2177,139 @@ class DiscordGatewayServiceTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class BotAuthorOptInTests(unittest.TestCase):
+    """Opt-in acceptance of bot-authored inbound messages (default: dropped)."""
+
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self._old_environ = os.environ.copy()
+        os.environ["GC_CITY_ROOT"] = self.tempdir.name
+        gateway_service.CHANNEL_INFO_CACHE.clear()
+        gateway_service.CHANNEL_INFO_FETCH_LOCKS.clear()
+        gateway_service.STALE_RECLAIM_LOCKS.clear()
+        gateway_service.INGRESS_PROCESS_LOCKS.clear()
+        gateway_service.GC_API_HEALTH_CACHE["checked_at"] = 0.0
+        gateway_service.GC_API_HEALTH_CACHE["reachable"] = True
+        gateway_service.AMBIENT_ROOM_BINDINGS_CACHE["config_signature"] = None
+        gateway_service.AMBIENT_ROOM_BINDINGS_CACHE["bindings"] = {}
+        gateway_service._bot_author_accept_times.clear()
+
+    def tearDown(self) -> None:
+        os.environ.clear()
+        os.environ.update(self._old_environ)
+
+    def _bind_room(self, extra_policy: dict | None = None) -> None:
+        policy = {"ambient_read_enabled": True}
+        policy.update(extra_policy or {})
+        common.set_chat_binding(
+            common.load_config(), "room", "22", ["sky"], guild_id="1", policy=policy
+        )
+
+    def _bot_message(self, message_id: str = "801", author_id: str = "77") -> dict:
+        return {
+            "id": message_id,
+            "guild_id": "1",
+            "channel_id": "22",
+            "content": "@sky status ping",
+            "mentions": [],
+            "author": {"id": author_id, "username": "peer-mayor", "bot": True},
+        }
+
+    def _process(self, message: dict):
+        with mock.patch.object(
+            common,
+            "session_index_by_name",
+            return_value={"sky": {"session_name": "sky", "state": "active"}},
+        ), mock.patch.object(
+            common, "deliver_session_message", return_value={"status": "accepted"}
+        ):
+            return gateway_service.process_inbound_message(message, bot_user_id="999")
+
+    def test_bot_message_dropped_by_default(self) -> None:
+        self._bind_room()
+        outcome = self._process(self._bot_message())
+        self.assertEqual(outcome["status"], "ignored")
+        self.assertEqual(outcome["reason"], "bot_message")
+
+    def test_explicitly_allowed_bot_author_routes(self) -> None:
+        self._bind_room({"allowed_bot_authors": ["77"]})
+        outcome = self._process(self._bot_message())
+        self.assertEqual(outcome["status"], "delivered")
+
+    def test_guild_bot_wildcard_routes_any_bot_author(self) -> None:
+        self._bind_room({"allow_guild_bots": True})
+        outcome = self._process(self._bot_message(author_id="4242"))
+        self.assertEqual(outcome["status"], "delivered")
+
+    def test_own_bot_id_never_accepted_even_with_wildcard(self) -> None:
+        self._bind_room({"allow_guild_bots": True})
+        outcome = self._process(self._bot_message(author_id="999"))
+        self.assertEqual(outcome["status"], "ignored")
+        self.assertEqual(outcome["reason"], "bot_message")
+
+    def test_unlisted_bot_author_still_dropped(self) -> None:
+        self._bind_room({"allowed_bot_authors": ["4242"]})
+        outcome = self._process(self._bot_message(author_id="77"))
+        self.assertEqual(outcome["status"], "ignored")
+        self.assertEqual(outcome["reason"], "bot_message")
+
+    def test_bot_message_in_unbound_channel_dropped(self) -> None:
+        self._bind_room({"allow_guild_bots": True})
+        message = self._bot_message()
+        message["channel_id"] = "33"  # no binding here; wildcard on "22" must not leak
+        with mock.patch.object(gateway_service, "_resolve_thread_parent", return_value=""):
+            outcome = self._process(message)
+        self.assertEqual(outcome["status"], "ignored")
+        self.assertEqual(outcome["reason"], "bot_message")
+
+    def test_bot_dm_always_dropped(self) -> None:
+        common.set_chat_binding(common.load_config(), "dm", "55", ["sky"])
+        message = {
+            "id": "802",
+            "channel_id": "55",
+            "content": "dm ping",
+            "author": {"id": "77", "username": "peer-mayor", "bot": True},
+        }
+        outcome = self._process(message)
+        self.assertEqual(outcome["status"], "ignored")
+        self.assertEqual(outcome["reason"], "bot_message")
+
+    def test_rate_limit_caps_accepted_bot_messages(self) -> None:
+        self._bind_room(
+            {"allowed_bot_authors": ["77"], "max_accepted_bot_author_messages_per_minute": 2}
+        )
+        self.assertEqual(self._process(self._bot_message("810")).get("status"), "delivered")
+        self.assertEqual(self._process(self._bot_message("811")).get("status"), "delivered")
+        outcome = self._process(self._bot_message("812"))
+        self.assertEqual(outcome["status"], "ignored")
+        self.assertEqual(outcome["reason"], "bot_author_rate_limited")
+
+    def test_rate_charge_idempotent_per_message_id(self) -> None:
+        self._bind_room(
+            {"allowed_bot_authors": ["77"], "max_accepted_bot_author_messages_per_minute": 1}
+        )
+        self.assertEqual(self._process(self._bot_message("820")).get("status"), "delivered")
+        # same message consulted again (extmsg + legacy both gate): not double-charged
+        accepted, reason = gateway_service.bot_author_acceptance(
+            common.load_config(), self._bot_message("820"), "999"
+        )
+        self.assertTrue(accepted)
+        self.assertEqual(reason, "")
+
+    def test_zero_rate_disables_acceptance(self) -> None:
+        self._bind_room(
+            {"allowed_bot_authors": ["77"], "max_accepted_bot_author_messages_per_minute": 0}
+        )
+        outcome = self._process(self._bot_message("830"))
+        self.assertEqual(outcome["status"], "ignored")
+        self.assertEqual(outcome["reason"], "bot_author_rate_limited")
+
+    def test_human_messages_unaffected(self) -> None:
+        self._bind_room()
+        message = self._bot_message("840")
+        message["author"] = {"id": "u-1", "username": "alice"}
+        outcome = self._process(message)
+        self.assertEqual(outcome["status"], "delivered")


### PR DESCRIPTION
## Problem
The gateway unconditionally ignores every bot-authored inbound message
(`process_inbound_message` + the extmsg path, `reason=bot_message`). Sensible anti-echo
hygiene — but it forecloses agent-to-agent participation entirely: in a shared guild of
cooperating operators' bots (e.g. several Gas City mayors), no bot can ever reach another
bot's bound session. Mentions, roles, and bindings are irrelevant; the drop happens at
ingest. Operators discover this only by staring at `chat-ingress` receipts.

## Change (default-off, per-binding, mirrors the room peer-policy pattern)
- `policy.allowed_bot_authors` — explicit Discord user-id allowlist.
- `policy.allow_guild_bots` — wildcard: accept any bot able to post in the bound
  channel. Trust boundary = guild membership (guild admins control who can post);
  a newly admitted bot needs zero per-binding config.
- `policy.max_accepted_bot_author_messages_per_minute` — anti-loop cap per
  (binding, author); default 6; `0` disables acceptance; message-id idempotent
  (the extmsg and legacy paths may both consult the gate for one message).
- The gateway's **own** bot id is never accepted (hard anti-echo). Bot DMs stay
  closed (Discord bots cannot DM each other anyway).
- Accepted messages follow **all existing routing rules** — mention-only rooms still
  require this bot's @mention; ambient/targeting/peer semantics unchanged.
- Rejections keep `reason=bot_message`; over-limit gets `reason=bot_author_rate_limited`.
- `bind-room` flags: `--allow-bot-author` (repeatable, additive) / `--remove-bot-author`
  / `--clear-bot-authors` / `--enable-guild-bot-authors` / `--disable-guild-bot-authors`
  / `--max-accepted-bot-author-messages-per-minute N`. Help text updated.

## Safety
- Unconfigured bindings behave byte-identically to today (default drop).
- Loop containment: per-author sliding-window cap + own-id hard block + all existing
  mention/targeting gates. Rate state is in-process (documented; resets on restart).
- The wildcard is deliberately **binding-scoped**, not global: it trusts only bots that
  can already post in that specific bound channel of a membership-controlled guild.

## Tests
11 new tests (`BotAuthorOptInTests`): default drop, explicit accept, wildcard accept,
own-id never accepted, unlisted bot dropped, unbound channel no-leak, bot-DM drop,
rate-limit trip, message-id idempotency, zero-rate disable, human regression.
Full discord suite: **270 tests OK** on upstream main (0c1fc59) + this branch.

