### PR TITLE
fix(gascity): make build-artifact validator robust to stripped sys.path and shallow vendoring

### DIFF
--- a/gascity/assets/scripts/validate_build_artifact.py
+++ b/gascity/assets/scripts/validate_build_artifact.py
@@ -9,15 +9,156 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-try:
-    import yaml
-except ImportError:  # pragma: no cover
-    yaml = None
+def _site_packages_roots() -> list[str]:
+    import site
+
+    roots: list[str] = []
+    for candidate in [site.getusersitepackages(), *site.getsitepackages()]:
+        if candidate and candidate not in roots:
+            roots.append(candidate)
+    return roots
+
+
+def _import_yaml() -> tuple[Any, list[str]]:
+    """Import PyYAML, retrying with site-packages roots that launchers can
+    strip from sys.path (e.g. PYTHONNOUSERSITE=1 hiding a user-site install).
+    Returns the module (or None) and the roots appended before the retry."""
+    try:
+        import yaml as module
+    except ImportError:
+        pass
+    else:
+        return module, []
+    roots = _site_packages_roots()
+    for root in roots:
+        if root not in sys.path:
+            sys.path.append(root)
+    try:
+        import yaml as module
+    except ImportError:
+        return None, roots
+    return module, roots
+
+
+yaml, YAML_SITE_ROOTS_CHECKED = _import_yaml()
 
 
 FRONT_MATTER_RE = re.compile(r"\A---\n(?P<front>.*?)\n---(?:\n|\Z)(?P<body>.*)\Z", re.DOTALL)
-SCHEMA_ROOT = Path(__file__).resolve().parents[2] / "schemas" / "build"
 FORBIDDEN_REQUIRED_FIELD_NAMES = {"owner", "stage-owner", "stage_owner", "persona", "role"}
