### PR TITLE
decompose-stage hardening: outcome-aware plan-review gate + runtime artifact-path resolution

### DIFF
--- a/compound-engineering/assets/workflows/compound-plan-review/{target}.md
+++ b/compound-engineering/assets/workflows/compound-plan-review/{target}.md
@@ -1,9 +1,49 @@
 Finalize the Compound Engineering plan-review expansion.
 
-Verify the latest synthesized verdict is approved, record the review report path on the parent build step, and close this expansion target. If the loop exhausted attempts or has unresolved required findings, record a failing review outcome with the report path.
+Verify the latest synthesized verdict is approved, promote the plan-review
+artifact path to the workflow root, and close this expansion target. If the loop
+exhausted attempts or has unresolved required findings, record a failing review
+outcome — honestly — with the report path.
 
 Use workflow root metadata `gc.build.plan_review_report_path` and
-`gc.build.plan_review_apply_summary_path`. On success, update the workflow root
-with `gc.build.plan_review_status=approved` and
-`gc.build.plan_review_approved_at=<UTC timestamp>`, then close with
-`gc.outcome=pass`.
+`gc.build.plan_review_apply_summary_path`.
+
+On SUCCESS (latest verdict approves), update the workflow root with all of the
+following, then close with `gc.outcome=pass`:
+
+- `gc.build.plan_review_status=approved`
+- `gc.build.plan_review_approved_at=<UTC timestamp>`
+- `gc.build.plan_review_path=<gc.build.plan_review_report_path value>` — promote
+  the approved plan-review artifact path to root so the downstream decompose
+  stage can read it at runtime (symmetric with `gc.build.plan_path`; dip-5hkepo).
+- `gc.var.plan_review_path=<same path>`
+
+Record them in one command, e.g.
+`bd update "<workflow-root-id>" --set-metadata "gc.build.plan_review_status=approved" --set-metadata "gc.build.plan_review_path=<path>" --set-metadata "gc.var.plan_review_path=<path>" --set-metadata "gc.build.plan_review_approved_at=<UTC timestamp>"`.
+Do not use `bd update --metadata 'key=value'`; `--metadata` only accepts a JSON
+object.
+
+On FAILURE (the loop exhausted its attempts or unresolved required findings
+remain — the plan review did NOT converge to approval), record the failing
+outcome HONESTLY so the plan-review-approved gate (dip-duj3e6) and any downstream
+consumer see the truth instead of a stale `draft`/`approved`. Update the workflow
+root with all of the following, then close with `gc.outcome=fail`:
+
+- `gc.build.plan_review_status=failed` — authoritative post-review verdict; the
+  status is now honest (approved XOR failed), so the gate's `status==approved`
+  predicate is self-sufficient.
+- `gc.build.plan_status=failed` — un-approve the pre-review self-declaration
+  written at plan-authoring time, so `plan_status` and `plan_review_status` never
+  disagree (closes the stale-approved trap). `gc.build.plan_review_status` remains
+  the authoritative field; this is defense-in-depth.
+- Keep `gc.build.plan_review_report_path` pointing at the report for triage.
+
+Record them in one command, e.g.
+`bd update "<workflow-root-id>" --set-metadata "gc.build.plan_review_status=failed" --set-metadata "gc.build.plan_status=failed"`,
+then `bd close "<claimed-step-id>" --reason "<why the review did not converge>"`
+after setting `gc.outcome=fail` on the claimed step with `bd update`. Do NOT close
+with `--metadata`/`--set-metadata`. Do NOT record `plan_review_status=approved`
+on the failing branch.
+
+Do not invoke provider-native subagents or upstream plugin runtime commands.
+This graph stage is the delegation mechanism.

