### PR TITLE
fix(gascity): surface gc bd stderr in check-gate failures so gc.attempt_log carries the real error

### DIFF
--- a/gascity/assets/scripts/checks/build-artifact-valid.sh
+++ b/gascity/assets/scripts/checks/build-artifact-valid.sh
@@ -50,8 +50,9 @@ print(value if isinstance(value, str) else "")
 }
 
 GC_ERR="$(mktemp)"
+trap 'rm -f "$GC_ERR"' EXIT
 SHOW_JSON="$(gc bd show "$BEAD_ID" --json 2>"$GC_ERR")" \
-  || fail "gc bd show $BEAD_ID failed: $(head -c 400 "$GC_ERR" | tr '\n' ' ')"
+  || fail "gc bd show $BEAD_ID failed: $(tail -c 400 "$GC_ERR" | tr '\n' ' ')"
 
 SCHEMA="$(metadata_value "$SHOW_JSON" "gc.build.artifact_schema")"
 PATH_KEYS="$(metadata_value "$SHOW_JSON" "gc.build.artifact_path_keys")"
@@ -62,7 +63,7 @@ ROOT_ID="$(metadata_value "$SHOW_JSON" "gc.root_bead_id")"
 ROOT_JSON="$SHOW_JSON"
 if [ -n "$ROOT_ID" ] && [ "$ROOT_ID" != "$BEAD_ID" ]; then
   ROOT_JSON="$(gc bd show "$ROOT_ID" --json 2>"$GC_ERR")" \
-    || fail "gc bd show $ROOT_ID failed: $(head -c 400 "$GC_ERR" | tr '\n' ' ')"
+    || fail "gc bd show $ROOT_ID failed: $(tail -c 400 "$GC_ERR" | tr '\n' ' ')"
 fi
 
 ARTIFACT_PATH=""

--- a/gascity/assets/scripts/checks/build-artifact-valid.sh
+++ b/gascity/assets/scripts/checks/build-artifact-valid.sh
@@ -49,7 +49,9 @@ print(value if isinstance(value, str) else "")
 ' "$2"
 }
 
-SHOW_JSON="$(gc bd show "$BEAD_ID" --json 2>/dev/null)" || fail "gc bd show $BEAD_ID failed"
+GC_ERR="$(mktemp)"
+SHOW_JSON="$(gc bd show "$BEAD_ID" --json 2>"$GC_ERR")" \
+  || fail "gc bd show $BEAD_ID failed: $(head -c 400 "$GC_ERR" | tr '\n' ' ')"
 
 SCHEMA="$(metadata_value "$SHOW_JSON" "gc.build.artifact_schema")"
 PATH_KEYS="$(metadata_value "$SHOW_JSON" "gc.build.artifact_path_keys")"
@@ -59,7 +61,8 @@ PATH_KEYS="$(metadata_value "$SHOW_JSON" "gc.build.artifact_path_keys")"
 ROOT_ID="$(metadata_value "$SHOW_JSON" "gc.root_bead_id")"
 ROOT_JSON="$SHOW_JSON"
 if [ -n "$ROOT_ID" ] && [ "$ROOT_ID" != "$BEAD_ID" ]; then
-  ROOT_JSON="$(gc bd show "$ROOT_ID" --json 2>/dev/null)" || fail "gc bd show $ROOT_ID failed"
+  ROOT_JSON="$(gc bd show "$ROOT_ID" --json 2>"$GC_ERR")" \
+    || fail "gc bd show $ROOT_ID failed: $(head -c 400 "$GC_ERR" | tr '\n' ' ')"
 fi
 
 ARTIFACT_PATH=""

--- a/gascity/assets/scripts/checks/build-artifact-valid.sh
+++ b/gascity/assets/scripts/checks/build-artifact-valid.sh
@@ -50,7 +50,10 @@ print(value if isinstance(value, str) else "")
 }
 
 GC_ERR="$(mktemp)"
-trap 'rm -f "$GC_ERR"' EXIT
+# EXIT alone does not fire on an untrapped signal, and check gates run under a
+# documented 10m dispatcher budget -- timeout kills are an expected path, not a
+# hypothetical one, so each would leak this capture file. SIGKILL leaks either way.
+trap 'rm -f "$GC_ERR"' EXIT INT TERM HUP
 SHOW_JSON="$(gc bd show "$BEAD_ID" --json 2>"$GC_ERR")" \
   || fail "gc bd show $BEAD_ID failed: $(tail -c 400 "$GC_ERR" | tr '\n' ' ')"
 

--- a/gascity/assets/scripts/checks/design-review-approved.sh
+++ b/gascity/assets/scripts/checks/design-review-approved.sh
@@ -44,8 +44,9 @@ if [ -z "$BEAD_ID" ]; then
 fi
 
 GC_ERR="$(mktemp)"
+trap 'rm -f "$GC_ERR"' EXIT
 BEAD_JSON=$(gc bd show "$BEAD_ID" --json 2>"$GC_ERR") || {
-    echo "ERROR: gc bd show $BEAD_ID failed: $(head -c 400 "$GC_ERR" | tr '\n' ' ')" >&2
+    echo "ERROR: gc bd show $BEAD_ID failed: $(tail -c 400 "$GC_ERR" | tr '\n' ' ')" >&2
     exit 1
 }
 ROOT_ID=$(printf '%s\n' "$BEAD_JSON" | jq -r 'if type == "array" then (.[0].metadata["gc.root_bead_id"] // "") else (.metadata["gc.root_bead_id"] // "") end')

