### PR TITLE
fix(gastown): pour refinery, witness and deacon patrol wisps as in_progress and resolve them via bd query

### DIFF
--- a/gastown/agents/deacon/prompt.template.md
+++ b/gastown/agents/deacon/prompt.template.md
@@ -61,8 +61,10 @@ Your formula: `mol-deacon-patrol`
 gc mail inbox
 
 # Step 3: Still nothing? Create patrol wisp (root-only — no child step beads)
+# --status=in_progress is load-bearing: a wisp poured at status=open is
+# invisible to the next restart's resume check, which pours a duplicate.
 NEW_WISP=$(gc bd mol wisp mol-deacon-patrol --root-only --var binding_prefix={{ .BindingPrefix }} --json | jq -r '.new_epic_id')
-gc bd update "$NEW_WISP" --assignee="$GC_ALIAS"
+gc bd update "$NEW_WISP" --assignee="$GC_ALIAS" --status=in_progress
 
 # Step 4: Read the formula recipe — these are the steps to execute
 # (Use 'gc bd formula show' for the recipe on disk; 'gc bd mol show' is
@@ -87,18 +89,24 @@ without running `next-iteration` (crash recovery or formula misread).
 If `next-iteration` already ran, do not pour again; run `gc hook`.
 
 ```bash
+# Wisp roots are ephemeral rows, which `gc bd list` hides unless it is given
+# --include-infra; the flagless lookup below used to return zero rows even
+# with wisps open. `gc bd query` selects the ephemeral tier directly, so there
+# is no flag left to forget.
+# ASSIGNED_WISP excludes $CURRENT_WISP by id — the wisp you are executing is
+# burned below, never mistaken for an already-queued successor.
 CURRENT_WISP=${GC_BEAD_ID:-}
 if [ -z "$CURRENT_WISP" ]; then
-  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
+  CURRENT_WISP=$(gc bd query --json 'ephemeral=true AND status=in_progress' --limit=0 | jq -r --arg id "$GC_AGENT" --arg f mol-deacon-patrol '[.[] | select((.assignee // "") == $id and (.title // "") == $f)] | .[0].id // empty')
 fi
-ASSIGNED_WISP=$(gc bd list --assignee="$GC_AGENT" --status=open --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
+ASSIGNED_WISP=$(gc bd query --json 'ephemeral=true AND (status=open OR status=in_progress)' --limit=0 | jq -r --arg id "$GC_AGENT" --arg f mol-deacon-patrol --arg self "$CURRENT_WISP" '[.[] | select((.assignee // "") == $id and (.title // "") == $f and .id != $self)] | sort_by(.created_at) | .[0].id // empty')
 if [ -n "$CURRENT_WISP" ] && [ -z "$ASSIGNED_WISP" ]; then
   NEXT=$(gc bd mol wisp mol-deacon-patrol --root-only --var binding_prefix={{ .BindingPrefix }} --json | jq -r '.new_epic_id // empty')
   if [ -z "$NEXT" ]; then
     echo "Could not pour next deacon wisp; not burning."
     exit 1
   fi
-  if ! gc bd update "$NEXT" --assignee="$GC_AGENT"; then
+  if ! gc bd update "$NEXT" --assignee="$GC_AGENT" --status=in_progress; then
     echo "Could not assign next deacon wisp; not burning."
     exit 1
   fi
@@ -111,7 +119,7 @@ elif [ -z "$ASSIGNED_WISP" ]; then
     echo "Could not bootstrap next deacon wisp."
     exit 1
   fi
-  if ! gc bd update "$NEXT" --assignee="$GC_AGENT"; then
+  if ! gc bd update "$NEXT" --assignee="$GC_AGENT" --status=in_progress; then
     echo "Could not assign bootstrap deacon wisp."
     exit 1
   fi

--- a/gastown/agents/refinery/prompt.template.md
+++ b/gastown/agents/refinery/prompt.template.md
@@ -69,14 +69,14 @@ external observers (witness, mayor) only catch on a slow patrol cycle.
 ```bash
 CURRENT_WISP=${GC_BEAD_ID:-}
 if [ -z "$CURRENT_WISP" ]; then
-  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
+  CURRENT_WISP=$(gc bd query --json 'ephemeral=true AND status=in_progress' --limit=0 | jq -r --arg id "$GC_AGENT" --arg f mol-refinery-patrol '[.[] | select((.assignee // "") == $id and (.title // "") == $f)] | .[0].id // empty')
 fi
 NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{ .DefaultBranch }} --var rig_name={{ .RigName }} --var binding_prefix={{ .BindingPrefix }} --json | jq -r '.new_epic_id // empty')
 if [ -z "$NEXT" ]; then
   echo "Could not pour next refinery wisp; not burning."
   exit 1
 fi
-if ! gc bd update "$NEXT" --assignee="$GC_AGENT"; then
+if ! gc bd update "$NEXT" --assignee="$GC_AGENT" --status=in_progress; then
   echo "Could not assign next refinery wisp; not burning."
   exit 1
 fi
