### PR TITLE
feat(gascity): add deterministic worktree lifecycle

### DIFF
--- a/docs/plans/workspace-scope-and-cleanup.md
+++ b/docs/plans/workspace-scope-and-cleanup.md
@@ -1,0 +1,280 @@
+# Workspace Reuse and Cleanup Plan
+
+## Goal
+
+Reuse one worktree for each co-located implementation unit instead of creating a
+new worktree for every drained step.
+
+Workspace ownership is derived from the implementation graph:
+
+- an implementation convoy with no epics owns one worktree;
+- an implementation convoy with epics uses one worktree per epic;
+- every runnable item in the same owner reuses that owner's worktree.
+
+There is no public workspace-scope selector. Agent session context and workspace
+ownership remain independent.
+
+## Scope
+
+This change is limited to workspace ownership, sequential reuse, and successful
+cleanup.
+
+Reuse the existing:
+
+- formula and drain boundaries;
+- host-local workspace command;
+- common-Git state root;
+- managed worktree path behavior;
+- file locking;
+- repository, worktree registration, detached-HEAD, and cleanliness checks.
+
+Do not add a result ledger, service, lease, fence, TTL, garbage collector,
+cross-host protocol, distributed transaction, telemetry, force deletion,
+destructive repair, review/publish integration, or compatibility layer.
+
+Commits and beads remain the durable implementation record. Workspace command
+state is transient bookkeeping for a local worktree.
+
+## Existing Boundary
+
+This checkout contains every required boundary: pack formulas, workflow prompts,
+the bead graph exposed through `gc bd`, and the host-local workspace command.
+
+Relevant pack files:
+
+- `gascity/formulas/implement.formula.toml`
+- `gascity/formulas/do-work.formula.toml`
+- `gascity/commands/workspace/run.sh`
+- `gascity/commands/workspace/help.md`
+- `gascity/commands/workspace/command.toml`
+- `gascity/tests/test_workspace_script.py`
+- the focused formula and workflow-asset tests
+
+Separate drain may continue creating one full `do-work` child workflow per leaf
+member. The workspace command's per-owner lock and state serialize preparation
+and handoff locally; no renderer or dispatcher change is required.
+
+## Automatic Workspace Ownership
+
+The user does not select workspace scope and workflow prompts do not pass a
+scope override.
+
+`run.sh` derives the immutable owner directly from existing graph data:
+
+1. resolve the claimed step's workflow root and source anchor as today;
+2. read the source anchor's `parent_convoy_id`;
+3. use that parent convoy as the workspace owner;
+4. read the owner's own `parent_convoy_id` only to classify it:
+   - empty parent: top-level convoy owner;
+   - non-empty parent: nested convoy/epic owner;
+5. fail closed on missing, malformed, or ambiguous graph identity.
+
+No new metadata protocol or user-facing selector is introduced. `run.sh` does
+not accept `--scope-kind`, `--scope-id`, an arbitrary state path, or an arbitrary
+worktree path.
+
+Every workspace action validates that the current graph-derived owner matches
+existing transient state and that the claimed source anchor is the current item
+when the action requires it.
+
+## Workspace Identity and Transient State
+
+Derive the state file, lock, and worktree name from:
+
+```text
+common Git repository identity + workspace owner kind + workspace owner ID
+```
+
+Including the kind prevents identical convoy and epic ID text from colliding.
+Keep state beneath the existing common-Git state root and preserve the current
+worktree-parent behavior.
+
+The local state contains only what is needed to validate and hand off the
+checkout:
+
+```text
+repository identity
+workspace_owner_kind
+workspace_owner_id
+worktree_path
+current_item = {
+  source_anchor_id,
+  input_oid,
+  phase,
+  output_oid
+}
+```
+
+Valid phases are the existing preparation/entry/result phases or direct renamed
+equivalents. A completed current item retains its output OID until the next item
+enters or cleanup succeeds.
+
+This state is not authoritative after acceptance and is not a historical result
+store.
+
+## Prepare and Reuse
+
+Use the existing `prepare` action. Do not add a general lifecycle transition.
+
+### First item for an owner
+
+When no state or worktree exists for the derived owner:
+
+1. resolve the supplied input ref to a commit;
+2. create the detached worktree using the existing safe path behavior;
+3. record that item as current;
+4. return the authoritative worktree path and input OID.
+
+### Replay of the current item
+
+An exact replay succeeds only when the owner, source anchor, input OID, state,
+path, worktree registration, and Git facts match. Conflicting replay fails
+without mutation.
+
+### Next item for the same owner
+
+`prepare` is the owner lane: a different item waits while current owner state is
+active and advances atomically only after the current item records a result.
+
+`prepare` may replace completed item A with item B only when:
+
+- A is in the completed/result phase with an output OID;
+- the worktree is registered to the expected repository;
+- the worktree is detached and clean, including no untracked files;
+- `HEAD` equals A's recorded output OID;
+- B resolves to the same workspace owner. Its launch input is advisory after the
+  first item; the previous recorded output becomes B's authoritative input.
+
+After those checks, retain the worktree path and record B as current. Never
+replace an active or incomplete item. On any mismatch, retain the state and
+worktree and fail closed.
+
+This supports a linear commit chain within each owner. Different epic owners use
+different worktrees and may be scheduled independently.
+
+## Existing Actions and Results
+
+`path`, `verify-entry`, `record-result`, and `result` continue to operate on the
+claimed current item.
+
+- `verify-entry` requires the expected clean detached input checkout.
+- `record-result` records the current clean detached output commit.
+- `result` returns the current item's exact source anchor, input OID, output OID,
+  and worktree path for source-anchor close.
+- Unknown or previous items cannot read the current item's transient result.
+
+The existing bead and commit boundary persists each accepted item before the
+owner lane advances. Historical lookup after that point is not a
+workspace-command responsibility.
+
+## Pack-Local Serialization
+
+`prepare` holds the derived owner's state lock while validating or advancing the
+workspace. If another item is active, it waits and retries. Once the current item
+has recorded a clean result, the next item atomically becomes current and uses
+the recorded output OID as its input. Different owners use different locks and
+worktrees, so they may proceed independently.
+
+This is local serialization only. A failed or interrupted active item retains
+state and blocks later items for that owner rather than permitting unsafe reuse.
+
+## Cleanup
+
+Add `cleanup-if-complete` to the workspace command and invoke it from the
+existing close-source-anchor prompt after that prompt closes and verifies its
+exact source anchor.
+
+The action queries existing beads, selects every direct source member whose
+`parent_convoy_id` equals the derived owner, and requires all of them to be
+`status=closed` with `gc.outcome=pass`. Earlier successful items return
+`cleanup=retained`. The last successful item validates completed result state,
+the clean detached output, and exact worktree registration, then removes the
+worktree without force and deletes transient state. Malformed or ambiguous graph
+data fails closed.
+Removal uses `git worktree remove` without `--force` and deletes transient state
+only after removal succeeds.
+
+If validation or removal fails, retain the worktree and state and report the
+path and reason. Session exit is not a cleanup trigger.
+
+If both the derived state and derived worktree are already absent, repeated
+cleanup succeeds as an already-completed no-op. If only one exists or facts are
+ambiguous, fail closed.
+
+## Pack Changes
+
+Update only behavior directly affected by owner derivation, reuse, and cleanup:
+
+- workspace command implementation, help, manifest description, and focused
+  tests;
+- close-source-anchor prompt wiring for `cleanup-if-complete`;
+- `implementation-base` and `do-work` prepare/implement/close wording where it
+  currently assumes one worktree per item;
+- focused requirements and README text that documents this command behavior.
+
+Do not change same-session/shared drain behavior, review/fix, publish/PR, remote
+operations, or unrelated formulas.
+
+## Tests
+
+### Workspace command tests
+
+Cover:
+
+1. first item creates one owner worktree;
+2. two sequential items with the same convoy owner reuse the same path;
+3. two sequential items with the same epic owner reuse the same path;
+4. different owner IDs and different owner kinds do not collide;
+5. exact current-item replay succeeds and conflicting replay fails;
+6. next input must equal the completed current `HEAD`;
+7. active, dirty, untracked, attached, wrong-HEAD, wrong-owner, path-substituted,
+   and registration-substituted reuse fails without mutation;
+8. `result` works for the current completed item and rejects a previous or
+   unknown item;
+9. safe cleanup removes the registered worktree and transient state;
+10. unsafe or failed cleanup retains both and never uses force;
+11. repeated cleanup with both derived artifacts absent is harmless; an
+    ambiguous partial absence fails closed.
+
+### Formula and workflow tests
+
+Prove:
+
+- no public workspace-scope selector or new owner metadata protocol exists;
+- workspace ownership is derived from existing `parent_convoy_id` graph fields;
+- prompts use the existing workspace actions;
+- source-anchor close reads the current item's exact result, closes and verifies
+  that exact anchor, then invokes `cleanup-if-complete`;
+- same-session/shared drain behavior is unchanged.
+
+## Acceptance
+
+The change is complete when:
+
+1. a convoy without epics uses one worktree for its serialized implementation
+   items;
+2. a convoy with epics uses one worktree per epic;
+3. items sharing an owner form a verified linear commit chain in one worktree;
+4. different owners cannot collide;
+5. accepted results remain durable in existing beads and commits, independent of
+   transient workspace cleanup;
+6. the command lock prevents overlapping owner handoffs while different owners
+   remain independent;
+7. the last successful direct member removes the owner worktree and transient
+   state;
+8. failed, dirty, interrupted, incomplete, or ambiguous workspaces are retained;
+9. cleanup never uses force;
+10. no unrelated lifecycle or architecture is introduced.
+## Review Gate
+
+Reject an implementation that:
+
+- adds a user-selected workspace scope;
+- creates a host-local historical result ledger;
+- permits overlapping writers for one owner;
+- lets prompts or agents own cleanup;
+- cleans an unsuccessful or incomplete owner;
+- force-removes or destructively repairs a worktree;
+- changes same-session/shared drain behavior;
+- introduces a new scheduler, service, lease, garbage collector, or cross-host
+  protocol.

--- a/gascity/REQUIREMENTS.md
+++ b/gascity/REQUIREMENTS.md
@@ -61,6 +61,13 @@ For every base-pack formula, prompt asset, adapter, or public override change:
 - **Gas City fanout** - A durable formula expansion or graph branch that
   replaces upstream subagent/task-tool dispatch while preserving reviewer or
   worker perspective.
+- **Graph-owned workspace lifecycle** - Deterministic host-local preparation,
+  per-owner serialization, verified entry, result recording, safe sequential
+  reuse, and successful terminal cleanup for a convoy or nested convoy/epic
+  owner. Commits and beads remain durable; workspace state is transient. It does
+  not provide integration, review/fix, publish, restart, cross-host, or
+  garbage-collection behavior.
+
 - **Artifact validator** - The shared base-pack validator invoked by
   formula-specific check steps to validate front matter, structural markdown,
   coverage, traceability, and schema identity.
@@ -758,6 +765,29 @@ Proof expectation: validation requires `workflow.formula`, `producer.formula`,
 `producer.stage`, `producer.attempt`, `methodology.pack`, and
 `methodology.name`, and does not require owner or role fields.
 
+### GC-METH-TS-009: Preserve Graph-Owned Workspace Identity
+
+As the implementation workflow, separately drained stages need one exact,
+locally recorded detached worktree per convoy or nested convoy/epic owner from
+preparation through owner completion, because co-located items must form one
+verified commit chain without treating ambient checkout state as authoritative.
+
+Proof expectation: prompt contracts invoke the rendered pack-local workspace
+asset for prepare, path, entry verification, result recording, current-item
+result lookup, and conditional terminal cleanup; script tests exercise owner
+serialization, linear reuse, graph completeness, Git validation, cleanup,
+filesystem, subprocess, and transient local-state behavior.
+### GC-METH-TS-010: Keep Unsupported Lifecycles Outside Workspace Claims
+
+As a pack maintainer, I need same-session drains and downstream integration,
+review/fix, publish, restart, cross-host, and garbage collection to remain
+outside the graph-owned workspace contract, so a deterministic local worktree
+is not misrepresented as an end-to-end delivery lifecycle.
+
+Proof expectation: same-session core and derived prompt owners contain no
+workspace-script wiring, and script scenarios reject unsupported actions without
+side effects, force deletion, or destructive repair.
+
 ## Behavior Requirements
 
 | ID | Trace | Requirement |
@@ -816,6 +846,13 @@ Proof expectation: validation requires `workflow.formula`, `producer.formula`,
 | GC-METH-BR-051 | GC-METH-US-001 | WHEN prerequisite inputs already exist for a build stage, THE base pack SHALL provide reusable `build-from-*-base` continuation suffixes that validate those prerequisites, perform only their owned stage or handoff, and delegate to the next suffix without silently rerunning skipped upstream stages. |
 | GC-METH-BR-052 | GC-METH-US-002 | WHEN a methodology pack needs a continuation entrypoint, THE pack SHOULD extend the matching `build-from-*-base` suffix and override selectors, routes, drain formulas, or review expansions instead of copying the suffix graph. |
 | GC-METH-BR-053 | GC-METH-US-001 | WHEN a user wants the built-in Gas City continuation behavior, THE base pack SHALL provide cataloged `build-from-*` wrappers that extend the matching suffix bases. |
