### PR TITLE
fix(gastown): stop witness patrol self-burn in next-iteration reconciliation

### DIFF
--- a/gastown/formulas/mol-witness-patrol.toml
+++ b/gastown/formulas/mol-witness-patrol.toml
@@ -529,22 +529,30 @@ Reconcile the wisps assigned to self down to exactly one before pouring or
 burning anything. `$GC_BEAD_ID` is **not** load-bearing here — it is an
 unpopulated optimization in the live witness runtime (confirmed empty for
 this session type; see vg-5kv) and must never gate behavior or cause a
-non-zero exit when absent. The load-bearing signal is an **open-status
-scan**: a patrol wisp stays `status=open` for its entire working life (the
-bootstrap/resume path only ever sets `assignee`), so scanning `--status=open`
-wisps assigned to self reliably finds the current wisp even with
-`$GC_BEAD_ID` empty. Reduce that scan to one `ASSIGNED_WISP`, burning any
-surplus left by a prior raced cycle, then pour+assign the next wisp before
-burning the current one. The steady state (`$GC_BEAD_ID` empty, exactly one
-open wisp already assigned) must fall through to a silent no-op, never an
-error exit — a status=open scan that stops there would confuse "the current
+non-zero exit when absent — but the query below excludes it **by id**
+whenever it *is* set, so a populated `$GC_BEAD_ID` can never be mistaken for
+an already-queued replacement (review pass 4 Finding 1: checking presence of
+`$CURRENT_WISP`/`$ASSIGNED_WISP` alone, without comparing identity, silently
+reproduces this bead's original starvation bug the moment `$GC_BEAD_ID`
+becomes non-empty). The load-bearing signal is an **open-status scan,
+excluding the current wisp's own id**: a patrol wisp stays `status=open` for
+its entire working life (the bootstrap/resume path only ever sets
+`assignee`), so scanning `--status=open` wisps assigned to self — minus
+`$CURRENT_WISP` itself — reliably finds any *other* already-queued wisp even
+with `$GC_BEAD_ID` empty, and never confuses the current wisp for one.
+Reduce that scan to one `ASSIGNED_WISP`, burning any surplus left by a prior
+raced cycle, then pour+assign the next wisp before burning the current one.
+The steady state (`$GC_BEAD_ID` empty, exactly one open wisp already
+assigned) must fall through to a silent no-op, never an error exit — a scan
+that failed to exclude the current wisp by id would confuse "the current
 wisp" for "a leaked one" and burn the only wisp that exists with nothing
 poured to replace it (wisp starvation — see vg-5kv). Matches the
 mol-deacon-patrol / mol-refinery-patrol next-iteration convention.
 ```bash
 CURRENT_WISP=${GC_BEAD_ID:-}
 
-OPEN_WISPS=$(gc bd list --assignee="$GC_AGENT" --status=open --type=molecule --limit=0 --json | jq -r '.[].id')
+OPEN_WISPS=$(gc bd list --assignee="$GC_AGENT" --status=open --type=molecule --limit=0 --json \
+  | jq -r --arg self "$CURRENT_WISP" '.[] | select(.id != $self) | .id')
 ASSIGNED_WISP=$(printf '%s\n' $OPEN_WISPS | sed -n '1p')
 for extra in $(printf '%s\n' $OPEN_WISPS | sed '1d'); do
   gc bd mol burn "$extra" --force

--- a/gastown/formulas/mol-witness-patrol.toml
+++ b/gastown/formulas/mol-witness-patrol.toml
@@ -523,31 +523,65 @@ gc runtime request-restart
 This blocks forever. The controller restarts you. The next wisp
 is already assigned — the new session resumes from context.
 
-**2. Pour next iteration BEFORE burning (reconcile to exactly one):**
+**2. Resolve the current wisp, pour next iteration, then burn this wisp:**
 
-Reuse an already-queued wisp instead of pouring a duplicate. A prior cycle
-may have poured a next wisp without burning, or a restart may have raced —
-keep one open patrol wisp and burn any surplus, so wisps never accumulate.
-Wisp roots are `issue_type=molecule` (never `--type=wisp`, which is not a
-valid gc bd type and matches nothing).
+Reconcile the wisps assigned to self down to exactly one before pouring or
+burning anything. `$GC_BEAD_ID` is **not** load-bearing here — it is an
+unpopulated optimization in the live witness runtime (confirmed empty for
+this session type; see vg-5kv) and must never gate behavior or cause a
+non-zero exit when absent. The load-bearing signal is an **open-status
+scan**: a patrol wisp stays `status=open` for its entire working life (the
+bootstrap/resume path only ever sets `assignee`), so scanning `--status=open`
+wisps assigned to self reliably finds the current wisp even with
+`$GC_BEAD_ID` empty. Reduce that scan to one `ASSIGNED_WISP`, burning any
+surplus left by a prior raced cycle, then pour+assign the next wisp before
+burning the current one. The steady state (`$GC_BEAD_ID` empty, exactly one
+open wisp already assigned) must fall through to a silent no-op, never an
+error exit — a status=open scan that stops there would confuse "the current
+wisp" for "a leaked one" and burn the only wisp that exists with nothing
+poured to replace it (wisp starvation — see vg-5kv). Matches the
+mol-deacon-patrol / mol-refinery-patrol next-iteration convention.
 ```bash
