### PR TITLE
feat(pr-review): add the incoming-PR adoption pack; fix two silent step-dropping formulas

### DIFF
--- a/pr-pipeline/formulas/mol-pr-from-issue.formula.toml
+++ b/pr-pipeline/formulas/mol-pr-from-issue.formula.toml
@@ -57,6 +57,17 @@ notes and metadata. Crash-safe: `gc bd mol current` resumes at the right step.
   Slack thread."""
 formula = "mol-pr-from-issue"
 phase = "vapor"
+# pour = true eager-materializes the graph steps. Without it this formula
+# compiles RootOnly and every one of its nine steps is dropped at
+# instantiation, so the root sits in_progress with nothing routed. The
+# predicate (internal/formula/compile.go) is
+#   rootOnly := (!f.Pour && f.Phase == "vapor") || len(f.Steps) == 0
+# which keys only on pour and phase; the graph declaration form is never
+# consulted, so `contract = "graph.v2"` does not protect against it. Note the
+# failure is silent: RecipeHasReadySurface still returns true because RootOnly
+# itself satisfies it, so the pool sling is accepted and only the steps go
+# missing.
+pour = true
 version = 1
 contract = "graph.v2"
 

--- a/pr-review/README.md
+++ b/pr-review/README.md
@@ -45,7 +45,7 @@ gc sling <rig>/polecat mol-adopt-pr --formula \
 3. **Review** — Run `/review-pr` (parallel Claude + Codex + Gemini)
 4. **Human gate** — Blocks until maintainer closes the step manually:
    ```bash
-   bd close <human-gate-step-id>
+   gc bd close <human-gate-step-id>
    ```
 5. **Finalize** — Resolve merge path, prepare local artifacts (squash/rebase/branch/synthesis), hand publish + merge to mayor, then clean up refs and update the root bead
 

--- a/pr-review/README.md
+++ b/pr-review/README.md
@@ -1,8 +1,8 @@
 # PR Review Pack
 
-Formula-driven adopt-PR workflow for Gas City. Reviews and merges contributor
+Formula-driven adopt-PR workflow for Gas City. Reviews contributor
 PRs using a multi-model review engine (Claude + Codex + Gemini), with a human
-gate between review and merge.
+gate before finalize and a publish/merge handoff to mayor.
 
 ## What's Included
 

--- a/pr-review/README.md
+++ b/pr-review/README.md
@@ -1,0 +1,66 @@
+# PR Review Pack
+
+Formula-driven adopt-PR workflow for Gas City. Reviews and merges contributor
+PRs using a multi-model review engine (Claude + Codex + Gemini), with a human
+gate between review and merge.
+
+## What's Included
+
+- **`mol-adopt-pr` formula** — 5-step molecule: intake, rebase-check, review,
+  human-gate, finalize
+- **`/review-pr` skill** — multi-model code review engine (overlay)
+
+## Prerequisites
+
+- `gh` CLI authenticated with repo access
+- Polecat agent (from consuming pack) with worktree support
+- `bd` CLI for bead operations
+
+## Usage
+
+Sling a PR review to a polecat:
+
+```bash
+gc sling <rig>/polecat mol-adopt-pr --formula \
+  --var pr=https://github.com/org/repo/pull/42
+```
+
+With bare integer (uses current repo):
+
+```bash
+gc sling <rig>/polecat mol-adopt-pr --formula --var pr=42
+```
+
+Skip Gemini (dual-model mode — Claude + Codex only):
+
+```bash
+gc sling <rig>/polecat mol-adopt-pr --formula \
+  --var pr=42 --var skip_gemini=true
+```
+
+## Workflow
+
+1. **Intake** — Parse PR, fetch metadata, validate scope, checkout branch
+2. **Rebase check** — Auto-rebase straightforward conflicts, reject complex ones
+3. **Review** — Run `/review-pr` (parallel Claude + Codex + Gemini)
+4. **Human gate** — Blocks until maintainer closes the step manually:
+   ```bash
+   bd close <human-gate-step-id>
+   ```
+5. **Finalize** — Resolve merge path, prepare local artifacts (squash/rebase/branch/synthesis), hand publish + merge to mayor, then clean up refs and update the root bead
+
+## Merge Paths
+
+| Path | Condition | Strategy |
+|------|-----------|----------|
+| A | No maintainer changes | Squash merge |
+| B | Maintainer changes + edits enabled | Merge commit (preserves dual authorship) |
+| C | Maintainer changes + edits disabled | New PR from maintainer's fork |
+| D | Original PR already merged | Follow-up PR for fixups |
+
+## Importing into pack.toml
+
+```toml
+[imports.pr-review]
+source = "../packs/pr-review"
+```

--- a/pr-review/formulas/mol-adopt-pr.formula.toml
+++ b/pr-review/formulas/mol-adopt-pr.formula.toml
@@ -3,10 +3,10 @@ Adopt-PR workflow — 5 steps from intake through merge-handoff.
 
 Sling a contributor PR to a polecat for review. The polecat follows each step
 in order; a human gate after review blocks until the maintainer closes it
-manually. Crash-safe: `bd mol current` resumes at the right step.
+manually. Crash-safe: `gc bd mol current` resumes at the right step.
 
 The molecule root bead IS the control bead — all run state is stored in its
-notes via `bd update <root-id> --notes "key: value"`. No separate tracking
+notes via `gc bd update <root-id> --notes "key: value"`. No separate tracking
 bead needed.
 
 **Polecat publish authority (hard rule):** The polecat NEVER runs `gh pr merge`,
@@ -64,7 +64,7 @@ formula = "mol-adopt-pr"
 phase = "vapor"
 # pour = true materializes each step as its own bead. Required here, not
 # cosmetic: the human-gate step must exist as a bead for the maintainer to
-# close, and `bd mol current` needs step rows to resume at the right step
+# close, and `gc bd mol current` needs step rows to resume at the right step
 # after a crash.
 pour = true
 version = 2
@@ -90,11 +90,11 @@ initial state in the root bead notes.
 
 **1. Find the root bead and claim it (BEFORE any `git checkout`):**
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
-bd update "$ROOT_ID" --claim
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
+gc bd update "$ROOT_ID" --claim
 ```
 
-`bd update --claim` atomically sets assignee to your session and transitions
+`gc bd update --claim` atomically sets assignee to your session and transitions
 status to `in_progress` (idempotent if already claimed by you). The claim
 **MUST** happen before any `git checkout` of the contributor's branch.
 Otherwise the bead stays `OPEN/assignee=none/started=no` while real review
@@ -129,7 +129,7 @@ status and continue:
   UNSALVAGEABLE *and* genuinely needs the author — i.e. one of the reserved
   cases holds: **cant-reproduce**, **needs-author-input** (secret/env/design
   intent / `maintainerCanModify = false`), or **author-wants-to-iterate**. When
-  you do, name the case in the RC body and `bd close $ROOT_ID --reason
+  you do, name the case in the RC body and `gc bd close $ROOT_ID --reason
   "request_changes: <case>"`, then exit.
 
 **5. Check maintainer edits:**
@@ -156,9 +156,9 @@ if [ -d "$PR_WORKTREE" ]; then
   WT_BRANCH=$(git branch --show-current)
   if [ "$WT_BRANCH" != "$EXPECTED_BRANCH" ] || [ -n "$(git status --porcelain)" ]; then
     echo "[adopt-pr] FATAL: staged worktree $PR_WORKTREE is on branch '$WT_BRANCH' (expected '$EXPECTED_BRANCH') or has uncommitted changes." >&2
-    bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
+    gc bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
       --set-metadata "summary_for_human=adopt-pr intake found a dirty or wrong-branch staged worktree at $PR_WORKTREE (branch '$WT_BRANCH', expected '$EXPECTED_BRANCH'). Inspect it, then 'git worktree remove --force $PR_WORKTREE' before re-slinging."
-    bd close "$ROOT_ID" --reason "dirty/wrong-branch staged worktree in intake"
+    gc bd close "$ROOT_ID" --reason "dirty/wrong-branch staged worktree in intake"
     exit 1
   fi
 else
@@ -173,12 +173,12 @@ Record the staging directory on the root bead. Every later step runs in a
 fresh shell that otherwise lands back in the slot worktree, so they re-enter
 `work_dir` from this metadata:
 ```bash
-bd update "$ROOT_ID" --set-metadata "work_dir=$PR_WORKTREE"
+gc bd update "$ROOT_ID" --set-metadata "work_dir=$PR_WORKTREE"
 ```
 
 **7. Record state in root bead notes:**
 ```bash
-bd update $ROOT_ID --notes "pr_number: <N>
+gc bd update $ROOT_ID --notes "pr_number: <N>
 pr_url: <url>
 repo: <owner/repo>
 pr_title: <title>
@@ -220,13 +220,13 @@ A fresh polecat shell starts in the slot worktree, not the per-PR worktree the
 step (the mergeable check and rebase) assumes it runs inside the staged
 worktree:
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
-WORK_DIR=$(bd show "$ROOT_ID" --json | jq -r '.[0].metadata.work_dir // empty')
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
+WORK_DIR=$(gc bd show "$ROOT_ID" --json | jq -r '.[0].metadata.work_dir // empty')
 if [ -z "$WORK_DIR" ] || [ ! -d "$WORK_DIR" ]; then
   echo "[adopt-pr] FATAL: work_dir metadata missing or not a directory ('$WORK_DIR'). Intake staging did not complete; cannot continue." >&2
-  bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
+  gc bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
     --set-metadata "summary_for_human=adopt-pr rebase-check could not re-enter the staged worktree (work_dir='$WORK_DIR', missing or not a dir). Re-sling from intake."
-  bd close "$ROOT_ID" --reason "work_dir missing in rebase-check"
+  gc bd close "$ROOT_ID" --reason "work_dir missing in rebase-check"
   exit 1
 fi
 cd "$WORK_DIR"
@@ -245,7 +245,7 @@ MERGEABLE=$(gh pr view <number> --json mergeable --jq '.mergeable')
 If `maintainer_edits` is false → **STOP**:
 - Post conflict comment asking author to rebase
 - Add label: `gh pr edit <number> --add-label "status/needs-info"`
-- Close root bead: `bd close $ROOT_ID --reason "conflicts, maintainerCanModify=false"`
+- Close root bead: `gc bd close $ROOT_ID --reason "conflicts, maintainerCanModify=false"`
 - Exit
 
 **4. Fetch upstream base:**
@@ -282,7 +282,7 @@ If complex conflicts found:
 git rebase --abort
 gh pr comment <number> --body "<conflict comment asking author to rebase>"
 gh pr edit <number> --add-label "status/needs-info"
-bd close $ROOT_ID --reason "complex merge conflicts"
+gc bd close $ROOT_ID --reason "complex merge conflicts"
 ```
 Exit.
 
@@ -310,13 +310,13 @@ A fresh polecat shell starts in the slot worktree, not the per-PR worktree the
 `intake` step staged. Re-enter it from `work_dir` before fetching the base or
 running the review:
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
-WORK_DIR=$(bd show "$ROOT_ID" --json | jq -r '.[0].metadata.work_dir // empty')
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
+WORK_DIR=$(gc bd show "$ROOT_ID" --json | jq -r '.[0].metadata.work_dir // empty')
 if [ -z "$WORK_DIR" ] || [ ! -d "$WORK_DIR" ]; then
   echo "[adopt-pr] FATAL: work_dir metadata missing or not a directory ('$WORK_DIR'). Intake staging did not complete; cannot continue." >&2
-  bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
+  gc bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
     --set-metadata "summary_for_human=adopt-pr review could not re-enter the staged worktree (work_dir='$WORK_DIR', missing or not a dir). Re-sling from intake."
-  bd close "$ROOT_ID" --reason "work_dir missing in review"
+  gc bd close "$ROOT_ID" --reason "work_dir missing in review"
   exit 1
 fi
 cd "$WORK_DIR"
@@ -347,7 +347,7 @@ synthesized comment.
 After the review completes, note the run_dir path from the output.
 Update root bead notes:
 ```bash
-bd update $ROOT_ID --notes "<existing notes>
+gc bd update $ROOT_ID --notes "<existing notes>
 review_run_dir: <run_dir_path>"
 ```
 
@@ -370,7 +370,7 @@ blockers only.
 
 Record the verdict in root bead notes so finalize and the human gate can read it:
 ```bash
-bd update $ROOT_ID --notes "<existing notes>
+gc bd update $ROOT_ID --notes "<existing notes>
 verdict: <approve|take-the-good|request_changes|block>
 salvageable: <true|false>
 rc_reason: <none|cant-reproduce|needs-author-input|author-wants-to-iterate>"
@@ -398,23 +398,23 @@ The polecat has completed the review. The human maintainer now:
 3. Optionally runs another review manually
 4. Closes this step when ready to proceed to finalize
 
-**For the polecat:** When you reach this step via `bd mol current`, there is
+**For the polecat:** When you reach this step via `gc bd mol current`, there is
 nothing for you to do. Print a status message and wait:
 
 ```
 [adopt-pr] Human gate reached — waiting for maintainer
 [adopt-pr]   Review findings are in the root bead notes (review_run_dir)
 [adopt-pr]   Close this step when ready to finalize:
-[adopt-pr]     bd close <this-step-id>
+[adopt-pr]     gc bd close <this-step-id>
 ```
 
 Then exit or idle. The maintainer closes the gate:
 ```bash
-bd close <human-gate-step-id>
+gc bd close <human-gate-step-id>
 ```
 
 This unblocks the `finalize` step. The polecat picks it up on its next loop
-iteration (via `bd mol current`) or when nudged.
+iteration (via `gc bd mol current`) or when nudged.
 
 **Exit criteria:** Human has closed this step."""
 
@@ -447,13 +447,13 @@ A fresh polecat shell starts in the slot worktree, not the per-PR worktree the
 `intake` step staged. Re-enter it from `work_dir` before resolving the merge
 path or touching git — every path below operates on the staged branch:
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
-WORK_DIR=$(bd show "$ROOT_ID" --json | jq -r '.[0].metadata.work_dir // empty')
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
+WORK_DIR=$(gc bd show "$ROOT_ID" --json | jq -r '.[0].metadata.work_dir // empty')
 if [ -z "$WORK_DIR" ] || [ ! -d "$WORK_DIR" ]; then
   echo "[adopt-pr] FATAL: work_dir metadata missing or not a directory ('$WORK_DIR'). Intake staging did not complete; cannot continue." >&2
-  bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
+  gc bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
     --set-metadata "summary_for_human=adopt-pr finalize could not re-enter the staged worktree (work_dir='$WORK_DIR', missing or not a dir). Re-sling from intake."
-  bd close "$ROOT_ID" --reason "work_dir missing in finalize"
+  gc bd close "$ROOT_ID" --reason "work_dir missing in finalize"
   exit 1
 fi
 cd "$WORK_DIR"
@@ -536,7 +536,7 @@ run the merge yourself. The maintainer (via mayor) performs the merge
 out-of-band per the per-action approval rule.
 
 ```bash
-bd update $ROOT_ID --notes "<notes with merge_path: A, merge_ready: true, status: ready-for-merge, merge_command: 'gh pr merge <number> --squash'>"
+gc bd update $ROOT_ID --notes "<notes with merge_path: A, merge_ready: true, status: ready-for-merge, merge_command: 'gh pr merge <number> --squash'>"
 ```
 
 Then mail mayor:
@@ -568,7 +568,7 @@ worktree path is deterministic per PR number, so a re-sling of the same PR
 REUSES it (guarded clean + on-branch in intake) rather than accumulating, and a
 re-sling that runs to completion reclaims it here:
 ```bash
-WORK_DIR=$(bd show "$ROOT_ID" --json | jq -r '.[0].metadata.work_dir // empty')
+WORK_DIR=$(gc bd show "$ROOT_ID" --json | jq -r '.[0].metadata.work_dir // empty')
 git update-ref -d refs/adopt-pr/upstream-base 2>/dev/null || true
 MAIN_WT=$(git worktree list --porcelain | awk '/^worktree /{print $2; exit}')
 cd "$MAIN_WT" 2>/dev/null || cd /
@@ -663,7 +663,7 @@ POST_SYNTH_CMD="gh pr comment <number> --body-file $SYNTH_PATH"
 CI_WAIT_CMD="gh pr checks <number> --watch"
 MERGE_CMD="gh pr merge <number> --merge"
 
-bd update "$ROOT_ID" --notes "<notes with
+gc bd update "$ROOT_ID" --notes "<notes with
   merge_path: B,
   status: ready-for-publish,
   branch: <head_ref>,
@@ -739,7 +739,7 @@ CI_WAIT_CMD="gh pr checks $NEW_NUMBER_PLACEHOLDER --watch"
 MERGE_CMD="gh pr merge $NEW_NUMBER_PLACEHOLDER --repo $REPO_FULL --merge"
 CLOSE_ORIG_CMD="gh pr comment <number> --body-file $CLOSE_PATH && gh pr close <number>"
 
-bd update "$ROOT_ID" --notes "<notes with
+gc bd update "$ROOT_ID" --notes "<notes with
   merge_path: C,
   status: ready-for-publish,
   branch: $NEW_BRANCH,
@@ -818,7 +818,7 @@ CI_WAIT_CMD="gh pr checks $FOLLOWUP_NUMBER_PLACEHOLDER --watch"
 MERGE_CMD="gh pr merge $FOLLOWUP_NUMBER_PLACEHOLDER --squash"
 COMMENT_ORIG_CMD="gh pr comment <number> --body-file $LINK_PATH"
 
-bd update "$ROOT_ID" --notes "<notes with
+gc bd update "$ROOT_ID" --notes "<notes with
   merge_path: D,
   status: ready-for-publish,
   branch: $FOLLOWUP_BRANCH,

--- a/pr-review/formulas/mol-adopt-pr.formula.toml
+++ b/pr-review/formulas/mol-adopt-pr.formula.toml
@@ -1,0 +1,876 @@
+description = """
+Adopt-PR workflow — 5 steps from intake through merge-handoff.
+
+Sling a contributor PR to a polecat for review. The polecat follows each step
+in order; a human gate after review blocks until the maintainer closes it
+manually. Crash-safe: `bd mol current` resumes at the right step.
+
+The molecule root bead IS the control bead — all run state is stored in its
+notes via `bd update <root-id> --notes "key: value"`. No separate tracking
+bead needed.
+
+**Polecat publish authority (hard rule):** The polecat NEVER runs `gh pr merge`,
+`git push`, `gh pr create`, or `gh pr comment` on paths B/C/D. The `finalize`
+step resolves the merge path, prepares all local artifacts (squash, rebase,
+branch, cherry-pick, synthesis body), then for paths B/C/D records a
+*branch-ready handoff bundle* (`status: ready-for-publish` plus the resolved
+publish + comment + merge commands) in the root bead, and mails mayor. The
+finalize cleanup ends the chain. Mayor performs publish (push + optionally
+`gh pr create`), posts the synthesis comment (`gh pr comment`), waits for CI,
+and merges asynchronously per the per-action approval rule, independent of the
+polecat's lifecycle. Path A is the contributor's own PR branch round-trip — the
+polecat still pushes the rebased contributor commits there (no new artifact
+under maintainer identity), posts the synthesis comment on the contributor's
+existing PR itself, and only hands off `gh pr merge` to mayor.
+
+## Contract
+
+1. Caller slings with `--var pr=<url-or-number>` (and optionally `--var skip_gemini=true`)
+2. Polecat reads steps, executes each in order
+3. After review, human-gate blocks until maintainer closes it
+4. Polecat resumes finalize → resolves merge path → prepares all local artifacts
+5. Path A: polecat pushes rebased contributor commits, posts synthesis, waits CI,
+   records merge_command, mails mayor; finalize cleanup ends the chain
+6. Paths B/C/D: polecat records branch-ready handoff bundle (push_command +
+   optional pr_create_command + synthesis body + merge_command) in root bead,
+   mails mayor; finalize cleanup ends the chain. Polecat does NOT push, create,
+   comment, wait CI, or merge on B/C/D.
+7. Mayor reads the root bead and performs publish + downstream actions
+   out-of-band, per the per-action approval rule
+
+## Variables
+
+| Variable | Source | Description |
+|----------|--------|-------------|
+| pr | caller | PR URL or bare integer (required) |
+| skip_gemini | caller | "true" to skip Gemini reviewer (default: "false") |
+
+## Failure Modes
+
+| Situation | Action |
+|-----------|--------|
+| gh command fails | Check `gh auth status`, report error, stop |
+| Rebase has complex conflicts | Abort rebase, post comment, close root bead, stop |
+| Push fails | Report error, stop. User resolves manually |
+| CI fails | Report failure, stop, wait for human-gate or nudge |
+| Review-pr fails | Report which step failed, stop. Retry on next nudge |"""
+formula = "mol-adopt-pr"
+# formulas v2. The root is stamped gc.kind = "workflow", which is what makes it
+# Ready-visible, so `gc sling <pool> mol-adopt-pr --formula` routes to the
+# polecat pool the workflow is written for. As a v1 molecule container the root
+# was not Ready-visible and every pool sling was rejected outright (gc-i2l9p);
+# the only other v1 escape, phase = "vapor" without pour, compiles a root-only
+# recipe that would drop all five step beads including the human gate.
+phase = "vapor"
+# pour = true materializes each step as its own bead. Required here, not
+# cosmetic: the human-gate step must exist as a bead for the maintainer to
+# close, and `bd mol current` needs step rows to resume at the right step
+# after a crash.
+pour = true
+version = 2
+
+[requires]
+formula_compiler = ">=2.0.0"
+
+[vars]
+[vars.pr]
+description = "PR URL (https://github.com/org/repo/pull/N) or bare integer"
+required = true
+
+[vars.skip_gemini]
+description = "Set to 'true' to skip Gemini reviewer (dual-model mode: Claude + Codex only)"
+default = "false"
+
+[[steps]]
+id = "intake"
+title = "Parse PR and checkout"
+description = """
+Parse the PR, fetch metadata, validate scope, checkout the branch, and record
+initial state in the root bead notes.
+
+**1. Find the root bead and claim it (BEFORE any `git checkout`):**
+```bash
+ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+bd update "$ROOT_ID" --claim
+```
+
+`bd update --claim` atomically sets assignee to your session and transitions
+status to `in_progress` (idempotent if already claimed by you). The claim
+**MUST** happen before any `git checkout` of the contributor's branch.
+Otherwise the bead stays `OPEN/assignee=none/started=no` while real review
+work is in flight, and monitoring reads false stalls.
+
+**2. Parse PR identifier from `{{pr}}`:**
+- If `{{pr}}` matches `https://github.com/.*/pull/\\d+` → extract owner, repo, PR number from URL
+- If `{{pr}}` is a bare integer → use current repo (`gh repo view --json nameWithOwner -q .nameWithOwner`)
+
+**3. Fetch PR metadata:**
+```bash
+gh pr view <number> --json title,body,author,baseRefName,headRefName,number,additions,deletions,changedFiles,maintainerCanModify,url,mergeable
+```
+
+**4. Validate PR scope:**
+
+Fetch changed files:
+```bash
+gh pr view <number> --json files --jq '.files[].path'
+```
+
+Compare against the PR title/description. If the changes are clearly outside
+the described scope (e.g., a "fix typo" PR that touches dozens of packages),
+the branch has diverged from main. **Do NOT reflexively request changes** —
+scope divergence is usually salvageable by us (rebase + finalize). Record the
+status and continue:
+- Record in root bead notes: `scope_status: diverged` (or `scope_status: clean`).
+- Continue to the `rebase-check` step. The default route is **take-the-good**:
+  we rebase the branch onto main ourselves, drop the stray commits, and the
+  review/finalize machinery merges the in-scope change.
+- Only `gh pr review <number> --request-changes` here when the divergence is
+  UNSALVAGEABLE *and* genuinely needs the author — i.e. one of the reserved
+  cases holds: **cant-reproduce**, **needs-author-input** (secret/env/design
+  intent / `maintainerCanModify = false`), or **author-wants-to-iterate**. When
+  you do, name the case in the RC body and `bd close $ROOT_ID --reason
+  "request_changes: <case>"`, then exit.
+
+**5. Check maintainer edits:**
+Record in root bead notes: `maintainer_edits: true` or `maintainer_edits: false`.
+If false, warn but continue — Phase 6 uses Path C if maintainer changes exist.
+
+**6. Stage a per-PR worktree and checkout the branch:**
+
+Do **NOT** run `gh pr checkout` in place. A fresh polecat shell starts in the
+persistent slot worktree (`/home/ds/gascity-worktrees/polecat-N`), which may
+hold another molecule's in-progress WIP; an in-place checkout clobbers/stashes
+it. Stage an ephemeral per-PR worktree instead (polecat-prompt Mode 4
+convention) and check the PR out there:
+
+```bash
+PR_WORKTREE="/home/ds/gascity-worktrees/adopt-pr-<number>"
+EXPECTED_BRANCH="<headRefName>"
+
+if [ -d "$PR_WORKTREE" ]; then
+  # Re-sling: a prior run already staged this worktree. Only TRUST it if it is
+  # on the expected PR branch AND clean. Otherwise fail loud — never silently
+  # clobber, stash, or build review work on top of unknown state.
+  cd "$PR_WORKTREE"
+  WT_BRANCH=$(git branch --show-current)
+  if [ "$WT_BRANCH" != "$EXPECTED_BRANCH" ] || [ -n "$(git status --porcelain)" ]; then
+    echo "[adopt-pr] FATAL: staged worktree $PR_WORKTREE is on branch '$WT_BRANCH' (expected '$EXPECTED_BRANCH') or has uncommitted changes." >&2
+    bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
+      --set-metadata "summary_for_human=adopt-pr intake found a dirty or wrong-branch staged worktree at $PR_WORKTREE (branch '$WT_BRANCH', expected '$EXPECTED_BRANCH'). Inspect it, then 'git worktree remove --force $PR_WORKTREE' before re-slinging."
+    bd close "$ROOT_ID" --reason "dirty/wrong-branch staged worktree in intake"
+    exit 1
+  fi
+else
+  git worktree add --detach "$PR_WORKTREE"
+  cd "$PR_WORKTREE"
+fi
+
+gh pr checkout <number>
+```
+
+Record the staging directory on the root bead. Every later step runs in a
+fresh shell that otherwise lands back in the slot worktree, so they re-enter
+`work_dir` from this metadata:
+```bash
+bd update "$ROOT_ID" --set-metadata "work_dir=$PR_WORKTREE"
+```
+
+**7. Record state in root bead notes:**
+```bash
+bd update $ROOT_ID --notes "pr_number: <N>
+pr_url: <url>
+repo: <owner/repo>
+pr_title: <title>
+pr_author: <author.login>
+head_ref: <headRefName>
+base_branch: <baseRefName>
+maintainer_edits: <true|false>
+original_head: pending
+rebase_status: pending
+merge_path: undetermined
+skip_gemini: {{skip_gemini}}
+review_run_dir: pending"
+```
+
+**8. Display summary:**
+```
+[adopt-pr] Intake complete
+[adopt-pr]   PR #<N>: "<title>"
+[adopt-pr]   Author: <author.login>
+[adopt-pr]   Base: <baseRefName> <- Head: <headRefName>
+[adopt-pr]   Stats: +<additions> -<deletions> across <changedFiles> files
+[adopt-pr]   Maintainer edits: <enabled|DISABLED>
+```
+
+**Exit criteria:** On PR branch, metadata recorded in root bead notes."""
+
+[[steps]]
+id = "rebase-check"
+title = "Check and resolve conflicts"
+needs = ["intake"]
+description = """
+Check mergeable status and handle conflicts. Auto-rebase straightforward
+cases; abort on complex conflicts that need the contributor.
+
+**1. Re-enter the staged PR worktree and read root bead state:**
+
+A fresh polecat shell starts in the slot worktree, not the per-PR worktree the
+`intake` step staged. Re-enter it from `work_dir` before any git work — this
+step (the mergeable check and rebase) assumes it runs inside the staged
+worktree:
+```bash
+ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+WORK_DIR=$(bd show "$ROOT_ID" --json | jq -r '.[0].metadata.work_dir // empty')
+if [ -z "$WORK_DIR" ] || [ ! -d "$WORK_DIR" ]; then
+  echo "[adopt-pr] FATAL: work_dir metadata missing or not a directory ('$WORK_DIR'). Intake staging did not complete; cannot continue." >&2
+  bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
+    --set-metadata "summary_for_human=adopt-pr rebase-check could not re-enter the staged worktree (work_dir='$WORK_DIR', missing or not a dir). Re-sling from intake."
+  bd close "$ROOT_ID" --reason "work_dir missing in rebase-check"
+  exit 1
+fi
+cd "$WORK_DIR"
+```
+
+**2. Check merge status:**
+```bash
+MERGEABLE=$(gh pr view <number> --json mergeable --jq '.mergeable')
+```
+
+- If `MERGEABLE` or `UNKNOWN` → record `rebase_status: not_needed`, record
+  `original_head: $(git rev-parse HEAD)`, close this step, proceed.
+- If `CONFLICTING` → continue.
+
+**3. Gate on maintainerCanModify:**
+If `maintainer_edits` is false → **STOP**:
+- Post conflict comment asking author to rebase
+- Add label: `gh pr edit <number> --add-label "status/needs-info"`
+- Close root bead: `bd close $ROOT_ID --reason "conflicts, maintainerCanModify=false"`
+- Exit
+
+**4. Fetch upstream base:**
+```bash
+UPSTREAM_URL="https://github.com/<owner>/<repo>.git"
+git fetch "$UPSTREAM_URL" <baseRefName>:refs/adopt-pr/upstream-base
+PRE_REBASE_HEAD=$(git rev-parse HEAD)
+PR_FILES=$(git diff --name-only refs/adopt-pr/upstream-base...HEAD)
+```
+
+**5. Attempt rebase:**
+```bash
+git rebase refs/adopt-pr/upstream-base
+```
+
+If clean → record state, proceed.
+
+**6. Handle conflicts (if rebase paused):**
+
+For each conflicting file, classify:
+- **Non-PR file** (not in PR_FILES) → `git checkout --theirs <file> && git add <file>`. Safe.
+- **Redundant commit** (PR file, but upstream already has identical content) → `git rebase --skip`. Safe.
+- **Add/add conflict** (PR file, empty base section in diff3 markers) → resolve with union merge:
+  ```bash
+  git show :1:"$file" > /tmp/base; git show :2:"$file" > /tmp/ours; git show :3:"$file" > /tmp/theirs
+  cp /tmp/ours /tmp/union
+  git merge-file --union /tmp/union /tmp/base /tmp/theirs
+  ```
+  Validate: no conflict markers survive, all PR additions present. If valid → `cp /tmp/union "$file" && git add "$file"`.
+- **Modify/modify conflict** (non-empty base section) → **complex**, abort.
+
+If complex conflicts found:
+```bash
+git rebase --abort
+gh pr comment <number> --body "<conflict comment asking author to rebase>"
+gh pr edit <number> --add-label "status/needs-info"
+bd close $ROOT_ID --reason "complex merge conflicts"
+```
+Exit.
+
+**7. Record state in root bead notes:**
+```bash
+ORIGINAL_HEAD=$(git rev-parse HEAD)
+```
+Update notes with:
+- `original_head: $ORIGINAL_HEAD`
+- `rebase_status: not_needed | clean | straightforward_resolved | redundant_skipped | trivial_resolved`
+- `pre_rebase_head: <sha>` (if rebased, else `n/a`)
+
+**Exit criteria:** On a clean branch (possibly rebased), ORIGINAL_HEAD recorded."""
+
+[[steps]]
+id = "review"
+title = "Run multi-model review"
+needs = ["rebase-check"]
+description = """
+Fetch the canonical upstream base and invoke the multi-model review engine.
+
+**1. Re-enter the staged PR worktree and read root bead state:**
+
+A fresh polecat shell starts in the slot worktree, not the per-PR worktree the
+`intake` step staged. Re-enter it from `work_dir` before fetching the base or
+running the review:
+```bash
+ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+WORK_DIR=$(bd show "$ROOT_ID" --json | jq -r '.[0].metadata.work_dir // empty')
+if [ -z "$WORK_DIR" ] || [ ! -d "$WORK_DIR" ]; then
+  echo "[adopt-pr] FATAL: work_dir metadata missing or not a directory ('$WORK_DIR'). Intake staging did not complete; cannot continue." >&2
+  bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
+    --set-metadata "summary_for_human=adopt-pr review could not re-enter the staged worktree (work_dir='$WORK_DIR', missing or not a dir). Re-sling from intake."
+  bd close "$ROOT_ID" --reason "work_dir missing in review"
+  exit 1
+fi
+cd "$WORK_DIR"
+```
+Extract `pr_number`, `repo`, `base_branch`, `skip_gemini` from notes.
+
+**2. Fetch canonical upstream base:**
+```bash
+UPSTREAM_URL="https://github.com/<owner>/<repo>.git"
+git fetch "$UPSTREAM_URL" <base_branch>:refs/adopt-pr/upstream-base
+```
+
+**3. Invoke /review-pr:**
+```
+/review-pr <pr_number>
+```
+If `skip_gemini` is "true", append `--skip-gemini`:
+```
+/review-pr <pr_number> --skip-gemini
+```
+
+**CRITICAL:** When the review completes and asks whether to post the comment
+to GitHub, **DECLINE** (do not post). The finalize step posts its own
+synthesized comment.
+
+**4. Save the run_dir:**
+
+After the review completes, note the run_dir path from the output.
+Update root bead notes:
+```bash
+bd update $ROOT_ID --notes "<existing notes>
+review_run_dir: <run_dir_path>"
+```
+
+The synthesis artifact is at `<run_dir>/outputs/synthesis.md`.
+
+**5. Present findings summary (salvage-first):**
+
+Read the synthesis and present a brief summary to orient the human reviewer.
+For every finding, lead with the salvage question — *can WE fix it?* (it is
+reproducible AND needs no author-only input). If yes, the default verdict is
+**take-the-good**: we adopt + apply fixups + merge via finalize. `request_changes`
+is reserved for the three cases (cant-reproduce / needs-author-input /
+author-wants-to-iterate); `block` is reserved for security/release-safety
+blockers only.
+- Decision (approve / take-the-good / request_changes / block)
+- For take-the-good: which findings WE fix in finalize
+- For request_changes: which reserved case applies
+- Top findings by severity
+- Key files affected
+
+Record the verdict in root bead notes so finalize and the human gate can read it:
+```bash
+bd update $ROOT_ID --notes "<existing notes>
+verdict: <approve|take-the-good|request_changes|block>
+salvageable: <true|false>
+rc_reason: <none|cant-reproduce|needs-author-input|author-wants-to-iterate>"
+```
+
+```
+[adopt-pr] Review complete
+[adopt-pr]   Decision: <approve|take-the-good|request_changes|block>
+[adopt-pr]   Findings: <N> total (<blockers>, <majors>, <minors>)
+[adopt-pr]   Run dir: <path>
+```
+
+**Exit criteria:** Review complete, findings presented, verdict recorded in notes, run_dir saved in notes."""
+
+[[steps]]
+id = "human-gate"
+title = "Human review checkpoint"
+needs = ["review"]
+description = """
+**This step is closed by a HUMAN, not by the polecat.**
+
+The polecat has completed the review. The human maintainer now:
+1. Reads the review findings (synthesis available at the run_dir in root bead notes)
+2. Optionally makes fixup commits on the PR branch
+3. Optionally runs another review manually
+4. Closes this step when ready to proceed to finalize
+
+**For the polecat:** When you reach this step via `bd mol current`, there is
+nothing for you to do. Print a status message and wait:
+
+```
+[adopt-pr] Human gate reached — waiting for maintainer
+[adopt-pr]   Review findings are in the root bead notes (review_run_dir)
+[adopt-pr]   Close this step when ready to finalize:
+[adopt-pr]     bd close <this-step-id>
+```
+
+Then exit or idle. The maintainer closes the gate:
+```bash
+bd close <human-gate-step-id>
+```
+
+This unblocks the `finalize` step. The polecat picks it up on its next loop
+iteration (via `bd mol current`) or when nudged.
+
+**Exit criteria:** Human has closed this step."""
+
+[[steps]]
+id = "finalize"
+title = "Resolve path, prepare artifacts, hand publish + merge to mayor"
+needs = ["human-gate"]
+description = """
+Determine the merge path, then:
+- **Path A** (contributor PR, no maintainer changes): push the rebased
+  contributor branch, post synthesis comment, wait for CI, record the merge
+  command + `merge_ready: true` in root bead, mail mayor, then run the A.5
+  cleanup. Mayor performs the merge asynchronously.
+- **Paths B/C/D** (involve maintainer-authored content publishing to upstream):
+  prepare all local artifacts (squash, branch, cherry-pick, synthesis body),
+  record a *branch-ready handoff bundle* (status + push_command + optional
+  pr_create_command + synthesis body + merge_command) in the root bead, mail
+  mayor, then run the A.5 cleanup. Mayor performs publish + downstream actions
+  asynchronously.
+
+**Polecats NEVER run `gh pr merge`** on any path.
+**Polecats NEVER run `git push`, `gh pr create`, or `gh pr comment` on paths
+B/C/D** — those publish maintainer-authored content (push of new history,
+new PRs, or synthesis comments under maintainer identity) and require
+per-action mayor approval.
+
+**1. Re-enter the staged PR worktree and read root bead state:**
+
+A fresh polecat shell starts in the slot worktree, not the per-PR worktree the
+`intake` step staged. Re-enter it from `work_dir` before resolving the merge
+path or touching git — every path below operates on the staged branch:
+```bash
+ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+WORK_DIR=$(bd show "$ROOT_ID" --json | jq -r '.[0].metadata.work_dir // empty')
+if [ -z "$WORK_DIR" ] || [ ! -d "$WORK_DIR" ]; then
+  echo "[adopt-pr] FATAL: work_dir metadata missing or not a directory ('$WORK_DIR'). Intake staging did not complete; cannot continue." >&2
+  bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
+    --set-metadata "summary_for_human=adopt-pr finalize could not re-enter the staged worktree (work_dir='$WORK_DIR', missing or not a dir). Re-sling from intake."
+  bd close "$ROOT_ID" --reason "work_dir missing in finalize"
+  exit 1
+fi
+cd "$WORK_DIR"
+```
+Extract all state: `pr_number`, `repo`, `base_branch`, `original_head`,
+`head_ref`, `maintainer_edits`, `rebase_status`, `review_run_dir`,
+`pr_title`, `pr_author`.
+
+**2. Check if PR was already merged:**
+```bash
+PR_STATE=$(gh pr view <number> --json state --jq '.state')
+```
+
+If `MERGED`:
+- If maintainer commits exist (`git rev-list --count $ORIGINAL_HEAD..HEAD > 0`) → **Path D**
+- If no maintainer commits → done, close root bead with "PR already merged", exit
+
+**3. Determine merge path (if not already merged):**
+```bash
+MAINTAINER_COMMIT_COUNT=$(git rev-list --count $ORIGINAL_HEAD..HEAD)
+```
+
+- `MAINTAINER_COMMIT_COUNT == 0` → **Path A** (squash merge, no maintainer changes)
+- `MAINTAINER_COMMIT_COUNT > 0` AND `maintainer_edits: true` → **Path B** (merge commit)
+- `MAINTAINER_COMMIT_COUNT > 0` AND `maintainer_edits: false` → **Path C** (new PR)
+
+Update notes: `merge_path: A|B|C|D`
+
+---
+
+### Path A: Squash Merge (no maintainer changes)
+
+**A.1: Post synthesis comment.**
+Read `<review_run_dir>/outputs/synthesis.md`. Build comment using Path A template:
+
+```markdown
+## Adoption Review
+
+Thanks for the contribution, @<author>! <specific acknowledgment>.
+
+### Review Summary
+<Decision + 2-3 sentence summary from synthesis>
+
+### Review Findings
+| # | Category | Severity | Confidence | Source | Summary |
+|---|----------|----------|------------|--------|---------|
+<findings from synthesis, or "No issues found.">
+
+---
+_Adopted via `/adopt-pr` workflow. Contributor commits preserved._
+```
+
+Post: `gh pr comment <number> --body "<comment>"`
+
+**A.2: Wait for CI.**
+
+First verify CI checks exist:
+```bash
+gh pr checks <number>
+```
+If no checks reported → **STOP**, print message telling maintainer to approve
+GitHub Actions workflow run. Wait for nudge.
+
+Once checks exist:
+```bash
+gh pr checks <number> --watch
+```
+If CI fails → **STOP**, report failure, wait for nudge.
+
+**A.3: Push rebased branch (if applicable).**
+If rebase was performed (`rebase_status` is not `not_needed`):
+```bash
+git push --force-with-lease
+```
+
+**A.4: Hand off the merge to mayor.**
+**Polecats NEVER run `gh pr merge`.** Record the resolved merge command +
+readiness flag in the root bead, mail mayor, and proceed to A.5 — do NOT
+run the merge yourself. The maintainer (via mayor) performs the merge
+out-of-band per the per-action approval rule.
+
+```bash
+bd update $ROOT_ID --notes "<notes with merge_path: A, merge_ready: true, status: ready-for-merge, merge_command: 'gh pr merge <number> --squash'>"
+```
+
+Then mail mayor:
+```
+[adopt-pr] Path A ready for merge — synthesis posted, CI green, no maintainer changes.
+[adopt-pr]   PR:            <number>
+[adopt-pr]   Merge command: gh pr merge <number> --squash
+[adopt-pr]   Root bead:     $ROOT_ID
+```
+
+The polecat then runs A.5 (cleanup), the final step in the molecule. Mayor's
+merge happens asynchronously — the polecat's own lifecycle does not wait for it.
+
+**A.5: Cleanup and final report (terminal — all paths).**
+
+Remove the temporary upstream-base ref and reclaim the per-PR worktree the
+`intake` step staged. This is the last step on every path (there is no separate
+`complete` step); the polecat's work ends here. Keep the per-path status already
+recorded (`ready-for-merge` for Path A, `ready-for-publish` for B/C/D) — the
+merge/publish itself is mayor's asynchronous work, so the polecat does not mark
+the PR "merged".
+
+`cd` out of the staged worktree before removing it (git refuses to remove the
+worktree you are standing in), then force-remove it so the slot is reclaimed on
+the success path of every merge path (A/B/C/D). Earlier-step halts (intake
+request-changes, rebase-check abort) `exit` without reaching here and leave
+their `adopt-pr-<N>` worktree in place; that is intentional and bounded — the
+worktree path is deterministic per PR number, so a re-sling of the same PR
+REUSES it (guarded clean + on-branch in intake) rather than accumulating, and a
+re-sling that runs to completion reclaims it here:
+```bash
+WORK_DIR=$(bd show "$ROOT_ID" --json | jq -r '.[0].metadata.work_dir // empty')
+git update-ref -d refs/adopt-pr/upstream-base 2>/dev/null || true
+MAIN_WT=$(git worktree list --porcelain | awk '/^worktree /{print $2; exit}')
+cd "$MAIN_WT" 2>/dev/null || cd /
+if [ -n "$WORK_DIR" ]; then
+  git worktree remove --force "$WORK_DIR" 2>/dev/null || true
+fi
+```
+
+**Report:**
+```
+[adopt-pr] Polecat work complete — handed off to mayor
+[adopt-pr]   Merge path: <A|B|C|D>
+[adopt-pr]   Status:     <ready-for-merge | ready-for-publish>
+[adopt-pr]   Refs:       cleaned up
+[adopt-pr]   Root bead:  $ROOT_ID
+```
+
+---
+
+### Path B: Merge Commit (maintainer changes present)
+
+**B.1: Squash contributor commits (if >1).**
+```bash
+CONTRIBUTOR_COUNT=$(git rev-list --count refs/adopt-pr/upstream-base..$ORIGINAL_HEAD)
+```
+
+If `CONTRIBUTOR_COUNT > 1`:
+```bash
+# Get contributor authorship
+AUTHOR_NAME=$(git log --format="%an" $ORIGINAL_HEAD -1)
+AUTHOR_EMAIL=$(git log --format="%ae" $ORIGINAL_HEAD -1)
+AUTHOR_DATE=$(git log --format="%aD" $ORIGINAL_HEAD -1)
+
+OLD_TIP=$(git rev-parse HEAD)
+BASE_SHA=$(git rev-parse refs/adopt-pr/upstream-base)
+MERGE_BASE=$(git merge-base refs/adopt-pr/upstream-base $ORIGINAL_HEAD)
+
+# Rebase contributor commits onto upstream-base, then squash
+git checkout --detach $ORIGINAL_HEAD
+git rebase --onto refs/adopt-pr/upstream-base $MERGE_BASE
+REBASED_TREE=$(git rev-parse HEAD^{tree})
+
+SQUASH_SHA=$(GIT_AUTHOR_NAME="$AUTHOR_NAME" GIT_AUTHOR_EMAIL="$AUTHOR_EMAIL" \
+  GIT_AUTHOR_DATE="$AUTHOR_DATE" \
+  git commit-tree "$REBASED_TREE" -p "$BASE_SHA" -m "<pr_title> (#<number>)")
+
+git checkout $SQUASH_SHA
+git cherry-pick ${ORIGINAL_HEAD}..${OLD_TIP}
+git checkout -B <branch-name> HEAD
+```
+
+**Guardrails (all four must pass, else restore and STOP):**
+1. Contributor diff identity — sorted added/removed lines match original
+2. File count — squashed commit touches same files as original
+3. Commit count — exactly 1 + MAINTAINER_COMMIT_COUNT
+4. Authorship — contributor name/email preserved
+
+If any fails: `git checkout -B <branch> $OLD_TIP` and **STOP**.
+
+**B.2: Hand off branch-ready bundle to mayor.**
+**Polecats NEVER run `git push` or `gh pr merge` on Path B.** B.1 already
+rewrote the contributor branch locally with maintainer changes squashed in;
+publishing that rewrite under maintainer identity is mayor's per-action
+publish step.
+
+Resolve the push command. `REBASE_STATUS` is the shell variable carrying the
+`rebase_status` field extracted from root bead notes in step 1 (see also
+A.3, which reads the same field):
+```bash
+REBASE_STATUS=$(bd_notes_get "$ROOT_ID" rebase_status)   # extracted in step 1
+if [ "$CONTRIBUTOR_COUNT" -gt 1 ] || [ "$REBASE_STATUS" != "not_needed" ]; then
+    PUSH_CMD="git push --force-with-lease"
+else
+    PUSH_CMD="git push"
+fi
+```
+
+Compose the Path B synthesis comment body (template — includes Initial Review,
+Maintainer Changes, Final Review Status sections) into a file:
+```bash
+SYNTH_PATH="<review_run_dir>/outputs/comment-path-b.md"
+# write the rendered comment body to $SYNTH_PATH
+```
+
+Resolve concrete handoff values and record the full branch-ready handoff
+bundle on the root bead. Use double-quoted command strings so `$SYNTH_PATH`
+and other shell variables expand at write time — the notes must contain
+fully resolved, copy-pasteable commands for mayor:
+```bash
+HEAD_SHA=$(git rev-parse HEAD)
+POST_SYNTH_CMD="gh pr comment <number> --body-file $SYNTH_PATH"
+CI_WAIT_CMD="gh pr checks <number> --watch"
+MERGE_CMD="gh pr merge <number> --merge"
+
+bd update "$ROOT_ID" --notes "<notes with
+  merge_path: B,
+  status: ready-for-publish,
+  branch: <head_ref>,
+  head_sha: $HEAD_SHA,
+  push_command: $PUSH_CMD,
+  synthesis_path: $SYNTH_PATH,
+  post_synthesis_command: $POST_SYNTH_CMD,
+  ci_check_command: $CI_WAIT_CMD,
+  merge_command: $MERGE_CMD>"
+```
+
+Then mail mayor (variable values shown for the example; substitute actual
+resolved values in the body):
+```
+[adopt-pr] Path B branch-ready — squash + maintainer-rebase done locally; ready for publish.
+[adopt-pr]   PR:                   <number>
+[adopt-pr]   Branch / SHA:         <head_ref> @ $HEAD_SHA
+[adopt-pr]   Push command:         $PUSH_CMD
+[adopt-pr]   Post-synthesis cmd:   $POST_SYNTH_CMD
+[adopt-pr]   CI wait cmd:          $CI_WAIT_CMD
+[adopt-pr]   Merge command:        $MERGE_CMD
+[adopt-pr]   Root bead:            $ROOT_ID
+```
+
+The polecat then runs B.3 (cleanup), the final step. Mayor performs
+push → post synthesis → wait CI → merge asynchronously per the per-action
+approval rule, independent of the polecat's lifecycle.
+
+**B.3: Cleanup** (same as Path A.5).
+
+---
+
+### Path C: New PR from Maintainer's Fork (maintainer_edits disabled)
+
+**C.1:** Squash contributor commits (same as B.1).
+**C.2:** Create new branch from upstream main:
+```bash
+NEW_BRANCH="fix/<head_ref>-complete"
+git checkout -b "$NEW_BRANCH" refs/adopt-pr/upstream-base
+```
+**C.3:** Cherry-pick contributor commit + maintainer commits.
+
+**C.4: Hand off branch-ready bundle to mayor.**
+**Polecats NEVER run `git push`, `gh pr create`, or `gh pr merge` on Path C.**
+C.1–C.3 prepared the new branch locally under maintainer identity; publishing
+that branch as a new upstream PR is mayor's per-action publish step.
+
+Compose the Path C synthesis comment body (credits contributor) and the
+original-PR thank-you/close comment into files:
+```bash
+SYNTH_PATH="<review_run_dir>/outputs/comment-path-c.md"
+CLOSE_PATH="<review_run_dir>/outputs/comment-path-c-original-close.md"
+# write the rendered bodies
+```
+
+Resolve concrete handoff values and record the full branch-ready handoff
+bundle on the root bead. Build each command in a shell variable first so the
+recorded notes contain fully resolved, copy-pasteable commands for mayor
+(no unexpanded `$NEW_BRANCH` / `$SYNTH_PATH` / etc. in the recorded text):
+```bash
+HEAD_SHA=$(git rev-parse HEAD)
+REPO_FULL="<owner>/<repo>"
+BASE_REF="<baseRefName>"
+ORIGIN_OWNER="<origin-owner>"
+PR_TITLE="<pr_title>"
+PR_BODY="<body referencing original PR>"
+NEW_NUMBER_PLACEHOLDER="<new-number>"   # mayor substitutes after gh pr create
+
+PUSH_CMD="git push -u origin $NEW_BRANCH"
+PR_CREATE_CMD="gh pr create --repo $REPO_FULL --base $BASE_REF --head $ORIGIN_OWNER:$NEW_BRANCH --title \"$PR_TITLE\" --body \"$PR_BODY\""
+POST_SYNTH_CMD="gh pr comment $NEW_NUMBER_PLACEHOLDER --body-file $SYNTH_PATH"
+CI_WAIT_CMD="gh pr checks $NEW_NUMBER_PLACEHOLDER --watch"
+MERGE_CMD="gh pr merge $NEW_NUMBER_PLACEHOLDER --repo $REPO_FULL --merge"
+CLOSE_ORIG_CMD="gh pr comment <number> --body-file $CLOSE_PATH && gh pr close <number>"
+
+bd update "$ROOT_ID" --notes "<notes with
+  merge_path: C,
+  status: ready-for-publish,
+  branch: $NEW_BRANCH,
+  head_sha: $HEAD_SHA,
+  push_command: $PUSH_CMD,
+  pr_create_command: $PR_CREATE_CMD,
+  synthesis_path: $SYNTH_PATH,
+  post_synthesis_command: $POST_SYNTH_CMD,
+  ci_check_command: $CI_WAIT_CMD,
+  merge_command: $MERGE_CMD,
+  close_original_comment_path: $CLOSE_PATH,
+  close_original_command: $CLOSE_ORIG_CMD>"
+```
+
+Then mail mayor:
+```
+[adopt-pr] Path C branch-ready — local branch prepared with maintainer + contributor commits; ready for publish.
+[adopt-pr]   New branch / SHA:     $NEW_BRANCH @ $HEAD_SHA
+[adopt-pr]   Push command:         $PUSH_CMD
+[adopt-pr]   PR-create command:    $PR_CREATE_CMD
+[adopt-pr]   Post-synthesis cmd:   $POST_SYNTH_CMD
+[adopt-pr]   CI wait cmd:          $CI_WAIT_CMD
+[adopt-pr]   Merge command:        $MERGE_CMD
+[adopt-pr]   Close-original cmds:  $CLOSE_ORIG_CMD
+[adopt-pr]   Original PR:          <number>
+[adopt-pr]   Root bead:            $ROOT_ID
+```
+
+The polecat then runs C.5 (cleanup), the final step. Mayor performs
+push → create PR → post synthesis → wait CI → merge → close original
+asynchronously per the per-action approval rule.
+
+**C.5:** Cleanup (same as Path A.5).
+
+---
+
+### Path D: Follow-up PR (original already merged)
+
+**D.1:** Fetch latest upstream, create branch:
+```bash
+FOLLOWUP_BRANCH="fix/<head_ref>-review-fixups"
+git checkout -b "$FOLLOWUP_BRANCH" <upstream-base>
+```
+**D.2:** Cherry-pick maintainer fixup commits only.
+
+**D.3: Hand off branch-ready bundle to mayor.**
+**Polecats NEVER run `git push`, `gh pr create`, or `gh pr merge` on Path D.**
+D.1–D.2 prepared the follow-up branch locally under maintainer identity;
+publishing it as a new upstream PR is mayor's per-action publish step.
+
+Compose the Path D synthesis comment body and the original-PR link-back
+comment into files:
+```bash
+SYNTH_PATH="<review_run_dir>/outputs/comment-path-d.md"
+LINK_PATH="<review_run_dir>/outputs/comment-path-d-original-link.md"
+# write the rendered bodies
+```
+
+Resolve concrete handoff values and record the full branch-ready handoff
+bundle on the root bead. Build each command in a shell variable first so the
+recorded notes contain fully resolved, copy-pasteable commands for mayor
+(no unexpanded `$FOLLOWUP_BRANCH` / `$SYNTH_PATH` / etc. in the recorded text):
+```bash
+HEAD_SHA=$(git rev-parse HEAD)
+REPO_FULL="<owner>/<repo>"
+BASE_REF="<baseRefName>"
+ORIGIN_OWNER="<origin-owner>"
+FOLLOWUP_TITLE="<followup-title>"
+FOLLOWUP_BODY="<body linking to original PR>"
+FOLLOWUP_NUMBER_PLACEHOLDER="<followup-number>"   # mayor substitutes after gh pr create
+
+PUSH_CMD="git push -u origin $FOLLOWUP_BRANCH"
+PR_CREATE_CMD="gh pr create --repo $REPO_FULL --base $BASE_REF --head $ORIGIN_OWNER:$FOLLOWUP_BRANCH --title \"$FOLLOWUP_TITLE\" --body \"$FOLLOWUP_BODY\""
+POST_SYNTH_CMD="gh pr comment $FOLLOWUP_NUMBER_PLACEHOLDER --body-file $SYNTH_PATH"
+CI_WAIT_CMD="gh pr checks $FOLLOWUP_NUMBER_PLACEHOLDER --watch"
+MERGE_CMD="gh pr merge $FOLLOWUP_NUMBER_PLACEHOLDER --squash"
+COMMENT_ORIG_CMD="gh pr comment <number> --body-file $LINK_PATH"
+
+bd update "$ROOT_ID" --notes "<notes with
+  merge_path: D,
+  status: ready-for-publish,
+  branch: $FOLLOWUP_BRANCH,
+  head_sha: $HEAD_SHA,
+  push_command: $PUSH_CMD,
+  pr_create_command: $PR_CREATE_CMD,
+  synthesis_path: $SYNTH_PATH,
+  post_synthesis_command: $POST_SYNTH_CMD,
+  ci_check_command: $CI_WAIT_CMD,
+  merge_command: $MERGE_CMD,
+  original_link_comment_path: $LINK_PATH,
+  comment_original_command: $COMMENT_ORIG_CMD>"
+```
+
+Then mail mayor:
+```
+[adopt-pr] Path D branch-ready — follow-up branch prepared with maintainer fixups; ready for publish.
+[adopt-pr]   Follow-up branch:     $FOLLOWUP_BRANCH @ $HEAD_SHA
+[adopt-pr]   Push command:         $PUSH_CMD
+[adopt-pr]   PR-create command:    $PR_CREATE_CMD
+[adopt-pr]   Post-synthesis cmd:   $POST_SYNTH_CMD
+[adopt-pr]   CI wait cmd:          $CI_WAIT_CMD
+[adopt-pr]   Merge command:        $MERGE_CMD
+[adopt-pr]   Comment-original cmd: $COMMENT_ORIG_CMD
+[adopt-pr]   Original PR:          <number>
+[adopt-pr]   Root bead:            $ROOT_ID
+```
+
+The polecat then runs D.4 (cleanup), the final step. Mayor performs
+push → create follow-up PR → post synthesis → wait CI → merge → comment on
+original asynchronously per the per-action approval rule.
+
+**D.4:** Cleanup (same as Path A.5).
+
+---
+
+**Critical rules for all paths:**
+- **No force-push** except after contributor squash or rebase (always `--force-with-lease`)
+- **Contributor credit preserved** — squash commit keeps original author
+- **CI checks must exist** — never merge without CI. First-time forks need manual approval.
+- **Squash guardrails mandatory** — all four checks must pass before pushing rewritten history
+- **All reviews use canonical upstream base** — fetched from the real upstream URL, not origin
+
+**Exit criteria:** Merge path resolved. Then:
+- **Path A:** synthesis posted, CI green, `merge_ready: true` + `merge_command`
+  recorded in root bead notes, mayor mailed, A.5 cleanup run.
+- **Paths B/C/D:** local artifacts prepared (squash / branch / cherry-pick /
+  synthesis body), `status: ready-for-publish` + full publish-and-merge bundle
+  recorded in root bead notes, mayor mailed, A.5 cleanup run — without pushing,
+  creating PRs, posting comments, waiting on CI, or merging.
+
+The polecat never invokes `gh pr merge` on any path, and never invokes
+`git push` or `gh pr create` on paths B/C/D. Mayor performs publish and
+downstream actions asynchronously per the per-action approval rule,
+independent of the polecat's lifecycle."""

--- a/pr-review/formulas/mol-pr-ci-diagnose.formula.toml
+++ b/pr-review/formulas/mol-pr-ci-diagnose.formula.toml
@@ -1,0 +1,316 @@
+description = """
+PR CI diagnose — 4 steps to answer "why is CI failing on PR N?"
+
+Narrow read-only formula: parse the PR, fetch its check runs, classify any
+failures, write a verdict to the root bead notes. No checkout, no rebase,
+no review, no human-gate, no merge. Safe to run on PRs in any repo and
+any state.
+
+The molecule root bead IS the control bead — all run state is stored in its
+notes via `bd update <root-id> --notes "key: value"`. Crash-safe: `bd mol
+current` resumes at the right step.
+
+## Contract
+
+1. Caller slings with `--var pr=<url-or-number>`
+2. Polecat reads steps, executes each in order
+3. On exit, root bead notes carry the verdict and a per-check failure summary
+
+## Variables
+
+| Variable | Source | Description |
+|----------|--------|-------------|
+| pr | caller | PR URL or bare integer (required) |
+
+## Failure Modes
+
+| Situation | Action |
+|-----------|--------|
+| gh command fails | Check `gh auth status`, report error, stop |
+| PR not found | Record error in root bead notes, close formula |
+| No checks reported | Record `verdict: no_checks` in notes, exit cleanly |
+| Log fetch fails for a check | Record per-check `log_fetch: failed`, continue with others |"""
+formula = "mol-pr-ci-diagnose"
+version = 1
+
+[vars]
+[vars.pr]
+description = "PR URL (https://github.com/org/repo/pull/N) or bare integer"
+required = true
+
+[[steps]]
+id = "intake"
+title = "Parse PR and record metadata"
+description = """
+Parse the PR identifier, fetch metadata, record initial state in the root
+bead notes. No checkout — this formula is read-only.
+
+**1. Find the root bead:**
+```bash
+ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+```
+
+**2. Parse PR identifier from `{{pr}}`:**
+- If `{{pr}}` matches `https://github.com/.*/pull/\\d+` → extract owner, repo, PR number from URL
+- If `{{pr}}` is a bare integer → use current repo (`gh repo view --json nameWithOwner -q .nameWithOwner`)
+
+**3. Fetch PR metadata:**
+```bash
+gh pr view <number> --repo <owner>/<repo> --json title,author,baseRefName,headRefName,number,state,url,mergedAt,isDraft
+```
+
+**4. Record state in root bead notes:**
+```bash
+bd update $ROOT_ID --notes "pr_number: <N>
+pr_url: <url>
+repo: <owner/repo>
+pr_title: <title>
+pr_author: <author.login>
+pr_state: <OPEN|CLOSED|MERGED>
+pr_is_draft: <true|false>
+head_ref: <headRefName>
+base_branch: <baseRefName>
+verdict: pending
+checks_total: pending
+checks_passing: pending
+checks_failing: pending
+checks_pending: pending"
+```
+
+**5. Display summary:**
+```
+[ci-diagnose] Intake complete
+[ci-diagnose]   PR #<N>: "<title>" (<state>)
+[ci-diagnose]   Repo: <owner/repo>
+[ci-diagnose]   Author: <author.login>
+[ci-diagnose]   Base: <baseRefName> <- Head: <headRefName>
+```
+
+**Exit criteria:** PR metadata recorded in root bead notes."""
+
+[[steps]]
+id = "checks"
+title = "Fetch CI check runs"
+needs = ["intake"]
+description = """
+Pull the full CI check matrix for the PR. Aggregate counts; persist the
+per-check status table for the classify step.
+
+**1. Read root bead notes for PR metadata:**
+```bash
+ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+```
+Extract `pr_number` and `repo` from notes.
+
+**2. Fetch check runs as JSON:**
+```bash
+gh pr checks <pr_number> --repo <repo> --json name,state,bucket,workflow,link,description > /tmp/ci-diagnose-checks.json
+```
+
+`bucket` is gh's normalized status: `pass`, `fail`, `pending`, `skipping`, `cancel`.
+
+**3. Handle the no-checks case:**
+
+If `/tmp/ci-diagnose-checks.json` is `[]` (no checks reported):
+```bash
+bd update $ROOT_ID --notes "<existing notes with these overrides>
+verdict: no_checks
+checks_total: 0
+checks_passing: 0
+checks_failing: 0
+checks_pending: 0"
+```
+Print message and exit cleanly — proceed to report step which will short-circuit
+on `verdict: no_checks`.
+
+**4. Aggregate counts:**
+```bash
+TOTAL=$(jq 'length' /tmp/ci-diagnose-checks.json)
+PASS=$(jq '[.[] | select(.bucket == "pass")] | length' /tmp/ci-diagnose-checks.json)
+FAIL=$(jq '[.[] | select(.bucket == "fail" or .bucket == "cancel")] | length' /tmp/ci-diagnose-checks.json)
+PENDING=$(jq '[.[] | select(.bucket == "pending")] | length' /tmp/ci-diagnose-checks.json)
+```
+
+**5. Extract failing check list (for the classify step):**
+```bash
+jq -r '.[] | select(.bucket == "fail" or .bucket == "cancel") | "\\(.name)\\t\\(.link)\\t\\(.workflow // \"\")"' \\
+    /tmp/ci-diagnose-checks.json > /tmp/ci-diagnose-failed.tsv
+```
+
+**6. Record state in root bead notes:**
+```bash
+bd update $ROOT_ID --notes "<existing notes with these overrides>
+checks_total: $TOTAL
+checks_passing: $PASS
+checks_failing: $FAIL
+checks_pending: $PENDING
+failed_checks_artifact: /tmp/ci-diagnose-failed.tsv
+checks_artifact: /tmp/ci-diagnose-checks.json"
+```
+
+**7. Display summary:**
+```
+[ci-diagnose] Checks fetched: <TOTAL> total — <PASS> pass, <FAIL> fail, <PENDING> pending
+```
+
+**Exit criteria:** Per-check status fetched; failing-check list at `/tmp/ci-diagnose-failed.tsv`."""
+
+[[steps]]
+id = "classify"
+title = "Classify failed checks"
+needs = ["checks"]
+description = """
+For each failing check, fetch its run log and classify the failure. Pure
+mechanical extraction — record the failure category, the matching log line
+range, and a short evidence quote. No semantic judgment beyond pattern
+matching (ZFC: keep coded heuristics narrow and transparent).
+
+**1. Read root bead notes:**
+```bash
+ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+```
+Extract `pr_number`, `repo`, `checks_failing`, `failed_checks_artifact`.
+
+**2. Short-circuit if nothing failed:**
+
+If `checks_failing == 0` (and `verdict != no_checks`):
+- Record `classifications_artifact: n/a` and proceed to report.
+
+If `verdict == no_checks` from the previous step, short-circuit to report.
+
+**3. For each failed check, fetch and classify:**
+
+Iterate `/tmp/ci-diagnose-failed.tsv`. For each row (`name<TAB>link<TAB>workflow`):
+
+a. Extract the GitHub Actions run id from `link` (last path segment), if present.
+   If `link` is empty or doesn't match the actions URL pattern, record
+   `log_fetch: skipped_no_run_id` for this check and continue.
+
+b. Fetch the run log:
+   ```bash
+   gh run view <run_id> --repo <repo> --log-failed > /tmp/ci-diagnose-log-<run_id>.txt 2>/tmp/ci-diagnose-log-<run_id>.err
+   ```
+   If the fetch fails (non-zero exit or empty output), record `log_fetch: failed` and continue.
+
+c. Classify by grepping the log for known failure signatures. Apply in order;
+   first match wins:
+
+   | Category | Signature (case-insensitive grep) |
+   |----------|------------------------------------|
+   | test_failure | `FAIL\\s`, `--- FAIL:`, `failed tests`, `AssertionError`, `expected:.*got:`, `panic: test` |
+   | build_failure | `undefined reference to`, `cannot find package`, `compilation failed`, `error: cannot find symbol`, `cannot find module`, `error TS\\d+` |
+   | lint_failure | `golangci-lint`, `eslint`, `ruff`, `flake8`, `error:.*lint`, `linter exited` |
+   | type_check_failure | `tsc`, `error TS\\d+`, `mypy`, `pyright` |
+   | timeout | `\\bcontext deadline exceeded\\b`, `timeout\\b`, `timed out after`, `Job was cancelled` |
+   | dependency_failure | `connection refused`, `no such host`, `dial tcp`, `network is unreachable`, `unable to resolve`, `403\\sForbidden`, `429\\sToo Many Requests` |
+   | secret_or_auth_failure | `not authorized`, `permission denied`, `bad credentials`, `secret not found`, `missing\\srequired\\ssecret` |
+   | infra_flake | `runner.*lost`, `the runner has not received any responses`, `ECONNRESET`, `received signal: terminated` |
+   | other | (no match) |
+
+   Record the matching line (first occurrence) as evidence.
+
+d. Append a JSON record per check to `/tmp/ci-diagnose-classifications.jsonl`:
+   ```json
+   {"name": "<check name>", "category": "<category>", "evidence": "<first matching log line, truncated to 200 chars>", "log_path": "/tmp/ci-diagnose-log-<run_id>.txt"}
+   ```
+
+**4. Aggregate categories:**
+```bash
+jq -s 'group_by(.category) | map({category: .[0].category, count: length}) | sort_by(-.count)' \\
+    /tmp/ci-diagnose-classifications.jsonl > /tmp/ci-diagnose-category-summary.json
+```
+
+**5. Record state in root bead notes:**
+```bash
+bd update $ROOT_ID --notes "<existing notes with these overrides>
+classifications_artifact: /tmp/ci-diagnose-classifications.jsonl
+category_summary_artifact: /tmp/ci-diagnose-category-summary.json"
+```
+
+**6. Display summary:**
+```
+[ci-diagnose] Classified <N> failures:
+[ci-diagnose]   <category>: <count>
+[ci-diagnose]   ...
+```
+
+**Exit criteria:** Each failed check has a category and evidence line, persisted as JSONL."""
+
+[[steps]]
+id = "report"
+title = "Synthesize verdict and update bead notes"
+needs = ["classify"]
+description = """
+Read the classifications, write a human-readable summary, set a verdict on
+the root bead, and exit. This is the formula's final output.
+
+**1. Read root bead notes:**
+```bash
+ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+```
+Extract: `pr_number`, `pr_url`, `pr_title`, `pr_state`, `checks_total`,
+`checks_passing`, `checks_failing`, `checks_pending`, `verdict` (current),
+`classifications_artifact`, `category_summary_artifact`.
+
+**2. Determine verdict:**
+
+| Condition | Verdict |
+|-----------|---------|
+| `verdict == no_checks` (from checks step) | `no_checks` |
+| `checks_failing == 0` AND `checks_pending == 0` | `green` |
+| `checks_failing == 0` AND `checks_pending > 0` | `pending` |
+| `checks_failing > 0` AND dominant category is `infra_flake`, `dependency_failure`, or `timeout` | `failing_infra` |
+| `checks_failing > 0` otherwise | `failing_code` |
+
+"Dominant" = the category with the highest count in
+`category_summary_artifact`. Tiebreak by the first category in the priority
+order listed above.
+
+**3. Build the report markdown** at `/tmp/ci-diagnose-report.md`:
+
+```markdown
+# CI Diagnose — PR #<pr_number>: <pr_title>
+
+- **URL:** <pr_url>
+- **State:** <pr_state>
+- **Verdict:** <verdict>
+- **Totals:** <checks_total> checks — <checks_passing> pass, <checks_failing> fail, <checks_pending> pending
+
+## Failure Categories
+
+| Category | Count |
+|----------|-------|
+<rows from category_summary_artifact, or "_no failures_">
+
+## Per-Check Detail
+
+| Check | Category | Evidence |
+|-------|----------|----------|
+<rows from classifications_artifact, evidence truncated to 120 chars>
+
+## Artifacts
+
+- Check matrix: `<checks_artifact>`
+- Failed checks: `<failed_checks_artifact>`
+- Classifications: `<classifications_artifact>`
+- Category summary: `<category_summary_artifact>`
+- Run logs: `/tmp/ci-diagnose-log-*.txt`
+```
+
+**4. Update root bead notes with final verdict and report path:**
+```bash
+bd update $ROOT_ID --notes "<existing notes with these overrides>
+verdict: <green|pending|failing_infra|failing_code|no_checks>
+report_artifact: /tmp/ci-diagnose-report.md
+status: complete"
+```
+
+**5. Display final summary:**
+```
+[ci-diagnose] Complete
+[ci-diagnose]   Verdict: <verdict>
+[ci-diagnose]   Totals: <pass> pass / <fail> fail / <pending> pending of <total>
+[ci-diagnose]   Report: /tmp/ci-diagnose-report.md
+```
+
+**Exit criteria:** Verdict recorded in root bead notes; report markdown written."""