+| GC-METH-BR-054 | GC-METH-TS-009 | WHEN a separately drained implementation is prepared, THE prompt SHALL invoke `gc gc workspace prepare` with the claimed step ID and an explicit input ref, and SHALL NOT derive the worktree from ambient `$PWD`, mutate source-anchor `work_dir`, or perform destructive repair. |
+| GC-METH-BR-055 | GC-METH-TS-009 | BEFORE a separately drained implementation reads or mutates source, THE prompt SHALL obtain the authoritative path with `gc gc workspace path` and require `verify-entry`; AFTER clean commit and verification, it SHALL require `record-result`; source-anchor close SHALL require `result` and use its exact source-anchor ID, path, input OID, and output OID. |
+| GC-METH-BR-056 | GC-METH-TS-009 | WHEN the workspace command records lifecycle state, THE state SHALL remain host-local under the repository common Git directory, keyed by repository and graph-derived convoy or nested convoy/epic owner; a waiting next item SHALL atomically inherit the prior recorded output as its input only after that item reaches result phase. |
+| GC-METH-BR-057 | GC-METH-TS-010 | WHEN implementation uses `same-session` shared-drain item formulas, core and derived shared-drain assets SHALL remain outside `gc gc workspace` wiring and SHALL NOT claim deterministic setup, checkpoint, fallback, or result semantics from the graph-owned lifecycle. |
+| GC-METH-BR-058 | GC-METH-TS-010 | WHEN callers request integration, review/fix, publish/PR, restart inheritance, cross-host reuse, garbage collection, or force removal from `gc gc workspace`, THE command SHALL fail closed without remote operations, destructive repair, lifecycle beads, or a canonical integrated result. |
+| GC-METH-BR-060 | GC-METH-TS-009 | AFTER close-source-anchor closes and verifies its exact source anchor, IT SHALL call `cleanup-if-complete`; that action SHALL retain the workspace until every direct member of the graph-derived owner is closed with `gc.outcome=pass`, then remove the clean completed worktree without force and delete transient state. |
+| GC-METH-BR-059 | GC-METH-TS-009 | WHEN the workspace command resolves a source anchor, IT SHALL derive ownership from the anchor's existing `parent_convoy_id`, classify a nested parent convoy as an epic owner, and fail closed on missing, malformed, or ambiguous graph identity. |
 
 ## Scenario Ledger
 

--- a/gascity/assets/workflows/do-work/close-source-anchor.md
+++ b/gascity/assets/workflows/do-work/close-source-anchor.md
@@ -1,13 +1,31 @@
 
-Resolve `<source-anchor-id>` using the same rules as `prepare-worktree`. Read `work_dir` from the source anchor and verify the implementation commit and
-summary evidence are present in that worktree. Write per-item summary to
-{{summary_path}} when set. If `summary_path` is not set, first use
-`gc.implementation.summary_path` from the preceding implementation step when it
-is present; otherwise use `{{artifact_root}}/task-<source-anchor-id>-summary.md`.
+Obtain the recorded current-item implementation result for this claimed step:
 
-On success, close only `<source-anchor-id>` with `gc.outcome=pass`. Include the
-verified commit and summary path in the source-anchor close reason. Read the
-source anchor back with `gc bd show <source-anchor-id> --json` and verify
-`status=closed` and `gc.outcome=pass`; if either check fails, fix the source
-anchor before closing this step. Do not close this step with pass while the source anchor remains open. Then close this step. Do not close the drain-unit
-convoy, parent convoy, or broader workflow root from this step.
+```sh
+gc gc workspace result --step-id "<claimed-step-id>"
+```
+
+Use only its exact source anchor, prepared workspace, input revision, and output
+revision for implementation-commit and summary evidence checks; do not infer or
+reconstruct any of them.
+
+Write the per-item summary to {{summary_path}} when set. If `summary_path` is
+not set, first use `gc.implementation.summary_path` from the preceding
+implementation step when present; otherwise use
+`{{artifact_root}}/task-<source-anchor-id>-summary.md`.
+
+On success, close only the recorded source anchor with `gc.outcome=pass`.
+Include the verified exact output revision and summary path in the source-anchor
+close reason. Read the source anchor back with
+`gc bd show <source-anchor-id> --json` and verify `status=closed` and
+`gc.outcome=pass`; if either check fails, fix the source anchor before invoking
+conditional cleanup:
+
+```sh
+gc gc workspace cleanup-if-complete --step-id "<claimed-step-id>"
+```
+
+Treat `cleanup=retained`, `cleanup=removed`, and `cleanup=already-removed` as
+successful outcomes. Any command failure is hard; do not close this step with
+pass after a failure. Then close this step. Do not close the drain-unit convoy,
+parent convoy, or broader workflow root from this step.

--- a/gascity/assets/workflows/do-work/implement.md
+++ b/gascity/assets/workflows/do-work/implement.md
@@ -1,32 +1,37 @@
 
-Resolve `<source-anchor-id>` using the same rules as `prepare-worktree`. For a
-synthetic drain-unit convoy, the source anchor is the original drain member in
-`gc.drain_member_id`, not the synthetic convoy id. Read `work_dir` from the source anchor, never read `work_dir` from the synthetic drain-unit convoy,
-validate that it is an absolute existing git worktree, set `WORKTREE` to that
-path, then `cd "$WORKTREE"` before reading or editing source files. If
-`work_dir` is missing, invalid, or points at the launcher checkout, fail this step before editing.
+Before any source read, edit, test, hash, `git add`, or `git commit`, obtain and
+verify the authoritative convoy- or epic-owned workspace for this claimed item:
 
-Do not infer the source anchor from dependency ids such as the
-`prepare-worktree` step. Read the claimed step bead's `gc.root_bead_id`, read
-that do-work root with `gc bd show <root-bead-id> --json`, then read the root
-metadata `gc.input_convoy_id`. Read that input convoy with `gc bd show
-<input-convoy-id> --json`; if the JSON output is a one-element list, unwrap the
-first element before reading metadata. If the input convoy has
-`gc.synthetic_kind=drain-unit-convoy`, use its `gc.drain_member_id` as the
-source anchor. Otherwise use the input convoy id as the source anchor. Then
-read the source anchor and use only its `work_dir` metadata as `WORKTREE`.
+```sh
+gc gc workspace path --step-id "<claimed-step-id>"
+gc gc workspace verify-entry --step-id "<claimed-step-id>"
+```
 
-`gc.work_dir` is the launcher rig root, not the implementation worktree. Use
-`gc.work_dir` only later to run `.gc/scripts/checks/build-artifact-valid.sh`.
-After resolving `WORKTREE`, run `cd "$WORKTREE"` and verify `pwd -P` equals
-`$WORKTREE` before any source read, source edit, test, file hash, `git add`, or
-`git commit`. If a command uses the launcher checkout path for source edits,
-verification, hashes, or commits, the step is invalid and must fail.
+Work only in the returned workspace. Treat a missing or invalid workspace as
+fatal. Do not infer or reconstruct its location and do not repair workspace
+state.
 
-Do not edit files in the launcher checkout. Implement only the owned source
-anchor boundary, run sandboxed verification from inside the worktree, and make a
-focused commit in the worktree. Leave the source anchor open for
-`close-source-anchor`; close only this implementation step when done.
+Implement only the owned source-anchor boundary, run sandboxed verification
+inside the workspace, and make a focused commit there. Leave the source anchor
+open for `close-source-anchor`; close only this implementation step when done.
+
+After implementation, tests, and the focused commit are complete, require a
+clean workspace and run:
+
+```sh
+gc gc workspace record-result --step-id "<claimed-step-id>"
+```
+
+No-change results are valid; do not close this step with pass until that command
+succeeds.
+
+For artifact validation, read the launcher rig root from the workflow root bead's `gc.work_dir`, then run:
+
+```sh
+GC_BEAD_ID="$CLAIMED_STEP_ID" .gc/scripts/checks/build-artifact-valid.sh
+```
+
+fix every reported validation error before setting `gc.outcome=pass`.
 
 Write or update the task summary with these schema-required body sections,
 using the exact `##` headings below in this order:
@@ -74,4 +79,4 @@ Trace front matter must use the validator shape exactly:
   requirements; do not use `approved` in `trace.coverage[].status` or the
   Markdown coverage table.
 
-Artifact validation: this step is gated by `.gc/scripts/checks/build-artifact-valid.sh`, which validates the summary recorded at `gc.implementation.summary_path` (fallbacks `gc.build.implementation_summary_path`, then `gc.var.summary_path`) against schema `gc.build.implementation-summary.v1`. Before closing this step, read the launcher rig root from the workflow root bead's `gc.work_dir`, then run the same validator locally from that rig root with `GC_BEAD_ID=<claimed-step-id> .gc/scripts/checks/build-artifact-valid.sh`; fix every reported validation error before setting `gc.outcome=pass`. On repair attempts (`gc.attempt` greater than 1), read the validator errors from `gc.attempt_log` on the validation loop control bead (the dependent of this step bead) and repair the summary in place instead of rewriting it. Two bounded repair attempts follow the first failure; exhausting them closes this stage with `gc.outcome=fail` and machine-readable validation errors that block downstream stages. Never ask questions in headless mode; record unresolved ambiguity inside the summary.
+Artifact validation gates this step and validates the summary recorded at `gc.implementation.summary_path` (fallbacks `gc.build.implementation_summary_path`, then `gc.var.summary_path`) against schema `gc.build.implementation-summary.v1`. Fix every reported validation error before setting `gc.outcome=pass`. On repair attempts (`gc.attempt` greater than 1), read the validator errors from `gc.attempt_log` on the validation loop control bead (the dependent of this step bead) and repair the summary in place instead of rewriting it. Two bounded repair attempts follow the first failure; exhausting them closes this stage with `gc.outcome=fail` and machine-readable validation errors that block downstream stages. Never ask questions in headless mode; record unresolved ambiguity inside the summary.

--- a/gascity/assets/workflows/do-work/prepare-worktree.md
+++ b/gascity/assets/workflows/do-work/prepare-worktree.md
@@ -1,28 +1,17 @@
 
-Resolve and publish the isolated worktree for this item. This is infrastructure
-setup only. Do not edit source files in the launcher checkout.
+Prepare the graph-owned workspace for this item. Items in the same convoy or
+epic owner reuse one serialized worktree. This is infrastructure setup only;
+do not edit source files during this step.
 
-1. Read current step bead metadata and get `gc.root_bead_id`; hard-fail if it is
-   missing. Read that do-work root with `gc bd show <root-bead-id> --json`.
-2. Resolve `<source-anchor-id>` from the do-work root:
-   - read root metadata `gc.input_convoy_id`; hard-fail if it is missing
-   - verify `gc.input_convoy_id` matches rendered runtime convoy `{{convoy_id}}`
-   - read that input convoy with `gc bd show <input-convoy-id> --json`
-   - if input convoy metadata has `gc.synthetic_kind=drain-unit-convoy`, use
-     input convoy metadata `gc.drain_member_id`
-   - do not use the synthetic drain-unit convoy id as `<source-anchor-id>`;
-     hard-fail if the selected source anchor id equals the synthetic input convoy id
-   - otherwise use `<input-convoy-id>` as the source anchor
-   - if root metadata also has `gc.drain_member_id`, it must match the selected
-     drain member
-3. Validate context path {{context_path}}, files ownership, and verification
-   policy for the resolved source anchor.
-4. Create or reuse a deterministic git worktree at
-   `$(pwd)/worktrees/<source-anchor-id>`. If the path is missing, run
-   `git worktree add "$WORKTREE" --detach HEAD`. If the path exists but is not
-   the worktree for this repository, fail closed.
-5. Persist the absolute path on the source anchor with
-   `gc bd update <source-anchor-id> --set-metadata work_dir=<absolute worktree path>`.
-   For synthetic drain-unit convoys, never persist `work_dir` on the synthetic drain-unit convoy; the original drain member/source anchor is authoritative.
-   Verify the source anchor now has `work_dir` before closing this step with
-   `gc.outcome=pass`.
+1. Validate the supplied context path {{context_path}}, file ownership, and
+   verification policy for the source anchor represented by this workflow.
+2. Prepare the workspace with:
+   ```sh
+   gc gc workspace prepare --step-id "<claimed-step-id>" --input-ref "<input-revision>"
+   ```
+   Use its returned `worktree_path` and `input_oid` as authoritative. Confirm
+   the workspace exists and its input revision matches the intended source
+   revision.
+3. Close this step with `gc.outcome=pass` only after the command succeeds. A
+   failure is hard; do not reset, checkout, prune, delete, adopt, or otherwise
+   repair workspace state.

--- a/gascity/assets/workflows/implement/drain-separate.md
+++ b/gascity/assets/workflows/implement/drain-separate.md
@@ -1,6 +1,8 @@
 
 Use core graph.v2 drain to materialize one full `do-work` lifecycle per
-selected non-convoy runnable member. The pack does not enumerate members before
-formula instantiation; core owns drain-unit convoy creation and manifest state.
-Drain item workflows route through implementation target
+selected non-convoy runnable member. The workspace command derives the owning
+convoy or nested convoy directly from the source anchor's existing
+`parent_convoy_id` graph fields. The pack does not enumerate members before
+formula instantiation; core continues to own drain-unit convoy creation and
+manifest state. Drain item workflows route through implementation target
 {{implementation_target}} and this pack's operator role agents.

--- a/gascity/assets/workflows/implementation-base/close-source-anchor.md
+++ b/gascity/assets/workflows/implementation-base/close-source-anchor.md
@@ -2,6 +2,24 @@ This is the `implementation-base` methodology contract source-anchor close
 step.
 
 Concrete methodology packs override this step only when they need additional
-artifact checks. Verify the implementation result and close the source anchor
-before this workflow step closes pass. If `{{summary_path}}` is set, write or
-verify the per-item implementation summary there before closing.
+artifact checks. Core separately drained implementations obtain the recorded
+current-item result for this claimed step with:
+
+```sh
+gc gc workspace result --step-id "<claimed-step-id>"
+```
+
+Use only its exact source anchor, prepared workspace, input revision, and output
+revision for existing implementation-result and summary checks. Never infer or
+reconstruct those values. Write the per-item summary to `{{summary_path}}` when
+set. Otherwise first use `gc.implementation.summary_path` from the preceding
+implementation step when present, then fall back to
+`{{artifact_root}}/task-<source-anchor-id>-summary.md`.
+
+Close only the recorded source anchor with `gc.outcome=pass`, including the
+exact output revision and summary path in the close reason. Read that source
+anchor back and verify `status=closed` and `gc.outcome=pass`, then call
+`gc gc workspace cleanup-if-complete --step-id "<claimed-step-id>"`. Retained,
+removed, and already-removed are successful outcomes; command failure is hard
+and prevents this workflow step from closing with pass. Do not close a
+drain-unit convoy, parent convoy, or broader workflow root.

--- a/gascity/assets/workflows/implementation-base/implement.md
+++ b/gascity/assets/workflows/implementation-base/implement.md
@@ -4,12 +4,33 @@ Concrete methodology packs override this step to apply their native
 implementation discipline. Work only inside the prepared worktree and preserve
 the source anchor for the close step.
 