@@ -114,14 +114,14 @@ assign the next wisp, burn the current wisp, THEN request restart**:
 ```bash
 CURRENT_WISP=${GC_BEAD_ID:-}
 if [ -z "$CURRENT_WISP" ]; then
-  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
+  CURRENT_WISP=$(gc bd query --json 'ephemeral=true AND status=in_progress' --limit=0 | jq -r --arg id "$GC_AGENT" --arg f mol-refinery-patrol '[.[] | select((.assignee // "") == $id and (.title // "") == $f)] | .[0].id // empty')
 fi
 NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{ .DefaultBranch }} --var rig_name={{ .RigName }} --var binding_prefix={{ .BindingPrefix }} --json | jq -r '.new_epic_id // empty')
 if [ -z "$NEXT" ]; then
   echo "Could not pour next refinery wisp; not requesting restart."
   exit 1
 fi
-if ! gc bd update "$NEXT" --assignee="$GC_AGENT"; then
+if ! gc bd update "$NEXT" --assignee="$GC_AGENT" --status=in_progress; then
   echo "Could not assign next refinery wisp; not requesting restart."
   exit 1
 fi
@@ -178,7 +178,7 @@ done
 
 # If none found, pour one (root-only — no child step beads) and assign it
 WISP=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{ .DefaultBranch }} --var rig_name={{ .RigName }} --var binding_prefix={{ .BindingPrefix }} --json | jq -r '.new_epic_id')
-gc bd update "$WISP" --assignee="$GC_AGENT"
+gc bd update "$WISP" --assignee="$GC_AGENT" --status=in_progress
 ```
 
 Then follow the formula. The step descriptions below are your instructions —

--- a/gastown/agents/witness/prompt.template.md
+++ b/gastown/agents/witness/prompt.template.md
@@ -156,31 +156,39 @@ Your patrol wisps are ephemeral molecules on the **town ledger**
 (`th-wisp-*`), poured and assigned with `gc bd`. Find them the same way you
 pour them — with `gc bd`, never bare `bd`. Bare `bd` resolves to the rig
 ledger from your CWD and never sees your wisps, so every restart would pour a
-fresh one while the prior wisp leaks. Wisp roots are `issue_type=molecule`;
-never filter `--type=wisp` (not a valid gc bd type — the query errors and matches
-nothing).
+fresh one while the prior wisp leaks. Enumerate them with `gc bd query` on
+`ephemeral=true`: wisp roots are ephemeral rows, and `gc bd list` hides those
+unless it is passed `--include-infra`, so the flagless scan this replaces
+returned zero rows even when the wisps were sitting right there — it found no
+surplus to burn and no wisp to resume, and poured a duplicate every restart.
+`gc bd list --include-infra` does see them, but `gc bd query` needs no flag to
+be remembered, which is why it is the form used here. (`--type=wisp` is worse
+either way: `wisp` is not a valid gc bd type, so the command hard-errors.)
 
 ```bash
 # Step 1: Reconcile your patrol wisps to exactly one (town ledger, via gc bd).
 # Collect every open/in_progress patrol wisp assigned to you, keep one, and
-# burn the surplus so restarts never accumulate duplicates. Wisp roots are
-# molecules — filter --type=molecule, never --type=wisp.
-WISP_IDS=$(
-  gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=0 --json | jq -r '.[].id'
-  gc bd list --assignee="$GC_AGENT" --status=open --type=molecule --limit=0 --json | jq -r '.[].id'
-)
+# burn the surplus so restarts never accumulate duplicates.
+WISP_IDS=$(gc bd query --json 'ephemeral=true AND (status=open OR status=in_progress)' --limit=0 \
+  | jq -r --arg id "$GC_AGENT" --arg f mol-witness-patrol \
+      '[.[] | select((.assignee // "") == $id and (.title // "") == $f)]
+       | sort_by((if .status == "in_progress" then 0 else 1 end), .created_at)
+       | .[].id')
 WISP=$(printf '%s\n' $WISP_IDS | sed -n '1p')           # keep one (prefers in_progress)
 for extra in $(printf '%s\n' $WISP_IDS | sed '1d'); do  # burn any surplus
   gc bd mol burn "$extra" --force
 done
 
 # Step 2: Already have a wisp? Resume it. Otherwise check mail, then pour ONE.
+# Either way the wisp must end up in_progress: --assignee alone leaves it at
+# status=open, where the next restart's resume check cannot see it.
 if [ -n "$WISP" ]; then
   echo "Resuming patrol wisp $WISP"
+  gc bd update "$WISP" --assignee="$GC_AGENT" --status=in_progress
 else
   gc mail inbox
   WISP=$(gc bd mol wisp mol-witness-patrol --root-only --var binding_prefix='{{ .BindingPrefix }}' --json | jq -r '.new_epic_id')
-  gc bd update "$WISP" --assignee="$GC_AGENT"
+  gc bd update "$WISP" --assignee="$GC_AGENT" --status=in_progress
 fi
 
 # Step 3: Execute — read formula steps and work through them in order
@@ -203,14 +211,18 @@ If `next-iteration` already ran, do not pour again; run `gc hook`.
 ```bash
 CURRENT_WISP=${GC_BEAD_ID:-}
 if [ -z "$CURRENT_WISP" ]; then
-  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
+  CURRENT_WISP=$(gc bd query --json 'ephemeral=true AND status=in_progress' --limit=0 | jq -r --arg id "$GC_AGENT" --arg f mol-witness-patrol '[.[] | select((.assignee // "") == $id and (.title // "") == $f)] | .[0].id // empty')
 fi
