### PR TITLE
slack-full: resilient adapter registration (bounded retry + periodic re-register)

### DIFF
--- a/bmad/formulas/bmad-build.formula.toml
+++ b/bmad/formulas/bmad-build.formula.toml
@@ -7,9 +7,11 @@ epics/stories so it matches the upstream workflow.
 """
 formula = "bmad-build"
 version = 1
-contract = "graph.v2"
 extends = ["build-base"]
 target_required = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "bmad-build"

--- a/bmad/formulas/bmad-code-review-flow.formula.toml
+++ b/bmad/formulas/bmad-code-review-flow.formula.toml
@@ -7,7 +7,9 @@ review lanes, including gap analysis, with synthesis and fix application.
 formula = "bmad-code-review-flow"
 type = "expansion"
 version = 1
-contract = "graph.v2"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/bmad/formulas/bmad-decomposition.formula.toml
+++ b/bmad/formulas/bmad-decomposition.formula.toml
@@ -3,10 +3,12 @@ BMAD implementation of the decomposition-base methodology contract.
 """
 formula = "bmad-decomposition"
 version = 1
-contract = "graph.v2"
 extends = ["decomposition-base"]
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [[steps]]
 id = "decompose"

--- a/bmad/formulas/bmad-fix-loop.formula.toml
+++ b/bmad/formulas/bmad-fix-loop.formula.toml
@@ -3,10 +3,12 @@ BMAD implementation of the fix-loop-base methodology contract.
 """
 formula = "bmad-fix-loop"
 version = 1
-contract = "graph.v2"
 extends = ["fix-loop-base"]
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_formula]

--- a/bmad/formulas/bmad-implementation.formula.toml
+++ b/bmad/formulas/bmad-implementation.formula.toml
@@ -3,10 +3,12 @@ BMAD implementation of the public implement methodology contract.
 """
 formula = "bmad-implementation"
 version = 1
-contract = "graph.v2"
 extends = ["implement"]
 target_required = true
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/bmad/formulas/bmad-planning.formula.toml
+++ b/bmad/formulas/bmad-planning.formula.toml
@@ -3,10 +3,12 @@ BMAD implementation of the planning-base methodology contract.
 """
 formula = "bmad-planning"
 version = 1
-contract = "graph.v2"
 extends = ["planning-base"]
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [[steps]]
 id = "requirements"

--- a/bmad/formulas/bmad-review.formula.toml
+++ b/bmad/formulas/bmad-review.formula.toml
@@ -3,11 +3,13 @@ BMAD implementation of the code-review-base methodology contract.
 """
 formula = "bmad-review"
 version = 1
-contract = "graph.v2"
 extends = ["code-review-base"]
 target_required = false
 internal = true
 mode = "report"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/bmad/formulas/bmad-story-development-item.formula.toml
+++ b/bmad/formulas/bmad-story-development-item.formula.toml
@@ -6,11 +6,13 @@ shared drain lifecycle and serializes item work.
 """
 formula = "bmad-story-development-item"
 version = 1
-contract = "graph.v2"
 extends = ["do-work-item"]
 target_required = true
 internal = true
 single_lane = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [[steps]]
 id = "implement-item"

--- a/bmad/formulas/bmad-story-development.formula.toml
+++ b/bmad/formulas/bmad-story-development.formula.toml
@@ -6,9 +6,11 @@ implementation and review lanes.
 """
 formula = "bmad-story-development"
 version = 1
-contract = "graph.v2"
 extends = ["do-work"]
 target_required = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [[steps]]
 id = "implement"

--- a/compound-engineering/formulas/compound-build.formula.toml
+++ b/compound-engineering/formulas/compound-build.formula.toml
@@ -7,9 +7,11 @@ is a finalize-stage behavior.
 """
 formula = "compound-build"
 version = 1
-contract = "graph.v2"
 extends = ["build-base"]
 target_required = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "compound-build"

--- a/compound-engineering/formulas/compound-code-review.formula.toml
+++ b/compound-engineering/formulas/compound-code-review.formula.toml
@@ -10,7 +10,9 @@ invoked.
 formula = "compound-code-review"
 type = "expansion"
 version = 1
-contract = "graph.v2"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/compound-engineering/formulas/compound-decomposition.formula.toml
+++ b/compound-engineering/formulas/compound-decomposition.formula.toml
@@ -3,10 +3,12 @@ Compound Engineering implementation of the decomposition-base methodology contra
 """
 formula = "compound-decomposition"
 version = 1
-contract = "graph.v2"
 extends = ["decomposition-base"]
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [[steps]]
 id = "decompose"

--- a/compound-engineering/formulas/compound-fix-loop.formula.toml
+++ b/compound-engineering/formulas/compound-fix-loop.formula.toml
@@ -3,10 +3,12 @@ Compound Engineering implementation of the fix-loop-base methodology contract.
 """
 formula = "compound-fix-loop"
 version = 1
-contract = "graph.v2"
 extends = ["fix-loop-base"]
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_formula]

--- a/compound-engineering/formulas/compound-implementation.formula.toml
+++ b/compound-engineering/formulas/compound-implementation.formula.toml
@@ -3,10 +3,12 @@ Compound Engineering implementation of the public implement methodology contract
 """
 formula = "compound-implementation"
 version = 1
-contract = "graph.v2"
 extends = ["implement"]
 target_required = true
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/compound-engineering/formulas/compound-plan-review.formula.toml
+++ b/compound-engineering/formulas/compound-plan-review.formula.toml
@@ -8,7 +8,9 @@ all execution is routed through Gas City `gc.*` agents.
 formula = "compound-plan-review"
 type = "expansion"
 version = 1
-contract = "graph.v2"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [[template]]
 id = "{target}.setup-compound-plan-review"

--- a/compound-engineering/formulas/compound-planning.formula.toml
+++ b/compound-engineering/formulas/compound-planning.formula.toml
@@ -3,10 +3,12 @@ Compound Engineering implementation of the planning-base methodology contract.
 """
 formula = "compound-planning"
 version = 1
-contract = "graph.v2"
 extends = ["planning-base"]
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [[steps]]
 id = "requirements"

--- a/compound-engineering/formulas/compound-resolution.formula.toml
+++ b/compound-engineering/formulas/compound-resolution.formula.toml
@@ -8,7 +8,9 @@ and records a single build-base finalize result.
 formula = "compound-resolution"
 type = "expansion"
 version = 1
-contract = "graph.v2"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [[template]]
 id = "{target}.inventory-artifacts"

--- a/compound-engineering/formulas/compound-review.formula.toml
+++ b/compound-engineering/formulas/compound-review.formula.toml
@@ -3,11 +3,13 @@ Compound Engineering implementation of the code-review-base methodology contract
 """
 formula = "compound-review"
 version = 1
-contract = "graph.v2"
 extends = ["code-review-base"]
 target_required = false
 internal = true
 mode = "report"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/compound-engineering/formulas/compound-work-item.formula.toml
+++ b/compound-engineering/formulas/compound-work-item.formula.toml
@@ -6,11 +6,13 @@ without creating an isolated source-anchor worktree.
 """
 formula = "compound-work-item"
 version = 1
-contract = "graph.v2"
 extends = ["do-work-item"]
 target_required = true
 internal = true
 single_lane = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/compound-engineering/formulas/compound-work.formula.toml
+++ b/compound-engineering/formulas/compound-work.formula.toml
@@ -6,9 +6,11 @@ top of Gas City's source-anchor worktree lifecycle.
 """
 formula = "compound-work"
 version = 1
-contract = "graph.v2"
 extends = ["do-work"]
 target_required = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/gascity/formulas/build-base.formula.toml
+++ b/gascity/formulas/build-base.formula.toml
@@ -27,9 +27,11 @@ Launch inputs:
 """
 formula = "build-base"
 version = 1
-contract = "graph.v2"
 target_required = true
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [metadata.gc.methodology]
 allowed_drain_policies = ["separate", "same-session"]

--- a/gascity/formulas/build-basic-review.formula.toml
+++ b/gascity/formulas/build-basic-review.formula.toml
@@ -8,7 +8,9 @@ synthesize into one fix loop.
 formula = "build-basic-review"
 type = "expansion"
 version = 1
-contract = "graph.v2"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/gascity/formulas/build-basic.formula.toml
+++ b/gascity/formulas/build-basic.formula.toml
@@ -7,9 +7,11 @@ same full-lifecycle stage contract exposed by build-base.
 """
 formula = "build-basic"
 version = 1
-contract = "graph.v2"
 extends = ["build-base"]
 target_required = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "build-basic"

--- a/gascity/formulas/build-from-convoy-base.formula.toml
+++ b/gascity/formulas/build-from-convoy-base.formula.toml
@@ -7,10 +7,12 @@ to `build-from-review-base` through the inherited `prepare-review` step.
 """
 formula = "build-from-convoy-base"
 version = 1
-contract = "graph.v2"
 extends = ["build-from-review-base"]
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [metadata.gc.methodology]
 allowed_drain_policies = ["separate", "same-session"]

--- a/gascity/formulas/build-from-convoy.formula.toml
+++ b/gascity/formulas/build-from-convoy.formula.toml
@@ -6,9 +6,11 @@ Gas City methodology defaults.
 """
 formula = "build-from-convoy"
 version = 1
-contract = "graph.v2"
 extends = ["build-from-convoy-base"]
 target_required = false
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "build-from-convoy"

--- a/gascity/formulas/build-from-decompose-base.formula.toml
+++ b/gascity/formulas/build-from-decompose-base.formula.toml
@@ -29,10 +29,12 @@ Launch inputs:
 """
 formula = "build-from-decompose-base"
 version = 1
-contract = "graph.v2"
 extends = ["build-from-convoy-base"]
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [metadata.gc.methodology]
 allowed_drain_policies = ["separate", "same-session"]

--- a/gascity/formulas/build-from-decompose.formula.toml
+++ b/gascity/formulas/build-from-decompose.formula.toml
@@ -8,9 +8,11 @@ selectors, routes, drains, or review expansions they need.
 """
 formula = "build-from-decompose"
 version = 1
-contract = "graph.v2"
 extends = ["build-from-decompose-base"]
 target_required = false
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "build-from-decompose"

--- a/gascity/formulas/build-from-plan-base.formula.toml
+++ b/gascity/formulas/build-from-plan-base.formula.toml
@@ -7,10 +7,12 @@ implementation plan and plan-review verdict, then hands off to
 """
 formula = "build-from-plan-base"
 version = 1
-contract = "graph.v2"
 extends = ["build-from-decompose-base"]
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [metadata.gc.methodology]
 allowed_drain_policies = ["separate", "same-session"]

--- a/gascity/formulas/build-from-plan.formula.toml
+++ b/gascity/formulas/build-from-plan.formula.toml
@@ -6,9 +6,11 @@ City methodology defaults.
 """
 formula = "build-from-plan"
 version = 1
-contract = "graph.v2"
 extends = ["build-from-plan-base"]
 target_required = false
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "build-from-plan"

--- a/gascity/formulas/build-from-requirements-base.formula.toml
+++ b/gascity/formulas/build-from-requirements-base.formula.toml
@@ -7,10 +7,12 @@ inherited `prepare-plan` step.
 """
 formula = "build-from-requirements-base"
 version = 1
-contract = "graph.v2"
 extends = ["build-from-plan-base"]
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [metadata.gc.methodology]
 allowed_drain_policies = ["separate", "same-session"]

--- a/gascity/formulas/build-from-requirements.formula.toml
+++ b/gascity/formulas/build-from-requirements.formula.toml
@@ -6,9 +6,11 @@ built-in Gas City methodology defaults.
 """
 formula = "build-from-requirements"
 version = 1
-contract = "graph.v2"
 extends = ["build-from-requirements-base"]
 target_required = false
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "build-from-requirements"

--- a/gascity/formulas/build-from-review-base.formula.toml
+++ b/gascity/formulas/build-from-review-base.formula.toml
@@ -8,9 +8,11 @@ to `prepare-review` after producing implementation evidence.
 """
 formula = "build-from-review-base"
 version = 1
-contract = "graph.v2"
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [metadata.gc.methodology]
 allowed_drain_policies = ["separate", "same-session"]

--- a/gascity/formulas/build-from-review.formula.toml
+++ b/gascity/formulas/build-from-review.formula.toml
@@ -6,9 +6,11 @@ Gas City methodology defaults.
 """
 formula = "build-from-review"
 version = 1
-contract = "graph.v2"
 extends = ["build-from-review-base"]
 target_required = false
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "build-from-review"

--- a/gascity/formulas/code-review-base.formula.toml
+++ b/gascity/formulas/code-review-base.formula.toml
@@ -7,10 +7,12 @@ scoring while entrypoint adapters keep GitHub/comment lifecycle ownership.
 """
 formula = "code-review-base"
 version = 1
-contract = "graph.v2"
 target_required = false
 internal = true
 mode = "report"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.context_path]

--- a/gascity/formulas/decomposition-base.formula.toml
+++ b/gascity/formulas/decomposition-base.formula.toml
@@ -7,9 +7,11 @@ native output uses stories, cards, or another task shape.
 """
 formula = "decomposition-base"
 version = 1
-contract = "graph.v2"
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.context_path]

--- a/gascity/formulas/design-review.formula.toml
+++ b/gascity/formulas/design-review.formula.toml
@@ -8,8 +8,10 @@ graphs while preserving launch and finalization semantics.
 """
 formula = "design-review"
 version = 1
-contract = "graph.v2"
 target_required = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "design-review"

--- a/gascity/formulas/do-work-item.formula.toml
+++ b/gascity/formulas/do-work-item.formula.toml
@@ -8,11 +8,13 @@ Launch inputs:
 """
 formula = "do-work-item"
 version = 1
-contract = "graph.v2"
 extends = ["implementation-item-base"]
 target_required = true
 internal = true
 single_lane = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.context_path]

--- a/gascity/formulas/do-work.formula.toml
+++ b/gascity/formulas/do-work.formula.toml
@@ -10,9 +10,11 @@ Launch inputs:
 """
 formula = "do-work"
 version = 1
-contract = "graph.v2"
 extends = ["implementation-base"]
 target_required = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.context_path]

--- a/gascity/formulas/fix-convoy.formula.toml
+++ b/gascity/formulas/fix-convoy.formula.toml
@@ -8,9 +8,11 @@ Launch inputs:
 """
 formula = "fix-convoy"
 version = 1
