### PR TITLE
fix(gastown/refinery): require a target-side re-run before merging a failing check

### DIFF
--- a/gastown/formulas/mol-refinery-patrol.toml
+++ b/gastown/formulas/mol-refinery-patrol.toml
@@ -366,19 +366,45 @@ TARGET=$(gc bd show $WORK --json | jq -r '.[0].metadata.target // "{{target_bran
      ```
    - Close this step after the current wisp is burned.
 
-3. If pre-existing on target:
-   - Check for duplicates first:
+3. If you judge it pre-existing on target: PROVE IT before acting on that
+   judgment. "Pre-existing" is not something you get to assert — it is
+   something you must reproduce.
+   - Re-run the SAME failing check against $TARGET itself (not the rebased
+     `temp` branch), at the exact commit this branch would merge onto. Prefer
+     the full gate command (`{{test_command}}`) over a hand-picked subset, so
+     the comparison is apples-to-apples:
+     ```bash
+     TARGET_SHA=$(git rev-parse origin/$TARGET)
+     git checkout "$TARGET_SHA"
+     {{test_command}}
+     TARGET_RESULT=$?
+     git checkout temp
+     ```
+   - If the re-run FAILS on target too (`TARGET_RESULT != 0`): genuinely
+     pre-existing. Check for duplicates first:
      ```bash
      gc bd list --type=bug --status=open --search "<failure summary>"
      ```
-   - If a matching bug already exists: note its ID and proceed with merge.
-   - If no duplicate: file a new bead:
+     If a matching bug already exists: note its ID. If no duplicate: file a
+     new bead:
      ```bash
      gc bd create --type=bug --priority=1 --title="Pre-existing failure: <summary>"
      ```
-   - Proceed with merge (failure not caused by this branch)
+     Record the target-side reproduction as evidence on the bug bead (the
+     command run, $TARGET_SHA, and the failing output) — this is the proof,
+     not a formality. Proceed with merge (failure not caused by this branch).
+   - If the re-run PASSES on target (`TARGET_RESULT == 0`): your "pre-existing"
+     judgment was wrong. The branch caused it. Do NOT file a pre-existing bug
+     bead. Take branch 2 (reject) instead.
+   - If the re-run cannot be performed for any reason (target checkout fails,
+     the command errors out for infra reasons, etc.): that is a REJECT, not a
+     merge. Take branch 2 (reject) instead.
 
-**GATE**: Cannot merge without all checks passing OR pre-existing bug filed/found.
+**GATE**: Branch 3 (merge despite a failing check) is unreachable without a
+recorded target-side re-run of the SAME check showing it fails on $TARGET at
+$TARGET_SHA too. No re-run, a re-run that passes on target, or a re-run that
+cannot be performed all route to branch 2 (reject, rejection_reason set, bead
+returns to the pool) — never to merge.
 **FORBIDDEN**: Writing code to fix failures. You are a merge processor."""
 
 [[steps]]


### PR DESCRIPTION
## The hole

`mol-refinery-patrol.toml`, step `handle-failures`, branch 3: the refinery may
classify a failing quality check as "pre-existing on target" and merge anyway,
filing or matching a bug bead. Nothing verifies the claim. The gate reads:

> **GATE**: Cannot merge without all checks passing OR pre-existing bug filed/found.

So a red gate is convertible into a merge by an unconstrained model judgment,
and the bug bead makes the bypass look like diligence in the ledger.

This is more than theoretical because the gate has a documented false-FAIL
history in practice — a teardown signal producing rc=143 long after the real
stages had passed, and a load-sensitive watchdog timeout. A gate that cries
wolf, sitting under an agent empowered to overrule it, is the combination that
lets a genuine regression through.

A compounding factor we measured downstream: the refinery makes this judgment
inside a single long-lived conversation. One session ran 23h16m to a peak of
~607k tokens with zero compactions, so every prior merge was in context when it
judged the next one. The verdict is not reproducible. That half is a separate
concern, but it is why "it's just a judgment call" is not reassuring here.

## The fix

Replace the judgment with a mechanical proof. Before branch 3 may be taken,
re-run the **same** failing check against `$TARGET` at the commit the branch
would merge onto:

- **fails on target too** → genuinely pre-existing; file/match the bug, merge,
  and record the reproduction (command, `$TARGET_SHA`, failing output) on the
  bug bead as evidence
- **passes on target** → the branch caused it; take branch 2 (reject)
- **cannot be performed** → REJECT, not merge

That last case matches the stance the gate already takes for infra failures
elsewhere: an unperformable check fails closed, with no local fallback.

Prefers the full `{{test_command}}` over a hand-picked subset so the comparison
is apples-to-apples.

## Notes for review

- Diff is +33/−7, confined to branch 3 and the `**GATE**` line. TOML parses;
  step count unchanged at 9.
- Ported onto current `main` (6373985), not onto the sha we consume. The file
  has drifted +101/−16 since our pin, but the drift is elsewhere — branch 3 and
  the GATE line are byte-identical at both revisions, and `main` has not
  independently fixed this.
- Found and fixed downstream in a consumer city that had forked this formula.
  Upstreaming it so consumers converge here rather than each carrying a private
  divergence — retiring that fork is blocked on this landing.
- Contains no consumer-specific content; the downstream text named a repo's
  `scripts/verify.sh` as an example, which is generalized to `{{test_command}}`
  here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)