### PR TITLE
feat(gastown/boot): gate reasoning triage behind a deterministic stuck-probe

### DIFF
--- a/gastown/agents/boot/prompt.template.md
+++ b/gastown/agents/boot/prompt.template.md
@@ -17,47 +17,98 @@ from wisps, pane output, and mail.
 gives each wake a new provider context. Observe, decide, act, drain-ack, exit.
 Do not rely on prior conversation context or handoff mail. Narrow scope keeps each wake cheap.
 
+**Cost discipline:** the deacon patrols on a ~10-minute cadence and
+is healthy on the overwhelming majority of wakes. A full reasoning triage every
+wake is pure churn (measured: 134 passes/24h, 601 read-only gc calls, ZERO
+interventions). So each wake runs a **cheap deterministic stuck-probe FIRST**
+and does the expensive reasoning triage **only when a stuck-signal actually
+trips**. On a clear probe you exit immediately — no further tool calls, no
+reasoning.
+
 ---
 
-## Triage Steps
+## Step 0 — Deterministic stuck-probe (ALWAYS run this FIRST)
 
-### Step 1: Check if deacon session exists
-
-```bash
-{{ cmd }} session peek {{ .BindingPrefix }}deacon --lines 1
-```
-
-If the deacon session does not exist, drain-ack and exit. The controller will
-restart dead agents.
-
-### Step 2: Observe deacon state
+Run this single block verbatim. It emits exactly one line: `PROBE: CLEAR ...`
+or `PROBE: STUCK ...`. Do not reason about deacon health before running it, and
+do not run any other command first.
 
 ```bash
-# Recent pane output — is the deacon actively working?
-{{ cmd }} session peek {{ .BindingPrefix }}deacon --lines 30
+{{ cmd }} runtime heartbeat 2>/dev/null || true
+STALE_WISP_SECS=1200   # 20m: > deacon's 300s backoff cap + a full ~10m patrol
+DEACON={{ .BindingPrefix }}deacon
 
-# Deacon's current patrol wisp — how fresh is it?
-gc bd list --assignee={{ .BindingPrefix }}deacon --status=in_progress --json --limit=5
-
-# Does the deacon have unread mail? (may explain idle state)
-gc mail count {{ .BindingPrefix }}deacon 2>/dev/null
+# 1. Session liveness — absence is the controller's job, not a stuck signal.
+if ! {{ cmd }} session peek "$DEACON" --lines 1 >/dev/null 2>&1; then
+  echo "PROBE: CLEAR deacon-session-absent (controller restarts dead agents)"
+else
+  PANE="$({{ cmd }} session peek "$DEACON" --lines 30 2>/dev/null)"
+  MAIL="$(gc mail count "$DEACON" 2>/dev/null | grep -oE '[0-9]+' | head -1)"; MAIL=${MAIL:-0}
+  WISP_JSON="$(gc bd list --assignee="$DEACON" --status=in_progress --json --limit=1 2>/dev/null)"
+  REASONS=""
+  # 2. Error markers in the pane => escalate.
+  if printf '%s' "$PANE" | grep -qiE 'error|panic|traceback|exception|rate.?limit|permission denied|fatal|command not found'; then
+    REASONS="$REASONS pane-errors"
+  fi
+  # 3. Unread mail => may need a nudge => escalate.
+  [ "$MAIL" -gt 0 ] 2>/dev/null && REASONS="$REASONS unread-mail($MAIL)"
+  # 4. Stale in-progress patrol wisp => escalate. (Absent/young wisp = legit idle.)
+  AGE="$(printf '%s' "$WISP_JSON" | python3 -c '
+import sys,json,datetime
+try:
+    d=json.load(sys.stdin)
+    rows=d if isinstance(d,list) else d.get("issues",d.get("beads",[]))
+    if not rows: print(-1); sys.exit()
+    ts=rows[0].get("updated_at") or rows[0].get("created_at")
+    t=datetime.datetime.fromisoformat(ts.replace("Z","+00:00"))
+    now=datetime.datetime.now(datetime.timezone.utc)
+    print(int((now-t).total_seconds()))
+except Exception:
+    print(-1)
+' 2>/dev/null)"; AGE=${AGE:-0}
+  if [ "$AGE" -ge "$STALE_WISP_SECS" ] 2>/dev/null; then
+    REASONS="$REASONS stale-wisp(${AGE}s)"
+  fi
+  if [ -n "$REASONS" ]; then
+    echo "PROBE: STUCK$REASONS"
+  else
+    echo "PROBE: CLEAR healthy (mail=$MAIL wisp_age=${AGE}s)"
+  fi
+fi
 ```
 
