### PR TITLE
feat(gascity): add publish-handoff guard to worker close-out

### DIFF
--- a/gascity/template-fragments/gc-role-worker.template.md
+++ b/gascity/template-fragments/gc-role-worker.template.md
@@ -65,6 +65,19 @@ as more issue ids and may fuzzy-match unrelated beads.
 gc bd close "$CLAIMED_BEAD_ID" --reason '...'
 ```
 
+Publish handoff — PR deliverables. If the bead's deliverable is a pull request,
+do not close it done until one of these holds; never silently drop the merge
+baton:
+
+- the PR is merged — a mayor merges it, you never merge your own, or
+- you mailed the mayor a merge request AND referenced that mail in the close
+  reason.
+
+```bash
+gc mail send mayor -s 'MERGE REQUEST: PR #<n>' -m '<branch> green; ready to merge'
+gc bd close "$CLAIMED_BEAD_ID" --reason 'PR #<n>; merge-request mailed to mayor.'
+```
+
 ## Continue
 
 After close, inspect `CLAIMED_CONTINUATION_GROUP` before another claim:

--- a/gascity/template-fragments/gc-role-worker.template.md
+++ b/gascity/template-fragments/gc-role-worker.template.md
@@ -65,22 +65,28 @@ as more issue ids and may fuzzy-match unrelated beads.
 gc bd close "$CLAIMED_BEAD_ID" --reason '...'
 ```
 
-Publish handoff — PR deliverables. If the bead's deliverable is a
-merge-ready pull request, do not close it done until one of these holds; never
-silently drop the merge baton:
+Publish handoff — PR deliverables. If the bead's deliverable is a pull
+request and it is NOT a deliberate draft, do not close the bead done until one
+of these holds; never silently drop the merge baton. This covers merge-ready
+PRs and ready-for-review PRs whose checks or approvals are still pending —
+someone must own noticing when they go green:
 
 - the PR is merged — a mayor merges it, you never merge your own, or
-- you mailed the mayor a merge request AND referenced that mail in the close
-  reason.
+- you mailed the mayor a merge/status handoff AND referenced that mail in the
+  close reason (say plainly whether CI is green or still pending).
+
+The close depends on the mail actually sending — chain them so a failed
+`gc mail send` (recipient resolution, mail-store failure) aborts the close
+instead of silently recording a handoff that never happened:
 
 ```bash
-gc mail send mayor -s 'MERGE REQUEST: PR #<n>' -m '<branch> green; ready to merge'
-gc bd close "$CLAIMED_BEAD_ID" --reason 'PR #<n>; merge-request mailed to mayor.'
+gc mail send mayor -s 'MERGE REQUEST: PR #<n>' -m '<branch> green; ready to merge' \
+  && gc bd close "$CLAIMED_BEAD_ID" --reason 'PR #<n>; merge-request mailed to mayor.'
 ```
 
 A deliberately-draft PR (the workflow ran with `pr_mode=draft`, or the bead
-asks for a draft) is NOT merge-ready: do not merge it and do not send a merge
-request for it. Hand it off for review instead — reference the draft PR URL in
+asks for a draft) is the ONLY exemption: do not merge it and do not send a
+merge request for it. Hand it off for review instead — reference the draft PR URL in
 the close reason so the baton stays visible:
 
 ```bash

--- a/gascity/template-fragments/gc-role-worker.template.md
+++ b/gascity/template-fragments/gc-role-worker.template.md
@@ -65,9 +65,9 @@ as more issue ids and may fuzzy-match unrelated beads.
 gc bd close "$CLAIMED_BEAD_ID" --reason '...'
 ```
 
-Publish handoff — PR deliverables. If the bead's deliverable is a pull request,
-do not close it done until one of these holds; never silently drop the merge
-baton:
+Publish handoff — PR deliverables. If the bead's deliverable is a
+merge-ready pull request, do not close it done until one of these holds; never
+silently drop the merge baton:
 
 - the PR is merged — a mayor merges it, you never merge your own, or
 - you mailed the mayor a merge request AND referenced that mail in the close
@@ -76,6 +76,15 @@ baton:
 ```bash
 gc mail send mayor -s 'MERGE REQUEST: PR #<n>' -m '<branch> green; ready to merge'
 gc bd close "$CLAIMED_BEAD_ID" --reason 'PR #<n>; merge-request mailed to mayor.'
+```
+
+A deliberately-draft PR (the workflow ran with `pr_mode=draft`, or the bead
+asks for a draft) is NOT merge-ready: do not merge it and do not send a merge
+request for it. Hand it off for review instead — reference the draft PR URL in
+the close reason so the baton stays visible:
+
+```bash
+gc bd close "$CLAIMED_BEAD_ID" --reason 'Draft PR published per pr_mode=draft: <canonical PR URL>; awaiting review.'
 ```
 
 ## Continue


### PR DESCRIPTION
## What

Adds a **publish-handoff guard** to the shared `gc-role-worker` close-out fragment (`gascity/template-fragments/gc-role-worker.template.md`, `## Close`). A bead whose deliverable is a pull request may not be closed *done* until one of these holds:

- the PR is **merged** — a mayor merges it, a worker never merges its own, **or**
- the worker has **mailed the mayor a merge request** and referenced that mail in the close reason.

Short and checklist-shaped, in the compact style of the surrounding prompt.

## Why (two real incidents)

- **#469 (2026-07-16):** a worker self-merged its own PR.
- **#483 (2026-07-19):** worker `hw-yhxmt` closed its bead citing PR #483 but never mailed the mayor for merge — the PR sat open + green + unnoticed until the morning sweep. Compare `hw-tb96o` / `hw-e2cus` / `hw-6of2d`, workers on the same wave who all mailed correctly.

The gap: nothing in the worker close-out told the worker what to do with a PR-shaped deliverable, so the merge baton could be silently dropped at close time.

## Scope

This is the **publish-handoff** half of a two-part hardening. It is a companion to the separately-tracked **no-self-merge** guard (worker may never merge its own PR; a mayor merges). Together they make the merge handoff airtight: workers cannot merge, and cannot silently drop the baton either. Approved by Afik 2026-07-20.

Placed in `gc-role-worker` because that is the shared close-out for the production `graph.v2` workers (`gc.implementation-worker` et al.) — the exact role behind the cited incidents.

## Verification

- `gc lint gascity` → ok
- `pytest gascity/tests/test_formula_assets.py -k role_agent_prompts` → passed (all `## Close` required-substring assertions preserved)
- Full `test_formula_assets.py` + `test_derived_pack_compatibility.py`: no new failures from this change. (3 pre-existing `gc gc claim` runtime-command failures reproduce identically on clean `main` — local `gc` binary/env mismatch, unrelated to this template edit.)
- Change is inside the existing `{{ define "gc-role-worker" }} … {{- end }}` block; introduces no new template actions.

**Deployed-binary caveat:** pack-formula/template changes take effect for **new** dispatches only, after cities bump their `gascity` import pin.