### PR TITLE
fix(gastown): harden the polecat work protocol against races, duplicate work, and failed drains

### DIFF
--- a/gastown/agents/polecat/prompt.template.md
+++ b/gastown/agents/polecat/prompt.template.md
@@ -383,21 +383,45 @@ refinery wake is a bug). Do not trust memory for this — check mechanically.
 Derive the work bead from your convoy exactly as the formula's workspace-setup
 step does (never pass a bare or guessed id to `bd`, which fuzzy-matches and can
 reassign the wrong bead); `$GC_BEAD_ID` is the convoy the molecule was poured
-on. If the work bead is no longer `in_progress` for this session, submit-and-exit
-already ran — drain and exit. Otherwise run it:
+on. If a clean read shows the work bead is no longer `in_progress` for this
+session, submit-and-exit already ran — drain and exit. Otherwise run it:
 
 ```bash
 EXPECTED_ASSIGNEE="${BEADS_ACTOR:-${GC_SESSION_NAME:-${GC_SESSION_ID:-${GC_AGENT:-}}}}"
-CONVOY_STATUS=$(gc convoy status "$GC_BEAD_ID" --json)
-WORK_BEAD_ID=$(printf '%s' "$CONVOY_STATUS" | jq -r 'if (.children | length) == 1 then .children[0].id else empty end')
-WORK_JSON=$(gc bd show "$WORK_BEAD_ID" --json)
-WORK_STATUS=$(printf '%s' "$WORK_JSON" | jq -r '.[0].status // empty')
-WORK_ASSIGNEE=$(printf '%s' "$WORK_JSON" | jq -r '.[0].assignee // empty')
-if [ "$WORK_STATUS" != "in_progress" ] || [ "$WORK_ASSIGNEE" != "$EXPECTED_ASSIGNEE" ]; then
+# Read the convoy + work bead with retry — same unreadable-is-not-terminal
+# discipline as the claim block above. An unreadable state (empty JSON, a convoy
+# blip, or 0/>=2 children so WORK_BEAD_ID is empty) is NOT proof that
+# submit-and-exit already ran. Only a SUCCESSFUL read showing the bead genuinely
+# moved off this session (closed, or reassigned to refinery) means it is done.
+WORK_BEAD_ID=""
+WORK_STATUS=""
+WORK_ASSIGNEE=""
+READ_OK=0
+READ_TRY=0
+while [ "$READ_TRY" -lt 3 ]; do
+  READ_TRY=$((READ_TRY + 1))
+  CONVOY_STATUS=$(gc convoy status "$GC_BEAD_ID" --json 2>/dev/null)
+  WORK_BEAD_ID=$(printf '%s' "$CONVOY_STATUS" | jq -r 'if (.children | length) == 1 then .children[0].id else empty end' 2>/dev/null)
+  if [ -n "$WORK_BEAD_ID" ]; then
+    WORK_JSON=$(gc bd show "$WORK_BEAD_ID" --json 2>/dev/null)
+    SHOW_CODE=$?
+    WORK_STATUS=$(printf '%s' "$WORK_JSON" | jq -r '.[0].status // empty' 2>/dev/null)
+    WORK_ASSIGNEE=$(printf '%s' "$WORK_JSON" | jq -r '.[0].assignee // empty' 2>/dev/null)
+    if [ "$SHOW_CODE" -eq 0 ] && [ -n "$WORK_STATUS" ] && [ -n "$WORK_ASSIGNEE" ]; then
+      READ_OK=1
+      break
+    fi
+  fi
+  sleep 1
+done
+if [ "$READ_OK" -eq 1 ] && { [ "$WORK_STATUS" != "in_progress" ] || [ "$WORK_ASSIGNEE" != "$EXPECTED_ASSIGNEE" ]; }; then
   echo "ALREADY_SUBMITTED $WORK_BEAD_ID status=$WORK_STATUS assignee=$WORK_ASSIGNEE — submit-and-exit already ran; draining."
   gc runtime drain-ack
   exit
 fi
+# Unreadable after retries, or still in_progress for this session: DO NOT assume
+# already-submitted — fall through and run submit-and-exit. A stranded
+# in_progress bead with an unpushed branch is the worse outcome.
 ```
 
 The `auto_push=false` opt-out (mol-pr-from-issue's halt-at-branch-ready) is

--- a/gastown/agents/polecat/prompt.template.md
+++ b/gastown/agents/polecat/prompt.template.md
@@ -408,7 +408,7 @@ while [ "$READ_TRY" -lt 3 ]; do
     SHOW_CODE=$?
     WORK_STATUS=$(printf '%s' "$WORK_JSON" | jq -r '.[0].status // empty' 2>/dev/null)
     WORK_ASSIGNEE=$(printf '%s' "$WORK_JSON" | jq -r '.[0].assignee // empty' 2>/dev/null)
-    if [ "$SHOW_CODE" -eq 0 ] && [ -n "$WORK_STATUS" ] && [ -n "$WORK_ASSIGNEE" ]; then
+    if [ "$SHOW_CODE" -eq 0 ] && [ -n "$WORK_STATUS" ]; then
       READ_OK=1
       break
     fi

--- a/gastown/agents/polecat/prompt.template.md
+++ b/gastown/agents/polecat/prompt.template.md
@@ -140,33 +140,83 @@ Default implementation formula: `mol-polecat-work`
 
 > **The Universal Propulsion Principle: If your hook/work query finds work, YOU RUN IT.**
 
-> **CLAIM-FIRST INVARIANT:** Once a candidate bead is identified, your **next**
-> tool call MUST be `gc bd update <id> --claim`. Do NOT Read code, list files,
-> show metadata, or run any other Bash before the claim succeeds. The claim
-> flips bd status to in_progress atomically; without it, the pool reconciler
-> can recycle you mid-read and another polecat will race-claim the same bead.
-> Polecat-vs-polecat races are the #1 source of churn — close the window.
+`gc hook --claim --json` is the ONLY permitted discovery source for your work.
+Do NOT run broad `bd ready`, `bd list`, root-bead searches, metadata searches,
+mail inspection, or repository scans to find a bead — those race other polecats
+and surface work that is not yours. Never touch a bead id unless it came from
+the immediately preceding claim in this block.
+
+Your first action is the scripted claim below, run as ONE Bash command. Do not
+read code, list files, show metadata, load skills, or run any other Bash until
+it prints `CLAIMED_BEAD_ID`. The claim flips bd status to `in_progress`
+atomically; without it the pool reconciler can recycle you mid-read and another
+polecat race-claims the same bead. Polecat-vs-polecat races are the #1 source of
+churn — close the window.
 
 ```bash
-# Step 1: Claim exactly one work item through the standard hook protocol.
-gc hook --claim --json
+bash <<'GC_CLAIM'
+set +e
+EXPECTED_ASSIGNEE="${BEADS_ACTOR:-${GC_SESSION_NAME:-${GC_SESSION_ID:-${GC_AGENT:-}}}}"
+if [ -z "$EXPECTED_ASSIGNEE" ]; then
+  echo "CLAIM_REJECTED no session identity in env; cannot verify ownership"
+  gc runtime drain-ack
+  exit 0
+fi
 
-# Step 2: AFTER successful claim, only then read code, formula steps, etc.
-gc bd show <id> --json | jq '.[0].metadata'
+CLAIM_JSON="$(gc hook --claim --json 2>/dev/null)"
+ACTION="$(printf '%s' "$CLAIM_JSON" | jq -r '.action // empty')"
+WORK_ID="$(printf '%s' "$CLAIM_JSON" | jq -r '.bead_id // empty')"
 
-# Step 3: Work found? -> Follow formula steps. Nothing? -> Check mail
-gc mail inbox
+# No work routed to you -> the hook already drain-acked. Stop; do not search.
+if [ "$ACTION" = "drain" ] || [ -z "$WORK_ID" ]; then
+  echo "NO_ROUTED_WORK"
+  gc runtime drain-ack
+  exit 0
+fi
 
-# Step 4: Execute — read formula steps and work through them in order
+# Post-claim ownership verification. The bead MUST be yours and in_progress
+# before you touch any code. A polecat NEVER works a bead it did not claim this
+# session. On CLAIM_REJECTED / already-assigned-to-another, STOP and drain —
+# do not retry by hand, repair the assignment, or race the other owner.
+SHOW_JSON="$(gc bd show "$WORK_ID" --json 2>/dev/null)"
+STATUS="$(printf '%s' "$SHOW_JSON" | jq -r '.[0].status // empty')"
+ASSIGNEE="$(printf '%s' "$SHOW_JSON" | jq -r '.[0].assignee // empty')"
+if [ "$ASSIGNEE" != "$EXPECTED_ASSIGNEE" ] || [ "$STATUS" != "in_progress" ]; then
+  echo "CLAIM_REJECTED $WORK_ID assignee=$ASSIGNEE status=$STATUS (expected $EXPECTED_ASSIGNEE / in_progress)"
+  gc runtime drain-ack
+  exit 0
+fi
+
+printf 'CLAIMED_BEAD_ID=%s\n' "$WORK_ID"
+printf '%s' "$SHOW_JSON" | jq '.[0].metadata'
+GC_CLAIM
 ```
 
-When nudged after dispatch, run `gc hook --claim --json`. That single command
-checks assigned work first (session bead ID, runtime session name, then alias)
-and only falls through to unassigned pool work routed to
-`${GC_RIG:+$GC_RIG/}{{ .BindingPrefix }}polecat`; it also performs the atomic
-claim before you inspect the bead.
+If the block prints `NO_ROUTED_WORK` or `CLAIM_REJECTED`, it has already
+drain-acked — stop and exit. Only after it prints `CLAIMED_BEAD_ID` do you read
+formula steps and begin. The claim checks assigned work first (session bead ID,
+runtime session name, then alias) and only falls through to unassigned pool work
+routed to `${GC_RIG:+$GC_RIG/}{{ .BindingPrefix }}polecat`.
 
-**Hook claim -> Read formula steps -> Follow in order -> claim next step or drain.**
+**Resume / crash re-verify (FIRST action on restart).** Pool restarts mint a
+NEW session identity. If you wake into a session that context says was already
+mid-work on a claimed bead, your FIRST action — before touching code — is to
+re-check ownership against THIS session's identity:
+
+```bash
+EXPECTED_ASSIGNEE="${BEADS_ACTOR:-${GC_SESSION_NAME:-${GC_SESSION_ID:-${GC_AGENT:-}}}}"
+ASSIGNEE="$(gc bd show "$GC_BEAD_ID" --json | jq -r '.[0].assignee // empty')"
+if [ "$ASSIGNEE" != "$EXPECTED_ASSIGNEE" ]; then
+  echo "OWNERSHIP_LOST $GC_BEAD_ID now assigned to $ASSIGNEE, not $EXPECTED_ASSIGNEE. Stopping."
+  gc runtime drain-ack
+  exit 0
+fi
+```
+
+If ownership was lost, another agent owns the work now — STOP and drain. Do not
+race it.
+
+**Claim -> verify ownership -> read formula steps -> follow in order -> claim next step or drain.**
 
 ## Context Exhaustion
 

--- a/gastown/agents/polecat/prompt.template.md
+++ b/gastown/agents/polecat/prompt.template.md
@@ -305,52 +305,40 @@ Nudges from other agents may arrive via your hook. When working:
 
 ---
 
-## FINAL REMINDER: RUN THE DONE SEQUENCE
+## FINAL REMINDER: RUN THE FORMULA'S SUBMIT-AND-EXIT
 
-**Before your session ends, you MUST run the done sequence.**
+**Before your session ends, hand off through the formula.** The
+`mol-polecat-work` `submit-and-exit` step is the single source of truth for the
+done sequence — branch-shape gate, push + push-verify, metadata, refinery
+reassignment, wake/nudge, and drain all live there. Run that step.
+
+**If you have already run submit-and-exit, do NOT run it again** — drain and
+exit. Running the done sequence twice (double push, double reassign, double
+refinery wake) is a bug:
 
 ```bash
-# Explicit opt-out gate: respect mol-pr-from-issue auto_push=false (halt-at-branch-ready).
-# mol-pr-from-issue writes metadata.auto_push on the work bead. Other formulas
-# (mol-polecat-work) leave it unset — those flow through unchanged.
-AUTO_PUSH=$(gc bd show <work-bead> --json | jq -r '.[0].metadata | if has("auto_push") then (.auto_push | tostring) else "" end')
-if [ "$AUTO_PUSH" = "false" ]; then
-  echo "auto_push=false: halting at branch-ready (no push, no refinery handoff)"
-  BRANCH=$(git branch --show-current)
-  gc bd update <work-bead> \
-    --status=open --assignee="" \
-    --set-metadata branch="$BRANCH" \
-    --set-metadata target={{ .DefaultBranch }} \
-    --set-metadata branch_ready=true \
-    --set-metadata halt_reason=auto_push_false \
-    --set-metadata gc.routed_to="" \
-    --notes "Branch ready: auto_push=false (no push, no refinery handoff)"
-  gc runtime drain-ack
-  exit 0
-fi
-git push origin HEAD && {
-  BRANCH=$(git branch --show-current)
-  REMOTE_REF=$(git ls-remote origin "refs/heads/$BRANCH" 2>/dev/null | awk '{print $1}')
-  LOCAL_HEAD=$(git rev-parse HEAD)
-  if [ -z "$REMOTE_REF" ] || [ "$REMOTE_REF" != "$LOCAL_HEAD" ]; then
-    echo "PUSH VERIFICATION FAILED: origin/$BRANCH does not match local HEAD. Aborting handoff."
-    gc runtime drain-ack
-    exit 1
-  fi
-} || { echo "PUSH FAILED. Aborting handoff — bead stays with polecat."; gc runtime drain-ack; exit 1; }
-gc bd update <work-bead> \
-  --set-metadata branch=$(git branch --show-current) \
-  --set-metadata target={{ .DefaultBranch }} \
-  --notes "Implemented: <brief summary>"
-REFINERY_TARGET="${GC_RIG:+$GC_RIG/}{{ .BindingPrefix }}refinery"
-gc bd update <work-bead> --status=open --assignee="$REFINERY_TARGET" --set-metadata gc.routed_to=""
-gc session wake "$REFINERY_TARGET" || true
-gc session nudge "$REFINERY_TARGET" "Run 'gc prime' to check merge queue and begin processing." || true
 gc runtime drain-ack
 exit
 ```
 
-Your work is not complete until you run these commands. `gc runtime drain-ack`
+The one thing worth checking before you hand off is the `auto_push=false`
+opt-out (mol-pr-from-issue's halt-at-branch-ready; mol-polecat-work leaves it
+unset). Derive the work bead from your convoy exactly as the formula's
+workspace-setup step does — never pass a bare or guessed id to `bd`, which
+fuzzy-matches and can reassign the wrong bead. `$GC_BEAD_ID` is the convoy the
+molecule was poured on:
+
+```bash
+CONVOY_STATUS=$(gc convoy status "$GC_BEAD_ID" --json)
+WORK_BEAD_ID=$(printf '%s' "$CONVOY_STATUS" | jq -r 'if (.children | length) == 1 then .children[0].id else empty end')
+AUTO_PUSH=$(gc bd show "$WORK_BEAD_ID" --json | jq -r '.[0].metadata | if has("auto_push") then (.auto_push | tostring) else "" end')
+```
+
+If `AUTO_PUSH` is `false`, submit-and-exit halts at branch-ready (no push, no
+refinery handoff). Otherwise it pushes and reassigns to the refinery. Either
+way, submit-and-exit performs the mutation — the check above is read-only.
+
+Your work is not complete until submit-and-exit runs. `gc runtime drain-ack`
 signals the reconciler to kill this session — it will only restart you if the
 pool check command finds more work. Sitting idle after finishing implementation
 is the "Idle Polecat heresy."
@@ -363,7 +351,7 @@ is the "Idle Polecat heresy."
 
 | Want to... | Correct command |
 |------------|----------------|
-| Signal work complete | Done sequence (push, set metadata, reassign, wake refinery, nudge refinery, `gc runtime drain-ack`, exit) |
+| Signal work complete | Run the `mol-polecat-work` `submit-and-exit` step (its single source of truth); if already run, `gc runtime drain-ack` + exit |
 | Read formula steps | `gc bd show <wisp-id>` (shows formula ref) |
 | Escalate blocker | `WITNESS_TARGET="${GC_RIG:+$GC_RIG/}{{ .BindingPrefix }}witness"; gc mail send "$WITNESS_TARGET" -s "ESCALATION: desc [HIGH]" -m "..."` |
 | Context exhaustion | `gc runtime request-restart` |

--- a/gastown/agents/polecat/prompt.template.md
+++ b/gastown/agents/polecat/prompt.template.md
@@ -239,7 +239,8 @@ fi
 
 # Ownership confirmed. Stamp a stable session identity so the churn-watcher and
 # the resume re-verify can key on metadata.polecat_session.
-gc bd update "$WORK_ID" --set-metadata polecat_session="$EXPECTED_ASSIGNEE"
+gc bd update "$WORK_ID" --set-metadata polecat_session="$EXPECTED_ASSIGNEE" \
+  || echo "WARN metadata stamp failed for $WORK_ID; churn-watcher/resume lose session keying (proceeding — the claim is valid)"
 
 printf 'CLAIMED_BEAD_ID=%s\n' "$WORK_ID"
 printf '%s' "$SHOW_JSON" | jq '.[0].metadata'

--- a/gastown/agents/polecat/prompt.template.md
+++ b/gastown/agents/polecat/prompt.template.md
@@ -163,37 +163,91 @@ if [ -z "$EXPECTED_ASSIGNEE" ]; then
   exit 0
 fi
 
-CLAIM_JSON="$(gc hook --claim --json 2>/dev/null)"
-ACTION="$(printf '%s' "$CLAIM_JSON" | jq -r '.action // empty')"
-WORK_ID="$(printf '%s' "$CLAIM_JSON" | jq -r '.bead_id // empty')"
-
-# No work routed to you -> the hook already drain-acked. Stop; do not search.
-if [ "$ACTION" = "drain" ] || [ -z "$WORK_ID" ]; then
-  echo "NO_ROUTED_WORK"
+# Claim with retry. A hook-call failure (non-zero exit, malformed JSON) is a
+# transient CLI/daemon fault — NOT "no work" — so retry it before giving up.
+# Only action==drain, or a clean empty result, is genuine NO_ROUTED_WORK.
+WORK_ID=""
+CLAIM_TRY=0
+while [ "$CLAIM_TRY" -lt 3 ]; do
+  CLAIM_TRY=$((CLAIM_TRY + 1))
+  CLAIM_ERR="$(mktemp)"
+  CLAIM_JSON="$(gc hook --claim --json 2>"$CLAIM_ERR")"
+  CLAIM_CODE=$?
+  CLAIM_ERR_TEXT="$(sed -n '1p' "$CLAIM_ERR")"
+  rm -f "$CLAIM_ERR"
+  ACTION="$(printf '%s' "$CLAIM_JSON" | jq -r '.action // empty' 2>/dev/null)"
+  WORK_ID="$(printf '%s' "$CLAIM_JSON" | jq -r '.bead_id // empty' 2>/dev/null)"
+  if [ "$ACTION" = "drain" ]; then
+    echo "NO_ROUTED_WORK"
+    gc runtime drain-ack
+    exit 0
+  fi
+  if [ "$CLAIM_CODE" -eq 0 ] && [ -n "$WORK_ID" ]; then
+    break
+  fi
+  if [ "$CLAIM_CODE" -eq 0 ] && [ -z "$ACTION" ] && [ -z "$WORK_ID" ]; then
+    echo "NO_ROUTED_WORK"
+    gc runtime drain-ack
+    exit 0
+  fi
+  echo "CLAIM_RETRY hook call failed (code=$CLAIM_CODE): ${CLAIM_ERR_TEXT:-malformed claim result}"
+  WORK_ID=""
+  sleep 2
+done
+if [ -z "$WORK_ID" ]; then
+  echo "CLAIM_REJECTED gc hook --claim returned no workable bead after retries"
   gc runtime drain-ack
   exit 0
 fi
 
 # Post-claim ownership verification. The bead MUST be yours and in_progress
 # before you touch any code. A polecat NEVER works a bead it did not claim this
-# session. On CLAIM_REJECTED / already-assigned-to-another, STOP and drain —
-# do not retry by hand, repair the assignment, or race the other owner.
-SHOW_JSON="$(gc bd show "$WORK_ID" --json 2>/dev/null)"
-STATUS="$(printf '%s' "$SHOW_JSON" | jq -r '.[0].status // empty')"
-ASSIGNEE="$(printf '%s' "$SHOW_JSON" | jq -r '.[0].assignee // empty')"
+# session. Distinguish a READ FAILURE (gc bd show non-zero / empty JSON —
+# transient) from a genuine MISMATCH (non-empty assignee that differs, or
+# status not in_progress). Retry the read before deciding; only a genuine
+# mismatch is CLAIM_REJECTED.
+STATUS=""
+ASSIGNEE=""
+SHOW_JSON=""
+SHOW_OK=0
+SHOW_TRY=0
+while [ "$SHOW_TRY" -lt 3 ]; do
+  SHOW_TRY=$((SHOW_TRY + 1))
+  SHOW_JSON="$(gc bd show "$WORK_ID" --json 2>/dev/null)"
+  SHOW_CODE=$?
+  STATUS="$(printf '%s' "$SHOW_JSON" | jq -r '.[0].status // empty' 2>/dev/null)"
+  ASSIGNEE="$(printf '%s' "$SHOW_JSON" | jq -r '.[0].assignee // empty' 2>/dev/null)"
+  if [ "$SHOW_CODE" -eq 0 ] && [ -n "$STATUS" ] && [ -n "$ASSIGNEE" ]; then
+    SHOW_OK=1
+    break
+  fi
+  sleep 1
+done
+if [ "$SHOW_OK" -ne 1 ]; then
+  # Never leave a claimed bead stranded in_progress on an unreadable state:
+  # release it so it re-enters the pool instead of being lost.
+  echo "CLAIM_RELEASED $WORK_ID unreadable after retries; returning it to the pool"
+  gc bd update "$WORK_ID" --status=open --assignee=""
+  gc runtime drain-ack
+  exit 0
+fi
 if [ "$ASSIGNEE" != "$EXPECTED_ASSIGNEE" ] || [ "$STATUS" != "in_progress" ]; then
   echo "CLAIM_REJECTED $WORK_ID assignee=$ASSIGNEE status=$STATUS (expected $EXPECTED_ASSIGNEE / in_progress)"
   gc runtime drain-ack
   exit 0
 fi
 
+# Ownership confirmed. Stamp a stable session identity so the churn-watcher and
+# the resume re-verify can key on metadata.polecat_session.
+gc bd update "$WORK_ID" --set-metadata polecat_session="$EXPECTED_ASSIGNEE"
+
 printf 'CLAIMED_BEAD_ID=%s\n' "$WORK_ID"
 printf '%s' "$SHOW_JSON" | jq '.[0].metadata'
 GC_CLAIM
 ```
 
-If the block prints `NO_ROUTED_WORK` or `CLAIM_REJECTED`, it has already
-drain-acked — stop and exit. Only after it prints `CLAIMED_BEAD_ID` do you read
+If the block prints `NO_ROUTED_WORK`, `CLAIM_REJECTED`, or `CLAIM_RELEASED`, it
+has already drain-acked — stop and exit. Only after it prints `CLAIMED_BEAD_ID` do you read
 formula steps and begin. The claim checks assigned work first (session bead ID,
 runtime session name, then alias) and only falls through to unassigned pool work
 routed to `${GC_RIG:+$GC_RIG/}{{ .BindingPrefix }}polecat`.
@@ -203,11 +257,23 @@ NEW session identity. If you wake into a session that context says was already
 mid-work on a claimed bead, your FIRST action — before touching code — is to
 re-check ownership against THIS session's identity:
 
+`$GC_BEAD_ID` is the convoy, not the work bead — derive the child work bead
+first (exactly as the done sequence does), then verify THAT bead's ownership:
+
 ```bash
 EXPECTED_ASSIGNEE="${BEADS_ACTOR:-${GC_SESSION_NAME:-${GC_SESSION_ID:-${GC_AGENT:-}}}}"
-ASSIGNEE="$(gc bd show "$GC_BEAD_ID" --json | jq -r '.[0].assignee // empty')"
-if [ "$ASSIGNEE" != "$EXPECTED_ASSIGNEE" ]; then
-  echo "OWNERSHIP_LOST $GC_BEAD_ID now assigned to $ASSIGNEE, not $EXPECTED_ASSIGNEE. Stopping."
+CONVOY_STATUS=$(gc convoy status "$GC_BEAD_ID" --json)
+WORK_BEAD_ID=$(printf '%s' "$CONVOY_STATUS" | jq -r 'if (.children | length) == 1 then .children[0].id else empty end')
+if [ -z "$WORK_BEAD_ID" ]; then
+  echo "RESUME_INDETERMINATE convoy $GC_BEAD_ID has no single child work bead; re-claim instead of guessing."
+  gc runtime drain-ack
+  exit 0
+fi
+WORK_JSON=$(gc bd show "$WORK_BEAD_ID" --json)
+ASSIGNEE=$(printf '%s' "$WORK_JSON" | jq -r '.[0].assignee // empty')
+SESSION_TAG=$(printf '%s' "$WORK_JSON" | jq -r '.[0].metadata.polecat_session // empty')
+if [ "$ASSIGNEE" != "$EXPECTED_ASSIGNEE" ] || { [ -n "$SESSION_TAG" ] && [ "$SESSION_TAG" != "$EXPECTED_ASSIGNEE" ]; }; then
+  echo "OWNERSHIP_LOST $WORK_BEAD_ID assignee=$ASSIGNEE session=$SESSION_TAG, not $EXPECTED_ASSIGNEE. Stopping."
   gc runtime drain-ack
   exit 0
 fi
@@ -312,31 +378,30 @@ Nudges from other agents may arrive via your hook. When working:
 done sequence — branch-shape gate, push + push-verify, metadata, refinery
 reassignment, wake/nudge, and drain all live there. Run that step.
 
-**If you have already run submit-and-exit, do NOT run it again** — drain and
-exit. Running the done sequence twice (double push, double reassign, double
-refinery wake) is a bug:
+**Do NOT run submit-and-exit twice** (double push, double reassign, double
+refinery wake is a bug). Do not trust memory for this — check mechanically.
+Derive the work bead from your convoy exactly as the formula's workspace-setup
+step does (never pass a bare or guessed id to `bd`, which fuzzy-matches and can
+reassign the wrong bead); `$GC_BEAD_ID` is the convoy the molecule was poured
+on. If the work bead is no longer `in_progress` for this session, submit-and-exit
+already ran — drain and exit. Otherwise run it:
 
 ```bash
-gc runtime drain-ack
-exit
-```
-
-The one thing worth checking before you hand off is the `auto_push=false`
-opt-out (mol-pr-from-issue's halt-at-branch-ready; mol-polecat-work leaves it
-unset). Derive the work bead from your convoy exactly as the formula's
-workspace-setup step does — never pass a bare or guessed id to `bd`, which
-fuzzy-matches and can reassign the wrong bead. `$GC_BEAD_ID` is the convoy the
-molecule was poured on:
-
-```bash
+EXPECTED_ASSIGNEE="${BEADS_ACTOR:-${GC_SESSION_NAME:-${GC_SESSION_ID:-${GC_AGENT:-}}}}"
 CONVOY_STATUS=$(gc convoy status "$GC_BEAD_ID" --json)
 WORK_BEAD_ID=$(printf '%s' "$CONVOY_STATUS" | jq -r 'if (.children | length) == 1 then .children[0].id else empty end')
-AUTO_PUSH=$(gc bd show "$WORK_BEAD_ID" --json | jq -r '.[0].metadata | if has("auto_push") then (.auto_push | tostring) else "" end')
+WORK_JSON=$(gc bd show "$WORK_BEAD_ID" --json)
+WORK_STATUS=$(printf '%s' "$WORK_JSON" | jq -r '.[0].status // empty')
+WORK_ASSIGNEE=$(printf '%s' "$WORK_JSON" | jq -r '.[0].assignee // empty')
+if [ "$WORK_STATUS" != "in_progress" ] || [ "$WORK_ASSIGNEE" != "$EXPECTED_ASSIGNEE" ]; then
+  echo "ALREADY_SUBMITTED $WORK_BEAD_ID status=$WORK_STATUS assignee=$WORK_ASSIGNEE — submit-and-exit already ran; draining."
+  gc runtime drain-ack
+  exit
+fi
 ```
 
-If `AUTO_PUSH` is `false`, submit-and-exit halts at branch-ready (no push, no
-refinery handoff). Otherwise it pushes and reassigns to the refinery. Either
-way, submit-and-exit performs the mutation — the check above is read-only.
+The `auto_push=false` opt-out (mol-pr-from-issue's halt-at-branch-ready) is
+handled inside submit-and-exit; the "No Idle Polecats" fragment above covers it.
 
 Your work is not complete until submit-and-exit runs. `gc runtime drain-ack`
 signals the reconciler to kill this session — it will only restart you if the

--- a/gastown/assets/scripts/polecat-churn-watcher.sh
+++ b/gastown/assets/scripts/polecat-churn-watcher.sh
@@ -3,13 +3,21 @@
 #
 # What it watches:
 #   - $GC_CITY/.gc/nudges/pollers/polecat-*.pid   (live polecat sessions)
-#   - rig bd: open beads with metadata.work_dir set OR
-#             metadata.polecat_session set                (claimed work)
+#   - rig bd: open AND UNASSIGNED beads whose metadata.polecat_session
+#             exactly matches a dead session identity                (churned claim)
 #
 # What it logs:
 #   When a polecat PID file disappears AND a bead it had claimed is back
-#   in OPEN/no-assignee state — that's churn. The pool reconciler killed
+#   in OPEN + UNASSIGNED state — that's churn. The pool reconciler killed
 #   a polecat mid-claim and silently recycled.
+#
+#   A normal refinery handoff is NOT churn: it leaves the bead open but
+#   assigned to the refinery (with work_dir still set), so requiring
+#   assignee=="" excludes it. Detection keys on an EXACT
+#   metadata.polecat_session match, not a work_dir substring, so a path that
+#   merely contains a session name no longer false-positives. Beads must
+#   record metadata.polecat_session = <session identity> matching the poller
+#   name for a churn event to be attributable.
 #
 # Output: appends one JSON line per detected churn event to LOG_FILE.
 #
@@ -73,9 +81,11 @@ printf "%s\n" "$current_pids" > "$STATE_FILE"
 
 [ -z "$disappeared" ] && exit 0
 
-# For each disappeared polecat session, check rig bd for orphan-claim.
-# We look at OPEN beads whose metadata.work_dir mentions the dead session,
-# OR whose metadata.polecat_session equals it (if the field is set).
+# For each disappeared polecat session, check rig bd for a churned claim.
+# Churn = an OPEN + UNASSIGNED bead whose metadata.polecat_session EXACTLY
+# matches the dead session. Requiring assignee=="" excludes a normal refinery
+# handoff (open, assigned to refinery, work_dir still set). Exact-match on the
+# recorded session identity avoids the old work_dir-substring false positives.
 ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 open_beads_json=$(gc --rig "$GC_RIG" bd list --status=open --json 2>/dev/null || echo "[]")
@@ -84,7 +94,7 @@ for dead in $disappeared; do
   orphans=$(printf '%s' "$open_beads_json" \
     | jq -r --arg s "$dead" '
         .[] | select(
-          (.metadata.work_dir // "" | contains($s)) or
+          ((.assignee // "") == "") and
           ((.metadata.polecat_session // "") == $s)
         ) | .id' 2>/dev/null || true)
 

--- a/gastown/formulas/mol-deacon-patrol.toml
+++ b/gastown/formulas/mol-deacon-patrol.toml
@@ -239,12 +239,22 @@ gc session nudge "$STUCK_SESSION" "Queue has $ASSIGNED open beads, no bead activ
 ```
 
 If the nudge doesn't unstick within the next patrol cycle, escalate
-by filing a warrant for the dog pool:
+by filing a warrant for the dog pool. Check for an existing open warrant
+against the same target first — a duplicate warrant spawns a second shutdown
+dance racing the first:
 
 ```bash
-gc bd create --type=task --label=warrant \\
-    --title="Stuck queue: <session> — $ASSIGNED beads, no activity $duration" \\
-    --metadata '{"target":"<session>","reason":"queue starvation: N beads, no bead.updated_at progress","requester":"deacon","gc.routed_to":"{{binding_prefix}}dog"}'
+TARGET_SESSION="<session>"
+EXISTING_WARRANT=$(gc bd list --label=warrant --json --limit=0 \\
+    | jq -r --arg t "$TARGET_SESSION" \\
+        '[.[] | select((.status == "open" or .status == "in_progress") and (.metadata.target == $t))] | length')
+if [ "${EXISTING_WARRANT:-0}" -gt 0 ]; then
+    echo "Skipping warrant for $TARGET_SESSION — an open warrant already exists."
+else
+    gc bd create --type=task --label=warrant \\
+        --title="Stuck queue: <session> — $ASSIGNED beads, no activity $duration" \\
+        --metadata '{"target":"<session>","reason":"queue starvation: N beads, no bead.updated_at progress","requester":"deacon","gc.routed_to":"{{binding_prefix}}dog"}'
+fi
 ```
 
 The dog runs `mol-shutdown-dance` and the controller respawns a fresh
@@ -281,11 +291,22 @@ will naturally take longer than a quick dep propagation.
 
 No hardcoded thresholds. Use judgment.
 
-**Step 3: For stuck utility agents, file a warrant:**
+**Step 3: For stuck utility agents, file a warrant (deduped).**
+
+Check for an existing open warrant against the same target first — a duplicate
+warrant spawns a second shutdown dance racing the first:
 ```bash
-gc bd create --type=task --label=warrant \
-  --title="Stuck dog: <agent>" \
-  --metadata '{"target":"<session>","reason":"<reason>","requester":"deacon","gc.routed_to":"{{binding_prefix}}dog"}'
+TARGET_SESSION="<session>"
+EXISTING_WARRANT=$(gc bd list --label=warrant --json --limit=0 \
+  | jq -r --arg t "$TARGET_SESSION" \
+      '[.[] | select((.status == "open" or .status == "in_progress") and (.metadata.target == $t))] | length')
+if [ "${EXISTING_WARRANT:-0}" -gt 0 ]; then
+  echo "Skipping warrant for $TARGET_SESSION — an open warrant already exists."
+else
+  gc bd create --type=task --label=warrant \
+    --title="Stuck dog: <agent>" \
+    --metadata '{"target":"<session>","reason":"<reason>","requester":"deacon","gc.routed_to":"{{binding_prefix}}dog"}'
+fi
 ```
 
 A different dog from the pool picks up the warrant and runs the

--- a/gastown/formulas/mol-deacon-patrol.toml
+++ b/gastown/formulas/mol-deacon-patrol.toml
@@ -160,11 +160,23 @@ Check refinery patrol wisp freshness + queue state:
 the nature of the current work. Make a judgment call about whether
 something is stuck. This is exactly why an LLM does it, not Go code.
 
-**For stuck coordination agents, file a warrant:**
+**For stuck coordination agents, file a warrant (deduped).**
+
+Check for an existing open warrant against the same target first — a duplicate
+warrant spawns a second shutdown dance racing the first (duplicate kills,
+wasted dog cycles). Skip filing if one is already open or in progress:
 ```bash
-gc bd create --type=task --label=warrant \
-  --title="Stuck: <rig>/<role>" \
-  --metadata '{"target":"<session>","reason":"<reason>","requester":"deacon","gc.routed_to":"{{binding_prefix}}dog"}'
+TARGET_SESSION="<session>"
+EXISTING_WARRANT=$(gc bd list --label=warrant --json --limit=0 \
+  | jq -r --arg t "$TARGET_SESSION" \
+      '[.[] | select((.status == "open" or .status == "in_progress") and (.metadata.target == $t))] | length')
+if [ "${EXISTING_WARRANT:-0}" -gt 0 ]; then
+  echo "Skipping warrant for $TARGET_SESSION — an open warrant already exists."
+else
+  gc bd create --type=task --label=warrant \
+    --title="Stuck: <session>" \
+    --metadata '{"target":"<session>","reason":"<reason>","requester":"deacon","gc.routed_to":"{{binding_prefix}}dog"}'
+fi
 ```
 
 The dog pool runs `mol-shutdown-dance` for due process.

--- a/gastown/formulas/mol-deacon-patrol.toml
+++ b/gastown/formulas/mol-deacon-patrol.toml
@@ -245,14 +245,14 @@ dance racing the first:
 
 ```bash
 TARGET_SESSION="<session>"
-EXISTING_WARRANT=$(gc bd list --label=warrant --json --limit=0 \\
-    | jq -r --arg t "$TARGET_SESSION" \\
+EXISTING_WARRANT=$(gc bd list --label=warrant --json --limit=0 \
+    | jq -r --arg t "$TARGET_SESSION" \
         '[.[] | select((.status == "open" or .status == "in_progress") and (.metadata.target == $t))] | length')
 if [ "${EXISTING_WARRANT:-0}" -gt 0 ]; then
     echo "Skipping warrant for $TARGET_SESSION — an open warrant already exists."
 else
-    gc bd create --type=task --label=warrant \\
-        --title="Stuck queue: <session> — $ASSIGNED beads, no activity $duration" \\
+    gc bd create --type=task --label=warrant \
+        --title="Stuck queue: <session> — $ASSIGNED beads, no activity $duration" \
         --metadata '{"target":"<session>","reason":"queue starvation: N beads, no bead.updated_at progress","requester":"deacon","gc.routed_to":"{{binding_prefix}}dog"}'
 fi
 ```

--- a/gastown/formulas/mol-polecat-work.toml
+++ b/gastown/formulas/mol-polecat-work.toml
@@ -158,7 +158,9 @@ if [ -n "$REJECTION" ]; then
     git rebase origin/{{base_branch}}
     # If conflicts: resolve them (this is likely the rejection reason)
     # After resolving: git rebase --continue
-    gc bd update "$WORK_BEAD_ID" --unset-metadata rejection_reason
+    gc bd update "$WORK_BEAD_ID" \
+      --unset-metadata rejection_reason \
+      --set-metadata fork_sha="$(git rev-parse "origin/{{base_branch}}")"
 fi
 ```
 
@@ -175,13 +177,20 @@ git fetch origin {{base_branch}}                     # ensure origin ref is curr
 BRANCH="polecat/$WORK_BEAD_ID"
 git branch -D "$BRANCH" 2>/dev/null || true          # drop any stale local branch with the same name
 git checkout -B "$BRANCH" "origin/{{base_branch}}"   # force-create from the freshly-fetched remote tip
-gc bd update "$WORK_BEAD_ID" --set-metadata branch="$BRANCH"
+gc bd update "$WORK_BEAD_ID" \
+  --set-metadata branch="$BRANCH" \
+  --set-metadata fork_sha="$(git rev-parse "origin/{{base_branch}}")"
 ```
 
 Recording the branch early means:
 - Witness can find and salvage your work if you crash
 - Rejection-aware resume knows which branch to check out
 - The submit step updates the metadata (branch may change after rebase)
+
+`fork_sha` is the base commit this branch was cut from. The refinery uses it to
+tell a genuine already-merged branch (>=1 commit since fork) from a starved
+0-commit branch (tip still at the fork point) when both look like ancestors of
+the target.
 
 **4. Ensure clean working state:**
 ```bash

--- a/gastown/formulas/mol-refinery-patrol.toml
+++ b/gastown/formulas/mol-refinery-patrol.toml
@@ -681,8 +681,11 @@ fi
 
 Two failure modes share this gate, so evaluate them in one script that shares
 shell state — an early `exit` in the already-merged branch below then provably
-prevents the false-completion guard and the merge script from running on a
-closed bead.
+prevents the false-completion guard in this same script from running on a
+closed bead. That `exit` does NOT drain: an already-merged close is a real
+completion, so it skips the merge script and joins the normal path's
+Cleanup -> patrol-summary -> next-iteration tail (pour next wisp, burn this
+one), exactly like a normal merge. Only genuine errors drain-ack.
 
 - **Already merged (close, do NOT halt):** a previous refinery pass merged this
   branch and the polecat crashed before the bead closed. That is a real
@@ -721,8 +724,7 @@ case "$ANCESTOR_STATUS" in
         --set-metadata merged_target="$TARGET" \
         --unset-metadata rejection_reason && \
       gc bd close "$WORK" --reason "Already merged to $TARGET at $ALREADY_SHORT (branch is an ancestor of target; closed instead of halting)"
-      echo "ALREADY_MERGED: origin/$BRANCH is an ancestor of origin/$TARGET with $REAL_COMMITS commit(s) since fork — closed $WORK as merged; draining."
-      gc runtime drain-ack
+      echo "ALREADY_MERGED: origin/$BRANCH is an ancestor of origin/$TARGET with $REAL_COMMITS commit(s) since fork — closed $WORK as merged. Skip the merge script; run Cleanup, then patrol-summary + next-iteration."
       exit 0
     fi
     # Ancestor but no recorded real commits: a 0-commit branch. Fall through to
@@ -748,9 +750,12 @@ case "$BHRC_STATUS" in
     ;;
 esac
 ```
-If this block closed the bead as already-merged it drain-acked and exited, so
-neither the guard above nor the merge script below runs. Otherwise the branch
-has a verified real change and you continue to the merge.
+If this block closed the bead as already-merged, the merge is already done:
+SKIP the merge script (step 1 below) and go straight to **2. Cleanup**, then
+let this step complete so **patrol-summary** and **next-iteration** run (they
+pour the next wisp and burn this one) — the same tail a normal merge takes. Do
+NOT drain-ack here; that would strand the loop and leak the merged branch.
+Otherwise the branch has a verified real change and you continue to the merge.
 
 **1. Merge, push, verify, and close work bead:**
 

--- a/gastown/formulas/mol-refinery-patrol.toml
+++ b/gastown/formulas/mol-refinery-patrol.toml
@@ -677,7 +677,32 @@ fi
 
 **If MERGE_STRATEGY = "direct" (default):**
 
-**0. Refuse a 0-diff branch (false-completion guard):**
+**0a. Already-merged short-circuit (close as merged, do NOT halt):**
+
+If the source branch is already an ancestor of the target, a previous refinery
+pass merged it and the polecat crashed before the bead closed. That is a real
+completion, not a false one — but the 0-diff guard below would see an empty
+diff and escalate a done bead to a human. Catch it first and close the bead as
+merged, with `merged_sha` forensics:
+```bash
+git fetch origin "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}" "+refs/heads/${TARGET}:refs/remotes/origin/${TARGET}"
+if git merge-base --is-ancestor "origin/$BRANCH" "origin/$TARGET"; then
+  ALREADY_SHA=$(git rev-parse "origin/$BRANCH")
+  ALREADY_SHORT=$(git rev-parse --short "origin/$BRANCH")
+  gc bd update "$WORK" \
+    --set-metadata merge_result=already_merged \
+    --set-metadata merged_sha="$ALREADY_SHA" \
+    --set-metadata merged_target="$TARGET" \
+    --unset-metadata rejection_reason && \
+  gc bd close "$WORK" --reason "Already merged to $TARGET at $ALREADY_SHORT (branch is an ancestor of target; closed instead of halting)"
+  echo "ALREADY_MERGED: origin/$BRANCH is an ancestor of origin/$TARGET — closed $WORK as merged."
+  echo "Skip the rest of merge-push; go to the Cleanup step, then patrol-summary."
+fi
+```
+If this closed the bead, do NOT run the 0-diff guard or the merge script below
+— skip straight to **2. Cleanup**.
+
+**0b. Refuse a 0-diff branch (false-completion guard):**
 
 A close-as-merged asserts "work was merged"; a branch that introduces no
 change vs its merge-base merging is definitionally false. Refuse it before

--- a/gastown/formulas/mol-refinery-patrol.toml
+++ b/gastown/formulas/mol-refinery-patrol.toml
@@ -677,41 +677,80 @@ fi
 
 **If MERGE_STRATEGY = "direct" (default):**
 
-**0a. Already-merged short-circuit (close as merged, do NOT halt):**
+**0. Merge-state gate (already-merged short-circuit + false-completion guard):**
 
-If the source branch is already an ancestor of the target, a previous refinery
-pass merged it and the polecat crashed before the bead closed. That is a real
-completion, not a false one — but the 0-diff guard below would see an empty
-diff and escalate a done bead to a human. Catch it first and close the bead as
-merged, with `merged_sha` forensics:
+Two failure modes share this gate, so evaluate them in one script that shares
+shell state — an early `exit` in the already-merged branch below then provably
+prevents the false-completion guard and the merge script from running on a
+closed bead.
+
+- **Already merged (close, do NOT halt):** a previous refinery pass merged this
+  branch and the polecat crashed before the bead closed. That is a real
+  completion, so close it as merged with `merged_sha` forensics rather than let
+  the 0-diff guard escalate a done bead to a human. An ancestor check alone is
+  not enough: a 0-commit branch is trivially an ancestor of the target (its tip
+  is still the fork point), so gate the close on the branch also carrying >=1
+  commit since its recorded `metadata.fork_sha`. Without `fork_sha` recorded,
+  stay conservative and fall through to the false-completion guard.
+- **False completion (halt):** a branch that introduces no change vs its
+  merge-base is definitionally not a merge. Refuse it before touching `$TARGET`.
+  Legit no-op resolutions use wontfix/duplicate/not-planned, never merged — so
+  this never blocks a real merge.
+
 ```bash
-git fetch origin "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}" "+refs/heads/${TARGET}:refs/remotes/origin/${TARGET}"
-if git merge-base --is-ancestor "origin/$BRANCH" "origin/$TARGET"; then
-  ALREADY_SHA=$(git rev-parse "origin/$BRANCH")
-  ALREADY_SHORT=$(git rev-parse --short "origin/$BRANCH")
-  gc bd update "$WORK" \
-    --set-metadata merge_result=already_merged \
-    --set-metadata merged_sha="$ALREADY_SHA" \
-    --set-metadata merged_target="$TARGET" \
-    --unset-metadata rejection_reason && \
-  gc bd close "$WORK" --reason "Already merged to $TARGET at $ALREADY_SHORT (branch is an ancestor of target; closed instead of halting)"
-  echo "ALREADY_MERGED: origin/$BRANCH is an ancestor of origin/$TARGET — closed $WORK as merged."
-  echo "Skip the rest of merge-push; go to the Cleanup step, then patrol-summary."
+FORK_SHA=$(gc bd show "$WORK" --json | jq -r '.[0].metadata.fork_sha // empty')
+if ! git fetch origin "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}" "+refs/heads/${TARGET}:refs/remotes/origin/${TARGET}"; then
+  echo "git fetch failed; cannot evaluate merge state. STOP. Do not mutate bead state."
+  gc runtime drain-ack
+  exit 1
 fi
-```
-If this closed the bead, do NOT run the 0-diff guard or the merge script below
-— skip straight to **2. Cleanup**.
+git merge-base --is-ancestor "origin/$BRANCH" "origin/$TARGET"
+ANCESTOR_STATUS=$?
+case "$ANCESTOR_STATUS" in
+  0)
+    REAL_COMMITS=0
+    if [ -n "$FORK_SHA" ]; then
+      REAL_COMMITS=$(git rev-list --count "$FORK_SHA..origin/$BRANCH" 2>/dev/null || echo 0)
+    fi
+    if [ -n "$FORK_SHA" ] && [ "$REAL_COMMITS" -ge 1 ]; then
+      ALREADY_SHA=$(git rev-parse "origin/$BRANCH")
+      ALREADY_SHORT=$(git rev-parse --short "origin/$BRANCH")
+      gc bd update "$WORK" \
+        --set-metadata merge_result=already_merged \
+        --set-metadata merged_sha="$ALREADY_SHA" \
+        --set-metadata merged_target="$TARGET" \
+        --unset-metadata rejection_reason && \
+      gc bd close "$WORK" --reason "Already merged to $TARGET at $ALREADY_SHORT (branch is an ancestor of target; closed instead of halting)"
+      echo "ALREADY_MERGED: origin/$BRANCH is an ancestor of origin/$TARGET with $REAL_COMMITS commit(s) since fork — closed $WORK as merged; draining."
+      gc runtime drain-ack
+      exit 0
+    fi
+    # Ancestor but no recorded real commits: a 0-commit branch. Fall through to
+    # the false-completion guard, which refuses to close it as merged.
+    ;;
+  1) : ;;  # not an ancestor -> a normal merge candidate; fall through
+  *)
+    echo "git merge-base --is-ancestor errored (status $ANCESTOR_STATUS); cannot evaluate already-merged. STOP. Do not mutate bead state."
+    gc runtime drain-ack
+    exit 1
+    ;;
+esac
 
-**0b. Refuse a 0-diff branch (false-completion guard):**
-
-A close-as-merged asserts "work was merged"; a branch that introduces no
-change vs its merge-base merging is definitionally false. Refuse it before
-touching `$TARGET`. Legit no-op resolutions MUST use wontfix/duplicate/
-not-planned, never merged — so this never blocks a real merge.
-```bash
-branch_has_real_change "origin/$TARGET" temp || \
-  halt_false_completion "$BRANCH" "$(git merge-base "origin/$TARGET" temp 2>/dev/null || printf '%s' "origin/$TARGET")"
+branch_has_real_change "origin/$TARGET" temp
+BHRC_STATUS=$?
+case "$BHRC_STATUS" in
+  0) : ;;  # verified real change -> continue to the merge script below
+  1) halt_false_completion "$BRANCH" "$(git merge-base "origin/$TARGET" temp 2>/dev/null || printf '%s' "origin/$TARGET")" ;;
+  *)
+    echo "branch_has_real_change could not evaluate temp vs origin/$TARGET (tool error, status $BHRC_STATUS). STOP. Do not mutate bead state."
+    gc runtime drain-ack
+    exit 1
+    ;;
+esac
 ```
+If this block closed the bead as already-merged it drain-acked and exited, so
+neither the guard above nor the merge script below runs. Otherwise the branch
+has a verified real change and you continue to the merge.
 
 **1. Merge, push, verify, and close work bead:**
 
@@ -782,10 +821,20 @@ request and treats PR creation as the terminal handoff for this work bead.
 The same predicate covers the empty-PR / 0-commit concern: do not publish a
 pull request for a branch that introduces no change vs its merge-base. The
 PR handoff closes the bead, so an empty PR is the same false completion as
-an empty direct merge.
+an empty direct merge. A tool error (status 2) is not an empty branch — stop
+without mutating bead state rather than halt-escalating a healthy branch.
 ```bash
-branch_has_real_change "origin/$TARGET" temp || \
-  halt_false_completion "$BRANCH" "$(git merge-base "origin/$TARGET" temp 2>/dev/null || printf '%s' "origin/$TARGET")"
+branch_has_real_change "origin/$TARGET" temp
+BHRC_STATUS=$?
+case "$BHRC_STATUS" in
+  0) : ;;  # verified real change -> continue to publish the PR
+  1) halt_false_completion "$BRANCH" "$(git merge-base "origin/$TARGET" temp 2>/dev/null || printf '%s' "origin/$TARGET")" ;;
+  *)
+    echo "branch_has_real_change could not evaluate temp vs origin/$TARGET (tool error, status $BHRC_STATUS). STOP. Do not mutate bead state."
+    gc runtime drain-ack
+    exit 1
+    ;;
+esac
 ```
 
 **1. Push the rebased branch back to origin:**

--- a/gastown/formulas/mol-refinery-patrol.toml
+++ b/gastown/formulas/mol-refinery-patrol.toml
@@ -718,14 +718,20 @@ case "$ANCESTOR_STATUS" in
     if [ -n "$FORK_SHA" ] && [ "$REAL_COMMITS" -ge 1 ]; then
       ALREADY_SHA=$(git rev-parse "origin/$BRANCH")
       ALREADY_SHORT=$(git rev-parse --short "origin/$BRANCH")
-      gc bd update "$WORK" \
-        --set-metadata merge_result=already_merged \
-        --set-metadata merged_sha="$ALREADY_SHA" \
-        --set-metadata merged_target="$TARGET" \
-        --unset-metadata rejection_reason && \
-      gc bd close "$WORK" --reason "Already merged to $TARGET at $ALREADY_SHORT (branch is an ancestor of target; closed instead of halting)"
-      echo "ALREADY_MERGED: origin/$BRANCH is an ancestor of origin/$TARGET with $REAL_COMMITS commit(s) since fork — closed $WORK as merged. Skip the merge script; run Cleanup, then patrol-summary + next-iteration."
-      exit 0
+      if gc bd update "$WORK" \
+           --set-metadata merge_result=already_merged \
+           --set-metadata merged_sha="$ALREADY_SHA" \
+           --set-metadata merged_target="$TARGET" \
+           --unset-metadata rejection_reason && \
+         gc bd close "$WORK" --reason "Already merged to $TARGET at $ALREADY_SHORT (branch is an ancestor of target; closed instead of halting)"; then
+        echo "ALREADY_MERGED: origin/$BRANCH is an ancestor of origin/$TARGET with $REAL_COMMITS commit(s) since fork — closed $WORK as merged. Skip the merge script; run Cleanup, then patrol-summary + next-iteration."
+        exit 0
+      fi
+      # The update/close did not land (transient API failure). Do NOT report
+      # merged with the bead still open; STOP so a later patrol retries.
+      echo "ALREADY_MERGED close failed for $WORK; bead still open. STOP; a later patrol will retry."
+      gc runtime drain-ack
+      exit 1
     fi
     # Ancestor but no recorded real commits: a 0-commit branch. Fall through to
     # the false-completion guard, which refuses to close it as merged.

--- a/gastown/formulas/mol-shutdown-dance.toml
+++ b/gastown/formulas/mol-shutdown-dance.toml
@@ -239,7 +239,53 @@ id = "execute"
 title = "Execute warrant — kill session"
 needs = ["interrogate-3"]
 description = """
-Three attempts, no response. Execute the warrant.
+Three attempts, no response. Before killing, prove the target is actually dead.
+
+**0. Final progress check — pardon a working agent (BEFORE the kill).**
+
+Three nudges went unanswered, but an agent deep inside one long tool call (a
+full test suite, a large rebase) is alive and simply not reading nudges.
+Killing it discards real work mid-flight. Check for objective progress on the
+target's claimed work before executing — its bead `updated_at` and the newest
+file under its worktree:
+
+```bash
+target_bead="$(gc bd list --assignee="$target" --status=in_progress --json --limit=1 | jq -r '.[0].id // empty')"
+progress="none"
+now_epoch="$(date -u +%s)"
+if [ -n "$target_bead" ]; then
+  bead_json="$(gc bd show "$target_bead" --json)"
+  bead_updated="$(printf '%s' "$bead_json" | jq -r '.[0].updated_at // empty')"
+  work_dir="$(printf '%s' "$bead_json" | jq -r '.[0].metadata.work_dir // empty')"
+  echo "target_bead=$target_bead updated_at=$bead_updated work_dir=$work_dir"
+  # Bead moved within the 7-minute interrogation window (60s+120s+240s = 420s)?
+  bead_epoch="$(date -u -d "$bead_updated" +%s 2>/dev/null || echo 0)"
+  if [ "$bead_epoch" -gt 0 ] && [ $((now_epoch - bead_epoch)) -lt 420 ]; then
+    progress="bead"
+  fi
+  # Newest worktree file touched within the same window?
+  if [ -n "$work_dir" ] && [ -d "$work_dir" ]; then
+    recent_file="$(find "$work_dir" -type f -newermt '-7 minutes' 2>/dev/null | head -n 1)"
+    [ -n "$recent_file" ] && progress="worktree:$recent_file"
+  fi
+fi
+echo "progress_signal=$progress"
+```
+
+The 7-minute window is the interrogation budget the three attempts already
+spent. If either signal shows movement inside it, the target is progressing —
+PARDON it instead of killing. A polecat inside a full test suite is not dead:
+```bash
+if [ "$progress" != "none" ]; then
+  gc bd close "$GC_BEAD_ID" --reason "PARDONED: $target showed work progress within the interrogation window ($progress)"
+  gc session nudge "$requester_endpoint" "DOG_DONE: $target - PARDONED (progress within interrogation window; likely inside one long tool call)"
+  gc runtime drain-ack
+  exit 0
+fi
+```
+
+Only when neither signal shows recent progress do you proceed to the kill.
+This is judgment work — an LLM weighs the signals, not a hardcoded Go check.
 
 **1. Capture final pane output for forensics:**
 ```bash

--- a/gastown/formulas/mol-witness-patrol.toml
+++ b/gastown/formulas/mol-witness-patrol.toml
@@ -466,16 +466,28 @@ There are no hardcoded thresholds. Consider the nature of the work, the
 time elapsed, and whether the agent shows any signs of activity. This is
 judgment work — exactly why an LLM does it, not Go code.
 
-**Step 3: For stuck polecats, file a warrant:**
+**Step 3: For stuck polecats, file a warrant (deduped).**
 
 Do NOT kill the agent directly. File a warrant bead and let the dog pool
-handle the shutdown dance (multi-stage interrogation with due process):
+handle the shutdown dance (multi-stage interrogation with due process).
+
+First check for an existing open warrant against the same target — a second
+warrant spawns a second shutdown dance racing the first (duplicate kills,
+wasted dog cycles). Skip filing if one is already open or in progress:
 
 ```bash
-gc bd create --type=task \
-  --title="Stuck: <agent>" \
-  --metadata '{"target":"<session-name>","reason":"No progress on <bead> for <duration>","requester":"witness","gc.routed_to":"{{binding_prefix}}dog"}' \
-  --label=warrant
+TARGET_SESSION="<session-name>"
+EXISTING_WARRANT=$(gc bd list --label=warrant --json --limit=0 \
+  | jq -r --arg t "$TARGET_SESSION" \
+      '[.[] | select((.status == "open" or .status == "in_progress") and (.metadata.target == $t))] | length')
+if [ "${EXISTING_WARRANT:-0}" -gt 0 ]; then
+  echo "Skipping warrant for $TARGET_SESSION — an open warrant already exists."
+else
+  gc bd create --type=task \
+    --title="Stuck: <session-name>" \
+    --metadata '{"target":"<session-name>","reason":"No progress on <bead> for <duration>","requester":"witness","gc.routed_to":"{{binding_prefix}}dog"}' \
+    --label=warrant
+fi
 ```
 
 The dog pool picks up the warrant and runs `mol-shutdown-dance`, which

--- a/gastown/template-fragments/approval-fallacy.template.md
+++ b/gastown/template-fragments/approval-fallacy.template.md
@@ -27,22 +27,46 @@ reassignment, wake/nudge, and drain. **Run that step.**
 Do not trust memory for this; check mechanically. Derive the work bead from your
 convoy exactly as the formula's workspace-setup step does — never pass a bare or
 guessed id to `bd`, which fuzzy-matches and can reassign the wrong bead.
-`$GC_BEAD_ID` is the convoy the molecule was poured on. If the work bead is no
-longer `in_progress` for this session, submit-and-exit already reassigned it —
-drain and exit. Otherwise run it:
+`$GC_BEAD_ID` is the convoy the molecule was poured on. If a clean read shows
+the work bead is no longer `in_progress` for this session, submit-and-exit
+already reassigned it — drain and exit. Otherwise run it:
 
 ```bash
 EXPECTED_ASSIGNEE="${BEADS_ACTOR:-${GC_SESSION_NAME:-${GC_SESSION_ID:-${GC_AGENT:-}}}}"
-CONVOY_STATUS=$(gc convoy status "$GC_BEAD_ID" --json)
-WORK_BEAD_ID=$(printf '%s' "$CONVOY_STATUS" | jq -r 'if (.children | length) == 1 then .children[0].id else empty end')
-WORK_JSON=$(gc bd show "$WORK_BEAD_ID" --json)
-WORK_STATUS=$(printf '%s' "$WORK_JSON" | jq -r '.[0].status // empty')
-WORK_ASSIGNEE=$(printf '%s' "$WORK_JSON" | jq -r '.[0].assignee // empty')
-if [ "$WORK_STATUS" != "in_progress" ] || [ "$WORK_ASSIGNEE" != "$EXPECTED_ASSIGNEE" ]; then
+# Read the convoy + work bead with retry — same unreadable-is-not-terminal
+# discipline as the claim block. An unreadable state (empty JSON, a convoy blip,
+# or 0/>=2 children so WORK_BEAD_ID is empty) is NOT proof that submit-and-exit
+# already ran. Only a SUCCESSFUL read showing the bead genuinely moved off this
+# session (closed, or reassigned to refinery) means it is done.
+WORK_BEAD_ID=""
+WORK_STATUS=""
+WORK_ASSIGNEE=""
+READ_OK=0
+READ_TRY=0
+while [ "$READ_TRY" -lt 3 ]; do
+  READ_TRY=$((READ_TRY + 1))
+  CONVOY_STATUS=$(gc convoy status "$GC_BEAD_ID" --json 2>/dev/null)
+  WORK_BEAD_ID=$(printf '%s' "$CONVOY_STATUS" | jq -r 'if (.children | length) == 1 then .children[0].id else empty end' 2>/dev/null)
+  if [ -n "$WORK_BEAD_ID" ]; then
+    WORK_JSON=$(gc bd show "$WORK_BEAD_ID" --json 2>/dev/null)
+    SHOW_CODE=$?
+    WORK_STATUS=$(printf '%s' "$WORK_JSON" | jq -r '.[0].status // empty' 2>/dev/null)
+    WORK_ASSIGNEE=$(printf '%s' "$WORK_JSON" | jq -r '.[0].assignee // empty' 2>/dev/null)
+    if [ "$SHOW_CODE" -eq 0 ] && [ -n "$WORK_STATUS" ] && [ -n "$WORK_ASSIGNEE" ]; then
+      READ_OK=1
+      break
+    fi
+  fi
+  sleep 1
+done
+if [ "$READ_OK" -eq 1 ] && { [ "$WORK_STATUS" != "in_progress" ] || [ "$WORK_ASSIGNEE" != "$EXPECTED_ASSIGNEE" ]; }; then
   echo "ALREADY_SUBMITTED $WORK_BEAD_ID status=$WORK_STATUS assignee=$WORK_ASSIGNEE — draining."
   gc runtime drain-ack
   exit
 fi
+# Unreadable after retries, or still in_progress for this session: DO NOT assume
+# already-submitted — fall through and run submit-and-exit. A stranded
+# in_progress bead with an unpushed branch is the worse outcome.
 ```
 
 The `auto_push=false` opt-out (mol-pr-from-issue's halt-at-branch-ready) is

--- a/gastown/template-fragments/approval-fallacy.template.md
+++ b/gastown/template-fragments/approval-fallacy.template.md
@@ -13,54 +13,41 @@ When work is done, finish the cycle. Do not summarize and wait for permission.
 {{ define "approval-fallacy-polecat" }}
 ## No Idle Polecats
 
-When implementation and checks are done, run the done sequence immediately.
-There is no approval wait. An idle polecat blocks the refinery and wastes the
-pool slot.
+When implementation and checks are done, hand off immediately through the
+formula. There is no approval wait. An idle polecat blocks the refinery and
+wastes the pool slot.
 
-### The Done Sequence
+### The Done Sequence Lives in the Formula
+
+The `mol-polecat-work` `submit-and-exit` step is the single source of truth for
+handoff — branch-shape gate, push + push-verify, metadata, refinery
+reassignment, wake/nudge, and drain. **Run that step.**
+
+**If you have already run submit-and-exit, do NOT run it again** — drain and
+exit. Running the done sequence twice is a bug:
 
 ```bash
-# Explicit opt-out gate: respect mol-pr-from-issue auto_push=false (halt-at-branch-ready).
-AUTO_PUSH=$(gc bd show <work-bead> --json | jq -r '.[0].metadata | if has("auto_push") then (.auto_push | tostring) else "" end')
-if [ "$AUTO_PUSH" = "false" ]; then
-  echo "auto_push=false: halting at branch-ready (no push, no refinery handoff)"
-  BRANCH=$(git branch --show-current)
-  gc bd update <work-bead> \
-    --status=open --assignee="" \
-    --set-metadata branch="$BRANCH" \
-    --set-metadata target={{ .DefaultBranch }} \
-    --set-metadata branch_ready=true \
-    --set-metadata halt_reason=auto_push_false \
-    --set-metadata gc.routed_to="" \
-    --notes "Branch ready: auto_push=false (no push, no refinery handoff)"
-  gc runtime drain-ack
-  exit 0
-fi
-git push origin HEAD && {
-  BRANCH=$(git branch --show-current)
-  REMOTE_REF=$(git ls-remote origin "refs/heads/$BRANCH" 2>/dev/null | awk '{print $1}')
-  LOCAL_HEAD=$(git rev-parse HEAD)
-  if [ -z "$REMOTE_REF" ] || [ "$REMOTE_REF" != "$LOCAL_HEAD" ]; then
-    echo "PUSH VERIFICATION FAILED: origin/$BRANCH does not match local HEAD. Aborting handoff."
-    gc runtime drain-ack
-    exit 1
-  fi
-} || { echo "PUSH FAILED. Aborting handoff — bead stays with polecat."; gc runtime drain-ack; exit 1; }
-gc bd update <work-bead> \
-  --set-metadata branch=$(git branch --show-current) \
-  --set-metadata target={{ .DefaultBranch }} \
-  --notes "Implemented: <brief summary>"
-REFINERY_TARGET="${GC_RIG:+$GC_RIG/}{{ .BindingPrefix }}refinery"
-gc bd update <work-bead> --status=open --assignee="$REFINERY_TARGET" --set-metadata gc.routed_to=""
 gc runtime drain-ack
 exit
 ```
 
-This pushes your branch, sets metadata so the Refinery knows what to merge,
-reassigns the work bead to the Refinery, and signals the reconciler to kill
-this session. `gc runtime drain-ack` makes the shutdown immediate. Polecats
-do not push to main, close beads, create MR beads, or wait around.
+The only opt-out worth checking inline is `auto_push=false` (mol-pr-from-issue's
+halt-at-branch-ready). Derive the work bead from your convoy exactly as the
+formula's workspace-setup step does — never pass a bare or guessed id to `bd`,
+which fuzzy-matches and can reassign the wrong bead. `$GC_BEAD_ID` is the convoy
+the molecule was poured on:
 
-If work appears already merged, still reassign it to the Refinery with a note.
-Only the Refinery verifies patch identity and closes beads.
+```bash
+CONVOY_STATUS=$(gc convoy status "$GC_BEAD_ID" --json)
+WORK_BEAD_ID=$(printf '%s' "$CONVOY_STATUS" | jq -r 'if (.children | length) == 1 then .children[0].id else empty end')
+AUTO_PUSH=$(gc bd show "$WORK_BEAD_ID" --json | jq -r '.[0].metadata | if has("auto_push") then (.auto_push | tostring) else "" end')
+```
+
+When `AUTO_PUSH` is `false`, submit-and-exit halts at branch-ready (no push, no
+refinery handoff). Otherwise it pushes and reassigns to the refinery — the
+mutation is the formula's, the check above is read-only.
+
+Polecats do not push to main, close beads, create MR beads, or wait around. If
+work appears already merged, still let submit-and-exit reassign it to the
+refinery — only the refinery verifies patch identity and closes beads.
 {{ end }}

--- a/gastown/template-fragments/approval-fallacy.template.md
+++ b/gastown/template-fragments/approval-fallacy.template.md
@@ -52,7 +52,7 @@ while [ "$READ_TRY" -lt 3 ]; do
     SHOW_CODE=$?
     WORK_STATUS=$(printf '%s' "$WORK_JSON" | jq -r '.[0].status // empty' 2>/dev/null)
     WORK_ASSIGNEE=$(printf '%s' "$WORK_JSON" | jq -r '.[0].assignee // empty' 2>/dev/null)
-    if [ "$SHOW_CODE" -eq 0 ] && [ -n "$WORK_STATUS" ] && [ -n "$WORK_ASSIGNEE" ]; then
+    if [ "$SHOW_CODE" -eq 0 ] && [ -n "$WORK_STATUS" ]; then
       READ_OK=1
       break
     fi

--- a/gastown/template-fragments/approval-fallacy.template.md
+++ b/gastown/template-fragments/approval-fallacy.template.md
@@ -23,29 +23,31 @@ The `mol-polecat-work` `submit-and-exit` step is the single source of truth for
 handoff — branch-shape gate, push + push-verify, metadata, refinery
 reassignment, wake/nudge, and drain. **Run that step.**
 
-**If you have already run submit-and-exit, do NOT run it again** — drain and
-exit. Running the done sequence twice is a bug:
+**Do NOT run submit-and-exit twice** — running the done sequence twice is a bug.
+Do not trust memory for this; check mechanically. Derive the work bead from your
+convoy exactly as the formula's workspace-setup step does — never pass a bare or
+guessed id to `bd`, which fuzzy-matches and can reassign the wrong bead.
+`$GC_BEAD_ID` is the convoy the molecule was poured on. If the work bead is no
+longer `in_progress` for this session, submit-and-exit already reassigned it —
+drain and exit. Otherwise run it:
 
 ```bash
-gc runtime drain-ack
-exit
-```
-
-The only opt-out worth checking inline is `auto_push=false` (mol-pr-from-issue's
-halt-at-branch-ready). Derive the work bead from your convoy exactly as the
-formula's workspace-setup step does — never pass a bare or guessed id to `bd`,
-which fuzzy-matches and can reassign the wrong bead. `$GC_BEAD_ID` is the convoy
-the molecule was poured on:
-
-```bash
+EXPECTED_ASSIGNEE="${BEADS_ACTOR:-${GC_SESSION_NAME:-${GC_SESSION_ID:-${GC_AGENT:-}}}}"
 CONVOY_STATUS=$(gc convoy status "$GC_BEAD_ID" --json)
 WORK_BEAD_ID=$(printf '%s' "$CONVOY_STATUS" | jq -r 'if (.children | length) == 1 then .children[0].id else empty end')
-AUTO_PUSH=$(gc bd show "$WORK_BEAD_ID" --json | jq -r '.[0].metadata | if has("auto_push") then (.auto_push | tostring) else "" end')
+WORK_JSON=$(gc bd show "$WORK_BEAD_ID" --json)
+WORK_STATUS=$(printf '%s' "$WORK_JSON" | jq -r '.[0].status // empty')
+WORK_ASSIGNEE=$(printf '%s' "$WORK_JSON" | jq -r '.[0].assignee // empty')
+if [ "$WORK_STATUS" != "in_progress" ] || [ "$WORK_ASSIGNEE" != "$EXPECTED_ASSIGNEE" ]; then
+  echo "ALREADY_SUBMITTED $WORK_BEAD_ID status=$WORK_STATUS assignee=$WORK_ASSIGNEE — draining."
+  gc runtime drain-ack
+  exit
+fi
 ```
 
-When `AUTO_PUSH` is `false`, submit-and-exit halts at branch-ready (no push, no
-refinery handoff). Otherwise it pushes and reassigns to the refinery — the
-mutation is the formula's, the check above is read-only.
+The `auto_push=false` opt-out (mol-pr-from-issue's halt-at-branch-ready) is
+handled inside submit-and-exit itself: when set, it halts at branch-ready (no
+push, no refinery handoff); otherwise it pushes and reassigns to the refinery.
 
 Polecats do not push to main, close beads, create MR beads, or wait around. If
 work appears already merged, still let submit-and-exit reassign it to the

--- a/gastown/template-fragments/propulsion.template.md
+++ b/gastown/template-fragments/propulsion.template.md
@@ -137,21 +137,20 @@ agent. The pool thinks it's full. New work can't be dispatched.
 
 ## Your Role: A Piston
 
-**Your startup behavior:**
-1. Check for work (`{{ .AssignedInProgressQuery }}`)
-2. Work MUST be assigned (polecats always have work) → EXECUTE immediately
-3. If nothing assigned → ERROR: escalate to Witness
-
-If you were nudged rather than freshly spawned, run `gc hook --claim --json`.
-That single command checks assigned work first (session bead ID, runtime
-session name, then alias), falls through to routed pool work, and performs the
-atomic claim before you inspect the bead.
+**Your startup behavior:** run the scripted claim block in the Startup Protocol
+as your first action. `gc hook --claim --json` is the ONLY permitted discovery
+source — it checks assigned work first (session bead ID, runtime session name,
+then alias), falls through to routed pool work, and performs the atomic claim
+before you inspect the bead. Do NOT run `bd ready`, `bd list`, or any other
+search to find work; that races other polecats. Work only the bead the claim
+block prints as `CLAIMED_BEAD_ID`.
 
 Formula workflows are split into child step beads. After closing a step bead,
 immediately run `gc hook --claim --json` again. Keep claiming and executing
 ready steps until a final formula step drains you or the hook returns no work.
 
-You were spawned with work. There is no extra decision to make. Run it.
+You were spawned with work. There is no extra decision to make. Run the claim
+block, then run what it hands you.
 
 **Who depends on you:** The witness monitors your health. The refinery waits
 for your branch. The mayor's dispatch plan assumes you're grinding. Every

--- a/gastown/tests/test_polecat_churn_watcher.sh
+++ b/gastown/tests/test_polecat_churn_watcher.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+SCRIPT="$ROOT/gastown/assets/scripts/polecat-churn-watcher.sh"
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+write_gc_stub() {
+    local bin="$1"
+    mkdir -p "$bin"
+    cat >"$bin/gc" <<'SH'
+#!/usr/bin/env sh
+# Only `gc --rig <rig> bd list --status=open --json` is exercised here.
+case "$*" in
+    *"bd list"*"--json"*) cat "$GC_BEADS_JSON" ;;
+    *) printf '[]' ;;
+esac
+SH
+    chmod +x "$bin/gc"
+}
+
+test_exact_session_match_is_churn_and_handoff_is_not() {
+    local tmp city bin beads pollers logdir
+    tmp=$(mktemp -d)
+    city="$tmp/city"
+    bin="$tmp/bin"
+    beads="$tmp/beads.json"
+    pollers="$city/.gc/nudges/pollers"
+    logdir="$tmp/logs"
+    mkdir -p "$city" "$pollers" "$logdir"
+    : >"$city/city.toml"
+    write_gc_stub "$bin"
+
+    # A dead session's churned claim (open + unassigned + exact polecat_session),
+    # a normal refinery handoff (open but assigned — must be excluded), a live
+    # session's bead, and a bead whose work_dir merely contains the dead session
+    # name as a substring (must NOT false-positive under exact-match keying).
+    cat >"$beads" <<'JSON'
+[
+  {"id":"churn-1","assignee":"","metadata":{"polecat_session":"deadsess"}},
+  {"id":"handoff-1","assignee":"refinery","metadata":{"polecat_session":"deadsess","work_dir":"/w/deadsess"}},
+  {"id":"live-1","assignee":"","metadata":{"polecat_session":"othersess"}},
+  {"id":"substr-1","assignee":"","metadata":{"work_dir":"/w/deadsess/wt"}}
+]
+JSON
+
+    # Tick 1: the dead session is still live (pid file present). Seeds the state
+    # file so tick 2 can observe the disappearance.
+    : >"$pollers/polecat-deadsess.pid"
+    GC_CITY="$city" GC_RIG="helm" LOG_DIR="$logdir" \
+        GC_BEADS_JSON="$beads" PATH="$bin:$PATH" bash "$SCRIPT"
+
+    # Tick 2: the pid file is gone -> the session disappeared.
+    rm -f "$pollers/polecat-deadsess.pid"
+    GC_CITY="$city" GC_RIG="helm" LOG_DIR="$logdir" \
+        GC_BEADS_JSON="$beads" PATH="$bin:$PATH" bash "$SCRIPT"
+
+    local log="$logdir/polecat-churn.log"
+    [[ -f "$log" ]] || fail "churn watcher wrote no log"
+    grep -F '"event":"polecat_killed_mid_claim"' "$log" >/dev/null ||
+        fail "exact metadata.polecat_session match was not detected as churn"
+    grep -F '"bead":"churn-1"' "$log" >/dev/null ||
+        fail "the churned claim bead was not reported"
+    ! grep -F 'handoff-1' "$log" >/dev/null ||
+        fail "a refinery-handoff bead (assigned) was wrongly flagged as churn"
+    ! grep -F 'live-1' "$log" >/dev/null ||
+        fail "a different live session's bead was wrongly flagged"
+    ! grep -F 'substr-1' "$log" >/dev/null ||
+        fail "a work_dir substring match wrongly false-positived as churn"
+}
+
+test_exact_session_match_is_churn_and_handoff_is_not
+
+echo "polecat churn watcher tests passed"


### PR DESCRIPTION
# Harden the polecat work protocol against races, duplicate work, and failed drains

## Why

An architecture audit of the polecat work loop (across gascity, beads, and this pack) found the gastown polecat protocol pushes concurrency safety onto model reasoning where the sibling `gascity` pack already enforces it mechanically. The gaps produce the failure modes operators see: polecats racing each other, duplicating work, failing to claim, and failing to drain.

This PR ports the proven `gascity/roles/prompts/shared/gc-role-worker.md.tmpl` discipline into the gastown polecat and closes the surrounding protocol holes. Pack text and formulas only; no gascity or beads changes.

## What changed

- **Claim discipline** (`agents/polecat/prompt.template.md`): one canonical scripted claim via `gc hook --claim --json`, a post-claim ownership verification (assignee and status must match this session) before any work, STOP-and-drain on rejection, a resume-time re-verify against the work bead (pool restarts mint new session identities), and a ban on freelance `bd ready`/`bd list` discovery. Read failures retry rather than being treated as terminal, so a transient blip can neither strand a claimed bead nor drop a push.
- **One done-sequence** (`prompt.template.md`, `template-fragments/approval-fallacy.template.md`): the three divergent copies collapse to the formula's `submit-and-exit` as the single source of truth, with a mechanical "already submitted?" guard so a compaction or restart can't double-push or wrongly drain.
- **Evidence-gated shutdown dance** (`formulas/mol-shutdown-dance.toml`): a progress check on the target's claimed-bead `updated_at` and worktree mtime pardons a worker that is alive inside a long tool call, instead of killing it as dead.
- **Warrant dedup** (`mol-witness-patrol.toml`, `mol-deacon-patrol.toml`): all warrant filers skip when an open warrant already exists for the same target, so patrols can't spawn concurrent shutdown dances against one worker.
- **Refinery already-merged short-circuit** (`mol-refinery-patrol.toml`): a branch already merged to the base closes as merged instead of escalating a false completion to a human, gated on a real post-fork commit so a zero-commit branch still trips the false-completion guard, with explicit git-error handling. The path flows into the normal cleanup and next-iteration tail rather than stalling the patrol loop.
- **Churn-watcher** (`assets/scripts/polecat-churn-watcher.sh`): keys on an exact `metadata.polecat_session` (now stamped on claim) and only flags open-and-unassigned beads, so a normal refinery handoff is no longer a false positive.

## Test plan

- `python3 -m pytest tests/`: 60 passed
- `bash gastown/tests/test_gastown_pack_assets.sh`: pass
- `bash gastown/tests/test_polecat_churn_watcher.sh`: new test; asserts detection of a dead-session orphan and non-detection of the handoff, live-session, and work_dir-substring cases
- `python3 validate_registry.py registry.toml`: ok
- `bash -n` on the churn-watcher and every edited embedded-bash block; all touched TOML parses under `tomllib`

## Review

Reviewed across multiple rounds by independent reviewers plus a Codex grounded pass on the embedded shell. Each fix round was re-reviewed until clean; findings and their closures are captured in the branch history.
