### PR TITLE
feat(gastown): detect witnesses whose patrol loop silently died

### DIFF
--- a/gastown/assets/scripts/witness-heartbeat-check.sh
+++ b/gastown/assets/scripts/witness-heartbeat-check.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+# witness-heartbeat-check.sh — deterministic staleness check for witness patrol
+# loops. Read-only: it measures, prints, and exits. It never mails, nudges, or
+# files warrants — the deacon's health-scan step owns those decisions.
+#
+# The gap it closes: a witness whose self-scheduled patrol loop has died still
+# reports a healthy session state. It sits in `asleep` or `active` forever, so
+# the controller's liveness reconcile sees nothing wrong and the deacon's
+# LLM health-scan reads the quiet as legitimate idle. Patrol stalls of 14h to
+# 63h were observed in production this way with no alert. Heartbeat age is the
+# one signal that separates "idle and fine" from "loop is gone", and it is
+# exactly the kind of measurement an LLM should not be eyeballing.
+#
+# For every witness session in a state that implies it should be patrolling
+# (active / awake / asleep / running) it takes the NEWER of `last_active` and
+# `last_nudge_delivered_at` as the heartbeat and compares its age against
+# $GASTOWN_WITNESS_STALE_MIN. Sessions the controller or an operator owns
+# (creating / drained / draining / suspended / quarantined / closed) are the
+# controller's business and are skipped.
+#
+# Output: one TSV row per checked witness on stdout, column header on stderr.
+#
+#   verdict <TAB> rig <TAB> session <TAB> state <TAB> age_seconds <TAB> heartbeat
+#
+#   fresh        heartbeat inside the window
+#   stalled      heartbeat older than the window — the patrol loop is gone
+#   no-heartbeat session records no usable timestamp yet (see below)
+#   schema-drift session exposes no `last_active` at all — nothing was measured
+#
+# Exit codes:  0 = every checked witness is fresh (or none to check)
+#              1 = findings on stdout (stalled and/or no-heartbeat)
+#              2 = the check could not run (bad env, unreadable roster, or a
+#                  `gc session list` schema drift that hid `last_active`)
+#
+# A `no-heartbeat` witness is deliberately NOT reported as stalled. `gc` emits
+# the Go zero-time sentinel (0001-01-01T00:00:00Z) for a timestamp it has never
+# set, and a naive parse of that turns a brand-new witness into a false stall.
+# It is still a finding rather than silence, because an unset heartbeat means
+# nothing was measured — it must never read as health.
+#
+# Env:
+#   GC_CITY                    city root (auto-discovered if unset, walks up)
+#   GASTOWN_WITNESS_STALE_MIN  staleness window in minutes (default: 90)
+#   GASTOWN_WITNESS_ROLE       role suffix to match (default: witness)
+#
+# Usage:
+#   witness-heartbeat-check.sh
+#   GASTOWN_WITNESS_STALE_MIN=45 witness-heartbeat-check.sh
+#
+# The heartbeat-freshness idea comes from gascity-packs PR #99 by
+# sarendipitee, which added it as "Check 1b" to a watchdog in the retired
+# maintenance pack.
+
+set -euo pipefail
+
+# Resolve city root: env wins, else walk up from cwd looking for city.toml.
+if [ -z "${GC_CITY:-}" ]; then
+  dir=$(pwd)
+  while [ "$dir" != "/" ]; do
+    if [ -f "$dir/city.toml" ]; then
+      GC_CITY="$dir"
+      break
+    fi
+    dir=$(dirname "$dir")
+  done
+fi
+
+if [ -z "${GC_CITY:-}" ] || [ ! -f "$GC_CITY/city.toml" ]; then
+  echo "witness-heartbeat-check: GC_CITY not set and no city.toml found" >&2
+  exit 2
+fi
+
+# Default window: the gastown witness does NOT self-schedule a ~60s wakeup — it
+# ends its turn with `IDLE:` and the controller's session_sleep policy restarts
+# it, bounded by the witness agent's idle_timeout of 1h. 1h is therefore the
+# longest legitimate silence for a healthy witness, so the window sits at 1.5x
+# that. Well clear of legitimate idle, and still an order of magnitude under the
+# 14h floor of the stalls this check exists to catch. Lower it only if your
+# city's witness idle_timeout is lower.
+STALE_MIN="${GASTOWN_WITNESS_STALE_MIN:-90}"
+ROLE="${GASTOWN_WITNESS_ROLE:-witness}"
+
+case "$STALE_MIN" in
+  ''|*[!0-9]*)
+    echo "witness-heartbeat-check: GASTOWN_WITNESS_STALE_MIN must be a positive integer (got '$STALE_MIN')" >&2
+    exit 2
+    ;;
+esac
+if [ "$STALE_MIN" -le 0 ]; then
+  echo "witness-heartbeat-check: GASTOWN_WITNESS_STALE_MIN must be a positive integer (got '$STALE_MIN')" >&2
+  exit 2
+fi
+
+STALE_SECS=$((STALE_MIN * 60))
+NOW=$(date -u +%s)
+
+# ts_epoch — RFC3339 timestamp to epoch seconds, printing 0 for "no usable
+# signal": empty, null, or the Go zero-time sentinel `gc` emits for a field it
+# has never set. 0 means unknown, never "ancient" — parsing 0001-01-01 as a real
+# instant is what turns a newly-spawned witness into a false stall.
+#
+# GNU `date -d` first, BSD `date -j -f` second: the fleet includes macOS.
+# Fractional seconds are stripped because `gc` emits them and BSD `date -f`
+# cannot parse them.
+ts_epoch() {
+  local ts="$1" norm epoch
+  case "$ts" in
+    ''|null|0001-*) printf '0'; return 0 ;;
+  esac
+  norm=$(printf '%s' "$ts" | sed -E 's/\.[0-9]+(Z|[+-][0-9:]+)?$/\1/')
+  epoch=$(date -u -d "$norm" +%s 2>/dev/null) \
+    || epoch=$(date -u -j -f '%Y-%m-%dT%H:%M:%S%z' \
+                 "$(printf '%s' "$norm" | sed 's/Z$/+0000/')" +%s 2>/dev/null) \
+    || epoch=''
+  # Anything non-numeric or pre-epoch is another unusable value, not "ancient".
+  case "$epoch" in
+    ''|*[!0-9]*) printf '0'; return 0 ;;
+  esac
+  [ "$epoch" -gt 0 ] && printf '%s' "$epoch" || printf '0'
+}
+
+# `--state=all` because the default listing hides asleep sessions, and asleep is
+# the state a stalled witness parks in.
+if ! ROSTER=$(gc session list --state=all --json 2>/dev/null); then
+  echo "witness-heartbeat-check: 'gc session list --state=all --json' failed — heartbeat freshness NOT measured" >&2
+  exit 2
+fi
+
+# `gc session list --json` (schema 1.1.1) returns an OBJECT with a `sessions`
+# array. Tolerate a bare top-level array too: that shape shipped previously and
+# the schema has drifted before (gc-3tn8g).
+JQ_SESSIONS='def sessions_of: (.sessions? // .) | if type == "array" then . else [] end;'
+
+if ! TOTAL=$(printf '%s' "$ROSTER" | jq -r "$JQ_SESSIONS sessions_of | length" 2>/dev/null); then
+  echo "witness-heartbeat-check: could not parse the session roster — heartbeat freshness NOT measured" >&2
+  exit 2
+fi
+
+# Match the role by exact identifier or dot/slash-delimited suffix across every
+# identity field a session exposes, so an import binding prefix
+# (gastown.witness) or a rig-qualified name (alpha/witness) still matches. Never
+# a bare substring — that would catch unrelated names.
+ROWS=$(printf '%s' "$ROSTER" | jq -r --arg role "$ROLE" "
+  $JQ_SESSIONS
+  def is_role(\$r):
+    [ (.template // \"\"), (.agent_name // \"\"), (.name // \"\"),
+      (.session_name // \"\"), (.alias // \"\") ]
+    | map(select(. != \"\"))
+    | any(. == \$r or endswith(\".\" + \$r) or endswith(\"/\" + \$r));
+  sessions_of
+  | .[]
+  | select((.closed // false) | not)
+  | select(is_role(\$role))
+  | [ (if (.name // \"\") != \"\" then .name
+       elif (.alias // \"\") != \"\" then .alias
+       else (.id // \"?\") end),
+      (if (.rig // \"\") != \"\" then .rig else \"-\" end),
+      (.state // \"\"),
+      (if has(\"last_active\") then \"1\" else \"0\" end),
+      ([ (.last_active // \"\"), (.last_nudge_delivered_at // \"\") ]
+       | map(select(. != null and . != \"\")) | join(\",\"))
+    ]
+  | @tsv
+" 2>/dev/null) || ROWS=''
+
+printf 'verdict\trig\tsession\tstate\tage_seconds\theartbeat\n' >&2
+
+CHECKED=0
+FINDINGS=0
+STALLED=0
+DRIFTED=0
+
+while IFS=$'\t' read -r ident rig state has_last_active stamps; do
+  [ -n "${ident:-}" ] || continue
+
+  case "$(printf '%s' "$state" | tr '[:upper:]' '[:lower:]')" in
+    active|awake|asleep|running) ;;
+    # creating / drained / draining / suspended / quarantined / archived /
+    # closed are controller- or operator-owned. Not this check's business.
+    *) continue ;;
+  esac
+
+  CHECKED=$((CHECKED + 1))
+
+  if [ "$has_last_active" != "1" ]; then
+    DRIFTED=$((DRIFTED + 1))
+    printf 'schema-drift\t%s\t%s\t%s\t-\t-\n' "$rig" "$ident" "$state"
+    continue
+  fi
+
+  # Newest of the available stamps. The patrol loop's self-nudge keeps
+  # last_nudge_delivered_at moving, and last_active is often the zero sentinel
+  # on an asleep session, so neither field alone is a reliable heartbeat.
+  # Compared as epochs rather than sorted as strings so a mixed UTC/offset
+  # roster still orders correctly.
+  best=0
+  best_ts='-'
+  saved_ifs=$IFS
+  IFS=','
+  for ts in ${stamps:-}; do
+    IFS=$saved_ifs
+    epoch=$(ts_epoch "$ts")
+    if [ "$epoch" -gt "$best" ]; then
+      best=$epoch
+      best_ts=$ts
+    fi
+    IFS=','
+  done
+  IFS=$saved_ifs
+
+  if [ "$best" -eq 0 ]; then
+    FINDINGS=$((FINDINGS + 1))
+    printf 'no-heartbeat\t%s\t%s\t%s\t-\t-\n' "$rig" "$ident" "$state"
+    continue
+  fi
+
+  age=$((NOW - best))
+  # A heartbeat in the future is clock skew, not staleness.
+  [ "$age" -lt 0 ] && age=0
+
+  if [ "$age" -ge "$STALE_SECS" ]; then
+    STALLED=$((STALLED + 1))
+    FINDINGS=$((FINDINGS + 1))
+    printf 'stalled\t%s\t%s\t%s\t%s\t%s\n' "$rig" "$ident" "$state" "$age" "$best_ts"
+  else
+    printf 'fresh\t%s\t%s\t%s\t%s\t%s\n' "$rig" "$ident" "$state" "$age" "$best_ts"
+  fi
+done <<EOF
+$ROWS
+EOF
+
+if [ "$DRIFTED" -gt 0 ]; then
+  echo "witness-heartbeat-check: $DRIFTED session(s) expose no last_active field — gc session list schema drifted; heartbeat freshness NOT measured" >&2
+  exit 2
+fi
+
+if [ "$CHECKED" -eq 0 ]; then
+  echo "witness-heartbeat-check: no patrolling '$ROLE' session among $TOTAL session(s) — nothing to check" >&2
+  exit 0
+fi
+
+echo "witness-heartbeat-check: checked $CHECKED '$ROLE' session(s), $STALLED stalled (window ${STALE_MIN}m)" >&2
+
+[ "$FINDINGS" -eq 0 ] || exit 1

--- a/gastown/formulas/mol-deacon-patrol.toml
+++ b/gastown/formulas/mol-deacon-patrol.toml
@@ -27,8 +27,8 @@ can't or shouldn't do.
 4. **System diagnostics** — run `gc doctor`, act on findings.
 
 Mechanical tasks (gate evaluation, cross-rig deps, orphan bead sweeps,
-wisp compaction) are handled by exec orders in the maintenance
-pack — no LLM needed.
+wisp compaction) are handled by exec orders in the Gas City builtin
+core pack — no LLM needed. The retired maintenance pack no longer exists.
 
 ## Idle Town Principle
 
@@ -55,6 +55,10 @@ default = ""
 [vars.event_timeout]
 description = "Seconds to sleep before re-checking. Replaces former event-watch loop which hot-spun on cache-reconcile firehose."
 default = "60"
+
+[vars.witness_stale_min]
+description = "Minutes of witness heartbeat silence before health-scan's deterministic pass calls the patrol loop stalled. The default is 1.5x the witness idle_timeout (1h) — the longest legitimate silence for a healthy witness, and an order of magnitude under the multi-hour stalls this catches. Lower it only if your witness idle_timeout is lower."
+default = "90"
 
 [[steps]]
 id = "check-inbox"
@@ -142,12 +146,69 @@ The controller handles "is the agent running?" The deacon handles
 
 **Skip docked/parked rigs.** Only check active rigs.
 
+**Deterministic first pass — witness heartbeat freshness.**
+
+**Config: witness_stale_min = {{witness_stale_min}}**
+
+Run this before forming any judgment. A witness whose self-scheduled patrol
+loop has died still reports a healthy session state: it sits `asleep` or
+`active` and reads as legitimate idle in every other signal in this step. The
+controller sees a live session, and wisp staleness on an idle rig is
+indistinguishable from a healthy lull. Patrol stalls of 14h to 63h were
+observed in production exactly this way, with no alert. Heartbeat age is the
+one signal that separates "idle and fine" from "the loop is gone", so it gets
+measured rather than judged.
+
+```bash
+CHECK="${GC_PACK_DIR:-}/assets/scripts/witness-heartbeat-check.sh"
+if [ -x "$CHECK" ]; then
+  GASTOWN_WITNESS_STALE_MIN={{witness_stale_min}} bash "$CHECK"; echo "heartbeat check exit: $?"
+else
+  echo "witness-heartbeat-check.sh not resolvable under GC_PACK_DIR — use the judgment pass below only."
+fi
+```
+
+Exit 0 means every checked witness heartbeat is inside the window. Exit 1 means
+findings, one TSV row per witness
+(`verdict rig session state age_seconds heartbeat`):
+
+| verdict | meaning | action |
+|---------|---------|--------|
+| `fresh` | heartbeat inside the window | nothing |
+| `stalled` | heartbeat older than the window — the patrol loop is gone | nudge, then warrant if the stall survives the nudge |
+| `no-heartbeat` | no usable timestamp recorded yet | do NOT warrant. A freshly-spawned witness has no heartbeat yet; only a no-heartbeat that persists across cycles is a real signal |
+
+Exit 2 means the check could not run — bad config, an unreadable session
+roster, or a `gc session list` schema drift that hid `last_active`. That is
+"freshness was NOT measured", not health. Escalate the drift the way
+`recover-orphaned-beads` does in `mol-witness-patrol`:
+
+```bash
+gc mail send mayor/ -s "DEACON: witness heartbeat check cannot run" -m "<the check's stderr>"
+```
+
+A `stalled` verdict is deterministic evidence and needs no further judgment,
+but it takes the same escalation route as everything else in this step — nudge
+first, so a witness that is merely wedged mid-turn gets to recover on its own:
+
+```bash
+gc session nudge "$STALLED_SESSION" "Heartbeat silent for <age>. Run gc hook and resume your patrol."
+```
+
+If the next cycle still reports the same session `stalled`, file a deduped
+warrant with the snippet at the end of this step. Do not invent a second
+escalation path, and do not mail a named role directly for a single stall —
+systemic patterns are what the mayor escalation at the end of this step is for.
+
 **For each active rig, assess witness health:**
 
 Check witness patrol wisp freshness. Each patrol cycle burns a wisp.
 If the last wisp is much older than the maximum backoff cap (300s) plus
 buffer, the witness may be stuck. But if there's no active work in the
-rig, the witness is legitimately idle — not stuck.
+rig, the witness is legitimately idle — not stuck. Idle only excuses a stale
+*wisp*: the heartbeat pass above already ruled on whether the loop itself is
+alive, and an empty queue does not stop a live witness from waking. If the
+heartbeat pass returned `stalled`, do not talk yourself out of it here.
 
 **For each active rig, assess refinery health:**
 

--- a/gastown/tests/test_witness_heartbeat_check.sh
+++ b/gastown/tests/test_witness_heartbeat_check.sh
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+SCRIPT="$ROOT/gastown/assets/scripts/witness-heartbeat-check.sh"
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+write_gc_stub() {
+    local bin="$1"
+    mkdir -p "$bin"
+    cat >"$bin/gc" <<'SH'
+#!/usr/bin/env sh
+# Only `gc session list --state=all --json` is exercised here.
+case "$*" in
+    *"session"*"list"*"--json"*) cat "$GC_SESSIONS_JSON" ;;
+    *) printf '{}' ;;
+esac
+SH
+    chmod +x "$bin/gc"
+}
+
+# run_check <sessions-json-literal> [env assignments...] — prints the TSV rows,
+# sets RC to the exit code. stderr is captured separately so row assertions stay
+# clean.
+run_check() {
+    local payload="$1"
+    shift
+    printf '%s' "$payload" >"$SESSIONS"
+    set +e
+    # ${1+"$@"} rather than "$@": bash 3.2 under `set -u` treats an empty "$@"
+    # as an unbound variable.
+    OUT=$(env GC_CITY="$CITY" GC_SESSIONS_JSON="$SESSIONS" PATH="$BIN:$PATH" ${1+"$@"} \
+        bash "$SCRIPT" 2>"$ERRFILE")
+    RC=$?
+    set -e
+    ERR=$(cat "$ERRFILE")
+}
+
+ts_ago() {
+    # Seconds ago -> RFC3339 UTC. GNU date here; the script under test is what
+    # needs BSD portability, not this Linux-only CI test.
+    date -u -d "@$(( $(date -u +%s) - $1 ))" +%Y-%m-%dT%H:%M:%SZ
+}
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+CITY="$tmp/city"
+BIN="$tmp/bin"
+SESSIONS="$tmp/sessions.json"
+ERRFILE="$tmp/stderr.txt"
+mkdir -p "$CITY"
+: >"$CITY/city.toml"
+write_gc_stub "$BIN"
+
+FRESH=$(ts_ago 45)
+STALE=$(ts_ago 72000)   # 20h — inside the 14h-63h band this check exists for
+
+test_fresh_heartbeat_is_not_flagged() {
+    run_check "$(printf '{"sessions":[{"id":"s1","name":"alpha/witness","rig":"alpha","template":"gastown.witness","state":"asleep","last_active":"%s","closed":false}]}' "$FRESH")"
+    [ "$RC" -eq 0 ] || fail "a fresh witness must exit 0, got $RC ($OUT)"
+    printf '%s' "$OUT" | grep -q '^fresh	alpha	alpha/witness	asleep	' ||
+        fail "a fresh witness should report the fresh verdict, got: $OUT"
+    printf '%s' "$OUT" | grep -q 'stalled' &&
+        fail "a fresh witness must never be reported stalled"
+    return 0
+}
+
+test_stale_heartbeat_is_stalled() {
+    run_check "$(printf '{"sessions":[{"id":"s1","name":"alpha/witness","rig":"alpha","template":"gastown.witness","state":"asleep","last_active":"%s","closed":false}]}' "$STALE")"
+    [ "$RC" -eq 1 ] || fail "a stalled witness must exit 1, got $RC ($OUT)"
+    printf '%s' "$OUT" | grep -q '^stalled	alpha	alpha/witness	asleep	7[0-9][0-9][0-9][0-9]	' ||
+        fail "a 20h-silent witness should report stalled with its age, got: $OUT"
+}
+
+test_zero_time_sentinel_is_no_heartbeat_not_stalled() {
+    run_check '{"sessions":[{"id":"s1","name":"alpha/witness","rig":"alpha","state":"asleep","last_active":"0001-01-01T00:00:00Z","closed":false}]}'
+    printf '%s' "$OUT" | grep -q '^no-heartbeat	alpha	alpha/witness	asleep	-	-$' ||
+        fail "the Go zero-time sentinel should report no-heartbeat, got: $OUT"
+    printf '%s' "$OUT" | grep -q 'stalled' &&
+        fail "the zero-time sentinel must never be parsed as an ancient heartbeat"
+    [ "$RC" -eq 1 ] || fail "an unmeasurable heartbeat is a finding (exit 1), got $RC"
+    return 0
+}
+
+test_malformed_timestamp_is_no_heartbeat_not_stalled() {
+    run_check '{"sessions":[{"id":"s1","name":"alpha/witness","rig":"alpha","state":"active","last_active":"not-a-timestamp","closed":false}]}'
+    printf '%s' "$OUT" | grep -q '^no-heartbeat	alpha	alpha/witness	active	-	-$' ||
+        fail "an unparseable timestamp should report no-heartbeat, got: $OUT"
+    printf '%s' "$OUT" | grep -q 'stalled' &&
+        fail "an unparseable timestamp must not be reported stalled"
+    [ "$RC" -eq 1 ] || fail "an unparseable heartbeat is a finding (exit 1), got $RC"
+    return 0
+}
+
+test_newer_of_the_two_stamps_wins() {
+    # Stale last_active + fresh self-nudge = healthy. This is the pairing that
+    # makes the check usable on an asleep witness at all.
+    run_check "$(printf '{"sessions":[{"id":"s1","name":"alpha/witness","rig":"alpha","state":"asleep","last_active":"%s","last_nudge_delivered_at":"%s","closed":false}]}' "$STALE" "$FRESH")"
+    [ "$RC" -eq 0 ] || fail "a fresh self-nudge should keep the witness fresh, got $RC ($OUT)"
+    printf '%s' "$OUT" | grep -q "^fresh	alpha	alpha/witness	asleep	[0-9]*	$FRESH\$" ||
+        fail "the newer of last_active/last_nudge_delivered_at should win, got: $OUT"
+
+    # ...and the reverse ordering must give the same answer.
+    run_check "$(printf '{"sessions":[{"id":"s1","name":"alpha/witness","rig":"alpha","state":"asleep","last_active":"%s","last_nudge_delivered_at":"%s","closed":false}]}' "$FRESH" "$STALE")"
+    [ "$RC" -eq 0 ] || fail "stamp order must not change the verdict, got $RC ($OUT)"
+}
+
+test_fractional_seconds_parse() {
+    run_check "$(printf '{"sessions":[{"id":"s1","name":"alpha/witness","rig":"alpha","state":"asleep","last_active":"%s","closed":false}]}' "${FRESH%Z}.123456789Z")"
+    [ "$RC" -eq 0 ] || fail "a fractional-second timestamp should parse as fresh, got $RC ($OUT)"
+    printf '%s' "$OUT" | grep -q '^fresh	' ||
+        fail "a fractional-second timestamp should report fresh, got: $OUT"
+}
+
+test_future_heartbeat_is_clock_skew_not_stale() {
+    run_check "$(printf '{"sessions":[{"id":"s1","name":"alpha/witness","rig":"alpha","state":"asleep","last_active":"%s","closed":false}]}' "$(date -u -d "@$(( $(date -u +%s) + 3600 ))" +%Y-%m-%dT%H:%M:%SZ)")"
+    [ "$RC" -eq 0 ] || fail "a future heartbeat is skew, not staleness, got $RC ($OUT)"
+    printf '%s' "$OUT" | grep -q '^fresh	alpha	alpha/witness	asleep	0	' ||
+        fail "a future heartbeat should clamp to age 0, got: $OUT"
+}
+
+test_threshold_is_configurable() {
+    local ninety_one_min
+    ninety_one_min=$(ts_ago 5460)
+    # Inside the 90m default...
+    run_check "$(printf '{"sessions":[{"id":"s1","name":"alpha/witness","rig":"alpha","state":"asleep","last_active":"%s","closed":false}]}' "$(ts_ago 3600)")"
+    [ "$RC" -eq 0 ] || fail "a 1h-old heartbeat is inside the 90m default, got $RC ($OUT)"
+    # ...outside it.
+    run_check "$(printf '{"sessions":[{"id":"s1","name":"alpha/witness","rig":"alpha","state":"asleep","last_active":"%s","closed":false}]}' "$ninety_one_min")"
+    [ "$RC" -eq 1 ] || fail "a 91m-old heartbeat should breach the 90m default, got $RC ($OUT)"
+    # ...and a tighter window flags what the default tolerates.
+    run_check "$(printf '{"sessions":[{"id":"s1","name":"alpha/witness","rig":"alpha","state":"asleep","last_active":"%s","closed":false}]}' "$(ts_ago 3600)")" \
+        GASTOWN_WITNESS_STALE_MIN=15
+    [ "$RC" -eq 1 ] || fail "GASTOWN_WITNESS_STALE_MIN=15 should flag a 1h-old heartbeat, got $RC ($OUT)"
+    printf '%s' "$ERR" | grep -q 'window 15m' ||
+        fail "the summary should report the configured window, got: $ERR"
+}
+
+test_bad_threshold_fails_loudly() {
+    run_check '{"sessions":[]}' GASTOWN_WITNESS_STALE_MIN=abc
+    [ "$RC" -eq 2 ] || fail "a non-numeric window must exit 2, got $RC"
+    run_check '{"sessions":[]}' GASTOWN_WITNESS_STALE_MIN=0
+    [ "$RC" -eq 2 ] || fail "a zero window must exit 2, got $RC"
+}
+
+test_controller_owned_states_are_skipped() {
+    run_check "$(printf '{"sessions":[
+      {"id":"s1","name":"a/witness","rig":"a","state":"creating","last_active":"%s","closed":false},
+      {"id":"s2","name":"b/witness","rig":"b","state":"suspended","last_active":"%s","closed":false},
+      {"id":"s3","name":"c/witness","rig":"c","state":"drained","last_active":"%s","closed":false},
+      {"id":"s4","name":"d/witness","rig":"d","state":"closed","last_active":"%s","closed":true}
+    ]}' "$STALE" "$STALE" "$STALE" "$STALE")"
+    [ "$RC" -eq 0 ] || fail "controller/operator-owned states must not be flagged, got $RC ($OUT)"
+    [ -z "$OUT" ] || fail "controller/operator-owned states should emit no rows, got: $OUT"
+    printf '%s' "$ERR" | grep -q "no patrolling 'witness' session among 4" ||
+        fail "the summary should say nothing was checked, got: $ERR"
+}
+
+test_non_witness_sessions_are_ignored() {
+    run_check "$(printf '{"sessions":[
+      {"id":"s1","name":"deacon","template":"gastown.deacon","state":"asleep","last_active":"%s","closed":false},
+      {"id":"s2","name":"a/refinery","rig":"a","template":"gastown.refinery","state":"asleep","last_active":"%s","closed":false},
+      {"id":"s3","name":"a/witnessing-tool","rig":"a","state":"asleep","last_active":"%s","closed":false},
+      {"id":"s4","name":"a/witness","rig":"a","template":"gastown.witness","state":"asleep","last_active":"%s","closed":false}
+    ]}' "$STALE" "$STALE" "$STALE" "$FRESH")"
+    [ "$RC" -eq 0 ] || fail "only witness sessions should be checked, got $RC ($OUT)"
+    [ "$(printf '%s\n' "$OUT" | grep -c .)" -eq 1 ] ||
+        fail "exactly one row (the witness) expected, got: $OUT"
+    printf '%s' "$OUT" | grep -q 'a/witness	asleep' ||
+        fail "the witness row should be the one reported, got: $OUT"
+    printf '%s' "$OUT" | grep -q 'witnessing-tool' &&
+        fail "a bare substring match must not pull in unrelated session names"
+    return 0
+}
+
+test_binding_prefixed_template_matches() {
+    run_check "$(printf '{"sessions":[{"id":"s1","state":"asleep","template":"gastown.witness","last_active":"%s","closed":false}]}' "$STALE")"
+    [ "$RC" -eq 1 ] || fail "a binding-prefixed template should still match, got $RC ($OUT)"
+    printf '%s' "$OUT" | grep -q '^stalled	-	s1	asleep	' ||
+        fail "a session with no name/rig should fall back to its id, got: $OUT"
+}
+
+test_role_override() {
+    run_check "$(printf '{"sessions":[{"id":"s1","name":"a/scout","rig":"a","state":"asleep","last_active":"%s","closed":false}]}' "$STALE")" \
+        GASTOWN_WITNESS_ROLE=scout
+    [ "$RC" -eq 1 ] || fail "GASTOWN_WITNESS_ROLE should retarget the check, got $RC ($OUT)"
+    printf '%s' "$OUT" | grep -q '^stalled	a	a/scout	' ||
+        fail "the overridden role should be checked, got: $OUT"
+}
+
+test_legacy_top_level_array_is_tolerated() {
+    run_check "$(printf '[{"id":"s1","name":"alpha/witness","rig":"alpha","state":"asleep","last_active":"%s","closed":false}]' "$STALE")"
+    [ "$RC" -eq 1 ] || fail "the legacy top-level array shape should still parse, got $RC ($OUT)"
+    printf '%s' "$OUT" | grep -q '^stalled	alpha	alpha/witness	' ||
+        fail "the legacy array shape should yield the same verdict, got: $OUT"
+}
+
+test_missing_last_active_field_fails_loud() {
+    # Schema drift must never read as health: nothing was measured, so say so
+    # instead of quietly reporting every witness fresh.
+    run_check '{"sessions":[{"id":"s1","name":"alpha/witness","rig":"alpha","state":"asleep","closed":false}]}'
+    [ "$RC" -eq 2 ] || fail "a roster with no last_active field must exit 2, got $RC ($OUT)"
+    printf '%s' "$OUT" | grep -q '^schema-drift	alpha	alpha/witness	asleep	-	-$' ||
+        fail "the drifted session should be named, got: $OUT"
+    printf '%s' "$ERR" | grep -q 'NOT measured' ||
+        fail "the drift message should say freshness was not measured, got: $ERR"
+}
+
+test_unreadable_roster_fails_loud() {
+    mkdir -p "$tmp/badbin"
+    printf '#!/usr/bin/env sh\nexit 1\n' >"$tmp/badbin/gc"
+    chmod +x "$tmp/badbin/gc"
+    set +e
+    OUT=$(GC_CITY="$CITY" PATH="$tmp/badbin:$PATH" bash "$SCRIPT" 2>"$ERRFILE")
+    RC=$?
+    set -e
+    [ "$RC" -eq 2 ] || fail "a failing 'gc session list' must exit 2, got $RC"
+    grep -q 'NOT measured' "$ERRFILE" ||
+        fail "a failing roster read should say freshness was not measured"
+}
+
+test_missing_city_fails_loud() {
+    set +e
+    OUT=$(cd "$tmp" && GC_CITY="$tmp/nope" PATH="$BIN:$PATH" bash "$SCRIPT" 2>"$ERRFILE")
+    RC=$?
+    set -e
+    [ "$RC" -eq 2 ] || fail "a missing city must exit 2, got $RC"
+    grep -q 'no city.toml found' "$ERRFILE" || fail "expected the city-resolution error"
+}
+
+test_multiple_rigs_report_every_witness() {
+    run_check "$(printf '{"sessions":[
+      {"id":"s1","name":"a/witness","rig":"a","state":"asleep","last_active":"%s","closed":false},
+      {"id":"s2","name":"b/witness","rig":"b","state":"active","last_active":"%s","closed":false},
+      {"id":"s3","name":"c/witness","rig":"c","state":"asleep","last_active":"0001-01-01T00:00:00Z","closed":false}
+    ]}' "$FRESH" "$STALE")"
+    [ "$RC" -eq 1 ] || fail "a mixed roster with findings must exit 1, got $RC ($OUT)"
+    printf '%s' "$OUT" | grep -q '^fresh	a	a/witness	' || fail "rig a should be fresh: $OUT"
+    printf '%s' "$OUT" | grep -q '^stalled	b	b/witness	active	' || fail "rig b should be stalled: $OUT"
+    printf '%s' "$OUT" | grep -q '^no-heartbeat	c	c/witness	' || fail "rig c should be no-heartbeat: $OUT"
+    printf '%s' "$ERR" | grep -q "checked 3 'witness' session(s), 1 stalled (window 90m)" ||
+        fail "the summary should count what was checked, got: $ERR"
+}
+
+test_uses_no_bash4_only_constructs() {
+    ! grep -nE 'declare -A|local -A|mapfile|readarray|\$\{[A-Za-z_]+\^|\$\{[A-Za-z_]+,,|&>>|\[\[ -v ' "$SCRIPT" >/dev/null ||
+        fail "the check must stay bash 3.2 compatible (the fleet includes macOS)"
+}
+
+test_fresh_heartbeat_is_not_flagged
+test_stale_heartbeat_is_stalled
+test_zero_time_sentinel_is_no_heartbeat_not_stalled
+test_malformed_timestamp_is_no_heartbeat_not_stalled
+test_newer_of_the_two_stamps_wins
+test_fractional_seconds_parse
+test_future_heartbeat_is_clock_skew_not_stale
+test_threshold_is_configurable
+test_bad_threshold_fails_loudly
+test_controller_owned_states_are_skipped
+test_non_witness_sessions_are_ignored
+test_binding_prefixed_template_matches
+test_role_override
+test_legacy_top_level_array_is_tolerated
+test_missing_last_active_field_fails_loud
+test_unreadable_roster_fails_loud
+test_missing_city_fails_loud
+test_multiple_rigs_report_every_witness
+test_uses_no_bash4_only_constructs
+
+echo "witness heartbeat check tests passed"


### PR DESCRIPTION
Adopts the one genuinely new idea from #99 (thanks @sarendipitee) into gastown, and closes a gap
that turns out to be sharper than that PR realized.

## The failure mode

A witness whose self-scheduled patrol loop has died still reports a healthy session state. It parks
in `asleep` or `active` forever, so the controller's liveness reconcile sees nothing wrong. Patrol
stalls of **14 to 63 hours** were observed in production this way, with no alert and work quietly
accumulating.

## Why gastown didn't already catch it

Both existing checks explicitly *excused* the exact production case:

- `health-scan`: "if there's no active work in the rig, the witness is legitimately idle — not stuck."
- `queue-starvation-check` Step 4: "A genuinely-idle session (no assigned beads) is NOT flagged."

So the **empty-queue silent stall** was reasoned away twice. This PR amends that sentence so the
file no longer contradicts the new pass: idle now only excuses a stale *wisp*, and if the heartbeat
pass returns `stalled`, don't talk yourself out of it.

Heartbeat age is also precisely the kind of measurement an LLM shouldn't be eyeballing, which is why
it's a deterministic script rather than more prompt.

## Shape

A read-only script (`gastown/assets/scripts/witness-heartbeat-check.sh`) run as the first pass of the
existing `health-scan` step — not a new step, not a parallel order. It measures, prints TSV, and
exits; it never mails, nudges, or files warrants. `health-scan` keeps the decision, which is what
avoids hardcoding an escalation target (#99 hardcoded `mayor`, bypassing core's `escalate.sh`).

Matches the existing `polecat-churn-watcher.sh` shape: same city resolution, same `gc` + `jq`, same
env-only config, sibling test under `gastown/tests/`.

## The threshold is deliberately not #99's

**#99 used 15 minutes. In gastown that would be a misfire machine.** #99 calibrated against a witness
with a self-scheduled ~60s `ScheduleWakeup` loop. Gastown's witness deliberately does *not*
self-schedule — `mol-witness-patrol`'s `next-iteration` says "Do NOT sleep, call ScheduleWakeup, or
use Monitor", and `agents/witness/agent.toml` sets `idle_timeout = "1h"`. So 1h is the longest
legitimate silence for a *healthy* gastown witness.

Default is **90 minutes** (1.5× that): clear of legitimate idle, still an order of magnitude under
the 14h stall floor. Configurable via `[vars.witness_stale_min]`.

## Robustness

Roster field names verified against the real binary (`gc session list --json-schema=result`, gc
1.1.1) rather than trusting #99: `last_active` is **required**, `last_nudge_delivered_at` optional.
So a missing nudge field is normal, but a missing `last_active` is schema drift → exit 2 and an
explicit "NOT measured", mirroring the fail-safe `mol-witness-patrol` already carries for gc-3tn8g.

- Zero-time sentinel (`0001-…`) → `no-heartbeat`, never `stalled` — a brand-new witness must not be
  killed — but still a finding, because "nothing was measured" must not read as health.
- GNU `date -d` then BSD `date -j -f`; fractional seconds stripped first, which #99 didn't do and
  which BSD `date -f` can't parse. Verified against a BSD-only `date` stub on PATH: identical verdicts.
- bash 3.2 throughout (no `declare -A` — #99 used it, and the fleet includes macOS bash 3.2). A test
  greps for bash-4 constructs to keep it that way.
- Heartbeat candidates compared as epochs, not #99's `sort | last` string sort, which is wrong across
  mixed UTC/offset. A future heartbeat clamps to age 0 — clock skew isn't staleness.

## Verification

`bash -n` clean; 19 new tests; CI's exact loop (`for t in gastown/tests/test_*.sh`) all four suites
pass; formula TOML parses; `check-scripts` executable gate passes; `validate_registry.py
--require-git` ok; `pytest` 276 passed / 9385 subtests; `go test .` ok. `gc lint gastown` findings
byte-identical to the base commit (35 pre-existing, 0 new).

Six timestamp cases exercised end to end: fresh, 20h-stale, zero-time, malformed, stale-`last_active`
-with-fresh-nudge, and `last_active` absent.

**Test-teeth note, for honesty:** mutating the staleness window makes the suite fail as expected. The
zero-time path, though, is defended four layers deep (prefix sentinel → non-numeric guard → pre-epoch
guard → the `best=0` max comparison), so removing fewer than all four leaves it still correct and the
suite still green. That's intentional defense-in-depth, not a gap in the assertions — but it means no
single-guard mutation can demonstrate that particular test's teeth.

## Not ported from #99

Its dead-state check (the controller owns process liveness), its refinery merge-freshness check
(`mol-refinery-patrol` + `queue-starvation-check` cover it), and its JSON dedup ledger
(`health-scan`'s existing warrant-dedup plus the `boot` watchdog cover the deacon side).

Also fixes a ghost reference in this formula's header claiming mechanical housekeeping runs as exec
orders "in the maintenance pack" — that pack was folded into the SDK's `core` pack in gascity
`f895c0ff4`.
