### PR TITLE
decompose: stamp gc.routed_to on work-units so they are claimable

### DIFF
--- a/bmad/formulas/bmad-build.formula.toml
+++ b/bmad/formulas/bmad-build.formula.toml
@@ -105,7 +105,7 @@ timeout = "5m"
 [[steps]]
 id = "implementation-readiness"
 title = "BMAD implementation readiness"
-needs = ["decompose"]
+needs = ["route-workunits"]
 metadata = { "gc.run_target" = "bmad.readiness-reviewer" }
 description_file = "../assets/workflows/bmad-build/implementation-readiness.md"
 

--- a/compound-engineering/formulas/compound-build.formula.toml
+++ b/compound-engineering/formulas/compound-build.formula.toml
@@ -91,7 +91,7 @@ description_file = "../assets/workflows/compound-build/plan-review.md"
 [[steps]]
 id = "implement"
 title = "Drain Compound Engineering work"
-needs = ["decompose"]
+needs = ["route-workunits"]
 condition = "{{drain_policy}} == separate"
 metadata = { "gc.run_target" = "{{implementation_target}}" }
 description_file = "../assets/workflows/compound-build/implement.md"
@@ -104,7 +104,7 @@ member_access = "exclusive"
 [[steps]]
 id = "implement-same-session"
 title = "Drain Compound Engineering work in one shared session"
-needs = ["decompose"]
+needs = ["route-workunits"]
 condition = "{{drain_policy}} == same-session"
 metadata = { "gc.run_target" = "{{implementation_target}}" }
 description_file = "../assets/workflows/compound-build/implement-same-session.md"

