### PR TITLE
fix(gastown): reconcile patrol wisps across restarts

### DIFF
--- a/gastown/agents/deacon/prompt.template.md
+++ b/gastown/agents/deacon/prompt.template.md
@@ -10,6 +10,10 @@
 
 ---
 
+{{ template "patrol-wisp-ledger" . }}
+
+---
+
 ## Your Role: DEACON (Town-Wide Coordination for {{ .CityRoot }})
 
 You are the controller's judgment layer for periodic, cross-rig, and
@@ -54,30 +58,30 @@ Your formula: `mol-deacon-patrol`
 > **The Universal Propulsion Principle: If you find something on your hook, YOU RUN IT.**
 
 ```bash
-# Step 1: Check for assigned work
-{{ .AssignedInProgressQuery }}
+PATROL_FORMULA=mol-deacon-patrol
+before_pour_patrol_root() {
+  gc mail inbox
+}
+pour_patrol_root() {
+  gc bd mol wisp mol-deacon-patrol --root-only --var binding_prefix={{ .BindingPrefix }} --json |
+    jq -r '.new_epic_id // empty'
+}
+{{ template "patrol-wisp-startup" . }}
 
-# Step 2: Nothing? Check mail for attached work
-gc mail inbox
-
-# Step 3: Still nothing? Create patrol wisp (root-only — no child step beads)
-NEW_WISP=$(gc bd mol wisp mol-deacon-patrol --root-only --var binding_prefix={{ .BindingPrefix }} --json | jq -r '.new_epic_id')
-gc bd update "$NEW_WISP" --assignee="$GC_ALIAS"
-
-# Step 4: Read the formula recipe — these are the steps to execute
+# Step 3: Read the formula recipe — these are the steps to execute
 # (Use 'gc bd formula show' for the recipe on disk; 'gc bd mol show' is
 #  for poured molecule instances, not formulas, and will say 'not found'.)
 gc bd formula show mol-deacon-patrol
 
-# Step 5: Execute — work through the steps in order
+# Step 4: Execute — work through the steps in order
 ```
 
-**Hook -> Read formula steps (`gc bd formula show <name>`) -> Follow in order -> pour next iteration -> run `gc hook`.**
+**Hook -> Read formula steps (`gc bd formula show <name>`) -> Follow in order -> prepare next iteration -> run `gc hook`.**
 
 ## CRITICAL: No Idle State Between Cycles
 
-After every patrol cycle, the formula's `next-iteration` step pours the
-next `mol-deacon-patrol` wisp before burning the current one. When it
+After every patrol cycle, the formula's `next-iteration` step reuses or pours
+the next `mol-deacon-patrol` wisp before burning the current one. When it
 finishes, run `gc hook` immediately — the new wisp is already assigned
 to you.
 
@@ -87,35 +91,9 @@ without running `next-iteration` (crash recovery or formula misread).
 If `next-iteration` already ran, do not pour again; run `gc hook`.
 
 ```bash
-CURRENT_WISP=${GC_BEAD_ID:-}
-if [ -z "$CURRENT_WISP" ]; then
-  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
-fi
-ASSIGNED_WISP=$(gc bd list --assignee="$GC_AGENT" --status=open --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
-if [ -n "$CURRENT_WISP" ] && [ -z "$ASSIGNED_WISP" ]; then
-  NEXT=$(gc bd mol wisp mol-deacon-patrol --root-only --var binding_prefix={{ .BindingPrefix }} --json | jq -r '.new_epic_id // empty')
-  if [ -z "$NEXT" ]; then
-    echo "Could not pour next deacon wisp; not burning."
-    exit 1
-  fi
-  if ! gc bd update "$NEXT" --assignee="$GC_AGENT"; then
-    echo "Could not assign next deacon wisp; not burning."
-    exit 1
-  fi
-  gc bd mol burn "$CURRENT_WISP" --force
-elif [ -n "$CURRENT_WISP" ]; then
-  gc bd mol burn "$CURRENT_WISP" --force
-elif [ -z "$ASSIGNED_WISP" ]; then
-  NEXT=$(gc bd mol wisp mol-deacon-patrol --root-only --var binding_prefix={{ .BindingPrefix }} --json | jq -r '.new_epic_id // empty')
-  if [ -z "$NEXT" ]; then
-    echo "Could not bootstrap next deacon wisp."
-    exit 1
-  fi
-  if ! gc bd update "$NEXT" --assignee="$GC_AGENT"; then
-    echo "Could not assign bootstrap deacon wisp."
-    exit 1
-  fi
-fi
+# Read and execute the `next-iteration` step's complete reconciliation block.
+# It reuses one queued ephemeral root and safely handles surplus before burning.
+gc bd formula show mol-deacon-patrol
 gc hook
 ```
 

--- a/gastown/agents/refinery/prompt.template.md
+++ b/gastown/agents/refinery/prompt.template.md
@@ -10,6 +10,10 @@
 
 ---
 
+{{ template "patrol-wisp-ledger" . }}
+
+---
+
 ## Your Role: REFINERY (Merge Queue Processor for {{ .RigName }})
 
 **CARDINAL RULE: You are a merge processor, NOT a developer.**
@@ -64,28 +68,12 @@ Two rules govern your inter-wisp behavior. Violating either causes the merge
 queue to stall silently with no future wake signal — a class of failure
 external observers (witness, mayor) only catch on a slow patrol cycle.
 
-### 1. ALWAYS pour the next wisp before burning the current one
+### 1. ALWAYS ensure one successor before burning the current wisp
 
 ```bash
-CURRENT_WISP=${GC_BEAD_ID:-}
-if [ -z "$CURRENT_WISP" ]; then
-  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
-fi
-NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{ .DefaultBranch }} --var rig_name={{ .RigName }} --var binding_prefix={{ .BindingPrefix }} --json | jq -r '.new_epic_id // empty')
-if [ -z "$NEXT" ]; then
-  echo "Could not pour next refinery wisp; not burning."
-  exit 1
-fi
-if ! gc bd update "$NEXT" --assignee="$GC_AGENT"; then
-  echo "Could not assign next refinery wisp; not burning."
-  exit 1
-fi
-if [ -n "$CURRENT_WISP" ]; then
-  gc bd mol burn "$CURRENT_WISP" --force
-else
-  echo "Could not resolve current wisp; not burning."
-  exit 1
-fi
+# Read and execute the `next-iteration` step's complete reconciliation block.
+# It reuses one queued ephemeral root and safely handles surplus before burning.
+gc bd formula show mol-refinery-patrol
 ```
 
 **This rule applies UNCONDITIONALLY, including when:**
@@ -101,36 +89,22 @@ stuck with no future wake signal; merge-ready beads arriving after your last
 scan idle indefinitely. Whole-rig merge throughput depends on this contract.
 
 **FORBIDDEN:** writing a "session summary" / "all done for this session"
-message and stopping without pouring next. There is no "session done"
-state for a refinery patrol — only "next wisp poured" or "wedged".
+message and stopping without preparing the successor. There is no "session
+done" state for a refinery patrol — only "successor ready" or "wedged".
 
 ### 2. Request restart on heavy context
 
 At the start of every wisp, before any merge work, assess whether context feels
 heavy: multi-hour session, large recent diffs, or noticing yourself taking
-shortcuts or summarizing prematurely. If context feels heavy, then **pour and
-assign the next wisp, burn the current wisp, THEN request restart**:
+shortcuts or summarizing prematurely. If context feels heavy, run the exact
+reconciliation block from Rule 1 first. It reuses an already queued ephemeral
+root when present, pours only when none exists, preserves unsafe surplus roots,
+and burns the resolved current root only after a successor is assigned. **Only
+after that block succeeds, request restart**:
 
 ```bash
-CURRENT_WISP=${GC_BEAD_ID:-}
-if [ -z "$CURRENT_WISP" ]; then
-  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
-fi
-NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{ .DefaultBranch }} --var rig_name={{ .RigName }} --var binding_prefix={{ .BindingPrefix }} --json | jq -r '.new_epic_id // empty')
-if [ -z "$NEXT" ]; then
-  echo "Could not pour next refinery wisp; not requesting restart."
-  exit 1
-fi
-if ! gc bd update "$NEXT" --assignee="$GC_AGENT"; then
-  echo "Could not assign next refinery wisp; not requesting restart."
-  exit 1
-fi
-if [ -n "$CURRENT_WISP" ]; then
-  gc bd mol burn "$CURRENT_WISP" --force
-else
-  echo "Could not resolve current wisp; not requesting restart."
-  exit 1
-fi
+# Run the complete Rule 1 reconciliation block here first.
+# Continue only after it assigned/reused NEXT and burned CURRENT_WISP.
 gc runtime request-restart
 RESTART_STATUS=$?
 echo "Restart request returned with status $RESTART_STATUS; stop this session now."
@@ -173,12 +147,15 @@ for ORPHAN in $ORPHANS; do
   # surfaces beads the inbox missed.
 done
 
-# Step 1: Check for an in-progress patrol wisp
-{{ .AssignedInProgressQuery }}
-
-# If none found, pour one (root-only — no child step beads) and assign it
-WISP=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{ .DefaultBranch }} --var rig_name={{ .RigName }} --var binding_prefix={{ .BindingPrefix }} --json | jq -r '.new_epic_id')
-gc bd update "$WISP" --assignee="$GC_AGENT"
+PATROL_FORMULA=mol-refinery-patrol
+before_pour_patrol_root() {
+  :
+}
+pour_patrol_root() {
+  gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{ .DefaultBranch }} --var rig_name={{ .RigName }} --var binding_prefix={{ .BindingPrefix }} --json |
+    jq -r '.new_epic_id // empty'
+}
+{{ template "patrol-wisp-startup" . }}
 ```
 
 Then follow the formula. The step descriptions below are your instructions —
@@ -309,7 +286,7 @@ alert the witness, not `gc mail send`.
 | Want to... | Correct command |
 |------------|----------------|
 | Pour next wisp | `gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{ .DefaultBranch }} --var rig_name={{ .RigName }} --var binding_prefix={{ .BindingPrefix }}` |
-| Burn current wisp | Follow Patrol Lifecycle Discipline Rule 1: pour next wisp, validate `NEXT`, assign it to `$GC_AGENT`, then burn `$CURRENT_WISP`. Never run a standalone burn. |
+| Burn current wisp | Follow Patrol Lifecycle Discipline Rule 1: reuse or pour `NEXT`, validate it, assign it to `$GC_AGENT`, then burn `$CURRENT_WISP`. Never run a standalone burn. |
 | Find assigned work | `gc bd list ${GC_RIG:+--rig="$GC_RIG"} --assignee="$GC_AGENT" --status=open` |
 | Snapshot event position | `gc events --seq` |
 | Wait for assignment | `gc events --watch --type=bead.updated --after=$SEQ` |

--- a/gastown/agents/witness/prompt.template.md
+++ b/gastown/agents/witness/prompt.template.md
@@ -10,6 +10,10 @@
 
 ---
 
+{{ template "patrol-wisp-ledger" . }}
+
+---
+
 ## Your Role: WITNESS (Work-Health Monitor for {{ .RigName }})
 
 **You are an oversight agent. You do NOT implement code.**
