### PR TITLE
fix(gastown): refinery patrol resolves CURRENT_WISP via ephemeral-aware query

### DIFF
--- a/gastown/agents/refinery/prompt.template.md
+++ b/gastown/agents/refinery/prompt.template.md
@@ -69,7 +69,12 @@ external observers (witness, mayor) only catch on a slow patrol cycle.
 ```bash
 CURRENT_WISP=${GC_BEAD_ID:-}
 if [ -z "$CURRENT_WISP" ]; then
-  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
+  # Patrol wisps are ephemeral and poured with status=open (never in_progress);
+  # `gc bd list` does not surface ephemeral beads, so resolve via `gc bd query`.
+  # Without this the burn below silently no-ops and a wisp leaks each idle
+  # cycle. Pick the newest matching wisp for this agent.
+  CURRENT_WISP=$(gc bd query --json 'ephemeral=true AND status=open' --limit=0 2>/dev/null \
+    | jq -r --arg agent "$GC_AGENT" '[.[] | select(.assignee==$agent) | select(.title=="mol-refinery-patrol")] | sort_by(.created_at // "") | .[-1].id // empty')
 fi
 NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{ .DefaultBranch }} --var rig_name={{ .RigName }} --var binding_prefix={{ .BindingPrefix }} --json | jq -r '.new_epic_id // empty')
 if [ -z "$NEXT" ]; then
@@ -114,7 +119,12 @@ assign the next wisp, burn the current wisp, THEN request restart**:
 ```bash
 CURRENT_WISP=${GC_BEAD_ID:-}
 if [ -z "$CURRENT_WISP" ]; then
-  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
+  # Patrol wisps are ephemeral and poured with status=open (never in_progress);
+  # `gc bd list` does not surface ephemeral beads, so resolve via `gc bd query`.
+  # Without this the burn below silently no-ops and a wisp leaks each idle
+  # cycle. Pick the newest matching wisp for this agent.
+  CURRENT_WISP=$(gc bd query --json 'ephemeral=true AND status=open' --limit=0 2>/dev/null \
+    | jq -r --arg agent "$GC_AGENT" '[.[] | select(.assignee==$agent) | select(.title=="mol-refinery-patrol")] | sort_by(.created_at // "") | .[-1].id // empty')
 fi
 NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{ .DefaultBranch }} --var rig_name={{ .RigName }} --var binding_prefix={{ .BindingPrefix }} --json | jq -r '.new_epic_id // empty')
 if [ -z "$NEXT" ]; then

--- a/gastown/formulas/mol-refinery-patrol.toml
+++ b/gastown/formulas/mol-refinery-patrol.toml
@@ -119,7 +119,12 @@ wisp, burn the current wisp, then request a restart:
 ```bash
 CURRENT_WISP=${GC_BEAD_ID:-}
 if [ -z "$CURRENT_WISP" ]; then
-  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
+  # Patrol wisps are ephemeral and poured with status=open (never in_progress);
+  # `gc bd list` does not surface ephemeral beads, so resolve via `gc bd query`.
+  # Without this the burn below silently no-ops and a wisp leaks each idle
+  # cycle. Pick the newest matching wisp for this agent.
+  CURRENT_WISP=$(gc bd query --json 'ephemeral=true AND status=open' --limit=0 2>/dev/null \
+    | jq -r --arg agent "$GC_AGENT" '[.[] | select(.assignee==$agent) | select(.title=="mol-refinery-patrol")] | sort_by(.created_at // "") | .[-1].id // empty')
 fi
 NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{target_branch}} --var rig_name={{rig_name}} --var binding_prefix={{binding_prefix}} --json | jq -r '.new_epic_id // empty')
 if [ -z "$NEXT" ]; then
@@ -242,7 +247,12 @@ gc bd update $WORK \
 ```bash
 CURRENT_WISP=${GC_BEAD_ID:-}
 if [ -z "$CURRENT_WISP" ]; then
