### PR TITLE
fix(gastown): refinery lifecycle hardening — branch/worktree/ref cleanup + idle restart contract

### DIFF
--- a/gastown/README.md
+++ b/gastown/README.md
@@ -45,3 +45,19 @@ Gastown deliberately does not ship retired dog formulas for JSONL export or
 stale-session reaping. The Gas City builtin core pack provides JSONL export,
 stale-session and stale-data cleanup, and Dolt housekeeping as deterministic
 exec orders.
+
+## Refinery Idle Contract
+
+Gastown refinery has two recycle paths:
+
+- Normal no-work idle prints `IDLE: no work, exiting turn.` and relies on
+  `sleep_after_idle = "300s"` in `agents/refinery/agent.toml` so session_sleep
+  wakes a fresh patrol after configured idle interval.
+- Heavy-context path pours next wisp, burns current wisp, then calls
+  `gc runtime request-restart` immediately.
+
+Treat those as one contract across `agents/refinery/agent.toml`,
+`agents/refinery/prompt.template.md`, and
+`formulas/mol-refinery-patrol.toml`. Do not clear `sleep_after_idle` as a
+latency tweak unless you also update prompt/formula wake contract and
+regression tests.

--- a/gastown/agents/refinery/agent.toml
+++ b/gastown/agents/refinery/agent.toml
@@ -4,5 +4,8 @@ work_dir = ".gc/worktrees/{{.Rig}}/refinery"
 nudge = "Run 'gc prime' to check merge queue and begin processing."
 pre_start = ["{{.ConfigDir}}/assets/scripts/worktree-setup.sh {{.RigRoot}} {{.WorkDir}} {{.AgentBase}} --sync"]
 idle_timeout = "2h"
+# Normal no-work exit path depends on session_sleep restart policy via
+# sleep_after_idle. Heavy-context recycling uses `gc runtime request-restart`
+# from prompt/formula instead; do not clear this without updating that contract.
 sleep_after_idle = "300s"
 max_active_sessions = 1

--- a/gastown/agents/refinery/prompt.template.md
+++ b/gastown/agents/refinery/prompt.template.md
@@ -147,6 +147,12 @@ and processes the queue with a clean context. This is how a long-running
 refinery stays useful — fresh agents follow the formula correctly; tired agents
 skip steps and write summaries.
 
+Normal no-work idle is different: that path exits without `gc runtime request-restart`
+and depends on `sleep_after_idle` in `agents/refinery/agent.toml` so
+session_sleep re-runs the patrol after the configured idle interval. Do not
+clear or blank `sleep_after_idle` unless you also redesign and update this
+prompt and `mol-refinery-patrol` to provide an equivalent wake contract.
+
 ---
 
 ## Startup

--- a/gastown/formulas/mol-refinery-patrol.toml
+++ b/gastown/formulas/mol-refinery-patrol.toml
@@ -189,12 +189,41 @@ The bead MUST have `metadata.branch`. If `metadata.target` is missing,
 use {{target_branch}} as default. Note the work bead ID and close this step.
 
 If NO work found:
-Write exactly:
+Pour the next patrol iteration and transition before exiting:
+```bash
+CURRENT_WISP=${GC_BEAD_ID:-}
+if [ -z "$CURRENT_WISP" ]; then
+  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=wisp --limit=1 --json | jq -r '.[0].id // empty')
+fi
+NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{target_branch}} --var rig_name={{rig_name}} --var binding_prefix={{binding_prefix}} --json | jq -r '.new_epic_id // empty')
+if [ -z "$NEXT" ]; then
+  echo "Could not pour next refinery wisp when idle; will exit without transition."
+  echo "IDLE: no work, exiting turn."
+  gc runtime drain-ack
+  exit 1
+fi
+if ! gc bd update "$NEXT" --assignee="$GC_AGENT"; then
+  echo "Could not assign next refinery wisp; exiting without proper transition."
+  echo "IDLE: no work, exiting turn."
+  gc runtime drain-ack
+  exit 1
+fi
+if [ -n "$CURRENT_WISP" ]; then
+  gc bd mol burn "$CURRENT_WISP" --force
+else
+  echo "Could not resolve current wisp for burning."
+  echo "IDLE: no work, exiting turn."
+  gc runtime drain-ack
+  exit 1
+fi
+```
+
+Then write exactly:
 ```
 IDLE: no work, exiting turn.
 ```
 Then stop immediately. Do NOT sleep, call ScheduleWakeup, or use Monitor.