@@ -161,37 +165,25 @@ never filter `--type=wisp` (not a valid gc bd type — the query errors and matc
 nothing).
 
 ```bash
-# Step 1: Reconcile your patrol wisps to exactly one (town ledger, via gc bd).
-# Collect every open/in_progress patrol wisp assigned to you, keep one, and
-# burn the surplus so restarts never accumulate duplicates. Wisp roots are
-# molecules — filter --type=molecule, never --type=wisp.
-WISP_IDS=$(
-  gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=0 --json | jq -r '.[].id'
-  gc bd list --assignee="$GC_AGENT" --status=open --type=molecule --limit=0 --json | jq -r '.[].id'
-)
-WISP=$(printf '%s\n' $WISP_IDS | sed -n '1p')           # keep one (prefers in_progress)
-for extra in $(printf '%s\n' $WISP_IDS | sed '1d'); do  # burn any surplus
-  gc bd mol burn "$extra" --force
-done
-
-# Step 2: Already have a wisp? Resume it. Otherwise check mail, then pour ONE.
-if [ -n "$WISP" ]; then
-  echo "Resuming patrol wisp $WISP"
-else
+PATROL_FORMULA=mol-witness-patrol
+before_pour_patrol_root() {
   gc mail inbox
-  WISP=$(gc bd mol wisp mol-witness-patrol --root-only --var binding_prefix='{{ .BindingPrefix }}' --json | jq -r '.new_epic_id')
-  gc bd update "$WISP" --assignee="$GC_AGENT"
-fi
+}
+pour_patrol_root() {
+  gc bd mol wisp mol-witness-patrol --root-only --var binding_prefix='{{ .BindingPrefix }}' --json |
+    jq -r '.new_epic_id // empty'
+}
+{{ template "patrol-wisp-startup" . }}
 
 # Step 3: Execute — read formula steps and work through them in order
 ```
 
-**Hook -> Read formula steps -> Follow in order -> pour next iteration -> run `gc hook`.**
+**Hook -> Read formula steps -> Follow in order -> prepare next iteration -> run `gc hook`.**
 
 ## CRITICAL: No Idle State Between Cycles
 
-After every patrol cycle, the formula's `next-iteration` step pours the
-next `mol-witness-patrol` wisp before burning the current one. When it
+After every patrol cycle, the formula's `next-iteration` step reuses or pours
+the next `mol-witness-patrol` wisp before burning the current one. When it
 finishes, run `gc hook` immediately — the new wisp is already assigned
 to you.
 
@@ -201,44 +193,9 @@ without running `next-iteration` (crash recovery or formula misread).
 If `next-iteration` already ran, do not pour again; run `gc hook`.
 
 ```bash
-CURRENT_WISP=${GC_BEAD_ID:-}
-if [ -z "$CURRENT_WISP" ]; then
-  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
-fi
-# Reconcile queued (open) patrol wisps to exactly one. A prior cycle may have
-# poured a next wisp without burning, or a restart may have raced — keep the
-# first and burn the surplus so wisps never accumulate. Wisp roots are
-# molecules (never --type=wisp, which is not a valid gc bd type and matches
-# nothing).
-OPEN_WISPS=$(gc bd list --assignee="$GC_AGENT" --status=open --type=molecule --limit=0 --json | jq -r '.[].id')
-ASSIGNED_WISP=$(printf '%s\n' $OPEN_WISPS | sed -n '1p')
-for extra in $(printf '%s\n' $OPEN_WISPS | sed '1d'); do
-  gc bd mol burn "$extra" --force
-done
-if [ -n "$CURRENT_WISP" ] && [ -z "$ASSIGNED_WISP" ]; then
-  NEXT=$(gc bd mol wisp mol-witness-patrol --root-only --var binding_prefix='{{ .BindingPrefix }}' --json | jq -r '.new_epic_id // empty')
-  if [ -z "$NEXT" ]; then
-    echo "Could not pour next witness wisp; not burning."
-    exit 1
-  fi
-  if ! gc bd update "$NEXT" --assignee="$GC_AGENT"; then
-    echo "Could not assign next witness wisp; not burning."
-    exit 1
-  fi
-  gc bd mol burn "$CURRENT_WISP" --force
-elif [ -n "$CURRENT_WISP" ]; then
-  gc bd mol burn "$CURRENT_WISP" --force
-elif [ -z "$ASSIGNED_WISP" ]; then
-  NEXT=$(gc bd mol wisp mol-witness-patrol --root-only --var binding_prefix='{{ .BindingPrefix }}' --json | jq -r '.new_epic_id // empty')
-  if [ -z "$NEXT" ]; then
-    echo "Could not bootstrap next witness wisp."
-    exit 1
-  fi
-  if ! gc bd update "$NEXT" --assignee="$GC_AGENT"; then
-    echo "Could not assign bootstrap witness wisp."
-    exit 1
-  fi
-fi
+# Read and execute the `next-iteration` step's complete reconciliation block.
+# It reuses one queued ephemeral root and safely handles surplus before burning.
+gc bd formula show mol-witness-patrol
 gc hook
 ```
 

--- a/gastown/formulas/mol-deacon-patrol.toml
+++ b/gastown/formulas/mol-deacon-patrol.toml
@@ -5,14 +5,14 @@ Deacon patrol loop. Poured as a root-only wisp on startup:
   gc bd update $WISP --assignee=$GC_AGENT
 
 Each wisp is ONE iteration: check inbox, run town-wide coordination
-tasks, pour the next iteration. On crash, re-read the formula steps
+tasks, prepare the next iteration. On crash, re-read the formula steps
 and determine where you left off from context.
 
 Formula steps are NOT materialized as child beads. Read the step
 descriptions below and work through them in order.
 
-The loop mechanism: every exit path (happy or early) pours the next
-wisp before burning this one. The prompt only bootstraps the first wisp.
+The loop mechanism: every exit path (happy or early) prepares one successor
+before burning this wisp. The prompt only bootstraps the first wisp.
 
 ## Deacon Role
 
@@ -495,12 +495,12 @@ Close this step after check."""
 
 [[steps]]
 id = "next-iteration"
-title = "Pour next iteration and loop"
+title = "Prepare next iteration and loop"
 needs = ["system-health"]
 description = """
 **Config: event_timeout = {{event_timeout}}**
 
-End of patrol cycle. Pour the next iteration, then wait or exit.
+End of patrol cycle. Reuse or pour the next iteration, then wait or exit.
 
 **1. Context check:**
 
@@ -517,40 +517,131 @@ gc mail inbox
 ```
 Handle any urgent messages that arrived during patrol. Archive the rest.
 
-**3. Resolve current wisp and pour next iteration BEFORE burning:**
-```bash
-CURRENT_WISP=${GC_BEAD_ID:-}
-if [ -z "$CURRENT_WISP" ]; then
-  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
-fi
+**3. Reconcile current/queued roots, then pour only if needed:**
 
-NEXT=$(gc bd mol wisp mol-deacon-patrol --root-only --var binding_prefix='{{binding_prefix}}' --json | jq -r '.new_epic_id // empty')
-if [ -z "$NEXT" ]; then
-  echo "Could not pour next deacon wisp; not burning."
-  gc runtime drain-ack
+Ephemeral patrol roots are invisible to `gc bd list`. Query both open and
+in-progress ephemeral rows, filter the exact formula title and either the
+canonical assignee or an unassigned open root, keep the active/current root
+plus at most one queued successor, and re-read every surplus before cleanup.
+An unassigned open match closes the crash window after pour commits but before
+assignment. Never burn surplus in-progress or materialized work.
+```bash
+PATROL_FORMULA=mol-deacon-patrol
+if [ -z "${GC_AGENT:-}" ]; then
+  echo "GC_AGENT is empty; refusing patrol-root reconciliation."
   exit 1
 fi
-if ! gc bd update "$NEXT" --assignee="$GC_AGENT"; then
-  echo "Could not assign next deacon wisp; not burning."
-  gc runtime drain-ack
+if ! PATROL_QUERY=$(gc bd ${GC_RIG:+--rig="$GC_RIG"} query --json \
+  'ephemeral=true AND (status=open OR status=in_progress)' --limit=0); then
+  echo "Could not query deacon patrol roots; not pouring or burning."
+  exit 1
+fi
+PATROL_ROOTS=$(printf '%s\n' "$PATROL_QUERY" | jq -c \
+  --arg agent "$GC_AGENT" --arg formula "$PATROL_FORMULA" '
+  [.[] | select(.ephemeral == true)
+    | select((.issue_type // .type // "") == "molecule")
+    | select((.title // "") == $formula)
+    | select((.assignee // "") == $agent
+        or ((.assignee // "") == "" and .status == "open"))]
+  | sort_by([
+      (if .status == "in_progress" then 0 else 1 end),
+      (if (.assignee // "") == $agent then 0 else 1 end),
+      (.created_at // ""), (.id // "")
+    ])') || { echo "Could not parse deacon patrol roots."; exit 1; }
+CURRENT_WISP=$(printf '%s\n' "$PATROL_ROOTS" | jq -r --arg current "${GC_BEAD_ID:-}" '
+  ([.[] | select($current != "" and .id == $current)][0].id //
+   [.[] | select(.status == "in_progress")][0].id // empty)')
+NEXT=$(printf '%s\n' "$PATROL_ROOTS" | jq -r --arg current "$CURRENT_WISP" '
+  [.[] | select(.status == "open" and .id != $current)][0].id // empty')
+for extra in $(printf '%s\n' "$PATROL_ROOTS" | jq -r \
+  --arg current "$CURRENT_WISP" --arg next "$NEXT" \
+  '.[] | select(.id != $current and .id != $next) | .id'); do
+  EXTRA_STATE=$(gc bd ${GC_RIG:+--rig="$GC_RIG"} show "$extra" --json 2>/dev/null || printf '[]')
+  if printf '%s\n' "$EXTRA_STATE" | jq -e --arg id "$extra" --arg agent "$GC_AGENT" \
+    --arg formula "$PATROL_FORMULA" '
+      (.[0] // {}) as $w
+      | $w.id == $id and $w.ephemeral == true
+        and ($w.issue_type // $w.type // "") == "molecule"
+        and ($w.title // "") == $formula
+        and (($w.assignee // "") == $agent or ($w.assignee // "") == "")
+        and $w.status == "open"
+        and ($w.dependency_count // -1) == 0
+        and ($w.dependent_count // -1) == 0' >/dev/null; then
+    gc bd ${GC_RIG:+--rig="$GC_RIG"} mol burn "$extra" --force ||
+      { echo "Could not burn empty surplus patrol root $extra."; exit 1; }
+  else
+    echo "Preserving non-empty or active surplus patrol root $extra for inspection."
+  fi
+done
+if [ -z "$NEXT" ]; then
+  NEXT=$(gc bd mol wisp mol-deacon-patrol --root-only --var binding_prefix='{{binding_prefix}}' --json | jq -r '.new_epic_id // empty')
+  if [ -z "$NEXT" ]; then
+    echo "Could not create next deacon wisp; not burning."
+    exit 1
+  fi
+fi
+NEXT_STATE=$(gc bd ${GC_RIG:+--rig="$GC_RIG"} show "$NEXT" --json 2>/dev/null || printf '[]')
+if ! printf '%s\n' "$NEXT_STATE" | jq -e --arg id "$NEXT" --arg agent "$GC_AGENT" \
+  --arg formula "$PATROL_FORMULA" '
+    (.[0] // {}) as $w
+    | $w.id == $id and $w.ephemeral == true
+      and ($w.issue_type // $w.type // "") == "molecule"
+      and ($w.title // "") == $formula
+      and (($w.assignee // "") == $agent or ($w.assignee // "") == "")
+      and $w.status == "open"' >/dev/null; then
+  echo "Queued deacon successor changed during reconciliation; not burning."
   exit 1
 fi
 ```
 
 **4. Burn this wisp before waiting:**
 ```bash
-if [ -n "$CURRENT_WISP" ]; then
-  gc bd mol burn "$CURRENT_WISP" --force
-else
-  echo "Could not resolve current deacon wisp; not burning."
-  gc runtime drain-ack
+if [ -z "$CURRENT_WISP" ]; then
+  echo "Could not resolve current deacon wisp; preserving queued $NEXT."
+  exit 1
+fi
+CURRENT_STATE=$(gc bd ${GC_RIG:+--rig="$GC_RIG"} show "$CURRENT_WISP" --json 2>/dev/null || printf '[]')
+if ! printf '%s\n' "$CURRENT_STATE" | jq -e --arg id "$CURRENT_WISP" --arg agent "$GC_AGENT" \
+  --arg formula "$PATROL_FORMULA" '
+    (.[0] // {}) as $w
+    | $w.id == $id and $w.ephemeral == true
+      and ($w.issue_type // $w.type // "") == "molecule"
+      and ($w.assignee // "") == $agent and ($w.title // "") == $formula
+      and $w.status == "in_progress"
+      and ($w.dependency_count // -1) == 0
+      and ($w.dependent_count // -1) == 0' >/dev/null; then
+  echo "Current deacon root changed during reconciliation; not burning."
+  exit 1
+fi
+if ! gc bd ${GC_RIG:+--rig="$GC_RIG"} update "$NEXT" --assignee="$GC_AGENT"; then
+  echo "Could not assign deacon successor $NEXT; not burning."
+  exit 1
+fi
+NEXT_STATE=$(gc bd ${GC_RIG:+--rig="$GC_RIG"} show "$NEXT" --json 2>/dev/null || printf '[]')
+if ! printf '%s\n' "$NEXT_STATE" | jq -e --arg id "$NEXT" --arg agent "$GC_AGENT" \
+  --arg formula "$PATROL_FORMULA" '
+    (.[0] // {}) as $w
+    | $w.id == $id and $w.ephemeral == true
+      and ($w.issue_type // $w.type // "") == "molecule"
+      and ($w.assignee // "") == $agent and ($w.title // "") == $formula
+      and $w.status == "open"' >/dev/null; then
+  echo "Could not confirm assigned deacon successor $NEXT; not burning."
+  exit 1
+fi
+if ! gc bd mol burn "$CURRENT_WISP" --force; then
+  echo "Could not burn current deacon wisp; successor remains queued."
+  exit 1
+fi
+if ! gc bd ${GC_RIG:+--rig="$GC_RIG"} update "$NEXT" \
+  --status=in_progress --assignee="$GC_AGENT"; then
+  echo "Could not mark deacon successor $NEXT current; it remains recoverable."
   exit 1
 fi
 ```
 
 Do not sleep with the current wisp still open. The backoff belongs to the
 already-assigned successor wisp; if the session restarts during the sleep, the