+
+# Embedded copies of gascity/schemas/build/*.yaml so this script stays
+# self-contained when consumers vendor only the scripts/ subtree (no sibling
+# schemas/ directory at any depth). Those YAML files remain the source of
+# truth; test_validators.py fails if the two drift apart.
+_BUILD_REQUIRED_FRONT_MATTER = [
+    "schema",
+    "workflow.id",
+    "workflow.formula",
+    "methodology.pack",
+    "methodology.name",
+    "producer.formula",
+    "producer.stage",
+    "producer.attempt",
+    "status",
+    "trace",
+]
+_BUILD_COVERAGE_STATUSES = [
+    "covered",
+    "not_applicable",
+    "deferred",
+    "blocked",
+    "out_of_scope",
+    "superseded",
+]
+_REVIEWED_STATUSES = ["draft", "questions", "approved", "changes_required", "blocked", "superseded"]
+_REPORT_STATUSES = ["draft", "approved", "blocked", "superseded"]
+
+EMBEDDED_SCHEMAS: dict[str, dict[str, Any]] = {
+    "gc.build.requirements.v1": {
+        "schema_id": "gc.build.requirements.v1",
+        "artifact": "requirements",
+        "allowed_statuses": _REVIEWED_STATUSES,
+        "required_front_matter": _BUILD_REQUIRED_FRONT_MATTER,
+        "coverage_statuses": _BUILD_COVERAGE_STATUSES,
+        "required_sections": [
+            "Problem Statement",
+            "W6H",
+            "User Stories",
+            "Technical Stories",
+            "Behavior Requirements",
+            "Example Mapping",
+            "Acceptance Criteria",
+            "Out Of Scope",
+            "Open Questions",
+        ],
+    },
+    "gc.build.plan.v1": {
+        "schema_id": "gc.build.plan.v1",
+        "artifact": "plan",
+        "allowed_statuses": _REVIEWED_STATUSES,
+        "required_front_matter": _BUILD_REQUIRED_FRONT_MATTER,
+        "coverage_statuses": _BUILD_COVERAGE_STATUSES,
+        "required_sections": [
+            "Summary",
+            "Current System",
+            "Proposed Implementation",
+            "Non-Goals",
+            "Verification",
+        ],
+    },
+    "gc.build.decomposition.v1": {
+        "schema_id": "gc.build.decomposition.v1",
+        "artifact": "decomposition",
+        "allowed_statuses": _REVIEWED_STATUSES,
+        "required_front_matter": _BUILD_REQUIRED_FRONT_MATTER,
+        "coverage_statuses": _BUILD_COVERAGE_STATUSES,
+        "required_sections": [
+            "Summary",
+            "Selected Downstream Formulas",
+            "Implementation Convoy",
+            "Work Items",
+        ],
+    },
+    "gc.build.implementation-summary.v1": {
+        "schema_id": "gc.build.implementation-summary.v1",
+        "artifact": "implementation-summary",
+        "allowed_statuses": _REPORT_STATUSES,
+        "required_front_matter": _BUILD_REQUIRED_FRONT_MATTER,
+        "coverage_statuses": _BUILD_COVERAGE_STATUSES,
+        "required_sections": [
+            "Summary",
+            "Intended Behavior",
+            "Changed Files",
+            "Verification",
+            "Remaining Risks",
+        ],
+    },
+    "gc.build.review.v1": {
+        "schema_id": "gc.build.review.v1",
+        "artifact": "review",
+        "allowed_statuses": _REVIEWED_STATUSES,
+        "required_front_matter": _BUILD_REQUIRED_FRONT_MATTER,
+        "coverage_statuses": _BUILD_COVERAGE_STATUSES,
+        "required_sections": [
+            "Verdict",
+            "Findings",
+            "Verification",
+        ],
+    },
+    "gc.build.final-report.v1": {
+        "schema_id": "gc.build.final-report.v1",
+        "artifact": "final-report",
+        "allowed_statuses": _REPORT_STATUSES,
+        "required_front_matter": _BUILD_REQUIRED_FRONT_MATTER,
+        "coverage_statuses": _BUILD_COVERAGE_STATUSES,
+        "required_sections": [
+            "Summary",
+            "Outcome",
+            "Artifacts",
+            "Remaining Risks",
+        ],
+    },
+}
 
 
 class ValidationError(Exception):
@@ -62,7 +203,11 @@ def validate_artifact_text(text: str, *, expected_schema: str = "") -> BuildArti
 
 def parse_front_matter(text: str) -> tuple[str, dict[str, Any], str]:
     if yaml is None:
-        raise ValidationError("PyYAML is required to parse build artifacts")
+        raise ValidationError(
+            "PyYAML is required to parse build artifacts; import failed even after "
+            f"appending these site-packages roots to sys.path: {', '.join(YAML_SITE_ROOTS_CHECKED)}. "
+            "Install PyYAML for this interpreter or into one of those roots."
+        )
     match = FRONT_MATTER_RE.match(text)
     if not match:
         raise ValidationError("build artifact must start with YAML front matter")
@@ -74,14 +219,11 @@ def parse_front_matter(text: str) -> tuple[str, dict[str, Any], str]:
 
 
 def load_schema(schema_id: str) -> dict[str, Any]:
-    if yaml is None:
-        raise ValidationError("PyYAML is required to parse build schemas")
-    for path in sorted(SCHEMA_ROOT.glob("*.yaml")):
-        raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
-        if isinstance(raw, dict) and raw.get("schema_id") == schema_id:
-            validate_schema_definition(raw)
-            return raw
-    raise ValidationError(f"unknown build artifact schema {schema_id!r}")
+    schema = EMBEDDED_SCHEMAS.get(schema_id)
+    if schema is None:
+        raise ValidationError(f"unknown build artifact schema {schema_id!r}")
+    validate_schema_definition(schema)
+    return schema
 
 
 def validate_schema_definition(schema: dict[str, Any]) -> None:

--- a/gascity/tests/test_validators.py
+++ b/gascity/tests/test_validators.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
+import os
 import pathlib
