### PR TITLE
Fix graph-aware claimed work inspection

### DIFF
--- a/gascity/roles/agents/design-author/prompt.template.md
+++ b/gascity/roles/agents/design-author/prompt.template.md
@@ -136,7 +136,7 @@ export GC_CONTINUATION_GROUP="$CLAIM_GROUP"
 printf 'CLAIMED_BEAD_ID=%s\n' "$WORK_ID"
 printf 'CLAIMED_ROOT_BEAD_ID=%s\n' "$CLAIM_ROOT"
 printf 'CLAIMED_CONTINUATION_GROUP=%s\n' "$CLAIM_GROUP"
-bd show "$GC_BEAD_ID"
+gc bd show "$GC_BEAD_ID"
 GC_CLAIM
 ```
 

--- a/gascity/roles/agents/design-implementation-reviewer/prompt.template.md
+++ b/gascity/roles/agents/design-implementation-reviewer/prompt.template.md
@@ -136,7 +136,7 @@ export GC_CONTINUATION_GROUP="$CLAIM_GROUP"
 printf 'CLAIMED_BEAD_ID=%s\n' "$WORK_ID"
 printf 'CLAIMED_ROOT_BEAD_ID=%s\n' "$CLAIM_ROOT"
 printf 'CLAIMED_CONTINUATION_GROUP=%s\n' "$CLAIM_GROUP"
-bd show "$GC_BEAD_ID"
+gc bd show "$GC_BEAD_ID"
 GC_CLAIM
 ```
 

--- a/gascity/roles/agents/design-test-risk-reviewer/prompt.template.md
+++ b/gascity/roles/agents/design-test-risk-reviewer/prompt.template.md
@@ -136,7 +136,7 @@ export GC_CONTINUATION_GROUP="$CLAIM_GROUP"
 printf 'CLAIMED_BEAD_ID=%s\n' "$WORK_ID"
 printf 'CLAIMED_ROOT_BEAD_ID=%s\n' "$CLAIM_ROOT"
 printf 'CLAIMED_CONTINUATION_GROUP=%s\n' "$CLAIM_GROUP"
-bd show "$GC_BEAD_ID"
+gc bd show "$GC_BEAD_ID"
 GC_CLAIM
 ```
 

--- a/gascity/roles/agents/gap-analyst/prompt.template.md
+++ b/gascity/roles/agents/gap-analyst/prompt.template.md
@@ -136,7 +136,7 @@ export GC_CONTINUATION_GROUP="$CLAIM_GROUP"
 printf 'CLAIMED_BEAD_ID=%s\n' "$WORK_ID"
 printf 'CLAIMED_ROOT_BEAD_ID=%s\n' "$CLAIM_ROOT"
 printf 'CLAIMED_CONTINUATION_GROUP=%s\n' "$CLAIM_GROUP"
-bd show "$GC_BEAD_ID"
+gc bd show "$GC_BEAD_ID"
 GC_CLAIM
 ```
 

--- a/gascity/roles/agents/implementation-reviewer/prompt.template.md
+++ b/gascity/roles/agents/implementation-reviewer/prompt.template.md
@@ -136,7 +136,7 @@ export GC_CONTINUATION_GROUP="$CLAIM_GROUP"
 printf 'CLAIMED_BEAD_ID=%s\n' "$WORK_ID"
 printf 'CLAIMED_ROOT_BEAD_ID=%s\n' "$CLAIM_ROOT"
 printf 'CLAIMED_CONTINUATION_GROUP=%s\n' "$CLAIM_GROUP"
-bd show "$GC_BEAD_ID"
+gc bd show "$GC_BEAD_ID"
 GC_CLAIM
 ```
 

--- a/gascity/roles/agents/implementation-worker/prompt.template.md
+++ b/gascity/roles/agents/implementation-worker/prompt.template.md
@@ -136,7 +136,7 @@ export GC_CONTINUATION_GROUP="$CLAIM_GROUP"
 printf 'CLAIMED_BEAD_ID=%s\n' "$WORK_ID"
 printf 'CLAIMED_ROOT_BEAD_ID=%s\n' "$CLAIM_ROOT"
 printf 'CLAIMED_CONTINUATION_GROUP=%s\n' "$CLAIM_GROUP"
-bd show "$GC_BEAD_ID"
+gc bd show "$GC_BEAD_ID"
 GC_CLAIM
 ```
 

--- a/gascity/roles/agents/issue-triager/prompt.template.md
+++ b/gascity/roles/agents/issue-triager/prompt.template.md
@@ -136,7 +136,7 @@ export GC_CONTINUATION_GROUP="$CLAIM_GROUP"
 printf 'CLAIMED_BEAD_ID=%s\n' "$WORK_ID"
 printf 'CLAIMED_ROOT_BEAD_ID=%s\n' "$CLAIM_ROOT"
 printf 'CLAIMED_CONTINUATION_GROUP=%s\n' "$CLAIM_GROUP"
-bd show "$GC_BEAD_ID"
+gc bd show "$GC_BEAD_ID"
 GC_CLAIM
 ```
 

--- a/gascity/roles/agents/publisher/prompt.template.md
+++ b/gascity/roles/agents/publisher/prompt.template.md
@@ -136,7 +136,7 @@ export GC_CONTINUATION_GROUP="$CLAIM_GROUP"
 printf 'CLAIMED_BEAD_ID=%s\n' "$WORK_ID"
 printf 'CLAIMED_ROOT_BEAD_ID=%s\n' "$CLAIM_ROOT"
 printf 'CLAIMED_CONTINUATION_GROUP=%s\n' "$CLAIM_GROUP"
-bd show "$GC_BEAD_ID"
+gc bd show "$GC_BEAD_ID"
 GC_CLAIM
 ```
 

