### PR TITLE
fix(gascity): resolve close-source-anchor from the root's stamped anchor id

### DIFF
--- a/gascity/assets/workflows/do-work/close-source-anchor.md
+++ b/gascity/assets/workflows/do-work/close-source-anchor.md
@@ -1,5 +1,21 @@
 
-Resolve `<source-anchor-id>` using the same rules as `prepare-worktree`. Read `work_dir` from the source anchor and verify the implementation commit and
+Resolve `<source-anchor-id>` from the workflow ROOT, which is the SINGLE SOURCE
+OF TRUTH for every step of this lane: read the claimed step bead's
+`gc.root_bead_id`, then read that root's `gc.source_anchor_id` metadata.
+`prepare-worktree` resolved the anchor deterministically and stamped it there,
+so DO NOT re-derive it — close EXACTLY that id, and use exactly that value as
+`<source-anchor-id>` everywhere below (worktree resolution AND every
+`gc bd show` / `bd update --set-metadata` that names the source anchor).
+
+FALLBACK — only if the root has NO `gc.source_anchor_id` (e.g. a hand-run step
+where `prepare-worktree` never ran): derive it exactly as `prepare-worktree`
+does — read the root's `gc.input_convoy_id`, unwrap a one-element list, and if
+that convoy has `gc.synthetic_kind=drain-unit-convoy` use its
+`gc.drain_member_id`, otherwise use the input convoy id itself. Never infer the
+anchor from dependency ids such as the `prepare-worktree` or implementation
+step bead.
+
+Read `work_dir` from the source anchor and verify the implementation commit and
 summary evidence are present in that worktree. Write per-item summary to
 {{summary_path}} when set. If `summary_path` is not set, first use
 `gc.implementation.summary_path` from the preceding implementation step when it

--- a/gascity/tests/test_formula_assets.py
+++ b/gascity/tests/test_formula_assets.py
@@ -3395,6 +3395,12 @@ class FormulaAssetTests(unittest.TestCase):
 
         close_source = node_description(root, steps["close-source-anchor"])
         for fragment in (
+            "gc.root_bead_id",
+            "gc.source_anchor_id",
+            "DO NOT re-derive",
+            "FALLBACK — only if the root has NO `gc.source_anchor_id`",
+            "gc.synthetic_kind=drain-unit-convoy",
+            "gc.drain_member_id",
             "Read `work_dir` from the source anchor",
             "close only `<source-anchor-id>`",
             "gc bd show <source-anchor-id> --json",
@@ -3405,6 +3411,28 @@ class FormulaAssetTests(unittest.TestCase):
             "Do not close this step with pass while the source anchor remains open",
         ):
             with self.subTest(step="close-source-anchor", fragment=fragment):
+                self.assertIn(fragment, close_source)
+
+    def test_pack_close_source_anchor_overrides_read_root_stamped_anchor(self) -> None:
+        gascity_root = pathlib.Path(__file__).resolve().parents[1]
+        pack_root = gascity_root.parent / "superpowers"
+
+        resolved = resolve_formula_from_dirs(
+            [gascity_root / "formulas", pack_root / "formulas"],
+            "superpowers-development",
+        )
+        steps = {step["id"]: step for step in resolved["steps"]}
+        close_source = node_description(pack_root, steps["close-source-anchor"])
+        for fragment in (
+            "gc.root_bead_id",
+            "gc.source_anchor_id",
+            "DO NOT re-derive",
+            "FALLBACK — only if the root has NO `gc.source_anchor_id`",
+            "gc.synthetic_kind=drain-unit-convoy",
+            "gc.drain_member_id",
+            "close only the source anchor with `gc.outcome=pass`",
+        ):
+            with self.subTest(pack="superpowers", fragment=fragment):
                 self.assertIn(fragment, close_source)
 
     def test_wrapper_formulas_route_role_agents(self) -> None:

--- a/superpowers/assets/workflows/superpowers-development/close-source-anchor.md
+++ b/superpowers/assets/workflows/superpowers-development/close-source-anchor.md
@@ -1,6 +1,19 @@
 Close the Superpowers implementation source anchor.
 