--- a/gascity/assets/scripts/checks/decompose-inputs-present.sh
+++ b/gascity/assets/scripts/checks/decompose-inputs-present.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Decompose-inputs-present FAIL-LOUD guard (canonical; platform bug dip-5hkepo).
+#
+# The compound-build/build-from-plan decompose (and prepare-decompose) step beads render their
+# descriptions at INSTANTIATION (frozen, one pass) — before plan/plan-review produce their artifacts.
+# When plan_path / plan_review_path default to "" and are never promoted to the workflow root, the
+# frozen render carries an EMPTY path and decompose silently proceeds on empty inputs. The real fix is
+# runtime-read (decompose.md/prepare-decompose.md read the root var store) + promotion (plan-review
+# records gc.build.plan_review_path on root). This guard is the no-silent-failure backstop: it asserts
+# BOTH paths are present+non-empty on the workflow ROOT before decompose proceeds, and exits non-zero
+# with a clear single-line diagnostic otherwise. Fail-CLOSED (default-deny).
+#
+# The prepare-decompose OPERATOR step runs this guard and, on a non-zero exit, leaves prepare-decompose
+# OPEN and BLOCKED (never closed) — because decompose depends on it, the task-decomposer never activates.
+# That blocked-open barrier (not a plain [steps.check], which would close-fail and release on close) is
+# what turns a silent empty-decompose into a loud halt.
+#
+# PREDICATE (pass iff BOTH hold), each key resolved as gc.build.<k> with fallback gc.var.<k>:
+#   1. plan_path        is present and non-empty on the workflow-ROOT bead, AND
+#   2. plan_review_path is present and non-empty on the workflow-ROOT bead.
+# The gc.build/gc.var fallback matches build-artifact-valid.sh and covers both flows: build-from-plan
+# promotes gc.build.plan_review_path via the plan-review stage, while a directly-launched
+# build-from-decompose supplies the paths as gc.var.* launch vars.
+#
+# SOURCE OF TRUTH: the workflow-ROOT bead, resolved via gc.root_bead_id on the running step (a bead with
+# no gc.root_bead_id IS its own root). Pattern mirrors plan-review-approved.sh.
+set -euo pipefail
+
+fail() {
+    # Machine-readable refusal on stderr; the operator records it as the halt diagnostic.
+    echo "decompose inputs unresolved: $*" >&2
+    exit 1
+}
+
+BEAD_ID="${GC_BEAD_ID:-}"
+[ -n "$BEAD_ID" ] || fail "GC_BEAD_ID not set — cannot resolve workflow root (fail-closed)"
+command -v bd >/dev/null 2>&1 || fail "bd not on PATH (fail-closed)"
+command -v jq >/dev/null 2>&1 || fail "jq not on PATH (fail-closed)"
+
+meta_field() {
+    # meta_field <json> <key> -> metadata[key] or empty (handles array-or-object `bd show` output)
+    printf '%s\n' "$1" | jq -r --arg k "$2" '
+        (if type == "array" then (.[0] // {}) else . end) | (.metadata[$k] // "")
+    ' 2>/dev/null || true
+}
+
+# --- resolve the workflow ROOT bead ------------------------------------------
+BEAD_JSON=$(bd show "$BEAD_ID" --json 2>/dev/null || true)
+[ -n "$BEAD_JSON" ] || fail "bd show $BEAD_ID returned nothing — bead unreadable (fail-closed)"
+ROOT_ID=$(meta_field "$BEAD_JSON" "gc.root_bead_id")
+[ -n "$ROOT_ID" ] || ROOT_ID="$BEAD_ID"   # no root ref => the bead is its own workflow root
+
+if [ "$ROOT_ID" = "$BEAD_ID" ]; then
+    ROOT_JSON="$BEAD_JSON"
+else
+    ROOT_JSON=$(bd show "$ROOT_ID" --json 2>/dev/null || true)
+    [ -n "$ROOT_JSON" ] || fail "bd show root $ROOT_ID returned nothing — workflow root unreadable (fail-closed)"
+fi
+
+# --- assert BOTH decompose inputs are present + non-empty on the root ---------
+# Each key: gc.build.<k> is authoritative; fall back to gc.var.<k> (launch var).
+PLAN_PATH=$(meta_field "$ROOT_JSON" "gc.build.plan_path")
+[ -n "$PLAN_PATH" ] || PLAN_PATH=$(meta_field "$ROOT_JSON" "gc.var.plan_path")
+PLAN_REVIEW_PATH=$(meta_field "$ROOT_JSON" "gc.build.plan_review_path")
+[ -n "$PLAN_REVIEW_PATH" ] || PLAN_REVIEW_PATH=$(meta_field "$ROOT_JSON" "gc.var.plan_review_path")
+
+MISSING=""
+[ -n "$PLAN_PATH" ] || MISSING="plan_path"
+if [ -z "$PLAN_REVIEW_PATH" ]; then
+    [ -z "$MISSING" ] && MISSING="plan_review_path" || MISSING="$MISSING, plan_review_path"
+fi
+
+[ -z "$MISSING" ] \
+    || fail "root=$ROOT_ID missing/empty: $MISSING (plan_path='$PLAN_PATH' plan_review_path='$PLAN_REVIEW_PATH'); decompose halts — its inputs were never promoted to the workflow root."
+
+# --- happy path — decompose inputs resolved ----------------------------------
+echo "decompose inputs present on workflow root $ROOT_ID: plan_path=$PLAN_PATH plan_review_path=$PLAN_REVIEW_PATH. Decompose may proceed."
+exit 0

--- a/gascity/assets/scripts/checks/plan-review-approved.sh
+++ b/gascity/assets/scripts/checks/plan-review-approved.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Decompose plan-review-approved PRECONDITION guard (canonical; platform bug dip-duj3e6).
+#
+# Makes CODED the fail-safe that was EMERGENT on 2026-08-03: the compound-build decompose step gated
+# only on `needs=["plan-review"]` (step-DONE, not outcome) + a post-output build-artifact-valid.sh
+# check on its OWN output — NO input-status gate. When the plan-review loop hard-failed (6/6 native
+# cap, plan NOT approved) the decompose edge still released and a task-decomposer went active; only
+# the decomposer AGENT's judgment refused. This makes it CODE: hard-refuse to decompose unless the
+# plan-review terminated APPROVED on the workflow ROOT bead. Fail-CLOSED (default-deny).
+#
+# This is the check predicate for the `plan-review-approved-gate` operator step (build-base.formula.toml,
+# build-from-plan-base.formula.toml). The GATE, not this script, owns the barrier: on a non-zero exit the
+# gate step is left OPEN and BLOCKED (never closed), so the plain `blocks` edge to decompose never fires
+# and the task-decomposer cannot activate on an unapproved plan. The proven DIP rig interim (dip-b78hkn)
+# validated this exact mechanism; this is its canonical promotion.
+#
+# PREDICATE (pass iff BOTH hold):
+#   1. gc.build.plan_review_status == "approved" on the workflow-ROOT bead, AND
+#   2. no plan-review loop/finalize bead under that root recorded gc.outcome=fail.
+# Any non-approved / MISSING / unreadable status, or a failing plan-review loop => hard refuse
+# (exit non-zero). The gate operator interprets that exit and holds the gate blocked-open.
+#
+# SOURCE OF TRUTH: gc.build.plan_review_status on the workflow-ROOT bead, resolved via gc.root_bead_id
+# on the running step (a bead with no gc.root_bead_id IS its own root). NEVER the per-iteration
+# plan-review report artifact — mid-loop it reads draft/pass and is the stale-status trap.
+#
+# Mirror of design-review-approved.sh (which gates the plan-review LOOP by reading design_review.verdict);
+# this gates the DECOMPOSE step by reading gc.build.plan_review_status on the workflow ROOT.
+set -euo pipefail
+
+fail() {
+    # Machine-readable refusal on stderr; the dispatcher records it as attempt context.
+    echo "decompose precondition FAILED: $*" >&2
+    exit 1
+}
+
+BEAD_ID="${GC_BEAD_ID:-}"
+[ -n "$BEAD_ID" ] || fail "GC_BEAD_ID not set — cannot resolve workflow root (fail-closed)"
+command -v bd >/dev/null 2>&1 || fail "bd not on PATH (fail-closed)"
+command -v jq >/dev/null 2>&1 || fail "jq not on PATH (fail-closed)"
+
+meta_field() {
+    # meta_field <json> <key> -> metadata[key] or empty (handles array-or-object `bd show` output)
+    printf '%s\n' "$1" | jq -r --arg k "$2" '
+        (if type == "array" then (.[0] // {}) else . end) | (.metadata[$k] // "")
+    ' 2>/dev/null || true
+}
+
+# --- resolve the workflow ROOT bead ------------------------------------------
+BEAD_JSON=$(bd show "$BEAD_ID" --json 2>/dev/null || true)
+[ -n "$BEAD_JSON" ] || fail "bd show $BEAD_ID returned nothing — bead unreadable (fail-closed)"
+ROOT_ID=$(meta_field "$BEAD_JSON" "gc.root_bead_id")
+[ -n "$ROOT_ID" ] || ROOT_ID="$BEAD_ID"   # no root ref => the bead is its own workflow root
+
+if [ "$ROOT_ID" = "$BEAD_ID" ]; then
+    ROOT_JSON="$BEAD_JSON"
+else
+    ROOT_JSON=$(bd show "$ROOT_ID" --json 2>/dev/null || true)
+    [ -n "$ROOT_JSON" ] || fail "bd show root $ROOT_ID returned nothing — workflow root unreadable (fail-closed)"
+fi
+
+# --- gate 1: AUTHORITATIVE plan-review status on the workflow root ------------
+PLAN_REVIEW_STATUS=$(meta_field "$ROOT_JSON" "gc.build.plan_review_status")
+[ -n "$PLAN_REVIEW_STATUS" ] || PLAN_REVIEW_STATUS="MISSING"
+[ "$PLAN_REVIEW_STATUS" = "approved" ] \
+    || fail "root=$ROOT_ID plan_review_status=$PLAN_REVIEW_STATUS, plan NOT approved — decompose refused, build halts at plan-review."
+
+# --- gate 2 (hardening): refuse if a plan-review loop/finalize bead failed ----
+# The plan-review finalize/loop beads carry gc.step_ref ending in ".plan-review" (the finalize, e.g.
+# "compound-build.plan-review") or the "...plan-review...loop" scope (the loop bead); per-iteration and
+# *.spec beads are excluded. If any recorded gc.outcome=fail the loop did not converge — refuse even if
+# the status field somehow reads approved (defense-in-depth for the stale-status trap). Generalized
+# across methodology packs (build-base / compound-build / ...), not pinned to one loop name.
+LOOP_FAIL=$(bd list --all --metadata-field "gc.root_bead_id=$ROOT_ID" --json --limit=0 2>/dev/null \
+    | jq -r '
+        (if type == "array" then . else [.] end)
+        | [ .[]
+            | .metadata as $m
+            | (($m["gc.step_ref"] // "")) as $sr
+            | select(
+                ($sr | endswith(".plan-review"))
+                or ($sr == "plan-review")
+                or ( ($sr | contains(".plan-review."))
+                     and ($sr | contains("loop"))
+                     and (($sr | contains("iteration")) | not)
+                     and (($sr | endswith(".spec")) | not) )
+              )
+            | select((($m["gc.outcome"] // "")) == "fail")
+            | .id
+          ] | (first // "")
+    ' 2>/dev/null || true)
+
+[ -z "$LOOP_FAIL" ] \
+    || fail "plan-review loop bead $LOOP_FAIL recorded gc.outcome=fail on root $ROOT_ID — plan-review did not converge, decompose refused, build halts at plan-review."
+
+# --- SILENT-ON-APPROVED: happy path — decompose proceeds unchanged ------------
+echo "decompose precondition OK: plan_review_status=approved on workflow root $ROOT_ID; no plan-review loop failure. Decompose may proceed."
+exit 0

--- a/gascity/assets/workflows/build-base/plan-review-approved-gate.md
+++ b/gascity/assets/workflows/build-base/plan-review-approved-gate.md
@@ -1,0 +1,54 @@
+Enforce the build's plan-review approval precondition before decomposition.
+This is the canonical outcome-aware decompose gate (platform bug dip-duj3e6):
+do not invoke the task decomposer until the workflow root records an approved
+plan review. On refusal this gate deliberately stays OPEN and BLOCKED — because
+the decompose controller (and its iteration) depend on this still-open gate, the
+task-decomposer never runs and cannot create an orphan convoy or work beads.
+
+The claimed bead id is `$GC_BEAD_ID`. Run
+`.gc/scripts/checks/plan-review-approved.sh` with that environment unchanged and
+capture its exit code and single-line diagnostic output. Record the current UTC
+timestamp. Never rewrite or bypass the guard.
+
+If the script exits 0, update only the claimed gate bead with
+`gc.outcome=pass`, `gc.build.plan_review_gate_decision=approved`, and
+`gc.build.plan_review_gate_checked_at=<UTC timestamp>`. Close the gate bead with
+reason `plan review approved; decomposition released`, read it back, and verify
+it is closed with `gc.outcome=pass`. The decompose controller and iteration may
+become ready only after this close. Do not create a report artifact on the
+approved path. Your exact final action must be `gc runtime drain-ack`; emit no
+text after it.
+
+If the script exits non-zero, extract `plan_review_status=<value>` from the guard
+diagnostic, using `MISSING` when it cannot be read. Build this refusal reason:
+
+`decompose refused: plan_review_status=<value>, plan NOT approved — build halts at plan-review`
+
+Update only the claimed gate bead with all of the following in one operation:
+
+- status `blocked`
+- `gc.outcome=blocked`
+- `gc.failure_class=plan-review-not-approved`
+- `gc.build.plan_review_gate_decision=refused`
+- `gc.build.plan_review_gate_checked_at=<UTC timestamp>`
+- `gc.build.plan_review_gate_diagnostic=<single-line guard diagnostic>`
+- append the exact refusal reason to the bead notes
+
+Read the claimed gate bead back and verify it is `status=blocked`, is not
+closed, and records the refusal decision. If that read-back fails, leave the
+gate unclosed and page the mayor with the verification failure.
+
+Page the mayor with subject `BLOCKED: decompose plan-review gate refused` and a
+body containing the gate bead id, workflow-root id, refusal reason, and guard
+diagnostic. The message is required evidence that the fail-closed path fired.
+
+On the refused path, do NOT close the gate bead, do NOT return a failing exit,
+and do NOT update or close any decompose controller or iteration bead. The open,
+blocked gate is the barrier: both decompose beads depend on it and therefore
+remain blocked. Do not create or route a replacement decomposition bead,
+implementation convoy, or work bead. Your exact final action must be
+`gc runtime drain-ack`; emit no text after it.
+
+Use `gc bd update <id> --set-metadata key=value` for metadata and `--status
+blocked` for the refusal state. Close with `gc bd close <id> --reason <reason>`
+only on the approved path. Do not invoke provider-native subagents.

--- a/gascity/assets/workflows/build-base/plan-review.md
+++ b/gascity/assets/workflows/build-base/plan-review.md
@@ -3,3 +3,10 @@ This is the `build-base` plan-review stage. Treat it as a virtual contract that 
 Review the plan for traceability to requirements, feasibility, missing edge cases, and implementation readiness. If changes are required, update or route the plan before closing this stage.
 
 Close this step only when the plan is approved or the blocking issues are recorded in the step summary.
+
+On approval, PROMOTE the plan-review artifact path to the workflow root so the
+downstream decompose stage can read it at runtime (symmetric with
+`gc.build.plan_path`; dip-5hkepo). Record the absolute path of the plan-review
+artifact you produced:
+`bd update "<workflow-root-id>" --set-metadata "gc.build.plan_review_path=<absolute path>" --set-metadata "gc.var.plan_review_path=<absolute path>"`.
+Do not use `bd update --metadata 'key=value'`; `--metadata` only accepts a JSON object.

--- a/gascity/assets/workflows/build-from-decompose-base/decompose.md
+++ b/gascity/assets/workflows/build-from-decompose-base/decompose.md
@@ -1,6 +1,10 @@
 This is the `build-from-decompose-base` decomposition stage.
 
-Read the approved requirements from `{{requirements_path}}`, the approved implementation plan from `{{plan_path}}`, and the plan-review verdict from `{{plan_review_path}}`. Use the selected decomposition methodology `{{decomposition_formula}}` when translating the plan into durable work items.
+Read the approved requirements from `{{requirements_path}}` (provided at launch, so its interpolation is stable).
+
+Resolve the approved implementation plan and the plan-review artifact at RUNTIME from the workflow ROOT var store — do NOT rely on the instantiation-frozen `{{plan_path}}`/`{{plan_review_path}}`. Those render at instantiation, before the plan and plan-review stages produce their paths, so when the paths are produced mid-flow they freeze EMPTY (dip-5hkepo). By the time this step is claimable the producing stages have promoted the real paths to the workflow root (plan via the plan stage, plan-review via the plan-review stage). Run `bd show "<workflow-root-id>" --json` and read `gc.build.plan_path` (fallback `gc.var.plan_path`) for the approved implementation plan and `gc.build.plan_review_path` (fallback `gc.var.plan_review_path`) for the plan-review verdict. Resolve `<workflow-root-id>` via `gc.root_bead_id` on this step bead (a bead with no `gc.root_bead_id` is its own workflow root).
+
+Use the selected decomposition methodology `{{decomposition_formula}}` when translating the plan into durable work items.
 
 Create or adopt an implementation convoy for the work units. The convoy must contain only runnable implementation beads for this continuation; do not reuse any original request, planning, or workflow-control convoy.
 

--- a/gascity/assets/workflows/build-from-decompose-base/prepare-decompose.md
+++ b/gascity/assets/workflows/build-from-decompose-base/prepare-decompose.md
@@ -1,25 +1,51 @@
-This is the `build-from-decompose-base` decompose handoff step.
+This is the `build-from-decompose-base` decompose handoff step. It is the
+FAIL-LOUD guard for decompose inputs (dip-5hkepo): decompose must never run on
+empty plan_path / plan_review_path.
 
 Concrete rule: concrete methodology packs extend this base rather than copying the suffix graph.
 
-Validate the prerequisite inputs before any side effects:
+Validate the prerequisite inputs before any side effects. `artifact_root`,
+`context_path`, `requirements_path`, `decomposition_path`,
+`decomposition_formula`, `drain_policy`, `interaction_mode`, and `review_mode`
+are provided-upfront launch inputs. Resolve `plan_path` and `plan_review_path` at
+RUNTIME from the workflow ROOT var store — do NOT trust the instantiation-frozen
+`{{plan_path}}`/`{{plan_review_path}}`. Resolve `<workflow-root-id>` via
+`gc.root_bead_id` on this step bead (a bead with no `gc.root_bead_id` is its own
+root).
 
-- artifact_root: {{artifact_root}}
-- context_path: {{context_path}}
-- requirements_path: {{requirements_path}}
-- plan_path: {{plan_path}}
-- plan_review_path: {{plan_review_path}}
-- decomposition_path: {{decomposition_path}}
-- decomposition_formula: {{decomposition_formula}}
-- drain_policy: {{drain_policy}}
-- interaction_mode: {{interaction_mode}}
-- review_mode: {{review_mode}}
-
-Do not rerun requirements, plan, or plan-review. This continuation is valid
+The claimed bead id is `$GC_BEAD_ID`. Run
+`.gc/scripts/checks/decompose-inputs-present.sh` with that environment unchanged
+and capture its exit code and single-line diagnostic. Never rewrite or bypass the
+guard. Do not rerun requirements, plan, or plan-review. This continuation is valid
 only when the supplied requirements, implementation plan, and plan-review
 artifacts exist and the plan-review artifact records approval or an equivalent
 pass verdict.
 
-Record `gc.build.continuation_entrypoint=decompose` when this suffix is
-launched directly. Close only after the decompose stage can create or reuse the
-decomposition artifact and implementation convoy.
+If the script exits 0 (both `gc.build.plan_path` and `gc.build.plan_review_path`
+are present and non-empty on the root — fallbacks `gc.var.plan_path` /
+`gc.var.plan_review_path`), record
+`gc.build.continuation_entrypoint=decompose` when this suffix is launched
+directly, set the claimed step `gc.outcome=pass`, and close it only after the
+decompose stage can create or reuse the decomposition artifact and implementation
+convoy.
+
+If the script exits non-zero, DO NOT close this step. The build halts loudly here
+so the task-decomposer never activates on empty inputs. Update only the claimed
+step, in one operation, with:
+
+- status `blocked`
+- `gc.outcome=blocked`
+- `gc.failure_class=decompose-inputs-unresolved`
+- append the guard's single-line diagnostic to the bead notes
+
+Read the claimed step back and verify it is `status=blocked` and is NOT closed.
+Then page the mayor with subject `BLOCKED: decompose inputs unresolved` and a body
+containing the step bead id, workflow-root id, and the guard diagnostic. The open,
+blocked step is the barrier: the decompose beads depend on it and therefore remain
+blocked. Do NOT create or route a replacement decomposition bead, implementation
+convoy, or work bead.
+
+Use `gc bd update <id> --set-metadata key=value` for metadata and `--status
+blocked` for the halt state. Close with `gc bd close <id> --reason <reason>` only
+on the inputs-present path. Do not invoke provider-native subagents. Your exact
+final action must be `gc runtime drain-ack`; emit no text after it.

--- a/gascity/assets/workflows/build-from-plan-base/plan-review-approved-gate.md
+++ b/gascity/assets/workflows/build-from-plan-base/plan-review-approved-gate.md
@@ -1,4 +1,4 @@
-This is the `build-base` plan-review-approved-gate stage. Treat it as a virtual contract that concrete formulas may override.
+This is the `build-from-plan-base` plan-review-approved-gate stage.
 
 Enforce the build's plan-review approval precondition before decomposition.
 This is the canonical outcome-aware decompose gate (platform bug dip-duj3e6):

--- a/gascity/assets/workflows/build-from-plan-base/plan-review.md
+++ b/gascity/assets/workflows/build-from-plan-base/plan-review.md
@@ -4,7 +4,23 @@ Review the implementation plan before decomposition. The verdict must map to
 approved, questions, changes_required, or blocked, and it must honor
 interaction_mode {{interaction_mode}}.
 
-Write the plan-review artifact to `{{plan_review_path}}` when supplied;
-otherwise write it under `{{artifact_root}}`. Close only after an approved or
-equivalent pass verdict is recorded, or after a blocked/changes-required verdict
-is recorded with a concrete reason.
+Write the plan-review artifact to `{{plan_review_path}}` when a concrete path was
+supplied at launch; otherwise write it to a deterministic path under the artifact
+root, `{{artifact_root}}/plan-review/report.md`. (`plan_review_path` is produced
+by this stage, so at launch it is typically empty — do not treat the empty
+interpolation as a real path.)
+
+Close only after an approved or equivalent pass verdict is recorded, or after a
+blocked/changes-required verdict is recorded with a concrete reason.
+
+Before closing, PROMOTE the plan-review artifact path to the workflow root so the
+downstream decompose stage can read it at runtime (symmetric with
+`gc.build.plan_path`; dip-5hkepo). Record the absolute path you actually wrote:
+
+`bd update "<workflow-root-id>" --set-metadata "gc.build.plan_review_path=<absolute path>" --set-metadata "gc.var.plan_review_path=<absolute path>"`
+
+Do not use `bd update --metadata 'key=value'`; `--metadata` only accepts a JSON
+object. Before closing this step, set the claimed step outcome with
+`bd update "<claimed-step-id>" --set-metadata "gc.outcome=pass"`, then close with
+`bd close "<claimed-step-id>" --reason "<concise reason>"`. Do not pass
+`--metadata` or `--set-metadata` to `bd close`.

--- a/gascity/assets/workflows/build-from-plan-base/prepare-decompose.md
+++ b/gascity/assets/workflows/build-from-plan-base/prepare-decompose.md
@@ -1,9 +1,46 @@
 This is the `build-from-plan-base` handoff into the inherited decompose suffix.
+It is the FAIL-LOUD guard for decompose inputs (dip-5hkepo): decompose must never
+run on empty plan_path / plan_review_path.
 
-Validate that the plan and plan-review artifacts now exist, that the
-plan-review verdict approves decomposition, and that downstream decompose
-selectors are present.
+Resolve the decompose inputs at RUNTIME from the workflow ROOT var store — do NOT
+trust the instantiation-frozen `{{plan_path}}`/`{{plan_review_path}}`, which mint
+empty when the plan/plan-review stages produce their paths mid-flow. Resolve
+`<workflow-root-id>` via `gc.root_bead_id` on this step bead (a bead with no
+`gc.root_bead_id` is its own root).
 
-Do not create implementation beads in this handoff step. Close only after the
-inherited `build-from-decompose-base` suffix has the approved plan inputs it
-requires.
+The claimed bead id is `$GC_BEAD_ID`. Run
+`.gc/scripts/checks/decompose-inputs-present.sh` with that environment unchanged
+and capture its exit code and single-line diagnostic. Never rewrite or bypass the
+guard. Do not create implementation beads in this handoff step.
+
+If the script exits 0 (both `gc.build.plan_path` and `gc.build.plan_review_path`
+are present and non-empty on the root — fallbacks `gc.var.plan_path` /
+`gc.var.plan_review_path`), the plan and plan-review artifacts exist and the
+plan-review verdict already approved decomposition (the upstream
+plan-review-approved gate enforced that). Set the claimed step
+`gc.outcome=pass` and close it with reason
+`decompose inputs resolved on root; handoff complete`. The inherited
+`build-from-decompose-base` decompose suffix may become ready only after this
+close.
+
+If the script exits non-zero, DO NOT close this step. The build halts loudly
+here so the task-decomposer never activates on empty inputs. Update only the
+claimed step, in one operation, with:
+
+- status `blocked`
+- `gc.outcome=blocked`
+- `gc.failure_class=decompose-inputs-unresolved`
+- append the guard's single-line diagnostic to the bead notes
+
+Read the claimed step back and verify it is `status=blocked` and is NOT closed.
+Then page the mayor with subject
+`BLOCKED: decompose inputs unresolved` and a body containing the step bead id,
+workflow-root id, and the guard diagnostic. The open, blocked step is the
+barrier: the inherited decompose beads depend on it and therefore remain blocked.
+Do NOT create or route a replacement decomposition bead, implementation convoy,
+or work bead.
+
+Use `gc bd update <id> --set-metadata key=value` for metadata and `--status
+blocked` for the halt state. Close with `gc bd close <id> --reason <reason>` only
+on the inputs-present path. Do not invoke provider-native subagents. Your exact
+final action must be `gc runtime drain-ack`; emit no text after it.

--- a/gascity/formulas/build-base.formula.toml
+++ b/gascity/formulas/build-base.formula.toml
@@ -150,13 +150,24 @@ timeout = "5m"
 id = "plan-review"
 title = "Review implementation plan"
 needs = ["plan"]
-metadata = { "gc.run_target" = "gc.review-synthesizer" }
+metadata = { "gc.run_target" = "gc.review-synthesizer", "gc.build.artifact_path_keys" = "gc.build.plan_review_path,gc.var.plan_review_path" }
 description_file = "../assets/workflows/build-base/plan-review.md"
+
+# Outcome-aware decompose gate (dip-duj3e6): an operator step between plan-review
+# and decompose. On refusal it stays OPEN and BLOCKED (never closed), so the
+# plain `blocks` edge to decompose never releases and the task-decomposer cannot
+# activate on an unapproved plan. Proven live as the dip-b78hkn rig interim.
+[[steps]]
+id = "plan-review-approved-gate"
+title = "Require approved plan review before decomposition"
+needs = ["plan-review"]
+metadata = { "gc.run_target" = "gc.run-operator" }
+description_file = "../assets/workflows/build-base/plan-review-approved-gate.md"
 
 [[steps]]
 id = "decompose"
 title = "Decompose approved plan"
-needs = ["plan-review"]
+needs = ["plan-review-approved-gate"]
 metadata = { "gc.run_target" = "gc.task-decomposer", "gc.build.artifact_schema" = "gc.build.decomposition.v1", "gc.build.artifact_path_keys" = "gc.build.decomposition_path,gc.var.decomposition_path" }
 description_file = "../assets/workflows/build-base/decompose.md"
 

--- a/gascity/formulas/build-from-plan-base.formula.toml
+++ b/gascity/formulas/build-from-plan-base.formula.toml
@@ -56,12 +56,23 @@ timeout = "5m"
 id = "plan-review"
 title = "Review implementation plan"
 needs = ["plan"]
-metadata = { "gc.run_target" = "gc.review-synthesizer" }
+metadata = { "gc.run_target" = "gc.review-synthesizer", "gc.build.artifact_path_keys" = "gc.build.plan_review_path,gc.var.plan_review_path" }
 description_file = "../assets/workflows/build-from-plan-base/plan-review.md"
+
+# Outcome-aware decompose gate (dip-duj3e6): interposed between plan-review and
+# the decompose handoff. On refusal it stays OPEN and BLOCKED (never closed), so
+# prepare-decompose/decompose never release and the task-decomposer cannot
+# activate on an unapproved plan. Shares the build-base gate asset + check script.
+[[steps]]
+id = "plan-review-approved-gate"
+title = "Require approved plan review before decomposition"
+needs = ["plan-review"]
+metadata = { "gc.run_target" = "gc.run-operator" }
+description_file = "../assets/workflows/build-base/plan-review-approved-gate.md"
 
 [[steps]]
 id = "prepare-decompose"
 title = "Validate decompose continuation inputs"
-needs = ["plan-review"]
+needs = ["plan-review-approved-gate"]
 metadata = { "gc.run_target" = "gc.run-operator" }
 description_file = "../assets/workflows/build-from-plan-base/prepare-decompose.md"

--- a/gascity/formulas/build-from-plan-base.formula.toml
+++ b/gascity/formulas/build-from-plan-base.formula.toml
@@ -62,13 +62,14 @@ description_file = "../assets/workflows/build-from-plan-base/plan-review.md"
 # Outcome-aware decompose gate (dip-duj3e6): interposed between plan-review and
 # the decompose handoff. On refusal it stays OPEN and BLOCKED (never closed), so
 # prepare-decompose/decompose never release and the task-decomposer cannot
-# activate on an unapproved plan. Shares the build-base gate asset + check script.
+# activate on an unapproved plan. Carries its own gate asset (shadowable per
+# build-from-plan-base) and reuses the shared plan-review-approved.sh check script.
 [[steps]]
 id = "plan-review-approved-gate"
 title = "Require approved plan review before decomposition"
 needs = ["plan-review"]
 metadata = { "gc.run_target" = "gc.run-operator" }
-description_file = "../assets/workflows/build-base/plan-review-approved-gate.md"
+description_file = "../assets/workflows/build-from-plan-base/plan-review-approved-gate.md"
 
 [[steps]]
 id = "prepare-decompose"

--- a/gascity/tests/test_formula_assets.py
+++ b/gascity/tests/test_formula_assets.py
@@ -83,6 +83,7 @@ BUILD_BASE_STEPS = [
     "requirements",
     "plan",
     "plan-review",
+    "plan-review-approved-gate",
     "decompose",
     "implement",
     "implement-same-session",
@@ -115,6 +116,7 @@ BUILD_FROM_PLAN_STEPS = BUILD_FROM_DECOMPOSE_STEPS | {
     "prepare-plan",
     "plan",
     "plan-review",
+    "plan-review-approved-gate",
 }
 
 BUILD_FROM_REQUIREMENTS_STEPS = BUILD_FROM_PLAN_STEPS | {
@@ -1743,7 +1745,8 @@ class FormulaAssetTests(unittest.TestCase):
         self.assertEqual(steps["prepare-plan"]["needs"], ["requirements"])
         self.assertEqual(steps["plan"]["needs"], ["prepare-plan"])
         self.assertEqual(steps["plan-review"]["needs"], ["plan"])
-        self.assertEqual(steps["prepare-decompose"]["needs"], ["plan-review"])
+        self.assertEqual(steps["plan-review-approved-gate"]["needs"], ["plan-review"])
+        self.assertEqual(steps["prepare-decompose"]["needs"], ["plan-review-approved-gate"])
         self.assertEqual(steps["decompose"]["needs"], ["prepare-decompose"])
         self.assertEqual(steps["prepare-convoy"]["needs"], ["decompose"])
         self.assertEqual(steps["implement"]["needs"], ["prepare-convoy"])
@@ -3987,9 +3990,11 @@ description = "Override sink that writes the base triage report contract."
             [script.name for script in scripts],
             [
                 "build-artifact-valid.sh",
+                "decompose-inputs-present.sh",
                 "design-review-approved.sh",
                 "gap-analysis-approved.sh",
                 "implementation-review-approved.sh",
+                "plan-review-approved.sh",
             ],
         )
         for script in scripts:


### PR DESCRIPTION
## Canonical decompose-stage hardening: outcome-aware plan-review gate + runtime artifact-path resolution

Fixes two related correctness bugs in the `build-base` / `build-from-plan-base` decompose stage, both proven live before this PR.

### Bug 1 — outcome-blind decompose release
The `finalize → decompose` dependency was a plain `blocks` edge that released the decompose step whenever plan-review **closed**, regardless of `gc.outcome`. A FAILED/exhausted plan-review (plan not approved) still unblocked decompose → a task-decomposer could activate on an unapproved plan. Harm was previously averted only by the decomposer agent's *emergent* refusal — not a coded guarantee.

**Fix:** interpose a `plan-review-approved-gate` operator step (`needs = ["plan-review"]`) before decompose/prepare-decompose. On refusal the gate sets `status blocked` / `gc.outcome=blocked` and **does not close** — so the plain `blocks` edge never releases decompose (engine-enforced). On approval it closes and releases. This is a canonical port of a mechanism proven live against failed-path fixtures. `compound-build` inherits the gate via `extends` with zero edit.

Adjudicated over a `steps.check` alternative deliberately: a `steps.check` deterministically exhausts → closes-fail → *releases* downstream, which would reintroduce this exact bug. The blocked-open operator gate is the correct pattern.

### Bug 2 — decompose mints empty artifact paths
Step descriptions are rendered once at graph instantiation, before upstream steps run. `decompose`/`prepare-decompose` interpolated `{{plan_path}}`/`{{plan_review_path}}` at that point — but those paths are produced mid-flow, and `plan-review` never promoted `plan_review_path` to the workflow root, so decompose froze with empty paths and required a manual re-mint.

**Fix:** (a) `plan-review` now promotes `plan_review_path` to the workflow **root** (`artifact_path_keys` + asset instruction, symmetric with `plan_path`); (b) `decompose`/`prepare-decompose` **read the paths from the root at runtime** (`gc.root_bead_id`, `gc.build.*` with `gc.var.*` fallback) instead of the instantiation-frozen `{{}}`; (c) `prepare-decompose` is a fail-loud blocked-open guard (`decompose-inputs-present.sh`) that refuses (stays blocked, never closes) if either path is absent/empty — no silent empty decompose. (d) The compound-plan-review finalize now writes `plan_review_status=failed` + `plan_status=failed` + `gc.outcome=fail` on the fail branch, so status is honest (approved XOR failed).

### Change size
Production (formula TOML + prompt/shell assets, **zero Go**): ~477 lines across 12 files — the gate step + 2 check scripts, per-formula gate assets, runtime-read decompose/prepare-decompose, plan-review promotion, finalize status honesty. Tests: 7 lines (test_formula_assets.py topology fixtures). No generated, no docs.

### Verification
- Behavioral guard proof: 6/6 exit-code assertions (failed→refuse, approved→release, empty→refuse, present→release, stale-approved+loop-fail→refuse).
- `compound-build` inherits the gate via `extends`, zero override.
- Pack asset suite: 0 net-new failures vs base (the 2 failures + 28 errors present on this branch are pre-existing graph.v2 contract-drift in checked-in fixtures, confirmed identical on the base commit).
- Two independent adversarial reviews (correctness / fail-path tracing / happy-path / minimal-delta): both green, no material issues.

Companion PR (gascity-src): a cook-time warning when an `extends` var-override silently drops a parent's `required=true` — surfaces the misconfiguration class behind Bug 2, behavior-preserving.
