### PR TITLE
fix(gastown): align polecat startup with hook claim contract

### DIFF
--- a/gastown/agents/polecat/agent.toml
+++ b/gastown/agents/polecat/agent.toml
@@ -1,7 +1,7 @@
 scope = "rig"
 wake_mode = "fresh"
 work_dir = ".gc/worktrees/{{.Rig}}/polecats/{{.AgentBase}}"
-nudge = "Run gc hook --claim --json now; if it returns work, execute the claimed formula immediately."
+nudge = "After prompt restoration, run the Startup Protocol's complete POLECAT_CLAIM_CONTRACT block as your first operational action; do not substitute a direct hook call or inspect formula, workspace, metadata, or source state first. Continue only after it prints CLAIMED_BEAD_ID."
 pre_start = ["{{.ConfigDir}}/assets/scripts/worktree-setup.sh {{.RigRoot}} {{.WorkDir}} {{.AgentBase}} --sync"]
 idle_timeout = "2h"
 min_active_sessions = 0

--- a/gastown/agents/polecat/prompt.template.md
+++ b/gastown/agents/polecat/prompt.template.md
@@ -158,9 +158,9 @@ scripted claim below, run as ONE Bash command. Do not read code, list files,
 show metadata, load skills, or run any other operational Bash until it prints
 `CLAIMED_BEAD_ID`. A fresh `claimed` result is atomically
 `in_progress`; `existing_assignment` resumes work already `in_progress`; and
-`ready_assignment` adopts work that is legitimately still `open` but already
-assigned to this session. These are distinct supported hook outcomes — do not
-rewrite one into another. Execute the block verbatim: do not retype, shorten,
+`ready_assignment` atomically promotes already-assigned ready work to
+`in_progress` before returning it. These are distinct supported hook outcomes
+— do not rewrite one into another. Execute the block verbatim: do not retype, shorten,
 or simplify its jq receipt validator.
 
 ```bash
@@ -262,8 +262,7 @@ if ! claim_identity_matches "$CLAIM_ASSIGNEE"; then
 fi
 
 case "$REASON" in
-  claimed|existing_assignment) EXPECTED_STATUS=in_progress ;;
-  ready_assignment) EXPECTED_STATUS=open ;;
+  claimed|existing_assignment|ready_assignment) EXPECTED_STATUS=in_progress ;;
 esac
 
 # Confirm the receipt through the normal work context before touching code.

--- a/gastown/agents/polecat/prompt.template.md
+++ b/gastown/agents/polecat/prompt.template.md
@@ -1,6 +1,11 @@
 # Polecat Context
 
-> **Recovery**: Run `{{ cmd }} prime` after compaction, clear, or new session
+> **Recovery/bootstrap**: If context must be restored after compaction, clear,
+> or a new session, `{{ cmd }} prime` may reload this prompt only; it is not
+> work discovery. After prompt restoration, run the Startup Protocol's complete
+> `POLECAT_CLAIM_CONTRACT` block as your first operational action. Until it
+> prints `CLAIMED_BEAD_ID`, do not read a formula, inspect metadata or source,
+> or enter a task workspace.
 
 {{ template "approval-fallacy-polecat" . }}
 
@@ -114,8 +119,10 @@ Implementation work follows the **mol-polecat-work** formula. If your hook
 claim or current molecule identifies a different formula, such as
 `mol-review-leg`, that formula's step descriptions are your instructions.
 
-**FIRST: Read your formula steps.** Do NOT use Claude's internal task tools.
-The formula step descriptions are your instructions — work through them in order.
+**After the Startup Protocol prints `CLAIMED_BEAD_ID`: read your formula
+steps.** The scripted claim block is always the first operational action. Do
+NOT use Claude's internal task tools. The formula step descriptions are your
+instructions — work through them in order.
 
 **Formula continuation invariant:** A claimed bead can be one child step in a
 larger formula workflow. After closing any formula step bead, immediately run
@@ -146,142 +153,183 @@ mail inspection, or repository scans to find a bead — those race other polecat
 and surface work that is not yours. Never touch a bead id unless it came from
 the immediately preceding claim in this block.
 
-Your first action is the scripted claim below, run as ONE Bash command. Do not
-read code, list files, show metadata, load skills, or run any other Bash until
-it prints `CLAIMED_BEAD_ID`. The claim flips gc bd status to `in_progress`
-atomically; without it the pool reconciler can recycle you mid-read and another
-polecat race-claims the same bead. Polecat-vs-polecat races are the #1 source of
-churn — close the window.
+After any prompt-only restoration, your first operational action is the
+scripted claim below, run as ONE Bash command. Do not read code, list files,
+show metadata, load skills, or run any other operational Bash until it prints
+`CLAIMED_BEAD_ID`. A fresh `claimed` result is atomically
+`in_progress`; `existing_assignment` resumes work already `in_progress`; and
+`ready_assignment` adopts work that is legitimately still `open` but already
+assigned to this session. These are distinct supported hook outcomes — do not
+rewrite one into another.
 
 ```bash
 bash <<'GC_CLAIM'
+# BEGIN POLECAT_CLAIM_CONTRACT
 set +e
