### PR TITLE
fix(gastown): make the refinery's mr handoff forge-aware (gh or glab)

### DIFF
--- a/gastown/agents/refinery/prompt.template.md
+++ b/gastown/agents/refinery/prompt.template.md
@@ -256,20 +256,50 @@ contradictory record on the bead.
 `metadata.merge_strategy` controls the terminal handoff:
 
 - `direct` — merge to target and push normally
-- `mr` / `pr` — push the rebased source branch and create or update a GitHub PR
+- `mr` / `pr` — push the rebased source branch and create or update a
+  pull/merge request on the rig's forge
 
 In `mr` mode, this pack treats PR creation as the terminal handoff for the
 direct-bead workflow. Record `pr_url` on the work bead, close the bead, and
 leave the source branch intact for the PR lifecycle.
 
-In `mr` / `pr` mode, if `metadata.existing_pr` is set, reuse that PR URL.
-Do not call `gh pr create` for the work bead. Before pushing or closing
-the bead, verify `gh pr view` reports an open same-repository PR whose
-`headRefName` equals `metadata.branch` and whose `baseRefName` equals
-`metadata.target`; then record the canonical PR URL as `pr_url` and close
-the bead when the branch has been pushed. If validation fails, record a
-durable blocked reason on the bead and escalate to mayor instead of
-closing the work.
+### Select the forge first
+
+`mr` mode is not GitHub-only. Before any PR command, resolve the forge from
+the remote — a GitLab rig has no `gh`, and running it there fails the handoff:
+
+```bash
+FORGE_HOST=$(git remote get-url origin | sed -E 's#^[a-z]+://##; s#^[^@]+@##; s#[:/].*$##')
+case "$FORGE_HOST" in
+  github.com) FORGE=gh ;;
+  *gitlab*)   FORGE=glab ;;   # self-managed GitLab included
+  *) echo "unknown forge $FORGE_HOST"; exit 1 ;;   # escalate, do not guess
+esac
+```
+
+If the forge cannot be determined, or its CLI is not installed and
+authenticated, record a durable blocked reason on the bead and escalate to
+mayor. Never fall back to `direct` — that lands unreviewed work on the target
+branch, which is exactly what `mr` mode exists to prevent.
+
+Self-managed GitLab needs `GITLAB_HOST` exported (for example
+`GITLAB_HOST=gitlab.example.com`) before `glab` will target the right instance.
+
+### Create and verify
+
+In `mr` / `pr` mode, if `metadata.existing_pr` is set, reuse that PR URL and do
+not create a new one. Before pushing or closing the bead, verify the request
+exists, is open, targets the **same repository**, and that its source branch
+equals `metadata.branch` and its target branch equals `metadata.target`:
+
+| | GitHub (`gh`) | GitLab (`glab`) |
+|---|---|---|
+| create | `gh pr create --head "$BRANCH" --base "$TARGET" --fill` | `glab mr create --source-branch "$BRANCH" --target-branch "$TARGET" --fill --yes` |
+| verify | `gh pr view "$BRANCH" --json headRefName,baseRefName,state,url` | `glab mr view "$BRANCH" --output json` (`source_branch`, `target_branch`, `state`, `web_url`) |
+
+Then record the canonical URL as `pr_url` and close the bead once the branch has
+been pushed. If validation fails, record a durable blocked reason on the bead and
+escalate to mayor instead of closing the work.
 
 If `metadata.existing_pr` is present while `merge_strategy` is unset or
 `direct`, treat the handoff as `mr`. An existing PR cannot be validated


### PR DESCRIPTION
## Problem

The refinery's `mr` / `pr` handoff hard-codes `gh pr create` and `gh pr view`. On a GitLab-hosted rig those commands don't exist, so the terminal handoff cannot run.

The failure is late and expensive: by the time the refinery reaches the handoff, the polecat has already rebased and pushed the source branch. The work bead ends up with a pushed branch, no merge request, and no reviewer — and `mr` mode's entire purpose (don't land unreviewed work) is defeated without anything obviously breaking.

## Change

Resolve the forge from `git remote get-url origin` and dispatch to `gh` or `glab`:

```sh
FORGE_HOST=$(git remote get-url origin | sed -E 's#^[a-z]+://##; s#^[^@]+@##; s#[:/].*$##')
case "$FORGE_HOST" in
  github.com) FORGE=gh ;;
  *gitlab*)   FORGE=glab ;;   # self-managed GitLab included
  *) escalate ;;
esac
```

Create/verify commands are given for both forges in a small table, preserving every existing rule: `metadata.existing_pr` is reused rather than recreated; the request must be open, same-repository, and match `metadata.branch` / `metadata.target`; the canonical URL is recorded as `pr_url`.

**Fails closed.** An unknown host, or a CLI that is missing or unauthenticated, records a durable blocked reason and escalates to mayor. It never falls back to `direct` — that would land unreviewed work on the target branch, which is the exact outcome `mr` mode exists to prevent.

Self-managed GitLab also needs `GITLAB_HOST` exported for `glab` to target the right instance; noted inline.

## Testing

Forge detection verified against ssh and https remote forms for `github.com` and for a self-managed GitLab host, plus an unrecognized forge (fails closed):

```
https://gitlab.example.dev/group/repo.git    -> glab
git@gitlab.example.dev:group/repo.git        -> glab
git@github.com:org/repo.git                  -> gh
https://github.com/org/repo.git              -> gh
https://bitbucket.org/x/y.git                -> UNKNOWN (escalate)
```

Found while running a worker pool against a GitLab rig: the polecat completed cleanly, pushed `polecat/<bead-id>`, and the refinery had no way to open the merge request.

This is prompt-only; no formula, agent config, or registry change.
