### PR TITLE
fix(gastown): wire real dependency edges from the planner

### DIFF
--- a/gastown/formulas/mol-idea-to-plan.toml
+++ b/gastown/formulas/mol-idea-to-plan.toml
@@ -13,7 +13,8 @@ have:
 - parallel dispatch via `gc sling ... --on mol-review-leg`
 - completion mail via `gc mail send`
 - one human clarification gate in the live conversation
-- final bead graph creation with `gc bd create` + `gc bd dep add`
+- final bead graph creation with `gc bd create` + `gc bd dep add`, wired from a
+  capability ledger that maps plan slugs to the bead IDs created in this run
 
 Run this from a coordinator workspace that has the target repo checked out
 (typically a crew worker, or a mayor who has already `cd`'d into the rig repo).
@@ -26,7 +27,7 @@ Run this from a coordinator workspace that has the target repo checked out
 4. Dispatch 6 design-exploration legs in parallel
 5. Run 3 PRD-alignment rounds (2 legs each)
 6. Run 3 plan self-review rounds (2 legs each)
-7. Convert the refined plan into beads with dependencies
+7. Convert the refined plan into beads and verified dependency edges
 
 The goal is parity of outcome, not a verbatim port of upstream's convoy DSL.
 """
@@ -427,6 +428,14 @@ needs = ["plan-review-3"]
 description = """
 Turn the final design doc into executable work.
 
+The deliverable of this step is a machine-readable graph, not a prose roadmap.
+Everything downstream of the planner reads **dependency edges**: `gc bd ready`
+computes readiness from them, `gc bd blocked` lists them, the refinery honours
+them, and the `cascade-nudge-on-blocker-close` order exists only to wake the
+dependents of a closed blocker. None of those readers parse labels, bead notes,
+or the design doc. An edge that was never written is a scheduling relationship
+that does not exist.
+
 **1. Read the final plan:**
 ```bash
 cat ".designs/$REVIEW_ID/design-doc.md"
@@ -452,26 +461,182 @@ Each task bead should include:
 - affected files or subsystems
 - acceptance criteria
 - notes copied from the design doc
+- exactly one `capability:<slug>` label naming the capability this slice
+  delivers, in kebab-case, for example `--labels capability:abi-widening`
 
-Prefer thin vertical slices over giant phases.
+Prefer thin vertical slices over giant phases. Several slices may share one
+capability slug when the capability only exists once every one of them lands.
+
+**Never encode a blocking relationship as a label.** `blocked-on:<slug>` is a
+human-readable string, and a slug is not a bead ID. `gc bd ready` computes
+readiness from dependency edges, so a bead whose only blocker is a label is
+reported as ready while it is genuinely blocked, and
+`cascade-nudge-on-blocker-close` has nothing to fire on when the blocker
+closes. A label describes what a bead *is*; only an edge describes what it
+*waits for*.
 
 After creating the task beads, add them to the convoy with:
 ```bash
 gc convoy add <convoy-id> <task-id>
 ```
 
-**4. Wire dependencies with `gc bd dep add`:**
-Model the actual "X needs Y" relationships. Verify with:
-```bash
-gc bd blocked
+`gc convoy add` writes a `tracks` edge, which is membership and reporting only.
+`tracks` never blocks, so convoy membership is not a substitute for step 5.
+
+**4. Record the capability ledger as you create each bead:**
+The design doc names blockers by capability slug, but `gc bd dep add` only
+accepts bead IDs, so the slug-to-ID mapping has to be written down at the one
+moment it is known: when the IDs come back from `gc bd create`. Append one row
+per created task bead to `.plan-reviews/$REVIEW_ID/plan-ledger.tsv` with three
+whitespace-separated columns:
+
+```
+<bead-id>  <capability-this-bead-delivers>  <capability slugs this bead waits for, comma separated, or - for none>
 ```
 
-**5. Record the created bead IDs in:**
+Example:
+```
+ki-a01  abi-widening         -
+ki-a02  abi-widening         -
+ki-a03  abi-widening         -
+ki-b01  bounded-asset-reads  -
+ki-c01  cache-rewrite        abi-widening,bounded-asset-reads
+```
+
+Every blocker slug in column 3 must appear in column 2 of this same file. A
+slug that names work outside this plan is not something the planner can wire;
+either give it its own bead in this plan or drop the claim.
+
+**5. Wire real dependency edges from the ledger:**
+Run this from the repo root. It resolves each blocker slug to every bead that
+delivers it, adds the `blocks` edges, and reads each one back. It is
+idempotent, so rerun it after a partial or restarted planning run.
+
+```bash
+# BEGIN PLAN_DEPENDENCY_WIRING
+# Converts the capability ledger into real `blocks` dependency edges.
+# Reads:  $PLAN_LEDGER (default .plan-reviews/$REVIEW_ID/plan-ledger.tsv)
+# Writes: one verified `gc bd dep add` per (dependent, provider) pair.
+# Fails closed: a malformed row, an unresolvable slug, a failed add, an edge
+# that does not read back, or a surviving `blocked-on:` label aborts with
+# PLAN_DEP_WIRING_FAILURE and a nonzero return. A label is never an acceptable
+# substitute for an edge, and a partially wired graph is never reported as done.
+PLAN_LEDGER="${PLAN_LEDGER:-.plan-reviews/$REVIEW_ID/plan-ledger.tsv}"
+
+plan_dep_stop() {
+    echo "PLAN_DEP_WIRING_FAILURE: $*" >&2
+    return 1
+}
+
+plan_dep_rows() {
+    awk 'NF > 0 && $1 !~ /^#/ { print $1, $2, $3 }' "$PLAN_LEDGER"
+}
+
+plan_dep_providers() {
+    awk -v want="$1" 'NF > 0 && $1 !~ /^#/ && $2 == want { print $1 }' "$PLAN_LEDGER"
+}
+
+plan_dep_edge_exists() {
+    gc bd dep list "$1" --type blocks --json 2>/dev/null |
+        jq -e --arg blocker "$2" '
+            [ .[]? | (.depends_on_id // .target_id // .id) ] | index($blocker) != null
+        ' >/dev/null 2>&1
+}
+
+plan_dep_blocked_on_labels() {
+    gc bd show "$1" --json 2>/dev/null |
+        jq -r 'if type == "array" then (.[0] // {}) else . end | (.labels // [])[]' 2>/dev/null |
+        grep '^blocked-on:' || true
+}
+
+wire_plan_dependencies() {
+    local bead capability blockers slug providers provider rows edges leaked
+    edges=0
+    leaked=""
+
+    if [ ! -s "$PLAN_LEDGER" ]; then
+        plan_dep_stop "ledger $PLAN_LEDGER is missing or empty; step 4 never ran"
+        return 1
+    fi
+    if awk 'NF > 0 && $1 !~ /^#/ && NF != 3 { bad = 1 } END { exit !bad }' "$PLAN_LEDGER"; then
+        plan_dep_stop "every ledger row needs 3 columns: <bead-id> <capability> <blockers|->"
+        return 1
+    fi
+    if awk 'NF > 0 && $1 !~ /^#/ && ($1 !~ /^[A-Za-z0-9_-]+$/ || $2 !~ /^[A-Za-z0-9_-]+$/ || $3 !~ /^[A-Za-z0-9_,-]+$/) { bad = 1 } END { exit !bad }' "$PLAN_LEDGER"; then
+        plan_dep_stop "ledger IDs and slugs must match [A-Za-z0-9_-]; refusing to shell out unvalidated names"
+        return 1
+    fi
+
+    rows=$(plan_dep_rows)
+    while read -r bead capability blockers; do
+        [ -n "$bead" ] || continue
+        [ "$blockers" != "-" ] || continue
+        for slug in $(echo "$blockers" | tr ',' ' '); do
+            [ -n "$slug" ] || continue
+            if [ "$slug" = "$capability" ]; then
+                plan_dep_stop "$bead cannot wait on its own capability '$slug'"
+                return 1
+            fi
+            providers=$(plan_dep_providers "$slug")
+            if [ -z "$providers" ]; then
+                plan_dep_stop "$bead waits on '$slug' but no ledger bead delivers it"
+                return 1
+            fi
+            for provider in $providers; do
+                [ "$provider" != "$bead" ] || continue
+                if ! plan_dep_edge_exists "$bead" "$provider"; then
+                    if ! gc bd dep add "$bead" "$provider"; then
+                        plan_dep_stop "gc bd dep add $bead $provider failed"
+                        return 1
+                    fi
+                fi
+                if ! plan_dep_edge_exists "$bead" "$provider"; then
+                    plan_dep_stop "edge $bead -> $provider did not read back as a blocks dependency"
+                    return 1
+                fi
+                edges=$((edges + 1))
+            done
+        done
+    done <<< "$rows"
+
+    for bead in $(echo "$rows" | awk 'NF > 0 { print $1 }'); do
+        if [ -n "$(plan_dep_blocked_on_labels "$bead")" ]; then
+            leaked="$leaked $bead"
+        fi
+    done
+    if [ -n "$leaked" ]; then
+        plan_dep_stop "blocked-on: labels are not dependencies; replace them with edges on:$leaked"
+        return 1
+    fi
+
+    echo "PLAN_DEP_WIRING_OK edges=$edges"
+}
+
+wire_plan_dependencies
+# END PLAN_DEPENDENCY_WIRING
+```
+
+A slug that several beads deliver fans out to one edge per delivering bead, so
+the dependent unblocks exactly when the last piece of that capability closes.
+
+**6. Verify the graph, not the prose:**
+```bash
+gc bd blocked
+gc bd ready
+```
+Every bead that column 3 of the ledger gave a blocker to must appear under
+`gc bd blocked` and must NOT appear under `gc bd ready`. `gc bd blocked` on a
+graph with zero edges prints nothing and exits 0, so an empty result is only
+correct when the ledger's column 3 is entirely `-`. If a bead with blockers
+shows up as ready, the edge is missing: stop and fix it before reporting.
+
+**7. Record the created bead IDs in:**
 `.plan-reviews/$REVIEW_ID/beads-created.md`
 
-**6. Finish by telling the human:**
+**8. Finish by telling the human:**
 - which convoy/task beads were created
 - where the artifacts live
+- the `PLAN_DEP_WIRING_OK edges=<n>` count from step 5
 - which bead should be dispatched first
 
 The final output of this workflow is a reviewed plan plus a beads DAG, not code.

--- a/gastown/tests/test_idea_to_plan_dependencies.sh
+++ b/gastown/tests/test_idea_to_plan_dependencies.sh
@@ -1,0 +1,287 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+GASTOWN="$ROOT/gastown"
+FORMULA="$GASTOWN/formulas/mol-idea-to-plan.toml"
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+extract_wiring_block() {
+    local output=$1
+    python3 - "$FORMULA" "$output" <<'PY'
+import pathlib
+import sys
+import tomllib
+
+formula_path = pathlib.Path(sys.argv[1])
+output_path = pathlib.Path(sys.argv[2])
+with formula_path.open("rb") as handle:
+    formula = tomllib.load(handle)
+step = next(step for step in formula["steps"] if step["id"] == "create-beads")
+description = step["description"]
+try:
+    begin = description.index("# BEGIN PLAN_DEPENDENCY_WIRING")
+    end = description.index("# END PLAN_DEPENDENCY_WIRING", begin)
+except ValueError:
+    sys.exit("create-beads has no PLAN_DEPENDENCY_WIRING block; dependencies are unwired")
+block = description[begin:end].splitlines()[1:]
+output_path.write_text("\n".join(block) + "\n", encoding="utf-8")
+PY
+}
+
+# Minimal bead store: EDGES records `<dependent> <blocker>` pairs written by
+# `gc bd dep add`, LABELS records `<bead> <label>` pairs read by `gc bd show`.
+# Everything the wiring block observes has to come back through gc, so a step
+# that only wrote a label cannot make the store report an edge.
+write_gc_stub() {
+    gc() {
+        printf 'gc %s\n' "$*" >>"$CALLS"
+        [[ "${1:-}" == "bd" ]] || return 1
+        shift
+        case "${1:-} ${2:-}" in
+            "dep add")
+                [[ "${DEP_ADD_FAILS:-0}" != "1" ]] || return 1
+                # DEP_ADD_SILENT models a store that accepts the write and does
+                # not persist the edge; the block must not trust its own add.
+                [[ "${DEP_ADD_SILENT:-0}" == "1" ]] || printf '%s %s\n' "$3" "$4" >>"$EDGES"
+                return 0
+                ;;
+            "dep list")
+                awk -v id="$3" '$1 == id { print $2 }' "$EDGES" |
+                    jq -R -s 'split("\n") | map(select(length > 0) | {id: ., dependency_type: "blocks"})'
+                return 0
+                ;;
+            "show "*)
+                awk -v id="$2" '$1 == id { print $2 }' "$LABELS" |
+                    jq -R -s --arg id "$2" \
+                        '[{id: $id, labels: (split("\n") | map(select(length > 0)))}]'
+                return 0
+                ;;
+        esac
+        return 1
+    }
+}
+
+run_wiring() {
+    local status=0
+    (
+        set +e
+        write_gc_stub
+        # shellcheck source=/dev/null
+        source "$BLOCK"
+    ) >"$OUT" 2>"$ERR" || status=$?
+    return "$status"
+}
+
+setup_case() {
+    TMP=$(mktemp -d)
+    BLOCK="$TMP/wiring.sh"
+    CALLS="$TMP/calls"
+    EDGES="$TMP/edges"
+    LABELS="$TMP/labels"
+    OUT="$TMP/out"
+    ERR="$TMP/err"
+    PLAN_LEDGER="$TMP/plan-ledger.tsv"
+    REVIEW_ID="regression"
+    export PLAN_LEDGER REVIEW_ID
+    unset DEP_ADD_FAILS DEP_ADD_SILENT || true
+    : >"$CALLS"
+    : >"$EDGES"
+    : >"$LABELS"
+    extract_wiring_block "$BLOCK"
+}
+
+# The headline regression: a plan that says "cache-rewrite waits on
+# bounded-asset-reads" must end with a real dep edge in the store. A
+# `blocked-on:` label satisfies nothing here, because the assertion reads the
+# edge store, not the ledger.
+test_blocking_relationship_becomes_a_real_dep_edge() {
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+    cat >"$PLAN_LEDGER" <<'LEDGER'
+ki-vxc bounded-asset-reads -
+ki-msb cache-rewrite bounded-asset-reads
+LEDGER
+
+    run_wiring || fail "wiring block failed on a well-formed single-blocker plan: $(cat "$ERR")"
+
+    grep -Fx 'gc bd dep add ki-msb ki-vxc' "$CALLS" >/dev/null ||
+        fail "a blocking relationship did not produce gc bd dep add <dependent> <blocker>"
+    grep -Fx 'ki-msb ki-vxc' "$EDGES" >/dev/null ||
+        fail "no blocks edge was persisted for the blocked bead"
+    grep -F 'PLAN_DEP_WIRING_OK edges=1' "$OUT" >/dev/null ||
+        fail "wiring block did not report the edge it wrote"
+    ! grep -F 'blocked-on:' "$CALLS" >/dev/null ||
+        fail "the wiring step must never emit a blocked-on: label as a dependency"
+    # Temporal inversion guard: "X needs Y" is `dep add X Y`, never `dep add Y X`.
+    ! grep -Fx 'gc bd dep add ki-vxc ki-msb' "$CALLS" >/dev/null ||
+        fail "dependency direction was inverted; the blocker must be the second argument"
+}
+
+# A slug can name work that is not a single bead. abi-widening covers three
+# beads, so the dependent must wait on all three, not on an arbitrary one.
+test_multi_bead_capability_fans_out_to_every_provider() {
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+    cat >"$PLAN_LEDGER" <<'LEDGER'
+ki-a01 abi-widening -
+ki-a02 abi-widening -
+ki-a03 abi-widening -
+ki-cw9 production-ci abi-widening
+LEDGER
+
+    run_wiring || fail "wiring block failed on a multi-provider capability: $(cat "$ERR")"
+
+    local edge
+    for edge in "ki-cw9 ki-a01" "ki-cw9 ki-a02" "ki-cw9 ki-a03"; do
+        grep -Fx "$edge" "$EDGES" >/dev/null ||
+            fail "capability fan-out missed edge $edge"
+    done
+    [[ "$(wc -l <"$EDGES")" -eq 3 ]] ||
+        fail "expected exactly one edge per delivering bead"
+    grep -F 'PLAN_DEP_WIRING_OK edges=3' "$OUT" >/dev/null ||
+        fail "wiring block miscounted the fan-out"
+}
+
+test_rerun_is_idempotent() {
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+    cat >"$PLAN_LEDGER" <<'LEDGER'
+ki-vxc bounded-asset-reads -
+ki-7ea cache-rewrite bounded-asset-reads
+LEDGER
+
+    run_wiring || fail "first wiring run failed: $(cat "$ERR")"
+    : >"$CALLS"
+    run_wiring || fail "second wiring run failed: $(cat "$ERR")"
+
+    ! grep -F 'gc bd dep add' "$CALLS" >/dev/null ||
+        fail "rerun re-added an edge that already existed"
+    [[ "$(wc -l <"$EDGES")" -eq 1 ]] ||
+        fail "rerun duplicated the dependency edge"
+    grep -F 'PLAN_DEP_WIRING_OK edges=1' "$OUT" >/dev/null ||
+        fail "rerun did not confirm the pre-existing edge"
+}
+
+# A surviving blocked-on: label is the defect this step exists to prevent, so
+# the step must refuse to report success while one is still on a planned bead.
+test_surviving_blocked_on_label_fails_the_step() {
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+    cat >"$PLAN_LEDGER" <<'LEDGER'
+ki-vxc bounded-asset-reads -
+ki-yvj cache-rewrite bounded-asset-reads
+LEDGER
+    printf 'ki-yvj blocked-on:bounded-asset-reads\n' >"$LABELS"
+
+    ! run_wiring || fail "a bead still carrying a blocked-on: label was reported as wired"
+    grep -F 'PLAN_DEP_WIRING_FAILURE' "$ERR" >/dev/null ||
+        fail "label leak did not raise PLAN_DEP_WIRING_FAILURE"
+    grep -F 'ki-yvj' "$ERR" >/dev/null ||
+        fail "label leak did not name the offending bead"
+}
+
+test_unresolvable_slug_fails_closed() {
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+    cat >"$PLAN_LEDGER" <<'LEDGER'
+ki-msb cache-rewrite production-ci
+LEDGER
+
+    ! run_wiring || fail "a blocker slug no bead delivers was silently accepted"
+    grep -F "waits on 'production-ci' but no ledger bead delivers it" "$ERR" >/dev/null ||
+        fail "unresolvable slug did not fail closed with a usable message"
+    ! grep -F 'gc bd dep add' "$CALLS" >/dev/null ||
+        fail "an edge was written despite an unresolvable slug"
+}
+
+test_missing_ledger_and_malformed_rows_fail_closed() {
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+
+    ! run_wiring || fail "a missing capability ledger was treated as an empty plan"
+    grep -F 'PLAN_DEP_WIRING_FAILURE' "$ERR" >/dev/null ||
+        fail "missing ledger did not raise PLAN_DEP_WIRING_FAILURE"
+
+    printf 'ki-msb cache-rewrite\n' >"$PLAN_LEDGER"
+    ! run_wiring || fail "a two-column ledger row was accepted"
+    grep -F 'every ledger row needs 3 columns' "$ERR" >/dev/null ||
+        fail "malformed ledger row did not report the expected shape"
+
+    printf 'ki-msb;reboot cache-rewrite -\n' >"$PLAN_LEDGER"
+    ! run_wiring || fail "an unvalidated bead ID reached the shell"
+    grep -F 'refusing to shell out unvalidated names' "$ERR" >/dev/null ||
+        fail "ledger identifier validation did not fail closed"
+}
+
+# The store is the authority, not the exit status of the add.
+test_unpersisted_edge_fails_closed() {
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+    cat >"$PLAN_LEDGER" <<'LEDGER'
+ki-vxc bounded-asset-reads -
+ki-msb cache-rewrite bounded-asset-reads
+LEDGER
+
+    DEP_ADD_SILENT=1
+    ! run_wiring || fail "an edge that never persisted was reported as wired"
+    unset DEP_ADD_SILENT
+    grep -F 'did not read back as a blocks dependency' "$ERR" >/dev/null ||
+        fail "unpersisted edge did not fail closed"
+
+    : >"$CALLS"
+    DEP_ADD_FAILS=1
+    ! run_wiring || fail "a failed gc bd dep add was reported as wired"
+    unset DEP_ADD_FAILS
+    grep -F 'gc bd dep add ki-msb ki-vxc failed' "$ERR" >/dev/null ||
+        fail "failed dep add did not fail closed"
+}
+
+test_formula_contracts_keep_dependencies_machine_readable() {
+    python3 - "$FORMULA" <<'PY'
+import sys
+import tomllib
+
+with open(sys.argv[1], "rb") as handle:
+    tomllib.load(handle)
+PY
+
+    grep -F 'gc bd dep add "$bead" "$provider"' "$FORMULA" >/dev/null ||
+        fail "the planner must execute gc bd dep add, not merely mention it"
+    grep -F '# BEGIN PLAN_DEPENDENCY_WIRING' "$FORMULA" >/dev/null ||
+        fail "dependency wiring must stay an extractable, testable block"
+    grep -F 'plan-ledger.tsv' "$FORMULA" >/dev/null ||
+        fail "the planner needs a slug-to-bead-ID ledger recorded at creation time"
+    grep -F 'capability:<slug>' "$FORMULA" >/dev/null ||
+        fail "task beads should declare the capability they deliver"
+    grep -F 'Never encode a blocking relationship as a label.' "$FORMULA" >/dev/null ||
+        fail "the label-instead-of-edge failure mode must stay called out"
+    grep -F 'cascade-nudge-on-blocker-close' "$FORMULA" >/dev/null ||
+        fail "the formula should explain which reader depends on real edges"
+    grep -F 'gc convoy add <convoy-id> <task-id>' "$FORMULA" >/dev/null ||
+        fail "convoy membership wiring should be preserved"
+    grep -F 'tracks' "$FORMULA" >/dev/null ||
+        fail "convoy tracks edges should be distinguished from blocking edges"
+    ! grep -E -- '--labels[^\n]*blocked-on:' "$FORMULA" >/dev/null ||
+        fail "the formula must never instruct the planner to create blocked-on: labels"
+    # gascity_pack_inference_gate.GASTOWN_FORMULA_CONTRACTS pins these strings.
+    grep -F 'Convert the refined plan into beads' "$FORMULA" >/dev/null ||
+        fail "create-beads step title is pinned by the pack inference gate"
+    grep -F 'gc bd dep add' "$FORMULA" >/dev/null ||
+        fail "gc bd dep add is pinned by the pack inference gate"
+}
+
+test_blocking_relationship_becomes_a_real_dep_edge
+test_formula_contracts_keep_dependencies_machine_readable
+test_multi_bead_capability_fans_out_to_every_provider
+test_rerun_is_idempotent
+test_surviving_blocked_on_label_fails_the_step
+test_unresolvable_slug_fails_closed
+test_missing_ledger_and_malformed_rows_fail_closed
+test_unpersisted_edge_fails_closed
+
+echo "idea-to-plan dependency wiring tests passed"