-Resolve the source anchor using the same rules as the inherited worktree setup.
+Resolve `<source-anchor-id>` from the workflow ROOT, which is the SINGLE SOURCE
+OF TRUTH for every step of this lane: read the claimed step bead's
+`gc.root_bead_id`, then read that root's `gc.source_anchor_id` metadata. The
+inherited `prepare-worktree` resolved the anchor deterministically and stamped
+it there, so DO NOT re-derive it — close EXACTLY that id.
+
+FALLBACK — only if the root has NO `gc.source_anchor_id` (e.g. a hand-run step
+where `prepare-worktree` never ran): derive it exactly as the inherited
+`prepare-worktree` does — read the root's `gc.input_convoy_id`, unwrap a
+one-element list, and if that convoy has `gc.synthetic_kind=drain-unit-convoy`
+use its `gc.drain_member_id`, otherwise use the input convoy id itself. Never
+infer the anchor from dependency ids such as the `prepare-worktree` or
+implementation step bead.
+
 Read `work_dir`, verify the task summary exists, verify the expected task commit
 or clean working-tree evidence exists, and confirm the source anchor still
 matches the current drained item.


### PR DESCRIPTION
> [!WARNING]
> **Opened as DRAFT — the test gate could not be verified (not a detected failure).**
> The automated review loop APPROVED this commit, but the suite could not be run on
> GitHub: `ci.yml` has no `workflow_dispatch` trigger, and the ci-gate step is forbidden
> from opening a PR or pushing `main` to trigger it. Opening this PR is itself the first
> chance `ci.yml` gets to run. Once a maintainer approves the run and it is green,
> `gh pr ready` is all that is needed.

## What changed

