### PR TITLE
Fix gastown Boot watchdog wake loop

### DIFF
--- a/gastown/agents/boot/prompt.template.md
+++ b/gastown/agents/boot/prompt.template.md
@@ -13,9 +13,11 @@ from wisps, pane output, and mail.
 
 ## Your Lifecycle
 
-`mode = "always"` keeps the `boot` identity present. `wake_mode = "fresh"`
-gives each wake a new provider context. Observe, decide, act, drain-ack, exit.
-Do not rely on prior conversation context or handoff mail. Narrow scope keeps each wake cheap.
+`mode = "on_demand"` reserves the `boot` identity without immediately
+recreating it after a clean drain. A city-scoped cooldown order wakes Boot
+periodically, and `wake_mode = "fresh"` gives each wake a new provider context.
+Observe, decide, act, drain-ack, exit. Do not rely on prior conversation
+context or handoff mail. Narrow scope keeps each wake cheap.
 
 ---
 
@@ -93,8 +95,8 @@ exit
 ```
 
 `drain-ack` tells the controller you're finished. The controller cleans
-up this provider session and can wake the configured `boot` identity again
-with a fresh provider context.
+up this provider session. The cooldown order can wake the configured `boot`
+identity again with a fresh provider context on the next tick.
 
 ---
 

--- a/gastown/assets/scripts/boot-watchdog.sh
+++ b/gastown/assets/scripts/boot-watchdog.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+message=${GASTOWN_BOOT_MESSAGE:-"Boot watchdog tick"}
+last_error=""
+targets=()
+
+add_target() {
+    local target=$1
+    local existing
+
+    [[ -n "$target" ]] || return 0
+    for existing in "${targets[@]}"; do
+        [[ "$existing" != "$target" ]] || return 0
+    done
+    targets+=("$target")
+}
+
+if [[ -n "${GASTOWN_BOOT_TARGET:-}" ]]; then
+    add_target "$GASTOWN_BOOT_TARGET"
+else
+    if [[ -n "${GC_PACK_NAME:-}" ]]; then
+        add_target "$GC_PACK_NAME.boot"
+    fi
+    add_target "boot"
+fi
+
+for target in "${targets[@]}"; do
+    if output=$(gc session nudge "$target" "$message" 2>&1); then
+        printf '%s\n' "$output"
+        exit 0
+    fi
+    last_error="target $target failed: $output"
+done
+
+printf 'boot watchdog: unable to nudge boot target; set GASTOWN_BOOT_TARGET for non-standard bindings. %s\n' "$last_error" >&2
+exit 1

--- a/gastown/orders/boot-watchdog.toml
+++ b/gastown/orders/boot-watchdog.toml
@@ -1,0 +1,12 @@
+[order]
+description = "Wake Boot to check Deacon health"
+# Boot is intentionally on-demand: every wake uses a fresh provider context and
+# the prompt drain-acks when the single watchdog pass is complete. The cooldown
+# order provides the periodic tick without making the controller re-create Boot
+# immediately after every clean drain-ack.
+scope = "city"
+exec = "\"$PACK_DIR/assets/scripts/boot-watchdog.sh\""
+trigger = "cooldown"
+interval = "30m"
+timeout = "30s"
+idempotent = true

--- a/gastown/pack.toml
+++ b/gastown/pack.toml
@@ -39,7 +39,7 @@ mode = "always"
 [[named_session]]
 template = "boot"
 scope = "city"
-mode = "always"
+mode = "on_demand"
 
 [[named_session]]
 template = "witness"

--- a/gastown/tests/test_gastown_pack_assets.sh
+++ b/gastown/tests/test_gastown_pack_assets.sh
@@ -130,6 +130,67 @@ test_composition_is_documented() {
         fail "pack.toml should not reference the retired maintenance pack import"
 }
 
+test_boot_watchdog_uses_ordered_on_demand_lifecycle() {
+    local pack order script prompt
+    pack="$GASTOWN/pack.toml"
+    order="$GASTOWN/orders/boot-watchdog.toml"
+    script="$GASTOWN/assets/scripts/boot-watchdog.sh"
+    prompt="$GASTOWN/agents/boot/prompt.template.md"
+
+    [[ -f "$order" ]] || fail "boot watchdog order should be present"
+    [[ -f "$script" ]] || fail "boot watchdog script should be present"
+    [[ -x "$script" ]] || fail "boot watchdog script should be executable"
+    parse_toml "$pack" "$order"
+
+    python3 - "$pack" <<'PY' || fail "boot named session should be on_demand, not always"
+import sys
+import tomllib
+
+with open(sys.argv[1], "rb") as handle:
+    data = tomllib.load(handle)
+for session in data.get("named_session", []):
+    if session.get("template") == "boot":
+        if session.get("scope") != "city" or session.get("mode") != "on_demand":
+            raise SystemExit(1)
+        break
+else:
+    raise SystemExit(1)
+PY
+
+    python3 - "$order" <<'PY' || fail "boot watchdog order should be a city-scoped cooldown exec"
+import sys
+import tomllib
+
+with open(sys.argv[1], "rb") as handle:
+    order = tomllib.load(handle)["order"]
+if order.get("scope") != "city":
+    raise SystemExit(1)
+if order.get("trigger") != "cooldown":
+    raise SystemExit(1)
+if order.get("interval") != "30m":
+    raise SystemExit(1)
+if order.get("timeout") != "30s":
+    raise SystemExit(1)
+if order.get("idempotent") is not True:
+    raise SystemExit(1)
+if order.get("exec") != '"$PACK_DIR/assets/scripts/boot-watchdog.sh"':
+    raise SystemExit(1)
+PY
+
+    grep -F 'message=${GASTOWN_BOOT_MESSAGE:-"Boot watchdog tick"}' "$script" >/dev/null ||
+        fail "boot watchdog script should default to the standard tick message"
+    grep -F 'gc session nudge "$target" "$message"' "$script" >/dev/null ||
+        fail "boot watchdog script should nudge the resolved boot target"
+    grep -F 'GASTOWN_BOOT_TARGET' "$script" >/dev/null ||
+        fail "boot watchdog script should expose an explicit target override"
+    ! grep -F '`mode = "always"` keeps the `boot` identity present' "$prompt" >/dev/null ||
+        fail "boot prompt must not describe boot as an always session"
+    grep -F '`mode = "on_demand"` reserves the `boot` identity' "$prompt" >/dev/null ||
+        fail "boot prompt should document the on_demand lifecycle"
+    grep -F 'cooldown order' "$prompt" >/dev/null ||
+        fail "boot prompt should explain that an order wakes boot"
+}
+
 test_polecat_startup_uses_standard_hook_claim() {
     local agent prompt propulsion
     agent="$GASTOWN/agents/polecat/agent.toml"
@@ -219,6 +280,7 @@ test_retired_dog_formulas_are_not_reintroduced
 test_shutdown_dance_contracts_are_executable
 test_shutdown_dance_lifecycle_and_audit_contracts
 test_composition_is_documented
+test_boot_watchdog_uses_ordered_on_demand_lifecycle
 test_polecat_startup_uses_standard_hook_claim
 test_review_leg_contract_forbids_synthetic_mutation
 test_refinery_direct_merge_is_worktree_safe_and_fail_closed


### PR DESCRIPTION
## Summary
- Change the Gastown boot named session from `always` to `on_demand` so a clean `drain-ack` does not immediately recreate a fresh provider context.
- Add a city-scoped, idempotent cooldown exec order that nudges Boot every 30 minutes through a pack-local script.
- Update Boot prompt lifecycle docs and add an asset regression test for the ordered on-demand lifecycle.

## Incident
`ga-ylib` showed repeated `session.stopped` after clean drain-ack followed by immediate `session.woke` events for `gastown.boot`. Source tracing showed the controller intentionally re-wakes drained `mode = "always"` named sessions; the pack contract was the mismatch because Boot prompt explicitly says observe, `drain-ack`, and exit each wake.

## Verification
- `bash gastown/tests/test_gastown_pack_assets.sh`
- `make registry-format-validate`
- `make registry-validate GC=gc`
- `bash -n gastown/assets/scripts/boot-watchdog.sh`
- Fake-`gc` script checks for default and `GASTOWN_BOOT_TARGET` target selection