### PR DESCRIPTION
## Problem

`mol-idea-to-plan`'s `create-beads` step ships roadmap blocking as **labels**, not dependency edges. Observed on a live city: beads carry `blocked-on:abi-widening`, `blocked-on:production-ci` — human-readable slugs, not bead IDs. Nothing machine-readable exists, so dependency scheduling is silently off.

To be precise about the defect: `blocked-on` appears nowhere in this repo. The planner **invented** that encoding, because it is the only thing reachable from what the formula actually asks for. The whole dependency half of the step is five lines (`gastown/formulas/mol-idea-to-plan.toml:463-467`):

```
**4. Wire dependencies with `gc bd dep add`:**
Model the actual "X needs Y" relationships. Verify with:
```bash
gc bd blocked
```
```

No command form, no ID source, no failure condition. The design doc names blockers by slug; `gc bd dep add` accepts only bead IDs; step 3 creates the beads and never records the slug→ID mapping. By step 4 the only artifact that could resolve a slug is gone, and the one field on `gc bd create` that takes a free-form human string is `--labels`. The lone "verification", `gc bd blocked`, prints nothing and exits 0 on a graph with zero edges, so the hand-wave self-certifies.

This is a deliberate design that never got a second half — not a missing step, and not a failing one.

### Reproduction

