### PR TITLE
fix(gastown): gate refinery closes on hosted-CI REGRESSIONS, not on redness

### DIFF
--- a/gastown/agents/refinery/prompt.template.md
+++ b/gastown/agents/refinery/prompt.template.md
@@ -39,6 +39,12 @@ the bead. No separate MR beads.
 | Push fails | Retry with backoff, or abort and investigate |
 | Pre-existing test failure | File bead for tracking (NEVER fix it yourself) — check for duplicates first |
 | Uncertain merge order | Choose based on priority, dependencies, timing |
+| Hosted check red here, green on {{ .DefaultBranch }} | Reject, naming the check. This branch broke it. |
+| Hosted check red here AND red on {{ .DefaultBranch }} | Allow, and say so. Inherited, not caused here. |
+| Hosted check red here, absent on {{ .DefaultBranch }} | Reject: the branch added a failing job. |
+| Hosted CI still running | Wait, bounded. Then UNDETERMINED — stop, do not blame the branch. |
+| Hosted CI reports no checks at all, on both sides | Allow: there is no CI here to degrade. |
+| Hosted CI reports no checks here but does on {{ .DefaultBranch }} | Reject: coverage the target has was lost. |
 
 {{ template "following-mol" . }}
 
@@ -55,6 +61,70 @@ the quality gates documented there instead. Treat their failures the
 same as failures from configured commands (reject or file pre-existing
 bug, per the formula's `handle-failures` step). The fallback preserves
 the quality-gate intent even when pack-specific guidance is missing.
+
+## Hosted-CI Regression Gate
+
+**That section is about running commands. This one is not.** Everything the
+`run-tests` step executes runs on this machine, so it can only prove what this
+machine builds. A Linux worker cannot build `Windows x86 / Release` or
+`Portable tests / macOS arm64`. Passing every configured command earns you the
+right to reach this gate, never the right to skip it.
+
+This is the failure it exists to prevent. One rig's `{{ .DefaultBranch }}`,
+merged bead by bead by a refinery whose entire quality gate was local:
+
+```
+07-22 15:04  beda5d39   success:9            <- last fully green
+07-23 09:34  0d5a7558   failure:3 success:6  <- first red
+07-24 01:25  dd1f26ba   failure:8 success:1
+07-24 22:00  08050416   failure:11
+```
+
+Every failing check was a cross-platform target. Polecat green on Linux,
+refinery green on Linux, merge, hosted CI red, nobody reads it, next merge
+stacks on top.
+
+**The gate is scoped to REGRESSIONS, and this distinction is the whole
+design.** Before a work bead closes, the formula's `merge-push` step reads the
+hosted verdict for the merge SHA *and* for `origin/{{ .DefaultBranch }}`, and
+compares them check name by check name:
+
+| on `{{ .DefaultBranch }}` | on this branch | verdict |
+|---|---|---|
+| green | red | **REGRESSION — reject, naming the check** |
+| absent | red | **REGRESSION — a new failing job is worse** |
+| still running | red | not *proven* inherited — reject |
+| red | red | pre-existing — **allow**, report it, stamp it |
+| anything | green | pass |
+| anything | still running | bounded wait, then UNDETERMINED |
+
+A check is red on `failure`, `timed_out`, `cancelled`, `action_required`, or
+any conclusion not on the accept list (`success`, `neutral`, `skipped`) —
+an unrecognized conclusion is not a pass.
+
+**A red {{ .DefaultBranch }} does not block work, and must not.** On one rig
+the target branch went red and stayed red; every branch cut from it inherited
+those failures. Under a gate that demanded green, no fix could have landed —
+including the fixes for the failures causing the red. That repository sat
+frozen for roughly 16 hours and only moved when a human authorised a
+deliberate override. So an already-failing check is announced
+(`CI_GATE_PREEXISTING_RED`), recorded on the bead in `ci_gate_inherited`, and
+**allowed through**. Report it; do not treat it as your merge's fault, and do
+not treat it as permission to break anything else.
+
+Zero checks follows the same rule. Zero on both sides means this repository
+publishes no CI on this path and there is nothing to degrade: allow. Zero here
+while `{{ .DefaultBranch }}` publishes checks means coverage the target has was
+lost on this branch: reject. Pending is the case people get wrong in the other
+direction — the gate waits, bounded by `ci_timeout_seconds`, and then reports
+UNDETERMINED rather than rejecting. A check that never finished is not evidence
+this branch degraded anything, and a slow CI queue is not the branch's fault.
+
+A rig with no hosted CI at all sets `ci_gate=false`. That is an explicit
+operator waiver, it is announced, and it stamps `ci_gate_result=disabled` on
+every bead it lets through. The gate never turns itself off: an unreadable API
+is *undetermined*, which STOPs without mutating bead state, and is never
+treated as a pass.
 
 ---
 
@@ -228,13 +298,23 @@ Never infer a branch name. If `metadata.branch` is missing, reject the bead.
 
 ## Rejection Flow
 
-On rebase conflict or test failure:
+On rebase conflict, test failure, or a hosted-CI rejection:
 1. Put work bead back in pool:
    `gc bd update $WORK --status=open --assignee="" --set-metadata rejection_reason="..."`
 2. Branch handling depends on failure type:
    - Conflict: leave branch intact (polecat needs it for rebase)
    - Test failure: delete branch (polecat redoes work)
+   - Hosted-CI regression: **leave branch intact.** A CI rejection is
+     fix-forward — the polecat pushes another commit to the same branch and
+     reassigns. Deleting it would throw away work that is one commit from
+     correct, and in `mr` mode it would orphan an open PR.
 3. Pour next wisp, burn current one
+
+A CI `rejection_reason` must be specific enough to act on: which checks this
+branch broke and what they were doing on the base, or that the SHA carried no
+checks at all while the base did. `"CI failed"` is not a rejection reason, and
+neither is `"CI is red"` when the base is red too — that one is not a rejection
+at all.
 
 A new polecat picks up the bead, sees `metadata.branch` and
 `metadata.rejection_reason`, rebases or redoes work, reassigns to refinery.
@@ -257,6 +337,18 @@ contradictory record on the bead.
 
 - `direct` — merge to target and push normally
 - `mr` / `pr` — push the rebased source branch and create or update a GitHub PR
+
+**The hosted-CI gate runs in both modes; only the SHA it can read differs.**
+`mr` mode already pushes the rebased branch, so the gate reads the PR's head
+SHA and rules on the exact object. `direct` mode does not push the source
+branch and this gate does not make it start: it rules on the published tip of
+`metadata.branch`, which IS the commit being landed whenever the rebase was a
+no-op, and when a rebase rewrote the branch it says which SHA it proved and
+which one lands. A rig that wants the exact-object guarantee in `direct` mode
+sets `ci_gate_publish_head=true` and accepts the branch push that comes with
+it; a rig that does not set it pushes exactly what it pushed before. The BASE
+side of the comparison is the same in both modes: `origin/$TARGET`, the tip the
+work lands on and the commit hosted CI actually publishes a board for.
 
 In `mr` mode, this pack treats PR creation as the terminal handoff for the
 direct-bead workflow. Record `pr_url` on the work bead, close the bead, and
@@ -316,6 +408,9 @@ alert the witness, not `gc mail send`.
 | Read work metadata | `gc bd show $WORK --json \| jq '.[0].metadata'` |
 | Set metadata field | `gc bd update $WORK --set-metadata key=value` |
 | Remove metadata field | `gc bd update $WORK --unset-metadata key` |
+| Read hosted check-runs for a SHA | `gh api "repos/$ORIGIN_REPO/commits/$SHA/check-runs?per_page=100"` |
+| Read legacy commit statuses for a SHA | `gh api "repos/$ORIGIN_REPO/commits/$SHA/status?per_page=100"` |
+| Resolve the base the gate compares against | `git rev-parse refs/remotes/origin/$TARGET` |
 | Fetch remote branches | `git fetch --prune origin` |
 | Rebase on target | `git rebase origin/$TARGET` |
 | Fast-forward merge | `git merge --ff-only temp` |

--- a/gastown/formulas/mol-refinery-patrol.toml
+++ b/gastown/formulas/mol-refinery-patrol.toml
@@ -27,6 +27,13 @@ In `mr` mode, refinery treats PR publication as the terminal handoff for
 the direct-bead workflow: it records the PR URL on the work bead and
 closes the bead once the PR is verified.
 
+Before a work bead closes in either mode, hosted CI must be green on the
+merge SHA. The `run-tests` step runs configured commands on THIS machine, so
+it can only prove what this machine builds; the CI gate reads the verdict of
+the checks it cannot run. Pending is not green and zero checks is not green.
+A CI rejection uses the SAME flow as a conflict or a test failure: bead back
+in the pool with a specific `rejection_reason`, branch left intact.
+
 Read each step's description before acting — Config values override defaults."""
 formula = "mol-refinery-patrol"
 
@@ -77,6 +84,26 @@ default = "false"
 [vars.event_timeout]
 description = "Seconds to sleep before re-checking for work. Replaces former event-watch loop which hot-spun on cache-reconcile firehose."
 default = "60"
+
+[vars.ci_gate]
+description = "Require that a work bead's hosted CI is no WORSE than the target branch it lands on before the bead closes. The commands in run-tests only prove what THIS machine can build; a Linux worker cannot build a Windows or macOS target. The gate is scoped to regressions, not to redness: a check that is already failing on the target is reported and allowed through, so a repository whose base is red is never frozen. 'false' is an explicit operator waiver; it stamps ci_gate_result=disabled on every bead it lets through. The gate never self-disables on error."
+default = "true"
+
+[vars.ci_timeout_seconds]
+description = "Bounded wait for still-running checks on the head. Pending is never a pass: at this deadline the gate reports UNDETERMINED and stops without mutating bead state, because an unfinished check is not evidence the branch degraded anything and a slow CI queue is not the branch's fault."
+default = "900"
+
+[vars.ci_poll_seconds]
+description = "Seconds between check-run polls while the CI gate waits."
+default = "60"
+
+[vars.ci_zero_check_grace_seconds]
+description = "How long the head may report zero check-runs and zero commit statuses before the gate rules on it. Covers the seconds between a push and GitHub registering workflow runs. After it: zero on the head AND zero on the base means this repository publishes no CI on this path and the bead is allowed through; zero on the head while the base publishes checks means coverage the target has was lost here, and is a rejection."
+default = "300"
+
+[vars.ci_gate_publish_head]
+description = "Direct mode only, and OFF by default because it changes what this rig pushes. When a rebase rewrites the branch, the commit that lands is one no forge has seen. 'false' (default) gates the published branch tip instead and says so out loud — direct mode publishes nothing it did not publish before. 'true' pushes the rebased head to origin/$BRANCH with --force-with-lease first, so the gate rules on the exact object that lands."
+default = "false"
 
 [[steps]]
 id = "validate-identity"
@@ -379,7 +406,13 @@ TARGET=$(gc bd show $WORK --json | jq -r '.[0].metadata.target // "{{target_bran
    - Proceed with merge (failure not caused by this branch)
 
 **GATE**: Cannot merge without all checks passing OR pre-existing bug filed/found.
-**FORBIDDEN**: Writing code to fix failures. You are a merge processor."""
+**FORBIDDEN**: Writing code to fix failures. You are a merge processor.
+
+**These checks are local, and local is not enough.** Everything above runs on
+this machine, so it can only prove what this machine can build. A Linux worker
+cannot build `Windows x86 / Release`; a green run here says nothing about it.
+Passing this step earns the right to reach the hosted-CI gate in `merge-push`,
+never the right to skip it."""
 
 [[steps]]
 id = "merge-push"
@@ -613,6 +646,391 @@ lookup_pr_info() {
     | jq '{url:.html_url, number, state:(.state | ascii_upcase), headRefName:.head.ref, baseRefName:.base.ref, headRepositoryOwner:{login:.head.repo.owner.login}, headRepository:{name:.head.repo.name}}'
 }
 
+# BEGIN REFINERY_CI_GATE
+# Hosted-CI REGRESSION gate. Everything the run-tests step executes runs on
+# THIS machine, so it can only prove what this machine builds. On one live rig
+# every quality check the refinery ran was local, the hosted verdict was never
+# read, and the target branch went success:9 -> failure:3 -> failure:11 over 55
+# hours, one refinery merge at a time. Every failing check was a cross-platform
+# target (Windows x86, portable macOS/Windows arm64) that a Linux worker cannot
+# build.
+#
+# The gate is scoped to DEGRADATION, not to redness. It reads the head's check
+# board AND the target tip's check board and rejects only what this branch made
+# worse:
+#
+#   on the base   on the head   verdict
+#   green         red           REGRESSION -- reject, naming the check
+#   absent        red           REGRESSION -- a new failing job is worse
+#   still running red           not PROVEN inherited -- reject (recoverable)
+#   red           red           pre-existing -- ALLOW, reported loudly, stamped
+#   anything      green         nothing to answer for -- pass
+#   anything      still running bounded wait, then UNDETERMINED
+#
+# An absolute "red head = reject" gate cannot ship. On the operator's own rig
+# the target branch went red and STAYED red; every branch cut from it inherited
+# those failures, so an absolute gate would have blocked every fix -- including
+# the fixes for the very failures causing the red. That repository sat frozen
+# for roughly 16 hours and only moved when a human authorised a deliberate
+# override. A gate that no repository with a red base can use is not a gate, it
+# is a freeze, and it would be turned off on the first day it mattered.
+#
+# Return convention:
+#   0 = no attributable degradation, or explicitly waived by ci_gate=false
+#   1 = the BRANCH degraded the board -> ci_gate_reject: bead back in the pool
+#       with a specific rejection_reason, branch left INTACT for fix-forward
+#   2 = the gate could not be evaluated (API/tool/config fault, or the head is
+#       still running) -> STOP without mutating bead state. "Cannot tell" is
+#       never "no regression", and it is never blamed on the branch either.
+# CI_GATE_DETAIL carries the specific, quotable reason for both 1 and 2.
+
+CI_GATE="{{ci_gate}}"
+CI_TIMEOUT_SECONDS="{{ci_timeout_seconds}}"
+CI_POLL_SECONDS="{{ci_poll_seconds}}"
+CI_ZERO_CHECK_GRACE_SECONDS="{{ci_zero_check_grace_seconds}}"
+CI_GATE_PUBLISH_HEAD="{{ci_gate_publish_head}}"
+CI_GATE_DETAIL=""
+CI_GATE_SUMMARY=""
+CI_GATE_LANDS=""
+CI_GATE_BASE_SHA=""
+CI_GATE_INHERITED_NAMES=""
+
+ci_gate_now() {
+  date +%s
+}
+
+ci_gate_reject() {
+  # The EXISTING rejection flow, the same shape the rebase and handle-failures
+  # steps use: reopen the source bead, work bead back in the pool with a
+  # specific rejection_reason, routed to the polecat pool, then pour the next
+  # wisp and burn this one so the queue keeps moving. A CI rejection is
+  # fix-forward -- the polecat pushes another commit to the SAME branch -- so
+  # the branch is NEVER deleted here, and in mr mode deleting it would orphan
+  # an open PR. The base SHA the verdict was measured against is stamped on the
+  # bead too: a reviewer must never have to guess what "worse" was worse than.
+  cgr_reason="$1"
+  gc workflow delete-source "$WORK" --apply && gc workflow reopen-source "$WORK"
+  gc bd update "$WORK" --status=open --assignee="" --set-metadata rejection_reason="CI gate: $cgr_reason" --set-metadata ci_gate_base_sha="${CI_GATE_BASE_SHA:-unresolved}" --set-metadata ci_gate_result="rejected: $cgr_reason" --set-metadata gc.routed_to="${GC_RIG:+$GC_RIG/}{{binding_prefix}}polecat"
+  echo "CI_GATE_REJECTED $WORK: $cgr_reason"
+  echo "Branch $BRANCH left intact for fix-forward; bead NOT closed and NOT merged."
+  CURRENT_WISP=${GC_BEAD_ID:-}
+  if [ -z "$CURRENT_WISP" ]; then
+    CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
+  fi
+  NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{target_branch}} --var rig_name={{rig_name}} --var binding_prefix={{binding_prefix}} --json | jq -r '.new_epic_id // empty')
+  if [ -z "$NEXT" ] || ! gc bd update "$NEXT" --assignee="$GC_AGENT"; then
+    echo "Could not pour or assign the next refinery wisp; not burning."
+    gc runtime drain-ack
+    exit 1
+  fi
+  if [ -n "$CURRENT_WISP" ]; then
+    gc bd mol burn "$CURRENT_WISP" --force
+  else
+    echo "Could not resolve current wisp; not burning."
+    gc runtime drain-ack
+    exit 1
+  fi
+  exit 1
+}
+
+ci_gate_api() {
+  # One GitHub REST reader for the gate, over gh when present and the same
+  # token/curl fallback the PR handoff already uses when it is not. No new
+  # coupling: this is the plumbing lookup_pr_info and the PR handoff run on.
+  cga_path="$1"
+  cga_err="$2"
+  if command -v gh >/dev/null 2>&1; then
+    gh api -H "Accept: application/vnd.github+json" "repos/$ORIGIN_REPO/$cga_path" 2>"$cga_err"
+    return $?
+  fi
+  init_github_rest 2>>"$cga_err" || return 1
+  curl_gh_api "$cga_err" "$API/$cga_path"
+}
+
+ci_gate_stamp() {
+  # Forensics written the moment the gate rules, not at close time: which SHA
+  # was proven, which SHA it was measured AGAINST, and which failures were let
+  # through as inherited. A bead that closed without a ci_gate_sha is a bead
+  # that was never gated; a bead with a ci_gate_inherited is a bead that landed
+  # onto a board that was already red, and both stay readable off the bead
+  # months later.
+  cgs_sha="$1"
+  [ -n "${WORK:-}" ] || return 0
+  gc bd update "$WORK" --set-metadata ci_gate_sha="$cgs_sha" --set-metadata ci_gate_base_sha="${CI_GATE_BASE_SHA:-none}" --set-metadata ci_gate_inherited="${CI_GATE_INHERITED_NAMES:-none}" --set-metadata ci_gate_result="$CI_GATE_SUMMARY"
+}
+
+ci_gate_resolve_base() {
+  # WHICH BASE: the target branch tip at gate time, NOT the merge-base.
+  #
+  # The merge-base is the more theoretically honest attribution boundary -- it
+  # is exactly the point the branch diverged, so everything after it is the
+  # branch's own doing. It is also frequently un-gradeable: hosted CI attaches
+  # check-runs to commits it was triggered for, and an arbitrary interior
+  # commit of the target's history was very often never a branch tip any
+  # workflow ran against. A comparison against a commit with an empty board
+  # would classify every red check on the head as "absent on the base", i.e.
+  # as a regression, which is the absolute gate wearing a disguise.
+  #
+  # The target tip does not have that problem: it is the commit `on: push`
+  # workflows fire for, so a repository with CI has a board there, and it is
+  # also the commit this work will actually land on. The two only differ when
+  # the target moved after the rebase -- and this step rebases onto the target
+  # tip immediately before gating, which makes the merge-base BE the target tip
+  # in the normal case. When they do differ, a --ff-only merge onto a moved
+  # target fails anyway and the branch comes back through here after another
+  # rebase, so the window is a race of seconds, not a design gap.
+  #
+  # The residual: a check that the moved target broke is charged to the base,
+  # not the branch, which is the direction that errs toward letting work land.
+  CI_GATE_BASE_SHA=$(git rev-parse --verify --quiet "refs/remotes/origin/$TARGET" 2>/dev/null || true)
+  if [ -z "$CI_GATE_BASE_SHA" ]; then
+    CI_GATE_DETAIL="could not resolve refs/remotes/origin/$TARGET, so there is no base board to measure degradation against. Fetch origin and re-run. A missing base is UNDETERMINED, never a pass: without it the gate cannot tell a regression from an inherited failure."
+    return 2
+  fi
+  return 0
+}
+
+ci_gate_board() {
+  # Reads one commit's hosted verdict into CI_GATE_BOARD, normalised to one
+  # entry per check NAME. Reads check-runs AND legacy commit statuses, because
+  # a repo can publish either or both, and "I only looked at one API" is a way
+  # to mistake silence for success.
+  #
+  # Aggregation of repeat runs of the same name is deliberately ASYMMETRIC, and
+  # both directions are fail-closed:
+  #   head: RED beats PENDING beats GREEN -- a red run on the head is red.
+  #   base: GREEN beats RED beats PENDING -- a name only counts as already
+  #         broken if nothing on the base ever passed it, so a flaky base
+  #         cannot be used to excuse a head failure.
+  cgb_sha="$1"
+  cgb_mode="$2"
+  CI_GATE_BOARD=""
+  cgb_err=$(mktemp)
+  cgb_checks=$(ci_gate_api "commits/$cgb_sha/check-runs?per_page=100" "$cgb_err")
+  cgb_status=$?
+  cgb_error=$(cat "$cgb_err")
+  if [ "$cgb_status" -ne 0 ] || [ -z "$cgb_checks" ]; then
+    rm -f "$cgb_err"
+    CI_GATE_DETAIL="could not read check-runs for the $cgb_mode commit $cgb_sha: ${cgb_error:-no response}"
+    return 2
+  fi
+  cgb_statuses=$(ci_gate_api "commits/$cgb_sha/status?per_page=100" "$cgb_err")
+  cgb_status=$?
+  cgb_error=$(cat "$cgb_err")
+  rm -f "$cgb_err"
+  if [ "$cgb_status" -ne 0 ] || [ -z "$cgb_statuses" ]; then
+    CI_GATE_DETAIL="could not read commit statuses for the $cgb_mode commit $cgb_sha: ${cgb_error:-no response}"
+    return 2
+  fi
+  CI_GATE_BOARD=$(jq -n -c --arg mode "$cgb_mode" --argjson checks "$cgb_checks" --argjson statuses "$cgb_statuses" '
+      def clean: (. // "") | tostring | gsub("[[:space:]]+"; " ");
+      def classify_run:
+        (.conclusion // "") as $conclusion
+        | if .status != "completed" then "PENDING"
+          elif (["success","neutral","skipped"] | index($conclusion)) then "GREEN"
+          else "RED" end;
+      def classify_status:
+        if .state == "pending" then "PENDING"
+        elif .state == "success" then "GREEN"
+        else "RED" end;
+      ($checks.check_runs // []) as $runs
+      | ($statuses.statuses // []) as $sts
+      | (($runs | map({key: ("check-run:" + (.name | clean)), label: (.name | clean), state: classify_run, detail: ((.conclusion // .status // "unknown") | clean)}))
+         + ($sts | map({key: ("status:" + (.context | clean)), label: (.context | clean), state: classify_status, detail: ((.state // "unknown") | clean)}))) as $all
+      | {truncated: ((($checks.total_count // 0) > ($runs | length)) or (($statuses.total_count // 0) > ($sts | length))),
+         checks: ($all | group_by(.key) | map(
+             . as $group
+             | ($group | map(.state)) as $states
+             | (if $mode == "base"
+                then (if ($states | index("GREEN")) then "GREEN" elif ($states | index("RED")) then "RED" else "PENDING" end)
+                else (if ($states | index("RED")) then "RED" elif ($states | index("PENDING")) then "PENDING" else "GREEN" end) end) as $state
+             | {key: $group[0].key, label: $group[0].label, state: $state,
+                detail: (($group | map(select(.state == $state)) | .[0].detail) // $group[0].detail)}))}' 2>/dev/null)
+  if [ -z "$CI_GATE_BOARD" ]; then
+    CI_GATE_DETAIL="could not parse the hosted check response for the $cgb_mode commit $cgb_sha"
+    return 2
+  fi
+  if [ "$(printf '%s\n' "$CI_GATE_BOARD" | jq -r '.truncated')" = "true" ]; then
+    CI_GATE_BOARD=""
+    CI_GATE_DETAIL="more checks on the $cgb_mode commit $cgb_sha than one page can report; the whole board is not visible, so nothing about it can be attributed either way"
+    return 2
+  fi
+  return 0
+}
+
+ci_gate_compare() {
+  # The whole verdict, in one pass over the two boards. A red check on the head
+  # is a REGRESSION when the base is green, absent, or still running, and is
+  # INHERITED when the base is red too.
+  #
+  # The one exception is a base with NO board at all: a repository whose CI
+  # only runs on pull requests never publishes checks for its target tip, so
+  # "absent on the base" there means "there is no baseline", not "this branch
+  # added a failing job". Charging a head failure to the branch on that
+  # evidence would freeze exactly the repositories this gate was rescoped to
+  # unfreeze, so an empty base makes every red head check unattributable rather
+  # than a regression, and the summary says so out loud.
+  cgc_out=$(jq -n -r --argjson base "$CI_GATE_BASE_BOARD" --argjson head "$CI_GATE_HEAD_BOARD" '
+      ($base.checks | map({(.key): .state}) | add // {}) as $bmap
+      | ($base.checks | length) as $bcount
+      | [ $head.checks[] | select(.state == "RED") | . + {base: ($bmap[.key] // "ABSENT")} ] as $reds
+      | ($reds | map(select($bcount > 0 and .base != "RED"))) as $regressed
+      | ($reds | map(select($bcount == 0 or .base == "RED"))) as $inherited
+      | [ $head.checks[] | select(.state == "PENDING") ] as $pending
+      | [ ($head.checks | length),
+          $bcount,
+          ($regressed | length),
+          ($inherited | length),
+          ($pending | length),
+          ($regressed | map(.label + " [" + .detail + "; on the base: " + (if .base == "ABSENT" then "no such check" elif .base == "PENDING" then "still running" else (.base | ascii_downcase) end) + "]") | join("; ")),
+          ($inherited | map(.label + " [" + .detail + "]") | join("; ")),
+          ($pending | map(.label + " [" + .detail + "]") | join("; ")) ]
+      | .[]' 2>/dev/null)
+  if [ -z "$cgc_out" ]; then
+    CI_GATE_DETAIL="could not compare the head board against the base board"
+    return 2
+  fi
+  CI_GATE_TOTAL=$(printf '%s\n' "$cgc_out" | sed -n '1p')
+  CI_GATE_BASE_TOTAL=$(printf '%s\n' "$cgc_out" | sed -n '2p')
+  CI_GATE_REGRESSED=$(printf '%s\n' "$cgc_out" | sed -n '3p')
+  CI_GATE_INHERITED=$(printf '%s\n' "$cgc_out" | sed -n '4p')
+  CI_GATE_PENDING=$(printf '%s\n' "$cgc_out" | sed -n '5p')
+  CI_GATE_REGRESSED_NAMES=$(printf '%s\n' "$cgc_out" | sed -n '6p')
+  CI_GATE_INHERITED_NAMES=$(printf '%s\n' "$cgc_out" | sed -n '7p')
+  CI_GATE_PENDING_NAMES=$(printf '%s\n' "$cgc_out" | sed -n '8p')
+  return 0
+}
+
+ci_gate_check() {
+  # Hosted CI must be no worse on the SHA this merge rests on than it already
+  # is on the target it lands on.
+  #   RED         failure, timed_out, cancelled, action_required, or any
+  #               conclusion not on the accept list (default deny -- an
+  #               unrecognized conclusion is not a pass)
+  #   ACCEPTABLE  success, neutral, skipped
+  #   PENDING     anything not completed: WAIT, bounded, then UNDETERMINED. A
+  #               check that has not finished is not evidence of a regression,
+  #               and a slow build is not the branch's fault.
+  #   ZERO CHECKS on BOTH sides: this repo publishes no CI for this path and
+  #               there is nothing to degrade -- allow. On the HEAD ONLY, with
+  #               a base that does publish checks: coverage the target has was
+  #               lost here -- reject.
+  cgc_sha="$1"
+  CI_GATE_DETAIL=""
+  CI_GATE_SUMMARY=""
+  CI_GATE_INHERITED_NAMES=""
+  if [ "$CI_GATE" = "false" ]; then
+    # An explicit operator waiver for a rig with no hosted CI. It is loud and
+    # it is recorded on every bead it lets through. The gate itself never
+    # reaches this state on its own -- no error path sets CI_GATE.
+    CI_GATE_SUMMARY="disabled"
+    echo "CI_GATE_DISABLED_BY_CONFIG: $cgc_sha closes without a hosted-CI comparison (ci_gate=false); stamping ci_gate_result=disabled on the bead."
+    ci_gate_stamp "$cgc_sha"
+    return 0
+  fi
+  if [ -z "${ORIGIN_REPO:-}" ]; then
+    CI_GATE_DETAIL="could not resolve the origin repository to read hosted CI from: ${ORIGIN_REPO_ERROR:-origin is not a github.com remote}. Install gh, or set ci_gate=false if this rig genuinely has no hosted CI."
+    return 2
+  fi
+  ci_gate_resolve_base || return 2
+  # The base board is snapshotted ONCE, before the wait loop. The verdict is
+  # then measured against a single fixed commit for the whole run rather than
+  # against a target that may move underneath it mid-wait.
+  ci_gate_board "$CI_GATE_BASE_SHA" base || return 2
+  CI_GATE_BASE_BOARD="$CI_GATE_BOARD"
+  echo "CI_GATE_BASE: measuring $cgc_sha against $TARGET at $CI_GATE_BASE_SHA."
+  cgc_deadline=$(( $(ci_gate_now) + CI_TIMEOUT_SECONDS ))
+  cgc_zero_deadline=$(( $(ci_gate_now) + CI_ZERO_CHECK_GRACE_SECONDS ))
+  while : ; do
+    ci_gate_board "$cgc_sha" head
+    cgc_poll_status=$?
+    if [ "$cgc_poll_status" -ne 0 ]; then
+      # A transient API failure is not a green light. Retry inside the same
+      # bounded window, then report it as undeterminable.
+      if [ "$(ci_gate_now)" -ge "$cgc_deadline" ]; then
+        return 2
+      fi
+      sleep "$CI_POLL_SECONDS"
+      continue
+    fi
+    CI_GATE_HEAD_BOARD="$CI_GATE_BOARD"
+    ci_gate_compare || return 2
+    if [ "$CI_GATE_TOTAL" -eq 0 ]; then
+      if [ "$(ci_gate_now)" -lt "$cgc_zero_deadline" ]; then
+        # A push takes seconds to register workflow runs; give it the window
+        # before concluding anything from an empty head board.
+        sleep "$CI_POLL_SECONDS"
+        continue
+      fi
+      if [ "$CI_GATE_BASE_TOTAL" -eq 0 ]; then
+        CI_GATE_SUMMARY="no hosted checks on $cgc_sha and none on $TARGET at $CI_GATE_BASE_SHA either; this repository publishes no CI on this path, so this branch cannot have degraded it"
+        echo "CI_GATE_NO_HOSTED_CI: $CI_GATE_SUMMARY"
+        ci_gate_stamp "$cgc_sha"
+        return 0
+      fi
+      CI_GATE_DETAIL="$TARGET at $CI_GATE_BASE_SHA publishes $CI_GATE_BASE_TOTAL checks and $cgc_sha publishes none after ${CI_ZERO_CHECK_GRACE_SECONDS}s. CI ran for the base and did not run here, so this branch lost coverage the target already has: a workflow was removed or renamed, or it never triggered for this ref. Nothing ran, so nothing can be compared."
+      return 1
+    fi
+    if [ "$CI_GATE_REGRESSED" -gt 0 ]; then
+      # Proven degradation. Do not wait for the rest of the board: the verdict
+      # cannot improve, and the polecat can start on these names now.
+      CI_GATE_DETAIL="$CI_GATE_REGRESSED of $CI_GATE_TOTAL checks are red on $cgc_sha and are NOT red on $TARGET at $CI_GATE_BASE_SHA: $CI_GATE_REGRESSED_NAMES. This branch made hosted CI worse. Fix these checks on the same branch and reassign."
+      return 1
+    fi
+    if [ "$CI_GATE_PENDING" -gt 0 ]; then
+      if [ "$(ci_gate_now)" -ge "$cgc_deadline" ]; then
+        CI_GATE_DETAIL="$CI_GATE_PENDING of $CI_GATE_TOTAL checks on $cgc_sha were still running after ${CI_TIMEOUT_SECONDS}s: $CI_GATE_PENDING_NAMES. Unfinished is neither proof of a regression nor proof there is none, and a slow queue is not this branch's fault; re-run the gate once they finish."
+        return 2
+      fi
+      sleep "$CI_POLL_SECONDS"
+      continue
+    fi
+    if [ "$CI_GATE_INHERITED" -eq 0 ]; then
+      CI_GATE_SUMMARY="$CI_GATE_TOTAL checks green on $cgc_sha, no regression against $TARGET at $CI_GATE_BASE_SHA ($CI_GATE_BASE_TOTAL checks)"
+      cgc_marker="CI_GATE_GREEN"
+    elif [ "$CI_GATE_BASE_TOTAL" -eq 0 ]; then
+      CI_GATE_SUMMARY="$CI_GATE_TOTAL checks on $cgc_sha with $CI_GATE_INHERITED red and UNATTRIBUTABLE: $TARGET at $CI_GATE_BASE_SHA publishes no checks at all, so there is no baseline that could charge them to this branch: $CI_GATE_INHERITED_NAMES"
+      cgc_marker="CI_GATE_UNATTRIBUTABLE"
+    else
+      CI_GATE_SUMMARY="$CI_GATE_TOTAL checks on $cgc_sha with no regression against $TARGET at $CI_GATE_BASE_SHA; $CI_GATE_INHERITED of them are already red on the base and are INHERITED, not caused here: $CI_GATE_INHERITED_NAMES"
+      cgc_marker="CI_GATE_PREEXISTING_RED"
+    fi
+    if [ -n "$CI_GATE_LANDS" ]; then
+      # Direct mode with ci_gate_publish_head=false and a rebase that rewrote
+      # the branch: CI ruled on the published tip, and the commit that lands is
+      # a replay of it onto a newer target. Say which SHA was proven and which
+      # one lands, on stdout and on the bead, rather than implying they match.
+      CI_GATE_SUMMARY="$CI_GATE_SUMMARY (landing $CI_GATE_LANDS, a rebase of it; set ci_gate_publish_head=true to gate the exact object)"
+    fi
+    echo "$cgc_marker: $CI_GATE_SUMMARY"
+    if [ "$CI_GATE_INHERITED" -gt 0 ]; then
+      echo "This work is allowed through because it did not make hosted CI worse, NOT because hosted CI is well. The base is red and stays red until something fixes it; ci_gate_inherited on the bead names what was let through."
+    fi
+    ci_gate_stamp "$cgc_sha"
+    return 0
+  done
+}
+
+ci_gate_run() {
+  # Turns the gate's return code into the pack's two existing dispositions:
+  # reject to the pool (the branch's fault) or STOP without mutating bead
+  # state (ours). There is no third disposition and no path that silently
+  # continues.
+  ci_gate_check "$1"
+  cgn_status=$?
+  case "$cgn_status" in
+    0) return 0 ;;
+    1) ci_gate_reject "$CI_GATE_DETAIL" ;;
+    *)
+      echo "CI_GATE_UNDETERMINED: $CI_GATE_DETAIL"
+      echo "STOP. Do not mutate bead state, do not merge, do not close. Cannot tell whether this branch degraded CI is not a licence to assume it did not."
+      gc runtime drain-ack
+      exit 1
+      ;;
+  esac
+}
+# END REFINERY_CI_GATE
+
 if [ "$MERGE_STRATEGY" = "mr" ] && [ -n "$EXISTING_PR" ]; then
   if [ -z "$BRANCH" ] || [ "$BRANCH" = "null" ]; then
     block_existing_pr "metadata.existing_pr is set but metadata.branch is missing."
@@ -763,6 +1181,63 @@ pour the next wisp and burn this one) — the same tail a normal merge takes. Do
 NOT drain-ack here; that would strand the loop and leak the merged branch.
 Otherwise the branch has a verified real change and you continue to the merge.
 
+**0b. Hosted-CI regression gate:**
+
+Direct mode lands straight onto `$TARGET`, so it is the mode where a branch
+that breaks a check does the damage, and it is the mode the incident happened
+in. The gate runs here, before the merge script touches the target.
+
+It asks one question: **is hosted CI worse on this branch than it already is
+on `$TARGET`?** Not "is it green" — a target that is already red must still be
+fixable, and a gate that blocks every branch cut from a red base freezes the
+repository exactly when it most needs work to land. The base it measures
+against is `origin/$TARGET`, the tip this work will land on and the commit
+`on: push` workflows actually publish checks for.
+
+**Which SHA it reads, and why direct mode does not publish anything.** Hosted
+CI rules on SHAs that exist on the forge. `origin/$BRANCH` is already there —
+the polecat pushed it. When the rebase onto `$TARGET` was a no-op, the commit
+you are about to land IS that published tip and the gate is exact. When the
+rebase rewrote the branch, the commit that lands is one no forge has seen, and
+there are only two honest options: gate the published tip and say so, or push
+the rewritten head first. Pushing is a real change to what this rig does with
+remote refs, so it is opt-in (`ci_gate_publish_head`, default `false`) and a
+rig that does not set it pushes exactly what it pushed before.
+
+```bash
+CI_GATE_SHA=$(git rev-parse temp)
+if [ "$CI_GATE" != "false" ]; then
+  CI_GATE_PUBLISHED_SHA=$(git rev-parse --verify --quiet "refs/remotes/origin/$BRANCH" || true)
+  if [ "$CI_GATE_SHA" = "$CI_GATE_PUBLISHED_SHA" ]; then
+    echo "CI_GATE_EXACT: the SHA being landed is the published tip of $BRANCH."
+  elif [ "$CI_GATE_PUBLISH_HEAD" = "true" ]; then
+    git checkout temp
+    if ! git push origin "HEAD:$BRANCH" --force-with-lease; then
+      echo "--force-with-lease refused: $BRANCH moved after your fetch. STOP, re-fetch, rebase again, and re-run the gate against the new SHA. Never plain --force, and never merge a SHA the gate did not rule on. Do not mutate bead state."
+      gc runtime drain-ack
+      exit 1
+    fi
+  elif [ -n "$CI_GATE_PUBLISHED_SHA" ]; then
+    CI_GATE_LANDS="$CI_GATE_SHA"
+    CI_GATE_SHA="$CI_GATE_PUBLISHED_SHA"
+    echo "CI_GATE_REBASED_HEAD: gating the published tip $CI_GATE_PUBLISHED_SHA; the rebase onto $TARGET produces $CI_GATE_LANDS, which no forge has seen. Set ci_gate_publish_head=true to publish and gate the exact object."
+  else
+    echo "$BRANCH has no published tip to read hosted CI from. STOP. Do not mutate bead state."
+    gc runtime drain-ack
+    exit 1
+  fi
+fi
+
+ci_gate_run "$CI_GATE_SHA"
+```
+
+A board this branch made worse rejects here — bead back in the pool, branch
+left intact, next wisp poured — and the merge script below never runs. A board
+that is red in exactly the ways `$TARGET` is already red passes, loudly, with
+the inherited failures named on the bead in `ci_gate_inherited`. An unfinished
+board is UNDETERMINED: it stops without touching bead state, because a check
+that has not finished is not evidence against the branch.
+
 **1. Merge, push, verify, and close work bead:**
 
 Run this as one script. It uses a temporary detached worktree for the
@@ -814,6 +1289,17 @@ Both the `--set-metadata` write and the `gc bd close` are required —
 closed bead to its merge commit on `$TARGET`. `--unset-metadata
 rejection_reason` clears any stale rejection field from an earlier
 rejected/reworked attempt before the successful close.
+
+`ci_gate_sha`, `ci_gate_base_sha`, `ci_gate_inherited` and `ci_gate_result`
+are already on the bead — the CI gate stamped them the moment it ruled. A
+`--ff-only` merge makes `merged_sha` the same object as `temp`, so
+`ci_gate_sha == merged_sha` is the readable proof that hosted CI ruled on
+exactly what landed; when they differ, `ci_gate_result` names the published tip
+that was proven and the rebase that landed. `ci_gate_base_sha` is what "no
+worse" was measured against, and `ci_gate_inherited` names every check that was
+already failing there and was therefore not charged to this branch — the two
+fields together are why an operator never has to guess whether a red target was
+caused by a given bead or merely survived it.
 
 **2. Cleanup:**
 ```bash
@@ -1046,6 +1532,52 @@ fi
 ```
 If this command fails or prints empty output: STOP. Debug and retry. Do NOT continue.
 
+**3b. Hosted-CI regression gate:**
+
+The pull request exists; it is not finished. Publishing a PR closes this work
+bead, so the hosted checks a local worker cannot run have to have ruled BEFORE
+the close — otherwise the bead reads "done" while the branch broke a check
+nobody is tracking. The question here is the same one direct mode asks: not
+"is the PR green" but "is the PR worse than `$TARGET` already is". The base is
+`origin/$TARGET`, the same branch the PR targets (step 3 already refused a PR
+whose base is anything else).
+
+This path gates the exact object: step 1 already pushed `temp` to
+`origin/$BRANCH`, so no new push is needed here. Ask GitHub for the PR head
+rather than trusting the local ref — if the two disagree, something pushed
+after you and the checks you are about to read belong to a different commit.
+
+```bash
+CI_GATE_SHA=$(git rev-parse temp)
+if [ "$CI_GATE" != "false" ]; then
+  CI_GATE_HEAD_ERR=$(mktemp)
+  CI_GATE_PR_RAW=$(ci_gate_api "pulls/$PR_NUMBER" "$CI_GATE_HEAD_ERR")
+  CI_GATE_HEAD_STATUS=$?
+  CI_GATE_HEAD_ERROR=$(cat "$CI_GATE_HEAD_ERR")
+  rm -f "$CI_GATE_HEAD_ERR"
+  if [ "$CI_GATE_HEAD_STATUS" -ne 0 ] || [ -z "$CI_GATE_PR_RAW" ]; then
+    echo "Could not read the head SHA of PR #$PR_NUMBER: ${CI_GATE_HEAD_ERROR:-no response}"
+    echo "STOP. Do not mutate bead state, do not close."
+    gc runtime drain-ack
+    exit 1
+  fi
+  CI_GATE_PR_HEAD_SHA=$(printf '%s' "$CI_GATE_PR_RAW" | jq -r '.head.sha // empty')
+  if [ -z "$CI_GATE_PR_HEAD_SHA" ] || [ "$CI_GATE_PR_HEAD_SHA" != "$CI_GATE_SHA" ]; then
+    echo "PR #$PR_NUMBER head is '${CI_GATE_PR_HEAD_SHA:-unknown}' but you pushed $CI_GATE_SHA."
+    echo "STOP. Re-fetch, rebase, and re-run the gate against the SHA the PR actually carries."
+    gc runtime drain-ack
+    exit 1
+  fi
+  CI_GATE_SHA="$CI_GATE_PR_HEAD_SHA"
+fi
+
+ci_gate_run "$CI_GATE_SHA"
+```
+
+A rejection here leaves the PR open and the branch intact: the polecat pushes
+a fix to the same branch, the PR updates, and the bead comes back. Deleting
+the branch would orphan the PR.
+
 **4. Record PR metadata and close the work bead:**
 
 Run as a single chained command so the metadata write cannot be skipped
@@ -1085,7 +1617,17 @@ The Gastown example refinery supports direct and mr/pr merge strategies only."
 ```
 Do NOT close the bead, delete the branch, or burn the wisp until a human decides how to proceed.
 
-**GATE**: direct mode requires verified target push. mr mode requires verified PR URL. Bead closure only happens after the selected handoff is confirmed."""
+**GATE**: direct mode requires verified target push. mr mode requires verified
+PR URL. Both modes require the hosted-CI regression gate to have ruled that
+this branch did not make hosted CI worse than `$TARGET` already is (or to have
+been explicitly waived with `ci_gate=false`, which stamps
+`ci_gate_result=disabled` on the bead). Bead closure only happens after the
+selected handoff is confirmed AND the gate has ruled. The gate is never
+skipped because the local checks passed: local checks passing while hosted CI
+regressed is the exact shape of the incident this gate exists to stop. It is
+also never escalated into "hosted CI must be green": inherited failures are
+reported on the bead and allowed through, because a repository with a red base
+that cannot land its own fix is a repository nobody can rescue."""
 
 [[steps]]
 id = "patrol-summary"

--- a/gastown/tests/test_refinery_ci_gate.sh
+++ b/gastown/tests/test_refinery_ci_gate.sh
@@ -1,0 +1,1153 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Regression suite for the refinery's hosted-CI regression gate.
+#
+# Reproduction: on a live rig the refinery merged every bead whose LOCAL checks
+# passed, and nothing anywhere in its assets read the hosted verdict. The target
+# branch went success:9 (07-22) -> failure:3 (07-23) -> failure:11 (07-24), every
+# failure a cross-platform target a Linux worker cannot build.
+#
+# The counter-reproduction matters just as much, and it is the reason the gate
+# is scoped the way it is: on the same operator's rig the target branch then
+# STAYED red, every branch cut from it inherited those failures, and an absolute
+# "red head = reject" gate would have blocked every fix -- including the fixes
+# for the failures causing the red. That branch sat frozen for roughly 16 hours
+# and only moved when a human authorised a deliberate override.
+# test_a_red_base_does_not_freeze_the_repository is that case, and it must pass
+# for this gate to be shippable at all.
+#
+# The gate ships as an executable block inside mol-refinery-patrol, so this
+# suite extracts the SHIPPED block and the SHIPPED call chains and runs them
+# against a hermetic `gh`/`gc` and a real throwaway git repository, rather than
+# asserting on prose. Timing knobs are overridden in the driver so the bounded
+# waits resolve immediately; their shipped defaults are asserted separately.
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+GASTOWN="$ROOT/gastown"
+FORMULA="$GASTOWN/formulas/mol-refinery-patrol.toml"
+PROMPT="$GASTOWN/agents/refinery/prompt.template.md"
+
+WORK_ID="ki-hu3"
+BRANCH_NAME="fix/sp-int-truncation"
+ORIGIN_REPO_NAME="gastownhall/kisakcod"
+
+# The real failing checks from the incident, verbatim.
+RED_CHECK_ONE="Windows x86 / Release"
+RED_CHECK_TWO="Portable tests / macOS arm64"
+# The two jobs a bead ADDED to the board, which failed on their first run and
+# took the target from 9 failures to 11 while the bead's own acceptance criteria
+# claimed a hosted validation it never performed. They are on no earlier commit,
+# so they are the "absent on the base" row of the table.
+NEW_CHECK_ONE="Windows x86 SP / Debug"
+NEW_CHECK_TWO="Windows x86 SP / Release"
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+# Extracts a shipped fragment from the formula: the gate block itself, one of
+# the two call chains that drive it, or the direct-mode close command. Formula
+# vars are substituted with their SHIPPED defaults, so the suite exercises what
+# a poured wisp actually runs.
+extract_shipped() {
+    local what=$1 output=$2
+    python3 - "$FORMULA" "$what" "$output" <<'PY'
+import pathlib
+import sys
+import tomllib
+
+formula_path, what, output_path = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(formula_path, "rb") as handle:
+    data = tomllib.load(handle)
+steps = {step["id"]: step for step in data["steps"]}
+description = steps["merge-push"]["description"]
+
+
+def fenced(section_marker):
+    section = description[description.index(section_marker):]
+    return section.split("```bash", 1)[1].split("```", 1)[0]
+
+
+if what == "gate-block":
+    begin = description.index("# BEGIN REFINERY_CI_GATE")
+    end = description.index("# END REFINERY_CI_GATE", begin)
+    fragment = description[begin:end]
+elif what == "direct-chain":
+    fragment = fenced("**0b. Hosted-CI regression gate")
+elif what == "mr-chain":
+    fragment = fenced("**3b. Hosted-CI regression gate")
+elif what == "direct-close":
+    start = description.index('gc bd update "$WORK" --set-metadata merge_result=merged')
+    end = description.index("\n", description.index('gc bd close "$WORK"', start))
+    fragment = description[start:end]
+else:
+    sys.exit(f"unknown fragment {what}")
+
+for name, spec in data["vars"].items():
+    fragment = fragment.replace("{{%s}}" % name, spec.get("default", ""))
+fragment = fragment.replace("{{rig_name}}", "kisakcod")
+if "{{" in fragment:
+    sys.exit("shipped fragment still carries an unsubstituted formula var")
+pathlib.Path(output_path).write_text(fragment + "\n", encoding="utf-8")
+PY
+}
+
+# Hermetic GitHub. Serves per-request fixtures out of a directory; a missing
+# fixture models an API failure, which the gate must never read as a pass.
+# Boards are per-COMMIT because the gate reads two of them -- the head's and the
+# base's -- so a fixture named for a SHA wins over the generic one. Sequenced
+# fixtures (<name>.<sha>.1.json, <name>.<sha>.2.json) model checks that finish
+# between polls.
+write_gh_stub() {
+    cat >"$BIN/gh" <<'SH'
+#!/usr/bin/env bash
+printf 'GH %s\n' "$*" >>"$GC_TEST_CALLS"
+serve() {
+    name="$1"
+    if [ ! -f "$GH_FIXTURES/$name.json" ] && [ ! -f "$GH_FIXTURES/$name.1.json" ]; then
+        return 1
+    fi
+    count=$(( $(cat "$GH_FIXTURES/$name.count" 2>/dev/null || echo 0) + 1 ))
+    printf '%s' "$count" >"$GH_FIXTURES/$name.count"
+    if [ -f "$GH_FIXTURES/$name.$count.json" ]; then
+        cat "$GH_FIXTURES/$name.$count.json"
+        return 0
+    fi
+    if [ -f "$GH_FIXTURES/$name.json" ]; then
+        cat "$GH_FIXTURES/$name.json"
+        return 0
+    fi
+    return 1
+}
+serve_commit() {
+    kind="$1"
+    shift
+    all="$*"
+    rest="${all#*/commits/}"
+    sha="${rest%%/*}"
+    serve "$kind.$sha" && return 0
+    serve "$kind" && return 0
+    printf 'HTTP 502: upstream unavailable (%s for %s)\n' "$kind" "$sha" >&2
+    return 1
+}
+case "$*" in
+    */commits/*/check-runs*) serve_commit check-runs "$@" ;;
+    */commits/*/status*) serve_commit status "$@" ;;
+    */pulls/*) serve pull || { printf 'HTTP 502: upstream unavailable (pull)\n' >&2; exit 1; } ;;
+    *) printf 'unexpected gh call: %s\n' "$*" >&2; exit 97 ;;
+esac
+SH
+    chmod +x "$BIN/gh"
+}
+
+# Hermetic stand-in for the real CLI. It dispatches on argv positions and never
+# spells out a bare "<beads-cli> <subcommand>" string: tests/test_no_bare_bd_commands.py
+# rejects that spelling anywhere in tracked assets, fixtures included. Mutating
+# calls are logged under distinct markers so assertions never have to match on
+# that spelling either.
+write_gc_stub() {
+    cat >"$BIN/gc" <<'SH'
+#!/usr/bin/env bash
+case "$1" in
+    bd)
+        case "$2" in
+            update) printf 'UPDATE %s\n' "$*" >>"$GC_TEST_CALLS" ;;
+            close) printf 'CLOSE %s\n' "$*" >>"$GC_TEST_CALLS" ;;
+            list) printf 'LIST %s\n' "$*" >>"$GC_TEST_CALLS"; printf '[{"id": "wisp-current"}]\n' ;;
+            mol)
+                case "$3" in
+                    wisp) printf 'POUR %s\n' "$*" >>"$GC_TEST_CALLS"; printf '{"new_epic_id": "wisp-next"}\n' ;;
+                    burn) printf 'BURN %s\n' "$*" >>"$GC_TEST_CALLS" ;;
+                    *) printf 'unexpected: %s\n' "$*" >&2; exit 97 ;;
+                esac
+                ;;
+            *) printf 'unexpected: %s\n' "$*" >&2; exit 97 ;;
+        esac
+        ;;
+    workflow) printf 'WORKFLOW %s\n' "$*" >>"$GC_TEST_CALLS" ;;
+    runtime) printf 'RUNTIME %s\n' "$*" >>"$GC_TEST_CALLS" ;;
+    session|mail) printf 'NOTIFY %s\n' "$*" >>"$GC_TEST_CALLS" ;;
+    *) printf 'unexpected: %s\n' "$*" >&2; exit 97 ;;
+esac
+exit 0
+SH
+    chmod +x "$BIN/gc"
+}
+
+write_driver() {
+    cat >"$DRIVER" <<'SH'
+#!/usr/bin/env bash
+# Stands in for the refinery session: the same variables the earlier merge-push
+# script sets, then the shipped gate block, then the shipped call chain.
+cd "$GATE_TEST_REPO_DIR" || exit 90
+WORK="$GATE_TEST_WORK"
+BRANCH="$GATE_TEST_BRANCH"
+TARGET="$GATE_TEST_TARGET"
+ORIGIN_REPO="$GATE_TEST_ORIGIN_REPO"
+ORIGIN_REPO_ERROR=""
+PR_NUMBER="${GATE_TEST_PR_NUMBER:-}"
+GC_RIG="kisakcod"
+GC_AGENT="kisakcod/refinery"
+GC_BEAD_ID="wisp-current"
+. "$GATE_BLOCK"
+CI_POLL_SECONDS=0
+CI_TIMEOUT_SECONDS="$GATE_TEST_CI_TIMEOUT"
+CI_ZERO_CHECK_GRACE_SECONDS="$GATE_TEST_CI_GRACE"
+CI_GATE="$GATE_TEST_CI_GATE"
+CI_GATE_PUBLISH_HEAD="$GATE_TEST_PUBLISH_HEAD"
+. "$GATE_CHAIN"
+echo "CHAIN_COMPLETED"
+SH
+}
+
+# A real repository, because the direct chain really inspects refs and, when
+# opted in, really pushes, and because the gate resolves its base out of
+# refs/remotes/origin/$TARGET rather than out of a fixture. `origin` is a local
+# bare repo, so --force-with-lease behaves exactly as it does against GitHub.
+setup_case() {
+    TMP=$(mktemp -d)
+    BIN="$TMP/bin"
+    FIX="$TMP/fixtures"
+    CALLS="$TMP/calls"
+    BLOCK="$TMP/gate-block.sh"
+    DRIVER="$TMP/driver.sh"
+    REPO="$TMP/work"
+    ORIGIN="$TMP/origin.git"
+    mkdir -p "$BIN" "$FIX"
+    : >"$CALLS"
+    extract_shipped gate-block "$BLOCK"
+    bash -n "$BLOCK" || fail "the shipped gate block is not valid shell"
+    write_gh_stub
+    write_gc_stub
+    write_driver
+
+    git init --quiet --bare "$ORIGIN"
+    git init --quiet "$REPO"
+    git -C "$REPO" symbolic-ref HEAD refs/heads/main
+    git -C "$REPO" config user.email "refinery@test.invalid"
+    git -C "$REPO" config user.name "Refinery Test"
+    git -C "$REPO" remote add origin "$ORIGIN"
+    mkdir -p "$REPO/src"
+    printf 'int route_legacy(void) { return 0; }\n' >"$REPO/src/route.c"
+    git -C "$REPO" add -A
+    git -C "$REPO" commit --quiet -m "base"
+    git -C "$REPO" push --quiet origin main
+    git -C "$REPO" checkout --quiet -b temp
+    printf 'int route_legacy(void) { return 0; }\nint route_candidate(void) { return 1; }\n' >"$REPO/src/route.c"
+    git -C "$REPO" commit --quiet -am "candidate route"
+    git -C "$REPO" push --quiet origin "temp:$BRANCH_NAME"
+    git -C "$REPO" fetch --quiet origin
+    HEAD_SHA=$(git -C "$REPO" rev-parse temp)
+    PUBLISHED_SHA=$(git -C "$REPO" rev-parse "origin/$BRANCH_NAME")
+    BASE_SHA=$(git -C "$REPO" rev-parse "origin/main")
+}
+
+# The steady state of a busy merge queue: the target moved since the polecat
+# pushed, so the rebase rewrites the branch and the commit that would land is
+# one no forge has seen. `temp` and `origin/$BRANCH` now differ, and the base
+# the gate measures against is the MOVED target tip.
+setup_rebased_case() {
+    setup_case
+    git -C "$REPO" checkout --quiet main
+    printf 'unrelated target-side change\n' >"$REPO/src/other.c"
+    git -C "$REPO" add -A
+    git -C "$REPO" commit --quiet -m "target moved"
+    git -C "$REPO" push --quiet origin main
+    git -C "$REPO" fetch --quiet origin
+    git -C "$REPO" checkout --quiet temp
+    git -C "$REPO" rebase --quiet origin/main
+    HEAD_SHA=$(git -C "$REPO" rev-parse temp)
+    PUBLISHED_SHA=$(git -C "$REPO" rev-parse "origin/$BRANCH_NAME")
+    BASE_SHA=$(git -C "$REPO" rev-parse "origin/main")
+    [[ "$HEAD_SHA" != "$PUBLISHED_SHA" ]] ||
+        fail "the rebased fixture must produce a head the forge has never seen"
+}
+
+fixture() {
+    cat >"$FIX/$1"
+}
+
+# board_for <sha>: check-run JSON on stdin, plus an empty legacy status board so
+# a test only has to think about check-runs unless it is about statuses.
+board_for() {
+    cat >"$FIX/check-runs.$1.json"
+    cat >"$FIX/status.$1.json" <<'JSON'
+{"state": "success", "total_count": 0, "statuses": []}
+JSON
+}
+
+statuses_for() {
+    cat >"$FIX/status.$1.json"
+}
+
+empty_board() {
+    board_for "$1" <<'JSON'
+{"total_count": 0, "check_runs": []}
+JSON
+}
+
+green_board() {
+    board_for "$1" <<'JSON'
+{"total_count": 2, "check_runs": [
+  {"name": "Portable tests / Linux amd64", "status": "completed", "conclusion": "success"},
+  {"name": "Lint", "status": "completed", "conclusion": "skipped"}
+]}
+JSON
+}
+
+# The same names as green_board, plus the two that fail. A base carrying this
+# board and a head carrying red_board is the green -> red row.
+base_board_for_red_head() {
+    board_for "$1" <<JSON
+{"total_count": 3, "check_runs": [
+  {"name": "$RED_CHECK_ONE", "status": "completed", "conclusion": "success"},
+  {"name": "$RED_CHECK_TWO", "status": "completed", "conclusion": "success"},
+  {"name": "Portable tests / Linux amd64", "status": "completed", "conclusion": "success"}
+]}
+JSON
+}
+
+red_board() {
+    board_for "$1" <<JSON
+{"total_count": 3, "check_runs": [
+  {"name": "$RED_CHECK_ONE", "status": "completed", "conclusion": "failure"},
+  {"name": "$RED_CHECK_TWO", "status": "completed", "conclusion": "timed_out"},
+  {"name": "Portable tests / Linux amd64", "status": "completed", "conclusion": "success"}
+]}
+JSON
+}
+
+# The eleven checks that were failing on the operator's target branch on 07-24,
+# after it had been red for a day. Used as BOTH boards in the deadlock case.
+incident_red_board() {
+    jq -n '["Windows x86 / Release", "Windows x86 / Debug",
+            "Portable tests / Linux amd64", "Portable tests / Linux arm64",
+            "Portable tests / macOS amd64", "Portable tests / macOS arm64",
+            "Portable tests / Windows amd64", "Portable tests / Windows arm64",
+            "Windows x86 SP / Release", "Windows x86 SP / Debug",
+            "Sanitizers / asan"]
+           | {total_count: length,
+              check_runs: map({name: ., status: "completed", conclusion: "failure"})}' \
+        | board_for "$1"
+}
+
+run_chain() {
+    local chain=$1
+    CODE=0
+    set +e
+    OUTPUT=$(
+        PATH="$BIN:$PATH" \
+        GC_TEST_CALLS="$CALLS" \
+        GH_FIXTURES="$FIX" \
+        GATE_TEST_REPO_DIR="$REPO" \
+        GATE_TEST_WORK="$WORK_ID" \
+        GATE_TEST_BRANCH="$BRANCH_NAME" \
+        GATE_TEST_TARGET="main" \
+        GATE_TEST_ORIGIN_REPO="$ORIGIN_REPO_NAME" \
+        GATE_TEST_PR_NUMBER="${PR_NUMBER_OVERRIDE:-}" \
+        GATE_TEST_CI_TIMEOUT="${CI_TIMEOUT_OVERRIDE:-0}" \
+        GATE_TEST_CI_GRACE="${CI_GRACE_OVERRIDE:-0}" \
+        GATE_TEST_CI_GATE="${CI_GATE_OVERRIDE:-true}" \
+        GATE_TEST_PUBLISH_HEAD="${PUBLISH_HEAD_OVERRIDE:-false}" \
+        GATE_BLOCK="$BLOCK" \
+        GATE_CHAIN="$chain" \
+        bash "$DRIVER" 2>&1
+    )
+    CODE=$?
+    set -e
+}
+
+run_direct_chain() {
+    local chain="$TMP/direct-chain.sh"
+    extract_shipped direct-chain "$chain"
+    bash -n "$chain" || fail "the shipped direct-mode chain is not valid shell"
+    run_chain "$chain"
+}
+
+run_mr_chain() {
+    local chain="$TMP/mr-chain.sh"
+    extract_shipped mr-chain "$chain"
+    bash -n "$chain" || fail "the shipped mr-mode chain is not valid shell"
+    run_chain "$chain"
+}
+
+assert_not_closed() {
+    ! grep -q '^CLOSE ' "$CALLS" ||
+        fail "$1: the bead was closed anyway: $(grep '^CLOSE ' "$CALLS")"
+}
+
+# A rejection is the recoverable disposition: the bead goes back to the pool
+# with a reason a polecat can act on, the branch survives for fix-forward, and
+# the patrol loop keeps turning. Anything less strands the queue.
+assert_rejected() {
+    local needle=$1
+    [[ "$CODE" -eq 1 ]] || fail "the CI gate must reject with exit 1 (got $CODE): $OUTPUT"
+    [[ "$OUTPUT" == *"CI_GATE_REJECTED $WORK_ID"* ]] ||
+        fail "a rejection must announce CI_GATE_REJECTED: $OUTPUT"
+    grep -F -- '--status=open' "$CALLS" >/dev/null ||
+        fail "a rejection must put the bead back in the pool"
+    grep -F -- '--assignee=' "$CALLS" >/dev/null ||
+        fail "a rejection must release the refinery claim"
+    grep -F -- '--set-metadata rejection_reason=CI gate:' "$CALLS" >/dev/null ||
+        fail "a rejection must write a rejection_reason naming the gate: $(cat "$CALLS")"
+    grep -F -- "$needle" "$CALLS" >/dev/null ||
+        fail "the rejection_reason must be specific enough to act on (want '$needle'): $(cat "$CALLS")"
+    grep -F -- "--set-metadata ci_gate_base_sha=$BASE_SHA" "$CALLS" >/dev/null ||
+        fail "a rejection must record the base SHA it measured against; a reviewer must never have to guess what 'worse' was worse than: $(cat "$CALLS")"
+    grep -F -- 'gc.routed_to' "$CALLS" >/dev/null ||
+        fail "a rejection must route the bead back to the polecat pool"
+    grep -q '^POUR ' "$CALLS" ||
+        fail "a rejection must pour the next patrol wisp; a stalled loop is worse than a red merge"
+    grep -q '^BURN ' "$CALLS" ||
+        fail "a rejection must burn the current wisp after pouring the next"
+    assert_not_closed "a rejection"
+    [[ "$OUTPUT" == *"left intact for fix-forward"* ]] ||
+        fail "a CI rejection must leave the branch intact for fix-forward: $OUTPUT"
+}
+
+assert_undetermined() {
+    local label=$1 needle=$2
+    [[ "$CODE" -ne 0 ]] || fail "$label must not pass: $OUTPUT"
+    [[ "$OUTPUT" == *"CI_GATE_UNDETERMINED"* ]] ||
+        fail "$label must report CI_GATE_UNDETERMINED: $OUTPUT"
+    [[ "$OUTPUT" == *"$needle"* ]] ||
+        fail "$label must say why it could not be determined (want '$needle'): $OUTPUT"
+    ! grep -F -- '--status=open' "$CALLS" >/dev/null ||
+        fail "$label is our fault, not the branch's: it must not reject the bead"
+    assert_not_closed "$label"
+}
+
+# The other half of the contract, and the one an absolute gate gets wrong: work
+# that did not degrade anything has to get through.
+assert_allowed() {
+    local label=$1
+    [[ "$CODE" -eq 0 ]] || fail "$label must be allowed through (exit $CODE): $OUTPUT"
+    [[ "$OUTPUT" != *"CI_GATE_REJECTED"* ]] || fail "$label must not be rejected: $OUTPUT"
+    [[ "$OUTPUT" != *"CI_GATE_UNDETERMINED"* ]] ||
+        fail "$label must reach a verdict, not stall: $OUTPUT"
+    ! grep -F -- '--status=open' "$CALLS" >/dev/null ||
+        fail "$label must not put the bead back in the pool: $(cat "$CALLS")"
+}
+
+assert_branch_not_republished() {
+    [[ "$(git -C "$REPO" rev-parse "refs/remotes/origin/$BRANCH_NAME")" == "$PUBLISHED_SHA" ]] ||
+        fail "$1: the gate moved the remote branch"
+    git -C "$REPO" fetch --quiet origin
+    [[ "$(git -C "$REPO" rev-parse "refs/remotes/origin/$BRANCH_NAME")" == "$PUBLISHED_SHA" ]] ||
+        fail "$1: the gate published the branch to origin"
+}
+
+# ---------------------------------------------------------------------------
+
+# The shipped defaults decide what a city gets without configuration, so they
+# are part of the contract.
+test_shipped_defaults_are_fail_closed() {
+    python3 - "$FORMULA" "$PROMPT" <<'PY'
+import sys
+import tomllib
+
+with open(sys.argv[1], "rb") as handle:
+    data = tomllib.load(handle)
+variables = data["vars"]
+if variables["ci_gate"]["default"] != "true":
+    raise SystemExit("ci_gate must default to on; a gate off by default is not a gate")
+for name in ("ci_timeout_seconds", "ci_zero_check_grace_seconds", "ci_poll_seconds"):
+    if int(variables[name]["default"]) < 0:
+        raise SystemExit(f"{name} must not be negative")
+for name in ("ci_timeout_seconds", "ci_zero_check_grace_seconds"):
+    if int(variables[name]["default"]) <= 0:
+        raise SystemExit(f"{name} must leave a real window; 0 would rule on every honest branch too early")
+if variables["ci_gate_publish_head"]["default"] != "false":
+    raise SystemExit(
+        "ci_gate_publish_head must default to off: publishing the source branch is a change "
+        "to what a direct-mode rig pushes, and an upgrade must not start pushing refs on its own"
+    )
+
+steps = {step["id"]: step for step in data["steps"]}
+if steps["merge-push"]["needs"] != ["handle-failures"]:
+    raise SystemExit("the CI gate must not reshape the step graph; merge-push still follows handle-failures")
+if any(step["id"] == "review-diff" for step in data["steps"]):
+    raise SystemExit("this change ships the CI gate only; there is no diff-review step")
+
+prompt = open(sys.argv[2], encoding="utf-8").read()
+for needle in ("Hosted-CI Regression Gate", "ci_gate=false", "fix-forward",
+               "REGRESSION", "inherited", "ci_gate_inherited"):
+    if needle not in prompt:
+        raise SystemExit(f"refinery prompt must document {needle}")
+if 'FORBIDDEN: Reading polecat code to "understand what they were trying to do."' not in prompt:
+    raise SystemExit("the CARDINAL RULE is upstream's decision and this change does not touch it")
+PY
+}
+
+# The gate has to rule before the merge script touches the target, in both
+# modes, and before the close in either -- and it has to read TWO boards.
+test_the_gate_rules_before_anything_lands() {
+    python3 - "$FORMULA" <<'PY'
+import sys
+import tomllib
+
+with open(sys.argv[1], "rb") as handle:
+    data = tomllib.load(handle)
+description = {step["id"]: step for step in data["steps"]}["merge-push"]["description"]
+direct = description[description.index('**If MERGE_STRATEGY = "direct"'):description.index('**If MERGE_STRATEGY = "mr"')]
+if "ci_gate_run" not in direct:
+    raise SystemExit("direct mode must run the CI gate")
+if direct.index("ci_gate_run") > direct.index("git worktree add --detach"):
+    raise SystemExit("the CI gate must rule before direct mode touches the target branch")
+
+mr = description[description.index('**If MERGE_STRATEGY = "mr"'):]
+if mr.index("ci_gate_run") > mr.index("--set-metadata merge_result=pull_request"):
+    raise SystemExit("mr mode must run the CI gate before it closes the bead")
+
+gate = description[description.index("# BEGIN REFINERY_CI_GATE"):description.index("# END REFINERY_CI_GATE")]
+# Without a base board there is nothing to compare against, and the gate
+# silently becomes the absolute gate that freezes any repo with a red target.
+if "ci_gate_resolve_base" not in gate or 'ci_gate_board "$CI_GATE_BASE_SHA" base' not in gate:
+    raise SystemExit(
+        "the gate must resolve and read a BASE board; without one every red check on the head "
+        "looks like a regression and a repository with a red target can never land its own fix"
+    )
+if "ci_gate_base_sha" not in gate:
+    raise SystemExit("the gate must stamp the base SHA it measured against")
+
+# Publishing a branch is the behaviour change this pack refuses to make by
+# default, so the only push in direct mode must sit behind the opt-in.
+if direct.count('git push origin "HEAD:$BRANCH"') != 1:
+    raise SystemExit("direct mode must have exactly one branch-publishing push, inside the opt-in")
+if '"$CI_GATE_PUBLISH_HEAD" = "true"' not in direct:
+    raise SystemExit(
+        "direct mode publishes the source branch without the ci_gate_publish_head opt-in guard; "
+        "an upgrade must not start pushing refs a rig never pushed"
+    )
+publish = direct.index('git push origin "HEAD:$BRANCH"')
+opt_in = direct.index('"$CI_GATE_PUBLISH_HEAD" = "true"')
+if not opt_in < publish < direct.index("ci_gate_run"):
+    raise SystemExit("direct mode may only publish the branch inside the ci_gate_publish_head opt-in")
+PY
+}
+
+# The incident itself, correctly scoped: checks that PASS on the target and fail
+# on the branch. This branch broke them, so this branch answers for them.
+test_green_to_red_is_a_regression_and_rejects() {
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+    base_board_for_red_head "$BASE_SHA"
+    red_board "$HEAD_SHA"
+
+    run_direct_chain
+    assert_rejected "$RED_CHECK_ONE"
+    grep -F -- "$RED_CHECK_TWO" "$CALLS" >/dev/null ||
+        fail "a timed_out check is red too and must be named"
+    grep -F -- "on the base: green" "$CALLS" >/dev/null ||
+        fail "a regression must say what the check was doing on the base, or nobody can tell a regression from an inherited failure: $(cat "$CALLS")"
+    grep -F -- "Portable tests / Linux amd64" "$CALLS" >/dev/null &&
+        fail "a check that is green on the head must never appear in the rejection reason: $(cat "$CALLS")"
+    [[ "$OUTPUT" != *"CI_GATE_GREEN"* ]] || fail "a degraded board must never be reported green: $OUTPUT"
+}
+
+# The row an absolute gate gets wrong. The branch did not touch these checks;
+# they were already failing on the target it lands on.
+test_red_to_red_is_inherited_and_allows() {
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+    red_board "$BASE_SHA"
+    red_board "$HEAD_SHA"
+
+    run_direct_chain
+    assert_allowed "a head that is red in exactly the ways its base is already red"
+    [[ "$OUTPUT" == *"CI_GATE_PREEXISTING_RED"* ]] ||
+        fail "an inherited failure must be reported loudly, not swallowed: $OUTPUT"
+    [[ "$OUTPUT" == *"$RED_CHECK_ONE"* ]] ||
+        fail "the report must name the inherited failures: $OUTPUT"
+    grep -F -- '--set-metadata ci_gate_inherited=' "$CALLS" >/dev/null ||
+        fail "the bead must record which failures were let through as inherited: $(cat "$CALLS")"
+    grep -F -- "ci_gate_inherited=" "$CALLS" | grep -F -- "$RED_CHECK_ONE" >/dev/null ||
+        fail "ci_gate_inherited must name the inherited failures: $(cat "$CALLS")"
+    grep -F -- "ci_gate_inherited=" "$CALLS" | grep -F -- "$RED_CHECK_TWO" >/dev/null ||
+        fail "ci_gate_inherited must name every inherited failure, not just the first: $(cat "$CALLS")"
+    grep -F -- "--set-metadata ci_gate_base_sha=$BASE_SHA" "$CALLS" >/dev/null ||
+        fail "the bead must record the base those failures were inherited from"
+    [[ "$OUTPUT" == *"NOT because hosted CI is well"* ]] ||
+        fail "allowing an inherited failure must not read as an all-clear: $OUTPUT"
+
+    # ... but only failures PROVEN inherited are excused. A base check that has
+    # not finished has not proven anything, and excusing on "it might fail too"
+    # is the direction that lets a real regression through.
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+    board_for "$BASE_SHA" <<JSON
+{"total_count": 1, "check_runs": [
+  {"name": "$RED_CHECK_ONE", "status": "in_progress", "conclusion": null}
+]}
+JSON
+    board_for "$HEAD_SHA" <<JSON
+{"total_count": 1, "check_runs": [
+  {"name": "$RED_CHECK_ONE", "status": "completed", "conclusion": "failure"}
+]}
+JSON
+    run_direct_chain
+    assert_rejected "$RED_CHECK_ONE"
+    grep -F -- "on the base: still running" "$CALLS" >/dev/null ||
+        fail "an unfinished base check must be named as unproven, not reported as inherited: $(cat "$CALLS")"
+}
+
+# THE case this rework exists for. On the operator's rig the target branch went
+# red on 07-23 and stayed red; every branch cut from it inherited all eleven
+# failures. Under an absolute gate no fix could land -- including the fixes for
+# the failures causing the red -- and the branch sat frozen for ~16 hours until
+# a human authorised an override. Same failures on both sides must ALLOW, or
+# this gate is a freeze with better manners.
+test_a_red_base_does_not_freeze_the_repository() {
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+    incident_red_board "$BASE_SHA"
+    incident_red_board "$HEAD_SHA"
+
+    run_direct_chain
+    assert_allowed "a branch inheriting all eleven of its base's failures"
+    [[ "$OUTPUT" == *"CI_GATE_PREEXISTING_RED"* ]] ||
+        fail "eleven inherited failures must still be reported: $OUTPUT"
+    [[ "$OUTPUT" == *"11 of them are already red on the base"* ]] ||
+        fail "the report must account for every inherited failure: $OUTPUT"
+    grep -F -- "--set-metadata ci_gate_sha=$HEAD_SHA" "$CALLS" >/dev/null ||
+        fail "a bead allowed through onto a red base must still record what was gated"
+    for check in "Windows x86 / Release" "Sanitizers / asan" "Portable tests / Windows arm64"; do
+        grep -F -- "$check" "$CALLS" >/dev/null ||
+            fail "ci_gate_inherited must name every failure let through, missing '$check': $(cat "$CALLS")"
+    done
+}
+
+# A branch that ADDS a failing job has made things worse even though nothing
+# that was passing broke. Observed: a bead added two Windows SP jobs that failed
+# on their first run, taking the target from 9 failures to 11.
+test_absent_on_base_and_red_on_head_is_a_regression() {
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+    # The base is ALREADY RED -- so this also proves the absent -> red rule is
+    # not just the absolute gate reappearing on a green base.
+    board_for "$BASE_SHA" <<JSON
+{"total_count": 2, "check_runs": [
+  {"name": "$RED_CHECK_ONE", "status": "completed", "conclusion": "failure"},
+  {"name": "Portable tests / Linux amd64", "status": "completed", "conclusion": "success"}
+]}
+JSON
+    board_for "$HEAD_SHA" <<JSON
+{"total_count": 4, "check_runs": [
+  {"name": "$RED_CHECK_ONE", "status": "completed", "conclusion": "failure"},
+  {"name": "Portable tests / Linux amd64", "status": "completed", "conclusion": "success"},
+  {"name": "$NEW_CHECK_ONE", "status": "completed", "conclusion": "failure"},
+  {"name": "$NEW_CHECK_TWO", "status": "completed", "conclusion": "failure"}
+]}
+JSON
+
+    run_direct_chain
+    assert_rejected "$NEW_CHECK_ONE"
+    grep -F -- "$NEW_CHECK_TWO" "$CALLS" >/dev/null ||
+        fail "both added failing jobs must be named"
+    grep -F -- "on the base: no such check" "$CALLS" >/dev/null ||
+        fail "the rejection must say the job did not exist on the base: $(cat "$CALLS")"
+    grep -F -- "2 of 4 checks are red" "$CALLS" >/dev/null ||
+        fail "the pre-existing failure must not be counted as a regression: $(cat "$CALLS")"
+}
+
+# The happy path, end to end: the gate finds no degradation, stamps its
+# forensics, and the shipped terminal update closes the bead with the merged SHA.
+test_green_to_green_passes_and_the_bead_closes() {
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+    green_board "$BASE_SHA"
+    green_board "$HEAD_SHA"
+
+    run_direct_chain
+    assert_allowed "a green head on a green base"
+    [[ "$OUTPUT" == *"CHAIN_COMPLETED"* ]] || fail "the gate chain did not complete: $OUTPUT"
+    [[ "$OUTPUT" == *"CI_GATE_EXACT"* ]] ||
+        fail "an un-rebased branch is landed at its published tip and the gate must say so: $OUTPUT"
+    [[ "$OUTPUT" == *"CI_GATE_BASE: measuring $HEAD_SHA against main at $BASE_SHA"* ]] ||
+        fail "the gate must announce which base it measured against: $OUTPUT"
+    grep -F -- "--set-metadata ci_gate_sha=$HEAD_SHA" "$CALLS" >/dev/null ||
+        fail "the gate must stamp the SHA it proved onto the bead"
+    grep -F -- "--set-metadata ci_gate_base_sha=$BASE_SHA" "$CALLS" >/dev/null ||
+        fail "the gate must stamp the base SHA it compared against"
+    grep -F -- '--set-metadata ci_gate_inherited=none' "$CALLS" >/dev/null ||
+        fail "a clean pass must record that nothing was let through as inherited: $(cat "$CALLS")"
+    grep -F -- '--set-metadata ci_gate_result=2 checks green' "$CALLS" >/dev/null ||
+        fail "the gate must stamp what it proved, not just that it passed: $(cat "$CALLS")"
+    ! grep -q '^CLOSE ' "$CALLS" || fail "the gate itself must never close the bead"
+
+    # The shipped terminal update + close, run with the same fake CLI.
+    local close="$TMP/close.sh"
+    extract_shipped direct-close "$close"
+    : >"$CALLS"
+    (
+        PATH="$BIN:$PATH" GC_TEST_CALLS="$CALLS" \
+        WORK="$WORK_ID" MERGED_SHA="$HEAD_SHA" MERGED_SHORT="${HEAD_SHA:0:7}" TARGET=main \
+        bash "$close"
+    ) || fail "the shipped close chain did not run"
+    grep -q '^CLOSE ' "$CALLS" || fail "the happy path must close the bead"
+    grep -F -- '--unset-metadata rejection_reason' "$CALLS" >/dev/null ||
+        fail "the successful close must clear rejection_reason"
+    grep -F -- "--set-metadata merged_sha=$HEAD_SHA" "$CALLS" >/dev/null ||
+        fail "the close must record the merged SHA, which is the SHA the gate proved"
+}
+
+# A repository with no hosted CI at all has nothing for a branch to degrade.
+# Rejecting here would make the gate unusable for every repo without a forge
+# CI, which is the same class of mistake as freezing a repo with a red base.
+test_zero_checks_on_both_sides_allows() {
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+    empty_board "$BASE_SHA"
+    empty_board "$HEAD_SHA"
+
+    run_direct_chain
+    assert_allowed "a repository that publishes no checks on either side"
+    [[ "$OUTPUT" == *"CI_GATE_NO_HOSTED_CI"* ]] ||
+        fail "a repo with no hosted CI must be told so explicitly, not silently passed: $OUTPUT"
+    grep -F -- 'publishes no CI on this path' "$CALLS" >/dev/null ||
+        fail "the bead must record that it closed without any hosted verdict: $(cat "$CALLS")"
+
+    # The grace window still applies: checks that register a moment after the
+    # push must not be missed just because the first poll was empty.
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+    green_board "$BASE_SHA"
+    fixture "check-runs.$HEAD_SHA.1.json" <<'JSON'
+{"total_count": 0, "check_runs": []}
+JSON
+    fixture "check-runs.$HEAD_SHA.2.json" <<'JSON'
+{"total_count": 2, "check_runs": [
+  {"name": "Portable tests / Linux amd64", "status": "completed", "conclusion": "success"},
+  {"name": "Lint", "status": "completed", "conclusion": "skipped"}
+]}
+JSON
+    fixture "status.$HEAD_SHA.json" <<'JSON'
+{"state": "success", "total_count": 0, "statuses": []}
+JSON
+    CI_GRACE_OVERRIDE=120 CI_TIMEOUT_OVERRIDE=120 run_direct_chain
+    assert_allowed "a head whose checks register on the second poll"
+    [[ "$OUTPUT" == *"CI_GATE_GREEN"* ]] ||
+        fail "a board that appears inside the grace window must be read, not treated as absent: $OUTPUT"
+}
+
+# The base publishes checks and this head publishes none. CI ran for the target
+# and did not run here, so coverage the target already has was lost on this
+# branch: a removed or renamed workflow, or a ref no workflow triggers for.
+test_head_with_no_checks_rejects_when_the_base_has_them() {
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+    green_board "$BASE_SHA"
+    empty_board "$HEAD_SHA"
+
+    run_direct_chain
+    assert_rejected "publishes none"
+    grep -F -- "publishes 2 checks" "$CALLS" >/dev/null ||
+        fail "the rejection must say how much coverage the base has that this head lost: $(cat "$CALLS")"
+    [[ "$OUTPUT" != *"CI_GATE_NO_HOSTED_CI"* ]] ||
+        fail "a head with no checks and a base with checks is not a repo without CI: $OUTPUT"
+}
+
+# A repository whose CI only runs `on: pull_request` never publishes checks for
+# its target tip, so "absent on the base" there means "there is no baseline",
+# not "this branch added a failing job". Charging the head's failures to the
+# branch on that evidence would freeze exactly the repositories this gate was
+# rescoped to unfreeze, so they are reported as unattributable and allowed.
+test_a_base_with_no_board_cannot_attribute_a_red_head() {
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+    empty_board "$BASE_SHA"
+    red_board "$HEAD_SHA"
+
+    run_direct_chain
+    assert_allowed "a red head measured against a base that publishes no board"
+    [[ "$OUTPUT" == *"CI_GATE_UNATTRIBUTABLE"* ]] ||
+        fail "a head that cannot be compared must say so, not pass quietly: $OUTPUT"
+    [[ "$OUTPUT" == *"no baseline"* ]] ||
+        fail "the report must say WHY the failures could not be charged to this branch: $OUTPUT"
+    [[ "$OUTPUT" == *"$RED_CHECK_ONE"* ]] ||
+        fail "the unattributable failures must still be named: $OUTPUT"
+    grep -F -- "ci_gate_inherited=" "$CALLS" | grep -F -- "$RED_CHECK_ONE" >/dev/null ||
+        fail "unattributable failures must be recorded on the bead like inherited ones: $(cat "$CALLS")"
+    [[ "$OUTPUT" != *"CI_GATE_GREEN"* ]] ||
+        fail "a red head must never be reported green, even when it cannot be attributed: $OUTPUT"
+}
+
+# Pending is a wait, and then it is OUR problem, not the branch's. An unfinished
+# check is not evidence of a regression, so blaming the branch for a slow CI
+# queue would be the absolute gate leaking back in through the timeout.
+test_pending_waits_then_goes_undetermined() {
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+    green_board "$BASE_SHA"
+    board_for "$HEAD_SHA" <<'JSON'
+{"total_count": 2, "check_runs": [
+  {"name": "Windows x86 / Debug", "status": "in_progress", "conclusion": null},
+  {"name": "Portable tests / Linux amd64", "status": "completed", "conclusion": "success"}
+]}
+JSON
+
+    run_direct_chain
+    assert_undetermined "a head board that never finished" "still running"
+    [[ "$OUTPUT" == *"Windows x86 / Debug"* ]] ||
+        fail "the unfinished checks must be named so the wait can be resumed: $OUTPUT"
+    [[ "$OUTPUT" != *"CI_GATE_GREEN"* ]] ||
+        fail "an unfinished check board must never be reported green: $OUTPUT"
+
+    # The same board, given a window: it finishes green between polls and the
+    # gate proceeds. Pending is a wait, not a verdict.
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+    green_board "$BASE_SHA"
+    fixture "check-runs.$HEAD_SHA.1.json" <<'JSON'
+{"total_count": 2, "check_runs": [
+  {"name": "Windows x86 / Debug", "status": "queued", "conclusion": null},
+  {"name": "Portable tests / Linux amd64", "status": "completed", "conclusion": "success"}
+]}
+JSON
+    fixture "check-runs.$HEAD_SHA.2.json" <<'JSON'
+{"total_count": 2, "check_runs": [
+  {"name": "Windows x86 / Debug", "status": "completed", "conclusion": "success"},
+  {"name": "Portable tests / Linux amd64", "status": "completed", "conclusion": "success"}
+]}
+JSON
+    fixture "status.$HEAD_SHA.json" <<'JSON'
+{"state": "success", "total_count": 0, "statuses": []}
+JSON
+
+    CI_TIMEOUT_OVERRIDE=120 run_direct_chain
+    assert_allowed "checks that finish green inside the window"
+    [[ "$OUTPUT" == *"CI_GATE_GREEN"* ]] || fail "a green board must be reported green: $OUTPUT"
+
+    # A proven regression does not wait for the rest of the board. The verdict
+    # cannot improve, and the polecat can start on the named check now.
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+    base_board_for_red_head "$BASE_SHA"
+    board_for "$HEAD_SHA" <<JSON
+{"total_count": 2, "check_runs": [
+  {"name": "$RED_CHECK_ONE", "status": "completed", "conclusion": "failure"},
+  {"name": "Portable tests / Linux amd64", "status": "in_progress", "conclusion": null}
+]}
+JSON
+    CI_TIMEOUT_OVERRIDE=3600 run_direct_chain
+    assert_rejected "$RED_CHECK_ONE"
+}
+
+# An unrecognized conclusion is not on the accept list, so it is not a pass --
+# and against a base where that check passes, it is a regression.
+test_unknown_conclusions_are_red_and_regress() {
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+    board_for "$BASE_SHA" <<'JSON'
+{"total_count": 1, "check_runs": [
+  {"name": "Windows x86 (no Steam)", "status": "completed", "conclusion": "success"}
+]}
+JSON
+    board_for "$HEAD_SHA" <<'JSON'
+{"total_count": 1, "check_runs": [
+  {"name": "Windows x86 (no Steam)", "status": "completed", "conclusion": "stale"}
+]}
+JSON
+
+    run_direct_chain
+    assert_rejected "Windows x86 (no Steam)"
+    grep -F -- "stale" "$CALLS" >/dev/null ||
+        fail "the unrecognized conclusion must be quoted so an operator can classify it: $(cat "$CALLS")"
+
+    # The same unknown conclusion on BOTH sides is inherited, not a regression.
+    # Default-deny decides what is RED; it does not decide who is to blame.
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+    board_for "$BASE_SHA" <<'JSON'
+{"total_count": 1, "check_runs": [
+  {"name": "Windows x86 (no Steam)", "status": "completed", "conclusion": "stale"}
+]}
+JSON
+    board_for "$HEAD_SHA" <<'JSON'
+{"total_count": 1, "check_runs": [
+  {"name": "Windows x86 (no Steam)", "status": "completed", "conclusion": "stale"}
+]}
+JSON
+    run_direct_chain
+    assert_allowed "an unknown conclusion that is equally unknown on the base"
+}
+
+# A repo can publish check-runs, legacy commit statuses, or both. Reading only
+# one API is a way to mistake silence for success -- and both sides of the
+# comparison have to read both.
+test_legacy_commit_statuses_are_compared_too() {
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+    green_board "$BASE_SHA"
+    statuses_for "$BASE_SHA" <<'JSON'
+{"state": "success", "total_count": 1, "statuses": [
+  {"context": "buildbot/windows-msvc", "state": "success"}
+]}
+JSON
+    green_board "$HEAD_SHA"
+    statuses_for "$HEAD_SHA" <<'JSON'
+{"state": "failure", "total_count": 1, "statuses": [
+  {"context": "buildbot/windows-msvc", "state": "failure"}
+]}
+JSON
+
+    run_direct_chain
+    assert_rejected "buildbot/windows-msvc"
+
+    # And a legacy status already failing on the base is inherited, exactly as
+    # a check-run would be.
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+    green_board "$BASE_SHA"
+    statuses_for "$BASE_SHA" <<'JSON'
+{"state": "failure", "total_count": 1, "statuses": [
+  {"context": "buildbot/windows-msvc", "state": "failure"}
+]}
+JSON
+    green_board "$HEAD_SHA"
+    statuses_for "$HEAD_SHA" <<'JSON'
+{"state": "failure", "total_count": 1, "statuses": [
+  {"context": "buildbot/windows-msvc", "state": "failure"}
+]}
+JSON
+    run_direct_chain
+    assert_allowed "a legacy status that is already failing on the base"
+    grep -F -- '--set-metadata ci_gate_inherited=buildbot/windows-msvc' "$CALLS" >/dev/null ||
+        fail "an inherited legacy status must be recorded like any other: $(cat "$CALLS")"
+}
+
+# Without a base there is no comparison, and no comparison is UNDETERMINED. It
+# is emphatically not a pass: falling open here would be a gate that quietly
+# stops gating the moment a fetch is stale.
+test_base_lookup_failure_is_undetermined_not_a_pass() {
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+    green_board "$HEAD_SHA"
+    git -C "$REPO" update-ref -d "refs/remotes/origin/main"
+
+    run_direct_chain
+    assert_undetermined "an unresolvable base ref" "refs/remotes/origin/main"
+    [[ "$OUTPUT" != *"CI_GATE_GREEN"* ]] ||
+        fail "a green head with no base to compare against is not a proven non-regression: $OUTPUT"
+
+    # The base ref resolves but its board cannot be read: same disposition.
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+    green_board "$HEAD_SHA"
+    run_direct_chain
+    assert_undetermined "an unreadable base board" "for the base commit $BASE_SHA"
+
+    # More checks on the base than one page reports: the board is not fully
+    # visible, so "absent on the base" cannot be trusted and nothing is ruled.
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+    green_board "$HEAD_SHA"
+    board_for "$BASE_SHA" <<'JSON'
+{"total_count": 140, "check_runs": [
+  {"name": "Portable tests / Linux amd64", "status": "completed", "conclusion": "success"}
+]}
+JSON
+    run_direct_chain
+    assert_undetermined "a truncated base board" "one page can report"
+}
+
+# The upgrade contract. An existing direct-mode rig does not opt in, so this
+# change must not make it push anything it did not push before -- not even to
+# let CI rule on the exact object.
+test_direct_mode_publishes_nothing_by_default() {
+    setup_rebased_case
+    trap 'rm -rf "$TMP"' RETURN
+    green_board "$BASE_SHA"
+    green_board "$PUBLISHED_SHA"
+    green_board "$HEAD_SHA"
+
+    run_direct_chain
+    assert_allowed "a rebased branch with a green published tip"
+    assert_branch_not_republished "the default direct-mode path"
+    ! grep -q 'CI_GATE_EXACT' <<<"$OUTPUT" ||
+        fail "a rebased head is not the published tip and must not be claimed as exact: $OUTPUT"
+    [[ "$OUTPUT" == *"CI_GATE_REBASED_HEAD"* ]] ||
+        fail "gating the published tip instead of the landing SHA must be stated, not implied: $OUTPUT"
+    grep -F -- "--set-metadata ci_gate_sha=$PUBLISHED_SHA" "$CALLS" >/dev/null ||
+        fail "the stamp must name the SHA actually proven, not the one being landed"
+    grep -F -- "--set-metadata ci_gate_base_sha=$BASE_SHA" "$CALLS" >/dev/null ||
+        fail "the base must be the MOVED target tip the work is about to land on"
+    grep -F -- "landing $HEAD_SHA" "$CALLS" >/dev/null ||
+        fail "the bead must record that the landed SHA differs from the proven one: $(cat "$CALLS")"
+
+    # A regression on the published tip still rejects, without publishing.
+    setup_rebased_case
+    trap 'rm -rf "$TMP"' RETURN
+    base_board_for_red_head "$BASE_SHA"
+    red_board "$PUBLISHED_SHA"
+    red_board "$HEAD_SHA"
+    run_direct_chain
+    assert_rejected "$RED_CHECK_ONE"
+    assert_branch_not_republished "a default-path rejection"
+}
+
+# The opt-in exists for rigs that want the exact-object guarantee, and it is
+# the only thing that makes direct mode push the source branch.
+test_the_publish_opt_in_gates_the_exact_landing_sha() {
+    setup_rebased_case
+    trap 'rm -rf "$TMP"' RETURN
+    green_board "$BASE_SHA"
+    green_board "$PUBLISHED_SHA"
+    green_board "$HEAD_SHA"
+
+    PUBLISH_HEAD_OVERRIDE=true run_direct_chain
+    assert_allowed "the publish opt-in on a green board"
+    git -C "$REPO" fetch --quiet origin
+    [[ "$(git -C "$REPO" rev-parse "refs/remotes/origin/$BRANCH_NAME")" == "$HEAD_SHA" ]] ||
+        fail "ci_gate_publish_head=true must publish the rebased head so CI can rule on it"
+    grep -F -- "--set-metadata ci_gate_sha=$HEAD_SHA" "$CALLS" >/dev/null ||
+        fail "the opt-in path must gate and stamp the exact SHA being landed"
+    if grep -F -- "landing " "$CALLS" >/dev/null; then
+        fail "the opt-in path proved the landing SHA itself; there is no divergence to record"
+    fi
+}
+
+# Every way the gate can fail to reach an answer must stop, not proceed. An
+# outage is not a verdict, and it must never reject the branch either.
+test_api_failures_are_undetermined_never_green() {
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+    green_board "$BASE_SHA"
+
+    # No head check-run fixture: the request fails.
+    run_direct_chain
+    assert_undetermined "an unreadable check-run API" "could not read check-runs for the head commit"
+
+    # Head check-runs readable, head legacy statuses not. Half an answer is not
+    # an answer.
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+    green_board "$BASE_SHA"
+    fixture "check-runs.$HEAD_SHA.json" <<'JSON'
+{"total_count": 1, "check_runs": [
+  {"name": "Portable tests / Linux amd64", "status": "completed", "conclusion": "success"}
+]}
+JSON
+    run_direct_chain
+    assert_undetermined "unreadable commit statuses" "could not read commit statuses for the head commit"
+
+    # More checks than one page can report: the gate cannot see the whole board,
+    # so it cannot attribute anything on it either way.
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+    green_board "$BASE_SHA"
+    board_for "$HEAD_SHA" <<'JSON'
+{"total_count": 140, "check_runs": [
+  {"name": "Portable tests / Linux amd64", "status": "completed", "conclusion": "success"}
+]}
+JSON
+    run_direct_chain
+    assert_undetermined "a truncated check-run page" "one page can report"
+}
+
+# The waiver exists for rigs that want no hosted gate at all. It is explicit, it
+# is loud, and every bead it lets through carries the mark.
+test_the_waiver_is_loud_and_recorded() {
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+
+    CI_GATE_OVERRIDE=false run_direct_chain
+    assert_allowed "an explicit waiver"
+    [[ "$OUTPUT" == *"CI_GATE_DISABLED_BY_CONFIG"* ]] ||
+        fail "a waived CI gate must announce itself: $OUTPUT"
+    grep -F -- '--set-metadata ci_gate_result=disabled' "$CALLS" >/dev/null ||
+        fail "a bead closed without CI proof must carry that on the record"
+    ! grep -q '^GH ' "$CALLS" ||
+        fail "a waived gate should not be querying checks at all: $(grep '^GH ' "$CALLS")"
+    assert_branch_not_republished "a waived gate"
+
+    # The waiver is the only way off. A rig with no gh and no github.com origin
+    # is undetermined, not green.
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+    green_board "$BASE_SHA"
+    green_board "$HEAD_SHA"
+    rm -f "$BIN/gh"
+    ORIGIN_REPO_NAME="" run_direct_chain
+    assert_undetermined "an unresolvable origin repository" "could not resolve the origin repository"
+    [[ "$OUTPUT" == *"ci_gate=false"* ]] ||
+        fail "an unresolvable origin must point at the waiver rather than dead-end: $OUTPUT"
+    ORIGIN_REPO_NAME="gastownhall/kisakcod"
+}
+
+# The pull-request handoff gates the exact object: step 1 already pushed the
+# rebased branch, so the gate reads the SHA the PR actually carries -- and
+# compares it against the same target tip direct mode uses.
+test_mr_mode_gates_the_pr_head_sha() {
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+    PR_NUMBER_OVERRIDE=84
+    fixture pull.json <<'JSON'
+{"number": 84, "head": {"sha": "beda5d39beda5d39beda5d39beda5d39beda5d39"}}
+JSON
+
+    run_mr_chain
+    [[ "$CODE" -ne 0 ]] || fail "a PR whose head is not what we pushed must not be gated as ours: $OUTPUT"
+    [[ "$OUTPUT" == *"but you pushed"* ]] || fail "the SHA mismatch must be named: $OUTPUT"
+    assert_not_closed "an mr-mode head SHA mismatch"
+
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+    PR_NUMBER_OVERRIDE=84
+    jq -n --arg sha "$HEAD_SHA" '{number: 84, head: {sha: $sha}}' >"$FIX/pull.json"
+    base_board_for_red_head "$BASE_SHA"
+    red_board "$HEAD_SHA"
+
+    run_mr_chain
+    assert_rejected "$RED_CHECK_ONE"
+    [[ "$OUTPUT" == *"left intact for fix-forward"* ]] ||
+        fail "an mr-mode rejection must leave the branch intact; deleting it orphans the PR"
+
+    # A PR whose failures the target already has is a PR that may be published.
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+    PR_NUMBER_OVERRIDE=84
+    jq -n --arg sha "$HEAD_SHA" '{number: 84, head: {sha: $sha}}' >"$FIX/pull.json"
+    red_board "$BASE_SHA"
+    red_board "$HEAD_SHA"
+    run_mr_chain
+    assert_allowed "an mr-mode head inheriting its base's failures"
+    grep -F -- "--set-metadata ci_gate_base_sha=$BASE_SHA" "$CALLS" >/dev/null ||
+        fail "mr mode must measure against the same target tip direct mode uses"
+
+    setup_case
+    trap 'rm -rf "$TMP"' RETURN
+    PR_NUMBER_OVERRIDE=84
+    jq -n --arg sha "$HEAD_SHA" '{number: 84, head: {sha: $sha}}' >"$FIX/pull.json"
+    green_board "$BASE_SHA"
+    green_board "$HEAD_SHA"
+    run_mr_chain
+    assert_allowed "a green PR head"
+    grep -F -- "--set-metadata ci_gate_sha=$HEAD_SHA" "$CALLS" >/dev/null ||
+        fail "mr mode must stamp the PR head SHA it proved"
+    PR_NUMBER_OVERRIDE=""
+}
+
+test_shipped_defaults_are_fail_closed
+test_the_gate_rules_before_anything_lands
+test_green_to_red_is_a_regression_and_rejects
+test_red_to_red_is_inherited_and_allows
+test_a_red_base_does_not_freeze_the_repository
+test_absent_on_base_and_red_on_head_is_a_regression
+test_green_to_green_passes_and_the_bead_closes
+test_zero_checks_on_both_sides_allows
+test_head_with_no_checks_rejects_when_the_base_has_them
+test_a_base_with_no_board_cannot_attribute_a_red_head
+test_pending_waits_then_goes_undetermined
+test_unknown_conclusions_are_red_and_regress
+test_legacy_commit_statuses_are_compared_too
+test_base_lookup_failure_is_undetermined_not_a_pass
+test_direct_mode_publishes_nothing_by_default
+test_the_publish_opt_in_gates_the_exact_landing_sha
+test_api_failures_are_undetermined_never_green
+test_the_waiver_is_loud_and_recorded
+test_mr_mode_gates_the_pr_head_sha
+
+echo "refinery CI regression gate tests passed"


### PR DESCRIPTION
A refinery must not close work that makes hosted CI **worse**.

Not "work whose CI is red" — worse. That distinction is the entire design, and getting it wrong is what makes a CI gate unshippable.

| on the target | on the branch | verdict |
|---|---|---|
| green | red | **REGRESSION — reject, naming the check** |
| absent | red | **REGRESSION — the branch added a failing job** |
| still running | red | not *proven* inherited — reject |
| red | red | pre-existing — **allow**, report it loudly, stamp it on the bead |
| anything | green | pass |
| anything | still running | bounded wait, then UNDETERMINED |
| zero checks | zero checks | no CI on this path — allow |
| has checks | zero checks | coverage the target has was lost here — reject |

That is the whole scope of this PR. It does not review diffs, does not read PR comments, does not name any bot, and does not change what any existing rig pushes.

## Why

One rig's `master`, merged bead by bead by a refinery whose entire quality gate was local:

```
07-22 15:04  beda5d39   success:9            <- last fully green
07-23 09:34  0d5a7558   failure:3 success:6  <- first red
07-24 01:25  dd1f26ba   failure:8 success:1
07-24 22:00  08050416   failure:11
```

Fully green to eleven failing checks in 55 hours. Every failing check was a cross-platform target a Linux worker cannot build: `Windows x86 / {Release,Debug}`, `Portable tests / {Linux,macOS,Windows} {amd64,arm64}`. Polecat green on Linux, refinery green on Linux, merge, hosted CI red, nobody reads it, next merge stacks on top of the last one's red.

## Mechanism

The refinery's quality gate is *entirely local*, and that is visible in the assets rather than inferred:

- `mol-refinery-patrol.toml:272` `run-tests` executes exactly `{{setup_command}}`, `{{typecheck_command}}`, `{{lint_command}}`, `{{build_command}}` (`:285`) and `{{test_command}}` (`:293`) — five shell commands on the machine the refinery runs on.
- `mol-refinery-patrol.toml:298` the Quality-Gate Fallback, for rigs that configure none of those, reads the repo's instructions file and runs *the gates documented there*. Also local.
- `prompt.template.md:47` says the same thing to the agent.
- `mol-refinery-patrol.toml:385` `merge-push` then fast-forwards the target and closes the bead (`:806` direct, `:1066` mr). Its terminal `**GATE**` (`:1088`) requires "verified target push" / "verified PR URL" — the handoff mechanics, not the verdict.

```
$ grep -rn 'check-run\|check_run\|gh pr checks\|commits/.*/status' gastown/agents/refinery/ gastown/formulas/mol-refinery-patrol.toml
$
```

Nothing in the refinery's assets queries a hosted check-run. A Linux worker cannot build `Windows x86 / Release`, so a green local run says nothing about it, and the refinery had no way to find out. That is the bug: not a missing test, a missing *reader*.

## A red base does not block work, and this is not a footnote

**The obvious fix — "hosted CI must be green before close" — is wrong, and we have the receipts.**

On the same operator's rig, `master` went red on 2026-07-23 and *stayed* red. Every branch cut from it afterwards inherited those eleven failures. Under a gate that demanded green, no branch could ever have landed — **including the branches that fixed the failures causing the red**. It sat frozen for roughly 16 hours and only moved when a human authorised a deliberate gate override. An absolute gate would have made that permanent instead of temporary.

So a check that is already failing on the target is **announced, recorded, and allowed through**:

```
CI_GATE_PREEXISTING_RED: 11 checks on 2b2c5626 with no regression against main at 8d446d23;
11 of them are already red on the base and are INHERITED, not caused here:
Portable tests / Linux amd64 [failure]; Portable tests / Linux arm64 [failure]; ...
This work is allowed through because it did not make hosted CI worse, NOT because hosted CI
is well. The base is red and stays red until something fixes it; ci_gate_inherited on the
bead names what was let through.
```

`test_a_red_base_does_not_freeze_the_repository` pins exactly that case — the incident's real eleven failures on both the base and the head — and asserts exit 0, no bead-back-to-pool write, and every inherited name on the record. If that test ever goes red, this gate has become a freeze and must not ship.

The same reasoning drives two other rows people get backwards:

- **Zero checks on both sides passes.** A repository that publishes no CI on this path has nothing for a branch to degrade. Rejecting there locks out every repo without a forge CI — the same class of mistake as freezing a red base. It announces `CI_GATE_NO_HOSTED_CI` and stamps the bead, so nobody mistakes it for a proof.
- **Pending ends in UNDETERMINED, not rejection.** The gate waits, bounded by `ci_timeout_seconds`, and then stops without touching bead state. An unfinished check is not evidence the branch degraded anything, and a slow CI queue is not the branch's fault. Blaming it would be the absolute gate leaking back in through the timeout.

## The fix

One gate between a rebased branch and `gc bd close` (`mol-refinery-patrol.toml:649-1032`, block `REFINERY_CI_GATE`). It resolves the SHA the merge rests on **and** the SHA of the target it lands on, reads check-runs **and** legacy commit statuses for both (a repo can publish either or both; reading one API is a way to mistake silence for success), matches them **by check name**, and rules on the difference.

A check is RED on `failure`, `timed_out`, `cancelled`, `action_required`, or **any conclusion not on the accept list** (`success`, `neutral`, `skipped`) — default deny, because an unrecognized conclusion is not a pass. Default-deny decides what is red; the base comparison decides who answers for it. `test_unknown_conclusions_are_red_and_regress` pins both halves: `stale` against a green base rejects, `stale` against a `stale` base is inherited.

Repeat runs of the same check name are collapsed per name, **asymmetrically**, and both directions are fail-closed (`ci_gate_board`, `:793`):

- **head**: RED beats PENDING beats GREEN. A red run on the head is a red check.
- **base**: GREEN beats RED beats PENDING. A name only counts as already-broken if nothing on the base ever passed it, so a flaky base cannot be used to excuse a head failure.

Three dispositions, no fourth, and no path that silently continues (`:1014` `ci_gate_run`):

- **no attributable degradation** → proceed. `ci_gate_sha`, `ci_gate_base_sha`, `ci_gate_inherited` and `ci_gate_result` are stamped the moment the gate rules (`:750`), not at close time. A `--ff-only` merge makes `merged_sha` the same object as `temp`, so `ci_gate_sha == merged_sha` is readable proof months later that hosted CI ruled on exactly what landed.
- **degraded** → reject through the **existing** rejection flow (`:702`), the same shape `rebase` (`:233`) and `handle-failures` (`:334`) already use: `--status=open --assignee="" --set-metadata rejection_reason=... --set-metadata gc.routed_to=...polecat`, then pour the next wisp and burn this one so the queue keeps turning. The branch is **left intact** — a CI rejection is fix-forward, the polecat pushes another commit to the same branch, and in `mr` mode deleting it would orphan the open PR.
- **unreadable / unresolvable / unfinished** → *undetermined*: STOP without mutating bead state. Cannot-tell is never no-regression, and it is never blamed on the branch either.

`ci_gate=false` is the explicit operator waiver. It is announced on stdout and stamps `ci_gate_result=disabled` on every bead it lets through. The gate never self-disables on error — no error path assigns `CI_GATE`.

This reuses the formula's existing GitHub plumbing rather than introducing new coupling: `resolve_github_token` (`:567`), `init_github_rest` (`:579`), `curl_gh_api` (`:605`), and the `gh`-when-present / token-curl-otherwise pattern that `lookup_pr_info` (`:616`) and the whole PR handoff already run on. `ci_gate_api` (`:736`) is one more reader over the same two paths.

## Which base: the target tip, not the merge-base

**Decision: `refs/remotes/origin/$TARGET`, resolved locally at gate time (`ci_gate_resolve_base`, `:762`).**

The merge-base is the more honest attribution boundary in theory — it is exactly where the branch diverged, so everything after it is the branch's own doing. It is also frequently **un-gradeable**, and that is decisive. Hosted CI attaches check-runs to the commits it was *triggered for*. An arbitrary interior commit of the target's history very often was never a branch tip any workflow ran against, so it carries an empty board — and a comparison against an empty board classifies every red check on the head as "absent on the base", i.e. as a regression. That is the absolute gate wearing a disguise, and it reintroduces the 16-hour freeze through the back door.

The target tip does not have that problem. It is the commit `on: push` workflows fire for, so a repository with CI has a real board there, and it is also the commit this work will actually land on.

**They mostly coincide anyway.** This step rebases `temp` onto `origin/$TARGET` immediately before the gate runs, and after a successful rebase `git merge-base origin/$TARGET temp` **is** `origin/$TARGET`. The two differ only when the target moved between the rebase and the gate — and in that window the `--ff-only` merge below fails anyway, the branch comes back through here after another rebase, and the gate re-runs. A race of seconds, not a design gap.

**The residual, stated plainly:** if the target moved and broke a check in that window, the breakage is charged to the base, not the branch — the direction that errs toward letting work land. And if `origin/$TARGET` cannot be resolved at all, the gate is **undetermined, not a pass** (`test_base_lookup_failure_is_undetermined_not_a_pass`); a gate that quietly stops gating when a fetch is stale is worse than no gate, because it is trusted.

## Zero check-runs: two cases, not one

The previous revision of this PR rejected on zero checks, full stop. Under regression-scoping that is wrong in one direction and right in the other, so it splits:

| | verdict | why |
|---|---|---|
| zero on the head, zero on the base | **allow** | This repository publishes no CI on this path. There is nothing to degrade, and rejecting would lock out every rig without a forge CI for the same bad reason an absolute gate locks out every rig with a red base. Announced as `CI_GATE_NO_HOSTED_CI` and stamped on the bead, so it is never mistaken for proof. |
| zero on the head, the base has checks | **reject** | CI ran for the target and did not run here. The branch lost coverage the target already has: a workflow removed or renamed, or a ref nothing triggers for. "Nothing ran" cannot be compared to anything, and a branch that silences the board has degraded it. |

`ci_zero_check_grace_seconds` still applies before either verdict — a push takes seconds to register workflow runs, and `test_zero_checks_on_both_sides_allows` includes the case where the board appears on the second poll and must be read rather than treated as absent.

## Forensics: you can see *why*, not just *what*

A reviewer must never have to guess which check triggered a rejection, or whether a red target was caused by a given bead or merely survived it. Four metadata fields, on both the pass and the reject path:

| field | records |
|---|---|
| `ci_gate_sha` | the SHA the verdict was measured *on* |
| `ci_gate_base_sha` | the SHA it was measured *against* — what "worse" was worse than |
| `ci_gate_inherited` | every failure let through as pre-existing, by name |
| `ci_gate_result` | the full verdict sentence, counts and names included |

Rejection reasons name the specific checks **and what those checks were doing on the base**:

```
2 of 4 checks are red on <sha> and are NOT red on main at <base>:
Windows x86 SP / Debug [failure; on the base: no such check];
Windows x86 SP / Release [failure; on the base: no such check].
This branch made hosted CI worse. Fix these checks on the same branch and reassign.
```

That is the real observed case behind the `absent → red` row: a bead added two new CI jobs that failed immediately, taking the target from 9 failures to 11, while its own acceptance criteria claimed a hosted validation it never performed. Nothing that was passing broke — and the branch still made things worse. `test_absent_on_base_and_red_on_head_is_a_regression` runs it against an **already-red** base, so it also proves that rule is not the absolute gate reappearing on a green base.

## Direct mode: gated, but it publishes nothing new

**Decision: the gate runs in both modes. `direct` mode does not push the source branch today, and this change does not make it start.**

Exempting `direct` would exempt the failure — it is the default (`metadata.merge_strategy`), it lands straight onto the target, and it is the mode the incident happened in. But hosted CI rules on SHAs that exist on the forge, and the obvious way to get the rebased head onto the forge is to push it. That push is a behaviour change every direct-mode rig would inherit on upgrade: remote branches where it never had them. Not worth taking uninvited.

So the gate reads the SHA it can honestly read, and says which one it read (`:1184`):

| | what the gate rules on |
|---|---|
| `mr` / `pr` | the PR head SHA. Step 1 already pushed `temp` to `origin/$BRANCH`, so this is the exact object, with **no new push**. The gate asks GitHub for the head rather than trusting the local ref: if they disagree, something pushed after us and the checks belong to a different commit. |
| `direct`, rebase was a no-op | `origin/$BRANCH`, which **is** the commit being landed. Exact, and it announces `CI_GATE_EXACT`. |
| `direct`, rebase rewrote the branch | the published tip. It announces `CI_GATE_REBASED_HEAD` naming both SHAs, and records `landing <sha>, a rebase of it` in `ci_gate_result`, rather than implying the two match. |
| `direct` + `ci_gate_publish_head=true` | the exact landing SHA. Opt-in, default `false`. This is the only thing in the change that pushes a ref, and only a rig that asks for it gets it. |

The **base** side is the same in both modes: `origin/$TARGET`, which in `mr` mode is also the branch the PR targets (step 3 already refuses a PR whose base is anything else).

The middle case is the honest compromise, and it is worth being precise about what it does and does not prove. It proves hosted CI ruled on the branch's own content — which is exactly the incident's failure mode, since rebasing onto a newer target does not fix a Windows build break in the branch's diff. It does not prove the *combination* of branch and newer target. That residual is the same one every "CI on the PR branch" merge queue carries and the reason GitHub ships "require branches to be up to date before merging"; `ci_gate_publish_head=true` closes it for rigs that want it closed.

New vars, all namespaced `ci_*`, zero collisions with existing pack vocabulary: `ci_gate` (`true`), `ci_timeout_seconds` (`900`), `ci_poll_seconds` (`60`), `ci_zero_check_grace_seconds` (`300`), `ci_gate_publish_head` (`false`).

## Upgrade behaviour

- A direct-mode rig **pushes exactly what it pushed before**. Pinned by `test_direct_mode_publishes_nothing_by_default`, which fetches and compares `origin/$BRANCH` on both the pass and the reject path, and by a structural assertion that the single `git push origin "HEAD:$BRANCH"` in direct mode sits inside the `ci_gate_publish_head` opt-in.
- A rig **with** hosted CI starts rejecting branches that break checks the target passes. That is the fix.
- A rig **with a red target branch keeps landing work.** That is the other fix, and it is the one that decides whether the first is usable.
- A rig **without** hosted CI is unaffected: zero on both sides passes. No flag needed, no wedge, no `ci_gate=false` required just to keep moving.
- No step-graph change: `merge-push` still `needs = ["handle-failures"]`, asserted.
- No metadata key is repurposed. `ci_gate_sha` / `ci_gate_base_sha` / `ci_gate_inherited` / `ci_gate_result` are new; `rejection_reason` and `gc.routed_to` are used exactly as the existing rejection paths use them.

## Regression coverage

`gastown/tests/test_refinery_ci_gate.sh`, 19 cases. It extracts the **shipped** gate block and the **shipped** call chains out of the TOML, substitutes the **shipped** var defaults, and runs them against a hermetic `gh`/`gc` and a real throwaway git repo with a local bare `origin` — so `--force-with-lease`, ref comparison, and the gate's own `git rev-parse refs/remotes/origin/$TARGET` behave as they do against GitHub. Fixtures are per-commit, because the gate reads two boards. It asserts on behaviour, not prose. Timing knobs are overridden in the driver so the bounded waits resolve immediately; the shipped defaults are asserted separately.

Every row of the table, plus the machinery around it:

green→red rejects naming the check *and* what it was doing on the base · red→red allows and reports · **eleven-red base with an eleven-red head allows, proving a red repo is not frozen** · absent→red rejects, against an already-red base · pending-on-base does not excuse a red head · green→green passes and the shipped close chain closes the bead · zero/zero allows · base-has-checks/head-has-none rejects · a base with no board at all cannot attribute a red head, and says so · pending waits, then goes undetermined, but passes when it finishes green inside the window · a proven regression does not wait for the rest of the board · unknown conclusions are red, and are inherited when equally unknown on the base · legacy commit statuses are compared on both sides · an unresolvable base, an unreadable base board, and a truncated base page are all undetermined, never a pass · every head-side API failure mode is undetermined, never green and never a branch rejection · direct mode publishes nothing by default on both paths · the opt-in publishes and gates the exact landing SHA · the waiver is loud and recorded and skips the API entirely · mr mode gates the PR head SHA, refuses a head that is not what we pushed, and measures against the same target tip.

Every rejection assertion requires a *specific* `rejection_reason` — the regressed check names with their base state, or the lost-coverage sentence — plus `ci_gate_base_sha` on the record, bead-to-pool, claim released, routed to polecat, next wisp poured, current wisp burned, branch intact, and bead not closed.

Mutation-tested; 10 of 10 caught, with the message each produces:

| mutation | caught by |
|---|---|
| the absolute gate returns: every red check on the head is a regression | `FAIL: a head that is red in exactly the ways its base is already red must be allowed through (exit 1)` |
| a failing job the branch ADDED is excused as pre-existing | `FAIL: the CI gate must reject with exit 1 (got 0)` |
| a base with no board at all is used to attribute the head's failures | `FAIL: a red head measured against a base that publishes no board must be allowed through (exit 1)` |
| a still-running base check is treated as proof the failure is inherited | `FAIL: the CI gate must reject with exit 1 (got 0)` |
| a head that publishes no checks while the base does is waved through | `FAIL: the CI gate must reject with exit 1 (got 0)` |
| zero checks on both sides rejects, as the absolute gate did | `FAIL: a repository that publishes no checks on either side must be allowed through (exit 1)` |
| an unresolvable base falls through instead of stopping | `FAIL: an unresolvable base ref must not pass` |
| a head still running at the deadline is blamed on the branch | `FAIL: a head board that never finished must report CI_GATE_UNDETERMINED` |
| a rejection does not record the base it measured against | `FAIL: a rejection must record the base SHA it measured against; a reviewer must never have to guess what 'worse' was worse than` |
| the gate stops reading a base board at all | `the gate must resolve and read a BASE board; without one every red check on the head looks like a regression and a repository with a red target can never land its own fix` |

The structural suite additionally pins that `ci_gate` defaults on, `ci_gate_publish_head` defaults off, direct mode runs the gate before it touches the target, `mr` mode runs it before the close, and that `prompt.template.md:19` — `FORBIDDEN: Reading polecat code to "understand what they were trying to do."` — stays untouched, so nothing later drifts a CI reader into a code reviewer. Whether the refinery should also review diffs is a separate question with an existing upstream answer (`superpowers-code-review`, `compound-code-review`, `gstack-code-review`), and it is not this PR's question.

## What this deliberately does not catch

A regression gate is **narrower than an absolute gate**, on purpose, and it is worth naming the gap rather than letting a reviewer find it:

- **It does not make a red target green.** Eleven inherited failures land eleven inherited failures, one bead at a time, forever, until something fixes them. The gate reports them on every bead (`ci_gate_inherited`) and stops there. Driving them to zero is a human's job, or a separate bead; this gate only guarantees the number never goes up because of a merge.
- **It does not catch a branch that trades one failure for another** if both check names are already red on the base. Name-level comparison sees `X: red → red`; it does not read the failure text.
- **It cannot attribute anything when the base publishes no board but the head does.** A repository whose CI runs only `on: pull_request` never has checks on its target tip. Charging the head's failures to the branch on that evidence would freeze exactly the repositories this rescoping exists to unfreeze, so those failures are reported as `CI_GATE_UNATTRIBUTABLE`, recorded on the bead, and allowed (`test_a_base_with_no_board_cannot_attribute_a_red_head`). It is a real hole, and it is the deliberate choice over a real freeze.
- **It cannot see past one page.** More than 100 check-runs or statuses on either side is truncation, and truncation is undetermined rather than a guess. A repo that large needs pagination here before it needs anything else in this PR.
- **A `paths:`-filtered workflow can produce a false rejection.** A docs-only branch that legitimately triggers no jobs, in a repo whose target tip has a full board, hits the lost-coverage rule. It is recoverable (bead back to pool, branch intact, reason self-describing) but it is not fix-forwardable by a polecat, and a rig that hits it repeatedly should be running an always-succeeding required job — the same remedy GitHub's own required-checks documentation gives.

## Validation

- `bash gastown/tests/test_refinery_ci_gate.sh` — pass (19 cases)
- all five `gastown/tests/test_*.sh` suites — pass (`test_gastown_pack_assets`, `test_gastown_theme_scripts`, `test_polecat_churn_watcher`, `test_witness_heartbeat_check`, and this one). `test_gastown_pack_assets.sh` is untouched.
- `python3 -m pytest tests -q` — 101 passed, 8 skipped (includes `test_no_bare_bd_commands`, which the hermetic `gc` stub is written to satisfy)
- `bash -n` on every `gastown/**/*.sh`, and on the extracted gate block and both extracted call chains at the top of every test case — a fragment that is not valid shell fails the suite before it asserts anything
- TOML: all 307 TOML files in the repo parse; the gate block is asserted to carry no unsubstituted `{{var}}` after default substitution
- `gc lint gastown` — ok
- each mutation above confirmed FAILING with the suite applied

## Composition with open PRs

Test-merged against `upstream/main` (6373985) + this branch, one at a time; each merge clean, full suite + `gc lint gastown` run on every merged tree that shares a file:

| PR | merge | note |
|---|---|---|
| #221 witness orphan-close evidence | clean | no shared file |
| #222 polecat claim fail-closed | clean | no shared file |
| #226 patrol wisp reconciliation | clean textually, **one semantic follow-up** | below |
| #227 artifact worktree safety | clean | shares both refinery files; full suite + `gc lint gastown` pass on the merged tree |
| #232 planner dependency edges | clean | no shared file |
| #240 polecat blocked-row prompt contract | clean | no shared file |
| #190 forge-aware `mr` handoff | clean | shares `prompt.template.md`; full suite + `gc lint gastown` pass on the merged tree |

**#226** replaces the patrol-root query idiom repo-wide and adds a test forbidding `gc bd list --status=in_progress --type=molecule` in refinery assets. `ci_gate_reject` reuses the idiom that is on `main` today — the same one five other sites in this file use, and the one `block_existing_pr` uses for exactly this mid-script terminal case. After a merge, #226's sweep leaves exactly **one** remaining hit (the line in `ci_gate_reject`), and #226's own `test_patrol_wisp_reconciliation.sh` fails on it — verified on the merged tree, which is the failure mode you want. Whoever lands second replaces that one line with #226's reconciliation block. The alternative — omitting the pour/burn to dodge the idiom — would strand the patrol loop on every CI rejection, so this branch keeps it and takes the one-line rebase.

**#190** makes the refinery's `mr` handoff forge-aware (`gh` or `glab`) and is prose-only in `prompt.template.md`. No textual conflict, and no directional tension in the shipped code: the gate's GitHub calls go through `ci_gate_api`, a single reader that already has the `gh` / token-curl split, so making it forge-aware later is one function rather than a scattered edit. The prompt's Command Quick-Reference does gain three rows; if #190 lands first they should be spelled in its two-column GitHub/GitLab table. That is a table row, not a design conflict — and the RED/acceptable vocabulary above is GitHub check-run vocabulary that a GitLab reader would need mapped, which is #190's shape of problem to solve, not a reason to withhold the reader from the rigs that have it today.

## Not in this PR

Deliberately, so this stays one reviewable idea:

- requiring hosted CI to be *green* — that is the design this PR exists to reject, for the reasons in the second section
- reviewing the diff on its merits — inverts `prompt.template.md:19` and duplicates the pack's existing review workflows
- any gate on automated reviewer comments — that hardcodes *someone's* bot list into an upstream pack
- publishing the source branch in direct mode by default — the opt-in is here; the default is not
- pagination past 100 checks — truncation is honest today; making it complete is a separate change
