### PR TITLE
Harden the gc bd migration guard

### DIFF
--- a/bmad/template-fragments/gc-role-worker.template.md
+++ b/bmad/template-fragments/gc-role-worker.template.md
@@ -178,8 +178,9 @@ Close it with the requested `gc.outcome` metadata. If the bead does not specify
 a failure contract, mark an unrecoverable failure with `gc.outcome=fail` and a
 concise `gc.failure_class`/reason before closing it.
 
-Never use `gc bd close` for a bead that asks for close metadata. First set
-the requested metadata on the claimed bead, then close the same bead id:
+Never close a bead that asks for close metadata before setting that metadata.
+First set the requested metadata on the claimed bead, then close the same bead
+id:
 
 ```bash
 gc bd update "$GC_BEAD_ID" \

--- a/compound-engineering/agents/ce-code-review-selector/template-fragments/gc-role-worker.template.md
+++ b/compound-engineering/agents/ce-code-review-selector/template-fragments/gc-role-worker.template.md
@@ -178,8 +178,9 @@ Close it with the requested `gc.outcome` metadata. If the bead does not specify
 a failure contract, mark an unrecoverable failure with `gc.outcome=fail` and a
 concise `gc.failure_class`/reason before closing it.
 
-Never use `gc bd close` for a bead that asks for close metadata. First set
-the requested metadata on the claimed bead, then close the same bead id:
+Never close a bead that asks for close metadata before setting that metadata.
+First set the requested metadata on the claimed bead, then close the same bead
+id:
 
 ```bash
 gc bd update "$GC_BEAD_ID" \

--- a/compound-engineering/template-fragments/gc-role-worker.template.md
+++ b/compound-engineering/template-fragments/gc-role-worker.template.md
@@ -178,8 +178,9 @@ Close it with the requested `gc.outcome` metadata. If the bead does not specify
 a failure contract, mark an unrecoverable failure with `gc.outcome=fail` and a
 concise `gc.failure_class`/reason before closing it.
 
-Never use `gc bd close` for a bead that asks for close metadata. First set
-the requested metadata on the claimed bead, then close the same bead id:
+Never close a bead that asks for close metadata before setting that metadata.
+First set the requested metadata on the claimed bead, then close the same bead
+id:
 
 ```bash
 gc bd update "$GC_BEAD_ID" \

--- a/discord/doctor/bd/doctor.toml
+++ b/discord/doctor/bd/doctor.toml
@@ -1,2 +1,2 @@
-description = 'bd CLI is available for Discord bead lifecycle commands'
+description = 'gc bd is available for Discord bead lifecycle commands'
 run = '../check-bd.sh'

--- a/discord/tests/test_discord_doctor_scripts.py
+++ b/discord/tests/test_discord_doctor_scripts.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pathlib
 import subprocess
 import tempfile
+import tomllib
 import unittest
 
 import os
@@ -15,6 +16,7 @@ class DiscordDoctorScriptTests(unittest.TestCase):
         self._old_environ = os.environ.copy()
         os.environ["GC_CITY_ROOT"] = self.tempdir.name
         self.script = pathlib.Path(__file__).resolve().parents[1] / "doctor" / "check-legacy-pack-conflict.sh"
+        self.bd_doctor = pathlib.Path(__file__).resolve().parents[1] / "doctor" / "bd" / "doctor.toml"
 
     def tearDown(self) -> None:
         os.environ.clear()
@@ -35,6 +37,13 @@ class DiscordDoctorScriptTests(unittest.TestCase):
 
         self.assertEqual(result.returncode, 2)
         self.assertIn("legacy discord-intake state detected", result.stdout)
+
+    def test_bd_doctor_describes_the_store_aware_gc_wrapper(self) -> None:
+        with self.bd_doctor.open("rb") as handle:
+            doctor = tomllib.load(handle)
+
+        self.assertIn("gc bd", doctor["description"])
+        self.assertNotIn("bd CLI", doctor["description"])
 
 
 if __name__ == "__main__":

--- a/gascity/roles/agents/design-author/prompt.template.md
+++ b/gascity/roles/agents/design-author/prompt.template.md
@@ -177,8 +177,9 @@ Close it with the requested `gc.outcome` metadata. If the bead does not specify
 a failure contract, mark an unrecoverable failure with `gc.outcome=fail` and a
 concise `gc.failure_class`/reason before closing it.
 
-Never use `gc bd close` for a bead that asks for close metadata. First set
-the requested metadata on the claimed bead, then close the same bead id:
+Never close a bead that asks for close metadata before setting that metadata.
+First set the requested metadata on the claimed bead, then close the same bead
+id:
 
 ```bash
 gc bd update "$GC_BEAD_ID" \

