### PR TITLE
fix(gascity/do-work): base worktree off fresh remote default branch, not stale local HEAD

### DIFF
--- a/gascity/assets/workflows/do-work/prepare-worktree.md
+++ b/gascity/assets/workflows/do-work/prepare-worktree.md
@@ -18,9 +18,17 @@ setup only. Do not edit source files in the launcher checkout.
 3. Validate context path {{context_path}}, files ownership, and verification
    policy for the resolved source anchor.
 4. Create or reuse a deterministic git worktree at
-   `$(pwd)/worktrees/<source-anchor-id>`. If the path is missing, run
-   `git worktree add "$WORKTREE" --detach HEAD`. If the path exists but is not
-   the worktree for this repository, fail closed.
+   `$(pwd)/worktrees/<source-anchor-id>`, based on the up-to-date remote
+   default branch — never the launcher's local `HEAD`, which may be behind
+   `origin`. If the path is missing:
+   - Resolve the remote default branch (do not hardcode `main`):
+     `DEFAULT_BRANCH=$(git remote show origin 2>/dev/null | sed -n 's/.*HEAD branch: //p')`.
+     If it is empty, fail closed — do not fall back to local `HEAD`.
+   - Fetch it so the base is current:
+     `git fetch --prune origin "$DEFAULT_BRANCH"`.
+   - Create the worktree detached at the freshly fetched tip:
+     `git worktree add "$WORKTREE" --detach "origin/$DEFAULT_BRANCH"`.
+   If the path exists but is not the worktree for this repository, fail closed.
 5. Persist the absolute path on the source anchor with
    `gc bd update <source-anchor-id> --set-metadata work_dir=<absolute worktree path>`.
    For synthetic drain-unit convoys, never persist `work_dir` on the synthetic drain-unit convoy; the original drain member/source anchor is authoritative.


### PR DESCRIPTION
## Problem

`do-work`'s `prepare-worktree` step creates the ephemeral worktree from the
launcher's **local `HEAD`** and never fetches:

```
git worktree add "$WORKTREE" --detach HEAD
```

There is no `git fetch` anywhere in the do-work steps, so every do-work
worktree inherits whatever the launcher checkout happens to be — commonly
**behind `origin`**. Workers dispatched onto city rigs then branch off a stale
base, producing diffs against an old tree and spurious conflicts.

## Fix

Mirror the pattern the other worktree-creating formulas already use —
`core/formulas/mol-scoped-work.toml` (`git fetch --prune origin` +
`git worktree add … --detach origin/{{base_branch}}`) and
`gastown/formulas/mol-polecat-work.toml` (`git fetch origin {{base_branch}}` +
checkout of `origin/{{base_branch}}`).

`do-work` is a workflow (prose steps), not a formula with a `base_branch` var,
so the default branch is resolved dynamically using the same idiom already
present elsewhere in this repo (`pr-pipeline`, `contributing`, `discord`
formulas):

```
DEFAULT_BRANCH=$(git remote show origin 2>/dev/null | sed -n 's/.*HEAD branch: //p')
git fetch --prune origin "$DEFAULT_BRANCH"
git worktree add "$WORKTREE" --detach "origin/$DEFAULT_BRANCH"
```

- **No hardcoded `main`** — the default branch is discovered from the remote.
- **Fail closed** — if the default branch can't be resolved, the step fails
  rather than silently falling back to (stale) local `HEAD`.
- **`work_dir` recording (step 5) is unchanged.**

## Scope

One hunk, in `gascity/assets/workflows/do-work/prepare-worktree.md` step 4.
No formula graph, metadata, or step-ordering changes.

## Test

`gascity/tests/test_formula_assets.py::FormulaAssetTests::test_do_work_formula_requires_persisted_item_worktree`
passes — all asserted description fragments (`worktrees/<source-anchor-id>`,
`git worktree add`, `gc bd update … work_dir=`, the convoy/anchor invariants)
are preserved.

## Notes

- Reported downstream as a stale-base symptom: do-work workers on city rigs
  branching off a base behind `origin/main`.
- A companion improvement (not in this PR) is a periodic per-rig "freshen rig
  source from `origin`" order, so agents doing reads/research against a rig's
  checked-out source also get a current tree — tracked separately.