--- a/gascity/assets/scripts/checks/route-workunits.sh
+++ b/gascity/assets/scripts/checks/route-workunits.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Post-decompose route-stamp gate: makes decomposed work-units CLAIMABLE.
+#
+# Decompose creates the implementation convoy's work-unit beads via ad-hoc
+# `gc bd create` inside the decompose prompt. That path bypasses the
+# formula-graph materializer (which stamps gc.routed_to on graph steps), so the
+# work-units land ready with gc.routed_to AND gc.execution_routed_to both empty.
+# Pool demand keys EXCLUSIVELY on gc.routed_to, so a routeless work-unit is
+# structurally invisible to every pool and sits until a human `gc sling` stamps
+# it -- the manual-sling-per-stage tax that makes builds crawl.
+#
+# This gate closes that gap with a CODED stamp (not "the decomposer agent
+# remembers to set it"): it resolves the implementation convoy and the DECLARED
+# implementation_target off the workflow root, then stamps
+#   gc.routed_to           = <implementation_target>
+#   gc.execution_routed_to = <implementation_target>
+# on every routeless convoy member -- mirroring the formula-graph stamper
+# (internal/dispatch/control.go stamps both keys to `target`). The route is a
+# COPIED declared value, not controller judgment (ZFC): implementation_target is
+# an authored factory var, exactly what the drain step routes to.
+#
+# NO-SILENT-FAILURE: after stamping, every member must carry a route. If
+# implementation_target is undeclared, or any member stays routeless, this gate
+# FAILS LOUDLY (machine-readable stderr, non-zero exit) so the bounded producer
+# repair loop surfaces it in gc.attempt_log instead of leaving work-units to sit
+# invisibly. This gate never prompts. It is idempotent: an already-routed member
+# is left untouched (an explicit route is never clobbered).
+
+fail() {
+  echo "route-workunits-check: $*" >&2
+  exit 1
+}
+
+BEAD_ID="${GC_BEAD_ID:-}"
+[ -n "$BEAD_ID" ] || fail "GC_BEAD_ID is required"
+command -v gc >/dev/null 2>&1 || fail "gc is required on PATH"
+command -v python3 >/dev/null 2>&1 || fail "python3 is required on PATH"
+
+metadata_value() {
+  # metadata_value <json> <key> -> prints metadata[key] or empty
+  printf '%s' "$1" | python3 -c '
+import json
+import sys
+
+key = sys.argv[1]
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    print("")
+    raise SystemExit(0)
+if isinstance(data, list):
+    data = data[0] if data else {}
+if not isinstance(data, dict):
+    print("")
+    raise SystemExit(0)
+metadata = data.get("metadata") or {}
+value = metadata.get(key, "") if isinstance(metadata, dict) else ""
+print(value if isinstance(value, str) else "")
+' "$2"
+}
+
+packed_var() {
+  # packed_var <root-json> <var-name> -> prints the var from gc.graphv2_vars.v1
+  # (the packed runtime-vars JSON object {name: value}), or empty.
+  printf '%s' "$1" | python3 -c '
+import json
+import sys
+
+name = sys.argv[1]
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    print("")
+    raise SystemExit(0)
+if isinstance(data, list):
+    data = data[0] if data else {}
+if not isinstance(data, dict):
+    print("")
+    raise SystemExit(0)
+metadata = data.get("metadata") or {}
+raw = metadata.get("gc.graphv2_vars.v1", "") if isinstance(metadata, dict) else ""
+if not isinstance(raw, str) or not raw.strip():
+    print("")
+    raise SystemExit(0)
+try:
+    packed = json.loads(raw)
+except Exception:
+    print("")
+    raise SystemExit(0)
+value = packed.get(name, "") if isinstance(packed, dict) else ""
+print(value if isinstance(value, str) else "")
+' "$2"
+}
+
+convoy_child_ids() {
+  # convoy_child_ids <convoy-status-json> -> prints each child id, one per line
+  printf '%s' "$1" | python3 -c '
+import json
+import sys
+
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    raise SystemExit(0)
+if not isinstance(data, dict):
+    raise SystemExit(0)
+for child in data.get("children") or []:
+    if isinstance(child, dict):
+        cid = child.get("id", "")
+        if isinstance(cid, str) and cid:
+            print(cid)
+'
+}
+
+SHOW_JSON="$(gc bd show "$BEAD_ID" --json 2>/dev/null)" || fail "gc bd show $BEAD_ID failed"
+
+ROOT_ID="$(metadata_value "$SHOW_JSON" "gc.root_bead_id")"
+ROOT_JSON="$SHOW_JSON"
+if [ -n "$ROOT_ID" ] && [ "$ROOT_ID" != "$BEAD_ID" ]; then
+  ROOT_JSON="$(gc bd show "$ROOT_ID" --json 2>/dev/null)" || fail "gc bd show $ROOT_ID failed"
+fi
+ROOT_LABEL="${ROOT_ID:-$BEAD_ID}"
+
+CONVOY_ID="$(metadata_value "$ROOT_JSON" "gc.build.implementation_convoy_id")"
+[ -n "$CONVOY_ID" ] || CONVOY_ID="$(metadata_value "$ROOT_JSON" "gc.input_convoy_id")"
+[ -n "$CONVOY_ID" ] || fail "no implementation convoy recorded on root $ROOT_LABEL (gc.build.implementation_convoy_id and gc.input_convoy_id both empty); decompose must record the convoy before work-units can be routed"
+
+TARGET="$(metadata_value "$ROOT_JSON" "gc.var.implementation_target")"
+[ -n "$TARGET" ] || TARGET="$(packed_var "$ROOT_JSON" "implementation_target")"
+[ -n "$TARGET" ] || fail "no implementation_target declared on root $ROOT_LABEL (gc.var.implementation_target and gc.graphv2_vars.v1 both empty); cannot route decomposed work-units -- they would sit unclaimable"
+
+CONVOY_JSON="$(gc convoy status "$CONVOY_ID" --json 2>/dev/null)" || fail "gc convoy status $CONVOY_ID failed"
+MEMBERS="$(convoy_child_ids "$CONVOY_JSON")"
+
+TOTAL=0
+STAMPED=0
+while IFS= read -r member; do
+  [ -n "$member" ] || continue
+  TOTAL=$((TOTAL + 1))
+  MEMBER_JSON="$(gc bd show "$member" --json 2>/dev/null)" || fail "gc bd show $member failed"
+  ROUTE="$(metadata_value "$MEMBER_JSON" "gc.routed_to")"
+  if [ -z "$ROUTE" ]; then
+    gc bd update "$member" \
+      --set-metadata "gc.routed_to=$TARGET" \
+      --set-metadata "gc.execution_routed_to=$TARGET" >/dev/null 2>&1 \
+      || fail "failed to stamp gc.routed_to=$TARGET on work-unit $member"
+    STAMPED=$((STAMPED + 1))
+  fi
+done <<EOF
+$MEMBERS
+EOF
+
+if [ "$TOTAL" -eq 0 ]; then
+  # Decompose is contracted to never create an empty implementation convoy; a
+  # zero-member convoy is the decomposition artifact gate's concern, not this
+  # gate's. Nothing to route -- pass without inventing a failure.
+  echo "route-workunits: convoy=$CONVOY_ID target=$TARGET members=0 (nothing to route)"
+  exit 0
+fi
+
+# NO-SILENT-FAILURE verify: re-read every member; each must now carry a route.
+UNROUTED=""
+while IFS= read -r member; do
+  [ -n "$member" ] || continue
+  MEMBER_JSON="$(gc bd show "$member" --json 2>/dev/null)" || fail "gc bd show $member failed"
+  ROUTE="$(metadata_value "$MEMBER_JSON" "gc.routed_to")"
+  [ -n "$ROUTE" ] || UNROUTED="$UNROUTED $member"
+done <<EOF
+$MEMBERS
+EOF
+[ -z "$UNROUTED" ] || fail "work-units remain routeless after stamping (would sit unclaimable, invisible to every pool):$UNROUTED"
+
+echo "route-workunits: convoy=$CONVOY_ID target=$TARGET members=$TOTAL stamped=$STAMPED (all claimable)"
+exit 0