+CURRENT_WISP=${GC_BEAD_ID:-}
+
 OPEN_WISPS=$(gc bd list --assignee="$GC_AGENT" --status=open --type=molecule --limit=0 --json | jq -r '.[].id')
-NEXT=$(printf '%s\n' $OPEN_WISPS | sed -n '1p')
+ASSIGNED_WISP=$(printf '%s\n' $OPEN_WISPS | sed -n '1p')
 for extra in $(printf '%s\n' $OPEN_WISPS | sed '1d'); do
   gc bd mol burn "$extra" --force
 done
-if [ -z "$NEXT" ]; then
-  NEXT=$(gc bd mol wisp mol-witness-patrol --root-only --var binding_prefix='{{binding_prefix}}' --json | jq -r '.new_epic_id')
-  gc bd update "$NEXT" --assignee="$GC_AGENT"
+
+if   [ -n "$CURRENT_WISP" ] && [ -z "$ASSIGNED_WISP" ]; then
+  NEXT=$(gc bd mol wisp mol-witness-patrol --root-only --var binding_prefix='{{binding_prefix}}' --json | jq -r '.new_epic_id // empty')
+  if [ -z "$NEXT" ]; then
+    echo "Could not pour next witness wisp; not burning."
+    gc runtime drain-ack
+    exit 1
+  fi
+  if ! gc bd update "$NEXT" --assignee="$GC_AGENT"; then
+    echo "Could not assign next witness wisp; not burning."
+    gc runtime drain-ack
+    exit 1
+  fi
+  gc bd mol burn "$CURRENT_WISP" --force
+elif [ -n "$CURRENT_WISP" ]; then
+  gc bd mol burn "$CURRENT_WISP" --force
+elif [ -z "$ASSIGNED_WISP" ]; then
+  NEXT=$(gc bd mol wisp mol-witness-patrol --root-only --var binding_prefix='{{binding_prefix}}' --json | jq -r '.new_epic_id // empty')
+  if [ -z "$NEXT" ]; then
+    echo "Could not bootstrap next witness wisp."
+    gc runtime drain-ack
+    exit 1
+  fi
+  if ! gc bd update "$NEXT" --assignee="$GC_AGENT"; then
+    echo "Could not assign bootstrap witness wisp."
+    gc runtime drain-ack
+    exit 1
+  fi
 fi
+# else: current unknown (GC_BEAD_ID empty), one already queued -> nothing to do.
 ```
 
-**3. Burn this wisp:**
-```bash
-gc bd mol burn <this-wisp-id> --force
-```
-
-**4. Exit this turn:**
+**3. Exit this turn:**
 Write exactly:
 ```
 IDLE: no work, exiting turn.
@@ -556,4 +590,4 @@ Then stop immediately. Do NOT sleep, call ScheduleWakeup, or use Monitor.
 The session_sleep policy will restart this session after the configured idle interval;
 the next wisp is already assigned and the restarted session resumes from it.
 