--- a/gascity/assets/scripts/checks/design-review-approved.sh
+++ b/gascity/assets/scripts/checks/design-review-approved.sh
@@ -44,7 +44,10 @@ if [ -z "$BEAD_ID" ]; then
 fi
 
 GC_ERR="$(mktemp)"
-trap 'rm -f "$GC_ERR"' EXIT
+# EXIT alone does not fire on an untrapped signal, and check gates run under a
+# documented 10m dispatcher budget -- timeout kills are an expected path, not a
+# hypothetical one, so each would leak this capture file. SIGKILL leaks either way.
+trap 'rm -f "$GC_ERR"' EXIT INT TERM HUP
 BEAD_JSON=$(gc bd show "$BEAD_ID" --json 2>"$GC_ERR") || {
     echo "ERROR: gc bd show $BEAD_ID failed: $(tail -c 400 "$GC_ERR" | tr '\n' ' ')" >&2
     exit 1

--- a/gascity/assets/scripts/checks/design-review-approved.sh
+++ b/gascity/assets/scripts/checks/design-review-approved.sh
@@ -43,7 +43,11 @@ if [ -z "$BEAD_ID" ]; then
     exit 1
 fi
 
-BEAD_JSON=$(gc bd show "$BEAD_ID" --json 2>/dev/null)
+GC_ERR="$(mktemp)"
+BEAD_JSON=$(gc bd show "$BEAD_ID" --json 2>"$GC_ERR") || {
+    echo "ERROR: gc bd show $BEAD_ID failed: $(head -c 400 "$GC_ERR" | tr '\n' ' ')" >&2
+    exit 1
+}
 ROOT_ID=$(printf '%s\n' "$BEAD_JSON" | jq -r 'if type == "array" then (.[0].metadata["gc.root_bead_id"] // "") else (.metadata["gc.root_bead_id"] // "") end')
 ATTEMPT=$(printf '%s\n' "$BEAD_JSON" | jq -r 'if type == "array" then (.[0].metadata["gc.attempt"] // "") else (.metadata["gc.attempt"] // "") end')
 SCOPE_REF=$(printf '%s\n' "$BEAD_JSON" | jq -r 'if type == "array" then (.[0].metadata["gc.scope_ref"] // .[0].metadata["gc.step_ref"] // "") else (.metadata["gc.scope_ref"] // .metadata["gc.step_ref"] // "") end')

--- a/gascity/assets/scripts/checks/gap-analysis-approved.sh
+++ b/gascity/assets/scripts/checks/gap-analysis-approved.sh
@@ -57,7 +57,10 @@ metadata_value() {
 }
 
 GC_ERR="$(mktemp)"
-trap 'rm -f "$GC_ERR"' EXIT
+# EXIT alone does not fire on an untrapped signal, and check gates run under a
+# documented 10m dispatcher budget -- timeout kills are an expected path, not a
+# hypothetical one, so each would leak this capture file. SIGKILL leaks either way.
+trap 'rm -f "$GC_ERR"' EXIT INT TERM HUP
 if ! ROOT_JSON="$(gc bd show "$ROOT_ID" --json 2>"$GC_ERR")"; then
   echo "gap check: note: gc bd show $ROOT_ID failed: $(tail -c 400 "$GC_ERR" | tr '\n' ' ')" >&2
 fi

--- a/gascity/assets/scripts/checks/gap-analysis-approved.sh
+++ b/gascity/assets/scripts/checks/gap-analysis-approved.sh
@@ -56,7 +56,9 @@ metadata_value() {
   ' 2>/dev/null
 }
 
-ROOT_JSON="$(gc bd show "$ROOT_ID" --json 2>/dev/null || true)"
+GC_ERR="$(mktemp)"
+ROOT_JSON="$(gc bd show "$ROOT_ID" --json 2>"$GC_ERR" || true)"
+[ -n "$ROOT_JSON" ] || echo "gap check: note: gc bd show $ROOT_ID failed: $(head -c 400 "$GC_ERR" | tr '\n' ' ')" >&2
 PARENT_ROOT="$(metadata_value "$ROOT_JSON" "gc.root_bead_id")"
 if [ -z "$PARENT_ROOT" ]; then
   PARENT_ROOT="$ROOT_ID"

--- a/gascity/assets/scripts/checks/gap-analysis-approved.sh
+++ b/gascity/assets/scripts/checks/gap-analysis-approved.sh
@@ -57,8 +57,10 @@ metadata_value() {
 }
 
 GC_ERR="$(mktemp)"
-ROOT_JSON="$(gc bd show "$ROOT_ID" --json 2>"$GC_ERR" || true)"
-[ -n "$ROOT_JSON" ] || echo "gap check: note: gc bd show $ROOT_ID failed: $(head -c 400 "$GC_ERR" | tr '\n' ' ')" >&2
+trap 'rm -f "$GC_ERR"' EXIT
+if ! ROOT_JSON="$(gc bd show "$ROOT_ID" --json 2>"$GC_ERR")"; then
+  echo "gap check: note: gc bd show $ROOT_ID failed: $(tail -c 400 "$GC_ERR" | tr '\n' ' ')" >&2
+fi
 PARENT_ROOT="$(metadata_value "$ROOT_JSON" "gc.root_bead_id")"
 if [ -z "$PARENT_ROOT" ]; then
   PARENT_ROOT="$ROOT_ID"

--- a/gascity/assets/scripts/checks/implementation-review-approved.sh
+++ b/gascity/assets/scripts/checks/implementation-review-approved.sh
@@ -90,14 +90,17 @@ is_approved() {
   return 1
 }
 
-ROOT_JSON="$(gc bd show "$ROOT_ID" --json 2>/dev/null || true)"
+GC_ERR="$(mktemp)"
+ROOT_JSON="$(gc bd show "$ROOT_ID" --json 2>"$GC_ERR" || true)"
+[ -n "$ROOT_JSON" ] || echo "review check: note: gc bd show $ROOT_ID failed: $(head -c 400 "$GC_ERR" | tr '\n' ' ')" >&2
 PARENT_ROOT="$(metadata_value "$ROOT_JSON" "gc.root_bead_id")"
 if [ -z "$PARENT_ROOT" ]; then
   PARENT_ROOT="$ROOT_ID"
 fi
 PARENT_JSON="$ROOT_JSON"
 if [ "$PARENT_ROOT" != "$ROOT_ID" ]; then
-  PARENT_JSON="$(gc bd show "$PARENT_ROOT" --json 2>/dev/null || true)"
+  PARENT_JSON="$(gc bd show "$PARENT_ROOT" --json 2>"$GC_ERR" || true)"
+  [ -n "$PARENT_JSON" ] || echo "review check: note: gc bd show $PARENT_ROOT failed: $(head -c 400 "$GC_ERR" | tr '\n' ' ')" >&2
 fi
 STEP_ID="$(metadata_value "$ROOT_JSON" "gc.step_id")"
 SCOPE_REF="$(metadata_value "$ROOT_JSON" "gc.scope_ref")"

--- a/gascity/assets/scripts/checks/implementation-review-approved.sh
+++ b/gascity/assets/scripts/checks/implementation-review-approved.sh
@@ -91,16 +91,19 @@ is_approved() {
 }
 
 GC_ERR="$(mktemp)"
-ROOT_JSON="$(gc bd show "$ROOT_ID" --json 2>"$GC_ERR" || true)"
-[ -n "$ROOT_JSON" ] || echo "review check: note: gc bd show $ROOT_ID failed: $(head -c 400 "$GC_ERR" | tr '\n' ' ')" >&2
+trap 'rm -f "$GC_ERR"' EXIT
+if ! ROOT_JSON="$(gc bd show "$ROOT_ID" --json 2>"$GC_ERR")"; then
+  echo "review check: note: gc bd show $ROOT_ID failed: $(tail -c 400 "$GC_ERR" | tr '\n' ' ')" >&2
+fi
 PARENT_ROOT="$(metadata_value "$ROOT_JSON" "gc.root_bead_id")"
 if [ -z "$PARENT_ROOT" ]; then
   PARENT_ROOT="$ROOT_ID"
 fi
 PARENT_JSON="$ROOT_JSON"
 if [ "$PARENT_ROOT" != "$ROOT_ID" ]; then
-  PARENT_JSON="$(gc bd show "$PARENT_ROOT" --json 2>"$GC_ERR" || true)"
-  [ -n "$PARENT_JSON" ] || echo "review check: note: gc bd show $PARENT_ROOT failed: $(head -c 400 "$GC_ERR" | tr '\n' ' ')" >&2
+  if ! PARENT_JSON="$(gc bd show "$PARENT_ROOT" --json 2>"$GC_ERR")"; then
+    echo "review check: note: gc bd show $PARENT_ROOT failed: $(tail -c 400 "$GC_ERR" | tr '\n' ' ')" >&2
+  fi
 fi
 STEP_ID="$(metadata_value "$ROOT_JSON" "gc.step_id")"
 SCOPE_REF="$(metadata_value "$ROOT_JSON" "gc.scope_ref")"

--- a/gascity/assets/scripts/checks/implementation-review-approved.sh
+++ b/gascity/assets/scripts/checks/implementation-review-approved.sh
@@ -91,7 +91,10 @@ is_approved() {
 }
 
 GC_ERR="$(mktemp)"
-trap 'rm -f "$GC_ERR"' EXIT
+# EXIT alone does not fire on an untrapped signal, and check gates run under a
+# documented 10m dispatcher budget -- timeout kills are an expected path, not a
+# hypothetical one, so each would leak this capture file. SIGKILL leaks either way.
+trap 'rm -f "$GC_ERR"' EXIT INT TERM HUP
 if ! ROOT_JSON="$(gc bd show "$ROOT_ID" --json 2>"$GC_ERR")"; then
   echo "review check: note: gc bd show $ROOT_ID failed: $(tail -c 400 "$GC_ERR" | tr '\n' ' ')" >&2
 fi

--- a/gascity/tests/test_formula_assets.py
+++ b/gascity/tests/test_formula_assets.py
@@ -6011,12 +6011,14 @@ description = "Override sink that writes the base triage report contract."
             fake_gc = bin_dir / "gc"
             fake_gc.write_text(
                 "#!/bin/sh\n"
+                # The member read is `gc ready` (see gmol); let it succeed with an
+                # empty union so this test isolates the tolerant `gc bd show` site.
+                "if [ \"$1\" = \"ready\" ]; then\n"
+                "  printf '[]\\n'\n"
+                "  exit 0\n"
+                "fi\n"
                 "if [ \"$2\" = \"show\" ]; then\n"
                 "  echo 'STDERR_A root lookup unavailable' >&2\n"
-                "  exit 3\n"
-                "fi\n"
-                "if [ \"$2\" = \"list\" ]; then\n"
-                "  echo 'STDERR_B list lookup unavailable' >&2\n"
                 "  exit 3\n"
                 "fi\n"
                 "exit 99\n",
@@ -6036,11 +6038,9 @@ description = "Override sink that writes the base triage report contract."
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("review check: note: gc bd show root-err failed", result.stderr)
         self.assertIn("STDERR_A", result.stderr)
-        self.assertIn("review check: note: gc bd list for root root-err failed", result.stderr)
-        self.assertIn("STDERR_B", result.stderr)
         self.assertIn("Implementation review needs another iteration: missing verdict", result.stdout)
 
-    def test_design_review_check_surfaces_gc_bd_list_pipeline_stderr(self) -> None:
+    def test_design_review_check_surfaces_member_read_stderr(self) -> None:
         root = pathlib.Path(__file__).resolve().parents[1]
         script = root / "assets" / "scripts" / "checks" / "design-review-approved.sh"
 
@@ -6067,7 +6067,7 @@ description = "Override sink that writes the base triage report contract."
             result = subprocess.run([str(script)], capture_output=True, env=env, text=True)
 
         self.assertEqual(result.returncode, 1)
-        self.assertIn("ERROR: gc bd list/jq pipeline for root root-ok failed", result.stderr)
+        self.assertIn("gmol: gc ready failed for status:", result.stderr)
         self.assertIn("DISTINCTIVE_LIST_FAILURE", result.stderr)
 
     def test_gap_analysis_check_notes_gc_bd_stderr_on_tolerant_paths(self) -> None:
@@ -6080,12 +6080,17 @@ description = "Override sink that writes the base triage report contract."
             fake_gc = bin_dir / "gc"
             fake_gc.write_text(
                 "#!/bin/sh\n"
+                # The member read is `gc ready` (see gmol); let it succeed with an
+                # empty union so this test isolates the tolerant `gc bd show` site.
+                "if [ \"$1\" = \"ready\" ]; then\n"
+                "  printf '[]\\n'\n"
+                "  exit 0\n"
+                "fi\n"
                 "if [ \"$2\" = \"show\" ]; then\n"
                 "  echo 'GAP_SHOW_FAILURE' >&2\n"
-                "else\n"
-                "  echo 'GAP_LIST_FAILURE' >&2\n"
+                "  exit 3\n"
                 "fi\n"
-                "exit 3\n",
+                "exit 99\n",
                 encoding="utf-8",
             )
             fake_gc.chmod(0o755)
@@ -6100,9 +6105,78 @@ description = "Override sink that writes the base triage report contract."
         self.assertEqual(result.returncode, 1)
         self.assertIn("gap check: note: gc bd show gap-root failed", result.stderr)
         self.assertIn("GAP_SHOW_FAILURE", result.stderr)
-        self.assertIn("gap check: note: gc bd list for root gap-root failed", result.stderr)
-        self.assertIn("GAP_LIST_FAILURE", result.stderr)
         self.assertIn("Gap analysis needs another iteration: missing verdict", result.stdout)
+
+    # The member read these gates make is `gc ready`, one leg per status, and a
+    # failed leg has to fail the gate rather than contribute an empty set: an
+    # empty union is indistinguishable from "no verdict yet", so swallowing the
+    # error starves the gate silently until Ralph runs out of attempts. The two
+    # tests below pin that -- the underlying stderr reaches the gate's stderr,
+    # and the gate does NOT reach its "needs another iteration" dispatch.
+
+    def test_implementation_review_check_fails_loudly_when_member_read_fails(self) -> None:
+        root = pathlib.Path(__file__).resolve().parents[1]
+        script = root / "assets" / "scripts" / "checks" / "implementation-review-approved.sh"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            bin_dir = pathlib.Path(tmp) / "bin"
+            bin_dir.mkdir()
+            fake_gc = bin_dir / "gc"
+            fake_gc.write_text(
+                "#!/bin/sh\n"
+                "if [ \"$2\" = \"show\" ]; then\n"
+                "  printf '%s\\n' '{\"metadata\":{\"gc.root_bead_id\":\"root-ok\",\"gc.attempt\":\"1\"}}'\n"
+                "  exit 0\n"
+                "fi\n"
+                "echo 'REVIEW_MEMBER_READ_FAILURE' >&2\n"
+                "exit 3\n",
+                encoding="utf-8",
+            )
+            fake_gc.chmod(0o755)
+            env = {
+                **os.environ,
+                "GC_BEAD_ID": "root-ok",
+                "GC_ITERATION": "1",
+                "PATH": f"{bin_dir}:{os.environ.get('PATH', '')}",
+            }
+            result = subprocess.run([str(script)], capture_output=True, env=env, text=True)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("gmol: gc ready failed for status:", result.stderr)
+        self.assertIn("REVIEW_MEMBER_READ_FAILURE", result.stderr)
+        self.assertNotIn("needs another iteration", result.stdout)
+
+    def test_gap_analysis_check_fails_loudly_when_member_read_fails(self) -> None:
+        root = pathlib.Path(__file__).resolve().parents[1]
+        script = root / "assets" / "scripts" / "checks" / "gap-analysis-approved.sh"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            bin_dir = pathlib.Path(tmp) / "bin"
+            bin_dir.mkdir()
+            fake_gc = bin_dir / "gc"
+            fake_gc.write_text(
+                "#!/bin/sh\n"
+                "if [ \"$2\" = \"show\" ]; then\n"
+                "  printf '%s\\n' '{\"metadata\":{\"gc.root_bead_id\":\"gap-ok\",\"gc.attempt\":\"1\"}}'\n"
+                "  exit 0\n"
+                "fi\n"
+                "echo 'GAP_MEMBER_READ_FAILURE' >&2\n"
+                "exit 3\n",
+                encoding="utf-8",
+            )
+            fake_gc.chmod(0o755)
+            env = {
+                **os.environ,
+                "GC_BEAD_ID": "gap-ok",
+                "GC_ITERATION": "1",
+                "PATH": f"{bin_dir}:{os.environ.get('PATH', '')}",
+            }
+            result = subprocess.run([str(script)], capture_output=True, env=env, text=True)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("gmol: gc ready failed for status:", result.stderr)
+        self.assertIn("GAP_MEMBER_READ_FAILURE", result.stderr)
+        self.assertNotIn("needs another iteration", result.stdout)
 
 
 if __name__ == "__main__":

--- a/gascity/tests/test_formula_assets.py
+++ b/gascity/tests/test_formula_assets.py
@@ -4,6 +4,7 @@ import json
 import os
 import pathlib
 import re
+import shutil
 import subprocess
 import tempfile
 import tomllib
@@ -5972,6 +5973,64 @@ description = "Override sink that writes the base triage report contract."
             write_report_step["expand_vars"]["artifact_path_keys"],
             artifact_keys,
         )
+
+
+    def test_build_artifact_check_failure_surfaces_gc_bd_stderr(self) -> None:
+        root = pathlib.Path(__file__).resolve().parents[1]
+        script = root / "assets" / "scripts" / "checks" / "build-artifact-valid.sh"
+        jq_dir = pathlib.Path(shutil.which("jq") or "/usr/bin/jq").parent
+
+        with tempfile.TemporaryDirectory() as tmp:
+            bin_dir = pathlib.Path(tmp) / "bin"
+            bin_dir.mkdir()
+            fake_gc = bin_dir / "gc"
+            fake_gc.write_text(
+                "#!/bin/sh\n"
+                "echo 'IMPORT_LOCKED_NOT_CACHED run gc import install' >&2\n"
+                "exit 3\n",
+                encoding="utf-8",
+            )
+            fake_gc.chmod(0o755)
+            env = {
+                **os.environ,
+                "GC_BEAD_ID": "bd-err",
+                "PATH": f"{bin_dir}:{jq_dir}:/usr/bin:/bin",
+            }
+            result = subprocess.run([str(script)], capture_output=True, env=env, text=True)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("gc bd show bd-err failed", result.stderr)
+        self.assertIn("IMPORT_LOCKED_NOT_CACHED", result.stderr)
+
+    def test_implementation_review_check_notes_gc_bd_stderr_on_tolerant_paths(self) -> None:
+        root = pathlib.Path(__file__).resolve().parents[1]
+        script = root / "assets" / "scripts" / "checks" / "implementation-review-approved.sh"
+        jq_dir = pathlib.Path(shutil.which("jq") or "/usr/bin/jq").parent
+
+        with tempfile.TemporaryDirectory() as tmp:
+            bin_dir = pathlib.Path(tmp) / "bin"
+            bin_dir.mkdir()
+            fake_gc = bin_dir / "gc"
+            fake_gc.write_text(
+                "#!/bin/sh\n"
+                "echo 'STORE_UNAVAILABLE backing store offline' >&2\n"
+                "exit 3\n",
+                encoding="utf-8",
+            )
+            fake_gc.chmod(0o755)
+            env = {
+                **os.environ,
+                "GC_BEAD_ID": "root-err",
+                "GC_ITERATION": "1",
+                "PATH": f"{bin_dir}:{jq_dir}:/usr/bin:/bin",
+            }
+            result = subprocess.run([str(script)], capture_output=True, env=env, text=True)
+
+        # Tolerant sites keep their fallbacks (the gate still iterates rather
+        # than crashing), but the attempt log now carries the real error.
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("review check: note: gc bd show root-err failed", result.stderr)
+        self.assertIn("STORE_UNAVAILABLE", result.stderr)
 
 
 if __name__ == "__main__":

--- a/gascity/tests/test_formula_assets.py
+++ b/gascity/tests/test_formula_assets.py
@@ -5978,7 +5978,6 @@ description = "Override sink that writes the base triage report contract."
     def test_build_artifact_check_failure_surfaces_gc_bd_stderr(self) -> None:
         root = pathlib.Path(__file__).resolve().parents[1]
         script = root / "assets" / "scripts" / "checks" / "build-artifact-valid.sh"
-        jq_dir = pathlib.Path(shutil.which("jq") or "/usr/bin/jq").parent
 
         with tempfile.TemporaryDirectory() as tmp:
             bin_dir = pathlib.Path(tmp) / "bin"
@@ -5994,7 +5993,7 @@ description = "Override sink that writes the base triage report contract."
             env = {
                 **os.environ,
                 "GC_BEAD_ID": "bd-err",
-                "PATH": f"{bin_dir}:{jq_dir}:/usr/bin:/bin",
+                "PATH": f"{bin_dir}:{os.environ.get('PATH', '')}",
             }
             result = subprocess.run([str(script)], capture_output=True, env=env, text=True)
 
@@ -6005,7 +6004,6 @@ description = "Override sink that writes the base triage report contract."
     def test_implementation_review_check_notes_gc_bd_stderr_on_tolerant_paths(self) -> None:
         root = pathlib.Path(__file__).resolve().parents[1]
         script = root / "assets" / "scripts" / "checks" / "implementation-review-approved.sh"
-        jq_dir = pathlib.Path(shutil.which("jq") or "/usr/bin/jq").parent
 
         with tempfile.TemporaryDirectory() as tmp:
             bin_dir = pathlib.Path(tmp) / "bin"
@@ -6013,8 +6011,15 @@ description = "Override sink that writes the base triage report contract."
             fake_gc = bin_dir / "gc"
             fake_gc.write_text(
                 "#!/bin/sh\n"
-                "echo 'STORE_UNAVAILABLE backing store offline' >&2\n"
-                "exit 3\n",
+                "if [ \"$2\" = \"show\" ]; then\n"
+                "  echo 'STDERR_A root lookup unavailable' >&2\n"
+                "  exit 3\n"
+                "fi\n"
+                "if [ \"$2\" = \"list\" ]; then\n"
+                "  echo 'STDERR_B list lookup unavailable' >&2\n"
+                "  exit 3\n"
+                "fi\n"
+                "exit 99\n",
                 encoding="utf-8",
             )
             fake_gc.chmod(0o755)
@@ -6022,7 +6027,7 @@ description = "Override sink that writes the base triage report contract."
                 **os.environ,
                 "GC_BEAD_ID": "root-err",
                 "GC_ITERATION": "1",
-                "PATH": f"{bin_dir}:{jq_dir}:/usr/bin:/bin",
+                "PATH": f"{bin_dir}:{os.environ.get('PATH', '')}",
             }
             result = subprocess.run([str(script)], capture_output=True, env=env, text=True)
 
