### PR TITLE
fix(deacon): add convoy-reconciliation step to reliably auto-close completed convoys

### DIFF
--- a/gastown/formulas/mol-deacon-patrol.toml
+++ b/gastown/formulas/mol-deacon-patrol.toml
@@ -400,9 +400,28 @@ gc mail send mayor/ -s "DOCTOR: <finding>" -m "<details>"
 Close this step after check."""
 
 [[steps]]
+id = "convoy-reconciliation"
+title = "Auto-close completed convoys"
+needs = ["system-health"]
+description = """
+Run convoy reconciliation to auto-close any convoys where all children are resolved.
+
+```bash
+gc convoy check
+```
+
+This is a lightweight, idempotent operation that scans open convoy beads and
+closes any where all child issues have status "closed". Run it every patrol cycle.
+
+If errors occur, log them for observability but do not escalate — convoy
+completion is not a blocker for other patrol steps.
+
+Close this step after check."""
+
+[[steps]]
 id = "next-iteration"
 title = "Pour next iteration and loop"
-needs = ["system-health"]
+needs = ["convoy-reconciliation"]
 description = """
 **Config: event_timeout = {{event_timeout}}**
 


### PR DESCRIPTION
## Problem

The deacon patrol loop never runs `gc convoy check`, so convoys whose children are all closed accumulate indefinitely. In one production deployment this left 42 stale open convoy beads over a 2-day lapse — nothing in the patrol cycle reconciles convoy completion.

## Root cause

`gastown/formulas/mol-deacon-patrol.toml` has no step that performs convoy reconciliation; convoy auto-close only happens if something else incidentally triggers it.

## Fix

Add a `convoy-reconciliation` step to the patrol formula, between `system-health` and `next-iteration`, that runs `gc convoy check` every cycle. The command is lightweight and idempotent: it scans open convoy beads and closes any where all children are closed. Errors are logged but not escalated, since convoy completion is not a blocker for other patrol steps. `next-iteration` now depends on the new step so cycle ordering is preserved.

## Testing

- `tomllib` parse of the formula succeeds; step chain is `... -> system-health -> convoy-reconciliation -> next-iteration`.
- Prompt/formula-only change (no code); running this patrol formula in a live deployment closed the accumulated completed convoys and keeps them from re-accumulating.

Related deacon PRs #134 and #146 touch adjacent patrol behavior (wisp-type filter, patrol-wisp idempotency) but do not overlap with this step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)