### PR TITLE
fix(gastown): persist polecat blocker before stopping

### DIFF
--- a/gastown/agents/polecat/prompt.template.md
+++ b/gastown/agents/polecat/prompt.template.md
@@ -331,7 +331,7 @@ When blocked, you MUST escalate. Do NOT wait for human input.
 - Tests fail and you can't determine why after 2-3 attempts
 - Need credentials, secrets, or external access
 
-**How:**
+**How when you can continue:**
 ```bash
 # Blocking issues
 WITNESS_TARGET="${GC_RIG:+$GC_RIG/}{{ .BindingPrefix }}witness"
@@ -341,7 +341,59 @@ gc mail send "$WITNESS_TARGET" -s "ESCALATION: Brief description [HIGH]" -m "Det
 gc mail send mayor/ -s "BLOCKED: <topic>" -m "Context"
 ```
 
-After escalating: continue if possible, otherwise `gc bd update <bead> --status=escalated && gc runtime drain-ack && exit`.
+If you must stop, do **not** send the standalone mail above first. Use the
+single block below; it records the blocker on the bead, sends the one allowed
+witness mail, marks the bead blocked, and then drains.
+
+Mail is addressed to the witness, not attached to the bead, and there is no
+bead-to-mail lookup — so it does not reach whoever picks this bead up next.
+Write the reason **on the bead**, and write it before the status flip: a bead
+left `blocked` with nothing on it is indistinguishable from a crash.
+
+```bash
+BLOCKED_BEAD="<the id printed as CLAIMED_BEAD_ID>"
+BLOCKED_REASON="<what blocked you, and what would unblock it>"
+WITNESS_TARGET="${GC_RIG:+$GC_RIG/}{{ .BindingPrefix }}witness"
+# BEGIN POLECAT_BLOCKED_CONTRACT
+if [ -z "$BLOCKED_BEAD" ] || [ -z "$BLOCKED_REASON" ]; then
+  echo "BLOCK_REFUSED: no bead id or no reason; bead NOT modified"
+  exit 2
+fi
+gc bd update "$BLOCKED_BEAD" \
+  --set-metadata blocked_reason="$BLOCKED_REASON" \
+  --append-notes "BLOCKED: $BLOCKED_REASON" || true   # the read-back decides, not this exit code
+RECORDED=$(gc bd show "$BLOCKED_BEAD" --json 2>/dev/null | jq -r '.[0].metadata.blocked_reason // empty')
+if [ "$RECORDED" != "$BLOCKED_REASON" ]; then
+  echo "BLOCK_REFUSED $BLOCKED_BEAD: blocked_reason did not persist; status NOT changed"
+  gc mail send "$WITNESS_TARGET" -s "ESCALATION: cannot record blocked_reason on $BLOCKED_BEAD [HIGH]" \
+    -m "Could not persist blocked_reason on $BLOCKED_BEAD, so its status was left unchanged rather than blocked with no explanation. Intended reason: $BLOCKED_REASON"
+  exit 1
+fi
+if ! gc bd update "$BLOCKED_BEAD" --status=blocked; then
+  echo "BLOCK_REFUSED $BLOCKED_BEAD: status transition failed; session NOT drain-acked"
+  gc mail send "$WITNESS_TARGET" -s "ESCALATION: cannot mark $BLOCKED_BEAD blocked [HIGH]" \
+    -m "blocked_reason persisted on $BLOCKED_BEAD, but the status transition to blocked failed. Session was not drain-acked. Reason: $BLOCKED_REASON"
+  exit 1
+fi
+RECORDED_STATUS=$(gc bd show "$BLOCKED_BEAD" --json 2>/dev/null | jq -r '.[0].status // empty')
+if [ "$RECORDED_STATUS" != "blocked" ]; then
+  echo "BLOCK_REFUSED $BLOCKED_BEAD: status transition did not read back; session NOT drain-acked"
+  gc mail send "$WITNESS_TARGET" -s "ESCALATION: blocked status did not persist on $BLOCKED_BEAD [HIGH]" \
+    -m "blocked_reason persisted on $BLOCKED_BEAD, but status read back as '${RECORDED_STATUS:-missing}' instead of blocked. Session was not drain-acked. Reason: $BLOCKED_REASON"
+  exit 1
+fi
+if ! gc mail send "$WITNESS_TARGET" -s "ESCALATION: $BLOCKED_BEAD blocked [HIGH]" \
+  -m "Blocked $BLOCKED_BEAD. Reason: $BLOCKED_REASON"; then
+  echo "BLOCK_REFUSED $BLOCKED_BEAD: witness escalation failed; session NOT drain-acked"
+  exit 1
+fi
+if ! gc runtime drain-ack; then
+  echo "BLOCK_REFUSED $BLOCKED_BEAD: drain acknowledgement failed"
+  exit 1
+fi
+exit 0
+# END POLECAT_BLOCKED_CONTRACT
+```
 
 ---
 