-successor remains the single resumable patrol item.
+successor is promoted to the single durable current patrol item.
 
 **5. Exit this turn:**
 Write exactly:

--- a/gastown/formulas/mol-refinery-patrol.toml
+++ b/gastown/formulas/mol-refinery-patrol.toml
@@ -11,8 +11,8 @@ where you left off from context (git state, bead state, last action).
 Formula steps are NOT materialized as child beads. Read the step
 descriptions below and work through them in order.
 
-The loop mechanism: every exit path (happy or early) pours the next
-wisp before burning this one. The prompt only bootstraps the first wisp.
+The loop mechanism: every exit path (happy or early) prepares one successor
+before burning this wisp. The prompt only bootstraps the first wisp.
 
 Work beads flow directly: pool → polecat → refinery → closed.
 No separate MR beads. The polecat sets metadata (branch, target) on
@@ -114,31 +114,13 @@ description = """
 **1. Context check (FIRST — before any work):**
 
 If context feels heavy (multi-hour session, large recent diffs, or you notice
-yourself taking shortcuts or summarizing prematurely), pour and assign the next
-wisp, burn the current wisp, then request a restart:
+yourself taking shortcuts or summarizing prematurely), run the complete
+ephemeral-root reconciliation and handoff in `next-iteration` sections 2-3.
+That block reuses an already queued root and preserves unsafe surplus. Only
+after it successfully assigns a successor and burns the current root, request
+a restart:
 ```bash
-CURRENT_WISP=${GC_BEAD_ID:-}
-if [ -z "$CURRENT_WISP" ]; then
-  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
-fi
-NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{target_branch}} --var rig_name={{rig_name}} --var binding_prefix={{binding_prefix}} --json | jq -r '.new_epic_id // empty')
-if [ -z "$NEXT" ]; then
-  echo "Could not pour next refinery wisp; not requesting restart."
-  gc runtime drain-ack
-  exit 1
-fi
-if ! gc bd update "$NEXT" --assignee="$GC_AGENT"; then
-  echo "Could not assign next refinery wisp; not requesting restart."
-  gc runtime drain-ack
-  exit 1
-fi
-if [ -n "$CURRENT_WISP" ]; then
-  gc bd mol burn "$CURRENT_WISP" --force
-else
-  echo "Could not resolve current wisp; not requesting restart."
-  gc runtime drain-ack
-  exit 1
-fi
+# First execute next-iteration sections 2-3 exactly; stop if they fail.
 gc runtime request-restart
 RESTART_STATUS=$?
 echo "Restart request returned with status $RESTART_STATUS; stop this session now."
@@ -238,31 +220,11 @@ gc bd update $WORK \
 ```
 4. Do NOT delete the branch (new polecat needs it for conflict resolution).
 5. Clean up temp branch: `git checkout {{target_branch}} && git branch -D temp`
-6. Pour next patrol iteration before burning:
-```bash
-CURRENT_WISP=${GC_BEAD_ID:-}
-if [ -z "$CURRENT_WISP" ]; then
-  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
-fi
-NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{target_branch}} --var rig_name={{rig_name}} --var binding_prefix={{binding_prefix}} --json | jq -r '.new_epic_id // empty')
-if [ -z "$NEXT" ]; then
-  echo "Could not pour next refinery wisp; not burning."
-  gc runtime drain-ack
-  exit 1
-fi
-if ! gc bd update "$NEXT" --assignee="$GC_AGENT"; then
-  echo "Could not assign next refinery wisp; not burning."
-  gc runtime drain-ack
-  exit 1
-fi
-if [ -n "$CURRENT_WISP" ]; then
-  gc bd mol burn "$CURRENT_WISP" --force
-else
-  echo "Could not resolve current wisp; not burning."
-  gc runtime drain-ack
-  exit 1
-fi
-```
+6. Run the complete ephemeral-root reconciliation and handoff from
+   `next-iteration` sections 2-3. Do not use a standalone pour here: a prior
+   restart may already have left an open successor. The canonical block reuses
+   that successor, cleans only revalidated empty/open surplus, and then burns
+   the resolved current root.
 7. Close this step after the current wisp is burned.
 
 **A new polecat will pick up the bead, see the branch and rejection,
@@ -339,31 +301,9 @@ TARGET=$(gc bd show $WORK --json | jq -r '.[0].metadata.target // "{{target_bran
      ```
    - Delete branch: `git push origin --delete $BRANCH`
    - Clean up: `git checkout "$TARGET" && git branch -D temp`
-   - Pour next patrol iteration before burning:
-     ```bash
-     CURRENT_WISP=${GC_BEAD_ID:-}
-     if [ -z "$CURRENT_WISP" ]; then
-       CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
-     fi
-     NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{target_branch}} --var rig_name={{rig_name}} --var binding_prefix={{binding_prefix}} --json | jq -r '.new_epic_id // empty')
-     if [ -z "$NEXT" ]; then
-       echo "Could not pour next refinery wisp; not burning."
-       gc runtime drain-ack
-       exit 1
-     fi
-     if ! gc bd update "$NEXT" --assignee="$GC_AGENT"; then
-       echo "Could not assign next refinery wisp; not burning."
-       gc runtime drain-ack
-       exit 1
-     fi
-     if [ -n "$CURRENT_WISP" ]; then
-       gc bd mol burn "$CURRENT_WISP" --force
-     else
-       echo "Could not resolve current wisp; not burning."
-       gc runtime drain-ack
-       exit 1
-     fi
-     ```
+   - Run the complete ephemeral-root reconciliation and handoff from
+     `next-iteration` sections 2-3. Reuse a queued successor if one already
+     exists; never issue a standalone pour from this failure path.
    - Close this step after the current wisp is burned.
 
 3. If pre-existing on target:
@@ -433,39 +373,10 @@ Work bead: $WORK
 Existing PR: $EXISTING_PR
 Branch: $BRANCH
 Target: $TARGET"
-  CURRENT_WISP=${GC_BEAD_ID:-}
-  if [ -z "$CURRENT_WISP" ]; then
-    CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
-  fi
-  if [ -z "$CURRENT_WISP" ]; then
-    echo "Could not resolve current wisp; not burning."
-    echo "$reason"
-    echo "STOP. Existing PR metadata needs human correction."
-    gc runtime drain-ack
-    exit 1
-  fi
-  NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{target_branch}} --var rig_name={{rig_name}} --var binding_prefix={{binding_prefix}} --json | jq -r '.new_epic_id // empty')
-  if [ -z "$NEXT" ]; then
-    echo "Could not pour next refinery wisp; not burning."
-    gc runtime drain-ack
-    exit 1
-  fi
-  if ! gc bd update "$NEXT" --assignee="$GC_AGENT"; then
-    echo "Could not assign next refinery wisp; not burning."
-    gc runtime drain-ack
-    exit 1
-  fi
-  if [ -n "$CURRENT_WISP" ]; then
-    gc bd mol burn "$CURRENT_WISP" --force
-  else
-    echo "Could not resolve current wisp; not burning."
-    echo "$reason"
-    echo "STOP. Existing PR metadata needs human correction."
-    gc runtime drain-ack
-    exit 1
-  fi
   echo "$reason"
   echo "STOP. Existing PR metadata needs human correction."
+  echo "Preserving the current patrol root; do not pour from this blocked path."
+  echo "On the next turn, use the canonical next-iteration reconciliation."
   gc runtime drain-ack
   exit 1
 }
@@ -684,7 +595,7 @@ shell state — an early `exit` in the already-merged branch below then provably
 prevents the false-completion guard in this same script from running on a
 closed bead. That `exit` does NOT drain: an already-merged close is a real
 completion, so it skips the merge script and joins the normal path's
-Cleanup -> patrol-summary -> next-iteration tail (pour next wisp, burn this
+Cleanup -> patrol-summary -> next-iteration tail (prepare next wisp, burn this
 one), exactly like a normal merge. Only genuine errors drain-ack.
 
 - **Already merged (close, do NOT halt):** a previous refinery pass merged this
@@ -759,7 +670,7 @@ esac
 If this block closed the bead as already-merged, the merge is already done:
 SKIP the merge script (step 1 below) and go straight to **2. Cleanup**, then
 let this step complete so **patrol-summary** and **next-iteration** run (they
-pour the next wisp and burn this one) — the same tail a normal merge takes. Do
+prepare the next wisp and burn this one) — the same tail a normal merge takes. Do
 NOT drain-ack here; that would strand the loop and leak the merged branch.
 Otherwise the branch has a verified real change and you continue to the merge.
 
@@ -1139,28 +1050,120 @@ The convoy bead assignment is the ONLY path.
 
 If auto_land = "false": skip this entirely.
 
-**2. Resolve the current wisp, pour next iteration, then burn this wisp:**
+**2. Reconcile current/queued roots, then pour only if needed:**
+
+Ephemeral patrol roots are invisible to `gc bd list`. Query both open and
+in-progress ephemeral rows, filter the exact formula title and either the
+canonical assignee or an unassigned open root, keep the active/current root
+plus at most one queued successor, and re-read every surplus before cleanup.
+An unassigned open match closes the crash window after pour commits but before
+assignment. Never burn surplus in-progress or materialized work.
 ```bash
-CURRENT_WISP=${GC_BEAD_ID:-}
-if [ -z "$CURRENT_WISP" ]; then
-  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
+PATROL_FORMULA=mol-refinery-patrol
+if [ -z "${GC_AGENT:-}" ]; then
+  echo "GC_AGENT is empty; refusing patrol-root reconciliation."
+  exit 1
 fi
-NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{target_branch}} --var rig_name={{rig_name}} --var binding_prefix={{binding_prefix}} --json | jq -r '.new_epic_id // empty')
+if ! PATROL_QUERY=$(gc bd ${GC_RIG:+--rig="$GC_RIG"} query --json \
+  'ephemeral=true AND (status=open OR status=in_progress)' --limit=0); then
+  echo "Could not query refinery patrol roots; not pouring or burning."
+  exit 1
+fi
+PATROL_ROOTS=$(printf '%s\n' "$PATROL_QUERY" | jq -c \
+  --arg agent "$GC_AGENT" --arg formula "$PATROL_FORMULA" '
+  [.[] | select(.ephemeral == true)
+    | select((.issue_type // .type // "") == "molecule")
+    | select((.title // "") == $formula)
+    | select((.assignee // "") == $agent
+        or ((.assignee // "") == "" and .status == "open"))]
+  | sort_by([
+      (if .status == "in_progress" then 0 else 1 end),
+      (if (.assignee // "") == $agent then 0 else 1 end),
+      (.created_at // ""), (.id // "")
+    ])') || { echo "Could not parse refinery patrol roots."; exit 1; }
+CURRENT_WISP=$(printf '%s\n' "$PATROL_ROOTS" | jq -r --arg current "${GC_BEAD_ID:-}" '
+  ([.[] | select($current != "" and .id == $current)][0].id //
+   [.[] | select(.status == "in_progress")][0].id // empty)')
+NEXT=$(printf '%s\n' "$PATROL_ROOTS" | jq -r --arg current "$CURRENT_WISP" '
+  [.[] | select(.status == "open" and .id != $current)][0].id // empty')
+for extra in $(printf '%s\n' "$PATROL_ROOTS" | jq -r \
+  --arg current "$CURRENT_WISP" --arg next "$NEXT" \
+  '.[] | select(.id != $current and .id != $next) | .id'); do
+  EXTRA_STATE=$(gc bd ${GC_RIG:+--rig="$GC_RIG"} show "$extra" --json 2>/dev/null || printf '[]')
+  if printf '%s\n' "$EXTRA_STATE" | jq -e --arg id "$extra" --arg agent "$GC_AGENT" \
+    --arg formula "$PATROL_FORMULA" '
+      (.[0] // {}) as $w
+      | $w.id == $id and $w.ephemeral == true
+        and ($w.issue_type // $w.type // "") == "molecule"
+        and ($w.title // "") == $formula
+        and (($w.assignee // "") == $agent or ($w.assignee // "") == "")
+        and $w.status == "open"
+        and ($w.dependency_count // -1) == 0
+        and ($w.dependent_count // -1) == 0' >/dev/null; then
+    gc bd ${GC_RIG:+--rig="$GC_RIG"} mol burn "$extra" --force ||
+      { echo "Could not burn empty surplus patrol root $extra."; exit 1; }
+  else
+    echo "Preserving non-empty or active surplus patrol root $extra for inspection."
+  fi
+done
 if [ -z "$NEXT" ]; then
-  echo "Could not pour next refinery wisp; not burning."
-  gc runtime drain-ack
+  NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{target_branch}} --var rig_name={{rig_name}} --var binding_prefix={{binding_prefix}} --json | jq -r '.new_epic_id // empty')
+  if [ -z "$NEXT" ]; then
+    echo "Could not create next refinery wisp; not burning."
+    exit 1
+  fi
+fi
+NEXT_STATE=$(gc bd ${GC_RIG:+--rig="$GC_RIG"} show "$NEXT" --json 2>/dev/null || printf '[]')
+if ! printf '%s\n' "$NEXT_STATE" | jq -e --arg id "$NEXT" --arg agent "$GC_AGENT" \
+  --arg formula "$PATROL_FORMULA" '
+    (.[0] // {}) as $w
+    | $w.id == $id and $w.ephemeral == true
+      and ($w.issue_type // $w.type // "") == "molecule"
+      and ($w.title // "") == $formula
+      and (($w.assignee // "") == $agent or ($w.assignee // "") == "")
+      and $w.status == "open"' >/dev/null; then
+  echo "Queued refinery successor changed during reconciliation; not burning."
   exit 1
 fi
-if ! gc bd update "$NEXT" --assignee="$GC_AGENT"; then
-  echo "Could not assign next refinery wisp; not burning."
-  gc runtime drain-ack
+if [ -z "$CURRENT_WISP" ]; then
+  echo "Could not resolve current refinery wisp; preserving queued $NEXT."
   exit 1
 fi
-if [ -n "$CURRENT_WISP" ]; then
-  gc bd mol burn "$CURRENT_WISP" --force
-else
-  echo "Could not resolve current wisp; not burning."
-  gc runtime drain-ack
+CURRENT_STATE=$(gc bd ${GC_RIG:+--rig="$GC_RIG"} show "$CURRENT_WISP" --json 2>/dev/null || printf '[]')
+if ! printf '%s\n' "$CURRENT_STATE" | jq -e --arg id "$CURRENT_WISP" --arg agent "$GC_AGENT" \
+  --arg formula "$PATROL_FORMULA" '
+    (.[0] // {}) as $w
+    | $w.id == $id and $w.ephemeral == true
+      and ($w.issue_type // $w.type // "") == "molecule"
+      and ($w.assignee // "") == $agent and ($w.title // "") == $formula
+      and $w.status == "in_progress"
+      and ($w.dependency_count // -1) == 0
+      and ($w.dependent_count // -1) == 0' >/dev/null; then
+  echo "Current refinery root changed during reconciliation; not burning."
+  exit 1
+fi
+if ! gc bd ${GC_RIG:+--rig="$GC_RIG"} update "$NEXT" --assignee="$GC_AGENT"; then
+  echo "Could not assign refinery successor $NEXT; not burning."
+  exit 1
+fi
+NEXT_STATE=$(gc bd ${GC_RIG:+--rig="$GC_RIG"} show "$NEXT" --json 2>/dev/null || printf '[]')
+if ! printf '%s\n' "$NEXT_STATE" | jq -e --arg id "$NEXT" --arg agent "$GC_AGENT" \
+  --arg formula "$PATROL_FORMULA" '
+    (.[0] // {}) as $w
+    | $w.id == $id and $w.ephemeral == true
+      and ($w.issue_type // $w.type // "") == "molecule"
+      and ($w.assignee // "") == $agent and ($w.title // "") == $formula
+      and $w.status == "open"' >/dev/null; then
+  echo "Could not confirm assigned refinery successor $NEXT; not burning."
+  exit 1
+fi
+if ! gc bd mol burn "$CURRENT_WISP" --force; then
+  echo "Could not burn current refinery wisp; successor remains queued."
+  exit 1
+fi
+if ! gc bd ${GC_RIG:+--rig="$GC_RIG"} update "$NEXT" \
+  --status=in_progress --assignee="$GC_AGENT"; then
+  echo "Could not mark refinery successor $NEXT current; it remains recoverable."
   exit 1
 fi
 ```

--- a/gastown/formulas/mol-witness-patrol.toml
+++ b/gastown/formulas/mol-witness-patrol.toml
@@ -4,7 +4,7 @@ Witness patrol loop. Poured as a root-only wisp on startup:
   gc bd mol wisp mol-witness-patrol --root-only --var binding_prefix='{{binding_prefix}}'
   gc bd update $WISP --assignee=$GC_AGENT
 
-Each wisp is ONE iteration: check for work, patrol, pour the next
+Each wisp is ONE iteration: check for work, patrol, prepare the next
 iteration. On crash, re-read the formula steps and determine where
 you left off from context (bead state, mail state, last action).
 
@@ -503,16 +503,16 @@ polecats, systemic issue).
 **Exit criteria:** All active polecat work beads assessed. Warrants
 filed for stuck agents. Or no stuck polecats found. Continue to
 `next-iteration` — do NOT exit the wisp here. The `next-iteration` step
-is the only place that pours the next wisp and burns this one."""
+is the only place that prepares the next wisp and burns this one."""
 
 [[steps]]
 id = "next-iteration"
-title = "Pour next iteration and loop"
+title = "Prepare next iteration and loop"
 needs = ["check-polecat-health"]
 description = """
 **Config: event_timeout = {{event_timeout}}**
 
