### PR TITLE
fix(gastown): fail the polecat push gate closed when a no-push rail has no auto_push

### DIFF
--- a/gastown/agents/mayor/prompt.template.md
+++ b/gastown/agents/mayor/prompt.template.md
@@ -141,6 +141,26 @@ coordination with no owning repository belongs at city scope.
 
 **Rule**: Think "X needs Y", not "X comes before Y". Verify with `gc bd blocked`.
 
+**A rail expressed only in prose is enforced by nothing.** If you write "no
+push", "HALT branch-ready", or "the mayor publishes" into a bead, record the
+decision as metadata in the SAME write. Prose is read by an agent exercising
+judgement; the push gate is a shell test on `metadata.auto_push`.
+
+- WRONG: description says "branch + HALT branch-ready, mayor publishes" — and nothing else
+- RIGHT: that description, plus `gc bd update <id> --set-metadata auto_push=false`
+
+`mol-polecat-work` fails closed on the mismatch — a bead whose prose asserts a
+no-push rail with no `auto_push` key halts at branch-ready and escalates rather
+than pushing. That is a backstop, not a substitute: it costs a round trip and a
+human read every time, and it can only see DESCRIPTION and NOTES, so a rail
+that lives in a comment is invisible to it.
+
+**Rule**: if a rail changes what the polecat DOES, it belongs in metadata. Use
+`--set-metadata` (never bare `--metadata`) so `branch` and `gc.routed_to`
+survive the write. Reading it back, prefer
+`if has("auto_push") then .auto_push else "absent" end` over `.auto_push // "-"`
+— the `//` idiom treats the legitimate value `false` as absent.
+
 ## Responsibilities
 
 - **Work dispatch**: Assign work to polecats for issues, coordinate batch work on epics

--- a/gastown/agents/mayor/prompt.template.md
+++ b/gastown/agents/mayor/prompt.template.md
@@ -149,17 +149,63 @@ judgement; the push gate is a shell test on `metadata.auto_push`.
 - WRONG: description says "branch + HALT branch-ready, mayor publishes" — and nothing else
 - RIGHT: that description, plus `gc bd update <id> --set-metadata auto_push=false`
 
+The vocabulary is closed and case-folded: `false`/`no`/`0` halt, `true`/`yes`/`1`
+push. Anything else is not read as consent — it halts and escalates, the same as
+metadata the gate cannot decode. A `null` value is the exception, because it is
+JSON's own spelling of "nothing recorded": it is treated as an ABSENT key, not as
+a halt, so it falls through to the prose scan and a rail-less bead still pushes.
+Record one of the six words; do not record `null` expecting a halt.
+
 `mol-polecat-work` fails closed on the mismatch — a bead whose prose asserts a
 no-push rail with no `auto_push` key halts at branch-ready and escalates rather
 than pushing. That is a backstop, not a substitute: it costs a round trip and a
-human read every time, and it can only see DESCRIPTION and NOTES, so a rail
-that lives in a comment is invisible to it.
+human read every time, it can only see DESCRIPTION and NOTES, so a rail that
+lives in a comment is invisible to it, and it only covers the polecat's own
+submit-and-exit. A polecat that DIES mid-work is recovered by the witness's
+orphan salvage, which pushes the branch without consulting `auto_push` or the
+prose at all — so on a bead that must not reach the remote, the metadata is the
+record that survives the crash, and even it is not enforced on that path.
 
 **Rule**: if a rail changes what the polecat DOES, it belongs in metadata. Use
 `--set-metadata` (never bare `--metadata`) so `branch` and `gc.routed_to`
-survive the write. Reading it back, prefer
-`if has("auto_push") then .auto_push else "absent" end` over `.auto_push // "-"`
-— the `//` idiom treats the legitimate value `false` as absent.
+survive the write. Read it back with the shape NORMALISED before the key test:
+
+```bash
+WORK_JSON=$(gc bd show <id> --json)
+if [ -z "$WORK_JSON" ]; then
+  echo "unreadable"   # the ledger read failed; retry. NOT the same as "absent".
+else
+  printf '%s' "$WORK_JSON" | jq -r '
+    if (type != "array") or (length == 0) or ((.[0] | type) != "object")
+    then "unreadable"
+    else (.[0].metadata
+          | if type == "string" then (fromjson? // "unreadable")
+            elif type == "null" then {}
+            else . end)
+         | if type != "object" then "unreadable"
+           elif has("auto_push")
+           then (if .auto_push == null then "absent" else (.auto_push | tostring) end)
+           else "absent" end
+    end'
+fi
+```
+
+`.auto_push // "-"` reports the legitimate value `false` as absent, and a bare
+`has("auto_push")` ERRORS on a `metadata` payload served as a JSON string — jq
+exits 5 printing nothing, so the read shows up as "no key" on the beads most
+worth checking. That is the same shape trap `mol-polecat-work`'s own probe
+normalises; the three answers above are its three outcomes.
+
+The guards around the jq are the rest of that mirror, and they exist because a
+FAILED READ must not be reportable as a settled answer. `jq` prints nothing and
+exits 0 on empty input, so an unguarded pipe answers a dead ledger with silence —
+indistinguishable from "the write did not land", which invites a re-write of a
+bead whose state you never actually read. `[]` is the same trap one level in: a
+payload with no bead record is not a bead without metadata. The gate halts on
+both (`[ -z "$WORK_JSON" ]` and `error("no bead record in the payload")` →
+`metadata_unreadable`), so this reads them the same way. A `null` VALUE is the
+one case that is not an error: it maps to `absent`, matching the gate, rather
+than printing the bare word `null` for you to misread as a recorded decision.
 
 ## Responsibilities
 

--- a/gastown/agents/polecat/prompt.template.md
+++ b/gastown/agents/polecat/prompt.template.md
@@ -425,8 +425,10 @@ fi
 # in_progress bead with an unpushed branch is the worse outcome.
 ```
 
-The `auto_push=false` opt-out (mol-pr-from-issue's halt-at-branch-ready) is
-handled inside submit-and-exit; the "No Idle Polecats" fragment above covers it.
+The push gate lives inside submit-and-exit; the "No Idle Polecats" fragment
+above covers it. It fails closed: `auto_push=false` halts at branch-ready, and
+an ABSENT `auto_push` on a bead whose prose asserts a no-push rail also halts —
+and escalates — rather than pushing on a guess. Absent metadata is not consent.
 
 Your work is not complete until submit-and-exit runs. `gc runtime drain-ack`
 signals the reconciler to kill this session — it will only restart you if the

--- a/gastown/agents/polecat/prompt.template.md
+++ b/gastown/agents/polecat/prompt.template.md
@@ -426,9 +426,13 @@ fi
 ```
 
 The push gate lives inside submit-and-exit; the "No Idle Polecats" fragment
-above covers it. It fails closed: `auto_push=false` halts at branch-ready, and
-an ABSENT `auto_push` on a bead whose prose asserts a no-push rail also halts —
-and escalates — rather than pushing on a guess. Absent metadata is not consent.
+above covers it. It fails closed: `auto_push=false` (or `no`/`0`, any case)
+halts at branch-ready, an ABSENT `auto_push` on a bead whose prose asserts a
+no-push rail also halts — and escalates — rather than pushing on a guess, and
+metadata the gate cannot READ, or an `auto_push` value outside the vocabulary,
+halts too (`halt_reason=metadata_unreadable`), since a decision that will not
+decode cannot be shown to lack the opt-out. Absent metadata is not consent, and
+unreadable metadata is not absent metadata.
 
 Your work is not complete until submit-and-exit runs. `gc runtime drain-ack`
 signals the reconciler to kill this session — it will only restart you if the

--- a/gastown/formulas/mol-polecat-work.toml
+++ b/gastown/formulas/mol-polecat-work.toml
@@ -366,10 +366,20 @@ because an absent key yielded the empty string and the empty string is not
 `"false"`. Two of the affected rigs are customer repos, and an unintended push
 to a customer repo has already caused an unintended prod deploy once. So the
 gate reads the bead's prose as well as its metadata, and halts rather than
-guess. Four outcomes, evaluated in order:
+guess.
+
+The metadata itself is read through a shape-normalising probe, because the one
+thing worse than an unenforced rail is a *recorded* rail the gate silently
+fails to read: `jq`'s `has()` errors on a string, so on a ledger that serves
+`metadata` as a JSON string the explicit `auto_push=false` opt-out used to
+evaluate to the empty string and the bead was pushed (gci-to0l). Object, null
+and JSON-string payloads are all read; anything else halts.
+
+Five outcomes, evaluated in order:
 
 | `auto_push` | Bead prose | Outcome |
 |---|---|---|
+| metadata unreadable | not read | halt at branch-ready **and escalate** — a payload that cannot be read cannot be shown to lack the opt-out |
 | `false` | not read | halt at branch-ready — the explicit opt-out |
 | absent | asserts a no-push rail | halt at branch-ready **and escalate** — ambiguous, a human owns the call |
 | absent | no rail | push + refinery handoff — the normal path |
@@ -377,8 +387,92 @@ guess. Four outcomes, evaluated in order:
 
 ```bash
 WORK_JSON=$(gc bd show "$WORK_BEAD_ID" --json)
-AUTO_PUSH=$(printf '%s' "$WORK_JSON" | jq -r '(.[0].metadata // {}) | if has("auto_push") then (.auto_push | tostring) else "" end')
 BRANCH=$(git branch --show-current)
+
+# The metadata probe — NORMALISED, and fail CLOSED on a payload it cannot read.
+#
+# jq's has() ERRORS on a string, printing nothing to stdout, so the old probe
+# turned a string-shaped metadata payload into "" — and "" is not "false", so
+# outcome (a), the EXPLICIT opt-out, silently stopped firing and control
+# reached git push. A fail-OPEN on the one outcome nobody expects to be
+# conditional, and it inverted the incentive the whole no-push-rail arc has
+# been pushing: a bead that recorded its rail properly AS METADATA, and said
+# nothing in prose, is exactly the bead with no prose for (b) to match on.
+# Reproduced against this gate's own shipped text, 2026-09-05: explicit
+# auto_push=false + string-shaped metadata -> PUSH.
+#
+# MEASURED 2026-09-05 across all 7 active ledgers (control, sb, sb-app,
+# gas-city, flinders, arnotts, detmold) through this gate's own probe shape
+# (gc bd show <id> --json | jq of .[0].metadata | type): every one serves an
+# OBJECT when metadata is present and NULL when it is absent. No ledger serves
+# a string today, so this is a latent trap rather than a live hole — but
+# instruments/no-push-rail-detector.sh records that the shape varies by rig
+# (its META_JQ normalises object / string / null for the same reason), so the
+# normalisation is lifted here now rather than on the day it bites.
+#
+#   object -> read it.
+#   null   -> the bead carries no metadata. A legitimate live shape on every
+#             rig and the MAJORITY of beads (308 of the 410 open/in_progress
+#             beads across the six queryable ledgers), so it must fall through
+#             to (b) and never halt.
+#   string -> a JSON-encoded object. Parse it, then read it.
+#   anything else, a string that does not parse to an object, or a probe that
+#             fails outright -> UNREADABLE, handled at (a0) below. Note this is
+#             the OPPOSITE default to the (b) prose scan's empty INPUT case:
+#             there, nothing said is a legitimate "no rail"; here, nothing read
+#             is a failure to retrieve a decision that may well exist.
+AUTO_PUSH=""
+META_UNREADABLE=""
+if [ -z "$WORK_JSON" ]; then
+  META_UNREADABLE=1
+elif ! AUTO_PUSH=$(printf '%s' "$WORK_JSON" | jq -r '
+      if (type != "array") or (length == 0) or ((.[0] | type) != "object")
+      then error("no bead record in the payload")
+      else (.[0].metadata
+            | if   type == "object" then .
+              elif type == "null"   then {}
+              elif type == "string" then (fromjson? // "unparseable")
+              else "not-an-object" end)
+           | if type != "object" then error("metadata is not an object")
+             elif has("auto_push") then (.auto_push | tostring)
+             else "" end
+      end' 2>/dev/null); then
+  META_UNREADABLE=1
+fi
+
+# (a0) The payload could not be read. Absent metadata is not consent, and
+# UNREADABLE metadata is not absent metadata — it is a bead whose recorded
+# decision the gate failed to retrieve. Reading the prose instead would be
+# guessing, so halt and hand it to a human.
+if [ -n "$META_UNREADABLE" ]; then
+  echo "metadata unreadable: halting at branch-ready (fail closed) and escalating."
+  # --append-notes, NEVER --notes — same rule as the other two halts (gci-3f5u).
+  gc bd update "$WORK_BEAD_ID" \
+    --status=open --assignee="" \
+    --set-metadata branch="$BRANCH" \
+    --set-metadata target={{base_branch}} \
+    --set-metadata branch_ready=true \
+    --set-metadata halt_reason=metadata_unreadable \
+    --set-metadata gc.routed_to="" \
+    --append-notes "Branch ready: the push gate could not read this bead's metadata — the ledger read returned no bead record, or served metadata in a shape the probe cannot decode. An unreadable payload cannot be shown to lack auto_push=false, so the gate halted instead of pushing. Re-read the bead, record the push decision explicitly, then re-sling."
+  gc mail send "${GC_RIG:+$GC_RIG/}{{binding_prefix}}witness" \
+    -s "HELP: push-gate metadata unreadable on $WORK_BEAD_ID [HIGH]" \
+    -m "Halted at branch-ready instead of pushing.
+
+Bead:   $WORK_BEAD_ID
+Branch: $BRANCH (local only — NOT pushed)
+Reason: the ledger read returned no readable bead record, or served the
+        metadata in a shape the gate cannot decode (expected an object, a
+        JSON string, or null). The gate cannot tell 'halt' from 'go', so it
+        halted.
+
+Resolve: check the ledger is healthy, then record the decision as metadata —
+  gc bd update $WORK_BEAD_ID --set-metadata auto_push=false   # confirm the halt
+  gc bd update $WORK_BEAD_ID --set-metadata auto_push=true    # authorise the push
+and re-sling. Use --set-metadata so branch and gc.routed_to survive."
+  gc runtime drain-ack
+  exit 0
+fi
 
 # (a) Explicit opt-out. Never read the prose — the metadata already decided.
 if [ "$AUTO_PUSH" = "false" ]; then

--- a/gastown/formulas/mol-polecat-work.toml
+++ b/gastown/formulas/mol-polecat-work.toml
@@ -357,12 +357,32 @@ BODY
 This is a belt-and-suspenders check — self-review should have caught this,
 but we never push with untracked work left behind.
 
-**3. Push your branch:**
+**3. Push gate — FAIL CLOSED, then push:**
+
+Absent metadata is not consent. A rail expressed only in prose is enforced by
+nothing: a bead whose DESCRIPTION says "no push — the mayor publishes" but
+which carries no `auto_push` key used to fall straight through to `git push`,
+because an absent key yielded the empty string and the empty string is not
+`"false"`. Two of the affected rigs are customer repos, and an unintended push
+to a customer repo has already caused an unintended prod deploy once. So the
+gate reads the bead's prose as well as its metadata, and halts rather than
+guess. Four outcomes, evaluated in order:
+
+| `auto_push` | Bead prose | Outcome |
+|---|---|---|
+| `false` | not read | halt at branch-ready — the explicit opt-out |
+| absent | asserts a no-push rail | halt at branch-ready **and escalate** — ambiguous, a human owns the call |
+| absent | no rail | push + refinery handoff — the normal path |
+| any other value | not read | push + refinery handoff — explicit consent |
+
 ```bash