--- a/gascity/assets/workflows/build-base/route-workunits.md
+++ b/gascity/assets/workflows/build-base/route-workunits.md
@@ -1,0 +1,19 @@
+This is the `build-base` route-workunits stage. Treat it as a virtual contract that concrete formulas may override.
+
+The decomposition stage created the implementation convoy and its work-unit
+beads, but ad-hoc `gc bd create` leaves those beads route-less
+(`gc.routed_to` empty). Pool demand keys exclusively on `gc.routed_to`, so a
+route-less work-unit is invisible to every pool and cannot be claimed until it
+is routed. This stage makes the decomposed work-units claimable.
+
+The routing is applied and verified by the automated check
+`.gc/scripts/checks/route-workunits.sh`, which resolves the implementation
+convoy (`gc.build.implementation_convoy_id`, fallback `gc.input_convoy_id`) and
+the declared `implementation_target` off the workflow root, then stamps
+`gc.routed_to` and `gc.execution_routed_to` to that target on every route-less
+member. The stamp is coded, not agent-remembered; do not stamp routes by hand.
+
+Confirm the implementation convoy is recorded on the workflow root, then close
+this step. If the convoy or `implementation_target` is missing, do not paper
+over it — the check fails loudly so the gap is surfaced rather than leaving
+work-units to sit unclaimable. Never ask questions in headless mode.

--- a/gascity/assets/workflows/build-from-decompose-base/route-workunits.md
+++ b/gascity/assets/workflows/build-from-decompose-base/route-workunits.md
@@ -1,0 +1,20 @@
+This is the `build-from-decompose-base` route-workunits stage.
+
+The decomposition stage created (or adopted) the implementation convoy and its
+work-unit beads. Work-units minted by ad-hoc `gc bd create` land route-less
+(`gc.routed_to` empty); pool demand keys exclusively on `gc.routed_to`, so a
+route-less work-unit is invisible to every pool and cannot be claimed until it
+is routed. This stage makes the decomposed work-units claimable before the
+inherited convoy suffix drains them.
+
+The routing is applied and verified by the automated check
+`.gc/scripts/checks/route-workunits.sh`, which resolves the implementation
+convoy (`gc.build.implementation_convoy_id`, fallback `gc.input_convoy_id`) and
+the declared `implementation_target` off the workflow root, then stamps
+`gc.routed_to` and `gc.execution_routed_to` to that target on every route-less
+member. The stamp is coded, not agent-remembered; do not stamp routes by hand.
+
+Confirm the implementation convoy is recorded on the workflow root, then close
+this step. If the convoy or `implementation_target` is missing, do not paper
+over it — the check fails loudly so the gap is surfaced rather than leaving
+work-units to sit unclaimable. Never ask questions in headless mode.

--- a/gascity/formulas/build-base.formula.toml
+++ b/gascity/formulas/build-base.formula.toml
@@ -169,9 +169,24 @@ path = ".gc/scripts/checks/build-artifact-valid.sh"
 timeout = "5m"
 
 [[steps]]
+id = "route-workunits"
+title = "Route decomposed work-units to the implementation target"
+needs = ["decompose"]
+metadata = { "gc.run_target" = "gc.run-operator" }
+description_file = "../assets/workflows/build-base/route-workunits.md"
+
+[steps.check]
+max_attempts = 3
+
+[steps.check.check]
+mode = "exec"
+path = ".gc/scripts/checks/route-workunits.sh"
+timeout = "5m"
+
+[[steps]]
 id = "implement"
 title = "Drain implementation convoy into separate sessions"
-needs = ["decompose"]
+needs = ["route-workunits"]
 condition = "{{drain_policy}} == separate"
 metadata = { "gc.run_target" = "{{implementation_target}}" }
 description_file = "../assets/workflows/build-base/implement.md"
@@ -184,7 +199,7 @@ member_access = "exclusive"
 [[steps]]
 id = "implement-same-session"
 title = "Drain implementation convoy in one shared session"