--- a/pr-review/formulas/mol-pr-ci-diagnose.formula.toml
+++ b/pr-review/formulas/mol-pr-ci-diagnose.formula.toml
@@ -7,7 +7,7 @@ no review, no human-gate, no merge. Safe to run on PRs in any repo and
 any state.
 
 The molecule root bead IS the control bead — all run state is stored in its
-notes via `bd update <root-id> --notes "key: value"`. Crash-safe: `bd mol
+notes via `gc bd update <root-id> --notes "key: value"`. Crash-safe: `gc bd mol
 current` resumes at the right step.
 
 ## Contract
@@ -47,7 +47,7 @@ bead notes. No checkout — this formula is read-only.
 
 **1. Find the root bead:**
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
 ```
 
 **2. Parse PR identifier from `{{pr}}`:**
@@ -61,7 +61,7 @@ gh pr view <number> --repo <owner>/<repo> --json title,author,baseRefName,headRe
 
 **4. Record state in root bead notes:**
 ```bash
-bd update $ROOT_ID --notes "pr_number: <N>
+gc bd update $ROOT_ID --notes "pr_number: <N>
 pr_url: <url>
 repo: <owner/repo>
 pr_title: <title>
@@ -98,7 +98,7 @@ per-check status table for the classify step.
 
 **1. Read root bead notes for PR metadata:**
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
 ```
 Extract `pr_number` and `repo` from notes.
 
@@ -113,7 +113,7 @@ gh pr checks <pr_number> --repo <repo> --json name,state,bucket,workflow,link,de
 
 If `/tmp/ci-diagnose-checks.json` is `[]` (no checks reported):
 ```bash
-bd update $ROOT_ID --notes "<existing notes with these overrides>
+gc bd update $ROOT_ID --notes "<existing notes with these overrides>
 verdict: no_checks
 checks_total: 0
 checks_passing: 0
@@ -139,7 +139,7 @@ jq -r '.[] | select(.bucket == "fail" or .bucket == "cancel") | "\\(.name)\\t\\(
 
 **6. Record state in root bead notes:**
 ```bash
-bd update $ROOT_ID --notes "<existing notes with these overrides>
+gc bd update $ROOT_ID --notes "<existing notes with these overrides>
 checks_total: $TOTAL
 checks_passing: $PASS
 checks_failing: $FAIL
@@ -167,7 +167,7 @@ matching (ZFC: keep coded heuristics narrow and transparent).
 
 **1. Read root bead notes:**
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
 ```
 Extract `pr_number`, `repo`, `checks_failing`, `failed_checks_artifact`.
 
@@ -222,7 +222,7 @@ jq -s 'group_by(.category) | map({category: .[0].category, count: length}) | sor
 
 **5. Record state in root bead notes:**
 ```bash
-bd update $ROOT_ID --notes "<existing notes with these overrides>
+gc bd update $ROOT_ID --notes "<existing notes with these overrides>
 classifications_artifact: /tmp/ci-diagnose-classifications.jsonl
 category_summary_artifact: /tmp/ci-diagnose-category-summary.json"
 ```
@@ -246,7 +246,7 @@ the root bead, and exit. This is the formula's final output.
 
 **1. Read root bead notes:**
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
 ```
 Extract: `pr_number`, `pr_url`, `pr_title`, `pr_state`, `checks_total`,
 `checks_passing`, `checks_failing`, `checks_pending`, `verdict` (current),
@@ -299,7 +299,7 @@ order listed above.
 
 **4. Update root bead notes with final verdict and report path:**
 ```bash
-bd update $ROOT_ID --notes "<existing notes with these overrides>
+gc bd update $ROOT_ID --notes "<existing notes with these overrides>
 verdict: <green|pending|failing_infra|failing_code|no_checks>
 report_artifact: /tmp/ci-diagnose-report.md
 status: complete"

--- a/pr-review/formulas/mol-pr-iterate.formula.toml
+++ b/pr-review/formulas/mol-pr-iterate.formula.toml
@@ -1,0 +1,672 @@
+description = """
+Iterate-PR workflow — 6 steps to address feedback on an outgoing PR.
+
+Source-agnostic pipeline that ingests feedback from one of four sources
+(codecov coverage report, GitHub Copilot review, a specific review comment,
+or free text), proposes a minimal patch, applies it on the PR branch,
+verifies the feedback is cleared, and reports.
+
+This is the *outgoing-PR* iteration analogue to mol-adopt-pr (incoming) and
+mol-pr-from-issue (issue → PR). It does NOT push or open PRs — the polecat
+commits to the local PR branch and the maintainer pushes after review.
+
+The molecule root bead IS the control bead — all run state is stored in its
+notes via `bd update <root-id> --notes "key: value"` and structured
+evidence in metadata via `bd update <root-id> --set-metadata "key=value"`.
+
+## Contract
+
+1. Caller slings with `--var pr=<int> --var feedback_source=<source>`
+   (and optionally `--var feedback_ref=<id-or-url-or-text>`).
+2. Polecat works through 6 sequential steps with explicit per-step gates.
+3. Chain ends with either:
+   - PR branch updated with a commit addressing the feedback, OR
+   - a halt with `metadata.summary_for_human` set on the root bead
+     and (when the bead specifies) an explicit mail to mayor.
+
+## Variables
+
+| Variable | Source | Description |
+|----------|--------|-------------|
+| pr | caller | PR number on the current repo's upstream (required, int) |
+| feedback_source | caller | One of: codecov, copilot, review-comment, text (required) |
+| feedback_ref | caller | Comment id, codecov report URL, or inline feedback text (optional; required for review-comment and text) |
+
+## Halt-and-mail-mayor conditions
+
+The polecat halts the chain AND mails mayor when:
+- **Feedback ambiguity** — parse-feedback cannot extract a structured
+  actionable signal from the source (e.g., codecov report unavailable,
+  copilot comments contain no concrete suggestions, text input is too
+  vague to plan from).
+- **Scope exceeds 200 LOC** — propose-patch's plan exceeds 200 LOC of
+  changes (sum of additions + deletions across affected files).
+- **Verify-clearance fails after 2 iterations** — apply + verify-clearance
+  has run twice without clearing the feedback signal.
+
+Halt-and-mail-mayor procedure (used by any step that hits one of the above):
+```bash
+bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
+                     --set-metadata "gc.escalate_to=mayor" \\
+                     --set-metadata "summary_for_human=<one-line synthesis>"
+gc mail send mayor -s "mol-pr-iterate halt: pr-{{pr}} (<reason>)" \\
+                    -m "<context with root bead id and failure detail>"
+bd close "$ROOT_ID" --reason "<reason>"
+```
+
+## Failure Modes
+
+| Situation | Action |
+|-----------|--------|
+| gh pr view fails / PR not found | intake halts; raw error in evidence + summary_for_human |
+| Cannot checkout PR branch (e.g. closed PR) | intake halts |
+| feedback_source not in enum | parse-feedback halts immediately |
+| feedback_ref missing when required | parse-feedback halts (review-comment/text need a ref) |
+| Codecov report URL unreachable | parse-feedback halts (ambiguity) |
+| Build fails after apply | apply halts; do NOT commit broken state |
+| Plan exceeds 200 LOC | propose-patch halts-and-mails-mayor |
+| Same feedback signal still present after 2 iterations | verify-clearance halts-and-mails-mayor |
+
+## Notes
+
+- No `auto_push` integration. The polecat never pushes; the maintainer
+  reviews the local commit and pushes manually.
+- Iteration counter is tracked in root bead notes (`iteration: N`).
+  apply + verify-clearance increment it on each cycle; verify-clearance
+  reads it to decide whether the halt-after-2 condition has fired."""
+formula = "mol-pr-iterate"
+version = 1
+
+[requires]
+formula_compiler = ">=2.0.0"
+
+[vars]
+[vars.pr]
+description = "PR number on the current repo's upstream (bare integer)"
+required = true
+
+[vars.feedback_source]
+description = "Source of the feedback to iterate on: codecov, copilot, review-comment, or text"
+required = true
+
+[vars.feedback_ref]
+description = "Comment id (for review-comment), codecov report URL (for codecov), or inline text (for text). Optional for copilot (the step queries the PR for copilot comments). Required for review-comment and text."
+default = ""
+
+[[steps]]
+id = "intake"
+title = "Parse PR and checkout"
+description = """
+Validate the feedback_source enum, fetch PR metadata, checkout the branch,
+and record initial state on the root bead.
+
+**1. Find the root bead:**
+```bash
+ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+```
+
+**2. Validate feedback_source enum:**
+```bash
+case "{{feedback_source}}" in
+  codecov|copilot|review-comment|text) ;;
+  *)
+    bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
+                         --set-metadata "summary_for_human=Invalid feedback_source: '{{feedback_source}}'. Must be one of codecov, copilot, review-comment, text."
+    bd close "$ROOT_ID" --reason "invalid feedback_source"
+    exit 1
+    ;;
+esac
+```
+
+**3. Validate feedback_ref presence (for sources that require it):**
+```bash
+case "{{feedback_source}}" in
+  review-comment|text)
+    if [ -z "{{feedback_ref}}" ]; then
+      bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
+                           --set-metadata "summary_for_human=feedback_source={{feedback_source}} requires --var feedback_ref=<value>."
+      bd close "$ROOT_ID" --reason "feedback_ref required"
+      exit 1
+    fi
+    ;;
+esac
+```
+
+**4. Fetch PR metadata:**
+```bash
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+gh pr view {{pr}} --json title,author,baseRefName,headRefName,number,state,url,headRefOid
+```
+
+If the PR is `CLOSED` or `MERGED` → halt:
+```bash
+bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
+                     --set-metadata "summary_for_human=PR #{{pr}} on $REPO is <state>; nothing to iterate on."
+bd close "$ROOT_ID" --reason "PR not open"
+exit 1
+```
+
+**5. Stage a per-PR worktree and checkout the branch:**
+
+Do **NOT** run `gh pr checkout` in place. A fresh polecat shell starts in the
+persistent slot worktree (`/home/ds/gascity-worktrees/polecat-N`), which may
+hold another molecule's in-progress WIP; an in-place checkout clobbers/stashes
+it. Stage an ephemeral per-PR worktree instead (polecat-prompt Mode 4
+convention), check the PR out there, then capture the base SHA:
+
+```bash
+PR_WORKTREE="/home/ds/gascity-worktrees/iterate-pr-{{pr}}"
+EXPECTED_BRANCH="<headRefName>"
+
+if [ -d "$PR_WORKTREE" ]; then
+  # Re-sling: a prior run already staged this worktree. Only TRUST it if it is
+  # on the expected PR branch AND clean. Otherwise fail loud — never silently
+  # clobber, stash, or build iteration work on top of unknown state.
+  cd "$PR_WORKTREE"
+  WT_BRANCH=$(git branch --show-current)
+  if [ "$WT_BRANCH" != "$EXPECTED_BRANCH" ] || [ -n "$(git status --porcelain)" ]; then
+    echo "[iterate] FATAL: staged worktree $PR_WORKTREE is on branch '$WT_BRANCH' (expected '$EXPECTED_BRANCH') or has uncommitted changes." >&2
+    bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
+                         --set-metadata "summary_for_human=iterate intake found a dirty or wrong-branch staged worktree at $PR_WORKTREE (branch '$WT_BRANCH', expected '$EXPECTED_BRANCH'). Inspect it, then 'git worktree remove --force $PR_WORKTREE' before re-slinging."
+    bd close "$ROOT_ID" --reason "dirty/wrong-branch staged worktree in intake"
+    exit 1
+  fi
+else
+  git worktree add --detach "$PR_WORKTREE"
+  cd "$PR_WORKTREE"
+fi
+
+gh pr checkout {{pr}}
+BASE_SHA=$(git rev-parse HEAD)
+```
+
+Record the staging directory on the root bead. Every later step runs in a
+fresh shell that otherwise lands back in the slot worktree, so they re-enter
+`work_dir` from this metadata:
+```bash
+bd update "$ROOT_ID" --set-metadata "work_dir=$PR_WORKTREE"
+```
+
+**6. Record state in root bead notes:**
+```bash
+bd update $ROOT_ID --notes "pr_number: {{pr}}
+repo: $REPO
+pr_title: <title>
+pr_author: <author.login>
+head_ref: <headRefName>
+base_branch: <baseRefName>
+base_sha: $BASE_SHA
+feedback_source: {{feedback_source}}
+feedback_ref: {{feedback_ref}}
+iteration: 0"
+```
+
+**7. Display summary:**
+```
+[iterate] Intake complete
+[iterate]   PR #{{pr}}: "<title>" on $REPO
+[iterate]   Author: <author.login>
+[iterate]   Base SHA: $BASE_SHA
+[iterate]   Feedback source: {{feedback_source}}
+```
+
+**Exit criteria:** On PR branch, metadata recorded in root bead notes, base SHA captured."""
+
+[[steps]]
+id = "parse-feedback"
+title = "Parse feedback into structured form"
+needs = ["intake"]
+description = """
+Dispatch on `feedback_source` and extract a structured actionable signal.
+Write the parsed feedback to the root bead notes under `parsed_feedback`.
+
+If the source yields no actionable signal (empty findings, unreachable URL,
+or content too vague to plan from), halt-and-mail-mayor with reason
+"feedback ambiguity".
+
+**1. Re-enter the staged PR worktree and read root bead state:**
+
+A fresh polecat shell starts in the slot worktree, not the per-PR worktree the
+`intake` step staged. Re-enter it from `work_dir` before any git or file work
+(the codecov path diffs the PR branch):
+```bash
+ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+WORK_DIR=$(bd show "$ROOT_ID" --json | jq -r '.[0].metadata.work_dir // empty')
+if [ -z "$WORK_DIR" ] || [ ! -d "$WORK_DIR" ]; then
+  echo "[iterate] FATAL: work_dir metadata missing or not a directory ('$WORK_DIR'). Intake staging did not complete; cannot continue." >&2
+  bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
+                       --set-metadata "summary_for_human=iterate parse-feedback could not re-enter the staged worktree (work_dir='$WORK_DIR', missing or not a dir). Re-sling from intake."
+  bd close "$ROOT_ID" --reason "work_dir missing in parse-feedback"
+  exit 1
+fi
+cd "$WORK_DIR"
+```
+
+**2. Dispatch on `feedback_source`:**
+
+### Source: codecov
+
+The `feedback_ref` should be a codecov report URL (e.g.
+`https://codecov.io/gh/<owner>/<repo>/pull/<N>`). If empty, attempt to
+locate it from the PR's check runs:
+```bash
+gh pr checks {{pr}} --json name,detailsUrl --jq '.[] | select(.name | test("codecov"; "i")) | .detailsUrl'
+```
+
+Fetch the report (codecov has a public JSON API):
+```bash
+# If feedback_ref is the html URL, derive the API URL.
+# Example: https://codecov.io/api/v2/github/<owner>/repos/<repo>/pulls/<N>
+curl -sf "<api_url>" > /tmp/codecov.json
+```
+
+Extract uncovered lines limited to files changed in the PR diff:
+```bash
+git diff --name-only $BASE_SHA..HEAD > /tmp/pr-files.txt
+# parse /tmp/codecov.json for uncovered lines per file, intersect with /tmp/pr-files.txt
+```
+
+If the report is unreachable, malformed, or shows 100% coverage on PR
+files → **halt-and-mail-mayor** (ambiguity / nothing to do).
+
+### Source: copilot
+
+Fetch PR review comments, filter to copilot bot author:
+```bash
+gh api "/repos/$REPO/pulls/{{pr}}/comments" \\
+  --jq '.[] | select(.user.login == "github-advanced-security[bot]" or .user.login == "copilot-pull-request-reviewer[bot]" or (.user.login | test("copilot"; "i"))) | {id, path, line, body}'
+```
+
+If no copilot comments found → **halt-and-mail-mayor** (ambiguity).
+
+### Source: review-comment
+
+Fetch the specific comment by id:
+```bash
+gh api "/repos/$REPO/pulls/comments/{{feedback_ref}}" \\
+  --jq '{id, path, line, body, user: .user.login}'
+```
+
+If the comment id doesn't exist or returns 404 → halt-and-mail-mayor.
+
+### Source: text
+
+The `feedback_ref` IS the feedback. Use it verbatim:
+```bash
+echo "{{feedback_ref}}" > /tmp/parsed_feedback.txt
+```
+
+If the text is empty or just whitespace → halt-and-mail-mayor.
+
+**3. Write parsed_feedback to root bead notes:**
+
+Serialize the parsed signal as a compact JSON string in notes, e.g.:
+```bash
+bd update $ROOT_ID --notes "<existing notes>
+parsed_feedback: <json>"
+```
+
+For codecov: `{\"type\": \"coverage\", \"uncovered\": [{\"file\": \"...\", \"lines\": [12, 15-18]}]}`
+For copilot: `{\"type\": \"copilot\", \"comments\": [{\"id\": ..., \"path\": \"...\", \"line\": ..., \"body\": \"...\"}]}`
+For review-comment: `{\"type\": \"review-comment\", \"comment\": {...}}`
+For text: `{\"type\": \"text\", \"body\": \"...\"}`
+
+**Halt-and-mail-mayor on ambiguity:**
+```bash
+bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
+                     --set-metadata "gc.escalate_to=mayor" \\
+                     --set-metadata "summary_for_human=Cannot extract actionable feedback from {{feedback_source}} for PR #{{pr}}: <reason>."
+gc mail send mayor -s "mol-pr-iterate halt: pr-{{pr}} (feedback ambiguity)" \\
+                    -m "Root bead $ROOT_ID. Feedback source {{feedback_source}} yielded no actionable signal. Detail: <reason>."
+bd close "$ROOT_ID" --reason "feedback ambiguity"
+```
+
+**Exit criteria:** `parsed_feedback` recorded on root bead notes, OR halt-and-mail-mayor fired."""
+
+[[steps]]
+id = "propose-patch"
+title = "Propose minimal patch plan"
+needs = ["parse-feedback"]
+description = """
+Read parsed feedback, design the smallest diff that clears the signal,
+write the plan to a markdown artifact under `.gc/pr-pipeline/iterate/`.
+Halt-and-mail-mayor if the plan exceeds 200 LOC.
+
+**1. Re-enter the staged PR worktree and read root bead state:**
+
+A fresh polecat shell starts in the slot worktree, not the per-PR worktree the
+`intake` step staged. Re-enter it from `work_dir` so the plan artifact is
+written under the staged worktree (where `apply` will read it):
+```bash
+ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+WORK_DIR=$(bd show "$ROOT_ID" --json | jq -r '.[0].metadata.work_dir // empty')
+if [ -z "$WORK_DIR" ] || [ ! -d "$WORK_DIR" ]; then
+  echo "[iterate] FATAL: work_dir metadata missing or not a directory ('$WORK_DIR'). Intake staging did not complete; cannot continue." >&2
+  bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
+                       --set-metadata "summary_for_human=iterate propose-patch could not re-enter the staged worktree (work_dir='$WORK_DIR', missing or not a dir). Re-sling from intake."
+  bd close "$ROOT_ID" --reason "work_dir missing in propose-patch"
+  exit 1
+fi
+cd "$WORK_DIR"
+```
+Extract `parsed_feedback`, `pr_number`, `repo`, `base_sha`.
+
+**2. Compose a plan.**
+
+The polecat reads `parsed_feedback` and drafts a markdown plan with:
+- **Goal** — one sentence stating what feedback signal will be cleared.
+- **Files to touch** — explicit list with reason per file.
+- **Estimated LOC** — sum of additions + deletions across the plan.
+- **Diff sketch** — for each file, a brief description of the change
+  (not the literal diff — that comes in `apply`).
+- **Verification** — how `verify-clearance` will confirm the signal is gone.
+
+Write the plan to:
+```bash
+mkdir -p .gc/pr-pipeline/iterate
+PLAN_PATH=".gc/pr-pipeline/iterate/pr-{{pr}}.md"
+# write the plan markdown to $PLAN_PATH
+```
+
+**3. Estimate LOC and enforce 200-LOC cap.**
+
+Compute the estimated LOC from the plan (sum of additions + deletions in
+the Diff sketch). If `EST_LOC > 200`:
+```bash
+bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
+                     --set-metadata "gc.escalate_to=mayor" \\
+                     --set-metadata "summary_for_human=Iteration plan for PR #{{pr}} exceeds 200 LOC ($EST_LOC). Plan at $PLAN_PATH. Recommend splitting the feedback into separate beads or accepting partial clearance."
+gc mail send mayor -s "mol-pr-iterate halt: pr-{{pr}} (scope > 200 LOC)" \\
+                    -m "Root bead $ROOT_ID. Plan at $PLAN_PATH estimates $EST_LOC LOC, exceeds 200 LOC cap."
+bd close "$ROOT_ID" --reason "scope > 200 LOC"
+exit 0
+```
+
+**4. Record evidence on root bead:**
+```bash
+bd update "$ROOT_ID" --set-metadata "evidence.plan_path=$PLAN_PATH" \\
+                     --set-metadata "evidence.estimated_loc=$EST_LOC"
+bd update $ROOT_ID --notes "<existing notes>
+plan_path: $PLAN_PATH
+estimated_loc: $EST_LOC"
+```
+
+**Exit criteria:** Plan markdown written at `.gc/pr-pipeline/iterate/pr-{{pr}}.md`,
+estimated_loc within cap, evidence recorded on root bead."""
+
+[[steps]]
+id = "apply"
+title = "Implement plan and commit"
+needs = ["propose-patch"]
+description = """
+Read the plan, implement the minimal diff, verify the build is green,
+commit on the PR branch with a conventional message. Do NOT push.
+
+**1. Re-enter the staged PR worktree and read root bead state:**
+
+A fresh polecat shell starts in the slot worktree, not the per-PR worktree the
+`intake` step staged. Re-enter it from `work_dir` before editing, building, or
+committing — the on-branch and clean-worktree checks below assume the staged
+worktree:
+```bash
+ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+WORK_DIR=$(bd show "$ROOT_ID" --json | jq -r '.[0].metadata.work_dir // empty')
+if [ -z "$WORK_DIR" ] || [ ! -d "$WORK_DIR" ]; then
+  echo "[iterate] FATAL: work_dir metadata missing or not a directory ('$WORK_DIR'). Intake staging did not complete; cannot continue." >&2
+  bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
+                       --set-metadata "summary_for_human=iterate apply could not re-enter the staged worktree (work_dir='$WORK_DIR', missing or not a dir). Re-sling from intake."
+  bd close "$ROOT_ID" --reason "work_dir missing in apply"
+  exit 1
+fi
+cd "$WORK_DIR"
+```
+Extract `plan_path`, `pr_number`, `head_ref`, `iteration`.
+
+**2. Verify we're on the PR branch:**
+```bash
+CURRENT=$(git branch --show-current)
+EXPECTED=<head_ref>
+if [ "$CURRENT" != "$EXPECTED" ]; then
+  bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
+                       --set-metadata "summary_for_human=apply step expected branch $EXPECTED, found $CURRENT. Did intake checkout fail?"
+  bd close "$ROOT_ID" --reason "branch mismatch in apply"
+  exit 1
+fi
+```
+
+**3. Verify worktree is clean (no in-flight changes from a prior partial apply):**
+```bash
+if [ -n "$(git status --porcelain)" ]; then
+  bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
+                       --set-metadata "summary_for_human=apply step found dirty worktree on $CURRENT. Manual cleanup needed before re-sling."
+  bd close "$ROOT_ID" --reason "dirty worktree in apply"
+  exit 1
+fi
+```
+
+**4. Implement the plan.**
+
+The polecat reads `$plan_path` and edits files according to the Diff sketch.
+Edits should match the plan; if the polecat discovers the plan is wrong
+mid-implementation, revert local changes and halt-and-mail-mayor with
+"plan vs. reality mismatch".
+
+**5. Run build verification.**
+
+The verification command is pack-dependent — check `pack.toml` of the
+consuming pack for hints, or run the repo's standard quality gates:
+- Go packs: `go build ./... && go vet ./...`
+- Python packs: `python3 -m pytest`
+- Mixed: run the pack's `tests/` script
+
+If build fails:
+```bash
+git checkout -- .  # revert the unsuccessful changes
+bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
+                     --set-metadata "summary_for_human=Build failed after apply for PR #{{pr}}. Plan at $plan_path may need revision. Worktree reverted."
+gc mail send mayor -s "mol-pr-iterate halt: pr-{{pr}} (build failed)" \\
+                    -m "Root bead $ROOT_ID. apply succeeded in editing files but build verification failed. Worktree reverted."
+bd close "$ROOT_ID" --reason "build failed after apply"
+exit 1
+```
+
+**6. Commit.**
+
+Use a conventional commit message referencing the bead and feedback source:
+```bash
+git add <changed files>
+git commit -m "fix(<scope>): address <feedback_source> feedback on PR #{{pr}}
+
+<one-line summary from plan>
+
+Refs: $ROOT_ID"
+```
+
+**7. Increment iteration counter:**
+```bash
+NEW_ITER=$(($iteration + 1))
+COMMIT_SHA=$(git rev-parse HEAD)
+bd update $ROOT_ID --notes "<existing notes with iteration: $NEW_ITER, last_apply_commit: $COMMIT_SHA>"
+```
+
+**Exit criteria:** New commit on PR branch, build green, iteration counter incremented, last_apply_commit recorded."""
+
+[[steps]]
+id = "verify-clearance"
+title = "Verify feedback signal is cleared"
+needs = ["apply"]
+description = """
+Re-run the feedback source check to confirm the signal is gone. Behavior
+varies by source. If the signal persists AND `iteration >= 2`,
+halt-and-mail-mayor.
+
+**1. Re-enter the staged PR worktree and read root bead state:**
+
+A fresh polecat shell starts in the slot worktree, not the per-PR worktree the
+`intake` step staged. Re-enter it from `work_dir` before re-running the
+source-specific verification (codecov diffs the PR branch):
+```bash
+ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+WORK_DIR=$(bd show "$ROOT_ID" --json | jq -r '.[0].metadata.work_dir // empty')
+if [ -z "$WORK_DIR" ] || [ ! -d "$WORK_DIR" ]; then
+  echo "[iterate] FATAL: work_dir metadata missing or not a directory ('$WORK_DIR'). Intake staging did not complete; cannot continue." >&2
+  bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
+                       --set-metadata "summary_for_human=iterate verify-clearance could not re-enter the staged worktree (work_dir='$WORK_DIR', missing or not a dir). Re-sling from intake."
+  bd close "$ROOT_ID" --reason "work_dir missing in verify-clearance"
+  exit 1
+fi
+cd "$WORK_DIR"
+```
+Extract `feedback_source`, `feedback_ref`, `pr_number`, `repo`, `iteration`,
+`last_apply_commit`.
+
+**2. Source-specific verification:**
+
+### codecov
+
+Codecov coverage is computed by CI. The polecat cannot directly re-trigger
+codecov — instead, the apply commit is local and unpushed, so codecov has
+nothing new to score. Mark verification as **deferred-to-push**:
+```bash
+bd update "$ROOT_ID" --set-metadata "evidence.verification=deferred-to-push" \\
+                     --set-metadata "evidence.verification_note=Codecov verification runs after maintainer pushes commit $last_apply_commit. Re-sling mol-pr-iterate after the next codecov run if uncovered lines persist."
+```
+Proceed to `report` (do NOT count this as a failed iteration).
+
+### copilot
+
+Re-query copilot comments. If the original comment(s) are now marked
+`resolved` or absent, signal is cleared.
+
+```bash
+gh api "/repos/$REPO/pulls/{{pr}}/comments" \\
+  --jq '.[] | select(.user.login | test("copilot"; "i")) | select(.in_reply_to_id == null) | {id, body}'
+```
+
+Compare with `parsed_feedback.comments` from earlier. For each prior
+comment, check if it's resolved (GraphQL only — `gh api graphql -F query=...`)
+or no longer present.
+
+If cleared, post a reply on the original copilot thread noting the change:
+```bash
+gh api "/repos/$REPO/pulls/{{pr}}/comments" \\
+  -f body="Addressed in $last_apply_commit." \\
+  -f in_reply_to=<original_comment_id>
+```
+
+### review-comment
+
+Similar to copilot — post a reply to `{{feedback_ref}}`:
+```bash
+gh api "/repos/$REPO/pulls/{{pr}}/comments" \\
+  -f body="Addressed in $last_apply_commit." \\
+  -f in_reply_to={{feedback_ref}}
+```
+
+The polecat does not auto-resolve the comment thread; the reviewer marks
+it resolved.
+
+### text
+
+Free-text feedback has no automated verification. Mark as
+**manual-verification**:
+```bash
+bd update "$ROOT_ID" --set-metadata "evidence.verification=manual" \\
+                     --set-metadata "evidence.verification_note=Text feedback addressed in $last_apply_commit. Manual verification by maintainer."
+```
+
+**3. Halt-after-2 check.**
+
+If the signal persists AND `iteration >= 2`:
+```bash
+bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
+                     --set-metadata "gc.escalate_to=mayor" \\
+                     --set-metadata "summary_for_human=PR #{{pr}} feedback signal persists after 2 iterations. Last apply commit $last_apply_commit. Manual review needed."
+gc mail send mayor -s "mol-pr-iterate halt: pr-{{pr}} (verify-clearance failed x2)" \\
+                    -m "Root bead $ROOT_ID. Feedback source {{feedback_source}}, $iteration iterations attempted, signal still present."
+bd close "$ROOT_ID" --reason "verify-clearance failed after 2 iterations"
+exit 1
+```
+
+If the signal persists AND `iteration < 2`:
+- Re-enter `parse-feedback` is NOT automatic in this formula — the polecat
+  exits this step and the maintainer (or mayor) decides whether to re-sling
+  for another iteration.
+
+**4. Record clearance evidence:**
+```bash
+bd update "$ROOT_ID" --set-metadata "evidence.cleared=<true|false>"
+```
+
+**Exit criteria:** Verification result recorded on root bead metadata,
+either as cleared / deferred-to-push / manual / not-cleared (with halt
+on iteration >= 2)."""
+
+[[steps]]
+id = "report"
+title = "Write evidence summary"
+needs = ["verify-clearance"]
+description = """
+Synthesize the run into `evidence.*` metadata + `summary_for_human` on the
+root bead so downstream loop-close handlers can surface the outcome.
+
+**1. Read root bead notes:**
+```bash
+ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+```
+Extract all state: `pr_number`, `repo`, `feedback_source`, `iteration`,
+`last_apply_commit`, `plan_path`, `estimated_loc`, and any prior
+`evidence.*` metadata.
+
+**2. Compose summary_for_human.**
+
+A one-to-three-line natural-language outcome. Examples:
+- `Iterated PR #42 on copilot feedback (1 comment). New commit abc1234 on branch fix/foo. Build green. Reply posted on copilot thread. Ready for maintainer review + push.`
+- `Iterated PR #42 on codecov coverage (3 uncovered lines in file.go). New commit abc1234. Verification deferred until next codecov run.`
+
+**3. Set evidence and summary:**
+```bash
+bd update "$ROOT_ID" \\
+  --set-metadata "evidence.pr_number={{pr}}" \\
+  --set-metadata "evidence.feedback_source={{feedback_source}}" \\
+  --set-metadata "evidence.iteration=$iteration" \\
+  --set-metadata "evidence.last_apply_commit=$last_apply_commit" \\
+  --set-metadata "evidence.plan_path=$plan_path" \\
+  --set-metadata "summary_for_human=<two-line synthesis>"
+```
+
+**4. Display report:**
+```
+[iterate] Complete
+[iterate]   PR #{{pr}} on $repo
+[iterate]   Feedback: {{feedback_source}} (iteration $iteration)
+[iterate]   New commit: $last_apply_commit
+[iterate]   Plan: $plan_path
+[iterate]   Verification: <evidence.verification | evidence.cleared>
+[iterate]   Ready for maintainer review + push.
+```
+
+**5. Reclaim the staged worktree.**
+
+The durable deliverable is the commit on the PR branch ref — it survives
+worktree removal. The ephemeral per-PR worktree is no longer needed, so remove
+it on the success path to keep per-PR worktrees from accumulating. `cd` to the
+main worktree first (git refuses to remove the worktree you are standing in):
+```bash
+WORK_DIR=$(bd show "$ROOT_ID" --json | jq -r '.[0].metadata.work_dir // empty')
+if [ -n "$WORK_DIR" ] && [ -d "$WORK_DIR" ]; then
+  MAIN_WT=$(git -C "$WORK_DIR" worktree list --porcelain | awk '/^worktree /{print $2; exit}')
+  cd "$MAIN_WT" 2>/dev/null || cd /
+  git worktree remove --force "$WORK_DIR" 2>/dev/null || true
+fi
+```
+
+The `iterate-pr-<N>` path is deterministic, so this is idempotent: an
+earlier-step halt leaves that single worktree in place (the plan artifact under
+it is transient — the actionable signal is the commit + `summary_for_human`),
+and a later re-sling of the same PR reuses it (guarded clean + on-branch in
+intake) before this step reclaims it on a clean run.
+
+**Exit criteria:** evidence.* and summary_for_human set on root bead; staged
+worktree reclaimed on the success path; chain is complete; polecat exits
+without pushing or opening a PR."""

--- a/pr-review/formulas/mol-pr-iterate.formula.toml
+++ b/pr-review/formulas/mol-pr-iterate.formula.toml
@@ -11,8 +11,8 @@ mol-pr-from-issue (issue → PR). It does NOT push or open PRs — the polecat
 commits to the local PR branch and the maintainer pushes after review.
 
 The molecule root bead IS the control bead — all run state is stored in its
-notes via `bd update <root-id> --notes "key: value"` and structured
-evidence in metadata via `bd update <root-id> --set-metadata "key=value"`.
+notes via `gc bd update <root-id> --notes "key: value"` and structured
+evidence in metadata via `gc bd update <root-id> --set-metadata "key=value"`.
 
 ## Contract
 
@@ -46,12 +46,12 @@ The polecat halts the chain AND mails mayor when:
 
 Halt-and-mail-mayor procedure (used by any step that hits one of the above):
 ```bash
-bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
-                     --set-metadata "gc.escalate_to=mayor" \\
-                     --set-metadata "summary_for_human=<one-line synthesis>"
+gc bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
+                        --set-metadata "gc.escalate_to=mayor" \\
+                        --set-metadata "summary_for_human=<one-line synthesis>"
 gc mail send mayor -s "mol-pr-iterate halt: pr-{{pr}} (<reason>)" \\
                     -m "<context with root bead id and failure detail>"
-bd close "$ROOT_ID" --reason "<reason>"
+gc bd close "$ROOT_ID" --reason "<reason>"
 ```
 
 ## Failure Modes
@@ -102,7 +102,7 @@ and record initial state on the root bead.
 
 **1. Find the root bead:**
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
 ```
 
 **2. Validate feedback_source enum:**
@@ -110,9 +110,9 @@ ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
 case "{{feedback_source}}" in
   codecov|copilot|review-comment|text) ;;
   *)
-    bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
-                         --set-metadata "summary_for_human=Invalid feedback_source: '{{feedback_source}}'. Must be one of codecov, copilot, review-comment, text."
-    bd close "$ROOT_ID" --reason "invalid feedback_source"
+    gc bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
+                            --set-metadata "summary_for_human=Invalid feedback_source: '{{feedback_source}}'. Must be one of codecov, copilot, review-comment, text."
+    gc bd close "$ROOT_ID" --reason "invalid feedback_source"
     exit 1
     ;;
 esac
@@ -123,9 +123,9 @@ esac
 case "{{feedback_source}}" in
   review-comment|text)
     if [ -z "{{feedback_ref}}" ]; then
-      bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
-                           --set-metadata "summary_for_human=feedback_source={{feedback_source}} requires --var feedback_ref=<value>."
-      bd close "$ROOT_ID" --reason "feedback_ref required"
+      gc bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
+                              --set-metadata "summary_for_human=feedback_source={{feedback_source}} requires --var feedback_ref=<value>."
+      gc bd close "$ROOT_ID" --reason "feedback_ref required"
       exit 1
     fi
     ;;
@@ -140,9 +140,9 @@ gh pr view {{pr}} --json title,author,baseRefName,headRefName,number,state,url,h
 
 If the PR is `CLOSED` or `MERGED` → halt:
 ```bash
-bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
-                     --set-metadata "summary_for_human=PR #{{pr}} on $REPO is <state>; nothing to iterate on."
-bd close "$ROOT_ID" --reason "PR not open"
+gc bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
+                        --set-metadata "summary_for_human=PR #{{pr}} on $REPO is <state>; nothing to iterate on."
+gc bd close "$ROOT_ID" --reason "PR not open"
 exit 1
 ```
 
@@ -166,9 +166,9 @@ if [ -d "$PR_WORKTREE" ]; then
   WT_BRANCH=$(git branch --show-current)
   if [ "$WT_BRANCH" != "$EXPECTED_BRANCH" ] || [ -n "$(git status --porcelain)" ]; then
     echo "[iterate] FATAL: staged worktree $PR_WORKTREE is on branch '$WT_BRANCH' (expected '$EXPECTED_BRANCH') or has uncommitted changes." >&2
-    bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
-                         --set-metadata "summary_for_human=iterate intake found a dirty or wrong-branch staged worktree at $PR_WORKTREE (branch '$WT_BRANCH', expected '$EXPECTED_BRANCH'). Inspect it, then 'git worktree remove --force $PR_WORKTREE' before re-slinging."
-    bd close "$ROOT_ID" --reason "dirty/wrong-branch staged worktree in intake"
+    gc bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
+                            --set-metadata "summary_for_human=iterate intake found a dirty or wrong-branch staged worktree at $PR_WORKTREE (branch '$WT_BRANCH', expected '$EXPECTED_BRANCH'). Inspect it, then 'git worktree remove --force $PR_WORKTREE' before re-slinging."
+    gc bd close "$ROOT_ID" --reason "dirty/wrong-branch staged worktree in intake"
     exit 1
   fi
 else
@@ -184,12 +184,12 @@ Record the staging directory on the root bead. Every later step runs in a
 fresh shell that otherwise lands back in the slot worktree, so they re-enter
 `work_dir` from this metadata:
 ```bash
-bd update "$ROOT_ID" --set-metadata "work_dir=$PR_WORKTREE"
+gc bd update "$ROOT_ID" --set-metadata "work_dir=$PR_WORKTREE"
 ```
 
 **6. Record state in root bead notes:**
 ```bash
-bd update $ROOT_ID --notes "pr_number: {{pr}}
+gc bd update $ROOT_ID --notes "pr_number: {{pr}}
 repo: $REPO
 pr_title: <title>
 pr_author: <author.login>
@@ -230,13 +230,13 @@ A fresh polecat shell starts in the slot worktree, not the per-PR worktree the
 `intake` step staged. Re-enter it from `work_dir` before any git or file work
 (the codecov path diffs the PR branch):
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
-WORK_DIR=$(bd show "$ROOT_ID" --json | jq -r '.[0].metadata.work_dir // empty')
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
+WORK_DIR=$(gc bd show "$ROOT_ID" --json | jq -r '.[0].metadata.work_dir // empty')
 if [ -z "$WORK_DIR" ] || [ ! -d "$WORK_DIR" ]; then
   echo "[iterate] FATAL: work_dir metadata missing or not a directory ('$WORK_DIR'). Intake staging did not complete; cannot continue." >&2
-  bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
-                       --set-metadata "summary_for_human=iterate parse-feedback could not re-enter the staged worktree (work_dir='$WORK_DIR', missing or not a dir). Re-sling from intake."
-  bd close "$ROOT_ID" --reason "work_dir missing in parse-feedback"
+  gc bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
+                          --set-metadata "summary_for_human=iterate parse-feedback could not re-enter the staged worktree (work_dir='$WORK_DIR', missing or not a dir). Re-sling from intake."
+  gc bd close "$ROOT_ID" --reason "work_dir missing in parse-feedback"
   exit 1
 fi
 cd "$WORK_DIR"
@@ -302,7 +302,7 @@ If the text is empty or just whitespace → halt-and-mail-mayor.
 
 Serialize the parsed signal as a compact JSON string in notes, e.g.:
 ```bash
-bd update $ROOT_ID --notes "<existing notes>
+gc bd update $ROOT_ID --notes "<existing notes>
 parsed_feedback: <json>"
 ```
 
@@ -313,12 +313,12 @@ For text: `{\"type\": \"text\", \"body\": \"...\"}`
 
 **Halt-and-mail-mayor on ambiguity:**
 ```bash
-bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
-                     --set-metadata "gc.escalate_to=mayor" \\
-                     --set-metadata "summary_for_human=Cannot extract actionable feedback from {{feedback_source}} for PR #{{pr}}: <reason>."
+gc bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
+                        --set-metadata "gc.escalate_to=mayor" \\
+                        --set-metadata "summary_for_human=Cannot extract actionable feedback from {{feedback_source}} for PR #{{pr}}: <reason>."
 gc mail send mayor -s "mol-pr-iterate halt: pr-{{pr}} (feedback ambiguity)" \\
                     -m "Root bead $ROOT_ID. Feedback source {{feedback_source}} yielded no actionable signal. Detail: <reason>."
-bd close "$ROOT_ID" --reason "feedback ambiguity"
+gc bd close "$ROOT_ID" --reason "feedback ambiguity"
 ```
 
 **Exit criteria:** `parsed_feedback` recorded on root bead notes, OR halt-and-mail-mayor fired."""