-AUTO_PUSH=$(gc bd show "$WORK_BEAD_ID" --json | jq -r '.[0].metadata | if has("auto_push") then (.auto_push | tostring) else "" end')
+WORK_JSON=$(gc bd show "$WORK_BEAD_ID" --json)
+AUTO_PUSH=$(printf '%s' "$WORK_JSON" | jq -r '(.[0].metadata // {}) | if has("auto_push") then (.auto_push | tostring) else "" end')
+BRANCH=$(git branch --show-current)
+
+# (a) Explicit opt-out. Never read the prose — the metadata already decided.
 if [ "$AUTO_PUSH" = "false" ]; then
   echo "auto_push=false: halting at branch-ready (no push, no refinery handoff)"
-  BRANCH=$(git branch --show-current)
   gc bd update "$WORK_BEAD_ID" \
     --status=open --assignee="" \
     --set-metadata branch="$BRANCH" \
@@ -374,6 +394,52 @@ if [ "$AUTO_PUSH" = "false" ]; then
   gc runtime drain-ack
   exit 0
 fi
+
+# (b) No decision recorded. Scan DESCRIPTION + NOTES for a no-push rail.
+# Lines about pushing *to main* are a DIFFERENT rail — one every polecat
+# already obeys, since it pushes a feature branch and never main — so they are
+# dropped before matching. Without that filter every bead quoting the standing
+# "polecats do not push to main" rule would halt, and a gate that cries wolf
+# gets routed around. Comments are deliberately out of scope: they are
+# discussion, not standing instructions, and they self-match on any bead that
+# merely talks about no-push rails.
+if [ -z "$AUTO_PUSH" ]; then
+  RAIL_HIT=$(printf '%s' "$WORK_JSON" \
+    | jq -r '(.[0].description // ""), (.[0].notes // "")' \
+    | grep -Eiv 'push(ing|es)?[[:space:]]+(directly[[:space:]]+)?to[[:space:]]+(main|master|trunk|origin)' \
+    | grep -Eic 'no[- ]push([^e]|$)|do not push|don.t push|never push([^e]|$)|(mayor|operator|human) publishes|halt[- ]*(at[- ]+)?branch[- ]ready|branch[- ]ready[- ]+halt|auto_push[[:space:]]*=[[:space:]]*false')
+  # ${RAIL_HIT:-1} — grep -c always prints a count when it runs, so an EMPTY
+  # result means the scan itself broke. Fail closed on that too: an
+  # undetermined rail is treated as an asserted one.
+  if [ "${RAIL_HIT:-1}" -gt 0 ]; then
+    echo "NO-PUSH RAIL IN PROSE + auto_push ABSENT — halting at branch-ready (fail closed) and escalating."
+    gc bd update "$WORK_BEAD_ID" \
+      --status=open --assignee="" \
+      --set-metadata branch="$BRANCH" \
+      --set-metadata target={{base_branch}} \
+      --set-metadata branch_ready=true \
+      --set-metadata halt_reason=no_push_rail_unresolved \
+      --set-metadata gc.routed_to="" \
+      --notes "Branch ready: DESCRIPTION/NOTES assert a no-push rail but the bead carries no auto_push metadata, so the rail is unenforceable. Halted instead of guessing. Whoever owns the rail: set auto_push=false to confirm the halt, or auto_push=true to authorise the push, then re-sling."
+    gc mail send "${GC_RIG:+$GC_RIG/}{{binding_prefix}}witness" \
+      -s "HELP: no-push rail unresolved on $WORK_BEAD_ID [HIGH]" \
+      -m "Halted at branch-ready instead of pushing.
+
+Bead:   $WORK_BEAD_ID
+Branch: $BRANCH (local only — NOT pushed)
+Reason: DESCRIPTION/NOTES assert a no-push rail, but metadata.auto_push is
+        absent. The push gate cannot tell 'halt' from 'go', so it halted.
+
+Resolve: read the rail, then record the decision as metadata —
+  gc bd update $WORK_BEAD_ID --set-metadata auto_push=false   # confirm the halt
+  gc bd update $WORK_BEAD_ID --set-metadata auto_push=true    # authorise the push
+and re-sling. Use --set-metadata so branch and gc.routed_to survive."
+    gc runtime drain-ack
+    exit 0
+  fi
+fi
+
+# (c) Normal path.
 git push origin HEAD
 PUSH_EXIT=$?
 if [ $PUSH_EXIT -ne 0 ]; then

--- a/gastown/formulas/mol-polecat-work.toml
+++ b/gastown/formulas/mol-polecat-work.toml
@@ -383,6 +383,8 @@ BRANCH=$(git branch --show-current)
 # (a) Explicit opt-out. Never read the prose — the metadata already decided.
 if [ "$AUTO_PUSH" = "false" ]; then
   echo "auto_push=false: halting at branch-ready (no push, no refinery handoff)"
+  # --append-notes, NEVER --notes. --notes REPLACES the entire notes field, so a
+  # halt note written with it destroys whatever the requester left on the bead.
   gc bd update "$WORK_BEAD_ID" \
     --status=open --assignee="" \
     --set-metadata branch="$BRANCH" \
@@ -390,7 +392,7 @@ if [ "$AUTO_PUSH" = "false" ]; then
     --set-metadata branch_ready=true \
     --set-metadata halt_reason=auto_push_false \
     --set-metadata gc.routed_to="" \
-    --notes "Branch ready: auto_push=false (no push, no refinery handoff)"
+    --append-notes "Branch ready: auto_push=false (no push, no refinery handoff)"
   gc runtime drain-ack
   exit 0
 fi
@@ -413,6 +415,9 @@ if [ -z "$AUTO_PUSH" ]; then
   # undetermined rail is treated as an asserted one.
   if [ "${RAIL_HIT:-1}" -gt 0 ]; then
     echo "NO-PUSH RAIL IN PROSE + auto_push ABSENT — halting at branch-ready (fail closed) and escalating."
+    # --append-notes, NEVER --notes. This halt cites a rail that is frequently
+    # written in the very notes a bare --notes would replace, so replacing them
+    # would delete the evidence the halt note tells the reader to go and read.
     gc bd update "$WORK_BEAD_ID" \
       --status=open --assignee="" \
       --set-metadata branch="$BRANCH" \
@@ -420,7 +425,7 @@ if [ -z "$AUTO_PUSH" ]; then
       --set-metadata branch_ready=true \
       --set-metadata halt_reason=no_push_rail_unresolved \
       --set-metadata gc.routed_to="" \
-      --notes "Branch ready: DESCRIPTION/NOTES assert a no-push rail but the bead carries no auto_push metadata, so the rail is unenforceable. Halted instead of guessing. Whoever owns the rail: set auto_push=false to confirm the halt, or auto_push=true to authorise the push, then re-sling."
+      --append-notes "Branch ready: DESCRIPTION/NOTES assert a no-push rail but the bead carries no auto_push metadata, so the rail is unenforceable. Halted instead of guessing. Whoever owns the rail: set auto_push=false to confirm the halt, or auto_push=true to authorise the push, then re-sling."
     gc mail send "${GC_RIG:+$GC_RIG/}{{binding_prefix}}witness" \
       -s "HELP: no-push rail unresolved on $WORK_BEAD_ID [HIGH]" \
       -m "Halted at branch-ready instead of pushing.
@@ -480,15 +485,33 @@ git branch -D "$BRANCH"              # Branch is pushed; refinery owns it now
 
 **5. Update metadata on the work bead:**
 ```bash
+# --append-notes, NEVER --notes — see the note under this block.
 gc bd update "$WORK_BEAD_ID" \
   --set-metadata target={{base_branch}} \
-  --notes "Implemented: <brief summary>"
+  --append-notes "Implemented: <brief summary>"
 ```
 Branch was recorded in workspace-setup and is already in metadata.
 This adds the target for the refinery. If an existing pull request was
 provided by the caller, `metadata.existing_pr` is preserved for refinery
 validation. The refinery records canonical `pr_url` only after verifying
 the PR is open and matches the branch, base, and origin repository.
+
+**Every `gc bd update` call in this step uses `--append-notes`. Never use
+`--notes`.** The two flags do not differ in emphasis: `--notes` REPLACES the
+whole notes field, `--append-notes` appends to it with a newline separator. The
+bead you are finishing is not yours — it carries the requester's instructions,
+and on a rig it may carry an operator's hold or a prior polecat's handover. A
+closing note written with `--notes` deletes all of it, in one call, with no
+warning and no diff. That is bead-history destruction by the normal happy path,
+which is why it went unnoticed twice.
+
+The rule binds the two halt writes in item 3 hardest, not least. Both of them
+tell the reader to go and act on what the bead says — the ambiguity halt asks
+whoever owns the rail to resolve a rail that is, in the usual case, written in
+the very notes a bare `--notes` would have just deleted. The identity-stamped
+bead record is also the city's anchor against nudge-text spoofing, so a rail
+that silently erases it is a P1, not a formatting nit. The same rule holds
+anywhere a formula writes a note onto a bead it did not create: append.
 
 **6. Reassign to refinery:**
 ```bash

--- a/gastown/formulas/mol-polecat-work.toml
+++ b/gastown/formulas/mol-polecat-work.toml
@@ -375,15 +375,22 @@ fails to read: `jq`'s `has()` errors on a string, so on a ledger that serves
 evaluate to the empty string and the bead was pushed (gci-to0l). Object, null
 and JSON-string payloads are all read; anything else halts.
 
+The `auto_push` VOCABULARY is closed and case-folded: `false`/`no`/`0` are the
+opt-out, `true`/`yes`/`1` are consent, a key present with a JSON `null` value is
+"nothing recorded". Anything else is an unreadable decision, not consent — the
+key is hand-written by humans following the mayor prompt, and reading `False`
+or `no` as "push" would fail open on exactly the beads that tried hardest to
+say no.
+
 Five outcomes, evaluated in order:
 
 | `auto_push` | Bead prose | Outcome |
 |---|---|---|
-| metadata unreadable | not read | halt at branch-ready **and escalate** — a payload that cannot be read cannot be shown to lack the opt-out |
-| `false` | not read | halt at branch-ready — the explicit opt-out |
-| absent | asserts a no-push rail | halt at branch-ready **and escalate** — ambiguous, a human owns the call |
-| absent | no rail | push + refinery handoff — the normal path |
-| any other value | not read | push + refinery handoff — explicit consent |
+| unreadable payload, or a value outside the vocabulary | not read | halt at branch-ready **and escalate** — a decision that cannot be read or understood cannot be shown to lack the opt-out |
+| `false`, `no`, `0` (any case) | not read | halt at branch-ready — the explicit opt-out |
+| absent, or present with a null value | asserts a no-push rail | halt at branch-ready **and escalate** — ambiguous, a human owns the call |
+| absent, or present with a null value | no rail | push + refinery handoff — the normal path |
+| `true`, `yes`, `1` (any case) | not read | push + refinery handoff — explicit consent |
 
 ```bash
 WORK_JSON=$(gc bd show "$WORK_BEAD_ID" --json)
