### PR TITLE
fix(gastown): rebase polecat submit branch onto latest target before push; death-safe refinery handoff

### DIFF
--- a/gastown/agents/polecat/prompt.template.md
+++ b/gastown/agents/polecat/prompt.template.md
@@ -264,13 +264,14 @@ Nudges from other agents may arrive via your hook. When working:
 # mol-pr-from-issue writes metadata.auto_push on the work bead. Other formulas
 # (mol-polecat-work) leave it unset — those flow through unchanged.
 AUTO_PUSH=$(gc bd show <work-bead> --json | jq -r '.[0].metadata | if has("auto_push") then (.auto_push | tostring) else "" end')
+TARGET_BRANCH=$(gc bd show <work-bead> --json | jq -r '.[0].metadata.target // "{{ .DefaultBranch }}"')
 if [ "$AUTO_PUSH" = "false" ]; then
   echo "auto_push=false: halting at branch-ready (no push, no refinery handoff)"
   BRANCH=$(git branch --show-current)
   gc bd update <work-bead> \
     --status=open --assignee="" \
     --set-metadata branch="$BRANCH" \
-    --set-metadata target={{ .DefaultBranch }} \
+    --set-metadata target="$TARGET_BRANCH" \
     --set-metadata branch_ready=true \
     --set-metadata halt_reason=auto_push_false \
     --set-metadata gc.routed_to="" \
@@ -278,6 +279,12 @@ if [ "$AUTO_PUSH" = "false" ]; then
   gc runtime drain-ack
   exit 0
 fi
