### PR TITLE
feat(gascity): resolve derived-pack build schemas via GC_BUILD_SCHEMA_ROOTS

### DIFF
--- a/gascity/assets/scripts/validate_build_artifact.py
+++ b/gascity/assets/scripts/validate_build_artifact.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import sys
 from dataclasses import dataclass
@@ -73,14 +74,32 @@ def parse_front_matter(text: str) -> tuple[str, dict[str, Any], str]:
     return schema_id, data, match.group("body")
 
 
+def schema_roots() -> list[Path]:
+    # Base root always first: a published base schema id resolves from the
+    # base pack before any extra root is consulted, so extra roots can only
+    # ADD new ids — they can never shadow or relax a published base schema
+    # (REQUIREMENTS "Schema IDs are immutable compatibility contracts").
+    # GC_BUILD_SCHEMA_ROOTS is os.pathsep-separated; missing dirs are skipped.
+    roots = [SCHEMA_ROOT]
+    for raw in os.environ.get("GC_BUILD_SCHEMA_ROOTS", "").split(os.pathsep):
+        raw = raw.strip()
+        if not raw:
+            continue
+        root = Path(raw)
+        if root.is_dir():
+            roots.append(root)
+    return roots
+
+
 def load_schema(schema_id: str) -> dict[str, Any]:
     if yaml is None:
         raise ValidationError("PyYAML is required to parse build schemas")
-    for path in sorted(SCHEMA_ROOT.glob("*.yaml")):
-        raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
-        if isinstance(raw, dict) and raw.get("schema_id") == schema_id:
-            validate_schema_definition(raw)
-            return raw
+    for root in schema_roots():
+        for path in sorted(root.glob("*.yaml")):
+            raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+            if isinstance(raw, dict) and raw.get("schema_id") == schema_id:
+                validate_schema_definition(raw)
+                return raw
     raise ValidationError(f"unknown build artifact schema {schema_id!r}")
 
 

--- a/gascity/tests/test_validators.py
+++ b/gascity/tests/test_validators.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import os
 import pathlib
 import sys
 import tempfile
 import unittest
+from unittest import mock
 from contextlib import redirect_stderr, redirect_stdout
 import io
 
@@ -550,6 +552,54 @@ findings:
             self.assertEqual(code, 1)
             self.assertIn("error:", stderr.getvalue())
             self.assertNotIn("Traceback", stderr.getvalue())