@@ -6030,7 +6035,74 @@ description = "Override sink that writes the base triage report contract."
         # than crashing), but the attempt log now carries the real error.
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("review check: note: gc bd show root-err failed", result.stderr)
-        self.assertIn("STORE_UNAVAILABLE", result.stderr)
+        self.assertIn("STDERR_A", result.stderr)
+        self.assertIn("review check: note: gc bd list for root root-err failed", result.stderr)
+        self.assertIn("STDERR_B", result.stderr)
+        self.assertIn("Implementation review needs another iteration: missing verdict", result.stdout)
+
+    def test_design_review_check_surfaces_gc_bd_list_pipeline_stderr(self) -> None:
+        root = pathlib.Path(__file__).resolve().parents[1]
+        script = root / "assets" / "scripts" / "checks" / "design-review-approved.sh"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            bin_dir = pathlib.Path(tmp) / "bin"
+            bin_dir.mkdir()
+            fake_gc = bin_dir / "gc"
+            fake_gc.write_text(
+                "#!/bin/sh\n"
+                "if [ \"$2\" = \"show\" ]; then\n"
+                "  printf '%s\\n' '{\"metadata\":{\"gc.root_bead_id\":\"root-ok\",\"gc.attempt\":\"1\"}}'\n"
+                "  exit 0\n"
+                "fi\n"
+                "echo 'DISTINCTIVE_LIST_FAILURE' >&2\n"
+                "exit 3\n",
+                encoding="utf-8",
+            )
+            fake_gc.chmod(0o755)
+            env = {
+                **os.environ,
+                "GC_BEAD_ID": "bead-ok",
+                "PATH": f"{bin_dir}:{os.environ.get('PATH', '')}",
+            }
+            result = subprocess.run([str(script)], capture_output=True, env=env, text=True)
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("ERROR: gc bd list/jq pipeline for root root-ok failed", result.stderr)
+        self.assertIn("DISTINCTIVE_LIST_FAILURE", result.stderr)
+
+    def test_gap_analysis_check_notes_gc_bd_stderr_on_tolerant_paths(self) -> None:
+        root = pathlib.Path(__file__).resolve().parents[1]
+        script = root / "assets" / "scripts" / "checks" / "gap-analysis-approved.sh"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            bin_dir = pathlib.Path(tmp) / "bin"
+            bin_dir.mkdir()
+            fake_gc = bin_dir / "gc"
+            fake_gc.write_text(
+                "#!/bin/sh\n"
+                "if [ \"$2\" = \"show\" ]; then\n"
+                "  echo 'GAP_SHOW_FAILURE' >&2\n"
+                "else\n"
+                "  echo 'GAP_LIST_FAILURE' >&2\n"
+                "fi\n"
+                "exit 3\n",
+                encoding="utf-8",
+            )
+            fake_gc.chmod(0o755)
+            env = {
+                **os.environ,
+                "GC_BEAD_ID": "gap-root",
+                "GC_ITERATION": "1",
+                "PATH": f"{bin_dir}:{os.environ.get('PATH', '')}",
+            }
+            result = subprocess.run([str(script)], capture_output=True, env=env, text=True)
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("gap check: note: gc bd show gap-root failed", result.stderr)
+        self.assertIn("GAP_SHOW_FAILURE", result.stderr)
+        self.assertIn("gap check: note: gc bd list for root gap-root failed", result.stderr)
+        self.assertIn("GAP_LIST_FAILURE", result.stderr)
+        self.assertIn("Gap analysis needs another iteration: missing verdict", result.stdout)
 
 
 if __name__ == "__main__":

