### PR TITLE
fix(gastown): stop witness patrol from burning its own wisp

### DIFF
--- a/gastown/formulas/mol-witness-patrol.toml
+++ b/gastown/formulas/mol-witness-patrol.toml
@@ -530,8 +530,17 @@ may have poured a next wisp without burning, or a restart may have raced —
 keep one open patrol wisp and burn any surplus, so wisps never accumulate.
 Wisp roots are `issue_type=molecule` (never `--type=wisp`, which is not a
 valid gc bd type and matches nothing).
+
+Set `THIS_WISP` to the id of the wisp you are executing right now, and
+exclude it from the reconcile. It must never be a reuse or burn candidate
+here — step 3 burns it. Do NOT rely on it being `in_progress`: the current
+wisp is frequently still `status=open`, so a query that only filters on
+status will match it, `NEXT` resolves to the id burned on the next line,
+and the witness is left holding zero wisps.
 ```bash
-OPEN_WISPS=$(gc bd list --assignee="$GC_AGENT" --status=open --type=molecule --limit=0 --json | jq -r '.[].id')
+THIS_WISP=<this-wisp-id>
+OPEN_WISPS=$(gc bd list --assignee="$GC_AGENT" --status=open --type=molecule --limit=0 --json \
+  | jq -r --arg self "$THIS_WISP" '.[] | select(.id != $self) | .id')
 NEXT=$(printf '%s\n' $OPEN_WISPS | sed -n '1p')
 for extra in $(printf '%s\n' $OPEN_WISPS | sed '1d'); do
   gc bd mol burn "$extra" --force
@@ -544,7 +553,7 @@ fi
 
 **3. Burn this wisp:**
 ```bash
-gc bd mol burn <this-wisp-id> --force
+gc bd mol burn "$THIS_WISP" --force
 ```
 
 **4. Exit this turn:**


### PR DESCRIPTION
## The bug

The `next-iteration` reconcile in `mol-witness-patrol` assumes the wisp the witness is currently executing is `in_progress`, so any `status=open` molecule the query returns must be a *distinct*, already-queued next iteration:

```bash
OPEN_WISPS=$(gc bd list --assignee="$GC_AGENT" --status=open --type=molecule --limit=0 --json | jq -r '.[].id')
NEXT=$(printf '%s\n' $OPEN_WISPS | sed -n '1p')
```

That assumption does not hold. The current wisp is frequently still `status=open` while it is being executed. When it is:

1. the query matches the wisp the witness is running,
2. `NEXT` resolves to that same id,
3. the `if [ -z "$NEXT" ]` pour is therefore skipped,
4. step 3 burns that id.

The witness ends the turn holding **zero** wisps.

## Why it matters

The patrol loop is wisp-driven and does not self-cycle. A witness that self-burns and then takes the `IDLE: no work, exiting turn` exit path sits with nothing on hook until something external wakes it — and a witness with no wisp is indistinguishable from a healthy idle one in the bead table, so the rig silently loses its work-health monitor.

That is the same class of silently-stalled patrol that #237 added detection for (14–63h stalls observed in production). This PR removes one root cause behind it rather than detecting it after the fact.

## The fix

Bind the current wisp id to `THIS_WISP` and exclude it from the reconcile, instead of inferring "not the current one" from status. Step 3 reuses the same variable, so the reuse candidate and the burn target can no longer disagree.

Surplus reconciliation is unchanged: genuinely duplicate queued wisps are still reused/burned down to exactly one.

## Evidence

Observed on a production gastown witness on 2026-07-29. The current wisp was `status=open`, the reconcile matched it, and the witness burned its only wisp and was left holding none.

After applying this change as a city-level formula override on that same witness, a live patrol turn ran the new step text and reconciled correctly: the wisp count held at exactly one and the id rotated (`sys-wisp-835` -> `sys-wisp-4f0`) — the new wisp was poured *before* the burn, which the previous code could not do once `NEXT` had resolved to the current id.

## Note on a separate, pre-existing defect

While soaking this I hit a second issue that this PR deliberately does **not** address, since it is independent and predates the change: the pour and the assign are two separate commands:

```bash
NEXT=$(gc bd mol wisp mol-witness-patrol --root-only ... | jq -r '.new_epic_id')
gc bd update "$NEXT" --assignee="$GC_AGENT"
```

If the session restarts between them, the freshly poured wisp is left unassigned and the witness still comes back with nothing on hook — the same end state, by a different route. Unassigned orphan `mol-witness-patrol` wisps dating back to 2026-07-15 are visible on the store I hit this on. Happy to send that as a follow-up if you'd like it fixed here too.