-End of patrol cycle. Pour the next iteration, then wait or exit.
+End of patrol cycle. Reuse or pour the next iteration, then wait or exit.
 
 **1. Context check:**
 
@@ -523,28 +523,126 @@ gc runtime request-restart
 This blocks forever. The controller restarts you. The next wisp
 is already assigned — the new session resumes from context.
 
-**2. Pour next iteration BEFORE burning (reconcile to exactly one):**
+**2. Reconcile current/queued roots, then pour only if needed:**
 
-Reuse an already-queued wisp instead of pouring a duplicate. A prior cycle
-may have poured a next wisp without burning, or a restart may have raced —
-keep one open patrol wisp and burn any surplus, so wisps never accumulate.
-Wisp roots are `issue_type=molecule` (never `--type=wisp`, which is not a
-valid gc bd type and matches nothing).
+Ephemeral patrol roots are invisible to `gc bd list`. Query both open and
+in-progress ephemeral rows, filter the exact formula title and either the
+canonical assignee or an unassigned open root, keep the active/current root
+plus at most one queued successor, and re-read every surplus before cleanup.
+An unassigned open match closes the crash window after pour commits but before
+assignment. Never burn surplus in-progress or materialized work.
 ```bash
-OPEN_WISPS=$(gc bd list --assignee="$GC_AGENT" --status=open --type=molecule --limit=0 --json | jq -r '.[].id')
-NEXT=$(printf '%s\n' $OPEN_WISPS | sed -n '1p')
-for extra in $(printf '%s\n' $OPEN_WISPS | sed '1d'); do
-  gc bd mol burn "$extra" --force
+PATROL_FORMULA=mol-witness-patrol
+if [ -z "${GC_AGENT:-}" ]; then
+  echo "GC_AGENT is empty; refusing patrol-root reconciliation."
+  exit 1
+fi
+if ! PATROL_QUERY=$(gc bd ${GC_RIG:+--rig="$GC_RIG"} query --json \
+  'ephemeral=true AND (status=open OR status=in_progress)' --limit=0); then
+  echo "Could not query witness patrol roots; not pouring or burning."
+  exit 1
+fi
+PATROL_ROOTS=$(printf '%s\n' "$PATROL_QUERY" | jq -c \
+  --arg agent "$GC_AGENT" --arg formula "$PATROL_FORMULA" '
+  [.[] | select(.ephemeral == true)
+    | select((.issue_type // .type // "") == "molecule")
+    | select((.title // "") == $formula)
+    | select((.assignee // "") == $agent
+        or ((.assignee // "") == "" and .status == "open"))]
+  | sort_by([
+      (if .status == "in_progress" then 0 else 1 end),
+      (if (.assignee // "") == $agent then 0 else 1 end),
+      (.created_at // ""), (.id // "")
+    ])') || { echo "Could not parse witness patrol roots."; exit 1; }
+CURRENT_WISP=$(printf '%s\n' "$PATROL_ROOTS" | jq -r --arg current "${GC_BEAD_ID:-}" '
+  ([.[] | select($current != "" and .id == $current)][0].id //
+   [.[] | select(.status == "in_progress")][0].id // empty)')
+NEXT=$(printf '%s\n' "$PATROL_ROOTS" | jq -r --arg current "$CURRENT_WISP" '
+  [.[] | select(.status == "open" and .id != $current)][0].id // empty')
+for extra in $(printf '%s\n' "$PATROL_ROOTS" | jq -r \
+  --arg current "$CURRENT_WISP" --arg next "$NEXT" \
+  '.[] | select(.id != $current and .id != $next) | .id'); do
+  EXTRA_STATE=$(gc bd ${GC_RIG:+--rig="$GC_RIG"} show "$extra" --json 2>/dev/null || printf '[]')
+  if printf '%s\n' "$EXTRA_STATE" | jq -e --arg id "$extra" --arg agent "$GC_AGENT" \
+    --arg formula "$PATROL_FORMULA" '
+      (.[0] // {}) as $w
+      | $w.id == $id and $w.ephemeral == true
+        and ($w.issue_type // $w.type // "") == "molecule"
+        and ($w.title // "") == $formula
+        and (($w.assignee // "") == $agent or ($w.assignee // "") == "")
+        and $w.status == "open"
+        and ($w.dependency_count // -1) == 0
+        and ($w.dependent_count // -1) == 0' >/dev/null; then
+    gc bd ${GC_RIG:+--rig="$GC_RIG"} mol burn "$extra" --force ||
+      { echo "Could not burn empty surplus patrol root $extra."; exit 1; }
+  else
+    echo "Preserving non-empty or active surplus patrol root $extra for inspection."
+  fi
 done
 if [ -z "$NEXT" ]; then
-  NEXT=$(gc bd mol wisp mol-witness-patrol --root-only --var binding_prefix='{{binding_prefix}}' --json | jq -r '.new_epic_id')
-  gc bd update "$NEXT" --assignee="$GC_AGENT"
+  NEXT=$(gc bd mol wisp mol-witness-patrol --root-only --var binding_prefix='{{binding_prefix}}' --json | jq -r '.new_epic_id // empty')
+  if [ -z "$NEXT" ]; then
+    echo "Could not create next witness wisp; not burning."
+    exit 1
+  fi
+fi
+NEXT_STATE=$(gc bd ${GC_RIG:+--rig="$GC_RIG"} show "$NEXT" --json 2>/dev/null || printf '[]')
+if ! printf '%s\n' "$NEXT_STATE" | jq -e --arg id "$NEXT" --arg agent "$GC_AGENT" \
+  --arg formula "$PATROL_FORMULA" '
+    (.[0] // {}) as $w
+    | $w.id == $id and $w.ephemeral == true
+      and ($w.issue_type // $w.type // "") == "molecule"
+      and ($w.title // "") == $formula
+      and (($w.assignee // "") == $agent or ($w.assignee // "") == "")
+      and $w.status == "open"' >/dev/null; then
+  echo "Queued witness successor changed during reconciliation; not burning."
+  exit 1
 fi
 ```
 
 **3. Burn this wisp:**
 ```bash
-gc bd mol burn <this-wisp-id> --force
+if [ -z "$CURRENT_WISP" ]; then
+  echo "Could not resolve current witness wisp; preserving queued $NEXT."
+  exit 1
+fi
+CURRENT_STATE=$(gc bd ${GC_RIG:+--rig="$GC_RIG"} show "$CURRENT_WISP" --json 2>/dev/null || printf '[]')
+if ! printf '%s\n' "$CURRENT_STATE" | jq -e --arg id "$CURRENT_WISP" --arg agent "$GC_AGENT" \
+  --arg formula "$PATROL_FORMULA" '
+    (.[0] // {}) as $w
+    | $w.id == $id and $w.ephemeral == true
+      and ($w.issue_type // $w.type // "") == "molecule"
+      and ($w.assignee // "") == $agent and ($w.title // "") == $formula
+      and $w.status == "in_progress"
+      and ($w.dependency_count // -1) == 0
+      and ($w.dependent_count // -1) == 0' >/dev/null; then
+  echo "Current witness root changed during reconciliation; not burning."
+  exit 1
+fi
+if ! gc bd ${GC_RIG:+--rig="$GC_RIG"} update "$NEXT" --assignee="$GC_AGENT"; then
+  echo "Could not assign witness successor $NEXT; not burning."
+  exit 1
+fi
+NEXT_STATE=$(gc bd ${GC_RIG:+--rig="$GC_RIG"} show "$NEXT" --json 2>/dev/null || printf '[]')
+if ! printf '%s\n' "$NEXT_STATE" | jq -e --arg id "$NEXT" --arg agent "$GC_AGENT" \
+  --arg formula "$PATROL_FORMULA" '
+    (.[0] // {}) as $w
+    | $w.id == $id and $w.ephemeral == true
+      and ($w.issue_type // $w.type // "") == "molecule"
+      and ($w.assignee // "") == $agent and ($w.title // "") == $formula
+      and $w.status == "open"' >/dev/null; then
+  echo "Could not confirm assigned witness successor $NEXT; not burning."
+  exit 1
+fi
+if ! gc bd mol burn "$CURRENT_WISP" --force; then
+  echo "Could not burn current witness wisp; successor remains queued."
+  exit 1
+fi
+if ! gc bd ${GC_RIG:+--rig="$GC_RIG"} update "$NEXT" \
+  --status=in_progress --assignee="$GC_AGENT"; then
+  echo "Could not mark witness successor $NEXT current; it remains recoverable."
+  exit 1
+fi
 ```
 
 **4. Exit this turn:**

