### PR TITLE
fix(compound-engineering): review-loop verdict requires an actionable delta (livelock guard)

### DIFF
--- a/compound-engineering/agents/ce-code-review-synthesizer/prompt.template.md
+++ b/compound-engineering/agents/ce-code-review-synthesizer/prompt.template.md
@@ -4,4 +4,6 @@
 
 Merge Compound Engineering code-review lane outputs into one verdict report. Deduplicate findings, suppress non-actionable noise, classify required fixes, and produce the approval signal consumed by the Gas City implementation-review check.
 
+Verdict contract: `iterate` requires an actionable delta — at least one blocking finding the apply lane can resolve against the reviewed tree inside this loop, or a non-empty apply plan for this iteration. If every finding is non-blocking, suppressed, human-ratified, or out of scope for this loop, or the reviewed tree and finding set are unchanged from the previous iteration, return `approve` (approve-with-notes: findings stay recorded, not gating). A blocking finding fixable only outside this loop never justifies `iterate`.
+
 Do not invoke provider-native subagents, slash commands, task tools, or the upstream plugin runtime. Work only in this assigned review-synthesis lane.

--- a/compound-engineering/assets/workflows/compound-code-review/{target}.apply-review-findings.md
+++ b/compound-engineering/assets/workflows/compound-code-review/{target}.apply-review-findings.md
@@ -20,6 +20,23 @@ perform a no-op pass, update workflow root metadata with
 workflow root metadata with `gc.build.code_review_status=draft` and close with
 `code_review.verdict=iterate`.
 
+Loop-verdict contract (livelock guard): `code_review.verdict=iterate` is
+permitted ONLY when this lane produced an actionable delta: it applied at
+least one fix this iteration, OR at least one blocking finding remains that
+the next iteration of THIS loop can resolve against the reviewed tree. If the
+applied set for this iteration is empty AND every remaining finding is
+non-blocking, suppressed, human-ratified, or resolvable only outside this loop
+(unmerged branches, integration folds, human decisions), the loop has
+converged: update workflow root metadata with
+`gc.build.code_review_status=approved` and close with
+`code_review.verdict=done` (approve-with-notes — findings stay recorded in the
+report and routed to beads/escalation; they do not gate this loop). Re-minting
+the same review lanes on unchanged code cannot produce a different outcome;
+never answer that state with `iterate`. Also record
+`code_review.applied_count=<fixes applied this iteration>` and
+`code_review.actionable_remaining=<remaining findings this loop can still
+resolve>` so the approval check can detect convergence deterministically.
+
 Always close with `gc.outcome=pass`,
 `code_review.report_path=<review fix summary path>`, and
 `code_review.output_path=<review fix summary path>`.

--- a/compound-engineering/assets/workflows/compound-code-review/{target}.synthesize-code-review.md
+++ b/compound-engineering/assets/workflows/compound-code-review/{target}.synthesize-code-review.md
@@ -9,6 +9,18 @@ noise, classify required fixes, and write the approval verdict used by
 `.gc/scripts/checks/implementation-review-approved.sh`. Required fixes must be
 specific enough for the single apply step to resolve them directly.
 
+Verdict contract (livelock guard): `iterate` requires an actionable delta —
+at least one blocking finding the apply lane can resolve against the reviewed
+tree inside this loop, OR a non-empty apply plan for this iteration. If every
+finding is non-blocking, suppressed, human-ratified, or out of scope for this
+loop, and nothing is applicable this iteration, the verdict MUST be `approve`
+with `status: approved` (approve-with-notes: findings stay recorded and
+out-of-loop work is routed to beads/escalation; nothing gates this loop). A
+blocking finding fixable only outside this loop never justifies `iterate`.
+Convergence guard: if the reviewed tree is byte-identical to the previous
+iteration AND the finding set is unchanged, return `approve` — iterating on
+unchanged input is futile.
+
 Read the review context from `gc.build.code_review_context_path` and all lane
 artifacts from `{{artifact_root}}/code-review/`. Write the synthesized report to
 `gc.build.code_review_report_path`, which should be

--- a/gascity/assets/scripts/checks/implementation-review-approved.sh
+++ b/gascity/assets/scripts/checks/implementation-review-approved.sh
@@ -57,6 +57,31 @@ REPORT="$(printf '%s\n' "$MATCHES" | jq -r --arg attempt "$ATTEMPT" '
   ] | last // ""
 ' 2>/dev/null)"
 