-**Exit criteria:** Next wisp poured, this wisp burned, turn ended with IDLE signal."""
+**Exit criteria:** Next wisp poured and assigned, this wisp burned, turn ended with IDLE signal."""

--- a/gastown/tests/test_mol_witness_patrol_next_iteration.sh
+++ b/gastown/tests/test_mol_witness_patrol_next_iteration.sh
@@ -112,6 +112,20 @@ test_next_iteration_empty_gc_bead_id_one_open_wisp_noop() {
     rm -rf "$work"
 }
 
+test_next_iteration_burns_surplus_without_gc_bead_id() {
+    run_next_iteration '[{"id":"wisp-current"},{"id":"wisp-surplus"}]'
+
+    [[ "$RC" -eq 0 ]] ||
+        fail "next-iteration must exit 0 reconciling a surplus wisp without GC_BEAD_ID (got rc=$RC); output: $(cat "$STDOUT_FILE")"
+    [[ "$(cat "$BURNS_FILE")" == "wisp-surplus" ]] ||
+        fail "next-iteration must burn exactly the surplus wisp (wisp-surplus) and keep wisp-current; burned: $(cat "$BURNS_FILE")"
+    ! grep -q '^bd mol wisp ' "$CALLS_FILE" ||
+        fail "next-iteration must not pour a new wisp when the reconciled set already has an assigned wisp"
+
+    rm -rf "$work"
+}
+
 test_next_iteration_empty_gc_bead_id_one_open_wisp_noop
+test_next_iteration_burns_surplus_without_gc_bead_id
 
 echo "mol-witness-patrol next-iteration tests passed"

--- a/gastown/tests/test_mol_witness_patrol_next_iteration.sh
+++ b/gastown/tests/test_mol_witness_patrol_next_iteration.sh
@@ -69,13 +69,16 @@ MOCKGC
     chmod +x "$1/gc"
 }
 
-# Run the extracted reconciliation bash under a mocked gc (real jq) with
-# GC_BEAD_ID unset — the proven live-witness-runtime shape, see bd memory
-# vg-5kv-gc-bead-id-empty-confirmed-live-witness — and a scripted
-# --status=open wisp set. Leaves RC/CALLS_FILE/BURNS_FILE/STDOUT_FILE/work
-# set in the caller's scope for assertions.
+# Run the extracted reconciliation bash under a mocked gc (real jq). By
+# default GC_BEAD_ID is unset — the proven live-witness-runtime shape, see
+# bd memory vg-5kv-gc-bead-id-empty-confirmed-live-witness. Pass a non-empty
+# 2nd arg to instead exercise the (currently dead-in-production, but not
+# guaranteed to stay dead — see Finding 1, review pass 4) populated-GC_BEAD_ID
+# path. Leaves RC/CALLS_FILE/BURNS_FILE/STDOUT_FILE/work set in the caller's
+# scope for assertions.
 run_next_iteration() {
     local open_wisps_json="$1"
+    local gc_bead_id="${2:-}"
     work=$(mktemp -d)
     write_mock_gc "$work"
     extract_next_iteration_bash "$FORMULA" > "$work/script.sh"
@@ -94,7 +97,11 @@ run_next_iteration() {
       export MOCK_BURN_LOG="$BURNS_FILE"
       export MOCK_OPEN_WISPS_JSON="$open_wisps_json"
       export MOCK_INPROGRESS_JSON='[]'
-      unset GC_BEAD_ID
+      if [ -n "$gc_bead_id" ]; then
+        export GC_BEAD_ID="$gc_bead_id"
+      else
+        unset GC_BEAD_ID
+      fi
       bash "$work/script.sh"
     ) >"$STDOUT_FILE" 2>&1 || RC=$?
 }
@@ -125,7 +132,29 @@ test_next_iteration_burns_surplus_without_gc_bead_id() {
     rm -rf "$work"
 }
 
