### PR TITLE
fix(ci): run required pack compatibility check on every PR

### DIFF
--- a/.github/workflows/pack-release-compatibility.yml
+++ b/.github/workflows/pack-release-compatibility.yml
@@ -3,12 +3,6 @@ name: Pack Release Compatibility
 on:
   pull_request:
     branches: [main]
-    paths:
-      - registry.toml
-      - scripts/pack_release_compat.py
-      - tests/test_pack_release_compat.py
-      - .github/workflows/pack-release-compatibility.yml
-      - "*/pack.toml"
   push:
     branches: [main]
     paths:

--- a/tests/test_gascity_pack_inference_gate.py
+++ b/tests/test_gascity_pack_inference_gate.py
@@ -485,6 +485,24 @@ def test_ci_workflows_use_blacksmith_runner_labels() -> None:
         assert marker in workflow
 
 
+def test_required_pack_release_compatibility_runs_for_every_main_pr() -> None:
+    workflow = yaml.load(
+        (
+            gascity_pack_inference_gate.REPO_ROOT
+            / ".github"
+            / "workflows"
+            / "pack-release-compatibility.yml"
+        ).read_text(encoding="utf-8"),
+        Loader=yaml.BaseLoader,
+    )
+
+    pull_request = workflow["on"]["pull_request"]
+    assert pull_request["branches"] == ["main"]
+    assert "paths" not in pull_request
+    assert "paths-ignore" not in pull_request
+    assert workflow["on"]["push"]["paths"]
+
+
 def test_readme_includes_blacksmith_sponsor_badge() -> None:
     readme = (gascity_pack_inference_gate.REPO_ROOT / "README.md").read_text(encoding="utf-8")
     readme_lines = {line.strip() for line in readme.splitlines()}


### PR DESCRIPTION
## Summary

Removes the `pull_request.paths` filter from Pack Release Compatibility so GitHub creates the required `Latest pack releases` check for every PR targeting `main`. The existing `push.paths` filter is unchanged.

## Validation

- `.venv/bin/python -m pytest tests/test_gascity_pack_inference_gate.py -q` — 44 passed
- YAML loaded with `yaml.BaseLoader`; verified `pull_request.branches == [main]`, no PR path filters, and retained push paths.
- `git diff --check`

## Scope and rollback

- Head: `e14afbfd1433cad3db018854e49de84f86380c22`
- Delta: 18 additions, 6 deletions across `.github/workflows/pack-release-compatibility.yml` and `tests/test_gascity_pack_inference_gate.py` only.
- Rollback: revert commit `e14afbf`.

This PR is intentionally draft and must not be merged until its required checks and independent review complete.