--- a/gascity/roles/agents/design-implementation-reviewer/prompt.template.md
+++ b/gascity/roles/agents/design-implementation-reviewer/prompt.template.md
@@ -177,8 +177,9 @@ Close it with the requested `gc.outcome` metadata. If the bead does not specify
 a failure contract, mark an unrecoverable failure with `gc.outcome=fail` and a
 concise `gc.failure_class`/reason before closing it.
 
-Never use `gc bd close` for a bead that asks for close metadata. First set
-the requested metadata on the claimed bead, then close the same bead id:
+Never close a bead that asks for close metadata before setting that metadata.
+First set the requested metadata on the claimed bead, then close the same bead
+id:
 
 ```bash
 gc bd update "$GC_BEAD_ID" \

--- a/gascity/roles/agents/design-test-risk-reviewer/prompt.template.md
+++ b/gascity/roles/agents/design-test-risk-reviewer/prompt.template.md
@@ -177,8 +177,9 @@ Close it with the requested `gc.outcome` metadata. If the bead does not specify
 a failure contract, mark an unrecoverable failure with `gc.outcome=fail` and a
 concise `gc.failure_class`/reason before closing it.
 
-Never use `gc bd close` for a bead that asks for close metadata. First set
-the requested metadata on the claimed bead, then close the same bead id:
+Never close a bead that asks for close metadata before setting that metadata.
+First set the requested metadata on the claimed bead, then close the same bead
+id:
 
 ```bash
 gc bd update "$GC_BEAD_ID" \

--- a/gascity/roles/agents/gap-analyst/prompt.template.md
+++ b/gascity/roles/agents/gap-analyst/prompt.template.md
@@ -177,8 +177,9 @@ Close it with the requested `gc.outcome` metadata. If the bead does not specify
 a failure contract, mark an unrecoverable failure with `gc.outcome=fail` and a
 concise `gc.failure_class`/reason before closing it.
 
-Never use `gc bd close` for a bead that asks for close metadata. First set
-the requested metadata on the claimed bead, then close the same bead id:
+Never close a bead that asks for close metadata before setting that metadata.
+First set the requested metadata on the claimed bead, then close the same bead
+id:
 
 ```bash
 gc bd update "$GC_BEAD_ID" \

--- a/gascity/roles/agents/implementation-reviewer/prompt.template.md
+++ b/gascity/roles/agents/implementation-reviewer/prompt.template.md
@@ -177,8 +177,9 @@ Close it with the requested `gc.outcome` metadata. If the bead does not specify
 a failure contract, mark an unrecoverable failure with `gc.outcome=fail` and a
 concise `gc.failure_class`/reason before closing it.
 
-Never use `gc bd close` for a bead that asks for close metadata. First set
-the requested metadata on the claimed bead, then close the same bead id:
+Never close a bead that asks for close metadata before setting that metadata.
+First set the requested metadata on the claimed bead, then close the same bead
+id:
 
 ```bash
 gc bd update "$GC_BEAD_ID" \

--- a/gascity/roles/agents/implementation-worker/prompt.template.md
+++ b/gascity/roles/agents/implementation-worker/prompt.template.md
@@ -177,8 +177,9 @@ Close it with the requested `gc.outcome` metadata. If the bead does not specify
 a failure contract, mark an unrecoverable failure with `gc.outcome=fail` and a
 concise `gc.failure_class`/reason before closing it.
 
-Never use `gc bd close` for a bead that asks for close metadata. First set
-the requested metadata on the claimed bead, then close the same bead id:
+Never close a bead that asks for close metadata before setting that metadata.
+First set the requested metadata on the claimed bead, then close the same bead
+id:
 
 ```bash
 gc bd update "$GC_BEAD_ID" \

--- a/gascity/roles/agents/issue-triager/prompt.template.md
+++ b/gascity/roles/agents/issue-triager/prompt.template.md
@@ -177,8 +177,9 @@ Close it with the requested `gc.outcome` metadata. If the bead does not specify
 a failure contract, mark an unrecoverable failure with `gc.outcome=fail` and a
 concise `gc.failure_class`/reason before closing it.
 
-Never use `gc bd close` for a bead that asks for close metadata. First set
-the requested metadata on the claimed bead, then close the same bead id:
+Never close a bead that asks for close metadata before setting that metadata.
+First set the requested metadata on the claimed bead, then close the same bead
+id:
 
 ```bash
 gc bd update "$GC_BEAD_ID" \