+test_next_iteration_populated_gc_bead_id_excludes_self() {
+    # Reviewer finding (vg-5kv, review pass 4, Finding 1 [HIGH]): OPEN_WISPS is
+    # computed with the unfiltered --status=open scan, never excluding
+    # $CURRENT_WISP by id. When GC_BEAD_ID happens to be populated (dead code
+    # in production today, but the PR's own prose calls it "an unpopulated
+    # optimization" -- wording that anticipates it becoming populated) and
+    # equals the sole open wisp, ASSIGNED_WISP resolves to that SAME id, the
+    # "-z ASSIGNED_WISP" pour-branch never fires, and the current wisp is
+    # burned with zero replacement -- this bead's original defect, reproduced.
+    run_next_iteration '[{"id":"wisp-current"}]' 'wisp-current'
+
+    [[ "$RC" -eq 0 ]] ||
+        fail "next-iteration must exit 0 when GC_BEAD_ID equals the sole open wisp (got rc=$RC); output: $(cat "$STDOUT_FILE")"
+    grep -q '^bd mol wisp ' "$CALLS_FILE" ||
+        fail "next-iteration must pour a replacement wisp before burning the current one when GC_BEAD_ID matches the only open wisp; calls: $(cat "$CALLS_FILE")"
+    [[ "$(cat "$BURNS_FILE")" == "wisp-current" ]] ||
+        fail "next-iteration must burn exactly the OLD id (wisp-current), never the newly-poured one; burned: $(cat "$BURNS_FILE")"
+
+    rm -rf "$work"
+}
+
 test_next_iteration_empty_gc_bead_id_one_open_wisp_noop
 test_next_iteration_burns_surplus_without_gc_bead_id
+test_next_iteration_populated_gc_bead_id_excludes_self
 
 echo "mol-witness-patrol next-iteration tests passed"