-contract = "graph.v2"
 target_required = true
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.report_path]

--- a/gascity/formulas/fix-loop-base.formula.toml
+++ b/gascity/formulas/fix-loop-base.formula.toml
@@ -8,9 +8,11 @@ discipline.
 """
 formula = "fix-loop-base"
 version = 1
-contract = "graph.v2"
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.context_path]

--- a/gascity/formulas/gap-analysis.formula.toml
+++ b/gascity/formulas/gap-analysis.formula.toml
@@ -8,9 +8,11 @@ Launch inputs:
 """
 formula = "gap-analysis"
 version = 1
-contract = "graph.v2"
 target_required = false
 mode = "report"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "gap-analysis"

--- a/gascity/formulas/github-issue-fix-base.formula.toml
+++ b/gascity/formulas/github-issue-fix-base.formula.toml
@@ -27,8 +27,10 @@ Launch inputs:
 """
 formula = "github-issue-fix-base"
 version = 1
-contract = "graph.v2"
 target_required = false
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.github_issue_url]

--- a/gascity/formulas/github-issue-fix-design-review-work.formula.toml
+++ b/gascity/formulas/github-issue-fix-design-review-work.formula.toml
@@ -10,7 +10,9 @@ contract for downstream bead creation.
 formula = "github-issue-fix-design-review-work"
 type = "expansion"
 version = 1
-contract = "graph.v2"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars.mode]
 description = "Issue-fix front-half mode, recorded in artifacts."

--- a/gascity/formulas/github-issue-fix.formula.toml
+++ b/gascity/formulas/github-issue-fix.formula.toml
@@ -18,8 +18,10 @@ Launch inputs:
 formula = "github-issue-fix"
 extends = ["github-issue-fix-base"]
 version = 1
-contract = "graph.v2"
 target_required = false
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "github-issue-fix"

--- a/gascity/formulas/github-issue-triage-base.formula.toml
+++ b/gascity/formulas/github-issue-triage-base.formula.toml
@@ -17,8 +17,10 @@ Launch inputs:
 """
 formula = "github-issue-triage-base"
 version = 1
-contract = "graph.v2"
 target_required = false
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.github_issue_url]

--- a/gascity/formulas/github-issue-triage.formula.toml
+++ b/gascity/formulas/github-issue-triage.formula.toml
@@ -16,8 +16,10 @@ Launch inputs:
 formula = "github-issue-triage"
 extends = ["github-issue-triage-base"]
 version = 1
-contract = "graph.v2"
 target_required = false
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "github-issue-triage"

--- a/gascity/formulas/github-pr-review.formula.toml
+++ b/gascity/formulas/github-pr-review.formula.toml
@@ -19,8 +19,10 @@ Launch inputs:
 """
 formula = "github-pr-review"
 version = 1
-contract = "graph.v2"
 target_required = false
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "github-pr-review"

--- a/gascity/formulas/implement.formula.toml
+++ b/gascity/formulas/implement.formula.toml
@@ -16,9 +16,11 @@ Launch inputs:
 """
 formula = "implement"
 version = 2
-contract = "graph.v2"
 target_required = true
 sling_container_mode = "source"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "implement"

--- a/gascity/formulas/implementation-base.formula.toml
+++ b/gascity/formulas/implementation-base.formula.toml
@@ -8,9 +8,11 @@ source-anchor close contract.
 """
 formula = "implementation-base"
 version = 1
-contract = "graph.v2"
 target_required = true
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.context_path]

--- a/gascity/formulas/implementation-item-base.formula.toml
+++ b/gascity/formulas/implementation-item-base.formula.toml
@@ -7,10 +7,12 @@ per-item procedure while keeping shared-drain sequencing stable.
 """
 formula = "implementation-item-base"
 version = 1
-contract = "graph.v2"
 target_required = true
 internal = true
 single_lane = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.context_path]

--- a/gascity/formulas/planning-base.formula.toml
+++ b/gascity/formulas/planning-base.formula.toml
@@ -8,9 +8,11 @@ artifact paths consumed by entrypoint adapters.
 """
 formula = "planning-base"
 version = 1
-contract = "graph.v2"
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.artifact_root]

--- a/gascity/formulas/publish.formula.toml
+++ b/gascity/formulas/publish.formula.toml
@@ -8,9 +8,11 @@ Launch inputs:
 """
 formula = "publish"
 version = 1
-contract = "graph.v2"
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.final_report]

--- a/gascity/formulas/review.formula.toml
+++ b/gascity/formulas/review.formula.toml
@@ -10,10 +10,12 @@ Launch inputs:
 """
 formula = "review"
 version = 1
-contract = "graph.v2"
 extends = ["code-review-base"]
 target_required = false
 mode = "report"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "review"

--- a/gascity/formulas/same-session-implement.formula.toml
+++ b/gascity/formulas/same-session-implement.formula.toml
@@ -9,9 +9,11 @@ Launch inputs:
 """
 formula = "same-session-implement"
 version = 1
-contract = "graph.v2"
 target_required = true
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.context_path]

--- a/gstack/formulas/gstack-build.formula.toml
+++ b/gstack/formulas/gstack-build.formula.toml
@@ -6,9 +6,11 @@ Think -> Plan -> Build -> Review -> Test -> Ship -> Reflect.
 """
 formula = "gstack-build"
 version = 1
-contract = "graph.v2"
 extends = ["build-base"]
 target_required = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "gstack-build"

--- a/gstack/formulas/gstack-code-review.formula.toml
+++ b/gstack/formulas/gstack-code-review.formula.toml
@@ -7,7 +7,9 @@ into explicit Gas City review lanes with synthesis and fix application.
 formula = "gstack-code-review"
 type = "expansion"
 version = 1
-contract = "graph.v2"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/gstack/formulas/gstack-decomposition.formula.toml
+++ b/gstack/formulas/gstack-decomposition.formula.toml
@@ -3,10 +3,12 @@ gstack implementation of the decomposition-base methodology contract.
 """
 formula = "gstack-decomposition"
 version = 1
-contract = "graph.v2"
 extends = ["decomposition-base"]
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [[steps]]
 id = "decompose"

--- a/gstack/formulas/gstack-fix-loop.formula.toml
+++ b/gstack/formulas/gstack-fix-loop.formula.toml
@@ -3,10 +3,12 @@ gstack implementation of the fix-loop-base methodology contract.
 """
 formula = "gstack-fix-loop"
 version = 1
-contract = "graph.v2"
 extends = ["fix-loop-base"]
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_formula]

--- a/gstack/formulas/gstack-implementation.formula.toml
+++ b/gstack/formulas/gstack-implementation.formula.toml
@@ -3,10 +3,12 @@ gstack implementation of the public implement methodology contract.
 """
 formula = "gstack-implementation"
 version = 1
-contract = "graph.v2"
 extends = ["implement"]
 target_required = true
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/gstack/formulas/gstack-plan-review.formula.toml
+++ b/gstack/formulas/gstack-plan-review.formula.toml
@@ -7,7 +7,9 @@ founder, design, engineering, and developer-experience lanes.
 formula = "gstack-plan-review"
 type = "expansion"
 version = 1
-contract = "graph.v2"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/gstack/formulas/gstack-planning.formula.toml
+++ b/gstack/formulas/gstack-planning.formula.toml
@@ -3,10 +3,12 @@ gstack implementation of the planning-base methodology contract.
 """
 formula = "gstack-planning"
 version = 1
-contract = "graph.v2"
 extends = ["planning-base"]
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.interaction_mode]

--- a/gstack/formulas/gstack-qa-review.formula.toml
+++ b/gstack/formulas/gstack-qa-review.formula.toml
@@ -7,7 +7,9 @@ and synthesis lanes.
 formula = "gstack-qa-review"
 type = "expansion"
 version = 1
-contract = "graph.v2"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/gstack/formulas/gstack-release-readiness.formula.toml
+++ b/gstack/formulas/gstack-release-readiness.formula.toml
@@ -7,7 +7,9 @@ explicit Gas City readiness lanes before the build finalize and publish stages.
 formula = "gstack-release-readiness"
 type = "expansion"
 version = 1
-contract = "graph.v2"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.review_mode]

--- a/gstack/formulas/gstack-review.formula.toml
+++ b/gstack/formulas/gstack-review.formula.toml
@@ -3,11 +3,13 @@ gstack implementation of the code-review-base methodology contract.
 """
 formula = "gstack-review"
 version = 1
-contract = "graph.v2"
 extends = ["code-review-base"]
 target_required = false
 internal = true
 mode = "report"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/gstack/formulas/gstack-work-item.formula.toml
+++ b/gstack/formulas/gstack-work-item.formula.toml
@@ -3,11 +3,13 @@ gstack single-lane implementation item formula.
 """
 formula = "gstack-work-item"
 version = 1
-contract = "graph.v2"
 extends = ["do-work-item"]
 target_required = true
 internal = true
 single_lane = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/gstack/formulas/gstack-work.formula.toml
+++ b/gstack/formulas/gstack-work.formula.toml
@@ -3,9 +3,11 @@ gstack implementation item formula.
 """
 formula = "gstack-work"
 version = 1
-contract = "graph.v2"
 extends = ["do-work"]
 target_required = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/pr-pipeline/formulas/mol-pr-from-issue.formula.toml
+++ b/pr-pipeline/formulas/mol-pr-from-issue.formula.toml
@@ -58,7 +58,9 @@ notes and metadata. Crash-safe: `bd mol current` resumes at the right step.
 formula = "mol-pr-from-issue"
 phase = "vapor"
 version = 1
-contract = "graph.v2"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.issue_number]

--- a/slack-full/CHANGELOG.md
+++ b/slack-full/CHANGELOG.md
@@ -8,6 +8,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Binding rehydration on adapter (re-)registration.** After the adapter
+  registers with gc it now replays every room binding recorded in
+  `.gc/services/slack/data/config.json` back to gc (`/extmsg/groups` →
+  `/extmsg/participants` → `/extmsg/bind`), restoring bindings that a
+  from-dead recovery (fresh pack cache clone / gc restart) would otherwise
+  drop as "no active binding" 422s — with no manual `gc slack bind-room`.
+  Best-effort and loud; a bind conflict (already-bound) is tolerated as the
+  desired state. See `adapter/rehydrate.go`. (`dip-klkcl`)
+- **`scripts/build-binaries.sh`** — one-command, idempotent, self-verifying
+  rebuild of both gitignored Go binaries in place. gc runs no pack build
+  hook on `import install`, so the binaries vanish on every repin (root
+  cause of the 2026-07-05 outage); run this after any import/repin. The
+  `binaries` doctor check's remediation message now points at it. (`dip-klkcl`)
+- **"Canonical gc 1.3.3 parity"** README section documenting the
+  `gc slack react` verb and `reply-current --thread-current` threading that
+  the deployed canonical lacks but this pack already provides, with interim
+  workarounds until a repin lands. (`dip-klkcl`)
+
+### Fixed
+
+- **Inbound silently dropped on a transient gc 5xx.** `postInbound` treated
+  a gc 500 as terminal, so a dolt "begin read tx: invalid connection"
+  hiccup on the bindings-resolution path dropped the Slack event — on the
+  oversight channel that can eat a page reply. It now retries transport
+  errors and 5xx with bounded backoff (idempotent via the inbound
+  `DedupKey`, so no double-delivery); 4xx stays terminal. On exhaustion the
+  failure log carries the event id (`ts`) + channel so the drop is
+  correlatable — the old `inbound POST failed:` line had neither. See
+  `adapter/main.go` `gcPostWithRetry`. (`dip-klkcl`)
+
 ### Changed
 
 - Renamed the pack directory from `slack-pack/` to `slack-full/` and the

--- a/slack-full/README.md
+++ b/slack-full/README.md
@@ -194,8 +194,50 @@ either can travel intact when the pack is mirrored upstream:
   `$GC_PACK_DIR/cli/gc-slack-cli` so operator command-line ergonomics
   stay identical to the pre-relocation gc-binary verbs.
 
