### PR TITLE
Fix Gas City formula check asset paths

### DIFF
--- a/gascity/formulas/build-base.formula.toml
+++ b/gascity/formulas/build-base.formula.toml
@@ -128,7 +128,7 @@ max_attempts = 3
 
 [steps.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/build-artifact-valid.sh"
+path = "../assets/scripts/checks/build-artifact-valid.sh"
 timeout = "5m"
 
 [[steps]]
@@ -143,7 +143,7 @@ max_attempts = 3
 
 [steps.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/build-artifact-valid.sh"
+path = "../assets/scripts/checks/build-artifact-valid.sh"
 timeout = "5m"
 
 [[steps]]
@@ -165,7 +165,7 @@ max_attempts = 3
 
 [steps.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/build-artifact-valid.sh"
+path = "../assets/scripts/checks/build-artifact-valid.sh"
 timeout = "5m"
 
 [[steps]]
@@ -210,7 +210,7 @@ max_attempts = 3
 
 [steps.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/build-artifact-valid.sh"
+path = "../assets/scripts/checks/build-artifact-valid.sh"
 timeout = "5m"
 
 [[steps]]
@@ -225,7 +225,7 @@ max_attempts = 3
 
 [steps.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/build-artifact-valid.sh"
+path = "../assets/scripts/checks/build-artifact-valid.sh"
 timeout = "5m"
 
 [[steps]]
@@ -240,7 +240,7 @@ max_attempts = 3
 
 [steps.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/build-artifact-valid.sh"
+path = "../assets/scripts/checks/build-artifact-valid.sh"
 timeout = "5m"
 
 [[steps]]

--- a/gascity/formulas/build-basic-review.formula.toml
+++ b/gascity/formulas/build-basic-review.formula.toml
@@ -33,7 +33,7 @@ max_attempts = 6
 
 [template.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/implementation-review-approved.sh"
+path = "../assets/scripts/checks/implementation-review-approved.sh"
 timeout = "10m"
 
 [[template.children]]
@@ -84,5 +84,5 @@ max_attempts = 3
 
 [template.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/build-artifact-valid.sh"
+path = "../assets/scripts/checks/build-artifact-valid.sh"
 timeout = "5m"

--- a/gascity/formulas/build-basic.formula.toml
+++ b/gascity/formulas/build-basic.formula.toml
@@ -33,7 +33,7 @@ max_attempts = 3
 
 [steps.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/build-artifact-valid.sh"
+path = "../assets/scripts/checks/build-artifact-valid.sh"
 timeout = "5m"
 
 [[steps]]
@@ -48,7 +48,7 @@ max_attempts = 3
 
 [steps.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/build-artifact-valid.sh"
+path = "../assets/scripts/checks/build-artifact-valid.sh"
 timeout = "5m"
 
 [[steps]]
@@ -70,7 +70,7 @@ max_attempts = 3
 
 [steps.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/build-artifact-valid.sh"
+path = "../assets/scripts/checks/build-artifact-valid.sh"
 timeout = "5m"
 
 [[steps]]
@@ -124,7 +124,7 @@ max_attempts = 3
 
 [steps.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/build-artifact-valid.sh"
+path = "../assets/scripts/checks/build-artifact-valid.sh"
 timeout = "5m"
 
 [[steps]]

--- a/gascity/formulas/build-from-decompose-base.formula.toml
+++ b/gascity/formulas/build-from-decompose-base.formula.toml
@@ -79,7 +79,7 @@ max_attempts = 3
 
 [steps.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/build-artifact-valid.sh"
+path = "../assets/scripts/checks/build-artifact-valid.sh"
 timeout = "5m"
 
 [[steps]]

--- a/gascity/formulas/build-from-plan-base.formula.toml
+++ b/gascity/formulas/build-from-plan-base.formula.toml
@@ -49,7 +49,7 @@ max_attempts = 3
 
 [steps.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/build-artifact-valid.sh"
+path = "../assets/scripts/checks/build-artifact-valid.sh"
 timeout = "5m"
 
 [[steps]]

--- a/gascity/formulas/build-from-requirements-base.formula.toml
+++ b/gascity/formulas/build-from-requirements-base.formula.toml
@@ -41,7 +41,7 @@ max_attempts = 3
 
 [steps.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/build-artifact-valid.sh"
+path = "../assets/scripts/checks/build-artifact-valid.sh"
 timeout = "5m"
 
 [[steps]]

--- a/gascity/formulas/build-from-review-base.formula.toml
+++ b/gascity/formulas/build-from-review-base.formula.toml
@@ -105,7 +105,7 @@ max_attempts = 3
 
 [steps.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/build-artifact-valid.sh"
+path = "../assets/scripts/checks/build-artifact-valid.sh"
 timeout = "5m"
 
 [[steps]]
@@ -127,7 +127,7 @@ max_attempts = 3
 
 [steps.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/build-artifact-valid.sh"
+path = "../assets/scripts/checks/build-artifact-valid.sh"
 timeout = "5m"
 
 [[steps]]

--- a/gascity/formulas/code-review-base.formula.toml
+++ b/gascity/formulas/code-review-base.formula.toml
@@ -51,5 +51,5 @@ max_attempts = 3
 
 [steps.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/build-artifact-valid.sh"
+path = "../assets/scripts/checks/build-artifact-valid.sh"
 timeout = "5m"

--- a/gascity/formulas/decomposition-base.formula.toml
+++ b/gascity/formulas/decomposition-base.formula.toml
@@ -35,5 +35,5 @@ max_attempts = 3
 
 [steps.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/build-artifact-valid.sh"
+path = "../assets/scripts/checks/build-artifact-valid.sh"
 timeout = "5m"

--- a/gascity/formulas/do-work-item.formula.toml
+++ b/gascity/formulas/do-work-item.formula.toml
@@ -34,5 +34,5 @@ max_attempts = 3
 
 [steps.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/build-artifact-valid.sh"
+path = "../assets/scripts/checks/build-artifact-valid.sh"
 timeout = "5m"

--- a/gascity/formulas/do-work.formula.toml
+++ b/gascity/formulas/do-work.formula.toml
@@ -45,7 +45,7 @@ max_attempts = 3
 
 [steps.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/build-artifact-valid.sh"
+path = "../assets/scripts/checks/build-artifact-valid.sh"
 timeout = "5m"
 
 [[steps]]

--- a/gascity/formulas/fix-loop-base.formula.toml
+++ b/gascity/formulas/fix-loop-base.formula.toml
@@ -62,5 +62,5 @@ max_attempts = 3
 
 [steps.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/build-artifact-valid.sh"
+path = "../assets/scripts/checks/build-artifact-valid.sh"
 timeout = "5m"

--- a/gascity/formulas/github-issue-fix-design-review-work.formula.toml
+++ b/gascity/formulas/github-issue-fix-design-review-work.formula.toml
@@ -34,7 +34,7 @@ max_attempts = 8
 
 [template.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/design-review-approved.sh"
+path = "../assets/scripts/checks/design-review-approved.sh"
 timeout = "10m"
 
 [[template.children]]

--- a/gascity/formulas/implement.formula.toml
+++ b/gascity/formulas/implement.formula.toml
@@ -104,7 +104,7 @@ max_attempts = 3
 
 [steps.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/build-artifact-valid.sh"
+path = "../assets/scripts/checks/build-artifact-valid.sh"
 timeout = "5m"
 
 [[steps]]

--- a/gascity/formulas/implementation-base.formula.toml
+++ b/gascity/formulas/implementation-base.formula.toml
@@ -43,7 +43,7 @@ max_attempts = 3
 
 [steps.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/build-artifact-valid.sh"
+path = "../assets/scripts/checks/build-artifact-valid.sh"
 timeout = "5m"
 
 [[steps]]

--- a/gascity/formulas/implementation-item-base.formula.toml
+++ b/gascity/formulas/implementation-item-base.formula.toml
@@ -32,5 +32,5 @@ max_attempts = 3
 
 [steps.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/build-artifact-valid.sh"
+path = "../assets/scripts/checks/build-artifact-valid.sh"
 timeout = "5m"

--- a/gascity/formulas/planning-base.formula.toml
+++ b/gascity/formulas/planning-base.formula.toml
@@ -55,7 +55,7 @@ max_attempts = 3
 
 [steps.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/build-artifact-valid.sh"
+path = "../assets/scripts/checks/build-artifact-valid.sh"
 timeout = "5m"
 
 [[steps]]
@@ -70,7 +70,7 @@ max_attempts = 3
 
 [steps.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/build-artifact-valid.sh"
+path = "../assets/scripts/checks/build-artifact-valid.sh"
 timeout = "5m"
 
 [[steps]]

--- a/gascity/formulas/review.formula.toml
+++ b/gascity/formulas/review.formula.toml
@@ -58,5 +58,5 @@ max_attempts = 3
 
 [steps.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/build-artifact-valid.sh"
+path = "../assets/scripts/checks/build-artifact-valid.sh"
 timeout = "5m"

--- a/gascity/tests/test_formula_assets.py
+++ b/gascity/tests/test_formula_assets.py
@@ -218,7 +218,7 @@ MODE_VAR_DEFAULTS = {
     "github-pr-review": {"interaction_mode": "interactive", "review_mode": "report"},
 }
 
-BUILD_ARTIFACT_CHECK_SCRIPT = ".gc/scripts/checks/build-artifact-valid.sh"
+BUILD_ARTIFACT_CHECK_SCRIPT = "../assets/scripts/checks/build-artifact-valid.sh"
 
 # One produce attempt plus two bounded schema-repair attempts per artifact stage.
 BUILD_ARTIFACT_GATE_MAX_ATTEMPTS = 3
@@ -2867,6 +2867,15 @@ class FormulaAssetTests(unittest.TestCase):
         for name in FORMULAS:
             with self.subTest(formula=name):
                 self.assertNotIn("gc.source_bead_id", effective_formula_text(root, name))
+
+    def test_formula_check_paths_use_pack_assets(self) -> None:
+        root = pathlib.Path(__file__).resolve().parents[1]
+        formulas_dir = root / "formulas"
+
+        for name in FORMULAS:
+            text = (formulas_dir / f"{name}.formula.toml").read_text(encoding="utf-8")
+            with self.subTest(formula=name):
+                self.assertNotIn('path = ".gc/scripts/checks/', text)
 
     def test_formula_node_descriptions_delegate_to_shadowable_assets(self) -> None:
         root = pathlib.Path(__file__).resolve().parents[1]


### PR DESCRIPTION
## Summary
- point Gas City formula check gates at pack-shipped assets instead of city-local `.gc/scripts/checks` paths
- update formula asset tests to enforce the asset-path contract
- add a regression guard against reintroducing `.gc/scripts/checks` formula paths

## Validation
- `python3 -m pytest gascity/tests/test_formula_assets.py -q`
- real-city smoke in `/data/projects/fff`: fresh `build-basic` workflow generated 7 check beads and 0 legacy `.gc/scripts/checks` paths

## Context
A real control-dispatcher run quarantined a build-basic ralph gate because the formula stamped `.gc/scripts/checks/build-artifact-valid.sh`, but the gascity pack ships the validator under `assets/scripts/checks/`. The formula compiler already resolves `../assets/...` check paths to the installed/cached pack asset, so this moves the pack formulas onto that supported path.