### PR TITLE
feat(registry): publish runtime-cloudflare 0.1.0

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -313,3 +313,16 @@ schema = 1
     commit = "636fdfaaf54195b293e8e56d5e9c30e4b8d5a9ef"
     hash = "sha256:ba0428bf51627bf465a693f2426cf6be0cef70ae81b043fce3ce6761a4772290"
     description = "First registry release of the superpowers build factory."
+
+[[pack]]
+  name = "runtime-cloudflare"
+  description = "The Cloudflare session runtime, shipped as a pack so it versions independently of the gc binary. Declares [runtimes.cloudflare] backed by the gc-runtime-cloudflare RPP v0 provider, replacing the deleted gascity builtin."
+  source = "https://github.com/gastownhall/gascity-packs/tree/main/runtime-cloudflare"
+  source_kind = "git"
+
+  [[pack.release]]
+    version = "0.1.0"
+    ref = "main"
+    commit = "ffcb02933f878c7c9ac2df470338c28a5e5d829d"
+    hash = "sha256:432a1f917c400a3497f1be7466e0297d108b5e2174eed4d7ae4a87579e45d2d1"
+    description = "First registry release of the Cloudflare session runtime as an RPP v0 pack."


### PR DESCRIPTION
`runtime-cloudflare` has existed as a top-level pack directory since `28c7e24` (2026-06-13) but
was never added to `registry.toml`, so the registry cannot serve it. That's a real gap rather than
a cosmetic one: the Gas City SDK **deleted** its Cloudflare builtin and now depends on this pack
being installable.

From `gascity/internal/runtime/REQUIREMENTS.md`:

> **RUNTIME-SEL-012** — The Cloudflare runtime ships as the `runtime-cloudflare` pack
> (gascity-packs), not a gascity builtin… `internal/runtime/cloudflare` is deleted; bumping the
> pack changes runtime behavior under an unchanged `gc` binary.

`cmd/gc/runtime_registry_test.go::TestCloudflareIsNoLongerABuiltin` enforces the builtin's absence,
and RUNTIME-SEL-002 lists `cloudflare` as deliberately not a builtin.

The failure mode of the omission is the quiet kind: a city selecting `session = "cloudflare"`
without the pack doesn't error — it falls through to the tmux fallback (RUNTIME-SEL-006).

## What's here

One `[[pack]]` entry, 13 insertions, nothing else touched. Produced by the repo's own
`make registry-publish` (`gc pack release stamp` for the content hash, then
`scripts/registry_release.py set-source` for the canonical `/tree/main/<dir>` source form) rather
than hand-authored.

The pin is content-stable: `28c7e24` is the only commit that has ever touched the directory,
`git diff 28c7e24 HEAD -- runtime-cloudflare` is empty, and the validator's own hasher returns an
identical hash at both commits. Pinned at the `main` tip, matching the bmad/gstack/superpowers
precedent.

## Verification

- `python3 validate_registry.py --require-git` → `registry.toml: ok` (the CI gate)
- `make registry-format-validate` → `registry.toml: ok`
- `gc pack release validate registry.toml` → `registry release hashes ok (33 checked)`
- `python3 -m pytest …` → 1077 passed, 7 skipped, 9412 subtests
- `go test .` → ok
- `scripts/pack_release_compat.py --pack runtime-cloudflare` → `compatibility smoke passed` — this
  is the real consumer path: `gc import install` fetched the pack from GitHub at the pinned commit,
  verified the hash, and `import check` / `config show` passed. The entry is genuinely servable,
  not merely well-formed.

## Noted, not fixed here

- `validate_registry.py --emit-entry` renders unindented keys, which doesn't match this file's
  actual 2/4-space style — anyone pasting its output has to reindent. The `make registry-publish`
  path writes correct style.
- `runtime-cloudflare/conformance.sh` is still `continue-on-error: true` in CI because
  `gc runtime check` doesn't exist on gascity `main` yet, so the pack's RPP conformance isn't
  actually gated today. Unrelated to this entry.
- `contributing` and `pr-pipeline` were last modified in `9b4df3e`, after their newest pinned
  releases — they have unreleased content on `main`. Pre-existing.
