### PR TITLE
fix(gascity): migrate formulas off deprecated graph.v2 contract

### DIFF
--- a/gascity/formulas/REQUIREMENTS.md
+++ b/gascity/formulas/REQUIREMENTS.md
@@ -45,7 +45,8 @@ For every formula change:
 
 ## Global Invariants
 
-- Every formula uses `contract = "graph.v2"`.
+- Every formula declares the formulas v2 contract via `[requires]
+  formula_compiler = ">=2.0.0"`.
 - No formula declares reserved runtime vars `issue`, `bead_id`, or `convoy_id`.
 - Cataloged formulas are user-runnable; internal/base/helper formulas are not
   cataloged unless deliberately promoted.

--- a/gascity/formulas/build-base.formula.toml
+++ b/gascity/formulas/build-base.formula.toml
@@ -27,9 +27,11 @@ Launch inputs:
 """
 formula = "build-base"
 version = 1
-contract = "graph.v2"
 target_required = true
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [metadata.gc.methodology]
 allowed_drain_policies = ["separate", "same-session"]

--- a/gascity/formulas/build-basic-review.formula.toml
+++ b/gascity/formulas/build-basic-review.formula.toml
@@ -8,7 +8,9 @@ synthesize into one fix loop.
 formula = "build-basic-review"
 type = "expansion"
 version = 1
-contract = "graph.v2"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/gascity/formulas/build-basic.formula.toml
+++ b/gascity/formulas/build-basic.formula.toml
@@ -7,9 +7,11 @@ same full-lifecycle stage contract exposed by build-base.
 """
 formula = "build-basic"
 version = 1
-contract = "graph.v2"
 extends = ["build-base"]
 target_required = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "build-basic"

--- a/gascity/formulas/build-from-convoy-base.formula.toml
+++ b/gascity/formulas/build-from-convoy-base.formula.toml
@@ -7,10 +7,12 @@ to `build-from-review-base` through the inherited `prepare-review` step.
 """
 formula = "build-from-convoy-base"
 version = 1
-contract = "graph.v2"
 extends = ["build-from-review-base"]
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [metadata.gc.methodology]
 allowed_drain_policies = ["separate", "same-session"]

--- a/gascity/formulas/build-from-convoy.formula.toml
+++ b/gascity/formulas/build-from-convoy.formula.toml
@@ -6,9 +6,11 @@ Gas City methodology defaults.
 """
 formula = "build-from-convoy"
 version = 1
-contract = "graph.v2"
 extends = ["build-from-convoy-base"]
 target_required = false
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "build-from-convoy"

--- a/gascity/formulas/build-from-decompose-base.formula.toml
+++ b/gascity/formulas/build-from-decompose-base.formula.toml
@@ -29,10 +29,12 @@ Launch inputs:
 """
 formula = "build-from-decompose-base"
 version = 1
-contract = "graph.v2"
 extends = ["build-from-convoy-base"]
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [metadata.gc.methodology]
 allowed_drain_policies = ["separate", "same-session"]

--- a/gascity/formulas/build-from-decompose.formula.toml
+++ b/gascity/formulas/build-from-decompose.formula.toml
@@ -8,9 +8,11 @@ selectors, routes, drains, or review expansions they need.
 """
 formula = "build-from-decompose"
 version = 1
-contract = "graph.v2"
 extends = ["build-from-decompose-base"]
 target_required = false
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "build-from-decompose"

--- a/gascity/formulas/build-from-plan-base.formula.toml
+++ b/gascity/formulas/build-from-plan-base.formula.toml
@@ -7,10 +7,12 @@ implementation plan and plan-review verdict, then hands off to
 """
 formula = "build-from-plan-base"
 version = 1
-contract = "graph.v2"
 extends = ["build-from-decompose-base"]
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [metadata.gc.methodology]
 allowed_drain_policies = ["separate", "same-session"]

--- a/gascity/formulas/build-from-plan.formula.toml
+++ b/gascity/formulas/build-from-plan.formula.toml
@@ -6,9 +6,11 @@ City methodology defaults.
 """
 formula = "build-from-plan"
 version = 1
-contract = "graph.v2"
 extends = ["build-from-plan-base"]
 target_required = false
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "build-from-plan"

--- a/gascity/formulas/build-from-requirements-base.formula.toml
+++ b/gascity/formulas/build-from-requirements-base.formula.toml
@@ -7,10 +7,12 @@ inherited `prepare-plan` step.
 """
 formula = "build-from-requirements-base"
 version = 1
-contract = "graph.v2"
 extends = ["build-from-plan-base"]
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [metadata.gc.methodology]
 allowed_drain_policies = ["separate", "same-session"]

--- a/gascity/formulas/build-from-requirements.formula.toml
+++ b/gascity/formulas/build-from-requirements.formula.toml
@@ -6,9 +6,11 @@ built-in Gas City methodology defaults.
 """
 formula = "build-from-requirements"
 version = 1