-The session_sleep policy will restart this session after the configured idle interval.
+The next wisp is ready and will be re-read on session restart by the session_sleep policy.
 When restarted, re-read formula steps — this step stays open until a work bead is found.
 
 **Do not close this step until you have a work bead with branch metadata.**"""

--- a/gastown/formulas/mol-refinery-patrol.toml
+++ b/gastown/formulas/mol-refinery-patrol.toml
@@ -228,6 +228,12 @@ IDLE: no work, exiting turn.
 ```
 Then stop immediately. Do NOT sleep, call ScheduleWakeup, or use Monitor.
 The next wisp is ready and will be re-read on session restart by the session_sleep policy.
+This normal idle path depends on `sleep_after_idle` in
+`agents/refinery/agent.toml`; session_sleep will restart this session after
+that configured idle interval. Heavy-context recycling uses
+`gc runtime request-restart` from the earlier step instead. Do not clear or
+blank `sleep_after_idle` unless this wake contract is redesigned here and in
+the refinery prompt.
 When restarted, re-read formula steps — this step stays open until a work bead is found.
 
 **Do not close this step until you have a work bead with branch metadata.**"""

--- a/gastown/formulas/mol-refinery-patrol.toml
+++ b/gastown/formulas/mol-refinery-patrol.toml
@@ -805,6 +805,24 @@ rejection_reason` clears any stale rejection field from an earlier
 rejected/reworked attempt before the successful close.
 
 **2. Cleanup — run as a single sequence so interruption cannot strand a branch:**
+After the close is confirmed, prune stale local polecat refs that no longer
+correspond to active work:
+```bash
+cleanup_stale_polecat_refs() {
+  git for-each-ref --format='%(refname:short)' refs/heads/polecat/ \
+    | while IFS= read -r ref; do
+        [ -n "$ref" ] || continue
+        bead_id=${ref#polecat/}
+        bead_json=$(gc bd show "$bead_id" --json 2>/dev/null || true)
+        bead_status=$(printf '%s\n' "$bead_json" | jq -r '.[0].status // empty')
+        if [ "$bead_status" = "closed" ] || [ "$bead_status" = "rejected" ] || [ "$bead_status" = "abandoned" ]; then
+          git update-ref -d "refs/heads/$ref" || true
+        fi
+      done
+}
+cleanup_stale_polecat_refs
+```
+
 ```bash
 git checkout --detach "origin/$TARGET" >/dev/null 2>&1 || true
 git branch -d temp || git branch -D temp || true
@@ -1067,6 +1085,21 @@ gc bd update $WORK \
   --set-metadata merged_target="$TARGET" \
   --unset-metadata rejection_reason && \
 gc bd close $WORK --reason "Pull request ready: $PR_URL"
+```
+
+After the close is confirmed, prune the matching local polecat ref if it
+now points at completed work:
+```bash
+cleanup_stale_polecat_ref() {
+  local branch_ref="refs/heads/$BRANCH"
+  local bead_json bead_status
+  bead_json=$(gc bd show "$WORK" --json 2>/dev/null || true)
+  bead_status=$(printf '%s\n' "$bead_json" | jq -r '.[0].status // empty')
+  if [ "$bead_status" = "closed" ] || [ "$bead_status" = "rejected" ] || [ "$bead_status" = "abandoned" ]; then
+    git update-ref -d "$branch_ref" || true
+  fi
+}
+cleanup_stale_polecat_ref
 ```
 
 **5. Cleanup:**

--- a/gastown/formulas/mol-refinery-patrol.toml
+++ b/gastown/formulas/mol-refinery-patrol.toml
@@ -461,11 +461,13 @@ Target: $TARGET"
     echo "Could not resolve current wisp; not burning."
     echo "$reason"
     echo "STOP. Existing PR metadata needs human correction."
+    cleanup_temp_only
     gc runtime drain-ack
     exit 1
   fi
   echo "$reason"
   echo "STOP. Existing PR metadata needs human correction."
+  cleanup_temp_only
   gc runtime drain-ack
   exit 1
 }
@@ -513,8 +515,28 @@ halt_false_completion() {
   gc session nudge "${GC_RIG:+$GC_RIG/}{{binding_prefix}}witness" "FALSE-COMPLETION HALT: $WORK — branch $fc_branch no verified change vs $fc_base; refused close-as-merged."
   echo "REFUSED close-as-merged: $WORK branch $fc_branch introduces no real change vs $fc_base."
   echo "STOP. Bead left blocked + escalated to mayor/witness. NEVER silent retry."
+  cleanup_branch
   gc runtime drain-ack
   exit 1
+}
+
+cleanup_branch() {
+  # Idempotent cleanup: always delete local temp; conditionally delete remote
+  # $BRANCH when delete_merged_branches=true. Errors suppressed — this is
+  # best-effort; the caller's exit path takes precedence.
+  git checkout "$TARGET" 2>/dev/null || true
+  git branch -D temp 2>/dev/null || true
+  if [ "{{delete_merged_branches}}" = "true" ] && [ -n "${BRANCH:-}" ]; then
+    git push origin --delete "$BRANCH" 2>/dev/null || true
+  fi
+}
+
+cleanup_temp_only() {
+  # Like cleanup_branch but never deletes the remote source branch.
+  # Use when $BRANCH must be preserved (e.g. an open PR depends on it,
+  # or the branch is needed for a retry).
+  git checkout "$TARGET" 2>/dev/null || true
+  git branch -D temp 2>/dev/null || true
 }
 
 pr_lookup_missing() {
@@ -621,6 +643,7 @@ if [ "$MERGE_STRATEGY" = "mr" ] && [ -n "$EXISTING_PR" ]; then
   if [ -z "$ORIGIN_REPO" ]; then
     [ -n "$ORIGIN_REPO_ERROR" ] && echo "$ORIGIN_REPO_ERROR"
     echo "Could not resolve origin repository for existing PR validation. STOP. Debug and retry without mutating bead state."
+    cleanup_temp_only
     gc runtime drain-ack
     exit 1
   fi
@@ -639,6 +662,7 @@ if [ "$MERGE_STRATEGY" = "mr" ] && [ -n "$EXISTING_PR" ]; then
     fi
     echo "Could not resolve existing PR $EXISTING_PR. STOP. Debug and retry without mutating bead state."
     [ -n "$EXISTING_PR_ERROR" ] && echo "$EXISTING_PR_ERROR"
+    cleanup_temp_only
     gc runtime drain-ack
     exit 1
   fi
@@ -670,6 +694,7 @@ fi
 if [ "$MERGE_STRATEGY" = "mr" ] && [ -z "$ORIGIN_REPO" ]; then
   [ -n "$ORIGIN_REPO_ERROR" ] && echo "$ORIGIN_REPO_ERROR"
   echo "Could not resolve origin repository for pull-request handoff. STOP. Debug and retry without mutating bead state."
+  cleanup_temp_only
   gc runtime drain-ack
   exit 1
 fi
@@ -740,12 +765,15 @@ closed bead to its merge commit on `$TARGET`. `--unset-metadata
 rejection_reason` clears any stale rejection field from an earlier
 rejected/reworked attempt before the successful close.
 
-**2. Cleanup:**
+**2. Cleanup — run as a single sequence so interruption cannot strand a branch:**
 ```bash
 git checkout --detach "origin/$TARGET" >/dev/null 2>&1 || true
 git branch -d temp || git branch -D temp || true
+[ "{{delete_merged_branches}}" = "true" ] && git push origin --delete "$BRANCH" || true
 ```
-If delete_merged_branches = "true": `git push origin --delete $BRANCH`
+Always delete the local `temp` branch. The remote source branch is deleted when
+`delete_merged_branches = "{{delete_merged_branches}}"` (i.e. the substituted value is `"true"`).
+Run both in the same turn.
 
 **If MERGE_STRATEGY = "mr":**
 
@@ -831,6 +859,7 @@ else
     if ! init_github_rest 2>"$PR_ERR"; then
       cat "$PR_ERR"
       rm -f "$PR_ERR"
+      cleanup_temp_only
       gc runtime drain-ack
       exit 1
     fi
@@ -845,6 +874,7 @@ else
       echo "GitHub API request failed while checking for an existing PR for $BRANCH."
       [ -n "$PR_ERROR" ] && echo "$PR_ERROR"
       rm -f "$PR_ERR"
+      cleanup_temp_only
       gc runtime drain-ack
       exit 1
     fi
@@ -865,6 +895,7 @@ else
         echo "GitHub API request failed while creating a PR for $BRANCH."
         [ -n "$PR_ERROR" ] && echo "$PR_ERROR"
         rm -f "$PR_ERR"
+        cleanup_temp_only
         gc runtime drain-ack
         exit 1
       fi
@@ -872,6 +903,7 @@ else
       if [ -z "$PR_NUMBER" ]; then
         echo "GitHub API response did not include a pull request number."
         rm -f "$PR_ERR"
+        cleanup_temp_only
         gc runtime drain-ack
         exit 1
       fi
@@ -883,6 +915,7 @@ else
     if [ "$PR_STATUS" -ne 0 ]; then
       echo "GitHub API request failed while reading PR $PR_NUMBER."
       [ -n "$PR_ERROR" ] && echo "$PR_ERROR"
+      cleanup_temp_only
       gc runtime drain-ack
       exit 1
     fi
@@ -907,6 +940,7 @@ if [ "$PR_STATUS" -ne 0 ] || [ -z "$PR_INFO" ]; then
   fi
   echo "Pull request $PR_REF was not found."
   [ -n "$PR_ERROR" ] && echo "$PR_ERROR"
+  cleanup_temp_only
   gc runtime drain-ack
   exit 1
 fi
@@ -923,6 +957,7 @@ if [ "$PR_STATE" != "OPEN" ]; then
     block_existing_pr "Existing PR $EXISTING_PR is $PR_STATE, want OPEN."
   fi
   echo "Pull request $PR_REF is $PR_STATE, want OPEN."
+  cleanup_temp_only
   gc runtime drain-ack
   exit 1
 fi
@@ -931,6 +966,7 @@ if [ "$PR_HEAD" != "$BRANCH" ]; then
     block_existing_pr "Existing PR $EXISTING_PR targets branch $PR_HEAD, want $BRANCH."
   fi
   echo "Pull request $PR_REF targets branch $PR_HEAD, want $BRANCH."
+  cleanup_temp_only
   gc runtime drain-ack
   exit 1
 fi
@@ -939,6 +975,7 @@ if [ "$PR_BASE" != "$TARGET" ]; then
     block_existing_pr "Existing PR $EXISTING_PR targets base $PR_BASE, want $TARGET."
   fi
   echo "Pull request $PR_REF targets base $PR_BASE, want $TARGET."
+  cleanup_temp_only
   gc runtime drain-ack
   exit 1
 fi
@@ -947,6 +984,7 @@ if [ "$PR_REPO" != "$ORIGIN_REPO" ]; then
     block_existing_pr "Existing PR $EXISTING_PR belongs to repo $PR_REPO, want $ORIGIN_REPO."
   fi
   echo "Pull request $PR_REF belongs to repo $PR_REPO, want $ORIGIN_REPO."
+  cleanup_temp_only
   gc runtime drain-ack
   exit 1
 fi
@@ -955,6 +993,7 @@ if [ "$PR_HEAD_REPO" != "$ORIGIN_REPO" ]; then
     block_existing_pr "Existing PR $EXISTING_PR head repo $PR_HEAD_REPO, want $ORIGIN_REPO."
   fi
   echo "Pull request $PR_REF head repo $PR_HEAD_REPO, want $ORIGIN_REPO."
+  cleanup_temp_only
   gc runtime drain-ack
   exit 1
 fi

--- a/gastown/formulas/mol-refinery-patrol.toml
+++ b/gastown/formulas/mol-refinery-patrol.toml
@@ -70,6 +70,10 @@ default = "main"
 description = "Whether to delete source branches after merge"
 default = "true"
 
+[vars.delete_merged_worktrees]
+description = "Whether to delete the polecat worktree after a successful merge"
+default = "true"
+
 [vars.integration_branch_auto_land]
 description = "Auto-create work beads to land completed integration branches"
 default = "false"
@@ -804,6 +808,16 @@ Always delete the local `temp` branch. The remote source branch is deleted when
 `delete_merged_branches = "{{delete_merged_branches}}"` (i.e. the substituted value is `"true"`).
 Run both in the same turn.
 
+If delete_merged_worktrees = "true":
+```bash
+WORKTREE=$(gc bd show $WORK --json | jq -r '.[0].metadata.work_dir // empty')
+if [ -n "$WORKTREE" ] && [ -d "$WORKTREE" ]; then
+  git worktree remove --force "$WORKTREE" || rm -rf "$WORKTREE"
+  git worktree prune
+fi
+gc bd update $WORK --unset-metadata work_dir
+```
+
 **If MERGE_STRATEGY = "mr":**
 
 Refinery does NOT land the branch directly. Instead it publishes a pull
@@ -1055,6 +1069,16 @@ git checkout "$TARGET"
 git branch -d temp
 ```
 Do NOT delete `$BRANCH` in mr mode — GitHub pull requests need the source branch.
+
+If delete_merged_worktrees = "true":
+```bash
+WORKTREE=$(gc bd show $WORK --json | jq -r '.[0].metadata.work_dir // empty')
+if [ -n "$WORKTREE" ] && [ -d "$WORKTREE" ]; then
+  git worktree remove --force "$WORKTREE" || rm -rf "$WORKTREE"
+  git worktree prune
+fi
+gc bd update $WORK --unset-metadata work_dir
+```
 
 **If MERGE_STRATEGY = "local":**
 

--- a/gastown/tests/test_gastown_pack_assets.sh
+++ b/gastown/tests/test_gastown_pack_assets.sh
@@ -214,6 +214,26 @@ if verify >= metadata:
 PY
 }
 