--- a/gascity/roles/agents/publisher/prompt.template.md
+++ b/gascity/roles/agents/publisher/prompt.template.md
@@ -177,8 +177,9 @@ Close it with the requested `gc.outcome` metadata. If the bead does not specify
 a failure contract, mark an unrecoverable failure with `gc.outcome=fail` and a
 concise `gc.failure_class`/reason before closing it.
 
-Never use `gc bd close` for a bead that asks for close metadata. First set
-the requested metadata on the claimed bead, then close the same bead id:
+Never close a bead that asks for close metadata before setting that metadata.
+First set the requested metadata on the claimed bead, then close the same bead
+id:
 
 ```bash
 gc bd update "$GC_BEAD_ID" \

--- a/gascity/roles/agents/requirements-planner/prompt.template.md
+++ b/gascity/roles/agents/requirements-planner/prompt.template.md
@@ -177,8 +177,9 @@ Close it with the requested `gc.outcome` metadata. If the bead does not specify
 a failure contract, mark an unrecoverable failure with `gc.outcome=fail` and a
 concise `gc.failure_class`/reason before closing it.
 
-Never use `gc bd close` for a bead that asks for close metadata. First set
-the requested metadata on the claimed bead, then close the same bead id:
+Never close a bead that asks for close metadata before setting that metadata.
+First set the requested metadata on the claimed bead, then close the same bead
+id:
 
 ```bash
 gc bd update "$GC_BEAD_ID" \

--- a/gascity/roles/agents/review-synthesizer/prompt.template.md
+++ b/gascity/roles/agents/review-synthesizer/prompt.template.md
@@ -177,8 +177,9 @@ Close it with the requested `gc.outcome` metadata. If the bead does not specify
 a failure contract, mark an unrecoverable failure with `gc.outcome=fail` and a
 concise `gc.failure_class`/reason before closing it.
 
-Never use `gc bd close` for a bead that asks for close metadata. First set
-the requested metadata on the claimed bead, then close the same bead id:
+Never close a bead that asks for close metadata before setting that metadata.
+First set the requested metadata on the claimed bead, then close the same bead
+id:
 
 ```bash
 gc bd update "$GC_BEAD_ID" \

--- a/gascity/roles/agents/run-operator/prompt.template.md
+++ b/gascity/roles/agents/run-operator/prompt.template.md
@@ -177,8 +177,9 @@ Close it with the requested `gc.outcome` metadata. If the bead does not specify
 a failure contract, mark an unrecoverable failure with `gc.outcome=fail` and a
 concise `gc.failure_class`/reason before closing it.
 
-Never use `gc bd close` for a bead that asks for close metadata. First set
-the requested metadata on the claimed bead, then close the same bead id:
+Never close a bead that asks for close metadata before setting that metadata.
+First set the requested metadata on the claimed bead, then close the same bead
+id:
 
 ```bash
 gc bd update "$GC_BEAD_ID" \

--- a/gascity/roles/agents/task-decomposer/prompt.template.md
+++ b/gascity/roles/agents/task-decomposer/prompt.template.md
@@ -177,8 +177,9 @@ Close it with the requested `gc.outcome` metadata. If the bead does not specify
 a failure contract, mark an unrecoverable failure with `gc.outcome=fail` and a
 concise `gc.failure_class`/reason before closing it.
 
-Never use `gc bd close` for a bead that asks for close metadata. First set
-the requested metadata on the claimed bead, then close the same bead id:
+Never close a bead that asks for close metadata before setting that metadata.
+First set the requested metadata on the claimed bead, then close the same bead
+id:
 
 ```bash
 gc bd update "$GC_BEAD_ID" \

--- a/gascity/roles/prompts/shared/gc-role-worker.md.tmpl
+++ b/gascity/roles/prompts/shared/gc-role-worker.md.tmpl
@@ -178,8 +178,9 @@ Close it with the requested `gc.outcome` metadata. If the bead does not specify
 a failure contract, mark an unrecoverable failure with `gc.outcome=fail` and a
 concise `gc.failure_class`/reason before closing it.
 
-Never use `gc bd close` for a bead that asks for close metadata. First set
-the requested metadata on the claimed bead, then close the same bead id:
+Never close a bead that asks for close metadata before setting that metadata.
+First set the requested metadata on the claimed bead, then close the same bead
+id:
 
 ```bash
 gc bd update "$GC_BEAD_ID" \