On the affected city, `ki-msb` (M5), `ki-cw9` (M7), `ki-7ea` (M0) and `ki-yvj` all appear in `gc bd ready` with "no active blockers" while carrying `blocked-on:` labels that name unfinished work. Minimal reproduction against a scratch beads DB:

```console
$ bd create "provider b" -t task --labels capability:abi-widening   # -> pr-cry
$ bd create "dependent c" -t task --labels blocked-on:abi-widening  # -> pr-zob
$ bd ready --json | jq -r '.[].id'
pr-cry
pr-zob          # <-- genuinely blocked, reported ready

$ bd dep add pr-zob pr-cry
$ bd ready --json | jq -r '.[].id'
pr-cry          # <-- pr-zob correctly withheld
```

Downstream: nothing auto-schedules. When `ki-vxc` merged, satisfying `blocked-on:bounded-asset-reads`, three dependents stayed dormant until a human noticed and routed them.

### Why the convoy wiring works and this does not

The same run produced correct `tracks` edges — the convoy bead tracks all 10 of its children. Both paths live in the same step, ~5 lines apart, and differ on exactly one property: **who resolves the names.**

Convoy membership (`:458-461`) is one mechanical command, `gc convoy add <convoy-id> <task-id>`, whose arguments are IDs the agent is already holding, and whose `tracks` edge is a **side effect of a core primitive**. No name resolution, no modeling, no judgement.