@@ -338,13 +338,13 @@ A fresh polecat shell starts in the slot worktree, not the per-PR worktree the
 `intake` step staged. Re-enter it from `work_dir` so the plan artifact is
 written under the staged worktree (where `apply` will read it):
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
-WORK_DIR=$(bd show "$ROOT_ID" --json | jq -r '.[0].metadata.work_dir // empty')
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
+WORK_DIR=$(gc bd show "$ROOT_ID" --json | jq -r '.[0].metadata.work_dir // empty')
 if [ -z "$WORK_DIR" ] || [ ! -d "$WORK_DIR" ]; then
   echo "[iterate] FATAL: work_dir metadata missing or not a directory ('$WORK_DIR'). Intake staging did not complete; cannot continue." >&2
-  bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
-                       --set-metadata "summary_for_human=iterate propose-patch could not re-enter the staged worktree (work_dir='$WORK_DIR', missing or not a dir). Re-sling from intake."
-  bd close "$ROOT_ID" --reason "work_dir missing in propose-patch"
+  gc bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
+                          --set-metadata "summary_for_human=iterate propose-patch could not re-enter the staged worktree (work_dir='$WORK_DIR', missing or not a dir). Re-sling from intake."
+  gc bd close "$ROOT_ID" --reason "work_dir missing in propose-patch"
   exit 1
 fi
 cd "$WORK_DIR"
@@ -373,20 +373,20 @@ PLAN_PATH=".gc/pr-pipeline/iterate/pr-{{pr}}.md"
 Compute the estimated LOC from the plan (sum of additions + deletions in
 the Diff sketch). If `EST_LOC > 200`:
 ```bash
-bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
-                     --set-metadata "gc.escalate_to=mayor" \\
-                     --set-metadata "summary_for_human=Iteration plan for PR #{{pr}} exceeds 200 LOC ($EST_LOC). Plan at $PLAN_PATH. Recommend splitting the feedback into separate beads or accepting partial clearance."
+gc bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
+                        --set-metadata "gc.escalate_to=mayor" \\
+                        --set-metadata "summary_for_human=Iteration plan for PR #{{pr}} exceeds 200 LOC ($EST_LOC). Plan at $PLAN_PATH. Recommend splitting the feedback into separate beads or accepting partial clearance."
 gc mail send mayor -s "mol-pr-iterate halt: pr-{{pr}} (scope > 200 LOC)" \\
                     -m "Root bead $ROOT_ID. Plan at $PLAN_PATH estimates $EST_LOC LOC, exceeds 200 LOC cap."
-bd close "$ROOT_ID" --reason "scope > 200 LOC"
+gc bd close "$ROOT_ID" --reason "scope > 200 LOC"
 exit 0
 ```
 
 **4. Record evidence on root bead:**
 ```bash
-bd update "$ROOT_ID" --set-metadata "evidence.plan_path=$PLAN_PATH" \\
-                     --set-metadata "evidence.estimated_loc=$EST_LOC"
-bd update $ROOT_ID --notes "<existing notes>
+gc bd update "$ROOT_ID" --set-metadata "evidence.plan_path=$PLAN_PATH" \\
+                        --set-metadata "evidence.estimated_loc=$EST_LOC"
+gc bd update $ROOT_ID --notes "<existing notes>
 plan_path: $PLAN_PATH
 estimated_loc: $EST_LOC"
 ```
@@ -409,13 +409,13 @@ A fresh polecat shell starts in the slot worktree, not the per-PR worktree the
 committing — the on-branch and clean-worktree checks below assume the staged
 worktree:
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
-WORK_DIR=$(bd show "$ROOT_ID" --json | jq -r '.[0].metadata.work_dir // empty')
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
+WORK_DIR=$(gc bd show "$ROOT_ID" --json | jq -r '.[0].metadata.work_dir // empty')
 if [ -z "$WORK_DIR" ] || [ ! -d "$WORK_DIR" ]; then
   echo "[iterate] FATAL: work_dir metadata missing or not a directory ('$WORK_DIR'). Intake staging did not complete; cannot continue." >&2
-  bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
-                       --set-metadata "summary_for_human=iterate apply could not re-enter the staged worktree (work_dir='$WORK_DIR', missing or not a dir). Re-sling from intake."
-  bd close "$ROOT_ID" --reason "work_dir missing in apply"
+  gc bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
+                          --set-metadata "summary_for_human=iterate apply could not re-enter the staged worktree (work_dir='$WORK_DIR', missing or not a dir). Re-sling from intake."
+  gc bd close "$ROOT_ID" --reason "work_dir missing in apply"
   exit 1
 fi
 cd "$WORK_DIR"
@@ -427,9 +427,9 @@ Extract `plan_path`, `pr_number`, `head_ref`, `iteration`.
 CURRENT=$(git branch --show-current)
 EXPECTED=<head_ref>
 if [ "$CURRENT" != "$EXPECTED" ]; then
-  bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
-                       --set-metadata "summary_for_human=apply step expected branch $EXPECTED, found $CURRENT. Did intake checkout fail?"
-  bd close "$ROOT_ID" --reason "branch mismatch in apply"
+  gc bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
+                          --set-metadata "summary_for_human=apply step expected branch $EXPECTED, found $CURRENT. Did intake checkout fail?"
+  gc bd close "$ROOT_ID" --reason "branch mismatch in apply"
   exit 1
 fi
 ```
@@ -437,9 +437,9 @@ fi
 **3. Verify worktree is clean (no in-flight changes from a prior partial apply):**
 ```bash
 if [ -n "$(git status --porcelain)" ]; then
-  bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
-                       --set-metadata "summary_for_human=apply step found dirty worktree on $CURRENT. Manual cleanup needed before re-sling."
-  bd close "$ROOT_ID" --reason "dirty worktree in apply"
+  gc bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
+                          --set-metadata "summary_for_human=apply step found dirty worktree on $CURRENT. Manual cleanup needed before re-sling."
+  gc bd close "$ROOT_ID" --reason "dirty worktree in apply"
   exit 1
 fi
 ```
@@ -462,11 +462,11 @@ consuming pack for hints, or run the repo's standard quality gates:
 If build fails:
 ```bash
 git checkout -- .  # revert the unsuccessful changes
-bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
-                     --set-metadata "summary_for_human=Build failed after apply for PR #{{pr}}. Plan at $plan_path may need revision. Worktree reverted."
+gc bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
+                        --set-metadata "summary_for_human=Build failed after apply for PR #{{pr}}. Plan at $plan_path may need revision. Worktree reverted."
 gc mail send mayor -s "mol-pr-iterate halt: pr-{{pr}} (build failed)" \\
                     -m "Root bead $ROOT_ID. apply succeeded in editing files but build verification failed. Worktree reverted."
-bd close "$ROOT_ID" --reason "build failed after apply"
+gc bd close "$ROOT_ID" --reason "build failed after apply"
 exit 1
 ```
 
@@ -486,7 +486,7 @@ Refs: $ROOT_ID"
 ```bash
 NEW_ITER=$(($iteration + 1))
 COMMIT_SHA=$(git rev-parse HEAD)
-bd update $ROOT_ID --notes "<existing notes with iteration: $NEW_ITER, last_apply_commit: $COMMIT_SHA>"
+gc bd update $ROOT_ID --notes "<existing notes with iteration: $NEW_ITER, last_apply_commit: $COMMIT_SHA>"
 ```
 
 **Exit criteria:** New commit on PR branch, build green, iteration counter incremented, last_apply_commit recorded."""
@@ -506,13 +506,13 @@ A fresh polecat shell starts in the slot worktree, not the per-PR worktree the
 `intake` step staged. Re-enter it from `work_dir` before re-running the
 source-specific verification (codecov diffs the PR branch):
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
-WORK_DIR=$(bd show "$ROOT_ID" --json | jq -r '.[0].metadata.work_dir // empty')
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
+WORK_DIR=$(gc bd show "$ROOT_ID" --json | jq -r '.[0].metadata.work_dir // empty')
 if [ -z "$WORK_DIR" ] || [ ! -d "$WORK_DIR" ]; then
   echo "[iterate] FATAL: work_dir metadata missing or not a directory ('$WORK_DIR'). Intake staging did not complete; cannot continue." >&2
-  bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
-                       --set-metadata "summary_for_human=iterate verify-clearance could not re-enter the staged worktree (work_dir='$WORK_DIR', missing or not a dir). Re-sling from intake."
-  bd close "$ROOT_ID" --reason "work_dir missing in verify-clearance"
+  gc bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
+                          --set-metadata "summary_for_human=iterate verify-clearance could not re-enter the staged worktree (work_dir='$WORK_DIR', missing or not a dir). Re-sling from intake."
+  gc bd close "$ROOT_ID" --reason "work_dir missing in verify-clearance"
   exit 1
 fi
 cd "$WORK_DIR"
@@ -528,8 +528,8 @@ Codecov coverage is computed by CI. The polecat cannot directly re-trigger
 codecov — instead, the apply commit is local and unpushed, so codecov has
 nothing new to score. Mark verification as **deferred-to-push**:
 ```bash
-bd update "$ROOT_ID" --set-metadata "evidence.verification=deferred-to-push" \\
-                     --set-metadata "evidence.verification_note=Codecov verification runs after maintainer pushes commit $last_apply_commit. Re-sling mol-pr-iterate after the next codecov run if uncovered lines persist."
+gc bd update "$ROOT_ID" --set-metadata "evidence.verification=deferred-to-push" \\
+                        --set-metadata "evidence.verification_note=Codecov verification runs after maintainer pushes commit $last_apply_commit. Re-sling mol-pr-iterate after the next codecov run if uncovered lines persist."
 ```
 Proceed to `report` (do NOT count this as a failed iteration).
 
@@ -571,20 +571,20 @@ it resolved.
 Free-text feedback has no automated verification. Mark as
 **manual-verification**:
 ```bash
-bd update "$ROOT_ID" --set-metadata "evidence.verification=manual" \\
-                     --set-metadata "evidence.verification_note=Text feedback addressed in $last_apply_commit. Manual verification by maintainer."
+gc bd update "$ROOT_ID" --set-metadata "evidence.verification=manual" \\
+                        --set-metadata "evidence.verification_note=Text feedback addressed in $last_apply_commit. Manual verification by maintainer."
 ```
 
 **3. Halt-after-2 check.**
 
 If the signal persists AND `iteration >= 2`:
 ```bash
-bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
-                     --set-metadata "gc.escalate_to=mayor" \\
-                     --set-metadata "summary_for_human=PR #{{pr}} feedback signal persists after 2 iterations. Last apply commit $last_apply_commit. Manual review needed."
+gc bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
+                        --set-metadata "gc.escalate_to=mayor" \\
+                        --set-metadata "summary_for_human=PR #{{pr}} feedback signal persists after 2 iterations. Last apply commit $last_apply_commit. Manual review needed."
 gc mail send mayor -s "mol-pr-iterate halt: pr-{{pr}} (verify-clearance failed x2)" \\
                     -m "Root bead $ROOT_ID. Feedback source {{feedback_source}}, $iteration iterations attempted, signal still present."
-bd close "$ROOT_ID" --reason "verify-clearance failed after 2 iterations"
+gc bd close "$ROOT_ID" --reason "verify-clearance failed after 2 iterations"
 exit 1
 ```
 
@@ -595,7 +595,7 @@ If the signal persists AND `iteration < 2`:
 
 **4. Record clearance evidence:**
 ```bash
-bd update "$ROOT_ID" --set-metadata "evidence.cleared=<true|false>"
+gc bd update "$ROOT_ID" --set-metadata "evidence.cleared=<true|false>"
 ```
 
 **Exit criteria:** Verification result recorded on root bead metadata,
@@ -612,7 +612,7 @@ root bead so downstream loop-close handlers can surface the outcome.
 
 **1. Read root bead notes:**
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
 ```
 Extract all state: `pr_number`, `repo`, `feedback_source`, `iteration`,
 `last_apply_commit`, `plan_path`, `estimated_loc`, and any prior
@@ -626,7 +626,7 @@ A one-to-three-line natural-language outcome. Examples:
 
 **3. Set evidence and summary:**
 ```bash
-bd update "$ROOT_ID" \\
+gc bd update "$ROOT_ID" \\
   --set-metadata "evidence.pr_number={{pr}}" \\
   --set-metadata "evidence.feedback_source={{feedback_source}}" \\
   --set-metadata "evidence.iteration=$iteration" \\
@@ -653,7 +653,7 @@ worktree removal. The ephemeral per-PR worktree is no longer needed, so remove
 it on the success path to keep per-PR worktrees from accumulating. `cd` to the
 main worktree first (git refuses to remove the worktree you are standing in):
 ```bash
-WORK_DIR=$(bd show "$ROOT_ID" --json | jq -r '.[0].metadata.work_dir // empty')
+WORK_DIR=$(gc bd show "$ROOT_ID" --json | jq -r '.[0].metadata.work_dir // empty')
 if [ -n "$WORK_DIR" ] && [ -d "$WORK_DIR" ]; then
   MAIN_WT=$(git -C "$WORK_DIR" worktree list --porcelain | awk '/^worktree /{print $2; exit}')
   cd "$MAIN_WT" 2>/dev/null || cd /

--- a/pr-review/formulas/mol-pr-merge-only.formula.toml
+++ b/pr-review/formulas/mol-pr-merge-only.formula.toml
@@ -1,0 +1,310 @@
+description = """
+Merge-Only PR workflow — 3 steps from intake through merge.
+
+Sling a contributor PR to a polecat for rebase + squash merge, SKIPPING the
+review and human-gate steps. Use only when the maintainer has already
+eyeballed the PR and wants a fast merge path. Crash-safe: `bd mol current`
+resumes at the right step.
+
+The molecule root bead IS the control bead — all run state is stored in its
+notes via `bd update <root-id> --notes "key: value"`. No separate tracking
+bead needed.
+
+## Contract
+
+1. Caller slings with `--var pr=<url-or-number>` (and optionally `--var skip_gemini=true` for compat)
+2. Polecat reads steps, executes each in order
+3. After rebase-check, polecat proceeds directly to finalize (NO review, NO human-gate)
+4. Polecat finalizes via Path A: squash merge
+
+## Variables
+
+| Variable | Source | Description |
+|----------|--------|-------------|
+| pr | caller | PR URL or bare integer (required) |
+| skip_gemini | caller | Kept for compat with mol-adopt-pr callers; ignored here (no review step) |
+
+## Failure Modes
+
+| Situation | Action |
+|-----------|--------|
+| gh command fails | Check `gh auth status`, report error, stop |
+| Rebase has complex conflicts | Abort rebase, post comment, close root bead, stop |
+| Push fails | Report error, stop. User resolves manually |
+| CI fails | Report failure, stop, wait for nudge |
+
+## Difference from mol-adopt-pr
+
+mol-pr-merge-only omits the `review` and `human-gate` steps. Paths B/C/D
+from mol-adopt-pr.finalize are also omitted: with no review, there are no
+maintainer fixup commits, so MAINTAINER_COMMIT_COUNT is always 0 → Path A.
+
+Use mol-adopt-pr when you want the full review + human-gate flow.
+Use mol-pr-merge-only when the maintainer has already eyeballed the PR and
+wants a fast skip-review merge path."""
+formula = "mol-pr-merge-only"
+version = 1
+
+[vars]
+[vars.pr]
+description = "PR URL (https://github.com/org/repo/pull/N) or bare integer"
+required = true
+
+[vars.skip_gemini]
+description = "Kept for compatibility with mol-adopt-pr callers; has no effect (no review step)"
+default = "false"
+
+[[steps]]
+id = "intake"
+title = "Parse PR and checkout"
+description = """
+Parse the PR, fetch metadata, validate scope, checkout the branch, and record
+initial state in the root bead notes.
+
+**1. Find the root bead:**
+```bash
+ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+```
+
+**2. Parse PR identifier from `{{pr}}`:**
+- If `{{pr}}` matches `https://github.com/.*/pull/\\d+` → extract owner, repo, PR number from URL
+- If `{{pr}}` is a bare integer → use current repo (`gh repo view --json nameWithOwner -q .nameWithOwner`)
+
+**3. Fetch PR metadata:**
+```bash
+gh pr view <number> --json title,body,author,baseRefName,headRefName,number,additions,deletions,changedFiles,maintainerCanModify,url,mergeable
+```
+
+**4. Validate PR scope:**
+
+Fetch changed files:
+```bash
+gh pr view <number> --json files --jq '.files[].path'
+```
+
+Compare against the PR title/description. If the changes are clearly outside
+the described scope (e.g., a "fix typo" PR that touches dozens of packages),
+the branch has diverged from main. **STOP immediately:**
+- Post a scope mismatch comment asking the contributor to rebase
+- Request changes: `gh pr review <number> --request-changes --body "Branch has diverged from main"`
+- Close the root bead: `bd close $ROOT_ID --reason "scope mismatch"`
+- Exit
+
+**5. Check maintainer edits:**
+Record in root bead notes: `maintainer_edits: true` or `maintainer_edits: false`.
+If false, warn but continue — finalize will still use Path A since no review
+was performed (no maintainer fixup commits are expected in this flow).
+
+**6. Checkout the PR branch:**
+```bash
+gh pr checkout <number>
+```
+
+**7. Record state in root bead notes:**
+```bash
+bd update $ROOT_ID --notes "pr_number: <N>
+pr_url: <url>
+repo: <owner/repo>
+pr_title: <title>
+pr_author: <author.login>
+head_ref: <headRefName>
+base_branch: <baseRefName>
+maintainer_edits: <true|false>
+original_head: pending
+rebase_status: pending
+merge_path: A"
+```
+
+**8. Display summary:**
+```
+[merge-only] Intake complete
+[merge-only]   PR #<N>: "<title>"
+[merge-only]   Author: <author.login>
+[merge-only]   Base: <baseRefName> <- Head: <headRefName>
+[merge-only]   Stats: +<additions> -<deletions> across <changedFiles> files
+[merge-only]   Maintainer edits: <enabled|DISABLED>
+```
+
+**Exit criteria:** On PR branch, metadata recorded in root bead notes."""
+
+[[steps]]
+id = "rebase-check"
+title = "Check and resolve conflicts"
+needs = ["intake"]
+description = """
+Check mergeable status and handle conflicts. Auto-rebase straightforward
+cases; abort on complex conflicts that need the contributor.
+
+**1. Read root bead notes for PR metadata:**
+```bash
+ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+```
+
+**2. Check merge status:**
+```bash
+MERGEABLE=$(gh pr view <number> --json mergeable --jq '.mergeable')
+```
+
+- If `MERGEABLE` or `UNKNOWN` → record `rebase_status: not_needed`, record
+  `original_head: $(git rev-parse HEAD)`, close this step, proceed.
+- If `CONFLICTING` → continue.
+
+**3. Gate on maintainerCanModify:**
+If `maintainer_edits` is false → **STOP**:
+- Post conflict comment asking author to rebase
+- Add label: `gh pr edit <number> --add-label "status/needs-info"`
+- Close root bead: `bd close $ROOT_ID --reason "conflicts, maintainerCanModify=false"`
+- Exit
+
+**4. Fetch upstream base:**
+```bash
+UPSTREAM_URL="https://github.com/<owner>/<repo>.git"
+git fetch "$UPSTREAM_URL" <baseRefName>:refs/adopt-pr/upstream-base
+PRE_REBASE_HEAD=$(git rev-parse HEAD)
+PR_FILES=$(git diff --name-only refs/adopt-pr/upstream-base...HEAD)
+```
+
+**5. Attempt rebase:**
+```bash
+git rebase refs/adopt-pr/upstream-base
+```
+
+If clean → record state, proceed.
+
+**6. Handle conflicts (if rebase paused):**
+
+For each conflicting file, classify:
+- **Non-PR file** (not in PR_FILES) → `git checkout --theirs <file> && git add <file>`. Safe.
+- **Redundant commit** (PR file, but upstream already has identical content) → `git rebase --skip`. Safe.
+- **Add/add conflict** (PR file, empty base section in diff3 markers) → resolve with union merge:
+  ```bash
+  git show :1:"$file" > /tmp/base; git show :2:"$file" > /tmp/ours; git show :3:"$file" > /tmp/theirs
+  cp /tmp/ours /tmp/union
+  git merge-file --union /tmp/union /tmp/base /tmp/theirs
+  ```
+  Validate: no conflict markers survive, all PR additions present. If valid → `cp /tmp/union "$file" && git add "$file"`.
+- **Modify/modify conflict** (non-empty base section) → **complex**, abort.
+
+If complex conflicts found:
+```bash
+git rebase --abort
+gh pr comment <number> --body "<conflict comment asking author to rebase>"
+gh pr edit <number> --add-label "status/needs-info"
+bd close $ROOT_ID --reason "complex merge conflicts"
+```
+Exit.
+
+**7. Record state in root bead notes:**
+```bash
+ORIGINAL_HEAD=$(git rev-parse HEAD)
+```
+Update notes with:
+- `original_head: $ORIGINAL_HEAD`
+- `rebase_status: not_needed | clean | straightforward_resolved | redundant_skipped | trivial_resolved`
+- `pre_rebase_head: <sha>` (if rebased, else `n/a`)
+
+**Exit criteria:** On a clean branch (possibly rebased), ORIGINAL_HEAD recorded."""
+
+[[steps]]
+id = "finalize"
+title = "Push and squash-merge (skip-review)"
+needs = ["rebase-check"]
+description = """
+Skip-review finalize: post a minimal merge-only ack, wait for CI, push if
+rebased, squash-merge. This is Path A from mol-adopt-pr.finalize with the
+synthesis-comment machinery pruned (no review_run_dir to read from).
+
+**1. Read root bead notes:**
+```bash
+ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+```
+Extract state: `pr_number`, `repo`, `base_branch`, `original_head`,
+`head_ref`, `rebase_status`, `pr_title`, `pr_author`.
+
+**2. Check if PR was already merged:**
+```bash
+PR_STATE=$(gh pr view <number> --json state --jq '.state')
+```
+
+If `MERGED` → done, close root bead with "PR already merged", exit.
+
+**3. Determine merge path:**
+
+This formula always uses Path A. With no review step there are no
+maintainer fixup commits, so `MAINTAINER_COMMIT_COUNT` is expected to be 0.
+As a guard:
+```bash
+MAINTAINER_COMMIT_COUNT=$(git rev-list --count $ORIGINAL_HEAD..HEAD)
+```
+- `MAINTAINER_COMMIT_COUNT == 0` → continue with Path A.
+- `MAINTAINER_COMMIT_COUNT > 0` → **STOP**. mol-pr-merge-only does not
+  handle maintainer fixup commits. Record the unexpected state and exit:
+  ```bash
+  bd update $ROOT_ID --notes "<existing notes>
+  unexpected_state: maintainer commits present in merge-only flow ($MAINTAINER_COMMIT_COUNT)"
+  bd close $ROOT_ID --reason "merge-only flow saw maintainer commits; re-sling under mol-adopt-pr"
+  ```
+
+Update notes: `merge_path: A`.
+
+---
+
+### Path A: Squash Merge (skip-review)
+
+**A.1: Post merge-only ack comment.**
+
+Build a minimal comment (no synthesis — review was skipped):
+
+```markdown
+## Adoption (skip-review merge)
+
+Thanks for the contribution, @<author>! Merging via the maintainer's
+fast-path workflow — the maintainer has reviewed the changes manually
+and elected to skip the automated multi-model review.
+
+---
+_Adopted via `mol-pr-merge-only` workflow. Contributor commits preserved._
+```
+
+Post: `gh pr comment <number> --body "<comment>"`
+
+**A.2: Wait for CI.**
+
+First verify CI checks exist:
+```bash
+gh pr checks <number>
+```
+If no checks reported → **STOP**, print message telling maintainer to approve
+GitHub Actions workflow run. Wait for nudge.
+
+Once checks exist:
+```bash
+gh pr checks <number> --watch
+```
+If CI fails → **STOP**, report failure, wait for nudge.
+
+**A.3: Push rebased branch (if applicable).**
+If rebase was performed (`rebase_status` is not `not_needed`):
+```bash
+git push --force-with-lease
+```
+
+**A.4: Squash merge:**
+```bash
+gh pr merge <number> --squash
+```
+
+**A.5: Cleanup:**
+```bash
+git update-ref -d refs/adopt-pr/upstream-base 2>/dev/null || true
+bd update $ROOT_ID --notes "<notes with merge_path: A, status: merged>"
+```
+
+---
+
+**Critical rules:**
+- **No force-push** except after a rebase (always `--force-with-lease`)
+- **Contributor credit preserved** — squash commit keeps original author
+- **CI checks must exist** — never merge without CI. First-time forks need manual approval.
+
+**Exit criteria:** PR squash-merged, root bead updated with `status: merged`."""

