### PR TITLE
fix(gascity): accept gc.build.review.v1 reports in the github-pr-review adapter

### DIFF
--- a/gascity/assets/scripts/github_reports.py
+++ b/gascity/assets/scripts/github_reports.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+import validate_build_artifact
 import validate_verdict_report
 
 try:
@@ -45,7 +46,13 @@ class ValidationError(Exception):
 
 
 YAML_ERROR_TYPES = (yaml.YAMLError,) if yaml is not None else ()
-CLI_ERROR_TYPES = (OSError, UnicodeDecodeError, ValidationError, validate_verdict_report.ValidationError) + YAML_ERROR_TYPES
+CLI_ERROR_TYPES = (
+    OSError,
+    UnicodeDecodeError,
+    ValidationError,
+    validate_verdict_report.ValidationError,
+    validate_build_artifact.ValidationError,
+) + YAML_ERROR_TYPES
 
 
 @dataclass(frozen=True)
@@ -137,6 +144,60 @@ def review_outcome(verdict: str, severity: str) -> str:
     raise ValidationError(f"unsupported review verdict/severity combination: {verdict}/{severity}")
 
 
+REVIEW_REPORT_SCHEMAS = {"gc.verdict-report.v1", "gc.build.review.v1"}
+BUILD_REVIEW_STATUS_OUTCOMES = {
+    "approved": "approve",
+    "questions": "comment",
+    "changes_required": "request_changes",
+    "blocked": "block",
+}
+
+
+@dataclass(frozen=True)
+class ReviewOutcome:
+    schema: str
+    outcome: str
+    report_label: str
+
+
+def build_review_outcome(status: str) -> str:
+    outcome = BUILD_REVIEW_STATUS_OUTCOMES.get(status)
+    if outcome is None:
+        raise ValidationError(
+            f"review report status must be a final review status "
+            f"{sorted(BUILD_REVIEW_STATUS_OUTCOMES)}, got {status!r}"
+        )
+    return outcome
+
+
+def peek_report_schema(text: str) -> str:
+    if yaml is None:
+        raise ValidationError("PyYAML is required to parse review reports")
+    match = FRONT_MATTER_RE.match(text)
+    if not match:
+        raise ValidationError("review report must start with YAML front matter")
+    data = yaml.safe_load(match.group("body")) or {}
+    if not isinstance(data, dict):
+        raise ValidationError("review report front matter must be a mapping")
+    return required_string(data, "schema")
+
+
+def load_review_outcome(text: str) -> ReviewOutcome:
+    schema = peek_report_schema(text)
+    if schema == "gc.verdict-report.v1":
+        report = validate_verdict_report.validate_report_text(text, expected_kind="review")
+        return ReviewOutcome(
+            schema=schema,
+            outcome=review_outcome(report.verdict, report.severity),
+            report_label=f"{report.verdict}/{report.severity}",
+        )
+    if schema == "gc.build.review.v1":
+        artifact = validate_build_artifact.validate_artifact_text(text, expected_schema=schema)
+        status = str(artifact.front_matter["status"]).strip()
+        return ReviewOutcome(schema=schema, outcome=build_review_outcome(status), report_label=status)
+    raise ValidationError(f"review report schema must be one of {sorted(REVIEW_REPORT_SCHEMAS)}, got {schema!r}")
+
+
 def render_pr_review_comment(
     report_path: Path,
     *,
@@ -145,9 +206,9 @@ def render_pr_review_comment(
     artifact_ref: str = "",
     human_approved: bool = False,
 ) -> str:
-    report = validate_verdict_report.validate_report_text(report_path.read_text(encoding="utf-8"), expected_kind="review")
-    if outcome != review_outcome(report.verdict, report.severity):
-        raise ValidationError(f"outcome {outcome!r} does not match review report {report.verdict}/{report.severity}")
+    report = load_review_outcome(report_path.read_text(encoding="utf-8"))
+    if outcome != report.outcome:
+        raise ValidationError(f"outcome {outcome!r} does not match review report {report.report_label}")
     head_sha = marker_value("head_sha", head_sha)
     artifact = public_line("artifact_ref", artifact_ref or str(report_path))
     gate_text = "human approved" if human_approved else "not human approved"
@@ -155,7 +216,7 @@ def render_pr_review_comment(
         f"<!-- gc:github-pr-review head_sha={head_sha} outcome={outcome} -->\n"
         "## GC PR Review\n\n"
         f"- outcome: {outcome}\n"
-        f"- report: {report.verdict}/{report.severity}\n"
+        f"- report: {report.report_label}\n"
         f"- gate: {gate_text}\n"
         f"- artifact: {artifact}\n"
     )
@@ -328,11 +389,10 @@ def main(argv: list[str] | None = None) -> int:
             )
             output = {"ok": True, "verdict": report.verdict, "recommended_next_action": report.recommended_next_action}
         elif args.command == "review-outcome":
