### PR TITLE
fix(slack-full): make the adapter build and pass tests on darwin (syscall.Openat is Linux-only)

### DIFF
--- a/slack-full/CHANGELOG.md
+++ b/slack-full/CHANGELOG.md
@@ -48,6 +48,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The adapter builds and its tests pass on darwin again. The confined-open
+  walk called `syscall.Openat`, which exists only on Linux — darwin's
+  libSystem-based `syscall` package exports neither `Openat` nor
+  `SYS_OPENAT` — so the entire adapter failed to compile on macOS. The
+  walk now binds `golang.org/x/sys/unix`; every flag constant and syscall
+  it swaps is a value-identical mirror on Linux, so behavior there is
+  unchanged. Three `readConfinedFile` tests also failed on macOS, where
+  `TMPDIR` lives under `/var`, itself a symlink to `/private/var`:
+  `confineFileUploadPath` EvalSymlinks-resolves only the *root* and
+  documents the path as caller-pre-resolved, so a fixture handing it a
+  raw `t.TempDir()` broke that contract and made every path — including
+  genuinely in-root ones — read as an escape. The fixtures now resolve
+  their temp dir once through `tempDirResolved`. A harness defect, not a
+  confinement one: no production behavior changed.
 - Inbound files recorded inside Slack itself — voice clips (file subtype
   `slack_audio`) and video clips (`slack_video`) — arrive with an empty
   `mimetype` AND `filetype`, which the adapter passed through verbatim.
@@ -100,6 +114,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The adapter module takes its first dependency, `golang.org/x/sys`
+  (hash-pinned in `adapter/go.sum`), because it is the only maintained
+  source of a darwin-capable `Openat`. The module's zero-dependency
+  property was traded away deliberately; the rejected alternatives and
+  the reason are recorded in `adapter/confined_open.go`. One
+  operator-visible consequence: `adapter/run.sh`'s build-on-missing
+  self-heal used to rebuild the binary with no module downloads at all,
+  and now needs either a warm module cache or GOPROXY egress the first
+  time it builds. On a host behind an egress allowlist, pre-warm with
+  `go mod download` in `slack-full/adapter/` before relying on the
+  self-heal — a cold cache there fails the rebuild with `module lookup
+  disabled by GOPROXY=off`, and the remedy `run.sh` prints on failure
+  hits the same wall.
 - **Behavior change on upgrade:** the slack service now *exits 1 at
   startup* when `GC_SLACK_ADAPTER_ENV` is set to a path that does not
   exist, where it previously logged one warning and started on the

--- a/slack-full/adapter/confined_open.go
+++ b/slack-full/adapter/confined_open.go
@@ -5,7 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
 // openBeneath opens rel (a Clean, root-relative path containing no
@@ -14,8 +15,20 @@ import (
 // with O_NOFOLLOW set. The parent fd pins the verified directory inode,
 // so a directory swapped for a symlink mid-walk cannot redirect the
 // traversal — the userspace equivalent of openat2(RESOLVE_BENEATH),
-// which stdlib syscall does not expose (and the adapter's
-// zero-dependency go.mod keeps us from importing x/sys for).
+// which stdlib syscall does not expose.
+//
+// Uses golang.org/x/sys/unix rather than stdlib syscall: `syscall.Openat`
+// exists only on Linux, so the stdlib version failed to COMPILE on darwin
+// ("undefined: syscall.Openat"), taking the whole adapter with it. Neither
+// stdlib escape hatch works here — darwin's syscall package is libSystem-
+// based and does not export SYS_OPENAT either, and os.Root (Go 1.24+)
+// confines correctly but silently IGNORES O_NOFOLLOW, so it would follow a
+// symlink planted inside the file store and quietly relax the guarantee
+// this function exists to provide. x/sys/unix keeps the semantics exact
+// (verified on darwin/arm64: an in-root symlink still fails ELOOP under
+// O_NOFOLLOW) at the cost of the one dependency this file's original
+// comment was avoiding. That trade is deliberate: correctness of a security
+// primitive over a dependency count.
 //
 // O_NOFOLLOW applies to every component, not just the leaf, so any
 // symlink anywhere beneath root is a hard failure (ELOOP / ENOTDIR).
@@ -33,18 +46,18 @@ func openBeneath(rootAbs, rel string) (*os.File, error) {
 			return nil, fmt.Errorf("openBeneath: invalid path component %q in %q", c, rel)
 		}
 	}
