### PR TITLE
fix(gastown): require a recorded reason before a polecat blocks work

### DIFF
--- a/gastown/agents/polecat/prompt.template.md
+++ b/gastown/agents/polecat/prompt.template.md
@@ -341,7 +341,145 @@ gc mail send "$WITNESS_TARGET" -s "ESCALATION: Brief description [HIGH]" -m "Det
 gc mail send mayor/ -s "BLOCKED: <topic>" -m "Context"
 ```
 
-After escalating: continue if possible, otherwise `gc bd update <bead> --status=escalated && gc runtime drain-ack && exit`.
+After escalating: continue if possible, otherwise stop through the Blocked
+Work Contract below. **Never** hand-write `gc bd update <bead>
+--status=blocked` or `--status=escalated`. A bare status flip is the exact
+defect this contract exists to prevent.
+
+### Blocked Work Contract (fail-closed — the ONLY way to stop on a bead)
+
+A bead you leave `blocked` (or `escalated`) with no recorded reason is
+indistinguishable from a crashed session. The next human or agent has to
+re-derive your entire investigation from nothing, and — because the bead is
+still routed and still claimed — the pool keeps counting it as demand while
+the claim path refuses to hand it out, respawning workers in a loop.
+
+This mirrors the refinery's rejection contract exactly: the durable record
+lives in bead metadata, not in your session transcript.
+
+| Metadata key | Set by | Value |
+|---|---|---|
+| `blocked_reason` | polecat (on block) | Free text: what blocked you AND what would unblock it |
+| `blocked_disposition` | polecat (on block) | One kebab-case token naming the required unblock, e.g. `upstream-dependency-required`, `credentials-required`, `human-decision-required`, `target-platform-validation-required` |
+| `blocked_by` | polecat (on block) | The session identity that blocked it |
+| `gc.routed_to` | polecat (on block) | `human` — a blocked bead must leave the polecat pool |
+
+Run this as ONE Bash command. It records the reason **first**, reads it back,
+and only then flips status and releases the claim. If the reason cannot be
+persisted, it refuses to change status at all: a stale `in_progress` claim is
+recoverable by the witness, a silent `blocked` bead is not.
+
+```bash
+export BLOCKED_BEAD="<the id printed as CLAIMED_BEAD_ID>"
+export BLOCKED_REASON="<what blocked you and what would unblock it — specific, mechanical, no placeholders>"
+export BLOCKED_DISPOSITION="<one kebab-case token: what must happen to unblock>"
+export BLOCKED_STATUS="blocked"   # or "escalated"
+bash <<'GC_BLOCKED'
+# BEGIN POLECAT_BLOCKED_CONTRACT
+set +e
+
+BLOCKED_ACTOR="${BEADS_ACTOR:-${GC_SESSION_NAME:-${GC_SESSION_ID:-${GC_AGENT:-}}}}"
+WITNESS_TARGET="${GC_RIG:+$GC_RIG/}{{ .BindingPrefix }}witness"
+STATUS="${BLOCKED_STATUS:-blocked}"
+
+# --- 0. Refuse before touching the bead. A refusal must mutate nothing. ---
+if [ -z "$BLOCKED_BEAD" ]; then
+  echo "BLOCK_REFUSED no bead id supplied; refusing to touch any bead"
+  exit 2
+fi
+if [ "$STATUS" != "blocked" ] && [ "$STATUS" != "escalated" ]; then
+  echo "BLOCK_REFUSED $BLOCKED_BEAD: BLOCKED_STATUS must be 'blocked' or 'escalated', got '$STATUS'"
+  exit 2
+fi
+REASON="$(printf '%s' "${BLOCKED_REASON:-}" | tr '\n\t' '  ' | tr -s ' ' | sed -e 's/^ *//' -e 's/ *$//')"
+DISPOSITION="$(printf '%s' "${BLOCKED_DISPOSITION:-}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
+case "$(printf '%s' "$REASON" | tr '[:upper:]' '[:lower:]')" in
+  ''|blocked|stuck|unknown|n/a|na|tbd|todo|'see notes'|'see above'|'no reason'|"<what blocked you"*)
+    echo "BLOCK_REFUSED $BLOCKED_BEAD: blocked_reason is empty or a placeholder. State what blocked you and what would unblock it. Bead NOT modified."
+    exit 2
+    ;;
+esac
+if [ "${#REASON}" -lt 24 ]; then
+  echo "BLOCK_REFUSED $BLOCKED_BEAD: blocked_reason must describe what blocked you and what would unblock it (got ${#REASON} chars). Bead NOT modified."
+  exit 2
+fi
+case "$DISPOSITION" in
+  ''|blocked|stuck|unknown|n/a|na|tbd|todo)
+    echo "BLOCK_REFUSED $BLOCKED_BEAD: blocked_disposition must be a kebab-case token naming what would unblock the work (e.g. upstream-dependency-required). Bead NOT modified."
+    exit 2
+    ;;
+esac
+
+# --- 1. Record the reason FIRST and read it back. No reason, no block. ---
+gc bd update "$BLOCKED_BEAD" \
+  --set-metadata blocked_reason="$REASON" \
+  --set-metadata blocked_disposition="$DISPOSITION" \
+  --set-metadata blocked_by="${BLOCKED_ACTOR:-unknown}" \
+  --notes "BLOCKED ($DISPOSITION): $REASON"
+REASON_CODE=$?
+VERIFY_JSON="$(gc bd show "$BLOCKED_BEAD" --json 2>/dev/null)"
+VERIFY_REASON="$(printf '%s' "$VERIFY_JSON" | jq -r '.[0].metadata.blocked_reason // empty' 2>/dev/null)"
+VERIFY_DISPOSITION="$(printf '%s' "$VERIFY_JSON" | jq -r '.[0].metadata.blocked_disposition // empty' 2>/dev/null)"
+if [ "$REASON_CODE" -ne 0 ] || [ "$VERIFY_REASON" != "$REASON" ] || [ "$VERIFY_DISPOSITION" != "$DISPOSITION" ]; then
+  # FAIL CLOSED. Leave the bead in_progress and claimed: a stale claim is
+  # visible to the witness stale/stuck-polecat path, a silently blocked bead
+  # is not. Do NOT drain-ack — that would report idle and hide the outage.
+  echo "BLOCK_ABORTED $BLOCKED_BEAD reason metadata did not persist (update exit=$REASON_CODE, read back reason='${VERIFY_REASON:-empty}' disposition='${VERIFY_DISPOSITION:-empty}'); status NOT changed and claim NOT released"
+  gc mail send "$WITNESS_TARGET" -s "ESCALATION: cannot record blocked_reason on $BLOCKED_BEAD [HIGH]" \
+    -m "Polecat $BLOCKED_ACTOR needed to stop on $BLOCKED_BEAD but could not persist blocked_reason (gc bd update exit=$REASON_CODE; read-back reason='${VERIFY_REASON:-empty}'). Refused to set status=$STATUS, so the bead is NOT silently blocked. It remains in_progress and claimed by this session. Intended reason: $REASON (disposition: $DISPOSITION)"
+  exit 1
+fi
+
+# --- 2. Only now: flip status, release the claim, leave the polecat pool. ---
+gc bd update "$BLOCKED_BEAD" \
+  --status="$STATUS" \
+  --assignee="" \
+  --set-metadata gc.routed_to=human
+STATUS_CODE=$?
+FINAL_JSON="$(gc bd show "$BLOCKED_BEAD" --json 2>/dev/null)"
+FINAL_STATUS="$(printf '%s' "$FINAL_JSON" | jq -r '.[0].status // empty' 2>/dev/null)"
+FINAL_REASON="$(printf '%s' "$FINAL_JSON" | jq -r '.[0].metadata.blocked_reason // empty' 2>/dev/null)"
+if [ "$STATUS_CODE" -ne 0 ] || [ "$FINAL_STATUS" != "$STATUS" ] || [ -z "$FINAL_REASON" ]; then
+  echo "BLOCK_ABORTED $BLOCKED_BEAD status transition failed (exit=$STATUS_CODE status='${FINAL_STATUS:-unavailable}' reason='${FINAL_REASON:-empty}'); the reason IS recorded on the bead"
+  gc mail send "$WITNESS_TARGET" -s "ESCALATION: blocked transition failed on $BLOCKED_BEAD [HIGH]" \
+    -m "Polecat $BLOCKED_ACTOR recorded blocked_reason on $BLOCKED_BEAD but the status/release update failed (exit=$STATUS_CODE, status now '${FINAL_STATUS:-unavailable}'). Reason: $REASON (disposition: $DISPOSITION)"
+  exit 1
+fi
+
+echo "BLOCKED_RECORDED $BLOCKED_BEAD status=$STATUS disposition=$DISPOSITION"
+gc mail send "$WITNESS_TARGET" -s "BLOCKED: $BLOCKED_BEAD needs $DISPOSITION [HIGH]" \
+  -m "$REASON
+
+Bead: $BLOCKED_BEAD
+Status: $STATUS
+Disposition: $DISPOSITION
+Blocked by: $BLOCKED_ACTOR
+Claim released and gc.routed_to=human, so the polecat pool will not respawn on this bead."
+gc runtime drain-ack
+exit 1
+# END POLECAT_BLOCKED_CONTRACT
+GC_BLOCKED
+```
+
+Outcomes:
+
+- `BLOCK_REFUSED` — your reason or disposition was missing/placeholder. The
+  bead was **not** modified. Write a real reason and re-run; do not work
+  around the gate with a bare `gc bd update`.
+- `BLOCK_ABORTED` — the reason could not be persisted. The bead was
+  deliberately left claimed and `in_progress` rather than silently blocked.
+  The witness has been escalated. End your turn; do not drain-ack.
+- `BLOCKED_RECORDED` — done. The bead carries the reason, the claim is
+  released, the bead is routed to `human`, and the session has drain-acked.
+  Stop.
+
+**Why the claim is released.** A blocked bead held by a session that is about
+to exit can never be progressed by that session. Holding the assignee hides
+the bead from the pool and from witness orphan classification, while
+`gc.routed_to` still advertises it as polecat demand. That combination —
+unclaimable status plus live route — is what respawns a worker every 20–40
+seconds. Releasing to `gc.routed_to=human` is the same disposal the refinery
+already performs when it blocks a bead.
 
 ---
 

--- a/gastown/formulas/mol-polecat-work.toml
+++ b/gastown/formulas/mol-polecat-work.toml
@@ -39,9 +39,36 @@ refinery. Resume the existing branch — don't redo all the work.
 | Situation | Action |
 |-----------|--------|
 | Tests fail | Fix them. Do not proceed with failures. |
-| Blocked on external | Mail Witness, mark yourself stuck |
+| Blocked on external | Run the Blocked Work Contract below — never a bare status flip |
 | Context filling | `gc runtime request-restart` (blocks until controller kills you) |
-| Unsure what to do | Mail Witness, don't guess |"""
+| Unsure what to do | Mail Witness, don't guess |
+
+## Blocked Work Contract
+
+**A polecat may not leave a bead `blocked` (or `escalated`) without a durable,
+structured reason on the bead.** This mirrors the refinery's rejection
+contract: the refinery never rejects work without writing
+`metadata.rejection_reason`, and a polecat must never block work without
+writing `metadata.blocked_reason`.
+
+Required on any block, in this order:
+
+1. `--set-metadata blocked_reason="<what blocked you AND what would unblock it>"`
+2. `--set-metadata blocked_disposition="<kebab-case token naming the required unblock>"`
+3. `--set-metadata blocked_by="<your session identity>"` and a matching `--notes`
+4. Read the metadata back. If it did not persist, **do not change status** —
+   leave the bead `in_progress` and claimed, escalate to the witness, and stop.
+5. Only after read-back succeeds: `--status=<blocked|escalated> --assignee=""
+   --set-metadata gc.routed_to=human`, then `gc runtime drain-ack`.
+
+Never run `gc bd update <bead> --status=blocked` on its own. Status first
+means a silently blocked bead if the reason write fails, and a blocked bead
+that is still claimed and still routed to the polecat pool respawns workers
+in a loop while refusing to hand the bead out.
+
+The polecat prompt's **Blocked Work Contract** section carries the executable
+`GC_BLOCKED` block that implements all five requirements. Run that block; do
+not reimplement it."""
 formula = "mol-polecat-work"
 extends = ["mol-polecat-base"]
 

--- a/gastown/tests/test_polecat_blocked_reason.sh
+++ b/gastown/tests/test_polecat_blocked_reason.sh
@@ -1,0 +1,291 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Regression suite for the polecat Blocked Work Contract.
+#
+# Reproduction: ki-0aq and ki-gu2 were both left `blocked` with no recorded
+# reason. Each read as a crashed session — the next agent had to re-derive the
+# whole investigation from nothing — and because the beads stayed claimed while
+# still routed to the polecat pool, the pool respawned workers on work it then
+# refused to hand out. The fix is a fail-closed contract: record the reason,
+# read it back, and only then flip status and release the claim.
+#
+# The contract ships as an executable block inside the polecat prompt, so this
+# suite extracts the shipped block and runs it against a hermetic `gc` stub
+# rather than asserting on prose.
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+GASTOWN="$ROOT/gastown"
+PROMPT="$GASTOWN/agents/polecat/prompt.template.md"
+FORMULA="$GASTOWN/formulas/mol-polecat-work.toml"
+
+BLOCKED_BEAD_REASON="ki-0aq needs the ki-vxc bounded-asset-read landing before SP int truncation can be removed"
+BLOCKED_BEAD_DISPOSITION="upstream-dependency-required"
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+extract_blocked_contract() {
+    local output=$1
+    python3 - "$PROMPT" "$output" <<'PY'
+import pathlib
+import sys
+
+prompt_path = pathlib.Path(sys.argv[1])
+output_path = pathlib.Path(sys.argv[2])
+text = prompt_path.read_text(encoding="utf-8")
+if "bash <<'GC_BLOCKED'\n" not in text:
+    sys.exit("polecat prompt lost the executable GC_BLOCKED contract block")
+try:
+    begin = text.index("# BEGIN POLECAT_BLOCKED_CONTRACT")
+    end = text.index("# END POLECAT_BLOCKED_CONTRACT", begin)
+except ValueError:
+    sys.exit("blocked-work contract must stay an extractable, testable block")
+block = text[begin:end].splitlines()[1:]
+rendered = "\n".join(block).replace("{{ .BindingPrefix }}", "gastown.")
+output_path.write_text(rendered + "\n", encoding="utf-8")
+PY
+}
+
+# Hermetic stand-in for the real CLI. It dispatches on argv positions and never
+# spells out a bare "<beads-cli> <subcommand>" string: tests/test_no_bare_bd_commands.py
+# rejects that spelling anywhere in tracked assets, fixtures included.
+#
+# GC_TEST_SCENARIO=reason_lost models a store that accepts the metadata write
+# and does not persist it, so the block cannot trust its own update's exit code.
+write_gc_stub() {
+    cat >"$FAKE_BIN/gc" <<'SH'
+#!/bin/sh
+printf '%s\n' "$*" >>"$GC_TEST_CALLS"
+REASON_JSON='"blocked_reason":"'"$GC_TEST_REASON"'","blocked_disposition":"'"$GC_TEST_DISPOSITION"'"'
+if [ "$1" != "bd" ]; then
+    case "$1" in
+      mail|runtime) exit 0 ;;
+      *) printf 'unexpected command: %s\n' "$*" >&2; exit 97 ;;
+    esac
+fi
+case "$2" in
+  update) exit 0 ;;
+  show)
+    if [ "${GC_TEST_SCENARIO:-}" = "reason_lost" ]; then
+      printf '%s\n' '[{"id":"'"$GC_TEST_BEAD"'","status":"in_progress","assignee":"kisakcod/gastown.cheedo","metadata":{}}]'
+    elif grep -q -- '--status=blocked' "$GC_TEST_CALLS"; then
+      printf '%s\n' '[{"id":"'"$GC_TEST_BEAD"'","status":"blocked","assignee":"","metadata":{'"$REASON_JSON"'}}]'
+    else
+      printf '%s\n' '[{"id":"'"$GC_TEST_BEAD"'","status":"in_progress","assignee":"kisakcod/gastown.cheedo","metadata":{'"$REASON_JSON"'}}]'
+    fi
+    ;;
+  *) printf 'unexpected command: %s\n' "$*" >&2; exit 97 ;;
+esac
+SH
+    chmod +x "$FAKE_BIN/gc"
+}
+
+setup_case() {
+    TMP=$(mktemp -d)
+    FAKE_BIN="$TMP/bin"
+    BLOCK="$TMP/block.sh"
+    CALLS="$TMP/calls"
+    mkdir -p "$FAKE_BIN"
+    : >"$CALLS"
+    extract_blocked_contract "$BLOCK"
+    write_gc_stub
+}
+
+# Runs the shipped block exactly as a polecat would: as its own bash process,
+# with only the documented BLOCKED_* environment. Sets CODE and OUTPUT.
+run_block() {
+    local bead=$1 reason=$2 disposition=$3 scenario=${4:-}
+    CODE=0
+    set +e
+    OUTPUT="$(
+        PATH="$FAKE_BIN:$PATH" \
+        GC_TEST_CALLS="$CALLS" \
+        GC_TEST_SCENARIO="$scenario" \
+        GC_TEST_BEAD="$bead" \
+        GC_TEST_REASON="$reason" \
+        GC_TEST_DISPOSITION="$disposition" \
+        GC_RIG="kisakcod" BEADS_ACTOR="kisakcod/gastown.cheedo" \
+        BLOCKED_BEAD="$bead" \
+        BLOCKED_REASON="$reason" \
+        BLOCKED_DISPOSITION="$disposition" \
+        bash "$BLOCK" 2>&1
+    )"
+    CODE=$?
+    set -e
+}
+
+# The contract must exist and must be the only sanctioned stop path.
+test_blocked_work_contract_is_documented() {
+    grep -F 'Blocked Work Contract' "$PROMPT" >/dev/null ||
+        fail "polecat prompt must document a Blocked Work Contract"
+    grep -F 'blocked_reason' "$PROMPT" >/dev/null ||
+        fail "polecat prompt must require blocked_reason metadata when blocking"
+    grep -F 'blocked_disposition' "$PROMPT" >/dev/null ||
+        fail "polecat prompt must require a blocked_disposition token when blocking"
+    grep -F 'Blocked Work Contract' "$FORMULA" >/dev/null ||
+        fail "mol-polecat-work must carry the Blocked Work Contract"
+    grep -F 'blocked_reason' "$FORMULA" >/dev/null ||
+        fail "mol-polecat-work must require blocked_reason metadata when blocking"
+    ! grep -F 'mark yourself stuck' "$FORMULA" >/dev/null ||
+        fail "mol-polecat-work must not tell a polecat to 'mark yourself stuck' with no reason contract"
+
+    python3 - "$FORMULA" <<'PY'
+import sys
+import tomllib
+
+with open(sys.argv[1], "rb") as handle:
+    tomllib.load(handle)
+PY
+}
+
+# Every runnable blocked/escalated status flip must live inside the contract
+# block, after the reason has been written and read back.
+test_bare_status_flip_is_not_copyable_from_any_shipped_snippet() {
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+
+    python3 - "$PROMPT" "$FORMULA" "$BLOCK" <<'PY'
+import sys
+
+text = open(sys.argv[1], encoding="utf-8").read()
+formula = open(sys.argv[2], encoding="utf-8").read()
+block = open(sys.argv[3], encoding="utf-8").read()
+
+# Any other fenced shell snippet an agent could copy verbatim must not offer a
+# bare status flip. Prose that forbids the bare flip is exactly the point.
+for source, label in ((text, "polecat prompt"), (formula, "mol-polecat-work")):
+    fenced = source.split("```")[1::2]
+    for snippet in fenced:
+        if "GC_BLOCKED" in snippet:
+            continue
+        if "--status=blocked" in snippet or "--status=escalated" in snippet:
+            raise SystemExit(
+                f"{label} offers a copyable bare blocked/escalated status flip outside GC_BLOCKED"
+            )
+
+for source, label in ((text, "polecat prompt"), (formula, "mol-polecat-work")):
+    if "--status=blocked" not in source:
+        raise SystemExit(f"{label} must name the bare status flip it forbids")
+
+reason_write = block.index("--set-metadata blocked_reason=")
+readback = block.index(".[0].metadata.blocked_reason")
+status_flip = block.index('--status="$STATUS"')
+if not reason_write < readback < status_flip:
+    raise SystemExit("GC_BLOCKED must write the reason, read it back, and only then flip status")
+for needle in ('--assignee=""', "--set-metadata gc.routed_to=human", "gc runtime drain-ack"):
+    if needle not in block:
+        raise SystemExit(f"GC_BLOCKED must release the claim and leave the pool: missing {needle}")
+PY
+}
+
+# The live defect: block with no reason at all. Must refuse, and must not touch
+# the bead, so no bead can end up blocked-and-silent.
+test_reasonless_block_is_refused_and_touches_nothing() {
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+
+    run_block "ki-0aq" "" ""
+    [[ "$CODE" -eq 2 ]] || fail "a blocked transition with no reason must be refused"
+    [[ "$OUTPUT" == *'BLOCK_REFUSED ki-0aq'* ]] ||
+        fail "a reasonless block must report BLOCK_REFUSED"
+    [[ ! -s "$CALLS" ]] ||
+        fail "a refused block must not issue any gc command: $(cat "$CALLS")"
+}
+
+# A placeholder reason is the same defect wearing a hat.
+test_placeholder_reason_is_refused_and_touches_nothing() {
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+
+    local placeholder
+    for placeholder in blocked stuck unknown n/a tbd; do
+        : >"$CALLS"
+        run_block "ki-gu2" "$placeholder" "unknown"
+        [[ "$CODE" -eq 2 ]] ||
+            fail "placeholder blocked_reason '$placeholder' must be refused"
+        [[ "$OUTPUT" == *'BLOCK_REFUSED ki-gu2'* ]] ||
+            fail "placeholder blocked_reason '$placeholder' must report BLOCK_REFUSED"
+        # Named as a placeholder, not merely short: a longer placeholder must
+        # not slip past a length check alone.
+        [[ "$OUTPUT" == *'is empty or a placeholder'* ]] ||
+            fail "blocked_reason '$placeholder' must be rejected as a placeholder, not incidentally"
+        [[ ! -s "$CALLS" ]] ||
+            fail "a refused block must not issue any gc command: $(cat "$CALLS")"
+    done
+
+    # A real reason paired with a placeholder disposition is refused too, and
+    # just as silently as far as the bead is concerned.
+    : >"$CALLS"
+    run_block "ki-gu2" "$BLOCKED_BEAD_REASON" "unknown"
+    [[ "$CODE" -eq 2 ]] || fail "a placeholder blocked_disposition must be refused"
+    [[ "$OUTPUT" == *'BLOCK_REFUSED ki-gu2'* ]] ||
+        fail "a placeholder blocked_disposition must report BLOCK_REFUSED"
+    [[ "$OUTPUT" == *'blocked_disposition must be a kebab-case token'* ]] ||
+        fail "a placeholder blocked_disposition must be named as the refusal cause"
+    [[ ! -s "$CALLS" ]] ||
+        fail "a refused block must not issue any gc command: $(cat "$CALLS")"
+}
+
+# Reason write silently does not persist: fail closed. Never flip status, never
+# release the claim, never drain-ack — escalate instead.
+test_unpersisted_reason_fails_closed_and_escalates_once() {
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+
+    run_block "ki-0aq" "$BLOCKED_BEAD_REASON" "$BLOCKED_BEAD_DISPOSITION" reason_lost
+    [[ "$CODE" -eq 1 ]] || fail "an unpersisted blocked_reason must fail closed with exit 1"
+    [[ "$OUTPUT" == *'BLOCK_ABORTED ki-0aq'* ]] ||
+        fail "an unpersisted blocked_reason must report BLOCK_ABORTED"
+    ! grep -F -- '--status=blocked' "$CALLS" >/dev/null ||
+        fail "status must never flip to blocked when the reason did not persist"
+    ! grep -F -- '--assignee=' "$CALLS" >/dev/null ||
+        fail "the claim must not be released when the reason did not persist"
+    ! grep -F 'runtime drain-ack' "$CALLS" >/dev/null ||
+        fail "a failed block must not drain-ack; that reports idle and hides it"
+    [[ "$(grep -c '^mail send ' "$CALLS")" -eq 1 ]] ||
+        fail "a failed block must send exactly one witness escalation"
+}
+
+# Happy path: reason recorded first, then the status flip and claim release in
+# one update.
+test_recorded_block_writes_the_reason_before_the_status_flip() {
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+
+    run_block "ki-0aq" "$BLOCKED_BEAD_REASON" "$BLOCKED_BEAD_DISPOSITION"
+    [[ "$CODE" -eq 1 ]] ||
+        fail "a recorded block mirrors the refinery: drain-ack then non-zero exit"
+    [[ "$OUTPUT" == *'BLOCKED_RECORDED ki-0aq'* ]] ||
+        fail "a recorded block must report BLOCKED_RECORDED"
+    grep -F -- '--set-metadata blocked_reason=' "$CALLS" >/dev/null ||
+        fail "a recorded block must write blocked_reason metadata"
+    grep -F -- '--set-metadata gc.routed_to=human' "$CALLS" >/dev/null ||
+        fail "a blocked bead must leave the polecat pool (gc.routed_to=human)"
+    grep -F 'runtime drain-ack' "$CALLS" >/dev/null ||
+        fail "a recorded block must drain-ack so the session is reaped"
+
+    python3 - "$CALLS" <<'PY'
+import sys
+
+calls = open(sys.argv[1], encoding="utf-8").read().splitlines()
+reason = next(i for i, c in enumerate(calls) if "--set-metadata blocked_reason=" in c)
+status = next(i for i, c in enumerate(calls) if "--status=blocked" in c)
+release = next(i for i, c in enumerate(calls) if "--assignee=" in c)
+if not reason < status:
+    raise SystemExit("blocked_reason must be written before the status flip")
+if status != release:
+    raise SystemExit("the status flip must release the claim in the same update")
+PY
+}
+
+test_blocked_work_contract_is_documented
+test_bare_status_flip_is_not_copyable_from_any_shipped_snippet
+test_reasonless_block_is_refused_and_touches_nothing
+test_placeholder_reason_is_refused_and_touches_nothing
+test_unpersisted_reason_fails_closed_and_escalates_once
+test_recorded_block_writes_the_reason_before_the_status_flip
+
+echo "polecat blocked-reason contract tests passed"