-Build commands and CI for both binaries are documented in
+Both binaries are **gitignored build artifacts**: a fresh pack cache
+clone — `gc import install`, a repin, `gc pack fetch` — does not contain
+them, and gc runs **no pack build hook on import**. After any such clone
+the `[[service]]` command and the `commands/<cmd>.sh` wrappers point at
+binaries that do not exist (this is the root cause of the 2026-07-05
+~16.6h Slack outage). Rebuild both in place with the pack's build script:
+
+```
+./scripts/build-binaries.sh
+# equivalent to: (cd adapter && go build -o gc-slack-adapter) && (cd cli && go build -o gc-slack-cli .)
+```
+
+The script is idempotent and fails loudly on a partial build; the pack's
+`binaries` doctor check (`doctor/check-binaries.sh`) verifies both are
+present in place. Build commands and CI are documented in
 [CONTRIBUTING.md](./CONTRIBUTING.md#build-flow).
+
+## Canonical gc 1.3.3 parity
+
+The deployed **canonical gc 1.3.3** exposes an *older* snapshot of this
+pack's verb surface than the source in this tree. Two gaps bite the
+oversight loop; both are **already implemented here** and land when this
+pack is repinned + rebuilt:
+
+- **`gc slack react` verb.** The adapter serves `POST /react`
+  (`reactions.add` passthrough) and the pack ships `commands/react/` +
+  `scripts/slack_chat_react.py`, so an agent can eyes-react on the latest
+  inbound (`gc slack react --emoji eyes`) or an explicit `(channel, ts)`.
+  Canonical 1.3.3 may not surface the verb — if `gc slack react` is
+  absent, the reaction step is skipped (inbounds still deliver); post the
+  reply and note "no eyes-react on this build" until the repin lands.
+- **`reply-current --thread-current` threading.** `slack_chat_reply_current.py`
+  resolves the latest inbound's thread anchor and sends it as
+  `reply_to_message_id`, which the adapter maps to Slack `thread_ts`
+  (`main.go`, `PublishRequest.ReplyToMessageID → thread_ts`) — so replies
+  land *in-thread*. On canonical 1.3.3 `--thread-current` was silently
+  swallowed (un-threaded replies). Interim workaround until the repin: POST
+  `/v0/city/<city>/extmsg/outbound` directly with an explicit
+  `reply_to_message_id` (the thread root), which threads correctly on every
+  build.
+
+Neither is a code change in this batch — they are documented here so an
+operator on canonical 1.3.3 knows what to expect and which workaround to
+reach for before the pack is repinned.
 
 ## Architecture (current)
 
@@ -463,8 +505,11 @@ GC_CITY_NAME=<your-city-name>
 ### Cutover sequence
 
 ```
-# 1. Build the adapter binary in place (source colocated with the pack)
-( cd slack-full/adapter && go build -o gc-slack-adapter )
+# 1. Build the pack's Go binaries in place (adapter + operator CLI). They
+#    are gitignored artifacts: a fresh cache clone / repin loses them and
+#    gc runs no build hook on import, so rebuild after every import/repin.
+#    build-binaries.sh builds both and verifies they landed.
+( cd slack-full && ./scripts/build-binaries.sh )
 
 # 2. Source the secrets so the supervisor inherits them
 set -a; source "${XDG_CONFIG_HOME:-$HOME/.config}/gc-slack-adapter/env"; set +a
@@ -521,6 +566,16 @@ TCP-only mode, so the same binary serves both deployments.
   declared in the city. If you reboot the host or `tailscale funnel
 reset`, traffic stops landing at the adapter. Re-add the rule
   manually until Phase C lands.
+- **Binaries vanish on repin.** The adapter and CLI are gitignored build
+  artifacts; `gc import install` / a repin / `gc pack fetch` clones a
+  fresh copy *without* them, and gc runs no build hook on import. Symptom:
+  the `slack` service fails to start (missing `./adapter/gc-slack-adapter`)
+  and `gc slack <cmd>` wrappers cannot find `$GC_PACK_DIR/cli/gc-slack-cli`.
+  Fix: rerun `./scripts/build-binaries.sh` after any import/repin (this was
+  the 2026-07-05 ~16.6h outage). **Bindings do not rehydrate on their own
+  either** — but as of this pack version the adapter replays them from
+  `config.json` on (re-)registration, so a manual `gc slack bind-room` is
+  only needed if that rehydration logs a failure.
 
 ## Where the work that's still missing comes from
 

--- a/slack-full/adapter/main.go
+++ b/slack-full/adapter/main.go
@@ -166,6 +166,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/hmac"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -1161,7 +1162,71 @@ func listenUDS(path string) (net.Listener, error) {
 	return lis, nil
 }
 
+// registerAdapter self-registers this adapter with gc's extmsg registry so
+// gc will route outbound to us and accept our inbound. It retries the
+// transient boot-ordering conditions until the city is up — see
+// registerAdapterWith. This production entry point uses a per-attempt
+// timeout client that does NOT follow redirects, plus the boot-register
+// retry budget and real sleep.
 func registerAdapter(cfg config) error {
+	// A per-attempt timeout keeps a single hung dial from stalling the whole
+	// retry-until-ready loop past one backoff cycle. gc is on loopback so a
+	// not-yet-listening port fails fast (connection refused) anyway; this is
+	// the belt-and-suspenders bound for a slow / half-open connect.
+	//
+	// Do NOT follow redirects: a misconfigured GC_API_BASE_URL that 302s to a
+	// login/proxy would otherwise be followed to a 200 and reported as a
+	// successful registration while nothing was registered — silent
+	// stranding. Surfacing the 3xx (ErrUseLastResponse) lets it be classified
+	// as a permanent misconfiguration and fail fast/loud instead.
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	return registerAdapterWith(cfg, client, bootRegisterRetryConfig(), time.Sleep)
+}
+
+// registerAdapterWith is the testable core of adapter self-registration: the
+// HTTP client, retry policy, and sleep are injected (mirrors
+// rehydrateBindingsWith).
+//
+// The supervisor spawns this adapter as it boots the city, BEFORE the city
+// is marked running/resolvable (gc's workspacesvc manager reload runs in the
+// CityRuntime constructor, ahead of reconciliation). Until the city
+// resolves, three transient boot-ordering conditions can occur, all retried
+// with bounded backoff:
+//   - the gc API is not listening yet — the POST fails in transport
+//     (connection refused);
+//   - gc's per-city bindCity gate 404s every city-scoped route (including
+//     this /extmsg/adapters POST) with the structured code "city-not-found"
+//     (see isCityNotReady);
+//   - the city has resolved but its extmsg registry is not wired yet — gc
+//     returns 503, handled by retryableStatus.
+//
+// This is the fix for the one-shot registration that stranded the adapter on
+// every supervisor restart: a single boot-race failure no longer kills it.
+//
+// A genuinely permanent rejection — any other non-2xx (a malformed request,
+// an auth failure, a redirect, a 404 that decodes to a different error code)
+// — is returned immediately so a real misconfiguration dies loud and fast
+// instead of being masked by minutes of futile retries. After the whole
+// budget is exhausted the last error is returned, naming the city and
+// attempt count so the caller's fatal log points at the likely cause; the
+// supervisor then respawns the adapter (see bootRegisterRetryConfig).
+//
+// A stable per-boot Idempotency-Key is sent on every attempt so that if a
+// POST commits on the gc side but its response is lost (transport error or
+// the client timeout firing after commit), the retry does not double-emit
+// gc's ExtMsgAdapterAdded event. The key is regenerated each boot, so a
+// legitimate re-register after gc wipes its in-memory registry is NOT
+// suppressed. Registration is otherwise idempotent already — gc upserts the
+// adapter by (provider, account).
+func registerAdapterWith(cfg config, client *http.Client, rc gcRetryConfig, sleep func(time.Duration)) error {
+	if rc.maxAttempts < 1 {
+		rc.maxAttempts = 1
+	}
 	body, _ := json.Marshal(adapterRegisterRequest{
 		Provider:    cfg.provider,
 		AccountID:   cfg.accountID,
@@ -1179,22 +1244,132 @@ func registerAdapter(cfg config) error {
 	// per-call escape keeps the wire format correct regardless and matches
 	// the dispatch paths that cby-set-c hardened. gc-cby.28.
 	target := fmt.Sprintf("%s/v0/city/%s/extmsg/adapters", cfg.gcAPIBase, url.PathEscape(cfg.cityName))
-	req, err := http.NewRequest(http.MethodPost, target, bytes.NewReader(body))
-	if err != nil {
-		return err
+	idempotencyKey := newIdempotencyKey()
+
+	var lastErr error
+	for attempt := 1; attempt <= rc.maxAttempts; attempt++ {
+		req, err := http.NewRequest(http.MethodPost, target, bytes.NewReader(body))
+		if err != nil {
+			// A malformed request will not fix itself — terminal.
+			return err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("X-GC-Request", "gc-slack-adapter")
+		req.Header.Set("Idempotency-Key", idempotencyKey)
+
+		resp, err := client.Do(req)
+		if err != nil {
+			// gc API not listening yet (connection refused) — transient boot race.
+			lastErr = err
+			if attempt < rc.maxAttempts {
+				d := rc.backoffFor(attempt)
+				log.Printf("WARN: register adapter: gc API at %s not reachable yet (attempt %d/%d), retrying in %s: %v", cfg.gcAPIBase, attempt, rc.maxAttempts, d, err)
+				sleep(d)
+				continue
+			}
+			break
+		}
+		respBody, readErr := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if readErr != nil {
+			// The body classifies transient-vs-permanent (isCityNotReady); a
+			// truncated read mid-boot must not be misread as a permanent
+			// rejection. Treat it like a transport failure and retry.
+			lastErr = fmt.Errorf("register: reading %s response body: %w", resp.Status, readErr)
+			if attempt < rc.maxAttempts {
+				d := rc.backoffFor(attempt)
+				log.Printf("WARN: register adapter: incomplete response from gc (attempt %d/%d), retrying in %s: %v", attempt, rc.maxAttempts, d, readErr)
+				sleep(d)
+				continue
+			}
+			break
+		}
+		// Accept only 2xx as success. A 3xx (redirect surfaced by the
+		// no-follow client) or any other status is a failure to classify.
+		if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+			return nil
+		}
+		regErr := fmt.Errorf("register failed: %s — %s", resp.Status, string(respBody))
+		if !isCityNotReady(resp.StatusCode, respBody) && !retryableStatus(resp.StatusCode) {
+			// Permanent rejection (e.g. 400 malformed, 401/403 auth, a 3xx
+			// redirect, or a 404 that decodes to a different error code) — the
+			// same request will keep failing; fail fast and loud.
+			return regErr
+		}
+		// City not up yet (404 city-not-found) or a transient 5xx — retry.
+		lastErr = regErr
+		if attempt < rc.maxAttempts {
+			d := rc.backoffFor(attempt)
+			log.Printf("WARN: register adapter: city %q not ready yet (attempt %d/%d), retrying in %s: %s", cfg.cityName, attempt, rc.maxAttempts, d, resp.Status)
+			sleep(d)
+			continue
+		}
 	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-GC-Request", "gc-slack-adapter")
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return err
+	return fmt.Errorf("register adapter: city %q still unavailable after %d attempts — is GC_CITY_NAME correct and the city running? last error: %w", cfg.cityName, rc.maxAttempts, lastErr)
+}
+
+// newIdempotencyKey returns a random per-call key. gc's adapter-register
+// handler honors an Idempotency-Key header specifically to suppress a
+// duplicate ExtMsgAdapterAdded event when a POST is retried after a
+// committed-but-lost response. Generated once per registerAdapterWith call
+// (per boot) and reused across that call's retries, so a retry is
+// deduplicated while a fresh boot's re-register is not. Falls back to a
+// time-seeded value if the CSPRNG is unavailable — the key only needs
+// per-boot uniqueness, not cryptographic strength.
+func newIdempotencyKey() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return fmt.Sprintf("slack-adapter-%d", time.Now().UnixNano())
 	}
-	defer resp.Body.Close()
-	respBody, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode >= 400 {
-		return fmt.Errorf("register failed: %s — %s", resp.Status, string(respBody))
+	return "slack-adapter-" + hex.EncodeToString(b[:])
+}
+
+// isCityNotReady reports whether a 404 register response is gc's per-city
+// bindCity gate rejecting the POST because the city is not yet
+// running/resolvable — the transient boot-ordering condition. gc's gate
+// returns HTTP 404 carrying the structured error code "city-not-found"
+// (urn:gascity:error:city-not-found).
+//
+// Only 404 is considered here; 5xx (including the registry-not-ready 503) is
+// handled by retryableStatus. On current gc the register route's ONLY 404
+// source is this gate, so classification leans toward "not ready": a 404
+// whose body is empty, unparseable (e.g. truncated mid-boot), or carries no
+// code is treated as the boot gate and retried. Only a 404 that explicitly
+// decodes to a DIFFERENT error code is a genuine permanent rejection (a wrong
+// route / gc version skew) worth failing fast on — which also rejects a false
+// positive from a body that merely mentions "city-not-found" in some other
+// field.
+func isCityNotReady(status int, body []byte) bool {
+	if status != http.StatusNotFound {
+		return false
 	}
-	return nil
+	var env struct {
+		Code string `json:"code"`
+	}
+	if err := json.Unmarshal(body, &env); err != nil {
+		return true // unparseable / truncated 404 body — assume the boot gate
+	}
+	return env.Code == "" || env.Code == "city-not-found"
+}
+
+// bootRegisterRetryConfig is the retry budget for adapter self-registration
+// at startup. Unlike the inbound message path (a few attempts over a few
+// seconds — defaultGCRetryConfig), registration must outlast the city-boot
+// window during which gc is unreachable / 404s "city-not-found". base 1s
+// doubling to a 5s cap over 30 attempts is ~137s of backoff in the common
+// case (boot-race failures return in milliseconds); a pathological hung
+// attempt can add up to the client's per-attempt timeout on top, so the true
+// worst case is longer.
+//
+// The budget is deliberately bounded, not unbounded: if the city never comes
+// up the adapter exits loudly (the caller Fatalf's) and the supervisor's
+// proxy_process construction-retry respawns it with a fresh budget — the
+// backstop for boot windows longer than the in-process budget, and the reason
+// a bounded budget does not reintroduce permanent stranding. It is kept
+// moderate so it does not outlast gc's own service-start health grace (which
+// would otherwise preempt the retry mid-loop).
+func bootRegisterRetryConfig() gcRetryConfig {
+	return gcRetryConfig{maxAttempts: 30, baseBackoff: time.Second, maxBackoff: 5 * time.Second}
 }
 
 // publishDedupTTL bounds how long a delivered receipt is remembered for

--- a/slack-full/adapter/main.go
+++ b/slack-full/adapter/main.go
@@ -1060,6 +1060,14 @@ func main() {
 		}
 		log.Printf("registered with gc as provider=%s account=%s callback=%s/publish (%s)",
 			cfg.provider, cfg.accountID, cfg.internalCallbackURL, mode)
+
+		// Replay locally-recorded room bindings to gc. On a from-dead
+		// recovery (fresh pack cache clone / gc restart) the gc-side
+		// groups/participants/bindings are gone; this restores them from
+		// the pack's config.json so an operator no longer has to re-run
+		// `gc slack bind-room` after every such restart. Best-effort and
+		// loud — never fatal (see rehydrate.go).
+		rehydrateBindings(cfg)
 	}
 
 	janitorCtx, janitorCancel := context.WithCancel(context.Background())
@@ -2190,7 +2198,14 @@ func processSlackEvent(cfg config, aliasReg *handleAliasRegistry, threadReg *thr
 		ReceivedAt:       time.Now().UTC(),
 	}
 	if err := postInbound(cfg, inbound); err != nil {
-		log.Printf("inbound POST failed: %v", err)
+		// Loud, greppable, message-dropped log carrying the event id (ts)
+		// and channel — the old "inbound POST failed: %v" line had neither,
+		// so failures could not be correlated to a specific Slack message.
+		// Diagnose with an unfiltered time-window scan of the adapter log
+		// (this line has no "inbound:" token by design; the id-grep is for
+		// deliveries). Fields mirror the success line below.
+		log.Printf("inbound POST FAILED (message dropped): chan=%s user=%s ts=%s thread=%s target=%q files=%d text=%dch: %v",
+			msg.Channel, msg.User, msg.TS, msg.ThreadTS, target, len(attachments), len(text), err)
 		return
 	}
 	log.Printf("inbound: chan=%s user=%s ts=%s thread=%s target=%q files=%d text=%dch",
@@ -3472,26 +3487,114 @@ func handleIdentityDelete(reg *identityRegistry) http.HandlerFunc {
 	}
 }
 
+// gcRetryConfig bounds retry-with-backoff for idempotent gc API calls.
+//
+// Inbound POSTs to gc can transiently fail with a 5xx when gc's bindings
+// resolution path hits a dolt "begin read tx: invalid connection" hiccup
+// (Chris hit it live 2026-07-02 17:23:58 ET). The adapter used to treat
+// that 500 as terminal and silently drop the inbound — on the oversight
+// channel a dropped inbound can eat a page reply and hang the escalation
+// loop. Retries are safe because every inbound carries a stable DedupKey
+// ("slack-"+ts) that gc dedups on, so retrying a delivered-but-500'd POST
+// does not double-deliver. gc-side transient-retry on the same path is
+// filed separately (overseer sc-wisp-wul353); this adapter retry is
+// defense-in-depth. maxAttempts=5 with base 250ms → ~3.75s worst-case
+// backoff, a bounded hold on the dispatch slot.
+type gcRetryConfig struct {
+	maxAttempts int           // total attempts including the first (min 1)
+	baseBackoff time.Duration // backoff before the 2nd attempt; doubles each retry
+	maxBackoff  time.Duration // cap on any single backoff sleep
+}
+
+func defaultGCRetryConfig() gcRetryConfig {
+	return gcRetryConfig{
+		maxAttempts: 5,
+		baseBackoff: 250 * time.Millisecond,
+		maxBackoff:  3 * time.Second,
+	}
+}
+
+// backoffFor returns the sleep before the retry that follows attempt n
+// (1-indexed). Exponential from baseBackoff, capped at maxBackoff.
+func (rc gcRetryConfig) backoffFor(attempt int) time.Duration {
+	d := rc.baseBackoff
+	for i := 1; i < attempt; i++ {
+		if d >= rc.maxBackoff {
+			return rc.maxBackoff
+		}
+		d *= 2
+	}
+	if d > rc.maxBackoff {
+		return rc.maxBackoff
+	}
+	return d
+}
+
+// retryableStatus reports whether an HTTP status warrants a retry. 5xx is
+// server-side and typically transient; 4xx means the same request will
+// fail again, so it is terminal and returned immediately.
+func retryableStatus(code int) bool {
+	return code >= 500
+}
+
+// gcPostWithRetry POSTs jsonBody to target with the gc CSRF header,
+// retrying transport errors and 5xx responses with bounded backoff (rc).
+// label appears in log lines only. sleep is injected so tests run without
+// real delay (pass time.Sleep in production). On success (<400) it returns
+// the response body. A 4xx is returned immediately as a terminal error
+// (no retry). After the final attempt it returns an error naming the
+// attempt count and the last failure.
+func gcPostWithRetry(client *http.Client, rc gcRetryConfig, sleep func(time.Duration), target, label string, jsonBody []byte) ([]byte, error) {
+	if rc.maxAttempts < 1 {
+		rc.maxAttempts = 1
+	}
+	var lastErr error
+	for attempt := 1; attempt <= rc.maxAttempts; attempt++ {
+		req, err := http.NewRequest(http.MethodPost, target, bytes.NewReader(jsonBody))
+		if err != nil {
+			// A malformed request will not fix itself — terminal.
+			return nil, err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("X-GC-Request", "gc-slack-adapter")
+		resp, err := client.Do(req)
+		if err != nil {
+			lastErr = err
+			if attempt < rc.maxAttempts {
+				d := rc.backoffFor(attempt)
+				log.Printf("WARN: %s POST transport error (attempt %d/%d), retrying in %s: %v", label, attempt, rc.maxAttempts, d, err)
+				sleep(d)
+				continue
+			}
+			break
+		}
+		respBody, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if resp.StatusCode < 400 {
+			return respBody, nil
+		}
+		if !retryableStatus(resp.StatusCode) {
+			return nil, fmt.Errorf("%s: %s: %s", label, resp.Status, string(respBody))
+		}
+		lastErr = fmt.Errorf("%s: %s: %s", label, resp.Status, string(respBody))
+		if attempt < rc.maxAttempts {
+			d := rc.backoffFor(attempt)
+			log.Printf("WARN: %s POST %s (attempt %d/%d), retrying in %s", label, resp.Status, attempt, rc.maxAttempts, d)
+			sleep(d)
+			continue
+		}
+	}
+	return nil, fmt.Errorf("%s failed after %d attempts: %w", label, rc.maxAttempts, lastErr)
+}
+
 func postInbound(cfg config, msg externalInboundMessage) error {
 	body, _ := json.Marshal(map[string]any{
 		"message": msg,
 	})
 	// PathEscape cityName for the same reason as registerAdapter (gc-cby.28).
 	target := fmt.Sprintf("%s/v0/city/%s/extmsg/inbound", cfg.gcAPIBase, url.PathEscape(cfg.cityName))
-	req, err := http.NewRequest(http.MethodPost, target, bytes.NewReader(body))
-	if err != nil {
-		return err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-GC-Request", "gc-slack-adapter")
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode >= 400 {
-		respBody, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("%s: %s", resp.Status, string(respBody))
-	}
-	return nil
+	// Bounded retry on transport errors + 5xx (idempotent via DedupKey);
+	// see gcRetryConfig. A 4xx returns immediately as terminal.
+	_, err := gcPostWithRetry(http.DefaultClient, defaultGCRetryConfig(), time.Sleep, target, "inbound", body)
+	return err
 }

--- a/slack-full/adapter/register_retry_test.go
+++ b/slack-full/adapter/register_retry_test.go
@@ -1,0 +1,502 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// cityNotReadyBody is the exact JSON gc's per-city bindCity gate returns
+// while the city is still booting — a 404 carrying the structured
+// "city-not-found" code (urn:gascity:error:city-not-found). Reproduced from
+// the live incident log (sc-vr3ygj): every supervisor restart 404'd the
+// adapter's registration POST with this body until the city finished coming
+// up.
+const cityNotReadyBody = `{"type":"urn:gascity:error:city-not-found","title":"City Not Found","status":404,"detail":"not_found: city not found or not running: sct-city","code":"city-not-found"}`
+
+// TestRegisterAdapter_RetriesCityNotReadyThenSucceeds is the core regression:
+// registration survives the boot-ordering race. gc 404s "city-not-found"
+// while the city is still booting, then accepts once it is up; registration
+// must retry through the 404s and end REGISTERED without manual intervention.
+// Before the fix registerAdapter was one-shot and the first 404 was fatal.
+func TestRegisterAdapter_RetriesCityNotReadyThenSucceeds(t *testing.T) {
+	var n int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if attempt := atomic.AddInt32(&n, 1); attempt < 3 {
+			// City still booting: bindCity gate 404s with city-not-found.
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(cityNotReadyBody))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	sleep, slept := recordingSleep()
+	err := registerAdapterWith(testConfig("", srv.URL), srv.Client(), fastRetry(5), sleep)
+	if err != nil {
+		t.Fatalf("registration should recover once the city is up, got: %v", err)
+	}
+	if got := atomic.LoadInt32(&n); got != 3 {
+		t.Errorf("requests = %d, want 3 (2 city-not-ready 404s + 1 success)", got)
+	}
+	if len(*slept) != 2 {
+		t.Errorf("sleeps = %d, want 2 (between the 3 attempts)", len(*slept))
+	}
+}
+
+// TestRegisterAdapter_SucceedsFirstTryNoRetry: the common case — the city is
+// already up — registers on the first attempt with no backoff, so the fix
+// adds no latency to a normal boot.
+func TestRegisterAdapter_SucceedsFirstTryNoRetry(t *testing.T) {
+	var n int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&n, 1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	sleep, slept := recordingSleep()
+	if err := registerAdapterWith(testConfig("", srv.URL), srv.Client(), bootRegisterRetryConfig(), sleep); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if got := atomic.LoadInt32(&n); got != 1 {
+		t.Errorf("requests = %d, want 1 (city already up)", got)
+	}
+	if len(*slept) != 0 {
+		t.Errorf("slept %v, want none on first-try success", *slept)
+	}
+}
+
+// TestRegisterAdapter_RetriesTransportErrorThenSucceeds covers the other
+// boot-race face: the gc API process is not yet listening, so the POST fails
+// in transport (connection refused) before any HTTP status. Registration
+// must retry these too.
+func TestRegisterAdapter_RetriesTransportErrorThenSucceeds(t *testing.T) {
+	var served int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&served, 1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	client := &http.Client{Transport: &flakyTransport{failN: 2, inner: srv.Client().Transport}}
+	sleep, slept := recordingSleep()
+	err := registerAdapterWith(testConfig("", srv.URL), client, fastRetry(5), sleep)
+	if err != nil {
+		t.Fatalf("registration should recover once gc is listening, got: %v", err)
+	}
+	if got := atomic.LoadInt32(&served); got != 1 {
+		t.Errorf("server served %d, want 1 (first 2 died in transport)", got)
+	}
+	if len(*slept) != 2 {
+		t.Errorf("sleeps = %d, want 2 (two transport failures retried)", len(*slept))
+	}
+}
+
+// TestRegisterAdapter_Retries5xxThenSucceeds: a city mid-boot may briefly
+// 5xx; that is transient and reuses the inbound path's retryableStatus.
+func TestRegisterAdapter_Retries5xxThenSucceeds(t *testing.T) {
+	var n int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&n, 1) < 2 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte("gc still starting"))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	sleep, slept := recordingSleep()
+	if err := registerAdapterWith(testConfig("", srv.URL), srv.Client(), fastRetry(5), sleep); err != nil {
+		t.Fatalf("registration should retry a transient 5xx, got: %v", err)
+	}
+	if got := atomic.LoadInt32(&n); got != 2 {
+		t.Errorf("requests = %d, want 2 (1 5xx + 1 success)", got)
+	}
+	if len(*slept) != 1 {
+		t.Errorf("sleeps = %d, want 1", len(*slept))
+	}
+}
+
+// TestRegisterAdapter_ExhaustsWhenCityNeverReady: if the city genuinely never
+// comes up (or GC_CITY_NAME is wrong — indistinguishable at the wire, both
+// are city-not-found), the retry budget is bounded, not infinite, and the
+// final error names the city and attempt count so the caller's fatal log is
+// actionable.
+func TestRegisterAdapter_ExhaustsWhenCityNeverReady(t *testing.T) {
+	var n int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&n, 1)
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(cityNotReadyBody))
+	}))
+	defer srv.Close()
+
+	sleep, slept := recordingSleep()
+	err := registerAdapterWith(testConfig("", srv.URL), srv.Client(), fastRetry(4), sleep)
+	if err == nil {
+		t.Fatal("expected exhaustion error when the city never comes up, got nil")
+	}
+	if !strings.Contains(err.Error(), "after 4 attempts") {
+		t.Errorf("error should report the attempt count: %v", err)
+	}
+	if !strings.Contains(err.Error(), "sct-city") {
+		t.Errorf("error should name the city for an actionable fatal log: %v", err)
+	}
+	if !strings.Contains(err.Error(), "GC_CITY_NAME") {
+		t.Errorf("error should hint at the likely misconfiguration: %v", err)
+	}
+	if got := atomic.LoadInt32(&n); got != 4 {
+		t.Errorf("requests = %d, want 4 (all attempts made)", got)
+	}
+	if len(*slept) != 3 {
+		t.Errorf("sleeps = %d, want 3 (between 4 attempts)", len(*slept))
+	}
+}
+
+// TestRegisterAdapter_PermanentBadRequestFailsFast: a real 4xx that is not
+// city-not-found (a malformed request, an auth failure) is permanent — the
+// same request will keep failing, so it returns immediately rather than
+// burning the whole boot budget masking a genuine misconfiguration.
+func TestRegisterAdapter_PermanentBadRequestFailsFast(t *testing.T) {
+	var n int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&n, 1)
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte("malformed register request"))
+	}))
+	defer srv.Close()
+
+	sleep, slept := recordingSleep()
+	err := registerAdapterWith(testConfig("", srv.URL), srv.Client(), fastRetry(5), sleep)
+	if err == nil {
+		t.Fatal("expected a terminal error on a permanent 4xx, got nil")
+	}
+	if !strings.Contains(err.Error(), "400") {
+		t.Errorf("error should name the status: %v", err)
+	}
+	if strings.Contains(err.Error(), "after") {
+		t.Errorf("a permanent 4xx should be terminal, not an exhaustion error: %v", err)
+	}
+	if got := atomic.LoadInt32(&n); got != 1 {
+		t.Errorf("requests = %d, want 1 (permanent 4xx is not retried)", got)
+	}
+	if len(*slept) != 0 {
+		t.Errorf("slept %v, want none on a terminal 4xx", *slept)
+	}
+}
+
+// TestRegisterAdapter_GenericNotFoundFailsFast: a 404 that is NOT the
+// city-not-found gate (e.g. a genuinely wrong route / gc version skew) is
+// terminal. Only the precise city-not-found marker is treated as a boot race;
+// a bare 404 must not spin for the whole budget.
+func TestRegisterAdapter_GenericNotFoundFailsFast(t *testing.T) {
+	var n int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&n, 1)
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"code":"not-found","detail":"no such route"}`))
+	}))
+	defer srv.Close()
+
+	sleep, slept := recordingSleep()
+	err := registerAdapterWith(testConfig("", srv.URL), srv.Client(), fastRetry(5), sleep)
+	if err == nil {
+		t.Fatal("expected a terminal error on a non-city-not-found 404, got nil")
+	}
+	if strings.Contains(err.Error(), "after") {
+		t.Errorf("a generic 404 should be terminal, not an exhaustion error: %v", err)
+	}
+	if got := atomic.LoadInt32(&n); got != 1 {
+		t.Errorf("requests = %d, want 1 (a generic 404 is not retried)", got)
+	}
+	if len(*slept) != 0 {
+		t.Errorf("slept %v, want none on a terminal 404", *slept)
+	}
+}
+
+// TestRegisterAdapter_SingleAttemptFloor: maxAttempts <= 0 is floored to a
+// single attempt, never a zero- or infinite-attempt loop.
+func TestRegisterAdapter_SingleAttemptFloor(t *testing.T) {
+	var n int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&n, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	rc := gcRetryConfig{maxAttempts: 0, baseBackoff: time.Millisecond, maxBackoff: time.Millisecond}
+	if err := registerAdapterWith(testConfig("", srv.URL), srv.Client(), rc, noSleep); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if got := atomic.LoadInt32(&n); got != 1 {
+		t.Errorf("requests = %d, want exactly 1", got)
+	}
+}
+
+// TestRegisterAdapter_SendsCorrectRequest confirms the retry refactor
+// preserved the full wire contract: POST to the city-escaped adapters route,
+// the gc CSRF + content-type + Idempotency-Key headers, and the register body
+// carrying provider/account/callback/name/capabilities.
+func TestRegisterAdapter_SendsCorrectRequest(t *testing.T) {
+	type captured struct {
+		method, path, csrf, ctype, idem string
+		body                            adapterRegisterRequest
+	}
+	got := make(chan captured, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		var body adapterRegisterRequest
+		_ = json.Unmarshal(raw, &body)
+		got <- captured{
+			method: r.Method,
+			path:   r.URL.Path,
+			csrf:   r.Header.Get("X-GC-Request"),
+			ctype:  r.Header.Get("Content-Type"),
+			idem:   r.Header.Get("Idempotency-Key"),
+			body:   body,
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := config{
+		gcAPIBase:           srv.URL,
+		cityName:            "sct-city",
+		provider:            "slack",
+		accountID:           "T0BF5GQ0DNU",
+		internalCallbackURL: "http://127.0.0.1:8372/v0/city/sct-city/svc/slack",
+	}
+	if err := registerAdapterWith(cfg, srv.Client(), fastRetry(2), noSleep); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	c := <-got
+	if c.method != http.MethodPost {
+		t.Errorf("method = %s, want POST", c.method)
+	}
+	if c.path != "/v0/city/sct-city/extmsg/adapters" {
+		t.Errorf("path = %s, want /v0/city/sct-city/extmsg/adapters", c.path)
+	}
+	if c.csrf != "gc-slack-adapter" {
+		t.Errorf("X-GC-Request = %q, want gc-slack-adapter", c.csrf)
+	}
+	if c.ctype != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", c.ctype)
+	}
+	if c.idem == "" {
+		t.Error("Idempotency-Key header missing; retries would double-emit gc's ExtMsgAdapterAdded event")
+	}
+	if c.body.Provider != "slack" || c.body.AccountID != "T0BF5GQ0DNU" {
+		t.Errorf("register body provider/account = %q/%q, want slack/T0BF5GQ0DNU", c.body.Provider, c.body.AccountID)
+	}
+	if c.body.CallbackURL != cfg.internalCallbackURL {
+		t.Errorf("register body callback = %q, want %q", c.body.CallbackURL, cfg.internalCallbackURL)
+	}
+	if c.body.Name != "slack-adapter" {
+		t.Errorf("register body name = %q, want slack-adapter", c.body.Name)
+	}
+	if !c.body.Capabilities.SupportsAttachments || c.body.Capabilities.MaxMessageLength != 40000 {
+		t.Errorf("register body capabilities = %+v, want attachments + 40000 max", c.body.Capabilities)
+	}
+}
+
+// TestRegisterAdapter_SameIdempotencyKeyAcrossRetries: a boot's registration
+// retries must carry ONE stable Idempotency-Key so gc dedups the
+// ExtMsgAdapterAdded event if an earlier attempt committed but its response
+// was lost; a distinct boot gets a distinct key (verified separately by the
+// value being non-empty and per-call).
+func TestRegisterAdapter_SameIdempotencyKeyAcrossRetries(t *testing.T) {
+	var mu sync.Mutex
+	var keys []string
+	var n int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		keys = append(keys, r.Header.Get("Idempotency-Key"))
+		mu.Unlock()
+		if atomic.AddInt32(&n, 1) < 3 {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(cityNotReadyBody))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	if err := registerAdapterWith(testConfig("", srv.URL), srv.Client(), fastRetry(5), noSleep); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(keys) != 3 {
+		t.Fatalf("server saw %d requests, want 3", len(keys))
+	}
+	if keys[0] == "" {
+		t.Fatal("Idempotency-Key was empty")
+	}
+	for i, k := range keys {
+		if k != keys[0] {
+			t.Errorf("Idempotency-Key[%d] = %q, want stable %q across the boot's retries", i, k, keys[0])
+		}
+	}
+}
+
+// TestRegisterAdapter_TransportErrorExhausts covers the transport-error arm on
+// the FINAL attempt (the break path + lastErr wrapping): gc never becomes
+// reachable, so every attempt dies in transport and the budget exhausts.
+func TestRegisterAdapter_TransportErrorExhausts(t *testing.T) {
+	// A transport that always fails the dial — gc never comes up.
+	client := &http.Client{Transport: &flakyTransport{failN: 1 << 30, inner: http.DefaultTransport}}
+	sleep, slept := recordingSleep()
+	err := registerAdapterWith(testConfig("", "http://127.0.0.1:0"), client, fastRetry(3), sleep)
+	if err == nil {
+		t.Fatal("expected exhaustion error when gc never becomes reachable, got nil")
+	}
+	if !strings.Contains(err.Error(), "after 3 attempts") {
+		t.Errorf("error should report the attempt count: %v", err)
+	}
+	if !strings.Contains(err.Error(), "connection refused") {
+		t.Errorf("error should wrap the last transport failure: %v", err)
+	}
+	if len(*slept) != 2 {
+		t.Errorf("sleeps = %d, want 2 (between 3 attempts)", len(*slept))
+	}
+}
+
+// TestRegisterAdapter_RedirectFailsFast: the production client does not follow
+// redirects, so a 3xx (e.g. a misconfigured base URL that 302s to a login) is
+// surfaced and must be treated as a permanent failure — never a false success.
+func TestRegisterAdapter_RedirectFailsFast(t *testing.T) {
+	var n int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&n, 1)
+		http.Redirect(w, r, "https://example.invalid/login", http.StatusFound)
+	}))
+	defer srv.Close()
+
+	// Mirror the production no-follow client.
+	client := &http.Client{
+		Timeout:       5 * time.Second,
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+	}
+	sleep, slept := recordingSleep()
+	err := registerAdapterWith(testConfig("", srv.URL), client, fastRetry(5), sleep)
+	if err == nil {
+		t.Fatal("expected a terminal error on a 3xx redirect, got nil (false success)")
+	}
+	if strings.Contains(err.Error(), "after") {
+		t.Errorf("a redirect should be terminal, not an exhaustion error: %v", err)
+	}
+	if got := atomic.LoadInt32(&n); got != 1 {
+		t.Errorf("requests = %d, want 1 (redirect is not retried)", got)
+	}
+	if len(*slept) != 0 {
+		t.Errorf("slept %v, want none on a terminal redirect", *slept)
+	}
+}
+
+// TestRegisterAdapter_BodyReadErrorRetries: a response whose body errors
+// mid-read (truncated mid-boot) classifies transient-vs-permanent, so it must
+// be retried like a transport failure, not misread as a permanent rejection.
+func TestRegisterAdapter_BodyReadErrorRetries(t *testing.T) {
+	var n int32
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if atomic.AddInt32(&n, 1) < 2 {
+			return &http.Response{
+				StatusCode: http.StatusNotFound,
+				Status:     "404 Not Found",
+				Body:       io.NopCloser(errReader{}),
+				Header:     make(http.Header),
+				Request:    r,
+			}, nil
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+			Header:     make(http.Header),
+			Request:    r,
+		}, nil
+	})}
+	sleep, slept := recordingSleep()
+	if err := registerAdapterWith(testConfig("", "http://gc.invalid"), client, fastRetry(5), sleep); err != nil {
+		t.Fatalf("a mid-read body error should be retried, got: %v", err)
+	}
+	if got := atomic.LoadInt32(&n); got != 2 {
+		t.Errorf("requests = %d, want 2 (1 read-error retry + 1 success)", got)
+	}
+	if len(*slept) != 1 {
+		t.Errorf("sleeps = %d, want 1", len(*slept))
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+// errReader fails on the first Read, simulating a connection dropped after
+// the response headers but before the body is fully delivered.
+type errReader struct{}
+
+func (errReader) Read([]byte) (int, error) { return 0, io.ErrUnexpectedEOF }
+
+func TestIsCityNotReady(t *testing.T) {
+	cases := []struct {
+		name   string
+		status int
+		body   string
+		want   bool
+	}{
+		{"boot-race 404 city-not-found", http.StatusNotFound, cityNotReadyBody, true},
+		// A 404 that decodes to a DIFFERENT code is a genuine permanent
+		// rejection (wrong route / version skew) — fail fast, not the gate.
+		{"404 explicit different code", http.StatusNotFound, `{"code":"route-not-found"}`, false},
+		// codex-flagged false positive: "city-not-found" appears in a non-code
+		// field but the code is something else — must NOT be treated as the gate.
+		{"404 marker only in detail field", http.StatusNotFound, `{"code":"route-not-found","detail":"upstream said city-not-found"}`, false},
+		// Lean toward "not ready" when the body cannot pin down a different
+		// code: on this route the only 404 source is the boot gate, and a
+		// truncated/odd body mid-boot must retry, not strand.
+		{"empty 404 (truncated mid-boot)", http.StatusNotFound, "", true},
+		{"non-JSON 404 body", http.StatusNotFound, "not found", true},
+		{"404 JSON with no code field", http.StatusNotFound, `{"detail":"nope"}`, true},
+		// Status gating: 5xx/2xx/other are not this predicate's job.
+		{"503 with marker is not 404", http.StatusServiceUnavailable, cityNotReadyBody, false},
+		{"200 ok", http.StatusOK, `{"ok":true}`, false},
+		{"400 bad request", http.StatusBadRequest, `{"code":"city-not-found"}`, false},
+	}
+	for _, c := range cases {
+		if got := isCityNotReady(c.status, []byte(c.body)); got != c.want {
+			t.Errorf("%s: isCityNotReady(%d, %q) = %v, want %v", c.name, c.status, c.body, got, c.want)
+		}
+	}
+}
+
+// TestBootRegisterRetryConfig documents the boot budget: it must outlast a
+// real city boot (well over the inbound path's few seconds) yet stay bounded.
+func TestBootRegisterRetryConfig(t *testing.T) {
+	rc := bootRegisterRetryConfig()
+	if rc.maxAttempts < 20 {
+		t.Errorf("maxAttempts = %d, want >= 20 to outlast a slow boot", rc.maxAttempts)
+	}
+	// Sum the backoff schedule to assert the wall-clock budget spans minutes,
+	// not the inbound path's seconds.
+	var total time.Duration
+	for attempt := 1; attempt < rc.maxAttempts; attempt++ {
+		total += rc.backoffFor(attempt)
+	}
+	if total < 90*time.Second {
+		t.Errorf("worst-case budget = %s, want >= 90s to cover an unhurried boot", total)
+	}
+}

--- a/slack-full/adapter/rehydrate.go
+++ b/slack-full/adapter/rehydrate.go
@@ -1,0 +1,233 @@
+package main
+
+// rehydrate.go — replay locally-recorded room bindings to gc after the
+// adapter (re-)registers.
+//
+// Why: gc-side conversation groups / participants / bindings do NOT
+// rehydrate when the adapter re-registers after a from-dead recovery
+// (fresh pack cache clone / gc restart). The pack's `bind-room` command
+// records every binding it creates under
+//
+//	<GC_CITY_PATH>/.gc/services/slack/data/config.json
+//
+// so on (re-)registration this replays those records back to gc,
+// restoring bindings that would otherwise present as "no active binding"
+// 422s — without a human re-running `gc slack bind-room`.
+//
+// Faithful to scripts/slack_chat_bind_room.py's POST sequence:
+//
+//	1. POST /extmsg/groups       {root_conversation, mode:"launcher", default_handle, [fanout_policy]}
+//	2. POST /extmsg/participants {group_id, handle, session_id, public:true}   (per participant)
+//	3. POST /extmsg/bind         {session_id: binding_owner, conversation}     (if an owner was recorded)
+//
+// Idempotency: /extmsg/groups is ensure-by-root_conversation and
+// /extmsg/participants is upsert — bind_room.py re-runs both on every
+// re-bind with no conflict handling, so they must be idempotent.
+// /extmsg/bind is 1:1 per conversation and returns a conflict when the
+// conversation is already bound (the clean-restart case); that conflict is
+// the desired end-state, so it is tolerated, not treated as a failure.
+//
+// Every step is best-effort and LOUD: a failure is logged and the next
+// binding still runs; the adapter never dies on a rehydrate error (a human
+// `gc slack bind-room` stays the documented fallback). REVIEW NOTE: the
+// group ensure-semantics assumption is inferred from bind_room.py (the gc
+// source is not in this repo) — worth a live confirmation before landing.
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// packStateConfig mirrors the subset of
+// <GC_CITY_PATH>/.gc/services/slack/data/config.json written by
+// slack_chat_bind_room.py that rehydration needs.
+type packStateConfig struct {
+	Bindings map[string]storedBinding `json:"bindings"`
+}
+
+type storedBinding struct {
+	Kind          string              `json:"kind"`
+	Conversation  conversationRef     `json:"conversation"`
+	GroupID       string              `json:"group_id"`
+	DefaultHandle string              `json:"default_handle"`
+	FanoutPolicy  json.RawMessage     `json:"fanout_policy"` // opaque; may be JSON null
+	Participants  []storedParticipant `json:"participants"`
+	BindingOwner  string              `json:"binding_owner"` // may be "" / JSON null
+}
+
+type storedParticipant struct {
+	Handle      string `json:"handle"`
+	SessionName string `json:"session_name"`
+}
+
+type rehydrateSummary struct {
+	total    int
+	restored int
+	failed   int
+}
+
+// packConfigPath is the on-disk location bind_room.py writes bindings to,
+// rooted at GC_CITY_PATH (see slack_intake_common.pack_state_dir).
+func packConfigPath(cityPath string) string {
+	return filepath.Join(cityPath, ".gc", "services", "slack", "data", "config.json")
+}
+
+// rehydrateBindings loads the pack binding config and replays every
+// recorded binding to gc. Best-effort and non-fatal — see file header.
+func rehydrateBindings(cfg config) rehydrateSummary {
+	return rehydrateBindingsWith(cfg, http.DefaultClient, defaultGCRetryConfig(), time.Sleep)
+}
+
+// rehydrateBindingsWith is the testable core: the HTTP client, retry
+// policy, and sleep are injected.
+func rehydrateBindingsWith(cfg config, client *http.Client, rc gcRetryConfig, sleep func(time.Duration)) rehydrateSummary {
+	var sum rehydrateSummary
+	if cfg.cityPath == "" {
+		log.Printf("WARN: binding rehydrate skipped: GC_CITY_PATH unset, cannot locate pack config")
+		return sum
+	}
+	path := packConfigPath(cfg.cityPath)
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			log.Printf("binding rehydrate: no pack config at %s (nothing to rehydrate)", path)
+			return sum
+		}
+		log.Printf("WARN: binding rehydrate: cannot read %s: %v", path, err)
+		return sum
+	}
+	var pc packStateConfig
+	if err := json.Unmarshal(raw, &pc); err != nil {
+		log.Printf("WARN: binding rehydrate: corrupt pack config %s: %v", path, err)
+		return sum
+	}
+	if len(pc.Bindings) == 0 {
+		log.Printf("binding rehydrate: pack config has no bindings (nothing to rehydrate)")
+		return sum
+	}
+
+	// Deterministic order for stable, greppable logs.
+	keys := make([]string, 0, len(pc.Bindings))
+	for k := range pc.Bindings {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	log.Printf("binding rehydrate: replaying %d binding(s) from %s", len(keys), path)
+	for _, key := range keys {
+		sum.total++
+		if err := rehydrateOne(cfg, client, rc, sleep, key, pc.Bindings[key]); err != nil {
+			log.Printf("WARN: binding rehydrate: %s FAILED (run `gc slack bind-room` to restore it): %v", key, err)
+			sum.failed++
+			continue
+		}
+		sum.restored++
+	}
+	log.Printf("binding rehydrate: done — %d/%d restored (%d failed)", sum.restored, sum.total, sum.failed)
+	return sum
+}
+
+// rehydrateOne replays a single stored binding's group → participants →
+// bind sequence. Returns an error only for a genuine, unrecovered failure
+// (a bind conflict is tolerated as the already-bound end-state).
+func rehydrateOne(cfg config, client *http.Client, rc gcRetryConfig, sleep func(time.Duration), key string, b storedBinding) error {
+	base := fmt.Sprintf("%s/v0/city/%s", cfg.gcAPIBase, url.PathEscape(cfg.cityName))
+
+	// 1. ensure the launcher-mode group exists (idempotent by root_conversation).
+	groupBody := map[string]any{
+		"root_conversation": b.Conversation,
+		"mode":              "launcher",
+		"default_handle":    b.DefaultHandle,
+	}
+	if hasFanoutPolicy(b.FanoutPolicy) {
+		groupBody["fanout_policy"] = b.FanoutPolicy
+	}
+	gb, err := json.Marshal(groupBody)
+	if err != nil {
+		return fmt.Errorf("marshal group: %w", err)
+	}
+	respBody, err := gcPostWithRetry(client, rc, sleep, base+"/extmsg/groups", "rehydrate-group["+key+"]", gb)
+	if err != nil {
+		return fmt.Errorf("ensure group: %w", err)
+	}
+	var groupResp struct {
+		ID string `json:"ID"`
+	}
+	if err := json.Unmarshal(respBody, &groupResp); err != nil {
+		return fmt.Errorf("parse group response: %w", err)
+	}
+	groupID := groupResp.ID
+	if groupID == "" {
+		groupID = b.GroupID // fall back to the recorded id if gc echoed none
+	}
+	if groupID == "" {
+		return fmt.Errorf("ensure group: neither response nor record carried a group id")
+	}
+
+	// 2. upsert each participant membership (idempotent).
+	for _, p := range b.Participants {
+		pb, err := json.Marshal(map[string]any{
+			"group_id":   groupID,
+			"handle":     p.Handle,
+			"session_id": p.SessionName,
+			"public":     true,
+		})
+		if err != nil {
+			return fmt.Errorf("marshal participant %s: %w", p.Handle, err)
+		}
+		if _, err := gcPostWithRetry(client, rc, sleep, base+"/extmsg/participants", "rehydrate-participant["+p.Handle+"]", pb); err != nil {
+			return fmt.Errorf("upsert participant %s=%s: %w", p.Handle, p.SessionName, err)
+		}
+	}
+
+	// 3. re-bind the publisher/owner (required for /extmsg/outbound). A
+	// conflict means the binding already exists — the desired state.
+	if b.BindingOwner != "" {
+		bb, err := json.Marshal(map[string]any{
+			"session_id":   b.BindingOwner,
+			"conversation": b.Conversation,
+		})
+		if err != nil {
+			return fmt.Errorf("marshal bind: %w", err)
+		}
+		if _, err := gcPostWithRetry(client, rc, sleep, base+"/extmsg/bind", "rehydrate-bind["+b.BindingOwner+"]", bb); err != nil {
+			if isBindingConflict(err) {
+				log.Printf("binding rehydrate: %s already bound to %s (conflict tolerated)", key, b.BindingOwner)
+			} else {
+				return fmt.Errorf("bind owner %s: %w", b.BindingOwner, err)
+			}
+		}
+	}
+
+	log.Printf("binding rehydrate: %s restored (group=%s participants=%d owner=%q)", key, groupID, len(b.Participants), b.BindingOwner)
+	return nil
+}
+
+// hasFanoutPolicy reports whether a recorded fanout_policy value is a real
+// object rather than absent or JSON null.
+func hasFanoutPolicy(raw json.RawMessage) bool {
+	s := strings.TrimSpace(string(raw))
+	return s != "" && s != "null"
+}
+
+// isBindingConflict reports whether err looks like gc rejecting a bind
+// because the conversation is already bound (clean-restart case), in which
+// case the existing binding is the desired end-state and the bind is a
+// no-op success rather than a failure.
+func isBindingConflict(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := strings.ToLower(err.Error())
+	return strings.Contains(s, "409") ||
+		strings.Contains(s, "conflict") ||
+		strings.Contains(s, "already bound")
+}