Blocking (`:463-467`) is a modeling exercise: extract relations from prose, resolve slugs with no mapping available, invert temporal language, and invoke a command that was never spelled out. The pack shipped a primitive invocation for one and a documentation sentence for the other. `tracks` never blocks, so convoy membership could not have compensated.

The pack's own guard did not catch this: `scripts/gascity_pack_inference_gate.py:81` asserts only that the literal substring `gc bd dep add` appears somewhere in the formula. The backtick mention on line 463 satisfies it.

## Fix

Give the planner the ID source it never had, then make the wiring mechanical and fail-closed.

- **Capability ledger** (new step 4): one row per task bead, written at the only moment the mapping exists — as `gc bd create` returns the ID. `.plan-reviews/$REVIEW_ID/plan-ledger.tsv`, three whitespace-separated columns: `<bead-id> <capability-delivered> <capabilities-waited-on|->`. Task beads also carry a `capability:<slug>` label so the mapping outlives the run.
- **`PLAN_DEPENDENCY_WIRING` block** (new step 5): resolves each blocker slug to every bead delivering it, adds the `blocks` edges, and reads each one back through `gc bd dep list --type blocks`. Idempotent — safe to rerun after a partial or restarted planning run. Prints `PLAN_DEP_WIRING_OK edges=<n>`.
- **Fails closed** with `PLAN_DEP_WIRING_FAILURE` and a nonzero return on: missing or empty ledger, wrong column count, identifiers outside `[A-Za-z0-9_-]`, a slug no bead delivers, a self-blocking slug, a failed add, an edge that does not read back, or **any surviving `blocked-on:` label**. A partially wired graph is never reported as done.
- **States the invariant**: a label describes what a bead *is*; only an edge describes what it *waits for*. Convoy `tracks` is membership and reporting only.
- **Verification** upgraded from `gc bd blocked` alone to `gc bd blocked` + `gc bd ready`, with the empty-output trap called out explicitly.

