### PR TITLE
fix(tmux): don't force copy-mode over alternate-screen apps ([0/0] scroll)

### DIFF
--- a/gastown/assets/scripts/tmux-keybindings.sh
+++ b/gastown/assets/scripts/tmux-keybindings.sh
@@ -29,5 +29,11 @@ fi
 # even over mouse-reporting apps (no mouse_any_flag check) so scrollback wins;
 # once in copy-mode the wheel passes through (-M) for normal scrolling, and -e
 # exits at the bottom. Shift+wheel still does native terminal selection.
-gcmux bind-key -T root WheelUpPane   if-shell -F -t= "#{pane_in_mode}" "send-keys -M" "copy-mode -e"
+#
+# Exception — the alternate screen (#{alternate_on}): a full-screen TUI on the
+# alternate buffer (Claude Code, vim, less) has NO tmux scrollback, so forcing
+# copy-mode there just opens an empty [0/0] — "can't scroll back". Hand the wheel
+# to the app instead so it scrolls its own history; scrollback still wins on the
+# main screen, including mouse-reporting apps.
+gcmux bind-key -T root WheelUpPane   if-shell -F -t= "#{||:#{pane_in_mode},#{alternate_on}}" "send-keys -M" "copy-mode -e"
 gcmux bind-key -T root WheelDownPane send-keys -M


### PR DESCRIPTION
## Problem

Scrolling the wheel over a full-screen TUI on the **alternate screen** (Claude Code, vim, less) opens an empty copy-mode — the indicator shows `[0/0]` and nothing scrolls. Users read this as "tmux can't scroll back."

## Why

`tmux-keybindings.sh` binds `WheelUpPane` to force copy-mode over any pane not already in copy-mode. That's deliberate (per the comment): so tmux scrollback wins over app-local scrolling on mouse-reporting apps. But the alternate screen has **no tmux scrollback to enter** — the TUI owns the alternate buffer — so forcing copy-mode there just opens an empty `[0/0]`. The binding's own goal ("scrollback wins") can't be met on the alternate screen; the result is "nothing works."

## Fix

Add `#{alternate_on}` to the passthrough condition:

```diff
-if-shell -F -t= "#{pane_in_mode}" "send-keys -M" "copy-mode -e"
+if-shell -F -t= "#{||:#{pane_in_mode},#{alternate_on}}" "send-keys -M" "copy-mode -e"
```

- **Alternate screen** → `send -M`: hand the wheel to the app so it scrolls its own history (Claude Code scrolls its conversation; less/vim scroll).
- **Main screen** (incl. mouse-reporting apps) → `copy-mode -e`: unchanged — the original "scrollback wins" intent is preserved exactly where scrollback actually exists.
- **Already in copy-mode** → `send -M`: unchanged passthrough.

Keying on `alternate_on` (rather than `mouse_any_flag`) is intentional: it targets the actual defect (no scrollback on the alternate screen) without reversing the deliberate main-screen behavior.

## Testing

- `sh -n` clean.
- tmux accepts the format string live (`if-shell -F "#{||:#{pane_in_mode},#{alternate_on}}" ...`).
- Verified on a live Claude Code pane: `alternate_on=1`, so the wheel now routes to the app instead of an empty copy-mode; main-screen shell panes still enter scrollback.