--- a/slack-full/adapter/rehydrate_test.go
+++ b/slack-full/adapter/rehydrate_test.go
@@ -1,0 +1,440 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// --- test harness ---------------------------------------------------------
+
+type recordedReq struct {
+	method string
+	path   string
+	body   map[string]any
+}
+
+// rehydrateStub is a recording gc API used to assert the exact replay sequence.
+// resp lets a test inject a status + body per (path, nth-hit); returning
+// status 0 means "use the default 200 with defaultBody".
+type rehydrateStub struct {
+	mu          sync.Mutex
+	reqs        []recordedReq
+	hits        map[string]int
+	resp        func(path string, nth int) (int, string)
+	defaultBody string
+}
+
+func newRehydrateStub(resp func(path string, nth int) (int, string)) *rehydrateStub {
+	return &rehydrateStub{hits: map[string]int{}, resp: resp, defaultBody: `{}`}
+}
+
+func (s *rehydrateStub) server(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		var body map[string]any
+		_ = json.Unmarshal(raw, &body)
+		s.mu.Lock()
+		s.hits[r.URL.Path]++
+		nth := s.hits[r.URL.Path]
+		s.reqs = append(s.reqs, recordedReq{method: r.Method, path: r.URL.Path, body: body})
+		s.mu.Unlock()
+		status, respBody := 200, s.defaultBody
+		if s.resp != nil {
+			if st, b := s.resp(r.URL.Path, nth); st != 0 {
+				status, respBody = st, b
+			}
+		}
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(respBody))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func (s *rehydrateStub) requestsFor(suffix string) []recordedReq {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []recordedReq
+	for _, r := range s.reqs {
+		if strings.HasSuffix(r.path, suffix) {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+func (s *rehydrateStub) orderedSuffixes() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []string
+	for _, r := range s.reqs {
+		i := strings.LastIndex(r.path, "/extmsg/")
+		if i >= 0 {
+			out = append(out, r.path[i:])
+		}
+	}
+	return out
+}
+
+func writeConfig(t *testing.T, cityPath, contents string) {
+	t.Helper()
+	dir := filepath.Join(cityPath, ".gc", "services", "slack", "data")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config.json"), []byte(contents), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func testConfig(cityPath, gcURL string) config {
+	return config{cityPath: cityPath, gcAPIBase: gcURL, cityName: "sct-city"}
+}
+
+func noSleep(time.Duration) {}
+
+const oversightConfigJSON = `{
+  "version": 1,
+  "bindings": {
+    "room:C0BED9MRXH7": {
+      "kind": "room",
+      "conversation": {
+        "scope_id": "sct-city",
+        "provider": "slack",
+        "account_id": "T0BF5GQ0DNU",
+        "conversation_id": "C0BED9MRXH7",
+        "kind": "room"
+      },
+      "group_id": "grp_old_123",
+      "default_handle": "mayor",
+      "fanout_policy": {"enabled": true, "allow_untargeted_publication": true, "max_peer_triggered_publishes": 8, "max_total_peer_deliveries": 24},
+      "participants": [
+        {"handle": "mayor", "session_name": "oversight-rig.mayor"},
+        {"handle": "geo-pl", "session_name": "geo/oversight-rig.project-lead"}
+      ],
+      "binding_owner": "gc-77139",
+      "binding_record": "bnd_old_456"
+    }
+  }
+}`
+
+// --- tests ----------------------------------------------------------------
+
+func TestRehydrate_FullReplaySequence(t *testing.T) {
+	stub := newRehydrateStub(func(path string, nth int) (int, string) {
+		if strings.HasSuffix(path, "/extmsg/groups") {
+			return 200, `{"ID":"grp_new_789"}`
+		}
+		return 0, ""
+	})
+	srv := stub.server(t)
+	cityPath := t.TempDir()
+	writeConfig(t, cityPath, oversightConfigJSON)
+
+	sum := rehydrateBindingsWith(testConfig(cityPath, srv.URL), srv.Client(), fastRetry(3), noSleep)
+
+	if sum.total != 1 || sum.restored != 1 || sum.failed != 0 {
+		t.Fatalf("summary = %+v, want total1 restored1 failed0", sum)
+	}
+
+	// order: group, then both participants, then bind.
+	got := stub.orderedSuffixes()
+	want := []string{"/extmsg/groups", "/extmsg/participants", "/extmsg/participants", "/extmsg/bind"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("call order = %v, want %v", got, want)
+	}
+
+	// group body
+	groups := stub.requestsFor("/extmsg/groups")
+	if len(groups) != 1 {
+		t.Fatalf("group calls = %d, want 1", len(groups))
+	}
+	gb := groups[0].body
+	if gb["mode"] != "launcher" {
+		t.Errorf("group mode = %v, want launcher", gb["mode"])
+	}
+	if gb["default_handle"] != "mayor" {
+		t.Errorf("group default_handle = %v, want mayor", gb["default_handle"])
+	}
+	rc, _ := gb["root_conversation"].(map[string]any)
+	if rc["conversation_id"] != "C0BED9MRXH7" {
+		t.Errorf("root_conversation.conversation_id = %v", rc["conversation_id"])
+	}
+	if rc["account_id"] != "T0BF5GQ0DNU" {
+		t.Errorf("root_conversation.account_id = %v", rc["account_id"])
+	}
+	fp, ok := gb["fanout_policy"].(map[string]any)
+	if !ok {
+		t.Fatalf("fanout_policy missing/wrong type: %v", gb["fanout_policy"])
+	}
+	if fp["enabled"] != true {
+		t.Errorf("fanout_policy.enabled = %v, want true", fp["enabled"])
+	}
+
+	// participants use the RETURNED group id, not the stored stale one.
+	parts := stub.requestsFor("/extmsg/participants")
+	if len(parts) != 2 {
+		t.Fatalf("participant calls = %d, want 2", len(parts))
+	}
+	seen := map[string]string{}
+	for _, p := range parts {
+		if p.body["group_id"] != "grp_new_789" {
+			t.Errorf("participant group_id = %v, want returned grp_new_789 (not stored grp_old_123)", p.body["group_id"])
+		}
+		if p.body["public"] != true {
+			t.Errorf("participant public = %v, want true", p.body["public"])
+		}
+		seen[p.body["handle"].(string)] = p.body["session_id"].(string)
+	}
+	if seen["mayor"] != "oversight-rig.mayor" || seen["geo-pl"] != "geo/oversight-rig.project-lead" {
+		t.Errorf("participant handle→session map wrong: %v", seen)
+	}
+
+	// bind body
+	binds := stub.requestsFor("/extmsg/bind")
+	if len(binds) != 1 {
+		t.Fatalf("bind calls = %d, want 1", len(binds))
+	}
+	if binds[0].body["session_id"] != "gc-77139" {
+		t.Errorf("bind session_id = %v, want gc-77139", binds[0].body["session_id"])
+	}
+	bc, _ := binds[0].body["conversation"].(map[string]any)
+	if bc["conversation_id"] != "C0BED9MRXH7" {
+		t.Errorf("bind conversation_id = %v", bc["conversation_id"])
+	}
+}
+
+func TestRehydrate_BindConflictTolerated(t *testing.T) {
+	stub := newRehydrateStub(func(path string, nth int) (int, string) {
+		if strings.HasSuffix(path, "/extmsg/groups") {
+			return 200, `{"ID":"grp1"}`
+		}
+		if strings.HasSuffix(path, "/extmsg/bind") {
+			// gc rejects a re-bind of an already-bound conversation.
+			return 409, "ErrBindingConflict: conversation already bound"
+		}
+		return 0, ""
+	})
+	srv := stub.server(t)
+	cityPath := t.TempDir()
+	writeConfig(t, cityPath, oversightConfigJSON)
+
+	sum := rehydrateBindingsWith(testConfig(cityPath, srv.URL), srv.Client(), fastRetry(3), noSleep)
+
+	// A bind conflict is the desired already-bound state — still restored.
+	if sum.restored != 1 || sum.failed != 0 {
+		t.Fatalf("summary = %+v, want restored1 failed0 (conflict tolerated)", sum)
+	}
+	// The conflict is a 4xx, so it must NOT have been retried.
+	if n := len(stub.requestsFor("/extmsg/bind")); n != 1 {
+		t.Errorf("bind attempts = %d, want 1 (409 is terminal, tolerated)", n)
+	}
+}
+
+func TestRehydrate_GroupFailureCountsAsFailed(t *testing.T) {
+	stub := newRehydrateStub(func(path string, nth int) (int, string) {
+		if strings.HasSuffix(path, "/extmsg/groups") {
+			return 500, "gc down"
+		}
+		return 0, ""
+	})
+	srv := stub.server(t)
+	cityPath := t.TempDir()
+	writeConfig(t, cityPath, oversightConfigJSON)
+
+	sum := rehydrateBindingsWith(testConfig(cityPath, srv.URL), srv.Client(), fastRetry(3), noSleep)
+
+	if sum.total != 1 || sum.restored != 0 || sum.failed != 1 {
+		t.Fatalf("summary = %+v, want total1 restored0 failed1", sum)
+	}
+	// group retried up to maxAttempts; participants/bind never reached.
+	if n := len(stub.requestsFor("/extmsg/groups")); n != 3 {
+		t.Errorf("group attempts = %d, want 3 (retried to exhaustion)", n)
+	}
+	if n := len(stub.requestsFor("/extmsg/participants")); n != 0 {
+		t.Errorf("participant calls = %d, want 0 (group never succeeded)", n)
+	}
+}
+
+func TestRehydrate_5xxOnGroupThenSucceeds(t *testing.T) {
+	stub := newRehydrateStub(func(path string, nth int) (int, string) {
+		if strings.HasSuffix(path, "/extmsg/groups") {
+			if nth < 3 {
+				return 500, "transient"
+			}
+			return 200, `{"ID":"grp1"}`
+		}
+		return 0, ""
+	})
+	srv := stub.server(t)
+	cityPath := t.TempDir()
+	writeConfig(t, cityPath, oversightConfigJSON)
+
+	sum := rehydrateBindingsWith(testConfig(cityPath, srv.URL), srv.Client(), fastRetry(5), noSleep)
+
+	if sum.restored != 1 {
+		t.Fatalf("summary = %+v, want restored1 after transient 5xx", sum)
+	}
+	if n := len(stub.requestsFor("/extmsg/groups")); n != 3 {
+		t.Errorf("group attempts = %d, want 3 (2 x 500 then 200)", n)
+	}
+}
+
+func TestRehydrate_NoOwnerNoFanout(t *testing.T) {
+	const cfgJSON = `{
+      "bindings": {
+        "room:C1": {
+          "kind": "room",
+          "conversation": {"scope_id":"sct-city","provider":"slack","account_id":"T0","conversation_id":"C1","kind":"room"},
+          "group_id": "g1",
+          "default_handle": "solo",
+          "fanout_policy": null,
+          "participants": [{"handle":"solo","session_name":"rig.solo"}],
+          "binding_owner": null,
+          "binding_record": null
+        }
+      }
+    }`
+	stub := newRehydrateStub(func(path string, nth int) (int, string) {
+		if strings.HasSuffix(path, "/extmsg/groups") {
+			return 200, `{"ID":"g1"}`
+		}
+		return 0, ""
+	})
+	srv := stub.server(t)
+	cityPath := t.TempDir()
+	writeConfig(t, cityPath, cfgJSON)
+
+	sum := rehydrateBindingsWith(testConfig(cityPath, srv.URL), srv.Client(), fastRetry(3), noSleep)
+
+	if sum.restored != 1 {
+		t.Fatalf("summary = %+v, want restored1", sum)
+	}
+	// no owner → no bind call.
+	if n := len(stub.requestsFor("/extmsg/bind")); n != 0 {
+		t.Errorf("bind calls = %d, want 0 (no binding_owner)", n)
+	}
+	// null fanout_policy → key omitted from the group body.
+	groups := stub.requestsFor("/extmsg/groups")
+	if len(groups) != 1 {
+		t.Fatalf("group calls = %d, want 1", len(groups))
+	}
+	if _, present := groups[0].body["fanout_policy"]; present {
+		t.Errorf("fanout_policy should be omitted when null, got %v", groups[0].body["fanout_policy"])
+	}
+}
+
+func TestRehydrate_MissingConfigIsNoOp(t *testing.T) {
+	stub := newRehydrateStub(nil)
+	srv := stub.server(t)
+	cityPath := t.TempDir() // no config.json written
+
+	sum := rehydrateBindingsWith(testConfig(cityPath, srv.URL), srv.Client(), fastRetry(3), noSleep)
+
+	if sum.total != 0 || sum.restored != 0 || sum.failed != 0 {
+		t.Fatalf("summary = %+v, want all zero on missing config", sum)
+	}
+	if len(stub.reqs) != 0 {
+		t.Errorf("made %d gc calls, want 0 on missing config", len(stub.reqs))
+	}
+}
+
+func TestRehydrate_EmptyBindingsIsNoOp(t *testing.T) {
+	stub := newRehydrateStub(nil)
+	srv := stub.server(t)
+	cityPath := t.TempDir()
+	writeConfig(t, cityPath, `{"version":1,"bindings":{}}`)
+
+	sum := rehydrateBindingsWith(testConfig(cityPath, srv.URL), srv.Client(), fastRetry(3), noSleep)
+
+	if sum.total != 0 {
+		t.Fatalf("summary = %+v, want zero on empty bindings", sum)
+	}
+	if len(stub.reqs) != 0 {
+		t.Errorf("made %d gc calls, want 0", len(stub.reqs))
+	}
+}
+
+func TestRehydrate_NoCityPathIsNoOp(t *testing.T) {
+	stub := newRehydrateStub(nil)
+	srv := stub.server(t)
+
+	sum := rehydrateBindingsWith(testConfig("", srv.URL), srv.Client(), fastRetry(3), noSleep)
+
+	if sum.total != 0 {
+		t.Fatalf("summary = %+v, want zero when GC_CITY_PATH unset", sum)
+	}
+	if len(stub.reqs) != 0 {
+		t.Errorf("made %d gc calls, want 0 with no cityPath", len(stub.reqs))
+	}
+}
+
+func TestRehydrate_CorruptConfigIsNoOp(t *testing.T) {
+	stub := newRehydrateStub(nil)
+	srv := stub.server(t)
+	cityPath := t.TempDir()
+	writeConfig(t, cityPath, `{"bindings": {`) // truncated JSON
+
+	sum := rehydrateBindingsWith(testConfig(cityPath, srv.URL), srv.Client(), fastRetry(3), noSleep)
+
+	if sum.total != 0 || sum.failed != 0 {
+		t.Fatalf("summary = %+v, want zero on corrupt config (no crash, no calls)", sum)
+	}
+	if len(stub.reqs) != 0 {
+		t.Errorf("made %d gc calls, want 0 on corrupt config", len(stub.reqs))
+	}
+}
+
+func TestHasFanoutPolicy(t *testing.T) {
+	cases := map[string]bool{
+		``:                 false,
+		`null`:             false,
+		`  null `:          false,
+		`{}`:               true,
+		`{"enabled":true}`: true,
+	}
+	for in, want := range cases {
+		if got := hasFanoutPolicy(json.RawMessage(in)); got != want {
+			t.Errorf("hasFanoutPolicy(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+func TestIsBindingConflict(t *testing.T) {
+	yes := []string{
+		"rehydrate-bind: 409 Conflict: x",
+		"bind: ErrBindingConflict",
+		"already bound to this conversation",
+	}
+	for _, s := range yes {
+		if !isBindingConflict(errString(s)) {
+			t.Errorf("isBindingConflict(%q) = false, want true", s)
+		}
+	}
+	no := []string{
+		"500 Internal Server Error",
+		"connection refused",
+		"404 not found",
+	}
+	for _, s := range no {
+		if isBindingConflict(errString(s)) {
+			t.Errorf("isBindingConflict(%q) = true, want false", s)
+		}
+	}
+	if isBindingConflict(nil) {
+		t.Error("isBindingConflict(nil) = true, want false")
+	}
+}
+
+type errString string
+
+func (e errString) Error() string { return string(e) }

--- a/slack-full/adapter/retry_test.go
+++ b/slack-full/adapter/retry_test.go
@@ -1,0 +1,248 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestBackoffFor(t *testing.T) {
+	rc := gcRetryConfig{maxAttempts: 5, baseBackoff: 250 * time.Millisecond, maxBackoff: 3 * time.Second}
+	cases := []struct {
+		attempt int
+		want    time.Duration
+	}{
+		{1, 250 * time.Millisecond},
+		{2, 500 * time.Millisecond},
+		{3, 1 * time.Second},
+		{4, 2 * time.Second},
+		{5, 3 * time.Second}, // 4s capped to 3s
+		{6, 3 * time.Second}, // stays capped
+	}
+	for _, c := range cases {
+		if got := rc.backoffFor(c.attempt); got != c.want {
+			t.Errorf("backoffFor(%d) = %s, want %s", c.attempt, got, c.want)
+		}
+	}
+}
+
+func TestRetryableStatus(t *testing.T) {
+	for code, want := range map[int]bool{
+		200: false, 201: false, 400: false, 401: false, 404: false,
+		409: false, 422: false, 499: false, 500: true, 502: true, 503: true, 504: true,
+	} {
+		if got := retryableStatus(code); got != want {
+			t.Errorf("retryableStatus(%d) = %v, want %v", code, got, want)
+		}
+	}
+}
+
+// fastRetry keeps the backoff loop bounded but non-zero so tests exercise
+// the sleep path without real latency (the injected sleep is a no-op).
+func fastRetry(maxAttempts int) gcRetryConfig {
+	return gcRetryConfig{maxAttempts: maxAttempts, baseBackoff: time.Millisecond, maxBackoff: 4 * time.Millisecond}
+}
+
+func recordingSleep() (func(time.Duration), *[]time.Duration) {
+	var slept []time.Duration
+	return func(d time.Duration) { slept = append(slept, d) }, &slept
+}
+
+func TestGCPostWithRetry_SuccessFirstTry(t *testing.T) {
+	var n int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&n, 1)
+		if r.Header.Get("X-GC-Request") != "gc-slack-adapter" {
+			t.Errorf("missing/wrong CSRF header: %q", r.Header.Get("X-GC-Request"))
+		}
+		if ct := r.Header.Get("Content-Type"); ct != "application/json" {
+			t.Errorf("Content-Type = %q, want application/json", ct)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	sleep, slept := recordingSleep()
+	body, err := gcPostWithRetry(srv.Client(), defaultGCRetryConfig(), sleep, srv.URL, "inbound", []byte(`{"x":1}`))
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if string(body) != `{"ok":true}` {
+		t.Errorf("body = %s, want {\"ok\":true}", body)
+	}
+	if got := atomic.LoadInt32(&n); got != 1 {
+		t.Errorf("requests = %d, want 1", got)
+	}
+	if len(*slept) != 0 {
+		t.Errorf("slept %v, want no sleeps on first-try success", *slept)
+	}
+}
+
+func TestGCPostWithRetry_RetriesOn5xxThenSucceeds(t *testing.T) {
+	var n int32
+	var mu sync.Mutex
+	var gotBodies []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		gotBodies = append(gotBodies, string(b))
+		mu.Unlock()
+		if atomic.AddInt32(&n, 1) < 3 {
+			// Emulate the live dolt transient that caused silent drops.
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte("resolving binding ... begin read tx: invalid connection"))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	sleep, slept := recordingSleep()
+	body, err := gcPostWithRetry(srv.Client(), fastRetry(5), sleep, srv.URL, "inbound", []byte(`{"x":1}`))
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if string(body) != `{"ok":true}` {
+		t.Errorf("body = %s, want success body", body)
+	}
+	if got := atomic.LoadInt32(&n); got != 3 {
+		t.Errorf("requests = %d, want 3 (2 fails + 1 success)", got)
+	}
+	if len(*slept) != 2 {
+		t.Errorf("sleeps = %d, want 2 (between the 3 attempts)", len(*slept))
+	}
+	// Idempotency: the retried request body must be byte-identical each time
+	// (so gc's DedupKey dedups a delivered-but-500'd POST).
+	mu.Lock()
+	defer mu.Unlock()
+	if len(gotBodies) != 3 {
+		t.Fatalf("server saw %d bodies, want 3", len(gotBodies))
+	}
+	for i, b := range gotBodies {
+		if b != `{"x":1}` {
+			t.Errorf("body[%d] = %q, want identical resend {\"x\":1}", i, b)
+		}
+	}
+}
+
+func TestGCPostWithRetry_NoRetryOn4xx(t *testing.T) {
+	var n int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&n, 1)
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte("malformed"))
+	}))
+	defer srv.Close()
+
+	sleep, slept := recordingSleep()
+	_, err := gcPostWithRetry(srv.Client(), fastRetry(5), sleep, srv.URL, "inbound", []byte(`{"x":1}`))
+	if err == nil {
+		t.Fatal("expected terminal error on 4xx, got nil")
+	}
+	if !strings.Contains(err.Error(), "400") {
+		t.Errorf("error should name the status: %v", err)
+	}
+	if strings.Contains(err.Error(), "after") {
+		t.Errorf("4xx should be terminal, not an exhaustion error: %v", err)
+	}
+	if got := atomic.LoadInt32(&n); got != 1 {
+		t.Errorf("requests = %d, want 1 (4xx is terminal, no retry)", got)
+	}
+	if len(*slept) != 0 {
+		t.Errorf("slept %v, want none on terminal 4xx", *slept)
+	}
+}
+
+func TestGCPostWithRetry_ExhaustsOnPersistent5xx(t *testing.T) {
+	var n int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&n, 1)
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte("gc down"))
+	}))
+	defer srv.Close()
+
+	sleep, slept := recordingSleep()
+	_, err := gcPostWithRetry(srv.Client(), fastRetry(4), sleep, srv.URL, "inbound", []byte(`{"x":1}`))
+	if err == nil {
+		t.Fatal("expected exhaustion error, got nil")
+	}
+	if !strings.Contains(err.Error(), "after 4 attempts") {
+		t.Errorf("error should report attempt count: %v", err)
+	}
+	if got := atomic.LoadInt32(&n); got != 4 {
+		t.Errorf("requests = %d, want 4 (all attempts made)", got)
+	}
+	if len(*slept) != 3 {
+		t.Errorf("sleeps = %d, want 3 (between 4 attempts)", len(*slept))
+	}
+}
+
+// flakyTransport returns a transport error the first failN calls, then
+// delegates to inner — models gc being briefly unreachable.
+type flakyTransport struct {
+	failN int32
+	calls int32
+	inner http.RoundTripper
+}
+
+func (f *flakyTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	if atomic.AddInt32(&f.calls, 1) <= f.failN {
+		return nil, fmt.Errorf("dial tcp 127.0.0.1: connect: connection refused")
+	}
+	return f.inner.RoundTrip(r)
+}
+
+func TestGCPostWithRetry_RetriesOnTransportError(t *testing.T) {
+	var served int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&served, 1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	client := &http.Client{Transport: &flakyTransport{failN: 2, inner: srv.Client().Transport}}
+	sleep, slept := recordingSleep()
+	body, err := gcPostWithRetry(client, fastRetry(5), sleep, srv.URL, "inbound", []byte(`{"x":1}`))
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if string(body) != `{"ok":true}` {
+		t.Errorf("body = %s, want success", body)
+	}
+	if got := atomic.LoadInt32(&served); got != 1 {
+		t.Errorf("server served %d, want 1 (first 2 died in transport)", got)
+	}
+	if len(*slept) != 2 {
+		t.Errorf("sleeps = %d, want 2 (two transport failures retried)", len(*slept))
+	}
+}
+
+func TestGCPostWithRetry_SingleAttemptFloor(t *testing.T) {
+	var n int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&n, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	sleep, _ := recordingSleep()
+	// maxAttempts <= 0 must be floored to a single attempt, not an infinite
+	// or zero-attempt loop.
+	rc := gcRetryConfig{maxAttempts: 0, baseBackoff: time.Millisecond, maxBackoff: time.Millisecond}
+	if _, err := gcPostWithRetry(srv.Client(), rc, sleep, srv.URL, "inbound", []byte(`{}`)); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if got := atomic.LoadInt32(&n); got != 1 {
+		t.Errorf("requests = %d, want exactly 1", got)
+	}
+}