@@ -405,10 +412,12 @@ BRANCH=$(git branch --show-current)
 # gas-city, flinders, arnotts, detmold) through this gate's own probe shape
 # (gc bd show <id> --json | jq of .[0].metadata | type): every one serves an
 # OBJECT when metadata is present and NULL when it is absent. No ledger serves
-# a string today, so this is a latent trap rather than a live hole — but
-# instruments/no-push-rail-detector.sh records that the shape varies by rig
-# (its META_JQ normalises object / string / null for the same reason), so the
-# normalisation is lifted here now rather than on the day it bites.
+# a string today, so this is a latent trap rather than a live hole — but the
+# shape is not a guarantee this gate owns: metadata is whatever the ledger
+# binding serialises, it varied by rig when the detector this arc grew out of
+# was written (that detector normalises object / string / null for exactly this
+# reason), and nothing pins it. The normalisation is lifted here now rather
+# than on the day it bites.
 #
 #   object -> read it.
 #   null   -> the bead carries no metadata. A legitimate live shape on every
@@ -416,8 +425,12 @@ BRANCH=$(git branch --show-current)
 #             beads across the six queryable ledgers), so it must fall through
 #             to (b) and never halt.
 #   string -> a JSON-encoded object. Parse it, then read it.
-#   anything else, a string that does not parse to an object, or a probe that
-#             fails outright -> UNREADABLE, handled at (a0) below. Note this is
+#   anything else, a string that does not parse to an object, an auto_push
+#             value outside the closed vocabulary, or a probe that fails
+#             outright -> UNREADABLE, handled at (a0) below. The vocabulary is
+#             closed on purpose: the key is hand-written by humans, and reading
+#             `False` or `no` as "any other value -> explicit consent" fails
+#             open on the beads that tried hardest to say no. Note this is
 #             the OPPOSITE default to the (b) prose scan's empty INPUT case:
 #             there, nothing said is a legitimate "no rail"; here, nothing read
 #             is a failure to retrieve a decision that may well exist.
