### PR TITLE
fix(do-work): base item worktree on fresh origin/<default>, not stale local HEAD

### DIFF
--- a/gascity/assets/workflows/do-work/prepare-worktree.md
+++ b/gascity/assets/workflows/do-work/prepare-worktree.md
@@ -18,9 +18,19 @@ setup only. Do not edit source files in the launcher checkout.
 3. Validate context path {{context_path}}, files ownership, and verification
    policy for the resolved source anchor.
 4. Create or reuse a deterministic git worktree at
-   `$(pwd)/worktrees/<source-anchor-id>`. If the path is missing, run
-   `git worktree add "$WORKTREE" --detach HEAD`. If the path exists but is not
-   the worktree for this repository, fail closed.
+   `$(pwd)/worktrees/<source-anchor-id>`, based on the current upstream default
+   branch — never the launcher checkout's local `HEAD`, which drifts behind
+   `origin` as PRs merge and would otherwise produce stale-base worktrees whose
+   PRs conflict with already-merged work. If the path is missing:
+   - Resolve the repo default branch into `DEF`:
+     `DEF=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##')`.
+     If `DEF` is empty, populate the remote head once with
+     `git remote set-head origin --auto` and re-read (fall back to `main` only
+     if the remote advertises no default branch).
+   - Fetch the latest tip: `git fetch origin "$DEF"`.
+   - Create the worktree from the freshly-fetched remote tip:
+     `git worktree add "$WORKTREE" --detach "origin/$DEF"`.
+   If the path exists but is not the worktree for this repository, fail closed.
 5. Persist the absolute path on the source anchor with
    `gc bd update <source-anchor-id> --set-metadata work_dir=<absolute worktree path>`.
    For synthetic drain-unit convoys, never persist `work_dir` on the synthetic drain-unit convoy; the original drain member/source anchor is authoritative.


### PR DESCRIPTION
## Problem

`gascity/assets/workflows/do-work/prepare-worktree.md` step 4 creates each item worktree with:

    git worktree add "$WORKTREE" --detach HEAD

i.e. branched from the launcher (pool) checkout's **local** `HEAD`. In a long-running city the pool checkout's local default branch drifts behind `origin` as PRs merge — nothing fetches it between items — so agents implement on a stale base and open PRs that conflict with, or wholesale **duplicate**, work already merged to the default branch.

Observed downstream: an item re-dispatched while the pool checkout was **23 commits behind `origin/main`** rebuilt a feature already merged, producing a PR with 8 add/add conflicts against the existing files.

## Fix

Resolve the repo's default branch, fetch it, and create the worktree from the freshly-fetched `origin/<default>` tip instead of local `HEAD`. This mirrors what `gastown/assets/scripts/worktree-setup.sh` already does (fetch + `origin/HEAD` start-point) — the do-work `prepare-worktree` path just wasn't applying the same pattern.

Docs-only change to an agent-run workflow prompt; no code paths altered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hay6oLxVAGDWgFyRRgifaU