--- a/slack-full/doctor/check-binaries.sh
+++ b/slack-full/doctor/check-binaries.sh
@@ -12,7 +12,7 @@ done
 
 if [ -n "$missing" ]; then
   echo "pack binaries not built:$missing"
-  echo "Build them in place: (cd adapter && go build -o gc-slack-adapter) and (cd cli && go build -o gc-slack-cli .) — see CONTRIBUTING.md."
+  echo "Build them: run scripts/build-binaries.sh (rebuilds both in place; needed after any 'gc import install' / repin). See CONTRIBUTING.md."
   exit 2
 fi
 

--- a/slack-full/scripts/build-binaries.sh
+++ b/slack-full/scripts/build-binaries.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+# build-binaries.sh — build the slack-full pack's Go binaries in place.
+#
+# The adapter (adapter/gc-slack-adapter) and operator CLI (cli/gc-slack-cli)
+# are gitignored build artifacts. A fresh pack cache clone — `gc import
+# install`, a repin, `gc pack fetch` — does NOT contain them, and gc runs
+# no pack build hook on import, so after every such clone the [[service]]
+# command and the commands/<cmd>.sh wrappers point at binaries that do not
+# exist. That is the root cause of the 2026-07-05 ~16.6h Slack outage.
+#
+# Run this once after any import/repin to (re)build both binaries in place;
+# the binaries/doctor check (`gc slack-full doctor`, doctor/check-binaries.sh)
+# then verifies the result. Idempotent — re-running rebuilds in place. Loud —
+# a failed compile aborts non-zero with the toolchain output and never
+# leaves a half-built pack reported as success.
+#
+# Pack dir resolves from $GC_PACK_DIR when set (the installed-pack path gc
+# exports), else from this script's location — same idiom as
+# doctor/check-binaries.sh.
+set -eu
+
+pack_dir="${GC_PACK_DIR:-$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)}"
+
+if ! command -v go >/dev/null 2>&1; then
+	echo "build-binaries: 'go' toolchain not found on PATH — cannot build pack binaries" >&2
+	exit 1
+fi
+
+echo "build-binaries: pack dir = $pack_dir"
+echo "build-binaries: using $(command -v go) — $(go version)"
+
+echo "build-binaries: building adapter/gc-slack-adapter ..."
+( cd "$pack_dir/adapter" && go build -o gc-slack-adapter . )
+
+echo "build-binaries: building cli/gc-slack-cli ..."
+( cd "$pack_dir/cli" && go build -o gc-slack-cli . )
+
+# Never report success on a partial build: confirm both binaries landed as
+# executables (mirrors doctor/check-binaries.sh's own check).
+missing=""
+for bin in adapter/gc-slack-adapter cli/gc-slack-cli; do
+	if [ ! -x "$pack_dir/$bin" ]; then
+		missing="$missing $bin"
+	fi
+done
+if [ -n "$missing" ]; then
+	echo "build-binaries: FAILED — expected binaries missing after build:$missing" >&2
+	exit 1
+fi
+
+echo "build-binaries: OK — adapter and CLI binaries built in place"