-  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
+  # Patrol wisps are ephemeral and poured with status=open (never in_progress);
+  # `gc bd list` does not surface ephemeral beads, so resolve via `gc bd query`.
+  # Without this the burn below silently no-ops and a wisp leaks each idle
+  # cycle. Pick the newest matching wisp for this agent.
+  CURRENT_WISP=$(gc bd query --json 'ephemeral=true AND status=open' --limit=0 2>/dev/null \
+    | jq -r --arg agent "$GC_AGENT" '[.[] | select(.assignee==$agent) | select(.title=="mol-refinery-patrol")] | sort_by(.created_at // "") | .[-1].id // empty')
 fi
 NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{target_branch}} --var rig_name={{rig_name}} --var binding_prefix={{binding_prefix}} --json | jq -r '.new_epic_id // empty')
 if [ -z "$NEXT" ]; then
@@ -343,7 +353,12 @@ TARGET=$(gc bd show $WORK --json | jq -r '.[0].metadata.target // "{{target_bran
      ```bash
      CURRENT_WISP=${GC_BEAD_ID:-}
      if [ -z "$CURRENT_WISP" ]; then
-       CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
+       # Patrol wisps are ephemeral and poured with status=open (never in_progress);
+       # `gc bd list` does not surface ephemeral beads, so resolve via `gc bd query`.
+       # Without this the burn below silently no-ops and a wisp leaks each idle
+       # cycle. Pick the newest matching wisp for this agent.
+       CURRENT_WISP=$(gc bd query --json 'ephemeral=true AND status=open' --limit=0 2>/dev/null \
+         | jq -r --arg agent "$GC_AGENT" '[.[] | select(.assignee==$agent) | select(.title=="mol-refinery-patrol")] | sort_by(.created_at // "") | .[-1].id // empty')
      fi
      NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{target_branch}} --var rig_name={{rig_name}} --var binding_prefix={{binding_prefix}} --json | jq -r '.new_epic_id // empty')
      if [ -z "$NEXT" ]; then
@@ -435,7 +450,12 @@ Branch: $BRANCH
 Target: $TARGET"
   CURRENT_WISP=${GC_BEAD_ID:-}
   if [ -z "$CURRENT_WISP" ]; then
-    CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
+    # Patrol wisps are ephemeral and poured with status=open (never in_progress);
+    # `gc bd list` does not surface ephemeral beads, so resolve via `gc bd query`.
+    # Without this the burn below silently no-ops and a wisp leaks each idle
+    # cycle. Pick the newest matching wisp for this agent.
+    CURRENT_WISP=$(gc bd query --json 'ephemeral=true AND status=open' --limit=0 2>/dev/null \
+      | jq -r --arg agent "$GC_AGENT" '[.[] | select(.assignee==$agent) | select(.title=="mol-refinery-patrol")] | sort_by(.created_at // "") | .[-1].id // empty')
   fi
   if [ -z "$CURRENT_WISP" ]; then
     echo "Could not resolve current wisp; not burning."
@@ -1058,7 +1078,12 @@ If auto_land = "false": skip this entirely.
 ```bash
 CURRENT_WISP=${GC_BEAD_ID:-}
 if [ -z "$CURRENT_WISP" ]; then
-  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
+  # Patrol wisps are ephemeral and poured with status=open (never in_progress);
+  # `gc bd list` does not surface ephemeral beads, so resolve via `gc bd query`.
+  # Without this the burn below silently no-ops and a wisp leaks each idle
+  # cycle. Pick the newest matching wisp for this agent.
+  CURRENT_WISP=$(gc bd query --json 'ephemeral=true AND status=open' --limit=0 2>/dev/null \
+    | jq -r --arg agent "$GC_AGENT" '[.[] | select(.assignee==$agent) | select(.title=="mol-refinery-patrol")] | sort_by(.created_at // "") | .[-1].id // empty')
 fi
 NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{target_branch}} --var rig_name={{rig_name}} --var binding_prefix={{binding_prefix}} --json | jq -r '.new_epic_id // empty')
 if [ -z "$NEXT" ]; then