-contract = "graph.v2"
 extends = ["build-from-requirements-base"]
 target_required = false
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "build-from-requirements"

--- a/gascity/formulas/build-from-review-base.formula.toml
+++ b/gascity/formulas/build-from-review-base.formula.toml
@@ -8,9 +8,11 @@ to `prepare-review` after producing implementation evidence.
 """
 formula = "build-from-review-base"
 version = 1
-contract = "graph.v2"
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [metadata.gc.methodology]
 allowed_drain_policies = ["separate", "same-session"]

--- a/gascity/formulas/build-from-review.formula.toml
+++ b/gascity/formulas/build-from-review.formula.toml
@@ -6,9 +6,11 @@ Gas City methodology defaults.
 """
 formula = "build-from-review"
 version = 1
-contract = "graph.v2"
 extends = ["build-from-review-base"]
 target_required = false
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "build-from-review"

--- a/gascity/formulas/code-review-base.formula.toml
+++ b/gascity/formulas/code-review-base.formula.toml
@@ -7,10 +7,12 @@ scoring while entrypoint adapters keep GitHub/comment lifecycle ownership.
 """
 formula = "code-review-base"
 version = 1
-contract = "graph.v2"
 target_required = false
 internal = true
 mode = "report"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.context_path]

--- a/gascity/formulas/decomposition-base.formula.toml
+++ b/gascity/formulas/decomposition-base.formula.toml
@@ -7,9 +7,11 @@ native output uses stories, cards, or another task shape.
 """
 formula = "decomposition-base"
 version = 1
-contract = "graph.v2"
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.context_path]

--- a/gascity/formulas/design-review.formula.toml
+++ b/gascity/formulas/design-review.formula.toml
@@ -8,8 +8,10 @@ graphs while preserving launch and finalization semantics.
 """
 formula = "design-review"
 version = 1
-contract = "graph.v2"
 target_required = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "design-review"

--- a/gascity/formulas/do-work-item.formula.toml
+++ b/gascity/formulas/do-work-item.formula.toml
@@ -8,11 +8,13 @@ Launch inputs:
 """
 formula = "do-work-item"
 version = 1
-contract = "graph.v2"
 extends = ["implementation-item-base"]
 target_required = true
 internal = true
 single_lane = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.context_path]

--- a/gascity/formulas/do-work.formula.toml
+++ b/gascity/formulas/do-work.formula.toml
@@ -10,9 +10,11 @@ Launch inputs:
 """
 formula = "do-work"
 version = 1
-contract = "graph.v2"
 extends = ["implementation-base"]
 target_required = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.context_path]

--- a/gascity/formulas/fix-convoy.formula.toml
+++ b/gascity/formulas/fix-convoy.formula.toml
@@ -8,9 +8,11 @@ Launch inputs:
 """
 formula = "fix-convoy"
 version = 1
-contract = "graph.v2"
 target_required = true
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.report_path]

--- a/gascity/formulas/fix-loop-base.formula.toml
+++ b/gascity/formulas/fix-loop-base.formula.toml
@@ -8,9 +8,11 @@ discipline.
 """
 formula = "fix-loop-base"
 version = 1
-contract = "graph.v2"
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.context_path]

--- a/gascity/formulas/gap-analysis.formula.toml
+++ b/gascity/formulas/gap-analysis.formula.toml
@@ -8,9 +8,11 @@ Launch inputs:
 """
 formula = "gap-analysis"
 version = 1
-contract = "graph.v2"
 target_required = false
 mode = "report"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "gap-analysis"

--- a/gascity/formulas/github-issue-fix-base.formula.toml
+++ b/gascity/formulas/github-issue-fix-base.formula.toml
@@ -27,8 +27,10 @@ Launch inputs:
 """
 formula = "github-issue-fix-base"
 version = 1
-contract = "graph.v2"
 target_required = false
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.github_issue_url]

--- a/gascity/formulas/github-issue-fix-design-review-work.formula.toml
+++ b/gascity/formulas/github-issue-fix-design-review-work.formula.toml
@@ -10,7 +10,9 @@ contract for downstream bead creation.
 formula = "github-issue-fix-design-review-work"
 type = "expansion"
 version = 1
-contract = "graph.v2"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars.mode]
 description = "Issue-fix front-half mode, recorded in artifacts."

--- a/gascity/formulas/github-issue-fix.formula.toml
+++ b/gascity/formulas/github-issue-fix.formula.toml
@@ -18,8 +18,10 @@ Launch inputs:
 formula = "github-issue-fix"
 extends = ["github-issue-fix-base"]
 version = 1
-contract = "graph.v2"
 target_required = false
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "github-issue-fix"

--- a/gascity/formulas/github-issue-triage-base.formula.toml
+++ b/gascity/formulas/github-issue-triage-base.formula.toml
@@ -17,8 +17,10 @@ Launch inputs:
 """
 formula = "github-issue-triage-base"
 version = 1