--- a/superpowers/formulas/superpowers-brainstorming.formula.toml
+++ b/superpowers/formulas/superpowers-brainstorming.formula.toml
@@ -9,7 +9,9 @@ and review guidance available through the provider skill directory.
 formula = "superpowers-brainstorming"
 type = "expansion"
 version = 1
-contract = "graph.v2"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.brainstorming_approval_mode]

--- a/superpowers/formulas/superpowers-build.formula.toml
+++ b/superpowers/formulas/superpowers-build.formula.toml
@@ -6,9 +6,11 @@ build-base lifecycle.
 """
 formula = "superpowers-build"
 version = 1
-contract = "graph.v2"
 extends = ["build-base"]
 target_required = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "superpowers-build"

--- a/superpowers/formulas/superpowers-code-review.formula.toml
+++ b/superpowers/formulas/superpowers-code-review.formula.toml
@@ -7,7 +7,9 @@ into explicit Gas City review, gap-analysis, and feedback-processing lanes.
 formula = "superpowers-code-review"
 type = "expansion"
 version = 1
-contract = "graph.v2"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/superpowers/formulas/superpowers-decomposition.formula.toml
+++ b/superpowers/formulas/superpowers-decomposition.formula.toml
@@ -3,10 +3,12 @@ Superpowers implementation of the decomposition-base methodology contract.
 """
 formula = "superpowers-decomposition"
 version = 1