-Default fallback behavior must still enforce the worktree contract: resolve the
-source anchor from workflow metadata, read `work_dir` from that source anchor,
-and `cd "$WORKTREE"` before source reads, edits, tests, hashes, or commits.
-`gc.work_dir` is the launcher rig root, not the implementation worktree. When
-reading beads with `gc bd show --json`, handle both an object and a one-element
-list before reading metadata.
+Core separately drained implementations obtain and verify their owner workspace
+before any source read, edit, test, hash, `git add`, or `git commit`:
+
+```sh
+gc gc workspace path --step-id "<claimed-step-id>"
+gc gc workspace verify-entry --step-id "<claimed-step-id>"
+```
+
+Work only in the returned workspace. Treat a missing or invalid workspace as
+fatal. Never infer or reconstruct its location, and do not repair workspace
+state. After a clean commit and test completion, record the exact result:
+
+```sh
+gc gc workspace record-result --step-id "<claimed-step-id>"
+```
+
+No-change results are valid. Close this step with pass only after that command
+succeeds.
+
+For artifact validation, read the launcher rig root from the workflow root bead's `gc.work_dir`, then run:
+
+```sh
+GC_BEAD_ID="$CLAIMED_STEP_ID" .gc/scripts/checks/build-artifact-valid.sh
+```
+
+fix every reported validation error before setting `gc.outcome=pass`.
+
 
 Write the per-item implementation summary as a `gc.build.implementation-summary.v1`
 artifact and record its absolute path on the workflow root bead as
@@ -24,4 +45,4 @@ order:
 - `## Verification`
 - `## Remaining Risks`
 
-Artifact validation: this step is gated by `.gc/scripts/checks/build-artifact-valid.sh`, which validates the summary recorded at `gc.implementation.summary_path` (fallbacks `gc.build.implementation_summary_path`, then `gc.var.summary_path`) against schema `gc.build.implementation-summary.v1`. Before closing this step, read the launcher rig root from the workflow root bead's `gc.work_dir`, then run the same validator locally from that rig root with `GC_BEAD_ID=<claimed-step-id> .gc/scripts/checks/build-artifact-valid.sh`; fix every reported validation error before setting `gc.outcome=pass`. On repair attempts (`gc.attempt` greater than 1), read the validator errors from `gc.attempt_log` on the validation loop control bead (the dependent of this step bead) and repair the summary in place instead of rewriting it. Two bounded repair attempts follow the first failure; exhausting them closes this stage with `gc.outcome=fail` and machine-readable validation errors that block downstream stages. Never ask questions in headless mode; record unresolved ambiguity inside the summary.
+Artifact validation gates this step and validates the summary recorded at `gc.implementation.summary_path` (fallbacks `gc.build.implementation_summary_path`, then `gc.var.summary_path`) against schema `gc.build.implementation-summary.v1`. Fix every reported validation error before setting `gc.outcome=pass`. On repair attempts (`gc.attempt` greater than 1), read the validator errors from `gc.attempt_log` on the validation loop control bead (the dependent of this step bead) and repair the summary in place instead of rewriting it. Two bounded repair attempts follow the first failure; exhausting them closes this stage with `gc.outcome=fail` and machine-readable validation errors that block downstream stages. Never ask questions in headless mode; record unresolved ambiguity inside the summary.

--- a/gascity/assets/workflows/implementation-base/prepare-worktree.md
+++ b/gascity/assets/workflows/implementation-base/prepare-worktree.md
@@ -2,6 +2,18 @@ This is the `implementation-base` methodology contract worktree preparation
 step.
 
 Concrete methodology packs override this step only when their implementation
-items need different setup. Preserve the source-anchor metadata contract, pass
-through optional context `{{context_path}}`, and do not edit launcher-checkout
-files here.
+items need different setup. Preserve optional context `{{context_path}}` and do
+not edit source files here.
+
+Core separately drained implementations prepare their graph-owned workspace with:
+
+```sh
+gc gc workspace prepare --step-id "<claimed-step-id>" --input-ref "<input-revision>"
+```
+
+Use the returned `worktree_path` and `input_oid` as authoritative. The command
+automatically reuses the convoy- or epic-owned worktree when this item follows a
+completed item in the same owner. Confirm the workspace exists and its input
+revision matches the intended source revision. Never reconstruct the workspace
+or attempt destructive repair. Close preparation with pass only after the
+command succeeds.

--- a/gascity/commands/workspace/command.toml
+++ b/gascity/commands/workspace/command.toml
@@ -1,0 +1,2 @@
+description = "Reuse and clean deterministic convoy- or epic-owned worktrees"
+run = "run.sh"

--- a/gascity/commands/workspace/help.md
+++ b/gascity/commands/workspace/help.md
@@ -1,0 +1,31 @@
+Manage deterministic host-local worktrees shared by the convoy or epic that
+owns each separately drained implementation item.
+
+Usage:
+
+```sh
+gc gc workspace prepare --step-id <claimed-step-id> --input-ref <git-revision>
+gc gc workspace path --step-id <claimed-step-id>
+gc gc workspace verify-entry --step-id <claimed-step-id>
+gc gc workspace record-result --step-id <claimed-step-id>
+gc gc workspace result --step-id <claimed-step-id>
+gc gc workspace cleanup --step-id <claimed-step-id>
+gc gc workspace cleanup-if-complete --step-id <claimed-step-id>
+```
+
+`prepare` creates, exactly replays, or safely advances the detached workspace
+for the claimed item's graph-derived owner. Items owned by the same convoy or
+epic reuse one clean linear worktree. `path` returns the recorded workspace.
+`verify-entry` requires a clean detached workspace at the recorded input.
+`record-result` records the clean output revision; `result` returns that exact
+current-item result for source-anchor close. `cleanup-if-complete` queries the
+existing bead graph after that exact anchor closes. It retains the workspace
+until every direct member of the derived owner is closed with `gc.outcome=pass`;
+the last successful item removes the clean result worktree without force and
+deletes transient state. Prompts invoke this conditional action; `cleanup`
+remains the strict unconditional operation for validated orchestration.
+
+`prepare` optionally accepts `--workspace-parent <path>`; otherwise it creates
+worktrees beneath the rig root. The command requires `GC_WORK_DIR` (or the
+legacy `GC_RIG_ROOT`) to identify that root. It rejects unsupported lifecycle
+actions, destructive repair, and cross-host reuse.

