### PR TITLE
fix(registry): fail closed on unverifiable registry.toml sources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,10 @@ jobs:
         run: python3 -m pip install PyYAML pytest jsonschema
 
       - name: Validate registry
-        run: python3 validate_registry.py
+        # --require-git: without git, no commit or content-hash verification runs at
+        # all, so a missing worktree must fail rather than silently downgrade this to
+        # a format-only check. (checkout above uses fetch-depth: 0, as it must.)
+        run: python3 validate_registry.py --require-git
 
       - name: Run Python pack tests
         run: python3 -m pytest tests contributing/tests gascity/tests discord/tests github/tests slack-full/tests slack-channel/tests pr-pipeline/tests -q

--- a/README.md
+++ b/README.md
@@ -250,6 +250,14 @@ GC=/path/to/gc make registry-validate
 
 ### Publishing a pack to the registry
 
+> **`registry.toml` describes packs that live in this repository only.** Its
+> `source` must be a `https://github.com/gastownhall/gascity-packs/tree/<ref>/<dir>`
+> URL (or the bare repository URL for a root pack) — anything else is rejected,
+> because the content hash can only be verified against this repository's own
+> history. If your pack lives in **your** repo, you do not need a PR here: publish
+> it directly to the Gas City registry under a scoped `<owner>/<pack>` name and you
+> keep ownership of it.
+
 `registry.toml` is the public catalog. Each `[[pack.release]]` carries a
 content hash that `validate_registry.py` enforces against the pack tree at the
 pinned `commit`. To register a new pack, commit it on your branch, then mint a

--- a/registry.toml
+++ b/registry.toml
@@ -212,7 +212,7 @@ schema = 1
 [[pack]]
   name = "pr-pipeline"
   description = "Author-side PR discipline as a pack: planning, blast-radius mapping, outgoing-PR scorecard review, and pre-push gating (mol-pr-start / mol-pr-blast-radius / mol-pr-review / mol-pr-ship)."
-  source = "https://github.com/gastownhall/gascity-packs//pr-pipeline"
+  source = "https://github.com/gastownhall/gascity-packs/tree/main/pr-pipeline"
   source_kind = "git"
 
   [[pack.release]]
@@ -225,7 +225,7 @@ schema = 1
 [[pack]]
   name = "contributing"
   description = "The external-contributor lifecycle for gastownhall/gascity — write a good issue, find priority work, plan a PR, map its blast radius, and self-review against the codebase audit. Each step produces an artifact you act on; the pack stops before pushing — opening the PR is your call. Self-contained: gas-city's actual standards (the B-rule adoption-review audit, blast-radius dimensions, test tiers) are baked into the skills; no imports."
-  source = "https://github.com/gastownhall/gascity-packs//contributing"
+  source = "https://github.com/gastownhall/gascity-packs/tree/main/contributing"
   source_kind = "git"
 
   [[pack.release]]

--- a/scripts/pack_release_compat.py
+++ b/scripts/pack_release_compat.py
@@ -247,7 +247,10 @@ def validate_registry_locally(registry_path: Path) -> None:
             file=sys.stderr,
         )
         return
-    run_checked([sys.executable, str(validator)], cwd=registry_path.parent)
+    # --require-git: this is the release-HASH validation fallback, and without git no
+    # hash is verified at all. Failing is the point; silently degrading to a
+    # format-only check would defeat the fallback.
+    run_checked([sys.executable, str(validator), "--require-git"], cwd=registry_path.parent)
 
 
 def validate_registry_hashes(gc_bin: str, registry_path: Path, pack_filters: Sequence[str] | None) -> None:

--- a/tests/test_validate_registry.py
+++ b/tests/test_validate_registry.py
@@ -31,10 +31,158 @@ def _init_pack_repo(root) -> str:
     return run_git(root, "rev-parse", "HEAD")
 
 
-def test_source_pack_path_accepts_tree_urls() -> None:
-    source = "https://github.com/gastownhall/gascity-packs/tree/main/cass"
+def test_parse_source_accepts_canonical_tree_url() -> None:
+    spec = validate_registry.parse_source(
+        "https://github.com/gastownhall/gascity-packs/tree/main/cass"
+    )
 
