### PR TITLE
fix(gascity): migrate 34 formulas off deprecated contract=graph.v2

### DIFF
--- a/gascity/formulas/build-base.formula.toml
+++ b/gascity/formulas/build-base.formula.toml
@@ -27,9 +27,11 @@ Launch inputs:
 """
 formula = "build-base"
 version = 1
-contract = "graph.v2"
 target_required = true
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [metadata.gc.methodology]
 allowed_drain_policies = ["separate", "same-session"]

--- a/gascity/formulas/build-basic-review.formula.toml
+++ b/gascity/formulas/build-basic-review.formula.toml
@@ -8,7 +8,9 @@ synthesize into one fix loop.
 formula = "build-basic-review"
 type = "expansion"
 version = 1
-contract = "graph.v2"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/gascity/formulas/build-basic.formula.toml
+++ b/gascity/formulas/build-basic.formula.toml
@@ -7,9 +7,11 @@ same full-lifecycle stage contract exposed by build-base.
 """
 formula = "build-basic"
 version = 1
-contract = "graph.v2"
 extends = ["build-base"]
 target_required = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "build-basic"

--- a/gascity/formulas/build-from-convoy-base.formula.toml
+++ b/gascity/formulas/build-from-convoy-base.formula.toml
@@ -7,10 +7,12 @@ to `build-from-review-base` through the inherited `prepare-review` step.
 """
 formula = "build-from-convoy-base"
 version = 1
-contract = "graph.v2"
 extends = ["build-from-review-base"]
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [metadata.gc.methodology]
 allowed_drain_policies = ["separate", "same-session"]

--- a/gascity/formulas/build-from-convoy.formula.toml
+++ b/gascity/formulas/build-from-convoy.formula.toml
@@ -6,9 +6,11 @@ Gas City methodology defaults.
 """
 formula = "build-from-convoy"
 version = 1
-contract = "graph.v2"
 extends = ["build-from-convoy-base"]
 target_required = false
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "build-from-convoy"

--- a/gascity/formulas/build-from-decompose-base.formula.toml
+++ b/gascity/formulas/build-from-decompose-base.formula.toml
@@ -29,10 +29,12 @@ Launch inputs:
 """
 formula = "build-from-decompose-base"
 version = 1
-contract = "graph.v2"
 extends = ["build-from-convoy-base"]
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [metadata.gc.methodology]
 allowed_drain_policies = ["separate", "same-session"]

--- a/gascity/formulas/build-from-decompose.formula.toml
+++ b/gascity/formulas/build-from-decompose.formula.toml
@@ -8,9 +8,11 @@ selectors, routes, drains, or review expansions they need.
 """
 formula = "build-from-decompose"
 version = 1
-contract = "graph.v2"
 extends = ["build-from-decompose-base"]
 target_required = false
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "build-from-decompose"

--- a/gascity/formulas/build-from-plan-base.formula.toml
+++ b/gascity/formulas/build-from-plan-base.formula.toml
@@ -7,10 +7,12 @@ implementation plan and plan-review verdict, then hands off to
 """
 formula = "build-from-plan-base"
 version = 1
-contract = "graph.v2"
 extends = ["build-from-decompose-base"]
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [metadata.gc.methodology]
 allowed_drain_policies = ["separate", "same-session"]

--- a/gascity/formulas/build-from-plan.formula.toml
+++ b/gascity/formulas/build-from-plan.formula.toml
@@ -6,9 +6,11 @@ City methodology defaults.
 """
 formula = "build-from-plan"
 version = 1
-contract = "graph.v2"
 extends = ["build-from-plan-base"]
 target_required = false
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "build-from-plan"

--- a/gascity/formulas/build-from-requirements-base.formula.toml
+++ b/gascity/formulas/build-from-requirements-base.formula.toml
@@ -7,10 +7,12 @@ inherited `prepare-plan` step.
 """
 formula = "build-from-requirements-base"
 version = 1
-contract = "graph.v2"
 extends = ["build-from-plan-base"]
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [metadata.gc.methodology]
 allowed_drain_policies = ["separate", "same-session"]

--- a/gascity/formulas/build-from-requirements.formula.toml
+++ b/gascity/formulas/build-from-requirements.formula.toml
@@ -6,9 +6,11 @@ built-in Gas City methodology defaults.
 """
 formula = "build-from-requirements"
 version = 1
-contract = "graph.v2"
 extends = ["build-from-requirements-base"]
 target_required = false
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "build-from-requirements"