+test_refinery_idle_contract_is_explicit_and_guarded() {
+    local agent prompt formula
+    agent="$GASTOWN/agents/refinery/agent.toml"
+    prompt="$GASTOWN/agents/refinery/prompt.template.md"
+    formula="$GASTOWN/formulas/mol-refinery-patrol.toml"
+
+    grep -F 'sleep_after_idle = "300s"' "$agent" >/dev/null ||
+        fail "refinery agent must keep an explicit sleep_after_idle patrol interval"
+    grep -F 'Normal no-work exit path depends on session_sleep restart policy via' "$agent" >/dev/null ||
+        fail "refinery agent should document that normal idle depends on sleep_after_idle"
+    grep -F 'depends on `sleep_after_idle` in `agents/refinery/agent.toml`' "$prompt" >/dev/null ||
+        fail "refinery prompt must document that no-work idle depends on sleep_after_idle"
+    grep -F 'without `gc runtime request-restart`' "$prompt" >/dev/null ||
+        fail "refinery prompt must distinguish idle exit from heavy-context restart"
+    grep -F 'This normal idle path depends on `sleep_after_idle` in' "$formula" >/dev/null ||
+        fail "refinery formula must document that no-work idle depends on sleep_after_idle"
+    grep -F 'Heavy-context recycling uses' "$formula" >/dev/null ||
+        fail "refinery formula must distinguish heavy-context restart from idle exit"
+}
+
 test_dog_assets_are_pack_local
 test_retired_dog_formulas_are_not_reintroduced
 test_shutdown_dance_contracts_are_executable