@@ -434,7 +447,12 @@ elif ! AUTO_PUSH=$(printf '%s' "$WORK_JSON" | jq -r '
               elif type == "string" then (fromjson? // "unparseable")
               else "not-an-object" end)
            | if type != "object" then error("metadata is not an object")
-             elif has("auto_push") then (.auto_push | tostring)
+             elif has("auto_push") then (.auto_push | tostring | ascii_downcase
+                   | if   . == "false" or . == "no"  or . == "0" then "false"
+                     elif . == "true"  or . == "yes" or . == "1" then "true"
+                     elif . == "null" then ""
+                     else error("auto_push value is outside the vocabulary")
+                     end)
              else "" end
       end' 2>/dev/null); then
   META_UNREADABLE=1
@@ -454,17 +472,18 @@ if [ -n "$META_UNREADABLE" ]; then
     --set-metadata branch_ready=true \
     --set-metadata halt_reason=metadata_unreadable \
     --set-metadata gc.routed_to="" \
-    --append-notes "Branch ready: the push gate could not read this bead's metadata — the ledger read returned no bead record, or served metadata in a shape the probe cannot decode. An unreadable payload cannot be shown to lack auto_push=false, so the gate halted instead of pushing. Re-read the bead, record the push decision explicitly, then re-sling."
+    --append-notes "Branch ready: the push gate could not read this bead's push decision — the ledger read returned no bead record, the metadata came in a shape the probe cannot decode, or auto_push carried a value outside the vocabulary (false/no/0 to halt, true/yes/1 to push). A decision that cannot be read cannot be shown to lack auto_push=false, so the gate halted instead of pushing. Re-record the push decision in the vocabulary, then re-sling."
   gc mail send "${GC_RIG:+$GC_RIG/}{{binding_prefix}}witness" \
     -s "HELP: push-gate metadata unreadable on $WORK_BEAD_ID [HIGH]" \
     -m "Halted at branch-ready instead of pushing.
 
 Bead:   $WORK_BEAD_ID
 Branch: $BRANCH (local only — NOT pushed)
-Reason: the ledger read returned no readable bead record, or served the
-        metadata in a shape the gate cannot decode (expected an object, a
-        JSON string, or null). The gate cannot tell 'halt' from 'go', so it
-        halted.
+Reason: the ledger read returned no readable bead record, served the metadata
+        in a shape the gate cannot decode (expected an object, a JSON string,
+        or null), or carried an auto_push value outside the vocabulary
+        (false/no/0 halt, true/yes/1 push, case-folded). The gate cannot tell
+        'halt' from 'go', so it halted.
 
 Resolve: check the ledger is healthy, then record the decision as metadata —
   gc bd update $WORK_BEAD_ID --set-metadata auto_push=false   # confirm the halt
@@ -493,20 +512,77 @@ fi
 
 # (b) No decision recorded. Scan DESCRIPTION + NOTES for a no-push rail.
 # Lines about pushing *to main* are a DIFFERENT rail — one every polecat
-# already obeys, since it pushes a feature branch and never main — so they are
-# dropped before matching. Without that filter every bead quoting the standing
-# "polecats do not push to main" rule would halt, and a gate that cries wolf
-# gets routed around. Comments are deliberately out of scope: they are
-# discussion, not standing instructions, and they self-match on any bead that
-# merely talks about no-push rails.
+# already obeys, since it pushes a feature branch and never main — so the
+# PHRASE that states it is stripped out and the REMAINDER is matched. Without
+# that every bead quoting the standing "polecats do not push to main" rule
+# would halt, and a gate that cries wolf gets routed around.
+#
+# Strip the PHRASE, not the LINE. A line-granular exclusion took any real rail
+# that shared a line with a push-to-main mention down with it, and its target
+# list included bare `origin` — the remote this gate is about to push to — so
+# "do not push to origin" was read as the standing rule. MEASURED 2026-09-08
+# against this gate's own shipped patterns: 7 real rail wordings scored zero
+# hits and the gate PUSHED, among them "never push to origin — the customer
+# tenant is frozen" and "Polecats do not push to main. HALT branch-ready for
+# this bead." Narrowing the destination alone closes only 5 of those 7; the
+# other 2 need the strip, because rail and quote share one line. All 15
+# rail-detection rows keep their verdicts under the strip.
+#
+# The destination must end on a word boundary, or "never push to
+# origin/main-line-customer" loses its rail to the `origin/main` prefix. `/` is
+# in the protected class for the same reason `-` and `_` are: "never push to
+# main/customer" names a branch UNDER main, not main, and no English sentence
+# continues "main/…". `.` cannot join them — "Polecats never push to main. Open
+# a PR." would keep its quote and cry wolf — so the dotted-branch case stays in
+# the residual below. The text is downcased first because the strip has to catch
+# "Do Not Push To Main" and sed's case-insensitive flag is GNU-only; the match
+# grep is already -i, so downcasing upstream costs nothing.
+#
+# KNOWN RESIDUAL, two shapes, both measured 2026-09-09 and both ended by
+# recording the rail as auto_push=false:
+#   1. A rail whose ONLY signal sits inside the stripped phrase still reads as
+#      the standing rule — "never push to main or anywhere else" pushes. So does
+#      the dotted-branch form "never push to main.customer, it is frozen", which
+#      is the same shape: `.` is unprotectable without sentence semantics.
+#      Separating these needs sentence semantics, not a regex, and the cheap cure
+#      (keep the line whenever the strip would remove every signal) halts every
+#      bead that quotes the standing rule, which is the cry-wolf failure this
+#      filter exists to prevent.
+#   2. A NORMATIVE sentence about some other system's pushing — "Establish why
+#      the sync should not push twice" — halts, because the match arms below
+#      cannot tell a requirement about the subject under repair from a rail about
+#      this branch. Over-halting is the recoverable direction (a human records
+#      auto_push and re-slings) where a missed rail is not, so this is left as a
+#      halt rather than narrowed.
+#
+# Comments are deliberately out of scope: they are discussion, not standing
+# instructions, and they self-match on any bead that merely talks about
+# no-push rails.
 if [ -z "$AUTO_PUSH" ]; then
-  RAIL_HIT=$(printf '%s' "$WORK_JSON" \
-    | jq -r '(.[0].description // ""), (.[0].notes // "")' \
-    | grep -Eiv 'push(ing|es)?[[:space:]]+(directly[[:space:]]+)?to[[:space:]]+(main|master|trunk|origin)' \
-    | grep -Eic 'no[- ]push([^e]|$)|do not push|don.t push|never push([^e]|$)|(mayor|operator|human) publishes|halt[- ]*(at[- ]+)?branch[- ]ready|branch[- ]ready[- ]+halt|auto_push[[:space:]]*=[[:space:]]*false')
-  # ${RAIL_HIT:-1} — grep -c always prints a count when it runs, so an EMPTY
-  # result means the scan itself broke. Fail closed on that too: an
-  # undetermined rail is treated as an asserted one.
+  # Extract, downcase and strip in CHECKED stages. grep -c prints a count
+  # whenever it runs, so a failure INSIDE one long pipe arrives at the match
+  # grep as an empty stream and scores 0 — a push. Each stage that can fail is
+  # its own command and any failure sets RAIL_HIT=1: an undetermined rail is
+  # treated as an asserted one. ${RAIL_HIT:-1} then covers the last stage,
+  # where an empty result can only mean grep itself never ran.
+  RAIL_HIT=""
+  if ! PROSE=$(printf '%s' "$WORK_JSON" | jq -r '(.[0].description // ""), (.[0].notes // "")' 2>/dev/null); then
+    RAIL_HIT=1
+  elif ! LOWER=$(printf '%s' "$PROSE" | tr '[:upper:]' '[:lower:]'); then
+    RAIL_HIT=1
+  elif ! SCAN=$(printf '%s' "$LOWER" | sed -E 's#push(ing|es)?[[:space:]]+(directly[[:space:]]+)?to[[:space:]]+(origin/)?(main|master|trunk)([^-[:alnum:]_/]|$)# #g'); then
+    RAIL_HIT=1
+  else
+    # The match arms mirror the vocabulary this gate blesses elsewhere, or the
+    # gate fails open on the prose channel for words it accepts in metadata.
+    # `must not push`/`should not push` carry the same ([^e]|$) guard as
+    # `never push` for consistency, though a modal cannot take the -es/-ed form
+    # that guard exists for, so on those two arms it only catches ungrammatical
+    # prose. The value arm takes the FULL closed vocabulary — `no` and `0` are
+    # the same word as `false` at :450-455, and reading them as consent here
+    # while halting on them there is the mismatch this gate is about.
+    RAIL_HIT=$(printf '%s' "$SCAN" | grep -Eic 'no[- ]push([^e]|$)|do not push|don.t push|never push([^e]|$)|(must|should) not push([^e]|$)|(mayor|operator|human) publishes|halt[- ]*(at[- ]+)?branch[- ]ready|branch[- ]ready[- ]+halt|auto_push[[:space:]]*=[[:space:]]*(false|no|0)')
+  fi
   if [ "${RAIL_HIT:-1}" -gt 0 ]; then
     echo "NO-PUSH RAIL IN PROSE + auto_push ABSENT — halting at branch-ready (fail closed) and escalating."
     # --append-notes, NEVER --notes. This halt cites a rail that is frequently

--- a/gastown/formulas/mol-review-leg.toml
+++ b/gastown/formulas/mol-review-leg.toml
@@ -83,11 +83,15 @@ Use a structured report, not a one-line summary. Preserve the substance of
 your findings in the notes so the coordinator can re-read them after your
 session exits.
 
-Suggested pattern:
+Suggested pattern — `--append-notes`, never bare `--notes`. This bead is a
+convoy member you did not create: it carries the coordinator's assignment, and
+`--notes` REPLACES the whole field, so a report written with it deletes the
+instructions the report is answering (and the previous leg's report, on a
+re-served or multi-leg review).
 ```bash
 CONVOY_STATUS=$(gc convoy status {{convoy_id}} --json)
 WORK_BEAD_ID=$(printf '%s' "$CONVOY_STATUS" | jq -r 'if (.children | length) == 1 then .children[0].id else empty end')
-gc bd update "$WORK_BEAD_ID" --notes "$(cat <<'EOF'
+gc bd update "$WORK_BEAD_ID" --append-notes "$(cat <<'EOF'
 # <report title>
 
 ## Summary

--- a/gastown/template-fragments/approval-fallacy.template.md
+++ b/gastown/template-fragments/approval-fallacy.template.md
@@ -69,9 +69,11 @@ fi
 # in_progress bead with an unpushed branch is the worse outcome.
 ```
 
-The `auto_push=false` opt-out (mol-pr-from-issue's halt-at-branch-ready) is
-handled inside submit-and-exit itself: when set, it halts at branch-ready (no
-push, no refinery handoff); otherwise it pushes and reassigns to the refinery.
+The push gate is handled inside submit-and-exit itself, and it fails closed:
+`auto_push=false` halts at branch-ready (no push, no refinery handoff); an
+ABSENT `auto_push` on a bead whose DESCRIPTION or NOTES assert a no-push rail
+also halts, and escalates, because absent metadata is not consent; anything
+else pushes and reassigns to the refinery.
 
 Polecats do not push to main, close beads, create MR beads, or wait around. If
 work appears already merged, still let submit-and-exit reassign it to the

--- a/gastown/template-fragments/approval-fallacy.template.md
+++ b/gastown/template-fragments/approval-fallacy.template.md
@@ -72,8 +72,13 @@ fi
 The push gate is handled inside submit-and-exit itself, and it fails closed:
 `auto_push=false` halts at branch-ready (no push, no refinery handoff); an
 ABSENT `auto_push` on a bead whose DESCRIPTION or NOTES assert a no-push rail
-also halts, and escalates, because absent metadata is not consent; anything
-else pushes and reassigns to the refinery.
+also halts, and escalates, because absent metadata is not consent; metadata the
+gate cannot decode halts and escalates as well (`metadata_unreadable`), because
+unreadable metadata is not absent metadata — it is a recorded decision the gate
+failed to retrieve — as does an `auto_push` value outside the closed vocabulary
+(`false`/`no`/`0` halt, `true`/`yes`/`1` push, case-folded), because a decision
+the gate cannot understand is not consent either; consent pushes and reassigns
+to the refinery.
 
 Polecats do not push to main, close beads, create MR beads, or wait around. If
 work appears already merged, still let submit-and-exit reassign it to the

--- a/gastown/tests/test_polecat_push_gate.sh
+++ b/gastown/tests/test_polecat_push_gate.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# The mol-polecat-work push gate must FAIL CLOSED.
+#
+# A rail expressed only in prose is enforced by nothing. Before this gate, a
+# bead whose DESCRIPTION said "no push — the mayor publishes" but which carried
+# no auto_push key fell through to `git push`, because an absent key yields ""
+# and "" != "false". These tests pin the three properties that keep that shut:
+#   1. the ambiguity branch exists, and sits BEFORE `git push origin HEAD`;
+#   2. its rail detection fires on the real rail wordings in use, and stays
+#      quiet on prose that merely mentions pushing;
+#   3. the explicit opt-out and the ambiguity halt stay distinguishable by
+#      halt_reason, so a re-sling can tell "operator said no" from "nobody said".
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+FORMULA="$ROOT/gastown/formulas/mol-polecat-work.toml"
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+[[ -f "$FORMULA" ]] || fail "formula not found: $FORMULA"
+
+# --- 1. structure -----------------------------------------------------------
+
+test_gate_structure() {
+    grep -qF 'halt_reason=auto_push_false' "$FORMULA" ||
+        fail "the explicit auto_push=false opt-out halt is gone"
+    grep -qF 'halt_reason=no_push_rail_unresolved' "$FORMULA" ||
+        fail "the fail-closed ambiguity halt is gone"
+    grep -qF 'gc mail send' "$FORMULA" ||
+        fail "the ambiguity halt no longer escalates"
+
+    # The ambiguity halt is worthless if it lands after the push.
+    local ambiguity_line push_line
+    ambiguity_line=$(grep -nF 'halt_reason=no_push_rail_unresolved' "$FORMULA" | head -1 | cut -d: -f1)
+    push_line=$(grep -nF 'git push origin HEAD' "$FORMULA" | head -1 | cut -d: -f1)
+    [[ "$ambiguity_line" -lt "$push_line" ]] ||
+        fail "fail-closed halt (line $ambiguity_line) comes after git push (line $push_line)"
+}
+
+# --- 2. rail detection ------------------------------------------------------
+
+# Lift the shipped filter/match pair straight out of the formula so this test
+# can never drift from the gate it is testing.
+EXCLUDE_RE=$(grep -oE "grep -Eiv '[^']+'" "$FORMULA" | head -1 | sed -E "s/^grep -Eiv '//; s/'\$//")
+MATCH_RE=$(grep -oE "grep -Eic '[^']+'" "$FORMULA" | head -1 | sed -E "s/^grep -Eic '//; s/'\$//")
+
+[[ -n "$EXCLUDE_RE" ]] || fail "could not lift the exclude pattern out of $FORMULA"
+[[ -n "$MATCH_RE" ]] || fail "could not lift the match pattern out of $FORMULA"
+
+rail_hits() {
+    printf '%s\n' "$1" | grep -Eiv "$EXCLUDE_RE" | grep -Eic "$MATCH_RE" || true
+}
+
+assert_rail() {
+    local want="$1" text="$2" got
+    got=$(rail_hits "$text")
+    if [[ "$want" == "halt" ]]; then
+        [[ "$got" -gt 0 ]] || fail "expected a rail hit, got none: $text"
+    else
+        [[ "$got" -eq 0 ]] || fail "expected no rail hit, got $got: $text"
+    fi
+}
+
+test_rail_detection() {
+    # Rails actually in use across the rigs (verbatim shapes, 2026-08-06).
+    assert_rail halt 'HALT branch-ready — the re-run is operator-attended (customer tenant).'
+    assert_rail halt 'ACCEPTANCE: full offline suite green. HALT branch-ready — do NOT deploy.'
+    assert_rail halt 'PLAIN rail: branch + HALT branch-ready, mayor publishes, no push.'
+    assert_rail halt 'Halt at branch-ready; the operator publishes.'
+    assert_rail halt 'branch-ready halt, then hand to the PL.'
+    assert_rail halt 'Do not push this anywhere; the mayor publishes it.'
+    assert_rail halt 'no-push rail applies to this arc.'
+    assert_rail halt 'Rails: auto_push=false, base=main.'
+
+    # The standing "polecats push a branch, never main" rule is a DIFFERENT
+    # rail. Every polecat already obeys it, and half the beads in the city
+    # quote it — matching on it would make the gate cry wolf.
+    assert_rail push 'Polecats do not push to main, close beads, or wait around.'
+    assert_rail push 'Never push directly to main; open a PR.'
+    assert_rail push 'Do not push to origin/main under any circumstances.'
+
+    # Descriptive prose about pushing is not an instruction not to push.
+    # (gci-5bm: "commits locally and never pushes" is a bug report.)
+    assert_rail push 'Establish why mirror-sync commits locally and never pushes.'
+    assert_rail push 'The tag was never pushed, so the release is invisible.'
+    assert_rail push 'Add a retry to the ingest job when the API 429s.'
+    assert_rail push 'Refactor the emissions-factor loader and add tests.'
+}
+
+test_gate_structure
+test_rail_detection
+
+echo "polecat push gate tests passed"

--- a/gastown/tests/test_polecat_push_gate.sh
+++ b/gastown/tests/test_polecat_push_gate.sh
@@ -9,7 +9,10 @@
 #   2. its rail detection fires on the real rail wordings in use, and stays
 #      quiet on prose that merely mentions pushing;
 #   3. the explicit opt-out and the ambiguity halt stay distinguishable by
-#      halt_reason, so a re-sling can tell "operator said no" from "nobody said".
+#      halt_reason, so a re-sling can tell "operator said no" from "nobody said";
+#   4. every note this step writes APPENDS. Both halts hand the bead back to a
+#      human and tell them to go and read what it says, so a halt that replaced
+#      the notes would delete the instructions it is pointing at.
 set -euo pipefail
 
 ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
@@ -90,7 +93,82 @@ test_rail_detection() {
     assert_rail push 'Refactor the emissions-factor loader and add tests.'
 }
 
+# --- 3. the halts must append their notes, never replace them ---------------
+
+# `gc bd update --notes X` REPLACES the whole notes field; `--append-notes X`
+# appends. Both halts below write a note onto a bead they did not create, and
+# both then ask a human to act on what that bead says — the ambiguity halt asks
+# whoever owns the rail to resolve it, and in the usual case the rail is written
+# in the very notes a bare `--notes` would have just deleted. So the gate would
+# destroy the evidence for its own escalation. This was observed twice on a live
+# rig via the auto_push=false halt, destroying a project lead's instruction text
+# (gci-3f5u); it is asserted here so the ambiguity halt cannot reintroduce it.
+#
+# Asserted over EXECUTABLE lines only. The step names `--notes` on purpose in
+# its prose and in two recipe comments, and a negative check over the whole step
+# text would fail on a correct patch — a guard that is red on correct input gets
+# deleted for being noisy.
+test_halt_notes_append() {
+    python3 - "$FORMULA" <<'PY' || fail "submit-and-exit must append its notes, never replace them"
+import sys
+import tomllib
+
+with open(sys.argv[1], "rb") as handle:
+    steps = tomllib.load(handle)["steps"]
+step = [s for s in steps if s["id"] == "submit-and-exit"]
+if len(step) != 1:
+    raise SystemExit("submit-and-exit step not found")
+
+# The lines an agent RUNS: inside a bash fence, not a comment.
+code, inside = [], False
+for line in step[0]["description"].split("\n"):
+    if line.startswith("```"):
+        inside = line.startswith("```bash")
+        continue
+    if inside and not line.lstrip().startswith("#"):
+        code.append(line)
+
+problems = []
+body = "\n".join(code)
+if "--notes " in body or "--notes=" in body:
+    problems.append("a bare --notes survives in a recipe: it REPLACES the bead's notes")
+
+# Every `gc bd update` that writes a note must write it with --append-notes,
+# and both halts must be among them.
+invocations, current = [], None
+for line in code:
+    if current is not None:
+        current.append(line)
+        if not line.rstrip().endswith("\\"):
+            invocations.append("\n".join(current))
+            current = None
+        continue
+    if "gc bd update" in line:
+        current = [line]
+        if not line.rstrip().endswith("\\"):
+            invocations.append("\n".join(current))
+            current = None
+if current is not None:
+    invocations.append("\n".join(current))
+
+for marker, what in (("halt_reason=auto_push_false", "the explicit opt-out halt"),
+                     ("halt_reason=no_push_rail_unresolved", "the fail-closed ambiguity halt"),
+                     ("Implemented:", "the refinery handoff")):
+    hits = [i for i in invocations if marker in i]
+    if len(hits) != 1:
+        problems.append("expected exactly one gc bd update for %s, found %d" % (what, len(hits)))
+        continue
+    if "--append-notes" not in hits[0]:
+        problems.append("%s does not use --append-notes" % what)
+
+for p in problems:
+    print("  " + p, file=sys.stderr)
+raise SystemExit(1 if problems else 0)
+PY
+}
+
 test_gate_structure
 test_rail_detection
+test_halt_notes_append
 
 echo "polecat push gate tests passed"

--- a/gastown/tests/test_polecat_push_gate.sh
+++ b/gastown/tests/test_polecat_push_gate.sh
@@ -12,7 +12,17 @@
 #      halt_reason, so a re-sling can tell "operator said no" from "nobody said";
 #   4. every note this step writes APPENDS. Both halts hand the bead back to a
 #      human and tell them to go and read what it says, so a halt that replaced
-#      the notes would delete the instructions it is pointing at.
+#      the notes would delete the instructions it is pointing at;
+#   5. the metadata probe decodes the shapes ledgers actually serve, and halts
+#      on the rest. `jq`'s has() ERRORS on a string, so a bare has("auto_push")
+#      reported "no key" on a ledger serving metadata as a JSON string and the
+#      EXPLICIT auto_push=false opt-out silently stopped firing (gci-to0l).
+#
+# Properties 1-4 assert what the gate SAYS. The last block runs it: the gate's
+# bash is lifted out of the shipped step and executed against stubbed `gc` and
+# `git`, so what is tested is the text an agent reads at pour time, never a
+# retyped copy. "The words are all present" is a weaker claim than "it does not
+# push" for a gate whose failure mode is a push to a customer estate.
 set -euo pipefail
 
 ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
@@ -32,15 +42,86 @@ test_gate_structure() {
         fail "the explicit auto_push=false opt-out halt is gone"
     grep -qF 'halt_reason=no_push_rail_unresolved' "$FORMULA" ||
         fail "the fail-closed ambiguity halt is gone"
-    grep -qF 'gc mail send' "$FORMULA" ||
-        fail "the ambiguity halt no longer escalates"
+    grep -qF 'halt_reason=metadata_unreadable' "$FORMULA" ||
+        fail "the fail-closed unreadable-metadata halt is gone (gci-to0l)"
+    local mail_sends
+    mail_sends=$(grep -cF 'gc mail send' "$FORMULA")
+    [[ "$mail_sends" -eq 2 ]] ||
+        fail "both fail-closed halts must escalate; found $mail_sends 'gc mail send'"
 
-    # The ambiguity halt is worthless if it lands after the push.
-    local ambiguity_line push_line
+    # A halt that lands after the push is worthless.
+    local ambiguity_line push_line unreadable_line optout_line
     ambiguity_line=$(grep -nF 'halt_reason=no_push_rail_unresolved' "$FORMULA" | head -1 | cut -d: -f1)
     push_line=$(grep -nF 'git push origin HEAD' "$FORMULA" | head -1 | cut -d: -f1)
+    unreadable_line=$(grep -nF 'halt_reason=metadata_unreadable' "$FORMULA" | head -1 | cut -d: -f1)
+    optout_line=$(grep -nF 'halt_reason=auto_push_false' "$FORMULA" | head -1 | cut -d: -f1)
     [[ "$ambiguity_line" -lt "$push_line" ]] ||
         fail "fail-closed halt (line $ambiguity_line) comes after git push (line $push_line)"
+    [[ "$unreadable_line" -lt "$push_line" ]] ||
+        fail "unreadable-metadata halt (line $unreadable_line) comes after git push (line $push_line)"
+    # It must also precede the opt-out test: AUTO_PUSH is meaningless when the
+    # probe that produced it failed, so reading it first is reading a guess.
+    [[ "$unreadable_line" -lt "$optout_line" ]] ||
+        fail "unreadable-metadata halt (line $unreadable_line) comes after the auto_push test (line $optout_line)"
+}
+
+# --- 1b. the metadata probe is shape-normalised (gci-to0l) ------------------
+
+# The regression: `jq`'s has() errors on a string, prints nothing, and exits
+# non-zero — so `(.[0].metadata // {}) | if has("auto_push") ...` yielded "" for
+# a ledger serving metadata as a JSON string. "" is not "false", so outcome (a),
+# the EXPLICIT opt-out, stopped firing and control reached git push. A bead that
+# recorded its rail properly AS METADATA and said nothing in prose is exactly
+# the bead the (b) prose scan cannot save.
+#
+# Asserted over the step's EXECUTABLE lines, for the same reason the notes check
+# is: the step names the old probe shape in its prose, and a check over the whole
+# step text would be red on a correct patch.
+test_metadata_probe_shape() {
+    python3 - "$FORMULA" <<'PY' || fail "the metadata probe must decode object/null/string and halt on the rest"
+import sys
+import tomllib
+
+with open(sys.argv[1], "rb") as handle:
+    steps = tomllib.load(handle)["steps"]
+step = [s for s in steps if s["id"] == "submit-and-exit"][0]["description"]
+
+code, inside = [], False
+for line in step.split("\n"):
+    if line.startswith("```"):
+        inside = line.startswith("```bash")
+        continue
+    if inside and not line.lstrip().startswith("#"):
+        code.append(line)
+body = "\n".join(code)
+
+problems = []
+if "fromjson" not in body:
+    problems.append("the probe does not decode a JSON-string metadata payload")
+if body.count('has("auto_push")') != 1 or 'type != "object" then error' not in body:
+    problems.append('has("auto_push") must be reached only on an object, and error otherwise')
+if 'type == "null"   then {}' not in body and 'type == "null" then {}' not in body:
+    # null is how every measured ledger says "this bead has no metadata", and it
+    # is the majority shape — halting on it would halt the city, not gate it.
+    problems.append("null metadata must read as empty, NOT as unreadable")
+if '[ -z "$WORK_JSON" ]' not in body:
+    # jq prints nothing for empty input and exits 0, so a dead ledger cannot be
+    # caught on jq's exit status alone.
+    problems.append("no explicit guard for an empty payload from the ledger read")
+if body.count("halt_reason=") != 3:
+    problems.append("expected exactly three halt_reason writes, found %d" % body.count("halt_reason="))
+
+# Every halt hands the bead back the same way. A halt that forgets one of these
+# leaves the bead assigned and routed, and the next sweep treats it as ordinary
+# mergeable work — a publish-without-approval bug, worse than the one being fixed.
+for marker in ("branch_ready=true", 'gc.routed_to=""', '--assignee=""', "--status=open"):
+    if body.count(marker) < 3:
+        problems.append("halt marker not written by all three halts: %s" % marker)
+
+for p in problems:
+    print("  " + p, file=sys.stderr)
+raise SystemExit(1 if problems else 0)
+PY
 }
 
 # --- 2. rail detection ------------------------------------------------------
@@ -96,8 +177,8 @@ test_rail_detection() {
 # --- 3. the halts must append their notes, never replace them ---------------
 
 # `gc bd update --notes X` REPLACES the whole notes field; `--append-notes X`
-# appends. Both halts below write a note onto a bead they did not create, and
-# both then ask a human to act on what that bead says — the ambiguity halt asks
+# appends. Every halt below writes a note onto a bead it did not create, and
+# each then asks a human to act on what that bead says — the ambiguity halt asks
 # whoever owns the rail to resolve it, and in the usual case the rail is written
 # in the very notes a bare `--notes` would have just deleted. So the gate would
 # destroy the evidence for its own escalation. This was observed twice on a live
@@ -153,6 +234,7 @@ if current is not None:
 
 for marker, what in (("halt_reason=auto_push_false", "the explicit opt-out halt"),
                      ("halt_reason=no_push_rail_unresolved", "the fail-closed ambiguity halt"),
+                     ("halt_reason=metadata_unreadable", "the unreadable-metadata halt"),
                      ("Implemented:", "the refinery handoff")):
     hits = [i for i in invocations if marker in i]
     if len(hits) != 1:
@@ -167,8 +249,185 @@ raise SystemExit(1 if problems else 0)
 PY
 }
 
+# --- 4. the shipped gate recipe, executed -----------------------------------
+
+# Properties 1-3 assert what the gate SAYS. This one runs it. The gate's bash
+# block is lifted out of the shipped step, rendered, and executed against
+# stubbed `gc` and `git`, so what is tested is the SHIPPED TEXT an agent reads
+# at pour time and never a retyped copy. Retyping is how a tested rule drifts
+# from the rule that actually runs.
+
+test_gate_execution() {
+    if ! command -v jq >/dev/null 2>&1; then
+        echo "  skip  jq not available (the gate's own scan needs it)"
+        return 0
+    fi
+
+    local tmp
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' RETURN
+
+    # Render the two formula variables the gate uses. Everything else verbatim.
+    python3 - "$FORMULA" >"$tmp/gate.sh" <<'PY' || fail "could not lift the gate recipe out of $FORMULA"
+import re
+import sys
+import tomllib
+
+with open(sys.argv[1], "rb") as handle:
+    steps = tomllib.load(handle)["steps"]
+step = [s for s in steps if s["id"] == "submit-and-exit"][0]["description"]
+blocks = [b for b in re.findall(r"^```bash\n(.*?)^```$", step, re.S | re.M)
+          if "git push origin HEAD" in b]
+if len(blocks) != 1:
+    raise SystemExit("expected exactly 1 gate block, got %d" % len(blocks))
+sys.stdout.write(blocks[0].replace("{{base_branch}}", "main")
+                          .replace("{{binding_prefix}}", "gastown."))
+PY
+
+    bash -n "$tmp/gate.sh" || fail "the rendered gate is not valid bash"
+
+    # run_gate <label> <bead-json> -> the action log on stdout
+    run_gate() {
+        local d="$tmp/run.$1"
+        rm -rf "$d"; mkdir -p "$d/bin"
+        printf '%s' "$2" >"$d/bead.json"
+        : >"$d/log"
+        cat >"$d/bin/gc" <<'GCSTUB'
+#!/usr/bin/env bash
+if [ "$1" = "bd" ] && [ "$2" = "show" ]; then cat "$GATE_DIR/bead.json"; exit 0; fi
+case "$1" in
+  bd)      printf 'BD_UPDATE %s\n' "$*" >>"$GATE_DIR/log" ;;
+  mail)    printf 'MAIL %s\n' "$*" >>"$GATE_DIR/log" ;;
+  runtime) printf 'DRAIN\n' >>"$GATE_DIR/log" ;;
+esac
+exit 0
+GCSTUB
+        cat >"$d/bin/git" <<'GITSTUB'
+#!/usr/bin/env bash
+case "$1 $2" in
+  "branch --show-current") echo "polecat/test-1"; exit 0 ;;
+  "push origin")           printf 'PUSH\n' >>"$GATE_DIR/log"; exit 0 ;;
+  "ls-remote origin")      echo "deadbeef	refs/heads/polecat/test-1"; exit 0 ;;
+  "rev-parse HEAD")        echo "deadbeef"; exit 0 ;;
+esac
+exit 0
+GITSTUB
+        chmod +x "$d/bin/gc" "$d/bin/git"
+        GATE_DIR="$d" PATH="$d/bin:$PATH" WORK_BEAD_ID=test-1 \
+            CURRENT_BRANCH=polecat/test-1 GC_RIG=testrig \
+            bash "$tmp/gate.sh" >"$d/out" 2>&1 || true
+        cat "$d/log"
+    }
+
+    saw() {
+        case "$2" in
+            *"$3"*) : ;;
+            *) fail "$1: expected '$3' in the action log: $2" ;;
+        esac
+    }
+    never() {
+        case "$2" in
+            *"$3"*) fail "$1: '$3' happened and must not have: $2" ;;
+            *) : ;;
+        esac
+    }
+
+    local log
+
+    # (a) explicit opt-out — halts without reading the prose.
+    log=$(run_gate a '[{"metadata":{"auto_push":"false"},"description":"","notes":""}]')
+    saw   "(a) auto_push=false" "$log" "halt_reason=auto_push_false"
+    never "(a) auto_push=false" "$log" "PUSH"
+
+    # (b) absent metadata + a rail in the NOTES. Notes, not description, because
+    # that is the half an earlier scan was blind to.
+    log=$(run_gate b '[{"metadata":{},"description":null,"notes":"PLAIN rail: branch + HALT branch-ready, mayor publishes, no push."}]')
+    saw   "(b) absent + rail" "$log" "halt_reason=no_push_rail_unresolved"
+    saw   "(b) absent + rail" "$log" "MAIL"
+    never "(b) absent + rail" "$log" "PUSH"
+
+    # (c) absent metadata, no rail — the normal path must still push, or the
+    # gate has stopped being a gate and started being a wall.
+    log=$(run_gate c '[{"metadata":{},"description":"Add a retry to the ingest job when the API 429s.","notes":""}]')
+    saw   "(c) absent + no rail" "$log" "PUSH"
+    never "(c) absent + no rail" "$log" "halt_reason"
+
+    # (c2) the standing "never push to main" rule is not a rail. Half the beads
+    # in the city quote it; if it halted them the gate would be routed around.
+    log=$(run_gate c2 '[{"metadata":{},"description":"Polecats do not push to main, close beads, or wait around.","notes":""}]')
+    saw   "(c2) push-to-main quote" "$log" "PUSH"
+    never "(c2) push-to-main quote" "$log" "halt_reason"
+
+    # (d) explicit consent beats prose — an operator who set auto_push=true has
+    # already read the rail, and the gate must not second-guess them.
+    log=$(run_gate d '[{"metadata":{"auto_push":"true"},"description":"no push — the mayor publishes","notes":""}]')
+    saw   "(d) auto_push=true" "$log" "PUSH"
+    never "(d) auto_push=true" "$log" "halt_reason"
+
+    # ---- metadata SHAPE (gci-to0l) -----------------------------------------
+    # The regression these arms exist for: jq's has() errors on a string, so the
+    # probe reported "no auto_push key" and the EXPLICIT opt-out stopped firing.
+    # Against the pre-fix probe, arms (e), (g3) and (g4) all log PUSH.
+
+    # (e) string-shaped metadata carrying the explicit opt-out. Nothing in the
+    # prose asserts a rail, so (b) cannot save it: the metadata is the ONLY
+    # record of the decision, which is the shape beads are being asked to adopt.
+    log=$(run_gate e '[{"metadata":"{\"auto_push\":\"false\"}","description":"Refactor the emissions-factor loader and add tests.","notes":""}]')
+    saw   "(e) string metadata + auto_push=false" "$log" "halt_reason=auto_push_false"
+    never "(e) string metadata + auto_push=false" "$log" "PUSH"
+
+    # (e2) string-shaped metadata with NO auto_push and no rail. Decoding must
+    # not turn into halting: this is the normal path wearing a different shape,
+    # and a gate that halts it halts every bead on a string-serving ledger.
+    log=$(run_gate e2 '[{"metadata":"{\"gc.work_branch\":\"main\"}","description":"Add a retry to the ingest job when the API 429s.","notes":""}]')
+    saw   "(e2) string metadata, no rail" "$log" "PUSH"
+    never "(e2) string metadata, no rail" "$log" "halt_reason"
+
+    # (f) null metadata — the shape every measured ledger serves for a bead with
+    # none, and the majority of beads. It is "nothing recorded", not
+    # "unreadable", so it must fall through to the prose scan and push. This is
+    # the arm that stops the fail-closed default being widened into a wall.
+    log=$(run_gate f '[{"metadata":null,"description":"Add a retry to the ingest job when the API 429s.","notes":""}]')
+    saw   "(f) null metadata, no rail" "$log" "PUSH"
+    never "(f) null metadata, no rail" "$log" "halt_reason"
+
+    # (f2) null metadata WITH a rail in prose still reaches the ambiguity halt —
+    # decoding null as {} must not skip (b).
+    log=$(run_gate f2 '[{"metadata":null,"description":"","notes":"PLAIN rail: branch + HALT branch-ready, mayor publishes, no push."}]')
+    saw   "(f2) null metadata + rail" "$log" "halt_reason=no_push_rail_unresolved"
+    never "(f2) null metadata + rail" "$log" "PUSH"
+
+    # (g) a shape the probe cannot decode at all. No prose rail, so only the
+    # fail-closed default stands between this and a push.
+    log=$(run_gate g '[{"metadata":[1,2],"description":"Refactor the emissions-factor loader and add tests.","notes":""}]')
+    saw   "(g) array metadata" "$log" "halt_reason=metadata_unreadable"
+    saw   "(g) array metadata" "$log" "MAIL"
+    never "(g) array metadata" "$log" "PUSH"
+
+    # (g2) a string that is not JSON at all.
+    log=$(run_gate g2 '[{"metadata":"auto_push=false","description":"Refactor the loader.","notes":""}]')
+    saw   "(g2) unparseable string metadata" "$log" "halt_reason=metadata_unreadable"
+    never "(g2) unparseable string metadata" "$log" "PUSH"
+
+    # (g3) the read itself failed — the ledger returned an empty array. Before
+    # this fix that pushed: no bead record meant no auto_push, an empty prose
+    # scan meant no rail, and the gate fell straight through.
+    log=$(run_gate g3 '[]')
+    saw   "(g3) empty bead payload" "$log" "halt_reason=metadata_unreadable"
+    never "(g3) empty bead payload" "$log" "PUSH"
+
+    # (g4) the ledger read produced NO output — a dead ledger, not a bead
+    # without metadata. jq prints nothing for empty input and exits 0, so this
+    # one cannot be caught on jq's exit status; it needs the explicit -z guard.
+    log=$(run_gate g4 '')
+    saw   "(g4) no output from the ledger read" "$log" "halt_reason=metadata_unreadable"
+    never "(g4) no output from the ledger read" "$log" "PUSH"
+}
+
 test_gate_structure
