### PR TITLE
fix(slack-full): file ingest gates, name-bound react lookup, busy-reaction lifecycle, event_id dedup

### DIFF
--- a/slack-full/CHANGELOG.md
+++ b/slack-full/CHANGELOG.md
@@ -10,6 +10,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Busy-reaction clears are now attributed to the publishing agent
+  (codex r11): each mark records the parsed target handle, and a
+  delivered reply consumes only marks whose handle resolves (via the
+  handle-alias registry) to the publishing session — so when M1
+  targets agent A and M2 re-targets agent B in the same thread, A's
+  late reply can no longer strip B's pending hourglass. Marks with no
+  recorded handle, an unregistered handle, or an unattributable
+  publisher clear unconditionally, preserving the prior behavior.
+- Launcher alias bootstrap no longer hijacks a handle onto another
+  handle's thread session (codex r9): the thread-session registry
+  records which `@@handle` created each binding (persisted; absent on
+  pre-existing records), and the unclaimed-handle alias bootstrap on
+  thread reuse fires only for the same handle (the codex r8 retry
+  case) — a different `@@handle` converging on an existing thread
+  still posts into that session but is not globally alias-bound to
+  it.
 - Busy-reaction lifecycle (hq-xizo, ported from
   `feat/hq-xizo-slack-full-hardening`): a targeted inbound gets a busy
   reaction (`BUSY_REACTION`, default `hourglass`; set-but-empty

--- a/slack-full/CHANGELOG.md
+++ b/slack-full/CHANGELOG.md
@@ -8,6 +8,111 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Busy-reaction lifecycle (hq-xizo, ported from
+  `feat/hq-xizo-slack-full-hardening`): a targeted inbound gets a busy
+  reaction (`BUSY_REACTION`, default `hourglass`; set-but-empty
+  disables) added on dispatch and removed when the agent's reply
+  publishes back into the same conversation/thread, tracked in a
+  bounded in-memory registry keyed by (conversation, thread key) with
+  a 30-minute TTL. Replaces the prior unconditional `eyes` reaction on
+  targeted inbounds; the ⚠️ dispatch-failure reaction stays. `/react`
+  gains an optional `remove:true` issuing `reactions.remove`
+  (`no_reaction` treated as benign delivery, mirroring
+  `already_reacted`), surfaced on the CLI as `gc slack react
+  --remove`. Beyond the original hq-xizo commit, the removal is
+  ordered after the corresponding `reactions.add` completes (a fast
+  reply otherwise races the in-flight add and the busy emoji sticks
+  forever) and a threaded `/publish-file` reply clears the mark
+  exactly like a text publish. A thread-reply inbound is marked under
+  both its thread root AND its own ts — reply-current and the
+  alias-dispatch instructions thread replies under the inbound's own
+  ts, which the root-only key missed. A channel-root reply (the
+  documented default `gc slack reply-current` shape, no thread ts)
+  clears every pending mark in the conversation, and re-targeting a
+  thread before the first reply lands removes the displaced message's
+  reaction instead of stranding it. The mark registers before the
+  forward to gc (a reply can arrive before postInbound even returns;
+  a failed forward cancels the mark before releasing the event's
+  dedup claim and restores any marks the failed inbound displaced),
+  displaced-mark reactions are removed only after the displacing
+  forward succeeds, and a re-mark of the same message merges
+  add-completion channels so a remove waits for every in-flight add
+  (the wait bound exceeds the Slack client timeout, so ordering
+  provably holds). Registry entries carry displaced-ancestor
+  reactions across overlapping failed re-targets (deduplicated,
+  bounded per entry) so every added emoji stays clearable; displaced
+  marks are retired only once the event's FINAL delivery succeeds
+  (the alias POST when one fires, postInbound otherwise) and restored
+  if it fails — unless a reply consumed the thread while the dispatch
+  was in flight (consumed keys are tombstoned; blocked marks get
+  their reactions removed instead of being re-parked unclearably);
+  and a failed cross-channel alias delivery removes its own busy
+  emoji next to the ⚠️ — synchronously, before any parked retry
+  wakes — instead of stranding it. Note the lifecycle fires only when an agent target
+  is
+  parsed from the message (`@handle:` prefix, User Group mention, or
+  sticky thread handle) — plain messages that reach a session solely
+  through a channel binding carry no parsed target and get no busy
+  reaction, by design. (hw-94w5k finding #3)
+
+### Fixed
+
+- Slack Events API redeliveries are now deduplicated on `event_id`
+  with a 10-minute seen-set: Slack retries any delivery it considers
+  unacknowledged and each retry re-forwarded the same message into the
+  bound session as a duplicate notification (observed as
+  byte-identical inbound log pairs). Entries are two-state
+  (in-flight → committed): a redelivery racing the first delivery's
+  still-running forward parks (slot released, no dispatch-semaphore
+  starvation) until the owner's verdict — commit drops it, forget
+  hands it the event — and never gives up: it already returned a 200,
+  so Slack will not resend it. The wait runs in a goroutine after the
+  handler has returned, so Slack's ack is never delayed behind it.
+  Adapter→gc forwards run on a 20-second-timeout client and Slack Web
+  API calls on 30s/120s-timeout clients so claims always conclude,
+  and a take-over blocks for dispatch capacity instead of dropping
+  the event's last copy on a full queue. For targeted inbounds the alias dispatch
+  owns the verdict (success commits, failure forgets). Deliveries
+  dropped at the queue-full boundary are never recorded, and a failed
+  forward releases its id, so a Slack retry can always recover the
+  message. Redeliveries of known events are routed past the
+  queue-full load-shed (a parked wait needs no dispatch slot), so a
+  saturated queue can never discard the only remaining copy of an
+  in-flight event. Transient `@@handle` launcher failures (spawn or
+  first-message forward) forget the claim like every other forward
+  failure — the launcher alias registers only after a first message
+  lands (on any attempt, including a retry that re-acquired the
+  thread session), so a retry re-enters the launcher instead of
+  dead-ending in the pre-claimed branch; terminal launcher outcomes
+  (delivered, user-error ephemerals) commit. (hw-94w5k finding #4)
+- `openBeneath` (the confined open backing `/publish-file`) restores
+  the old per-component no-follow guarantee on top of `os.Root`
+  (which follows a symlink at the root argument and resolves in-root
+  symlinks at every component, ignoring `O_NOFOLLOW` for them): the
+  root is pre-opened with `O_NOFOLLOW|O_DIRECTORY` and
+  identity-matched against the `os.Root` handle, every intermediate
+  component is Lstat'd (symlink → hard failure) and descended into
+  via a pinned sub-root whose identity must match, and the leaf is
+  Lstat'd + inode-pinned — so a raced-in link anywhere on the path
+  fails instead of substituting a different (even in-root) file.
+- Human file posts delivered with subtype `file_share` are no longer
+  discarded by the system-noise subtype gate, and file-only posts (no
+  caption) are no longer discarded by the empty-text gate — both now
+  reach the attachment download pipeline. Other subtypes
+  (`message_changed`, `bot_message`, …) and bot-authored file posts
+  stay filtered. (hw-94w5k finding #1)
+- `gc slack react` / `reply-current` latest-inbound lookup now matches
+  `target_session` against every identifier the session is known by
+  (id, `GC_SESSION_NAME`, gc-reported alias/session_name), not just
+  `GC_SESSION_ID`. Name-bound sessions produce inbound events carrying
+  the NAME, so the id-only match made the default `--current` mode
+  bail with "no recent inbound transcript entry" right after an
+  inbound landed. The ambient `GC_SESSION_NAME` only joins the match
+  set when the requested session IS the current one — an explicit
+  `--session <other>` never inherits it. (hw-94w5k finding #2)
+
 ### Changed
 
 - Renamed the pack directory from `slack-pack/` to `slack-full/` and the

--- a/slack-full/CHANGELOG.md
+++ b/slack-full/CHANGELOG.md
@@ -10,6 +10,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- A retaken Slack redelivery whose channel leg already reached gc
+  skips `postInbound` and retries only the failed alias leg (codex
+  r12): core does not consume `dedup_key`, so the old
+  forget-the-whole-event recovery duplicated the bound session's
+  turn. The completed leg is remembered next to the event-dedup entry
+  (TTL-bounded, cleared on commit) before `forget` wakes the parked
+  retry.
+- The launcher alias is reserved BEFORE the first-message POST and
+  rolled back if that POST fails (codex r13): a user's `@handle`
+  follow-up processed during the multi-second first post used to miss
+  the alias lookup and fall to the channel-bound path — which the
+  launcher session is not on — losing the follow-up. The rollback
+  runs before the event's dedup claim is released, so a woken
+  redelivery re-enters the launcher path (re-posting the remainder)
+  instead of the pre-claimed alias branch.
 - Busy-reaction clears are now attributed to the publishing agent
   (codex r11): each mark records the parsed target handle, and a
   delivered reply consumes only marks whose handle resolves (via the

--- a/slack-full/adapter/busy_reaction.go
+++ b/slack-full/adapter/busy_reaction.go
@@ -449,6 +449,22 @@ func (r *busyReactionRegistry) restoreDisplaced(channel string, restore []busyDi
 // so a delivered root publish clears every busy affordance pending in
 // that conversation rather than leaving hourglasses stuck forever.
 // Expired entries are dropped, not returned.
+
+// splitByAllow partitions marks into those the publisher may clear
+// (unattributed, or allow reports a match) and those that must stay
+// parked for their own agents (codex r16). A nil allow clears
+// everything.
+func splitByAllow(marks []busyTaken, allow func(handle string) bool) (want, keep []busyTaken) {
+	for _, t := range marks {
+		if allow == nil || t.handle == "" || allow(t.handle) {
+			want = append(want, t)
+		} else {
+			keep = append(keep, t)
+		}
+	}
+	return want, keep
+}
+
 // allow gates consumption by the mark's target handle (codex r11):
 // a live mark whose handle the publisher does not match is left in
 // place — untouched, untombstoned — for its own agent's reply (or
@@ -466,16 +482,36 @@ func (r *busyReactionRegistry) takeConversation(channel string, allow func(handl
 		if k.channel != channel {
 			continue
 		}
-		expired := now.Sub(m.addedAt) > busyReactionTTL
-		if !expired && allow != nil && !allow(m.handle) {
+		if now.Sub(m.addedAt) > busyReactionTTL {
+			delete(r.entries, k)
+			r.tombstoneLocked(k, now)
+			continue
+		}
+		// Partition the entry's pool — its own mark plus stale
+		// ancestors — per mark (codex r16): overlapping re-targets can
+		// leave another agent's orphaned reaction riding in m.stale,
+		// and it must neither be cleared by this publisher nor block
+		// this publisher's own marks.
+		pool := append([]busyTaken{{messageTS: m.messageTS, handle: m.handle, addDone: m.addDone}}, m.stale...)
+		want, keep := splitByAllow(pool, allow)
+		if len(want) == 0 {
 			continue
 		}
 		delete(r.entries, k)
-		r.tombstoneLocked(k, now)
-		if expired {
-			continue
+		if len(keep) > 0 {
+			// Re-park the survivors under the key for their own
+			// agents' replies (or TTL); the thread is not consumed.
+			r.entries[k] = busyReactionMark{
+				messageTS: keep[0].messageTS,
+				handle:    keep[0].handle,
+				addedAt:   now,
+				addDone:   keep[0].addDone,
+				stale:     mergeStale(nil, keep[1:]),
+			}
+		} else {
+			r.tombstoneLocked(k, now)
 		}
-		for _, t := range append([]busyTaken{{messageTS: m.messageTS, handle: m.handle, addDone: m.addDone}}, m.stale...) {
+		for _, t := range want {
 			if !seen[t.messageTS] {
 				seen[t.messageTS] = true
 				taken = append(taken, t)
@@ -563,33 +599,53 @@ func (r *busyReactionRegistry) take(channel, threadKey string, allow func(handle
 		return nil
 	}
 	now := r.clock()
-	expired := now.Sub(m.addedAt) > busyReactionTTL
-	if !expired && allow != nil && !allow(m.handle) {
-		return nil
-	}
-	delete(r.entries, key)
-	r.tombstoneLocked(key, now)
 	seen := map[string]bool{}
 	var taken []busyTaken
-	collect := func(cm busyReactionMark, cmExpired bool) {
-		if cmExpired {
-			return
+	// consume partitions one entry's pool per mark (codex r16): marks
+	// the publisher owns (or unattributed ones) are collected; another
+	// agent's marks — the entry's own or stale ancestors from
+	// overlapping re-targets — are re-parked under the key untombstoned
+	// so their own replies (or TTL) still clear them. Reports whether
+	// anything was consumed.
+	consume := func(k busyReactionKey, cm busyReactionMark) bool {
+		if now.Sub(cm.addedAt) > busyReactionTTL {
+			delete(r.entries, k)
+			r.tombstoneLocked(k, now)
+			return false
 		}
-		for _, t := range append([]busyTaken{{messageTS: cm.messageTS, handle: cm.handle, addDone: cm.addDone}}, cm.stale...) {
+		pool := append([]busyTaken{{messageTS: cm.messageTS, handle: cm.handle, addDone: cm.addDone}}, cm.stale...)
+		want, keep := splitByAllow(pool, allow)
+		if len(want) == 0 {
+			return false
+		}
+		delete(r.entries, k)
+		if len(keep) > 0 {
+			r.entries[k] = busyReactionMark{
+				messageTS: keep[0].messageTS,
+				handle:    keep[0].handle,
+				addedAt:   now,
+				addDone:   keep[0].addDone,
+				stale:     mergeStale(nil, keep[1:]),
+			}
+		} else {
+			r.tombstoneLocked(k, now)
+		}
+		for _, t := range want {
 			if !seen[t.messageTS] {
 				seen[t.messageTS] = true
 				taken = append(taken, t)
 			}
 		}
+		return true
 	}
-	collect(m, expired)
+	if !consume(key, m) {
+		return taken
+	}
 	for k, sib := range r.entries {
 		if k.channel != channel || sib.messageTS != m.messageTS {
 			continue
 		}
-		delete(r.entries, k)
-		r.tombstoneLocked(k, now)
-		collect(sib, now.Sub(sib.addedAt) > busyReactionTTL)
+		consume(k, sib)
 	}
 	return taken
 }

--- a/slack-full/adapter/busy_reaction.go
+++ b/slack-full/adapter/busy_reaction.go
@@ -117,9 +117,15 @@ type busyReactionKey struct {
 // is eventually removed when the key's current mark concludes.
 type busyReactionMark struct {
 	messageTS string
-	addedAt   time.Time
-	addDone   chan struct{}
-	stale     []busyTaken
+	// handle is the parsed target handle the mark was recorded for
+	// ("" for legacy/unattributed marks). The remove side matches the
+	// publishing session against it (via the alias registry) so agent
+	// A's late reply cannot clear agent B's pending affordance in the
+	// same thread (codex r11).
+	handle  string
+	addedAt time.Time
+	addDone chan struct{}
+	stale   []busyTaken
 }
 
 // busyThreadKey derives the registry thread key for an inbound
@@ -223,6 +229,7 @@ func (r *busyReactionRegistry) clock() time.Time {
 // ordering).
 type busyTaken struct {
 	messageTS string
+	handle    string
 	addDone   chan struct{}
 }
 
@@ -243,7 +250,7 @@ type busyDisplaced struct {
 // superseded marks so their reactions can be cleaned up.
 func (r *busyReactionRegistry) mark(channel, threadKey, messageTS string) chan struct{} {
 	addDone := make(chan struct{})
-	r.markWithDone(channel, threadKey, messageTS, addDone)
+	r.markWithDone(channel, threadKey, messageTS, "", addDone)
 	return addDone
 }
 
@@ -265,7 +272,7 @@ func (r *busyReactionRegistry) mark(channel, threadKey, messageTS string) chan s
 // deletes metadata, never the Slack-side emoji); if the forward
 // fails, the caller restores them via cancelBoth instead (codex r5).
 // Deduplicated by message ts and never includes messageTS itself.
-func (r *busyReactionRegistry) markBoth(channel, threadTS, messageTS string) (addDone chan struct{}, superseded []busyDisplaced) {
+func (r *busyReactionRegistry) markBoth(channel, threadTS, messageTS, handle string) (addDone chan struct{}, superseded []busyDisplaced) {
 	addDone = make(chan struct{})
 	seen := map[string]bool{messageTS: true}
 	collect := func(key string, old busyTaken, ok bool) {
@@ -275,11 +282,11 @@ func (r *busyReactionRegistry) markBoth(channel, threadTS, messageTS string) (ad
 		}
 	}
 	rootKey := busyThreadKey(threadTS, messageTS)
-	for _, old := range r.markWithDone(channel, rootKey, messageTS, addDone) {
+	for _, old := range r.markWithDone(channel, rootKey, messageTS, handle, addDone) {
 		collect(rootKey, old, true)
 	}
 	if threadTS != "" && threadTS != messageTS {
-		for _, old := range r.markWithDone(channel, messageTS, messageTS, addDone) {
+		for _, old := range r.markWithDone(channel, messageTS, messageTS, handle, addDone) {
 			collect(messageTS, old, true)
 		}
 	}
@@ -296,7 +303,7 @@ func (r *busyReactionRegistry) markBoth(channel, threadTS, messageTS string) (ad
 // reactions.add may still be in flight and could land after a remove
 // that only waited for the newer add — and keeps the previous entry's
 // stale ancestors.
-func (r *busyReactionRegistry) markWithDone(channel, threadKey, messageTS string, addDone chan struct{}) (displaced []busyTaken) {
+func (r *busyReactionRegistry) markWithDone(channel, threadKey, messageTS, handle string, addDone chan struct{}) (displaced []busyTaken) {
 	if r == nil || channel == "" || threadKey == "" || messageTS == "" {
 		return nil
 	}
@@ -310,7 +317,7 @@ func (r *busyReactionRegistry) markWithDone(channel, threadKey, messageTS string
 	if prev, present := r.entries[key]; present {
 		switch {
 		case prev.messageTS != messageTS:
-			displaced = append([]busyTaken{{messageTS: prev.messageTS, addDone: prev.addDone}}, prev.stale...)
+			displaced = append([]busyTaken{{messageTS: prev.messageTS, handle: prev.handle, addDone: prev.addDone}}, prev.stale...)
 		default:
 			keepStale = prev.stale
 			if prev.addDone != nil && prev.addDone != addDone {
@@ -325,7 +332,7 @@ func (r *busyReactionRegistry) markWithDone(channel, threadKey, messageTS string
 			}
 		}
 	}
-	r.entries[key] = busyReactionMark{messageTS: messageTS, addedAt: now, addDone: storeDone, stale: keepStale}
+	r.entries[key] = busyReactionMark{messageTS: messageTS, handle: handle, addedAt: now, addDone: storeDone, stale: keepStale}
 	// A fresh targeted inbound re-arms the thread: the next reply is a
 	// legitimate clearing event, so any consumed-key tombstone stops
 	// applying (tombstones only block RESTORING old marks, codex r8).
@@ -407,6 +414,7 @@ func (r *busyReactionRegistry) restoreLocked(channel string, now time.Time, perK
 		}
 		r.entries[key] = busyReactionMark{
 			messageTS: marks[0].messageTS,
+			handle:    marks[0].handle,
 			addedAt:   now,
 			addDone:   marks[0].addDone,
 			stale:     mergeStale(nil, marks[1:]),
@@ -441,7 +449,11 @@ func (r *busyReactionRegistry) restoreDisplaced(channel string, restore []busyDi
 // so a delivered root publish clears every busy affordance pending in
 // that conversation rather than leaving hourglasses stuck forever.
 // Expired entries are dropped, not returned.
-func (r *busyReactionRegistry) takeConversation(channel string) []busyTaken {
+// allow gates consumption by the mark's target handle (codex r11):
+// a live mark whose handle the publisher does not match is left in
+// place — untouched, untombstoned — for its own agent's reply (or
+// TTL) to clear. A nil allow consumes everything (legacy behavior).
+func (r *busyReactionRegistry) takeConversation(channel string, allow func(handle string) bool) []busyTaken {
 	if r == nil || channel == "" {
 		return nil
 	}
@@ -454,12 +466,16 @@ func (r *busyReactionRegistry) takeConversation(channel string) []busyTaken {
 		if k.channel != channel {
 			continue
 		}
-		delete(r.entries, k)
-		r.tombstoneLocked(k, now)
-		if now.Sub(m.addedAt) > busyReactionTTL {
+		expired := now.Sub(m.addedAt) > busyReactionTTL
+		if !expired && allow != nil && !allow(m.handle) {
 			continue
 		}
-		for _, t := range append([]busyTaken{{messageTS: m.messageTS, addDone: m.addDone}}, m.stale...) {
+		delete(r.entries, k)
+		r.tombstoneLocked(k, now)
+		if expired {
+			continue
+		}
+		for _, t := range append([]busyTaken{{messageTS: m.messageTS, handle: m.handle, addDone: m.addDone}}, m.stale...) {
 			if !seen[t.messageTS] {
 				seen[t.messageTS] = true
 				taken = append(taken, t)
@@ -501,13 +517,14 @@ func (r *busyReactionRegistry) takeMessage(channel, threadTS, messageTS string) 
 		expired := now.Sub(m.addedAt) > busyReactionTTL
 		if !expired && !seen[m.messageTS] {
 			seen[m.messageTS] = true
-			taken = append(taken, busyTaken{messageTS: m.messageTS, addDone: m.addDone})
+			taken = append(taken, busyTaken{messageTS: m.messageTS, handle: m.handle, addDone: m.addDone})
 		}
 		if len(m.stale) > 0 && !expired {
 			// Re-park the ancestors: first becomes the key's mark,
 			// the rest stay stale on it.
 			r.entries[key] = busyReactionMark{
 				messageTS: m.stale[0].messageTS,
+				handle:    m.stale[0].handle,
 				addedAt:   now,
 				addDone:   m.stale[0].addDone,
 				stale:     mergeStale(nil, m.stale[1:]),
@@ -529,7 +546,12 @@ func (r *busyReactionRegistry) takeMessage(channel, threadTS, messageTS string) 
 // deleted but NOT returned — the caller must not fire a
 // reactions.remove for a mark past its TTL (its stale ancestors
 // expire with it).
-func (r *busyReactionRegistry) take(channel, threadKey string) []busyTaken {
+// allow gates consumption by the mark's target handle (codex r11): a
+// live mark whose handle the publisher does not match is left in
+// place — untouched, untombstoned — so agent A's late reply into a
+// thread re-targeted at agent B cannot strip B's affordance. A nil
+// allow consumes unconditionally (legacy behavior).
+func (r *busyReactionRegistry) take(channel, threadKey string, allow func(handle string) bool) []busyTaken {
 	if r == nil {
 		return nil
 	}
@@ -540,17 +562,20 @@ func (r *busyReactionRegistry) take(channel, threadKey string) []busyTaken {
 	if !present {
 		return nil
 	}
-	delete(r.entries, key)
 	now := r.clock()
-	r.tombstoneLocked(key, now)
 	expired := now.Sub(m.addedAt) > busyReactionTTL
+	if !expired && allow != nil && !allow(m.handle) {
+		return nil
+	}
+	delete(r.entries, key)
+	r.tombstoneLocked(key, now)
 	seen := map[string]bool{}
 	var taken []busyTaken
 	collect := func(cm busyReactionMark, cmExpired bool) {
 		if cmExpired {
 			return
 		}
-		for _, t := range append([]busyTaken{{messageTS: cm.messageTS, addDone: cm.addDone}}, cm.stale...) {
+		for _, t := range append([]busyTaken{{messageTS: cm.messageTS, handle: cm.handle, addDone: cm.addDone}}, cm.stale...) {
 			if !seen[t.messageTS] {
 				seen[t.messageTS] = true
 				taken = append(taken, t)

--- a/slack-full/adapter/busy_reaction.go
+++ b/slack-full/adapter/busy_reaction.go
@@ -1,0 +1,627 @@
+package main
+
+import (
+	"sync"
+	"time"
+)
+
+// Busy-reaction lifecycle (hq-xizo).
+//
+// Multi-party channel threads are the primary surface for talking to
+// agents through this adapter, and Slack Assistant mode — whose
+// assistant.threads.setStatus would normally render a "working on it"
+// status — is deliberately not used. The channel-native
+// replacement: when a targeted inbound is dispatched,
+// processSlackEvent adds a busy reaction (BUSY_REACTION, default
+// "hourglass") to the inbound Slack message and records the pending
+// mark here; when the agent's reply is published back into the same
+// conversation/thread, handlePublish looks the mark up and removes
+// the reaction via reactions.remove — add on dispatch, remove on
+// reply.
+//
+// Entries are keyed by (conversation id, thread key), where the
+// thread key is the inbound's thread_ts when it was a thread reply
+// and its own ts when it was a channel-root message. A reply publish
+// carries reply_to_message_id equal to exactly that thread key in
+// both shapes (replies to a root message thread under the root's own
+// ts), so a single lookup form covers both.
+//
+// The registry is memory-only and best-effort by design: a mark whose
+// reply never arrives expires after busyReactionTTL (the entry is
+// dropped and the reaction simply stops being removable), and an
+// adapter restart forgets pending marks. Nothing here may block or
+// fail the dispatch or publish paths.
+
+// busyReactionDefault is the emoji added when BUSY_REACTION is unset.
+const busyReactionDefault = "hourglass"
+
+// busyReactionTTL bounds how long a pending busy mark stays
+// removable. A reply landing later than this is either a very slow
+// agent or a session that died mid-task; in both cases silently
+// keeping the map entry forever is worse than leaving a stale
+// hourglass on one old message.
+const busyReactionTTL = 30 * time.Minute
+
+// busyReactionMaxEntries hard-caps the registry so a pathological
+// event stream (many distinct targeted inbounds, no replies) cannot
+// grow it without bound. Mirrors dmGateMaxEntries: on overflow,
+// expired entries are already swept and the oldest surviving mark is
+// evicted — that mark's reaction just stops being removable.
+const busyReactionMaxEntries = 4096
+
+// busyStaleMaxPerEntry caps how many orphaned ancestor reactions one
+// registry entry retains (codex r7): a stream of overlapping failed
+// re-targets on a hot thread would otherwise grow the ancestry — and
+// copy it on every displacement — without bound. On overflow the
+// OLDEST ancestors drop; their reactions simply stop being removable,
+// which is the pre-ancestry behavior.
+const busyStaleMaxPerEntry = 16
+
+// mergeStale merges add into existing, deduplicating by message ts
+// (first occurrence wins) and capping at busyStaleMaxPerEntry by
+// dropping from the front (oldest).
+func mergeStale(existing, add []busyTaken) []busyTaken {
+	if len(add) == 0 && len(existing) <= busyStaleMaxPerEntry {
+		return existing
+	}
+	seen := map[string]bool{}
+	merged := make([]busyTaken, 0, len(existing)+len(add))
+	for _, t := range existing {
+		if !seen[t.messageTS] {
+			seen[t.messageTS] = true
+			merged = append(merged, t)
+		}
+	}
+	for _, t := range add {
+		if !seen[t.messageTS] {
+			seen[t.messageTS] = true
+			merged = append(merged, t)
+		}
+	}
+	if len(merged) > busyStaleMaxPerEntry {
+		merged = merged[len(merged)-busyStaleMaxPerEntry:]
+	}
+	return merged
+}
+
+// busyReactionAddWait bounds how long the remove side waits for the
+// corresponding reactions.add call to finish before issuing
+// reactions.remove anyway. It MUST exceed slackAPIClient's timeout
+// (30s): the add is bounded by that client, so waiting past it means
+// addDone has provably closed and remove-after-add ordering holds; a
+// shorter bound would reopen the very race this wait exists to
+// prevent (codex r6). The timeout branch is therefore effectively
+// unreachable and exists only as a leak backstop.
+const busyReactionAddWait = 45 * time.Second
+
+// busyReactionKey identifies one conversation/thread with a pending
+// busy mark.
+type busyReactionKey struct {
+	channel   string
+	threadKey string
+}
+
+// busyReactionMark is one pending busy reaction: the ts of the Slack
+// message the reaction was added to, when it was added (for TTL), and
+// the channel the add goroutine closes once its reactions.add call has
+// returned. The remove side waits on addDone (bounded by
+// busyReactionAddWait) before firing reactions.remove, so a reply that
+// lands while the add is still in flight cannot have its remove
+// overtaken by the delayed add — which would leave a permanent busy
+// emoji on the message.
+//
+// stale carries orphaned predecessor reactions that still ride under
+// this key (codex r6): when a re-target's forward fails while an even
+// newer mark owns the key, the failed attempt's restore list merges
+// here instead of being lost, so every reaction added under the key
+// is eventually removed when the key's current mark concludes.
+type busyReactionMark struct {
+	messageTS string
+	addedAt   time.Time
+	addDone   chan struct{}
+	stale     []busyTaken
+}
+
+// busyThreadKey derives the registry thread key for an inbound
+// message: its thread_ts when it is a thread reply, its own ts when
+// it is a channel-root message (a reply to it will thread under that
+// same ts).
+func busyThreadKey(threadTS, messageTS string) string {
+	if threadTS != "" {
+		return threadTS
+	}
+	return messageTS
+}
+
+// busyReactionRegistry tracks pending busy marks. Safe for concurrent
+// callers; the mutex guards the map only — Slack API calls never run
+// under it.
+//
+// A nil *busyReactionRegistry is inert: mark is a no-op and take
+// reports no pending mark, so tests (and a misordered main) degrade
+// to "no lifecycle" rather than panicking.
+type busyReactionRegistry struct {
+	mu      sync.Mutex
+	entries map[busyReactionKey]busyReactionMark
+	// tombstones records keys a reply recently CONSUMED (take /
+	// takeConversation). Restoration paths consult them (codex r8): a
+	// displaced mark must not be re-parked under a key whose thread
+	// already got its reply while the displacing dispatch was in
+	// flight — the reply was that thread's one clearing event, so a
+	// restored mark would never be consumed and its reaction would
+	// stick forever. Blocked marks are returned to the caller for
+	// immediate removal instead. Entries expire after
+	// busyTombstoneTTL and are swept opportunistically.
+	tombstones map[busyReactionKey]time.Time
+	// now is the clock; nil means time.Now. Injectable so tests can
+	// drive TTL expiry without sleeping.
+	now func() time.Time
+}
+
+// busyTombstoneTTL bounds how long a consumed key blocks restoration.
+// The races it guards close within one bounded dispatch round trip
+// (≤ the 20s gc-forward timeout plus scheduling slack); 5 minutes is
+// comfortably past that while keeping the map small.
+const busyTombstoneTTL = 5 * time.Minute
+
+// busyTombstoneMaxEntries hard-caps the tombstone map (codex r9):
+// every consumed thread writes one, so sustained traffic would grow
+// it unboundedly between mark-site sweeps, and traffic stopping would
+// strand expired entries. tombstoneLocked sweeps expired entries on
+// every insert and evicts the oldest at the cap — an evicted
+// tombstone just stops blocking one restoration, the pre-tombstone
+// behavior.
+const busyTombstoneMaxEntries = 4096
+
+// tombstoneLocked records a consumed key, sweeping expired tombstones
+// and enforcing the cap. Called with r.mu held.
+func (r *busyReactionRegistry) tombstoneLocked(key busyReactionKey, now time.Time) {
+	for k, at := range r.tombstones {
+		if now.Sub(at) > busyTombstoneTTL {
+			delete(r.tombstones, k)
+		}
+	}
+	r.tombstones[key] = now
+	if len(r.tombstones) > busyTombstoneMaxEntries {
+		var oldestK busyReactionKey
+		var oldestAt time.Time
+		first := true
+		for k, at := range r.tombstones {
+			if first || at.Before(oldestAt) {
+				oldestK, oldestAt, first = k, at, false
+			}
+		}
+		if !first {
+			delete(r.tombstones, oldestK)
+		}
+	}
+}
+
+func newBusyReactionRegistry() *busyReactionRegistry {
+	return &busyReactionRegistry{
+		entries:    make(map[busyReactionKey]busyReactionMark),
+		tombstones: make(map[busyReactionKey]time.Time),
+	}
+}
+
+func (r *busyReactionRegistry) clock() time.Time {
+	if r.now != nil {
+		return r.now()
+	}
+	return time.Now()
+}
+
+// mark records a pending busy reaction on messageTS under
+// (channel, threadKey), sweeping expired entries opportunistically
+// and evicting the oldest surviving mark if the map is still over
+// cap. A re-mark of the same key (human re-tags the agent in the same
+// thread before the first reply lands) overwrites — the reaction sits
+// on the newest targeted message and the reply clears that one.
+//
+// busyTaken is one consumed mark: the ts the reaction sits on and the
+// channel its add goroutine closes on completion (remove-after-add
+// ordering).
+type busyTaken struct {
+	messageTS string
+	addDone   chan struct{}
+}
+
+// busyDisplaced is a mark displaced by a re-target, together with the
+// registry key it was displaced from — enough to restore it if the
+// displacing inbound's forward then fails (codex r5).
+type busyDisplaced struct {
+	threadKey string
+	mark      busyTaken
+}
+
+// The returned channel is the mark's addDone: the caller's add
+// goroutine MUST close it once its reactions.add call has returned so
+// the remove side can order remove-after-add. Always non-nil — a
+// nil/invalid-args no-op still returns a fresh channel so the caller
+// can close it unconditionally. Any mark this overwrites is silently
+// discarded — production code uses markBoth, which surfaces
+// superseded marks so their reactions can be cleaned up.
+func (r *busyReactionRegistry) mark(channel, threadKey, messageTS string) chan struct{} {
+	addDone := make(chan struct{})
+	r.markWithDone(channel, threadKey, messageTS, addDone)
+	return addDone
+}
+
+// markBoth records the pending mark under EVERY thread key a reply may
+// carry (codex r2). The canonical key is the thread root (thread_ts
+// for a thread-reply inbound, own ts for a channel-root one) — but
+// reply-current and the alias-dispatch instructions thread replies
+// under the inbound's OWN ts (Slack normalizes either form into the
+// same thread), so a thread-reply inbound is additionally marked under
+// its own ts. Both entries share one addDone; consuming one leaves the
+// sibling to expire by TTL, whose eventual redundant reactions.remove
+// is benign ("no_reaction" counts as delivered).
+//
+// superseded returns the marks these writes displaced (a human
+// re-targeting the same thread before the first reply lands, codex
+// r3): those messages already carry a busy reaction that no registry
+// entry points at anymore. Once the displacing inbound's forward
+// SUCCEEDS the caller must remove those reactions (TTL expiry only
+// deletes metadata, never the Slack-side emoji); if the forward
+// fails, the caller restores them via cancelBoth instead (codex r5).
+// Deduplicated by message ts and never includes messageTS itself.
+func (r *busyReactionRegistry) markBoth(channel, threadTS, messageTS string) (addDone chan struct{}, superseded []busyDisplaced) {
+	addDone = make(chan struct{})
+	seen := map[string]bool{messageTS: true}
+	collect := func(key string, old busyTaken, ok bool) {
+		if ok && !seen[old.messageTS] {
+			seen[old.messageTS] = true
+			superseded = append(superseded, busyDisplaced{threadKey: key, mark: old})
+		}
+	}
+	rootKey := busyThreadKey(threadTS, messageTS)
+	for _, old := range r.markWithDone(channel, rootKey, messageTS, addDone) {
+		collect(rootKey, old, true)
+	}
+	if threadTS != "" && threadTS != messageTS {
+		for _, old := range r.markWithDone(channel, messageTS, messageTS, addDone) {
+			collect(messageTS, old, true)
+		}
+	}
+	return addDone, superseded
+}
+
+// markWithDone is the mark implementation with a caller-supplied
+// addDone, letting markBoth share one channel across its two entries.
+// Returns every displaced pending reaction — the previous mark (when
+// its reaction sits on a DIFFERENT message) plus any stale ancestors
+// riding on it (codex r6). A re-mark of the SAME message (a retaken
+// Slack redelivery re-marking after a failed dispatch, codex r4)
+// merges completion channels instead of overwriting — the earlier
+// reactions.add may still be in flight and could land after a remove
+// that only waited for the newer add — and keeps the previous entry's
+// stale ancestors.
+func (r *busyReactionRegistry) markWithDone(channel, threadKey, messageTS string, addDone chan struct{}) (displaced []busyTaken) {
+	if r == nil || channel == "" || threadKey == "" || messageTS == "" {
+		return nil
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	now := r.clock()
+	r.sweepLocked(now)
+	key := busyReactionKey{channel: channel, threadKey: threadKey}
+	storeDone := addDone
+	var keepStale []busyTaken
+	if prev, present := r.entries[key]; present {
+		switch {
+		case prev.messageTS != messageTS:
+			displaced = append([]busyTaken{{messageTS: prev.messageTS, addDone: prev.addDone}}, prev.stale...)
+		default:
+			keepStale = prev.stale
+			if prev.addDone != nil && prev.addDone != addDone {
+				prevDone := prev.addDone
+				merged := make(chan struct{})
+				go func() {
+					<-prevDone
+					<-addDone
+					close(merged)
+				}()
+				storeDone = merged
+			}
+		}
+	}
+	r.entries[key] = busyReactionMark{messageTS: messageTS, addedAt: now, addDone: storeDone, stale: keepStale}
+	// A fresh targeted inbound re-arms the thread: the next reply is a
+	// legitimate clearing event, so any consumed-key tombstone stops
+	// applying (tombstones only block RESTORING old marks, codex r8).
+	delete(r.tombstones, key)
+	if len(r.entries) > busyReactionMaxEntries {
+		r.evictOldestLocked()
+	}
+	return displaced
+}
+
+// cancelBoth removes the entries markBoth created for (channel,
+// threadTS, messageTS) — the inbound never reached gc, so no reply
+// will ever come to clear them — restores any marks that inbound had
+// displaced (their agents may still be working and their reactions
+// were deliberately NOT removed yet, codex r5), and closes addDone so
+// any waiter that already consumed a mark proceeds to its benign
+// no-op remove (the reactions.add for a cancelled mark never fires).
+// Entries are deleted only while they still point at messageTS, and a
+// restore never clobbers a key a racing retry has already re-marked.
+// Callers must run this BEFORE releasing the event's dedup claim, so
+// a woken redelivery cannot re-mark the timestamp while the old
+// attempt's cancellation is still in flight.
+func (r *busyReactionRegistry) cancelBoth(channel, threadTS, messageTS string, addDone chan struct{}, restore []busyDisplaced) (blocked []busyTaken) {
+	if r != nil && channel != "" && messageTS != "" {
+		r.mu.Lock()
+		now := r.clock()
+		keys := []string{busyThreadKey(threadTS, messageTS)}
+		if threadTS != "" && threadTS != messageTS {
+			keys = append(keys, messageTS)
+		}
+		// Restore pool: the marks this failed inbound displaced, plus
+		// any stale ancestors that were riding on the cancelled
+		// entries themselves (merged there by an even earlier failed
+		// re-target, codex r6). Grouped per key.
+		perKey := map[string][]busyTaken{}
+		for _, d := range restore {
+			perKey[d.threadKey] = append(perKey[d.threadKey], d.mark)
+		}
+		for _, k := range keys {
+			key := busyReactionKey{channel: channel, threadKey: k}
+			if m, ok := r.entries[key]; ok && m.messageTS == messageTS {
+				delete(r.entries, key)
+				perKey[k] = append(perKey[k], m.stale...)
+			}
+		}
+		blocked = r.restoreLocked(channel, now, perKey)
+		r.mu.Unlock()
+	}
+	if addDone != nil {
+		close(addDone)
+	}
+	return blocked
+}
+
+// restoreLocked re-parks per-key mark pools: an unowned key gets the
+// pool's first mark as its entry (rest as stale ancestry); a key a
+// racing retry or newer re-target owns is never clobbered — the pool
+// merges into its stale ancestry so its conclusion still clears them.
+// A key whose thread was CONSUMED by a reply after the displacement
+// (live tombstone, codex r8) blocks restoration entirely — that reply
+// was the thread's one clearing event, so a restored mark would never
+// be consumed; the blocked marks are returned for the caller to
+// remove their reactions instead. Ancestry is deduplicated and
+// bounded (busyStaleMaxPerEntry). Called with r.mu held.
+func (r *busyReactionRegistry) restoreLocked(channel string, now time.Time, perKey map[string][]busyTaken) (blocked []busyTaken) {
+	for k, marks := range perKey {
+		if len(marks) == 0 {
+			continue
+		}
+		key := busyReactionKey{channel: channel, threadKey: k}
+		if at, dead := r.tombstones[key]; dead && now.Sub(at) <= busyTombstoneTTL {
+			blocked = append(blocked, marks...)
+			continue
+		}
+		if cur, taken := r.entries[key]; taken {
+			cur.stale = mergeStale(cur.stale, marks)
+			r.entries[key] = cur
+			continue
+		}
+		r.entries[key] = busyReactionMark{
+			messageTS: marks[0].messageTS,
+			addedAt:   now,
+			addDone:   marks[0].addDone,
+			stale:     mergeStale(nil, marks[1:]),
+		}
+	}
+	return blocked
+}
+
+// restoreDisplaced re-parks marks a failed delivery had displaced
+// (codex r7): the displacing message's affordance is being rolled
+// back, but the displaced agents may still be working and their
+// reactions were deliberately not removed. Marks blocked by a
+// consumed-key tombstone are returned — the caller must remove their
+// reactions (codex r8).
+func (r *busyReactionRegistry) restoreDisplaced(channel string, restore []busyDisplaced) (blocked []busyTaken) {
+	if r == nil || channel == "" || len(restore) == 0 {
+		return nil
+	}
+	perKey := map[string][]busyTaken{}
+	for _, d := range restore {
+		perKey[d.threadKey] = append(perKey[d.threadKey], d.mark)
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.restoreLocked(channel, r.clock(), perKey)
+}
+
+// takeConversation removes and returns every pending mark in channel,
+// deduplicated by message ts (dual-key entries share one message).
+// Backs the unthreaded-reply path (codex r3): the documented default
+// `gc slack reply-current` posts at channel root with no thread ts,
+// so a delivered root publish clears every busy affordance pending in
+// that conversation rather than leaving hourglasses stuck forever.
+// Expired entries are dropped, not returned.
+func (r *busyReactionRegistry) takeConversation(channel string) []busyTaken {
+	if r == nil || channel == "" {
+		return nil
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	now := r.clock()
+	seen := map[string]bool{}
+	var taken []busyTaken
+	for k, m := range r.entries {
+		if k.channel != channel {
+			continue
+		}
+		delete(r.entries, k)
+		r.tombstoneLocked(k, now)
+		if now.Sub(m.addedAt) > busyReactionTTL {
+			continue
+		}
+		for _, t := range append([]busyTaken{{messageTS: m.messageTS, addDone: m.addDone}}, m.stale...) {
+			if !seen[t.messageTS] {
+				seen[t.messageTS] = true
+				taken = append(taken, t)
+			}
+		}
+	}
+	return taken
+}
+
+// takeMessage removes the entries markBoth created for (channel,
+// threadTS, messageTS) while they still point at messageTS, returning
+// that message's pending reaction for removal. Backs the
+// alias-delivery-failure path (codex r6): the reactions.add already
+// launched but no reply is coming (the addressed session never got
+// the message and the bound session stays silent), so the emoji must
+// come off now. Stale ancestors riding on a consumed entry are NOT
+// removed — their messages' fate is independent — they are re-parked
+// under the key so a later conclusion still clears them.
+func (r *busyReactionRegistry) takeMessage(channel, threadTS, messageTS string) []busyTaken {
+	if r == nil || channel == "" || messageTS == "" {
+		return nil
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	now := r.clock()
+	keys := []string{busyThreadKey(threadTS, messageTS)}
+	if threadTS != "" && threadTS != messageTS {
+		keys = append(keys, messageTS)
+	}
+	var taken []busyTaken
+	seen := map[string]bool{}
+	for _, k := range keys {
+		key := busyReactionKey{channel: channel, threadKey: k}
+		m, ok := r.entries[key]
+		if !ok || m.messageTS != messageTS {
+			continue
+		}
+		delete(r.entries, key)
+		expired := now.Sub(m.addedAt) > busyReactionTTL
+		if !expired && !seen[m.messageTS] {
+			seen[m.messageTS] = true
+			taken = append(taken, busyTaken{messageTS: m.messageTS, addDone: m.addDone})
+		}
+		if len(m.stale) > 0 && !expired {
+			// Re-park the ancestors: first becomes the key's mark,
+			// the rest stay stale on it.
+			r.entries[key] = busyReactionMark{
+				messageTS: m.stale[0].messageTS,
+				addedAt:   now,
+				addDone:   m.stale[0].addDone,
+				stale:     mergeStale(nil, m.stale[1:]),
+			}
+		}
+	}
+	return taken
+}
+
+// take removes and returns every pending reaction for (channel,
+// threadKey) — the current mark plus any stale ancestors riding on it
+// (codex r6) — and also consumes every OTHER entry in the channel
+// pointing at the same message (codex r10): markBoth records a
+// thread-reply inbound under both its thread root and its own ts, and
+// a reply threading under one alias is the clearing event for both;
+// leaving the sibling behind would strand it (and any ancestors an
+// overlapping failed re-target parked on it) with no later clearing
+// event. All consumed keys are tombstoned. An expired entry is
+// deleted but NOT returned — the caller must not fire a
+// reactions.remove for a mark past its TTL (its stale ancestors
+// expire with it).
+func (r *busyReactionRegistry) take(channel, threadKey string) []busyTaken {
+	if r == nil {
+		return nil
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	key := busyReactionKey{channel: channel, threadKey: threadKey}
+	m, present := r.entries[key]
+	if !present {
+		return nil
+	}
+	delete(r.entries, key)
+	now := r.clock()
+	r.tombstoneLocked(key, now)
+	expired := now.Sub(m.addedAt) > busyReactionTTL
+	seen := map[string]bool{}
+	var taken []busyTaken
+	collect := func(cm busyReactionMark, cmExpired bool) {
+		if cmExpired {
+			return
+		}
+		for _, t := range append([]busyTaken{{messageTS: cm.messageTS, addDone: cm.addDone}}, cm.stale...) {
+			if !seen[t.messageTS] {
+				seen[t.messageTS] = true
+				taken = append(taken, t)
+			}
+		}
+	}
+	collect(m, expired)
+	for k, sib := range r.entries {
+		if k.channel != channel || sib.messageTS != m.messageTS {
+			continue
+		}
+		delete(r.entries, k)
+		r.tombstoneLocked(k, now)
+		collect(sib, now.Sub(sib.addedAt) > busyReactionTTL)
+	}
+	return taken
+}
+
+// pending reports the recorded message ts for (channel, threadKey)
+// without consuming or TTL-checking the entry. Test/observability
+// helper.
+func (r *busyReactionRegistry) pending(channel, threadKey string) (messageTS string, ok bool) {
+	if r == nil {
+		return "", false
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	m, present := r.entries[busyReactionKey{channel: channel, threadKey: threadKey}]
+	if !present {
+		return "", false
+	}
+	return m.messageTS, true
+}
+
+// size reports the number of pending marks. Test helper.
+func (r *busyReactionRegistry) size() int {
+	if r == nil {
+		return 0
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.entries)
+}
+
+// sweepLocked drops expired marks and tombstones. Called with r.mu held.
+func (r *busyReactionRegistry) sweepLocked(now time.Time) {
+	for k, m := range r.entries {
+		if now.Sub(m.addedAt) > busyReactionTTL {
+			delete(r.entries, k)
+		}
+	}
+	for k, at := range r.tombstones {
+		if now.Sub(at) > busyTombstoneTTL {
+			delete(r.tombstones, k)
+		}
+	}
+}
+
+// evictOldestLocked drops the single oldest mark. Called with r.mu
+// held, only on the insert that pushed the map past the cap (expired
+// entries were already swept by mark).
+func (r *busyReactionRegistry) evictOldestLocked() {
+	var oldestKey busyReactionKey
+	var oldestAt time.Time
+	first := true
+	for k, m := range r.entries {
+		if first || m.addedAt.Before(oldestAt) {
+			oldestKey, oldestAt, first = k, m.addedAt, false
+		}
+	}
+	if !first {
+		delete(r.entries, oldestKey)
+	}
+}

--- a/slack-full/adapter/busy_reaction_test.go
+++ b/slack-full/adapter/busy_reaction_test.go
@@ -1102,3 +1102,55 @@ func TestClearBusyReactionMatchesPublisherSession(t *testing.T) {
 		t.Fatalf("owning session's reply: got (%s on %s), want remove on 1.0", got.op, got.timestamp)
 	}
 }
+
+// codex r16: stale ancestors are matched per handle. Alpha's orphaned
+// reaction riding in beta's entry must be cleared by ALPHA's reply
+// (and only alpha's), while beta's own mark stays for beta.
+func TestBusyReactionRegistry_StaleAncestorsMatchedPerHandle(t *testing.T) {
+	r := newBusyReactionRegistry()
+	// alpha targets the thread; beta re-targets it, displacing alpha's
+	// mark under the thread-root key; the failed-re-target path then
+	// restores alpha's mark as a stale ancestor on beta's entry.
+	dA, _ := r.markBoth("C1", "root.0", "1.0", "alpha")
+	close(dA)
+	dB, superseded := r.markBoth("C1", "root.0", "2.0", "beta")
+	close(dB)
+	if len(superseded) != 1 {
+		t.Fatalf("superseded = %v, want alpha's displaced mark", superseded)
+	}
+	r.restoreDisplaced("C1", superseded)
+
+	// Beta's reply clears ONLY beta's mark; alpha's ancestor re-parks.
+	taken := r.take("C1", "root.0", func(h string) bool { return h == "beta" })
+	got := map[string]bool{}
+	for _, tk := range taken {
+		got[tk.messageTS] = true
+	}
+	if !got["2.0"] || got["1.0"] || len(taken) != 1 {
+		t.Fatalf("beta's take = %v, want exactly [2.0]", taken)
+	}
+	// Alpha's reply then clears its re-parked mark.
+	taken = r.take("C1", "root.0", func(h string) bool { return h == "alpha" })
+	if len(taken) != 1 || taken[0].messageTS != "1.0" {
+		t.Fatalf("alpha's take = %v, want [1.0]", taken)
+	}
+}
+
+// codex r16: takeConversation partitions per mark too — a root reply
+// by alpha clears alpha's marks and unattributed ones while beta's
+// survive, including when they ride the same entry.
+func TestBusyReactionRegistry_TakeConversationPartitionsStale(t *testing.T) {
+	r := newBusyReactionRegistry()
+	dB, _ := r.markBoth("C1", "", "2.0", "beta")
+	close(dB)
+	// Alpha's orphan rides beta's entry as a stale ancestor.
+	r.restoreDisplaced("C1", []busyDisplaced{{threadKey: "2.0", mark: busyTaken{messageTS: "1.0", handle: "alpha"}}})
+
+	taken := r.takeConversation("C1", func(h string) bool { return h == "alpha" })
+	if len(taken) != 1 || taken[0].messageTS != "1.0" {
+		t.Fatalf("alpha's root reply took %v, want exactly [1.0]", taken)
+	}
+	if _, ok := r.pending("C1", "2.0"); !ok {
+		t.Fatal("beta's mark gone after alpha's root reply")
+	}
+}

--- a/slack-full/adapter/busy_reaction_test.go
+++ b/slack-full/adapter/busy_reaction_test.go
@@ -240,13 +240,13 @@ func TestBusyReaction_PublishToSameThreadRemovesBusy(t *testing.T) {
 
 			marks := newBusyReactionRegistry()
 			// Close addDone: the add already completed in this scenario.
-			done, _ := marks.markBoth("C1", tc.seedThreadTS, tc.seedTS)
+			done, _ := marks.markBoth("C1", tc.seedThreadTS, tc.seedTS, "")
 			close(done)
 			cfg := config{slackBotToken: "xoxb-fake", busyReaction: "hourglass", busyMarks: marks}
 
 			req := httptest.NewRequest(http.MethodPost, "/publish", strings.NewReader(publishBody("C1", tc.replyTo)))
 			rec := httptest.NewRecorder()
-			handlePublish(cfg, nil, nil, newPublishDedupCache(publishDedupTTL))(rec, req)
+			handlePublish(cfg, nil, nil, nil, newPublishDedupCache(publishDedupTTL))(rec, req)
 			if rec.Code != http.StatusOK {
 				t.Fatalf("publish status = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
 			}
@@ -296,7 +296,7 @@ func TestBusyReaction_UnrelatedPublishDoesNotRemove(t *testing.T) {
 
 			req := httptest.NewRequest(http.MethodPost, "/publish", strings.NewReader(publishBody(tc.conversation, tc.replyTo)))
 			rec := httptest.NewRecorder()
-			handlePublish(cfg, nil, nil, newPublishDedupCache(publishDedupTTL))(rec, req)
+			handlePublish(cfg, nil, nil, nil, newPublishDedupCache(publishDedupTTL))(rec, req)
 			if rec.Code != http.StatusOK {
 				t.Fatalf("publish status = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
 			}
@@ -319,15 +319,15 @@ func TestBusyReaction_RootPublishClearsConversationMarks(t *testing.T) {
 	withSlackAPIStub(t, slackStub)
 
 	marks := newBusyReactionRegistry()
-	doneA, _ := marks.markBoth("C1", "", "100.000010")
+	doneA, _ := marks.markBoth("C1", "", "100.000010", "")
 	close(doneA)
-	doneB, _ := marks.markBoth("C1", "200.000001", "200.000020")
+	doneB, _ := marks.markBoth("C1", "200.000001", "200.000020", "")
 	close(doneB)
 	cfg := config{slackBotToken: "xoxb-fake", busyReaction: "hourglass", busyMarks: marks}
 
 	req := httptest.NewRequest(http.MethodPost, "/publish", strings.NewReader(publishBody("C1", "")))
 	rec := httptest.NewRecorder()
-	handlePublish(cfg, nil, nil, newPublishDedupCache(publishDedupTTL))(rec, req)
+	handlePublish(cfg, nil, nil, nil, newPublishDedupCache(publishDedupTTL))(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("publish status = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
 	}
@@ -484,7 +484,7 @@ func TestBusyReaction_CustomEmojiHonored(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodPost, "/publish", strings.NewReader(publishBody("C1", "100.000010")))
 	rec := httptest.NewRecorder()
-	handlePublish(cfg, nil, nil, newPublishDedupCache(publishDedupTTL))(rec, req)
+	handlePublish(cfg, nil, nil, nil, newPublishDedupCache(publishDedupTTL))(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("publish status = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
 	}
@@ -537,7 +537,7 @@ func TestBusyReaction_FastReplyWaitsForAddBeforeRemove(t *testing.T) {
 	// Reply immediately — well before the 400ms add completes.
 	req := httptest.NewRequest(http.MethodPost, "/publish", strings.NewReader(publishBody("C1", "100.000010")))
 	rec := httptest.NewRecorder()
-	handlePublish(cfg, nil, nil, newPublishDedupCache(publishDedupTTL))(rec, req)
+	handlePublish(cfg, nil, nil, nil, newPublishDedupCache(publishDedupTTL))(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("publish status = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
 	}
@@ -599,7 +599,7 @@ func TestBusyReaction_PublishFileToSameThreadRemovesBusy(t *testing.T) {
 	body := fmt.Sprintf(`{"conversation":{"conversation_id":"C1"},"file_path":%q,"reply_to_message_id":"100.000010"}`, filePath)
 	req := httptest.NewRequest(http.MethodPost, "/publish-file", strings.NewReader(body))
 	rec := httptest.NewRecorder()
-	handlePublishFile(cfg, nil)(rec, req)
+	handlePublishFile(cfg, nil, nil)(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("publish-file status = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
 	}
@@ -670,7 +670,7 @@ func TestBusyReaction_ReplyDuringForwardFindsMark(t *testing.T) {
 	// Reply while the forward is still in flight: the mark must exist.
 	req := httptest.NewRequest(http.MethodPost, "/publish", strings.NewReader(publishBody("C1", "100.000010")))
 	rec := httptest.NewRecorder()
-	handlePublish(cfg, nil, nil, newPublishDedupCache(publishDedupTTL))(rec, req)
+	handlePublish(cfg, nil, nil, nil, newPublishDedupCache(publishDedupTTL))(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("publish status = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
 	}
@@ -719,7 +719,7 @@ func TestBusyReaction_FailedRetargetRestoresDisplacedMark(t *testing.T) {
 
 	cfg := busyTestConfig(gcStub.URL)
 	// Pre-existing mark: root message M1, its add already completed.
-	doneM1, _ := cfg.busyMarks.markBoth("C1", "", "100.000010")
+	doneM1, _ := cfg.busyMarks.markBoth("C1", "", "100.000010", "")
 	close(doneM1)
 
 	// Targeted thread reply M2 in M1's thread; its forward fails.
@@ -745,13 +745,13 @@ func TestBusyReactionRegistry_FailedMiddleRetargetPreservesAncestors(t *testing.
 	r := newBusyReactionRegistry()
 	const m1, m2, m3 = "1.0", "2.0", "3.0"
 
-	d1, disp := r.markBoth("C1", "", m1)
+	d1, disp := r.markBoth("C1", "", m1, "")
 	close(d1)
 	if len(disp) != 0 {
 		t.Fatalf("M1 displaced %v, want none", disp)
 	}
-	d2, disp2 := r.markBoth("C1", m1, m2) // M2 re-targets M1's thread
-	d3, disp3 := r.markBoth("C1", m1, m3) // M3 re-targets again
+	d2, disp2 := r.markBoth("C1", m1, m2, "") // M2 re-targets M1's thread
+	d3, disp3 := r.markBoth("C1", m1, m3, "") // M3 re-targets again
 	close(d3)
 	if len(disp2) == 0 || disp2[0].mark.messageTS != m1 {
 		t.Fatalf("M2 displaced %v, want M1", disp2)
@@ -767,7 +767,7 @@ func TestBusyReactionRegistry_FailedMiddleRetargetPreservesAncestors(t *testing.
 		t.Fatalf("key owner after failed M2 = (%q, %v), want M3", ts, ok)
 	}
 
-	taken := r.take("C1", m1)
+	taken := r.take("C1", m1, nil)
 	got := map[string]bool{}
 	for _, tk := range taken {
 		got[tk.messageTS] = true
@@ -786,10 +786,10 @@ func TestBusyReactionRegistry_FailedMiddleRetargetPreservesAncestors(t *testing.
 func TestBusyReactionRegistry_TakeMessageReparksAncestors(t *testing.T) {
 	r := newBusyReactionRegistry()
 	const m1, m2, m3 = "1.0", "2.0", "3.0"
-	d1, _ := r.markBoth("C1", "", m1)
+	d1, _ := r.markBoth("C1", "", m1, "")
 	close(d1)
-	d2, disp2 := r.markBoth("C1", m1, m2)
-	d3, disp3 := r.markBoth("C1", m1, m3)
+	d2, disp2 := r.markBoth("C1", m1, m2, "")
+	d3, disp3 := r.markBoth("C1", m1, m3, "")
 	close(d3)
 	r.cancelBoth("C1", m1, m2, d2, disp2) // M1 → M3's stale
 	_ = disp3
@@ -799,7 +799,7 @@ func TestBusyReactionRegistry_TakeMessageReparksAncestors(t *testing.T) {
 		t.Fatalf("takeMessage = %v, want exactly M3", taken)
 	}
 	// M1 must have been re-parked under the key, still clearable.
-	remaining := r.take("C1", m1)
+	remaining := r.take("C1", m1, nil)
 	got := map[string]bool{}
 	for _, tk := range remaining {
 		got[tk.messageTS] = true
@@ -814,10 +814,10 @@ func TestBusyReactionRegistry_TakeMessageReparksAncestors(t *testing.T) {
 // inbound's own ts is the clearing event for the root-key sibling too.
 func TestBusyReactionRegistry_TakeConsumesBothDualKeys(t *testing.T) {
 	r := newBusyReactionRegistry()
-	d, _ := r.markBoth("C1", "1.0", "2.0") // root key 1.0 + own-ts key 2.0
+	d, _ := r.markBoth("C1", "1.0", "2.0", "") // root key 1.0 + own-ts key 2.0
 	close(d)
 
-	taken := r.take("C1", "2.0") // reply threads under the inbound's own ts
+	taken := r.take("C1", "2.0", nil) // reply threads under the inbound's own ts
 	if len(taken) != 1 || taken[0].messageTS != "2.0" {
 		t.Fatalf("take = %v, want exactly the 2.0 mark once", taken)
 	}
@@ -842,15 +842,15 @@ func TestBusyReactionRegistry_TombstoneBlocksRestoreAfterConsume(t *testing.T) {
 	r := newBusyReactionRegistry()
 	const m1, m2 = "1.0", "2.0"
 
-	d1, _ := r.markBoth("C1", "", m1)
+	d1, _ := r.markBoth("C1", "", m1, "")
 	close(d1)
-	d2, disp2 := r.markBoth("C1", m1, m2) // M2 displaces M1
+	d2, disp2 := r.markBoth("C1", m1, m2, "") // M2 displaces M1
 	if len(disp2) == 0 || disp2[0].mark.messageTS != m1 {
 		t.Fatalf("displaced = %v, want M1", disp2)
 	}
 	// A reply lands while M2's dispatch is in flight and consumes the
 	// thread (root key + own-ts key).
-	if taken := r.take("C1", m1); len(taken) == 0 {
+	if taken := r.take("C1", m1, nil); len(taken) == 0 {
 		t.Fatal("reply take found no mark")
 	}
 	// M2's dispatch fails: restore must be blocked by the tombstone and
@@ -868,7 +868,7 @@ func TestBusyReactionRegistry_TombstoneBlocksRestoreAfterConsume(t *testing.T) {
 	}
 
 	// A fresh targeted inbound re-arms the key despite the tombstone.
-	d3, _ := r.markBoth("C1", "", m1)
+	d3, _ := r.markBoth("C1", "", m1, "")
 	close(d3)
 	if _, ok := r.pending("C1", m1); !ok {
 		t.Error("fresh mark did not re-arm the tombstoned key")
@@ -880,10 +880,10 @@ func TestBusyReactionRegistry_TombstoneBlocksRestoreAfterConsume(t *testing.T) {
 // concluded (codex r4).
 func TestBusyReactionRegistry_SameMessageRemarkMergesAddDone(t *testing.T) {
 	r := newBusyReactionRegistry()
-	d1, _ := r.markBoth("C1", "", "1.0")
-	d2, _ := r.markBoth("C1", "", "1.0")
+	d1, _ := r.markBoth("C1", "", "1.0", "")
+	d2, _ := r.markBoth("C1", "", "1.0", "")
 
-	taken := r.take("C1", "1.0")
+	taken := r.take("C1", "1.0", nil)
 	if len(taken) != 1 || taken[0].addDone == nil {
 		t.Fatalf("take = %v, want one entry with a merged done channel", taken)
 	}
@@ -929,7 +929,7 @@ func TestBusyReaction_ExpiredMarkDoesNotRemove(t *testing.T) {
 	cfg := config{slackBotToken: "xoxb-fake", busyReaction: "hourglass", busyMarks: marks}
 	req := httptest.NewRequest(http.MethodPost, "/publish", strings.NewReader(publishBody("C1", "100.000010")))
 	rec := httptest.NewRecorder()
-	handlePublish(cfg, nil, nil, newPublishDedupCache(publishDedupTTL))(rec, req)
+	handlePublish(cfg, nil, nil, nil, newPublishDedupCache(publishDedupTTL))(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("publish status = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
 	}
@@ -957,10 +957,10 @@ func TestBusyReactionRegistry_TakeAndSweep(t *testing.T) {
 	}
 
 	r.mark("C1", "1.0", "1.0")
-	if taken := r.take("C1", "1.0"); len(taken) != 1 || taken[0].messageTS != "1.0" {
+	if taken := r.take("C1", "1.0", nil); len(taken) != 1 || taken[0].messageTS != "1.0" {
 		t.Fatalf("take = %v, want one entry for 1.0", taken)
 	}
-	if taken := r.take("C1", "1.0"); len(taken) != 0 {
+	if taken := r.take("C1", "1.0", nil); len(taken) != 0 {
 		t.Fatal("second take succeeded; want consumed on first take")
 	}
 
@@ -1017,7 +1017,7 @@ func TestBusyReactionRegistry_NilSafe(t *testing.T) {
 	if done := r.mark("C1", "1.0", "1.0"); done == nil {
 		t.Error("mark on nil registry returned a nil addDone channel; want closable")
 	}
-	if taken := r.take("C1", "1.0"); len(taken) != 0 {
+	if taken := r.take("C1", "1.0", nil); len(taken) != 0 {
 		t.Error("take on nil registry reported a mark")
 	}
 	if _, ok := r.pending("C1", "1.0"); ok {
@@ -1025,5 +1025,80 @@ func TestBusyReactionRegistry_NilSafe(t *testing.T) {
 	}
 	if n := r.size(); n != 0 {
 		t.Errorf("size on nil registry = %d, want 0", n)
+	}
+}
+
+// codex r11: a reply may only clear marks recorded for the publishing
+// agent. M1 targets alpha, M2 re-targets beta in the same thread —
+// alpha's late reply must not consume beta's mark.
+func TestBusyReactionRegistry_TakeRespectsHandleMatcher(t *testing.T) {
+	r := newBusyReactionRegistry()
+	done, _ := r.markBoth("C1", "", "1.0", "beta")
+	close(done)
+
+	if taken := r.take("C1", "1.0", func(h string) bool { return h == "alpha" }); len(taken) != 0 {
+		t.Fatalf("non-matching publisher consumed %d marks; want 0", len(taken))
+	}
+	if _, ok := r.pending("C1", "1.0"); !ok {
+		t.Fatal("beta's mark gone after non-matching take; want left in place")
+	}
+	taken := r.take("C1", "1.0", func(h string) bool { return h == "beta" })
+	if len(taken) != 1 || taken[0].messageTS != "1.0" {
+		t.Fatalf("matching take = %v, want the 1.0 mark", taken)
+	}
+}
+
+// codex r11: an unthreaded (channel-root) reply clears only the
+// publisher's own marks in the conversation, leaving other agents'
+// pending affordances alone. Unattributed (empty-handle) marks still
+// clear for any publisher.
+func TestBusyReactionRegistry_TakeConversationRespectsHandleMatcher(t *testing.T) {
+	r := newBusyReactionRegistry()
+	dA, _ := r.markBoth("C1", "", "1.0", "alpha")
+	close(dA)
+	dB, _ := r.markBoth("C1", "", "2.0", "beta")
+	close(dB)
+	dU, _ := r.markBoth("C1", "", "3.0", "")
+	close(dU)
+
+	taken := r.takeConversation("C1", func(h string) bool { return h == "" || h == "alpha" })
+	got := map[string]bool{}
+	for _, tk := range taken {
+		got[tk.messageTS] = true
+	}
+	if !got["1.0"] || !got["3.0"] || got["2.0"] || len(taken) != 2 {
+		t.Fatalf("takeConversation = %v, want exactly [1.0 3.0]", taken)
+	}
+	if _, ok := r.pending("C1", "2.0"); !ok {
+		t.Fatal("beta's mark gone after alpha's root reply; want left in place")
+	}
+}
+
+// codex r11 wiring: clearBusyReaction resolves the publisher via the
+// alias registry — a session that does not own the mark's handle
+// cannot clear it; the owning session can.
+func TestClearBusyReactionMatchesPublisherSession(t *testing.T) {
+	slackStub, reactions := newReactionRecordingSlackStub(t)
+	withSlackAPIStub(t, slackStub)
+
+	aliasReg := newTestHandleAliasRegistry(t)
+	if err := aliasReg.Set("beta", "gc-beta"); err != nil {
+		t.Fatalf("aliasReg.Set: %v", err)
+	}
+	marks := newBusyReactionRegistry()
+	done, _ := marks.markBoth("C1", "", "1.0", "beta")
+	close(done)
+	cfg := config{slackBotToken: "xoxb-fake", busyReaction: "hourglass", busyMarks: marks}
+
+	clearBusyReaction(cfg, aliasReg, "gc-alpha", "C1", "1.0")
+	reactions.assertNoCall(t, 300*time.Millisecond)
+	if _, ok := marks.pending("C1", "1.0"); !ok {
+		t.Fatal("foreign session's reply consumed beta's mark")
+	}
+
+	clearBusyReaction(cfg, aliasReg, "gc-beta", "C1", "1.0")
+	got := reactions.await(t, 2*time.Second)
+	if got.op != "remove" || got.timestamp != "1.0" {
+		t.Fatalf("owning session's reply: got (%s on %s), want remove on 1.0", got.op, got.timestamp)
 	}
 }

--- a/slack-full/adapter/busy_reaction_test.go
+++ b/slack-full/adapter/busy_reaction_test.go
@@ -1,0 +1,1029 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// Tests for the busy-reaction lifecycle (hq-xizo): a targeted inbound
+// gets the BUSY_REACTION emoji (default "hourglass") added to the
+// inbound Slack message and a pending mark recorded; the agent's
+// reply publishing back into the same conversation/thread removes the
+// reaction and consumes the mark. The lifecycle replaces the previous
+// unconditional "eyes" reaction on targeted inbounds and is the
+// channel-native stand-in for Slack Assistant-mode setStatus.
+
+// recordedReaction is one captured reactions.add / reactions.remove
+// call, decoded from the stub Slack server's request body.
+type recordedReaction struct {
+	op        string // "add" | "remove"
+	channel   string
+	name      string
+	timestamp string
+}
+
+// reactionRecorder collects reaction calls hitting the stub Slack
+// server. Each call is also pushed onto ch so tests can await the
+// async reaction goroutines without polling.
+type reactionRecorder struct {
+	mu    sync.Mutex
+	calls []recordedReaction
+	ch    chan recordedReaction
+}
+
+func (r *reactionRecorder) record(rec recordedReaction) {
+	r.mu.Lock()
+	r.calls = append(r.calls, rec)
+	r.mu.Unlock()
+	select {
+	case r.ch <- rec:
+	default:
+	}
+}
+
+// await blocks until one reaction call arrives or d elapses.
+func (r *reactionRecorder) await(t *testing.T, d time.Duration) recordedReaction {
+	t.Helper()
+	select {
+	case rec := <-r.ch:
+		return rec
+	case <-time.After(d):
+		t.Fatalf("no reaction call reached the Slack stub within %v", d)
+		return recordedReaction{}
+	}
+}
+
+// assertNoCall asserts that no (further) reaction call arrives within d.
+func (r *reactionRecorder) assertNoCall(t *testing.T, d time.Duration) {
+	t.Helper()
+	select {
+	case rec := <-r.ch:
+		t.Fatalf("unexpected reaction call: op=%s chan=%s name=%s ts=%s",
+			rec.op, rec.channel, rec.name, rec.timestamp)
+	case <-time.After(d):
+		// expected: silence
+	}
+}
+
+// newReactionRecordingSlackStub returns an httptest Slack API stub
+// that records reactions.add / reactions.remove calls (answering
+// ok:true), answers chat.postMessage with a fixed ts, and answers
+// every other method with a bare ok:true. Callers pair it with
+// withSlackAPIStub.
+func newReactionRecordingSlackStub(t *testing.T) (*httptest.Server, *reactionRecorder) {
+	t.Helper()
+	rr := &reactionRecorder{ch: make(chan recordedReaction, 16)}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/reactions.add"), strings.HasSuffix(r.URL.Path, "/reactions.remove"):
+			var body slackReactionsAddReq
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			op := "add"
+			if strings.HasSuffix(r.URL.Path, "/reactions.remove") {
+				op = "remove"
+			}
+			rr.record(recordedReaction{op: op, channel: body.Channel, name: body.Name, timestamp: body.Timestamp})
+			_, _ = fmt.Fprint(w, `{"ok":true}`)
+		case strings.HasSuffix(r.URL.Path, "/chat.postMessage"):
+			_, _ = fmt.Fprint(w, `{"ok":true,"ts":"999.000001"}`)
+		default:
+			_, _ = fmt.Fprint(w, `{"ok":true}`)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv, rr
+}
+
+// busyTestConfig builds the minimal cfg for processSlackEvent tests of
+// the busy lifecycle, targeting the supplied gc stub.
+func busyTestConfig(gcURL string) config {
+	return config{
+		gcAPIBase:     gcURL,
+		cityName:      "test-city",
+		provider:      "slack",
+		accountID:     "T1",
+		handlePrefix:  "@",
+		slackBotToken: "xoxb-fake",
+		dispatchSem:   defaultTestDispatchSem,
+		busyReaction:  busyReactionDefault,
+		busyMarks:     newBusyReactionRegistry(),
+	}
+}
+
+// targetedInboundEnvelope builds an event_callback envelope for a
+// channel message explicitly addressing @mayor.
+func targetedInboundEnvelope(t *testing.T, channel, ts, threadTS string) slackEventEnvelope {
+	t.Helper()
+	rawMsg, err := json.Marshal(slackMessageEvent{
+		Type:     "message",
+		Channel:  channel,
+		User:     "U_ALICE",
+		TS:       ts,
+		ThreadTS: threadTS,
+		Text:     "@mayor please deploy the thing",
+	})
+	if err != nil {
+		t.Fatalf("marshal event: %v", err)
+	}
+	return slackEventEnvelope{Type: "event_callback", Event: rawMsg}
+}
+
+// publishBody builds a /publish request body targeting conversation
+// with an optional thread ts.
+func publishBody(conversationID, replyTo string) string {
+	b, _ := json.Marshal(publishRequest{
+		SessionID:        "gc-1",
+		Conversation:     conversationRef{ConversationID: conversationID},
+		Text:             "done — deployed",
+		ReplyToMessageID: replyTo,
+	})
+	return string(b)
+}
+
+// (a) A targeted inbound adds exactly one busy reaction — the
+// configured default "hourglass", NOT the legacy "eyes" — on the
+// inbound ts, and records the pending mark under (channel, own-ts)
+// for a channel-root message.
+func TestBusyReaction_TargetedInboundAddsBusyAndRecordsMark(t *testing.T) {
+	slackStub, reactions := newReactionRecordingSlackStub(t)
+	withSlackAPIStub(t, slackStub)
+	capture := &inboundCapture{}
+	gcStub := httptest.NewServer(capture.handler())
+	t.Cleanup(gcStub.Close)
+
+	cfg := busyTestConfig(gcStub.URL)
+	env := targetedInboundEnvelope(t, "C1", "100.000010", "")
+	processSlackEvent(cfg, newTestHandleAliasRegistry(t), nil, nil, nil, nil, env, func() {})
+
+	got := reactions.await(t, 2*time.Second)
+	if got.op != "add" {
+		t.Errorf("reaction op = %q, want %q", got.op, "add")
+	}
+	if got.name != "hourglass" {
+		t.Errorf("reaction name = %q, want %q (busy emoji replaces the legacy eyes)", got.name, "hourglass")
+	}
+	if got.channel != "C1" || got.timestamp != "100.000010" {
+		t.Errorf("reaction target = (%s, %s), want (C1, 100.000010)", got.channel, got.timestamp)
+	}
+	// Exactly one reaction call: no second add, and in particular no
+	// legacy "eyes".
+	reactions.assertNoCall(t, 300*time.Millisecond)
+
+	if ts, ok := cfg.busyMarks.pending("C1", "100.000010"); !ok || ts != "100.000010" {
+		t.Errorf("busy mark = (%q, %v), want (100.000010, true)", ts, ok)
+	}
+	if msgs := capture.snapshot(); len(msgs) != 1 {
+		t.Fatalf("captured %d inbound messages, want 1", len(msgs))
+	}
+}
+
+// A targeted inbound that is itself a thread reply records its mark
+// under BOTH the thread's root ts (thread_ts) and its own ts — reply
+// paths thread under either (codex r2) — still reacting on the
+// inbound message's own ts.
+func TestBusyReaction_ThreadReplyInboundKeyedByThreadTS(t *testing.T) {
+	slackStub, reactions := newReactionRecordingSlackStub(t)
+	withSlackAPIStub(t, slackStub)
+	capture := &inboundCapture{}
+	gcStub := httptest.NewServer(capture.handler())
+	t.Cleanup(gcStub.Close)
+
+	cfg := busyTestConfig(gcStub.URL)
+	env := targetedInboundEnvelope(t, "C1", "100.000020", "100.000001")
+	processSlackEvent(cfg, newTestHandleAliasRegistry(t), nil, nil, nil, nil, env, func() {})
+
+	got := reactions.await(t, 2*time.Second)
+	if got.op != "add" || got.timestamp != "100.000020" {
+		t.Errorf("reaction = (%s on %s), want add on 100.000020", got.op, got.timestamp)
+	}
+	if ts, ok := cfg.busyMarks.pending("C1", "100.000001"); !ok || ts != "100.000020" {
+		t.Errorf("busy mark under thread-root key = (%q, %v), want (100.000020, true)", ts, ok)
+	}
+	if ts, ok := cfg.busyMarks.pending("C1", "100.000020"); !ok || ts != "100.000020" {
+		t.Errorf("busy mark under own-ts key = (%q, %v), want (100.000020, true)", ts, ok)
+	}
+}
+
+// (b) A subsequent /publish into the same conversation+thread removes
+// the busy emoji from the recorded message ts and consumes the
+// registry entry. Covers both inbound shapes: a channel-root inbound
+// (marked under its own ts) and a thread-reply inbound (marked under
+// its thread_ts, reaction on its own ts).
+func TestBusyReaction_PublishToSameThreadRemovesBusy(t *testing.T) {
+	cases := []struct {
+		name         string
+		seedThreadTS string // inbound's thread_ts ("" = channel-root inbound)
+		seedTS       string // inbound's own ts
+		replyTo      string // publish reply_to_message_id
+		markedTS     string // ts the reaction sits on
+	}{
+		{name: "root inbound, reply threads under its ts",
+			seedThreadTS: "", seedTS: "100.000010", replyTo: "100.000010", markedTS: "100.000010"},
+		{name: "thread-reply inbound, reply threads under the root",
+			seedThreadTS: "100.000001", seedTS: "100.000020", replyTo: "100.000001", markedTS: "100.000020"},
+		{name: "thread-reply inbound, reply threads under the inbound's own ts (codex r2)",
+			seedThreadTS: "100.000001", seedTS: "100.000020", replyTo: "100.000020", markedTS: "100.000020"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			slackStub, reactions := newReactionRecordingSlackStub(t)
+			withSlackAPIStub(t, slackStub)
+
+			marks := newBusyReactionRegistry()
+			// Close addDone: the add already completed in this scenario.
+			done, _ := marks.markBoth("C1", tc.seedThreadTS, tc.seedTS)
+			close(done)
+			cfg := config{slackBotToken: "xoxb-fake", busyReaction: "hourglass", busyMarks: marks}
+
+			req := httptest.NewRequest(http.MethodPost, "/publish", strings.NewReader(publishBody("C1", tc.replyTo)))
+			rec := httptest.NewRecorder()
+			handlePublish(cfg, nil, nil, newPublishDedupCache(publishDedupTTL))(rec, req)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("publish status = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+			}
+			var receipt publishReceipt
+			if err := json.Unmarshal(rec.Body.Bytes(), &receipt); err != nil || !receipt.Delivered {
+				t.Fatalf("publish receipt delivered = %v (err=%v, body=%s)", receipt.Delivered, err, rec.Body.String())
+			}
+
+			got := reactions.await(t, 2*time.Second)
+			if got.op != "remove" {
+				t.Errorf("reaction op = %q, want %q", got.op, "remove")
+			}
+			if got.name != "hourglass" {
+				t.Errorf("reaction name = %q, want %q", got.name, "hourglass")
+			}
+			if got.channel != "C1" || got.timestamp != tc.markedTS {
+				t.Errorf("remove target = (%s, %s), want (C1, %s)", got.channel, got.timestamp, tc.markedTS)
+			}
+			if _, ok := marks.pending("C1", tc.replyTo); ok {
+				t.Error("registry entry survived the publish; want consumed")
+			}
+		})
+	}
+}
+
+// (c) A /publish that matches no pending mark — unrelated
+// conversation (threaded or root), or unrelated thread in the same
+// conversation — fires no reactions.remove and leaves existing marks
+// untouched.
+func TestBusyReaction_UnrelatedPublishDoesNotRemove(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		conversation string
+		replyTo      string
+	}{
+		{name: "different conversation, threaded", conversation: "C_OTHER", replyTo: "100.000010"},
+		{name: "different conversation, channel root", conversation: "C_OTHER", replyTo: ""},
+		{name: "different thread", conversation: "C1", replyTo: "555.000001"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			slackStub, reactions := newReactionRecordingSlackStub(t)
+			withSlackAPIStub(t, slackStub)
+
+			marks := newBusyReactionRegistry()
+			marks.mark("C1", "100.000010", "100.000010")
+			cfg := config{slackBotToken: "xoxb-fake", busyReaction: "hourglass", busyMarks: marks}
+
+			req := httptest.NewRequest(http.MethodPost, "/publish", strings.NewReader(publishBody(tc.conversation, tc.replyTo)))
+			rec := httptest.NewRecorder()
+			handlePublish(cfg, nil, nil, newPublishDedupCache(publishDedupTTL))(rec, req)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("publish status = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+			}
+
+			reactions.assertNoCall(t, 300*time.Millisecond)
+			if _, ok := marks.pending("C1", "100.000010"); !ok {
+				t.Error("unrelated publish consumed the pending mark; want untouched")
+			}
+		})
+	}
+}
+
+// A channel-root publish into the SAME conversation — the documented
+// default `gc slack reply-current` shape, which carries no
+// reply_to_message_id — clears every pending mark in that
+// conversation (codex r3): a busy emoji nothing will ever remove is
+// worse than clearing a sibling thread's affordance early.
+func TestBusyReaction_RootPublishClearsConversationMarks(t *testing.T) {
+	slackStub, reactions := newReactionRecordingSlackStub(t)
+	withSlackAPIStub(t, slackStub)
+
+	marks := newBusyReactionRegistry()
+	doneA, _ := marks.markBoth("C1", "", "100.000010")
+	close(doneA)
+	doneB, _ := marks.markBoth("C1", "200.000001", "200.000020")
+	close(doneB)
+	cfg := config{slackBotToken: "xoxb-fake", busyReaction: "hourglass", busyMarks: marks}
+
+	req := httptest.NewRequest(http.MethodPost, "/publish", strings.NewReader(publishBody("C1", "")))
+	rec := httptest.NewRecorder()
+	handlePublish(cfg, nil, nil, newPublishDedupCache(publishDedupTTL))(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("publish status = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+
+	// Two distinct marked messages → two removes (dual-key entries for
+	// the thread-reply inbound dedupe to one).
+	got := map[string]bool{}
+	for i := 0; i < 2; i++ {
+		rec := reactions.await(t, 2*time.Second)
+		if rec.op != "remove" {
+			t.Errorf("reaction op = %q, want remove", rec.op)
+		}
+		got[rec.timestamp] = true
+	}
+	if !got["100.000010"] || !got["200.000020"] {
+		t.Errorf("removed set = %v, want both 100.000010 and 200.000020", got)
+	}
+	reactions.assertNoCall(t, 300*time.Millisecond)
+	if n := marks.size(); n != 0 {
+		t.Errorf("registry has %d entries after root-publish clear, want 0", n)
+	}
+}
+
+// Re-targeting the same thread before the first reply lands moves the
+// busy affordance: the displaced mark's reaction is removed (codex
+// r3) — TTL expiry only deletes metadata, never the Slack-side emoji.
+func TestBusyReaction_RetargetRemovesSupersededReaction(t *testing.T) {
+	slackStub, reactions := newReactionRecordingSlackStub(t)
+	withSlackAPIStub(t, slackStub)
+	capture := &inboundCapture{}
+	gcStub := httptest.NewServer(capture.handler())
+	t.Cleanup(gcStub.Close)
+
+	cfg := busyTestConfig(gcStub.URL)
+	// First targeted inbound: channel-root message M1.
+	env1 := targetedInboundEnvelope(t, "C1", "100.000010", "")
+	processSlackEvent(cfg, newTestHandleAliasRegistry(t), nil, nil, nil, nil, env1, func() {})
+	first := reactions.await(t, 2*time.Second)
+	if first.op != "add" || first.timestamp != "100.000010" {
+		t.Fatalf("first reaction = (%s on %s), want add on 100.000010", first.op, first.timestamp)
+	}
+
+	// Second targeted inbound M2 replying in M1's thread: displaces
+	// M1's mark (root key now points at M2).
+	env2 := targetedInboundEnvelope(t, "C1", "100.000020", "100.000010")
+	processSlackEvent(cfg, newTestHandleAliasRegistry(t), nil, nil, nil, nil, env2, func() {})
+
+	// Expect an add on M2 and a remove on the superseded M1, in any
+	// order (both async).
+	ops := map[string]string{}
+	for i := 0; i < 2; i++ {
+		rec := reactions.await(t, 2*time.Second)
+		ops[rec.op] = rec.timestamp
+	}
+	if ops["add"] != "100.000020" {
+		t.Errorf("add landed on %q, want 100.000020", ops["add"])
+	}
+	if ops["remove"] != "100.000010" {
+		t.Errorf("remove landed on %q, want superseded 100.000010", ops["remove"])
+	}
+}
+
+// (d) BUSY_REACTION= (set-but-empty) disables the lifecycle: the
+// config loads as empty, a targeted inbound adds NO reaction (the
+// legacy eyes included — the lifecycle replaced it) and records no
+// mark, while the inbound still forwards to gc.
+func TestBusyReaction_EmptyEnvDisablesLifecycle(t *testing.T) {
+	// Config level: present-but-empty must NOT fall back to the
+	// default. Requires the lookup entry point — a plain getenv cannot
+	// express "set but empty".
+	env := baseSlackEnv()
+	env["BUSY_REACTION"] = ""
+	cfg0, err := loadConfigFromLookup(func(key string) (string, bool) {
+		v, ok := env[key]
+		return v, ok
+	})
+	if err != nil {
+		t.Fatalf("loadConfigFromLookup: %v", err)
+	}
+	if cfg0.busyReaction != "" {
+		t.Fatalf("busyReaction = %q with BUSY_REACTION= set-but-empty, want disabled (empty)", cfg0.busyReaction)
+	}
+
+	// Behavior level: no reaction of any kind, no mark, inbound still
+	// forwarded.
+	slackStub, reactions := newReactionRecordingSlackStub(t)
+	withSlackAPIStub(t, slackStub)
+	capture := &inboundCapture{}
+	gcStub := httptest.NewServer(capture.handler())
+	t.Cleanup(gcStub.Close)
+
+	cfg := busyTestConfig(gcStub.URL)
+	cfg.busyReaction = ""
+	env2 := targetedInboundEnvelope(t, "C1", "100.000010", "")
+	processSlackEvent(cfg, newTestHandleAliasRegistry(t), nil, nil, nil, nil, env2, func() {})
+
+	reactions.assertNoCall(t, 400*time.Millisecond)
+	if n := cfg.busyMarks.size(); n != 0 {
+		t.Errorf("registry has %d entries with the lifecycle disabled, want 0", n)
+	}
+	if msgs := capture.snapshot(); len(msgs) != 1 {
+		t.Fatalf("captured %d inbound messages, want 1 (disable must not drop the forward)", len(msgs))
+	}
+}
+
+// BUSY_REACTION config defaults and overrides through the standard
+// env entry points.
+func TestBusyReaction_ConfigDefaultsAndOverrides(t *testing.T) {
+	cases := []struct {
+		name  string
+		set   bool
+		value string
+		want  string
+	}{
+		{name: "unset defaults to hourglass", set: false, want: "hourglass"},
+		{name: "custom emoji honored", set: true, value: "hourglass_flowing_sand", want: "hourglass_flowing_sand"},
+		{name: "surrounding colons stripped", set: true, value: ":hourglass_flowing_sand:", want: "hourglass_flowing_sand"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			env := baseSlackEnv()
+			if tc.set {
+				env["BUSY_REACTION"] = tc.value
+			}
+			cfg, err := loadConfigFromEnv(stubEnv(env))
+			if err != nil {
+				t.Fatalf("loadConfigFromEnv: %v", err)
+			}
+			if cfg.busyReaction != tc.want {
+				t.Errorf("busyReaction = %q, want %q", cfg.busyReaction, tc.want)
+			}
+		})
+	}
+}
+
+// (e) A custom BUSY_REACTION emoji is used on both sides of the
+// lifecycle: the add on dispatch and the remove on reply.
+func TestBusyReaction_CustomEmojiHonored(t *testing.T) {
+	slackStub, reactions := newReactionRecordingSlackStub(t)
+	withSlackAPIStub(t, slackStub)
+	capture := &inboundCapture{}
+	gcStub := httptest.NewServer(capture.handler())
+	t.Cleanup(gcStub.Close)
+
+	cfg := busyTestConfig(gcStub.URL)
+	cfg.busyReaction = "hourglass_flowing_sand"
+	env := targetedInboundEnvelope(t, "C1", "100.000010", "")
+	processSlackEvent(cfg, newTestHandleAliasRegistry(t), nil, nil, nil, nil, env, func() {})
+
+	added := reactions.await(t, 2*time.Second)
+	if added.op != "add" || added.name != "hourglass_flowing_sand" {
+		t.Errorf("add = (%s, %s), want (add, hourglass_flowing_sand)", added.op, added.name)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/publish", strings.NewReader(publishBody("C1", "100.000010")))
+	rec := httptest.NewRecorder()
+	handlePublish(cfg, nil, nil, newPublishDedupCache(publishDedupTTL))(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("publish status = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+	removed := reactions.await(t, 2*time.Second)
+	if removed.op != "remove" || removed.name != "hourglass_flowing_sand" || removed.timestamp != "100.000010" {
+		t.Errorf("remove = (%s, %s on %s), want (remove, hourglass_flowing_sand on 100.000010)",
+			removed.op, removed.name, removed.timestamp)
+	}
+}
+
+// (f) A reply that lands while the reactions.add is still in flight
+// must not have its reactions.remove overtake the add — Slack would
+// apply the delayed add last and the busy emoji would stick forever.
+// The remove side waits on the mark's addDone channel (hw-94w5k
+// codex r1).
+func TestBusyReaction_FastReplyWaitsForAddBeforeRemove(t *testing.T) {
+	rr := &reactionRecorder{ch: make(chan recordedReaction, 16)}
+	slackStub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/reactions.add"):
+			// Simulate a slow Slack: the add is still in flight when
+			// the reply's publish arrives.
+			time.Sleep(400 * time.Millisecond)
+			var body slackReactionsAddReq
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			rr.record(recordedReaction{op: "add", channel: body.Channel, name: body.Name, timestamp: body.Timestamp})
+			_, _ = fmt.Fprint(w, `{"ok":true}`)
+		case strings.HasSuffix(r.URL.Path, "/reactions.remove"):
+			var body slackReactionsAddReq
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			rr.record(recordedReaction{op: "remove", channel: body.Channel, name: body.Name, timestamp: body.Timestamp})
+			_, _ = fmt.Fprint(w, `{"ok":true}`)
+		case strings.HasSuffix(r.URL.Path, "/chat.postMessage"):
+			_, _ = fmt.Fprint(w, `{"ok":true,"ts":"999.000001"}`)
+		default:
+			_, _ = fmt.Fprint(w, `{"ok":true}`)
+		}
+	}))
+	t.Cleanup(slackStub.Close)
+	withSlackAPIStub(t, slackStub)
+	capture := &inboundCapture{}
+	gcStub := httptest.NewServer(capture.handler())
+	t.Cleanup(gcStub.Close)
+
+	cfg := busyTestConfig(gcStub.URL)
+	env := targetedInboundEnvelope(t, "C1", "100.000010", "")
+	processSlackEvent(cfg, newTestHandleAliasRegistry(t), nil, nil, nil, nil, env, func() {})
+
+	// Reply immediately — well before the 400ms add completes.
+	req := httptest.NewRequest(http.MethodPost, "/publish", strings.NewReader(publishBody("C1", "100.000010")))
+	rec := httptest.NewRecorder()
+	handlePublish(cfg, nil, nil, newPublishDedupCache(publishDedupTTL))(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("publish status = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+
+	first := rr.await(t, 2*time.Second)
+	second := rr.await(t, 2*time.Second)
+	if first.op != "add" || second.op != "remove" {
+		t.Errorf("reaction order = (%s, %s), want (add, remove) — remove must not overtake the in-flight add",
+			first.op, second.op)
+	}
+}
+
+// A threaded /publish-file reply — possibly the agent's entire answer
+// — clears the pending busy mark exactly like a text publish
+// (hw-94w5k codex r1).
+func TestBusyReaction_PublishFileToSameThreadRemovesBusy(t *testing.T) {
+	rr := &reactionRecorder{ch: make(chan recordedReaction, 16)}
+	uploadStub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(uploadStub.Close)
+	slackStub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/files.getUploadURLExternal"):
+			_, _ = fmt.Fprintf(w, `{"ok":true,"upload_url":%q,"file_id":"F1"}`, uploadStub.URL+"/upload")
+		case strings.HasSuffix(r.URL.Path, "/files.completeUploadExternal"):
+			_, _ = fmt.Fprint(w, `{"ok":true,"files":[{"id":"F1"}]}`)
+		case strings.HasSuffix(r.URL.Path, "/reactions.remove"):
+			var body slackReactionsAddReq
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			rr.record(recordedReaction{op: "remove", channel: body.Channel, name: body.Name, timestamp: body.Timestamp})
+			_, _ = fmt.Fprint(w, `{"ok":true}`)
+		default:
+			_, _ = fmt.Fprint(w, `{"ok":true}`)
+		}
+	}))
+	t.Cleanup(slackStub.Close)
+	withSlackAPIStub(t, slackStub)
+
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatalf("EvalSymlinks: %v", err)
+	}
+	filePath := filepath.Join(root, "answer.png")
+	if err := os.WriteFile(filePath, []byte("PNGDATA"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	marks := newBusyReactionRegistry()
+	close(marks.mark("C1", "100.000010", "100.000010"))
+	cfg := config{
+		slackBotToken:  "xoxb-fake",
+		busyReaction:   "hourglass",
+		busyMarks:      marks,
+		fileUploadRoot: root,
+	}
+
+	body := fmt.Sprintf(`{"conversation":{"conversation_id":"C1"},"file_path":%q,"reply_to_message_id":"100.000010"}`, filePath)
+	req := httptest.NewRequest(http.MethodPost, "/publish-file", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	handlePublishFile(cfg, nil)(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("publish-file status = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+	var receipt publishFileReceipt
+	if err := json.Unmarshal(rec.Body.Bytes(), &receipt); err != nil || !receipt.Delivered {
+		t.Fatalf("publish-file receipt delivered = %v (err=%v, body=%s)", receipt.Delivered, err, rec.Body.String())
+	}
+
+	got := rr.await(t, 2*time.Second)
+	if got.op != "remove" || got.name != "hourglass" || got.channel != "C1" || got.timestamp != "100.000010" {
+		t.Errorf("reaction = (%s, %s on %s/%s), want (remove, hourglass on C1/100.000010)",
+			got.op, got.name, got.channel, got.timestamp)
+	}
+	if _, ok := marks.pending("C1", "100.000010"); ok {
+		t.Error("registry entry survived the file publish; want consumed")
+	}
+}
+
+// (h) The mark registers BEFORE the forward to gc (codex r4): a reply
+// published while postInbound is still in flight must find the mark,
+// and the eventual add must still be removed (ordered after the add).
+func TestBusyReaction_ReplyDuringForwardFindsMark(t *testing.T) {
+	rr := &reactionRecorder{ch: make(chan recordedReaction, 16)}
+	slackStub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/reactions.add"):
+			var body slackReactionsAddReq
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			rr.record(recordedReaction{op: "add", channel: body.Channel, name: body.Name, timestamp: body.Timestamp})
+			_, _ = fmt.Fprint(w, `{"ok":true}`)
+		case strings.HasSuffix(r.URL.Path, "/reactions.remove"):
+			var body slackReactionsAddReq
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			rr.record(recordedReaction{op: "remove", channel: body.Channel, name: body.Name, timestamp: body.Timestamp})
+			_, _ = fmt.Fprint(w, `{"ok":true}`)
+		case strings.HasSuffix(r.URL.Path, "/chat.postMessage"):
+			_, _ = fmt.Fprint(w, `{"ok":true,"ts":"999.000001"}`)
+		default:
+			_, _ = fmt.Fprint(w, `{"ok":true}`)
+		}
+	}))
+	t.Cleanup(slackStub.Close)
+	withSlackAPIStub(t, slackStub)
+
+	// gc stub: the inbound forward stalls long enough for the agent's
+	// reply to arrive first.
+	forwardStarted := make(chan struct{}, 1)
+	gcStub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case forwardStarted <- struct{}{}:
+		default:
+		}
+		time.Sleep(300 * time.Millisecond)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	t.Cleanup(gcStub.Close)
+
+	cfg := busyTestConfig(gcStub.URL)
+	env := targetedInboundEnvelope(t, "C1", "100.000010", "")
+	procDone := make(chan struct{})
+	go func() {
+		defer close(procDone)
+		processSlackEvent(cfg, newTestHandleAliasRegistry(t), nil, nil, nil, nil, env, func() {})
+	}()
+	<-forwardStarted
+
+	// Reply while the forward is still in flight: the mark must exist.
+	req := httptest.NewRequest(http.MethodPost, "/publish", strings.NewReader(publishBody("C1", "100.000010")))
+	rec := httptest.NewRecorder()
+	handlePublish(cfg, nil, nil, newPublishDedupCache(publishDedupTTL))(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("publish status = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+
+	first := rr.await(t, 3*time.Second)
+	second := rr.await(t, 3*time.Second)
+	if first.op != "add" || second.op != "remove" || second.timestamp != "100.000010" {
+		t.Errorf("reaction sequence = (%s, %s on %s), want (add, remove on 100.000010)",
+			first.op, second.op, second.timestamp)
+	}
+	<-procDone
+}
+
+// A failed forward cancels the pre-registered mark: no reply is
+// coming, and the redelivery re-marks on take-over.
+func TestBusyReaction_FailedForwardCancelsMark(t *testing.T) {
+	slackStub, reactions := newReactionRecordingSlackStub(t)
+	withSlackAPIStub(t, slackStub)
+	gcStub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(gcStub.Close)
+
+	cfg := busyTestConfig(gcStub.URL)
+	env := targetedInboundEnvelope(t, "C1", "100.000010", "")
+	processSlackEvent(cfg, newTestHandleAliasRegistry(t), nil, nil, nil, nil, env, func() {})
+
+	if n := cfg.busyMarks.size(); n != 0 {
+		t.Errorf("registry has %d entries after failed forward, want 0 (mark cancelled)", n)
+	}
+	// No reactions.add either — the forward never succeeded.
+	reactions.assertNoCall(t, 300*time.Millisecond)
+}
+
+// A re-target whose forward FAILS must not strip the previous
+// message's busy affordance: no remove fires, and the displaced mark
+// is restored so the earlier agent's eventual reply can still clear
+// it (codex r5).
+func TestBusyReaction_FailedRetargetRestoresDisplacedMark(t *testing.T) {
+	slackStub, reactions := newReactionRecordingSlackStub(t)
+	withSlackAPIStub(t, slackStub)
+	gcStub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(gcStub.Close)
+
+	cfg := busyTestConfig(gcStub.URL)
+	// Pre-existing mark: root message M1, its add already completed.
+	doneM1, _ := cfg.busyMarks.markBoth("C1", "", "100.000010")
+	close(doneM1)
+
+	// Targeted thread reply M2 in M1's thread; its forward fails.
+	env := targetedInboundEnvelope(t, "C1", "100.000020", "100.000010")
+	processSlackEvent(cfg, newTestHandleAliasRegistry(t), nil, nil, nil, nil, env, func() {})
+
+	// No reactions at all: M2's add never fired (forward failed) and
+	// M1's emoji must NOT have been removed.
+	reactions.assertNoCall(t, 300*time.Millisecond)
+	if ts, ok := cfg.busyMarks.pending("C1", "100.000010"); !ok || ts != "100.000010" {
+		t.Errorf("displaced mark = (%q, %v), want restored (100.000010, true)", ts, ok)
+	}
+	if _, ok := cfg.busyMarks.pending("C1", "100.000020"); ok {
+		t.Error("failed re-target's own-ts mark survived; want cancelled")
+	}
+}
+
+// Overlapping re-targets with a failure in the middle must not orphan
+// the oldest reaction (codex r6): M2 displaced M1, M3 displaced M2,
+// M2's forward fails while M3 owns the key — M1 must merge into M3's
+// stale ancestry so the thread's eventual clear removes it.
+func TestBusyReactionRegistry_FailedMiddleRetargetPreservesAncestors(t *testing.T) {
+	r := newBusyReactionRegistry()
+	const m1, m2, m3 = "1.0", "2.0", "3.0"
+
+	d1, disp := r.markBoth("C1", "", m1)
+	close(d1)
+	if len(disp) != 0 {
+		t.Fatalf("M1 displaced %v, want none", disp)
+	}
+	d2, disp2 := r.markBoth("C1", m1, m2) // M2 re-targets M1's thread
+	d3, disp3 := r.markBoth("C1", m1, m3) // M3 re-targets again
+	close(d3)
+	if len(disp2) == 0 || disp2[0].mark.messageTS != m1 {
+		t.Fatalf("M2 displaced %v, want M1", disp2)
+	}
+	if len(disp3) == 0 || disp3[0].mark.messageTS != m2 {
+		t.Fatalf("M3 displaced %v, want M2", disp3)
+	}
+
+	// M2's forward fails while M3 owns the key: restore must not
+	// clobber M3, and M1 must survive as M3's stale ancestor.
+	r.cancelBoth("C1", m1, m2, d2, disp2)
+	if ts, ok := r.pending("C1", m1); !ok || ts != m3 {
+		t.Fatalf("key owner after failed M2 = (%q, %v), want M3", ts, ok)
+	}
+
+	taken := r.take("C1", m1)
+	got := map[string]bool{}
+	for _, tk := range taken {
+		got[tk.messageTS] = true
+	}
+	if !got[m3] || !got[m1] {
+		t.Errorf("take returned %v, want M3's mark plus preserved ancestor M1", got)
+	}
+	if got[m2] {
+		t.Errorf("take returned failed M2 (%v); its reaction never landed and it was displaced into M3's superseded set", got)
+	}
+}
+
+// takeMessage consumes exactly the named message's reaction and
+// re-parks any stale ancestors riding on the entry (codex r6 alias-
+// failure cleanup).
+func TestBusyReactionRegistry_TakeMessageReparksAncestors(t *testing.T) {
+	r := newBusyReactionRegistry()
+	const m1, m2, m3 = "1.0", "2.0", "3.0"
+	d1, _ := r.markBoth("C1", "", m1)
+	close(d1)
+	d2, disp2 := r.markBoth("C1", m1, m2)
+	d3, disp3 := r.markBoth("C1", m1, m3)
+	close(d3)
+	r.cancelBoth("C1", m1, m2, d2, disp2) // M1 → M3's stale
+	_ = disp3
+
+	taken := r.takeMessage("C1", m1, m3)
+	if len(taken) != 1 || taken[0].messageTS != m3 {
+		t.Fatalf("takeMessage = %v, want exactly M3", taken)
+	}
+	// M1 must have been re-parked under the key, still clearable.
+	remaining := r.take("C1", m1)
+	got := map[string]bool{}
+	for _, tk := range remaining {
+		got[tk.messageTS] = true
+	}
+	if !got[m1] {
+		t.Errorf("re-parked set = %v, want ancestor M1 preserved", got)
+	}
+}
+
+// Consuming either alias of a dual-key mark consumes BOTH entries and
+// tombstones both keys (codex r10): a reply threading under the
+// inbound's own ts is the clearing event for the root-key sibling too.
+func TestBusyReactionRegistry_TakeConsumesBothDualKeys(t *testing.T) {
+	r := newBusyReactionRegistry()
+	d, _ := r.markBoth("C1", "1.0", "2.0") // root key 1.0 + own-ts key 2.0
+	close(d)
+
+	taken := r.take("C1", "2.0") // reply threads under the inbound's own ts
+	if len(taken) != 1 || taken[0].messageTS != "2.0" {
+		t.Fatalf("take = %v, want exactly the 2.0 mark once", taken)
+	}
+	if _, ok := r.pending("C1", "1.0"); ok {
+		t.Error("root-key sibling survived the own-ts take; want consumed")
+	}
+	// Both keys are tombstoned: a restore under the root key blocks.
+	dOld := make(chan struct{})
+	close(dOld)
+	blocked := r.restoreDisplaced("C1", []busyDisplaced{{threadKey: "1.0", mark: busyTaken{messageTS: "0.5", addDone: dOld}}})
+	if len(blocked) != 1 || blocked[0].messageTS != "0.5" {
+		t.Errorf("restore under consumed root key = blocked %v, want the 0.5 mark handed back", blocked)
+	}
+}
+
+// A reply that consumed the thread while a displacing dispatch was in
+// flight tombstones the key: a failed dispatch must NOT restore the
+// displaced mark afterwards — the thread's clearing event already
+// happened — and the blocked mark is returned for reaction removal
+// (codex r8). A fresh mark on the key re-arms it.
+func TestBusyReactionRegistry_TombstoneBlocksRestoreAfterConsume(t *testing.T) {
+	r := newBusyReactionRegistry()
+	const m1, m2 = "1.0", "2.0"
+
+	d1, _ := r.markBoth("C1", "", m1)
+	close(d1)
+	d2, disp2 := r.markBoth("C1", m1, m2) // M2 displaces M1
+	if len(disp2) == 0 || disp2[0].mark.messageTS != m1 {
+		t.Fatalf("displaced = %v, want M1", disp2)
+	}
+	// A reply lands while M2's dispatch is in flight and consumes the
+	// thread (root key + own-ts key).
+	if taken := r.take("C1", m1); len(taken) == 0 {
+		t.Fatal("reply take found no mark")
+	}
+	// M2's dispatch fails: restore must be blocked by the tombstone and
+	// M1 handed back for removal.
+	blocked := r.cancelBoth("C1", m1, m2, d2, disp2)
+	got := map[string]bool{}
+	for _, tk := range blocked {
+		got[tk.messageTS] = true
+	}
+	if !got[m1] {
+		t.Errorf("blocked = %v, want M1 handed back for removal", got)
+	}
+	if _, ok := r.pending("C1", m1); ok {
+		t.Error("mark restored under a tombstoned key; want blocked")
+	}
+
+	// A fresh targeted inbound re-arms the key despite the tombstone.
+	d3, _ := r.markBoth("C1", "", m1)
+	close(d3)
+	if _, ok := r.pending("C1", m1); !ok {
+		t.Error("fresh mark did not re-arm the tombstoned key")
+	}
+}
+
+// A re-mark of the SAME message (retaken redelivery) merges add
+// completions: the stored done closes only when every add attempt has
+// concluded (codex r4).
+func TestBusyReactionRegistry_SameMessageRemarkMergesAddDone(t *testing.T) {
+	r := newBusyReactionRegistry()
+	d1, _ := r.markBoth("C1", "", "1.0")
+	d2, _ := r.markBoth("C1", "", "1.0")
+
+	taken := r.take("C1", "1.0")
+	if len(taken) != 1 || taken[0].addDone == nil {
+		t.Fatalf("take = %v, want one entry with a merged done channel", taken)
+	}
+	done := taken[0].addDone
+	assertOpen := func(label string) {
+		t.Helper()
+		select {
+		case <-done:
+			t.Fatalf("merged done closed %s", label)
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+	assertOpen("before either add concluded")
+	close(d1)
+	assertOpen("with the second add still in flight")
+	close(d2)
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("merged done not closed after both adds concluded")
+	}
+}
+
+// (g) A mark past busyReactionTTL is dead: the publish consumes the
+// stale entry but fires no reactions.remove.
+func TestBusyReaction_ExpiredMarkDoesNotRemove(t *testing.T) {
+	slackStub, reactions := newReactionRecordingSlackStub(t)
+	withSlackAPIStub(t, slackStub)
+
+	var mu sync.Mutex
+	current := time.Now()
+	marks := newBusyReactionRegistry()
+	marks.now = func() time.Time {
+		mu.Lock()
+		defer mu.Unlock()
+		return current
+	}
+	marks.mark("C1", "100.000010", "100.000010")
+	mu.Lock()
+	current = current.Add(busyReactionTTL + time.Minute)
+	mu.Unlock()
+
+	cfg := config{slackBotToken: "xoxb-fake", busyReaction: "hourglass", busyMarks: marks}
+	req := httptest.NewRequest(http.MethodPost, "/publish", strings.NewReader(publishBody("C1", "100.000010")))
+	rec := httptest.NewRecorder()
+	handlePublish(cfg, nil, nil, newPublishDedupCache(publishDedupTTL))(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("publish status = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+	var receipt publishReceipt
+	if err := json.Unmarshal(rec.Body.Bytes(), &receipt); err != nil || !receipt.Delivered {
+		t.Fatalf("publish receipt delivered = %v (err=%v)", receipt.Delivered, err)
+	}
+
+	reactions.assertNoCall(t, 300*time.Millisecond)
+	if n := marks.size(); n != 0 {
+		t.Errorf("registry has %d entries after expired-take, want 0 (stale entry dropped)", n)
+	}
+}
+
+// Registry semantics: take consumes, re-take misses, expired entries
+// are swept opportunistically on mark.
+func TestBusyReactionRegistry_TakeAndSweep(t *testing.T) {
+	var mu sync.Mutex
+	current := time.Now()
+	r := newBusyReactionRegistry()
+	r.now = func() time.Time {
+		mu.Lock()
+		defer mu.Unlock()
+		return current
+	}
+
+	r.mark("C1", "1.0", "1.0")
+	if taken := r.take("C1", "1.0"); len(taken) != 1 || taken[0].messageTS != "1.0" {
+		t.Fatalf("take = %v, want one entry for 1.0", taken)
+	}
+	if taken := r.take("C1", "1.0"); len(taken) != 0 {
+		t.Fatal("second take succeeded; want consumed on first take")
+	}
+
+	// Opportunistic sweep: an expired entry disappears on the next mark.
+	r.mark("C1", "2.0", "2.0")
+	mu.Lock()
+	current = current.Add(busyReactionTTL + time.Minute)
+	mu.Unlock()
+	r.mark("C1", "3.0", "3.0")
+	if n := r.size(); n != 1 {
+		t.Errorf("size after sweep = %d, want 1 (expired 2.0 swept, fresh 3.0 kept)", n)
+	}
+	if _, ok := r.pending("C1", "2.0"); ok {
+		t.Error("expired entry 2.0 survived the sweep")
+	}
+}
+
+// Registry semantics: the size cap evicts the oldest surviving mark
+// (mirroring the dmGateMaxEntries pattern), keeping the map bounded.
+func TestBusyReactionRegistry_CapEvictsOldest(t *testing.T) {
+	var mu sync.Mutex
+	current := time.Now()
+	r := newBusyReactionRegistry()
+	r.now = func() time.Time {
+		mu.Lock()
+		defer mu.Unlock()
+		return current
+	}
+
+	for i := 0; i <= busyReactionMaxEntries; i++ {
+		mu.Lock()
+		current = current.Add(time.Millisecond)
+		mu.Unlock()
+		key := fmt.Sprintf("%d.0", i)
+		r.mark("C1", key, key)
+	}
+	if n := r.size(); n != busyReactionMaxEntries {
+		t.Errorf("size = %d, want cap %d", n, busyReactionMaxEntries)
+	}
+	if _, ok := r.pending("C1", "0.0"); ok {
+		t.Error("oldest entry survived cap eviction; want evicted")
+	}
+	last := fmt.Sprintf("%d.0", busyReactionMaxEntries)
+	if _, ok := r.pending("C1", last); !ok {
+		t.Error("newest entry missing after cap eviction; want kept")
+	}
+}
+
+// A nil registry is inert on every method — the lifecycle degrades to
+// "no busy affordance" instead of panicking (old tests construct cfg
+// without busyMarks).
+func TestBusyReactionRegistry_NilSafe(t *testing.T) {
+	var r *busyReactionRegistry
+	if done := r.mark("C1", "1.0", "1.0"); done == nil {
+		t.Error("mark on nil registry returned a nil addDone channel; want closable")
+	}
+	if taken := r.take("C1", "1.0"); len(taken) != 0 {
+		t.Error("take on nil registry reported a mark")
+	}
+	if _, ok := r.pending("C1", "1.0"); ok {
+		t.Error("pending on nil registry reported a mark")
+	}
+	if n := r.size(); n != 0 {
+		t.Errorf("size on nil registry = %d, want 0", n)
+	}
+}

--- a/slack-full/adapter/confined_open.go
+++ b/slack-full/adapter/confined_open.go
@@ -9,20 +9,33 @@ import (
 )
 
 // openBeneath opens rel (a Clean, root-relative path containing no
-// "..") beneath rootAbs by walking one path component at a time: each
-// step is an openat(2) relative to the fd of the already-opened parent,
-// with O_NOFOLLOW set. The parent fd pins the verified directory inode,
-// so a directory swapped for a symlink mid-walk cannot redirect the
-// traversal — the userspace equivalent of openat2(RESOLVE_BENEATH),
-// which stdlib syscall does not expose (and the adapter's
-// zero-dependency go.mod keeps us from importing x/sys for).
+// "..") beneath rootAbs with a per-component pinned walk built on
+// os.Root — the portable replacement for the raw syscall.Openat walk
+// (which does not exist on darwin and made the adapter linux-only).
 //
-// O_NOFOLLOW applies to every component, not just the leaf, so any
-// symlink anywhere beneath root is a hard failure (ELOOP / ENOTDIR).
-// That matches the caller's contract: realPath is EvalSymlinks-resolved
-// before it gets here, so every component of a legitimate path is a
-// real directory or file and the walk succeeds; only a mid-flight swap
-// trips it.
+// os.Root alone follows symlinks it considers safe: a symlink at the
+// ROOT argument itself, and in-root symlinks at ANY component
+// (O_NOFOLLOW passed to Root.OpenFile does not opt out — verified
+// empirically on go1.26). The caller's contract is stronger than
+// confinement: realPath was EvalSymlinks-resolved before this call,
+// so every component of a legitimate path is a real directory or
+// file, and ANY symlink anywhere on the path means an inode was
+// swapped in the race window — the open must fail rather than return
+// a different (even in-root) file than the one validated.
+//
+// The walk restores the old per-component guarantee portably:
+//
+//   - The root is first opened with plain open(2) +
+//     O_NOFOLLOW|O_DIRECTORY (rejecting a root swapped for a symlink)
+//     and the os.Root handle must match that fd's (dev, ino).
+//   - Each intermediate component is Lstat'd through the current
+//     pinned sub-root (symlink → hard failure), descended into with
+//     Root.OpenRoot, and the opened sub-root must match the Lstat'd
+//     (dev, ino) — so a component swapped between the two calls fails
+//     the identity check instead of being silently followed.
+//   - The leaf is Lstat'd (symlink → hard failure), opened with
+//     O_NOFOLLOW, and the opened file must match the Lstat'd
+//     (dev, ino).
 func openBeneath(rootAbs, rel string) (*os.File, error) {
 	if rel == "" || rel == "." || filepath.IsAbs(rel) {
 		return nil, fmt.Errorf("openBeneath: invalid relative path %q", rel)
@@ -33,22 +46,104 @@ func openBeneath(rootAbs, rel string) (*os.File, error) {
 			return nil, fmt.Errorf("openBeneath: invalid path component %q in %q", c, rel)
 		}
 	}
-	dirFlags := syscall.O_RDONLY | syscall.O_DIRECTORY | syscall.O_NOFOLLOW | syscall.O_CLOEXEC
-	fd, err := syscall.Open(rootAbs, dirFlags, 0)
+
+	// Pin the verified root directory. O_NOFOLLOW applies to the final
+	// component of rootAbs, so a root swapped for a symlink fails here
+	// (ELOOP on linux, ENOTDIR via O_DIRECTORY on darwin).
+	rootFD, err := syscall.Open(rootAbs, syscall.O_RDONLY|syscall.O_DIRECTORY|syscall.O_NOFOLLOW|syscall.O_CLOEXEC, 0)
 	if err != nil {
 		return nil, fmt.Errorf("openBeneath: open root %q: %w", rootAbs, err)
 	}
-	for i, c := range comps {
-		flags := syscall.O_RDONLY | syscall.O_NOFOLLOW | syscall.O_CLOEXEC
-		if i < len(comps)-1 {
-			flags |= syscall.O_DIRECTORY
+	defer syscall.Close(rootFD)
+	var rootSt syscall.Stat_t
+	if err := syscall.Fstat(rootFD, &rootSt); err != nil {
+		return nil, fmt.Errorf("openBeneath: fstat root %q: %w", rootAbs, err)
+	}
+
+	cur, err := os.OpenRoot(rootAbs)
+	if err != nil {
+		return nil, fmt.Errorf("openBeneath: open root %q: %w", rootAbs, err)
+	}
+	defer func() { _ = cur.Close() }()
+	// os.OpenRoot re-resolved rootAbs independently of the pinned fd
+	// above; require both opens to have landed on the same directory
+	// inode so a swap between the two calls cannot substitute a
+	// different root.
+	rootFI, err := cur.Stat(".")
+	if err != nil {
+		return nil, fmt.Errorf("openBeneath: stat root %q: %w", rootAbs, err)
+	}
+	if !sameInode(rootFI, &rootSt) {
+		return nil, fmt.Errorf("openBeneath: root %q changed identity between opens", rootAbs)
+	}
+
+	// Descend one pinned sub-root at a time (see doc comment).
+	for _, c := range comps[:len(comps)-1] {
+		li, err := cur.Lstat(c)
+		if err != nil {
+			return nil, fmt.Errorf("openBeneath: lstat component %q of %q: %w", c, rel, err)
 		}
-		next, err := syscall.Openat(fd, c, flags, 0)
-		syscall.Close(fd)
+		if li.Mode()&os.ModeSymlink != 0 {
+			return nil, fmt.Errorf("openBeneath: component %q of %q is a symlink", c, rel)
+		}
+		compSt, ok := li.Sys().(*syscall.Stat_t)
+		if !ok {
+			return nil, fmt.Errorf("openBeneath: lstat component %q of %q: no unix stat", c, rel)
+		}
+		next, err := cur.OpenRoot(c)
 		if err != nil {
 			return nil, fmt.Errorf("openBeneath: open component %q of %q: %w", c, rel, err)
 		}
-		fd = next
+		nextFI, err := next.Stat(".")
+		if err != nil {
+			_ = next.Close()
+			return nil, fmt.Errorf("openBeneath: stat component %q of %q: %w", c, rel, err)
+		}
+		if !sameInode(nextFI, compSt) {
+			_ = next.Close()
+			return nil, fmt.Errorf("openBeneath: component %q of %q changed identity during open", c, rel)
+		}
+		_ = cur.Close()
+		cur = next
 	}
-	return os.NewFile(uintptr(fd), filepath.Join(rootAbs, rel)), nil
+
+	// Leaf swap detection: a symlink at the leaf is a hard failure,
+	// and the opened file must be the exact inode the Lstat verified —
+	// covering both swap orders around the two calls.
+	leaf := comps[len(comps)-1]
+	li, err := cur.Lstat(leaf)
+	if err != nil {
+		return nil, fmt.Errorf("openBeneath: lstat %q beneath %q: %w", rel, rootAbs, err)
+	}
+	if li.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("openBeneath: %q beneath %q is a symlink", rel, rootAbs)
+	}
+	leafSt, ok := li.Sys().(*syscall.Stat_t)
+	if !ok {
+		return nil, fmt.Errorf("openBeneath: lstat %q beneath %q: no unix stat", rel, rootAbs)
+	}
+	f, err := cur.OpenFile(leaf, os.O_RDONLY|syscall.O_NOFOLLOW, 0)
+	if err != nil {
+		return nil, fmt.Errorf("openBeneath: open %q beneath %q: %w", rel, rootAbs, err)
+	}
+	openedFI, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("openBeneath: stat opened %q beneath %q: %w", rel, rootAbs, err)
+	}
+	if !sameInode(openedFI, leafSt) {
+		_ = f.Close()
+		return nil, fmt.Errorf("openBeneath: %q beneath %q changed identity during open", rel, rootAbs)
+	}
+	return f, nil
+}
+
+// sameInode reports whether fi refers to the same (dev, ino) identity
+// as want. A FileInfo without a unix *syscall.Stat_t fails closed.
+func sameInode(fi os.FileInfo, want *syscall.Stat_t) bool {
+	st, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		return false
+	}
+	return st.Dev == want.Dev && st.Ino == want.Ino
 }

--- a/slack-full/adapter/confined_open_test.go
+++ b/slack-full/adapter/confined_open_test.go
@@ -58,6 +58,65 @@ func TestOpenBeneathRefusesSymlinkComponents(t *testing.T) {
 	}
 }
 
+func TestOpenBeneathRefusesInRootLeafSymlink(t *testing.T) {
+	// A RELATIVE leaf symlink to another file INSIDE the root: os.Root
+	// happily resolves it (O_NOFOLLOW is not honored for in-root
+	// links), which would upload a different in-root file than the one
+	// the caller validated. The Lstat + inode-pin gate must reject it.
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "target.txt"), []byte("other"), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	if err := os.Symlink("target.txt", filepath.Join(root, "link")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	if _, err := openBeneath(root, "link"); err == nil {
+		t.Fatal("openBeneath followed an in-root leaf symlink, want failure")
+	}
+}
+
+func TestOpenBeneathRefusesInRootIntermediateSymlink(t *testing.T) {
+	// An intermediate directory swapped for a RELATIVE symlink to
+	// another directory INSIDE the root: os.Root follows it (it never
+	// escapes), so both the leaf Lstat and the open would resolve
+	// through the link to a different in-root file than validated.
+	// The per-component Lstat + identity pin must reject it.
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "real"), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "real", "f.txt"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := os.Symlink("real", filepath.Join(root, "alias")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	if _, err := openBeneath(root, filepath.Join("alias", "f.txt")); err == nil {
+		t.Fatal("openBeneath followed an in-root intermediate symlink, want failure")
+	}
+}
+
+func TestOpenBeneathRefusesSymlinkedRoot(t *testing.T) {
+	// The ROOT itself swapped for a symlink — the post-swap shape of
+	// the terminal-root race. os.OpenRoot follows it by contract, so
+	// the O_NOFOLLOW pre-open must reject it.
+	base := t.TempDir()
+	realRoot := filepath.Join(base, "real")
+	if err := os.MkdirAll(realRoot, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(realRoot, "f.txt"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	rootLink := filepath.Join(base, "rootlink")
+	if err := os.Symlink(realRoot, rootLink); err != nil {
+		t.Fatalf("symlink root: %v", err)
+	}
+	if _, err := openBeneath(rootLink, "f.txt"); err == nil {
+		t.Fatal("openBeneath accepted a symlinked root, want failure")
+	}
+}
+
 func TestOpenBeneathRejectsInvalidRel(t *testing.T) {
 	root := t.TempDir()
 	// "a/../b" is absent: filepath.Clean collapses it to "b" before the
@@ -70,7 +129,13 @@ func TestOpenBeneathRejectsInvalidRel(t *testing.T) {
 }
 
 func TestReadConfinedFileStillReadsAndStillConfines(t *testing.T) {
-	root := t.TempDir()
+	// Canonicalize: readConfinedFile's contract is an EvalSymlinks-resolved
+	// path, and on darwin t.TempDir() sits under the /var -> /private/var
+	// symlink.
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatalf("EvalSymlinks: %v", err)
+	}
 	sub := filepath.Join(root, "files")
 	if err := os.MkdirAll(sub, 0o700); err != nil {
 		t.Fatalf("mkdir: %v", err)

--- a/slack-full/adapter/double_handle_prefix.go
+++ b/slack-full/adapter/double_handle_prefix.go
@@ -134,7 +134,13 @@ func parseDoubleHandlePrefix(text, prefix string) (handle, remainder string, ok 
 // threadReg is non-nil at the call site (the caller checks for nil
 // before parsing). It is captured here so 5.3 can wire the
 // AcquireOrCreate call without touching this function's signature.
-func handleDoubleHandleDispatch(cfg config, aliasReg *handleAliasRegistry, threadReg *threadSessionRegistry, roomLaunchReg *roomLaunchMappingRegistry, msg slackMessageEvent, teamID, handle, remainder string) {
+// The returned verdict feeds the event-dedup claim (codex r6):
+// concluded=true means the event was handled terminally (delivered,
+// or a user-error/not-enabled ephemeral a redelivery would repeat
+// identically) and the claim should commit; false means a TRANSIENT
+// launcher failure (spawn or first-message forward) and the claim
+// should be forgotten so a Slack redelivery can retry it.
+func handleDoubleHandleDispatch(cfg config, aliasReg *handleAliasRegistry, threadReg *threadSessionRegistry, roomLaunchReg *roomLaunchMappingRegistry, msg slackMessageEvent, teamID, handle, remainder string) (concluded bool) {
 	if aliasReg != nil {
 		if existingSessionID, ok := aliasReg.Get(handle); ok {
 			body := fmt.Sprintf(
@@ -147,11 +153,11 @@ func handleDoubleHandleDispatch(cfg config, aliasReg *handleAliasRegistry, threa
 			}
 			log.Printf("launcher dispatch: pre-claimed handle=%q session=%s team=%s channel=%s user=%s",
 				handle, existingSessionID, teamID, msg.Channel, msg.User)
-			return
+			return true
 		}
 	}
 
-	dispatchRoomLaunch(cfg, aliasReg, threadReg, roomLaunchReg, msg, teamID, handle, remainder)
+	return dispatchRoomLaunch(cfg, aliasReg, threadReg, roomLaunchReg, msg, teamID, handle, remainder)
 }
 
 // slackPostEphemeralReq is the chat.postEphemeral request shape we
@@ -206,7 +212,10 @@ func postSlackEphemeral(token, channel, user, threadTS, text string) error {
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")
-	resp, err := http.DefaultClient.Do(req)
+	// slackAPIClient, not http.DefaultClient: this runs synchronously
+	// on the event path while a dedup claim is open — an unbounded
+	// hang would park acked redeliveries forever (codex r5).
+	resp, err := slackAPIClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("postEphemeral transport: %w", err)
 	}

--- a/slack-full/adapter/event_dedup.go
+++ b/slack-full/adapter/event_dedup.go
@@ -1,0 +1,206 @@
+package main
+
+import (
+	"sync"
+	"time"
+)
+
+// Events API redelivery dedup (hw-94w5k finding #4).
+//
+// Slack retries any /slack/events delivery it considers unacknowledged
+// — the initial POST timing out, a dropped connection, or a non-2xx —
+// up to three times (immediately, ~1 minute, ~5 minutes), and every
+// retry carries the same event_id. handleSlackEvents acks with a 200
+// before processing, but an ack lost in transit still produces a
+// retry, and without a seen-set that retry re-forwards the same
+// message into the bound session as a duplicate notification
+// (observed as byte-identical inbound log pairs).
+//
+// Entries are two-state so a retry can never be dropped while the
+// outcome it would recover from is still undecided (codex r2 P1):
+//
+//   - in-flight: a delivery is processing. A concurrent redelivery
+//     waits on the entry's done channel instead of being discarded —
+//     if the first forward fails (forget), the waiter takes over; if
+//     it succeeds (commit), the waiter drops as a duplicate.
+//   - committed: the event reached gc. Redeliveries within the TTL
+//     drop immediately.
+//
+// Processing failure calls forget, which erases the entry entirely —
+// the retry (waiting or future) is then the recovery path.
+
+// eventDedupTTL bounds how long a committed event_id is remembered.
+// Slack's last retry fires ~5 minutes after the original delivery;
+// 10 minutes covers the ladder with slack for clock skew and queue
+// delay while keeping the map small.
+const eventDedupTTL = 10 * time.Minute
+
+// eventDedupParkLogInterval paces the "still parked" log line for a
+// redelivery waiting on an in-flight claim. The wait itself is
+// UNBOUNDED by design (codex r4): the redelivery already returned a
+// 200, so Slack will never resend it — dropping it while the owner's
+// outcome is undecided would permanently lose the event if that owner
+// then fails. Every claim concludes deterministically (the gc forward
+// calls are bounded by gcForwardClient and processSlackEvent concludes
+// on every return path), so parked goroutines cannot leak; the parked
+// waiter holds no dispatch slot (released before parking, re-acquired
+// on takeover).
+const eventDedupParkLogInterval = 30 * time.Second
+
+// eventDedupMaxEntries hard-caps the seen-set so a pathological event
+// flood cannot grow it without bound. At the cap, the oldest committed
+// entry is evicted — that event's redeliveries just stop being
+// deduplicable, which is the pre-cache behavior. 4096 ids at ~10
+// minutes of traffic is far beyond any realistic workspace's rate.
+const eventDedupMaxEntries = 4096
+
+// eventDedupEntry is one tracked event_id. committedAt is zero while
+// the owning delivery is still processing; done is closed exactly once
+// when the entry leaves the in-flight state (commit or forget).
+type eventDedupEntry struct {
+	committedAt time.Time
+	done        chan struct{}
+	closed      bool
+}
+
+// eventDedupCache tracks Slack event ids across the in-flight →
+// committed lifecycle. Safe for concurrent callers. A nil
+// *eventDedupCache never dedupes, so tests (and a misordered main)
+// degrade to "no dedup" rather than panicking.
+type eventDedupCache struct {
+	mu      sync.Mutex
+	entries map[string]*eventDedupEntry
+	ttl     time.Duration
+	// now is the clock; nil means time.Now. Injectable so tests can
+	// drive TTL expiry without sleeping.
+	now func() time.Time
+}
+
+func newEventDedupCache(ttl time.Duration) *eventDedupCache {
+	return &eventDedupCache{entries: make(map[string]*eventDedupEntry), ttl: ttl}
+}
+
+func (c *eventDedupCache) clock() time.Time {
+	if c.now != nil {
+		return c.now()
+	}
+	return time.Now()
+}
+
+// begin claims id for processing. Exactly one of:
+//
+//   - proceed=true: the caller owns this event and MUST conclude it
+//     with commit (success) or forget (failure).
+//   - proceed=false, wait=nil: a delivery already committed within the
+//     TTL — drop this one as a duplicate.
+//   - proceed=false, wait!=nil: another delivery is in flight — wait
+//     on the channel (bounded) and call begin again for the verdict.
+//
+// A nil cache and an empty id always proceed (no dedup, nothing to
+// conclude — commit/forget on them are no-ops).
+func (c *eventDedupCache) begin(id string) (proceed bool, wait <-chan struct{}) {
+	if c == nil || id == "" {
+		return true, nil
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	now := c.clock()
+	for k, e := range c.entries {
+		if !e.committedAt.IsZero() && now.Sub(e.committedAt) > c.ttl {
+			delete(c.entries, k)
+		}
+	}
+	if e, ok := c.entries[id]; ok {
+		if e.committedAt.IsZero() {
+			return false, e.done
+		}
+		return false, nil
+	}
+	c.entries[id] = &eventDedupEntry{done: make(chan struct{})}
+	if len(c.entries) > eventDedupMaxEntries {
+		c.evictOldestLocked()
+	}
+	return true, nil
+}
+
+// commit marks id as successfully processed: redeliveries within the
+// TTL now drop, and any waiter re-begins into the committed verdict.
+// No-op for unknown ids (evicted under cap pressure, or empty).
+func (c *eventDedupCache) commit(id string) {
+	if c == nil || id == "" {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e, ok := c.entries[id]
+	if !ok {
+		return
+	}
+	e.committedAt = c.clock()
+	if !e.closed {
+		e.closed = true
+		close(e.done)
+	}
+}
+
+// forget erases id entirely: processing failed and nothing reached gc,
+// so a redelivery (waiting or future) must be treated as brand new —
+// it is the only recovery path for the message. No-op for unknown ids.
+func (c *eventDedupCache) forget(id string) {
+	if c == nil || id == "" {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e, ok := c.entries[id]
+	if !ok {
+		return
+	}
+	delete(c.entries, id)
+	if !e.closed {
+		e.closed = true
+		close(e.done)
+	}
+}
+
+// size reports the number of tracked ids. Test helper.
+func (c *eventDedupCache) size() int {
+	if c == nil {
+		return 0
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.entries)
+}
+
+// evictOldestLocked drops the single oldest committed entry, falling
+// back to any entry only if every entry is in-flight (pathological).
+// Called with c.mu held, only on the insert that pushed the map past
+// the cap (expired entries were already swept by begin).
+func (c *eventDedupCache) evictOldestLocked() {
+	var oldestID string
+	var oldestAt time.Time
+	first := true
+	for k, e := range c.entries {
+		if e.committedAt.IsZero() {
+			continue
+		}
+		if first || e.committedAt.Before(oldestAt) {
+			oldestID, oldestAt, first = k, e.committedAt, false
+		}
+	}
+	if first {
+		// No committed entries at all: evict an arbitrary in-flight
+		// one rather than growing without bound. Its conclusion
+		// (commit/forget) becomes a harmless no-op.
+		for k, e := range c.entries {
+			delete(c.entries, k)
+			if !e.closed {
+				e.closed = true
+				close(e.done)
+			}
+			return
+		}
+	}
+	delete(c.entries, oldestID)
+}

--- a/slack-full/adapter/event_dedup.go
+++ b/slack-full/adapter/event_dedup.go
@@ -70,14 +70,66 @@ type eventDedupEntry struct {
 type eventDedupCache struct {
 	mu      sync.Mutex
 	entries map[string]*eventDedupEntry
-	ttl     time.Duration
+	// channelLegDone remembers event ids whose postInbound leg
+	// SUCCEEDED before a later leg (the alias dispatch) failed and
+	// forgot the entry (codex r12). The retaken redelivery must skip
+	// the channel leg — core does not consume DedupKey (see
+	// docs/phase5-ledger-readiness.md), so re-running postInbound
+	// duplicates the bound session's turn — and retry only the alias
+	// leg. Markers expire with the same TTL as committed entries and
+	// are cleared on commit.
+	channelLegDone map[string]time.Time
+	ttl            time.Duration
 	// now is the clock; nil means time.Now. Injectable so tests can
 	// drive TTL expiry without sleeping.
 	now func() time.Time
 }
 
 func newEventDedupCache(ttl time.Duration) *eventDedupCache {
-	return &eventDedupCache{entries: make(map[string]*eventDedupEntry), ttl: ttl}
+	return &eventDedupCache{
+		entries:        make(map[string]*eventDedupEntry),
+		channelLegDone: make(map[string]time.Time),
+		ttl:            ttl,
+	}
+}
+
+// markChannelLegDone records that id's postInbound leg succeeded, so
+// a retaken redelivery (after forget) skips it and retries only the
+// failed alias leg. Must be called BEFORE forget(id) wakes a parked
+// retry.
+func (c *eventDedupCache) markChannelLegDone(id string) {
+	if c == nil || id == "" {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	now := c.clock()
+	for k, at := range c.channelLegDone {
+		if now.Sub(at) > c.ttl {
+			delete(c.channelLegDone, k)
+		}
+	}
+	c.channelLegDone[id] = now
+	if len(c.channelLegDone) > eventDedupMaxEntries {
+		for k := range c.channelLegDone {
+			delete(c.channelLegDone, k)
+			if len(c.channelLegDone) <= eventDedupMaxEntries {
+				break
+			}
+		}
+	}
+}
+
+// isChannelLegDone reports whether id's channel leg already reached
+// gc within the TTL.
+func (c *eventDedupCache) isChannelLegDone(id string) bool {
+	if c == nil || id == "" {
+		return false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	at, ok := c.channelLegDone[id]
+	return ok && c.clock().Sub(at) <= c.ttl
 }
 
 func (c *eventDedupCache) clock() time.Time {
@@ -137,6 +189,7 @@ func (c *eventDedupCache) commit(id string) {
 		return
 	}
 	e.committedAt = c.clock()
+	delete(c.channelLegDone, id)
 	if !e.closed {
 		e.closed = true
 		close(e.done)

--- a/slack-full/adapter/event_dedup_test.go
+++ b/slack-full/adapter/event_dedup_test.go
@@ -370,3 +370,37 @@ func TestHandleSlackEventsInflightRetryDropsAfterSuccess(t *testing.T) {
 	postSignedEvent(t, cfg, envBody) // waits on the in-flight claim, then drops
 	awaitInboundHits(t, &hits, 1)
 }
+
+// codex r12: a completed channel leg survives forget so a retaken
+// redelivery skips postInbound and retries only the alias leg;
+// commit clears the marker.
+func TestEventDedupChannelLegMarker(t *testing.T) {
+	c := newEventDedupCache(eventDedupTTL)
+	if c.isChannelLegDone("ev1") {
+		t.Fatal("marker set before markChannelLegDone")
+	}
+	proceed, _ := c.begin("ev1")
+	if !proceed {
+		t.Fatal("begin ev1: want proceed")
+	}
+	c.markChannelLegDone("ev1")
+	c.forget("ev1")
+	if !c.isChannelLegDone("ev1") {
+		t.Fatal("marker lost across forget; retaken delivery would duplicate the channel leg")
+	}
+	// The retaken delivery succeeds end-to-end: commit clears the marker.
+	proceed, _ = c.begin("ev1")
+	if !proceed {
+		t.Fatal("re-begin ev1 after forget: want proceed")
+	}
+	c.commit("ev1")
+	if c.isChannelLegDone("ev1") {
+		t.Fatal("marker survived commit")
+	}
+	// nil-safety
+	var nilCache *eventDedupCache
+	nilCache.markChannelLegDone("x")
+	if nilCache.isChannelLegDone("x") {
+		t.Fatal("nil cache reported a marker")
+	}
+}

--- a/slack-full/adapter/event_dedup_test.go
+++ b/slack-full/adapter/event_dedup_test.go
@@ -1,0 +1,372 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Tests for the Events API redelivery seen-set (hw-94w5k finding #4):
+// a Slack retry re-delivers the same envelope with the same event_id,
+// and the adapter must forward it into gc exactly once.
+
+// postSignedEvent signs and POSTs one events-API envelope through
+// handleSlackEvents, returning the recorder.
+func postSignedEvent(t *testing.T, cfg config, envBody []byte) *httptest.ResponseRecorder {
+	t.Helper()
+	ts := strconv.FormatInt(time.Now().Unix(), 10)
+	sig := signFor(cfg.slackSigningKey, ts, envBody)
+	req := httptest.NewRequest(http.MethodPost, "/slack/events", bytes.NewReader(envBody))
+	req.Header.Set("X-Slack-Request-Timestamp", ts)
+	req.Header.Set("X-Slack-Signature", sig)
+	w := httptest.NewRecorder()
+	handleSlackEvents(cfg, newTestHandleAliasRegistry(t), nil, nil, nil, nil)(w, req)
+	return w
+}
+
+// eventEnvelopeBody marshals a plain channel-message event_callback
+// with the given event_id (empty means "omit").
+func eventEnvelopeBody(t *testing.T, eventID, ts, text string) []byte {
+	t.Helper()
+	rawMsg, err := json.Marshal(slackMessageEvent{
+		Type: "message", Channel: "C1", User: "U1", TS: ts, Text: text,
+	})
+	if err != nil {
+		t.Fatalf("marshal event: %v", err)
+	}
+	envBody, err := json.Marshal(slackEventEnvelope{
+		Type: "event_callback", EventID: eventID, Event: rawMsg,
+	})
+	if err != nil {
+		t.Fatalf("marshal envelope: %v", err)
+	}
+	return envBody
+}
+
+// awaitInboundHits polls until the gc stub has seen want inbound POSTs
+// or the deadline passes, then asserts the count holds (no extras).
+func awaitInboundHits(t *testing.T, hits *int32, want int32) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if atomic.LoadInt32(hits) >= want {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	// Settle window: catch a duplicate forward racing in late.
+	time.Sleep(150 * time.Millisecond)
+	if got := atomic.LoadInt32(hits); got != want {
+		t.Errorf("inbound POSTs = %d, want %d", got, want)
+	}
+}
+
+func dedupTestConfig(t *testing.T, gcURL string) config {
+	t.Helper()
+	return config{
+		gcAPIBase:       gcURL,
+		cityName:        "test-city",
+		provider:        "slack",
+		accountID:       "T1",
+		slackSigningKey: "secret",
+		dispatchSem:     make(chan struct{}, 4),
+		eventDedup:      newEventDedupCache(eventDedupTTL),
+	}
+}
+
+func countingGCStub(t *testing.T) (*httptest.Server, *int32) {
+	t.Helper()
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.ReadAll(r.Body)
+		atomic.AddInt32(&hits, 1)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &hits
+}
+
+// A retried delivery — same envelope, same event_id — forwards to gc
+// exactly once; the retry is dropped with a dedup log line and still
+// sees a 200 ack.
+func TestHandleSlackEventsDedupsRetriedEventID(t *testing.T) {
+	gcStub, hits := countingGCStub(t)
+	cfg := dedupTestConfig(t, gcStub.URL)
+
+	read, cleanup := captureLog(t)
+	t.Cleanup(cleanup)
+
+	envBody := eventEnvelopeBody(t, "Ev0001", "1.0", "hi")
+	if w := postSignedEvent(t, cfg, envBody); w.Result().StatusCode != http.StatusOK {
+		t.Fatalf("first delivery status = %d, want 200", w.Result().StatusCode)
+	}
+	awaitInboundHits(t, hits, 1)
+
+	if w := postSignedEvent(t, cfg, envBody); w.Result().StatusCode != http.StatusOK {
+		t.Fatalf("retry delivery status = %d, want 200 (retries must still be acked)", w.Result().StatusCode)
+	}
+	awaitInboundHits(t, hits, 1)
+	// The drop verdict is logged from the async claim goroutine — poll.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && !strings.Contains(read(), "slack event dedup") {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if !strings.Contains(read(), "slack event dedup") {
+		t.Errorf("log missing 'slack event dedup' marker:\n%s", read())
+	}
+}
+
+// Distinct event ids are independent — both forward.
+func TestHandleSlackEventsDistinctEventIDsBothForward(t *testing.T) {
+	gcStub, hits := countingGCStub(t)
+	cfg := dedupTestConfig(t, gcStub.URL)
+
+	postSignedEvent(t, cfg, eventEnvelopeBody(t, "Ev0001", "1.0", "hi"))
+	postSignedEvent(t, cfg, eventEnvelopeBody(t, "Ev0002", "2.0", "hello"))
+	awaitInboundHits(t, hits, 2)
+}
+
+// An envelope with no event_id is never deduped: two deliveries both
+// forward. (Only event_callback envelopes carry event_id; nothing
+// else must get caught in the seen-set.)
+func TestHandleSlackEventsNoEventIDNoDedup(t *testing.T) {
+	gcStub, hits := countingGCStub(t)
+	cfg := dedupTestConfig(t, gcStub.URL)
+
+	envBody := eventEnvelopeBody(t, "", "1.0", "hi")
+	postSignedEvent(t, cfg, envBody)
+	postSignedEvent(t, cfg, envBody)
+	awaitInboundHits(t, hits, 2)
+}
+
+// A delivery dropped at the queue-full boundary must NOT record its
+// event_id: Slack's retry is the only recovery for that event, and it
+// has to pass the seen-set when capacity is back.
+func TestHandleSlackEventsQueueFullDropDoesNotRecordEventID(t *testing.T) {
+	gcStub, hits := countingGCStub(t)
+	cfg := dedupTestConfig(t, gcStub.URL)
+	cfg.dispatchSem = make(chan struct{}, 1)
+
+	holdRelease, _, ok := cfg.acquireDispatchSlot()
+	if !ok {
+		t.Fatal("acquireDispatchSlot: failed to take initial slot in fresh sem")
+	}
+	envBody := eventEnvelopeBody(t, "Ev0001", "1.0", "hi")
+	postSignedEvent(t, cfg, envBody) // dropped: queue full
+	awaitInboundHits(t, hits, 0)
+
+	holdRelease()
+	postSignedEvent(t, cfg, envBody) // Slack retry after capacity freed
+	awaitInboundHits(t, hits, 1)
+}
+
+// A delivery whose forward to gc FAILS must release its event_id: in
+// the lost-ack scenario the Slack retry is the only path for the
+// message to reach gc, and a committed id would turn the transient
+// failure into permanent message loss.
+func TestHandleSlackEventsFailedForwardReleasesEventID(t *testing.T) {
+	var hits int32
+	gcStub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.ReadAll(r.Body)
+		// First request fails (gc hiccup); subsequent requests accept.
+		if atomic.AddInt32(&hits, 1) == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	t.Cleanup(gcStub.Close)
+	cfg := dedupTestConfig(t, gcStub.URL)
+
+	envBody := eventEnvelopeBody(t, "Ev0001", "1.0", "hi")
+	postSignedEvent(t, cfg, envBody) // forward fails with 500
+	awaitInboundHits(t, &hits, 1)
+
+	postSignedEvent(t, cfg, envBody) // Slack retry: must NOT be deduped
+	awaitInboundHits(t, &hits, 2)
+}
+
+// A nil cache (mis-wired test config) never dedupes and never panics.
+func TestHandleSlackEventsNilDedupCacheForwardsEverything(t *testing.T) {
+	gcStub, hits := countingGCStub(t)
+	cfg := dedupTestConfig(t, gcStub.URL)
+	cfg.eventDedup = nil
+
+	envBody := eventEnvelopeBody(t, "Ev0001", "1.0", "hi")
+	postSignedEvent(t, cfg, envBody)
+	postSignedEvent(t, cfg, envBody)
+	awaitInboundHits(t, hits, 2)
+}
+
+// Cache semantics: begin claims an unknown id; a second begin while
+// in flight reports a wait channel; after commit it drops; after the
+// TTL it proceeds again; empty ids never dedupe.
+func TestEventDedupCacheLifecycle(t *testing.T) {
+	var mu sync.Mutex
+	current := time.Now()
+	c := newEventDedupCache(eventDedupTTL)
+	c.now = func() time.Time {
+		mu.Lock()
+		defer mu.Unlock()
+		return current
+	}
+
+	proceed, wait := c.begin("Ev1")
+	if !proceed || wait != nil {
+		t.Fatalf("first begin = (%v, %v), want (true, nil)", proceed, wait)
+	}
+	proceed, wait = c.begin("Ev1")
+	if proceed || wait == nil {
+		t.Fatalf("in-flight begin = (%v, %v), want (false, wait-chan)", proceed, wait)
+	}
+	select {
+	case <-wait:
+		t.Fatal("wait channel closed before the first delivery concluded")
+	default:
+	}
+	c.commit("Ev1")
+	select {
+	case <-wait:
+	default:
+		t.Fatal("wait channel not closed by commit")
+	}
+	proceed, wait = c.begin("Ev1")
+	if proceed || wait != nil {
+		t.Fatalf("committed begin = (%v, %v), want (false, nil) — duplicate drop", proceed, wait)
+	}
+	mu.Lock()
+	current = current.Add(eventDedupTTL + time.Minute)
+	mu.Unlock()
+	if proceed, _ = c.begin("Ev1"); !proceed {
+		t.Error("begin after TTL = false, want true (entry expired)")
+	}
+	if proceed, _ = c.begin(""); !proceed {
+		t.Error("begin(\"\") = false, want true (empty ids never dedupe)")
+	}
+}
+
+// Cache semantics: forget erases the claim (closing any waiter) so a
+// redelivery proceeds as brand new.
+func TestEventDedupCacheForgetReleases(t *testing.T) {
+	c := newEventDedupCache(eventDedupTTL)
+	if proceed, _ := c.begin("Ev1"); !proceed {
+		t.Fatal("first begin = false, want true")
+	}
+	_, wait := c.begin("Ev1")
+	if wait == nil {
+		t.Fatal("in-flight begin returned nil wait channel")
+	}
+	c.forget("Ev1")
+	select {
+	case <-wait:
+	default:
+		t.Fatal("wait channel not closed by forget")
+	}
+	if proceed, _ := c.begin("Ev1"); !proceed {
+		t.Error("begin after forget = false, want true (retry takes over)")
+	}
+	if n := c.size(); n != 1 {
+		t.Errorf("size = %d, want 1 (the retry's fresh claim)", n)
+	}
+}
+
+// Cache semantics: the size cap evicts the oldest committed id,
+// keeping the map bounded under an event flood.
+func TestEventDedupCacheCapEvictsOldest(t *testing.T) {
+	var mu sync.Mutex
+	current := time.Now()
+	c := newEventDedupCache(eventDedupTTL)
+	c.now = func() time.Time {
+		mu.Lock()
+		defer mu.Unlock()
+		return current
+	}
+
+	for i := 0; i <= eventDedupMaxEntries; i++ {
+		mu.Lock()
+		current = current.Add(time.Millisecond)
+		mu.Unlock()
+		id := fmt.Sprintf("Ev%d", i)
+		c.begin(id)
+		c.commit(id)
+	}
+	if n := c.size(); n != eventDedupMaxEntries {
+		t.Errorf("size = %d, want cap %d", n, eventDedupMaxEntries)
+	}
+	if proceed, _ := c.begin("Ev0"); !proceed {
+		t.Error("oldest id survived cap eviction; want evicted (begin proceeds)")
+	}
+	last := fmt.Sprintf("Ev%d", eventDedupMaxEntries)
+	if proceed, _ := c.begin(last); proceed {
+		t.Error("newest id missing after cap eviction; want kept (begin drops)")
+	}
+}
+
+// A nil cache is inert on every method.
+func TestEventDedupCacheNilSafe(t *testing.T) {
+	var c *eventDedupCache
+	if proceed, wait := c.begin("Ev1"); !proceed || wait != nil {
+		t.Error("begin on nil cache must proceed with no wait")
+	}
+	c.commit("Ev1")
+	c.forget("Ev1")
+	if n := c.size(); n != 0 {
+		t.Errorf("size on nil cache = %d, want 0", n)
+	}
+}
+
+// A redelivery racing the FIRST delivery's still-running forward must
+// wait for its outcome (codex r2 P1): if the forward fails, the
+// waiting retry takes over and the message still reaches gc.
+func TestHandleSlackEventsInflightRetryTakesOverAfterFailure(t *testing.T) {
+	var hits int32
+	gcStub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.ReadAll(r.Body)
+		if atomic.AddInt32(&hits, 1) == 1 {
+			// First forward: slow AND failing — the retry arrives
+			// while this is still in flight.
+			time.Sleep(300 * time.Millisecond)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	t.Cleanup(gcStub.Close)
+	cfg := dedupTestConfig(t, gcStub.URL)
+
+	envBody := eventEnvelopeBody(t, "Ev0001", "1.0", "hi")
+	postSignedEvent(t, cfg, envBody) // async: forward now in flight
+	// Redelivery while the first forward is still running. The handler
+	// blocks on the in-flight claim, sees the failure verdict, and
+	// takes over.
+	postSignedEvent(t, cfg, envBody)
+	awaitInboundHits(t, &hits, 2)
+}
+
+// ...and if the in-flight first delivery SUCCEEDS, the waiting retry
+// drops as a duplicate.
+func TestHandleSlackEventsInflightRetryDropsAfterSuccess(t *testing.T) {
+	var hits int32
+	gcStub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.ReadAll(r.Body)
+		atomic.AddInt32(&hits, 1)
+		time.Sleep(300 * time.Millisecond)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	t.Cleanup(gcStub.Close)
+	cfg := dedupTestConfig(t, gcStub.URL)
+
+	envBody := eventEnvelopeBody(t, "Ev0001", "1.0", "hi")
+	postSignedEvent(t, cfg, envBody)
+	postSignedEvent(t, cfg, envBody) // waits on the in-flight claim, then drops
+	awaitInboundHits(t, &hits, 1)
+}

--- a/slack-full/adapter/file_share_gate_test.go
+++ b/slack-full/adapter/file_share_gate_test.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// Tests for the inbound message gate's file handling (hw-94w5k
+// finding #1): Slack delivers human file posts both as plain message
+// events with files[] (modern composer) and as subtype "file_share"
+// (older/API surfaces). Both must reach postInbound so the attachment
+// pipeline can run; file-only posts (no caption) must not be dropped
+// by the empty-text gate; every other subtype stays filtered.
+
+func fileGateConfig(gcURL string) config {
+	return config{
+		gcAPIBase:   gcURL,
+		cityName:    "test-city",
+		provider:    "slack",
+		accountID:   "T1",
+		dispatchSem: defaultTestDispatchSem,
+	}
+}
+
+// processAndSnapshot runs one event through processSlackEvent and
+// returns the inbounds captured by the gc stub after a settle window.
+func processAndSnapshot(t *testing.T, msg slackMessageEvent) []externalInboundMessage {
+	t.Helper()
+	capture := &inboundCapture{}
+	gcStub := httptest.NewServer(capture.handler())
+	t.Cleanup(gcStub.Close)
+
+	rawMsg, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal event: %v", err)
+	}
+	env := slackEventEnvelope{Type: "event_callback", Event: rawMsg}
+	processSlackEvent(fileGateConfig(gcStub.URL), newTestHandleAliasRegistry(t), nil, nil, nil, nil, env, func() {})
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(capture.snapshot()) > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return capture.snapshot()
+}
+
+func testSlackFile() slackFile {
+	return slackFile{ID: "F1", Name: "screenshot.png", MIMEType: "image/png"}
+}
+
+// A file_share-subtyped human message forwards to gc instead of being
+// dropped with the system-noise subtypes.
+func TestFileShareSubtypeForwards(t *testing.T) {
+	got := processAndSnapshot(t, slackMessageEvent{
+		Type: "message", Subtype: "file_share", Channel: "C1", User: "U1",
+		TS: "1.0", Text: "look at this", Files: []slackFile{testSlackFile()},
+	})
+	if len(got) != 1 {
+		t.Fatalf("captured %d inbound messages, want 1 (file_share must pass the subtype gate)", len(got))
+	}
+	if got[0].Text != "look at this" {
+		t.Errorf("forwarded text = %q, want %q", got[0].Text, "look at this")
+	}
+}
+
+// A file-only post — files attached, no caption — forwards despite the
+// empty text. (INBOUND_FILE_STORE is unset here so the attachment
+// download itself is skipped; the gate decision is what's under test.)
+func TestFileOnlyMessageForwards(t *testing.T) {
+	got := processAndSnapshot(t, slackMessageEvent{
+		Type: "message", Channel: "C1", User: "U1",
+		TS: "1.0", Text: "", Files: []slackFile{testSlackFile()},
+	})
+	if len(got) != 1 {
+		t.Fatalf("captured %d inbound messages, want 1 (file-only post must not be dropped)", len(got))
+	}
+}
+
+// Empty text with no files still drops — nothing to route.
+func TestEmptyMessageStillDropped(t *testing.T) {
+	got := processAndSnapshot(t, slackMessageEvent{
+		Type: "message", Channel: "C1", User: "U1", TS: "1.0", Text: "   ",
+	})
+	if len(got) != 0 {
+		t.Fatalf("captured %d inbound messages, want 0 (no text, no files)", len(got))
+	}
+}
+
+// Non-file_share subtypes stay filtered as system noise.
+func TestOtherSubtypesStillDropped(t *testing.T) {
+	for _, subtype := range []string{"message_changed", "message_deleted", "channel_join", "bot_message"} {
+		got := processAndSnapshot(t, slackMessageEvent{
+			Type: "message", Subtype: subtype, Channel: "C1", User: "U1",
+			TS: "1.0", Text: "hi", Files: []slackFile{testSlackFile()},
+		})
+		if len(got) != 0 {
+			t.Errorf("subtype %q: captured %d inbound messages, want 0", subtype, len(got))
+		}
+	}
+}
+
+// A bot-authored file_share stays dropped — the bot gate outranks the
+// file_share allowance (echo-loop protection).
+func TestBotFileShareStillDropped(t *testing.T) {
+	got := processAndSnapshot(t, slackMessageEvent{
+		Type: "message", Subtype: "file_share", Channel: "C1", User: "U1",
+		BotID: "B1", TS: "1.0", Text: "bot upload", Files: []slackFile{testSlackFile()},
+	})
+	if len(got) != 0 {
+		t.Fatalf("captured %d inbound messages, want 0 (bot file_share must stay dropped)", len(got))
+	}
+}

--- a/slack-full/adapter/main.go
+++ b/slack-full/adapter/main.go
@@ -4165,6 +4165,23 @@ func (r *handleAliasRegistry) Delete(handle string) (bool, error) {
 	return existed, nil
 }
 
+// DeleteIf removes handle only while it still maps to sessionID, under
+// one lock (codex r15): the launcher rollback's separate Get+Delete
+// left a window where a racing re-registration could be installed
+// between the check and the delete and then be unconditionally
+// removed, leaving that session unaddressable. Reports whether the
+// mapping was deleted.
+func (r *handleAliasRegistry) DeleteIf(handle, sessionID string) (bool, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	sid, ok := r.byHandle[handle]
+	if !ok || sid != sessionID {
+		return false, nil
+	}
+	delete(r.byHandle, handle)
+	return true, r.saveLocked()
+}
+
 func (r *handleAliasRegistry) load() error {
 	if r.diskPath == "" {
 		return nil

--- a/slack-full/adapter/main.go
+++ b/slack-full/adapter/main.go
@@ -1311,8 +1311,8 @@ func main() {
 	// proxies through /svc/{name}/ (proxy_process mode), or on a
 	// 127.0.0.1 TCP listener (legacy nohup mode).
 	internalMux := http.NewServeMux()
-	internalMux.HandleFunc("/publish", handlePublish(cfg, identityReg, userAliases, newPublishDedupCache(publishDedupTTL)))
-	internalMux.HandleFunc("/publish-file", handlePublishFile(cfg, identityReg))
+	internalMux.HandleFunc("/publish", handlePublish(cfg, identityReg, userAliases, aliasReg, newPublishDedupCache(publishDedupTTL)))
+	internalMux.HandleFunc("/publish-file", handlePublishFile(cfg, identityReg, aliasReg))
 	internalMux.HandleFunc("/react", handleReact(cfg))
 	internalMux.HandleFunc("POST /identity", handleIdentity(identityReg))
 	internalMux.HandleFunc("DELETE /identity", handleIdentityDelete(identityReg))
@@ -1562,7 +1562,7 @@ func (c *publishDedupCache) Put(key string, receipt publishReceipt) {
 	}
 }
 
-func handlePublish(cfg config, reg *identityRegistry, userAliases *userAliasMap, dedup *publishDedupCache) http.HandlerFunc {
+func handlePublish(cfg config, reg *identityRegistry, userAliases *userAliasMap, aliasReg *handleAliasRegistry, dedup *publishDedupCache) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -1666,7 +1666,7 @@ func handlePublish(cfg config, reg *identityRegistry, userAliases *userAliasMap,
 		// emoji. The dedup-replay path above returns earlier without
 		// re-checking: the original delivery already consumed the mark.
 		if receipt.Delivered {
-			clearBusyReaction(cfg, req.Conversation.ConversationID, req.ReplyToMessageID)
+			clearBusyReaction(cfg, aliasReg, identitySessionID, req.Conversation.ConversationID, req.ReplyToMessageID)
 		}
 		// Remember delivered receipts so a subsequent retry with the same
 		// idempotency key replays this receipt instead of re-posting. Put
@@ -1689,7 +1689,7 @@ func handlePublish(cfg config, reg *identityRegistry, userAliases *userAliasMap,
 // identity even when an identity record is registered for the source
 // session. This is a Slack platform limitation, not an adapter bug.
 // The identity lookup still happens for log parity with /publish.
-func handlePublishFile(cfg config, reg *identityRegistry) http.HandlerFunc {
+func handlePublishFile(cfg config, reg *identityRegistry, aliasReg *handleAliasRegistry) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -1834,7 +1834,7 @@ func handlePublishFile(cfg config, reg *identityRegistry) http.HandlerFunc {
 		// Busy-reaction lifecycle, remove side: a threaded file upload
 		// may be the agent's entire reply — it must clear the pending
 		// busy mark exactly like a text publish (hw-94w5k codex r1).
-		clearBusyReaction(cfg, req.Conversation.ConversationID, req.ReplyToMessageID)
+		clearBusyReaction(cfg, aliasReg, identitySessionID, req.Conversation.ConversationID, req.ReplyToMessageID)
 		writeJSON(w, receipt)
 	}
 }
@@ -2173,15 +2173,32 @@ func handleReact(cfg config) http.HandlerFunc {
 // in-flight add, Slack applies the delayed add after the remove, and
 // the busy emoji sticks forever. Best-effort and async — failures are
 // logged and never affect the caller's receipt.
-func clearBusyReaction(cfg config, conversationID, threadKey string) {
+// The publisher's session id gates WHICH marks the reply may clear
+// (codex r11): a mark recorded for handle H whose alias registry
+// entry resolves to a different session belongs to another agent —
+// M1 targeting A then M2 re-targeting B in the same thread must not
+// let A's late reply consume B's mark and strip B's hourglass before
+// B answered. Marks with no recorded handle, an unregistered handle,
+// or an unattributable publisher (empty session id) clear
+// unconditionally — the pre-r11 behavior.
+func clearBusyReaction(cfg config, aliasReg *handleAliasRegistry, publisherSessionID, conversationID, threadKey string) {
 	if cfg.busyReaction == "" || conversationID == "" {
 		return
 	}
+	allow := func(markHandle string) bool {
+		if markHandle == "" || aliasReg == nil || publisherSessionID == "" {
+			return true
+		}
+		if sid, ok := aliasReg.Get(markHandle); ok {
+			return sid == publisherSessionID
+		}
+		return true
+	}
 	var taken []busyTaken
 	if threadKey == "" {
-		taken = cfg.busyMarks.takeConversation(conversationID)
+		taken = cfg.busyMarks.takeConversation(conversationID, allow)
 	} else {
-		taken = cfg.busyMarks.take(conversationID, threadKey)
+		taken = cfg.busyMarks.take(conversationID, threadKey, allow)
 	}
 	for _, tk := range taken {
 		go removeBusyReaction(cfg, conversationID, tk)
@@ -2901,7 +2918,7 @@ func processSlackEvent(cfg config, aliasReg *handleAliasRegistry, threadReg *thr
 	var busyAddDone chan struct{}
 	var busyDisplacedMarks []busyDisplaced
 	if busyEligible {
-		busyAddDone, busyDisplacedMarks = cfg.busyMarks.markBoth(msg.Channel, msg.ThreadTS, msg.TS)
+		busyAddDone, busyDisplacedMarks = cfg.busyMarks.markBoth(msg.Channel, msg.ThreadTS, msg.TS, target)
 	}
 
 	if err := postInbound(cfg, inbound); err != nil {

--- a/slack-full/adapter/main.go
+++ b/slack-full/adapter/main.go
@@ -78,6 +78,15 @@
 //     recognized on inbound messages for
 //     keyword routing (e.g. "@name: text").
 //     Empty string disables routing.
+//   - BUSY_REACTION                Default "hourglass". Emoji name (no
+//     colons) added to a targeted inbound
+//     message when it is dispatched and removed
+//     when the agent's reply is published back
+//     into the same conversation/thread — the
+//     channel-native replacement for Slack
+//     Assistant-mode assistant.threads.setStatus
+//     (hq-xizo). Set-but-empty (BUSY_REACTION=)
+//     disables the lifecycle entirely.
 //   - IDENTITY_STORE_PATH          Default "/tmp/gc-slack-adapter/identities.json".
 //     JSON file backing the per-session
 //     chat:write.customize identity registry.
@@ -512,10 +521,36 @@ type config struct {
 	// every inbound then flows through the legacy path byte-for-byte.
 	// Wired in main() before any handler closes over the cfg value.
 	companyGateway *companyGateway
+	// busyReaction is the emoji name (no colons) added to a targeted
+	// inbound message when it is dispatched and removed when the
+	// agent's reply is published back into the same conversation/
+	// thread — the channel-native busy affordance replacing Slack
+	// Assistant-mode assistant.threads.setStatus (hq-xizo). Sourced
+	// from BUSY_REACTION, defaulting to busyReactionDefault
+	// ("hourglass"); the set-but-empty form (BUSY_REACTION=) yields ""
+	// here and disables the lifecycle entirely — no reaction is added
+	// and no mark is recorded. Replaces the previous unconditional
+	// "eyes" reaction on targeted inbounds.
+	busyReaction string
+	// busyMarks is the in-memory registry of pending busy reactions,
+	// keyed by (conversation id, thread key). processSlackEvent
+	// records a mark when it adds the busy reaction; handlePublish
+	// consumes it (and removes the reaction) when the reply lands.
+	// Nil-safe: mark/take on a nil registry are no-ops reporting no
+	// pending mark. Initialized in main(). hq-xizo.
+	busyMarks *busyReactionRegistry
+	// eventDedup is the short-TTL seen-set over Slack event_id that
+	// drops Events API redeliveries before they re-forward to gc.
+	// Slack retries any event delivery it considers unacknowledged
+	// (up to 3 times, minutes apart) and each retry carries the same
+	// event_id, so a hiccup on the first delivery otherwise turns
+	// into a duplicate session notification (hw-94w5k finding #4).
+	// Nil-safe: a nil cache never dedupes. Initialized in main().
+	eventDedup *eventDedupCache
 }
 
 func loadConfig() (config, error) {
-	return loadConfigFromEnv(os.Getenv)
+	return loadConfigFromLookup(os.LookupEnv)
 }
 
 // companyStateDirDefault resolves a Phase 2 shared-state directory default:
@@ -530,13 +565,31 @@ func companyStateDirDefault(cityPath, leaf string) string {
 	return filepath.Join("/tmp/gc-slack-adapter", leaf)
 }
 
-// loadConfigFromEnv reads adapter configuration from a getenv function. When
-// $GC_SERVICE_SOCKET is set, the adapter switches to proxy_process mode: it
-// binds a Unix domain socket for /publish (and /healthz) instead of an
-// internal TCP listener, and registers the callback URL gc routes through
-// its /svc/{name} mount. This keeps a single binary serving both the legacy
-// nohup-managed deployment and the proxy_process deployment.
+// loadConfigFromEnv reads adapter configuration from a plain getenv
+// function (os.Getenv shape: missing keys read as ""). It cannot
+// distinguish set-but-empty from unset, so vars whose empty form is
+// meaningful (BUSY_REACTION=) behave as unset through this entry
+// point; callers that need presence information use
+// loadConfigFromLookup directly.
 func loadConfigFromEnv(getenv func(string) string) (config, error) {
+	return loadConfigFromLookup(func(key string) (string, bool) {
+		v := getenv(key)
+		return v, v != ""
+	})
+}
+
+// loadConfigFromLookup reads adapter configuration from a lookup function
+// (os.LookupEnv shape). When $GC_SERVICE_SOCKET is set, the adapter switches
+// to proxy_process mode: it binds a Unix domain socket for /publish (and
+// /healthz) instead of an internal TCP listener, and registers the callback
+// URL gc routes through its /svc/{name} mount. This keeps a single binary
+// serving both the legacy nohup-managed deployment and the proxy_process
+// deployment.
+func loadConfigFromLookup(lookup func(string) (string, bool)) (config, error) {
+	getenv := func(key string) string {
+		v, _ := lookup(key)
+		return v
+	}
 	envOrFn := func(key, fallback string) string {
 		if v := getenv(key); v != "" {
 			return v
@@ -561,6 +614,19 @@ func loadConfigFromEnv(getenv func(string) string) (config, error) {
 		handleAliasStorePath: envOrFn("HANDLE_ALIAS_STORE_PATH", "/tmp/gc-slack-adapter/handle-aliases.json"),
 		inboundFileStore:     envOrFn("INBOUND_FILE_STORE", "/tmp/gc-slack-adapter/inbound"),
 		fileUploadRoot:       getenv("FILE_UPLOAD_ROOT"),
+	}
+
+	// BUSY_REACTION: emoji added to a targeted inbound while the agent
+	// works, removed when the reply publishes back (hq-xizo). Read
+	// through lookup (not envOrFn) because the set-but-empty form
+	// (BUSY_REACTION=) means "disable the lifecycle" and must not fall
+	// back to the default. Surrounding colons are stripped so operators
+	// can write ":hourglass:" or "hourglass" interchangeably, matching
+	// /react's emoji handling.
+	if v, ok := lookup("BUSY_REACTION"); ok {
+		cfg.busyReaction = strings.Trim(v, ":")
+	} else {
+		cfg.busyReaction = busyReactionDefault
 	}
 
 	// channelMappingPath default: prefer the city-rooted path when
@@ -942,6 +1008,10 @@ type reactRequest struct {
 	Conversation conversationRef `json:"conversation"`
 	MessageID    string          `json:"message_id"`
 	Emoji        string          `json:"emoji"`
+	// Remove selects reactions.remove instead of reactions.add
+	// (hq-xizo). Absent or false preserves the historical add-only
+	// behavior, so existing callers are unaffected.
+	Remove bool `json:"remove,omitempty"`
 }
 
 type reactReceipt struct {
@@ -1014,12 +1084,15 @@ type gcSessionMessageRequest struct {
 }
 
 type slackEventEnvelope struct {
-	Type      string          `json:"type"`
-	Challenge string          `json:"challenge,omitempty"`
-	TeamID    string          `json:"team_id,omitempty"`
-	APIAppID  string          `json:"api_app_id,omitempty"`
-	EventID   string          `json:"event_id,omitempty"`
-	Event     json.RawMessage `json:"event,omitempty"`
+	Type      string `json:"type"`
+	Challenge string `json:"challenge,omitempty"`
+	TeamID    string `json:"team_id,omitempty"`
+	APIAppID  string `json:"api_app_id,omitempty"`
+	// EventID is Slack's unique id for one event (Ev…). Retried
+	// deliveries of the same event carry the same event_id, which is
+	// what the redelivery seen-set keys on (hw-94w5k finding #4).
+	EventID string          `json:"event_id,omitempty"`
+	Event   json.RawMessage `json:"event,omitempty"`
 }
 
 // slackFile is a subset of Slack's file object, just the fields we need
@@ -1072,6 +1145,14 @@ func main() {
 	// Wire the process-wide thread-context cache. Nil-safe consumer
 	// path; only the production main() initializes it. gc-px8.5.
 	cfg.threadContextCache = newThreadContextCache()
+	// Wire the busy-reaction registry before the event and publish
+	// handlers close over cfg — both sides of the add-on-dispatch /
+	// remove-on-reply lifecycle must see the same map. Nil-safe
+	// consumer path (a nil registry just disables removal). hq-xizo.
+	cfg.busyMarks = newBusyReactionRegistry()
+	// Wire the Events API redelivery seen-set before handleSlackEvents
+	// closes over cfg. Nil-safe (nil disables dedup). hw-94w5k #4.
+	cfg.eventDedup = newEventDedupCache(eventDedupTTL)
 	internalDescr := cfg.internalListen
 	if cfg.serviceSocket != "" {
 		internalDescr = "uds:" + cfg.serviceSocket
@@ -1398,7 +1479,7 @@ func registerAdapter(cfg config) error {
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-GC-Request", "gc-slack-adapter")
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := gcForwardClient.Do(req)
 	if err != nil {
 		return err
 	}
@@ -1579,6 +1660,14 @@ func handlePublish(cfg config, reg *identityRegistry, userAliases *userAliasMap,
 			receipt.Delivered = true
 			receipt.MessageID = slackResp.TS
 		}
+		// Busy-reaction lifecycle, remove side (hq-xizo): a delivered
+		// publish into a conversation/thread carrying a pending busy
+		// mark means the agent's reply has landed — clear the busy
+		// emoji. The dedup-replay path above returns earlier without
+		// re-checking: the original delivery already consumed the mark.
+		if receipt.Delivered {
+			clearBusyReaction(cfg, req.Conversation.ConversationID, req.ReplyToMessageID)
+		}
 		// Remember delivered receipts so a subsequent retry with the same
 		// idempotency key replays this receipt instead of re-posting. Put
 		// ignores empty keys and non-delivered receipts.
@@ -1742,6 +1831,10 @@ func handlePublishFile(cfg config, reg *identityRegistry) http.HandlerFunc {
 
 		receipt.Delivered = true
 		receipt.FileID = urlResp.FileID
+		// Busy-reaction lifecycle, remove side: a threaded file upload
+		// may be the agent's entire reply — it must clear the pending
+		// busy mark exactly like a text publish (hw-94w5k codex r1).
+		clearBusyReaction(cfg, req.Conversation.ConversationID, req.ReplyToMessageID)
 		writeJSON(w, receipt)
 	}
 }
@@ -1886,7 +1979,7 @@ func slackGetUploadURL(token, filename string, length int) (*slackGetUploadURLRe
 	}
 	httpReq.Header.Set("Authorization", "Bearer "+token)
 	httpReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	httpResp, err := http.DefaultClient.Do(httpReq)
+	httpResp, err := slackAPIClient.Do(httpReq)
 	if err != nil {
 		return nil, err
 	}
@@ -1947,7 +2040,7 @@ func slackPutFileBytes(uploadURL string, filename string, body []byte) error {
 		return redactTransportError("build upload request to", safeURL, err)
 	}
 	req.Header.Set("Content-Type", mw.FormDataContentType())
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := slackUploadClient.Do(req)
 	if err != nil {
 		return redactTransportError("upload POST to", safeURL, err)
 	}
@@ -1975,7 +2068,7 @@ func slackCompleteUpload(token string, req slackCompleteUploadReq) (*slackComple
 	}
 	httpReq.Header.Set("Authorization", "Bearer "+token)
 	httpReq.Header.Set("Content-Type", "application/json; charset=utf-8")
-	httpResp, err := http.DefaultClient.Do(httpReq)
+	httpResp, err := slackAPIClient.Do(httpReq)
 	if err != nil {
 		return nil, err
 	}
@@ -1997,8 +2090,9 @@ func slackCompleteUpload(token string, req slackCompleteUploadReq) (*slackComple
 }
 
 // handleReact serves POST /react. It maps reactRequest → Slack
-// reactions.add. Emoji name is forwarded verbatim minus surrounding
-// colons (clients can send "eyes" or ":eyes:").
+// reactions.add, or reactions.remove when the request sets
+// remove:true (hq-xizo). Emoji name is forwarded verbatim minus
+// surrounding colons (clients can send "eyes" or ":eyes:").
 func handleReact(cfg config) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
@@ -2015,9 +2109,18 @@ func handleReact(cfg config) http.HandlerFunc {
 			http.Error(w, "conversation.conversation_id, message_id, and emoji are required", http.StatusBadRequest)
 			return
 		}
-		log.Printf("react: conv=%s ts=%s emoji=%s", req.Conversation.ConversationID, req.MessageID, emoji)
+		// Benign no-op errors mirror each other across the two ops:
+		// adding an emoji that is already on the message
+		// ("already_reacted") and removing one that is not there
+		// ("no_reaction") both leave the message in the requested
+		// state, so both count as delivered.
+		method, benignErr := "reactions.add", "already_reacted"
+		if req.Remove {
+			method, benignErr = "reactions.remove", "no_reaction"
+		}
+		log.Printf("react: op=%s conv=%s ts=%s emoji=%s", method, req.Conversation.ConversationID, req.MessageID, emoji)
 
-		slackResp, err := postReactionToSlack(cfg.slackBotToken, slackReactionsAddReq{
+		slackResp, err := callSlackReactions(cfg.slackBotToken, method, slackReactionsAddReq{
 			Channel:   req.Conversation.ConversationID,
 			Name:      emoji,
 			Timestamp: req.MessageID,
@@ -2025,14 +2128,13 @@ func handleReact(cfg config) http.HandlerFunc {
 		receipt := reactReceipt{}
 		switch {
 		case err != nil:
-			log.Printf("slack reactions.add error: %v", err)
+			log.Printf("slack %s error: %v", method, err)
 			receipt.FailureKind = "transient"
 		case !slackResp.OK:
-			// "already_reacted" is benign: the emoji is already on the message.
-			if slackResp.Error == "already_reacted" {
+			if slackResp.Error == benignErr {
 				receipt.Delivered = true
 			} else {
-				log.Printf("slack reactions.add returned error: %s", slackResp.Error)
+				log.Printf("slack %s returned error: %s", method, slackResp.Error)
 				switch slackResp.Error {
 				case "channel_not_found", "not_in_channel", "message_not_found":
 					receipt.FailureKind = "not_found"
@@ -2052,14 +2154,95 @@ func handleReact(cfg config) http.HandlerFunc {
 	}
 }
 
+// clearBusyReaction consumes pending busy mark(s) for a delivered
+// reply into conversationID and removes the busy emoji from the
+// marked message(s). threadKey is the reply's reply_to_message_id,
+// which matches the registry key in both inbound shapes: a
+// thread-reply inbound was marked under its thread_ts AND its own ts,
+// and a channel-root inbound under its own ts. An EMPTY threadKey is
+// the documented default `gc slack reply-current` shape — a
+// channel-root reply — and clears every pending mark in the
+// conversation (codex r3): the agent answered in-channel, and a busy
+// emoji nothing will ever remove is worse than clearing a sibling
+// thread's affordance early. Shared by handlePublish and
+// handlePublishFile — either reply shape (text or file) is the
+// agent's answer (hw-94w5k codex r1).
+//
+// Each removal waits for its mark's reactions.add to finish first
+// (bounded by busyReactionAddWait): a fast reply otherwise races the
+// in-flight add, Slack applies the delayed add after the remove, and
+// the busy emoji sticks forever. Best-effort and async — failures are
+// logged and never affect the caller's receipt.
+func clearBusyReaction(cfg config, conversationID, threadKey string) {
+	if cfg.busyReaction == "" || conversationID == "" {
+		return
+	}
+	var taken []busyTaken
+	if threadKey == "" {
+		taken = cfg.busyMarks.takeConversation(conversationID)
+	} else {
+		taken = cfg.busyMarks.take(conversationID, threadKey)
+	}
+	for _, tk := range taken {
+		go removeBusyReaction(cfg, conversationID, tk)
+	}
+}
+
+// removeBusyReaction removes the busy emoji from one marked message,
+// after its reactions.add has finished (bounded wait — see
+// clearBusyReaction). Also used to clean up marks superseded by a
+// re-target of the same thread (codex r3). Best-effort: errors are
+// logged only, and "no_reaction" is benign — the emoji already came
+// off (human removed it, or the add never landed).
+func removeBusyReaction(cfg config, channel string, tk busyTaken) {
+	if tk.addDone != nil {
+		select {
+		case <-tk.addDone:
+		case <-time.After(busyReactionAddWait):
+			log.Printf("busy reaction remove: chan=%s ts=%s: add still in flight after %v, removing anyway", channel, tk.messageTS, busyReactionAddWait)
+		}
+	}
+	resp, err := removeReactionFromSlack(cfg.slackBotToken, slackReactionsAddReq{
+		Channel:   channel,
+		Name:      cfg.busyReaction,
+		Timestamp: tk.messageTS,
+	})
+	if err != nil {
+		log.Printf("busy reaction remove failed: chan=%s ts=%s emoji=%s: %v", channel, tk.messageTS, cfg.busyReaction, err)
+		return
+	}
+	if !resp.OK && resp.Error != "no_reaction" {
+		log.Printf("busy reaction remove: chan=%s ts=%s emoji=%s: slack error=%s", channel, tk.messageTS, cfg.busyReaction, resp.Error)
+	}
+}
+
+// postReactionToSlack calls reactions.add for req over the timeout-bounded
+// slackAPIClient. The busy-reaction lifecycle orders its remove after this
+// add with a wait derived from slackAPIClient's timeout (hq-xizo), so the
+// add must stay on a bounded client.
 func postReactionToSlack(token string, req slackReactionsAddReq) (*slackReactionsAddResp, error) {
-	return postReactionMethod(http.DefaultClient, token, "reactions.add", req)
+	return callSlackReactions(token, "reactions.add", req)
+}
+
+// removeReactionFromSlack calls reactions.remove for req — same
+// request shape, auth, and slackAPIBase as reactions.add (hq-xizo).
+func removeReactionFromSlack(token string, req slackReactionsAddReq) (*slackReactionsAddResp, error) {
+	return callSlackReactions(token, "reactions.remove", req)
+}
+
+// callSlackReactions posts req to the given Slack reactions method
+// ("reactions.add" or "reactions.remove") over the timeout-bounded
+// slackAPIClient; the two endpoints share a request and response wire
+// shape.
+func callSlackReactions(token, method string, req slackReactionsAddReq) (*slackReactionsAddResp, error) {
+	return postReactionMethod(slackAPIClient, token, method, req)
 }
 
 // postReactionMethod is the single Slack reactions POST path, parameterized by
-// method ("reactions.add" | "reactions.remove") and HTTP client. handleReact
-// (add, DefaultClient) and the company visible-ack path (add/remove over the
-// gateway's timeout-bounded client) both route through here, so there is no
+// method ("reactions.add" | "reactions.remove") and HTTP client. The legacy
+// paths (handleReact, busy-reaction lifecycle — via callSlackReactions over
+// slackAPIClient) and the company visible-ack path (add/remove over the
+// gateway's timeout-bounded client) all route through here, so there is no
 // second reactions POST implementation.
 func postReactionMethod(client *http.Client, token, method string, req slackReactionsAddReq) (*slackReactionsAddResp, error) {
 	if client == nil {
@@ -2184,19 +2367,102 @@ func handleSlackEvents(cfg config, aliasReg *handleAliasRegistry, threadReg *thr
 
 		// Process event_callback. Always 200 quickly to avoid Slack retries.
 		w.WriteHeader(http.StatusOK)
-		release, capacity, ok := cfg.acquireDispatchSlot()
-		if !ok {
-			log.Printf("slack adapter: dispatch queue full (cap=%d), dropping slack event type=%q",
-				capacity, env.Type)
+		// Dedup Events API redeliveries. Slack retries any delivery it
+		// considers unacknowledged (network hiccup, slow first ack, its
+		// own read timeout) with the SAME event_id, and every retry that
+		// slips through forwards a duplicate notification into the bound
+		// session (hw-94w5k finding #4: byte-identical inbound log pairs).
+		// The 200 above already acknowledged this delivery, so a drop
+		// below is safe. Keyed on event_id only — it is unique per
+		// event and stable across retries. Envelopes without an
+		// event_id (not event_callback shaped) are never deduped.
+		//
+		// The claim is taken SYNCHRONOUSLY, before load shedding
+		// (codex r9): two simultaneous deliveries of one event both
+		// racing an async claim could otherwise each read "unknown",
+		// with the loser dropped at the queue-full check — and if the
+		// winner's forward then failed, that dropped, already-acked
+		// copy was the event's only recovery. With the claim taken
+		// here, exactly one delivery owns the event; every other copy
+		// either drops (committed) or parks slotless (in flight).
+		// Cheap in-memory op — the handler still acks promptly.
+		retryNum := r.Header.Get("X-Slack-Retry-Num")
+		proceed, wait := cfg.eventDedup.begin(env.EventID)
+		if !proceed && wait == nil {
+			log.Printf("slack event dedup: dropping redelivery event_id=%s retry_num=%q team_id=%q",
+				env.EventID, retryNum, clipTeamIDForLog(env.TeamID))
 			return
 		}
+		var release func()
+		if proceed {
+			// This delivery owns the event: contend at the nonblocking
+			// load-shed. On queue-full the claim is forgotten so a
+			// parked or future copy can take over — the event is only
+			// lost if no other copy exists, which is the accepted
+			// saturation-shedding behavior for unowned events too.
+			var capacity int
+			var ok bool
+			release, capacity, ok = cfg.acquireDispatchSlot()
+			if !ok {
+				cfg.eventDedup.forget(env.EventID)
+				log.Printf("slack adapter: dispatch queue full (cap=%d), dropping slack event type=%q event_id=%q",
+					capacity, env.Type, env.EventID)
+				return
+			}
+		}
+		// A redelivery that races the FIRST delivery's still-running
+		// forward must not be discarded: if that forward then fails,
+		// the discarded retry was the message's last chance (Slack got
+		// a 200 for it and stops the ladder). It parks — slotless, in
+		// a goroutine, so the handler returns and net/http FINISHES
+		// the 200 before any waiting happens (codex r3 P2) — until the
+		// in-flight claim concludes: commit → drop, forget → take over
+		// (blocking-acquiring a fresh slot; codex r5). Parked
+		// goroutines cannot leak because every claim concludes
+		// (bounded gc forwards + conclude-on-every-return in
+		// processSlackEvent).
+		//
 		// Slot ownership transfers to processSlackEvent, which either
 		// releases on its own return path or hands the slot to its
 		// alias-dispatch goroutine. This avoids double-counting against
 		// cfg.dispatchSem when an inbound triggers an alias dispatch (which
 		// would otherwise hold two slots concurrently — see gc-cby.26
-		// Phase 4 review fix).
-		go processSlackEvent(cfg, aliasReg, threadReg, roomLaunchReg, subteamMap, threadHandleSticky, env, release)
+		// Phase 4 review fix). The drop paths below release explicitly.
+		go func() {
+			ownsSlot := release != nil
+			for !proceed {
+				for parked := true; parked; {
+					select {
+					case <-wait:
+						parked = false
+					case <-time.After(eventDedupParkLogInterval):
+						log.Printf("slack event dedup: redelivery of event_id=%s still parked behind an in-flight delivery (retry_num=%q)",
+							env.EventID, retryNum)
+					}
+				}
+				proceed, wait = cfg.eventDedup.begin(env.EventID)
+				if !proceed && wait == nil {
+					log.Printf("slack event dedup: dropping redelivery event_id=%s retry_num=%q team_id=%q",
+						env.EventID, retryNum, clipTeamIDForLog(env.TeamID))
+					return
+				}
+			}
+			if !ownsSlot {
+				// Taking over after a parked wait: the original slot
+				// went back to the pool, so contend for a fresh one —
+				// BLOCKING, unlike the handler's entry check. This
+				// delivery already got its 200 and may be the event's
+				// only remaining copy, so a queue-full drop here would
+				// lose it permanently (codex r5). The blocked
+				// goroutine holds no slot and every slot holder
+				// releases in bounded time, so this always makes
+				// progress; new deliveries still shed load at the
+				// handler's nonblocking check.
+				cfg.dispatchSem <- struct{}{}
+				release = func() { <-cfg.dispatchSem }
+			}
+			processSlackEvent(cfg, aliasReg, threadReg, roomLaunchReg, subteamMap, threadHandleSticky, env, release)
+		}()
 	}
 }
 
@@ -2416,6 +2682,19 @@ func processSlackEvent(cfg config, aliasReg *handleAliasRegistry, threadReg *thr
 			release()
 		}
 	}()
+	// Conclude the dedup claim begun in handleSlackEvents: every path
+	// out of this function is a final handling of the event — noise
+	// drops included, a redelivery would take the identical path — so
+	// the default verdict is commit. The one exception is a failed
+	// forward to gc, which flips this off and forgets the id so a
+	// redelivery can take over (codex r2 P1). No-op when the envelope
+	// carries no event_id or the cache is nil.
+	commitDedup := true
+	defer func() {
+		if commitDedup {
+			cfg.eventDedup.commit(env.EventID)
+		}
+	}()
 	if env.Type != "event_callback" || len(env.Event) == 0 {
 		return
 	}
@@ -2427,11 +2706,21 @@ func processSlackEvent(cfg config, aliasReg *handleAliasRegistry, threadReg *thr
 	if msg.Type != "message" && msg.Type != "app_mention" {
 		return
 	}
-	// Skip bot/system messages.
-	if msg.BotID != "" || msg.Subtype != "" || msg.User == "" {
+	// Skip bot/system messages. Subtyped messages are system noise
+	// (message_changed, message_deleted, channel_join, bot_message, …)
+	// with one exception: "file_share" is a human posting a file and
+	// must flow through so downloadSlackFiles can fetch the
+	// attachment. Slack delivers file posts both ways — the modern
+	// composer emits a plain message event with files[] and no
+	// subtype, older/API surfaces emit subtype "file_share" — and
+	// dropping the latter silently loses the upload (hw-94w5k #1).
+	if msg.BotID != "" || (msg.Subtype != "" && msg.Subtype != "file_share") || msg.User == "" {
 		return
 	}
-	if strings.TrimSpace(msg.Text) == "" {
+	// A message with neither text nor files carries nothing to route.
+	// Files without a caption are common (a teammate drops a
+	// screenshot and says nothing) and must not be discarded.
+	if strings.TrimSpace(msg.Text) == "" && len(msg.Files) == 0 {
 		return
 	}
 
@@ -2445,7 +2734,15 @@ func processSlackEvent(cfg config, aliasReg *handleAliasRegistry, threadReg *thr
 	// existing alias dispatch behavior is unchanged.
 	if cfg.handlePrefix != "" && threadReg != nil {
 		if h, remainder, ok := parseDoubleHandlePrefix(msg.Text, cfg.handlePrefix); ok {
-			handleDoubleHandleDispatch(cfg, aliasReg, threadReg, roomLaunchReg, msg, env.TeamID, h, remainder)
+			// A transient launcher failure (spawn / first-message
+			// forward) forgets the dedup claim so a Slack redelivery
+			// retries it — same contract as the postInbound and alias
+			// failure paths (codex r6). Terminal outcomes (delivered,
+			// user-error ephemerals) commit via the defer.
+			if !handleDoubleHandleDispatch(cfg, aliasReg, threadReg, roomLaunchReg, msg, env.TeamID, h, remainder) {
+				commitDedup = false
+				cfg.eventDedup.forget(env.EventID)
+			}
 			return
 		}
 	}
@@ -2574,36 +2871,90 @@ func processSlackEvent(cfg config, aliasReg *handleAliasRegistry, threadReg *thr
 		DedupKey:         "slack-" + msg.TS,
 		ReceivedAt:       time.Now().UTC(),
 	}
+	// Busy-reaction lifecycle, mark registration (hq-xizo; replaces the
+	// earlier unconditional "eyes" reaction). The reaction signals to
+	// the human that an agent was explicitly addressed (via `@handle:`
+	// prefix or a Slack User Group mention resolved via subteamAliasMap)
+	// and is working on the message; handlePublish removes it when the
+	// agent's reply lands in the same conversation/thread — the
+	// channel-native replacement for Slack Assistant-mode
+	// assistant.threads.setStatus, which this adapter deliberately does
+	// not use. Only fires when a target was parsed — generic channel
+	// chatter that merely lands on the bound session via postInbound
+	// does NOT trigger it, because most channel messages aren't
+	// intentionally directed at an agent.
+	//
+	// The MARK is recorded BEFORE the forward (codex r4): gc can hand
+	// the inbound to the agent — and the agent can /publish a reply —
+	// before postInbound's response even returns here, and a reply
+	// that finds no mark would leave the subsequently-added emoji
+	// stuck forever. The reactions.add itself still fires only after
+	// the forward succeeds (an emoji on a message no agent received
+	// would be a lie); a failed forward cancels the mark. A mark whose
+	// reply never arrives expires after busyReactionTTL. If alias
+	// dispatch later fails, reactAliasDispatchFailure posts ⚠️ on the
+	// same TS — semantically distinct (busy affordance vs. delivery
+	// failure). Best-effort: errors are logged and don't block the
+	// dispatch path. BUSY_REACTION= (set-but-empty) disables all of
+	// this — no reaction, no mark.
+	busyEligible := target != "" && cfg.slackBotToken != "" && cfg.busyReaction != ""
+	var busyAddDone chan struct{}
+	var busyDisplacedMarks []busyDisplaced
+	if busyEligible {
+		busyAddDone, busyDisplacedMarks = cfg.busyMarks.markBoth(msg.Channel, msg.ThreadTS, msg.TS)
+	}
+
 	if err := postInbound(cfg, inbound); err != nil {
 		log.Printf("inbound POST failed: %v", err)
+		// Nothing reached gc. Cancel the busy mark FIRST — no agent
+		// received the message, so no reply will ever come to clear
+		// it — restoring any marks it displaced (their agents may
+		// still be working, codex r5). Only THEN release the dedup
+		// claim: forget wakes a parked redelivery, and it must not
+		// re-mark this timestamp while the old attempt's cancellation
+		// is still pending (a late cancel would delete the retry's
+		// fresh mark and strand its hourglass).
+		if busyEligible {
+			// Marks whose thread a reply already consumed cannot be
+			// restored (tombstoned) — remove their reactions instead
+			// (codex r8).
+			for _, tk := range cfg.busyMarks.cancelBoth(msg.Channel, msg.ThreadTS, msg.TS, busyAddDone, busyDisplacedMarks) {
+				go removeBusyReaction(cfg, msg.Channel, tk)
+			}
+		}
+		commitDedup = false
+		cfg.eventDedup.forget(env.EventID)
 		return
 	}
 	log.Printf("inbound: chan=%s user=%s ts=%s thread=%s target=%q files=%d text=%dch",
 		msg.Channel, msg.User, msg.TS, msg.ThreadTS, target, len(attachments), len(text))
 
-	// "Eyes" reaction signals to the human that an agent was explicitly
-	// addressed (via `@handle:` prefix or a Slack User Group mention
-	// resolved via subteamAliasMap) and is processing the message. Only
-	// fires when a target was parsed — generic channel chatter that
-	// merely lands on the bound session via postInbound does NOT trigger
-	// the eye, because most channel messages aren't intentionally
-	// directed at an agent. Fires once per inbound (the alias-dispatch
-	// fanout below targets the same Slack TS, so a duplicate react would
-	// be a Slack no-op). If alias dispatch later fails, reactAliasDispatchFailure
-	// posts ⚠️ on the same TS — that is semantically distinct (transport-layer
-	// ack vs. delivery failure) and not a duplicate. Best-effort: errors are
-	// logged and don't block the dispatch path.
-	if target != "" && cfg.slackBotToken != "" {
-		go func(channel, ts string) {
+	// Busy-reaction lifecycle, add side: fires once per inbound (the
+	// alias-dispatch fanout below targets the same Slack TS, so a
+	// duplicate react would be a Slack no-op). Marks displaced by this
+	// re-target are cleaned up only after the FINAL delivery for this
+	// event succeeded — postInbound for plain channel routing, the
+	// alias POST when an alias dispatch fires (codex r3 + r5 + r7):
+	// their messages still wear the busy emoji and nothing else would
+	// ever remove it, but removing before the event's outcome is
+	// known could strip an affordance whose agent is still working.
+	// The affordance moves to the newest targeted message. See the
+	// displaced-cleanup dispatch after the alias block.
+	if busyEligible {
+		go func(channel, ts, emoji string, addDone chan struct{}) {
+			// Closing addDone releases any remove waiting to run
+			// after this add (clearBusyReaction orders remove-after-
+			// add so a fast reply cannot leave a stale busy emoji).
+			defer close(addDone)
 			_, err := postReactionToSlack(cfg.slackBotToken, slackReactionsAddReq{
 				Channel:   channel,
-				Name:      "eyes",
+				Name:      emoji,
 				Timestamp: ts,
 			})
 			if err != nil {
-				log.Printf("react eyes failed: chan=%s ts=%s: %v", channel, ts, err)
+				log.Printf("react busy %s failed: chan=%s ts=%s: %v", emoji, channel, ts, err)
 			}
-		}(msg.Channel, msg.TS)
+		}(msg.Channel, msg.TS, cfg.busyReaction, busyAddDone)
 	}
 
 	// Cross-channel address-by-handle: if the parsed target matches a
@@ -2612,6 +2963,7 @@ func processSlackEvent(cfg config, aliasReg *handleAliasRegistry, threadReg *thr
 	// binding. The originating channel's bound session still sees the
 	// inbound (above) and is expected to stay silent (per its prompt)
 	// because target != its handle.
+	displacedOwned := false
 	if target != "" && aliasReg != nil {
 		if aliasedSessionID, ok := aliasReg.Get(target); ok {
 			// Thread-stickiness bind: record (channel, msg.TS) -> target
@@ -2627,16 +2979,82 @@ func processSlackEvent(cfg config, aliasReg *handleAliasRegistry, threadReg *thr
 			// Transfer the slot we already hold to the alias goroutine.
 			// No new acquireDispatchSlot — that would double-count
 			// against dispatchSem (gc-cby.26 Phase 4 review fix).
+			//
+			// The dedup verdict transfers with it (codex r3 P1): for a
+			// targeted inbound the alias dispatch IS the delivery to
+			// the addressed session, so committing at processSlackEvent
+			// return would drop a waiting Slack redelivery even when
+			// this dispatch then fails. Success commits; failure
+			// forgets so the redelivery can take over. The retaken
+			// delivery re-runs postInbound too — a duplicate for the
+			// channel-bound session (which self-dedupes by message ts)
+			// is the acceptable cost of not losing the addressed
+			// session's copy.
+			commitDedup = false
+			displacedOwned = true
 			released = true
 			dispatchInflightWG.Add(1)
-			go func() {
+			go func(displaced []busyDisplaced) {
 				defer dispatchInflightWG.Done()
 				defer release()
-				if !dispatchToAliasedSession(cfg, aliasedSessionID, inbound, target) {
-					reactAliasDispatchFailure(cfg.slackBotToken,
-						inbound.Conversation.ConversationID, inbound.ProviderMessageID)
+				if dispatchToAliasedSession(cfg, aliasedSessionID, inbound, target) {
+					// Final delivery landed: NOW retire the marks
+					// this re-target displaced (codex r7).
+					for _, d := range displaced {
+						go removeBusyReaction(cfg, inbound.Conversation.ConversationID, d.mark)
+					}
+					cfg.eventDedup.commit(env.EventID)
+					return
 				}
-			}()
+				// The busy reaction was already launched for this
+				// message, but no reply is coming — the addressed
+				// session never got it and the channel-bound session
+				// stays silent — so without cleanup the hourglass
+				// sits forever next to the ⚠️ (codex r6). The removal
+				// runs SYNCHRONOUSLY and completes before forget wakes
+				// any parked retry: an async removal could otherwise
+				// land after the retry's re-add (already_reacted) and
+				// strip the recovered attempt's emoji (codex r7). The
+				// marks this attempt displaced are restored — their
+				// agents may still be working (codex r7).
+				if cfg.busyReaction != "" {
+					// ALL registry mutations happen before any Slack
+					// network I/O (codex r10): take this message's
+					// marks and restore the displaced ones first —
+					// both are instant in-memory ops — so a displaced
+					// agent's reply arriving during the (bounded, up
+					// to add-wait + Slack timeout) removal calls below
+					// finds its restored mark and clears normally
+					// instead of missing the registry entirely.
+					taken := cfg.busyMarks.takeMessage(
+						inbound.Conversation.ConversationID, inbound.ReplyToMessageID, inbound.ProviderMessageID)
+					// Displaced marks whose thread a reply consumed
+					// while this dispatch was in flight cannot be
+					// restored (tombstoned) — remove their reactions
+					// instead (codex r8).
+					blocked := cfg.busyMarks.restoreDisplaced(inbound.Conversation.ConversationID, displaced)
+					for _, tk := range taken {
+						removeBusyReaction(cfg, inbound.Conversation.ConversationID, tk)
+					}
+					for _, tk := range blocked {
+						go removeBusyReaction(cfg, inbound.Conversation.ConversationID, tk)
+					}
+				}
+				cfg.eventDedup.forget(env.EventID)
+				reactAliasDispatchFailure(cfg.slackBotToken,
+					inbound.Conversation.ConversationID, inbound.ProviderMessageID)
+			}(busyDisplacedMarks)
+		}
+	}
+
+	// No alias dispatch owns this event: postInbound was the final
+	// delivery and it succeeded, so retire the displaced marks now
+	// (codex r7 — when an alias dispatch fires, ITS success branch
+	// does this instead, because the alias POST is the delivery that
+	// decides the event).
+	if busyEligible && !displacedOwned {
+		for _, d := range busyDisplacedMarks {
+			go removeBusyReaction(cfg, msg.Channel, d.mark)
 		}
 	}
 }
@@ -3924,7 +4342,7 @@ func dispatchToAliasedSession(cfg config, sessionID string, msg externalInboundM
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-GC-Request", "gc-slack-adapter-alias")
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := gcForwardClient.Do(req)
 	if err != nil {
 		log.Printf("alias dispatch: POST %s: %v", target, err)
 		return false
@@ -4037,6 +4455,27 @@ func handleIdentityDelete(reg *identityRegistry) http.HandlerFunc {
 	}
 }
 
+// gcForwardClient bounds every adapter→gc control-plane call
+// (postInbound, adapter registration, alias dispatch). These ran on
+// http.DefaultClient with no timeout, which let a hung gc keep a
+// dedup claim undecided indefinitely — parking acked Slack
+// redeliveries forever (codex r4). 20 seconds is generous for a
+// same-host API; a timeout surfaces as a normal forward failure,
+// which forgets the claim so a redelivery can take over.
+var gcForwardClient = &http.Client{Timeout: 20 * time.Second}
+
+// slackAPIClient bounds Slack Web API JSON calls (chat.postMessage,
+// reactions, ephemerals, upload bookkeeping). Every synchronous call
+// reachable while a dedup claim is open must conclude, or parked
+// redeliveries wait forever (codex r5); the rest simply shouldn't
+// hang goroutines on a stalled upstream either.
+var slackAPIClient = &http.Client{Timeout: 30 * time.Second}
+
+// slackUploadClient bounds the pre-signed file-bytes POST, which
+// carries whole file payloads and deserves a longer leash than the
+// JSON calls.
+var slackUploadClient = &http.Client{Timeout: 120 * time.Second}
+
 func postInbound(cfg config, msg externalInboundMessage) error {
 	body, _ := json.Marshal(map[string]any{
 		"message": msg,
@@ -4049,7 +4488,7 @@ func postInbound(cfg config, msg externalInboundMessage) error {
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-GC-Request", "gc-slack-adapter")
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := gcForwardClient.Do(req)
 	if err != nil {
 		return err
 	}

--- a/slack-full/adapter/main.go
+++ b/slack-full/adapter/main.go
@@ -2035,7 +2035,18 @@ func slackPutFileBytes(uploadURL string, filename string, body []byte) error {
 	if err := mw.Close(); err != nil {
 		return fmt.Errorf("close multipart writer: %w", err)
 	}
-	req, err := http.NewRequest(http.MethodPost, uploadURL, &buf)
+	// Size-aware deadline (codex r17): the fixed 120s client rejected
+	// otherwise-valid large/slow uploads (a 1 GB file needs >2 min
+	// below ~67 Mb/s). Grant the base window plus 1 MiB/s of transfer
+	// budget, capped at 30 minutes — the handler imposes no file-size
+	// limit, so the deadline must scale with the payload instead.
+	deadline := uploadBaseTimeout + time.Duration(buf.Len()/(1<<20))*time.Second
+	if deadline > uploadMaxTimeout {
+		deadline = uploadMaxTimeout
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), deadline)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, uploadURL, &buf)
 	if err != nil {
 		return redactTransportError("build upload request to", safeURL, err)
 	}
@@ -4519,10 +4530,20 @@ var gcForwardClient = &http.Client{Timeout: 20 * time.Second}
 // hang goroutines on a stalled upstream either.
 var slackAPIClient = &http.Client{Timeout: 30 * time.Second}
 
-// slackUploadClient bounds the pre-signed file-bytes POST, which
-// carries whole file payloads and deserves a longer leash than the
-// JSON calls.
-var slackUploadClient = &http.Client{Timeout: 120 * time.Second}
+// slackUploadClient carries the pre-signed file-bytes POST. It has NO
+// client-level timeout: slackPutFileBytes applies a per-request
+// size-aware deadline (uploadBaseTimeout + 1s per MiB, capped at
+// uploadMaxTimeout), because a fixed window rejected valid large or
+// slow uploads (codex r17). Every request through it is
+// context-bounded, so goroutines still cannot hang on a stalled
+// upstream.
+var slackUploadClient = &http.Client{}
+
+// uploadBaseTimeout is the floor every upload gets regardless of size.
+const uploadBaseTimeout = 120 * time.Second
+
+// uploadMaxTimeout caps the size-scaled upload deadline.
+const uploadMaxTimeout = 30 * time.Minute
 
 func postInbound(cfg config, msg externalInboundMessage) error {
 	body, _ := json.Marshal(map[string]any{

--- a/slack-full/adapter/main.go
+++ b/slack-full/adapter/main.go
@@ -2921,7 +2921,15 @@ func processSlackEvent(cfg config, aliasReg *handleAliasRegistry, threadReg *thr
 		busyAddDone, busyDisplacedMarks = cfg.busyMarks.markBoth(msg.Channel, msg.ThreadTS, msg.TS, target)
 	}
 
-	if err := postInbound(cfg, inbound); err != nil {
+	// A retaken redelivery whose channel leg already reached gc must
+	// not re-run postInbound — core does not consume DedupKey, so the
+	// bound session would receive a duplicate turn (codex r12). Only
+	// the failed alias leg below is retried.
+	channelLegDone := cfg.eventDedup.isChannelLegDone(env.EventID)
+	if channelLegDone {
+		log.Printf("inbound: channel leg already delivered event=%s chan=%s ts=%s — retrying alias leg only",
+			env.EventID, msg.Channel, msg.TS)
+	} else if err := postInbound(cfg, inbound); err != nil {
 		log.Printf("inbound POST failed: %v", err)
 		// Nothing reached gc. Cancel the busy mark FIRST — no agent
 		// received the message, so no reply will ever come to clear
@@ -2942,9 +2950,10 @@ func processSlackEvent(cfg config, aliasReg *handleAliasRegistry, threadReg *thr
 		commitDedup = false
 		cfg.eventDedup.forget(env.EventID)
 		return
+	} else {
+		log.Printf("inbound: chan=%s user=%s ts=%s thread=%s target=%q files=%d text=%dch",
+			msg.Channel, msg.User, msg.TS, msg.ThreadTS, target, len(attachments), len(text))
 	}
-	log.Printf("inbound: chan=%s user=%s ts=%s thread=%s target=%q files=%d text=%dch",
-		msg.Channel, msg.User, msg.TS, msg.ThreadTS, target, len(attachments), len(text))
 
 	// Busy-reaction lifecycle, add side: fires once per inbound (the
 	// alias-dispatch fanout below targets the same Slack TS, so a
@@ -3057,6 +3066,11 @@ func processSlackEvent(cfg config, aliasReg *handleAliasRegistry, threadReg *thr
 						go removeBusyReaction(cfg, inbound.Conversation.ConversationID, tk)
 					}
 				}
+				// Remember the completed channel leg BEFORE forget
+				// wakes any parked retry (codex r12): the retaken
+				// delivery then skips postInbound and re-runs only
+				// this failed alias dispatch.
+				cfg.eventDedup.markChannelLegDone(env.EventID)
 				cfg.eventDedup.forget(env.EventID)
 				reactAliasDispatchFailure(cfg.slackBotToken,
 					inbound.Conversation.ConversationID, inbound.ProviderMessageID)

--- a/slack-full/adapter/main_test.go
+++ b/slack-full/adapter/main_test.go
@@ -323,6 +323,34 @@ func TestHandleReact(t *testing.T) {
 			wantSlackPath: "/reactions.add",
 		},
 		{
+			name:          "remove:true issues reactions.remove",
+			method:        http.MethodPost,
+			body:          `{"conversation":{"conversation_id":"C123"},"message_id":"1.2","emoji":"hourglass","remove":true}`,
+			slackResponse: `{"ok":true}`,
+			wantStatus:    http.StatusOK,
+			wantDelivered: true,
+			wantSlackPath: "/reactions.remove",
+		},
+		{
+			name:          "no_reaction on remove is benign success",
+			method:        http.MethodPost,
+			body:          `{"conversation":{"conversation_id":"C123"},"message_id":"1.2","emoji":"hourglass","remove":true}`,
+			slackResponse: `{"ok":false,"error":"no_reaction"}`,
+			wantStatus:    http.StatusOK,
+			wantDelivered: true,
+			wantSlackPath: "/reactions.remove",
+		},
+		{
+			name:          "channel_not_found on remove maps to not_found",
+			method:        http.MethodPost,
+			body:          `{"conversation":{"conversation_id":"C123"},"message_id":"1.2","emoji":"hourglass","remove":true}`,
+			slackResponse: `{"ok":false,"error":"channel_not_found"}`,
+			wantStatus:    http.StatusOK,
+			wantDelivered: false,
+			wantFailKind:  "not_found",
+			wantSlackPath: "/reactions.remove",
+		},
+		{
 			name:       "GET rejected",
 			method:     http.MethodGet,
 			body:       "",
@@ -2236,7 +2264,13 @@ func TestHandlePublishFile(t *testing.T) {
 // reading a regular file inside the upload root must succeed and return
 // the file's bytes verbatim.
 func TestReadConfinedFileReadsRealFile(t *testing.T) {
-	dir := t.TempDir()
+	// Canonicalize: readConfinedFile's contract is an EvalSymlinks-resolved
+	// path, and on darwin t.TempDir() sits under the /var -> /private/var
+	// symlink.
+	dir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatalf("EvalSymlinks: %v", err)
+	}
 	path := filepath.Join(dir, "real.txt")
 	want := []byte("hello world")
 	if err := os.WriteFile(path, want, 0o600); err != nil {
@@ -2256,12 +2290,18 @@ func TestReadConfinedFileReadsRealFile(t *testing.T) {
 // In production the call site has already EvalSymlinks-resolved the path
 // to a canonical target with no symlinks; if a symlink appears at the leaf
 // between the confinement re-check and the read, an attacker would have
-// swapped the inode in the race window. O_NOFOLLOW makes that swap visible
-// as ELOOP rather than silent arbitrary-read. Both Linux and macOS return
-// ELOOP from open(2) with O_NOFOLLOW on a symlink — errors.Is unwraps
-// through *os.PathError to the underlying syscall.Errno.
+// swapped the inode in the race window. The open must fail rather than
+// silently read through the link. The exact error depends on which layer
+// trips first: O_NOFOLLOW on the leaf yields ELOOP, while os.Root's
+// resolution reports an absolute-target symlink as escaping the root
+// before the leaf open happens. Either way the swap is detected.
 func TestReadConfinedFileRejectsSymlink(t *testing.T) {
-	dir := t.TempDir()
+	// Canonical dir, non-canonical leaf: the symlink at the leaf is the
+	// simulated race-window inode swap and must stay unresolved.
+	dir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatalf("EvalSymlinks: %v", err)
+	}
 	target := filepath.Join(dir, "target.txt")
 	if err := os.WriteFile(target, []byte("secret"), 0o600); err != nil {
 		t.Fatalf("write target: %v", err)
@@ -2271,12 +2311,13 @@ func TestReadConfinedFileRejectsSymlink(t *testing.T) {
 		t.Fatalf("symlink: %v", err)
 	}
 
-	_, err := readConfinedFile(dir, link)
+	_, err = readConfinedFile(dir, link)
 	if err == nil {
 		t.Fatal("readConfinedFile(symlink): want error, got nil — TOCTOU window unclosed")
 	}
-	if !errors.Is(err, syscall.ELOOP) {
-		t.Errorf("readConfinedFile(symlink) error = %v, want ELOOP", err)
+	if !errors.Is(err, syscall.ELOOP) && !strings.Contains(err.Error(), "escapes") &&
+		!strings.Contains(err.Error(), "is a symlink") {
+		t.Errorf("readConfinedFile(symlink) error = %v, want ELOOP / root-escape / leaf-symlink rejection", err)
 	}
 }
 
@@ -4120,21 +4161,41 @@ func TestLoadConfigDispatchConcurrencyRejectsNonNumeric(t *testing.T) {
 }
 
 // captureLog redirects log.Printf output to an in-memory buffer for
-// the duration of the returned cleanup. Caller must not call t.Parallel.
+// the duration of the returned cleanup. Caller must not call
+// t.Parallel. The buffer is mutex-guarded so read() is safe while
+// async goroutines under test are still logging.
 func captureLog(t *testing.T) (read func() string, cleanup func()) {
 	t.Helper()
 	prevOut := log.Writer()
 	prevFlags := log.Flags()
 	prevPrefix := log.Prefix()
-	var buf strings.Builder
-	log.SetOutput(&buf)
+	w := &lockedLogBuffer{}
+	log.SetOutput(w)
 	log.SetFlags(0)
 	log.SetPrefix("")
-	return func() string { return buf.String() }, func() {
+	return w.String, func() {
 		log.SetOutput(prevOut)
 		log.SetFlags(prevFlags)
 		log.SetPrefix(prevPrefix)
 	}
+}
+
+// lockedLogBuffer is a mutex-guarded strings.Builder for captureLog.
+type lockedLogBuffer struct {
+	mu  sync.Mutex
+	buf strings.Builder
+}
+
+func (b *lockedLogBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *lockedLogBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
 }
 
 // TestProcessSlackEventReleasesSlotOnNoAliasPath verifies the

--- a/slack-full/adapter/main_test.go
+++ b/slack-full/adapter/main_test.go
@@ -655,7 +655,7 @@ func TestHandlePublishInjectsIdentity(t *testing.T) {
 			cfg := config{slackBotToken: "xoxb-test"}
 			req := httptest.NewRequest(http.MethodPost, "/publish", strings.NewReader(tc.publishBody))
 			rec := httptest.NewRecorder()
-			handlePublish(cfg, reg, nil, newPublishDedupCache(publishDedupTTL))(rec, req)
+			handlePublish(cfg, reg, nil, nil, newPublishDedupCache(publishDedupTTL))(rec, req)
 
 			if rec.Code != http.StatusOK {
 				t.Fatalf("status = %d, want 200 (body=%q)", rec.Code, rec.Body.String())
@@ -723,7 +723,7 @@ func TestHandlePublishIdentityFallsBackToMetadataSourceSessionID(t *testing.T) {
 			cfg := config{slackBotToken: "xoxb-test"}
 			req := httptest.NewRequest(http.MethodPost, "/publish", strings.NewReader(tc.body))
 			rec := httptest.NewRecorder()
-			handlePublish(cfg, reg, nil, newPublishDedupCache(publishDedupTTL))(rec, req)
+			handlePublish(cfg, reg, nil, nil, newPublishDedupCache(publishDedupTTL))(rec, req)
 
 			if rec.Code != http.StatusOK {
 				t.Fatalf("status = %d, want 200 (body=%q)", rec.Code, rec.Body.String())
@@ -779,7 +779,7 @@ func TestHandlePublishRejectsEmptySession(t *testing.T) {
 			cfg := config{slackBotToken: "xoxb-test"}
 			req := httptest.NewRequest(http.MethodPost, "/publish", strings.NewReader(tc.body))
 			rec := httptest.NewRecorder()
-			handlePublish(cfg, reg, nil, newPublishDedupCache(publishDedupTTL))(rec, req)
+			handlePublish(cfg, reg, nil, nil, newPublishDedupCache(publishDedupTTL))(rec, req)
 
 			if rec.Code != http.StatusBadRequest {
 				t.Fatalf("status = %d, want 400 (body=%q)", rec.Code, rec.Body.String())
@@ -822,7 +822,7 @@ func TestHandlePublishDedupesOnIdempotencyKey(t *testing.T) {
 
 	cfg := config{slackBotToken: "xoxb-test"}
 	dedup := newPublishDedupCache(publishDedupTTL)
-	handler := handlePublish(cfg, reg, nil, dedup)
+	handler := handlePublish(cfg, reg, nil, nil, dedup)
 	body := `{"session_id":"gc-1","conversation":{"conversation_id":"C1","kind":"room"},"text":"hello","idempotency_key":"k-1"}`
 
 	publish := func() *httptest.ResponseRecorder {
@@ -875,7 +875,7 @@ func TestHandlePublishNoDedupWithoutKey(t *testing.T) {
 	slackAPIBase = fakeSlack.URL
 
 	cfg := config{slackBotToken: "xoxb-test"}
-	handler := handlePublish(cfg, reg, nil, newPublishDedupCache(publishDedupTTL))
+	handler := handlePublish(cfg, reg, nil, nil, newPublishDedupCache(publishDedupTTL))
 	body := `{"session_id":"gc-1","conversation":{"conversation_id":"C1","kind":"room"},"text":"hi"}`
 	for i := 0; i < 2; i++ {
 		req := httptest.NewRequest(http.MethodPost, "/publish", strings.NewReader(body))
@@ -2215,7 +2215,7 @@ func TestHandlePublishFile(t *testing.T) {
 			}
 			req := httptest.NewRequest(tc.method, "/publish-file", strings.NewReader(body))
 			rec := httptest.NewRecorder()
-			handlePublishFile(cfg, reg)(rec, req)
+			handlePublishFile(cfg, reg, nil)(rec, req)
 
 			if rec.Code != tc.wantStatus {
 				t.Fatalf("status = %d, want %d (body=%q)", rec.Code, tc.wantStatus, rec.Body.String())

--- a/slack-full/adapter/room_launch_dispatch.go
+++ b/slack-full/adapter/room_launch_dispatch.go
@@ -78,15 +78,15 @@ func dispatchRoomLaunch(
 	roomLaunchReg *roomLaunchMappingRegistry,
 	msg slackMessageEvent,
 	teamID, handle, remainder string,
-) {
+) (concluded bool) {
 	if roomLaunchReg == nil {
 		emitRoomLaunchNotEnabledEphemeral(cfg, msg, handle)
-		return
+		return true
 	}
 	pool, ok := roomLaunchReg.LookupPoolTemplate(teamID, msg.Channel)
 	if !ok {
 		emitRoomLaunchNotEnabledEphemeral(cfg, msg, handle)
-		return
+		return true
 	}
 
 	// Thread-root resolution: a top-level `@@new-handle ...` post has
@@ -113,20 +113,9 @@ func dispatchRoomLaunch(
 		if err := postSlackEphemeral(cfg.slackBotToken, msg.Channel, msg.User, msg.ThreadTS, body); err != nil {
 			log.Printf("launcher dispatch: ephemeral after spawn failure: %v", err)
 		}
-		return
-	}
-
-	// Bootstrap alias on first spawn so the next `@<handle> ...` post
-	// in the thread (or any other channel) routes via the existing
-	// single-`@` alias dispatch path. Idempotent on Set if the handle
-	// is already registered to this same session.
-	if created && aliasReg != nil {
-		if err := aliasReg.Set(handle, sessionID); err != nil {
-			log.Printf("launcher dispatch: aliasReg.Set handle=%q session=%s: %v",
-				handle, sessionID, err)
-			// Continue — the spawn succeeded; alias bootstrap is best-effort.
-			// The user can re-register manually via /handle-alias if needed.
-		}
+		// Transient: the session never spawned — a Slack redelivery
+		// should retry the launcher forward (codex r6).
+		return false
 	}
 
 	// Post the remainder as the session's first/next message via the
@@ -148,7 +137,33 @@ func dispatchRoomLaunch(
 		if err := postSlackEphemeral(cfg.slackBotToken, msg.Channel, msg.User, msg.ThreadTS, body); err != nil {
 			log.Printf("launcher dispatch: ephemeral after message failure: %v", err)
 		}
-		return
+		// Transient: the session exists but never got the message — a
+		// redelivery re-acquires the same thread session and re-posts.
+		// The alias is deliberately NOT registered yet (below, after
+		// this succeeds): a registered alias would send the redelivery
+		// down handleDoubleHandleDispatch's pre-claimed branch, which
+		// commits without ever re-posting the remainder (codex r7).
+		return false
+	}
+
+	// Bootstrap alias only after the first message actually landed, so
+	// the next `@<handle> ...` post routes via the single-`@` alias
+	// dispatch path. Ordered after postSessionMessage (codex r7) — see
+	// the failure comment above. Gated on the handle being unclaimed
+	// rather than on `created` (codex r8): a retry after a failed
+	// first message re-acquires the existing thread session
+	// (created=false) and must still bind the handle it advertises in
+	// the acknowledgement below.
+	if aliasReg != nil {
+		if _, claimed := aliasReg.Get(handle); !claimed {
+			if err := aliasReg.Set(handle, sessionID); err != nil {
+				log.Printf("launcher dispatch: aliasReg.Set handle=%q session=%s: %v",
+					handle, sessionID, err)
+				// Continue — the message landed; alias bootstrap is
+				// best-effort. The user can re-register manually via
+				// /handle-alias if needed.
+			}
+		}
 	}
 
 	// Acknowledge to the user. Different wording for spawn vs. reuse so
@@ -174,6 +189,7 @@ func dispatchRoomLaunch(
 	}
 	log.Printf("launcher dispatch: handle=%q session=%s created=%v team=%s channel=%s thread=%s pool=%q",
 		handle, sessionID, created, teamID, msg.Channel, threadTS, pool)
+	return true
 }
 
 // emitRoomLaunchNotEnabledEphemeral surfaces the actionable fix-it for

--- a/slack-full/adapter/room_launch_dispatch.go
+++ b/slack-full/adapter/room_launch_dispatch.go
@@ -142,13 +142,18 @@ func dispatchRoomLaunch(
 	aliasReserved := false
 	if aliasReg != nil && (created || boundHandle == handle) {
 		if _, claimed := aliasReg.Get(handle); !claimed {
+			// Reserved even when Set returns an error (codex r15): Set
+			// inserts into the in-memory map BEFORE persisting, so a
+			// persistence failure still leaves a live reservation that
+			// the rollback below must be able to undo — otherwise a
+			// parked redelivery would see the handle pre-claimed and
+			// commit without ever re-posting the remainder.
+			aliasReserved = true
 			if err := aliasReg.Set(handle, sessionID); err != nil {
 				log.Printf("launcher dispatch: aliasReg.Set handle=%q session=%s: %v",
 					handle, sessionID, err)
 				// Continue — alias bootstrap is best-effort. The user
 				// can re-register manually via /handle-alias if needed.
-			} else {
-				aliasReserved = true
 			}
 		}
 	}
@@ -171,10 +176,11 @@ func dispatchRoomLaunch(
 		// at OUR session, so a racing re-registration is never
 		// clobbered.
 		if aliasReserved {
-			if sid, ok := aliasReg.Get(handle); ok && sid == sessionID {
-				if _, err := aliasReg.Delete(handle); err != nil {
-					log.Printf("launcher dispatch: rollback aliasReg.Delete handle=%q: %v", handle, err)
-				}
+			// Compare-and-delete under one registry lock (codex r15):
+			// a racing re-registration installed between a separate
+			// Get and Delete would otherwise be removed too.
+			if _, err := aliasReg.DeleteIf(handle, sessionID); err != nil {
+				log.Printf("launcher dispatch: rollback aliasReg.DeleteIf handle=%q: %v", handle, err)
 			}
 		}
 		body := fmt.Sprintf(

--- a/slack-full/adapter/room_launch_dispatch.go
+++ b/slack-full/adapter/room_launch_dispatch.go
@@ -118,6 +118,41 @@ func dispatchRoomLaunch(
 		return false
 	}
 
+	// Reserve the alias BEFORE the first-message round trip (codex
+	// r13): postSessionMessage can take seconds, and a user's
+	// `@<handle>` follow-up processed in that window used to miss the
+	// alias lookup and fall through to the channel-bound path — which
+	// the launcher session is not on — losing the follow-up. The
+	// reservation is rolled back below if the first post fails,
+	// BEFORE this function returns false and the caller releases the
+	// event's dedup claim, so a woken redelivery sees no alias and
+	// correctly re-enters the launcher path (the codex r7 concern
+	// about the pre-claimed branch swallowing the un-posted remainder).
+	//
+	// Gated on the handle being unclaimed rather than on `created`
+	// alone (codex r8): a retry after a failed first message
+	// re-acquires the existing thread session (created=false) and
+	// must still bind the handle it advertises in the acknowledgement
+	// below. But ONLY when the stored binding was created for this
+	// same handle (codex r9): a DIFFERENT `@@handle` converging on an
+	// existing thread session must not register its unclaimed handle
+	// globally onto that old session — that would route every later
+	// `@handle` post anywhere to the wrong session and permanently
+	// block the handle from launching its own.
+	aliasReserved := false
+	if aliasReg != nil && (created || boundHandle == handle) {
+		if _, claimed := aliasReg.Get(handle); !claimed {
+			if err := aliasReg.Set(handle, sessionID); err != nil {
+				log.Printf("launcher dispatch: aliasReg.Set handle=%q session=%s: %v",
+					handle, sessionID, err)
+				// Continue — alias bootstrap is best-effort. The user
+				// can re-register manually via /handle-alias if needed.
+			} else {
+				aliasReserved = true
+			}
+		}
+	}
+
 	// Post the remainder as the session's first/next message via the
 	// shared session-message helper. The receiving session sees the
 	// raw remainder so the user's first message reads naturally; we
@@ -128,6 +163,20 @@ func dispatchRoomLaunch(
 	if err := postSessionMessage(cfg, sessionID, remainder, "gc-slack-adapter-launcher"); err != nil {
 		log.Printf("launcher dispatch: post session message handle=%q session=%s: %v",
 			handle, sessionID, err)
+		// Roll the reservation back before the caller releases the
+		// dedup claim (codex r13): a woken redelivery must re-enter
+		// the launcher path (which re-posts the remainder), not the
+		// pre-claimed alias branch (which would commit without ever
+		// posting it — codex r7). Deleted only while it still points
+		// at OUR session, so a racing re-registration is never
+		// clobbered.
+		if aliasReserved {
+			if sid, ok := aliasReg.Get(handle); ok && sid == sessionID {
+				if _, err := aliasReg.Delete(handle); err != nil {
+					log.Printf("launcher dispatch: rollback aliasReg.Delete handle=%q: %v", handle, err)
+				}
+			}
+		}
 		body := fmt.Sprintf(
 			"launcher started session %s for @@%s but the first message could not be delivered: %s",
 			neutralizeMarkupBoundaries(sessionID),
@@ -139,36 +188,7 @@ func dispatchRoomLaunch(
 		}
 		// Transient: the session exists but never got the message — a
 		// redelivery re-acquires the same thread session and re-posts.
-		// The alias is deliberately NOT registered yet (below, after
-		// this succeeds): a registered alias would send the redelivery
-		// down handleDoubleHandleDispatch's pre-claimed branch, which
-		// commits without ever re-posting the remainder (codex r7).
 		return false
-	}
-
-	// Bootstrap alias only after the first message actually landed, so
-	// the next `@<handle> ...` post routes via the single-`@` alias
-	// dispatch path. Ordered after postSessionMessage (codex r7) — see
-	// the failure comment above. Gated on the handle being unclaimed
-	// rather than on `created` alone (codex r8): a retry after a
-	// failed first message re-acquires the existing thread session
-	// (created=false) and must still bind the handle it advertises in
-	// the acknowledgement below. But ONLY when the stored binding was
-	// created for this same handle (codex r9): a DIFFERENT `@@handle`
-	// converging on an existing thread session must not register its
-	// unclaimed handle globally onto that old session — that would
-	// route every later `@handle` post anywhere to the wrong session
-	// and permanently block the handle from launching its own.
-	if aliasReg != nil && (created || boundHandle == handle) {
-		if _, claimed := aliasReg.Get(handle); !claimed {
-			if err := aliasReg.Set(handle, sessionID); err != nil {
-				log.Printf("launcher dispatch: aliasReg.Set handle=%q session=%s: %v",
-					handle, sessionID, err)
-				// Continue — the message landed; alias bootstrap is
-				// best-effort. The user can re-register manually via
-				// /handle-alias if needed.
-			}
-		}
 	}
 
 	// Acknowledge to the user. Different wording for spawn vs. reuse so

--- a/slack-full/adapter/room_launch_dispatch.go
+++ b/slack-full/adapter/room_launch_dispatch.go
@@ -99,7 +99,7 @@ func dispatchRoomLaunch(
 		threadTS = msg.TS
 	}
 
-	sessionID, created, err := threadReg.AcquireOrCreate(msg.Channel, threadTS, func() (string, error) {
+	sessionID, boundHandle, created, err := threadReg.AcquireOrCreate(msg.Channel, threadTS, handle, func() (string, error) {
 		return roomLaunchSpawnSession(cfg, pool, handle, msg)
 	})
 	if err != nil {
@@ -150,11 +150,16 @@ func dispatchRoomLaunch(
 	// the next `@<handle> ...` post routes via the single-`@` alias
 	// dispatch path. Ordered after postSessionMessage (codex r7) — see
 	// the failure comment above. Gated on the handle being unclaimed
-	// rather than on `created` (codex r8): a retry after a failed
-	// first message re-acquires the existing thread session
+	// rather than on `created` alone (codex r8): a retry after a
+	// failed first message re-acquires the existing thread session
 	// (created=false) and must still bind the handle it advertises in
-	// the acknowledgement below.
-	if aliasReg != nil {
+	// the acknowledgement below. But ONLY when the stored binding was
+	// created for this same handle (codex r9): a DIFFERENT `@@handle`
+	// converging on an existing thread session must not register its
+	// unclaimed handle globally onto that old session — that would
+	// route every later `@handle` post anywhere to the wrong session
+	// and permanently block the handle from launching its own.
+	if aliasReg != nil && (created || boundHandle == handle) {
 		if _, claimed := aliasReg.Get(handle); !claimed {
 			if err := aliasReg.Set(handle, sessionID); err != nil {
 				log.Printf("launcher dispatch: aliasReg.Set handle=%q session=%s: %v",

--- a/slack-full/adapter/room_launch_dispatch_test.go
+++ b/slack-full/adapter/room_launch_dispatch_test.go
@@ -481,3 +481,46 @@ func TestRoomLaunchDispatchSaturationDropsAtOuterSlot(t *testing.T) {
 		t.Errorf("/v0/sessions POSTs = %d, want 0 on saturation", got)
 	}
 }
+
+// codex r13: the alias is reserved before the first-message POST (so
+// a fast `@handle` follow-up routes to the launcher session instead
+// of falling to the channel-bound path), and rolled back when that
+// POST fails — a woken redelivery must re-enter the launcher path,
+// not the pre-claimed alias branch that would swallow the un-posted
+// remainder.
+func TestRoomLaunchDispatchRollsBackAliasWhenFirstMessageFails(t *testing.T) {
+	srv, hits := newGCStub(t)
+	_ = captureSlackPostEphemeral(t)
+	hits.messageStatus.Store(http.StatusInternalServerError)
+
+	cfg := config{
+		gcAPIBase:           srv.URL,
+		cityName:            "test-city",
+		provider:            "slack",
+		accountID:           "T1",
+		handlePrefix:        "@",
+		slackBotToken:       "xoxb-test",
+		dispatchConcurrency: 8,
+		dispatchSem:         defaultTestDispatchSem,
+	}
+	aliasReg := newTestHandleAliasRegistry(t)
+	threadReg := newTestThreadSessionRegistry(t)
+	roomReg := newTestRoomLaunchRegistry(t, "T1", "C1", "mission-control/launcher")
+
+	rawMsg, _ := json.Marshal(slackMessageEvent{
+		Type:    "message",
+		Channel: "C1",
+		User:    "U1",
+		TS:      "1700000000.000300",
+		Text:    "@@rollback-handle first message",
+	})
+	env := slackEventEnvelope{Type: "event_callback", Event: rawMsg, TeamID: "T1"}
+	processSlackEvent(cfg, aliasReg, threadReg, roomReg, nil, nil, env, func() {})
+
+	if got := atomic.LoadInt32(&hits.sessionMessages); got == 0 {
+		t.Fatal("first-message POST never attempted")
+	}
+	if sid, ok := aliasReg.Get("rollback-handle"); ok {
+		t.Errorf("alias survived failed first message: bound to %q; want rolled back", sid)
+	}
+}

--- a/slack-full/adapter/room_launch_dispatch_test.go
+++ b/slack-full/adapter/room_launch_dispatch_test.go
@@ -228,7 +228,7 @@ func TestRoomLaunchDispatchReuseOnHitSkipsCreateAndPostsToExistingSession(t *tes
 
 	// Pre-bind the thread → existing session.
 	threadTS := "1700000000.000100"
-	_, _, err := threadReg.AcquireOrCreate("C1", threadTS, func() (string, error) {
+	_, _, _, err := threadReg.AcquireOrCreate("C1", threadTS, "h", func() (string, error) {
 		return "sess-existing-9", nil
 	})
 	if err != nil {
@@ -259,6 +259,60 @@ func TestRoomLaunchDispatchReuseOnHitSkipsCreateAndPostsToExistingSession(t *tes
 	wantPath := "/v0/city/test-city/session/sess-existing-9/messages"
 	if msgPath != wantPath {
 		t.Errorf("message path = %q, want %q", msgPath, wantPath)
+	}
+	// codex r9: the reused thread session was created for handle "h" —
+	// the converging @@new-handle must NOT be globally alias-bound onto
+	// it, or every later `@new-handle` post anywhere routes to the old
+	// session and new-handle can never launch its own.
+	if sid, ok := aliasReg.Get("new-handle"); ok {
+		t.Errorf("new-handle alias-bound to %q on thread reuse; want no binding", sid)
+	}
+}
+
+// TestRoomLaunchDispatchRetrySameHandleStillBootstrapsAlias — the
+// codex r8 retry case survives the r9 hijack fix: a redelivery after a
+// failed first message re-acquires the thread session CREATED FOR THE
+// SAME handle (created=false, boundHandle==handle) and must still bind
+// the alias it advertises in the acknowledgement.
+func TestRoomLaunchDispatchRetrySameHandleStillBootstrapsAlias(t *testing.T) {
+	srv, _ := newGCStub(t)
+	_ = captureSlackPostEphemeral(t)
+
+	cfg := config{
+		gcAPIBase:           srv.URL,
+		cityName:            "test-city",
+		provider:            "slack",
+		accountID:           "T1",
+		handlePrefix:        "@",
+		slackBotToken:       "xoxb-test",
+		dispatchConcurrency: 8,
+		dispatchSem:         defaultTestDispatchSem,
+	}
+	aliasReg := newTestHandleAliasRegistry(t)
+	threadReg := newTestThreadSessionRegistry(t)
+	roomReg := newTestRoomLaunchRegistry(t, "T1", "C1", "mission-control/launcher")
+
+	threadTS := "1700000000.000100"
+	if _, _, _, err := threadReg.AcquireOrCreate("C1", threadTS, "new-handle", func() (string, error) {
+		return "sess-existing-9", nil
+	}); err != nil {
+		t.Fatalf("seed AcquireOrCreate: %v", err)
+	}
+
+	rawMsg, _ := json.Marshal(slackMessageEvent{
+		Type:     "message",
+		Channel:  "C1",
+		User:     "U1",
+		TS:       "1700000000.000200",
+		ThreadTS: threadTS,
+		Text:     "@@new-handle follow up",
+	})
+	env := slackEventEnvelope{Type: "event_callback", Event: rawMsg, TeamID: "T1"}
+
+	processSlackEvent(cfg, aliasReg, threadReg, roomReg, nil, nil, env, func() {})
+
+	if sid, ok := aliasReg.Get("new-handle"); !ok || sid != "sess-existing-9" {
+		t.Errorf("alias after same-handle retry = (%q, %v), want (sess-existing-9, true)", sid, ok)
 	}
 }
 

--- a/slack-full/adapter/room_launch_dispatch_test.go
+++ b/slack-full/adapter/room_launch_dispatch_test.go
@@ -524,3 +524,24 @@ func TestRoomLaunchDispatchRollsBackAliasWhenFirstMessageFails(t *testing.T) {
 		t.Errorf("alias survived failed first message: bound to %q; want rolled back", sid)
 	}
 }
+
+// codex r15: DeleteIf is an atomic compare-and-delete — it removes
+// the mapping only while it still points at the given session.
+func TestHandleAliasRegistryDeleteIf(t *testing.T) {
+	reg := newTestHandleAliasRegistry(t)
+	if err := reg.Set("h", "s1"); err != nil {
+		t.Fatal(err)
+	}
+	if deleted, err := reg.DeleteIf("h", "s2"); err != nil || deleted {
+		t.Fatalf("DeleteIf wrong session = (%v, %v), want (false, nil)", deleted, err)
+	}
+	if sid, ok := reg.Get("h"); !ok || sid != "s1" {
+		t.Fatalf("mapping disturbed by non-matching DeleteIf: (%q, %v)", sid, ok)
+	}
+	if deleted, err := reg.DeleteIf("h", "s1"); err != nil || !deleted {
+		t.Fatalf("DeleteIf matching session = (%v, %v), want (true, nil)", deleted, err)
+	}
+	if _, ok := reg.Get("h"); ok {
+		t.Fatal("mapping survived matching DeleteIf")
+	}
+}

--- a/slack-full/adapter/thread_context_test.go
+++ b/slack-full/adapter/thread_context_test.go
@@ -170,7 +170,7 @@ func TestThreadContext_SecondMentionWithoutNewActivityNoPreamble(t *testing.T) {
 	}
 	var calls int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Only count conversations.replies; the adapter's eyes-react
+		// Only count conversations.replies; the adapter's busy-reaction
 		// path posts to /reactions.add and is out of scope here.
 		if strings.HasSuffix(r.URL.Path, "/conversations.replies") {
 			atomic.AddInt32(&calls, 1)
@@ -389,7 +389,7 @@ func TestThreadContext_NoPriorsAfterFilteringEmitsNoPreamble(t *testing.T) {
 func TestThreadContext_FetchFailureRetriesNextInbound(t *testing.T) {
 	var calls int32
 	failingSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Only count conversations.replies; the adapter's eyes-react
+		// Only count conversations.replies; the adapter's busy-reaction
 		// path posts to /reactions.add and is out of scope here.
 		if strings.HasSuffix(r.URL.Path, "/conversations.replies") {
 			atomic.AddInt32(&calls, 1)
@@ -465,7 +465,7 @@ func TestThreadContext_CrossAgentDeltaVisibility(t *testing.T) {
 	}
 	var calls int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Only count conversations.replies; the adapter's eyes-react
+		// Only count conversations.replies; the adapter's busy-reaction
 		// path posts to /reactions.add and is out of scope here.
 		if strings.HasSuffix(r.URL.Path, "/conversations.replies") {
 			atomic.AddInt32(&calls, 1)

--- a/slack-full/adapter/thread_session_registry.go
+++ b/slack-full/adapter/thread_session_registry.go
@@ -48,10 +48,22 @@ import (
 //     rig_mappings.json.
 type threadSessionRegistry struct {
 	mu        sync.Mutex
-	byKey     map[threadKey]string // (channel, thread) → sessionID
-	bySession map[string]threadKey // sessionID → (channel, thread)
+	byKey     map[threadKey]threadSessionBinding // (channel, thread) → binding
+	bySession map[string]threadKey               // sessionID → (channel, thread)
 	gates     map[threadKey]*sync.Mutex
 	diskPath  string
+}
+
+// threadSessionBinding is one thread's session plus the launcher
+// handle it was created for. Handle lets the room-launch alias
+// bootstrap distinguish "retry of the same @@handle after a failed
+// first message" (re-bind is correct) from "a DIFFERENT @@handle
+// reusing the thread's session" (binding would hijack the new handle
+// globally onto the old session — codex r9). "" on records persisted
+// before the field existed; those never re-bootstrap on reuse.
+type threadSessionBinding struct {
+	SessionID string
+	Handle    string
 }
 
 // threadKey is the composite (channelID, threadTS) lookup key. Both
@@ -69,6 +81,7 @@ type threadSessionDiskRecord struct {
 	ChannelID string `json:"channel_id"`
 	ThreadTS  string `json:"thread_ts"`
 	SessionID string `json:"session_id"`
+	Handle    string `json:"handle,omitempty"`
 }
 
 // maxThreadSessionRegistryBytes caps the on-disk file size accepted at
@@ -83,7 +96,7 @@ const maxThreadSessionRegistryBytes = 10 << 20 // 10 MiB
 // returned.
 func newThreadSessionRegistry(diskPath string) (*threadSessionRegistry, error) {
 	r := &threadSessionRegistry{
-		byKey:     make(map[threadKey]string),
+		byKey:     make(map[threadKey]threadSessionBinding),
 		bySession: make(map[string]threadKey),
 		gates:     make(map[threadKey]*sync.Mutex),
 		diskPath:  diskPath,
@@ -97,25 +110,28 @@ func newThreadSessionRegistry(diskPath string) (*threadSessionRegistry, error) {
 // AcquireOrCreate returns the session id bound to (channelID,
 // threadTS). If no binding exists, the create callback is invoked
 // under a per-key mutex; the returned sessionID is cached and
-// persisted. created reports whether this call was the one that ran
-// the callback (true) versus served a cached value (false).
+// persisted along with the launcher handle the create ran for.
+// created reports whether this call was the one that ran the callback
+// (true) versus served a cached value (false); boundHandle is the
+// handle recorded when the binding was CREATED — on a cache hit it
+// may differ from this call's handle ("" for pre-handle records).
 //
 // channelID and threadTS must both be non-empty. An error from create
 // is returned to the caller and NOT cached.
-func (r *threadSessionRegistry) AcquireOrCreate(channelID, threadTS string, create func() (string, error)) (sessionID string, created bool, err error) {
+func (r *threadSessionRegistry) AcquireOrCreate(channelID, threadTS, handle string, create func() (string, error)) (sessionID string, boundHandle string, created bool, err error) {
 	if channelID == "" || threadTS == "" {
-		return "", false, fmt.Errorf("thread session registry: channelID and threadTS required")
+		return "", "", false, fmt.Errorf("thread session registry: channelID and threadTS required")
 	}
 	if create == nil {
-		return "", false, fmt.Errorf("thread session registry: create callback required")
+		return "", "", false, fmt.Errorf("thread session registry: create callback required")
 	}
 	key := threadKey{ChannelID: channelID, ThreadTS: threadTS}
 
 	// Fast path: already cached.
 	r.mu.Lock()
-	if sid, ok := r.byKey[key]; ok {
+	if b, ok := r.byKey[key]; ok {
 		r.mu.Unlock()
-		return sid, false, nil
+		return b.SessionID, b.Handle, false, nil
 	}
 	// Acquire (or install) the per-key gate while holding the
 	// registry lock so we publish a single gate to all racers on the
@@ -135,9 +151,9 @@ func (r *threadSessionRegistry) AcquireOrCreate(channelID, threadTS string, crea
 	// Re-check under the gate: an earlier racer may have already run
 	// the callback and populated the cache.
 	r.mu.Lock()
-	if sid, ok := r.byKey[key]; ok {
+	if b, ok := r.byKey[key]; ok {
 		r.mu.Unlock()
-		return sid, false, nil
+		return b.SessionID, b.Handle, false, nil
 	}
 	r.mu.Unlock()
 
@@ -150,22 +166,22 @@ func (r *threadSessionRegistry) AcquireOrCreate(channelID, threadTS string, crea
 		// miss, and either reuse this gate (if still in r.gates) or
 		// install a fresh one.
 		r.removeGateIfUnused(key, gate)
-		return "", false, fmt.Errorf("thread session registry: create callback failed for channel=%q thread=%q: %w", channelID, threadTS, createErr)
+		return "", "", false, fmt.Errorf("thread session registry: create callback failed for channel=%q thread=%q: %w", channelID, threadTS, createErr)
 	}
 	if sid == "" {
 		r.removeGateIfUnused(key, gate)
-		return "", false, fmt.Errorf("thread session registry: create callback returned empty sessionID for channel=%q thread=%q", channelID, threadTS)
+		return "", "", false, fmt.Errorf("thread session registry: create callback returned empty sessionID for channel=%q thread=%q", channelID, threadTS)
 	}
 
 	r.mu.Lock()
-	r.byKey[key] = sid
+	r.byKey[key] = threadSessionBinding{SessionID: sid, Handle: handle}
 	r.bySession[sid] = key
 	saveErr := r.saveLocked()
 	r.mu.Unlock()
 	if saveErr != nil {
-		return sid, true, fmt.Errorf("thread session registry: persist binding for channel=%q thread=%q: %w", channelID, threadTS, saveErr)
+		return sid, handle, true, fmt.Errorf("thread session registry: persist binding for channel=%q thread=%q: %w", channelID, threadTS, saveErr)
 	}
-	return sid, true, nil
+	return sid, handle, true, nil
 }
 
 // Lookup returns the session id for (channelID, threadTS) and a
@@ -177,8 +193,8 @@ func (r *threadSessionRegistry) Lookup(channelID, threadTS string) (sessionID st
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	sid, ok := r.byKey[threadKey{ChannelID: channelID, ThreadTS: threadTS}]
-	return sid, ok
+	b, ok := r.byKey[threadKey{ChannelID: channelID, ThreadTS: threadTS}]
+	return b.SessionID, ok
 }
 
 // Remove drops the binding for (channelID, threadTS) and persists.
@@ -190,9 +206,9 @@ func (r *threadSessionRegistry) Remove(channelID, threadTS string) error {
 	}
 	key := threadKey{ChannelID: channelID, ThreadTS: threadTS}
 	r.mu.Lock()
-	if sid, ok := r.byKey[key]; ok {
+	if b, ok := r.byKey[key]; ok {
 		delete(r.byKey, key)
-		delete(r.bySession, sid)
+		delete(r.bySession, b.SessionID)
 	}
 	delete(r.gates, key)
 	err := r.saveLocked()
@@ -289,7 +305,7 @@ func (r *threadSessionRegistry) load() error {
 		if _, dup := r.byKey[k]; dup {
 			log.Printf("WARN: thread session registry: duplicate key %q in store; last write wins", storedKey)
 		}
-		r.byKey[k] = rec.SessionID
+		r.byKey[k] = threadSessionBinding{SessionID: rec.SessionID, Handle: rec.Handle}
 		r.bySession[rec.SessionID] = k
 	}
 	return nil
@@ -300,11 +316,12 @@ func (r *threadSessionRegistry) saveLocked() error {
 		return nil
 	}
 	out := make(map[string]threadSessionDiskRecord, len(r.byKey))
-	for k, sid := range r.byKey {
+	for k, b := range r.byKey {
 		out[diskKeyFor(k)] = threadSessionDiskRecord{
 			ChannelID: k.ChannelID,
 			ThreadTS:  k.ThreadTS,
-			SessionID: sid,
+			SessionID: b.SessionID,
+			Handle:    b.Handle,
 		}
 	}
 	data, err := json.MarshalIndent(out, "", "  ")

--- a/slack-full/adapter/thread_session_registry_test.go
+++ b/slack-full/adapter/thread_session_registry_test.go
@@ -20,7 +20,7 @@ func TestThreadSessionRegistryRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newThreadSessionRegistry: %v", err)
 	}
-	sid, created, err := reg.AcquireOrCreate("C1", "1700000000.000100", func() (string, error) {
+	sid, _, created, err := reg.AcquireOrCreate("C1", "1700000000.000100", "h", func() (string, error) {
 		return "gc-sess-1", nil
 	})
 	if err != nil {
@@ -70,7 +70,7 @@ func TestThreadSessionRegistryConcurrentAcquireOrCreateOnSameKey(t *testing.T) {
 		go func(idx int) {
 			defer wg.Done()
 			<-start
-			sid, created, err := reg.AcquireOrCreate("C1", "1700000000.000100", func() (string, error) {
+			sid, _, created, err := reg.AcquireOrCreate("C1", "1700000000.000100", "h", func() (string, error) {
 				atomic.AddInt32(&createCount, 1)
 				return "gc-sess-1", nil
 			})
@@ -111,7 +111,7 @@ func TestThreadSessionRegistryRemoveThenReacquire(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newThreadSessionRegistry: %v", err)
 	}
-	if _, _, err := reg.AcquireOrCreate("C1", "T1", func() (string, error) { return "gc-sess-1", nil }); err != nil {
+	if _, _, _, err := reg.AcquireOrCreate("C1", "T1", "h", func() (string, error) { return "gc-sess-1", nil }); err != nil {
 		t.Fatalf("first acquire: %v", err)
 	}
 	if err := reg.Remove("C1", "T1"); err != nil {
@@ -120,7 +120,7 @@ func TestThreadSessionRegistryRemoveThenReacquire(t *testing.T) {
 	if _, ok := reg.Lookup("C1", "T1"); ok {
 		t.Errorf("Lookup ok=true after Remove; want false")
 	}
-	sid, created, err := reg.AcquireOrCreate("C1", "T1", func() (string, error) { return "gc-sess-2", nil })
+	sid, _, created, err := reg.AcquireOrCreate("C1", "T1", "h", func() (string, error) { return "gc-sess-2", nil })
 	if err != nil {
 		t.Fatalf("second acquire: %v", err)
 	}
@@ -142,10 +142,10 @@ func TestThreadSessionRegistryRemoveBySessionID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newThreadSessionRegistry: %v", err)
 	}
-	if _, _, err := reg.AcquireOrCreate("C1", "T1", func() (string, error) { return "gc-sess-1", nil }); err != nil {
+	if _, _, _, err := reg.AcquireOrCreate("C1", "T1", "h", func() (string, error) { return "gc-sess-1", nil }); err != nil {
 		t.Fatalf("acquire C1/T1: %v", err)
 	}
-	if _, _, err := reg.AcquireOrCreate("C2", "T2", func() (string, error) { return "gc-sess-2", nil }); err != nil {
+	if _, _, _, err := reg.AcquireOrCreate("C2", "T2", "h", func() (string, error) { return "gc-sess-2", nil }); err != nil {
 		t.Fatalf("acquire C2/T2: %v", err)
 	}
 
@@ -218,7 +218,7 @@ func TestThreadSessionRegistryTolerantLoadMalformedFile(t *testing.T) {
 	// After a tolerant load, a fresh AcquireOrCreate must still
 	// persist correctly — the registry should overwrite the corrupt
 	// file on next save.
-	if _, _, err := reg.AcquireOrCreate("C1", "T1", func() (string, error) { return "gc-sess-1", nil }); err != nil {
+	if _, _, _, err := reg.AcquireOrCreate("C1", "T1", "h", func() (string, error) { return "gc-sess-1", nil }); err != nil {
 		t.Fatalf("AcquireOrCreate after malformed load: %v", err)
 	}
 	reg2, err := newThreadSessionRegistry(path)
@@ -240,7 +240,7 @@ func TestThreadSessionRegistryCreateErrorDoesNotCacheFailure(t *testing.T) {
 		t.Fatalf("newThreadSessionRegistry: %v", err)
 	}
 	wantErr := errors.New("spawn rejected")
-	_, _, err = reg.AcquireOrCreate("C1", "T1", func() (string, error) {
+	_, _, _, err = reg.AcquireOrCreate("C1", "T1", "h", func() (string, error) {
 		return "", wantErr
 	})
 	if !errors.Is(err, wantErr) {
@@ -250,7 +250,7 @@ func TestThreadSessionRegistryCreateErrorDoesNotCacheFailure(t *testing.T) {
 		t.Errorf("failed create cached; Lookup ok=true after error")
 	}
 	// Retry succeeds and is treated as a fresh create.
-	sid, created, err := reg.AcquireOrCreate("C1", "T1", func() (string, error) {
+	sid, _, created, err := reg.AcquireOrCreate("C1", "T1", "h", func() (string, error) {
 		return "gc-sess-retry", nil
 	})
 	if err != nil {
@@ -287,7 +287,7 @@ func TestThreadSessionRegistryConcurrentDistinctKeysDoNotSerialize(t *testing.T)
 			defer wg.Done()
 			ch := fmt.Sprintf("C%d", idx)
 			ts := fmt.Sprintf("T%d", idx)
-			sid, _, err := reg.AcquireOrCreate(ch, ts, func() (string, error) {
+			sid, _, _, err := reg.AcquireOrCreate(ch, ts, "h", func() (string, error) {
 				cur := atomic.AddInt32(&inFlight, 1)
 				for {
 					m := atomic.LoadInt32(&maxInFlight)
@@ -318,5 +318,23 @@ func TestThreadSessionRegistryConcurrentDistinctKeysDoNotSerialize(t *testing.T)
 	wg.Wait()
 	if got := atomic.LoadInt32(&maxInFlight); got < 2 {
 		t.Errorf("max in-flight creates = %d; want >= 2 (per-key mutex must not serialize distinct keys)", got)
+	}
+}
+
+// codex r9: the binding remembers which handle created it, and a
+// cache hit reports THAT handle — not the caller's — so the launcher
+// can tell a same-handle retry from a different handle converging on
+// the thread.
+func TestThreadSessionRegistryReportsCreatingHandle(t *testing.T) {
+	reg := newTestThreadSessionRegistry(t)
+	if _, _, _, err := reg.AcquireOrCreate("C1", "T1", "alpha", func() (string, error) { return "s1", nil }); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	sid, boundHandle, created, err := reg.AcquireOrCreate("C1", "T1", "beta", func() (string, error) { return "s2", nil })
+	if err != nil {
+		t.Fatalf("hit: %v", err)
+	}
+	if created || sid != "s1" || boundHandle != "alpha" {
+		t.Fatalf("hit = (sid=%q handle=%q created=%v), want (s1, alpha, false)", sid, boundHandle, created)
 	}
 }

--- a/slack-full/scripts/slack_chat_react.py
+++ b/slack-full/scripts/slack_chat_react.py
@@ -55,6 +55,14 @@ def main(argv: list[str]) -> int:
         default="eyes",
         help="Emoji name without colons (default: eyes).",
     )
+    parser.add_argument(
+        "--remove",
+        action="store_true",
+        help=(
+            "Remove the reaction instead of adding it "
+            "(adapter maps this to Slack reactions.remove)."
+        ),
+    )
     args = parser.parse_args(argv)
 
     explicit = bool(args.conversation_id) or bool(args.message_id)
@@ -86,6 +94,7 @@ def main(argv: list[str]) -> int:
             conversation_id=conv_id,
             message_id=msg_id,
             emoji=args.emoji,
+            remove=args.remove,
         )
     except common.AdapterError as exc:
         raise SystemExit(str(exc)) from exc
@@ -94,6 +103,7 @@ def main(argv: list[str]) -> int:
         "conversation_id": conv_id,
         "message_id": msg_id,
         "emoji": args.emoji,
+        "remove": args.remove,
         "result": result,
     }, indent=2))
     return 0

--- a/slack-full/scripts/slack_intake_common.py
+++ b/slack-full/scripts/slack_intake_common.py
@@ -350,6 +350,50 @@ def current_session_id() -> str:
     raise GCAPIError(f"could not resolve session id for name {name!r}")
 
 
+def session_identity_candidates(session_id: str) -> set[str]:
+    """Every identifier an extmsg.inbound event may carry for this session.
+
+    Bindings are registered with whatever identifier the operator passed
+    to ``gc slack bind`` — for named sessions that is usually the session
+    NAME, and gc stamps the bound identifier into the inbound event's
+    ``target_session`` verbatim. The calling environment, meanwhile,
+    knows the session by its ID (GC_SESSION_ID). Matching on the id
+    alone therefore misses every extmsg-routed inbound for a
+    name-bound session (hw-94w5k finding #2: `gc slack react` bailing
+    with "no recent inbound transcript entry" right after an inbound
+    landed). The candidate set is the id plus GC_SESSION_NAME plus the
+    alias/session_name gc reports for the id.
+
+    Best-effort: the /sessions resolve failing (gc down, restricted
+    token) degrades to the env-derived candidates rather than raising —
+    the caller's lookup then behaves exactly as before this fix.
+
+    GC_SESSION_NAME names the CURRENT process's session, so it only
+    joins the set when session_id is that session (id or name match) —
+    an explicit ``--session <other>`` must never inherit the ambient
+    name, or a newer inbound for the current session would win the
+    scan and misroute the reply/reaction to the wrong conversation.
+    """
+    candidates = {session_id}
+    env_name = os.environ.get("GC_SESSION_NAME", "").strip()
+    env_id = os.environ.get("GC_SESSION_ID", "").strip()
+    if env_name and session_id in (env_id, env_name):
+        candidates.add(env_name)
+    try:
+        res = gc_get("/sessions")
+    except GCAPIError:
+        return candidates
+    for entry in res.get("items", []):
+        if entry.get("id") != session_id:
+            continue
+        for key in ("alias", "session_name"):
+            value = (entry.get(key) or "").strip()
+            if value:
+                candidates.add(value)
+        break
+    return candidates
+
+
 # --- inbound-event lookup -------------------------------------------------
 
 # Windows tried in order when scanning for a session's latest inbound.
@@ -367,6 +411,11 @@ _INBOUND_SCAN_WINDOWS = ("10m", "2h", "48h")
 def find_latest_inbound_for_session(session_id: str) -> dict[str, Any] | None:
     """Find the most recent extmsg.inbound event targeting session_id.
 
+    ``target_session`` is matched against every identifier the session
+    is known by (id, GC_SESSION_NAME, gc-reported alias/session_name —
+    see session_identity_candidates): name-bound sessions produce
+    events carrying the NAME, not the id (hw-94w5k finding #2).
+
     Queries the gc events stream (HTTP, not SSE — single shot snapshot)
     over escalating `since` windows (see _INBOUND_SCAN_WINDOWS).
     Returns the parsed event dict, or None if no window matched.
@@ -379,6 +428,7 @@ def find_latest_inbound_for_session(session_id: str) -> dict[str, Any] | None:
     (total > items), the scan was incomplete and a warning is emitted
     so truncation is never silent.
     """
+    identities = session_identity_candidates(session_id)
     for window in _INBOUND_SCAN_WINDOWS:
         url = (
             f"{gc_api_base()}/v0/city/{gc_city_name()}/events"
@@ -393,7 +443,7 @@ def find_latest_inbound_for_session(session_id: str) -> dict[str, Any] | None:
                 f"{len(raw)}/{total} oldest events; the latest inbound may be missed",
                 file=sys.stderr,
             )
-        matches = [e for e in raw if (e.get("payload") or {}).get("target_session") == session_id]
+        matches = [e for e in raw if (e.get("payload") or {}).get("target_session") in identities]
         if matches:
             return matches[-1]  # events are in chronological order
     return None
@@ -471,12 +521,14 @@ def react_via_adapter(
     conversation_id: str,
     message_id: str,
     emoji: str,
+    remove: bool = False,
 ) -> dict[str, Any]:
     """POST a reaction directly to the local adapter /react endpoint.
 
     Reactions are not part of the gc extmsg API — they go straight to
-    the adapter, which calls Slack reactions.add. The adapter listens
-    on the legacy internal TCP listener.
+    the adapter, which calls Slack reactions.add (or reactions.remove
+    when ``remove`` is set). The adapter listens on the legacy
+    internal TCP listener.
     """
     base = adapter_publish_url()
     # /publish -> /react: same host:port, different path.
@@ -486,6 +538,8 @@ def react_via_adapter(
         "message_id": message_id,
         "emoji": emoji,
     }
+    if remove:
+        body["remove"] = True
     headers = _adapter_csrf_headers()
     req = urllib.request.Request(
         react_url,

--- a/slack-full/tests/gc_mock.py
+++ b/slack-full/tests/gc_mock.py
@@ -94,6 +94,9 @@ class GcMock:
         # without a direct binding can still authorize through an
         # extmsg-group it participates in.
         self._group_memberships: dict[str, set[str]] = {}
+        # sessions listed by GET /sessions — the shape
+        # session_identity_candidates resolves names/aliases from.
+        self._sessions: list[dict[str, Any]] = []
         self._adapter_callback_url: str | None = None
         self._msg_counter = 0
         self._server = self._build_server()
@@ -187,6 +190,23 @@ class GcMock:
         }
         with self._lock:
             self._inbound_events.append(event)
+
+    def register_session(
+        self,
+        *,
+        session_id: str,
+        alias: str = "",
+        session_name: str = "",
+    ) -> None:
+        """Seed a GET /sessions entry so identity-candidate resolution
+        can map the session's id to its alias / session_name."""
+        entry: dict[str, Any] = {"id": session_id}
+        if alias:
+            entry["alias"] = alias
+        if session_name:
+            entry["session_name"] = session_name
+        with self._lock:
+            self._sessions.append(entry)
 
     def register_transcript_entry(
         self,
@@ -293,6 +313,17 @@ class GcMock:
 
         if method == "GET" and suffix == "/events":
             self._handle_events_query(req, query)
+            return
+
+        if method == "GET" and suffix == "/sessions":
+            with self._lock:
+                items = list(self._sessions)
+            resp = json.dumps({"items": items}).encode()
+            req.send_response(200)
+            req.send_header("Content-Type", "application/json")
+            req.send_header("Content-Length", str(len(resp)))
+            req.end_headers()
+            req.wfile.write(resp)
             return
 
         if method == "GET" and suffix == "/extmsg/transcript":

--- a/slack-full/tests/test_inbound_event_scan.py
+++ b/slack-full/tests/test_inbound_event_scan.py
@@ -43,6 +43,9 @@ def _isolate_env(
     monkeypatch.setenv("GC_CITY_PATH", str(tmp_path))
     monkeypatch.setenv("SLACK_WORKSPACE_ID", "T0TESTWS")
     monkeypatch.setenv("GC_SESSION_ID", "gc-test-session")
+    # Ambient GC_SESSION_NAME (tests may run inside a gc session) must
+    # not leak into the identity-candidate set.
+    monkeypatch.delenv("GC_SESSION_NAME", raising=False)
     monkeypatch.delenv("GC_SLACK_ADAPTER_ENV", raising=False)
 
 
@@ -117,6 +120,93 @@ def test_latest_match_wins_within_a_window(gc_mock: "GcMock") -> None:
 
     assert event is not None
     assert event["payload"]["conversation_id"] == "D0NEWEST"
+
+
+def test_name_bound_session_matched_via_gc_alias(gc_mock: "GcMock") -> None:
+    # Name-bound sessions (gc slack bind <name>) produce inbound events
+    # whose target_session is the NAME, while the calling environment
+    # knows the session by GC_SESSION_ID. The lookup must resolve the
+    # id's alias/session_name via GET /sessions and match on any of
+    # them (hw-94w5k finding #2).
+    common = _import_common()
+    gc_mock.register_session(session_id="gc-test-session", alias="mayor")
+    gc_mock.register_inbound_event(
+        target_session="mayor", conversation_id="C0NAMED",
+    )
+
+    event = common.find_latest_inbound_for_session("gc-test-session")
+
+    assert event is not None
+    assert event["payload"]["conversation_id"] == "C0NAMED"
+
+
+def test_name_bound_session_matched_via_env_name(
+    gc_mock: "GcMock",
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Even when gc's /sessions doesn't know the session (restart races,
+    # restricted listing), GC_SESSION_NAME from the calling environment
+    # still matches the name-carrying event.
+    common = _import_common()
+    monkeypatch.setenv("GC_SESSION_NAME", "mayor")
+    gc_mock.register_inbound_event(
+        target_session="mayor", conversation_id="C0ENVNAME",
+    )
+
+    event = common.find_latest_inbound_for_session("gc-test-session")
+
+    assert event is not None
+    assert event["payload"]["conversation_id"] == "C0ENVNAME"
+
+
+def test_explicit_other_session_ignores_ambient_env_name(
+    gc_mock: "GcMock",
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # `--session <other>` must not inherit the CURRENT process's
+    # GC_SESSION_NAME: a newer inbound targeting the ambient name would
+    # otherwise win the scan and misroute the reply/reaction.
+    common = _import_common()
+    monkeypatch.setenv("GC_SESSION_NAME", "mayor")  # current session's name
+    gc_mock.register_inbound_event(
+        target_session="mayor", conversation_id="C0AMBIENT", age_seconds=5,
+    )
+    gc_mock.register_inbound_event(
+        target_session="other-session", conversation_id="C0THEIRS", age_seconds=60,
+    )
+
+    event = common.find_latest_inbound_for_session("other-session")
+
+    assert event is not None
+    assert event["payload"]["conversation_id"] == "C0THEIRS", (
+        "ambient GC_SESSION_NAME leaked into an explicit --session lookup"
+    )
+
+
+def test_identity_candidates_degrade_without_sessions_endpoint(
+    gc_mock: "GcMock",
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A gc build without GET /sessions (or a failing call) must degrade
+    # to env-derived candidates, not raise out of the lookup.
+    common = _import_common()
+
+    real_gc_get = common.gc_get
+
+    def failing_gc_get(path: str) -> dict[str, Any]:
+        if path == "/sessions":
+            raise common.GCAPIError("GET /sessions -> 404")
+        return real_gc_get(path)
+
+    monkeypatch.setattr(common, "gc_get", failing_gc_get)
+    gc_mock.register_inbound_event(
+        target_session="gc-test-session", conversation_id="D0FALLBACK",
+    )
+
+    event = common.find_latest_inbound_for_session("gc-test-session")
+
+    assert event is not None
+    assert event["payload"]["conversation_id"] == "D0FALLBACK"
 
 
 def test_truncated_scan_warns_on_stderr(


### PR DESCRIPTION
Four adapter defects found by running this pack against a live Slack workspace, plus the darwin build fix that was a prerequisite for testing them on macOS. Each fix ships with regression tests; the branch is rebased onto current `main` with the recent company-rooms/DM work reconciled.

## Root causes and fixes

**1. Human file posts never reached sessions.** The system-noise subtype gate dropped subtype `file_share` (a human posting a file), and the empty-text gate dropped file-only posts (a screenshot with no caption). Both now flow through to the existing `downloadSlackFiles` path; other subtypes and bot-authored file posts stay filtered.

**2. `/react` and reply-current lookups missed name-registered sessions.** Bindings register whatever identifier the operator passed — for named sessions, the *name* — and gc stamps it into the inbound `target_session` verbatim, while the scan matched only `GC_SESSION_ID`. The scan now matches the id, `GC_SESSION_NAME`, and the gc-reported alias/session name for the id (best-effort `/sessions` resolve). The ambient `GC_SESSION_NAME` only joins the match set when the requested session *is* the current one, so an explicit `--session <other>` cannot be misrouted.

**3. No busy affordance on targeted inbounds.** New busy-reaction lifecycle: `BUSY_REACTION` (default `hourglass`; set-but-empty disables) is added to a targeted inbound message on dispatch and removed when the agent's reply publishes back into the same conversation/thread — a channel-native replacement for Slack Assistant-mode `assistant.threads.setStatus`. Bounded-TTL registry with cap eviction; the remove is ordered after the in-flight add (a fast reply cannot leave a stale emoji); failed forwards cancel the mark; re-targets move the affordance to the newest targeted message and restore the displaced mark if the re-target fails. `/react` gains `remove:true`. Only parsed targets (`@handle:` prefix, user-group mention, sticky thread handle) get the reaction — channel-binding-only inbounds carry no parsed target by design, since the adapter has no visibility into gc-side bindings.

**4. Slack Events API redeliveries double-delivered messages.** Slack retries any delivery it considers unacknowledged (network hiccup, slow first ack, its own read timeout) with the same `event_id`, and each retry that slipped through forwarded a byte-identical duplicate into the bound session. A short-TTL seen-set on envelope `event_id` now dedups redeliveries. The claim is taken synchronously before load-shedding (two simultaneous copies cannot both slip through); a delivery whose forward into gc fails releases its claim so Slack's retry ladder can still deliver — a transient downstream hiccup no longer becomes message loss; and a redelivery that races the first delivery's still-running forward parks until that claim concludes instead of being dropped.

**Darwin build (prerequisite):** `openBeneath`'s hand-rolled `openat(2)` walk used raw `syscall.Openat`, which does not exist on darwin — the adapter package failed to compile there, so its tests never ran on macOS. Replaced with stdlib `os.Root` confined resolution, with the root pre-opened `O_NOFOLLOW|O_DIRECTORY` and identity-matched against the `os.Root` handle, and the leaf `Lstat`'d (symlink → hard failure) plus inode-pinned — keeping the symlink-race protections of the old walk.

## Rebase notes

Reconciled with the company-rooms/DM work on `main`:

- `postReactionMethod` stays the single reactions POST path; `callSlackReactions` / `removeReactionFromSlack` are thin wrappers over it using the timeout-bounded `slackAPIClient` (the busy-reaction remove orders itself after the add with a wait derived from that timeout, so the add must stay on a bounded client).
- The dedup log lines use `env.TeamID` (the raw-body `teamID` local no longer exists in the events handler).

## Tests

- `busy_reaction_test.go` — 23 tests: add/remove lifecycle, thread keying, retarget/displacement/restore, add-before-remove ordering, TTL expiry, cap eviction, nil-safety.
- `event_dedup_test.go` — 12 tests: retried `event_id` dropped, distinct ids both forward, queue-full drop releases the claim, failed forward releases the claim, in-flight retry parks and takes over after failure / drops after success.
- `file_share_gate_test.go` — `file_share` and file-only posts forward; empty, bot-authored, and other-subtype posts stay dropped.
- `confined_open_test.go` — regression tests for in-root leaf/intermediate symlinks and a symlinked root.

Verified on this branch: `gofmt` / `go build` / `go vet` / full adapter `go test` (plus `-race` on the new and touched tests) on darwin/arm64 go1.26.5, and the 387 slack-full pytests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