-EXPECTED_ASSIGNEE="${BEADS_ACTOR:-${GC_SESSION_NAME:-${GC_SESSION_ID:-${GC_AGENT:-}}}}"
-if [ -z "$EXPECTED_ASSIGNEE" ]; then
-  echo "CLAIM_REJECTED no session identity in env; cannot verify ownership"
-  gc runtime drain-ack
+WITNESS_TARGET="${GC_RIG:+$GC_RIG/}{{ .BindingPrefix }}witness"
+
+claim_infra_failure() {
+  echo "CLAIM_INFRA_FAILURE: $*"
+  gc mail send "$WITNESS_TARGET" \
+    -s "ESCALATION: polecat claim contract failed [HIGH]" \
+    -m "$*. The startup wrapper made no follow-up bead mutation and did not manually acknowledge drain." \
+    >/dev/null 2>&1 || true
+}
+
+claim_identity_matches() {
+  local actual=$1 candidate
+  for candidate in "${BEADS_ACTOR:-}" "${GC_SESSION_NAME:-}" \
+                   "${GC_SESSION_ID:-}" "${GC_ALIAS:-}" "${GC_AGENT:-}"; do
+    [ -n "$candidate" ] && [ "$actual" = "$candidate" ] && return 0
+  done
+  return 1
+}
+
+if [ -z "${BEADS_ACTOR:-}${GC_SESSION_NAME:-}${GC_SESSION_ID:-}${GC_ALIAS:-}${GC_AGENT:-}" ]; then
+  claim_infra_failure "no runtime identity is available to validate hook ownership"
+  exit 1
+fi
+
+# --drain-ack is part of the hook transaction. Every structured drain reason
+# (`no_work`, `claims_errored`, or `stale_session`) is intentional and terminal:
+# the hook acknowledges drain before returning it. Never retry or manually
+# drain-ack one of those results.
+CLAIM_ERR=$(mktemp) || {
+  claim_infra_failure "could not allocate hook stderr capture"
+  exit 1
+}
+CLAIM_JSON=$(gc hook --claim --drain-ack --json 2>"$CLAIM_ERR")
+CLAIM_CODE=$?
+CLAIM_ERR_TEXT=$(sed -n '1p' "$CLAIM_ERR")
+rm -f "$CLAIM_ERR"
+
+if [ "$CLAIM_CODE" -ne 0 ]; then
+  claim_infra_failure "gc hook --claim failed (exit=$CLAIM_CODE): ${CLAIM_ERR_TEXT:-no diagnostic}"
+  exit 1
+fi
+
+# Validate the complete schema-v1 action/reason matrix before trusting fields.
+# A successful empty result, an unknown reason, or a work result without a
+# receipt is malformed infrastructure output — never ordinary idleness.
+if ! printf '%s' "$CLAIM_JSON" | jq -e '
+    . as $r
+    | type == "object"
+      and $r.schema_version == "1"
+      and $r.ok == true
+      and $r.command == "hook"
+      and (
+        ($r.action == "drain"
+          and (["no_work", "claims_errored", "stale_session"] | index($r.reason) != null)
+          and $r.drain_acknowledged == true)
+        or
+        ($r.action == "work"
+          and (["claimed", "existing_assignment", "ready_assignment"] | index($r.reason) != null)
+          and ($r.bead_id | type == "string" and length > 0)
+          and ($r.assignee | type == "string" and length > 0))
+      )
+  ' >/dev/null 2>&1; then
+  claim_infra_failure "gc hook --claim returned a malformed or unsupported schema-v1 result"
+  exit 1
+fi
+
+ACTION=$(printf '%s' "$CLAIM_JSON" | jq -r '.action')
+REASON=$(printf '%s' "$CLAIM_JSON" | jq -r '.reason')
+if [ "$ACTION" = "drain" ]; then
+  case "$REASON" in
+    no_work)
+      echo "NO_ROUTED_WORK reason=no_work"
+      ;;
+    claims_errored)
+      echo "CLAIM_DEFERRED reason=claims_errored; claim writes failed and core will reclaim work on a later tick"
+      ;;
+    stale_session)
+      echo "STALE_SESSION_DRAINED reason=stale_session"
+      ;;
+  esac
   exit 0
 fi
 
-# Claim with retry. A hook-call failure (non-zero exit, malformed JSON) is a
-# transient CLI/daemon fault — NOT "no work" — so retry it before giving up.
-# Only action==drain, or a clean empty result, is genuine NO_ROUTED_WORK.
-WORK_ID=""
-CLAIM_TRY=0
-while [ "$CLAIM_TRY" -lt 3 ]; do
-  CLAIM_TRY=$((CLAIM_TRY + 1))
-  CLAIM_ERR="$(mktemp)"
-  CLAIM_JSON="$(gc hook --claim --json 2>"$CLAIM_ERR")"
-  CLAIM_CODE=$?
-  CLAIM_ERR_TEXT="$(sed -n '1p' "$CLAIM_ERR")"
-  rm -f "$CLAIM_ERR"
-  ACTION="$(printf '%s' "$CLAIM_JSON" | jq -r '.action // empty' 2>/dev/null)"
-  WORK_ID="$(printf '%s' "$CLAIM_JSON" | jq -r '.bead_id // empty' 2>/dev/null)"
-  if [ "$ACTION" = "drain" ]; then
-    echo "NO_ROUTED_WORK"
-    gc runtime drain-ack
-    exit 0
-  fi
-  if [ "$CLAIM_CODE" -eq 0 ] && [ -n "$WORK_ID" ]; then
-    break
-  fi
-  if [ "$CLAIM_CODE" -eq 0 ] && [ -z "$ACTION" ] && [ -z "$WORK_ID" ]; then
-    echo "NO_ROUTED_WORK"
-    gc runtime drain-ack
-    exit 0
-  fi
-  echo "CLAIM_RETRY hook call failed (code=$CLAIM_CODE): ${CLAIM_ERR_TEXT:-malformed claim result}"
-  WORK_ID=""
-  sleep 2
-done
-if [ -z "$WORK_ID" ]; then
-  echo "CLAIM_REJECTED gc hook --claim returned no workable bead after retries"
-  gc runtime drain-ack
-  exit 0
+WORK_ID=$(printf '%s' "$CLAIM_JSON" | jq -r '.bead_id')
+CLAIM_ASSIGNEE=$(printf '%s' "$CLAIM_JSON" | jq -r '.assignee')
+CLAIM_ROUTE=$(printf '%s' "$CLAIM_JSON" | jq -r '.route // empty')
+if ! claim_identity_matches "$CLAIM_ASSIGNEE"; then
+  claim_infra_failure "hook receipt for $WORK_ID names assignee=$CLAIM_ASSIGNEE, which is not this runtime identity"
+  exit 1
 fi
 
-# Post-claim ownership verification. The bead MUST be yours and in_progress
-# before you touch any code. A polecat NEVER works a bead it did not claim this
-# session. Distinguish a READ FAILURE (gc bd show non-zero / empty JSON —
-# transient) from a genuine MISMATCH (non-empty assignee that differs, or
-# status not in_progress). Retry the read before deciding; only a genuine
-# mismatch is CLAIM_REJECTED.
-STATUS=""
-ASSIGNEE=""
-SHOW_JSON=""
-SHOW_OK=0
+case "$REASON" in
+  claimed|existing_assignment) EXPECTED_STATUS=in_progress ;;
+  ready_assignment) EXPECTED_STATUS=open ;;
+esac
+
+# Confirm the receipt through the normal work context before touching code.
+# This catches a selected-store/mutation mismatch without releasing or
+# reopening through an ambiguous context. Retry only the read projection, never
+# the hook claim itself.
+SHOW_CONFIRMED=false
+SHOW_JSON=
+STATUS=
+ASSIGNEE=
 SHOW_TRY=0
 while [ "$SHOW_TRY" -lt 3 ]; do
   SHOW_TRY=$((SHOW_TRY + 1))
-  SHOW_JSON="$(gc bd show "$WORK_ID" --json 2>/dev/null)"
+  SHOW_JSON=$(gc bd show "$WORK_ID" --json 2>/dev/null)
   SHOW_CODE=$?