### PR DESCRIPTION
## Problem

A Gastown polecat could set a work bead to a terminal status with no reason recorded anywhere, while keeping the claim.

Observed live on 2026-07-24 ~16:45 EDT, minutes after routing seven beads and scaling a pool 1 → 8. Worker `gastown.cheedo` (`ac-nkk`) claimed `ki-0aq` ("ABI: SP int-truncation removal") and `ki-gu2` ("Integration hygiene: upstream re-audit"), set **both** to `status=blocked`, and kept both claims. It recorded nothing: empty `notes`, no metadata, no mail. A human had to guess why two ready, unblocked, polecat-sized beads had stopped.

The pack already had the answer to half of this.

The refinery never rejects work silently. It writes `metadata.rejection_reason`, and that record is what drives the normal refinery → polecat correction cycle — `mol-polecat-work`'s `workspace-setup` reads it, resumes the existing branch instead of redoing the work, and clears it. Its two block helpers go further: `blocked_reason` plus a structured result key, `--assignee=""`, and `gc.routed_to=human`. Real record from the affected city:

```
rejection_reason: "Acceptance unmet: candidate has no production route
                   call site; legacy db_load path remains the only path"
recovery.disposition: "production-wiring-rework-required"
```

The polecat had no equivalent. Its entire blocked-path guidance was one unactionable table row in `mol-polecat-work`:

```
| Blocked on external | Mail Witness, mark yourself stuck |
```

and one prompt line offering a bare `gc bd update <bead> --status=escalated`. **There is no `--status=blocked` anywhere in the polecat's assets** — the transition was completely unconstrained, so the agent invented it. `--status=escalated` is the documented sibling and has the same hole, so both tokens are covered here.

### Second-order effect (separate fix)

Because the beads stayed `gc.routed_to=<pool>` while being unclaimable, route discovery kept counting them as demand while the claim path kept refusing them. The controller respawned the worker every 20–40 seconds — spawn → prime → `gc hook --claim` returns nothing → drain-ack → respawn — reaching **15 provider starts and 3 `NO_ROUTED_WORK` in a 10-minute window** and still climbing.

Making route discovery skip non-claimable statuses is a Gas City core fix and is **not** in this PR. This is the pack-side boundary that stops a polecat from creating the state in the first place.

## Fix

A fail-closed **Blocked Work Contract**, mirroring the refinery's shape and reusing its existing `blocked_reason` key rather than inventing a parallel convention.

| Metadata key | Value |
|---|---|
| `blocked_reason` | Free text: what blocked you AND what would unblock it |
| `blocked_disposition` | Kebab-case token naming the required unblock, e.g. `upstream-dependency-required` |
| `blocked_by` | The session identity that blocked it |
| `gc.routed_to` | `human` — a blocked bead leaves the polecat pool |

