### PR TITLE
fix(gastown): dispatch witness heartbeat through pack command

### DIFF
--- a/gastown/commands/witness-heartbeat-check/help.md
+++ b/gastown/commands/witness-heartbeat-check/help.md
@@ -1,0 +1,12 @@
+# gc gastown witness-heartbeat-check
+
+Measure heartbeat freshness for every running or sleeping Gastown witness.
+
+The command is read-only. It prints one TSV row per checked witness and exits
+with:
+
+- `0` when every checked witness is fresh (or none are eligible)
+- `1` when it finds a stalled witness or a witness with no usable heartbeat
+- `2` when configuration or session-roster errors prevent measurement
+
+Set `GASTOWN_WITNESS_STALE_MIN` to override the default 90-minute window.

--- a/gastown/commands/witness-heartbeat-check/run.sh
+++ b/gastown/commands/witness-heartbeat-check/run.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -eu
+
+if [ -z "${GC_PACK_DIR:-}" ]; then
+    echo "gc gastown witness-heartbeat-check: missing Gas City pack context" >&2
+    exit 2
+fi
+
+exec "$GC_PACK_DIR/assets/scripts/witness-heartbeat-check.sh" "$@"

--- a/gastown/formulas/mol-deacon-patrol.toml
+++ b/gastown/formulas/mol-deacon-patrol.toml
@@ -160,12 +160,8 @@ one signal that separates "idle and fine" from "the loop is gone", so it gets
 measured rather than judged.
 
 ```bash
-CHECK="${GC_PACK_DIR:-}/assets/scripts/witness-heartbeat-check.sh"
-if [ -x "$CHECK" ]; then
-  GASTOWN_WITNESS_STALE_MIN={{witness_stale_min}} bash "$CHECK"; echo "heartbeat check exit: $?"
-else
-  echo "witness-heartbeat-check.sh not resolvable under GC_PACK_DIR — use the judgment pass below only."
-fi
+GASTOWN_WITNESS_STALE_MIN={{witness_stale_min}} gc gastown witness-heartbeat-check
+echo "heartbeat check exit: $?"
 ```
 
 Exit 0 means every checked witness heartbeat is inside the window. Exit 1 means

--- a/gastown/tests/test_witness_heartbeat_check.sh
+++ b/gastown/tests/test_witness_heartbeat_check.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
 SCRIPT="$ROOT/gastown/assets/scripts/witness-heartbeat-check.sh"