-    assert validate_registry.source_pack_path(source) == "cass"
+    assert spec == validate_registry.SourceSpec(ref="main", pack_path="cass")
+
+
+def test_parse_source_accepts_bare_repo_url_as_root_pack() -> None:
+    spec = validate_registry.parse_source("https://github.com/gastownhall/gascity-packs")
+
+    assert spec == validate_registry.SourceSpec(ref=None, pack_path="")
+
+
+def test_parse_source_tolerates_trailing_slash_and_host_case() -> None:
+    spec = validate_registry.parse_source(
+        "https://GITHUB.COM/gastownhall/gascity-packs/tree/main/cass/"
+    )
+
+    assert spec == validate_registry.SourceSpec(ref="main", pack_path="cass")
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        # The headline bug: a foreign source must be refused, not silently unverified.
+        ("https://github.com/eve/packs", "external pack sources are not accepted"),
+        ("https://github.com/eve/packs/tree/main/x", "external pack sources are not accepted"),
+        ("https://evil.com/gastownhall/gascity-packs/tree/main/x", "external pack sources are not accepted"),
+        # Legacy forms that used to skip every check.
+        ("https://github.com/gastownhall/gascity-packs//cass", "legacy '<repo>//<dir>' source form"),
+        ("https://github.com/gastownhall/gascity-packs.git//cass", "legacy '<repo>//<dir>' source form"),
+        # Plausible-but-wrong shapes previously mis-read as "repository root".
+        ("https://github.com/gastownhall/gascity-packs/packs/cass", "unrecognized source URL form"),
+        ("https://github.com/gastownhall/gascity-packs/blob/main/cass", "source uses /blob/"),
+        ("https://github.com/gastownhall/gascity-packs/tree/main", "missing the pack directory"),
+        ("https://github.com/gastownhall/gascity-packs/tree/main/../etc", "invalid segment"),
+        # Transport / identity.
+        ("http://github.com/gastownhall/gascity-packs/tree/main/cass", "must be an HTTPS URL"),
+        ("git@github.com:gastownhall/gascity-packs.git", "must be an HTTPS URL"),
+        ("https://github.com/GasTownHall/gascity-packs/tree/main/cass", "canonical repository URL"),
+        ("https://github.com/gastownhall/gascity-packs/tree/main/cass#v1", "must not embed a ref fragment"),
+        ("https://github.com/gastownhall/gascity-packs/tree/main/cass?x=1", "no query, credentials, or port"),
+    ],
+)
+def test_parse_source_rejects_unverifiable_sources(source: str, expected: str) -> None:
+    with pytest.raises(validate_registry.SourceError) as excinfo:
+        validate_registry.parse_source(source)
+
+    assert expected in str(excinfo.value)
+
+
+def test_validate_rejects_foreign_source_with_bogus_hash(tmp_path) -> None:
+    """Regression: this exact entry validated "ok" before the fail-closed fix."""
+    commit = _init_pack_repo(tmp_path)
+    registry = tmp_path / "registry.toml"
+    registry.write_text(
+        textwrap.dedent(
+            f"""\
+            schema = 1
+
+            [[pack]]
+              name = "evil-pack"
+              description = "d"
+              source = "https://github.com/eve/packs"
+              source_kind = "git"
+
+              [[pack.release]]
+                version = "0.1.0"
+                ref = "main"
+                commit = "{"a" * 40}"
+                hash = "sha256:{"0" * 64}"
+                description = "d"
+            """
+        )
+    )
+    del commit
+
+    errors = validate_registry.validate(registry)
+
+    assert any("external pack sources are not accepted" in e for e in errors)
+
+
+def test_validate_reports_uncomputable_hash_instead_of_passing(tmp_path) -> None:
+    """A canonical source whose commit is absent must error, not silently verify."""
+    _init_pack_repo(tmp_path)
+    registry = tmp_path / "registry.toml"
+    registry.write_text(
+        textwrap.dedent(
+            f"""\
+            schema = 1
+
+            [[pack]]
+              name = "cass"
+              description = "d"
+              source = "https://github.com/gastownhall/gascity-packs/tree/main/cass"
+              source_kind = "git"
+
+              [[pack.release]]
+                version = "0.1.0"
+                ref = "main"
+                commit = "{"a" * 40}"
+                hash = "sha256:{"0" * 64}"
+                description = "d"
+            """
+        )
+    )
+
+    errors = validate_registry.validate(registry)
+
+    assert any("content hash could not be computed" in e for e in errors)
+
+
+def test_validate_verifies_root_pack_hash(tmp_path) -> None:
+    """A repo-root pack (pack_path == "") must be verified, not skipped."""
+    run_git(tmp_path, "init")
+    run_git(tmp_path, "config", "user.email", "test@example.com")
+    run_git(tmp_path, "config", "user.name", "Test User")
+    (tmp_path / "pack.toml").write_bytes(b'[pack]\nname = "rootpack"\nschema = 2\n')
+    run_git(tmp_path, "add", "pack.toml")
+    run_git(tmp_path, "commit", "-m", "root pack")
+    commit = run_git(tmp_path, "rev-parse", "HEAD")
+    registry = tmp_path / "registry.toml"
+
+    def write(hash_value: str) -> None:
+        registry.write_text(
+            textwrap.dedent(
+                f"""\
+                schema = 1
+
+                [[pack]]
+                  name = "rootpack"
+                  description = "d"
+                  source = "https://github.com/gastownhall/gascity-packs"
+                  source_kind = "git"
+
+                  [[pack.release]]
+                    version = "0.1.0"
+                    ref = "main"
+                    commit = "{commit}"
+                    hash = "{hash_value}"
+                    description = "d"
+                """
+            )
+        )
+
+    real = validate_registry.git_pack_content_hash(tmp_path, commit, "")
+    write(real)
+    assert not [e for e in validate_registry.validate(registry) if "rootpack" in e]
+
+    write(f"sha256:{'0' * 64}")
+    assert any("does not match" in e for e in validate_registry.validate(registry) if "rootpack" in e)
 
 
 def test_validate_tree_url_source_checks_pack_toml_name(tmp_path) -> None:
@@ -103,20 +251,22 @@ def test_resolve_commit_returns_full_lowercase_sha(tmp_path) -> None:
     assert resolved == head
 
 
-def test_compute_pack_hash_matches_validator_and_raises_when_absent(tmp_path) -> None:
+def test_git_pack_content_hash_raises_rather_than_returning_none(tmp_path) -> None:
+    """The fail-closed contract: an uncomputable hash must raise, never be falsy."""
     commit = _init_pack_repo(tmp_path)
 
-    computed = validate_registry.compute_pack_hash(tmp_path, "cass", commit)
+    computed = validate_registry.git_pack_content_hash(tmp_path, commit, "cass")
 
-    assert computed == validate_registry.git_pack_content_hash(tmp_path, commit, "cass")
     assert validate_registry.HASH_RE.fullmatch(computed)
-    with pytest.raises(ValueError):
-        validate_registry.compute_pack_hash(tmp_path, "missing", commit)
+    with pytest.raises(ValueError, match="does not contain"):
+        validate_registry.git_pack_content_hash(tmp_path, commit, "missing")
+    with pytest.raises(ValueError, match="not present in this repository"):
+        validate_registry.git_pack_content_hash(tmp_path, "a" * 40, "cass")
 
 
 def test_render_pack_entry_parses_and_carries_computed_hash(tmp_path) -> None:
     commit = _init_pack_repo(tmp_path)
