### PR TITLE
fix(slack-full): redact token-bearing uploadURL from 2 remaining leak sites (download + getUploadURL)

### DIFF
--- a/slack-full/adapter/main.go
+++ b/slack-full/adapter/main.go
@@ -1672,7 +1672,14 @@ func slackGetUploadURL(token, filename string, length int) (*slackGetUploadURLRe
 	}
 	var sr slackGetUploadURLResp
 	if err := json.Unmarshal(respBody, &sr); err != nil {
-		return nil, fmt.Errorf("decode slack: %w (body=%s)", err, string(respBody))
+		// Do not embed respBody: a truncated/partial response can still
+		// carry upload_url — pre-signed token included — and this error
+		// reaches both log.Printf and the HTTP receipt body upstream.
+		// Status, size, and the unmarshal error (which reports offsets,
+		// not content) are enough to diagnose a malformed response.
+		// gpk-la1y.
+		return nil, fmt.Errorf("decode slack getUploadURLExternal response (status %s, %d bytes): %w",
+			httpResp.Status, len(respBody), err)
 	}
 	return &sr, nil
 }
@@ -1754,7 +1761,12 @@ func slackCompleteUpload(token string, req slackCompleteUploadReq) (*slackComple
 	}
 	var sr slackCompleteUploadResp
 	if err := json.Unmarshal(respBody, &sr); err != nil {
-		return nil, fmt.Errorf("decode slack: %w (body=%s)", err, string(respBody))
+		// Do not embed respBody: completeUploadExternal responses carry
+		// full file objects (url_private, url_private_download) whose
+		// URLs can bear auth tokens, and this error reaches log.Printf
+		// and the HTTP receipt body upstream. gpk-la1y.
+		return nil, fmt.Errorf("decode slack completeUploadExternal response (status %s, %d bytes): %w",
+			httpResp.Status, len(respBody), err)
 	}
 	return &sr, nil
 }