-needs = ["decompose"]
+needs = ["route-workunits"]
 condition = "{{drain_policy}} == same-session"
 metadata = { "gc.run_target" = "{{implementation_target}}" }
 description_file = "../assets/workflows/build-base/implement-same-session.md"

--- a/gascity/formulas/build-basic.formula.toml
+++ b/gascity/formulas/build-basic.formula.toml
@@ -76,7 +76,7 @@ timeout = "5m"
 [[steps]]
 id = "implement"
 title = "Drain build implementation"
-needs = ["decompose"]
+needs = ["route-workunits"]
 condition = "{{drain_policy}} == separate"
 metadata = { "gc.run_target" = "{{implementation_target}}" }
 description_file = "../assets/workflows/build-basic/implement.md"
@@ -89,7 +89,7 @@ member_access = "exclusive"
 [[steps]]
 id = "implement-same-session"
 title = "Drain build implementation in one shared session"
-needs = ["decompose"]
+needs = ["route-workunits"]
 condition = "{{drain_policy}} == same-session"
 metadata = { "gc.run_target" = "{{implementation_target}}" }
 description_file = "../assets/workflows/build-basic/implement-same-session.md"

--- a/gascity/formulas/build-from-decompose-base.formula.toml
+++ b/gascity/formulas/build-from-decompose-base.formula.toml
@@ -83,8 +83,23 @@ path = ".gc/scripts/checks/build-artifact-valid.sh"
 timeout = "5m"
 
 [[steps]]
+id = "route-workunits"
+title = "Route decomposed work-units to the implementation target"
+needs = ["decompose"]
+metadata = { "gc.run_target" = "gc.run-operator" }
+description_file = "../assets/workflows/build-from-decompose-base/route-workunits.md"
+
+[steps.check]
+max_attempts = 3
+
+[steps.check.check]
+mode = "exec"
+path = ".gc/scripts/checks/route-workunits.sh"
+timeout = "5m"
+
+[[steps]]
 id = "prepare-convoy"
 title = "Validate implementation convoy"
-needs = ["decompose"]
+needs = ["route-workunits"]
 metadata = { "gc.run_target" = "gc.run-operator" }
 description_file = "../assets/workflows/build-from-decompose-base/prepare-convoy.md"

--- a/gascity/tests/test_formula_assets.py
+++ b/gascity/tests/test_formula_assets.py
@@ -84,6 +84,7 @@ BUILD_BASE_STEPS = [
     "plan",
     "plan-review",
     "decompose",
+    "route-workunits",
     "implement",
     "implement-same-session",
     "summarize-implementation",
@@ -109,6 +110,7 @@ BUILD_FROM_CONVOY_STEPS = BUILD_FROM_REVIEW_STEPS | {
 BUILD_FROM_DECOMPOSE_STEPS = BUILD_FROM_CONVOY_STEPS | {
     "prepare-decompose",
     "decompose",
+    "route-workunits",
 }
 
 BUILD_FROM_PLAN_STEPS = BUILD_FROM_DECOMPOSE_STEPS | {
@@ -1632,7 +1634,13 @@ class FormulaAssetTests(unittest.TestCase):
         self.assertEqual(steps["prepare-decompose"]["metadata"]["gc.run_target"], "gc.run-operator")
         self.assertEqual(steps["decompose"]["metadata"]["gc.run_target"], "gc.task-decomposer")
         self.assertEqual(steps["decompose"]["needs"], ["prepare-decompose"])
-        self.assertEqual(steps["prepare-convoy"]["needs"], ["decompose"])
+        self.assertEqual(steps["route-workunits"]["needs"], ["decompose"])
+        self.assertEqual(steps["route-workunits"]["metadata"]["gc.run_target"], "gc.run-operator")
+        self.assertEqual(
+            steps["route-workunits"]["check"]["check"]["path"],
+            ".gc/scripts/checks/route-workunits.sh",
+        )
+        self.assertEqual(steps["prepare-convoy"]["needs"], ["route-workunits"])
         self.assertEqual(steps["implement"]["needs"], ["prepare-convoy"])
         self.assertEqual(steps["implement"]["condition"], "{{drain_policy}} == separate")
         self.assertEqual(steps["implement"]["metadata"]["gc.run_target"], "{{implementation_target}}")
@@ -1745,7 +1753,8 @@ class FormulaAssetTests(unittest.TestCase):
         self.assertEqual(steps["plan-review"]["needs"], ["plan"])
         self.assertEqual(steps["prepare-decompose"]["needs"], ["plan-review"])
         self.assertEqual(steps["decompose"]["needs"], ["prepare-decompose"])
-        self.assertEqual(steps["prepare-convoy"]["needs"], ["decompose"])
+        self.assertEqual(steps["route-workunits"]["needs"], ["decompose"])
+        self.assertEqual(steps["prepare-convoy"]["needs"], ["route-workunits"])
         self.assertEqual(steps["implement"]["needs"], ["prepare-convoy"])
         self.assertEqual(steps["implement-same-session"]["needs"], ["prepare-convoy"])
         self.assertEqual(steps["prepare-review"]["needs"], ["implement", "implement-same-session"])
@@ -3990,6 +3999,7 @@ description = "Override sink that writes the base triage report contract."
                 "design-review-approved.sh",
                 "gap-analysis-approved.sh",
                 "implementation-review-approved.sh",
+                "route-workunits.sh",
             ],
         )
         for script in scripts:
@@ -4029,6 +4039,177 @@ description = "Override sink that writes the base triage report contract."
                 )
                 self.assertEqual(step["metadata"]["gc.build.artifact_schema"], schema)
                 self.assertEqual(step["metadata"]["gc.build.artifact_path_keys"], path_keys)
