### PR TITLE
fix(gastown): fail closed on polecat claim failures

### DIFF
--- a/gastown/agents/polecat/prompt.template.md
+++ b/gastown/agents/polecat/prompt.template.md
@@ -195,9 +195,17 @@ while [ "$CLAIM_TRY" -lt 3 ]; do
   sleep 2
 done
 if [ -z "$WORK_ID" ]; then
-  echo "CLAIM_REJECTED gc hook --claim returned no workable bead after retries"
-  gc runtime drain-ack
-  exit 0
+  # Hook infrastructure failure, NOT "no work". Do NOT drain-ack: drain-ack
+  # reports idle and puts the session to sleep, which hides the outage from
+  # town oversight and loops wake->drain->sleep forever (a polecat that never
+  # claims leaves no stale bead, so no health check ever fires). Escalate and
+  # exit non-zero WITHOUT acknowledging drain, so the failure stays visible
+  # and the controller's crash-loop path engages instead of the sleep cycle.
+  echo "CLAIM_INFRA_FAILURE gc hook --claim failed after $CLAIM_TRY attempts (last code=$CLAIM_CODE): ${CLAIM_ERR_TEXT:-malformed claim result}"
+  WITNESS_TARGET="${GC_RIG:+$GC_RIG/}{{ .BindingPrefix }}witness"
+  gc mail send "$WITNESS_TARGET" -s "ESCALATION: gc hook --claim failing [HIGH]" \
+    -m "gc hook --claim failed $CLAIM_TRY times in a row (last exit=$CLAIM_CODE): ${CLAIM_ERR_TEXT:-malformed claim result}. Session is NOT drain-acking; this is an infrastructure fault (agent resolution, daemon, or store), not a work shortage."
+  exit 1
 fi
 
 # Post-claim ownership verification. The bead MUST be yours and in_progress