### Design decision: fan-out, not a grouping bead

A slug can name work that is not a single bead — `abi-widening` covered three. The dependent gets **one edge per delivering bead**, so it unblocks exactly when the last piece of that capability closes.

Rejected the grouping-bead alternative: a grouping node must be closed by someone, and if nobody closes it every dependent stays blocked forever — a new silent-stall mode, invisible until a human audits, strictly worse than the bug being fixed. It also collides with convoys, which already occupy the grouping role via `tracks`, a deliberately non-blocking edge type.

**Tradeoff, stated plainly:** fan-out is O(dependents × providers) edges, so `bd dep list` gets noisier, and the edge set is a **snapshot of plan time** — a bead added to a capability after the run does not retroactively block existing dependents. A grouping bead would have absorbed late additions automatically. Accepted because the planning run is the authority, post-plan scope growth is already a human replan event, and the wiring block is idempotent, so re-running it after amending the ledger reconciles the graph without duplicating edges.

## Regression coverage

New standalone suite `gastown/tests/test_idea_to_plan_dependencies.sh` extracts the wiring block from the formula via `tomllib` and runs it against a minimal `gc` bead-store stub. The only way an assertion sees an edge is if `gc bd dep add` actually wrote one, so a step that emits a label cannot pass.

- a plan with one blocking relationship produces a real `blocks` edge — plus direction (`dep add <dependent> <blocker>`, never inverted) and **no `blocked-on:` label in any emitted call**
- a capability delivered by three beads fans out to exactly three edges
- rerun adds nothing and duplicates nothing
- a surviving `blocked-on:` label fails the step and names the bead
- an unresolvable slug, a missing ledger, a malformed row, and a shell-injection payload in a bead ID each fail closed with no edge written
- an add that "succeeds" without persisting, and a hard add failure, both fail closed — the store is the authority, not the exit status
- the formula must *execute* `gc bd dep add`, not merely mention it