--- a/gascity/commands/workspace/run.sh
+++ b/gascity/commands/workspace/run.sh
@@ -1,0 +1,325 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() { printf 'workspace: %s\n' "$*" >&2; exit 1; }
+need_value() { [ "$#" -ge 2 ] || fail "missing value for $1"; [ -n "$2" ] || fail "empty value for $1"; case "$2" in -*) fail "malformed value for $1";; esac; }
+
+[ "$#" -ge 1 ] || fail "missing action"
+ACTION=$1; shift
+case "$ACTION" in prepare|path|verify-entry|record-result|result|cleanup|cleanup-if-complete) ;; *) fail "unknown action: $ACTION";; esac
+STEP_ID= INPUT_REF= WORKSPACE_PARENT=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --step-id) [ -z "$STEP_ID" ] || fail "duplicate --step-id"; need_value "$@"; STEP_ID=$2; shift 2;;
+    --input-ref) [ "$ACTION" = prepare ] || fail "--input-ref is only valid for prepare"; [ -z "$INPUT_REF" ] || fail "duplicate --input-ref"; need_value "$@"; INPUT_REF=$2; shift 2;;
+    --workspace-parent) [ "$ACTION" = prepare ] || fail "--workspace-parent is only valid for prepare"; [ -z "$WORKSPACE_PARENT" ] || fail "duplicate --workspace-parent"; need_value "$@"; WORKSPACE_PARENT=$2; shift 2;;
+    *) fail "unknown argument: $1";;
+  esac
+done
+[ -n "$STEP_ID" ] || fail "missing --step-id"
+if [ "$ACTION" = prepare ]; then [ -n "$INPUT_REF" ] || fail "missing --input-ref"; fi
+GC_WORK_DIR=${GC_WORK_DIR:-${GC_RIG_ROOT:-}}
+[ -n "$GC_WORK_DIR" ] || fail "GC_WORK_DIR or GC_RIG_ROOT is required"
+
+canonical_dir() { python3 - "$1" <<'PY'
+import os,sys
+p=sys.argv[1]
+if not os.path.isdir(p): raise SystemExit(1)
+print(os.path.realpath(p))
+PY
+}
+RIG_ROOT=$(canonical_dir "$GC_WORK_DIR") || fail "GC_WORK_DIR is not an existing directory"
+unset GIT_DIR GIT_WORK_TREE
+if [ -d "$RIG_ROOT/.git" ] && [ "$(git --git-dir="$RIG_ROOT/.git" rev-parse --is-bare-repository 2>/dev/null || :)" = true ]; then
+  REPO_KIND=control; COMMON_GIT_DIR=$(canonical_dir "$RIG_ROOT/.git") || fail "invalid bare .git control repository"
+elif git -C "$RIG_ROOT" rev-parse --git-common-dir >/dev/null 2>&1 && [ "$(git -C "$RIG_ROOT" rev-parse --is-bare-repository 2>/dev/null || :)" = false ]; then
+  REPO_KIND=ordinary; RAW_COMMON=$(git -C "$RIG_ROOT" rev-parse --path-format=absolute --git-common-dir) || fail "cannot resolve Git common directory"; COMMON_GIT_DIR=$(canonical_dir "$RAW_COMMON") || fail "invalid Git common directory"
+elif [ "$(git --git-dir="$RIG_ROOT" rev-parse --is-bare-repository 2>/dev/null || :)" = true ]; then
+  REPO_KIND=bare; COMMON_GIT_DIR=$RIG_ROOT
+else fail "GC_WORK_DIR does not identify a supported Git repository"; fi
+GIT=(git --git-dir="$COMMON_GIT_DIR")
+
+show_bead() { gc bd show "$1" --json 2>/dev/null || fail "gc bd show failed for $1"; }
+json_string_field() { python3 -c '
+import json,sys
+label,key=sys.argv[1:]
+try: value=json.load(sys.stdin)
+except Exception: raise SystemExit(f"malformed JSON for {label}")
+if isinstance(value,list):
+ if len(value)!=1: raise SystemExit(f"ambiguous JSON array for {label}")
+ value=value[0]
+if not isinstance(value,dict): raise SystemExit(f"malformed object for {label}")
+result=value.get(key,"")
+if result is None: result=""
+if not isinstance(result,str): raise SystemExit(f"malformed {key} on {label}")
+print(result)
+' "$1" "$2"; }
+metadata_value() { python3 -c '
+import json,sys
+label,key=sys.argv[1:]
+try: value=json.load(sys.stdin)
+except Exception: raise SystemExit(f"malformed JSON for {label}")
+if isinstance(value,list):
+ if len(value)!=1: raise SystemExit(f"ambiguous JSON array for {label}")
+ value=value[0]
+if not isinstance(value,dict): raise SystemExit(f"malformed object for {label}")
+metadata=value.get("metadata")
+if not isinstance(metadata,dict): raise SystemExit(f"malformed metadata for {label}")
+result=metadata.get(key,"")
+if result is None: result=""
+if not isinstance(result,str): raise SystemExit(f"malformed {key} on {label}")
+print(result)
+' "$1" "$2"; }
+STEP_JSON=$(show_bead "$STEP_ID")
+ROOT_ID=$(metadata_value "$STEP_ID" gc.root_bead_id <<<"$STEP_JSON") || fail "invalid step metadata"
+[ -n "$ROOT_ID" ] || fail "missing gc.root_bead_id on $STEP_ID"
+ROOT_JSON=$(show_bead "$ROOT_ID")
+CONVOY_ID=$(metadata_value "$ROOT_ID" gc.input_convoy_id <<<"$ROOT_JSON") || fail "invalid workflow root metadata"
+[ -n "$CONVOY_ID" ] || fail "missing gc.input_convoy_id on $ROOT_ID"
+ROOT_DRAIN=$(metadata_value "$ROOT_ID" gc.drain_member_id <<<"$ROOT_JSON") || fail "invalid workflow root metadata"
+CONVOY_JSON=$(show_bead "$CONVOY_ID")
+SYNTHETIC_KIND=$(metadata_value "$CONVOY_ID" gc.synthetic_kind <<<"$CONVOY_JSON") || fail "invalid input convoy metadata"
+if [ "$SYNTHETIC_KIND" = drain-unit-convoy ]; then
+  SOURCE_ANCHOR_ID=$(metadata_value "$CONVOY_ID" gc.drain_member_id <<<"$CONVOY_JSON") || fail "invalid input convoy metadata"
+  [ -n "$SOURCE_ANCHOR_ID" ] || fail "missing gc.drain_member_id on drain-unit convoy $CONVOY_ID"
+  [ "$SOURCE_ANCHOR_ID" != "$CONVOY_ID" ] || fail "drain-unit convoy cannot anchor itself"
+else SOURCE_ANCHOR_ID=$CONVOY_ID; fi
+if [ -n "$ROOT_DRAIN" ] && [ "$ROOT_DRAIN" != "$SOURCE_ANCHOR_ID" ]; then fail "workflow root drain member does not match source anchor"; fi
+SOURCE_JSON=$(show_bead "$SOURCE_ANCHOR_ID")
+OWNER_ID=$(json_string_field "$SOURCE_ANCHOR_ID" parent_convoy_id <<<"$SOURCE_JSON") || fail "invalid source anchor graph identity"
+[ -n "$OWNER_ID" ] || fail "source anchor has no parent convoy"
+OWNER_JSON=$(show_bead "$OWNER_ID")
+OWNER_PARENT_ID=$(json_string_field "$OWNER_ID" parent_convoy_id <<<"$OWNER_JSON") || fail "invalid workspace owner graph identity"
+if [ -n "$OWNER_PARENT_ID" ]; then OWNER_KIND=epic; else OWNER_KIND=convoy; fi
+
+read -r OWNER_DIGEST NAME_DIGEST HOST_ID <<EOF
+$(python3 - "$COMMON_GIT_DIR" "$OWNER_KIND" "$OWNER_ID" <<'PY'
+import hashlib,socket,sys
+common,kind,owner=sys.argv[1:]
+value=common+"\0"+kind+"\0"+owner
+digest=hashlib.sha256(value.encode()).hexdigest()
+print(digest,digest[:20],socket.gethostname())
+PY
+)
+EOF
+SAFE_PREFIX=$(python3 - "$OWNER_ID" <<'PY'
+import re,sys
+s=re.sub(r"[^A-Za-z0-9._-]+","-",sys.argv[1]).strip(".-_")[:32]
+print(s or "workspace")
+PY
+)
+WORKTREE_NAME="$SAFE_PREFIX-$NAME_DIGEST"
+STATE_DIR="$COMMON_GIT_DIR/gc-workspace-state/$OWNER_KIND"
+STATE_FILE="$STATE_DIR/$OWNER_DIGEST.json"
+LOCK_DIR="$STATE_FILE.lock"; LOCK_OWNED=0
+cleanup_lock() { if [ "$LOCK_OWNED" = 1 ]; then python3 - "$LOCK_DIR" <<'PY' 2>/dev/null || :
+import os,sys
+try: os.unlink(os.path.join(sys.argv[1],"owner.json")); os.rmdir(sys.argv[1])
+except FileNotFoundError: pass
+PY
+fi; }
+trap cleanup_lock EXIT HUP INT TERM
+acquire_lock() { python3 - "$STATE_DIR" "$LOCK_DIR" "$HOST_ID" <<'PY' || return 1
+import json,os,sys
+state_dir,lock_dir,host=sys.argv[1:]; os.makedirs(state_dir,mode=0o700,exist_ok=True)
+try: os.mkdir(lock_dir,0o700)
+except FileExistsError:
+ print("workspace lock already exists",file=sys.stderr); raise SystemExit(1)
+with open(os.path.join(lock_dir,"owner.json"),"x",encoding="utf-8") as f: json.dump({"pid":os.getpid(),"host_id":host},f,separators=(",",":"))
+PY
+LOCK_OWNED=1; }
+release_lock() { cleanup_lock; LOCK_OWNED=0; }
+
+owner_complete() {
+  gc bd list --all --json --limit=0 2>/dev/null | python3 -c '
+import json,sys
+owner,current=sys.argv[1:]
+try: values=json.load(sys.stdin)
+except Exception: raise SystemExit(2)
+if not isinstance(values,list): raise SystemExit(2)
+members=[]
+for value in values:
+ if not isinstance(value,dict): raise SystemExit(2)
+ parent=value.get("parent_convoy_id","")
+ if parent is None: parent=""
+ if not isinstance(parent,str): raise SystemExit(2)
+ if parent==owner: members.append(value)
+member_ids=[]
+for value in members:
+ ident=value.get("id")
+ if not isinstance(ident,str) or not ident: raise SystemExit(2)
+ member_ids.append(ident)
+if not members or current not in member_ids or len(member_ids)!=len(set(member_ids)):
+ raise SystemExit(2)
+for value in members:
+ metadata=value.get("metadata",{})
+ if not isinstance(metadata,dict): raise SystemExit(2)
+ if value.get("status")!="closed" or metadata.get("gc.outcome")!="pass": raise SystemExit(1)
+' "$OWNER_ID" "$SOURCE_ANCHOR_ID"
+}
+
+emit_cleanup() { python3 - "$1" "$OWNER_KIND" "$OWNER_ID" <<'PY'
+import json,sys
+status,kind,owner=sys.argv[1:]
+print(json.dumps({"cleanup":status,"workspace_owner_kind":kind,"workspace_owner_id":owner},separators=(",",":")))
+PY
+}
+
+managed_worktree_absent() {
+  [ ! -e "$RIG_ROOT/worktrees/$WORKTREE_NAME" ] && [ ! -L "$RIG_ROOT/worktrees/$WORKTREE_NAME" ] || return 1
+  "${GIT[@]}" worktree list --porcelain -z | python3 -c '
+import os,sys
+name=sys.argv[1]
+raw=sys.stdin.buffer.read()
+if raw and not raw.endswith(b"\0"): raise SystemExit(2)
+for field in raw.split(b"\0"):
+ if not field: continue
+ if field.startswith(b"worktree "):
+  path=os.fsdecode(field[len(b"worktree "):])
+  if os.path.basename(path)==name: raise SystemExit(1)
+' "$WORKTREE_NAME"
+}
+
+state_field() { python3 - "$STATE_FILE" "$1" <<'PY'
+import json,sys
+path,field=sys.argv[1:]
+expected={"version","workspace_owner_kind","workspace_owner_id","source_anchor_id","host_id","common_git_dir","worktree_path","input_oid","phase","output_oid"}
+try:
+ with open(path,encoding="utf-8") as f: state=json.load(f)
+except Exception as e: raise SystemExit(f"invalid workspace state: {e}")
+if not isinstance(state,dict) or set(state)!=expected: raise SystemExit("workspace state has invalid fields")
+if state["version"]!=2 or any(not isinstance(state[k],str) for k in expected-{"version"}): raise SystemExit("workspace state has invalid values")
+if state["phase"] not in ("preparing","entry","result"): raise SystemExit("workspace state has invalid phase")
+print(state[field])
+PY
+}
+write_state() { python3 - "$STATE_FILE" "$OWNER_KIND" "$OWNER_ID" "$SOURCE_ANCHOR_ID" "$HOST_ID" "$COMMON_GIT_DIR" "$WORKTREE_PATH" "$INPUT_OID" "$PHASE" "$OUTPUT_OID" <<'PY'
+import json,os,sys,tempfile
+path,kind,owner,anchor,host,common,worktree,input_oid,phase,output_oid=sys.argv[1:]
+state={"version":2,"workspace_owner_kind":kind,"workspace_owner_id":owner,"source_anchor_id":anchor,"host_id":host,"common_git_dir":common,"worktree_path":worktree,"input_oid":input_oid,"phase":phase,"output_oid":output_oid}
+fd,tmp=tempfile.mkstemp(prefix=".state-",dir=os.path.dirname(path),text=True)
+try:
+ with os.fdopen(fd,"w",encoding="utf-8") as f: json.dump(state,f,separators=(",",":")); f.write("\n"); f.flush(); os.fsync(f.fileno())
+ os.replace(tmp,path)
+finally:
+ try: os.unlink(tmp)
+ except FileNotFoundError: pass
+PY
+}
+load_state() {
+  [ -f "$STATE_FILE" ] || fail "workspace state not found"
+  STATE_OWNER_KIND=$(state_field workspace_owner_kind) || fail "cannot read workspace state"; STATE_OWNER_ID=$(state_field workspace_owner_id) || fail "cannot read workspace state"; STATE_ANCHOR=$(state_field source_anchor_id) || fail "cannot read workspace state"; STATE_HOST=$(state_field host_id) || fail "cannot read workspace state"; STATE_COMMON=$(state_field common_git_dir) || fail "cannot read workspace state"
+  WORKTREE_PATH=$(state_field worktree_path) || fail "cannot read workspace state"; INPUT_OID=$(state_field input_oid) || fail "cannot read workspace state"; PHASE=$(state_field phase) || fail "cannot read workspace state"; OUTPUT_OID=$(state_field output_oid) || fail "cannot read workspace state"
+  [ "$STATE_OWNER_KIND" = "$OWNER_KIND" ] || fail "workspace state owner kind mismatch"; [ "$STATE_OWNER_ID" = "$OWNER_ID" ] || fail "workspace state owner mismatch"; [ "$STATE_HOST" = "$HOST_ID" ] || fail "workspace state belongs to another host"; [ "$STATE_COMMON" = "$COMMON_GIT_DIR" ] || fail "workspace state repository mismatch"
+  case "$WORKTREE_PATH" in /*) ;; *) fail "recorded worktree path is not absolute";; esac
+  EXPECTED_NAME=$(python3 - "$OWNER_ID" "$NAME_DIGEST" <<'PY'
+import re,sys
+s=re.sub(r"[^A-Za-z0-9._-]+","-",sys.argv[1]).strip(".-_")[:32]
+print((s or "workspace")+"-"+sys.argv[2])
+PY
+)
+  [ "$(basename "$WORKTREE_PATH")" = "$EXPECTED_NAME" ] || fail "recorded worktree path does not match workspace identity"
+}
+is_registered_path() { "${GIT[@]}" worktree list --porcelain | python3 -c 'import os,sys; target=os.path.realpath(sys.argv[1]); found=any(line.startswith("worktree ") and os.path.realpath(line[9:].rstrip("\n"))==target for line in sys.stdin); raise SystemExit(0 if found else 1)' "$WORKTREE_PATH"; }
+validate_path_registration() {
+  [ -d "$WORKTREE_PATH" ] || fail "recorded worktree path is missing"; [ ! -L "$WORKTREE_PATH" ] || fail "recorded worktree path is a symlink"
+  CANON_WORKTREE=$(canonical_dir "$WORKTREE_PATH") || fail "cannot canonicalize recorded worktree"; [ "$CANON_WORKTREE" = "$WORKTREE_PATH" ] || fail "recorded worktree canonical path changed"; is_registered_path || fail "recorded worktree is not registered"
+  ACTUAL_COMMON=$(git -C "$WORKTREE_PATH" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || fail "recorded path is not a Git worktree"; ACTUAL_COMMON=$(canonical_dir "$ACTUAL_COMMON") || fail "worktree common directory is invalid"; [ "$ACTUAL_COMMON" = "$COMMON_GIT_DIR" ] || fail "worktree belongs to another repository"
+}
+validate_detached_clean() {
+  git -C "$WORKTREE_PATH" symbolic-ref -q HEAD >/dev/null 2>&1 && fail "worktree HEAD is attached"
+  HEAD_OID=$(git -C "$WORKTREE_PATH" rev-parse --verify HEAD 2>/dev/null) || fail "worktree HEAD is invalid"; STATUS=$(git -C "$WORKTREE_PATH" status --porcelain=v1 --untracked-files=all) || fail "cannot inspect worktree status"; [ -z "$STATUS" ] || fail "worktree is dirty"
+  WORKTREE_GIT_DIR=$(git -C "$WORKTREE_PATH" rev-parse --path-format=absolute --git-dir) || fail "cannot resolve worktree Git directory"
+  python3 - "$WORKTREE_GIT_DIR" <<'PY' || fail "worktree has an in-progress Git operation"
+import os,sys
+markers=("MERGE_HEAD","CHERRY_PICK_HEAD","REVERT_HEAD","REBASE_HEAD","BISECT_LOG","sequencer","rebase-apply","rebase-merge")
+raise SystemExit(1 if any(os.path.exists(os.path.join(sys.argv[1],marker)) for marker in markers) else 0)
+PY
+}
+emit_json() { python3 - "$WORKTREE_PATH" "$INPUT_OID" "$OUTPUT_OID" "$PHASE" "$SOURCE_ANCHOR_ID" <<'PY'
+import json,sys
+path,input_oid,output_oid,phase,source_anchor_id=sys.argv[1:]
+result={"worktree_path":path,"input_oid":input_oid,"phase":phase,"source_anchor_id":source_anchor_id}
+if output_oid: result["output_oid"]=output_oid
+print(json.dumps(result,separators=(",",":")))
+PY
+}
+
+if [ "$ACTION" = prepare ]; then
+  while :; do
+    if acquire_lock; then
+      if [ ! -f "$STATE_FILE" ]; then break; fi
+      load_state
+      if [ "$STATE_ANCHOR" = "$SOURCE_ANCHOR_ID" ] || [ "$PHASE" = result ]; then break; fi
+      release_lock
+    fi
+    sleep 1
+  done
+else
+  acquire_lock || fail "cannot acquire workspace lock"
+fi
+if { [ "$ACTION" = cleanup ] || [ "$ACTION" = cleanup-if-complete ]; } && [ ! -f "$STATE_FILE" ]; then
+  managed_worktree_absent || fail "workspace state is absent but the managed worktree still exists or is ambiguous"
+  if [ "$ACTION" = cleanup-if-complete ]; then emit_cleanup already-removed; fi
+  exit 0
+fi
+if [ "$ACTION" = prepare ]; then
+  REQUESTED_INPUT=$("${GIT[@]}" rev-parse --verify "$INPUT_REF^{commit}" 2>/dev/null) || fail "input ref does not resolve to a commit"
+  if [ -f "$STATE_FILE" ]; then
+    load_state
+    if [ -n "$WORKSPACE_PARENT" ]; then REQUESTED_PARENT=$(canonical_dir "$WORKSPACE_PARENT") || fail "workspace parent must already exist on replay"; [ "$(dirname "$WORKTREE_PATH")" = "$REQUESTED_PARENT" ] || fail "workspace parent does not match recorded state"; fi
+    validate_path_registration; validate_detached_clean
+    if [ "$STATE_ANCHOR" = "$SOURCE_ANCHOR_ID" ]; then
+      [ "$REQUESTED_INPUT" = "$INPUT_OID" ] || fail "input revision does not match recorded state"
+      case "$PHASE" in entry) [ "$HEAD_OID" = "$INPUT_OID" ] || fail "entry HEAD does not match recorded input";; result) [ "$HEAD_OID" = "$OUTPUT_OID" ] || fail "result HEAD does not match recorded output";; preparing) [ "$HEAD_OID" = "$INPUT_OID" ] || fail "preparing HEAD does not match recorded input"; PHASE=entry; write_state;; esac
+    else
+      [ "$PHASE" = result ] || fail "cannot replace an incomplete workspace item"
+      [ -n "$OUTPUT_OID" ] || fail "completed workspace item has no output"
+      [ "$HEAD_OID" = "$OUTPUT_OID" ] || fail "completed item HEAD does not match recorded output"
+      INPUT_OID=$OUTPUT_OID; PHASE=entry; OUTPUT_OID=; write_state
+    fi
+  else
+    INPUT_OID=$REQUESTED_INPUT
+    if [ -z "$WORKSPACE_PARENT" ]; then [ "$REPO_KIND" != bare ] || fail "true bare repository requires --workspace-parent"; WORKSPACE_PARENT="$RIG_ROOT/worktrees"; fi
+    REQUESTED_PARENT=$(python3 - "$WORKSPACE_PARENT" <<'PY'
+import os,sys
+print(os.path.realpath(os.path.abspath(sys.argv[1])))
+PY
+)
+    python3 - "$REQUESTED_PARENT" <<'PY' || fail "cannot create workspace parent"
+import os,sys
+os.makedirs(sys.argv[1],mode=0o755,exist_ok=True)
+PY
+    WORKSPACE_PARENT=$(canonical_dir "$REQUESTED_PARENT") || fail "invalid workspace parent"
+    WORKTREE_PATH="$WORKSPACE_PARENT/$WORKTREE_NAME"; [ ! -e "$WORKTREE_PATH" ] && [ ! -L "$WORKTREE_PATH" ] || fail "workspace path already exists"; PHASE=preparing; OUTPUT_OID=; write_state
+    if ! "${GIT[@]}" worktree add --detach "$WORKTREE_PATH" "$INPUT_OID" >/dev/null; then fail "git worktree add failed; retained preparing state at $WORKTREE_PATH"; fi
+    validate_path_registration; validate_detached_clean; [ "$HEAD_OID" = "$INPUT_OID" ] || fail "created worktree HEAD does not match input"; PHASE=entry; write_state
+  fi
+else
+  load_state
+  [ "$STATE_ANCHOR" = "$SOURCE_ANCHOR_ID" ] || fail "action must use the current workspace item"
+fi
+
+case "$ACTION" in
+  prepare) emit_json;;
+  path) validate_path_registration; printf '%s\n' "$WORKTREE_PATH";;
+  verify-entry) [ "$PHASE" = entry ] || fail "workspace is not in entry phase"; validate_path_registration; validate_detached_clean; [ "$HEAD_OID" = "$INPUT_OID" ] || fail "entry HEAD does not match recorded input"; emit_json;;
+  record-result)
+    case "$PHASE" in
+      entry) validate_path_registration; validate_detached_clean; "${GIT[@]}" merge-base --is-ancestor "$INPUT_OID" "$HEAD_OID" || fail "result does not descend from input"; "${GIT[@]}" rev-list --parents "$INPUT_OID..$HEAD_OID" | python3 -c 'import sys; raise SystemExit(1 if any(len(line.split()) > 2 for line in sys.stdin) else 0)' || fail "result history is not linear"; OUTPUT_OID=$HEAD_OID; PHASE=result; write_state;;
+      result) validate_path_registration; validate_detached_clean; [ "$HEAD_OID" = "$OUTPUT_OID" ] || fail "recorded result HEAD changed";;
+      *) fail "workspace is not ready to record a result";;
+    esac
+    emit_json;;
+  result) [ "$PHASE" = result ] && [ -n "$OUTPUT_OID" ] || fail "workspace result is not recorded"; validate_path_registration; validate_detached_clean; [ "$HEAD_OID" = "$OUTPUT_OID" ] || fail "recorded result HEAD changed"; emit_json;;
+  cleanup|cleanup-if-complete)
+    if [ "$ACTION" = cleanup-if-complete ]; then
+      if owner_complete; then :; else COMPLETE_STATUS=$?; [ "$COMPLETE_STATUS" = 1 ] || fail "cannot validate workspace owner completion"; emit_cleanup retained; exit 0; fi
+    fi
+    [ "$PHASE" = result ] && [ -n "$OUTPUT_OID" ] || fail "workspace item is incomplete"
+    validate_path_registration; validate_detached_clean; [ "$HEAD_OID" = "$OUTPUT_OID" ] || fail "cleanup HEAD differs from recorded output"
+    "${GIT[@]}" worktree remove "$WORKTREE_PATH" || fail "worktree removal failed"
+    [ ! -e "$WORKTREE_PATH" ] || fail "worktree path remains after removal"
+    rm -f "$STATE_FILE" || fail "cannot remove workspace state"
+    if [ "$ACTION" = cleanup-if-complete ]; then emit_cleanup removed; fi;;
+esac

--- a/gascity/formulas/REQUIREMENTS.md
+++ b/gascity/formulas/REQUIREMENTS.md
@@ -71,6 +71,13 @@ For every formula change:
   prompt assets.
 - `build-basic` owns stable path-shadow override files for its major prompt
   pieces, including exactly one override file per default review lane.
+- Separately drained `implementation-base` and `do-work` prompt stages use the
+  `gc gc workspace` command lifecycle for deterministic convoy- or nested
+  convoy/epic-owned serialization, preparation, safe sequential reuse, verified
+  entry, exact current-item result handoff, and conditional terminal cleanup.
+  Same-session item formulas and their derived owners remain outside that
+  lifecycle.
+
 
 ## User Stories
 
@@ -122,6 +129,11 @@ this ledger against the `FORMULAS` constant and formula directory.
 | GC-BF-BR-011 | GC-BF-US-002 | WHEN shared artifact validation fails, THE formula graph SHALL route back to the producer for bounded repair or stop as `blocked` after finite attempts. |
 | GC-BF-BR-012 | GC-BF-US-002 | WHEN formula output includes traceability, THE formula SHALL preserve YAML coverage as the machine-readable source and mirrored markdown coverage for humans. |
 | GC-BF-BR-013 | GC-BF-US-002 | WHEN a continuation review, drain, or repair stage cannot reach approval, THE formula graph SHALL record `gc.build.repair_status`, `gc.restart.*` metadata, and a failing blocked outcome instead of allowing finalize or publish no-op to close the workflow as pass. |
+| GC-BF-BR-014 | GC-BF-US-001 | WHEN `implementation-base` or `do-work` executes a separately drained lifecycle, prepare SHALL call `gc gc workspace prepare` with an explicit input ref, implementation SHALL call `path`, `verify-entry`, and `record-result`, and close SHALL call `result`. |
+| GC-BF-BR-015 | GC-BF-US-001 | WHEN separately drained prompts consume workspace data, they SHALL NOT derive paths from ambient `$PWD`, create or repair Git worktrees directly, or read/write source-anchor `work_dir`; `gc.work_dir` remains launcher rig root only. |
+| GC-BF-BR-016 | GC-BF-US-001 | WHEN `implementation-item-base`, `do-work-item`, or a derived same-session item formula executes, its formula and prompt assets SHALL remain outside `gc gc workspace` wiring and SHALL make no deterministic graph-owned lifecycle claim. |
+| GC-BF-BR-017 | GC-BF-US-001 | WHEN `implement` separately drains a convoy, the workspace command SHALL derive each item's owner from existing source-anchor and parent-convoy graph fields without a new selector or metadata protocol. |
+| GC-BF-BR-018 | GC-BF-US-001 | WHEN a separately drained close-source-anchor step closes and verifies its exact source anchor, IT SHALL invoke `gc gc workspace cleanup-if-complete`; retained, removed, and already-removed SHALL be valid outcomes while command failure remains hard. |
 
 ## Scenario Ledger
 
@@ -132,8 +144,8 @@ this ledger against the `FORMULAS` constant and formula directory.
 | GC-BF-001 | `build-base` | Virtual targeted full-lifecycle contract | Defines the stable build stage sequence, selector variables, mode variables, methodology metadata, implementation strategy selection, artifact validation/repair gates, review/fix loop, finalization, and optional publication contract that concrete methodology packs extend. | `build-base.formula.toml`; `../tests/test_formula_assets.py` |
 | GC-BF-002 | `planning-base` | Virtual targetless planning contract | Produces approved requirements and implementation-plan artifacts through prepare, requirements, plan, and plan-review stages while preserving strict artifact shape, approval states, hashes, coverage, validator repair, and mode behavior for adapters. | `planning-base.formula.toml`; `../tests/test_formula_assets.py` |
 | GC-BF-003 | `decomposition-base` | Virtual targetless decomposition contract | Converts an approved plan into durable work units and implementation convoy identity that downstream drain or convoy-step implementation strategies consume, after validating decomposition schema, coverage, and upstream hashes. | `decomposition-base.formula.toml`; `../tests/test_formula_assets.py` |
-| GC-BF-004 | `implementation-base` | Virtual targeted implementation contract | Executes one implementation source anchor with prepare-worktree, implement, and close-source-anchor stages while preserving source-anchor close, work-item evidence, requirement coverage, and neutral producer metadata. | `implementation-base.formula.toml`; `../tests/test_formula_assets.py` |
-| GC-BF-005 | `implementation-item-base` | Virtual targeted shared-drain item contract | Executes exactly one item in a shared single-lane drain while preserving shared-session context, item sequencing, item evidence, requirement coverage, and neutral producer metadata. | `implementation-item-base.formula.toml`; `../tests/test_formula_assets.py` |
+| GC-BF-004 | `implementation-base` | Virtual targeted implementation contract | Executes one separate-item source anchor through `gc gc workspace` prepare, verified entry, exact result recording, and result-backed source-anchor close while preserving work-item evidence, requirement coverage, and neutral producer metadata. Its deterministic claim is host-local and does not extend to shared drains or downstream integration/review/publish. | `implementation-base.formula.toml`; `../assets/workflows/implementation-base/`; `../tests/test_formula_assets.py` |
+| GC-BF-005 | `implementation-item-base` | Virtual targeted shared-drain item contract | Executes exactly one item in a legacy shared single-lane drain while preserving shared-session context, item sequencing, item evidence, requirement coverage, and neutral producer metadata. It does not invoke or fall back to the separate-item `gc gc workspace` lifecycle. | `implementation-item-base.formula.toml`; `../assets/workflows/implementation-item-base/`; `../tests/test_formula_assets.py` |
 | GC-BF-006 | `code-review-base` | Virtual targetless report contract | Writes validated review output over a supplied subject, maps verdicts to base approval states, honors `review_mode`, preserves coverage/drift evidence, and leaves external lifecycle ownership to callers. | `code-review-base.formula.toml`; `../tests/test_formula_assets.py` |
 | GC-BF-007 | `fix-loop-base` | Virtual targetless review-fix contract | Turns failed review findings into planned fixes, applies fixes with the selected implementation path, records per-attempt validated fix artifacts, and re-runs the selected review formula up to the iteration limit. | `fix-loop-base.formula.toml`; `../tests/test_formula_assets.py` |
 
@@ -164,9 +176,9 @@ this ledger against the `FORMULAS` constant and formula directory.
 | ID | Formula | Type | Required behavior | Evidence |
 | --- | --- | --- | --- | --- |
 | GC-BF-010 | `implement` | Cataloged targeted implementation entrypoint | Validates the input convoy, drains implementation work using an allowed policy, waits for completion, writes validated item-mapped implementation summary evidence, and optionally delegates publishing. | `implement.formula.toml`; `../tests/test_formula_assets.py` |
-| GC-BF-011 | `do-work` | Targeted implementation item helper | Extends `implementation-base`, prepares one item worktree, implements owned work with the selected implementation target, and closes the source anchor after implementation succeeds. | `do-work.formula.toml`; `../tests/test_formula_assets.py` |
-| GC-BF-012 | `do-work-item` | Targeted shared-drain item helper | Extends `implementation-item-base`, runs exactly one shared-drain item with the selected implementation target, and stays internal/single-lane. | `do-work-item.formula.toml`; `../tests/test_formula_assets.py` |
-| GC-BF-013 | `same-session-implement` | Targeted internal shared-drain helper | Documents and executes the pack-facing same-session policy by draining through `do-work-item` with exclusive member access and single-lane sequencing. | `same-session-implement.formula.toml`; `../tests/test_formula_assets.py` |
+| GC-BF-011 | `do-work` | Targeted implementation item helper | Extends `implementation-base`; invokes `gc gc workspace` to prepare one exact detached workspace, verify entry before owned work, record the clean linear result, and validate that result before closing the returned source anchor. | `do-work.formula.toml`; `../assets/workflows/do-work/`; `../tests/test_formula_assets.py` |
+| GC-BF-012 | `do-work-item` | Targeted shared-drain item helper | Extends `implementation-item-base`, runs exactly one legacy shared-drain item with the selected implementation target, stays internal/single-lane, and remains outside `gc gc workspace` setup, checkpoint, fallback, and result semantics. | `do-work-item.formula.toml`; `../tests/test_formula_assets.py` |
+| GC-BF-013 | `same-session-implement` | Targeted internal shared-drain helper | Documents and executes the pack-facing legacy same-session policy by draining through `do-work-item` with exclusive member access and single-lane sequencing; it makes no deterministic-workspace claim. | `same-session-implement.formula.toml`; `../tests/test_formula_assets.py` |
 
 ### Review And Fix Utilities
 

--- a/gascity/tests/test_formula_assets.py
+++ b/gascity/tests/test_formula_assets.py
@@ -1969,9 +1969,20 @@ class FormulaAssetTests(unittest.TestCase):
             "assets/workflows/build-base/summarize-implementation.md",
         ):
             text = (root / relative_path).read_text(encoding="utf-8")
+            validator_command = (
+                'GC_BEAD_ID="$CLAIMED_STEP_ID" '
+                ".gc/scripts/checks/build-artifact-valid.sh"
+                if relative_path
+                in {
+                    "assets/workflows/do-work/implement.md",
+                    "assets/workflows/implementation-base/implement.md",
+                }
+                else "GC_BEAD_ID=<claimed-step-id> "
+                ".gc/scripts/checks/build-artifact-valid.sh"
+            )
             for fragment in (
                 "read the launcher rig root from the workflow root bead's `gc.work_dir`",
-                "GC_BEAD_ID=<claimed-step-id> .gc/scripts/checks/build-artifact-valid.sh",
+                validator_command,
                 "fix every reported validation error before setting `gc.outcome=pass`",
             ):
                 with self.subTest(asset=relative_path, fragment=fragment):
@@ -3354,58 +3365,52 @@ class FormulaAssetTests(unittest.TestCase):
         self.assertEqual(do_work_item["vars"]["implementation_target"]["default"], "gc.implementation-worker")
         self.assertEqual(do_work_item["steps"][0]["metadata"]["gc.run_target"], "{{implementation_target}}")
 
-    def test_do_work_formula_requires_persisted_item_worktree(self) -> None:
+    def test_do_work_formula_uses_orchestrated_workspace_lifecycle(self) -> None:
         root = pathlib.Path(__file__).resolve().parents[1]
         do_work = tomllib.loads((root / "formulas" / "do-work.formula.toml").read_text(encoding="utf-8"))
         steps = {step["id"]: step for step in do_work["steps"]}
 
-        prepare = node_description(root, steps["prepare-worktree"])
-        for fragment in (
-            "current step bead metadata",
-            "gc.root_bead_id",
-            "gc.input_convoy_id",
-            "gc.synthetic_kind",
-            "gc.drain_member_id",
-            "do not use the synthetic drain-unit convoy id as `<source-anchor-id>`",
-            "never persist `work_dir` on the synthetic drain-unit convoy",
-            "hard-fail if the selected source anchor id equals the synthetic input convoy id",
-            "worktrees/<source-anchor-id>",
+        expected = {
+            "prepare-worktree": (
+                "gc gc workspace prepare",
+                '"<claimed-step-id>"',
+                '"<input-revision>"',
+                "returned `worktree_path` and `input_oid` as authoritative",
+            ),
+            "implement": (
+                "gc gc workspace path",
+                "gc gc workspace verify-entry",
+                "gc gc workspace record-result",
+                "No-change results are valid",
+            ),
+            "close-source-anchor": (
+                "gc gc workspace result",
+                "exact source anchor, prepared workspace, input revision, and output revision",
+                "close only the recorded source anchor",
+                "status=closed",
+                "gc.outcome=pass",
+                "gc gc workspace cleanup-if-complete",
+                "cleanup=retained",
+                "cleanup=removed",
+                "cleanup=already-removed",
+            ),
+        }
+        forbidden = (
+            "workspace.sh",
+            "pack_root",
+            "$(pwd)/worktrees",
             "git worktree add",
-            "gc bd update <source-anchor-id> --set-metadata work_dir=",
-            "Do not edit source files in the launcher checkout",
-        ):
-            with self.subTest(step="prepare-worktree", fragment=fragment):
-                self.assertIn(fragment, prepare)
+        )
 
-        implement = node_description(root, steps["implement"])
-        for fragment in (
-            "Read `work_dir` from the source anchor",
-            "never read `work_dir` from the synthetic drain-unit convoy",
-            "Do not infer the source anchor from dependency ids",
-            "`gc.work_dir` is the launcher rig root, not the implementation worktree",
-            "if the JSON output is a one-element list, unwrap the",
-            "verify `pwd -P` equals",
-            "cd \"$WORKTREE\"",
-            "fail this step before editing",
-            "Do not edit files in the launcher checkout",
-            "Leave the source anchor open",
-        ):
-            with self.subTest(step="implement", fragment=fragment):
-                self.assertIn(fragment, implement)
-
-        close_source = node_description(root, steps["close-source-anchor"])
-        for fragment in (
-            "Read `work_dir` from the source anchor",
-            "close only `<source-anchor-id>`",
-            "gc bd show <source-anchor-id> --json",
-            "status=closed",
-            "gc.outcome=pass",
-            "if either check fails",
-            "anchor before closing this step",
-            "Do not close this step with pass while the source anchor remains open",
-        ):
-            with self.subTest(step="close-source-anchor", fragment=fragment):
-                self.assertIn(fragment, close_source)
+        for step_id, fragments in expected.items():
+            description = node_description(root, steps[step_id])
+            description = " ".join(description.split())
+            for fragment in fragments:
+                with self.subTest(step=step_id, fragment=fragment):
+                    self.assertIn(fragment, description)
+            for fragment in forbidden:
+                with self.subTest(step=step_id, forbidden=fragment):
+                    self.assertNotIn(fragment, description)
 
     def test_wrapper_formulas_route_role_agents(self) -> None:
         root = pathlib.Path(__file__).resolve().parents[1]
@@ -4892,6 +4897,96 @@ description = "Override sink that writes the base triage report contract."
             write_report_step["expand_vars"]["artifact_path_keys"],
             artifact_keys,
         )
+
+
+    def test_separate_worktree_prompts_use_orchestrated_workspace_lifecycle(self) -> None:
+        root = pathlib.Path(__file__).resolve().parents[1]
+        workflow_root = root / "assets" / "workflows"
+        prompt_pairs = {
+            "prepare": (
+                workflow_root / "do-work" / "prepare-worktree.md",
+                workflow_root / "implementation-base" / "prepare-worktree.md",
+            ),
+            "implement": (
+                workflow_root / "do-work" / "implement.md",
+                workflow_root / "implementation-base" / "implement.md",
+            ),
+            "close": (
+                workflow_root / "do-work" / "close-source-anchor.md",
+                workflow_root / "implementation-base" / "close-source-anchor.md",
+            ),
+        }
+        required = {
+            "prepare": (
+                "gc gc workspace prepare",
+                "input revision matches the intended source revision",
+            ),
+            "implement": (
+                "gc gc workspace path",
+                "gc gc workspace verify-entry",
+                "gc gc workspace record-result",
+                "No-change results are valid",
+            ),
+            "close": (
+                "gc gc workspace result",
+                "exact source anchor, prepared workspace, input revision, and output revision",
+                "recorded source anchor",
+            ),
+        }
+        forbidden = (
+            "workspace.sh",
+            "pack_root",
+            "$(pwd)/worktrees",
+            "git worktree add",
+        )
+
+        for stage, paths in prompt_pairs.items():
+            for path in paths:
+                text = path.read_text(encoding="utf-8")
+                text = " ".join(text.split())
+                for fragment in required[stage]:
+                    with self.subTest(path=path.relative_to(root), fragment=fragment):
+                        self.assertIn(fragment, text)
+                for fragment in forbidden:
+                    with self.subTest(path=path.relative_to(root), forbidden=fragment):
+                        self.assertNotIn(fragment, text)
+
+    def test_shared_session_assets_remain_legacy_without_workspace_script_wiring(self) -> None:
+        packs_root = pathlib.Path(__file__).resolve().parents[2]
+        shared_formulas = {
+            "gascity/formulas/implementation-item-base.formula.toml": "implementation-item-base",
+            "gascity/formulas/do-work-item.formula.toml": "do-work-item",
+            "bmad/formulas/bmad-story-development-item.formula.toml": "bmad-story-development-item",
+            "compound-engineering/formulas/compound-work-item.formula.toml": "compound-work-item",
+            "gstack/formulas/gstack-work-item.formula.toml": "gstack-work-item",
+            "superpowers/formulas/superpowers-development-item.formula.toml": "superpowers-development-item",
+        }
+
+        for relative_path, formula_name in shared_formulas.items():
+            formula_path = packs_root / relative_path
+            formula_text = formula_path.read_text(encoding="utf-8")
+            formula = tomllib.loads(formula_text)
+            self.assertEqual(formula["formula"], formula_name)
+            if formula_name != "implementation-item-base":
+                self.assertIn(
+                    "implementation-item-base" if formula_name == "do-work-item" else "do-work-item",
+                    formula.get("extends", []),
+                )
+            self.assertNotIn("workspace.sh", formula_text)
+
+            owner_prompt_paths = {
+                (formula_path.parent / step["description_file"]).resolve()
+                for step in formula.get("steps", [])
+                if "description_file" in step
+            }
+            with self.subTest(formula=formula_name, contract="prompt ownership"):
+                self.assertTrue(owner_prompt_paths)
+            for path in owner_prompt_paths:
+                text = path.read_text(encoding="utf-8")
+                with self.subTest(formula=formula_name, path=path.relative_to(packs_root)):
+                    self.assertNotIn("workspace.sh", text)
+                    self.assertNotIn("verify-entry", text)
+                    self.assertNotIn("record-result", text)
 
 
 if __name__ == "__main__":

--- a/gascity/tests/test_workspace_script.py
+++ b/gascity/tests/test_workspace_script.py
@@ -1,0 +1,562 @@
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import subprocess
+import tempfile
+import unittest
+
+SCRIPT = pathlib.Path(__file__).resolve().parents[1] / "commands" / "workspace" / "run.sh"
+
+
+class WorkspaceScriptTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = pathlib.Path(self.tmp.name) / "rig"
+        self.root.mkdir()
+        self.git("init", "-q")
+        self.git("config", "user.email", "test@example.invalid")
+        self.git("config", "user.name", "Workspace Tests")
+        (self.root / "README").write_text("base\n")
+        self.git("add", "README")
+        self.git("commit", "-qm", "base")
+        self.oid = self.git("rev-parse", "HEAD").stdout.strip()
+        self.bin = pathlib.Path(self.tmp.name) / "bin"
+        self.bin.mkdir()
+        self.data = pathlib.Path(self.tmp.name) / "gc.json"
+        self.data.write_text(json.dumps({
+            "step": {"id": "step-1", "metadata": {"gc.root_bead_id": "root-1"}},
+            "root": {"id": "root-1", "metadata": {"gc.input_convoy_id": "convoy-1"}},
+            "convoy": {"id": "convoy-1", "parent_convoy_id": "implementation-1", "metadata": {}},
+            "owner": {"id": "implementation-1", "parent_convoy_id": "", "metadata": {}},
+        }))
+        stub = self.bin / "gc"
+        stub.write_text("""#!/usr/bin/env python3
+import json, os, sys
+if sys.argv[1:3] == ["bd", "list"] and sys.argv[3:] == ["--all", "--json", "--limit=0"]:
+    data = json.load(open(os.environ["GC_STUB_DATA"], encoding="utf-8"))
+    values = []
+    for value in data.values():
+        candidates = value if isinstance(value, list) else [value]
+        for candidate in candidates:
+            if isinstance(candidate, dict) and "id" in candidate and candidate not in values:
+                values.append(candidate)
+    print(json.dumps(values, separators=(",", ":")))
+    raise SystemExit(0)
+if sys.argv[1:3] != ["bd", "show"] or len(sys.argv) != 5 or sys.argv[4] != "--json":  # gc-bd-argv-tail: fake gc receives wrapper argv tail
+    print("malformed gc invocation", file=sys.stderr)
+    raise SystemExit(2)
+ident = sys.argv[3]
+data = json.load(open(os.environ["GC_STUB_DATA"], encoding="utf-8"))
+value = next((bead for bead in data.values() if (isinstance(bead, dict) and bead.get("id") == ident) or (isinstance(bead, list) and any(isinstance(item, dict) and item.get("id") == ident for item in bead))), None)
+if value is None:
+    value = data.get(ident)
+if value is None:
+    print(json.dumps([]))
+elif isinstance(value, dict) and "_raw" in value:
+    print(value["_raw"])
+else:
+    print(json.dumps(value, separators=(",", ":")))
+""")
+        stub.chmod(0o755)
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def git(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(["git", *args], cwd=self.root, text=True, capture_output=True, check=True)
+
+    def run_ws(
+        self,
+        action: str,
+        step: str = "step-1",
+        ref: str | None = None,
+        *,
+        workspace_parent: pathlib.Path | None = None,
+        use_rig_root: bool = False,
+    ) -> subprocess.CompletedProcess[str]:
+        args = [str(SCRIPT), action, "--step-id", step]
+        if action == "prepare":
+            args += ["--input-ref", ref or self.oid]
+            if workspace_parent is not None:
+                args += ["--workspace-parent", str(workspace_parent)]
+        env = os.environ.copy()
+        env.update({"GC_STUB_DATA": str(self.data), "PATH": f"{self.bin}:{env['PATH']}"})
+        env.pop("GC_WORK_DIR", None)
+        env.pop("GC_RIG_ROOT", None)
+        env["GC_RIG_ROOT" if use_rig_root else "GC_WORK_DIR"] = str(self.root)
+        return subprocess.run(args, cwd=self.tmp.name, env=env, text=True, capture_output=True)
+
+    def payload(self, result: subprocess.CompletedProcess[str]) -> dict[str, str]:
+        self.assertEqual(result.returncode, 0, result.stderr)
+        value = json.loads(result.stdout)
+        self.assertIsInstance(value, dict)
+        return value
+
+    def prepare(self, step: str = "step-1", ref: str | None = None) -> dict[str, str]:
+        return self.payload(self.run_ws("prepare", step, ref))
+
+    def assert_compact(self, value: dict[str, str], *, output: bool = False, anchor: str = "convoy-1") -> None:
+        expected = {"worktree_path", "input_oid", "phase", "source_anchor_id"}
+        if output:
+            expected.add("output_oid")
+        self.assertEqual(set(value), expected)
+        self.assertEqual(value["source_anchor_id"], anchor)
+
+    def state_path(self) -> pathlib.Path:
+        git_dir = pathlib.Path(self.git("rev-parse", "--path-format=absolute", "--git-common-dir").stdout.strip())
+        return next((git_dir / "gc-workspace-state").rglob("*.json"))
+
+    def assert_failed_unchanged(self, action: str, state: pathlib.Path) -> subprocess.CompletedProcess[str]:
+        before = state.read_bytes()
+        result = self.run_ws(action)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(state.read_bytes(), before)
+        return result
+
+    def test_separate_anchor_captures_and_replays_exact_oid(self):
+        first = self.prepare()
+        self.assert_compact(first)
+        self.assertEqual(first["input_oid"], self.oid)
+        replay = self.prepare()
+        self.assertEqual(replay["worktree_path"], first["worktree_path"])
+        self.assertEqual(replay["input_oid"], self.oid)
+        self.assertEqual(set(replay), {"worktree_path", "input_oid", "phase", "source_anchor_id"})
+
+    def test_agent_rig_root_prepares_workspace_without_work_dir(self):
+        prepared = self.payload(self.run_ws("prepare", use_rig_root=True))
+        self.assert_compact(prepared)
+        self.assertEqual(prepared["input_oid"], self.oid)
+
+    def test_multiple_anchors_do_not_claim_common_base(self):
+        data = json.loads(self.data.read_text())
+        data.update({
+            "step-2": {"id": "step-2", "metadata": {"gc.root_bead_id": "root-2"}},
+            "root-2": {"id": "root-2", "metadata": {"gc.input_convoy_id": "convoy-2"}},
+            "convoy-2": {"id": "convoy-2", "parent_convoy_id": "implementation-2", "metadata": {}},
+            "owner-2": {"id": "implementation-2", "parent_convoy_id": "", "metadata": {}},
+        })
+        self.data.write_text(json.dumps(data))
+        first = self.prepare()
+        (self.root / "README").write_text("second\n")
+        self.git("commit", "-qam", "second")
+        second = self.prepare("step-2", self.git("rev-parse", "HEAD").stdout.strip())
+        self.assertNotEqual(first["input_oid"], second["input_oid"])
+        self.assertNotEqual(first["worktree_path"], second["worktree_path"])
+
+    def test_scheduling_dependency_does_not_change_input_oid(self):
+        data = json.loads(self.data.read_text())
+        data["step"]["metadata"]["gc.scheduling_dependency"] = "other-step"
+        self.data.write_text(json.dumps(data))
+        self.assertEqual(self.prepare()["input_oid"], self.oid)
+
+    def test_same_session_assets_remain_legacy_without_script_wiring(self):
+        result = self.run_ws("checkpoint")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("unknown action", result.stderr)
+
+    def test_multiple_results_do_not_create_integration_or_canonical_state(self):
+        data = json.loads(self.data.read_text())
+        data.update({
+            "step-2": {"id": "step-2", "metadata": {"gc.root_bead_id": "root-2"}},
+            "root-2": {"id": "root-2", "metadata": {"gc.input_convoy_id": "convoy-2"}},
+            "convoy-2": {"id": "convoy-2", "parent_convoy_id": "implementation-2", "metadata": {}},
+            "owner-2": {"id": "implementation-2", "parent_convoy_id": "", "metadata": {}},
+        })
+        self.data.write_text(json.dumps(data))
+        first = self.prepare()
+        second = self.prepare("step-2")
+        first_result = self.payload(self.run_ws("record-result"))
+        second_result = self.payload(self.run_ws("record-result", "step-2"))
+        self.assertEqual(first_result["output_oid"], first["input_oid"])
+        self.assertEqual(second_result["output_oid"], second["input_oid"])
+        states = list((self.root / ".git" / "gc-workspace-state").rglob("*.json"))
+        self.assertEqual(len(states), 2)
+        self.assertFalse((self.root / ".git" / "gc-workspace-state" / "state.json").exists())
+
+    def test_review_and_fix_actions_are_side_effect_free_rejections(self):
+        self.prepare()
+        state = next((self.root / ".git" / "gc-workspace-state").rglob("*.json"))
+        before = state.read_bytes()
+        for action in ("review", "fix"):
+            result = self.run_ws(action)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertEqual(state.read_bytes(), before)
+
+    def test_publish_and_pr_actions_never_call_remote_operations(self):
+        self.prepare()
+        state = next((self.root / ".git" / "gc-workspace-state").rglob("*.json"))
+        before = state.read_bytes()
+        for action in ("publish", "pr"):
+            result = self.run_ws(action)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("unknown action", result.stderr)
+        self.assertEqual(state.read_bytes(), before)
+
+    def test_new_workflow_root_with_same_parent_convoy_reuses_workspace(self):
+        first = self.prepare()
+        self.payload(self.run_ws("record-result"))
+        data = json.loads(self.data.read_text())
+        data.update({
+            "step-2": {"id": "step-2", "metadata": {"gc.root_bead_id": "root-2"}},
+            "root-2": {"id": "root-2", "metadata": {
+                "gc.input_convoy_id": "unit-2",
+                "gc.drain_member_id": "member-2",
+            }},
+            "unit-2": {"id": "unit-2", "metadata": {
+                "gc.synthetic_kind": "drain-unit-convoy",
+                "gc.drain_member_id": "member-2",
+            }},
+            "member-2": {"id": "member-2", "parent_convoy_id": "implementation-1", "metadata": {}},
+        })
+        self.data.write_text(json.dumps(data))
+        second = self.prepare("step-2", first["input_oid"])
+        self.assertEqual(first["worktree_path"], second["worktree_path"])
+        self.assertEqual(second["source_anchor_id"], "member-2")
+
+    def test_next_owner_item_uses_recorded_output_not_launch_base(self):
+        first = self.prepare()
+        worktree = pathlib.Path(first["worktree_path"])
+        (worktree / "README").write_text("first\n")
+        subprocess.run(["git", "add", "README"], cwd=worktree, check=True)
+        subprocess.run(["git", "commit", "-qm", "first"], cwd=worktree, check=True)
+        output = self.payload(self.run_ws("record-result"))["output_oid"]
+        data = json.loads(self.data.read_text())
+        data.update({
+            "step-2": {"id": "step-2", "metadata": {"gc.root_bead_id": "root-2"}},
+            "root-2": {"id": "root-2", "metadata": {"gc.input_convoy_id": "member-2"}},
+            "member-2": {"id": "member-2", "parent_convoy_id": "implementation-1", "metadata": {}},
+        })
+        self.data.write_text(json.dumps(data))
+        second = self.prepare("step-2", self.oid)
+        self.assertEqual(second["input_oid"], output)
+        self.assertEqual(pathlib.Path(second["worktree_path"]) / "README", worktree / "README")
+
+    def test_cleanup_if_complete_retains_until_all_direct_members_pass(self):
+        prepared = self.prepare()
+        self.payload(self.run_ws("record-result"))
+        data = json.loads(self.data.read_text())
+        data["convoy"].update({"status": "closed", "metadata": {"gc.outcome": "pass"}})
+        data["member-2"] = {"id": "member-2", "parent_convoy_id": "implementation-1", "status": "open", "metadata": {}}
+        self.data.write_text(json.dumps(data))
+        retained = self.payload(self.run_ws("cleanup-if-complete"))
+        self.assertEqual(retained["cleanup"], "retained")
+        self.assertTrue(pathlib.Path(prepared["worktree_path"]).is_dir())
+        data["member-2"].update({"status": "closed", "metadata": {"gc.outcome": "pass"}})
+        self.data.write_text(json.dumps(data))
+        removed = self.payload(self.run_ws("cleanup-if-complete"))
+        self.assertEqual(removed["cleanup"], "removed")
+        self.assertFalse(pathlib.Path(prepared["worktree_path"]).exists())
+
+    def test_cleanup_if_complete_fails_closed_on_malformed_member_list(self):
+        self.prepare()
+        self.payload(self.run_ws("record-result"))
+        data = json.loads(self.data.read_text())
+        data["malformed-member"] = {"id": "bad", "parent_convoy_id": 7, "metadata": {}}
+        self.data.write_text(json.dumps(data))
+        result = self.run_ws("cleanup-if-complete")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertTrue(self.state_path().exists())
+    def test_cleanup_if_complete_rejects_missing_state_with_live_worktree(self):
+        prepared = self.prepare()
+        self.payload(self.run_ws("record-result"))
+        self.state_path().unlink()
+        result = self.run_ws("cleanup-if-complete")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertTrue(pathlib.Path(prepared["worktree_path"]).is_dir())
+
+    def test_cleanup_if_complete_rejects_duplicate_direct_member_ids(self):
+        prepared = self.prepare()
+        self.payload(self.run_ws("record-result"))
+        data = json.loads(self.data.read_text())
+        member = {"id": "convoy-1", "parent_convoy_id": "implementation-1", "status": "closed", "metadata": {"gc.outcome": "pass"}}
+        data["convoy"] = [member, {**member, "title": "duplicate"}]
+        self.data.write_text(json.dumps(data))
+        result = self.run_ws("cleanup-if-complete")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertTrue(self.state_path().exists())
+        self.assertTrue(pathlib.Path(prepared["worktree_path"]).is_dir())
+
+    def test_cleanup_if_complete_rejects_malformed_direct_member_id(self):
+        prepared = self.prepare()
+        self.payload(self.run_ws("record-result"))
+        data = json.loads(self.data.read_text())
+        data["convoy"].update({"id": "", "status": "closed", "metadata": {"gc.outcome": "pass"}})
+        self.data.write_text(json.dumps(data))
+        result = self.run_ws("cleanup-if-complete")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertTrue(self.state_path().exists())
+        self.assertTrue(pathlib.Path(prepared["worktree_path"]).is_dir())
+
+    def test_nested_parent_convoy_is_epic_owner_and_does_not_collide(self):
+        data = json.loads(self.data.read_text())
+        data["convoy"]["parent_convoy_id"] = "epic-1"
+        data["owner"] = {"id": "epic-1", "parent_convoy_id": "implementation-1", "metadata": {}}
+        data["implementation"] = {"id": "implementation-1", "parent_convoy_id": "", "metadata": {}}
+        self.data.write_text(json.dumps(data))
+        epic = self.prepare()
+        self.payload(self.run_ws("record-result"))
+
+        data = json.loads(self.data.read_text())
+        data.update({
+            "step-2": {"id": "step-2", "metadata": {"gc.root_bead_id": "root-2"}},
+            "root-2": {"id": "root-2", "metadata": {
+                "gc.input_convoy_id": "unit-2", "gc.drain_member_id": "member-2",
+            }},
+            "unit-2": {"id": "unit-2", "metadata": {
+                "gc.synthetic_kind": "drain-unit-convoy", "gc.drain_member_id": "member-2",
+            }},
+            "member-2": {"id": "member-2", "parent_convoy_id": "epic-1", "metadata": {}},
+            "step-3": {"id": "step-3", "metadata": {"gc.root_bead_id": "root-3"}},
+            "root-3": {"id": "root-3", "metadata": {
+                "gc.input_convoy_id": "unit-3", "gc.drain_member_id": "member-3",
+            }},
+            "unit-3": {"id": "unit-3", "metadata": {
+                "gc.synthetic_kind": "drain-unit-convoy", "gc.drain_member_id": "member-3",
+            }},
+            "member-3": {"id": "member-3", "parent_convoy_id": "implementation-1", "metadata": {}},
+        })
+        self.data.write_text(json.dumps(data))
+        next_epic = self.prepare("step-2", epic["input_oid"])
+        convoy = self.prepare("step-3", epic["input_oid"])
+        self.assertEqual(next_epic["worktree_path"], epic["worktree_path"])
+        self.assertNotEqual(convoy["worktree_path"], epic["worktree_path"])
+
+    def test_missing_or_malformed_parent_convoy_fails_closed(self):
+        for value in (None, 7):
+            with self.subTest(parent_convoy_id=value):
+                data = json.loads(self.data.read_text())
+                if value is None:
+                    data["convoy"].pop("parent_convoy_id", None)
+                else:
+                    data["convoy"]["parent_convoy_id"] = value
+                self.data.write_text(json.dumps(data))
+                result = self.run_ws("prepare")
+                self.assertNotEqual(result.returncode, 0)
+
+
+    def test_recorded_host_mismatch_fails_closed(self):
+        self.prepare()
+        state_path = next((self.root / ".git" / "gc-workspace-state").rglob("*.json"))
+        state = json.loads(state_path.read_text())
+        state["host_id"] = "foreign-host"
+        state_path.write_text(json.dumps(state))
+        before = state_path.read_bytes()
+        result = self.run_ws("path")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(state_path.read_bytes(), before)
+
+    def test_cleanup_removes_completed_workspace_and_state(self):
+        prepared = self.prepare()
+        state_path = self.state_path()
+        self.payload(self.run_ws("record-result"))
+        result = self.run_ws("cleanup")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertFalse(state_path.exists())
+        self.assertFalse(pathlib.Path(prepared["worktree_path"]).exists())
+        repeated = self.run_ws("cleanup")
+        self.assertEqual(repeated.returncode, 0, repeated.stderr)
+
+    def test_cleanup_retains_incomplete_workspace(self):
+        prepared = self.prepare()
+        state_path = self.state_path()
+        before = state_path.read_bytes()
+        result = self.run_ws("cleanup")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(state_path.read_bytes(), before)
+        self.assertTrue(pathlib.Path(prepared["worktree_path"]).is_dir())
+
+    def test_exact_preparing_partial_resumes(self):
+        prepared = self.prepare()
+        state_path = next((self.root / ".git" / "gc-workspace-state").rglob("*.json"))
+        state = json.loads(state_path.read_text())
+        state["phase"] = "preparing"
+        state_path.write_text(json.dumps(state))
+        resumed = self.prepare()
+        self.assertEqual(resumed["phase"], "entry")
+        self.assertEqual(resumed["input_oid"], prepared["input_oid"])
+        self.assertEqual(resumed["worktree_path"], prepared["worktree_path"])
+
+    def test_unknown_state_fails_without_mutation(self):
+        prepared = self.prepare()
+        worktree = pathlib.Path(prepared["worktree_path"])
+        (worktree / "dirty").write_text("x\n")
+        dirty_result = self.run_ws("verify-entry")
+        self.assertNotEqual(dirty_result.returncode, 0)
+        state_path = next((self.root / ".git" / "gc-workspace-state").rglob("*.json"))
+        state = json.loads(state_path.read_text())
+        state["phase"] = "mystery"
+        state_path.write_text(json.dumps(state))
+        before = state_path.read_bytes()
+        result = self.run_ws("path")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(state_path.read_bytes(), before)
+
+    def test_repository_layouts_ordinary_control_and_true_bare(self):
+        ordinary = self.prepare()
+        self.assert_compact(ordinary)
+
+        seed = pathlib.Path(self.tmp.name) / "seed.git"
+        subprocess.run(["git", "clone", "-q", "--bare", str(self.root), str(seed)], check=True)
+        control = pathlib.Path(self.tmp.name) / "control"
+        control.mkdir()
+        subprocess.run(["git", "clone", "-q", "--bare", str(self.root), str(control / ".git")], check=True)
+        self.root = control
+        self.oid = subprocess.run(
+            ["git", "--git-dir", str(control / ".git"), "rev-parse", "HEAD"],
+            text=True, capture_output=True, check=True,
+        ).stdout.strip()
+        controlled = self.payload(self.run_ws("prepare"))
+        self.assert_compact(controlled)
+
+        self.root = seed
+        self.oid = subprocess.run(
+            ["git", "--git-dir", str(seed), "rev-parse", "HEAD"],
+            text=True, capture_output=True, check=True,
+        ).stdout.strip()
+        rejected = self.run_ws("prepare")
+        self.assertNotEqual(rejected.returncode, 0)
+        parent = pathlib.Path(self.tmp.name) / "bare-worktrees"
+        bare = self.payload(self.run_ws("prepare", workspace_parent=parent))
+        self.assert_compact(bare)
+        self.assertEqual(pathlib.Path(bare["worktree_path"]).parent, parent.resolve())
+
+    def test_synthetic_anchor_and_lookup_shapes_fail_closed(self):
+        data = json.loads(self.data.read_text())
+        data["root"]["metadata"]["gc.drain_member_id"] = "member-1"
+        data["convoy"] = {"id": "convoy-1", "metadata": {"gc.synthetic_kind": "drain-unit-convoy", "gc.drain_member_id": "member-1"}}
+        data["member"] = {"id": "member-1", "parent_convoy_id": "implementation-1", "metadata": {}}
+        self.data.write_text(json.dumps(data))
+        synthetic = self.prepare()
+        self.assert_compact(synthetic, anchor="member-1")
+        result = self.payload(self.run_ws("record-result"))
+        self.assert_compact(result, output=True, anchor="member-1")
+
+        for bad in (
+            [],
+            [data["step"], data["step"]],
+            {"_raw": "not-json"},
+            7,
+        ):
+            with self.subTest(shape=bad):
+                bad_data = dict(data)
+                bad_data["step"] = bad
+                self.data.write_text(json.dumps(bad_data))
+                failure = self.run_ws("path")
+                self.assertNotEqual(failure.returncode, 0)
+        data["step"] = [data["step"]]
+        self.data.write_text(json.dumps(data))
+        one = self.payload(self.run_ws("result"))
+        self.assertEqual(one["source_anchor_id"], "member-1")
+
+    def test_dirty_tracked_untracked_and_operation_markers_fail_without_state_mutation(self):
+        prepared = self.prepare()
+        worktree = pathlib.Path(prepared["worktree_path"])
+        state = self.state_path()
+        (worktree / "README").write_text("tracked dirty\n")
+        self.assert_failed_unchanged("verify-entry", state)
+        subprocess.run(["git", "checkout", "--", "README"], cwd=worktree, check=True)
+        (worktree / "untracked").write_text("dirty\n")
+        self.assert_failed_unchanged("verify-entry", state)
+        (worktree / "untracked").unlink()
+        git_dir = pathlib.Path(subprocess.run(
+            ["git", "rev-parse", "--path-format=absolute", "--git-dir"], cwd=worktree,
+            text=True, capture_output=True, check=True,
+        ).stdout.strip())
+        for marker in ("MERGE_HEAD", "CHERRY_PICK_HEAD", "REVERT_HEAD", "BISECT_LOG"):
+            with self.subTest(marker=marker):
+                (git_dir / marker).write_text(self.oid + "\n")
+                self.assert_failed_unchanged("verify-entry", state)
+                (git_dir / marker).unlink()
+
+    def test_dirty_submodule_is_rejected_without_state_mutation(self):
+        child = pathlib.Path(self.tmp.name) / "child"
+        child.mkdir()
+        subprocess.run(["git", "init", "-q"], cwd=child, check=True)
+        subprocess.run(["git", "config", "user.email", "test@example.invalid"], cwd=child, check=True)
+        subprocess.run(["git", "config", "user.name", "Workspace Tests"], cwd=child, check=True)
+        (child / "file").write_text("one\n")
+        subprocess.run(["git", "add", "file"], cwd=child, check=True)
+        subprocess.run(["git", "commit", "-qm", "child"], cwd=child, check=True)
+        self.git("-c", "protocol.file.allow=always", "submodule", "add", "-q", str(child), "child")
+        self.git("commit", "-qm", "submodule")
+        self.oid = self.git("rev-parse", "HEAD").stdout.strip()
+        prepared = self.prepare()
+        worktree = pathlib.Path(prepared["worktree_path"])
+        subprocess.run(["git", "-c", "protocol.file.allow=always", "submodule", "update", "--init"], cwd=worktree, check=True, capture_output=True)
+        (worktree / "child" / "file").write_text("dirty\n")
+        self.assert_failed_unchanged("verify-entry", self.state_path())
+
+    def test_symlink_path_escape_and_held_lock_fail_closed(self):
+        prepared = self.prepare()
+        worktree = pathlib.Path(prepared["worktree_path"])
+        state = self.state_path()
+        before = state.read_bytes()
+        lock = pathlib.Path(str(state) + ".lock")
+        lock.mkdir()
+        (lock / "owner.json").write_text(json.dumps({"pid": os.getpid(), "host": os.uname().nodename, "created": 0}))
+        locked = self.run_ws("path")
+        self.assertNotEqual(locked.returncode, 0)
+        self.assertEqual(state.read_bytes(), before)
+        (lock / "owner.json").unlink()
+        lock.rmdir()
+
+        subprocess.run(["git", "worktree", "remove", "--force", str(worktree)], cwd=self.root, check=True)
+        target = pathlib.Path(self.tmp.name) / "escape"
+        target.mkdir()
+        worktree.symlink_to(target, target_is_directory=True)
+        escaped = self.run_ws("path")
+        self.assertNotEqual(escaped.returncode, 0)
+        self.assertEqual(state.read_bytes(), before)
+
+    def test_record_result_no_change_linear_and_non_linear_history(self):
+        no_change = self.prepare()
+        unchanged = self.payload(self.run_ws("record-result"))
+        self.assert_compact(unchanged, output=True)
+        self.assertEqual(unchanged["output_oid"], no_change["input_oid"])
+        authoritative = self.payload(self.run_ws("result"))
+        self.assertEqual(authoritative["source_anchor_id"], "convoy-1")
+
+        data = json.loads(self.data.read_text())
+        data.update({
+            "step-2": {"id": "step-2", "metadata": {"gc.root_bead_id": "root-2"}},
+            "root-2": {"id": "root-2", "metadata": {"gc.input_convoy_id": "convoy-2"}},
+            "convoy-2": {"id": "convoy-2", "parent_convoy_id": "implementation-2", "metadata": {}},
+            "owner-2": {"id": "implementation-2", "parent_convoy_id": "", "metadata": {}},
+            "step-3": {"id": "step-3", "metadata": {"gc.root_bead_id": "root-3"}},
+            "root-3": {"id": "root-3", "metadata": {"gc.input_convoy_id": "convoy-3"}},
+            "convoy-3": {"id": "convoy-3", "parent_convoy_id": "implementation-3", "metadata": {}},
+            "owner-3": {"id": "implementation-3", "parent_convoy_id": "", "metadata": {}},
+        })
+        self.data.write_text(json.dumps(data))
+        linear = self.prepare("step-2")
+        linear_wt = pathlib.Path(linear["worktree_path"])
+        (linear_wt / "linear").write_text("commit\n")
+        subprocess.run(["git", "add", "linear"], cwd=linear_wt, check=True)
+        subprocess.run(["git", "commit", "-qm", "linear"], cwd=linear_wt, check=True)
+        linear_result = self.payload(self.run_ws("record-result", "step-2"))
+        self.assert_compact(linear_result, output=True, anchor="convoy-2")
+        self.assertNotEqual(linear_result["output_oid"], linear["input_oid"])
+
+        merged = self.prepare("step-3")
+        merge_wt = pathlib.Path(merged["worktree_path"])
+        subprocess.run(["git", "checkout", "-qb", "side"], cwd=merge_wt, check=True)
+        (merge_wt / "side").write_text("side\n")
+        subprocess.run(["git", "add", "side"], cwd=merge_wt, check=True)
+        subprocess.run(["git", "commit", "-qm", "side"], cwd=merge_wt, check=True)
+        side_oid = subprocess.run(["git", "rev-parse", "HEAD"], cwd=merge_wt, text=True, capture_output=True, check=True).stdout.strip()
+        subprocess.run(["git", "checkout", "--detach", merged["input_oid"]], cwd=merge_wt, check=True, capture_output=True)
+        (merge_wt / "main").write_text("main\n")
+        subprocess.run(["git", "add", "main"], cwd=merge_wt, check=True)
+        subprocess.run(["git", "commit", "-qm", "main"], cwd=merge_wt, check=True)
+        subprocess.run(["git", "merge", "--no-ff", "-qm", "merge", side_oid], cwd=merge_wt, check=True)
+        state3 = next(path for path in (self.root / ".git" / "gc-workspace-state").rglob("*.json") if json.loads(path.read_text())["source_anchor_id"] == "convoy-3")
+        before = state3.read_bytes()
+        rejected = self.run_ws("record-result", "step-3")
+        self.assertNotEqual(rejected.returncode, 0)
+        self.assertEqual(state3.read_bytes(), before)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_no_bare_bd_commands.py
+++ b/tests/test_no_bare_bd_commands.py
@@ -143,11 +143,15 @@ BARE_BD_SERIALIZED_ARGV = re.compile(
     rf'''(?:\[|\{{|=|:)\s*["']bd["']\s*,\s*["'](?:{BD_SUBCOMMAND_PATTERN})["']'''
 )
 GC_BD_ARGV_TAIL_MARKER = "gc-bd-argv-tail"
-GC_BD_ARGV_TAIL_FIXTURE = Path("tests/test_gascity_pack_inference_gate.py")
 GC_BD_ARGV_TAIL_LINES = {
-    '*"bd show fi-root --json"*) # gc-bd-argv-tail: fake gc receives the wrapper\'s argv tail',
-    '*"bd list --json --limit 1000"*) # gc-bd-argv-tail: fake gc receives the wrapper\'s argv tail',
-    'assert "bd show fi-root --json" in args_path.read_text(encoding="utf-8")  # gc-bd-argv-tail',
+    Path("tests/test_gascity_pack_inference_gate.py"): {
+        '*"bd show fi-root --json"*) # gc-bd-argv-tail: fake gc receives the wrapper\'s argv tail',
+        '*"bd list --json --limit 1000"*) # gc-bd-argv-tail: fake gc receives the wrapper\'s argv tail',
+        'assert "bd show fi-root --json" in args_path.read_text(encoding="utf-8")  # gc-bd-argv-tail',
+    },
+    Path("gascity/tests/test_workspace_script.py"): {
+        'if sys.argv[1:3] != ["bd", "show"] or len(sys.argv) != 5 or sys.argv[4] != "--json":  # gc-bd-argv-tail: fake gc receives wrapper argv tail',
+    },
 }
 
 
@@ -161,17 +165,29 @@ def tracked_files() -> list[Path]:
     return [REPO_ROOT / path for path in result.stdout.decode().split("\0") if path]
 
 
+def intentional_gc_bd_argv_tail(relative: Path, line: str) -> bool:
+    return (
+        GC_BD_ARGV_TAIL_MARKER in line
+        and line.strip() in GC_BD_ARGV_TAIL_LINES.get(relative, set())
+    )
+
+
 def python_argv_violations(path: Path, text: str) -> list[str]:
     if path.suffix != ".py":
         return []
     tree = ast.parse(text, filename=str(path))
+    relative = path.relative_to(REPO_ROOT)
+    lines = text.splitlines()
     violations = []
     for node in ast.walk(tree):
         if not isinstance(node, (ast.List, ast.Tuple)) or not node.elts:
             continue
         first = node.elts[0]
         if isinstance(first, ast.Constant) and first.value == "bd":
-            violations.append(f"{path.relative_to(REPO_ROOT)}:{node.lineno}: argv starts with bd")
+            line = lines[node.lineno - 1]
+            if intentional_gc_bd_argv_tail(relative, line):
+                continue
+            violations.append(f"{relative}:{node.lineno}: argv starts with bd")
     return violations
 
 
@@ -203,14 +219,6 @@ def gc_routes_bd(line: str, bd_start: int) -> bool:
     return True
 
 
-def intentional_gc_bd_argv_tail(relative: Path, line: str) -> bool:
-    return (
-        relative == GC_BD_ARGV_TAIL_FIXTURE
-        and GC_BD_ARGV_TAIL_MARKER in line
-        and line.strip() in GC_BD_ARGV_TAIL_LINES
-    )
-
-
 def bare_bd_violations(path: Path, text: str) -> list[str]:
     violations = []
     relative = path.relative_to(REPO_ROOT)
@@ -236,6 +244,12 @@ def bare_bd_violations(path: Path, text: str) -> list[str]:
         line_number = text.count("\n", 0, match.start()) + 1
         violations.append(f"{relative}:{line_number}: bd command is split across lines")
     for match in BARE_BD_SERIALIZED_ARGV.finditer(text):
+        line_start = text.rfind("\n", 0, match.start()) + 1
+        line_end = text.find("\n", match.start())
+        if line_end == -1:
+            line_end = len(text)
+        if intentional_gc_bd_argv_tail(relative, text[line_start:line_end]):
+            continue
         line_number = text.count("\n", 0, match.start()) + 1
         violations.append(f"{relative}:{line_number}: serialized argv starts with bd")
     violations.extend(python_argv_violations(path, text))
@@ -270,3 +284,20 @@ def test_detector_covers_shell_multiline_and_serialized_argv_forms() -> None:
     assert not bare_bd_violations(fixture, 'command = ["gc", "bd", "show"]')
     assert not bare_bd_violations(fixture, "gc --city /tmp/city bd list --json")
     assert not bare_bd_violations(fixture, "gc --rig demo bd show demo-1")
+
+
+def test_detector_allows_only_audited_fake_gc_argv_tails() -> None:
+    allowed_path = REPO_ROOT / "gascity/tests/test_workspace_script.py"
+    allowed_line = next(iter(GC_BD_ARGV_TAIL_LINES[allowed_path.relative_to(REPO_ROOT)]))
+    allowed_source = f"{allowed_line}\n    pass\n"
+
+    assert not bare_bd_violations(allowed_path, allowed_source)
+    assert bare_bd_violations(REPO_ROOT / "fixture.py", allowed_source)
+    assert bare_bd_violations(
+        allowed_path,
+        allowed_source.replace(f"  # {GC_BD_ARGV_TAIL_MARKER}: fake gc receives wrapper argv tail", ""),
+    )
+    assert bare_bd_violations(
+        allowed_path,
+        allowed_source.replace('["bd", "show"]', '["bd", "update"]'),
+    )


### PR DESCRIPTION
## Summary

- add a pack-owned `workspace.sh` lifecycle for deterministic detached implementation worktrees
- let routed agents resolve the launcher repository from `GC_RIG_ROOT` while preserving `GC_WORK_DIR` precedence
- require one exact claimed bead ID across workspace prepare, entry verification, result recording, and result validation
- add focused lifecycle, prompt-contract, and repository scanner coverage

## Why

Implementation workers need a single authoritative worktree contract. The lifecycle records exact source anchor, input commit, worktree path, phase, and output commit; rejects cross-step reuse, dirty or attached worktrees, non-linear output history, and result drift; and removes state after successful source-anchor closure.

Routed workers provide `GC_RIG_ROOT`, while the initial script accepted only `GC_WORK_DIR`. Workflow prompts also used `<claimed-step-id>` without distinguishing the exact claimed bead ID from logical metadata such as `implement`. Both cases failed in isolated `build-basic` probes and are covered here.

The fake-`gc` workspace test keeps its literal `bd show` argv tail. The repository guard permits it only through an exact path-and-line allowlist shared by serialized-argv and Python AST detection; wrong path, missing marker, or changed command remains a violation.

## Validation

- focused scanner/workspace gate: 22 passed, 8 subtests passed
- full pack gate: 763 passed, 7 skipped, 9490 subtests passed
- `git diff --check upstream/main..feat-det-wt`

An isolated `build-basic` workflow exercised the lifecycle through prepare, path, entry verification, result recording, and source-anchor closure with all 48 spawned beads reporting pass. The outer harness exceeded its 3600-second limit before recording its own final acceptance marker, so that run is supporting evidence rather than formal E2E acceptance.

## Coordination

- deliberately excludes pack-relative validator path changes already covered by #149 (with narrower overlap in #169 and #194)
- #203 changes some of the same `do-work` prompt files for provenance enforcement but does not provide this exact claimed-bead workspace contract; rebase or conflict resolution may be needed if it lands first
