### PR TITLE
fix(registry): re-pin slack-full 0.0.3 + slack-channel 0.1.1 to the on-main re-stamp commit

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -172,8 +172,8 @@ schema = 1
   [[pack.release]]
     version = "0.0.3"
     ref = "main"
-    commit = "0d4bcb98416fb1e3bbc1e4a58070def0c86c4da9"
-    hash = "sha256:0a82cd34281a9f14149606b7e468d250f879ed7aed1f7f0184e48f3db847426d"
+    commit = "23605740d0dd0d7dcd0bfcedbac347980547648c"
+    hash = "sha256:2d2255e68175b7d464845100654839a0956e8cd6fefa259e85cd03915213186b"
     description = "Ship idempotent reply-current (stops delivered-but-timed-out double-post) and mark pack scripts/tests executable to align release hash with materialized modes."
 
 [[pack]]
@@ -192,7 +192,7 @@ schema = 1
   [[pack.release]]
     version = "0.1.1"
     ref = "main"
-    commit = "0d4bcb98416fb1e3bbc1e4a58070def0c86c4da9"
+    commit = "23605740d0dd0d7dcd0bfcedbac347980547648c"
     hash = "sha256:e8da9a9dab6e6d3ce8a3cded94104a1c64d88f39130e63b09653ce3e7457dd36"
     description = "Ship idempotent reply-current (stops delivered-but-timed-out double-post) and mark schema test executable to align release hash with materialized modes."
 


### PR DESCRIPTION
The two releases are pinned to `0d4bcb98`, a commit on the unmerged `bd-gpk-9qxy` branch. It is not reachable from `main`, so a CI checkout (or any fresh clone) does not have the object, and `validate_registry` fails with `commit does not contain slack-full/pack.toml` on **every** packs PR regardless of what the PR changes. Local runs pass only in clones that happen to have that branch fetched.

The content is on `main` at `23605740` (#163: "rebase mode-only +x sweep on upstream main, re-stamp slack-full 0.0.3 + slack-channel 0.1.1"), which is the intended pin. This re-pins both releases there.

- **slack-channel 0.1.1**: hash unchanged; `main`'s tree at `23605740` reproduces the stored hash exactly.
- **slack-full 0.0.3**: hash updated to the value the on-`main` content produces. `main`'s materialized file modes differ from the unmerged branch, and no `main` commit reproduces the old branch-only hash, so aligning to `main` completes the re-stamp #163 began (its stated intent was to "align release hash with materialized modes").

`python3 validate_registry.py` passes, and `23605740` is an ancestor of `main`, so CI checkouts will have the object. Unblocks the packs `Check` job for all open PRs (including #185).