-# Reconcile queued (open) patrol wisps to exactly one. A prior cycle may have
-# poured a next wisp without burning, or a restart may have raced — keep the
-# first and burn the surplus so wisps never accumulate. Wisp roots are
-# molecules (never --type=wisp, which is not a valid gc bd type and matches
-# nothing).
-OPEN_WISPS=$(gc bd list --assignee="$GC_AGENT" --status=open --type=molecule --limit=0 --json | jq -r '.[].id')
+# Reconcile queued patrol wisps — every one assigned to you EXCEPT the one you
+# are executing — to exactly one. A prior cycle may have poured a next wisp
+# without burning, or a restart may have raced: keep the first and burn the
+# surplus so wisps never accumulate. Enumerate with `gc bd query`; `gc bd list`
+# hides ephemeral wisps unless given --include-infra, and returned zero rows here.
+# Exclude $CURRENT_WISP by id — it is burned below, never reused.
+OPEN_WISPS=$(gc bd query --json 'ephemeral=true AND (status=open OR status=in_progress)' --limit=0 \
+  | jq -r --arg id "$GC_AGENT" --arg f mol-witness-patrol --arg self "$CURRENT_WISP" \
+      '[.[] | select((.assignee // "") == $id and (.title // "") == $f and .id != $self)]
+       | sort_by(.created_at) | .[].id')
 ASSIGNED_WISP=$(printf '%s\n' $OPEN_WISPS | sed -n '1p')
 for extra in $(printf '%s\n' $OPEN_WISPS | sed '1d'); do
   gc bd mol burn "$extra" --force
@@ -221,7 +233,7 @@ if [ -n "$CURRENT_WISP" ] && [ -z "$ASSIGNED_WISP" ]; then
     echo "Could not pour next witness wisp; not burning."
     exit 1
   fi
-  if ! gc bd update "$NEXT" --assignee="$GC_AGENT"; then
+  if ! gc bd update "$NEXT" --assignee="$GC_AGENT" --status=in_progress; then
     echo "Could not assign next witness wisp; not burning."
     exit 1
   fi
@@ -234,7 +246,7 @@ elif [ -z "$ASSIGNED_WISP" ]; then
     echo "Could not bootstrap next witness wisp."
     exit 1
   fi
-  if ! gc bd update "$NEXT" --assignee="$GC_AGENT"; then
+  if ! gc bd update "$NEXT" --assignee="$GC_AGENT" --status=in_progress; then
     echo "Could not assign bootstrap witness wisp."
     exit 1
   fi

--- a/gastown/formulas/mol-deacon-patrol.toml
+++ b/gastown/formulas/mol-deacon-patrol.toml
@@ -2,7 +2,18 @@ description = """
 Deacon patrol loop. Poured as a root-only wisp on startup:
 
   gc bd mol wisp mol-deacon-patrol --root-only --var binding_prefix='{{binding_prefix}}'
-  gc bd update $WISP --assignee=$GC_AGENT
+  gc bd update $WISP --assignee=$GC_AGENT --status=in_progress
+
+`--status=in_progress` is not optional. `gc bd mol wisp` pours at
+status=open and `--assignee` alone does not transition it, so a wisp
+poured without it is invisible to the startup resume check (which filters
+`status=in_progress`). A restarted session then finds nothing in progress,
+pours ANOTHER wisp, and orphans the previous one — open, assigned, never
+burned, never resumed. Silent duplication on every restart.
+
+Do not substitute `gc bd update <id> --claim`: it errors "already claimed"
+instead of repairing status when the assignee already matches, so it cannot
+recover a wisp left in the open+assigned partial state.
 
 Each wisp is ONE iteration: check inbox, run town-wide coordination
 tasks, pour the next iteration. On crash, re-read the formula steps
@@ -533,10 +544,23 @@ gc mail inbox
 Handle any urgent messages that arrived during patrol. Archive the rest.
 
 **3. Resolve current wisp and pour next iteration BEFORE burning:**
+
+Wisp roots are ephemeral rows, and `gc bd list` hides those unless it is
+passed `--include-infra`. The flagless lookup this replaces silently resolved
+empty and the loop refused to burn. Resolve through `gc bd query` instead: it
+selects the ephemeral tier directly, so the correct result does not depend on
+remembering a flag. The second query repairs a
+wisp left at `status=open` by a session that predates this fix: adopt the
+oldest one as the wisp you are executing and promote it, so the burn below
+has a real id instead of draining the patrol.
 ```bash
 CURRENT_WISP=${GC_BEAD_ID:-}
 if [ -z "$CURRENT_WISP" ]; then
-  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
+  CURRENT_WISP=$(gc bd query --json 'ephemeral=true AND status=in_progress' --limit=0 | jq -r --arg id "$GC_AGENT" '[.[] | select((.assignee // "") == $id)] | .[0].id // empty')
+fi
+if [ -z "$CURRENT_WISP" ]; then
+  CURRENT_WISP=$(gc bd query --json 'ephemeral=true AND status=open' --limit=0 | jq -r --arg id "$GC_AGENT" --arg f mol-deacon-patrol '[.[] | select((.assignee // "") == $id and (.title // "") == $f)] | sort_by(.created_at) | .[0].id // empty')
+  [ -n "$CURRENT_WISP" ] && gc bd update "$CURRENT_WISP" --status=in_progress
 fi
 
 NEXT=$(gc bd mol wisp mol-deacon-patrol --root-only --var binding_prefix='{{binding_prefix}}' --json | jq -r '.new_epic_id // empty')
@@ -545,7 +569,7 @@ if [ -z "$NEXT" ]; then
   gc runtime drain-ack
   exit 1
 fi
-if ! gc bd update "$NEXT" --assignee="$GC_AGENT"; then
+if ! gc bd update "$NEXT" --assignee="$GC_AGENT" --status=in_progress; then
   echo "Could not assign next deacon wisp; not burning."
   gc runtime drain-ack
   exit 1

--- a/gastown/formulas/mol-refinery-patrol.toml
+++ b/gastown/formulas/mol-refinery-patrol.toml
@@ -2,7 +2,18 @@ description = """
 Refinery patrol loop. Poured as a root-only wisp on startup:
 
   gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{target_branch}} --var rig_name={{rig_name}} --var binding_prefix={{binding_prefix}}