-    content_hash = validate_registry.compute_pack_hash(tmp_path, "cass", commit)
+    content_hash = validate_registry.git_pack_content_hash(tmp_path, commit, "cass")
 
     block = validate_registry.render_pack_entry(
         name="cass",
@@ -141,7 +291,7 @@ def test_render_pack_entry_parses_and_carries_computed_hash(tmp_path) -> None:
 
 def test_render_pack_entry_escapes_quotes_in_descriptions(tmp_path) -> None:
     commit = _init_pack_repo(tmp_path)
-    content_hash = validate_registry.compute_pack_hash(tmp_path, "cass", commit)
+    content_hash = validate_registry.git_pack_content_hash(tmp_path, commit, "cass")
 
     description = 'Has a "quote" and a \\ backslash'
     block = validate_registry.render_pack_entry(

--- a/validate_registry.py
+++ b/validate_registry.py
@@ -9,9 +9,21 @@ import re
 import subprocess
 import sys
 import tomllib
+from dataclasses import dataclass
 from pathlib import Path
 from urllib.parse import urlparse
 
+
+# registry.toml describes packs that live in THIS repository, and nothing else.
+# Community packs are published directly to the Gas City registry under a scoped
+# <owner>/<pack> name; they never get an entry here. That keeps this validator a
+# purely local, network-free, fail-closed check: every source it accepts is one
+# whose content it can actually verify against the local object database.
+CANONICAL_REPO_HOST = "github.com"
+CANONICAL_REPO_OWNER = "gastownhall"
+CANONICAL_REPO_NAME = "gascity-packs"
+CANONICAL_REPO_URL = f"https://{CANONICAL_REPO_HOST}/{CANONICAL_REPO_OWNER}/{CANONICAL_REPO_NAME}"
+PACK_PATH_SEGMENT_RE = re.compile(r"^[A-Za-z0-9._-]+$")
 
 PACK_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]*(/[a-z0-9][a-z0-9-]*)?$")
 RELEASE_VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+(\.[0-9]+)?$")
@@ -91,10 +103,21 @@ def manifest_perm(mode: str) -> str:
     raise ValueError(f"unsupported git file mode {mode!r}")
 
 
-def git_pack_content_hash(root: Path, commit: str, pack_path: str) -> str | None:
+def git_pack_content_hash(root: Path, commit: str, pack_path: str) -> str:
+    """Content hash for a pack subtree at a commit.
+
+    Raises ValueError with a reason rather than returning None: a hash that
+    cannot be computed must surface as an error, never be mistaken for "verified".
+    """
+    if not git_object_exists(root, f"{commit}^{{commit}}"):
+        raise ValueError(
+            f"commit {commit} is not present in this repository "
+            "(shallow clone? CI must check out with fetch-depth: 0)"
+        )
     pack_toml_object = f"{commit}:{pack_path}/pack.toml" if pack_path else f"{commit}:pack.toml"
     if not git_object_exists(root, pack_toml_object):
-        return None
+        location = f"{pack_path}/pack.toml" if pack_path else "pack.toml at the repository root"
+        raise ValueError(f"commit {commit} does not contain {location}")
     args = ["ls-tree", "-r", "-z", "--full-tree", commit]
     if pack_path:
         args.extend(["--", pack_path])
@@ -115,7 +138,7 @@ def git_pack_content_hash(root: Path, commit: str, pack_path: str) -> str | None
         check=False,
     )
     if result.returncode != 0:
-        return None
+        raise ValueError(f"git ls-tree failed for {commit} ({result.stderr.decode('utf-8', 'replace').strip()})")
     entries: list[str] = []
     for record in result.stdout.rstrip(b"\0").split(b"\0"):
         if not record:
@@ -131,26 +154,121 @@ def git_pack_content_hash(root: Path, commit: str, pack_path: str) -> str | None
         data = git_bytes(root, "cat-file", "blob", object_id)
         entries.append(f"{rel} {manifest_perm(mode)} {hashlib.sha256(data).hexdigest()}")
     if not entries:
-        return None
+        raise ValueError(f"no tracked files under {pack_path or 'the repository root'} at {commit}")
     manifest = "\n".join(sorted(entries)).encode("utf-8")
     return "sha256:" + hashlib.sha256(manifest).hexdigest()
 
 