Verified the suite fails on `main` (`create-beads has no PLAN_DEPENDENCY_WIRING block; dependencies are unwired`) and passes with the fix. The block was also validated against a real scratch beads DB before the pack test was written: 5 beads, a capability delivered by 3, fan-out produced 4 edges, `bd ready` dropped the dependent, rerun produced 0 new edges, and all five fail-closed paths reproduced.

## Validation

- Gastown shell suites: 4 passed, 0 failed
- `bash -n`: 104/104 tracked shell scripts
- TOML parse: 291/291 tracked `.toml`
- `gc lint gastown`: ok
- `python3 -m pytest -q`: 773 passed, 7 skipped, 9412 subtests — unchanged from the `main` baseline measured in a throwaway worktree
- `tests/test_gascity_pack_inference_gate.py`: 63 passed
- `tests/test_no_bare_bd_commands.py`: 2 passed
- `go test -count=1 .`: ok
- `git diff --check`: clean

No model-backed inference gate was run (needs a live city and paid inference).

## Composition

Touches only `gastown/formulas/mol-idea-to-plan.toml` and one new test file. No overlap with #221, #222, #226 or #227 — none of them touch that formula, and the new suite avoids the three-way-contested `test_gastown_pack_assets.sh`.


---

## Open question for maintainers — please push back if you disagree