-  gc bd update $WISP --assignee=$GC_AGENT
+  gc bd update $WISP --assignee=$GC_AGENT --status=in_progress
+
+`--status=in_progress` is not optional. `gc bd mol wisp` pours at
+status=open and `--assignee` alone does not transition it, so a wisp
+poured without it is invisible to the startup resume check (which filters
+`status=in_progress`). A restarted session then finds nothing in progress,
+pours ANOTHER wisp, and orphans the previous one — open, assigned, never
+burned, never resumed. Silent duplication on every restart.
+
+Do not substitute `gc bd update <id> --claim`: it errors "already claimed"
+instead of repairing status when the assignee already matches, so it cannot
+recover a wisp left in the open+assigned partial state.
 
 Each wisp is ONE iteration: check for work, merge one branch, pour
 the next iteration. On crash, re-read the formula steps and determine
@@ -119,7 +130,7 @@ wisp, burn the current wisp, then request a restart:
 ```bash
 CURRENT_WISP=${GC_BEAD_ID:-}
 if [ -z "$CURRENT_WISP" ]; then
-  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
+  CURRENT_WISP=$(gc bd query --json 'ephemeral=true AND status=in_progress' --limit=0 | jq -r --arg id "$GC_AGENT" '[.[] | select((.assignee // "") == $id)] | .[0].id // empty')
 fi
 NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{target_branch}} --var rig_name={{rig_name}} --var binding_prefix={{binding_prefix}} --json | jq -r '.new_epic_id // empty')
 if [ -z "$NEXT" ]; then
@@ -127,7 +138,7 @@ if [ -z "$NEXT" ]; then
   gc runtime drain-ack
   exit 1
 fi
-if ! gc bd update "$NEXT" --assignee="$GC_AGENT"; then
+if ! gc bd update "$NEXT" --assignee="$GC_AGENT" --status=in_progress; then
   echo "Could not assign next refinery wisp; not requesting restart."
   gc runtime drain-ack
   exit 1
@@ -242,7 +253,7 @@ gc bd update $WORK \
 ```bash
 CURRENT_WISP=${GC_BEAD_ID:-}
 if [ -z "$CURRENT_WISP" ]; then
-  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
+  CURRENT_WISP=$(gc bd query --json 'ephemeral=true AND status=in_progress' --limit=0 | jq -r --arg id "$GC_AGENT" '[.[] | select((.assignee // "") == $id)] | .[0].id // empty')
 fi
 NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{target_branch}} --var rig_name={{rig_name}} --var binding_prefix={{binding_prefix}} --json | jq -r '.new_epic_id // empty')
 if [ -z "$NEXT" ]; then
@@ -250,7 +261,7 @@ if [ -z "$NEXT" ]; then
   gc runtime drain-ack
   exit 1
 fi
-if ! gc bd update "$NEXT" --assignee="$GC_AGENT"; then
+if ! gc bd update "$NEXT" --assignee="$GC_AGENT" --status=in_progress; then
   echo "Could not assign next refinery wisp; not burning."
   gc runtime drain-ack
   exit 1
@@ -343,7 +354,7 @@ TARGET=$(gc bd show $WORK --json | jq -r '.[0].metadata.target // "{{target_bran
      ```bash
      CURRENT_WISP=${GC_BEAD_ID:-}
      if [ -z "$CURRENT_WISP" ]; then
-       CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
+       CURRENT_WISP=$(gc bd query --json 'ephemeral=true AND status=in_progress' --limit=0 | jq -r --arg id "$GC_AGENT" '[.[] | select((.assignee // "") == $id)] | .[0].id // empty')
      fi
      NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{target_branch}} --var rig_name={{rig_name}} --var binding_prefix={{binding_prefix}} --json | jq -r '.new_epic_id // empty')
      if [ -z "$NEXT" ]; then
@@ -351,7 +362,7 @@ TARGET=$(gc bd show $WORK --json | jq -r '.[0].metadata.target // "{{target_bran
        gc runtime drain-ack
        exit 1
      fi
-     if ! gc bd update "$NEXT" --assignee="$GC_AGENT"; then
+     if ! gc bd update "$NEXT" --assignee="$GC_AGENT" --status=in_progress; then
        echo "Could not assign next refinery wisp; not burning."
        gc runtime drain-ack
        exit 1
@@ -435,7 +446,7 @@ Branch: $BRANCH
 Target: $TARGET"
   CURRENT_WISP=${GC_BEAD_ID:-}
   if [ -z "$CURRENT_WISP" ]; then
-    CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
+    CURRENT_WISP=$(gc bd query --json 'ephemeral=true AND status=in_progress' --limit=0 | jq -r --arg id "$GC_AGENT" '[.[] | select((.assignee // "") == $id)] | .[0].id // empty')
   fi
   if [ -z "$CURRENT_WISP" ]; then
     echo "Could not resolve current wisp; not burning."
@@ -450,7 +461,7 @@ Target: $TARGET"
     gc runtime drain-ack
     exit 1
   fi
-  if ! gc bd update "$NEXT" --assignee="$GC_AGENT"; then
+  if ! gc bd update "$NEXT" --assignee="$GC_AGENT" --status=in_progress; then
     echo "Could not assign next refinery wisp; not burning."
     gc runtime drain-ack
     exit 1
@@ -1143,7 +1154,7 @@ If auto_land = "false": skip this entirely.
 ```bash
 CURRENT_WISP=${GC_BEAD_ID:-}
 if [ -z "$CURRENT_WISP" ]; then
-  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
+  CURRENT_WISP=$(gc bd query --json 'ephemeral=true AND status=in_progress' --limit=0 | jq -r --arg id "$GC_AGENT" '[.[] | select((.assignee // "") == $id)] | .[0].id // empty')
 fi
 NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{target_branch}} --var rig_name={{rig_name}} --var binding_prefix={{binding_prefix}} --json | jq -r '.new_epic_id // empty')
 if [ -z "$NEXT" ]; then