-            report = validate_verdict_report.validate_report_text(args.path.read_text(encoding="utf-8"), expected_kind="review")
-            output = {"ok": True, "outcome": review_outcome(report.verdict, report.severity)}
+            report = load_review_outcome(args.path.read_text(encoding="utf-8"))
+            output = {"ok": True, "outcome": report.outcome, "schema": report.schema}
         elif args.command == "render-review-comment":
-            report = validate_verdict_report.validate_report_text(args.report_path.read_text(encoding="utf-8"), expected_kind="review")
-            outcome = review_outcome(report.verdict, report.severity)
+            outcome = load_review_outcome(args.report_path.read_text(encoding="utf-8")).outcome
             args.output.write_text(
                 render_pr_review_comment(
                     args.report_path,

--- a/gascity/assets/workflows/github-pr-review/render-comment.md
+++ b/gascity/assets/workflows/github-pr-review/render-comment.md
@@ -1,9 +1,13 @@
 
 Read workflow root metadata from `gc bd show <root-bead-id> --json`. Validate the
 generic review verdict report at `gc.github.review_report_path` and map it with
-`{{pack_root}}/assets/scripts/github_reports.py review-outcome`:
+`{{pack_root}}/assets/scripts/github_reports.py review-outcome`. Both review
+report schemas are accepted. For `gc.verdict-report.v1`:
 `pass/none -> approve`, `fail/minor -> comment`, `fail/major -> request_changes`,
-and `fail/blocker -> block`.
+and `fail/blocker -> block`. For `gc.build.review.v1` (what the generic `review`
+formula emits): `approved -> approve`, `questions -> comment`,
+`changes_required -> request_changes`, and `blocked -> block`; non-final
+statuses (`draft`, `superseded`) are rejected.
 
 If workflow root metadata has `gc.github.reused_current_output=true`, validate
 that `gc.github.comment_path` points to an existing `comment.md` under

--- a/gascity/assets/workflows/github-pr-review/run-review.md
+++ b/gascity/assets/workflows/github-pr-review/run-review.md
@@ -47,6 +47,9 @@ If the selected formula does not declare the mode vars, omit the two mode
 
 Do not close this step until `REPORT_PATH` exists and validates through
 `{{pack_root}}/assets/scripts/github_reports.py review-outcome "$REPORT_PATH"`.
+The validator accepts either review report schema (`gc.verdict-report.v1` or
+`gc.build.review.v1`, the latter being what the generic `review` formula
+emits) and returns the mapped outcome.
 Persist the review handoff and result on workflow root metadata:
 `gc bd update <root-bead-id> --set-metadata gc.github.review_subject_path="$SUBJECT_PATH" --set-metadata gc.github.review_report_path="$REPORT_PATH" --set-metadata gc.github.review_outcome=<approve|comment|request_changes|block>`.
 

--- a/gascity/tests/test_github_reports.py
+++ b/gascity/tests/test_github_reports.py
@@ -12,6 +12,40 @@ sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "assets" / 
 import github_reports
 
 
+def build_review_report(status: str) -> str:
+    return (
+        "---\n"
+        "schema: gc.build.review.v1\n"
+        "workflow:\n"
+        "  id: wf-1\n"
+        "  formula: review\n"
+        "methodology:\n"
+        "  pack: gascity\n"
+        "  name: implementation-review\n"
+        "producer:\n"
+        "  formula: review\n"
+        "  stage: write-report\n"
+        "  attempt: 1\n"
+        f"status: {status}\n"
+        "trace:\n"
+        "  upstream: []\n"
+        "  coverage: []\n"
+        "---\n"
+        "\n"
+        "## Verdict\n"
+        "\n"
+        "Verdict text.\n"
+        "\n"
+        "## Findings\n"
+        "\n"
+        "Findings text.\n"
+        "\n"
+        "## Verification\n"
+        "\n"
+        "Verification text.\n"
+    )
+
+
 class GitHubReportsTests(unittest.TestCase):
     def test_validate_triage_report_accepts_expected_front_matter(self) -> None:
         report = """---
@@ -79,6 +113,71 @@ recommended_next_action: ask_reporter
 
         with self.assertRaises(github_reports.ValidationError):
             github_reports.review_outcome("pass", "minor")
+
+    def test_load_review_outcome_maps_build_review_statuses(self) -> None:
+        expected = {
+            "approved": "approve",
+            "questions": "comment",
+            "changes_required": "request_changes",
+            "blocked": "block",
+        }
+        for status, outcome in expected.items():
+            report = github_reports.load_review_outcome(build_review_report(status))
+            self.assertEqual(report.outcome, outcome)
+            self.assertEqual(report.schema, "gc.build.review.v1")
+            self.assertEqual(report.report_label, status)
+
+    def test_load_review_outcome_rejects_non_final_build_review_statuses(self) -> None:
+        for status in ("draft", "superseded"):
+            with self.assertRaisesRegex(github_reports.ValidationError, "final review status"):
+                github_reports.load_review_outcome(build_review_report(status))
+
+    def test_load_review_outcome_rejects_unknown_schema(self) -> None:
+        report = "---\nschema: gc.some-other.v1\n---\n\nBody.\n"
+        with self.assertRaisesRegex(github_reports.ValidationError, "gc.build.review.v1"):
+            github_reports.load_review_outcome(report)
+
+    def test_load_review_outcome_accepts_verdict_report_schema(self) -> None:
+        report = (
+            "---\n"
+            "schema: gc.verdict-report.v1\n"
+            "kind: review\n"
+            "verdict: pass\n"
+            "severity: none\n"
+            "---\n"
+        )
+        parsed = github_reports.load_review_outcome(report)
+        self.assertEqual(parsed.outcome, "approve")
+        self.assertEqual(parsed.report_label, "pass/none")
+
+    def test_render_pr_review_comment_accepts_build_review_schema(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            review_path = pathlib.Path(tmp) / "review.md"
+            review_path.write_text(build_review_report("approved"), encoding="utf-8")
+            comment = github_reports.render_pr_review_comment(
+                review_path,
+                outcome="approve",
+                head_sha="abc123",
+                artifact_ref="artifact",
+            )
+            with self.assertRaisesRegex(github_reports.ValidationError, "does not match"):
+                github_reports.render_pr_review_comment(review_path, outcome="block")
+
+        self.assertIn("<!-- gc:github-pr-review", comment)
+        self.assertIn("outcome: approve", comment)
+        self.assertIn("report: approved", comment)
+
+    def test_review_outcome_cli_accepts_build_review_schema(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            review_path = pathlib.Path(tmp) / "review.md"
+            review_path.write_text(build_review_report("changes_required"), encoding="utf-8")
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                exit_code = github_reports.main(["review-outcome", str(review_path)])
+
+        self.assertEqual(exit_code, 0)
+        self.assertIn('"outcome": "request_changes"', stdout.getvalue())
+        self.assertIn('"schema": "gc.build.review.v1"', stdout.getvalue())
 
     def test_renderers_write_sticky_marker_comments(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
`github-pr-review` is non-functional end-to-end with its default `code_review_formula=review`: the review runs and produces a valid report, but the adapter's hand-off rejects it and the PR comment is never posted.

**Root cause:** the adapter validated review reports only against `gc.verdict-report.v1`, but its default delegate — the generic `review` formula — emits `gc.build.review.v1`. A report that passed the review formula's own gate could never validate through the adapter (`kind must be a non-empty string`), so the workflow blocked before rendering the comment on every run.

**Fix (issue's ranked option 1 — localized, non-breaking):** `review-outcome` and `render-review-comment` now dispatch on the report's front-matter `schema`. Verdict reports keep the existing verdict/severity mapping; build-review reports map `status` → outcome (`approved→approve`, `questions→comment`, `changes_required→request_changes`, `blocked→block`) and reject non-final statuses (`draft`, `superseded`). No existing `gc.build.review.v1` consumer changes — the adapter's accepted input just widens.

## Verification
- `python3 -m unittest gascity.tests.test_github_reports` → **17 passed** (6 new: schema dispatch, status mapping, non-final rejection, unknown-schema rejection, render + CLI accept build-review).

---
Files: `gascity/assets/scripts/github_reports.py` (+78/−11), `github-pr-review/render-comment.md`, `github-pr-review/run-review.md`, `gascity/tests/test_github_reports.py` (+99).

Fixes gastownhall/gascity#4247

🤖 Generated with [Claude Code](https://claude.com/claude-code)