--- a/gastown/template-fragments/patrol-wisp.template.md
+++ b/gastown/template-fragments/patrol-wisp.template.md
@@ -1,0 +1,109 @@
+{{ define "patrol-wisp-ledger" }}
+## Patrol Wisp Ledger Contract
+
+Patrol roots are ephemeral molecule rows. `gc bd list` reads the durable tier
+and can return `[]` even while an assigned patrol root exists. Always discover
+patrol roots with:
+
+```bash
+gc bd ${GC_RIG:+--rig="$GC_RIG"} query --json \
+  'ephemeral=true AND (status=open OR status=in_progress)' --limit=0
+```
+
+Then filter the JSON to the exact patrol formula title and either the canonical
+`$GC_AGENT` assignee or an unassigned `open` root. The latter is the recoverable
+crash window after `mol wisp` commits but before the following assignment.
+Prefer `$GC_BEAD_ID`, then an assigned `in_progress` root, then an assigned
+`open` root, then the oldest unassigned `open` root (with ID as the final
+tie-breaker). Reuse that root instead of pouring a duplicate. Before doing
+patrol work, revalidate the survivor and promote it to `in_progress` with the
+canonical assignee. At handoff, promote the successor after burning the prior
+current root. These durable markers are required because persistent providers
+can re-read the formula with an empty `$GC_BEAD_ID`.
+
+Cleanup is deliberately conservative. Before burning a surplus root, re-read
+it and verify all of these are still true: it is `open`, ephemeral, a molecule,
+has the exact patrol title, is assigned to `$GC_AGENT` or still unassigned, and
+both dependency counts are zero. Never burn a surplus `in_progress` or materialized root.
+Preserve it and report the conflict instead.
+{{ end }}
+
+{{ define "patrol-wisp-startup" }}
+# Reconcile open/in-progress roots from the ephemeral tier.
+if [ -z "${GC_AGENT:-}" ]; then
+  echo "GC_AGENT is empty; refusing patrol-root reconciliation."
+  exit 1
+fi
+if ! PATROL_QUERY=$(gc bd ${GC_RIG:+--rig="$GC_RIG"} query --json \
+  'ephemeral=true AND (status=open OR status=in_progress)' --limit=0); then
+  echo "Could not query patrol roots; refusing to pour a duplicate."
+  exit 1
+fi
+if ! PATROL_ROOTS=$(printf '%s\n' "$PATROL_QUERY" | jq -c \
+  --arg agent "$GC_AGENT" --arg formula "$PATROL_FORMULA" --arg current "${GC_BEAD_ID:-}" '
+  [.[] | select(.ephemeral == true)
+    | select((.issue_type // .type // "") == "molecule")
+    | select((.title // "") == $formula)
+    | select((.assignee // "") == $agent
+        or ((.assignee // "") == "" and .status == "open"))
+    | . + {_patrol_rank: [
+        (if $current != "" and .id == $current then 0 else 1 end),
+        (if .status == "in_progress" then 0 else 1 end),
+        (if (.assignee // "") == $agent then 0 else 1 end),
+        (.created_at // ""), (.id // "")
+      ]}]
+  | sort_by(._patrol_rank)'); then
+  echo "Could not parse patrol roots; refusing to pour a duplicate."
+  exit 1
+fi
+WISP=$(printf '%s\n' "$PATROL_ROOTS" | jq -r '.[0].id // empty')
+for extra in $(printf '%s\n' "$PATROL_ROOTS" | jq -r --arg keep "$WISP" \
+  '.[] | select(.id != $keep) | .id'); do
+  EXTRA_STATE=$(gc bd ${GC_RIG:+--rig="$GC_RIG"} show "$extra" --json 2>/dev/null || printf '[]')
+  if printf '%s\n' "$EXTRA_STATE" | jq -e --arg id "$extra" --arg agent "$GC_AGENT" \
+    --arg formula "$PATROL_FORMULA" '
+      (.[0] // {}) as $w
+      | $w.id == $id and $w.ephemeral == true
+        and ($w.issue_type // $w.type // "") == "molecule"
+        and ($w.title // "") == $formula
+        and (($w.assignee // "") == $agent or ($w.assignee // "") == "")
+        and $w.status == "open"
+        and ($w.dependency_count // -1) == 0
+        and ($w.dependent_count // -1) == 0' >/dev/null; then
+    gc bd ${GC_RIG:+--rig="$GC_RIG"} mol burn "$extra" --force ||
+      { echo "Could not burn empty surplus patrol root $extra."; exit 1; }
+  else
+    echo "Preserving non-empty or active surplus patrol root $extra for inspection."
+  fi
+done
+
+# Reuse and durably mark the survivor. Only a truly empty result may pour.
+if [ -n "$WISP" ]; then
+  WISP_STATE=$(gc bd ${GC_RIG:+--rig="$GC_RIG"} show "$WISP" --json 2>/dev/null || printf '[]')
+  if ! printf '%s\n' "$WISP_STATE" | jq -e --arg id "$WISP" --arg agent "$GC_AGENT" \
+    --arg formula "$PATROL_FORMULA" '
+      (.[0] // {}) as $w
+      | $w.id == $id and $w.ephemeral == true
+        and ($w.issue_type // $w.type // "") == "molecule"
+        and ($w.title // "") == $formula
+        and (($w.assignee // "") == $agent
+          or (($w.assignee // "") == "" and $w.status == "open"))
+        and ($w.status == "open" or $w.status == "in_progress")' >/dev/null; then
+    echo "Selected patrol root changed during reconciliation; refusing to continue."
+    exit 1
+  fi
+else
+  before_pour_patrol_root
+  WISP=$(pour_patrol_root)
+  if [ -z "$WISP" ]; then
+    echo "Could not create patrol root."
+    exit 1
+  fi
+fi
+if ! gc bd ${GC_RIG:+--rig="$GC_RIG"} update "$WISP" \
+  --status=in_progress --assignee="$GC_AGENT"; then
+  echo "Could not mark patrol root $WISP current."
+  exit 1
+fi
+echo "Resuming patrol wisp $WISP"
+{{ end }}

--- a/gastown/template-fragments/propulsion.template.md
+++ b/gastown/template-fragments/propulsion.template.md
@@ -94,9 +94,9 @@ filed. The refinery can't merge branches you haven't pushed.
 ## Your Role: The Flywheel
 
 **Your startup behavior:**
-1. Check for work (`{{ .AssignedInProgressQuery }}`)
-2. If patrol wisp assigned → EXECUTE immediately (read formula steps)
-3. If nothing assigned → Create patrol wisp and execute
+1. Reconcile assigned ephemeral patrol roots (open and in-progress)
+2. If a patrol root exists → EXECUTE immediately (read formula steps)
+3. Only if no matching root exists → Create one patrol wisp and execute
 
 You are the heartbeat. There is no decision to make. Run.
 
@@ -116,9 +116,9 @@ heartbeat stopped.
 ## Your Role: The Pressure Gauge
 
 **Your startup behavior:**
-1. Check for work (`{{ .AssignedInProgressQuery }}`)
-2. If patrol wisp assigned → EXECUTE immediately (read formula steps)
-3. If nothing assigned → Create patrol wisp and execute
+1. Reconcile assigned ephemeral patrol roots (open and in-progress)
+2. If a patrol root exists → EXECUTE immediately (read formula steps)
+3. Only if no matching root exists → Create one patrol wisp and execute
 
 You are the watchman. There is no decision to make. Patrol.
 
@@ -171,9 +171,9 @@ Work flows in as branches. Work flows out as merged commits on the target
 branch. Your throughput determines how fast the team's work becomes real.
 
 **Your startup behavior:**
-1. Check for an in-progress patrol wisp (`{{ .AssignedInProgressQuery }}`)
-2. If found → Resume where you left off (read formula steps, determine current position)
-3. If none → Pour a new wisp and assign it to yourself
+1. Reconcile assigned ephemeral patrol roots (open and in-progress)
+2. If a patrol root exists → Resume where you left off
+3. Only if no matching root exists → Pour one wisp and assign it to yourself
 
 You are a merge processor. There is no decision to make about the code.
 Follow the formula.

--- a/gastown/tests/test_patrol_wisp_reconciliation.sh
+++ b/gastown/tests/test_patrol_wisp_reconciliation.sh
@@ -1,0 +1,529 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+GASTOWN="$ROOT/gastown"
+TMP=$(mktemp -d "${TMPDIR:-/tmp}/patrol-wisp-test.XXXXXX")
+trap 'rm -rf "$TMP"' EXIT
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+role_prompt() {
+    printf '%s/agents/%s/prompt.template.md\n' "$GASTOWN" "$1"
+}
+
+role_formula() {
+    printf '%s/formulas/mol-%s-patrol.toml\n' "$GASTOWN" "$1"
+}
+
+test_assets_use_ephemeral_query_contract() {
+    local role asset handoff
+    for role in deacon witness refinery; do
+        for asset in "$(role_prompt "$role")" "$(role_formula "$role")"; do
+            ! grep -E 'gc bd list .*--type=molecule.*--status=(open|in_progress)|gc bd list .*--status=(open|in_progress).*--type=molecule' "$asset" >/dev/null ||
+                fail "$asset must not use durable-tier gc bd list for patrol roots"
+        done
+        asset=$(role_formula "$role")
+        grep -F "'ephemeral=true AND (status=open OR status=in_progress)'" "$asset" >/dev/null ||
+            fail "$asset must query both open and in-progress ephemeral patrol roots"
+        for asset in "$(role_formula "$role")" "$GASTOWN/template-fragments/patrol-wisp.template.md"; do
+            grep -F '($w.dependency_count // -1) == 0' "$asset" >/dev/null ||
+                fail "$asset must fail closed when dependency_count is absent or nonzero"
+            grep -F '($w.dependent_count // -1) == 0' "$asset" >/dev/null ||
+                fail "$asset must fail closed when dependent_count is absent or nonzero"
+        done
+        grep -F '{{ template "patrol-wisp-ledger" . }}' "$(role_prompt "$role")" >/dev/null ||
+            fail "$role prompt must include the shared patrol-wisp ledger contract"
+        handoff="$TMP/$role-static-handoff.sh"
+        extract_formula_handoff "$role" "$handoff"
+        grep -F 'if [ -z "${GC_AGENT:-}" ]; then' "$handoff" >/dev/null ||
+            fail "$role formula handoff must reject an empty GC_AGENT"
+        ! grep -F 'gc runtime drain-ack' "$handoff" >/dev/null ||
+            fail "$role formula handoff must preserve provider state on every failure"
+    done
+
+    local shared="$GASTOWN/template-fragments/patrol-wisp.template.md"
+    grep -F 'Patrol roots are ephemeral molecule rows' "$shared" >/dev/null ||
+        fail "shared contract must document the ephemeral tier"
+    grep -F 'Never burn a surplus `in_progress` or materialized root' "$shared" >/dev/null ||
+        fail "shared contract must preserve active/materialized surplus"
+    grep -F 'if [ -z "${GC_AGENT:-}" ]; then' "$shared" >/dev/null ||
+        fail "shared startup reconciliation must reject an empty GC_AGENT"
+}
+
+extract_prompt_startup() {
+    local role=$1 output=$2
+    python3 - "$(role_prompt "$role")" \
+        "$GASTOWN/template-fragments/patrol-wisp.template.md" "$output" "$role" <<'PY'
+import pathlib
+import re
+import sys
+
+source = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+shared = pathlib.Path(sys.argv[2]).read_text(encoding="utf-8")
+marker = f"PATROL_FORMULA=mol-{sys.argv[4]}-patrol"
+marker_pos = source.index(marker)
+start = source.rfind("```bash\n", 0, marker_pos) + len("```bash\n")
+end = source.index("\n```", start)
+block = source[start:end]
+match = re.search(
+    r'\{\{ define "patrol-wisp-startup" \}\}\n(.*?)\n\{\{ end \}\}',
+    shared,
+    flags=re.S,
+)
+if match is None:
+    raise SystemExit("patrol-wisp-startup template not found")
+block = block.replace('{{ template "patrol-wisp-startup" . }}', match.group(1))
+while "{{" in block:
+    left = block.index("{{")
+    right = block.index("}}", left) + 2
+    block = block[:left] + "fixture" + block[right:]
+pathlib.Path(sys.argv[3]).write_text(block + "\n", encoding="utf-8")
+PY
+}
+
+extract_formula_handoff() {
+    local role=$1 output=$2
+    python3 - "$(role_formula "$role")" "$output" <<'PY'
+import pathlib
+import re
+import sys
+import tomllib
+
+with open(sys.argv[1], "rb") as handle:
+    formula = tomllib.load(handle)
+description = next(step["description"] for step in formula["steps"] if step["id"] == "next-iteration")
+blocks = re.findall(r"```bash\n(.*?)```", description, flags=re.S)
+selected = []
+started = False
+for block in blocks:
+    if "PATROL_FORMULA=" in block:
+        started = True
+    if started:
+        selected.append(block)
+    if started and 'gc bd mol burn "$CURRENT_WISP" --force' in block:
+        break
+if not selected:
+    raise SystemExit("next-iteration patrol handoff block not found")
+text = "\n".join(selected)
+text = re.sub(r"\{\{[^{}]+\}\}", "fixture", text)
+pathlib.Path(sys.argv[2]).write_text(text + "\n", encoding="utf-8")
+PY
+}
+
+make_fake_gc() {
+    mkdir -p "$TMP/bin" "$TMP/state"
+    cat >"$TMP/bin/gc" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%q ' "$@" >>"$GC_TEST_LOG"
+printf '\n' >>"$GC_TEST_LOG"
+
+if [[ ${1:-} == runtime && ${2:-} == drain-ack ]]; then
+    printf 'DRAIN_ACK\n' >>"$GC_TEST_ACTIONS"
+    exit 0
+fi
+if [[ ${1:-} != bd ]]; then
+    exit 0
+fi
+shift
+case ${1:-} in
+    --rig=*) shift ;;
+    --rig)
+        shift
+        shift
+        ;;
+esac
+
+case "${1:-} ${2:-}" in
+    "query --json")
+        if [[ ${GC_TEST_QUERY_FAIL:-0} == 1 ]]; then
+            exit 7
+        fi
+        shopt -s nullglob
+        rows=("$GC_TEST_STATE_DIR"/*.json)
+        if ((${#rows[@]} == 0)); then
+            printf '[]\n'
+        else
+            jq -s '[.[] | .[0] | select(.status == "open" or .status == "in_progress")]' "${rows[@]}"
+        fi
+        ;;
+    "show "*)
+        cat "$GC_TEST_STATE_DIR/$2.json"
+        ;;
+    "mol burn")
+        printf 'BURN %s\n' "$3" >>"$GC_TEST_ACTIONS"
+        jq '.[0].status = "closed"' "$GC_TEST_STATE_DIR/$3.json" \
+            >"$GC_TEST_STATE_DIR/$3.json.tmp"
+        mv "$GC_TEST_STATE_DIR/$3.json.tmp" "$GC_TEST_STATE_DIR/$3.json"
+        ;;
+    "mol wisp")
+        count=1
+        if [[ -f "$GC_TEST_STATE_DIR/.pour-count" ]]; then
+            count=$(( $(<"$GC_TEST_STATE_DIR/.pour-count") + 1 ))
+        fi
+        printf '%s\n' "$count" >"$GC_TEST_STATE_DIR/.pour-count"
+        id="fixture-wisp-new-$count"
+        printf 'POUR %s\n' "$id" >>"$GC_TEST_ACTIONS"
+        jq -n --arg id "$id" --arg formula "$3" \
+            '[{id:$id,title:$formula,status:"open",issue_type:"molecule",assignee:"",
+               created_at:"2026-07-23T01:00:00Z",ephemeral:true,
+               dependency_count:0,dependent_count:0}]' \
+            >"$GC_TEST_STATE_DIR/$id.json"
+        printf '{"new_epic_id":"%s"}\n' "$id"
+        ;;
+    "update "*)
+        id=$2
+        shift 2
+        status=
+        assignee=
+        while (($#)); do
+            case $1 in
+                --status=*) status=${1#--status=} ;;
+                --status)
+                    shift
+                    status=${1:-}
+                    ;;
+                --assignee=*) assignee=${1#--assignee=} ;;
+                --assignee)
+                    shift
+                    assignee=${1:-}
+                    ;;
+            esac
+            shift
+        done
+        state="$GC_TEST_STATE_DIR/$id.json"
+        if [[ -n "$status" ]]; then
+            jq --arg status "$status" '.[0].status = $status' "$state" >"$state.tmp"
+            mv "$state.tmp" "$state"
+        fi
+        if [[ -n "$assignee" ]]; then
+            jq --arg assignee "$assignee" '.[0].assignee = $assignee' "$state" >"$state.tmp"
+            mv "$state.tmp" "$state"
+        fi
+        printf 'UPDATE %s status=%s assignee=%s\n' "$id" "$status" "$assignee" >>"$GC_TEST_ACTIONS"
+        ;;
+    "formula show")
+        ;;
+    *)
+        ;;
+esac
+SH
+    chmod +x "$TMP/bin/gc"
+}
+
+write_fixture() {
+    local output=$1 agent=$2 formula=$3 rows=$4
+    printf '%s\n' "$rows" |
+        jq --arg agent "$agent" --arg formula "$formula" '
+          map(. + {
+            assignee: (.assignee // $agent),
+            title: (.title // $formula),
+            issue_type: (.issue_type // "molecule"),
+            ephemeral: (.ephemeral // true),
+            dependency_count: (.dependency_count // 0),
+            dependent_count: (.dependent_count // 0)
+          })' >"$output"
+    jq -c '.[]' "$output" | while IFS= read -r row; do
+        local id
+        id=$(printf '%s\n' "$row" | jq -r '.id')
+        printf '[%s]\n' "$row" >"$TMP/state/$id.json"
+    done
+}
+
+run_block() {
+    local script=$1 agent=$2 current=${3:-} query_fail=${4:-0}
+    PATH="$TMP/bin:$PATH" \
+        GC_AGENT="$agent" \
+        GC_RIG=fixture \
+        GC_BEAD_ID="$current" \
+        GC_TEST_QUERY_FAIL="$query_fail" \
+        GC_TEST_LOG="$TMP/calls.log" \
+        GC_TEST_ACTIONS="$TMP/actions.log" \
+        GC_TEST_STATE_DIR="$TMP/state" \
+        bash "$script"
+}
+
+reset_fake_state() {
+    : >"$TMP/calls.log"
+    : >"$TMP/actions.log"
+    rm -f "$TMP/state"/*.json
+    rm -f "$TMP/state/.pour-count"
+}
+
+test_startup_reuses_existing_open_root() {
+    local role agent formula script
+    for role in deacon witness refinery; do
+        reset_fake_state
+        agent="fixture/gastown.$role"
+        formula="mol-$role-patrol"
+        script="$TMP/$role-startup.sh"
+        extract_prompt_startup "$role" "$script"
+        bash -n "$script"
+        write_fixture "$TMP/query.json" "$agent" "$formula" \
+            '[{"id":"wisp-existing","status":"open","created_at":"2026-07-23T00:00:00Z"},
+              {"id":"wrong-title","status":"open","title":"mol-other-patrol"},
+              {"id":"wrong-agent","status":"open","assignee":"fixture/someone-else"}]'
+        run_block "$script" "$agent" >"$TMP/$role-startup.out"
+        grep -F 'Resuming patrol wisp wisp-existing' "$TMP/$role-startup.out" >/dev/null ||
+            fail "$role startup did not reuse the existing open ephemeral root"
+        ! grep -E '^(POUR|BURN) ' "$TMP/actions.log" >/dev/null ||
+            fail "$role startup poured or burned instead of reusing the sole existing root"
+        grep -E '^UPDATE wisp-existing status=in_progress ' "$TMP/actions.log" >/dev/null ||
+            fail "$role startup did not durably mark the reused root current"
+    done
+}
+
+test_startup_adopts_unassigned_post_pour_root() {
+    local role agent formula script
+    for role in deacon witness refinery; do
+        reset_fake_state
+        agent="fixture/gastown.$role"
+        formula="mol-$role-patrol"
+        script="$TMP/$role-startup-unassigned.sh"
+        extract_prompt_startup "$role" "$script"
+        write_fixture "$TMP/query.json" "$agent" "$formula" \
+            '[{"id":"post-pour-orphan","status":"open","assignee":"",
+               "created_at":"2026-07-23T00:00:00Z"}]'
+
+        run_block "$script" "$agent" >"$TMP/$role-startup-unassigned.out"
+        ! grep -E '^(POUR|BURN) ' "$TMP/actions.log" >/dev/null ||
+            fail "$role startup poured over or burned an unassigned post-pour root"
+        grep -E '^UPDATE post-pour-orphan status=in_progress assignee=fixture/gastown\.'"$role"'$' \
+            "$TMP/actions.log" >/dev/null ||
+            fail "$role startup did not adopt the unassigned post-pour root"
+    done
+}
+
+test_startup_burns_only_revalidated_empty_open_surplus() {
+    local role=refinery
+    local agent=fixture/gastown.refinery
+    local formula=mol-refinery-patrol
+    local script="$TMP/refinery-startup-surplus.sh"
+    reset_fake_state
+    extract_prompt_startup "$role" "$script"
+    write_fixture "$TMP/query.json" "$agent" "$formula" \
+        '[{"id":"current","status":"in_progress","created_at":"2026-07-23T00:00:00Z"},
+          {"id":"empty-open","status":"open","created_at":"2026-07-23T00:01:00Z"},
+          {"id":"materialized-open","status":"open","created_at":"2026-07-23T00:02:00Z","dependent_count":1},
+          {"id":"other-active","status":"in_progress","created_at":"2026-07-23T00:03:00Z"}]'
+    run_block "$script" "$agent" current >"$TMP/refinery-surplus.out"
+    [[ $(grep -c '^BURN ' "$TMP/actions.log") -eq 1 ]] ||
+        fail "startup cleanup must burn exactly one safe empty surplus: $(cat "$TMP/actions.log")"
+    grep -Fx 'BURN empty-open' "$TMP/actions.log" >/dev/null ||
+        fail "startup cleanup did not burn the revalidated empty/open surplus"
+    ! grep -E 'BURN (materialized-open|other-active|current)' "$TMP/actions.log" >/dev/null ||
+        fail "startup cleanup burned active/current/materialized work"
+    grep -F 'Preserving non-empty or active surplus patrol root materialized-open' "$TMP/refinery-surplus.out" >/dev/null ||
+        fail "startup cleanup must surface preserved materialized surplus"
+    grep -F 'Preserving non-empty or active surplus patrol root other-active' "$TMP/refinery-surplus.out" >/dev/null ||
+        fail "startup cleanup must surface preserved active surplus"
+}
+
+test_cycle_reuses_one_successor_and_preserves_unsafe_surplus() {
+    local role agent formula script
+    for role in deacon witness refinery; do
+        reset_fake_state
+        agent="fixture/gastown.$role"
+        formula="mol-$role-patrol"
+        script="$TMP/$role-handoff.sh"
+        extract_formula_handoff "$role" "$script"
+        bash -n "$script"
+        write_fixture "$TMP/query.json" "$agent" "$formula" \
+            '[{"id":"current","status":"in_progress","created_at":"2026-07-23T00:00:00Z"},
+              {"id":"queued","status":"open","created_at":"2026-07-23T00:01:00Z"},
+              {"id":"empty-extra","status":"open","created_at":"2026-07-23T00:02:00Z"},
+              {"id":"materialized-extra","status":"open","created_at":"2026-07-23T00:03:00Z","dependency_count":1},
+              {"id":"active-extra","status":"in_progress","created_at":"2026-07-23T00:04:00Z"}]'
+        run_block "$script" "$agent" current >"$TMP/$role-handoff.out"
+        ! grep -E '^POUR ' "$TMP/actions.log" >/dev/null ||
+            fail "$role handoff poured despite an existing queued successor"
+        grep -Fx 'BURN empty-extra' "$TMP/actions.log" >/dev/null ||
+            fail "$role handoff did not clean the safe empty surplus"
+        grep -Fx 'BURN current' "$TMP/actions.log" >/dev/null ||
+            fail "$role handoff did not burn its resolved current root"
+        ! grep -E 'BURN (queued|materialized-extra|active-extra)' "$TMP/actions.log" >/dev/null ||
+            fail "$role handoff burned the queued, materialized, or active root"
+        grep -E '^UPDATE queued status=in_progress ' "$TMP/actions.log" >/dev/null ||
+            fail "$role handoff did not durably promote its queued successor"
+    done
+}
+
+test_cycle_adopts_unassigned_post_pour_successor() {
+    local role agent formula script
+    for role in deacon witness refinery; do
+        reset_fake_state
+        agent="fixture/gastown.$role"
+        formula="mol-$role-patrol"
+        script="$TMP/$role-handoff-unassigned.sh"
+        extract_formula_handoff "$role" "$script"
+        write_fixture "$TMP/query.json" "$agent" "$formula" \
+            '[{"id":"current","status":"in_progress",
+               "created_at":"2026-07-23T00:00:00Z"},
+              {"id":"post-pour-orphan","status":"open","assignee":"",
+               "created_at":"2026-07-23T00:01:00Z"}]'
+
+        run_block "$script" "$agent" current >"$TMP/$role-handoff-unassigned.out"
+        ! grep -E '^POUR ' "$TMP/actions.log" >/dev/null ||
+            fail "$role handoff poured over an unassigned post-pour successor"
+        grep -E '^UPDATE post-pour-orphan status= assignee=fixture/gastown\.'"$role"'$' \
+            "$TMP/actions.log" >/dev/null ||
+            fail "$role handoff did not claim the unassigned successor before burning"
+        grep -Fx 'BURN current' "$TMP/actions.log" >/dev/null ||
+            fail "$role handoff did not burn the prior current root"
+        grep -E '^UPDATE post-pour-orphan status=in_progress assignee=fixture/gastown\.'"$role"'$' \
+            "$TMP/actions.log" >/dev/null ||
+            fail "$role handoff did not promote the adopted successor"
+    done
+}
+
+test_all_open_empty_bead_id_survives_immediate_handoffs() {
+    # A controlled supervisor restart adopted the same provider sessions while
+    # open patrol roots grew 6 -> 9; every root was open and GC_BEAD_ID empty.
+    local role agent formula startup handoff
+    for role in deacon witness refinery; do
+        reset_fake_state
+        agent="fixture/gastown.$role"
+        formula="mol-$role-patrol"
+        startup="$TMP/$role-all-open-startup.sh"
+        handoff="$TMP/$role-all-open-handoff.sh"
+        extract_prompt_startup "$role" "$startup"
+        extract_formula_handoff "$role" "$handoff"
+        write_fixture "$TMP/query.json" "$agent" "$formula" \
+            '[{"id":"a-open","status":"open","created_at":"2026-07-23T00:00:00Z"},
+              {"id":"z-open","status":"open","created_at":"2026-07-23T00:00:00Z"}]'
+
+        run_block "$startup" "$agent" >"$TMP/$role-all-open-startup.out"
+        [[ $(jq -r '.[0].status' "$TMP/state/a-open.json") == in_progress ]] ||
+            fail "$role startup did not deterministically promote the ID-first all-open survivor"
+        [[ $(jq -r '.[0].status' "$TMP/state/z-open.json") == closed ]] ||
+            fail "$role startup did not safely close the empty all-open duplicate"
+
+        # GC_BEAD_ID stays empty, matching the adopted persistent sessions seen
+        # in production. The durable in_progress marker must resolve CURRENT.
+        run_block "$handoff" "$agent" >"$TMP/$role-all-open-handoff-1.out"
+        [[ $(jq -r '.[0].status' "$TMP/state/fixture-wisp-new-1.json") == in_progress ]] ||
+            fail "$role handoff did not promote its first successor"
+
+        # The same provider immediately re-reads the formula without a restart
+        # or GC_BEAD_ID update. A second cycle must still resolve the successor.
+        run_block "$handoff" "$agent" >"$TMP/$role-all-open-handoff-2.out"
+        [[ $(jq -r '.[0].status' "$TMP/state/fixture-wisp-new-2.json") == in_progress ]] ||
+            fail "$role immediate second cycle did not resolve/promote its successor"
+        ! grep -F 'Could not resolve current' "$TMP/$role-all-open-handoff-1.out" \
+            "$TMP/$role-all-open-handoff-2.out" >/dev/null ||
+            fail "$role repeated the empty-GC_BEAD_ID current-root failure"
+    done
+}
+
+test_query_failure_is_fail_closed() {
+    local script="$TMP/witness-startup-query-failure.sh"
+    reset_fake_state
+    extract_prompt_startup witness "$script"
+    printf '[]\n' >"$TMP/query.json"
+    if PATH="$TMP/bin:$PATH" \
+        GC_AGENT=fixture/gastown.witness \
+        GC_RIG=fixture \
+        GC_BEAD_ID= \
+        GC_TEST_QUERY_FAIL=1 \
+        GC_TEST_LOG="$TMP/calls.log" \
+        GC_TEST_ACTIONS="$TMP/actions.log" \
+        GC_TEST_STATE_DIR="$TMP/state" \
+        bash "$script" >"$TMP/query-failure.out" 2>&1; then
+        fail "startup must fail when the ephemeral query fails"
+    fi
+    [[ ! -s "$TMP/actions.log" ]] ||
+        fail "query failure must not pour or burn: $(cat "$TMP/actions.log")"
+}
+
+test_formula_query_failure_preserves_provider_and_roots() {
+    local role agent formula script
+    for role in deacon witness refinery; do
+        reset_fake_state
+        agent="fixture/gastown.$role"
+        formula="mol-$role-patrol"
+        script="$TMP/$role-handoff-query-failure.sh"
+        extract_formula_handoff "$role" "$script"
+        write_fixture "$TMP/query.json" "$agent" "$formula" \
+            '[{"id":"current","status":"in_progress","created_at":"2026-07-23T00:00:00Z"},
+              {"id":"queued","status":"open","created_at":"2026-07-23T00:01:00Z"}]'
+        if run_block "$script" "$agent" current 1 >"$TMP/$role-handoff-query-failure.out" 2>&1; then
+            fail "$role formula handoff must fail when its ephemeral query fails"
+        fi
+        [[ ! -s "$TMP/actions.log" ]] ||
+            fail "$role query failure must not drain, pour, burn, or update: $(cat "$TMP/actions.log")"
+        [[ $(jq -r '.[0].status' "$TMP/state/current.json") == in_progress ]] ||
+            fail "$role query failure mutated the current patrol root"
+        [[ $(jq -r '.[0].status' "$TMP/state/queued.json") == open ]] ||
+            fail "$role query failure mutated the queued patrol root"
+    done
+}
+
+test_empty_agent_reconciliation_has_no_mutation() {
+    local role formula script
+    for role in deacon witness refinery; do
+        reset_fake_state
+        formula="mol-$role-patrol"
+        script="$TMP/$role-handoff-empty-agent.sh"
+        extract_formula_handoff "$role" "$script"
+        write_fixture "$TMP/query.json" "" "$formula" \
+            '[{"id":"current","status":"in_progress","created_at":"2026-07-23T00:00:00Z"},
+              {"id":"queued","status":"open","created_at":"2026-07-23T00:01:00Z"}]'
+        if run_block "$script" "" current >"$TMP/$role-handoff-empty-agent.out" 2>&1; then
+            fail "$role formula handoff must reject an empty GC_AGENT"
+        fi
+        [[ ! -s "$TMP/actions.log" ]] ||
+            fail "$role empty-agent failure must not drain, pour, burn, or update: $(cat "$TMP/actions.log")"
+        [[ $(jq -r '.[0].status' "$TMP/state/current.json") == in_progress ]] ||
+            fail "$role empty-agent failure mutated the current patrol root"
+        [[ $(jq -r '.[0].status' "$TMP/state/queued.json") == open ]] ||
+            fail "$role empty-agent failure mutated the queued patrol root"
+    done
+}
+
+test_nonempty_current_root_is_never_burned() {
+    local role agent formula script count_field rows
+    for role in deacon witness refinery; do
+        agent="fixture/gastown.$role"
+        formula="mol-$role-patrol"
+        script="$TMP/$role-handoff-nonempty-current.sh"
+        extract_formula_handoff "$role" "$script"
+        for count_field in dependency_count dependent_count; do
+            reset_fake_state
+            rows=$(jq -nc --arg field "$count_field" '
+              [{id:"current",status:"in_progress",created_at:"2026-07-23T00:00:00Z"},
+               {id:"queued",status:"open",created_at:"2026-07-23T00:01:00Z"}]
+              | .[0][$field] = 1')
+            write_fixture "$TMP/query.json" "$agent" "$formula" "$rows"
+            if run_block "$script" "$agent" current \
+                >"$TMP/$role-handoff-$count_field.out" 2>&1; then
+                fail "$role formula handoff must fail closed for nonzero current $count_field"
+            fi
+            [[ ! -s "$TMP/actions.log" ]] ||
+                fail "$role nonzero current $count_field must not drain, pour, burn, or update: $(cat "$TMP/actions.log")"
+            [[ $(jq -r '.[0].status' "$TMP/state/current.json") == in_progress ]] ||
+                fail "$role nonzero current $count_field was burned"
+            [[ $(jq -r '.[0].status' "$TMP/state/queued.json") == open ]] ||
+                fail "$role nonzero current $count_field promoted the successor"
+        done
+    done
+}
+
+make_fake_gc
+test_assets_use_ephemeral_query_contract
+test_startup_reuses_existing_open_root
+test_startup_adopts_unassigned_post_pour_root
+test_startup_burns_only_revalidated_empty_open_surplus
+test_cycle_reuses_one_successor_and_preserves_unsafe_surplus
+test_cycle_adopts_unassigned_post_pour_successor
+test_all_open_empty_bead_id_survives_immediate_handoffs
+test_query_failure_is_fail_closed
+test_formula_query_failure_preserves_provider_and_roots
+test_empty_agent_reconciliation_has_no_mutation
+test_nonempty_current_root_is_never_burned
+
+echo "patrol wisp reconciliation tests passed"


### PR DESCRIPTION
## Problem

Deacon, Witness, and Refinery patrol roots are ephemeral molecule rows, but
their startup and handoff logic searched durable or only `in_progress` work.
After a persistent-provider restart with an empty `GC_BEAD_ID`, an existing
open patrol root could therefore be missed and another root poured.

There is a second restart window: `gc bd mol wisp` commits the new root before
the following assignment command. A crash between those commands leaves an
unassigned open root. Looking only for the canonical assignee also misses that
root and pours another one on restart.

## Change

A shared patrol-ledger contract now:

- queries both open and in-progress roots from the ephemeral tier;
- filters the exact formula and scoped role identity;
- also recognizes an exact-formula unassigned `open` root as a recoverable
  post-pour/pre-assignment result;
- prefers the explicit current ID, then assigned in-progress/open roots, then
  the oldest unassigned open root;
- re-reads the selected root before assigning or promoting it;
- reuses one queued successor instead of pouring another; and
- burns only surplus roots that still read as open, ephemeral, empty,
  exact-formula molecules assigned to this role or still unassigned.

Active, materialized, foreign, or changed roots are preserved for inspection.
Query, identity, parse, and revalidation failures stop without draining or
mutating patrol state.

The same contract is used by Deacon, Witness, and Refinery startup and
next-iteration handoff.

## Regression coverage

`gastown/tests/test_patrol_wisp_reconciliation.sh` executes the rendered
startup and handoff blocks for all three roles. It covers:

- restart with only open assigned roots and an empty `GC_BEAD_ID`;
- adoption of an unassigned post-pour root at startup;
- adoption of an unassigned queued successor at handoff;
- repeated same-provider handoffs;
- deterministic survivor selection and conservative surplus cleanup;
- query failure and empty identity;
- failed validation of active/materialized roots; and
- preservation of provider state on every failure.

## Validation

- all `gastown/tests/test_*.sh` suites
- `python3 -m pytest ...`: 1,170 passed, 8 skipped, 9,412 subtests passed
- `gc lint gastown`
- `go test .`
- Bash syntax over tracked shell scripts
- `git diff --check`