@@ -1151,7 +1162,7 @@ if [ -z "$NEXT" ]; then
   gc runtime drain-ack
   exit 1
 fi
-if ! gc bd update "$NEXT" --assignee="$GC_AGENT"; then
+if ! gc bd update "$NEXT" --assignee="$GC_AGENT" --status=in_progress; then
   echo "Could not assign next refinery wisp; not burning."
   gc runtime drain-ack
   exit 1

--- a/gastown/formulas/mol-refinery-patrol.toml
+++ b/gastown/formulas/mol-refinery-patrol.toml
@@ -1117,8 +1117,10 @@ If the cycle ended early (conflict rejection, no work found), note
 why and what state was left.
 
 This summary is not stored separately — it lives in the wisp's
-closing reason. The next session can find it via `gc bd list --type=molecule
---status=closed --limit=5` if it needs predecessor context."""
+closing reason. The next session can find it via
+`gc bd query --json 'ephemeral=true AND status=closed' --limit=5` if it
+needs predecessor context. `gc bd list` needs `--include-infra` to return
+wisps at all, so the flagless form finds nothing."""
 
 [[steps]]
 id = "next-iteration"

--- a/gastown/formulas/mol-witness-patrol.toml
+++ b/gastown/formulas/mol-witness-patrol.toml
@@ -2,7 +2,18 @@ description = """
 Witness patrol loop. Poured as a root-only wisp on startup:
 
   gc bd mol wisp mol-witness-patrol --root-only --var binding_prefix='{{binding_prefix}}'
-  gc bd update $WISP --assignee=$GC_AGENT
+  gc bd update $WISP --assignee=$GC_AGENT --status=in_progress
+
+`--status=in_progress` is not optional. `gc bd mol wisp` pours at
+status=open and `--assignee` alone does not transition it, so a wisp
+poured without it is invisible to the startup resume check (which filters
+`status=in_progress`). A restarted session then finds nothing in progress,
+pours ANOTHER wisp, and orphans the previous one — open, assigned, never
+burned, never resumed. Silent duplication on every restart.
+
+Do not substitute `gc bd update <id> --claim`: it errors "already claimed"
+instead of repairing status when the assignee already matches, so it cannot
+recover a wisp left in the open+assigned partial state.
 
 Each wisp is ONE iteration: check for work, patrol, pour the next
 iteration. On crash, re-read the formula steps and determine where
@@ -527,24 +538,67 @@ is already assigned — the new session resumes from context.
 
 Reuse an already-queued wisp instead of pouring a duplicate. A prior cycle
 may have poured a next wisp without burning, or a restart may have raced —
-keep one open patrol wisp and burn any surplus, so wisps never accumulate.
-Wisp roots are `issue_type=molecule` (never `--type=wisp`, which is not a
-valid gc bd type and matches nothing).
+keep one patrol wisp and burn any surplus, so wisps never accumulate.
+
+Two rules make this reconcile work, and both are load-bearing:
+
+- **Enumerate with `gc bd query` on `ephemeral=true`.** Wisp roots are
+  ephemeral rows, and `gc bd list` hides those unless it is passed
+  `--include-infra` — the flagless scan this replaces returned zero rows even
+  when the wisps were sitting right there, so it found no surplus to burn and
+  no successor to reuse, and every cycle poured a fresh wisp. `gc bd list
+  --include-infra` does return them; `gc bd query` is used here because it
+  selects the ephemeral tier directly and leaves no flag to forget.
+  (`--type=wisp` is worse either way: `wisp` is not a valid gc bd type, so the
+  command hard-errors.)
+- **Exclude the wisp you are executing, by id.** It is never a reuse or a
+  burn candidate here — step 3 burns it. Resolve it first, and if nothing
+  resolves, pour nothing and burn nothing.
+
 ```bash
-OPEN_WISPS=$(gc bd list --assignee="$GC_AGENT" --status=open --type=molecule --limit=0 --json | jq -r '.[].id')
-NEXT=$(printf '%s\n' $OPEN_WISPS | sed -n '1p')
-for extra in $(printf '%s\n' $OPEN_WISPS | sed '1d'); do
+CURRENT_WISP=${GC_BEAD_ID:-}
+if [ -z "$CURRENT_WISP" ]; then
+  CURRENT_WISP=$(gc bd query --json 'ephemeral=true AND status=in_progress' --limit=0 | jq -r --arg id "$GC_AGENT" '[.[] | select((.assignee // "") == $id)] | .[0].id // empty')
+fi
+if [ -z "$CURRENT_WISP" ]; then
+  # Repair path: a wisp poured before this fix is still status=open. Adopt the
+  # oldest one as the wisp you are executing and promote it.
+  CURRENT_WISP=$(gc bd query --json 'ephemeral=true AND status=open' --limit=0 | jq -r --arg id "$GC_AGENT" --arg f mol-witness-patrol '[.[] | select((.assignee // "") == $id and (.title // "") == $f)] | sort_by(.created_at) | .[0].id // empty')
+  [ -n "$CURRENT_WISP" ] && gc bd update "$CURRENT_WISP" --status=in_progress
+fi
+if [ -z "$CURRENT_WISP" ]; then
+  echo "Could not resolve current witness wisp; not pouring and not burning."
+  gc runtime drain-ack
+  exit 1
+fi
+
+SURPLUS=$(gc bd query --json 'ephemeral=true AND (status=open OR status=in_progress)' --limit=0 | jq -r --arg id "$GC_AGENT" --arg f mol-witness-patrol --arg self "$CURRENT_WISP" '[.[] | select((.assignee // "") == $id and (.title // "") == $f and .id != $self)] | sort_by(.created_at) | .[].id')
+NEXT=$(printf '%s\n' $SURPLUS | sed -n '1p')
+for extra in $(printf '%s\n' $SURPLUS | sed '1d'); do
   gc bd mol burn "$extra" --force
 done
 if [ -z "$NEXT" ]; then
-  NEXT=$(gc bd mol wisp mol-witness-patrol --root-only --var binding_prefix='{{binding_prefix}}' --json | jq -r '.new_epic_id')
-  gc bd update "$NEXT" --assignee="$GC_AGENT"
+  NEXT=$(gc bd mol wisp mol-witness-patrol --root-only --var binding_prefix='{{binding_prefix}}' --json | jq -r '.new_epic_id // empty')
+  if [ -z "$NEXT" ]; then
+    echo "Could not pour next witness wisp; not burning."
+    gc runtime drain-ack
+    exit 1
+  fi
+fi
+if ! gc bd update "$NEXT" --assignee="$GC_AGENT" --status=in_progress; then
+  echo "Could not assign next witness wisp; not burning."
+  gc runtime drain-ack
+  exit 1
 fi
 ```
 
+Assigning an adopted successor is idempotent, and re-running the update is
+what repairs a wisp stuck in the open+assigned partial state that
+`gc bd update --claim` refuses to touch.
+
 **3. Burn this wisp:**
 ```bash
-gc bd mol burn <this-wisp-id> --force
+gc bd mol burn "$CURRENT_WISP" --force
 ```
 
 **4. Exit this turn:**

--- a/gastown/tests/test_gastown_pack_assets.sh
+++ b/gastown/tests/test_gastown_pack_assets.sh
@@ -245,6 +245,36 @@ test_prime_prompts_are_city_generic_and_compact() {
         fail "operational awareness should direct agents to the effective Dolt port"
 }
 
+test_refinery_wisp_pour_is_resumable() {
+    local formula pours assigns resolves stale_list
+    formula="$GASTOWN/formulas/mol-refinery-patrol.toml"
+
+    # Every pour must be paired with an assign that also transitions the new
+    # wisp to in_progress. A wisp left at status=open is invisible to the
+    # startup resume check, so the next session pours a duplicate and orphans
+    # this one (open, assigned, never burned, never resumed).
+    # `|| true` on every count: grep -c exits 1 on zero matches, which under
+    # `set -e` would abort the script before the explanatory fail() ran.
+    pours=$(grep -c 'NEXT=\$(gc bd mol wisp mol-refinery-patrol --root-only' "$formula" || true)
+    assigns=$(grep -c 'gc bd update "\$NEXT" --assignee="\$GC_AGENT" --status=in_progress' "$formula" || true)
+    [[ "$assigns" -eq "$pours" ]] ||
+        fail "refinery pour sites ($pours) must each assign with --status=in_progress ($assigns)"
+    ! grep -E 'gc bd update "\$NEXT" --assignee="\$GC_AGENT";' "$formula" >/dev/null ||
+        fail "refinery pour must not assign the next wisp without --status=in_progress"
+    grep -F 'gc bd update $WISP --assignee=$GC_AGENT --status=in_progress' "$formula" >/dev/null ||
+        fail "refinery bootstrap snippet must pour the first wisp as in_progress"
+
+    # Current-wisp resolution must use `gc bd query` on ephemeral beads.
+    # `gc bd list` never returns ephemeral beads regardless of --type, so a
+    # list-based fallback silently resolves empty and the loop refuses to burn.
+    resolves=$(grep -c "CURRENT_WISP=\$(gc bd query --json 'ephemeral=true AND status=in_progress'" "$formula" || true)
+    [[ "$resolves" -eq "$pours" ]] ||
+        fail "refinery pour sites ($pours) must each resolve the current wisp via gc bd query ($resolves)"
+    stale_list=$(grep -c 'CURRENT_WISP=\$(gc bd list' "$formula" || true)
+    [[ "$stale_list" -eq 0 ]] ||
+        fail "refinery must not resolve the current wisp with gc bd list (ephemeral beads are excluded)"
+}
+
 test_dog_assets_are_pack_local
 test_retired_dog_formulas_are_not_reintroduced
 test_shutdown_dance_contracts_are_executable
@@ -254,5 +284,6 @@ test_polecat_startup_uses_standard_hook_claim
 test_review_leg_contract_forbids_synthetic_mutation
 test_prime_prompts_are_city_generic_and_compact
 test_refinery_direct_merge_is_worktree_safe_and_fail_closed
+test_refinery_wisp_pour_is_resumable
 
 echo "gastown pack asset tests passed"

--- a/gastown/tests/test_gastown_pack_assets.sh
+++ b/gastown/tests/test_gastown_pack_assets.sh
@@ -245,9 +245,8 @@ test_prime_prompts_are_city_generic_and_compact() {
         fail "operational awareness should direct agents to the effective Dolt port"
 }
 
-test_refinery_wisp_pour_is_resumable() {
-    local formula pours assigns resolves stale_list
-    formula="$GASTOWN/formulas/mol-refinery-patrol.toml"
+assert_patrol_wisp_pour_is_resumable() {
+    local role="$1" asset="$2" pours assigns
 
     # Every pour must be paired with an assign that also transitions the new
     # wisp to in_progress. A wisp left at status=open is invisible to the
@@ -255,24 +254,55 @@ test_refinery_wisp_pour_is_resumable() {
     # this one (open, assigned, never burned, never resumed).
     # `|| true` on every count: grep -c exits 1 on zero matches, which under
     # `set -e` would abort the script before the explanatory fail() ran.
-    pours=$(grep -c 'NEXT=\$(gc bd mol wisp mol-refinery-patrol --root-only' "$formula" || true)
-    assigns=$(grep -c 'gc bd update "\$NEXT" --assignee="\$GC_AGENT" --status=in_progress' "$formula" || true)
-    [[ "$assigns" -eq "$pours" ]] ||
-        fail "refinery pour sites ($pours) must each assign with --status=in_progress ($assigns)"
-    ! grep -E 'gc bd update "\$NEXT" --assignee="\$GC_AGENT";' "$formula" >/dev/null ||
-        fail "refinery pour must not assign the next wisp without --status=in_progress"
-    grep -F 'gc bd update $WISP --assignee=$GC_AGENT --status=in_progress' "$formula" >/dev/null ||
-        fail "refinery bootstrap snippet must pour the first wisp as in_progress"
+    pours=$(grep -c "gc bd mol wisp mol-$role-patrol --root-only" "$asset" || true)
+    [[ "$pours" -gt 0 ]] ||
+        fail "$role $(basename "$asset") should pour at least one patrol wisp"
+    assigns=$(grep -cE 'gc bd update "?\$(NEXT|WISP|NEW_WISP)"? --assignee=("?\$GC_(AGENT|ALIAS)"?) --status=in_progress' "$asset" || true)
+    [[ "$assigns" -gt 0 ]] ||
+        fail "$role $(basename "$asset") must assign poured wisps with --status=in_progress"
+    ! grep -E 'gc bd update "?\$(NEXT|WISP|NEW_WISP)"? --assignee=("?\$GC_(AGENT|ALIAS)"?)\s*(;|$)' "$asset" >/dev/null ||
+        fail "$role $(basename "$asset") must not assign a wisp without --status=in_progress"
 
-    # Current-wisp resolution must use `gc bd query` on ephemeral beads.
-    # `gc bd list` never returns ephemeral beads regardless of --type, so a
-    # list-based fallback silently resolves empty and the loop refuses to burn.
+    # Wisp lookups must reach the ephemeral tier. `gc bd list` hides ephemeral
+    # beads unless it is passed --include-infra, so a flagless --type=molecule
+    # lookup silently resolves empty: no surplus is burned, no successor is
+    # reused, and every cycle pours a fresh wisp on top of the leaked one.
+    # A list that does pass --include-infra is not a defect, so only the
+    # flagless form fails here -- pinning the query form instead would make
+    # this a style rule and collide with #278, which fixes the same bug that
+    # way.
+    ! grep -E 'gc bd list[^`]*--type=molecule' "$asset" | grep -vq -- '--include-infra' ||
+        fail "$role $(basename "$asset") looks up wisps with gc bd list and no --include-infra (ephemeral beads are hidden)"
+    grep -F "gc bd query --json 'ephemeral=true" "$asset" >/dev/null ||
+        fail "$role $(basename "$asset") must resolve wisps via gc bd query on ephemeral=true"
+}
+
+test_patrol_wisp_pour_is_resumable() {
+    local role formula
+    for role in refinery witness deacon; do
+        assert_patrol_wisp_pour_is_resumable "$role" "$GASTOWN/formulas/mol-$role-patrol.toml"
+        assert_patrol_wisp_pour_is_resumable "$role" "$GASTOWN/agents/$role/prompt.template.md"
+    done
+
+    # The refinery formula repeats the pour/resolve pair at every exit path;
+    # each one needs its own current-wisp resolution or that path burns nothing.
+    formula="$GASTOWN/formulas/mol-refinery-patrol.toml"
+    local pours resolves
+    pours=$(grep -c 'NEXT=\$(gc bd mol wisp mol-refinery-patrol --root-only' "$formula" || true)
     resolves=$(grep -c "CURRENT_WISP=\$(gc bd query --json 'ephemeral=true AND status=in_progress'" "$formula" || true)
     [[ "$resolves" -eq "$pours" ]] ||
         fail "refinery pour sites ($pours) must each resolve the current wisp via gc bd query ($resolves)"
-    stale_list=$(grep -c 'CURRENT_WISP=\$(gc bd list' "$formula" || true)
-    [[ "$stale_list" -eq 0 ]] ||
-        fail "refinery must not resolve the current wisp with gc bd list (ephemeral beads are excluded)"
+
+    # The witness reconcile must exclude the wisp it is executing. Without the
+    # self-exclusion it reuses its own wisp as the successor, then burns it in
+    # the next step and the patrol is left holding nothing.
+    local witness_formula="$GASTOWN/formulas/mol-witness-patrol.toml"
+    grep -F -- '--arg self "$CURRENT_WISP"' "$witness_formula" >/dev/null ||
+        fail "witness wisp reconcile must pass the current wisp id into the surplus query"
+    grep -E '\.id != \$self\)\]' "$witness_formula" >/dev/null ||
+        fail "witness wisp reconcile must exclude the current wisp by id"
+    grep -F 'gc bd mol burn "$CURRENT_WISP" --force' "$GASTOWN/formulas/mol-witness-patrol.toml" >/dev/null ||
+        fail "witness must burn the resolved current wisp, not a placeholder id"
 }
 
 test_dog_assets_are_pack_local
@@ -284,6 +314,6 @@ test_polecat_startup_uses_standard_hook_claim
 test_review_leg_contract_forbids_synthetic_mutation
 test_prime_prompts_are_city_generic_and_compact
 test_refinery_direct_merge_is_worktree_safe_and_fail_closed
-test_refinery_wisp_pour_is_resumable
+test_patrol_wisp_pour_is_resumable
 
 echo "gastown pack asset tests passed"


### PR DESCRIPTION
## Problem

Every patrol role — refinery, witness, deacon — pours its next wisp and then assigns it:

```bash
NEXT=$(gc bd mol wisp mol-<role>-patrol --root-only ... | jq -r '.new_epic_id')
gc bd update "$NEXT" --assignee="$GC_AGENT"
```

Two independent mechanisms make that leak wisps, and fixing either one alone is not enough.

**1. The wisp is never transitioned.** `gc bd mol wisp` pours at `status=open`, and `--assignee` alone does not move it. The startup resume check filters explicitly on `status=in_progress`, so **a wisp poured by the documented snippet is invisible to its own resume check.** A restarted session finds nothing in progress, pours another wisp, and orphans the previous one — open, assigned, never burned, never resumed.

**2. The reconciliation cannot see wisps at all.** Wisp roots are ephemeral rows, and `gc bd list` excludes ephemeral beads regardless of `--type`. Every list-based lookup — current-wisp resolution, surplus reconciliation, queued-successor reuse — silently resolves empty. So the block that exists to keep exactly one wisp finds no surplus to burn and no successor to reuse, and pours a fresh one every cycle. This is the #1884 wisp-leak pattern.

The same defect is in the **agent prompt templates**, not just the formulas — and the prompt is what actually bootstraps the first wisp and runs the no-idle-state reconciliation.

## Verified behaviour

Against a live gas-city ledger carrying **two leaked witness wisps**:

| Command | Result |
|---|---|
| `gc bd query 'ephemeral=true'` | returns both wisps: `status=open`, `ephemeral=true`, `issue_type=molecule`, assigned to the witness |
| `gc bd list --assignee=<witness> --status=open --type=molecule` | **0 rows** |
| `gc bd list --status=open --type=molecule` (no assignee filter) | **0 rows** |
| `gc bd mol wisp --root-only` | `status=open`, `assignee=null` |
| `gc bd update <id> --assignee=X` | `status=open` — unchanged |
| `gc bd update <id> --assignee=X --status=in_progress` | `status=in_progress` ✅ |
| `gc bd update <id> --claim` (assignee matches, status open) | errors `already claimed`, status stays `open` |

Dry-run of the old vs new witness reconcile against that live pair:

```
OLD:  OPEN_WISPS=[]            -> NEXT=[]        => pours a duplicate every cycle
NEW:  current=gci-wisp-8kq (adopted+promoted)
      surplus (excl self)=[gci-wisp-bvr]
      -> NEXT = gci-wisp-bvr   (reused, no pour)
      -> burn = gci-wisp-8kq   => 2 wisps become 1, leak drains
```

## Changes

Across all three patrol roles, in both the formula and the agent prompt template:

1. **Every pour assigns with `--status=in_progress`** — including the bootstrap snippets in the formula headers and the prompt startup protocols.
2. **Every wisp lookup goes through `gc bd query` on `ephemeral=true`**, filtered by assignee and exact formula title. (The earlier `--type=wisp` spelling was worse still: `wisp` is not a valid issue type, so the command hard-errors.)
3. **The witness reconcile excludes the wisp it is executing, by id.** Once wisps are correctly `in_progress`, a status-only scan matches the current wisp — it would be reused as the successor and then burned on the next line, leaving the witness holding nothing. `next-iteration` now resolves the current wisp first and burns `$CURRENT_WISP` instead of a `<this-wisp-id>` placeholder.
4. **A repair path** adopts and promotes a wisp left at `status=open` by a session predating this fix. Without it, every already-deployed patrol wedges on an unresolvable current wisp after the pin bump instead of draining its existing leak.
5. **Header notes** explain why `--status=in_progress` is load-bearing and why `--claim` is not a safe substitute.

## Validation

- `test_patrol_wisp_pour_is_resumable` in `gastown/tests/test_gastown_pack_assets.sh` covers all six assets. Mutation-tested: it fails independently when *each* role's formula is reverted, when *each* role's prompt template is reverted, when the witness self-exclusion is removed, and when a single lookup is put back to `gc bd list`.
- All `gastown/tests/test_*.sh` pass.
- `tests/test_no_bare_bd_commands.py` passes (every new call routes through `gc bd`).
- `validate_registry.py --require-git` passes (`registry.toml: ok`); `registry.toml` is untouched.
- All three formulas parse under `tomllib` (9 / 5 / 8 steps intact).
- `bash -n` over all 14 wisp-handling shell blocks, with template placeholders neutralized.

## Relationship to other open PRs

This overlaps work already in your queue, and I would rather you merge whichever shape you prefer than have three variants of the same block sitting open:

- **#226** (`fix(gastown): reconcile patrol wisps across restarts`) covers the same three formulas and prompts with a much larger shared patrol-ledger contract. If you prefer that shape, this PR should be closed in its favour — it is the more thorough change. This one is the surgical version, with the live evidence above.
- **#189** and **#253** both fix witness self-burn in the same `next-iteration` block. Both keep `gc bd list --status=open --type=molecule`, which returns zero rows for ephemeral wisps — so their reconciliation operates on an always-empty list. #189 additionally states as an invariant that "a patrol wisp stays `status=open` for its entire working life"; that is true today only *because* of the defect this PR fixes. The self-exclusion insight in #253 is correct and is carried here, with credit.

Happy to split this back into refinery-only, rebase onto any of the above, or close it — whichever unblocks the queue fastest.

## Not in this change

- `mol-deacon-patrol`'s prompt bootstrap assigns with `$GC_ALIAS` while its reconcile reads `$GC_AGENT`; a mismatch there is the same leak by a different route, but it belongs with the identity-resolution work in #280 / #282.
- Fixing the class in the binary instead of per formula: make `gc bd mol wisp --root-only` default to `in_progress`, or make `--claim` idempotent when assignee matches but status differs.

Filed from a production deployment as gci-ly4 (refinery) and gci-5fa (witness + deacon).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0182tfjiB7nbSt7tJvfnEuZM
