### PR TITLE
feat(registry): publish bmad, compound-engineering, gstack and superpowers

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -261,3 +261,55 @@ schema = 1
     commit = "a1490ecf90238f3af52ab2e7f24e30b5b62cbfc2"
     hash = "sha256:c06f30e61407994cef7e16aafecbc71afbbc9f8cdfd0d506146fdf95837333cf"
     description = "Initial oversight-rig release: rig-scoped project-lead + deterministic escalation machinery."
+
+[[pack]]
+  name = "bmad"
+  description = "BMAD Method delivery process (PRD, architecture, epics and stories, readiness, adversarial review) as a Gas City build factory."
+  source = "https://github.com/gastownhall/gascity-packs/tree/main/bmad"
+  source_kind = "git"
+
+  [[pack.release]]
+    version = "0.1.0"
+    ref = "main"
+    commit = "636fdfaaf54195b293e8e56d5e9c30e4b8d5a9ef"
+    hash = "sha256:cb81d9e35fe4ca2263922e901eac34aec6183d92832aa0695e43ff038462087d"
+    description = "First registry release of the BMAD build factory."
+
+[[pack]]
+  name = "compound-engineering"
+  description = "Every Inc.'s Compound Engineering methodology as a Gas City build factory, with the widest reviewer-persona fanout in the catalog."
+  source = "https://github.com/gastownhall/gascity-packs/tree/main/compound-engineering"
+  source_kind = "git"
+
+  [[pack.release]]
+    version = "0.1.0"
+    ref = "main"
+    commit = "636fdfaaf54195b293e8e56d5e9c30e4b8d5a9ef"
+    hash = "sha256:7981abfa28021a99accacc097d32a04e2d28c344f09ebf17e3f0ca51768140af"
+    description = "First registry release of the Compound Engineering build factory."
+
+[[pack]]
+  name = "gstack"
+  description = "garrytan/gstack founder sprint (office hours, autoplan, QA, security, release readiness) as a Gas City build factory."
+  source = "https://github.com/gastownhall/gascity-packs/tree/main/gstack"
+  source_kind = "git"
+
+  [[pack.release]]
+    version = "0.1.0"
+    ref = "main"
+    commit = "636fdfaaf54195b293e8e56d5e9c30e4b8d5a9ef"
+    hash = "sha256:4f180f1327933239a29918e661c0cd3a54ff3de84ab981324665e776de2eff8f"
+    description = "First registry release of the gstack build factory."
+
+[[pack]]
+  name = "superpowers"
+  description = "obra/superpowers TDD-first skill library as a Gas City build factory."
+  source = "https://github.com/gastownhall/gascity-packs/tree/main/superpowers"
+  source_kind = "git"
+
+  [[pack.release]]
+    version = "0.1.0"
+    ref = "main"
+    commit = "636fdfaaf54195b293e8e56d5e9c30e4b8d5a9ef"
+    hash = "sha256:ba0428bf51627bf465a693f2426cf6be0cef70ae81b043fce3ce6761a4772290"
+    description = "First registry release of the superpowers build factory."


### PR DESCRIPTION
## Why

These four have lived in the repo and carry the **most expensive first-party test investment we have** — they're the only packs in the nightly model-backed inference gate alongside `gascity` and `gastown` — yet none had a `registry.toml` entry, so the registry couldn't see them at all. Publishing at `0.1.0`, matching the version each `pack.toml` already declares. Catalog goes **11 → 15 packs**, the maintained roster.

## How

Minted via the documented maintainer flow (`make registry-publish` → `gc pack release stamp` → `registry_release.py set-source`), so format and provenance match every existing entry — no hand-pasted blocks.

## Verification

- `gc` computed each content hash and **`validate_registry.py` independently recomputed and matched** it (two implementations agreeing).
- **Tampering each of the four hashes is caught** → these entries are genuinely verified, not skipped.
- `registry.toml: ok` with and without `--require-git`; suite **101 passed, 7 skipped**.
- Confirmed empirically that the live **`[imports.gc] source = "../gascity"`** resolves for a consumer: registry install clones the whole repo at the pinned commit and strips the subpath from the cache key, so `bmad/` and `gascity/` land as siblings in one clone. The README's `gc import add …git//bmad` path is the *same* mechanism, not a divergent one. (These are the first published packs with a live relative import, so this needed proving rather than assuming.)

## Known gap — pre-existing, not introduced here

`gc import add` resolves versions from **repo-wide semver tags**, and the latest tag `v0.3.0` predates these packs. It also predates the **already-published `pr-pipeline` and `contributing`**. So until a tag containing them is cut, the documented no-version install fails for all six and only `--version sha:<commit>` works.

That's a live pre-existing bug in the release process, tracked separately. Publishing these entries makes the packs discoverable and regresses nothing — but the tag is what actually completes delivery for all six.

🤖 Generated with [Claude Code](https://claude.com/claude-code)