### PR TITLE
fix: scope patrol-project-leads as a city order to stop per-rig duplicate patrols

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
                       pr-pipeline slack-channel slack-full slack-mini; do
             "$GC_BIN" lint "$pack"
           done
+          GC_TEST_BIN="$GC_BIN" python3 -m pytest oversight-rig/tests/test_order_scopes.py -q
           GC_TEST_BIN="$GC_BIN" python3 -m pytest tests/test_gc_role_prompt_integration.py tests/test_pack_composition_warnings.py -q
 
       # Installed, not parsed. `gc lint` above reads each pack on its own and

--- a/oversight-rig/orders/escalate-rollups.toml
+++ b/oversight-rig/orders/escalate-rollups.toml
@@ -1,5 +1,10 @@
 [order]
 description = "Watch for severity:escalate rollup beads and deliver them. Pure mechanical — no agent decision."
+# Deliberately NOT city-scoped, unlike patrol-project-leads: deliver-rollup.sh
+# routes each bead by its own `rig:` label and is idempotent per bead
+# (idempotency_key `rollup-<id>`, plus an `--add-label delivered` on success),
+# so overlapping per-rig instances converge on the same delivery instead of
+# fanning out. oversight-rig/tests/test_order_scopes.py pins this fan-out.
 trigger = "condition"
 check = "bash $GC_PACK_DIR/assets/scripts/has-undelivered-escalates.sh"
 exec = "bash $GC_PACK_DIR/assets/scripts/deliver-rollup.sh"

--- a/oversight-rig/orders/patrol-project-leads.toml
+++ b/oversight-rig/orders/patrol-project-leads.toml
@@ -1,5 +1,6 @@
 [order]
 description = "Nudge every project-lead to run a triage tick. Cooldown sets the cadence."
+scope = "city"
 trigger = "cooldown"
 interval = "15m"
 exec = "bash $GC_PACK_DIR/assets/scripts/nudge-project-leads.sh"

--- a/oversight-rig/orders/patrol-project-leads.toml
+++ b/oversight-rig/orders/patrol-project-leads.toml
@@ -1,5 +1,13 @@
 [order]
 description = "Nudge every project-lead to run a triage tick. Cooldown sets the cadence."
+# City-scoped: nudge-project-leads.sh enumerates every active project-lead
+# session city-wide (`gc session list` filtered on template + state, no rig
+# filter), so it already covers the whole city in one run. Left unscoped, each
+# per-rig pack import registers its own instance, and every one of them fires
+# on its own independent cooldown -- N rigs means each lead is nudged N+1 times
+# per tick. Unlike gastown/orders/digest-generate.toml, whose per-rig instances
+# never fire, these do fire; the reason for `scope = "city"` is duplicate work,
+# not a stuck order.
 scope = "city"
 trigger = "cooldown"
 interval = "15m"