--- a/gastown/formulas/mol-polecat-work.toml
+++ b/gastown/formulas/mol-polecat-work.toml
@@ -39,7 +39,7 @@ refinery. Resume the existing branch — don't redo all the work.
 | Situation | Action |
 |-----------|--------|
 | Tests fail | Fix them. Do not proceed with failures. |
-| Blocked on external | Mail Witness, mark yourself stuck |
+| Blocked on external | Mail Witness, then stop via Escalation in your prompt (records `blocked_reason` before the status flip) |
 | Context filling | `gc runtime request-restart` (blocks until controller kills you) |
 | Unsure what to do | Mail Witness, don't guess |"""
 formula = "mol-polecat-work"

--- a/gastown/tests/test_polecat_blocked_reason.sh
+++ b/gastown/tests/test_polecat_blocked_reason.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+# The polecat's escalation stop must record blocked_reason on the bead before it
+# flips status, and must refuse to flip at all if it cannot. This suite extracts
+# the shipped POLECAT_BLOCKED_CONTRACT region from the prompt and executes it,
+# so it tests the real artifact rather than prose about it.
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+PROMPT="$ROOT/gastown/agents/polecat/prompt.template.md"
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+# Extracts the contract verbatim. WITNESS_TARGET is set by the surrounding
+# prompt snippet (it carries a {{ .BindingPrefix }} template var), so the tests
+# supply it from the environment the way the rendered prompt would.
+extract_contract() {
+    sed -n '/# BEGIN POLECAT_BLOCKED_CONTRACT/,/# END POLECAT_BLOCKED_CONTRACT/p' "$PROMPT" >"$1"
+    [[ -s "$1" ]] || fail "POLECAT_BLOCKED_CONTRACT region not found in $PROMPT"
+    grep -q 'blocked_reason' "$1" || fail "extracted contract does not mention blocked_reason"
+}
+
+# Logs every gc invocation in order to $GC_CALLS. The update operation persists
+# blocked_reason only when GC_STUB_PERSIST=1, and status only when
+# GC_STUB_STATUS_PERSIST=1. The stub also models append-notes so the suite can
+# prove that an existing task record is preserved rather than overwritten.
+write_gc_stub() {
+    local bin="$1"
+    mkdir -p "$bin"
+    cat >"$bin/gc" <<'SH'
+#!/usr/bin/env bash
+noun="${1:-}"
+verb="${2:-}"
+{
+    printf 'CALL:%s:%s' "$noun" "$verb"
+    for arg in "${@:3}"; do printf ' %s' "$arg"; done
+    printf '\n'
+} >>"$GC_CALLS"
+if [[ "$noun" == "bd" && "$verb" == "update" ]]; then
+    for arg in "$@"; do
+        case "$arg" in
+            blocked_reason=*)
+                [[ "${GC_STUB_PERSIST:-1}" == "1" ]] &&
+                    printf '%s' "${arg#blocked_reason=}" >"$GC_STATE/reason"
+                ;;
+            --append-notes)
+                append_next=1
+                ;;
+            --status=blocked)
+                if [[ "${GC_STUB_STATUS_FAIL:-0}" == "1" ]]; then
+                    exit 1
+                fi
+                [[ "${GC_STUB_STATUS_PERSIST:-1}" == "1" ]] &&
+                    printf '%s' "${arg#--status=}" >"$GC_STATE/status"
+                ;;
+            --status=*)
+                echo "unsupported status: ${arg#--status=}" >&2
+                exit 2
+                ;;
+            *)
+                if [[ "${append_next:-0}" == "1" ]]; then
+                    printf '\n%s' "$arg" >>"$GC_STATE/notes"
+                    append_next=0
+                fi
+                ;;
+        esac
+    done
+elif [[ "$noun" == "bd" && "$verb" == "show" ]]; then
+    reason=""
+    status=""
+    [[ -f "$GC_STATE/reason" ]] && reason="$(cat "$GC_STATE/reason")"
+    [[ -f "$GC_STATE/status" ]] && status="$(cat "$GC_STATE/status")"
+    jq -n --arg r "$reason" --arg s "$status" \
+        '[{status:$s,metadata:(if $r == "" then {} else {blocked_reason:$r} end)}]'
+elif [[ "$noun" == "mail" && "$verb" == "send" ]]; then
+    [[ "${GC_STUB_MAIL_FAIL:-0}" == "1" ]] && exit 1
+elif [[ "$noun" == "runtime" && "$verb" == "drain-ack" ]]; then
+    [[ "${GC_STUB_DRAIN_FAIL:-0}" == "1" ]] && exit 1
+fi
+exit 0
+SH
+    chmod +x "$bin/gc"
+}
+
+# Runs the shipped contract against the stub. Echoes the exit code; the call log
+# and persisted state land in $GC_CALLS / $GC_STATE for the caller to assert on.
+run_contract() {
+    local bead="$1" reason="$2" persist="$3" status_persist="${4:-1}" status_fail="${5:-0}"
+    local drain_fail="${6:-0}" mail_fail="${7:-0}" rc=0
+    BLOCKED_BEAD="$bead" BLOCKED_REASON="$reason" \
+        WITNESS_TARGET="helm/witness" GC_STUB_PERSIST="$persist" \
+        GC_STUB_STATUS_PERSIST="$status_persist" GC_STUB_STATUS_FAIL="$status_fail" \
+        GC_STUB_DRAIN_FAIL="$drain_fail" GC_STUB_MAIL_FAIL="$mail_fail" \
+        GC_CALLS="$GC_CALLS" GC_STATE="$GC_STATE" PATH="$BIN:$PATH" \
+        bash "$CONTRACT" >"$OUT" 2>&1 || rc=$?
+    echo "$rc"
+}
+
+setup() {
+    TMP=$(mktemp -d)
+    BIN="$TMP/bin"
+    GC_STATE="$TMP/state"
+    GC_CALLS="$TMP/calls"
+    CONTRACT="$TMP/contract.sh"
+    OUT="$TMP/out"
+    mkdir -p "$BIN" "$GC_STATE"
+    : >"$GC_CALLS"
+    printf '%s' "existing task notes" >"$GC_STATE/notes"
+    write_gc_stub "$BIN"
+    extract_contract "$CONTRACT"
+}
+
+# A refusal must be a no-op. Not "mostly a no-op" — the bead must not be
+# touched at all, so the contract may not issue a single gc command.
+test_missing_reason_or_bead_is_refused_and_issues_no_gc_command() {
+    local rc
+    for case_ in "ki-0aq|" "|a real reason"; do
+        setup
+        rc=$(run_contract "${case_%%|*}" "${case_#*|}" 1)
+        [[ "$rc" == "2" ]] || fail "refusal for [$case_] exited $rc, want 2"
+        [[ ! -s "$GC_CALLS" ]] ||
+            fail "refusal for [$case_] issued gc commands: $(tr '\n' ';' <"$GC_CALLS")"
+        grep -q 'BLOCK_REFUSED' "$OUT" || fail "refusal for [$case_] printed no BLOCK_REFUSED"
+    done
+}
+
+# The whole point of the read-back: a write that does not stick must not be
+# allowed to become a silently blocked bead.
+test_unpersisted_reason_never_flips_status() {
+    setup
+    local rc
+    rc=$(run_contract "ki-0aq" "needs an AWS profile that this worktree has no access to" 0)
+
+    [[ "$rc" == "1" ]] || fail "unpersisted reason exited $rc, want 1"
+    ! grep -q -- '--status=' "$GC_CALLS" ||
+        fail "status was flipped despite the reason not persisting"
+    [[ ! -f "$GC_STATE/status" ]] || fail "bead status changed despite the reason not persisting"
+    [[ "$(grep -c '^CALL:mail:send' "$GC_CALLS")" == "1" ]] ||
+        fail "want exactly one witness escalation, got $(grep -c '^CALL:mail:send' "$GC_CALLS")"
+    ! grep -q '^CALL:runtime:drain-ack' "$GC_CALLS" ||
+        fail "drain-acked after refusing to block — reports idle and hides the failure"
+}
+
+# Ordering is the contract. The reason must be on the bead before the flip is
+# even attempted, with the read-back in between.
+test_recorded_path_writes_reason_strictly_before_the_flip() {
+    setup
+    local rc reason_line show_line status_line
+    rc=$(run_contract "ki-0aq" "upstream API returns 501; needs the v2 endpoint enabled" 1)
+
+    [[ "$rc" == "0" ]] || fail "recorded path exited $rc, want 0: $(cat "$OUT")"
+    reason_line=$(grep -n -- 'blocked_reason=' "$GC_CALLS" | head -1 | cut -d: -f1)
+    show_line=$(grep -n '^CALL:bd:show' "$GC_CALLS" | head -1 | cut -d: -f1)
+    status_line=$(grep -n -- '--status=blocked' "$GC_CALLS" | head -1 | cut -d: -f1)
+
+    [[ -n "$reason_line" ]] || fail "the reason was never written"
+    [[ -n "$status_line" ]] || fail "the status was never flipped"
+    (( reason_line < show_line )) || fail "read-back ($show_line) preceded the write ($reason_line)"
+    (( show_line < status_line )) ||
+        fail "status flip ($status_line) was not gated on the read-back ($show_line)"
+    [[ "$(cat "$GC_STATE/status")" == "blocked" ]] || fail "bead did not reach status=blocked"
+    grep -q '^existing task notes$' "$GC_STATE/notes" ||
+        fail "the blocked record replaced pre-existing task notes"
+    grep -q '^BLOCKED: upstream API returns 501' "$GC_STATE/notes" ||
+        fail "the blocked record was not appended to task notes"
+    grep -q '^CALL:runtime:drain-ack' "$GC_CALLS" || fail "recorded path did not drain-ack"
+    [[ "$(grep -c '^CALL:mail:send' "$GC_CALLS")" == "1" ]] ||
+        fail "recorded path did not use exactly one witness mail"
+}
+
+test_failed_or_unpersisted_status_never_drain_acks() {
+    local rc
+    for mode in fail unpersisted; do
+        setup
+        if [[ "$mode" == "fail" ]]; then
+            rc=$(run_contract "ki-0aq" "needs operator credentials" 1 1 1)
+        else
+            rc=$(run_contract "ki-0aq" "needs operator credentials" 1 0 0)
+        fi
+        [[ "$rc" == "1" ]] || fail "$mode status transition exited $rc, want 1"
+        ! grep -q '^CALL:runtime:drain-ack' "$GC_CALLS" ||
+            fail "$mode status transition drain-acked"
+        [[ "$(grep -c '^CALL:mail:send' "$GC_CALLS")" == "1" ]] ||
+            fail "$mode status transition did not escalate exactly once"
+    done
+}
+
+test_failed_witness_mail_or_drain_ack_never_reports_success() {
+    local rc
+
+    setup
+    rc=$(run_contract "ki-0aq" "needs operator credentials" 1 1 0 0 1)
+    [[ "$rc" == "1" ]] || fail "failed witness mail exited $rc, want 1"
+    ! grep -q '^CALL:runtime:drain-ack' "$GC_CALLS" ||
+        fail "drain-acked after witness mail failed"
+    [[ "$(grep -c '^CALL:mail:send' "$GC_CALLS")" == "1" ]] ||
+        fail "failed witness mail was retried"
+
+    setup
+    rc=$(run_contract "ki-0aq" "needs operator credentials" 1 1 0 1)
+    [[ "$rc" == "1" ]] || fail "failed drain acknowledgement exited $rc, want 1"
+    [[ "$(grep -c '^CALL:runtime:drain-ack' "$GC_CALLS")" == "1" ]] ||
+        fail "failed drain acknowledgement was not attempted exactly once"
+    [[ "$(grep -c '^CALL:mail:send' "$GC_CALLS")" == "1" ]] ||
+        fail "drain failure exceeded the one-mail budget"
+}
+
+test_missing_reason_or_bead_is_refused_and_issues_no_gc_command
+test_unpersisted_reason_never_flips_status
+test_recorded_path_writes_reason_strictly_before_the_flip
+test_failed_or_unpersisted_status_never_drain_acks
+test_failed_witness_mail_or_drain_ack_never_reports_success
+
+echo "polecat blocked-reason contract tests passed"