-def source_pack_path(source: str) -> str:
-    git_subdir = re.search(r"\.git//([^#]+)", source)
-    if git_subdir:
-        return git_subdir.group(1).strip("/")
-    tree_path = re.search(r"/tree/[^/]+/([^#]+)", source)
-    if tree_path:
-        return tree_path.group(1).strip("/")
-    return ""
+class SourceError(ValueError):
+    """A source URL this validator refuses to accept, with a human-readable reason."""
 
 
-def validate(path: Path) -> list[str]:
+@dataclass(frozen=True)
+class SourceSpec:
+    """A parsed, accepted source URL.
+
+    ref is the /tree/<ref> segment, or None for the bare repository URL.
+    pack_path is "" if and only if the pack lives at the repository root — a
+    distinct, fully-verified state, never a signal to skip checks.
+    """
+
+    ref: str | None
+    pack_path: str
+
+
+_FOREIGN_SOURCE_MESSAGE = (
+    "external pack sources are not accepted in this registry, because this validator can "
+    "only verify content hashes against this repository's own history. Your pack keeps "
+    "living in your repo: publish it to the Gas City registry (registry.gascity.com/publish) "
+    "under a scoped <owner>/<pack> name, where you stay its owner. No PR here is needed - "
+    "drop this registry.toml change"
+)
+
+
+def parse_source(source: str) -> SourceSpec:
+    """Parse a source URL, or raise SourceError explaining why it is unacceptable.
+
+    Only URLs pointing at this repository are accepted, because only those can be
+    verified against the local object database.
+    """
+    parsed = urlparse(source)
+    if parsed.scheme != "https":
+        raise SourceError(
+            f"source must be an HTTPS URL of this repository ({CANONICAL_REPO_URL}); "
+            f"got scheme {parsed.scheme!r}"
+        )
+    if parsed.fragment:
+        raise SourceError("source must not embed a ref fragment; use [[pack.release]].ref")
+    if parsed.query or parsed.username or parsed.password or parsed.port:
+        raise SourceError("source must be a plain repository URL with no query, credentials, or port")
+    if (parsed.hostname or "").lower() != CANONICAL_REPO_HOST:
+        raise SourceError(_FOREIGN_SOURCE_MESSAGE)
+
+    # Split before discarding empties so an interior "//" is caught rather than
+    # silently collapsing into a valid-looking path.
+    raw = parsed.path[:-1] if parsed.path.endswith("/") else parsed.path
+    segments = raw.split("/")[1:] if raw.startswith("/") else raw.split("/")
+    if segments == [""]:
+        raise SourceError(f"source must use the canonical repository URL {CANONICAL_REPO_URL}")
+    if any(segment == "" for segment in segments):
+        raise SourceError(
+            "legacy '<repo>//<dir>' source form is no longer accepted; use "
+            f"{CANONICAL_REPO_URL}/tree/<ref>/<dir>"
+        )
+    if len(segments) < 2:
+        raise SourceError(f"source must use the canonical repository URL {CANONICAL_REPO_URL}")
+
+    owner, repo, *rest = segments
+    if repo.endswith(".git"):
+        raise SourceError(f"source must use the canonical repository URL {CANONICAL_REPO_URL}")
+    if owner != CANONICAL_REPO_OWNER or repo != CANONICAL_REPO_NAME:
+        # A different repo on github.com is still an external source.
+        if (owner.lower(), repo.lower()) == (CANONICAL_REPO_OWNER, CANONICAL_REPO_NAME):
+            raise SourceError(f"source must use the canonical repository URL {CANONICAL_REPO_URL}")
+        raise SourceError(_FOREIGN_SOURCE_MESSAGE)
+
+    if not rest:
+        return SourceSpec(ref=None, pack_path="")
+
+    if rest[0] == "blob":
+        raise SourceError(f"source uses /blob/ (a file view); use {CANONICAL_REPO_URL}/tree/<ref>/<dir>")
+    if rest[0] != "tree":
+        raise SourceError(
+            f"unrecognized source URL form {source!r}; expected "
+            f"{CANONICAL_REPO_URL}/tree/<ref>/<dir> or the bare repository URL for a root pack"
+        )
+
+    ref, *dirs = rest[1:] or [""]
+    if not ref:
+        raise SourceError(f"source /tree/ URL is missing a ref; use {CANONICAL_REPO_URL}/tree/<ref>/<dir>")
+    if not dirs:
+        raise SourceError(
+            "source /tree/ URL is missing the pack directory; for a repository-root pack "
+            f"use the bare repository URL {CANONICAL_REPO_URL}"
+        )
+    for segment in dirs:
+        if segment in {".", ".."} or not PACK_PATH_SEGMENT_RE.fullmatch(segment):
+            raise SourceError(f"source pack path contains an invalid segment {segment!r}")
+    return SourceSpec(ref=ref, pack_path="/".join(dirs))
+
+
+def validate(path: Path, *, require_git: bool = False) -> list[str]:
     errors: list[str] = []
     with path.open("rb") as handle:
         data = tomllib.load(handle)
     git_checks_enabled = inside_git_worktree(path.parent)
