### PR TITLE
fix(gastown): refinery baseline-failure dedupe gate cannot run — bd list has no --search

### DIFF
--- a/gastown/agents/refinery/prompt.template.md
+++ b/gastown/agents/refinery/prompt.template.md
@@ -15,7 +15,8 @@
 **CARDINAL RULE: You are a merge processor, NOT a developer.**
 - You NEVER write application code. You merge branches mechanically.
 - If tests fail due to the branch: REJECT it back to the pool.
-- If tests fail due to pre-existing issues: file a bead. Do NOT fix it yourself.
+- If tests fail due to pre-existing issues: look for an existing bead first, then
+  file one only if there is none. Do NOT fix it yourself.
 - FORBIDDEN: Reading polecat code to "understand what they were trying to do."
 - FORBIDDEN: Landing integration branches to {{ .DefaultBranch }} via raw git commands
   (`git merge`, `git push`). Integration branches are landed by assigning the
@@ -37,7 +38,7 @@ the bead. No separate MR beads.
 | Merge conflict detected | Abort and reject to pool, or attempt trivial resolution |
 | Tests fail after merge | Diagnose: branch regression or pre-existing? Reject or file bug. |
 | Push fails | Retry with backoff, or abort and investigate |
-| Pre-existing test failure | File bead for tracking (NEVER fix it yourself) — check for duplicates first |
+| Pre-existing test failure | Dedupe first (`handle-failures` step 3), then comment on the match or file one bead (NEVER fix it yourself) |
 | Uncertain merge order | Choose based on priority, dependencies, timing |
 
 {{ template "following-mol" . }}