--- a/gascity/formulas/build-from-review-base.formula.toml
+++ b/gascity/formulas/build-from-review-base.formula.toml
@@ -8,9 +8,11 @@ to `prepare-review` after producing implementation evidence.
 """
 formula = "build-from-review-base"
 version = 1
-contract = "graph.v2"
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [metadata.gc.methodology]
 allowed_drain_policies = ["separate", "same-session"]

--- a/gascity/formulas/build-from-review.formula.toml
+++ b/gascity/formulas/build-from-review.formula.toml
@@ -6,9 +6,11 @@ Gas City methodology defaults.
 """
 formula = "build-from-review"
 version = 1
-contract = "graph.v2"
 extends = ["build-from-review-base"]
 target_required = false
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "build-from-review"

--- a/gascity/formulas/code-review-base.formula.toml
+++ b/gascity/formulas/code-review-base.formula.toml
@@ -7,10 +7,12 @@ scoring while entrypoint adapters keep GitHub/comment lifecycle ownership.
 """
 formula = "code-review-base"
 version = 1
-contract = "graph.v2"
 target_required = false
 internal = true
 mode = "report"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.context_path]

--- a/gascity/formulas/decomposition-base.formula.toml
+++ b/gascity/formulas/decomposition-base.formula.toml
@@ -7,9 +7,11 @@ native output uses stories, cards, or another task shape.
 """
 formula = "decomposition-base"
 version = 1
-contract = "graph.v2"
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.context_path]

--- a/gascity/formulas/design-review.formula.toml
+++ b/gascity/formulas/design-review.formula.toml
@@ -8,8 +8,10 @@ graphs while preserving launch and finalization semantics.
 """
 formula = "design-review"
 version = 1
-contract = "graph.v2"
 target_required = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "design-review"

--- a/gascity/formulas/do-work-item.formula.toml
+++ b/gascity/formulas/do-work-item.formula.toml
@@ -8,11 +8,13 @@ Launch inputs:
 """
 formula = "do-work-item"
 version = 1
-contract = "graph.v2"
 extends = ["implementation-item-base"]
 target_required = true
 internal = true
 single_lane = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.context_path]

--- a/gascity/formulas/do-work.formula.toml
+++ b/gascity/formulas/do-work.formula.toml
@@ -10,9 +10,11 @@ Launch inputs:
 """
 formula = "do-work"
 version = 1
-contract = "graph.v2"
 extends = ["implementation-base"]
 target_required = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.context_path]

--- a/gascity/formulas/fix-convoy.formula.toml
+++ b/gascity/formulas/fix-convoy.formula.toml
@@ -8,9 +8,11 @@ Launch inputs:
 """
 formula = "fix-convoy"
 version = 1
-contract = "graph.v2"
 target_required = true
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.report_path]

--- a/gascity/formulas/fix-loop-base.formula.toml
+++ b/gascity/formulas/fix-loop-base.formula.toml
@@ -8,9 +8,11 @@ discipline.
 """
 formula = "fix-loop-base"
 version = 1
-contract = "graph.v2"
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.context_path]

--- a/gascity/formulas/gap-analysis.formula.toml
+++ b/gascity/formulas/gap-analysis.formula.toml
@@ -8,9 +8,11 @@ Launch inputs:
 """
 formula = "gap-analysis"
 version = 1
-contract = "graph.v2"
 target_required = false
 mode = "report"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "gap-analysis"

--- a/gascity/formulas/github-issue-fix-base.formula.toml
+++ b/gascity/formulas/github-issue-fix-base.formula.toml
@@ -27,8 +27,10 @@ Launch inputs:
 """
 formula = "github-issue-fix-base"
 version = 1
-contract = "graph.v2"
 target_required = false
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.github_issue_url]

--- a/gascity/formulas/github-issue-fix-design-review-work.formula.toml
+++ b/gascity/formulas/github-issue-fix-design-review-work.formula.toml
@@ -10,7 +10,9 @@ contract for downstream bead creation.
 formula = "github-issue-fix-design-review-work"
 type = "expansion"
 version = 1
-contract = "graph.v2"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars.mode]
 description = "Issue-fix front-half mode, recorded in artifacts."

--- a/gascity/formulas/github-issue-fix.formula.toml
+++ b/gascity/formulas/github-issue-fix.formula.toml
@@ -18,8 +18,10 @@ Launch inputs:
 formula = "github-issue-fix"
 extends = ["github-issue-fix-base"]
 version = 1
-contract = "graph.v2"
 target_required = false
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "github-issue-fix"

--- a/gascity/formulas/github-issue-triage-base.formula.toml
+++ b/gascity/formulas/github-issue-triage-base.formula.toml
@@ -17,8 +17,10 @@ Launch inputs:
 """
 formula = "github-issue-triage-base"
 version = 1