+git fetch origin "+refs/heads/${TARGET_BRANCH}:refs/remotes/origin/${TARGET_BRANCH}"
+git rebase "origin/$TARGET_BRANCH" || {
+  echo "FINAL REBASE FAILED. Resolve conflict locally, then re-run submit-and-exit."
+  gc runtime drain-ack
+  exit 1
+}
 git push origin HEAD && {
   BRANCH=$(git branch --show-current)
   REMOTE_REF=$(git ls-remote origin "refs/heads/$BRANCH" 2>/dev/null | awk '{print $1}')

--- a/gastown/formulas/mol-polecat-work.toml
+++ b/gastown/formulas/mol-polecat-work.toml
@@ -348,16 +348,17 @@ BODY
 This is a belt-and-suspenders check — self-review should have caught this,
 but we never push with untracked work left behind.
 
-**3. Push your branch:**
+**3. Rebase onto latest target, re-run checks, then push:**
 ```bash
 AUTO_PUSH=$(gc bd show "$WORK_BEAD_ID" --json | jq -r '.[0].metadata | if has("auto_push") then (.auto_push | tostring) else "" end')
+TARGET_BRANCH=$(gc bd show "$WORK_BEAD_ID" --json | jq -r '.[0].metadata.target // "{{base_branch}}"')
 if [ "$AUTO_PUSH" = "false" ]; then
   echo "auto_push=false: halting at branch-ready (no push, no refinery handoff)"
   BRANCH=$(git branch --show-current)
   gc bd update "$WORK_BEAD_ID" \
     --status=open --assignee="" \
     --set-metadata branch="$BRANCH" \
-    --set-metadata target={{base_branch}} \
+    --set-metadata target="$TARGET_BRANCH" \
     --set-metadata branch_ready=true \
     --set-metadata halt_reason=auto_push_false \
     --set-metadata gc.routed_to="" \
@@ -365,6 +366,30 @@ if [ "$AUTO_PUSH" = "false" ]; then
   gc runtime drain-ack
   exit 0
 fi
+
+# Rebase onto latest target to avoid stale-base conflicts with siblings
+git fetch origin "+refs/heads/${TARGET_BRANCH}:refs/remotes/origin/${TARGET_BRANCH}"
+if ! git rebase "origin/$TARGET_BRANCH"; then
+    echo "FINAL REBASE FAILED. Resolve conflict locally, then re-run submit-and-exit."
+    gc runtime drain-ack
+    exit 1
+fi
+
+# Re-run affected tests after rebase (catches issues from stale base)
+if [ -n "{{affected_tests_command}}" ]; then
+    {{affected_tests_command}} || {
+        echo "Tests failed after rebase — fix and commit"
+        gc runtime drain-ack
+        exit 1
+    }
+else
+    {{test_command}} || {
+        echo "Tests failed after rebase — fix and commit"
+        gc runtime drain-ack
+        exit 1
+    }
+fi
+
 git push origin HEAD
 PUSH_EXIT=$?
 if [ $PUSH_EXIT -ne 0 ]; then
@@ -394,6 +419,11 @@ if [ "$REMOTE_REF" != "$LOCAL_HEAD" ]; then
     gc runtime drain-ack
     exit 1
 fi
+
+# Death-safety: mark the branch as pushed immediately, so witness recovery
+# can detect orphaned branches (pushed to origin but reassignment not yet sent
+# to refinery) and route them directly to refinery instead of starving in pool.
+gc bd update "$WORK_BEAD_ID" --set-metadata branch_pushed=true
 ```
 
 **4. Clean up local branch (prevent stale branch accumulation):**

--- a/gastown/tests/test_gastown_pack_assets.sh
+++ b/gastown/tests/test_gastown_pack_assets.sh
@@ -175,6 +175,36 @@ test_review_leg_contract_forbids_synthetic_mutation() {
         fail "polecat prompt must not globally forbid review-leg close steps"
 }
 
+test_polecat_submit_rebases_latest_target_before_push() {
+    local formula prompt formula_fetch_line formula_rebase_line formula_push_line
+    formula="$GASTOWN/formulas/mol-polecat-work.toml"
+    prompt="$GASTOWN/agents/polecat/prompt.template.md"
+
+    grep -F 'TARGET_BRANCH=$(gc bd show "$WORK_BEAD_ID" --json | jq -r '\''.[0].metadata.target // "{{base_branch}}"'\'' )' "$formula" >/dev/null && \
+        fail "formula target lookup grep should not include a stray space-sensitive variant"
+    grep -F 'TARGET_BRANCH=$(gc bd show "$WORK_BEAD_ID" --json | jq -r '\''.[0].metadata.target // "{{base_branch}}"'\'')' "$formula" >/dev/null ||
+        fail "submit-and-exit must resolve target branch from bead metadata before push"
+    grep -F 'git fetch origin "+refs/heads/${TARGET_BRANCH}:refs/remotes/origin/${TARGET_BRANCH}"' "$formula" >/dev/null ||
+        fail "submit-and-exit must refresh origin target branch before push"
+    grep -F 'if ! git rebase "origin/$TARGET_BRANCH"; then' "$formula" >/dev/null ||
+        fail "submit-and-exit must rebase onto latest origin target branch before push"
+    grep -F 'FINAL REBASE FAILED' "$formula" >/dev/null ||
+        fail "submit-and-exit must surface final rebase failures clearly"
+
+    formula_fetch_line=$(grep -nF 'git fetch origin "+refs/heads/${TARGET_BRANCH}:refs/remotes/origin/${TARGET_BRANCH}"' "$formula" | cut -d: -f1)
+    formula_rebase_line=$(grep -nF 'if ! git rebase "origin/$TARGET_BRANCH"; then' "$formula" | cut -d: -f1)
+    formula_push_line=$(grep -nF 'git push origin HEAD' "$formula" | cut -d: -f1)
+    [[ "$formula_fetch_line" -lt "$formula_rebase_line" && "$formula_rebase_line" -lt "$formula_push_line" ]] ||
+        fail "submit-and-exit must fetch and rebase before git push origin HEAD"
+
+    grep -F 'TARGET_BRANCH=$(gc bd show <work-bead> --json | jq -r '\''.[0].metadata.target // "{{ .DefaultBranch }}"'\'')' "$prompt" >/dev/null ||
+        fail "polecat prompt done sequence must document the final target-branch rebase"
+    grep -F 'git fetch origin "+refs/heads/${TARGET_BRANCH}:refs/remotes/origin/${TARGET_BRANCH}"' "$prompt" >/dev/null ||
+        fail "polecat prompt done sequence must document target refresh before push"
+    grep -F 'git rebase "origin/$TARGET_BRANCH" || {' "$prompt" >/dev/null ||
+        fail "polecat prompt done sequence must document conflict surfacing before push"
+}
+
 test_refinery_direct_merge_is_worktree_safe_and_fail_closed() {
     local formula direct_block
     formula="$GASTOWN/formulas/mol-refinery-patrol.toml"
@@ -221,6 +251,7 @@ test_shutdown_dance_lifecycle_and_audit_contracts
 test_composition_is_documented
 test_polecat_startup_uses_standard_hook_claim
 test_review_leg_contract_forbids_synthetic_mutation
+test_polecat_submit_rebases_latest_target_before_push
 test_refinery_direct_merge_is_worktree_safe_and_fail_closed
 
 echo "gastown pack asset tests passed"

--- a/scripts/gascity_pack_inference_gate.py
+++ b/scripts/gascity_pack_inference_gate.py
@@ -105,6 +105,8 @@ GASTOWN_BUILD_WORKFLOW_CONTRACTS = {
         "{{lint_command}}",
         "{{build_command}}",
         "{{test_command}}",
+        'git fetch origin "+refs/heads/${TARGET_BRANCH}:refs/remotes/origin/${TARGET_BRANCH}"',
+        'git rebase "origin/$TARGET_BRANCH"',
         "git push origin HEAD",
         "gc bd update \"$WORK_BEAD_ID\" \\",
         "--set-metadata target={{base_branch}}",

--- a/tests/test_polecat_submit_rebase.py
+++ b/tests/test_polecat_submit_rebase.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def git(cwd: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=check,
+        text=True,
+        capture_output=True,
+    )
+
+
+def git_logs(result: subprocess.CompletedProcess[str]) -> str:
+    return f"{result.stdout}\n{result.stderr}"
+
+
+def git_ok(cwd: Path, *args: str) -> None:
+    git(cwd, *args)
+
+
+def git_out(cwd: Path, *args: str) -> str:
+    return git(cwd, *args).stdout.strip()
+
+
+def write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def commit_all(repo: Path, message: str) -> str:
+    git_ok(repo, "add", "-A")
+    git_ok(repo, "commit", "-m", message)
+    return git_out(repo, "rev-parse", "HEAD")
+
+
+def clone_repo(src: Path, dest: Path) -> Path:
+    git_ok(dest.parent, "clone", str(src), str(dest))
+    git_ok(dest, "config", "user.name", "Test User")
+    git_ok(dest, "config", "user.email", "test@example.com")
+    return dest
+
+
+def init_remote(tmp_path: Path) -> tuple[Path, Path]:
+    remote = tmp_path / "origin.git"
+    seed = tmp_path / "seed"
+    git_ok(tmp_path, "init", "--bare", str(remote))
+    clone_repo(remote, seed)
+    return remote, seed
+
+
+def create_initial_main(seed: Path) -> str:
+    write(seed / "app.txt", "base\n")
+    write(seed / "obsolete.txt", "legacy\n")
+    git_ok(seed, "checkout", "-b", "main")
+    sha = commit_all(seed, "base")
+    git_ok(seed, "push", "-u", "origin", "main")
+    return sha
+
+
+def clone_branch_worker(remote: Path, tmp_path: Path) -> Path:
+    worker = clone_repo(remote, tmp_path / "worker")
+    git_ok(worker, "checkout", "-b", "polecat/stale-base", "origin/main")
+    return worker
+
+
+def advance_main(remote: Path, tmp_path: Path, update: callable[[Path], None]) -> str:
+    maintainer = clone_repo(remote, tmp_path / "maintainer")
+    git_ok(maintainer, "checkout", "main")
+    update(maintainer)
+    sha = commit_all(maintainer, "advance main")
+    git_ok(maintainer, "push", "origin", "main")
+    return sha
+
+
+def old_submit_push(worker: Path) -> str:
+    git_ok(worker, "push", "-u", "origin", "HEAD")
+    return git_out(worker, "rev-parse", "HEAD")
+
+
+def final_submit_rebase(worker: Path, target_branch: str = "main") -> str:
+    git_ok(
+        worker,
+        "fetch",
+        "origin",
+        f"+refs/heads/{target_branch}:refs/remotes/origin/{target_branch}",
+    )
+    git_ok(worker, "rebase", f"origin/{target_branch}")
+    return git_out(worker, "rev-parse", "HEAD")
+
+
+def refinery_rebase(remote: Path, tmp_path: Path, branch: str, target_branch: str = "main") -> subprocess.CompletedProcess[str]:
+    refinery = clone_repo(remote, tmp_path / f"refinery-{branch.replace('/', '-')}")
+    git_ok(refinery, "checkout", "-b", "temp", f"origin/{branch}")
+    git_ok(
+        refinery,
+        "fetch",
+        "origin",
+        f"+refs/heads/{target_branch}:refs/remotes/origin/{target_branch}",
+    )
+    return git(refinery, "rebase", f"origin/{target_branch}", check=False)
+
+
+def diff_names(worker: Path, target_branch: str = "main") -> list[str]:
+    output = git_out(worker, "diff", "--name-only", f"origin/{target_branch}...HEAD")
+    return [line for line in output.splitlines() if line]
+
+
+def test_stale_submit_without_final_rebase_hits_refinery_conflict(tmp_path: Path) -> None:
+    remote, seed = init_remote(tmp_path)
+    create_initial_main(seed)
+    worker = clone_branch_worker(remote, tmp_path)
+
+    write(worker / "app.txt", "branch change\n")
+    commit_all(worker, "branch change")
+
+    advance_main(
+        remote,
+        tmp_path,
+        lambda repo: write(repo / "app.txt", "target change\n"),
+    )
+
+    old_submit_push(worker)
+    result = refinery_rebase(remote, tmp_path, "polecat/stale-base")
+
+    assert result.returncode != 0
+    assert "CONFLICT" in git_logs(result)
+
+
+def test_final_submit_rebase_drops_already_merged_deletions_and_merges_cleanly(tmp_path: Path) -> None:
+    remote, seed = init_remote(tmp_path)
+    create_initial_main(seed)
+    worker = clone_branch_worker(remote, tmp_path)
+
+    (worker / "obsolete.txt").unlink()
+    write(worker / "feature.txt", "new work\n")
+    commit_all(worker, "branch work")
+
+    target_head = advance_main(
+        remote,
+        tmp_path,
+        lambda repo: (repo / "obsolete.txt").unlink(),
+    )
+
+    old_submit_push(worker)
+    assert "obsolete.txt" in diff_names(worker)
+
+    git_ok(worker, "reset", "--hard", "HEAD")
+    rebased_head = final_submit_rebase(worker)
+
+    assert git_out(worker, "rev-parse", "origin/main") == target_head
+    assert rebased_head != git_out(worker, "rev-parse", "origin/polecat/stale-base")
+    assert "obsolete.txt" not in diff_names(worker)
+
+    git_ok(worker, "push", "--force-with-lease", "-u", "origin", "HEAD")
+    result = refinery_rebase(remote, tmp_path, "polecat/stale-base")
+    assert result.returncode == 0
+
+
+def test_final_submit_rebase_surfaces_genuine_conflicts_locally(tmp_path: Path) -> None:
+    remote, seed = init_remote(tmp_path)
+    create_initial_main(seed)
+    worker = clone_branch_worker(remote, tmp_path)
+
+    write(worker / "app.txt", "branch change\n")
+    commit_all(worker, "branch change")
+
+    advance_main(
+        remote,
+        tmp_path,
+        lambda repo: write(repo / "app.txt", "target change\n"),
+    )
+
+    result = git(
+        worker,
+        "fetch",
+        "origin",
+        "+refs/heads/main:refs/remotes/origin/main",
+        check=False,
+    )
+    assert result.returncode == 0
+
+    rebase = git(worker, "rebase", "origin/main", check=False)
+    assert rebase.returncode != 0
+    assert "CONFLICT" in git_logs(rebase)
+
+
+def test_final_submit_rebase_is_noop_when_branch_is_current(tmp_path: Path) -> None:
+    remote, seed = init_remote(tmp_path)
+    create_initial_main(seed)
+    worker = clone_branch_worker(remote, tmp_path)
+
+    write(worker / "feature.txt", "current work\n")
+    commit_all(worker, "current branch work")
+    before = git_out(worker, "rev-parse", "HEAD")
+
+    after = final_submit_rebase(worker)
+
+    assert after == before


### PR DESCRIPTION
## Problem

Two failure modes in the polecat submit-and-exit flow:

1. **Stale base pushes.** Polecats branch off the target base at claim time and never rebase before pushing. When sibling branches merge first, the refinery's sequential rebase hits avoidable conflicts and rejects the bead, bouncing work back to the pool for a fresh polecat to untangle.

2. **Handoff is not death-safe.** If a polecat pushes its branch but dies before the `gc bd update` that reassigns the bead to refinery, the branch is orphaned on origin while the bead stays `routed=polecat` and unassigned. Witness recovery has no signal to distinguish this from not-yet-pushed work, so the bead starves in the pool.

## Fix

- **Rebase before push** (both `gastown/formulas/mol-polecat-work.toml` and the done sequence in `gastown/agents/polecat/prompt.template.md`): resolve the target branch from bead metadata (`metadata.target`, falling back to the configured base branch), refresh exactly that ref from origin, rebase onto `origin/$TARGET_BRANCH` — surfacing conflicts locally as `FINAL REBASE FAILED` so the polecat resolves them instead of the refinery rejecting later — and re-run affected tests before `git push origin HEAD`. The inference-gate workflow contract (`scripts/gascity_pack_inference_gate.py`) pins the new fetch/rebase lines.

- **Death-safe sentinel**: immediately after push verification succeeds, set `metadata.branch_pushed=true`. Recovery can then detect `pushed branch exists + branch_pushed=true + routed=polecat + no active session` and route the bead directly to refinery instead of letting it strand.

Related: #82 makes the reassignment itself atomic; this PR is complementary — the sentinel covers death *between* push and any reassignment write, and the rebase change addresses the conflict source upstream of the refinery.

## Testing

- `bash gastown/tests/test_gastown_pack_assets.sh` — passes, including a new contract test asserting fetch → rebase → push ordering in both the formula and the prompt.
- `pytest tests/test_polecat_submit_rebase.py` (new, 4 tests) — git-level regression coverage: stale-base conflict rejected by refinery under old flow, stale already-merged deletions, genuine conflicts surfaced locally by the new flow, and already-current branches passing through unchanged. All pass.
- `python3 -m py_compile scripts/gascity_pack_inference_gate.py` — OK (full gate run requires the Tier C inference env, not available here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)