### PR TITLE
fix(gastown): require durable artifact handoffs

### DIFF
--- a/gastown/agents/polecat/prompt.template.md
+++ b/gastown/agents/polecat/prompt.template.md
@@ -101,9 +101,13 @@ Work beads carry structured metadata for lifecycle tracking and handoff:
 
 **On branch-setup:** You record `artifact_dir` and `branch` immediately.
 This enables crash recovery — the witness can find and salvage your work.
-Legacy task `work_dir` metadata is migrated only after the workspace step
-validates that it is an existing `*/worktrees/<bead-id>` worktree in this rig;
-an agent/provider root cannot pass that exact task-worktree shape.
+Legacy task `work_dir` metadata is adopted only after the workspace step
+validates the exact historical path
+`$GC_CITY_PATH/.gc/worktrees/$GC_RIG/polecats/<provider>/worktrees/<bead-id>`
+in this rig repository. Adoption migrates the metadata key, not the physical
+directory: an in-flight legacy artifact remains provider-nested until its
+terminal handoff cleanup. New artifacts always use the exact canonical path;
+same-repository paths in another city, rig, or namespace are rejected.
 
 **On submission:** You update `branch` (may have changed after rebase),
 set `target`, then reassign to refinery. If `existing_pr` is present, leave

--- a/gastown/agents/polecat/prompt.template.md
+++ b/gastown/agents/polecat/prompt.template.md
@@ -22,8 +22,10 @@ beads or unrelated workflow beads.
 
 ## CRITICAL: Directory Discipline
 
-Your branch-setup step creates a git worktree and records it in `metadata.work_dir`
-on your work bead. Once created, **stay in your worktree.**
+Your branch-setup step creates a git worktree and records it in
+`metadata.artifact_dir` on your work bead. Once created, **stay in your
+worktree.** `gc.work_dir` is controller execution context, not the durable
+task-artifact key.
 
 - **ALL file edits** must be within your worktree directory
 - **NEVER edit files in** `{{ .RigRoot }}/` (shared rig repo) — polecats must stay in
@@ -31,7 +33,7 @@ on your work bead. Once created, **stay in your worktree.**
 
 The failure mode: You `cd` to the shared rig repo and edit files there. You bypass
 your isolated worktree, stomp on the canonical checkout, and break the recovery
-metadata that points back to `metadata.work_dir`.
+metadata that points back to `metadata.artifact_dir`.
 
 Stay in your worktree. Install deps there if needed (`npm install`). Commit and push from there.
 
@@ -85,15 +87,18 @@ Work beads carry structured metadata for lifecycle tracking and handoff:
 
 | Field | Set by | When | Description |
 |-------|--------|------|-------------|
-| `work_dir` | polecat (branch-setup) | Early | Absolute path to git worktree |
+| `artifact_dir` | polecat (branch-setup) | Early | Absolute path to the validated per-bead git worktree |
 | `branch` | polecat (branch-setup) | Early | Source branch name |
 | `target` | polecat (submit) | Late | Target branch (default: {{ .DefaultBranch }}) |
 | `existing_pr` | caller | Before dispatch | Existing PR URL to reuse instead of creating another PR |
 | `pr_url` | refinery | PR handoff | Canonical PR URL recorded after validation |
 | `rejection_reason` | refinery (on failure) | On reject | Why the merge was rejected |
 
-**On branch-setup:** You record `work_dir` and `branch` immediately.
+**On branch-setup:** You record `artifact_dir` and `branch` immediately.
 This enables crash recovery — the witness can find and salvage your work.
+Legacy task `work_dir` metadata is migrated only after the workspace step
+validates that it is an existing `*/worktrees/<bead-id>` worktree in this rig;
+an agent/provider root cannot pass that exact task-worktree shape.
 
 **On submission:** You update `branch` (may have changed after rebase),
 set `target`, then reassign to refinery. If `existing_pr` is present, leave

--- a/gastown/agents/polecat/prompt.template.md
+++ b/gastown/agents/polecat/prompt.template.md
@@ -30,6 +30,11 @@ task-artifact key.
 - **ALL file edits** must be within your worktree directory
 - **NEVER edit files in** `{{ .RigRoot }}/` (shared rig repo) — polecats must stay in
   their dedicated worktree, not the canonical repo checkout
+- A new task artifact has exactly this canonical shape:
+  `$GC_CITY_PATH/.gc/worktrees/$GC_RIG/artifacts/worktrees/<bead-id>`
+- **NEVER create a task worktree below the provider home**, including
+  `<provider-home>/worktrees/<bead-id>`. Provider homes are controller context
+  and may be pruned independently of task artifacts.
 
 The failure mode: You `cd` to the shared rig repo and edit files there. You bypass
 your isolated worktree, stomp on the canonical checkout, and break the recovery
@@ -53,7 +58,7 @@ has no valid merge target and the work is silently stranded.
 |---|---|
 | Branch name | `polecat/vg-1jp` |
 | Base | freshly-fetched `origin/<base_branch>` |
-| Worktree path | `<home>/worktrees/vg-1jp` |
+| Worktree path | `$GC_CITY_PATH/.gc/worktrees/$GC_RIG/artifacts/worktrees/vg-1jp` |
 | Push target | `origin/polecat/vg-1jp` |
 | `metadata.branch` | `polecat/vg-1jp` |
 
@@ -121,6 +126,15 @@ claim or current molecule identifies a different formula, such as
 
 **FIRST: Read your formula steps.** Do NOT use Claude's internal task tools.
 The formula step descriptions are your instructions — work through them in order.
+
+For default implementation work, read the recipe with this exact command:
+```bash
+gc bd formula show mol-polecat-work --rig "$GC_RIG"
+```
+Execute its `workspace-setup` step before reading or editing task source. Do not
+invent variants such as `gc formula step` or `gc formula show-step`. Do not search
+the filesystem for formula files. If the exact recipe command fails, drain and
+escalate instead of manually creating a worktree.
 
 **Formula continuation invariant:** A claimed bead can be one child step in a
 larger formula workflow. After closing any formula step bead, immediately run
@@ -254,9 +268,11 @@ GC_CLAIM
 
 If the block prints `NO_ROUTED_WORK`, `CLAIM_REJECTED`, or `CLAIM_RELEASED`, it
 has already drain-acked — stop and exit. Only after it prints `CLAIMED_BEAD_ID` do you read
-formula steps and begin. The claim checks assigned work first (session bead ID,
-runtime session name, then alias) and only falls through to unassigned pool work
-routed to `${GC_RIG:+$GC_RIG/}{{ .BindingPrefix }}polecat`.
+the recipe with `gc bd formula show mol-polecat-work --rig "$GC_RIG"` and run
+`workspace-setup` before inspecting task source. The claim checks assigned work
+first (session bead ID, runtime session name, then alias) and only falls through
+to unassigned pool work routed to
+`${GC_RIG:+$GC_RIG/}{{ .BindingPrefix }}polecat`.
 
 **Resume / crash re-verify (FIRST action on restart).** Pool restarts mint a
 NEW session identity. If you wake into a session that context says was already
@@ -448,6 +464,7 @@ is the "Idle Polecat heresy."
 |------------|----------------|
 | Signal work complete | Run the `mol-polecat-work` `submit-and-exit` step (its single source of truth); if already run, `gc runtime drain-ack` + exit |
 | Read formula steps | `gc bd show <wisp-id>` (shows formula ref) |
+| Read implementation recipe | `gc bd formula show mol-polecat-work --rig "$GC_RIG"` (NOT `find /`, `gc formula step`, or `gc formula show-step`) |
 | Escalate blocker | `WITNESS_TARGET="${GC_RIG:+$GC_RIG/}{{ .BindingPrefix }}witness"; gc mail send "$WITNESS_TARGET" -s "ESCALATION: desc [HIGH]" -m "..."` |
 | Context exhaustion | `gc runtime request-restart` |
 | Handoff to next session | `gc mail send -s "HANDOFF: ..." -m "..."` then `gc runtime drain-ack && exit` |

--- a/gastown/agents/witness/prompt.template.md
+++ b/gastown/agents/witness/prompt.template.md
@@ -24,7 +24,8 @@ Your job:
 **What you never do:**
 - Write code or fix bugs (polecats do that)
 - Manage processes (controller handles start/stop/restart/zombies)
-- Delete branches after merge (refinery does that)
+- Delete a successfully handed-off source branch; its exact remote ref is
+  retained as recovery evidence
 - Spawn or kill agents directly (file warrants for the dog pool)
 - Check gates or convoy completion (deacon handles town-wide coordination)
 
@@ -40,12 +41,16 @@ reuse polecat or refinery worktrees as your home.
 
 ```
 worktree -> (push) -> branch -> (merge) -> target branch
-   canonical         canonical            canonical
-   until push        until merge          forever
+   canonical         canonical input      canonical merged result
+   until push        exact ref retained   after merge
+                     for recovery
 ```
 
-Each transition moves where the canonical work lives. Once moved, the
-previous location is disposable. This chain drives all your recovery logic.
+Each transition moves where the canonical work lives. Once the exact branch is
+proven on origin, the local worktree is eligible for validated cleanup. After
+merge, the target is canonical, but the exact successfully handed-off source
+ref remains independent recovery evidence. Witness recovery never deletes it.
+This chain drives all your recovery logic.
 
 ## Work Flow (What You Monitor)
 
@@ -57,7 +62,8 @@ Pool (open, unassigned) -> Polecat (in_progress) -> Refinery (open, assigned) ->
 `metadata.branch` and `metadata.target` on work bead -> reassign to
 refinery -> drain-ack -> exit.
 
-**Refinery:** rebase -> test -> merge -> close bead -> delete branch.
+**Refinery:** rebase -> test -> merge -> close bead -> retire the local
+artifact while retaining the validated remote source ref for recovery.
 
 **Rejection:** refinery puts bead back in pool with `metadata.rejection_reason`.
 A new polecat picks it up, sees the existing branch and reason, and resumes.
@@ -96,12 +102,14 @@ city, rig, or namespace are unsafe. Do not infer artifact ownership from
 `gc.work_dir`; it is controller execution context. For each orphaned bead:
 
 1. **Branch on origin** (`metadata.branch` exists, verified on remote) ->
-   worktree disposable. Delete worktree, reset bead to pool.
+   the worktree is eligible for validated cleanup. Remove the worktree, reset
+   the bead to the pool, and retain the exact remote source ref.
 
 2. **Worktree exists, unpushed commits** ->
    commit any remaining uncommitted work (`git add -A && git commit`),
-   push branch to make it canonical. Update `metadata.branch`. Delete
-   worktree, reset bead.
+   push branch to make it canonical. Update `metadata.branch`. After fresh
+   validation, remove the clean worktree, reset the bead, and retain the exact
+   remote source ref.
 
 3. **Worktree exists, only uncommitted/untracked changes** ->
    same as above. All work is useful work — never discard.
@@ -332,7 +340,7 @@ gc mail send mayor/ -s "ESCALATION: Brief description [HIGH]" -m "Details"
 | Context exhaustion | `gc runtime request-restart` |
 | Recover orphaned bead | `gc workflow delete-source <id> --apply && gc workflow reopen-source <id>` |
 | Salvage worktree work | `git add -A && git commit && git push origin HEAD` |