-contract = "graph.v2"
 target_required = false
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.github_issue_url]

--- a/gascity/formulas/github-issue-triage.formula.toml
+++ b/gascity/formulas/github-issue-triage.formula.toml
@@ -16,8 +16,10 @@ Launch inputs:
 formula = "github-issue-triage"
 extends = ["github-issue-triage-base"]
 version = 1
-contract = "graph.v2"
 target_required = false
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "github-issue-triage"

--- a/gascity/formulas/github-pr-review.formula.toml
+++ b/gascity/formulas/github-pr-review.formula.toml
@@ -19,8 +19,10 @@ Launch inputs:
 """
 formula = "github-pr-review"
 version = 1
-contract = "graph.v2"
 target_required = false
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "github-pr-review"

--- a/gascity/formulas/implement.formula.toml
+++ b/gascity/formulas/implement.formula.toml
@@ -16,9 +16,11 @@ Launch inputs:
 """
 formula = "implement"
 version = 2
-contract = "graph.v2"
 target_required = true
 sling_container_mode = "source"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "implement"

--- a/gascity/formulas/implementation-base.formula.toml
+++ b/gascity/formulas/implementation-base.formula.toml
@@ -8,9 +8,11 @@ source-anchor close contract.
 """
 formula = "implementation-base"
 version = 1
-contract = "graph.v2"
 target_required = true
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.context_path]

--- a/gascity/formulas/implementation-item-base.formula.toml
+++ b/gascity/formulas/implementation-item-base.formula.toml
@@ -7,10 +7,12 @@ per-item procedure while keeping shared-drain sequencing stable.
 """
 formula = "implementation-item-base"
 version = 1
-contract = "graph.v2"
 target_required = true
 internal = true
 single_lane = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.context_path]

--- a/gascity/formulas/planning-base.formula.toml
+++ b/gascity/formulas/planning-base.formula.toml
@@ -8,9 +8,11 @@ artifact paths consumed by entrypoint adapters.
 """
 formula = "planning-base"
 version = 1
-contract = "graph.v2"
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.artifact_root]

--- a/gascity/formulas/publish.formula.toml
+++ b/gascity/formulas/publish.formula.toml
@@ -8,9 +8,11 @@ Launch inputs:
 """
 formula = "publish"
 version = 1
-contract = "graph.v2"
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.final_report]

--- a/gascity/formulas/review.formula.toml
+++ b/gascity/formulas/review.formula.toml
@@ -10,10 +10,12 @@ Launch inputs:
 """
 formula = "review"
 version = 1
-contract = "graph.v2"
 extends = ["code-review-base"]
 target_required = false
 mode = "report"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "review"

--- a/gascity/formulas/same-session-implement.formula.toml
+++ b/gascity/formulas/same-session-implement.formula.toml
@@ -9,9 +9,11 @@ Launch inputs:
 """
 formula = "same-session-implement"
 version = 1
-contract = "graph.v2"
 target_required = true
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.context_path]


### PR DESCRIPTION
## What

Replaces the deprecated `contract = "graph.v2"` declaration with `[requires] formula_compiler = ">=2.0.0"` in all 34 gascity formulas, per `gc doctor`'s formula-requirements hint:

> replace deprecated contract = "graph.v2" with [requires] formula_compiler = ">=2.0.0"

## Why

Under gc 1.3.5, `gc formula cook --attach` on any `contract = "graph.v2"` formula fails at compile:

```
gc formula cook: decorate formulas v2 recipe: step github-issue-triage.snapshot: unknown formulas v2 target "gc.run-operator"
```

This breaks late-bound DAG expansion for every adapter workflow in the pack (`github-issue-triage`, `github-issue-fix`, the build-from-* family, etc.). Formulas that already declare the `formula_compiler` requirement (e.g. `mol-scoped-work`) cook and attach correctly on the same install — verified empirically on a live city: the graph.v2 formulas reproducibly fail while `mol-scoped-work --attach` created its full 29-bead sub-DAG.

## Validation

- All 34 files re-parsed with `tomllib` after the edit; asserted `[requires]` contains exactly `formula_compiler` (no adjacent top-level keys swallowed into the table) and `contract` is gone.
- `gc lint gascity` (gc 1.3.5): ok.
- The edit is mechanical and placement-consistent: the `contract` line is removed and the `[requires]` block is inserted at the end of the top-level key block, before the first table header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)