+import shutil
+import subprocess
 import sys
 import tempfile
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
 import io
+
+import yaml
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "assets" / "scripts"))
 
@@ -423,6 +428,113 @@ trace:
             self.assertEqual(code, 1)
             self.assertIn("error:", stderr.getvalue())
             self.assertNotIn("Traceback", stderr.getvalue())
+
+    def test_build_artifact_embedded_schemas_match_schema_source_files(self) -> None:
+        embedded = build_artifact_validator.EMBEDDED_SCHEMAS
+
+        self.assertEqual(set(embedded), set(self.SCHEMA_FILES))
+        for schema_id, filename in self.SCHEMA_FILES.items():
+            with self.subTest(schema=schema_id):
+                source = yaml.safe_load((self.SCHEMA_ROOT / filename).read_text(encoding="utf-8"))
+                self.assertEqual(embedded[schema_id], source)
+
+    def test_build_artifact_cli_validates_when_vendored_without_schemas_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            vendored = root / ".gc" / "scripts" / "validate_build_artifact.py"
+            vendored.parent.mkdir(parents=True)
+            shutil.copy2(self.VALIDATOR_SCRIPT, vendored)
+            artifact = root / "requirements.md"
+            artifact.write_text(self.valid_artifact(), encoding="utf-8")
+
+            result = subprocess.run(
+                [sys.executable, str(vendored), "--schema", "gc.build.requirements.v1", "--path", str(artifact)],
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertIn('"ok": true', result.stdout)
+
+    def test_build_artifact_cli_recovers_pyyaml_from_user_site_packages(self) -> None:
+        yaml_package_dir = pathlib.Path(yaml.__file__).resolve().parent
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            artifact = root / "requirements.md"
+            artifact.write_text(self.valid_artifact(), encoding="utf-8")
+            user_base = root / "user-base"
+            env = {key: value for key, value in os.environ.items() if key not in {"PYTHONPATH", "PYTHONUSERBASE"}}
+            env["PYTHONUSERBASE"] = str(user_base)
+            env["PYTHONNOUSERSITE"] = "1"
+            user_site = subprocess.run(
+                [sys.executable, "-S", "-c", "import site; print(site.getusersitepackages())"],
+                env=env,
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout.strip()
+            shutil.copytree(yaml_package_dir, pathlib.Path(user_site) / "yaml")
+            default_import = subprocess.run(
+                [sys.executable, "-S", "-c", "import yaml"], env=env, capture_output=True, text=True
+            )
+            self.assertNotEqual(default_import.returncode, 0, "expected PyYAML to be unimportable under -S")
+
+            provenance = subprocess.run(
+                [
+                    sys.executable,
+                    "-S",
+                    "-c",
+                    f"import sys; sys.path.insert(0, {str(self.VALIDATOR_SCRIPT.parent)!r}); "
+                    "import validate_build_artifact as v; print(v.yaml.__file__)",
+                ],
+                env=env,
+                capture_output=True,
+                text=True,
+            )
+            result = subprocess.run(
+                [sys.executable, "-S", str(self.VALIDATOR_SCRIPT), "--schema", "gc.build.requirements.v1", "--path", str(artifact)],
+                env=env,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(provenance.returncode, 0, provenance.stderr)
+            self.assertTrue(
+                provenance.stdout.strip().startswith(str(user_base)),
+                f"expected PyYAML recovered from {user_base}, got {provenance.stdout!r}",
+            )
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertIn('"ok": true', result.stdout)
+
+    def test_build_artifact_cli_names_site_roots_when_pyyaml_missing_everywhere(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            artifact = root / "requirements.md"
+            artifact.write_text(self.valid_artifact(), encoding="utf-8")
+            poison = root / "poison" / "yaml"
+            poison.mkdir(parents=True)
+            (poison / "__init__.py").write_text('raise ImportError("PyYAML not installed for test")\n', encoding="utf-8")
+            env = {key: value for key, value in os.environ.items() if key != "PYTHONPATH"}
+            env["PYTHONPATH"] = str(root / "poison")
+            expected_root = subprocess.run(
+                [sys.executable, "-c", "import site; print(site.getusersitepackages())"],
+                env=env,
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout.strip()
+
+            result = subprocess.run(
+                [sys.executable, str(self.VALIDATOR_SCRIPT), "--schema", "gc.build.requirements.v1", "--path", str(artifact)],
+                env=env,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+            self.assertIn("PyYAML", result.stderr)
+            self.assertIn(expected_root, result.stderr)
+            self.assertNotIn("Traceback", result.stderr)
 
 
 class VerdictReportValidatorTests(unittest.TestCase):


### PR DESCRIPTION
Fixes two field-reported robustness bugs in `gascity/assets/scripts/validate_build_artifact.py`.

## Bug 1: PyYAML unavailability was deferred to a hard failure, not handled

The script caught `ImportError` at import time and set `yaml = None`, but `parse_front_matter` and `load_schema` then unconditionally raised `PyYAML is required...` — no recovery attempt.

Observed in the field: a check-runner had PyYAML installed only under the invoking user's `~/.local/.../site-packages`, and the launcher excluded user site-packages (reproduced exactly with `PYTHONNOUSERSITE=1`). Every artifact check in that environment failed regardless of artifact validity.

**Fix:** on `ImportError`, retry the import after explicitly appending `site.getusersitepackages()` and `site.getsitepackages()` to `sys.path` (user site first). If yaml is still unavailable, the validation error now names the site-packages roots that were checked, e.g.:

```
error: PyYAML is required to parse build artifacts; import failed even after appending
these site-packages roots to sys.path: /home/ci/.local/lib/python3.12/site-packages, ...
Install PyYAML for this interpreter or into one of those roots.
```

## Bug 2: `SCHEMA_ROOT` path math broke under partial vendoring — and `schemas/` isn't vendored there anyway

`SCHEMA_ROOT = Path(__file__).resolve().parents[2] / "schemas" / "build"` assumed the canonical pack depth. A consumer vendoring only the `scripts/` subtree (observed: `.gc/scripts/validate_build_artifact.py`, two levels deep) made `parents[2]` overshoot — and the `schemas/` directory wasn't vendored at any depth, so path-math fixes alone couldn't work.

**Fix:** the six schema definitions are embedded in the script as `EMBEDDED_SCHEMAS`, and `load_schema` is a direct dict lookup with no filesystem access. Schema lookup now works at any vendoring depth with the script as the only file present. `gascity/schemas/build/*.yaml` remain the source of truth: a new test asserts each embedded definition equals `yaml.safe_load` of its source file (and that the schema-id sets match exactly), so any unmirrored schema edit fails CI. `load_schema` no longer needs yaml at all.

No changes to `build-artifact-valid.sh` or any vendoring logic.

## Tests

Four new tests in `gascity/tests/test_validators.py`, each written first and confirmed to reproduce the original failure before the fix:

- CLI run of a shallow-vendored copy (`.gc/scripts/`, no `schemas/` anywhere) validates successfully
- CLI recovers PyYAML from user site-packages when the default `sys.path` lacks it (`python -S` + `PYTHONUSERBASE`), including asserting the recovered module's provenance
- PyYAML missing everywhere still fails cleanly (exit 1, no traceback) with the checked roots named in stderr
- Embedded schemas stay in sync with `gascity/schemas/build/*.yaml`

## Verification

- Full CI pytest invocation (`tests contributing/tests gascity/tests discord/tests github/tests slack-full/tests slack-channel/tests pr-pipeline/tests`): **734 passed, 11088 subtests**
- Gastown shell tests and root-module `go test .` (embed tests): pass
- Manual reproduction of the exact field scenario (`PYTHONNOUSERSITE=1`, PyYAML only in user site): validator now exits 0
