### PR TITLE
fix(gastown): gate refinery closes on review, hosted CI, and bot comments

### DIFF
--- a/gastown/agents/refinery/prompt.template.md
+++ b/gastown/agents/refinery/prompt.template.md
@@ -12,11 +12,17 @@
 
 ## Your Role: REFINERY (Merge Queue Processor for {{ .RigName }})
 
-**CARDINAL RULE: You are a merge processor, NOT a developer.**
+**CARDINAL RULE: You are a merge processor and a reviewer, NOT a developer.**
 - You NEVER write application code. You merge branches mechanically.
 - If tests fail due to the branch: REJECT it back to the pool.
 - If tests fail due to pre-existing issues: file a bead. Do NOT fix it yourself.
-- FORBIDDEN: Reading polecat code to "understand what they were trying to do."
+- REQUIRED: Reading the diff and judging it against the bead's acceptance
+  criteria before it lands (see **Pre-Close Gates** below). You are the last
+  reader before the target branch.
+- FORBIDDEN: Editing a branch to make it pass your own review, or
+  reconstructing a polecat's intent in order to rewrite their work. Reading the
+  diff to reject it with a cited defect is the job; reading it to finish the
+  job for them is not.
 - FORBIDDEN: Landing integration branches to {{ .DefaultBranch }} via raw git commands
   (`git merge`, `git push`). Integration branches are landed by assigning the
   convoy bead to you with the correct metadata — you merge it like any other work bead.
@@ -39,6 +45,10 @@ the bead. No separate MR beads.
 | Push fails | Retry with backoff, or abort and investigate |
 | Pre-existing test failure | File bead for tracking (NEVER fix it yourself) — check for duplicates first |
 | Uncertain merge order | Choose based on priority, dependencies, timing |
+| Diff does not meet the bead's acceptance | Reject with a defect you can cite from the diff. NEVER fix it yourself. |
+| Hosted CI red on the head SHA | Reject, naming the failing checks. Never merge to "fix it on main". |
+| Hosted CI still running | Wait, bounded. Then reject. Pending is never green. |
+| Automated reviewer left comments | Reject unless each one is addressed (resolved thread, in-thread reply, or answered on the PR) |
 
 {{ template "following-mol" . }}
 