The polecat prompt gains an executable `GC_BLOCKED` block that is the only sanctioned way to stop on a bead:

1. **Refuse before mutating.** An empty or placeholder reason/disposition (`blocked`, `stuck`, `unknown`, `n/a`, `tbd`), or a reason under 24 characters, prints `BLOCK_REFUSED` and exits 2 having issued **zero** `gc` commands. A refusal cannot leave a bead half-blocked.
2. **Reason first, then read it back.** Metadata and `--notes` are written, then re-read and compared.
3. **If the reason did not persist, do not block.** Print `BLOCK_ABORTED`, leave the bead `in_progress` and claimed, escalate once to the witness, exit non-zero, and do **not** drain-ack. A stale `in_progress` claim is visible to the witness stale/stuck-polecat path; a silently `blocked` bead is not. That is the direction the failure must fall.
4. **Only then** flip status, release the claim, and route to `human` in a single update; re-verify; mail the witness once; `drain-ack`; exit non-zero — the same terminal shape as the refinery's `block_existing_pr` and `halt_false_completion`.

`mol-polecat-work` replaces `mark yourself stuck` with a pointer to the contract and states the five requirements normatively. The executable block is not duplicated.

**Releasing the claim is deliberate.** A blocked bead held by a session that is about to exit can never be progressed by that session, and holding the assignee hides it from the pool and from witness orphan classification while `gc.routed_to` still advertises pool demand — precisely the combination that respawned `cheedo`. Releasing to `gc.routed_to=human` is the same disposal the refinery already performs, and it is what the operator did by hand to stop the live loop.

