### PR TITLE
feat: publish native PostgreSQL and SQLite Beads backend packs

### DIFF
--- a/bd-native-postgres/README.md
+++ b/bd-native-postgres/README.md
@@ -1,0 +1,32 @@
+# Native PostgreSQL Beads backend
+
+This pack selects the PostgreSQL backend compiled into upstream `bd`. Gas City
+uses one PostgreSQL database connection and derives a separate schema for each
+city or rig bead scope. There is no external Beads backend-plugin process.
+
+Requires a `bd` release with `bd init --backend=postgres` support and a local
+PostgreSQL installation reachable through the current OS user's admin access.
+With no URL configured, `gc init` creates the database, login role, generated
+password, and city schema automatically. Set `GC_POSTGRES_ADMIN_URL` when local
+admin access needs an explicit connection.
+
+```toml
+[imports.bd-native-postgres]
+source = "../gascity-packs/bd-native-postgres"
+
+[beads]
+provider = "bd"
+backend = "postgres"
+# Optional: omit for automatic local provisioning.
+postgres_url = "postgres://beads@127.0.0.1:5432/beads?sslmode=disable"
+```
+
+Omit `postgres_url` for automatic local provisioning. Set it only to use an
+already-provisioned PostgreSQL database. Keep its password out of `city.toml`.
+Provide the password through the upstream variable
+`BEADS_PG_PASSWORD`, the compatibility variable `BEADS_POSTGRES_PASSWORD`, a
+scope-local `.beads/.env` file with mode `0600`, or the Beads credentials file.
+
+The city scope defaults to schema `hq`; rig schemas use their Gas City prefix.
+Set `[beads].postgres_schema` only when the city scope needs an explicit name.
+PostgreSQL does not provide Dolt history, remotes, or `bd dolt push/pull`.

--- a/bd-native-postgres/pack.toml
+++ b/bd-native-postgres/pack.toml
@@ -1,0 +1,19 @@
+[pack]
+name = "bd-native-postgres"
+schema = 2
+
+[[backend_plugins]]
+backend = "postgres"
+kind = "native"
+driver = "postgres"
+capabilities = ["provider", "metadata", "postgres-auth", "sql-backend", "no-version-control"]
+
+[backend_plugins.scope]
+model = "per_scope"
+resource = "schema"
+namespace_from = "city_or_prefix"
+inherits_city_connection = true
+metadata_owner = "bd"
+routes = "gc-prefix-routes"
+adopt = "validate_or_repair"
+remove = "preserve"

--- a/bd-native-sqlite/README.md
+++ b/bd-native-sqlite/README.md
@@ -1,0 +1,21 @@
+# Native SQLite Beads backend
+
+This pack selects the SQLite backend compiled into upstream `bd`. It has no
+backend plugin process, server, or credentials. Every Gas City bead scope gets
+its own SQLite file beneath that scope's `.beads/` directory.
+
+Requires a `bd` release with `bd init --backend=sqlite` support.
+
+```toml
+[imports.bd-native-sqlite]
+source = "../gascity-packs/bd-native-sqlite"
+
+[beads]
+provider = "bd"
+backend = "sqlite"
+# sqlite_path = "beads.db" # optional; pack default shown
+```
+
+Gas City initializes each scope with stock `bd`, then all `gc bd` and
+controller operations use the backend recorded in `.beads/metadata.json`.
+SQLite does not provide Dolt history, remotes, or `bd dolt push/pull`.

--- a/bd-native-sqlite/pack.toml
+++ b/bd-native-sqlite/pack.toml
@@ -1,0 +1,20 @@
+[pack]
+name = "bd-native-sqlite"
+schema = 2
+
+[[backend_plugins]]
+backend = "sqlite"
+kind = "native"
+driver = "sqlite"
+sqlite_path = "beads.db"
+capabilities = ["provider", "metadata", "sql-backend", "no-version-control"]
+
+[backend_plugins.scope]
+model = "per_scope"
+resource = "file"
+namespace_from = "prefix"
+inherits_city_connection = false
+metadata_owner = "bd"
+routes = "gc-prefix-routes"
+adopt = "validate_or_repair"
+remove = "preserve"

--- a/registry.toml
+++ b/registry.toml
@@ -261,3 +261,41 @@ schema = 1
     commit = "a1490ecf90238f3af52ab2e7f24e30b5b62cbfc2"
     hash = "sha256:c06f30e61407994cef7e16aafecbc71afbbc9f8cdfd0d506146fdf95837333cf"
     description = "Initial oversight-rig release: rig-scoped project-lead + deterministic escalation machinery."
+
+[[pack]]
+  name = "bd-native-postgres"
+  description = "Stock upstream bd with native PostgreSQL storage, automatic local provisioning, and per-scope schemas."
+  source = "https://github.com/duncan4123/gascity-packs.git//bd-native-postgres"
+  source_kind = "git"
+
+  [[pack.plugin]]
+    kind = "beads-backend"
+    backend = "postgres"
+    display_name = "PostgreSQL (native bd)"
+    capabilities = ["provider", "metadata", "native", "local-provisioning", "postgres-auth", "sql-backend", "no-version-control"]
+
+  [[pack.release]]
+    version = "0.1.0"
+    ref = "native-beads-backends-publish"
+    commit = "c28de5336cf24dfcbed8cbd2bf09572f713dc092"
+    hash = "sha256:5ea0c4320677878737c7edff7a07937be5c233672e7c64394a4e3e1597984324"
+    description = "Selects stock bd's PostgreSQL backend, provisions a local role and database by default, and isolates Gas City scopes by schema."
+
+[[pack]]
+  name = "bd-native-sqlite"
+  description = "Stock upstream bd with native SQLite storage and a separate database file for each Gas City bead scope."
+  source = "https://github.com/duncan4123/gascity-packs.git//bd-native-sqlite"
+  source_kind = "git"
+
+  [[pack.plugin]]
+    kind = "beads-backend"
+    backend = "sqlite"
+    display_name = "SQLite (native bd)"
+    capabilities = ["provider", "metadata", "native", "sql-backend", "no-version-control"]
+
+  [[pack.release]]
+    version = "0.1.0"
+    ref = "native-beads-backends-publish"
+    commit = "c28de5336cf24dfcbed8cbd2bf09572f713dc092"
+    hash = "sha256:e9b802a4ef94eb3a2995847d5c03da85ae945d3566834788d000ae8cb4586955"
+    description = "Selects stock bd's SQLite backend and isolates Gas City scopes by database file."


### PR DESCRIPTION
Publishes two registry-discoverable backend packs for stock upstream bd:

- bd-native-postgres: automatic local role/database/password provisioning by default, explicit URL support for external PostgreSQL, and per-scope schemas
- bd-native-sqlite: per-scope SQLite database files

Depends on gastownhall/gascity#3980. DoltLite remains on the external plugin bridge.

This branch is rebased on current upstream main and changes exactly five files: the two pack manifests, two READMEs, and registry.toml.

Validation:
- registry.toml validator passes
- registry unit tests: 13 passed
- clean registry-driven gc init smoke passes for SQLite
- clean registry-driven gc init smoke passes for PostgreSQL with no URL/password environment; it provisions the local role/database/schema, writes mode-0600 credentials, and supports real gc bd create/list