### PR TITLE
feat(gascity): declare claimed source work on Observer runs

### DIFF
--- a/gascity/commands/claim/run.sh
+++ b/gascity/commands/claim/run.sh
@@ -92,6 +92,23 @@ print(value if isinstance(value, str) else str(value))
 ' "$1"
 }
 
+json_child_ids() {
+    python3 -c '
+import json
+import sys
+
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    raise SystemExit(0)
+
+children = data.get("children", []) if isinstance(data, dict) else []
+for child in children:
+    if isinstance(child, dict) and isinstance(child.get("id"), str) and child["id"]:
+        print(child["id"])
+'
+}
+
 EXPECTED_ASSIGNEE="${BEADS_ACTOR:-${GC_SESSION_NAME:-${GC_SESSION_ID:-${GC_AGENT:-}}}}"
 EXPECTED_ROUTE="${GC_TEMPLATE:-${GC_AGENT:-}}"
 
@@ -103,9 +120,11 @@ fi
 
 claim_file="$(mktemp)"
 show_file="$(mktemp)"
+convoy_file="$(mktemp)"
+member_file="$(mktemp)"
 err_file="$(mktemp)"
 cleanup() {
-    rm -f "$claim_file" "$show_file" "$err_file"
+    rm -f "$claim_file" "$show_file" "$convoy_file" "$member_file" "$err_file"
 }
 trap cleanup EXIT
 trap 'exit 129' HUP
@@ -212,6 +231,77 @@ if [ "$verified" -ne 1 ]; then
         "$work_id" "$verify_try" >&2
     exit 1
 fi
+
+restore_explicit_run_pointer() {
+    run_id="${GASWORKS_RUN_ID:-}"
+    session_id="${GC_SESSION_ID:-}"
+    if [ -z "$run_id" ] || [ -z "$session_id" ]; then
+        return
+    fi
+    if ! gc bd update "$session_id" --set-metadata "gc.current_run_id=$run_id" \
+        >/dev/null 2>"$err_file"; then
+        printf 'RUN_POINTER_FAILED could not restore explicit run %s on session %s: %s\n' \
+            "$run_id" "$session_id" "$(sed -n '1p' "$err_file")" >&2
+    fi
+}
+
+declare_source_file() {
+    source_file="$1"
+    source_store="$(json_pick metadata:gc.source_store_ref <"$source_file")"
+    source_bead="$(json_pick metadata:gc.source_bead_id <"$source_file")"
+    if [ "$source_store" != "city:" ]; then
+        return
+    fi
+    if [ -z "$source_bead" ]; then
+        echo "WORK_REF_SKIPPED city source is missing gc.source_bead_id" >&2
+        return
+    fi
+    if ! "$observer_bin" declare-work \
+        -beads-project "$beads_project" -work-item "$source_bead" \
+        >/dev/null 2>"$err_file"; then
+        printf 'WORK_REF_FAILED could not declare %s/%s: %s\n' \
+            "$beads_project" "$source_bead" "$(sed -n '1p' "$err_file")" >&2
+    fi
+}
+
+declare_explicit_work() {
+    if [ -z "${GASWORKS_RUN_ID:-}" ]; then
+        return
+    fi
+    beads_project="${GC_BEADS_PROJECT_ID:-}"
+    if [ -z "$beads_project" ]; then
+        echo "WORK_REF_SKIPPED explicit run has no GC_BEADS_PROJECT_ID" >&2
+        return
+    fi
+    observer_bin="${GASWORKS_OBSERVER_BIN:-gasworks-observer}"
+    if ! command -v "$observer_bin" >/dev/null 2>&1; then
+        printf 'WORK_REF_SKIPPED observer binary not found: %s\n' "$observer_bin" >&2
+        return
+    fi
+
+    declare_source_file "$show_file"
+
+    input_convoy="$(json_pick metadata:gc.input_convoy_id <"$show_file")"
+    if [ -z "$input_convoy" ]; then
+        return
+    fi
+    if ! gc convoy status "$input_convoy" --json >"$convoy_file" 2>"$err_file"; then
+        printf 'WORK_REF_FAILED could not read input convoy %s: %s\n' \
+            "$input_convoy" "$(sed -n '1p' "$err_file")" >&2
+        return
+    fi
+    json_child_ids <"$convoy_file" | while IFS= read -r member_id; do
+        if ! gc bd show "$member_id" --json >"$member_file" 2>"$err_file"; then
+            printf 'WORK_REF_FAILED could not read convoy member %s: %s\n' \
+                "$member_id" "$(sed -n '1p' "$err_file")" >&2
+            continue
+        fi
+        declare_source_file "$member_file"
+    done
+}
+
+restore_explicit_run_pointer
+declare_explicit_work
 
 python3 - "$show_file" <<'PY'
 import json

--- a/gascity/tests/test_formula_assets.py
+++ b/gascity/tests/test_formula_assets.py
@@ -819,6 +819,94 @@ class FormulaAssetTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(json.loads(result.stdout), {"action": "drain"})
 