`close-source-anchor` re-resolved the source anchor with its own prose ("using the same
rules as prepare-worktree") instead of reading the deterministic `gc.source_anchor_id`
that `prepare-worktree` stamps on the workflow root. On a single-item sling the
independent derivation picked the *wrapper convoy*, so the step closed the convoy and
left the real item OPEN (repro: pr-work-loop run `tlp-unm1k`, item `tlp-rrecc` stayed
open while close-source-anchor passed).

This gives `close-source-anchor` the same single-source-of-truth treatment the
pr-work-loop steps already have: read the claimed step bead's `gc.root_bead_id`, then
that root's `gc.source_anchor_id`, and close EXACTLY that id. The multi-hop derivation is
kept only as an explicit fallback for hand-run steps where `prepare-worktree` never ran.

The `superpowers-development` pack overrides this step with the same defective prose, so
it gets the identical change. `implementation-base`'s stub carries no anchor-resolution
prose and is unchanged.

3 files changed, +59/-2:

| File | Why |
| --- | --- |
| `gascity/assets/workflows/do-work/close-source-anchor.md` | the fix |
| `superpowers/assets/workflows/superpowers-development/close-source-anchor.md` | same defect in the override |
| `gascity/tests/test_formula_assets.py` | fragment assertions lock both descriptions in |

## How it was tested

All results below were produced by the automated review lanes running inside the item
worktree, and are reproduced here as they reported them. This PR-opening step ran no
tests of its own.

The review lanes reported that the new fragment assertions *bite*: `git show
HEAD~1:<file>` returned 0 hits for `gc.source_anchor_id` in both assets, so every new
assertion fails pre-change. They further reported green runs of `gascity/tests` (86/86),
`test_derived_pack_compatibility` (10/10), `gc lint gascity`, `gc lint superpowers`,
`go test .`, and `validate_registry.py --require-git`.

All of that was executed on a developer machine, NOT on GitHub's runners. Nothing in this
PR has yet been verified by CI — see the CI gate section.

Closes gp-a1i
Refs: gp-cs3, gp-fk9

## CI gate

⚠️ **Test gate NOT VERIFIED** — no failure was attributed to this diff, because the suite could not be run at all (raw suite conclusion: `unknown`; run URL: none). This is an infrastructure limitation, **not** a detected test failure. Per the lane's fail-closed rule an unverifiable gate opens a DRAFT rather than a ready PR.

<details>
<summary>Full gate adjudication</summary>

```
VERDICT fail — the specified suite could NOT be run on GitHub. Infra, not a code failure.
Branch pr-work/gp-a1i-80b050b @80b050b pushed to figgeous/gascity-packs (gc.pr_head_repo);
origin gastownhall/gascity-packs is pull-only for this account (permissions.push=false), so
open-pr must use --head figgeous:pr-work/gp-a1i-80b050b.

Why no run (verified, not assumed):
* ci.yml has NO workflow_dispatch — only pull_request[main] + push[main]. Dispatch on origin
  -> HTTP 403 "Must have admin rights"; on the fork -> HTTP 404 "not found on default branch".
* Fork Actions are enabled but its workflow registry is empty (actions/workflows count=0).
* A feature-branch push triggers nothing. The only live triggers are opening a PR and pushing
  the base branch — both explicitly forbidden by this step.

BASELINE (established, and stronger than the step's 24h heuristic): ci.yml run 30152962616,
event=push, headSha 637398502880... which is BOTH origin/main tip AND this branch's exact
merge-base (HEAD~1), conclusion=success.
https://github.com/gastownhall/gascity-packs/actions/runs/30152962616
So the baseline failure set is EMPTY at the merge-base. The BRANCH failure set is unobtainable,
so NEW is UNDETERMINED, not empty — recording pass would assert a suite ran and none did.
Fail-closed -> DRAFT PR, matching this formula's stated design.

Read this as "NOT VERIFIED", not "this diff breaks tests": the review loop approved 80b050b and
both review lanes ran the touched suites green inside the worktree. Note also that every recent
ci.yml pull_request run concluded action_required, so the draft PR will not auto-green either —
a gastownhall maintainer must approve the run.
Formula defect (ci-gate assumes a dispatchable ci.yml this rig lacks) filed as bead gp-fk9.
```

</details>

## Automated review — synthesis (verdict: approved)

```
verdict=approved polish=clean: both lanes returned OK on 80b050b with zero actionable findings. Correctness: the new rule is strictly additive (pinned root gc.source_anchor_id when present, otherwise the prior derivation verbatim), the new fragment assertions were shown to bite against HEAD~1, and gascity/tests is 86/86. Risk: no guardrail path touched (.github/, schema, auth, billing, env, pool all untouched), and gc lint gascity/superpowers, go test ., validate_registry --require-git all pass locally. Everything each lane raised sits under its NOTES: heading as PR-body follow-up material — dormant-stamp wording, deferred REQ-004, a suggested assertNotIn, the unfixed implement.md prose, drain-unit fail-safe, and release-pin rollout — none of which is a must-fix or a minor-gap.

FINDINGS: none
```

<details>
<summary>Automated review — correctness + tests</summary>

```
OK — no actionable findings above the severity floor.

Reviewed 80b050b (3 files, +59/-2): do-work + superpowers-development
close-source-anchor.md prose, plus fragment assertions in test_formula_assets.py.
First pass (no prior GC-REVIEW-SYNTHESIS block on the anchor).

- Correctness: the new rule is strictly additive. When the root carries
  `gc.source_anchor_id` the step pins to it; when it does not, the FALLBACK
  reproduces the previous derivation verbatim (root `gc.input_convoy_id` ->
  unwrap one-element list -> `gc.drain_member_id` when
  `gc.synthetic_kind=drain-unit-convoy`, else the convoy id). No lane can now
  resolve a *different* anchor than it did before, so there is no regression
  path; worst case is status quo.
- Scope: `implementation-base/close-source-anchor.md` is genuinely a contract
  stub with no anchor-resolution prose (read it) — correct to exclude.
  `superpowers-development-item.formula.toml` points at the same edited asset,
  so it is fixed transitively. `do-work-item` / `implementation-item-base` own
  no `close-source-anchor.md` (the bead's sibling list was stale).
- Tests bite: `git show HEAD~1:<file>` returns 0 hits for `gc.source_anchor_id`
  in both assets, so every new fragment assertion fails pre-change. Suites green
  from inside the worktree: `test_formula_assets` 86/86, and
  `test_derived_pack_compatibility` 10/10 (which is what guards the superpowers
  asset's native-dispatch sentence).
- The summary's "pre-existing failure" claim checks out independently:
  `gascity/commands/claim/run.sh:96` uses `EXPECTED_ROUTE="${GC_TEMPLATE:-...}"`
  while the claim tests build env as `{**os.environ, "GC_AGENT": ...}`, so
  `test_city_claim_command_verifies_and_normalizes_claim` fails only when a
  GC_TEMPLATE is ambient. Present at HEAD~1; not this diff.

NOTES:
- N1 The pinned branch is dormant for base `do-work` lanes: that
  `prepare-worktree` stamps only `work_dir` on the anchor, never
  `gc.source_anchor_id` on the root, so line 5's "prepare-worktree ... stamped
  it there" and the FALLBACK's "(e.g. a hand-run step where prepare-worktree
  never ran)" mis-describe the *common* case rather than an edge case. Behavior
  is unaffected (fallback == old rule), but the parenthetical invites a worker
  to treat a missing stamp as an anomaly. Cheap fix: "(e.g. lanes whose
  prepare-worktree does not stamp it, or a hand-run step)".
- N2 The reported symptom still reproduces on this very run's shape: root gp-2by
  stamps `gc.source_anchor_id=gp-a1i`, the synthetic wrapper convoy, so
  close-source-anchor will close gp-a1i and gp-cs3 stays OPEN. That is REQ-004,
  which gp-cs3 itself calls SECONDARY / needs-a-design-decision and the summary
  defers — fine, but no follow-up bead exists yet (bd list shows only gp-cs3),
  and neither does one for adding the stamper to base `prepare-worktree`.
- N3 The assertions are positive-only. Re-adding "Resolve `<source-anchor-id>`
  using the same rules as `prepare-worktree`" alongside the new paragraphs would
  keep both tests green while restoring the independent derivation. One
  `assertNotIn("using the same rules as", close_source)` per test closes that.
- N4 `do-work/implement.md:2` and `superpowers-development/implement.md:3` still
  carry the identical "same rules as `prepare-worktree`" independent-resolution
  prose this diff just removed from close-source-anchor — same defect class,
  out of this bead's scope, but it is what makes implement and close disagree in
  any lane where the root IS stamped.
```

</details>

<details>
<summary>Automated review — guardrails + risk</summary>

```
OK — no guardrail-path exposure and no plausible prod failure mode.

Reviewed 80b050b (3 files, +59/-2). First pass (no prior GC-REVIEW-SYNTHESIS
block). Correctness/test-adequacy is the sibling lane's; this is guardrails,
blast radius, and rollout.

- Guardrail sweep: nothing here touches schema/migrations, auth, billing,
  env/secrets, DB pool routing, or CI config — `.github/` is untouched. The diff
  is two workflow prompt assets plus `gascity/tests/test_formula_assets.py`. No
  runtime code, no shell scripts, no formula wiring changes (`description_file`
  targets are unchanged, so no step re-points at a different asset).
- PR gates verified locally from inside the worktree rather than assumed. Every
  `ci.yml` step this diff can reach is green: `gc lint gascity` ok,
  `gc lint superpowers` ok, `go test .` ok (embed asserts file presence, and no
  file was added/removed/renamed), `python3 validate_registry.py --require-git`
  ok, `gascity/tests` 86/86. The module the summary recorded as un-run,
  `tests/test_gascity_pack_inference_gate.py`, *is* a PR gate (ci.yml's pytest
  step includes `tests`), but it has zero references to workflow assets — that
  gap is closed, not merely deferred to ci-gate.
- Blast radius is wide but uniform, which is the safe shape: `do-work`'s
  close-source-anchor description is inherited unchanged by
  `bmad-story-development`, `compound-work`, `build-basic`,
  `build-from-convoy-base` and `gstack-work`; `superpowers-development` is the
  only override in the tree and it got the identical edit. No pack here stamps
  `gc.source_anchor_id` (zero hits repo-wide), so all inherited lanes take the
  fallback and behave exactly as before — no half-migrated pack.
- Security: no secrets, tenant scoping, or input-validation surface. The prose
  introduces no new command shapes; the `gc bd show` / `bd update
  --set-metadata` forms it names already existed in the same file.

NOTES:
- Fail-safe interaction worth knowing: on the pinned path the step trusts one
  externally-stamped id, and the old derivation's guard ("hard-fail if the
  selected anchor is the synthetic drain-unit convoy") now lives only in the
  fallback. A mis-stamped root could therefore point the step at the drain-unit
  convoy. Two backstops survive — the `work_dir`/commit/summary evidence check
  before closing, and the standing "do not close the drain-unit convoy" line —
  so it fails closed rather than closing a stranger. No stamper in this repo can
  produce that state today.
- Rollout: `gascity` reaches the `gc` binary via `//go:embed all:gascity` and
  reaches installs via registry.toml release pins at historical commits (gascity
  0.1.6, superpowers 0.1.0). Nothing already installed changes; the fix is inert
  for pinned consumers until new pins are cut post-merge, and when they are it
  lands in every do-work-derived lane at once. Rollback = revert + re-pin.
- No PR gate can prove a worker obeys new prose. The live inference gates
  (`gascity-pack-inference.yml`) are workflow_dispatch/repository_dispatch only,
  so the first real validation is a `pr-work-loop` run closing the stamped
  anchor — worth watching on the run that merges this.
```

</details>
