### PR TITLE
Add Postgres backend pack

### DIFF
--- a/bd-gc-postgres/README.md
+++ b/bd-gc-postgres/README.md
@@ -18,6 +18,10 @@ launches a trusted local plugin process over the `beads.backend.v1alpha1`
 newline-delimited JSON protocol. The plugin owns direct Postgres access and
 Beads core talks to it through the plugin adapter.
 
+If the runtime plugin binary is missing during `gc init`, the setup hook runs
+the pack build command itself before provisioning Postgres. This keeps init
+working even when the caller has not run the pack prepare step yet.
+
 ## Configuration
 
 By default, `gc init --beads-backend postgres` provisions a local Postgres

--- a/bd-gc-postgres/README.md
+++ b/bd-gc-postgres/README.md
@@ -20,7 +20,30 @@ Beads core talks to it through the plugin adapter.
 
 ## Configuration
 
-Set these values before running `gc init --beads-backend postgres`:
+By default, `gc init --beads-backend postgres` provisions a local Postgres
+database, login role, generated password, and city schema. The provider stores
+the password in `.beads/.env`, writes redacted connection metadata to
+`.beads/metadata.json`, and runs plugin init against that database.
+
+Local provisioning uses `psql` through the current OS user's local Postgres
+admin access. To use a specific admin connection, set:
+
+```sh
+export GC_POSTGRES_ADMIN_URL='postgres://postgres:admin-secret@127.0.0.1:5432/postgres?sslmode=disable'
+```
+
+Optional local provisioning overrides:
+
+```sh
+export GC_POSTGRES_DATABASE=my_city_beads
+export GC_POSTGRES_USER=my_city_beads
+export GC_POSTGRES_SCHEMA=my_city
+export GC_POSTGRES_HOST=127.0.0.1
+export GC_POSTGRES_PORT=5432
+export GC_POSTGRES_PASSWORD=...
+```
+
+To use an already-provisioned Postgres database instead, set:
 
 ```sh
 export GC_POSTGRES_URL='postgres://beads:secret@127.0.0.1:5432/beads?sslmode=disable'
@@ -48,7 +71,8 @@ export BEADS_PG_PASSWORD=...
 ```
 
 The provider exports `GC_POSTGRES_PASSWORD` as `BEADS_PG_PASSWORD` while running
-plugin init, but it does not persist secrets.
+plugin init. For local provisioning, it persists the generated password in
+`.beads/.env` so trusted Beads and GC commands can reconnect through the plugin.
 
 ## Build
 

--- a/bd-gc-postgres/README.md
+++ b/bd-gc-postgres/README.md
@@ -1,0 +1,63 @@
+# BD GC Postgres
+
+`bd-gc-postgres` is a Gas City beads-backend plugin pack for a Postgres
+backend-process plugin that conforms to the Beads backend plugin protocol from
+our Beads plugin architecture PR.
+
+The pack provides the setup/provider layer and a build command:
+
+- builds `bd-backend-postgres` from the standalone plugin source containing
+  `cmd/bd-backend-postgres`;
+- runs that plugin's `init` method during `gc init`;
+- writes `.beads/metadata.json` with `backend = "postgres"`,
+  `postgres_dsn`, and `postgres_schema`;
+- writes `.beads/config.local.yaml` with the trusted local plugin command.
+
+The runtime shape matches `bd-gc-dl`: Beads from the plugin architecture PR
+launches a trusted local plugin process over the `beads.backend.v1alpha1`
+newline-delimited JSON protocol. The plugin owns direct Postgres access and
+Beads core talks to it through the plugin adapter.
+
+## Configuration
+
+Set these values before running `gc init --beads-backend postgres`:
+
+```sh
+export GC_POSTGRES_URL='postgres://beads:secret@127.0.0.1:5432/beads?sslmode=disable'
+export GC_POSTGRES_SCHEMA=my_city
+```
+
+The provider also accepts the upstream Beads names:
+
+```sh
+export BEADS_POSTGRES_URL='postgres://beads:secret@127.0.0.1:5432/beads?sslmode=disable'
+export BEADS_POSTGRES_SCHEMA=my_city
+```
+
+The plugin redacts any password in the init URL before writing
+`.beads/metadata.json`. For runtime commands, prefer:
+
+```sh
+export GC_POSTGRES_PASSWORD=...
+```
+
+or the upstream Beads variable:
+
+```sh
+export BEADS_PG_PASSWORD=...
+```
+
+The provider exports `GC_POSTGRES_PASSWORD` as `BEADS_PG_PASSWORD` while running
+plugin init, but it does not persist secrets.
+
+## Build
+
+```sh
+gc bd-gc-postgres build backend --install \
+  --plugin-source /data/projects/doltlite-gascity/rigs/beads-backend-postgres-plugin
+```
+
+The default local plugin source is
+`$BD_GC_POSTGRES_PLUGIN_SOURCE` when set. Otherwise the build command clones
+`https://github.com/duncan4123/beads-backend-postgres.git` into the city cache
+and builds from that checkout.

--- a/bd-gc-postgres/README.md
+++ b/bd-gc-postgres/README.md
@@ -6,17 +6,20 @@ our Beads plugin architecture PR.
 
 The pack provides the setup/provider layer and a build command:
 
-- builds `bd-backend-postgres` from the standalone plugin source containing
-  `cmd/bd-backend-postgres`;
+- builds `bd-backend-postgres` and `gc-backend-postgres` from the standalone
+  plugin source;
 - runs that plugin's `init` method during `gc init`;
 - writes `.beads/metadata.json` with `backend = "postgres"`,
-  `postgres_dsn`, and `postgres_schema`;
+  `postgres_dsn`, `postgres_schema`, and both plugin endpoint commands;
 - writes `.beads/config.local.yaml` with the trusted local plugin command.
 
 The runtime shape matches `bd-gc-dl`: Beads from the plugin architecture PR
 launches a trusted local plugin process over the `beads.backend.v1alpha1`
-newline-delimited JSON protocol. The plugin owns direct Postgres access and
-Beads core talks to it through the plugin adapter.
+newline-delimited JSON protocol. GC launches the companion
+`gc-backend-postgres` process over `gascity.backend.v1alpha1` for native
+fastpath operations such as session/status issue queries. The plugin owns
+direct Postgres access and both Beads core and GC talk to it through plugin
+adapters.
 
 If the runtime plugin binary is missing during `gc init`, the setup hook runs
 the pack build command itself before provisioning Postgres. This keeps init
@@ -77,6 +80,8 @@ export BEADS_PG_PASSWORD=...
 The provider exports `GC_POSTGRES_PASSWORD` as `BEADS_PG_PASSWORD` while running
 plugin init. For local provisioning, it persists the generated password in
 `.beads/.env` so trusted Beads and GC commands can reconnect through the plugin.
+The GC fastpath plugin reads only the Postgres credential keys from this local
+file when the process environment does not already provide them.
 
 ## Build
 

--- a/bd-gc-postgres/assets/scripts/agent-menu.sh
+++ b/bd-gc-postgres/assets/scripts/agent-menu.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+# agent-menu.sh — tmux popup menu for switching between GC agent sessions.
+# Usage: agent-menu.sh <client-tty>
+# Called via tmux run-shell from a keybinding (typically prefix-g).
+# Always exits 0 — tmux must never see errors from run-shell.
+#
+# With per-city socket isolation, all sessions on the socket are GC sessions.
+
+client="$1"
+[ -z "$client" ] && exit 0
+
+# Socket-aware tmux command (uses GC_TMUX_SOCKET when set).
+gcmux() { tmux ${GC_TMUX_SOCKET:+-L "$GC_TMUX_SOCKET"} "$@"; }
+
+# Collect all sessions (all are GC sessions on this socket).
+sessions=$(gcmux list-sessions -F '#{session_name}' 2>/dev/null | sort)
+[ -z "$sessions" ] && exit 0
+
+# Build tmux display-menu arguments.
+# Each session gets a numbered shortcut (1-9, then a-z).
+set -- "display-menu" "-T" "#[fg=cyan,bold]Gas City Agents" "-x" "C" "-y" "C"
+
+i=0
+for s in $sessions; do
+    # Shortcut key: 1-9, then a-z.
+    if [ "$i" -lt 9 ]; then
+        key=$((i + 1))
+    elif [ "$i" -lt 35 ]; then
+        key=$(printf "\\$(printf '%03o' $((i - 9 + 97)))")
+    else
+        key=""
+    fi
+
+    set -- "$@" "$s" "$key" "switch-client -c '$client' -t '$s'"
+    i=$((i + 1))
+done
+
+gcmux "$@"

