### PR TITLE
fix(gastown): bound and single-flight status-line.sh store queries

### DIFF
--- a/gastown/assets/scripts/status-line.sh
+++ b/gastown/assets/scripts/status-line.sh
@@ -20,6 +20,19 @@ fi
 run_bounded() {
     if command -v timeout >/dev/null 2>&1; then
         timeout 2s "$@"
+    elif command -v perl >/dev/null 2>&1; then
+        # macOS ships no coreutils timeout. A plain alarm+exec is not enough:
+        # the Go runtime swallows SIGALRM, so gc would run unbounded anyway.
+        # Fork and SIGTERM (then SIGKILL) the child instead — Go honors TERM.
+        perl -e '
+            my $t = shift @ARGV;
+            my $p = fork;
+            if (!$p) { exec @ARGV or exit 127 }
+            $SIG{ALRM} = sub { kill "TERM", $p; select undef, undef, undef, 0.5; kill "KILL", $p; waitpid $p, 0; exit 124 };
+            alarm $t;
+            waitpid $p, 0;
+            exit($? >> 8);
+        ' 2 "$@"
     else
         "$@"
     fi
@@ -80,17 +93,36 @@ if is_number "$now" && is_number "$mtime" && [ "$mtime" -gt 0 ] && [ "$((now - m
     is_number "${w:-}" || w=0
     is_number "${m:-}" || m=0
 else
-    # Preserve gc hook ready-work semantics while bounding tmux refreshes.
-    w=$(json_array_count gc hook "$agent")
-
-    # Preserve gc mail check unread/recipient-route semantics while caching.
-    m=$(first_number gc mail check "$agent")
-
+    # Single-flight: only one render per agent may refresh; concurrent
+    # renders serve the stale cache instead of piling more gc (store)
+    # queries onto an already-slow store — stacked slow renders are the
+    # exact feedback loop that makes the store slower.
     mkdir -p "$cache_dir" 2>/dev/null || true
     if [ "$cache_private" = 1 ]; then
         chmod 700 "$cache_dir" 2>/dev/null || true
     fi
-    printf '%s %s\n' "${w:-0}" "${m:-0}" > "$cache" 2>/dev/null || true
+    lock="$cache.lock"
+    if mkdir "$lock" 2>/dev/null; then
+        trap 'rmdir "$lock" 2>/dev/null' EXIT INT TERM
+
+        # Preserve gc hook ready-work semantics while bounding tmux refreshes.
+        w=$(json_array_count gc hook "$agent")
+
+        # Preserve gc mail check unread/recipient-route semantics while caching.
+        m=$(first_number gc mail check "$agent")
+
+        printf '%s %s\n' "${w:-0}" "${m:-0}" > "$cache" 2>/dev/null || true
+    else
+        # Refresh already in flight: serve stale values. Break locks older
+        # than 120s so a killed refresher cannot wedge the status line.
+        lock_mtime=$(cache_mtime "$lock")
+        if is_number "$lock_mtime" && [ "$lock_mtime" -gt 0 ] && [ "$((now - lock_mtime))" -gt 120 ]; then
+            rmdir "$lock" 2>/dev/null || true
+        fi
+        read -r w m < "$cache" 2>/dev/null || true
+        is_number "${w:-}" || w=0
+        is_number "${m:-}" || m=0
+    fi
 fi
 
 # Format: agent | hook-icon N | mail-icon N  (omit segments that are 0)


### PR DESCRIPTION
status-line.sh piles up concurrent renders that each hit the bead store, self-amplifying exactly when the store is already slow. Observed live: 4 concurrent renders for one session, the oldest at 32s.

Two compounding bugs:

1. **`run_bounded` silently runs unbounded on macOS** — there is no coreutils `timeout`, so the fallback branch runs `gc hook` + `gc mail check` with no bound; under a slow store a single render hangs for 30s+. A plain `alarm`+`exec` fallback is not enough either: the Go runtime swallows SIGALRM, so `gc` sails past the alarm (verified: python child dies at 2s, gc child survives). The perl fallback forks and SIGTERMs (then SIGKILLs) the child, which Go honors.

2. **No single-flight**: while one slow render holds a stale cache, every tmux status tick (5s in gastown sessions) misses the cache and spawns its own full refresh. Refreshes now take a `mkdir` lock; losers serve the stale cache instead of piling on. Locks older than 120s are broken so a killed refresher cannot wedge the status line.

Measured on the affected host (dolt-backed store under load): refresher render 28s → 5.2s worst case; concurrent render 28s → 0.12s (stale-served); cache hit 0.09s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)