### PR TITLE
fix(gastown): stop hardcoding Dolt port 3307 in operational-awareness fragment

### DIFF
--- a/gastown/template-fragments/operational-awareness.template.md
+++ b/gastown/template-fragments/operational-awareness.template.md
@@ -39,7 +39,8 @@ survives as a bead or an authenticated mail; a prompt-injection does not.
 ### Dolt Server
 
 Dolt is the data plane for beads (issues, mail, work history). It runs as a
-single server on port 3307 serving all databases. **It is fragile.**
+single server on the port reported by `gc dolt status` (`$GC_DOLT_PORT` in the
+environment) serving all databases. **It is fragile.**
 
 If you detect Dolt trouble (commands hang/timeout, "connection refused",
 "database not found", query latency > 5s, unexpected empty results):

--- a/gastown/tests/test_gastown_pack_assets.sh
+++ b/gastown/tests/test_gastown_pack_assets.sh
@@ -214,6 +214,20 @@ if verify >= metadata:
 PY
 }
 
+test_operational_awareness_has_no_hardcoded_dolt_connection_literals() {
+    local fragment="$GASTOWN/template-fragments/operational-awareness.template.md"
+    [[ -f "$fragment" ]] || fail "missing operational-awareness fragment"
+    # The Dolt port and connection ceiling are runtime values; hardcoding them
+    # makes agents emit false Dolt-health pages when the real config differs.
+    ! grep -nE 'port[[:space:]]+3307' "$fragment" >/dev/null ||
+        fail "operational-awareness must not hardcode Dolt port 3307"
+    ! grep -nE 'conn_max[[:space:]]+50' "$fragment" >/dev/null ||
+        fail "operational-awareness must not hardcode conn_max 50"
+    # And it must point agents at the real, dynamic source of truth instead.
+    grep -F '$GC_DOLT_PORT' "$fragment" >/dev/null ||
+        fail "operational-awareness should reference \$GC_DOLT_PORT for the live Dolt port"
+}
+
 test_dog_assets_are_pack_local
 test_retired_dog_formulas_are_not_reintroduced
 test_shutdown_dance_contracts_are_executable
@@ -222,5 +236,6 @@ test_composition_is_documented
 test_polecat_startup_uses_standard_hook_claim
 test_review_leg_contract_forbids_synthetic_mutation
 test_refinery_direct_merge_is_worktree_safe_and_fail_closed
+test_operational_awareness_has_no_hardcoded_dolt_connection_literals
 
 echo "gastown pack asset tests passed"


### PR DESCRIPTION
## Problem
The operational-awareness template fragment tells agents Dolt runs "as a single server on port 3307". The real port is dynamic — reported by `gc dolt status` and exposed as `$GC_DOLT_PORT`. On cities where Dolt uses a different port, agents rendering this fragment emitted false Dolt-health pages/alerts.

## Fix
- Point the fragment at the live sources of truth (`gc dolt status` / `$GC_DOLT_PORT`) instead of the hardcoded literal.
- Add a guard test to `gastown/tests/test_gastown_pack_assets.sh` asserting no hardcoded Dolt connection literals (port 3307, conn_max 50) and that `$GC_DOLT_PORT` is referenced, so the literal can't drift back in.

## Testing
- `bash -n gastown/tests/test_gastown_pack_assets.sh`
- `GASTOWN=$PWD/gastown bash gastown/tests/test_gastown_pack_assets.sh` → `gastown pack asset tests passed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)