### PR TITLE
Route design-pack beads commands through gc bd

### DIFF
--- a/gascity/assets/scripts/checks/design-review-approved.sh
+++ b/gascity/assets/scripts/checks/design-review-approved.sh
@@ -9,7 +9,7 @@ if [ -z "$BEAD_ID" ]; then
     exit 1
 fi
 
-BEAD_JSON=$(bd show "$BEAD_ID" --json 2>/dev/null)
+BEAD_JSON=$(gc bd show "$BEAD_ID" --json 2>/dev/null)
 ROOT_ID=$(printf '%s\n' "$BEAD_JSON" | jq -r 'if type == "array" then (.[0].metadata["gc.root_bead_id"] // "") else (.metadata["gc.root_bead_id"] // "") end')
 ATTEMPT=$(printf '%s\n' "$BEAD_JSON" | jq -r 'if type == "array" then (.[0].metadata["gc.attempt"] // "") else (.metadata["gc.attempt"] // "") end')
 if [ -z "$ROOT_ID" ]; then
@@ -18,7 +18,7 @@ if [ -z "$ROOT_ID" ]; then
 fi
 
 VERDICT=$(
-    bd list --all --metadata-field "gc.root_bead_id=$ROOT_ID" --json --limit=0 2>/dev/null |
+    gc bd list --all --metadata-field "gc.root_bead_id=$ROOT_ID" --json --limit=0 2>/dev/null |
         jq -r --arg root "$ROOT_ID" --arg attempt "$ATTEMPT" '
             [
               .[]

--- a/gascity/assets/scripts/checks/gap-analysis-approved.sh
+++ b/gascity/assets/scripts/checks/gap-analysis-approved.sh
@@ -22,13 +22,13 @@ metadata_value() {
   ' 2>/dev/null
 }
 
-ROOT_JSON="$(bd show "$ROOT_ID" --json 2>/dev/null || true)"
+ROOT_JSON="$(gc bd show "$ROOT_ID" --json 2>/dev/null || true)"
 PARENT_ROOT="$(metadata_value "$ROOT_JSON" "gc.root_bead_id")"
 if [ -z "$PARENT_ROOT" ]; then
   PARENT_ROOT="$ROOT_ID"
 fi
 
-MATCHES="$(bd list --all --metadata-field "gc.root_bead_id=$PARENT_ROOT" --json --limit=0 2>/dev/null || printf '[]')"
+MATCHES="$(gc bd list --all --metadata-field "gc.root_bead_id=$PARENT_ROOT" --json --limit=0 2>/dev/null || printf '[]')"
 
 VERDICT="$(printf '%s\n' "$MATCHES" | jq -r --arg attempt "$ATTEMPT" '
   [

--- a/gascity/assets/scripts/checks/implementation-review-approved.sh
+++ b/gascity/assets/scripts/checks/implementation-review-approved.sh
@@ -22,13 +22,13 @@ metadata_value() {
   ' 2>/dev/null
 }
 
-ROOT_JSON="$(bd show "$ROOT_ID" --json 2>/dev/null || true)"
+ROOT_JSON="$(gc bd show "$ROOT_ID" --json 2>/dev/null || true)"
 PARENT_ROOT="$(metadata_value "$ROOT_JSON" "gc.root_bead_id")"
 if [ -z "$PARENT_ROOT" ]; then
   PARENT_ROOT="$ROOT_ID"
 fi
 
-MATCHES="$(bd list --all --metadata-field "gc.root_bead_id=$PARENT_ROOT" --json --limit=0 2>/dev/null || printf '[]')"
+MATCHES="$(gc bd list --all --metadata-field "gc.root_bead_id=$PARENT_ROOT" --json --limit=0 2>/dev/null || printf '[]')"
 
 VERDICT="$(printf '%s\n' "$MATCHES" | jq -r --arg attempt "$ATTEMPT" '
   [

--- a/gascity/assets/workflows/do-work/close-source-anchor.md
+++ b/gascity/assets/workflows/do-work/close-source-anchor.md
@@ -4,7 +4,7 @@ summary evidence are present in that worktree. Write per-item summary to
 {{summary_path}} when set.
 
 On success, close only `<source-anchor-id>` with `gc.outcome=pass`. Read the
-source anchor back with `bd show <source-anchor-id> --json` and verify
+source anchor back with `gc bd show <source-anchor-id> --json` and verify
 `status=closed` and `gc.outcome=pass`; if either check fails, fix the source
 anchor before closing this step. Then close this step. Do not close the
 drain-unit convoy, parent convoy, or broader workflow root from this step.

--- a/gascity/assets/workflows/do-work/prepare-worktree.md
+++ b/gascity/assets/workflows/do-work/prepare-worktree.md
@@ -3,10 +3,10 @@ Resolve and publish the isolated worktree for this item. This is infrastructure
 setup only. Do not edit source files in the launcher checkout.
 
 1. Read current step bead metadata and get `gc.root_bead_id`; hard-fail if it is
-   missing. Read that do-work root with `bd show <root-bead-id> --json`.
+   missing. Read that do-work root with `gc bd show <root-bead-id> --json`.
 2. Resolve `<source-anchor-id>` from the do-work root:
    - read root metadata `gc.input_convoy_id`; hard-fail if it is missing
-   - read that input convoy with `bd show <input-convoy-id> --json`
+   - read that input convoy with `gc bd show <input-convoy-id> --json`
    - if input convoy metadata has `gc.synthetic_kind=drain-unit-convoy`, use
      input convoy metadata `gc.drain_member_id`
    - otherwise use `<input-convoy-id>` as the source anchor
@@ -19,6 +19,6 @@ setup only. Do not edit source files in the launcher checkout.
    `git worktree add "$WORKTREE" --detach HEAD`. If the path exists but is not
    the worktree for this repository, fail closed.
 5. Persist the absolute path on the source anchor with
-   `bd update <source-anchor-id> --set-metadata work_dir=<absolute worktree path>`.
+   `gc bd update <source-anchor-id> --set-metadata work_dir=<absolute worktree path>`.
    Verify the source anchor now has `work_dir` before closing this step with
    `gc.outcome=pass`.

--- a/gascity/assets/workflows/github-issue-fix-base/resume-or-create-run.md
+++ b/gascity/assets/workflows/github-issue-fix-base/resume-or-create-run.md
@@ -18,7 +18,7 @@ directory is known, resolve these absolute paths under that run directory:
 Then publish all path metadata on the workflow root in one update:
 
 ```bash
-bd update <root-bead-id> \
+gc bd update <root-bead-id> \
   --set-metadata gc.github.run_dir=<absolute run directory> \
   --set-metadata gc.github.requirements_path=<absolute requirements.md path> \
   --set-metadata gc.github.implementation_plan_path=<absolute implementation-plan.md path> \

--- a/gascity/assets/workflows/github-issue-fix-base/snapshot.md
+++ b/gascity/assets/workflows/github-issue-fix-base/snapshot.md
@@ -28,7 +28,7 @@ Then create or refresh the canonical GitHub source bead using this v0 contract:
 - Source beads are non-runnable index/cache beads. Do not route the source bead,
   assign it, depend on it, or use it as a readiness gate.
 - Lookup uses object identity only:
-  `bd list --metadata-field gc.kind=github_source --metadata-field gc.github.kind=issue --metadata-field gc.github.repo=<owner>/<repo> --metadata-field gc.github.number=<number> --status open,in_progress,closed --limit 1 --json`.
+  `gc bd list --metadata-field gc.kind=github_source --metadata-field gc.github.kind=issue --metadata-field gc.github.repo=<owner>/<repo> --metadata-field gc.github.number=<number> --status open,in_progress,closed --limit 1 --json`.
 - Write `source-metadata.json` with flat string metadata:
   `gc.kind=github_source`, `gc.github.kind=issue`,
   `gc.github.repo=<owner>/<repo>`, `gc.github.number=<number>`,
@@ -39,9 +39,9 @@ Then create or refresh the canonical GitHub source bead using this v0 contract:
   `gc.github.snapshot_path=<absolute source.json path>`,
   `gc.github.updated_at=<updated_at>`.
 - If no bead exists, create it with
-  `bd create "GitHub issue source: <owner>/<repo>#<number>" --type task --labels gc.github-source,gc.github-issue --external-ref <canonical_url> --metadata @source-metadata.json`.
+  `gc bd create "GitHub issue source: <owner>/<repo>#<number>" --type task --labels gc.github-source,gc.github-issue --external-ref <canonical_url> --metadata @source-metadata.json`.
 - If a bead exists, refresh it with
-  `bd update <source-bead-id> --external-ref <canonical_url> --metadata @source-metadata.json`.
+  `gc bd update <source-bead-id> --external-ref <canonical_url> --metadata @source-metadata.json`.
 
 Do not use title, label, assignee, or state changes to invalidate downstream
 fix reuse; `gc.github.body_hash` is the issue content key.

--- a/gascity/assets/workflows/github-issue-fix-design-review-work/{target}.setup-design-review.md
+++ b/gascity/assets/workflows/github-issue-fix-design-review-work/{target}.setup-design-review.md
@@ -1,7 +1,7 @@
 
 Recover context from bead metadata, not from a side-channel context file:
 
-1. Read this step bead and the workflow root bead through `bd show --json`.
+1. Read this step bead and the workflow root bead through `gc bd show --json`.
 2. Read `gc.github.implementation_plan_path` and `gc.github.requirements_path` from the
    workflow root or completed implementation-plan/requirements steps.
 3. Validate that `implementation-plan.md` exists. The plan may be `draft` or

--- a/gascity/assets/workflows/github-issue-triage-base/render-comment.md
+++ b/gascity/assets/workflows/github-issue-triage-base/render-comment.md
@@ -1,5 +1,5 @@
 
-Read workflow root metadata from `bd show <root-bead-id> --json`.
+Read workflow root metadata from `gc bd show <root-bead-id> --json`.
 If workflow root metadata has `gc.github.reused_current_output=true`, validate
 that `gc.github.comment_path` points to an existing `comment.md` under
 `gc.github.triage_dir`, validate the reused triage report still matches

--- a/gascity/assets/workflows/github-issue-triage-base/reuse-current-body-hash.md
+++ b/gascity/assets/workflows/github-issue-triage-base/reuse-current-body-hash.md
@@ -1,6 +1,6 @@
 
 Read the current step bead metadata, get `gc.root_bead_id`, then read
-workflow root metadata with `bd show <root-bead-id> --json`. Use
+workflow root metadata with `gc bd show <root-bead-id> --json`. Use
 `gc.github.repo`, `gc.github.number`, `gc.github.body_hash`,
 `gc.github.snapshot_path`, and `gc.github.triage_dir` as the context index.
 If any required key is missing, hard-fail and report that the snapshot handoff

--- a/gascity/assets/workflows/github-issue-triage-base/snapshot.md
+++ b/gascity/assets/workflows/github-issue-triage-base/snapshot.md
@@ -26,7 +26,7 @@ Then create or refresh the canonical GitHub source bead using this v0 contract:
 - Source beads are non-runnable index/cache beads. Do not route the source bead,
   assign it, depend on it, or use it as a readiness gate.
 - Lookup uses object identity only:
-  `bd list --metadata-field gc.kind=github_source --metadata-field gc.github.kind=issue --metadata-field gc.github.repo=<owner>/<repo> --metadata-field gc.github.number=<number> --status open,in_progress,closed --limit 1 --json`.
+  `gc bd list --metadata-field gc.kind=github_source --metadata-field gc.github.kind=issue --metadata-field gc.github.repo=<owner>/<repo> --metadata-field gc.github.number=<number> --status open,in_progress,closed --limit 1 --json`.
 - Write `source-metadata.json` with flat string metadata:
   `gc.kind=github_source`, `gc.github.kind=issue`,
   `gc.github.repo=<owner>/<repo>`, `gc.github.number=<number>`,
@@ -37,20 +37,20 @@ Then create or refresh the canonical GitHub source bead using this v0 contract:
   `gc.github.snapshot_path=<absolute source.json path>`,
   `gc.github.updated_at=<updated_at>`.
 - If no bead exists, create it with
-  `bd create "GitHub issue source: <owner>/<repo>#<number>" --type task --labels gc.github-source,gc.github-issue --external-ref <canonical_url> --metadata @source-metadata.json`.
+  `gc bd create "GitHub issue source: <owner>/<repo>#<number>" --type task --labels gc.github-source,gc.github-issue --external-ref <canonical_url> --metadata @source-metadata.json`.
 - If a bead exists, refresh it with
-  `bd update <source-bead-id> --external-ref <canonical_url> --metadata @source-metadata.json`.
+  `gc bd update <source-bead-id> --external-ref <canonical_url> --metadata @source-metadata.json`.
 
 Then stamp workflow root metadata as the context handoff index for downstream
 steps. Do not write a separate triage context file; bead metadata is the small
 stable index, and artifact files hold large payloads.
 
-- Read the current step bead with `bd show <current-step-bead-id> --json` and
+- Read the current step bead with `gc bd show <current-step-bead-id> --json` and
   take `gc.root_bead_id`; hard-fail if it is missing.
 - Resolve the current triage directory with
   `{{pack_root}}/assets/scripts/artifacts.py path --override "{{artifact_root}}" --relative "/github/issues/<owner>/<repo>/<number>/triage/<body-hash>/" --directory --mkdir-parents`.
 - Update the workflow root metadata with:
-  `bd update <root-bead-id> --set-metadata gc.github.source_bead_id=<source-bead-id> --set-metadata gc.github.kind=issue --set-metadata gc.github.repo=<owner>/<repo> --set-metadata gc.github.number=<number> --set-metadata gc.github.url=<canonical_url> --set-metadata gc.github.body_hash=<body_hash> --set-metadata gc.github.snapshot_path=<absolute source.json path> --set-metadata gc.github.triage_dir=<absolute triage directory> --set-metadata gc.github.artifact_root=<absolute artifact root> --set-metadata gc.github.post_mode={{post_mode}} --set-metadata gc.github.reused_current_output=false`.
+  `gc bd update <root-bead-id> --set-metadata gc.github.source_bead_id=<source-bead-id> --set-metadata gc.github.kind=issue --set-metadata gc.github.repo=<owner>/<repo> --set-metadata gc.github.number=<number> --set-metadata gc.github.url=<canonical_url> --set-metadata gc.github.body_hash=<body_hash> --set-metadata gc.github.snapshot_path=<absolute source.json path> --set-metadata gc.github.triage_dir=<absolute triage directory> --set-metadata gc.github.artifact_root=<absolute artifact root> --set-metadata gc.github.post_mode={{post_mode}} --set-metadata gc.github.reused_current_output=false`.
 
 Do not use title, label, assignee, or state changes to invalidate triage; only
 `gc.github.body_hash` controls body-hash-keyed triage reuse.

--- a/gascity/assets/workflows/github-issue-triage-base/write-triage-report.md
+++ b/gascity/assets/workflows/github-issue-triage-base/write-triage-report.md
@@ -5,7 +5,7 @@ work in this step.
 Load context from bead metadata before investigating:
 
 - Read the current step bead metadata, get `gc.root_bead_id`, then read
-  workflow root metadata with `bd show <root-bead-id> --json`.
+  workflow root metadata with `gc bd show <root-bead-id> --json`.
 - Required workflow root metadata keys are `gc.github.source_bead_id`,
   `gc.github.repo`, `gc.github.number`, `gc.github.body_hash`,
   `gc.github.snapshot_path`, and `gc.github.triage_dir`.
@@ -59,4 +59,4 @@ verdict by the validator. Reproduction work may write logs, repro scripts, and
 patch evidence under the triage artifact directory only.
 
 After validation, update the workflow root metadata with the report result:
-`bd update <root-bead-id> --set-metadata gc.github.triage_report_path=<absolute triage-report.md path> --set-metadata gc.github.triage_verdict=<verdict> --set-metadata gc.github.triage_priority=<priority> --set-metadata gc.github.triage_recommended_next_action=<recommended_next_action>`.
+`gc bd update <root-bead-id> --set-metadata gc.github.triage_report_path=<absolute triage-report.md path> --set-metadata gc.github.triage_verdict=<verdict> --set-metadata gc.github.triage_priority=<priority> --set-metadata gc.github.triage_recommended_next_action=<recommended_next_action>`.

--- a/gascity/assets/workflows/github-pr-review/render-comment.md
+++ b/gascity/assets/workflows/github-pr-review/render-comment.md
@@ -1,5 +1,5 @@
 
-Read workflow root metadata from `bd show <root-bead-id> --json`. Validate the
+Read workflow root metadata from `gc bd show <root-bead-id> --json`. Validate the
 generic review verdict report at `gc.github.review_report_path` and map it with
 `{{pack_root}}/assets/scripts/github_reports.py review-outcome`:
 `pass/none -> approve`, `fail/minor -> comment`, `fail/major -> request_changes`,

--- a/gascity/assets/workflows/github-pr-review/reuse-current-head.md
+++ b/gascity/assets/workflows/github-pr-review/reuse-current-head.md
@@ -1,6 +1,6 @@
 
 Read the current step bead metadata, get `gc.root_bead_id`, then read workflow
-root metadata with `bd show <root-bead-id> --json`. Use `gc.github.repo`,
+root metadata with `gc bd show <root-bead-id> --json`. Use `gc.github.repo`,
 `gc.github.number`, `gc.github.head_sha`, `gc.github.snapshot_path`, and
 `gc.github.review_dir` as the context index. If any required key is missing,
 hard-fail and report that the snapshot handoff metadata is incomplete.

--- a/gascity/assets/workflows/github-pr-review/run-review.md
+++ b/gascity/assets/workflows/github-pr-review/run-review.md
@@ -1,6 +1,6 @@
 
 Read the current step bead metadata, get `gc.root_bead_id`, then read workflow
-root metadata with `bd show <root-bead-id> --json`. Required workflow root
+root metadata with `gc bd show <root-bead-id> --json`. Required workflow root
 metadata keys are `gc.github.source_bead_id`, `gc.github.repo`,
 `gc.github.number`, `gc.github.url`, `gc.github.head_sha`,
 `gc.github.snapshot_path`, and `gc.github.review_dir`.
@@ -37,7 +37,7 @@ gc sling gc.run-operator review --formula \
 Do not close this step until `REPORT_PATH` exists and validates through
 `{{pack_root}}/assets/scripts/github_reports.py review-outcome "$REPORT_PATH"`.
 Persist the review handoff and result on workflow root metadata:
-`bd update <root-bead-id> --set-metadata gc.github.review_subject_path="$SUBJECT_PATH" --set-metadata gc.github.review_report_path="$REPORT_PATH" --set-metadata gc.github.review_outcome=<approve|comment|request_changes|block>`.
+`gc bd update <root-bead-id> --set-metadata gc.github.review_subject_path="$SUBJECT_PATH" --set-metadata gc.github.review_report_path="$REPORT_PATH" --set-metadata gc.github.review_outcome=<approve|comment|request_changes|block>`.
 
 The adapter does not check out a mutation worktree, push commits, amend
 contributor branches, submit formal GitHub review events, or create follow-up

--- a/gascity/assets/workflows/github-pr-review/snapshot.md
+++ b/gascity/assets/workflows/github-pr-review/snapshot.md
@@ -27,7 +27,7 @@ Then create or refresh the canonical GitHub source bead using this v0 contract:
 - Source beads are non-runnable index/cache beads. Do not route the source bead,
   assign it, depend on it, or use it as a readiness gate.
 - Lookup uses object identity only:
-  `bd list --metadata-field gc.kind=github_source --metadata-field gc.github.kind=pull --metadata-field gc.github.repo=<owner>/<repo> --metadata-field gc.github.number=<number> --status open,in_progress,closed --limit 1 --json`.
+  `gc bd list --metadata-field gc.kind=github_source --metadata-field gc.github.kind=pull --metadata-field gc.github.repo=<owner>/<repo> --metadata-field gc.github.number=<number> --status open,in_progress,closed --limit 1 --json`.
 - Write `source-metadata.json` with flat string metadata:
   `gc.kind=github_source`, `gc.github.kind=pull`,
   `gc.github.repo=<owner>/<repo>`, `gc.github.number=<number>`,
@@ -40,19 +40,19 @@ Then create or refresh the canonical GitHub source bead using this v0 contract:
   `gc.github.snapshot_path=<absolute source.json path>`,
   `gc.github.updated_at=<updated_at>`.
 - If no bead exists, create it with
-  `bd create "GitHub PR source: <owner>/<repo>#<number>" --type task --labels gc.github-source,gc.github-pr --external-ref <canonical_url> --metadata @source-metadata.json`.
+  `gc bd create "GitHub PR source: <owner>/<repo>#<number>" --type task --labels gc.github-source,gc.github-pr --external-ref <canonical_url> --metadata @source-metadata.json`.
 - If a bead exists, refresh it with
-  `bd update <source-bead-id> --external-ref <canonical_url> --metadata @source-metadata.json`.
+  `gc bd update <source-bead-id> --external-ref <canonical_url> --metadata @source-metadata.json`.
 
 Then stamp workflow root metadata as the context handoff index for downstream
 steps. Do not write a separate PR-review context file; bead metadata is the
 small stable index, and artifact files hold large payloads.
 
-- Read the current step bead with `bd show <current-step-bead-id> --json` and
+- Read the current step bead with `gc bd show <current-step-bead-id> --json` and
   take `gc.root_bead_id`; hard-fail if it is missing.
 - Resolve the current head-SHA review directory with
   `{{pack_root}}/assets/scripts/artifacts.py path --override "{{artifact_root}}" --relative "/github/pulls/<owner>/<repo>/<number>/reviews/<head-sha>/" --mkdir-parents --directory`.
 - Update the workflow root metadata with:
-  `bd update <root-bead-id> --set-metadata gc.github.source_bead_id=<source-bead-id> --set-metadata gc.github.kind=pull --set-metadata gc.github.repo=<owner>/<repo> --set-metadata gc.github.number=<number> --set-metadata gc.github.url=<canonical_url> --set-metadata gc.github.head_sha=<head_sha> --set-metadata gc.github.snapshot_path=<absolute source.json path> --set-metadata gc.github.review_dir=<absolute review directory> --set-metadata gc.github.artifact_root=<absolute artifact root> --set-metadata gc.github.context_path={{context_path}} --set-metadata gc.github.post_mode={{post_mode}} --set-metadata gc.github.reused_current_output=false`.
+  `gc bd update <root-bead-id> --set-metadata gc.github.source_bead_id=<source-bead-id> --set-metadata gc.github.kind=pull --set-metadata gc.github.repo=<owner>/<repo> --set-metadata gc.github.number=<number> --set-metadata gc.github.url=<canonical_url> --set-metadata gc.github.head_sha=<head_sha> --set-metadata gc.github.snapshot_path=<absolute source.json path> --set-metadata gc.github.review_dir=<absolute review directory> --set-metadata gc.github.artifact_root=<absolute artifact root> --set-metadata gc.github.context_path={{context_path}} --set-metadata gc.github.post_mode={{post_mode}} --set-metadata gc.github.reused_current_output=false`.
 
 Only `gc.github.head_sha` controls head-SHA-keyed PR review reuse.

--- a/gascity/roles/agents/design-author/prompt.template.md
+++ b/gascity/roles/agents/design-author/prompt.template.md
@@ -6,14 +6,14 @@ You are `{{ .AgentName }}`, a Gas City `graph.v2` role worker for template
 ## Core Rule
 
 You work only the routed bead assigned to this live session. Do not use
-`bd mol current` to infer workflow position. Do not assume a parent bead or
+`gc bd mol current` to infer workflow position. Do not assume a parent bead or
 root bead describes your work. The workflow graph advances through explicit
 ready beads, and you execute the ready bead claimed by this session.
 
 ## Startup Claim Protocol
 
 `gc hook` is the only permitted discovery source for routed workflow work. Do
-not run broad `bd ready`, `bd list`, root-bead searches, metadata searches,
+not run broad `gc bd ready`, `gc bd list`, root-bead searches, metadata searches,
 mail inspection, session-log inspection, or repository context gathering to
 find a bead. Never claim a bead id unless it came from the immediately
 preceding `gc hook` result in this claim block.
@@ -110,7 +110,7 @@ while true; do
   # The `gc hook --claim` JSON is the authoritative, graph-aware source: it
   # already resolved the routed bead (including graph-resident gcg- beads) and
   # claimed it atomically, so a successful claim IS the verification. Derive the
-  # root/group from that JSON. Never re-read with `bd show` here: bare `bd` is
+  # root/group from that JSON. Never re-read with `gc bd show` here: bare `bd` is
   # graph-aware only via the PATH shim and silently falls through to the Dolt bd
   # ("no issue found") for a stale session whose shimbin predates a gc refresh,
   # which looped CLAIM_REJECTED forever and stalled the review-loop.
@@ -149,8 +149,8 @@ unrecoverable failure with `gc.outcome=fail` and a concise
 
 If later terminal commands do not inherit shell variables, use the explicit
 `CLAIMED_BEAD_ID`, `CLAIMED_ROOT_BEAD_ID`, and
-`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `bd
-update` or `bd close` with an empty id.
+`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run
+`gc bd update` or `gc bd close` with an empty id.
 
 ## Continuation Group Protocol
 

--- a/gascity/roles/agents/design-implementation-reviewer/prompt.template.md
+++ b/gascity/roles/agents/design-implementation-reviewer/prompt.template.md
@@ -6,14 +6,14 @@ You are `{{ .AgentName }}`, a Gas City `graph.v2` role worker for template
 ## Core Rule
 
 You work only the routed bead assigned to this live session. Do not use
-`bd mol current` to infer workflow position. Do not assume a parent bead or
+`gc bd mol current` to infer workflow position. Do not assume a parent bead or
 root bead describes your work. The workflow graph advances through explicit
 ready beads, and you execute the ready bead claimed by this session.
 
 ## Startup Claim Protocol
 
 `gc hook` is the only permitted discovery source for routed workflow work. Do
-not run broad `bd ready`, `bd list`, root-bead searches, metadata searches,
+not run broad `gc bd ready`, `gc bd list`, root-bead searches, metadata searches,
 mail inspection, session-log inspection, or repository context gathering to
 find a bead. Never claim a bead id unless it came from the immediately
 preceding `gc hook` result in this claim block.
@@ -110,7 +110,7 @@ while true; do
   # The `gc hook --claim` JSON is the authoritative, graph-aware source: it
   # already resolved the routed bead (including graph-resident gcg- beads) and
   # claimed it atomically, so a successful claim IS the verification. Derive the
-  # root/group from that JSON. Never re-read with `bd show` here: bare `bd` is
+  # root/group from that JSON. Never re-read with `gc bd show` here: bare `bd` is
   # graph-aware only via the PATH shim and silently falls through to the Dolt bd
   # ("no issue found") for a stale session whose shimbin predates a gc refresh,
   # which looped CLAIM_REJECTED forever and stalled the review-loop.
@@ -149,8 +149,8 @@ unrecoverable failure with `gc.outcome=fail` and a concise
 
 If later terminal commands do not inherit shell variables, use the explicit
 `CLAIMED_BEAD_ID`, `CLAIMED_ROOT_BEAD_ID`, and
-`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `bd
-update` or `bd close` with an empty id.
+`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run
+`gc bd update` or `gc bd close` with an empty id.
 
 ## Continuation Group Protocol
 

--- a/gascity/roles/agents/design-test-risk-reviewer/prompt.template.md
+++ b/gascity/roles/agents/design-test-risk-reviewer/prompt.template.md
@@ -6,14 +6,14 @@ You are `{{ .AgentName }}`, a Gas City `graph.v2` role worker for template
 ## Core Rule
 
 You work only the routed bead assigned to this live session. Do not use
-`bd mol current` to infer workflow position. Do not assume a parent bead or
+`gc bd mol current` to infer workflow position. Do not assume a parent bead or
 root bead describes your work. The workflow graph advances through explicit
 ready beads, and you execute the ready bead claimed by this session.
 
 ## Startup Claim Protocol
 
 `gc hook` is the only permitted discovery source for routed workflow work. Do
-not run broad `bd ready`, `bd list`, root-bead searches, metadata searches,
+not run broad `gc bd ready`, `gc bd list`, root-bead searches, metadata searches,
 mail inspection, session-log inspection, or repository context gathering to
 find a bead. Never claim a bead id unless it came from the immediately
 preceding `gc hook` result in this claim block.
@@ -110,7 +110,7 @@ while true; do
   # The `gc hook --claim` JSON is the authoritative, graph-aware source: it
   # already resolved the routed bead (including graph-resident gcg- beads) and
   # claimed it atomically, so a successful claim IS the verification. Derive the
-  # root/group from that JSON. Never re-read with `bd show` here: bare `bd` is
+  # root/group from that JSON. Never re-read with `gc bd show` here: bare `bd` is
   # graph-aware only via the PATH shim and silently falls through to the Dolt bd
   # ("no issue found") for a stale session whose shimbin predates a gc refresh,
   # which looped CLAIM_REJECTED forever and stalled the review-loop.
@@ -149,8 +149,8 @@ unrecoverable failure with `gc.outcome=fail` and a concise
 
 If later terminal commands do not inherit shell variables, use the explicit
 `CLAIMED_BEAD_ID`, `CLAIMED_ROOT_BEAD_ID`, and
-`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `bd
-update` or `bd close` with an empty id.
+`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run
+`gc bd update` or `gc bd close` with an empty id.
 
 ## Continuation Group Protocol
 

--- a/gascity/roles/agents/gap-analyst/prompt.template.md
+++ b/gascity/roles/agents/gap-analyst/prompt.template.md
@@ -6,14 +6,14 @@ You are `{{ .AgentName }}`, a Gas City `graph.v2` role worker for template
 ## Core Rule
 
 You work only the routed bead assigned to this live session. Do not use
-`bd mol current` to infer workflow position. Do not assume a parent bead or
+`gc bd mol current` to infer workflow position. Do not assume a parent bead or
 root bead describes your work. The workflow graph advances through explicit
 ready beads, and you execute the ready bead claimed by this session.
 
 ## Startup Claim Protocol
 
 `gc hook` is the only permitted discovery source for routed workflow work. Do
-not run broad `bd ready`, `bd list`, root-bead searches, metadata searches,
+not run broad `gc bd ready`, `gc bd list`, root-bead searches, metadata searches,
 mail inspection, session-log inspection, or repository context gathering to
 find a bead. Never claim a bead id unless it came from the immediately
 preceding `gc hook` result in this claim block.
@@ -110,7 +110,7 @@ while true; do
   # The `gc hook --claim` JSON is the authoritative, graph-aware source: it
   # already resolved the routed bead (including graph-resident gcg- beads) and
   # claimed it atomically, so a successful claim IS the verification. Derive the
-  # root/group from that JSON. Never re-read with `bd show` here: bare `bd` is
+  # root/group from that JSON. Never re-read with `gc bd show` here: bare `bd` is
   # graph-aware only via the PATH shim and silently falls through to the Dolt bd
   # ("no issue found") for a stale session whose shimbin predates a gc refresh,
   # which looped CLAIM_REJECTED forever and stalled the review-loop.
@@ -149,8 +149,8 @@ unrecoverable failure with `gc.outcome=fail` and a concise
 
 If later terminal commands do not inherit shell variables, use the explicit
 `CLAIMED_BEAD_ID`, `CLAIMED_ROOT_BEAD_ID`, and
-`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `bd
-update` or `bd close` with an empty id.
+`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run
+`gc bd update` or `gc bd close` with an empty id.
 
 ## Continuation Group Protocol
 

--- a/gascity/roles/agents/implementation-reviewer/prompt.template.md
+++ b/gascity/roles/agents/implementation-reviewer/prompt.template.md
@@ -6,14 +6,14 @@ You are `{{ .AgentName }}`, a Gas City `graph.v2` role worker for template
 ## Core Rule
 
 You work only the routed bead assigned to this live session. Do not use
-`bd mol current` to infer workflow position. Do not assume a parent bead or
+`gc bd mol current` to infer workflow position. Do not assume a parent bead or
 root bead describes your work. The workflow graph advances through explicit
 ready beads, and you execute the ready bead claimed by this session.
 
 ## Startup Claim Protocol
 
 `gc hook` is the only permitted discovery source for routed workflow work. Do
-not run broad `bd ready`, `bd list`, root-bead searches, metadata searches,
+not run broad `gc bd ready`, `gc bd list`, root-bead searches, metadata searches,
 mail inspection, session-log inspection, or repository context gathering to
 find a bead. Never claim a bead id unless it came from the immediately
 preceding `gc hook` result in this claim block.
@@ -110,7 +110,7 @@ while true; do
   # The `gc hook --claim` JSON is the authoritative, graph-aware source: it
   # already resolved the routed bead (including graph-resident gcg- beads) and
   # claimed it atomically, so a successful claim IS the verification. Derive the
-  # root/group from that JSON. Never re-read with `bd show` here: bare `bd` is
+  # root/group from that JSON. Never re-read with `gc bd show` here: bare `bd` is
   # graph-aware only via the PATH shim and silently falls through to the Dolt bd
   # ("no issue found") for a stale session whose shimbin predates a gc refresh,
   # which looped CLAIM_REJECTED forever and stalled the review-loop.
@@ -149,8 +149,8 @@ unrecoverable failure with `gc.outcome=fail` and a concise
 
 If later terminal commands do not inherit shell variables, use the explicit
 `CLAIMED_BEAD_ID`, `CLAIMED_ROOT_BEAD_ID`, and
-`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `bd
-update` or `bd close` with an empty id.
+`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run
+`gc bd update` or `gc bd close` with an empty id.
 
 ## Continuation Group Protocol
 

--- a/gascity/roles/agents/implementation-worker/prompt.template.md
+++ b/gascity/roles/agents/implementation-worker/prompt.template.md
@@ -6,14 +6,14 @@ You are `{{ .AgentName }}`, a Gas City `graph.v2` role worker for template
 ## Core Rule
 
 You work only the routed bead assigned to this live session. Do not use
-`bd mol current` to infer workflow position. Do not assume a parent bead or
+`gc bd mol current` to infer workflow position. Do not assume a parent bead or
 root bead describes your work. The workflow graph advances through explicit
 ready beads, and you execute the ready bead claimed by this session.
 
 ## Startup Claim Protocol
 
 `gc hook` is the only permitted discovery source for routed workflow work. Do
-not run broad `bd ready`, `bd list`, root-bead searches, metadata searches,
+not run broad `gc bd ready`, `gc bd list`, root-bead searches, metadata searches,
 mail inspection, session-log inspection, or repository context gathering to
 find a bead. Never claim a bead id unless it came from the immediately
 preceding `gc hook` result in this claim block.
@@ -110,7 +110,7 @@ while true; do
   # The `gc hook --claim` JSON is the authoritative, graph-aware source: it
   # already resolved the routed bead (including graph-resident gcg- beads) and
   # claimed it atomically, so a successful claim IS the verification. Derive the
-  # root/group from that JSON. Never re-read with `bd show` here: bare `bd` is
+  # root/group from that JSON. Never re-read with `gc bd show` here: bare `bd` is
   # graph-aware only via the PATH shim and silently falls through to the Dolt bd
   # ("no issue found") for a stale session whose shimbin predates a gc refresh,
   # which looped CLAIM_REJECTED forever and stalled the review-loop.
@@ -149,8 +149,8 @@ unrecoverable failure with `gc.outcome=fail` and a concise
 
 If later terminal commands do not inherit shell variables, use the explicit
 `CLAIMED_BEAD_ID`, `CLAIMED_ROOT_BEAD_ID`, and
-`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `bd
-update` or `bd close` with an empty id.
+`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run
+`gc bd update` or `gc bd close` with an empty id.
 
 ## Continuation Group Protocol
 

--- a/gascity/roles/agents/issue-triager/prompt.template.md
+++ b/gascity/roles/agents/issue-triager/prompt.template.md
@@ -6,14 +6,14 @@ You are `{{ .AgentName }}`, a Gas City `graph.v2` role worker for template
 ## Core Rule
 
 You work only the routed bead assigned to this live session. Do not use
-`bd mol current` to infer workflow position. Do not assume a parent bead or
+`gc bd mol current` to infer workflow position. Do not assume a parent bead or
 root bead describes your work. The workflow graph advances through explicit
 ready beads, and you execute the ready bead claimed by this session.
 
 ## Startup Claim Protocol
 
 `gc hook` is the only permitted discovery source for routed workflow work. Do
-not run broad `bd ready`, `bd list`, root-bead searches, metadata searches,
+not run broad `gc bd ready`, `gc bd list`, root-bead searches, metadata searches,
 mail inspection, session-log inspection, or repository context gathering to
 find a bead. Never claim a bead id unless it came from the immediately
 preceding `gc hook` result in this claim block.
@@ -110,7 +110,7 @@ while true; do
   # The `gc hook --claim` JSON is the authoritative, graph-aware source: it
   # already resolved the routed bead (including graph-resident gcg- beads) and
   # claimed it atomically, so a successful claim IS the verification. Derive the
-  # root/group from that JSON. Never re-read with `bd show` here: bare `bd` is
+  # root/group from that JSON. Never re-read with `gc bd show` here: bare `bd` is
   # graph-aware only via the PATH shim and silently falls through to the Dolt bd
   # ("no issue found") for a stale session whose shimbin predates a gc refresh,
   # which looped CLAIM_REJECTED forever and stalled the review-loop.
@@ -149,8 +149,8 @@ unrecoverable failure with `gc.outcome=fail` and a concise
 
 If later terminal commands do not inherit shell variables, use the explicit
 `CLAIMED_BEAD_ID`, `CLAIMED_ROOT_BEAD_ID`, and
-`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `bd
-update` or `bd close` with an empty id.
+`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run
+`gc bd update` or `gc bd close` with an empty id.
 
 ## Continuation Group Protocol
 

--- a/gascity/roles/agents/publisher/prompt.template.md
+++ b/gascity/roles/agents/publisher/prompt.template.md
@@ -6,14 +6,14 @@ You are `{{ .AgentName }}`, a Gas City `graph.v2` role worker for template
 ## Core Rule
 
 You work only the routed bead assigned to this live session. Do not use
-`bd mol current` to infer workflow position. Do not assume a parent bead or
+`gc bd mol current` to infer workflow position. Do not assume a parent bead or
 root bead describes your work. The workflow graph advances through explicit
 ready beads, and you execute the ready bead claimed by this session.
 
 ## Startup Claim Protocol
 
 `gc hook` is the only permitted discovery source for routed workflow work. Do
-not run broad `bd ready`, `bd list`, root-bead searches, metadata searches,
+not run broad `gc bd ready`, `gc bd list`, root-bead searches, metadata searches,
 mail inspection, session-log inspection, or repository context gathering to
 find a bead. Never claim a bead id unless it came from the immediately
 preceding `gc hook` result in this claim block.
@@ -110,7 +110,7 @@ while true; do
   # The `gc hook --claim` JSON is the authoritative, graph-aware source: it
   # already resolved the routed bead (including graph-resident gcg- beads) and
   # claimed it atomically, so a successful claim IS the verification. Derive the
-  # root/group from that JSON. Never re-read with `bd show` here: bare `bd` is
+  # root/group from that JSON. Never re-read with `gc bd show` here: bare `bd` is
   # graph-aware only via the PATH shim and silently falls through to the Dolt bd
   # ("no issue found") for a stale session whose shimbin predates a gc refresh,
   # which looped CLAIM_REJECTED forever and stalled the review-loop.
@@ -149,8 +149,8 @@ unrecoverable failure with `gc.outcome=fail` and a concise
 
 If later terminal commands do not inherit shell variables, use the explicit
 `CLAIMED_BEAD_ID`, `CLAIMED_ROOT_BEAD_ID`, and
-`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `bd
-update` or `bd close` with an empty id.
+`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run
+`gc bd update` or `gc bd close` with an empty id.
 
 ## Continuation Group Protocol
 

--- a/gascity/roles/agents/requirements-planner/prompt.template.md
+++ b/gascity/roles/agents/requirements-planner/prompt.template.md
@@ -6,14 +6,14 @@ You are `{{ .AgentName }}`, a Gas City `graph.v2` role worker for template
 ## Core Rule
 
 You work only the routed bead assigned to this live session. Do not use
-`bd mol current` to infer workflow position. Do not assume a parent bead or
+`gc bd mol current` to infer workflow position. Do not assume a parent bead or
 root bead describes your work. The workflow graph advances through explicit
 ready beads, and you execute the ready bead claimed by this session.
 
 ## Startup Claim Protocol
 
 `gc hook` is the only permitted discovery source for routed workflow work. Do
-not run broad `bd ready`, `bd list`, root-bead searches, metadata searches,
+not run broad `gc bd ready`, `gc bd list`, root-bead searches, metadata searches,
 mail inspection, session-log inspection, or repository context gathering to
 find a bead. Never claim a bead id unless it came from the immediately
 preceding `gc hook` result in this claim block.
@@ -110,7 +110,7 @@ while true; do
   # The `gc hook --claim` JSON is the authoritative, graph-aware source: it
   # already resolved the routed bead (including graph-resident gcg- beads) and
   # claimed it atomically, so a successful claim IS the verification. Derive the
-  # root/group from that JSON. Never re-read with `bd show` here: bare `bd` is
+  # root/group from that JSON. Never re-read with `gc bd show` here: bare `bd` is
   # graph-aware only via the PATH shim and silently falls through to the Dolt bd
   # ("no issue found") for a stale session whose shimbin predates a gc refresh,
   # which looped CLAIM_REJECTED forever and stalled the review-loop.
@@ -149,8 +149,8 @@ unrecoverable failure with `gc.outcome=fail` and a concise
 
 If later terminal commands do not inherit shell variables, use the explicit
 `CLAIMED_BEAD_ID`, `CLAIMED_ROOT_BEAD_ID`, and
-`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `bd
-update` or `bd close` with an empty id.
+`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run
+`gc bd update` or `gc bd close` with an empty id.
 
 ## Continuation Group Protocol
 

--- a/gascity/roles/agents/review-synthesizer/prompt.template.md
+++ b/gascity/roles/agents/review-synthesizer/prompt.template.md
@@ -6,14 +6,14 @@ You are `{{ .AgentName }}`, a Gas City `graph.v2` role worker for template
 ## Core Rule
 
 You work only the routed bead assigned to this live session. Do not use
-`bd mol current` to infer workflow position. Do not assume a parent bead or
+`gc bd mol current` to infer workflow position. Do not assume a parent bead or
 root bead describes your work. The workflow graph advances through explicit
 ready beads, and you execute the ready bead claimed by this session.
 
 ## Startup Claim Protocol
 
 `gc hook` is the only permitted discovery source for routed workflow work. Do
-not run broad `bd ready`, `bd list`, root-bead searches, metadata searches,
+not run broad `gc bd ready`, `gc bd list`, root-bead searches, metadata searches,
 mail inspection, session-log inspection, or repository context gathering to
 find a bead. Never claim a bead id unless it came from the immediately
 preceding `gc hook` result in this claim block.
@@ -110,7 +110,7 @@ while true; do
   # The `gc hook --claim` JSON is the authoritative, graph-aware source: it
   # already resolved the routed bead (including graph-resident gcg- beads) and
   # claimed it atomically, so a successful claim IS the verification. Derive the
-  # root/group from that JSON. Never re-read with `bd show` here: bare `bd` is
+  # root/group from that JSON. Never re-read with `gc bd show` here: bare `bd` is
   # graph-aware only via the PATH shim and silently falls through to the Dolt bd
   # ("no issue found") for a stale session whose shimbin predates a gc refresh,
   # which looped CLAIM_REJECTED forever and stalled the review-loop.
@@ -149,8 +149,8 @@ unrecoverable failure with `gc.outcome=fail` and a concise
 
 If later terminal commands do not inherit shell variables, use the explicit
 `CLAIMED_BEAD_ID`, `CLAIMED_ROOT_BEAD_ID`, and
-`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `bd
-update` or `bd close` with an empty id.
+`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run
+`gc bd update` or `gc bd close` with an empty id.
 
 ## Continuation Group Protocol
 

--- a/gascity/roles/agents/run-operator/prompt.template.md
+++ b/gascity/roles/agents/run-operator/prompt.template.md
@@ -6,14 +6,14 @@ You are `{{ .AgentName }}`, a Gas City `graph.v2` role worker for template
 ## Core Rule
 
 You work only the routed bead assigned to this live session. Do not use
-`bd mol current` to infer workflow position. Do not assume a parent bead or
+`gc bd mol current` to infer workflow position. Do not assume a parent bead or
 root bead describes your work. The workflow graph advances through explicit
 ready beads, and you execute the ready bead claimed by this session.
 
 ## Startup Claim Protocol
 
 `gc hook` is the only permitted discovery source for routed workflow work. Do
-not run broad `bd ready`, `bd list`, root-bead searches, metadata searches,
+not run broad `gc bd ready`, `gc bd list`, root-bead searches, metadata searches,
 mail inspection, session-log inspection, or repository context gathering to
 find a bead. Never claim a bead id unless it came from the immediately
 preceding `gc hook` result in this claim block.
@@ -110,7 +110,7 @@ while true; do
   # The `gc hook --claim` JSON is the authoritative, graph-aware source: it
   # already resolved the routed bead (including graph-resident gcg- beads) and
   # claimed it atomically, so a successful claim IS the verification. Derive the
-  # root/group from that JSON. Never re-read with `bd show` here: bare `bd` is
+  # root/group from that JSON. Never re-read with `gc bd show` here: bare `bd` is
   # graph-aware only via the PATH shim and silently falls through to the Dolt bd
   # ("no issue found") for a stale session whose shimbin predates a gc refresh,
   # which looped CLAIM_REJECTED forever and stalled the review-loop.
@@ -149,8 +149,8 @@ unrecoverable failure with `gc.outcome=fail` and a concise
 
 If later terminal commands do not inherit shell variables, use the explicit
 `CLAIMED_BEAD_ID`, `CLAIMED_ROOT_BEAD_ID`, and
-`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `bd
-update` or `bd close` with an empty id.
+`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run
+`gc bd update` or `gc bd close` with an empty id.
 
 ## Continuation Group Protocol
 

--- a/gascity/roles/agents/task-decomposer/prompt.template.md
+++ b/gascity/roles/agents/task-decomposer/prompt.template.md
@@ -6,14 +6,14 @@ You are `{{ .AgentName }}`, a Gas City `graph.v2` role worker for template
 ## Core Rule
 
 You work only the routed bead assigned to this live session. Do not use
-`bd mol current` to infer workflow position. Do not assume a parent bead or
+`gc bd mol current` to infer workflow position. Do not assume a parent bead or
 root bead describes your work. The workflow graph advances through explicit
 ready beads, and you execute the ready bead claimed by this session.
 
 ## Startup Claim Protocol
 
 `gc hook` is the only permitted discovery source for routed workflow work. Do
-not run broad `bd ready`, `bd list`, root-bead searches, metadata searches,
+not run broad `gc bd ready`, `gc bd list`, root-bead searches, metadata searches,
 mail inspection, session-log inspection, or repository context gathering to
 find a bead. Never claim a bead id unless it came from the immediately
 preceding `gc hook` result in this claim block.
@@ -110,7 +110,7 @@ while true; do
   # The `gc hook --claim` JSON is the authoritative, graph-aware source: it
   # already resolved the routed bead (including graph-resident gcg- beads) and
   # claimed it atomically, so a successful claim IS the verification. Derive the
-  # root/group from that JSON. Never re-read with `bd show` here: bare `bd` is
+  # root/group from that JSON. Never re-read with `gc bd show` here: bare `bd` is
   # graph-aware only via the PATH shim and silently falls through to the Dolt bd
   # ("no issue found") for a stale session whose shimbin predates a gc refresh,
   # which looped CLAIM_REJECTED forever and stalled the review-loop.
@@ -149,8 +149,8 @@ unrecoverable failure with `gc.outcome=fail` and a concise
 
 If later terminal commands do not inherit shell variables, use the explicit
 `CLAIMED_BEAD_ID`, `CLAIMED_ROOT_BEAD_ID`, and
-`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `bd
-update` or `bd close` with an empty id.
+`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run
+`gc bd update` or `gc bd close` with an empty id.
 
 ## Continuation Group Protocol
 

--- a/gascity/roles/prompts/shared/gc-role-worker.md.tmpl
+++ b/gascity/roles/prompts/shared/gc-role-worker.md.tmpl
@@ -7,14 +7,14 @@ You are `{{ .AgentName }}`, a Gas City `graph.v2` role worker for template
 ## Core Rule
 
 You work only the routed bead assigned to this live session. Do not use
-`bd mol current` to infer workflow position. Do not assume a parent bead or
+`gc bd mol current` to infer workflow position. Do not assume a parent bead or
 root bead describes your work. The workflow graph advances through explicit
 ready beads, and you execute the ready bead claimed by this session.
 
 ## Startup Claim Protocol
 
 `gc hook` is the only permitted discovery source for routed workflow work. Do
-not run broad `bd ready`, `bd list`, root-bead searches, metadata searches,
+not run broad `gc bd ready`, `gc bd list`, root-bead searches, metadata searches,
 mail inspection, session-log inspection, or repository context gathering to
 find a bead. Never claim a bead id unless it came from the immediately
 preceding `gc hook` result in this claim block.
@@ -111,7 +111,7 @@ while true; do
   # The `gc hook --claim` JSON is the authoritative, graph-aware source: it
   # already resolved the routed bead (including graph-resident gcg- beads) and
   # claimed it atomically, so a successful claim IS the verification. Derive the
-  # root/group from that JSON. Never re-read with `bd show` here: bare `bd` is
+  # root/group from that JSON. Never re-read with `gc bd show` here: bare `bd` is
   # graph-aware only via the PATH shim and silently falls through to the Dolt bd
   # ("no issue found") for a stale session whose shimbin predates a gc refresh,
   # which looped CLAIM_REJECTED forever and stalled the review-loop.
@@ -150,8 +150,8 @@ unrecoverable failure with `gc.outcome=fail` and a concise
 
 If later terminal commands do not inherit shell variables, use the explicit
 `CLAIMED_BEAD_ID`, `CLAIMED_ROOT_BEAD_ID`, and
-`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run `bd
-update` or `bd close` with an empty id.
+`CLAIMED_CONTINUATION_GROUP` printed by the claim command. Never run
+`gc bd update` or `gc bd close` with an empty id.
 
 ## Continuation Group Protocol
 

--- a/gascity/tests/test_formula_assets.py
+++ b/gascity/tests/test_formula_assets.py
@@ -385,7 +385,7 @@ class FormulaAssetTests(unittest.TestCase):
             "gc.drain_member_id",
             "worktrees/<source-anchor-id>",
             "git worktree add",
-            "bd update <source-anchor-id> --set-metadata work_dir=",
+            "gc bd update <source-anchor-id> --set-metadata work_dir=",
             "Do not edit source files in the launcher checkout",
         ):
             with self.subTest(step="prepare-worktree", fragment=fragment):
@@ -406,7 +406,7 @@ class FormulaAssetTests(unittest.TestCase):
         for fragment in (
             "Read `work_dir` from the source anchor",
             "close only `<source-anchor-id>`",
-            "bd show <source-anchor-id> --json",
+            "gc bd show <source-anchor-id> --json",
             "status=closed",
             "gc.outcome=pass",
             "if either check fails",
@@ -508,9 +508,9 @@ class FormulaAssetTests(unittest.TestCase):
             "github-pr-review": ("pull", "gc.github.head_sha"),
         }
         required_common = {
-            "bd list --metadata-field gc.kind=github_source",
-            "bd create",
-            "bd update",
+            "gc bd list --metadata-field gc.kind=github_source",
+            "gc bd create",
+            "gc bd update",
             "--external-ref",
             "gc.github.kind",
             "gc.github.repo",
@@ -607,7 +607,7 @@ class FormulaAssetTests(unittest.TestCase):
         implementation_plan_normalized = " ".join(implementation_plan.split())
 
         for fragment in (
-            "bd update <root-bead-id>",
+            "gc bd update <root-bead-id>",
             "gc.github.run_dir",
             "gc.github.requirements_path",
             "gc.github.implementation_plan_path",
@@ -727,8 +727,8 @@ description = "Override sink that writes the base triage report contract."
             "gc.root_bead_id",
             "gc.github.source_bead_id",
             "gc.github.triage_dir",
-            "bd show <root-bead-id> --json",
-            "bd update <root-bead-id>",
+            "gc bd show <root-bead-id> --json",
+            "gc bd update <root-bead-id>",
             "Read `gc.github.snapshot_path`",
             "Do not write a separate triage context file",
         }

--- a/gascity/tests/test_no_bare_bd_commands.py
+++ b/gascity/tests/test_no_bare_bd_commands.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+import re
+import subprocess
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+THIS_FILE = Path(__file__).resolve()
+
+BD_SUBCOMMANDS = (
+    "admin",
+    "ado",
+    "assign",
+    "audit",
+    "backup",
+    "batch",
+    "blocked",
+    "bootstrap",
+    "branch",
+    "children",
+    "close",
+    "comment",
+    "comments",
+    "compact",
+    "completion",
+    "config",
+    "context",
+    "cook",
+    "count",
+    "create",
+    "create-form",
+    "defer",
+    "delete",
+    "dep",
+    "diff",
+    "doctor",
+    "dolt",
+    "duplicate",
+    "duplicates",
+    "edit",
+    "epic",
+    "export",
+    "federation",
+    "find-duplicates",
+    "flatten",
+    "forget",
+    "formula",
+    "gate",
+    "gc",
+    "github",
+    "gitlab",
+    "graph",
+    "heartbeat",
+    "help",
+    "history",
+    "hooks",
+    "human",
+    "import",
+    "info",
+    "init",
+    "init-safety",
+    "jira",
+    "kv",
+    "label",
+    "linear",
+    "link",
+    "list",
+    "lint",
+    "mail",
+    "memories",
+    "merge-slot",
+    "meta",
+    "metrics",
+    "migrate",
+    "migrate-personal",
+    "mol",
+    "note",
+    "notion",
+    "onboard",
+    "orphans",
+    "ping",
+    "preflight",
+    "prime",
+    "priority",
+    "promote",
+    "prune",
+    "purge",
+    "q",
+    "query",
+    "quickstart",
+    "ready",
+    "recall",
+    "reclaim",
+    "recompute-blocked",
+    "remember",
+    "rename-prefix",
+    "rename",
+    "reopen",
+    "repo",
+    "restore",
+    "rules",
+    "search",
+    "set-state",
+    "setup",
+    "show",
+    "ship",
+    "sql",
+    "stale",
+    "state",
+    "status",
+    "statuses",
+    "supersede",
+    "swarm",
+    "sync",
+    "tag",
+    "todo",
+    "type",
+    "types",
+    "unclaim",
+    "undefer",
+    "update",
+    "upgrade",
+    "vc",
+    "version",
+    "where",
+    "worktree",
+)
+BD_SUBCOMMAND_PATTERN = "|".join(re.escape(command) for command in BD_SUBCOMMANDS)
+BARE_BD_COMMAND = re.compile(rf"\bbd[ \t]+(?:{BD_SUBCOMMAND_PATTERN})\b")
+MULTILINE_BARE_BD_COMMAND = re.compile(
+    rf"\bbd[ \t]*\r?\n[ \t]*(?:{BD_SUBCOMMAND_PATTERN})\b"
+)
+BARE_BD_GO_EXEC = re.compile(
+    r'(?:exec\.Command(?:Context)?|dispatchExecCommand)\(\s*["\']bd["\']'
+)
+BARE_BD_PATH_CHECK = re.compile(r"\bcommand[ \t]+-v[ \t]+bd\b")
+BARE_BD_SERIALIZED_ARGV = re.compile(
+    rf'''(?:\[|\{{|=|:)[ \t]*["']bd["'][ \t]*,[ \t]*["'](?:{BD_SUBCOMMAND_PATTERN})["']'''
+)
+GC_BD_ARGV_TAIL_MARKER = "gc-bd-argv-tail"
+
+
+def tracked_files() -> list[Path]:
+    result = subprocess.run(
+        ["git", "ls-files", "-z"],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+    )
+    return [
+        REPO_ROOT / path
+        for path in result.stdout.decode().split("\0")
+        if path.startswith("gascity/")
+    ]
+
+
+def python_argv_violations(path: Path, text: str) -> list[str]:
+    if path.suffix != ".py":
+        return []
+    tree = ast.parse(text, filename=str(path))
+    violations = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.List, ast.Tuple)) or not node.elts:
+            continue
+        first = node.elts[0]
+        if isinstance(first, ast.Constant) and first.value == "bd":
+            violations.append(f"{path.relative_to(REPO_ROOT)}:{node.lineno}: argv starts with bd")
+    return violations
+
+
+def bare_bd_violations(path: Path, text: str) -> list[str]:
+    violations = []
+    relative = path.relative_to(REPO_ROOT)
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        if GC_BD_ARGV_TAIL_MARKER in line:
+            continue
+        for match in BARE_BD_COMMAND.finditer(line):
+            before = line[: match.start()]
+            if re.search(r"\bgc[ \t]+$", before):
+                continue
+            violations.append(f"{relative}:{line_number}: {line.strip()}")
+        if BARE_BD_GO_EXEC.search(line):
+            violations.append(f"{relative}:{line_number}: direct bd argv")
+        if BARE_BD_PATH_CHECK.search(line):
+            violations.append(f"{relative}:{line_number}: checks bd instead of gc")
+        if BARE_BD_SERIALIZED_ARGV.search(line):
+            violations.append(f"{relative}:{line_number}: serialized argv starts with bd")
+        if "BD_BIN" in line:
+            violations.append(f"{relative}:{line_number}: BD_BIN bypasses gc bd routing")
+    for match in MULTILINE_BARE_BD_COMMAND.finditer(text):
+        if re.search(r"\bgc[ \t]+$", text[: match.start()]):
+            continue
+        line_number = text.count("\n", 0, match.start()) + 1
+        violations.append(f"{relative}:{line_number}: bd command is split across lines")
+    violations.extend(python_argv_violations(path, text))
+    return violations
+
+
+def test_gascity_pack_assets_route_beads_commands_through_gc() -> None:
+    violations = []
+    for path in tracked_files():
+        if path.resolve() == THIS_FILE:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        violations.extend(bare_bd_violations(path, text))
+
+    assert not violations, "bare bd commands bypass store-aware routing:\n" + "\n".join(violations)
+
+
+def test_detector_covers_shell_multiline_and_serialized_argv_forms() -> None:
+    fixture = REPO_ROOT / "fixture.txt"
+
+    assert bare_bd_violations(fixture, 'command = ["bd", "show"]')
+    assert bare_bd_violations(fixture, "value=$(bd\n  list --json)")
+    assert not bare_bd_violations(fixture, 'command = ["gc", "bd", "show"]')


### PR DESCRIPTION
## Summary
- route the independent `design/gc-plan-pack` Gas City assets and generated role prompts through `gc bd`
- preserve PR #198's graph-aware claimed-work inspection
- add a Gas City-scoped static guard for shell, multiline, Python, Go, and serialized argv forms

## Why
This branch remains independent of main and still shipped bare commands around the PR #198 fix. Those commands can resolve against the wrong store and recreate the review treadmill.

## Verification
- `python3 -m pytest -q gascity/tests/test_no_bare_bd_commands.py` (2 passed)
- `git diff --check`
- full `gascity.tests.test_formula_assets` has the same seven pre-existing `github-issue-triage-work` failures on both base commit 604bb0b and this branch; no new failures
- generated role prompts remain equal to the shared template