### PR TITLE
fix(gastown): require origin merge evidence for witness orphan closes

### DIFF
--- a/gastown/agents/witness/prompt.template.md
+++ b/gastown/agents/witness/prompt.template.md
@@ -89,7 +89,12 @@ bead metadata; do not use template-pattern or fixed-prefix matching.
 branch-setup. For each orphaned bead:
 
 1. **Branch on origin** (`metadata.branch` exists, verified on remote) ->
-   worktree disposable. Delete worktree, reset bead to pool.
+   worktree disposable. Delete worktree, reset bead to pool — UNLESS
+   `origin/$BRANCH` is an ancestor of `origin/$TARGET` per
+   `mol-witness-patrol` Step 3, in which case close as merged instead.
+   Never close without that origin-side merge evidence: a wrong reset
+   self-heals (the refinery closes a genuinely merged bead on
+   re-dispatch), a wrong close does not.
 
 2. **Worktree exists, unpushed commits** ->
    commit any remaining uncommitted work (`git add -A && git commit`),

--- a/gastown/formulas/mol-witness-patrol.toml
+++ b/gastown/formulas/mol-witness-patrol.toml
@@ -320,28 +320,56 @@ no branch on origin.**
 Nothing to salvage. The bead goes back to pool and a new polecat
 starts fresh.
 
-**Step 3: Verify work on main before resetting.**
+**Step 3: Verify work on the target branch before resetting.**
 
 Before resetting the bead to pool, check if the branch was already merged
-to main (polecat finished, pushed, but crashed before closing the bead):
+(polecat finished, pushed, but crashed before closing the bead). Merge
+evidence is origin-side ONLY: a commit-subject grep or a local ref is never
+evidence of a merge. Resolve the target from the bead, never a hardcoded
+branch name. When in doubt, reset to pool instead of closing — a wrong reset
+self-heals (the refinery closes a genuinely merged bead on re-dispatch), a
+wrong close is unrecoverable:
 ```bash
-git log main --oneline | grep -q "$BRANCH"
-# Or check if branch commits are reachable from main:
-git merge-base --is-ancestor origin/$BRANCH origin/main
+TARGET=$(gc bd show <bead> --json | jq -r '.[0].metadata.target // empty')
+if [ -z "$TARGET" ]; then
+  TARGET=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
+fi
+git fetch origin "+refs/heads/${TARGET}:refs/remotes/origin/${TARGET}"
+
+# A branch that was never pushed cannot be merged — reset, never close.
+if [ -z "$(git ls-remote --heads origin "$BRANCH")" ]; then
+  echo "NOT_MERGED: $BRANCH does not exist on origin; cannot be on $TARGET. Proceed with reset."
+else
+  git fetch origin "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}"
+  git merge-base --is-ancestor "origin/$BRANCH" "origin/$TARGET"
+  MERGE_STATE=$?
+  case "$MERGE_STATE" in
+    0)
+      # Merged. Close with forensics — only if BOTH writes land. Use --force:
+      # the bead is still assigned to the crashed polecat, so this is a
+      # cross-actor close and bd's close-authority guard
+      # (gastownhall/beads#3734) would otherwise refuse it.
+      MERGED_SHA=$(git rev-parse "origin/$BRANCH")
+      if gc bd update <bead> --set-metadata merge_result=already_merged \
+           --set-metadata merged_sha="$MERGED_SHA" \
+           --set-metadata merged_target="$TARGET" && \
+         gc bd close <bead> --force --reason "Already merged to $TARGET (origin/$BRANCH is an ancestor of origin/$TARGET; closed by witness orphan salvage)"; then
+        gc mail send mayor/ -s "ORPHAN_CLOSED: <bead> already merged" \
+          -m "origin/$BRANCH is an ancestor of origin/$TARGET at $MERGED_SHA. Closed instead of resetting."
+        # Clean up worktree and skip to Step 4.
+      else
+        echo "ORPHAN_CLOSE failed for <bead>; bead still open. STOP — a later patrol retries."
+      fi
+      ;;
+    1) : ;;  # not merged -> proceed with reset below
+    *)
+      echo "merge-base errored (status $MERGE_STATE); cannot evaluate merge state. STOP. Do not mutate bead state."
+      ;;
+  esac
+fi
 ```
 
-If the work is already on main:
-- **Close the bead** (work is done, don't re-dispatch). Use `--force`: the bead
-  is still assigned to the crashed polecat, so this is a cross-actor close and
-  bd's close-authority guard (gastownhall/beads#3734) would otherwise refuse it:
-```bash
-gc bd close <bead> --force
-gc mail send mayor/ -s "ORPHAN_CLOSED: <bead> already merged" \
-  -m "Branch $BRANCH already on main. Closed instead of resetting."
-```
-- Clean up worktree and skip to Step 4.
-
-If the work is NOT on main, proceed with reset:
+If the work is NOT on the target branch, proceed with reset:
 
 **Step 3b: Clean up worktree and return bead to pool.**
 


### PR DESCRIPTION
## Problem

The witness's `recover-orphaned-beads` **Step 3** judged "already merged" with checks that are not merge evidence:

```bash
git log main --oneline | grep -q "$BRANCH"        # commit-subject grep on a LOCAL ref
git merge-base --is-ancestor origin/$BRANCH origin/main   # hardcoded main, no error handling
```

Observed in the wild: a polecat finished work on a **local-only** branch and crashed before pushing. `origin/$BRANCH` did not resolve, so `git merge-base --is-ancestor` exited **128 (error), not 1 (not-ancestor)** — and the agent executing the formula improvised around the failure and ran `gc bd close --force`. Four task beads were closed as "already merged" while their commits existed only on local polecat branches: no push, no PR, nothing on the target branch. The convoy reported them complete and the work silently vanished from the queue until a human audited git ancestry by hand.

The failure shape is asymmetric: a **wrong reset** self-heals (the refinery's own already-merged gate closes a genuinely merged bead on re-dispatch), but a **wrong close** is unrecoverable. Step 3 should fail open toward reset.

## Fix

Rewrite Step 3 to mirror the refinery's well-defended already-merged gate (`mol-refinery-patrol.toml`, direct-merge strategy), which this pack already treats as canonical:

- **Origin-side evidence only** — subject greps and local refs are never evidence of a merge.
- **Target resolved from the bead** (`metadata.target`, falling back to `origin/HEAD`) — never a hardcoded branch name.
- **A branch absent from origin cannot be merged** (`git ls-remote --heads origin "$BRANCH"`) → reset, never close. This alone prevents the observed failure.
- **Explicit 3-way `merge-base` case**: `0` = merged → close with forensics (`merge_result`/`merged_sha`/`merged_target` metadata) **only if both the update and the close land**; `1` = not merged → reset; anything else → STOP without mutating bead state.

Also adds the same evidence bar to the witness prompt's recovery-chain summary (case 1), which previously documented reset paths but never mentioned the close path.

## Testing

- `bash gastown/tests/test_gastown_pack_assets.sh` — pass
- `bash gastown/tests/test_gastown_theme_scripts.sh` — pass
- `bash gastown/tests/test_polecat_churn_watcher.sh` — pass
- `python3 -c "import tomllib; tomllib.load(...)"` on the formula — valid TOML

No behavior change for genuinely merged work: it is still closed (with forensics), now with proof.