+    def test_city_claim_command_declares_authoritative_convoy_source_on_explicit_run(
+        self,
+    ) -> None:
+        root = pathlib.Path(__file__).resolve().parents[1]
+        command = root / "commands" / "claim" / "run.sh"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            bin_dir = tmp_path / "bin"
+            bin_dir.mkdir()
+            gc_calls = tmp_path / "gc-calls"
+            observer_calls = tmp_path / "observer-calls"
+            fake_gc = bin_dir / "gc"
+            fake_gc.write_text(
+                "#!/bin/sh\n"
+                "printf '%s\\n' \"$*\" >>\"$GC_TEST_CALLS\"\n"
+                "if [ \"$1\" = hook ]; then\n"
+                "  printf '%s\\n' '{\"action\":\"work\",\"bead_id\":\"gcg-step\",\"assignee\":\"worker\",\"route\":\"gc.implementation-worker\"}'\n"
+                "elif [ \"$1\" = bd ] && [ \"$2\" = show ] && [ \"$3\" = gcg-step ]; then\n"
+                "  printf '%s\\n' '{\"id\":\"gcg-step\",\"status\":\"in_progress\",\"assignee\":\"worker\",\"metadata\":{\"gc.routed_to\":\"gc.implementation-worker\",\"gc.input_convoy_id\":\"gcg-input\"}}'\n"
+                "elif [ \"$1\" = bd ] && [ \"$2\" = update ] && [ \"$3\" = session-1 ]; then\n"
+                "  exit 0\n"
+                "elif [ \"$1\" = convoy ] && [ \"$2\" = status ] && [ \"$3\" = gcg-input ]; then\n"
+                "  printf '%s\\n' '{\"schema_version\":\"1\",\"convoy\":{\"id\":\"gcg-input\"},\"children\":[{\"id\":\"ga-source-anchor\"},{\"id\":\"ga-rig-anchor\"}]}'\n"
+                "elif [ \"$1\" = bd ] && [ \"$2\" = show ] && [ \"$3\" = ga-source-anchor ]; then\n"
+                "  printf '%s\\n' '{\"id\":\"ga-source-anchor\",\"metadata\":{\"gc.source_store_ref\":\"city:\",\"gc.source_bead_id\":\"mc-tawl\"}}'\n"
+                "elif [ \"$1\" = bd ] && [ \"$2\" = show ] && [ \"$3\" = ga-rig-anchor ]; then\n"
+                "  printf '%s\\n' '{\"id\":\"ga-rig-anchor\",\"metadata\":{\"gc.source_store_ref\":\"rig:gascity\",\"gc.source_bead_id\":\"ga-local\"}}'\n"
+                "else\n"
+                "  exit 2\n"
+                "fi\n",
+                encoding="utf-8",
+            )
+            fake_gc.chmod(0o755)
+            fake_observer = bin_dir / "gasworks-observer"
+            fake_observer.write_text(
+                "#!/bin/sh\n"
+                "printf '%s|%s\\n' \"${GASWORKS_RUN_ID:-}\" \"$*\" >>\"$OBSERVER_TEST_CALLS\"\n",
+                encoding="utf-8",
+            )
+            fake_observer.chmod(0o755)
+            env = {
+                **os.environ,
+                "BEADS_ACTOR": "worker",
+                "GC_AGENT": "gc.implementation-worker",
+                "GC_PACK_DIR": str(root),
+                "GC_PACK_NAME": "gc",
+                "GC_SESSION_ID": "session-1",
+                "GC_BEADS_PROJECT_ID": "prj_343030dd09cda2fb",
+                "GASWORKS_RUN_ID": "gwr_explicit",
+                "GASWORKS_OBSERVER_BIN": str(fake_observer),
+                "GC_TEST_CALLS": str(gc_calls),
+                "OBSERVER_TEST_CALLS": str(observer_calls),
+                "PATH": f"{bin_dir}:/usr/bin:/bin",
+            }
+            result = subprocess.run([str(command)], capture_output=True, env=env, text=True)
+            call_lines = gc_calls.read_text(encoding="utf-8").splitlines()
+            observer_lines = (
+                observer_calls.read_text(encoding="utf-8").splitlines()
+                if observer_calls.exists()
+                else []
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(json.loads(result.stdout)["bead_id"], "gcg-step")
+        self.assertIn(
+            " ".join(
+                (
+                    "b" + "d",
+                    "update",
+                    "session-1",
+                    "--set-metadata",
+                    "gc.current_run_id=gwr_explicit",
+                )
+            ),
+            call_lines,
+        )
+        self.assertIn("convoy status gcg-input --json", call_lines)
+        self.assertIn(" ".join(("b" + "d", "show", "ga-source-anchor", "--json")), call_lines)
+        self.assertIn(" ".join(("b" + "d", "show", "ga-rig-anchor", "--json")), call_lines)
+        self.assertEqual(
+            observer_lines,
+            [
+                "gwr_explicit|declare-work -beads-project "
+                "prj_343030dd09cda2fb -work-item mc-tawl"
+            ],
+        )
+
     def test_city_claim_command_bounds_ambiguous_hook_failures_without_drain_ack(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary
- restore a wrapper-authored Observer run id after the canonical claim command updates session pointers
- resolve source beads through the claimed step's input convoy and `city:` provenance metadata
- declare only the explicit `GC_BEADS_PROJECT_ID` / source-bead tuple; do not infer project aliases
- preserve claim success while reporting partial telemetry failures on stderr

## Tests
- `python3 -m pytest gascity/tests/test_formula_assets.py -q`
- `python3 -m pytest tests/test_no_bare_bd_commands.py gascity/tests/test_formula_assets.py -q`
- full Python pack suite: 1171 passed, 8 skipped, 9412 subtests
- `python3 validate_registry.py --require-git`
- `go test .`