+    if not git_checks_enabled:
+        # Without git we can only check formatting — no commit or content-hash
+        # verification happens at all. Never let that pass silently in CI.
+        message = (
+            "git content verification is unavailable "
+            f"({path.parent} is not a git worktree); commit and hash checks were NOT performed"
+        )
+        if require_git:
+            # Record and keep going: format errors are still worth reporting.
+            errors.append(message + " (--require-git)")
+        else:
+            print(f"warning: {message}", file=sys.stderr)
 
     if data.get("schema", 1) != 1:
         errors.append("schema must be 1")
@@ -175,6 +293,14 @@ def validate(path: Path) -> list[str]:
         if pack.get("source_kind") != "git":
             errors.append(f"{label}: source_kind must be git")
 
+        # Parse the source BEFORE validating releases: the release checks need the
+        # pack path, and an unparseable source must never silently disable them.
+        spec: SourceSpec | None = None
+        try:
+            spec = parse_source(pack.get("source", ""))
+        except SourceError as exc:
+            errors.append(f"{label}: {exc}")
+
         releases = pack.get("release", [])
         if not isinstance(releases, list) or len(releases) == 0:
             errors.append(f"{label}: at least one [[pack.release]] is required")
@@ -196,38 +322,42 @@ def validate(path: Path) -> list[str]:
                 errors.append(f"{label}: release {version!r} description is required")
 
             commit = release.get("commit", "")
-            if git_checks_enabled and (pack_path := source_pack_path(pack.get("source", ""))):
-                pack_toml_object = f"{commit}:{pack_path}/pack.toml"
-                if COMMIT_RE.fullmatch(commit) and not git_object_exists(path.parent, pack_toml_object):
-                    errors.append(f"{label}: release {version!r} commit does not contain {pack_path}/pack.toml")
-                expected_hash = git_pack_content_hash(path.parent, commit, pack_path) if COMMIT_RE.fullmatch(commit) else None
-                if expected_hash and release.get("hash", "") != expected_hash:
-                    errors.append(f"{label}: release {version!r} hash {release.get('hash', '')!r} does not match {expected_hash!r}")
+            # No ref-vs-source-URL comparison: the source URL carries ONE /tree/<ref>
+            # segment while releases are per-version, so any pack releasing from two
+            # refs would be unsatisfiable. commit + content hash are the real anchor;
+            # the ref segment is display metadata.
+            if spec is not None and git_checks_enabled and COMMIT_RE.fullmatch(commit):
+                # A hash that cannot be computed is an error, never a pass.
+                try:
+                    expected_hash = git_pack_content_hash(path.parent, commit, spec.pack_path)
+                except (ValueError, OSError, subprocess.SubprocessError) as exc:
+                    errors.append(f"{label}: release {version!r} content hash could not be computed: {exc}")
+                else:
+                    if release.get("hash", "") != expected_hash:
+                        errors.append(
+                            f"{label}: release {version!r} hash {release.get('hash', '')!r} "
+                            f"does not match {expected_hash!r}"
+                        )
 