-contract = "graph.v2"
 extends = ["decomposition-base"]
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [[steps]]
 id = "decompose"

--- a/superpowers/formulas/superpowers-development-item.formula.toml
+++ b/superpowers/formulas/superpowers-development-item.formula.toml
@@ -7,11 +7,13 @@ the task scope; this formula carries the execution process.
 """
 formula = "superpowers-development-item"
 version = 1
-contract = "graph.v2"
 extends = ["do-work-item"]
 target_required = true
 internal = true
 single_lane = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/superpowers/formulas/superpowers-development.formula.toml
+++ b/superpowers/formulas/superpowers-development.formula.toml
@@ -7,9 +7,11 @@ scope; this formula carries the execution process.
 """
 formula = "superpowers-development"
 version = 1
-contract = "graph.v2"
 extends = ["do-work"]
 target_required = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/superpowers/formulas/superpowers-fix-loop.formula.toml
+++ b/superpowers/formulas/superpowers-fix-loop.formula.toml
@@ -3,10 +3,12 @@ Superpowers implementation of the fix-loop-base methodology contract.
 """
 formula = "superpowers-fix-loop"
 version = 1
-contract = "graph.v2"
 extends = ["fix-loop-base"]
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_formula]

--- a/superpowers/formulas/superpowers-implementation.formula.toml
+++ b/superpowers/formulas/superpowers-implementation.formula.toml
@@ -3,10 +3,12 @@ Superpowers implementation of the public implement methodology contract.
 """
 formula = "superpowers-implementation"
 version = 1