--- a/pr-review/formulas/mol-pr-merge-only.formula.toml
+++ b/pr-review/formulas/mol-pr-merge-only.formula.toml
@@ -3,11 +3,11 @@ Merge-Only PR workflow — 3 steps from intake through merge.
 
 Sling a contributor PR to a polecat for rebase + squash merge, SKIPPING the
 review and human-gate steps. Use only when the maintainer has already
-eyeballed the PR and wants a fast merge path. Crash-safe: `bd mol current`
+eyeballed the PR and wants a fast merge path. Crash-safe: `gc bd mol current`
 resumes at the right step.
 
 The molecule root bead IS the control bead — all run state is stored in its
-notes via `bd update <root-id> --notes "key: value"`. No separate tracking
+notes via `gc bd update <root-id> --notes "key: value"`. No separate tracking
 bead needed.
 
 ## Contract
@@ -63,7 +63,7 @@ initial state in the root bead notes.
 
 **1. Find the root bead:**
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
 ```
 
 **2. Parse PR identifier from `{{pr}}`:**
@@ -87,7 +87,7 @@ the described scope (e.g., a "fix typo" PR that touches dozens of packages),
 the branch has diverged from main. **STOP immediately:**
 - Post a scope mismatch comment asking the contributor to rebase
 - Request changes: `gh pr review <number> --request-changes --body "Branch has diverged from main"`
-- Close the root bead: `bd close $ROOT_ID --reason "scope mismatch"`
+- Close the root bead: `gc bd close $ROOT_ID --reason "scope mismatch"`
 - Exit
 
 **5. Check maintainer edits:**
@@ -102,7 +102,7 @@ gh pr checkout <number>
 
 **7. Record state in root bead notes:**
 ```bash
-bd update $ROOT_ID --notes "pr_number: <N>
+gc bd update $ROOT_ID --notes "pr_number: <N>
 pr_url: <url>
 repo: <owner/repo>
 pr_title: <title>
@@ -137,7 +137,7 @@ cases; abort on complex conflicts that need the contributor.
 
 **1. Read root bead notes for PR metadata:**
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
 ```
 
 **2. Check merge status:**
@@ -153,7 +153,7 @@ MERGEABLE=$(gh pr view <number> --json mergeable --jq '.mergeable')
 If `maintainer_edits` is false → **STOP**:
 - Post conflict comment asking author to rebase
 - Add label: `gh pr edit <number> --add-label "status/needs-info"`
-- Close root bead: `bd close $ROOT_ID --reason "conflicts, maintainerCanModify=false"`
+- Close root bead: `gc bd close $ROOT_ID --reason "conflicts, maintainerCanModify=false"`
 - Exit
 
 **4. Fetch upstream base:**
@@ -190,7 +190,7 @@ If complex conflicts found:
 git rebase --abort
 gh pr comment <number> --body "<conflict comment asking author to rebase>"
 gh pr edit <number> --add-label "status/needs-info"
-bd close $ROOT_ID --reason "complex merge conflicts"
+gc bd close $ROOT_ID --reason "complex merge conflicts"
 ```
 Exit.
 
@@ -216,7 +216,7 @@ synthesis-comment machinery pruned (no review_run_dir to read from).
 
 **1. Read root bead notes:**
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
 ```
 Extract state: `pr_number`, `repo`, `base_branch`, `original_head`,
 `head_ref`, `rebase_status`, `pr_title`, `pr_author`.
@@ -240,9 +240,9 @@ MAINTAINER_COMMIT_COUNT=$(git rev-list --count $ORIGINAL_HEAD..HEAD)
 - `MAINTAINER_COMMIT_COUNT > 0` → **STOP**. mol-pr-merge-only does not
   handle maintainer fixup commits. Record the unexpected state and exit:
   ```bash
-  bd update $ROOT_ID --notes "<existing notes>
+  gc bd update $ROOT_ID --notes "<existing notes>
   unexpected_state: maintainer commits present in merge-only flow ($MAINTAINER_COMMIT_COUNT)"
-  bd close $ROOT_ID --reason "merge-only flow saw maintainer commits; re-sling under mol-adopt-pr"
+  gc bd close $ROOT_ID --reason "merge-only flow saw maintainer commits; re-sling under mol-adopt-pr"
   ```
 
 Update notes: `merge_path: A`.
@@ -297,7 +297,7 @@ gh pr merge <number> --squash
 **A.5: Cleanup:**
 ```bash
 git update-ref -d refs/adopt-pr/upstream-base 2>/dev/null || true
-bd update $ROOT_ID --notes "<notes with merge_path: A, status: merged>"
+gc bd update $ROOT_ID --notes "<notes with merge_path: A, status: merged>"
 ```
 
 ---

--- a/pr-review/formulas/mol-pr-revert.formula.toml
+++ b/pr-review/formulas/mol-pr-revert.formula.toml
@@ -1,0 +1,629 @@
+description = """
+PR revert — 6 steps to revert a merged PR.
+
+Mayor-only invocation initially (no PL dispatch row). Reverts a merged PR
+via `git revert <merge-sha>` on a fresh branch off `origin/<default>`,
+opens a revert PR upstream, and comments on the original PR with the
+revert-PR URL.
+
+This is a WRITE-side formula. Three of its steps perform writes against
+the upstream repo:
+
+  - `revert-branch` pushes the revert branch to the fork.
+  - `open-revert-pr` calls `gh pr create`.
+  - `comment-on-original` calls `gh pr comment`.
+
+The polecat's default policy forbids `git push`, `gh pr create`, and
+`gh pr edit`. This formula carves out an exception scoped to the
+invocation. The push step is permitted only when ONE of the following
+holds:
+
+  a. Root bead metadata `auto_push == "true"` (set by mayor at sling
+     time via `--metadata auto_push=true`) AND the prior
+     `verify-revertable` step's `evidence.reviewer_verdict == "pass"`.
+  b. Env var `GASCITY_SHIP_BYPASS == "mayor_revert"` — emergency
+     override for cases where the verify-revertable heuristic
+     false-negatives (e.g. complex-but-still-revertable history). The
+     mayor sets this env var in the polecat's invocation environment.
+
+The carve-out is verified once in `revert-branch`; on pass it records
+`evidence.carve_out_verified == "true"` on the root bead. Subsequent
+write steps (`open-revert-pr`, `comment-on-original`) gate on that flag
+so a crash-resumed polecat with no env carryover stays authorized.
+
+This is the same carve-out shape used by mol-pr-from-issue's `open-pr`
+step — scoped to the macro formula's contract, not a polecat-wide
+policy change.
+
+The molecule root bead IS the control bead — all run state lives in its
+notes/metadata. Crash-safe: `bd mol current` resumes at the right step.
+
+## Contract
+
+1. Caller (mayor) slings with:
+   `--var pr=<N> --var reason="<text>" --metadata auto_push=true`
+   (or with `GASCITY_SHIP_BYPASS=mayor_revert` in the polecat's env).
+2. Polecat executes steps in order.
+3. Chain ends with either:
+   - an opened revert PR on the upstream repo + a comment on the
+     original PR pointing at the revert PR, OR
+   - a halt with `metadata.summary_for_human` set on the root bead.
+
+## Variables
+
+| Variable | Source | Description |
+|----------|--------|-------------|
+| pr | caller | PR number to revert (must be merged on the default branch) |
+| reason | caller | Explanation for the revert; lands in PR comment + commit message + revert-PR body |
+
+## Failure Modes
+
+| Situation | Action |
+|-----------|--------|
+| PR not merged (state != MERGED or mergedAt is null) | intake-pr halts; summary_for_human set |
+| PR merge commit no longer on default branch (already reverted, or branch reset) | verify-revertable halts |
+| Subsequent commits modify the same files as the merge | verify-revertable records warning; verdict still pass; revert may produce conflicts caught downstream |
+| `auto_push` not set AND no `GASCITY_SHIP_BYPASS` | revert-branch halts BEFORE push; no upstream writes |
+| `git revert` produces conflicts | revert-branch aborts the revert, halts; manual revert recommended |
+| `git push` fails | revert-branch halts; raw error captured in evidence |
+| `gh pr create` fails | open-revert-pr halts; commit sha kept in notes for manual recovery |
+| `gh pr comment` fails on original PR | comment-on-original logs failure but does NOT halt — revert PR is already open; final report records the gap |"""
+formula = "mol-pr-revert"
+phase = "vapor"
+# pour = true eager-materializes the steps. Without it this compiles RootOnly
+# (internal/formula/compile.go: `(!f.Pour && f.Phase == "vapor") || len(f.Steps) == 0`)
+# and all seven steps are dropped at instantiation. The failure is silent
+# rather than loud: RecipeHasReadySurface returns true because RootOnly itself
+# satisfies it, so a pool sling is accepted and only the work goes missing.
+pour = true
+version = 1
+
+[vars]
+[vars.pr]
+description = "PR number to revert. Must be merged on the default branch."
+required = true
+
+[vars.reason]
+description = "Explanation for the revert. Lands in revert-PR title/body and original-PR comment."
+required = true
+
+[[steps]]
+id = "intake-pr"
+title = "Parse PR #{{pr}} and assert merged"
+description = """
+Fetch PR metadata, assert it is merged, and record initial state in the
+root bead notes.
+
+**1. Find root bead and resolve repo:**
+```bash
+ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+UPSTREAM_REPO=$(gh repo view --json parent --jq '.parent.nameWithOwner // empty')
+[ -z "$UPSTREAM_REPO" ] && UPSTREAM_REPO="$REPO"
+```
+
+**2. Fetch PR metadata:**
+```bash
+gh pr view {{pr}} --repo "$UPSTREAM_REPO" \\
+    --json title,author,baseRefName,headRefName,number,state,url,mergedAt,mergeCommit
+```
+
+**3. Assert merged:**
+
+Parse the response. Required: `state == "MERGED"`, `mergedAt` non-null,
+`mergeCommit.oid` non-empty.
+
+If not merged:
+```bash
+bd update "$ROOT_ID" \\
+  --set-metadata "gc.halt_chain=true" \\
+  --set-metadata "summary_for_human=Cannot revert PR #{{pr}}: state=<state>, mergedAt=<value>. Only merged PRs are revertable through this formula."
+bd close "$ROOT_ID" --reason "PR #{{pr}} not merged"
+exit 0
+```
+
+**4. Record state in root bead notes:**
+```bash
+bd update "$ROOT_ID" --notes "pr_number: {{pr}}
+pr_url: <url>
+pr_title: <title>
+pr_author: <author.login>
+upstream_repo: $UPSTREAM_REPO
+local_repo: $REPO
+merge_sha: <mergeCommit.oid>
+head_ref: <headRefName>
+base_branch: <baseRefName>
+merged_at: <mergedAt>
+reason: {{reason}}"
+```
+
+**5. Display:**
+```
+[pr-revert] Intake complete
+[pr-revert]   PR #{{pr}}: "<title>"
+[pr-revert]   Author: <author.login>
+[pr-revert]   Merged at <mergedAt> via commit <mergeCommit.oid>
+[pr-revert]   Reason: {{reason}}
+```
+
+**Exit criteria:** PR confirmed merged; merge_sha + repo identifiers
+recorded in root bead notes."""
+
+[[steps]]
+id = "verify-revertable"
+title = "Verify PR #{{pr}} is safely revertable"
+needs = ["intake-pr"]
+description = """
+Confirm the merge commit is still on the default branch and scan history
+for commits that touch the same files. Sets `evidence.reviewer_verdict`
+which the carve-out at revert-branch reads.
+
+**1. Find root bead and resolve identifiers:**
+```bash
+ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+NOTES=$(bd show "$ROOT_ID" --json | jq -r '.[0].notes // ""')
+MERGE_SHA=$(echo "$NOTES" | awk -F': ' '/^merge_sha:/ {print $2}')
+UPSTREAM_REPO=$(echo "$NOTES" | awk -F': ' '/^upstream_repo:/ {print $2}')
+DEFAULT_BRANCH=$(gh repo view "$UPSTREAM_REPO" --json defaultBranchRef --jq '.defaultBranchRef.name // "main"')
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "$REPO_ROOT"
+```
+
+**2. Ensure local main is up-to-date and merge_sha is fetchable:**
+```bash
+git fetch origin "$DEFAULT_BRANCH"
+git cat-file -e "$MERGE_SHA" 2>/dev/null || git fetch origin "$MERGE_SHA"
+```
+
+If `git cat-file -e` still fails after fetch, the merge SHA is not
+reachable — halt:
+```bash
+bd update "$ROOT_ID" \\
+  --set-metadata "gc.halt_chain=true" \\
+  --set-metadata "evidence.reviewer_verdict=blocked" \\
+  --set-metadata "summary_for_human=Cannot revert PR #{{pr}}: merge_sha $MERGE_SHA is not reachable from this checkout. Branch may have been force-pushed or deleted."
+bd close "$ROOT_ID" --reason "merge_sha not reachable"
+exit 0
+```
+
+**3. Assert merge_sha is on default branch:**
+```bash
+if ! git merge-base --is-ancestor "$MERGE_SHA" "origin/$DEFAULT_BRANCH"; then
+    bd update "$ROOT_ID" \\
+      --set-metadata "gc.halt_chain=true" \\
+      --set-metadata "evidence.reviewer_verdict=blocked" \\
+      --set-metadata "summary_for_human=Cannot revert PR #{{pr}}: merge_sha $MERGE_SHA is not an ancestor of origin/$DEFAULT_BRANCH. The merge may have already been reverted, or $DEFAULT_BRANCH was reset."
+    bd close "$ROOT_ID" --reason "merge_sha not on default branch"
+    exit 0
+fi
+```
+
+**4. Scan subsequent history for file overlap:**
+
+Files touched by the merge commit (use `-m` to include merge commits):
+```bash
+MERGE_FILES=$(git show -m --name-only --pretty=format: "$MERGE_SHA" | sort -u | grep -v '^$')
+```
+
+Files touched by any commit between merge_sha and HEAD of default:
+```bash
+RANGE="${MERGE_SHA}..origin/${DEFAULT_BRANCH}"
+SUBSEQUENT_COUNT=$(git rev-list --count "$RANGE")
+SUBSEQUENT_FILES=$(git log --name-only --pretty=format: "$RANGE" | sort -u | grep -v '^$')
+```
+
+Compute overlap (files modified both in the merge and subsequently):
+```bash
+OVERLAP=$(comm -12 <(echo "$MERGE_FILES") <(echo "$SUBSEQUENT_FILES"))
+OVERLAP_COUNT=$(echo "$OVERLAP" | grep -c '^[^[:space:]]' || true)
+```
+
+**5. Set verdict:**
+
+The verdict is `pass` even when overlap exists — `git revert` may still
+succeed, and if it conflicts we catch it in revert-branch. Overlap is
+recorded as evidence so the report and PR body can reference it.
+
+```bash
+bd update "$ROOT_ID" \\
+  --set-metadata "evidence.reviewer_verdict=pass" \\
+  --set-metadata "evidence.reviewer_agent=<this polecat session>" \\
+  --set-metadata "evidence.subsequent_commits=$SUBSEQUENT_COUNT" \\
+  --set-metadata "evidence.overlap_files=$OVERLAP_COUNT"
+bd update "$ROOT_ID" --notes "$(echo "$NOTES")
+default_branch: $DEFAULT_BRANCH
+subsequent_commits: $SUBSEQUENT_COUNT
+overlap_files: $OVERLAP_COUNT
+overlap_file_list: $(echo "$OVERLAP" | tr '\\n' ',' | sed 's/,$//')"
+```
+
+**6. Display:**
+```
+[pr-revert] verify-revertable: pass
+[pr-revert]   merge_sha $MERGE_SHA is on origin/$DEFAULT_BRANCH
+[pr-revert]   $SUBSEQUENT_COUNT subsequent commits; $OVERLAP_COUNT overlap with merge files
+```
+
+**Exit criteria:** verdict recorded; overlap stats noted. revert-branch
+reads these to decide whether to proceed."""
+
+[[steps]]
+id = "revert-branch"
+title = "Create revert branch, run git revert, push"
+needs = ["verify-revertable"]
+description = """
+**WRITE STEP — requires auto_push carve-out.**
+
+Creates branch `revert/pr-{{pr}}` off `origin/<default>`, runs
+`git revert --no-edit <merge_sha>`, and pushes to the fork remote.
+
+The polecat's default policy forbids `git push`. This step performs the
+carve-out check ONCE at the top and records the result. If the carve-out
+fails, the step halts BEFORE any upstream write.
+
+**1. Find root bead and read state:**
+```bash
+ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+META=$(bd show "$ROOT_ID" --json | jq '.[0].metadata')
+AUTO_PUSH=$(echo "$META" | jq -r '.auto_push // "false"')
+VERDICT=$(echo "$META" | jq -r '."evidence.reviewer_verdict" // ""')
+BYPASS="${GASCITY_SHIP_BYPASS:-}"
+NOTES=$(bd show "$ROOT_ID" --json | jq -r '.[0].notes // ""')
+MERGE_SHA=$(echo "$NOTES" | awk -F': ' '/^merge_sha:/ {print $2}')
+DEFAULT_BRANCH=$(echo "$NOTES" | awk -F': ' '/^default_branch:/ {print $2}')
+PR_TITLE=$(echo "$NOTES" | awk -F': ' '/^pr_title:/ {print $2}')
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "$REPO_ROOT"
+```
+
+**2. Carve-out check (BEFORE any write):**
+```bash
+CARVE_OK=false
+CARVE_PATH=""
+if [ "$AUTO_PUSH" = "true" ] && [ "$VERDICT" = "pass" ]; then
+    CARVE_OK=true
+    CARVE_PATH="auto_push+verdict"
+elif [ "$BYPASS" = "mayor_revert" ]; then
+    CARVE_OK=true
+    CARVE_PATH="ship_bypass"
+fi
+
+if [ "$CARVE_OK" != "true" ]; then
+    bd update "$ROOT_ID" \\
+      --set-metadata "gc.halt_chain=true" \\
+      --set-metadata "summary_for_human=Refusing to push revert of PR #{{pr}}. auto_push=$AUTO_PUSH, verify-revertable verdict=$VERDICT, GASCITY_SHIP_BYPASS=${BYPASS:-unset}. Polecat's default policy forbids git push; carve-out requires either (a) --metadata auto_push=true at sling time with a clean verify-revertable verdict, or (b) GASCITY_SHIP_BYPASS=mayor_revert in env. No upstream writes performed."
+    bd close "$ROOT_ID" --reason "push carve-out not satisfied"
+    exit 0
+fi
+
+bd update "$ROOT_ID" --set-metadata "evidence.carve_out_verified=true" \\
+                      --set-metadata "evidence.carve_out_path=$CARVE_PATH"
+```
+
+**3. Confirm tree is clean before creating the branch:**
+```bash
+if [ -n "$(git status --porcelain | grep -v '^??')" ]; then
+    bd update "$ROOT_ID" \\
+      --set-metadata "gc.halt_chain=true" \\
+      --set-metadata "summary_for_human=Refusing to revert PR #{{pr}}: working tree is dirty. Commit or stash before retrying."
+    bd close "$ROOT_ID" --reason "dirty working tree"
+    exit 0
+fi
+```
+
+**4. Create the revert branch and run git revert:**
+```bash
+git fetch origin "$DEFAULT_BRANCH"
+BRANCH="revert/pr-{{pr}}"
+git checkout -B "$BRANCH" "origin/$DEFAULT_BRANCH"
+```
+
+Run `git revert`. Use `-m 1` for merge commits (revert the changes
+relative to the first parent, i.e. the base branch). Detect merge vs
+non-merge:
+```bash
+PARENT_COUNT=$(git cat-file -p "$MERGE_SHA" | grep -c '^parent ')
+if [ "$PARENT_COUNT" -gt 1 ]; then
+    REVERT_CMD=(git revert --no-edit -m 1 "$MERGE_SHA")
+else
+    REVERT_CMD=(git revert --no-edit "$MERGE_SHA")
+fi
+
+if ! "${REVERT_CMD[@]}"; then
+    git revert --abort 2>/dev/null || true
+    bd update "$ROOT_ID" \\
+      --set-metadata "gc.halt_chain=true" \\
+      --set-metadata "summary_for_human=git revert of $MERGE_SHA produced conflicts on branch $BRANCH. Aborted. Manual revert recommended — subsequent commits likely modified the same code paths."
+    bd close "$ROOT_ID" --reason "git revert conflict"
+    exit 0
+fi
+```
+
+**5. Amend the revert commit message to include the reason:**
+
+`git revert --no-edit` produces "Revert \\"<original subject>\\"". Append
+the reason so the commit message references both:
+```bash
+ORIGINAL_MSG=$(git log -1 --pretty=%B)
+git commit --amend -m "$ORIGINAL_MSG" -m "Reverts PR #{{pr}}." -m "Reason: {{reason}}"
+REVERT_SHA=$(git rev-parse HEAD)
+```
+
+**6. Resolve fork remote and push:**
+```bash
+LOCAL_REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
+FORK_REMOTE=$(git remote -v | awk -v fork="$LOCAL_REPO" 'index($2, fork) && /\\(push\\)/ {print $1; exit}')
+[ -z "$FORK_REMOTE" ] && FORK_REMOTE="origin"
+
+if ! git push -u "$FORK_REMOTE" "$BRANCH"; then
+    bd update "$ROOT_ID" \\
+      --set-metadata "gc.halt_chain=true" \\
+      --set-metadata "summary_for_human=git push of $BRANCH to $FORK_REMOTE failed for PR #{{pr}} revert. Revert commit is local at $REVERT_SHA; investigate push permissions and retry manually."
+    bd close "$ROOT_ID" --reason "git push failed"
+    exit 0
+fi
+```
+
+**7. Record state:**
+```bash
+bd update "$ROOT_ID" \\
+  --set-metadata "evidence.revert_branch=$BRANCH" \\
+  --set-metadata "evidence.revert_sha=$REVERT_SHA" \\
+  --set-metadata "evidence.fork_remote=$FORK_REMOTE"
+bd update "$ROOT_ID" --notes "$(echo "$NOTES")
+revert_branch: $BRANCH
+revert_sha: $REVERT_SHA
+fork_remote: $FORK_REMOTE
+carve_out_path: $CARVE_PATH"
+```
+
+**8. Display:**
+```
+[pr-revert] revert-branch: pushed
+[pr-revert]   Branch: $BRANCH
+[pr-revert]   Revert commit: $REVERT_SHA
+[pr-revert]   Reverts: $MERGE_SHA ("$PR_TITLE")
+[pr-revert]   Carve-out path: $CARVE_PATH
+```
+
+**Exit criteria:** revert branch pushed to fork; evidence.revert_branch
+and evidence.revert_sha recorded."""
+
+[[steps]]
+id = "open-revert-pr"
+title = "Open revert PR upstream"
+needs = ["revert-branch"]
+description = """
+Open the revert PR on the upstream repo. Gated on
+`evidence.carve_out_verified == "true"` so a crash-resumed polecat with
+no env carryover stays authorized.
+
+**1. Find root bead and read state:**
+```bash
+ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+META=$(bd show "$ROOT_ID" --json | jq '.[0].metadata')
+CARVE_OK=$(echo "$META" | jq -r '."evidence.carve_out_verified" // "false"')
+NOTES=$(bd show "$ROOT_ID" --json | jq -r '.[0].notes // ""')
+UPSTREAM_REPO=$(echo "$NOTES" | awk -F': ' '/^upstream_repo:/ {print $2}')
+DEFAULT_BRANCH=$(echo "$NOTES" | awk -F': ' '/^default_branch:/ {print $2}')
+BRANCH=$(echo "$NOTES" | awk -F': ' '/^revert_branch:/ {print $2}')
+REVERT_SHA=$(echo "$NOTES" | awk -F': ' '/^revert_sha:/ {print $2}')
+PR_TITLE=$(echo "$NOTES" | awk -F': ' '/^pr_title:/ {print $2}')
+PR_URL=$(echo "$NOTES" | awk -F': ' '/^pr_url:/ {print $2}')
+SUBSEQUENT_COUNT=$(echo "$META" | jq -r '."evidence.subsequent_commits" // "0"')
+OVERLAP_COUNT=$(echo "$META" | jq -r '."evidence.overlap_files" // "0"')
+LOCAL_REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
+FORK_OWNER=$(echo "$LOCAL_REPO" | cut -d/ -f1)
+```
+
+**2. Gate on carve-out:**
+```bash
+if [ "$CARVE_OK" != "true" ]; then
+    bd update "$ROOT_ID" \\
+      --set-metadata "gc.halt_chain=true" \\
+      --set-metadata "summary_for_human=Refusing to open revert PR for #{{pr}}: evidence.carve_out_verified is not true. Branch $BRANCH at $REVERT_SHA is on the fork but no PR was opened. Re-sling with auto_push=true or set GASCITY_SHIP_BYPASS=mayor_revert."
+    bd close "$ROOT_ID" --reason "open-pr carve-out not satisfied"
+    exit 0
+fi
+```
+
+**3. Compose PR title and body:**
+
+Read MERGE_SHA out of root bead notes first so the heredoc only does
+variable interpolation (no embedded subshells, no backtick escaping):
+```bash
+MERGE_SHA=$(echo "$NOTES" | awk -F': ' '/^merge_sha:/ {print $2}')
+REVERT_TITLE="Revert PR #{{pr}}: {{reason}}"
+BODY_FILE=$(mktemp)
+cat > "$BODY_FILE" <<MD
+Reverts PR #{{pr}} ($PR_URL): "$PR_TITLE".
+
+## Reason
+
+{{reason}}
+
+## Context
+
+- Original merge commit: $MERGE_SHA
+- Revert commit: $REVERT_SHA on branch $BRANCH
+- Subsequent commits on $DEFAULT_BRANCH since the merge: $SUBSEQUENT_COUNT
+- Files modified both in the merge and subsequently: $OVERLAP_COUNT
+
+Generated by mol-pr-revert (mayor-invoked).
+MD
+```
+
+**4. Open the PR:**
+```bash
+PR_URL_OUT=$(gh pr create \\
+    --repo "$UPSTREAM_REPO" \\
+    --base "$DEFAULT_BRANCH" \\
+    --head "$FORK_OWNER:$BRANCH" \\
+    --title "$REVERT_TITLE" \\
+    --body-file "$BODY_FILE" 2>&1)
+PR_EXIT=$?
+rm -f "$BODY_FILE"
+
+if [ "$PR_EXIT" -eq 0 ] && [ -z "$(echo "$PR_URL_OUT" | grep -oE 'https://[^ ]+/pull/[0-9]+')" ]; then
+    # No URL — recover by looking up an existing PR on this head.
+    PR_URL_OUT=$(gh pr list --repo "$UPSTREAM_REPO" --head "$BRANCH" --state open \\
+                  --json url --jq '.[0].url // empty')
+fi
+
+if [ "$PR_EXIT" -ne 0 ] || [ -z "$PR_URL_OUT" ]; then
+    bd update "$ROOT_ID" \\
+      --set-metadata "gc.halt_chain=true" \\
+      --set-metadata "summary_for_human=Revert branch $BRANCH pushed at $REVERT_SHA but gh pr create failed for PR #{{pr}}. Investigate before retrying. Manual command: gh pr create --repo $UPSTREAM_REPO --base $DEFAULT_BRANCH --head $FORK_OWNER:$BRANCH --title \\"$REVERT_TITLE\\""
+    bd close "$ROOT_ID" --reason "gh pr create failed"
+    exit 0
+fi
+
+REVERT_PR_URL=$(echo "$PR_URL_OUT" | grep -oE 'https://[^ ]+/pull/[0-9]+' | head -1)
+REVERT_PR_NUM=$(echo "$REVERT_PR_URL" | grep -oE '/pull/[0-9]+' | sed 's|/pull/||')
+```
+
+**5. Record state:**
+```bash
+bd update "$ROOT_ID" \\
+  --set-metadata "evidence.revert_pr_url=$REVERT_PR_URL" \\
+  --set-metadata "evidence.revert_pr_number=$REVERT_PR_NUM"
+bd update "$ROOT_ID" --notes "$(echo "$NOTES")
+revert_pr_url: $REVERT_PR_URL
+revert_pr_number: $REVERT_PR_NUM"
+```
+
+**6. Display:**
+```
+[pr-revert] open-revert-pr: opened
+[pr-revert]   Revert PR: $REVERT_PR_URL
+[pr-revert]   Reverts: #{{pr}} ($PR_URL)
+```
+
+**Exit criteria:** revert PR opened upstream; URL recorded in
+evidence.revert_pr_url."""
+
+[[steps]]
+id = "comment-on-original"
+title = "Comment on original PR #{{pr}} with revert link"
+needs = ["open-revert-pr"]
+description = """
+Post a comment on the original PR pointing at the revert PR. Best-effort:
+failure here does NOT halt the chain (the revert PR is already open and
+visible to the maintainer).
+
+**1. Find root bead and read state:**
+```bash
+ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+CARVE_OK=$(bd show "$ROOT_ID" --json | jq -r '.[0].metadata."evidence.carve_out_verified" // "false"')
+NOTES=$(bd show "$ROOT_ID" --json | jq -r '.[0].notes // ""')
+UPSTREAM_REPO=$(echo "$NOTES" | awk -F': ' '/^upstream_repo:/ {print $2}')
+REVERT_PR_URL=$(echo "$NOTES" | awk -F': ' '/^revert_pr_url:/ {print $2}')
+```
+
+**2. Gate on carve-out (defensive — should always be true at this point):**
+```bash
+if [ "$CARVE_OK" != "true" ]; then
+    bd update "$ROOT_ID" \\
+      --set-metadata "evidence.comment_status=skipped_carve_out"
+    echo "[pr-revert] comment-on-original: skipped (carve_out_verified != true)"
+    exit 0
+fi
+```
+
+**3. Compose and post the comment:**
+```bash
+BODY_FILE=$(mktemp)
+cat > "$BODY_FILE" <<MD
+This PR has been reverted: $REVERT_PR_URL
+
+**Reason:** {{reason}}
+
+_Posted automatically by mol-pr-revert._
+MD
+
+if gh pr comment {{pr}} --repo "$UPSTREAM_REPO" --body-file "$BODY_FILE"; then
+    COMMENT_STATUS="posted"
+else
+    COMMENT_STATUS="failed"
+fi
+rm -f "$BODY_FILE"
+```
+
+**4. Record state (NEVER halt on failure — revert PR is already open):**
+```bash
+bd update "$ROOT_ID" \\
+  --set-metadata "evidence.comment_status=$COMMENT_STATUS"
+bd update "$ROOT_ID" --notes "$(echo "$NOTES")
+comment_status: $COMMENT_STATUS"
+```
+
+**5. Display:**
+```
+[pr-revert] comment-on-original: $COMMENT_STATUS
+```
+
+**Exit criteria:** comment posted (or status=failed recorded). Chain
+continues regardless."""
+
+[[steps]]
+id = "report"
+title = "Synthesize summary_for_human and close molecule"
+needs = ["comment-on-original"]
+description = """
+Final step. Compose `summary_for_human` from collected evidence, ensure
+`evidence.revert_pr_url` is set, and close the molecule.
+
+**1. Find root bead and read state:**
+```bash
+ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+META=$(bd show "$ROOT_ID" --json | jq '.[0].metadata')
+NOTES=$(bd show "$ROOT_ID" --json | jq -r '.[0].notes // ""')
+PR_NUM={{pr}}
+PR_URL=$(echo "$NOTES" | awk -F': ' '/^pr_url:/ {print $2}')
+PR_TITLE=$(echo "$NOTES" | awk -F': ' '/^pr_title:/ {print $2}')
+REVERT_PR_URL=$(echo "$META" | jq -r '."evidence.revert_pr_url" // ""')
+REVERT_PR_NUM=$(echo "$META" | jq -r '."evidence.revert_pr_number" // ""')
+REVERT_SHA=$(echo "$META" | jq -r '."evidence.revert_sha" // ""')
+COMMENT_STATUS=$(echo "$META" | jq -r '."evidence.comment_status" // "unknown"')
+CARVE_PATH=$(echo "$META" | jq -r '."evidence.carve_out_path" // ""')
+OVERLAP_COUNT=$(echo "$META" | jq -r '."evidence.overlap_files" // "0"')
+```
+
+**2. Compose summary:**
+
+`summary_for_human` is the message the loop-close handler surfaces. Keep
+it tight; the maintainer can drill into evidence/notes for detail.
+
+```bash
+COMMENT_NOTE=""
+case "$COMMENT_STATUS" in
+    posted) COMMENT_NOTE="Original PR commented." ;;
+    failed) COMMENT_NOTE="Original PR comment FAILED — post manually at $PR_URL." ;;
+    *) COMMENT_NOTE="Original PR comment status: $COMMENT_STATUS." ;;
+esac
+
+OVERLAP_NOTE=""
+[ "$OVERLAP_COUNT" -gt 0 ] && OVERLAP_NOTE=" $OVERLAP_COUNT files were modified after the original merge — watch CI on the revert PR."
+
+bd update "$ROOT_ID" \\
+  --set-metadata "evidence.reviewer_verdict=pass" \\
+  --set-metadata "evidence.artifact_path=github-pr:$REVERT_PR_URL" \\
+  --set-metadata "summary_for_human=Reverted PR #$PR_NUM (\\"$PR_TITLE\\"). Revert PR: $REVERT_PR_URL (#$REVERT_PR_NUM). Revert commit: $REVERT_SHA. Carve-out path: $CARVE_PATH. $COMMENT_NOTE$OVERLAP_NOTE Reason: {{reason}}"
+```
+
+**3. Close the molecule:**
+```bash
+bd close "$ROOT_ID" --reason "revert PR #$REVERT_PR_NUM opened for #$PR_NUM"
+```
+
+**4. Display:**
+```
+[pr-revert] Complete
+[pr-revert]   Reverted #$PR_NUM: $PR_URL
+[pr-revert]   Revert PR: $REVERT_PR_URL
+[pr-revert]   Revert commit: $REVERT_SHA
+[pr-revert]   Comment on original: $COMMENT_STATUS
+```
+
+**Exit criteria:** evidence.revert_pr_url and summary_for_human set;
+molecule closed."""

--- a/pr-review/formulas/mol-pr-revert.formula.toml
+++ b/pr-review/formulas/mol-pr-revert.formula.toml
@@ -36,7 +36,7 @@ step — scoped to the macro formula's contract, not a polecat-wide
 policy change.
 
 The molecule root bead IS the control bead — all run state lives in its
-notes/metadata. Crash-safe: `bd mol current` resumes at the right step.
+notes/metadata. Crash-safe: `gc bd mol current` resumes at the right step.
 
 ## Contract
 
@@ -96,7 +96,7 @@ root bead notes.
 
 **1. Find root bead and resolve repo:**
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
 REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
 UPSTREAM_REPO=$(gh repo view --json parent --jq '.parent.nameWithOwner // empty')
 [ -z "$UPSTREAM_REPO" ] && UPSTREAM_REPO="$REPO"
@@ -115,16 +115,16 @@ Parse the response. Required: `state == "MERGED"`, `mergedAt` non-null,
 
 If not merged:
 ```bash