+test_metadata_probe_shape
 test_rail_detection
 test_halt_notes_append
+test_gate_execution
 
 echo "polecat push gate tests passed"

--- a/gastown/tests/test_polecat_push_gate.sh
+++ b/gastown/tests/test_polecat_push_gate.sh
@@ -27,6 +27,7 @@ set -euo pipefail
 
 ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
 FORMULA="$ROOT/gastown/formulas/mol-polecat-work.toml"
+MAYOR_PROMPT="$ROOT/gastown/agents/mayor/prompt.template.md"
 
 fail() {
     echo "FAIL: $*" >&2
@@ -34,35 +35,91 @@ fail() {
 }
 
 [[ -f "$FORMULA" ]] || fail "formula not found: $FORMULA"
+[[ -f "$MAYOR_PROMPT" ]] || fail "mayor prompt not found: $MAYOR_PROMPT"
 
 # --- 1. structure -----------------------------------------------------------
 
+# Scoped to the submit-and-exit gate block, like every sibling property. This
+# one used to grep the WHOLE FILE: it counted `gc mail send` across every step
+# and required exactly 2, and took first-occurrence line numbers for the
+# ordering. Both are green today only by accident of the file's contents — a
+# legitimate mail send in another step, or a prose mention of `git push origin
+# HEAD` above the real one, turns the suite red on correct code, which is the
+# "a guard that is red on correct input gets deleted for being noisy" failure
+# the notes check below warns about.
+#
+# The mail assertion is also per-halt now rather than a total. A total of 2 is
+# satisfiable by the WRONG two: moving the escalation off the ambiguity halt and
+# onto the operator's explicit opt-out keeps the count at 2 while the fail-closed
+# halt stops escalating. The opt-out is a decision a human already made and is
+# deliberately silent; only the two halts that mean "the gate could not tell"
+# page anyone.
 test_gate_structure() {
-    grep -qF 'halt_reason=auto_push_false' "$FORMULA" ||
-        fail "the explicit auto_push=false opt-out halt is gone"
-    grep -qF 'halt_reason=no_push_rail_unresolved' "$FORMULA" ||
-        fail "the fail-closed ambiguity halt is gone"
-    grep -qF 'halt_reason=metadata_unreadable' "$FORMULA" ||
-        fail "the fail-closed unreadable-metadata halt is gone (gci-to0l)"
-    local mail_sends
-    mail_sends=$(grep -cF 'gc mail send' "$FORMULA")
-    [[ "$mail_sends" -eq 2 ]] ||
-        fail "both fail-closed halts must escalate; found $mail_sends 'gc mail send'"
+    python3 - "$FORMULA" <<'PY' || fail "the gate's halts, their escalations and their order are wrong"
+import re
+import sys
+import tomllib
 
-    # A halt that lands after the push is worthless.
-    local ambiguity_line push_line unreadable_line optout_line
-    ambiguity_line=$(grep -nF 'halt_reason=no_push_rail_unresolved' "$FORMULA" | head -1 | cut -d: -f1)
-    push_line=$(grep -nF 'git push origin HEAD' "$FORMULA" | head -1 | cut -d: -f1)
-    unreadable_line=$(grep -nF 'halt_reason=metadata_unreadable' "$FORMULA" | head -1 | cut -d: -f1)
-    optout_line=$(grep -nF 'halt_reason=auto_push_false' "$FORMULA" | head -1 | cut -d: -f1)
-    [[ "$ambiguity_line" -lt "$push_line" ]] ||
-        fail "fail-closed halt (line $ambiguity_line) comes after git push (line $push_line)"
-    [[ "$unreadable_line" -lt "$push_line" ]] ||
-        fail "unreadable-metadata halt (line $unreadable_line) comes after git push (line $push_line)"
-    # It must also precede the opt-out test: AUTO_PUSH is meaningless when the
-    # probe that produced it failed, so reading it first is reading a guess.
-    [[ "$unreadable_line" -lt "$optout_line" ]] ||
-        fail "unreadable-metadata halt (line $unreadable_line) comes after the auto_push test (line $optout_line)"
+with open(sys.argv[1], "rb") as handle:
+    steps = tomllib.load(handle)["steps"]
+step = [s for s in steps if s["id"] == "submit-and-exit"][0]["description"]
+blocks = [b for b in re.findall(r"^```bash\n(.*?)^```$", step, re.S | re.M)
+          if "git push origin HEAD" in b]
+if len(blocks) != 1:
+    raise SystemExit("expected exactly 1 gate block, got %d" % len(blocks))
+body = "\n".join(l for l in blocks[0].split("\n") if not l.lstrip().startswith("#"))
+
+HALTS = {
+    "metadata_unreadable": ("the fail-closed unreadable-metadata halt (gci-to0l)", True),
+    "auto_push_false": ("the explicit auto_push=false opt-out halt", False),
+    "no_push_rail_unresolved": ("the fail-closed ambiguity halt", True),
+}
+
+problems, at = [], {}
+for reason, (what, escalates) in HALTS.items():
+    marker = "halt_reason=" + reason
+    if body.count(marker) != 1:
+        problems.append("%s: expected exactly 1 %s, found %d"
+                        % (what, marker, body.count(marker)))
+        continue
+    at[reason] = body.index(marker)
+    # The halt's OWN region: its metadata write through to the exit that ends
+    # it. Fail closed if that terminator is missing — an unbounded slice would
+    # run to the end of the gate and borrow a neighbouring halt's escalation.
+    end = re.compile(r"^[ \t]*exit 0[ \t]*$", re.M).search(body, at[reason])
+    if end is None:
+        problems.append("%s: no `exit 0` terminates it, so its region cannot be read"
+                        % what)
+        continue
+    sends = body[at[reason]:end.start()].count("gc mail send")
+    if escalates and sends != 1:
+        problems.append("%s must escalate exactly once; its region has %d `gc mail send`"
+                        % (what, sends))
+    if not escalates and sends != 0:
+        problems.append("%s is a decision a human already made and must not page anyone; "
+                        "its region has %d `gc mail send`" % (what, sends))
+
+# A halt that lands after the push is worthless, and the unreadable halt must
+# also precede the opt-out TEST: AUTO_PUSH is meaningless when the probe that
+# produced it failed, so reading it first is reading a guess.
+if len(at) == len(HALTS):
+    push = body.index("git push origin HEAD")
+    for earlier, later, why in (
+        ("metadata_unreadable", "auto_push_false",
+         "the unreadable-metadata halt must come before the auto_push test"),
+        ("auto_push_false", "no_push_rail_unresolved",
+         "the explicit opt-out must be tested before the prose scan"),
+    ):
+        if at[earlier] >= at[later]:
+            problems.append(why)
+    for reason in ("metadata_unreadable", "no_push_rail_unresolved"):
+        if at[reason] >= push:
+            problems.append("%s comes after git push origin HEAD" % reason)
+
+for p in problems:
+    print("  " + p, file=sys.stderr)
+raise SystemExit(1 if problems else 0)
+PY
 }
 
 # --- 1b. the metadata probe is shape-normalised (gci-to0l) ------------------
@@ -110,6 +167,15 @@ if '[ -z "$WORK_JSON" ]' not in body:
     problems.append("no explicit guard for an empty payload from the ledger read")
 if body.count("halt_reason=") != 3:
     problems.append("expected exactly three halt_reason writes, found %d" % body.count("halt_reason="))
+if "ascii_downcase" not in body:
+    # `False` and `no` are hand-written by humans following the mayor prompt;
+    # reading them as "any other value -> explicit consent" fails open on the
+    # beads that tried hardest to say no.
+    problems.append("the auto_push vocabulary is not case-folded")
+if 'error("auto_push value is outside the vocabulary")' not in body:
+    # An unrecognised value routes into the SAME unreadable halt rather than a
+    # fourth one: a decision the gate cannot understand is not consent.
+    problems.append("an auto_push value outside the vocabulary must not be read as consent")
 
 # Every halt hands the bead back the same way. A halt that forgets one of these
 # leaves the bead assigned and routed, and the next sweep treats it as ordinary
@@ -126,16 +192,53 @@ PY
 
 # --- 2. rail detection ------------------------------------------------------
 
-# Lift the shipped filter/match pair straight out of the formula so this test
-# can never drift from the gate it is testing.
-EXCLUDE_RE=$(grep -oE "grep -Eiv '[^']+'" "$FORMULA" | head -1 | sed -E "s/^grep -Eiv '//; s/'\$//")
-MATCH_RE=$(grep -oE "grep -Eic '[^']+'" "$FORMULA" | head -1 | sed -E "s/^grep -Eic '//; s/'\$//")
+# Lift the shipped strip/match pair straight out of the gate so this test can
+# never drift from the code it is testing. The lift is ANCHORED: tomllib parses
+# the formula, the submit-and-exit bash block containing `git push origin HEAD`
+# is selected, comments are dropped, and the pattern must occur exactly ONCE in
+# what remains. A position-based lift over the raw file (the first `grep -E..`
+# anywhere in it) starts testing some other step's regex the day one is added
+# above the gate, and stays green while doing it.
+#
+# The extraction is also non-fatal on purpose. Under `set -euo pipefail` an
+# empty result aborted this whole suite at the assignment — before the guards
+# below could run — so a lift that stopped matching printed nothing at all and
+# read as a crash rather than as "the pattern moved". `|| true` inside the
+# helper keeps the guards reachable so they can name what went missing.
+lift_gate_pattern() {
+    # stderr is left connected: the reason ("got 2 matches", "no gate block")
+    # is the useful half of the failure, and stdout stays clean either way.
+    python3 - "$FORMULA" "$1" <<'PY' || true
+import re
+import sys
+import tomllib
 
-[[ -n "$EXCLUDE_RE" ]] || fail "could not lift the exclude pattern out of $FORMULA"
-[[ -n "$MATCH_RE" ]] || fail "could not lift the match pattern out of $FORMULA"
+with open(sys.argv[1], "rb") as handle:
+    steps = tomllib.load(handle)["steps"]
+step = [s for s in steps if s["id"] == "submit-and-exit"][0]["description"]
+blocks = [b for b in re.findall(r"^```bash\n(.*?)^```$", step, re.S | re.M)
+          if "git push origin HEAD" in b]
+if len(blocks) != 1:
+    raise SystemExit("expected exactly 1 gate block, got %d" % len(blocks))
+body = "\n".join(l for l in blocks[0].split("\n") if not l.lstrip().startswith("#"))
+hits = re.findall(sys.argv[2], body)
+if len(hits) != 1:
+    raise SystemExit("expected exactly 1 match for %s, got %d" % (sys.argv[2], len(hits)))
+sys.stdout.write(hits[0])
+PY
+}
 
+STRIP_SED=$(lift_gate_pattern "sed -E '(s#[^#]*#[^#]*#g)'")
+MATCH_RE=$(lift_gate_pattern "grep -Eic '([^']+)'")
+
+[[ -n "$STRIP_SED" ]] ||
+    fail "could not lift the push-to-main strip out of the submit-and-exit gate block in $FORMULA"
+[[ -n "$MATCH_RE" ]] ||
+    fail "could not lift the rail match pattern out of the submit-and-exit gate block in $FORMULA"
+
+# The gate's own three scan stages, in the gate's order.
 rail_hits() {
-    printf '%s\n' "$1" | grep -Eiv "$EXCLUDE_RE" | grep -Eic "$MATCH_RE" || true
+    printf '%s\n' "$1" | tr '[:upper:]' '[:lower:]' | sed -E "$STRIP_SED" | grep -Eic "$MATCH_RE" || true
 }
 
 assert_rail() {
@@ -172,6 +275,156 @@ test_rail_detection() {
     assert_rail push 'The tag was never pushed, so the release is invisible.'
     assert_rail push 'Add a retry to the ingest job when the API 429s.'
     assert_rail push 'Refactor the emissions-factor loader and add tests.'
+
+    # The 7 wordings the line-dropping exclusion swallowed. Measured 2026-09-08
+    # against the shipped patterns: every one scored ZERO hits, so the gate
+    # pushed a bead whose prose forbids it. Rows 1-5 are the bare `origin`
+    # alternative — origin is the remote the gate is about to push to, so
+    # "do not push to origin" is a full rail, not the standing rule.
+    assert_rail halt 'never push to origin — the customer tenant is frozen'
+    assert_rail halt 'Do not push to origin; wait for the operator to take it.'
+    assert_rail halt 'Do not push to origin; the mayor publishes.'
+    assert_rail halt 'never push to origin/customer-prod, it is frozen'
+    assert_rail halt 'do not push to origin until legal signs off'
+    # Rows 6-7 are why narrowing the destination is not enough on its own: the
+    # rail and the standing-rule quote share ONE line, so the line has to
+    # survive with the quote cut out of it. A narrowing-only patch leaves these
+    # two pushing.
+    assert_rail halt 'Do not push to main - in fact do not push at all, the operator publishes.'
+    assert_rail halt 'Polecats do not push to main. HALT branch-ready for this bead.'
+
+    # The stripped destination must end on a word boundary, or the origin/main
+    # prefix eats the rail off a branch whose name merely starts with it.
+    assert_rail halt 'never push to origin/main-line-customer, frozen'
+    assert_rail halt 'do not push to master_frozen, ever'
+    # `/` is in that class too: these name branches UNDER the stripped
+    # namespaces, so without it the strip removes the verb and the gate pushes.
+    # Measured at 0 hits before `/` was protected.
+    assert_rail halt 'never push to main/customer, the tenant is frozen'
+    assert_rail halt 'do not push to origin/main/customer-prod, frozen'
+
+    # The prose arms must cover the words the metadata vocabulary blesses, or a
+    # rail is enforced in one channel and fail-open in the other. All four
+    # scored ZERO hits before, measured 2026-09-09 against the shipped patterns.
+    assert_rail halt 'You must not push this branch until the audit clears.'
+    assert_rail halt 'You should not push this branch until the audit clears.'
+    assert_rail halt 'Rails: auto_push=no, base=main.'
+    assert_rail halt 'Rails: auto_push=0, base=main.'
+    # ...and the standing-rule quote survives the new verbs, because the strip
+    # runs first. These are the rows that would redden if the wider alternation
+    # were bought by dropping the strip.
+    assert_rail push 'Polecats must not push to main; open a PR.'
+    assert_rail push 'Contributors should not push to master; open a PR.'
+    # The consent half of the vocabulary must not be read as a rail by the
+    # value arm's alternation.
+    assert_rail push 'Rails: auto_push=true, base=main.'
+    assert_rail push 'Rails: auto_push=1, base=main.'
+    # Same past-tense guard as the `never pushes` row above. A modal cannot take
+    # the -es/-ed form, so this shape is ungrammatical rather than idiomatic; the
+    # guard is carried for consistency across the three verb arms and this row
+    # pins it so a later edit cannot quietly drop it from one arm only.
+    assert_rail push 'Establish why mirror-sync should not pushes twice.'
+
+    # The strip is case-insensitive because the scan is downcased first, NOT
+    # because sed was asked to be (its I flag is GNU-only, and this gate runs
+    # wherever a polecat runs). If the downcase went away these two would halt
+    # on the standing rule — cry wolf — while the halt row below stayed green,
+    # so all three are needed to pin the direction.
+    assert_rail push 'Do Not Push To Main; open a PR.'
+    assert_rail push 'NEVER PUSH DIRECTLY TO MAIN; open a PR.'
+    assert_rail halt 'Do Not Push; the Mayor Publishes.'
+
+    # KNOWN RESIDUAL, deliberately not asserted either way. Two shapes, one
+    # mechanism — the regex cannot read a sentence — recorded here so the next
+    # reader does not have to rediscover them; auto_push=false ends both.
+    #
+    #   1. A rail whose only signal sits INSIDE the stripped phrase still reads
+    #      as the standing rule: "never push to main or anywhere else" scores
+    #      zero, and so does the dotted form "never push to main.customer, it is
+    #      frozen" — `.` cannot join `-_/` in the protected class without
+    #      reddening "Polecats never push to main. Open a PR." Separating these
+    #      from "polecats do not push to main" needs sentence semantics, and the
+    #      cheap cure (keep the line whenever the strip removes every signal)
+    #      halts every bead quoting the standing rule, which is the failure the
+    #      strip exists to prevent. Left as a push.
+    #   2. The converse, opened by the wider verb alternation: a NORMATIVE
+    #      sentence about another system — "Establish why the sync should not
+    #      push twice" — halts, where the past-tense report ("...never pushes")
+    #      does not. Left as a halt: a spurious halt costs a human round trip,
+    #      a missed rail costs a push to a customer estate.
+}
+
+# --- 2b. the scan's shape: strip the phrase, and fail closed ----------------
+
+# Two properties the row table cannot see, because it runs the lifted patterns
+# rather than the pipeline they sit in:
+#   1. the line-dropping `grep -Eiv` must not come back. It is what made the 7
+#      wordings above score zero; re-adding it BESIDE the strip would leave
+#      every row here green while the gate went back to pushing them.
+#   2. the prose must be extracted in CHECKED stages. `grep -c` prints a count
+#      whenever it runs, so a stage that dies inside one long pipe reaches the
+#      match grep as an empty stream, scores 0, and pushes — which made the
+#      fail-closed claim true only for a missing grep binary.
+# Asserted over EXECUTABLE lines, like the notes and probe checks: the step
+# describes the old shape in its prose on purpose.
+test_rail_scan_shape() {
+    python3 - "$FORMULA" <<'PY' || fail "the rail scan must strip the push-to-main phrase and fail closed"
+import re
+import sys
+import tomllib
+
+with open(sys.argv[1], "rb") as handle:
+    steps = tomllib.load(handle)["steps"]
+step = [s for s in steps if s["id"] == "submit-and-exit"][0]["description"]
+blocks = [b for b in re.findall(r"^```bash\n(.*?)^```$", step, re.S | re.M)
+          if "git push origin HEAD" in b]
+if len(blocks) != 1:
+    raise SystemExit("expected exactly 1 gate block, got %d" % len(blocks))
+body = "\n".join(l for l in blocks[0].split("\n") if not l.lstrip().startswith("#"))
+
+problems = []
+if "grep -Eiv" in body:
+    problems.append("the line-dropping exclusion is back: strip the push-to-main PHRASE, not the line")
+
+strip = re.findall(r"sed -E '(s#[^#]*#[^#]*#g)'", body)
+if len(strip) != 1:
+    problems.append("expected exactly one push-to-main strip, found %d" % len(strip))
+else:
+    if "(origin/)?" not in strip[0]:
+        # Bare `origin` is the remote the gate is about to push to, so
+        # "do not push to origin" is a rail, not the push-to-main rule.
+        problems.append("the strip does not narrow `origin` to a branch under it")
+    if "([^-[:alnum:]_/]|$)" not in strip[0]:
+        # `/` belongs in the protected class with `-` and `_`: main/customer is
+        # a branch UNDER main, so stripping the phrase there eats a real rail's
+        # verb. The row table pins the behaviour; this pins the class itself so
+        # a narrowing edit cannot silently drop one character of it.
+        problems.append("the strip has no trailing word boundary over -_/: "
+                        "origin/main-line-customer and main/customer lose their "
+                        "rail to the origin/main prefix")
+if "tr '[:upper:]' '[:lower:]'" not in body:
+    problems.append("the scan is not downcased, so the strip misses 'Do Not Push To Main' "
+                    "(sed's case-insensitive flag is GNU-only and this gate is not)")
+
+# The scan runs between the "no metadata decision" test and the halt test.
+scan = body.split('if [ -z "$AUTO_PUSH" ]; then', 1)[-1].split('if [ "${RAIL_HIT:-1}"', 1)[0]
+guarded = [l.strip() for l in scan.split("\n") if l.strip().startswith(("if ! ", "elif ! "))]
+for stage, what in (("jq -r", "the prose extraction"),
+                    ("tr '[:upper:]'", "the downcase"),
+                    ("sed -E", "the strip")):
+    if not any(stage in g for g in guarded):
+        problems.append("%s is not a checked stage: a mid-pipe failure there would "
+                        "score 0 hits and push" % what)
+if scan.count("RAIL_HIT=1") != len(guarded) or not guarded:
+    problems.append("every checked stage must assert the rail on failure: %d guards, "
+                    "%d RAIL_HIT=1" % (len(guarded), scan.count("RAIL_HIT=1")))
+if '"${RAIL_HIT:-1}" -gt 0' not in body:
+    problems.append("the empty-result default is gone: a grep that never ran must halt")
+
+for p in problems:
+    print("  " + p, file=sys.stderr)
+raise SystemExit(1 if problems else 0)
+PY
 }
 
 # --- 3. the halts must append their notes, never replace them ---------------
@@ -263,8 +516,9 @@ test_gate_execution() {
         return 0
     fi
 
-    local tmp
+    local tmp REAL_JQ
     tmp=$(mktemp -d)
+    REAL_JQ=$(command -v jq)
     trap 'rm -rf "$tmp"' RETURN
 
     # Render the two formula variables the gate uses. Everything else verbatim.
@@ -286,7 +540,7 @@ PY
 
     bash -n "$tmp/gate.sh" || fail "the rendered gate is not valid bash"
 
-    # run_gate <label> <bead-json> -> the action log on stdout
+    # run_gate <label> <bead-json> [jq-calls-that-succeed] -> action log on stdout
     run_gate() {
         local d="$tmp/run.$1"
         rm -rf "$d"; mkdir -p "$d/bin"
@@ -313,8 +567,24 @@ esac
 exit 0
 GITSTUB
         chmod +x "$d/bin/gc" "$d/bin/git"
+        # Optional fault injection: let the first N jq calls through, then fail
+        # them. The metadata probe is call 1; the prose extraction is call 2.
+        if [[ -n "${3:-}" ]]; then
+            cat >"$d/bin/jq" <<'JQSTUB'
+#!/usr/bin/env bash
+n=$(( $(cat "$GATE_DIR/jqcalls" 2>/dev/null || echo 0) + 1 ))
+printf '%s' "$n" >"$GATE_DIR/jqcalls"
+if [ "$n" -gt "$JQ_OK_CALLS" ]; then
+  echo "jq: simulated mid-run failure" >&2
+  exit 5
+fi
+exec "$REAL_JQ" "$@"
+JQSTUB
+            chmod +x "$d/bin/jq"
+        fi
         GATE_DIR="$d" PATH="$d/bin:$PATH" WORK_BEAD_ID=test-1 \
             CURRENT_BRANCH=polecat/test-1 GC_RIG=testrig \
+            JQ_OK_CALLS="${3:-}" REAL_JQ="$REAL_JQ" \
             bash "$tmp/gate.sh" >"$d/out" 2>&1 || true
         cat "$d/log"
     }
@@ -422,12 +692,167 @@ GITSTUB
     log=$(run_gate g4 '')
     saw   "(g4) no output from the ledger read" "$log" "halt_reason=metadata_unreadable"
     never "(g4) no output from the ledger read" "$log" "PUSH"
+
+    # ---- the auto_push VOCABULARY is closed and case-folded -----------------
+    # `auto_push` is hand-written by humans following the mayor prompt, so the
+    # near misses are the interesting values. Under "any other value -> push,
+    # explicit consent" every arm below except (i4)/(i6) pushed — a bead
+    # carrying BOTH `auto_push=False` and a written rail pushed, because the
+    # opt-out row short-circuits the prose scan.
+
+    # (i) the opt-out in the wrong case, with a rail in the prose behind it.
+    log=$(run_gate i '[{"metadata":{"auto_push":"False"},"description":"PLAIN rail: branch + HALT branch-ready, mayor publishes, no push.","notes":""}]')
+    saw   "(i) auto_push=False" "$log" "halt_reason=auto_push_false"
+    never "(i) auto_push=False" "$log" "PUSH"
+
+    # (i2) the other spellings of no.
+    log=$(run_gate i2 '[{"metadata":{"auto_push":"no"},"description":"Refactor the loader.","notes":""}]')
+    saw   "(i2) auto_push=no" "$log" "halt_reason=auto_push_false"
+    never "(i2) auto_push=no" "$log" "PUSH"
+    log=$(run_gate i3 '[{"metadata":{"auto_push":false},"description":"Refactor the loader.","notes":""}]')
+    saw   "(i3) auto_push JSON false" "$log" "halt_reason=auto_push_false"
+    never "(i3) auto_push JSON false" "$log" "PUSH"
+
+    # (i4) consent, spelled the ways a human spells it.
+    log=$(run_gate i4 '[{"metadata":{"auto_push":"YES"},"description":"no push — the mayor publishes","notes":""}]')
+    saw   "(i4) auto_push=YES" "$log" "PUSH"
+    never "(i4) auto_push=YES" "$log" "halt_reason"
+
+    # (i5) a key present with a null value is NOTHING RECORDED, not consent and
+    # not unreadable: JSON's own spelling of "no value". It must fall through to
+    # the prose scan — here to a rail, so the ambiguity halt.
+    log=$(run_gate i5 '[{"metadata":{"auto_push":null},"description":"","notes":"PLAIN rail: branch + HALT branch-ready, mayor publishes, no push."}]')
+    saw   "(i5) auto_push null + rail" "$log" "halt_reason=no_push_rail_unresolved"
+    never "(i5) auto_push null + rail" "$log" "PUSH"
+
+    # (i6) ... and with no rail it is the normal path, or a null-valued key
+    # would become a wall.
+    log=$(run_gate i6 '[{"metadata":{"auto_push":null},"description":"Add a retry to the ingest job when the API 429s.","notes":""}]')
+    saw   "(i6) auto_push null, no rail" "$log" "PUSH"
+    never "(i6) auto_push null, no rail" "$log" "halt_reason"
+
+    # (i7) a value nobody can interpret is a decision the gate failed to read,
+    # so it lands in the unreadable halt rather than being waved through as
+    # "explicit consent". Note the prose here asserts nothing: the metadata is
+    # the only record, which is the shape beads are being asked to adopt.
+    log=$(run_gate i7 '[{"metadata":{"auto_push":"maybe"},"description":"Refactor the loader.","notes":""}]')
+    saw   "(i7) auto_push=maybe" "$log" "halt_reason=metadata_unreadable"
+    saw   "(i7) auto_push=maybe" "$log" "MAIL"
+    never "(i7) auto_push=maybe" "$log" "PUSH"
+
+    # ---- the scan's own failure is a rail ----------------------------------
+
+    # (h) the PROSE extraction breaks after the probe has already succeeded.
+    # This is the bead from arm (c), which pushes; the only difference is the
+    # dead stage. `grep -c` prints a count whenever it runs, so before the scan
+    # was split into checked stages a mid-pipe death arrived at the match grep
+    # as an empty stream, counted 0 rails, and PUSHED — the fail-closed comment
+    # held only for a grep binary that was missing outright.
+    log=$(run_gate h '[{"metadata":{},"description":"Add a retry to the ingest job when the API 429s.","notes":""}]' 1)
+    saw   "(h) prose extraction failed" "$log" "halt_reason=no_push_rail_unresolved"
+    never "(h) prose extraction failed" "$log" "PUSH"
+
+    # (h2) the same injection with the fault set BEYOND the scan: the stub is
+    # in $PATH and counting for both arms, so (h)'s halt is the failure talking
+    # and not the stub's mere presence.
+    log=$(run_gate h2 '[{"metadata":{},"description":"Add a retry to the ingest job when the API 429s.","notes":""}]' 9)
+    saw   "(h2) jq stub, no fault" "$log" "PUSH"
+    never "(h2) jq stub, no fault" "$log" "halt_reason"
+}
+
+# --- 5. the mayor's read-back recipe, executed ------------------------------
+
+# The mayor prompt tells an operator how to read `auto_push` back after writing
+# it, and that recipe is a copy of the gate's probe kept in prose. It drifted
+# once already — the same divergence was raised, patched in prose, and raised
+# again next iteration — because nothing executed it. So this executes the
+# SHIPPED text: the block is lifted out of the prompt with exactly one edit (the
+# ledger read becomes a fixture read) and its answers are pinned.
+#
+# The three answers mirror the probe's three outcomes: a recorded value, `absent`
+# (nothing recorded, so the bead falls through to the prose scan), and
+# `unreadable` (the read itself failed, which the gate turns into the
+# metadata_unreadable halt). The third is the one worth pinning: a failed read
+# reported as a settled answer invites re-writing a bead whose state was never
+# actually read.
+test_mayor_readback_mirrors_probe() {
+    if ! command -v jq >/dev/null 2>&1; then
+        echo "  skip  jq not available (the recipe under test is a jq pipeline)"
+        return 0
+    fi
+
+    local tmp
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' RETURN
+
+    python3 - "$MAYOR_PROMPT" >"$tmp/readback.sh" <<'PY' || fail "could not lift the read-back recipe out of the mayor prompt"
+import re
+import sys
+
+doc = open(sys.argv[1], encoding="utf-8").read()
+blocks = [b for b in re.findall(r"^```bash\n(.*?)^```$", doc, re.S | re.M)
+          if "WORK_JSON" in b and "auto_push" in b]
+if len(blocks) != 1:
+    raise SystemExit("expected exactly 1 read-back block, got %d" % len(blocks))
+body = blocks[0]
+
+# The ONLY edit. If the prompt stops spelling the read exactly this way the lift
+# has to fail loudly rather than substitute nothing: an unsubstituted block would
+# run the operator's real `gc bd show` from the test and pass or fail on whatever
+# the live ledger happened to answer.
+READ = "gc bd show <id> --json"
+if body.count(READ) != 1:
+    raise SystemExit("expected exactly 1 `%s` in the recipe, got %d"
+                     % (READ, body.count(READ)))
+sys.stdout.write(body.replace(READ, 'cat "$FIXTURE"'))
+PY
+
+    bash -n "$tmp/readback.sh" || fail "the lifted read-back recipe is not valid bash"
+
+    # answers <label> <expected> <payload>
+    answers() {
+        local label="$1" want="$2" payload="$3" got
+        printf '%s' "$payload" >"$tmp/fixture.json"
+        got=$(FIXTURE="$tmp/fixture.json" bash "$tmp/readback.sh" 2>/dev/null)
+        [[ "$got" == "$want" ]] \
+            || fail "mayor read-back ($label): expected '$want', got '$got'"
+    }
+
+    # A recorded decision reads back as itself, through every metadata shape the
+    # ledgers actually serve. The string-metadata row is the shape that made the
+    # pre-fix one-liner exit 5 printing nothing.
+    answers "object metadata, false" false '[{"metadata":{"auto_push":false}}]'
+    answers "object metadata, true"  true  '[{"metadata":{"auto_push":true}}]'
+    answers "string metadata"        false '[{"metadata":"{\"auto_push\":false}"}]'
+    answers "string value"           no    '[{"metadata":{"auto_push":"no"}}]'
+
+    # `absent` is "nothing recorded", which is not a halt: it falls through to
+    # the prose scan. A null VALUE is JSON's own spelling of nothing recorded, so
+    # it belongs here and not in the answers above — printing the bare word
+    # `null` would read as a decision the operator never made.
+    answers "no auto_push key" absent '[{"metadata":{}}]'
+    answers "null metadata"    absent '[{"metadata":null}]'
+    answers "null value"       absent '[{"metadata":{"auto_push":null}}]'
+
+    # `unreadable` is the read failing, which the gate answers with the
+    # metadata_unreadable halt. Each row below is permissive-by-default without
+    # its guard: jq prints nothing and exits 0 on empty input, and `[] | .[0]`
+    # is null, so an unguarded pipe answers a dead ledger and a bead-less payload
+    # with silence and with `absent` respectively.
+    answers "empty payload"                unreadable ''
+    answers "no bead record"               unreadable '[]'
+    answers "payload is not an array"      unreadable '{"metadata":{"auto_push":false}}'
+    answers "bead record is not an object" unreadable '[7]'
+    answers "undecodable string metadata"  unreadable '[{"metadata":"not json at all"}]'
+    answers "metadata is a scalar"         unreadable '[{"metadata":7}]'
 }
 
 test_gate_structure
 test_metadata_probe_shape
 test_rail_detection
+test_rail_scan_shape
 test_halt_notes_append
 test_gate_execution
+test_mayor_readback_mirrors_probe
 
 echo "polecat push gate tests passed"

--- a/scripts/gascity_pack_inference_gate.py
+++ b/scripts/gascity_pack_inference_gate.py
@@ -69,7 +69,7 @@ GASTOWN_ALWAYS_ON_AGENTS = ("mayor", "deacon", "boot", "witness")
 GASTOWN_FORMULA_CONTRACTS = {
     "mol-review-leg": (
         "write the FULL report into the bead notes",
-        "gc bd update \"$WORK_BEAD_ID\" --notes",
+        "gc bd update \"$WORK_BEAD_ID\" --append-notes",
         "gc mail send \"$COORD\"",
         "gc bd update \"$WORK_BEAD_ID\" --status=closed",
     ),


### PR DESCRIPTION
## The bug

`mol-polecat-work`'s `submit-and-exit` read the no-push opt-out as:

```bash
AUTO_PUSH=$(gc bd show "$WORK_BEAD_ID" --json | jq -r '.[0].metadata | if has("auto_push") then (.auto_push | tostring) else "" end')
if [ "$AUTO_PUSH" = "false" ]; then <halt> fi
git push origin HEAD
```

An **absent** `auto_push` key yields the empty string, which is not `"false"`, so control falls straight through to the push and the refinery handoff. A bead whose DESCRIPTION says *"HALT branch-ready, the mayor publishes, no push"* but which carries no `auto_push` key gets **pushed** by a polecat following the gate exactly as written.

A rail expressed only in prose is enforced by nothing.

A sweep of one live city found **21 open beads in that state across four rigs**. Fifteen had halted anyway — the polecats read the prose and complied with intent over mechanism. That is good behaviour, not enforcement; it is one differently-prompted agent away from an unintended push. Two of the four rigs are customer repos, and an unintended push to a customer repo has already caused an unintended prod deploy once.

## The fix

A push gate should fail **closed**. Absent metadata is not consent.

| `auto_push` | Bead prose | Outcome |
|---|---|---|
| `false` | not read | halt at branch-ready — unchanged |
| absent | asserts a no-push rail | **halt at branch-ready and escalate** (`halt_reason=no_push_rail_unresolved`) |
| absent | no rail | push + refinery handoff — unchanged |
| any other value | not read | push + refinery handoff — explicit consent |

The escalation mail tells the rail's owner exactly how to resolve it (`--set-metadata auto_push=false|true`, then re-sling), so the halt is a round trip, not a dead end.

### Why the detection is deliberately narrow

- **DESCRIPTION + NOTES only.** Comments are discussion, not standing instructions, and they self-match on any bead that merely *talks about* no-push rails.
- **The push-_to-main_ phrase is stripped before matching** (the phrase, not the whole line). "Do not push to main" is a different rail — every polecat already obeys it, since it pushes a feature branch and never main — and half the beads in a city quote it. Matching on it would make the gate cry wolf, and a gate that cries wolf gets routed around. Stripping only the phrase keeps any *other* rail asserted on the same line visible to the scan.
- **An empty scan result halts too** (`${RAIL_HIT:-1}`): `grep -c` always prints a count when it runs, so an empty result means the scan itself broke, and an undetermined rail is treated as an asserted one.

### Closing the gap at the authoring end

The gate is a backstop, not a substitute. It costs a round trip and a human read every time it fires; it can only see DESCRIPTION and NOTES, so a rail that lives in a comment is invisible to it; and **it covers only the polecat's own `submit-and-exit`**. A polecat that dies mid-work is recovered by the witness's orphan salvage (`mol-witness-patrol.toml:301,313`), which pushes the branch without consulting `auto_push` or the prose at all — that path is untouched by this PR and is filed as its own follow-up. So on a bead that must not reach the remote, the metadata is the record that survives the crash. The mayor's bead-filing gotchas now require a prose rail to be recorded as metadata **in the same write**, and warn that the `.auto_push // "-"` jq idiom reads the legitimate value `false` as absent.

## Verification

Run against a live city, not just fixtures:

- All six beads where the gate could still fire (`det-aur`, `fph-aijq`, `fph-7grj`, `sb-fmly`, `sb-n2qj`, `gci-omd`) now **halt**.
- A bug report reading *"mirror-sync commits locally and never pushes"* does **not** halt. That was a real false positive during development (`never push` matched `never pushes`); it is now a test case.
- Sweep of 142 open beads across nine rigs: hits land on the no-push cohort, not on ordinary work.

`gastown/tests/test_polecat_push_gate.sh` (new, CI auto-runs `gastown/tests/test_*.sh`):

- pins the **ordering** — the ambiguity halt must appear before `git push origin HEAD`;
- **lifts the shipped regexes out of the formula** so the test cannot drift from the gate it tests;
- covers both directions of the rail / no-rail split, including the standing "do not push to main" phrasing.

Mutation-tested: removing the ambiguity halt fails the test, and loosening `never push([^e]|$)` back to `never push` fails it on the false-positive case.

Local gates green: `tomllib` parse, `bash -n` on the rendered gate, `validate_registry.py --require-git`, all five `gastown/tests/test_*.sh`, `shellcheck --severity=style` on the new test, and `gc lint gastown` unchanged at 35 pre-existing findings (0 new).