--- a/bd-gc-postgres/assets/scripts/bind-key.sh
+++ b/bd-gc-postgres/assets/scripts/bind-key.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# bind-key.sh — install a tmux prefix keybinding directly.
+# Usage: bind-key.sh <key> <command>
+#
+# Per-city tmux socket isolation (GC_TMUX_SOCKET, set by the controller
+# in internal/runtime/tmux/adapter.go) makes every session on the socket
+# a GC session. There is no non-GC fallback path to preserve, so the
+# binding installs <command> directly without if-shell wrapping.
+#
+# tmux's bind-key naturally overwrites existing bindings; calling this
+# script twice with the same args is a no-op at the tmux level. The
+# early-exit on already-matching binding is an optimization to skip the
+# tmux call.
+set -e
+
+key="$1"
+command="$2"
+
+[ -z "$key" ] || [ -z "$command" ] && exit 1
+
+# Socket-aware tmux command (uses GC_TMUX_SOCKET when set).
+gcmux() { tmux ${GC_TMUX_SOCKET:+-L "$GC_TMUX_SOCKET"} "$@"; }
+
+# Skip the bind-key call if the binding already contains the requested
+# command. Fixed-string substring match is robust against tmux's quoting
+# variations across versions.
+existing=$(gcmux list-keys -T prefix "$key" 2>/dev/null || true)
+if printf '%s' "$existing" | grep -qF "$command"; then
+    exit 0
+fi
+
+gcmux bind-key -T prefix "$key" "$command"

