### PR TITLE
fix(gascity): make worker claims binding-independent

### DIFF
--- a/gascity/README.md
+++ b/gascity/README.md
@@ -21,7 +21,7 @@ Prerequisites: Gas City installed and a city running (`gc init`, `gc start`),
 and your project added as a rig (`gc rig add .` inside the repo). See the
 [repository README](../README.md) for the from-scratch path.
 
-1. Import formulas, claim command, and rig roles. From city directory:
+1. Import formulas, coordinator skill, and rig roles. From city directory:
 
    ```sh
    gc import add --name gc https://github.com/gastownhall/gascity-packs.git//gascity
@@ -37,10 +37,11 @@ and your project added as a rig (`gc rig add .` inside the repo). See the
    source = "https://github.com/gastownhall/gascity-packs.git//gascity/roles"
    ```
 
-   Both imports are required. The rig-scoped roles pack supplies agents but,
-   by design, rig imports do not register city commands; importing roles alone
-   renders prompts that reference `gc gc claim` without installing that
-   command. Keep the top-level Gas City pack imported at city scope.
+   Both imports are required for the full build pack. The rig-scoped roles pack
+   supplies agents; worker prompts claim through native
+   `gc hook --claim --drain-ack --json`, independent of the top-level pack's
+   import binding. Keep the top-level Gas City pack imported at city scope for
+   formulas and the coordinator skill.
 
    (Contributors hacking on packs can point this source at a local clone.)
 
@@ -140,10 +141,12 @@ the core-injected reserved convoy target; they do not declare `issue`,
 default. Use `same-session` only when preserving one shared worktree and
 conversation is explicitly desired and core shared drain support is available.
 
-The pack ships its city-scoped claim command alongside formulas, plus
-providerless rig role agents under `gascity/roles`. Standalone use requires
-the top-level `gc` import for formulas, mayor skill, and `gc gc claim`, and
-`gascity/roles` on each target rig for `gc.*` role agents.
+The pack retains its city-scoped claim command as a compatibility wrapper and
+ships providerless rig role agents under `gascity/roles`. Worker prompts use
+native `gc hook --claim --drain-ack --json`, so claim correctness does not
+depend on the top-level pack's import binding. Standalone use requires the
+top-level import for formulas and mayor skill, plus `gascity/roles` on each
+target rig for `gc.*` role agents.
 
 Import roles for each target rig. By default agents inherit city/workspace
 provider; advanced users can patch individual roles without overriding formulas:

--- a/gascity/template-fragments/gc-role-worker.template.md
+++ b/gascity/template-fragments/gc-role-worker.template.md
@@ -9,11 +9,11 @@ You are `{{ .AgentName }}`, Gas City `graph.v2` worker for
 First action. Before skills, files, runtime state, or repository inspection:
 
 ```bash
-gc gc claim
+gc hook --claim --drain-ack --json
 ```
 
-This is your only work-discovery command. It atomically claims one routed bead
-through `gc hook --claim --drain-ack --json`. Never discover work through
+This is your only work-discovery command. It atomically claims one routed bead.
+Never discover work through
 `gc bd mol current`, broad `gc bd ready`/`gc bd list`, root or parent beads, searches,
 mail, logs, or repository context.
 
@@ -71,8 +71,8 @@ After close, inspect `CLAIMED_CONTINUATION_GROUP` before another claim:
 
 - An empty continuation group is a hard session boundary. Run
   `gc runtime drain-ack` and exit so unrelated work starts with clean context.
-- For a non-empty group, run `gc gc claim` again unless the result contract
-  requires final drain. On `action=drain`, exit.
+- For a non-empty group, run `gc hook --claim --drain-ack --json` again unless
+  the result contract requires final drain. On `action=drain`, exit.
 
 Every successful claim result is authoritative. Execute it immediately even if
 its continuation group or root differs from the bead just closed; never drain

--- a/gascity/tests/test_formula_assets.py
+++ b/gascity/tests/test_formula_assets.py
@@ -728,6 +728,7 @@ class FormulaAssetTests(unittest.TestCase):
             with self.subTest(required=required):
                 self.assertIn(required, text)
         self.assertNotIn("GC_CLAIM", text)
+        self.assertNotIn("gc gc claim", text)
 
         for agent_name in ROLE_AGENTS:
             prompt = root / "roles" / "agents" / agent_name / "prompt.template.md"

--- a/tests/test_gc_role_prompt_integration.py
+++ b/tests/test_gc_role_prompt_integration.py
@@ -126,7 +126,8 @@ def assert_clean_worker_render(prompt: str, persona_heading: str) -> None:
     assert persona_heading in prompt
     assert prompt.count("# GC Role Worker") == 1
     assert '{{ template "gc-role-worker" . }}' not in prompt
-    assert "gc gc claim" in prompt
+    assert "gc hook --claim --drain-ack --json" in prompt
+    assert "gc gc claim" not in prompt
     assert "CLAIMED_BEAD_ID" in prompt
     assert "CLAIMED_ROOT_BEAD_ID" in prompt
     assert "CLAIMED_CONTINUATION_GROUP" in prompt


### PR DESCRIPTION
## Why

Gas City pack commands are invoked as `gc <binding> <command>`. Import bindings are deployment configuration, so worker prompts that hard-code `gc gc claim` only work when the city-scoped Gas City pack happens to be imported as `gc`. Derived packs commonly use other top-level bindings while importing `gascity/roles` on a rig, making claim correctness depend on an unrelated alias choice.

Native `gc hook --claim --drain-ack --json` is the binding-independent claim boundary. It already owns session identity, federated store selection, atomic claim handling, continuation preassignment, and drain acknowledgement. Source PR https://github.com/gastownhall/gascity/pull/4415 adds the two workflow-context fields these prompts consume: `root_bead_id` and `continuation_group`.

## What changed

- Call native `gc hook --claim --drain-ack --json` for initial and continuation claims.
- Assert rendered workers from Gas City and all derived packs contain the native command and no `gc gc claim` dependency.
- Update setup docs to separate required formula/skill imports from claim mechanics.
- Retain the city-scoped `claim` command as a compatibility wrapper; this PR removes it from workflow correctness, not from the public surface.

This is intentionally dependent on gascity PR #4415. Merge source first, then this pack change.

All 61 current open pack PR heads were fetched once and searched; none removes the binding-specific worker claim. PR #203 also edits the shared worker fragment to clarify exact claimed identifiers, but `git merge-tree` combines both changes without conflict.

## Validation

- `741 passed, 7 skipped, 9412 subtests passed`
- `GC_TEST_BIN=/var/tmp/gc-hook-context-4415 ... tests/test_gc_role_prompt_integration.py`: 7 passed using exact source commit `40f9cbc74`
- `go test ./...`
- `make registry-format-validate`
- `GC=/var/tmp/gc-hook-context-4415 make registry-validate`