-	dirFlags := syscall.O_RDONLY | syscall.O_DIRECTORY | syscall.O_NOFOLLOW | syscall.O_CLOEXEC
-	fd, err := syscall.Open(rootAbs, dirFlags, 0)
+	dirFlags := unix.O_RDONLY | unix.O_DIRECTORY | unix.O_NOFOLLOW | unix.O_CLOEXEC
+	fd, err := unix.Open(rootAbs, dirFlags, 0)
 	if err != nil {
 		return nil, fmt.Errorf("openBeneath: open root %q: %w", rootAbs, err)
 	}
 	for i, c := range comps {
-		flags := syscall.O_RDONLY | syscall.O_NOFOLLOW | syscall.O_CLOEXEC
+		flags := unix.O_RDONLY | unix.O_NOFOLLOW | unix.O_CLOEXEC
 		if i < len(comps)-1 {
-			flags |= syscall.O_DIRECTORY
+			flags |= unix.O_DIRECTORY
 		}
-		next, err := syscall.Openat(fd, c, flags, 0)
-		syscall.Close(fd)
+		next, err := unix.Openat(fd, c, flags, 0)
+		unix.Close(fd)
 		if err != nil {
 			return nil, fmt.Errorf("openBeneath: open component %q of %q: %w", c, rel, err)
 		}

--- a/slack-full/adapter/confined_open_test.go
+++ b/slack-full/adapter/confined_open_test.go
@@ -12,6 +12,30 @@ import (
 // paths open, and a symlink at ANY component — the stand-in for a
 // parent directory swapped mid-flight — is a hard failure.
 
+// tempDirResolved is t.TempDir() with symlinks resolved.
+//
+// readConfinedFile's contract is that the caller passes an already
+// EvalSymlinks-resolved path — in production confineFileUploadPath does
+// that — and confineFileUploadPath resolves the ROOT but only Abs+Cleans
+// the PATH. A test that hands it a raw t.TempDir() therefore compares a
+// resolved root against an unresolved path.
+//
+// On Linux that is invisible: TMPDIR has no symlinked component, so the
+// two forms are identical. On macOS TMPDIR lives under /var, which IS a
+// symlink to private/var, so the root canonicalizes to /private/var/...
+// while the path stays /var/..., filepath.Rel returns a ../.. escape and
+// every one of these tests fails with "is outside root" — a test-harness
+// artifact, not a confinement defect.
+func tempDirResolved(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	resolved, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatalf("resolving temp dir %q: %v", dir, err)
+	}
+	return resolved
+}
+
 func TestOpenBeneathReadsNestedFile(t *testing.T) {
 	root := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(root, "a", "b"), 0o700); err != nil {
@@ -70,7 +94,7 @@ func TestOpenBeneathRejectsInvalidRel(t *testing.T) {
 }
 
 func TestReadConfinedFileStillReadsAndStillConfines(t *testing.T) {
-	root := t.TempDir()
+	root := tempDirResolved(t)
 	sub := filepath.Join(root, "files")
 	if err := os.MkdirAll(sub, 0o700); err != nil {
 		t.Fatalf("mkdir: %v", err)

--- a/slack-full/adapter/go.mod
+++ b/slack-full/adapter/go.mod
@@ -1,3 +1,5 @@
 module github.com/sjarmak/gc-slack-adapter
 
 go 1.25.9
+
+require golang.org/x/sys v0.47.0

--- a/slack-full/adapter/go.sum
+++ b/slack-full/adapter/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
+golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=

--- a/slack-full/adapter/main_test.go
+++ b/slack-full/adapter/main_test.go
@@ -2720,7 +2720,7 @@ func TestHandlePublishFile(t *testing.T) {
 // reading a regular file inside the upload root must succeed and return
 // the file's bytes verbatim.
 func TestReadConfinedFileReadsRealFile(t *testing.T) {
-	dir := t.TempDir()
+	dir := tempDirResolved(t)
 	path := filepath.Join(dir, "real.txt")
 	want := []byte("hello world")
 	if err := os.WriteFile(path, want, 0o600); err != nil {
@@ -2745,7 +2745,7 @@ func TestReadConfinedFileReadsRealFile(t *testing.T) {
 // ELOOP from open(2) with O_NOFOLLOW on a symlink — errors.Is unwraps
 // through *os.PathError to the underlying syscall.Errno.
 func TestReadConfinedFileRejectsSymlink(t *testing.T) {
-	dir := t.TempDir()
+	dir := tempDirResolved(t)
 	target := filepath.Join(dir, "target.txt")
 	if err := os.WriteFile(target, []byte("secret"), 0o600); err != nil {
 		t.Fatalf("write target: %v", err)


### PR DESCRIPTION
`slack-full`'s adapter does not compile on macOS, and fixing that exposes three test failures that were previously unobservable there.

## 1. The build failure

```
./confined_open.go:46:24: undefined: syscall.Openat
```

`syscall.Openat` is Linux-only. darwin's `syscall` package is libSystem-based and exports neither `Openat` nor `SYS_OPENAT`, so there is no stdlib route to the `openat(2)` walk `openBeneath` needs. That single symbol fails the whole package, so every macOS build of the pack is broken — including the documented `cd adapter && go build -o gc-slack-adapter`.

Fixed by switching `openBeneath` to `golang.org/x/sys/unix`, which exposes `Openat` on both platforms with identical semantics.

**`os.Root` (Go 1.24+) was considered and rejected.** It confines correctly, but it *silently ignores* `O_NOFOLLOW` — it would follow a symlink planted inside the file store and quietly relax the exact guarantee `openBeneath` exists to provide. The file's original comment avoided `x/sys` to keep `go.mod` dependency-free; that isn't worth a weakened security primitive.

Semantics verified unchanged on darwin/arm64 — an in-root symlink at any component still fails `ELOOP` under `O_NOFOLLOW` (`TestOpenBeneathRefusesSymlinkComponents`, `TestReadConfinedFileRejectsSymlink`).

## 2. Three tests that could never run on macOS

With the package compiling for the first time on darwin:

```
--- FAIL: TestReadConfinedFileStillReadsAndStillConfines
--- FAIL: TestReadConfinedFileReadsRealFile
--- FAIL: TestReadConfinedFileRejectsSymlink
    readConfinedFile: path "/var/folders/.../real.txt"
    is outside root "/private/var/folders/.../001"
```

This is a **test-harness artifact, not a confinement defect.** `confineFileUploadPath` `EvalSymlinks`-resolves the *root* but only `Abs`+`Clean`s the *path*, because its documented contract is that callers pass an already-resolved path — which the production call site honours. The tests passed a raw `t.TempDir()`.

On Linux that is invisible: `TMPDIR` has no symlinked component, so both forms are identical. On macOS `TMPDIR` lives under `/var`, which **is** a symlink to `private/var` — so the root canonicalized to `/private/var/...` while the path stayed `/var/...`, `filepath.Rel` returned a `../..` escape, and the confinement check correctly rejected its own fixture.

Added a `tempDirResolved` helper that resolves the temp dir (matching what production guarantees) and pointed those three tests at it. **No production behaviour changes** — the only non-test edits are `confined_open.go`, `go.mod`, `go.sum`.

## Verification

On darwin/arm64, go1.26.2:

- `go build ./...` — clean (fails on `main` with the error above)
- `go vet ./...` — clean
- `go test ./...` — **ok**, full suite

Happy to split the test fix into its own commit if you'd prefer to review them separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