-        source = pack.get("source", "")
-        parsed = urlparse(source)
-        if parsed.scheme != "https" or not parsed.netloc:
-            errors.append(f"{label}: source must be an HTTPS git locator")
-            continue
-        if parsed.fragment:
-            errors.append(f"{label}: source must not embed a ref fragment; use [[pack.release]].ref")
-            continue
-
-        pack_path = source_pack_path(source)
-        if pack_path:
-            pack_toml = path.parent / pack_path / "pack.toml"
+        # Worktree cross-check — runs for root packs too (pack_path == "").
+        if spec is not None:
+            pack_dir = path.parent / spec.pack_path if spec.pack_path else path.parent
+            # "cass/pack.toml" for a subdir pack; "pack.toml" for a repo-root pack.
+            toml_label = f"{spec.pack_path}/pack.toml" if spec.pack_path else "pack.toml"
+            where = repr(spec.pack_path) if spec.pack_path else "the repository root"
+            pack_toml = pack_dir / "pack.toml"
             if not pack_toml.exists():
-                errors.append(f"{label}: source path {pack_path!r} does not contain pack.toml")
+                errors.append(f"{label}: source path {where} does not contain pack.toml")
                 continue
             try:
                 with pack_toml.open("rb") as handle:
                     pack_data = tomllib.load(handle)
             except tomllib.TOMLDecodeError as exc:
-                errors.append(f"{label}: source path {pack_path!r} pack.toml is invalid: {exc}")
+                errors.append(f"{label}: source path {where} pack.toml is invalid: {exc}")
                 continue
             actual_name = pack_data.get("pack", {}).get("name", "")
             if actual_name != name:
-                errors.append(f"{label}: registry name does not match {pack_path}/pack.toml name {actual_name!r}")
+                errors.append(f"{label}: registry name does not match {toml_label} name {actual_name!r}")
 
     missing = REQUIRED_WAVE_1 - seen
     if missing:
@@ -264,19 +394,6 @@ def _toml_escape(value: str) -> str:
         else:
             result.append(ch)
     return "".join(result)