## Regression coverage

New standalone suite `gastown/tests/test_polecat_blocked_reason.sh` extracts the shipped `GC_BLOCKED` block from the prompt asset and executes it against a fake `gc`, modelling the production incident with the real bead IDs:

- `ki-0aq` with no reason at all — the live defect — must exit 2, print `BLOCK_REFUSED`, and issue **no `gc` command whatsoever**;
- `ki-gu2` with each of the five placeholder reasons must be refused the same way, asserting the *placeholder* refusal message so the list cannot be deleted and still pass on the length check alone;
- a reason write that silently does not persist must never flip status, never release the claim, never drain-ack, and must send exactly one witness escalation;
- the recorded path must write `blocked_reason` **strictly before** the status flip, release the claim in that same update, set `gc.routed_to=human`, and drain-ack;
- a fenced-snippet scan rejects any copyable bare `--status=blocked|escalated` outside `GC_BLOCKED`.

Mutation-tested: neutering the reason guard fails the suite with `a blocked transition with no reason must be refused`; neutering the read-back gate fails with `status must never flip to blocked when the reason did not persist`.

Deliberately a **new** suite file rather than an addition to `test_gastown_pack_assets.sh`, which is contested by #222, #171 and #227. Discovery is convention-based via the CI glob `for test_script in gastown/tests/test_*.sh`, so no registration edit exists to make.

## Validation

- Gastown shell suites: 4/4 pass
- `bash -n` over changed scripts and the extracted `GC_BLOCKED` block
- TOML parse: 15 gastown TOML files incl. `mol-polecat-work.toml`
- `python3 -m pytest -q`: 773 passed, 7 skipped, 9412 subtests
- `tests/test_no_bare_bd_commands.py`: 2 passed (the fake `gc` dispatches on argv positions, not literal `bd <subcommand>` strings)
- `gc lint gastown`: ok
- `git diff --check`: clean

## Composition with open PRs

Merges cleanly with **#221, #222, #226 and #227** (verified by `git merge --no-commit` against freshly fetched heads). The prompt edits are disjoint from #222, which rewrites the `GC_CLAIM` startup block ~50 lines above; the two share the same fail-closed posture (escalate, exit non-zero, never drain-ack a hidden failure). I deliberately stayed out of #227's regions — the new keys are documented in a self-contained table inside the Escalation section rather than added to the Work Bead Metadata Contract table or the Command Quick-Reference, both of which #227 rewrites. A trivial follow-up can hoist them once #227 lands.