-  STATUS="$(printf '%s' "$SHOW_JSON" | jq -r '.[0].status // empty' 2>/dev/null)"
-  ASSIGNEE="$(printf '%s' "$SHOW_JSON" | jq -r '.[0].assignee // empty' 2>/dev/null)"
-  if [ "$SHOW_CODE" -eq 0 ] && [ -n "$STATUS" ] && [ -n "$ASSIGNEE" ]; then
-    SHOW_OK=1
+  SHOW_ROW=$(printf '%s' "$SHOW_JSON" | jq -c --arg id "$WORK_ID" '
+      (if type == "array" then (.[0] // empty) else . end)
+      | select(.id == $id)
+    ' 2>/dev/null)
+  STATUS=$(printf '%s' "$SHOW_ROW" | jq -r '.status // empty' 2>/dev/null)
+  ASSIGNEE=$(printf '%s' "$SHOW_ROW" | jq -r '.assignee // empty' 2>/dev/null)
+  if [ "$SHOW_CODE" -eq 0 ] &&
+     [ "$STATUS" = "$EXPECTED_STATUS" ] &&
+     [ "$ASSIGNEE" = "$CLAIM_ASSIGNEE" ]; then
+    SHOW_CONFIRMED=true
     break
   fi
-  sleep 1
+  [ "$SHOW_TRY" -lt 3 ] && sleep 1
 done
-if [ "$SHOW_OK" -ne 1 ]; then
-  # Never leave a claimed bead stranded in_progress on an unreadable state:
-  # release it so it re-enters the pool instead of being lost.
-  echo "CLAIM_RELEASED $WORK_ID unreadable after retries; returning it to the pool"
-  gc bd update "$WORK_ID" --status=open --assignee=""
-  gc runtime drain-ack
-  exit 0
-fi
-if [ "$ASSIGNEE" != "$EXPECTED_ASSIGNEE" ] || [ "$STATUS" != "in_progress" ]; then
-  echo "CLAIM_REJECTED $WORK_ID assignee=$ASSIGNEE status=$STATUS (expected $EXPECTED_ASSIGNEE / in_progress)"
-  gc runtime drain-ack
-  exit 0
+
+if [ "$SHOW_CONFIRMED" != true ]; then
+  claim_infra_failure "$WORK_ID receipt reason=$REASON assignee=$CLAIM_ASSIGNEE but direct reads remained status=${STATUS:-unavailable} assignee=${ASSIGNEE:-unavailable}; expected $EXPECTED_STATUS/$CLAIM_ASSIGNEE"
+  exit 1
 fi
 
-# Ownership confirmed. Stamp a stable session identity so the churn-watcher and
-# the resume re-verify can key on metadata.polecat_session.
-gc bd update "$WORK_ID" --set-metadata polecat_session="$EXPECTED_ASSIGNEE" \
-  || echo "WARN metadata stamp failed for $WORK_ID; churn-watcher/resume lose session keying (proceeding — the claim is valid)"
+# Ownership is confirmed. This metadata is observability only; failure to stamp
+# it cannot invalidate the authoritative hook receipt plus direct read.
+gc bd update "$WORK_ID" --set-metadata polecat_session="$CLAIM_ASSIGNEE" \
+  || echo "WARN metadata stamp failed for $WORK_ID; claim remains valid"
 
 printf 'CLAIMED_BEAD_ID=%s\n' "$WORK_ID"
-printf '%s' "$SHOW_JSON" | jq '.[0].metadata'
+printf 'CLAIMED_REASON=%s\n' "$REASON"
+printf 'CLAIMED_ASSIGNEE=%s\n' "$CLAIM_ASSIGNEE"
+printf 'CLAIMED_ROUTE=%s\n' "$CLAIM_ROUTE"
+printf '%s' "$SHOW_ROW" | jq '.metadata // {}'
+# END POLECAT_CLAIM_CONTRACT
 GC_CLAIM
 ```
 
-If the block prints `NO_ROUTED_WORK`, `CLAIM_REJECTED`, or `CLAIM_RELEASED`, it
-has already drain-acked — stop and exit. Only after it prints `CLAIMED_BEAD_ID` do you read
-formula steps and begin. The claim checks assigned work first (session bead ID,
-runtime session name, then alias) and only falls through to unassigned pool work
-routed to `${GC_RIG:+$GC_RIG/}{{ .BindingPrefix }}polecat`.
+If the block prints `NO_ROUTED_WORK`, `CLAIM_DEFERRED`, or
+`STALE_SESSION_DRAINED`, the hook has already drain-acked — stop and exit
+without retrying. `claims_errored` is a deliberate core drain: a claim write
+failed and the work is reclaimed on a later controller tick; it is not a
+license for this stale snapshot to retry. If the block prints
+`CLAIM_INFRA_FAILURE`, it has escalated once and deliberately has not released,
+mutated, or manually drain-acked through an uncertain context — stop and exit
+nonzero. Only after it prints `CLAIMED_BEAD_ID` do you read formula steps and
+begin. The hook checks assigned work first (session bead ID, runtime session
+name, then alias) and only falls through to unassigned pool work routed to
+`${GC_RIG:+$GC_RIG/}{{ .BindingPrefix }}polecat`.
 
-**Resume / crash re-verify (FIRST action on restart).** Pool restarts mint a
-NEW session identity. If you wake into a session that context says was already
-mid-work on a claimed bead, your FIRST action — before touching code — is to
-re-check ownership against THIS session's identity:
-
-`$GC_BEAD_ID` is the convoy, not the work bead — derive the child work bead
-first (exactly as the done sequence does), then verify THAT bead's ownership:
-
-```bash
-EXPECTED_ASSIGNEE="${BEADS_ACTOR:-${GC_SESSION_NAME:-${GC_SESSION_ID:-${GC_AGENT:-}}}}"
-CONVOY_STATUS=$(gc convoy status "$GC_BEAD_ID" --json)
-WORK_BEAD_ID=$(printf '%s' "$CONVOY_STATUS" | jq -r 'if (.children | length) == 1 then .children[0].id else empty end')
-if [ -z "$WORK_BEAD_ID" ]; then
-  echo "RESUME_INDETERMINATE convoy $GC_BEAD_ID has no single child work bead; re-claim instead of guessing."
-  gc runtime drain-ack
-  exit 0
-fi
-WORK_JSON=$(gc bd show "$WORK_BEAD_ID" --json)
-ASSIGNEE=$(printf '%s' "$WORK_JSON" | jq -r '.[0].assignee // empty')
-SESSION_TAG=$(printf '%s' "$WORK_JSON" | jq -r '.[0].metadata.polecat_session // empty')
-if [ "$ASSIGNEE" != "$EXPECTED_ASSIGNEE" ] || { [ -n "$SESSION_TAG" ] && [ "$SESSION_TAG" != "$EXPECTED_ASSIGNEE" ]; }; then
-  echo "OWNERSHIP_LOST $WORK_BEAD_ID assignee=$ASSIGNEE session=$SESSION_TAG, not $EXPECTED_ASSIGNEE. Stopping."
-  gc runtime drain-ack
-  exit 0
-fi
-```
-
-If ownership was lost, another agent owns the work now — STOP and drain. Do not
-race it.
+**Restart / resume:** Pool restarts mint a new session identity. After prompt
+restoration, run the same complete Startup Protocol claim block above as the
+first operational action. Do not substitute a separate convoy lookup, metadata
+read, or manual ownership probe. An `existing_assignment` or `ready_assignment`
+receipt already checks the hook assignee against `BEADS_ACTOR`,
+`GC_SESSION_NAME`, `GC_SESSION_ID`, `GC_ALIAS`, and `GC_AGENT`, then confirms
+the exact bead status and assignee through a direct read.
+Only after `CLAIMED_BEAD_ID` may you re-read formula steps, enter the validated
+workspace, inspect source state, and resume.
 
 **Claim -> verify ownership -> read formula steps -> follow in order -> claim next step or drain.**
 
@@ -292,7 +340,9 @@ If your context is filling up during long implementation:
 gc runtime request-restart
 ```
 This blocks until the controller kills your session. The new session
-re-reads formula steps and resumes from context.
+restores this prompt if necessary, then runs the complete Startup Protocol
+claim block as its first operational action. Only after `CLAIMED_BEAD_ID` does
+it re-read formula steps and resume from context.
 
 For lighter handoffs (e.g., waiting for external input):
 ```bash

--- a/gastown/agents/polecat/prompt.template.md
+++ b/gastown/agents/polecat/prompt.template.md
@@ -160,7 +160,8 @@ show metadata, load skills, or run any other operational Bash until it prints
 `in_progress`; `existing_assignment` resumes work already `in_progress`; and
 `ready_assignment` adopts work that is legitimately still `open` but already
 assigned to this session. These are distinct supported hook outcomes — do not
-rewrite one into another.
+rewrite one into another. Execute the block verbatim: do not retype, shorten,
+or simplify its jq receipt validator.
 
 ```bash
 bash <<'GC_CLAIM'
@@ -211,6 +212,9 @@ fi
 # Validate the complete schema-v1 action/reason matrix before trusting fields.
 # A successful empty result, an unknown reason, or a work result without a
 # receipt is malformed infrastructure output — never ordinary idleness.
+# Keep the receipt bound as $r: inside `allowed | index(...)`, jq's `.` is the
+# allowed-reasons array. `index(.reason)` would therefore reject every valid
+# receipt instead of reading its reason.
 if ! printf '%s' "$CLAIM_JSON" | jq -e '
     . as $r
     | type == "object"

--- a/gastown/template-fragments/following-mol.template.md
+++ b/gastown/template-fragments/following-mol.template.md
@@ -8,8 +8,13 @@ Read the step descriptions and work through them in order.
 **THE RULE**: Execute one step at a time. Verify completion. Move to next.
 Do NOT skip ahead. Do NOT claim steps done without actually doing them.
 
-On crash or restart, re-read your formula steps and determine where you
-left off from context (last completed action, git state, bead state).
+On crash or restart, first re-establish the role's current assignment through
+its role-specific startup protocol. A polecat runs the Startup Protocol's
+complete `POLECAT_CLAIM_CONTRACT` as its first operational action and waits for
+`CLAIMED_BEAD_ID`; it does not read formula steps or inspect workspace,
+metadata, or source state first. After assignment and ownership are confirmed,
+re-read your formula steps and determine where you left off from context (last
+completed action, git state, bead state).
 
 **Never use wide filesystem searches when a CLI command exists.** Wide
 traversals (`find /`, `find ~`, `find /Users`, `find $HOME`) walk

--- a/gastown/tests/test_gastown_pack_assets.sh
+++ b/gastown/tests/test_gastown_pack_assets.sh
@@ -130,16 +130,39 @@ test_composition_is_documented() {
         fail "pack.toml should not reference the retired maintenance pack import"
 }
 
-test_polecat_startup_uses_standard_hook_claim() {
-    local agent prompt propulsion
+test_polecat_startup_uses_scripted_hook_claim() {
+    local agent prompt propulsion following restart
     agent="$GASTOWN/agents/polecat/agent.toml"
     prompt="$GASTOWN/agents/polecat/prompt.template.md"
     propulsion="$GASTOWN/template-fragments/propulsion.template.md"
+    following="$GASTOWN/template-fragments/following-mol.template.md"
+    restart=$(sed -n '/^\*\*Restart \/ resume:\*\*/,/^\*\*Claim ->/p' "$prompt")
 
-    grep -F 'gc hook --claim --json' "$agent" >/dev/null ||
-        fail "polecat nudge should call the standard hook claim path"
-    grep -F 'gc hook --claim --json' "$prompt" >/dev/null ||
-        fail "polecat prompt should call the standard hook claim path"
+    grep -F 'POLECAT_CLAIM_CONTRACT' "$agent" >/dev/null ||
+        fail "polecat nudge should enter the complete scripted claim contract"
+    grep -F 'first operational action' "$agent" >/dev/null ||
+        fail "polecat nudge should make the complete contract the first operational action"
+    grep -F 'CLAIMED_BEAD_ID' "$agent" >/dev/null ||
+        fail "polecat nudge should gate continuation on a claim receipt"
+    ! grep -F 'gc hook --claim' "$agent" >/dev/null ||
+        fail "polecat nudge must not bypass the scripted startup contract"
+    grep -F 'gc hook --claim --drain-ack --json' "$prompt" >/dev/null ||
+        fail "polecat prompt should use the transactional startup claim path"
+    grep -F '`{{ cmd }} prime` may reload this prompt only' "$prompt" >/dev/null ||
+        fail "prime recovery should be context restoration only"
+    grep -F 'Only after `CLAIMED_BEAD_ID` may you re-read formula steps' "$prompt" >/dev/null ||
+        fail "polecat restart should gate formula/workspace access on the claim receipt"
+    ! grep -F 'FIRST action on restart' "$prompt" >/dev/null ||
+        fail "polecat prompt should not retain a competing manual first action"
+    [[ "$restart" != *'CONVOY_STATUS=$(gc convoy status'* ]] ||
+        fail "polecat prompt should not retain a manual resume bypass"
+    grep -F 'complete `POLECAT_CLAIM_CONTRACT` as its first operational action' \
+        "$following" >/dev/null ||
+        fail "shared restart guidance should preserve the polecat claim-first gate"
+    grep -F '`CLAIMED_BEAD_ID`' "$following" >/dev/null ||
+        fail "shared restart guidance should wait for the polecat claim receipt"
+    ! grep -F 'On crash or restart, re-read your formula steps' "$following" >/dev/null ||
+        fail "shared restart guidance should not read formulas before polecat claim"
     grep -F 'gc hook --claim --json' "$propulsion" >/dev/null ||
         fail "polecat propulsion fragment should call the standard hook claim path"
     grep -F 'After closing any formula step bead, immediately run' "$prompt" >/dev/null ||
@@ -221,7 +244,7 @@ test_retired_dog_formulas_are_not_reintroduced
 test_shutdown_dance_contracts_are_executable
 test_shutdown_dance_lifecycle_and_audit_contracts
 test_composition_is_documented
-test_polecat_startup_uses_standard_hook_claim
+test_polecat_startup_uses_scripted_hook_claim
 test_review_leg_contract_forbids_synthetic_mutation
 test_refinery_direct_merge_is_worktree_safe_and_fail_closed
 

--- a/gastown/tests/test_polecat_claim_contract.sh
+++ b/gastown/tests/test_polecat_claim_contract.sh
@@ -145,6 +145,12 @@ test_structural_contract() {
     setup_case
     grep -q 'gc hook --claim --drain-ack --json' "$CONTRACT" ||
         fail "claim must request transactional drain acknowledgement"
+    grep -qF '. as $r' "$CONTRACT" ||
+        fail "claim validator must bind the schema-v1 receipt root"
+    grep -qF 'index($r.reason)' "$CONTRACT" ||
+        fail "claim validator must read reason from the bound receipt root"
+    ! grep -Eq '^[[:space:]]+and .*index\(\.reason\)' "$CONTRACT" ||
+        fail "claim validator reads reason from the piped allowed-values array"
     ! grep -q 'gc runtime drain-ack' "$CONTRACT" ||
         fail "contract must not manually acknowledge a structured drain"
     ! grep -q -- '--status=open --assignee=""' "$CONTRACT" ||
@@ -154,6 +160,35 @@ test_structural_contract() {
         grep -q "\"$reason\"" "$CONTRACT" ||
             fail "schema-v1 reason $reason is absent from the contract"
     done
+}
+
+test_receipt_root_reason_membership_regression() {
+    local drain_fixture work_fixture rc
+
+    # `index()` runs with the allowed-values array as jq's current input.
+    # These valid work and drain receipts both fail if the validator is
+    # shortened from `index($r.reason)` to `index(.reason)`.
+    drain_fixture='{"schema_version":"1","ok":true,"command":"hook","action":"drain","reason":"no_work","drain_acknowledged":true}'
+    setup_case
+    rc=$(run_contract "$drain_fixture")
+    [[ "$rc" == "0" ]] || fail "schema-v1 drain receipt root exited $rc"
+    grep -q 'NO_ROUTED_WORK reason=no_work' "$OUT" ||
+        fail "schema-v1 drain receipt root was rejected"
+    [[ "$(count_calls "CALL:hook:--claim --drain-ack --json")" == "1" ]] ||
+        fail "schema-v1 drain receipt retried the hook"
+    [[ "$(count_calls "CALL:mail:send")" == "0" ]] ||
+        fail "schema-v1 drain receipt produced a false escalation"
+
+    work_fixture='{"schema_version":"1","ok":true,"command":"hook","action":"work","reason":"existing_assignment","bead_id":"ki-work","assignee":"rig/gastown.polecat-1","route":"rig/gastown.polecat"}'
+    setup_case
+    rc=$(run_contract "$work_fixture" 0 "$(show_json in_progress)")
+    [[ "$rc" == "0" ]] || fail "schema-v1 work receipt root exited $rc"
+    grep -q 'CLAIMED_BEAD_ID=ki-work' "$OUT" ||
+        fail "schema-v1 work receipt root was rejected"
+    grep -q 'CLAIMED_REASON=existing_assignment' "$OUT" ||
+        fail "schema-v1 work receipt reason was not preserved"
+    [[ "$(count_calls "CALL:mail:send")" == "0" ]] ||
+        fail "schema-v1 work receipt produced a false escalation"
 }
 
 test_fresh_session_enters_the_scripted_contract() {
@@ -177,6 +212,10 @@ with open(sys.argv[1], "rb") as handle:
     [[ "$nudge" == *"formula, workspace, metadata, or source"* ]] ||
         fail "fresh-session nudge does not gate formula/workspace/source access"
 
+    grep -qF 'Execute the block verbatim: do not retype, shorten,' "$PROMPT" ||
+        fail "startup guidance permits rewriting the claim validator"
+    grep -qF 'or simplify its jq receipt validator.' "$PROMPT" ||
+        fail "startup guidance does not protect the receipt-root predicate"
     grep -qF \
         '**After the Startup Protocol prints `CLAIMED_BEAD_ID`: read your formula' \
         "$PROMPT" ||
@@ -369,6 +408,7 @@ test_observability_stamp_is_best_effort() {
 }
 
 test_structural_contract
+test_receipt_root_reason_membership_regression
 test_fresh_session_enters_the_scripted_contract
 test_all_structured_drains_are_terminal
 test_complete_work_reason_status_matrix

--- a/gastown/tests/test_polecat_claim_contract.sh
+++ b/gastown/tests/test_polecat_claim_contract.sh
@@ -1,0 +1,382 @@
+#!/usr/bin/env bash
+# Execute the polecat startup claim contract against the complete schema-v1
+# action/reason matrix from Gas City's schemas/hook/result.schema.json.
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+PROMPT="$ROOT/gastown/agents/polecat/prompt.template.md"
+AGENT_TOML="$ROOT/gastown/agents/polecat/agent.toml"
+FOLLOWING_MOL="$ROOT/gastown/template-fragments/following-mol.template.md"
+TMP_ROOT=$(mktemp -d)
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+count_calls() {
+    local pattern=$1
+    awk -v pattern="$pattern" 'index($0, pattern) == 1 { count++ } END { print count + 0 }' "$GC_CALLS"
+}
+
+extract_contract() {
+    sed -n '/# BEGIN POLECAT_CLAIM_CONTRACT/,/# END POLECAT_CLAIM_CONTRACT/p' \
+        "$PROMPT" >"$CONTRACT"
+    [[ -s "$CONTRACT" ]] || fail "POLECAT_CLAIM_CONTRACT region not found"
+    bash -n "$CONTRACT" || fail "claim contract is not valid Bash"
+    [[ "$(grep -c '# BEGIN POLECAT_CLAIM_CONTRACT' "$PROMPT")" == "1" ]] ||
+        fail "claim contract must appear exactly once"
+}
+
+write_stubs() {
+    mkdir -p "$BIN"
+    cat >"$BIN/gc" <<'SH'
+#!/usr/bin/env bash
+noun="${1:-}"
+verb="${2:-}"
+{
+    printf 'CALL:%s:%s' "$noun" "$verb"
+    for arg in "${@:3}"; do printf ' %s' "$arg"; done
+    printf '\n'
+} >>"$GC_CALLS"
+case "$noun:$verb" in
+    "hook:--claim")
+        printf '%s' "${HOOK_JSON:-}"
+        exit "${HOOK_CODE:-0}"
+        ;;
+    "bd:show")
+        printf '%s' "${GC_STUB_SHOW_JSON:-}"
+        exit "${GC_STUB_SHOW_CODE:-0}"
+        ;;
+    "bd:update")
+        exit "${UPDATE_CODE:-0}"
+        ;;
+    "mail:send")
+        exit 0
+        ;;
+    "runtime:drain-ack")
+        exit 0
+        ;;
+esac
+exit 64
+SH
+    cat >"$BIN/sleep" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+    chmod +x "$BIN/gc" "$BIN/sleep"
+}
+
+setup_case() {
+    CASE_DIR=$(mktemp -d "$TMP_ROOT/case.XXXXXX")
+    BIN="$CASE_DIR/bin"
+    GC_CALLS="$CASE_DIR/calls"
+    CONTRACT="$CASE_DIR/contract.sh"
+    OUT="$CASE_DIR/out"
+    : >"$GC_CALLS"
+    write_stubs
+    extract_contract
+}
+
+run_contract_as() {
+    local identity_field=$1 identity_value=$2 hook_json=$3
+    local hook_code=${4:-0} show_json=${5:-'[]'}
+    local show_code=${6:-0} update_code=${7:-0} rc=0
+    local beads_actor="" session_name="" session_id="" alias="" agent=""
+    case "$identity_field" in
+        BEADS_ACTOR) beads_actor=$identity_value ;;
+        GC_SESSION_NAME) session_name=$identity_value ;;
+        GC_SESSION_ID) session_id=$identity_value ;;
+        GC_ALIAS) alias=$identity_value ;;
+        GC_AGENT) agent=$identity_value ;;
+        *) fail "unsupported identity field in test: $identity_field" ;;
+    esac
+    HOOK_JSON="$hook_json" HOOK_CODE="$hook_code" \
+        GC_STUB_SHOW_JSON="$show_json" GC_STUB_SHOW_CODE="$show_code" \
+        UPDATE_CODE="$update_code" \
+        GC_CALLS="$GC_CALLS" PATH="$BIN:$PATH" \
+        BEADS_ACTOR="$beads_actor" GC_SESSION_NAME="$session_name" \
+        GC_SESSION_ID="$session_id" GC_ALIAS="$alias" GC_AGENT="$agent" \
+        bash "$CONTRACT" >"$OUT" 2>&1 || rc=$?
+    echo "$rc"
+}
+
+run_contract() {
+    run_contract_as BEADS_ACTOR "rig/gastown.polecat-1" "$@"
+}
+
+drain_json() {
+    jq -cn --arg reason "$1" \
+        '{schema_version:"1",ok:true,command:"hook",action:"drain",
+          reason:$reason,drain_acknowledged:true}'
+}
+
+work_json() {
+    jq -cn --arg reason "$1" --arg assignee "${2:-rig/gastown.polecat-1}" \
+        --arg route "${3:-rig/gastown.polecat}" \
+        '{schema_version:"1",ok:true,command:"hook",action:"work",
+          reason:$reason,bead_id:"ki-work",assignee:$assignee,
+          route:$route}
+         | if $route == "__omit" then del(.route) else . end'
+}
+
+show_json() {
+    jq -cn --arg status "$1" --arg assignee "${2:-rig/gastown.polecat-1}" \
+        '[{id:"ki-work",status:$status,assignee:$assignee,
+           metadata:{"gc.routed_to":"rig/gastown.polecat"}}]'
+}
+
+assert_fail_closed_without_mutation() {
+    local context=$1
+    [[ "$(count_calls "CALL:mail:send")" == "1" ]] ||
+        fail "$context: expected exactly one witness escalation"
+    [[ "$(count_calls "CALL:bd:update")" == "0" ]] ||
+        fail "$context: mutated the bead"
+    [[ "$(count_calls "CALL:runtime:drain-ack")" == "0" ]] ||
+        fail "$context: manually drain-acked an uncertain result"
+    ! grep -q 'CLAIMED_BEAD_ID=' "$OUT" ||
+        fail "$context: emitted a work receipt"
+    grep -q 'CLAIM_INFRA_FAILURE' "$OUT" ||
+        fail "$context: did not surface CLAIM_INFRA_FAILURE"
+}
+
+test_structural_contract() {
+    setup_case
+    grep -q 'gc hook --claim --drain-ack --json' "$CONTRACT" ||
+        fail "claim must request transactional drain acknowledgement"
+    ! grep -q 'gc runtime drain-ack' "$CONTRACT" ||
+        fail "contract must not manually acknowledge a structured drain"
+    ! grep -q -- '--status=open --assignee=""' "$CONTRACT" ||
+        fail "contract must not release through an unconfirmed store context"
+    for reason in claimed existing_assignment ready_assignment \
+                  no_work claims_errored stale_session; do
+        grep -q "\"$reason\"" "$CONTRACT" ||
+            fail "schema-v1 reason $reason is absent from the contract"
+    done
+}
+
+test_fresh_session_enters_the_scripted_contract() {
+    local nudge restart
+    nudge=$(python3 -c '
+import sys
+import tomllib
+with open(sys.argv[1], "rb") as handle:
+    print(tomllib.load(handle)["nudge"])
+' "$AGENT_TOML")
+    [[ "$nudge" == *"Startup Protocol"* ]] ||
+        fail "fresh-session nudge does not enter the Startup Protocol"
+    [[ "$nudge" == *"POLECAT_CLAIM_CONTRACT"* ]] ||
+        fail "fresh-session nudge does not name the complete scripted contract"
+    [[ "$nudge" == *"first operational action"* ]] ||
+        fail "fresh-session nudge does not make the claim contract the first operational action"
+    [[ "$nudge" == *"CLAIMED_BEAD_ID"* ]] ||
+        fail "fresh-session nudge does not gate continuation on a work receipt"
+    [[ "$nudge" != *"gc hook --claim"* ]] ||
+        fail "fresh-session nudge still invites a raw claim-hook bypass"
+    [[ "$nudge" == *"formula, workspace, metadata, or source"* ]] ||
+        fail "fresh-session nudge does not gate formula/workspace/source access"
+
+    grep -qF \
+        '**After the Startup Protocol prints `CLAIMED_BEAD_ID`: read your formula' \
+        "$PROMPT" ||
+        fail "work protocol does not place recipe reading after confirmed claim"
+    grep -qF 'The scripted claim block is always the first operational action.' "$PROMPT" ||
+        fail "work protocol does not make the scripted claim block first"
+    ! grep -qF '**FIRST: Read your formula steps.**' "$PROMPT" ||
+        fail "prompt still tells a fresh polecat to read formula steps before claiming"
+    grep -qF '`{{ cmd }} prime` may reload this prompt only' "$PROMPT" ||
+        fail "prime recovery is not limited to prompt restoration"
+    grep -qF 'After prompt restoration, run the Startup Protocol' "$PROMPT" ||
+        fail "prime/new-session recovery does not return to the startup contract"
+    grep -qF '**Restart / resume:**' "$PROMPT" ||
+        fail "restart guidance is missing"
+    restart=$(sed -n '/^\*\*Restart \/ resume:\*\*/,/^\*\*Claim ->/p' "$PROMPT")
+    [[ -n "$restart" ]] ||
+        fail "could not extract restart guidance"
+    grep -qF 'Do not substitute a separate convoy lookup, metadata' "$PROMPT" ||
+        fail "restart guidance still permits a competing ownership path"
+    grep -qF 'Only after `CLAIMED_BEAD_ID` may you re-read formula steps' "$PROMPT" ||
+        fail "restart guidance does not gate formula/workspace/source access"
+    ! grep -qF 'FIRST action on restart' "$PROMPT" ||
+        fail "manual restart verification still competes as a first action"
+    [[ "$restart" != *'CONVOY_STATUS=$(gc convoy status'* ]] ||
+        fail "manual convoy resume path still bypasses the startup contract"
+    ! grep -qF 'The new session re-reads formula steps' "$PROMPT" ||
+        fail "context-restart guidance still reads formula steps before claiming"
+    grep -qF 'your first operational action is the' "$PROMPT" ||
+        fail "startup protocol does not account for prompt-only restoration"
+
+    grep -qF 'complete `POLECAT_CLAIM_CONTRACT` as its first operational action' \
+        "$FOLLOWING_MOL" ||
+        fail "shared restart guidance does not route polecats through the complete claim contract"
+    grep -qF 'waits for' "$FOLLOWING_MOL" &&
+        grep -qF '`CLAIMED_BEAD_ID`' "$FOLLOWING_MOL" ||
+        fail "shared restart guidance does not wait for a claim receipt"
+    ! grep -qF 'On crash or restart, re-read your formula steps' "$FOLLOWING_MOL" ||
+        fail "shared restart guidance still sends polecats to formula steps first"
+}
+
+test_all_structured_drains_are_terminal() {
+    local reason marker rc
+    while read -r reason marker; do
+        setup_case
+        rc=$(run_contract "$(drain_json "$reason")")
+        [[ "$rc" == "0" ]] || fail "$reason drain exited $rc"
+        grep -q "$marker" "$OUT" || fail "$reason drain omitted marker $marker"
+        [[ "$(count_calls "CALL:hook:--claim --drain-ack --json")" == "1" ]] ||
+            fail "$reason drain retried the hook"
+        [[ "$(count_calls "CALL:bd:show")" == "0" ]] ||
+            fail "$reason drain tried to read a bead"
+        [[ "$(count_calls "CALL:mail:send")" == "0" ]] ||
+            fail "$reason drain escalated an intentional terminal result"
+        [[ "$(count_calls "CALL:runtime:drain-ack")" == "0" ]] ||
+            fail "$reason drain manually acknowledged after the hook already did"
+    done <<'CASES'
+no_work NO_ROUTED_WORK
+claims_errored CLAIM_DEFERRED
+stale_session STALE_SESSION_DRAINED
+CASES
+}
+
+test_complete_work_reason_status_matrix() {
+    local reason status route rc
+    while read -r reason status route; do
+        setup_case
+        rc=$(run_contract "$(work_json "$reason" "rig/gastown.polecat-1" "$route")" \
+            0 "$(show_json "$status")")
+        [[ "$rc" == "0" ]] || fail "$reason/$status exited $rc: $(cat "$OUT")"
+        grep -q 'CLAIMED_BEAD_ID=ki-work' "$OUT" ||
+            fail "$reason/$status emitted no work receipt"
+        grep -q "CLAIMED_REASON=$reason" "$OUT" ||
+            fail "$reason/$status emitted the wrong reason"
+        [[ "$(count_calls "CALL:hook:--claim --drain-ack --json")" == "1" ]] ||
+            fail "$reason/$status called the hook more than once"
+        [[ "$(count_calls "CALL:bd:show")" == "1" ]] ||
+            fail "$reason/$status did not confirm through one direct read"
+        [[ "$(count_calls "CALL:bd:update")" == "1" ]] ||
+            fail "$reason/$status did not stamp observability metadata"
+        [[ "$(count_calls "CALL:mail:send")" == "0" ]] ||
+            fail "$reason/$status escalated valid work"
+    done <<'CASES'
+claimed in_progress rig/gastown.polecat
+existing_assignment in_progress __omit
+ready_assignment open __omit
+CASES
+}
+
+test_all_runtime_identity_fields_are_accepted() {
+    local field value rc
+    while read -r field value; do
+        setup_case
+        rc=$(run_contract_as "$field" "$value" \
+            "$(work_json ready_assignment "$value" __omit)" 0 \
+            "$(show_json open "$value")")
+        [[ "$rc" == "0" ]] ||
+            fail "$field-owned ready assignment exited $rc: $(cat "$OUT")"
+        grep -q "CLAIMED_ASSIGNEE=$value" "$OUT" ||
+            fail "$field-owned ready assignment was not accepted"
+    done <<'CASES'
+BEADS_ACTOR actor-1
+GC_SESSION_NAME session-name-1
+GC_SESSION_ID session-id-1
+GC_ALIAS alias-1
+GC_AGENT agent-1
+CASES
+}
+
+test_wrong_reason_status_pairs_fail_closed() {
+    local reason status rc
+    while read -r reason status; do
+        setup_case
+        rc=$(run_contract "$(work_json "$reason")" 0 "$(show_json "$status")")
+        [[ "$rc" == "1" ]] || fail "$reason/$status mismatch exited $rc"
+        [[ "$(count_calls "CALL:bd:show")" == "3" ]] ||
+            fail "$reason/$status mismatch did not bound direct-read retries at 3"
+        assert_fail_closed_without_mutation "$reason/$status mismatch"
+    done <<'CASES'
+claimed open
+existing_assignment open
+ready_assignment in_progress
+CASES
+}
+
+test_receipt_and_direct_assignee_mismatches_fail_closed() {
+    local rc
+
+    setup_case
+    rc=$(run_contract "$(work_json claimed other/polecat)" 0 \
+        "$(show_json in_progress other/polecat)")
+    [[ "$rc" == "1" ]] || fail "foreign receipt exited $rc"
+    [[ "$(count_calls "CALL:bd:show")" == "0" ]] ||
+        fail "foreign receipt was trusted enough to read work"
+    assert_fail_closed_without_mutation "foreign receipt"
+
+    setup_case
+    rc=$(run_contract "$(work_json claimed)" 0 \
+        "$(show_json in_progress other/polecat)")
+    [[ "$rc" == "1" ]] || fail "direct assignee mismatch exited $rc"
+    [[ "$(count_calls "CALL:bd:show")" == "3" ]] ||
+        fail "direct assignee mismatch did not bound retries at 3"
+    assert_fail_closed_without_mutation "direct assignee mismatch"
+}
+
+test_hook_errors_and_malformed_results_fail_closed_once() {
+    local name code payload rc
+    while IFS='|' read -r name code payload; do
+        setup_case
+        rc=$(run_contract "$payload" "$code")
+        [[ "$rc" == "1" ]] || fail "$name exited $rc"
+        [[ "$(count_calls "CALL:hook:--claim --drain-ack --json")" == "1" ]] ||
+            fail "$name retried the hook"
+        [[ "$(count_calls "CALL:bd:show")" == "0" ]] ||
+            fail "$name read a bead without a valid work receipt"
+        assert_fail_closed_without_mutation "$name"
+    done <<'CASES'
+nonzero|1|
+empty|0|
+not-json|0|not-json
+empty-object|0|{}
+wrong-schema|0|{"schema_version":1,"ok":true,"command":"hook","action":"drain","reason":"no_work","drain_acknowledged":true}
+unknown-reason|0|{"schema_version":"1","ok":true,"command":"hook","action":"drain","reason":"future","drain_acknowledged":true}
+unacknowledged-drain|0|{"schema_version":"1","ok":true,"command":"hook","action":"drain","reason":"no_work","drain_acknowledged":false}
+wrong-pair|0|{"schema_version":"1","ok":true,"command":"hook","action":"work","reason":"no_work","bead_id":"ki-work","assignee":"rig/gastown.polecat-1"}
+CASES
+}
+
+test_unreadable_direct_projection_is_never_released() {
+    setup_case
+    local rc
+    rc=$(run_contract "$(work_json claimed)" 0 '[]' 1)
+    [[ "$rc" == "1" ]] || fail "unreadable direct projection exited $rc"
+    [[ "$(count_calls "CALL:bd:show")" == "3" ]] ||
+        fail "unreadable projection did not retry exactly 3 times"
+    assert_fail_closed_without_mutation "unreadable direct projection"
+}
+
+test_observability_stamp_is_best_effort() {
+    setup_case
+    local rc
+    rc=$(run_contract "$(work_json existing_assignment)" 0 \
+        "$(show_json in_progress)" 0 1)
+    [[ "$rc" == "0" ]] || fail "metadata stamp failure invalidated confirmed work"
+    grep -q 'WARN metadata stamp failed' "$OUT" ||
+        fail "metadata stamp failure was not reported"
+    grep -q 'CLAIMED_BEAD_ID=ki-work' "$OUT" ||
+        fail "confirmed work was hidden after metadata stamp failure"
+    [[ "$(count_calls "CALL:mail:send")" == "0" ]] ||
+        fail "best-effort observability failure escalated the claim"
+}
+
+test_structural_contract
+test_fresh_session_enters_the_scripted_contract
+test_all_structured_drains_are_terminal
+test_complete_work_reason_status_matrix
+test_all_runtime_identity_fields_are_accepted
+test_wrong_reason_status_pairs_fail_closed
+test_receipt_and_direct_assignee_mismatches_fail_closed
+test_hook_errors_and_malformed_results_fail_closed_once
+test_unreadable_direct_projection_is_never_released
+test_observability_stamp_is_best_effort
+
+echo "polecat claim contract tests passed"

--- a/gastown/tests/test_polecat_claim_contract.sh
+++ b/gastown/tests/test_polecat_claim_contract.sh
@@ -300,7 +300,7 @@ test_complete_work_reason_status_matrix() {
     done <<'CASES'
 claimed in_progress rig/gastown.polecat
 existing_assignment in_progress __omit
-ready_assignment open __omit
+ready_assignment in_progress __omit
 CASES
 }
 
@@ -310,7 +310,7 @@ test_all_runtime_identity_fields_are_accepted() {
         setup_case
         rc=$(run_contract_as "$field" "$value" \
             "$(work_json ready_assignment "$value" __omit)" 0 \
-            "$(show_json open "$value")")
+            "$(show_json in_progress "$value")")
         [[ "$rc" == "0" ]] ||
             fail "$field-owned ready assignment exited $rc: $(cat "$OUT")"
         grep -q "CLAIMED_ASSIGNEE=$value" "$OUT" ||
@@ -336,7 +336,7 @@ test_wrong_reason_status_pairs_fail_closed() {
     done <<'CASES'
 claimed open
 existing_assignment open
-ready_assignment in_progress
+ready_assignment open
 CASES
 }
 


### PR DESCRIPTION
Replaces #222 with a wrapper that follows the schema-v1
`gc hook --claim --drain-ack --json` contract.

Validated candidate: `bbb4a6e697eb0a8cddb7a2096fa32677350b6a87`.

## Dependency and merge order

This head requires
[gastownhall/gascity#4835](https://github.com/gastownhall/gascity/pull/4835)
to land first. Core #4835 atomically promotes an already-assigned ready bead to
`in_progress` using its exact current assignee before returning the
`ready_assignment` receipt. Deploying this pack change on older core fails
closed, but would reject valid ready assignments and can create startup
escalation churn.

This PR also overlaps the polecat prompt changed by Packs #244. Whichever lands
second must merge current `main` normally and retain both contracts: #244's
canonical `artifact_dir` ownership and this PR's one-shot claim wrapper.

## Problem

The existing polecat startup prompt adds retry, release, and manual-drain logic
around a stateful claim hook. That behavior can:

- repeat a claim after an uncertain response;
- release work through an ambiguous store context;
- mishandle a structured terminal drain;
- trust a locally selected identity instead of the receipt's exact assignee;
  and
- let fresh-session and restart guidance enter different ownership paths.

The fresh-session nudge also invokes the raw hook directly, bypassing the
prompt's validation.

## Change

The startup block now:

- calls `gc hook --claim --drain-ack --json` exactly once;
- validates the complete schema-v1 action/reason matrix;
- accepts `claimed`, `existing_assignment`, and post-#4835
  `ready_assignment` only when a direct read confirms `in_progress` under the
  receipt's exact assignee;
- checks that assignee against the bounded runtime identity set;
- treats `no_work`, `claims_errored`, and `stale_session` as terminal
  acknowledged drains;
- retries only the confirmation read, never the stateful hook;
- never reopens, releases, or manually drain-acks after an uncertain result;
- keeps the session metadata stamp best-effort after authoritative ownership
  is confirmed; and
- routes fresh-session, prompt restoration, and restart guidance through this
  same block before formula, workspace, metadata, mail, or source access.

The receipt is bound once as `$r`; the jq membership checks deliberately use
`index($r.reason)`. Retyping that as `index(.reason)` changes jq's input and
rejects valid receipts, so the shipped block and tests protect the exact
predicate.

## Regression coverage

`gastown/tests/test_polecat_claim_contract.sh` executes the shipped prompt
block and covers:

- every work and drain reason/status pair;
- all supported runtime identity fields and exact-assignee readback;
- malformed, empty, unknown, and nonzero hook results;
- foreign/mismatched assignees and unreadable direct projections;
- exactly one stateful hook call;
- no uncertain release or manual drain acknowledgement;
- best-effort observability metadata; and
- fresh-session/restart instruction ordering.

## Validation

- all five Gastown shell suites
- `1,182 passed, 8 skipped, 9,412 subtests passed`
- `python3 validate_registry.py --require-git`
- `gc lint gastown`
- `go test ./...`
- `go vet ./...`
- Bash syntax over tracked shell scripts
- parsed all 307 tracked TOML files
- `git diff --check`
- independent exact-diff review: SHIP, no high/medium findings

ShellCheck was unavailable in this local environment.