-bd update "$ROOT_ID" \\
+gc bd update "$ROOT_ID" \\
   --set-metadata "gc.halt_chain=true" \\
   --set-metadata "summary_for_human=Cannot revert PR #{{pr}}: state=<state>, mergedAt=<value>. Only merged PRs are revertable through this formula."
-bd close "$ROOT_ID" --reason "PR #{{pr}} not merged"
+gc bd close "$ROOT_ID" --reason "PR #{{pr}} not merged"
 exit 0
 ```
 
 **4. Record state in root bead notes:**
 ```bash
-bd update "$ROOT_ID" --notes "pr_number: {{pr}}
+gc bd update "$ROOT_ID" --notes "pr_number: {{pr}}
 pr_url: <url>
 pr_title: <title>
 pr_author: <author.login>
@@ -160,8 +160,8 @@ which the carve-out at revert-branch reads.
 
 **1. Find root bead and resolve identifiers:**
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
-NOTES=$(bd show "$ROOT_ID" --json | jq -r '.[0].notes // ""')
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
+NOTES=$(gc bd show "$ROOT_ID" --json | jq -r '.[0].notes // ""')
 MERGE_SHA=$(echo "$NOTES" | awk -F': ' '/^merge_sha:/ {print $2}')
 UPSTREAM_REPO=$(echo "$NOTES" | awk -F': ' '/^upstream_repo:/ {print $2}')
 DEFAULT_BRANCH=$(gh repo view "$UPSTREAM_REPO" --json defaultBranchRef --jq '.defaultBranchRef.name // "main"')
@@ -178,22 +178,22 @@ git cat-file -e "$MERGE_SHA" 2>/dev/null || git fetch origin "$MERGE_SHA"
 If `git cat-file -e` still fails after fetch, the merge SHA is not
 reachable — halt:
 ```bash
-bd update "$ROOT_ID" \\
+gc bd update "$ROOT_ID" \\
   --set-metadata "gc.halt_chain=true" \\
   --set-metadata "evidence.reviewer_verdict=blocked" \\
   --set-metadata "summary_for_human=Cannot revert PR #{{pr}}: merge_sha $MERGE_SHA is not reachable from this checkout. Branch may have been force-pushed or deleted."
-bd close "$ROOT_ID" --reason "merge_sha not reachable"
+gc bd close "$ROOT_ID" --reason "merge_sha not reachable"
 exit 0
 ```
 
 **3. Assert merge_sha is on default branch:**
 ```bash
 if ! git merge-base --is-ancestor "$MERGE_SHA" "origin/$DEFAULT_BRANCH"; then
-    bd update "$ROOT_ID" \\
+    gc bd update "$ROOT_ID" \\
       --set-metadata "gc.halt_chain=true" \\
       --set-metadata "evidence.reviewer_verdict=blocked" \\
       --set-metadata "summary_for_human=Cannot revert PR #{{pr}}: merge_sha $MERGE_SHA is not an ancestor of origin/$DEFAULT_BRANCH. The merge may have already been reverted, or $DEFAULT_BRANCH was reset."
-    bd close "$ROOT_ID" --reason "merge_sha not on default branch"
+    gc bd close "$ROOT_ID" --reason "merge_sha not on default branch"
     exit 0
 fi
 ```
@@ -225,12 +225,12 @@ succeed, and if it conflicts we catch it in revert-branch. Overlap is
 recorded as evidence so the report and PR body can reference it.
 
 ```bash
-bd update "$ROOT_ID" \\
+gc bd update "$ROOT_ID" \\
   --set-metadata "evidence.reviewer_verdict=pass" \\
   --set-metadata "evidence.reviewer_agent=<this polecat session>" \\
   --set-metadata "evidence.subsequent_commits=$SUBSEQUENT_COUNT" \\
   --set-metadata "evidence.overlap_files=$OVERLAP_COUNT"
-bd update "$ROOT_ID" --notes "$(echo "$NOTES")
+gc bd update "$ROOT_ID" --notes "$(echo "$NOTES")
 default_branch: $DEFAULT_BRANCH
 subsequent_commits: $SUBSEQUENT_COUNT
 overlap_files: $OVERLAP_COUNT
@@ -263,12 +263,12 @@ fails, the step halts BEFORE any upstream write.
 
 **1. Find root bead and read state:**
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
-META=$(bd show "$ROOT_ID" --json | jq '.[0].metadata')
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
+META=$(gc bd show "$ROOT_ID" --json | jq '.[0].metadata')
 AUTO_PUSH=$(echo "$META" | jq -r '.auto_push // "false"')
 VERDICT=$(echo "$META" | jq -r '."evidence.reviewer_verdict" // ""')
 BYPASS="${GASCITY_SHIP_BYPASS:-}"
-NOTES=$(bd show "$ROOT_ID" --json | jq -r '.[0].notes // ""')
+NOTES=$(gc bd show "$ROOT_ID" --json | jq -r '.[0].notes // ""')
 MERGE_SHA=$(echo "$NOTES" | awk -F': ' '/^merge_sha:/ {print $2}')
 DEFAULT_BRANCH=$(echo "$NOTES" | awk -F': ' '/^default_branch:/ {print $2}')
 PR_TITLE=$(echo "$NOTES" | awk -F': ' '/^pr_title:/ {print $2}')
@@ -289,24 +289,24 @@ elif [ "$BYPASS" = "mayor_revert" ]; then
 fi
 
 if [ "$CARVE_OK" != "true" ]; then
-    bd update "$ROOT_ID" \\
+    gc bd update "$ROOT_ID" \\
       --set-metadata "gc.halt_chain=true" \\
       --set-metadata "summary_for_human=Refusing to push revert of PR #{{pr}}. auto_push=$AUTO_PUSH, verify-revertable verdict=$VERDICT, GASCITY_SHIP_BYPASS=${BYPASS:-unset}. Polecat's default policy forbids git push; carve-out requires either (a) --metadata auto_push=true at sling time with a clean verify-revertable verdict, or (b) GASCITY_SHIP_BYPASS=mayor_revert in env. No upstream writes performed."
-    bd close "$ROOT_ID" --reason "push carve-out not satisfied"
+    gc bd close "$ROOT_ID" --reason "push carve-out not satisfied"
     exit 0
 fi
 
-bd update "$ROOT_ID" --set-metadata "evidence.carve_out_verified=true" \\
-                      --set-metadata "evidence.carve_out_path=$CARVE_PATH"
+gc bd update "$ROOT_ID" --set-metadata "evidence.carve_out_verified=true" \\
+                         --set-metadata "evidence.carve_out_path=$CARVE_PATH"
 ```
 
 **3. Confirm tree is clean before creating the branch:**
 ```bash
 if [ -n "$(git status --porcelain | grep -v '^??')" ]; then
-    bd update "$ROOT_ID" \\
+    gc bd update "$ROOT_ID" \\
       --set-metadata "gc.halt_chain=true" \\
       --set-metadata "summary_for_human=Refusing to revert PR #{{pr}}: working tree is dirty. Commit or stash before retrying."
-    bd close "$ROOT_ID" --reason "dirty working tree"
+    gc bd close "$ROOT_ID" --reason "dirty working tree"
     exit 0
 fi
 ```
@@ -331,10 +331,10 @@ fi
 
 if ! "${REVERT_CMD[@]}"; then
     git revert --abort 2>/dev/null || true
-    bd update "$ROOT_ID" \\
+    gc bd update "$ROOT_ID" \\
       --set-metadata "gc.halt_chain=true" \\
       --set-metadata "summary_for_human=git revert of $MERGE_SHA produced conflicts on branch $BRANCH. Aborted. Manual revert recommended — subsequent commits likely modified the same code paths."
-    bd close "$ROOT_ID" --reason "git revert conflict"
+    gc bd close "$ROOT_ID" --reason "git revert conflict"
     exit 0
 fi
 ```
@@ -356,21 +356,21 @@ FORK_REMOTE=$(git remote -v | awk -v fork="$LOCAL_REPO" 'index($2, fork) && /\\(
 [ -z "$FORK_REMOTE" ] && FORK_REMOTE="origin"
 
 if ! git push -u "$FORK_REMOTE" "$BRANCH"; then
-    bd update "$ROOT_ID" \\
+    gc bd update "$ROOT_ID" \\
       --set-metadata "gc.halt_chain=true" \\
       --set-metadata "summary_for_human=git push of $BRANCH to $FORK_REMOTE failed for PR #{{pr}} revert. Revert commit is local at $REVERT_SHA; investigate push permissions and retry manually."
-    bd close "$ROOT_ID" --reason "git push failed"
+    gc bd close "$ROOT_ID" --reason "git push failed"
     exit 0
 fi
 ```
 
 **7. Record state:**
 ```bash
-bd update "$ROOT_ID" \\
+gc bd update "$ROOT_ID" \\
   --set-metadata "evidence.revert_branch=$BRANCH" \\
   --set-metadata "evidence.revert_sha=$REVERT_SHA" \\
   --set-metadata "evidence.fork_remote=$FORK_REMOTE"
-bd update "$ROOT_ID" --notes "$(echo "$NOTES")
+gc bd update "$ROOT_ID" --notes "$(echo "$NOTES")
 revert_branch: $BRANCH
 revert_sha: $REVERT_SHA
 fork_remote: $FORK_REMOTE
@@ -400,10 +400,10 @@ no env carryover stays authorized.
 
 **1. Find root bead and read state:**
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
-META=$(bd show "$ROOT_ID" --json | jq '.[0].metadata')
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
+META=$(gc bd show "$ROOT_ID" --json | jq '.[0].metadata')
 CARVE_OK=$(echo "$META" | jq -r '."evidence.carve_out_verified" // "false"')
-NOTES=$(bd show "$ROOT_ID" --json | jq -r '.[0].notes // ""')
+NOTES=$(gc bd show "$ROOT_ID" --json | jq -r '.[0].notes // ""')
 UPSTREAM_REPO=$(echo "$NOTES" | awk -F': ' '/^upstream_repo:/ {print $2}')
 DEFAULT_BRANCH=$(echo "$NOTES" | awk -F': ' '/^default_branch:/ {print $2}')
 BRANCH=$(echo "$NOTES" | awk -F': ' '/^revert_branch:/ {print $2}')
@@ -419,10 +419,10 @@ FORK_OWNER=$(echo "$LOCAL_REPO" | cut -d/ -f1)
 **2. Gate on carve-out:**
 ```bash
 if [ "$CARVE_OK" != "true" ]; then
-    bd update "$ROOT_ID" \\
+    gc bd update "$ROOT_ID" \\
       --set-metadata "gc.halt_chain=true" \\
       --set-metadata "summary_for_human=Refusing to open revert PR for #{{pr}}: evidence.carve_out_verified is not true. Branch $BRANCH at $REVERT_SHA is on the fork but no PR was opened. Re-sling with auto_push=true or set GASCITY_SHIP_BYPASS=mayor_revert."
-    bd close "$ROOT_ID" --reason "open-pr carve-out not satisfied"
+    gc bd close "$ROOT_ID" --reason "open-pr carve-out not satisfied"
     exit 0
 fi
 ```
@@ -471,10 +471,10 @@ if [ "$PR_EXIT" -eq 0 ] && [ -z "$(echo "$PR_URL_OUT" | grep -oE 'https://[^ ]+/
 fi
 
 if [ "$PR_EXIT" -ne 0 ] || [ -z "$PR_URL_OUT" ]; then
-    bd update "$ROOT_ID" \\
+    gc bd update "$ROOT_ID" \\
       --set-metadata "gc.halt_chain=true" \\
       --set-metadata "summary_for_human=Revert branch $BRANCH pushed at $REVERT_SHA but gh pr create failed for PR #{{pr}}. Investigate before retrying. Manual command: gh pr create --repo $UPSTREAM_REPO --base $DEFAULT_BRANCH --head $FORK_OWNER:$BRANCH --title \\"$REVERT_TITLE\\""
-    bd close "$ROOT_ID" --reason "gh pr create failed"
+    gc bd close "$ROOT_ID" --reason "gh pr create failed"
     exit 0
 fi
 
@@ -484,10 +484,10 @@ REVERT_PR_NUM=$(echo "$REVERT_PR_URL" | grep -oE '/pull/[0-9]+' | sed 's|/pull/|
 
 **5. Record state:**
 ```bash
-bd update "$ROOT_ID" \\
+gc bd update "$ROOT_ID" \\
   --set-metadata "evidence.revert_pr_url=$REVERT_PR_URL" \\
   --set-metadata "evidence.revert_pr_number=$REVERT_PR_NUM"
-bd update "$ROOT_ID" --notes "$(echo "$NOTES")
+gc bd update "$ROOT_ID" --notes "$(echo "$NOTES")
 revert_pr_url: $REVERT_PR_URL
 revert_pr_number: $REVERT_PR_NUM"
 ```
@@ -513,9 +513,9 @@ visible to the maintainer).
 
 **1. Find root bead and read state:**
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
-CARVE_OK=$(bd show "$ROOT_ID" --json | jq -r '.[0].metadata."evidence.carve_out_verified" // "false"')
-NOTES=$(bd show "$ROOT_ID" --json | jq -r '.[0].notes // ""')
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
+CARVE_OK=$(gc bd show "$ROOT_ID" --json | jq -r '.[0].metadata."evidence.carve_out_verified" // "false"')
+NOTES=$(gc bd show "$ROOT_ID" --json | jq -r '.[0].notes // ""')
 UPSTREAM_REPO=$(echo "$NOTES" | awk -F': ' '/^upstream_repo:/ {print $2}')
 REVERT_PR_URL=$(echo "$NOTES" | awk -F': ' '/^revert_pr_url:/ {print $2}')
 ```
@@ -523,7 +523,7 @@ REVERT_PR_URL=$(echo "$NOTES" | awk -F': ' '/^revert_pr_url:/ {print $2}')
 **2. Gate on carve-out (defensive — should always be true at this point):**
 ```bash
 if [ "$CARVE_OK" != "true" ]; then
-    bd update "$ROOT_ID" \\
+    gc bd update "$ROOT_ID" \\
       --set-metadata "evidence.comment_status=skipped_carve_out"
     echo "[pr-revert] comment-on-original: skipped (carve_out_verified != true)"
     exit 0
@@ -551,9 +551,9 @@ rm -f "$BODY_FILE"
 
 **4. Record state (NEVER halt on failure — revert PR is already open):**
 ```bash
-bd update "$ROOT_ID" \\
+gc bd update "$ROOT_ID" \\
   --set-metadata "evidence.comment_status=$COMMENT_STATUS"
-bd update "$ROOT_ID" --notes "$(echo "$NOTES")
+gc bd update "$ROOT_ID" --notes "$(echo "$NOTES")
 comment_status: $COMMENT_STATUS"
 ```
 
@@ -575,9 +575,9 @@ Final step. Compose `summary_for_human` from collected evidence, ensure
 
 **1. Find root bead and read state:**
 ```bash
-ROOT_ID=$(bd mol current --json | jq -r '.molecule_id')
-META=$(bd show "$ROOT_ID" --json | jq '.[0].metadata')
-NOTES=$(bd show "$ROOT_ID" --json | jq -r '.[0].notes // ""')
+ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
+META=$(gc bd show "$ROOT_ID" --json | jq '.[0].metadata')
+NOTES=$(gc bd show "$ROOT_ID" --json | jq -r '.[0].notes // ""')
 PR_NUM={{pr}}
 PR_URL=$(echo "$NOTES" | awk -F': ' '/^pr_url:/ {print $2}')
 PR_TITLE=$(echo "$NOTES" | awk -F': ' '/^pr_title:/ {print $2}')
@@ -605,7 +605,7 @@ esac
 OVERLAP_NOTE=""
 [ "$OVERLAP_COUNT" -gt 0 ] && OVERLAP_NOTE=" $OVERLAP_COUNT files were modified after the original merge — watch CI on the revert PR."
 
-bd update "$ROOT_ID" \\
+gc bd update "$ROOT_ID" \\
   --set-metadata "evidence.reviewer_verdict=pass" \\
   --set-metadata "evidence.artifact_path=github-pr:$REVERT_PR_URL" \\
   --set-metadata "summary_for_human=Reverted PR #$PR_NUM (\\"$PR_TITLE\\"). Revert PR: $REVERT_PR_URL (#$REVERT_PR_NUM). Revert commit: $REVERT_SHA. Carve-out path: $CARVE_PATH. $COMMENT_NOTE$OVERLAP_NOTE Reason: {{reason}}"
@@ -613,7 +613,7 @@ bd update "$ROOT_ID" \\
 
 **3. Close the molecule:**
 ```bash
-bd close "$ROOT_ID" --reason "revert PR #$REVERT_PR_NUM opened for #$PR_NUM"
+gc bd close "$ROOT_ID" --reason "revert PR #$REVERT_PR_NUM opened for #$PR_NUM"
 ```
 
 **4. Display:**

--- a/pr-review/formulas/mol-pr-revert.formula.toml
+++ b/pr-review/formulas/mol-pr-revert.formula.toml
@@ -466,7 +466,7 @@ rm -f "$BODY_FILE"
 
 if [ "$PR_EXIT" -eq 0 ] && [ -z "$(echo "$PR_URL_OUT" | grep -oE 'https://[^ ]+/pull/[0-9]+')" ]; then
     # No URL — recover by looking up an existing PR on this head.
