### PR TITLE
fix(gascity): resolve validators from pack assets

### DIFF
--- a/gascity/REQUIREMENTS.md
+++ b/gascity/REQUIREMENTS.md
@@ -193,6 +193,12 @@ The base pack owns machine-readable schemas for base artifacts. The human
 requirements ledger is normative, and schema files are the enforcement target
 for formula checks. Base schemas are expected at stable paths:
 
+Formula checks owned by this pack use paths relative to the defining formula
+layer, such as `../assets/scripts/checks/build-artifact-valid.sh`. Gas City
+resolves those paths to the winning pack layer before instantiation. They are
+not launcher- or store-relative `.gc/scripts` paths, and a target rig is not
+required to install a copy of the validator.
+
 | Schema | Expected path |
 | --- | --- |
 | `gc.build.requirements.v1` | `gascity/schemas/build/requirements.v1.yaml` |

--- a/gascity/formulas/build-base.formula.toml
+++ b/gascity/formulas/build-base.formula.toml
@@ -128,7 +128,7 @@ max_attempts = 3
 
 [steps.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/build-artifact-valid.sh"
+path = "../assets/scripts/checks/build-artifact-valid.sh"
 timeout = "5m"
 
 [[steps]]
@@ -143,7 +143,7 @@ max_attempts = 3
 
 [steps.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/build-artifact-valid.sh"
+path = "../assets/scripts/checks/build-artifact-valid.sh"
 timeout = "5m"
 
 [[steps]]
@@ -165,7 +165,7 @@ max_attempts = 3
 
 [steps.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/build-artifact-valid.sh"
+path = "../assets/scripts/checks/build-artifact-valid.sh"
 timeout = "5m"
 
 [[steps]]
@@ -210,7 +210,7 @@ max_attempts = 3
 
 [steps.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/build-artifact-valid.sh"
+path = "../assets/scripts/checks/build-artifact-valid.sh"
 timeout = "5m"
 
 [[steps]]
@@ -225,7 +225,7 @@ max_attempts = 3
 
 [steps.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/build-artifact-valid.sh"
+path = "../assets/scripts/checks/build-artifact-valid.sh"
 timeout = "5m"
 
 [[steps]]
@@ -240,7 +240,7 @@ max_attempts = 3
 
 [steps.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/build-artifact-valid.sh"
+path = "../assets/scripts/checks/build-artifact-valid.sh"
 timeout = "5m"
 
 [[steps]]

--- a/gascity/formulas/build-basic-review.formula.toml
+++ b/gascity/formulas/build-basic-review.formula.toml
@@ -33,7 +33,7 @@ max_attempts = 6
 
 [template.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/implementation-review-approved.sh"
+path = "../assets/scripts/checks/implementation-review-approved.sh"
 timeout = "10m"
 
 [[template.children]]
@@ -84,5 +84,5 @@ max_attempts = 3
 
 [template.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/build-artifact-valid.sh"
+path = "../assets/scripts/checks/build-artifact-valid.sh"
 timeout = "5m"

--- a/gascity/formulas/build-basic.formula.toml
+++ b/gascity/formulas/build-basic.formula.toml
@@ -33,7 +33,7 @@ max_attempts = 3
 
 [steps.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/build-artifact-valid.sh"
+path = "../assets/scripts/checks/build-artifact-valid.sh"
 timeout = "5m"
 
 [[steps]]
@@ -48,7 +48,7 @@ max_attempts = 3
 
 [steps.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/build-artifact-valid.sh"
+path = "../assets/scripts/checks/build-artifact-valid.sh"
 timeout = "5m"
 
 [[steps]]
@@ -70,7 +70,7 @@ max_attempts = 3
 
 [steps.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/build-artifact-valid.sh"
+path = "../assets/scripts/checks/build-artifact-valid.sh"
 timeout = "5m"
 
 [[steps]]
@@ -124,7 +124,7 @@ max_attempts = 3
 
 [steps.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/build-artifact-valid.sh"
+path = "../assets/scripts/checks/build-artifact-valid.sh"
 timeout = "5m"
 
 [[steps]]

--- a/gascity/formulas/build-from-decompose-base.formula.toml
+++ b/gascity/formulas/build-from-decompose-base.formula.toml
@@ -79,7 +79,7 @@ max_attempts = 3
 
 [steps.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/build-artifact-valid.sh"
+path = "../assets/scripts/checks/build-artifact-valid.sh"
 timeout = "5m"
 
 [[steps]]

--- a/gascity/formulas/build-from-plan-base.formula.toml
+++ b/gascity/formulas/build-from-plan-base.formula.toml
@@ -49,7 +49,7 @@ max_attempts = 3
 
 [steps.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/build-artifact-valid.sh"
+path = "../assets/scripts/checks/build-artifact-valid.sh"
 timeout = "5m"
 
 [[steps]]

--- a/gascity/formulas/build-from-requirements-base.formula.toml
+++ b/gascity/formulas/build-from-requirements-base.formula.toml
@@ -41,7 +41,7 @@ max_attempts = 3
 
 [steps.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/build-artifact-valid.sh"
+path = "../assets/scripts/checks/build-artifact-valid.sh"
 timeout = "5m"
 
 [[steps]]

--- a/gascity/formulas/build-from-review-base.formula.toml
+++ b/gascity/formulas/build-from-review-base.formula.toml
@@ -105,7 +105,7 @@ max_attempts = 3
 
 [steps.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/build-artifact-valid.sh"
+path = "../assets/scripts/checks/build-artifact-valid.sh"
 timeout = "5m"
 
 [[steps]]
@@ -127,7 +127,7 @@ max_attempts = 3
 
 [steps.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/build-artifact-valid.sh"
+path = "../assets/scripts/checks/build-artifact-valid.sh"
 timeout = "5m"
 
 [[steps]]

--- a/gascity/formulas/code-review-base.formula.toml
+++ b/gascity/formulas/code-review-base.formula.toml
@@ -51,5 +51,5 @@ max_attempts = 3
 
 [steps.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/build-artifact-valid.sh"
+path = "../assets/scripts/checks/build-artifact-valid.sh"
 timeout = "5m"

--- a/gascity/formulas/decomposition-base.formula.toml
+++ b/gascity/formulas/decomposition-base.formula.toml
@@ -35,5 +35,5 @@ max_attempts = 3
 
 [steps.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/build-artifact-valid.sh"
+path = "../assets/scripts/checks/build-artifact-valid.sh"
 timeout = "5m"

--- a/gascity/formulas/do-work-item.formula.toml
+++ b/gascity/formulas/do-work-item.formula.toml
@@ -34,5 +34,5 @@ max_attempts = 3
 
 [steps.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/build-artifact-valid.sh"
+path = "../assets/scripts/checks/build-artifact-valid.sh"
 timeout = "5m"

--- a/gascity/formulas/do-work.formula.toml
+++ b/gascity/formulas/do-work.formula.toml
@@ -45,7 +45,7 @@ max_attempts = 3
 
 [steps.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/build-artifact-valid.sh"
+path = "../assets/scripts/checks/build-artifact-valid.sh"
 timeout = "5m"
 
 [[steps]]

--- a/gascity/formulas/fix-loop-base.formula.toml
+++ b/gascity/formulas/fix-loop-base.formula.toml
@@ -62,5 +62,5 @@ max_attempts = 3
 
 [steps.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/build-artifact-valid.sh"
+path = "../assets/scripts/checks/build-artifact-valid.sh"
 timeout = "5m"

--- a/gascity/formulas/github-issue-fix-design-review-work.formula.toml
+++ b/gascity/formulas/github-issue-fix-design-review-work.formula.toml
@@ -34,7 +34,7 @@ max_attempts = 8
 
 [template.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/design-review-approved.sh"
+path = "../assets/scripts/checks/design-review-approved.sh"
 timeout = "10m"
 
 [[template.children]]

--- a/gascity/formulas/implement.formula.toml
+++ b/gascity/formulas/implement.formula.toml
@@ -104,7 +104,7 @@ max_attempts = 3
 
 [steps.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/build-artifact-valid.sh"
+path = "../assets/scripts/checks/build-artifact-valid.sh"
 timeout = "5m"
 
 [[steps]]

--- a/gascity/formulas/implementation-base.formula.toml
+++ b/gascity/formulas/implementation-base.formula.toml
@@ -43,7 +43,7 @@ max_attempts = 3
 
 [steps.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/build-artifact-valid.sh"
+path = "../assets/scripts/checks/build-artifact-valid.sh"
 timeout = "5m"
 
 [[steps]]

--- a/gascity/formulas/implementation-item-base.formula.toml
+++ b/gascity/formulas/implementation-item-base.formula.toml
@@ -32,5 +32,5 @@ max_attempts = 3
 
 [steps.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/build-artifact-valid.sh"
+path = "../assets/scripts/checks/build-artifact-valid.sh"
 timeout = "5m"

--- a/gascity/formulas/planning-base.formula.toml
+++ b/gascity/formulas/planning-base.formula.toml
@@ -55,7 +55,7 @@ max_attempts = 3
 
 [steps.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/build-artifact-valid.sh"
+path = "../assets/scripts/checks/build-artifact-valid.sh"
 timeout = "5m"
 
 [[steps]]
@@ -70,7 +70,7 @@ max_attempts = 3
 
 [steps.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/build-artifact-valid.sh"
+path = "../assets/scripts/checks/build-artifact-valid.sh"
 timeout = "5m"
 
 [[steps]]

--- a/gascity/formulas/review.formula.toml
+++ b/gascity/formulas/review.formula.toml
@@ -58,5 +58,5 @@ max_attempts = 3
 
 [steps.check.check]
 mode = "exec"
-path = ".gc/scripts/checks/build-artifact-valid.sh"
+path = "../assets/scripts/checks/build-artifact-valid.sh"
 timeout = "5m"

--- a/gascity/tests/test_derived_pack_compatibility.py
+++ b/gascity/tests/test_derived_pack_compatibility.py
@@ -474,12 +474,17 @@ class DerivedPackCompatibilityTests(unittest.TestCase):
                             step["check"]["max_attempts"],
                             base_contract.BUILD_ARTIFACT_GATE_MAX_ATTEMPTS,
                         )
-                        self.assertEqual(
-                            step["check"]["check"],
+                        check = step["check"]["check"]
+                        self.assertEqual(check["mode"], "exec")
+                        self.assertEqual(check["timeout"], "5m")
+                        # A derived step may either inherit the gascity
+                        # formula's pack-relative asset or replace the whole
+                        # step with its existing launcher-compatibility path.
+                        self.assertIn(
+                            check["path"],
                             {
-                                "mode": "exec",
-                                "path": base_contract.BUILD_ARTIFACT_CHECK_SCRIPT,
-                                "timeout": "5m",
+                                base_contract.BUILD_ARTIFACT_CHECK_SCRIPT,
+                                base_contract.GASCITY_BUILD_ARTIFACT_CHECK_SCRIPT,
                             },
                         )
                         self.assertEqual(

--- a/gascity/tests/test_formula_assets.py
+++ b/gascity/tests/test_formula_assets.py
@@ -218,7 +218,11 @@ MODE_VAR_DEFAULTS = {
     "github-pr-review": {"interaction_mode": "interactive", "review_mode": "report"},
 }
 
+# Derived packs still use the launcher-installed compatibility path in their
+# explicit step overrides. The base gascity pack owns and resolves its script
+# from the sibling asset tree.
 BUILD_ARTIFACT_CHECK_SCRIPT = ".gc/scripts/checks/build-artifact-valid.sh"
+GASCITY_BUILD_ARTIFACT_CHECK_SCRIPT = "../assets/scripts/checks/build-artifact-valid.sh"
 
 # One produce attempt plus two bounded schema-repair attempts per artifact stage.
 BUILD_ARTIFACT_GATE_MAX_ATTEMPTS = 3
@@ -3542,6 +3546,29 @@ description = "Override sink that writes the base triage report contract."
             self.assertNotIn("/data/projects", text)
             self.assertNotIn("gascity-packs-worktrees", text)
 
+    def test_formula_checks_resolve_from_versioned_pack_assets(self) -> None:
+        root = pathlib.Path(__file__).resolve().parents[1]
+        formula_paths = sorted((root / "formulas").glob("*.formula.toml"))
+        referenced_checks: set[pathlib.Path] = set()
+
+        for formula_path in formula_paths:
+            text = formula_path.read_text(encoding="utf-8")
+            with self.subTest(formula=formula_path.name):
+                self.assertNotIn(
+                    '.gc/scripts/checks/',
+                    text,
+                    "pack-owned validators must not depend on launcher-local .gc files",
+                )
+                for relative_path in re.findall(
+                    r'path = "(\.\./assets/scripts/checks/[^\"]+\.sh)"', text
+                ):
+                    script = (formula_path.parent / relative_path).resolve()
+                    self.assertTrue(script.is_file(), f"missing pack check asset: {script}")
+                    self.assertTrue(os.access(script, os.X_OK), f"{script} must be executable")
+                    referenced_checks.add(script)
+
+        self.assertTrue(referenced_checks, "expected formulas to reference pack check assets")
+
     def test_producer_stages_gate_artifacts_with_bounded_repair(self) -> None:
         root = pathlib.Path(__file__).resolve().parents[1]
 
@@ -3567,7 +3594,7 @@ description = "Override sink that writes the base triage report contract."
                     step["check"]["check"],
                     {
                         "mode": "exec",
-                        "path": BUILD_ARTIFACT_CHECK_SCRIPT,
+                        "path": GASCITY_BUILD_ARTIFACT_CHECK_SCRIPT,
                         "timeout": "5m",
                     },
                 )


### PR DESCRIPTION
## Summary

- migrate all 29 Gas City formula check paths from launcher-relative `.gc/scripts/checks/...` locations to the defining pack layer's `../assets/scripts/checks/...` assets
- document formula-layer path ownership and verify every referenced check exists and is executable
- preserve derived-pack compatibility for inherited pack-relative gates and explicit launcher-compatibility overrides

This removes the accidental requirement that a target rig or transient worker directory contain a separately materialized `.gc/scripts/checks` tree.

## Tests

- `python3 -m unittest gascity.tests.test_formula_assets`
- `python3 -m pytest gascity/tests -q` (168 passed, 11,089 subtests passed)
- broader `python3 -m pytest gascity/tests tests/test_gascity_pack_inference_gate.py -q` used during validation

Fixes #193.

Companion runtime fix: gastownhall/gascity#4128.