--- a/oversight-rig/tests/test_order_scopes.py
+++ b/oversight-rig/tests/test_order_scopes.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import textwrap
+
+import pytest
+
+
+PACK_ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture(scope="session")
+def gc_test_bin() -> Path:
+    configured = os.environ.get("GC_TEST_BIN")
+    if not configured:
+        pytest.skip("set GC_TEST_BIN to run real Gas City CLI integration tests")
+
+    binary = Path(configured).expanduser().resolve()
+    if not binary.is_file() or not os.access(binary, os.X_OK):
+        pytest.fail(f"GC_TEST_BIN is not an executable file: {binary}")
+    return binary
+
+
+def write_order_scope_city(root: Path) -> Path:
+    city = root / "city"
+    control_pack = root / "control-pack"
+    (city / ".gc").mkdir(parents=True)
+    (city / "alpha").mkdir()
+    (city / "beta").mkdir()
+    (control_pack / "orders").mkdir(parents=True)
+
+    city.joinpath("pack.toml").write_text(
+        textwrap.dedent(
+            f"""\
+            [pack]
+            name = "order-scope-test"
+            schema = 2
+
+            [imports.oversight-rig]
+            source = {json.dumps(str(PACK_ROOT))}
+            """
+        ),
+        encoding="utf-8",
+    )
+    city.joinpath("city.toml").write_text(
+        textwrap.dedent(
+            f"""\
+            [workspace]
+            provider = "codex"
+
+            [providers.codex]
+            base = "builtin:codex"
+
+            [[rigs]]
+            name = "alpha"
+
+            [rigs.imports.oversight-rig]
+            source = {json.dumps(str(PACK_ROOT))}
+
+            [rigs.imports.control]
+            source = {json.dumps(str(control_pack))}
+
+            [[rigs]]
+            name = "beta"
+
+            [rigs.imports.oversight-rig]
+            source = {json.dumps(str(PACK_ROOT))}
+
+            [rigs.imports.control]
+            source = {json.dumps(str(control_pack))}
+            """
+        ),
+        encoding="utf-8",
+    )
+    city.joinpath(".gc", "site.toml").write_text(
+        textwrap.dedent(
+            f"""\
+            workspace_name = "order-scope-test"
+
+            [[rig]]
+            name = "alpha"
+            path = {json.dumps(str(city / "alpha"))}
+
+            [[rig]]
+            name = "beta"
+            path = {json.dumps(str(city / "beta"))}
+            """
+        ),
+        encoding="utf-8",
+    )
+    control_pack.joinpath("pack.toml").write_text(
+        textwrap.dedent(
+            """\
+            [pack]
+            name = "control"
+            schema = 2
+            """
+        ),
+        encoding="utf-8",
+    )
+    control_pack.joinpath("orders", "rig-health.toml").write_text(
+        textwrap.dedent(
+            """\
+            [order]
+            exec = "true"
+            trigger = "cooldown"
+            interval = "5m"
+            """
+        ),
+        encoding="utf-8",
+    )
+    return city
+
+
+def scoped_names(orders: list[dict[str, object]], name: str) -> set[str]:
+    return {str(order["scoped_name"]) for order in orders if order.get("name") == name}
+
+
+def test_oversight_orders_preserve_declared_scope_across_rig_imports(
+    tmp_path: Path,
+    gc_test_bin: Path,
+) -> None:
+    city = write_order_scope_city(tmp_path)
+
+    result = subprocess.run(
+        [str(gc_test_bin), "--city", str(city), "order", "list", "--json"],
+        cwd=city,
+        text=True,
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    orders = json.loads(result.stdout)["orders"]
+    assert scoped_names(orders, "patrol-project-leads") == {
+        "patrol-project-leads",
+    }
+    assert scoped_names(orders, "escalate-rollups") == {
+        "escalate-rollups",
+        "escalate-rollups:rig:alpha",
+        "escalate-rollups:rig:beta",
+    }
+    assert scoped_names(orders, "rig-health") == {
+        "rig-health:rig:alpha",
+        "rig-health:rig:beta",
+    }

--- a/oversight-rig/tests/test_order_scopes.py
+++ b/oversight-rig/tests/test_order_scopes.py
@@ -115,8 +115,15 @@ def write_order_scope_city(root: Path) -> Path:
     return city
 
 
-def scoped_names(orders: list[dict[str, object]], name: str) -> set[str]:
-    return {str(order["scoped_name"]) for order in orders if order.get("name") == name}
+def order_identities(
+    orders: list[dict[str, object]],
+    name: str,
+) -> list[tuple[str, object, str]]:
+    return [
+        (str(order["name"]), order.get("rig"), str(order["scoped_name"]))
+        for order in orders
+        if order.get("name") == name
+    ]
 
 
 def test_oversight_orders_preserve_declared_scope_across_rig_imports(
@@ -136,15 +143,17 @@ def test_oversight_orders_preserve_declared_scope_across_rig_imports(
 
     assert result.returncode == 0, result.stderr
     orders = json.loads(result.stdout)["orders"]
-    assert scoped_names(orders, "patrol-project-leads") == {
-        "patrol-project-leads",
-    }
-    assert scoped_names(orders, "escalate-rollups") == {
-        "escalate-rollups",
-        "escalate-rollups:rig:alpha",
-        "escalate-rollups:rig:beta",
-    }
-    assert scoped_names(orders, "rig-health") == {
-        "rig-health:rig:alpha",
-        "rig-health:rig:beta",
-    }
+    patrol = order_identities(orders, "patrol-project-leads")
+    assert len(patrol) == 1
+    assert patrol == [
+        ("patrol-project-leads", None, "patrol-project-leads"),
+    ]
+    assert order_identities(orders, "escalate-rollups") == [
+        ("escalate-rollups", None, "escalate-rollups"),
+        ("escalate-rollups", "alpha", "escalate-rollups:rig:alpha"),
+        ("escalate-rollups", "beta", "escalate-rollups:rig:beta"),
+    ]
+    assert order_identities(orders, "rig-health") == [
+        ("rig-health", "alpha", "rig-health:rig:alpha"),
+        ("rig-health", "beta", "rig-health:rig:beta"),
+    ]

--- a/oversight-rig/tests/test_order_scopes.py
+++ b/oversight-rig/tests/test_order_scopes.py
@@ -132,9 +132,32 @@ def test_oversight_orders_preserve_declared_scope_across_rig_imports(
 ) -> None:
     city = write_order_scope_city(tmp_path)
 
+    # Hermetic child env, matching tests/gc_live_city.py: an inherited GC_*/
+    # BEADS_*/XDG_* key can point the CLI at a live city's store or the
+    # developer's real dotfiles. `order list` is a pure config scan today, so
+    # this is preventive -- it keeps the first store-touching assertion added
+    # here from silently inheriting that failure mode.
+    home = tmp_path / "home"
+    home.mkdir()
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith(("GC_", "BEADS_", "XDG_"))
+    }
+    env.update(
+        {
+            "HOME": str(home),
+            "XDG_CONFIG_HOME": str(home / ".config"),
+            "XDG_DATA_HOME": str(home / ".local" / "share"),
+            "XDG_STATE_HOME": str(home / ".local" / "state"),
+            "XDG_CACHE_HOME": str(home / ".cache"),
+        }
+    )
+
     result = subprocess.run(
         [str(gc_test_bin), "--city", str(city), "order", "list", "--json"],
         cwd=city,
+        env=env,
         text=True,
         capture_output=True,
         timeout=30,

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -11,13 +11,14 @@ def test_order_scope_regression_runs_with_installed_gc() -> None:
         REPO_ROOT.joinpath(".github", "workflows", "ci.yml").read_text(encoding="utf-8")
     )
     steps = workflow["jobs"]["check"]["steps"]
-    integration_step = next(
-        step
-        for step in steps
-        if step.get("name") == "Lint and exercise shared role prompt composition"
+    step_name = "Lint and exercise shared role prompt composition"
+    matching = [step for step in steps if step.get("name") == step_name]
+    assert matching, (
+        f"no step named {step_name!r} in CI job 'check'; "
+        f"found: {[step.get('name') for step in steps]}"
     )
 
-    command = integration_step["run"]
+    command = matching[0]["run"]
     assert (
         'GC_TEST_BIN="$GC_BIN" python3 -m pytest '
         "oversight-rig/tests/test_order_scopes.py -q"

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_order_scope_regression_runs_with_installed_gc() -> None:
+    workflow = yaml.safe_load(
+        REPO_ROOT.joinpath(".github", "workflows", "ci.yml").read_text(encoding="utf-8")
+    )
+    steps = workflow["jobs"]["check"]["steps"]
+    integration_step = next(
+        step
+        for step in steps
+        if step.get("name") == "Lint and exercise shared role prompt composition"
+    )
+
+    command = integration_step["run"]
+    assert (
+        'GC_TEST_BIN="$GC_BIN" python3 -m pytest '
+        "oversight-rig/tests/test_order_scopes.py -q"
+    ) in command

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -10,7 +10,9 @@ def test_order_scope_regression_runs_with_installed_gc() -> None:
     workflow = yaml.safe_load(
         REPO_ROOT.joinpath(".github", "workflows", "ci.yml").read_text(encoding="utf-8")
     )
-    steps = workflow["jobs"]["check"]["steps"]
+    jobs = workflow["jobs"]
+    assert "check" in jobs, f"no job 'check' in CI; found: {sorted(jobs)}"
+    steps = jobs["check"]["steps"]
     step_name = "Lint and exercise shared role prompt composition"
     matching = [step for step in steps if step.get("name") == step_name]
     assert matching, (
@@ -18,8 +20,24 @@ def test_order_scope_regression_runs_with_installed_gc() -> None:
         f"found: {[step.get('name') for step in steps]}"
     )
 
-    command = matching[0]["run"]
-    assert (
+    invocation = (
         'GC_TEST_BIN="$GC_BIN" python3 -m pytest '
         "oversight-rig/tests/test_order_scopes.py -q"
-    ) in command
+    )
+    # Look at the step's *active* lines, not the raw block: a commented-out or
+    # `|| true`-suffixed invocation still contains the substring while no
+    # longer running, or no longer able to fail the job.
+    active = [
+        line.strip()
+        for line in matching[0]["run"].splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    ]
+    running = [line for line in active if line.startswith(invocation)]
+    assert running, (
+        f"{step_name!r} does not run the order-scope regression "
+        f"(absent or commented out); active lines: {active}"
+    )
+    assert not any("||" in line for line in running), (
+        "the order-scope regression is short-circuited, so a failure cannot "
+        f"fail the job: {running}"
+    )


### PR DESCRIPTION
## Summary
- scope `patrol-project-leads` as a city order so imported rigs do not repeat the same citywide patrol
- preserve `escalate-rollups` and unrelated unscoped orders as rig-scoped identities
- add an installed-`gc` integration regression and CI contract check that prove exactly one complete patrol record

## Why
`patrol-project-leads` enumerates all active project leads on every invocation. With the default rig scope, the same source was materialized and executed once for the city plus once per importing rig. This created duplicate global work and avoidable process churn. GasCity order discovery is behaving as designed; the pack must declare this particular order city-scoped.

## Test plan
- `python3 -m pytest -q`
- `GC_TEST_BIN=$(command -v gc) python3 -m pytest oversight-rig/tests/test_order_scopes.py -q`
- `python3 -m pytest tests/test_ci_workflow.py -q`
- `go test ./...`
- pack lint, Ruff, py_compile, and diff checks