-contract = "graph.v2"
 extends = ["implement"]
 target_required = true
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/superpowers/formulas/superpowers-plan-review.formula.toml
+++ b/superpowers/formulas/superpowers-plan-review.formula.toml
@@ -7,7 +7,9 @@ City-native review loop.
 formula = "superpowers-plan-review"
 type = "expansion"
 version = 1
-contract = "graph.v2"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [[template]]
 id = "{target}.setup-superpowers-plan-review"

--- a/superpowers/formulas/superpowers-planning.formula.toml
+++ b/superpowers/formulas/superpowers-planning.formula.toml
@@ -3,10 +3,12 @@ Superpowers implementation of the planning-base methodology contract.
 """
 formula = "superpowers-planning"
 version = 1
-contract = "graph.v2"
 extends = ["planning-base"]
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.brainstorming_approval_mode]

--- a/superpowers/formulas/superpowers-review.formula.toml
+++ b/superpowers/formulas/superpowers-review.formula.toml
@@ -3,11 +3,13 @@ Superpowers implementation of the code-review-base methodology contract.
 """
 formula = "superpowers-review"
 version = 1
-contract = "graph.v2"
 extends = ["code-review-base"]
 target_required = false
 internal = true
 mode = "report"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/superpowers/formulas/superpowers-task-review.formula.toml
+++ b/superpowers/formulas/superpowers-task-review.formula.toml
@@ -8,7 +8,9 @@ implementation lane applies findings; provider-native subagents are not used.
 formula = "superpowers-task-review"
 type = "expansion"
 version = 1
-contract = "graph.v2"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]


### PR DESCRIPTION
## Summary

Every `gc` supervisor restart caused a **~2-3 minute Slack outbound blackout** — the `slack-full` adapter registered with gc exactly once at boot and `log.Fatalf`'d on any failure, so it crashed on gc's transient boot-race `404` instead of retrying. Make registration resilient: bounded transient-retry + idempotent periodic re-register.

## Root cause

`slack-full/adapter/main.go` registered with gc's outbound adapter registry **once at boot** and turned any failure into `log.Fatalf` → process exit. gc's registry is in-memory and **wiped on every gc restart by design** (adapters are expected to re-register), and during gc's boot the controller answers HTTP but briefly rejects registrations with a transient `404 "not_found: city not found or not running"`. So the adapter crashed on that boot-race 404 and burned full respawn cycles until gc happened to be ready.

Live repro from the adapter `service.log`:
```
22:34:13  register adapter: register failed: 404 ... not_found: city not found or not running: sct-city
          (no recovery — process exited)
22:36:06  starting gc-slack-adapter ...   ← full respawn ~2 min later
22:36:06  registered with gc as provider=slack ...
```
During that gap, outbound Slack (rollups / escalations / daily digests) is silently dropped — and this city relies on Slack for human paging.

## Fix

New `slack-full/adapter/register_retry.go`:
1. **`registerWithRetry`** — bounded exponential backoff + jitter (1s→30s cap, mirroring the existing `runThreadTeardownSubscriber` pattern) on **transient** failures (404 city-not-ready, connection refused, timeouts, 5xx). **Fail fast** on 401/403 and other non-404 4xx (malformed/auth — retrying can't help). Gives up after a generous 5-min deadline so a genuinely-down controller still surfaces as a hard failure rather than looping forever. Boot call runs under a `signal.NotifyContext` so SIGTERM during a slow controller boot stops the process promptly.
2. **`runPeriodicReregister`** — idempotent last-writer-wins re-POST on a jittered ~20s interval, started **only after** the callback listener is up (so a re-register never advertises a transport that isn't listening). This lets the adapter survive an **in-place** gc restart (registry wiped, adapter not respawned) by re-establishing routing within one interval.

`registerAdapter` now returns a typed `*registerError` carrying the HTTP status so the loop can classify transient vs permanent.

**Window reduction:** ~2-3 min per gc restart → controller-ready time (seconds) on respawn; self-heals within ~20s for an in-place restart with no respawn.

## Tests

`slack-full/adapter/register_retry_test.go` (httptest fake gc):
- `TestRegisterWithRetrySucceedsThroughTransient404` — rides through 3 transient 404s, succeeds on attempt 4, **no process exit** (4 POSTs, ~9ms). The first single-shot attempt is asserted to return the error the old code fed to `log.Fatalf`.
- `TestRegisterWithRetryFailsFastOnAuth` — 401 and 403 each fail after **exactly 1 POST** (no retry).
- `TestPeriodicReregisterRePostsOnInterval` — re-POSTs an identical idempotent payload on the interval.

`go build ./...`, `go vet ./...`, `gofmt -l` clean; `go test ./...` green.

## Risks / honest limits

- **Idempotency:** relies on gc register being last-writer-wins; the first periodic tick after boot is a redundant no-op POST. If gc ever makes register non-idempotent, this changes.
- **Ordering:** the periodic goroutine is gated after the listener starts (+ an initial interval sleep), so it won't advertise a dead transport. The **initial** boot registration keeps the pre-existing order (register before `ListenAndServe`) — unchanged by this PR.
- **Thundering herd:** +25% jitter on both backoff and interval mitigates lockstep re-registration across a fleet sharing one gc.
- **Not included:** an immediate re-register on a publish-callback 404 — the adapter is the *receiver* of gc's `/publish` and can't observe the `/svc` proxy's 404 for a deregistered adapter from its own side, so there's no clean signal to hook without new plumbing; the ~20s periodic already covers this. Clean follow-up.
- `defaultReregisterInterval` (20s) is tunable; not yet validated against a live gc's operational tolerance for an in-place restart.