--- a/gastown/tests/test_gastown_pack_assets.sh
+++ b/gastown/tests/test_gastown_pack_assets.sh
@@ -214,6 +214,24 @@ if verify >= metadata:
 PY
 }
 
+test_refinery_patrol_wisp_resolution_is_ephemeral_aware() {
+    local formula
+    formula="$GASTOWN/formulas/mol-refinery-patrol.toml"
+
+    # Patrol wisps are ephemeral and poured with status=open, so they are
+    # never in_progress and are invisible to `gc bd list`. Resolving CURRENT_WISP via
+    # `gc bd list ... --status=in_progress` always returns empty, the burn no-ops, and
+    # a fresh wisp leaks every idle cycle. The fallback must use an ephemeral-aware query.
+    ! grep -F 'gc bd list --assignee="$GC_AGENT" --status=in_progress' "$formula" >/dev/null ||
+        fail "refinery patrol must not resolve the current wisp via 'gc bd list --status=in_progress' (ephemeral wisps are open and invisible to bd list)"
+
+    grep -F "gc bd query --json 'ephemeral=true AND status=open' --limit=0" "$formula" >/dev/null ||
+        fail "refinery patrol must resolve the current wisp via an ephemeral-aware 'gc bd query'"
+
+    grep -F 'select(.title=="mol-refinery-patrol")' "$formula" >/dev/null ||
+        fail "ephemeral wisp resolution must filter to mol-refinery-patrol wisps"
+}
+
 test_dog_assets_are_pack_local
 test_retired_dog_formulas_are_not_reintroduced
 test_shutdown_dance_contracts_are_executable
@@ -222,5 +240,6 @@ test_composition_is_documented
 test_polecat_startup_uses_standard_hook_claim
 test_review_leg_contract_forbids_synthetic_mutation
 test_refinery_direct_merge_is_worktree_safe_and_fail_closed
+test_refinery_patrol_wisp_resolution_is_ephemeral_aware
 
 echo "gastown pack asset tests passed"


### PR DESCRIPTION
## Problem
Refinery patrol wisps still leak after #121. On a live rig we accumulated 60+ leaked `mol-refinery-patrol` wisps.

## Root cause
#121 fixed the invalid `--type=wisp` to `--type=molecule`, but the `CURRENT_WISP` fallback query is still:

```bash
gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json
```

Patrol wisps are **ephemeral** and poured with **status=open** — they are never `in_progress`, and `gc bd list` does not surface ephemeral beads at all. So the fallback always resolves empty, the `gc bd mol burn "$CURRENT_WISP"` step silently no-ops, and a fresh wisp leaks every idle cycle.

(Note: open PR #138 proposes the same `--type=wisp → --type=molecule` swap that #121 already merged; this PR addresses the remaining leak beyond both.)

## Fix
Replace all seven `CURRENT_WISP` resolution fallbacks (2 in `gastown/agents/refinery/prompt.template.md`, 5 in `gastown/formulas/mol-refinery-patrol.toml`) with an ephemeral-aware query:

```bash
CURRENT_WISP=$(gc bd query --json 'ephemeral=true AND status=open' --limit=0 2>/dev/null \
  | jq -r --arg agent "$GC_AGENT" '[.[] | select(.assignee==$agent) | select(.title=="mol-refinery-patrol")] | sort_by(.created_at // "") | .[-1].id // empty')
```

filtered to this agent's newest `mol-refinery-patrol` wisp.

## Testing
- Added `test_refinery_patrol_wisp_resolution_is_ephemeral_aware` to `gastown/tests/test_gastown_pack_assets.sh` (asserts no `gc bd list --status=in_progress` resolution remains and the ephemeral-aware query + title filter are present).
- `./gastown/tests/test_gastown_pack_assets.sh` → all pass.
- `bash -n` on the test script; formula still parses as valid TOML (`tomllib`).
- Deployed on a live rig where it stopped the wisp leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)