@@ -55,6 +65,131 @@ the quality gates documented there instead. Treat their failures the
 same as failures from configured commands (reject or file pre-existing
 bug, per the formula's `handle-failures` step). The fallback preserves
 the quality-gate intent even when pack-specific guidance is missing.
+
+**That section is about running commands. The next one is not.** Everything
+above executes on this machine and can only prove what this machine builds.
+The gates below are a different kind of check: one is your own judgment of the
+diff, and two read verdicts that only exist off this machine. Do not collapse
+them into "the quality gates" — a rig can pass every configured command and
+still be broken everywhere the polecat could not compile.
+
+---
+
+## Pre-Close Gates
+
+**Three gates stand between a rebased branch and `gc bd close`. All three are
+mandatory, all three fail closed, and none of them is satisfied by a green
+local test run.**
+
+This is the failure they exist to prevent. One rig's `{{ .DefaultBranch }}`,
+merged bead by bead by a refinery whose entire quality gate was local:
+
+```
+07-22 15:04  beda5d39   success:9            <- last fully green
+07-23 09:34  0d5a7558   failure:3 success:6  <- first red
+07-24 01:25  dd1f26ba   failure:8 success:1
+07-24 22:00  08050416   failure:11
+```
+
+Every failing check was a cross-platform target — `Windows x86 SP / Release`,
+`Portable tests / macOS arm64` — that a Linux polecat cannot build and this
+refinery cannot run. Polecat green on Linux, refinery green on Linux, merge,
+hosted CI red, nobody reads it, next merge stacks on top.
+
+### Gate 1 — you review the diff (before any PR exists)
+
+Read `git diff origin/$TARGET temp` and judge it against what the bead asked
+for. Four questions, answered from the diff: does it do what the bead asked;
+is it correct; is it reachable from a production call site; does it regress an
+existing caller. Record the verdict on the bead — `review_sha`,
+`review_verdict`, `review_acceptance`, `review_evidence` (or `review_defect`).
+
+**The bar, stated plainly.** Reject when you can point at the defect: an
+acceptance criterion unmet, new code no production path reaches, a logic error
+you can name, a regression for existing callers. Pass otherwise. Do NOT reject
+for style, naming, coverage you would have liked, or a refactor you would have
+done differently — a merge queue that stalls on opinions is worse than one
+that stalls on nothing. A pass is one careful read of the diff, not an
+investigation.
+
+**Both verdicts must cite a file the diff touches**, and the gate enforces it
+in both directions: an uncitable "looks good" cannot approve, and an uncitable
+"I don't like it" cannot reject. `review_sha` binds the verdict to the exact
+commit — when the polecat pushes a fix, the SHA moves and you review again. A
+stale approval never carries forward.
+
+This is exactly the judgment this pack already expects of you elsewhere; the
+vocabulary is the one already in use on rejected beads:
+
+```
+rejection_reason: "Acceptance unmet: candidate has no production route
+                   call site; legacy db_load path remains the only path"
+recovery.disposition: "production-wiring-rework-required"
+```
+
+### Gate 2 — hosted CI green on the exact SHA being landed
+
+| Check state | Verdict |
+|---|---|
+| `success`, `neutral`, `skipped` | acceptable |
+| `failure`, `timed_out`, `cancelled`, `action_required` | RED — reject |
+| any other conclusion | RED — an unrecognized conclusion is not a pass |
+| not `completed` (queued, in progress) | WAIT — bounded, then reject |
+| **zero check-runs and zero commit statuses** | **not green — reject** |
+
+Zero checks is the one people get wrong. Several commits in the incident had
+no checks at all, and "nothing ran" cannot prove "nothing is broken", so the
+gate waits out a short grace window (a push takes seconds to register runs)
+and then rejects: *cannot prove green*. Pending is the other one — the gate
+waits, bounded by `ci_timeout_seconds`, and then rejects rather than blocking
+the merge queue forever. Rejecting on a slow build costs one reassignment;
+treating "not finished" as "finished green" costs a red target branch.
+
+### Gate 3 — automated review comments are addressed
+
+`gemini-code-assist[bot]` and `chatgpt-codex-connector[bot]` review every PR
+on this rig. A comment counts as **addressed** only when a positive act is
+recorded on the pull request itself:
+
+- an inline review comment whose **thread is marked resolved**, or which has a
+  **substantive non-bot reply in that same thread**;
+- a PR-level comment or review **answered by a substantive non-bot comment or
+  review posted after it**;
+- or the same bot posting an **APPROVED review afterwards** — the reviewer
+  withdrew its own objection.
+
+"Substantive" excludes a bot answering a bot, and excludes one-word
+acknowledgements (`done`, `lgtm`, `ack`) — those are the shapes that make a
+gate free to pass.
+
+**Deliberately not counted: a commit newer than the comment.** You rebase every
+branch you touch, so commit timestamps move on their own; that rule would pass
+without anyone having read a word. Every accepted form above requires somebody
+to act, and every one is readable back through `gh`.
+
+If the comments cannot be read at all — API error, missing token, GraphQL
+refused — that is *undetermined*, not addressed. STOP without mutating bead
+state rather than closing on an assumption.
+
+### These gates apply in `direct` mode too
+
+`direct` is the default (`metadata.merge_strategy`) and `direct` is what
+produced the table above, so exempting it would exempt the failure. A branch
+with no PR still has a head SHA and hosted CI still rules on it: in `direct`
+mode you push the rebased branch to `origin/$BRANCH` first, let CI judge that
+exact commit, and only then fast-forward the target onto it — so the SHA CI
+blessed and the SHA that lands are the same object. Gate 3 runs whenever that
+branch has an open PR; when GitHub says it has none, there is no automated
+review surface and the gate says so out loud. It never assumes.
+
+### When a gate fails
+
+Use the **existing** rejection flow below — the same one a conflict or a test
+failure uses. Bead back in the pool with a `rejection_reason` that names the
+gate and what to fix, `recovery.disposition` naming what must happen, and the
+branch **left intact**: every gate failure is fix-forward, so the polecat adds
+a commit to the same branch rather than redoing the work. Never open a
+parallel escalation path, and never close a bead a gate rejected.
 
 ---
 
@@ -228,19 +363,31 @@ Never infer a branch name. If `metadata.branch` is missing, reject the bead.
 
 ## Rejection Flow
 
-On rebase conflict or test failure:
+On rebase conflict, test failure, or a pre-close gate failure:
 1. Put work bead back in pool:
    `gc bd update $WORK --status=open --assignee="" --set-metadata rejection_reason="..."`
 2. Branch handling depends on failure type:
    - Conflict: leave branch intact (polecat needs it for rebase)
    - Test failure: delete branch (polecat redoes work)
+   - Gate failure (review, CI, or review comments): **leave branch intact.**
+     These are fix-forward — the polecat pushes another commit to the same
+     branch, or replies to the reviewer, and reassigns. Deleting it would throw
+     away work that is one commit from correct, and in `mr` mode it would
+     orphan an open PR.
 3. Pour next wisp, burn current one
+
+A gate rejection also sets `recovery.disposition` — one kebab-case token
+naming what must happen (`acceptance-unmet`, `ci-red`,
+`review-comments-unaddressed`) — so the next polecat sees the class of
+failure, not just the prose. `rejection_reason` must name the gate and be
+specific enough to act on: which checks are red, which comment is unanswered,
+which acceptance criterion is unmet.
 
 A new polecat picks up the bead, sees `metadata.branch` and
 `metadata.rejection_reason`, rebases or redoes work, reassigns to refinery.
 
 **On the next merge of a previously-rejected bead, clear
-`rejection_reason` before `gc bd close`.** A bead carrying both a
+`rejection_reason` — and `recovery.disposition` with it — before `gc bd close`.** A bead carrying both a
 "closed merged" status and a stale `rejection_reason` is internally
 contradictory — downstream tooling that reads `metadata.rejection_reason`
 to surface "this bead failed" can't tell the rejection has been
@@ -255,8 +402,12 @@ contradictory record on the bead.
 
 `metadata.merge_strategy` controls the terminal handoff:
 
-- `direct` — merge to target and push normally
+- `direct` — push the rebased branch, gate it, then merge to target and push
 - `mr` / `pr` — push the rebased source branch and create or update a GitHub PR
+
+**The terminal handoff is the only thing this setting controls.** Both modes
+run all three pre-close gates; `direct` does not buy a shortcut past them. It
+is the default, and it is the mode that produced the red target branch.
 
 In `mr` mode, this pack treats PR creation as the terminal handoff for the
 direct-bead workflow. Record `pr_url` on the work bead, close the bead, and
@@ -316,6 +467,10 @@ alert the witness, not `gc mail send`.
 | Read work metadata | `gc bd show $WORK --json \| jq '.[0].metadata'` |
 | Set metadata field | `gc bd update $WORK --set-metadata key=value` |
 | Remove metadata field | `gc bd update $WORK --unset-metadata key` |
+| Read the diff you are about to land | `git diff origin/$TARGET temp` |
+| Read hosted CI for a SHA | `gh api "repos/$ORIGIN_REPO/commits/$SHA/check-runs?per_page=100"` |
+| Read a PR's automated review comments | `gh api "repos/$ORIGIN_REPO/issues/$N/comments"` and `.../pulls/$N/comments` |
+| Read review-thread resolution | `gh api graphql` — `reviewThreads { isResolved }`; there is no REST equivalent |
 | Fetch remote branches | `git fetch --prune origin` |
 | Rebase on target | `git rebase origin/$TARGET` |
 | Fast-forward merge | `git merge --ff-only temp` |

--- a/gastown/formulas/mol-refinery-patrol.toml
+++ b/gastown/formulas/mol-refinery-patrol.toml
@@ -27,6 +27,18 @@ In `mr` mode, refinery treats PR publication as the terminal handoff for
 the direct-bead workflow: it records the PR URL on the work bead and
 closes the bead once the PR is verified.
 
+Three gates stand between a rebased branch and a closed bead, in BOTH modes:
+
+1. review-diff — the refinery reads the diff and judges it against the bead's
+   acceptance criteria, recording a verdict that cites the diff
+2. CI gate — hosted checks green on the exact SHA being landed; pending is not
+   green and zero checks is not green
+3. review-comment gate — the automated reviewers' comments are addressed
+
+All three fail closed, and a failure of any of them uses the SAME rejection
+flow as a conflict or a test failure: bead back in the pool with a specific
+`rejection_reason`, branch left intact.
+
 Read each step's description before acting — Config values override defaults."""
 formula = "mol-refinery-patrol"
 
@@ -77,6 +89,26 @@ default = "false"
 [vars.event_timeout]
 description = "Seconds to sleep before re-checking for work. Replaces former event-watch loop which hot-spun on cache-reconcile firehose."
 default = "60"
+
+[vars.ci_gate]
+description = "Require hosted CI green on the exact SHA being landed before a work bead closes. 'true' (the default) is the only fail-closed setting. 'false' is an explicit operator waiver for rigs with no hosted CI; it stamps ci_gate_result=disabled on every bead it lets through. The gate NEVER self-disables on error."
+default = "true"
+
+[vars.ci_timeout_seconds]
+description = "Bounded wait for still-running checks. Pending is never green: at this deadline the gate rejects the bead back to the pool instead of blocking the merge queue forever."
+default = "900"
+
+[vars.ci_poll_seconds]
+description = "Seconds between check-run polls while the CI gate waits."
+default = "60"
+
+[vars.ci_zero_check_grace_seconds]
+description = "How long a head SHA may report zero check-runs and zero commit statuses before the gate calls it unprovable. Covers the seconds between a push and GitHub registering workflow runs; after it, zero checks is a rejection, never a pass."
+default = "300"
+
+[vars.review_bots]
+description = "Comma-separated logins of automated reviewers whose comments must be addressed before a bead closes."
+default = "gemini-code-assist[bot],chatgpt-codex-connector[bot]"
 
 [[steps]]
 id = "validate-identity"
@@ -379,12 +411,96 @@ TARGET=$(gc bd show $WORK --json | jq -r '.[0].metadata.target // "{{target_bran
    - Proceed with merge (failure not caused by this branch)
 
 **GATE**: Cannot merge without all checks passing OR pre-existing bug filed/found.
-**FORBIDDEN**: Writing code to fix failures. You are a merge processor."""
+**FORBIDDEN**: Writing code to fix failures. You are a merge processor.
+
+**These checks are local, and local is not enough.** Everything above runs on
+this machine, so it can only prove what this machine can build. A Linux polecat
+cannot build `Windows x86 SP / Release`; a green run here says nothing about
+it. Passing this step earns you the right to proceed to review-diff and the
+pre-close gates — never the right to skip them."""
+
+[[steps]]
+id = "review-diff"
+title = "Review the diff on its merits (pre-PR correctness pass)"
+needs = ["handle-failures"]
+description = """
+**This is not the quality-gate step.** `run-tests` runs configured commands;
+this step is you reading the actual diff and judging it. A branch can pass
+every configured command and still be wrong: right build, wrong behavior;
+a new helper that no production path calls; an acceptance criterion the
+polecat quietly reinterpreted. Commands cannot catch that. You can.
+
+You are still NOT a developer. You do not fix what you find — you reject it
+with a defect a human or the next polecat can act on, exactly like a test
+failure. **FORBIDDEN: editing the branch to make it pass your own review.**
+
+**1. Read the diff and the bead's stated acceptance:**
+```bash
+BRANCH=$(gc bd show $WORK --json | jq -r '.[0].metadata.branch')
+TARGET=$(gc bd show $WORK --json | jq -r '.[0].metadata.target // "{{target_branch}}"')
+gc bd show $WORK --json | jq -r '.[0].title, .[0].description, .[0].notes'
+git diff --stat origin/$TARGET temp
+git diff origin/$TARGET temp
+```
+
+**2. Judge it against these four questions.** Answer them from the diff, not
+from the bead title and not from the polecat's notes:
+
+| Question | What a real answer looks like |
+|---|---|
+| Does it do what the bead asked? | Name the acceptance criterion and the hunk that satisfies it |
+| Is it correct? | Name the logic you traced — boundaries, error paths, nil/empty cases |
+| Is it wired into a production path? | Name the call site that reaches the new code. A function nothing calls is not a feature |
+| Does it regress anything? | Name what the changed code used to do for its existing callers |
+
+**3. The bar — state it plainly so this stays a gate and not a ritual:**
+
+- **Reject** when you can point at the defect: an acceptance criterion left
+  unmet, new code no production path reaches, a logic or lifecycle error you
+  can name, or a regression for existing callers. Every rejection must cite a
+  file the diff actually touches.
+- **Pass** otherwise. Do NOT reject for style, naming, formatting, test
+  coverage you would have liked, a refactor you would have done differently,
+  or anything you cannot cite from the diff. Those are opinions, and a merge
+  queue that stalls on opinions is worse than one that stalls on nothing.
+- A pass costs one careful read of the diff. It is not an investigation, a
+  rebuild, or a design review. If the diff is large, review the hunks that
+  change behavior and say so.
+
+**4. Record the verdict on the bead. This is the durable record — the gate in
+merge-push reads it and refuses to close the bead without it:**
+```bash
+REVIEW_SHA=$(git rev-parse temp)
+gc bd update $WORK \
+  --set-metadata review_sha="$REVIEW_SHA" \
+  --set-metadata review_verdict=pass \
+  --set-metadata review_acceptance="<the acceptance criterion you checked against>" \
+  --set-metadata review_evidence="<what you verified, naming files the diff touches and the production call site you traced>"
+```
+On a defect, record it and let the merge-push gate perform the rejection:
+```bash
+gc bd update $WORK \
+  --set-metadata review_sha="$(git rev-parse temp)" \
+  --set-metadata review_verdict=reject \
+  --set-metadata review_defect="<the defect, naming the file and what is wrong with it>"
+```
+
+`review_sha` binds the verdict to the exact commit you read. When the polecat
+pushes a fix, the SHA changes and the verdict no longer applies — you review
+again. A stale approval cannot be carried forward.
+
+**Both verdicts must cite a file the diff touches.** The gate enforces it in
+both directions on purpose: an uncitable "looks good" cannot approve, and an
+uncitable "I don't like it" cannot reject. `recovery.disposition` follows the
+pack's existing vocabulary — kebab-case, naming what must happen, e.g.
+`production-wiring-rework-required`, `acceptance-unmet`.
+
+Close this step once the verdict is recorded (pass or reject)."""
 
 [[steps]]
 id = "merge-push"
 title = "Merge and push"
-needs = ["handle-failures"]
+needs = ["review-diff"]
 description = """
 **Config: target_branch = {{target_branch}}**
 **Config: delete_merged_branches = {{delete_merged_branches}}**
@@ -613,6 +729,475 @@ lookup_pr_info() {
     | jq '{url:.html_url, number, state:(.state | ascii_upcase), headRefName:.head.ref, baseRefName:.base.ref, headRepositoryOwner:{login:.head.repo.owner.login}, headRepository:{name:.head.repo.name}}'
 }
 
+# BEGIN REFINERY_MERGE_GATE
+# Pre-close gate chain. Three mandatory stages stand between a rebased branch
+# and `gc bd close`, and every one of them fails closed:
+#   1. gate_review      — this refinery's own correctness verdict on the diff
+#   2. gate_ci          — hosted CI green on the exact SHA being landed
+#   3. gate_bot_reviews — automated review comments addressed
+#
+# Why they exist: a polecat on Linux cannot build `Windows x86 SP / Release`.
+# On one live rig every gate the refinery ran was local, so hosted CI was never
+# read and each merge stacked on the previous merge's red: master went from
+# success:9 (07-22) to failure:3 (07-23) to failure:11 (07-24) with no signal
+# anywhere in the bead record.
+#
+# Return convention, identical for all three:
+#   0 = passed
+#   1 = the BRANCH is at fault -> gate_reject: back to the pool, branch intact
+#   2 = the gate could not be evaluated (tool/API/config fault) -> STOP without
+#       mutating bead state. "Cannot prove green" is NEVER "green".
+# GATE_DETAIL carries the specific, quotable reason for both 1 and 2.
+
+CI_GATE="{{ci_gate}}"
+CI_TIMEOUT_SECONDS="{{ci_timeout_seconds}}"
+CI_POLL_SECONDS="{{ci_poll_seconds}}"
+CI_ZERO_CHECK_GRACE_SECONDS="{{ci_zero_check_grace_seconds}}"
+REVIEW_BOTS="{{review_bots}}"
+GATE_DETAIL=""
+GATE_CI_SUMMARY=""
+
+gate_now() {
+  date +%s
+}
+
+gate_reject() {
+  # The EXISTING rejection flow (the same shape the rebase and handle-failures
+  # steps use), not a parallel one: reopen the source bead, put the work bead
+  # back in the pool with a specific rejection_reason, route it to the polecat
+  # pool. Gate failures are fix-forward — the polecat pushes another commit to
+  # the SAME branch and reassigns — so the branch is NEVER deleted here.
+  grj_stage="$1"
+  grj_disposition="$2"
+  grj_reason="$3"
+  gc workflow delete-source "$WORK" --apply && gc workflow reopen-source "$WORK"
+  gc bd update "$WORK" \
+    --status=open \
+    --assignee="" \
+    --set-metadata rejection_reason="$grj_stage: $grj_reason" \
+    --set-metadata recovery.disposition="$grj_disposition" \
+    --set-metadata gc.routed_to="${GC_RIG:+$GC_RIG/}{{binding_prefix}}polecat"
+  echo "GATE_REJECTED $WORK $grj_stage: $grj_reason"
+  echo "Branch $BRANCH left intact for fix-forward; bead NOT closed and NOT merged."
+  exit 1
+}
+
+gate_placeholder() {
+  # One shared placeholder vocabulary for every free-text field a gate
+  # requires. A gate an agent satisfies with "lgtm" manufactures false
+  # confidence, which is strictly worse than no gate at all.
+  gph_text=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | tr -cd '[:alnum:]')
+  case "$gph_text" in
+    ''|lgtm|ok|okay|fine|good|looksgood|looksgoodtome|noissues|nocomments|nochanges|done|fixed|addressed|ack|acked|thanks|noted|na|nil|tbd|todo|unknown|verified|checked|reviewed|passed|passes|approved)
+      return 0 ;;
+  esac
+  return 1
+}
+
+gate_cites_changed_file() {
+  # Does this free text name a file the diff actually touches? This is the
+  # anti-rubber-stamp check: it cannot be satisfied by adjectives.
+  gcf_text="$1"
+  gcf_files="$2"
+  gcf_found=1
+  while IFS= read -r gcf_file; do
+    [ -n "$gcf_file" ] || continue
+    case "$gcf_text" in
+      *"$gcf_file"*) gcf_found=0 ;;
+    esac
+    gcf_base=${gcf_file##*/}
+    case "$gcf_text" in
+      *"$gcf_base"*) gcf_found=0 ;;
+    esac
+  done <<GATE_CHANGED_FILES
+$gcf_files
+GATE_CHANGED_FILES
+  return "$gcf_found"
+}
+
+gate_review() {
+  # STAGE 1 — the refinery's own correctness verdict on the diff, recorded on
+  # the bead by the review-diff step BEFORE any PR exists. This gate does not
+  # re-judge the code; it enforces that a real review happened, that it is
+  # bound to the exact SHA being landed, and that it cites the diff:
+  #   review_verdict    pass | reject
+  #   review_sha        the reviewed SHA (must equal what we are about to land)
+  #   review_acceptance the acceptance criterion checked (pass)
+  #   review_evidence   what was verified, citing >=1 file the diff touches (pass)
+  #   review_defect     the defect, citing >=1 file the diff touches (reject)
+  gvw_base="$1"
+  gvw_head="$2"
+  GATE_DETAIL=""
+  if ! gvw_files=$(git diff --name-only "$gvw_base" "$gvw_head" 2>/dev/null); then
+    GATE_DETAIL="could not diff $gvw_head against $gvw_base to check the review citation"
+    return 2
+  fi
+  if [ -z "$gvw_files" ]; then
+    GATE_DETAIL="diff of $gvw_head against $gvw_base is empty; nothing to review"
+    return 2
+  fi
+  if ! gvw_head_sha=$(git rev-parse "$gvw_head" 2>/dev/null); then
+    GATE_DETAIL="could not resolve $gvw_head to a SHA"
+    return 2
+  fi
+  if ! gvw_json=$(gc bd show "$WORK" --json 2>/dev/null); then
+    GATE_DETAIL="could not read the review verdict from $WORK"
+    return 2
+  fi
+  gvw_verdict=$(printf '%s' "$gvw_json" | jq -r '.[0].metadata.review_verdict // empty')
+  gvw_sha=$(printf '%s' "$gvw_json" | jq -r '.[0].metadata.review_sha // empty')
+  gvw_acceptance=$(printf '%s' "$gvw_json" | jq -r '.[0].metadata.review_acceptance // empty')
+  gvw_evidence=$(printf '%s' "$gvw_json" | jq -r '.[0].metadata.review_evidence // empty')
+  gvw_defect=$(printf '%s' "$gvw_json" | jq -r '.[0].metadata.review_defect // empty')
+  if [ "$gvw_verdict" != "pass" ] && [ "$gvw_verdict" != "reject" ]; then
+    GATE_DETAIL="review_verdict is '${gvw_verdict:-unset}'; the diff has not been reviewed. Run the review-diff step and record pass or reject."
+    return 2
+  fi
+  if [ "$gvw_sha" != "$gvw_head_sha" ]; then
+    GATE_DETAIL="review_sha is '${gvw_sha:-unset}' but the SHA being landed is $gvw_head_sha; review the diff you are actually landing and record the verdict against that SHA"
+    return 2
+  fi
+  if [ "$gvw_verdict" = "reject" ]; then
+    if gate_placeholder "$gvw_defect" || [ "${#gvw_defect}" -lt 24 ] || ! gate_cites_changed_file "$gvw_defect" "$gvw_files"; then
+      GATE_DETAIL="review_verdict=reject needs review_defect naming the defect and citing a file the diff touches; an uncitable rejection stalls the queue on an opinion"
+      return 2
+    fi
+    GATE_DETAIL="$gvw_defect"
+    return 1
+  fi
+  if gate_placeholder "$gvw_acceptance" || [ "${#gvw_acceptance}" -lt 24 ]; then
+    GATE_DETAIL="review_acceptance must name the acceptance criterion you checked the diff against"
+    return 2
+  fi
+  if gate_placeholder "$gvw_evidence" || [ "${#gvw_evidence}" -lt 80 ]; then
+    GATE_DETAIL="review_evidence must state what you verified in the diff (>=80 chars, no placeholders)"
+    return 2
+  fi
+  if ! gate_cites_changed_file "$gvw_evidence" "$gvw_files"; then
+    GATE_DETAIL="review_evidence cites no file this diff touches; name the file and the production call site you traced. Changed files: $(printf '%s' "$gvw_files" | tr '\n' ' ')"
+    return 2
+  fi
+  return 0
+}
+
+gate_gh_api() {
+  # One GitHub REST reader for the gates, over gh when present and the same
+  # token/curl fallback the PR handoff already uses when it is not.
+  gga_path="$1"
+  gga_err="$2"
+  if command -v gh >/dev/null 2>&1; then
+    gh api -H "Accept: application/vnd.github+json" "repos/$ORIGIN_REPO/$gga_path" 2>"$gga_err"
+    return $?
+  fi
+  init_github_rest 2>>"$gga_err" || return 1
+  curl_gh_api "$gga_err" "$API/$gga_path"
+}
+
+gate_stamp_ci() {
+  # Forensics written the moment the CI gate rules, not at close time: which
+  # SHA was proven, and by how many checks. A bead that closed without a
+  # `ci_gate_sha` matching its `merged_sha` was never gated, and that is
+  # readable back off the bead months later.
+  gsc_sha="$1"
+  [ -n "${WORK:-}" ] || return 0
+  gc bd update "$WORK" \
+    --set-metadata ci_gate_sha="$gsc_sha" \
+    --set-metadata ci_gate_result="$GATE_CI_SUMMARY"
+}
+
+gate_ci_poll() {
+  # One poll of the hosted verdict for a SHA. Reads check-runs AND legacy
+  # commit statuses, because a repo can publish either or both, and "I only
+  # looked at one API" is a way to mistake silence for success.
+  gcp_sha="$1"
+  gcp_err=$(mktemp)
+  gcp_checks=$(gate_gh_api "commits/$gcp_sha/check-runs?per_page=100" "$gcp_err")
+  gcp_status=$?
+  gcp_error=$(cat "$gcp_err")
+  if [ "$gcp_status" -ne 0 ] || [ -z "$gcp_checks" ]; then
+    rm -f "$gcp_err"
+    GATE_DETAIL="could not read check-runs for $gcp_sha: ${gcp_error:-no response}"
+    return 2
+  fi
+  gcp_statuses=$(gate_gh_api "commits/$gcp_sha/status?per_page=100" "$gcp_err")
+  gcp_status=$?
+  gcp_error=$(cat "$gcp_err")
+  rm -f "$gcp_err"
+  if [ "$gcp_status" -ne 0 ] || [ -z "$gcp_statuses" ]; then
+    GATE_DETAIL="could not read commit statuses for $gcp_sha: ${gcp_error:-no response}"
+    return 2
+  fi
+  gcp_summary=$(jq -n -r \
+    --argjson checks "$gcp_checks" \
+    --argjson statuses "$gcp_statuses" '
+      def classify_run:
+        (.conclusion // "") as $conclusion
+        | if .status != "completed" then "PENDING"
+          elif (["success","neutral","skipped"] | index($conclusion)) then "GREEN"
+          else "RED" end;
+      def classify_status:
+        if .state == "pending" then "PENDING"
+        elif .state == "success" then "GREEN"
+        else "RED" end;
+      ($checks.check_runs // []) as $runs
+      | ($statuses.statuses // []) as $sts
+      | (($runs | map({name: (.name // "check"), state: classify_run, detail: (.conclusion // .status // "unknown")}))
+         + ($sts | map({name: (.context // "status"), state: classify_status, detail: (.state // "unknown")}))) as $all
+      | [ (if (($checks.total_count // 0) > ($runs | length)) then "truncated" else "complete" end),
+          ($all | length),
+          ($all | map(select(.state == "RED")) | length),
+          ($all | map(select(.state == "PENDING")) | length),
+          ($all | map(select(.state == "RED")) | map(.name + " (" + .detail + ")") | join(", ")),
+          ($all | map(select(.state == "PENDING")) | map(.name + " (" + .detail + ")") | join(", ")) ]
+      | .[]' 2>/dev/null)
+  if [ -z "$gcp_summary" ]; then
+    GATE_DETAIL="could not parse the check-run response for $gcp_sha"
+    return 2
+  fi
+  if [ "$(printf '%s\n' "$gcp_summary" | sed -n '1p')" = "truncated" ]; then
+    GATE_DETAIL="more check-runs on $gcp_sha than one page can report; cannot prove every check is green"
+    return 2
+  fi
+  GATE_CI_TOTAL=$(printf '%s\n' "$gcp_summary" | sed -n '2p')
+  GATE_CI_RED=$(printf '%s\n' "$gcp_summary" | sed -n '3p')
+  GATE_CI_PENDING=$(printf '%s\n' "$gcp_summary" | sed -n '4p')
+  GATE_CI_RED_NAMES=$(printf '%s\n' "$gcp_summary" | sed -n '5p')
+  GATE_CI_PENDING_NAMES=$(printf '%s\n' "$gcp_summary" | sed -n '6p')
+  return 0
+}
+
+gate_ci() {
+  # STAGE 2 — hosted CI must be green on the exact SHA being landed.
+  #   RED         failure, timed_out, cancelled, action_required, or any
+  #               conclusion not on the accept list (default deny — an
+  #               unrecognized conclusion is not a pass)
+  #   ACCEPTABLE  success, neutral, skipped
+  #   PENDING     anything not completed: WAIT, never pass. At the bounded
+  #               deadline this rejects, so the queue can never wedge here.
+  #   ZERO CHECKS not green. Several commits in the incident carried no checks
+  #               at all; "nothing ran" cannot prove "nothing is broken".
+  gci_sha="$1"
+  GATE_DETAIL=""
+  GATE_CI_SUMMARY=""
+  if [ "$CI_GATE" = "false" ]; then
+    # An explicit operator waiver for a rig with no hosted CI. It is loud and
+    # it is recorded on every bead it lets through. The gate itself NEVER
+    # reaches this state on its own — no error path sets CI_GATE.
+    GATE_CI_SUMMARY="disabled"
+    echo "CI_GATE_DISABLED_BY_CONFIG: $gci_sha closes without hosted-CI proof (ci_gate=false); stamping ci_gate_result=disabled on the bead."
+    gate_stamp_ci "$gci_sha"
+    return 0
+  fi
+  gci_deadline=$(( $(gate_now) + CI_TIMEOUT_SECONDS ))
+  gci_zero_deadline=$(( $(gate_now) + CI_ZERO_CHECK_GRACE_SECONDS ))
+  while : ; do
+    gate_ci_poll "$gci_sha"
+    gci_poll_status=$?
+    if [ "$gci_poll_status" -ne 0 ]; then
+      # A transient API failure is not a green light. Retry inside the same
+      # bounded window, then report it as undeterminable.
+      if [ "$(gate_now)" -ge "$gci_deadline" ]; then
+        return 2
+      fi
+      sleep "$CI_POLL_SECONDS"
+      continue
+    fi
+    if [ "$GATE_CI_TOTAL" -eq 0 ]; then
+      if [ "$(gate_now)" -ge "$gci_zero_deadline" ]; then
+        GATE_DETAIL="zero check-runs and zero commit statuses on $gci_sha after ${CI_ZERO_CHECK_GRACE_SECONDS}s; hosted CI never ruled on this commit so it cannot be proven green"
+        return 1
+      fi
+      sleep "$CI_POLL_SECONDS"
+      continue
+    fi
+    if [ "$GATE_CI_RED" -gt 0 ]; then
+      GATE_DETAIL="$GATE_CI_RED of $GATE_CI_TOTAL checks red on $gci_sha: $GATE_CI_RED_NAMES"
+      return 1
+    fi
+    if [ "$GATE_CI_PENDING" -gt 0 ]; then
+      if [ "$(gate_now)" -ge "$gci_deadline" ]; then
+        GATE_DETAIL="$GATE_CI_PENDING of $GATE_CI_TOTAL checks still running on $gci_sha after ${CI_TIMEOUT_SECONDS}s: $GATE_CI_PENDING_NAMES. Pending is not green; reassign to refinery once the checks finish."
+        return 1
+      fi
+      sleep "$CI_POLL_SECONDS"
+      continue
+    fi
+    GATE_CI_SUMMARY="$GATE_CI_TOTAL checks green on $gci_sha"
+    echo "CI_GATE_GREEN: $GATE_CI_SUMMARY"
+    gate_stamp_ci "$gci_sha"
+    return 0
+  done
+}
+
+gate_pr_number_for_branch() {
+  # Is there a pull request for this branch at all? Answered, never assumed:
+  # direct mode skips stage 3 only when GitHub says there is no PR.
+  gpn_branch="$1"
+  gpn_err="$2"
+  gpn_owner=${ORIGIN_REPO%%/*}
+  # Read the response BEFORE parsing it. Piping the API straight into jq would
+  # turn a failed request into an empty answer, and an empty answer here reads
+  # as "this branch has no pull request" — a silent pass built out of an
+  # outage. The status has to survive to the caller.
+  gpn_raw=$(gate_gh_api "pulls?state=open&head=$gpn_owner:$gpn_branch&per_page=100" "$gpn_err") || return 1
+  [ -n "$gpn_raw" ] || return 1
+  printf '%s' "$gpn_raw" | jq -r '.[0].number // empty'
+}
+
+gate_review_threads() {
+  # Thread resolution lives only in GraphQL; there is no REST equivalent.
+  grt_number="$1"
+  grt_err="$2"
+  grt_owner=${ORIGIN_REPO%%/*}
+  grt_repo=${ORIGIN_REPO#*/}
+  grt_query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewThreads(first:100){nodes{isResolved comments(first:100){nodes{databaseId}}}}}}}'
+  if command -v gh >/dev/null 2>&1; then
+    gh api graphql -f query="$grt_query" -F owner="$grt_owner" -F name="$grt_repo" -F number="$grt_number" 2>"$grt_err"
+    return $?
+  fi
+  init_github_rest 2>>"$grt_err" || return 1
+  grt_payload=$(jq -n --arg q "$grt_query" --arg o "$grt_owner" --arg n "$grt_repo" --argjson num "$grt_number" \
+    '{query: $q, variables: {owner: $o, name: $n, number: $num}}')
+  curl -fsS \
+    -H "Accept: application/vnd.github+json" \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "Content-Type: application/json" \
+    -X POST "https://api.github.com/graphql" \
+    -d "$grt_payload" 2>"$grt_err"
+}
+
+gate_bot_reviews() {
+  # STAGE 3 — every comment the automated reviewers left must be ADDRESSED.
+  #
+  # "Addressed" means a positive act recorded on the pull request itself:
+  #   * an inline review comment whose thread is marked resolved, or which has
+  #     a substantive non-bot reply in that same thread; or
+  #   * a PR-level comment or review answered by a substantive non-bot comment
+  #     or review posted after it; or
+  #   * the same bot posting an APPROVED review after it — the reviewer
+  #     withdrew its own objection.
+  #
+  # Deliberately NOT "a commit newer than the comment": this refinery rebases
+  # every branch it touches, so commit timestamps move on their own and that
+  # rule would pass without anyone reading a word. Every accepted form above
+  # requires somebody to act, and every one is readable back from the API.
+  gbr_number="$1"
+  GATE_DETAIL=""
+  if [ -z "$gbr_number" ]; then
+    GATE_DETAIL="no pull request number to check automated review comments against"
+    return 2
+  fi
+  gbr_err=$(mktemp)
+  gbr_issue_comments=$(gate_gh_api "issues/$gbr_number/comments?per_page=100" "$gbr_err")
+  gbr_status=$?
+  gbr_error=$(cat "$gbr_err")
+  if [ "$gbr_status" -ne 0 ] || [ -z "$gbr_issue_comments" ]; then
+    rm -f "$gbr_err"
+    GATE_DETAIL="could not read PR #$gbr_number comments: ${gbr_error:-no response}"
+    return 2
+  fi
+  gbr_review_comments=$(gate_gh_api "pulls/$gbr_number/comments?per_page=100" "$gbr_err")
+  gbr_status=$?
+  gbr_error=$(cat "$gbr_err")
+  if [ "$gbr_status" -ne 0 ] || [ -z "$gbr_review_comments" ]; then
+    rm -f "$gbr_err"
+    GATE_DETAIL="could not read PR #$gbr_number review comments: ${gbr_error:-no response}"
+    return 2
+  fi
+  gbr_reviews=$(gate_gh_api "pulls/$gbr_number/reviews?per_page=100" "$gbr_err")
+  gbr_status=$?
+  gbr_error=$(cat "$gbr_err")
+  if [ "$gbr_status" -ne 0 ] || [ -z "$gbr_reviews" ]; then
+    rm -f "$gbr_err"
+    GATE_DETAIL="could not read PR #$gbr_number reviews: ${gbr_error:-no response}"
+    return 2
+  fi
+  gbr_threads=$(gate_review_threads "$gbr_number" "$gbr_err")
+  gbr_status=$?
+  gbr_error=$(cat "$gbr_err")
+  rm -f "$gbr_err"
+  if [ "$gbr_status" -ne 0 ] || [ -z "$gbr_threads" ]; then
+    GATE_DETAIL="could not read PR #$gbr_number review-thread resolution: ${gbr_error:-no response}"
+    return 2
+  fi
+  gbr_resolved=$(printf '%s' "$gbr_threads" | jq -c '
+    [ (.data.repository.pullRequest.reviewThreads.nodes // [])[]
+      | select(.isResolved) | (.comments.nodes // [])[] | .databaseId ]' 2>/dev/null)
+  if [ -z "$gbr_resolved" ]; then
+    GATE_DETAIL="could not parse PR #$gbr_number review-thread resolution"
+    return 2
+  fi
+  gbr_unaddressed=$(jq -n -r \
+    --arg bots "$REVIEW_BOTS" \
+    --argjson issue_comments "$gbr_issue_comments" \
+    --argjson review_comments "$gbr_review_comments" \
+    --argjson reviews "$gbr_reviews" \
+    --argjson resolved "$gbr_resolved" '
+      def trimmed: (. // "") | gsub("^[[:space:]]+|[[:space:]]+$"; "");
+      def botlist: ($bots | split(",") | map(trimmed));
+      def isreviewbot: ((.user.login // "")) as $login | ((botlist | index($login)) != null);
+      def isanybot: (isreviewbot or ((.user.type // "User") == "Bot"));
+      def substantive:
+        (trimmed) as $t
+        | ($t | ascii_downcase | gsub("[^a-z]"; "")) as $key
+        | ($t | length) >= 24
+          and ((["done","fixed","ok","okay","lgtm","addressed","ack","acked","thanks","noted","na","tbd","todo","wontfix","looksgood","noissues"] | index($key)) == null);
+      [ ($issue_comments[] | select(isanybot | not) | select(.body | substantive) | .created_at),
+        ($reviews[] | select(isanybot | not) | select(.body | substantive) | .submitted_at) ] as $replies
+      | [ $reviews[] | select(isreviewbot) | select(.state == "APPROVED")
+          | {login: (.user.login // ""), ts: .submitted_at} ] as $approvals
+      | [ ($issue_comments[] | select(isreviewbot) | select((.body | trimmed | length) > 0)
+            | {kind: "pr_comment", id: .id, login: (.user.login // ""), ts: .created_at}),
+          ($reviews[] | select(isreviewbot) | select(.state != "APPROVED") | select((.body | trimmed | length) > 0)
+            | {kind: "review", id: .id, login: (.user.login // ""), ts: .submitted_at}) ] as $prlevel
+      | ($review_comments | map(. + {root: (.in_reply_to_id // .id)})) as $threaded
+      | [ ($prlevel[] | . as $a
+            | select(([$replies[] | select(. > $a.ts)] | length) == 0)
+            | select(([$approvals[] | select(.login == $a.login and .ts > $a.ts)] | length) == 0)),
+          ($threaded[] | select(isreviewbot) | . as $c
+            | select(($resolved | index($c.id)) == null and ($resolved | index($c.root)) == null)
+            | select(([$threaded[]
+                       | select(.root == $c.root and (isanybot | not)
+                                and .created_at > $c.created_at and (.body | substantive))] | length) == 0)
+            | {kind: "inline_comment", id: $c.id, login: ($c.user.login // ""), ts: $c.created_at}) ]
+      | map(.login + " " + .kind + " " + (.id | tostring) + " @" + .ts)
+      | .[]' 2>/dev/null)
+  gbr_jq_status=$?
+  if [ "$gbr_jq_status" -ne 0 ]; then
+    GATE_DETAIL="could not evaluate automated review comments on PR #$gbr_number"
+    return 2
+  fi
+  if [ -n "$gbr_unaddressed" ]; then
+    GATE_DETAIL="$(printf '%s\n' "$gbr_unaddressed" | grep -c '') unaddressed automated review comment(s) on PR #$gbr_number: $(printf '%s' "$gbr_unaddressed" | tr '\n' ';')"
+    return 1
+  fi
+  echo "REVIEW_GATE_CLEAR: no unaddressed automated review comments on PR #$gbr_number"
+  return 0
+}
+
+gate_run() {
+  # Drives one stage and turns its return code into the pack's two existing
+  # dispositions: reject to the pool (branch's fault) or STOP without mutating
+  # bead state (ours). There is no third disposition, and no path that
+  # silently continues.
+  grn_stage="$1"
+  grn_disposition="$2"
+  shift 2
+  "$@"
+  grn_status=$?
+  case "$grn_status" in
+    0) return 0 ;;
+    1) gate_reject "$grn_stage" "$grn_disposition" "$GATE_DETAIL" ;;
+    *)
+      echo "GATE_UNDETERMINED $grn_stage: $GATE_DETAIL"
+      echo "STOP. Do not mutate bead state, do not merge, do not close. Cannot prove green is not green."
+      gc runtime drain-ack
+      exit 1
+      ;;
+  esac
+}
+# END REFINERY_MERGE_GATE
+
 if [ "$MERGE_STRATEGY" = "mr" ] && [ -n "$EXISTING_PR" ]; then
   if [ -z "$BRANCH" ] || [ "$BRANCH" = "null" ]; then
     block_existing_pr "metadata.existing_pr is set but metadata.branch is missing."
@@ -763,6 +1348,47 @@ pour the next wisp and burn this one) — the same tail a normal merge takes. Do
 NOT drain-ack here; that would strand the loop and leak the merged branch.
 Otherwise the branch has a verified real change and you continue to the merge.
 
+**0c. Gate chain — review, hosted CI, automated review comments:**
+
+Direct mode runs the SAME three gates as the pull-request handoff, and it
+needs them most: landing straight onto the target with only local checks is
+what took a rig's target branch from success:9 to failure:11 in two days. A
+branch with no pull request still has a head SHA, and hosted CI rules on SHAs
+— so publish the exact commit you intend to land, let CI judge that commit,
+and only then fast-forward the target onto it. The SHA CI blessed and the SHA
+that lands are then the same object, which is the whole point.
+
+```bash
+gate_run "Review gate" acceptance-unmet gate_review "origin/$TARGET" temp
+
+git checkout temp
+git push origin "HEAD:$BRANCH" --force-with-lease
+LAND_SHA=$(git rev-parse temp)
+
+gate_run "CI gate" ci-red gate_ci "$LAND_SHA"
+
+GATE_PR_ERR=$(mktemp)
+GATE_PR_NUMBER=$(gate_pr_number_for_branch "$BRANCH" "$GATE_PR_ERR")
+GATE_PR_STATUS=$?
+GATE_PR_ERROR=$(cat "$GATE_PR_ERR")
+rm -f "$GATE_PR_ERR"
+if [ "$GATE_PR_STATUS" -ne 0 ]; then
+  echo "GATE_UNDETERMINED Review-comment gate: could not ask GitHub whether $BRANCH has a pull request: ${GATE_PR_ERROR:-no response}"
+  echo "STOP. Do not mutate bead state, do not merge, do not close."
+  gc runtime drain-ack
+  exit 1
+fi
+if [ -n "$GATE_PR_NUMBER" ]; then
+  gate_run "Review-comment gate" review-comments-unaddressed gate_bot_reviews "$GATE_PR_NUMBER"
+else
+  echo "REVIEW_GATE_CLEAR: $BRANCH has no pull request, so there is no automated review surface."
+fi
+```
+
+If `--force-with-lease` fails, the source branch moved after your fetch: STOP,
+re-fetch, rebase again, and re-run the gates against the new SHA. Never plain
+`--force`, and never merge a SHA the gates did not rule on.
+
 **1. Merge, push, verify, and close work bead:**
 
 Run this as one script. It uses a temporary detached worktree for the
@@ -802,7 +1428,8 @@ gc bd update "$WORK" \
   --set-metadata merge_result=merged \
   --set-metadata merged_sha="$MERGED_SHA" \
   --set-metadata merged_target="$TARGET" \
-  --unset-metadata rejection_reason && \
+  --unset-metadata rejection_reason \
+  --unset-metadata recovery.disposition && \
 gc bd close "$WORK" --reason "Merged to $TARGET at $MERGED_SHORT"
 ```
 
@@ -813,7 +1440,12 @@ Both the `--set-metadata` write and the `gc bd close` are required —
 `merged_sha` and `merged_target` are the only forensic breadcrumbs tying a
 closed bead to its merge commit on `$TARGET`. `--unset-metadata
 rejection_reason` clears any stale rejection field from an earlier
-rejected/reworked attempt before the successful close.
+rejected/reworked attempt before the successful close, and
+`--unset-metadata recovery.disposition` clears its companion from a gate
+rejection. Do not split the chain: a bead carrying both "closed merged" and a
+live rejection field is internally contradictory. `ci_gate_sha` is already on
+the bead — the CI gate stamped it — and it must equal `merged_sha`; if it does
+not, the SHA that landed is not the SHA CI proved.
 
 **2. Cleanup:**
 ```bash
@@ -846,6 +1478,17 @@ case "$BHRC_STATUS" in
     exit 1
     ;;
 esac
+```
+
+**0b. Review gate (before any pull request exists):**
+
+The correctness verdict is judged here, not after publication: a PR is a
+handoff, and handing off a diff you have not read is the same defect as
+merging one. The gate reads the verdict the review-diff step recorded and
+refuses to publish without it.
+
+```bash
+gate_run "Review gate" acceptance-unmet gate_review "origin/$TARGET" temp
 ```
 
 **1. Push the rebased branch back to origin:**
@@ -1046,6 +1689,42 @@ fi
 ```
 If this command fails or prints empty output: STOP. Debug and retry. Do NOT continue.
 
+**3b. Gate chain: hosted CI, then automated review comments:**
+
+The pull request exists; it is not finished. Publishing a PR closes this work
+bead, so everything a human reviewer would wait for has to be true BEFORE the
+close: the hosted checks that a Linux polecat cannot run locally, and the
+automated reviewers that comment on every PR on this rig.
+
+Ask GitHub for the PR head SHA rather than trusting the local ref — if the two
+disagree, something pushed after you and the checks you are about to read
+belong to a different commit.
+
+```bash
+GATE_HEAD_ERR=$(mktemp)
+GATE_PR_RAW=$(gate_gh_api "pulls/$PR_NUMBER" "$GATE_HEAD_ERR")
+GATE_HEAD_STATUS=$?
+GATE_HEAD_ERROR=$(cat "$GATE_HEAD_ERR")
+rm -f "$GATE_HEAD_ERR"
+if [ "$GATE_HEAD_STATUS" -ne 0 ] || [ -z "$GATE_PR_RAW" ]; then
+  echo "Could not read the head SHA of PR #$PR_NUMBER: ${GATE_HEAD_ERROR:-no response}"
+  echo "STOP. Do not mutate bead state, do not close."
+  gc runtime drain-ack
+  exit 1
+fi
+GATE_PR_HEAD_SHA=$(printf '%s' "$GATE_PR_RAW" | jq -r '.head.sha // empty')
+LOCAL_HEAD_SHA=$(git rev-parse temp)
+if [ -z "$GATE_PR_HEAD_SHA" ] || [ "$GATE_PR_HEAD_SHA" != "$LOCAL_HEAD_SHA" ]; then
+  echo "PR #$PR_NUMBER head is '${GATE_PR_HEAD_SHA:-unknown}' but you pushed $LOCAL_HEAD_SHA."
+  echo "STOP. Re-fetch, rebase, re-run the gates against the SHA the PR actually carries."
+  gc runtime drain-ack
+  exit 1
+fi
+
+gate_run "CI gate" ci-red gate_ci "$GATE_PR_HEAD_SHA"
+gate_run "Review-comment gate" review-comments-unaddressed gate_bot_reviews "$PR_NUMBER"
+```
+
 **4. Record PR metadata and close the work bead:**
 
 Run as a single chained command so the metadata write cannot be skipped
@@ -1062,9 +1741,15 @@ gc bd update $WORK \
   --set-metadata pr_url="$PR_URL" \
   --set-metadata pr_number="$PR_NUMBER" \
   --set-metadata merged_target="$TARGET" \
-  --unset-metadata rejection_reason && \
+  --unset-metadata rejection_reason \
+  --unset-metadata recovery.disposition && \
 gc bd close $WORK --reason "Pull request ready: $PR_URL"
 ```
+
+`--unset-metadata recovery.disposition` clears the companion field a gate
+rejection sets, for the same reason `rejection_reason` is cleared: a closed
+bead advertising a live rejection is a contradictory record. `ci_gate_sha` and
+`ci_gate_result` stay — they are the proof this PR was green when it closed.
 
 **5. Cleanup:**
 ```bash
@@ -1085,7 +1770,12 @@ The Gastown example refinery supports direct and mr/pr merge strategies only."
 ```
 Do NOT close the bead, delete the branch, or burn the wisp until a human decides how to proceed.
 
-**GATE**: direct mode requires verified target push. mr mode requires verified PR URL. Bead closure only happens after the selected handoff is confirmed."""
+**GATE**: direct mode requires verified target push. mr mode requires verified
+PR URL. Both modes require all three pre-close gates — recorded review verdict,
+hosted CI green on the exact SHA being landed, and no unaddressed automated
+review comments. Bead closure only happens after the selected handoff is
+confirmed AND every gate has ruled. No gate may be skipped because the local
+checks passed: local checks are why the incident was invisible."""
 
 [[steps]]
 id = "patrol-summary"

--- a/gastown/tests/test_refinery_merge_gate.sh
+++ b/gastown/tests/test_refinery_merge_gate.sh
@@ -1,0 +1,894 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Regression suite for the refinery's three pre-close gates.
+#
+# Reproduction: on a live rig the refinery merged every bead whose LOCAL checks
+# passed, and nothing anywhere in its assets read the hosted verdict. The target
+# branch went success:9 (07-22) -> failure:3 (07-23) -> failure:11 (07-24), every
+# failure a cross-platform target a Linux polecat cannot build. The fix is three
+# fail-closed gates between a rebased branch and `gc bd close`: the refinery's
+# own review of the diff, hosted CI green on the exact SHA being landed, and
+# automated review comments addressed.
+#
+# The gates ship as an executable block inside mol-refinery-patrol, so this
+# suite extracts the SHIPPED block and the SHIPPED call chains and runs them
+# against a hermetic `gh`/`gc` and a real throwaway git repository, rather than
+# asserting on prose. Timing knobs are overridden in the driver so the bounded
+# waits resolve immediately; their shipped defaults are asserted separately.
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+GASTOWN="$ROOT/gastown"
+FORMULA="$GASTOWN/formulas/mol-refinery-patrol.toml"
+PROMPT="$GASTOWN/agents/refinery/prompt.template.md"
+
+WORK_ID="ki-hu3"
+BRANCH_NAME="fix/sp-int-truncation"
+ORIGIN_REPO_NAME="gastownhall/kisakcod"
+
+# The real failing checks from the incident, verbatim.
+RED_CHECK_ONE="Windows x86 SP / Release"
+RED_CHECK_TWO="Portable tests / macOS arm64"
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+# Extracts a shipped fragment from the formula: the gate block itself, one of
+# the two call chains that drive it, or the direct-mode close command. Formula
+# vars are substituted with their SHIPPED defaults, so the suite exercises what
+# a poured wisp actually runs.
+extract_shipped() {
+    local what=$1 output=$2
+    python3 - "$FORMULA" "$what" "$output" <<'PY'
+import pathlib
+import sys
+import tomllib
+
+formula_path, what, output_path = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(formula_path, "rb") as handle:
+    data = tomllib.load(handle)
+steps = {step["id"]: step for step in data["steps"]}
+if "review-diff" not in steps:
+    sys.exit("formula lost the pre-PR review step")
+description = steps["merge-push"]["description"]
+
+
+def fenced(section_marker):
+    section = description[description.index(section_marker):]
+    return section.split("```bash", 1)[1].split("```", 1)[0]
+
+
+if what == "gate-block":
+    begin = description.index("# BEGIN REFINERY_MERGE_GATE")
+    end = description.index("# END REFINERY_MERGE_GATE", begin)
+    fragment = description[begin:end]
+elif what == "direct-chain":
+    fragment = fenced("**0c. Gate chain")
+elif what == "mr-chain":
+    fragment = fenced("**3b. Gate chain")
+elif what == "direct-close":
+    start = description.index('gc bd update "$WORK" --set-metadata merge_result=merged')
+    end = description.index("\n", description.index('gc bd close "$WORK"', start))
+    fragment = description[start:end]
+else:
+    sys.exit(f"unknown fragment {what}")
+
+for name, spec in data["vars"].items():
+    fragment = fragment.replace("{{%s}}" % name, spec.get("default", ""))
+fragment = fragment.replace("{{rig_name}}", "kisakcod")
+if "{{" in fragment:
+    sys.exit("shipped fragment still carries an unsubstituted formula var")
+pathlib.Path(output_path).write_text(fragment + "\n", encoding="utf-8")
+PY
+}
+
+# Hermetic GitHub. Serves per-request fixtures out of a directory; a missing
+# fixture models an API failure, which the gates must never read as a pass.
+# Sequenced fixtures (<name>.1.json, <name>.2.json) model checks that finish
+# between polls.
+write_gh_stub() {
+    cat >"$BIN/gh" <<'SH'
+#!/usr/bin/env bash
+printf 'GH %s\n' "$*" >>"$GC_TEST_CALLS"
+serve() {
+    name="$1"
+    count=$(( $(cat "$GH_FIXTURES/$name.count" 2>/dev/null || echo 0) + 1 ))
+    printf '%s' "$count" >"$GH_FIXTURES/$name.count"
+    if [ -f "$GH_FIXTURES/$name.$count.json" ]; then
+        cat "$GH_FIXTURES/$name.$count.json"
+        return 0
+    fi
+    if [ -f "$GH_FIXTURES/$name.json" ]; then
+        cat "$GH_FIXTURES/$name.json"
+        return 0
+    fi
+    printf 'HTTP 502: upstream unavailable (%s)\n' "$name" >&2
+    return 1
+}
+case "$*" in
+    *graphql*) serve threads ;;
+    */check-runs*) serve check-runs ;;
+    */commits/*/status*) serve status ;;
+    */issues/*/comments*) serve issue-comments ;;
+    */pulls/*/comments*) serve review-comments ;;
+    */pulls/*/reviews*) serve reviews ;;
+    *pulls?state=open*) serve pulls ;;
+    */pulls/*) serve pull ;;
+    *) printf 'unexpected gh call: %s\n' "$*" >&2; exit 97 ;;
+esac
+SH
+    chmod +x "$BIN/gh"
+}
+
+# Hermetic stand-in for the real CLI. It dispatches on argv positions and never
+# spells out a bare "<beads-cli> <subcommand>" string: tests/test_no_bare_bd_commands.py
+# rejects that spelling anywhere in tracked assets, fixtures included. Mutating
+# calls are logged under distinct markers so assertions never have to match on
+# that spelling either.
+write_gc_stub() {
+    cat >"$BIN/gc" <<'SH'
+#!/usr/bin/env bash
+case "$1" in
+    bd)
+        case "$2" in
+            show) cat "$GC_TEST_BEAD_JSON" ;;
+            update) printf 'UPDATE %s\n' "$*" >>"$GC_TEST_CALLS" ;;
+            close) printf 'CLOSE %s\n' "$*" >>"$GC_TEST_CALLS" ;;
+            *) printf 'unexpected: %s\n' "$*" >&2; exit 97 ;;
+        esac
+        ;;
+    workflow) printf 'WORKFLOW %s\n' "$*" >>"$GC_TEST_CALLS" ;;
+    runtime) printf 'RUNTIME %s\n' "$*" >>"$GC_TEST_CALLS" ;;
+    session|mail) printf 'NOTIFY %s\n' "$*" >>"$GC_TEST_CALLS" ;;
+    *) printf 'unexpected: %s\n' "$*" >&2; exit 97 ;;
+esac
+exit 0
+SH
+    chmod +x "$BIN/gc"
+}
+
+write_driver() {
+    cat >"$DRIVER" <<'SH'
+#!/usr/bin/env bash
+# Stands in for the refinery session: the same variables the earlier merge-push
+# script sets, then the shipped gate block, then the shipped call chain.
+cd "$GATE_TEST_REPO_DIR" || exit 90
+WORK="$GATE_TEST_WORK"
+BRANCH="$GATE_TEST_BRANCH"
+TARGET="$GATE_TEST_TARGET"
+ORIGIN_REPO="$GATE_TEST_ORIGIN_REPO"
+PR_NUMBER="${GATE_TEST_PR_NUMBER:-}"
+GC_RIG="kisakcod"
+. "$GATE_BLOCK"
+CI_POLL_SECONDS=0
+CI_TIMEOUT_SECONDS="$GATE_TEST_CI_TIMEOUT"
+CI_ZERO_CHECK_GRACE_SECONDS="$GATE_TEST_CI_GRACE"
+CI_GATE="$GATE_TEST_CI_GATE"
+. "$GATE_CHAIN"
+echo "CHAIN_COMPLETED"
+SH
+}
+
+# A real repository, because the review gate diffs real refs and the direct
+# chain really pushes. `origin` is a local bare repo, so --force-with-lease
+# behaves exactly as it does against GitHub.
+setup_case() {
+    TMP=$(mktemp -d)
+    BIN="$TMP/bin"
+    FIX="$TMP/fixtures"
+    CALLS="$TMP/calls"
+    BEAD="$TMP/bead.json"
+    BLOCK="$TMP/gate-block.sh"
+    DRIVER="$TMP/driver.sh"
+    REPO="$TMP/work"
+    ORIGIN="$TMP/origin.git"
+    mkdir -p "$BIN" "$FIX"
+    : >"$CALLS"
+    extract_shipped gate-block "$BLOCK"
+    bash -n "$BLOCK" || fail "the shipped gate block is not valid shell"
+    write_gh_stub
+    write_gc_stub
+    write_driver
+
+    git init --quiet --bare "$ORIGIN"
+    git init --quiet "$REPO"
+    git -C "$REPO" symbolic-ref HEAD refs/heads/main
+    git -C "$REPO" config user.email "refinery@test.invalid"
+    git -C "$REPO" config user.name "Refinery Test"
+    git -C "$REPO" remote add origin "$ORIGIN"
+    mkdir -p "$REPO/src"
+    printf 'int route_legacy(void) { return 0; }\n' >"$REPO/src/route.c"
+    git -C "$REPO" add -A
+    git -C "$REPO" commit --quiet -m "base"
+    git -C "$REPO" push --quiet origin main
+    git -C "$REPO" checkout --quiet -b temp
+    printf 'int route_legacy(void) { return 0; }\nint route_candidate(void) { return 1; }\n' >"$REPO/src/route.c"
+    git -C "$REPO" commit --quiet -am "candidate route"
+    git -C "$REPO" push --quiet origin "temp:$BRANCH_NAME"
+    git -C "$REPO" fetch --quiet origin
+    HEAD_SHA=$(git -C "$REPO" rev-parse temp)
+    PUBLISHED_SHA=$(git -C "$REPO" rev-parse "origin/$BRANCH_NAME")
+}
+
+# Records the review-diff step's verdict on the bead.
+write_bead() {
+    local sha=$1 verdict=$2 acceptance=$3 evidence=$4 defect=$5
+    jq -n \
+        --arg id "$WORK_ID" \
+        --arg branch "$BRANCH_NAME" \
+        --arg sha "$sha" \
+        --arg verdict "$verdict" \
+        --arg acceptance "$acceptance" \
+        --arg evidence "$evidence" \
+        --arg defect "$defect" \
+        '[{id: $id, status: "in_progress", metadata: {
+             branch: $branch, target: "main",
+             review_sha: $sha, review_verdict: $verdict,
+             review_acceptance: $acceptance, review_evidence: $evidence,
+             review_defect: $defect}}]' >"$BEAD"
+}
+
+# The verdict a real, cited review produces: names the criterion, names the
+# file the diff touches, names the production call site.
+pass_bead() {
+    write_bead "$HEAD_SHA" pass \
+        "Acceptance: SP int truncation removed from the candidate route path" \
+        "src/route.c adds route_candidate and the legacy db_load path in src/route.c now calls it; traced the caller, boundary at 0 and INT_MAX handled" \
+        ""
+}
+
+fixture() {
+    cat >"$FIX/$1"
+}
+
+green_ci_fixtures() {
+    fixture check-runs.json <<JSON
+{"total_count": 2, "check_runs": [
+  {"name": "Portable tests / Linux amd64", "status": "completed", "conclusion": "success"},
+  {"name": "Lint", "status": "completed", "conclusion": "skipped"}
+]}
+JSON
+    fixture status.json <<'JSON'
+{"state": "success", "statuses": []}
+JSON
+}
+
+no_pr_fixtures() {
+    fixture pulls.json <<'JSON'
+[]
+JSON
+}
+
+clean_review_fixtures() {
+    fixture pulls.json <<'JSON'
+[{"number": 84}]
+JSON
+    fixture issue-comments.json <<'JSON'
+[]
+JSON
+    fixture review-comments.json <<'JSON'
+[]
+JSON
+    fixture reviews.json <<'JSON'
+[]
+JSON
+    fixture threads.json <<'JSON'
+{"data": {"repository": {"pullRequest": {"reviewThreads": {"nodes": []}}}}}
+JSON
+}
+
+run_chain() {
+    local chain=$1
+    CODE=0
+    set +e
+    OUTPUT=$(
+        PATH="$BIN:$PATH" \
+        GC_TEST_CALLS="$CALLS" \
+        GC_TEST_BEAD_JSON="$BEAD" \
+        GH_FIXTURES="$FIX" \
+        GATE_TEST_REPO_DIR="$REPO" \
+        GATE_TEST_WORK="$WORK_ID" \
+        GATE_TEST_BRANCH="$BRANCH_NAME" \
+        GATE_TEST_TARGET="main" \
+        GATE_TEST_ORIGIN_REPO="$ORIGIN_REPO_NAME" \
+        GATE_TEST_PR_NUMBER="${PR_NUMBER_OVERRIDE:-}" \
+        GATE_TEST_CI_TIMEOUT="${CI_TIMEOUT_OVERRIDE:-0}" \
+        GATE_TEST_CI_GRACE="${CI_GRACE_OVERRIDE:-0}" \
+        GATE_TEST_CI_GATE="${CI_GATE_OVERRIDE:-true}" \
+        GATE_BLOCK="$BLOCK" \
+        GATE_CHAIN="$chain" \
+        bash "$DRIVER" 2>&1
+    )
+    CODE=$?
+    set -e
+}
+
+run_direct_chain() {
+    local chain="$TMP/direct-chain.sh"
+    extract_shipped direct-chain "$chain"
+    run_chain "$chain"
+}
+
+run_mr_chain() {
+    local chain="$TMP/mr-chain.sh"
+    extract_shipped mr-chain "$chain"
+    run_chain "$chain"
+}
+
+assert_not_closed() {
+    ! grep -q '^CLOSE ' "$CALLS" ||
+        fail "$1: the bead was closed anyway: $(grep '^CLOSE ' "$CALLS")"
+}
+
+assert_rejected() {
+    local stage=$1 disposition=$2 needle=$3
+    [[ "$CODE" -eq 1 ]] || fail "$stage must reject with exit 1 (got $CODE): $OUTPUT"
+    [[ "$OUTPUT" == *"GATE_REJECTED $WORK_ID $stage"* ]] ||
+        fail "$stage must report GATE_REJECTED naming the gate: $OUTPUT"
+    grep -F -- '--status=open' "$CALLS" >/dev/null ||
+        fail "$stage must put the bead back in the pool"
+    grep -F -- '--assignee=' "$CALLS" >/dev/null ||
+        fail "$stage must release the refinery claim"
+    grep -F -- "--set-metadata rejection_reason=$stage:" "$CALLS" >/dev/null ||
+        fail "$stage must write a rejection_reason naming the gate: $(cat "$CALLS")"
+    grep -F -- "--set-metadata recovery.disposition=$disposition" "$CALLS" >/dev/null ||
+        fail "$stage must write recovery.disposition=$disposition"
+    grep -F -- "$needle" "$CALLS" >/dev/null ||
+        fail "$stage rejection_reason must be specific enough to act on (want '$needle'): $(cat "$CALLS")"
+    grep -F -- 'gc.routed_to' "$CALLS" >/dev/null ||
+        fail "$stage must route the bead back to the polecat pool"
+    assert_not_closed "$stage"
+    [[ "$OUTPUT" == *"left intact for fix-forward"* ]] ||
+        fail "$stage must leave the branch intact for fix-forward: $OUTPUT"
+}
+
+assert_undetermined() {
+    local label=$1 needle=$2
+    [[ "$CODE" -ne 0 ]] || fail "$label must not pass: $OUTPUT"
+    [[ "$OUTPUT" == *"GATE_UNDETERMINED"* ]] ||
+        fail "$label must report GATE_UNDETERMINED: $OUTPUT"
+    [[ "$OUTPUT" == *"$needle"* ]] ||
+        fail "$label must say why it could not be determined (want '$needle'): $OUTPUT"
+    ! grep -F -- '--status=open' "$CALLS" >/dev/null ||
+        fail "$label is our fault, not the branch's: it must not reject the bead"
+    assert_not_closed "$label"
+}
+
+# ---------------------------------------------------------------------------
+
+# The shipped defaults decide what a city gets without configuration, so they
+# are part of the contract.
+test_shipped_defaults_are_fail_closed() {
+    python3 - "$FORMULA" "$PROMPT" <<'PY'
+import sys
+import tomllib
+
+with open(sys.argv[1], "rb") as handle:
+    data = tomllib.load(handle)
+variables = data["vars"]
+if variables["ci_gate"]["default"] != "true":
+    raise SystemExit("ci_gate must default to on; a gate off by default is not a gate")
+for name in ("ci_timeout_seconds", "ci_zero_check_grace_seconds"):
+    if int(variables[name]["default"]) <= 0:
+        raise SystemExit(f"{name} must leave a real window; 0 would reject every honest branch")
+bots = variables["review_bots"]["default"]
+for bot in ("gemini-code-assist[bot]", "chatgpt-codex-connector[bot]"):
+    if bot not in bots:
+        raise SystemExit(f"review_bots must cover {bot}")
+
+steps = {step["id"]: step for step in data["steps"]}
+if steps["merge-push"]["needs"] != ["review-diff"]:
+    raise SystemExit("merge-push must depend on the review step; a skippable review is not a gate")
+prompt = open(sys.argv[2], encoding="utf-8").read()
+for needle in ("Pre-Close Gates", "zero check-runs", "gemini-code-assist[bot]",
+               "chatgpt-codex-connector[bot]", "recovery.disposition"):
+    if needle not in prompt:
+        raise SystemExit(f"refinery prompt must document {needle}")
+if 'FORBIDDEN: Reading polecat code to "understand what they were trying to do."' in prompt:
+    raise SystemExit("the prompt cannot forbid reading the diff and also require reviewing it")
+PY
+}
+
+# Direct mode is the default and is what produced the incident, so it must run
+# every gate the pull-request path runs, and it must gate the SHA it lands.
+test_direct_mode_runs_all_three_gates_before_it_merges() {
+    python3 - "$FORMULA" <<'PY'
+import sys
+import tomllib
+
+with open(sys.argv[1], "rb") as handle:
+    data = tomllib.load(handle)
+description = {step["id"]: step for step in data["steps"]}["merge-push"]["description"]
+direct = description[description.index('**If MERGE_STRATEGY = "direct"'):description.index('**If MERGE_STRATEGY = "mr"')]
+merge_script = direct.index("git worktree add --detach")
+for call in ("gate_review", "gate_ci", "gate_bot_reviews"):
+    if call not in direct:
+        raise SystemExit(f"direct mode must run {call}")
+    if direct.index(call) > merge_script:
+        raise SystemExit(f"{call} must rule before direct mode touches the target branch")
+if direct.index("gate_review") > direct.index("gate_ci"):
+    raise SystemExit("the review verdict must precede publication and CI")
+if 'git push origin "HEAD:$BRANCH"' not in direct:
+    raise SystemExit("direct mode must publish the exact SHA it intends to land so CI can rule on it")
+for unset in ("--unset-metadata rejection_reason", "--unset-metadata recovery.disposition"):
+    if unset not in direct:
+        raise SystemExit(f"the successful close must clear {unset.split()[-1]}")
+
+mr = description[description.index('**If MERGE_STRATEGY = "mr"'):]
+close = mr.index("--set-metadata merge_result=pull_request")
+for call in ("gate_review", "gate_ci", "gate_bot_reviews"):
+    if mr.index(call) > close:
+        raise SystemExit(f"mr mode must run {call} before it closes the bead")
+PY
+}
+
+# Stage 1, the live shape from the affected city: acceptance unmet because the
+# candidate has no production call site. It must reject BEFORE anything is
+# published, and without asking GitHub anything.
+test_review_gate_rejects_a_cited_defect_before_anything_is_published() {
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+
+    write_bead "$HEAD_SHA" reject "" "" \
+        "Acceptance unmet: src/route.c adds route_candidate but no production route call site reaches it; legacy db_load path remains the only path"
+
+    run_direct_chain
+    assert_rejected "Review gate" "acceptance-unmet" "no production route call site"
+    ! grep -q '^GH ' "$CALLS" ||
+        fail "a review rejection must not need GitHub at all: $(grep '^GH ' "$CALLS")"
+    [[ "$(git -C "$REPO" rev-parse "origin/$BRANCH_NAME")" == "$PUBLISHED_SHA" ]] ||
+        fail "a review rejection must happen before the branch is published"
+}
+
+# A gate an agent satisfies by asserting "looks good" manufactures false
+# confidence. Every one of these must refuse rather than pass.
+test_review_gate_refuses_verdicts_that_cite_nothing() {
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+
+    write_bead "" "" "" "" ""
+    run_direct_chain
+    assert_undetermined "an unreviewed diff" "review_verdict is 'unset'"
+
+    : >"$CALLS"
+    write_bead "$HEAD_SHA" pass "Acceptance: the candidate route is wired in" "LGTM" ""
+    run_direct_chain
+    assert_undetermined "a rubber-stamp approval" "review_evidence"
+
+    : >"$CALLS"
+    write_bead "$HEAD_SHA" pass \
+        "Acceptance: SP int truncation removed from the candidate route path" \
+        "I read the whole change carefully and traced the logic end to end; everything looks correct and I am confident it behaves" \
+        ""
+    run_direct_chain
+    assert_undetermined "an approval citing no file in the diff" "cites no file this diff touches"
+
+    : >"$CALLS"
+    pass_bead
+    jq '.[0].metadata.review_sha = "0000000000000000000000000000000000000000"' "$BEAD" >"$BEAD.tmp"
+    mv "$BEAD.tmp" "$BEAD"
+    run_direct_chain
+    assert_undetermined "an approval of a different SHA" "review_sha"
+
+    : >"$CALLS"
+    write_bead "$HEAD_SHA" reject "" "" "this is wrong"
+    run_direct_chain
+    assert_undetermined "an uncitable rejection" "review_defect"
+}
+
+# The incident itself: hosted CI red on the head SHA.
+test_red_ci_rejects_and_does_not_close() {
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+    pass_bead
+
+    fixture check-runs.json <<JSON
+{"total_count": 3, "check_runs": [
+  {"name": "$RED_CHECK_ONE", "status": "completed", "conclusion": "failure"},
+  {"name": "$RED_CHECK_TWO", "status": "completed", "conclusion": "timed_out"},
+  {"name": "Portable tests / Linux amd64", "status": "completed", "conclusion": "success"}
+]}
+JSON
+    fixture status.json <<'JSON'
+{"state": "failure", "statuses": []}
+JSON
+
+    run_direct_chain
+    assert_rejected "CI gate" "ci-red" "$RED_CHECK_ONE"
+    grep -F -- "$RED_CHECK_TWO" "$CALLS" >/dev/null ||
+        fail "a timed_out check is red too and must be named"
+    [[ "$(git -C "$REPO" rev-parse "origin/$BRANCH_NAME")" == "$HEAD_SHA" ]] ||
+        fail "the reviewed SHA must be published so CI can rule on it, and left there for fix-forward"
+}
+
+# Several commits in the incident carried no checks at all. Nothing ran cannot
+# prove nothing is broken.
+test_zero_check_runs_is_not_green() {
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+    pass_bead
+
+    fixture check-runs.json <<'JSON'
+{"total_count": 0, "check_runs": []}
+JSON
+    fixture status.json <<'JSON'
+{"state": "pending", "statuses": []}
+JSON
+
+    run_direct_chain
+    assert_rejected "CI gate" "ci-red" "zero check-runs"
+}
+
+# Pending must WAIT, never pass — and the wait must be bounded.
+test_pending_checks_wait_and_never_pass() {
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+    pass_bead
+
+    # A red-free but unfinished board, with the wait window already exhausted.
+    fixture check-runs.json <<'JSON'
+{"total_count": 2, "check_runs": [
+  {"name": "Windows x86 / Debug", "status": "in_progress", "conclusion": null},
+  {"name": "Portable tests / Linux amd64", "status": "completed", "conclusion": "success"}
+]}
+JSON
+    fixture status.json <<'JSON'
+{"state": "pending", "statuses": []}
+JSON
+
+    run_direct_chain
+    assert_rejected "CI gate" "ci-red" "still running"
+    [[ "$OUTPUT" != *"CI_GATE_GREEN"* ]] ||
+        fail "an unfinished check board must never be reported green"
+
+    # The same board, given a window: it finishes green between polls and the
+    # gate proceeds. Pending is a wait, not a verdict.
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+    pass_bead
+    fixture check-runs.1.json <<'JSON'
+{"total_count": 2, "check_runs": [
+  {"name": "Windows x86 / Debug", "status": "queued", "conclusion": null},
+  {"name": "Portable tests / Linux amd64", "status": "completed", "conclusion": "success"}
+]}
+JSON
+    fixture check-runs.2.json <<'JSON'
+{"total_count": 2, "check_runs": [
+  {"name": "Windows x86 / Debug", "status": "completed", "conclusion": "success"},
+  {"name": "Portable tests / Linux amd64", "status": "completed", "conclusion": "success"}
+]}
+JSON
+    fixture status.json <<'JSON'
+{"state": "success", "statuses": []}
+JSON
+    no_pr_fixtures
+
+    CI_TIMEOUT_OVERRIDE=120 run_direct_chain
+    [[ "$CODE" -eq 0 ]] || fail "checks that finish green inside the window must pass: $OUTPUT"
+    [[ "$OUTPUT" == *"CI_GATE_GREEN"* ]] || fail "a green board must be reported green: $OUTPUT"
+}
+
+# An unrecognized conclusion is not on the accept list, so it is not a pass.
+test_unknown_conclusions_default_to_red() {
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+    pass_bead
+
+    fixture check-runs.json <<'JSON'
+{"total_count": 1, "check_runs": [
+  {"name": "Windows x86 (no Steam)", "status": "completed", "conclusion": "stale"}
+]}
+JSON
+    fixture status.json <<'JSON'
+{"state": "success", "statuses": []}
+JSON
+
+    run_direct_chain
+    assert_rejected "CI gate" "ci-red" "Windows x86 (no Steam)"
+}
+
+# Stage 3: the two bots that review every PR on this rig.
+test_unaddressed_bot_comments_reject() {
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+    pass_bead
+    green_ci_fixtures
+    fixture pulls.json <<'JSON'
+[{"number": 84}]
+JSON
+    fixture issue-comments.json <<'JSON'
+[
+  {"id": 9001, "user": {"login": "gemini-code-assist[bot]", "type": "Bot"},
+   "created_at": "2026-07-23T09:00:00Z",
+   "body": "The retry loop in src/route.c can spin forever when the transport returns EAGAIN."}
+]
+JSON
+    fixture review-comments.json <<'JSON'
+[]
+JSON
+    fixture reviews.json <<'JSON'
+[]
+JSON
+    fixture threads.json <<'JSON'
+{"data": {"repository": {"pullRequest": {"reviewThreads": {"nodes": []}}}}}
+JSON
+
+    run_direct_chain
+    assert_rejected "Review-comment gate" "review-comments-unaddressed" "gemini-code-assist[bot]"
+    grep -F -- 'PR #84' "$CALLS" >/dev/null ||
+        fail "the rejection must name the pull request the comments are on"
+}
+
+# The two shapes that would make the gate free: a bot answering a bot, and a
+# one-word acknowledgement. Neither is addressing anything.
+test_bot_replies_and_one_word_acks_do_not_address_anything() {
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+    pass_bead
+    green_ci_fixtures
+    fixture pulls.json <<'JSON'
+[{"number": 84}]
+JSON
+    fixture issue-comments.json <<'JSON'
+[
+  {"id": 9001, "user": {"login": "chatgpt-codex-connector[bot]", "type": "Bot"},
+   "created_at": "2026-07-23T09:00:00Z",
+   "body": "route_candidate never checks the return of route_legacy in src/route.c."},
+  {"id": 9002, "user": {"login": "github-actions[bot]", "type": "Bot"},
+   "created_at": "2026-07-23T09:05:00Z",
+   "body": "Coverage report: 84% of statements covered, no change from the base commit."},
+  {"id": 9003, "user": {"login": "polecat-nux", "type": "User"},
+   "created_at": "2026-07-23T09:06:00Z",
+   "body": "done"}
+]
+JSON
+    fixture review-comments.json <<'JSON'
+[]
+JSON
+    fixture reviews.json <<'JSON'
+[]
+JSON
+    fixture threads.json <<'JSON'
+{"data": {"repository": {"pullRequest": {"reviewThreads": {"nodes": []}}}}}
+JSON
+
+    run_direct_chain
+    assert_rejected "Review-comment gate" "review-comments-unaddressed" "chatgpt-codex-connector[bot]"
+}
+
+# An unresolved inline thread is unaddressed even when the PR has plenty of
+# unrelated conversation: inline comments are cleared in their own thread.
+test_unresolved_inline_thread_rejects() {
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+    pass_bead
+    green_ci_fixtures
+    fixture pulls.json <<'JSON'
+[{"number": 84}]
+JSON
+    fixture issue-comments.json <<'JSON'
+[
+  {"id": 9100, "user": {"login": "polecat-nux", "type": "User"},
+   "created_at": "2026-07-23T12:00:00Z",
+   "body": "Rebased onto main and re-ran the portable suites locally, all green."}
+]
+JSON
+    fixture review-comments.json <<'JSON'
+[
+  {"id": 501, "in_reply_to_id": null, "user": {"login": "gemini-code-assist[bot]", "type": "Bot"},
+   "created_at": "2026-07-23T10:00:00Z",
+   "body": "This drops the SP truncation guard; int overflow is reachable from the candidate path."}
+]
+JSON
+    fixture reviews.json <<'JSON'
+[]
+JSON
+    fixture threads.json <<'JSON'
+{"data": {"repository": {"pullRequest": {"reviewThreads": {"nodes": [
+  {"isResolved": false, "comments": {"nodes": [{"databaseId": 501}]}}
+]}}}}}
+JSON
+
+    run_direct_chain
+    assert_rejected "Review-comment gate" "review-comments-unaddressed" "inline_comment"
+}
+
+# Every accepted form of "addressed", then the close. This is the happy path,
+# end to end: gates rule, the merge lands, and the terminal update clears both
+# rejection fields before the close.
+test_addressed_comments_pass_and_the_happy_path_closes() {
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+    pass_bead
+    green_ci_fixtures
+    fixture pulls.json <<'JSON'
+[{"number": 84}]
+JSON
+    fixture issue-comments.json <<'JSON'
+[
+  {"id": 9001, "user": {"login": "gemini-code-assist[bot]", "type": "Bot"},
+   "created_at": "2026-07-23T09:00:00Z",
+   "body": "The retry loop in src/route.c can spin forever when the transport returns EAGAIN."},
+  {"id": 9002, "user": {"login": "polecat-nux", "type": "User"},
+   "created_at": "2026-07-23T11:00:00Z",
+   "body": "Bounded the retry loop in src/route.c at 5 attempts with backoff; EAGAIN now surfaces to the caller."}
+]
+JSON
+    fixture review-comments.json <<'JSON'
+[
+  {"id": 501, "in_reply_to_id": null, "user": {"login": "gemini-code-assist[bot]", "type": "Bot"},
+   "created_at": "2026-07-23T10:00:00Z",
+   "body": "This drops the SP truncation guard."},
+  {"id": 502, "in_reply_to_id": null, "user": {"login": "chatgpt-codex-connector[bot]", "type": "Bot"},
+   "created_at": "2026-07-23T10:05:00Z",
+   "body": "Prefer a named constant for the retry ceiling."}
+]
+JSON
+    fixture reviews.json <<'JSON'
+[
+  {"id": 700, "user": {"login": "chatgpt-codex-connector[bot]", "type": "Bot"},
+   "state": "CHANGES_REQUESTED", "submitted_at": "2026-07-23T10:05:00Z",
+   "body": "The candidate route path is not reachable from production yet."},
+  {"id": 701, "user": {"login": "chatgpt-codex-connector[bot]", "type": "Bot"},
+   "state": "APPROVED", "submitted_at": "2026-07-23T12:00:00Z",
+   "body": "Wiring now reaches the candidate route."}
+]
+JSON
+    fixture threads.json <<'JSON'
+{"data": {"repository": {"pullRequest": {"reviewThreads": {"nodes": [
+  {"isResolved": true, "comments": {"nodes": [{"databaseId": 501}]}},
+  {"isResolved": true, "comments": {"nodes": [{"databaseId": 502}]}}
+]}}}}}
+JSON
+
+    run_direct_chain
+    [[ "$CODE" -eq 0 ]] || fail "the happy path must clear every gate: $OUTPUT"
+    [[ "$OUTPUT" == *"CHAIN_COMPLETED"* ]] || fail "the gate chain did not complete: $OUTPUT"
+    [[ "$OUTPUT" == *"REVIEW_GATE_CLEAR"* ]] || fail "the review-comment gate did not report clear: $OUTPUT"
+    grep -F -- "--set-metadata ci_gate_sha=$HEAD_SHA" "$CALLS" >/dev/null ||
+        fail "the CI gate must stamp the SHA it proved onto the bead"
+    ! grep -q '^CLOSE ' "$CALLS" ||
+        fail "the gates themselves must never close the bead"
+
+    # The shipped terminal update + close, run with the same fake CLI.
+    local close="$TMP/close.sh"
+    extract_shipped direct-close "$close"
+    : >"$CALLS"
+    (
+        PATH="$BIN:$PATH" GC_TEST_CALLS="$CALLS" GC_TEST_BEAD_JSON="$BEAD" \
+        WORK="$WORK_ID" MERGED_SHA="$HEAD_SHA" MERGED_SHORT="${HEAD_SHA:0:7}" TARGET=main \
+        bash "$close"
+    ) || fail "the shipped close chain did not run"
+    grep -q '^CLOSE ' "$CALLS" || fail "the happy path must close the bead"
+    grep -F -- '--unset-metadata rejection_reason' "$CALLS" >/dev/null ||
+        fail "the successful close must clear rejection_reason"
+    grep -F -- '--unset-metadata recovery.disposition' "$CALLS" >/dev/null ||
+        fail "the successful close must clear recovery.disposition"
+    grep -F -- "--set-metadata merged_sha=$HEAD_SHA" "$CALLS" >/dev/null ||
+        fail "the close must record the merged SHA that the CI gate proved"
+}
+
+# Every way the gates can fail to reach an answer must stop, not proceed. An
+# outage is not a verdict.
+test_api_failures_are_undetermined_never_green() {
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+    pass_bead
+
+    # No check-run fixture at all: the request fails.
+    run_direct_chain
+    assert_undetermined "an unreadable check-run API" "could not read check-runs"
+
+    # Checks are green, but asking whether the branch has a PR fails. An empty
+    # answer here would read as "no PR, nothing to review" — a silent pass.
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+    pass_bead
+    green_ci_fixtures
+    run_direct_chain
+    [[ "$CODE" -ne 0 ]] || fail "a failed PR lookup must not pass as 'no pull request': $OUTPUT"
+    [[ "$OUTPUT" == *"could not ask GitHub whether"* ]] ||
+        fail "a failed PR lookup must say so: $OUTPUT"
+    assert_not_closed "a failed PR lookup"
+
+    # Comments readable, thread resolution not. Resolution is half the
+    # definition of addressed, so without it nothing is determined.
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+    pass_bead
+    green_ci_fixtures
+    clean_review_fixtures
+    rm -f "$FIX/threads.json"
+    run_direct_chain
+    assert_undetermined "unreadable review-thread resolution" "review-thread resolution"
+}
+
+# A branch with no pull request has no automated review surface — but that is
+# an answer from GitHub, not an assumption.
+test_direct_mode_without_a_pr_says_so_out_loud() {
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+    pass_bead
+    green_ci_fixtures
+    no_pr_fixtures
+
+    run_direct_chain
+    [[ "$CODE" -eq 0 ]] || fail "a branch with no PR must still pass the other gates: $OUTPUT"
+    [[ "$OUTPUT" == *"has no pull request"* ]] ||
+        fail "the absence of a review surface must be stated, not assumed: $OUTPUT"
+}
+
+# The waiver exists for rigs with no hosted CI. It is explicit, and every bead
+# it lets through carries the mark.
+test_the_ci_waiver_is_loud_and_recorded() {
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+    pass_bead
+    no_pr_fixtures
+
+    CI_GATE_OVERRIDE=false run_direct_chain
+    [[ "$CODE" -eq 0 ]] || fail "an explicit waiver must not wedge the queue: $OUTPUT"
+    [[ "$OUTPUT" == *"CI_GATE_DISABLED_BY_CONFIG"* ]] ||
+        fail "a waived CI gate must announce itself: $OUTPUT"
+    grep -F -- '--set-metadata ci_gate_result=disabled' "$CALLS" >/dev/null ||
+        fail "a bead closed without CI proof must carry that on the record"
+    ! grep -F -- 'check-runs' "$CALLS" >/dev/null ||
+        fail "a waived CI gate should not be querying checks at all"
+    [[ "$OUTPUT" == *"has no pull request"* ]] ||
+        fail "waiving CI must not waive the review-comment gate: $OUTPUT"
+}
+
+# The pull-request handoff gates the SHA the PR actually carries.
+test_mr_mode_gates_the_pr_head_sha() {
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+    pass_bead
+    PR_NUMBER_OVERRIDE=84
+    fixture pull.json <<'JSON'
+{"number": 84, "head": {"sha": "beda5d39beda5d39beda5d39beda5d39beda5d39"}}
+JSON
+
+    run_mr_chain
+    [[ "$CODE" -ne 0 ]] || fail "a PR whose head is not what we pushed must not be gated as ours: $OUTPUT"
+    [[ "$OUTPUT" == *"but you pushed"* ]] || fail "the SHA mismatch must be named: $OUTPUT"
+    assert_not_closed "an mr-mode head SHA mismatch"
+
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+    pass_bead
+    PR_NUMBER_OVERRIDE=84
+    jq -n --arg sha "$HEAD_SHA" '{number: 84, head: {sha: $sha}}' >"$FIX/pull.json"
+    fixture check-runs.json <<JSON
+{"total_count": 1, "check_runs": [
+  {"name": "$RED_CHECK_ONE", "status": "completed", "conclusion": "failure"}
+]}
+JSON
+    fixture status.json <<'JSON'
+{"state": "failure", "statuses": []}
+JSON
+
+    run_mr_chain
+    assert_rejected "CI gate" "ci-red" "$RED_CHECK_ONE"
+    PR_NUMBER_OVERRIDE=""
+}
+
+test_shipped_defaults_are_fail_closed
+test_direct_mode_runs_all_three_gates_before_it_merges
+test_review_gate_rejects_a_cited_defect_before_anything_is_published
+test_review_gate_refuses_verdicts_that_cite_nothing
+test_red_ci_rejects_and_does_not_close
+test_zero_check_runs_is_not_green
+test_pending_checks_wait_and_never_pass
+test_unknown_conclusions_default_to_red
+test_unaddressed_bot_comments_reject
+test_bot_replies_and_one_word_acks_do_not_address_anything
+test_unresolved_inline_thread_rejects
+test_addressed_comments_pass_and_the_happy_path_closes
+test_api_failures_are_undetermined_never_green
+test_direct_mode_without_a_pr_says_so_out_loud
+test_the_ci_waiver_is_loud_and_recorded
+test_mr_mode_gates_the_pr_head_sha
+
+echo "refinery merge gate tests passed"


### PR DESCRIPTION
## Problem

The Gastown refinery closed work it could not prove was good. Its entire quality gate was **local**, so a branch that broke every Windows target merged as readily as one that broke nothing, and the red never reached a bead.

Observed live on `jm2/kisakcod`. `master` degraded from fully green to 11 failing checks in 55 hours, one refinery merge at a time:

```
07-22 15:04  beda5d39   success:9            <- last fully green
07-22 19:35  PR #84 merged                   <- last PR-based merge
07-23 09:34  0d5a7558   failure:3 success:6  <- first red
07-24 01:25  dd1f26ba   failure:8 success:1
07-24 22:00  08050416   failure:11
```

Every failing check is a cross-platform target a Linux polecat cannot build and this refinery cannot run: `Windows x86 / {Release,Debug}`, `Windows x86 SP / {Release,Debug}`, `Windows x86 (no Steam)`, `Windows x86 (headless dedicated)`, `Portable tests / {Linux,macOS,Windows} {amd64,arm64}`.

The mechanism is entirely in the pack. `prompt.template.md:47-57` ("Quality-Gate Fallback") and the formula's `run-tests` step (`mol-refinery-patrol.toml:272-308`) run `setup_command`, `typecheck_command`, `lint_command`, `build_command`, `test_command` from wisp vars, falling back to the repo instructions file. **Nothing anywhere in the refinery's assets queries a hosted check-run.** The rejection flow (`prompt.template.md:229-240`) fires on rebase conflict or *local* test failure only. So: polecat green on Linux → refinery green on Linux → merge → hosted CI red → nobody reads it → the next merge stacks on top of the red.

A second gap sits beside it. The refinery ran *no* judgment pass at all — a branch could satisfy every configured command and still not do what the bead asked, and `git diff` was never read by anything before `gc bd close`.

## Fix

Three gates between a rebased branch and `gc bd close`. All mandatory, all fail closed, in **both** merge strategies.

They ship as one extractable block, `# BEGIN REFINERY_MERGE_GATE` (`mol-refinery-patrol.toml:732-1199`), with a single return convention: `0` pass, `1` the branch is at fault (reject), `2` the gate could not be evaluated (stop without touching bead state). There is no third disposition and no path that silently continues.

### Gate 1 — the refinery reviews the diff (new `review-diff` step, pre-PR)

A new formula step (`:423`) between `handle-failures` and `merge-push`, which now `needs = ["review-diff"]`. The refinery reads `git diff origin/$TARGET temp` and judges it against the bead's stated acceptance on four questions: does it do what the bead asked, is it correct, is it reachable from a production call site, does it regress an existing caller. It records the verdict on the bead — `review_sha`, `review_verdict`, `review_acceptance`, `review_evidence` (or `review_defect`).

**This is explicitly not the Quality-Gate Fallback**, and the prompt says so where a reader would otherwise conflate them (`prompt.template.md:69-74`): that section runs commands, this one is judgment. The CARDINAL RULE was reconciled in the same edit — the old bullet `FORBIDDEN: Reading polecat code to "understand what they were trying to do."` (`:19` on main) cannot coexist with a mandatory review, so reading the diff to reject it with a cited defect is now REQUIRED, and editing the branch to make it pass your own review is what is FORBIDDEN.

**The gate enforces shape, never opinion** (`gate_review`, `:818`):

- `review_sha` must equal the SHA about to be landed. A verdict is bound to the exact commit it read; when the polecat pushes a fix the SHA moves and the approval does not carry forward.
- `review_evidence` must clear a length floor, survive a placeholder list, **and name a file that appears in `git diff --name-only`**. That last check is the anti-rubber-stamp: it cannot be satisfied by adjectives.
- A **rejection** carries the same citation requirement. Lazy approval and lazy rejection are the same failure — one merges garbage, the other stalls the queue on an opinion.

The prompt states the bar plainly (`:107-118`) so this does not become unfalsifiable busywork: reject for an unmet acceptance criterion, dead code no production path reaches, a nameable logic error, or a regression for existing callers; do **not** reject for style, naming, coverage wishes, or a refactor you would have done differently. A pass is one careful read, not an investigation.

The vocabulary is the pack's existing one, not a new one — this is the shape already found on rejected beads in the affected city:

```
rejection_reason: "Acceptance unmet: candidate has no production route
                   call site; legacy db_load path remains the only path"
recovery.disposition: "production-wiring-rework-required"
```

### Gate 2 — hosted CI green on the exact SHA being landed

`gate_ci` (`:969`) reads check-runs **and** legacy commit statuses (a repo can publish either; looking at one API is a way to mistake silence for success).

| Check state | Verdict |
|---|---|
| `success`, `neutral`, `skipped` | acceptable |
| `failure`, `timed_out`, `cancelled`, `action_required` | RED |
| any other conclusion (e.g. `stale`) | RED — default deny; the reason string names the conclusion so the accept list can be extended deliberately |
| not `completed` | WAIT, bounded, then reject |
| zero check-runs **and** zero statuses | not green — reject |

**Pending is never green.** The gate polls every `ci_poll_seconds` (60) up to `ci_timeout_seconds` (900) and then rejects with a reason that says exactly what to do — reassign when the checks finish, nothing to fix if they pass. Bounded-then-reject over blocking forever: rejecting on a slow build costs one reassignment, and a wedged merge queue costs everything behind it.

**Zero checks is not green.** Several commits in the incident carried no checks at all. A push takes seconds to register workflow runs, so zero is treated as pending for `ci_zero_check_grace_seconds` (300) and is then a rejection: *cannot prove green*.

An API failure is retried inside the same window and then reported as **undetermined** — stop, do not mutate bead state. An outage is not a verdict.

### Gate 3 — automated review comments addressed

`gate_bot_reviews` (`:1069`) covers `gemini-code-assist[bot]` and `chatgpt-codex-connector[bot]` (`review_bots` var). A comment is **addressed** only when a positive act is recorded on the pull request itself:

1. its review thread is marked **resolved** (GraphQL `reviewThreads { isResolved }` — there is no REST equivalent);
2. it has a **substantive non-bot reply in that same thread** (inline comments);
3. for PR-level comments and formal reviews, a **substantive non-bot comment or review posted after it**;
4. or the **same bot posted an APPROVED review afterwards** — the reviewer withdrew its own objection.

"Substantive" is a ≥24-char, non-placeholder body from an author that is neither a listed review bot nor any account with `user.type == "Bot"`. That closes the two shapes that would make the gate free: a bot answering a bot, and `done`.

**Why this definition and not the alternatives.** "A commit newer than the comment" was rejected outright: this refinery *rebases every branch it touches*, so commit timestamps move on their own and that rule would pass without anyone having read a word — it would have been green throughout the incident. Thread resolution alone was rejected as insufficient: it does not exist for the PR-level issue comments that gemini actually posts, so half the surface would be unreachable. The four forms above are each a deliberate human or bot act, each readable back through `gh`, and inline comments are deliberately held to their own thread rather than being cleared by unrelated PR chatter. The prompt documents the two `gh` calls that clear a thread, so a rejection is actionable rather than a wall.

If the comments cannot be read — API error, missing token, GraphQL refused — that is undetermined, not addressed.

### Decision: the gates apply in `direct` mode

`merge_strategy` defaults to `direct` (`prompt.template.md:216`), and `direct` is what produced the table above, so exempting it would exempt the failure. But direct mode has no PR, and CI rules on SHAs, not PRs. So **direct mode now publishes the exact commit it intends to land** — `git push origin "HEAD:$BRANCH" --force-with-lease` from the rebased `temp` — lets CI judge that SHA, and only then fast-forwards the target onto it (`:1351`). The SHA CI blessed and the SHA that lands are then the same object, which is the entire point; a pre-rebase verdict would have been a verdict on a different commit. When the rebase was a no-op the push is a no-op and the existing results apply unchanged.

Gate 3 runs in direct mode whenever the branch has an open PR. When GitHub says it has none, the gate says so out loud (`REVIEW_GATE_CLEAR: ... has no pull request`) rather than assuming — and a *failed* PR lookup is undetermined, never "no PR". That distinction is one of the regressions below, because an empty answer built out of an outage is exactly how a fail-open gets shipped.

### Rejection shape

Gate failures use the **existing** rejection flow — the same `gc workflow delete-source` / `reopen-source` / `--status=open --assignee=""` shape the `rebase` and `handle-failures` steps already use — with:

- `rejection_reason` naming the gate and the specifics (which checks are red, which comment is unanswered, which acceptance criterion is unmet);
- `recovery.disposition` — `acceptance-unmet`, `ci-red`, `review-comments-unaddressed`;
- `gc.routed_to` back to the polecat pool;
- **the branch left intact.** Every gate failure is fix-forward: the polecat adds a commit to the same branch or replies to the reviewer. Deleting it would throw away work that is one commit from correct, and in `mr` mode it would orphan an open PR. The prompt's rejection table now carries this as a third case beside conflict and test failure.

Per the pack's existing rule, both terminal closes clear `rejection_reason` — and now `recovery.disposition` with it, for the same reason: a closed bead advertising a live rejection is a contradictory record.

`ci_gate=false` remains for rigs with no hosted CI. It is an explicit operator waiver, it announces itself, and it stamps `ci_gate_result=disabled` on every bead it lets through. **No error path can reach it** — the gate never self-disables.

## Regression coverage

New standalone suite `gastown/tests/test_refinery_merge_gate.sh` (16 tests). It extracts the **shipped** gate block *and the shipped call chains* from the formula, substitutes the **shipped var defaults**, and runs them against a hermetic `gh`/`gc` and a real throwaway git repository with a local bare `origin` — so `git diff`, `git rev-parse` and `--force-with-lease` behave exactly as they do live. Fixtures use the incident's real check names.

- red CI (`Windows x86 SP / Release` failure + `Portable tests / macOS arm64` timed_out) rejects, names both, does not close, and leaves the reviewed SHA published for fix-forward
- zero check-runs rejects — `"zero check-runs ... cannot be proven green"`
- an unfinished board rejects and is never reported green; the same board **given a window finishes green between polls and passes**, so the test distinguishes WAIT from PASS rather than just asserting failure
- an unrecognized conclusion (`stale`) is red
- an unanswered gemini PR comment rejects; a `github-actions[bot]` reply plus a `done` reply do not address anything; an unresolved inline thread rejects even with unrelated PR conversation
- resolved threads + a substantive human reply + a later APPROVED review pass, then the **shipped close chain** runs and closes with both `--unset-metadata` flags
- every undeterminable path — unreadable check-runs, failed PR lookup, unreadable thread resolution — stops without rejecting the bead and without closing it
- the review gate rejects a cited defect **before anything is published** (asserted: `origin/$BRANCH` unmoved, and zero `gh` calls made), and refuses an unreviewed diff, an `LGTM`, an approval citing no file in the diff, an approval of a different SHA, and an uncitable rejection
- structural: shipped defaults are the fail-closed ones, `merge-push` needs `review-diff`, and both modes run all three gates before they touch the target or close the bead

**Mutation-tested**, each neutered singly against the shipped formula:

| Mutation | Suite result |
|---|---|
| CI gate ignores red checks (`-gt 0` → `-gt 999`) | `FAIL: CI gate must report GATE_REJECTED naming the gate` |
| zero check-runs counts as green (`-eq 0` → `-eq -1`) | `FAIL: CI gate must report GATE_REJECTED naming the gate` |
| an unfinished check classifies as green (`then "PENDING"` → `then "GREEN"`) | `FAIL: CI gate must report GATE_REJECTED naming the gate` |
| review gate accepts evidence citing nothing | `FAIL: an approval citing no file in the diff must say why it could not be determined (want 'cites no file this diff touches')` |
| review-comment gate never reports anything unaddressed | `FAIL: Review-comment gate must reject with exit 1 (got 0)` |
| stale review verdict carries to a new SHA | `FAIL: an approval of a different SHA must say why it could not be determined (want 'review_sha')` |
| PR lookup loses its status guards (fail-open) | `FAIL: a failed PR lookup must not pass as 'no pull request'` |

Deliberately a **new** suite file rather than an addition to `test_gastown_pack_assets.sh`, which is contested by #222, #227 and #231. Discovery is convention-based via the CI glob `for test_script in gastown/tests/test_*.sh`, so there is no registration edit to make — the same route #231 and #232 took.

## Validation

- Gastown shell suites: 4/4 pass
- `bash -n` over the new suite and over the extracted gate block (the suite re-runs that check on every case, so the shipped block can never drift into invalid shell)
- TOML parse: 17 gastown TOML files incl. `mol-refinery-patrol.toml`
- `python3 -m pytest -q`: 1089 passed, 7 skipped, 9412 subtests
- `tests/test_no_bare_bd_commands.py`: passes (the fake CLI dispatches on argv positions and logs mutations under `UPDATE`/`CLOSE` markers, so neither the fixture nor its assertions spell a bare `bd <subcommand>`)
- `gc lint gastown`: ok
- `git diff --check`: clean

## Composition with open PRs

Merges cleanly with **#221, #222, #226, #227, #231 and #232** against freshly fetched heads, and the full gastown suite passes on the merged tree for #222, #227, #231 and #232 (verified, not assumed — #227 also edits both files this PR touches).

**#190 (`fix/refinery-forge-aware`) conflicts**, trivially and only there: both PRs reword the same two bullets of the refinery prompt's Merge Strategy list. #190 makes the `mr` bullet forge-neutral ("pull/merge request on the rig's forge"); this PR makes the `direct` bullet describe the new publish-then-gate order. The resolution is to take both edits — one bullet each. Nothing else overlaps: #190 does not touch the formula, and the gate block's GitHub calls are additive, so a follow-up can route them through the same forge abstraction once #190 lands.
