### PR TITLE
fix(gastown): fetch refinery branch explicitly

### DIFF
--- a/gastown/agents/refinery/prompt.template.md
+++ b/gastown/agents/refinery/prompt.template.md
@@ -316,7 +316,7 @@ alert the witness, not `gc mail send`.
 | Read work metadata | `gc bd show $WORK --json \| jq '.[0].metadata'` |
 | Set metadata field | `gc bd update $WORK --set-metadata key=value` |
 | Remove metadata field | `gc bd update $WORK --unset-metadata key` |
-| Fetch remote branches | `git fetch --prune origin` |
+| Fetch metadata branch and target | `git fetch origin "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}" "+refs/heads/${TARGET}:refs/remotes/origin/${TARGET}"` |
 | Rebase on target | `git rebase origin/$TARGET` |
 | Fast-forward merge | `git merge --ff-only temp` |
 | Push merged changes | `git push origin $TARGET` |

--- a/gastown/formulas/mol-refinery-patrol.toml
+++ b/gastown/formulas/mol-refinery-patrol.toml
@@ -212,12 +212,37 @@ BRANCH=$(gc bd show $WORK --json | jq -r '.[0].metadata.branch')
 TARGET=$(gc bd show $WORK --json | jq -r '.[0].metadata.target // "{{target_branch}}"')
 ```
 
-Fetch and attempt mechanical rebase:
+Fetch the exact metadata branch and target ref. Do not rely on
+`remote.origin.fetch`: refinery clones may deliberately track only the target
+branch, so the configured refspec can leave a newly-pushed polecat branch
+invisible locally even though it exists on the remote.
 ```bash
-git fetch --prune origin
-git checkout -b temp origin/$BRANCH
-git rebase origin/$TARGET
+if ! git fetch origin "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}" "+refs/heads/${TARGET}:refs/remotes/origin/${TARGET}"; then
+  echo "Could not fetch metadata.branch=$BRANCH or target=$TARGET from origin. STOP. Do not mutate bead state."
+  gc runtime drain-ack
+  exit 1
+fi
+if ! git checkout -B temp "origin/$BRANCH"; then
+  echo "Could not check out fetched metadata.branch=$BRANCH. STOP. Do not mutate bead state."
+  gc runtime drain-ack
+  exit 1
+fi
+git rebase "origin/$TARGET"
+REBASE_STATUS=$?
+if [ "$REBASE_STATUS" -ne 0 ] && [ -z "$(git diff --name-only --diff-filter=U)" ]; then
+  git rebase --abort >/dev/null 2>&1 || true
+  echo "Rebase failed with status $REBASE_STATUS but produced no unmerged paths. STOP. Do not mutate bead state."
+  gc runtime drain-ack
+  exit 1
+fi
+if [ "$REBASE_STATUS" -ne 0 ]; then
+  exit "$REBASE_STATUS"
+fi
 ```
+
+Only a nonzero rebase with actual unmerged paths is a conflict. Fetch,
+checkout, and non-conflict rebase failures stop above without reopening,
+rejecting, or otherwise mutating the work bead.
 
 If rebase SUCCEEDED (exit 0): close this step, proceed to run-tests.
 

--- a/gastown/tests/test_gastown_pack_assets.sh
+++ b/gastown/tests/test_gastown_pack_assets.sh
@@ -216,6 +216,36 @@ if verify >= metadata:
 PY
 }
 
+test_refinery_rebase_fetches_metadata_branch_explicitly() {
+    local formula prompt rebase_block
+    formula="$GASTOWN/formulas/mol-refinery-patrol.toml"
+    prompt="$GASTOWN/agents/refinery/prompt.template.md"
+
+    rebase_block=$(python3 - "$formula" <<'PY'
+import sys
+text = open(sys.argv[1], encoding="utf-8").read()
+start = text.index('id = "rebase"')
+end = text.index('id = "run-tests"')
+print(text[start:end])
+PY
+)
+
+    [[ "$rebase_block" == *'+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}'* ]] ||
+        fail "refinery rebase must fetch metadata.branch independently of remote.origin.fetch"
+    [[ "$rebase_block" == *'+refs/heads/${TARGET}:refs/remotes/origin/${TARGET}'* ]] ||
+        fail "refinery rebase must fetch target independently of remote.origin.fetch"
+    [[ "$rebase_block" == *'STOP. Do not mutate bead state.'* ]] ||
+        fail "refinery rebase fetch failure must leave the work bead untouched"
+    [[ "$rebase_block" == *'git diff --name-only --diff-filter=U'* ]] ||
+        fail "refinery must reject only when rebase produced actual unmerged paths"
+    [[ "$rebase_block" == *'exit "$REBASE_STATUS"'* ]] ||
+        fail "refinery must preserve nonzero rebase status for conflict rejection flow"
+    [[ "$rebase_block" != *'git fetch --prune origin'* ]] ||
+        fail "refinery rebase must not rely on the clone's configured fetch refspec"
+    grep -F 'Fetch metadata branch and target' "$prompt" >/dev/null ||
+        fail "refinery prompt cheatsheet must teach explicit metadata-branch fetches"
+}
+
 test_dog_assets_are_pack_local
 test_retired_dog_formulas_are_not_reintroduced
 test_shutdown_dance_contracts_are_executable
@@ -224,5 +254,6 @@ test_composition_is_documented
 test_polecat_startup_uses_standard_hook_claim
 test_review_leg_contract_forbids_synthetic_mutation
 test_refinery_direct_merge_is_worktree_safe_and_fail_closed
+test_refinery_rebase_fetches_metadata_branch_explicitly
 
 echo "gastown pack asset tests passed"


### PR DESCRIPTION
## Summary
- fetch `metadata.branch` and target with explicit refspecs so main-only clones see newly pushed polecat branches
- fail closed on fetch, checkout, and non-conflict rebase failures
- preserve nonzero rebase status for the existing conflict rejection path

## Verification
- `bash gastown/tests/test_gastown_pack_assets.sh`
- `go test ./...`
- TOML parse with Python `tomllib`
- live qcore clone with main-only `remote.origin.fetch`: explicit polecat ref fetch resolved `polecat/qc-fe5ht` to the remote SHA

Tracks ga-1x31y.