+COMMAND="$ROOT/gastown/commands/witness-heartbeat-check/run.sh"
+FORMULA="$ROOT/gastown/formulas/mol-deacon-patrol.toml"
 
 fail() {
     echo "FAIL: $*" >&2
@@ -251,6 +253,54 @@ test_uses_no_bash4_only_constructs() {
         fail "the check must stay bash 3.2 compatible (the fleet includes macOS)"
 }
 
+test_formula_dispatches_via_pack_command_without_agent_pack_env() {
+    grep -Fqx 'GASTOWN_WITNESS_STALE_MIN={{witness_stale_min}} gc gastown witness-heartbeat-check' "$FORMULA" ||
+        fail "health-scan must invoke the heartbeat check through the gastown command namespace"
+    ! grep -Fq 'GC_PACK_DIR' "$FORMULA" ||
+        fail "agent formulas must not assume managed sessions receive GC_PACK_DIR"
+    [ -x "$COMMAND" ] ||
+        fail "the witness-heartbeat-check pack command must be executable"
+
+    local dispatch_bin="$tmp/dispatch-bin"
+    mkdir -p "$dispatch_bin"
+    cat >"$dispatch_bin/gc" <<'SH'
+#!/usr/bin/env sh
+case "$*" in
+    "gastown witness-heartbeat-check")
+        if [ -n "${GC_PACK_DIR:-}" ]; then
+            echo "agent unexpectedly inherited GC_PACK_DIR" >&2
+            exit 90
+        fi
+        GC_PACK_DIR="$GC_TEST_PACK_DIR"
+        export GC_PACK_DIR
+        exec "$GC_PACK_DIR/commands/witness-heartbeat-check/run.sh"
+        ;;
+    "session list --state=all --json")
+        cat "$GC_SESSIONS_JSON"
+        ;;
+    *)
+        echo "unexpected gc invocation: $*" >&2
+        exit 91
+        ;;
+esac
+SH
+    chmod +x "$dispatch_bin/gc"
+
+    printf '{"sessions":[{"id":"s1","name":"alpha/witness","rig":"alpha","template":"gastown.witness","state":"asleep","last_active":"%s","closed":false}]}' "$FRESH" >"$SESSIONS"
+    set +e
+    OUT=$(env -u GC_PACK_DIR GC_CITY="$CITY" GC_TEST_PACK_DIR="$ROOT/gastown" \
+        GC_SESSIONS_JSON="$SESSIONS" PATH="$dispatch_bin:$PATH" \
+        GASTOWN_WITNESS_STALE_MIN=90 gc gastown witness-heartbeat-check 2>"$ERRFILE")
+    RC=$?
+    set -e
+    ERR=$(cat "$ERRFILE")
+
+    [ "$RC" -eq 0 ] ||
+        fail "pack-command dispatch without agent GC_PACK_DIR must succeed, got $RC ($ERR)"
+    printf '%s' "$OUT" | grep -q '^fresh	alpha	alpha/witness	asleep	' ||
+        fail "pack-command dispatch should reach the heartbeat implementation, got: $OUT"
+}
+
 test_fresh_heartbeat_is_not_flagged
 test_stale_heartbeat_is_stalled
 test_zero_time_sentinel_is_no_heartbeat_not_stalled
@@ -270,5 +320,6 @@ test_unreadable_roster_fails_loud
 test_missing_city_fails_loud
 test_multiple_rigs_report_every_witness
 test_uses_no_bash4_only_constructs
+test_formula_dispatches_via_pack_command_without_agent_pack_env
 
 echo "witness heartbeat check tests passed"


### PR DESCRIPTION
## Failure mode

#237 added a deterministic witness-heartbeat pass to `mol-deacon-patrol`, but
the formula resolves its helper through `${GC_PACK_DIR:-}`. Gas City supplies
that variable while dispatching pack commands, orders, and doctor checks; it is
not part of a managed agent session's environment.

In a deacon session the path therefore becomes
`/assets/scripts/witness-heartbeat-check.sh`. The executable check fails its
existence guard, the formula falls back to the LLM judgment pass, and the
deterministic protection added by #237 never runs.

## Fix

- expose the existing read-only helper as
  `gc gastown witness-heartbeat-check`
- invoke that pack command from `health-scan`, letting Gas City's dispatcher
  supply the canonical city and pack context
- document the command's output and exit-code contract
- add a regression that starts with no `GC_PACK_DIR` in the agent environment
  and proves pack-command dispatch reaches the heartbeat implementation

The checker itself and its threshold/verdict behavior are unchanged.

## Validation

- `bash gastown/tests/test_witness_heartbeat_check.sh`
- all `gastown/tests/test_*.sh` suites
- `bash -n` on every Gastown shell script; `sh -n` on the new wrapper
- all 17 Gastown TOML files parse
- `python3 -m pytest tests contributing/tests gascity/tests discord/tests github/tests slack-full/tests slack-channel/tests pr-pipeline/tests profiler/tests -q`
  — 1170 passed, 8 skipped, 9412 subtests passed
- `go test .`
- real convention-discovered dispatch against Gas City main `bccc52f`, in an
  isolated city with both city- and rig-scoped Gastown imports, with
  `GC_PACK_DIR` explicitly removed from the caller environment
- `gc lint gastown` output is byte-identical to the base after path
  normalization: the same 35 pre-existing findings, no new finding