@@ -248,8 +256,10 @@ GC_CLAIM
 ```
 
 If the block prints `NO_ROUTED_WORK`, `CLAIM_REJECTED`, or `CLAIM_RELEASED`, it
-has already drain-acked — stop and exit. Only after it prints `CLAIMED_BEAD_ID` do you read
-formula steps and begin. The claim checks assigned work first (session bead ID,
+has already drain-acked — stop and exit. If it prints `CLAIM_INFRA_FAILURE`,
+the hook itself is broken: it has already escalated to the witness and NOT
+drain-acked — end your turn without retrying the claim or drain-acking. Only
+after it prints `CLAIMED_BEAD_ID` do you read formula steps and begin. The claim checks assigned work first (session bead ID,
 runtime session name, then alias) and only falls through to unassigned pool work
 routed to `${GC_RIG:+$GC_RIG/}{{ .BindingPrefix }}polecat`.
 

--- a/gastown/agents/polecat/prompt.template.md
+++ b/gastown/agents/polecat/prompt.template.md
@@ -158,14 +158,15 @@ bash <<'GC_CLAIM'
 set +e
 EXPECTED_ASSIGNEE="${BEADS_ACTOR:-${GC_SESSION_NAME:-${GC_SESSION_ID:-${GC_AGENT:-}}}}"
 if [ -z "$EXPECTED_ASSIGNEE" ]; then
-  echo "CLAIM_REJECTED no session identity in env; cannot verify ownership"
-  gc runtime drain-ack
-  exit 0
+  echo "CLAIM_INFRA_FAILURE no session identity in env; cannot validate hook ownership"
+  exit 1
 fi
+EXPECTED_ROUTE="${GC_RIG:+$GC_RIG/}{{ .BindingPrefix }}polecat"
 
 # Claim with retry. A hook-call failure (non-zero exit, malformed JSON) is a
 # transient CLI/daemon fault — NOT "no work" — so retry it before giving up.
-# Only action==drain, or a clean empty result, is genuine NO_ROUTED_WORK.
+# Only a schema-valid action==drain with reason=no_work is a genuine terminal
+# drain. Any other drain reason is infrastructure failure, not idle.
 WORK_ID=""
 CLAIM_TRY=0
 while [ "$CLAIM_TRY" -lt 3 ]; do
@@ -175,22 +176,33 @@ while [ "$CLAIM_TRY" -lt 3 ]; do
   CLAIM_CODE=$?
   CLAIM_ERR_TEXT="$(sed -n '1p' "$CLAIM_ERR")"
   rm -f "$CLAIM_ERR"
+  SCHEMA_VERSION="$(printf '%s' "$CLAIM_JSON" | jq -r '.schema_version // empty' 2>/dev/null)"
+  CLAIM_OK="$(printf '%s' "$CLAIM_JSON" | jq -r '.ok // empty' 2>/dev/null)"
+  COMMAND="$(printf '%s' "$CLAIM_JSON" | jq -r '.command // empty' 2>/dev/null)"
   ACTION="$(printf '%s' "$CLAIM_JSON" | jq -r '.action // empty' 2>/dev/null)"
+  REASON="$(printf '%s' "$CLAIM_JSON" | jq -r '.reason // empty' 2>/dev/null)"
   WORK_ID="$(printf '%s' "$CLAIM_JSON" | jq -r '.bead_id // empty' 2>/dev/null)"
+  CLAIM_ASSIGNEE="$(printf '%s' "$CLAIM_JSON" | jq -r '.assignee // empty' 2>/dev/null)"
+  CLAIM_ROUTE="$(printf '%s' "$CLAIM_JSON" | jq -r '.route // empty' 2>/dev/null)"
   if [ "$ACTION" = "drain" ]; then
-    echo "NO_ROUTED_WORK"
-    gc runtime drain-ack
-    exit 0
+    if [ "$SCHEMA_VERSION" = "1" ] && [ "$CLAIM_OK" = "true" ] &&
+       [ "$COMMAND" = "hook" ] && [ "$REASON" = "no_work" ]; then
+      echo "NO_ROUTED_WORK reason=$REASON"
+      gc runtime drain-ack
+      exit 0
+    fi
+    CLAIM_ERR_TEXT="hook returned non-idle drain reason=${REASON:-missing}"
   fi
-  if [ "$CLAIM_CODE" -eq 0 ] && [ -n "$WORK_ID" ]; then
+  if [ "$CLAIM_CODE" -eq 0 ] &&
+     [ "$SCHEMA_VERSION" = "1" ] && [ "$CLAIM_OK" = "true" ] &&
+     [ "$COMMAND" = "hook" ] && [ "$ACTION" = "work" ] &&
+     { [ "$REASON" = "claimed" ] || [ "$REASON" = "existing_assignment" ] || [ "$REASON" = "ready_assignment" ]; } &&
+     [ -n "$WORK_ID" ] && [ "$CLAIM_ASSIGNEE" = "$EXPECTED_ASSIGNEE" ] &&
+     { [ "$CLAIM_ROUTE" = "$EXPECTED_ROUTE" ] ||
+       { [ "$REASON" != "claimed" ] && [ -z "$CLAIM_ROUTE" ]; }; }; then
     break
   fi
-  if [ "$CLAIM_CODE" -eq 0 ] && [ -z "$ACTION" ] && [ -z "$WORK_ID" ]; then
-    echo "NO_ROUTED_WORK"
-    gc runtime drain-ack
-    exit 0
-  fi
-  echo "CLAIM_RETRY hook call failed (code=$CLAIM_CODE): ${CLAIM_ERR_TEXT:-malformed claim result}"
+  echo "CLAIM_RETRY hook result invalid (code=$CLAIM_CODE action=${ACTION:-missing} reason=${REASON:-missing} assignee=${CLAIM_ASSIGNEE:-missing} route=${CLAIM_ROUTE:-missing}): ${CLAIM_ERR_TEXT:-malformed claim result}"
   WORK_ID=""
   sleep 2
 done
@@ -208,16 +220,14 @@ if [ -z "$WORK_ID" ]; then
   exit 1
 fi
 
-# Post-claim ownership verification. The bead MUST be yours and in_progress
-# before you touch any code. A polecat NEVER works a bead it did not claim this
-# session. Distinguish a READ FAILURE (gc bd show non-zero / empty JSON —
-# transient) from a genuine MISMATCH (non-empty assignee that differs, or
-# status not in_progress). Retry the read before deciding; only a genuine
-# mismatch is CLAIM_REJECTED.
+# The schema-valid hook result above is the authoritative claim receipt. This
+# direct read is best-effort enrichment only: a federated/cache read can lag the
+# committed hook mutation and temporarily report open/unassigned. Never release,
+# mutate, or drain-ack because this secondary read is stale or unavailable.
 STATUS=""
 ASSIGNEE=""
 SHOW_JSON=""
-SHOW_OK=0
+SHOW_CONFIRMED=0
 SHOW_TRY=0
 while [ "$SHOW_TRY" -lt 3 ]; do
   SHOW_TRY=$((SHOW_TRY + 1))
@@ -225,38 +235,32 @@ while [ "$SHOW_TRY" -lt 3 ]; do
   SHOW_CODE=$?
   STATUS="$(printf '%s' "$SHOW_JSON" | jq -r '.[0].status // empty' 2>/dev/null)"
   ASSIGNEE="$(printf '%s' "$SHOW_JSON" | jq -r '.[0].assignee // empty' 2>/dev/null)"
-  if [ "$SHOW_CODE" -eq 0 ] && [ -n "$STATUS" ] && [ -n "$ASSIGNEE" ]; then
-    SHOW_OK=1
+  if [ "$SHOW_CODE" -eq 0 ] && [ "$STATUS" = "in_progress" ] &&
+     [ "$ASSIGNEE" = "$CLAIM_ASSIGNEE" ]; then
+    SHOW_CONFIRMED=1
     break
   fi
   sleep 1
 done
-if [ "$SHOW_OK" -ne 1 ]; then
-  # Never leave a claimed bead stranded in_progress on an unreadable state:
-  # release it so it re-enters the pool instead of being lost.
-  echo "CLAIM_RELEASED $WORK_ID unreadable after retries; returning it to the pool"
-  gc bd update "$WORK_ID" --status=open --assignee=""
-  gc runtime drain-ack
-  exit 0
-fi
-if [ "$ASSIGNEE" != "$EXPECTED_ASSIGNEE" ] || [ "$STATUS" != "in_progress" ]; then
-  echo "CLAIM_REJECTED $WORK_ID assignee=$ASSIGNEE status=$STATUS (expected $EXPECTED_ASSIGNEE / in_progress)"
-  gc runtime drain-ack
-  exit 0
-fi
 
-# Ownership confirmed. Stamp a stable session identity so the churn-watcher and
-# the resume re-verify can key on metadata.polecat_session.
-gc bd update "$WORK_ID" --set-metadata polecat_session="$EXPECTED_ASSIGNEE" \
-  || echo "WARN metadata stamp failed for $WORK_ID; churn-watcher/resume lose session keying (proceeding — the claim is valid)"
+if [ "$SHOW_CONFIRMED" -eq 1 ]; then
+  # Stamp only after the secondary read converges. The hook itself already
+  # records durable session identity; this pack-local key is observability-only.
+  gc bd update "$WORK_ID" --set-metadata polecat_session="$CLAIM_ASSIGNEE" \
+    || echo "WARN metadata stamp failed for $WORK_ID; churn-watcher/resume lose session keying (proceeding — the claim is valid)"
+  printf '%s' "$SHOW_JSON" | jq '.[0].metadata'
+else
+  echo "CLAIM_READ_STALE $WORK_ID direct_status=${STATUS:-unavailable} direct_assignee=${ASSIGNEE:-unavailable}; trusting schema-valid hook receipt"
+fi
 
 printf 'CLAIMED_BEAD_ID=%s\n' "$WORK_ID"
-printf '%s' "$SHOW_JSON" | jq '.[0].metadata'
+printf 'CLAIMED_ASSIGNEE=%s\n' "$CLAIM_ASSIGNEE"
+printf 'CLAIMED_ROUTE=%s\n' "$CLAIM_ROUTE"
 GC_CLAIM
 ```
 