+
+
+class BuildArtifactSchemaRootsTests(unittest.TestCase):
+    def _write_schema(self, root: pathlib.Path, name: str, schema_id: str) -> None:
+        (root / name).write_text(
+            "schema_id: " + schema_id + "\n"
+            "required_front_matter: [schema, status, trace]\n"
+            "allowed_statuses: [approved]\n"
+            "coverage_statuses: [covered]\n"
+            "required_sections: []\n",
+            encoding="utf-8",
+        )
+
+    def test_extra_root_resolves_new_schema_id(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            self._write_schema(root, "custom.v1.yaml", "acme.build.custom.v1")
+            with mock.patch.dict(os.environ, {"GC_BUILD_SCHEMA_ROOTS": str(root)}):
+                schema = build_artifact_validator.load_schema("acme.build.custom.v1")
+            self.assertEqual(schema["schema_id"], "acme.build.custom.v1")
+
+    def test_extra_root_cannot_shadow_base_schema_id(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            self._write_schema(root, "requirements.v1.yaml", "gc.build.requirements.v1")
+            with mock.patch.dict(os.environ, {"GC_BUILD_SCHEMA_ROOTS": str(root)}):
+                schema = build_artifact_validator.load_schema("gc.build.requirements.v1")
+            # Base-first ordering: the published base definition wins; the
+            # shadow attempt in the extra root is never consulted.
+            self.assertIn("workflow.id", schema.get("required_front_matter", []))
+
+    def test_unset_env_is_byte_identical_base_behavior(self) -> None:
+        env = {k: v for k, v in os.environ.items() if k != "GC_BUILD_SCHEMA_ROOTS"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            self.assertEqual(
+                build_artifact_validator.schema_roots(),
+                [build_artifact_validator.SCHEMA_ROOT],
+            )
+            with self.assertRaises(build_artifact_validator.ValidationError):
+                build_artifact_validator.load_schema("acme.build.custom.v1")
+
+    def test_missing_or_blank_extra_roots_are_skipped(self) -> None:
+        bogus = os.pathsep.join(["", "  ", "/nonexistent/schema/root"])
+        with mock.patch.dict(os.environ, {"GC_BUILD_SCHEMA_ROOTS": bogus}):
+            self.assertEqual(
+                build_artifact_validator.schema_roots(),
+                [build_artifact_validator.SCHEMA_ROOT],
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

`gascity/REQUIREMENTS.md §Artifact Layout And Schemas` invites derived packs to extend the schema set:

> "Derived packs may add stricter methodology-specific schemas or extension fields, but they must not relax the base schema or replace required base sections, fields, statuses, traceability, or coverage."

…but the shared validator gives them no loading mechanism. `validate_build_artifact.py` hardcodes `SCHEMA_ROOT` to the base pack's own tree and `load_schema()` globs only that directory — no env override, no derived-pack search path. A derived pack's new-id schema (e.g. `acme.build.bdd.v1`) fails as `unknown build artifact schema`, so a derived pack cannot use the shared artifact gate (`build-artifact-valid.sh`) for the stages it adds. Today no derived pack in this repo ships a `schemas/build/` dir — plausibly *because* this resolution gap makes it a dead end.

This is the schema-side sibling of the check-script delivery work in gastownhall/gascity#3834 / `feat/migrate-checks-to-assets`: that migration makes the *gate script* resolvable from pack layers; this PR makes *derived-pack schemas* resolvable by the validator the script invokes.

## Change

- `schema_roots()` — the base `SCHEMA_ROOT` always first, then any extra roots from a new `GC_BUILD_SCHEMA_ROOTS` env var (`os.pathsep`-separated; blank/missing entries skipped).
- `load_schema()` iterates the roots in order.

**Immutability is preserved by construction**: base-first ordering means a published base schema id always resolves from the base pack before any extra root is consulted — extra roots can only ADD new ids, never shadow or relax a published one (per "Schema IDs are immutable compatibility contracts"). `validate_schema_definition()` continues to apply to schemas from extra roots unchanged.

**Zero behavior change when the env var is unset** — `schema_roots()` returns exactly `[SCHEMA_ROOT]` and `load_schema()` is unchanged in effect (covered by an explicit test).

The CLI surface (`--schema`/`--path`) and `build-artifact-valid.sh` are untouched: a city/deployment that wants derived-pack schemas exports the env var wherever the check runs.

## Tests

New `BuildArtifactSchemaRootsTests` in `gascity/tests/test_validators.py`:

1. `test_extra_root_resolves_new_schema_id` — a new-id schema in an extra root loads.
2. `test_extra_root_cannot_shadow_base_schema_id` — a `gc.build.requirements.v1` file in an extra root is never consulted; the base definition (with `workflow.id` required) wins.
3. `test_unset_env_is_byte_identical_base_behavior` — unset env → `[SCHEMA_ROOT]` only; unknown id still raises.
4. `test_missing_or_blank_extra_roots_are_skipped` — blank/nonexistent entries degrade silently.

Full `gascity/tests` directory: 171/171 green on this branch.

## Alternatives considered

- `--schema-root` CLI flag: rejected — would require changing `build-artifact-valid.sh` and every formula `[steps.check]` contract; the env var flows through the existing exec seam untouched.
- Globbing derived packs' `schemas/build/` automatically: rejected — the validator has no reliable view of the import graph from its execution context; explicit deployment-owned roots are simpler and auditable.

---
Context: we build a methodology pack downstream that extends `build-base` with additional gated stages (test-first + verification lanes) and hit this as the one blocker to schema-gating them with the shared validator.