### PR DESCRIPTION
Replaces #231 with a narrow persistence contract for the polecat's existing
escalation path.

## Problem

The prompt already tells a blocked polecat to mail the witness, then offers a
separate one-line status transition. If the model executes the transition
without the preceding mail, the bead carries no explanation for the next agent.
Mail and bead state serve different readers; the status transition should not
succeed unless the reason is also attached to the bead.

## Change

Before changing status, the prompt now:

1. requires a bead ID and a non-empty reason;
2. writes `blocked_reason` metadata and **appends** the reason to task notes;
3. reads the metadata back and refuses the status change if it did not persist;
4. transitions only to the standard `blocked` status;
5. reads that status back; and
6. sends the one allowed witness mail and drain-acks only after both writes are
   confirmed.

If either write fails or does not read back, the session does not drain-ack and
uses at most one focused witness escalation. Mail or drain-ack failures are
also returned as failures rather than masked by an unconditional successful
exit. Existing task notes are never replaced.

This does not introduce routing, claim-release, disposition, or reason-quality
policy. It reuses the existing `blocked_reason` key and the status transition
already documented by the prompt.

## Regression coverage

`gastown/tests/test_polecat_blocked_reason.sh` extracts and executes the shipped
contract against a stateful `gc` stub. It proves:

- missing bead/reason is a no-op;
- an unpersisted reason never changes status;
- pre-existing task notes survive and the reason is appended;
- reason write → read-back → status write → read-back ordering;
- failed or silently unpersisted status never drain-acks; and
- unsupported statuses are rejected by the test double;
- mail and drain-ack failures never report success; and
- the successful path reaches `blocked` before its single mail and drain-ack.

## Validation

- `bash gastown/tests/test_polecat_blocked_reason.sh`
- all `gastown/tests/test_*.sh` suites
- Bash syntax over tracked shell scripts
- TOML parse / registry validation
- `gc lint gastown`
- `go test .`
- `git diff --check`