-If the block prints `NO_ROUTED_WORK`, `CLAIM_REJECTED`, or `CLAIM_RELEASED`, it
-has already drain-acked — stop and exit. If it prints `CLAIM_INFRA_FAILURE`,
+If the block prints `NO_ROUTED_WORK`, it has already drain-acked — stop and
+exit. If it prints `CLAIM_INFRA_FAILURE`,
 the hook itself is broken: it has already escalated to the witness and NOT
 drain-acked — end your turn without retrying the claim or drain-acking. Only
 after it prints `CLAIMED_BEAD_ID` do you read formula steps and begin. The claim checks assigned work first (session bead ID,

--- a/gastown/agents/polecat/prompt.template.md
+++ b/gastown/agents/polecat/prompt.template.md
@@ -159,6 +159,9 @@ set +e
 EXPECTED_ASSIGNEE="${BEADS_ACTOR:-${GC_SESSION_NAME:-${GC_SESSION_ID:-${GC_AGENT:-}}}}"
 if [ -z "$EXPECTED_ASSIGNEE" ]; then
   echo "CLAIM_INFRA_FAILURE no session identity in env; cannot validate hook ownership"
+  WITNESS_TARGET="${GC_RIG:+$GC_RIG/}{{ .BindingPrefix }}witness"
+  gc mail send "$WITNESS_TARGET" -s "ESCALATION: polecat session identity missing [HIGH]" \
+    -m "Polecat startup cannot validate gc hook ownership because BEADS_ACTOR, GC_SESSION_NAME, GC_SESSION_ID, and GC_AGENT are all empty. Session did NOT claim, mutate, or drain-ack."
   exit 1
 fi
 EXPECTED_ROUTE="${GC_RIG:+$GC_RIG/}{{ .BindingPrefix }}polecat"
@@ -220,10 +223,11 @@ if [ -z "$WORK_ID" ]; then
   exit 1
 fi
 
-# The schema-valid hook result above is the authoritative claim receipt. This
-# direct read is best-effort enrichment only: a federated/cache read can lag the
-# committed hook mutation and temporarily report open/unassigned. Never release,
-# mutate, or drain-ack because this secondary read is stale or unavailable.
+# The schema-valid hook result above says a claim mutation succeeded, but the
+# direct work-context read must confirm that mutation before work starts. A
+# cross-store discovery/mutation bug can return a valid hook receipt while the
+# work-context projection remains open/unassigned. Never release, mutate,
+# drain-ack, or start work when the two views disagree: escalate and fail closed.
 STATUS=""
 ASSIGNEE=""
 SHOW_JSON=""
@@ -243,15 +247,18 @@ while [ "$SHOW_TRY" -lt 3 ]; do
   sleep 1
 done
 
-if [ "$SHOW_CONFIRMED" -eq 1 ]; then
-  # Stamp only after the secondary read converges. The hook itself already
-  # records durable session identity; this pack-local key is observability-only.
-  gc bd update "$WORK_ID" --set-metadata polecat_session="$CLAIM_ASSIGNEE" \
-    || echo "WARN metadata stamp failed for $WORK_ID; churn-watcher/resume lose session keying (proceeding — the claim is valid)"
-  printf '%s' "$SHOW_JSON" | jq '.[0].metadata'
-else
-  echo "CLAIM_READ_STALE $WORK_ID direct_status=${STATUS:-unavailable} direct_assignee=${ASSIGNEE:-unavailable}; trusting schema-valid hook receipt"
+if [ "$SHOW_CONFIRMED" -ne 1 ]; then
+  echo "CLAIM_INFRA_FAILURE $WORK_ID hook reported assignee=$CLAIM_ASSIGNEE route=$CLAIM_ROUTE but direct work read remained status=${STATUS:-unavailable} assignee=${ASSIGNEE:-unavailable}"
+  WITNESS_TARGET="${GC_RIG:+$GC_RIG/}{{ .BindingPrefix }}witness"
+  gc mail send "$WITNESS_TARGET" -s "ESCALATION: hook claim unconfirmed by work read [HIGH]" \
+    -m "gc hook --claim returned work bead=$WORK_ID assignee=$CLAIM_ASSIGNEE route=$CLAIM_ROUTE, but after $SHOW_TRY direct work reads gc bd show remained status=${STATUS:-unavailable} assignee=${ASSIGNEE:-unavailable}. Possible cross-store discovery/mutation mismatch. Session did NOT release, mutate, or drain-ack the bead and will not start work."
+  exit 1
 fi
+
+# Only a confirmed in_progress read may proceed or mutate observability metadata.
+gc bd update "$WORK_ID" --set-metadata polecat_session="$CLAIM_ASSIGNEE" \
+  || echo "WARN metadata stamp failed for $WORK_ID; churn-watcher/resume lose session keying (proceeding — the claim is valid)"
+printf '%s' "$SHOW_JSON" | jq '.[0].metadata'
 
 printf 'CLAIMED_BEAD_ID=%s\n' "$WORK_ID"
 printf 'CLAIMED_ASSIGNEE=%s\n' "$CLAIM_ASSIGNEE"
@@ -261,8 +268,9 @@ GC_CLAIM
 
 If the block prints `NO_ROUTED_WORK`, it has already drain-acked — stop and
 exit. If it prints `CLAIM_INFRA_FAILURE`,
-the hook itself is broken: it has already escalated to the witness and NOT
-drain-acked — end your turn without retrying the claim or drain-acking. Only
+the hook path or cross-store confirmation is broken: it has already escalated
+to the witness and NOT drain-acked — end your turn without retrying the claim
+or drain-acking. Only
 after it prints `CLAIMED_BEAD_ID` do you read formula steps and begin. The claim checks assigned work first (session bead ID,
 runtime session name, then alias) and only falls through to unassigned pool work
 routed to `${GC_RIG:+$GC_RIG/}{{ .BindingPrefix }}polecat`.

--- a/gastown/tests/test_gastown_pack_assets.sh
+++ b/gastown/tests/test_gastown_pack_assets.sh
@@ -176,7 +176,7 @@ test_polecat_claim_infra_failure_escalates_without_drain_ack() {
         fail "claim-block outcome guidance must cover CLAIM_INFRA_FAILURE"
 }
 
-test_polecat_claim_trusts_hook_receipt_when_direct_read_lags() {
+test_polecat_claim_fails_closed_when_work_read_disagrees() {
     local prompt tmpdir fake_bin claim_script output calls claim_code
     prompt="$GASTOWN/agents/polecat/prompt.template.md"
     tmpdir="$(mktemp -d)"
@@ -186,9 +186,8 @@ test_polecat_claim_trusts_hook_receipt_when_direct_read_lags() {
     mkdir -p "$fake_bin"
 
     # Execute the exact startup block from the asset. The hook returns the
-    # authoritative successful claim observed in production, while the
-    # immediately-following direct read repeatedly returns its stale
-    # open/unassigned projection.
+    # successful receipt observed in production, while the direct work read
+    # repeatedly shows the real open/unassigned wrong-store outcome.
     python3 - "$prompt" >"$claim_script" <<'PY'
 import sys
 
@@ -227,27 +226,32 @@ exit 0
 SH
     chmod +x "$fake_bin/gc" "$fake_bin/sleep" "$claim_script"
 
+    set +e
     output="$(
         PATH="$fake_bin:$PATH" \
         GC_TEST_CALLS="$calls" \
         GC_RIG="kisakcod" \
         GC_SESSION_NAME="kisakcod/gastown.polecat-1" \
         BEADS_ACTOR="kisakcod/gastown.polecat-1" \
-        bash "$claim_script"
-    )" || fail "schema-valid hook claim must survive a stale direct read"
+        bash "$claim_script" 2>&1
+    )"
+    claim_code=$?
+    set -e
 
-    [[ "$output" == *'CLAIM_READ_STALE ac-3iv direct_status=open direct_assignee=unavailable'* ]] ||
-        fail "stale direct claim projection should be diagnosed without overriding the hook receipt"
-    [[ "$output" == *'CLAIMED_BEAD_ID=ac-3iv'* ]] ||
-        fail "authoritative hook bead id must remain claimed when the direct read lags"
-    [[ "$output" == *'CLAIMED_ASSIGNEE=kisakcod/gastown.polecat-1'* ]] ||
-        fail "authoritative hook assignee must be preserved"
-    [[ "$output" == *'CLAIMED_ROUTE=kisakcod/gastown.polecat'* ]] ||
-        fail "authoritative hook route must be preserved"
+    [[ "$claim_code" -eq 1 ]] ||
+        fail "unconfirmed hook receipt must fail closed with a non-zero exit"
+    [[ "$output" == *'CLAIM_INFRA_FAILURE ac-3iv'* ]] ||
+        fail "wrong-store/unconfirmed claim must surface as CLAIM_INFRA_FAILURE"
+    [[ "$output" == *'status=open assignee=unavailable'* ]] ||
+        fail "claim failure must report the disagreeing work-context state"
+    [[ "$output" != *'CLAIMED_BEAD_ID='* ]] ||
+        fail "unconfirmed hook receipt must never emit CLAIMED_BEAD_ID or start work"
     ! grep -F 'bd update' "$calls" >/dev/null ||
-        fail "stale post-claim reads must never mutate or release the claimed bead"
+        fail "unconfirmed post-claim reads must never mutate or release the bead"
     ! grep -F 'runtime drain-ack' "$calls" >/dev/null ||
-        fail "stale post-claim reads must never drain-ack the worker"
+        fail "unconfirmed post-claim reads must never drain-ack the worker"
+    [[ "$(grep -c '^mail send ' "$calls")" -eq 1 ]] ||
+        fail "unconfirmed post-claim state must send exactly one witness escalation"
 
     # A structured claims_errored result means routed work existed but its
     # claim mutation failed. It must remain an observable infrastructure
@@ -348,7 +352,7 @@ test_shutdown_dance_lifecycle_and_audit_contracts
 test_composition_is_documented
 test_polecat_startup_uses_standard_hook_claim
 test_polecat_claim_infra_failure_escalates_without_drain_ack
-test_polecat_claim_trusts_hook_receipt_when_direct_read_lags
+test_polecat_claim_fails_closed_when_work_read_disagrees
 test_review_leg_contract_forbids_synthetic_mutation
 test_refinery_direct_merge_is_worktree_safe_and_fail_closed
 

--- a/gastown/tests/test_gastown_pack_assets.sh
+++ b/gastown/tests/test_gastown_pack_assets.sh
@@ -152,6 +152,30 @@ test_polecat_startup_uses_standard_hook_claim() {
         fail "polecat propulsion fragment must not regress to an unclaimed hook/work-query choice"
 }
 
+test_polecat_claim_infra_failure_escalates_without_drain_ack() {
+    local prompt block
+    prompt="$GASTOWN/agents/polecat/prompt.template.md"
+
+    grep -F 'CLAIM_INFRA_FAILURE' "$prompt" >/dev/null ||
+        fail "polecat claim loop must distinguish hook infrastructure failure from no-work"
+    ! grep -F 'CLAIM_REJECTED gc hook --claim returned no workable bead after retries' "$prompt" >/dev/null ||
+        fail "exhausted hook retries must not be reported as 'no workable bead'"
+
+    # The terminal infra-failure path must escalate and exit non-zero WITHOUT
+    # drain-ack: drain-ack reports idle and sleeps, hiding the outage from
+    # town oversight in a wake->drain->sleep loop no health check can see.
+    block="$(awk '/CLAIM_INFRA_FAILURE/{found=1} found{print} found && /^fi$/{exit}' "$prompt")"
+    [[ "$block" == *'exit 1'* ]] ||
+        fail "hook infrastructure failure must exit non-zero, not exit 0 like genuine no-work"
+    [[ "$block" != *'gc runtime drain-ack'* ]] ||
+        fail "hook infrastructure failure must NOT drain-ack — that reports idle and hides the outage"
+    [[ "$block" == *'ESCALATION: gc hook --claim failing [HIGH]'* ]] ||
+        fail "hook infrastructure failure must escalate to the witness"
+
+    grep -F 'If it prints `CLAIM_INFRA_FAILURE`' "$prompt" >/dev/null ||
+        fail "claim-block outcome guidance must cover CLAIM_INFRA_FAILURE"
+}
+
 test_review_leg_contract_forbids_synthetic_mutation() {
     local formula prompt
     formula="$GASTOWN/formulas/mol-review-leg.toml"
@@ -222,6 +246,7 @@ test_shutdown_dance_contracts_are_executable
 test_shutdown_dance_lifecycle_and_audit_contracts
 test_composition_is_documented
 test_polecat_startup_uses_standard_hook_claim
+test_polecat_claim_infra_failure_escalates_without_drain_ack
 test_review_leg_contract_forbids_synthetic_mutation
 test_refinery_direct_merge_is_worktree_safe_and_fail_closed
 

--- a/gastown/tests/test_gastown_pack_assets.sh
+++ b/gastown/tests/test_gastown_pack_assets.sh
@@ -164,7 +164,7 @@ test_polecat_claim_infra_failure_escalates_without_drain_ack() {
     # The terminal infra-failure path must escalate and exit non-zero WITHOUT
     # drain-ack: drain-ack reports idle and sleeps, hiding the outage from
     # town oversight in a wake->drain->sleep loop no health check can see.
-    block="$(awk '/CLAIM_INFRA_FAILURE/{found=1} found{print} found && /^fi$/{exit}' "$prompt")"
+    block="$(awk '/CLAIM_INFRA_FAILURE gc hook --claim failed after/{found=1} found{print} found && /^fi$/{exit}' "$prompt")"
     [[ "$block" == *'exit 1'* ]] ||
         fail "hook infrastructure failure must exit non-zero, not exit 0 like genuine no-work"
     [[ "$block" != *'gc runtime drain-ack'* ]] ||
@@ -174,6 +174,107 @@ test_polecat_claim_infra_failure_escalates_without_drain_ack() {
 
     grep -F 'If it prints `CLAIM_INFRA_FAILURE`' "$prompt" >/dev/null ||
         fail "claim-block outcome guidance must cover CLAIM_INFRA_FAILURE"
+}
+
+test_polecat_claim_trusts_hook_receipt_when_direct_read_lags() {
+    local prompt tmpdir fake_bin claim_script output calls claim_code
+    prompt="$GASTOWN/agents/polecat/prompt.template.md"
+    tmpdir="$(mktemp -d)"
+    fake_bin="$tmpdir/bin"
+    claim_script="$tmpdir/claim.sh"
+    calls="$tmpdir/calls"
+    mkdir -p "$fake_bin"
+
+    # Execute the exact startup block from the asset. The hook returns the
+    # authoritative successful claim observed in production, while the
+    # immediately-following direct read repeatedly returns its stale
+    # open/unassigned projection.
+    python3 - "$prompt" >"$claim_script" <<'PY'
+import sys
+
+text = open(sys.argv[1], encoding="utf-8").read()
+start_marker = "bash <<'GC_CLAIM'\n"
+start = text.index(start_marker) + len(start_marker)
+end = text.index("\nGC_CLAIM", start)
+print(text[start:end].replace("{{ .BindingPrefix }}", "gastown."))
+PY
+    cat >"$fake_bin/gc" <<'SH'
+#!/bin/sh
+printf '%s\n' "$*" >>"$GC_TEST_CALLS"
+case "$*" in
+  "hook --claim --json")
+    if [ "${GC_TEST_SCENARIO:-}" = "claims_errored" ]; then
+      printf '%s\n' '{"schema_version":"1","ok":true,"command":"hook","action":"drain","reason":"claims_errored"}'
+      exit 1
+    fi
+    printf '%s\n' '{"schema_version":"1","ok":true,"command":"hook","action":"work","reason":"claimed","bead_id":"ac-3iv","assignee":"kisakcod/gastown.polecat-1","route":"kisakcod/gastown.polecat"}'
+    ;;
+  "bd show ac-3iv --json")
+    printf '%s\n' '[{"id":"ac-3iv","status":"open","assignee":"","metadata":{"gc.routed_to":"kisakcod/gastown.polecat"}}]'
+    ;;
+  "mail send "*)
+    exit 0
+    ;;
+  *)
+    printf 'unexpected mutation after authoritative claim: %s\n' "$*" >&2
+    exit 97
+    ;;
+esac
+SH
+    cat >"$fake_bin/sleep" <<'SH'
+#!/bin/sh
+exit 0
+SH
+    chmod +x "$fake_bin/gc" "$fake_bin/sleep" "$claim_script"
+
+    output="$(
+        PATH="$fake_bin:$PATH" \
+        GC_TEST_CALLS="$calls" \
+        GC_RIG="kisakcod" \
+        GC_SESSION_NAME="kisakcod/gastown.polecat-1" \
+        BEADS_ACTOR="kisakcod/gastown.polecat-1" \
+        bash "$claim_script"
+    )" || fail "schema-valid hook claim must survive a stale direct read"
+
+    [[ "$output" == *'CLAIM_READ_STALE ac-3iv direct_status=open direct_assignee=unavailable'* ]] ||
+        fail "stale direct claim projection should be diagnosed without overriding the hook receipt"
+    [[ "$output" == *'CLAIMED_BEAD_ID=ac-3iv'* ]] ||
+        fail "authoritative hook bead id must remain claimed when the direct read lags"
+    [[ "$output" == *'CLAIMED_ASSIGNEE=kisakcod/gastown.polecat-1'* ]] ||
+        fail "authoritative hook assignee must be preserved"
+    [[ "$output" == *'CLAIMED_ROUTE=kisakcod/gastown.polecat'* ]] ||
+        fail "authoritative hook route must be preserved"
+    ! grep -F 'bd update' "$calls" >/dev/null ||
+        fail "stale post-claim reads must never mutate or release the claimed bead"
+    ! grep -F 'runtime drain-ack' "$calls" >/dev/null ||
+        fail "stale post-claim reads must never drain-ack the worker"
+
+    # A structured claims_errored result means routed work existed but its
+    # claim mutation failed. It must remain an observable infrastructure
+    # failure, never be laundered into the same drain path as genuine no_work.
+    : >"$calls"
+    set +e
+    output="$(
+        PATH="$fake_bin:$PATH" \
+        GC_TEST_CALLS="$calls" \
+        GC_TEST_SCENARIO="claims_errored" \
+        GC_RIG="kisakcod" \
+        GC_SESSION_NAME="kisakcod/gastown.polecat-1" \
+        BEADS_ACTOR="kisakcod/gastown.polecat-1" \
+        bash "$claim_script" 2>&1
+    )"
+    claim_code=$?
+    set -e
+    [[ "$claim_code" -eq 1 ]] ||
+        fail "claims_errored must remain a non-zero infrastructure failure"
+    [[ "$output" == *'CLAIM_INFRA_FAILURE'* ]] ||
+        fail "claims_errored must surface as CLAIM_INFRA_FAILURE"
+    ! grep -F 'bd update' "$calls" >/dev/null ||
+        fail "claims_errored must never mutate or release a bead"
+    ! grep -F 'runtime drain-ack' "$calls" >/dev/null ||
+        fail "claims_errored must never acknowledge drain"
+
+    rm -rf "$tmpdir"
 }
 
 test_review_leg_contract_forbids_synthetic_mutation() {
@@ -247,6 +348,7 @@ test_shutdown_dance_lifecycle_and_audit_contracts
 test_composition_is_documented
 test_polecat_startup_uses_standard_hook_claim
 test_polecat_claim_infra_failure_escalates_without_drain_ack
+test_polecat_claim_trusts_hook_receipt_when_direct_read_lags
 test_review_leg_contract_forbids_synthetic_mutation
 test_refinery_direct_merge_is_worktree_safe_and_fail_closed
 


### PR DESCRIPTION
## Problem

Gastown's polecat startup claim block converted two claim-system failures into ordinary idle/drain behavior:

1. After exhausted or malformed `gc hook --claim` attempts, it drain-acked and exited successfully.
2. After a hook reported a successful claim, a disagreeing `gc bd show` caused the prompt to release/reopen the bead, drain-ack, and exit.

Both paths hide infrastructure failures as no-work. Routed demand then wakes or recreates the polecat, producing a wake/claim/drain loop with no useful progress.

The second path was reproduced in a live v1.3.5 canary. `gc hook --claim` discovered canonical `ac-3iv` in the city store but, because v1.3.5 discarded the selected federated-store context, applied the mutation to a same-ID row in the rig store. The normal work-context read correctly still saw the canonical bead as `open` and unassigned. The old prompt then mutated/released through an ambiguous context and drain-acked. Five provider generations consumed roughly 70k input tokens in about two minutes without starting the task.

The selected-store bug is a Gas City core issue; upstream main fixed it in gastownhall/gascity#3785. This pack change is the required fail-closed boundary and does not pretend to replace that core fix.

## Fix

- Validate the schema-v1 `gc hook --claim --json` envelope and work receipt (`bead_id`, `assignee`, and route).
- Allow only schema-v1 `action=drain, reason=no_work` to take the terminal idle/drain path.
- Treat exhausted, malformed, identity-mismatched, and other non-idle hook results as `CLAIM_INFRA_FAILURE`: send one Witness escalation, exit nonzero, and do not drain-ack.
- Require the direct work-context read to confirm `in_progress` plus the hook receipt's assignee before emitting `CLAIMED_BEAD_ID` or starting work.
- If the hook receipt and work read disagree, send one high-priority Witness escalation and exit nonzero. Do not release, reopen, mutate, drain-ack, or begin work through an ambiguous store context.
- Stamp optional `polecat_session` observability metadata only after confirmation.
- Missing runtime identity also fails visibly without claiming or draining.

This makes the pack safe on both sides of the core fix: pre-fix, wrong-store claims stop visibly instead of churning or doing work against the wrong row; post-fix, a correctly selected claim proceeds only after its normal work view confirms ownership.

## Regression coverage

The executable startup-block regression models the production `ac-3iv` disagreement:

- hook returns a schema-valid work receipt;
- repeated direct work reads remain `open` and unassigned;
- the block must exit 1, emit `CLAIM_INFRA_FAILURE`, send exactly one Witness escalation, issue no `bd update`, issue no `runtime drain-ack`, and emit no `CLAIMED_BEAD_ID`.

A structured non-idle/invalid hook result is also pinned to the visible failure path. The original hook-infrastructure escalation contract remains covered.

## Validation

- `bash gastown/tests/test_gastown_pack_assets.sh`
- `bash gastown/tests/test_gastown_theme_scripts.sh`
- `bash gastown/tests/test_polecat_churn_watcher.sh`
- `go test .`
- `gc lint gastown`
- `git diff --check`

All pass locally.