+# Convergence guard (opt-in): the apply lane may record how many fixes it
+# applied this iteration and how many remaining findings this loop can still
+# act on. An `iterate` verdict with zero applied fixes and zero actionable
+# remaining findings is a livelock (nothing can change on the next identical
+# iteration), so it is treated as approve-with-notes. Both keys must be
+# present and exactly "0"; when the apply lane does not write them, behavior
+# is unchanged.
+APPLIED_COUNT="$(printf '%s\n' "$MATCHES" | jq -r --arg attempt "$ATTEMPT" '
+  [
+    .[]
+    | select((.metadata["gc.attempt"] // "") == $attempt)
+    | select((.metadata["code_review.applied_count"] // "") != "")
+    | .metadata["code_review.applied_count"]
+  ] | last // ""
+' 2>/dev/null)"
+
+ACTIONABLE_REMAINING="$(printf '%s\n' "$MATCHES" | jq -r --arg attempt "$ATTEMPT" '
+  [
+    .[]
+    | select((.metadata["gc.attempt"] // "") == $attempt)
+    | select((.metadata["code_review.actionable_remaining"] // "") != "")
+    | .metadata["code_review.actionable_remaining"]
+  ] | last // ""
+' 2>/dev/null)"
+
 REVIEW_MODE="$(metadata_value "$ROOT_JSON" "gc.var.review_mode")"
 if [ -z "$REVIEW_MODE" ]; then
   REVIEW_MODE="$(metadata_value "$PARENT_JSON" "gc.var.review_mode")"
@@ -159,6 +184,10 @@ if [ "$VERDICT" != "done" ]; then
       exit 1
       ;;
     *)
+      if [ "$APPLIED_COUNT" = "0" ] && [ "$ACTIONABLE_REMAINING" = "0" ]; then
+        echo "Implementation review converged: verdict=$VERDICT with applied_count=0 and actionable_remaining=0 (no actionable delta; approving with notes)"
+        exit 0
+      fi
       echo "Implementation review needs another iteration: $VERDICT"
       exit 1
       ;;


### PR DESCRIPTION
### Symptom

The compound-code-review loop livelocks. On a review whose findings are all non-blocking, human-ratified, or resolvable only outside the loop (e.g. fixes target unmerged branches), the synthesizer returns `verdict: iterate` on unchanged code, the apply lane completes a no-op pass (`applied_this_iteration: []`) and echoes `iterate`, the approval check correctly fails, and the controller re-mints a full ~15-lane review cycle that reproduces the identical findings — until max_attempts. A production run burned 6 full cycles before manual termination.

### Root cause

`iterate` is permitted without an actionable delta. The apply step's contract says "if required fixes remain → iterate" with no requirement that any fix be applicable inside the loop, and the synthesize step never defines when `iterate` is justified. A blocking finding that can only land elsewhere loops forever.

### Fix

Verdict contract: `iterate` ⇒ (≥1 blocking finding resolvable against the reviewed tree inside this loop) ∨ (non-empty apply plan this iteration). Otherwise approve-with-notes: `status: approved`, findings recorded, out-of-loop work routed to beads/escalation. Convergence guard: reviewed tree byte-identical to the previous iteration ∧ unchanged finding set ⇒ approve — iterating on identical input is definitionally futile.

The apply lane additionally records `code_review.applied_count` and `code_review.actionable_remaining`, and `implementation-review-approved.sh` gains a **deterministic opt-in guard**: `iterate` with `0/0` is convergence → approved with notes. This converts "the model must reason correctly about verdict semantics" into "the model must honestly report two integers" — a much smaller trust surface — and it is fail-safe: missing or nonzero keys → byte-for-byte legacy behavior; it can never suppress a review that applied fixes or has actionable work. (Stub-tested 4/4: 0/0→approve; 0/2→iterate; legacy no-keys→iterate; done→approve.)

### Evidence

The livelocked run's own iteration-6 report: "the resolvable-in-loop set is EMPTY, and iteration-5's apply lane has now proven it by running... completed a full no-op apply pass — `applied_this_iteration: []`, `verdict: iterate`"; "no flips... because the code they review is byte-identical"; verdict still `iterate — status changes_required`.

### Back-compat

Reviews with real blocking in-loop findings or applied fixes behave identically. The check-script guard only fires when both new metadata keys are present and exactly `0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