This adds ~172 lines where the formula previously had 5, and it makes one design choice that a maintainer may reasonably want the other way. Presenting it as an open question rather than settled:

**Fan-out vs. a grouping bead.** A capability slug can name work spread across several beads (`abi-widening` covered three in the observed run). This PR gives the dependent **one edge per delivering bead**, so it unblocks exactly when the last piece closes. The alternative — synthesising a grouping bead per capability and having dependents block on that — was rejected here because a grouping node must be closed by someone, and if nobody does, every dependent blocks forever: a new silent-stall mode, invisible until a human audits, arguably worse than the bug being fixed. It also collides with convoys, which already occupy the grouping role via the deliberately non-blocking `tracks` edge.

The cost of fan-out, stated plainly: O(dependents x providers) edges, noisier `bd dep list`, and the edge set is a **snapshot of plan time** — a bead added to a capability *after* the run does not retroactively block existing dependents. A grouping bead would have absorbed late additions automatically.

If you would rather have the grouping-bead shape, or a third option, the wiring block is self-contained and idempotent — it is a small change to swap. The part I would argue is not optional is the **fail-closed** behaviour: the current formula's only verification is `gc bd blocked`, which prints nothing and exits 0 on a graph with zero edges, so a step that silently wires nothing self-certifies as success.