-contract = "graph.v2"
 target_required = false
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.github_issue_url]

--- a/gascity/formulas/github-issue-triage.formula.toml
+++ b/gascity/formulas/github-issue-triage.formula.toml
@@ -16,8 +16,10 @@ Launch inputs:
 formula = "github-issue-triage"
 extends = ["github-issue-triage-base"]
 version = 1
-contract = "graph.v2"
 target_required = false
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "github-issue-triage"

--- a/gascity/formulas/github-pr-review.formula.toml
+++ b/gascity/formulas/github-pr-review.formula.toml
@@ -19,8 +19,10 @@ Launch inputs:
 """
 formula = "github-pr-review"
 version = 1
-contract = "graph.v2"
 target_required = false
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "github-pr-review"

--- a/gascity/formulas/implement.formula.toml
+++ b/gascity/formulas/implement.formula.toml
@@ -16,9 +16,11 @@ Launch inputs:
 """
 formula = "implement"
 version = 2
-contract = "graph.v2"
 target_required = true
 sling_container_mode = "source"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "implement"

--- a/gascity/formulas/implementation-base.formula.toml
+++ b/gascity/formulas/implementation-base.formula.toml
@@ -8,9 +8,11 @@ source-anchor close contract.
 """
 formula = "implementation-base"
 version = 1
-contract = "graph.v2"
 target_required = true
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.context_path]

--- a/gascity/formulas/implementation-item-base.formula.toml
+++ b/gascity/formulas/implementation-item-base.formula.toml
@@ -7,10 +7,12 @@ per-item procedure while keeping shared-drain sequencing stable.
 """
 formula = "implementation-item-base"
 version = 1
-contract = "graph.v2"
 target_required = true
 internal = true
 single_lane = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.context_path]

--- a/gascity/formulas/planning-base.formula.toml
+++ b/gascity/formulas/planning-base.formula.toml
@@ -8,9 +8,11 @@ artifact paths consumed by entrypoint adapters.
 """
 formula = "planning-base"
 version = 1
-contract = "graph.v2"
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.artifact_root]

--- a/gascity/formulas/publish.formula.toml
+++ b/gascity/formulas/publish.formula.toml
@@ -8,9 +8,11 @@ Launch inputs:
 """
 formula = "publish"
 version = 1
-contract = "graph.v2"
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.final_report]

--- a/gascity/formulas/review.formula.toml
+++ b/gascity/formulas/review.formula.toml
@@ -10,10 +10,12 @@ Launch inputs:
 """
 formula = "review"
 version = 1
-contract = "graph.v2"
 extends = ["code-review-base"]
 target_required = false
 mode = "report"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "review"

--- a/gascity/formulas/same-session-implement.formula.toml
+++ b/gascity/formulas/same-session-implement.formula.toml
@@ -9,9 +9,11 @@ Launch inputs:
 """
 formula = "same-session-implement"
 version = 1
-contract = "graph.v2"
 target_required = true
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.context_path]


### PR DESCRIPTION
Migrates all 34 formulas in `gascity/formulas` from the deprecated
`contract = "graph.v2"` declaration to the `[requires] formula_compiler = ">=2.0.0"`
form that `gc doctor`'s `formula-requirements` check now expects.

**Why:** every consuming city currently emits a `⚠ formula-requirements` doctor
warning per imported formula. This clears the `gascity/formulas` subset of those.

**Scope:** `gascity/formulas` only — a **partial fix for #167**. The
`compound-engineering/` and `bmad/` formulas still carry `contract = "graph.v2"`
and are intentionally left for a follow-up.

**Verification:** all 34 files parse as valid TOML and assert
`requires.formula_compiler == ">=2.0.0"` with no residual `contract` key. The one
remaining `graph.v2` string in `implement.formula.toml` is prose inside a
description, not a declaration.

---

### Mechanical transform
For each `gascity/formulas/*.formula.toml`:
- removed the top-level `contract = "graph.v2"` line
- inserted a `[requires]` table with `formula_compiler = ">=2.0.0"` immediately
  before the first table section (preserving TOML key/table ordering so no
  subsequent top-level key is captured by the new table)

Also updated the stale global invariant in `gascity/formulas/REQUIREMENTS.md`
("Every formula uses `contract = "graph.v2"`") to describe the new `[requires]` form.

35 files changed (34 formulas + REQUIREMENTS.md), +104 / -35.

Fixes the `gascity/formulas` portion of #167.