@@ -2423,14 +2435,22 @@ func safeFilename(name string) string {
 func isSlackFileURL(rawURL string) (bool, error) {
 	u, err := url.ParseRequestURI(rawURL)
 	if err != nil {
-		return false, fmt.Errorf("parse url_private: %w", err)
+		// The *url.Error text embeds the full raw URL — token-bearing
+		// query included — and this error propagates verbatim into
+		// slackDownloadToFile's returned error and adapter logs. Unwrap
+		// to the bare cause and report a redacted form instead. gpk-la1y.
+		var uerr *url.Error
+		if errors.As(err, &uerr) {
+			err = uerr.Err
+		}
+		return false, fmt.Errorf("parse url_private %q: %w", redactSlackURL(rawURL), err)
 	}
 	if !u.IsAbs() {
 		// ParseRequestURI accepts absolute paths (e.g. "/files-pri/...") and
 		// protocol-relative URLs ("//attacker.com/...") without an error;
 		// IsAbs() returns false for both, so they are caught here. A forged
 		// url_private must be a full absolute URL, never a path.
-		return false, fmt.Errorf("url_private not absolute: %q", rawURL)
+		return false, fmt.Errorf("url_private not absolute: %q", redactSlackURL(rawURL))
 	}
 	if u.Scheme != "https" {
 		return false, nil
@@ -2450,6 +2470,24 @@ func isSlackFileURL(rawURL string) (bool, error) {
 		return true, nil
 	}
 	return false, nil
+}
+
+// redactSlackURL returns a form of raw safe to embed in error messages
+// and logs: the query string is dropped and any userinfo password is
+// masked. Slack CDN url_private links and pre-signed upload URLs carry
+// auth tokens in the query (t=xoxe-..., token=...), and a forged
+// url_private may carry attacker-chosen credentials in
+// user:password@host form. url.URL.Redacted() alone is NOT sufficient:
+// it masks userinfo passwords only and leaves the query intact. For
+// input that does not parse, the fallback cuts at the first '?', which
+// still drops the token-bearing query. gpk-la1y.
+func redactSlackURL(raw string) string {
+	if u, err := url.Parse(raw); err == nil {
+		u.RawQuery = ""
+		return u.Redacted()
+	}
+	safe, _, _ := strings.Cut(raw, "?")
+	return safe
 }
 
 // validateSlackFileURL is the SSRF gate applied to inbound url_private
@@ -2480,40 +2518,47 @@ var slackDialIPGuard = isPrivateOrLoopbackIP
 // validated against the Slack allowlist before any network I/O — see
 // isSlackFileURL for the threat model (gc-0fn).
 func slackDownloadToFile(token, urlPrivate, dest string) error {
+	// Every error below reports safeURL — never the raw urlPrivate — to
+	// keep its token-bearing query and any attacker-chosen userinfo out
+	// of adapter logs (see redactSlackURL for the threat model). The
+	// validateSlackFileURL branch is covered too: isSlackFileURL redacts
+	// its own error messages. gpk-la1y.
+	safeURL := redactSlackURL(urlPrivate)
+	// redactTransport re-wraps a net/http transport failure. Such
+	// failures arrive as a *url.Error whose Error() text embeds the full
+	// request URL (token included), so wrapping it directly with %w would
+	// still leak; unwrap to the underlying cause and report it against
+	// safeURL instead. gpk-la1y.
+	redactTransport := func(action string, e error) error {
+		cause := e
+		var uerr *url.Error
+		if errors.As(e, &uerr) {
+			cause = uerr.Err
+		}
+		return fmt.Errorf("%s %s: %w", action, safeURL, cause)
+	}
+
 	ok, err := validateSlackFileURL(urlPrivate)
 	if err != nil {
 		return fmt.Errorf("validating url_private: %w", err)
 	}
 	if !ok {
-		// Redact userinfo before logging — a forged url_private may carry
-		// attacker-chosen credentials in user:password@host form, which
-		// would otherwise land in adapter logs verbatim. Redacted() also
-		// preserves the host/path for log-scanner matching.
-		safe := urlPrivate
-		if u, perr := url.Parse(urlPrivate); perr == nil {
-			safe = u.Redacted()
-		}
-		return fmt.Errorf("url_private host not in slack allowlist: %q", safe)
+		// safeURL preserves the host/path for log-scanner matching while
+		// masking attacker-chosen credentials and dropping the query.
+		return fmt.Errorf("url_private host not in slack allowlist: %q", safeURL)
 	}
 	req, err := http.NewRequest(http.MethodGet, urlPrivate, nil)
 	if err != nil {
-		return err
+		return redactTransport("build download request to", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 	resp, err := slackHTTPClientSingleton().Do(req)
 	if err != nil {
-		return err
+		return redactTransport("GET", err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode >= 300 {
 		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		// Redact url_private query string before logging — Slack CDN
-		// links can carry t=xoxe-... user tokens that must not reach
-		// the structured error reaching log.Printf upstream.
-		safeURL := urlPrivate
-		if u, perr := url.Parse(urlPrivate); perr == nil {
-			safeURL = u.Redacted()
-		}
 		return fmt.Errorf("GET %s: %s — %s", safeURL, resp.Status, string(respBody))
 	}
 	tmp := dest + ".tmp"
@@ -2652,15 +2697,20 @@ func buildSlackHTTPClient() *http.Client {
 		Timeout:   5 * time.Minute,
 		Transport: transport,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			// Redirect targets carry the same token-bearing query as the
+			// original url_private, and this error's text survives inside
+			// the *url.Error returned by Client.Do — redactTransport only
+			// sanitizes the outer URL, not this message. Redacted() alone
+			// keeps the query, so redact fully here. gpk-la1y.
 			if len(via) >= 10 {
-				return fmt.Errorf("redirect chain exceeded 10 hops at %s", req.URL.Redacted())
+				return fmt.Errorf("redirect chain exceeded 10 hops at %s", redactSlackURL(req.URL.String()))
 			}
 			ok, err := validateSlackFileURL(req.URL.String())
 			if err != nil {
 				return fmt.Errorf("validating redirect target: %w", err)
 			}
 			if !ok {
-				return fmt.Errorf("refusing redirect to non-slack host %q", req.URL.Redacted())
+				return fmt.Errorf("refusing redirect to non-slack host %q", redactSlackURL(req.URL.String()))
 			}
 			return nil
 		},

--- a/slack-full/adapter/main.go
+++ b/slack-full/adapter/main.go
@@ -1700,6 +1700,13 @@ func slackGetUploadURL(token, filename string, length int) (*slackGetUploadURLRe
 // multipart-with-filename pattern as the canonical shape; raw PUT silently
 // degrades to a "ghost upload" the channel post step can't bind to.
 func slackPutFileBytes(uploadURL string, filename string, body []byte) error {
+	// uploadURL is a pre-signed, token-bearing URL (see doc above). Every
+	// error below reports safeURL — never the raw uploadURL — so its embedded
+	// auth never reaches log.Printf or the HTTP receipt at the publishFile
+	// handler's sink. This mirrors slackDownloadToFile's redaction; the two
+	// sibling upload steps (slackGetUploadURL, slackCompleteUpload) already
+	// redact, and this one must too. gpk-la1y.
+	safeURL := redactSlackURL(uploadURL)
 	var buf bytes.Buffer
 	mw := multipart.NewWriter(&buf)
 	part, err := mw.CreateFormFile("filename", filename)
@@ -1714,26 +1721,19 @@ func slackPutFileBytes(uploadURL string, filename string, body []byte) error {
 	}
 	req, err := http.NewRequest(http.MethodPost, uploadURL, &buf)
 	if err != nil {
-		return err
+		return redactTransportError("build upload request to", safeURL, err)
 	}
 	req.Header.Set("Content-Type", mw.FormDataContentType())
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return err
+		return redactTransportError("upload POST to", safeURL, err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode >= 300 {
 		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		// Redact the pre-signed upload URL — its query string carries a
-		// short-lived auth token; strip RawQuery so it does not reach adapter
-		// logs verbatim. url.Redacted() alone only handles userinfo passwords
-		// and would leave query-string tokens intact.
-		safeURL := uploadURL
-		if u, perr := url.Parse(uploadURL); perr == nil {
-			u.RawQuery = ""
-			safeURL = u.String()
-		}
-		return fmt.Errorf("upload POST %s: %s — %s", safeURL, resp.Status, string(respBody))
+		// respBody is untrusted origin content: sanitize control chars
+		// (log-line injection) and scrub any reflected URL/token. gpk-la1y.
+		return fmt.Errorf("upload POST %s: %s — %s", safeURL, resp.Status, sanitizeSlackErrorBody(respBody))
 	}
 	_, _ = io.Copy(io.Discard, resp.Body)
 	return nil
@@ -2588,6 +2588,30 @@ func unwrapURLError(err error) error {
 	return err
 }
 
+// redactTransportError re-wraps a net/http transport failure so no
+// token-bearing URL reaches adapter logs or HTTP receipts, reporting safeURL
+// (a redactSlackURL form) in place of the raw target. unwrapURLError strips
+// the *url.Error wrapper — whose Error() embeds the full request URL —
+// then scrubSlackSecrets removes any token the bare cause still carries.
+// The critical case: net/http parses a redirect Location BEFORE
+// CheckRedirect runs and, on a malformed header, returns a *url.Error whose
+// .Err text interpolates the raw, token-bearing Location verbatim (absolute
+// or relative). Safety rests on unwrapURLError reading only .Err (never
+// .URL, which net/http also sets to the raw redirect target) and on
+// scrubSlackSecrets as the redaction of last resort. The %w wrap is kept
+// when scrubbing is a no-op so errors.Is still matches plain transport
+// errors (e.g. connection-refused); it degrades to %s only on the
+// URL-bearing path. Shared by slackDownloadToFile (GET) and
+// slackPutFileBytes (upload POST). gpk-la1y.
+func redactTransportError(action, safeURL string, e error) error {
+	cause := unwrapURLError(e)
+	causeText := cause.Error()
+	if scrubbed := scrubSlackSecrets(causeText); scrubbed != causeText {
+		return fmt.Errorf("%s %s: %s", action, safeURL, scrubbed)
+	}
+	return fmt.Errorf("%s %s: %w", action, safeURL, cause)
+}
+
 // validateSlackFileURL is the SSRF gate applied to inbound url_private
 // values before slackDownloadToFile sends the bot token. Indirected through
 // a package var so tests of unrelated download mechanics (atomic write,
@@ -2622,28 +2646,10 @@ func slackDownloadToFile(token, urlPrivate, dest string) error {
 	// validateSlackFileURL branch is covered too: isSlackFileURL redacts
 	// its own error messages. gpk-la1y.
 	safeURL := redactSlackURL(urlPrivate)
-	// redactTransport re-wraps a net/http transport failure against
-	// safeURL. unwrapURLError strips the *url.Error wrapper (whose Error()
-	// embeds the full request URL); scrubSlackSecrets then removes any
-	// token the bare cause still carries. The critical case: net/http
-	// parses a redirect Location BEFORE CheckRedirect runs and, on a
-	// malformed header, returns a *url.Error whose .Err text interpolates
-	// the raw, token-bearing Location verbatim — absolute or relative.
-	// Safety rests on unwrapURLError reading only .Err (never .URL, which
-	// net/http also sets to the raw redirect target) and on scrubSlackSecrets
-	// as the redaction of last resort. Keep the %w wrap when scrubbing is a
-	// no-op so errors.Is still matches plain transport errors (e.g.
-	// connection-refused); degrade to %s only on the URL-bearing path.
+	// Transport failures below route through redactTransportError, which
+	// unwraps the *url.Error (whose Error() embeds the full token-bearing
+	// request URL, including a raw redirect Location) and reports safeURL.
 	// gpk-la1y.
-	redactTransport := func(action string, e error) error {
-		cause := unwrapURLError(e)
-		causeText := cause.Error()
-		if scrubbed := scrubSlackSecrets(causeText); scrubbed != causeText {
-			return fmt.Errorf("%s %s: %s", action, safeURL, scrubbed)
-		}
-		return fmt.Errorf("%s %s: %w", action, safeURL, cause)
-	}
-
 	ok, err := validateSlackFileURL(urlPrivate)
 	if err != nil {
 		return fmt.Errorf("validating url_private: %w", err)
@@ -2655,12 +2661,12 @@ func slackDownloadToFile(token, urlPrivate, dest string) error {
 	}
 	req, err := http.NewRequest(http.MethodGet, urlPrivate, nil)
 	if err != nil {
-		return redactTransport("build download request to", err)
+		return redactTransportError("build download request to", safeURL, err)
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 	resp, err := slackHTTPClientSingleton().Do(req)
 	if err != nil {
-		return redactTransport("GET", err)
+		return redactTransportError("GET", safeURL, err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode >= 300 {

--- a/slack-full/adapter/main.go
+++ b/slack-full/adapter/main.go
@@ -180,11 +180,13 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
 	"syscall"
 	"time"
+	"unicode"
 )
 
 const (
@@ -2468,21 +2470,110 @@ func isSlackFileURL(rawURL string) (bool, error) {
 }
 
 // redactSlackURL returns a form of raw safe to embed in error messages
-// and logs: the query string is dropped and any userinfo password is
-// masked. Slack CDN url_private links and pre-signed upload URLs carry
-// auth tokens in the query (t=xoxe-..., token=...), and a forged
-// url_private may carry attacker-chosen credentials in
-// user:password@host form. url.URL.Redacted() alone is NOT sufficient:
-// it masks userinfo passwords only and leaves the query intact. For
-// input that does not parse, the fallback cuts at the first '?', which
-// still drops the token-bearing query. gpk-la1y.
+// and logs: the query string AND fragment are dropped and userinfo is
+// removed entirely, while host/path are preserved so log scanners can
+// still correlate on the CDN link. Slack CDN url_private links and
+// pre-signed upload URLs carry auth tokens in the query (t=xoxe-...,
+// token=...) and sometimes the fragment, and a forged url_private may
+// carry attacker-chosen credentials in user[:password]@host form.
+// url.URL.Redacted() alone is NOT sufficient: it masks the userinfo
+// password only (leaving a bare username or the query/fragment intact),
+// so we clear those fields explicitly.
+//
+// Two input shapes bypass the structural field clears: input url.Parse
+// rejects outright (handled by the '?'/'#' cut + stripURLUserinfo
+// fallback), and an "opaque" URI (scheme:opaque with no "//"), where the
+// credential-bearing text lives in u.Opaque untouched by the clears.
+// url.Parse accepts the opaque form without error, so we detect it and
+// route it through the same textual fallback. Finally, a slackTokenRe
+// backstop guarantees no Slack token shape survives in ANY form
+// (hierarchical, opaque, or backslash-delimited). gpk-la1y.
 func redactSlackURL(raw string) string {
-	if u, err := url.Parse(raw); err == nil {
+	var safe string
+	if u, err := url.Parse(raw); err == nil && u.Opaque == "" {
 		u.RawQuery = ""
-		return u.Redacted()
+		u.Fragment = ""
+		u.RawFragment = ""
+		u.User = nil
+		safe = u.String()
+	} else {
+		safe, _, _ = strings.Cut(raw, "?")
+		safe, _, _ = strings.Cut(safe, "#")
+		safe = stripURLUserinfo(safe)
 	}
-	safe, _, _ := strings.Cut(raw, "?")
-	return safe
+	return slackTokenRe.ReplaceAllString(safe, "[redacted-token]")
+}
+
+// stripURLUserinfo removes a "user[:pass]@" prefix from the authority of
+// a URL-ish string that redactSlackURL could not clear structurally, so
+// forged credentials (or a token stuffed into userinfo) do not survive
+// its fallback. Only the authority between "://" and the next '/' is
+// considered, so an '@' in a later path segment is left alone. Inputs
+// lacking a "://" (e.g. an opaque scheme:host@... or backslash-delimited
+// form) have no authority we can locate textually; the slackTokenRe
+// backstop in redactSlackURL covers token-shaped credentials there. gpk-la1y.
+func stripURLUserinfo(s string) string {
+	i := strings.Index(s, "://")
+	if i < 0 {
+		return s
+	}
+	authStart := i + len("://")
+	rest := s[authStart:]
+	authority := rest
+	if end := strings.IndexByte(rest, '/'); end >= 0 {
+		authority = rest[:end]
+	}
+	at := strings.LastIndexByte(authority, '@')
+	if at < 0 {
+		return s
+	}
+	return s[:authStart] + authority[at+1:] + s[authStart+len(authority):]
+}
+
+// urlInTextRe matches an absolute URL embedded in free-form text,
+// bounded by whitespace, quotes, or angle brackets. It scrubs raw URLs
+// that appear inside error text we do not author — see scrubSlackSecrets.
+var urlInTextRe = regexp.MustCompile(`[a-zA-Z][a-zA-Z0-9+.-]*://[^\s"'<>]+`)
+
+// slackTokenRe matches Slack auth token shapes (xoxb-/xoxe-/xoxp-/xoxa-/
+// xoxr-/xoxs-/xoxd- and xapp- app tokens). It is the backstop for a token
+// that reaches error text WITHOUT travelling inside an absolute URL — a
+// token in a relative redirect Location (no scheme://, so urlInTextRe
+// misses it), or one reflected bare by a compromised-but-allowlisted
+// origin in a 4xx body. gpk-la1y.
+var slackTokenRe = regexp.MustCompile(`(xox[a-zA-Z]|xapp)-[A-Za-z0-9-]+`)
+
+// scrubSlackSecrets removes secrets that must never reach adapter logs or
+// HTTP receipts from free-form text: every embedded absolute URL is passed
+// through redactSlackURL (dropping token-bearing query, fragment, and
+// userinfo), and any bare Slack token shape that survives is replaced.
+// Both passes are required: net/http parses a redirect Location BEFORE
+// CheckRedirect runs and, on failure, interpolates the raw header into a
+// *url.Error's text — and that header may be relative, so the URL pass
+// alone would miss its token. gpk-la1y.
+func scrubSlackSecrets(s string) string {
+	s = urlInTextRe.ReplaceAllStringFunc(s, redactSlackURL)
+	s = slackTokenRe.ReplaceAllString(s, "[redacted-token]")
+	return s
+}
+
+// sanitizeSlackErrorBody makes an untrusted HTTP error-response body safe
+// to embed in an error that reaches log.Printf and an HTTP receipt: it
+// strips control characters (defeating log-line injection via embedded
+// CR/LF) and scrubs any URL or bare Slack token the origin reflected.
+// gpk-la1y.
+func sanitizeSlackErrorBody(b []byte) string {
+	cleaned := strings.Map(func(r rune) rune {
+		switch r {
+		case '\t', '\n', '\r':
+			return ' '
+		}
+		if unicode.IsControl(r) {
+			return -1
+		}
+		return r
+	}, string(b))
+	return scrubSlackSecrets(cleaned)
 }
 
 // unwrapURLError returns the underlying cause of a *url.Error, or err
@@ -2533,10 +2624,25 @@ func slackDownloadToFile(token, urlPrivate, dest string) error {
 	// its own error messages. gpk-la1y.
 	safeURL := redactSlackURL(urlPrivate)
 	// redactTransport re-wraps a net/http transport failure against
-	// safeURL — see unwrapURLError for why the *url.Error cannot be
-	// wrapped raw. gpk-la1y.
+	// safeURL. unwrapURLError strips the *url.Error wrapper (whose Error()
+	// embeds the full request URL); scrubSlackSecrets then removes any
+	// token the bare cause still carries. The critical case: net/http
+	// parses a redirect Location BEFORE CheckRedirect runs and, on a
+	// malformed header, returns a *url.Error whose .Err text interpolates
+	// the raw, token-bearing Location verbatim — absolute or relative.
+	// Safety rests on unwrapURLError reading only .Err (never .URL, which
+	// net/http also sets to the raw redirect target) and on scrubSlackSecrets
+	// as the redaction of last resort. Keep the %w wrap when scrubbing is a
+	// no-op so errors.Is still matches plain transport errors (e.g.
+	// connection-refused); degrade to %s only on the URL-bearing path.
+	// gpk-la1y.
 	redactTransport := func(action string, e error) error {
-		return fmt.Errorf("%s %s: %w", action, safeURL, unwrapURLError(e))
+		cause := unwrapURLError(e)
+		causeText := cause.Error()
+		if scrubbed := scrubSlackSecrets(causeText); scrubbed != causeText {
+			return fmt.Errorf("%s %s: %s", action, safeURL, scrubbed)
+		}
+		return fmt.Errorf("%s %s: %w", action, safeURL, cause)
 	}
 
 	ok, err := validateSlackFileURL(urlPrivate)
@@ -2560,7 +2666,9 @@ func slackDownloadToFile(token, urlPrivate, dest string) error {
 	defer resp.Body.Close()
 	if resp.StatusCode >= 300 {
 		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return fmt.Errorf("GET %s: %s — %s", safeURL, resp.Status, string(respBody))
+		// respBody is untrusted origin content: sanitize control chars
+		// (log-line injection) and scrub any reflected URL/token. gpk-la1y.
+		return fmt.Errorf("GET %s: %s — %s", safeURL, resp.Status, sanitizeSlackErrorBody(respBody))
 	}
 	tmp := dest + ".tmp"
 	// 0o600: file content may be DM-private; rename below preserves this mode. gc-ywe.6.

--- a/slack-full/adapter/main.go
+++ b/slack-full/adapter/main.go
@@ -2493,7 +2493,6 @@ func redactSlackURL(raw string) string {
 	if u, err := url.Parse(raw); err == nil && u.Opaque == "" {
 		u.RawQuery = ""
 		u.Fragment = ""
-		u.RawFragment = ""
 		u.User = nil
 		safe = u.String()
 	} else {

--- a/slack-full/adapter/main.go
+++ b/slack-full/adapter/main.go
@@ -2435,15 +2435,10 @@ func safeFilename(name string) string {
 func isSlackFileURL(rawURL string) (bool, error) {
 	u, err := url.ParseRequestURI(rawURL)
 	if err != nil {
-		// The *url.Error text embeds the full raw URL — token-bearing
-		// query included — and this error propagates verbatim into
-		// slackDownloadToFile's returned error and adapter logs. Unwrap
-		// to the bare cause and report a redacted form instead. gpk-la1y.
-		var uerr *url.Error
-		if errors.As(err, &uerr) {
-			err = uerr.Err
-		}
-		return false, fmt.Errorf("parse url_private %q: %w", redactSlackURL(rawURL), err)
+		// This error propagates verbatim into slackDownloadToFile's
+		// returned error and adapter logs — see unwrapURLError for why
+		// it cannot be wrapped raw. gpk-la1y.
+		return false, fmt.Errorf("parse url_private %q: %w", redactSlackURL(rawURL), unwrapURLError(err))
 	}
 	if !u.IsAbs() {
 		// ParseRequestURI accepts absolute paths (e.g. "/files-pri/...") and
@@ -2490,6 +2485,19 @@ func redactSlackURL(raw string) string {
 	return safe
 }
 
+// unwrapURLError returns the underlying cause of a *url.Error, or err
+// unchanged. A *url.Error's Error() text embeds the full request URL —
+// token-bearing query included — so wrapping one with %w leaks the URL
+// even when the surrounding message is redacted. Callers unwrap here and
+// re-wrap the bare cause against a redactSlackURL form. gpk-la1y.
+func unwrapURLError(err error) error {
+	var uerr *url.Error
+	if errors.As(err, &uerr) {
+		return uerr.Err
+	}
+	return err
+}
+
 // validateSlackFileURL is the SSRF gate applied to inbound url_private
 // values before slackDownloadToFile sends the bot token. Indirected through
 // a package var so tests of unrelated download mechanics (atomic write,
@@ -2524,18 +2532,11 @@ func slackDownloadToFile(token, urlPrivate, dest string) error {
 	// validateSlackFileURL branch is covered too: isSlackFileURL redacts
 	// its own error messages. gpk-la1y.
 	safeURL := redactSlackURL(urlPrivate)
-	// redactTransport re-wraps a net/http transport failure. Such
-	// failures arrive as a *url.Error whose Error() text embeds the full
-	// request URL (token included), so wrapping it directly with %w would
-	// still leak; unwrap to the underlying cause and report it against
-	// safeURL instead. gpk-la1y.
+	// redactTransport re-wraps a net/http transport failure against
+	// safeURL — see unwrapURLError for why the *url.Error cannot be
+	// wrapped raw. gpk-la1y.
 	redactTransport := func(action string, e error) error {
-		cause := e
-		var uerr *url.Error
-		if errors.As(e, &uerr) {
-			cause = uerr.Err
-		}
-		return fmt.Errorf("%s %s: %w", action, safeURL, cause)
+		return fmt.Errorf("%s %s: %w", action, safeURL, unwrapURLError(e))
 	}
 
 	ok, err := validateSlackFileURL(urlPrivate)

--- a/slack-full/adapter/main_test.go
+++ b/slack-full/adapter/main_test.go
@@ -3254,6 +3254,233 @@ func TestSlackPutFileBytesRedactsTokenInError(t *testing.T) {
 	}
 }
 
+// withDownloadToken appends the CDN-style auth token Slack embeds in
+// url_private links (?t=xoxe-...) to a test server URL.
+func withDownloadToken(base string) string {
+	return base + "/files-pri/T123-F456/plot.png?t=xoxe-supersecret-download-token"
+}
+
+func TestSlackDownloadToFileRedactsTokenOn4xx(t *testing.T) {
+	// Slack CDN url_private links carry a t=xoxe-... user token in the
+	// query string. The 4xx error path previously used url.URL.Redacted(),
+	// which masks userinfo passwords only and leaves the query intact, so
+	// the token reached log.Printf upstream. The error must strip the
+	// query string entirely.
+	testAllowAnyURL(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte("forbidden"))
+	}))
+	defer srv.Close()
+
+	dest := filepath.Join(t.TempDir(), "out")
+	err := slackDownloadToFile("xoxb-fake-bot-token", withDownloadToken(srv.URL), dest)
+	if err == nil {
+		t.Fatal("expected error from 403 download server, got nil")
+	}
+	if strings.Contains(err.Error(), "xoxe-supersecret-download-token") {
+		t.Errorf("url_private token leaked in 4xx error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "GET") {
+		t.Errorf("expected error to contain 'GET', got: %v", err)
+	}
+}
+
+func TestSlackDownloadToFileRedactsTokenOnTransportError(t *testing.T) {
+	// A transport failure (DNS, connection refused, timeout, TLS) makes
+	// http.Client.Do return a *url.Error whose Error() embeds the full
+	// request URL — query token and all (net/http's stripPassword redacts
+	// userinfo only). Returning that error raw — or wrapped with %w, which
+	// preserves the inner string — leaks the token into log.Printf
+	// upstream. slackDownloadToFile must unwrap the *url.Error and report
+	// a query-stripped URL instead. Exercise it by closing the listener
+	// before the request (connection refused).
+	testAllowAnyURL(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	unreachable := srv.URL
+	srv.Close() // listener closed → connection refused
+
+	dest := filepath.Join(t.TempDir(), "out")
+	err := slackDownloadToFile("xoxb-fake-bot-token", withDownloadToken(unreachable), dest)
+	if err == nil {
+		t.Fatal("expected transport error from closed server, got nil")
+	}
+	if strings.Contains(err.Error(), "xoxe-supersecret-download-token") {
+		t.Errorf("url_private token leaked in transport-error path: %v", err)
+	}
+	if !strings.Contains(err.Error(), "GET") {
+		t.Errorf("expected error to contain 'GET', got: %v", err)
+	}
+}
+
+func TestSlackGetUploadURLDecodeErrorOmitsBody(t *testing.T) {
+	// A truncated/partial getUploadURLExternal response can fail JSON
+	// decoding while still containing the pre-signed upload_url — token
+	// included. Embedding the raw body in the decode error leaked that
+	// token to both log.Printf and the HTTP receipt body upstream. The
+	// error must describe the failure (status, size, unmarshal error)
+	// without reproducing any body content.
+	cases := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "truncated JSON with upload_url",
+			body: `{"ok":true,"upload_url":"https://files.slack.com/upload/v1/ABC?token=xoxe-supersecret-upload-token","file_id":"F1`,
+		},
+		{
+			name: "HTML error page echoing upload_url",
+			body: `<html>error: https://files.slack.com/upload/v1/ABC?token=xoxe-supersecret-upload-token</html>`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer srv.Close()
+			origBase := slackAPIBase
+			slackAPIBase = srv.URL
+			t.Cleanup(func() { slackAPIBase = origBase })
+
+			resp, err := slackGetUploadURL("xoxb-fake-bot-token", "plot.png", 42)
+			if err == nil {
+				t.Fatalf("expected decode error, got resp=%+v", resp)
+			}
+			if strings.Contains(err.Error(), "xoxe-supersecret-upload-token") {
+				t.Errorf("upload_url token leaked in decode error: %v", err)
+			}
+			if strings.Contains(err.Error(), "files.slack.com") {
+				t.Errorf("response body content leaked in decode error: %v", err)
+			}
+			if !strings.Contains(err.Error(), "decode slack") {
+				t.Errorf("expected error to mention 'decode slack', got: %v", err)
+			}
+		})
+	}
+}
+
+func TestSlackCompleteUploadDecodeErrorOmitsBody(t *testing.T) {
+	// completeUploadExternal responses embed full file objects whose
+	// url_private / url_private_download URLs can bear auth tokens. A
+	// truncated response fails JSON decoding while still containing those
+	// URLs, so the decode error must not reproduce any body content —
+	// same class as the slackGetUploadURL leak above.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"ok":true,"files":[{"id":"F123","url_private":"https://files.slack.com/files-pri/T123-F123/plot.png?t=xoxe-supersecret-file-token"`))
+	}))
+	defer srv.Close()
+	origBase := slackAPIBase
+	slackAPIBase = srv.URL
+	t.Cleanup(func() { slackAPIBase = origBase })
+
+	resp, err := slackCompleteUpload("xoxb-fake-bot-token", slackCompleteUploadReq{})
+	if err == nil {
+		t.Fatalf("expected decode error, got resp=%+v", resp)
+	}
+	if strings.Contains(err.Error(), "xoxe-supersecret-file-token") {
+		t.Errorf("url_private token leaked in decode error: %v", err)
+	}
+	if strings.Contains(err.Error(), "files.slack.com") {
+		t.Errorf("response body content leaked in decode error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "decode slack") {
+		t.Errorf("expected error to mention 'decode slack', got: %v", err)
+	}
+}
+
+func TestIsSlackFileURLErrorsOmitToken(t *testing.T) {
+	// isSlackFileURL's own error messages propagate verbatim into
+	// slackDownloadToFile's "validating url_private" error and adapter
+	// logs. A parse failure previously %w-wrapped the *url.Error, whose
+	// text embeds the full raw URL; the not-absolute branch embedded
+	// rawURL via %q. Both must report a query-stripped form only.
+	cases := []struct {
+		name string
+		raw  string
+	}{
+		{
+			name: "parse failure with token in query",
+			raw:  "https://files.slack.com/files-pri/T1-F1/plot.png?t=xoxe-supersecret-download-token&x=\x7f",
+		},
+		{
+			name: "protocol-relative URL with token in query",
+			raw:  "//attacker.example.com/files-pri/T1-F1/plot.png?t=xoxe-supersecret-download-token",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ok, err := isSlackFileURL(tc.raw)
+			if ok || err == nil {
+				t.Fatalf("expected validation error, got ok=%v err=%v", ok, err)
+			}
+			if strings.Contains(err.Error(), "xoxe-supersecret-download-token") {
+				t.Errorf("url_private token leaked in validation error: %v", err)
+			}
+		})
+	}
+}
+
+func TestSlackDownloadToFileValidationErrorOmitsToken(t *testing.T) {
+	// End-to-end variant of TestIsSlackFileURLErrorsOmitToken: the
+	// validateSlackFileURL error branch in slackDownloadToFile returns
+	// before safeURL is consulted, so redaction must already have
+	// happened inside isSlackFileURL. Uses the production validator —
+	// no testAllowAnyURL override.
+	dest := filepath.Join(t.TempDir(), "out")
+	err := slackDownloadToFile("xoxb-fake-bot-token",
+		"//attacker.example.com/files-pri/T1-F1/plot.png?t=xoxe-supersecret-download-token", dest)
+	if err == nil {
+		t.Fatal("expected validation error for protocol-relative url_private, got nil")
+	}
+	if strings.Contains(err.Error(), "xoxe-supersecret-download-token") {
+		t.Errorf("url_private token leaked in validation error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "validating url_private") {
+		t.Errorf("expected validation-error message, got: %v", err)
+	}
+}
+
+func TestSlackDownloadToFileRedirectRejectionOmitsToken(t *testing.T) {
+	// CheckRedirect's rejection message names the redirect target, which
+	// carries the same token-bearing query as any Slack CDN link. That
+	// message becomes the inner cause of the *url.Error returned by
+	// Client.Do, so redactTransport cannot sanitize it — CheckRedirect
+	// itself must. Previously it used req.URL.Redacted(), which keeps
+	// the query. The validator override allows only the origin server so
+	// the redirect target is rejected; CheckRedirect fires before any
+	// connection to the target is attempted.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r,
+			"https://evil.example.com/steal?t=xoxe-supersecret-redirect-token",
+			http.StatusFound)
+	}))
+	defer srv.Close()
+
+	prevURL := validateSlackFileURL
+	validateSlackFileURL = func(u string) (bool, error) {
+		return strings.HasPrefix(u, srv.URL), nil
+	}
+	prevIP := slackDialIPGuard
+	slackDialIPGuard = func(net.IP) bool { return false }
+	t.Cleanup(func() {
+		validateSlackFileURL = prevURL
+		slackDialIPGuard = prevIP
+	})
+
+	dest := filepath.Join(t.TempDir(), "out")
+	err := slackDownloadToFile("xoxb-fake-bot-token", srv.URL+"/files-pri/T1-F1/plot.png", dest)
+	if err == nil {
+		t.Fatal("expected redirect-rejection error, got nil")
+	}
+	if strings.Contains(err.Error(), "xoxe-supersecret-redirect-token") {
+		t.Errorf("redirect-target token leaked: %v", err)
+	}
+	if !strings.Contains(err.Error(), "refusing redirect") {
+		t.Errorf("expected redirect-rejection message, got: %v", err)
+	}
+}
+
 func TestSlackDownloadToFileRejectsNonSlackHostHTTPS(t *testing.T) {
 	// Forged url_private pointing at a local TLS server. If the SSRF gate
 	// works, slackDownloadToFile must NOT make the HTTP request — verified

--- a/slack-full/adapter/main_test.go
+++ b/slack-full/adapter/main_test.go
@@ -3698,6 +3698,192 @@ func TestSlackHTTPClientRejectsRedirectEndToEnd(t *testing.T) {
 	}
 }
 
+func TestRedactSlackURL(t *testing.T) {
+	// redactSlackURL must strip every token-bearing component — query,
+	// fragment, and userinfo (password AND bare username) — from both
+	// parseable and unparseable URLs, while preserving host/path so log
+	// scanners can still correlate on the CDN link. gpk-la1y.
+	const tok = "xoxe-supersecret-token"
+	cases := []struct {
+		name       string
+		raw        string
+		mustAbsent []string
+		mustHave   []string
+	}{
+		{
+			name:       "query token stripped, host/path preserved",
+			raw:        "https://files.slack.com/files-pri/T1-F2/plot.png?t=" + tok,
+			mustAbsent: []string{tok},
+			mustHave:   []string{"files.slack.com", "/files-pri/T1-F2/plot.png"},
+		},
+		{
+			name:       "fragment token stripped",
+			raw:        "https://files.slack.com/plot.png#t=" + tok,
+			mustAbsent: []string{tok},
+		},
+		{
+			name:       "query and fragment token stripped",
+			raw:        "https://files.slack.com/plot.png?a=" + tok + "#b=" + tok,
+			mustAbsent: []string{tok},
+		},
+		{
+			name:       "userinfo password stripped",
+			raw:        "https://alice:" + tok + "@files.slack.com/p",
+			mustAbsent: []string{tok},
+		},
+		{
+			name:       "bare username stripped",
+			raw:        "https://" + tok + "@files.slack.com/p",
+			mustAbsent: []string{tok},
+		},
+		{
+			name:       "unparseable query token stripped (fallback)",
+			raw:        "https://files.slack.com/p%zz?t=" + tok,
+			mustAbsent: []string{tok},
+		},
+		{
+			name:       "unparseable fragment token stripped (fallback)",
+			raw:        "https://files.slack.com/p%zz#t=" + tok,
+			mustAbsent: []string{tok},
+		},
+		{
+			name:       "unparseable userinfo token stripped (fallback)",
+			raw:        "https://" + tok + "@files.slack.com/p%zz",
+			mustAbsent: []string{tok},
+		},
+		{
+			// url.Parse accepts "scheme:opaque" (no "//") as an opaque URI:
+			// the credential text lands in u.Opaque, which the field clears
+			// never touch. The slackTokenRe backstop must still catch it.
+			name:       "opaque-form token stripped (backstop)",
+			raw:        "https:" + tok + "@evil.example.com/x?t=" + tok,
+			mustAbsent: []string{tok},
+		},
+		{
+			// Backslash-delimited pseudo-URL: no "://" for the fallback to
+			// key on, so again only the backstop saves it.
+			name:       "backslash-form token stripped (backstop)",
+			raw:        `https:\\` + tok + `@evil.example.com\x?t=` + tok,
+			mustAbsent: []string{tok},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := redactSlackURL(tc.raw)
+			for _, s := range tc.mustAbsent {
+				if strings.Contains(got, s) {
+					t.Errorf("redactSlackURL(%q) = %q; must not contain %q", tc.raw, got, s)
+				}
+			}
+			for _, s := range tc.mustHave {
+				if !strings.Contains(got, s) {
+					t.Errorf("redactSlackURL(%q) = %q; must contain %q", tc.raw, got, s)
+				}
+			}
+		})
+	}
+}
+
+func TestSlackDownloadToFileRedactsTokenOnMalformedRedirectLocation(t *testing.T) {
+	// net/http parses a 3xx Location header BEFORE CheckRedirect runs; on a
+	// malformed header it returns a *url.Error whose .Err text interpolates
+	// the RAW, token-bearing Location verbatim, so redactTransport is the
+	// only line of defense. The header is set raw here (http.Redirect would
+	// sanitize it). Covers an absolute Location (scrubbed by the URL pass)
+	// and a relative one (no scheme://, scrubbed only by the bare-token
+	// backstop). gpk-la1y.
+	testAllowAnyURL(t)
+	cases := []struct {
+		name     string
+		location string
+		token    string
+	}{
+		{
+			name:     "absolute malformed Location",
+			location: "https://evil.example.com/%zz?t=xoxe-supersecret-abs-redirect",
+			token:    "xoxe-supersecret-abs-redirect",
+		},
+		{
+			name:     "relative malformed Location",
+			location: "/steal%zz?t=xoxe-supersecret-rel-redirect",
+			token:    "xoxe-supersecret-rel-redirect",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Location", tc.location)
+				w.WriteHeader(http.StatusFound)
+			}))
+			defer srv.Close()
+
+			dest := filepath.Join(t.TempDir(), "out")
+			err := slackDownloadToFile("xoxb-fake-bot-token", withDownloadToken(srv.URL), dest)
+			if err == nil {
+				t.Fatal("expected error from malformed redirect Location, got nil")
+			}
+			if strings.Contains(err.Error(), tc.token) {
+				t.Errorf("redirect Location token leaked: %v", err)
+			}
+			if _, statErr := os.Stat(dest); !errors.Is(statErr, os.ErrNotExist) {
+				t.Errorf("dest %q should not exist after failed redirect, stat err: %v", dest, statErr)
+			}
+		})
+	}
+}
+
+func TestSlackDownloadToFileSanitizes4xxBody(t *testing.T) {
+	// A 4xx response body is untrusted origin content. It must not carry a
+	// reflected Slack token into logs/receipts (an allowlisted origin can be
+	// compromised, or echo the token-bearing request URL), and embedded
+	// CR/LF must be stripped so a malicious body cannot forge extra log
+	// lines. gpk-la1y.
+	testAllowAnyURL(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte("denied\nFORGED-LOG-LINE url=https://files.slack.com/x?token=xoxe-reflected-body-token bare=xoxb-reflected-bare-token"))
+	}))
+	defer srv.Close()
+
+	dest := filepath.Join(t.TempDir(), "out")
+	err := slackDownloadToFile("xoxb-fake-bot-token", withDownloadToken(srv.URL), dest)
+	if err == nil {
+		t.Fatal("expected error from 403 server, got nil")
+	}
+	msg := err.Error()
+	for _, leak := range []string{"xoxe-reflected-body-token", "xoxb-reflected-bare-token"} {
+		if strings.Contains(msg, leak) {
+			t.Errorf("reflected token %q leaked from 4xx body: %v", leak, err)
+		}
+	}
+	if strings.Contains(msg, "\n") {
+		t.Errorf("un-stripped newline enables log-line injection: %q", msg)
+	}
+	if !strings.Contains(msg, "GET") {
+		t.Errorf("expected 'GET' in error, got: %v", err)
+	}
+}
+
+func TestSlackHTTPClientCheckRedirectHopLimitOmitsToken(t *testing.T) {
+	// The redirect hop-limit branch names the current target, which carries
+	// the same token-bearing query as any Slack CDN link. It must redact the
+	// query before the abort message reaches log.Printf. gpk-la1y.
+	client := buildSlackHTTPClient()
+	tokURL := mustParseURL(t, "https://files.slack.com/files-pri/T1-F2/plot.png?t=xoxe-supersecret-hoplimit-token")
+	req := &http.Request{URL: tokURL}
+	manyVia := make([]*http.Request, 11)
+	for i := range manyVia {
+		manyVia[i] = &http.Request{URL: tokURL}
+	}
+	err := client.CheckRedirect(req, manyVia)
+	if err == nil {
+		t.Fatal("expected hop-limit abort, got nil")
+	}
+	if strings.Contains(err.Error(), "xoxe-supersecret-hoplimit-token") {
+		t.Errorf("hop-limit error leaked query token: %v", err)
+	}
+}
+
 func mustParseURL(t *testing.T, s string) *url.URL {
 	t.Helper()
 	u, err := url.Parse(s)

--- a/slack-full/adapter/main_test.go
+++ b/slack-full/adapter/main_test.go
@@ -3864,6 +3864,87 @@ func TestSlackDownloadToFileSanitizes4xxBody(t *testing.T) {
 	}
 }
 
+// withUploadToken appends the auth token a pre-signed Slack upload URL
+// carries in its query (?t=xoxe-...) to a test server URL. The upload URL
+// "itself encodes auth" (see slackPutFileBytes doc), so a leaked upload URL
+// is a leaked credential.
+func withUploadToken(base string) string {
+	return base + "/upload/T123-F456?t=xoxe-supersecret-upload-token"
+}
+
+func TestSlackPutFileBytesRedactsTokenOn4xx(t *testing.T) {
+	// A non-2xx upload response must not leak the pre-signed URL's token into
+	// the error that reaches log.Printf and the publish-file HTTP receipt.
+	// gpk-la1y.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte("forbidden"))
+	}))
+	defer srv.Close()
+
+	err := slackPutFileBytes(withUploadToken(srv.URL), "plot.png", []byte("data"))
+	if err == nil {
+		t.Fatal("expected error from 403 upload server, got nil")
+	}
+	if strings.Contains(err.Error(), "xoxe-supersecret-upload-token") {
+		t.Errorf("upload URL token leaked in 4xx error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "upload POST") {
+		t.Errorf("expected error to contain 'upload POST', got: %v", err)
+	}
+}
+
+func TestSlackPutFileBytesRedactsTokenOnTransportError(t *testing.T) {
+	// A transport failure makes http.Client.Do return a *url.Error whose
+	// Error() embeds the full token-bearing upload URL. slackPutFileBytes
+	// must unwrap it and report a query-stripped URL instead. Exercise it by
+	// closing the listener before the request (connection refused). gpk-la1y.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	unreachable := srv.URL
+	srv.Close() // listener closed → connection refused
+
+	err := slackPutFileBytes(withUploadToken(unreachable), "plot.png", []byte("data"))
+	if err == nil {
+		t.Fatal("expected transport error from closed server, got nil")
+	}
+	if strings.Contains(err.Error(), "xoxe-supersecret-upload-token") {
+		t.Errorf("upload URL token leaked in transport-error path: %v", err)
+	}
+	if !strings.Contains(err.Error(), "upload POST") {
+		t.Errorf("expected error to contain 'upload POST', got: %v", err)
+	}
+}
+
+func TestSlackPutFileBytesSanitizes4xxBody(t *testing.T) {
+	// The upload endpoint's error body is untrusted origin content: a
+	// reflected token or URL must not reach logs/receipts, and embedded CR/LF
+	// must be stripped so a malicious body cannot forge extra log lines.
+	// gpk-la1y.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte("denied\nFORGED-LOG-LINE url=https://files.slack.com/x?token=xoxe-reflected-upload-body-token bare=xoxb-reflected-upload-bare-token"))
+	}))
+	defer srv.Close()
+
+	err := slackPutFileBytes(withUploadToken(srv.URL), "plot.png", []byte("data"))
+	if err == nil {
+		t.Fatal("expected error from 403 upload server, got nil")
+	}
+	msg := err.Error()
+	for _, leak := range []string{
+		"xoxe-reflected-upload-body-token",
+		"xoxb-reflected-upload-bare-token",
+		"xoxe-supersecret-upload-token",
+	} {
+		if strings.Contains(msg, leak) {
+			t.Errorf("token %q leaked from upload 4xx path: %v", leak, err)
+		}
+	}
+	if strings.Contains(msg, "\n") {
+		t.Errorf("un-stripped newline enables log-line injection: %q", msg)
+	}
+}
+
 func TestSlackHTTPClientCheckRedirectHopLimitOmitsToken(t *testing.T) {
 	// The redirect hop-limit branch names the current target, which carries
 	// the same token-bearing query as any Slack CDN link. It must redact the


### PR DESCRIPTION
## Summary
SECURITY (CRIT): closes the remaining 2 of 3 slack-full token-leak sites (site 1 already fixed upstream in #89). Follow-up to the gpk-7kch double-run findings.

- `slackDownloadToFile` (~L2484-2519): 4xx path used `u.Redacted()` which does not strip the query token; transport path returned a raw `*url.Error` leaking the pre-signed URL + query token.
- `slackGetUploadURL` (~L1673-1674): decode-failure error embedded the raw response body, which can contain `upload_url` + its query token; reached both `log.Printf` and the HTTP error response.

Fix: `errors.As` unwrap + redact (strip query via `url.Parse`/clear `RawQuery`, with a `strings.Cut` fallback for unparseable URLs) — the `redactTransport()` pattern from #89, reused consistently across all three sites via a shared `redactSlackURL` + `sanitizeSlackErrorBody` helper.

Rebased 2026-07-05 onto current upstream main (e7bd25d) — see gpk-rp90 for the full rebase/conflict-resolution record. Two expected conflicts resolved against upstream #89 (kept both new test blocks; kept our shared-helper fix over #89's narrower ad-hoc patch, which our fix supersedes without breaking #89's own test).

## Test plan
- [x] `go build ./...` / `go vet ./...` / `go test -race -count=1 ./...` (slack-full/adapter) — 4 consecutive runs
- [x] `go build`/`vet`/`test` (slack-full/cli)
- [x] `pytest slack-full/tests/` — 86 passed
- [x] Reviewed: architect (plan) + code-reviewer + security-reviewer + go-reviewer (diff)

Note: bd-gpk-zwdb (unmerged, not in this branch) independently solves the same `slackDownloadToFile` transport-error problem via a different approach (`redactURLPrivateForLog`). Whoever lands second should reconcile/dedupe — flagged, not resolved here.