--- a/gastown/tests/test_mol_witness_patrol_next_iteration.sh
+++ b/gastown/tests/test_mol_witness_patrol_next_iteration.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+GASTOWN="$ROOT/gastown"
+FORMULA="$GASTOWN/formulas/mol-witness-patrol.toml"
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+# Pull the next-iteration step's reconciliation bash (the fenced ```bash
+# block that resolves CURRENT_WISP) straight out of the live formula TOML.
+# This harness always exercises whatever is currently on disk: red against
+# the PR#189 $GC_BEAD_ID-only version (vg-5kv), green only once the
+# ASSIGNED_WISP open-scan reconciliation replaces it.
+extract_next_iteration_bash() {
+    python3 - "$1" <<'PY'
+import re
+import sys
+import tomllib
+
+with open(sys.argv[1], "rb") as handle:
+    data = tomllib.load(handle)
+
+for step in data.get("steps", []):
+    if step.get("id") == "next-iteration":
+        desc = step["description"]
+        for block in re.findall(r"```bash\n(.*?)\n```", desc, re.S):
+            if "CURRENT_WISP" in block:
+                sys.stdout.write(block)
+                sys.exit(0)
+        sys.exit("next-iteration step has no CURRENT_WISP bash block")
+sys.exit("no next-iteration step found in formula")
+PY
+}
+
+# Mock `gc` — logs every invocation and answers just enough to drive the
+# reconciliation bash through both the defective and corrected shapes.
+# `jq` is left as the real binary; only gc's JSON output is faked.
+write_mock_gc() {
+    cat > "$1/gc" <<'MOCKGC'
+#!/usr/bin/env bash
+echo "$*" >> "$MOCK_CALL_LOG"
+case "$1" in
+  bd)
+    case "$2" in
+      list)
+        if [[ "$*" == *"--status=open"* ]]; then
+          echo "${MOCK_OPEN_WISPS_JSON:-[]}"
+        else
+          echo "${MOCK_INPROGRESS_JSON:-[]}"
+        fi
+        ;;
+      mol)
+        case "$3" in
+          wisp) echo "{\"new_epic_id\": \"${MOCK_NEW_EPIC_ID:-wisp-new}\"}" ;;
+          burn) echo "$4" >> "$MOCK_BURN_LOG" ;;
+        esac
+        ;;
+      update) : ;;
+    esac
+    ;;
+  runtime) : ;;
+esac
+exit 0
+MOCKGC
+    chmod +x "$1/gc"
+}
+
+# Run the extracted reconciliation bash under a mocked gc (real jq) with
+# GC_BEAD_ID unset — the proven live-witness-runtime shape, see bd memory
+# vg-5kv-gc-bead-id-empty-confirmed-live-witness — and a scripted
+# --status=open wisp set. Leaves RC/CALLS_FILE/BURNS_FILE/STDOUT_FILE/work
+# set in the caller's scope for assertions.
+run_next_iteration() {
+    local open_wisps_json="$1"
+    work=$(mktemp -d)
+    write_mock_gc "$work"
+    extract_next_iteration_bash "$FORMULA" > "$work/script.sh"
+
+    CALLS_FILE="$work/calls.log"
+    BURNS_FILE="$work/burns.log"
+    STDOUT_FILE="$work/stdout.log"
+    : > "$CALLS_FILE"
+    : > "$BURNS_FILE"
+
+    RC=0
+    (
+      export PATH="$work:$PATH"
+      export GC_AGENT="voxlingo/gastown.witness"
+      export MOCK_CALL_LOG="$CALLS_FILE"
+      export MOCK_BURN_LOG="$BURNS_FILE"
+      export MOCK_OPEN_WISPS_JSON="$open_wisps_json"
+      export MOCK_INPROGRESS_JSON='[]'
+      unset GC_BEAD_ID
+      bash "$work/script.sh"
+    ) >"$STDOUT_FILE" 2>&1 || RC=$?
+}
+
+test_next_iteration_empty_gc_bead_id_one_open_wisp_noop() {
+    run_next_iteration '[{"id":"wisp-current"}]'
+
+    [[ "$RC" -eq 0 ]] ||
+        fail "next-iteration must exit 0 when GC_BEAD_ID is unset and exactly one open self-assigned wisp exists (got rc=$RC); output: $(cat "$STDOUT_FILE")"
+    [[ ! -s "$BURNS_FILE" ]] ||
+        fail "next-iteration must not burn any wisp in the steady-state noop case; burned: $(cat "$BURNS_FILE")"
+    ! grep -q '^bd mol wisp ' "$CALLS_FILE" ||
+        fail "next-iteration must not pour a new wisp when one is already open and assigned"
+
+    rm -rf "$work"
+}
+
+test_next_iteration_empty_gc_bead_id_one_open_wisp_noop
+
+echo "mol-witness-patrol next-iteration tests passed"


### PR DESCRIPTION
## Summary
- \`mol-witness-patrol\`'s \`next-iteration\` step scanned \`--status=open\` wisps assigned to self to tell a genuinely leaked wisp (from a prior crashed/raced cycle) apart from the current one. But the bootstrap/resume path only ever sets \`assignee\` (never transitions status to \`in_progress\`), so the current wisp *is* open and becomes the only member of that scan.
- Net effect: \`NEXT\` resolves to the current wisp itself, the pour-new-wisp branch is skipped, and the wisp is burned with **no replacement poured** — wisp starvation, breaking the intended continuous same-turn handoff.
- Fix: replace the open-status scan with the \`CURRENT_WISP=${GC_BEAD_ID:-}\` pattern already proven in \`mol-deacon-patrol\` and \`mol-refinery-patrol\`'s own \`next-iteration\` steps — resolve the current wisp from runtime ground truth, pour+validate+assign the next wisp first, then burn the correctly-identified current one.

Companion fix for the same underlying issue: Voxist/beads#21 (\`bd update --claim\` wasn't actually idempotent for gc-orchestrated agents, which had foreclosed the alternate one-line fix of just always calling \`--claim\` on resume).

## Test plan
- [x] \`python3 -c 'tomllib.load(...)'\` — edited TOML parses, same 5-step graph intact
- [x] \`gastown/tests/test_gastown_pack_assets.sh\` — still passes
- [ ] Next witness patrol cycle after this lands: confirm \`next-iteration\` no longer self-burns (manual/runtime verification, can't unit-test a prompt formula)