--- a/gascity/roles/agents/requirements-planner/prompt.template.md
+++ b/gascity/roles/agents/requirements-planner/prompt.template.md
@@ -136,7 +136,7 @@ export GC_CONTINUATION_GROUP="$CLAIM_GROUP"
 printf 'CLAIMED_BEAD_ID=%s\n' "$WORK_ID"
 printf 'CLAIMED_ROOT_BEAD_ID=%s\n' "$CLAIM_ROOT"
 printf 'CLAIMED_CONTINUATION_GROUP=%s\n' "$CLAIM_GROUP"
-bd show "$GC_BEAD_ID"
+gc bd show "$GC_BEAD_ID"
 GC_CLAIM
 ```
 

--- a/gascity/roles/agents/review-synthesizer/prompt.template.md
+++ b/gascity/roles/agents/review-synthesizer/prompt.template.md
@@ -136,7 +136,7 @@ export GC_CONTINUATION_GROUP="$CLAIM_GROUP"
 printf 'CLAIMED_BEAD_ID=%s\n' "$WORK_ID"
 printf 'CLAIMED_ROOT_BEAD_ID=%s\n' "$CLAIM_ROOT"
 printf 'CLAIMED_CONTINUATION_GROUP=%s\n' "$CLAIM_GROUP"
-bd show "$GC_BEAD_ID"
+gc bd show "$GC_BEAD_ID"
 GC_CLAIM
 ```
 

--- a/gascity/roles/agents/run-operator/prompt.template.md
+++ b/gascity/roles/agents/run-operator/prompt.template.md
@@ -136,7 +136,7 @@ export GC_CONTINUATION_GROUP="$CLAIM_GROUP"
 printf 'CLAIMED_BEAD_ID=%s\n' "$WORK_ID"
 printf 'CLAIMED_ROOT_BEAD_ID=%s\n' "$CLAIM_ROOT"
 printf 'CLAIMED_CONTINUATION_GROUP=%s\n' "$CLAIM_GROUP"
-bd show "$GC_BEAD_ID"
+gc bd show "$GC_BEAD_ID"
 GC_CLAIM
 ```
 

--- a/gascity/roles/agents/task-decomposer/prompt.template.md
+++ b/gascity/roles/agents/task-decomposer/prompt.template.md
@@ -136,7 +136,7 @@ export GC_CONTINUATION_GROUP="$CLAIM_GROUP"
 printf 'CLAIMED_BEAD_ID=%s\n' "$WORK_ID"
 printf 'CLAIMED_ROOT_BEAD_ID=%s\n' "$CLAIM_ROOT"
 printf 'CLAIMED_CONTINUATION_GROUP=%s\n' "$CLAIM_GROUP"
-bd show "$GC_BEAD_ID"
+gc bd show "$GC_BEAD_ID"
 GC_CLAIM
 ```
 

--- a/gascity/roles/prompts/shared/gc-role-worker.md.tmpl
+++ b/gascity/roles/prompts/shared/gc-role-worker.md.tmpl
@@ -137,7 +137,7 @@ export GC_CONTINUATION_GROUP="$CLAIM_GROUP"
 printf 'CLAIMED_BEAD_ID=%s\n' "$WORK_ID"
 printf 'CLAIMED_ROOT_BEAD_ID=%s\n' "$CLAIM_ROOT"
 printf 'CLAIMED_CONTINUATION_GROUP=%s\n' "$CLAIM_GROUP"
-bd show "$GC_BEAD_ID"
+gc bd show "$GC_BEAD_ID"
 GC_CLAIM
 ```
 

--- a/gascity/tests/test_formula_assets.py
+++ b/gascity/tests/test_formula_assets.py
@@ -214,7 +214,8 @@ class FormulaAssetTests(unittest.TestCase):
         for fragment in (
             "GC_CLAIM",
             "`gc hook` is the only permitted discovery source",
-            "bd update \"$WORK_ID\" --claim --json",
+            "gc hook --claim --json",
+            "gc bd show \"$GC_BEAD_ID\"",
             "CLAIM_REJECTED",
             "gc runtime drain-ack",
             "gc.continuation_group",
@@ -224,6 +225,12 @@ class FormulaAssetTests(unittest.TestCase):
         ):
             with self.subTest(fragment=fragment):
                 self.assertIn(fragment, expected)
+
+        self.assertNotIn(
+            '\nbd show "$GC_BEAD_ID"\n',
+            f"\n{expected}\n",
+            "claimed graph work must be read through the store-aware gc bd wrapper",
+        )
 
         for agent_name in ROLE_AGENTS:
             prompt = root / "roles" / "agents" / agent_name / "prompt.template.md"


### PR DESCRIPTION
After an atomic graph-aware gc hook claim, rig-scoped workers were immediately re-reading the gcg bead with bare bd. Bare bd stayed pinned to the rig Dolt store and returned no issue found for infra SQLite graph beads, stranding review workers. Route the post-claim display through gc bd, sync every generated Gas City role prompt, and pin the protocol in the asset test.\n\nValidation:\n- focused claim-protocol asset test passes\n- full gascity unittest suite has the same seven pre-existing github-issue-triage-work failures as the base; this patch removes the additional stale claim-protocol failure