### PR TITLE
Route all shipped beads commands through gc bd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 
-# Beads / Dolt files (added by bd init)
+# Beads / Dolt files (added by gc bd init)
 .dolt/
 *.db
 .beads-credential-key
@@ -10,7 +10,7 @@
 !.beads/config.yaml
 !.beads/metadata.json
 
-# bd export artifact auto-staged by pre-commit hook (export.git-add: true in
+# gc bd export artifact auto-staged by pre-commit hook (export.git-add: true in
 # /home/ds/gascity-packs/.beads/config.yaml). Keep it out of repo history —
 # beads issues canonical store is the Dolt DB, not this file.
 /issues.jsonl

--- a/bmad/assets/workflows/bmad-build/decompose.md
+++ b/bmad/assets/workflows/bmad-build/decompose.md
@@ -7,7 +7,7 @@ implementation convoy.
 
 Record the implementation convoy ID on the workflow root bead as
 `gc.input_convoy_id=<implementation-convoy-id>` with
-`bd update <workflow-root-id> --set-metadata gc.input_convoy_id=<implementation-convoy-id>`
+`gc bd update <workflow-root-id> --set-metadata gc.input_convoy_id=<implementation-convoy-id>`
 before closing.
 
 Do not invoke provider-native subagents or upstream BMAD runtime commands.

--- a/bmad/template-fragments/gc-role-worker.template.md
+++ b/bmad/template-fragments/gc-role-worker.template.md
@@ -195,7 +195,8 @@ verdict is `iterate`, `changes_required`, or similar.
 
 If later terminal commands do not inherit shell variables, use the explicit
 `CLAIMED_BEAD_ID`, `CLAIMED_ROOT_BEAD_ID`, and
-`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `gc bd update` or `gc bd close` with an empty id.
+`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run
+`gc bd update` or `gc bd close` with an empty id.
 
 When updating or closing a bead, pass exactly one explicit claimed bead id.
 Quote every metadata assignment and close reason. Do not put freeform prose or

--- a/bmad/template-fragments/gc-role-worker.template.md
+++ b/bmad/template-fragments/gc-role-worker.template.md
@@ -7,14 +7,14 @@ You are `{{ .AgentName }}`, a Gas City `graph.v2` role worker for template
 ## Core Rule
 
 You work only the routed bead assigned to this live session. Do not use
-`bd mol current` to infer workflow position. Do not assume a parent bead or
+`gc bd mol current` to infer workflow position. Do not assume a parent bead or
 root bead describes your work. The workflow graph advances through explicit
 ready beads, and you execute the ready bead claimed by this session.
 
 ## Startup Claim Protocol
 
 `gc hook --claim --json` is the only permitted discovery source for routed
-workflow work. Do not run broad `bd ready`, `bd list`, root-bead searches,
+workflow work. Do not run broad `gc bd ready`, `gc bd list`, root-bead searches,
 metadata searches, mail inspection, session-log inspection, or repository
 context gathering to find a bead. Never work a bead id unless it came from the
 immediately preceding `gc hook --claim --json` result in this claim block.
@@ -109,7 +109,7 @@ while true; do
   fi
 
   SHOW_ERR="$(mktemp)"
-  if ! SHOW_JSON="$(bd show "$WORK_ID" --json 2>"$SHOW_ERR")"; then
+  if ! SHOW_JSON="$(gc bd show "$WORK_ID" --json 2>"$SHOW_ERR")"; then
     SHOW_ERR_TEXT="$(sed -n '1p' "$SHOW_ERR")"
     rm -f "$SHOW_ERR"
     if [ -n "$SHOW_ERR_TEXT" ]; then
@@ -167,7 +167,7 @@ export GC_CONTINUATION_GROUP="$CLAIM_GROUP"
 printf 'CLAIMED_BEAD_ID=%s\n' "$WORK_ID"
 printf 'CLAIMED_ROOT_BEAD_ID=%s\n' "$CLAIM_ROOT"
 printf 'CLAIMED_CONTINUATION_GROUP=%s\n' "$CLAIM_GROUP"
-bd show "$GC_BEAD_ID"
+gc bd show "$GC_BEAD_ID"
 GC_CLAIM
 ```
 
@@ -178,14 +178,14 @@ Close it with the requested `gc.outcome` metadata. If the bead does not specify
 a failure contract, mark an unrecoverable failure with `gc.outcome=fail` and a
 concise `gc.failure_class`/reason before closing it.
 
-Never use a bare `bd close` for a bead that asks for close metadata. First set
+Never use `gc bd close` for a bead that asks for close metadata. First set
 the requested metadata on the claimed bead, then close the same bead id:
 
 ```bash
-bd update "$GC_BEAD_ID" \
+gc bd update "$GC_BEAD_ID" \
   --set-metadata 'gc.outcome=pass' \
   --set-metadata 'example.key=example-value'
-bd close "$GC_BEAD_ID"
+gc bd close "$GC_BEAD_ID"
 ```
 
 Finding review issues, missing tests, or required follow-up is usually the
@@ -195,13 +195,12 @@ verdict is `iterate`, `changes_required`, or similar.
 
 If later terminal commands do not inherit shell variables, use the explicit
 `CLAIMED_BEAD_ID`, `CLAIMED_ROOT_BEAD_ID`, and
-`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `bd
-update` or `bd close` with an empty id.
+`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `gc bd update` or `gc bd close` with an empty id.
 
 When updating or closing a bead, pass exactly one explicit claimed bead id.
 Quote every metadata assignment and close reason. Do not put freeform prose or
 bare words after the bead id; `bd` treats every extra positional argument as
-another issue id and may fuzzy-match unrelated beads. Use `bd close
+another issue id and may fuzzy-match unrelated beads. Use `gc bd close
 "$CLAIMED_BEAD_ID" --reason '...'` for close notes.
 
 ## Continuation Group Protocol

--- a/compound-engineering/agents/ce-code-review-selector/prompt.template.md
+++ b/compound-engineering/agents/ce-code-review-selector/prompt.template.md
@@ -128,11 +128,11 @@ concise reason.
 If `ce.review_key` is selected, update and close only the gate bead:
 
 ```bash
-bd update "$CLAIMED_BEAD_ID" \
+gc bd update "$CLAIMED_BEAD_ID" \
   --set-metadata 'gc.outcome=pass' \
   --set-metadata 'code_review.gate_decision=selected' \
   --set-metadata 'code_review.review_key=<ce.review_key>'
-bd close "$CLAIMED_BEAD_ID" --reason 'conditional reviewer selected'
+gc bd close "$CLAIMED_BEAD_ID" --reason 'conditional reviewer selected'
 ```
 
 Do not touch the paired reviewer bead when the lane is selected; closing the
@@ -141,7 +141,7 @@ gate lets that real review bead become ready.
 If `ce.review_key` is skipped:
 
 1. Find the paired reviewer bead under the same workflow root with
-   `bd list --all --metadata-field "gc.root_bead_id=$CLAIMED_ROOT_BEAD_ID"
+   `gc bd list --all --metadata-field "gc.root_bead_id=$CLAIMED_ROOT_BEAD_ID"
    --metadata-field "gc.step_ref=<paired step ref>" --json --limit 0`. The
    paired step ref is the current gate `gc.step_ref` with the trailing `-gate`
    removed. If the current bead does not expose `gc.step_ref`, derive the paired

--- a/compound-engineering/agents/ce-code-review-selector/template-fragments/gc-role-worker.template.md
+++ b/compound-engineering/agents/ce-code-review-selector/template-fragments/gc-role-worker.template.md
@@ -195,7 +195,8 @@ verdict is `iterate`, `changes_required`, or similar.
 
 If later terminal commands do not inherit shell variables, use the explicit
 `CLAIMED_BEAD_ID`, `CLAIMED_ROOT_BEAD_ID`, and
-`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `gc bd update` or `gc bd close` with an empty id.
+`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run
+`gc bd update` or `gc bd close` with an empty id.
 
 When updating or closing a bead, pass exactly one explicit claimed bead id.
 Quote every metadata assignment and close reason. Do not put freeform prose or

--- a/compound-engineering/agents/ce-code-review-selector/template-fragments/gc-role-worker.template.md
+++ b/compound-engineering/agents/ce-code-review-selector/template-fragments/gc-role-worker.template.md
@@ -7,14 +7,14 @@ You are `{{ .AgentName }}`, a Gas City `graph.v2` role worker for template
 ## Core Rule
 
 You work only the routed bead assigned to this live session. Do not use
-`bd mol current` to infer workflow position. Do not assume a parent bead or
+`gc bd mol current` to infer workflow position. Do not assume a parent bead or
 root bead describes your work. The workflow graph advances through explicit
 ready beads, and you execute the ready bead claimed by this session.
 
 ## Startup Claim Protocol
 
 `gc hook --claim --json` is the only permitted discovery source for routed
-workflow work. Do not run broad `bd ready`, `bd list`, root-bead searches,
+workflow work. Do not run broad `gc bd ready`, `gc bd list`, root-bead searches,
 metadata searches, mail inspection, session-log inspection, or repository
 context gathering to find a bead. Never work a bead id unless it came from the
 immediately preceding `gc hook --claim --json` result in this claim block.
@@ -109,7 +109,7 @@ while true; do
   fi
 
   SHOW_ERR="$(mktemp)"
-  if ! SHOW_JSON="$(bd show "$WORK_ID" --json 2>"$SHOW_ERR")"; then
+  if ! SHOW_JSON="$(gc bd show "$WORK_ID" --json 2>"$SHOW_ERR")"; then
     SHOW_ERR_TEXT="$(sed -n '1p' "$SHOW_ERR")"
     rm -f "$SHOW_ERR"
     if [ -n "$SHOW_ERR_TEXT" ]; then
@@ -167,7 +167,7 @@ export GC_CONTINUATION_GROUP="$CLAIM_GROUP"
 printf 'CLAIMED_BEAD_ID=%s\n' "$WORK_ID"
 printf 'CLAIMED_ROOT_BEAD_ID=%s\n' "$CLAIM_ROOT"
 printf 'CLAIMED_CONTINUATION_GROUP=%s\n' "$CLAIM_GROUP"
-bd show "$GC_BEAD_ID"
+gc bd show "$GC_BEAD_ID"
 GC_CLAIM
 ```
 
@@ -178,14 +178,14 @@ Close it with the requested `gc.outcome` metadata. If the bead does not specify
 a failure contract, mark an unrecoverable failure with `gc.outcome=fail` and a
 concise `gc.failure_class`/reason before closing it.
 
-Never use a bare `bd close` for a bead that asks for close metadata. First set
+Never use `gc bd close` for a bead that asks for close metadata. First set
 the requested metadata on the claimed bead, then close the same bead id:
 
 ```bash
-bd update "$GC_BEAD_ID" \
+gc bd update "$GC_BEAD_ID" \
   --set-metadata 'gc.outcome=pass' \
   --set-metadata 'example.key=example-value'
-bd close "$GC_BEAD_ID"
+gc bd close "$GC_BEAD_ID"
 ```
 
 Finding review issues, missing tests, or required follow-up is usually the
@@ -195,13 +195,12 @@ verdict is `iterate`, `changes_required`, or similar.
 
 If later terminal commands do not inherit shell variables, use the explicit
 `CLAIMED_BEAD_ID`, `CLAIMED_ROOT_BEAD_ID`, and
-`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `bd
-update` or `bd close` with an empty id.
+`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `gc bd update` or `gc bd close` with an empty id.
 
 When updating or closing a bead, pass exactly one explicit claimed bead id.
 Quote every metadata assignment and close reason. Do not put freeform prose or
 bare words after the bead id; `bd` treats every extra positional argument as
-another issue id and may fuzzy-match unrelated beads. Use `bd close
+another issue id and may fuzzy-match unrelated beads. Use `gc bd close
 "$CLAIMED_BEAD_ID" --reason '...'` for close notes.
 
 ## Continuation Group Protocol

--- a/compound-engineering/assets/workflows/compound-code-review/{target}.conditional-review-gate.md
+++ b/compound-engineering/assets/workflows/compound-code-review/{target}.conditional-review-gate.md
@@ -10,7 +10,7 @@ If the manifest selects `ce.review_key`, close only this gate bead with
 ready after this gate closes.
 
 If the manifest skips `ce.review_key`, find the paired reviewer bead with
-`bd list --all --metadata-field "gc.root_bead_id=$CLAIMED_ROOT_BEAD_ID"
+`gc bd list --all --metadata-field "gc.root_bead_id=$CLAIMED_ROOT_BEAD_ID"
 --metadata-field "gc.step_ref=<paired step ref>" --json --limit 0`, where the
 paired step ref is this gate's `gc.step_ref` without the trailing `-gate`. If
 the current bead does not expose `gc.step_ref`, derive the paired step ref from
@@ -26,7 +26,7 @@ reviewer bead. After that, close this gate bead with `gc.outcome=pass`,
 `code_review.gate_decision=skipped`, `code_review.review_key=<ce.review_key>`,
 and `code_review.skip_reason=<manifest reason>`.
 
-Use exact bead ids from filtered `bd list --json` results. Do not update a
+Use exact bead ids from filtered `gc bd list --json` results. Do not update a
 template name, do not fuzzy-match, and do not close a bead without reading it
 back afterward.
 

--- a/compound-engineering/template-fragments/gc-role-worker.template.md
+++ b/compound-engineering/template-fragments/gc-role-worker.template.md
@@ -195,7 +195,8 @@ verdict is `iterate`, `changes_required`, or similar.
 
 If later terminal commands do not inherit shell variables, use the explicit
 `CLAIMED_BEAD_ID`, `CLAIMED_ROOT_BEAD_ID`, and
-`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `gc bd update` or `gc bd close` with an empty id.
+`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run
+`gc bd update` or `gc bd close` with an empty id.
 
 When updating or closing a bead, pass exactly one explicit claimed bead id.
 Quote every metadata assignment and close reason. Do not put freeform prose or

--- a/compound-engineering/template-fragments/gc-role-worker.template.md
+++ b/compound-engineering/template-fragments/gc-role-worker.template.md
@@ -7,14 +7,14 @@ You are `{{ .AgentName }}`, a Gas City `graph.v2` role worker for template
 ## Core Rule
 
 You work only the routed bead assigned to this live session. Do not use
-`bd mol current` to infer workflow position. Do not assume a parent bead or
+`gc bd mol current` to infer workflow position. Do not assume a parent bead or
 root bead describes your work. The workflow graph advances through explicit
 ready beads, and you execute the ready bead claimed by this session.
 
 ## Startup Claim Protocol
 
 `gc hook --claim --json` is the only permitted discovery source for routed
-workflow work. Do not run broad `bd ready`, `bd list`, root-bead searches,
+workflow work. Do not run broad `gc bd ready`, `gc bd list`, root-bead searches,
 metadata searches, mail inspection, session-log inspection, or repository
 context gathering to find a bead. Never work a bead id unless it came from the
 immediately preceding `gc hook --claim --json` result in this claim block.
@@ -109,7 +109,7 @@ while true; do
   fi
 
   SHOW_ERR="$(mktemp)"
-  if ! SHOW_JSON="$(bd show "$WORK_ID" --json 2>"$SHOW_ERR")"; then
+  if ! SHOW_JSON="$(gc bd show "$WORK_ID" --json 2>"$SHOW_ERR")"; then
     SHOW_ERR_TEXT="$(sed -n '1p' "$SHOW_ERR")"
     rm -f "$SHOW_ERR"
     if [ -n "$SHOW_ERR_TEXT" ]; then
@@ -167,7 +167,7 @@ export GC_CONTINUATION_GROUP="$CLAIM_GROUP"
 printf 'CLAIMED_BEAD_ID=%s\n' "$WORK_ID"
 printf 'CLAIMED_ROOT_BEAD_ID=%s\n' "$CLAIM_ROOT"
 printf 'CLAIMED_CONTINUATION_GROUP=%s\n' "$CLAIM_GROUP"
-bd show "$GC_BEAD_ID"
+gc bd show "$GC_BEAD_ID"
 GC_CLAIM
 ```
 
@@ -178,14 +178,14 @@ Close it with the requested `gc.outcome` metadata. If the bead does not specify
 a failure contract, mark an unrecoverable failure with `gc.outcome=fail` and a
 concise `gc.failure_class`/reason before closing it.
 
-Never use a bare `bd close` for a bead that asks for close metadata. First set
+Never use `gc bd close` for a bead that asks for close metadata. First set
 the requested metadata on the claimed bead, then close the same bead id:
 
 ```bash
-bd update "$GC_BEAD_ID" \
+gc bd update "$GC_BEAD_ID" \
   --set-metadata 'gc.outcome=pass' \
   --set-metadata 'example.key=example-value'
-bd close "$GC_BEAD_ID"
+gc bd close "$GC_BEAD_ID"
 ```
 
 Finding review issues, missing tests, or required follow-up is usually the
@@ -195,13 +195,12 @@ verdict is `iterate`, `changes_required`, or similar.
 
 If later terminal commands do not inherit shell variables, use the explicit
 `CLAIMED_BEAD_ID`, `CLAIMED_ROOT_BEAD_ID`, and
-`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `bd
-update` or `bd close` with an empty id.
+`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `gc bd update` or `gc bd close` with an empty id.
 
 When updating or closing a bead, pass exactly one explicit claimed bead id.
 Quote every metadata assignment and close reason. Do not put freeform prose or
 bare words after the bead id; `bd` treats every extra positional argument as
-another issue id and may fuzzy-match unrelated beads. Use `bd close
+another issue id and may fuzzy-match unrelated beads. Use `gc bd close
 "$CLAIMED_BEAD_ID" --reason '...'` for close notes.
 
 ## Continuation Group Protocol

--- a/contributing/formulas/mol-contributing-find-work.formula.toml
+++ b/contributing/formulas/mol-contributing-find-work.formula.toml
@@ -13,7 +13,7 @@ live in the `find-work` skill, which is the single source of truth. The
 steps below say *apply the skill*; they do not restate it.
 
 The molecule root bead IS the control bead — run state is recorded in its
-notes via `bd update <root-id> --notes "<key>: <value>"`.
+notes via `gc bd update <root-id> --notes "<key>: <value>"`.
 
 ## Contract
 
@@ -53,25 +53,25 @@ verify gh auth, and record the run vars + output path. This is pure
 mechanism — no triage judgment happens here.
 
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
     echo "Not in a git repository — cannot triage."
-    bd close "$ROOT_ID" --reason "not a git checkout"
+    gc bd close "$ROOT_ID" --reason "not a git checkout"
     exit 1
 }
 cd "$REPO_ROOT"
 REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
 if [ "$REPO" != "gastownhall/gascity" ]; then
-    bd update "$ROOT_ID" --notes "status: blocked
+    gc bd update "$ROOT_ID" --notes "status: blocked
 gate: wrong_repo
 detail: $REPO"
-    bd close "$ROOT_ID" --reason "wrong repo for contributor triage"
+    gc bd close "$ROOT_ID" --reason "wrong repo for contributor triage"
     exit 0
 fi
 gh auth status >/dev/null 2>&1 || {
-    bd update "$ROOT_ID" --notes "status: blocked
+    gc bd update "$ROOT_ID" --notes "status: blocked
 gate: gh_not_authed"
-    bd close "$ROOT_ID" --reason "gh not authenticated"
+    gc bd close "$ROOT_ID" --reason "gh not authenticated"
     exit 1
 }
 ```
@@ -95,11 +95,11 @@ mkdir -p "$REPORT_DIR"
 # Resume-safe: reuse the report path already recorded in the root-bead notes;
 # only mint a fresh timestamp on the first run, so re-running setup after an
 # interruption does not orphan a partial report under a new path.
-REPORT_PATH=$(bd show "$ROOT_ID" --json | jq -r '.[0].notes // ""' | grep -m1 '^report_path:' | sed 's/^report_path: //')
+REPORT_PATH=$(gc bd show "$ROOT_ID" --json | jq -r '.[0].notes // ""' | grep -m1 '^report_path:' | sed 's/^report_path: //')
 if [ -z "$REPORT_PATH" ]; then
     REPORT_PATH="$REPORT_DIR/$(date +%Y%m%d-%H%M%S).md"
 fi
-bd update "$ROOT_ID" --notes "category: $CATEGORY
+gc bd update "$ROOT_ID" --notes "category: $CATEGORY
 limit: $LIMIT
 repo: $REPO
 report_path: $REPORT_PATH
@@ -132,9 +132,9 @@ recommended next pick in the root-bead notes so the caller can act without
 re-reading the file:
 
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
-REPORT_PATH=$(bd show "$ROOT_ID" --json | jq -r '.[0].notes // ""' | grep -m1 '^report_path:' | sed 's/^report_path: //')
-bd update "$ROOT_ID" --notes "tier1: <n>
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
+REPORT_PATH=$(gc bd show "$ROOT_ID" --json | jq -r '.[0].notes // ""' | grep -m1 '^report_path:' | sed 's/^report_path: //')
+gc bd update "$ROOT_ID" --notes "tier1: <n>
 tier2: <n>
 tier3: <n>
 tier4: <n>
@@ -155,8 +155,8 @@ close the root bead. No further work happens — the caller reviews the
 report and decides which issue to dispatch via `mol-contributing-plan-implementation`.
 
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
-NOTES=$(bd show "$ROOT_ID" --json | jq -r '.[0].notes // ""')
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
+NOTES=$(gc bd show "$ROOT_ID" --json | jq -r '.[0].notes // ""')
 REPORT_PATH=$(echo "$NOTES" | grep -m1 '^report_path:' | sed 's/^report_path: //')
 RECOMMENDED=$(echo "$NOTES" | grep -m1 '^recommended:' | sed 's/^recommended: //')
 cat <<EOF
@@ -165,8 +165,8 @@ cat <<EOF
 [contributing-find-work]   Recommended next pick: #$RECOMMENDED
 [contributing-find-work] Next: review the report, then dispatch mol-contributing-plan-implementation --var issue=<N>.
 EOF
-bd update "$ROOT_ID" --notes "status: complete"
-bd close "$ROOT_ID" --reason "contributor triage report written: $REPORT_PATH"
+gc bd update "$ROOT_ID" --notes "status: complete"
+gc bd close "$ROOT_ID" --reason "contributor triage report written: $REPORT_PATH"
 ```
 
 **Exit criteria:** Report path printed, root bead closed with status:complete.

--- a/contributing/formulas/mol-contributing-fine-tune.formula.toml
+++ b/contributing/formulas/mol-contributing-fine-tune.formula.toml
@@ -13,7 +13,7 @@ not restate it. The one thing the formula enforces is the hard STOP: push
 and PR open are caller actions gated on human review of the report.
 
 The molecule root bead IS the control bead — run state is recorded in its
-notes via `bd update <root-id> --notes "<key>: <value>"`. The skill's
+notes via `gc bd update <root-id> --notes "<key>: <value>"`. The skill's
 simplify and self-review stages CAN modify files; every other stage is
 read-only.
 
@@ -53,29 +53,29 @@ and prepare the report path. Pure mechanism — the staged review is the
 skill's job.
 
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
     echo "Not in a git repository — cannot fine-tune."
-    bd close "$ROOT_ID" --reason "not a git checkout"
+    gc bd close "$ROOT_ID" --reason "not a git checkout"
     exit 1
 }
 cd "$REPO_ROOT"
 BRANCH="{{branch}}"
 [ -z "$BRANCH" ] && BRANCH=$(git branch --show-current)
 if [ -z "$BRANCH" ] || [ "$BRANCH" = "HEAD" ]; then
-    bd close "$ROOT_ID" --reason "no branch resolved"
+    gc bd close "$ROOT_ID" --reason "no branch resolved"
     exit 1
 fi
 DEFAULT=$(git remote show origin 2>/dev/null | sed -n 's/.*HEAD branch: //p' || echo "main")
 if [ "$BRANCH" = "$DEFAULT" ] || [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then
     echo "Cannot fine-tune from default branch ($BRANCH). Create a feature branch first."
-    bd close "$ROOT_ID" --reason "on default branch"
+    gc bd close "$ROOT_ID" --reason "on default branch"
     exit 1
 fi
 mkdir -p .gc/contributing/fine-tune
 SAFE=$(echo "$BRANCH" | tr '/' '_')
 REPORT_PATH=".gc/contributing/fine-tune/${SAFE}.md"
-bd update "$ROOT_ID" --notes "branch: $BRANCH
+gc bd update "$ROOT_ID" --notes "branch: $BRANCH
 report_path: $REPORT_PATH
 status: in_progress"
 ```
@@ -100,10 +100,10 @@ the skill's Stage 4 readiness report to `$REPORT_PATH`.
 Record the readiness verdict the skill produces:
 
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
 READINESS="<ready | blocked>"
 BLOCKERS="<one-line summary of what blocks, or 'none'>"
-bd update "$ROOT_ID" --notes "readiness: $READINESS
+gc bd update "$ROOT_ID" --notes "readiness: $READINESS
 blockers: $BLOCKERS
 status: report_written"
 ```
@@ -120,8 +120,8 @@ Display the report path and readiness verdict, then close the bead. The
 caller decides whether to push based on the report.
 
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
-NOTES=$(bd show "$ROOT_ID" --json | jq -r '.[0].notes // ""')
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
+NOTES=$(gc bd show "$ROOT_ID" --json | jq -r '.[0].notes // ""')
 REPORT_PATH=$(echo "$NOTES" | grep -m1 '^report_path:' | sed 's/^report_path: //')
 READINESS=$(echo "$NOTES" | grep -m1 '^readiness:' | sed 's/^readiness: //')
 cat <<EOF
@@ -130,8 +130,8 @@ cat <<EOF
 [contributing-fine-tune]   Path: $REPORT_PATH
 [contributing-fine-tune] STOP — push and PR open are the caller's call, not this formula's.
 EOF
-bd update "$ROOT_ID" --notes "status: complete"
-bd close "$ROOT_ID" --reason "contributor fine-tune report written: $REPORT_PATH"
+gc bd update "$ROOT_ID" --notes "status: complete"
+gc bd close "$ROOT_ID" --reason "contributor fine-tune report written: $REPORT_PATH"
 ```
 
 **Critical:** This formula MUST NOT run `git push` or `gh pr create` under

--- a/contributing/formulas/mol-contributing-map-blast-radius.formula.toml
+++ b/contributing/formulas/mol-contributing-map-blast-radius.formula.toml
@@ -14,7 +14,7 @@ the `map-blast-radius` skill, which is the single source of truth. The steps
 below say *apply the skill*; they do not restate it.
 
 The molecule root bead IS the control bead — run state is recorded in its
-notes via `bd update <root-id> --notes "<key>: <value>"`.
+notes via `gc bd update <root-id> --notes "<key>: <value>"`.
 
 ## Contract
 
@@ -52,10 +52,10 @@ the decomposition into analyzable targets is the skill's job; here we only
 establish where the report lands.
 
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
     echo "Not in a git repository — cannot map blast radius."
-    bd close "$ROOT_ID" --reason "not a git checkout"
+    gc bd close "$ROOT_ID" --reason "not a git checkout"
     exit 1
 }
 cd "$REPO_ROOT"
@@ -65,7 +65,7 @@ if [ -z "$KEY" ]; then
 fi
 mkdir -p .gc/contributing/blast-radius
 REPORT_PATH=".gc/contributing/blast-radius/${KEY}.md"
-bd update "$ROOT_ID" --notes "scope: {{scope}}
+gc bd update "$ROOT_ID" --notes "scope: {{scope}}
 key: $KEY
 report_path: $REPORT_PATH
 status: in_progress"
@@ -90,9 +90,9 @@ step recorded (`report_path:` in the root-bead notes) — do not assume
 After writing the report, finalize:
 
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
-REPORT_PATH=$(bd show "$ROOT_ID" --json | jq -r '.[0].notes // ""' | grep -m1 '^report_path:' | sed 's/^report_path: //')
-bd update "$ROOT_ID" --notes "status: complete"
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
+REPORT_PATH=$(gc bd show "$ROOT_ID" --json | jq -r '.[0].notes // ""' | grep -m1 '^report_path:' | sed 's/^report_path: //')
+gc bd update "$ROOT_ID" --notes "status: complete"
 echo "[contributing-map-blast-radius] Complete for: {{scope}}"
 echo "[contributing-map-blast-radius]   Path: $REPORT_PATH"
 ```

--- a/contributing/formulas/mol-contributing-plan-implementation.formula.toml
+++ b/contributing/formulas/mol-contributing-plan-implementation.formula.toml
@@ -15,7 +15,7 @@ BLOCKING early-exit: when a gate the skill defines fires, the orchestration
 records the reason and closes the bead instead of producing a plan.
 
 The molecule root bead IS the control bead — run state is recorded in its
-notes via `bd update <root-id> --notes "<key>: <value>"`.
+notes via `gc bd update <root-id> --notes "<key>: <value>"`.
 
 ## Contract
 
@@ -49,16 +49,16 @@ Resolve the root bead, confirm we are in a git repo, read the issue, and
 record initial state. Pure mechanism — the planning judgment is the skill's.
 
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
     echo "Not in a git repository — cannot plan."
-    bd close "$ROOT_ID" --reason "not a git checkout"
+    gc bd close "$ROOT_ID" --reason "not a git checkout"
     exit 1
 }
 cd "$REPO_ROOT"
 REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
 gh issue view {{issue}} --repo "$REPO" --json title,body,labels,comments,state
-bd update "$ROOT_ID" --notes "issue: {{issue}}
+gc bd update "$ROOT_ID" --notes "issue: {{issue}}
 repo: $REPO
 repo_root: $REPO_ROOT
 status: in_progress"
@@ -83,19 +83,19 @@ The formula owns only the early-exit mechanic. If a gate fires, record the
 reason and close the bead — do not proceed to planning:
 
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
-bd update "$ROOT_ID" --notes "status: blocked
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
+gc bd update "$ROOT_ID" --notes "status: blocked
 gate: <competing_pr | architectural_refactor>
 detail: <one-line: which PR / which refactor and why>"
 echo "[contributing-plan-implementation] BLOCKED — <gate>: <detail>"
-bd close "$ROOT_ID" --reason "<gate> for issue #{{issue}}"
+gc bd close "$ROOT_ID" --reason "<gate> for issue #{{issue}}"
 exit 0
 ```
 
 If neither gate fires, record clearance and proceed:
 
 ```bash
-bd update "$ROOT_ID" --notes "gates: cleared"
+gc bd update "$ROOT_ID" --notes "gates: cleared"
 ```
 
 **Exit criteria:** Both gates cleared (or the formula exited via a gate). Root-bead notes record gates: cleared.
@@ -116,11 +116,11 @@ checklist. Do not restate any of that here; run it from the skill.
 Write the skill's structured plan output to the plan path:
 
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
 mkdir -p .gc/contributing/plans
 PLAN_PATH=".gc/contributing/plans/issue-{{issue}}.md"
 # (write the plan-implementation skill's plan into $PLAN_PATH)
-bd update "$ROOT_ID" --notes "plan_path: $PLAN_PATH
+gc bd update "$ROOT_ID" --notes "plan_path: $PLAN_PATH
 plan_status: finalized
 status: complete"
 cat <<EOF

--- a/contributing/formulas/mol-contributing-review.formula.toml
+++ b/contributing/formulas/mol-contributing-review.formula.toml
@@ -16,7 +16,7 @@ B1-B36 checklist — live in the `review` skill, which is the single source of
 truth. The steps below say *apply the skill*; they do not restate it.
 
 The molecule root bead IS the control bead — run state is recorded in its
-notes via `bd update <root-id> --notes "<key>: <value>"`.
+notes via `gc bd update <root-id> --notes "<key>: <value>"`.
 
 ## Contract
 
@@ -58,10 +58,10 @@ Confirm we are in a git repo and resolve where the report lands. Pure
 mechanism — the audit is the skill's job.
 
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
     echo "Not in a git repository — cannot run the codebase check."
-    bd close "$ROOT_ID" --reason "not a git checkout"
+    gc bd close "$ROOT_ID" --reason "not a git checkout"
     exit 1
 }
 cd "$REPO_ROOT"
@@ -73,7 +73,7 @@ if [ -z "$KEY" ]; then
 fi
 mkdir -p .gc/contributing/reviews
 REPORT_PATH=".gc/contributing/reviews/${KEY}.md"
-bd update "$ROOT_ID" --notes "base: ${BASE:-<skill-resolved upstream main>}
+gc bd update "$ROOT_ID" --notes "base: ${BASE:-<skill-resolved upstream main>}
 key: $KEY
 report_path: $REPORT_PATH
 status: in_progress"
@@ -100,9 +100,9 @@ regression or an unwaived B-rule blocker is `block`/`request_changes`; an
 all-green or minors-only result is `approve`. Record it:
 
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
 VERDICT="<block | request_changes | approve>"
-bd update "$ROOT_ID" --notes "verdict: $VERDICT
+gc bd update "$ROOT_ID" --notes "verdict: $VERDICT
 status: report_written"
 ```
 
@@ -118,8 +118,8 @@ Display the report path and verdict on stdout for the caller, then close the
 root bead. No fixes are applied here.
 
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
-NOTES=$(bd show "$ROOT_ID" --json | jq -r '.[0].notes // ""')
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
+NOTES=$(gc bd show "$ROOT_ID" --json | jq -r '.[0].notes // ""')
 REPORT_PATH=$(echo "$NOTES" | grep -m1 '^report_path:' | sed 's/^report_path: //')
 VERDICT=$(echo "$NOTES" | grep -m1 '^verdict:' | sed 's/^verdict: //')
 cat <<EOF
@@ -127,8 +127,8 @@ cat <<EOF
 [contributing-review]   Verdict: $VERDICT
 [contributing-review]   Path: $REPORT_PATH
 EOF
-bd update "$ROOT_ID" --notes "status: complete"
-bd close "$ROOT_ID" --reason "contributor codebase review written: $REPORT_PATH"
+gc bd update "$ROOT_ID" --notes "status: complete"
+gc bd close "$ROOT_ID" --reason "contributor codebase review written: $REPORT_PATH"
 ```
 
 **Exit criteria:** Report path + verdict printed, root bead closed with status:complete.

--- a/contributing/skills/orchestrate-contribution/SKILL.md
+++ b/contributing/skills/orchestrate-contribution/SKILL.md
@@ -75,7 +75,7 @@ When a dispatched step finishes, the worker has recorded its outcome in the
    complete`, the artifact path, and the one recommended next action:
 
    ```bash
-   NOTES=$(bd show "$ROOT_ID" --json | jq -r '.[0].notes // ""')
+   NOTES=$(gc bd show "$ROOT_ID" --json | jq -r '.[0].notes // ""')
    # find-work → report_path:, recommended:, tier counts
    # plan-implementation → plan_path:, plan_status: (or status: blocked + gate:)
    # fine-tune → report_path:, readiness: (ready | blocked), blockers:

--- a/discord/doctor/check-bd.sh
+++ b/discord/doctor/check-bd.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 set -eu
 
-if ! command -v bd >/dev/null 2>&1; then
-  echo "bd CLI not found"
-  echo "Install or expose the bd binary so the discord pack can manage fix-workflow beads."
+if ! command -v gc >/dev/null 2>&1 || ! gc bd version >/dev/null 2>&1; then
+  echo "gc bd unavailable"
+  echo "Install or expose gc with a working bd backend so the discord pack can manage fix-workflow beads."
   exit 2
 fi
 
-echo "bd CLI available"
+echo "gc bd available"

--- a/discord/formulas/mol-discord-fix-issue.formula.toml
+++ b/discord/formulas/mol-discord-fix-issue.formula.toml
@@ -68,13 +68,13 @@ message when work begins.
 **1. Prime the session:**
 ```bash
 gc prime
-bd prime
+gc bd prime
 ```
 
 **2. Inspect the bead and source context:**
 ```bash
-bd show {{issue}}
-bd show {{issue}} --json | jq '.metadata'
+gc bd show {{issue}}
+gc bd show {{issue}} --json | jq '.metadata'
 ```
 
 Read the bead notes carefully. They contain:
@@ -84,7 +84,7 @@ Read the bead notes carefully. They contain:
 
 **3. Post the "work started" Discord message exactly once:**
 ```bash
