### PR TITLE
fix(discord): make launcher rooms usable and add attach-first @@handle

### DIFF
--- a/discord/scripts/discord_gateway_service.py
+++ b/discord/scripts/discord_gateway_service.py
@@ -90,6 +90,20 @@ def participant_delivery_selector(participant: dict[str, Any]) -> str:
     return ""
 
 
+def participant_target_identity(participant: dict[str, Any]) -> dict[str, str]:
+    """Build the identity dict written into ingress receipt `targets` entries.
+    Including every known identifier lets find_latest_discord_reply_context /
+    reply-current match by whichever selector (id, name, alias) the caller
+    presents from GC_SESSION_* env vars.
+    """
+    fields: dict[str, str] = {}
+    for key in ("session_name", "session_id", "session_alias"):
+        value = str((participant or {}).get(key, "")).strip()
+        if value:
+            fields[key] = value
+    return fields
+
+
 def json_response(handler: BaseHTTPRequestHandler, status: int, payload: dict[str, Any]) -> None:
     body = json.dumps(payload, indent=2, sort_keys=True).encode("utf-8") + b"\n"
     handler.send_response(status)
@@ -695,6 +709,26 @@ def bound_room_claims_message(
     parent = str(parent_id).strip()
     if parent and explicit_room_binding(config, parent, app_name):
         return True
+    return False
+
+
+def launcher_claims_message(config: dict[str, Any], channel_id: str, parent_id: str = "") -> bool:
+    """True if this message belongs to launcher-managed routing: the message
+    is in a configured launcher room OR is inside a launcher-managed thread
+    (parent is a launcher OR channel_id matches a room_launch thread_id).
+    Extmsg's generic thread handler must skip these so the launcher pack's
+    process_room_launch_thread_message can run.
+    """
+    channel = str(channel_id).strip()
+    parent = str(parent_id).strip()
+    if channel and common.resolve_room_launcher(config, channel):
+        return True
+    if parent and common.resolve_room_launcher(config, parent):
+        return True
+    if channel:
+        launch = common.load_room_launch(common.room_launch_record_id(channel))
+        if launch and str(launch.get("thread_id", "")).strip() == channel:
+            return True
     return False
 
 
@@ -1388,7 +1422,27 @@ def process_room_launch_message(
             return {"status": "ignored_untargeted", "ingress_id": ingress_id, "receipt": receipt}
         used_default_handle = True
 
-    if used_default_handle:
+    # Attach-first: if the handle matches an already-running session
+    # (by alias/session_name/id), route to that session directly instead
+    # of resolving as a template + spawning a fresh clone.
+    attached_identity: dict[str, str] = {}
+    try:
+        attached_identity = common.resolve_existing_session_for_handle(requested_handle)
+    except common.GCAPIError as exc:
+        receipt = persist_ingress_receipt(
+            {
+                **base_receipt,
+                "binding_id": str(launcher.get("id", "")).strip(),
+                "status": "failed_lookup",
+                "reason": str(exc),
+                "targets": [],
+            }
+        )
+        return {"status": "failed_lookup", "ingress_id": ingress_id, "receipt": receipt}
+
+    if attached_identity:
+        qualified_handle, resolve_error = requested_handle, ""
+    elif used_default_handle:
         qualified_handle, resolve_error = requested_handle, ""
     else:
         try:
@@ -1442,7 +1496,7 @@ def process_room_launch_message(
         }
     )
     try:
-        launch = common.ensure_room_launch_session(launch)
+        launch = common.ensure_room_launch_session(launch, attached_identity=attached_identity or None)
     except (ValueError, common.GCAPIError) as exc:
         receipt = persist_ingress_receipt(
             {
@@ -1457,6 +1511,7 @@ def process_room_launch_message(
         return {"status": "failed_lookup", "ingress_id": ingress_id, "receipt": receipt}
 
     target_selector = participant_delivery_selector(launch)
+    target_identity = participant_target_identity(launch)
     envelope = build_room_launch_envelope(
         launcher=launcher,
         launch=launch,
@@ -1479,6 +1534,7 @@ def process_room_launch_message(
             "qualified_handle": qualified_handle,
             "targets": [
                 {
+                    **target_identity,
                     "session_name": target_selector,
                     "status": "pending",
                     "intent": "default",
@@ -1538,9 +1594,10 @@ def process_room_launch_thread_message(
         return {"status": "rejected_targeting", "ingress_id": ingress_id, "receipt": receipt}
     target_handle = ""
     routing_mode = ""
+    thread_attached_identity: dict[str, str] = {}
     if mentioned_handles:
         try:
-            qualified_handle, resolve_error = common.resolve_agent_handle(mentioned_handles[0])
+            thread_attached_identity = common.resolve_existing_session_for_handle(mentioned_handles[0])
         except common.GCAPIError as exc:
             receipt = persist_ingress_receipt(
                 {
@@ -1552,20 +1609,37 @@ def process_room_launch_thread_message(
                 }
             )
             return {"status": "failed_lookup", "ingress_id": ingress_id, "receipt": receipt}
-        if resolve_error:
-            receipt = persist_ingress_receipt(
-                {
-                    **base_receipt,
-                    "binding_id": str(launcher.get("id", "")).strip(),
-                    "status": "rejected_targeting",
-                    "reason": resolve_error,
-                    "mentioned_handles": mentioned_handles,
-                    "targets": [],
-                }
-            )
-            return {"status": "rejected_targeting", "ingress_id": ingress_id, "receipt": receipt}
-        target_handle = qualified_handle
-        routing_mode = "explicit_handle"
+        if thread_attached_identity:
+            target_handle = mentioned_handles[0]
+            routing_mode = "explicit_handle_attached"
+        else:
+            try:
+                qualified_handle, resolve_error = common.resolve_agent_handle(mentioned_handles[0])
+            except common.GCAPIError as exc:
+                receipt = persist_ingress_receipt(
+                    {
+                        **base_receipt,
+                        "binding_id": str(launcher.get("id", "")).strip(),
+                        "status": "failed_lookup",
+                        "reason": str(exc),
+                        "targets": [],
+                    }
+                )
+                return {"status": "failed_lookup", "ingress_id": ingress_id, "receipt": receipt}
+            if resolve_error:
+                receipt = persist_ingress_receipt(
+                    {
+                        **base_receipt,
+                        "binding_id": str(launcher.get("id", "")).strip(),
+                        "status": "rejected_targeting",
+                        "reason": resolve_error,
+                        "mentioned_handles": mentioned_handles,
+                        "targets": [],
+                    }
+                )
+                return {"status": "rejected_targeting", "ingress_id": ingress_id, "receipt": receipt}
+            target_handle = qualified_handle
+            routing_mode = "explicit_handle"
     if not target_handle and reply_to_id:
         target_handle = common.room_launch_message_target_handle(launch, reply_to_id)
         if target_handle:
@@ -1590,7 +1664,11 @@ def process_room_launch_thread_message(
         )
         return {"status": "failed_lookup", "ingress_id": ingress_id, "receipt": receipt}
     try:
-        launch, target_participant = common.ensure_room_launch_session_for_handle(launch, target_handle)
+        launch, target_participant = common.ensure_room_launch_session_for_handle(
+            launch,
+            target_handle,
+            attached_identity=thread_attached_identity or None,
+        )
     except (ValueError, common.GCAPIError) as exc:
         receipt = persist_ingress_receipt(
             {
@@ -1603,6 +1681,7 @@ def process_room_launch_thread_message(
         )
         return {"status": "failed_lookup", "ingress_id": ingress_id, "receipt": receipt}
     target_selector = participant_delivery_selector(target_participant)
+    target_identity = participant_target_identity(target_participant)
 
     envelope = build_room_launch_thread_envelope(
         launcher=launcher,
@@ -1630,6 +1709,7 @@ def process_room_launch_thread_message(
             "qualified_handle": target_handle,
             "targets": [
                 {
+                    **target_identity,
                     "session_name": target_selector,
                     "status": "pending",
                     "intent": "default",
@@ -2481,7 +2561,10 @@ class GatewayWorker:
             # Explicit room bindings take precedence over generic extmsg
             # mention/thread launching. This keeps sticky bound rooms, and
             # their inherited thread routing, from spawning new sessions.
-            if guild_id and channel_id and bound_room_claims_message(config, channel_id, parent_id):
+            if guild_id and channel_id and (
+                bound_room_claims_message(config, channel_id, parent_id)
+                or launcher_claims_message(config, channel_id, parent_id)
+            ):
                 return False
 
             # ROOM: @mentions required to launch a new thread.

--- a/discord/scripts/discord_gateway_service.py
+++ b/discord/scripts/discord_gateway_service.py
@@ -1440,7 +1440,15 @@ def process_room_launch_message(
         )
         return {"status": "failed_lookup", "ingress_id": ingress_id, "receipt": receipt}
 
-    if attached_identity:
+    # Named-session lookup: if the handle names a declared but not-yet-
+    # running named session (mode = "on_demand" crew, etc.), spawn it via
+    # its declared template + alias so this launch wakes it and future
+    # turns attach to the same instance.
+    named_session_ref: dict[str, str] = {}
+    if not attached_identity:
+        named_session_ref = common.resolve_named_session_for_handle(requested_handle)
+
+    if attached_identity or named_session_ref:
         qualified_handle, resolve_error = requested_handle, ""
     elif used_default_handle:
         qualified_handle, resolve_error = requested_handle, ""
@@ -1484,6 +1492,7 @@ def process_room_launch_message(
             "root_message_id": str(message.get("id", "")).strip(),
             "qualified_handle": qualified_handle,
             "session_alias": str(existing_launch.get("session_alias", "")).strip()
+            or (named_session_ref.get("alias", "") if named_session_ref else "")
             or common.room_launch_session_alias(
                 str(message.get("guild_id", "")).strip(),
                 str(message.get("channel_id", "")).strip(),
@@ -1496,7 +1505,12 @@ def process_room_launch_message(
         }
     )
     try:
-        launch = common.ensure_room_launch_session(launch, attached_identity=attached_identity or None)
+        launch = common.ensure_room_launch_session(
+            launch,
+            attached_identity=attached_identity or None,
+            spawn_template_override=(named_session_ref.get("spawn_template", "") if named_session_ref else ""),
+            session_alias_override=(named_session_ref.get("alias", "") if named_session_ref else ""),
+        )
     except (ValueError, common.GCAPIError) as exc:
         receipt = persist_ingress_receipt(
             {
@@ -1595,6 +1609,7 @@ def process_room_launch_thread_message(
     target_handle = ""
     routing_mode = ""
     thread_attached_identity: dict[str, str] = {}
+    thread_named_session_ref: dict[str, str] = {}
     if mentioned_handles:
         try:
             thread_attached_identity = common.resolve_existing_session_for_handle(mentioned_handles[0])
@@ -1613,33 +1628,38 @@ def process_room_launch_thread_message(
             target_handle = mentioned_handles[0]
             routing_mode = "explicit_handle_attached"
         else:
-            try:
-                qualified_handle, resolve_error = common.resolve_agent_handle(mentioned_handles[0])
-            except common.GCAPIError as exc:
-                receipt = persist_ingress_receipt(
-                    {
-                        **base_receipt,
-                        "binding_id": str(launcher.get("id", "")).strip(),
-                        "status": "failed_lookup",
-                        "reason": str(exc),
-                        "targets": [],
-                    }
-                )
-                return {"status": "failed_lookup", "ingress_id": ingress_id, "receipt": receipt}
-            if resolve_error:
-                receipt = persist_ingress_receipt(
-                    {
-                        **base_receipt,
-                        "binding_id": str(launcher.get("id", "")).strip(),
-                        "status": "rejected_targeting",
-                        "reason": resolve_error,
-                        "mentioned_handles": mentioned_handles,
-                        "targets": [],
-                    }
-                )
-                return {"status": "rejected_targeting", "ingress_id": ingress_id, "receipt": receipt}
-            target_handle = qualified_handle
-            routing_mode = "explicit_handle"
+            thread_named_session_ref = common.resolve_named_session_for_handle(mentioned_handles[0])
+            if thread_named_session_ref:
+                target_handle = mentioned_handles[0]
+                routing_mode = "explicit_handle_named_session"
+            else:
+                try:
+                    qualified_handle, resolve_error = common.resolve_agent_handle(mentioned_handles[0])
+                except common.GCAPIError as exc:
+                    receipt = persist_ingress_receipt(
+                        {
+                            **base_receipt,
+                            "binding_id": str(launcher.get("id", "")).strip(),
+                            "status": "failed_lookup",
+                            "reason": str(exc),
+                            "targets": [],
+                        }
+                    )
+                    return {"status": "failed_lookup", "ingress_id": ingress_id, "receipt": receipt}
+                if resolve_error:
+                    receipt = persist_ingress_receipt(
+                        {
+                            **base_receipt,
+                            "binding_id": str(launcher.get("id", "")).strip(),
+                            "status": "rejected_targeting",
+                            "reason": resolve_error,
+                            "mentioned_handles": mentioned_handles,
+                            "targets": [],
+                        }
+                    )
+                    return {"status": "rejected_targeting", "ingress_id": ingress_id, "receipt": receipt}
+                target_handle = qualified_handle
+                routing_mode = "explicit_handle"
     if not target_handle and reply_to_id:
         target_handle = common.room_launch_message_target_handle(launch, reply_to_id)
         if target_handle:
@@ -1668,6 +1688,8 @@ def process_room_launch_thread_message(
             launch,
             target_handle,
             attached_identity=thread_attached_identity or None,
+            spawn_template_override=(thread_named_session_ref.get("spawn_template", "") if thread_named_session_ref else ""),
+            session_alias_override=(thread_named_session_ref.get("alias", "") if thread_named_session_ref else ""),
         )
     except (ValueError, common.GCAPIError) as exc:
         receipt = persist_ingress_receipt(

--- a/discord/scripts/discord_gateway_service.py
+++ b/discord/scripts/discord_gateway_service.py
@@ -726,6 +726,12 @@ def launcher_claims_message(config: dict[str, Any], channel_id: str, parent_id: 
     if parent and common.resolve_room_launcher(config, parent):
         return True
     if channel:
+        # Deliberate record read, unlike the config-only checks above: it is
+        # the only way to catch threads that outlive their launcher's config
+        # entry. Narrowing this back to a config lookup re-opens that gap
+        # silently -- lingering threads would fall through to extmsg's generic
+        # handler. Memoize per batch if the disk read ever costs too much; do
+        # not drop it.
         launch = common.load_room_launch(common.room_launch_record_id(channel))
         if launch and str(launch.get("thread_id", "")).strip() == channel:
             return True

--- a/discord/scripts/discord_intake_common.py
+++ b/discord/scripts/discord_intake_common.py
@@ -62,7 +62,7 @@ ROOM_LAUNCH_IDENTITY_RESOLVE_DELAY_SECONDS = 0.25
 ROOM_LAUNCH_READY_RESOLVE_TIMEOUT_SECONDS = 90.0
 ROOM_LAUNCH_READY_RESOLVE_DELAY_SECONDS = 0.5
 ROOM_LAUNCH_PRIMER_VERSION = 1
-AGENT_HANDLE_SEGMENT = re.compile(r"^[a-z][a-z0-9_-]{0,31}$")
+AGENT_HANDLE_SEGMENT = re.compile(r"^[a-z][a-z0-9_.-]{0,31}$")
 DISCORD_APP_NAME = re.compile(r"^[a-z][a-z0-9_-]{0,31}$")
 
 
@@ -3456,6 +3456,49 @@ def _normalize_agent_handle(handle: str) -> str:
     return normalized
 
 
+def resolve_existing_session_for_handle(handle: str) -> dict[str, str]:
+    """Attach-first launcher lookup: return the routable existing session
+    that matches `handle` by alias, session_name, or id. Case-insensitive.
+    Returns {} if none matches. This is what lets @@handle target an
+    already-running session instead of spawning a new one from a template.
+    """
+    normalized = str(handle).strip()
+    if not normalized:
+        return {}
+    key = normalized.lower()
+    alias_match: dict[str, Any] | None = None
+    name_match: dict[str, Any] | None = None
+    id_match: dict[str, Any] | None = None
+    try:
+        sessions = list_city_sessions(state="all")
+    except GCAPIError:
+        # Attach lookup is best-effort; if the API is unreachable, fall
+        # through to template resolution rather than blocking the launcher.
+        return {}
+    for item in sessions:
+        if not session_record_routable(item):
+            continue
+        alias = str(item.get("alias", "")).strip().lower()
+        session_name = str(item.get("session_name", "")).strip().lower()
+        session_id = str(item.get("id", "")).strip().lower()
+        if alias == key and (
+            alias_match is None or _session_record_preference(item) > _session_record_preference(alias_match)
+        ):
+            alias_match = item
+        if session_name == key and (
+            name_match is None or _session_record_preference(item) > _session_record_preference(name_match)
+        ):
+            name_match = item
+        if session_id == key and (
+            id_match is None or _session_record_preference(item) > _session_record_preference(id_match)
+        ):
+            id_match = item
+    chosen = alias_match or name_match or id_match
+    if not chosen:
+        return {}
+    return _session_identity_fields(chosen)
+
+
 def resolve_agent_handle(handle: str) -> tuple[str, str]:
     normalized = _normalize_agent_handle(handle)
     if not normalized:
@@ -3643,6 +3686,77 @@ def resolve_routable_session_candidate_eventually(*selectors: str) -> tuple[str,
         time.sleep(min(ROOM_LAUNCH_IDENTITY_RESOLVE_DELAY_SECONDS, remaining))
 
 
+def _find_launched_session_by_suffix(
+    sessions: list[dict[str, Any]],
+    qualified_handle: str,
+    requested_alias: str,
+) -> dict[str, Any] | None:
+    """Locate a session created via async /v0/sessions when the platform
+    prefixes the requested alias (e.g. pack namespace) so exact-alias match
+    fails. Uniqueness comes from the sha digest embedded in the requested
+    alias by room_launch_session_alias().
+    """
+    template = str(qualified_handle).strip()
+    alias_suffix = str(requested_alias).strip()
+    if not alias_suffix:
+        return None
+    best: dict[str, Any] | None = None
+    for item in sessions:
+        if template and str(item.get("template", "")).strip() != template:
+            continue
+        alias = str(item.get("alias", "")).strip()
+        if not alias:
+            continue
+        if alias == alias_suffix or alias.endswith("." + alias_suffix) or alias.endswith("-" + alias_suffix) or alias.endswith("/" + alias_suffix):
+            if best is None or _session_record_preference(item) > _session_record_preference(best):
+                best = item
+    return best
+
+
+def resolve_launched_session_identity_eventually(
+    qualified_handle: str,
+    requested_alias: str,
+    *,
+    require_routable: bool = True,
+) -> tuple[str, dict[str, str]]:
+    if not str(requested_alias).strip():
+        return "", {}
+    deadline = time.monotonic() + ROOM_LAUNCH_IDENTITY_RESOLVE_TIMEOUT_SECONDS
+    while True:
+        sessions = list_city_sessions(state="all")
+        chosen = _find_launched_session_by_suffix(sessions, qualified_handle, requested_alias)
+        if chosen and (not require_routable or session_record_routable(chosen)):
+            identity = _session_identity_fields(chosen)
+            selector = identity.get("session_name") or identity.get("session_id") or identity.get("alias") or ""
+            if selector:
+                return selector, identity
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return "", {}
+        time.sleep(min(ROOM_LAUNCH_IDENTITY_RESOLVE_DELAY_SECONDS, remaining))
+
+
+def resolve_launched_ready_session_identity_eventually(
+    qualified_handle: str,
+    requested_alias: str,
+) -> tuple[str, dict[str, str]]:
+    if not str(requested_alias).strip():
+        return "", {}
+    deadline = time.monotonic() + ROOM_LAUNCH_READY_RESOLVE_TIMEOUT_SECONDS
+    while True:
+        sessions = list_city_sessions(state="all")
+        chosen = _find_launched_session_by_suffix(sessions, qualified_handle, requested_alias)
+        if chosen and session_record_ready(chosen):
+            identity = _session_identity_fields(chosen)
+            selector = identity.get("session_name") or identity.get("session_id") or identity.get("alias") or ""
+            if selector:
+                return selector, identity
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return "", {}
+        time.sleep(min(ROOM_LAUNCH_READY_RESOLVE_DELAY_SECONDS, remaining))
+
+
 def session_record_ready(item: dict[str, Any] | None) -> bool:
     if not session_record_routable(item):
         return False
@@ -3767,7 +3881,7 @@ def room_launch_session_alias(guild_id: str, conversation_id: str, root_message_
 
 
 def room_launch_thread_name(qualified_handle: str, source_display: str = "") -> str:
-    handle_label = str(qualified_handle).strip().rsplit("/", 1)[-1] or "agent"
+    handle_label = str(qualified_handle).strip() or "agent"
     display = " ".join(str(source_display).strip().split())
     if display:
         value = f"{handle_label} - {display}"
@@ -3958,6 +4072,7 @@ def ensure_room_launch_session_for_handle(
     *,
     title: str = "",
     initial_message: str = "",
+    attached_identity: dict[str, str] | None = None,
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     launch_id = str(launch.get("launch_id", "")).strip()
     normalized_handle = str(qualified_handle).strip()
@@ -3978,6 +4093,22 @@ def ensure_room_launch_session_for_handle(
                 normalized_handle,
             )
         )
+        if attached_identity:
+            # Attach mode: participant is an already-running session; skip
+            # create + prime + poll. Trust the caller's resolved identity.
+            participant["session_alias"] = str(attached_identity.get("alias", "")).strip() or session_alias
+            participant["session_id"] = str(attached_identity.get("session_id", "")).strip()
+            participant["session_name"] = str(attached_identity.get("session_name", "")).strip()
+            participant["delivery_selector"] = (
+                str(participant.get("session_name", "")).strip()
+                or str(participant.get("session_id", "")).strip()
+                or str(participant.get("session_alias", "")).strip()
+            )
+            participant["qualified_handle"] = normalized_handle
+            participant["attached"] = True
+            current = _sync_launch_participant(current, normalized_handle, participant)
+            current = save_room_launch(current)
+            return current, copy.deepcopy(participant)
         existing = None
         if str(participant.get("session_name", "")).strip():
             existing_by_name = session_index_by_name(state="all").get(str(participant.get("session_name", "")).strip())
@@ -4027,6 +4158,15 @@ def ensure_room_launch_session_for_handle(
                 participant.get("session_alias", ""),
                 participant.get("session_id", ""),
             )
+        if created_new and not selector_snapshot:
+            # Async POST /v0/sessions returns no identity fields, and the
+            # platform may store the alias under a pack-namespace prefix
+            # (e.g. gasburger.dc-...). Fall back to a suffix match keyed by
+            # the unique sha digest baked into session_alias.
+            selector_snapshot, hydrated = resolve_launched_session_identity_eventually(
+                normalized_handle,
+                session_alias,
+            )
         if hydrated:
             participant["session_alias"] = str(hydrated.get("alias", "")).strip() or str(participant.get("session_alias", "")).strip()
             participant["session_id"] = str(hydrated.get("session_id", "")).strip() or str(participant.get("session_id", "")).strip()
@@ -4063,6 +4203,11 @@ def ensure_room_launch_session_for_handle(
                     participant.get("delivery_selector", ""),
                 )
             if not ready_identity:
+                _ready_selector, ready_identity = resolve_launched_ready_session_identity_eventually(
+                    normalized_handle,
+                    session_alias,
+                )
+            if not ready_identity:
                 raise GCAPIError(f"created launch session is not ready yet: {participant['session_alias'] or normalized_handle}")
             participant["session_alias"] = str(ready_identity.get("alias", "")).strip() or str(participant.get("session_alias", "")).strip()
             participant["session_id"] = str(ready_identity.get("session_id", "")).strip() or str(participant.get("session_id", "")).strip()
@@ -4097,6 +4242,7 @@ def ensure_room_launch_session(
     *,
     title: str = "",
     initial_message: str = "",
+    attached_identity: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     qualified_handle = str(launch.get("qualified_handle", "")).strip()
     current, _participant = ensure_room_launch_session_for_handle(
@@ -4104,6 +4250,7 @@ def ensure_room_launch_session(
         qualified_handle,
         title=title,
         initial_message=initial_message,
+        attached_identity=attached_identity,
     )
     return current
 
@@ -4240,7 +4387,7 @@ def extract_agent_handles(body: str) -> list[str]:
             start = j
             while j < len(text):
                 lower = text[j].lower()
-                if ("a" <= lower <= "z") or text[j].isdigit() or text[j] in {"_", "-"}:
+                if ("a" <= lower <= "z") or text[j].isdigit() or text[j] in {"_", "-", "."}:
                     j += 1
                     continue
                 break

--- a/discord/scripts/discord_intake_common.py
+++ b/discord/scripts/discord_intake_common.py
@@ -4136,6 +4136,26 @@ def _room_launch_participant_matches_session(participant: dict[str, Any], *, ses
     return False
 
 
+def _alias_matches_qualified_handle(alias: str, qualified_handle: str) -> bool:
+    """Match a session alias against a participant's qualified handle,
+    accepting the rig-prefixed pack alias shape the launcher also accepts
+    (docbook/meltron matches docbook/gasburger.meltron, never across rigs).
+    """
+    alias_key = str(alias).strip().lower()
+    handle_key = str(qualified_handle).strip().lower()
+    if not alias_key or not handle_key:
+        return False
+    if alias_key == handle_key:
+        return True
+    if "/" not in alias_key or "/" not in handle_key:
+        return False
+    alias_rig, alias_tail = alias_key.split("/", 1)
+    handle_rig, handle_tail = handle_key.split("/", 1)
+    if alias_rig != handle_rig:
+        return False
+    return alias_tail == handle_tail or alias_tail.endswith("." + handle_tail)
+
+
 def ensure_room_launch_session_for_handle(
     launch: dict[str, Any],
     qualified_handle: str,
@@ -4195,10 +4215,23 @@ def ensure_room_launch_session_for_handle(
             existing_by_alias = session_index_by_alias(state="all").get(session_alias)
             if session_record_routable(existing_by_alias):
                 existing = existing_by_alias
+        repinned_identity: dict[str, str] = {}
+        if not session_record_routable(existing):
+            # The stored session identity no longer routes: the seat's old
+            # session retired and it woke as a new one. The qualified handle
+            # is the stable identity, so re-resolve it the same way a fresh
+            # @@mention would before spawning a replacement — the thread
+            # re-pins to the live session instead of going deaf or spawning
+            # a second body for an already-running seat.
+            repinned_identity = resolve_existing_session_for_handle(normalized_handle)
         if session_record_routable(existing):
             participant["session_alias"] = str(existing.get("alias", "")).strip() or session_alias
             participant["session_id"] = str(existing.get("id", "")).strip()
             participant["session_name"] = str(existing.get("session_name", "")).strip()
+        elif repinned_identity:
+            participant["session_alias"] = str(repinned_identity.get("alias", "")).strip() or session_alias
+            participant["session_id"] = str(repinned_identity.get("session_id", "")).strip()
+            participant["session_name"] = str(repinned_identity.get("session_name", "")).strip()
         else:
             created_new = True
             created = create_agent_session(
@@ -4335,6 +4368,59 @@ def ensure_room_launch_session(
         session_alias_override=session_alias_override,
     )
     return current
+
+
+def repin_room_launch_participant_for_session(
+    launch_id: str,
+    qualified_handle: str,
+    *,
+    session_name: str = "",
+    session_id: str = "",
+    session_alias: str = "",
+) -> dict[str, Any] | None:
+    """Re-pin a launch participant to a live session identity.
+
+    A seat's session retires and it wakes as a new one; the qualified handle
+    stays. When the seat publishes into its old launch thread, rebind the
+    stored participant entry to the publishing session so later deliveries
+    reach the live session instead of knocking on the retired one. Returns
+    the updated launch record, or None when nothing changed.
+    """
+    normalized_launch_id = str(launch_id).strip()
+    normalized_handle = str(qualified_handle).strip()
+    normalized_name = str(session_name).strip()
+    normalized_id = str(session_id).strip()
+    if not normalized_launch_id or not normalized_handle:
+        return None
+    if not normalized_name and not normalized_id:
+        return None
+    with advisory_lock(room_launch_lock_path(normalized_launch_id)):
+        current = load_room_launch(normalized_launch_id)
+        if not isinstance(current, dict):
+            return None
+        participant = room_launch_participant(current, normalized_handle)
+        if not participant:
+            return None
+        if _room_launch_participant_matches_session(
+            participant,
+            session_name=normalized_name,
+            session_id=normalized_id,
+        ):
+            return None
+        if normalized_name:
+            participant["session_name"] = normalized_name
+        if normalized_id:
+            participant["session_id"] = normalized_id
+        if str(session_alias).strip():
+            participant["session_alias"] = str(session_alias).strip()
+        participant["delivery_selector"] = (
+            str(participant.get("session_name", "")).strip()
+            or str(participant.get("session_id", "")).strip()
+            or str(participant.get("session_alias", "")).strip()
+        )
+        participant["qualified_handle"] = normalized_handle
+        current = _sync_launch_participant(current, normalized_handle, participant)
+        return save_room_launch(current)
 
 
 def create_thread_from_message(parent_channel_id: str, source_message_id: str, name: str) -> dict[str, Any]:
@@ -5769,11 +5855,50 @@ def publish_binding_message(
         or str(resolved_source_identity.get("session_id", "")).strip()
         or str(os.environ.get("GC_SESSION_ID", "")).strip()
     )
+    launch_record = launch
+    if launch_record is None and str(source_meta.get("launch_id", "")).strip():
+        launch_record = load_room_launch(str(source_meta.get("launch_id", "")).strip())
     effective_source_qualified_handle = room_launch_participant_handle_for_session(
-        launch or {},
+        launch_record or {},
         session_name=effective_source_session_name,
         session_id=effective_source_session_id,
     )
+    effective_source_alias = str(resolved_source_identity.get("alias", "")).strip()
+    if not effective_source_qualified_handle and launch_record:
+        # The stored participant entries may pin a retired session; match the
+        # publishing session to its participant by alias instead (a seat's
+        # alias is its qualified handle) so the publish can re-pin below.
+        if not effective_source_alias:
+            env_session_id = str(os.environ.get("GC_SESSION_ID", "")).strip()
+            env_session_name = str(os.environ.get("GC_SESSION_NAME", "")).strip()
+            if (effective_source_session_id and effective_source_session_id == env_session_id) or (
+                effective_source_session_name and effective_source_session_name == env_session_name
+            ):
+                effective_source_alias = str(os.environ.get("GC_ALIAS", "")).strip()
+        if not effective_source_alias and (effective_source_session_id or effective_source_session_name):
+            try:
+                effective_source_alias = str(
+                    resolve_session_identity(
+                        effective_source_session_id or effective_source_session_name
+                    ).get("alias", "")
+                ).strip()
+            except GCAPIError:
+                effective_source_alias = ""
+        if effective_source_alias:
+            for handle in room_launch_participants(launch_record):
+                if _alias_matches_qualified_handle(effective_source_alias, handle):
+                    effective_source_qualified_handle = str(handle).strip()
+                    break
+    if effective_source_qualified_handle and launch_record:
+        repinned = repin_room_launch_participant_for_session(
+            str(launch_record.get("launch_id", "")).strip() or str(source_meta.get("launch_id", "")).strip(),
+            effective_source_qualified_handle,
+            session_name=effective_source_session_name,
+            session_id=effective_source_session_id,
+            session_alias=effective_source_alias,
+        )
+        if repinned:
+            launch_record = repinned
     record = save_chat_publish(
         {
             "binding_id": str(binding.get("id", "")).strip(),
@@ -5790,14 +5915,11 @@ def publish_binding_message(
             "source_event_kind": source_meta.get("source_event_kind", ""),
             "root_ingress_receipt_id": source_meta.get("root_ingress_receipt_id", ""),
             "launch_id": source_meta.get("launch_id", ""),
-            "launch_thread_id": str((launch or {}).get("thread_id", "")).strip(),
+            "launch_thread_id": str((launch_record or {}).get("thread_id", "")).strip(),
             "body": body,
             "remote_message_id": remote_message_id,
         }
     )
-    launch_record = launch
-    if launch_record is None and str(source_meta.get("launch_id", "")).strip():
-        launch_record = load_room_launch(str(source_meta.get("launch_id", "")).strip())
     launch_thread_id = str((launch_record or {}).get("thread_id", "")).strip()
     launch_record_id = str((launch_record or {}).get("launch_id", "")).strip() or str(source_meta.get("launch_id", "")).strip()
     if launch_record_id and launch_thread_id and conversation_id == launch_thread_id:

--- a/discord/scripts/discord_intake_common.py
+++ b/discord/scripts/discord_intake_common.py
@@ -3461,14 +3461,25 @@ def resolve_existing_session_for_handle(handle: str) -> dict[str, str]:
     that matches `handle` by alias, session_name, or id. Case-insensitive.
     Returns {} if none matches. This is what lets @@handle target an
     already-running session instead of spawning a new one from a template.
+
+    Also matches rig-prefixed aliases produced by rig-scoped named sessions:
+    when the user types @@daytripper/fattony, this matches sessions whose
+    stored alias is daytripper/gasburger.fattony (rig + pack + name). The
+    match requires the alias to sit under the same rig prefix so a bare
+    tail cannot cross rigs.
     """
     normalized = str(handle).strip()
     if not normalized:
         return {}
     key = normalized.lower()
+    rig_prefix = ""
+    tail = key
+    if "/" in key:
+        rig_prefix, tail = key.split("/", 1)
     alias_match: dict[str, Any] | None = None
     name_match: dict[str, Any] | None = None
     id_match: dict[str, Any] | None = None
+    rig_alias_match: dict[str, Any] | None = None
     try:
         sessions = list_city_sessions(state="all")
     except GCAPIError:
@@ -3493,10 +3504,69 @@ def resolve_existing_session_for_handle(handle: str) -> dict[str, str]:
             id_match is None or _session_record_preference(item) > _session_record_preference(id_match)
         ):
             id_match = item
-    chosen = alias_match or name_match or id_match
+        if rig_prefix and tail and alias.startswith(rig_prefix + "/"):
+            alias_tail = alias.split("/", 1)[1]
+            if alias_tail == tail or alias_tail.endswith("." + tail):
+                if rig_alias_match is None or _session_record_preference(item) > _session_record_preference(rig_alias_match):
+                    rig_alias_match = item
+    chosen = alias_match or name_match or id_match or rig_alias_match
     if not chosen:
         return {}
     return _session_identity_fields(chosen)
+
+
+def resolve_named_session_for_handle(handle: str) -> dict[str, str]:
+    """Named-session launcher lookup: is `handle` a declared but not-yet-
+    running named session? Returns {qualified_handle, template, alias,
+    scope, dir, spawn_template} that the caller can use to spawn via
+    create_agent_session. Returns {} on no match. Best-effort: swallows
+    errors reading city.toml so the launcher stays usable.
+
+    Handle matches are case-insensitive. For scope=rig entries the handle
+    is <dir>/<name>; for scope=city it is <name>.
+
+    spawn_template is the value to pass as create_agent_session(name=...):
+    rig-scoped templates are qualified with the rig prefix (dir/template)
+    so the platform resolves the correct rig-instance of the template.
+    """
+    normalized = str(handle).strip()
+    if not normalized:
+        return {}
+    key = normalized.lower()
+    try:
+        city_cfg = load_city_toml()
+    except (GCAPIError, OSError):
+        return {}
+    entries = city_cfg.get("named_session")
+    if not isinstance(entries, list):
+        return {}
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        template = str(entry.get("template", "")).strip()
+        if not template:
+            continue
+        raw_name = str(entry.get("name", "")).strip()
+        scope = str(entry.get("scope", "")).strip().lower()
+        dir_name = str(entry.get("dir", "")).strip()
+        alias = raw_name or template.rsplit("/", 1)[-1]
+        if scope == "rig" and dir_name:
+            qualified = f"{dir_name}/{alias}".lower()
+            spawn_template = template if "/" in template else f"{dir_name}/{template}"
+        else:
+            qualified = alias.lower()
+            spawn_template = template
+        if qualified != key:
+            continue
+        return {
+            "qualified_handle": qualified,
+            "template": template,
+            "alias": alias,
+            "scope": scope,
+            "dir": dir_name,
+            "spawn_template": spawn_template,
+        }
+    return {}
 
 
 def resolve_agent_handle(handle: str) -> tuple[str, str]:
@@ -4073,6 +4143,8 @@ def ensure_room_launch_session_for_handle(
     title: str = "",
     initial_message: str = "",
     attached_identity: dict[str, str] | None = None,
+    spawn_template_override: str = "",
+    session_alias_override: str = "",
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     launch_id = str(launch.get("launch_id", "")).strip()
     normalized_handle = str(qualified_handle).strip()
@@ -4084,8 +4156,12 @@ def ensure_room_launch_session_for_handle(
         participants = room_launch_participants(current)
         participant = copy.deepcopy(participants.get(normalized_handle, {}))
         created_new = False
+        # For named-session launches the caller supplies a stable alias
+        # (e.g. "fattony") so subsequent @@handle turns attach to the same
+        # session instead of spawning a fresh per-launch clone.
         session_alias = (
             str(participant.get("session_alias", "")).strip()
+            or str(session_alias_override).strip()
             or room_launch_session_alias(
                 str(current.get("guild_id", "")).strip(),
                 str(current.get("conversation_id", "")).strip(),
@@ -4093,6 +4169,7 @@ def ensure_room_launch_session_for_handle(
                 normalized_handle,
             )
         )
+        spawn_target = str(spawn_template_override).strip() or normalized_handle
         if attached_identity:
             # Attach mode: participant is an already-running session; skip
             # create + prime + poll. Trust the caller's resolved identity.
@@ -4125,7 +4202,7 @@ def ensure_room_launch_session_for_handle(
         else:
             created_new = True
             created = create_agent_session(
-                normalized_handle,
+                spawn_target,
                 alias=session_alias,
                 title=title or room_launch_thread_name(normalized_handle, str(current.get("from_display", "")).strip()),
                 initial_message=initial_message,
@@ -4162,9 +4239,10 @@ def ensure_room_launch_session_for_handle(
             # Async POST /v0/sessions returns no identity fields, and the
             # platform may store the alias under a pack-namespace prefix
             # (e.g. gasburger.dc-...). Fall back to a suffix match keyed by
-            # the unique sha digest baked into session_alias.
+            # the unique sha digest baked into session_alias, or by the
+            # supplied named-session alias for named-session launches.
             selector_snapshot, hydrated = resolve_launched_session_identity_eventually(
-                normalized_handle,
+                spawn_target,
                 session_alias,
             )
         if hydrated:
@@ -4204,7 +4282,7 @@ def ensure_room_launch_session_for_handle(
                 )
             if not ready_identity:
                 _ready_selector, ready_identity = resolve_launched_ready_session_identity_eventually(
-                    normalized_handle,
+                    spawn_target,
                     session_alias,
                 )
             if not ready_identity:
@@ -4243,6 +4321,8 @@ def ensure_room_launch_session(
     title: str = "",
     initial_message: str = "",
     attached_identity: dict[str, str] | None = None,
+    spawn_template_override: str = "",
+    session_alias_override: str = "",
 ) -> dict[str, Any]:
     qualified_handle = str(launch.get("qualified_handle", "")).strip()
     current, _participant = ensure_room_launch_session_for_handle(
@@ -4251,6 +4331,8 @@ def ensure_room_launch_session(
         title=title,
         initial_message=initial_message,
         attached_identity=attached_identity,
+        spawn_template_override=spawn_template_override,
+        session_alias_override=session_alias_override,
     )
     return current
 

--- a/discord/scripts/discord_intake_common.py
+++ b/discord/scripts/discord_intake_common.py
@@ -62,7 +62,10 @@ ROOM_LAUNCH_IDENTITY_RESOLVE_DELAY_SECONDS = 0.25
 ROOM_LAUNCH_READY_RESOLVE_TIMEOUT_SECONDS = 90.0
 ROOM_LAUNCH_READY_RESOLVE_DELAY_SECONDS = 0.5
 ROOM_LAUNCH_PRIMER_VERSION = 1
-AGENT_HANDLE_SEGMENT = re.compile(r"^[a-z][a-z0-9_.-]{0,31}$")
+# Dots are legal *inside* a segment (pack-qualified names like gasburger.mayor)
+# but never at the end: a mention that closes a sentence ("ask @@sky.") must
+# resolve to `sky`, not `sky.`.
+AGENT_HANDLE_SEGMENT = re.compile(r"^[a-z](?:[a-z0-9_.-]{0,30}[a-z0-9_-])?$")
 DISCORD_APP_NAME = re.compile(r"^[a-z][a-z0-9_-]{0,31}$")
 
 
@@ -3462,24 +3465,21 @@ def resolve_existing_session_for_handle(handle: str) -> dict[str, str]:
     Returns {} if none matches. This is what lets @@handle target an
     already-running session instead of spawning a new one from a template.
 
-    Also matches rig-prefixed aliases produced by rig-scoped named sessions:
-    when the user types @@daytripper/fattony, this matches sessions whose
-    stored alias is daytripper/gasburger.fattony (rig + pack + name). The
-    match requires the alias to sit under the same rig prefix so a bare
-    tail cannot cross rigs.
+    Also matches the pack-qualified aliases the platform stores for named
+    sessions, via the shared _alias_matches_qualified_handle policy: typing
+    @@daytripper/fattony matches a stored daytripper/gasburger.fattony, and
+    the city-scope @@emma matches a stored employees.emma. Neither shape
+    crosses a scope — a bare tail cannot reach into a rig, and a
+    rig-qualified handle cannot leave its own rig.
     """
     normalized = str(handle).strip()
     if not normalized:
         return {}
     key = normalized.lower()
-    rig_prefix = ""
-    tail = key
-    if "/" in key:
-        rig_prefix, tail = key.split("/", 1)
     alias_match: dict[str, Any] | None = None
     name_match: dict[str, Any] | None = None
     id_match: dict[str, Any] | None = None
-    rig_alias_match: dict[str, Any] | None = None
+    tail_alias_match: dict[str, Any] | None = None
     try:
         sessions = list_city_sessions(state="all")
     except GCAPIError:
@@ -3504,12 +3504,11 @@ def resolve_existing_session_for_handle(handle: str) -> dict[str, str]:
             id_match is None or _session_record_preference(item) > _session_record_preference(id_match)
         ):
             id_match = item
-        if rig_prefix and tail and alias.startswith(rig_prefix + "/"):
-            alias_tail = alias.split("/", 1)[1]
-            if alias_tail == tail or alias_tail.endswith("." + tail):
-                if rig_alias_match is None or _session_record_preference(item) > _session_record_preference(rig_alias_match):
-                    rig_alias_match = item
-    chosen = alias_match or name_match or id_match or rig_alias_match
+        if alias and _alias_matches_qualified_handle(alias, key) and (
+            tail_alias_match is None or _session_record_preference(item) > _session_record_preference(tail_alias_match)
+        ):
+            tail_alias_match = item
+    chosen = alias_match or name_match or id_match or tail_alias_match
     if not chosen:
         return {}
     return _session_identity_fields(chosen)
@@ -3523,7 +3522,14 @@ def resolve_named_session_for_handle(handle: str) -> dict[str, str]:
     errors reading city.toml so the launcher stays usable.
 
     Handle matches are case-insensitive. For scope=rig entries the handle
-    is <dir>/<name>; for scope=city it is <name>.
+    is <dir>/<name>; for scope=city it is <name>. Declarations routinely
+    carry neither key, and gc fills both in: an omitted name leaves the
+    template itself as the public identity (config.go NamedSession.
+    IdentityName), so gastown.witness is addressed as @@<rig>/gastown.witness,
+    and a rig-scoped entry that omits dir declares one seat per configured
+    rig rather than a seat in a named rig, so it expands across city.toml's
+    rigs here the way gc expands it internally (config.go,
+    ExpandGenericRigNamedSessions).
 
     spawn_template is the value to pass as create_agent_session(name=...):
     rig-scoped templates are qualified with the rig prefix (dir/template)
@@ -3540,6 +3546,7 @@ def resolve_named_session_for_handle(handle: str) -> dict[str, str]:
     entries = city_cfg.get("named_session")
     if not isinstance(entries, list):
         return {}
+    rig_names = _city_rig_names(city_cfg)
     for entry in entries:
         if not isinstance(entry, dict):
             continue
@@ -3550,23 +3557,49 @@ def resolve_named_session_for_handle(handle: str) -> dict[str, str]:
         scope = str(entry.get("scope", "")).strip().lower()
         dir_name = str(entry.get("dir", "")).strip()
         alias = raw_name or template.rsplit("/", 1)[-1]
-        if scope == "rig" and dir_name:
-            qualified = f"{dir_name}/{alias}".lower()
-            spawn_template = template if "/" in template else f"{dir_name}/{template}"
+        if scope == "rig":
+            # A rig-scoped entry that names no dir declares a seat in every
+            # configured rig, so address it as <rig>/<name> for each of them.
+            # Falling back to city scope here would answer a bare @@name with
+            # an unqualified spawn template that resolves outside the rig the
+            # declaration asked for; with no rigs configured the seat simply
+            # has nowhere to live and stays unaddressable.
+            candidate_dirs = [dir_name] if dir_name else rig_names
         else:
-            qualified = alias.lower()
-            spawn_template = template
-        if qualified != key:
-            continue
-        return {
-            "qualified_handle": qualified,
-            "template": template,
-            "alias": alias,
-            "scope": scope,
-            "dir": dir_name,
-            "spawn_template": spawn_template,
-        }
+            candidate_dirs = [""]
+        for candidate_dir in candidate_dirs:
+            if candidate_dir:
+                qualified = f"{candidate_dir}/{alias}".lower()
+                spawn_template = template if "/" in template else f"{candidate_dir}/{template}"
+            else:
+                qualified = alias.lower()
+                spawn_template = template
+            if qualified != key:
+                continue
+            return {
+                "qualified_handle": qualified,
+                "template": template,
+                "alias": alias,
+                "scope": scope,
+                "dir": candidate_dir,
+                "spawn_template": spawn_template,
+            }
     return {}
+
+
+def _city_rig_names(city_cfg: dict[str, Any]) -> list[str]:
+    """Rig directory names declared in city.toml, in declaration order."""
+    rigs = city_cfg.get("rigs")
+    if not isinstance(rigs, list):
+        return []
+    names: list[str] = []
+    for rig in rigs:
+        if not isinstance(rig, dict):
+            continue
+        name = str(rig.get("name", "")).strip()
+        if name and name not in names:
+            names.append(name)
+    return names
 
 
 def resolve_agent_handle(handle: str) -> tuple[str, str]:
@@ -3733,21 +3766,29 @@ def resolve_routable_session_identity_eventually(*selectors: str) -> dict[str, s
     return identity
 
 
-def resolve_routable_session_candidate_eventually(*selectors: str) -> tuple[str, dict[str, str]]:
-    candidates: list[str] = []
-    seen: set[str] = set()
-    for selector in selectors:
-        normalized = str(selector).strip()
-        if not normalized or normalized in seen:
-            continue
-        seen.add(normalized)
-        candidates.append(normalized)
-    if not candidates:
+def resolve_routable_session_candidate_eventually(
+    *selectors: str,
+    suffix_template: str = "",
+    suffix_alias: str = "",
+    timeout: float | None = None,
+) -> tuple[str, dict[str, str]]:
+    candidates = _poll_candidates(selectors)
+    if not candidates and not str(suffix_alias).strip():
         return "", {}
-    deadline = time.monotonic() + ROOM_LAUNCH_IDENTITY_RESOLVE_TIMEOUT_SECONDS
+    deadline = time.monotonic() + _poll_timeout(timeout, ROOM_LAUNCH_IDENTITY_RESOLVE_TIMEOUT_SECONDS)
     while True:
         sessions = list_city_sessions(state="all")
         matched_selector, identity = resolve_routable_session_candidate_from_sessions(sessions, *candidates)
+        if identity:
+            return matched_selector, identity
+        # Same iteration, deliberately not a second deadline: when the
+        # platform stores the requested alias pack-prefixed, no exact
+        # candidate can ever match, so polling exact-only to exhaustion first
+        # would stall every such spawn for the full timeout while holding the
+        # launch advisory lock.
+        matched_selector, identity = _resolve_launched_session_by_suffix(
+            sessions, suffix_template, suffix_alias, ready=False,
+        )
         if identity:
             return matched_selector, identity
         remaining = deadline - time.monotonic()
@@ -3783,48 +3824,46 @@ def _find_launched_session_by_suffix(
     return best
 
 
-def resolve_launched_session_identity_eventually(
+def _resolve_launched_session_by_suffix(
+    sessions: list[dict[str, Any]],
     qualified_handle: str,
     requested_alias: str,
     *,
-    require_routable: bool = True,
+    ready: bool,
 ) -> tuple[str, dict[str, str]]:
+    """One suffix-match attempt against an already-fetched session list."""
     if not str(requested_alias).strip():
         return "", {}
-    deadline = time.monotonic() + ROOM_LAUNCH_IDENTITY_RESOLVE_TIMEOUT_SECONDS
-    while True:
-        sessions = list_city_sessions(state="all")
-        chosen = _find_launched_session_by_suffix(sessions, qualified_handle, requested_alias)
-        if chosen and (not require_routable or session_record_routable(chosen)):
-            identity = _session_identity_fields(chosen)
-            selector = identity.get("session_name") or identity.get("session_id") or identity.get("alias") or ""
-            if selector:
-                return selector, identity
-        remaining = deadline - time.monotonic()
-        if remaining <= 0:
-            return "", {}
-        time.sleep(min(ROOM_LAUNCH_IDENTITY_RESOLVE_DELAY_SECONDS, remaining))
-
-
-def resolve_launched_ready_session_identity_eventually(
-    qualified_handle: str,
-    requested_alias: str,
-) -> tuple[str, dict[str, str]]:
-    if not str(requested_alias).strip():
+    chosen = _find_launched_session_by_suffix(sessions, qualified_handle, requested_alias)
+    if not chosen:
         return "", {}
-    deadline = time.monotonic() + ROOM_LAUNCH_READY_RESOLVE_TIMEOUT_SECONDS
-    while True:
-        sessions = list_city_sessions(state="all")
-        chosen = _find_launched_session_by_suffix(sessions, qualified_handle, requested_alias)
-        if chosen and session_record_ready(chosen):
-            identity = _session_identity_fields(chosen)
-            selector = identity.get("session_name") or identity.get("session_id") or identity.get("alias") or ""
-            if selector:
-                return selector, identity
-        remaining = deadline - time.monotonic()
-        if remaining <= 0:
-            return "", {}
-        time.sleep(min(ROOM_LAUNCH_READY_RESOLVE_DELAY_SECONDS, remaining))
+    if not (session_record_ready(chosen) if ready else session_record_routable(chosen)):
+        return "", {}
+    identity = _session_identity_fields(chosen)
+    selector = identity.get("session_name") or identity.get("session_id") or identity.get("alias") or ""
+    if not selector:
+        return "", {}
+    return selector, identity
+
+
+def _poll_candidates(selectors: tuple[str, ...]) -> list[str]:
+    candidates: list[str] = []
+    seen: set[str] = set()
+    for selector in selectors:
+        normalized = str(selector).strip()
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        candidates.append(normalized)
+    return candidates
+
+
+def _poll_timeout(override: float | None, default_seconds: float) -> float:
+    """Injectable poll deadline: callers (and tests) may pin the timeout,
+    otherwise the module default is read at call time."""
+    if override is None:
+        return float(default_seconds)
+    return max(0.0, float(override))
 
 
 def session_record_ready(item: dict[str, Any] | None) -> bool:
@@ -3878,21 +3917,26 @@ def resolve_ready_session_candidate_from_sessions(
     return "", {}
 
 
-def resolve_ready_session_candidate_eventually(*selectors: str) -> tuple[str, dict[str, str]]:
-    candidates: list[str] = []
-    seen: set[str] = set()
-    for selector in selectors:
-        normalized = str(selector).strip()
-        if not normalized or normalized in seen:
-            continue
-        seen.add(normalized)
-        candidates.append(normalized)
-    if not candidates:
+def resolve_ready_session_candidate_eventually(
+    *selectors: str,
+    suffix_template: str = "",
+    suffix_alias: str = "",
+    timeout: float | None = None,
+) -> tuple[str, dict[str, str]]:
+    candidates = _poll_candidates(selectors)
+    if not candidates and not str(suffix_alias).strip():
         return "", {}
-    deadline = time.monotonic() + ROOM_LAUNCH_READY_RESOLVE_TIMEOUT_SECONDS
+    deadline = time.monotonic() + _poll_timeout(timeout, ROOM_LAUNCH_READY_RESOLVE_TIMEOUT_SECONDS)
     while True:
         sessions = list_city_sessions(state="all")
         matched_selector, identity = resolve_ready_session_candidate_from_sessions(sessions, *candidates)
+        if identity:
+            return matched_selector, identity
+        # Folded into this iteration for the same reason as the identity
+        # poll above: a pack-prefixed alias is unreachable by exact match.
+        matched_selector, identity = _resolve_launched_session_by_suffix(
+            sessions, suffix_template, suffix_alias, ready=True,
+        )
         if identity:
             return matched_selector, identity
         remaining = deadline - time.monotonic()
@@ -4137,9 +4181,18 @@ def _room_launch_participant_matches_session(participant: dict[str, Any], *, ses
 
 
 def _alias_matches_qualified_handle(alias: str, qualified_handle: str) -> bool:
-    """Match a session alias against a participant's qualified handle,
-    accepting the rig-prefixed pack alias shape the launcher also accepts
-    (docbook/meltron matches docbook/gasburger.meltron, never across rigs).
+    """Does a platform-stored session alias name the seat `qualified_handle`?
+
+    The platform qualifies an explicitly requested alias with the binding it
+    resolves under, so the seat we asked to call `meltron` comes back stored
+    as `docbook/gasburger.meltron` for a rig-scoped binding and as
+    `gasburger.meltron` for a city-scoped one. Both shapes match here, and
+    neither crosses a scope: a rig-qualified handle only matches aliases
+    under the same rig, and a bare handle only matches bare aliases.
+
+    This is the single tail-match policy — the attach lookup
+    (resolve_existing_session_for_handle) and the publish-side re-pin share
+    it so a seat reachable by @@handle is also re-pinnable, and vice versa.
     """
     alias_key = str(alias).strip().lower()
     handle_key = str(qualified_handle).strip().lower()
@@ -4147,12 +4200,15 @@ def _alias_matches_qualified_handle(alias: str, qualified_handle: str) -> bool:
         return False
     if alias_key == handle_key:
         return True
-    if "/" not in alias_key or "/" not in handle_key:
+    if ("/" in alias_key) != ("/" in handle_key):
         return False
-    alias_rig, alias_tail = alias_key.split("/", 1)
-    handle_rig, handle_tail = handle_key.split("/", 1)
-    if alias_rig != handle_rig:
-        return False
+    if "/" in handle_key:
+        alias_rig, alias_tail = alias_key.split("/", 1)
+        handle_rig, handle_tail = handle_key.split("/", 1)
+        if alias_rig != handle_rig:
+            return False
+    else:
+        alias_tail, handle_tail = alias_key, handle_key
     return alias_tail == handle_tail or alias_tail.endswith("." + handle_tail)
 
 
@@ -4262,21 +4318,18 @@ def ensure_room_launch_session_for_handle(
                 selector_snapshot = created_selector
                 hydrated = created_identity
         if created_new and not selector_snapshot:
+            # Async POST /v0/sessions returns no identity fields, and the
+            # platform may store the alias under a pack-namespace prefix
+            # (e.g. gasburger.dc-...). Each poll tries the exact selectors
+            # and then a suffix match keyed by the unique sha digest baked
+            # into session_alias (or by the supplied named-session alias).
             selector_snapshot, hydrated = resolve_routable_session_candidate_eventually(
                 participant.get("session_name", ""),
                 participant.get("delivery_selector", ""),
                 participant.get("session_alias", ""),
                 participant.get("session_id", ""),
-            )
-        if created_new and not selector_snapshot:
-            # Async POST /v0/sessions returns no identity fields, and the
-            # platform may store the alias under a pack-namespace prefix
-            # (e.g. gasburger.dc-...). Fall back to a suffix match keyed by
-            # the unique sha digest baked into session_alias, or by the
-            # supplied named-session alias for named-session launches.
-            selector_snapshot, hydrated = resolve_launched_session_identity_eventually(
-                spawn_target,
-                session_alias,
+                suffix_template=spawn_target,
+                suffix_alias=session_alias,
             )
         if hydrated:
             participant["session_alias"] = str(hydrated.get("alias", "")).strip() or str(participant.get("session_alias", "")).strip()
@@ -4312,11 +4365,8 @@ def ensure_room_launch_session_for_handle(
                     participant.get("session_id", ""),
                     participant.get("session_alias", ""),
                     participant.get("delivery_selector", ""),
-                )
-            if not ready_identity:
-                _ready_selector, ready_identity = resolve_launched_ready_session_identity_eventually(
-                    spawn_target,
-                    session_alias,
+                    suffix_template=spawn_target,
+                    suffix_alias=session_alias,
                 )
             if not ready_identity:
                 raise GCAPIError(f"created launch session is not ready yet: {participant['session_alias'] or normalized_handle}")
@@ -4559,7 +4609,12 @@ def extract_agent_handles(body: str) -> list[str]:
                     j += 1
                     continue
                 break
-            part = text[start:j]
+            # The scan set carries "." so pack-qualified segments
+            # (gasburger.mayor) survive, but sentence punctuation must not:
+            # "ask @@sky." names the seat `sky`, not `sky.`. Trailing dots are
+            # dropped here rather than terminating the scan so a mention
+            # followed by an ellipsis still resolves.
+            part = text[start:j].rstrip(".")
             if not part:
                 break
             parts.append(part)

--- a/discord/tests/test_discord_chat_scripts.py
+++ b/discord/tests/test_discord_chat_scripts.py
@@ -422,7 +422,7 @@ class DiscordChatScriptTests(unittest.TestCase):
                 code = reply_current_script.main(["--body-file", str(body_file)])
 
         self.assertEqual(code, 0)
-        create_thread_from_message.assert_called_once_with("22", "orig-22", "sky")
+        create_thread_from_message.assert_called_once_with("22", "orig-22", "corp/sky")
         post_channel_message.assert_called_once_with("333", "safe reply", reply_to_message_id="")
         payload = common.json.loads(stdout.getvalue())
         self.assertEqual(payload["record"]["conversation_id"], "333")
@@ -462,7 +462,7 @@ class DiscordChatScriptTests(unittest.TestCase):
                 )
 
         self.assertEqual(code, 0)
-        create_thread_from_message.assert_called_once_with("22", "orig-29", "sky")
+        create_thread_from_message.assert_called_once_with("22", "orig-29", "corp/sky")
         post_channel_message.assert_called_once_with("444", "hello launcher", reply_to_message_id="")
         payload = common.json.loads(stdout.getvalue())
         self.assertEqual(payload["record"]["launch_id"], "room-launch:orig-29")

--- a/discord/tests/test_discord_gateway_service.py
+++ b/discord/tests/test_discord_gateway_service.py
@@ -887,6 +887,239 @@ class DiscordGatewayServiceTests(unittest.TestCase):
         normalize_to_extmsg_message.assert_not_called()
         deliver_to_extmsg.assert_not_called()
 
+    def test_record_extmsg_inbound_skips_launcher_room_mentions(self) -> None:
+        # Same precedence as a bound room: extmsg must yield the launcher's
+        # own room so process_room_launch_message gets the message instead of
+        # spawning a generic session in a thread the launcher never sees.
+        self._configure_discord_app()
+        common.set_room_launcher(common.load_config(), "1", "22")
+        worker = self._new_gateway_worker()
+        message = {
+            "id": "207c",
+            "guild_id": "1",
+            "channel_id": "22",
+            "content": "@@corp/sky what changed?",
+            "author": {"id": "u-207c", "username": "alice"},
+        }
+
+        with mock.patch.object(common, "resolve_at_mentions", return_value=["sky"]) as resolve_at_mentions, mock.patch.object(
+            common, "resolve_mention_targets"
+        ) as resolve_mention_targets, mock.patch.object(common, "launch_thread_for_mentions") as launch_thread_for_mentions:
+            handled = worker._record_extmsg_inbound(message, bot_user_id="999")
+
+        self.assertFalse(handled)
+        resolve_at_mentions.assert_not_called()
+        resolve_mention_targets.assert_not_called()
+        launch_thread_for_mentions.assert_not_called()
+
+    def _record_extmsg_thread_message(
+        self, worker: "gateway_service.GatewayWorker", message: dict, parent_id: str,
+    ) -> tuple[object, mock.MagicMock]:
+        """Drive a thread message all the way to extmsg delivery, stubbing the
+        agent-directory lookups the thread branch makes on the way. Without
+        those stubs the branch raises and returns False on its own, and every
+        "extmsg did not take this thread" assertion passes vacuously.
+        """
+        with mock.patch.object(gateway_service, "_resolve_thread_parent", return_value=parent_id), mock.patch.object(
+            common, "resolve_at_mentions", return_value=[]
+        ), mock.patch.object(
+            common, "resolve_nl_agent_mentions", return_value=[]
+        ), mock.patch.object(
+            common, "normalize_to_extmsg_message", return_value={},
+        ), mock.patch.object(common, "deliver_to_extmsg") as deliver_to_extmsg:
+            handled = worker._record_extmsg_inbound(message, bot_user_id="999")
+        return handled, deliver_to_extmsg
+
+    def test_record_extmsg_inbound_delivers_threads_outside_a_launcher(self) -> None:
+        # Positive control for the two thread skips below: this fixture does
+        # reach extmsg delivery, so their assert_not_called is a real signal.
+        self._configure_discord_app()
+        worker = self._new_gateway_worker()
+        message = {
+            "id": "207g",
+            "guild_id": "1",
+            "channel_id": "223",
+            "content": "still there?",
+            "author": {"id": "u-207g", "username": "alice"},
+        }
+
+        handled, deliver_to_extmsg = self._record_extmsg_thread_message(worker, message, parent_id="33")
+
+        self.assertTrue(handled)
+        deliver_to_extmsg.assert_called_once()
+
+    def test_record_extmsg_inbound_skips_thread_inside_launcher_room(self) -> None:
+        self._configure_discord_app()
+        common.set_room_launcher(common.load_config(), "1", "22")
+        worker = self._new_gateway_worker()
+        message = {
+            "id": "207d",
+            "guild_id": "1",
+            "channel_id": "223",
+            "content": "still there?",
+            "author": {"id": "u-207d", "username": "alice"},
+        }
+
+        handled, deliver_to_extmsg = self._record_extmsg_thread_message(worker, message, parent_id="22")
+
+        self.assertFalse(handled)
+        deliver_to_extmsg.assert_not_called()
+
+    def test_record_extmsg_inbound_skips_lingering_launch_record_thread(self) -> None:
+        # Condition 3 carrying the claim alone: the launcher was unconfigured
+        # while its launch records lingered, so the parent is no longer a
+        # launcher room and only the record's thread_id still identifies the
+        # thread as launcher-managed.
+        self._configure_discord_app()
+        common.save_room_launch(
+            {
+                "launch_id": "room-launch:224",
+                "launcher_id": "launch-room:22",
+                "guild_id": "1",
+                "conversation_id": "22",
+                "root_message_id": "224",
+                "qualified_handle": "corp/sky",
+                "thread_id": "224",
+                "state": "active",
+            }
+        )
+        worker = self._new_gateway_worker()
+        message = {
+            "id": "207e",
+            "guild_id": "1",
+            "channel_id": "224",
+            "content": "follow up",
+            "author": {"id": "u-207e", "username": "alice"},
+        }
+
+        handled, deliver_to_extmsg = self._record_extmsg_thread_message(worker, message, parent_id="22")
+
+        self.assertFalse(handled)
+        deliver_to_extmsg.assert_not_called()
+
+    def test_record_extmsg_inbound_still_handles_rooms_without_a_launcher(self) -> None:
+        # Positive control for the two skips above: with no launcher and no
+        # binding, extmsg keeps its room-mention path. Without this, widening
+        # launcher_claims_message to claim everything stays green.
+        self._configure_discord_app()
+        worker = self._new_gateway_worker()
+        message = {
+            "id": "207f",
+            "guild_id": "1",
+            "channel_id": "22",
+            "content": "@randy what changed?",
+            "author": {"id": "u-207f", "username": "alice"},
+        }
+
+        with mock.patch.object(common, "resolve_at_mentions", return_value=["randy"]) as resolve_at_mentions, mock.patch.object(
+            common, "resolve_mention_targets", return_value=[]
+        ), mock.patch.object(common, "launch_thread_for_mentions"):
+            worker._record_extmsg_inbound(message, bot_user_id="999")
+
+        resolve_at_mentions.assert_called_once()
+
+    def test_participant_target_identity_carries_every_selector(self) -> None:
+        identity = gateway_service.participant_target_identity(
+            {"session_name": "s-gc-123", "session_id": "gc-123", "session_alias": "corp/gasburger.sky",
+             "delivery_selector": "s-gc-123"}
+        )
+
+        self.assertEqual(
+            identity,
+            {"session_name": "s-gc-123", "session_id": "gc-123", "session_alias": "corp/gasburger.sky"},
+        )
+        self.assertEqual(gateway_service.participant_target_identity({"session_id": " "}), {})
+        self.assertEqual(gateway_service.participant_target_identity({}), {})
+
+    def test_process_inbound_room_launch_receipt_target_carries_session_identity(self) -> None:
+        # reply-current matches a receipt target by whichever of
+        # GC_SESSION_ID / GC_SESSION_NAME / alias the replying session
+        # presents, so all three must survive into targets[].
+        common.set_room_launcher(common.load_config(), "1", "22")
+        message = {
+            "id": "208z",
+            "guild_id": "1",
+            "channel_id": "22",
+            "content": "@@corp/sky please help",
+            "author": {"id": "u-208z", "username": "alice"},
+        }
+
+        with mock.patch.object(common, "resolve_agent_handle", return_value=("corp/sky", "")), mock.patch.object(
+            common,
+            "ensure_room_launch_session",
+            return_value={
+                "launch_id": "room-launch:208z",
+                "qualified_handle": "corp/sky",
+                "session_alias": "corp/gasburger.sky",
+                "session_name": "s-gc-123",
+                "session_id": "gc-123",
+            },
+        ), mock.patch.object(common, "deliver_session_message", return_value={"status": "accepted"}):
+            gateway_service.process_inbound_message(message, bot_user_id="999")
+
+        receipt = common.load_chat_ingress("in-208z")
+        assert receipt is not None
+        target = receipt["targets"][0]
+        self.assertEqual(target["session_name"], "s-gc-123")
+        self.assertEqual(target["session_id"], "gc-123")
+        self.assertEqual(target["session_alias"], "corp/gasburger.sky")
+
+    def test_launcher_claims_message_matches_configured_launcher_room(self) -> None:
+        config = common.set_room_launcher(common.load_config(), "1", "22")
+
+        self.assertTrue(gateway_service.launcher_claims_message(config, "22"))
+
+    def test_launcher_claims_message_matches_thread_whose_parent_is_the_launcher(self) -> None:
+        # Condition 2 on its own: a thread channel with no launch record is
+        # still the launcher's, claimed via its parent.
+        config = common.set_room_launcher(common.load_config(), "1", "22")
+
+        self.assertTrue(gateway_service.launcher_claims_message(config, "999222", parent_id="22"))
+        self.assertFalse(gateway_service.launcher_claims_message(config, "999222"))
+
+    def test_launcher_claims_message_matches_launch_record_thread(self) -> None:
+        config = common.set_room_launcher(common.load_config(), "1", "22")
+        common.save_room_launch(
+            {
+                "launch_id": "room-launch:225",
+                "launcher_id": "launch-room:22",
+                "guild_id": "1",
+                "conversation_id": "22",
+                "root_message_id": "225",
+                "qualified_handle": "corp/sky",
+                "thread_id": "225",
+                "state": "active",
+            }
+        )
+
+        self.assertTrue(gateway_service.launcher_claims_message(config, "225"))
+
+    def test_launcher_claims_message_ignores_unrelated_channels(self) -> None:
+        config = common.set_room_launcher(common.load_config(), "1", "22")
+
+        self.assertFalse(gateway_service.launcher_claims_message(config, "33"))
+        self.assertFalse(gateway_service.launcher_claims_message(config, "33", parent_id="44"))
+        self.assertFalse(gateway_service.launcher_claims_message(config, ""))
+
+    def test_launcher_claims_message_ignores_launch_record_for_a_different_thread(self) -> None:
+        # The record must name this channel as its thread: a launch whose
+        # thread lives elsewhere does not claim the root message's channel.
+        config = common.set_room_launcher(common.load_config(), "1", "22")
+        common.save_room_launch(
+            {
+                "launch_id": "room-launch:226",
+                "launcher_id": "launch-room:22",
+                "guild_id": "1",
+                "conversation_id": "22",
+                "root_message_id": "226",
+                "qualified_handle": "corp/sky",
+                "thread_id": "22699",
+                "state": "active",
+            }
+        )
+
+        self.assertFalse(gateway_service.launcher_claims_message(config, "226"))
+
     def test_process_inbound_room_launch_routes_handle_without_bot_mention(self) -> None:
         common.set_room_launcher(common.load_config(), "1", "22")
         message = {

--- a/discord/tests/test_discord_intake_common.py
+++ b/discord/tests/test_discord_intake_common.py
@@ -914,6 +914,34 @@ class DiscordIntakeCommonTests(unittest.TestCase):
 
         self.assertEqual(handles, ["gasburger.mayor", "gc-packs/gasburger.crew"])
 
+    def test_extract_agent_handles_drops_sentence_final_dot(self) -> None:
+        # Dots are legal inside a segment, but a mention that ends a sentence
+        # names the seat, not "seat.": anything else fails every downstream
+        # lookup and answers ordinary prose with a rejected receipt.
+        handles = common.extract_agent_handles("please ask @@sky. thanks")
+
+        self.assertEqual(handles, ["sky"])
+
+    def test_extract_agent_handles_drops_trailing_dots_from_qualified_handle(self) -> None:
+        handles = common.extract_agent_handles("@@corp/sky... anyone?")
+
+        self.assertEqual(handles, ["corp/sky"])
+
+    def test_extract_agent_handles_collapses_dotted_and_bare_mention_of_one_seat(self) -> None:
+        handles = common.extract_agent_handles("@@sky. and @@sky")
+
+        self.assertEqual(handles, ["sky"])
+
+    def test_agent_handle_segment_rejects_trailing_dot(self) -> None:
+        # Defence in depth behind the extractor: the same pattern validates
+        # handles arriving from slash commands and stored records.
+        self.assertIsNone(common.AGENT_HANDLE_SEGMENT.fullmatch("sky."))
+        self.assertIsNotNone(common.AGENT_HANDLE_SEGMENT.fullmatch("gasburger.mayor"))
+        self.assertIsNotNone(common.AGENT_HANDLE_SEGMENT.fullmatch("sky"))
+        self.assertIsNotNone(common.AGENT_HANDLE_SEGMENT.fullmatch("s"))
+        self.assertIsNotNone(common.AGENT_HANDLE_SEGMENT.fullmatch("a" * 32))
+        self.assertIsNone(common.AGENT_HANDLE_SEGMENT.fullmatch("a" * 33))
+
     def test_build_command_payload_includes_rig_option(self) -> None:
         payload = common.build_command_payload("gc")
 
@@ -1763,6 +1791,79 @@ class DiscordIntakeCommonTests(unittest.TestCase):
         self.assertEqual(participant["delivery_selector"], "corp--sky")
         self.assertEqual(launch["message_targets"]["msg-launch-13"], "corp/sky")
 
+    def _save_cross_rig_launch(self, launch_id: str, root_message_id: str) -> None:
+        common.save_room_launch(
+            {
+                "launch_id": launch_id,
+                "launcher_id": "launch-room:22",
+                "guild_id": "1",
+                "conversation_id": "22",
+                "root_message_id": root_message_id,
+                "qualified_handle": "daytripper/sky",
+                "session_alias": "daytripper/pack.sky",
+                "session_name": "s-gc-old",
+                "session_id": "gc-old",
+                "thread_id": "333",
+                "participants": {
+                    "daytripper/sky": {
+                        "qualified_handle": "daytripper/sky",
+                        "session_alias": "daytripper/pack.sky",
+                        "session_name": "s-gc-old",
+                        "session_id": "gc-old",
+                        "delivery_selector": "s-gc-old",
+                    }
+                },
+            }
+        )
+
+    def _publish_as_session(self, launch_id: str, alias: str, message_id: str) -> dict[str, object]:
+        config = common.set_room_launcher(common.load_config(), "1", "22")
+        route = common.resolve_publish_route(config, "launch-room:22")
+        assert route is not None
+        with mock.patch.object(
+            common, "post_channel_message", return_value={"id": message_id},
+        ), mock.patch.object(
+            common,
+            "resolve_session_identity",
+            return_value={"session_name": "pub--sky", "session_id": "gc-new", "alias": alias},
+        ):
+            return common.publish_binding_message(
+                route,
+                "hello from my new body",
+                source_context={"kind": "discord_human_message", "publish_launch_id": launch_id},
+                source_session_name="pub--sky",
+                source_session_id="gc-new",
+            )
+
+    def test_publish_binding_message_repins_participant_matched_by_pack_alias(self) -> None:
+        # Positive arm: a live session under the participant's own rig, stored
+        # under the pack-qualified alias, is the same seat and re-pins.
+        self._save_cross_rig_launch("room-launch:orig-14", "orig-14")
+
+        payload = self._publish_as_session("room-launch:orig-14", "daytripper/pack.sky", "msg-launch-14")
+
+        self.assertEqual(payload["record"]["source_qualified_handle"], "daytripper/sky")
+        launch = common.load_room_launch("room-launch:orig-14")
+        assert launch is not None
+        self.assertEqual(launch["participants"]["daytripper/sky"]["session_id"], "gc-new")
+
+    def test_publish_binding_message_does_not_repin_participant_across_rigs(self) -> None:
+        # Negative arm for the same guard: an identically named seat in
+        # another rig must not claim this participant. Without the rig check
+        # the re-pin silently redirects every later thread delivery into
+        # docbook, and nothing else in the suite notices.
+        self._save_cross_rig_launch("room-launch:orig-15", "orig-15")
+
+        payload = self._publish_as_session("room-launch:orig-15", "docbook/pack.sky", "msg-launch-15")
+
+        self.assertEqual(payload["record"]["source_qualified_handle"], "")
+        launch = common.load_room_launch("room-launch:orig-15")
+        assert launch is not None
+        participant = launch["participants"]["daytripper/sky"]
+        self.assertEqual(participant["session_id"], "gc-old")
+        self.assertEqual(participant["session_name"], "s-gc-old")
+        self.assertEqual(participant["delivery_selector"], "s-gc-old")
+
     def test_publish_binding_message_does_not_record_non_thread_launch_publish_target(self) -> None:
         common.set_chat_binding(common.load_config(), "room", "22", ["corp--sky"], guild_id="1")
         binding = common.resolve_chat_binding(common.load_config(), "room:22")
@@ -2154,6 +2255,30 @@ class DiscordIntakeCommonTests(unittest.TestCase):
             identity = common.resolve_existing_session_for_handle("daytripper/fattony")
         self.assertEqual(identity, {})
 
+    def test_resolve_existing_session_for_handle_matches_city_scope_pack_alias(self) -> None:
+        # The platform qualifies an explicitly requested alias with the
+        # binding it resolves under, so a city-scoped seat requested as
+        # "emma" comes back stored as "employees.emma". Without the tail
+        # match the next @@emma misses the seat and spawns a second body.
+        sessions = [
+            {"id": "bo-7", "alias": "employees.emma",
+             "session_name": "s-bo-7", "state": "active", "running": True},
+        ]
+        with mock.patch.object(common, "list_city_sessions", return_value=sessions):
+            identity = common.resolve_existing_session_for_handle("emma")
+        self.assertEqual(identity["alias"], "employees.emma")
+
+    def test_resolve_existing_session_for_handle_bare_handle_does_not_cross_into_rig(self) -> None:
+        # Negative control for the tail match above: a bare handle is
+        # city-scoped and must not reach a rig-qualified seat.
+        sessions = [
+            {"id": "bo-8", "alias": "daytripper/gasburger.emma",
+             "session_name": "s-bo-8", "state": "active", "running": True},
+        ]
+        with mock.patch.object(common, "list_city_sessions", return_value=sessions):
+            identity = common.resolve_existing_session_for_handle("emma")
+        self.assertEqual(identity, {})
+
     def test_resolve_named_session_for_handle_matches_rig_scoped_named_session(self) -> None:
         with mock.patch.object(common, "load_city_toml", return_value={
             "named_session": [
@@ -2194,6 +2319,251 @@ class DiscordIntakeCommonTests(unittest.TestCase):
             ref = common.resolve_named_session_for_handle("anything")
         self.assertEqual(ref, {})
 
+    def test_resolve_named_session_for_handle_expands_rig_scope_without_dir(self) -> None:
+        # The declared shape (gastown/pack.toml "witness") carries neither
+        # name nor dir. gc leaves the template as the public identity when
+        # name is omitted and stamps one seat per configured rig, so the
+        # addressable handle is <rig>/<template> for each of them.
+        city = {
+            "rigs": [{"name": "gascity"}, {"name": "beads"}],
+            "named_session": [
+                {"template": "gastown.witness", "scope": "rig", "mode": "always"},
+            ],
+        }
+        with mock.patch.object(common, "load_city_toml", return_value=city):
+            ref = common.resolve_named_session_for_handle("beads/gastown.witness")
+            first_rig = common.resolve_named_session_for_handle("gascity/gastown.witness")
+        self.assertEqual(ref["alias"], "gastown.witness")
+        self.assertEqual(ref["dir"], "beads")
+        self.assertEqual(ref["scope"], "rig")
+        self.assertEqual(ref["spawn_template"], "beads/gastown.witness")
+        self.assertEqual(first_rig["dir"], "gascity")
+        self.assertEqual(first_rig["spawn_template"], "gascity/gastown.witness")
+
+    def test_resolve_named_session_for_handle_expands_named_rig_scope_without_dir(self) -> None:
+        city = {
+            "rigs": [{"name": "gascity"}, {"name": "beads"}],
+            "named_session": [
+                {"template": "gastown.witness", "scope": "rig", "name": "witness"},
+            ],
+        }
+        with mock.patch.object(common, "load_city_toml", return_value=city):
+            ref = common.resolve_named_session_for_handle("beads/witness")
+        self.assertEqual(ref["alias"], "witness")
+        self.assertEqual(ref["dir"], "beads")
+        self.assertEqual(ref["spawn_template"], "beads/gastown.witness")
+
+    def test_resolve_named_session_for_handle_rig_scope_without_dir_is_not_city_addressable(self) -> None:
+        # A rig-scoped entry must not answer a bare handle: falling back to
+        # city scope hands the caller an unqualified spawn template that
+        # resolves outside every rig the declaration asked for.
+        city = {
+            "rigs": [{"name": "gascity"}, {"name": "beads"}],
+            "named_session": [
+                {"template": "gastown.witness", "scope": "rig", "mode": "always"},
+            ],
+        }
+        with mock.patch.object(common, "load_city_toml", return_value=city):
+            ref = common.resolve_named_session_for_handle("gastown.witness")
+        self.assertEqual(ref, {})
+
+    def test_resolve_named_session_for_handle_rig_scope_without_rigs_is_unaddressable(self) -> None:
+        city = {"named_session": [{"template": "gastown.witness", "scope": "rig"}]}
+        with mock.patch.object(common, "load_city_toml", return_value=city):
+            self.assertEqual(common.resolve_named_session_for_handle("gastown.witness"), {})
+            self.assertEqual(common.resolve_named_session_for_handle("gascity/gastown.witness"), {})
+
+    def _platform_stored_alias(self, spawn_template: str, requested_alias: str) -> str:
+        """The alias the platform stores for an explicitly requested one: the
+        request qualified by the binding it resolves under, i.e.
+        <rig>/<pack>.<alias> for a rig-scoped template and <pack>.<alias> for
+        a city-scoped one. Same premise as the hydration tests below.
+        """
+        rig, _, template = spawn_template.rpartition("/")
+        pack = template.rsplit(".", 1)[0] if "." in template else template
+        qualified = f"{pack}.{requested_alias}"
+        return f"{rig}/{qualified}" if rig else qualified
+
+    def test_named_session_round_trip_attaches_next_turn_rig_scope(self) -> None:
+        # Spawn -> stored alias -> next-turn attach. If the stored shape is
+        # unreachable by the attach lookup, every mention spawns another seat
+        # and "stable named session" is not stable at all.
+        city = {
+            "rigs": [{"name": "daytripper"}],
+            "named_session": [{"template": "gasburger.crew", "scope": "rig", "name": "fattony"}],
+        }
+        with mock.patch.object(common, "load_city_toml", return_value=city):
+            ref = common.resolve_named_session_for_handle("daytripper/fattony")
+        self.assertEqual(ref["spawn_template"], "daytripper/gasburger.crew")
+
+        stored_alias = self._platform_stored_alias(ref["spawn_template"], ref["alias"])
+        self.assertEqual(stored_alias, "daytripper/gasburger.fattony")
+        sessions = [{"id": "bo-1", "alias": stored_alias, "session_name": "s-bo-1",
+                     "state": "active", "running": True}]
+        with mock.patch.object(common, "list_city_sessions", return_value=sessions):
+            identity = common.resolve_existing_session_for_handle("daytripper/fattony")
+        self.assertEqual(identity["session_id"], "bo-1")
+        self.assertTrue(common._alias_matches_qualified_handle(stored_alias, "daytripper/fattony"))
+
+    def test_named_session_round_trip_attaches_next_turn_city_scope(self) -> None:
+        # Same round trip for the shape maintainer-city actually declares
+        # (scope = "city", template = "employees.emma").
+        city = {
+            "named_session": [{"template": "employees.emma", "scope": "city", "name": "emma"}],
+        }
+        with mock.patch.object(common, "load_city_toml", return_value=city):
+            ref = common.resolve_named_session_for_handle("emma")
+        self.assertEqual(ref["spawn_template"], "employees.emma")
+
+        stored_alias = self._platform_stored_alias(ref["spawn_template"], ref["alias"])
+        self.assertEqual(stored_alias, "employees.emma")
+        sessions = [{"id": "bo-2", "alias": stored_alias, "session_name": "s-bo-2",
+                     "state": "active", "running": True}]
+        with mock.patch.object(common, "list_city_sessions", return_value=sessions):
+            identity = common.resolve_existing_session_for_handle("emma")
+        self.assertEqual(identity["session_id"], "bo-2")
+        self.assertTrue(common._alias_matches_qualified_handle(stored_alias, "emma"))
+
+    def test_named_session_round_trip_city_scope_survives_pack_prefix(self) -> None:
+        # And when the platform prefixes a differently named seat the same
+        # way (requested "emma", stored "employees.emma" under a pack that
+        # is not the template's own), the bare handle still attaches.
+        sessions = [{"id": "bo-3", "alias": "gasburger.emma", "session_name": "s-bo-3",
+                     "state": "active", "running": True}]
+        with mock.patch.object(common, "list_city_sessions", return_value=sessions):
+            identity = common.resolve_existing_session_for_handle("emma")
+        self.assertEqual(identity["session_id"], "bo-3")
+
+    def test_alias_matches_qualified_handle_rejects_cross_rig(self) -> None:
+        # The publish-side re-pin's routing-integrity guard: a rig-A session
+        # whose tail matches must not claim a rig-B participant.
+        self.assertFalse(
+            common._alias_matches_qualified_handle("docbook/gasburger.fattony", "daytripper/fattony")
+        )
+        self.assertFalse(common._alias_matches_qualified_handle("docbook/fattony", "daytripper/fattony"))
+        self.assertTrue(
+            common._alias_matches_qualified_handle("daytripper/gasburger.fattony", "daytripper/fattony")
+        )
+        self.assertTrue(common._alias_matches_qualified_handle("daytripper/fattony", "daytripper/fattony"))
+
+    def test_alias_matches_qualified_handle_does_not_mix_scopes(self) -> None:
+        self.assertFalse(common._alias_matches_qualified_handle("daytripper/gasburger.emma", "emma"))
+        self.assertFalse(common._alias_matches_qualified_handle("employees.emma", "daytripper/emma"))
+        self.assertTrue(common._alias_matches_qualified_handle("employees.emma", "emma"))
+        self.assertFalse(common._alias_matches_qualified_handle("employees.emmalou", "emma"))
+        self.assertFalse(common._alias_matches_qualified_handle("", "emma"))
+        self.assertFalse(common._alias_matches_qualified_handle("employees.emma", ""))
+
+    def test_room_launch_poll_timeout_defaults_are_unchanged(self) -> None:
+        # The injectable seam exists so tests do not pay the deadline;
+        # production must keep waiting it out for a slow async accept.
+        self.assertEqual(common.ROOM_LAUNCH_IDENTITY_RESOLVE_TIMEOUT_SECONDS, 30.0)
+        self.assertEqual(common.ROOM_LAUNCH_READY_RESOLVE_TIMEOUT_SECONDS, 90.0)
+        self.assertEqual(common._poll_timeout(None, 30.0), 30.0)
+        self.assertEqual(common._poll_timeout(0.0, 30.0), 0.0)
+
+    def test_resolve_routable_session_candidate_eventually_honors_timeout_override(self) -> None:
+        sleeps: list[float] = []
+        with mock.patch.object(common, "list_city_sessions", return_value=[]), mock.patch.object(
+            common.time, "sleep", side_effect=sleeps.append,
+        ):
+            selector, identity = common.resolve_routable_session_candidate_eventually(
+                "nobody", timeout=0.0,
+            )
+        self.assertEqual((selector, identity), ("", {}))
+        self.assertEqual(sleeps, [])
+
+    def test_resolve_ready_session_candidate_eventually_honors_timeout_override(self) -> None:
+        sleeps: list[float] = []
+        with mock.patch.object(common, "list_city_sessions", return_value=[]), mock.patch.object(
+            common.time, "sleep", side_effect=sleeps.append,
+        ):
+            selector, identity = common.resolve_ready_session_candidate_eventually(
+                "nobody", timeout=0.0,
+            )
+        self.assertEqual((selector, identity), ("", {}))
+        self.assertEqual(sleeps, [])
+
+    def test_resolve_ready_session_candidate_eventually_matches_prefixed_alias_by_suffix(self) -> None:
+        # The ready poll's folded suffix attempt is the only path by which a
+        # spawn whose alias the platform stored pack-prefixed can become ready:
+        # no exact candidate can ever match that stored alias. Its identity-side
+        # twin is pinned through ensure_room_launch_session (the no-stall test);
+        # this one is pinned at the poll on purpose.
+        #
+        # Pinning the ready side end-to-end is not possible through
+        # ensure_room_launch_session: whenever a record is listed early enough
+        # for the ready stage to want it, the identity poll's twin resolves it
+        # first and writes that record's real alias/session_id/session_name onto
+        # the participant, so the ready stage exact-matches those hydrated
+        # selectors and never calls this poll at all (measured: 0 calls). An
+        # ensure-level test in that shape therefore passes unchanged with the
+        # block deleted, which is why the pin lives here.
+        sessions = [
+            {
+                "id": "bo-9cm",
+                "alias": "gasburger.dc-abc123-gasburgermayor",
+                "session_name": "s-bo-9cm",
+                "template": "gasburger.mayor",
+                "state": "active",
+                "running": True,
+                "created_at": "2026-08-02T16:58:14Z",
+            }
+        ]
+        sleeps: list[float] = []
+        with mock.patch.object(
+            common, "list_city_sessions", return_value=sessions,
+        ), mock.patch.object(
+            common.time, "sleep", side_effect=sleeps.append,
+        ):
+            selector, identity = common.resolve_ready_session_candidate_eventually(
+                "dc-abc123-gasburgermayor",
+                suffix_template="gasburger.mayor",
+                suffix_alias="dc-abc123-gasburgermayor",
+                timeout=0.0,
+            )
+        self.assertEqual(
+            selector,
+            "s-bo-9cm",
+            "the ready poll did not fall back to a suffix match: a pack-prefixed "
+            "spawn that is already running raises 'not ready yet' instead of "
+            "being adopted",
+        )
+        self.assertEqual(identity.get("session_id"), "bo-9cm")
+        self.assertEqual(identity.get("alias"), "gasburger.dc-abc123-gasburgermayor")
+        # Same iteration as the exact attempt, so the fallback costs no sleep.
+        self.assertEqual(sleeps, [])
+
+    def test_resolve_ready_session_candidate_eventually_suffix_still_requires_ready(self) -> None:
+        # The suffix fallback must keep the ready/routable distinction: a
+        # matching record that is not running yet is not a ready session, and
+        # accepting it here would hand the launcher a session it cannot deliver
+        # to. Pins the ready=True argument the poll passes, which a deletion
+        # probe alone would not catch.
+        sessions = [
+            {
+                "id": "bo-9cm",
+                "alias": "gasburger.dc-abc123-gasburgermayor",
+                "session_name": "s-bo-9cm",
+                "template": "gasburger.mayor",
+                "state": "active",
+                "running": False,
+                "created_at": "2026-08-02T16:58:14Z",
+            }
+        ]
+        with mock.patch.object(
+            common, "list_city_sessions", return_value=sessions,
+        ), mock.patch.object(
+            common.time, "sleep", side_effect=lambda _seconds: None,
+        ):
+            selector, identity = common.resolve_ready_session_candidate_eventually(
+                "dc-abc123-gasburgermayor",
+                suffix_template="gasburger.mayor",
+                suffix_alias="dc-abc123-gasburgermayor",
+                timeout=0.0,
+            )
+        self.assertEqual((selector, identity), ("", {}))
+
     def test_ensure_room_launch_session_spawns_named_session_with_alias(self) -> None:
         # For a named-session launch, we spawn via the qualified template
         # (e.g. daytripper/gasburger.crew) but with the declared alias
@@ -2230,7 +2600,11 @@ class DiscordIntakeCommonTests(unittest.TestCase):
             common, "create_agent_session", return_value={},
         ) as create_agent_session, mock.patch.object(
             common, "deliver_session_message", return_value={"status": "accepted"},
-        ), mock.patch.object(common.time, "sleep"):
+        ), mock.patch.object(common.time, "sleep"), mock.patch.object(
+            common, "ROOM_LAUNCH_IDENTITY_RESOLVE_TIMEOUT_SECONDS", 1.0,
+        ), mock.patch.object(
+            common, "ROOM_LAUNCH_READY_RESOLVE_TIMEOUT_SECONDS", 1.0,
+        ):
             current = common.ensure_room_launch_session(
                 launch,
                 spawn_template_override="daytripper/gasburger.crew",
@@ -2312,13 +2686,67 @@ class DiscordIntakeCommonTests(unittest.TestCase):
             common,
             "deliver_session_message",
             return_value={"status": "accepted", "id": "bo-9cm"},
-        ), mock.patch.object(common.time, "sleep"):
+        ), mock.patch.object(common.time, "sleep"), mock.patch.object(
+            common, "ROOM_LAUNCH_IDENTITY_RESOLVE_TIMEOUT_SECONDS", 0.0,
+        ), mock.patch.object(
+            common, "ROOM_LAUNCH_READY_RESOLVE_TIMEOUT_SECONDS", 0.0,
+        ):
             current = common.ensure_room_launch_session(launch)
 
         create_agent_session.assert_called_once()
         self.assertEqual(current["session_id"], "bo-9cm")
         self.assertEqual(current["session_name"], "s-bo-9cm")
         self.assertEqual(current["session_alias"], "gasburger.dc-abc123-gasburgermayor")
+
+    def test_ensure_room_launch_session_hydrates_prefixed_alias_without_waiting_out_the_deadline(self) -> None:
+        # The suffix match must run in the SAME poll iteration as the exact
+        # one. Sequenced after it instead, a pack-prefixed alias — which no
+        # exact candidate can ever match — costs the full identity deadline
+        # on every such spawn, spent holding the launch advisory lock that
+        # blocks concurrent deliveries and the publish-side re-pin. A session
+        # listed from the first poll must hydrate without the poll sleeping.
+        launch = {
+            "launch_id": "room-launch:no-stall",
+            "qualified_handle": "gasburger.mayor",
+            "session_alias": "dc-abc123-gasburgermayor",
+            "from_display": "thunderchief",
+        }
+        sessions = [
+            {
+                "id": "bo-9cm",
+                "alias": "gasburger.dc-abc123-gasburgermayor",
+                "session_name": "s-bo-9cm",
+                "template": "gasburger.mayor",
+                "state": "active",
+                "running": True,
+                "created_at": "2026-08-02T16:58:14Z",
+            }
+        ]
+        sleeps: list[float] = []
+
+        with mock.patch.object(
+            common, "list_city_sessions", return_value=sessions,
+        ), mock.patch.object(
+            common, "create_agent_session", return_value={},
+        ), mock.patch.object(
+            common, "deliver_session_message", return_value={"status": "accepted", "id": "bo-9cm"},
+        ), mock.patch.object(
+            common.time, "sleep", side_effect=sleeps.append,
+        ), mock.patch.object(
+            common, "ROOM_LAUNCH_IDENTITY_RESOLVE_TIMEOUT_SECONDS", 5.0,
+        ), mock.patch.object(
+            common, "ROOM_LAUNCH_READY_RESOLVE_TIMEOUT_SECONDS", 5.0,
+        ):
+            current = common.ensure_room_launch_session(launch)
+
+        self.assertEqual(current["session_id"], "bo-9cm")
+        self.assertEqual(
+            sleeps,
+            [],
+            "hydration kept polling after the session was already listed: the suffix "
+            "match is not folded into the exact-match poll, so every pack-prefixed "
+            "spawn stalls for the whole deadline under the launch lock",
+        )
 
     def test_ensure_room_launch_session_hydrates_routable_identity_after_longer_async_delay(self) -> None:
         launch = {

--- a/discord/tests/test_discord_intake_common.py
+++ b/discord/tests/test_discord_intake_common.py
@@ -1711,6 +1711,58 @@ class DiscordIntakeCommonTests(unittest.TestCase):
         assert launch is not None
         self.assertEqual(launch["message_targets"]["msg-launch-11"], "corp/sky")
 
+    def test_publish_binding_message_repins_participant_from_new_session(self) -> None:
+        config = common.set_room_launcher(common.load_config(), "1", "22")
+        route = common.resolve_publish_route(config, "launch-room:22")
+        assert route is not None
+        common.save_room_launch(
+            {
+                "launch_id": "room-launch:orig-13",
+                "launcher_id": "launch-room:22",
+                "guild_id": "1",
+                "conversation_id": "22",
+                "root_message_id": "orig-13",
+                "qualified_handle": "corp/sky",
+                "session_alias": "corp/pack.sky",
+                "session_name": "s-gc-old",
+                "session_id": "gc-old",
+                "thread_id": "333",
+                "participants": {
+                    "corp/sky": {
+                        "qualified_handle": "corp/sky",
+                        "session_alias": "corp/pack.sky",
+                        "session_name": "s-gc-old",
+                        "session_id": "gc-old",
+                        "delivery_selector": "s-gc-old",
+                    }
+                },
+            }
+        )
+
+        with mock.patch.object(
+            common, "post_channel_message", return_value={"id": "msg-launch-13"}
+        ), mock.patch.object(
+            common,
+            "resolve_session_identity",
+            return_value={"session_name": "corp--sky", "session_id": "gc-new", "alias": "corp/sky"},
+        ):
+            payload = common.publish_binding_message(
+                route,
+                "hello from my new body",
+                source_context={"kind": "discord_human_message", "publish_launch_id": "room-launch:orig-13"},
+                source_session_name="corp--sky",
+                source_session_id="gc-new",
+            )
+
+        self.assertEqual(payload["record"]["source_qualified_handle"], "corp/sky")
+        launch = common.load_room_launch("room-launch:orig-13")
+        assert launch is not None
+        participant = launch["participants"]["corp/sky"]
+        self.assertEqual(participant["session_id"], "gc-new")
+        self.assertEqual(participant["session_name"], "corp--sky")
+        self.assertEqual(participant["delivery_selector"], "corp--sky")
+        self.assertEqual(launch["message_targets"]["msg-launch-13"], "corp/sky")
+
     def test_publish_binding_message_does_not_record_non_thread_launch_publish_target(self) -> None:
         common.set_chat_binding(common.load_config(), "room", "22", ["corp--sky"], guild_id="1")
         binding = common.resolve_chat_binding(common.load_config(), "room:22")
@@ -1918,6 +1970,125 @@ class DiscordIntakeCommonTests(unittest.TestCase):
         self.assertEqual(current["session_id"], "gc-new")
         self.assertEqual(current["session_name"], "dc-new-sky")
 
+    def test_ensure_room_launch_session_repins_to_live_handle_session(self) -> None:
+        common.save_room_launch(
+            {
+                "launch_id": "room-launch:repin",
+                "launcher_id": "launch-room:22",
+                "guild_id": "1",
+                "conversation_id": "22",
+                "root_message_id": "repin",
+                "qualified_handle": "corp/sky",
+                "session_alias": "corp/pack.sky",
+                "session_name": "s-gc-old",
+                "session_id": "gc-old",
+                "thread_id": "333",
+                "participants": {
+                    "corp/sky": {
+                        "qualified_handle": "corp/sky",
+                        "session_alias": "corp/pack.sky",
+                        "session_name": "s-gc-old",
+                        "session_id": "gc-old",
+                        "delivery_selector": "s-gc-old",
+                    }
+                },
+            }
+        )
+        launch = common.load_room_launch("room-launch:repin")
+        assert launch is not None
+        sessions = [
+            {
+                "id": "gc-old",
+                "alias": "corp/pack.sky",
+                "session_name": "s-gc-old",
+                "state": "closed",
+                "running": False,
+                "created_at": "2026-03-20T00:00:00Z",
+            },
+            {
+                "id": "gc-new",
+                "alias": "corp/sky",
+                "session_name": "corp--sky",
+                "state": "active",
+                "running": True,
+                "created_at": "2026-03-22T00:00:00Z",
+            },
+        ]
+
+        with mock.patch.object(
+            common, "list_city_sessions", return_value=sessions
+        ), mock.patch.object(
+            common, "create_agent_session"
+        ) as create_agent_session, mock.patch.object(
+            common,
+            "prime_room_launch_participant",
+            side_effect=lambda current, participant, extra_message="": dict(participant),
+        ):
+            current, participant = common.ensure_room_launch_session_for_handle(launch, "corp/sky")
+
+        create_agent_session.assert_not_called()
+        self.assertEqual(participant["session_id"], "gc-new")
+        self.assertEqual(participant["session_name"], "corp--sky")
+        self.assertEqual(participant["delivery_selector"], "corp--sky")
+        self.assertEqual(current["session_id"], "gc-new")
+
+    def test_repin_room_launch_participant_for_session_rebinds_stale_entry(self) -> None:
+        common.save_room_launch(
+            {
+                "launch_id": "room-launch:repin-helper",
+                "launcher_id": "launch-room:22",
+                "guild_id": "1",
+                "conversation_id": "22",
+                "root_message_id": "repin-helper",
+                "qualified_handle": "corp/sky",
+                "session_alias": "corp/pack.sky",
+                "session_name": "s-gc-old",
+                "session_id": "gc-old",
+                "thread_id": "333",
+                "participants": {
+                    "corp/sky": {
+                        "qualified_handle": "corp/sky",
+                        "session_alias": "corp/pack.sky",
+                        "session_name": "s-gc-old",
+                        "session_id": "gc-old",
+                        "delivery_selector": "s-gc-old",
+                    }
+                },
+            }
+        )
+
+        updated = common.repin_room_launch_participant_for_session(
+            "room-launch:repin-helper",
+            "corp/sky",
+            session_name="corp--sky",
+            session_id="gc-new",
+            session_alias="corp/sky",
+        )
+
+        assert updated is not None
+        participant = updated["participants"]["corp/sky"]
+        self.assertEqual(participant["session_id"], "gc-new")
+        self.assertEqual(participant["session_name"], "corp--sky")
+        self.assertEqual(participant["session_alias"], "corp/sky")
+        self.assertEqual(participant["delivery_selector"], "corp--sky")
+        self.assertEqual(updated["session_id"], "gc-new")
+        self.assertIsNone(
+            common.repin_room_launch_participant_for_session(
+                "room-launch:repin-helper",
+                "corp/sky",
+                session_name="corp--sky",
+                session_id="gc-new",
+            )
+        )
+        self.assertIsNone(
+            common.repin_room_launch_participant_for_session(
+                "room-launch:repin-helper",
+                "corp/other",
+                session_name="other-name",
+                session_id="other-id",
+            )
+        )
+
     def test_resolve_existing_session_for_handle_matches_alias_case_insensitively(self) -> None:
         sessions = [
             {"id": "bo-1", "alias": "gasburger.mayor", "session_name": "gasburger__mayor",
@@ -2041,8 +2212,20 @@ class DiscordIntakeCommonTests(unittest.TestCase):
              "session_name": "s-bo-9", "template": "daytripper/gasburger.crew",
              "state": "active", "running": True},
         ]
+        # The named session must not be listed until after the spawn: if a
+        # live session already matches the handle, ensure attaches to it
+        # instead of creating (see the repin fallback).
+        calls = {"count": 0}
+
+        def list_sessions(*, state: str = "all") -> list[dict[str, object]]:
+            self.assertEqual(state, "all")
+            calls["count"] += 1
+            if calls["count"] < 3:
+                return []
+            return sessions_after
+
         with mock.patch.object(
-            common, "list_city_sessions", return_value=sessions_after,
+            common, "list_city_sessions", side_effect=list_sessions,
         ), mock.patch.object(
             common, "create_agent_session", return_value={},
         ) as create_agent_session, mock.patch.object(

--- a/discord/tests/test_discord_intake_common.py
+++ b/discord/tests/test_discord_intake_common.py
@@ -1960,6 +1960,108 @@ class DiscordIntakeCommonTests(unittest.TestCase):
             identity = common.resolve_existing_session_for_handle("nope")
         self.assertEqual(identity, {})
 
+    def test_resolve_existing_session_for_handle_matches_rig_prefixed_alias(self) -> None:
+        # A rig-scoped named session ("fattony" on rig "daytripper" from pack
+        # "gasburger") lands with alias "daytripper/gasburger.fattony". User
+        # types @@daytripper/fattony; suffix match should route to it.
+        sessions = [
+            {"id": "bo-9", "alias": "daytripper/gasburger.fattony",
+             "session_name": "s-bo-9", "state": "active", "running": True},
+        ]
+        with mock.patch.object(common, "list_city_sessions", return_value=sessions):
+            identity = common.resolve_existing_session_for_handle("daytripper/fattony")
+        self.assertEqual(identity["alias"], "daytripper/gasburger.fattony")
+
+    def test_resolve_existing_session_for_handle_rig_alias_stays_scoped_to_rig(self) -> None:
+        # Same-name session under a different rig must NOT match — cross-rig
+        # collision would be a routing bug.
+        sessions = [
+            {"id": "bo-1", "alias": "docbook/gasburger.fattony",
+             "session_name": "s-bo-1", "state": "active", "running": True},
+        ]
+        with mock.patch.object(common, "list_city_sessions", return_value=sessions):
+            identity = common.resolve_existing_session_for_handle("daytripper/fattony")
+        self.assertEqual(identity, {})
+
+    def test_resolve_named_session_for_handle_matches_rig_scoped_named_session(self) -> None:
+        with mock.patch.object(common, "load_city_toml", return_value={
+            "named_session": [
+                {"template": "gasburger.crew", "scope": "rig",
+                 "dir": "daytripper", "name": "fattony", "mode": "on_demand"},
+            ],
+        }):
+            ref = common.resolve_named_session_for_handle("daytripper/fattony")
+        self.assertEqual(ref["template"], "gasburger.crew")
+        self.assertEqual(ref["alias"], "fattony")
+        self.assertEqual(ref["spawn_template"], "daytripper/gasburger.crew")
+        self.assertEqual(ref["scope"], "rig")
+        self.assertEqual(ref["dir"], "daytripper")
+
+    def test_resolve_named_session_for_handle_case_insensitive(self) -> None:
+        with mock.patch.object(common, "load_city_toml", return_value={
+            "named_session": [
+                {"template": "gasburger.crew", "scope": "rig",
+                 "dir": "docbook", "name": "meltron"},
+            ],
+        }):
+            ref = common.resolve_named_session_for_handle("Docbook/Meltron")
+        self.assertEqual(ref["alias"], "meltron")
+
+    def test_resolve_named_session_for_handle_returns_empty_when_no_match(self) -> None:
+        with mock.patch.object(common, "load_city_toml", return_value={
+            "named_session": [
+                {"template": "gasburger.crew", "scope": "rig",
+                 "dir": "daytripper", "name": "fattony"},
+            ],
+        }):
+            ref = common.resolve_named_session_for_handle("daytripper/nobody")
+        self.assertEqual(ref, {})
+
+    def test_resolve_named_session_for_handle_swallows_toml_errors(self) -> None:
+        with mock.patch.object(common, "load_city_toml",
+                               side_effect=common.GCAPIError("boom")):
+            ref = common.resolve_named_session_for_handle("anything")
+        self.assertEqual(ref, {})
+
+    def test_ensure_room_launch_session_spawns_named_session_with_alias(self) -> None:
+        # For a named-session launch, we spawn via the qualified template
+        # (e.g. daytripper/gasburger.crew) but with the declared alias
+        # (fattony) so the session is discoverable next turn.
+        launch = {
+            "launch_id": "room-launch:named",
+            "qualified_handle": "daytripper/fattony",
+            "session_alias": "fattony",
+            "guild_id": "g1",
+            "conversation_id": "c1",
+            "root_message_id": "m1",
+            "from_display": "thunderchief",
+        }
+        sessions_after = [
+            {"id": "bo-9", "alias": "daytripper/gasburger.fattony",
+             "session_name": "s-bo-9", "template": "daytripper/gasburger.crew",
+             "state": "active", "running": True},
+        ]
+        with mock.patch.object(
+            common, "list_city_sessions", return_value=sessions_after,
+        ), mock.patch.object(
+            common, "create_agent_session", return_value={},
+        ) as create_agent_session, mock.patch.object(
+            common, "deliver_session_message", return_value={"status": "accepted"},
+        ), mock.patch.object(common.time, "sleep"):
+            current = common.ensure_room_launch_session(
+                launch,
+                spawn_template_override="daytripper/gasburger.crew",
+                session_alias_override="fattony",
+            )
+
+        create_agent_session.assert_called_once()
+        call_args = create_agent_session.call_args
+        self.assertEqual(call_args.args[0], "daytripper/gasburger.crew")
+        self.assertEqual(call_args.kwargs["alias"], "fattony")
+        self.assertEqual(current["session_id"], "bo-9")
+        self.assertEqual(current["session_name"], "s-bo-9")
+        self.assertEqual(current["session_alias"], "daytripper/gasburger.fattony")
+
     def test_ensure_room_launch_session_attaches_without_creating(self) -> None:
         launch = {
             "launch_id": "room-launch:attach",

--- a/discord/tests/test_discord_intake_common.py
+++ b/discord/tests/test_discord_intake_common.py
@@ -909,6 +909,11 @@ class DiscordIntakeCommonTests(unittest.TestCase):
 
         self.assertEqual(handles, ["sky", "corp/priya"])
 
+    def test_extract_agent_handles_allows_dotted_segments(self) -> None:
+        handles = common.extract_agent_handles("hi @@gasburger.mayor and @@gc-packs/gasburger.crew")
+
+        self.assertEqual(handles, ["gasburger.mayor", "gc-packs/gasburger.crew"])
+
     def test_build_command_payload_includes_rig_option(self) -> None:
         payload = common.build_command_payload("gc")
 
@@ -1660,7 +1665,7 @@ class DiscordIntakeCommonTests(unittest.TestCase):
                 source_context={"kind": "discord_human_message", "publish_launch_id": "room-launch:orig-9"},
             )
 
-        create_thread_from_message.assert_called_once_with("22", "orig-9", "sky")
+        create_thread_from_message.assert_called_once_with("22", "orig-9", "corp/sky")
         post_channel_message.assert_called_once_with("333", "hello humans", reply_to_message_id="")
         self.assertEqual(payload["record"]["conversation_id"], "333")
         self.assertEqual(payload["record"]["launch_id"], "room-launch:orig-9")
@@ -1912,6 +1917,123 @@ class DiscordIntakeCommonTests(unittest.TestCase):
         create_agent_session.assert_called_once()
         self.assertEqual(current["session_id"], "gc-new")
         self.assertEqual(current["session_name"], "dc-new-sky")
+
+    def test_resolve_existing_session_for_handle_matches_alias_case_insensitively(self) -> None:
+        sessions = [
+            {"id": "bo-1", "alias": "gasburger.mayor", "session_name": "gasburger__mayor",
+             "state": "active", "running": True},
+        ]
+        with mock.patch.object(common, "list_city_sessions", return_value=sessions):
+            identity = common.resolve_existing_session_for_handle("Gasburger.Mayor")
+        self.assertEqual(identity["session_name"], "gasburger__mayor")
+        self.assertEqual(identity["alias"], "gasburger.mayor")
+
+    def test_resolve_existing_session_for_handle_matches_session_name(self) -> None:
+        sessions = [
+            {"id": "bo-1", "alias": "some-alias", "session_name": "s-bo-1",
+             "state": "active", "running": True},
+        ]
+        with mock.patch.object(common, "list_city_sessions", return_value=sessions):
+            identity = common.resolve_existing_session_for_handle("s-bo-1")
+        self.assertEqual(identity["session_name"], "s-bo-1")
+
+    def test_resolve_existing_session_for_handle_matches_id(self) -> None:
+        sessions = [
+            {"id": "bo-1", "alias": "some-alias", "session_name": "s-bo-1",
+             "state": "active", "running": True},
+        ]
+        with mock.patch.object(common, "list_city_sessions", return_value=sessions):
+            identity = common.resolve_existing_session_for_handle("bo-1")
+        self.assertEqual(identity["session_id"], "bo-1")
+
+    def test_resolve_existing_session_for_handle_skips_non_routable(self) -> None:
+        sessions = [
+            {"id": "bo-1", "alias": "gasburger.mayor", "session_name": "s-bo-1",
+             "state": "closed", "running": False},
+        ]
+        with mock.patch.object(common, "list_city_sessions", return_value=sessions):
+            identity = common.resolve_existing_session_for_handle("gasburger.mayor")
+        self.assertEqual(identity, {})
+
+    def test_resolve_existing_session_for_handle_returns_empty_when_no_match(self) -> None:
+        with mock.patch.object(common, "list_city_sessions", return_value=[]):
+            identity = common.resolve_existing_session_for_handle("nope")
+        self.assertEqual(identity, {})
+
+    def test_ensure_room_launch_session_attaches_without_creating(self) -> None:
+        launch = {
+            "launch_id": "room-launch:attach",
+            "qualified_handle": "gasburger.mayor",
+            "session_alias": "",
+            "guild_id": "g1",
+            "conversation_id": "c1",
+            "root_message_id": "m1",
+            "from_display": "thunderchief",
+        }
+        attached = {"session_name": "gasburger__mayor", "session_id": "bo-1",
+                    "alias": "gasburger.mayor"}
+        with mock.patch.object(
+            common, "list_city_sessions", return_value=[],
+        ), mock.patch.object(
+            common, "create_agent_session",
+        ) as create_agent_session, mock.patch.object(
+            common, "prime_room_launch_participant",
+        ) as prime, mock.patch.object(common.time, "sleep"):
+            current = common.ensure_room_launch_session(launch, attached_identity=attached)
+
+        create_agent_session.assert_not_called()
+        prime.assert_not_called()
+        self.assertEqual(current["session_name"], "gasburger__mayor")
+        self.assertEqual(current["session_id"], "bo-1")
+        self.assertEqual(current["session_alias"], "gasburger.mayor")
+        participant = current["participants"]["gasburger.mayor"]
+        self.assertTrue(participant["attached"])
+        self.assertEqual(participant["delivery_selector"], "gasburger__mayor")
+
+    def test_ensure_room_launch_session_hydrates_when_platform_prefixes_alias_and_returns_no_identity(self) -> None:
+        # Simulates the real /v0/sessions async accept: create_agent_session
+        # returns {} (no id/alias/session_name) and the platform stores the
+        # session under a pack-namespace-prefixed alias.
+        launch = {
+            "launch_id": "room-launch:prefixed",
+            "qualified_handle": "gasburger.mayor",
+            "session_alias": "dc-abc123-gasburgermayor",
+            "from_display": "thunderchief",
+        }
+        sessions_after_create = [
+            {
+                "id": "bo-9cm",
+                "alias": "gasburger.dc-abc123-gasburgermayor",
+                "session_name": "s-bo-9cm",
+                "template": "gasburger.mayor",
+                "state": "active",
+                "running": True,
+                "created_at": "2026-08-02T16:58:14Z",
+            }
+        ]
+
+        def list_sessions(*, state: str = "all") -> list[dict[str, object]]:
+            return sessions_after_create
+
+        with mock.patch.object(
+            common,
+            "list_city_sessions",
+            side_effect=list_sessions,
+        ), mock.patch.object(
+            common,
+            "create_agent_session",
+            return_value={},
+        ) as create_agent_session, mock.patch.object(
+            common,
+            "deliver_session_message",
+            return_value={"status": "accepted", "id": "bo-9cm"},
+        ), mock.patch.object(common.time, "sleep"):
+            current = common.ensure_room_launch_session(launch)
+
+        create_agent_session.assert_called_once()
+        self.assertEqual(current["session_id"], "bo-9cm")
+        self.assertEqual(current["session_name"], "s-bo-9cm")
+        self.assertEqual(current["session_alias"], "gasburger.dc-abc123-gasburgermayor")
 
     def test_ensure_room_launch_session_hydrates_routable_identity_after_longer_async_delay(self) -> None:
         launch = {


### PR DESCRIPTION
## Summary

Six interlocking fixes to the `discord` pack that were needed to get launcher-room ad-hoc sessions working end-to-end for a real workspace, plus a small feature so `@@handle` attaches to an already-running session instead of always spawning a new one.

Verified end-to-end in a real workspace: `@@gasburger.mayor` now routes to the running mayor session, `@@gc-packs/gasburger.crew` spawns/attaches under the correct rig, thread follow-ups reach the same session, and `gc discord reply-current` succeeds — none of which was possible before this change.

## Motivation

Every step of the launcher-room flow was broken for the naming convention this town actually uses (dotted, optionally rig-prefixed agent handles like `gasburger.mayor`, `gc-packs/gasburger.crew`). I traced each failure by watching `data/chat-ingress/*.json` receipts; each item below is what a receipt actually returned before the fix.

## What changed

### Handle parsing — dotted handles were silently truncated
`AGENT_HANDLE_SEGMENT` (`^[a-z][a-z0-9_-]{0,31}$`) and the char class in `extract_agent_handles` rejected `.`, so `@@gasburger.mayor` parsed as `gasburger` and `@@gc-packs/gasburger.crew` parsed as `gc-packs/gasburger`. Every attempt returned `unknown_handle`. Both call sites now accept `.` inside a segment.

### Session identity after async create — hydration polled forever
`create_agent_session` posts `/v0/sessions` with `async: true`. That endpoint returns only `{status, request_id, event_cursor}` — no `id`/`alias`/`session_name`. Meanwhile the platform stores the alias with the pack namespace prepended (`dc-<hex>-slug` → `gasburger.dc-<hex>-slug`), so the exact-alias hydration in `ensure_room_launch_session_for_handle` never found the just-created session and eventually raised `created launch session is not routable yet`.

Added `resolve_launched_session_identity_eventually` / `_ready_` variants that locate the session by (`template == qualified_handle` **and** alias suffix-matches the requested alias). Safe because `room_launch_session_alias` embeds a sha256 digest of guild/channel/message/handle, so the requested-alias suffix is unique per launch.

### Attach-first launcher (feature)
`resolve_existing_session_for_handle` looks up existing routable sessions by `alias`, `session_name`, or `id` (case-insensitive). If the handle already names a running session, `process_room_launch_message` and `process_room_launch_thread_message` route to it directly; otherwise the previous template-and-spawn path runs unchanged. `ensure_room_launch_session_for_handle` gained an `attached_identity` kwarg that skips create + prime + hydration polling and marks the participant `attached=True`.

Lookup is best-effort: a `GCAPIError` from `list_city_sessions` is swallowed so the spawn path still runs if the API blips.

**Semantics to know:** `@@handle` attaches when a matching routable session exists, and only spawns when none does. To force a fresh spawn, close the existing session first — or use a handle that isn't currently a running session.

### Receipt targets carry full identity
Ingress receipt `targets[]` recorded only `session_name`, so `gc discord reply-current` failed with `no recent discord event with publish metadata found for <selector>` whenever `GC_SESSION_ID` (or alias) was the selector coming from env. New `participant_target_identity()` helper populates `session_name`, `session_id`, and `session_alias` on every launcher target dict (pending/delivered/failed, root and thread paths). Fixes attached **and** spawned sessions.

### Launcher-managed threads bypass the extmsg fabric
`_record_extmsg_inbound` treated every thread message as an extmsg event and returned True, so `process_room_launch_thread_message` never saw follow-ups posted inside a launcher-created thread. Added `launcher_claims_message(config, channel_id, parent_id)` mirroring the existing `bound_room_claims_message` bypass — true when `channel_id` or `parent_id` is a configured launcher room, or when `channel_id` matches a `room_launch` record's `thread_id`. Extmsg falls through in those cases so the launcher pack routes the follow-up.

### Thread name keeps the rig prefix
`room_launch_thread_name` did `rsplit("/", 1)[-1]` on the handle, so `@@gc-packs/gasburger.refinery` produced a Discord thread titled `gasburger.refinery` — indistinguishable from a root-level agent of the same name. Now retains the qualified form; still trimmed to Discord's 100-char thread-name limit.

## Test plan

- [x] `python3 -m unittest discover discord/tests` — 267/268 pass. The one pre-existing failure (`test_run_fix_dispatch_returns_bead_init_failure_without_slinging`) is an environment issue unrelated to this branch: the test hardcodes bare `gc` but this machine's PATH resolves it to `/home/b/go/bin/gc`.
- [x] Six new intake tests: dotted-handle extraction, prefixed-alias hydration under async create, four resolver cases for existing sessions, attach path skips create/prime and populates identity.
- [x] Two existing chat-script assertions updated for the new rig-prefixed thread-name format.
- [x] End-to-end verification in a live workspace: launcher room `@@gasburger.mayor` attached to the running mayor session; a follow-up in the launcher-created Discord thread also reached that same session; `gc discord reply-current` returned a non-empty `record.remote_message_id` and the reply appeared in Discord.

## Files touched

- `discord/scripts/discord_intake_common.py` — regex, resolvers, attach path, thread-name helper
- `discord/scripts/discord_gateway_service.py` — attach-first branches, target-identity helper, extmsg bypass
- `discord/tests/test_discord_intake_common.py` — 6 new tests
- `discord/tests/test_discord_chat_scripts.py` — 2 assertion updates