--- a/gastown/formulas/mol-refinery-patrol.toml
+++ b/gastown/formulas/mol-refinery-patrol.toml
@@ -367,19 +367,72 @@ TARGET=$(gc bd show $WORK --json | jq -r '.[0].metadata.target // "{{target_bran
    - Close this step after the current wisp is burned.
 
 3. If pre-existing on target:
-   - Check for duplicates first:
+
+   **Dedupe before filing. This is a gate, not a courtesy.** A baseline failure is
+   re-discovered on every branch gated against the same target, so one defect
+   surfaces once per branch you process. Filing per discovery turns a single fix
+   into N beads, N polecats, and N branches that then conflict with each other at
+   this very gate. The bead you are about to duplicate is usually sitting in YOUR
+   OWN queue — finding it needs no cross-agent knowledge, just a lookup.
+
+   - Derive a stable key from the failing test identifier, never from your prose
+     summary. Two agents describing one failure write different sentences but read
+     the same test name:
      ```bash
-     gc bd list --type=bug --status=open --search "<failure summary>"
+     FAILURE_TEST="TestGeneratedClientInSync"   # the failing test/case name
+     FAILURE_PKG="internal/api/genclient"       # its package/suite path
+     FAILURE_KEY=$(printf '%s::%s' "$FAILURE_PKG" "$FAILURE_TEST" | tr 'A-Z' 'a-z' | tr -c 'a-z0-9' '-' | sed -E 's/-+/-/g; s/^-|-$//g')
+     BASELINE_SHA=$(git rev-parse "origin/$TARGET")
      ```
-   - If a matching bug already exists: note its ID and proceed with merge.
-   - If no duplicate: file a new bead:
+   - Look for an existing bead. Filter on status only: **not** `--type` (it may be
+     filed as a task), **not** `--assignee` (it is probably assigned to you), and
+     always include `in_progress` — a fix that is already written and queued is
+     `in_progress`, which is precisely the bead worth finding.
      ```bash
-     gc bd create --type=bug --priority=1 --title="Pre-existing failure: <summary>"
+     STATUSES=open,in_progress,blocked,deferred
+     LOOKUP_OK=1
+     DUPES=$(gc bd list --status "$STATUSES" --metadata-field baseline_failure_key="$FAILURE_KEY" --limit 0 --json) || LOOKUP_OK=0
+     if [ "$LOOKUP_OK" = "1" ] && [ "$(printf '%s' "$DUPES" | jq 'length')" = "0" ]; then
+       DUPES=$(gc bd list --status "$STATUSES" --title-contains "$FAILURE_TEST" --limit 0 --json) || LOOKUP_OK=0
+     fi
+     if [ "$LOOKUP_OK" = "1" ] && [ "$(printf '%s' "$DUPES" | jq 'length')" = "0" ]; then
+       DUPES=$(gc bd list --status "$STATUSES" --desc-contains "$FAILURE_TEST" --limit 0 --json) || LOOKUP_OK=0
+     fi
+     printf '%s' "$DUPES" | jq -r '.[] | .id + " [" + .status + "] " + .title'
      ```
+     The key pass matches beads this step filed; the text passes catch beads filed
+     by hand or before the key existed. Use flags that exist — `bd list` has no
+     `--search`, and a lookup that errors returns nothing.
+   - **Read the candidates; do not auto-take the first hit.** The text passes match
+     on mention, so they also surface beads that merely *discuss* the failure
+     (incident reports, tracking beads, this very formula's own bug reports). A
+     match is a bead reporting *the same failing test on the same target*. Commenting
+     on a meta-bead instead of filing would silently drop a real failure — the one
+     outcome worse than a duplicate. Set `EXISTING` to the matching bead ID, or
+     leave it empty if none of the candidates is the same failure:
+     ```bash
+     EXISTING=            # e.g. EXISTING=ga-1h0z, or leave empty to file
+     ```
+   - Act on the result. **A failed lookup is not an all-clear.** If you could not
+     check, do not file:
+     ```bash
+     if [ "$LOOKUP_OK" != "1" ]; then
+       gc bd comment "$WORK" "Pre-existing failure on $TARGET@$BASELINE_SHA NOT filed: dedupe lookup failed. Failure: <summary>"
+     elif [ -n "$EXISTING" ]; then
+       gc bd comment "$EXISTING" "Re-observed on $TARGET@$BASELINE_SHA while gating $WORK ($BRANCH). Not re-filed."
+     else
+       gc bd create --type=bug --priority=1 --title="Pre-existing failure: <summary>" --metadata "$(jq -nc --arg k "$FAILURE_KEY" --arg s "$BASELINE_SHA" '{baseline_failure_key: $k, baseline_sha: $s}')"
+     fi
+     ```
+     Stamping `baseline_failure_key` on create is what makes the next discovery an
+     exact match instead of a text guess.
    - Proceed with merge (failure not caused by this branch)
 
-**GATE**: Cannot merge without all checks passing OR pre-existing bug filed/found.
-**FORBIDDEN**: Writing code to fix failures. You are a merge processor."""
+**GATE**: Cannot merge without all checks passing OR the pre-existing failure
+filed, matched to an existing bead, or — when the dedupe lookup itself failed —
+recorded as a comment on $WORK.
+**FORBIDDEN**: Writing code to fix failures. You are a merge processor.
+**FORBIDDEN**: Filing a baseline-failure bead without a completed dedupe lookup."""
 
 [[steps]]
 id = "merge-push"


### PR DESCRIPTION
## Why

`handle-failures` step 3 in `mol-refinery-patrol.toml` tells the refinery to check
for duplicates before filing a baseline-failure bead. The check cannot succeed:

```console
$ gc bd list --type=bug --status=open --search "client_gen"
Error: unknown flag: --search
```

`bd list` has no `--search` flag. The documented lookup errors on every run, returns
nothing, and the very next instruction — "If no duplicate: file a new bead" — reads
that nothing as an all-clear. So every *discovery* gets filed, and a baseline failure
is re-discovered once per branch gated against the same target.

Observed downstream (witness patrol, 2026-07-26): five duplicate P1s in ~1h — three
for a single stale `internal/api/genclient/client_gen.go`, plus two that duplicated
beads **already sitting in the refinery's own queue with fix branches written and
awaiting merge**. Three beads filed 12 and 126 seconds apart is not a judgement
lapse; it is a command that cannot succeed.

This is the sole occurrence of the `--search` idiom in the pack.

Two further defects would have kept the gate leaky even with a working flag:

- `--status=open` excludes `in_progress` — which is exactly where a queued,
  already-fixed bead lives. That is what hid the two queue duplicates.
- `--type=bug` misses the same failure filed as a task.

## What changed

- Replace the impossible `--search` call with flags that exist, verified against the
  CLI: `--metadata-field`, `--title-contains`, `--desc-contains`.
- Derive a stable `baseline_failure_key` from the failing **test identifier**
  (`pkg::test`, normalized), never from prose. Two agents describing one failure
  write different sentences but read the same test name.
- Widen the status filter to `open,in_progress,blocked,deferred`, and stop filtering
  on `--type` and `--assignee`.
- Fail **closed**: `LOOKUP_OK` tracks lookup success, so a failing query no longer
  reads as "no duplicate found". This is the property whose absence caused the bug.
- Three-pass lookup: the metadata key matches beads this step filed; the title/desc
  passes catch beads filed by hand or before the key existed.

## Notes for review

- Cut fresh from `upstream/main` (`6373985`); cherry-picks cleanly, no stacking.
- Documentation/formula text only — no Go code, no schema change.
- Independent of #226: that PR reworks patrol-wisp *reconciliation*; this touches the
  baseline-failure *dedupe gate*. The only textual `search` in #226 is a Python
  `re.search(`. No overlap.