-STARTED=$(bd show {{issue}} --json | jq -r '.metadata.discord_fix_started_message_id // empty')
+STARTED=$(gc bd show {{issue}} --json | jq -r '.metadata.discord_fix_started_message_id // empty')
 if [ -z "$STARTED" ]; then
   REQUESTER=$(python3 - <<'PY'
 import base64
@@ -109,7 +109,7 @@ EOF
   MESSAGE_JSON=$(gc discord post-message --request-id {{discord_request_id}} --body-file "$BODY")
   MESSAGE_ID=$(printf '%s' "$MESSAGE_JSON" | jq -r '.id // empty')
   if [ -n "$MESSAGE_ID" ]; then
-    bd update {{issue}} --set-metadata discord_fix_started_message_id="$MESSAGE_ID"
+    gc bd update {{issue}} --set-metadata discord_fix_started_message_id="$MESSAGE_ID"
   fi
   rm -f "$BODY"
 fi
@@ -132,7 +132,7 @@ git fetch --prune origin
 
 **2. Reuse or create the bead-scoped worktree:**
 ```bash
-WORKTREE=$(bd show {{issue}} --json | jq -r '.metadata.work_dir // empty')
+WORKTREE=$(gc bd show {{issue}} --json | jq -r '.metadata.work_dir // empty')
 if [ -n "$WORKTREE" ] && [ -d "$WORKTREE" ]; then
   cd "$WORKTREE"
 else
@@ -141,19 +141,19 @@ else
   WORKTREE_PATH="$WORKTREE_ROOT/{{issue}}"
   git worktree add "$WORKTREE_PATH" --detach origin/$(git remote show origin | sed -n '/HEAD branch/s/.*: //p')
   cd "$WORKTREE_PATH"
-  bd update {{issue}} --set-metadata work_dir="$WORKTREE_PATH"
+  gc bd update {{issue}} --set-metadata work_dir="$WORKTREE_PATH"
 fi
 ```
 
 **3. Reuse or create the branch:**
 ```bash
-BRANCH=$(bd show {{issue}} --json | jq -r '.metadata.branch // empty')
+BRANCH=$(gc bd show {{issue}} --json | jq -r '.metadata.branch // empty')
 if [ -n "$BRANCH" ]; then
   git checkout "$BRANCH" 2>/dev/null || git checkout -b "$BRANCH"
 else
   BRANCH="fix-discord-{{issue}}"
   git checkout -b "$BRANCH"
-  bd update {{issue}} --set-metadata branch="$BRANCH"
+  gc bd update {{issue}} --set-metadata branch="$BRANCH"
 fi
 ```
 
@@ -179,7 +179,7 @@ Take a read-first pass so you understand the problem before changing code.
 
 **2. Record the working theory in bead notes:**
 ```bash
-CURRENT_NOTES=$(bd show {{issue}} --json | jq -r '.notes // empty')
+CURRENT_NOTES=$(gc bd show {{issue}} --json | jq -r '.notes // empty')
 NOTES_FILE=$(mktemp)
 cat >"$NOTES_FILE" <<EOF
 $CURRENT_NOTES
@@ -195,7 +195,7 @@ $CURRENT_NOTES
 ### Test plan
 - <the failing test you will write first>
 EOF
-bd update {{issue}} --notes "$(cat "$NOTES_FILE")"
+gc bd update {{issue}} --notes "$(cat "$NOTES_FILE")"
 rm -f "$NOTES_FILE"
 ```
 
@@ -248,8 +248,8 @@ same thread can be used again later.
 
 **1. Capture the branch and validation summary:**
 ```bash
-BRANCH=$(bd show {{issue}} --json | jq -r '.metadata.branch // empty')
-WORKTREE=$(bd show {{issue}} --json | jq -r '.metadata.work_dir // empty')
+BRANCH=$(gc bd show {{issue}} --json | jq -r '.metadata.branch // empty')
+WORKTREE=$(gc bd show {{issue}} --json | jq -r '.metadata.work_dir // empty')
 ```
 
 **2. Attempt the completion message:**
@@ -283,7 +283,7 @@ gc_discord_fix_cleanup() {
 }
 trap gc_discord_fix_cleanup EXIT
 if command -v gt >/dev/null 2>&1; then
-  if ! bd ready {{issue}}; then
+  if ! gc bd ready {{issue}}; then
     echo "error: failed to ready bead {{issue}} before gt done" >&2
     RELEASE_WORKFLOW=0
     exit 1
@@ -311,18 +311,18 @@ else
       RELEASE_WORKFLOW=0
       exit 1
     fi
-    if ! bd update {{issue}} --unset-metadata work_dir; then
+    if ! gc bd update {{issue}} --unset-metadata work_dir; then
       echo "error: failed to clear work_dir metadata for {{issue}}" >&2
       RELEASE_WORKFLOW=0
       exit 1
     fi
   fi
-  if ! bd ready {{issue}}; then
+  if ! gc bd ready {{issue}}; then
     echo "error: failed to ready bead {{issue}}" >&2
     RELEASE_WORKFLOW=0
     exit 1
   fi
-  if ! bd close {{issue}}; then
+  if ! gc bd close {{issue}}; then
     echo "error: failed to close bead {{issue}}" >&2
     RELEASE_WORKFLOW=0
     exit 1

--- a/discord/scripts/discord_intake_service.py
+++ b/discord/scripts/discord_intake_service.py
@@ -361,6 +361,17 @@ def rig_from_target(target: str) -> str:
     return rig.strip()
 
 
+def gc_bd_command(city_root: str, *args: str, rig: str = "") -> list[str]:
+    command = [os.environ.get("GC_BIN", "gc")]
+    if city_root not in {"", "."}:
+        command.extend(["--city", city_root])
+    if rig:
+        command.extend(["--rig", rig])
+    command.append("bd")
+    command.extend(args)
+    return command
+
+
 def rig_workdir(rig: str) -> str:
     """Resolve a rig's working directory from .beads/routes.jsonl."""
     root = common.city_root() or "."
@@ -424,10 +435,13 @@ def load_bead_snapshot(bead_id: str, rig: str = "") -> dict[str, Any]:
     normalized_bead_id = str(bead_id).strip()
     if not normalized_bead_id:
         return {}
-    bd_bin = os.environ.get("BD_BIN", "bd")
-    bd_cwd = rig_workdir(rig) or (common.city_root() or ".")
+    city_root = common.city_root() or "."
+    bd_cwd = rig_workdir(rig) or city_root
     try:
-        result = run_subprocess([bd_bin, "show", normalized_bead_id, "--json"], bd_cwd)
+        result = run_subprocess(
+            gc_bd_command(city_root, "show", normalized_bead_id, "--json", rig=rig),
+            bd_cwd,
+        )
     except (DispatchSubprocessTimeout, FileNotFoundError):
         return {}
     if result.returncode != 0:
@@ -499,15 +513,22 @@ def create_fix_bead(request: dict[str, Any], target: str) -> dict[str, Any]:
     if not rig:
         return {"status": "dispatch_failed", "reason": "invalid_dispatch_target"}
     city_root = common.city_root() or "."
-    bd_bin = os.environ.get("BD_BIN", "bd")
     bd_cwd = rig_workdir(rig)
     if not bd_cwd:
         return {"status": "dispatch_failed", "reason": "rig_workdir_missing"}
-    create_command = [bd_bin, "create", "--json", build_fix_bead_title(request), "-t", "task"]
+    create_command = gc_bd_command(
+        city_root,
+        "create",
+        "--json",
+        build_fix_bead_title(request),
+        "-t",
+        "task",
+        rig=rig,
+    )
     try:
         create_result = run_subprocess(create_command, bd_cwd)
     except FileNotFoundError:
-        return {"status": "dispatch_failed", "reason": "bead_create_failed", "dispatch_stderr": "bd not available"}
+        return {"status": "dispatch_failed", "reason": "bead_create_failed", "dispatch_stderr": "gc not available"}
     except DispatchSubprocessTimeout as exc:
         return {
             "status": "dispatch_failed",
@@ -535,7 +556,7 @@ def create_fix_bead(request: dict[str, Any], target: str) -> dict[str, Any]:
     request["status"] = "bead_created"
     common.save_request(request)
 
-    update_command = [bd_bin, "update", bead_id, "--notes", build_fix_bead_notes(request)]
+    update_command = gc_bd_command(city_root, "update", bead_id, "--notes", build_fix_bead_notes(request), rig=rig)
     metadata = {
         "discord_request_id": str(request.get("request_id", "")),
         "discord_guild_id": str(request.get("guild_id", "")),
@@ -554,7 +575,7 @@ def create_fix_bead(request: dict[str, Any], target: str) -> dict[str, Any]:
             "status": "dispatch_failed",
             "reason": "bead_update_failed",
             "bead_id": bead_id,
-            "dispatch_stderr": "bd not available",
+            "dispatch_stderr": "gc not available",
         }
     except DispatchSubprocessTimeout as exc:
         return {
@@ -594,7 +615,6 @@ def close_failed_bead(bead_id: str, reason: str, rig: str = "") -> bool:
     bead_id = bead_id.strip()
     if not bead_id:
         return True
-    bd_bin = os.environ.get("BD_BIN", "bd")
     city_root = common.city_root() or "."
     if rig:
         bd_cwd = rig_workdir(rig)
@@ -605,11 +625,18 @@ def close_failed_bead(bead_id: str, reason: str, rig: str = "") -> bool:
     try:
         # Prefer closing a failed bead even if we could not persist the close_reason metadata.
         run_subprocess(
-            [bd_bin, "update", bead_id, "--set-metadata", f"close_reason=discord:{reason or 'dispatch_failed'}"],
+            gc_bd_command(
+                city_root,
+                "update",
+                bead_id,
+                "--set-metadata",
+                f"close_reason=discord:{reason or 'dispatch_failed'}",
+                rig=rig,
+            ),
             bd_cwd,
         )
-        run_subprocess([bd_bin, "ready", bead_id], bd_cwd)
-        result = run_subprocess([bd_bin, "close", bead_id], bd_cwd)
+        run_subprocess(gc_bd_command(city_root, "ready", bead_id, rig=rig), bd_cwd)
+        result = run_subprocess(gc_bd_command(city_root, "close", bead_id, rig=rig), bd_cwd)
     except (DispatchSubprocessTimeout, FileNotFoundError):
         return False
     return result.returncode == 0

--- a/discord/tests/test_discord_intake_service.py
+++ b/discord/tests/test_discord_intake_service.py
@@ -294,13 +294,19 @@ class DiscordIntakeServiceTests(unittest.TestCase):
         with mock.patch.object(
             service,
             "run_subprocess",
-            side_effect=service.DispatchSubprocessTimeout(["bd", "create"], service.DISPATCH_SUBPROCESS_TIMEOUT_SECONDS),
+            side_effect=service.DispatchSubprocessTimeout(
+                ["gc", "--city", self.tempdir.name, "--rig", "product", "bd", "create"],
+                service.DISPATCH_SUBPROCESS_TIMEOUT_SECONDS,
+            ),
         ):
             outcome = service.create_fix_bead(request, "product/polecat")
 
         self.assertEqual(outcome["status"], "dispatch_failed")
         self.assertEqual(outcome["reason"], "dispatch_timeout")
-        self.assertEqual(outcome["dispatch_command"], ["bd", "create"])
+        self.assertEqual(
+            outcome["dispatch_command"],
+            ["gc", "--city", self.tempdir.name, "--rig", "product", "bd", "create"],
+        )
 
     def test_run_fix_dispatch_returns_bead_init_failure_without_slinging(self) -> None:
         self.write_rig_route("product")
@@ -325,10 +331,13 @@ class DiscordIntakeServiceTests(unittest.TestCase):
         self.assertEqual(outcome["bead_id"], "bd-1")
         self.assertTrue(outcome["bead_closed"])
         commands = [call.args[0] for call in run_subprocess.call_args_list]
-        self.assertEqual(commands[0], ["bd", "update", "bd-1", "--set-metadata", "close_reason=discord:bead_update_failed"])
-        self.assertEqual(commands[1], ["bd", "ready", "bd-1"])
-        self.assertEqual(commands[2], ["bd", "close", "bd-1"])
-        self.assertNotIn("gc", [command[0] for command in commands])
+        prefix = ["gc", "--city", self.tempdir.name, "--rig", "product", "bd"]
+        self.assertEqual(
+            commands[0],
+            prefix + ["update", "bd-1", "--set-metadata", "close_reason=discord:bead_update_failed"],
+        )
+        self.assertEqual(commands[1], prefix + ["ready", "bd-1"])
+        self.assertEqual(commands[2], prefix + ["close", "bd-1"])
 
     def test_run_fix_dispatch_returns_dispatch_timeout_when_gc_sling_hangs(self) -> None:
         request = {

--- a/gascity/assets/scripts/checks/build-artifact-valid.sh
+++ b/gascity/assets/scripts/checks/build-artifact-valid.sh
@@ -22,7 +22,7 @@ fail() {
 
 BEAD_ID="${GC_BEAD_ID:-}"
 [ -n "$BEAD_ID" ] || fail "GC_BEAD_ID is required"
-command -v bd >/dev/null 2>&1 || fail "bd is required on PATH"
+command -v gc >/dev/null 2>&1 || fail "gc is required on PATH"
 command -v python3 >/dev/null 2>&1 || fail "python3 is required on PATH"
 
 metadata_value() {
@@ -48,7 +48,7 @@ print(value if isinstance(value, str) else "")
 ' "$2"
 }
 
-SHOW_JSON="$(bd show "$BEAD_ID" --json 2>/dev/null)" || fail "bd show $BEAD_ID failed"
+SHOW_JSON="$(gc bd show "$BEAD_ID" --json 2>/dev/null)" || fail "gc bd show $BEAD_ID failed"
 
 SCHEMA="$(metadata_value "$SHOW_JSON" "gc.build.artifact_schema")"
 PATH_KEYS="$(metadata_value "$SHOW_JSON" "gc.build.artifact_path_keys")"
@@ -58,7 +58,7 @@ PATH_KEYS="$(metadata_value "$SHOW_JSON" "gc.build.artifact_path_keys")"
 ROOT_ID="$(metadata_value "$SHOW_JSON" "gc.root_bead_id")"
 ROOT_JSON="$SHOW_JSON"
 if [ -n "$ROOT_ID" ] && [ "$ROOT_ID" != "$BEAD_ID" ]; then
-  ROOT_JSON="$(bd show "$ROOT_ID" --json 2>/dev/null)" || fail "bd show $ROOT_ID failed"
+  ROOT_JSON="$(gc bd show "$ROOT_ID" --json 2>/dev/null)" || fail "gc bd show $ROOT_ID failed"
 fi
 
 ARTIFACT_PATH=""

--- a/gascity/assets/scripts/checks/design-review-approved.sh
+++ b/gascity/assets/scripts/checks/design-review-approved.sh
@@ -9,7 +9,7 @@ if [ -z "$BEAD_ID" ]; then
     exit 1
 fi
 
-BEAD_JSON=$(bd show "$BEAD_ID" --json 2>/dev/null)
+BEAD_JSON=$(gc bd show "$BEAD_ID" --json 2>/dev/null)
 ROOT_ID=$(printf '%s\n' "$BEAD_JSON" | jq -r 'if type == "array" then (.[0].metadata["gc.root_bead_id"] // "") else (.metadata["gc.root_bead_id"] // "") end')
 ATTEMPT=$(printf '%s\n' "$BEAD_JSON" | jq -r 'if type == "array" then (.[0].metadata["gc.attempt"] // "") else (.metadata["gc.attempt"] // "") end')
 SCOPE_REF=$(printf '%s\n' "$BEAD_JSON" | jq -r 'if type == "array" then (.[0].metadata["gc.scope_ref"] // .[0].metadata["gc.step_ref"] // "") else (.metadata["gc.scope_ref"] // .metadata["gc.step_ref"] // "") end')
@@ -20,7 +20,7 @@ if [ -z "$ROOT_ID" ]; then
 fi
 
 VERDICT=$(
-    bd list --all --metadata-field "gc.root_bead_id=$ROOT_ID" --json --limit=0 2>/dev/null |
+    gc bd list --all --metadata-field "gc.root_bead_id=$ROOT_ID" --json --limit=0 2>/dev/null |
         jq -r --arg root "$ROOT_ID" --arg attempt "$ATTEMPT" --arg scope "$SCOPE_REF" --arg step "$STEP_ID" '
             [
               .[]

--- a/gascity/assets/scripts/checks/gap-analysis-approved.sh
+++ b/gascity/assets/scripts/checks/gap-analysis-approved.sh
@@ -22,13 +22,13 @@ metadata_value() {
   ' 2>/dev/null
 }
 
-ROOT_JSON="$(bd show "$ROOT_ID" --json 2>/dev/null || true)"
+ROOT_JSON="$(gc bd show "$ROOT_ID" --json 2>/dev/null || true)"
 PARENT_ROOT="$(metadata_value "$ROOT_JSON" "gc.root_bead_id")"
 if [ -z "$PARENT_ROOT" ]; then
   PARENT_ROOT="$ROOT_ID"
 fi
 
-MATCHES="$(bd list --all --metadata-field "gc.root_bead_id=$PARENT_ROOT" --json --limit=0 2>/dev/null || printf '[]')"
+MATCHES="$(gc bd list --all --metadata-field "gc.root_bead_id=$PARENT_ROOT" --json --limit=0 2>/dev/null || printf '[]')"
 
 VERDICT="$(printf '%s\n' "$MATCHES" | jq -r --arg attempt "$ATTEMPT" '
   [

--- a/gascity/assets/scripts/checks/implementation-review-approved.sh
+++ b/gascity/assets/scripts/checks/implementation-review-approved.sh
@@ -22,14 +22,14 @@ metadata_value() {
   ' 2>/dev/null
 }
 
-ROOT_JSON="$(bd show "$ROOT_ID" --json 2>/dev/null || true)"
+ROOT_JSON="$(gc bd show "$ROOT_ID" --json 2>/dev/null || true)"
 PARENT_ROOT="$(metadata_value "$ROOT_JSON" "gc.root_bead_id")"
 if [ -z "$PARENT_ROOT" ]; then
   PARENT_ROOT="$ROOT_ID"
 fi
 PARENT_JSON="$ROOT_JSON"
 if [ "$PARENT_ROOT" != "$ROOT_ID" ]; then
-  PARENT_JSON="$(bd show "$PARENT_ROOT" --json 2>/dev/null || true)"
+  PARENT_JSON="$(gc bd show "$PARENT_ROOT" --json 2>/dev/null || true)"
 fi
 STEP_ID="$(metadata_value "$ROOT_JSON" "gc.step_id")"
 SCOPE_REF="$(metadata_value "$ROOT_JSON" "gc.scope_ref")"
@@ -37,7 +37,7 @@ if [ -z "$SCOPE_REF" ]; then
   SCOPE_REF="$(metadata_value "$ROOT_JSON" "gc.step_ref")"
 fi
 
-MATCHES="$(bd list --all --metadata-field "gc.root_bead_id=$PARENT_ROOT" --json --limit=0 2>/dev/null || printf '[]')"
+MATCHES="$(gc bd list --all --metadata-field "gc.root_bead_id=$PARENT_ROOT" --json --limit=0 2>/dev/null || printf '[]')"
 
 VERDICT="$(printf '%s\n' "$MATCHES" | jq -r --arg attempt "$ATTEMPT" '
   [

--- a/gascity/assets/workflows/build-base/decompose.md
+++ b/gascity/assets/workflows/build-base/decompose.md
@@ -16,9 +16,9 @@ Record the implementation convoy ID on the workflow root bead as both:
 - `gc.build.implementation_convoy_id=<implementation-convoy-id>` for build
   reporting and downstream methodology-specific stages.
 
-Use one quoted `bd update` command against the workflow root bead, for example:
+Use one quoted `gc bd update` command against the workflow root bead, for example:
 
-`bd update "<workflow-root-id>" --set-metadata "gc.input_convoy_id=<implementation-convoy-id>" --set-metadata "gc.build.implementation_convoy_id=<implementation-convoy-id>"`
+`gc bd update "<workflow-root-id>" --set-metadata "gc.input_convoy_id=<implementation-convoy-id>" --set-metadata "gc.build.implementation_convoy_id=<implementation-convoy-id>"`
 
 Close this step only after the decomposition artifact or task beads are
 recorded on the workflow root bead and both convoy metadata fields are set
@@ -27,12 +27,12 @@ launch/source convoy.
 
 Write the decomposition artifact to the resolved decomposition path and ensure
 that path is recorded on the workflow root bead as `gc.build.decomposition_path`.
-Use `bd update "<workflow-root-id>" --set-metadata "gc.build.decomposition_path=<absolute path>"`.
-Do not use `bd update --metadata 'key=value'`; `--metadata` only accepts a JSON
+Use `gc bd update "<workflow-root-id>" --set-metadata "gc.build.decomposition_path=<absolute path>"`.
+Do not use `gc bd update --metadata 'key=value'`; `--metadata` only accepts a JSON
 object.
 Before closing this step, set the claimed step outcome with
-`bd update "<claimed-step-id>" --set-metadata "gc.outcome=pass"`, then close
-with `bd close "<claimed-step-id>" --reason "<concise reason>"`. Do not pass
-`--metadata` or `--set-metadata` to `bd close`.
+`gc bd update "<claimed-step-id>" --set-metadata "gc.outcome=pass"`, then close
+with `gc bd close "<claimed-step-id>" --reason "<concise reason>"`. Do not pass
+`--metadata` or `--set-metadata` to `gc bd close`.
 
 Artifact validation: this stage is gated by `.gc/scripts/checks/build-artifact-valid.sh`, which validates the artifact recorded at `gc.build.decomposition_path` (fallback `gc.var.decomposition_path`) against schema `gc.build.decomposition.v1`. On repair attempts (`gc.attempt` greater than 1), read the validator errors from `gc.attempt_log` on the validation loop control bead (the dependent of this step bead) and repair the artifact in place instead of rewriting it. Two bounded repair attempts follow the first failure; exhausting them closes this stage with `gc.outcome=fail` and machine-readable validation errors that block downstream stages. Never ask questions in headless mode; record unresolved ambiguity inside the artifact.

--- a/gascity/assets/workflows/build-base/finalize.md
+++ b/gascity/assets/workflows/build-base/finalize.md
@@ -4,13 +4,13 @@ Synthesize the workflow result from the requirements, plan, decomposition, imple
 
 Write the final build report to the resolved final report path and ensure that
 path is recorded on the workflow root bead as `gc.build.final_report_path`.
-Use `bd update "<workflow-root-id>" --set-metadata "gc.build.final_report_path=<absolute path>"`.
-Do not use `bd update --metadata 'key=value'`; `--metadata` only accepts a JSON
+Use `gc bd update "<workflow-root-id>" --set-metadata "gc.build.final_report_path=<absolute path>"`.
+Do not use `gc bd update --metadata 'key=value'`; `--metadata` only accepts a JSON
 object.
 Before closing this step, set the claimed step outcome with
-`bd update "<claimed-step-id>" --set-metadata "gc.outcome=pass"`, then close
-with `bd close "<claimed-step-id>" --reason "<concise reason>"`. Do not pass
-`--metadata` or `--set-metadata` to `bd close`.
+`gc bd update "<claimed-step-id>" --set-metadata "gc.outcome=pass"`, then close
+with `gc bd close "<claimed-step-id>" --reason "<concise reason>"`. Do not pass
+`--metadata` or `--set-metadata` to `gc bd close`.
 
 Close this step only after the workflow root bead has the final outcome metadata needed by publish.
 

--- a/gascity/assets/workflows/build-base/plan.md
+++ b/gascity/assets/workflows/build-base/plan.md
@@ -3,12 +3,12 @@ This is the `build-base` plan stage. Treat it as a virtual contract that concret
 Use the requirements artifact and repository context to produce an implementation plan or design artifact. The artifact must identify affected areas, sequencing, risks, test strategy, and handoff criteria.
 
 Close this step only after the plan path is recorded on the workflow root bead.
-Use `bd update "<workflow-root-id>" --set-metadata "gc.build.plan_path=<absolute path>"`.
-Do not use `bd update --metadata 'key=value'`; `--metadata` only accepts a JSON
+Use `gc bd update "<workflow-root-id>" --set-metadata "gc.build.plan_path=<absolute path>"`.
+Do not use `gc bd update --metadata 'key=value'`; `--metadata` only accepts a JSON
 object.
 Before closing this step, set the claimed step outcome with
-`bd update "<claimed-step-id>" --set-metadata "gc.outcome=pass"`, then close
-with `bd close "<claimed-step-id>" --reason "<concise reason>"`. Do not pass
-`--metadata` or `--set-metadata` to `bd close`.
+`gc bd update "<claimed-step-id>" --set-metadata "gc.outcome=pass"`, then close
+with `gc bd close "<claimed-step-id>" --reason "<concise reason>"`. Do not pass
+`--metadata` or `--set-metadata` to `gc bd close`.
 
 Artifact validation: this stage is gated by `.gc/scripts/checks/build-artifact-valid.sh`, which validates the artifact recorded at `gc.build.plan_path` (fallback `gc.var.plan_path`) against schema `gc.build.plan.v1`. On repair attempts (`gc.attempt` greater than 1), read the validator errors from `gc.attempt_log` on the validation loop control bead (the dependent of this step bead) and repair the artifact in place instead of rewriting it. Two bounded repair attempts follow the first failure; exhausting them closes this stage with `gc.outcome=fail` and machine-readable validation errors that block downstream stages. Never ask questions in headless mode; record unresolved ambiguity inside the artifact.

--- a/gascity/assets/workflows/build-base/prepare.md
+++ b/gascity/assets/workflows/build-base/prepare.md
@@ -70,15 +70,15 @@ validation gates read these keys, so record every derived path even when the
 matching launch input was blank.
 
 When updating metadata, store plain scalar strings without embedded quote
-characters. Prefer a single JSON-object update with `bd update <root> --metadata
+characters. Prefer a single JSON-object update with `gc bd update <root> --metadata
 '{"gc.var.push":"false","gc.var.open_pr":"false","gc.var.max_iterations":"10"}'`
 or individually quoted `--set-metadata 'key=value'` arguments. Do not write
 values like `"false"` or `"10"` that include literal double quotes.
 
 Close commands do not accept metadata flags. Before closing this step, set the
-step outcome with `bd update <claimed-step-id> --set-metadata 'gc.outcome=pass'`
-and then close with `bd close <claimed-step-id> --reason '<concise reason>'`.
-Do not pass `--set-metadata` or `--metadata` to `bd close`, and do not use
+step outcome with `gc bd update <claimed-step-id> --set-metadata 'gc.outcome=pass'`
+and then close with `gc bd close <claimed-step-id> --reason '<concise reason>'`.
+Do not pass `--set-metadata` or `--metadata` to `gc bd close`, and do not use
 `gc.outcome=success`; successful workflow stages use `gc.outcome=pass`.
 
 Do not edit source files. Close this step only after the required paths and input assumptions are explicit.

--- a/gascity/assets/workflows/build-base/requirements.md
+++ b/gascity/assets/workflows/build-base/requirements.md
@@ -4,12 +4,12 @@ Produce or reuse a requirements artifact under the build artifact root. The arti
 
 Close this step only after the requirements path is recorded on the workflow
 root bead. Use
-`bd update "<workflow-root-id>" --set-metadata "gc.build.requirements_path=<absolute path>"`.
-Do not use `bd update --metadata 'key=value'`; `--metadata` only accepts a JSON
+`gc bd update "<workflow-root-id>" --set-metadata "gc.build.requirements_path=<absolute path>"`.
+Do not use `gc bd update --metadata 'key=value'`; `--metadata` only accepts a JSON
 object.
 Before closing this step, set the claimed step outcome with
-`bd update "<claimed-step-id>" --set-metadata "gc.outcome=pass"`, then close
-with `bd close "<claimed-step-id>" --reason "<concise reason>"`. Do not pass
-`--metadata` or `--set-metadata` to `bd close`.
+`gc bd update "<claimed-step-id>" --set-metadata "gc.outcome=pass"`, then close
+with `gc bd close "<claimed-step-id>" --reason "<concise reason>"`. Do not pass
+`--metadata` or `--set-metadata` to `gc bd close`.
 
 Artifact validation: this stage is gated by `.gc/scripts/checks/build-artifact-valid.sh`, which validates the artifact recorded at `gc.build.requirements_path` (fallback `gc.var.requirements_path`) against schema `gc.build.requirements.v1`. On repair attempts (`gc.attempt` greater than 1), read the validator errors from `gc.attempt_log` on the validation loop control bead (the dependent of this step bead) and repair the artifact in place instead of rewriting it. Two bounded repair attempts follow the first failure; exhausting them closes this stage with `gc.outcome=fail` and machine-readable validation errors that block downstream stages. Never ask questions in headless mode; record unresolved ambiguity inside the artifact.

--- a/gascity/assets/workflows/build-base/review.md
+++ b/gascity/assets/workflows/build-base/review.md
@@ -14,13 +14,13 @@ and its reason must be recorded in the review artifact.
 
 Write the review report to the resolved review report path and record that path
 on the workflow root bead as `gc.build.review_report_path` before closing. Use
-`bd update "<workflow-root-id>" --set-metadata "gc.build.review_report_path=<absolute path>"`.
-Do not use `bd update --metadata 'key=value'`; `--metadata` only accepts a JSON
+`gc bd update "<workflow-root-id>" --set-metadata "gc.build.review_report_path=<absolute path>"`.
+Do not use `gc bd update --metadata 'key=value'`; `--metadata` only accepts a JSON
 object.
 Before closing this step, set the claimed step outcome with
-`bd update "<claimed-step-id>" --set-metadata "gc.outcome=pass"`, then close
-with `bd close "<claimed-step-id>" --reason "<concise reason>"`. Do not pass
-`--metadata` or `--set-metadata` to `bd close`.
+`gc bd update "<claimed-step-id>" --set-metadata "gc.outcome=pass"`, then close
+with `gc bd close "<claimed-step-id>" --reason "<concise reason>"`. Do not pass
+`--metadata` or `--set-metadata` to `gc bd close`.
 
 Close this step only when the implementation is clean enough to finalize or when unresolved findings are recorded.
 

--- a/gascity/assets/workflows/build-base/summarize-implementation.md
+++ b/gascity/assets/workflows/build-base/summarize-implementation.md
@@ -14,9 +14,9 @@ Resolve the workflow root bead and artifact root from root metadata. If
 `gc.var.artifact_root` or `gc.build.artifact_root` as
 `implementation-summary.md`, then record it on the workflow root:
 
-`bd update "<workflow-root-id>" --set-metadata "gc.build.implementation_summary_path=<absolute path>"`
+`gc bd update "<workflow-root-id>" --set-metadata "gc.build.implementation_summary_path=<absolute path>"`
 
-Do not use `bd update --metadata 'key=value'`; `--metadata` only accepts a JSON
+Do not use `gc bd update --metadata 'key=value'`; `--metadata` only accepts a JSON
 object.
 
 Collect the closed implementation source anchors and drain child workflows from
@@ -78,8 +78,8 @@ Before closing this step, read the launcher rig root from the workflow root bead
 
 fix every reported validation error before setting `gc.outcome=pass`. Then set
 the claimed step outcome with
-`bd update "<claimed-step-id>" --set-metadata "gc.outcome=pass"`, and close
-with `bd close "<claimed-step-id>" --reason "<concise reason>"`. Do not pass
-`--metadata` or `--set-metadata` to `bd close`.
+`gc bd update "<claimed-step-id>" --set-metadata "gc.outcome=pass"`, and close
+with `gc bd close "<claimed-step-id>" --reason "<concise reason>"`. Do not pass
+`--metadata` or `--set-metadata` to `gc bd close`.
 
 Artifact validation: this stage is gated by `.gc/scripts/checks/build-artifact-valid.sh`, which validates the artifact recorded at `gc.build.implementation_summary_path` against schema `gc.build.implementation-summary.v1`. On repair attempts (`gc.attempt` greater than 1), read the validator errors from `gc.attempt_log` on the validation loop control bead (the dependent of this step bead) and repair the summary in place instead of rewriting it. Two bounded repair attempts follow the first failure; exhausting them closes this stage with `gc.outcome=fail` and machine-readable validation errors that block downstream stages. Never ask questions in headless mode; record unresolved ambiguity inside the artifact.

--- a/gascity/assets/workflows/build-basic-review/{target}.acceptance-review.md
+++ b/gascity/assets/workflows/build-basic-review/{target}.acceptance-review.md
@@ -23,11 +23,11 @@ Close with `gc.outcome=pass`,
 Use explicit close metadata so the review loop can detect the lane result:
 
 ```bash
-bd update "$CLAIMED_BEAD_ID" \
+gc bd update "$CLAIMED_BEAD_ID" \
   --set-metadata 'gc.outcome=pass' \
   --set-metadata 'code_review.acceptance_verdict=approve' \
   --set-metadata 'code_review.output_path=<acceptance review report path>'
-bd close "$CLAIMED_BEAD_ID" --reason 'Build-basic acceptance review approved.'
+gc bd close "$CLAIMED_BEAD_ID" --reason 'Build-basic acceptance review approved.'
 ```
 
 If you find required fixes, set

--- a/gascity/assets/workflows/build-basic-review/{target}.apply-review-findings.md
+++ b/gascity/assets/workflows/build-basic-review/{target}.apply-review-findings.md
@@ -23,16 +23,16 @@ Always close with `gc.outcome=pass`,
 `code_review.output_path=<starter review summary path>`.
 
 Use the exact claimed bead id when updating metadata. Do not pass freeform notes
-or additional positional arguments to `bd update`; unquoted words can resolve to
+or additional positional arguments to `gc bd update`; unquoted words can resolve to
 unrelated beads. Use this command shape:
 
 ```bash
-bd update "$CLAIMED_BEAD_ID" \
+gc bd update "$CLAIMED_BEAD_ID" \
   --set-metadata 'gc.outcome=pass' \
   --set-metadata 'code_review.verdict=done' \
   --set-metadata 'code_review.report_path=<starter review summary path>' \
   --set-metadata 'code_review.output_path=<starter review summary path>'
-bd close "$CLAIMED_BEAD_ID" --reason 'Build-basic starter review approved.'
+gc bd close "$CLAIMED_BEAD_ID" --reason 'Build-basic starter review approved.'
 ```
 
 Do not invoke provider-native subagents. This starter factory graph lane is the

--- a/gascity/assets/workflows/build-basic-review/{target}.md
+++ b/gascity/assets/workflows/build-basic-review/{target}.md
@@ -3,8 +3,8 @@ Finalize the build-basic starter factory review.
 Verify the latest starter review loop approved the implementation and wrote a
 starter review summary path. Record the approved review path on the workflow
 root bead so the build-basic finalize stage can include it in `factory-run.md`.
-Use `bd update "<workflow-root-id>" --set-metadata "gc.build.review_report_path=<absolute path>"`.
-Do not use `bd update --metadata 'key=value'`; `--metadata` only accepts a JSON
+Use `gc bd update "<workflow-root-id>" --set-metadata "gc.build.review_report_path=<absolute path>"`.
+Do not use `gc bd update --metadata 'key=value'`; `--metadata` only accepts a JSON
 object.
 
 Review approval is based on the implementation source anchor/worktree recorded
@@ -61,8 +61,8 @@ Trace front matter must use the validator shape exactly:
 - Verification
 
 Before closing this expansion target, set the claimed step outcome with
-`bd update "<claimed-step-id>" --set-metadata "gc.outcome=pass"`, then close
-with `bd close "<claimed-step-id>" --reason "<concise reason>"`. Do not pass
-`--metadata` or `--set-metadata` to `bd close`.
+`gc bd update "<claimed-step-id>" --set-metadata "gc.outcome=pass"`, then close
+with `gc bd close "<claimed-step-id>" --reason "<concise reason>"`. Do not pass
+`--metadata` or `--set-metadata` to `gc bd close`.
 
 Do not invoke provider-native subagents or provider-specific task tools.

--- a/gascity/assets/workflows/build-basic-review/{target}.simplicity-review.md
+++ b/gascity/assets/workflows/build-basic-review/{target}.simplicity-review.md
@@ -15,11 +15,11 @@ Close with `gc.outcome=pass`,
 Use explicit close metadata so the review loop can detect the lane result:
 
 ```bash
-bd update "$CLAIMED_BEAD_ID" \
+gc bd update "$CLAIMED_BEAD_ID" \
   --set-metadata 'gc.outcome=pass' \
   --set-metadata 'code_review.simplicity_verdict=approve' \
   --set-metadata 'code_review.output_path=<simplicity review report path>'
-bd close "$CLAIMED_BEAD_ID" --reason 'Build-basic simplicity review approved.'
+gc bd close "$CLAIMED_BEAD_ID" --reason 'Build-basic simplicity review approved.'
 ```
 
 If you find required fixes, set

--- a/gascity/assets/workflows/build-basic-review/{target}.test-evidence-review.md
+++ b/gascity/assets/workflows/build-basic-review/{target}.test-evidence-review.md
@@ -16,11 +16,11 @@ Close with `gc.outcome=pass`,
 Use explicit close metadata so the review loop can detect the lane result:
 
 ```bash
-bd update "$CLAIMED_BEAD_ID" \
+gc bd update "$CLAIMED_BEAD_ID" \
   --set-metadata 'gc.outcome=pass' \
   --set-metadata 'code_review.test_evidence_verdict=approve' \
   --set-metadata 'code_review.output_path=<test evidence report path>'
-bd close "$CLAIMED_BEAD_ID" --reason 'Build-basic test evidence review approved.'
+gc bd close "$CLAIMED_BEAD_ID" --reason 'Build-basic test evidence review approved.'
 ```
 
 If proof is missing or insufficient, set

--- a/gascity/assets/workflows/build-basic/decompose.md
+++ b/gascity/assets/workflows/build-basic/decompose.md
@@ -54,7 +54,7 @@ work units. Do not reuse the source or launch convoy from `gc.var.convoy_id`.
 
 Use the convoy creation flow exactly:
 
-1. Create each work item with `bd create ...` and capture the returned work-item
+1. Create each work item with `gc bd create ...` and capture the returned work-item
    bead IDs.
 2. Create and link the implementation convoy in one command:
    `gc convoy create <name> <work-item-id...> --json`.
@@ -62,25 +62,25 @@ Use the convoy creation flow exactly:
    convoy with `gc convoy list --json`.
 
 Do not create an empty convoy. Do not call `gc convoy add` for newly-created beads.
-The freshly-created IDs may not be visible to that path yet. Do not call `bd show <implementation-convoy-id>`.
+The freshly-created IDs may not be visible to that path yet. Do not call `gc bd show <implementation-convoy-id>`.
 Convoy IDs are not bd issue IDs.
 
 Record the decomposition output on the workflow root bead with
-`bd update "<workflow-root-id>" --set-metadata "gc.build.decomposition_path=<absolute path>"`.
-Do not use `bd update --metadata 'key=value'`; `--metadata` only accepts a JSON
+`gc bd update "<workflow-root-id>" --set-metadata "gc.build.decomposition_path=<absolute path>"`.
+Do not use `gc bd update --metadata 'key=value'`; `--metadata` only accepts a JSON
 object.
 
 Then set both `gc.input_convoy_id=<implementation-convoy-id>` and
 `gc.build.implementation_convoy_id=<implementation-convoy-id>` on the workflow
 root bead with a quoted command like:
 
-`bd update "<workflow-root-id>" --set-metadata "gc.input_convoy_id=<implementation-convoy-id>" --set-metadata "gc.build.implementation_convoy_id=<implementation-convoy-id>"`
+`gc bd update "<workflow-root-id>" --set-metadata "gc.input_convoy_id=<implementation-convoy-id>" --set-metadata "gc.build.implementation_convoy_id=<implementation-convoy-id>"`
 
 before closing, verify both metadata fields exist on the workflow root and point
 to the new implementation convoy.
 Before closing this step, set the claimed step outcome with
-`bd update "<claimed-step-id>" --set-metadata "gc.outcome=pass"`, then close
-with `bd close "<claimed-step-id>" --reason "<concise reason>"`. Do not pass
-`--metadata` or `--set-metadata` to `bd close`.
+`gc bd update "<claimed-step-id>" --set-metadata "gc.outcome=pass"`, then close
+with `gc bd close "<claimed-step-id>" --reason "<concise reason>"`. Do not pass
+`--metadata` or `--set-metadata` to `gc bd close`.
 
 Artifact validation: this stage is gated by `.gc/scripts/checks/build-artifact-valid.sh`, which validates the artifact recorded at `gc.build.decomposition_path` (fallback `gc.var.decomposition_path`) against schema `gc.build.decomposition.v1`. On repair attempts (`gc.attempt` greater than 1), read the validator errors from `gc.attempt_log` on the validation loop control bead (the dependent of this step bead) and repair the artifact in place instead of rewriting it. Two bounded repair attempts follow the first failure; exhausting them closes this stage with `gc.outcome=fail` and machine-readable validation errors that block downstream stages. Never ask questions in headless mode; record unresolved ambiguity inside the artifact.

--- a/gascity/assets/workflows/build-basic/finalize.md
+++ b/gascity/assets/workflows/build-basic/finalize.md
@@ -43,8 +43,8 @@ coverage matrix described here, and these sections:
 
 Record the canonical path on the workflow root bead before validating or
 writing the final report. Use
-`bd update "<workflow-root-id>" --set-metadata "gc.build.implementation_summary_path=<absolute path>"`.
-Do not use `bd update --metadata 'key=value'`; `--metadata` only accepts a JSON
+`gc bd update "<workflow-root-id>" --set-metadata "gc.build.implementation_summary_path=<absolute path>"`.
+Do not use `gc bd update --metadata 'key=value'`; `--metadata` only accepts a JSON
 object.
 
 Use mapping objects for front matter; do not use scalar shortcuts such as
@@ -95,13 +95,13 @@ In those sections, include:
 
 Record the final report path on the workflow root bead as both
 `gc.build.final_report_path=<path>` and `gc.build.factory_run_path=<path>`.
-Use `bd update "<workflow-root-id>" --set-metadata "gc.build.final_report_path=<absolute path>" --set-metadata "gc.build.factory_run_path=<absolute path>"`.
-Do not use `bd update --metadata 'key=value'`; `--metadata` only accepts a JSON
+Use `gc bd update "<workflow-root-id>" --set-metadata "gc.build.final_report_path=<absolute path>" --set-metadata "gc.build.factory_run_path=<absolute path>"`.
+Do not use `gc bd update --metadata 'key=value'`; `--metadata` only accepts a JSON
 object.
 Before closing this step, set the claimed step outcome with
-`bd update "<claimed-step-id>" --set-metadata "gc.outcome=pass"`, then close
-with `bd close "<claimed-step-id>" --reason "<concise reason>"`. Do not pass
-`--metadata` or `--set-metadata` to `bd close`.
+`gc bd update "<claimed-step-id>" --set-metadata "gc.outcome=pass"`, then close
+with `gc bd close "<claimed-step-id>" --reason "<concise reason>"`. Do not pass
+`--metadata` or `--set-metadata` to `gc bd close`.
 
 Do not publish from this step.
 

--- a/gascity/assets/workflows/build-basic/plan.md
+++ b/gascity/assets/workflows/build-basic/plan.md
@@ -46,12 +46,12 @@ Include the required schema sections:
 - Verification
 
 Record the implementation plan path on the workflow root bead before closing.
-Use `bd update "<workflow-root-id>" --set-metadata "gc.build.plan_path=<absolute path>"`.
-Do not use `bd update --metadata 'key=value'`; `--metadata` only accepts a JSON
+Use `gc bd update "<workflow-root-id>" --set-metadata "gc.build.plan_path=<absolute path>"`.
+Do not use `gc bd update --metadata 'key=value'`; `--metadata` only accepts a JSON
 object.
 Before closing this step, set the claimed step outcome with
-`bd update "<claimed-step-id>" --set-metadata "gc.outcome=pass"`, then close
-with `bd close "<claimed-step-id>" --reason "<concise reason>"`. Do not pass
-`--metadata` or `--set-metadata` to `bd close`.
+`gc bd update "<claimed-step-id>" --set-metadata "gc.outcome=pass"`, then close
+with `gc bd close "<claimed-step-id>" --reason "<concise reason>"`. Do not pass
+`--metadata` or `--set-metadata` to `gc bd close`.
 
 Artifact validation: this stage is gated by `.gc/scripts/checks/build-artifact-valid.sh`, which validates the artifact recorded at `gc.build.plan_path` (fallback `gc.var.plan_path`) against schema `gc.build.plan.v1`. On repair attempts (`gc.attempt` greater than 1), read the validator errors from `gc.attempt_log` on the validation loop control bead (the dependent of this step bead) and repair the artifact in place instead of rewriting it. Two bounded repair attempts follow the first failure; exhausting them closes this stage with `gc.outcome=fail` and machine-readable validation errors that block downstream stages. Never ask questions in headless mode; record unresolved ambiguity inside the artifact.

--- a/gascity/assets/workflows/build-basic/publish.md
+++ b/gascity/assets/workflows/build-basic/publish.md
@@ -11,14 +11,14 @@ result while preserving the approved build outcome.
 `gc.outcome=noop`. A disabled/no-op publish is a successful publish step:
 
 ```bash
-bd update "$CLAIMED_BEAD_ID" \
+gc bd update "$CLAIMED_BEAD_ID" \
   --set-metadata 'gc.outcome=pass' \
   --set-metadata 'gc.publish_outcome=noop' \
   --set-metadata 'gc.publish_mode=disabled' \
   --set-metadata 'gc.build_outcome=pass' \
   --set-metadata 'gc.final_report=<final report path>' \
   --set-metadata 'gc.artifact_root=<artifact root>'
-bd close "$CLAIMED_BEAD_ID" --reason 'Publishing disabled; build-basic result approved.'
+gc bd close "$CLAIMED_BEAD_ID" --reason 'Publishing disabled; build-basic result approved.'
 ```
 
 Close only after the push, PR creation, or no-op publish result is recorded.

--- a/gascity/assets/workflows/build-basic/requirements.md
+++ b/gascity/assets/workflows/build-basic/requirements.md
@@ -63,12 +63,12 @@ or headless, record unresolved ambiguity in open questions instead of blocking
 without a clear need.
 
 Record the requirements path on the workflow root bead before closing. Use
-`bd update "<workflow-root-id>" --set-metadata "gc.build.requirements_path=<absolute path>"`.
-Do not use `bd update --metadata 'key=value'`; `--metadata` only accepts a JSON
+`gc bd update "<workflow-root-id>" --set-metadata "gc.build.requirements_path=<absolute path>"`.
+Do not use `gc bd update --metadata 'key=value'`; `--metadata` only accepts a JSON
 object.
 Before closing this step, set the claimed step outcome with
-`bd update "<claimed-step-id>" --set-metadata "gc.outcome=pass"`, then close
-with `bd close "<claimed-step-id>" --reason "<concise reason>"`. Do not pass
-`--metadata` or `--set-metadata` to `bd close`.
+`gc bd update "<claimed-step-id>" --set-metadata "gc.outcome=pass"`, then close
+with `gc bd close "<claimed-step-id>" --reason "<concise reason>"`. Do not pass
+`--metadata` or `--set-metadata` to `gc bd close`.
 
 Artifact validation: this stage is gated by `.gc/scripts/checks/build-artifact-valid.sh`, which validates the artifact recorded at `gc.build.requirements_path` (fallback `gc.var.requirements_path`) against schema `gc.build.requirements.v1`. On repair attempts (`gc.attempt` greater than 1), read the validator errors from `gc.attempt_log` on the validation loop control bead (the dependent of this step bead) and repair the artifact in place instead of rewriting it. Two bounded repair attempts follow the first failure; exhausting them closes this stage with `gc.outcome=fail` and machine-readable validation errors that block downstream stages. Never ask questions in headless mode; record unresolved ambiguity inside the artifact.

--- a/gascity/assets/workflows/build-basic/review.md
+++ b/gascity/assets/workflows/build-basic/review.md
@@ -7,12 +7,12 @@ review synthesis, required fixes, and the final `code_review.verdict`.
 
 Record the synthesized review report path and pass/fail outcome on the workflow
 root bead. Use
-`bd update "<workflow-root-id>" --set-metadata "gc.build.review_report_path=<absolute path>"`.
-Do not use `bd update --metadata 'key=value'`; `--metadata` only accepts a JSON
+`gc bd update "<workflow-root-id>" --set-metadata "gc.build.review_report_path=<absolute path>"`.
+Do not use `gc bd update --metadata 'key=value'`; `--metadata` only accepts a JSON
 object.
 Before closing this step, set the claimed step outcome with
-`bd update "<claimed-step-id>" --set-metadata "gc.outcome=pass"`, then close
-with `bd close "<claimed-step-id>" --reason "<concise reason>"`. Do not pass
-`--metadata` or `--set-metadata` to `bd close`.
+`gc bd update "<claimed-step-id>" --set-metadata "gc.outcome=pass"`, then close
+with `gc bd close "<claimed-step-id>" --reason "<concise reason>"`. Do not pass
+`--metadata` or `--set-metadata` to `gc bd close`.
 
 Artifact validation: this stage is gated by `.gc/scripts/checks/build-artifact-valid.sh`, which validates the artifact recorded at `gc.build.review_report_path` against schema `gc.build.review.v1`. On repair attempts (`gc.attempt` greater than 1), read the validator errors from `gc.attempt_log` on the validation loop control bead (the dependent of this step bead) and repair the artifact in place instead of rewriting it. Two bounded repair attempts follow the first failure; exhausting them closes this stage with `gc.outcome=fail` and machine-readable validation errors that block downstream stages. Never ask questions in headless mode; record unresolved ambiguity inside the artifact.

--- a/gascity/assets/workflows/do-work-item/implement-item.md
+++ b/gascity/assets/workflows/do-work-item/implement-item.md
@@ -5,7 +5,7 @@ verification policy, validate context path {{context_path}} when set, implement
 the item, write an item summary, and close only the source anchor on success.
 
 Do not infer the source anchor from dependency ids. Read the reserved convoy and
-source anchor metadata directly; when `bd show --json` returns a one-element
+source anchor metadata directly; when `gc bd show --json` returns a one-element
 list, unwrap the first element before reading metadata. `gc.work_dir` is the
 launcher rig root, not the implementation location. Use the authoritative
 worktree recorded on the source anchor, run `cd "$WORKTREE"`, and verify

--- a/gascity/assets/workflows/do-work/close-source-anchor.md
+++ b/gascity/assets/workflows/do-work/close-source-anchor.md
@@ -7,7 +7,7 @@ is present; otherwise use `{{artifact_root}}/task-<source-anchor-id>-summary.md`
 
 On success, close only `<source-anchor-id>` with `gc.outcome=pass`. Include the
 verified commit and summary path in the source-anchor close reason. Read the
-source anchor back with `bd show <source-anchor-id> --json` and verify
+source anchor back with `gc bd show <source-anchor-id> --json` and verify
 `status=closed` and `gc.outcome=pass`; if either check fails, fix the source
 anchor before closing this step. Do not close this step with pass while the source anchor remains open. Then close this step. Do not close the drain-unit
 convoy, parent convoy, or broader workflow root from this step.

--- a/gascity/assets/workflows/do-work/implement.md
+++ b/gascity/assets/workflows/do-work/implement.md
@@ -8,8 +8,8 @@ path, then `cd "$WORKTREE"` before reading or editing source files. If
 
 Do not infer the source anchor from dependency ids such as the
 `prepare-worktree` step. Read the claimed step bead's `gc.root_bead_id`, read
-that do-work root with `bd show <root-bead-id> --json`, then read the root
-metadata `gc.input_convoy_id`. Read that input convoy with `bd show
+that do-work root with `gc bd show <root-bead-id> --json`, then read the root
+metadata `gc.input_convoy_id`. Read that input convoy with `gc bd show
 <input-convoy-id> --json`; if the JSON output is a one-element list, unwrap the
 first element before reading metadata. If the input convoy has
 `gc.synthetic_kind=drain-unit-convoy`, use its `gc.drain_member_id` as the

--- a/gascity/assets/workflows/do-work/prepare-worktree.md
+++ b/gascity/assets/workflows/do-work/prepare-worktree.md
@@ -3,11 +3,11 @@ Resolve and publish the isolated worktree for this item. This is infrastructure
 setup only. Do not edit source files in the launcher checkout.
 
 1. Read current step bead metadata and get `gc.root_bead_id`; hard-fail if it is
-   missing. Read that do-work root with `bd show <root-bead-id> --json`.
+   missing. Read that do-work root with `gc bd show <root-bead-id> --json`.
 2. Resolve `<source-anchor-id>` from the do-work root:
    - read root metadata `gc.input_convoy_id`; hard-fail if it is missing
    - verify `gc.input_convoy_id` matches rendered runtime convoy `{{convoy_id}}`
-   - read that input convoy with `bd show <input-convoy-id> --json`
+   - read that input convoy with `gc bd show <input-convoy-id> --json`
    - if input convoy metadata has `gc.synthetic_kind=drain-unit-convoy`, use
      input convoy metadata `gc.drain_member_id`
    - do not use the synthetic drain-unit convoy id as `<source-anchor-id>`;
@@ -22,7 +22,7 @@ setup only. Do not edit source files in the launcher checkout.
    `git worktree add "$WORKTREE" --detach HEAD`. If the path exists but is not
    the worktree for this repository, fail closed.
 5. Persist the absolute path on the source anchor with
-   `bd update <source-anchor-id> --set-metadata work_dir=<absolute worktree path>`.
+   `gc bd update <source-anchor-id> --set-metadata work_dir=<absolute worktree path>`.
    For synthetic drain-unit convoys, never persist `work_dir` on the synthetic drain-unit convoy; the original drain member/source anchor is authoritative.
    Verify the source anchor now has `work_dir` before closing this step with
    `gc.outcome=pass`.

--- a/gascity/assets/workflows/github-issue-fix-base/resume-or-create-run.md
+++ b/gascity/assets/workflows/github-issue-fix-base/resume-or-create-run.md
@@ -58,7 +58,7 @@ directory is known, resolve these absolute paths under that run directory:
 Then publish all path metadata on the workflow root in one update:
 
 ```bash
-bd update <root-bead-id> \
+gc bd update <root-bead-id> \
   --set-metadata gc.github.run_dir=<absolute run directory> \
   --set-metadata gc.github.requirements_path=<absolute requirements.md path> \
   --set-metadata gc.github.implementation_plan_path=<absolute implementation-plan.md path> \

--- a/gascity/assets/workflows/github-issue-fix-base/snapshot.md
+++ b/gascity/assets/workflows/github-issue-fix-base/snapshot.md
@@ -12,10 +12,10 @@ backward-compatible alias: the effective interaction mode is
 `interaction_mode` when non-empty, otherwise `mode`. The effective value must
 be `interactive`, `autonomous`, or `headless`; `review_mode` must be `report`,
 `agent`, or `interactive`; `drain_policy` must be `separate` or
-`same-session`. Read the current step bead with `bd show <current-step-bead-id>
+`same-session`. Read the current step bead with `gc bd show <current-step-bead-id>
 --json`, take `gc.root_bead_id` (hard-fail if missing), and record the
 normalized value on the workflow root with
-`bd update <root-bead-id> --set-metadata gc.var.interaction_mode=<effective interaction mode>`.
+`gc bd update <root-bead-id> --set-metadata gc.var.interaction_mode=<effective interaction mode>`.
 Downstream steps read `gc.var.interaction_mode`, never the raw alias.
 
 Methodology selector compatibility gate. For each selected formula —
@@ -72,7 +72,7 @@ Then create or refresh the canonical GitHub source bead using this v0 contract:
 - Source beads are non-runnable index/cache beads. Do not route the source bead,
   assign it, depend on it, or use it as a readiness gate.
 - Lookup uses object identity only:
-  `bd list --metadata-field gc.kind=github_source --metadata-field gc.github.kind=issue --metadata-field gc.github.repo=<owner>/<repo> --metadata-field gc.github.number=<number> --status open,in_progress,closed --limit 1 --json`.
+  `gc bd list --metadata-field gc.kind=github_source --metadata-field gc.github.kind=issue --metadata-field gc.github.repo=<owner>/<repo> --metadata-field gc.github.number=<number> --status open,in_progress,closed --limit 1 --json`.
 - Write `source-metadata.json` with flat string metadata:
   `gc.kind=github_source`, `gc.github.kind=issue`,
   `gc.github.repo=<owner>/<repo>`, `gc.github.number=<number>`,
@@ -83,9 +83,9 @@ Then create or refresh the canonical GitHub source bead using this v0 contract:
   `gc.github.snapshot_path=<absolute source.json path>`,
   `gc.github.updated_at=<updated_at>`.
 - If no bead exists, create it with
-  `bd create "GitHub issue source: <owner>/<repo>#<number>" --type task --labels gc.github-source,gc.github-issue --external-ref <canonical_url> --metadata @source-metadata.json`.
+  `gc bd create "GitHub issue source: <owner>/<repo>#<number>" --type task --labels gc.github-source,gc.github-issue --external-ref <canonical_url> --metadata @source-metadata.json`.
 - If a bead exists, refresh it with
-  `bd update <source-bead-id> --external-ref <canonical_url> --metadata @source-metadata.json`.
+  `gc bd update <source-bead-id> --external-ref <canonical_url> --metadata @source-metadata.json`.
 
 Do not use title, label, assignee, or state changes to invalidate downstream
 fix reuse; `gc.github.body_hash` is the issue content key.

--- a/gascity/assets/workflows/github-issue-fix-design-review-work/{target}.setup-design-review.md
+++ b/gascity/assets/workflows/github-issue-fix-design-review-work/{target}.setup-design-review.md
@@ -1,7 +1,7 @@
 
 Recover context from bead metadata, not from a side-channel context file:
 
-1. Read this step bead and the workflow root bead through `bd show --json`.
+1. Read this step bead and the workflow root bead through `gc bd show --json`.
 2. Read `gc.github.implementation_plan_path` and `gc.github.requirements_path` from the
    workflow root or completed implementation-plan/requirements steps.
 3. Validate that `implementation-plan.md` exists. The plan may be `draft` or

--- a/gascity/assets/workflows/github-issue-triage-base/render-comment.md
+++ b/gascity/assets/workflows/github-issue-triage-base/render-comment.md
@@ -1,5 +1,5 @@
 
-Read workflow root metadata from `bd show <root-bead-id> --json`.
+Read workflow root metadata from `gc bd show <root-bead-id> --json`.
 If workflow root metadata has `gc.github.reused_current_output=true`, validate
 that `gc.github.comment_path` points to an existing `comment.md` under
 `gc.github.triage_dir`, validate the reused triage report still matches

--- a/gascity/assets/workflows/github-issue-triage-base/reuse-current-body-hash.md
+++ b/gascity/assets/workflows/github-issue-triage-base/reuse-current-body-hash.md
@@ -1,6 +1,6 @@
 
 Read the current step bead metadata, get `gc.root_bead_id`, then read
-workflow root metadata with `bd show <root-bead-id> --json`. Use
+workflow root metadata with `gc bd show <root-bead-id> --json`. Use
 `gc.github.repo`, `gc.github.number`, `gc.github.body_hash`,
 `gc.github.snapshot_path`, and `gc.github.triage_dir` as the context index.
 If any required key is missing, hard-fail and report that the snapshot handoff

--- a/gascity/assets/workflows/github-issue-triage-base/snapshot.md
+++ b/gascity/assets/workflows/github-issue-triage-base/snapshot.md
@@ -26,7 +26,7 @@ Then create or refresh the canonical GitHub source bead using this v0 contract:
 - Source beads are non-runnable index/cache beads. Do not route the source bead,
   assign it, depend on it, or use it as a readiness gate.
 - Lookup uses object identity only:
-  `bd list --metadata-field gc.kind=github_source --metadata-field gc.github.kind=issue --metadata-field gc.github.repo=<owner>/<repo> --metadata-field gc.github.number=<number> --status open,in_progress,closed --limit 1 --json`.
+  `gc bd list --metadata-field gc.kind=github_source --metadata-field gc.github.kind=issue --metadata-field gc.github.repo=<owner>/<repo> --metadata-field gc.github.number=<number> --status open,in_progress,closed --limit 1 --json`.
 - Write `source-metadata.json` with flat string metadata:
   `gc.kind=github_source`, `gc.github.kind=issue`,
   `gc.github.repo=<owner>/<repo>`, `gc.github.number=<number>`,
@@ -37,20 +37,20 @@ Then create or refresh the canonical GitHub source bead using this v0 contract:
   `gc.github.snapshot_path=<absolute source.json path>`,
   `gc.github.updated_at=<updated_at>`.
 - If no bead exists, create it with
-  `bd create "GitHub issue source: <owner>/<repo>#<number>" --type task --labels gc.github-source,gc.github-issue --external-ref <canonical_url> --metadata @source-metadata.json`.
+  `gc bd create "GitHub issue source: <owner>/<repo>#<number>" --type task --labels gc.github-source,gc.github-issue --external-ref <canonical_url> --metadata @source-metadata.json`.
 - If a bead exists, refresh it with
-  `bd update <source-bead-id> --external-ref <canonical_url> --metadata @source-metadata.json`.
+  `gc bd update <source-bead-id> --external-ref <canonical_url> --metadata @source-metadata.json`.
 
 Then stamp workflow root metadata as the context handoff index for downstream
 steps. Do not write a separate triage context file; bead metadata is the small
 stable index, and artifact files hold large payloads.
 
-- Read the current step bead with `bd show <current-step-bead-id> --json` and
+- Read the current step bead with `gc bd show <current-step-bead-id> --json` and
   take `gc.root_bead_id`; hard-fail if it is missing.
 - Resolve the current triage directory with
   `{{pack_root}}/assets/scripts/artifacts.py path --override "{{artifact_root}}" --relative "/github/issues/<owner>/<repo>/<number>/triage/<body-hash>/" --directory --mkdir-parents`.
 - Update the workflow root metadata with:
-  `bd update <root-bead-id> --set-metadata gc.github.source_bead_id=<source-bead-id> --set-metadata gc.github.kind=issue --set-metadata gc.github.repo=<owner>/<repo> --set-metadata gc.github.number=<number> --set-metadata gc.github.url=<canonical_url> --set-metadata gc.github.body_hash=<body_hash> --set-metadata gc.github.snapshot_path=<absolute source.json path> --set-metadata gc.github.triage_dir=<absolute triage directory> --set-metadata gc.github.artifact_root=<absolute artifact root> --set-metadata gc.github.post_mode={{post_mode}} --set-metadata gc.github.reused_current_output=false`.
+  `gc bd update <root-bead-id> --set-metadata gc.github.source_bead_id=<source-bead-id> --set-metadata gc.github.kind=issue --set-metadata gc.github.repo=<owner>/<repo> --set-metadata gc.github.number=<number> --set-metadata gc.github.url=<canonical_url> --set-metadata gc.github.body_hash=<body_hash> --set-metadata gc.github.snapshot_path=<absolute source.json path> --set-metadata gc.github.triage_dir=<absolute triage directory> --set-metadata gc.github.artifact_root=<absolute artifact root> --set-metadata gc.github.post_mode={{post_mode}} --set-metadata gc.github.reused_current_output=false`.
 
 Do not use title, label, assignee, or state changes to invalidate triage; only
 `gc.github.body_hash` controls body-hash-keyed triage reuse.

--- a/gascity/assets/workflows/github-issue-triage-base/write-triage-report.md
+++ b/gascity/assets/workflows/github-issue-triage-base/write-triage-report.md
@@ -5,7 +5,7 @@ work in this step.
 Load context from bead metadata before investigating:
 
 - Read the current step bead metadata, get `gc.root_bead_id`, then read
-  workflow root metadata with `bd show <root-bead-id> --json`.
+  workflow root metadata with `gc bd show <root-bead-id> --json`.
 - Required workflow root metadata keys are `gc.github.source_bead_id`,
   `gc.github.repo`, `gc.github.number`, `gc.github.body_hash`,
   `gc.github.snapshot_path`, and `gc.github.triage_dir`.
@@ -59,4 +59,4 @@ verdict by the validator. Reproduction work may write logs, repro scripts, and
 patch evidence under the triage artifact directory only.
 
 After validation, update the workflow root metadata with the report result:
-`bd update <root-bead-id> --set-metadata gc.github.triage_report_path=<absolute triage-report.md path> --set-metadata gc.github.triage_verdict=<verdict> --set-metadata gc.github.triage_priority=<priority> --set-metadata gc.github.triage_recommended_next_action=<recommended_next_action>`.
+`gc bd update <root-bead-id> --set-metadata gc.github.triage_report_path=<absolute triage-report.md path> --set-metadata gc.github.triage_verdict=<verdict> --set-metadata gc.github.triage_priority=<priority> --set-metadata gc.github.triage_recommended_next_action=<recommended_next_action>`.

--- a/gascity/assets/workflows/github-pr-review/render-comment.md
+++ b/gascity/assets/workflows/github-pr-review/render-comment.md
@@ -1,5 +1,5 @@
 
-Read workflow root metadata from `bd show <root-bead-id> --json`. Validate the
+Read workflow root metadata from `gc bd show <root-bead-id> --json`. Validate the
 generic review verdict report at `gc.github.review_report_path` and map it with
 `{{pack_root}}/assets/scripts/github_reports.py review-outcome`:
 `pass/none -> approve`, `fail/minor -> comment`, `fail/major -> request_changes`,

--- a/gascity/assets/workflows/github-pr-review/reuse-current-head.md
+++ b/gascity/assets/workflows/github-pr-review/reuse-current-head.md
@@ -1,6 +1,6 @@
 
 Read the current step bead metadata, get `gc.root_bead_id`, then read workflow
-root metadata with `bd show <root-bead-id> --json`. Use `gc.github.repo`,
+root metadata with `gc bd show <root-bead-id> --json`. Use `gc.github.repo`,
 `gc.github.number`, `gc.github.head_sha`, `gc.github.snapshot_path`, and
 `gc.github.review_dir` as the context index. If any required key is missing,
 hard-fail and report that the snapshot handoff metadata is incomplete.

--- a/gascity/assets/workflows/github-pr-review/run-review.md
+++ b/gascity/assets/workflows/github-pr-review/run-review.md
@@ -1,6 +1,6 @@
 
 Read the current step bead metadata, get `gc.root_bead_id`, then read workflow
-root metadata with `bd show <root-bead-id> --json`. Required workflow root
+root metadata with `gc bd show <root-bead-id> --json`. Required workflow root
 metadata keys are `gc.github.source_bead_id`, `gc.github.repo`,
 `gc.github.number`, `gc.github.url`, `gc.github.head_sha`,
 `gc.github.snapshot_path`, and `gc.github.review_dir`.
@@ -48,7 +48,7 @@ If the selected formula does not declare the mode vars, omit the two mode
 Do not close this step until `REPORT_PATH` exists and validates through
 `{{pack_root}}/assets/scripts/github_reports.py review-outcome "$REPORT_PATH"`.
 Persist the review handoff and result on workflow root metadata:
-`bd update <root-bead-id> --set-metadata gc.github.review_subject_path="$SUBJECT_PATH" --set-metadata gc.github.review_report_path="$REPORT_PATH" --set-metadata gc.github.review_outcome=<approve|comment|request_changes|block>`.
+`gc bd update <root-bead-id> --set-metadata gc.github.review_subject_path="$SUBJECT_PATH" --set-metadata gc.github.review_report_path="$REPORT_PATH" --set-metadata gc.github.review_outcome=<approve|comment|request_changes|block>`.
 
 The adapter does not check out a mutation worktree, push commits, amend
 contributor branches, submit formal GitHub review events, or create follow-up

--- a/gascity/assets/workflows/github-pr-review/snapshot.md
+++ b/gascity/assets/workflows/github-pr-review/snapshot.md
@@ -49,7 +49,7 @@ Then create or refresh the canonical GitHub source bead using this v0 contract:
 - Source beads are non-runnable index/cache beads. Do not route the source bead,
   assign it, depend on it, or use it as a readiness gate.
 - Lookup uses object identity only:
-  `bd list --metadata-field gc.kind=github_source --metadata-field gc.github.kind=pull --metadata-field gc.github.repo=<owner>/<repo> --metadata-field gc.github.number=<number> --status open,in_progress,closed --limit 1 --json`.
+  `gc bd list --metadata-field gc.kind=github_source --metadata-field gc.github.kind=pull --metadata-field gc.github.repo=<owner>/<repo> --metadata-field gc.github.number=<number> --status open,in_progress,closed --limit 1 --json`.
 - Write `source-metadata.json` with flat string metadata:
   `gc.kind=github_source`, `gc.github.kind=pull`,
   `gc.github.repo=<owner>/<repo>`, `gc.github.number=<number>`,
@@ -62,19 +62,19 @@ Then create or refresh the canonical GitHub source bead using this v0 contract:
   `gc.github.snapshot_path=<absolute source.json path>`,
   `gc.github.updated_at=<updated_at>`.
 - If no bead exists, create it with
-  `bd create "GitHub PR source: <owner>/<repo>#<number>" --type task --labels gc.github-source,gc.github-pr --external-ref <canonical_url> --metadata @source-metadata.json`.
+  `gc bd create "GitHub PR source: <owner>/<repo>#<number>" --type task --labels gc.github-source,gc.github-pr --external-ref <canonical_url> --metadata @source-metadata.json`.
 - If a bead exists, refresh it with
-  `bd update <source-bead-id> --external-ref <canonical_url> --metadata @source-metadata.json`.
+  `gc bd update <source-bead-id> --external-ref <canonical_url> --metadata @source-metadata.json`.
 
 Then stamp workflow root metadata as the context handoff index for downstream
 steps. Do not write a separate PR-review context file; bead metadata is the
 small stable index, and artifact files hold large payloads.
 
-- Read the current step bead with `bd show <current-step-bead-id> --json` and
+- Read the current step bead with `gc bd show <current-step-bead-id> --json` and
   take `gc.root_bead_id`; hard-fail if it is missing.
 - Resolve the current head-SHA review directory with
   `{{pack_root}}/assets/scripts/artifacts.py path --override "{{artifact_root}}" --relative "/github/pulls/<owner>/<repo>/<number>/reviews/<head-sha>/" --mkdir-parents --directory`.
 - Update the workflow root metadata with:
-  `bd update <root-bead-id> --set-metadata gc.github.source_bead_id=<source-bead-id> --set-metadata gc.github.kind=pull --set-metadata gc.github.repo=<owner>/<repo> --set-metadata gc.github.number=<number> --set-metadata gc.github.url=<canonical_url> --set-metadata gc.github.head_sha=<head_sha> --set-metadata gc.github.snapshot_path=<absolute source.json path> --set-metadata gc.github.review_dir=<absolute review directory> --set-metadata gc.github.artifact_root=<absolute artifact root> --set-metadata gc.github.context_path={{context_path}} --set-metadata gc.github.post_mode={{post_mode}} --set-metadata gc.github.reused_current_output=false`.
+  `gc bd update <root-bead-id> --set-metadata gc.github.source_bead_id=<source-bead-id> --set-metadata gc.github.kind=pull --set-metadata gc.github.repo=<owner>/<repo> --set-metadata gc.github.number=<number> --set-metadata gc.github.url=<canonical_url> --set-metadata gc.github.head_sha=<head_sha> --set-metadata gc.github.snapshot_path=<absolute source.json path> --set-metadata gc.github.review_dir=<absolute review directory> --set-metadata gc.github.artifact_root=<absolute artifact root> --set-metadata gc.github.context_path={{context_path}} --set-metadata gc.github.post_mode={{post_mode}} --set-metadata gc.github.reused_current_output=false`.
 
 Only `gc.github.head_sha` controls head-SHA-keyed PR review reuse.

--- a/gascity/assets/workflows/implement/prepare.md
+++ b/gascity/assets/workflows/implement/prepare.md
@@ -8,15 +8,15 @@ Requirements:
 - identify the current claimed step bead from `CLAIMED_BEAD_ID` in the startup
   claim output, or `$GC_BEAD_ID` if the claim output did not expose one;
   hard-fail if neither value is present
-- read the claimed step JSON with `bd show "$CLAIMED_BEAD_ID" --json`, then
+- read the claimed step JSON with `gc bd show "$CLAIMED_BEAD_ID" --json`, then
   read the current workflow root id from `metadata["gc.root_bead_id"]`
-- read the current workflow root JSON with `bd show "$ROOT_ID" --json`
+- read the current workflow root JSON with `gc bd show "$ROOT_ID" --json`
 - resolve the implementation input convoy from the current workflow root
   metadata key `gc.input_convoy_id`
 - verify the resolved input convoy id matches rendered runtime convoy
   `{{convoy_id}}`
 - validate that input bead is a convoy or normalized singleton convoy with
-  `bd show "<gc.input_convoy_id>" --json` before treating it as implementation
+  `gc bd show "<gc.input_convoy_id>" --json` before treating it as implementation
   work
 - do not search repo, plan, report, artifact, session-log, or runtime files for
   convoy ids; stale files are not graph context

--- a/gascity/assets/workflows/implementation-base/implement.md
+++ b/gascity/assets/workflows/implementation-base/implement.md
@@ -8,7 +8,7 @@ Default fallback behavior must still enforce the worktree contract: resolve the
 source anchor from workflow metadata, read `work_dir` from that source anchor,
 and `cd "$WORKTREE"` before source reads, edits, tests, hashes, or commits.
 `gc.work_dir` is the launcher rig root, not the implementation worktree. When
-reading beads with `bd show --json`, handle both an object and a one-element
+reading beads with `gc bd show --json`, handle both an object and a one-element
 list before reading metadata.
 
 Write the per-item implementation summary as a `gc.build.implementation-summary.v1`

--- a/gascity/assets/workflows/implementation-item-base/implement-item.md
+++ b/gascity/assets/workflows/implementation-item-base/implement-item.md
@@ -9,7 +9,7 @@ Default fallback behavior must still enforce the worktree contract: resolve the
 source anchor from workflow metadata, read the authoritative worktree from the
 source anchor, and `cd "$WORKTREE"` before source reads, edits, tests, hashes,
 or commits. `gc.work_dir` is the launcher rig root, not the implementation
-worktree. When reading beads with `bd show --json`, handle both an object and a
+worktree. When reading beads with `gc bd show --json`, handle both an object and a
 one-element list before reading metadata.
 
 Write the per-item implementation summary as a `gc.build.implementation-summary.v1`

--- a/gascity/roles/agents/design-author/prompt.template.md
+++ b/gascity/roles/agents/design-author/prompt.template.md
@@ -194,7 +194,8 @@ verdict is `iterate`, `changes_required`, or similar.
 
 If later terminal commands do not inherit shell variables, use the explicit
 `CLAIMED_BEAD_ID`, `CLAIMED_ROOT_BEAD_ID`, and
-`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `gc bd update` or `gc bd close` with an empty id.
+`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run
+`gc bd update` or `gc bd close` with an empty id.
 
 When updating or closing a bead, pass exactly one explicit claimed bead id.
 Quote every metadata assignment and close reason. Do not put freeform prose or

--- a/gascity/roles/agents/design-author/prompt.template.md
+++ b/gascity/roles/agents/design-author/prompt.template.md
@@ -6,14 +6,14 @@ You are `{{ .AgentName }}`, a Gas City `graph.v2` role worker for template
 ## Core Rule
 
 You work only the routed bead assigned to this live session. Do not use
-`bd mol current` to infer workflow position. Do not assume a parent bead or
+`gc bd mol current` to infer workflow position. Do not assume a parent bead or
 root bead describes your work. The workflow graph advances through explicit
 ready beads, and you execute the ready bead claimed by this session.
 
 ## Startup Claim Protocol
 
 `gc hook --claim --json` is the only permitted discovery source for routed
-workflow work. Do not run broad `bd ready`, `bd list`, root-bead searches,
+workflow work. Do not run broad `gc bd ready`, `gc bd list`, root-bead searches,
 metadata searches, mail inspection, session-log inspection, or repository
 context gathering to find a bead. Never work a bead id unless it came from the
 immediately preceding `gc hook --claim --json` result in this claim block.
@@ -108,7 +108,7 @@ while true; do
   fi
 
   SHOW_ERR="$(mktemp)"
-  if ! SHOW_JSON="$(bd show "$WORK_ID" --json 2>"$SHOW_ERR")"; then
+  if ! SHOW_JSON="$(gc bd show "$WORK_ID" --json 2>"$SHOW_ERR")"; then
     SHOW_ERR_TEXT="$(sed -n '1p' "$SHOW_ERR")"
     rm -f "$SHOW_ERR"
     if [ -n "$SHOW_ERR_TEXT" ]; then
@@ -166,7 +166,7 @@ export GC_CONTINUATION_GROUP="$CLAIM_GROUP"
 printf 'CLAIMED_BEAD_ID=%s\n' "$WORK_ID"
 printf 'CLAIMED_ROOT_BEAD_ID=%s\n' "$CLAIM_ROOT"
 printf 'CLAIMED_CONTINUATION_GROUP=%s\n' "$CLAIM_GROUP"
-bd show "$GC_BEAD_ID"
+gc bd show "$GC_BEAD_ID"
 GC_CLAIM
 ```
 
@@ -177,14 +177,14 @@ Close it with the requested `gc.outcome` metadata. If the bead does not specify
 a failure contract, mark an unrecoverable failure with `gc.outcome=fail` and a
 concise `gc.failure_class`/reason before closing it.
 
-Never use a bare `bd close` for a bead that asks for close metadata. First set
+Never use `gc bd close` for a bead that asks for close metadata. First set
 the requested metadata on the claimed bead, then close the same bead id:
 
 ```bash
-bd update "$GC_BEAD_ID" \
+gc bd update "$GC_BEAD_ID" \
   --set-metadata 'gc.outcome=pass' \
   --set-metadata 'example.key=example-value'
-bd close "$GC_BEAD_ID"
+gc bd close "$GC_BEAD_ID"
 ```
 
 Finding review issues, missing tests, or required follow-up is usually the
@@ -194,13 +194,12 @@ verdict is `iterate`, `changes_required`, or similar.
 
 If later terminal commands do not inherit shell variables, use the explicit
 `CLAIMED_BEAD_ID`, `CLAIMED_ROOT_BEAD_ID`, and
-`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `bd
-update` or `bd close` with an empty id.
+`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `gc bd update` or `gc bd close` with an empty id.
 
 When updating or closing a bead, pass exactly one explicit claimed bead id.
 Quote every metadata assignment and close reason. Do not put freeform prose or
 bare words after the bead id; `bd` treats every extra positional argument as
-another issue id and may fuzzy-match unrelated beads. Use `bd close
+another issue id and may fuzzy-match unrelated beads. Use `gc bd close
 "$CLAIMED_BEAD_ID" --reason '...'` for close notes.
 
 ## Continuation Group Protocol

--- a/gascity/roles/agents/design-implementation-reviewer/prompt.template.md
+++ b/gascity/roles/agents/design-implementation-reviewer/prompt.template.md
@@ -194,7 +194,8 @@ verdict is `iterate`, `changes_required`, or similar.
 
 If later terminal commands do not inherit shell variables, use the explicit
 `CLAIMED_BEAD_ID`, `CLAIMED_ROOT_BEAD_ID`, and
-`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `gc bd update` or `gc bd close` with an empty id.
+`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run
+`gc bd update` or `gc bd close` with an empty id.
 
 When updating or closing a bead, pass exactly one explicit claimed bead id.
 Quote every metadata assignment and close reason. Do not put freeform prose or

--- a/gascity/roles/agents/design-implementation-reviewer/prompt.template.md
+++ b/gascity/roles/agents/design-implementation-reviewer/prompt.template.md
@@ -6,14 +6,14 @@ You are `{{ .AgentName }}`, a Gas City `graph.v2` role worker for template
 ## Core Rule
 
 You work only the routed bead assigned to this live session. Do not use
-`bd mol current` to infer workflow position. Do not assume a parent bead or
+`gc bd mol current` to infer workflow position. Do not assume a parent bead or
 root bead describes your work. The workflow graph advances through explicit
 ready beads, and you execute the ready bead claimed by this session.
 
 ## Startup Claim Protocol
 
 `gc hook --claim --json` is the only permitted discovery source for routed
-workflow work. Do not run broad `bd ready`, `bd list`, root-bead searches,
+workflow work. Do not run broad `gc bd ready`, `gc bd list`, root-bead searches,
 metadata searches, mail inspection, session-log inspection, or repository
 context gathering to find a bead. Never work a bead id unless it came from the
 immediately preceding `gc hook --claim --json` result in this claim block.
@@ -108,7 +108,7 @@ while true; do
   fi
 
   SHOW_ERR="$(mktemp)"
-  if ! SHOW_JSON="$(bd show "$WORK_ID" --json 2>"$SHOW_ERR")"; then
+  if ! SHOW_JSON="$(gc bd show "$WORK_ID" --json 2>"$SHOW_ERR")"; then
     SHOW_ERR_TEXT="$(sed -n '1p' "$SHOW_ERR")"
     rm -f "$SHOW_ERR"
     if [ -n "$SHOW_ERR_TEXT" ]; then
@@ -166,7 +166,7 @@ export GC_CONTINUATION_GROUP="$CLAIM_GROUP"
 printf 'CLAIMED_BEAD_ID=%s\n' "$WORK_ID"
 printf 'CLAIMED_ROOT_BEAD_ID=%s\n' "$CLAIM_ROOT"
 printf 'CLAIMED_CONTINUATION_GROUP=%s\n' "$CLAIM_GROUP"
-bd show "$GC_BEAD_ID"
+gc bd show "$GC_BEAD_ID"
 GC_CLAIM
 ```
 
@@ -177,14 +177,14 @@ Close it with the requested `gc.outcome` metadata. If the bead does not specify
 a failure contract, mark an unrecoverable failure with `gc.outcome=fail` and a
 concise `gc.failure_class`/reason before closing it.
 
-Never use a bare `bd close` for a bead that asks for close metadata. First set
+Never use `gc bd close` for a bead that asks for close metadata. First set
 the requested metadata on the claimed bead, then close the same bead id:
 
 ```bash
-bd update "$GC_BEAD_ID" \
+gc bd update "$GC_BEAD_ID" \
   --set-metadata 'gc.outcome=pass' \
   --set-metadata 'example.key=example-value'
-bd close "$GC_BEAD_ID"
+gc bd close "$GC_BEAD_ID"
 ```
 
 Finding review issues, missing tests, or required follow-up is usually the
@@ -194,13 +194,12 @@ verdict is `iterate`, `changes_required`, or similar.
 
 If later terminal commands do not inherit shell variables, use the explicit
 `CLAIMED_BEAD_ID`, `CLAIMED_ROOT_BEAD_ID`, and
-`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `bd
-update` or `bd close` with an empty id.
+`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `gc bd update` or `gc bd close` with an empty id.
 
 When updating or closing a bead, pass exactly one explicit claimed bead id.
 Quote every metadata assignment and close reason. Do not put freeform prose or
 bare words after the bead id; `bd` treats every extra positional argument as
-another issue id and may fuzzy-match unrelated beads. Use `bd close
+another issue id and may fuzzy-match unrelated beads. Use `gc bd close
 "$CLAIMED_BEAD_ID" --reason '...'` for close notes.
 
 ## Continuation Group Protocol

--- a/gascity/roles/agents/design-test-risk-reviewer/prompt.template.md
+++ b/gascity/roles/agents/design-test-risk-reviewer/prompt.template.md
@@ -194,7 +194,8 @@ verdict is `iterate`, `changes_required`, or similar.
 
 If later terminal commands do not inherit shell variables, use the explicit
 `CLAIMED_BEAD_ID`, `CLAIMED_ROOT_BEAD_ID`, and
-`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `gc bd update` or `gc bd close` with an empty id.
+`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run
+`gc bd update` or `gc bd close` with an empty id.
 
 When updating or closing a bead, pass exactly one explicit claimed bead id.
 Quote every metadata assignment and close reason. Do not put freeform prose or

--- a/gascity/roles/agents/design-test-risk-reviewer/prompt.template.md
+++ b/gascity/roles/agents/design-test-risk-reviewer/prompt.template.md
@@ -6,14 +6,14 @@ You are `{{ .AgentName }}`, a Gas City `graph.v2` role worker for template
 ## Core Rule
 
 You work only the routed bead assigned to this live session. Do not use
-`bd mol current` to infer workflow position. Do not assume a parent bead or
+`gc bd mol current` to infer workflow position. Do not assume a parent bead or
 root bead describes your work. The workflow graph advances through explicit
 ready beads, and you execute the ready bead claimed by this session.
 
 ## Startup Claim Protocol
 
 `gc hook --claim --json` is the only permitted discovery source for routed
-workflow work. Do not run broad `bd ready`, `bd list`, root-bead searches,
+workflow work. Do not run broad `gc bd ready`, `gc bd list`, root-bead searches,
 metadata searches, mail inspection, session-log inspection, or repository
 context gathering to find a bead. Never work a bead id unless it came from the
 immediately preceding `gc hook --claim --json` result in this claim block.
@@ -108,7 +108,7 @@ while true; do
   fi
 
   SHOW_ERR="$(mktemp)"
-  if ! SHOW_JSON="$(bd show "$WORK_ID" --json 2>"$SHOW_ERR")"; then
+  if ! SHOW_JSON="$(gc bd show "$WORK_ID" --json 2>"$SHOW_ERR")"; then
     SHOW_ERR_TEXT="$(sed -n '1p' "$SHOW_ERR")"
     rm -f "$SHOW_ERR"
     if [ -n "$SHOW_ERR_TEXT" ]; then
@@ -166,7 +166,7 @@ export GC_CONTINUATION_GROUP="$CLAIM_GROUP"
 printf 'CLAIMED_BEAD_ID=%s\n' "$WORK_ID"
 printf 'CLAIMED_ROOT_BEAD_ID=%s\n' "$CLAIM_ROOT"
 printf 'CLAIMED_CONTINUATION_GROUP=%s\n' "$CLAIM_GROUP"
-bd show "$GC_BEAD_ID"
+gc bd show "$GC_BEAD_ID"
 GC_CLAIM
 ```
 
@@ -177,14 +177,14 @@ Close it with the requested `gc.outcome` metadata. If the bead does not specify
 a failure contract, mark an unrecoverable failure with `gc.outcome=fail` and a
 concise `gc.failure_class`/reason before closing it.
 
-Never use a bare `bd close` for a bead that asks for close metadata. First set
+Never use `gc bd close` for a bead that asks for close metadata. First set
 the requested metadata on the claimed bead, then close the same bead id:
 
 ```bash
-bd update "$GC_BEAD_ID" \
+gc bd update "$GC_BEAD_ID" \
   --set-metadata 'gc.outcome=pass' \
   --set-metadata 'example.key=example-value'
-bd close "$GC_BEAD_ID"
+gc bd close "$GC_BEAD_ID"
 ```
 
 Finding review issues, missing tests, or required follow-up is usually the
@@ -194,13 +194,12 @@ verdict is `iterate`, `changes_required`, or similar.
 
 If later terminal commands do not inherit shell variables, use the explicit
 `CLAIMED_BEAD_ID`, `CLAIMED_ROOT_BEAD_ID`, and
-`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `bd
-update` or `bd close` with an empty id.
+`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `gc bd update` or `gc bd close` with an empty id.
 
 When updating or closing a bead, pass exactly one explicit claimed bead id.
 Quote every metadata assignment and close reason. Do not put freeform prose or
 bare words after the bead id; `bd` treats every extra positional argument as
-another issue id and may fuzzy-match unrelated beads. Use `bd close
+another issue id and may fuzzy-match unrelated beads. Use `gc bd close
 "$CLAIMED_BEAD_ID" --reason '...'` for close notes.
 
 ## Continuation Group Protocol

--- a/gascity/roles/agents/gap-analyst/prompt.template.md
+++ b/gascity/roles/agents/gap-analyst/prompt.template.md
@@ -194,7 +194,8 @@ verdict is `iterate`, `changes_required`, or similar.
 
 If later terminal commands do not inherit shell variables, use the explicit
 `CLAIMED_BEAD_ID`, `CLAIMED_ROOT_BEAD_ID`, and
-`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `gc bd update` or `gc bd close` with an empty id.
+`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run
+`gc bd update` or `gc bd close` with an empty id.
 
 When updating or closing a bead, pass exactly one explicit claimed bead id.
 Quote every metadata assignment and close reason. Do not put freeform prose or

--- a/gascity/roles/agents/gap-analyst/prompt.template.md
+++ b/gascity/roles/agents/gap-analyst/prompt.template.md
@@ -6,14 +6,14 @@ You are `{{ .AgentName }}`, a Gas City `graph.v2` role worker for template
 ## Core Rule
 
 You work only the routed bead assigned to this live session. Do not use
-`bd mol current` to infer workflow position. Do not assume a parent bead or
+`gc bd mol current` to infer workflow position. Do not assume a parent bead or
 root bead describes your work. The workflow graph advances through explicit
 ready beads, and you execute the ready bead claimed by this session.
 
 ## Startup Claim Protocol
 
 `gc hook --claim --json` is the only permitted discovery source for routed
-workflow work. Do not run broad `bd ready`, `bd list`, root-bead searches,
+workflow work. Do not run broad `gc bd ready`, `gc bd list`, root-bead searches,
 metadata searches, mail inspection, session-log inspection, or repository
 context gathering to find a bead. Never work a bead id unless it came from the
 immediately preceding `gc hook --claim --json` result in this claim block.
@@ -108,7 +108,7 @@ while true; do
   fi
 
   SHOW_ERR="$(mktemp)"
-  if ! SHOW_JSON="$(bd show "$WORK_ID" --json 2>"$SHOW_ERR")"; then
+  if ! SHOW_JSON="$(gc bd show "$WORK_ID" --json 2>"$SHOW_ERR")"; then
     SHOW_ERR_TEXT="$(sed -n '1p' "$SHOW_ERR")"
     rm -f "$SHOW_ERR"
     if [ -n "$SHOW_ERR_TEXT" ]; then
@@ -166,7 +166,7 @@ export GC_CONTINUATION_GROUP="$CLAIM_GROUP"
 printf 'CLAIMED_BEAD_ID=%s\n' "$WORK_ID"
 printf 'CLAIMED_ROOT_BEAD_ID=%s\n' "$CLAIM_ROOT"
 printf 'CLAIMED_CONTINUATION_GROUP=%s\n' "$CLAIM_GROUP"
-bd show "$GC_BEAD_ID"
+gc bd show "$GC_BEAD_ID"
 GC_CLAIM
 ```
 
@@ -177,14 +177,14 @@ Close it with the requested `gc.outcome` metadata. If the bead does not specify
 a failure contract, mark an unrecoverable failure with `gc.outcome=fail` and a
 concise `gc.failure_class`/reason before closing it.
 
-Never use a bare `bd close` for a bead that asks for close metadata. First set
+Never use `gc bd close` for a bead that asks for close metadata. First set
 the requested metadata on the claimed bead, then close the same bead id:
 
 ```bash
-bd update "$GC_BEAD_ID" \
+gc bd update "$GC_BEAD_ID" \
   --set-metadata 'gc.outcome=pass' \
   --set-metadata 'example.key=example-value'
-bd close "$GC_BEAD_ID"
+gc bd close "$GC_BEAD_ID"
 ```
 
 Finding review issues, missing tests, or required follow-up is usually the
@@ -194,13 +194,12 @@ verdict is `iterate`, `changes_required`, or similar.
 
 If later terminal commands do not inherit shell variables, use the explicit
 `CLAIMED_BEAD_ID`, `CLAIMED_ROOT_BEAD_ID`, and
-`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `bd
-update` or `bd close` with an empty id.
+`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `gc bd update` or `gc bd close` with an empty id.
 
 When updating or closing a bead, pass exactly one explicit claimed bead id.
 Quote every metadata assignment and close reason. Do not put freeform prose or
 bare words after the bead id; `bd` treats every extra positional argument as
-another issue id and may fuzzy-match unrelated beads. Use `bd close
+another issue id and may fuzzy-match unrelated beads. Use `gc bd close
 "$CLAIMED_BEAD_ID" --reason '...'` for close notes.
 
 ## Continuation Group Protocol

--- a/gascity/roles/agents/implementation-reviewer/prompt.template.md
+++ b/gascity/roles/agents/implementation-reviewer/prompt.template.md
@@ -194,7 +194,8 @@ verdict is `iterate`, `changes_required`, or similar.
 
 If later terminal commands do not inherit shell variables, use the explicit
 `CLAIMED_BEAD_ID`, `CLAIMED_ROOT_BEAD_ID`, and
-`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `gc bd update` or `gc bd close` with an empty id.
+`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run
+`gc bd update` or `gc bd close` with an empty id.
 
 When updating or closing a bead, pass exactly one explicit claimed bead id.
 Quote every metadata assignment and close reason. Do not put freeform prose or

--- a/gascity/roles/agents/implementation-reviewer/prompt.template.md
+++ b/gascity/roles/agents/implementation-reviewer/prompt.template.md
@@ -6,14 +6,14 @@ You are `{{ .AgentName }}`, a Gas City `graph.v2` role worker for template
 ## Core Rule
 
 You work only the routed bead assigned to this live session. Do not use
-`bd mol current` to infer workflow position. Do not assume a parent bead or
+`gc bd mol current` to infer workflow position. Do not assume a parent bead or
 root bead describes your work. The workflow graph advances through explicit
 ready beads, and you execute the ready bead claimed by this session.
 
 ## Startup Claim Protocol
 
 `gc hook --claim --json` is the only permitted discovery source for routed
-workflow work. Do not run broad `bd ready`, `bd list`, root-bead searches,
+workflow work. Do not run broad `gc bd ready`, `gc bd list`, root-bead searches,
 metadata searches, mail inspection, session-log inspection, or repository
 context gathering to find a bead. Never work a bead id unless it came from the
 immediately preceding `gc hook --claim --json` result in this claim block.
@@ -108,7 +108,7 @@ while true; do
   fi
 
   SHOW_ERR="$(mktemp)"
-  if ! SHOW_JSON="$(bd show "$WORK_ID" --json 2>"$SHOW_ERR")"; then
+  if ! SHOW_JSON="$(gc bd show "$WORK_ID" --json 2>"$SHOW_ERR")"; then
     SHOW_ERR_TEXT="$(sed -n '1p' "$SHOW_ERR")"
     rm -f "$SHOW_ERR"
     if [ -n "$SHOW_ERR_TEXT" ]; then
@@ -166,7 +166,7 @@ export GC_CONTINUATION_GROUP="$CLAIM_GROUP"
 printf 'CLAIMED_BEAD_ID=%s\n' "$WORK_ID"
 printf 'CLAIMED_ROOT_BEAD_ID=%s\n' "$CLAIM_ROOT"
 printf 'CLAIMED_CONTINUATION_GROUP=%s\n' "$CLAIM_GROUP"
-bd show "$GC_BEAD_ID"
+gc bd show "$GC_BEAD_ID"
 GC_CLAIM
 ```
 
@@ -177,14 +177,14 @@ Close it with the requested `gc.outcome` metadata. If the bead does not specify
 a failure contract, mark an unrecoverable failure with `gc.outcome=fail` and a
 concise `gc.failure_class`/reason before closing it.
 
-Never use a bare `bd close` for a bead that asks for close metadata. First set
+Never use `gc bd close` for a bead that asks for close metadata. First set
 the requested metadata on the claimed bead, then close the same bead id:
 
 ```bash
-bd update "$GC_BEAD_ID" \
+gc bd update "$GC_BEAD_ID" \
   --set-metadata 'gc.outcome=pass' \
   --set-metadata 'example.key=example-value'
-bd close "$GC_BEAD_ID"
+gc bd close "$GC_BEAD_ID"
 ```
 
 Finding review issues, missing tests, or required follow-up is usually the
@@ -194,13 +194,12 @@ verdict is `iterate`, `changes_required`, or similar.
 
 If later terminal commands do not inherit shell variables, use the explicit
 `CLAIMED_BEAD_ID`, `CLAIMED_ROOT_BEAD_ID`, and
-`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `bd
-update` or `bd close` with an empty id.
+`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `gc bd update` or `gc bd close` with an empty id.
 
 When updating or closing a bead, pass exactly one explicit claimed bead id.
 Quote every metadata assignment and close reason. Do not put freeform prose or
 bare words after the bead id; `bd` treats every extra positional argument as
-another issue id and may fuzzy-match unrelated beads. Use `bd close
+another issue id and may fuzzy-match unrelated beads. Use `gc bd close
 "$CLAIMED_BEAD_ID" --reason '...'` for close notes.
 
 ## Continuation Group Protocol

--- a/gascity/roles/agents/implementation-worker/prompt.template.md
+++ b/gascity/roles/agents/implementation-worker/prompt.template.md
@@ -194,7 +194,8 @@ verdict is `iterate`, `changes_required`, or similar.
 
 If later terminal commands do not inherit shell variables, use the explicit
 `CLAIMED_BEAD_ID`, `CLAIMED_ROOT_BEAD_ID`, and
-`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `gc bd update` or `gc bd close` with an empty id.
+`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run
+`gc bd update` or `gc bd close` with an empty id.
 
 When updating or closing a bead, pass exactly one explicit claimed bead id.
 Quote every metadata assignment and close reason. Do not put freeform prose or

--- a/gascity/roles/agents/implementation-worker/prompt.template.md
+++ b/gascity/roles/agents/implementation-worker/prompt.template.md
@@ -6,14 +6,14 @@ You are `{{ .AgentName }}`, a Gas City `graph.v2` role worker for template
 ## Core Rule
 
 You work only the routed bead assigned to this live session. Do not use
-`bd mol current` to infer workflow position. Do not assume a parent bead or
+`gc bd mol current` to infer workflow position. Do not assume a parent bead or
 root bead describes your work. The workflow graph advances through explicit
 ready beads, and you execute the ready bead claimed by this session.
 
 ## Startup Claim Protocol
 
 `gc hook --claim --json` is the only permitted discovery source for routed
-workflow work. Do not run broad `bd ready`, `bd list`, root-bead searches,
+workflow work. Do not run broad `gc bd ready`, `gc bd list`, root-bead searches,
 metadata searches, mail inspection, session-log inspection, or repository
 context gathering to find a bead. Never work a bead id unless it came from the
 immediately preceding `gc hook --claim --json` result in this claim block.
@@ -108,7 +108,7 @@ while true; do
   fi
 
   SHOW_ERR="$(mktemp)"
-  if ! SHOW_JSON="$(bd show "$WORK_ID" --json 2>"$SHOW_ERR")"; then
+  if ! SHOW_JSON="$(gc bd show "$WORK_ID" --json 2>"$SHOW_ERR")"; then
     SHOW_ERR_TEXT="$(sed -n '1p' "$SHOW_ERR")"
     rm -f "$SHOW_ERR"
     if [ -n "$SHOW_ERR_TEXT" ]; then
@@ -166,7 +166,7 @@ export GC_CONTINUATION_GROUP="$CLAIM_GROUP"
 printf 'CLAIMED_BEAD_ID=%s\n' "$WORK_ID"
 printf 'CLAIMED_ROOT_BEAD_ID=%s\n' "$CLAIM_ROOT"
 printf 'CLAIMED_CONTINUATION_GROUP=%s\n' "$CLAIM_GROUP"
-bd show "$GC_BEAD_ID"
+gc bd show "$GC_BEAD_ID"
 GC_CLAIM
 ```
 
@@ -177,14 +177,14 @@ Close it with the requested `gc.outcome` metadata. If the bead does not specify
 a failure contract, mark an unrecoverable failure with `gc.outcome=fail` and a
 concise `gc.failure_class`/reason before closing it.
 
-Never use a bare `bd close` for a bead that asks for close metadata. First set
+Never use `gc bd close` for a bead that asks for close metadata. First set
 the requested metadata on the claimed bead, then close the same bead id:
 
 ```bash
-bd update "$GC_BEAD_ID" \
+gc bd update "$GC_BEAD_ID" \
   --set-metadata 'gc.outcome=pass' \
   --set-metadata 'example.key=example-value'
-bd close "$GC_BEAD_ID"
+gc bd close "$GC_BEAD_ID"
 ```
 
 Finding review issues, missing tests, or required follow-up is usually the
@@ -194,13 +194,12 @@ verdict is `iterate`, `changes_required`, or similar.
 
 If later terminal commands do not inherit shell variables, use the explicit
 `CLAIMED_BEAD_ID`, `CLAIMED_ROOT_BEAD_ID`, and
-`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `bd
-update` or `bd close` with an empty id.
+`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `gc bd update` or `gc bd close` with an empty id.
 
 When updating or closing a bead, pass exactly one explicit claimed bead id.
 Quote every metadata assignment and close reason. Do not put freeform prose or
 bare words after the bead id; `bd` treats every extra positional argument as
-another issue id and may fuzzy-match unrelated beads. Use `bd close
+another issue id and may fuzzy-match unrelated beads. Use `gc bd close
 "$CLAIMED_BEAD_ID" --reason '...'` for close notes.
 
 ## Continuation Group Protocol

--- a/gascity/roles/agents/issue-triager/prompt.template.md
+++ b/gascity/roles/agents/issue-triager/prompt.template.md
@@ -194,7 +194,8 @@ verdict is `iterate`, `changes_required`, or similar.
 
 If later terminal commands do not inherit shell variables, use the explicit
 `CLAIMED_BEAD_ID`, `CLAIMED_ROOT_BEAD_ID`, and
-`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `gc bd update` or `gc bd close` with an empty id.
+`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run
+`gc bd update` or `gc bd close` with an empty id.
 
 When updating or closing a bead, pass exactly one explicit claimed bead id.
 Quote every metadata assignment and close reason. Do not put freeform prose or

--- a/gascity/roles/agents/issue-triager/prompt.template.md
+++ b/gascity/roles/agents/issue-triager/prompt.template.md
@@ -6,14 +6,14 @@ You are `{{ .AgentName }}`, a Gas City `graph.v2` role worker for template
 ## Core Rule
 
 You work only the routed bead assigned to this live session. Do not use
-`bd mol current` to infer workflow position. Do not assume a parent bead or
+`gc bd mol current` to infer workflow position. Do not assume a parent bead or
 root bead describes your work. The workflow graph advances through explicit
 ready beads, and you execute the ready bead claimed by this session.
 
 ## Startup Claim Protocol
 
 `gc hook --claim --json` is the only permitted discovery source for routed
-workflow work. Do not run broad `bd ready`, `bd list`, root-bead searches,
+workflow work. Do not run broad `gc bd ready`, `gc bd list`, root-bead searches,
 metadata searches, mail inspection, session-log inspection, or repository
 context gathering to find a bead. Never work a bead id unless it came from the
 immediately preceding `gc hook --claim --json` result in this claim block.
@@ -108,7 +108,7 @@ while true; do
   fi
 
   SHOW_ERR="$(mktemp)"
-  if ! SHOW_JSON="$(bd show "$WORK_ID" --json 2>"$SHOW_ERR")"; then
+  if ! SHOW_JSON="$(gc bd show "$WORK_ID" --json 2>"$SHOW_ERR")"; then
     SHOW_ERR_TEXT="$(sed -n '1p' "$SHOW_ERR")"
     rm -f "$SHOW_ERR"
     if [ -n "$SHOW_ERR_TEXT" ]; then
@@ -166,7 +166,7 @@ export GC_CONTINUATION_GROUP="$CLAIM_GROUP"
 printf 'CLAIMED_BEAD_ID=%s\n' "$WORK_ID"
 printf 'CLAIMED_ROOT_BEAD_ID=%s\n' "$CLAIM_ROOT"
 printf 'CLAIMED_CONTINUATION_GROUP=%s\n' "$CLAIM_GROUP"
-bd show "$GC_BEAD_ID"
+gc bd show "$GC_BEAD_ID"
 GC_CLAIM
 ```
 
@@ -177,14 +177,14 @@ Close it with the requested `gc.outcome` metadata. If the bead does not specify
 a failure contract, mark an unrecoverable failure with `gc.outcome=fail` and a
 concise `gc.failure_class`/reason before closing it.
 
-Never use a bare `bd close` for a bead that asks for close metadata. First set
+Never use `gc bd close` for a bead that asks for close metadata. First set
 the requested metadata on the claimed bead, then close the same bead id:
 
 ```bash
-bd update "$GC_BEAD_ID" \
+gc bd update "$GC_BEAD_ID" \
   --set-metadata 'gc.outcome=pass' \
   --set-metadata 'example.key=example-value'
-bd close "$GC_BEAD_ID"
+gc bd close "$GC_BEAD_ID"
 ```
 
 Finding review issues, missing tests, or required follow-up is usually the
@@ -194,13 +194,12 @@ verdict is `iterate`, `changes_required`, or similar.
 
 If later terminal commands do not inherit shell variables, use the explicit
 `CLAIMED_BEAD_ID`, `CLAIMED_ROOT_BEAD_ID`, and
-`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `bd
-update` or `bd close` with an empty id.
+`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `gc bd update` or `gc bd close` with an empty id.
 
 When updating or closing a bead, pass exactly one explicit claimed bead id.
 Quote every metadata assignment and close reason. Do not put freeform prose or
 bare words after the bead id; `bd` treats every extra positional argument as
-another issue id and may fuzzy-match unrelated beads. Use `bd close
+another issue id and may fuzzy-match unrelated beads. Use `gc bd close
 "$CLAIMED_BEAD_ID" --reason '...'` for close notes.
 
 ## Continuation Group Protocol

--- a/gascity/roles/agents/publisher/prompt.template.md
+++ b/gascity/roles/agents/publisher/prompt.template.md
@@ -194,7 +194,8 @@ verdict is `iterate`, `changes_required`, or similar.
 
 If later terminal commands do not inherit shell variables, use the explicit
 `CLAIMED_BEAD_ID`, `CLAIMED_ROOT_BEAD_ID`, and
-`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `gc bd update` or `gc bd close` with an empty id.
+`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run
+`gc bd update` or `gc bd close` with an empty id.
 
 When updating or closing a bead, pass exactly one explicit claimed bead id.
 Quote every metadata assignment and close reason. Do not put freeform prose or

--- a/gascity/roles/agents/publisher/prompt.template.md
+++ b/gascity/roles/agents/publisher/prompt.template.md
@@ -6,14 +6,14 @@ You are `{{ .AgentName }}`, a Gas City `graph.v2` role worker for template
 ## Core Rule
 
 You work only the routed bead assigned to this live session. Do not use
-`bd mol current` to infer workflow position. Do not assume a parent bead or
+`gc bd mol current` to infer workflow position. Do not assume a parent bead or
 root bead describes your work. The workflow graph advances through explicit
 ready beads, and you execute the ready bead claimed by this session.
 
 ## Startup Claim Protocol
 
 `gc hook --claim --json` is the only permitted discovery source for routed
-workflow work. Do not run broad `bd ready`, `bd list`, root-bead searches,
+workflow work. Do not run broad `gc bd ready`, `gc bd list`, root-bead searches,
 metadata searches, mail inspection, session-log inspection, or repository
 context gathering to find a bead. Never work a bead id unless it came from the
 immediately preceding `gc hook --claim --json` result in this claim block.
@@ -108,7 +108,7 @@ while true; do
   fi
 
   SHOW_ERR="$(mktemp)"
-  if ! SHOW_JSON="$(bd show "$WORK_ID" --json 2>"$SHOW_ERR")"; then
+  if ! SHOW_JSON="$(gc bd show "$WORK_ID" --json 2>"$SHOW_ERR")"; then
     SHOW_ERR_TEXT="$(sed -n '1p' "$SHOW_ERR")"
     rm -f "$SHOW_ERR"
     if [ -n "$SHOW_ERR_TEXT" ]; then
@@ -166,7 +166,7 @@ export GC_CONTINUATION_GROUP="$CLAIM_GROUP"
 printf 'CLAIMED_BEAD_ID=%s\n' "$WORK_ID"
 printf 'CLAIMED_ROOT_BEAD_ID=%s\n' "$CLAIM_ROOT"
 printf 'CLAIMED_CONTINUATION_GROUP=%s\n' "$CLAIM_GROUP"
-bd show "$GC_BEAD_ID"
+gc bd show "$GC_BEAD_ID"
 GC_CLAIM
 ```
 
@@ -177,14 +177,14 @@ Close it with the requested `gc.outcome` metadata. If the bead does not specify
 a failure contract, mark an unrecoverable failure with `gc.outcome=fail` and a
 concise `gc.failure_class`/reason before closing it.
 
-Never use a bare `bd close` for a bead that asks for close metadata. First set
+Never use `gc bd close` for a bead that asks for close metadata. First set
 the requested metadata on the claimed bead, then close the same bead id:
 
 ```bash
-bd update "$GC_BEAD_ID" \
+gc bd update "$GC_BEAD_ID" \
   --set-metadata 'gc.outcome=pass' \
   --set-metadata 'example.key=example-value'
-bd close "$GC_BEAD_ID"
+gc bd close "$GC_BEAD_ID"
 ```
 
 Finding review issues, missing tests, or required follow-up is usually the
@@ -194,13 +194,12 @@ verdict is `iterate`, `changes_required`, or similar.
 
 If later terminal commands do not inherit shell variables, use the explicit
 `CLAIMED_BEAD_ID`, `CLAIMED_ROOT_BEAD_ID`, and
-`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `bd
-update` or `bd close` with an empty id.
+`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `gc bd update` or `gc bd close` with an empty id.
 
 When updating or closing a bead, pass exactly one explicit claimed bead id.
 Quote every metadata assignment and close reason. Do not put freeform prose or
 bare words after the bead id; `bd` treats every extra positional argument as
-another issue id and may fuzzy-match unrelated beads. Use `bd close
+another issue id and may fuzzy-match unrelated beads. Use `gc bd close
 "$CLAIMED_BEAD_ID" --reason '...'` for close notes.
 
 ## Continuation Group Protocol

--- a/gascity/roles/agents/requirements-planner/prompt.template.md
+++ b/gascity/roles/agents/requirements-planner/prompt.template.md
@@ -194,7 +194,8 @@ verdict is `iterate`, `changes_required`, or similar.
 
 If later terminal commands do not inherit shell variables, use the explicit
 `CLAIMED_BEAD_ID`, `CLAIMED_ROOT_BEAD_ID`, and
-`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `gc bd update` or `gc bd close` with an empty id.
+`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run
+`gc bd update` or `gc bd close` with an empty id.
 
 When updating or closing a bead, pass exactly one explicit claimed bead id.
 Quote every metadata assignment and close reason. Do not put freeform prose or

--- a/gascity/roles/agents/requirements-planner/prompt.template.md
+++ b/gascity/roles/agents/requirements-planner/prompt.template.md
@@ -6,14 +6,14 @@ You are `{{ .AgentName }}`, a Gas City `graph.v2` role worker for template
 ## Core Rule
 
 You work only the routed bead assigned to this live session. Do not use
-`bd mol current` to infer workflow position. Do not assume a parent bead or
+`gc bd mol current` to infer workflow position. Do not assume a parent bead or
 root bead describes your work. The workflow graph advances through explicit
 ready beads, and you execute the ready bead claimed by this session.
 
 ## Startup Claim Protocol
 
 `gc hook --claim --json` is the only permitted discovery source for routed
-workflow work. Do not run broad `bd ready`, `bd list`, root-bead searches,
+workflow work. Do not run broad `gc bd ready`, `gc bd list`, root-bead searches,
 metadata searches, mail inspection, session-log inspection, or repository
 context gathering to find a bead. Never work a bead id unless it came from the
 immediately preceding `gc hook --claim --json` result in this claim block.
@@ -108,7 +108,7 @@ while true; do
   fi
 
   SHOW_ERR="$(mktemp)"
-  if ! SHOW_JSON="$(bd show "$WORK_ID" --json 2>"$SHOW_ERR")"; then
+  if ! SHOW_JSON="$(gc bd show "$WORK_ID" --json 2>"$SHOW_ERR")"; then
     SHOW_ERR_TEXT="$(sed -n '1p' "$SHOW_ERR")"
     rm -f "$SHOW_ERR"
     if [ -n "$SHOW_ERR_TEXT" ]; then
@@ -166,7 +166,7 @@ export GC_CONTINUATION_GROUP="$CLAIM_GROUP"
 printf 'CLAIMED_BEAD_ID=%s\n' "$WORK_ID"
 printf 'CLAIMED_ROOT_BEAD_ID=%s\n' "$CLAIM_ROOT"
 printf 'CLAIMED_CONTINUATION_GROUP=%s\n' "$CLAIM_GROUP"
-bd show "$GC_BEAD_ID"
+gc bd show "$GC_BEAD_ID"
 GC_CLAIM
 ```
 
@@ -177,14 +177,14 @@ Close it with the requested `gc.outcome` metadata. If the bead does not specify
 a failure contract, mark an unrecoverable failure with `gc.outcome=fail` and a
 concise `gc.failure_class`/reason before closing it.
 
-Never use a bare `bd close` for a bead that asks for close metadata. First set
+Never use `gc bd close` for a bead that asks for close metadata. First set
 the requested metadata on the claimed bead, then close the same bead id:
 
 ```bash
-bd update "$GC_BEAD_ID" \
+gc bd update "$GC_BEAD_ID" \
   --set-metadata 'gc.outcome=pass' \
   --set-metadata 'example.key=example-value'
-bd close "$GC_BEAD_ID"
+gc bd close "$GC_BEAD_ID"
 ```
 
 Finding review issues, missing tests, or required follow-up is usually the
@@ -194,13 +194,12 @@ verdict is `iterate`, `changes_required`, or similar.
 
 If later terminal commands do not inherit shell variables, use the explicit
 `CLAIMED_BEAD_ID`, `CLAIMED_ROOT_BEAD_ID`, and
-`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `bd
-update` or `bd close` with an empty id.
+`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `gc bd update` or `gc bd close` with an empty id.
 
 When updating or closing a bead, pass exactly one explicit claimed bead id.
 Quote every metadata assignment and close reason. Do not put freeform prose or
 bare words after the bead id; `bd` treats every extra positional argument as
-another issue id and may fuzzy-match unrelated beads. Use `bd close
+another issue id and may fuzzy-match unrelated beads. Use `gc bd close
 "$CLAIMED_BEAD_ID" --reason '...'` for close notes.
 
 ## Continuation Group Protocol

--- a/gascity/roles/agents/review-synthesizer/prompt.template.md
+++ b/gascity/roles/agents/review-synthesizer/prompt.template.md
@@ -194,7 +194,8 @@ verdict is `iterate`, `changes_required`, or similar.
 
 If later terminal commands do not inherit shell variables, use the explicit
 `CLAIMED_BEAD_ID`, `CLAIMED_ROOT_BEAD_ID`, and
-`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `gc bd update` or `gc bd close` with an empty id.
+`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run
+`gc bd update` or `gc bd close` with an empty id.
 
 When updating or closing a bead, pass exactly one explicit claimed bead id.
 Quote every metadata assignment and close reason. Do not put freeform prose or

--- a/gascity/roles/agents/review-synthesizer/prompt.template.md
+++ b/gascity/roles/agents/review-synthesizer/prompt.template.md
@@ -6,14 +6,14 @@ You are `{{ .AgentName }}`, a Gas City `graph.v2` role worker for template
 ## Core Rule
 
 You work only the routed bead assigned to this live session. Do not use
-`bd mol current` to infer workflow position. Do not assume a parent bead or
+`gc bd mol current` to infer workflow position. Do not assume a parent bead or
 root bead describes your work. The workflow graph advances through explicit
 ready beads, and you execute the ready bead claimed by this session.
 
 ## Startup Claim Protocol
 
 `gc hook --claim --json` is the only permitted discovery source for routed
-workflow work. Do not run broad `bd ready`, `bd list`, root-bead searches,
+workflow work. Do not run broad `gc bd ready`, `gc bd list`, root-bead searches,
 metadata searches, mail inspection, session-log inspection, or repository
 context gathering to find a bead. Never work a bead id unless it came from the
 immediately preceding `gc hook --claim --json` result in this claim block.
@@ -108,7 +108,7 @@ while true; do
   fi
 
   SHOW_ERR="$(mktemp)"
-  if ! SHOW_JSON="$(bd show "$WORK_ID" --json 2>"$SHOW_ERR")"; then
+  if ! SHOW_JSON="$(gc bd show "$WORK_ID" --json 2>"$SHOW_ERR")"; then
     SHOW_ERR_TEXT="$(sed -n '1p' "$SHOW_ERR")"
     rm -f "$SHOW_ERR"
     if [ -n "$SHOW_ERR_TEXT" ]; then
@@ -166,7 +166,7 @@ export GC_CONTINUATION_GROUP="$CLAIM_GROUP"
 printf 'CLAIMED_BEAD_ID=%s\n' "$WORK_ID"
 printf 'CLAIMED_ROOT_BEAD_ID=%s\n' "$CLAIM_ROOT"
 printf 'CLAIMED_CONTINUATION_GROUP=%s\n' "$CLAIM_GROUP"
-bd show "$GC_BEAD_ID"
+gc bd show "$GC_BEAD_ID"
 GC_CLAIM
 ```
 
@@ -177,14 +177,14 @@ Close it with the requested `gc.outcome` metadata. If the bead does not specify
 a failure contract, mark an unrecoverable failure with `gc.outcome=fail` and a
 concise `gc.failure_class`/reason before closing it.
 
-Never use a bare `bd close` for a bead that asks for close metadata. First set
+Never use `gc bd close` for a bead that asks for close metadata. First set
 the requested metadata on the claimed bead, then close the same bead id:
 
 ```bash
-bd update "$GC_BEAD_ID" \
+gc bd update "$GC_BEAD_ID" \
   --set-metadata 'gc.outcome=pass' \
   --set-metadata 'example.key=example-value'
-bd close "$GC_BEAD_ID"
+gc bd close "$GC_BEAD_ID"
 ```
 
 Finding review issues, missing tests, or required follow-up is usually the
@@ -194,13 +194,12 @@ verdict is `iterate`, `changes_required`, or similar.
 
 If later terminal commands do not inherit shell variables, use the explicit
 `CLAIMED_BEAD_ID`, `CLAIMED_ROOT_BEAD_ID`, and
-`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `bd
-update` or `bd close` with an empty id.
+`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `gc bd update` or `gc bd close` with an empty id.
 
 When updating or closing a bead, pass exactly one explicit claimed bead id.
 Quote every metadata assignment and close reason. Do not put freeform prose or
 bare words after the bead id; `bd` treats every extra positional argument as
-another issue id and may fuzzy-match unrelated beads. Use `bd close
+another issue id and may fuzzy-match unrelated beads. Use `gc bd close
 "$CLAIMED_BEAD_ID" --reason '...'` for close notes.
 
 ## Continuation Group Protocol

--- a/gascity/roles/agents/run-operator/prompt.template.md
+++ b/gascity/roles/agents/run-operator/prompt.template.md
@@ -194,7 +194,8 @@ verdict is `iterate`, `changes_required`, or similar.
 
 If later terminal commands do not inherit shell variables, use the explicit
 `CLAIMED_BEAD_ID`, `CLAIMED_ROOT_BEAD_ID`, and
-`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `gc bd update` or `gc bd close` with an empty id.
+`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run
+`gc bd update` or `gc bd close` with an empty id.
 
 When updating or closing a bead, pass exactly one explicit claimed bead id.
 Quote every metadata assignment and close reason. Do not put freeform prose or

--- a/gascity/roles/agents/run-operator/prompt.template.md
+++ b/gascity/roles/agents/run-operator/prompt.template.md
@@ -6,14 +6,14 @@ You are `{{ .AgentName }}`, a Gas City `graph.v2` role worker for template
 ## Core Rule
 
 You work only the routed bead assigned to this live session. Do not use
-`bd mol current` to infer workflow position. Do not assume a parent bead or
+`gc bd mol current` to infer workflow position. Do not assume a parent bead or
 root bead describes your work. The workflow graph advances through explicit
 ready beads, and you execute the ready bead claimed by this session.
 
 ## Startup Claim Protocol
 
 `gc hook --claim --json` is the only permitted discovery source for routed
-workflow work. Do not run broad `bd ready`, `bd list`, root-bead searches,
+workflow work. Do not run broad `gc bd ready`, `gc bd list`, root-bead searches,
 metadata searches, mail inspection, session-log inspection, or repository
 context gathering to find a bead. Never work a bead id unless it came from the
 immediately preceding `gc hook --claim --json` result in this claim block.
@@ -108,7 +108,7 @@ while true; do
   fi
 
   SHOW_ERR="$(mktemp)"
-  if ! SHOW_JSON="$(bd show "$WORK_ID" --json 2>"$SHOW_ERR")"; then
+  if ! SHOW_JSON="$(gc bd show "$WORK_ID" --json 2>"$SHOW_ERR")"; then
     SHOW_ERR_TEXT="$(sed -n '1p' "$SHOW_ERR")"
     rm -f "$SHOW_ERR"
     if [ -n "$SHOW_ERR_TEXT" ]; then
@@ -166,7 +166,7 @@ export GC_CONTINUATION_GROUP="$CLAIM_GROUP"
 printf 'CLAIMED_BEAD_ID=%s\n' "$WORK_ID"
 printf 'CLAIMED_ROOT_BEAD_ID=%s\n' "$CLAIM_ROOT"
 printf 'CLAIMED_CONTINUATION_GROUP=%s\n' "$CLAIM_GROUP"
-bd show "$GC_BEAD_ID"
+gc bd show "$GC_BEAD_ID"
 GC_CLAIM
 ```
 
@@ -177,14 +177,14 @@ Close it with the requested `gc.outcome` metadata. If the bead does not specify
 a failure contract, mark an unrecoverable failure with `gc.outcome=fail` and a
 concise `gc.failure_class`/reason before closing it.
 
-Never use a bare `bd close` for a bead that asks for close metadata. First set
+Never use `gc bd close` for a bead that asks for close metadata. First set
 the requested metadata on the claimed bead, then close the same bead id:
 
 ```bash
-bd update "$GC_BEAD_ID" \
+gc bd update "$GC_BEAD_ID" \
   --set-metadata 'gc.outcome=pass' \
   --set-metadata 'example.key=example-value'
-bd close "$GC_BEAD_ID"
+gc bd close "$GC_BEAD_ID"
 ```
 
 Finding review issues, missing tests, or required follow-up is usually the
@@ -194,13 +194,12 @@ verdict is `iterate`, `changes_required`, or similar.
 
 If later terminal commands do not inherit shell variables, use the explicit
 `CLAIMED_BEAD_ID`, `CLAIMED_ROOT_BEAD_ID`, and
-`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `bd
-update` or `bd close` with an empty id.
+`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `gc bd update` or `gc bd close` with an empty id.
 
 When updating or closing a bead, pass exactly one explicit claimed bead id.
 Quote every metadata assignment and close reason. Do not put freeform prose or
 bare words after the bead id; `bd` treats every extra positional argument as
-another issue id and may fuzzy-match unrelated beads. Use `bd close
+another issue id and may fuzzy-match unrelated beads. Use `gc bd close
 "$CLAIMED_BEAD_ID" --reason '...'` for close notes.
 
 ## Continuation Group Protocol

--- a/gascity/roles/agents/task-decomposer/prompt.template.md
+++ b/gascity/roles/agents/task-decomposer/prompt.template.md
@@ -194,7 +194,8 @@ verdict is `iterate`, `changes_required`, or similar.
 
 If later terminal commands do not inherit shell variables, use the explicit
 `CLAIMED_BEAD_ID`, `CLAIMED_ROOT_BEAD_ID`, and
-`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `gc bd update` or `gc bd close` with an empty id.
+`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run
+`gc bd update` or `gc bd close` with an empty id.
 
 When updating or closing a bead, pass exactly one explicit claimed bead id.
 Quote every metadata assignment and close reason. Do not put freeform prose or

--- a/gascity/roles/agents/task-decomposer/prompt.template.md
+++ b/gascity/roles/agents/task-decomposer/prompt.template.md
@@ -6,14 +6,14 @@ You are `{{ .AgentName }}`, a Gas City `graph.v2` role worker for template
 ## Core Rule
 
 You work only the routed bead assigned to this live session. Do not use
-`bd mol current` to infer workflow position. Do not assume a parent bead or
+`gc bd mol current` to infer workflow position. Do not assume a parent bead or
 root bead describes your work. The workflow graph advances through explicit
 ready beads, and you execute the ready bead claimed by this session.
 
 ## Startup Claim Protocol
 
 `gc hook --claim --json` is the only permitted discovery source for routed
-workflow work. Do not run broad `bd ready`, `bd list`, root-bead searches,
+workflow work. Do not run broad `gc bd ready`, `gc bd list`, root-bead searches,
 metadata searches, mail inspection, session-log inspection, or repository
 context gathering to find a bead. Never work a bead id unless it came from the
 immediately preceding `gc hook --claim --json` result in this claim block.
@@ -108,7 +108,7 @@ while true; do
   fi
 
   SHOW_ERR="$(mktemp)"
-  if ! SHOW_JSON="$(bd show "$WORK_ID" --json 2>"$SHOW_ERR")"; then
+  if ! SHOW_JSON="$(gc bd show "$WORK_ID" --json 2>"$SHOW_ERR")"; then
     SHOW_ERR_TEXT="$(sed -n '1p' "$SHOW_ERR")"
     rm -f "$SHOW_ERR"
     if [ -n "$SHOW_ERR_TEXT" ]; then
@@ -166,7 +166,7 @@ export GC_CONTINUATION_GROUP="$CLAIM_GROUP"
 printf 'CLAIMED_BEAD_ID=%s\n' "$WORK_ID"
 printf 'CLAIMED_ROOT_BEAD_ID=%s\n' "$CLAIM_ROOT"
 printf 'CLAIMED_CONTINUATION_GROUP=%s\n' "$CLAIM_GROUP"
-bd show "$GC_BEAD_ID"
+gc bd show "$GC_BEAD_ID"
 GC_CLAIM
 ```
 
@@ -177,14 +177,14 @@ Close it with the requested `gc.outcome` metadata. If the bead does not specify
 a failure contract, mark an unrecoverable failure with `gc.outcome=fail` and a
 concise `gc.failure_class`/reason before closing it.
 
-Never use a bare `bd close` for a bead that asks for close metadata. First set
+Never use `gc bd close` for a bead that asks for close metadata. First set
 the requested metadata on the claimed bead, then close the same bead id:
 
 ```bash
-bd update "$GC_BEAD_ID" \
+gc bd update "$GC_BEAD_ID" \
   --set-metadata 'gc.outcome=pass' \
   --set-metadata 'example.key=example-value'
-bd close "$GC_BEAD_ID"
+gc bd close "$GC_BEAD_ID"
 ```
 
 Finding review issues, missing tests, or required follow-up is usually the
@@ -194,13 +194,12 @@ verdict is `iterate`, `changes_required`, or similar.
 
 If later terminal commands do not inherit shell variables, use the explicit
 `CLAIMED_BEAD_ID`, `CLAIMED_ROOT_BEAD_ID`, and
-`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `bd
-update` or `bd close` with an empty id.
+`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `gc bd update` or `gc bd close` with an empty id.
 
 When updating or closing a bead, pass exactly one explicit claimed bead id.
 Quote every metadata assignment and close reason. Do not put freeform prose or
 bare words after the bead id; `bd` treats every extra positional argument as
-another issue id and may fuzzy-match unrelated beads. Use `bd close
+another issue id and may fuzzy-match unrelated beads. Use `gc bd close
 "$CLAIMED_BEAD_ID" --reason '...'` for close notes.
 
 ## Continuation Group Protocol

--- a/gascity/roles/prompts/shared/gc-role-worker.md.tmpl
+++ b/gascity/roles/prompts/shared/gc-role-worker.md.tmpl
@@ -195,7 +195,8 @@ verdict is `iterate`, `changes_required`, or similar.
 
 If later terminal commands do not inherit shell variables, use the explicit
 `CLAIMED_BEAD_ID`, `CLAIMED_ROOT_BEAD_ID`, and
-`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `gc bd update` or `gc bd close` with an empty id.
+`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run
+`gc bd update` or `gc bd close` with an empty id.
 
 When updating or closing a bead, pass exactly one explicit claimed bead id.
 Quote every metadata assignment and close reason. Do not put freeform prose or

--- a/gascity/roles/prompts/shared/gc-role-worker.md.tmpl
+++ b/gascity/roles/prompts/shared/gc-role-worker.md.tmpl
@@ -7,14 +7,14 @@ You are `{{ .AgentName }}`, a Gas City `graph.v2` role worker for template
 ## Core Rule
 
 You work only the routed bead assigned to this live session. Do not use
-`bd mol current` to infer workflow position. Do not assume a parent bead or
+`gc bd mol current` to infer workflow position. Do not assume a parent bead or
 root bead describes your work. The workflow graph advances through explicit
 ready beads, and you execute the ready bead claimed by this session.
 
 ## Startup Claim Protocol
 
 `gc hook --claim --json` is the only permitted discovery source for routed
-workflow work. Do not run broad `bd ready`, `bd list`, root-bead searches,
+workflow work. Do not run broad `gc bd ready`, `gc bd list`, root-bead searches,
 metadata searches, mail inspection, session-log inspection, or repository
 context gathering to find a bead. Never work a bead id unless it came from the
 immediately preceding `gc hook --claim --json` result in this claim block.
@@ -109,7 +109,7 @@ while true; do
   fi
 
   SHOW_ERR="$(mktemp)"
-  if ! SHOW_JSON="$(bd show "$WORK_ID" --json 2>"$SHOW_ERR")"; then
+  if ! SHOW_JSON="$(gc bd show "$WORK_ID" --json 2>"$SHOW_ERR")"; then
     SHOW_ERR_TEXT="$(sed -n '1p' "$SHOW_ERR")"
     rm -f "$SHOW_ERR"
     if [ -n "$SHOW_ERR_TEXT" ]; then
@@ -167,7 +167,7 @@ export GC_CONTINUATION_GROUP="$CLAIM_GROUP"
 printf 'CLAIMED_BEAD_ID=%s\n' "$WORK_ID"
 printf 'CLAIMED_ROOT_BEAD_ID=%s\n' "$CLAIM_ROOT"
 printf 'CLAIMED_CONTINUATION_GROUP=%s\n' "$CLAIM_GROUP"
-bd show "$GC_BEAD_ID"
+gc bd show "$GC_BEAD_ID"
 GC_CLAIM
 ```
 
@@ -178,14 +178,14 @@ Close it with the requested `gc.outcome` metadata. If the bead does not specify
 a failure contract, mark an unrecoverable failure with `gc.outcome=fail` and a
 concise `gc.failure_class`/reason before closing it.
 
-Never use a bare `bd close` for a bead that asks for close metadata. First set
+Never use `gc bd close` for a bead that asks for close metadata. First set
 the requested metadata on the claimed bead, then close the same bead id:
 
 ```bash
-bd update "$GC_BEAD_ID" \
+gc bd update "$GC_BEAD_ID" \
   --set-metadata 'gc.outcome=pass' \
   --set-metadata 'example.key=example-value'
-bd close "$GC_BEAD_ID"
+gc bd close "$GC_BEAD_ID"
 ```
 
 Finding review issues, missing tests, or required follow-up is usually the
@@ -195,13 +195,12 @@ verdict is `iterate`, `changes_required`, or similar.
 
 If later terminal commands do not inherit shell variables, use the explicit
 `CLAIMED_BEAD_ID`, `CLAIMED_ROOT_BEAD_ID`, and
-`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `bd
-update` or `bd close` with an empty id.
+`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `gc bd update` or `gc bd close` with an empty id.
 
 When updating or closing a bead, pass exactly one explicit claimed bead id.
 Quote every metadata assignment and close reason. Do not put freeform prose or
 bare words after the bead id; `bd` treats every extra positional argument as
-another issue id and may fuzzy-match unrelated beads. Use `bd close
+another issue id and may fuzzy-match unrelated beads. Use `gc bd close
 "$CLAIMED_BEAD_ID" --reason '...'` for close notes.
 
 ## Continuation Group Protocol

--- a/gascity/roles/template-fragments/gc-role-worker.template.md
+++ b/gascity/roles/template-fragments/gc-role-worker.template.md
@@ -195,7 +195,8 @@ verdict is `iterate`, `changes_required`, or similar.
 
 If later terminal commands do not inherit shell variables, use the explicit
 `CLAIMED_BEAD_ID`, `CLAIMED_ROOT_BEAD_ID`, and
-`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `gc bd update` or `gc bd close` with an empty id.
+`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run
+`gc bd update` or `gc bd close` with an empty id.
 
 When updating or closing a bead, pass exactly one explicit claimed bead id.
 Quote every metadata assignment and close reason. Do not put freeform prose or

--- a/gascity/roles/template-fragments/gc-role-worker.template.md
+++ b/gascity/roles/template-fragments/gc-role-worker.template.md
@@ -7,14 +7,14 @@ You are `{{ .AgentName }}`, a Gas City `graph.v2` role worker for template
 ## Core Rule
 
 You work only the routed bead assigned to this live session. Do not use
-`bd mol current` to infer workflow position. Do not assume a parent bead or
+`gc bd mol current` to infer workflow position. Do not assume a parent bead or
 root bead describes your work. The workflow graph advances through explicit
 ready beads, and you execute the ready bead claimed by this session.
 
 ## Startup Claim Protocol
 
 `gc hook --claim --json` is the only permitted discovery source for routed
-workflow work. Do not run broad `bd ready`, `bd list`, root-bead searches,
+workflow work. Do not run broad `gc bd ready`, `gc bd list`, root-bead searches,
 metadata searches, mail inspection, session-log inspection, or repository
 context gathering to find a bead. Never work a bead id unless it came from the
 immediately preceding `gc hook --claim --json` result in this claim block.
@@ -109,7 +109,7 @@ while true; do
   fi
 
   SHOW_ERR="$(mktemp)"
-  if ! SHOW_JSON="$(bd show "$WORK_ID" --json 2>"$SHOW_ERR")"; then
+  if ! SHOW_JSON="$(gc bd show "$WORK_ID" --json 2>"$SHOW_ERR")"; then
     SHOW_ERR_TEXT="$(sed -n '1p' "$SHOW_ERR")"
     rm -f "$SHOW_ERR"
     if [ -n "$SHOW_ERR_TEXT" ]; then
@@ -167,7 +167,7 @@ export GC_CONTINUATION_GROUP="$CLAIM_GROUP"
 printf 'CLAIMED_BEAD_ID=%s\n' "$WORK_ID"
 printf 'CLAIMED_ROOT_BEAD_ID=%s\n' "$CLAIM_ROOT"
 printf 'CLAIMED_CONTINUATION_GROUP=%s\n' "$CLAIM_GROUP"
-bd show "$GC_BEAD_ID"
+gc bd show "$GC_BEAD_ID"
 GC_CLAIM
 ```
 
@@ -178,14 +178,14 @@ Close it with the requested `gc.outcome` metadata. If the bead does not specify
 a failure contract, mark an unrecoverable failure with `gc.outcome=fail` and a
 concise `gc.failure_class`/reason before closing it.
 
-Never use a bare `bd close` for a bead that asks for close metadata. First set
+Never use `gc bd close` for a bead that asks for close metadata. First set
 the requested metadata on the claimed bead, then close the same bead id:
 
 ```bash
-bd update "$GC_BEAD_ID" \
+gc bd update "$GC_BEAD_ID" \
   --set-metadata 'gc.outcome=pass' \
   --set-metadata 'example.key=example-value'
-bd close "$GC_BEAD_ID"
+gc bd close "$GC_BEAD_ID"
 ```
 
 Finding review issues, missing tests, or required follow-up is usually the
@@ -195,13 +195,12 @@ verdict is `iterate`, `changes_required`, or similar.
 
 If later terminal commands do not inherit shell variables, use the explicit
 `CLAIMED_BEAD_ID`, `CLAIMED_ROOT_BEAD_ID`, and
-`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `bd
-update` or `bd close` with an empty id.
+`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `gc bd update` or `gc bd close` with an empty id.
 
 When updating or closing a bead, pass exactly one explicit claimed bead id.
 Quote every metadata assignment and close reason. Do not put freeform prose or
 bare words after the bead id; `bd` treats every extra positional argument as
-another issue id and may fuzzy-match unrelated beads. Use `bd close
+another issue id and may fuzzy-match unrelated beads. Use `gc bd close
 "$CLAIMED_BEAD_ID" --reason '...'` for close notes.
 
 ## Continuation Group Protocol

--- a/gascity/template-fragments/gc-role-worker.template.md
+++ b/gascity/template-fragments/gc-role-worker.template.md
@@ -195,7 +195,8 @@ verdict is `iterate`, `changes_required`, or similar.
 
 If later terminal commands do not inherit shell variables, use the explicit
 `CLAIMED_BEAD_ID`, `CLAIMED_ROOT_BEAD_ID`, and
-`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `gc bd update` or `gc bd close` with an empty id.
+`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run
+`gc bd update` or `gc bd close` with an empty id.
 
 When updating or closing a bead, pass exactly one explicit claimed bead id.
 Quote every metadata assignment and close reason. Do not put freeform prose or

--- a/gascity/template-fragments/gc-role-worker.template.md
+++ b/gascity/template-fragments/gc-role-worker.template.md
@@ -7,14 +7,14 @@ You are `{{ .AgentName }}`, a Gas City `graph.v2` role worker for template
 ## Core Rule
 
 You work only the routed bead assigned to this live session. Do not use
-`bd mol current` to infer workflow position. Do not assume a parent bead or
+`gc bd mol current` to infer workflow position. Do not assume a parent bead or
 root bead describes your work. The workflow graph advances through explicit
 ready beads, and you execute the ready bead claimed by this session.
 
 ## Startup Claim Protocol
 
 `gc hook --claim --json` is the only permitted discovery source for routed
-workflow work. Do not run broad `bd ready`, `bd list`, root-bead searches,
+workflow work. Do not run broad `gc bd ready`, `gc bd list`, root-bead searches,
 metadata searches, mail inspection, session-log inspection, or repository
 context gathering to find a bead. Never work a bead id unless it came from the
 immediately preceding `gc hook --claim --json` result in this claim block.
@@ -109,7 +109,7 @@ while true; do
   fi
 
   SHOW_ERR="$(mktemp)"
-  if ! SHOW_JSON="$(bd show "$WORK_ID" --json 2>"$SHOW_ERR")"; then
+  if ! SHOW_JSON="$(gc bd show "$WORK_ID" --json 2>"$SHOW_ERR")"; then
     SHOW_ERR_TEXT="$(sed -n '1p' "$SHOW_ERR")"
     rm -f "$SHOW_ERR"
     if [ -n "$SHOW_ERR_TEXT" ]; then
@@ -167,7 +167,7 @@ export GC_CONTINUATION_GROUP="$CLAIM_GROUP"
 printf 'CLAIMED_BEAD_ID=%s\n' "$WORK_ID"
 printf 'CLAIMED_ROOT_BEAD_ID=%s\n' "$CLAIM_ROOT"
 printf 'CLAIMED_CONTINUATION_GROUP=%s\n' "$CLAIM_GROUP"
-bd show "$GC_BEAD_ID"
+gc bd show "$GC_BEAD_ID"
 GC_CLAIM
 ```
 
@@ -178,14 +178,14 @@ Close it with the requested `gc.outcome` metadata. If the bead does not specify
 a failure contract, mark an unrecoverable failure with `gc.outcome=fail` and a
 concise `gc.failure_class`/reason before closing it.
 
-Never use a bare `bd close` for a bead that asks for close metadata. First set
+Never use `gc bd close` for a bead that asks for close metadata. First set
 the requested metadata on the claimed bead, then close the same bead id:
 
 ```bash
-bd update "$GC_BEAD_ID" \
+gc bd update "$GC_BEAD_ID" \
   --set-metadata 'gc.outcome=pass' \
   --set-metadata 'example.key=example-value'
-bd close "$GC_BEAD_ID"
+gc bd close "$GC_BEAD_ID"
 ```
 
 Finding review issues, missing tests, or required follow-up is usually the
@@ -195,13 +195,12 @@ verdict is `iterate`, `changes_required`, or similar.
 
 If later terminal commands do not inherit shell variables, use the explicit
 `CLAIMED_BEAD_ID`, `CLAIMED_ROOT_BEAD_ID`, and
-`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `bd
-update` or `bd close` with an empty id.
+`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `gc bd update` or `gc bd close` with an empty id.
 
 When updating or closing a bead, pass exactly one explicit claimed bead id.
 Quote every metadata assignment and close reason. Do not put freeform prose or
 bare words after the bead id; `bd` treats every extra positional argument as
-another issue id and may fuzzy-match unrelated beads. Use `bd close
+another issue id and may fuzzy-match unrelated beads. Use `gc bd close
 "$CLAIMED_BEAD_ID" --reason '...'` for close notes.
 
 ## Continuation Group Protocol

--- a/gascity/tests/test_formula_assets.py
+++ b/gascity/tests/test_formula_assets.py
@@ -715,15 +715,15 @@ class FormulaAssetTests(unittest.TestCase):
             "gc runtime drain-ack",
             "gc.continuation_group",
             "gc.scope_role=teardown",
-            "Never use a bare `bd close` for a bead that asks for close metadata",
-            'bd update "$GC_BEAD_ID"',
+            "Never use `gc bd close` for a bead that asks for close metadata",
+            'gc bd update "$GC_BEAD_ID"',
             "Finding review issues, missing tests, or required follow-up is usually the\nbead's output",
             "check for more routed work before draining",
             "running the same `GC_CLAIM` block again",
         ):
             with self.subTest(fragment=fragment):
                 self.assertIn(fragment, expected)
-        self.assertNotIn("bd update \"$WORK_ID\" --claim --json", expected)
+        self.assertNotIn("gc bd update \"$WORK_ID\" --claim --json", expected)
 
         for agent_name in ROLE_AGENTS:
             prompt = root / "roles" / "agents" / agent_name / "prompt.template.md"
@@ -1049,9 +1049,9 @@ class FormulaAssetTests(unittest.TestCase):
             "Do not inspect pack source directories",
             ".beads/config.yaml",
             "Close commands do not accept metadata flags",
-            "bd update <claimed-step-id> --set-metadata 'gc.outcome=pass'",
-            "bd close <claimed-step-id> --reason",
-            "Do not pass `--set-metadata` or `--metadata` to `bd close`",
+            "gc bd update <claimed-step-id> --set-metadata 'gc.outcome=pass'",
+            "gc bd close <claimed-step-id> --reason",
+            "Do not pass `--set-metadata` or `--metadata` to `gc bd close`",
             "do not use\n`gc.outcome=success`",
         ):
             with self.subTest(asset="build-base/prepare.md", fragment=fragment):
@@ -1391,7 +1391,7 @@ class FormulaAssetTests(unittest.TestCase):
             "gc convoy create <name> <work-item-id...> --json",
             "Do not create an empty convoy",
             "Do not call `gc convoy add` for newly-created beads",
-            "Do not call `bd show <implementation-convoy-id>`",
+            "Do not call `gc bd show <implementation-convoy-id>`",
         ):
             with self.subTest(step="decompose", fragment=fragment):
                 self.assertIn(fragment, decompose_description)
@@ -1448,7 +1448,7 @@ class FormulaAssetTests(unittest.TestCase):
             "code_review.acceptance_verdict=approve",
             "code_review.test_evidence_verdict=approve",
             "code_review.simplicity_verdict=approve",
-            "bd update \"$CLAIMED_BEAD_ID\"",
+            "gc bd update \"$CLAIMED_BEAD_ID\"",
             "source anchor/worktree",
             "launcher rig root may remain unchanged",
             "not to the launcher rig root",
@@ -1633,11 +1633,11 @@ class FormulaAssetTests(unittest.TestCase):
         for relative_path, keys in path_contracts.items():
             text = (root / relative_path).read_text(encoding="utf-8")
             with self.subTest(asset=relative_path, fragment="metadata warning"):
-                self.assertIn("Do not use `bd update --metadata 'key=value'`", text)
+                self.assertIn("Do not use `gc bd update --metadata 'key=value'`", text)
             for fragment in (
-                'bd update "<claimed-step-id>" --set-metadata "gc.outcome=pass"',
-                'bd close "<claimed-step-id>" --reason "<concise reason>"',
-                "Do not pass\n`--metadata` or `--set-metadata` to `bd close`",
+                'gc bd update "<claimed-step-id>" --set-metadata "gc.outcome=pass"',
+                'gc bd close "<claimed-step-id>" --reason "<concise reason>"',
+                "Do not pass\n`--metadata` or `--set-metadata` to `gc bd close`",
             ):
                 with self.subTest(asset=relative_path, fragment=fragment):
                     self.assertIn(fragment, text)
@@ -1645,7 +1645,7 @@ class FormulaAssetTests(unittest.TestCase):
                 line for line in text.splitlines() if "Do not use" not in line
             )
             self.assertIsNone(
-                re.search(r"bd update[^`\n]*--metadata ['\"]?[A-Za-z0-9_.-]+=", positive_guidance),
+                re.search(r"gc bd update[^`\n]*--metadata ['\"]?[A-Za-z0-9_.-]+=", positive_guidance),
                 relative_path,
             )
             for key in keys:
@@ -2583,16 +2583,16 @@ class FormulaAssetTests(unittest.TestCase):
         self.assertIn("re-opens the design loop", design_approval)
         self.assertIn("revision summary", design_approval)
         self.assertIn("specific design sections", design_approval)
-        self.assertIn('bd update "$CLAIMED_BEAD_ID"', design_approval)
-        self.assertIn("Do not pass `--metadata` or `--set-metadata` to `bd close`", design_approval)
+        self.assertIn('gc bd update "$CLAIMED_BEAD_ID"', design_approval)
+        self.assertIn("Do not pass `--metadata` or `--set-metadata` to `gc bd close`", design_approval)
         self.assertIn("stock Superpowers checklist items 6-7", write_spec)
         self.assertIn("Spec self-review", write_spec)
         self.assertIn("stock design-doc state", write_spec)
         self.assertIn("docs/superpowers/specs/", write_spec)
         self.assertIn("On repeated attempts", write_spec)
         self.assertIn("without clobbering loop feedback", write_spec)
-        self.assertIn('bd update "$CLAIMED_BEAD_ID"', write_spec)
-        self.assertIn("Do not pass `--metadata` or `--set-metadata` to `bd close`", write_spec)
+        self.assertIn('gc bd update "$CLAIMED_BEAD_ID"', write_spec)
+        self.assertIn("Do not pass `--metadata` or `--set-metadata` to `gc bd close`", write_spec)
         self.assertIn("written spec", spec_approval)
         self.assertIn("stock `User reviews spec?` approval gate", spec_approval)
         self.assertIn("stock checklist item 8", spec_approval)
@@ -2608,20 +2608,20 @@ class FormulaAssetTests(unittest.TestCase):
         self.assertIn("silence", spec_approval)
         self.assertIn("spec revision summary", spec_approval)
         self.assertIn("Do not run `.gc/scripts/checks/design-review-approved.sh`", spec_approval)
-        self.assertIn("Do not use\n`bd update --metadata`", spec_approval)
+        self.assertIn("Do not use\n`gc bd update --metadata`", spec_approval)
         self.assertIn("--metadata-field gc.step_id=requirements.review-written-spec", spec_approval)
         self.assertIn("--metadata-field gc.step_id=requirements.apply-spec-feedback", spec_approval)
         self.assertIn("--metadata-field gc.scope_role=member", spec_approval)
-        self.assertIn("Do not use `bd list --root`", spec_approval)
-        self.assertIn('bd update "$CLAIMED_BEAD_ID"', spec_approval)
-        self.assertIn('bd show "$CLAIMED_BEAD_ID" --json', spec_approval)
+        self.assertIn("Do not use `gc bd list --root`", spec_approval)
+        self.assertIn('gc bd update "$CLAIMED_BEAD_ID"', spec_approval)
+        self.assertIn('gc bd show "$CLAIMED_BEAD_ID" --json', spec_approval)
         self.assertIn("design_review.approval_mode=autonomous", spec_approval)
         self.assertIn("design_review.output_path=<approval-summary path>", spec_approval)
         self.assertIn('if type == "array" then .[0] else . end', spec_approval)
         self.assertIn('design_review.verdict == "done"', spec_approval)
-        self.assertIn("Do not pass `--metadata` or `--set-metadata` to `bd close`", spec_approval)
-        self.assertIn('bd update "$CLAIMED_BEAD_ID"', apply_spec_feedback)
-        self.assertIn("Do not pass `--metadata` or `--set-metadata` to `bd close`", apply_spec_feedback)
+        self.assertIn("Do not pass `--metadata` or `--set-metadata` to `gc bd close`", spec_approval)
+        self.assertIn('gc bd update "$CLAIMED_BEAD_ID"', apply_spec_feedback)
+        self.assertIn("Do not pass `--metadata` or `--set-metadata` to `gc bd close`", apply_spec_feedback)
         self.assertIn("stock brainstorming terminal state", final_requirements)
         self.assertIn("where Superpowers\nwould invoke `writing-plans`", final_requirements)
         self.assertIn("stock checklist item 9", final_requirements)
@@ -2650,8 +2650,8 @@ class FormulaAssetTests(unittest.TestCase):
         ):
             with self.subTest(fragment=fragment):
                 self.assertIn(fragment, brainstorm_design)
-        self.assertIn('bd update "$CLAIMED_BEAD_ID"', brainstorm_design)
-        self.assertIn("Do not pass `--metadata` or `--set-metadata` to `bd close`", brainstorm_design)
+        self.assertIn('gc bd update "$CLAIMED_BEAD_ID"', brainstorm_design)
+        self.assertIn("Do not pass `--metadata` or `--set-metadata` to `gc bd close`", brainstorm_design)
 
         review_written_spec = (
             pack_root
@@ -2662,8 +2662,8 @@ class FormulaAssetTests(unittest.TestCase):
         ).read_text(encoding="utf-8")
         self.assertIn("stock spec reviewer subagent as a Gas City graph lane", review_written_spec)
         self.assertIn("spec-document-reviewer-prompt.md", review_written_spec)
-        self.assertIn('bd update "$CLAIMED_BEAD_ID"', review_written_spec)
-        self.assertIn("Do not pass `--metadata` or `--set-metadata` to `bd close`", review_written_spec)
+        self.assertIn('gc bd update "$CLAIMED_BEAD_ID"', review_written_spec)
+        self.assertIn("Do not pass `--metadata` or `--set-metadata` to `gc bd close`", review_written_spec)
 
         vendor_skill_root = pack_root / "vendor" / "superpowers" / "skills" / "brainstorming"
         installed_skill_root = pack_root / "skills" / "brainstorming"
@@ -3003,7 +3003,7 @@ class FormulaAssetTests(unittest.TestCase):
             "hard-fail if the selected source anchor id equals the synthetic input convoy id",
             "worktrees/<source-anchor-id>",
             "git worktree add",
-            "bd update <source-anchor-id> --set-metadata work_dir=",
+            "gc bd update <source-anchor-id> --set-metadata work_dir=",
             "Do not edit source files in the launcher checkout",
         ):
             with self.subTest(step="prepare-worktree", fragment=fragment):
@@ -3029,7 +3029,7 @@ class FormulaAssetTests(unittest.TestCase):
         for fragment in (
             "Read `work_dir` from the source anchor",
             "close only `<source-anchor-id>`",
-            "bd show <source-anchor-id> --json",
+            "gc bd show <source-anchor-id> --json",
             "status=closed",
             "gc.outcome=pass",
             "if either check fails",
@@ -3150,9 +3150,9 @@ class FormulaAssetTests(unittest.TestCase):
             "github-pr-review": ("pull", "gc.github.head_sha"),
         }
         required_common = {
-            "bd list --metadata-field gc.kind=github_source",
-            "bd create",
-            "bd update",
+            "gc bd list --metadata-field gc.kind=github_source",
+            "gc bd create",
+            "gc bd update",
             "--external-ref",
             "gc.github.kind",
             "gc.github.repo",
@@ -3251,7 +3251,7 @@ class FormulaAssetTests(unittest.TestCase):
         implementation_plan_normalized = " ".join(implementation_plan.split())
 
         for fragment in (
-            "bd update <root-bead-id>",
+            "gc bd update <root-bead-id>",
             "gc.github.run_dir",
             "gc.github.requirements_path",
             "gc.github.implementation_plan_path",
@@ -3386,8 +3386,8 @@ description = "Override sink that writes the base triage report contract."
             "gc.root_bead_id",
             "gc.github.source_bead_id",
             "gc.github.triage_dir",
-            "bd show <root-bead-id> --json",
-            "bd update <root-bead-id>",
+            "gc bd show <root-bead-id> --json",
+            "gc bd update <root-bead-id>",
             "Read `gc.github.snapshot_path`",
             "Do not write a separate triage context file",
         }
@@ -3591,17 +3591,20 @@ description = "Override sink that writes the base triage report contract."
             show_dir.mkdir()
             for bead, payload in beads_by_id.items():
                 (show_dir / f"{bead}.json").write_text(payload, encoding="utf-8")
-            fake_bd = bin_dir / "bd"
-            fake_bd.write_text(
+            fake_gc = bin_dir / "gc"
+            fake_gc.write_text(
                 "#!/usr/bin/env bash\n"
                 "set -euo pipefail\n"
+                "while [ \"${1:-}\" != \"bd\" ]; do shift; done\n"
+                "shift\n"
                 "case \"$1\" in\n"
+                "  version) exit 0 ;;\n"
                 "  show) cat \"$BD_SHOW_DIR/$2.json\" ;;\n"
                 "  *) exit 2 ;;\n"
                 "esac\n",
                 encoding="utf-8",
             )
-            fake_bd.chmod(0o755)
+            fake_gc.chmod(0o755)
 
             env = {
                 **os.environ,
@@ -3639,11 +3642,14 @@ description = "Override sink that writes the base triage report contract."
             show_path.write_text(show_json, encoding="utf-8")
             parent_show_path.write_text(parent_show_json or show_json, encoding="utf-8")
             list_path.write_text(list_json, encoding="utf-8")
-            fake_bd = bin_dir / "bd"
-            fake_bd.write_text(
+            fake_gc = bin_dir / "gc"
+            fake_gc.write_text(
                 "#!/usr/bin/env bash\n"
                 "set -euo pipefail\n"
+                "while [ \"${1:-}\" != \"bd\" ]; do shift; done\n"
+                "shift\n"
                 "case \"$1\" in\n"
+                "  version) exit 0 ;;\n"
                 "  show)\n"
                 "    if [ \"${2:-}\" = \"root\" ]; then\n"
                 "      cat \"$BD_PARENT_SHOW_JSON\"\n"
@@ -3656,7 +3662,7 @@ description = "Override sink that writes the base triage report contract."
                 "esac\n",
                 encoding="utf-8",
             )
-            fake_bd.chmod(0o755)
+            fake_gc.chmod(0o755)
 
             env = {
                 **os.environ,
@@ -4110,18 +4116,21 @@ description = "Override sink that writes the base triage report contract."
             tmp = pathlib.Path(td)
             bin_dir = tmp / "bin"
             bin_dir.mkdir()
-            fake_bd = bin_dir / "bd"
-            fake_bd.write_text(
+            fake_gc = bin_dir / "gc"
+            fake_gc.write_text(
                 "#!/usr/bin/env bash\n"
                 "set -euo pipefail\n"
+                "while [ \"${1:-}\" != \"bd\" ]; do shift; done\n"
+                "shift\n"
                 "case \"$1\" in\n"
+                "  version) exit 0 ;;\n"
                 "  show) cat \"$BD_SHOW_JSON\" ;;\n"
                 "  list) cat \"$BD_LIST_JSON\" ;;\n"
                 "  *) exit 2 ;;\n"
                 "esac\n",
                 encoding="utf-8",
             )
-            fake_bd.chmod(0o755)
+            fake_gc.chmod(0o755)
 
             show_json = tmp / "show.json"
             list_json = tmp / "list.json"
@@ -4190,18 +4199,21 @@ description = "Override sink that writes the base triage report contract."
             tmp = pathlib.Path(td)
             bin_dir = tmp / "bin"
             bin_dir.mkdir()
-            fake_bd = bin_dir / "bd"
-            fake_bd.write_text(
+            fake_gc = bin_dir / "gc"
+            fake_gc.write_text(
                 "#!/usr/bin/env bash\n"
                 "set -euo pipefail\n"
+                "while [ \"${1:-}\" != \"bd\" ]; do shift; done\n"
+                "shift\n"
                 "case \"$1\" in\n"
+                "  version) exit 0 ;;\n"
                 "  show) cat \"$BD_SHOW_JSON\" ;;\n"
                 "  list) cat \"$BD_LIST_JSON\" ;;\n"
                 "  *) exit 2 ;;\n"
                 "esac\n",
                 encoding="utf-8",
             )
-            fake_bd.chmod(0o755)
+            fake_gc.chmod(0o755)
 
             show_json = tmp / "show.json"
             list_json = tmp / "list.json"
@@ -4283,18 +4295,21 @@ description = "Override sink that writes the base triage report contract."
             tmp = pathlib.Path(td)
             bin_dir = tmp / "bin"
             bin_dir.mkdir()
-            fake_bd = bin_dir / "bd"
-            fake_bd.write_text(
+            fake_gc = bin_dir / "gc"
+            fake_gc.write_text(
                 "#!/usr/bin/env bash\n"
                 "set -euo pipefail\n"
+                "while [ \"${1:-}\" != \"bd\" ]; do shift; done\n"
+                "shift\n"
                 "case \"$1\" in\n"
+                "  version) exit 0 ;;\n"
                 "  show) cat \"$BD_SHOW_JSON\" ;;\n"
                 "  list) cat \"$BD_LIST_JSON\" ;;\n"
                 "  *) exit 2 ;;\n"
                 "esac\n",
                 encoding="utf-8",
             )
-            fake_bd.chmod(0o755)
+            fake_gc.chmod(0o755)
 
             show_json = tmp / "show.json"
             list_json = tmp / "list.json"

--- a/gastown/agents/polecat/prompt.template.md
+++ b/gastown/agents/polecat/prompt.template.md
@@ -11,7 +11,7 @@
 For `mol-polecat-work` implementation assignments, **you MUST NOT close the
 implementation bead.** The Refinery closes it after verifying the merge.
 
-Do not run `bd close`, `gc bd close`, or set `--status=closed` on an
+Do not run `gc bd close`, `gc bd close`, or set `--status=closed` on an
 implementation bead. If code appears already merged, reassign to refinery with
 a note.
 
@@ -141,14 +141,14 @@ Default implementation formula: `mol-polecat-work`
 > **The Universal Propulsion Principle: If your hook/work query finds work, YOU RUN IT.**
 
 `gc hook --claim --json` is the ONLY permitted discovery source for your work.
-Do NOT run broad `bd ready`, `bd list`, root-bead searches, metadata searches,
+Do NOT run broad `gc bd ready`, `gc bd list`, root-bead searches, metadata searches,
 mail inspection, or repository scans to find a bead — those race other polecats
 and surface work that is not yours. Never touch a bead id unless it came from
 the immediately preceding claim in this block.
 
 Your first action is the scripted claim below, run as ONE Bash command. Do not
 read code, list files, show metadata, load skills, or run any other Bash until
-it prints `CLAIMED_BEAD_ID`. The claim flips bd status to `in_progress`
+it prints `CLAIMED_BEAD_ID`. The claim flips gc bd status to `in_progress`
 atomically; without it the pool reconciler can recycle you mid-read and another
 polecat race-claims the same bead. Polecat-vs-polecat races are the #1 source of
 churn — close the window.

--- a/gastown/agents/witness/prompt.template.md
+++ b/gastown/agents/witness/prompt.template.md
@@ -157,7 +157,7 @@ Your patrol wisps are ephemeral molecules on the **town ledger**
 pour them — with `gc bd`, never bare `bd`. Bare `bd` resolves to the rig
 ledger from your CWD and never sees your wisps, so every restart would pour a
 fresh one while the prior wisp leaks. Wisp roots are `issue_type=molecule`;
-never filter `--type=wisp` (not a valid bd type — the query errors and matches
+never filter `--type=wisp` (not a valid gc bd type — the query errors and matches
 nothing).
 
 ```bash
@@ -208,7 +208,7 @@ fi
 # Reconcile queued (open) patrol wisps to exactly one. A prior cycle may have
 # poured a next wisp without burning, or a restart may have raced — keep the
 # first and burn the surplus so wisps never accumulate. Wisp roots are
-# molecules (never --type=wisp, which is not a valid bd type and matches
+# molecules (never --type=wisp, which is not a valid gc bd type and matches
 # nothing).
 OPEN_WISPS=$(gc bd list --assignee="$GC_AGENT" --status=open --type=molecule --limit=0 --json | jq -r '.[].id')
 ASSIGNED_WISP=$(printf '%s\n' $OPEN_WISPS | sed -n '1p')

--- a/gastown/assets/scripts/checks/adopt-pr-review-approved.sh
+++ b/gastown/assets/scripts/checks/adopt-pr-review-approved.sh
@@ -8,8 +8,8 @@
 # Values: "done" (approved) | "iterate" (needs another round)
 #
 # The apply-fixes step sets this after applying synthesis findings:
-#   bd meta set $BEAD_ID review.verdict=done
-#   bd meta set $BEAD_ID review.verdict=iterate
+#   gc bd meta set $BEAD_ID review.verdict=done
+#   gc bd meta set $BEAD_ID review.verdict=iterate
 
 set -euo pipefail
 
@@ -92,7 +92,7 @@ load_verdict() {
     # so the caller can surface bead-store outages instead of spinning.
     while [ "$attempt" -lt 10 ]; do
         current=$(
-            bd list --all --json --limit=0 2>/dev/null |
+            gc bd list --all --json --limit=0 2>/dev/null |
                 json_payload |
                 jq -r --arg ref "$apply_ref" --arg root "$root_id" '
                     [

--- a/gastown/assets/scripts/checks/code-review-approved.sh
+++ b/gastown/assets/scripts/checks/code-review-approved.sh
@@ -83,7 +83,7 @@ load_verdict() {
     # TestReviewCheckScriptsPreferNewestVerdictAcrossRalphStep.
     while [ "$attempt" -lt 10 ]; do
         current=$(
-            bd list --all --json --limit=0 2>/dev/null |
+            gc bd list --all --json --limit=0 2>/dev/null |
                 json_payload |
                 jq -r --arg ref "$apply_ref" --arg root "$root_id" '
                     [

--- a/gastown/assets/scripts/checks/design-review-approved.sh
+++ b/gastown/assets/scripts/checks/design-review-approved.sh
@@ -83,7 +83,7 @@ load_verdict() {
     # TestReviewCheckScriptsPreferNewestVerdictAcrossRalphStep.
     while [ "$attempt" -lt 10 ]; do
         current=$(
-            bd list --all --json --limit=0 2>/dev/null |
+            gc bd list --all --json --limit=0 2>/dev/null |
                 json_payload |
                 jq -r --arg ref "$apply_ref" --arg root "$root_id" '
                     [

--- a/gastown/assets/scripts/polecat-churn-watcher.sh
+++ b/gastown/assets/scripts/polecat-churn-watcher.sh
@@ -52,7 +52,7 @@ if [ -z "${GC_CITY:-}" ] || [ ! -f "$GC_CITY/city.toml" ]; then
 fi
 
 if [ -z "${GC_RIG:-}" ]; then
-  echo "polecat-churn-watcher: GC_RIG must be set (rig name to scope bd list)" >&2
+  echo "polecat-churn-watcher: GC_RIG must be set (rig name to scope gc bd list)" >&2
   exit 2
 fi
 
@@ -88,7 +88,7 @@ printf "%s\n" "$current_pids" > "$STATE_FILE"
 # recorded session identity avoids the old work_dir-substring false positives.
 ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
-open_beads_json=$(gc --rig "$GC_RIG" bd list --status=open --json 2>/dev/null || echo "[]")
+open_beads_json=$(gc bd --rig "$GC_RIG" list --status=open --json 2>/dev/null || echo "[]")
 
 for dead in $disappeared; do
   orphans=$(printf '%s' "$open_beads_json" \

--- a/gastown/formulas/mol-polecat-work.toml
+++ b/gastown/formulas/mol-polecat-work.toml
@@ -17,7 +17,7 @@ merge review.
 The polecat sets `metadata.branch` and `metadata.target` on the work bead
 and reassigns it to the refinery. The refinery merges and closes.
 
-**NEVER CLOSE BEADS.** You must not run `bd close` or set status=closed.
+**NEVER CLOSE BEADS.** You must not run `gc bd close` or set status=closed.
 Even if you believe the code is already merged, reassign to refinery —
 only the refinery verifies merges and closes beads.
 `{{base_branch}}` may come from the work bead's own `metadata.target` or

--- a/gastown/formulas/mol-witness-patrol.toml
+++ b/gastown/formulas/mol-witness-patrol.toml
@@ -529,7 +529,7 @@ Reuse an already-queued wisp instead of pouring a duplicate. A prior cycle
 may have poured a next wisp without burning, or a restart may have raced —
 keep one open patrol wisp and burn any surplus, so wisps never accumulate.
 Wisp roots are `issue_type=molecule` (never `--type=wisp`, which is not a
-valid bd type and matches nothing).
+valid gc bd type and matches nothing).
 ```bash
 OPEN_WISPS=$(gc bd list --assignee="$GC_AGENT" --status=open --type=molecule --limit=0 --json | jq -r '.[].id')
 NEXT=$(printf '%s\n' $OPEN_WISPS | sed -n '1p')

--- a/gastown/template-fragments/propulsion.template.md
+++ b/gastown/template-fragments/propulsion.template.md
@@ -141,7 +141,7 @@ agent. The pool thinks it's full. New work can't be dispatched.
 as your first action. `gc hook --claim --json` is the ONLY permitted discovery
 source — it checks assigned work first (session bead ID, runtime session name,
 then alias), falls through to routed pool work, and performs the atomic claim
-before you inspect the bead. Do NOT run `bd ready`, `bd list`, or any other
+before you inspect the bead. Do NOT run `gc bd ready`, `gc bd list`, or any other
 search to find work; that races other polecats. Work only the bead the claim
 block prints as `CLAIMED_BEAD_ID`.
 

--- a/gastown/tests/test_polecat_churn_watcher.sh
+++ b/gastown/tests/test_polecat_churn_watcher.sh
@@ -14,9 +14,9 @@ write_gc_stub() {
     mkdir -p "$bin"
     cat >"$bin/gc" <<'SH'
 #!/usr/bin/env sh
-# Only `gc --rig <rig> bd list --status=open --json` is exercised here.
+# Only `gc bd --rig <rig> list --status=open --json` is exercised here.
 case "$*" in
-    *"bd list"*"--json"*) cat "$GC_BEADS_JSON" ;;
+    *"bd"*"list"*"--json"*) cat "$GC_BEADS_JSON" ;;
     *) printf '[]' ;;
 esac
 SH

--- a/github/formulas/mol-github-fix-issue.formula.toml
+++ b/github/formulas/mol-github-fix-issue.formula.toml
@@ -65,13 +65,13 @@ issue comment when work begins.
 **1. Prime the session:**
 ```bash
 gc prime
-bd prime
+gc bd prime
 ```
 
 **2. Inspect the bead and source context:**
 ```bash
-bd show {{issue}}
-bd show {{issue}} --json | jq '.metadata'
+gc bd show {{issue}}
+gc bd show {{issue}} --json | jq '.metadata'
 ```
 
 Read the bead notes carefully. They contain:
@@ -81,7 +81,7 @@ Read the bead notes carefully. They contain:
 
 **3. Post the "work started" issue comment exactly once:**
 ```bash
-STARTED=$(bd show {{issue}} --json | jq -r '.metadata.github_fix_started_comment_id // empty')
+STARTED=$(gc bd show {{issue}} --json | jq -r '.metadata.github_fix_started_comment_id // empty')
 if [ -z "$STARTED" ]; then
   BODY=$(mktemp)
   cat >"$BODY" <<EOF
@@ -99,7 +99,7 @@ EOF
   COMMENT_ID=$(printf '%s' "$COMMENT_JSON" | jq -r '.id // empty')
   COMMENT_URL=$(printf '%s' "$COMMENT_JSON" | jq -r '.html_url // empty')
   if [ -n "$COMMENT_ID" ]; then
-    bd update {{issue}} \
+    gc bd update {{issue}} \
       --set-metadata github_fix_started_comment_id="$COMMENT_ID" \
       --set-metadata github_fix_started_comment_url="$COMMENT_URL"
   fi
@@ -124,7 +124,7 @@ git fetch --prune origin
 
 **2. Reuse or create the bead-scoped worktree:**
 ```bash
-WORKTREE=$(bd show {{issue}} --json | jq -r '.metadata.work_dir // empty')
+WORKTREE=$(gc bd show {{issue}} --json | jq -r '.metadata.work_dir // empty')
 if [ -n "$WORKTREE" ] && [ -d "$WORKTREE" ]; then
   cd "$WORKTREE"
 else
@@ -133,13 +133,13 @@ else
   WORKTREE_PATH="$WORKTREE_ROOT/{{issue}}"
   git worktree add "$WORKTREE_PATH" --detach origin/{{github_default_branch}}
   cd "$WORKTREE_PATH"
-  bd update {{issue}} --set-metadata work_dir="$WORKTREE_PATH"
+  gc bd update {{issue}} --set-metadata work_dir="$WORKTREE_PATH"
 fi
 ```
 
 **3. Reuse or create the branch:**
 ```bash
-BRANCH=$(bd show {{issue}} --json | jq -r '.metadata.branch // empty')
+BRANCH=$(gc bd show {{issue}} --json | jq -r '.metadata.branch // empty')
 if [ -n "$BRANCH" ]; then
   git checkout "$BRANCH" 2>/dev/null \
     || git checkout -b "$BRANCH" origin/"$BRANCH" 2>/dev/null \
@@ -147,7 +147,7 @@ if [ -n "$BRANCH" ]; then
 else
   BRANCH="fix-{{github_issue_number}}-{{issue}}"
   git checkout -b "$BRANCH" origin/{{github_default_branch}}
-  bd update {{issue}} --set-metadata branch="$BRANCH"
+  gc bd update {{issue}} --set-metadata branch="$BRANCH"
 fi
 ```
 
@@ -173,7 +173,7 @@ Take a read-first pass so you understand the problem before changing code.
 
 **2. Record the working theory in bead notes:**
 ```bash
-CURRENT_NOTES=$(bd show {{issue}} --json | jq -r '.notes // empty')
+CURRENT_NOTES=$(gc bd show {{issue}} --json | jq -r '.notes // empty')
 NOTES_FILE=$(mktemp)
 cat >"$NOTES_FILE" <<EOF
 $CURRENT_NOTES
@@ -189,7 +189,7 @@ $CURRENT_NOTES
 ### Test plan
 - <the failing test you will write first>
 EOF
-bd update {{issue}} --notes "$(cat "$NOTES_FILE")"
+gc bd update {{issue}} --notes "$(cat "$NOTES_FILE")"
 rm -f "$NOTES_FILE"
 ```
 
@@ -279,7 +279,7 @@ back on the original issue when the PR is ready for review.
 
 **1. Load the branch name:**
 ```bash
-BRANCH=$(bd show {{issue}} --json | jq -r '.metadata.branch // empty')
+BRANCH=$(gc bd show {{issue}} --json | jq -r '.metadata.branch // empty')
 ```
 
 **2. Push the branch:**
@@ -291,9 +291,9 @@ gc github push-branch {{github_repo_full_name}} \
 
 **3. Draft the PR body with the real summary and validation before submission:**
 ```bash
-PR_URL=$(bd show {{issue}} --json | jq -r '.metadata.github_fix_pr_url // empty')
+PR_URL=$(gc bd show {{issue}} --json | jq -r '.metadata.github_fix_pr_url // empty')
 if [ -z "$PR_URL" ]; then
-  ISSUE_TITLE=$(bd show {{issue}} --json | jq -r '.metadata.github_issue_title // empty' | tr '\\n' ' ' | sed 's/[[:space:]]\\+/ /g' | sed 's/^ //; s/ $//')
+  ISSUE_TITLE=$(gc bd show {{issue}} --json | jq -r '.metadata.github_issue_title // empty' | tr '\\n' ' ' | sed 's/[[:space:]]\\+/ /g' | sed 's/^ //; s/ $//')
   if [ -z "$ISSUE_TITLE" ]; then
     ISSUE_TITLE="issue #{{github_issue_number}}"
   fi
@@ -325,7 +325,7 @@ if [ -z "$PR_URL" ]; then
   PR_URL=$(printf '%s' "$PR_JSON" | jq -r '.html_url // empty')
   PR_NUMBER=$(printf '%s' "$PR_JSON" | jq -r '.number // empty')
   if [ -n "$PR_URL" ]; then
-    bd update {{issue}} \
+    gc bd update {{issue}} \
       --set-metadata github_fix_pr_url="$PR_URL" \
       --set-metadata github_fix_pr_number="$PR_NUMBER"
   fi
@@ -335,8 +335,8 @@ fi
 
 **5. Post the completion issue comment exactly once:**
 ```bash
-DONE=$(bd show {{issue}} --json | jq -r '.metadata.github_fix_complete_comment_id // empty')
-PR_URL=$(bd show {{issue}} --json | jq -r '.metadata.github_fix_pr_url // empty')
+DONE=$(gc bd show {{issue}} --json | jq -r '.metadata.github_fix_complete_comment_id // empty')
+PR_URL=$(gc bd show {{issue}} --json | jq -r '.metadata.github_fix_pr_url // empty')
 if [ -z "$DONE" ] && [ -n "$PR_URL" ]; then
   BODY=$(mktemp)
   cat >"$BODY" <<EOF
@@ -353,7 +353,7 @@ EOF
   COMMENT_ID=$(printf '%s' "$COMMENT_JSON" | jq -r '.id // empty')
   COMMENT_URL=$(printf '%s' "$COMMENT_JSON" | jq -r '.html_url // empty')
   if [ -n "$COMMENT_ID" ]; then
-    bd update {{issue}} \
+    gc bd update {{issue}} \
       --set-metadata github_fix_complete_comment_id="$COMMENT_ID" \
       --set-metadata github_fix_complete_comment_url="$COMMENT_URL"
   fi
@@ -363,8 +363,8 @@ fi
 
 **6. Close the bead and exit:**
 ```bash
-PR_URL=$(bd show {{issue}} --json | jq -r '.metadata.github_fix_pr_url // empty')
-WORKTREE=$(bd show {{issue}} --json | jq -r '.metadata.work_dir // empty')
+PR_URL=$(gc bd show {{issue}} --json | jq -r '.metadata.github_fix_pr_url // empty')
+WORKTREE=$(gc bd show {{issue}} --json | jq -r '.metadata.work_dir // empty')
 if [ -n "$WORKTREE" ] && [ -d "$WORKTREE" ]; then
   GIT_COMMON_DIR=$(git -C "$WORKTREE" rev-parse --git-common-dir)
   case "$GIT_COMMON_DIR" in
@@ -374,9 +374,9 @@ if [ -n "$WORKTREE" ] && [ -d "$WORKTREE" ]; then
   CLEANUP_CWD=$(dirname "$GIT_COMMON_DIR")
   cd "$CLEANUP_CWD" || exit 1
   git --git-dir="$GIT_COMMON_DIR" worktree remove "$WORKTREE" --force
-  bd update {{issue}} --unset-metadata work_dir
+  gc bd update {{issue}} --unset-metadata work_dir
 fi
-CURRENT_NOTES=$(bd show {{issue}} --json | jq -r '.notes // empty')
+CURRENT_NOTES=$(gc bd show {{issue}} --json | jq -r '.notes // empty')
 FINAL_NOTES=$(mktemp)
 cat >"$FINAL_NOTES" <<EOF
 $CURRENT_NOTES
@@ -385,9 +385,9 @@ $CURRENT_NOTES
 
 PR ready for review: $PR_URL
 EOF
-bd update {{issue}} --notes "$(cat "$FINAL_NOTES")"
+gc bd update {{issue}} --notes "$(cat "$FINAL_NOTES")"
 rm -f "$FINAL_NOTES"
-bd close {{issue}}
+gc bd close {{issue}}
 gc runtime drain-ack
 exit
 ```

--- a/github/scripts/github_intake_release_workflow.py
+++ b/github/scripts/github_intake_release_workflow.py
@@ -15,11 +15,16 @@ def bead_metadata(bead_id: str) -> dict[str, object]:
     bead_id = bead_id.strip()
     if not bead_id:
         return {}
-    bd_bin = os.environ.get("BD_BIN", "bd")
+    gc_bin = os.environ.get("GC_BIN", "gc")
     city_root = common.city_root() or "."
+    command = [gc_bin]
+    if city_root not in {"", "."}:
+        command.extend(["--city", city_root])
+    command.append("bd")
+    command.extend(["show", bead_id, "--json"])
     try:
         result = subprocess.run(
-            [bd_bin, "show", bead_id, "--json"],
+            command,
             cwd=city_root,
             capture_output=True,
             text=True,

--- a/github/scripts/github_intake_service.py
+++ b/github/scripts/github_intake_service.py
@@ -122,6 +122,17 @@ def rig_from_target(target: str) -> str:
     return rig.strip()
 
 
+def gc_bd_command(city_root: str, *args: str, rig: str = "") -> list[str]:
+    command = [os.environ.get("GC_BIN", "gc")]
+    if city_root not in {"", "."}:
+        command.extend(["--city", city_root])
+    if rig:
+        command.extend(["--rig", rig])
+    command.append("bd")
+    command.extend(args)
+    return command
+
+
 def rig_workdir(rig: str) -> str:
     """Resolve a rig's working directory from .beads/routes.jsonl."""
     root = common.city_root() or "."
@@ -292,13 +303,20 @@ def create_fix_bead(request: dict[str, Any], target: str) -> dict[str, Any]:
     if not rig:
         return {"status": "dispatch_failed", "reason": "invalid_dispatch_target"}
     city_root = common.city_root() or "."
-    bd_bin = os.environ.get("BD_BIN", "bd")
     bd_cwd = rig_workdir(rig) or city_root
-    create_command = [bd_bin, "create", "--json", build_fix_bead_title(request), "-t", "task"]
+    create_command = gc_bd_command(
+        city_root,
+        "create",
+        "--json",
+        build_fix_bead_title(request),
+        "-t",
+        "task",
+        rig=rig,
+    )
     try:
         create_result = run_subprocess(create_command, bd_cwd)
     except FileNotFoundError:
-        return {"status": "dispatch_failed", "reason": "bead_create_failed", "dispatch_stderr": "bd not available"}
+        return {"status": "dispatch_failed", "reason": "bead_create_failed", "dispatch_stderr": "gc not available"}
     if create_result.returncode != 0:
         return {
             "status": "dispatch_failed",
@@ -327,7 +345,7 @@ def create_fix_bead(request: dict[str, Any], target: str) -> dict[str, Any]:
         "github_default_branch": str(request.get("repository_default_branch", "") or "main"),
         "github_comment_author": str(request.get("comment_author", "")),
     }
-    update_command = [bd_bin, "update", bead_id, "--notes", build_fix_bead_notes(request)]
+    update_command = gc_bd_command(city_root, "update", bead_id, "--notes", build_fix_bead_notes(request), rig=rig)
     for key, value in metadata.items():
         if value:
             update_command.extend(["--set-metadata", f"{key}={value}"])
@@ -338,7 +356,7 @@ def create_fix_bead(request: dict[str, Any], target: str) -> dict[str, Any]:
             "status": "dispatch_failed",
             "reason": "bead_update_failed",
             "bead_id": bead_id,
-            "dispatch_stderr": "bd not available",
+            "dispatch_stderr": "gc not available",
         }
     if update_result.returncode != 0:
         return {
@@ -369,17 +387,23 @@ def close_failed_bead(bead_id: str, reason: str, rig: str = "") -> bool:
     bead_id = bead_id.strip()
     if not bead_id:
         return True
-    bd_bin = os.environ.get("BD_BIN", "bd")
     city_root = common.city_root() or "."
     bd_cwd = (rig_workdir(rig) or city_root) if rig else city_root
     try:
         set_reason = run_subprocess(
-            [bd_bin, "update", bead_id, "--set-metadata", f"close_reason=github:{reason or 'dispatch_failed'}"],
+            gc_bd_command(
+                city_root,
+                "update",
+                bead_id,
+                "--set-metadata",
+                f"close_reason=github:{reason or 'dispatch_failed'}",
+                rig=rig,
+            ),
             bd_cwd,
         )
         if set_reason.returncode != 0:
             return False
-        result = run_subprocess([bd_bin, "close", bead_id], bd_cwd)
+        result = run_subprocess(gc_bd_command(city_root, "close", bead_id, rig=rig), bd_cwd)
     except FileNotFoundError:
         return False
     return result.returncode == 0
@@ -809,10 +833,9 @@ def addressed_source_metadata(request: dict[str, Any]) -> dict[str, str]:
 
 def addressed_sources_by_key(source_key: str) -> list[dict[str, Any]]:
     city_root = common.city_root() or "."
-    bd_bin = os.environ.get("BD_BIN", "bd")
     result = run_subprocess(
-        [
-            bd_bin,
+        gc_bd_command(
+            city_root,
             "list",
             "--json",
             "--all",
@@ -820,11 +843,11 @@ def addressed_sources_by_key(source_key: str) -> list[dict[str, Any]]:
             f"external.source_key={source_key}",
             "--limit",
             "0",
-        ],
+        ),
         city_root,
     )
     if result.returncode != 0:
-        raise RuntimeError(f"bd list failed: {trim_output(result.stderr or result.stdout)}")
+        raise RuntimeError(f"gc bd list failed: {trim_output(result.stderr or result.stdout)}")
     payload = extract_json_value(result.stdout)
     if not isinstance(payload, list):
         return []
@@ -852,10 +875,9 @@ def create_addressed_source(request: dict[str, Any]) -> dict[str, Any]:
         }
 
     city_root = common.city_root() or "."
-    bd_bin = os.environ.get("BD_BIN", "bd")
     metadata = addressed_source_metadata(request)
-    command = [
-        bd_bin,
+    command = gc_bd_command(
+        city_root,
         "create",
         "--json",
         addressed_source_title(request),
@@ -869,7 +891,7 @@ def create_addressed_source(request: dict[str, Any]) -> dict[str, Any]:
         source_key,
         "--metadata",
         json.dumps(metadata, sort_keys=True),
-    ]
+    )
     try:
         result = run_subprocess(command, city_root)
     except FileNotFoundError:
@@ -1563,10 +1585,10 @@ def process_event_rules(event: str, delivery_id: str, payload: dict[str, Any], a
 
 
 def list_addressed_router_sources(limit: int) -> list[dict[str, Any]]:
-    bd_bin = os.environ.get("BD_BIN", "bd")
+    city_root = common.city_root() or "."
     result = run_subprocess(
-        [
-            bd_bin,
+        gc_bd_command(
+            city_root,
             "list",
             "--json",
             "--status",
@@ -1575,11 +1597,11 @@ def list_addressed_router_sources(limit: int) -> list[dict[str, Any]]:
             "external.kind=addressed-message",
             "--limit",
             str(limit),
-        ],
-        common.city_root() or ".",
+        ),
+        city_root,
     )
     if result.returncode != 0:
-        raise RuntimeError(f"bd list failed: {trim_output(result.stderr or result.stdout)}")
+        raise RuntimeError(f"gc bd list failed: {trim_output(result.stderr or result.stdout)}")
     payload = extract_json_value(result.stdout)
     if not isinstance(payload, list):
         return []
@@ -1587,19 +1609,19 @@ def list_addressed_router_sources(limit: int) -> list[dict[str, Any]]:
 
 
 def update_bead_metadata(bead: str, values: dict[str, str]) -> subprocess.CompletedProcess[str]:
-    bd_bin = os.environ.get("BD_BIN", "bd")
-    command = [bd_bin, "update", bead]
+    city_root = common.city_root() or "."
+    command = gc_bd_command(city_root, "update", bead)
     for key, value in values.items():
         if value:
             command.extend(["--set-metadata", f"{key}={value}"])
-    return run_subprocess(command, common.city_root() or ".")
+    return run_subprocess(command, city_root)
 
 
 def close_addressed_source(source_id: str) -> subprocess.CompletedProcess[str]:
-    bd_bin = os.environ.get("BD_BIN", "bd")
+    city_root = common.city_root() or "."
     return run_subprocess(
-        [bd_bin, "close", source_id, "--reason", "github addressed message dispatched"],
-        common.city_root() or ".",
+        gc_bd_command(city_root, "close", source_id, "--reason", "github addressed message dispatched"),
+        city_root,
     )
 
 
@@ -1700,12 +1722,13 @@ def create_addressed_rig_launch_bead(
     if not rig:
         return {"status": "failed", "reason": "missing_rig"}
     gc_bin = os.environ.get("GC_BIN", "gc")
+    city_root = common.city_root() or "."
     launch_metadata = addressed_rig_launch_metadata(source_id, metadata, target, formula)
-    command = [
-        gc_bin,
-        "--rig",
-        rig,
-        "bd",
+    command = [gc_bin]
+    if city_root not in {"", "."}:
+        command.extend(["--city", city_root])
+    command.extend([
+        "--rig", rig, "bd",
         "create",
         str(source.get("title") or addressed_source_title(metadata)),
         "--type",
@@ -1717,9 +1740,9 @@ def create_addressed_rig_launch_bead(
         "--metadata",
         json.dumps(launch_metadata, sort_keys=True),
         "--json",
-    ]
+    ])
     try:
-        result = run_subprocess(command, common.city_root() or ".")
+        result = run_subprocess(command, city_root)
     except FileNotFoundError:
         return {"status": "failed", "reason": "gc_not_available"}
     if result.returncode != 0:

--- a/github/tests/test_github_intake_service.py
+++ b/github/tests/test_github_intake_service.py
@@ -885,8 +885,17 @@ GITHUB_INTAKE_APP_IDENTITY = "mayor"
         self.assertEqual(outcome["started"][0]["workflow_root_id"], "ga-root")
         commands = [call.args[0] for call in run_subprocess.call_args_list]
         self.assertEqual(
-            commands[2][:6],
-            ["gc", "--rig", "github-owner-repo", "bd", "create", "GitHub addressed message @mayor in owner/repo#42"],
+            commands[2][:8],
+            [
+                "gc",
+                "--city",
+                self.tempdir.name,
+                "--rig",
+                "github-owner-repo",
+                "bd",
+                "create",
+                "GitHub addressed message @mayor in owner/repo#42",
+            ],
         )
         create_metadata = json.loads(commands[2][commands[2].index("--metadata") + 1])
         self.assertEqual(create_metadata["addressed.city_source_bead_id"], "ga-src1")
@@ -911,9 +920,13 @@ GITHUB_INTAKE_APP_IDENTITY = "mayor"
         self.assertEqual(sling_vars["github_app_installation_id"], "profile-installation")
         self.assertEqual(sling_vars["github_app_identity"], "mayor")
         self.assertEqual(sling_vars["acknowledgement_requested"], "true")
-        self.assertEqual(commands[1][0:3], ["bd", "update", "ga-src1"])
-        self.assertEqual(commands[4][0:3], ["bd", "update", "ga-src1"])
-        self.assertEqual(commands[5], ["bd", "close", "ga-src1", "--reason", "github addressed message dispatched"])
+        city_prefix = ["gc", "--city", self.tempdir.name, "bd"]
+        self.assertEqual(commands[1][0:6], city_prefix + ["update", "ga-src1"])
+        self.assertEqual(commands[4][0:6], city_prefix + ["update", "ga-src1"])
+        self.assertEqual(
+            commands[5],
+            city_prefix + ["close", "ga-src1", "--reason", "github addressed message dispatched"],
+        )
 
     def test_route_addressed_source_marks_failed_when_post_sling_update_fails(self) -> None:
         source = {
@@ -969,7 +982,16 @@ GITHUB_INTAKE_APP_IDENTITY = "mayor"
         self.assertEqual(outcome["reason"], "already_dispatched_closed")
         self.assertEqual(outcome["workflow_root_id"], "ga-root")
         run_subprocess.assert_called_once_with(
-            ["bd", "close", "ga-src1", "--reason", "github addressed message dispatched"],
+            [
+                "gc",
+                "--city",
+                self.tempdir.name,
+                "bd",
+                "close",
+                "ga-src1",
+                "--reason",
+                "github addressed message dispatched",
+            ],
             self.tempdir.name,
         )
 
@@ -1249,9 +1271,12 @@ GITHUB_INTAKE_APP_IDENTITY = "mayor"
         self.assertEqual(outcome["bead_id"], "bd-1")
         self.assertTrue(outcome["bead_closed"])
         commands = [call.args[0] for call in run_subprocess.call_args_list]
-        self.assertEqual(commands[0], ["bd", "update", "bd-1", "--set-metadata", "close_reason=github:bead_update_failed"])
-        self.assertEqual(commands[1], ["bd", "close", "bd-1"])
-        self.assertNotIn("gc", [command[0] for command in commands])
+        prefix = ["gc", "--city", self.tempdir.name, "--rig", "product", "bd"]
+        self.assertEqual(
+            commands[0],
+            prefix + ["update", "bd-1", "--set-metadata", "close_reason=github:bead_update_failed"],
+        )
+        self.assertEqual(commands[1], prefix + ["close", "bd-1"])
 
     def test_run_fix_bugflow_dispatch_creates_source_and_routes_with_app_token(self) -> None:
         request = {
@@ -1388,8 +1413,12 @@ GITHUB_INTAKE_APP_IDENTITY = "mayor"
 
         self.assertTrue(closed)
         commands = [call.args[0] for call in run_subprocess.call_args_list]
-        self.assertEqual(commands[0], ["bd", "update", "bd-1", "--set-metadata", "close_reason=github:dispatch_failed"])
-        self.assertEqual(commands[1], ["bd", "close", "bd-1"])
+        prefix = ["gc", "--city", self.tempdir.name, "bd"]
+        self.assertEqual(
+            commands[0],
+            prefix + ["update", "bd-1", "--set-metadata", "close_reason=github:dispatch_failed"],
+        )
+        self.assertEqual(commands[1], prefix + ["close", "bd-1"])
 
     def test_process_request_releases_workflow_link_after_dispatch_failure_with_bead(self) -> None:
         request = {

--- a/gstack/template-fragments/gc-role-worker.template.md
+++ b/gstack/template-fragments/gc-role-worker.template.md
@@ -195,7 +195,8 @@ verdict is `iterate`, `changes_required`, or similar.
 
 If later terminal commands do not inherit shell variables, use the explicit
 `CLAIMED_BEAD_ID`, `CLAIMED_ROOT_BEAD_ID`, and
-`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `gc bd update` or `gc bd close` with an empty id.
+`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run
+`gc bd update` or `gc bd close` with an empty id.
 
 When updating or closing a bead, pass exactly one explicit claimed bead id.
 Quote every metadata assignment and close reason. Do not put freeform prose or

--- a/gstack/template-fragments/gc-role-worker.template.md
+++ b/gstack/template-fragments/gc-role-worker.template.md
@@ -7,14 +7,14 @@ You are `{{ .AgentName }}`, a Gas City `graph.v2` role worker for template
 ## Core Rule
 
 You work only the routed bead assigned to this live session. Do not use
-`bd mol current` to infer workflow position. Do not assume a parent bead or
+`gc bd mol current` to infer workflow position. Do not assume a parent bead or
 root bead describes your work. The workflow graph advances through explicit
 ready beads, and you execute the ready bead claimed by this session.
 
 ## Startup Claim Protocol
 
 `gc hook --claim --json` is the only permitted discovery source for routed
-workflow work. Do not run broad `bd ready`, `bd list`, root-bead searches,
+workflow work. Do not run broad `gc bd ready`, `gc bd list`, root-bead searches,
 metadata searches, mail inspection, session-log inspection, or repository
 context gathering to find a bead. Never work a bead id unless it came from the
 immediately preceding `gc hook --claim --json` result in this claim block.
@@ -109,7 +109,7 @@ while true; do
   fi
 
   SHOW_ERR="$(mktemp)"
-  if ! SHOW_JSON="$(bd show "$WORK_ID" --json 2>"$SHOW_ERR")"; then
+  if ! SHOW_JSON="$(gc bd show "$WORK_ID" --json 2>"$SHOW_ERR")"; then
     SHOW_ERR_TEXT="$(sed -n '1p' "$SHOW_ERR")"
     rm -f "$SHOW_ERR"
     if [ -n "$SHOW_ERR_TEXT" ]; then
@@ -167,7 +167,7 @@ export GC_CONTINUATION_GROUP="$CLAIM_GROUP"
 printf 'CLAIMED_BEAD_ID=%s\n' "$WORK_ID"
 printf 'CLAIMED_ROOT_BEAD_ID=%s\n' "$CLAIM_ROOT"
 printf 'CLAIMED_CONTINUATION_GROUP=%s\n' "$CLAIM_GROUP"
-bd show "$GC_BEAD_ID"
+gc bd show "$GC_BEAD_ID"
 GC_CLAIM
 ```
 
@@ -178,14 +178,14 @@ Close it with the requested `gc.outcome` metadata. If the bead does not specify
 a failure contract, mark an unrecoverable failure with `gc.outcome=fail` and a
 concise `gc.failure_class`/reason before closing it.
 
-Never use a bare `bd close` for a bead that asks for close metadata. First set
+Never use `gc bd close` for a bead that asks for close metadata. First set
 the requested metadata on the claimed bead, then close the same bead id:
 
 ```bash
-bd update "$GC_BEAD_ID" \
+gc bd update "$GC_BEAD_ID" \
   --set-metadata 'gc.outcome=pass' \
   --set-metadata 'example.key=example-value'
-bd close "$GC_BEAD_ID"
+gc bd close "$GC_BEAD_ID"
 ```
 
 Finding review issues, missing tests, or required follow-up is usually the
@@ -195,13 +195,12 @@ verdict is `iterate`, `changes_required`, or similar.
 
 If later terminal commands do not inherit shell variables, use the explicit
 `CLAIMED_BEAD_ID`, `CLAIMED_ROOT_BEAD_ID`, and
-`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `bd
-update` or `bd close` with an empty id.
+`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `gc bd update` or `gc bd close` with an empty id.
 
 When updating or closing a bead, pass exactly one explicit claimed bead id.
 Quote every metadata assignment and close reason. Do not put freeform prose or
 bare words after the bead id; `bd` treats every extra positional argument as
-another issue id and may fuzzy-match unrelated beads. Use `bd close
+another issue id and may fuzzy-match unrelated beads. Use `gc bd close
 "$CLAIMED_BEAD_ID" --reason '...'` for close notes.
 
 ## Continuation Group Protocol

--- a/pr-pipeline/formulas/mol-pr-blast-radius.formula.toml
+++ b/pr-pipeline/formulas/mol-pr-blast-radius.formula.toml
@@ -9,7 +9,7 @@ agent is given a free-text `scope` describing what code will change
 report to `.gc/pr-pipeline/blast-radius/<key>.md`. **No code is written.**
 
 The molecule root bead IS the control bead — run state is recorded in
-its notes via `bd update <root-id> --notes "<key>: <value>"`.
+its notes via `gc bd update <root-id> --notes "<key>: <value>"`.
 
 This formula is composable: the planner (`mol-pr-start`) currently does
 its own inline blast-radius analysis, but for changes that don't start
@@ -52,10 +52,10 @@ Confirm we're in a git repo and parse the scope into a list of analyzable
 targets.
 
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
     echo "Not in a git repository — cannot map blast radius."
-    bd close "$ROOT_ID" --reason "not a git checkout"
+    gc bd close "$ROOT_ID" --reason "not a git checkout"
     exit 1
 }
 cd "$REPO_ROOT"
@@ -78,7 +78,7 @@ if [ -z "$KEY" ]; then
 fi
 mkdir -p .gc/pr-pipeline/blast-radius
 REPORT_PATH=".gc/pr-pipeline/blast-radius/${KEY}.md"
-bd update "$ROOT_ID" --notes "scope: {{scope}}
+gc bd update "$ROOT_ID" --notes "scope: {{scope}}
 key: $KEY
 report_path: $REPORT_PATH
 status: in_progress"
@@ -253,8 +253,8 @@ Write the report to `$REPORT_PATH` using this structure:
 After writing, mark complete:
 
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
-bd update "$ROOT_ID" --notes "status: complete"
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
+gc bd update "$ROOT_ID" --notes "status: complete"
 echo "[blast-radius] Complete for: {{scope}}"
 echo "[blast-radius]   Path: $REPORT_PATH"
 ```

--- a/pr-pipeline/formulas/mol-pr-from-issue.formula.toml
+++ b/pr-pipeline/formulas/mol-pr-from-issue.formula.toml
@@ -11,7 +11,7 @@ loop-close handler picks up the root bead close and surfaces the halt to
 the originating Slack thread via the PL.
 
 The molecule root bead IS the control bead — run state is recorded in its
-notes and metadata. Crash-safe: `bd mol current` resumes at the right step.
+notes and metadata. Crash-safe: `gc bd mol current` resumes at the right step.
 
 ## Contract
 
@@ -90,12 +90,12 @@ and scoped to this macro formula.
 
 **1. Find the root bead and confirm we're in a git repo:**
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
     echo "Not in a git repository — cannot plan."
-    bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
+    gc bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
                          --set-metadata "summary_for_human=Cannot plan issue #{{issue_number}}: not in a git checkout. No PR opened."
-    bd close "$ROOT_ID" --reason "not a git checkout"
+    gc bd close "$ROOT_ID" --reason "not a git checkout"
     exit 1
 }
 cd "$REPO_ROOT"
@@ -121,7 +121,7 @@ Follow mol-pr-start's six step bodies in order (copy-with-prune from
 
      If either gate triggers:
      ```bash
-     bd update "$ROOT_ID" \\
+     gc bd update "$ROOT_ID" \\
        --set-metadata "gc.halt_chain=true" \\
        --set-metadata "summary_for_human=Issue #{{issue_number}} blocked by <gate>: <detail>. Recommended pivot: <one-line suggestion based on which gate fired>."
      ```
@@ -168,7 +168,7 @@ Implementation rules:
 
 **5. Write evidence on close:**
 ```bash
-bd update "$ROOT_ID" \\
+gc bd update "$ROOT_ID" \\
   --set-metadata "evidence.artifact_path=.gc/pr-pipeline/plans/issue-{{issue_number}}.md" \\
   --set-metadata "evidence.reviewer_verdict=pass" \\
   --set-metadata "evidence.reviewer_agent=<this polecat session>" \\
@@ -193,9 +193,9 @@ flag is present; otherwise close cleanly and proceed.
 
 **1. Find the root bead and read pr-start state:**
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
-HALT=$(bd show "$ROOT_ID" --json | jq -r '.[0].metadata."gc.halt_chain" // "false"')
-VERDICT=$(bd show "$ROOT_ID" --json | jq -r '.[0].metadata."evidence.reviewer_verdict" // ""')
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
+HALT=$(gc bd show "$ROOT_ID" --json | jq -r '.[0].metadata."gc.halt_chain" // "false"')
+VERDICT=$(gc bd show "$ROOT_ID" --json | jq -r '.[0].metadata."evidence.reviewer_verdict" // ""')
 ```
 
 **2. Decide:**
@@ -206,15 +206,15 @@ VERDICT=$(bd show "$ROOT_ID" --json | jq -r '.[0].metadata."evidence.reviewer_ve
     itself** (pr-start's internal gates already write specific halt
     summaries). Only write a fallback if the field is still empty:
     ```bash
-    EXISTING=$(bd show "$ROOT_ID" --json | jq -r '.[0].metadata.summary_for_human // ""')
+    EXISTING=$(gc bd show "$ROOT_ID" --json | jq -r '.[0].metadata.summary_for_human // ""')
     if [ -z "$EXISTING" ]; then
-        bd update "$ROOT_ID" --set-metadata \\
+        gc bd update "$ROOT_ID" --set-metadata \\
           "summary_for_human=Halt at gate-after-pr-start for issue #{{issue_number}}: <one-line synthesis of why>. No PR opened."
     fi
     ```
   - Close THIS step with status=closed:
     ```bash
-    bd close "$ROOT_ID" --reason "halt_chain set after pr-start"
+    gc bd close "$ROOT_ID" --reason "halt_chain set after pr-start"
     ```
   - Do NOT proceed. The downstream ship/open-pr steps will not run
     because the chain is halted. The loop-close handler picks up the
@@ -241,15 +241,15 @@ Copy-with-prune from
 
 **1. Find the root bead and resolve the branch:**
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
 REPO_ROOT=$(git rev-parse --show-toplevel)
 cd "$REPO_ROOT"
 BRANCH=$(git branch --show-current)
 DEFAULT=$(git remote show origin 2>/dev/null | sed -n 's/.*HEAD branch: //p' || echo "main")
 if [ "$BRANCH" = "$DEFAULT" ] || [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then
-    bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
+    gc bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
       --set-metadata "summary_for_human=Cannot ship from default branch ($BRANCH). pr-start did not create a feature branch — chain stopped."
-    bd close "$ROOT_ID" --reason "on default branch"
+    gc bd close "$ROOT_ID" --reason "on default branch"
     exit 0
 fi
 mkdir -p .gc/pr-pipeline/ship
@@ -297,7 +297,7 @@ points to the ship report (`.gc/pr-pipeline/ship/...`) before reading
 it in gate-after-ship.
 
 ```bash
-bd update "$ROOT_ID" \\
+gc bd update "$ROOT_ID" \\
   --set-metadata "evidence.artifact_path=$REPORT_PATH" \\
   --set-metadata "evidence.reviewer_verdict=<pass|blocked>" \\
   --set-metadata "evidence.reviewer_agent=<this polecat session>" \\
@@ -324,9 +324,9 @@ otherwise close cleanly and proceed to open-pr.
 
 **1. Find the root bead and read ship state:**
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
-VERDICT=$(bd show "$ROOT_ID" --json | jq -r '.[0].metadata."evidence.reviewer_verdict" // ""')
-REPORT_PATH=$(bd show "$ROOT_ID" --json | jq -r '.[0].metadata."evidence.artifact_path" // ""')
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
+VERDICT=$(gc bd show "$ROOT_ID" --json | jq -r '.[0].metadata."evidence.reviewer_verdict" // ""')
+REPORT_PATH=$(gc bd show "$ROOT_ID" --json | jq -r '.[0].metadata."evidence.artifact_path" // ""')
 ```
 
 **2. Decide:**
@@ -335,16 +335,16 @@ REPORT_PATH=$(bd show "$ROOT_ID" --json | jq -r '.[0].metadata."evidence.artifac
   - Read the blockers section of the ship report at `$REPORT_PATH`.
   - Write `summary_for_human` synthesizing the blockers:
     ```bash
-    bd update "$ROOT_ID" --set-metadata \\
+    gc bd update "$ROOT_ID" --set-metadata \\
       "summary_for_human=Ship gate halted on issue #{{issue_number}}: <one-line blocker summary>. Full readiness report at $REPORT_PATH. Branch left ready for human review — no PR opened."
     ```
   - Set halt_chain:
     ```bash
-    bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true"
+    gc bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true"
     ```
   - Close THIS step:
     ```bash
-    bd close "$ROOT_ID" --reason "ship verdict != pass"
+    gc bd close "$ROOT_ID" --reason "ship verdict != pass"
     ```
   - Do NOT proceed to open-pr.
 
@@ -381,7 +381,7 @@ through to `open-pr`, whose top-of-step check soft-halts at branch-ready
 
 **1. Find the root bead and resolve identifiers:**
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
 AUTO_PUSH="{{auto_push}}"
 ISSUE_NUM={{issue_number}}
 REPO_ROOT=$(git rev-parse --show-toplevel)
@@ -409,11 +409,11 @@ Helper:
 halt_gate() {
     local gate="$1"
     local detail="$2"
-    bd update "$ROOT_ID" \\
+    gc bd update "$ROOT_ID" \\
       --set-metadata "gc.halt_chain=true" \\
       --set-metadata "gc.escalate_to=mayor" \\
       --set-metadata "summary_for_human=Auto-push eligibility halt for issue #${ISSUE_NUM}: ${gate}: ${detail}. Branch ${BRANCH} ready at $(git rev-parse HEAD) for human review. Escalating to mayor for routing decision."
-    bd close "$ROOT_ID" --reason "auto-push gate halt: ${gate}"
+    gc bd close "$ROOT_ID" --reason "auto-push gate halt: ${gate}"
     exit 0
 }
 ```
@@ -421,12 +421,12 @@ halt_gate() {
   a. **kill-switch** (checked first so the gate fails fast when disarmed):
   ```bash
   if [ ! -e "${HOME}/.gc/auto-push-armed.flag" ]; then
-      bd update "$ROOT_ID" \\
+      gc bd update "$ROOT_ID" \\
         --set-metadata "evidence.review_required=true" \\
         --set-metadata "gc.halt_chain=true" \\
         --set-metadata "gc.escalate_to=mayor" \\
         --set-metadata "summary_for_human=Auto-push kill-switch ${HOME}/.gc/auto-push-armed.flag is absent. Halting at branch-ready for issue #${ISSUE_NUM}. Mayor must arm the flag before any auto-push proceeds."
-      bd close "$ROOT_ID" --reason "auto-push gate halt: kill-switch absent"
+      gc bd close "$ROOT_ID" --reason "auto-push gate halt: kill-switch absent"
       exit 0
   fi
   ```
@@ -527,7 +527,7 @@ halt_gate() {
   `metadata.polecat_confidence` written by an earlier step; default
   "medium" treated as gate-fail):
   ```bash
-  CONFIDENCE=$(bd show "$ROOT_ID" --json | jq -r '.[0].metadata.polecat_confidence // "medium"')
+  CONFIDENCE=$(gc bd show "$ROOT_ID" --json | jq -r '.[0].metadata.polecat_confidence // "medium"')
   if [ "$CONFIDENCE" != "high" ]; then
       halt_gate "polecat-confidence" "polecat_confidence=${CONFIDENCE}, required: high"
   fi
@@ -537,7 +537,7 @@ halt_gate() {
 
 ```bash
 BYPASS_TOKEN="auto_push_validated:${ROOT_ID}"
-bd update "$ROOT_ID" \\
+gc bd update "$ROOT_ID" \\
   --set-metadata "evidence.gate_passed=true" \\
   --set-metadata "evidence.auto_push_bypass_token=${BYPASS_TOKEN}" \\
   --set-metadata "evidence.gate_diff_loc=${DIFF_LOC}" \\
@@ -571,12 +571,12 @@ upstream.
 
 **1. Find the root bead and resolve identifiers:**
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
 BRANCH=$(git branch --show-current)
 ISSUE_NUM={{issue_number}}
 SKIP_OPEN_PR="{{skip_open_pr}}"
-GATE_PASSED=$(bd show "$ROOT_ID" --json | jq -r '.[0].metadata."evidence.gate_passed" // ""')
-BYPASS_TOKEN=$(bd show "$ROOT_ID" --json | jq -r '.[0].metadata."evidence.auto_push_bypass_token" // ""')
+GATE_PASSED=$(gc bd show "$ROOT_ID" --json | jq -r '.[0].metadata."evidence.gate_passed" // ""')
+BYPASS_TOKEN=$(gc bd show "$ROOT_ID" --json | jq -r '.[0].metadata."evidence.auto_push_bypass_token" // ""')
 ```
 
 **2. Honor skip_open_pr=true (early-exit before any write):**
@@ -584,13 +584,13 @@ BYPASS_TOKEN=$(bd show "$ROOT_ID" --json | jq -r '.[0].metadata."evidence.auto_p
 If `SKIP_OPEN_PR == "true"`:
 ```bash
 COMMIT_SHA=$(git rev-parse HEAD)
-bd update "$ROOT_ID" \\
+gc bd update "$ROOT_ID" \\
   --set-metadata "evidence.artifact_path=git:$COMMIT_SHA" \\
   --set-metadata "evidence.reviewer_verdict=pass" \\
   --set-metadata "evidence.reviewer_agent=<this polecat session>" \\
   --set-metadata "evidence.branch=$BRANCH" \\
   --set-metadata "summary_for_human=Branch $BRANCH ready at $COMMIT_SHA for issue #$ISSUE_NUM. skip_open_pr=true — no push, no PR. Run: git push <fork-remote> $BRANCH when ready."
-bd close "$ROOT_ID" --reason "skip_open_pr=true; branch ready for human-driven open"
+gc bd close "$ROOT_ID" --reason "skip_open_pr=true; branch ready for human-driven open"
 exit 0
 ```
 
@@ -616,13 +616,13 @@ same shape as the `skip_open_pr=true` exit, distinguishable by
 ```bash
 if [ "$GATE_PASSED" != "true" ]; then
     COMMIT_SHA=$(git rev-parse HEAD)
-    bd update "$ROOT_ID" \\
+    gc bd update "$ROOT_ID" \\
       --set-metadata "evidence.artifact_path=git:$COMMIT_SHA" \\
       --set-metadata "evidence.reviewer_verdict=pass" \\
       --set-metadata "evidence.reviewer_agent=<this polecat session>" \\
       --set-metadata "evidence.branch=$BRANCH" \\
       --set-metadata "summary_for_human=Branch $BRANCH ready at $COMMIT_SHA for issue #$ISSUE_NUM. auto_push not armed (default-deny) — no push, no PR. To proceed: re-sling with --var auto_push=true so the eligibility gate runs, or push manually with: git push <fork-remote> $BRANCH."
-    bd close "$ROOT_ID" --reason "auto_push=false; branch ready, halted at open-pr soft gate"
+    gc bd close "$ROOT_ID" --reason "auto_push=false; branch ready, halted at open-pr soft gate"
     exit 0
 fi
 ```
@@ -676,9 +676,9 @@ our fork":
 
 If you cannot complete this recovery automatically, halt:
 ```bash
-bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
+gc bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
   --set-metadata "summary_for_human=Push to fork failed with 403 for branch $BRANCH (maintainerCanModify gap). Implementation is local at $(git rev-parse HEAD); manual supersede-via-our-fork recovery needed before PR can be opened."
-bd close "$ROOT_ID" --reason "push 403; manual recovery required"
+gc bd close "$ROOT_ID" --reason "push 403; manual recovery required"
 exit 0
 ```
 
@@ -715,9 +715,9 @@ if [ "$PR_EXIT" -eq 0 ] && [ -z "$(echo "$PR_URL" | grep -E 'https://[^ ]+/pull/
 fi
 
 if [ "$PR_EXIT" -ne 0 ] || [ -z "$PR_URL" ]; then
-    bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
+    gc bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
       --set-metadata "summary_for_human=Branch $BRANCH pushed to fork but gh pr create failed or no PR URL captured. Investigate before retrying."
-    bd close "$ROOT_ID" --reason "gh pr create failed or url empty"
+    gc bd close "$ROOT_ID" --reason "gh pr create failed or url empty"
     exit 0
 fi
 
@@ -738,7 +738,7 @@ fi
 
 **8. Write evidence and summary_for_human:**
 ```bash
-bd update "$ROOT_ID" \\
+gc bd update "$ROOT_ID" \\
   --set-metadata "evidence.artifact_path=github-pr:gastownhall/gascity/$PR_NUM" \\
   --set-metadata "evidence.reviewer_verdict=pass" \\
   --set-metadata "evidence.reviewer_agent=<this polecat session>" \\
@@ -748,7 +748,7 @@ bd update "$ROOT_ID" \\
 
 **9. Close the molecule:**
 ```bash
-bd close "$ROOT_ID" --reason "PR #$PR_NUM opened"
+gc bd close "$ROOT_ID" --reason "PR #$PR_NUM opened"
 ```
 
 **Exit criteria:** PR opened upstream (or halt set with summary_for_human

--- a/pr-pipeline/formulas/mol-pr-review.formula.toml
+++ b/pr-pipeline/formulas/mol-pr-review.formula.toml
@@ -53,18 +53,18 @@ title = "Fetch PR metadata and diff"
 description = """
 Resolve the PR identifier, fetch its data, and prepare the workspace.
 
-**Claim the root bead BEFORE any review work begins.** `bd update --claim`
+**Claim the root bead BEFORE any review work begins.** `gc bd update --claim`
 atomically sets assignee to your session and transitions status to
 `in_progress` (idempotent if already claimed by you). Without the claim,
 the bead stays `OPEN/assignee=none/started=no` while review work is in
 flight, and monitoring reads false stalls.
 
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
-bd update "$ROOT_ID" --claim
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
+gc bd update "$ROOT_ID" --claim
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
     echo "Not in a git repository — cannot review PR."
-    bd close "$ROOT_ID" --reason "not a git checkout"
+    gc bd close "$ROOT_ID" --reason "not a git checkout"
     exit 1
 }
 cd "$REPO_ROOT"
@@ -97,7 +97,7 @@ Prepare the report path:
 ```bash
 mkdir -p .gc/pr-pipeline/reviews
 REPORT_PATH=".gc/pr-pipeline/reviews/pr-<N>.md"
-bd update "$ROOT_ID" --notes "pr: <N>
+gc bd update "$ROOT_ID" --notes "pr: <N>
 repo: <repo>
 report_path: $REPORT_PATH
 status: in_progress"
@@ -308,10 +308,10 @@ Write the report to `$REPORT_PATH` using this structure:
 Compute the verdict mechanically from finding counts:
 
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
 # After writing the report, set verdict in bead notes
 VERDICT="<block | request_changes | approve>"
-bd update "$ROOT_ID" --notes "verdict: $VERDICT
+gc bd update "$ROOT_ID" --notes "verdict: $VERDICT
 status: complete"
 echo "[pr-review] Review complete for PR <N>"
 echo "[pr-review]   Verdict: $VERDICT"

--- a/pr-pipeline/formulas/mol-pr-ship.formula.toml
+++ b/pr-pipeline/formulas/mol-pr-ship.formula.toml
@@ -50,10 +50,10 @@ description = """
 Confirm we're in a git repo, resolve the branch, and prepare workspace.
 
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
     echo "Not in a git repository — cannot ship."
-    bd close "$ROOT_ID" --reason "not a git checkout"
+    gc bd close "$ROOT_ID" --reason "not a git checkout"
     exit 1
 }
 cd "$REPO_ROOT"
@@ -64,7 +64,7 @@ if [ -z "$BRANCH" ]; then
 fi
 if [ -z "$BRANCH" ] || [ "$BRANCH" = "HEAD" ]; then
     echo "On detached HEAD or no branch — cannot ship."
-    bd close "$ROOT_ID" --reason "no branch resolved"
+    gc bd close "$ROOT_ID" --reason "no branch resolved"
     exit 1
 fi
 
@@ -72,14 +72,14 @@ fi
 DEFAULT=$(git remote show origin 2>/dev/null | sed -n 's/.*HEAD branch: //p' || echo "main")
 if [ "$BRANCH" = "$DEFAULT" ] || [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then
     echo "Cannot ship from default branch ($BRANCH). Create a feature branch first."
-    bd close "$ROOT_ID" --reason "on default branch"
+    gc bd close "$ROOT_ID" --reason "on default branch"
     exit 1
 fi
 
 mkdir -p .gc/pr-pipeline/ship
 SAFE=$(echo "$BRANCH" | tr '/' '_')
 REPORT_PATH=".gc/pr-pipeline/ship/${SAFE}.md"
-bd update "$ROOT_ID" --notes "branch: $BRANCH
+gc bd update "$ROOT_ID" --notes "branch: $BRANCH
 report_path: $REPORT_PATH
 status: in_progress"
 ```
@@ -144,8 +144,8 @@ echo "[ship] Stage 1 reverted — simplify broke the build"
 Record stage outcome:
 
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
-bd update "$ROOT_ID" --notes "simplify: <complete | reverted | skipped>
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
+gc bd update "$ROOT_ID" --notes "simplify: <complete | reverted | skipped>
 simplify_commits: <sha1>,<sha2>,..."
 ```
 
@@ -173,7 +173,7 @@ The loop:
 1. Prepare the diff context for this iteration:
 
    ```bash
-   ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+   ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
    git diff origin/main..HEAD > "/tmp/pr-ship-${BRANCH//\\//-}-iter${ITER_N}.patch"
    ```
 
@@ -230,7 +230,7 @@ Record per-iteration state:
 
 ```bash
 ITER_N=<1|2|3>
-bd update "$ROOT_ID" --notes "review_iter_$ITER_N: blockers=<n>, majors=<n>, minors=<n>
+gc bd update "$ROOT_ID" --notes "review_iter_$ITER_N: blockers=<n>, majors=<n>, minors=<n>
 review_panel_$ITER_N: <reviewers run>; dropped=<n high-severity flags refuted in synthesis>
 review_fix_commits_$ITER_N: <sha>,<sha>,..."
 ```
@@ -238,7 +238,7 @@ review_fix_commits_$ITER_N: <sha>,<sha>,..."
 After convergence (or 3-iter cap):
 
 ```bash
-bd update "$ROOT_ID" --notes "review_status: <converged | not_converged>
+gc bd update "$ROOT_ID" --notes "review_status: <converged | not_converged>
 review_final: blockers=<n>, majors=<n>, minors=<n>"
 ```
 
@@ -255,7 +255,7 @@ Read-only mechanical checks. The exact gate set depends on the repo's
 stack; run what's available.
 
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
 GATES_PASSED=""
 GATES_FAILED=""
 ```
@@ -312,7 +312,7 @@ fi
 Record outcomes:
 
 ```bash
-bd update "$ROOT_ID" --notes "gates_passed:$GATES_PASSED
+gc bd update "$ROOT_ID" --notes "gates_passed:$GATES_PASSED
 gates_failed:$GATES_FAILED"
 ```
 
@@ -333,8 +333,8 @@ Combine all stages into a single report and STOP. This formula does NOT
 push, does NOT open a PR. The caller decides next steps.
 
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
-NOTES=$(bd show "$ROOT_ID" --json | jq -r '.[0].notes')
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
+NOTES=$(gc bd show "$ROOT_ID" --json | jq -r '.[0].notes')
 ```
 
 Write the report to `$REPORT_PATH`:
@@ -391,7 +391,7 @@ Decide verdict mechanically:
 ```bash
 VERDICT="<READY | BLOCKED>"
 BLOCKERS="<one-line summary of what blocks, or 'none'>"
-bd update "$ROOT_ID" --notes "readiness: $VERDICT
+gc bd update "$ROOT_ID" --notes "readiness: $VERDICT
 blockers: $BLOCKERS
 status: complete"
 echo "[ship] Pipeline complete for branch $BRANCH"

--- a/pr-pipeline/formulas/mol-pr-start.formula.toml
+++ b/pr-pipeline/formulas/mol-pr-start.formula.toml
@@ -10,7 +10,7 @@ and produces a structured plan saved to `.gc/pr-pipeline/plans/issue-<N>.md`.
 implement it.
 
 The molecule root bead IS the control bead — run state is recorded in its
-notes via `bd update <root-id> --notes "<key>: <value>"`.
+notes via `gc bd update <root-id> --notes "<key>: <value>"`.
 
 ## Contract
 
@@ -44,10 +44,10 @@ Establish working state and read the issue.
 
 **1. Find the root bead and confirm we're in a git repo:**
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
     echo "Not in a git repository — cannot plan."
-    bd close "$ROOT_ID" --reason "not a git checkout"
+    gc bd close "$ROOT_ID" --reason "not a git checkout"
     exit 1
 }
 cd "$REPO_ROOT"
@@ -65,7 +65,7 @@ so a single record of the issue + closure ends up in bead notes.
 
 **3. Record initial state in root-bead notes:**
 ```bash
-bd update "$ROOT_ID" --notes "issue: {{issue}}
+gc bd update "$ROOT_ID" --notes "issue: {{issue}}
 repo: $REPO
 repo_root: $REPO_ROOT
 status: in_progress"
@@ -84,7 +84,7 @@ time planning an issue someone else is fixing or whose area is being
 consolidated by a refactor that'll supersede the work.
 
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
 REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
 ```
 
@@ -104,7 +104,7 @@ ISSUE_STATE=$(gh issue view {{issue}} --repo "$REPO" --json state -q .state)
 ```bash
 REASON="competing PR exists or issue already closed"
 DETAIL=$(echo "$COMPETING_PRS" | jq -c '.')
-bd update "$ROOT_ID" --notes "status: blocked
+gc bd update "$ROOT_ID" --notes "status: blocked
 gate: competing_pr
 detail: $DETAIL
 issue_state: $ISSUE_STATE"
@@ -112,7 +112,7 @@ echo "[pr-plan] BLOCKED — $REASON"
 echo "[pr-plan]   Detail: $DETAIL"
 echo "[pr-plan]   Caller options: pivot to a different issue, review the"
 echo "[pr-plan]                   competing PR, or coordinate with author."
-bd close "$ROOT_ID" --reason "$REASON"
+gc bd close "$ROOT_ID" --reason "$REASON"
 exit 0
 ```
 
@@ -159,7 +159,7 @@ The agent uses semantic judgment to decide whether any of these signals
 genuinely overlaps the issue's area. **If the agent determines yes:**
 
 ```bash
-bd update "$ROOT_ID" --notes "status: blocked
+gc bd update "$ROOT_ID" --notes "status: blocked
 gate: architectural_refactor
 active_docs: $ACTIVE_DOCS
 consolidations: $CONSOLIDATIONS
@@ -170,14 +170,14 @@ echo "[pr-plan]   Caller options: a) point-fix the refactor can absorb"
 echo "[pr-plan]                   (ask in the issue first);"
 echo "[pr-plan]                   b) wait for refactor + rebase;"
 echo "[pr-plan]                   c) pivot to an issue outside the area."
-bd close "$ROOT_ID" --reason "active refactor in area"
+gc bd close "$ROOT_ID" --reason "active refactor in area"
 exit 0
 ```
 
 If neither gate triggers, record clearance and proceed:
 
 ```bash
-bd update "$ROOT_ID" --notes "gates: cleared"
+gc bd update "$ROOT_ID" --notes "gates: cleared"
 ```
 
 **Exit criteria:** Both gates cleared (or formula already exited via gate
@@ -225,8 +225,8 @@ Capture:
 Save the analysis as a heredoc into the bead notes for downstream steps:
 
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
-bd update "$ROOT_ID" --notes "blast_radius: <one-line summary>"
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
+gc bd update "$ROOT_ID" --notes "blast_radius: <one-line summary>"
 ```
 
 **Exit criteria:** Blast-radius summary recorded in root-bead notes.
@@ -288,7 +288,7 @@ description = """
 Produce the structured plan as a markdown file. This is the deliverable.
 
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
 mkdir -p .gc/pr-pipeline/plans
 PLAN_PATH=".gc/pr-pipeline/plans/issue-{{issue}}.md"
 ```
@@ -336,7 +336,7 @@ Branch prefixes: `fix/`, `feat/`, `refactor/`, `docs/`, `test/`,
 After writing the file:
 
 ```bash
-bd update "$ROOT_ID" --notes "plan_path: $PLAN_PATH
+gc bd update "$ROOT_ID" --notes "plan_path: $PLAN_PATH
 plan_status: draft"
 ```
 
@@ -430,9 +430,9 @@ currently doesn't," update the plan file with the addition.
 After the audit, mark the plan finalized:
 
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
 PLAN_PATH=".gc/pr-pipeline/plans/issue-{{issue}}.md"
-bd update "$ROOT_ID" --notes "plan_status: finalized
+gc bd update "$ROOT_ID" --notes "plan_status: finalized
 themes_audit: complete"
 ```
 

--- a/pr-pipeline/formulas/mol-pr-triage.formula.toml
+++ b/pr-pipeline/formulas/mol-pr-triage.formula.toml
@@ -14,7 +14,7 @@ human caller reviews the report and decides which issue to dispatch via
 etc.
 
 The molecule root bead IS the control bead — run state is recorded in its
-notes via `bd update <root-id> --notes "<key>: <value>"`.
+notes via `gc bd update <root-id> --notes "<key>: <value>"`.
 
 ## Contract
 
@@ -52,10 +52,10 @@ title = "Establish working state and verify repo"
 description = """
 **1. Find the root bead and confirm we're in the upstream gascity tree:**
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
     echo "Not in a git repository — cannot triage."
-    bd close "$ROOT_ID" --reason "not a git checkout"
+    gc bd close "$ROOT_ID" --reason "not a git checkout"
     exit 1
 }
 cd "$REPO_ROOT"
@@ -63,10 +63,10 @@ REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
 
 if [ "$REPO" != "gastownhall/gascity" ]; then
     echo "Triage formula is gastownhall/gascity-specific. Got: $REPO"
-    bd update "$ROOT_ID" --notes "status: blocked
+    gc bd update "$ROOT_ID" --notes "status: blocked
 gate: wrong_repo
 detail: $REPO"
-    bd close "$ROOT_ID" --reason "wrong repo for triage"
+    gc bd close "$ROOT_ID" --reason "wrong repo for triage"
     exit 0
 fi
 ```
@@ -74,9 +74,9 @@ fi
 **2. Verify gh auth:**
 ```bash
 gh auth status >/dev/null 2>&1 || {
-    bd update "$ROOT_ID" --notes "status: blocked
+    gc bd update "$ROOT_ID" --notes "status: blocked
 gate: gh_not_authed"
-    bd close "$ROOT_ID" --reason "gh not authenticated"
+    gc bd close "$ROOT_ID" --reason "gh not authenticated"
     exit 1
 }
 ```
@@ -103,7 +103,7 @@ fi
 mkdir -p "$TRIAGE_DIR"
 TRIAGE_PATH="$TRIAGE_DIR/$TS.md"
 
-bd update "$ROOT_ID" --notes "category: $CATEGORY
+gc bd update "$ROOT_ID" --notes "category: $CATEGORY
 limit: $LIMIT
 repo: $REPO
 triage_path: $TRIAGE_PATH
@@ -121,10 +121,10 @@ description = """
 Three lists feed the classification:
 
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
-TS=$(grep -A1 'triage_path:' <(bd show "$ROOT_ID") | head -1 | sed 's|.*triage/||;s|\\.md$||')
-LIMIT=$(bd show "$ROOT_ID" --json | jq -r '.notes // "" | capture("limit: (?<v>\\\\d+)").v // "10"')
-CATEGORY=$(bd show "$ROOT_ID" --json | jq -r '.notes // "" | capture("category: (?<v>\\\\S+)").v // "all"')
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
+TS=$(grep -A1 'triage_path:' <(gc bd show "$ROOT_ID") | head -1 | sed 's|.*triage/||;s|\\.md$||')
+LIMIT=$(gc bd show "$ROOT_ID" --json | jq -r '.notes // "" | capture("limit: (?<v>\\\\d+)").v // "10"')
+CATEGORY=$(gc bd show "$ROOT_ID" --json | jq -r '.notes // "" | capture("category: (?<v>\\\\S+)").v // "all"')
 ```
 
 **1. Open issues (filtered by category):**
@@ -160,7 +160,7 @@ Record counts:
 ISSUE_COUNT=$(jq 'length' /tmp/triage-issues.json)
 OUR_PR_COUNT=$(jq 'length' /tmp/triage-our-prs.json)
 ALL_PR_COUNT=$(jq 'length' /tmp/triage-all-prs.json)
-bd update "$ROOT_ID" --notes "issue_count: $ISSUE_COUNT
+gc bd update "$ROOT_ID" --notes "issue_count: $ISSUE_COUNT
 our_pr_count: $OUR_PR_COUNT
 all_pr_count: $ALL_PR_COUNT"
 ```
@@ -235,8 +235,8 @@ description = """
 Produce the markdown report at the path recorded in step 1.
 
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
-TRIAGE_PATH=$(bd show "$ROOT_ID" --json | jq -r '.notes // ""' | grep -m1 '^triage_path:' | sed 's/^triage_path: //')
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
+TRIAGE_PATH=$(gc bd show "$ROOT_ID" --json | jq -r '.notes // ""' | grep -m1 '^triage_path:' | sed 's/^triage_path: //')
 ```
 
 Report structure:
@@ -307,7 +307,7 @@ TIER3=$(jq '[.[] | select(.tier==3)] | length' /tmp/triage-classified.json)
 TIER4=$(jq '[.[] | select(.tier==4)] | length' /tmp/triage-classified.json)
 RECOMMENDED=$(jq -r '[.[] | select(.tier <= 2)] | sort_by(.tier, -.priority_score) | .[0].number // "none"' /tmp/triage-classified.json)
 
-bd update "$ROOT_ID" --notes "triage_path: $TRIAGE_PATH
+gc bd update "$ROOT_ID" --notes "triage_path: $TRIAGE_PATH
 tier1: $TIER1
 tier2: $TIER2
 tier3: $TIER3
@@ -328,8 +328,8 @@ Display the report path and recommended pick on stdout for the maintenance
 PL to relay back to Slack:
 
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
-NOTES=$(bd show "$ROOT_ID" --json | jq -r '.notes // ""')
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
+NOTES=$(gc bd show "$ROOT_ID" --json | jq -r '.notes // ""')
 TRIAGE_PATH=$(echo "$NOTES" | grep -m1 '^triage_path:' | sed 's/^triage_path: //')
 TIER1=$(echo "$NOTES" | grep -m1 '^tier1:' | sed 's/^tier1: //')
 TIER2=$(echo "$NOTES" | grep -m1 '^tier2:' | sed 's/^tier2: //')
@@ -345,8 +345,8 @@ cat <<EOF
 [pr-triage] Next: human reviews report, picks an issue, dispatches mol-pr-start.
 EOF
 
-bd update "$ROOT_ID" --notes "status: complete"
-bd close "$ROOT_ID" --reason "triage report written: $TRIAGE_PATH"
+gc bd update "$ROOT_ID" --notes "status: complete"
+gc bd close "$ROOT_ID" --reason "triage report written: $TRIAGE_PATH"
 ```
 
 **Exit criteria:** Report path printed, root bead closed with status:complete.

--- a/scripts/gascity_pack_inference_gate.py
+++ b/scripts/gascity_pack_inference_gate.py
@@ -2175,7 +2175,7 @@ def create_gastown_review_assignment(gc_bin: str, workspace: GateWorkspace, *, e
     bead_id = find_first_key(extract_json_payload(output), ("id", "bead_id"))
     if bead_id:
         return bead_id
-    raise GateError(f"could not determine Gastown review assignment bead id from bd create output:\n{output}")
+    raise GateError(f"could not determine Gastown review assignment bead id from gc bd create output:\n{output}")
 
 
 def launch_gastown_review_leg(

--- a/slack-full/adapter/main.go
+++ b/slack-full/adapter/main.go
@@ -417,7 +417,7 @@ type config struct {
 	oauthSlackBaseURL string
 	// cityPath is the on-disk root of the gc city this adapter is bound
 	// to. Sourced from GC_CITY_PATH; required for the rig-target
-	// dispatch path (cby.18.3) which must shell `bd create` inside the
+	// dispatch path (cby.18.3) which must shell `gc bd create` inside the
 	// rig's workdir (read from <cityPath>/.beads/routes.jsonl) and
 	// `gc sling` from the city root. Empty when GC_CITY_PATH is unset;
 	// the rig dispatch path surfaces a fix-it ephemeral in that case.

--- a/slack-full/adapter/rig_dispatch.go
+++ b/slack-full/adapter/rig_dispatch.go
@@ -342,10 +342,10 @@ func dispatchRigFixFromViewSubmission(
 }
 
 // runRigDispatch performs the two subprocess legs of a rig-target
-// dispatch: `bd create` inside the rig workdir to mint a task bead,
+// dispatch: `gc bd create` inside the rig workdir to mint a task bead,
 // then `gc sling <target> <bead_id> [--on <fix_formula>] [--var k=v]…`
 // from the city root to invoke dispatch. Failures at the gc-sling leg
-// trigger a best-effort `bd close <bead_id> -r dispatch_failed` so the
+// trigger a best-effort `gc bd close <bead_id> -r dispatch_failed` so the
 // orphan task does not show up as queued work.
 //
 // Empty fixFormula deliberately omits the --on flag (cby.18.3 design
@@ -357,38 +357,38 @@ func dispatchRigFixFromViewSubmission(
 // intake (gc-cby.18.4) to pipe captured summary/context_markdown to
 // the dispatched formula.
 func runRigDispatch(workdir, cityPath, target, fixFormula, title, rigName string, vars map[string]string) {
-	beadID, err := runBdCreate(workdir, title)
+	beadID, err := runBdCreate(workdir, cityPath, rigName, title)
 	if err != nil {
-		log.Printf("rig dispatch: bd create in %s rig=%q: %v", workdir, rigName, err)
+		log.Printf("rig dispatch: gc bd create in %s rig=%q: %v", workdir, rigName, err)
 		return
 	}
 	if err := runGcSling(cityPath, target, beadID, fixFormula, vars); err != nil {
 		log.Printf("rig dispatch: gc sling target=%q bead=%s rig=%q: %v",
 			target, beadID, rigName, err)
-		closeOrphanBead(workdir, beadID)
+		closeOrphanBead(workdir, cityPath, rigName, beadID)
 		return
 	}
 	log.Printf("rig dispatch: bead=%s -> sling=%s formula=%q rig=%q OK",
 		beadID, target, fixFormula, rigName)
 }
 
-// runBdCreate invokes `bd create --json <title> -t task` inside the
+// runBdCreate invokes `gc bd create --json <title> -t task` inside the
 // rig workdir and returns the parsed bead id from stdout.
-func runBdCreate(workdir, title string) (string, error) {
-	cmd := dispatchExecCommand("bd", "create", "--json", title, "-t", "task")
+func runBdCreate(workdir, cityPath, rigName, title string) (string, error) {
+	cmd := dispatchExecCommand("gc", "--city", cityPath, "--rig", rigName, "bd", "create", "--json", title, "-t", "task")
 	cmd.Dir = workdir
 	out, err := cmd.Output()
 	if err != nil {
-		return "", fmt.Errorf("bd create exec in %q: %w", workdir, err)
+		return "", fmt.Errorf("gc bd create exec in %q: %w", workdir, err)
 	}
 	var rec struct {
 		ID string `json:"id"`
 	}
 	if err := json.Unmarshal(out, &rec); err != nil {
-		return "", fmt.Errorf("decode bd create output (%q): %w", string(out), err)
+		return "", fmt.Errorf("decode gc bd create output (%q): %w", string(out), err)
 	}
 	if rec.ID == "" {
-		return "", fmt.Errorf("bd create returned empty id (output %q)", string(out))
+		return "", fmt.Errorf("gc bd create returned empty id (output %q)", string(out))
 	}
 	return rec.ID, nil
 }
@@ -427,11 +427,11 @@ func runGcSling(cityPath, target, beadID, fixFormula string, vars map[string]str
 // after `gc sling` failed. Errors are logged and swallowed — the bead
 // is already orphaned at this point and a closure failure is at most a
 // queued-work display nit, not a correctness issue.
-func closeOrphanBead(workdir, beadID string) {
-	cmd := dispatchExecCommand("bd", "close", beadID, "-r", "dispatch_failed")
+func closeOrphanBead(workdir, cityPath, rigName, beadID string) {
+	cmd := dispatchExecCommand("gc", "--city", cityPath, "--rig", rigName, "bd", "close", beadID, "-r", "dispatch_failed")
 	cmd.Dir = workdir
 	if out, err := cmd.CombinedOutput(); err != nil {
-		log.Printf("rig dispatch: bd close %s in %q: %v (output=%q)",
+		log.Printf("rig dispatch: gc bd close %s in %q: %v (output=%q)",
 			beadID, workdir, err, string(out))
 		return
 	}

--- a/slack-full/adapter/rig_dispatch_test.go
+++ b/slack-full/adapter/rig_dispatch_test.go
@@ -26,9 +26,8 @@ type stubExecRecord struct {
 // records the invocations and produces deterministic stdout per command
 // name. It returns a pointer to the recorded slice and a restore func.
 //
-// `bd` invocations emit a JSON line containing {"id": bdID}; `gc`
-// invocations emit a single OK line. Tests asserting failure modes can
-// override behavior by inspecting Name/Args before this stub returns.
+// `gc bd create` invocations emit a JSON line containing {"id": bdID};
+// other `gc bd` invocations emit OK. The gc sling leg uses gcExitCode.
 func installStubExecCommand(t *testing.T, bdID string, gcExitCode int) (*[]stubExecRecord, func()) {
 	t.Helper()
 	prev := dispatchExecCommand
@@ -38,14 +37,23 @@ func installStubExecCommand(t *testing.T, bdID string, gcExitCode int) (*[]stubE
 		records = append(records, stubExecRecord{Name: name, Args: append([]string(nil), args...)})
 
 		// Each invocation routes to a tiny shell script that echoes a
-		// canned line so the dispatcher can parse JSON from `bd create`
+		// canned line so the dispatcher can parse JSON from `gc bd create`
 		// and proceed past `gc sling`.
 		var script string
 		switch name {
-		case "bd":
-			script = "printf '%s\\n' '" + `{"id":"` + bdID + `","title":"x","type":"task"}` + "'"
 		case "gc":
-			if gcExitCode != 0 {
+			bdIndex := -1
+			for i, arg := range args {
+				if arg == "bd" {
+					bdIndex = i
+					break
+				}
+			}
+			if bdIndex >= 0 && bdIndex+1 < len(args) && args[bdIndex+1] == "create" {
+				script = "printf '%s\\n' '" + `{"id":"` + bdID + `","title":"x","type":"task"}` + "'"
+			} else if bdIndex >= 0 {
+				script = "echo ok"
+			} else if gcExitCode != 0 {
 				script = "echo gc-fail >&2; exit 1"
 			} else {
 				script = "echo ok"
@@ -447,7 +455,7 @@ func TestSlackInteractionsRigSlashMissingWorkdir(t *testing.T) {
 // TestSlackInteractionsRigViewSubmissionDispatchesHappyPath — full
 // round-trip: slash opens modal (skipped here; covered by the modal
 // test above), user types summary + context, view_submission with
-// rig_fix metadata fires bd create then gc sling with --var pairs.
+// rig_fix metadata fires gc bd create then gc sling with --var pairs.
 func TestSlackInteractionsRigViewSubmissionDispatchesHappyPath(t *testing.T) {
 	cityPath := t.TempDir()
 	rigDir := filepath.Join(cityPath, "rigs", "alpha")
@@ -518,10 +526,11 @@ func TestSlackInteractionsRigViewSubmissionDispatchesHappyPath(t *testing.T) {
 		t.Fatalf("expected >=2 exec calls, got %+v", *records)
 	}
 
-	// bd create title must contain the user's summary.
+	// gc bd create title must contain the user's summary.
 	bd := (*records)[0]
-	if bd.Name != "bd" || bd.Args[0] != "create" {
-		t.Errorf("first call should be `bd create`; got %+v", bd)
+	if bd.Name != "gc" || len(bd.Args) < 6 || bd.Args[0] != "--city" || bd.Args[1] != cityPath ||
+		bd.Args[2] != "--rig" || bd.Args[3] != "alpha" || bd.Args[4] != "bd" || bd.Args[5] != "create" {
+		t.Errorf("first call should be `gc bd create`; got %+v", bd)
 	}
 	titleSeen := false
 	for _, a := range bd.Args {
@@ -753,7 +762,7 @@ func TestSlackInteractionsRigViewSubmissionRigUnmappedClearsModal(t *testing.T) 
 }
 
 // TestSlackInteractionsRigViewSubmissionGcFailureClosesBead — gc sling
-// fails post-bd-create; the dispatcher invokes bd close
+// fails post-bd-create; the dispatcher invokes gc bd close
 // -r dispatch_failed.
 func TestSlackInteractionsRigViewSubmissionGcFailureClosesBead(t *testing.T) {
 	cityPath := t.TempDir()
@@ -803,11 +812,13 @@ func TestSlackInteractionsRigViewSubmissionGcFailureClosesBead(t *testing.T) {
 		t.Fatal("dispatch goroutine did not finish")
 	}
 	if len(*records) < 3 {
-		t.Fatalf("want >=3 exec records (bd create, gc sling, bd close); got %+v", *records)
+		t.Fatalf("want >=3 exec records (gc bd create, gc sling, gc bd close); got %+v", *records)
 	}
 	last := (*records)[len(*records)-1]
-	if last.Name != "bd" || last.Args[0] != "close" || last.Args[1] != "bd-77" {
-		t.Errorf("expected `bd close bd-77 -r dispatch_failed`; got %+v", last)
+	if last.Name != "gc" || len(last.Args) < 7 || last.Args[0] != "--city" || last.Args[1] != cityPath ||
+		last.Args[2] != "--rig" || last.Args[3] != "alpha" || last.Args[4] != "bd" ||
+		last.Args[5] != "close" || last.Args[6] != "bd-77" {
+		t.Errorf("expected `gc bd close bd-77 -r dispatch_failed`; got %+v", last)
 	}
 }
 
@@ -941,8 +952,9 @@ func TestSlackInteractionsRigDispatchBlockActionsHappyPath(t *testing.T) {
 		t.Fatalf("expected >=2 exec calls; got %+v", *records)
 	}
 	bd := (*records)[0]
-	if bd.Name != "bd" || bd.Args[0] != "create" {
-		t.Errorf("first call should be `bd create`; got %+v", bd)
+	if bd.Name != "gc" || len(bd.Args) < 6 || bd.Args[0] != "--city" || bd.Args[1] != cityPath ||
+		bd.Args[2] != "--rig" || bd.Args[3] != "alpha" || bd.Args[4] != "bd" || bd.Args[5] != "create" {
+		t.Errorf("first call should be `gc bd create`; got %+v", bd)
 	}
 	titleSeen := false
 	for _, a := range bd.Args {

--- a/superpowers/assets/workflows/superpowers-brainstorming/{target}.apply-spec-feedback.md
+++ b/superpowers/assets/workflows/superpowers-brainstorming/{target}.apply-spec-feedback.md
@@ -10,15 +10,15 @@ For every attempt, write an apply summary and, when the artifact changed, a
 diff. Before closing, update the exact claimed bead id with the lane metadata:
 
 ```bash
-bd update "$CLAIMED_BEAD_ID" \
+gc bd update "$CLAIMED_BEAD_ID" \
   --set-metadata 'gc.outcome=pass' \
   --set-metadata 'design_review.output_path=<apply-summary path>' \
   --set-metadata 'design_review.required_changes_applied=false'
-bd close "$CLAIMED_BEAD_ID" --reason 'Superpowers spec feedback pass completed.'
+gc bd close "$CLAIMED_BEAD_ID" --reason 'Superpowers spec feedback pass completed.'
 ```
 
 If required changes were applied, set
-`design_review.required_changes_applied=true` instead. Do not pass `--metadata` or `--set-metadata` to `bd close`. Do not set `design_review.verdict`; the approval lane owns the loop verdict.
+`design_review.required_changes_applied=true` instead. Do not pass `--metadata` or `--set-metadata` to `gc bd close`. Do not set `design_review.verdict`; the approval lane owns the loop verdict.
 
 Do not invoke provider-native subagents. This Gas City lane owns the spec
 feedback pass.

--- a/superpowers/assets/workflows/superpowers-brainstorming/{target}.brainstorm-design.md
+++ b/superpowers/assets/workflows/superpowers-brainstorming/{target}.brainstorm-design.md
@@ -33,13 +33,13 @@ run instructions make that safe.
 Before closing, update the exact claimed bead id with the lane metadata:
 
 ```bash
-bd update "$CLAIMED_BEAD_ID" \
+gc bd update "$CLAIMED_BEAD_ID" \
   --set-metadata 'gc.outcome=pass' \
   --set-metadata 'design_review.output_path=<design-candidate path>'
-bd close "$CLAIMED_BEAD_ID" --reason 'Superpowers design candidate written.'
+gc bd close "$CLAIMED_BEAD_ID" --reason 'Superpowers design candidate written.'
 ```
 
-Do not pass `--metadata` or `--set-metadata` to `bd close`. Do not set
+Do not pass `--metadata` or `--set-metadata` to `gc bd close`. Do not set
 `design_review.verdict`; the approval lane owns the loop verdict.
 
 Do not invoke provider-native subagents or upstream plugin runtime commands.

--- a/superpowers/assets/workflows/superpowers-brainstorming/{target}.confirm-design-approval.md
+++ b/superpowers/assets/workflows/superpowers-brainstorming/{target}.confirm-design-approval.md
@@ -66,17 +66,17 @@ Before closing, update the exact claimed bead id with the lane metadata. The
 approval verdict metadata is `design_review.verdict=done|iterate`:
 
 ```bash
-bd update "$CLAIMED_BEAD_ID" \
+gc bd update "$CLAIMED_BEAD_ID" \
   --set-metadata 'gc.outcome=pass' \
   --set-metadata 'design_review.verdict=done' \
   --set-metadata 'design_review.output_path=<approval-summary path>' \
   --set-metadata 'gc.continuation_group=superpowers-design-fixes'
-bd close "$CLAIMED_BEAD_ID" --reason 'Superpowers design approved.'
+gc bd close "$CLAIMED_BEAD_ID" --reason 'Superpowers design approved.'
 ```
 
 If the design needs another pass, set `design_review.verdict=iterate` instead
 of `done` and name the required correction in the approval summary and close
-reason. Do not pass `--metadata` or `--set-metadata` to `bd close`.
+reason. Do not pass `--metadata` or `--set-metadata` to `gc bd close`.
 
 Do not invoke provider-native subagents or upstream plugin runtime commands.
 This Gas City lane owns the design approval decision.

--- a/superpowers/assets/workflows/superpowers-brainstorming/{target}.confirm-spec-approval.md
+++ b/superpowers/assets/workflows/superpowers-brainstorming/{target}.confirm-spec-approval.md
@@ -1,33 +1,33 @@
 Confirm Superpowers spec approval.
 
 HARD STOP: this bead is not complete until the exact claimed bead id has
-terminal metadata and that metadata has been read back from `bd show`. Closing
+terminal metadata and that metadata has been read back from `gc bd show`. Closing
 without `gc.outcome`, `design_review.verdict`, and
 `design_review.output_path` makes the approval loop retry forever.
 
 Do not run `.gc/scripts/checks/design-review-approved.sh` before writing this
 bead's terminal metadata; that script checks this approval bead and will report
 that another pass is needed until `design_review.verdict` is present. Do not use
-`bd update --metadata` for this lane. Use `--set-metadata` exactly as shown
+`gc bd update --metadata` for this lane. Use `--set-metadata` exactly as shown
 below so the workflow step outcome and approval metadata are all present.
 
 If autonomous approval conditions are satisfied, the final action must be this
 shape. Replace only `<approval-summary path>` after writing the summary:
 
 ```bash
-bd update "$CLAIMED_BEAD_ID" \
+gc bd update "$CLAIMED_BEAD_ID" \
   --set-metadata 'gc.outcome=pass' \
   --set-metadata 'design_review.verdict=done' \
   --set-metadata 'design_review.output_path=<approval-summary path>' \
   --set-metadata 'design_review.approval_mode=autonomous' \
   --set-metadata 'gc.continuation_group=superpowers-spec-fixes'
-bd show "$CLAIMED_BEAD_ID" --json | jq -e '
+gc bd show "$CLAIMED_BEAD_ID" --json | jq -e '
   (if type == "array" then .[0] else . end) as $bead |
   $bead.metadata["gc.outcome"] == "pass" and
   $bead.metadata["design_review.verdict"] == "done" and
   ($bead.metadata["design_review.output_path"] | type == "string" and length > 0)
 '
-bd close "$CLAIMED_BEAD_ID" --reason 'Superpowers spec approved.'
+gc bd close "$CLAIMED_BEAD_ID" --reason 'Superpowers spec approved.'
 ```
 
 This lane represents the stock `User reviews spec?` approval gate after the
@@ -83,18 +83,18 @@ the apply pass made no required changes in this attempt, and the requirements
 artifact has no unresolved questions. Otherwise close with
 `design_review.verdict=iterate`.
 
-Use the supported `bd list` metadata filters below to inspect predecessor lanes.
-Do not use `bd list --root`; that flag is not supported by the Beads CLI.
+Use the supported `gc bd list` metadata filters below to inspect predecessor lanes.
+Do not use `gc bd list --root`; that flag is not supported by the Beads CLI.
 Select only `gc.scope_role=member` so scope-check control beads do not get
 mistaken for the review or apply lane:
 
 ```bash
-bd list --all --has-metadata-key gc.step_id \
+gc bd list --all --has-metadata-key gc.step_id \
   --metadata-field gc.root_bead_id="$CLAIMED_ROOT_BEAD_ID" \
   --metadata-field gc.step_id=requirements.review-written-spec \
   --metadata-field gc.scope_role=member \
   --json
-bd list --all --has-metadata-key gc.step_id \
+gc bd list --all --has-metadata-key gc.step_id \
   --metadata-field gc.root_bead_id="$CLAIMED_ROOT_BEAD_ID" \
   --metadata-field gc.step_id=requirements.apply-spec-feedback \
   --metadata-field gc.scope_role=member \
@@ -114,32 +114,32 @@ metadata with `gc.build.requirements_status=approved`,
 human-requested iteration, update `gc.build.spec_gate_status=revision_requested`.
 
 Before closing, update the exact claimed bead id with the lane metadata, then
-verify it from `bd show "$CLAIMED_BEAD_ID" --json`. The approval verdict
+verify it from `gc bd show "$CLAIMED_BEAD_ID" --json`. The approval verdict
 metadata is `design_review.verdict=done|iterate`; for approval, verify
 `design_review.verdict == "done"`:
 
 ```bash
-bd update "$CLAIMED_BEAD_ID" \
+gc bd update "$CLAIMED_BEAD_ID" \
   --set-metadata 'gc.outcome=pass' \
   --set-metadata 'design_review.verdict=done' \
   --set-metadata 'design_review.output_path=<approval-summary path>' \
   --set-metadata 'design_review.approval_mode=autonomous' \
   --set-metadata 'gc.continuation_group=superpowers-spec-fixes'
-bd show "$CLAIMED_BEAD_ID" --json | jq -e '
+gc bd show "$CLAIMED_BEAD_ID" --json | jq -e '
   (if type == "array" then .[0] else . end) as $bead |
   $bead.metadata["gc.outcome"] == "pass" and
   $bead.metadata["design_review.verdict"] == "done" and
   ($bead.metadata["design_review.output_path"] | type == "string" and length > 0)
 '
-bd close "$CLAIMED_BEAD_ID" --reason 'Superpowers spec approved.'
+gc bd close "$CLAIMED_BEAD_ID" --reason 'Superpowers spec approved.'
 ```
 
 If the spec needs another pass, set `design_review.verdict=iterate` instead of
 `done` and name the required correction in the approval summary and close
 reason. For iteration, run the same read-back check with
 `.metadata["design_review.verdict"] == "iterate"`. If the read-back check
-fails, do not close the bead; rerun `bd update "$CLAIMED_BEAD_ID"` and verify
-again. Do not pass `--metadata` or `--set-metadata` to `bd close`.
+fails, do not close the bead; rerun `gc bd update "$CLAIMED_BEAD_ID"` and verify
+again. Do not pass `--metadata` or `--set-metadata` to `gc bd close`.
 
 Do not invoke provider-native subagents or upstream plugin runtime commands.
 This Gas City lane owns the approval decision.

--- a/superpowers/assets/workflows/superpowers-brainstorming/{target}.review-written-spec.md
+++ b/superpowers/assets/workflows/superpowers-brainstorming/{target}.review-written-spec.md
@@ -15,16 +15,16 @@ directory. Required issues must be concrete and actionable.
 Before closing, update the exact claimed bead id with the lane metadata:
 
 ```bash
-bd update "$CLAIMED_BEAD_ID" \
+gc bd update "$CLAIMED_BEAD_ID" \
   --set-metadata 'gc.outcome=pass' \
   --set-metadata 'design_review.review_verdict=approve' \
   --set-metadata 'design_review.output_path=<spec review artifact path>'
-bd close "$CLAIMED_BEAD_ID" --reason 'Superpowers written spec review approved.'
+gc bd close "$CLAIMED_BEAD_ID" --reason 'Superpowers written spec review approved.'
 ```
 
 If required issues remain, set `design_review.review_verdict=iterate` instead
 of `approve` and name the smallest required correction in the report and close
-reason. Do not pass `--metadata` or `--set-metadata` to `bd close`. Do not set
+reason. Do not pass `--metadata` or `--set-metadata` to `gc bd close`. Do not set
 `design_review.verdict`; the feedback and approval lanes own the loop verdict.
 
 Do not invoke provider-native subagents. You are the Gas City spec document

--- a/superpowers/assets/workflows/superpowers-brainstorming/{target}.write-requirements-spec.md
+++ b/superpowers/assets/workflows/superpowers-brainstorming/{target}.write-requirements-spec.md
@@ -36,14 +36,14 @@ commit from this lane unless the routed bead explicitly asks for it.
 Before closing, update the exact claimed bead id with the lane metadata:
 
 ```bash
-bd update "$CLAIMED_BEAD_ID" \
+gc bd update "$CLAIMED_BEAD_ID" \
   --set-metadata 'gc.outcome=pass' \
   --set-metadata 'design_review.output_path=<requirements artifact path>' \
   --set-metadata 'design_review.self_review_passed=true'
-bd close "$CLAIMED_BEAD_ID" --reason 'Superpowers requirements spec written and self-reviewed.'
+gc bd close "$CLAIMED_BEAD_ID" --reason 'Superpowers requirements spec written and self-reviewed.'
 ```
 
-Do not pass `--metadata` or `--set-metadata` to `bd close`. Do not set
+Do not pass `--metadata` or `--set-metadata` to `gc bd close`. Do not set
 `design_review.verdict`; the approval lane owns the loop verdict.
 
 Do not invoke provider-native subagents or upstream plugin runtime commands.

--- a/superpowers/assets/workflows/superpowers-build/decompose.md
+++ b/superpowers/assets/workflows/superpowers-build/decompose.md
@@ -31,7 +31,7 @@ member and record the skipped lifecycle sections in the decomposition artifact.
 Create or update the implementation convoy with those beads and dependency
 edges. Record the implementation convoy ID on the workflow root bead as
 `gc.input_convoy_id=<implementation-convoy-id>` with
-`bd update <workflow-root-id> --set-metadata gc.input_convoy_id=<implementation-convoy-id>`.
+`gc bd update <workflow-root-id> --set-metadata gc.input_convoy_id=<implementation-convoy-id>`.
 
 Write a decomposition artifact that maps every plan task to its bead ID and
 dependency edges. Close this step only after the decomposition artifact exists,

--- a/superpowers/assets/workflows/superpowers-code-review/{target}.gap-analysis-review.md
+++ b/superpowers/assets/workflows/superpowers-code-review/{target}.gap-analysis-review.md
@@ -71,16 +71,16 @@ Close with `gc.outcome=pass`, `code_review.gap_verdict=approve|iterate`,
 `code_review.output_path=<gap-analysis report path>`.
 
 Use the exact claimed bead id when updating metadata. Do not pass freeform notes
-or additional positional arguments to `bd update`; unquoted words can resolve to
+or additional positional arguments to `gc bd update`; unquoted words can resolve to
 unrelated beads. Use this command shape:
 
 ```bash
-bd update "$CLAIMED_BEAD_ID" \
+gc bd update "$CLAIMED_BEAD_ID" \
   --set-metadata 'gc.outcome=pass' \
   --set-metadata 'code_review.gap_verdict=approve' \
   --set-metadata 'code_review.gap_report_path=<gap-analysis report path>' \
   --set-metadata 'code_review.output_path=<gap-analysis report path>'
-bd close "$CLAIMED_BEAD_ID" --reason 'Gap-analysis review approved with no required findings.'
+gc bd close "$CLAIMED_BEAD_ID" --reason 'Gap-analysis review approved with no required findings.'
 ```
 
 Do not set `code_review.verdict` or `code_review.report_path`; the

--- a/superpowers/assets/workflows/superpowers-code-review/{target}.process-code-review.md
+++ b/superpowers/assets/workflows/superpowers-code-review/{target}.process-code-review.md
@@ -37,16 +37,16 @@ Always close with `gc.outcome=pass`, `code_review.verdict=done|iterate`,
 `code_review.output_path=<review fix summary path>`.
 
 Use the exact claimed bead id when updating metadata. Do not pass freeform notes
-or additional positional arguments to `bd update`; unquoted words can resolve to
+or additional positional arguments to `gc bd update`; unquoted words can resolve to
 unrelated beads. Use this command shape:
 
 ```bash
-bd update "$CLAIMED_BEAD_ID" \
+gc bd update "$CLAIMED_BEAD_ID" \
   --set-metadata 'gc.outcome=pass' \
   --set-metadata 'code_review.verdict=done' \
   --set-metadata 'code_review.report_path=<review fix summary path>' \
   --set-metadata 'code_review.output_path=<review fix summary path>'
-bd close "$CLAIMED_BEAD_ID" --reason 'Code-review feedback processed and approved.'
+gc bd close "$CLAIMED_BEAD_ID" --reason 'Code-review feedback processed and approved.'
 ```
 
 Do not invoke provider-native subagents. This graph lane is the delegation

--- a/superpowers/assets/workflows/superpowers-code-review/{target}.request-code-review.md
+++ b/superpowers/assets/workflows/superpowers-code-review/{target}.request-code-review.md
@@ -69,16 +69,16 @@ Close with `gc.outcome=pass`,
 `code_review.output_path=<implementation review report path>`.
 
 Use the exact claimed bead id when updating metadata. Do not pass freeform notes
-or additional positional arguments to `bd update`; unquoted words can resolve to
+or additional positional arguments to `gc bd update`; unquoted words can resolve to
 unrelated beads. Use this command shape:
 
 ```bash
-bd update "$CLAIMED_BEAD_ID" \
+gc bd update "$CLAIMED_BEAD_ID" \
   --set-metadata 'gc.outcome=pass' \
   --set-metadata 'code_review.review_verdict=approve' \
   --set-metadata 'code_review.review_report_path=<implementation review report path>' \
   --set-metadata 'code_review.output_path=<implementation review report path>'
-bd close "$CLAIMED_BEAD_ID" --reason 'Implementation review approved with no required findings.'
+gc bd close "$CLAIMED_BEAD_ID" --reason 'Implementation review approved with no required findings.'
 ```
 
 Do not set `code_review.verdict` or `code_review.report_path`; the

--- a/superpowers/assets/workflows/superpowers-task-review/{target}.apply-code-quality-findings.md
+++ b/superpowers/assets/workflows/superpowers-task-review/{target}.apply-code-quality-findings.md
@@ -17,16 +17,16 @@ Always close with `gc.outcome=pass`,
 `code_review.output_path=<task review summary path>`.
 
 Use the exact claimed bead id when updating metadata. Do not pass freeform notes
-or additional positional arguments to `bd update`; unquoted words can resolve to
+or additional positional arguments to `gc bd update`; unquoted words can resolve to
 unrelated beads. Use this command shape:
 
 ```bash
-bd update "$CLAIMED_BEAD_ID" \
+gc bd update "$CLAIMED_BEAD_ID" \
   --set-metadata 'gc.outcome=pass' \
   --set-metadata 'code_review.verdict=done' \
   --set-metadata 'code_review.report_path=<task review summary path>' \
   --set-metadata 'code_review.output_path=<task review summary path>'
-bd close "$CLAIMED_BEAD_ID" --reason 'Superpowers task review approved.'
+gc bd close "$CLAIMED_BEAD_ID" --reason 'Superpowers task review approved.'
 ```
 
 Do not invoke provider-native subagents. This Gas City fanout lane is the

--- a/superpowers/template-fragments/gc-role-worker.template.md
+++ b/superpowers/template-fragments/gc-role-worker.template.md
@@ -195,7 +195,8 @@ verdict is `iterate`, `changes_required`, or similar.
 
 If later terminal commands do not inherit shell variables, use the explicit
 `CLAIMED_BEAD_ID`, `CLAIMED_ROOT_BEAD_ID`, and
-`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `gc bd update` or `gc bd close` with an empty id.
+`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run
+`gc bd update` or `gc bd close` with an empty id.
 
 When updating or closing a bead, pass exactly one explicit claimed bead id.
 Quote every metadata assignment and close reason. Do not put freeform prose or

--- a/superpowers/template-fragments/gc-role-worker.template.md
+++ b/superpowers/template-fragments/gc-role-worker.template.md
@@ -7,14 +7,14 @@ You are `{{ .AgentName }}`, a Gas City `graph.v2` role worker for template
 ## Core Rule
 
 You work only the routed bead assigned to this live session. Do not use
-`bd mol current` to infer workflow position. Do not assume a parent bead or
+`gc bd mol current` to infer workflow position. Do not assume a parent bead or
 root bead describes your work. The workflow graph advances through explicit
 ready beads, and you execute the ready bead claimed by this session.
 
 ## Startup Claim Protocol
 
 `gc hook --claim --json` is the only permitted discovery source for routed
-workflow work. Do not run broad `bd ready`, `bd list`, root-bead searches,
+workflow work. Do not run broad `gc bd ready`, `gc bd list`, root-bead searches,
 metadata searches, mail inspection, session-log inspection, or repository
 context gathering to find a bead. Never work a bead id unless it came from the
 immediately preceding `gc hook --claim --json` result in this claim block.
@@ -109,7 +109,7 @@ while true; do
   fi
 
   SHOW_ERR="$(mktemp)"
-  if ! SHOW_JSON="$(bd show "$WORK_ID" --json 2>"$SHOW_ERR")"; then
+  if ! SHOW_JSON="$(gc bd show "$WORK_ID" --json 2>"$SHOW_ERR")"; then
     SHOW_ERR_TEXT="$(sed -n '1p' "$SHOW_ERR")"
     rm -f "$SHOW_ERR"
     if [ -n "$SHOW_ERR_TEXT" ]; then
@@ -167,7 +167,7 @@ export GC_CONTINUATION_GROUP="$CLAIM_GROUP"
 printf 'CLAIMED_BEAD_ID=%s\n' "$WORK_ID"
 printf 'CLAIMED_ROOT_BEAD_ID=%s\n' "$CLAIM_ROOT"
 printf 'CLAIMED_CONTINUATION_GROUP=%s\n' "$CLAIM_GROUP"
-bd show "$GC_BEAD_ID"
+gc bd show "$GC_BEAD_ID"
 GC_CLAIM
 ```
 
@@ -178,14 +178,14 @@ Close it with the requested `gc.outcome` metadata. If the bead does not specify
 a failure contract, mark an unrecoverable failure with `gc.outcome=fail` and a
 concise `gc.failure_class`/reason before closing it.
 
-Never use a bare `bd close` for a bead that asks for close metadata. First set
+Never use `gc bd close` for a bead that asks for close metadata. First set
 the requested metadata on the claimed bead, then close the same bead id:
 
 ```bash
-bd update "$GC_BEAD_ID" \
+gc bd update "$GC_BEAD_ID" \
   --set-metadata 'gc.outcome=pass' \
   --set-metadata 'example.key=example-value'
-bd close "$GC_BEAD_ID"
+gc bd close "$GC_BEAD_ID"
 ```
 
 Finding review issues, missing tests, or required follow-up is usually the
@@ -195,13 +195,12 @@ verdict is `iterate`, `changes_required`, or similar.
 
 If later terminal commands do not inherit shell variables, use the explicit
 `CLAIMED_BEAD_ID`, `CLAIMED_ROOT_BEAD_ID`, and
-`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `bd
-update` or `bd close` with an empty id.
+`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `gc bd update` or `gc bd close` with an empty id.
 
 When updating or closing a bead, pass exactly one explicit claimed bead id.
 Quote every metadata assignment and close reason. Do not put freeform prose or
 bare words after the bead id; `bd` treats every extra positional argument as
-another issue id and may fuzzy-match unrelated beads. Use `bd close
+another issue id and may fuzzy-match unrelated beads. Use `gc bd close
 "$CLAIMED_BEAD_ID" --reason '...'` for close notes.
 
 ## Continuation Group Protocol

--- a/tests/test_gascity_pack_inference_gate.py
+++ b/tests/test_gascity_pack_inference_gate.py
@@ -582,10 +582,10 @@ def test_wait_for_workflow_pass_uses_bd_show_for_closed_root(tmp_path) -> None:
         f"""#!/bin/sh
 printf '%s\\n' "$*" >> {shlex.quote(str(args_path))}
 case "$*" in
-  *"bd show fi-root --json"*)
+  *"bd show fi-root --json"*) # gc-bd-argv-tail: fake gc receives the wrapper's argv tail
     printf '[{{"id":"fi-root","title":"root","status":"closed","metadata":{{"gc.outcome":"pass"}}}}]\\n'
     ;;
-  *"bd list --json --limit 1000"*)
+  *"bd list --json --limit 1000"*) # gc-bd-argv-tail: fake gc receives the wrapper's argv tail
     printf '[{{"id":"fi-other","title":"other","status":"open"}}]\\n'
     ;;
   *)
@@ -607,7 +607,7 @@ esac
     )
 
     assert bead["id"] == "fi-root"
-    assert "bd show fi-root --json" in args_path.read_text(encoding="utf-8")
+    assert "bd show fi-root --json" in args_path.read_text(encoding="utf-8")  # gc-bd-argv-tail
 
 
 def test_validate_review_report_requires_blocking_base_gascity_report(tmp_path) -> None:

--- a/tests/test_no_bare_bd_commands.py
+++ b/tests/test_no_bare_bd_commands.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+import re
+import subprocess
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+THIS_FILE = Path(__file__).resolve()
+
+BD_SUBCOMMANDS = (
+    "admin",
+    "ado",
+    "assign",
+    "audit",
+    "backup",
+    "batch",
+    "blocked",
+    "bootstrap",
+    "branch",
+    "children",
+    "close",
+    "comment",
+    "comments",
+    "compact",
+    "completion",
+    "config",
+    "context",
+    "cook",
+    "count",
+    "create",
+    "create-form",
+    "defer",
+    "delete",
+    "dep",
+    "diff",
+    "doctor",
+    "dolt",
+    "duplicate",
+    "duplicates",
+    "edit",
+    "epic",
+    "export",
+    "federation",
+    "find-duplicates",
+    "flatten",
+    "forget",
+    "formula",
+    "gate",
+    "gc",
+    "github",
+    "gitlab",
+    "graph",
+    "heartbeat",
+    "help",
+    "history",
+    "hooks",
+    "human",
+    "import",
+    "info",
+    "init",
+    "init-safety",
+    "jira",
+    "kv",
+    "label",
+    "linear",
+    "link",
+    "list",
+    "lint",
+    "mail",
+    "memories",
+    "merge-slot",
+    "meta",
+    "metrics",
+    "migrate",
+    "migrate-personal",
+    "mol",
+    "note",
+    "notion",
+    "onboard",
+    "orphans",
+    "ping",
+    "preflight",
+    "prime",
+    "priority",
+    "promote",
+    "prune",
+    "purge",
+    "q",
+    "query",
+    "quickstart",
+    "ready",
+    "recall",
+    "reclaim",
+    "recompute-blocked",
+    "remember",
+    "rename-prefix",
+    "rename",
+    "reopen",
+    "repo",
+    "restore",
+    "rules",
+    "search",
+    "set-state",
+    "setup",
+    "show",
+    "ship",
+    "sql",
+    "stale",
+    "state",
+    "status",
+    "statuses",
+    "supersede",
+    "swarm",
+    "sync",
+    "tag",
+    "todo",
+    "type",
+    "types",
+    "unclaim",
+    "undefer",
+    "update",
+    "upgrade",
+    "vc",
+    "version",
+    "where",
+    "worktree",
+)
+BD_SUBCOMMAND_PATTERN = "|".join(re.escape(command) for command in BD_SUBCOMMANDS)
+BARE_BD_COMMAND = re.compile(rf"\bbd[ \t]+(?:{BD_SUBCOMMAND_PATTERN})\b")
+MULTILINE_BARE_BD_COMMAND = re.compile(
+    rf"\bbd[ \t]*\r?\n[ \t]*(?:{BD_SUBCOMMAND_PATTERN})\b"
+)
+BARE_BD_GO_EXEC = re.compile(
+    r'(?:exec\.Command(?:Context)?|dispatchExecCommand)\(\s*["\']bd["\']'
+)
+BARE_BD_PATH_CHECK = re.compile(r"\bcommand[ \t]+-v[ \t]+bd\b")
+BARE_BD_SERIALIZED_ARGV = re.compile(
+    rf'''(?:\[|\{{|=|:)[ \t]*["']bd["'][ \t]*,[ \t]*["'](?:{BD_SUBCOMMAND_PATTERN})["']'''
+)
+GC_BD_ARGV_TAIL_MARKER = "gc-bd-argv-tail"
+
+
+def tracked_files() -> list[Path]:
+    result = subprocess.run(
+        ["git", "ls-files", "-z"],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+    )
+    return [REPO_ROOT / path for path in result.stdout.decode().split("\0") if path]
+
+
+def python_argv_violations(path: Path, text: str) -> list[str]:
+    if path.suffix != ".py":
+        return []
+    tree = ast.parse(text, filename=str(path))
+    violations = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.List, ast.Tuple)) or not node.elts:
+            continue
+        first = node.elts[0]
+        if isinstance(first, ast.Constant) and first.value == "bd":
+            violations.append(f"{path.relative_to(REPO_ROOT)}:{node.lineno}: argv starts with bd")
+    return violations
+
+
+def bare_bd_violations(path: Path, text: str) -> list[str]:
+    violations = []
+    relative = path.relative_to(REPO_ROOT)
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        if GC_BD_ARGV_TAIL_MARKER in line:
+            continue
+        for match in BARE_BD_COMMAND.finditer(line):
+            before = line[: match.start()]
+            if re.search(r"\bgc[ \t]+$", before):
+                continue
+            violations.append(f"{relative}:{line_number}: {line.strip()}")
+        if BARE_BD_GO_EXEC.search(line):
+            violations.append(f"{relative}:{line_number}: direct bd argv")
+        if BARE_BD_PATH_CHECK.search(line):
+            violations.append(f"{relative}:{line_number}: checks bd instead of gc")
+        if BARE_BD_SERIALIZED_ARGV.search(line):
+            violations.append(f"{relative}:{line_number}: serialized argv starts with bd")
+        if "BD_BIN" in line:
+            violations.append(f"{relative}:{line_number}: BD_BIN bypasses gc bd routing")
+    for match in MULTILINE_BARE_BD_COMMAND.finditer(text):
+        if re.search(r"\bgc[ \t]+$", text[: match.start()]):
+            continue
+        line_number = text.count("\n", 0, match.start()) + 1
+        violations.append(f"{relative}:{line_number}: bd command is split across lines")
+    violations.extend(python_argv_violations(path, text))
+    return violations
+
+
+def test_shipped_pack_assets_route_beads_commands_through_gc() -> None:
+    violations = []
+    for path in tracked_files():
+        if path.resolve() == THIS_FILE:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        violations.extend(bare_bd_violations(path, text))
+
+    assert not violations, "bare bd commands bypass store-aware routing:\n" + "\n".join(violations)
+
+
+def test_detector_covers_shell_multiline_and_serialized_argv_forms() -> None:
+    fixture = REPO_ROOT / "fixture.txt"
+
+    assert bare_bd_violations(fixture, 'command = ["bd", "show"]')
+    assert bare_bd_violations(fixture, "value=$(bd\n  list --json)")
+    assert not bare_bd_violations(fixture, 'command = ["gc", "bd", "show"]')


### PR DESCRIPTION
## Summary
- route pack prompts, formulas, scripts, and examples through the store-aware `gc bd` wrapper
- preserve explicit city/rig scope in Discord, GitHub, and Slack runtime adapter command vectors
- add a repository-wide guard covering shell, multiline, Python, Go, and serialized argv forms

## Why
Bare `bd` can stay pinned to the wrong Dolt store when workflow graph beads and rig-local beads live in different scopes. Routing every shipped command through `gc bd` prevents review/triage treadmill stalls.

## Verification
- `python3 -m pytest tests contributing/tests gascity/tests discord/tests github/tests slack-full/tests slack-channel/tests pr-pipeline/tests -q` (732 passed, 11082 subtests)
- `python3 -m pytest -q tests/test_no_bare_bd_commands.py gascity/tests/test_formula_assets.py`
- Gastown pack/theme/churn-watcher shell suites
- Go suites for root embed, Slack full adapter/CLI, Slack channel, Slack mini, and runtime-cloudflare
- `python3 validate_registry.py registry.toml`
- `git diff --check`