### PR TITLE
fix(gastown): mayor wake_mode should be resume, not fresh

### DIFF
--- a/gastown/agents/mayor/agent.toml
+++ b/gastown/agents/mayor/agent.toml
@@ -1,5 +1,5 @@
 scope = "city"
-wake_mode = "fresh"
+wake_mode = "resume"
 work_dir = ".gc/agents/mayor"
 idle_timeout = "1h"
 max_active_sessions = 1


### PR DESCRIPTION
Note: @julianknutsen I don't know gascity internals well enough to know if this the right move. But I was encountering the problem below and this is what came from Claude and can confirm working Gas City with gastown pack now as expected.

## Problem Addressed

`gastown/agents/mayor/agent.toml` sets `wake_mode = "fresh"`, so every wake starts a brand-new provider session instead of resuming the prior conversation. Mayor'''s per-wake prompt includes a large boilerplate context block ("Mayor Context" — theory of operation, role definition, command reference, etc.), so every fresh wake pays that full context cost again.

Combined with mayor'''s wake frequency (mail delivery, nudges, dispatch checks), this repeatedly tripped gascity'''s churn-quarantine logic (`checkChurn`/`recordChurn` in `cmd/gc/session_reconcile.go`): a session that survives past the 30s crash-stability threshold but dies before the 5-minute productivity threshold, three times in a row, gets quarantined with `sleep_reason=context-churn`. Observed directly on a live city — mayor cycled through repeated short-lived wakes and was quarantined multiple times in a single session.

`wake_mode=fresh` is documented in gascity as "the polecat pattern" — intended for short-lived, disposable workers. Mayor is the opposite: the persistent global coordinator meant to run continuously for the town'''s lifetime.

## Root Cause

All seven gastown roles (mayor, deacon, witness, refinery, boot, dog, polecat) were stamped with `wake_mode = "fresh"` in a single bulk port commit, `dcb4e15` ("Port gastown and maintenance packs", 76 files, no linked PR), with no per-role review. The only later touch to mayor'''s `agent.toml` was **#73** ("chore(gastown): sync embedded pack updates"), which mechanically re-synced the file without revisiting `wake_mode`. This looks like an unreviewed scaffold default rather than a deliberate choice for a persistent coordinator role.

## Fix

One-line change: `wake_mode = "fresh"` → `wake_mode = "resume"` in `gastown/agents/mayor/agent.toml`.

## Testing

- Verified via `gc config explain --agent mayor` that the resolved config now shows `wake_mode = "resume"` for mayor while other roles (boot, deacon, dog) remain `"fresh"`, confirming the change is correctly scoped.
- Applied via a city-level `[[patches.agent]]` override first to validate on a live city before landing this pack change; after clearing mayor'''s `churn_count`/quarantine (`gc session wake gastown.mayor`) and restarting, mayor stayed continuously `active` past the 5-minute productivity threshold with `churn_count=0`, `wake_attempts=0`, no quarantine — no further churn observed.

## Related

- Root cause commit: `dcb4e15` ("Port gastown and maintenance packs")
- Last (unrelated) touch to this file: #73