--- a/gascity/tests/test_formula_assets.py
+++ b/gascity/tests/test_formula_assets.py
@@ -4,7 +4,6 @@ import json
 import os
 import pathlib
 import re
-import shutil
 import subprocess
 import tempfile
 import tomllib
@@ -6177,6 +6176,131 @@ description = "Override sink that writes the base triage report contract."
         self.assertIn("gmol: gc ready failed for status:", result.stderr)
         self.assertIn("GAP_MEMBER_READ_FAILURE", result.stderr)
         self.assertNotIn("needs another iteration", result.stdout)
+
+    # The three tests below pin the capture sites the fixtures above never
+    # reach. Every fixture above fails the *first* `gc bd show`, which short
+    # -circuits design-review and makes the tolerant gates fall back to
+    # `PARENT_ROOT=$ROOT_ID` -- so the fatal design-review handler (the exact
+    # symptom this change exists to fix) and the two re-show sites were
+    # unpinned. Each fixture below lets the first show succeed.
+
+    def test_design_review_check_surfaces_gc_bd_show_stderr(self) -> None:
+        root = pathlib.Path(__file__).resolve().parents[1]
+        script = root / "assets" / "scripts" / "checks" / "design-review-approved.sh"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            bin_dir = pathlib.Path(tmp) / "bin"
+            bin_dir.mkdir()
+            # A dedicated TMPDIR that nothing else writes to, so "empty after the
+            # run" is an exact pin on the EXIT trap reclaiming the capture file.
+            tmpdir = pathlib.Path(tmp) / "tmpdir"
+            tmpdir.mkdir()
+            fake_gc = bin_dir / "gc"
+            fake_gc.write_text(
+                "#!/bin/sh\n"
+                "echo 'DESIGN_SHOW_FAILURE store unavailable' >&2\n"
+                "exit 3\n",
+                encoding="utf-8",
+            )
+            fake_gc.chmod(0o755)
+            env = {
+                **os.environ,
+                "GC_BEAD_ID": "design-bead",
+                "TMPDIR": str(tmpdir),
+                "PATH": f"{bin_dir}:{os.environ.get('PATH', '')}",
+            }
+            result = subprocess.run([str(script)], capture_output=True, env=env, text=True)
+            leaked = sorted(p.name for p in tmpdir.iterdir())
+
+        # This site is fatal by design: a gate that cannot read its own bead
+        # must not fall through to a verdict decision.
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("ERROR: gc bd show design-bead failed", result.stderr)
+        self.assertIn("DESIGN_SHOW_FAILURE", result.stderr)
+        # `trap 'rm -f "$GC_ERR"' EXIT INT TERM HUP` actually reclaims the file.
+        self.assertEqual(leaked, [])
+
+    def test_implementation_review_check_notes_parent_show_stderr(self) -> None:
+        root = pathlib.Path(__file__).resolve().parents[1]
+        script = root / "assets" / "scripts" / "checks" / "implementation-review-approved.sh"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            bin_dir = pathlib.Path(tmp) / "bin"
+            bin_dir.mkdir()
+            fake_gc = bin_dir / "gc"
+            fake_gc.write_text(
+                "#!/bin/sh\n"
+                # The member read is `gc ready` (see gmol); let it succeed with an
+                # empty union so this test isolates the parent `gc bd show` site.
+                "if [ \"$1\" = \"ready\" ]; then\n"
+                "  printf '[]\\n'\n"
+                "  exit 0\n"
+                "fi\n"
+                "if [ \"$2\" = \"show\" ]; then\n"
+                # The root read succeeds and names a *different* parent, which is
+                # the only way control reaches the parent re-show.
+                "  if [ \"$3\" = \"parent-err\" ]; then\n"
+                "    echo 'PARENT_SHOW_FAILURE parent lookup unavailable' >&2\n"
+                "    exit 3\n"
+                "  fi\n"
+                "  printf '%s\\n' '{\"metadata\":{\"gc.root_bead_id\":\"parent-err\",\"gc.attempt\":\"1\"}}'\n"
+                "  exit 0\n"
+                "fi\n"
+                "exit 99\n",
+                encoding="utf-8",
+            )
+            fake_gc.chmod(0o755)
+            env = {
+                **os.environ,
+                "GC_BEAD_ID": "root-child",
+                "GC_ITERATION": "1",
+                "PATH": f"{bin_dir}:{os.environ.get('PATH', '')}",
+            }
+            result = subprocess.run([str(script)], capture_output=True, env=env, text=True)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("review check: note: gc bd show parent-err failed", result.stderr)
+        self.assertIn("PARENT_SHOW_FAILURE", result.stderr)
+        # The root read succeeded, so the tolerant note is the parent's alone --
+        # without this the fixture could regress into the already-pinned site.
+        self.assertNotIn("gc bd show root-child failed", result.stderr)
+
+    def test_build_artifact_check_root_reshow_failure_surfaces_gc_bd_stderr(self) -> None:
+        root = pathlib.Path(__file__).resolve().parents[1]
+        script = root / "assets" / "scripts" / "checks" / "build-artifact-valid.sh"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            bin_dir = pathlib.Path(tmp) / "bin"
+            bin_dir.mkdir()
+            fake_gc = bin_dir / "gc"
+            fake_gc.write_text(
+                "#!/bin/sh\n"
+                "if [ \"$3\" = \"root-err\" ]; then\n"
+                "  echo 'ROOT_RESHOW_FAILURE root lookup unavailable' >&2\n"
+                "  exit 3\n"
+                "fi\n"
+                # The step read succeeds with a complete artifact contract and a
+                # root that differs from the bead, so the re-show is reached.
+                "printf '%s\\n' '{\"metadata\":{"
+                "\"gc.build.artifact_schema\":\"gc.build.requirements.v1\","
+                "\"gc.build.artifact_path_keys\":\"gc.build.requirements_path\","
+                "\"gc.root_bead_id\":\"root-err\"}}'\n"
+                "exit 0\n",
+                encoding="utf-8",
+            )
+            fake_gc.chmod(0o755)
+            env = {
+                **os.environ,
+                "GC_BEAD_ID": "bd-child",
+                "PATH": f"{bin_dir}:{os.environ.get('PATH', '')}",
+            }
+            result = subprocess.run([str(script)], capture_output=True, env=env, text=True)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("build-artifact-check: gc bd show root-err failed", result.stderr)
+        self.assertIn("ROOT_RESHOW_FAILURE", result.stderr)
+        # The first show succeeded; only the root re-show is being reported.
+        self.assertNotIn("gc bd show bd-child failed", result.stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

The shared check-gate scripts suppress `gc bd` stderr
(`2>/dev/null || fail "gc bd show $ID failed"`), so when the nested `gc`
invocation fails for an infrastructure reason, `gc.attempt_log` records only
an opaque one-liner and the bounded repair loop burns its attempts blind.

Live case that motivated this: in a fresh city, every producer gate failed
three attempts with `build-artifact-check: gc bd show xs-... failed` while
the actual error - visible only after patching stderr capture into the
scripts - was:

```
gc bd: loading config: city import "...": import "gc": remote import
https://github.com/gastownhall/gascity-packs/tree/main/gascity is locked but
not cached at <city>/.gc/cache/repos/<hash>; run "gc import install"
```

With the real error in the attempt log, the misconfiguration is a
one-minute fix; without it, the artifacts looked at fault (they were valid)
and diagnosis took hours. The scripts' own header contract already promises
"All failures print machine-readable lines on stderr; the dispatcher
records them in gc.attempt_log as repair context" - this makes the fail
lines carry the context that matters.

## Fix

Capture `gc bd` stderr per call into a `mktemp` file and append a bounded
(400-byte, newline-flattened) tail to the existing fail message. The
machine-readable prefix and exit-code contract are unchanged; success paths
are unchanged (stderr is not merged into stdout, so captured JSON cannot be
corrupted - the reason this isn't a blanket `2>&1`).

Applied uniformly across all four gate scripts' `gc bd show`/`gc bd list`
suppression sites (grepped for siblings; B23). Two site classes needed
adaptation to the scripts as they actually are:

- Sites that deliberately tolerate bd failure (`|| true`,
  `|| printf '[]'`) keep their fallbacks unchanged; they now emit a bounded
  `<prefix>: note: ...` line on stderr instead of discarding the error. Core
  records check stderr on both pass and fail attempt entries, so on passing
  runs the `note:` prefix marks these as informational.
- `design-review-approved.sh` previously exited *silently* on bd failure
  (bare command substitution under `set -euo pipefail`); those sites now
  fail with a machine-readable ERROR line carrying the captured tail.

## Validation

- [x] `python3 -m unittest discover -s gascity/tests` - 177 tests; all pass
      except two pre-existing `claim` command timeout flakes that fail
      identically on a clean checkout of main on my machine (2s subprocess
      timeouts under load; untouched files)
- [x] new fake-gc cases (now four - all four gate scripts covered): `gc bd` exiting non-zero with a distinctive stderr
      line -> the gate's fail line (build-artifact) / note line
      (implementation-review tolerant path) includes that text
- [x] `gc lint gascity` - ok (gc 1.4.1)
- [x] `bash -n` on all four scripts; executables preserved
      (`test_check_scripts_are_executable_and_portable` green)

## Notes

- No `GC-BF-*` ledger row: no formula graph or behavior change; this
  strengthens the existing repair-context contract (cf. `GC-METH-BR-040`,
  validator errors as repair context).
- Anticipated question - secret leakage into bead metadata: the capture is
  stderr of `gc bd` only (config/store errors), bounded to 400 bytes, no
  env dumps; gate stderr already flowed into attempt logs when scripts
  chose to print it.

## Provenance

Found while running an external mission pack extending `build-base`; the
stderr-capturing variant of these gates has been running in that pack and
produced the diagnosis quoted above.