-| Delete worktree | `git worktree remove <path> --force` |
+| Remove validated clean artifact | `git -C "$GC_RIG_ROOT" worktree remove "$WORKTREE"` (only after the formula's fresh ownership, path, SHA, remote-ref, and status checks) |
 | Set branch metadata | `gc bd update <id> --set-metadata branch=<name>` |
 | File stuck-agent warrant | `gc bd create --type=task --label=warrant --metadata '{"target":"<session>","reason":"<reason>","requester":"witness","gc.routed_to":"{{ .BindingPrefix }}dog"}'` |
 

--- a/gastown/agents/witness/prompt.template.md
+++ b/gastown/agents/witness/prompt.template.md
@@ -84,9 +84,13 @@ It is the source of truth for orphan classification. Resolve bead assignees by
 exact session identity from `gc session list --state=all --json` and session
 bead metadata; do not use template-pattern or fixed-prefix matching.
 
-**Recovery follows the canonical chain.** Read `metadata.work_dir` and
-`metadata.branch` from the bead — polecats record both early in
-branch-setup. For each orphaned bead:
+**Recovery follows the canonical chain.** Read `metadata.artifact_dir` and
+`metadata.branch` from the bead — polecats record both early in branch-setup.
+Only if `artifact_dir` is absent may you consider deprecated
+`metadata.work_dir`, and only after the patrol formula proves it is an existing
+exact `*/worktrees/<bead-id>` Git worktree in this rig. Do not infer artifact
+ownership from `gc.work_dir`; it is controller execution context. For each
+orphaned bead:
 
 1. **Branch on origin** (`metadata.branch` exists, verified on remote) ->
    worktree disposable. Delete worktree, reset bead to pool.

--- a/gastown/agents/witness/prompt.template.md
+++ b/gastown/agents/witness/prompt.template.md
@@ -88,9 +88,12 @@ bead metadata; do not use template-pattern or fixed-prefix matching.
 `metadata.branch` from the bead — polecats record both early in branch-setup.
 Only if `artifact_dir` is absent may you consider deprecated
 `metadata.work_dir`, and only after the patrol formula proves it is an existing
-exact `*/worktrees/<bead-id>` Git worktree in this rig. Do not infer artifact
-ownership from `gc.work_dir`; it is controller execution context. For each
-orphaned bead:
+exact
+`$GC_CITY_PATH/.gc/worktrees/$GC_RIG/polecats/<provider>/worktrees/<bead-id>`
+Git worktree in this rig. That is an in-place compatibility adoption, not a
+physical move; terminal cleanup retires it. Same-repository paths in another
+city, rig, or namespace are unsafe. Do not infer artifact ownership from
+`gc.work_dir`; it is controller execution context. For each orphaned bead:
 
 1. **Branch on origin** (`metadata.branch` exists, verified on remote) ->
    worktree disposable. Delete worktree, reset bead to pool.

--- a/gastown/assets/scripts/polecat-churn-watcher.sh
+++ b/gastown/assets/scripts/polecat-churn-watcher.sh
@@ -12,7 +12,7 @@
 #   a polecat mid-claim and silently recycled.
 #
 #   A normal refinery handoff is NOT churn: it leaves the bead open but
-#   assigned to the refinery (with work_dir still set), so requiring
+#   assigned to the refinery (normally with artifact_dir still set), so requiring
 #   assignee=="" excludes it. Detection keys on an EXACT
 #   metadata.polecat_session match, not a work_dir substring, so a path that
 #   merely contains a session name no longer false-positives. Beads must
@@ -84,7 +84,7 @@ printf "%s\n" "$current_pids" > "$STATE_FILE"
 # For each disappeared polecat session, check rig bd for a churned claim.
 # Churn = an OPEN + UNASSIGNED bead whose metadata.polecat_session EXACTLY
 # matches the dead session. Requiring assignee=="" excludes a normal refinery
-# handoff (open, assigned to refinery, work_dir still set). Exact-match on the
+# handoff (open, assigned to refinery, artifact_dir normally still set). Exact-match on the
 # recorded session identity avoids the old work_dir-substring false positives.
 ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 

--- a/gastown/assets/scripts/task-artifact-cleanup.sh
+++ b/gastown/assets/scripts/task-artifact-cleanup.sh
@@ -1,0 +1,241 @@
+#!/bin/sh
+# Idempotently retire a Gastown task artifact after a terminal handoff.
+#
+# Usage: task-artifact-cleanup.sh <work-bead-id>
+#
+# Required environment:
+#   GC_CITY_PATH  physical Gas City root
+#   GC_RIG        rig name
+#   GC_RIG_ROOT   canonical rig repository
+
+set -eu
+
+WORK=${1:-}
+if [ "$#" -ne 1 ] || [ -z "$WORK" ]; then
+    echo "usage: task-artifact-cleanup.sh <work-bead-id>" >&2
+    exit 2
+fi
+
+case "$WORK" in
+    "."|".."|*[!A-Za-z0-9._-]*)
+        echo "ARTIFACT_CLEANUP_BLOCKED unsafe work bead id: $WORK" >&2
+        exit 2
+        ;;
+esac
+
+if [ -z "${GC_CITY_PATH:-}" ] || [ -z "${GC_RIG:-}" ] ||
+   [ -z "${GC_RIG_ROOT:-}" ]; then
+    echo "ARTIFACT_CLEANUP_BLOCKED GC_CITY_PATH, GC_RIG, and GC_RIG_ROOT are required" >&2
+    exit 2
+fi
+case "$GC_RIG" in
+    "."|".."|*[!A-Za-z0-9._-]*)
+        echo "ARTIFACT_CLEANUP_BLOCKED unsafe rig name: $GC_RIG" >&2
+        exit 2
+        ;;
+esac
+
+for required_command in gc git jq; do
+    if ! command -v "$required_command" >/dev/null 2>&1; then
+        echo "ARTIFACT_CLEANUP_BLOCKED missing command: $required_command" >&2
+        exit 2
+    fi
+done
+
+CITY_ROOT=$(CDPATH= cd -- "$GC_CITY_PATH" 2>/dev/null && pwd -P) || {
+    echo "ARTIFACT_CLEANUP_BLOCKED city root is missing: $GC_CITY_PATH" >&2
+    exit 2
+}
+RIG_ROOT=$(CDPATH= cd -- "$GC_RIG_ROOT" 2>/dev/null && pwd -P) || {
+    echo "ARTIFACT_CLEANUP_BLOCKED rig root is missing: $GC_RIG_ROOT" >&2
+    exit 2
+}
+RIG_NAMESPACE="$CITY_ROOT/.gc/worktrees/$GC_RIG"
+RIG_NAMESPACE_REAL=$(CDPATH= cd -- "$RIG_NAMESPACE" 2>/dev/null && pwd -P) || {
+    echo "ARTIFACT_CLEANUP_BLOCKED rig worktree namespace is missing: $RIG_NAMESPACE" >&2
+    exit 2
+}
+if [ "$RIG_NAMESPACE_REAL" != "$RIG_NAMESPACE" ]; then
+    echo "ARTIFACT_CLEANUP_BLOCKED rig worktree namespace is redirected: $RIG_NAMESPACE" >&2
+    exit 2
+fi
+
+artifact_git_common_dir() {
+    repo_dir=$1
+    common_dir=$(git -C "$repo_dir" rev-parse \
+        --path-format=absolute --git-common-dir 2>/dev/null) || return 1
+    (CDPATH= cd -- "$common_dir" 2>/dev/null && pwd -P)
+}
+
+task_artifact_path_shape() {
+    shaped_candidate=$1
+    shaped_bead=$2
+    shaped_canonical="$RIG_NAMESPACE_REAL/artifacts/worktrees/$shaped_bead"
+    shaped_worktrees_parent=
+    shaped_provider_home=
+    shaped_provider_root=
+    shaped_provider_name=
+
+    [ "$(basename -- "$shaped_candidate")" = "$shaped_bead" ] || return 1
+    [ "$(basename -- "$(dirname -- "$shaped_candidate")")" = worktrees ] ||
+        return 1
+    if [ "$shaped_candidate" = "$shaped_canonical" ]; then
+        return 0
+    fi
+
+    shaped_worktrees_parent=$(dirname -- "$shaped_candidate")
+    shaped_provider_home=$(dirname -- "$shaped_worktrees_parent")
+    shaped_provider_root=$(dirname -- "$shaped_provider_home")
+    shaped_provider_name=$(basename -- "$shaped_provider_home")
+    [ "$shaped_provider_root" = "$RIG_NAMESPACE_REAL/polecats" ] || return 1
+    case "$shaped_provider_name" in
+        ""|"."|".."|*[!A-Za-z0-9._-]*) return 1 ;;
+    esac
+}
+
+validate_task_artifact() {
+    candidate=$1
+    bead_id=$2
+    candidate_real=
+    candidate_top=
+    candidate_common=
+    rig_common=
+
+    [ -n "$candidate" ] && [ -d "$candidate" ] || return 1
+    candidate_real=$(CDPATH= cd -- "$candidate" 2>/dev/null && pwd -P) ||
+        return 1
+    task_artifact_path_shape "$candidate_real" "$bead_id" || return 1
+
+    candidate_top=$(git -C "$candidate_real" rev-parse \
+        --show-toplevel 2>/dev/null) || return 1
+    candidate_top=$(CDPATH= cd -- "$candidate_top" 2>/dev/null && pwd -P) ||
+        return 1
+    [ "$candidate_top" = "$candidate_real" ] || return 1
+    candidate_common=$(artifact_git_common_dir "$candidate_real") || return 1
+    rig_common=$(artifact_git_common_dir "$RIG_ROOT") || return 1
+    [ "$candidate_common" = "$rig_common" ] || return 1
+
+    printf '%s\n' "$candidate_real"
+}
+
+bd_show_work() {
+    gc bd --rig "$GC_RIG" show "$WORK" --json
+}
+
+bd_update_work() {
+    gc bd --rig "$GC_RIG" update "$WORK" "$@"
+}
+
+record_cleanup_state() {
+    state=$1
+    bd_update_work --set-metadata artifact_cleanup_state="$state"
+}
+
+complete_without_path() {
+    bd_update_work \
+        --unset-metadata artifact_dir \
+        --unset-metadata work_dir \
+        --set-metadata artifact_cleanup_state=complete
+    echo "ARTIFACT_CLEANUP_COMPLETE work=$WORK artifact=absent"
+}
+
+WORK_JSON=$(bd_show_work) || {
+    echo "ARTIFACT_CLEANUP_BLOCKED could not read work bead $WORK" >&2
+    exit 1
+}
+WORK_RECORD=$(printf '%s' "$WORK_JSON" | jq -ce '
+    if type == "array" and length == 1 and (.[0] | type) == "object" and
+       ((.[0].metadata // {}) | type) == "object"
+    then .[0]
+    else error("expected exactly one work bead object")
+    end
+') || {
+    echo "ARTIFACT_CLEANUP_BLOCKED invalid work bead response for $WORK" >&2
+    exit 1
+}
+
+STATUS=$(printf '%s' "$WORK_RECORD" | jq -r '.status // empty')
+META=$(printf '%s' "$WORK_RECORD" | jq -c '.metadata // {}')
+HANDOFF_RESULT=$(printf '%s' "$META" | jq -r '.merge_result // empty')
+CLEANUP_STATE=$(printf '%s' "$META" | jq -r '.artifact_cleanup_state // empty')
+EXPECTED_ARTIFACT_SHA=$(printf '%s' "$META" |
+    jq -r '.artifact_source_sha // empty')
+TASK_ARTIFACT=$(printf '%s' "$META" | jq -r '
+    if ((.artifact_dir // "") | length) > 0
+    then .artifact_dir
+    else (.work_dir // empty)
+    end')
+
+TERMINAL=false
+if [ "$STATUS" = closed ]; then
+    case "$HANDOFF_RESULT" in
+        merged|already_merged|pull_request|pull_request_merged|mr_merged)
+            TERMINAL=true
+            ;;
+    esac
+fi
+
+if [ "$TERMINAL" != true ]; then
+    if [ "$CLEANUP_STATE" != pending ]; then
+        record_cleanup_state pending || {
+            echo "ARTIFACT_CLEANUP_BLOCKED could not record pending state for $WORK" >&2
+            exit 1
+        }
+    fi
+    echo "ARTIFACT_CLEANUP_DEFERRED work=$WORK status=${STATUS:-unknown} result=${HANDOFF_RESULT:-unknown}"
+    exit 0
+fi
+
+if [ -z "$TASK_ARTIFACT" ]; then
+    if [ "$CLEANUP_STATE" = complete ]; then
+        echo "ARTIFACT_CLEANUP_COMPLETE work=$WORK artifact=absent"
+        exit 0
+    fi
+    complete_without_path
+    exit 0
+fi
+
+if [ ! -e "$TASK_ARTIFACT" ]; then
+    # Crash-safe retry: removal may have succeeded before its metadata update.
+    if ! task_artifact_path_shape "$TASK_ARTIFACT" "$WORK"; then
+        record_cleanup_state blocked || true
+        echo "ARTIFACT_CLEANUP_BLOCKED missing artifact path has an unsafe layout for $WORK: $TASK_ARTIFACT" >&2
+        exit 1
+    fi
+    complete_without_path
+    exit 0
+fi
+
+SAFE_ARTIFACT=$(validate_task_artifact "$TASK_ARTIFACT" "$WORK") || {
+    record_cleanup_state blocked || true
+    echo "ARTIFACT_CLEANUP_BLOCKED unsafe artifact path for $WORK: $TASK_ARTIFACT" >&2
+    exit 1
+}
+if [ -z "$EXPECTED_ARTIFACT_SHA" ]; then
+    record_cleanup_state blocked || true
+    echo "ARTIFACT_CLEANUP_BLOCKED missing artifact_source_sha for $WORK" >&2
+    exit 1
+fi
+LOCAL_SHA=$(git -C "$SAFE_ARTIFACT" rev-parse HEAD 2>/dev/null) || {
+    record_cleanup_state blocked || true
+    echo "ARTIFACT_CLEANUP_BLOCKED unreadable artifact HEAD for $WORK" >&2
+    exit 1
+}
+if [ "$LOCAL_SHA" != "$EXPECTED_ARTIFACT_SHA" ]; then
+    record_cleanup_state blocked || true
+    echo "ARTIFACT_CLEANUP_BLOCKED artifact HEAD mismatch for $WORK" >&2
+    exit 1
+fi
+if [ -n "$(git -C "$SAFE_ARTIFACT" status --porcelain --untracked-files=all)" ]; then
+    record_cleanup_state blocked || true
+    echo "ARTIFACT_CLEANUP_BLOCKED artifact is dirty for $WORK" >&2
+    exit 1
+fi
+
+if ! git -C "$RIG_ROOT" worktree remove "$SAFE_ARTIFACT"; then
+    record_cleanup_state blocked || true
+    echo "ARTIFACT_CLEANUP_BLOCKED clean artifact could not be removed for $WORK" >&2
+    exit 1
+fi
+
+complete_without_path

--- a/gastown/assets/scripts/task-artifact-cleanup.sh
+++ b/gastown/assets/scripts/task-artifact-cleanup.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
-# Idempotently retire a Gastown task artifact after a terminal handoff.
+# Idempotently retire a Gastown task artifact after a remotely durable
+# terminal handoff.
 #
-# Usage: task-artifact-cleanup.sh <work-bead-id>
+# Usage: task-artifact-cleanup.sh [work-bead-id]
 #
 # Required environment:
 #   GC_CITY_PATH  physical Gas City root
@@ -10,18 +11,11 @@
 
 set -eu
 
-WORK=${1:-}
-if [ "$#" -ne 1 ] || [ -z "$WORK" ]; then
-    echo "usage: task-artifact-cleanup.sh <work-bead-id>" >&2
+if [ "$#" -gt 1 ]; then
+    echo "usage: task-artifact-cleanup.sh [work-bead-id]" >&2
     exit 2
 fi
-
-case "$WORK" in
-    "."|".."|*[!A-Za-z0-9._-]*)
-        echo "ARTIFACT_CLEANUP_BLOCKED unsafe work bead id: $WORK" >&2
-        exit 2
-        ;;
-esac
+WORK=${1:-}
 
 if [ -z "${GC_CITY_PATH:-}" ] || [ -z "${GC_RIG:-}" ] ||
    [ -z "${GC_RIG_ROOT:-}" ]; then
@@ -41,6 +35,45 @@ for required_command in gc git jq; do
         exit 2
     fi
 done
+
+if [ -z "$WORK" ]; then
+    PENDING_JSON=$(gc bd --rig "$GC_RIG" list \
+        --status=closed \
+        --has-metadata-key=artifact_cleanup_state \
+        --limit=0 \
+        --json) || {
+        echo "ARTIFACT_CLEANUP_BLOCKED could not list pending cleanup work" >&2
+        exit 1
+    }
+    WORK=$(printf '%s' "$PENDING_JSON" | jq -r '
+        if type != "array" then
+            error("expected a work bead array")
+        else
+            [
+              .[]
+              | select(type == "object")
+              | select(((.metadata // {}) | type) == "object")
+              | select(.metadata.artifact_cleanup_state == "pending")
+            ]
+            | sort_by(.updated_at // "")
+            | .[0].id // empty
+        end
+    ') || {
+        echo "ARTIFACT_CLEANUP_BLOCKED invalid pending cleanup response" >&2
+        exit 1
+    }
+    if [ -z "$WORK" ]; then
+        echo "ARTIFACT_CLEANUP_IDLE no closed pending artifacts"
+        exit 0
+    fi
+fi
+
+case "$WORK" in
+    "."|".."|*[!A-Za-z0-9._-]*)
+        echo "ARTIFACT_CLEANUP_BLOCKED unsafe work bead id: $WORK" >&2
+        exit 2
+        ;;
+esac
 
 CITY_ROOT=$(CDPATH= cd -- "$GC_CITY_PATH" 2>/dev/null && pwd -P) || {
     echo "ARTIFACT_CLEANUP_BLOCKED city root is missing: $GC_CITY_PATH" >&2
@@ -65,6 +98,19 @@ artifact_git_common_dir() {
     common_dir=$(git -C "$repo_dir" rev-parse \
         --path-format=absolute --git-common-dir 2>/dev/null) || return 1
     (CDPATH= cd -- "$common_dir" 2>/dev/null && pwd -P)
+}
+
+valid_object_id() {
+    object_id=$1
+    case "$object_id" in
+        ""|*[!0-9a-fA-F]*) return 1 ;;
+    esac
+    [ "${#object_id}" -ge 40 ] && [ "${#object_id}" -le 64 ]
+}
+
+valid_branch() {
+    [ -n "$1" ] &&
+        git -C "$RIG_ROOT" check-ref-format "refs/heads/$1" >/dev/null 2>&1
 }
 
 task_artifact_path_shape() {
@@ -126,6 +172,18 @@ bd_update_work() {
     gc bd --rig "$GC_RIG" update "$WORK" "$@"
 }
 
+read_work_record() {
+    current_json=$(bd_show_work) || return 1
+    printf '%s' "$current_json" | jq -ceS --arg work "$WORK" '
+        if type == "array" and length == 1 and (.[0] | type) == "object" and
+           (.[0].id == $work) and
+           ((.[0].metadata // {}) | type) == "object"
+        then .[0]
+        else error("expected exactly the requested work bead object")
+        end
+    '
+}
+
 record_cleanup_state() {
     state=$1
     bd_update_work --set-metadata artifact_cleanup_state="$state"
@@ -139,17 +197,7 @@ complete_without_path() {
     echo "ARTIFACT_CLEANUP_COMPLETE work=$WORK artifact=absent"
 }
 
-WORK_JSON=$(bd_show_work) || {
-    echo "ARTIFACT_CLEANUP_BLOCKED could not read work bead $WORK" >&2
-    exit 1
-}
-WORK_RECORD=$(printf '%s' "$WORK_JSON" | jq -ce '
-    if type == "array" and length == 1 and (.[0] | type) == "object" and
-       ((.[0].metadata // {}) | type) == "object"
-    then .[0]
-    else error("expected exactly one work bead object")
-    end
-') || {
+WORK_RECORD=$(read_work_record) || {
     echo "ARTIFACT_CLEANUP_BLOCKED invalid work bead response for $WORK" >&2
     exit 1
 }
@@ -160,6 +208,10 @@ HANDOFF_RESULT=$(printf '%s' "$META" | jq -r '.merge_result // empty')
 CLEANUP_STATE=$(printf '%s' "$META" | jq -r '.artifact_cleanup_state // empty')
 EXPECTED_ARTIFACT_SHA=$(printf '%s' "$META" |
     jq -r '.artifact_source_sha // empty')
+BRANCH=$(printf '%s' "$META" | jq -r '.branch // empty')
+TARGET=$(printf '%s' "$META" | jq -r '.merged_target // empty')
+MERGED_SHA=$(printf '%s' "$META" | jq -r '.merged_sha // empty')
+PR_HEAD_SHA=$(printf '%s' "$META" | jq -r '.pr_head_sha // empty')
 TASK_ARTIFACT=$(printf '%s' "$META" | jq -r '
     if ((.artifact_dir // "") | length) > 0
     then .artifact_dir
@@ -226,9 +278,187 @@ if [ "$LOCAL_SHA" != "$EXPECTED_ARTIFACT_SHA" ]; then
     echo "ARTIFACT_CLEANUP_BLOCKED artifact HEAD mismatch for $WORK" >&2
     exit 1
 fi
-if [ -n "$(git -C "$SAFE_ARTIFACT" status --porcelain --untracked-files=all)" ]; then
+ARTIFACT_STATUS=$(git -C "$SAFE_ARTIFACT" status \
+    --porcelain --untracked-files=all) || {
+    record_cleanup_state blocked || true
+    echo "ARTIFACT_CLEANUP_BLOCKED could not inspect artifact status for $WORK" >&2
+    exit 1
+}
+if [ -n "$ARTIFACT_STATUS" ]; then
     record_cleanup_state blocked || true
     echo "ARTIFACT_CLEANUP_BLOCKED artifact is dirty for $WORK" >&2
+    exit 1
+fi
+
+remote_branch_matches() {
+    durable_branch=$1
+    durable_sha=$2
+    durable_record=$(git -C "$RIG_ROOT" ls-remote \
+        --exit-code --heads origin "refs/heads/$durable_branch" 2>/dev/null) ||
+        return 1
+    # An exact ref lookup must produce one <oid> <ref> record.
+    set -- $durable_record
+    if [ "$#" -eq 2 ] &&
+        [ "$1" = "$durable_sha" ] &&
+        [ "$2" = "refs/heads/$durable_branch" ]; then
+        return 0
+    fi
+    return 2
+}
+
+merged_target_contains() {
+    durable_target=$1
+    durable_sha=$2
+    git -C "$RIG_ROOT" fetch --no-tags origin \
+        "+refs/heads/$durable_target:refs/remotes/origin/$durable_target" \
+        >/dev/null 2>&1 || return 1
+    if GIT_GRAFT_FILE=/dev/null \
+        git --no-replace-objects -C "$RIG_ROOT" merge-base \
+            --is-ancestor "$durable_sha" \
+            "refs/remotes/origin/$durable_target" 2>/dev/null
+    then
+        return 0
+    fi
+    return 2
+}
+
+# Prove the handoff is durable from the remote itself. Metadata selects the
+# expected evidence, but cannot establish it: stale or manually-edited bead
+# fields must never be enough to retire the only reachable task worktree.
+case "$HANDOFF_RESULT" in
+    pull_request)
+        EXPECTED_BRANCH="polecat/$WORK"
+        if [ "$BRANCH" != "$EXPECTED_BRANCH" ] ||
+           ! valid_branch "$BRANCH" ||
+           ! valid_object_id "$PR_HEAD_SHA"; then
+            record_cleanup_state blocked || true
+            echo "ARTIFACT_CLEANUP_BLOCKED incomplete PR publication evidence for $WORK" >&2
+            exit 1
+        fi
+        if remote_branch_matches "$BRANCH" "$PR_HEAD_SHA"; then
+            :
+        else
+            REMOTE_STATUS=$?
+            if [ "$REMOTE_STATUS" -eq 1 ]; then
+                record_cleanup_state pending || true
+                echo "ARTIFACT_CLEANUP_BLOCKED could not read origin/$BRANCH for $WORK; cleanup remains pending" >&2
+            else
+                record_cleanup_state blocked || true
+                echo "ARTIFACT_CLEANUP_BLOCKED origin/$BRANCH does not match the validated PR head for $WORK" >&2
+            fi
+            exit 1
+        fi
+        ;;
+    merged|already_merged)
+        EXPECTED_BRANCH="polecat/$WORK"
+        if [ "$BRANCH" != "$EXPECTED_BRANCH" ] ||
+           ! valid_branch "$BRANCH" ||
+           ! valid_object_id "$EXPECTED_ARTIFACT_SHA" ||
+           ! valid_branch "$TARGET" ||
+           ! valid_object_id "$MERGED_SHA"; then
+            record_cleanup_state blocked || true
+            echo "ARTIFACT_CLEANUP_BLOCKED incomplete direct-merge evidence for $WORK" >&2
+            exit 1
+        fi
+        if remote_branch_matches "$BRANCH" "$EXPECTED_ARTIFACT_SHA"; then
+            :
+        else
+            REMOTE_STATUS=$?
+            if [ "$REMOTE_STATUS" -eq 1 ]; then
+                record_cleanup_state pending || true
+                echo "ARTIFACT_CLEANUP_BLOCKED could not read origin/$BRANCH for $WORK; cleanup remains pending" >&2
+            else
+                record_cleanup_state blocked || true
+                echo "ARTIFACT_CLEANUP_BLOCKED origin/$BRANCH does not retain the artifact source for $WORK" >&2
+            fi
+            exit 1
+        fi
+        if merged_target_contains "$TARGET" "$MERGED_SHA"; then
+            :
+        else
+            REMOTE_STATUS=$?
+            if [ "$REMOTE_STATUS" -eq 1 ]; then
+                record_cleanup_state pending || true
+                echo "ARTIFACT_CLEANUP_BLOCKED could not refresh origin/$TARGET for $WORK; cleanup remains pending" >&2
+            else
+                record_cleanup_state blocked || true
+                echo "ARTIFACT_CLEANUP_BLOCKED merged SHA is not durable on origin/$TARGET for $WORK" >&2
+            fi
+            exit 1
+        fi
+        ;;
+    pull_request_merged|mr_merged)
+        EXPECTED_BRANCH="polecat/$WORK"
+        if [ "$BRANCH" != "$EXPECTED_BRANCH" ] ||
+           ! valid_branch "$BRANCH" ||
+           ! valid_object_id "$PR_HEAD_SHA" ||
+           ! valid_branch "$TARGET" ||
+           ! valid_object_id "$MERGED_SHA"; then
+            record_cleanup_state blocked || true
+            echo "ARTIFACT_CLEANUP_BLOCKED incomplete verified-PR evidence for $WORK" >&2
+            exit 1
+        fi
+        if remote_branch_matches "$BRANCH" "$PR_HEAD_SHA"; then
+            :
+        else
+            REMOTE_STATUS=$?
+            if [ "$REMOTE_STATUS" -eq 1 ]; then
+                record_cleanup_state pending || true
+                echo "ARTIFACT_CLEANUP_BLOCKED could not read origin/$BRANCH for $WORK; cleanup remains pending" >&2
+            else
+                record_cleanup_state blocked || true
+                echo "ARTIFACT_CLEANUP_BLOCKED origin/$BRANCH does not match the merged PR head for $WORK" >&2
+            fi
+            exit 1
+        fi
+        if merged_target_contains "$TARGET" "$MERGED_SHA"; then
+            :
+        else
+            REMOTE_STATUS=$?
+            if [ "$REMOTE_STATUS" -eq 1 ]; then
+                record_cleanup_state pending || true
+                echo "ARTIFACT_CLEANUP_BLOCKED could not refresh origin/$TARGET for $WORK; cleanup remains pending" >&2
+            else
+                record_cleanup_state blocked || true
+                echo "ARTIFACT_CLEANUP_BLOCKED merged SHA is not durable on origin/$TARGET for $WORK" >&2
+            fi
+            exit 1
+        fi
+        ;;
+esac
+
+# Narrow the state race before deletion. Any concurrent reopen, reassignment,
+# path/SHA edit, or other bead mutation makes this attempt fail closed.
+CURRENT_WORK_RECORD=$(read_work_record) || {
+    echo "ARTIFACT_CLEANUP_BLOCKED could not refresh work bead $WORK before removal" >&2
+    exit 1
+}
+if [ "$CURRENT_WORK_RECORD" != "$WORK_RECORD" ]; then
+    echo "ARTIFACT_CLEANUP_BLOCKED work bead changed before artifact removal for $WORK" >&2
+    exit 1
+fi
+CURRENT_SAFE_ARTIFACT=$(validate_task_artifact \
+    "$SAFE_ARTIFACT" "$WORK" 2>/dev/null) || {
+    record_cleanup_state blocked || true
+    echo "ARTIFACT_CLEANUP_BLOCKED artifact changed before removal for $WORK" >&2
+    exit 1
+}
+CURRENT_ARTIFACT_SHA=$(git -C "$SAFE_ARTIFACT" rev-parse HEAD 2>/dev/null) || {
+    record_cleanup_state blocked || true
+    echo "ARTIFACT_CLEANUP_BLOCKED artifact HEAD became unreadable before removal for $WORK" >&2
+    exit 1
+}
+CURRENT_ARTIFACT_STATUS=$(git -C "$SAFE_ARTIFACT" status \
+    --porcelain --untracked-files=all) || {
+    record_cleanup_state blocked || true
+    echo "ARTIFACT_CLEANUP_BLOCKED could not re-inspect artifact status for $WORK" >&2
+    exit 1
+}
+if [ "$CURRENT_SAFE_ARTIFACT" != "$SAFE_ARTIFACT" ] ||
+   [ "$CURRENT_ARTIFACT_SHA" != "$EXPECTED_ARTIFACT_SHA" ] ||
+   [ -n "$CURRENT_ARTIFACT_STATUS" ]; then
+    record_cleanup_state blocked || true
+    echo "ARTIFACT_CLEANUP_BLOCKED artifact changed before removal for $WORK" >&2
     exit 1
 fi
 

--- a/gastown/assets/scripts/task-artifact-cleanup.sh
+++ b/gastown/assets/scripts/task-artifact-cleanup.sh
@@ -54,6 +54,12 @@ if [ -z "$WORK" ]; then
               | select(type == "object")
               | select(((.metadata // {}) | type) == "object")
               | select(.metadata.artifact_cleanup_state == "pending")
+              | select(
+                  .metadata.merge_result == "merged" or
+                  .metadata.merge_result == "already_merged" or
+                  .metadata.merge_result == "pull_request" or
+                  .metadata.merge_result == "mr_merged"
+                )
             ]
             | sort_by(.updated_at // "")
             | .[0].id // empty
@@ -221,7 +227,7 @@ TASK_ARTIFACT=$(printf '%s' "$META" | jq -r '
 TERMINAL=false
 if [ "$STATUS" = closed ]; then
     case "$HANDOFF_RESULT" in
-        merged|already_merged|pull_request|pull_request_merged|mr_merged)
+        merged|already_merged|pull_request|mr_merged)
             TERMINAL=true
             ;;
     esac
@@ -387,7 +393,7 @@ case "$HANDOFF_RESULT" in
             exit 1
         fi
         ;;
-    pull_request_merged|mr_merged)
+    mr_merged)
         EXPECTED_BRANCH="polecat/$WORK"
         if [ "$BRANCH" != "$EXPECTED_BRANCH" ] ||
            ! valid_branch "$BRANCH" ||

--- a/gastown/assets/scripts/worktree-setup.sh
+++ b/gastown/assets/scripts/worktree-setup.sh
@@ -194,6 +194,7 @@ install_local_excludes() {
     append_exclude "__pycache__/"
     append_exclude ".claude/"
     append_exclude ".codex/"
+    append_exclude ".agents/skills/"
     append_exclude ".gemini/"
     append_exclude ".opencode/"
     append_exclude ".github/hooks/"

--- a/gastown/assets/scripts/worktree-setup.sh
+++ b/gastown/assets/scripts/worktree-setup.sh
@@ -38,21 +38,125 @@ else
     SYNC="${4:-}"
 fi
 
-sync_worktree() {
-    [ "$SYNC" = "--sync" ] || return 0
-    if ! git -C "$WT" remote get-url origin >/dev/null 2>&1; then
-        return 0
-    fi
-    git -C "$WT" fetch origin 2>/dev/null || true
-    git -C "$WT" pull --rebase 2>/dev/null || true
-}
-
 branch_name() {
     # Namescape worktree branches by target path so multiple cities or rigs
     # can share one underlying repo without colliding on global refs like
     # gc-refinery or gc-polecat-1.
     HASH=$(printf '%s' "$WT" | git -C "$RIG_ROOT" hash-object --stdin | cut -c1-12)
     printf 'gc-%s-%s' "$AGENT" "$HASH"
+}
+
+git_common_dir() {
+    COMMON_REPO=$1
+    COMMON_DIR=$(git -C "$COMMON_REPO" rev-parse \
+        --path-format=absolute --git-common-dir 2>/dev/null) || return 1
+    (CDPATH= cd -- "$COMMON_DIR" 2>/dev/null && pwd -P)
+}
+
+validate_existing_worktree() {
+    WT_REAL=$(CDPATH= cd -- "$WT" 2>/dev/null && pwd -P) || return 1
+    WT_TOP=$(git -C "$WT_REAL" rev-parse --show-toplevel 2>/dev/null) ||
+        return 1
+    WT_TOP=$(CDPATH= cd -- "$WT_TOP" 2>/dev/null && pwd -P) || return 1
+    [ "$WT_TOP" = "$WT_REAL" ] || return 1
+    WT_COMMON=$(git_common_dir "$WT_REAL") || return 1
+    RIG_COMMON=$(git_common_dir "$RIG_ROOT") || return 1
+    [ "$WT_COMMON" = "$RIG_COMMON" ]
+}
+
+sync_worktree() {
+    [ "$SYNC" = "--sync" ] || return 0
+
+    WT_STATUS=$(git -C "$WT" status --porcelain --untracked-files=all) || {
+        echo "worktree-setup: could not inspect provider worktree status at $WT; refusing sync" >&2
+        return 1
+    }
+    if [ -n "$WT_STATUS" ]; then
+        echo "worktree-setup: refusing to sync dirty provider worktree at $WT" >&2
+        return 1
+    fi
+    if ! git -C "$WT" remote get-url origin >/dev/null 2>&1; then
+        echo "worktree-setup: refusing to sync provider worktree without origin at $WT" >&2
+        return 1
+    fi
+
+    DEFAULT_REF=$(git -C "$RIG_ROOT" symbolic-ref \
+        refs/remotes/origin/HEAD 2>/dev/null || true)
+    if [ -z "$DEFAULT_REF" ]; then
+        if ! git -C "$RIG_ROOT" remote set-head origin --auto >/dev/null 2>&1; then
+            echo "worktree-setup: could not discover origin/HEAD for $RIG_ROOT" >&2
+            return 1
+        fi
+        DEFAULT_REF=$(git -C "$RIG_ROOT" symbolic-ref \
+            refs/remotes/origin/HEAD 2>/dev/null || true)
+    fi
+    if [ -z "$DEFAULT_REF" ]; then
+        echo "worktree-setup: origin/HEAD is not configured for $RIG_ROOT" >&2
+        return 1
+    fi
+    DEFAULT_BRANCH=${DEFAULT_REF#refs/remotes/origin/}
+    [ -n "$DEFAULT_BRANCH" ] || {
+        echo "worktree-setup: could not resolve origin default branch for $RIG_ROOT" >&2
+        return 1
+    }
+    if ! git -C "$RIG_ROOT" fetch origin "$DEFAULT_BRANCH"; then
+        echo "worktree-setup: could not refresh origin/$DEFAULT_BRANCH" >&2
+        return 1
+    fi
+    if ! git -C "$RIG_ROOT" rev-parse --verify \
+        "$DEFAULT_REF^{commit}" >/dev/null 2>&1; then
+        echo "worktree-setup: fetched default ref is not a commit: $DEFAULT_REF" >&2
+        return 1
+    fi
+
+    STABLE_BRANCH=$(branch_name)
+    if ! git -C "$RIG_ROOT" check-ref-format \
+        "refs/heads/$STABLE_BRANCH" >/dev/null 2>&1; then
+        echo "worktree-setup: unsafe stable provider branch: $STABLE_BRANCH" >&2
+        return 1
+    fi
+
+    CURRENT_HEAD=$(git -C "$WT" rev-parse --verify HEAD^{commit}) || {
+        echo "worktree-setup: provider worktree has no valid HEAD: $WT" >&2
+        return 1
+    }
+    CURRENT_BRANCH=$(git -C "$WT" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
+    if [ -z "$CURRENT_BRANCH" ]; then
+        REACHABLE_REF=$(git -C "$RIG_ROOT" for-each-ref \
+            --format='%(refname)' --contains "$CURRENT_HEAD" \
+            refs/heads refs/remotes | head -n 1)
+        if [ -z "$REACHABLE_REF" ]; then
+            echo "worktree-setup: detached provider HEAD $CURRENT_HEAD is not ref-reachable; preserving it and refusing sync" >&2
+            return 1
+        fi
+    fi
+
+    if git -C "$RIG_ROOT" show-ref --verify --quiet \
+        "refs/heads/$STABLE_BRANCH"; then
+        if ! GIT_GRAFT_FILE=/dev/null \
+            git --no-replace-objects -C "$RIG_ROOT" merge-base \
+                --is-ancestor "refs/heads/$STABLE_BRANCH" "$DEFAULT_REF" \
+                2>/dev/null; then
+            echo "worktree-setup: stable provider branch $STABLE_BRANCH has unique or diverged work; preserving it and refusing sync" >&2
+            return 1
+        fi
+        if [ "$CURRENT_BRANCH" != "$STABLE_BRANCH" ]; then
+            if ! git -C "$WT" checkout "$STABLE_BRANCH"; then
+                echo "worktree-setup: could not switch $WT to $STABLE_BRANCH; current HEAD was preserved" >&2
+                return 1
+            fi
+        fi
+    else
+        if ! git -C "$WT" checkout -b "$STABLE_BRANCH" "$DEFAULT_REF"; then
+            echo "worktree-setup: could not create stable branch $STABLE_BRANCH at $WT; current HEAD was preserved" >&2
+            return 1
+        fi
+    fi
+
+    if ! git -C "$WT" merge --ff-only "$DEFAULT_REF"; then
+        echo "worktree-setup: could not fast-forward $STABLE_BRANCH to $DEFAULT_REF" >&2
+        return 1
+    fi
 }
 
 install_local_excludes() {
@@ -99,8 +203,12 @@ install_local_excludes() {
 
 # Idempotent: skip if worktree already exists.
 if [ -d "$WT/.git" ] || [ -f "$WT/.git" ]; then
+    if ! validate_existing_worktree; then
+        echo "worktree-setup: refusing existing path that is not a worktree of $RIG_ROOT: $WT" >&2
+        exit 1
+    fi
     install_local_excludes
-    sync_worktree
+    sync_worktree || exit 1
     exit 0
 fi
 
@@ -173,16 +281,21 @@ if git -C "$RIG_ROOT" show-ref --verify --quiet "refs/heads/$BRANCH"; then
     fi
 else
     if [ -n "$DEFAULT_REF" ]; then
-        WORKTREE_ADD="git -C $RIG_ROOT worktree add $WT -b $BRANCH $DEFAULT_REF"
+        if ! GIT_LFS_SKIP_SMUDGE=1 git -C "$RIG_ROOT" \
+            worktree add "$WT" -b "$BRANCH" "$DEFAULT_REF"; then
+            echo "worktree-setup: failed to create worktree at $WT from $RIG_ROOT (branch $BRANCH)" >&2
+            restore_stage
+            exit 1
+        fi
     else
         # Fallback: no origin/HEAD configured (detached, or no remote default
         # set). Create from current HEAD as before.
-        WORKTREE_ADD="git -C $RIG_ROOT worktree add $WT -b $BRANCH"
-    fi
-    if ! GIT_LFS_SKIP_SMUDGE=1 $WORKTREE_ADD; then
-        echo "worktree-setup: failed to create worktree at $WT from $RIG_ROOT (branch $BRANCH)" >&2
-        restore_stage
-        exit 1
+        if ! GIT_LFS_SKIP_SMUDGE=1 git -C "$RIG_ROOT" \
+            worktree add "$WT" -b "$BRANCH"; then
+            echo "worktree-setup: failed to create worktree at $WT from $RIG_ROOT (branch $BRANCH)" >&2
+            restore_stage
+            exit 1
+        fi
     fi
 fi
 

--- a/gastown/assets/scripts/worktree-setup.sh
+++ b/gastown/assets/scripts/worktree-setup.sh
@@ -55,8 +55,51 @@ branch_name() {
     printf 'gc-%s-%s' "$AGENT" "$HASH"
 }
 
+install_local_excludes() {
+    # Keep runtime ignores in repository-local Git metadata instead of mutating
+    # either the tracked .gitignore or the user's global excludes file.
+    # --git-path resolves the exclude file Git actually consults for this
+    # worktree, including linked-worktree layouts.
+    EXCLUDE=$(git -C "$WT" rev-parse --git-path info/exclude)
+    case "$EXCLUDE" in
+        /*) ;;
+        *) EXCLUDE="$WT/$EXCLUDE" ;;
+    esac
+    mkdir -p "$(dirname "$EXCLUDE")"
+    touch "$EXCLUDE"
+
+    MARKER="# Gas City worktree infrastructure (local excludes)"
+    if ! grep -qF "$MARKER" "$EXCLUDE" 2>/dev/null; then
+        if [ -s "$EXCLUDE" ] && [ "$(tail -c 1 "$EXCLUDE" 2>/dev/null || true)" != "" ]; then
+            printf '\n' >> "$EXCLUDE"
+        fi
+        printf '%s\n' "$MARKER" >> "$EXCLUDE"
+    fi
+
+    append_exclude() {
+        PATTERN="$1"
+        grep -qxF "$PATTERN" "$EXCLUDE" 2>/dev/null || printf '%s\n' "$PATTERN" >> "$EXCLUDE"
+    }
+
+    append_exclude ".beads/redirect"
+    append_exclude ".beads/hooks/"
+    append_exclude ".beads/formulas/"
+    append_exclude ".logs/"
+    append_exclude ".gc/"
+    append_exclude "worktrees/"
+    append_exclude "__pycache__/"
+    append_exclude ".claude/"
+    append_exclude ".codex/"
+    append_exclude ".gemini/"
+    append_exclude ".opencode/"
+    append_exclude ".github/hooks/"
+    append_exclude ".github/copilot-instructions.md"
+    append_exclude "state.json"
+}
+
 # Idempotent: skip if worktree already exists.
 if [ -d "$WT/.git" ] || [ -f "$WT/.git" ]; then
+    install_local_excludes
     sync_worktree
     exit 0
 fi
@@ -160,43 +203,7 @@ echo "$RIG_ROOT/.beads" > "$WT/.beads/redirect"
 # Submodule init (best-effort).
 git -C "$WT" submodule init 2>/dev/null || true
 
-# Keep runtime ignores local to git metadata instead of mutating the tracked
-# repository .gitignore. --git-path resolves the exclude file Git actually
-# consults for this worktree, including linked-worktree layouts.
-EXCLUDE=$(git -C "$WT" rev-parse --git-path info/exclude)
-case "$EXCLUDE" in
-    /*) ;;
-    *) EXCLUDE="$WT/$EXCLUDE" ;;
-esac
-mkdir -p "$(dirname "$EXCLUDE")"
-touch "$EXCLUDE"
-
-MARKER="# Gas City worktree infrastructure (local excludes)"
-if ! grep -qF "$MARKER" "$EXCLUDE" 2>/dev/null; then
-    if [ -s "$EXCLUDE" ] && [ "$(tail -c 1 "$EXCLUDE" 2>/dev/null || true)" != "" ]; then
-        printf '\n' >> "$EXCLUDE"
-    fi
-    printf '%s\n' "$MARKER" >> "$EXCLUDE"
-fi
-
-append_exclude() {
-    PATTERN="$1"
-    grep -qxF "$PATTERN" "$EXCLUDE" 2>/dev/null || printf '%s\n' "$PATTERN" >> "$EXCLUDE"
-}
-
-append_exclude ".beads/redirect"
-append_exclude ".beads/hooks/"
-append_exclude ".beads/formulas/"
-append_exclude ".logs/"
-append_exclude "worktrees/"
-append_exclude "__pycache__/"
-append_exclude ".claude/"
-append_exclude ".codex/"
-append_exclude ".gemini/"
-append_exclude ".opencode/"
-append_exclude ".github/hooks/"
-append_exclude ".github/copilot-instructions.md"
-append_exclude "state.json"
+install_local_excludes
 
 # Optional sync.
 sync_worktree

--- a/gastown/commands/task-artifact-cleanup/help.md
+++ b/gastown/commands/task-artifact-cleanup/help.md
@@ -1,0 +1,21 @@
+# gc gastown task-artifact-cleanup
+
+Idempotently retire a Gastown task worktree after its work bead reaches a
+verified terminal handoff.
+
+Usage:
+
+```bash
+gc gastown task-artifact-cleanup <work-bead-id>
+```
+
+The command requires `GC_CITY_PATH`, `GC_RIG`, and `GC_RIG_ROOT`. It accepts
+only the exact canonical artifact path for that city and rig, or the exact
+historical polecat-provider layout for an intentionally adopted legacy
+artifact. It never force-removes a worktree.
+
+Before removal it requires a closed work bead, terminal merge/PR evidence, a
+clean worktree, and an exact `artifact_source_sha` match. Non-terminal MR
+handoffs are marked `artifact_cleanup_state=pending`; verified-merge
+reconciliation calls the same command again. Successful or already-completed
+cleanup records `artifact_cleanup_state=complete`.

--- a/gastown/commands/task-artifact-cleanup/help.md
+++ b/gastown/commands/task-artifact-cleanup/help.md
@@ -6,7 +6,7 @@ verified terminal handoff.
 Usage:
 
 ```bash
-gc gastown task-artifact-cleanup <work-bead-id>
+gc gastown task-artifact-cleanup [work-bead-id]
 ```
 
 The command requires `GC_CITY_PATH`, `GC_RIG`, and `GC_RIG_ROOT`. It accepts
@@ -14,8 +14,19 @@ only the exact canonical artifact path for that city and rig, or the exact
 historical polecat-provider layout for an intentionally adopted legacy
 artifact. It never force-removes a worktree.
 
-Before removal it requires a closed work bead, terminal merge/PR evidence, a
-clean worktree, and an exact `artifact_source_sha` match. Non-terminal MR
-handoffs are marked `artifact_cleanup_state=pending`; verified-merge
-reconciliation calls the same command again. Successful or already-completed
-cleanup records `artifact_cleanup_state=complete`.
+Before removal it requires a closed work bead, a clean worktree, and an exact
+`artifact_source_sha` match. It then independently refreshes the recorded
+target and proves the merged SHA is reachable there as corroboration of
+terminal state; that target check does not prove a source-to-merge relation.
+Direct merges must retain the exact artifact source SHA at
+`origin/polecat/<bead>`, and that ref remains the durable recovery copy after
+local cleanup.
+Under the current PR-publication handoff, that source ref must instead equal
+the rebased PR head GitHub reported to the refinery. Mutable bead metadata
+alone is never sufficient deletion evidence.
+
+Non-terminal MR handoffs are marked `artifact_cleanup_state=pending`;
+verified-merge reconciliation calls the same command again. Successful or
+already-completed cleanup records `artifact_cleanup_state=complete`.
+With no bead ID, the command retries at most one closed artifact still marked
+`pending`; the refinery runs that bounded sweep before looking for new work.

--- a/gastown/commands/task-artifact-cleanup/help.md
+++ b/gastown/commands/task-artifact-cleanup/help.md
@@ -14,19 +14,30 @@ only the exact canonical artifact path for that city and rig, or the exact
 historical polecat-provider layout for an intentionally adopted legacy
 artifact. It never force-removes a worktree.
 
-Before removal it requires a closed work bead, a clean worktree, and an exact
-`artifact_source_sha` match. It then independently refreshes the recorded
-target and proves the merged SHA is reachable there as corroboration of
-terminal state; that target check does not prove a source-to-merge relation.
-Direct merges must retain the exact artifact source SHA at
-`origin/polecat/<bead>`, and that ref remains the durable recovery copy after
-local cleanup.
-Under the current PR-publication handoff, that source ref must instead equal
-the rebased PR head GitHub reported to the refinery. Mutable bead metadata
-alone is never sufficient deletion evidence.
+Before removal it requires a closed work bead, an exact supported
+`merge_result`, a clean worktree, and an exact `artifact_source_sha` match. It
+then applies the evidence matrix for that exact result:
 
-Non-terminal MR handoffs are marked `artifact_cleanup_state=pending`;
-verified-merge reconciliation calls the same command again. Successful or
-already-completed cleanup records `artifact_cleanup_state=complete`.
+- `merged` / `already_merged` requires the exact artifact source SHA at
+  `origin/polecat/<bead>` and independently refreshes the recorded target to
+  prove `merged_sha` is reachable there as terminal-state corroboration;
+- publication-only `pull_request` requires the source ref to equal the
+  validated `pr_head_sha`, but makes no merge or target-ancestry claim; and
+- `mr_merged` requires that same exact validated PR-head ref plus refreshed
+  target reachability for `merged_sha`.
+
+The target checks do not prove a source-to-merge relation. In every accepted
+case the exact source ref remains independent recovery evidence after local
+cleanup. Mutable bead metadata alone is never sufficient deletion evidence.
+
+The pending `merge_result=pull_request_pending`, obsolete
+`merge_result=pull_request_merged`, and unknown result values are not terminal,
+even on a closed bead. Non-terminal handoffs are marked
+`artifact_cleanup_state=pending`; a later verified transition calls the same
+command again. Successful or already-completed cleanup records
+`artifact_cleanup_state=complete`.
 With no bead ID, the command retries at most one closed artifact still marked
-`pending`; the refinery runs that bounded sweep before looking for new work.
+`pending` whose result is exactly `merged`, `already_merged`, `pull_request`,
+or `mr_merged`. Filtering terminal results before ordering the sweep prevents
+an older non-terminal record from starving a newer actionable cleanup. The
+refinery runs that bounded sweep before looking for new work.

--- a/gastown/commands/task-artifact-cleanup/run.sh
+++ b/gastown/commands/task-artifact-cleanup/run.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -eu
+
+if [ -z "${GC_PACK_DIR:-}" ]; then
+    echo "gc gastown task-artifact-cleanup: missing Gas City pack context" >&2
+    exit 2
+fi
+
+exec "$GC_PACK_DIR/assets/scripts/task-artifact-cleanup.sh" "$@"

--- a/gastown/formulas/mol-polecat-work.toml
+++ b/gastown/formulas/mol-polecat-work.toml
@@ -171,7 +171,7 @@ validate_artifact_worktree() {
 
 Canonical metadata wins. If it is absent, a valid legacy path can be adopted
 and migrated. A stale, missing, provider-root, wrong-bead, or foreign-repo path
-is ignored and a new nested worktree is created:
+is ignored and a new canonical artifact worktree is created:
 ```bash
 WORKTREE=
 if [ -n "$ARTIFACT_DIR" ]; then

--- a/gastown/formulas/mol-polecat-work.toml
+++ b/gastown/formulas/mol-polecat-work.toml
@@ -85,29 +85,174 @@ if [ -z "$WORK_BEAD_ID" ]; then
 fi
 ```
 
-**2. Ensure worktree exists.**
+**2. Ensure a safe per-bead artifact worktree exists.**
 
-Check if `metadata.work_dir` already records your worktree path:
+Task worktrees use the canonical `metadata.artifact_dir` key. The deprecated
+task `metadata.work_dir` key may be adopted only after proving that it is an
+existing per-bead Git worktree in this rig. A legacy core may already have
+launched the session inside that valid task worktree, so current cwd equality
+is not a rejection criterion; the exact path shape and Git repository are.
+Never `cd` to either task metadata path before it passes these checks.
+
+Load both task keys and resolve the city-managed artifact root before changing
+directories. New task worktrees are siblings of prunable polecat homes, never
+children of them:
 ```bash
-WORKTREE=$(gc bd show "$WORK_BEAD_ID" --json | jq -r '.[0].metadata.work_dir // empty')
+BEAD_META=$(gc bd show "$WORK_BEAD_ID" --json | jq '.[0].metadata')
+ARTIFACT_DIR=$(printf '%s' "$BEAD_META" | jq -r '.artifact_dir // empty')
+LEGACY_WORK_DIR=$(printf '%s' "$BEAD_META" | jq -r '.work_dir // empty')
+if [ -z "${GC_CITY_PATH:-}" ] || [ -z "${GC_RIG:-}" ] ||
+   [ -z "${GC_RIG_ROOT:-}" ]; then
+  echo "GC_CITY_PATH, GC_RIG, and GC_RIG_ROOT are required for task worktrees." >&2
+  gc runtime drain-ack
+  exit 1
+fi
+case "$WORK_BEAD_ID" in
+  ""|"."|".."|*[!A-Za-z0-9._-]*)
+    echo "Unsafe work bead id for artifact path: $WORK_BEAD_ID" >&2
+    gc runtime drain-ack
+    exit 1
+    ;;
+esac
+case "$GC_RIG" in
+  ""|"."|".."|*[!A-Za-z0-9._-]*)
+    echo "Unsafe rig name for artifact path: $GC_RIG" >&2
+    gc runtime drain-ack
+    exit 1
+    ;;
+esac
+CITY_ROOT=$(CDPATH= cd -- "$GC_CITY_PATH" 2>/dev/null && pwd -P) || {
+  echo "City root is missing: $GC_CITY_PATH" >&2
+  gc runtime drain-ack
+  exit 1
+}
+RIG_ROOT=$(CDPATH= cd -- "$GC_RIG_ROOT" 2>/dev/null && pwd -P) || {
+  echo "Rig root is missing: $GC_RIG_ROOT" >&2
+  gc runtime drain-ack
+  exit 1
+}
 ```
 
-**If worktree path exists in metadata** — reuse it:
+Use this validator for canonical paths, legacy adoption, and any newly-created
+path:
 ```bash
-cd "$WORKTREE"              # Enter existing worktree
-```
-If the directory is missing (witness cleaned it, disk issue), fall through
-to create a new one.
+# BEGIN ARTIFACT_WORKTREE_VALIDATOR
+artifact_git_common_dir() {
+  local repo_dir=$1 common_dir
+  common_dir=$(git -C "$repo_dir" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) ||
+    return 1
+  (CDPATH= cd -- "$common_dir" 2>/dev/null && pwd -P)
+}
 
-**If no worktree** — create one scoped to the bead, not the agent:
-```bash
-WORKTREE_PATH=$(pwd)/worktrees/"$WORK_BEAD_ID"
-git worktree add "$WORKTREE_PATH" --detach origin/{{base_branch}}
-cd "$WORKTREE_PATH"
+validate_artifact_worktree() {
+  local candidate=$1 rig_root=$2 bead_id=$3
+  local candidate_real candidate_top candidate_common rig_common
+
+  [ -n "$candidate" ] && [ -d "$candidate" ] || return 1
+  candidate_real=$(CDPATH= cd -- "$candidate" 2>/dev/null && pwd -P) || return 1
+
+  # Only the exact bead-scoped .../worktrees/<bead-id> shape is reusable.
+  [ "$(basename -- "$candidate_real")" = "$bead_id" ] || return 1
+  [ "$(basename -- "$(dirname -- "$candidate_real")")" = "worktrees" ] || return 1
+
+  # Reject a plain subdirectory of a worktree and worktrees from another repo.
+  candidate_top=$(git -C "$candidate_real" rev-parse --show-toplevel 2>/dev/null) ||
+    return 1
+  candidate_top=$(CDPATH= cd -- "$candidate_top" 2>/dev/null && pwd -P) || return 1
+  [ "$candidate_top" = "$candidate_real" ] || return 1
+  candidate_common=$(artifact_git_common_dir "$candidate_real") || return 1
+  rig_common=$(artifact_git_common_dir "$rig_root") || return 1
+  [ "$candidate_common" = "$rig_common" ] || return 1
+
+  printf '%s\n' "$candidate_real"
+}
+# END ARTIFACT_WORKTREE_VALIDATOR
 ```
-Record immediately so restarts and witness recovery can find it:
+
+Canonical metadata wins. If it is absent, a valid legacy path can be adopted
+and migrated. A stale, missing, provider-root, wrong-bead, or foreign-repo path
+is ignored and a new nested worktree is created:
 ```bash
-gc bd update "$WORK_BEAD_ID" --set-metadata work_dir="$WORKTREE_PATH"
+WORKTREE=
+if [ -n "$ARTIFACT_DIR" ]; then
+  if WORKTREE=$(validate_artifact_worktree \
+      "$ARTIFACT_DIR" "$RIG_ROOT" "$WORK_BEAD_ID"); then
+    echo "Reusing artifact_dir=$WORKTREE"
+  else
+    echo "Canonical artifact_dir is missing or unsafe: $ARTIFACT_DIR" >&2
+    echo "STOP. Preserve it for manual recovery; only an absent canonical key may fall back or create." >&2
+    gc runtime drain-ack
+    exit 1
+  fi
+elif [ -n "$LEGACY_WORK_DIR" ]; then
+  if WORKTREE=$(validate_artifact_worktree \
+      "$LEGACY_WORK_DIR" "$RIG_ROOT" "$WORK_BEAD_ID"); then
+    echo "Migrating validated legacy work_dir=$WORKTREE to artifact_dir."
+  else
+    echo "Ignoring unsafe legacy work_dir=$LEGACY_WORK_DIR; creating a new per-bead worktree." >&2
+  fi
+fi
+
+if [ -z "$WORKTREE" ]; then
+  ARTIFACT_HOME="$CITY_ROOT/.gc/worktrees/$GC_RIG/artifacts"
+  WORKTREE_PARENT="$ARTIFACT_HOME/worktrees"
+  mkdir -p -- "$WORKTREE_PARENT"
+  WORKTREE_PARENT=$(CDPATH= cd -- "$WORKTREE_PARENT" 2>/dev/null && pwd -P) || {
+    echo "Cannot resolve task worktree parent under the city artifact root." >&2
+    gc runtime drain-ack
+    exit 1
+  }
+  if [ "$WORKTREE_PARENT" != "$ARTIFACT_HOME/worktrees" ]; then
+    echo "Task worktree parent is redirected outside the city artifact root." >&2
+    gc runtime drain-ack
+    exit 1
+  fi
+  WORKTREE_PATH="$WORKTREE_PARENT/$WORK_BEAD_ID"
+
+  if [ -e "$WORKTREE_PATH" ]; then
+    # Recover the narrow crash window after git worktree add but before the
+    # metadata write. Never reuse an unrelated directory at this path.
+    if WORKTREE=$(validate_artifact_worktree \
+        "$WORKTREE_PATH" "$RIG_ROOT" "$WORK_BEAD_ID"); then
+      echo "Recovering existing validated per-bead worktree=$WORKTREE"
+    else
+      # Preserve the colliding path for human recovery and create elsewhere.
+      WORKTREE_GENERATION=$(mktemp -d \
+        "$ARTIFACT_HOME/.artifact-worktree-$WORK_BEAD_ID.XXXXXX") || {
+          echo "Could not allocate an alternate artifact worktree parent." >&2
+          gc runtime drain-ack
+          exit 1
+        }
+      mkdir -p -- "$WORKTREE_GENERATION/worktrees"
+      WORKTREE_PATH="$WORKTREE_GENERATION/worktrees/$WORK_BEAD_ID"
+    fi
+  fi
+
+  if [ -z "$WORKTREE" ]; then
+    git -C "$RIG_ROOT" worktree prune
+    git -C "$RIG_ROOT" worktree add "$WORKTREE_PATH" --detach origin/{{base_branch}}
+    WORKTREE=$(validate_artifact_worktree \
+      "$WORKTREE_PATH" "$RIG_ROOT" "$WORK_BEAD_ID") || {
+        echo "New task worktree failed validation: $WORKTREE_PATH" >&2
+        gc runtime drain-ack
+        exit 1
+      }
+  fi
+fi
+
+# Record the canonical key immediately, then retire any legacy task key.
+gc bd update "$WORK_BEAD_ID" \
+  --set-metadata artifact_dir="$WORKTREE" \
+  --unset-metadata work_dir || {
+    echo "Could not record artifact_dir; refusing to enter an untracked task worktree." >&2
+    gc runtime drain-ack
+    exit 1
+  }
+cd -- "$WORKTREE" || {
+  echo "Validated task worktree disappeared: $WORKTREE" >&2
+  gc runtime drain-ack
+  exit 1
+}
 ```
 
 Worktrees are scoped to the work bead (not the agent name) so that:
@@ -164,23 +309,62 @@ if [ -n "$REJECTION" ]; then
 fi
 ```
 
-**If no branch** — create one and record it. Always branch from the
-freshly-fetched `origin/{{base_branch}}`, never from local
-{{base_branch}} or whatever branch happens to be checked out.
-Polecat worktrees are reused across beads, so the local copy of
-{{base_branch}} may lag the remote — branching from a stale local ref
-inherits already-merged commits with stale hashes and causes the next
-refinery rebase to reject for spurious "duplicate" conflicts.
-
+**If no branch** — preserve the narrow interruption case where this worktree
+is already on the expected branch and only the metadata write was missed.
+Every other non-pristine state fails closed; never delete or reset a ref to
+repair empty metadata:
 ```bash
-git fetch origin {{base_branch}}                     # ensure origin ref is current
-BRANCH="polecat/$WORK_BEAD_ID"
-git branch -D "$BRANCH" 2>/dev/null || true          # drop any stale local branch with the same name
-git checkout -B "$BRANCH" "origin/{{base_branch}}"   # force-create from the freshly-fetched remote tip
-gc bd update "$WORK_BEAD_ID" \
-  --set-metadata branch="$BRANCH" \
-  --set-metadata fork_sha="$(git rev-parse "origin/{{base_branch}}")"
+EXPECTED_BRANCH="polecat/$WORK_BEAD_ID"
+CURRENT_BRANCH=$(git branch --show-current)
+if [ "$CURRENT_BRANCH" = "$EXPECTED_BRANCH" ]; then
+  BRANCH="$EXPECTED_BRANCH"
+  FORK_SHA=$(git merge-base "$BRANCH" "origin/{{base_branch}}") || {
+    echo "Cannot derive fork point for recovered branch $BRANCH." >&2
+    gc runtime drain-ack
+    exit 1
+  }
+  gc bd update "$WORK_BEAD_ID" \
+    --set-metadata branch="$BRANCH" \
+    --set-metadata fork_sha="$FORK_SHA" || {
+      echo "Could not record recovered branch metadata." >&2
+      gc runtime drain-ack
+      exit 1
+    }
+elif [ -n "$CURRENT_BRANCH" ] ||
+     [ -n "$(git status --porcelain)" ] ||
+     git show-ref --verify --quiet "refs/heads/$EXPECTED_BRANCH" ||
+     git show-ref --verify --quiet "refs/remotes/origin/$EXPECTED_BRANCH" ||
+     ! git merge-base --is-ancestor HEAD "origin/{{base_branch}}"; then
+  echo "artifact_dir contains branch/work not recorded in metadata.branch." >&2
+  echo "STOP. Recover and record it manually; do not reset or delete refs." >&2
+  gc runtime drain-ack
+  exit 1
+else
+  # A clean detached checkout at or behind the fetched base has no unique work.
+  git fetch origin {{base_branch}} || {
+    echo "Could not refresh origin/{{base_branch}}." >&2
+    gc runtime drain-ack
+    exit 1
+  }
+  BRANCH="$EXPECTED_BRANCH"
+  git checkout -b "$BRANCH" "origin/{{base_branch}}" || {
+    echo "Could not create $BRANCH from origin/{{base_branch}}." >&2
+    gc runtime drain-ack
+    exit 1
+  }
+  gc bd update "$WORK_BEAD_ID" \
+    --set-metadata branch="$BRANCH" \
+    --set-metadata fork_sha="$(git rev-parse "origin/{{base_branch}}")" || {
+      echo "Could not record new branch metadata." >&2
+      gc runtime drain-ack
+      exit 1
+    }
+fi
 ```
+
+Always create new branches from freshly-fetched `origin/{{base_branch}}`,
+never a stale local base. Existing expected refs with missing metadata are
+left untouched for manual recovery rather than force-deleted.
 
 Recording the branch early means:
 - Witness can find and salvage your work if you crash
@@ -320,9 +504,9 @@ if [ "$CURRENT_BRANCH" != "$EXPECTED_BRANCH" ]; then
     echo "Pushing this commit and reassigning to refinery would strand the work."
     echo ""
     echo "Recover by re-running the workspace-setup step:"
-    echo "  - Create the per-bead worktree at \\$(pwd)/worktrees/$WORK_BEAD_ID"
-    echo "  - Create branch '$EXPECTED_BRANCH' from origin/{{base_branch}}"
-    echo "  - Cherry-pick your commits from $CURRENT_BRANCH onto the new branch"
+    echo "  - Let workspace-setup validate or create metadata.artifact_dir"
+    echo "  - Preserve the existing branch/commits; never create a worktree under the provider home"
+    echo "  - Reconcile them onto '$EXPECTED_BRANCH' without deleting either ref"
     echo "  - Re-run submit-and-exit"
     echo ""
     echo "Do NOT proceed past this gate."
@@ -416,13 +600,16 @@ git branch -D "$BRANCH"              # Branch is pushed; refinery owns it now
 ```bash
 gc bd update "$WORK_BEAD_ID" \
   --set-metadata target={{base_branch}} \
+  --unset-metadata artifact_source_sha \
   --notes "Implemented: <brief summary>"
 ```
 Branch was recorded in workspace-setup and is already in metadata.
-This adds the target for the refinery. If an existing pull request was
-provided by the caller, `metadata.existing_pr` is preserved for refinery
-validation. The refinery records canonical `pr_url` only after verifying
-the PR is open and matches the branch, base, and origin repository.
+This adds the target for the refinery and clears any pre-rebase artifact proof
+left by a rejected refinery attempt; refinery captures the freshly-published
+source SHA on its next handoff. If an existing pull request was provided by
+the caller, `metadata.existing_pr` is preserved for refinery validation. The
+refinery records canonical `pr_url` only after verifying the PR is open and
+matches the branch, base, and origin repository.
 
 **6. Reassign to refinery:**
 ```bash

--- a/gastown/formulas/mol-polecat-work.toml
+++ b/gastown/formulas/mol-polecat-work.toml
@@ -667,6 +667,7 @@ git branch -D "$BRANCH"              # Branch is pushed; refinery owns it now
 gc bd update "$WORK_BEAD_ID" \
   --set-metadata target={{base_branch}} \
   --unset-metadata artifact_source_sha \
+  --unset-metadata artifact_cleanup_state \
   --notes "Implemented: <brief summary>"
 ```
 Branch was recorded in workspace-setup and is already in metadata.

--- a/gastown/formulas/mol-polecat-work.toml
+++ b/gastown/formulas/mol-polecat-work.toml
@@ -89,16 +89,33 @@ fi
 
 Task worktrees use the canonical `metadata.artifact_dir` key. The deprecated
 task `metadata.work_dir` key may be adopted only after proving that it is an
-existing per-bead Git worktree in this rig. A legacy core may already have
-launched the session inside that valid task worktree, so current cwd equality
-is not a rejection criterion; the exact path shape and Git repository are.
-Never `cd` to either task metadata path before it passes these checks.
+existing per-bead Git worktree at this city's exact historical Gastown
+provider path. A legacy core may already have launched the session inside that
+valid task worktree, so current cwd equality is not a rejection criterion.
+Adoption migrates the metadata key in place; it does not claim that a legacy
+provider-nested directory has physically moved. Never `cd` to either task
+metadata path before it passes the city, rig, layout, bead, and Git checks.
 
 Load both task keys and resolve the city-managed artifact root before changing
 directories. New task worktrees are siblings of prunable polecat homes, never
 children of them:
 ```bash
-BEAD_META=$(gc bd show "$WORK_BEAD_ID" --json | jq '.[0].metadata')
+BEAD_JSON=$(gc bd show "$WORK_BEAD_ID" --json) || {
+  echo "Could not read work bead metadata for $WORK_BEAD_ID." >&2
+  gc runtime drain-ack
+  exit 1
+}
+BEAD_META=$(printf '%s' "$BEAD_JSON" | jq -ce '
+  if type == "array" and length == 1 and (.[0] | type) == "object" and
+     ((.[0].metadata // {}) | type) == "object"
+  then .[0].metadata // {}
+  else error("expected exactly one work bead object")
+  end
+') || {
+  echo "Invalid work bead response for $WORK_BEAD_ID; refusing to create or adopt an artifact." >&2
+  gc runtime drain-ack
+  exit 1
+}
 ARTIFACT_DIR=$(printf '%s' "$BEAD_META" | jq -r '.artifact_dir // empty')
 LEGACY_WORK_DIR=$(printf '%s' "$BEAD_META" | jq -r '.work_dir // empty')
 if [ -z "${GC_CITY_PATH:-}" ] || [ -z "${GC_RIG:-}" ] ||
@@ -145,8 +162,11 @@ artifact_git_common_dir() {
 }
 
 validate_artifact_worktree() {
-  local candidate=$1 rig_root=$2 bead_id=$3
+  local candidate=$1 city_root=$2 rig_name=$3 rig_root=$4 bead_id=$5
+  local policy=${6:-existing}
   local candidate_real candidate_top candidate_common rig_common
+  local rig_namespace rig_namespace_real canonical_path
+  local worktrees_parent provider_home provider_root provider_name
 
   [ -n "$candidate" ] && [ -d "$candidate" ] || return 1
   candidate_real=$(CDPATH= cd -- "$candidate" 2>/dev/null && pwd -P) || return 1
@@ -154,6 +174,28 @@ validate_artifact_worktree() {
   # Only the exact bead-scoped .../worktrees/<bead-id> shape is reusable.
   [ "$(basename -- "$candidate_real")" = "$bead_id" ] || return 1
   [ "$(basename -- "$(dirname -- "$candidate_real")")" = "worktrees" ] || return 1
+
+  # Same-repository is not an ownership boundary: multiple cities and rigs can
+  # share one Git common dir. Require this city's exact canonical path or the
+  # one historical provider-nested layout that Gastown actually created.
+  rig_namespace="$city_root/.gc/worktrees/$rig_name"
+  rig_namespace_real=$(CDPATH= cd -- "$rig_namespace" 2>/dev/null && pwd -P) ||
+    return 1
+  [ "$rig_namespace_real" = "$rig_namespace" ] || return 1
+  canonical_path="$rig_namespace_real/artifacts/worktrees/$bead_id"
+  if [ "$candidate_real" = "$canonical_path" ]; then
+    [ "$policy" != legacy-only ] || return 1
+  else
+    [ "$policy" != canonical-only ] || return 1
+    worktrees_parent=$(dirname -- "$candidate_real")
+    provider_home=$(dirname -- "$worktrees_parent")
+    provider_root=$(dirname -- "$provider_home")
+    provider_name=$(basename -- "$provider_home")
+    [ "$provider_root" = "$rig_namespace_real/polecats" ] || return 1
+    case "$provider_name" in
+      ""|"."|".."|*[!A-Za-z0-9._-]*) return 1 ;;
+    esac
+  fi
 
   # Reject a plain subdirectory of a worktree and worktrees from another repo.
   candidate_top=$(git -C "$candidate_real" rev-parse --show-toplevel 2>/dev/null) ||
@@ -170,13 +212,15 @@ validate_artifact_worktree() {
 ```
 
 Canonical metadata wins. If it is absent, a valid legacy path can be adopted
-and migrated. A stale, missing, provider-root, wrong-bead, or foreign-repo path
-is ignored and a new canonical artifact worktree is created:
+in place. A stale, missing, provider-root, wrong-city, wrong-rig, wrong-bead,
+or foreign-repo legacy path is ignored and a new canonical artifact worktree
+is created:
 ```bash
 WORKTREE=
 if [ -n "$ARTIFACT_DIR" ]; then
   if WORKTREE=$(validate_artifact_worktree \
-      "$ARTIFACT_DIR" "$RIG_ROOT" "$WORK_BEAD_ID"); then
+      "$ARTIFACT_DIR" "$CITY_ROOT" "$GC_RIG" "$RIG_ROOT" \
+      "$WORK_BEAD_ID" existing); then
     echo "Reusing artifact_dir=$WORKTREE"
   else
     echo "Canonical artifact_dir is missing or unsafe: $ARTIFACT_DIR" >&2
@@ -186,8 +230,10 @@ if [ -n "$ARTIFACT_DIR" ]; then
   fi
 elif [ -n "$LEGACY_WORK_DIR" ]; then
   if WORKTREE=$(validate_artifact_worktree \
-      "$LEGACY_WORK_DIR" "$RIG_ROOT" "$WORK_BEAD_ID"); then
-    echo "Migrating validated legacy work_dir=$WORKTREE to artifact_dir."
+      "$LEGACY_WORK_DIR" "$CITY_ROOT" "$GC_RIG" "$RIG_ROOT" \
+      "$WORK_BEAD_ID" legacy-only); then
+    echo "Adopting validated in-place legacy work_dir=$WORKTREE as artifact_dir."
+    echo "It remains provider-nested until terminal cleanup; new artifacts are always canonical."
   else
     echo "Ignoring unsafe legacy work_dir=$LEGACY_WORK_DIR; creating a new per-bead worktree." >&2
   fi
@@ -195,7 +241,30 @@ fi
 
 if [ -z "$WORKTREE" ]; then
   ARTIFACT_HOME="$CITY_ROOT/.gc/worktrees/$GC_RIG/artifacts"
+  if [ -L "$ARTIFACT_HOME" ] ||
+     { [ -e "$ARTIFACT_HOME" ] && [ ! -d "$ARTIFACT_HOME" ]; }; then
+    echo "Task artifact root is redirected or is not a directory: $ARTIFACT_HOME" >&2
+    gc runtime drain-ack
+    exit 1
+  fi
+  mkdir -p -- "$ARTIFACT_HOME"
+  ARTIFACT_HOME_REAL=$(CDPATH= cd -- "$ARTIFACT_HOME" 2>/dev/null && pwd -P) || {
+    echo "Cannot resolve task artifact root." >&2
+    gc runtime drain-ack
+    exit 1
+  }
+  if [ "$ARTIFACT_HOME_REAL" != "$ARTIFACT_HOME" ]; then
+    echo "Task artifact root is redirected outside the city/rig namespace." >&2
+    gc runtime drain-ack
+    exit 1
+  fi
   WORKTREE_PARENT="$ARTIFACT_HOME/worktrees"
+  if [ -L "$WORKTREE_PARENT" ] ||
+     { [ -e "$WORKTREE_PARENT" ] && [ ! -d "$WORKTREE_PARENT" ]; }; then
+    echo "Task worktree parent is redirected or is not a directory: $WORKTREE_PARENT" >&2
+    gc runtime drain-ack
+    exit 1
+  fi
   mkdir -p -- "$WORKTREE_PARENT"
   WORKTREE_PARENT=$(CDPATH= cd -- "$WORKTREE_PARENT" 2>/dev/null && pwd -P) || {
     echo "Cannot resolve task worktree parent under the city artifact root." >&2
@@ -213,18 +282,14 @@ if [ -z "$WORKTREE" ]; then
     # Recover the narrow crash window after git worktree add but before the
     # metadata write. Never reuse an unrelated directory at this path.
     if WORKTREE=$(validate_artifact_worktree \
-        "$WORKTREE_PATH" "$RIG_ROOT" "$WORK_BEAD_ID"); then
+        "$WORKTREE_PATH" "$CITY_ROOT" "$GC_RIG" "$RIG_ROOT" \
+        "$WORK_BEAD_ID" canonical-only); then
       echo "Recovering existing validated per-bead worktree=$WORKTREE"
     else
-      # Preserve the colliding path for human recovery and create elsewhere.
-      WORKTREE_GENERATION=$(mktemp -d \
-        "$ARTIFACT_HOME/.artifact-worktree-$WORK_BEAD_ID.XXXXXX") || {
-          echo "Could not allocate an alternate artifact worktree parent." >&2
-          gc runtime drain-ack
-          exit 1
-        }
-      mkdir -p -- "$WORKTREE_GENERATION/worktrees"
-      WORKTREE_PATH="$WORKTREE_GENERATION/worktrees/$WORK_BEAD_ID"
+      echo "Canonical artifact path already exists but is not this bead's validated worktree: $WORKTREE_PATH" >&2
+      echo "STOP. Preserve and resolve the collision manually; do not create an alternate artifact." >&2
+      gc runtime drain-ack
+      exit 1
     fi
   fi
 
@@ -232,7 +297,8 @@ if [ -z "$WORKTREE" ]; then
     git -C "$RIG_ROOT" worktree prune
     git -C "$RIG_ROOT" worktree add "$WORKTREE_PATH" --detach origin/{{base_branch}}
     WORKTREE=$(validate_artifact_worktree \
-      "$WORKTREE_PATH" "$RIG_ROOT" "$WORK_BEAD_ID") || {
+      "$WORKTREE_PATH" "$CITY_ROOT" "$GC_RIG" "$RIG_ROOT" \
+      "$WORK_BEAD_ID" canonical-only) || {
         echo "New task worktree failed validation: $WORKTREE_PATH" >&2
         gc runtime drain-ack
         exit 1

--- a/gastown/formulas/mol-refinery-patrol.toml
+++ b/gastown/formulas/mol-refinery-patrol.toml
@@ -215,8 +215,24 @@ TARGET=$(gc bd show $WORK --json | jq -r '.[0].metadata.target // "{{target_bran
 Fetch and attempt mechanical rebase:
 ```bash
 git fetch --prune origin
-ARTIFACT_SOURCE_SHA=$(gc bd show "$WORK" --json |
-  jq -r '.[0].metadata.artifact_source_sha // empty')
+REFINERY_WORK_JSON=$(gc bd show "$WORK" --json) || {
+  echo "Cannot read work metadata before capturing artifact cleanup proof. STOP."
+  gc runtime drain-ack
+  exit 1
+}
+REFINERY_WORK_META=$(printf '%s' "$REFINERY_WORK_JSON" | jq -ce '
+  if type == "array" and length == 1 and (.[0] | type) == "object" and
+     ((.[0].metadata // {}) | type) == "object"
+  then .[0].metadata // {}
+  else error("expected exactly one work bead object")
+  end
+') || {
+  echo "Invalid work metadata response; refusing to overwrite artifact cleanup proof. STOP."
+  gc runtime drain-ack
+  exit 1
+}
+ARTIFACT_SOURCE_SHA=$(printf '%s' "$REFINERY_WORK_META" |
+  jq -r '.artifact_source_sha // empty')
 if [ -z "$ARTIFACT_SOURCE_SHA" ]; then
   ARTIFACT_SOURCE_SHA=$(git rev-parse "origin/$BRANCH") || {
     echo "Cannot capture the published source SHA for artifact cleanup. STOP."
@@ -1098,66 +1114,40 @@ Do NOT delete `$BRANCH` in mr mode — GitHub pull requests need the source bran
 
 **Successful task-artifact cleanup (direct and mr):**
 
-Only a successfully closed handoff reaches this block. Remove the polecat's
-nested task worktree only when its canonical-first metadata path is the exact
-bead-scoped worktree in this rig, the worktree is still clean, and its HEAD is
-the exact source SHA captured from `origin/$BRANCH` before refinery rebased.
-This durable proof is required because MR mode rewrites the source branch and
-the artifact deliberately remains at the pre-rebase commit. Rejections and
-ambiguous paths retain the worktree for recovery.
+Use the pack command below for both the immediate handoff path and retries.
+It is idempotent and is the only supported destructive cleanup path for a
+refinery terminal handoff:
 
 ```bash
-# BEGIN SUCCESSFUL_ARTIFACT_CLEANUP
-CLOSED_WORK=$(gc bd show "$WORK" --json)
-CLOSED_STATUS=$(printf '%s' "$CLOSED_WORK" | jq -r '.[0].status // empty')
-CLOSED_META=$(printf '%s' "$CLOSED_WORK" | jq '.[0].metadata')
-HANDOFF_RESULT=$(printf '%s' "$CLOSED_META" | jq -r '.merge_result // empty')
-EXPECTED_ARTIFACT_SHA=$(printf '%s' "$CLOSED_META" |
-  jq -r '.artifact_source_sha // empty')
-TASK_ARTIFACT=$(printf '%s' "$CLOSED_META" | jq -r '
-  if ((.artifact_dir // "") | length) > 0
-  then .artifact_dir
-  else (.work_dir // empty)
-  end')
-SAFE_ARTIFACT=
-
-if [ "$CLOSED_STATUS" = closed ] && [ -n "$TASK_ARTIFACT" ] &&
-   [ -d "$TASK_ARTIFACT" ]; then
-  if ARTIFACT_REAL=$(CDPATH= cd -- "$TASK_ARTIFACT" 2>/dev/null && pwd -P) &&
-     ARTIFACT_TOP=$(git -C "$ARTIFACT_REAL" rev-parse --show-toplevel 2>/dev/null) &&
-     ARTIFACT_TOP=$(CDPATH= cd -- "$ARTIFACT_TOP" 2>/dev/null && pwd -P) &&
-     ARTIFACT_COMMON=$(git -C "$ARTIFACT_REAL" rev-parse \
-       --path-format=absolute --git-common-dir 2>/dev/null) &&
-     ARTIFACT_COMMON=$(CDPATH= cd -- "$ARTIFACT_COMMON" 2>/dev/null && pwd -P) &&
-     RIG_COMMON=$(git -C "$GC_RIG_ROOT" rev-parse \
-       --path-format=absolute --git-common-dir 2>/dev/null) &&
-     RIG_COMMON=$(CDPATH= cd -- "$RIG_COMMON" 2>/dev/null && pwd -P) &&
-     LOCAL_SHA=$(git -C "$ARTIFACT_REAL" rev-parse HEAD 2>/dev/null); then
-    if [ "$(basename -- "$ARTIFACT_REAL")" = "$WORK" ] &&
-       [ "$(basename -- "$(dirname -- "$ARTIFACT_REAL")")" = worktrees ] &&
-       [ "$ARTIFACT_TOP" = "$ARTIFACT_REAL" ] &&
-       [ "$ARTIFACT_COMMON" = "$RIG_COMMON" ] &&
-       { [ "$HANDOFF_RESULT" = merged ] ||
-         [ "$HANDOFF_RESULT" = already_merged ] ||
-         [ "$HANDOFF_RESULT" = pull_request ]; } &&
-       [ -n "$EXPECTED_ARTIFACT_SHA" ] &&
-       [ "$LOCAL_SHA" = "$EXPECTED_ARTIFACT_SHA" ] &&
-       [ -z "$(git -C "$ARTIFACT_REAL" status --porcelain)" ]; then
-      SAFE_ARTIFACT=$ARTIFACT_REAL
-    fi
-  fi
-fi
-
-if [ -n "$SAFE_ARTIFACT" ] &&
-   git -C "$GC_RIG_ROOT" worktree remove "$SAFE_ARTIFACT"; then
-  gc bd update "$WORK" \
-    --unset-metadata artifact_dir \
-    --unset-metadata work_dir
-else
-  echo "Task artifact absent, changed, dirty, unpublished, or unsafe; preserving it for recovery."
-fi
-# END SUCCESSFUL_ARTIFACT_CLEANUP
+# BEGIN SUCCESSFUL_ARTIFACT_CLEANUP_COMMAND
+gc gastown task-artifact-cleanup "$WORK"
+# END SUCCESSFUL_ARTIFACT_CLEANUP_COMMAND
 ```
+
+The command accepts only this city's exact canonical artifact path or its exact
+historical `$GC_CITY_PATH/.gc/worktrees/$GC_RIG/polecats/<provider>/worktrees/<bead>`
+layout. Same-repository paths in another city, rig, or namespace are rejected.
+It never force-removes a worktree, and removal additionally requires a clean
+HEAD equal to the durable pre-rebase `artifact_source_sha`.
+
+For direct merges and legacy MR behavior, the bead is already closed and the
+command cleans immediately. A merge-gated MR implementation calls the same
+command at publication and again after verified-merge closure:
+
+- before terminal closure it preserves the artifact, records
+  `artifact_cleanup_state=pending`, prints `ARTIFACT_CLEANUP_DEFERRED`, and
+  exits successfully;
+- after verified closure it removes a proven-safe artifact and records
+  `artifact_cleanup_state=complete`;
+- a retry after removal but before the metadata write observes the missing
+  path, clears stale path metadata, and records `complete`;
+- invalid, dirty, or SHA-mismatched artifacts are preserved and marked
+  `artifact_cleanup_state=blocked`.
+
+MR reconciliation MUST run `gc gastown task-artifact-cleanup "$WORK"` after it
+durably records verified merge evidence and closes the bead. Rejections never
+reach terminal cleanup; a polecat's next successful submission clears the stale
+source-SHA proof so refinery captures a fresh one.
 
 **If MERGE_STRATEGY = "local":**
 

--- a/gastown/formulas/mol-refinery-patrol.toml
+++ b/gastown/formulas/mol-refinery-patrol.toml
@@ -67,7 +67,7 @@ description = "Default target branch for merges"
 default = "main"
 
 [vars.delete_merged_branches]
-description = "Whether to delete source branches after merge"
+description = "Deprecated compatibility setting; successful artifact handoffs retain source branches for recovery"
 default = "true"
 
 [vars.integration_branch_auto_land]
@@ -169,6 +169,16 @@ needs = ["check-inbox"]
 description = """
 **Config: event_timeout = {{event_timeout}}**
 
+Before looking for new work, retry at most one closed artifact whose durable
+cleanup marker is still pending. This closes the crash window after the merge
+or bead close but before the immediate cleanup command:
+
+```bash
+if ! gc gastown task-artifact-cleanup; then
+  echo "Pending task-artifact cleanup failed safely; the worktree was preserved for retry or inspection."
+fi
+```
+
 Search for work beads assigned to you with branch metadata:
 ```bash
 WORK=$(gc bd list ${GC_RIG:+--rig="$GC_RIG"} --assignee=$GC_AGENT --status=open \
@@ -233,6 +243,8 @@ REFINERY_WORK_META=$(printf '%s' "$REFINERY_WORK_JSON" | jq -ce '
 }
 ARTIFACT_SOURCE_SHA=$(printf '%s' "$REFINERY_WORK_META" |
   jq -r '.artifact_source_sha // empty')
+ARTIFACT_CLEANUP_STATE=$(printf '%s' "$REFINERY_WORK_META" |
+  jq -r '.artifact_cleanup_state // empty')
 if [ -z "$ARTIFACT_SOURCE_SHA" ]; then
   ARTIFACT_SOURCE_SHA=$(git rev-parse "origin/$BRANCH") || {
     echo "Cannot capture the published source SHA for artifact cleanup. STOP."
@@ -240,8 +252,16 @@ if [ -z "$ARTIFACT_SOURCE_SHA" ]; then
     exit 1
   }
   gc bd update "$WORK" \
-    --set-metadata artifact_source_sha="$ARTIFACT_SOURCE_SHA" || {
+    --set-metadata artifact_source_sha="$ARTIFACT_SOURCE_SHA" \
+    --set-metadata artifact_cleanup_state=pending || {
       echo "Cannot durably record the pre-rebase source SHA. STOP."
+      gc runtime drain-ack
+      exit 1
+    }
+elif [ "$ARTIFACT_CLEANUP_STATE" != pending ]; then
+  gc bd update "$WORK" \
+    --set-metadata artifact_cleanup_state=pending || {
+      echo "Cannot arm the artifact cleanup retry marker. STOP."
       gc runtime drain-ack
       exit 1
     }
@@ -424,7 +444,8 @@ title = "Merge and push"
 needs = ["handle-failures"]
 description = """
 **Config: target_branch = {{target_branch}}**
-**Config: delete_merged_branches = {{delete_merged_branches}}**
+**Config (deprecated; no effect on successful handoffs):
+delete_merged_branches = {{delete_merged_branches}}**
 
 Read the merge target and merge strategy from the work bead metadata:
 ```bash
@@ -621,7 +642,7 @@ lookup_pr_info() {
   ref="$1"
   err_file="$2"
   if command -v gh >/dev/null 2>&1; then
-    gh pr view --json url,number,state,headRefName,baseRefName,headRepositoryOwner,headRepository -- "$ref" 2>"$err_file"
+    gh pr view --json url,number,state,headRefName,headRefOid,baseRefName,headRepositoryOwner,headRepository -- "$ref" 2>"$err_file"
     return $?
   fi
   if ! init_github_rest 2>"$err_file"; then
@@ -647,7 +668,7 @@ lookup_pr_info() {
   fi
   PR_RAW=$(curl_gh_api "$err_file" "$API/pulls/$PR_NUMBER") || return 1
   printf '%s\n' "$PR_RAW" \
-    | jq '{url:.html_url, number, state:(.state | ascii_upcase), headRefName:.head.ref, baseRefName:.base.ref, headRepositoryOwner:{login:.head.repo.owner.login}, headRepository:{name:.head.repo.name}}'
+    | jq '{url:.html_url, number, state:(.state | ascii_upcase), headRefName:.head.ref, headRefOid:.head.sha, baseRefName:.base.ref, headRepositoryOwner:{login:.head.repo.owner.login}, headRepository:{name:.head.repo.name}}'
 }
 
 if [ "$MERGE_STRATEGY" = "mr" ] && [ -n "$EXISTING_PR" ]; then
@@ -797,7 +818,8 @@ If this block closed the bead as already-merged, the merge is already done:
 SKIP the merge script (step 1 below) and go straight to **2. Cleanup**, then
 let this step complete so **patrol-summary** and **next-iteration** run (they
 pour the next wisp and burn this one) — the same tail a normal merge takes. Do
-NOT drain-ack here; that would strand the loop and leak the merged branch.
+NOT drain-ack here; that would strand the loop and leak the current patrol
+wisp. The merged source branch is deliberately retained as recovery evidence.
 Otherwise the branch has a verified real change and you continue to the merge.
 
 **1. Merge, push, verify, and close work bead:**
@@ -857,8 +879,11 @@ rejected/reworked attempt before the successful close.
 git checkout --detach "origin/$TARGET" >/dev/null 2>&1 || true
 git branch -d temp || git branch -D temp || true
 ```
-Run **Successful task-artifact cleanup** below, then, if
-delete_merged_branches = "true": `git push origin --delete $BRANCH`
+Run **Successful task-artifact cleanup** below, then leave
+`origin/$BRANCH` intact. The exact remote source ref is the durable
+recovery copy after local artifact cleanup. `delete_merged_branches` is retained
+only for formula compatibility and MUST NOT delete a successfully handed-off
+artifact source branch.
 
 **If MERGE_STRATEGY = "mr":**
 
@@ -1037,6 +1062,7 @@ PR_URL=$(printf '%s\n' "$PR_INFO" | jq -r '.url')
 PR_NUMBER=$(printf '%s\n' "$PR_INFO" | jq -r '.number')
 PR_STATE=$(printf '%s\n' "$PR_INFO" | jq -r '.state')
 PR_HEAD=$(printf '%s\n' "$PR_INFO" | jq -r '.headRefName')
+PR_HEAD_SHA=$(printf '%s\n' "$PR_INFO" | jq -r '.headRefOid')
 PR_BASE=$(printf '%s\n' "$PR_INFO" | jq -r '.baseRefName')
 PR_REPO=$(printf '%s\n' "$PR_URL" | sed -E 's#^https://github.com/([^/]+/[^/]+)/pull/[0-9]+$#\\1#')
 PR_HEAD_REPO=$(printf '%s\n' "$PR_INFO" | jq -r '.headRepositoryOwner.login + "/" + .headRepository.name')
@@ -1054,6 +1080,12 @@ if [ "$PR_HEAD" != "$BRANCH" ]; then
     block_existing_pr "Existing PR $EXISTING_PR targets branch $PR_HEAD, want $BRANCH."
   fi
   echo "Pull request $PR_REF targets branch $PR_HEAD, want $BRANCH."
+  gc runtime drain-ack
+  exit 1
+fi
+EXPECTED_PR_HEAD=$(git rev-parse temp)
+if [ "$PR_HEAD_SHA" != "$EXPECTED_PR_HEAD" ]; then
+  echo "Pull request $PR_REF head is $PR_HEAD_SHA, want validated branch head $EXPECTED_PR_HEAD."
   gc runtime drain-ack
   exit 1
 fi
@@ -1099,6 +1131,7 @@ gc bd update $WORK \
   --set-metadata merge_result=pull_request \
   --set-metadata pr_url="$PR_URL" \
   --set-metadata pr_number="$PR_NUMBER" \
+  --set-metadata pr_head_sha="$PR_HEAD_SHA" \
   --set-metadata merged_target="$TARGET" \
   --unset-metadata rejection_reason && \
 gc bd close $WORK --reason "Pull request ready: $PR_URL"
@@ -1128,7 +1161,15 @@ The command accepts only this city's exact canonical artifact path or its exact
 historical `$GC_CITY_PATH/.gc/worktrees/$GC_RIG/polecats/<provider>/worktrees/<bead>`
 layout. Same-repository paths in another city, rig, or namespace are rejected.
 It never force-removes a worktree, and removal additionally requires a clean
-HEAD equal to the durable pre-rebase `artifact_source_sha`.
+HEAD equal to the durable pre-rebase `artifact_source_sha`. Mutable metadata
+is not deletion proof by itself: direct/verified merges refresh the recorded
+origin target and prove `merged_sha` ancestry as corroboration of terminal
+state, but do not mechanically prove a relation from the pre-rebase artifact
+source to that merge. Direct mode therefore requires the exact artifact source
+SHA at `origin/polecat/<bead>` and retains that source ref after local cleanup
+as the durable recovery copy.
+The current PR-publication path records GitHub's validated `pr_head_sha`, and
+cleanup independently requires that exact source ref to remain at that SHA.
 
 For direct merges and legacy MR behavior, the bead is already closed and the
 command cleans immediately. A merge-gated MR implementation calls the same

--- a/gastown/formulas/mol-refinery-patrol.toml
+++ b/gastown/formulas/mol-refinery-patrol.toml
@@ -215,9 +215,30 @@ TARGET=$(gc bd show $WORK --json | jq -r '.[0].metadata.target // "{{target_bran
 Fetch and attempt mechanical rebase:
 ```bash
 git fetch --prune origin
+ARTIFACT_SOURCE_SHA=$(gc bd show "$WORK" --json |
+  jq -r '.[0].metadata.artifact_source_sha // empty')
+if [ -z "$ARTIFACT_SOURCE_SHA" ]; then
+  ARTIFACT_SOURCE_SHA=$(git rev-parse "origin/$BRANCH") || {
+    echo "Cannot capture the published source SHA for artifact cleanup. STOP."
+    gc runtime drain-ack
+    exit 1
+  }
+  gc bd update "$WORK" \
+    --set-metadata artifact_source_sha="$ARTIFACT_SOURCE_SHA" || {
+      echo "Cannot durably record the pre-rebase source SHA. STOP."
+      gc runtime drain-ack
+      exit 1
+    }
+fi
 git checkout -b temp origin/$BRANCH
 git rebase origin/$TARGET
 ```
+
+Do not overwrite an existing `artifact_source_sha` on a retry: MR mode may
+already have rewritten the remote branch before a refinery restart, while the
+original artifact still correctly points at the first captured SHA. A polecat
+returning from a rejected attempt clears this proof during its next successful
+submission, so the next refinery handoff captures a fresh value.
 
 If rebase SUCCEEDED (exit 0): close this step, proceed to run-tests.
 
@@ -820,7 +841,8 @@ rejected/reworked attempt before the successful close.
 git checkout --detach "origin/$TARGET" >/dev/null 2>&1 || true
 git branch -d temp || git branch -D temp || true
 ```
-If delete_merged_branches = "true": `git push origin --delete $BRANCH`
+Run **Successful task-artifact cleanup** below, then, if
+delete_merged_branches = "true": `git push origin --delete $BRANCH`
 
 **If MERGE_STRATEGY = "mr":**
 
@@ -1071,7 +1093,71 @@ gc bd close $WORK --reason "Pull request ready: $PR_URL"
 git checkout "$TARGET"
 git branch -d temp
 ```
+Run **Successful task-artifact cleanup** below.
 Do NOT delete `$BRANCH` in mr mode — GitHub pull requests need the source branch.
+
+**Successful task-artifact cleanup (direct and mr):**
+
+Only a successfully closed handoff reaches this block. Remove the polecat's
+nested task worktree only when its canonical-first metadata path is the exact
+bead-scoped worktree in this rig, the worktree is still clean, and its HEAD is
+the exact source SHA captured from `origin/$BRANCH` before refinery rebased.
+This durable proof is required because MR mode rewrites the source branch and
+the artifact deliberately remains at the pre-rebase commit. Rejections and
+ambiguous paths retain the worktree for recovery.
+
+```bash
+# BEGIN SUCCESSFUL_ARTIFACT_CLEANUP
+CLOSED_WORK=$(gc bd show "$WORK" --json)
+CLOSED_STATUS=$(printf '%s' "$CLOSED_WORK" | jq -r '.[0].status // empty')
+CLOSED_META=$(printf '%s' "$CLOSED_WORK" | jq '.[0].metadata')
+HANDOFF_RESULT=$(printf '%s' "$CLOSED_META" | jq -r '.merge_result // empty')
+EXPECTED_ARTIFACT_SHA=$(printf '%s' "$CLOSED_META" |
+  jq -r '.artifact_source_sha // empty')
+TASK_ARTIFACT=$(printf '%s' "$CLOSED_META" | jq -r '
+  if ((.artifact_dir // "") | length) > 0
+  then .artifact_dir
+  else (.work_dir // empty)
+  end')
+SAFE_ARTIFACT=
+
+if [ "$CLOSED_STATUS" = closed ] && [ -n "$TASK_ARTIFACT" ] &&
+   [ -d "$TASK_ARTIFACT" ]; then
+  if ARTIFACT_REAL=$(CDPATH= cd -- "$TASK_ARTIFACT" 2>/dev/null && pwd -P) &&
+     ARTIFACT_TOP=$(git -C "$ARTIFACT_REAL" rev-parse --show-toplevel 2>/dev/null) &&
+     ARTIFACT_TOP=$(CDPATH= cd -- "$ARTIFACT_TOP" 2>/dev/null && pwd -P) &&
+     ARTIFACT_COMMON=$(git -C "$ARTIFACT_REAL" rev-parse \
+       --path-format=absolute --git-common-dir 2>/dev/null) &&
+     ARTIFACT_COMMON=$(CDPATH= cd -- "$ARTIFACT_COMMON" 2>/dev/null && pwd -P) &&
+     RIG_COMMON=$(git -C "$GC_RIG_ROOT" rev-parse \
+       --path-format=absolute --git-common-dir 2>/dev/null) &&
+     RIG_COMMON=$(CDPATH= cd -- "$RIG_COMMON" 2>/dev/null && pwd -P) &&
+     LOCAL_SHA=$(git -C "$ARTIFACT_REAL" rev-parse HEAD 2>/dev/null); then
+    if [ "$(basename -- "$ARTIFACT_REAL")" = "$WORK" ] &&
+       [ "$(basename -- "$(dirname -- "$ARTIFACT_REAL")")" = worktrees ] &&
+       [ "$ARTIFACT_TOP" = "$ARTIFACT_REAL" ] &&
+       [ "$ARTIFACT_COMMON" = "$RIG_COMMON" ] &&
+       { [ "$HANDOFF_RESULT" = merged ] ||
+         [ "$HANDOFF_RESULT" = already_merged ] ||
+         [ "$HANDOFF_RESULT" = pull_request ]; } &&
+       [ -n "$EXPECTED_ARTIFACT_SHA" ] &&
+       [ "$LOCAL_SHA" = "$EXPECTED_ARTIFACT_SHA" ] &&
+       [ -z "$(git -C "$ARTIFACT_REAL" status --porcelain)" ]; then
+      SAFE_ARTIFACT=$ARTIFACT_REAL
+    fi
+  fi
+fi
+
+if [ -n "$SAFE_ARTIFACT" ] &&
+   git -C "$GC_RIG_ROOT" worktree remove "$SAFE_ARTIFACT"; then
+  gc bd update "$WORK" \
+    --unset-metadata artifact_dir \
+    --unset-metadata work_dir
+else
+  echo "Task artifact absent, changed, dirty, unpublished, or unsafe; preserving it for recovery."
+fi
+# END SUCCESSFUL_ARTIFACT_CLEANUP
+```
 
 **If MERGE_STRATEGY = "local":**
 

--- a/gastown/formulas/mol-shutdown-dance.toml
+++ b/gastown/formulas/mol-shutdown-dance.toml
@@ -358,8 +358,10 @@ if [ -n "$target_bead" ] && [ -n "${bead_json:-}" ]; then
     (CDPATH= cd -- "$common_dir" 2>/dev/null && pwd -P)
   }
   validate_progress_artifact_dir() {
-    local candidate=$1 provider_dir=$2 bead_id=$3
+    local candidate=$1 provider_dir=$2 city_root=$3 rig_name=$4 bead_id=$5
     local candidate_real provider_real candidate_top candidate_common provider_common
+    local city_real rig_namespace rig_namespace_real canonical_path
+    local provider_parent provider_name
     [ -n "$candidate" ] && [ -d "$candidate" ] || return 1
     # Dogs are city-scoped and normally have no GC_RIG_ROOT. The exact target
     # session's worker directory is the independent repository anchor.
@@ -367,8 +369,27 @@ if [ -n "$target_bead" ] && [ -n "${bead_json:-}" ]; then
     candidate_real=$(CDPATH= cd -- "$candidate" 2>/dev/null && pwd -P) || return 1
     provider_real=$(CDPATH= cd -- "$provider_dir" 2>/dev/null && pwd -P) ||
       return 1
+    city_real=$(CDPATH= cd -- "$city_root" 2>/dev/null && pwd -P) || return 1
+    case "$rig_name" in
+      ""|"."|".."|*[!A-Za-z0-9._-]*) return 1 ;;
+    esac
+    rig_namespace="$city_real/.gc/worktrees/$rig_name"
+    rig_namespace_real=$(CDPATH= cd -- "$rig_namespace" 2>/dev/null && pwd -P) ||
+      return 1
+    [ "$rig_namespace_real" = "$rig_namespace" ] || return 1
+    provider_parent=$(dirname -- "$provider_real")
+    provider_name=$(basename -- "$provider_real")
+    [ "$provider_parent" = "$rig_namespace_real/polecats" ] || return 1
+    case "$provider_name" in
+      ""|"."|".."|*[!A-Za-z0-9._-]*) return 1 ;;
+    esac
     [ "$(basename -- "$candidate_real")" = "$bead_id" ] || return 1
     [ "$(basename -- "$(dirname -- "$candidate_real")")" = worktrees ] || return 1
+    canonical_path="$rig_namespace_real/artifacts/worktrees/$bead_id"
+    if [ "$candidate_real" != "$canonical_path" ] &&
+       [ "$candidate_real" != "$provider_real/worktrees/$bead_id" ]; then
+      return 1
+    fi
     candidate_top=$(git -C "$candidate_real" rev-parse --show-toplevel 2>/dev/null) ||
       return 1
     candidate_top=$(CDPATH= cd -- "$candidate_top" 2>/dev/null && pwd -P) || return 1
@@ -380,7 +401,8 @@ if [ -n "$target_bead" ] && [ -n "${bead_json:-}" ]; then
   }
   artifact_candidate=$artifact_dir
   if ! artifact_dir=$(validate_progress_artifact_dir \
-      "$artifact_candidate" "$provider_work_dir" "$target_bead"); then
+      "$artifact_candidate" "$provider_work_dir" "$GC_CITY_PATH" \
+      "$target_rig" "$target_bead"); then
     if [ -n "$artifact_candidate" ]; then
       echo "Ignoring unsafe $artifact_source for $target_bead; not scanning provider or unrelated paths." >&2
       progress=unknown

--- a/gastown/formulas/mol-shutdown-dance.toml
+++ b/gastown/formulas/mol-shutdown-dance.toml
@@ -250,33 +250,180 @@ target's claimed work before executing — its bead `updated_at` and the newest
 file under its worktree:
 
 ```bash
-target_bead="$(gc bd list --assignee="$target" --status=in_progress --json --limit=1 | jq -r '.[0].id // empty')"
-progress="none"
+# BEGIN SHUTDOWN_PROGRESS_PROBE
+progress="unknown"
 now_epoch="$(date -u +%s)"
+target_bead=
+target_bead_count=
+target_rig=
+target_session=
+target_match_file=
+
+if sessions_json="$(gc session list --state=all --json)" &&
+   target_session="$(printf '%s' "$sessions_json" |
+     jq -c --arg target "${target%/}" '
+       def identities: [.id, .name, .session_name, .alias, .agent_name]
+         | map(select((. // "") | length > 0));
+       [.sessions[] | select((identities | index($target)) != null)] as $matches
+       | if ($matches | length) == 1 then $matches[0] else empty end')"; then
+  :
+else
+  target_session=
+fi
+
+if [ -n "$target_session" ]; then
+  target_template="$(printf '%s' "$target_session" | jq -r '.template // empty')"
+  target_rig="$(printf '%s' "$target_session" | jq -r '.rig // empty')"
+  target_session_name="$(printf '%s' "$target_session" | jq -r '.session_name // empty')"
+  provider_work_dir="$(printf '%s' "$target_session" | jq -r '.work_dir // empty')"
+  if [ -z "$target_rig" ]; then
+    case "$target_template" in
+      */*) target_rig=${target_template%%/*} ;;
+    esac
+  fi
+  if [ -z "$target_rig" ]; then
+    case "$target_session_name" in
+      *--*) target_rig=${target_session_name%%--*} ;;
+    esac
+  fi
+
+  # A dog is city-scoped, so explicitly route the list to the target
+  # session's rig store. Select by every exact session identity because a
+  # work bead may be assigned by id, name, alias, or configured name.
+  if [ -n "$target_rig" ]; then
+    target_beads="$(gc bd --rig "$target_rig" list \
+      --status=in_progress --json --limit=0)" || target_beads=
+  else
+    target_beads="$(gc bd list --status=in_progress --json --limit=0)" ||
+      target_beads=
+  fi
+  if [ -n "$target_beads" ]; then
+    # Feed both JSON values without argv-sized --argjson data.
+    target_match_file="$(mktemp)" || target_match_file=
+    if [ -n "$target_match_file" ] &&
+       printf '%s\n' "$target_session" "$target_beads" > "$target_match_file"; then
+      target_bead_count="$(jq -s '
+      .[0] as $session | .[1] as $beads
+      | [$session.id, $session.name, $session.session_name,
+         $session.alias, $session.agent_name]
+        | map(select((. // "") | length > 0)) as $identities
+      | [$beads[] | select(.assignee as $a | $identities | index($a))]
+      | length' "$target_match_file")" || target_bead_count=
+      target_bead="$(jq -rs '
+      .[0] as $session | .[1] as $beads
+      | [$session.id, $session.name, $session.session_name,
+         $session.alias, $session.agent_name]
+        | map(select((. // "") | length > 0)) as $identities
+      | [$beads[] | select(.assignee as $a | $identities | index($a))]
+      | if length == 1 then .[0].id else empty end' \
+      "$target_match_file")" || target_bead=
+    fi
+    [ -z "$target_match_file" ] || rm -f "$target_match_file"
+    if [ "$target_bead_count" = 0 ]; then
+      progress=none
+    fi
+  fi
+fi
+
 if [ -n "$target_bead" ]; then
-  bead_json="$(gc bd show "$target_bead" --json)"
-  bead_updated="$(printf '%s' "$bead_json" | jq -r '.[0].updated_at // empty')"
-  work_dir="$(printf '%s' "$bead_json" | jq -r '.[0].metadata.work_dir // empty')"
-  echo "target_bead=$target_bead updated_at=$bead_updated work_dir=$work_dir"
+  if [ -n "$target_rig" ]; then
+    bead_json="$(gc bd --rig "$target_rig" show "$target_bead" --json)" ||
+      bead_json=
+  else
+    bead_json="$(gc bd show "$target_bead" --json)" || bead_json=
+  fi
+  if [ -z "$bead_json" ]; then
+    progress=unknown
+  else
+    progress=none
+    bead_updated="$(printf '%s' "$bead_json" | jq -r '.[0].updated_at // empty')"
+    artifact_dir="$(printf '%s' "$bead_json" | jq -r '.[0].metadata.artifact_dir // empty')"
+    legacy_work_dir="$(printf '%s' "$bead_json" | jq -r '.[0].metadata.work_dir // empty')"
+  fi
+fi
+
+if [ -n "$target_bead" ] && [ -n "${bead_json:-}" ]; then
+  artifact_source=artifact_dir
+  if [ -z "$artifact_dir" ]; then
+    artifact_dir=$legacy_work_dir
+    artifact_source=work_dir
+  fi
+
+  # A progress scan may inspect only a validated per-bead artifact worktree.
+  # In particular, never scan legacy work_dir when it is the provider cwd.
+  progress_git_common_dir() {
+    local repo_dir=$1 common_dir
+    common_dir=$(git -C "$repo_dir" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) ||
+      return 1
+    (CDPATH= cd -- "$common_dir" 2>/dev/null && pwd -P)
+  }
+  validate_progress_artifact_dir() {
+    local candidate=$1 provider_dir=$2 bead_id=$3
+    local candidate_real provider_real candidate_top candidate_common provider_common
+    [ -n "$candidate" ] && [ -d "$candidate" ] || return 1
+    # Dogs are city-scoped and normally have no GC_RIG_ROOT. The exact target
+    # session's worker directory is the independent repository anchor.
+    [ -n "$provider_dir" ] && [ -d "$provider_dir" ] || return 1
+    candidate_real=$(CDPATH= cd -- "$candidate" 2>/dev/null && pwd -P) || return 1
+    provider_real=$(CDPATH= cd -- "$provider_dir" 2>/dev/null && pwd -P) ||
+      return 1
+    [ "$(basename -- "$candidate_real")" = "$bead_id" ] || return 1
+    [ "$(basename -- "$(dirname -- "$candidate_real")")" = worktrees ] || return 1
+    candidate_top=$(git -C "$candidate_real" rev-parse --show-toplevel 2>/dev/null) ||
+      return 1
+    candidate_top=$(CDPATH= cd -- "$candidate_top" 2>/dev/null && pwd -P) || return 1
+    [ "$candidate_top" = "$candidate_real" ] || return 1
+    candidate_common=$(progress_git_common_dir "$candidate_real") || return 1
+    provider_common=$(progress_git_common_dir "$provider_real") || return 1
+    [ "$candidate_common" = "$provider_common" ] || return 1
+    printf '%s\n' "$candidate_real"
+  }
+  artifact_candidate=$artifact_dir
+  if ! artifact_dir=$(validate_progress_artifact_dir \
+      "$artifact_candidate" "$provider_work_dir" "$target_bead"); then
+    if [ -n "$artifact_candidate" ]; then
+      echo "Ignoring unsafe $artifact_source for $target_bead; not scanning provider or unrelated paths." >&2
+      progress=unknown
+    fi
+    artifact_dir=
+  fi
+
+  echo "target_bead=$target_bead updated_at=$bead_updated artifact_dir=$artifact_dir"
   # Bead moved within the 7-minute interrogation window (60s+120s+240s = 420s)?
-  bead_epoch="$(date -u -d "$bead_updated" +%s 2>/dev/null || echo 0)"
-  if [ "$bead_epoch" -gt 0 ] && [ $((now_epoch - bead_epoch)) -lt 420 ]; then
+  bead_epoch="$(date -u -d "$bead_updated" +%s 2>/dev/null)" || {
+    bead_epoch=0
+    progress=unknown
+  }
+  if [ "$bead_epoch" -gt 0 ] &&
+     [ $((now_epoch - bead_epoch)) -lt 420 ]; then
     progress="bead"
   fi
   # Newest worktree file touched within the same window?
-  if [ -n "$work_dir" ] && [ -d "$work_dir" ]; then
-    recent_file="$(find "$work_dir" -type f -newermt '-7 minutes' 2>/dev/null | head -n 1)"
-    [ -n "$recent_file" ] && progress="worktree:$recent_file"
+  if [ -n "$artifact_dir" ]; then
+    if recent_file="$(find "$artifact_dir" -type f \
+        -newermt '-7 minutes' -print -quit 2>/dev/null)"; then
+      [ -n "$recent_file" ] && progress="worktree:$recent_file"
+    else
+      progress=unknown
+    fi
   fi
 fi
 echo "progress_signal=$progress"
+# END SHUTDOWN_PROGRESS_PROBE
 ```
 
 The 7-minute window is the interrogation budget the three attempts already
 spent. If either signal shows movement inside it, the target is progressing —
 PARDON it instead of killing. A polecat inside a full test suite is not dead:
 ```bash
-if [ "$progress" != "none" ]; then
+if [ "$progress" = "unknown" ]; then
+  gc mail send mayor/ -s "DOG: inconclusive pre-kill safety check for $target" \
+    -m "Warrant $GC_BEAD_ID completed its interrogation, but exact session/rig/bead/artifact progress checks were inconclusive. The target was not killed."
+  gc bd close "$GC_BEAD_ID" --reason "PARDONED: pre-kill progress checks inconclusive"
+  gc session nudge "$requester_endpoint" "DOG_DONE: $target - PARDONED (pre-kill progress checks inconclusive; escalated to mayor)"
+  gc runtime drain-ack
+  exit 0
+elif [ "$progress" != "none" ]; then
   gc bd close "$GC_BEAD_ID" --reason "PARDONED: $target showed work progress within the interrogation window ($progress)"
   gc session nudge "$requester_endpoint" "DOG_DONE: $target - PARDONED (progress within interrogation window; likely inside one long tool call)"
   gc runtime drain-ack

--- a/gastown/formulas/mol-witness-patrol.toml
+++ b/gastown/formulas/mol-witness-patrol.toml
@@ -153,7 +153,8 @@ gc bd list --status=open --json --limit=0
 Filter for beads with an assignee (skip unassigned beads). This pass does not
 solve the controller race where orphaned work may already have been released to
 open/unassigned before witness observes it; that requires a separate
-worktree-salvage scan keyed by `metadata.work_dir`. Bound Gastown polecat
+worktree-salvage scan keyed by canonical `metadata.artifact_dir`, with a
+validated legacy `metadata.work_dir` fallback. Bound Gastown polecat
 assignees use the shape `<rig>/{{binding_prefix}}<polecat-suffix>`.
 
 Get the full session roster for liveness checks:
@@ -257,27 +258,163 @@ lifecycle directly.
 The canonical work chain: `worktree → (push) → branch → (merge) → target`.
 Our job is to ensure work reaches the branch so it's schedulable.
 
-Read the bead metadata to find the worktree and branch:
+Read the bead metadata to find the artifact worktree and branch. Canonical
+`artifact_dir` wins. A legacy `work_dir` may be migrated only if its physical
+path proves to be the exact bead-scoped Git worktree in this rig. The
+persistent Gastown provider home cannot pass that shape check.
 ```bash
 META=$(gc bd show <bead> --json | jq '.[0].metadata')
-WORKTREE=$(echo "$META" | jq -r '.worktree // empty')
-BRANCH=$(echo "$META" | jq -r '.branch // empty')
+ARTIFACT_DIR=$(printf '%s' "$META" | jq -r '.artifact_dir // empty')
+LEGACY_WORK_DIR=$(printf '%s' "$META" | jq -r '.work_dir // empty')
+BRANCH=$(printf '%s' "$META" | jq -r '.branch // empty')
+RECOVERY_BLOCKED=false
+
+recovery_git_common_dir() {
+  local repo_dir=$1 common_dir
+  common_dir=$(git -C "$repo_dir" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) ||
+    return 1
+  (CDPATH= cd -- "$common_dir" 2>/dev/null && pwd -P)
+}
+
+validate_recovery_artifact_worktree() {
+  local candidate=$1 rig_root=$2 bead_id=$3
+  local candidate_real candidate_top candidate_common rig_common
+
+  [ -n "$candidate" ] && [ -d "$candidate" ] || return 1
+  candidate_real=$(CDPATH= cd -- "$candidate" 2>/dev/null && pwd -P) || return 1
+  [ "$(basename -- "$candidate_real")" = "$bead_id" ] || return 1
+  [ "$(basename -- "$(dirname -- "$candidate_real")")" = "worktrees" ] || return 1
+  candidate_top=$(git -C "$candidate_real" rev-parse --show-toplevel 2>/dev/null) ||
+    return 1
+  candidate_top=$(CDPATH= cd -- "$candidate_top" 2>/dev/null && pwd -P) || return 1
+  [ "$candidate_top" = "$candidate_real" ] || return 1
+  candidate_common=$(recovery_git_common_dir "$candidate_real") || return 1
+  rig_common=$(recovery_git_common_dir "$rig_root") || return 1
+  [ "$candidate_common" = "$rig_common" ] || return 1
+  printf '%s\n' "$candidate_real"
+}
+
+# Re-check immediately before recovery mutations. The cycle-wide liveness map
+# is only a classifier; a replacement may have started since it was built.
+confirm_orphan_still_unowned() {
+  local current current_status current_assignee sessions live_count
+  current=$(gc bd show <bead> --json) || return 1
+  current_status=$(printf '%s' "$current" | jq -r '.[0].status // empty') ||
+    return 1
+  current_assignee=$(printf '%s' "$current" | jq -r '.[0].assignee // empty') ||
+    return 1
+  { [ "$current_status" = open ] || [ "$current_status" = in_progress ]; } ||
+    return 1
+  [ "$current_assignee" = "$ASSIGNEE" ] || return 1
+
+  sessions=$(gc session list --state=all --json) || return 1
+  live_count=$(printf '%s' "$sessions" | jq -r --arg owner "$current_assignee" '
+    def identities: [.id, .name, .session_name, .alias, .agent_name]
+      | map(select((. // "") | length > 0));
+    [.sessions[]
+     | select((identities | index($owner)) != null)
+     | select(.state == "active" or .state == "awake" or
+              .state == "creating" or .state == "asleep" or
+              .state == "drained" or .state == "suspended" or
+              .state == "draining" or .state == "quarantined")]
+    | length') || return 1
+  [ "$live_count" -eq 0 ]
+}
+
+WORKTREE=
+ARTIFACT_SOURCE=
+if [ -n "$ARTIFACT_DIR" ]; then
+  ARTIFACT_CANDIDATE=$ARTIFACT_DIR
+  ARTIFACT_SOURCE=artifact_dir
+elif [ -n "$LEGACY_WORK_DIR" ]; then
+  ARTIFACT_CANDIDATE=$LEGACY_WORK_DIR
+  ARTIFACT_SOURCE=work_dir
+else
+  ARTIFACT_CANDIDATE=
+fi
+
+if [ "$RECOVERY_BLOCKED" != true ] && [ -n "$ARTIFACT_CANDIDATE" ]; then
+  if WORKTREE=$(validate_recovery_artifact_worktree \
+      "$ARTIFACT_CANDIDATE" "$GC_RIG_ROOT" <bead>); then
+    if [ "$ARTIFACT_SOURCE" = work_dir ]; then
+      if confirm_orphan_still_unowned; then
+        gc bd update <bead> \
+          --set-metadata artifact_dir="$WORKTREE" \
+          --unset-metadata work_dir || RECOVERY_BLOCKED=true
+      else
+        RECOVERY_BLOCKED=true
+      fi
+    fi
+  else
+    echo "Unsafe $ARTIFACT_SOURCE=$ARTIFACT_CANDIDATE for <bead>; it is not a recoverable task worktree." >&2
+    if [ "$ARTIFACT_SOURCE" = artifact_dir ]; then
+      echo "Canonical artifact metadata is present but invalid; preserving the bead for manual recovery." >&2
+      RECOVERY_BLOCKED=true
+    fi
+    WORKTREE=
+  fi
+fi
+
+# Recover an interrupted branch-metadata write without resetting work.
+if [ "$RECOVERY_BLOCKED" != true ] && [ -z "$BRANCH" ] && [ -n "$WORKTREE" ]; then
+  if ! confirm_orphan_still_unowned; then
+    echo "Orphan ownership changed before branch recovery; leaving bead untouched." >&2
+    RECOVERY_BLOCKED=true
+  fi
+fi
+if [ "$RECOVERY_BLOCKED" != true ] && [ -z "$BRANCH" ] && [ -n "$WORKTREE" ]; then
+  EXPECTED_BRANCH="polecat/<bead>"
+  CURRENT_BRANCH=$(git -C "$WORKTREE" branch --show-current)
+  if [ "$CURRENT_BRANCH" = "$EXPECTED_BRANCH" ]; then
+    BRANCH=$EXPECTED_BRANCH
+  elif [ -z "$CURRENT_BRANCH" ] &&
+       ! git -C "$WORKTREE" show-ref --verify --quiet "refs/heads/$EXPECTED_BRANCH" &&
+       ! git -C "$WORKTREE" show-ref --verify --quiet "refs/remotes/origin/$EXPECTED_BRANCH"; then
+    # Preserve detached HEAD exactly; do not reset it to the target.
+    if git -C "$WORKTREE" checkout -b "$EXPECTED_BRANCH"; then
+      BRANCH=$EXPECTED_BRANCH
+    else
+      echo "Cannot attach detached orphan work to $EXPECTED_BRANCH; leaving bead untouched." >&2
+      RECOVERY_BLOCKED=true
+    fi
+  else
+    echo "Ambiguous orphan branch state for <bead>; refusing to reset or delete a ref." >&2
+    RECOVERY_BLOCKED=true
+  fi
+  if [ -n "$BRANCH" ]; then
+    gc bd update <bead> --set-metadata branch="$BRANCH" ||
+      RECOVERY_BLOCKED=true
+  fi
+fi
+if [ -n "$BRANCH" ] && ! git check-ref-format --branch "$BRANCH" >/dev/null 2>&1; then
+  echo "Unsafe metadata.branch=$BRANCH for <bead>; leaving bead untouched." >&2
+  RECOVERY_BLOCKED=true
+fi
 ```
 
-Check the bead and worktree state, then act:
+If `RECOVERY_BLOCKED=true`, escalate and stop processing this bead. Do not run
+Cases A-E, cleanup, or workflow reset for it during this patrol.
+
+Only Cases B-D apply when `WORKTREE` is non-empty after this validation.
+Never `cd` to, scan, or remove the unvalidated candidate. Check the bead and
+validated worktree state, then act:
 
 **Case A: Branch exists on origin (work already published).**
 Worktree is disposable — canonical work is on the branch.
 ```bash
-git ls-remote --heads origin $BRANCH  # Verify branch exists on remote
+if [ -n "$BRANCH" ]; then
+  git ls-remote --exit-code --heads origin "refs/heads/$BRANCH"
+fi
 ```
-If branch exists on origin → skip to Step 3 (cleanup).
+Only an exit-0 exact-ref lookup proves that the branch exists on origin. An
+empty branch is never passed to `ls-remote` (empty would list every head). If
+the exact branch exists on origin → skip to Step 3 (cleanup).
 
 **Case B: Worktree exists, branch pushed but not on origin yet.**
 Branch is recorded in metadata but polecat may have crashed before push.
 ```bash
 cd "$WORKTREE"
-git ls-remote --heads origin $BRANCH
+git ls-remote --exit-code --heads origin "refs/heads/$BRANCH"
 ```
 If branch IS on origin → skip to Step 3.
 If branch is NOT on origin → fall through to Case C.
@@ -285,8 +422,17 @@ If branch is NOT on origin → fall through to Case C.
 **Case C: Worktree exists with unpushed commits.**
 Work is committed locally but never pushed. Branch is not yet canonical.
 ```bash
+confirm_orphan_still_unowned || {
+  echo "Orphan ownership changed before salvage; do not commit or push." >&2
+  gc runtime drain-ack
+  exit 1
+}
 cd "$WORKTREE"
 BRANCH=$(git branch --show-current)
+if [ -z "$BRANCH" ]; then
+  echo "Validated orphan worktree is detached; refusing an ambiguous push." >&2
+  # Attach it to polecat/<bead> using the guarded recovery block above first.
+fi
 git log origin/main..HEAD --oneline  # Shows unpushed commits
 ```
 Commit any remaining uncommitted/untracked work first (safeguard):
@@ -298,7 +444,7 @@ git commit -m "witness: salvage uncommitted work (<bead>)"
 ```
 Publish the work to make branch canonical:
 ```bash
-git push origin HEAD
+git push origin "HEAD:refs/heads/$BRANCH"
 gc bd update <bead> --set-metadata branch=$BRANCH
 ```
 Skip to Step 3 (cleanup).
@@ -306,38 +452,55 @@ Skip to Step 3 (cleanup).
 **Case D: Worktree exists with ONLY uncommitted/untracked changes (no commits).**
 Same resolution as Case C. All work is useful work — never discard.
 ```bash
+confirm_orphan_still_unowned || {
+  echo "Orphan ownership changed before salvage; do not commit or push." >&2
+  gc runtime drain-ack
+  exit 1
+}
 cd "$WORKTREE"
 git add -A
 git commit -m "witness: salvage work from orphaned agent (<bead>)"
 BRANCH=$(git branch --show-current)
-git push origin HEAD
+if [ -z "$BRANCH" ]; then
+  echo "Validated orphan worktree is detached; refusing an ambiguous push." >&2
+  # Attach it to polecat/<bead> using the guarded recovery block above first.
+fi
+git push origin "HEAD:refs/heads/$BRANCH"
 gc bd update <bead> --set-metadata branch=$BRANCH
 ```
 Skip to Step 3 (cleanup).
 
-**Case E: No worktree exists (`metadata.work_dir` missing or directory gone),
-no branch on origin.**
+**Case E: Canonical `metadata.artifact_dir` is absent, no validated legacy
+worktree exists, and no branch exists on origin.**
 Nothing to salvage. The bead goes back to pool and a new polecat
 starts fresh.
 
 **Step 3: Verify work on main before resetting.**
 
-Before resetting the bead to pool, check if the branch was already merged
-to main (polecat finished, pushed, but crashed before closing the bead):
+Run the existing merge-evidence check only for a validated, non-empty branch.
+An empty branch with no worktree is Case E and must skip this merge check
+entirely:
 ```bash
-git log main --oneline | grep -q "$BRANCH"
-# Or check if branch commits are reachable from main:
-git merge-base --is-ancestor origin/$BRANCH origin/main
+if [ -n "$BRANCH" ]; then
+  git log main --oneline | grep -q "$BRANCH"
+  # Or check if branch commits are reachable from main:
+  git merge-base --is-ancestor "origin/$BRANCH" origin/main
+fi
 ```
 
-If the work is already on main:
+If the non-empty branch is already on main:
 - **Close the bead** (work is done, don't re-dispatch). Use `--force`: the bead
   is still assigned to the crashed polecat, so this is a cross-actor close and
   bd's close-authority guard (gastownhall/beads#3734) would otherwise refuse it:
 ```bash
-gc bd close <bead> --force
-gc mail send mayor/ -s "ORPHAN_CLOSED: <bead> already merged" \
-  -m "Branch $BRANCH already on main. Closed instead of resetting."
+if confirm_orphan_still_unowned; then
+  gc bd close <bead> --force
+  gc mail send mayor/ -s "ORPHAN_CLOSED: <bead> already merged" \
+    -m "Branch $BRANCH already on main. Closed instead of resetting."
+else
+  echo "Orphan ownership changed before close; leaving bead untouched." >&2
+  RECOVERY_BLOCKED=true
+fi
 ```
 - Clean up worktree and skip to Step 4.
 
@@ -345,18 +508,101 @@ If the work is NOT on main, proceed with reset:
 
 **Step 3b: Clean up worktree and return bead to pool.**
 
-Once the branch is canonical (on origin), the worktree is disposable:
+Immediately before any removal or workflow reset, re-read ownership and
+revalidate the current canonical-first artifact path. A restarted agent or
+changed artifact path means the earlier orphan decision is stale; leave
+everything untouched for the next patrol:
 ```bash
-# Delete worktree if it exists
-cd <rig-root>
-git worktree remove <worktree-path> --force 2>/dev/null
-rm -rf <worktree-path> 2>/dev/null  # Fallback
-git worktree prune
-```
+CURRENT_BEAD=$(gc bd show <bead> --json)
+CURRENT_STATUS=$(printf '%s' "$CURRENT_BEAD" | jq -r '.[0].status // empty')
+CURRENT_ASSIGNEE=$(printf '%s' "$CURRENT_BEAD" | jq -r '.[0].assignee // empty')
+CURRENT_META=$(printf '%s' "$CURRENT_BEAD" | jq '.[0].metadata')
+CURRENT_CANONICAL_ARTIFACT=$(printf '%s' "$CURRENT_META" |
+  jq -r '.artifact_dir // empty')
+CURRENT_ARTIFACT=$(printf '%s' "$CURRENT_META" | jq -r '
+  if ((.artifact_dir // "") | length) > 0
+  then .artifact_dir
+  else (.work_dir // empty)
+  end')
+OWNER_LIVE_COUNT=1
+if CURRENT_SESSIONS=$(gc session list --state=all --json); then
+  OWNER_LIVE_COUNT=$(printf '%s' "$CURRENT_SESSIONS" |
+    jq -r --arg owner "$CURRENT_ASSIGNEE" --arg original "$ASSIGNEE" '
+      def identities: [.id, .name, .session_name, .alias, .agent_name]
+        | map(select((. // "") | length > 0));
+      [.sessions[]
+       | select((identities | index($owner)) != null or
+                (identities | index($original)) != null)
+       | select(.state == "active" or .state == "awake" or
+                .state == "creating" or .state == "asleep" or
+                .state == "drained" or .state == "suspended" or
+                .state == "draining" or .state == "quarantined")]
+      | length') || OWNER_LIVE_COUNT=1
+fi
+RECOVERY_MODE=none
+if [ "$RECOVERY_BLOCKED" != true ] && [ "$OWNER_LIVE_COUNT" -eq 0 ]; then
+  if [ "$CURRENT_STATUS" = closed ]; then
+    RECOVERY_MODE=closed
+  elif { [ "$CURRENT_STATUS" = open ] || [ "$CURRENT_STATUS" = in_progress ]; } &&
+       [ "$CURRENT_ASSIGNEE" = "$ASSIGNEE" ]; then
+    RECOVERY_MODE=reset
+  fi
+fi
 
-Close any orphaned workflow subtree, then return the bead to pool:
-```bash
-gc workflow delete-source <bead> --apply && gc workflow reopen-source <bead>
+ARTIFACT_SAFE=false
+if [ "$RECOVERY_MODE" != none ]; then
+  if [ -z "$WORKTREE" ]; then
+    if [ -z "$CURRENT_CANONICAL_ARTIFACT" ] &&
+       { [ -z "$CURRENT_ARTIFACT" ] ||
+       ! validate_recovery_artifact_worktree \
+         "$CURRENT_ARTIFACT" "$GC_RIG_ROOT" <bead> >/dev/null; }; then
+      ARTIFACT_SAFE=true
+    fi
+  elif REVALIDATED_WORKTREE=$(validate_recovery_artifact_worktree \
+      "$CURRENT_ARTIFACT" "$GC_RIG_ROOT" <bead>) &&
+       [ "$REVALIDATED_WORKTREE" = "$WORKTREE" ]; then
+    LOCAL_SHA=$(git -C "$WORKTREE" rev-parse HEAD 2>/dev/null || true)
+    REMOTE_SHA=$(git -C "$GC_RIG_ROOT" ls-remote --heads origin \
+      "refs/heads/$BRANCH" 2>/dev/null | cut -f1)
+    if [ -n "$BRANCH" ] && [ -n "$LOCAL_SHA" ] &&
+       [ "$LOCAL_SHA" = "$REMOTE_SHA" ] &&
+       [ -z "$(git -C "$WORKTREE" status --porcelain)" ]; then
+      ARTIFACT_SAFE=true
+    fi
+  fi
+fi
+
+if [ "$ARTIFACT_SAFE" = true ]; then
+  cd "$GC_RIG_ROOT" || {
+    echo "Rig root disappeared before artifact removal; preserving bead state." >&2
+    ARTIFACT_SAFE=false
+  }
+fi
+
+if [ "$ARTIFACT_SAFE" = true ]; then
+  if [ -n "$WORKTREE" ] &&
+     ! git -C "$GC_RIG_ROOT" worktree remove "$WORKTREE"; then
+    echo "Validated artifact could not be removed cleanly; preserving bead state." >&2
+    ARTIFACT_SAFE=false
+  fi
+fi
+
+if [ "$ARTIFACT_SAFE" = true ]; then
+  if ! gc bd update <bead> \
+      --unset-metadata artifact_dir \
+      --unset-metadata work_dir; then
+    echo "Artifact removed but metadata cleanup failed; do not reopen this bead until the stale canonical path is cleared." >&2
+    ARTIFACT_SAFE=false
+  fi
+fi
+
+if [ "$ARTIFACT_SAFE" = true ] && [ "$RECOVERY_MODE" = reset ]; then
+  gc workflow delete-source <bead> --apply && gc workflow reopen-source <bead>
+elif [ "$ARTIFACT_SAFE" = true ] && [ "$RECOVERY_MODE" = closed ]; then
+  echo "Closed orphan artifact cleaned; leaving the closed bead closed."
+else
+  echo "Orphan ownership/artifact changed for <bead>; skipping cleanup and reset." >&2
+fi
 ```
 
 **Step 4: Assess and notify.**

--- a/gastown/formulas/mol-witness-patrol.toml
+++ b/gastown/formulas/mol-witness-patrol.toml
@@ -259,15 +259,44 @@ The canonical work chain: `worktree → (push) → branch → (merge) → target
 Our job is to ensure work reaches the branch so it's schedulable.
 
 Read the bead metadata to find the artifact worktree and branch. Canonical
-`artifact_dir` wins. A legacy `work_dir` may be migrated only if its physical
-path proves to be the exact bead-scoped Git worktree in this rig. The
-persistent Gastown provider home cannot pass that shape check.
+`artifact_dir` wins. A legacy `work_dir` may be adopted in place only if its
+physical path is this city's exact historical
+`.gc/worktrees/<rig>/polecats/<provider>/worktrees/<bead>` layout and the
+worktree belongs to this rig repository. Same-repository paths from another
+city, rig, or namespace are unsafe. The persistent Gastown provider home
+itself cannot pass the bead-scoped shape check.
 ```bash
-META=$(gc bd show <bead> --json | jq '.[0].metadata')
+RECOVERY_BLOCKED=false
+BEAD_JSON=$(gc bd show <bead> --json) || {
+  echo "Cannot read metadata for orphan candidate <bead>; leaving it untouched." >&2
+  RECOVERY_BLOCKED=true
+  BEAD_JSON='[]'
+}
+META=$(printf '%s' "$BEAD_JSON" | jq -ce '
+  if type == "array" and length == 1 and (.[0] | type) == "object" and
+     ((.[0].metadata // {}) | type) == "object"
+  then .[0].metadata // {}
+  else error("expected exactly one work bead object")
+  end
+') || {
+  echo "Invalid metadata response for orphan candidate <bead>; leaving it untouched." >&2
+  RECOVERY_BLOCKED=true
+  META='{}'
+}
 ARTIFACT_DIR=$(printf '%s' "$META" | jq -r '.artifact_dir // empty')
 LEGACY_WORK_DIR=$(printf '%s' "$META" | jq -r '.work_dir // empty')
 BRANCH=$(printf '%s' "$META" | jq -r '.branch // empty')
-RECOVERY_BLOCKED=false
+if [ -z "${GC_CITY_PATH:-}" ] || [ -z "${GC_RIG:-}" ] ||
+   [ -z "${GC_RIG_ROOT:-}" ]; then
+  echo "GC_CITY_PATH, GC_RIG, and GC_RIG_ROOT are required for orphan artifact recovery." >&2
+  RECOVERY_BLOCKED=true
+fi
+case "${GC_RIG:-}" in
+  ""|"."|".."|*[!A-Za-z0-9._-]*)
+    echo "Unsafe or missing rig name for orphan artifact recovery: ${GC_RIG:-<empty>}" >&2
+    RECOVERY_BLOCKED=true
+    ;;
+esac
 
 recovery_git_common_dir() {
   local repo_dir=$1 common_dir
@@ -277,13 +306,33 @@ recovery_git_common_dir() {
 }
 
 validate_recovery_artifact_worktree() {
-  local candidate=$1 rig_root=$2 bead_id=$3
+  local candidate=$1 city_root=$2 rig_name=$3 rig_root=$4 bead_id=$5
   local candidate_real candidate_top candidate_common rig_common
+  local city_real rig_namespace rig_namespace_real canonical_path
+  local worktrees_parent provider_home provider_root provider_name
 
   [ -n "$candidate" ] && [ -d "$candidate" ] || return 1
   candidate_real=$(CDPATH= cd -- "$candidate" 2>/dev/null && pwd -P) || return 1
   [ "$(basename -- "$candidate_real")" = "$bead_id" ] || return 1
   [ "$(basename -- "$(dirname -- "$candidate_real")")" = "worktrees" ] || return 1
+
+  city_real=$(CDPATH= cd -- "$city_root" 2>/dev/null && pwd -P) || return 1
+  rig_namespace="$city_real/.gc/worktrees/$rig_name"
+  rig_namespace_real=$(CDPATH= cd -- "$rig_namespace" 2>/dev/null && pwd -P) ||
+    return 1
+  [ "$rig_namespace_real" = "$rig_namespace" ] || return 1
+  canonical_path="$rig_namespace_real/artifacts/worktrees/$bead_id"
+  if [ "$candidate_real" != "$canonical_path" ]; then
+    worktrees_parent=$(dirname -- "$candidate_real")
+    provider_home=$(dirname -- "$worktrees_parent")
+    provider_root=$(dirname -- "$provider_home")
+    provider_name=$(basename -- "$provider_home")
+    [ "$provider_root" = "$rig_namespace_real/polecats" ] || return 1
+    case "$provider_name" in
+      ""|"."|".."|*[!A-Za-z0-9._-]*) return 1 ;;
+    esac
+  fi
+
   candidate_top=$(git -C "$candidate_real" rev-parse --show-toplevel 2>/dev/null) ||
     return 1
   candidate_top=$(CDPATH= cd -- "$candidate_top" 2>/dev/null && pwd -P) || return 1
@@ -299,9 +348,15 @@ validate_recovery_artifact_worktree() {
 confirm_orphan_still_unowned() {
   local current current_status current_assignee sessions live_count
   current=$(gc bd show <bead> --json) || return 1
-  current_status=$(printf '%s' "$current" | jq -r '.[0].status // empty') ||
+  current=$(printf '%s' "$current" | jq -ce '
+    if type == "array" and length == 1 and (.[0] | type) == "object"
+    then .[0]
+    else error("expected exactly one current work bead")
+    end
+  ') || return 1
+  current_status=$(printf '%s' "$current" | jq -r '.status // empty') ||
     return 1
-  current_assignee=$(printf '%s' "$current" | jq -r '.[0].assignee // empty') ||
+  current_assignee=$(printf '%s' "$current" | jq -r '.assignee // empty') ||
     return 1
   { [ "$current_status" = open ] || [ "$current_status" = in_progress ]; } ||
     return 1
@@ -335,7 +390,8 @@ fi
 
 if [ "$RECOVERY_BLOCKED" != true ] && [ -n "$ARTIFACT_CANDIDATE" ]; then
   if WORKTREE=$(validate_recovery_artifact_worktree \
-      "$ARTIFACT_CANDIDATE" "$GC_RIG_ROOT" <bead>); then
+      "$ARTIFACT_CANDIDATE" "$GC_CITY_PATH" "$GC_RIG" \
+      "$GC_RIG_ROOT" <bead>); then
     if [ "$ARTIFACT_SOURCE" = work_dir ]; then
       if confirm_orphan_still_unowned; then
         gc bd update <bead> \
@@ -431,7 +487,8 @@ cd "$WORKTREE"
 BRANCH=$(git branch --show-current)
 if [ -z "$BRANCH" ]; then
   echo "Validated orphan worktree is detached; refusing an ambiguous push." >&2
-  # Attach it to polecat/<bead> using the guarded recovery block above first.
+  gc runtime drain-ack
+  exit 1
 fi
 git log origin/main..HEAD --oneline  # Shows unpushed commits
 ```
@@ -463,7 +520,8 @@ git commit -m "witness: salvage work from orphaned agent (<bead>)"
 BRANCH=$(git branch --show-current)
 if [ -z "$BRANCH" ]; then
   echo "Validated orphan worktree is detached; refusing an ambiguous push." >&2
-  # Attach it to polecat/<bead> using the guarded recovery block above first.
+  gc runtime drain-ack
+  exit 1
 fi
 git push origin "HEAD:refs/heads/$BRANCH"
 gc bd update <bead> --set-metadata branch=$BRANCH
@@ -513,10 +571,25 @@ revalidate the current canonical-first artifact path. A restarted agent or
 changed artifact path means the earlier orphan decision is stale; leave
 everything untouched for the next patrol:
 ```bash
-CURRENT_BEAD=$(gc bd show <bead> --json)
-CURRENT_STATUS=$(printf '%s' "$CURRENT_BEAD" | jq -r '.[0].status // empty')
-CURRENT_ASSIGNEE=$(printf '%s' "$CURRENT_BEAD" | jq -r '.[0].assignee // empty')
-CURRENT_META=$(printf '%s' "$CURRENT_BEAD" | jq '.[0].metadata')
+CURRENT_BEAD=$(gc bd show <bead> --json) || {
+  echo "Cannot refresh <bead> before cleanup; preserving artifact and workflow." >&2
+  RECOVERY_BLOCKED=true
+  CURRENT_BEAD='[]'
+}
+CURRENT_RECORD=$(printf '%s' "$CURRENT_BEAD" | jq -ce '
+  if type == "array" and length == 1 and (.[0] | type) == "object" and
+     ((.[0].metadata // {}) | type) == "object"
+  then .[0]
+  else error("expected exactly one current work bead object")
+  end
+') || {
+  echo "Invalid refreshed metadata for <bead>; preserving artifact and workflow." >&2
+  RECOVERY_BLOCKED=true
+  CURRENT_RECORD='{"metadata":{}}'
+}
+CURRENT_STATUS=$(printf '%s' "$CURRENT_RECORD" | jq -r '.status // empty')
+CURRENT_ASSIGNEE=$(printf '%s' "$CURRENT_RECORD" | jq -r '.assignee // empty')
+CURRENT_META=$(printf '%s' "$CURRENT_RECORD" | jq '.metadata // {}')
 CURRENT_CANONICAL_ARTIFACT=$(printf '%s' "$CURRENT_META" |
   jq -r '.artifact_dir // empty')
 CURRENT_ARTIFACT=$(printf '%s' "$CURRENT_META" | jq -r '
@@ -555,11 +628,13 @@ if [ "$RECOVERY_MODE" != none ]; then
     if [ -z "$CURRENT_CANONICAL_ARTIFACT" ] &&
        { [ -z "$CURRENT_ARTIFACT" ] ||
        ! validate_recovery_artifact_worktree \
-         "$CURRENT_ARTIFACT" "$GC_RIG_ROOT" <bead> >/dev/null; }; then
+         "$CURRENT_ARTIFACT" "$GC_CITY_PATH" "$GC_RIG" \
+         "$GC_RIG_ROOT" <bead> >/dev/null; }; then
       ARTIFACT_SAFE=true
     fi
   elif REVALIDATED_WORKTREE=$(validate_recovery_artifact_worktree \
-      "$CURRENT_ARTIFACT" "$GC_RIG_ROOT" <bead>) &&
+      "$CURRENT_ARTIFACT" "$GC_CITY_PATH" "$GC_RIG" \
+      "$GC_RIG_ROOT" <bead>) &&
        [ "$REVALIDATED_WORKTREE" = "$WORKTREE" ]; then
     LOCAL_SHA=$(git -C "$WORKTREE" rev-parse HEAD 2>/dev/null || true)
     REMOTE_SHA=$(git -C "$GC_RIG_ROOT" ls-remote --heads origin \

--- a/gastown/formulas/mol-witness-patrol.toml
+++ b/gastown/formulas/mol-witness-patrol.toml
@@ -39,9 +39,13 @@ worktree → (push) → branch → (merge) → target branch
 ```
 
 Each transition moves the canonical location of the work. Once moved,
-the previous location is disposable:
-- After push: worktree disposable (branch is canonical)
-- After merge: branch disposable (target is canonical)
+the previous local execution state can be retired only after its remote
+replacement is proved:
+- After push: the worktree is eligible for validated cleanup (branch is
+  canonical).
+- After merge: the target is canonical, while the exact successfully
+  handed-off source ref is retained as independent recovery evidence. Witness
+  recovery never deletes that ref.
 
 The witness's core recovery job: when a bead is orphaned (agent won't
 come back), ensure the work reaches the branch (push), then clean up
@@ -456,7 +460,8 @@ Never `cd` to, scan, or remove the unvalidated candidate. Check the bead and
 validated worktree state, then act:
 
 **Case A: Branch exists on origin (work already published).**
-Worktree is disposable — canonical work is on the branch.
+The worktree is eligible for validated cleanup — canonical work is on the
+branch. The exact remote branch remains recovery evidence and is not deleted.
 ```bash
 if [ -n "$BRANCH" ]; then
   git ls-remote --exit-code --heads origin "refs/heads/$BRANCH"
@@ -622,6 +627,7 @@ if [ "$RECOVERY_BLOCKED" != true ] && [ "$OWNER_LIVE_COUNT" -eq 0 ]; then
   fi
 fi
 
+# BEGIN WITNESS_ARTIFACT_SAFETY_GATE
 ARTIFACT_SAFE=false
 if [ "$RECOVERY_MODE" != none ]; then
   if [ -z "$WORKTREE" ]; then
@@ -640,12 +646,24 @@ if [ "$RECOVERY_MODE" != none ]; then
     REMOTE_SHA=$(git -C "$GC_RIG_ROOT" ls-remote --heads origin \
       "refs/heads/$BRANCH" 2>/dev/null | cut -f1)
     if [ -n "$BRANCH" ] && [ -n "$LOCAL_SHA" ] &&
-       [ "$LOCAL_SHA" = "$REMOTE_SHA" ] &&
-       [ -z "$(git -C "$WORKTREE" status --porcelain)" ]; then
-      ARTIFACT_SAFE=true
+       [ "$LOCAL_SHA" = "$REMOTE_SHA" ]; then
+      if WORKTREE_STATUS=$(git -C "$WORKTREE" status --porcelain); then
+        if [ -z "$WORKTREE_STATUS" ]; then
+          ARTIFACT_SAFE=true
+        fi
+      else
+        echo "Cannot inspect <bead> artifact status; blocking cleanup and escalating for manual recovery." >&2
+        RECOVERY_BLOCKED=true
+        if ! gc mail send mayor/ \
+          -s "RECOVERY_BLOCKED: artifact status unreadable for <bead>" \
+          -m "Witness could not run git status for validated artifact $WORKTREE. The worktree and workflow were preserved; inspect Git and retry recovery manually."; then
+          echo "Could not notify mayor about blocked recovery for <bead>; artifact remains preserved." >&2
+        fi
+      fi
     fi
   fi
 fi
+# END WITNESS_ARTIFACT_SAFETY_GATE
 
 if [ "$ARTIFACT_SAFE" = true ]; then
   cd "$GC_RIG_ROOT" || {

--- a/gastown/tests/test_polecat_artifact_dir.sh
+++ b/gastown/tests/test_polecat_artifact_dir.sh
@@ -1,0 +1,327 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+GASTOWN="$ROOT/gastown"
+POLECAT_FORMULA="$GASTOWN/formulas/mol-polecat-work.toml"
+WITNESS_FORMULA="$GASTOWN/formulas/mol-witness-patrol.toml"
+SHUTDOWN_FORMULA="$GASTOWN/formulas/mol-shutdown-dance.toml"
+REFINERY_FORMULA="$GASTOWN/formulas/mol-refinery-patrol.toml"
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+extract_validator() {
+    local output=$1
+    python3 - "$POLECAT_FORMULA" "$output" <<'PY'
+import pathlib
+import sys
+import tomllib
+
+formula_path = pathlib.Path(sys.argv[1])
+output_path = pathlib.Path(sys.argv[2])
+with formula_path.open("rb") as handle:
+    formula = tomllib.load(handle)
+workspace = next(step for step in formula["steps"] if step["id"] == "workspace-setup")
+description = workspace["description"]
+begin = description.index("# BEGIN ARTIFACT_WORKTREE_VALIDATOR")
+end = description.index("# END ARTIFACT_WORKTREE_VALIDATOR", begin)
+block = description[begin:end].splitlines()[1:]
+output_path.write_text("\n".join(block) + "\n", encoding="utf-8")
+PY
+}
+
+extract_shutdown_probe() {
+    local output=$1
+    python3 - "$SHUTDOWN_FORMULA" "$output" <<'PY'
+import pathlib
+import sys
+import tomllib
+
+formula_path = pathlib.Path(sys.argv[1])
+output_path = pathlib.Path(sys.argv[2])
+with formula_path.open("rb") as handle:
+    formula = tomllib.load(handle)
+execute = next(step for step in formula["steps"] if step["id"] == "execute")
+description = execute["description"]
+begin = description.index("# BEGIN SHUTDOWN_PROGRESS_PROBE")
+end = description.index("# END SHUTDOWN_PROGRESS_PROBE", begin)
+block = description[begin:end].splitlines()[1:]
+output_path.write_text("\n".join(block) + "\n", encoding="utf-8")
+PY
+}
+
+init_repo() {
+    local repo=$1
+    git init -q "$repo"
+    git -C "$repo" config user.email artifact-test@example.com
+    git -C "$repo" config user.name "Artifact Test"
+    printf 'fixture\n' >"$repo/fixture.txt"
+    git -C "$repo" add fixture.txt
+    git -C "$repo" commit -qm "fixture"
+}
+
+test_shutdown_probe_scopes_rig_and_fails_closed() {
+    local tmp probe calls output
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' RETURN
+    probe="$tmp/probe.sh"
+    calls="$tmp/calls"
+    output="$tmp/output"
+    extract_shutdown_probe "$probe"
+
+    (
+        gc() {
+            printf '%s\n' "$*" >> "$calls"
+            case "$*" in
+                "session list --state=all --json")
+                    printf '%s\n' '{"sessions":[{"id":"session-1","name":"demo/gastown.worker","template":"gastown.polecat","rig":"demo","alias":"demo/gastown.worker","agent_name":"demo/gastown.worker","session_name":"demo--worker","work_dir":"/missing/provider"}]}'
+                    ;;
+                "bd --rig demo list --status=in_progress --json --limit=0")
+                    printf '%s\n' '[]'
+                    ;;
+                *)
+                    return 1
+                    ;;
+            esac
+        }
+        target="demo/gastown.worker"
+        # shellcheck source=/dev/null
+        source "$probe"
+    ) > "$output"
+
+    rg -q '^bd --rig demo list --status=in_progress --json --limit=0$' "$calls" ||
+        fail "shutdown probe did not route the target work query to its rig store"
+    rg -q '^progress_signal=none$' "$output" ||
+        fail "successful exact lookup with no claimed work did not produce progress=none"
+
+    : > "$calls"
+    (
+        gc() {
+            printf '%s\n' "$*" >> "$calls"
+            case "$*" in
+                "session list --state=all --json")
+                    printf '%s\n' '{"sessions":[{"id":"s1","name":"demo/gastown.worker","template":"demo/gastown.polecat"},{"id":"s2","alias":"demo/gastown.worker","template":"demo/gastown.polecat"}]}'
+                    ;;
+                *)
+                    return 1
+                    ;;
+            esac
+        }
+        target="demo/gastown.worker"
+        # shellcheck source=/dev/null
+        source "$probe"
+    ) > "$output"
+
+    rg -q '^progress_signal=unknown$' "$output" ||
+        fail "ambiguous target-session lookup did not fail closed"
+    if rg -q '^bd ' "$calls"; then
+        fail "ambiguous target-session lookup queried an arbitrary bead store"
+    fi
+}
+
+test_validator_rejects_provider_and_unrelated_paths() {
+    local tmp validator rig provider bead valid got plain alias_root foreign foreign_wt
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' RETURN
+    validator="$tmp/validator.sh"
+    extract_validator "$validator"
+    # shellcheck source=/dev/null
+    source "$validator"
+
+    rig="$tmp/rig"
+    provider="$tmp/provider-home"
+    bead="ac-safe1"
+    valid="$provider/worktrees/$bead"
+    init_repo "$rig"
+    git -C "$rig" worktree add -qb provider "$provider" HEAD
+    mkdir -p "$provider/worktrees"
+    git -C "$rig" worktree add -qb "polecat/$bead" "$valid" HEAD
+
+    if validate_artifact_worktree "$provider" "$rig" "$bead" >/dev/null; then
+        fail "persistent provider home was accepted as a task artifact"
+    fi
+
+    alias_root="$tmp/provider-alias/worktrees"
+    mkdir -p "$alias_root"
+    ln -s "$provider" "$alias_root/$bead"
+    if validate_artifact_worktree "$alias_root/$bead" "$rig" "$bead" >/dev/null; then
+        fail "symlink resolving to provider home was accepted"
+    fi
+
+    plain="$provider/worktrees/ac-plain"
+    mkdir -p "$plain"
+    if validate_artifact_worktree "$plain" "$rig" ac-plain >/dev/null; then
+        fail "plain nested directory was accepted as a Git worktree root"
+    fi
+
+    if validate_artifact_worktree "$valid" "$rig" ac-wrong >/dev/null; then
+        fail "worktree for a different bead id was accepted"
+    fi
+    if validate_artifact_worktree "$tmp/missing" "$rig" "$bead" >/dev/null; then
+        fail "missing artifact directory was accepted"
+    fi
+
+    foreign="$tmp/foreign"
+    foreign_wt="$tmp/foreign-parent/worktrees/$bead"
+    init_repo "$foreign"
+    mkdir -p "$(dirname "$foreign_wt")"
+    git -C "$foreign" worktree add -qb foreign-task "$foreign_wt" HEAD
+    if validate_artifact_worktree "$foreign_wt" "$rig" "$bead" >/dev/null; then
+        fail "same-shaped worktree from a foreign repository was accepted"
+    fi
+
+    got=$(validate_artifact_worktree "$valid" "$rig" "$bead") ||
+        fail "valid per-bead legacy worktree was rejected"
+    [[ "$got" == "$(cd "$valid" && pwd -P)" ]] ||
+        fail "validator did not return the physical valid worktree path"
+}
+
+test_metadata_migration_and_consumers_are_canonical_first() {
+    python3 - \
+        "$POLECAT_FORMULA" \
+        "$WITNESS_FORMULA" \
+        "$SHUTDOWN_FORMULA" \
+        "$REFINERY_FORMULA" \
+        "$GASTOWN/agents/polecat/prompt.template.md" \
+        "$GASTOWN/agents/witness/prompt.template.md" <<'PY'
+import pathlib
+import sys
+import tomllib
+
+(
+    polecat_path,
+    witness_path,
+    shutdown_path,
+    refinery_path,
+    polecat_prompt_path,
+    witness_prompt_path,
+) = (
+    pathlib.Path(arg) for arg in sys.argv[1:]
+)
+
+with polecat_path.open("rb") as handle:
+    polecat = tomllib.load(handle)
+workspace = next(step["description"] for step in polecat["steps"] if step["id"] == "workspace-setup")
+submit = next(step["description"] for step in polecat["steps"] if step["id"] == "submit-and-exit")
+
+required_workspace = (
+    ".artifact_dir // empty",
+    ".work_dir // empty",
+    "validate_artifact_worktree",
+    '--set-metadata artifact_dir="$WORKTREE"',
+    "--unset-metadata work_dir",
+    'cd -- "$WORKTREE"',
+    'ARTIFACT_HOME="$CITY_ROOT/.gc/worktrees/$GC_RIG/artifacts"',
+    'EXPECTED_BRANCH="polecat/$WORK_BEAD_ID"',
+    'git merge-base --is-ancestor HEAD "origin/{{base_branch}}"',
+    "Canonical artifact_dir is missing or unsafe",
+)
+for fragment in required_workspace:
+    if fragment not in workspace:
+        raise SystemExit(f"workspace contract missing: {fragment}")
+if workspace.index(".artifact_dir // empty") > workspace.index(".work_dir // empty"):
+    raise SystemExit("legacy task work_dir is read before canonical artifact_dir")
+if workspace.index("validate_artifact_worktree") > workspace.index('cd -- "$WORKTREE"'):
+    raise SystemExit("workspace enters the task path before defining/using its validator")
+if "--set-metadata work_dir=" in workspace:
+    raise SystemExit("workspace still writes deprecated task work_dir")
+if "GC_WORK_DIR" in workspace:
+    raise SystemExit("workspace relies on convergence-only GC_WORK_DIR")
+if 'git branch -D "$EXPECTED_BRANCH"' in workspace or 'git branch -D "$BRANCH"' in workspace:
+    raise SystemExit("empty-branch recovery can delete an unrecorded work branch")
+if "--unset-metadata artifact_source_sha" not in submit:
+    raise SystemExit("polecat submission does not retire stale refinery artifact proof")
+canonical_guard = workspace.index("Canonical artifact_dir is missing or unsafe")
+legacy_fallback = workspace.index('elif [ -n "$LEGACY_WORK_DIR" ]')
+if canonical_guard > legacy_fallback:
+    raise SystemExit("invalid canonical artifact_dir can fall through to legacy/new creation")
+
+with witness_path.open("rb") as handle:
+    witness = tomllib.load(handle)
+recovery = next(step["description"] for step in witness["steps"] if step["id"] == "recover-orphaned-beads")
+for fragment in (
+    "metadata.artifact_dir",
+    "validate_recovery_artifact_worktree",
+    '--set-metadata artifact_dir="$WORKTREE"',
+    "--unset-metadata work_dir",
+    'git ls-remote --exit-code --heads origin "refs/heads/$BRANCH"',
+    'merge-base --is-ancestor',
+    'git -C "$GC_RIG_ROOT" worktree remove "$WORKTREE"',
+    "confirm_orphan_still_unowned",
+    "Canonical artifact metadata is present but invalid",
+    'cd "$GC_RIG_ROOT"',
+):
+    if fragment not in recovery:
+        raise SystemExit(f"witness recovery contract missing: {fragment}")
+for forbidden in ("rm -rf <worktree-path>",):
+    if forbidden in recovery:
+        raise SystemExit(f"witness recovery retained unsafe legacy behavior: {forbidden}")
+if 'if [ -n "$BRANCH" ]; then' not in recovery:
+    raise SystemExit("witness recovery can run remote/merge checks with an empty branch")
+if 'worktree remove "$WORKTREE" --force' in recovery:
+    raise SystemExit("witness artifact cleanup force-removes a worktree")
+if recovery.index("confirm_orphan_still_unowned") > recovery.index(
+    "--set-metadata artifact_dir="
+):
+    raise SystemExit("witness migration mutates metadata before its fresh owner fence")
+if recovery.index("confirm_orphan_still_unowned") > recovery.index(
+    'checkout -b "$EXPECTED_BRANCH"'
+):
+    raise SystemExit("witness branch recovery runs before its fresh owner fence")
+
+with shutdown_path.open("rb") as handle:
+    shutdown = tomllib.load(handle)
+execute = next(step["description"] for step in shutdown["steps"] if step["id"] == "execute")
+if execute.index(".metadata.artifact_dir // empty") > execute.index(".metadata.work_dir // empty"):
+    raise SystemExit("shutdown dance does not read canonical artifact_dir first")
+if 'validate_progress_artifact_dir' not in execute:
+    raise SystemExit("shutdown dance lacks the artifact path validator")
+if 'find "$artifact_dir"' not in execute or 'find "$work_dir"' in execute:
+    raise SystemExit("shutdown dance can scan an unvalidated legacy/provider work_dir")
+for fragment in (
+    'progress="unknown"',
+    'gc bd --rig "$target_rig" list',
+    'gc bd --rig "$target_rig" show',
+    'if [ "$progress" = "unknown" ]; then',
+):
+    if fragment not in execute:
+        raise SystemExit(f"shutdown fail-closed rig lookup contract missing: {fragment}")
+
+with refinery_path.open("rb") as handle:
+    refinery = tomllib.load(handle)
+rebase = next(step["description"] for step in refinery["steps"] if step["id"] == "rebase")
+merge = next(step["description"] for step in refinery["steps"] if step["id"] == "merge-push")
+if '--set-metadata artifact_source_sha="$ARTIFACT_SOURCE_SHA"' not in rebase:
+    raise SystemExit("refinery does not durably capture the pre-rebase artifact SHA")
+for fragment in (
+    "**Successful task-artifact cleanup (direct and mr):**",
+    ".artifact_dir",
+    'git -C "$GC_RIG_ROOT" worktree remove "$SAFE_ARTIFACT"',
+    '--unset-metadata artifact_dir',
+    '--unset-metadata work_dir',
+    '[ -z "$(git -C "$ARTIFACT_REAL" status --porcelain)" ]',
+    '.artifact_source_sha // empty',
+    '[ "$LOCAL_SHA" = "$EXPECTED_ARTIFACT_SHA" ]',
+):
+    if fragment not in merge:
+        raise SystemExit(f"refinery artifact cleanup contract missing: {fragment}")
+if 'worktree remove --force "$SAFE_ARTIFACT"' in merge:
+    raise SystemExit("refinery task-artifact cleanup force-removes a worktree")
+
+polecat_prompt = polecat_prompt_path.read_text(encoding="utf-8")
+witness_prompt = witness_prompt_path.read_text(encoding="utf-8")
+if "`metadata.artifact_dir`" not in polecat_prompt:
+    raise SystemExit("polecat prompt does not document canonical artifact_dir")
+if "`metadata.artifact_dir`" not in witness_prompt:
+    raise SystemExit("witness prompt does not document canonical artifact_dir")
+PY
+}
+
+test_validator_rejects_provider_and_unrelated_paths
+test_shutdown_probe_scopes_rig_and_fails_closed
+test_metadata_migration_and_consumers_are_canonical_first
+
+echo "polecat artifact_dir tests passed"

--- a/gastown/tests/test_polecat_artifact_dir.sh
+++ b/gastown/tests/test_polecat_artifact_dir.sh
@@ -55,6 +55,29 @@ output_path.write_text("\n".join(block) + "\n", encoding="utf-8")
 PY
 }
 
+extract_witness_artifact_safety_gate() {
+    local output=$1
+    python3 - "$WITNESS_FORMULA" "$output" <<'PY'
+import pathlib
+import sys
+import tomllib
+
+formula_path = pathlib.Path(sys.argv[1])
+output_path = pathlib.Path(sys.argv[2])
+with formula_path.open("rb") as handle:
+    formula = tomllib.load(handle)
+recovery = next(
+    step for step in formula["steps"] if step["id"] == "recover-orphaned-beads"
+)
+description = recovery["description"]
+begin = description.index("# BEGIN WITNESS_ARTIFACT_SAFETY_GATE")
+end = description.index("```", begin)
+block = description[begin:end].splitlines()[1:]
+script = "\n".join(block).replace("<bead>", "ac-status")
+output_path.write_text(script + "\n", encoding="utf-8")
+PY
+}
+
 extract_workspace_creation() {
     local output=$1
     python3 - "$POLECAT_FORMULA" "$output" <<'PY'
@@ -208,6 +231,140 @@ test_worktree_setup_ignores_gc_without_mutating_tracked_or_global_ignores() {
         "$WORKTREE_SETUP" "$rig" "$provider" gastown.nux
     [[ "$(grep -cxF '.gc/' "$exclude")" -eq 1 ]] ||
         fail "existing-worktree fast path did not restore exactly one .gc/ entry"
+}
+
+test_worktree_sync_preserves_task_state_and_only_fast_forwards_stable_branch() {
+    local tmp rig remote city provider stable hash task_sha detached_sha
+    local stable_sha foreign foreign_head foreign_exclude_before status
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' RETURN
+    rig="$tmp/rig"
+    remote="$tmp/remote.git"
+    city="$tmp/city"
+    provider="$city/.gc/worktrees/demo/polecats/gastown.nux"
+    foreign="$city/.gc/worktrees/demo/polecats/gastown.foreign"
+
+    init_repo "$rig"
+    git -C "$rig" branch -M main
+    git init -q --bare "$remote"
+    git -C "$remote" symbolic-ref HEAD refs/heads/main
+    git -C "$rig" remote add origin "$remote"
+    git -C "$rig" push -qu origin main
+
+    "$WORKTREE_SETUP" "$rig" "$provider" gastown.nux
+    hash=$(printf '%s' "$provider" | git -C "$rig" hash-object --stdin | cut -c1-12)
+    stable="gc-gastown.nux-$hash"
+    [[ "$(git -C "$provider" branch --show-current)" == "$stable" ]] ||
+        fail "new provider did not use its path-derived stable branch"
+
+    # Normal --sync is idempotent.
+    "$WORKTREE_SETUP" "$rig" "$provider" gastown.nux --sync
+    "$WORKTREE_SETUP" "$rig" "$provider" gastown.nux --sync
+    [[ "$(git -C "$provider" branch --show-current)" == "$stable" ]] ||
+        fail "idempotent sync left the stable provider branch"
+
+    # A clean task branch may contain unique work. Sync must preserve its ref,
+    # switch back to the stable provider branch, and advance only that stable
+    # branch to freshly fetched origin/HEAD.
+    git -C "$provider" checkout -qb polecat/task-preserved
+    printf 'task work\n' >"$provider/task.txt"
+    git -C "$provider" add task.txt
+    git -C "$provider" commit -qm "task work"
+    task_sha=$(git -C "$provider" rev-parse HEAD)
+    printf 'main advance\n' >"$rig/main-b.txt"
+    git -C "$rig" add main-b.txt
+    git -C "$rig" commit -qm "main B"
+    git -C "$rig" push -qu origin main
+
+    "$WORKTREE_SETUP" "$rig" "$provider" gastown.nux --sync
+    [[ "$(git -C "$provider" branch --show-current)" == "$stable" ]] ||
+        fail "sync did not switch a preserved task branch to the stable branch"
+    [[ "$(git -C "$rig" rev-parse refs/heads/polecat/task-preserved)" == "$task_sha" ]] ||
+        fail "sync rewrote the preserved task branch"
+    [[ "$(git -C "$provider" rev-parse HEAD)" == \
+       "$(git -C "$rig" rev-parse refs/remotes/origin/main)" ]] ||
+        fail "stable provider branch was not fast-forwarded to fresh origin/HEAD"
+    [[ "$(git -C "$rig" show refs/heads/polecat/task-preserved:task.txt)" == "task work" ]] ||
+        fail "preserved task branch lost its committed work"
+
+    # A detached HEAD that is reachable from a real ref is safe to leave; the
+    # ref remains the durable owner when sync switches back to stable.
+    git -C "$provider" checkout -q --detach "$task_sha"
+    "$WORKTREE_SETUP" "$rig" "$provider" gastown.nux --sync
+    [[ "$(git -C "$provider" branch --show-current)" == "$stable" ]] ||
+        fail "sync did not leave a ref-reachable detached HEAD safely"
+    [[ "$(git -C "$rig" rev-parse refs/heads/polecat/task-preserved)" == "$task_sha" ]] ||
+        fail "ref-reachable detached state was not preserved"
+
+    # An unreferenced detached commit is the only durable copy of its work.
+    # Sync must fail without switching or rewriting it.
+    git -C "$provider" checkout -q --detach
+    printf 'detached unique\n' >"$provider/detached.txt"
+    git -C "$provider" add detached.txt
+    git -C "$provider" commit -qm "detached unique"
+    detached_sha=$(git -C "$provider" rev-parse HEAD)
+    set +e
+    "$WORKTREE_SETUP" "$rig" "$provider" gastown.nux --sync
+    status=$?
+    set -e
+    [[ "$status" -ne 0 ]] ||
+        fail "sync accepted an unreferenced detached provider HEAD"
+    [[ "$(git -C "$provider" rev-parse HEAD)" == "$detached_sha" ]] ||
+        fail "failed detached sync rewrote the unique HEAD"
+    [[ -z "$(git -C "$provider" branch --show-current)" ]] ||
+        fail "failed detached sync switched away from the unique HEAD"
+
+    # Give the test-only detached commit a durable ref, then verify dirty
+    # source state also blocks before any checkout or branch movement.
+    git -C "$rig" branch audit-detached-preserved "$detached_sha"
+    git -C "$provider" checkout -q "$stable"
+    stable_sha=$(git -C "$provider" rev-parse HEAD)
+    printf 'dirty\n' >"$provider/dirty.txt"
+    set +e
+    "$WORKTREE_SETUP" "$rig" "$provider" gastown.nux --sync
+    status=$?
+    set -e
+    [[ "$status" -ne 0 && -f "$provider/dirty.txt" ]] ||
+        fail "sync accepted or discarded dirty provider work"
+    [[ "$(git -C "$provider" rev-parse HEAD)" == "$stable_sha" ]] ||
+        fail "dirty sync moved the stable branch"
+    rm -f "$provider/dirty.txt"
+
+    # Unique/diverged work on the stable branch is not infrastructure state;
+    # preserve it for recovery instead of rebasing or resetting it.
+    printf 'stable unique\n' >"$provider/stable-unique.txt"
+    git -C "$provider" add stable-unique.txt
+    git -C "$provider" commit -qm "stable unique"
+    stable_sha=$(git -C "$provider" rev-parse HEAD)
+    printf 'main diverges\n' >"$rig/main-c.txt"
+    git -C "$rig" add main-c.txt
+    git -C "$rig" commit -qm "main C"
+    git -C "$rig" push -qu origin main
+    set +e
+    "$WORKTREE_SETUP" "$rig" "$provider" gastown.nux --sync
+    status=$?
+    set -e
+    [[ "$status" -ne 0 ]] ||
+        fail "sync accepted unique/diverged stable provider work"
+    [[ "$(git -C "$provider" rev-parse HEAD)" == "$stable_sha" ]] ||
+        fail "failed diverged sync rewrote the stable branch"
+
+    # A Git worktree at the configured path is not sufficient: it must share
+    # the exact rig repository common dir. Refuse foreign repositories before
+    # touching their excludes, branch, or HEAD.
+    init_repo "$foreign"
+    foreign_head=$(git -C "$foreign" rev-parse HEAD)
+    foreign_exclude_before=$(git hash-object "$foreign/.git/info/exclude")
+    set +e
+    "$WORKTREE_SETUP" "$rig" "$foreign" gastown.foreign --sync
+    status=$?
+    set -e
+    [[ "$status" -ne 0 ]] ||
+        fail "sync accepted a foreign repository at the provider path"
+    [[ "$(git -C "$foreign" rev-parse HEAD)" == "$foreign_head" ]] ||
+        fail "foreign-worktree refusal moved its HEAD"
+    [[ "$(git hash-object "$foreign/.git/info/exclude")" == "$foreign_exclude_before" ]] ||
+        fail "foreign-worktree refusal mutated its local excludes"
 }
 
 test_shutdown_probe_scopes_rig_and_fails_closed() {
@@ -568,8 +725,24 @@ cat >"$bin/gc" <<'SH'
 printf '%s\n' "$*" >>"$GC_STUB_CALLS"
 bd_subcommand=$(printf '%s%s' b d)
 case "$*" in
-    "$bd_subcommand --rig "*" show "*" --json")
+    "$bd_subcommand --rig "*" list --status=closed --has-metadata-key=artifact_cleanup_state --limit=0 --json")
         cat "$GC_STUB_BEAD_JSON"
+        ;;
+    "$bd_subcommand --rig "*" show "*" --json")
+        if [ -n "${GC_STUB_BEAD_JSON_SECOND:-}" ]; then
+            count=0
+            [ ! -f "$GC_STUB_SHOW_COUNT" ] ||
+                count=$(cat "$GC_STUB_SHOW_COUNT")
+            count=$((count + 1))
+            printf '%s\n' "$count" >"$GC_STUB_SHOW_COUNT"
+            if [ "$count" -ge 2 ]; then
+                cat "$GC_STUB_BEAD_JSON_SECOND"
+            else
+                cat "$GC_STUB_BEAD_JSON"
+            fi
+        else
+            cat "$GC_STUB_BEAD_JSON"
+        fi
         ;;
     "$bd_subcommand --rig "*" update "*)
         exit "${GC_STUB_UPDATE_EXIT:-0}"
@@ -583,29 +756,69 @@ SH
     chmod +x "$bin/gc"
 }
 
+write_git_status_failure_wrapper() {
+    local bin=$1
+    mkdir -p "$bin"
+cat >"$bin/git" <<'SH'
+#!/bin/sh
+for arg in "$@"; do
+    if [ "$arg" = status ]; then
+        count=0
+        [ ! -f "$GIT_STATUS_STUB_COUNT" ] ||
+            count=$(cat "$GIT_STATUS_STUB_COUNT")
+        count=$((count + 1))
+        printf '%s\n' "$count" >"$GIT_STATUS_STUB_COUNT"
+        if [ "$count" -eq "$GIT_STATUS_STUB_FAIL_ON" ]; then
+            echo "injected git status failure" >&2
+            exit 73
+        fi
+        break
+    fi
+done
+exec "$GIT_STATUS_STUB_REAL" "$@"
+SH
+    chmod +x "$bin/git"
+}
+
 write_cleanup_bead_json() {
-    local output=$1 status=$2 result=$3 sha=$4 artifact=$5 state=${6:-}
+    local output=$1 bead=$2 status=$3 result=$4 sha=$5 artifact=$6
+    local state=${7:-} branch=${8:-polecat/$bead} target=${9:-main}
+    local delivered_sha=${10:-$sha}
     jq -n \
+        --arg bead "$bead" \
         --arg status "$status" \
         --arg result "$result" \
         --arg sha "$sha" \
         --arg artifact "$artifact" \
         --arg state "$state" \
+        --arg branch "$branch" \
+        --arg target "$target" \
+        --arg delivered "$delivered_sha" \
         '[{
+          id: $bead,
           status: $status,
           metadata: ({
             merge_result: $result,
             artifact_source_sha: $sha,
-            artifact_dir: $artifact
-          } + (if $state == "" then {} else {artifact_cleanup_state: $state} end))
+            artifact_dir: $artifact,
+            branch: $branch,
+            merged_target: $target
+          } + (if $result == "pull_request"
+               then {pr_head_sha: $delivered}
+               elif $result == "pull_request_merged" or $result == "mr_merged"
+               then {pr_head_sha: $delivered, merged_sha: $delivered}
+               else {merged_sha: $delivered}
+               end)
+            + (if $state == "" then {} else {artifact_cleanup_state: $state} end))
         }]' >"$output"
 }
 
 test_cleanup_command_is_idempotent_and_mr_retryable() {
-    local tmp rig city canonical bin bead_json calls sha
+    local tmp rig remote city canonical sweep_artifact bin bead_json calls sha
     tmp=$(mktemp -d)
     trap 'rm -rf "$tmp"' RETURN
     rig="$tmp/rig"
+    remote="$tmp/remote.git"
     city="$tmp/city"
     canonical="$city/.gc/worktrees/demo/artifacts/worktrees/ac-safe1"
     bin="$tmp/bin"
@@ -613,12 +826,19 @@ test_cleanup_command_is_idempotent_and_mr_retryable() {
     calls="$tmp/calls"
 
     init_repo "$rig"
+    git -C "$rig" branch -M main
+    git init -q --bare "$remote"
+    git -C "$remote" symbolic-ref HEAD refs/heads/main
+    git -C "$rig" remote add origin "$remote"
+    git -C "$rig" push -qu origin main
     mkdir -p "$(dirname "$canonical")" "$city/.gc/worktrees/demo/polecats"
     git -C "$rig" worktree add -qb cleanup-task "$canonical" HEAD
     sha=$(git -C "$canonical" rev-parse HEAD)
+    git -C "$rig" push -qu origin HEAD:refs/heads/polecat/ac-safe1
     write_cleanup_gc_stub "$bin"
 
-    write_cleanup_bead_json "$bead_json" blocked pull_request "$sha" "$canonical"
+    write_cleanup_bead_json \
+        "$bead_json" ac-safe1 blocked pull_request "$sha" "$canonical"
     GC_STUB_BEAD_JSON="$bead_json" GC_STUB_CALLS="$calls" \
         GC_CITY_PATH="$city" GC_RIG=demo GC_RIG_ROOT="$rig" \
         PATH="$bin:$PATH" "$ARTIFACT_CLEANUP" ac-safe1
@@ -628,7 +848,8 @@ test_cleanup_command_is_idempotent_and_mr_retryable() {
         fail "non-terminal MR cleanup did not record a pending retry marker"
 
     : >"$calls"
-    write_cleanup_bead_json "$bead_json" closed merged "$sha" "$canonical" pending
+    write_cleanup_bead_json \
+        "$bead_json" ac-safe1 closed merged "$sha" "$canonical" pending
     GC_STUB_BEAD_JSON="$bead_json" GC_STUB_CALLS="$calls" \
         GC_CITY_PATH="$city" GC_RIG=demo GC_RIG_ROOT="$rig" \
         PATH="$bin:$PATH" "$ARTIFACT_CLEANUP" ac-safe1
@@ -645,15 +866,34 @@ test_cleanup_command_is_idempotent_and_mr_retryable() {
         PATH="$bin:$PATH" "$ARTIFACT_CLEANUP" ac-safe1
     grep -qF 'artifact_cleanup_state=complete' "$calls" ||
         fail "missing-path retry did not converge to complete"
+
+    # Simulate a crash after terminal closure but before the immediate cleanup
+    # invocation. The durable pending marker lets the next refinery scan find
+    # and retire one closed artifact without an explicit bead argument.
+    sweep_artifact="$city/.gc/worktrees/demo/artifacts/worktrees/ac-sweep"
+    git -C "$rig" worktree add -q --detach "$sweep_artifact" HEAD
+    sha=$(git -C "$sweep_artifact" rev-parse HEAD)
+    git -C "$rig" push -qu origin HEAD:refs/heads/polecat/ac-sweep
+    write_cleanup_bead_json \
+        "$bead_json" ac-sweep closed merged "$sha" "$sweep_artifact" pending
+    : >"$calls"
+    GC_STUB_BEAD_JSON="$bead_json" GC_STUB_CALLS="$calls" \
+        GC_CITY_PATH="$city" GC_RIG=demo GC_RIG_ROOT="$rig" \
+        PATH="$bin:$PATH" "$ARTIFACT_CLEANUP"
+    [[ ! -e "$sweep_artifact" ]] ||
+        fail "no-argument pending sweep did not close the pre-invocation crash window"
+    grep -qF 'list --status=closed --has-metadata-key=artifact_cleanup_state' "$calls" ||
+        fail "no-argument cleanup did not query the durable pending queue"
 }
 
 test_cleanup_command_rejects_cross_city_and_dirty_artifacts() {
     local tmp rig city_a city_b cross_city cross_rig wrong_namespace wrong_bead
     local symlink_path symlink_target foreign dirty provider legacy
-    local bin bead_json calls sha status
+    local remote bin bead_json calls sha status
     tmp=$(mktemp -d)
     trap 'rm -rf "$tmp"' RETURN
     rig="$tmp/rig"
+    remote="$tmp/remote.git"
     city_a="$tmp/city-a"
     city_b="$tmp/city-b"
     cross_city="$city_b/.gc/worktrees/demo/artifacts/worktrees/ac-safe1"
@@ -671,6 +911,11 @@ test_cleanup_command_rejects_cross_city_and_dirty_artifacts() {
     calls="$tmp/calls"
 
     init_repo "$rig"
+    git -C "$rig" branch -M main
+    git init -q --bare "$remote"
+    git -C "$remote" symbolic-ref HEAD refs/heads/main
+    git -C "$rig" remote add origin "$remote"
+    git -C "$rig" push -qu origin main
     mkdir -p \
         "$(dirname "$cross_city")" \
         "$(dirname "$cross_rig")" \
@@ -696,7 +941,7 @@ test_cleanup_command_rejects_cross_city_and_dirty_artifacts() {
         local bead=$1 artifact=$2 label=$3 artifact_sha
         artifact_sha=$(git -C "$artifact" rev-parse HEAD)
         write_cleanup_bead_json \
-            "$bead_json" closed merged "$artifact_sha" "$artifact"
+            "$bead_json" "$bead" closed merged "$artifact_sha" "$artifact"
         : >"$calls"
         set +e
         GC_STUB_BEAD_JSON="$bead_json" GC_STUB_CALLS="$calls" \
@@ -720,7 +965,8 @@ test_cleanup_command_rejects_cross_city_and_dirty_artifacts() {
 
     : >"$calls"
     sha=$(git -C "$dirty" rev-parse HEAD)
-    write_cleanup_bead_json "$bead_json" closed merged "$sha" "$dirty"
+    write_cleanup_bead_json \
+        "$bead_json" ac-dirty closed merged "$sha" "$dirty"
     set +e
     GC_STUB_BEAD_JSON="$bead_json" GC_STUB_CALLS="$calls" \
         GC_CITY_PATH="$city_a" GC_RIG=demo GC_RIG_ROOT="$rig" \
@@ -734,12 +980,378 @@ test_cleanup_command_rejects_cross_city_and_dirty_artifacts() {
 
     : >"$calls"
     sha=$(git -C "$legacy" rev-parse HEAD)
-    write_cleanup_bead_json "$bead_json" closed merged "$sha" "$legacy"
+    git -C "$rig" push -qu origin HEAD:refs/heads/polecat/ac-legacy
+    write_cleanup_bead_json \
+        "$bead_json" ac-legacy closed merged "$sha" "$legacy"
     GC_STUB_BEAD_JSON="$bead_json" GC_STUB_CALLS="$calls" \
         GC_CITY_PATH="$city_a" GC_RIG=demo GC_RIG_ROOT="$rig" \
         PATH="$bin:$PATH" "$ARTIFACT_CLEANUP" ac-legacy
     [[ ! -e "$legacy" && -d "$provider" ]] ||
         fail "valid in-place legacy artifact cleanup did not preserve its provider home"
+}
+
+test_cleanup_requires_live_remote_evidence_and_stable_state() {
+    local tmp rig remote city bin bead_json second_json calls show_count
+    local artifact source_sha delivered_sha target_sha remote_record status
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' RETURN
+    rig="$tmp/rig"
+    remote="$tmp/remote.git"
+    city="$tmp/city"
+    bin="$tmp/bin"
+    bead_json="$tmp/bead.json"
+    second_json="$tmp/bead-second.json"
+    calls="$tmp/calls"
+    show_count="$tmp/show-count"
+
+    init_repo "$rig"
+    git -C "$rig" branch -M main
+    git init -q --bare "$remote"
+    git -C "$remote" symbolic-ref HEAD refs/heads/main
+    git -C "$rig" remote add origin "$remote"
+    git -C "$rig" push -qu origin main
+    mkdir -p "$city/.gc/worktrees/demo/artifacts/worktrees" \
+        "$city/.gc/worktrees/demo/polecats"
+    write_cleanup_gc_stub "$bin"
+
+    # A stale merged_sha can independently name an unrelated commit that is
+    # genuinely present on the target. That corroborates terminal state but
+    # proves no relation from the pre-rebase artifact source. Local cleanup is
+    # safe only because the exact remote source ref remains the recovery copy.
+    artifact="$city/.gc/worktrees/demo/artifacts/worktrees/ac-unrelated"
+    git -C "$rig" worktree add -q --detach "$artifact" origin/main
+    printf 'artifact source\n' >"$artifact/artifact-source"
+    git -C "$artifact" add artifact-source
+    git -C "$artifact" commit -qm "artifact source"
+    source_sha=$(git -C "$artifact" rev-parse HEAD)
+    git -C "$artifact" push -qu origin \
+        HEAD:refs/heads/polecat/ac-unrelated
+    printf 'unrelated target delivery\n' >"$rig/unrelated-target"
+    git -C "$rig" add unrelated-target
+    git -C "$rig" commit -qm "unrelated target delivery"
+    git -C "$rig" push -qu origin main
+    target_sha=$(git -C "$rig" rev-parse HEAD)
+    if git -C "$rig" merge-base --is-ancestor "$source_sha" "$target_sha"; then
+        fail "stale-merged fixture unexpectedly relates artifact source to target"
+    fi
+    write_cleanup_bead_json \
+        "$bead_json" ac-unrelated closed merged \
+        "$source_sha" "$artifact" "" polecat/ac-unrelated main "$target_sha"
+    : >"$calls"
+    GC_STUB_BEAD_JSON="$bead_json" GC_STUB_CALLS="$calls" \
+        GC_CITY_PATH="$city" GC_RIG=demo GC_RIG_ROOT="$rig" \
+        PATH="$bin:$PATH" "$ARTIFACT_CLEANUP" ac-unrelated
+    [[ ! -e "$artifact" ]] ||
+        fail "cleanup did not retire stale-merged fixture's local artifact"
+    remote_record=$(git -C "$rig" ls-remote --exit-code --heads origin \
+        refs/heads/polecat/ac-unrelated)
+    [[ "$remote_record" == \
+       "$source_sha"$'\t'"refs/heads/polecat/ac-unrelated" ]] ||
+        fail "cleanup removed the unrelated fixture's durable source ref"
+
+    # A clean, metadata-matching artifact is not disposable when its claimed
+    # merge SHA is absent from the independently refreshed target. This is the
+    # only-reachable-worktree regression: detach and remove its local branch so
+    # no ref retains the unique commit.
+    artifact="$city/.gc/worktrees/demo/artifacts/worktrees/ac-unreachable"
+    git -C "$rig" worktree add -qb unreachable-task "$artifact" HEAD
+    printf 'only reachable from the task worktree\n' >"$artifact/unique"
+    git -C "$artifact" add unique
+    git -C "$artifact" commit -qm unique
+    source_sha=$(git -C "$artifact" rev-parse HEAD)
+    git -C "$artifact" checkout -q --detach
+    git -C "$rig" branch -D unreachable-task >/dev/null
+    target_sha=$(git -C "$rig" rev-parse refs/remotes/origin/main)
+    write_cleanup_bead_json \
+        "$bead_json" ac-unreachable closed merged \
+        "$source_sha" "$artifact" "" polecat/ac-unreachable main "$target_sha"
+    set +e
+    GC_STUB_BEAD_JSON="$bead_json" GC_STUB_CALLS="$calls" \
+        GC_CITY_PATH="$city" GC_RIG=demo GC_RIG_ROOT="$rig" \
+        PATH="$bin:$PATH" "$ARTIFACT_CLEANUP" ac-unreachable
+    status=$?
+    set -e
+    [[ "$status" -ne 0 && -d "$artifact" ]] ||
+        fail "cleanup removed the only reachable worktree without target evidence"
+
+    # A durable source ref is still insufficient when the claimed merge commit
+    # is not reachable from the freshly fetched target.
+    artifact="$city/.gc/worktrees/demo/artifacts/worktrees/ac-bad-target"
+    git -C "$rig" worktree add -q --detach "$artifact" origin/main
+    source_sha=$(git -C "$artifact" rev-parse HEAD)
+    git -C "$rig" push -qu origin \
+        refs/remotes/origin/main:refs/heads/polecat/ac-bad-target
+    printf 'not delivered to target\n' >"$rig/not-delivered"
+    git -C "$rig" add not-delivered
+    git -C "$rig" commit -qm "not delivered"
+    delivered_sha=$(git -C "$rig" rev-parse HEAD)
+    write_cleanup_bead_json \
+        "$bead_json" ac-bad-target closed merged \
+        "$source_sha" "$artifact" "" polecat/ac-bad-target main "$delivered_sha"
+    : >"$calls"
+    set +e
+    GC_STUB_BEAD_JSON="$bead_json" GC_STUB_CALLS="$calls" \
+        GC_CITY_PATH="$city" GC_RIG=demo GC_RIG_ROOT="$rig" \
+        PATH="$bin:$PATH" "$ARTIFACT_CLEANUP" ac-bad-target
+    status=$?
+    set -e
+    [[ "$status" -ne 0 && -d "$artifact" ]] ||
+        fail "cleanup accepted a merge SHA absent from the refreshed target"
+    grep -qF 'artifact_cleanup_state=blocked' "$calls" ||
+        fail "target ancestry mismatch was not marked blocked"
+
+    # Current-main MR semantics close at publication. The artifact still
+    # points at the pre-rebase source SHA, so cleanup must prove the validated
+    # rebased PR head through the exact remote source ref instead.
+    artifact="$city/.gc/worktrees/demo/artifacts/worktrees/ac-pr"
+    git -C "$rig" worktree add -q --detach "$artifact" HEAD
+    source_sha=$(git -C "$artifact" rev-parse HEAD)
+    printf 'rebased publication\n' >"$rig/published"
+    git -C "$rig" add published
+    git -C "$rig" commit -qm "published PR head"
+    delivered_sha=$(git -C "$rig" rev-parse HEAD)
+    write_cleanup_bead_json \
+        "$bead_json" ac-pr closed pull_request \
+        "$source_sha" "$artifact" "" polecat/ac-pr main "$delivered_sha"
+
+    set +e
+    : >"$calls"
+    GC_STUB_BEAD_JSON="$bead_json" GC_STUB_CALLS="$calls" \
+        GC_CITY_PATH="$city" GC_RIG=demo GC_RIG_ROOT="$rig" \
+        PATH="$bin:$PATH" "$ARTIFACT_CLEANUP" ac-pr
+    status=$?
+    set -e
+    [[ "$status" -ne 0 && -d "$artifact" ]] ||
+        fail "PR cleanup accepted a missing origin source ref"
+
+    git -C "$rig" push -qu origin \
+        refs/remotes/origin/main:refs/heads/polecat/ac-pr
+    set +e
+    : >"$calls"
+    GC_STUB_BEAD_JSON="$bead_json" GC_STUB_CALLS="$calls" \
+        GC_CITY_PATH="$city" GC_RIG=demo GC_RIG_ROOT="$rig" \
+        PATH="$bin:$PATH" "$ARTIFACT_CLEANUP" ac-pr
+    status=$?
+    set -e
+    [[ "$status" -ne 0 && -d "$artifact" ]] ||
+        fail "PR cleanup accepted a mismatched origin source ref"
+
+    git -C "$rig" push -qf origin HEAD:refs/heads/polecat/ac-pr
+    GC_STUB_BEAD_JSON="$bead_json" GC_STUB_CALLS="$calls" \
+        GC_CITY_PATH="$city" GC_RIG=demo GC_RIG_ROOT="$rig" \
+        PATH="$bin:$PATH" "$ARTIFACT_CLEANUP" ac-pr
+    [[ ! -e "$artifact" ]] ||
+        fail "PR cleanup rejected the exact remotely durable validated head"
+    remote_record=$(git -C "$rig" ls-remote --exit-code --heads origin \
+        refs/heads/polecat/ac-pr)
+    [[ "$remote_record" == \
+       "$delivered_sha"$'\t'"refs/heads/polecat/ac-pr" ]] ||
+        fail "PR cleanup removed the validated remote recovery source ref"
+
+    # Verified terminal MR cleanup likewise retires only the local artifact;
+    # the exact validated remote source ref remains recovery evidence.
+    artifact="$city/.gc/worktrees/demo/artifacts/worktrees/ac-mr"
+    git -C "$rig" worktree add -q --detach "$artifact" origin/main
+    source_sha=$(git -C "$artifact" rev-parse HEAD)
+    git -C "$rig" push -qu origin \
+        "$source_sha:refs/heads/polecat/ac-mr"
+    write_cleanup_bead_json \
+        "$bead_json" ac-mr closed mr_merged \
+        "$source_sha" "$artifact" "" polecat/ac-mr main "$source_sha"
+    GC_STUB_BEAD_JSON="$bead_json" GC_STUB_CALLS="$calls" \
+        GC_CITY_PATH="$city" GC_RIG=demo GC_RIG_ROOT="$rig" \
+        PATH="$bin:$PATH" "$ARTIFACT_CLEANUP" ac-mr
+    [[ ! -e "$artifact" ]] ||
+        fail "verified MR cleanup did not retire the local artifact"
+    remote_record=$(git -C "$rig" ls-remote --exit-code --heads origin \
+        refs/heads/polecat/ac-mr)
+    [[ "$remote_record" == \
+       "$source_sha"$'\t'"refs/heads/polecat/ac-mr" ]] ||
+        fail "verified MR cleanup removed its remote recovery source ref"
+
+    # Even valid remote evidence is stale if the bead changes between the
+    # initial decision and the final pre-removal read.
+    artifact="$city/.gc/worktrees/demo/artifacts/worktrees/ac-race"
+    git -C "$rig" worktree add -q --detach "$artifact" origin/main
+    source_sha=$(git -C "$artifact" rev-parse HEAD)
+    git -C "$rig" push -qu origin \
+        refs/remotes/origin/main:refs/heads/polecat/ac-race
+    write_cleanup_bead_json \
+        "$bead_json" ac-race closed merged \
+        "$source_sha" "$artifact" "" polecat/ac-race main "$source_sha"
+    write_cleanup_bead_json \
+        "$second_json" ac-race open merged \
+        "$source_sha" "$artifact" "" polecat/ac-race main "$source_sha"
+    : >"$calls"
+    : >"$show_count"
+    set +e
+    GC_STUB_BEAD_JSON="$bead_json" \
+        GC_STUB_BEAD_JSON_SECOND="$second_json" \
+        GC_STUB_SHOW_COUNT="$show_count" \
+        GC_STUB_CALLS="$calls" \
+        GC_CITY_PATH="$city" GC_RIG=demo GC_RIG_ROOT="$rig" \
+        PATH="$bin:$PATH" "$ARTIFACT_CLEANUP" ac-race
+    status=$?
+    set -e
+    [[ "$status" -ne 0 && -d "$artifact" ]] ||
+        fail "cleanup removed an artifact after the bead was reopened"
+    if grep -qF -- '--unset-metadata artifact_dir' "$calls"; then
+        fail "stale-state rejection cleared artifact metadata"
+    fi
+
+    # A one-row response must also be the requested row, not merely any object
+    # returned by a misrouted or corrupt metadata lookup.
+    jq '.[] .id = "ac-other"' "$bead_json" >"$second_json"
+    : >"$calls"
+    set +e
+    GC_STUB_BEAD_JSON="$second_json" GC_STUB_CALLS="$calls" \
+        GC_CITY_PATH="$city" GC_RIG=demo GC_RIG_ROOT="$rig" \
+        PATH="$bin:$PATH" "$ARTIFACT_CLEANUP" ac-race
+    status=$?
+    set -e
+    [[ "$status" -ne 0 && -d "$artifact" ]] ||
+        fail "cleanup accepted a different one-row bead response"
+}
+
+test_git_status_failures_preserve_artifacts_and_provider_state() {
+    local tmp rig remote city provider artifact bin bead_json calls
+    local fail_on source_sha stable_head stable_branch status real_git
+    local status_count
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' RETURN
+    rig="$tmp/rig"
+    remote="$tmp/remote.git"
+    city="$tmp/city"
+    provider="$city/.gc/worktrees/demo/polecats/gastown.nux"
+    artifact="$city/.gc/worktrees/demo/artifacts/worktrees/ac-status"
+    bin="$tmp/bin"
+    bead_json="$tmp/bead.json"
+    calls="$tmp/calls"
+    status_count="$tmp/status-count"
+    real_git=$(command -v git)
+
+    init_repo "$rig"
+    git -C "$rig" branch -M main
+    git init -q --bare "$remote"
+    git -C "$remote" symbolic-ref HEAD refs/heads/main
+    git -C "$rig" remote add origin "$remote"
+    git -C "$rig" push -qu origin main
+    "$WORKTREE_SETUP" "$rig" "$provider" gastown.nux
+    stable_head=$(git -C "$provider" rev-parse HEAD)
+    stable_branch=$(git -C "$provider" branch --show-current)
+
+    write_git_status_failure_wrapper "$bin"
+    : >"$status_count"
+    set +e
+    GIT_STATUS_STUB_REAL="$real_git" \
+        GIT_STATUS_STUB_COUNT="$status_count" \
+        GIT_STATUS_STUB_FAIL_ON=1 \
+        PATH="$bin:$PATH" \
+        "$WORKTREE_SETUP" "$rig" "$provider" gastown.nux --sync
+    status=$?
+    set -e
+    [[ "$status" -ne 0 ]] ||
+        fail "provider sync interpreted a failed git status as clean"
+    [[ "$(git -C "$provider" rev-parse HEAD)" == "$stable_head" &&
+       "$(git -C "$provider" branch --show-current)" == "$stable_branch" ]] ||
+        fail "provider sync moved state after git status failed"
+
+    mkdir -p "$(dirname "$artifact")"
+    git -C "$rig" worktree add -q --detach "$artifact" origin/main
+    source_sha=$(git -C "$artifact" rev-parse HEAD)
+    git -C "$rig" push -qu origin \
+        "$source_sha:refs/heads/polecat/ac-status"
+    write_cleanup_gc_stub "$bin"
+    write_cleanup_bead_json \
+        "$bead_json" ac-status closed merged \
+        "$source_sha" "$artifact" "" polecat/ac-status main "$source_sha"
+
+    # Exercise both the initial dirtiness check and the final race-narrowing
+    # recheck. Either command failure must preserve the artifact.
+    for fail_on in 1 2; do
+        : >"$calls"
+        : >"$status_count"
+        set +e
+        GC_STUB_BEAD_JSON="$bead_json" GC_STUB_CALLS="$calls" \
+            GC_CITY_PATH="$city" GC_RIG=demo GC_RIG_ROOT="$rig" \
+            GIT_STATUS_STUB_REAL="$real_git" \
+            GIT_STATUS_STUB_COUNT="$status_count" \
+            GIT_STATUS_STUB_FAIL_ON="$fail_on" \
+            PATH="$bin:$PATH" "$ARTIFACT_CLEANUP" ac-status
+        status=$?
+        set -e
+        [[ "$status" -ne 0 && -d "$artifact" ]] ||
+            fail "artifact cleanup removed work after git status check $fail_on failed"
+        grep -qF 'artifact_cleanup_state=blocked' "$calls" ||
+            fail "git status failure $fail_on did not record blocked cleanup"
+    done
+}
+
+test_witness_status_failure_blocks_artifact_removal() {
+    local tmp rig remote city artifact gate bin real_git source_sha
+    local status_count output
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' RETURN
+    rig="$tmp/rig"
+    remote="$tmp/remote.git"
+    city="$tmp/city"
+    artifact="$city/.gc/worktrees/demo/artifacts/worktrees/ac-status"
+    gate="$tmp/witness-artifact-safety-gate.sh"
+    bin="$tmp/bin"
+    status_count="$tmp/status-count"
+    output="$tmp/output"
+    real_git=$(command -v git)
+
+    init_repo "$rig"
+    git -C "$rig" branch -M main
+    git init -q --bare "$remote"
+    git -C "$remote" symbolic-ref HEAD refs/heads/main
+    git -C "$rig" remote add origin "$remote"
+    git -C "$rig" push -qu origin main
+    mkdir -p "$(dirname "$artifact")"
+    git -C "$rig" worktree add -q --detach "$artifact" origin/main
+    source_sha=$(git -C "$artifact" rev-parse HEAD)
+    git -C "$rig" push -qu origin \
+        "$source_sha:refs/heads/polecat/ac-status"
+
+    extract_witness_artifact_safety_gate "$gate"
+    write_git_status_failure_wrapper "$bin"
+    : >"$status_count"
+    (
+        export GIT_STATUS_STUB_REAL="$real_git"
+        export GIT_STATUS_STUB_COUNT="$status_count"
+        export GIT_STATUS_STUB_FAIL_ON=1
+        export PATH="$bin:$PATH"
+        GC_CITY_PATH="$city"
+        GC_RIG=demo
+        GC_RIG_ROOT="$rig"
+        RECOVERY_MODE=reset
+        RECOVERY_BLOCKED=false
+        WORKTREE="$artifact"
+        CURRENT_CANONICAL_ARTIFACT="$artifact"
+        CURRENT_ARTIFACT="$artifact"
+        BRANCH=polecat/ac-status
+        validate_recovery_artifact_worktree() {
+            printf '%s\n' "$1"
+        }
+        gc() {
+            printf 'mail=%s\n' "$*"
+        }
+        # shellcheck source=/dev/null
+        source "$gate"
+        printf 'artifact_safe=%s recovery_blocked=%s\n' \
+            "$ARTIFACT_SAFE" "$RECOVERY_BLOCKED"
+        if [ "$ARTIFACT_SAFE" = true ]; then
+            git -C "$rig" worktree remove "$artifact"
+        fi
+    ) >"$output" 2>&1
+
+    rg -q '^artifact_safe=false recovery_blocked=true$' "$output" ||
+        fail "witness treated a failed git status probe as safe"
+    rg -q '^mail=mail send mayor/ -s RECOVERY_BLOCKED: artifact status unreadable for ac-status ' "$output" ||
+        fail "witness status failure did not escalate to mayor"
+    [[ -d "$artifact" ]] ||
+        fail "witness status failure allowed artifact removal"
 }
 
 test_metadata_migration_and_consumers_are_canonical_first() {
@@ -813,6 +1425,8 @@ if 'git branch -D "$EXPECTED_BRANCH"' in workspace or 'git branch -D "$BRANCH"' 
     raise SystemExit("empty-branch recovery can delete an unrecorded work branch")
 if "--unset-metadata artifact_source_sha" not in submit:
     raise SystemExit("polecat submission does not retire stale refinery artifact proof")
+if "--unset-metadata artifact_cleanup_state" not in submit:
+    raise SystemExit("polecat submission does not retire stale cleanup state")
 canonical_guard = workspace.index("Canonical artifact_dir is missing or unsafe")
 legacy_fallback = workspace.index('elif [ -n "$LEGACY_WORK_DIR" ]')
 if canonical_guard > legacy_fallback:
@@ -820,6 +1434,7 @@ if canonical_guard > legacy_fallback:
 
 with witness_path.open("rb") as handle:
     witness = tomllib.load(handle)
+witness_description = witness["description"]
 recovery = next(step["description"] for step in witness["steps"] if step["id"] == "recover-orphaned-beads")
 for fragment in (
     "metadata.artifact_dir",
@@ -834,6 +1449,9 @@ for fragment in (
     'cd "$GC_RIG_ROOT"',
     'rig_namespace="$city_real/.gc/worktrees/$rig_name"',
     'provider_root" = "$rig_namespace_real/polecats',
+    'WORKTREE_STATUS=$(git -C "$WORKTREE" status --porcelain)',
+    "blocking cleanup and escalating for manual recovery",
+    "exact remote branch remains recovery evidence",
 ):
     if fragment not in recovery:
         raise SystemExit(f"witness recovery contract missing: {fragment}")
@@ -844,6 +1462,15 @@ if 'if [ -n "$BRANCH" ]; then' not in recovery:
     raise SystemExit("witness recovery can run remote/merge checks with an empty branch")
 if 'worktree remove "$WORKTREE" --force' in recovery:
     raise SystemExit("witness artifact cleanup force-removes a worktree")
+if '[ -z "$(git -C "$WORKTREE" status --porcelain)" ]' in recovery:
+    raise SystemExit("witness cleanup still treats git status failure as clean")
+for fragment in (
+    "target is canonical",
+    "exact successfully\n  handed-off source ref is retained",
+    "recovery never deletes that ref",
+):
+    if fragment not in witness_description:
+        raise SystemExit(f"witness role contract missing retained-ref policy: {fragment}")
 if recovery.index("confirm_orphan_still_unowned") > recovery.index(
     "--set-metadata artifact_dir="
 ):
@@ -876,19 +1503,31 @@ for fragment in (
 with refinery_path.open("rb") as handle:
     refinery = tomllib.load(handle)
 rebase = next(step["description"] for step in refinery["steps"] if step["id"] == "rebase")
+find_work = next(step["description"] for step in refinery["steps"] if step["id"] == "find-work")
 merge = next(step["description"] for step in refinery["steps"] if step["id"] == "merge-push")
 if '--set-metadata artifact_source_sha="$ARTIFACT_SOURCE_SHA"' not in rebase:
     raise SystemExit("refinery does not durably capture the pre-rebase artifact SHA")
+if "--set-metadata artifact_cleanup_state=pending" not in rebase:
+    raise SystemExit("refinery does not arm the durable cleanup retry marker")
+if "gc gastown task-artifact-cleanup" not in find_work:
+    raise SystemExit("refinery does not retry a closed pending artifact before new work")
 for fragment in (
     "**Successful task-artifact cleanup (direct and mr):**",
     'gc gastown task-artifact-cleanup "$WORK"',
+    '--set-metadata pr_head_sha="$PR_HEAD_SHA"',
+    'if [ "$PR_HEAD_SHA" != "$EXPECTED_PR_HEAD" ]',
     "artifact_cleanup_state=pending",
     "artifact_cleanup_state=complete",
     "ARTIFACT_CLEANUP_DEFERRED",
     "MR reconciliation MUST run",
+    "retains that source ref after local cleanup",
 ):
     if fragment not in merge:
         raise SystemExit(f"refinery artifact cleanup contract missing: {fragment}")
+if 'delete_merged_branches = "true": `git push origin --delete $BRANCH`' in merge:
+    raise SystemExit("successful direct cleanup can still delete its recovery source ref")
+if "leak the merged branch" in merge:
+    raise SystemExit("refinery still describes an intentionally retained source ref as leaked")
 polecat_prompt = polecat_prompt_path.read_text(encoding="utf-8")
 witness_prompt = witness_prompt_path.read_text(encoding="utf-8")
 if "`metadata.artifact_dir`" not in polecat_prompt:
@@ -909,6 +1548,13 @@ if "new nested worktree is created" in workspace:
     raise SystemExit("workspace recipe still describes canonical artifacts as nested worktrees")
 if "`metadata.artifact_dir`" not in witness_prompt:
     raise SystemExit("witness prompt does not document canonical artifact_dir")
+for forbidden in (
+    "Delete branches after merge",
+    "previous location is disposable",
+    "git worktree remove <path> --force",
+):
+    if forbidden in witness_prompt:
+        raise SystemExit(f"witness prompt retains unsafe source-ref guidance: {forbidden}")
 PY
 }
 
@@ -918,9 +1564,13 @@ test_workspace_metadata_reads_fail_closed_without_pipefail
 test_workspace_collision_fails_closed_without_alternate
 test_workspace_rejects_redirected_artifact_root_before_creation
 test_worktree_setup_ignores_gc_without_mutating_tracked_or_global_ignores
+test_worktree_sync_preserves_task_state_and_only_fast_forwards_stable_branch
 test_shutdown_probe_scopes_rig_and_fails_closed
 test_cleanup_command_is_idempotent_and_mr_retryable
 test_cleanup_command_rejects_cross_city_and_dirty_artifacts
+test_cleanup_requires_live_remote_evidence_and_stable_state
+test_git_status_failures_preserve_artifacts_and_provider_state
+test_witness_status_failure_blocks_artifact_removal
 if rg -n 'worktree remove .*--force' "$ARTIFACT_CLEANUP" >/dev/null; then
     fail "artifact cleanup contains a force-removal path"
 fi

--- a/gastown/tests/test_polecat_artifact_dir.sh
+++ b/gastown/tests/test_polecat_artifact_dir.sh
@@ -64,12 +64,13 @@ init_repo() {
 }
 
 test_shutdown_probe_scopes_rig_and_fails_closed() {
-    local tmp probe calls output
+    local tmp probe calls output bd_subcommand
     tmp=$(mktemp -d)
     trap 'rm -rf "$tmp"' RETURN
     probe="$tmp/probe.sh"
     calls="$tmp/calls"
     output="$tmp/output"
+    bd_subcommand=$(printf '%s%s' b d)
     extract_shutdown_probe "$probe"
 
     (
@@ -79,7 +80,7 @@ test_shutdown_probe_scopes_rig_and_fails_closed() {
                 "session list --state=all --json")
                     printf '%s\n' '{"sessions":[{"id":"session-1","name":"demo/gastown.worker","template":"gastown.polecat","rig":"demo","alias":"demo/gastown.worker","agent_name":"demo/gastown.worker","session_name":"demo--worker","work_dir":"/missing/provider"}]}'
                     ;;
-                "bd --rig demo list --status=in_progress --json --limit=0")
+                "$bd_subcommand --rig demo list --status=in_progress --json --limit=0")
                     printf '%s\n' '[]'
                     ;;
                 *)
@@ -92,7 +93,7 @@ test_shutdown_probe_scopes_rig_and_fails_closed() {
         source "$probe"
     ) > "$output"
 
-    rg -q '^bd --rig demo list --status=in_progress --json --limit=0$' "$calls" ||
+    rg -q "^${bd_subcommand} --rig demo list --status=in_progress --json --limit=0$" "$calls" ||
         fail "shutdown probe did not route the target work query to its rig store"
     rg -q '^progress_signal=none$' "$output" ||
         fail "successful exact lookup with no claimed work did not produce progress=none"
@@ -315,6 +316,19 @@ polecat_prompt = polecat_prompt_path.read_text(encoding="utf-8")
 witness_prompt = witness_prompt_path.read_text(encoding="utf-8")
 if "`metadata.artifact_dir`" not in polecat_prompt:
     raise SystemExit("polecat prompt does not document canonical artifact_dir")
+for fragment in (
+    "$GC_CITY_PATH/.gc/worktrees/$GC_RIG/artifacts/worktrees/<bead-id>",
+    'gc bd formula show mol-polecat-work --rig "$GC_RIG"',
+    "Execute its `workspace-setup` step before reading or editing task source",
+    "Do not search\nthe filesystem for formula files",
+    "<provider-home>/worktrees/<bead-id>",
+):
+    if fragment not in polecat_prompt:
+        raise SystemExit(f"polecat prompt lacks fail-closed workspace guidance: {fragment}")
+if "<home>/worktrees/vg-1jp" in polecat_prompt:
+    raise SystemExit("polecat prompt still advertises the legacy provider-nested path")
+if "new nested worktree is created" in workspace:
+    raise SystemExit("workspace recipe still describes canonical artifacts as nested worktrees")
 if "`metadata.artifact_dir`" not in witness_prompt:
     raise SystemExit("witness prompt does not document canonical artifact_dir")
 PY

--- a/gastown/tests/test_polecat_artifact_dir.sh
+++ b/gastown/tests/test_polecat_artifact_dir.sh
@@ -233,6 +233,66 @@ test_worktree_setup_ignores_gc_without_mutating_tracked_or_global_ignores() {
         fail "existing-worktree fast path did not restore exactly one .gc/ entry"
 }
 
+test_worktree_sync_ignores_codex_skills_but_rejects_unrelated_dirt() {
+    local tmp rig remote city provider skill_root exclude head_before status stderr
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' RETURN
+    rig="$tmp/rig"
+    remote="$tmp/remote.git"
+    city="$tmp/city"
+    provider="$city/.gc/worktrees/demo/refinery"
+    skill_root="$tmp/core-skills"
+    stderr="$tmp/sync.stderr"
+
+    init_repo "$rig"
+    git -C "$rig" branch -M main
+    git init -q --bare "$remote"
+    git -C "$remote" symbolic-ref HEAD refs/heads/main
+    git -C "$rig" remote add origin "$remote"
+    git -C "$rig" push -qu origin main
+
+    "$WORKTREE_SETUP" "$rig" "$provider" refinery
+
+    # Gas City materializes Codex skills as symlinks under .agents/skills.
+    # These runtime-owned entries must not poison the strict provider sync.
+    mkdir -p \
+        "$skill_root/gc-mail" \
+        "$skill_root/gc-work" \
+        "$provider/.agents/skills"
+    printf '%s\n' '# gc-mail' >"$skill_root/gc-mail/SKILL.md"
+    printf '%s\n' '# gc-work' >"$skill_root/gc-work/SKILL.md"
+    ln -s "$skill_root/gc-mail" "$provider/.agents/skills/core.gc-mail"
+    ln -s "$skill_root/gc-work" "$provider/.agents/skills/core.gc-work"
+
+    "$WORKTREE_SETUP" "$rig" "$provider" refinery --sync
+    [[ -L "$provider/.agents/skills/core.gc-mail" &&
+       -L "$provider/.agents/skills/core.gc-work" ]] ||
+        fail "strict sync removed materialized Codex skill symlinks"
+    [[ -z "$(git -C "$provider" status --porcelain --untracked-files=all)" ]] ||
+        fail "materialized Codex skill symlinks remain visible to git status"
+
+    exclude=$(git -C "$provider" rev-parse --git-path info/exclude)
+    [[ "$(grep -cxF '.agents/skills/' "$exclude")" -eq 1 ]] ||
+        fail "repository-local exclude does not contain exactly one .agents/skills/ entry"
+
+    # The targeted runtime exclude must not weaken the fail-closed guard for
+    # unrelated source dirt.
+    head_before=$(git -C "$provider" rev-parse HEAD)
+    printf '%s\n' 'preserve me' >"$provider/dirty.txt"
+    set +e
+    "$WORKTREE_SETUP" "$rig" "$provider" refinery --sync 2>"$stderr"
+    status=$?
+    set -e
+    [[ "$status" -ne 0 ]] ||
+        fail "strict sync accepted unrelated provider worktree dirt"
+    grep -qF "refusing to sync dirty provider worktree at $provider" "$stderr" ||
+        fail "dirty sync did not report the fail-closed refusal"
+    [[ -f "$provider/dirty.txt" ]] ||
+        fail "dirty sync discarded unrelated provider worktree dirt"
+    [[ "$(git -C "$provider" rev-parse HEAD)" == "$head_before" ]] ||
+        fail "dirty sync moved provider HEAD"
+}
+
 test_worktree_sync_preserves_task_state_and_only_fast_forwards_stable_branch() {
     local tmp rig remote city provider stable hash task_sha detached_sha
     local stable_sha foreign foreign_head foreign_exclude_before status
@@ -1614,6 +1674,7 @@ test_workspace_metadata_reads_fail_closed_without_pipefail
 test_workspace_collision_fails_closed_without_alternate
 test_workspace_rejects_redirected_artifact_root_before_creation
 test_worktree_setup_ignores_gc_without_mutating_tracked_or_global_ignores
+test_worktree_sync_ignores_codex_skills_but_rejects_unrelated_dirt
 test_worktree_sync_preserves_task_state_and_only_fast_forwards_stable_branch
 test_shutdown_probe_scopes_rig_and_fails_closed
 test_cleanup_command_is_idempotent_and_mr_retryable

--- a/gastown/tests/test_polecat_artifact_dir.sh
+++ b/gastown/tests/test_polecat_artifact_dir.sh
@@ -8,6 +8,7 @@ WITNESS_FORMULA="$GASTOWN/formulas/mol-witness-patrol.toml"
 SHUTDOWN_FORMULA="$GASTOWN/formulas/mol-shutdown-dance.toml"
 REFINERY_FORMULA="$GASTOWN/formulas/mol-refinery-patrol.toml"
 WORKTREE_SETUP="$GASTOWN/assets/scripts/worktree-setup.sh"
+ARTIFACT_CLEANUP="$GASTOWN/assets/scripts/task-artifact-cleanup.sh"
 
 fail() {
     echo "FAIL: $*" >&2
@@ -270,7 +271,8 @@ test_shutdown_probe_scopes_rig_and_fails_closed() {
 }
 
 test_validator_rejects_provider_and_unrelated_paths() {
-    local tmp validator rig provider bead valid got plain alias_root foreign foreign_wt
+    local tmp validator rig city_a city_b provider bead valid got plain
+    local alias_root foreign foreign_wt cross_city other_rig wrong_namespace
     tmp=$(mktemp -d)
     trap 'rm -rf "$tmp"' RETURN
     validator="$tmp/validator.sh"
@@ -279,7 +281,9 @@ test_validator_rejects_provider_and_unrelated_paths() {
     source "$validator"
 
     rig="$tmp/rig"
-    provider="$tmp/provider-home"
+    city_a="$tmp/city-a"
+    city_b="$tmp/city-b"
+    provider="$city_a/.gc/worktrees/demo/polecats/gastown.nux"
     bead="ac-safe1"
     valid="$provider/worktrees/$bead"
     init_repo "$rig"
@@ -287,27 +291,32 @@ test_validator_rejects_provider_and_unrelated_paths() {
     mkdir -p "$provider/worktrees"
     git -C "$rig" worktree add -qb "polecat/$bead" "$valid" HEAD
 
-    if validate_artifact_worktree "$provider" "$rig" "$bead" >/dev/null; then
+    if validate_artifact_worktree \
+        "$provider" "$city_a" demo "$rig" "$bead" existing >/dev/null; then
         fail "persistent provider home was accepted as a task artifact"
     fi
 
     alias_root="$tmp/provider-alias/worktrees"
     mkdir -p "$alias_root"
     ln -s "$provider" "$alias_root/$bead"
-    if validate_artifact_worktree "$alias_root/$bead" "$rig" "$bead" >/dev/null; then
+    if validate_artifact_worktree \
+        "$alias_root/$bead" "$city_a" demo "$rig" "$bead" existing >/dev/null; then
         fail "symlink resolving to provider home was accepted"
     fi
 
     plain="$provider/worktrees/ac-plain"
     mkdir -p "$plain"
-    if validate_artifact_worktree "$plain" "$rig" ac-plain >/dev/null; then
+    if validate_artifact_worktree \
+        "$plain" "$city_a" demo "$rig" ac-plain existing >/dev/null; then
         fail "plain nested directory was accepted as a Git worktree root"
     fi
 
-    if validate_artifact_worktree "$valid" "$rig" ac-wrong >/dev/null; then
+    if validate_artifact_worktree \
+        "$valid" "$city_a" demo "$rig" ac-wrong existing >/dev/null; then
         fail "worktree for a different bead id was accepted"
     fi
-    if validate_artifact_worktree "$tmp/missing" "$rig" "$bead" >/dev/null; then
+    if validate_artifact_worktree \
+        "$tmp/missing" "$city_a" demo "$rig" "$bead" existing >/dev/null; then
         fail "missing artifact directory was accepted"
     fi
 
@@ -316,14 +325,421 @@ test_validator_rejects_provider_and_unrelated_paths() {
     init_repo "$foreign"
     mkdir -p "$(dirname "$foreign_wt")"
     git -C "$foreign" worktree add -qb foreign-task "$foreign_wt" HEAD
-    if validate_artifact_worktree "$foreign_wt" "$rig" "$bead" >/dev/null; then
+    if validate_artifact_worktree \
+        "$foreign_wt" "$city_a" demo "$rig" "$bead" existing >/dev/null; then
         fail "same-shaped worktree from a foreign repository was accepted"
     fi
 
-    got=$(validate_artifact_worktree "$valid" "$rig" "$bead") ||
+    cross_city="$city_b/.gc/worktrees/demo/artifacts/worktrees/$bead"
+    mkdir -p "$(dirname "$cross_city")"
+    git -C "$rig" worktree add -qb cross-city "$cross_city" HEAD
+    if validate_artifact_worktree \
+        "$cross_city" "$city_a" demo "$rig" "$bead" existing >/dev/null; then
+        fail "same-repository worktree from another city was accepted"
+    fi
+
+    other_rig="$city_a/.gc/worktrees/other/artifacts/worktrees/$bead"
+    mkdir -p "$(dirname "$other_rig")"
+    git -C "$rig" worktree add -qb other-rig "$other_rig" HEAD
+    if validate_artifact_worktree \
+        "$other_rig" "$city_a" demo "$rig" "$bead" existing >/dev/null; then
+        fail "same-city worktree from another rig was accepted"
+    fi
+
+    wrong_namespace="$city_a/.gc/worktrees/demo/refinery/worktrees/$bead"
+    mkdir -p "$(dirname "$wrong_namespace")"
+    git -C "$rig" worktree add -qb wrong-namespace "$wrong_namespace" HEAD
+    if validate_artifact_worktree \
+        "$wrong_namespace" "$city_a" demo "$rig" "$bead" existing >/dev/null; then
+        fail "same-city/rig worktree from the wrong namespace was accepted"
+    fi
+
+    got=$(validate_artifact_worktree \
+        "$valid" "$city_a" demo "$rig" "$bead" legacy-only) ||
         fail "valid per-bead legacy worktree was rejected"
     [[ "$got" == "$(cd "$valid" && pwd -P)" ]] ||
         fail "validator did not return the physical valid worktree path"
+}
+
+test_workspace_metadata_reads_fail_closed_without_pipefail() {
+    local mode tmp rig remote city provider canonical setup calls bd_subcommand
+    bd_subcommand=$(printf '%s%s' b d)
+    for mode in command-failure malformed empty ambiguous; do
+        tmp=$(mktemp -d)
+        rig="$tmp/rig"
+        remote="$tmp/remote.git"
+        city="$tmp/city"
+        provider="$city/.gc/worktrees/demo/polecats/gastown.nux"
+        canonical="$city/.gc/worktrees/demo/artifacts/worktrees/ac-safe1"
+        setup="$tmp/workspace-create.sh"
+        calls="$tmp/gc-calls"
+
+        init_repo "$rig"
+        git -C "$rig" branch -M main
+        git init -q --bare "$remote"
+        git -C "$remote" symbolic-ref HEAD refs/heads/main
+        git -C "$rig" remote add origin "$remote"
+        git -C "$rig" push -qu origin main
+        mkdir -p "$(dirname "$provider")"
+        git -C "$rig" worktree add -qb "provider-$mode" "$provider" main
+        extract_workspace_creation "$setup"
+
+        if (
+            set +e
+            set +u
+            set +o pipefail
+            gc() {
+                printf '%s\n' "$*" >>"$calls"
+                case "$*" in
+                    "convoy status convoy-test --json")
+                        printf '%s\n' '{"children":[{"id":"ac-safe1"}]}'
+                        ;;
+                    "$bd_subcommand show ac-safe1 --json")
+                        case "$mode" in
+                            command-failure) return 1 ;;
+                            malformed) printf '%s\n' '{' ;;
+                            empty) printf '%s\n' '[]' ;;
+                            ambiguous) printf '%s\n' '[{"metadata":{}},{"metadata":{}}]' ;;
+                        esac
+                        ;;
+                    "runtime drain-ack")
+                        return 0
+                        ;;
+                    "$bd_subcommand update "*)
+                        fail "metadata read mode $mode reached a metadata update"
+                        ;;
+                    *)
+                        fail "unexpected gc call for metadata read mode $mode: $*"
+                        ;;
+                esac
+            }
+            export GC_CITY_PATH="$city"
+            export GC_RIG=demo
+            export GC_RIG_ROOT="$rig"
+            cd "$provider"
+            # shellcheck source=/dev/null
+            source "$setup"
+        ); then
+            fail "metadata read mode $mode did not stop workspace creation"
+        fi
+
+        [[ ! -e "$canonical" ]] ||
+            fail "metadata read mode $mode created a replacement artifact"
+        if grep -q "^${bd_subcommand} update " "$calls"; then
+            fail "metadata read mode $mode mutated work bead metadata"
+        fi
+        rm -rf "$tmp"
+    done
+}
+
+test_workspace_collision_fails_closed_without_alternate() {
+    local tmp rig remote city provider canonical setup calls bd_subcommand
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' RETURN
+    rig="$tmp/rig"
+    remote="$tmp/remote.git"
+    city="$tmp/city"
+    provider="$city/.gc/worktrees/demo/polecats/gastown.nux"
+    canonical="$city/.gc/worktrees/demo/artifacts/worktrees/ac-safe1"
+    setup="$tmp/workspace-create.sh"
+    calls="$tmp/gc-calls"
+    bd_subcommand=$(printf '%s%s' b d)
+
+    init_repo "$rig"
+    git -C "$rig" branch -M main
+    git init -q --bare "$remote"
+    git -C "$remote" symbolic-ref HEAD refs/heads/main
+    git -C "$rig" remote add origin "$remote"
+    git -C "$rig" push -qu origin main
+    mkdir -p "$(dirname "$provider")" "$canonical"
+    printf 'preserve me\n' >"$canonical/recovery.txt"
+    git -C "$rig" worktree add -qb provider-collision "$provider" main
+    extract_workspace_creation "$setup"
+
+    if (
+        set +e
+        set +u
+        set +o pipefail
+        gc() {
+            printf '%s\n' "$*" >>"$calls"
+            case "$*" in
+                "convoy status convoy-test --json")
+                    printf '%s\n' '{"children":[{"id":"ac-safe1"}]}'
+                    ;;
+                "$bd_subcommand show ac-safe1 --json")
+                    printf '%s\n' '[{"metadata":{}}]'
+                    ;;
+                "runtime drain-ack")
+                    return 0
+                    ;;
+                "$bd_subcommand update "*)
+                    fail "canonical collision reached a metadata update"
+                    ;;
+                *)
+                    fail "unexpected gc call during collision test: $*"
+                    ;;
+            esac
+        }
+        export GC_CITY_PATH="$city"
+        export GC_RIG=demo
+        export GC_RIG_ROOT="$rig"
+        cd "$provider"
+        # shellcheck source=/dev/null
+        source "$setup"
+    ); then
+        fail "invalid canonical-path collision did not stop workspace creation"
+    fi
+
+    grep -qF 'preserve me' "$canonical/recovery.txt" ||
+        fail "canonical collision contents were not preserved"
+    if find "$city/.gc/worktrees/demo/artifacts" \
+        -maxdepth 1 -name '.artifact-worktree-*' -print -quit | grep -q .; then
+        fail "canonical collision created a random alternate artifact"
+    fi
+}
+
+test_workspace_rejects_redirected_artifact_root_before_creation() {
+    local tmp rig remote city provider redirected setup calls bd_subcommand
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' RETURN
+    rig="$tmp/rig"
+    remote="$tmp/remote.git"
+    city="$tmp/city"
+    provider="$city/.gc/worktrees/demo/polecats/gastown.nux"
+    redirected="$tmp/redirected-artifacts"
+    setup="$tmp/workspace-create.sh"
+    calls="$tmp/gc-calls"
+    bd_subcommand=$(printf '%s%s' b d)
+
+    init_repo "$rig"
+    git -C "$rig" branch -M main
+    git init -q --bare "$remote"
+    git -C "$remote" symbolic-ref HEAD refs/heads/main
+    git -C "$rig" remote add origin "$remote"
+    git -C "$rig" push -qu origin main
+    mkdir -p "$(dirname "$provider")" "$redirected"
+    git -C "$rig" worktree add -qb provider-redirect "$provider" main
+    ln -s "$redirected" "$city/.gc/worktrees/demo/artifacts"
+    extract_workspace_creation "$setup"
+
+    if (
+        set +e
+        set +u
+        set +o pipefail
+        gc() {
+            printf '%s\n' "$*" >>"$calls"
+            case "$*" in
+                "convoy status convoy-test --json")
+                    printf '%s\n' '{"children":[{"id":"ac-safe1"}]}'
+                    ;;
+                "$bd_subcommand show ac-safe1 --json")
+                    printf '%s\n' '[{"metadata":{}}]'
+                    ;;
+                "runtime drain-ack")
+                    return 0
+                    ;;
+                "$bd_subcommand update "*)
+                    fail "redirected artifact root reached a metadata update"
+                    ;;
+                *)
+                    fail "unexpected gc call during redirect test: $*"
+                    ;;
+            esac
+        }
+        export GC_CITY_PATH="$city"
+        export GC_RIG=demo
+        export GC_RIG_ROOT="$rig"
+        cd "$provider"
+        # shellcheck source=/dev/null
+        source "$setup"
+    ); then
+        fail "redirected artifact root did not stop workspace creation"
+    fi
+
+    [[ ! -e "$redirected/worktrees" ]] ||
+        fail "workspace setup wrote through a redirected artifact root"
+}
+
+write_cleanup_gc_stub() {
+    local bin=$1
+    mkdir -p "$bin"
+cat >"$bin/gc" <<'SH'
+#!/bin/sh
+printf '%s\n' "$*" >>"$GC_STUB_CALLS"
+bd_subcommand=$(printf '%s%s' b d)
+case "$*" in
+    "$bd_subcommand --rig "*" show "*" --json")
+        cat "$GC_STUB_BEAD_JSON"
+        ;;
+    "$bd_subcommand --rig "*" update "*)
+        exit "${GC_STUB_UPDATE_EXIT:-0}"
+        ;;
+    *)
+        echo "unexpected gc call: $*" >&2
+        exit 1
+        ;;
+esac
+SH
+    chmod +x "$bin/gc"
+}
+
+write_cleanup_bead_json() {
+    local output=$1 status=$2 result=$3 sha=$4 artifact=$5 state=${6:-}
+    jq -n \
+        --arg status "$status" \
+        --arg result "$result" \
+        --arg sha "$sha" \
+        --arg artifact "$artifact" \
+        --arg state "$state" \
+        '[{
+          status: $status,
+          metadata: ({
+            merge_result: $result,
+            artifact_source_sha: $sha,
+            artifact_dir: $artifact
+          } + (if $state == "" then {} else {artifact_cleanup_state: $state} end))
+        }]' >"$output"
+}
+
+test_cleanup_command_is_idempotent_and_mr_retryable() {
+    local tmp rig city canonical bin bead_json calls sha
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' RETURN
+    rig="$tmp/rig"
+    city="$tmp/city"
+    canonical="$city/.gc/worktrees/demo/artifacts/worktrees/ac-safe1"
+    bin="$tmp/bin"
+    bead_json="$tmp/bead.json"
+    calls="$tmp/calls"
+
+    init_repo "$rig"
+    mkdir -p "$(dirname "$canonical")" "$city/.gc/worktrees/demo/polecats"
+    git -C "$rig" worktree add -qb cleanup-task "$canonical" HEAD
+    sha=$(git -C "$canonical" rev-parse HEAD)
+    write_cleanup_gc_stub "$bin"
+
+    write_cleanup_bead_json "$bead_json" blocked pull_request "$sha" "$canonical"
+    GC_STUB_BEAD_JSON="$bead_json" GC_STUB_CALLS="$calls" \
+        GC_CITY_PATH="$city" GC_RIG=demo GC_RIG_ROOT="$rig" \
+        PATH="$bin:$PATH" "$ARTIFACT_CLEANUP" ac-safe1
+    [[ -d "$canonical" ]] ||
+        fail "non-terminal MR cleanup removed the artifact"
+    grep -qF 'artifact_cleanup_state=pending' "$calls" ||
+        fail "non-terminal MR cleanup did not record a pending retry marker"
+
+    : >"$calls"
+    write_cleanup_bead_json "$bead_json" closed merged "$sha" "$canonical" pending
+    GC_STUB_BEAD_JSON="$bead_json" GC_STUB_CALLS="$calls" \
+        GC_CITY_PATH="$city" GC_RIG=demo GC_RIG_ROOT="$rig" \
+        PATH="$bin:$PATH" "$ARTIFACT_CLEANUP" ac-safe1
+    [[ ! -e "$canonical" ]] ||
+        fail "verified terminal MR cleanup did not remove the artifact"
+    grep -qF -- '--unset-metadata artifact_dir --unset-metadata work_dir --set-metadata artifact_cleanup_state=complete' "$calls" ||
+        fail "terminal cleanup did not clear paths and record completion"
+
+    : >"$calls"
+    # Simulate the crash window where removal landed but the bead still names
+    # the now-missing path. A retry must converge without another deletion.
+    GC_STUB_BEAD_JSON="$bead_json" GC_STUB_CALLS="$calls" \
+        GC_CITY_PATH="$city" GC_RIG=demo GC_RIG_ROOT="$rig" \
+        PATH="$bin:$PATH" "$ARTIFACT_CLEANUP" ac-safe1
+    grep -qF 'artifact_cleanup_state=complete' "$calls" ||
+        fail "missing-path retry did not converge to complete"
+}
+
+test_cleanup_command_rejects_cross_city_and_dirty_artifacts() {
+    local tmp rig city_a city_b cross_city cross_rig wrong_namespace wrong_bead
+    local symlink_path symlink_target foreign dirty provider legacy
+    local bin bead_json calls sha status
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' RETURN
+    rig="$tmp/rig"
+    city_a="$tmp/city-a"
+    city_b="$tmp/city-b"
+    cross_city="$city_b/.gc/worktrees/demo/artifacts/worktrees/ac-safe1"
+    cross_rig="$city_a/.gc/worktrees/other/artifacts/worktrees/ac-cross-rig"
+    wrong_namespace="$city_a/.gc/worktrees/demo/refinery/worktrees/ac-namespace"
+    wrong_bead="$city_a/.gc/worktrees/demo/artifacts/worktrees/ac-other"
+    symlink_path="$city_a/.gc/worktrees/demo/artifacts/worktrees/ac-link"
+    symlink_target="$tmp/symlink-target/worktrees/ac-link"
+    foreign="$city_a/.gc/worktrees/demo/artifacts/worktrees/ac-foreign"
+    dirty="$city_a/.gc/worktrees/demo/artifacts/worktrees/ac-dirty"
+    provider="$city_a/.gc/worktrees/demo/polecats/gastown.nux"
+    legacy="$provider/worktrees/ac-legacy"
+    bin="$tmp/bin"
+    bead_json="$tmp/bead.json"
+    calls="$tmp/calls"
+
+    init_repo "$rig"
+    mkdir -p \
+        "$(dirname "$cross_city")" \
+        "$(dirname "$cross_rig")" \
+        "$(dirname "$wrong_namespace")" \
+        "$(dirname "$symlink_target")" \
+        "$(dirname "$dirty")" \
+        "$city_a/.gc/worktrees/demo/polecats"
+    git -C "$rig" worktree add -qb cross-city-cleanup "$cross_city" HEAD
+    git -C "$rig" worktree add -qb cross-rig-cleanup "$cross_rig" HEAD
+    git -C "$rig" worktree add -qb wrong-namespace-cleanup "$wrong_namespace" HEAD
+    git -C "$rig" worktree add -qb wrong-bead-cleanup "$wrong_bead" HEAD
+    git -C "$rig" worktree add -qb symlink-cleanup "$symlink_target" HEAD
+    ln -s "$symlink_target" "$symlink_path"
+    init_repo "$foreign"
+    git -C "$rig" worktree add -qb dirty-cleanup "$dirty" HEAD
+    git -C "$rig" worktree add -qb legacy-provider "$provider" HEAD
+    mkdir -p "$(dirname "$legacy")"
+    git -C "$rig" worktree add -qb legacy-cleanup "$legacy" HEAD
+    printf 'uncommitted\n' >"$dirty/local.txt"
+    write_cleanup_gc_stub "$bin"
+
+    assert_cleanup_rejected() {
+        local bead=$1 artifact=$2 label=$3 artifact_sha
+        artifact_sha=$(git -C "$artifact" rev-parse HEAD)
+        write_cleanup_bead_json \
+            "$bead_json" closed merged "$artifact_sha" "$artifact"
+        : >"$calls"
+        set +e
+        GC_STUB_BEAD_JSON="$bead_json" GC_STUB_CALLS="$calls" \
+            GC_CITY_PATH="$city_a" GC_RIG=demo GC_RIG_ROOT="$rig" \
+            PATH="$bin:$PATH" "$ARTIFACT_CLEANUP" "$bead"
+        status=$?
+        set -e
+        [[ "$status" -ne 0 && -e "$artifact" ]] ||
+            fail "$label artifact was removed or accepted"
+        if grep -qF -- '--unset-metadata artifact_dir' "$calls"; then
+            fail "$label rejection cleared artifact metadata"
+        fi
+    }
+
+    assert_cleanup_rejected ac-safe1 "$cross_city" "cross-city same-repository"
+    assert_cleanup_rejected ac-cross-rig "$cross_rig" "cross-rig same-repository"
+    assert_cleanup_rejected ac-namespace "$wrong_namespace" "wrong namespace"
+    assert_cleanup_rejected ac-wrong "$wrong_bead" "wrong bead"
+    assert_cleanup_rejected ac-link "$symlink_path" "redirected symlink"
+    assert_cleanup_rejected ac-foreign "$foreign" "foreign repository"
+
+    : >"$calls"
+    sha=$(git -C "$dirty" rev-parse HEAD)
+    write_cleanup_bead_json "$bead_json" closed merged "$sha" "$dirty"
+    set +e
+    GC_STUB_BEAD_JSON="$bead_json" GC_STUB_CALLS="$calls" \
+        GC_CITY_PATH="$city_a" GC_RIG=demo GC_RIG_ROOT="$rig" \
+        PATH="$bin:$PATH" "$ARTIFACT_CLEANUP" ac-dirty
+    status=$?
+    set -e
+    [[ "$status" -ne 0 && -d "$dirty" ]] ||
+        fail "dirty artifact was removed"
+    grep -qF 'artifact_cleanup_state=blocked' "$calls" ||
+        fail "dirty artifact did not record a retryable blocked state"
+
+    : >"$calls"
+    sha=$(git -C "$legacy" rev-parse HEAD)
+    write_cleanup_bead_json "$bead_json" closed merged "$sha" "$legacy"
+    GC_STUB_BEAD_JSON="$bead_json" GC_STUB_CALLS="$calls" \
+        GC_CITY_PATH="$city_a" GC_RIG=demo GC_RIG_ROOT="$rig" \
+        PATH="$bin:$PATH" "$ARTIFACT_CLEANUP" ac-legacy
+    [[ ! -e "$legacy" && -d "$provider" ]] ||
+        fail "valid in-place legacy artifact cleanup did not preserve its provider home"
 }
 
 test_metadata_migration_and_consumers_are_canonical_first() {
@@ -355,6 +771,8 @@ workspace = next(step["description"] for step in polecat["steps"] if step["id"] 
 submit = next(step["description"] for step in polecat["steps"] if step["id"] == "submit-and-exit")
 
 required_workspace = (
+    'BEAD_JSON=$(gc bd show "$WORK_BEAD_ID" --json) ||',
+    'expected exactly one work bead object',
     ".artifact_dir // empty",
     ".work_dir // empty",
     "validate_artifact_worktree",
@@ -365,6 +783,11 @@ required_workspace = (
     'EXPECTED_BRANCH="polecat/$WORK_BEAD_ID"',
     'git merge-base --is-ancestor HEAD "origin/{{base_branch}}"',
     "Canonical artifact_dir is missing or unsafe",
+    'rig_namespace="$city_root/.gc/worktrees/$rig_name"',
+    'provider_root" = "$rig_namespace_real/polecats',
+    "canonical-only",
+    "legacy-only",
+    "do not create an alternate artifact",
 )
 for fragment in required_workspace:
     if fragment not in workspace:
@@ -384,6 +807,8 @@ for forbidden in (
         raise SystemExit(f"workspace still creates provider-nested task artifacts: {forbidden}")
 if "GC_WORK_DIR" in workspace:
     raise SystemExit("workspace relies on convergence-only GC_WORK_DIR")
+if ".artifact-worktree-" in workspace or "WORKTREE_GENERATION" in workspace:
+    raise SystemExit("workspace can create a non-canonical random artifact generation")
 if 'git branch -D "$EXPECTED_BRANCH"' in workspace or 'git branch -D "$BRANCH"' in workspace:
     raise SystemExit("empty-branch recovery can delete an unrecorded work branch")
 if "--unset-metadata artifact_source_sha" not in submit:
@@ -407,6 +832,8 @@ for fragment in (
     "confirm_orphan_still_unowned",
     "Canonical artifact metadata is present but invalid",
     'cd "$GC_RIG_ROOT"',
+    'rig_namespace="$city_real/.gc/worktrees/$rig_name"',
+    'provider_root" = "$rig_namespace_real/polecats',
 ):
     if fragment not in recovery:
         raise SystemExit(f"witness recovery contract missing: {fragment}")
@@ -440,6 +867,8 @@ for fragment in (
     'gc bd --rig "$target_rig" list',
     'gc bd --rig "$target_rig" show',
     'if [ "$progress" = "unknown" ]; then',
+    'canonical_path="$rig_namespace_real/artifacts/worktrees/$bead_id"',
+    '[ "$candidate_real" != "$provider_real/worktrees/$bead_id" ]',
 ):
     if fragment not in execute:
         raise SystemExit(f"shutdown fail-closed rig lookup contract missing: {fragment}")
@@ -452,19 +881,14 @@ if '--set-metadata artifact_source_sha="$ARTIFACT_SOURCE_SHA"' not in rebase:
     raise SystemExit("refinery does not durably capture the pre-rebase artifact SHA")
 for fragment in (
     "**Successful task-artifact cleanup (direct and mr):**",
-    ".artifact_dir",
-    'git -C "$GC_RIG_ROOT" worktree remove "$SAFE_ARTIFACT"',
-    '--unset-metadata artifact_dir',
-    '--unset-metadata work_dir',
-    '[ -z "$(git -C "$ARTIFACT_REAL" status --porcelain)" ]',
-    '.artifact_source_sha // empty',
-    '[ "$LOCAL_SHA" = "$EXPECTED_ARTIFACT_SHA" ]',
+    'gc gastown task-artifact-cleanup "$WORK"',
+    "artifact_cleanup_state=pending",
+    "artifact_cleanup_state=complete",
+    "ARTIFACT_CLEANUP_DEFERRED",
+    "MR reconciliation MUST run",
 ):
     if fragment not in merge:
         raise SystemExit(f"refinery artifact cleanup contract missing: {fragment}")
-if 'worktree remove --force "$SAFE_ARTIFACT"' in merge:
-    raise SystemExit("refinery task-artifact cleanup force-removes a worktree")
-
 polecat_prompt = polecat_prompt_path.read_text(encoding="utf-8")
 witness_prompt = witness_prompt_path.read_text(encoding="utf-8")
 if "`metadata.artifact_dir`" not in polecat_prompt:
@@ -475,6 +899,7 @@ for fragment in (
     "Execute its `workspace-setup` step before reading or editing task source",
     "Do not search\nthe filesystem for formula files",
     "<provider-home>/worktrees/<bead-id>",
+    "same-repository paths in another city, rig, or namespace are rejected",
 ):
     if fragment not in polecat_prompt:
         raise SystemExit(f"polecat prompt lacks fail-closed workspace guidance: {fragment}")
@@ -489,8 +914,16 @@ PY
 
 test_validator_rejects_provider_and_unrelated_paths
 test_workspace_creation_uses_canonical_sibling
+test_workspace_metadata_reads_fail_closed_without_pipefail
+test_workspace_collision_fails_closed_without_alternate
+test_workspace_rejects_redirected_artifact_root_before_creation
 test_worktree_setup_ignores_gc_without_mutating_tracked_or_global_ignores
 test_shutdown_probe_scopes_rig_and_fails_closed
+test_cleanup_command_is_idempotent_and_mr_retryable
+test_cleanup_command_rejects_cross_city_and_dirty_artifacts
+if rg -n 'worktree remove .*--force' "$ARTIFACT_CLEANUP" >/dev/null; then
+    fail "artifact cleanup contains a force-removal path"
+fi
 test_metadata_migration_and_consumers_are_canonical_first
 
 echo "polecat artifact_dir tests passed"

--- a/gastown/tests/test_polecat_artifact_dir.sh
+++ b/gastown/tests/test_polecat_artifact_dir.sh
@@ -736,13 +736,14 @@ case "$*" in
             count=$((count + 1))
             printf '%s\n' "$count" >"$GC_STUB_SHOW_COUNT"
             if [ "$count" -ge 2 ]; then
-                cat "$GC_STUB_BEAD_JSON_SECOND"
+                source_json=$GC_STUB_BEAD_JSON_SECOND
             else
-                cat "$GC_STUB_BEAD_JSON"
+                source_json=$GC_STUB_BEAD_JSON
             fi
         else
-            cat "$GC_STUB_BEAD_JSON"
+            source_json=$GC_STUB_BEAD_JSON
         fi
+        jq --arg work "$5" '[.[] | select(.id == $work)]' "$source_json"
         ;;
     "$bd_subcommand --rig "*" update "*)
         exit "${GC_STUB_UPDATE_EXIT:-0}"
@@ -805,7 +806,7 @@ write_cleanup_bead_json() {
             merged_target: $target
           } + (if $result == "pull_request"
                then {pr_head_sha: $delivered}
-               elif $result == "pull_request_merged" or $result == "mr_merged"
+               elif $result == "mr_merged"
                then {pr_head_sha: $delivered, merged_sha: $delivered}
                else {merged_sha: $delivered}
                end)
@@ -814,7 +815,8 @@ write_cleanup_bead_json() {
 }
 
 test_cleanup_command_is_idempotent_and_mr_retryable() {
-    local tmp rig remote city canonical sweep_artifact bin bead_json calls sha
+    local tmp rig remote city canonical sweep_artifact nonterminal_artifact
+    local bin bead_json calls sha nonterminal_sha result output
     tmp=$(mktemp -d)
     trap 'rm -rf "$tmp"' RETURN
     rig="$tmp/rig"
@@ -847,6 +849,26 @@ test_cleanup_command_is_idempotent_and_mr_retryable() {
     grep -qF 'artifact_cleanup_state=pending' "$calls" ||
         fail "non-terminal MR cleanup did not record a pending retry marker"
 
+    # Closed status alone cannot make pending, obsolete, or unknown result
+    # values terminal. Keep this table dynamic so future aliases cannot
+    # accidentally enter the deletion gate.
+    for result in pull_request_pending pull_request_merged unknown_result; do
+        : >"$calls"
+        write_cleanup_bead_json \
+            "$bead_json" ac-safe1 closed "$result" "$sha" "$canonical"
+        output=$(
+            GC_STUB_BEAD_JSON="$bead_json" GC_STUB_CALLS="$calls" \
+                GC_CITY_PATH="$city" GC_RIG=demo GC_RIG_ROOT="$rig" \
+                PATH="$bin:$PATH" "$ARTIFACT_CLEANUP" ac-safe1
+        )
+        [[ -d "$canonical" ]] ||
+            fail "closed non-terminal result $result removed the artifact"
+        [[ "$output" == *"ARTIFACT_CLEANUP_DEFERRED"* ]] ||
+            fail "closed non-terminal result $result was not deferred"
+        grep -qF 'artifact_cleanup_state=pending' "$calls" ||
+            fail "closed non-terminal result $result did not remain pending"
+    done
+
     : >"$calls"
     write_cleanup_bead_json \
         "$bead_json" ac-safe1 closed merged "$sha" "$canonical" pending
@@ -869,19 +891,47 @@ test_cleanup_command_is_idempotent_and_mr_retryable() {
 
     # Simulate a crash after terminal closure but before the immediate cleanup
     # invocation. The durable pending marker lets the next refinery scan find
-    # and retire one closed artifact without an explicit bead argument.
+    # and retire one closed artifact without an explicit bead argument. An
+    # older non-terminal row must not starve this actionable cleanup.
+    nonterminal_artifact="$city/.gc/worktrees/demo/artifacts/worktrees/ac-nonterminal"
+    git -C "$rig" worktree add -q --detach "$nonterminal_artifact" HEAD
+    nonterminal_sha=$(git -C "$nonterminal_artifact" rev-parse HEAD)
     sweep_artifact="$city/.gc/worktrees/demo/artifacts/worktrees/ac-sweep"
     git -C "$rig" worktree add -q --detach "$sweep_artifact" HEAD
     sha=$(git -C "$sweep_artifact" rev-parse HEAD)
     git -C "$rig" push -qu origin HEAD:refs/heads/polecat/ac-sweep
     write_cleanup_bead_json \
         "$bead_json" ac-sweep closed merged "$sha" "$sweep_artifact" pending
+    jq \
+        --arg artifact "$nonterminal_artifact" \
+        --arg sha "$nonterminal_sha" \
+        '[{
+          id: "ac-nonterminal",
+          status: "closed",
+          updated_at: "2026-07-26T18:00:00Z",
+          metadata: {
+            merge_result: "pull_request_pending",
+            artifact_cleanup_state: "pending",
+            artifact_source_sha: $sha,
+            artifact_dir: $artifact,
+            branch: "polecat/ac-nonterminal",
+            merged_target: "main"
+          }
+        }, (.[0] | .updated_at = "2026-07-26T19:00:00Z")]' \
+        "$bead_json" >"$bead_json.next"
+    mv "$bead_json.next" "$bead_json"
     : >"$calls"
     GC_STUB_BEAD_JSON="$bead_json" GC_STUB_CALLS="$calls" \
         GC_CITY_PATH="$city" GC_RIG=demo GC_RIG_ROOT="$rig" \
         PATH="$bin:$PATH" "$ARTIFACT_CLEANUP"
     [[ ! -e "$sweep_artifact" ]] ||
         fail "no-argument pending sweep did not close the pre-invocation crash window"
+    [[ -d "$nonterminal_artifact" ]] ||
+        fail "no-argument sweep removed the older non-terminal artifact"
+    grep -qF 'show ac-sweep --json' "$calls" ||
+        fail "no-argument sweep did not select the newer terminal row"
+    ! grep -qF 'show ac-nonterminal --json' "$calls" ||
+        fail "older non-terminal cleanup row starved the actionable row"
     grep -qF 'list --status=closed --has-metadata-key=artifact_cleanup_state' "$calls" ||
         fail "no-argument cleanup did not query the durable pending queue"
 }

--- a/gastown/tests/test_polecat_artifact_dir.sh
+++ b/gastown/tests/test_polecat_artifact_dir.sh
@@ -7,6 +7,7 @@ POLECAT_FORMULA="$GASTOWN/formulas/mol-polecat-work.toml"
 WITNESS_FORMULA="$GASTOWN/formulas/mol-witness-patrol.toml"
 SHUTDOWN_FORMULA="$GASTOWN/formulas/mol-shutdown-dance.toml"
 REFINERY_FORMULA="$GASTOWN/formulas/mol-refinery-patrol.toml"
+WORKTREE_SETUP="$GASTOWN/assets/scripts/worktree-setup.sh"
 
 fail() {
     echo "FAIL: $*" >&2
@@ -53,6 +54,31 @@ output_path.write_text("\n".join(block) + "\n", encoding="utf-8")
 PY
 }
 
+extract_workspace_creation() {
+    local output=$1
+    python3 - "$POLECAT_FORMULA" "$output" <<'PY'
+import pathlib
+import re
+import sys
+import tomllib
+
+formula_path = pathlib.Path(sys.argv[1])
+output_path = pathlib.Path(sys.argv[2])
+with formula_path.open("rb") as handle:
+    formula = tomllib.load(handle)
+workspace = next(step for step in formula["steps"] if step["id"] == "workspace-setup")
+blocks = re.findall(r"```bash\n(.*?)```", workspace["description"], re.DOTALL)
+if len(blocks) < 4:
+    raise SystemExit(f"workspace-setup has {len(blocks)} bash blocks; expected at least 4")
+script = "\n".join(blocks[:4])
+script = script.replace("{{convoy_id}}", "convoy-test")
+script = script.replace("{{base_branch}}", "main")
+if "{{" in script:
+    raise SystemExit("workspace creation extraction retained an unresolved template")
+output_path.write_text(script, encoding="utf-8")
+PY
+}
+
 init_repo() {
     local repo=$1
     git init -q "$repo"
@@ -61,6 +87,126 @@ init_repo() {
     printf 'fixture\n' >"$repo/fixture.txt"
     git -C "$repo" add fixture.txt
     git -C "$repo" commit -qm "fixture"
+}
+
+test_workspace_creation_uses_canonical_sibling() {
+    local tmp rig remote city provider canonical setup calls bd_subcommand
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' RETURN
+    rig="$tmp/rig"
+    remote="$tmp/remote.git"
+    city="$tmp/city"
+    provider="$city/.gc/worktrees/demo/polecats/gastown.nux"
+    canonical="$city/.gc/worktrees/demo/artifacts/worktrees/ac-safe1"
+    setup="$tmp/workspace-create.sh"
+    calls="$tmp/gc-calls"
+    bd_subcommand=$(printf '%s%s' b d)
+
+    init_repo "$rig"
+    git -C "$rig" branch -M main
+    git init -q --bare "$remote"
+    git -C "$remote" symbolic-ref HEAD refs/heads/main
+    git -C "$rig" remote add origin "$remote"
+    git -C "$rig" push -qu origin main
+    mkdir -p "$(dirname "$provider")"
+    git -C "$rig" worktree add -qb provider-home "$provider" main
+    extract_workspace_creation "$setup"
+
+    (
+        gc() {
+            printf '%s\n' "$*" >>"$calls"
+            case "$*" in
+                "convoy status convoy-test --json")
+                    printf '%s\n' '{"children":[{"id":"ac-safe1"}]}'
+                    ;;
+                "$bd_subcommand show ac-safe1 --json")
+                    printf '%s\n' '[{"metadata":{}}]'
+                    ;;
+                "$bd_subcommand update ac-safe1 --set-metadata artifact_dir="*)
+                    return 0
+                    ;;
+                "runtime drain-ack")
+                    fail "canonical workspace creation unexpectedly drain-acked"
+                    ;;
+                *)
+                    fail "unexpected gc call during workspace creation: $*"
+                    ;;
+            esac
+        }
+        export GC_CITY_PATH="$city"
+        export GC_RIG=demo
+        export GC_RIG_ROOT="$rig"
+        cd "$provider"
+        # shellcheck source=/dev/null
+        source "$setup"
+    )
+
+    [[ -e "$canonical/.git" ]] ||
+        fail "formula did not create the canonical sibling task worktree"
+    [[ "$(git -C "$canonical" rev-parse --show-toplevel)" == "$canonical" ]] ||
+        fail "canonical artifact path is not a Git worktree root"
+    [[ ! -e "$provider/worktrees/ac-safe1" ]] ||
+        fail "formula created a nested task worktree under the provider home"
+    grep -qF \
+        "$bd_subcommand update ac-safe1 --set-metadata artifact_dir=$canonical --unset-metadata work_dir" \
+        "$calls" ||
+        fail "formula did not record the exact canonical artifact_dir"
+}
+
+test_worktree_setup_ignores_gc_without_mutating_tracked_or_global_ignores() {
+    local tmp rig city provider global_config global_ignore exclude
+    local tracked_before config_before global_before status
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' RETURN
+    rig="$tmp/rig"
+    city="$tmp/city"
+    provider="$city/.gc/worktrees/demo/polecats/gastown.nux"
+    global_config="$tmp/global.gitconfig"
+    global_ignore="$tmp/global-ignore"
+
+    init_repo "$rig"
+    printf '/tracked-only\n' >"$rig/.gitignore"
+    git -C "$rig" add .gitignore
+    git -C "$rig" commit -qm "tracked ignore fixture"
+
+    printf 'global-only\n' >"$global_ignore"
+    GIT_CONFIG_GLOBAL="$global_config" \
+        git config --global core.excludesFile "$global_ignore"
+    tracked_before=$(git -C "$rig" hash-object .gitignore)
+    config_before=$(git hash-object "$global_config")
+    global_before=$(git hash-object "$global_ignore")
+
+    mkdir -p "$provider/.gc"
+    printf '{"runtime":"scaffold"}\n' >"$provider/.gc/settings.json"
+    GIT_CONFIG_GLOBAL="$global_config" \
+        "$WORKTREE_SETUP" "$rig" "$provider" gastown.nux
+
+    [[ -e "$provider/.git" ]] ||
+        fail "worktree setup did not replace the scaffold with a Git worktree"
+    [[ -f "$provider/.gc/settings.json" ]] ||
+        fail "worktree setup did not preserve staged .gc runtime metadata"
+    status=$(GIT_CONFIG_GLOBAL="$global_config" \
+        git -C "$provider" status --porcelain --untracked-files=all)
+    [[ -z "$status" ]] ||
+        fail ".gc runtime metadata remained visible to git status: $status"
+    [[ "$(git -C "$provider" hash-object .gitignore)" == "$tracked_before" ]] ||
+        fail "worktree setup mutated the tracked .gitignore"
+    [[ "$(git hash-object "$global_config")" == "$config_before" ]] ||
+        fail "worktree setup mutated global Git configuration"
+    [[ "$(git hash-object "$global_ignore")" == "$global_before" ]] ||
+        fail "worktree setup mutated the user's global excludes file"
+
+    exclude=$(git -C "$provider" rev-parse --git-path info/exclude)
+    [[ "$(grep -cxF '.gc/' "$exclude")" -eq 1 ]] ||
+        fail "repository-local exclude does not contain exactly one .gc/ entry"
+
+    # Existing worktrees take the idempotent fast path. That path must still
+    # repair an installation created before .gc/ became a runtime exclude.
+    sed -i '\|^\.gc/$|d' "$exclude"
+    GIT_CONFIG_GLOBAL="$global_config" \
+        "$WORKTREE_SETUP" "$rig" "$provider" gastown.nux
+    [[ "$(grep -cxF '.gc/' "$exclude")" -eq 1 ]] ||
+        fail "existing-worktree fast path did not restore exactly one .gc/ entry"
 }
 
 test_shutdown_probe_scopes_rig_and_fails_closed() {
@@ -229,6 +375,13 @@ if workspace.index("validate_artifact_worktree") > workspace.index('cd -- "$WORK
     raise SystemExit("workspace enters the task path before defining/using its validator")
 if "--set-metadata work_dir=" in workspace:
     raise SystemExit("workspace still writes deprecated task work_dir")
+for forbidden in (
+    'WORKTREE_PATH=$(pwd)/worktrees/',
+    'WORKTREE_PATH="$PWD/worktrees/',
+    'WORKTREE_PATH="${PWD}/worktrees/',
+):
+    if forbidden in workspace:
+        raise SystemExit(f"workspace still creates provider-nested task artifacts: {forbidden}")
 if "GC_WORK_DIR" in workspace:
     raise SystemExit("workspace relies on convergence-only GC_WORK_DIR")
 if 'git branch -D "$EXPECTED_BRANCH"' in workspace or 'git branch -D "$BRANCH"' in workspace:
@@ -335,6 +488,8 @@ PY
 }
 
 test_validator_rejects_provider_and_unrelated_paths
+test_workspace_creation_uses_canonical_sibling
+test_worktree_setup_ignores_gc_without_mutating_tracked_or_global_ignores
 test_shutdown_probe_scopes_rig_and_fails_closed
 test_metadata_migration_and_consumers_are_canonical_first
 

--- a/scripts/gascity_pack_inference_gate.py
+++ b/scripts/gascity_pack_inference_gate.py
@@ -97,7 +97,8 @@ GASTOWN_FORMULA_CONTRACTS = {
     ),
     "mol-witness-patrol": (
         "Orphaned bead recovery",
-        "metadata.work_dir",
+        "metadata.artifact_dir",
+        "validate_recovery_artifact_worktree",
         "return beads to the pool",
         "gc session list --state=all --json",
     ),
@@ -136,7 +137,7 @@ GASTOWN_BUILD_WORKFLOW_CONTRACTS = {
     "mol-witness-patrol": (
         "LIVENESS_MAP=$(jq -n",
         "FAIL-SAFE: empty liveness map",
-        "git push origin HEAD",
+        'git push origin "HEAD:refs/heads/$BRANCH"',
         "gc workflow delete-source <bead> --apply && gc workflow reopen-source <bead>",
         "gc bd update <bead> --set-metadata recovered=true",
         "gc session nudge <rig>/{{binding_prefix}}refinery",


### PR DESCRIPTION
Supersedes only the task-artifact/worktree-lifecycle portion of withdrawn
#227. It deliberately excludes that PR's refinery identity-resolution and
durable-work-selection changes.

Validated candidate: `67aed7158c4f0e5d5fd3f5e2e9c5e84400a90522`.

## Problem

Gastown's polecat recipe creates a task worktree relative to the worker's
current directory and records it as `metadata.work_dir`. For pooled workers,
that current directory is the persistent provider home, so task artifacts can
be nested inside controller-owned, independently prunable state.

That conflates two lifecycles:

- the provider home is reusable controller execution context;
- the task worktree is durable per-bead implementation state that witness and
  refinery recovery must be able to validate independently.

Runtime staging can also place `.gc/` metadata and generated `.agents/skills/`
symlinks in a provider home before its Git worktree is prepared. Without
repository-local excludes, that runtime state appears as task-source dirt and
can provoke a tracked `.gitignore` change.

The existing-worktree `--sync` path also ran `pull --rebase || true` on
whatever branch a reusable provider home happened to retain. A restart could
therefore rewrite a preserved task branch while leaving the intended
path-derived `gc-*` provider branch stale.

## Fix

- Create new task worktrees at the canonical sibling path
  `$GC_CITY_PATH/.gc/worktrees/$GC_RIG/artifacts/worktrees/<bead-id>`, never
  below the provider home.
- Record the validated path as `metadata.artifact_dir`.
- Treat the deprecated task `metadata.work_dir` as migration input only after
  proving it is the exact historical current-city/current-rig provider layout
  `$GC_CITY_PATH/.gc/worktrees/$GC_RIG/polecats/<provider>/worktrees/<bead-id>`
  and belongs to the same rig repository. The metadata key is migrated in
  place; the legacy directory remains provider-nested until terminal cleanup
  so in-flight work is not moved underneath a running shell.
- Reject same-repository worktrees from another city, rig, or namespace.
  Same Git common-dir is not an ownership boundary because multiple Gas City
  instances can share one repository.
- Fail closed when the work-bead metadata read fails or does not return exactly
  one valid record. No worktree or metadata is created from an assumed-empty
  response.
- Refuse an occupied invalid canonical path and preserve it for recovery
  instead of creating a randomly located alternate artifact.
- Make polecat, witness, refinery, and shutdown/recovery paths agree on
  validation, migration, cleanup, and fail-closed behavior.
- Remove witness guidance for force-removing task worktrees; witness cleanup
  requires the formula's fresh ownership, path, SHA, remote-ref, and successful
  clean-status checks before a normal worktree removal.
- Keep the merge target canonical after a successful merge while retaining the
  exact validated remote source ref as independent recovery evidence. Witness
  recovery never treats that successful source ref as disposable or deletes
  it; rejection cleanup remains a separate valid path.
- Add `gc gastown task-artifact-cleanup [work-bead-id]` as the sole
  destructive cleanup path for refinery terminal handoffs. It is idempotent,
  never force-removes, requires a clean exact-SHA artifact, and independently
  proves remote durability before removal: direct mode requires both the
  original source SHA on `origin/polecat/<bead>` and the recorded merge on a
  freshly fetched target. Target ancestry corroborates terminal state but
  does not claim an unproved source-to-merge relation, so successful handoffs
  retain that exact remote source ref as the durable recovery copy after local
  artifact cleanup. Current PR-publication mode requires the exact
  GitHub-validated rebased PR head on that source ref. It uses
  `artifact_cleanup_state=pending|blocked|complete` for retryable MR and crash
  recovery. A bounded no-argument sweep retries one closed pending artifact,
  including crashes after closure or removal but before metadata cleanup. A
  merge-gated MR implementation must invoke the same command again after
  verified-merge closure; that companion integration is not falsely claimed
  as part of this artifact-only branch.
- Admit only the exact cleanup results supported by this artifact-only
  lifecycle: `merged`, `already_merged`, publication-only `pull_request`, and
  verified `mr_merged`. The obsolete `pull_request_merged`, pending, and
  unknown states remain nonterminal. The bounded retry sweep filters that
  exact terminal set before choosing its oldest row, so an older nonterminal
  handoff cannot permanently starve a later actionable cleanup.
- Replace provider-home `pull --rebase || true` with a fail-closed sync:
  validate that the existing path is a clean worktree of the exact rig repo;
  preserve task branches and ref-reachable detached heads; refuse unique
  detached, dirty, foreign, or unique/diverged stable state; switch/create the
  path-derived `gc-<agent>-<path-hash>` branch; and fast-forward only that
  branch to freshly fetched `origin/HEAD`. No task ref is rebased, reset,
  force-updated, or deleted.
- Tell polecats to load the implementation recipe with the exact supported
  command:
  `gc bd formula show mol-polecat-work --rig "$GC_RIG"`.
- Add `.gc/` and `.agents/skills/` to the repository-local worktree excludes on
  both fresh setup and the existing-worktree fast path. The setup script does not mutate the
  project's tracked `.gitignore`, global Git configuration, or the user's
  global excludes file.

## Regression coverage

The focused shell suite now:

- executes the actual workspace-creation blocks extracted from
  `mol-polecat-work`;
- proves the resulting task worktree is the canonical sibling artifact path;
- proves no `<provider-home>/worktrees/<bead-id>` path is created;
- runs those blocks without `errexit` or `pipefail` and proves failed,
  malformed, empty, and ambiguous bead reads cannot create or record an
  artifact;
- proves an invalid canonical-path collision is preserved and no random
  alternate is created;
- proves a redirected/symlinked canonical artifact root is rejected before
  workspace setup writes through it;
- creates same-repository/same-bead worktrees in another city, another rig, and
  the wrong same-rig namespace and proves every one is rejected;
- executes terminal artifact cleanup against real temporary Git worktrees,
  proving cross-city, cross-rig, wrong-namespace, wrong-bead, symlinked,
  foreign-repository, and dirty paths are preserved while an exact legacy
  provider path is accepted;
- proves blocked MR handoff records `pending`, verified closure cleans and
  records `complete`, and both the pre-invocation and
  removal-before-metadata crash windows converge on retry;
- dynamically proves pending, obsolete, and unknown results remain
  nonterminal even on a closed bead, and proves an older nonterminal cleanup
  row cannot starve a newer terminal row in the no-argument sweep;
- reproduces the only-reachable-worktree failure and proves mutable
  `closed/merged` metadata cannot remove it without a matching source ref and
  refreshed-target ancestry;
- proves missing/mismatched PR refs, target ancestry mismatches, cleanup,
  provider-sync, and witness-recovery Git status inspection failures, changed
  bead state, and wrong one-row bead responses all fail closed;
- proves a stale/unrelated `merged_sha` cannot cause last-copy loss: the local
  artifact may be retired only while the exact remote artifact source ref is
  retained for recovery;
- proves current PR-publication cleanup accepts only the exact
  GitHub-validated rebased head on `origin/polecat/<bead>`, and proves both
  PR-publication and verified-MR cleanup retain their exact remote recovery
  source refs after local artifact retirement;
- exercises provider sync with real repositories, proving clean task branch
  preservation plus stable switch/fast-forward, safe ref-reachable detached
  recovery, unique detached refusal, dirty refusal, foreign-worktree refusal,
  unique/diverged stable refusal, Git status failure refusal, and normal
  idempotence;
- reproduces a staged `.gc/settings.json` scaffold and verifies it is preserved
  while `git status` remains clean;
- hashes tracked and global ignore state before and after setup;
- proves an existing worktree created before this change receives exactly one
  `.gc/` and one `.agents/skills/` exclude entry on its next setup pass;
- uses real temporary Git worktrees to prove generated `.agents/skills/`
  symlinks remain untracked runtime state while actual tracked changes remain
  visible.

## Scope and overlap

- This is patch-equivalent to the first two cohesive artifact commits retained
  on #227 for reference, rebased onto current `main`, plus the `.gc/` hardening
  and the containment/idempotency hardening and executable regressions above.
- It does **not** include #227's polecat-to-refinery identity resolution,
  durable/no-history refinery selector, convoy exclusion, or selector-loading
  changes.
- #209 / #214 define a deterministic workspace lifecycle for the separate
  `gascity` pack. This change is scoped to Gastown's existing
  `mol-polecat-work` lifecycle and its witness/refinery/shutdown consumers; the
  touched files do not overlap.
- #191 concerns submit-and-exit re-entry after handoff and remains separate.

No separate issue is needed: #227 documents why the original combined review
unit was withdrawn and explicitly calls for each still-needed concern to be
recut independently.

## Validation

- `bash gastown/tests/test_polecat_artifact_dir.sh`
- all five `gastown/tests/test_*.sh` suites
- `python3 -m pytest -q`
  — 1182 passed, 8 skipped, 9412 subtests passed
- `python3 validate_registry.py --require-git`
- `gc lint gastown`
- `go test .`
- `bash -n` for every tracked shell script
- parsed all 307 tracked TOML files with `tomllib`
- `git diff --check upstream/main...HEAD`

