### PR TITLE
fix(slack-mini): persist-and-retry inbound forwards, sender display names, mrkdwn conversion, registered reply instructions

### DIFF
--- a/slack-mini/CHANGELOG.md
+++ b/slack-mini/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Codex review round on this branch (1 P1 + 4 P2, all fixed): the
+  decoded mention is spooled synchronously BEFORE the events endpoint
+  200-acks Slack (the old ack → async users.info → spool order lost
+  acked mentions to a crash in the enrichment window; enrichment and
+  delivery stay async, and startup replay now finishes enrichment
+  too); spool entries are written atomically (same-dir temp file +
+  fsync + rename) so a torn write can no longer dead-letter an acked
+  message with no valid payload left; Markdown link destinations and
+  bare URLs are converted/protected BEFORE the emphasis passes (a
+  destination like `.../pkg/__init__.py` was being rewritten into a
+  broken href); `[text](url)` parsing handles balanced parentheses in
+  the destination (`.../Function_(mathematics)`); and multi-backtick
+  GFM code spans (``…`` with a backtick inside) pass through
+  verbatim like single-backtick spans.
+
 ### Added
 
 - Inbound mentions resolve the sender's display name via `users.info`

--- a/slack-mini/CHANGELOG.md
+++ b/slack-mini/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to slack-mini are documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Inbound mentions resolve the sender's display name via `users.info`
+  (cached in-memory for an hour; failures negative-cached for 5 minutes)
+  so gc's injected reminder shows a human name instead of a raw user id
+  like `U0AN32RPBFT` (hq-fh9). The app manifest now requests the
+  `users:read` bot scope — existing installs must re-approve the app for
+  name resolution to work; until then the adapter falls back to raw ids.
+- The adapter registers a Tier-1 `reply_instructions` template with gc, so
+  the inbound nudge advertises the real
+  `gc slack-mini post-message --channel … --thread-ts …` verb (with the
+  message's thread id filled in) instead of the non-existent
+  `gc slack reply-current` (hq-fh9).
+
+### Changed
+
+- `/post-message` converts common GitHub-flavored Markdown (`**bold**`,
+  `__bold__`, `~~strike~~`, `[text](url)`, `#`-headings) to Slack mrkdwn
+  before `chat.postMessage`; fenced and inline code pass through verbatim
+  (hq-fh9).
+
 ## [0.1.0] — Tier 1 extraction
 
 Initial release. slack-mini is Tier 1 of the Slack pack family — the

--- a/slack-mini/adapter/main.go
+++ b/slack-mini/adapter/main.go
@@ -381,12 +381,24 @@ func handleSlackEvents(cfg config) http.HandlerFunc {
 		// synchronous cost is one decode + one fsync'd file write,
 		// well inside Slack's 3s ack budget. Enrichment (users.info)
 		// and delivery stay async.
-		if inbound, spoolPath, ok := prepareInbound(cfg, env); ok {
+		inbound, spoolPath, spoolErr, ok := prepareInbound(cfg, env)
+		if !ok {
 			w.WriteHeader(http.StatusOK)
-			go finishInbound(cfg, inbound, spoolPath)
+			return
+		}
+		if spoolErr != nil {
+			// Spooling is CONFIGURED but failed (full/unwritable disk):
+			// acking now would let a crash lose the mention with no
+			// replayable entry — answer 5xx so Slack redelivers (codex
+			// round 3 P1; duplicates dedupe by ts). Explicitly disabled
+			// spooling (empty spoolDir) still acks and rides the
+			// in-memory retries.
+			log.Printf("inbound spool failed; NACKing for Slack retry: %v", spoolErr)
+			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
 		w.WriteHeader(http.StatusOK)
+		go finishInbound(cfg, inbound, spoolPath)
 	}
 }
 
@@ -395,7 +407,7 @@ func handleSlackEvents(cfg config) http.HandlerFunc {
 // handler calls the two halves itself so the spool write lands before
 // the Slack ack.
 func bridgeEvent(cfg config, env slackEventEnvelope) {
-	if inbound, spoolPath, ok := prepareInbound(cfg, env); ok {
+	if inbound, spoolPath, _, ok := prepareInbound(cfg, env); ok {
 		finishInbound(cfg, inbound, spoolPath)
 	}
 }
@@ -406,24 +418,24 @@ func bridgeEvent(cfg config, env slackEventEnvelope) {
 // empty body). The Actor's DisplayName is left as the raw user id here
 // — the users.info lookup can take seconds and must not delay the
 // Slack ack; finishInbound resolves it before the forward.
-func prepareInbound(cfg config, env slackEventEnvelope) (externalInboundMessage, string, bool) {
+func prepareInbound(cfg config, env slackEventEnvelope) (externalInboundMessage, string, error, bool) {
 	if env.Type != "event_callback" || len(env.Event) == 0 {
-		return externalInboundMessage{}, "", false
+		return externalInboundMessage{}, "", nil, false
 	}
 	var msg slackMessageEvent
 	if err := json.Unmarshal(env.Event, &msg); err != nil {
 		log.Printf("decode slack event: %v", err)
-		return externalInboundMessage{}, "", false
+		return externalInboundMessage{}, "", nil, false
 	}
 	if msg.Type != "app_mention" {
-		return externalInboundMessage{}, "", false
+		return externalInboundMessage{}, "", nil, false
 	}
 	if msg.BotID != "" || msg.Subtype != "" || msg.User == "" {
-		return externalInboundMessage{}, "", false
+		return externalInboundMessage{}, "", nil, false
 	}
 	text := stripLeadingMention(msg.Text)
 	if text == "" {
-		return externalInboundMessage{}, "", false
+		return externalInboundMessage{}, "", nil, false
 	}
 
 	// Log receipt before the first forward attempt so a message that later
@@ -450,14 +462,24 @@ func prepareInbound(cfg config, env slackEventEnvelope) (externalInboundMessage,
 		DedupKey:         "slack-" + msg.TS,
 		ReceivedAt:       time.Now().UTC(),
 	}
-	return inbound, spoolInbound(cfg.spoolDir, inbound), true
+	spoolPath, spoolErr := spoolInbound(cfg.spoolDir, inbound)
+	return inbound, spoolPath, spoolErr, true
 }
 
 // finishInbound runs the async half of the bridge: display-name
 // enrichment (bounded by userInfoTimeout) and the retried forward.
 // Each gc call is bounded by gcCallTimeout and the retry schedule
 // bounds the goroutine's total lifetime to ~2 minutes.
+// finishInboundSem bounds concurrent live deliveries (codex round 3):
+// each finishInbound can run users.info plus ~3 minutes of gc retries,
+// and an unbounded burst would exhaust sockets or hammer a recovering
+// gc. Waiters are accepted Slack events (rate-bounded upstream) parked
+// on a cheap channel; startup replay has its own 4-worker bound.
+var finishInboundSem = make(chan struct{}, 8)
+
 func finishInbound(cfg config, inbound externalInboundMessage, spoolPath string) {
+	finishInboundSem <- struct{}{}
+	defer func() { <-finishInboundSem }()
 	inbound.Actor.DisplayName = resolveUserDisplayName(context.Background(), userNames, cfg, inbound.Actor.ID)
 	deliverInbound(cfg, inbound, spoolPath)
 }
@@ -467,26 +489,23 @@ func finishInbound(cfg config, inbound externalInboundMessage, spoolPath string)
 // Returns the spool file path, or "" when spooling is disabled (no spool
 // dir) or the write fails — persistence is best-effort and never blocks
 // the bridge.
-func spoolInbound(spoolDir string, msg externalInboundMessage) string {
+func spoolInbound(spoolDir string, msg externalInboundMessage) (string, error) {
 	if spoolDir == "" {
-		return ""
+		return "", nil
 	}
 	if err := os.MkdirAll(spoolDir, 0o700); err != nil {
-		log.Printf("spool: mkdir %s: %v", spoolDir, err)
-		return ""
+		return "", fmt.Errorf("spool: mkdir %s: %w", spoolDir, err)
 	}
 	data, err := json.Marshal(msg)
 	if err != nil {
-		log.Printf("spool: marshal: %v", err)
-		return ""
+		return "", fmt.Errorf("spool: marshal: %w", err)
 	}
 	name := fmt.Sprintf("%d-%s.json", time.Now().UnixNano(), sanitizeSpoolName(msg.DedupKey))
 	path := filepath.Join(spoolDir, name)
 	if err := writeSpoolFileAtomic(path, data); err != nil {
-		log.Printf("spool: write %s: %v", path, err)
-		return ""
+		return "", fmt.Errorf("spool: write %s: %w", path, err)
 	}
-	return path
+	return path, nil
 }
 
 // writeSpoolFileAtomic writes data to path via a same-dir temp file +
@@ -526,7 +545,19 @@ func writeSpoolFileAtomic(path string, data []byte) error {
 		cleanup()
 		return fmt.Errorf("rename %q -> %q: %w", tmpName, path, err)
 	}
-	return nil
+	// Fsync the parent directory so the rename itself survives a host
+	// crash (codex round 3): the file contents were synced above, but
+	// the directory entry was not — and a spool entry that vanishes on
+	// reboot silently loses an acked Slack event.
+	d, err := os.Open(dir)
+	if err != nil {
+		return fmt.Errorf("open dir %q for sync: %w", dir, err)
+	}
+	if err := d.Sync(); err != nil {
+		_ = d.Close()
+		return fmt.Errorf("sync dir %q: %w", dir, err)
+	}
+	return d.Close()
 }
 
 // spoolNameRE matches characters unsafe in a spool filename.
@@ -686,12 +717,26 @@ type cachedUserName struct {
 // userNameCache is an in-memory users.info result cache. Tier 1 keeps no
 // on-disk registries by design, so entries live for the process lifetime.
 type userNameCache struct {
-	mu      sync.Mutex
-	entries map[string]cachedUserName
+	mu       sync.Mutex
+	entries  map[string]cachedUserName
+	inflight map[string]*userNameProbe
+}
+
+// userNameProbe coalesces concurrent users.info lookups for one user
+// (codex round 3): a burst of mentions from an uncached user — or the
+// four replay workers — would otherwise each fire users.info, tripping
+// rate limits and letting a late failure overwrite a success. done is
+// closed after name is populated; waiters read it only after <-done.
+type userNameProbe struct {
+	done chan struct{}
+	name string
 }
 
 func newUserNameCache() *userNameCache {
-	return &userNameCache{entries: make(map[string]cachedUserName)}
+	return &userNameCache{
+		entries:  make(map[string]cachedUserName),
+		inflight: make(map[string]*userNameProbe),
+	}
 }
 
 func (c *userNameCache) get(userID string, now time.Time) (string, bool) {
@@ -742,13 +787,32 @@ func resolveUserDisplayName(ctx context.Context, cache *userNameCache, cfg confi
 	if name, ok := cache.get(userID, now); ok {
 		return name
 	}
+	// Coalesce concurrent misses onto one users.info call (codex round
+	// 3): later callers wait on the winner's probe (bounded by its
+	// userInfoTimeout-scoped request) and adopt its answer.
+	cache.mu.Lock()
+	if p, ok := cache.inflight[userID]; ok {
+		cache.mu.Unlock()
+		<-p.done
+		return p.name
+	}
+	probe := &userNameProbe{done: make(chan struct{})}
+	cache.inflight[userID] = probe
+	cache.mu.Unlock()
+
 	name := fetchUserDisplayName(ctx, cfg, userID)
 	if name == "" {
 		cache.put(userID, userID, now, userNameFailureTTL)
-		return userID
+		probe.name = userID
+	} else {
+		cache.put(userID, name, now, userNameCacheTTL)
+		probe.name = name
 	}
-	cache.put(userID, name, now, userNameCacheTTL)
-	return name
+	cache.mu.Lock()
+	delete(cache.inflight, userID)
+	cache.mu.Unlock()
+	close(probe.done)
+	return probe.name
 }
 
 // fetchUserDisplayName performs the users.info call, returning "" on any
@@ -1062,7 +1126,12 @@ func slackifyMarkdown(text string) string {
 	// `**` belongs to the bold span, not the URL — swallowing it into
 	// the protected span would leave the bold pass without its closer.
 	out = bareURLRE.ReplaceAllStringFunc(out, func(m string) string {
-		trimmed := strings.TrimRight(m, "*_~")
+		// Sentence punctuation first, THEN emphasis delimiters (codex
+		// round 3): in `**see https://example.com**.` the trailing
+		// period hides the `**` from a delimiter-only trim.
+		trimmed := strings.TrimRight(m, ".,;:!?")
+		trimmed = strings.TrimRight(trimmed, "*_~")
+		trimmed = strings.TrimRight(trimmed, ".,;:!?")
 		if trimmed == "" {
 			return m
 		}
@@ -1146,11 +1215,17 @@ func protectFencedBlocks(s string, protect func(string) string) string {
 			i++
 			continue
 		}
+		// GFM: the closing fence must be AT LEAST as long as the
+		// opener (codex round 3) — a ```` fence may contain ``` lines.
+		opener := 0
+		for opener < len(trimmed) && trimmed[opener] == '`' {
+			opener++
+		}
 		j := i + 1
 		closed := -1
 		for j < len(lines) {
 			body := strings.TrimSpace(lines[j])
-			if len(body) >= 3 && strings.Count(body, "`") == len(body) {
+			if len(body) >= opener && strings.Count(body, "`") == len(body) {
 				closed = j
 				break
 			}
@@ -1160,7 +1235,16 @@ func protectFencedBlocks(s string, protect func(string) string) string {
 			b.WriteString(protect(strings.Join(lines[i:], "")))
 			break
 		}
-		b.WriteString(protect(strings.Join(lines[i:closed+1], "")))
+		// Keep the block's trailing newline OUTSIDE the placeholder
+		// (codex round 3): swallowing it would glue the next line onto
+		// the placeholder and break line-anchored passes (headings).
+		block := strings.Join(lines[i:closed+1], "")
+		if strings.HasSuffix(block, "\n") {
+			b.WriteString(protect(block[:len(block)-1]))
+			b.WriteString("\n")
+		} else {
+			b.WriteString(protect(block))
+		}
 		i = closed + 1
 	}
 	return b.String()
@@ -1267,7 +1351,11 @@ func convertMarkdownLinks(s string, protect func(string) string) string {
 		dest := destB.String()
 		if depth == 0 && linkText != "" &&
 			(strings.HasPrefix(dest, "http://") || strings.HasPrefix(dest, "https://")) {
-			b.WriteString(protect("<" + dest + "|" + linkText + ">"))
+			// Slack mrkdwn control characters in the label would
+			// terminate the <url|label> form early (codex round 3):
+			// `[x > y](…)` must not leak a raw '>' into the link.
+			label := strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;").Replace(linkText)
+			b.WriteString(protect("<" + dest + "|" + label + ">"))
 			i = j + 1
 			continue
 		}

--- a/slack-mini/adapter/main.go
+++ b/slack-mini/adapter/main.go
@@ -608,28 +608,58 @@ func replaySpool(cfg config) {
 		}
 		return
 	}
+	var paths []string
 	for _, e := range entries {
 		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
 			continue
 		}
-		path := filepath.Join(cfg.spoolDir, e.Name())
-		data, err := os.ReadFile(path)
-		if err != nil {
-			log.Printf("spool replay: read %s: %v", path, err)
-			continue
-		}
-		var msg externalInboundMessage
-		if err := json.Unmarshal(data, &msg); err != nil {
-			log.Printf("spool replay: decode %s: %v (dead-letter=%s)", path, err, moveToDeadLetter(path))
-			continue
-		}
-		log.Printf("spool replay: re-delivering %s (chan=%s ts=%s)",
-			e.Name(), msg.Conversation.ConversationID, msg.ProviderMessageID)
-		// Entries are spooled before display-name enrichment; finish
-		// it here so a replayed mention carries the same name a live
-		// delivery would.
-		go finishInbound(cfg, msg, path)
+		paths = append(paths, filepath.Join(cfg.spoolDir, e.Name()))
 	}
+	if len(paths) == 0 {
+		return
+	}
+	// Bounded worker pool (codex round 2): one goroutine per entry
+	// would run users.info + several timed gc retries for every
+	// backlog entry at once — a large crash backlog could exhaust
+	// sockets or rate-limit Slack and the recovering gc. Workers read
+	// and decode their own entries so payload memory is bounded too.
+	work := make(chan string)
+	for range replaySpoolWorkers {
+		go func() {
+			for path := range work {
+				replayPath(cfg, path)
+			}
+		}()
+	}
+	go func() {
+		for _, p := range paths {
+			work <- p
+		}
+		close(work)
+	}()
+}
+
+// replaySpoolWorkers bounds concurrent startup replay deliveries.
+const replaySpoolWorkers = 4
+
+// replayPath reads and decodes one spool entry (quarantining
+// undecodable files) and re-delivers it. Entries are spooled before
+// display-name enrichment; finishInbound completes it so a replayed
+// mention carries the same name a live delivery would.
+func replayPath(cfg config, path string) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		log.Printf("spool replay: read %s: %v", path, err)
+		return
+	}
+	var msg externalInboundMessage
+	if err := json.Unmarshal(data, &msg); err != nil {
+		log.Printf("spool replay: decode %s: %v (dead-letter=%s)", path, err, moveToDeadLetter(path))
+		return
+	}
+	log.Printf("spool replay: re-delivering %s (chan=%s ts=%s)",
+		filepath.Base(path), msg.Conversation.ConversationID, msg.ProviderMessageID)
+	finishInbound(cfg, msg, path)
 }
 
 // --- inbound: Slack user display-name resolution ---------------------------
@@ -994,12 +1024,13 @@ func writeJSONError(w http.ResponseWriter, status int, msg string) {
 // --- outbound: GitHub Markdown → Slack mrkdwn -------------------------------
 
 var (
-	fencedCodeRE = regexp.MustCompile("(?s)```.*?```")
-	boldStarsRE  = regexp.MustCompile(`\*\*(.+?)\*\*`)
-	boldUnderRE  = regexp.MustCompile(`__(.+?)__`)
-	strikeRE     = regexp.MustCompile(`~~(.+?)~~`)
-	headingRE    = regexp.MustCompile(`(?m)^#{1,6}[ \t]+(.+?)[ \t]*#*[ \t]*$`)
-	bareURLRE    = regexp.MustCompile(`https?://[^\s<>|]+`)
+	boldStarsRE = regexp.MustCompile(`\*\*(.+?)\*\*`)
+	strikeRE    = regexp.MustCompile(`~~(.+?)~~`)
+	// Closing heading hashes count only when whitespace-separated
+	// (codex round 2): GFM keeps the final '#' of `# C#` as content,
+	// so the optional closer requires a preceding blank.
+	headingRE = regexp.MustCompile(`(?m)^#{1,6}[ \t]+(.+?)(?:[ \t]+#+)?[ \t]*$`)
+	bareURLRE = regexp.MustCompile(`https?://[^\s<>|]+`)
 )
 
 // slackifyMarkdown converts the GitHub-flavored Markdown constructs agents
@@ -1023,18 +1054,23 @@ func slackifyMarkdown(text string) string {
 		protected = append(protected, s)
 		return fmt.Sprintf("\x00%d\x00", len(protected)-1)
 	}
-	out := fencedCodeRE.ReplaceAllStringFunc(text, protect)
-	// An unterminated fence swallows the rest of the message: protect it
-	// whole rather than reformatting half a code block.
-	if idx := strings.Index(out, "```"); idx >= 0 {
-		out = out[:idx] + protect(out[idx:])
-	}
+	out := protectFencedBlocks(text, protect)
 	out = protectCodeSpans(out, protect)
 	out = convertMarkdownLinks(out, protect)
-	out = bareURLRE.ReplaceAllStringFunc(out, protect)
+	// Bare URLs are protected sans any trailing emphasis delimiters
+	// (codex round 2): in `**see https://example.com**` the closing
+	// `**` belongs to the bold span, not the URL — swallowing it into
+	// the protected span would leave the bold pass without its closer.
+	out = bareURLRE.ReplaceAllStringFunc(out, func(m string) string {
+		trimmed := strings.TrimRight(m, "*_~")
+		if trimmed == "" {
+			return m
+		}
+		return protect(trimmed) + m[len(trimmed):]
+	})
 	out = headingRE.ReplaceAllString(out, "*$1*")
 	out = boldStarsRE.ReplaceAllString(out, "*$1*")
-	out = boldUnderRE.ReplaceAllString(out, "*$1*")
+	out = convertUnderscoreBold(out)
 	out = strikeRE.ReplaceAllString(out, "~$1~")
 	for i := len(protected) - 1; i >= 0; i-- {
 		out = strings.Replace(out, fmt.Sprintf("\x00%d\x00", i), protected[i], 1)
@@ -1092,6 +1128,86 @@ func protectCodeSpans(s string, protect func(string) string) string {
 	return b.String()
 }
 
+// protectFencedBlocks protects GFM fenced code blocks line-orientedly
+// (codex round 2): a fence opens at a line beginning with ``` and
+// closes only at a LINE that is nothing but ``` and whitespace — an
+// embedded sequence inside a code line (fmt.Println("```")) is block
+// content, not a closer, which the old (?s)```.*?``` regex got wrong.
+// An unterminated fence swallows the rest of the message: it is
+// protected whole rather than reformatting half a code block.
+func protectFencedBlocks(s string, protect func(string) string) string {
+	lines := strings.SplitAfter(s, "\n")
+	var b strings.Builder
+	i := 0
+	for i < len(lines) {
+		trimmed := strings.TrimLeft(lines[i], " \t")
+		if !strings.HasPrefix(trimmed, "```") {
+			b.WriteString(lines[i])
+			i++
+			continue
+		}
+		j := i + 1
+		closed := -1
+		for j < len(lines) {
+			body := strings.TrimSpace(lines[j])
+			if len(body) >= 3 && strings.Count(body, "`") == len(body) {
+				closed = j
+				break
+			}
+			j++
+		}
+		if closed < 0 {
+			b.WriteString(protect(strings.Join(lines[i:], "")))
+			break
+		}
+		b.WriteString(protect(strings.Join(lines[i:closed+1], "")))
+		i = closed + 1
+	}
+	return b.String()
+}
+
+// convertUnderscoreBold rewrites __bold__ → *bold* while honoring
+// GFM's intraword rule (codex round 2): an underscore run flanked by
+// word characters (foo__bar__baz) cannot open or close emphasis and
+// stays literal — the regex it replaces rewrote technical
+// identifiers. Hand-scanned because RE2 has no lookarounds.
+func convertUnderscoreBold(s string) string {
+	isWord := func(c byte) bool {
+		return c == '_' || c >= '0' && c <= '9' || c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z'
+	}
+	var b strings.Builder
+	i := 0
+	for i < len(s) {
+		if !strings.HasPrefix(s[i:], "__") || (i > 0 && isWord(s[i-1])) {
+			b.WriteByte(s[i])
+			i++
+			continue
+		}
+		matched := false
+		j := i + 2
+		for {
+			k := strings.Index(s[j:], "__")
+			if k < 0 {
+				break
+			}
+			k += j
+			after := k + 2
+			if k > i+2 && (after >= len(s) || !isWord(s[after])) {
+				b.WriteString("*" + s[i+2:k] + "*")
+				i = after
+				matched = true
+				break
+			}
+			j = k + 1
+		}
+		if !matched {
+			b.WriteString(s[i : i+2])
+			i += 2
+		}
+	}
+	return b.String()
+}
+
 // convertMarkdownLinks rewrites [text](http…) into Slack's <url|text>
 // and protects the result. Hand-parsed rather than regex (codex P2):
 // the destination may contain balanced parentheses
@@ -1123,22 +1239,32 @@ func convertMarkdownLinks(s string, protect func(string) string) string {
 		}
 		j := textEnd + 2
 		depth := 1
+		var destB strings.Builder
 		for j < len(s) && depth > 0 {
-			switch s[j] {
-			case '(':
+			c := s[j]
+			switch {
+			case c == '\\' && j+1 < len(s) && (s[j+1] == '(' || s[j+1] == ')'):
+				// Backslash-escaped parenthesis is URL data (codex
+				// round 2): unescape it into the destination instead
+				// of counting it toward balance.
+				destB.WriteByte(s[j+1])
+				j += 2
+				continue
+			case c == '(':
 				depth++
-			case ')':
+			case c == ')':
 				depth--
-			case ' ', '\t', '\n':
+			case c == ' ' || c == '\t' || c == '\n':
 				depth = -1
 			}
 			if depth <= 0 {
 				break
 			}
+			destB.WriteByte(c)
 			j++
 		}
 		linkText := s[i+1 : textEnd]
-		dest := s[textEnd+2 : j]
+		dest := destB.String()
 		if depth == 0 && linkText != "" &&
 			(strings.HasPrefix(dest, "http://") || strings.HasPrefix(dest, "https://")) {
 			b.WriteString(protect("<" + dest + "|" + linkText + ">"))

--- a/slack-mini/adapter/main.go
+++ b/slack-mini/adapter/main.go
@@ -5,7 +5,12 @@
 //   - Inbound: a public HTTPS receiver for the Slack Events API. Only
 //     `app_mention` is handled. Each verified mention is bridged to gc by
 //     POSTing /v0/city/{city}/extmsg/inbound, addressed to the mayor
-//     session (override with SLACK_MINI_INBOUND_TARGET).
+//     session (override with SLACK_MINI_INBOUND_TARGET). The mention is
+//     spooled to disk before the first forward attempt and the POST is
+//     retried with backoff, because Slack has already been 200-acked and
+//     will never redeliver: a dropped forward is a lost message. Exhausted
+//     retries dead-letter the spool entry for manual replay; entries left
+//     mid-retry by a crash are re-delivered at startup.
 //
 //   - Outbound: a UDS endpoint (/post-message) that posts plain text to a
 //     Slack channel via chat.postMessage using the workspace bot token.
@@ -46,6 +51,10 @@
 //	ADAPTER_PROVIDER           extmsg provider name (default "slack").
 //	SLACK_MINI_INBOUND_TARGET  Session handle inbound mentions address (default "mayor").
 //	SLACK_API_BASE             Slack web API base (default https://slack.com/api).
+//	SLACK_MINI_SPOOL_DIR       Directory for the inbound persist-and-retry spool
+//	                           (default $GC_SERVICE_STATE_ROOT/data/inbound-spool
+//	                           in proxy_process mode; unset otherwise, which
+//	                           disables spooling but keeps in-memory retries).
 package main
 
 import (
@@ -64,6 +73,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -98,6 +108,16 @@ const defaultSlackAPIBase = "https://slack.com/api"
 // pin an inbound-bridge goroutine (or block startup registration) forever.
 const gcCallTimeout = 15 * time.Second
 
+// inboundRetryDelays spaces the forward retries after a failed inbound POST
+// to gc: 5 attempts total over ~2 minutes, then dead-letter (bug hq-1q1).
+// Package-level var so tests can compress the schedule.
+var inboundRetryDelays = []time.Duration{
+	5 * time.Second,
+	15 * time.Second,
+	30 * time.Second,
+	60 * time.Second,
+}
+
 type config struct {
 	publicListen        string
 	internalListen      string
@@ -111,6 +131,7 @@ type config struct {
 	signingSecret       string
 	inboundTarget       string
 	slackAPIBase        string
+	spoolDir            string
 	registerOnStart     bool
 }
 
@@ -155,6 +176,10 @@ func main() {
 		log.Printf("registered with gc as provider=%s account=%s callback=%s/post-message",
 			cfg.provider, cfg.workspaceID, cfg.internalCallbackURL)
 	}
+
+	// Re-deliver any inbound events a previous run spooled but never
+	// confirmed forwarded (bug hq-1q1: Slack was already 200-acked).
+	replaySpool(cfg)
 
 	errCh := make(chan error, 2)
 	go func() {
@@ -222,7 +247,17 @@ func loadConfigFromEnv(getenv func(string) string) (config, error) {
 		signingSecret:   getenv("SLACK_SIGNING_SECRET"),
 		inboundTarget:   envOr("SLACK_MINI_INBOUND_TARGET", defaultInboundTarget),
 		slackAPIBase:    strings.TrimRight(envOr("SLACK_API_BASE", defaultSlackAPIBase), "/"),
+		spoolDir:        getenv("SLACK_MINI_SPOOL_DIR"),
 		registerOnStart: envOr("REGISTER_ON_START", "true") == "true",
+	}
+
+	// Default the persist-and-retry spool into the controller-provided state
+	// root (proxy_process mode). Standalone runs without an explicit
+	// SLACK_MINI_SPOOL_DIR get in-memory retries only.
+	if cfg.spoolDir == "" {
+		if stateRoot := getenv("GC_SERVICE_STATE_ROOT"); stateRoot != "" {
+			cfg.spoolDir = filepath.Join(stateRoot, "data", "inbound-spool")
+		}
 	}
 
 	// proxy_process mode: gc reaches the adapter via GC_API_BASE_URL +
@@ -343,11 +378,11 @@ func handleSlackEvents(cfg config) http.HandlerFunc {
 	}
 }
 
-// bridgeEvent decodes an app_mention and POSTs it to gc's extmsg inbound.
+// bridgeEvent decodes an app_mention and hands it to deliverInbound.
 // Non-app_mention events, bot/system messages, and empty bodies are
 // dropped — Tier 1 handles only direct human mentions. It runs in its own
-// goroutine; the gc call is bounded by gcCallTimeout so a stalled gc
-// cannot leak goroutines under sustained traffic.
+// goroutine; each gc call is bounded by gcCallTimeout and the retry
+// schedule bounds the goroutine's total lifetime to ~2 minutes.
 func bridgeEvent(cfg config, env slackEventEnvelope) {
 	if env.Type != "event_callback" || len(env.Event) == 0 {
 		return
@@ -368,6 +403,11 @@ func bridgeEvent(cfg config, env slackEventEnvelope) {
 		return
 	}
 
+	// Log receipt before the first forward attempt so a message that later
+	// fails every retry is still identifiable (and replayable from Slack).
+	log.Printf("inbound received: chan=%s user=%s ts=%s thread=%s target=%s text=%dch",
+		msg.Channel, msg.User, msg.TS, msg.ThreadTS, cfg.inboundTarget, len(text))
+
 	inbound := externalInboundMessage{
 		ProviderMessageID: msg.TS,
 		Conversation: conversationRef{
@@ -387,14 +427,134 @@ func bridgeEvent(cfg config, env slackEventEnvelope) {
 		DedupKey:         "slack-" + msg.TS,
 		ReceivedAt:       time.Now().UTC(),
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), gcCallTimeout)
-	defer cancel()
-	if err := postInbound(ctx, cfg, inbound); err != nil {
-		log.Printf("inbound POST failed: %v", err)
+	deliverInbound(cfg, inbound, spoolInbound(cfg.spoolDir, inbound))
+}
+
+// spoolInbound persists a decoded inbound event before the first forward
+// attempt, so a crash mid-retry cannot silently lose a Slack-acked message.
+// Returns the spool file path, or "" when spooling is disabled (no spool
+// dir) or the write fails — persistence is best-effort and never blocks
+// the bridge.
+func spoolInbound(spoolDir string, msg externalInboundMessage) string {
+	if spoolDir == "" {
+		return ""
+	}
+	if err := os.MkdirAll(spoolDir, 0o700); err != nil {
+		log.Printf("spool: mkdir %s: %v", spoolDir, err)
+		return ""
+	}
+	data, err := json.Marshal(msg)
+	if err != nil {
+		log.Printf("spool: marshal: %v", err)
+		return ""
+	}
+	name := fmt.Sprintf("%d-%s.json", time.Now().UnixNano(), sanitizeSpoolName(msg.DedupKey))
+	path := filepath.Join(spoolDir, name)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		log.Printf("spool: write %s: %v", path, err)
+		return ""
+	}
+	return path
+}
+
+// spoolNameRE matches characters unsafe in a spool filename.
+var spoolNameRE = regexp.MustCompile(`[^a-zA-Z0-9._-]+`)
+
+func sanitizeSpoolName(s string) string {
+	return spoolNameRE.ReplaceAllString(s, "_")
+}
+
+// deliverInbound forwards one inbound message to gc, retrying failures per
+// inboundRetryDelays. On success the spool entry is removed; when every
+// attempt fails the entry moves to the dead-letter directory. The final
+// failure line deliberately contains "inbound POST failed" — external
+// log-watchers (slack-nudge-bridge) key on that exact substring.
+func deliverInbound(cfg config, msg externalInboundMessage, spoolPath string) {
+	attempts := len(inboundRetryDelays) + 1
+	var lastErr error
+	for i := range attempts {
+		if i > 0 {
+			time.Sleep(inboundRetryDelays[i-1])
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), gcCallTimeout)
+		err := postInbound(ctx, cfg, msg)
+		cancel()
+		if err == nil {
+			if spoolPath != "" {
+				_ = os.Remove(spoolPath)
+			}
+			log.Printf("inbound: chan=%s user=%s ts=%s thread=%s target=%s text=%dch",
+				msg.Conversation.ConversationID, msg.Actor.ID, msg.ProviderMessageID,
+				msg.ReplyToMessageID, msg.ExplicitTarget, len(msg.Text))
+			return
+		}
+		lastErr = err
+		if i < attempts-1 {
+			log.Printf("inbound forward attempt %d/%d failed (retry in %s): %v",
+				i+1, attempts, inboundRetryDelays[i], err)
+		}
+	}
+	log.Printf("inbound POST failed after %d attempts (dead-letter=%s) chan=%s ts=%s: %v",
+		attempts, moveToDeadLetter(spoolPath), msg.Conversation.ConversationID,
+		msg.ProviderMessageID, lastErr)
+}
+
+// moveToDeadLetter quarantines an exhausted spool entry in the sibling
+// "dead" directory so it can be replayed by hand; returns the new path, or
+// "none" when spooling was disabled for this message. If the move fails the
+// entry stays in the spool, where startup replay will retry it.
+func moveToDeadLetter(spoolPath string) string {
+	if spoolPath == "" {
+		return "none"
+	}
+	deadDir := filepath.Join(filepath.Dir(spoolPath), "dead")
+	if err := os.MkdirAll(deadDir, 0o700); err != nil {
+		log.Printf("dead-letter: mkdir: %v", err)
+		return spoolPath
+	}
+	dest := filepath.Join(deadDir, filepath.Base(spoolPath))
+	if err := os.Rename(spoolPath, dest); err != nil {
+		log.Printf("dead-letter: rename: %v", err)
+		return spoolPath
+	}
+	return dest
+}
+
+// replaySpool re-delivers inbound events a previous run persisted but never
+// confirmed forwarded (crash mid-retry). Redelivery may duplicate an event
+// gc already accepted — the message DedupKey makes that safe. Dead-lettered
+// entries are NOT replayed automatically; they stay under spool/dead for
+// manual replay.
+func replaySpool(cfg config) {
+	if cfg.spoolDir == "" {
 		return
 	}
-	log.Printf("inbound: chan=%s user=%s ts=%s thread=%s target=%s text=%dch",
-		msg.Channel, msg.User, msg.TS, msg.ThreadTS, cfg.inboundTarget, len(text))
+	entries, err := os.ReadDir(cfg.spoolDir)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			log.Printf("spool replay: %v", err)
+		}
+		return
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		path := filepath.Join(cfg.spoolDir, e.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			log.Printf("spool replay: read %s: %v", path, err)
+			continue
+		}
+		var msg externalInboundMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			log.Printf("spool replay: decode %s: %v (dead-letter=%s)", path, err, moveToDeadLetter(path))
+			continue
+		}
+		log.Printf("spool replay: re-delivering %s (chan=%s ts=%s)",
+			e.Name(), msg.Conversation.ConversationID, msg.ProviderMessageID)
+		go deliverInbound(cfg, msg, path)
+	}
 }
 
 // leadingMentionRE matches one or more leading Slack user-mention tokens

--- a/slack-mini/adapter/main.go
+++ b/slack-mini/adapter/main.go
@@ -77,6 +77,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 )
@@ -419,7 +420,7 @@ func bridgeEvent(cfg config, env slackEventEnvelope) {
 		},
 		Actor: externalActor{
 			ID:          msg.User,
-			DisplayName: msg.User, // resolving a display name needs users.info — defer to Tier 2
+			DisplayName: resolveUserDisplayName(context.Background(), userNames, cfg, msg.User),
 		},
 		Text:             text,
 		ExplicitTarget:   cfg.inboundTarget,
@@ -557,6 +558,134 @@ func replaySpool(cfg config) {
 	}
 }
 
+// --- inbound: Slack user display-name resolution ---------------------------
+
+// userNameCacheTTL bounds how long a resolved display name is reused before
+// users.info is consulted again. Names change rarely; an hour keeps the
+// per-mention lookup cost near zero without pinning stale names forever.
+const userNameCacheTTL = time.Hour
+
+// userNameFailureTTL negative-caches a failed lookup (missing_scope on a
+// bot token without users:read, transient Slack errors) so a burst of
+// mentions does not hammer users.info, while healing quickly once the
+// scope is granted or the outage passes.
+const userNameFailureTTL = 5 * time.Minute
+
+// userInfoTimeout bounds the users.info call on the inbound bridge path.
+const userInfoTimeout = 5 * time.Second
+
+type cachedUserName struct {
+	name      string
+	expiresAt time.Time
+}
+
+// userNameCache is an in-memory users.info result cache. Tier 1 keeps no
+// on-disk registries by design, so entries live for the process lifetime.
+type userNameCache struct {
+	mu      sync.Mutex
+	entries map[string]cachedUserName
+}
+
+func newUserNameCache() *userNameCache {
+	return &userNameCache{entries: make(map[string]cachedUserName)}
+}
+
+func (c *userNameCache) get(userID string, now time.Time) (string, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry, ok := c.entries[userID]
+	if !ok || now.After(entry.expiresAt) {
+		return "", false
+	}
+	return entry.name, true
+}
+
+func (c *userNameCache) put(userID, name string, now time.Time, ttl time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries[userID] = cachedUserName{name: name, expiresAt: now.Add(ttl)}
+}
+
+// userNames caches users.info lookups across inbound mentions.
+var userNames = newUserNameCache()
+
+// slackUserInfoResp is the subset of a users.info response Tier 1 reads.
+type slackUserInfoResp struct {
+	OK    bool   `json:"ok"`
+	Error string `json:"error,omitempty"`
+	User  struct {
+		Name     string `json:"name"`
+		RealName string `json:"real_name"`
+		Profile  struct {
+			DisplayName string `json:"display_name"`
+			RealName    string `json:"real_name"`
+		} `json:"profile"`
+	} `json:"user"`
+}
+
+// resolveUserDisplayName resolves a Slack user id to a human-readable name
+// via users.info so the injected gc reminder shows "Afik Cohen (human)"
+// instead of a raw "U0AN32RPBFT" (hq-fh9). Successes are cached for
+// userNameCacheTTL; failures fall back to the raw id and are
+// negative-cached for userNameFailureTTL (a bot token without users:read
+// fails on every mention — see manifest/app.json, which grants the scope
+// for fresh installs; existing installs must re-approve it).
+func resolveUserDisplayName(ctx context.Context, cache *userNameCache, cfg config, userID string) string {
+	if userID == "" {
+		return userID
+	}
+	now := time.Now()
+	if name, ok := cache.get(userID, now); ok {
+		return name
+	}
+	name := fetchUserDisplayName(ctx, cfg, userID)
+	if name == "" {
+		cache.put(userID, userID, now, userNameFailureTTL)
+		return userID
+	}
+	cache.put(userID, name, now, userNameCacheTTL)
+	return name
+}
+
+// fetchUserDisplayName performs the users.info call, returning "" on any
+// failure (logged with the reason).
+func fetchUserDisplayName(ctx context.Context, cfg config, userID string) string {
+	ctx, cancel := context.WithTimeout(ctx, userInfoTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		cfg.slackAPIBase+"/users.info?user="+url.QueryEscape(userID), nil)
+	if err != nil {
+		return ""
+	}
+	req.Header.Set("Authorization", "Bearer "+cfg.botToken)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		log.Printf("users.info %s failed (using raw id): %v", userID, err)
+		return ""
+	}
+	defer func() { _ = resp.Body.Close() }()
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil || resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		log.Printf("users.info %s: http %d (using raw id)", userID, resp.StatusCode)
+		return ""
+	}
+	var info slackUserInfoResp
+	if err := json.Unmarshal(respBody, &info); err != nil || !info.OK {
+		log.Printf("users.info %s: ok=false error=%q (using raw id)", userID, info.Error)
+		return ""
+	}
+	return firstNonEmpty(info.User.Profile.DisplayName, info.User.Profile.RealName, info.User.RealName, info.User.Name)
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}
+
 // leadingMentionRE matches one or more leading Slack user-mention tokens
 // (`<@U…>`) and surrounding whitespace. Slack delivers app_mention text
 // with the bot mention inline (e.g. "<@U0BOT> status?"); stripping it
@@ -651,12 +780,27 @@ type adapterCapabilities struct {
 }
 
 type adapterRegisterRequest struct {
-	Provider     string              `json:"provider"`
-	AccountID    string              `json:"account_id"`
-	Name         string              `json:"name,omitempty"`
-	CallbackURL  string              `json:"callback_url,omitempty"`
-	Capabilities adapterCapabilities `json:"capabilities,omitempty"`
+	Provider          string              `json:"provider"`
+	AccountID         string              `json:"account_id"`
+	Name              string              `json:"name,omitempty"`
+	CallbackURL       string              `json:"callback_url,omitempty"`
+	Capabilities      adapterCapabilities `json:"capabilities,omitempty"`
+	ReplyInstructions string              `json:"reply_instructions,omitempty"`
 }
+
+// replyInstructionsTemplate is the Tier-1 reply instruction block gc renders
+// into the inbound-message <system-reminder> nudge in place of its generic
+// "gc slack reply-current ..." fallback, which does not exist at Tier 1
+// (hq-fh9). gc substitutes {conversation_id}, {message_ts}, {thread_ts}
+// (the inbound message's thread, falling back to the message itself), and
+// {handle}; the [bracketed segment] is dropped when no thread id is
+// available. Agents write standard Markdown — handlePostMessage converts it
+// to Slack mrkdwn on the way out.
+const replyInstructionsTemplate = "To reply in Slack, run:\n" +
+	"  gc slack-mini post-message --channel {conversation_id}[ --thread-ts {thread_ts}] --text '<your reply>'\n" +
+	"Keep --thread-ts so the reply lands in the thread. Write the reply in standard Markdown " +
+	"(it is converted to Slack formatting on post) and prefix it with your agent handle in bold " +
+	"(e.g., **{handle}:** your message)."
 
 // postInbound bridges a verified Slack mention into gc.
 func postInbound(ctx context.Context, cfg config, msg externalInboundMessage) error {
@@ -684,6 +828,7 @@ func registerAdapter(ctx context.Context, cfg config) error {
 			SupportsAttachments:        false,
 			MaxMessageLength:           40000, // Slack's chat.postMessage limit
 		},
+		ReplyInstructions: replyInstructionsTemplate,
 	})
 	if err != nil {
 		return err
@@ -747,6 +892,7 @@ func handlePostMessage(cfg config) http.HandlerFunc {
 			writeJSONError(w, http.StatusBadRequest, "text is required")
 			return
 		}
+		req.Text = slackifyMarkdown(req.Text)
 		resp, err := postToSlack(r.Context(), cfg.slackAPIBase, cfg.botToken, req)
 		if err != nil {
 			writeJSONError(w, http.StatusBadGateway, err.Error())
@@ -769,6 +915,52 @@ func writeJSONError(w http.ResponseWriter, status int, msg string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	_ = json.NewEncoder(w).Encode(map[string]any{"ok": false, "error": msg})
+}
+
+// --- outbound: GitHub Markdown → Slack mrkdwn -------------------------------
+
+var (
+	fencedCodeRE = regexp.MustCompile("(?s)```.*?```")
+	inlineCodeRE = regexp.MustCompile("`[^`\n]+`")
+	boldStarsRE  = regexp.MustCompile(`\*\*(.+?)\*\*`)
+	boldUnderRE  = regexp.MustCompile(`__(.+?)__`)
+	strikeRE     = regexp.MustCompile(`~~(.+?)~~`)
+	mdLinkRE     = regexp.MustCompile(`\[([^\]\n]+)\]\((https?://[^)\s]+)\)`)
+	headingRE    = regexp.MustCompile(`(?m)^#{1,6}[ \t]+(.+?)[ \t]*#*[ \t]*$`)
+)
+
+// slackifyMarkdown converts the GitHub-flavored Markdown constructs agents
+// habitually write into Slack mrkdwn, which renders **bold** as literal
+// asterisks (hq-fh9). Conservative by design: fenced code blocks and inline
+// code spans pass through verbatim; only **bold**/__bold__ → *bold*,
+// ~~strike~~ → ~strike~, [text](url) → <url|text>, and #-headings →
+// *bold lines* are rewritten. Single-asterisk/underscore emphasis is left
+// untouched so text already written as mrkdwn survives unchanged.
+func slackifyMarkdown(text string) string {
+	if text == "" {
+		return text
+	}
+	var protected []string
+	protect := func(s string) string {
+		protected = append(protected, s)
+		return fmt.Sprintf("\x00%d\x00", len(protected)-1)
+	}
+	out := fencedCodeRE.ReplaceAllStringFunc(text, protect)
+	// An unterminated fence swallows the rest of the message: protect it
+	// whole rather than reformatting half a code block.
+	if idx := strings.Index(out, "```"); idx >= 0 {
+		out = out[:idx] + protect(out[idx:])
+	}
+	out = inlineCodeRE.ReplaceAllStringFunc(out, protect)
+	out = headingRE.ReplaceAllString(out, "*$1*")
+	out = boldStarsRE.ReplaceAllString(out, "*$1*")
+	out = boldUnderRE.ReplaceAllString(out, "*$1*")
+	out = strikeRE.ReplaceAllString(out, "~$1~")
+	out = mdLinkRE.ReplaceAllString(out, "<$2|$1>")
+	for i := len(protected) - 1; i >= 0; i-- {
+		out = strings.Replace(out, fmt.Sprintf("\x00%d\x00", i), protected[i], 1)
+	}
+	return out
 }
 
 // postToSlack posts a message via chat.postMessage using the bot token.

--- a/slack-mini/adapter/main.go
+++ b/slack-mini/adapter/main.go
@@ -373,35 +373,57 @@ func handleSlackEvents(cfg config) http.HandlerFunc {
 			return
 		}
 
-		// Ack immediately so Slack does not retry, then bridge.
+		// Spool the decoded inbound BEFORE the 200 ack (codex P1):
+		// Slack never redelivers after a 200, and the old order —
+		// ack, then an async users.info lookup (up to 5s), then
+		// spool — left a window where a SIGTERM or crash during an
+		// ordinary restart silently lost an acked mention. The
+		// synchronous cost is one decode + one fsync'd file write,
+		// well inside Slack's 3s ack budget. Enrichment (users.info)
+		// and delivery stay async.
+		if inbound, spoolPath, ok := prepareInbound(cfg, env); ok {
+			w.WriteHeader(http.StatusOK)
+			go finishInbound(cfg, inbound, spoolPath)
+			return
+		}
 		w.WriteHeader(http.StatusOK)
-		go bridgeEvent(cfg, env)
 	}
 }
 
-// bridgeEvent decodes an app_mention and hands it to deliverInbound.
-// Non-app_mention events, bot/system messages, and empty bodies are
-// dropped — Tier 1 handles only direct human mentions. It runs in its own
-// goroutine; each gc call is bounded by gcCallTimeout and the retry
-// schedule bounds the goroutine's total lifetime to ~2 minutes.
+// bridgeEvent runs the full bridge synchronously: prepare (decode,
+// filter, spool) then finish (enrich, deliver). Test seam — the HTTP
+// handler calls the two halves itself so the spool write lands before
+// the Slack ack.
 func bridgeEvent(cfg config, env slackEventEnvelope) {
+	if inbound, spoolPath, ok := prepareInbound(cfg, env); ok {
+		finishInbound(cfg, inbound, spoolPath)
+	}
+}
+
+// prepareInbound decodes and filters an event and, for a deliverable
+// app_mention, builds the inbound message and durably spools it.
+// ok=false means "nothing to bridge" (non-mention, bot/system message,
+// empty body). The Actor's DisplayName is left as the raw user id here
+// — the users.info lookup can take seconds and must not delay the
+// Slack ack; finishInbound resolves it before the forward.
+func prepareInbound(cfg config, env slackEventEnvelope) (externalInboundMessage, string, bool) {
 	if env.Type != "event_callback" || len(env.Event) == 0 {
-		return
+		return externalInboundMessage{}, "", false
 	}
 	var msg slackMessageEvent
 	if err := json.Unmarshal(env.Event, &msg); err != nil {
 		log.Printf("decode slack event: %v", err)
-		return
+		return externalInboundMessage{}, "", false
 	}
 	if msg.Type != "app_mention" {
-		return
+		return externalInboundMessage{}, "", false
 	}
 	if msg.BotID != "" || msg.Subtype != "" || msg.User == "" {
-		return
+		return externalInboundMessage{}, "", false
 	}
 	text := stripLeadingMention(msg.Text)
 	if text == "" {
-		return
+		return externalInboundMessage{}, "", false
 	}
 
 	// Log receipt before the first forward attempt so a message that later
@@ -420,7 +442,7 @@ func bridgeEvent(cfg config, env slackEventEnvelope) {
 		},
 		Actor: externalActor{
 			ID:          msg.User,
-			DisplayName: resolveUserDisplayName(context.Background(), userNames, cfg, msg.User),
+			DisplayName: msg.User,
 		},
 		Text:             text,
 		ExplicitTarget:   cfg.inboundTarget,
@@ -428,7 +450,16 @@ func bridgeEvent(cfg config, env slackEventEnvelope) {
 		DedupKey:         "slack-" + msg.TS,
 		ReceivedAt:       time.Now().UTC(),
 	}
-	deliverInbound(cfg, inbound, spoolInbound(cfg.spoolDir, inbound))
+	return inbound, spoolInbound(cfg.spoolDir, inbound), true
+}
+
+// finishInbound runs the async half of the bridge: display-name
+// enrichment (bounded by userInfoTimeout) and the retried forward.
+// Each gc call is bounded by gcCallTimeout and the retry schedule
+// bounds the goroutine's total lifetime to ~2 minutes.
+func finishInbound(cfg config, inbound externalInboundMessage, spoolPath string) {
+	inbound.Actor.DisplayName = resolveUserDisplayName(context.Background(), userNames, cfg, inbound.Actor.ID)
+	deliverInbound(cfg, inbound, spoolPath)
 }
 
 // spoolInbound persists a decoded inbound event before the first forward
@@ -451,11 +482,51 @@ func spoolInbound(spoolDir string, msg externalInboundMessage) string {
 	}
 	name := fmt.Sprintf("%d-%s.json", time.Now().UnixNano(), sanitizeSpoolName(msg.DedupKey))
 	path := filepath.Join(spoolDir, name)
-	if err := os.WriteFile(path, data, 0o600); err != nil {
+	if err := writeSpoolFileAtomic(path, data); err != nil {
 		log.Printf("spool: write %s: %v", path, err)
 		return ""
 	}
 	return path
+}
+
+// writeSpoolFileAtomic writes data to path via a same-dir temp file +
+// fsync + rename (codex P2): a direct write to the replay-visible
+// .json path could be torn by a crash or short write AFTER Slack was
+// acked, and startup replay would then dead-letter the truncated
+// entry with no valid payload left to retry. The temp file is removed
+// on every error path.
+func writeSpoolFileAtomic(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	f, err := os.CreateTemp(dir, filepath.Base(path)+"-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp in %q: %w", dir, err)
+	}
+	tmpName := f.Name()
+	cleanup := func() { _ = os.Remove(tmpName) }
+	if err := f.Chmod(0o600); err != nil {
+		_ = f.Close()
+		cleanup()
+		return fmt.Errorf("chmod %q: %w", tmpName, err)
+	}
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		cleanup()
+		return fmt.Errorf("write %q: %w", tmpName, err)
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		cleanup()
+		return fmt.Errorf("sync %q: %w", tmpName, err)
+	}
+	if err := f.Close(); err != nil {
+		cleanup()
+		return fmt.Errorf("close %q: %w", tmpName, err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		cleanup()
+		return fmt.Errorf("rename %q -> %q: %w", tmpName, path, err)
+	}
+	return nil
 }
 
 // spoolNameRE matches characters unsafe in a spool filename.
@@ -554,7 +625,10 @@ func replaySpool(cfg config) {
 		}
 		log.Printf("spool replay: re-delivering %s (chan=%s ts=%s)",
 			e.Name(), msg.Conversation.ConversationID, msg.ProviderMessageID)
-		go deliverInbound(cfg, msg, path)
+		// Entries are spooled before display-name enrichment; finish
+		// it here so a replayed mention carries the same name a live
+		// delivery would.
+		go finishInbound(cfg, msg, path)
 	}
 }
 
@@ -921,12 +995,11 @@ func writeJSONError(w http.ResponseWriter, status int, msg string) {
 
 var (
 	fencedCodeRE = regexp.MustCompile("(?s)```.*?```")
-	inlineCodeRE = regexp.MustCompile("`[^`\n]+`")
 	boldStarsRE  = regexp.MustCompile(`\*\*(.+?)\*\*`)
 	boldUnderRE  = regexp.MustCompile(`__(.+?)__`)
 	strikeRE     = regexp.MustCompile(`~~(.+?)~~`)
-	mdLinkRE     = regexp.MustCompile(`\[([^\]\n]+)\]\((https?://[^)\s]+)\)`)
 	headingRE    = regexp.MustCompile(`(?m)^#{1,6}[ \t]+(.+?)[ \t]*#*[ \t]*$`)
+	bareURLRE    = regexp.MustCompile(`https?://[^\s<>|]+`)
 )
 
 // slackifyMarkdown converts the GitHub-flavored Markdown constructs agents
@@ -936,6 +1009,11 @@ var (
 // ~~strike~~ → ~strike~, [text](url) → <url|text>, and #-headings →
 // *bold lines* are rewritten. Single-asterisk/underscore emphasis is left
 // untouched so text already written as mrkdwn survives unchanged.
+//
+// Ordering matters (codex P2): links and bare URLs are converted and
+// protected BEFORE the emphasis passes, so a destination like
+// .../pkg/__init__.py or a URL with ** or ~~ in it can never be
+// rewritten into a broken href.
 func slackifyMarkdown(text string) string {
 	if text == "" {
 		return text
@@ -951,16 +1029,126 @@ func slackifyMarkdown(text string) string {
 	if idx := strings.Index(out, "```"); idx >= 0 {
 		out = out[:idx] + protect(out[idx:])
 	}
-	out = inlineCodeRE.ReplaceAllStringFunc(out, protect)
+	out = protectCodeSpans(out, protect)
+	out = convertMarkdownLinks(out, protect)
+	out = bareURLRE.ReplaceAllStringFunc(out, protect)
 	out = headingRE.ReplaceAllString(out, "*$1*")
 	out = boldStarsRE.ReplaceAllString(out, "*$1*")
 	out = boldUnderRE.ReplaceAllString(out, "*$1*")
 	out = strikeRE.ReplaceAllString(out, "~$1~")
-	out = mdLinkRE.ReplaceAllString(out, "<$2|$1>")
 	for i := len(protected) - 1; i >= 0; i-- {
 		out = strings.Replace(out, fmt.Sprintf("\x00%d\x00", i), protected[i], 1)
 	}
 	return out
+}
+
+// protectCodeSpans protects GFM inline code spans, including the
+// multi-backtick form (“span with ` inside“) the old single-backtick
+// regex missed (codex P2) — Go's RE2 has no backreferences, so equal
+// delimiter runs are matched by hand. A span opens with a run of N
+// backticks and closes at the next run of exactly N; runs of other
+// lengths are span content. Spans stay single-line, matching the prior
+// conservatism. An unclosed run passes through unprotected.
+func protectCodeSpans(s string, protect func(string) string) string {
+	var b strings.Builder
+	i := 0
+	for i < len(s) {
+		c := s[i]
+		if c != '`' {
+			b.WriteByte(c)
+			i++
+			continue
+		}
+		j := i
+		for j < len(s) && s[j] == '`' {
+			j++
+		}
+		n := j - i
+		closed := -1
+		k := j
+		for k < len(s) && s[k] != '\n' {
+			if s[k] != '`' {
+				k++
+				continue
+			}
+			m := k
+			for m < len(s) && s[m] == '`' {
+				m++
+			}
+			if m-k == n {
+				closed = m
+				break
+			}
+			k = m
+		}
+		if closed >= 0 && closed > j {
+			b.WriteString(protect(s[i:closed]))
+			i = closed
+			continue
+		}
+		b.WriteString(s[i:j])
+		i = j
+	}
+	return b.String()
+}
+
+// convertMarkdownLinks rewrites [text](http…) into Slack's <url|text>
+// and protects the result. Hand-parsed rather than regex (codex P2):
+// the destination may contain balanced parentheses
+// ([docs](https://host/Function_(mathematics))), which a
+// stop-at-first-')' pattern truncated into a malformed link. The
+// destination ends at the ')' that balances the opener; whitespace or
+// a newline inside aborts the candidate and the text passes through
+// untouched.
+func convertMarkdownLinks(s string, protect func(string) string) string {
+	var b strings.Builder
+	i := 0
+	for i < len(s) {
+		if s[i] != '[' {
+			b.WriteByte(s[i])
+			i++
+			continue
+		}
+		rel := strings.IndexAny(s[i+1:], "[]\n")
+		if rel < 0 || s[i+1+rel] != ']' {
+			b.WriteByte(s[i])
+			i++
+			continue
+		}
+		textEnd := i + 1 + rel
+		if textEnd+1 >= len(s) || s[textEnd+1] != '(' {
+			b.WriteByte(s[i])
+			i++
+			continue
+		}
+		j := textEnd + 2
+		depth := 1
+		for j < len(s) && depth > 0 {
+			switch s[j] {
+			case '(':
+				depth++
+			case ')':
+				depth--
+			case ' ', '\t', '\n':
+				depth = -1
+			}
+			if depth <= 0 {
+				break
+			}
+			j++
+		}
+		linkText := s[i+1 : textEnd]
+		dest := s[textEnd+2 : j]
+		if depth == 0 && linkText != "" &&
+			(strings.HasPrefix(dest, "http://") || strings.HasPrefix(dest, "https://")) {
+			b.WriteString(protect("<" + dest + "|" + linkText + ">"))
+			i = j + 1
+			continue
+		}
+		b.WriteByte(s[i])
+		i++
+	}
+	return b.String()
 }
 
 // postToSlack posts a message via chat.postMessage using the bot token.

--- a/slack-mini/adapter/main.go
+++ b/slack-mini/adapter/main.go
@@ -791,16 +791,16 @@ type adapterRegisterRequest struct {
 // replyInstructionsTemplate is the Tier-1 reply instruction block gc renders
 // into the inbound-message <system-reminder> nudge in place of its generic
 // "gc slack reply-current ..." fallback, which does not exist at Tier 1
-// (hq-fh9). gc substitutes {conversation_id}, {message_ts}, {thread_ts}
-// (the inbound message's thread, falling back to the message itself), and
-// {handle}; the [bracketed segment] is dropped when no thread id is
-// available. Agents write standard Markdown — handlePostMessage converts it
-// to Slack mrkdwn on the way out.
+// (hq-fh9). gc substitutes {conversation_id}, {message_ts}, and {thread_ts}
+// (the inbound message's thread, falling back to the message itself); the
+// [bracketed segment] is dropped when no thread id is available. Agents
+// write standard Markdown — handlePostMessage converts it to Slack mrkdwn
+// on the way out. No handle prefix: the bot posts under its own Slack
+// identity, so a "**{handle}:**" prefix would be redundant (hq-dy6).
 const replyInstructionsTemplate = "To reply in Slack, run:\n" +
 	"  gc slack-mini post-message --channel {conversation_id}[ --thread-ts {thread_ts}] --text '<your reply>'\n" +
 	"Keep --thread-ts so the reply lands in the thread. Write the reply in standard Markdown " +
-	"(it is converted to Slack formatting on post) and prefix it with your agent handle in bold " +
-	"(e.g., **{handle}:** your message)."
+	"(it is converted to Slack formatting on post)."
 
 // postInbound bridges a verified Slack mention into gc.
 func postInbound(ctx context.Context, cfg config, msg externalInboundMessage) error {

--- a/slack-mini/adapter/main_test.go
+++ b/slack-mini/adapter/main_test.go
@@ -721,6 +721,17 @@ func TestSlackifyMarkdown(t *testing.T) {
 		{"handle prefix example", "**mayor:** build is green", "*mayor:* build is green"},
 		{"empty", "", ""},
 		{"plain multiplication untouched", "2 * 3 * 4 = 24", "2 * 3 * 4 = 24"},
+		// codex P2: link destinations must survive the emphasis passes.
+		{"underscores in link destination", "[init](https://host/pkg/__init__.py)", "<https://host/pkg/__init__.py|init>"},
+		{"stars in link destination", "[x](https://host/a**b**c)", "<https://host/a**b**c|x>"},
+		{"underscores in bare url", "see https://host/pkg/__init__.py now", "see https://host/pkg/__init__.py now"},
+		{"tildes in bare url", "https://host/~~archive~~/x", "https://host/~~archive~~/x"},
+		// codex P2: balanced parentheses in link destinations.
+		{"parens in link destination", "[docs](https://host/Function_(mathematics))", "<https://host/Function_(mathematics)|docs>"},
+		{"nested parens with trailing text", "[d](https://h/a_(b_(c))) end", "<https://h/a_(b_(c))|d> end"},
+		// codex P2: multi-backtick code spans protect their contents.
+		{"double backtick span protected", "x ``has `tick` and **raw**`` y", "x ``has `tick` and **raw**`` y"},
+		{"unbalanced backtick run passes through", "a `` b **bold**", "a `` b *bold*"},
 	}
 	for _, tc := range cases {
 		if got := slackifyMarkdown(tc.in); got != tc.want {
@@ -879,5 +890,57 @@ func TestRegisterAdapterSendsReplyInstructions(t *testing.T) {
 	}
 	if strings.Contains(strings.ToLower(got.ReplyInstructions), "prefix") {
 		t.Errorf("reply_instructions must not mandate a handle prefix (hq-dy6): %q", got.ReplyInstructions)
+	}
+}
+
+// codex P1: the decoded mention must be durably spooled BEFORE the
+// handler writes the 200 ack — Slack never redelivers after a 200, so
+// an ack-then-async-spool order loses the message to a crash in the
+// enrichment window. The gc stub never answers successfully, so the
+// entry present right after the handler returns proves the write was
+// synchronous with the request, not the delivery goroutine.
+func TestHandleSlackEventsSpoolsBeforeAck(t *testing.T) {
+	spool := t.TempDir()
+	cfg := config{
+		signingSecret: "s3cr3t",
+		gcAPIBase:     "http://127.0.0.1:1", // refused: delivery cannot win the race
+		cityName:      "test-city",
+		provider:      "slack",
+		workspaceID:   "T1",
+		inboundTarget: "mayor",
+		spoolDir:      spool,
+	}
+	raw, _ := json.Marshal(slackMessageEvent{
+		Type: "app_mention", Channel: "C1", User: "U1", TS: "1.0",
+		Text: "<@BOT> hello",
+	})
+	env, _ := json.Marshal(slackEventEnvelope{Type: "event_callback", Event: raw})
+	ts := strconv.FormatInt(time.Now().Unix(), 10)
+	req := httptest.NewRequest(http.MethodPost, "/slack/events", strings.NewReader(string(env)))
+	req.Header.Set("X-Slack-Request-Timestamp", ts)
+	req.Header.Set("X-Slack-Signature", signSlack(cfg.signingSecret, ts, env))
+	rec := httptest.NewRecorder()
+	handleSlackEvents(cfg)(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	entries, err := os.ReadDir(spool)
+	if err != nil {
+		t.Fatalf("read spool: %v", err)
+	}
+	var jsons, tmps int
+	for _, e := range entries {
+		switch {
+		case strings.HasSuffix(e.Name(), ".json"):
+			jsons++
+		case strings.Contains(e.Name(), ".tmp"):
+			tmps++
+		}
+	}
+	if jsons != 1 {
+		t.Errorf("spool entries at ack time = %d, want 1 (spool must precede the 200)", jsons)
+	}
+	if tmps != 0 {
+		t.Errorf("atomic spool write left %d tmp files behind", tmps)
 	}
 }

--- a/slack-mini/adapter/main_test.go
+++ b/slack-mini/adapter/main_test.go
@@ -877,7 +877,7 @@ func TestRegisterAdapterSendsReplyInstructions(t *testing.T) {
 	if !strings.Contains(got.ReplyInstructions, "gc slack-mini post-message --channel {conversation_id}[ --thread-ts {thread_ts}]") {
 		t.Errorf("reply_instructions missing Tier-1 reply command: %q", got.ReplyInstructions)
 	}
-	if !strings.Contains(got.ReplyInstructions, "{handle}") {
-		t.Errorf("reply_instructions missing handle placeholder: %q", got.ReplyInstructions)
+	if strings.Contains(strings.ToLower(got.ReplyInstructions), "prefix") {
+		t.Errorf("reply_instructions must not mandate a handle prefix (hq-dy6): %q", got.ReplyInstructions)
 	}
 }

--- a/slack-mini/adapter/main_test.go
+++ b/slack-mini/adapter/main_test.go
@@ -700,3 +700,184 @@ func TestPostJSONSurfacesErrorStatus(t *testing.T) {
 		t.Fatalf("expected error surfacing body, got %v", err)
 	}
 }
+
+func TestSlackifyMarkdown(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"bold stars", "deploy **now** please", "deploy *now* please"},
+		{"bold underscores", "deploy __now__ please", "deploy *now* please"},
+		{"multiple bolds", "**a** and **b**", "*a* and *b*"},
+		{"strike", "~~gone~~", "~gone~"},
+		{"link", "see [the PR](https://example.com/pr/42) here", "see <https://example.com/pr/42|the PR> here"},
+		{"heading", "# Status\nall green", "*Status*\nall green"},
+		{"mrkdwn bold untouched", "*mayor:* on it", "*mayor:* on it"},
+		{"italic untouched", "_soon_", "_soon_"},
+		{"inline code protected", "run `gc status --json **not bold**`", "run `gc status --json **not bold**`"},
+		{"fenced code protected", "```\n**not bold**\n# not a heading\n```", "```\n**not bold**\n# not a heading\n```"},
+		{"unterminated fence protected", "before **bold**\n```\n**raw**", "before *bold*\n```\n**raw**"},
+		{"handle prefix example", "**mayor:** build is green", "*mayor:* build is green"},
+		{"empty", "", ""},
+		{"plain multiplication untouched", "2 * 3 * 4 = 24", "2 * 3 * 4 = 24"},
+	}
+	for _, tc := range cases {
+		if got := slackifyMarkdown(tc.in); got != tc.want {
+			t.Errorf("%s: slackifyMarkdown(%q) = %q, want %q", tc.name, tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestHandlePostMessageConvertsMarkdown(t *testing.T) {
+	var gotBody slackPostMessageReq
+	slack := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true,"ts":"1","channel":"C1"}`))
+	}))
+	defer slack.Close()
+
+	cfg := config{slackAPIBase: slack.URL, botToken: "xoxb-test"}
+	reqBody := `{"channel":"C1","text":"**mayor:** deploy [PR](https://example.com/42) done"}`
+	req := httptest.NewRequest(http.MethodPost, "/post-message", strings.NewReader(reqBody))
+	rec := httptest.NewRecorder()
+	handlePostMessage(cfg)(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body %s", rec.Code, rec.Body.String())
+	}
+	want := "*mayor:* deploy <https://example.com/42|PR> done"
+	if gotBody.Text != want {
+		t.Errorf("posted text = %q, want %q", gotBody.Text, want)
+	}
+}
+
+func TestResolveUserDisplayNameCachesSuccesses(t *testing.T) {
+	calls := 0
+	slack := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if r.URL.Path != "/users.info" {
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("user"); got != "U123" {
+			t.Errorf("user param = %q", got)
+		}
+		if auth := r.Header.Get("Authorization"); auth != "Bearer xoxb-test" {
+			t.Errorf("auth = %q", auth)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true,"user":{"name":"afik","real_name":"Afik Cohen","profile":{"display_name":"Afik","real_name":"Afik Cohen"}}}`))
+	}))
+	defer slack.Close()
+
+	cfg := config{slackAPIBase: slack.URL, botToken: "xoxb-test"}
+	cache := newUserNameCache()
+	if got := resolveUserDisplayName(context.Background(), cache, cfg, "U123"); got != "Afik" {
+		t.Fatalf("resolved = %q, want Afik (profile.display_name preferred)", got)
+	}
+	if got := resolveUserDisplayName(context.Background(), cache, cfg, "U123"); got != "Afik" {
+		t.Fatalf("second resolve = %q", got)
+	}
+	if calls != 1 {
+		t.Errorf("users.info calls = %d, want 1 (cached)", calls)
+	}
+}
+
+func TestResolveUserDisplayNameFallsBackToRawID(t *testing.T) {
+	calls := 0
+	slack := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":false,"error":"missing_scope"}`))
+	}))
+	defer slack.Close()
+
+	cfg := config{slackAPIBase: slack.URL, botToken: "xoxb-test"}
+	cache := newUserNameCache()
+	if got := resolveUserDisplayName(context.Background(), cache, cfg, "U404"); got != "U404" {
+		t.Fatalf("resolved = %q, want raw id fallback", got)
+	}
+	// Failures are negative-cached (a token without users:read fails on
+	// every mention) but expire on the shorter failure TTL, so the fix
+	// heals without a restart once the scope is granted.
+	if got := resolveUserDisplayName(context.Background(), cache, cfg, "U404"); got != "U404" {
+		t.Fatalf("second resolve = %q, want raw id fallback", got)
+	}
+	if calls != 1 {
+		t.Errorf("users.info calls = %d, want 1 (failure negative-cached)", calls)
+	}
+	if _, ok := cache.get("U404", time.Now().Add(userNameFailureTTL+time.Second)); ok {
+		t.Error("negative cache entry should expire after userNameFailureTTL")
+	}
+}
+
+func TestBridgeEventResolvesDisplayName(t *testing.T) {
+	var got externalInboundMessage
+	gc := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var wrap struct {
+			Message externalInboundMessage `json:"message"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&wrap)
+		got = wrap.Message
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer gc.Close()
+	slack := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true,"user":{"name":"afik","profile":{"display_name":"Afik"}}}`))
+	}))
+	defer slack.Close()
+
+	cfg := config{
+		gcAPIBase:     gc.URL,
+		slackAPIBase:  slack.URL,
+		botToken:      "xoxb-test",
+		cityName:      "mycity",
+		provider:      "slack",
+		workspaceID:   "T123",
+		inboundTarget: "mayor",
+	}
+	event := slackMessageEvent{
+		Type: "app_mention", User: "U777", Text: "<@U0BOT> hello",
+		Channel: "C42", TS: "1700000000.0001", ChannelType: "channel",
+	}
+	raw, _ := json.Marshal(event)
+	bridgeEvent(cfg, slackEventEnvelope{Type: "event_callback", Event: raw})
+
+	if got.Actor.DisplayName != "Afik" {
+		t.Errorf("DisplayName = %q, want resolved 'Afik'", got.Actor.DisplayName)
+	}
+	if got.Actor.ID != "U777" {
+		t.Errorf("Actor.ID = %q, want raw id preserved", got.Actor.ID)
+	}
+}
+
+func TestRegisterAdapterSendsReplyInstructions(t *testing.T) {
+	var got adapterRegisterRequest
+	gc := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/extmsg/adapters") {
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+		_ = json.NewDecoder(r.Body).Decode(&got)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer gc.Close()
+
+	cfg := config{
+		gcAPIBase:           gc.URL,
+		cityName:            "mycity",
+		provider:            "slack",
+		workspaceID:         "T123",
+		internalCallbackURL: "http://127.0.0.1:1/cb",
+	}
+	if err := registerAdapter(context.Background(), cfg); err != nil {
+		t.Fatalf("registerAdapter: %v", err)
+	}
+	if !strings.Contains(got.ReplyInstructions, "gc slack-mini post-message --channel {conversation_id}[ --thread-ts {thread_ts}]") {
+		t.Errorf("reply_instructions missing Tier-1 reply command: %q", got.ReplyInstructions)
+	}
+	if !strings.Contains(got.ReplyInstructions, "{handle}") {
+		t.Errorf("reply_instructions missing handle placeholder: %q", got.ReplyInstructions)
+	}
+}

--- a/slack-mini/adapter/main_test.go
+++ b/slack-mini/adapter/main_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -14,6 +15,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -474,6 +476,215 @@ func TestListenUDS(t *testing.T) {
 	defer func() { _ = lis2.Close() }()
 	if _, ok := lis2.(*net.UnixListener); !ok {
 		t.Errorf("listener type = %T, want *net.UnixListener", lis2)
+	}
+}
+
+// compressRetries shrinks the inbound retry schedule so retry-path tests
+// run in milliseconds instead of the production ~2 minutes.
+func compressRetries(t *testing.T) {
+	t.Helper()
+	saved := inboundRetryDelays
+	inboundRetryDelays = []time.Duration{time.Millisecond, time.Millisecond}
+	t.Cleanup(func() { inboundRetryDelays = saved })
+}
+
+func TestSpoolDirFromEnv(t *testing.T) {
+	base := map[string]string{
+		"SLACK_BOT_TOKEN":      "xoxb-1",
+		"SLACK_SIGNING_SECRET": "secret",
+		"SLACK_WORKSPACE_ID":   "T123",
+		"GC_CITY_NAME":         "mycity",
+	}
+	getenv := func(extra map[string]string) func(string) string {
+		m := map[string]string{}
+		for k, v := range base {
+			m[k] = v
+		}
+		for k, v := range extra {
+			m[k] = v
+		}
+		return func(k string) string { return m[k] }
+	}
+
+	t.Run("explicit override wins", func(t *testing.T) {
+		cfg, err := loadConfigFromEnv(getenv(map[string]string{
+			"SLACK_MINI_SPOOL_DIR":  "/tmp/custom-spool",
+			"GC_SERVICE_STATE_ROOT": "/state/root",
+		}))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.spoolDir != "/tmp/custom-spool" {
+			t.Errorf("spoolDir = %q, want /tmp/custom-spool", cfg.spoolDir)
+		}
+	})
+
+	t.Run("derived from state root", func(t *testing.T) {
+		cfg, err := loadConfigFromEnv(getenv(map[string]string{
+			"GC_SERVICE_STATE_ROOT": "/state/root",
+		}))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := filepath.Join("/state/root", "data", "inbound-spool")
+		if cfg.spoolDir != want {
+			t.Errorf("spoolDir = %q, want %q", cfg.spoolDir, want)
+		}
+	})
+
+	t.Run("unset disables spooling", func(t *testing.T) {
+		cfg, err := loadConfigFromEnv(getenv(nil))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.spoolDir != "" {
+			t.Errorf("spoolDir = %q, want empty", cfg.spoolDir)
+		}
+	})
+}
+
+// TestDeliverInboundRetriesUntilSuccess confirms a transient gc failure is
+// retried and the spool entry is removed once the forward lands (bug hq-1q1:
+// the adapter has already 200-acked Slack, so it must not drop the event).
+func TestDeliverInboundRetriesUntilSuccess(t *testing.T) {
+	compressRetries(t)
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if calls.Add(1) < 3 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	spool := t.TempDir()
+	cfg := config{gcAPIBase: srv.URL, cityName: "c", spoolDir: spool}
+	msg := externalInboundMessage{ProviderMessageID: "1700000000.0001", DedupKey: "slack-1700000000.0001"}
+	path := spoolInbound(spool, msg)
+	if path == "" {
+		t.Fatal("spoolInbound returned no path")
+	}
+
+	deliverInbound(cfg, msg, path)
+
+	if got := calls.Load(); got != 3 {
+		t.Errorf("gc calls = %d, want 3 (two failures then success)", got)
+	}
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("spool entry not removed after successful delivery: %v", err)
+	}
+}
+
+// TestDeliverInboundDeadLettersOnExhaustion confirms the spool entry
+// survives (in the dead-letter dir) when every forward attempt fails, and
+// that the final log line keeps the "inbound POST failed" marker external
+// log-watchers key on.
+func TestDeliverInboundDeadLettersOnExhaustion(t *testing.T) {
+	compressRetries(t)
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	spool := t.TempDir()
+	cfg := config{gcAPIBase: srv.URL, cityName: "c", spoolDir: spool}
+	msg := externalInboundMessage{
+		ProviderMessageID: "1700000000.0002",
+		DedupKey:          "slack-1700000000.0002",
+		Text:              "lost mention",
+	}
+	path := spoolInbound(spool, msg)
+	if path == "" {
+		t.Fatal("spoolInbound returned no path")
+	}
+
+	deliverInbound(cfg, msg, path)
+
+	wantCalls := int32(len(inboundRetryDelays) + 1)
+	if got := calls.Load(); got != wantCalls {
+		t.Errorf("gc calls = %d, want %d", got, wantCalls)
+	}
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("spool entry should have moved to dead-letter: %v", err)
+	}
+	deadPath := filepath.Join(spool, "dead", filepath.Base(path))
+	data, err := os.ReadFile(deadPath)
+	if err != nil {
+		t.Fatalf("dead-letter file: %v", err)
+	}
+	var got externalInboundMessage
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("dead-letter decode: %v", err)
+	}
+	if got.Text != "lost mention" || got.DedupKey != msg.DedupKey {
+		t.Errorf("dead-letter content = %+v", got)
+	}
+}
+
+// TestReplaySpoolRedelivers confirms events left in the spool by a previous
+// run (crash mid-retry) are re-forwarded at startup.
+func TestReplaySpoolRedelivers(t *testing.T) {
+	compressRetries(t)
+	var gotText atomic.Value
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var wrap struct {
+			Message externalInboundMessage `json:"message"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&wrap)
+		gotText.Store(wrap.Message.Text)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	spool := t.TempDir()
+	msg := externalInboundMessage{
+		ProviderMessageID: "1700000000.0003",
+		DedupKey:          "slack-1700000000.0003",
+		Text:              "orphaned by crash",
+	}
+	path := spoolInbound(spool, msg)
+	if path == "" {
+		t.Fatal("spoolInbound returned no path")
+	}
+
+	cfg := config{gcAPIBase: srv.URL, cityName: "c", spoolDir: spool}
+	replaySpool(cfg)
+
+	// Replay delivers asynchronously; wait for the spool entry to clear.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("spool entry not delivered within deadline")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got, _ := gotText.Load().(string); got != "orphaned by crash" {
+		t.Errorf("replayed text = %q, want 'orphaned by crash'", got)
+	}
+}
+
+// TestReplaySpoolDeadLettersCorruptEntries confirms an undecodable spool
+// file is quarantined instead of blocking or crash-looping replay.
+func TestReplaySpoolDeadLettersCorruptEntries(t *testing.T) {
+	spool := t.TempDir()
+	corrupt := filepath.Join(spool, "1-corrupt.json")
+	if err := os.WriteFile(corrupt, []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	replaySpool(config{gcAPIBase: "http://127.0.0.1:1", cityName: "c", spoolDir: spool})
+
+	if _, err := os.Stat(corrupt); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("corrupt entry should have moved to dead-letter: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(spool, "dead", "1-corrupt.json")); err != nil {
+		t.Errorf("corrupt entry missing from dead-letter dir: %v", err)
 	}
 }
 

--- a/slack-mini/adapter/main_test.go
+++ b/slack-mini/adapter/main_test.go
@@ -561,7 +561,7 @@ func TestDeliverInboundRetriesUntilSuccess(t *testing.T) {
 	spool := t.TempDir()
 	cfg := config{gcAPIBase: srv.URL, cityName: "c", spoolDir: spool}
 	msg := externalInboundMessage{ProviderMessageID: "1700000000.0001", DedupKey: "slack-1700000000.0001"}
-	path := spoolInbound(spool, msg)
+	path, _ := spoolInbound(spool, msg)
 	if path == "" {
 		t.Fatal("spoolInbound returned no path")
 	}
@@ -596,7 +596,7 @@ func TestDeliverInboundDeadLettersOnExhaustion(t *testing.T) {
 		DedupKey:          "slack-1700000000.0002",
 		Text:              "lost mention",
 	}
-	path := spoolInbound(spool, msg)
+	path, _ := spoolInbound(spool, msg)
 	if path == "" {
 		t.Fatal("spoolInbound returned no path")
 	}
@@ -645,7 +645,7 @@ func TestReplaySpoolRedelivers(t *testing.T) {
 		DedupKey:          "slack-1700000000.0003",
 		Text:              "orphaned by crash",
 	}
-	path := spoolInbound(spool, msg)
+	path, _ := spoolInbound(spool, msg)
 	if path == "" {
 		t.Fatal("spoolInbound returned no path")
 	}

--- a/slack-mini/adapter/main_test.go
+++ b/slack-mini/adapter/main_test.go
@@ -680,8 +680,16 @@ func TestReplaySpoolDeadLettersCorruptEntries(t *testing.T) {
 
 	replaySpool(config{gcAPIBase: "http://127.0.0.1:1", cityName: "c", spoolDir: spool})
 
-	if _, err := os.Stat(corrupt); !errors.Is(err, os.ErrNotExist) {
-		t.Errorf("corrupt entry should have moved to dead-letter: %v", err)
+	// Replay decodes in worker goroutines now; poll for the quarantine.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if _, err := os.Stat(corrupt); errors.Is(err, os.ErrNotExist) {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("corrupt entry should have moved to dead-letter")
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 	if _, err := os.Stat(filepath.Join(spool, "dead", "1-corrupt.json")); err != nil {
 		t.Errorf("corrupt entry missing from dead-letter dir: %v", err)
@@ -732,6 +740,18 @@ func TestSlackifyMarkdown(t *testing.T) {
 		// codex P2: multi-backtick code spans protect their contents.
 		{"double backtick span protected", "x ``has `tick` and **raw**`` y", "x ``has `tick` and **raw**`` y"},
 		{"unbalanced backtick run passes through", "a `` b **bold**", "a `` b *bold*"},
+		// codex round 2: embedded ``` inside a code line is not a closer.
+		{"fence with embedded triple backticks", "```\nfmt.Println(\"```\")\n**raw**\n```\nafter **b**", "```\nfmt.Println(\"```\")\n**raw**\n```\nafter *b*"},
+		// codex round 2: escaped parens are URL data.
+		{"escaped paren in link destination", `[x](https://h/a\)b)`, "<https://h/a)b|x>"},
+		// codex round 2: heading hash glued to text is content.
+		{"heading ending in hash", "# C#\nbody", "*C#*\nbody"},
+		{"heading with spaced closer", "## Title ##\nbody", "*Title*\nbody"},
+		// codex round 2: intraword underscores stay literal.
+		{"intraword underscores untouched", "foo__bar__baz", "foo__bar__baz"},
+		{"boundary underscore bold still converts", "say __hi__ now", "say *hi* now"},
+		// codex round 2: trailing emphasis delimiters are not URL bytes.
+		{"bold around bare url", "**see https://example.com**", "*see https://example.com*"},
 	}
 	for _, tc := range cases {
 		if got := slackifyMarkdown(tc.in); got != tc.want {

--- a/slack-mini/manifest/app.json
+++ b/slack-mini/manifest/app.json
@@ -20,7 +20,8 @@
       "bot": [
         "app_mentions:read",
         "chat:write",
-        "chat:write.public"
+        "chat:write.public",
+        "users:read"
       ]
     }
   },


### PR DESCRIPTION
Two commits hardening the slack-mini adapter, developed and live-verified on a Tier-1 city where Slack is the operator's primary mobile channel:

**1. Persist-and-retry for inbound forwards (hq-1q1, 1883248):** the adapter previously acked Slack before forwarding to gc — a gc-API timeout meant the message was lost AND fed Slack's per-app backoff. The adapter now logs receipt pre-forward, spools to disk (GC_SERVICE_STATE_ROOT/data/inbound-spool), retries 5x over ~2min, dead-letters with the original payload on exhaustion, and replays crash orphans at startup. (This path saved a real message from loss during a 3-minute gc-API stall the same night it deployed.)

**2. Reply UX fixes (hq-fh9, 34ea912):** sender display names via users.info (graceful raw-id fallback with 5m negative cache when users:read is not yet granted), Markdown→mrkdwn conversion on outbound posts, and reply instructions registered with gc so injected reminders name a verb that actually exists, with thread ts pre-filled.

Both deployed and verified end-to-end on a live city (signed synthetic inbound through funnel→adapter→gc→agent, reply posted in-thread with formatting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)