-
-
-def compute_pack_hash(root: Path, pack_path: str, commit: str) -> str:
-    """Compute the canonical content hash for a pack at a commit.
-
-    Wraps git_pack_content_hash with a clear error when the pack is absent at
-    that commit, so callers minting a registry entry fail loudly instead of
-    emitting a null hash.
-    """
-    digest = git_pack_content_hash(root, commit, pack_path)
-    if digest is None:
-        raise ValueError(f"pack {pack_path!r} not found at commit {commit}")
-    return digest
 
 
 def render_pack_entry(
@@ -323,6 +440,11 @@ def _pack_toml_name(root: Path, pack: str) -> str:
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("registry", nargs="?", default="registry.toml")
+    parser.add_argument(
+        "--require-git",
+        action="store_true",
+        help="fail instead of warning when git content verification is unavailable",
+    )
     parser.add_argument(
         "--compute",
         metavar="PACK",
@@ -371,7 +493,7 @@ def main() -> int:
             return 1
         try:
             commit = resolve_commit(root, args.commit)
-            print(compute_pack_hash(root, args.compute, commit))
+            print(git_pack_content_hash(root, commit, args.compute))
         except (ValueError, subprocess.CalledProcessError) as exc:
             print(f"compute failed: {exc}", file=sys.stderr)
             return 1
@@ -397,11 +519,17 @@ def main() -> int:
                     f"{pack}/pack.toml name {actual_name!r} does not match {pack!r}"
                 )
             commit = resolve_commit(root, args.commit)
-            content_hash = compute_pack_hash(root, pack, commit)
+            minted_source = f"{args.repo_url.rstrip('/')}/tree/{args.ref}/{pack}"
+            try:
+                parse_source(minted_source)
+            except SourceError as exc:
+                print(f"emit-entry failed: {exc}", file=sys.stderr)
+                return 1
+            content_hash = git_pack_content_hash(root, commit, pack)
             entry = render_pack_entry(
                 name=pack,
                 description=args.pack_description,
-                source=f"{args.repo_url.rstrip('/')}/tree/{args.ref}/{pack}",
+                source=minted_source,
                 version=args.version,
                 ref=args.ref,
                 commit=commit,
@@ -414,7 +542,7 @@ def main() -> int:
         print(entry, end="")
         return 0
 
-    errors = validate(Path(args.registry))
+    errors = validate(Path(args.registry), require_git=args.require_git)
     if errors:
         for error in errors:
             print(f"registry validation failed: {error}", file=sys.stderr)


### PR DESCRIPTION
## The bug

`validate_registry.py` failed **open** on external pack sources. `source_pack_path()` pulled a tree path out of *any* https URL without checking it pointed at this repo, then resolved it against the local checkout:

- A source URL **without `/tree/`** returned `""` — falsy — so the walrus guard and `if pack_path:` short-circuited, skipping pack.toml existence, content-hash verification **and** the name match entirely. **An entry with an all-zero `sha256` and a commit absent from the object database validated `ok`.**
- A **foreign** `/tree/` URL mis-resolved locally, and `git_pack_content_hash` returned `None`, which the caller read as "verified".

Foreign sources were therefore *more* permissive than our own — the inversion you least want in a supply-chain check.

**Two live in-repo instances:** `pr-pipeline` and `contributing` use a legacy `gascity-packs//<dir>` form matching neither regex, so **they have never been verified.** Their hashes were already correct (checked); this migrates both to the canonical form **in the same commit**, so CI is never red in between.

## The rule

`registry.toml` describes packs in **this repository only**. Community packs publish directly to the Gas City registry under a scoped `<owner>/<pack>` name and keep their author as owner — so rejecting foreign sources costs nothing and keeps this check local, network-free, and actually verifiable. (The registry server already does the authoritative external check.)

## Changes

- **`parse_source()` → `SourceSpec(ref, pack_path)`**, raising `SourceError`; accepts only canonical-repo URLs. Classifies every form that used to slip through: legacy `//` and `.git//`, `/blob/`, `/tree/<ref>` with no directory, bare paths like `/packs/foo` (previously mis-read as repo root), non-`https`, foreign host/owner, fragments, query/credentials/port, invalid segments.
- **`""` now means repo-root and nothing else** — a fully verified state, never a skip signal. Root packs were previously unchecked entirely.
- **`git_pack_content_hash()` raises with a reason instead of returning `None`**, and checks commit presence separately so a shallow clone is named as such. Deletes the `compute_pack_hash` wrapper whose only job was hiding that `None`.
- **`validate()` parses the source once *before* the release loop**, so an unparseable source can't silently disable the release checks.
- **`--require-git`** turns "git unavailable" from a silent downgrade into an error — wired into CI (already `fetch-depth: 0`) and into the release-hash fallback in `scripts/pack_release_compat.py`, which could not verify a hash without it.
- **`--emit-entry` refuses to mint a source its own validator would reject.**

Deliberately **not** added: a `release.ref` vs `/tree/<ref>` consistency check. The source URL carries one ref while releases are per-version, so a pack releasing from two refs would be unsatisfiable and `make registry-publish REGISTRY_REF=<tag>` would mint self-rejecting entries. `commit` + content hash are the real anchor.

## Verification

- 11 packs / 28 releases still validate (`registry.toml: ok`, with and without `--require-git`).
- Ten attack forms each rejected with a **specific** reason, including the reproduced all-zero-hash bypass.
- Positive controls: a tampered hash is caught with exact expected/actual; a repo-root pack with a wrong hash is caught (previously zero checks ran); a pack releasing from two refs still validates.
- Suite: **101 passed, 7 skipped.**

## Heads-up

This will correctly fail CI on **#180** (registry entry pointing at `boshu2/agentops`). The rejection message tells the author exactly what to do instead. #6 is *not* affected — it only adds a README, which this validator doesn't police (tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)