### PR TITLE
fix(gastown): force the witness orphan-salvage close (beads#3734 cross-actor guard)

### DIFF
--- a/gastown/formulas/mol-witness-patrol.toml
+++ b/gastown/formulas/mol-witness-patrol.toml
@@ -331,9 +331,11 @@ git merge-base --is-ancestor origin/$BRANCH origin/main
 ```
 
 If the work is already on main:
-- **Close the bead** (work is done, don't re-dispatch):
+- **Close the bead** (work is done, don't re-dispatch). Use `--force`: the bead
+  is still assigned to the crashed polecat, so this is a cross-actor close and
+  bd's close-authority guard (gastownhall/beads#3734) would otherwise refuse it:
 ```bash
-gc bd close <bead>
+gc bd close <bead> --force
 gc mail send mayor/ -s "ORPHAN_CLOSED: <bead> already merged" \
   -m "Branch $BRANCH already on main. Closed instead of resetting."
 ```


### PR DESCRIPTION
## Why

`gastown/formulas/mol-witness-patrol.toml` Step 3 closes an orphaned bead that is **still assigned to a crashed polecat** when that polecat's branch already merged to main:

```bash
gc bd close <bead>   # bead.assignee == dead polecat; witness acts as itself
```

This is a genuine **cross-actor** close. Once **gastownhall/beads#3734** ("refuse silent close on actor/assignee mismatch", unreleased, after v1.1.0) ships, this bare `gc bd close` — a CLI passthrough, not the force-closing SDK `BdStore` — is **refused**. The already-merged bead then stays open and is re-classified as orphaned on every witness patrol cycle.

## What

Add `--force` to that single close (+ a comment explaining the cross-actor rationale). No other close site in the file is cross-actor.

## Context

Companion to **gastownhall/gascity#4011**, which hardened all cross-actor `bd close` sites in the gascity repo for the same guard but could not reach this embedded-pack site (it ships from this module). An adversarial multi-agent review of #4011 flagged this as the one missed cross-actor close that would break at the next `BD_VERSION` bump. Bumping the `gascity-packs` pin in gascity to include this commit closes that gap.

## Safety

`--force` is a valid `bd`/`gc bd close` flag today, so the change is harmless on the currently pinned bd v1.1.0 and forward-compatible when the guard lands. Only the already-on-main salvage path is affected; the not-on-main path resets the bead to pool unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)