--- a/bd-gc-postgres/assets/scripts/cycle.sh
+++ b/bd-gc-postgres/assets/scripts/cycle.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+# cycle.sh — cycle between Gas City agent sessions in the same scope group.
+# Usage: cycle.sh next|prev <current-session> <client-tty>
+# Called via tmux run-shell from a keybinding.
+#
+# Grouping rules (driven by SDK session-name primitives — no role awareness):
+#   Rig group:      "<rig>--*"     all agents in same rig cycle together.
+#   Scope group:    "<scope>__*"   all agents in same scope cycle together.
+#   Pool:           "<base>-N"     same-base pool members cycle (e.g. dog-1).
+#   Catch-all:      anything else cycles all sessions on the socket.
+#
+# The "--" and "__" separators correspond to the SDK session-name mapping
+# (slash → "--", dot → "__") in internal/agent/session_name.go. Keying on
+# the separator rather than role names lets this script work for any pack,
+# including custom packs whose role taxonomy differs from gastown's.
+
+direction="$1"
+current="$2"
+client="$3"
+
+[ -z "$direction" ] || [ -z "$current" ] || [ -z "$client" ] && exit 0
+
+# Socket-aware tmux command (uses GC_TMUX_SOCKET when set).
+gcmux() { tmux ${GC_TMUX_SOCKET:+-L "$GC_TMUX_SOCKET"} "$@"; }
+
+# Determine the group filter pattern based on session-name shape.
+case "$current" in
+    # Rig-scoped: any "<rig>--*" session.
+    *--*)
+        rig="${current%%--*}"
+        pattern="^${rig}--"
+        ;;
+    # Scope-scoped: any "<scope>__*" session (city or imported scope).
+    *__*)
+        scope="${current%%__*}"
+        pattern="^${scope}__"
+        ;;
+    # Pool: "<base>-N" naming (generic; covers dog-1, dog-2, ... and any
+    # custom pool with the same shape).
+    *-[0-9]*)
+        base="${current%-*}"
+        pattern="^${base}-[0-9][0-9]*$"
+        ;;
+    # Unknown shape — cycle all sessions on this socket.
+    *)
+        pattern="."
+        ;;
+esac
+
+# Get target session: filter to same group, find current, pick next/prev.
+target=$(gcmux list-sessions -F '#{session_name}' 2>/dev/null \
+    | grep "$pattern" \
+    | sort \
+    | awk -v cur="$current" -v dir="$direction" '
+        { a[NR] = $0; if ($0 == cur) idx = NR }
+        END {
+            if (NR <= 1 || idx == 0) exit
+            if (dir == "next") t = (idx % NR) + 1
+            else t = ((idx - 2 + NR) % NR) + 1
+            print a[t]
+        }')
+
+[ -z "$target" ] && exit 0
+gcmux switch-client -c "$client" -t "$target"

--- a/bd-gc-postgres/assets/scripts/gc-bd-gc-postgres-provider.sh
+++ b/bd-gc-postgres/assets/scripts/gc-bd-gc-postgres-provider.sh
@@ -276,8 +276,11 @@ op_init() {
     chmod 700 "$dir/.beads" 2>/dev/null || true
 
     plugin_command="$(resolve_plugin_command)"
+    gascity_plugin_command="$(resolve_gascity_plugin_command)"
     prepare_plugin_command_if_missing "$plugin_command"
+    prepare_plugin_command_if_missing "$gascity_plugin_command"
     [ -x "$plugin_command" ] || die "bd-gc-postgres backend plugin is not executable: $plugin_command"
+    [ -x "$gascity_plugin_command" ] || die "bd-gc-postgres gascity backend plugin is not executable: $gascity_plugin_command"
 
     if [ "$postgres_url_source" = "metadata" ] && [ -z "$postgres_password" ] && ! postgres_dsn_has_password "$postgres_url"; then
         postgres_url=""
@@ -291,9 +294,10 @@ op_init() {
 
     city_root="$(resolve_city_root)"
     trace="${BEADS_BACKEND_POSTGRES_TRACE:-$city_root/.gc/backend-postgres-plugin-trace.jsonl}"
+    gascity_trace="${GASCITY_BACKEND_POSTGRES_TRACE:-$city_root/.gc/backend-postgres-gascity-trace.jsonl}"
     custom_types="${GC_BEADS_CUSTOM_TYPES:-${BEADS_CUSTOM_TYPES:-$custom_types_default}}"
     plugin_init "$dir" "$prefix" "$postgres_schema" "$custom_types" "$plugin_command" "$trace"
-    normalize_metadata "$dir" "$postgres_url" "$postgres_schema" "$plugin_command" "$trace"
+    normalize_metadata "$dir" "$postgres_url" "$postgres_schema" "$plugin_command" "$trace" "$gascity_plugin_command" "$gascity_trace"
     write_local_trust "$dir" "$plugin_command" "$trace"
 }
 
@@ -316,6 +320,19 @@ resolve_plugin_command() {
     fi
     city_root="$(resolve_city_root)"
     printf '%s\n' "$city_root/.gc/runtime/packs/bd-gc-postgres/bin/bd-backend-postgres"
+}
+
+resolve_gascity_plugin_command() {
+    if [ -n "${GC_GASCITY_BACKEND_PLUGIN_COMMAND:-}" ]; then
+        printf '%s\n' "$GC_GASCITY_BACKEND_PLUGIN_COMMAND"
+        return 0
+    fi
+    if [ -n "${GC_POSTGRES_GASCITY_PLUGIN_COMMAND:-}" ]; then
+        printf '%s\n' "$GC_POSTGRES_GASCITY_PLUGIN_COMMAND"
+        return 0
+    fi
+    city_root="$(resolve_city_root)"
+    printf '%s\n' "$city_root/.gc/runtime/packs/bd-gc-postgres/bin/gc-backend-postgres"
 }
 
 prepare_plugin_command_if_missing() {
@@ -417,8 +434,10 @@ normalize_metadata() {
     schema="$3"
     command="$4"
     trace="$5"
+    gascity_command="$6"
+    gascity_trace="$7"
 
-    python3 - "$dir" "$dsn" "$schema" "$command" "$trace" "$postgres_password" <<'PY'
+    python3 - "$dir" "$dsn" "$schema" "$command" "$trace" "$gascity_command" "$gascity_trace" "$postgres_password" <<'PY'
 import json
 import os
 import re
@@ -426,9 +445,10 @@ import sys
 from urllib.parse import parse_qs, unquote, urlparse
 from urllib.parse import quote, urlunparse
 
-dir_path, dsn, schema, command, trace, password = sys.argv[1:7]
+dir_path, dsn, schema, command, trace, gascity_command, gascity_trace, password = sys.argv[1:9]
 metadata_path = os.path.join(dir_path, ".beads", "metadata.json")
 args = ["--trace", trace, "serve"]
+gascity_args = ["--trace", gascity_trace, "serve"]
 
 def parse_postgres_dsn(raw):
     raw = (raw or "").strip()
@@ -498,6 +518,8 @@ metadata.update({
     "postgres_database": parsed["database"] or schema,
     "backend_plugin_command": command,
     "backend_plugin_args": args,
+    "gascity_backend_command": gascity_command,
+    "gascity_backend_args": gascity_args,
 })
 
 with open(metadata_path, "w", encoding="utf-8") as f:

--- a/bd-gc-postgres/assets/scripts/gc-bd-gc-postgres-provider.sh
+++ b/bd-gc-postgres/assets/scripts/gc-bd-gc-postgres-provider.sh
@@ -271,6 +271,14 @@ op_init() {
     if [ -n "$postgres_password" ] && [ -z "${BEADS_PG_PASSWORD:-}" ]; then
         export BEADS_PG_PASSWORD="$postgres_password"
     fi
+
+    mkdir -p "$dir/.beads" "$dir/.gc"
+    chmod 700 "$dir/.beads" 2>/dev/null || true
+
+    plugin_command="$(resolve_plugin_command)"
+    prepare_plugin_command_if_missing "$plugin_command"
+    [ -x "$plugin_command" ] || die "bd-gc-postgres backend plugin is not executable: $plugin_command"
+
     if [ "$postgres_url_source" = "metadata" ] && [ -z "$postgres_password" ] && ! postgres_dsn_has_password "$postgres_url"; then
         postgres_url=""
     fi
@@ -280,12 +288,6 @@ op_init() {
         postgres_password="${BEADS_PG_PASSWORD:-$postgres_password}"
     fi
     postgres_url="$(postgres_url_with_password "$postgres_url" "$postgres_password")"
-
-    plugin_command="$(resolve_plugin_command)"
-    [ -x "$plugin_command" ] || die "bd-gc-postgres backend plugin is not executable: $plugin_command"
-
-    mkdir -p "$dir/.beads" "$dir/.gc"
-    chmod 700 "$dir/.beads" 2>/dev/null || true
 
     city_root="$(resolve_city_root)"
     trace="${BEADS_BACKEND_POSTGRES_TRACE:-$city_root/.gc/backend-postgres-plugin-trace.jsonl}"
@@ -314,6 +316,25 @@ resolve_plugin_command() {
     fi
     city_root="$(resolve_city_root)"
     printf '%s\n' "$city_root/.gc/runtime/packs/bd-gc-postgres/bin/bd-backend-postgres"
+}
+
+prepare_plugin_command_if_missing() {
+    command_path="$1"
+    [ -x "$command_path" ] && return 0
+
+    script_path="$0"
+    case "$script_path" in
+        */*) ;;
+        *) return 0 ;;
+    esac
+    script_dir="$(CDPATH= cd "$(dirname "$script_path")" 2>/dev/null && pwd -P)" || return 0
+    pack_root="$(CDPATH= cd "$script_dir/../.." 2>/dev/null && pwd -P)" || return 0
+    build_script="$pack_root/commands/build/run.sh"
+    [ -x "$build_script" ] || return 0
+
+    city_root="$(resolve_city_root)"
+    echo "bd-gc-postgres: backend plugin missing; running pack prepare command" >&2
+    GC_CITY_PATH="$city_root" "$build_script" backend --install
 }
 
 plugin_init() {

--- a/bd-gc-postgres/assets/scripts/gc-bd-gc-postgres-provider.sh
+++ b/bd-gc-postgres/assets/scripts/gc-bd-gc-postgres-provider.sh
@@ -1,0 +1,321 @@
+#!/bin/sh
+# Provider bridge for the plugin-backed Postgres Beads backend.
+
+set -e
+
+die() {
+    echo "$@" >&2
+    exit 1
+}
+
+custom_types_default="molecule,convoy,message,event,gate,merge-request,agent,role,rig,session,spec,convergence,step"
+
+first_nonempty() {
+    for name in "$@"; do
+        eval "value=\${$name:-}"
+        if [ -n "$value" ]; then
+            printf '%s\n' "$value"
+            return 0
+        fi
+    done
+    return 1
+}
+
+sanitize_database() {
+    python3 - "$1" <<'PY'
+import re
+import sys
+
+raw = sys.argv[1].strip().lower()
+name = re.sub(r"[^a-z0-9_]+", "_", raw)
+name = re.sub(r"_+", "_", name).strip("_")
+if not name:
+    name = "beads"
+if not re.match(r"^[a-z_]", name):
+    name = "beads_" + name
+print(name[:63])
+PY
+}
+
+op_init() {
+    dir="${1:-}"
+    prefix="${2:-}"
+    database="${3:-}"
+    [ -n "$dir" ] && [ -n "$prefix" ] || die "usage: gc-bd-gc-postgres-provider init <dir> <prefix> [database]"
+    command -v python3 >/dev/null 2>&1 || die "python3 is required for bd-gc-postgres provider init"
+
+    postgres_url="$(first_nonempty GC_POSTGRES_URL BEADS_POSTGRES_URL || true)"
+    [ -n "$postgres_url" ] || die "postgres backend requires GC_POSTGRES_URL or BEADS_POSTGRES_URL"
+
+    postgres_schema="$(first_nonempty GC_POSTGRES_SCHEMA BEADS_POSTGRES_SCHEMA || true)"
+    if [ -z "$postgres_schema" ] && [ -n "$database" ]; then
+        postgres_schema="$(sanitize_database "$database")"
+    fi
+    if [ -z "$postgres_schema" ]; then
+        postgres_schema="$(sanitize_database "$prefix")"
+    fi
+
+    postgres_password="$(first_nonempty GC_POSTGRES_PASSWORD BEADS_PG_PASSWORD || true)"
+    if [ -n "$postgres_password" ] && [ -z "${BEADS_PG_PASSWORD:-}" ]; then
+        export BEADS_PG_PASSWORD="$postgres_password"
+    fi
+
+    plugin_command="$(resolve_plugin_command)"
+    [ -x "$plugin_command" ] || die "bd-gc-postgres backend plugin is not executable: $plugin_command"
+
+    mkdir -p "$dir/.beads" "$dir/.gc"
+    chmod 700 "$dir/.beads" 2>/dev/null || true
+
+    city_root="$(resolve_city_root)"
+    trace="${BEADS_BACKEND_POSTGRES_TRACE:-$city_root/.gc/backend-postgres-plugin-trace.jsonl}"
+    custom_types="${GC_BEADS_CUSTOM_TYPES:-${BEADS_CUSTOM_TYPES:-$custom_types_default}}"
+    plugin_init "$dir" "$prefix" "$postgres_schema" "$custom_types" "$plugin_command" "$trace"
+    normalize_metadata "$dir" "$postgres_url" "$postgres_schema" "$plugin_command" "$trace"
+    write_local_trust "$dir" "$plugin_command" "$trace"
+}
+
+resolve_city_root() {
+    if [ -n "${GC_CITY_PATH:-}" ]; then
+        printf '%s\n' "$GC_CITY_PATH"
+        return 0
+    fi
+    pwd -P
+}
+
+resolve_plugin_command() {
+    if [ -n "${GC_BEADS_BACKEND_PLUGIN_COMMAND:-}" ]; then
+        printf '%s\n' "$GC_BEADS_BACKEND_PLUGIN_COMMAND"
+        return 0
+    fi
+    if [ -n "${GC_POSTGRES_BACKEND_PLUGIN_COMMAND:-}" ]; then
+        printf '%s\n' "$GC_POSTGRES_BACKEND_PLUGIN_COMMAND"
+        return 0
+    fi
+    city_root="$(resolve_city_root)"
+    printf '%s\n' "$city_root/.gc/runtime/packs/bd-gc-postgres/bin/bd-backend-postgres"
+}
+
+plugin_init() {
+    dir="$1"
+    prefix="$2"
+    schema="$3"
+    custom_types="$4"
+    command="$5"
+    trace="$6"
+
+    BEADS_POSTGRES_URL="$postgres_url" \
+    GC_POSTGRES_SCHEMA="$schema" \
+    python3 - "$command" "$dir/.beads" "$schema" "$prefix" "$custom_types" "$trace" <<'PY'
+import json
+import subprocess
+import sys
+
+command, beads_dir, schema, prefix, custom_types, trace = sys.argv[1:7]
+proc = subprocess.Popen(
+    [command, "--trace", trace, "serve"],
+    stdin=subprocess.PIPE,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+    text=True,
+)
+counter = 0
+
+def call(method, params=None):
+    global counter
+    counter += 1
+    req = {"id": f"gc-pg-{counter}", "method": method}
+    if params is not None:
+        req["params"] = params
+    proc.stdin.write(json.dumps(req, separators=(",", ":")) + "\n")
+    proc.stdin.flush()
+    line = proc.stdout.readline()
+    if not line:
+        raise SystemExit(f"backend plugin did not answer {method}: {proc.stderr.read().strip()}")
+    resp = json.loads(line)
+    if not resp.get("ok"):
+        err = resp.get("error") or {}
+        raise SystemExit(f"backend plugin {method} failed: {err.get('code', 'error')}: {err.get('message', '')}")
+    return resp.get("result") or {}
+
+try:
+    hello = proc.stdout.readline()
+    if not hello:
+        raise SystemExit("backend plugin did not send hello: " + proc.stderr.read().strip())
+    opened = call("init", {
+        "beads_dir": beads_dir,
+        "database": schema,
+        "branch": "main",
+        "prefix": prefix,
+        "actor": "gascity",
+    })
+    session_id = opened.get("session_id")
+    if custom_types and session_id:
+        tx = call("begin_transaction", {"session_id": session_id, "commit_msg": "gc init custom types"}).get("tx_id")
+        call("tx_set_config", {"session_id": tx, "key": "types.custom", "value": custom_types})
+        call("commit_transaction", {"tx_id": tx})
+    if session_id:
+        call("close", {"session_id": session_id})
+finally:
+    try:
+        proc.stdin.close()
+    except Exception:
+        pass
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=5)
+PY
+}
+
+normalize_metadata() {
+    dir="$1"
+    dsn="$2"
+    schema="$3"
+    command="$4"
+    trace="$5"
+
+    python3 - "$dir" "$dsn" "$schema" "$command" "$trace" "$postgres_password" <<'PY'
+import json
+import os
+import re
+import sys
+from urllib.parse import parse_qs, unquote, urlparse
+
+dir_path, dsn, schema, command, trace, password = sys.argv[1:7]
+metadata_path = os.path.join(dir_path, ".beads", "metadata.json")
+args = ["--trace", trace, "serve"]
+
+def parse_postgres_dsn(raw):
+    raw = (raw or "").strip()
+    out = {"host": "", "port": "", "user": "", "database": "", "password": ""}
+    if raw.startswith(("postgres://", "postgresql://")):
+        u = urlparse(raw)
+        out["host"] = u.hostname or ""
+        out["port"] = str(u.port or 5432)
+        out["user"] = unquote(u.username or "")
+        out["database"] = unquote((u.path or "").lstrip("/"))
+        out["password"] = unquote(u.password or "")
+        query = parse_qs(u.query)
+        if not out["password"] and query.get("password"):
+            out["password"] = query["password"][0]
+        return out
+    for key, value in re.findall(r"([A-Za-z_][A-Za-z0-9_]*)=('[^']*'|\\S+)", raw):
+        value = value.strip("'")
+        k = key.lower()
+        if k == "host":
+            out["host"] = value
+        elif k == "port":
+            out["port"] = value
+        elif k == "user":
+            out["user"] = value
+        elif k == "dbname":
+            out["database"] = value
+        elif k == "password":
+            out["password"] = value
+    if not out["port"]:
+        out["port"] = "5432"
+    return out
+
+parsed = parse_postgres_dsn(dsn)
+with open(metadata_path, "r", encoding="utf-8") as f:
+    metadata = json.load(f)
+
+metadata.update({
+    "database": metadata.get("database") or schema,
+    "backend": "postgres",
+    "postgres_host": parsed["host"],
+    "postgres_port": parsed["port"],
+    "postgres_user": parsed["user"],
+    "postgres_database": parsed["database"] or schema,
+    "backend_plugin_command": command,
+    "backend_plugin_args": args,
+})
+
+with open(metadata_path, "w", encoding="utf-8") as f:
+    json.dump(metadata, f, indent=2, sort_keys=True)
+    f.write("\n")
+os.chmod(metadata_path, 0o600)
+
+password = password or parsed["password"]
+if password:
+    env_path = os.path.join(dir_path, ".beads", ".env")
+    quoted = "'" + password.replace("'", "'\"'\"'") + "'"
+    with open(env_path, "w", encoding="utf-8") as f:
+        f.write("BEADS_PG_PASSWORD=" + quoted + "\n")
+    os.chmod(env_path, 0o600)
+PY
+}
+
+write_local_trust() {
+    dir="$1"
+    command="$2"
+    trace="$3"
+    python3 - "$dir" "$command" "$trace" <<'PY'
+import json
+import os
+import sys
+
+dir_path, command, trace = sys.argv[1:4]
+beads_dir = os.path.join(dir_path, ".beads")
+local_cfg = os.path.join(beads_dir, "config.local.yaml")
+args = ["--trace", trace, "serve"]
+with open(local_cfg, "w", encoding="utf-8") as f:
+    f.write("backend_plugins:\n")
+    f.write("  postgres:\n")
+    f.write(f"    command: {json.dumps(command)}\n")
+    f.write(f"    args: {json.dumps(args)}\n")
+os.chmod(local_cfg, 0o600)
+
+gitignore = os.path.join(beads_dir, ".gitignore")
+existing = ""
+if os.path.exists(gitignore):
+    with open(gitignore, "r", encoding="utf-8") as f:
+        existing = f.read()
+lines = set(existing.splitlines())
+with open(gitignore, "a", encoding="utf-8") as f:
+    if existing and not existing.endswith("\n"):
+        f.write("\n")
+    for entry in ("config.local.yaml", ".env"):
+        if entry not in lines:
+            f.write(entry + "\n")
+os.chmod(gitignore, 0o600)
+PY
+}
+
+op_health() {
+    dir="${1:-.}"
+    metadata="$dir/.beads/metadata.json"
+    [ -f "$metadata" ] || die "postgres backend metadata not found: $metadata"
+    python3 - "$metadata" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as f:
+    data = json.load(f)
+if data.get("backend") != "postgres":
+    raise SystemExit(f"metadata backend is {data.get('backend')!r}, want 'postgres'")
+if not str(data.get("postgres_dsn", "")).strip():
+    raise SystemExit("postgres metadata missing postgres_dsn")
+if not str(data.get("postgres_schema", "")).strip():
+    raise SystemExit("postgres metadata missing postgres_schema")
+PY
+}
+
+case "${1:-}" in
+    init)
+        shift
+        op_init "$@"
+        ;;
+    health|probe)
+        shift
+        op_health "$@"
+        ;;
+    start|ensure-ready|stop|shutdown|recover)
+        exit 0
+        ;;
+    *)
+        die "usage: gc-bd-gc-postgres-provider <init|health|probe|start|ensure-ready|stop|shutdown|recover> ..."
+        ;;
+esac

--- a/bd-gc-postgres/assets/scripts/gc-bd-gc-postgres-provider.sh
+++ b/bd-gc-postgres/assets/scripts/gc-bd-gc-postgres-provider.sh
@@ -37,6 +37,204 @@ print(name[:63])
 PY
 }
 
+city_metadata_value() {
+    key="$1"
+    city_root="$(resolve_city_root)"
+    metadata="$city_root/.beads/metadata.json"
+    [ -f "$metadata" ] || return 1
+    python3 - "$metadata" "$key" <<'PY'
+import json
+import sys
+
+path, key = sys.argv[1:3]
+with open(path, "r", encoding="utf-8") as f:
+    value = json.load(f).get(key) or ""
+if value:
+    print(value)
+PY
+}
+
+postgres_url_with_password() {
+    dsn="$1"
+    password="$2"
+    [ -n "$password" ] || {
+        printf '%s\n' "$dsn"
+        return 0
+    }
+    python3 - "$dsn" "$password" <<'PY'
+import sys
+from urllib.parse import quote, urlparse, urlunparse
+
+dsn, password = sys.argv[1:3]
+if not dsn.startswith(("postgres://", "postgresql://")):
+    print(dsn)
+    raise SystemExit(0)
+u = urlparse(dsn)
+if u.password:
+    print(dsn)
+    raise SystemExit(0)
+host = u.hostname or ""
+if ":" in host and not host.startswith("["):
+    host = f"[{host}]"
+if u.port:
+    host = f"{host}:{u.port}"
+if u.username:
+    netloc = f"{quote(u.username)}:{quote(password)}@{host}"
+else:
+    netloc = host
+print(urlunparse((u.scheme, netloc, u.path, u.params, u.query, u.fragment)))
+PY
+}
+
+postgres_dsn_has_password() {
+    dsn="$1"
+    python3 - "$dsn" <<'PY'
+import re
+import sys
+from urllib.parse import parse_qs, urlparse
+
+dsn = sys.argv[1]
+has_password = False
+if dsn.startswith(("postgres://", "postgresql://")):
+    u = urlparse(dsn)
+    has_password = bool(u.password)
+    if not has_password:
+        has_password = bool(parse_qs(u.query).get("password"))
+else:
+    has_password = bool(re.search(r"(^|\\s)password=('[^']*'|\\S+)", dsn, re.I))
+raise SystemExit(0 if has_password else 1)
+PY
+}
+
+generate_postgres_password() {
+    python3 - <<'PY'
+import secrets
+
+print(secrets.token_urlsafe(32))
+PY
+}
+
+provision_local_postgres() {
+    schema="$1"
+    app_database="$(first_nonempty GC_POSTGRES_DATABASE BEADS_POSTGRES_DATABASE || true)"
+    if [ -z "$app_database" ]; then
+        app_database="$(city_metadata_value postgres_database || true)"
+    fi
+    if [ -z "$app_database" ]; then
+        app_database="gc_$(sanitize_database "$(basename "$(resolve_city_root)")")"
+    else
+        app_database="$(sanitize_database "$app_database")"
+    fi
+
+    app_user="$(first_nonempty GC_POSTGRES_USER BEADS_POSTGRES_USER || true)"
+    if [ -z "$app_user" ]; then
+        app_user="$(city_metadata_value postgres_user || true)"
+    fi
+    if [ -z "$app_user" ]; then
+        app_user="$app_database"
+    else
+        app_user="$(sanitize_database "$app_user")"
+    fi
+
+    app_host="$(first_nonempty GC_POSTGRES_HOST BEADS_POSTGRES_HOST || true)"
+    if [ -z "$app_host" ]; then
+        app_host="$(city_metadata_value postgres_host || true)"
+    fi
+    [ -n "$app_host" ] || app_host="127.0.0.1"
+    app_port="$(first_nonempty GC_POSTGRES_PORT BEADS_POSTGRES_PORT || true)"
+    if [ -z "$app_port" ]; then
+        app_port="$(city_metadata_value postgres_port || true)"
+    fi
+    [ -n "$app_port" ] || app_port="5432"
+
+    postgres_password="$(first_nonempty GC_POSTGRES_PASSWORD BEADS_PG_PASSWORD || true)"
+    [ -n "$postgres_password" ] || postgres_password="$(generate_postgres_password)"
+    export BEADS_PG_PASSWORD="$postgres_password"
+
+    command -v psql >/dev/null 2>&1 || die "postgres backend local provisioning requires psql"
+    python3 - "$app_database" "$app_user" "$postgres_password" "$schema" "$app_host" "$app_port" <<'PY'
+import os
+import re
+import subprocess
+import sys
+from urllib.parse import urlparse, urlunparse
+
+database, user, password, schema, host, port = sys.argv[1:7]
+admin_url = os.environ.get("GC_POSTGRES_ADMIN_URL") or os.environ.get("BEADS_POSTGRES_ADMIN_URL")
+name_re = re.compile(r"^[a-z_][a-z0-9_]{0,62}$")
+
+for kind, value in (("database", database), ("user", user), ("schema", schema)):
+    if not name_re.match(value):
+        raise SystemExit(f"invalid postgres {kind} name after sanitization: {value!r}")
+
+def ident(value):
+    return '"' + value.replace('"', '""') + '"'
+
+def lit(value):
+    return "'" + value.replace("'", "''") + "'"
+
+def admin_dsn(dbname):
+    if not admin_url:
+        return None
+    parsed = urlparse(admin_url)
+    if not parsed.scheme:
+        return admin_url
+    return urlunparse((parsed.scheme, parsed.netloc, "/" + dbname, parsed.params, parsed.query, parsed.fragment))
+
+def psql_cmd(dbname, quiet=True, tuples_only=False):
+    cmd = ["psql", "-X", "-v", "ON_ERROR_STOP=1"]
+    if quiet:
+        cmd.append("-q")
+    if tuples_only:
+        cmd.append("-At")
+    dsn = admin_dsn(dbname)
+    if dsn:
+        cmd.append(dsn)
+    else:
+        cmd.extend(["-d", dbname])
+    return cmd
+
+def run(dbname, sql):
+    subprocess.run(psql_cmd(dbname), input=sql, text=True, check=True)
+
+def scalar(dbname, sql):
+    out = subprocess.check_output(psql_cmd(dbname, tuples_only=True), input=sql, text=True)
+    return out.strip()
+
+if scalar("postgres", f"SELECT 1 FROM pg_roles WHERE rolname = {lit(user)}") == "1":
+    run("postgres", f"ALTER ROLE {ident(user)} WITH LOGIN PASSWORD {lit(password)};\n")
+else:
+    run("postgres", f"CREATE ROLE {ident(user)} LOGIN PASSWORD {lit(password)};\n")
+
+if scalar("postgres", f"SELECT 1 FROM pg_database WHERE datname = {lit(database)}") != "1":
+    run("postgres", f"CREATE DATABASE {ident(database)} OWNER {ident(user)} TEMPLATE template0 LC_COLLATE 'C' LC_CTYPE 'C';\n")
+else:
+    run("postgres", f"ALTER DATABASE {ident(database)} OWNER TO {ident(user)};\n")
+
+run(database, "\n".join([
+    f"CREATE SCHEMA IF NOT EXISTS {ident(schema)} AUTHORIZATION {ident(user)};",
+    f"ALTER SCHEMA {ident(schema)} OWNER TO {ident(user)};",
+    f"GRANT ALL PRIVILEGES ON DATABASE {ident(database)} TO {ident(user)};",
+    f"GRANT USAGE, CREATE ON SCHEMA {ident(schema)} TO {ident(user)};",
+    "",
+]))
+PY
+    echo "bd-gc-postgres: provisioned local Postgres database \"$app_database\" role \"$app_user\" schema \"$schema\"" >&2
+    provisioned_postgres_url="postgres://$app_user@$app_host:$app_port/$app_database?sslmode=disable"
+}
+
+load_city_password_env() {
+    city_root="$(resolve_city_root)"
+    env_file="$city_root/.beads/.env"
+    [ -f "$env_file" ] || return 0
+    # The provider writes this file itself with a single shell-quoted password.
+    # shellcheck disable=SC1090
+    . "$env_file"
+    if [ -n "${BEADS_PG_PASSWORD:-}" ]; then
+        export BEADS_PG_PASSWORD
+    fi
+}
+
 op_init() {
     dir="${1:-}"
     prefix="${2:-}"
@@ -44,10 +242,12 @@ op_init() {
     [ -n "$dir" ] && [ -n "$prefix" ] || die "usage: gc-bd-gc-postgres-provider init <dir> <prefix> [database]"
     command -v python3 >/dev/null 2>&1 || die "python3 is required for bd-gc-postgres provider init"
 
-    postgres_url="$(first_nonempty GC_POSTGRES_URL BEADS_POSTGRES_URL || true)"
-    [ -n "$postgres_url" ] || die "postgres backend requires GC_POSTGRES_URL or BEADS_POSTGRES_URL"
+    load_city_password_env
 
     postgres_schema="$(first_nonempty GC_POSTGRES_SCHEMA BEADS_POSTGRES_SCHEMA || true)"
+    if [ -z "$postgres_schema" ]; then
+        postgres_schema="$(city_metadata_value postgres_schema || true)"
+    fi
     if [ -z "$postgres_schema" ] && [ -n "$database" ]; then
         postgres_schema="$(sanitize_database "$database")"
     fi
@@ -55,10 +255,31 @@ op_init() {
         postgres_schema="$(sanitize_database "$prefix")"
     fi
 
+    postgres_url_source=""
+    postgres_url="$(first_nonempty GC_POSTGRES_URL BEADS_POSTGRES_URL || true)"
+    if [ -n "$postgres_url" ]; then
+        postgres_url_source="env"
+    fi
+    if [ -z "$postgres_url" ]; then
+        postgres_url="$(city_metadata_value postgres_dsn || true)"
+        if [ -n "$postgres_url" ]; then
+            postgres_url_source="metadata"
+        fi
+    fi
+
     postgres_password="$(first_nonempty GC_POSTGRES_PASSWORD BEADS_PG_PASSWORD || true)"
     if [ -n "$postgres_password" ] && [ -z "${BEADS_PG_PASSWORD:-}" ]; then
         export BEADS_PG_PASSWORD="$postgres_password"
     fi
+    if [ "$postgres_url_source" = "metadata" ] && [ -z "$postgres_password" ] && ! postgres_dsn_has_password "$postgres_url"; then
+        postgres_url=""
+    fi
+    if [ -z "$postgres_url" ]; then
+        provision_local_postgres "$postgres_schema"
+        postgres_url="$provisioned_postgres_url"
+        postgres_password="${BEADS_PG_PASSWORD:-$postgres_password}"
+    fi
+    postgres_url="$(postgres_url_with_password "$postgres_url" "$postgres_password")"
 
     plugin_command="$(resolve_plugin_command)"
     [ -x "$plugin_command" ] || die "bd-gc-postgres backend plugin is not executable: $plugin_command"
@@ -182,6 +403,7 @@ import os
 import re
 import sys
 from urllib.parse import parse_qs, unquote, urlparse
+from urllib.parse import quote, urlunparse
 
 dir_path, dsn, schema, command, trace, password = sys.argv[1:7]
 metadata_path = os.path.join(dir_path, ".beads", "metadata.json")
@@ -218,13 +440,37 @@ def parse_postgres_dsn(raw):
         out["port"] = "5432"
     return out
 
+def metadata_postgres_dsn(raw):
+    raw = (raw or "").strip()
+    if raw.startswith(("postgres://", "postgresql://")):
+        u = urlparse(raw)
+        host = u.hostname or ""
+        if ":" in host and not host.startswith("["):
+            host = f"[{host}]"
+        if u.port:
+            host = f"{host}:{u.port}"
+        netloc = host
+        if u.username:
+            netloc = f"{quote(unquote(u.username))}@{host}"
+        return urlunparse((u.scheme, netloc, u.path, u.params, u.query, u.fragment))
+    if not raw:
+        return raw
+    parts = []
+    for key, value in re.findall(r"([A-Za-z_][A-Za-z0-9_]*)=('[^']*'|\\S+)", raw):
+        if key.lower() == "password":
+            continue
+        parts.append(f"{key}={value}")
+    return " ".join(parts) if parts else raw
+
 parsed = parse_postgres_dsn(dsn)
 with open(metadata_path, "r", encoding="utf-8") as f:
     metadata = json.load(f)
 
 metadata.update({
-    "database": metadata.get("database") or schema,
+    "database": schema,
     "backend": "postgres",
+    "postgres_dsn": metadata_postgres_dsn(dsn),
+    "postgres_schema": schema,
     "postgres_host": parsed["host"],
     "postgres_port": parsed["port"],
     "postgres_user": parsed["user"],

--- a/bd-gc-postgres/assets/scripts/status-popup.sh
+++ b/bd-gc-postgres/assets/scripts/status-popup.sh
@@ -1,0 +1,123 @@
+#!/bin/sh
+# status-popup.sh - popup body for status-right clicks.
+# Usage: status-popup.sh <agent-name> [city-path]
+# Lists hook-ready work through gc hook without claiming and shows mail preview.
+
+agent="$1"
+city="${2:-${GC_CITY:-${GC_CITY_PATH:-${GT_ROOT:-${GC_DIR:-}}}}}"
+gc_cmd="${GC_BIN:-gc}"
+
+[ -z "$agent" ] && agent="${GC_AGENT:-${GC_SESSION_NAME:-}}"
+
+if [ -n "$city" ] && [ -d "$city" ]; then
+    cd "$city" 2>/dev/null || true
+fi
+
+run_bounded() {
+    if command -v timeout >/dev/null 2>&1; then
+        timeout 5s "$@"
+    else
+        "$@"
+    fi
+}
+
+render_ready_work() {
+    if command -v python3 >/dev/null 2>&1; then
+        GC_HOOK_POPUP_LIMIT="${GC_HOOK_POPUP_LIMIT:-20}" python3 -c '
+import json
+import os
+import sys
+import textwrap
+
+try:
+    limit = int(os.environ.get("GC_HOOK_POPUP_LIMIT", "20"))
+except ValueError:
+    limit = 20
+
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    data = []
+
+if isinstance(data, dict):
+    data = [data]
+if not isinstance(data, list):
+    data = []
+
+items = []
+for item in data:
+    if not isinstance(item, dict):
+        continue
+    ident = item.get("id") or item.get("bead_id") or item.get("issue_id") or item.get("key") or ""
+    title = item.get("title") or item.get("summary") or item.get("name") or ""
+    status = item.get("status") or ""
+    if ident or title:
+        items.append((str(ident), str(title), str(status)))
+
+if not items:
+    print("No hook-ready work.")
+    raise SystemExit(0)
+
+for ident, title, status in items[:limit]:
+    prefix = ident
+    if status:
+        prefix = f"{prefix} [{status}]"
+    line = f"{prefix} - {title}" if title else prefix
+    wrapped = textwrap.wrap(line, width=92, break_long_words=False) or [line]
+    for idx, part in enumerate(wrapped):
+        print(part if idx == 0 else "  " + part)
+
+remaining = len(items) - limit
+if remaining > 0:
+    print(f"... {remaining} more")
+'
+    elif command -v jq >/dev/null 2>&1; then
+        jq -r '
+            if type == "array" then . else [] end
+            | if length == 0 then "No hook-ready work."
+              else .[]
+                | ((.id // .bead_id // .issue_id // .key // "") as $id
+                  | (.title // .summary // .name // "") as $title
+                  | if $title == "" then $id else "\($id) - \($title)" end)
+              end
+        ' 2>/dev/null || printf 'No hook-ready work.\n'
+    else
+        printf 'Install python3 or jq to render hook-ready work.\n'
+    fi
+}
+
+printf 'Hook-ready work'
+if [ -n "$agent" ]; then
+    printf ' for %s' "$agent"
+fi
+printf '\n===============\n'
+
+if [ -z "$agent" ]; then
+    printf 'No agent name available.\n'
+elif command -v "$gc_cmd" >/dev/null 2>&1; then
+    if [ -n "$city" ]; then
+        run_bounded "$gc_cmd" --city "$city" hook "$agent" 2>/dev/null | render_ready_work
+    else
+        run_bounded "$gc_cmd" hook "$agent" 2>/dev/null | render_ready_work
+    fi
+else
+    printf 'gc not found.\n'
+fi
+
+printf '\nMail preview\n============\n'
+if command -v "$gc_cmd" >/dev/null 2>&1; then
+    if [ -n "$city" ]; then
+        mail_output=$(run_bounded "$gc_cmd" --city "$city" mail inbox 2>/dev/null || true)
+    else
+        mail_output=$(run_bounded "$gc_cmd" mail inbox 2>/dev/null || true)
+    fi
+    if [ -n "$mail_output" ]; then
+        printf '%s\n' "$mail_output"
+    else
+        printf 'No unread mail\n'
+    fi
+else
+    printf 'gc not found.\n'
+fi
+
+exit 0

--- a/bd-gc-postgres/assets/scripts/tmux-keybindings.sh
+++ b/bd-gc-postgres/assets/scripts/tmux-keybindings.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+# tmux-keybindings.sh — Gas Town navigation keybindings (n/p/g/a + status click)
+# Usage: tmux-keybindings.sh <config-dir> [agent-name]
+CONFIGDIR="$1"
+AGENT="$2"
+city="${GC_CITY:-${GC_CITY_PATH:-${GT_ROOT:-${GC_DIR:-}}}}"
+
+# Socket-aware tmux command (uses GC_TMUX_SOCKET when set).
+gcmux() { tmux ${GC_TMUX_SOCKET:+-L "$GC_TMUX_SOCKET"} "$@"; }
+
+shell_quote() {
+    printf "'"
+    printf '%s' "$1" | sed "s/'/'\\\\''/g"
+    printf "'"
+}
+
+# ── Navigation bindings (prefix table) ────────────────────────────────
+"$CONFIGDIR"/assets/scripts/bind-key.sh n "run-shell '$CONFIGDIR/assets/scripts/cycle.sh next #{session_name} #{client_tty}'"
+"$CONFIGDIR"/assets/scripts/bind-key.sh p "run-shell '$CONFIGDIR/assets/scripts/cycle.sh prev #{session_name} #{client_tty}'"
+"$CONFIGDIR"/assets/scripts/bind-key.sh g "run-shell '$CONFIGDIR/assets/scripts/agent-menu.sh #{client_tty}'"
+
+# ── Status click binding (root table: left-click on status-right) ─────
+# Shows hook-ready work and unread mail when clicking the status-right area.
+# Per-city socket isolation makes every session on this socket a GC
+# session, so we install the popup directly without an if-shell guard.
+popup_cmd="$(shell_quote "$CONFIGDIR/assets/scripts/status-popup.sh")"
+if [ -n "$AGENT" ]; then
+    popup_cmd="$popup_cmd $(shell_quote "$AGENT")"
+fi
+if [ -n "$city" ]; then
+    popup_cmd="$popup_cmd $(shell_quote "$city")"
+fi
+mail_popup="display-popup -E -w 90 -h 24 $popup_cmd"
+existing=$(gcmux list-keys -T root MouseDown1StatusRight 2>/dev/null || true)
+if ! printf '%s' "$existing" | grep -qF "$mail_popup"; then
+    gcmux bind-key -T root MouseDown1StatusRight "$mail_popup"
+fi
+
+# ── Mouse-wheel scrollback (root table) ───────────────────────────────
+# Make the wheel drive tmux copy-mode scrollback instead of leaking to the
+# focused app. Without this, "mouse on" (set in tmux-theme.sh) hands the wheel
+# to mouse-reporting TUIs — Claude Code scrolls its own history, a pager/shell
+# gets Up-arrows — and only a bare prompt reaches copy-mode. Force copy-mode
+# even over mouse-reporting apps (no mouse_any_flag check) so scrollback wins;
+# once in copy-mode the wheel passes through (-M) for normal scrolling, and -e
+# exits at the bottom. Shift+wheel still does native terminal selection.
+gcmux bind-key -T root WheelUpPane   if-shell -F -t= "#{pane_in_mode}" "send-keys -M" "copy-mode -e"
+gcmux bind-key -T root WheelDownPane send-keys -M

--- a/bd-gc-postgres/commands/build/command.toml
+++ b/bd-gc-postgres/commands/build/command.toml
@@ -1,0 +1,1 @@
+description = "Build the Postgres beads backend plugin binary"

--- a/bd-gc-postgres/commands/build/run.sh
+++ b/bd-gc-postgres/commands/build/run.sh
@@ -5,13 +5,13 @@ usage() {
   cat <<'EOF'
 usage: gc bd-gc-postgres build [backend] [--install] [--plugin-source DIR] [--output DIR]
 
-Build the plugin-backed Postgres beads backend process.
+Build the plugin-backed Postgres beads and Gas City backend processes.
 
 Targets:
-  backend   Build bd-backend-postgres (default)
+  backend   Build bd-backend-postgres and gc-backend-postgres (default)
 
 Options:
-  --plugin-source DIR   Standalone plugin source containing cmd/bd-backend-postgres.
+  --plugin-source DIR   Standalone plugin source containing backend commands.
                         Default: $BD_GC_POSTGRES_PLUGIN_SOURCE, else a cached
                         clone of duncan4123/beads-backend-postgres.
   --output DIR          Output directory. Default: pack runtime bin.
@@ -88,6 +88,7 @@ fi
 
 [ -f "$plugin_source/go.mod" ] || die "plugin source missing go.mod: $plugin_source"
 [ -d "$plugin_source/cmd/bd-backend-postgres" ] || die "plugin source missing cmd/bd-backend-postgres: $plugin_source"
+[ -d "$plugin_source/cmd/gc-backend-postgres" ] || die "plugin source missing cmd/gc-backend-postgres: $plugin_source"
 
 mkdir -p "$output_dir"
 
@@ -100,7 +101,13 @@ mkdir -p "$cache_root/build" "$cache_root/mod" "$cache_root/tmp"
   GOMODCACHE="${GOMODCACHE:-$cache_root/mod}" \
   GOTMPDIR="${GOTMPDIR:-$cache_root/tmp}" \
   go build -o "$output_dir/bd-backend-postgres" ./cmd/bd-backend-postgres
+  GOCACHE="${GOCACHE:-$cache_root/build}" \
+  GOMODCACHE="${GOMODCACHE:-$cache_root/mod}" \
+  GOTMPDIR="${GOTMPDIR:-$cache_root/tmp}" \
+  go build -o "$output_dir/gc-backend-postgres" ./cmd/gc-backend-postgres
 )
 
 chmod 755 "$output_dir/bd-backend-postgres"
+chmod 755 "$output_dir/gc-backend-postgres"
 echo "built $output_dir/bd-backend-postgres"
+echo "built $output_dir/gc-backend-postgres"

--- a/bd-gc-postgres/commands/build/run.sh
+++ b/bd-gc-postgres/commands/build/run.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+usage: gc bd-gc-postgres build [backend] [--install] [--plugin-source DIR] [--output DIR]
+
+Build the plugin-backed Postgres beads backend process.
+
+Targets:
+  backend   Build bd-backend-postgres (default)
+
+Options:
+  --plugin-source DIR   Standalone plugin source containing cmd/bd-backend-postgres.
+                        Default: $BD_GC_POSTGRES_PLUGIN_SOURCE, else a cached
+                        clone of duncan4123/beads-backend-postgres.
+  --output DIR          Output directory. Default: pack runtime bin.
+  --install             Kept for parity with other build packs; the output is
+                        always written to the runtime bin directory unless
+                        --output is supplied.
+  --help                Show this help.
+EOF
+}
+
+die() {
+  echo "$*" >&2
+  exit 1
+}
+
+require_value() {
+  if [ -z "${2:-}" ] || [[ "${2:-}" == --* ]]; then
+    die "$1 requires a value"
+  fi
+}
+
+city_root="${GC_CITY_PATH:-$(pwd -P)}"
+target="backend"
+plugin_source="${BD_GC_POSTGRES_PLUGIN_SOURCE:-}"
+output_dir="${BD_GC_POSTGRES_OUTPUT_DIR:-$city_root/.gc/runtime/packs/bd-gc-postgres/bin}"
+plugin_repo="${BD_GC_POSTGRES_PLUGIN_REPO:-https://github.com/duncan4123/beads-backend-postgres.git}"
+plugin_ref="${BD_GC_POSTGRES_PLUGIN_REF:-main}"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    backend)
+      target="$1"
+      shift
+      ;;
+    --plugin-source)
+      require_value "$1" "${2:-}"
+      plugin_source="$2"
+      shift 2
+      ;;
+    --output)
+      require_value "$1" "${2:-}"
+      output_dir="$2"
+      shift 2
+      ;;
+    --install)
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+[ "$target" = "backend" ] || die "unsupported target: $target"
+
+if [ -z "$plugin_source" ]; then
+  plugin_source="$city_root/.gc/cache/repos/beads-backend-postgres"
+  if [ ! -d "$plugin_source/.git" ]; then
+    command -v git >/dev/null 2>&1 || die "git is required to fetch $plugin_repo"
+    mkdir -p "$(dirname "$plugin_source")"
+    git clone "$plugin_repo" "$plugin_source"
+  fi
+  (
+    cd "$plugin_source"
+    git fetch --tags origin
+    git checkout "$plugin_ref"
+    git pull --ff-only origin "$plugin_ref" 2>/dev/null || true
+  )
+fi
+
+[ -f "$plugin_source/go.mod" ] || die "plugin source missing go.mod: $plugin_source"
+[ -d "$plugin_source/cmd/bd-backend-postgres" ] || die "plugin source missing cmd/bd-backend-postgres: $plugin_source"
+
+mkdir -p "$output_dir"
+
+cache_root="${BD_GC_POSTGRES_GO_CACHE_ROOT:-$city_root/.cache/go}"
+mkdir -p "$cache_root/build" "$cache_root/mod" "$cache_root/tmp"
+
+(
+  cd "$plugin_source"
+  GOCACHE="${GOCACHE:-$cache_root/build}" \
+  GOMODCACHE="${GOMODCACHE:-$cache_root/mod}" \
+  GOTMPDIR="${GOTMPDIR:-$cache_root/tmp}" \
+  go build -o "$output_dir/bd-backend-postgres" ./cmd/bd-backend-postgres
+)
+
+chmod 755 "$output_dir/bd-backend-postgres"
+echo "built $output_dir/bd-backend-postgres"

--- a/bd-gc-postgres/pack.toml
+++ b/bd-gc-postgres/pack.toml
@@ -8,9 +8,14 @@ setup_hook = "assets/scripts/gc-bd-gc-postgres-provider.sh"
 provider_command = "assets/scripts/gc-bd-gc-postgres-provider.sh"
 prepare_command = ["build", "backend", "--install"]
 bd_compatibility = "beads-backend-plugin-pr4561"
-capabilities = ["setup", "provider", "metadata", "backend-plugin", "postgres-auth", "sql-backend", "no-version-control"]
+capabilities = ["setup", "provider", "metadata", "backend-plugin", "postgres-auth", "sql-backend", "fastpath", "gascity-fastpath", "native-read-store", "no-version-control"]
 
 [backend_plugins.beads_endpoint]
 command = ".gc/runtime/packs/bd-gc-postgres/bin/bd-backend-postgres"
 args = ["serve"]
 protocol = "beads.backend.v1alpha1"
+
+[backend_plugins.gascity_endpoint]
+command = ".gc/runtime/packs/bd-gc-postgres/bin/gc-backend-postgres"
+args = ["serve"]
+protocol = "gascity.backend.v1alpha1"

--- a/bd-gc-postgres/pack.toml
+++ b/bd-gc-postgres/pack.toml
@@ -2,6 +2,11 @@
 name = "bd-gc-postgres"
 schema = 2
 
+[global]
+session_live = [
+    "{{.ConfigDir}}/assets/scripts/tmux-keybindings.sh {{.ConfigDir}} {{.Agent}}",
+]
+
 [[backend_plugins]]
 backend = "postgres"
 setup_hook = "assets/scripts/gc-bd-gc-postgres-provider.sh"

--- a/bd-gc-postgres/pack.toml
+++ b/bd-gc-postgres/pack.toml
@@ -1,0 +1,16 @@
+[pack]
+name = "bd-gc-postgres"
+schema = 2
+
+[[backend_plugins]]
+backend = "postgres"
+setup_hook = "assets/scripts/gc-bd-gc-postgres-provider.sh"
+provider_command = "assets/scripts/gc-bd-gc-postgres-provider.sh"
+prepare_command = ["build", "backend", "--install"]
+bd_compatibility = "beads-backend-plugin-pr4561"
+capabilities = ["setup", "provider", "metadata", "backend-plugin", "postgres-auth", "sql-backend", "no-version-control"]
+
+[backend_plugins.beads_endpoint]
+command = ".gc/runtime/packs/bd-gc-postgres/bin/bd-backend-postgres"
+args = ["serve"]
+protocol = "beads.backend.v1alpha1"

--- a/registry.toml
+++ b/registry.toml
@@ -272,7 +272,7 @@ schema = 1
     kind = "beads-backend"
     backend = "postgres"
     display_name = "Postgres"
-    capabilities = ["setup", "provider", "metadata", "backend-plugin", "postgres-auth", "sql-backend", "no-version-control"]
+    capabilities = ["setup", "provider", "metadata", "backend-plugin", "postgres-auth", "sql-backend", "fastpath", "gascity-fastpath", "native-read-store", "no-version-control"]
 
   [[pack.release]]
     version = "0.1.0"
@@ -294,3 +294,10 @@ schema = 1
     commit = "332de1d435b001a84398c13167012db574b286e0"
     hash = "sha256:974a44431988db93c9c6aeccc034044a1d14afec792346fc1ec9ea57b8406136"
     description = "Builds the missing Postgres backend plugin binary during gc init before provisioning the local database."
+
+  [[pack.release]]
+    version = "0.1.3"
+    ref = "bd-gc-postgres-publish"
+    commit = "4e235de19c2abc9a95d4dfececc43eb9831b5503"
+    hash = "sha256:6a0da9e61d995ca8e891e2eea9915f3297efd5cb5bdd27a7f80125b1e2dee752"
+    description = "Adds the GC Postgres fastpath endpoint, builds gc-backend-postgres with the Beads plugin, and writes gascity_backend metadata during gc init."

--- a/registry.toml
+++ b/registry.toml
@@ -261,3 +261,36 @@ schema = 1
     commit = "a1490ecf90238f3af52ab2e7f24e30b5b62cbfc2"
     hash = "sha256:c06f30e61407994cef7e16aafecbc71afbbc9f8cdfd0d506146fdf95837333cf"
     description = "Initial oversight-rig release: rig-scoped project-lead + deterministic escalation machinery."
+
+[[pack]]
+  name = "bd-gc-postgres"
+  description = "Plugin-backed Postgres Beads backend for Gas City. Installs a trusted bd-backend-postgres process and configures backend=postgres metadata during gc init."
+  source = "https://github.com/duncan4123/gascity-packs/tree/bd-gc-postgres-publish/bd-gc-postgres"
+  source_kind = "git"
+
+  [[pack.plugin]]
+    kind = "beads-backend"
+    backend = "postgres"
+    display_name = "Postgres"
+    capabilities = ["setup", "provider", "metadata", "backend-plugin", "postgres-auth", "sql-backend", "no-version-control"]
+
+  [[pack.release]]
+    version = "0.1.0"
+    ref = "bd-gc-postgres-publish"
+    commit = "8147678b49afa679c54746f97c591b20e486673d"
+    hash = "sha256:43e88dc31922bc03a92fcaa7dc2ab652df8ce47f23d6b004ef76a5db1776f90a"
+    description = "Initial Postgres backend plugin pack. Builds bd-backend-postgres from duncan4123/beads-backend-postgres and configures plugin-backed Beads metadata for Gas City."
+
+  [[pack.release]]
+    version = "0.1.1"
+    ref = "bd-gc-postgres-publish"
+    commit = "5a2c762d8161e9c9db10d7ef5a7931f8dfc4aa00"
+    hash = "sha256:f91da51fe200b6cd890bdd664b916f0772efbf4750366a54363a9664d4abd7b4"
+    description = "Adds default local Postgres provisioning for gc init: creates the database, login role, generated password, city schema, metadata, and local plugin trust config."
+
+  [[pack.release]]
+    version = "0.1.2"
+    ref = "bd-gc-postgres-publish"
+    commit = "332de1d435b001a84398c13167012db574b286e0"
+    hash = "sha256:974a44431988db93c9c6aeccc034044a1d14afec792346fc1ec9ea57b8406136"
+    description = "Builds the missing Postgres backend plugin binary during gc init before provisioning the local database."


### PR DESCRIPTION
## Summary
- add the bd-gc-postgres backend pack for plugin-backed Postgres Beads/Gas City cities
- include local Postgres provisioning, backend build/install commands, and GC fastpath endpoint metadata
- install tmux navigation/status keybinding assets from the pack so postgres cities do not depend on runtime workspace paths

## Validation
- sh -n on bd-gc-postgres tmux keybinding scripts
- gc config show in /data/projects/postgres resolves the keybinding hook from bd-gc-postgres/assets/scripts
- gc status in /data/projects/postgres reports the city running with GascityBackendStore