--- a/gascity/roles/template-fragments/gc-role-worker.template.md
+++ b/gascity/roles/template-fragments/gc-role-worker.template.md
@@ -178,8 +178,9 @@ Close it with the requested `gc.outcome` metadata. If the bead does not specify
 a failure contract, mark an unrecoverable failure with `gc.outcome=fail` and a
 concise `gc.failure_class`/reason before closing it.
 
-Never use `gc bd close` for a bead that asks for close metadata. First set
-the requested metadata on the claimed bead, then close the same bead id:
+Never close a bead that asks for close metadata before setting that metadata.
+First set the requested metadata on the claimed bead, then close the same bead
+id:
 
 ```bash
 gc bd update "$GC_BEAD_ID" \

--- a/gascity/template-fragments/gc-role-worker.template.md
+++ b/gascity/template-fragments/gc-role-worker.template.md
@@ -178,8 +178,9 @@ Close it with the requested `gc.outcome` metadata. If the bead does not specify
 a failure contract, mark an unrecoverable failure with `gc.outcome=fail` and a
 concise `gc.failure_class`/reason before closing it.
 
-Never use `gc bd close` for a bead that asks for close metadata. First set
-the requested metadata on the claimed bead, then close the same bead id:
+Never close a bead that asks for close metadata before setting that metadata.
+First set the requested metadata on the claimed bead, then close the same bead
+id:
 
 ```bash
 gc bd update "$GC_BEAD_ID" \

--- a/gascity/tests/test_formula_assets.py
+++ b/gascity/tests/test_formula_assets.py
@@ -715,7 +715,7 @@ class FormulaAssetTests(unittest.TestCase):
             "gc runtime drain-ack",
             "gc.continuation_group",
             "gc.scope_role=teardown",
-            "Never use `gc bd close` for a bead that asks for close metadata",
+            "Never close a bead that asks for close metadata before setting that metadata",
             'gc bd update "$GC_BEAD_ID"',
             "Finding review issues, missing tests, or required follow-up is usually the\nbead's output",
             "check for more routed work before draining",

--- a/gastown/agents/polecat/prompt.template.md
+++ b/gastown/agents/polecat/prompt.template.md
@@ -11,7 +11,7 @@
 For `mol-polecat-work` implementation assignments, **you MUST NOT close the
 implementation bead.** The Refinery closes it after verifying the merge.
 
-Do not run `gc bd close`, `gc bd close`, or set `--status=closed` on an
+Do not run `gc bd close` or set `--status=closed` on an
 implementation bead. If code appears already merged, reassign to refinery with
 a note.
 