-    PR_URL_OUT=$(gh pr list --repo "$UPSTREAM_REPO" --head "$BRANCH" --state open \\
+    PR_URL_OUT=$(gh pr list --repo "$UPSTREAM_REPO" --head "$FORK_OWNER:$BRANCH" --state open \\
                   --json url --jq '.[0].url // empty')
 fi
 

--- a/pr-review/overlay/.claude/skills/review-pr/SKILL.md
+++ b/pr-review/overlay/.claude/skills/review-pr/SKILL.md
@@ -1,0 +1,1429 @@
+---
+name: review-pr
+description: >-
+  Multi-model code review for gastown. Reviews GitHub PRs (by URL or number)
+  or local branches (by branch name). Spawns parallel Claude, Codex, and
+  (optionally) Gemini reviewers with specialized prompts optimized for
+  regression prevention, then synthesizes findings into a single
+  maintainer-grade decision report. Use --skip-gemini for dual-model mode
+  when Gemini quota is exhausted. Invoke with /review-pr <pr-url|number|branch>.
+---
+
+# Review PR Orchestrator
+
+You are the **Review PR Orchestrator**. When the user invokes `/review-pr <arg>`, you execute a multi-phase pipeline that produces a thorough, multi-model code review focused on **preventing regressions** in the gastown codebase. You coordinate parallel Claude, Codex, and (unless `--skip-gemini`) Gemini reviewers, merge their findings, and present a single actionable report. All reviewers get full codebase access via temporary worktrees to ensure accurate caller/callee tracing. You never delegate orchestration to a spawned agent -- you are the single controller.
+
+### Mode Detection
+
+`/review-pr <arg>` auto-detects the review mode from `<arg>`:
+
+| Pattern | Mode | Example |
+|---------|------|---------|
+| `https://github.com/.*/pull/\d+` | PR mode | `/review-pr https://github.com/org/gastown/pull/123` |
+| Bare integer | PR mode | `/review-pr 123` |
+| Anything else | Local branch mode | `/review-pr ci/close-stale-needs` |
+
+- **PR mode**: Fetches context from GitHub, posts comment after review (4 phases).
+- **Local branch mode**: Computes diff from local git refs, skips GitHub posting (3 phases).
+
+---
+
+## Pipeline Overview
+
+| Phase | Name | Agents | Modes | Description |
+|-------|------|--------|-------|-------------|
+| 1 | Context Gathering | Orchestrator | Both | Gather metadata + diff; create worktrees for codebase access |
+| 2 | Parallel Review | Claude ∥ Codex ∥ Gemini | Both | Independent reviews with role-specialized prompts |
+| 3 | Synthesis | Orchestrator | Both | Merge, deduplicate, resolve disagreements, produce final report |
+| 4 | Post to GitHub | Orchestrator | PR only | Format compact comment, present for user approval, post via `gh pr comment` on confirmation |
+
+---
+
+## Critical Rules
+
+1. **Claude and Codex are always required.** Both must succeed (non-empty output) or the pipeline stops. **Gemini is required unless `--skip-gemini` is set.** When `--skip-gemini` is active, the pipeline runs in dual-model mode (Claude + Codex only) — Gemini preflight, prompt, invocation, and output validation are all skipped. There is no single-model fallback.
+2. **Prompts saved first.** Before every agent invocation, save the full prompt to `<run_dir>/prompts/`. This is the audit trail.
+3. **Parallel execution.** Phase 2 spawns Claude and Codex in parallel. Neither depends on the other's output.
+4. **Worktree-based review.** Two temporary worktrees are created from the upstream repo: a **base worktree** (upstream main) for Claude, and a **PR head worktree** for Codex (and Gemini, unless `--skip-gemini`). Claude receives the diff in its prompt and uses the base worktree for caller/callee tracing. Codex and Gemini receive the diff in their prompts and run from the PR head worktree so they can read files for additional context.
+5. **Working directory conventions:**
+   - `run_dir` = `/tmp/review-pr/<run_id>/`
+   - `run_id` format: `YYYYMMDDTHHMMSSZ-<8-hex>`
+6. **All artifacts under `run_dir`.** Prompts, reviewer outputs, synthesis -- everything goes under `run_dir`.
+7. **Fail closed.** On agent failure, empty output, or malformed results, stop and report the failure. Do not attempt to interpret broken output.
+8. **North star: regression prevention.** Every decision in this pipeline optimizes for catching changes that break existing behavior, violate contracts, or corrupt state.
+
+---
+
+## CLI Interface
+
+```
+/review-pr <arg> [options]
+```
+
+### Arguments
+
+- `<arg>` (required): One of:
+  - **PR URL** — `https://github.com/org/gastown/pull/123` → PR mode
+  - **Bare integer** — `123` → PR mode (uses current repo)
+  - **Branch name** — `ci/close-stale-needs` → Local branch mode
+
+### Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--base <branch>` | auto-detect | Base branch for local branch mode. Auto-detects the best base by finding the most recent merge-base across `main`, `upstream/main`, and `origin/main`. Override with an explicit branch name. Ignored in PR mode. |
+| `--skip-gemini` | false | Run dual-model review (Claude + Codex only). Use when Gemini quota is exhausted. |
+| `--skip-synthesis` | false | Output raw reviewer findings without synthesis |
+| `--claude-only` | false | Run only Claude reviewer (degrades quality) |
+| `--codex-only` | false | Run only Codex reviewer (degrades quality) |
+| `--gemini-only` | false | Run only Gemini reviewer (degrades quality) |
+
+---
+
+## Phase 1: Context Gathering
+
+Gather all context needed to build self-contained prompts. Steps 1, 3, 4, and 5 are shared across both modes. Step 2 is mode-specific.
+
+### Step 1: Set up run directory
+
+```bash
+RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)-$(openssl rand -hex 4)"
+RUN_DIR="/tmp/review-pr/$RUN_ID"
+mkdir -p "$RUN_DIR"/{prompts,outputs,context,scripts}
+```
+
+### Step 2: Gather context (mode-specific)
+
+#### PR Mode
+
+1. **Parse PR identifier** from `<arg>`. Extract owner, repo, and PR number.
+
+2. **Fetch PR metadata, diff, and file list in parallel:**
+   These three `gh` calls are independent — run them concurrently to save ~5-10s:
+   ```bash
+   gh pr view <number> --repo <owner>/<repo> \
+     --json title,body,author,baseRefName,headRefName,number,additions,deletions,changedFiles \
+     > "$RUN_DIR/context/metadata.json" &
+   METADATA_PID=$!
+
+   gh pr diff <number> --repo <owner>/<repo> \
+     > "$RUN_DIR/context/diff.patch" &
+   DIFF_PID=$!
+
+   gh pr view <number> --repo <owner>/<repo> \
+     --json files --jq '.files[].path' \
+     > "$RUN_DIR/context/files.txt" &
+   FILES_PID=$!
+
+   wait $METADATA_PID $DIFF_PID $FILES_PID
+   ```
+   If any fetch fails, stop with the appropriate error.
+
+3. **Build the PR context block** (injected into all reviewer prompts):
+
+   ```
+   ## PR Context
+
+   PR #<number>: <title>
+   Author: <author>
+   Base: <baseRefName> <- Head: <headRefName>
+   Stats: +<additions> -<deletions> across <changedFiles> files
+
+   ### Description
+   <body>
+
+   ### Changed Files
+   <file list>
+
+   ### Full Diff
+   <diff>
+   ```
+
+4. **Create upstream worktrees (CRITICAL for accurate reviews):**
+
+   Fetch both the base branch and PR head from the upstream repo. Create two worktrees:
+   - **Base worktree** (`<run_dir>/worktree/`): For Claude reviewer — checked out at base branch (upstream main). Claude gets the diff in its prompt and uses the worktree to trace callers/callees.
+   - **PR head worktree** (`<run_dir>/worktree-pr/`): For Codex and Gemini reviewers — checked out at PR head. Both receive the diff in their prompts and can read files from this worktree for additional tracing.
+
+   ```bash
+   # Base worktree (for Claude)
+   # IMPORTANT: Do NOT use --depth=1. The local clone may already be shallow.
+   git fetch https://github.com/<owner>/<repo>.git <baseRefName>
+   git worktree add <run_dir>/worktree FETCH_HEAD --detach
+
+   # PR head worktree (for Codex and Gemini)
+   git fetch https://github.com/<owner>/<repo>.git +pull/<number>/head:refs/tmp/review-pr-head
+   git worktree add <run_dir>/worktree-pr refs/tmp/review-pr-head --detach
+   ```
+
+   - Both worktrees are cleaned up after synthesis.
+   - **Why this matters:** In PR #1288, reviewers flagged `router.go` sites as unmigrated because they were reading the local checkout, which was behind upstream main. The upstream worktree eliminates this class of false positive entirely.
+   - **Premise validation lesson (PR #1648, reverted in #1656):** Both Claude and Codex validated PR #1648's fix without verifying the bug existed. The PR claimed `ForceCloseWithReason` writing to a polecat branch would cause stuck HOOKED beads via merge conflicts. In reality, `MergePolecatBranch` already handles this conflict via `--theirs` resolution (polecat wins). The fix was reverted because it bypassed branch isolation unnecessarily. **Root cause:** reviewers validated the solution's internal consistency without tracing the existing conflict resolution path. All reviewer prompts now include explicit premise-validation guidance.
+   - If `git worktree add` fails (e.g., FETCH_HEAD conflict), fall back to:
+     ```bash
+     git fetch https://github.com/<owner>/<repo>.git +<baseRefName>:refs/tmp/review-base
+     git worktree add <run_dir>/worktree refs/tmp/review-base --detach
+     # Cleanup ref after worktree removal: git update-ref -d refs/tmp/review-base
+     ```
+
+#### Local Branch Mode
+
+1. **Verify branch exists:**
+   ```bash
+   git rev-parse --verify <branch>
+   ```
+   If this fails, stop: `"Branch '<branch>' not found in local repository."`
+
+2. **Resolve the effective base (CRITICAL for fork-based workflows):**
+
+   When working in a fork, the local `main` branch tracks `origin/main` (the fork), not `upstream/main` (the source repo). If the feature branch was created from `upstream/main`, using local `main` as the base produces a massive diff with hundreds of unrelated files from the fork's divergence.
+
+   **If `--base` was explicitly provided**, use it directly — the user knows what they want.
+
+   **If `--base` was NOT provided (auto-detect mode)**, find the best base automatically:
+
+   ```bash
+   # Fetch upstream to ensure refs are current
+   git fetch upstream main 2>/dev/null || true
+
+   # Collect candidate base refs
+   CANDIDATES=""
+   for ref in main upstream/main origin/main; do
+     if git rev-parse --verify "$ref" >/dev/null 2>&1; then
+       CANDIDATES="$CANDIDATES $ref"
+     fi
+   done
+
+   if [ -z "$CANDIDATES" ]; then
+     echo "ERROR: No base branch found. Tried: main, upstream/main, origin/main"
+     exit 1
+   fi
+
+   # Find the most recent merge-base (closest ancestor to the branch).
+   # The right base is the one whose merge-base with the branch is most recent,
+   # because that's where the branch actually diverged from.
+   BEST_BASE=""
+   BEST_MB=""
+   BEST_MB_TIME=0
+   for ref in $CANDIDATES; do
+     MB=$(git merge-base "$ref" <branch> 2>/dev/null) || continue
+     MB_TIME=$(git log -1 --format=%ct "$MB")
+     if [ "$MB_TIME" -gt "$BEST_MB_TIME" ]; then
+       BEST_MB_TIME=$MB_TIME
+       BEST_MB=$MB
+       BEST_BASE=$ref
+     fi
+   done
+
+   EFFECTIVE_BASE="$BEST_BASE"
+   ```
+
+   Report which base was selected:
+   ```
+   [review-pr]   Auto-detected base: <EFFECTIVE_BASE> (merge-base: <BEST_MB short>)
+   ```
+
+   If the auto-detected base differs from `main`, this means the branch was forked from a different ref (typically `upstream/main` in a fork workflow).
+
+3. **Verify commits exist between base and branch:**
+   ```bash
+   git log --oneline <EFFECTIVE_BASE>..<branch>
+   ```
+   If empty, stop: `"No commits between '<EFFECTIVE_BASE>' and '<branch>'. Nothing to review."`
+
+4. **Compute context locally:**
+   ```bash
+   # Full diff (three-dot uses merge-base automatically)
+   git diff <EFFECTIVE_BASE>...<branch>
+
+   # Diff stats
+   git diff --stat <EFFECTIVE_BASE>...<branch>
+
+   # Changed file list
+   git diff --name-only <EFFECTIVE_BASE>...<branch>
+
+   # Title (last commit subject)
+   git log -1 --format=%s <branch>
+
+   # Description (all commit messages between base and branch)
+   git log --reverse --format="* %s%n%n%b" <EFFECTIVE_BASE>..<branch>
+
+   # Author
+   git log -1 --format="%an" <branch>
+   ```
+
+5. **Build the context block** (same structure, different header):
+
+   ```
+   ## Review Context
+
+   Branch: <branch> (vs <EFFECTIVE_BASE>)
+   Author: <author>
+   Stats: +<additions> -<deletions> across <changedFiles> files
+
+   ### Description
+   <commit messages>
+
+   ### Changed Files
+   <file list>
+
+   ### Full Diff
+   <diff>
+   ```
+
+6. **Create local worktrees** (no fetch needed):
+   ```bash
+   # Base worktree (for Claude) — use the merge-base commit for the most accurate "before" state
+   git worktree add <run_dir>/worktree <EFFECTIVE_BASE> --detach
+
+   # Branch head worktree (for Codex and Gemini)
+   git worktree add <run_dir>/worktree-pr <branch> --detach
+   ```
+   - If `git worktree add` fails, report error — review cannot proceed without accurate codebase access.
+
+### Step 3: Save context
+
+Save the context block to `<run_dir>/context/pr-context.md`.
+
+### Step 4: Write PTY wrapper scripts
+
+Write to `<run_dir>/scripts/` (see Agent Invocations below):
+- `aimux-claude.sh` — PTY wrapper for Claude invocations
+- `aimux-codex.sh` — PTY wrapper for Codex invocations
+- `aimux-gemini.sh` — PTY wrapper for Gemini invocations (skip if `--skip-gemini`)
+
+### Step 5: Pre-flight check (parallel)
+
+Verify required agents are available. All preflight checks are independent — run them concurrently to save ~20-30s:
+```bash
+echo "Reply ONLY with: ok" > <run_dir>/prompts/preflight_claude.md
+echo "Reply ONLY with: ok" > <run_dir>/prompts/preflight_codex.md
+
+bash <run_dir>/scripts/aimux-claude.sh <run_dir>/prompts/preflight_claude.md /tmp/claude_preflight.txt &
+CLAUDE_PF=$!
+
+bash <run_dir>/scripts/aimux-codex.sh <run_dir>/prompts/preflight_codex.md /tmp/codex_preflight.txt &
+CODEX_PF=$!
+
+# Skip Gemini preflight if --skip-gemini
+if [ "$SKIP_GEMINI" != "true" ]; then
+  echo "Reply ONLY with: ok" > <run_dir>/prompts/preflight_gemini.md
+  bash <run_dir>/scripts/aimux-gemini.sh <run_dir>/prompts/preflight_gemini.md /tmp/gemini_preflight.txt &
+  GEMINI_PF=$!
+fi
+
+# Wait for all preflight checks
+if [ "$SKIP_GEMINI" = "true" ]; then
+  wait $CLAUDE_PF $CODEX_PF
+else
+  wait $CLAUDE_PF $CODEX_PF $GEMINI_PF
+fi
+
+# Validate all required preflights succeeded (non-empty output)
+cat /tmp/claude_preflight.txt
+cat /tmp/codex_preflight.txt
+if [ "$SKIP_GEMINI" != "true" ]; then
+  cat /tmp/gemini_preflight.txt
+fi
+```
+If any required agent fails, stop: `"Required agent <name> is not available. Check aimux status."`
+
+---
+
+## Phase 2: Parallel Review
+
+Build prompts, save them, then invoke all three reviewers in parallel. The process is identical for both modes — only the context block header differs (PR mode: `PR #<number>: <title>`, local branch mode: `Branch: <branch> (vs <base>)`).
+
+### Step 2a: Build Prompts
+
+**Claude prompt** — full context including diff (Claude receives the diff in-prompt):
+1. The claude-reviewer role prompt (see Reviewer Prompts below)
+2. The full PR context block from Phase 1 (metadata + diff)
+Save to: `<run_dir>/prompts/claude-reviewer.md`
+
+**Codex prompt** — full context including diff (same as Claude):
+1. The codex-reviewer role prompt (see Reviewer Prompts below)
+2. The full PR context block from Phase 1 (metadata + diff)
+Save to: `<run_dir>/prompts/codex-reviewer.md`
+
+**Gemini prompt** (skip if `--skip-gemini`) — full context including diff (same as Claude/Codex):
+1. The gemini-reviewer role prompt (see Reviewer Prompts below)
+2. The full PR context block from Phase 1 (metadata + diff)
+Save to: `<run_dir>/prompts/gemini-reviewer.md`
+
+> **Why `exec` with prompt, not `exec review --base`?** (Updated 2026-02-13):
+> - `--base` and `[PROMPT]` are **mutually exclusive** (confirmed: Codex returns error `the argument '--base <BRANCH>' cannot be used with '[PROMPT]'`).
+> - `exec review --base` consistently spends all capacity on codebase research (reading files, tracing callers) without producing a final review. The diff is included in the prompt so Codex doesn't need to compute it.
+> - This also eliminates the shallow clone / `git merge-base` failure that plagued `--base`.
+
+### Step 2b: Invoke in Parallel
+
+All reviewers use PTY wrapper scripts for output capture. Claude runs from the base worktree. Codex (and Gemini, unless `--skip-gemini`) run from the PR head worktree. All can read files from their respective worktrees for caller/callee tracing.
+
+```bash
+BASE_WORKTREE="<run_dir>/worktree"
+PR_WORKTREE="<run_dir>/worktree-pr"
+
+# Claude (via PTY wrapper) -- run in background from BASE worktree
+cd "$BASE_WORKTREE" && bash <run_dir>/scripts/aimux-claude.sh \
+  <run_dir>/prompts/claude-reviewer.md \
+  <run_dir>/outputs/claude-review.md &
+CLAUDE_PID=$!
+
+# Codex (via PTY wrapper) -- run in background from PR HEAD worktree.
+cd "$PR_WORKTREE" && bash <run_dir>/scripts/aimux-codex.sh \
+  <run_dir>/prompts/codex-reviewer.md \
+  <run_dir>/outputs/codex-review.md &
+CODEX_PID=$!
+
+# Gemini (via PTY wrapper) -- skip if --skip-gemini
+if [ "$SKIP_GEMINI" != "true" ]; then
+  cd "$PR_WORKTREE" && bash <run_dir>/scripts/aimux-gemini.sh \
+    <run_dir>/prompts/gemini-reviewer.md \
+    <run_dir>/outputs/gemini-review.md &
+  GEMINI_PID=$!
+fi
+
+# Wait for all reviewers
+if [ "$SKIP_GEMINI" = "true" ]; then
+  wait $CLAUDE_PID $CODEX_PID
+else
+  wait $CLAUDE_PID $CODEX_PID $GEMINI_PID
+fi
+```
+
+### Step 2c: Validate Outputs
+
+- `<run_dir>/outputs/claude-review.md` must be non-empty.
+- `<run_dir>/outputs/codex-review.md` must be non-empty.
+- `<run_dir>/outputs/gemini-review.md` must be non-empty (skip check if `--skip-gemini`).
+- If any required output is empty, report failure and stop.
+
+---
+
+## Phase 3: Synthesis
+
+Read all three review outputs and produce the final report.
+
+### Steps
+
+1. **Read** all reviewer outputs (2 if `--skip-gemini`, otherwise 3).
+2. **Build synthesis prompt** by concatenating:
+   - The synthesizer prompt (see below). If `--skip-gemini`, use the dual-model variant (see [Dual-Model Synthesizer Adjustments](#dual-model-synthesizer-adjustments) below).
+   - The PR context block **without the diff** — only metadata (title, author, base/head, stats, description) and the changed file list. The synthesizer merges findings; it doesn't need the raw diff.
+   - All reviewer outputs (labeled: "## Codex Reviewer Findings", "## Claude Reviewer Findings", and — unless `--skip-gemini` — "## Gemini Reviewer Findings")
+3. **Save** to `<run_dir>/prompts/synthesizer.md`.
+4. **Invoke Claude** for synthesis (Claude is better at reasoning-heavy merge tasks):
+   ```bash
+   bash <run_dir>/scripts/aimux-claude.sh \
+     <run_dir>/prompts/synthesizer.md \
+     <run_dir>/outputs/synthesis.md
+   ```
+5. **Clean up worktrees:**
+   ```bash
+   git worktree remove <run_dir>/worktree --force 2>/dev/null || true
+   git worktree remove <run_dir>/worktree-pr --force 2>/dev/null || true
+   # Clean up temporary refs (PR mode only — local branch mode has no temp refs):
+   git update-ref -d refs/tmp/review-base 2>/dev/null || true
+   git update-ref -d refs/tmp/review-pr-head 2>/dev/null || true
+   ```
+6. **Present** the synthesis to the user.
+
+---
+
+## Phase 4: Post to GitHub (PR Mode Only)
+
+**Local branch mode: Phase 4 is skipped entirely. Present the synthesis directly as the final output.**
+
+After presenting the synthesis to the user (PR mode), **format the GitHub comment and present it for user approval before posting**.
+
+### Pre-Comment Presentation
+
+Before showing the formatted comment, present a concise decision stanza:
+
+```
+# PR Review: <title> (#<number>)
+
+## Decision: <approve|take-the-good|request_changes|block>
+
+<1-3 sentence plain-English summary of the PR quality and key takeaways from the review. State the decision rationale.>
+
+**Salvage path:** [if take-the-good] WE adopt + apply fixups + merge — name which findings we fix and why no author input is needed.
+
+**Fixes Validated:** [if applicable]
+- <fix description>: correct/incomplete/wrong
+
+**New Findings:** [only issues WITH the PR, not bugs the PR fixes]
+1. **<Severity> (<confidence> confidence, <source(s)>):** <one-line summary>
+[repeat for each NEW finding]
+```
+
+**IMPORTANT:** Do NOT list pre-existing bugs that the PR fixes as "findings." Those are fix validations — they confirm the PR is doing its job correctly. Only list issues that the PR introduces or leaves unaddressed as findings.
+
+Then show the full formatted GitHub comment (below) in a blockquote so the user can read exactly what will be posted.
+
+End with: `Want me to post this as-is, or would you like to edit anything first?`
+
+Only post via `gh pr comment` after the user explicitly confirms. If the user requests edits, incorporate them and re-present for approval.
+
+### GitHub Comment Format
+
+The comment must follow this exact structure. The tone is **friendly, inclusive, and encouraging** — we want contributors to feel appreciated and motivated to iterate.
+
+```markdown
+## Automated PR Review — <MODE_LABEL>
+
+Where `<MODE_LABEL>` is:
+- Triple-model: `Triple-Model (Claude + Codex + Gemini)`
+- Dual-model (`--skip-gemini`): `Dual-Model (Claude + Codex)`
+
+### Decision: <approve | take-the-good | request_changes | block>
+
+<opening paragraph: 2-3 sentences thanking the contributor for the work, acknowledging the problem is real and worth solving, and noting what's good about the approach. Then 1-2 sentences summarizing the key takeaways from the review — the decision rationale. Be genuine, not formulaic.>
+
+[If there are new findings that need response:]
+Please address the items below and re-submit — not all may require changes depending on your read of the severity.
+
+---
+
+[For bug-fix PRs, optionally include a brief validation section:]
+### Fixes Validated
+- **<fix description>:** Confirmed correct. <1-sentence explanation of why the fix is right.>
+[repeat for each validated fix — keep these brief, 1-2 lines each]
+
+---
+
+[Then list ONLY new findings — issues with the PR itself, NOT pre-existing bugs it fixes:]
+
+### <Severity>: <One-line title>
+**Source:** <codex|claude|gemini|claude+codex|claude+gemini|codex+gemini|all>, <confidence> confidence
+
+<2-4 sentence explanation of the issue in plain language. No jargon walls. Explain the concrete failure scenario.>
+
+**Suggested fix:** <concrete action>
+
+[repeat for each NEW finding, ordered by severity: blocker → major → minor → nit]
+
+---
+
+### Pre-Merge Checklist
+- [ ] <derived from NEW findings only>
+
+---
+_🤖 Generated by automated review pipeline (<MODEL_LIST>)_
+
+Where `<MODEL_LIST>` is:
+- Triple-model: `Claude Opus 4.6 + GPT-5.3 Codex + Gemini 3 Pro`
+- Dual-model (`--skip-gemini`): `Claude Opus 4.6 + GPT-5.3 Codex`
+```
+
+### Format Rules
+
+1. **Compact, not verbose.** Each finding is one `###` heading + a short paragraph + suggested fix. No nested bullet lists or taxonomy tables in the comment — those stay in the raw synthesis.
+2. **Severity in the heading.** Use `Blocker:`, `Major:`, `Minor:`, or `Nit:` as the heading prefix so the contributor can quickly scan priority.
+3. **Source and confidence inline.** Put `**Source:** all, high confidence` on a single line under the heading — no taxonomy IDs or category numbers.
+4. **Plain language.** Explain *what breaks* and *when*, not abstract category names. The contributor may not know gastown internals.
+5. **No "No Finding" sections.** Only list things that need attention. Clean categories are omitted.
+6. **Encourage response.** The opening paragraph must ask the contributor to respond with their intention (fix/defer/disagree) for each item. Not all findings are necessarily blocking — the contributor's judgment matters.
+7. **Friendly closer.** End with the robot emoji footer attributing the pipeline.
+8. **Fix validations are NOT findings.** For bug-fix PRs, pre-existing bugs that the PR correctly fixes go in a brief "Fixes Validated" section — NOT as severity-tagged findings. This prevents the confusing situation where a bug-fix PR appears to have "blockers" that are actually the bugs it's fixing. Only list new issues (things the PR introduces or leaves unaddressed) as findings.
+
+### Tone Guidelines
+
+- **Thank first.** Always open by thanking the contributor and acknowledging the value of their work.
+- **Affirm the approach.** Note what's good about the direction before listing concerns.
+- **Collaborative, not gatekeeping.** Frame findings as "things to consider" not "things you got wrong." Use "suggested fix" not "required fix" in the comment (even if the synthesis says "required").
+- **Invite dialogue.** Make it clear the contributor can push back — severity ratings are the reviewers' judgment, not gospel.
+- **Encourage future contributions.** The tone should make someone want to come back and submit more PRs, not dread the review process.
+
+---
+
+## Agent Invocations
+
+### Claude PTY Wrapper (REQUIRED)
+
+**Claude CLI requires a TTY** to produce output. When stdout is a plain file or pipe, it hangs silently with 0 bytes. All Claude invocations MUST use the PTY wrapper script.
+
+**Critical environment fixes (learned 2026-02-13):**
+- **`unset CLAUDECODE`** — Claude Code refuses to launch inside another Claude Code session (detects via `CLAUDECODE` env var). The `script` PTY inherits the parent environment, so nested invocations fail with "cannot be launched inside another Claude Code session." Unsetting this var in the `script -c` command fixes it.
+- **`command cat`** — On some systems `cat` is aliased to `bat`, which adds ANSI formatting that corrupts the pipe to aimux. Using `command cat` bypasses aliases.
+
+**Stream-JSON output format (learned 2026-02-13):**
+- Claude's `--output-format stream-json` produces TWO different event formats depending on whether Claude uses tools:
+  - **No tool use:** `stream_event` events with `content_block_delta` / `text_delta` — the original parser handled this.
+  - **Multi-turn with tool use:** `assistant` events with `message.content[].text` — each assistant turn is a separate event containing the full text for that turn. The review content is in the longest text block that contains `##` markers.
+- The parser MUST handle both formats. Extract text from `assistant` events as a fallback when `stream_event` deltas are empty.
+
+Write this to `<run_dir>/scripts/aimux-claude.sh` during Phase 1:
+
+```bash
+#!/usr/bin/env bash
+# aimux-claude.sh — PTY-wrapped Claude invocation via aimux
+# Usage: aimux-claude.sh <prompt_file> <output_file> [timeout_seconds]
+set -euo pipefail
+
+PROMPT_FILE="$1"
+OUTPUT_FILE="$2"
+TIMEOUT="${3:-600}"
+
+if [[ ! -f "$PROMPT_FILE" ]]; then
+  echo "ERROR: Prompt file not found: $PROMPT_FILE" >&2
+  exit 1
+fi
+
+LOG_FILE=$(mktemp /tmp/claude-pty-XXXXXX.log)
+trap 'rm -f "$LOG_FILE"' EXIT
+
+timeout "$TIMEOUT" script -q -e -f -c \
+  "unset CLAUDECODE; command cat '$PROMPT_FILE' | aimux run claude -p --verbose --model opus --output-format stream-json -- -" \
+  "$LOG_FILE" > /dev/null 2>&1 || true
+
+python3 -c '
+import json, re, sys
+
+text = open(sys.argv[1], "r", errors="replace").read()
+text = re.sub(r"^Script (started|done) on .*\n?", "", text, flags=re.MULTILINE)
+text = re.sub(r"\x1bP[^\x1b]*\x1b\\\\", "", text)
+text = re.sub(r"\x1b\][^\x07\x1b]*(?:\x07|\x1b\\\\)", "", text)
+text = re.sub(r"\x1b\[[\x20-\x3f]*[\x40-\x7e]", "", text)
+text = re.sub(r"\x1b[()][A-Za-z0-9]", "", text)
+text = re.sub(r"\x1b[\x40-\x7e]", "", text)
+text = text.replace("\r", "")
+
+result = None
+content_deltas = []
+assistant_texts = []
+
+for line in text.splitlines():
+    line = line.strip()
+    if not line:
+        continue
+    try:
+        event = json.loads(line)
+        if not isinstance(event, dict):
+            continue
+        etype = event.get("type")
+        if etype == "result":
+            result = event.get("result", "")
+        elif etype == "stream_event":
+            inner = event.get("event", {})
+            if inner.get("type") == "content_block_delta":
+                delta = inner.get("delta", {})
+                if delta.get("type") == "text_delta":
+                    content_deltas.append(delta.get("text", ""))
+        elif etype == "assistant":
+            msg = event.get("message", {})
+            if isinstance(msg, dict):
+                content = msg.get("content", [])
+                if isinstance(content, list):
+                    for block in content:
+                        if isinstance(block, dict):
+                            t = block.get("text", "")
+                            if t:
+                                assistant_texts.append(t)
+    except (json.JSONDecodeError, ValueError, AttributeError):
+        pass
+
+# Priority: stream deltas > assistant text blocks > result > raw text
+all_deltas = "".join(content_deltas)
+if all_deltas:
+    out = all_deltas
+elif assistant_texts:
+    # Use the longest assistant text block containing review markers
+    review_blocks = [t for t in assistant_texts if "##" in t and len(t) > 500]
+    if review_blocks:
+        out = max(review_blocks, key=len)
+    else:
+        out = max(assistant_texts, key=len)
+elif result is not None:
+    out = result
+else:
+    out = text
+sys.stdout.write(out)
+' "$LOG_FILE" > "$OUTPUT_FILE"
+
+if [[ ! -s "$OUTPUT_FILE" ]]; then
+  echo "ERROR: Claude produced empty output. Check aimux status." >&2
+  tail -50 "$LOG_FILE" >&2 || true
+  exit 1
+fi
+```
+
+Make executable: `chmod +x <run_dir>/scripts/aimux-claude.sh`
+
+### Codex PTY Wrapper (REQUIRED)
+
+**Codex `exec -o` does NOT work for large review prompts.** Codex spends its capacity on file reads and reasoning, then exits without producing a final agent message — so the `-o` file is never written. This was verified across multiple runs on PR #1226 (83KB+ prompt). The fix is PTY capture via `script`, same pattern as Claude.
+
+**Key design decisions (verified 2026-02-13):**
+- Use `exec` (not `exec review --base`). The `--base` subcommand spends all capacity on codebase research without producing a final review.
+- **Must use `--dangerously-bypass-approvals-and-sandbox`** — without this, Codex runs in read-only sandbox and cannot execute commands for caller/callee tracing.
+- **Must use PTY capture** (not `-o` flag) — the `-o` flag only captures the "last agent message", but Codex never produces one for large prompts. PTY capture gets all output including intermediate "codex" blocks.
+- Include the full diff in the prompt so Codex doesn't need to compute it.
+- Use `-c model_reasoning_effort='"xhigh"'` for maximum reasoning depth.
+- Pipe the prompt via `cat <file> | ... -- -` (not stdin redirect `-- - < file`).
+
+Write this to `<run_dir>/scripts/aimux-codex.sh` during Phase 1:
+
+```bash
+#!/usr/bin/env bash
+# aimux-codex.sh — PTY-wrapped Codex invocation via aimux
+# Usage: aimux-codex.sh <prompt_file> <output_file> [timeout_seconds]
+set -euo pipefail
+
+PROMPT_FILE="$1"
+OUTPUT_FILE="$2"
+TIMEOUT="${3:-600}"
+
+if [[ ! -f "$PROMPT_FILE" ]]; then
+  echo "ERROR: Prompt file not found: $PROMPT_FILE" >&2
+  exit 1
+fi
+
+LOG_FILE=$(mktemp /tmp/codex-pty-XXXXXX.log)
+trap 'rm -f "$LOG_FILE"' EXIT
+
+# Build the command in a temp file (avoids quoting issues with script -c)
+CMD_FILE=$(mktemp /tmp/codex-cmd-XXXXXX.sh)
+printf 'unset CLAUDECODE; command cat %q | aimux run codex -m gpt-5.3-codex exec --dangerously-bypass-approvals-and-sandbox -c model_reasoning_effort='"'"'"xhigh"'"'"' -- -\n' "$PROMPT_FILE" > "$CMD_FILE"
+chmod +x "$CMD_FILE"
+
+timeout "$TIMEOUT" script -q -e -f -c "bash '$CMD_FILE'" "$LOG_FILE" > /dev/null 2>&1 || true
+
+rm -f "$CMD_FILE"
+
+# Extract "codex" blocks (agent messages) from the PTY log.
+# The longest block is the actual review content.
+# Note: Codex sometimes outputs the review twice (with a "tokens used" separator).
+# The "longest block" heuristic deduplicates this automatically.
+python3 -c '
+import re, sys
+
+text = open(sys.argv[1], "r", errors="replace").read()
+
+# Strip script header/footer
+text = re.sub(r"^Script (started|done) on .*\n?", "", text, flags=re.MULTILINE)
+
+# Strip ANSI escape sequences
+text = re.sub(r"\x1bP[^\x1b]*\x1b\\\\", "", text)
+text = re.sub(r"\x1b\][^\x07\x1b]*(?:\x07|\x1b\\\\)", "", text)
+text = re.sub(r"\x1b\[[\x20-\x3f]*[\x40-\x7e]", "", text)
+text = re.sub(r"\x1b[()][A-Za-z0-9]", "", text)
+text = re.sub(r"\x1b[\x40-\x7e]", "", text)
+text = text.replace("\r", "")
+
+# Find all "codex" blocks — these are agent messages
+blocks = []
+lines = text.split("\n")
+in_codex_block = False
+current_block = []
+
+for line in lines:
+    stripped = line.strip()
+    if stripped == "codex":
+        if current_block and in_codex_block:
+            blocks.append("\n".join(current_block))
+        in_codex_block = True
+        current_block = []
+    elif in_codex_block and stripped in ("thinking", "exec", "user"):
+        blocks.append("\n".join(current_block))
+        in_codex_block = False
+        current_block = []
+    elif in_codex_block:
+        current_block.append(line)
+
+if in_codex_block and current_block:
+    blocks.append("\n".join(current_block))
+
+if blocks:
+    # Output the longest codex block (the actual review)
+    longest = max(blocks, key=len)
+    sys.stdout.write(longest.strip() + "\n")
+else:
+    # Fallback: output everything
+    sys.stdout.write(text)
+' "$LOG_FILE" > "$OUTPUT_FILE"
+
+if [[ ! -s "$OUTPUT_FILE" ]]; then
+  echo "ERROR: Codex produced empty output. Check aimux status." >&2
+  tail -50 "$LOG_FILE" >&2 || true
+  exit 1
+fi
+```
+
+Make executable: `chmod +x <run_dir>/scripts/aimux-codex.sh`
+
+> **Historical note (2026-02-13):** The original approach used `codex exec -o <file>` to capture the last agent message. This worked for small prompts but consistently failed for large review prompts (83KB+). Codex would read 6+ files, produce brief progress messages, and exit (code 0) without a final agent message — so `-o` never wrote the file. The PTY capture approach (matching Forge's `agent-wrapper.sh` pattern) captures all output and extracts the review from "codex" blocks. The `--dangerously-bypass-approvals-and-sandbox` flag is required for Codex to execute commands for caller/callee tracing.
+
+### Gemini PTY Wrapper (REQUIRED)
+
+**Gemini is invoked via `aimux run gemini`**, matching the pattern used for Claude and Codex. Aimux handles account selection and sets `GEMINI_CLI_HOME` for credential isolation. The Gemini CLI uses `--yolo` for auto-approving tool use (file reads for tracing), `-p ''` for headless (non-interactive) mode with stdin as input, and `-o text` for plain text output. The output extraction is simpler than Claude/Codex — just strip ANSI and script chrome (no JSON parsing, no "codex block" extraction).
+
+Write this to `<run_dir>/scripts/aimux-gemini.sh` during Phase 1:
+
+```bash
+#!/usr/bin/env bash
+# aimux-gemini.sh — PTY-wrapped Gemini invocation via aimux
+# Usage: aimux-gemini.sh <prompt_file> <output_file> [timeout_seconds]
+set -euo pipefail
+
+PROMPT_FILE="$1"
+OUTPUT_FILE="$2"
+TIMEOUT="${3:-600}"
+
+if [[ ! -f "$PROMPT_FILE" ]]; then
+  echo "ERROR: Prompt file not found: $PROMPT_FILE" >&2
+  exit 1
+fi
+
+LOG_FILE=$(mktemp /tmp/gemini-pty-XXXXXX.log)
+trap 'rm -f "$LOG_FILE"' EXIT
+
+timeout "$TIMEOUT" script -q -e -f -c \
+  "command cat '$PROMPT_FILE' | aimux run gemini -- -m gemini-3-pro-preview --yolo -o text -p ''" \
+  "$LOG_FILE" > /dev/null 2>&1 || true
+
+# Extract clean text from PTY log (strip ANSI + script chrome)
+python3 -c '
+import re, sys
+
+text = open(sys.argv[1], "r", errors="replace").read()
+text = re.sub(r"^Script (started|done) on .*\n?", "", text, flags=re.MULTILINE)
+text = re.sub(r"\x1bP[^\x1b]*\x1b\\\\", "", text)
+text = re.sub(r"\x1b\][^\x07\x1b]*(?:\x07|\x1b\\\\)", "", text)
+text = re.sub(r"\x1b\[[\x20-\x3f]*[\x40-\x7e]", "", text)
+text = re.sub(r"\x1b[()][A-Za-z0-9]", "", text)
+text = re.sub(r"\x1b[\x40-\x7e]", "", text)
+text = text.replace("\r", "")
+sys.stdout.write(text.strip() + "\n")
+' "$LOG_FILE" > "$OUTPUT_FILE"
+
+if [[ ! -s "$OUTPUT_FILE" ]]; then
+  echo "ERROR: Gemini produced empty output. Check aimux status." >&2
+  tail -50 "$LOG_FILE" >&2 || true
+  exit 1
+fi
+```
+
+Make executable: `chmod +x <run_dir>/scripts/aimux-gemini.sh`
+
+---
+
+## Shared Taxonomy
+
+All three reviewers use this exact category taxonomy and priority ranking:
+
+| Priority | # | Category | Why it catches regressions |
+|----------|---|----------|---------------------------|
+| P0 | 1 | Behavioral Correctness | Logic bugs, edge cases, off-by-ones, nil derefs |
+| P0 | 2 | Contract & Interface Fidelity | Broken caller expectations, schema violations |
+| P0 | 3 | Change Impact / Blast Radius | Incomplete updates across callsites |
+| P0 | 4 | Concurrency, Ordering & State Safety | Races, deadlocks, ordering violations |
+| P1 | 5 | Error Handling & Resilience | Swallowed errors, missing retries/timeouts |
+| P1 | 6 | Security Surface | Injection, path traversal, secret leakage |
+| P1 | 7 | Resource Lifecycle & Cleanup | Leaked files, sessions, goroutines, worktrees |
+| P1 | 8 | Release Safety | Migration risk, rollback blockers, state corruption |
+| P2 | 9 | Test Evidence Quality | Changed behavior without test coverage |
+| P2 | 10 | Architectural Consistency | Pattern drift, role boundary violations |
+| P2 | 11 | Debuggability & Operability | Missing diagnostic output for failure investigation |
+
+### Severity Scale
+
+| Severity | Meaning | Action |
+|----------|---------|--------|
+| `blocker` | Will break existing behavior or corrupt state | Must fix before merge |
+| `major` | High risk of regression under realistic conditions | Should fix before merge |
+| `minor` | Low probability issue, but real mechanism exists | Fix or explicitly accept |
+| `nit` | Improvement opportunity with no regression risk | Optional |
+
+### Confidence Scale
+
+| Confidence | Meaning |
+|------------|---------|
+| `high` | Concrete evidence in code, reproducible reasoning |
+| `medium` | Strong signal but depends on runtime conditions |
+| `low` | Plausible concern, needs human verification |
+
+---
+
+## Reviewer Prompts
+
+### codex-reviewer
+
+This prompt is passed to Codex via PTY-wrapped `exec` along with the full context block (metadata + diff). Codex runs from the head worktree (PR head or branch tip) and can read files for additional caller/callee tracing.
+
+```
+You are "codex-reviewer" for a code review in the gastown codebase.
+
+Gastown is a Go-based multi-agent orchestration system. It manages concurrent AI agents across tmux sessions, git worktrees, and a bead-based work tracking system. Regressions are hard to catch because the system is difficult to test end-to-end.
+
+## Mission
+
+Produce a high-signal, evidence-first review focused on concrete code impact and repo-wide traceability. Your strength is indexing and tracing -- use it. Find every caller, every test, every contract touchpoint.
+
+IMPORTANT: You MUST produce a final review with findings. Do NOT spend all your time reading files. The diff below contains all changed code. Focus your analysis on the diff itself. Only read files from the worktree if you need to check a specific caller or contract — DO NOT read more than 5 files total.
+
+## Category Taxonomy (use exactly)
+
+1) Behavioral Correctness
+2) Contract & Interface Fidelity
+3) Change Impact / Blast Radius
+4) Concurrency, Ordering & State Safety
+5) Error Handling & Resilience
+6) Security Surface
+7) Resource Lifecycle & Cleanup
+8) Release Safety
+9) Test Evidence Quality
+10) Architectural Consistency
+11) Debuggability & Operability
+
+Priority: P0 = categories 1-4 (aggressively check). P1 = 5-8. P2 = 9-11.
+
+## How to Work
+
+### Codebase Access
+You are running from a git worktree checked out at the PR head. The full diff is included in this prompt. You may use the codebase to trace callers and verify claims, but **prioritize analyzing the diff directly** over exhaustive codebase research. The diff contains all changed code — focus your analysis there.
+
+### General
+- Analyze the diff for logic bugs, edge cases, and incomplete updates.
+- Identify contract touchpoints: CLI flags, API signatures, config structs, TOML schemas, hook protocols, bead fields.
+- Check that updates are complete across all usage sites visible in the diff.
+- Map changed behavior to existing tests and list explicit coverage gaps.
+- Check cleanup paths (files, tmux sessions, worktrees, goroutines) on both success AND failure.
+- Check that error messages and log output remain useful for debugging.
+
+### Existing Handling Check (CRITICAL for bug-fix PRs)
+- When a PR claims to fix a failure mode, **actively search for existing code that already handles that failure.** This is your highest-priority tracing task for bug-fix PRs.
+- Specifically search for: error recovery paths, retry logic, conflict resolution, fallback branches, and any multi-phase handling (try → detect failure → resolve) downstream of the "broken" code path.
+- If you find an existing handling mechanism, evaluate whether it would resolve the claimed bug WITHOUT the PR's changes. Cite the handler with path:line evidence.
+- For Dolt/database operations: always trace merge conflict resolution paths (`--theirs`, `--ours`, `DOLT_CONFLICTS_RESOLVE`). These are specifically designed to handle divergent branch state.
+- Include your findings in the Evidence Bundle under a new field: **Existing handlers checked:** [list with path:line, or "none found"]
+
+### Gastown-Specific Invariants
+- **Formula TOML contracts:** Step dependencies must form a DAG. No orphan steps. Variable references (Go text/template) must resolve. New steps must appear in TopologicalSort output.
+- **Role boundaries:** Polecats never touch main branch. Refinery never creates worktrees. Deacon never merges. Witness never does implementation work. Mayor never spawns polecats directly.
+- **Hook/bead protocol:** `bd ready`/`bd close` must be paired. Bead sync must happen before `gt done`. Hook environment variables must be set before agent spawn.
+- **Agent preset contracts:** `AgentPresetInfo` fields (SessionIDEnv, ResumeFlag, ResumeStyle, SupportsHooks) must match actual CLI behavior of the agent binary.
+- **Self-cleaning contract:** Polecats must call `gt done` which syncs beads, nukes worktree, and exits. No partial cleanup.
+- **Tmux session management:** Session names must be deterministic. Pane targeting must handle "no sessions" and "no current target" errors.
+
+## Output Format
+
+**CRITICAL: Separate fix validations from new findings.**
+
+Bug-fix PRs will have two classes of observations:
+1. **Fix Validations** — pre-existing bugs that the PR correctly fixes. These are NOT problems with the PR. List them to confirm correctness, but they do NOT count as findings.
+2. **New Findings** — issues introduced by the PR itself, or remaining issues that the PR should address. These ARE problems with the PR.
+
+Start with "## Fix Validations" (if the PR fixes bugs):
+```
+### <what was broken>
+- **Status:** correct | incomplete | wrong
+- **Evidence:** path:line
+- **Assessment:** [1-2 sentences confirming the fix is correct, or explaining why it's incomplete/wrong]
+```
+
+Then "## Findings" for NEW issues only:
+
+For each finding:
+```
+### [Category Name]
+- **Severity:** blocker|major|minor|nit
+- **Confidence:** high|medium|low
+- **Evidence:** path:line[, path:line]
+- **Why it matters:** [one sentence]
+- **Suggested fix:** [concrete action]
+```
+
+Then "## No Finding" for categories with no issues (list them explicitly).
+
+End with:
+## Evidence Bundle
+- **Changed hot paths:** [list]
+- **Impacted callers:** [list with path:line]
+- **Impacted tests:** [list with path:line]
+- **Unresolved uncertainty:** [list]
+
+## Constraints
+- No style/formatting issues unless they create behavioral risk.
+- No invented behavior -- cite code evidence for every claim. **Search the codebase** to back up claims about callers, patterns, or missing migrations.
+- Prefer precise path:line references over broad claims.
+- Fewer high-signal findings >> exhaustive speculative lists.
+- **Do NOT list pre-existing bugs that the PR fixes as "findings".** Those go under Fix Validations.
+```
+
+### claude-reviewer
+
+```
+You are "claude-reviewer" for a code review in the gastown codebase.
+
+Gastown is a Go-based multi-agent orchestration system. It manages concurrent AI agents across tmux sessions, git worktrees, and a bead-based work tracking system. Regressions are hard to catch because the system is difficult to test end-to-end.
+
+## Mission
+
+Produce a high-signal, reasoning-heavy review focused on intent fidelity, invariant safety, and subtle regression risk. Your strength is deep reasoning about correctness under edge conditions -- use it. Think about what happens when things fail halfway, when concurrent operations interleave, when assumptions don't hold.
+
+## Category Taxonomy (use exactly)
+
+1) Behavioral Correctness
+2) Contract & Interface Fidelity
+3) Change Impact / Blast Radius
+4) Concurrency, Ordering & State Safety
+5) Error Handling & Resilience
+6) Security Surface
+7) Resource Lifecycle & Cleanup
+8) Release Safety
+9) Test Evidence Quality
+10) Architectural Consistency
+11) Debuggability & Operability
+
+Priority: P0 = categories 1-4 (gatekeepers). P1 = 5-8. P2 = 9-11.
+
+## How to Work
+
+### Codebase Access
+You are running from a git worktree checked out at the base branch, which represents the authoritative codebase state before the changes. Use your tools (grep, find, read) freely to trace callers, callees, dependencies, and existing patterns. The diff is included in the prompt below — the worktree shows the codebase *before* the changes.
+
+### General
+- Evaluate whether implementation matches claimed PR intent. Flag divergence.
+- Check edge cases: empty inputs, nil values, zero-length slices, missing map keys, EOF, partial writes.
+- Check negative paths: what happens when the operation fails halfway? Is state left consistent?
+- Validate ordering assumptions under concurrent execution. If two goroutines or agents could race on shared state, flag it.
+- Inspect contract safety: backward compatibility of exported functions, schema/protocol stability, caller expectations preserved. **Search the codebase** to find callers of changed functions.
+- Threat-model trust boundaries: user input → exec.Command, file paths → os.Open, template data → TOML injection.
+- Assess rollback safety: could this change be reverted cleanly? Does it introduce persistent state that survives rollback?
+- Check operational diagnosability: if this change breaks in production, can you tell what happened from logs and bead state?
+
+### Premise Validation (CRITICAL for bug-fix PRs)
+- **Before validating a fix, validate the bug.** If the PR claims "X causes Y failure", trace the full execution path to verify Y actually occurs without this PR. Do NOT take the PR description's failure narrative at face value.
+- Search for existing handling mechanisms downstream: error recovery, conflict resolution (e.g., `--theirs` merge strategies), retry logic, fallback paths. The codebase may already handle the failure through a different code path that the PR author missed.
+- Ask: "If I remove this entire PR, does the claimed failure actually happen?" Trace end-to-end, across files.
+- Flag if the PR bypasses an existing mechanism (e.g., writing directly to a data store instead of going through the established merge/conflict-resolution pipeline). Even if the bypass "works", it breaks architectural contracts.
+- When you cannot fully verify the premise, mark the Fix Validation as `incomplete` with a note explaining what you couldn't trace, rather than defaulting to `correct`.
+
+### Gastown-Specific Invariants
+- **Formula TOML contracts:** Step dependencies must form a DAG. No orphan steps. Variable references (Go text/template) must resolve. Changed steps must not break TopologicalSort or ReadySteps computation.
+- **Role boundaries:** Polecats never touch main. Refinery never creates worktrees. Deacon never merges. Witness never implements. Mayor never spawns polecats directly. Violations are silent and catastrophic.
+- **Hook/bead protocol:** `bd ready`/`bd close` pairing. Bead sync before `gt done`. Hook env vars set before agent spawn. Violation means lost work or phantom state.
+- **Agent preset contracts:** `AgentPresetInfo` fields must match real CLI behavior. Wrong ResumeStyle = broken session resume. Wrong SupportsHooks = silent hook failure.
+- **Self-cleaning contract:** Polecats call `gt done` → sync beads → nuke worktree → exit. Partial cleanup leaves zombie worktrees that corrupt future operations.
+- **Tmux session management:** Session names deterministic. Pane targeting handles edge cases. Race between session creation and pane targeting is a known fragile area.
+- **Merge queue (Refinery):** Only Refinery merges to main. Merge ordering must respect dependency graph. Conflict resolution spawns fresh polecats, never retries in-place.
+
+## Output Format
+
+**CRITICAL: Separate fix validations from new findings.**
+
+Bug-fix PRs will have two classes of observations:
+1. **Fix Validations** — pre-existing bugs that the PR correctly fixes. These are NOT problems with the PR. List them to confirm correctness, but they do NOT count as findings.
+2. **New Findings** — issues introduced by the PR itself, or remaining issues that the PR should address. These ARE problems with the PR.
+
+Start with "## Fix Validations" (if the PR fixes bugs):
+```
+### <what was broken>
+- **Status:** correct | incomplete | wrong
+- **Evidence:** path:line
+- **Assessment:** [1-2 sentences confirming the fix is correct, or explaining why it's incomplete/wrong]
+```
+
+Then "## Findings" for NEW issues only:
+
+For each finding:
+```
+### [Category Name]
+- **Severity:** blocker|major|minor|nit
+- **Confidence:** high|medium|low
+- **Evidence:** path:line[, path:line]
+- **Why it matters:** [one sentence]
+- **Suggested fix:** [concrete action]
+```
+
+Then "## No Finding" for categories with no issues (list them explicitly).
+
+End with:
+## Assumptions Checked
+[List invariants you verified hold — cite codebase searches you performed]
+
+## Open Risks
+[List concerns that need human judgment or runtime verification]
+
+## Constraints
+- No style nits unless they hide a correctness/operability problem.
+- No speculative concerns without a concrete mechanism and evidence.
+- Deep, high-impact findings >> exhaustive low-signal lists.
+- If you are uncertain, say so with confidence=low rather than omitting.
+- **Search the codebase** to back up claims about callers, patterns, or missing migrations. Do not guess.
+- **Do NOT list pre-existing bugs that the PR fixes as "findings".** Those go under Fix Validations.
+```
+
+### gemini-reviewer
+
+This prompt is passed to Gemini via PTY-wrapped `aimux run gemini` along with the full context block (metadata + diff). Gemini runs from the PR head worktree and can read files for cross-file pattern analysis.
+
+```
+You are "gemini-reviewer" for a code review in the gastown codebase.
+
+Gastown is a Go-based multi-agent orchestration system. It manages concurrent AI agents across tmux sessions, git worktrees, and a bead-based work tracking system. Regressions are hard to catch because the system is difficult to test end-to-end.
+
+## Mission
+
+Produce a high-signal review focused on cross-file consistency, pattern adherence, and architectural coherence. Your strength is analyzing how changes ripple across files and whether the codebase remains internally consistent after the PR. Think holistically — zoom out from individual lines to the structural relationships between components.
+
+Two other reviewers (Claude and Codex) are analyzing this same PR in parallel. Claude focuses on invariant safety and edge-case reasoning. Codex focuses on caller/callee tracing and evidence gathering. Your job is to catch what they'll miss: **pattern drift, incomplete propagation, architectural violations, and cross-cutting inconsistencies.**
+
+## Category Taxonomy (use exactly)
+
+1) Behavioral Correctness
+2) Contract & Interface Fidelity
+3) Change Impact / Blast Radius
+4) Concurrency, Ordering & State Safety
+5) Error Handling & Resilience
+6) Security Surface
+7) Resource Lifecycle & Cleanup
+8) Release Safety
+9) Test Evidence Quality
+10) Architectural Consistency
+11) Debuggability & Operability
+
+Priority: Focus heavily on categories 3, 10, and 2. These are where cross-file analysis catches the most regressions. Categories 1 and 4 are well-covered by Claude. Evidence gathering for categories 5-9 is well-covered by Codex.
+
+## How to Work
+
+### Codebase Access
+You are running from a git worktree checked out at the PR head — the code as it will look after the change. Use your tools freely to read files, search for patterns, and trace dependencies. The diff is included in the prompt below.
+
+### Your Unique Focus Areas
+
+**Cross-file consistency (your #1 job):**
+- When the PR changes a struct, interface, or function signature: search the entire codebase for all usage sites. Are all callers updated? Are there test files, mock implementations, or generated code that need matching changes?
+- When the PR adds a new pattern (new helper function, new error type, new config field): does it follow the conventions established by similar existing patterns? Search for 2-3 analogous examples and compare.
+- When the PR modifies one file in a group of related files (e.g., one role's manager but not others): check whether sibling files need parallel changes.
+
+**Pattern drift detection:**
+- Compare the PR's approach against the dominant pattern in the codebase. If 8 out of 10 similar functions use pattern A and the PR introduces pattern B, flag it — even if B works. Consistency has value.
+- Look for copy-paste with incomplete adaptation: when code is clearly modeled on an existing function, check that ALL relevant differences were addressed (not just the obvious ones).
+
+**Dependency chain analysis:**
+- Map the chain: what calls the changed code, and what does the changed code call? Follow the chain 2-3 levels deep. Are there intermediate functions that make assumptions the PR violates?
+- Check for implicit contracts: does the changed code produce output that downstream consumers parse or depend on? (Log formats, bead field values, tmux session name patterns, file path conventions.)
+
+**Architectural coherence:**
+- Does the change respect the system's layering? (e.g., CLI layer should not import internal agent logic; role managers should not reach into each other's state.)
+- Does the change create new coupling between modules that were previously independent?
+- Does the change duplicate logic that already exists elsewhere? If so, should it call the existing code instead?
+
+**Bypass detection (critical for bug-fix PRs):**
+- When a PR changes the ordering or location of an operation to avoid a failure, check whether the existing code path already has a mechanism to handle that failure (conflict resolution, retry, fallback).
+- Flag PRs that bypass established data flow (e.g., writing directly to main instead of going through branch merge + conflict resolution). Even if the bypass "works", it violates the system's designed error-handling pipeline.
+- Compare the PR's approach against the system's designed multi-phase patterns. If the system has a deliberate try → conflict → resolve pipeline, and the PR avoids the conflict entirely rather than relying on the resolution phase, that's an architectural red flag worth investigating.
+
+### Gastown-Specific Patterns to Check
+- **Role boundary compliance:** Polecats never touch main. Refinery never creates worktrees. Deacon never merges. Mayor never spawns polecats directly. Check that the PR doesn't introduce cross-role coupling.
+- **Formula consistency:** If a formula TOML is changed, verify step IDs, dependency edges, and description fields are consistent with the formula's Go consumer code.
+- **Bead field conventions:** Bead labels follow `key:value` format. Status transitions follow open → closed. Description fields use consistent Markdown structure.
+- **Config/flag propagation:** When a new CLI flag or config field is added, check that it's wired through all layers: CLI parsing → config struct → runtime usage → help text → documentation.
+- **Error message consistency:** Gastown uses structured error wrapping (`fmt.Errorf("context: %w", err)`). Check that new error messages follow this pattern and don't lose error context.
+- **Logging conventions:** Check that new log output includes enough context (session name, bead ID, step ID) to diagnose issues without additional debugging.
+
+## Output Format
+
+**CRITICAL: Separate fix validations from new findings.**
+
+Bug-fix PRs will have two classes of observations:
+1. **Fix Validations** — pre-existing bugs that the PR correctly fixes. These are NOT problems with the PR.
+2. **New Findings** — issues introduced by the PR itself, or remaining issues the PR should address.
+
+Start with "## Fix Validations" (if the PR fixes bugs):
+### <what was broken>
+- **Status:** correct | incomplete | wrong
+- **Evidence:** path:line
+- **Assessment:** [1-2 sentences]
+
+Then "## Findings" for NEW issues only:
+
+### [Category Name]
+- **Severity:** blocker|major|minor|nit
+- **Confidence:** high|medium|low
+- **Evidence:** path:line[, path:line]
+- **Pattern comparison:** [cite the existing pattern this deviates from, with path:line]
+- **Why it matters:** [one sentence]
+- **Suggested fix:** [concrete action]
+
+Then "## No Finding" for categories with no issues.
+
+End with:
+## Consistency Report
+- **Patterns checked:** [list patterns you searched for and verified]
+- **Sibling files checked:** [list related files you compared against]
+- **Propagation verified:** [list dependency chains you traced]
+- **Drift detected:** [list any pattern deviations, even minor ones]
+
+## Constraints
+- No style nits unless they represent pattern drift from an established codebase convention.
+- Every finding must cite a **comparison point** — the existing pattern or file it deviates from. No abstract claims.
+- Your unique value is breadth of analysis across files. Prioritize findings that span multiple files over single-file issues.
+- Do NOT duplicate Claude's edge-case reasoning or Codex's caller tracing. Focus on what only cross-file analysis reveals.
+- **Search the codebase** to verify claims. Do not guess about patterns — find examples.
+- **Do NOT list pre-existing bugs that the PR fixes as "findings".** Those go under Fix Validations.
+```
+
+---
+
+## Synthesizer Prompt
+
+```
+You are the "review-synthesizer" combining outputs from codex-reviewer, claude-reviewer, and gemini-reviewer for a gastown code review.
+
+## Inputs
+
+You will receive:
+1. The review context (metadata, description, changed file list — NOT the full diff)
+2. Codex reviewer findings
+3. Claude reviewer findings
+4. Gemini reviewer findings
+
+## Task
+
+Create one maintainer-grade decision report. Deduplicated, severity-calibrated, action-oriented.
+
+## Method
+
+1) Normalize all findings into the shared taxonomy:
+   1. Behavioral Correctness
+   2. Contract & Interface Fidelity
+   3. Change Impact / Blast Radius
+   4. Concurrency, Ordering & State Safety
+   5. Error Handling & Resilience
+   6. Security Surface
+   7. Resource Lifecycle & Cleanup
+   8. Release Safety
+   9. Test Evidence Quality
+   10. Architectural Consistency
+   11. Debuggability & Operability
+
+2) Merge findings that share the same root cause into a single entry.
+
+3) Severity disagreement policy:
+   - If multiple reviewers flag the same issue, keep the stricter severity.
+   - If one reviewer flags blocker and the others don't mention it at all, mark confidence as "medium" and keep blocker -- this needs human attention.
+   - If severity differs by exactly one level (e.g., major vs minor), keep the stricter.
+
+4) Mark each final finding with source attribution: `codex`, `claude`, `gemini`, `claude+codex`, `claude+gemini`, `codex+gemini`, or `all`.
+
+5) Cross-reference Claude's findings against Codex's evidence bundle. Findings that have concrete path:line evidence from the bundle get confidence boosted. Findings with no evidence trail get confidence reduced.
+
+6) **Trust codebase-backed evidence.** All three reviewers had full access to the upstream codebase (via worktree). Findings that cite specific path:line evidence from codebase searches are high-signal. Findings that make claims about "remaining sites" or "missing callers" without citing search evidence should be treated with lower confidence — ask whether the reviewer actually searched.
+
+7) **Gemini cross-file findings are high-signal.** When Gemini flags a cross-file consistency issue that neither Claude nor Codex mentioned, treat it as high-signal — this is Gemini's specialty. Cross-reference Gemini's consistency report against Codex's evidence bundle. Gemini findings that align with Codex-traced callers get confidence boosted.
+
+8) **Premise validation consensus check.** For bug-fix PRs: check whether any reviewer independently verified that the claimed failure actually occurs (by tracing the full execution path including existing handling mechanisms like conflict resolution or retry logic). If ALL reviewers accepted the PR's stated bug at face value without independent verification, add a finding:
+   - Category: Behavioral Correctness
+   - Severity: major
+   - Confidence: medium
+   - Source: synthesis
+   - Summary: "No reviewer independently verified the claimed failure scenario. Existing handling mechanisms (e.g., [cite if any reviewer mentioned them]) may already resolve this case."
+   This is critical because a fix for a non-existent bug adds complexity, may bypass safety mechanisms, and sets incorrect precedents. See PR #1648 (reverted in #1656).
+
+## Output Format
+
+**CRITICAL: Separate fix validations from new findings.**
+
+Reviewers may report two classes of observations:
+1. **Fix Validations** — pre-existing bugs the PR correctly fixes. These confirm the fix is correct. They do NOT count toward the merge decision.
+2. **New Findings** — issues introduced by or remaining in the PR. These drive the merge decision.
+
+When merging, classify each reviewer observation into one of these two categories. If a reviewer listed a "fix validation" as a "finding" (e.g., severity: blocker with note "this PR fixes it"), reclassify it as a fix validation.
+
+Where `<identifier>` is `#<number>` for PR mode or `<branch> vs <base>` for local branch mode.
+
+```
+# Review: <title> (<identifier>)
+
+## Decision: approve | take-the-good | request_changes | block
+
+## Fix Validations
+[For bug-fix PRs: brief confirmation that pre-existing bugs are correctly fixed]
+- **<what was broken>:** <correct|incomplete|wrong> — <1-sentence assessment>
+
+## Top Risks (max 5, ordered by severity then confidence)
+[Only NEW findings — not fix validations]
+1. [one-line summary] — severity / confidence / source
+
+## New Findings
+
+### [Category Name]
+- **Severity:** blocker|major|minor|nit
+- **Confidence:** high|medium|low
+- **Source:** codex|claude|gemini|claude+codex|claude+gemini|codex+gemini|all
+- **Evidence:** path:line
+- **Why it matters:** [one sentence]
+- **Required fix:** [concrete action]
+
+[repeat for each NEW finding]
+
+## Category Coverage
+[For each of the 11 categories: either a finding reference or "No finding"]
+
+## Pre-Merge Checklist
+- [ ] [must-pass items derived from NEW findings only]
+```
+
+## Decision Policy
+
+Decision is based ONLY on new findings, NOT on fix validations. `request_changes`
+(bouncing the PR back to the author) is the LAST resort — the default for any
+finding WE can fix is `take-the-good` (adopt the change, apply the fixups
+ourselves, merge). For each unresolved new finding, ask in order:
+
+1. **Is it a security or release-safety blocker?** (category 6 Security, or
+   category 8 Release Safety, at blocker severity) → `block`. These are the
+   only blockers that block.
+2. **Can WE fix it?** — it is reproducible AND needs no author-only input
+   (no secret/credential, no environment we can't stand up, no design intent
+   only the author knows, and `maintainerCanModify` is not false) → `take-the-good`.
+   This is the default for fixable findings at ANY severity, including blocker
+   and major correctness issues in categories 1-5, 7, 9-11.
+3. **Does it genuinely need the author?** → `request_changes`, and name the
+   reserved case: **cant-reproduce**, **needs-author-input** (secret / env /
+   design-intent / `maintainerCanModify = false`), or **author-wants-to-iterate**
+   (the author explicitly asked to own the fix).
+4. **Purely minor/nit, or no new findings at all** → `approve`.
+
+- Fix validations marked "incomplete" or "wrong" → treat as new findings at the
+  appropriate severity, then run them through the same ladder.
+- **Never `request_changes` a finding WE can fix.** If none of the three reserved
+  cases applies, the finding is ours → `take-the-good`.
+
+## Constraints
+- No style-only commentary.
+- Concise, concrete, evidence-linked.
+- The output is for a human maintainer making a merge decision. Respect their time.
+```
+
+---
+
+## Dual-Model Synthesizer Adjustments
+
+When `--skip-gemini` is active, apply these adjustments to the synthesizer prompt and process:
+
+1. **Synthesizer prompt header:** Replace "combining outputs from codex-reviewer, claude-reviewer, and gemini-reviewer" with "combining outputs from codex-reviewer and claude-reviewer (dual-model mode, Gemini skipped)".
+2. **Inputs section:** Remove "3. Gemini reviewer findings" from the input list.
+3. **Method step 4:** Source attribution uses only: `codex`, `claude`, or `claude+codex` (not `gemini`, `claude+gemini`, `codex+gemini`, or `all`).
+4. **Method step 7 (Gemini cross-file findings):** Skip entirely — this step is N/A in dual-model mode.
+5. **Cross-file coverage gap:** Note in the synthesis output that cross-file consistency analysis (Gemini's specialty) was not performed. Add a line under Category Coverage: `"⚠ Cross-file consistency (category 3, 10) had reduced coverage — Gemini reviewer was skipped."`
+6. **GitHub comment heading:** Use `Dual-Model (Claude + Codex)` instead of `Triple-Model (Claude + Codex + Gemini)`.
+7. **GitHub comment footer:** Use `Claude Opus 4.6 + GPT-5.3 Codex` instead of the triple-model list.
+
+All other synthesis logic (deduplication, severity policy, decision policy, output format) remains identical.
+
+---
+
+## Progress Reporting
+
+Print phase transitions to terminal.
+
+**PR mode** (4 phases):
+
+```
+[review-pr] Phase 1/4: Gathering PR context...
+[review-pr]   PR #123: "Add formula validation for orphan steps"
+[review-pr]   +142 -38 across 5 files
+[review-pr]   Upstream worktrees created at <run_dir>/worktree{,-pr}
+[review-pr] Phase 2/4: Running parallel reviews (Claude || Codex [|| Gemini])...
+[review-pr]   Claude reviewer started
+[review-pr]   Codex reviewer started
+[review-pr]   Gemini reviewer started
+[review-pr]   Claude reviewer complete (60s)
+[review-pr]   Gemini reviewer complete (45s)
+[review-pr]   Codex reviewer complete (300s)
+[review-pr] Phase 3/4: Synthesizing findings...
+[review-pr]   Synthesis complete (90s)
+[review-pr]   Decision: request_changes (2 blockers, 1 major)
+[review-pr]   Worktrees cleaned up.
+[review-pr] Phase 4/4: Awaiting user approval to post to GitHub...
+[review-pr]   User approved. Comment posted.
+[review-pr] Done. Report at <run_dir>/outputs/synthesis.md
+```
+
+**Local branch mode** (3 phases — no Phase 4):
+
+```
+[review-pr] Phase 1/3: Gathering branch context...
+[review-pr]   Branch: ci/close-stale-needs
+[review-pr]   Auto-detected base: upstream/main (merge-base: fd7b5663)
+[review-pr]   +85 -12 across 3 files
+[review-pr]   Local worktrees created at <run_dir>/worktree{,-pr}
+[review-pr] Phase 2/3: Running parallel reviews (Claude || Codex [|| Gemini])...
+[review-pr]   Claude reviewer started
+[review-pr]   Codex reviewer started
+[review-pr]   Gemini reviewer started
+[review-pr]   Claude reviewer complete (60s)
+[review-pr]   Gemini reviewer complete (45s)
+[review-pr]   Codex reviewer complete (300s)
+[review-pr] Phase 3/3: Synthesizing findings...
+[review-pr]   Synthesis complete (90s)
+[review-pr]   Decision: approve (0 blockers, 1 minor)
+[review-pr]   Worktrees cleaned up.
+[review-pr] Done. Report at <run_dir>/outputs/synthesis.md
+```
+
+**Typical timing:** Phase 1: ~30s, Phase 2: ~5 min (Codex is the bottleneck; Claude finishes in ~60s, Gemini in ~45s), Phase 3: ~90s, Phase 4 (PR only): depends on user review.
+
+---
+
+## Error Handling
+
+| Failure | Action |
+|---------|--------|
+| `gh` command fails | Report error, check auth: `gh auth status` |
+| PR not found | Report "PR not found" with URL attempted |
+| Branch not found (local mode) | Report "Branch '<branch>' not found in local repository." |
+| Base branch not found (local mode) | Report "Base branch '<base>' not found in local repository." |
+| No commits between branches (local mode) | Report "No commits between '<base>' and '<branch>'. Nothing to review." |
+| `--base` used in PR mode | Ignore silently (base is determined by the PR) |
+| Worktree creation fails | Try fallback ref method (PR mode). If still fails, report error — review cannot proceed without accurate codebase access |
+| Agent pre-flight fails | Report which agent, suggest `aimux status` |
+| Gemini unavailable via aimux | If `--skip-gemini`: N/A. Otherwise: Report "Gemini not available. Check `aimux status` and `aimux verify gemini`.", stop |
+| One reviewer produces empty output | Report failure and stop. All required reviewers must succeed — no single-model fallback |
+| Gemini produces empty output | If `--skip-gemini`: N/A. Otherwise: Report failure, stop |
+| Codex PTY log has no "codex" blocks | Codex may have failed to start or hit an error. Check the PTY log file. Stop pipeline — all reviewers required |
+| Codex output is duplicated | Normal behavior — Codex sometimes outputs the review twice with a "tokens used" separator. The PTY parser's "longest block" heuristic handles this automatically |
+| Synthesis produces empty output | Present raw reviewer outputs directly |
+| Diff too large (>100KB) | All three reviewers get the full diff. No truncation. |
+| Worktree cleanup fails | Log warning but don't block. User can clean up manually: `git worktree list` then `git worktree remove` |
+| Claude produces tiny output (<500 bytes) | Claude spent all capacity on tool use (reading files) instead of producing a review. **Retry with shorter prompt** that includes explicit "CRITICAL: Do NOT use tools to read files" instruction. See Known Issues below |
+| Branch has large merge-base divergence | Should be auto-resolved by the base auto-detection (checks `main`, `upstream/main`, `origin/main` and picks the most recent merge-base). If auto-detection still produces a large diff, the user can override with `--base <ref>` pointing to the correct ancestor. |
+
+---
+
+## Known Issues & Operational Learnings
+
+### Claude reviewer fails on large prompts (>100KB)
+
+**Symptom:** Claude produces 100-300 bytes of output like "I'll start by searching the codebase..." instead of an actual review. This happens consistently when the prompt exceeds ~100KB and Claude has tool access.
+
+**Root cause:** Claude uses all its capacity on tool calls (reading files, grepping) and never produces the final review text.
+
+**Fix:** Use a shorter role prompt (~500 bytes vs ~4KB) with an explicit instruction: `CRITICAL: Do NOT use tools to read files. The diff contains everything you need. Produce your review directly.` This consistently produces 9-12KB reviews in ~60-180s.
+
+**When to retry:** If Claude output is <500 bytes, retry once with the short prompt. If still failing, report failure.
+
+### Local branch mode: fork-based workflows (resolved)
+
+**Symptom:** `git diff main...branch` returns hundreds of files and 70K+ lines when the branch only has ~15 feature commits.
+
+**Root cause:** In fork-based workflows, the local `main` tracks `origin/main` (the fork), not `upstream/main` (the source repo). When the feature branch was forked from `upstream/main`, `git merge-base main branch` returns a very old commit, and the three-dot diff includes all divergence between the fork's main and upstream.
+
+**Fix (implemented):** The local branch mode now auto-detects the best base by checking `main`, `upstream/main`, and `origin/main`, and picking the one with the most recent merge-base with the branch. This handles fork workflows automatically without manual intervention. Users can still override with `--base <branch>` if needed.
+
+### Codex output deduplication
+
+**Behavior:** Codex consistently produces its review output twice in the PTY log, separated by a "tokens used" line. The PTY parser's "longest block" heuristic handles this automatically — no action needed. But be aware that raw output file sizes appear ~2x larger than the actual review content.
+
+### Review iteration convergence
+
+**Pattern observed across 11 review passes:** Each review cycle fixes 3-5 findings but may introduce 1-2 new ones. Findings that persist across reviews fall into two categories:
+1. **Architecture limitations** (integration tests, stale snapshots) — these repeat every cycle and should be tracked as follow-ups rather than fixed in-loop.
+2. **Genuine new findings** from code changes made to fix previous findings — these are real and should be fixed.
+
+**Recommendation for adopt-pr-auto:** After 2-3 review iterations, categorize remaining findings as "fix now" vs "track as follow-up" rather than continuing to iterate. Convergence typically takes 2 iterations for code fixes and never resolves for architecture-level concerns.

--- a/pr-review/overlay/.claude/skills/review-pr/SKILL.md
+++ b/pr-review/overlay/.claude/skills/review-pr/SKILL.md
@@ -902,7 +902,7 @@ You are running from a git worktree checked out at the PR head. The full diff is
 ### Gastown-Specific Invariants
 - **Formula TOML contracts:** Step dependencies must form a DAG. No orphan steps. Variable references (Go text/template) must resolve. New steps must appear in TopologicalSort output.
 - **Role boundaries:** Polecats never touch main branch. Refinery never creates worktrees. Deacon never merges. Witness never does implementation work. Mayor never spawns polecats directly.
-- **Hook/bead protocol:** `bd ready`/`bd close` must be paired. Bead sync must happen before `gt done`. Hook environment variables must be set before agent spawn.
+- **Hook/bead protocol:** `gc bd ready`/`gc bd close` must be paired. Bead sync must happen before `gt done`. Hook environment variables must be set before agent spawn.
 - **Agent preset contracts:** `AgentPresetInfo` fields (SessionIDEnv, ResumeFlag, ResumeStyle, SupportsHooks) must match actual CLI behavior of the agent binary.
 - **Self-cleaning contract:** Polecats must call `gt done` which syncs beads, nukes worktree, and exits. No partial cleanup.
 - **Tmux session management:** Session names must be deterministic. Pane targeting must handle "no sessions" and "no current target" errors.
@@ -1004,7 +1004,7 @@ You are running from a git worktree checked out at the base branch, which repres
 ### Gastown-Specific Invariants
 - **Formula TOML contracts:** Step dependencies must form a DAG. No orphan steps. Variable references (Go text/template) must resolve. Changed steps must not break TopologicalSort or ReadySteps computation.
 - **Role boundaries:** Polecats never touch main. Refinery never creates worktrees. Deacon never merges. Witness never implements. Mayor never spawns polecats directly. Violations are silent and catastrophic.
-- **Hook/bead protocol:** `bd ready`/`bd close` pairing. Bead sync before `gt done`. Hook env vars set before agent spawn. Violation means lost work or phantom state.
+- **Hook/bead protocol:** `gc bd ready`/`gc bd close` pairing. Bead sync before `gt done`. Hook env vars set before agent spawn. Violation means lost work or phantom state.
 - **Agent preset contracts:** `AgentPresetInfo` fields must match real CLI behavior. Wrong ResumeStyle = broken session resume. Wrong SupportsHooks = silent hook failure.
 - **Self-cleaning contract:** Polecats call `gt done` → sync beads → nuke worktree → exit. Partial cleanup leaves zombie worktrees that corrupt future operations.
 - **Tmux session management:** Session names deterministic. Pane targeting handles edge cases. Race between session creation and pane targeting is a known fragile area.

--- a/pr-review/pack.toml
+++ b/pr-review/pack.toml
@@ -1,0 +1,19 @@
+# PR Review — formula-driven adopt-PR workflow.
+#
+# Provides a 5-step molecule formula for reviewing and merging contributor PRs.
+# The polecat follows the formula steps; a human gate after review blocks until
+# the maintainer is ready to finalize.
+#
+# No agents defined — this pack provides a formula and a review skill overlay.
+# The consuming pack must supply the polecat agent.
+#
+# Usage in your city's pack.toml:
+#   [imports.pr-review]
+#   source = "../packs/pr-review"
+#
+# Sling a PR review:
+#   gc sling <rig>/polecat mol-adopt-pr --formula --var pr=<url-or-number>
+
+[pack]
+name = "pr-review"
+schema = 2


### PR DESCRIPTION
## What this adds

`pr-review`, the maintainer-side incoming-PR adoption pack. It is the counterpart to `pr-pipeline`, which already ships here and covers the author-side outgoing flow. This pack has been running locally for months but has never existed on any branch of this repo.

Five formulas plus a `review-pr` skill overlay:

| Formula | Purpose |
|---|---|
| `mol-adopt-pr` | 5-step adopt workflow: intake, rebase-check, review, human gate, finalize |
| `mol-pr-ci-diagnose` | Diagnose a failing CI run on an incoming PR |
| `mol-pr-iterate` | Iterate on review feedback |
| `mol-pr-merge-only` | Merge-handoff without a fresh review |
| `mol-pr-revert` | Revert a landed PR |

No agents are defined. The consuming pack supplies the polecat.

`mol-adopt-pr` gates on a human: after the review step, a checkpoint blocks until a maintainer closes it, and only then can finalize run. The polecat never runs `gh pr merge`, `git push`, `gh pr create`, or `gh pr comment` on the branch-ready paths; it prepares artifacts locally and hands publish to the mayor.

## Why `mol-adopt-pr` is formulas v2

As v1 its root compiled to a molecule container rather than Ready-visible work, so `slingFormula` rejected every attempt to route it to the polecat pool it is written for:

```
formula "mol-adopt-pr" root is a molecule container, not Ready-visible work;
scale-from-zero pools will not wake for this wisp.
```

There was no working entry point at all. Routing to a city-level agent instead does not help, because formula search paths derive from the target agent's `Dir` and this pack is rig-scoped.

## Two formulas were silently dropping every step

| Formula | Was | Now |
|---|---|---|
| `pr-pipeline/mol-pr-from-issue` | `RootOnly=true`, 9 steps dropped | `RootOnly=false` |
| `pr-review/mol-pr-revert` | `RootOnly=true`, 7 steps dropped | `RootOnly=false` |

`mol-pr-from-issue` is pre-existing on `main`. Both now set `pour = true`.

The compiler predicate is:

```go
rootOnly := (!f.Pour && f.Phase == "vapor") || len(f.Steps) == 0
```

It keys only on `pour` and `phase`. The graph declaration form is never consulted, so `contract = "graph.v2"` offers no protection.

`RecipeHasReadySurface` returns true when `RootOnly` is set, since a root-only recipe is trivially Ready-visible. That is what hides the bug. A pool sling is accepted, the root goes `in_progress`, and only the steps go missing, with no error anywhere. Anyone reading the guard alone would conclude the formula is healthy.

That also makes `phase = "vapor"` without `pour` an attractive wrong fix for the v1 rejection above: it satisfies the guard while deleting the human gate from `mol-adopt-pr`, which would hand a polecat an unreviewed merge. The spec says as much, that the bare-vapor form is accepted for compatibility and must not be used to design new formulas.

## Formula name collision

`pr-review` carried its own repaired copy of `mol-pr-from-issue`, which would have declared the same formula name as `pr-pipeline`'s. The repair is ported into `pr-pipeline`'s copy and the duplicate dropped. No formula name is now declared by two packs.

## Verification

Every formula in both packs was compiled and checked for `RootOnly`:

```
pr-pipeline  mol-pr-blast-radius   RootOnly=false
pr-pipeline  mol-pr-from-issue     RootOnly=false   (was true)
pr-pipeline  mol-pr-review         RootOnly=false
pr-pipeline  mol-pr-ship           RootOnly=false
pr-pipeline  mol-pr-start          RootOnly=false
pr-pipeline  mol-pr-triage         RootOnly=false
pr-review    mol-adopt-pr          RootOnly=false, rootKind=workflow, 7 steps
pr-review    mol-pr-ci-diagnose    RootOnly=false
pr-review    mol-pr-iterate        RootOnly=false
pr-review    mol-pr-merge-only     RootOnly=false
pr-review    mol-pr-revert         RootOnly=false   (was true)
```

For `mol-adopt-pr` specifically, four assertions: the root is Ready-visible, `RootOnly` is false, all five steps survive, and the `finalize` step still has a blocking edge on `human-gate`. A mutation probe confirms the suite fails if `pour` is dropped, so the wrong fix cannot pass.

`go build ./...` and `go test ./...` are green.

## Test plan

- [ ] `go build ./... && go test ./...`
- [ ] Import `pr-review` into a city alongside `pr-pipeline` and confirm no formula name resolves ambiguously
- [ ] `gc sling <rig>/polecat mol-adopt-pr --formula --var pr=<N>` starts a workflow and routes to the pool
- [ ] Confirm the human gate blocks finalize until it is closed
- [ ] `gc sling` `mol-pr-from-issue` and `mol-pr-revert` and confirm their steps materialize