+
+    # --- route-workunits gate (auto-routing of decomposed work-units) ---
+
+    FAKE_GC_ROUTE_STATEFUL = '''#!/usr/bin/env python3
+import json
+import os
+import sys
+
+args = sys.argv[1:]
+# Record each invocation as the operator would type it (through gc), so this
+# fixture never reads as a bare beads command to the pack-asset scanner.
+with open(os.environ["GC_TEST_CALLS"], "a", encoding="utf-8") as fh:
+    fh.write("gc " + " ".join(args) + "\\n")
+state_path = os.environ["GC_TEST_STATE"]
+with open(state_path, encoding="utf-8") as fh:
+    state = json.load(fh)
+
+verb = args[0] if args else ""
+sub = args[1] if len(args) > 1 else ""
+
+
+def emit(obj):
+    print(json.dumps(obj))
+
+
+if verb == "bd" and sub == "show":
+    bid = args[2]
+    if bid == "step-1":
+        emit({"id": bid, "metadata": {"gc.root_bead_id": "root-1"}})
+    elif bid == "root-1":
+        emit({"id": bid, "metadata": state["root"]})
+    elif bid in state["members"]:
+        route = state["members"][bid]
+        emit({"id": bid, "metadata": ({"gc.routed_to": route} if route else {})})
+    else:
+        emit({})
+elif verb == "convoy" and sub == "status":
+    emit({
+        "schema_version": "1",
+        "convoy": {"id": args[2]},
+        "children": [{"id": m} for m in state["members"]],
+    })
+elif verb == "bd" and sub == "update":
+    bid = args[2]
+    for i, a in enumerate(args):
+        if a == "--set-metadata" and args[i + 1].startswith("gc.routed_to="):
+            state["members"][bid] = args[i + 1].split("=", 1)[1]
+    with open(state_path, "w", encoding="utf-8") as fh:
+        json.dump(state, fh)
+else:
+    sys.exit(2)
+'''
+
+    def _run_route_workunits_check(self, root_metadata: dict, members: dict):
+        """Run route-workunits.sh against a stateful fake gc.
+
+        members maps member-id -> starting gc.routed_to ("" == route-less).
+        Returns (result, call_lines, final_members).
+        """
+        root = pathlib.Path(__file__).resolve().parents[1]
+        script = root / "assets" / "scripts" / "checks" / "route-workunits.sh"
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            bin_dir = tmp_path / "bin"
+            bin_dir.mkdir()
+            calls = tmp_path / "calls"
+            calls.write_text("", encoding="utf-8")
+            state = tmp_path / "state.json"
+            state.write_text(
+                json.dumps({"root": root_metadata, "members": dict(members)}),
+                encoding="utf-8",
+            )
+            fake_gc = bin_dir / "gc"
+            fake_gc.write_text(self.FAKE_GC_ROUTE_STATEFUL, encoding="utf-8")
+            fake_gc.chmod(0o755)
+            env = {
+                **os.environ,
+                "GC_BEAD_ID": "step-1",
+                "GC_TEST_CALLS": str(calls),
+                "GC_TEST_STATE": str(state),
+                "PATH": f"{bin_dir}:{os.environ.get('PATH', '')}",
+            }
+            result = subprocess.run([str(script)], capture_output=True, env=env, text=True)
+            call_lines = calls.read_text(encoding="utf-8").splitlines()
+            final_members = json.loads(state.read_text(encoding="utf-8"))["members"]
+        return result, call_lines, final_members
+
+    def test_route_workunits_check_stamps_declared_target_on_routeless_members(self) -> None:
+        # Decomposed work-units land route-less; the coded gate must stamp the
+        # DECLARED implementation_target so they become claimable -- no agent
+        # memory, no manual sling.
+        result, call_lines, final = self._run_route_workunits_check(
+            {
+                "gc.build.implementation_convoy_id": "conv-1",
+                "gc.var.implementation_target": "gc.implementation-worker",
+            },
+            {"unit-1": "", "unit-2": "", "unit-3": ""},
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            final,
+            {
+                "unit-1": "gc.implementation-worker",
+                "unit-2": "gc.implementation-worker",
+                "unit-3": "gc.implementation-worker",
+            },
+        )
+        # Both routing keys are stamped, mirroring the formula-graph stamper.
+        for unit in ("unit-1", "unit-2", "unit-3"):
+            self.assertIn(
+                f"gc bd update {unit} --set-metadata gc.routed_to=gc.implementation-worker "
+                "--set-metadata gc.execution_routed_to=gc.implementation-worker",
+                call_lines,
+            )
+
+    def test_route_workunits_check_reads_target_from_input_convoy_and_packed_vars(self) -> None:
+        # Fallbacks: convoy id via gc.input_convoy_id, target via the packed
+        # gc.graphv2_vars.v1 runtime-vars blob.
+        result, _calls, final = self._run_route_workunits_check(
+            {
+                "gc.input_convoy_id": "conv-1",
+                "gc.graphv2_vars.v1": json.dumps(
+                    {"implementation_target": "compound-engineering.ce-work"}
+                ),
+            },
+            {"unit-1": ""},
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(final, {"unit-1": "compound-engineering.ce-work"})
+
+    def test_route_workunits_check_does_not_clobber_an_explicit_route(self) -> None:
+        # ZFC: an already-routed member keeps its route; only route-less units
+        # are stamped.
+        result, call_lines, final = self._run_route_workunits_check(
+            {
+                "gc.build.implementation_convoy_id": "conv-1",
+                "gc.var.implementation_target": "gc.implementation-worker",
+            },
+            {"unit-keep": "gc.other-worker", "unit-fill": ""},
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            final,
+            {"unit-keep": "gc.other-worker", "unit-fill": "gc.implementation-worker"},
+        )
+        self.assertFalse(
+            any(line.startswith("gc bd update unit-keep") for line in call_lines),
+            "must not re-stamp a member that already carries a route",
+        )
+
+    def test_route_workunits_check_fails_loudly_without_target(self) -> None:
+        # NO-SILENT-FAILURE: if implementation_target is undeclared the units
+        # would sit unclaimable; the gate must fail loudly, not pass silently.
+        result, call_lines, final = self._run_route_workunits_check(
+            {"gc.build.implementation_convoy_id": "conv-1"},
+            {"unit-1": ""},
+        )
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("implementation_target", result.stderr)
+        self.assertEqual(final, {"unit-1": ""})
+        self.assertFalse(any(line.startswith("gc bd update") for line in call_lines))
+
+    def test_route_workunits_check_fails_loudly_without_convoy(self) -> None:
+        # NO-SILENT-FAILURE: a missing implementation convoy is surfaced, not
+        # swallowed.
+        result, _calls, _final = self._run_route_workunits_check(
+            {"gc.var.implementation_target": "gc.implementation-worker"},
+            {"unit-1": ""},
+        )
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("convoy", result.stderr)
 
     def _run_build_artifact_check(
         self,

--- a/gascity/tests/test_formula_assets.py
+++ b/gascity/tests/test_formula_assets.py
@@ -124,6 +124,21 @@ BUILD_FROM_REQUIREMENTS_STEPS = BUILD_FROM_PLAN_STEPS | {
     "requirements",
 }
 
+# Concrete build formulas that extend build-base and RE-DECLARE their own
+# implement / implement-same-session step bodies (to swap description_file /
+# drain formula). Because formula composition is per-step-id REPLACEMENT (see
+# merged_steps), such an override drops the inherited route-workunits wiring
+# unless it repoints needs itself -- so the auto-routing gate must be asserted
+# on every one of them. Each entry is (formula-name, pack-subdir or None when
+# the formula lives in gascity/formulas).
+CONCRETE_BUILD_FORMULAS = [
+    ("build-basic", None),
+    ("compound-build", "compound-engineering"),
+    ("gstack-build", "gstack"),
+    ("bmad-build", "bmad"),
+    ("superpowers-build", "superpowers"),
+]
+
 METHODOLOGY_STAGE_CONTRACTS = {
     "planning-base": {
         "steps": ["prepare-planning", "requirements", "plan", "plan-review"],
@@ -570,6 +585,19 @@ def resolve_formula_from_dirs(formula_dirs: list[pathlib.Path], name: str, seen:
     if data.get("description"):
         merged["description"] = data["description"]
     return merged
+
+
+def transitive_needs(steps_by_id: dict, start: str) -> set:
+    """All step ids reachable from ``start`` through the needs graph (excludes start)."""
+    seen: set = set()
+    stack = list(steps_by_id.get(start, {}).get("needs", []))
+    while stack:
+        node = stack.pop()
+        if node in seen:
+            continue
+        seen.add(node)
+        stack.extend(steps_by_id.get(node, {}).get("needs", []))
+    return seen
 
 
 def effective_formula_text(root: pathlib.Path, name: str) -> str:
@@ -2143,7 +2171,10 @@ class FormulaAssetTests(unittest.TestCase):
                 self.assertNotIn("compound", [step["id"] for step in resolved["steps"]])
                 step_by_id = {step["id"]: step for step in data["steps"]}
                 if "implementation-readiness" in expected.get("extra_steps", []):
-                    self.assertEqual(step_by_id["implementation-readiness"]["needs"], ["decompose"])
+                    # bmad threads the auto-routing gate through its readiness
+                    # step: decompose -> route-workunits -> implementation-readiness
+                    # -> implement, so the drain transitively depends on the gate.
+                    self.assertEqual(step_by_id["implementation-readiness"]["needs"], ["route-workunits"])
                     self.assertEqual(
                         step_by_id["implementation-readiness"]["metadata"]["gc.run_target"],
                         "bmad.readiness-reviewer",
@@ -4210,6 +4241,54 @@ else:
         )
         self.assertEqual(result.returncode, 1)
         self.assertIn("convoy", result.stderr)
+
+    def test_concrete_build_formulas_gate_implement_through_route_workunits(self) -> None:
+        # REGRESSION GUARD (dip-ppvr7p): build-base wires implement's needs to
+        # route-workunits so decomposed work-units are stamped claimable BEFORE
+        # the convoy drain claim-scans them. But every concrete build pack
+        # RE-DECLARES its own implement / implement-same-session step bodies, and
+        # formula composition is per-step-id REPLACEMENT (see merged_steps). An
+        # override that still says needs = ["decompose"] therefore ORPHANS the
+        # gate: route-workunits still runs, but with no ordering guarantee vs the
+        # drain's claim-scan -- reproducing the original invisible-work-unit race.
+        # We must assert on the transitive NEEDS-CHAIN, not just the resolved
+        # step-id LIST: the gate step existing in the graph is exactly the
+        # condition that masked the gap from the list-only checks.
+        gascity_root = pathlib.Path(__file__).resolve().parents[1]
+        packs_root = gascity_root.parent
+        for name, pack_subdir in CONCRETE_BUILD_FORMULAS:
+            with self.subTest(formula=name):
+                if pack_subdir is None:
+                    resolved = resolve_formula(gascity_root, name)
+                else:
+                    formula_dirs = [gascity_root / "formulas", packs_root / pack_subdir / "formulas"]
+                    resolved = resolve_formula_from_dirs(formula_dirs, name)
+                steps_by_id = {step["id"]: step for step in resolved["steps"]}
+
+                # The gate step must actually exist in the resolved graph...
+                self.assertIn(
+                    "route-workunits",
+                    steps_by_id,
+                    f"{name}: route-workunits gate missing from the resolved graph",
+                )
+                # ...and be ordered AFTER decompose (the convoy must exist before
+                # its members can be stamped), never floating unordered.
+                self.assertIn(
+                    "decompose",
+                    transitive_needs(steps_by_id, "route-workunits"),
+                    f"{name}: route-workunits must depend transitively on decompose",
+                )
+                # Every implementation-drain step must depend TRANSITIVELY on the
+                # gate, so no override can claim-scan the convoy before routing
+                # has stamped its members claimable.
+                for drain in ("implement", "implement-same-session"):
+                    self.assertIn(drain, steps_by_id, f"{name}: missing {drain} step")
+                    self.assertIn(
+                        "route-workunits",
+                        transitive_needs(steps_by_id, drain),
+                        f"{name}: {drain}.needs must transitively include route-workunits "
+                        "(a per-step-id override silently dropped the auto-routing gate)",
+                    )
 
     def _run_build_artifact_check(
         self,

--- a/gstack/formulas/gstack-build.formula.toml
+++ b/gstack/formulas/gstack-build.formula.toml
@@ -114,7 +114,7 @@ timeout = "5m"
 [[steps]]
 id = "implement"
 title = "Drain gstack work"
-needs = ["decompose"]
+needs = ["route-workunits"]
 condition = "{{drain_policy}} == separate"
 metadata = { "gc.run_target" = "{{implementation_target}}" }
 description_file = "../assets/workflows/gstack-build/implement.md"
@@ -127,7 +127,7 @@ member_access = "exclusive"
 [[steps]]
 id = "implement-same-session"
 title = "Drain gstack work in one shared session"
-needs = ["decompose"]
+needs = ["route-workunits"]
 condition = "{{drain_policy}} == same-session"
 metadata = { "gc.run_target" = "{{implementation_target}}" }
 description_file = "../assets/workflows/gstack-build/implement-same-session.md"

--- a/scripts/gascity_pack_inference_gate.py
+++ b/scripts/gascity_pack_inference_gate.py
@@ -406,7 +406,10 @@ METHODOLOGY_FLOW_CONTRACTS = {
             },
             "implementation-readiness": {
                 "run_target": "bmad.readiness-reviewer",
-                "needs": ("decompose",),
+                # Auto-routing gate (dip-ppvr7p): decompose -> route-workunits ->
+                # implementation-readiness, so the drain transitively waits on the
+                # route-stamp that makes decomposed work-units claimable.
+                "needs": ("route-workunits",),
             },
             "implement": {
                 "run_target": "{{implementation_target}}",

--- a/superpowers/formulas/superpowers-build.formula.toml
+++ b/superpowers/formulas/superpowers-build.formula.toml
@@ -103,7 +103,7 @@ timeout = "5m"
 [[steps]]
 id = "implement"
 title = "Drain Superpowers development"
-needs = ["decompose"]
+needs = ["route-workunits"]
 condition = "{{drain_policy}} == separate"
 metadata = { "gc.run_target" = "{{implementation_target}}" }
 description_file = "../assets/workflows/superpowers-build/implement.md"
@@ -116,7 +116,7 @@ member_access = "exclusive"
 [[steps]]
 id = "implement-same-session"
 title = "Drain Superpowers development in one shared session"
-needs = ["decompose"]
+needs = ["route-workunits"]
 condition = "{{drain_policy}} == same-session"
 metadata = { "gc.run_target" = "{{implementation_target}}" }
 description_file = "../assets/workflows/superpowers-build/implement-same-session.md"


### PR DESCRIPTION
## decompose: stamp gc.routed_to on decomposed work-units so they are claimable

Decomposed implementation-convoy work-units are created via ad-hoc `bd create` in the decompose step, bypassing the formula-graph materializer's routing stamp. They land `bd ready` with `gc.routed_to` empty — and pool demand/claim keys exclusively on `gc.routed_to` — so they are structurally invisible to every pool until a human `gc sling` stamps them. That manual sling at every stage transition is the drag this fixes.

**Change:** a coded post-decompose gate (`route-workunits.sh`, run as a `steps.check`) stamps `gc.routed_to` (+ `gc.execution_routed_to`) = the **declared** `implementation_target` var onto each convoy work-unit, resolved via `gc.build.implementation_convoy_id` → `gc convoy status` members. The target is a copied declared value (no judgment-in-Go, no role hardcode); scoped to explicit convoy membership (no over-reach); idempotent (skips already-routed members); fail-loud if the target/convoy are undeclared or any member stays routeless (no silent failure). The decompose→route-workunits→implement `needs` chain guarantees the stamp completes before the drain's claim-scan.

**Wiring completeness:** every concrete build formula that `extends build-base` re-declares its own `implement`/`implement-same-session` steps (composition is per-step-id replacement), so each was repointed to `needs = ["route-workunits"]` (build-basic, compound-build, gstack-build, superpowers-build; bmad threads it via implementation-readiness). The `build-from-*` family gates via `prepare-convoy`. Zero orphans.

**Size:** ~477 production (formula TOML + prompt/shell assets, zero Go) + test. **Verification:** a `needs`-chain test asserts the transitive chain per concrete formula (non-vacuous: fails on the pre-fix wiring). Pack asset suite 0 net-new failures. Two independent adversarial reviews: both green (the wiring-completeness gap was caught + closed in review).

Note (transparency): the `CONCRETE_BUILD_FORMULAS` needs-chain guard covers the 5 `build-base` extenders, not the `build-from-*` family (benign — those don't re-declare `implement`; optional belt-and-suspenders).