@@ -222,5 +242,6 @@ test_composition_is_documented
 test_polecat_startup_uses_standard_hook_claim
 test_review_leg_contract_forbids_synthetic_mutation
 test_refinery_direct_merge_is_worktree_safe_and_fail_closed
+test_refinery_idle_contract_is_explicit_and_guarded
 
 echo "gastown pack asset tests passed"

--- a/gastown/tests/test_gastown_pack_assets.sh
+++ b/gastown/tests/test_gastown_pack_assets.sh
@@ -212,6 +212,18 @@ metadata = block.index('--set-metadata merge_result=merged')
 if verify >= metadata:
     raise SystemExit(1)
 PY
+
+    [[ "$direct_block" == *'cleanup_stale_polecat_refs()'* ]] ||
+        fail "direct refinery merge must define stale polecat ref cleanup"
+    [[ "$direct_block" == *'git for-each-ref --format='\''%(refname:short)'\'' refs/heads/polecat/'* ]] ||
+        fail "direct refinery merge must scan local polecat heads before cleanup"
+    [[ "$direct_block" == *'git update-ref -d "refs/heads/$ref"'* ]] ||
+        fail "direct refinery merge must delete stale local polecat refs"
+
+    grep -F 'cleanup_stale_polecat_ref()' "$formula" >/dev/null ||
+        fail "mr refinery merge must define stale polecat ref cleanup"
+    grep -F 'git update-ref -d "$branch_ref"' "$formula" >/dev/null ||
+        fail "mr refinery merge must delete the matching stale local polecat ref"
 }
 
 test_refinery_idle_contract_is_explicit_and_guarded() {

--- a/scripts/gascity_pack_inference_gate.py
+++ b/scripts/gascity_pack_inference_gate.py
@@ -2559,6 +2559,29 @@ def validate_gastown_orchestration_contract(pack_source: Path) -> None:
         for fragment in required_fragments:
             if fragment not in text:
                 missing.append(f"{formula_name}: missing contract fragment {fragment!r}")
+    idle_contract_files = {
+        "agents/refinery/agent.toml": (
+            'sleep_after_idle = "300s"',
+            "Normal no-work exit path depends on session_sleep restart policy via",
+        ),
+        "agents/refinery/prompt.template.md": (
+            "depends on `sleep_after_idle` in `agents/refinery/agent.toml`",
+            "without `gc runtime request-restart`",
+        ),
+        "formulas/mol-refinery-patrol.toml": (
+            "This normal idle path depends on `sleep_after_idle` in",
+            "Heavy-context recycling uses",
+        ),
+    }
+    for relpath, required_fragments in idle_contract_files.items():
+        path = pack_source / relpath
+        if not path.is_file():
+            missing.append(f"refinery idle contract: missing file {path}")
+            continue
+        text = path.read_text(encoding="utf-8", errors="replace")
+        for fragment in required_fragments:
+            if fragment not in text:
+                missing.append(f"refinery idle contract: {relpath} missing {fragment!r}")
     if missing:
         raise GateError("Gastown orchestration contract drifted:\n" + "\n".join(f"- {item}" for item in missing))
 

--- a/tests/test_gascity_pack_inference_gate.py
+++ b/tests/test_gascity_pack_inference_gate.py
@@ -823,6 +823,20 @@ def test_validate_gastown_orchestration_contract_rejects_missing_refinery_false_
         gascity_pack_inference_gate.validate_gastown_orchestration_contract(tmp_path / "gastown")
 
 
+def test_validate_gastown_orchestration_contract_rejects_missing_refinery_idle_contract(tmp_path) -> None:
+    spec = gascity_pack_inference_gate.PACK_SPECS["gastown"]
+    pack_source = tmp_path / "gastown"
+    shutil.copytree(spec.source, pack_source)
+    agent = pack_source / "agents" / "refinery" / "agent.toml"
+    agent.write_text(
+        agent.read_text(encoding="utf-8").replace('sleep_after_idle = "300s"', 'sleep_after_idle = ""'),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(gascity_pack_inference_gate.GateError, match="sleep_after_idle"):
+        gascity_pack_inference_gate.validate_gastown_orchestration_contract(pack_source)
+
+
 def test_validate_methodology_flow_contracts_accept_current_packs() -> None:
     for pack_name in gascity_pack_inference_gate.METHODOLOGY_PACKS:
         gascity_pack_inference_gate.validate_methodology_flow_contract(


### PR DESCRIPTION
## Problem

Long-running gastown refineries leak state on almost every non-happy path, and the idle path can go permanently dormant:

1. **Stranded branches.** `halt_false_completion()`, `block_existing_pr()`, and the early-exit paths (ORIGIN_REPO resolution failures, mr-mode PR creation/verification failures) exit without deleting `temp` — and in some cases leave the remote source branch behind. Observed as 130+ leftover branches on a busy rig.
2. **Dormant refinery on idle.** The no-work path exits without pouring the next patrol wisp; the refinery lands in `asleep` with no successor wisp and cannot restart despite 10+ beads routed to it, requiring manual resets. Relatedly, the idle wake contract lives implicitly in `sleep_after_idle` — blanking it as a latency tweak silently breaks the restart path.
3. **Disk bloat.** Merged polecat worktrees are never cleaned up (5–15 GB each for Rust projects with `target/` dirs).
4. **Dead local refs.** `polecat/<bead-id>` refs accumulate in the refinery worktree long after their beads are closed.

## Fix

Five logical commits:

- `fix(refinery): guarantee branch cleanup on all exit paths` — adds idempotent `cleanup_branch()` (deletes `temp` + conditional remote delete when `delete_merged_branches=true`) and `cleanup_temp_only()` (never deletes the remote branch, for paths where `$BRANCH` must be preserved for a PR or retry), wired into every exit path.
- `fix(refinery): pour next wisp before idle exit to prevent dormant state` — the no-work path now pours and assigns the next patrol iteration and burns the current wisp before exiting, so session_sleep can restart cleanly; falls back to the plain idle exit if the pour/assign fails.
- `feat(refinery): delete merged polecat worktrees after successful merge` — new `delete_merged_worktrees` var (default `"true"`); after a successful merge (direct and mr paths) removes the worktree recorded in the bead's `work_dir` metadata and unsets the metadata.
- `fix(gastown): guard refinery idle restart contract` — documents the two recycle paths (normal idle via `sleep_after_idle` vs heavy-context `gc runtime request-restart`) as one contract across README/agent/prompt/formula, and guards it with a pack asset test plus an inference-gate check so `sleep_after_idle` cannot be blanked without redesigning the wake contract.
- `fix(refinery): prune stale local polecat refs after successful close` — after a confirmed bead close, prunes local `polecat/` refs whose beads are closed/rejected/abandoned (direct path scans `refs/heads/polecat/`; mr path deletes the matching branch ref), with pack asset tests keeping both cleanups wired.

## Relationship to open PRs

- **#172** (`fix(gastown): verify refinery merges before close`) touches the same close/cleanup region of `mol-refinery-patrol.toml`. This PR is complementary, not conflicting in intent: #172's verification-failure paths deliberately preserve the source branch for recovery/debug, and nothing here deletes a branch on a failure path that #172 wants preserved (`cleanup_temp_only` only removes the local `temp` branch). The `cleanup_branch`/stale-polecat-ref helpers here were deliberately left out of #172 as separate concerns. Expect a textual (not semantic) merge conflict in the formula whichever lands second — happy to rebase.
- **#93** (`gc.routed_to=polecat un-droppable on reject paths`) covers the reject-path routing hardening; it is intentionally not duplicated here. A follow-up making the reject update priority-bumped and ordering-resilient is best stacked on #93 once it lands.

## Testing

- `bash gastown/tests/test_gastown_pack_assets.sh` — passes (includes the new idle-contract and stale-ref assertions).
- `bash -n` on the test script; `tomllib` parse of the formula and agent TOML — clean.
- `python -m pytest tests/test_gascity_pack_inference_gate.py` — 41 passed, 3 failed; the same 3 failures preexist on `upstream/main` (verified on a clean worktree: 40 passed, 3 failed). The new `rejects_missing_refinery_idle_contract` test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