-Read the wisp timestamps and pane output. Build a picture:
-- Recent burned wisp -> normal patrol loop
+**If the line begins `PROBE: CLEAR`** — the deacon is healthy or legitimately
+idle. Do the exit dance in Step 4 **now** and stop. Do not read the rest of this
+prompt, do not observe further, do not reason.
+
+**If the line begins `PROBE: STUCK`** — a real signal tripped. Proceed to the
+triage below; the reasoning pass has earned its cost.
+
+---
+
+## Triage Steps (STUCK path only)
+
+You reach this section only when Step 0 emitted `PROBE: STUCK`. The probe
+already peeked the pane, counted mail, and aged the wisp — reuse that output;
+re-peek only if you need more lines.
+
+### Observe
+
+```bash
+# More pane context if the 30-line probe view was ambiguous
+{{ cmd }} session peek {{ .BindingPrefix }}deacon --lines 60
+```
+
+Build a picture from the probe reasons and pane:
+- Recent burned wisp -> normal patrol loop (probe would not have flagged it)
 - Active pane output -> working
 - Young in-progress wisp with idle pane -> likely backoff wait
 - Very stale in-progress wisp with idle/error pane -> likely stuck
 - Idle with unread mail -> may need a nudge
 
-### Step 3: Decide
+### Decide
 
-Use judgment; there are no hardcoded thresholds. Consider:
-- The deacon's exponential backoff caps at 300s between cycles
-- A stale wisp during a period with no active work is legitimate idle
-- Active output (tool calls, command execution) means the deacon is functioning
-- A pane showing an error message or hanging prompt is a red flag
-- Legitimate work can take several minutes
+Use judgment; the probe's thresholds gate *whether* you reason, not the verdict.
 
 | Observation | Verdict | Action |
 |-------------|---------|--------|
@@ -73,7 +124,6 @@ next Boot tick re-evaluate.
 ```bash
 {{ cmd }} session nudge {{ .BindingPrefix }}deacon "Boot check: are you making progress?"
 ```
-Drain-ack and exit. Next Boot wake will re-evaluate.
 
 Clearly stuck: file a warrant for the dog pool.
 
@@ -85,7 +135,11 @@ gc bd create --type=task \
 ```
 The dog pool picks up the warrant and runs the shutdown dance.
 
-### Step 4: Signal done and exit
+---
+
+## Step 4 — Signal done and exit
+
+Every wake ends here (both the CLEAR fast-path and the STUCK path):
 
 ```bash
 {{ cmd }} runtime drain-ack
@@ -104,6 +158,7 @@ with a fresh provider context.
 - Start the deacon if it's dead (controller handles liveness)
 - Monitor witnesses, refineries, or polecats (deacon and witnesses do that)
 - Rely on prior conversation context or handoff mail (read live state each wake)
+- Reason about deacon health before the Step 0 probe, or after a `PROBE: CLEAR`
 
 ---
 
@@ -118,4 +173,4 @@ with a fresh provider context.
 | Check active sessions | `{{ cmd }} session list` |
 
 Working directory: {{ .WorkDir }}
-Formula: none (single-pass deacon watchdog, no patrol loop)
+Formula: none (deterministic-probe-gated deacon watchdog, no patrol loop)


### PR DESCRIPTION
## Problem

`gastown/boot` (the deacon watchdog) is a `mode="always"`, `wake_mode="fresh"` named session whose agent does **one triage pass then exits**. Because it's `always`-mode, the controller respawns it immediately on exit → a fresh full-reasoning session every **~80–90s**.

On a healthy town that's pure churn. A 24h sample on a live city logged:
- **134 boot passes**, **601 read-only `gc` calls**, **ZERO interventions** — every pass re-confirmed the same idle deacon state.
- Entirely automated burn; it was the **3rd-largest token consumer** in the city.

The deacon it watches patrols on a **~10-minute** cadence, so a per-90s reasoning watchdog is **~7× oversampled**.

## Fix

Gate the expensive reasoning pass behind a **cheap deterministic Step-0 probe** that runs first on every wake and escalates to the existing observe/decide/act logic **only** when a real stuck-signal trips:

- error markers in the deacon pane (`error|panic|traceback|exception|rate-limit|permission denied|fatal|command not found`), **or**
- unread mail for the deacon (`> 0`), **or**
- an in-progress patrol wisp older than **20m** (> the deacon's 300s backoff cap + a full ~10m patrol).

`PROBE: CLEAR` → `drain-ack` + exit, **no reasoning**. `PROBE: STUCK` → fall through to the (unchanged) triage / nudge / warrant path.

**Coverage is preserved** — the same signals are evaluated every tick, so a genuinely stuck deacon still escalates within one cadence interval. Absent/young wisps remain legitimate idle (not a stuck signal), matching the prior guidance.

## Why gate the pass instead of slowing the cadence

`sleep_after_idle` is rejected on `mode="always"` sessions, and converting boot to `on_demand` risks the watchdog not spawning (a monitoring gap). Gating the *reasoning* makes the frequent cadence cheap, which is the safe lever and needs no lifecycle/config change.

## Verification

Applied via a local `prompt_template` override on a running city:
- **Live:** gated `CLEAR` wakes drop from a multi-call reasoning triage to a **2-call** `probe → drain-ack → exit` with **zero reasoning text** (confirmed in boot session transcripts); `session.stopped` reason stays `drain acknowledged`.
- **STUCK paths unit-verified:** a 40-min stale wisp (2400s) trips `stale-wisp`; `rate limit` / `Traceback` trip `pane-errors`; benign pane output does not false-trip.

All Go template variables (`{{ cmd }}`, `{{ .BindingPrefix }}`, `{{ template "architecture" . }}`, `{{ .WorkDir }}`) are preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)