--- a/gastown/tests/test_gastown_pack_assets.sh
+++ b/gastown/tests/test_gastown_pack_assets.sh
@@ -169,6 +169,8 @@ test_review_leg_contract_forbids_synthetic_mutation() {
         fail "review-leg formula must forbid executing reviewed checklist items"
     grep -F 'Formula-specific non-implementation assignments may explicitly tell you' "$prompt" >/dev/null ||
         fail "polecat prompt must allow formula-specific review/control close steps"
+    ! grep -F '`gc bd close`, `gc bd close`' "$prompt" >/dev/null ||
+        fail "polecat prompt must not duplicate its close prohibition"
     grep -F 'Default implementation formula: `mol-polecat-work`' "$prompt" >/dev/null ||
         fail "polecat prompt must describe mol-polecat-work as the default implementation formula"
     ! grep -F '**You MUST NOT close beads. EVER. No exceptions.**' "$prompt" >/dev/null ||

--- a/gstack/template-fragments/gc-role-worker.template.md
+++ b/gstack/template-fragments/gc-role-worker.template.md
@@ -178,8 +178,9 @@ Close it with the requested `gc.outcome` metadata. If the bead does not specify
 a failure contract, mark an unrecoverable failure with `gc.outcome=fail` and a
 concise `gc.failure_class`/reason before closing it.
 
-Never use `gc bd close` for a bead that asks for close metadata. First set
-the requested metadata on the claimed bead, then close the same bead id:
+Never close a bead that asks for close metadata before setting that metadata.
+First set the requested metadata on the claimed bead, then close the same bead
+id:
 
 ```bash
 gc bd update "$GC_BEAD_ID" \

--- a/superpowers/template-fragments/gc-role-worker.template.md
+++ b/superpowers/template-fragments/gc-role-worker.template.md
@@ -178,8 +178,9 @@ Close it with the requested `gc.outcome` metadata. If the bead does not specify
 a failure contract, mark an unrecoverable failure with `gc.outcome=fail` and a
 concise `gc.failure_class`/reason before closing it.
 
-Never use `gc bd close` for a bead that asks for close metadata. First set
-the requested metadata on the claimed bead, then close the same bead id:
+Never close a bead that asks for close metadata before setting that metadata.
+First set the requested metadata on the claimed bead, then close the same bead
+id:
 
 ```bash
 gc bd update "$GC_BEAD_ID" \

--- a/tests/test_no_bare_bd_commands.py
+++ b/tests/test_no_bare_bd_commands.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 import re
+import shlex
 import subprocess
 
 
@@ -129,6 +130,8 @@ BD_SUBCOMMANDS = (
 )
 BD_SUBCOMMAND_PATTERN = "|".join(re.escape(command) for command in BD_SUBCOMMANDS)
 BARE_BD_COMMAND = re.compile(rf"\bbd[ \t]+(?:{BD_SUBCOMMAND_PATTERN})\b")
+BARE_BD_LEADING_FLAG = re.compile(r"\bbd[ \t]+-{1,2}[A-Za-z]")
+BARE_BD_DYNAMIC_COMMAND = re.compile(r'''\bbd[ \t]+(?:["']?\$\{?[A-Za-z_]|\$\()''')
 MULTILINE_BARE_BD_COMMAND = re.compile(
     rf"\bbd[ \t]*\r?\n[ \t]*(?:{BD_SUBCOMMAND_PATTERN})\b"
 )
@@ -137,9 +140,15 @@ BARE_BD_GO_EXEC = re.compile(
 )
 BARE_BD_PATH_CHECK = re.compile(r"\bcommand[ \t]+-v[ \t]+bd\b")
 BARE_BD_SERIALIZED_ARGV = re.compile(
-    rf'''(?:\[|\{{|=|:)[ \t]*["']bd["'][ \t]*,[ \t]*["'](?:{BD_SUBCOMMAND_PATTERN})["']'''
+    rf'''(?:\[|\{{|=|:)\s*["']bd["']\s*,\s*["'](?:{BD_SUBCOMMAND_PATTERN})["']'''
 )
 GC_BD_ARGV_TAIL_MARKER = "gc-bd-argv-tail"
+GC_BD_ARGV_TAIL_FIXTURE = Path("tests/test_gascity_pack_inference_gate.py")
+GC_BD_ARGV_TAIL_LINES = {
+    '*"bd show fi-root --json"*) # gc-bd-argv-tail: fake gc receives the wrapper\'s argv tail',
+    '*"bd list --json --limit 1000"*) # gc-bd-argv-tail: fake gc receives the wrapper\'s argv tail',
+    'assert "bd show fi-root --json" in args_path.read_text(encoding="utf-8")  # gc-bd-argv-tail',
+}
 
 
 def tracked_files() -> list[Path]:
@@ -166,32 +175,71 @@ def python_argv_violations(path: Path, text: str) -> list[str]:
     return violations
 
 
+def gc_routes_bd(line: str, bd_start: int) -> bool:
+    prefix = line[:bd_start]
+    gc_tokens = list(re.finditer(r"(?<![A-Za-z0-9_=/.-])gc\b", prefix))
+    if not gc_tokens:
+        return False
+    command_prefix = prefix[gc_tokens[-1].end() :].strip()
+    try:
+        tokens = shlex.split(command_prefix)
+    except ValueError:
+        return False
+
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        if token in {"--city", "--rig"}:
+            if index + 1 >= len(tokens):
+                return False
+            index += 2
+            continue
+        if token.startswith("--city=") or token.startswith("--rig="):
+            if token.endswith("="):
+                return False
+            index += 1
+            continue
+        return False
+    return True
+
+
+def intentional_gc_bd_argv_tail(relative: Path, line: str) -> bool:
+    return (
+        relative == GC_BD_ARGV_TAIL_FIXTURE
+        and GC_BD_ARGV_TAIL_MARKER in line
+        and line.strip() in GC_BD_ARGV_TAIL_LINES
+    )
+
+
 def bare_bd_violations(path: Path, text: str) -> list[str]:
     violations = []
     relative = path.relative_to(REPO_ROOT)
     for line_number, line in enumerate(text.splitlines(), start=1):
-        if GC_BD_ARGV_TAIL_MARKER in line:
-            continue
-        for match in BARE_BD_COMMAND.finditer(line):
-            before = line[: match.start()]
-            if re.search(r"\bgc[ \t]+$", before):
-                continue
-            violations.append(f"{relative}:{line_number}: {line.strip()}")
+        for pattern in (BARE_BD_COMMAND, BARE_BD_LEADING_FLAG, BARE_BD_DYNAMIC_COMMAND):
+            for match in pattern.finditer(line):
+                if gc_routes_bd(line, match.start()):
+                    continue
+                if intentional_gc_bd_argv_tail(relative, line):
+                    continue
+                violations.append(f"{relative}:{line_number}: {line.strip()}")
         if BARE_BD_GO_EXEC.search(line):
             violations.append(f"{relative}:{line_number}: direct bd argv")
         if BARE_BD_PATH_CHECK.search(line):
             violations.append(f"{relative}:{line_number}: checks bd instead of gc")
-        if BARE_BD_SERIALIZED_ARGV.search(line):
-            violations.append(f"{relative}:{line_number}: serialized argv starts with bd")
         if "BD_BIN" in line:
             violations.append(f"{relative}:{line_number}: BD_BIN bypasses gc bd routing")
     for match in MULTILINE_BARE_BD_COMMAND.finditer(text):
-        if re.search(r"\bgc[ \t]+$", text[: match.start()]):
+        line_start = text.rfind("\n", 0, match.start()) + 1
+        first_line = text[line_start : text.find("\n", match.start())]
+        if gc_routes_bd(first_line, match.start() - line_start):
             continue
         line_number = text.count("\n", 0, match.start()) + 1
         violations.append(f"{relative}:{line_number}: bd command is split across lines")
+    for match in BARE_BD_SERIALIZED_ARGV.finditer(text):
+        line_number = text.count("\n", 0, match.start()) + 1
+        violations.append(f"{relative}:{line_number}: serialized argv starts with bd")
     violations.extend(python_argv_violations(path, text))
-    return violations
+    return list(dict.fromkeys(violations))
 
 
 def test_shipped_pack_assets_route_beads_commands_through_gc() -> None:
@@ -213,4 +261,12 @@ def test_detector_covers_shell_multiline_and_serialized_argv_forms() -> None:
 
     assert bare_bd_violations(fixture, 'command = ["bd", "show"]')
     assert bare_bd_violations(fixture, "value=$(bd\n  list --json)")
+    assert bare_bd_violations(fixture, "bd --dir /tmp/rig list --json")
+    assert bare_bd_violations(fixture, 'bd "$verb" --json')
+    assert bare_bd_violations(fixture, 'command = ["bd",\n "show"]')
+    assert bare_bd_violations(fixture, "bd show x  # gc-bd-argv-tail")
+    assert bare_bd_violations(fixture, "echo gc; bd show x")
+    assert bare_bd_violations(fixture, "GC_BIN=gc bd show x")
     assert not bare_bd_violations(fixture, 'command = ["gc", "bd", "show"]')
+    assert not bare_bd_violations(fixture, "gc --city /tmp/city bd list --json")
+    assert not bare_bd_violations(fixture, "gc --rig demo bd show demo-1")


### PR DESCRIPTION
## Summary
- accept valid `gc --city/--rig ... bd` routing while detecting leading-flag, dynamic, multiline, and serialized bare-bd forms
- scope the argv-tail fixture escape to three exact test-fixture lines
- clarify close-metadata ordering across canonical/generated worker prompts
- remove duplicate Polecat guidance and align the Discord doctor description

## Verification
- RED regressions observed for all four review findings before fixes
- `python3 -m pytest -q tests/test_no_bare_bd_commands.py`
- `python3 -m pytest -q gascity/tests/test_formula_assets.py discord/tests/test_discord_doctor_scripts.py`
- full Python pack suite: 733 passed, 11,082 subtests
- Gastown pack/theme/churn-watcher shell suites
- root Go embed test
- registry validation and `git diff --check`