### PR TITLE
fix(gastown): add --include-infra to wisp reconciliation queries in patrol formulas (#252)

### DIFF
--- a/gastown/formulas/mol-deacon-patrol.toml
+++ b/gastown/formulas/mol-deacon-patrol.toml
@@ -542,7 +542,10 @@ Handle any urgent messages that arrived during patrol. Archive the rest.
 # or the deacon gains a second slot.
 CURRENT_WISP=${GC_BEAD_ID:-${GC_TRIGGER_WORK_BEAD_ID:-}}
 if [ -z "$CURRENT_WISP" ]; then
-  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
+  # --include-infra is required: wisp roots are ephemeral infrastructure
+  # beads, which gc bd list hides by default. Without it this resolves empty
+  # and the deacon pours a duplicate wisp instead of burning this one.
+  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --include-infra --limit=1 --json | jq -r '.[0].id // empty')
 fi
 
 NEXT=$(gc bd mol wisp mol-deacon-patrol --root-only --var binding_prefix='{{binding_prefix}}' --json | jq -r '.new_epic_id // empty')

--- a/gastown/formulas/mol-refinery-patrol.toml
+++ b/gastown/formulas/mol-refinery-patrol.toml
@@ -119,7 +119,7 @@ wisp, burn the current wisp, then request a restart:
 ```bash
 CURRENT_WISP=${GC_BEAD_ID:-}
 if [ -z "$CURRENT_WISP" ]; then
-  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
+  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --include-infra --limit=1 --json | jq -r '.[0].id // empty')
 fi
 NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{target_branch}} --var rig_name={{rig_name}} --var binding_prefix={{binding_prefix}} --json | jq -r '.new_epic_id // empty')
 if [ -z "$NEXT" ]; then
@@ -268,7 +268,7 @@ Target: $TARGET"
   # bead must not end the merge lane.
   CURRENT_WISP=${GC_BEAD_ID:-}
   if [ -z "$CURRENT_WISP" ]; then
-    CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
+    CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --include-infra --limit=1 --json | jq -r '.[0].id // empty')
   fi
   NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{target_branch}} --var rig_name={{rig_name}} --var binding_prefix={{binding_prefix}} --json | jq -r '.new_epic_id // empty')
   if [ -z "$NEXT" ]; then
@@ -323,7 +323,7 @@ Step 3a hand this already-rejected tip straight back here on the next crash.
 ```bash
 CURRENT_WISP=${GC_BEAD_ID:-}
 if [ -z "$CURRENT_WISP" ]; then
-  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
+  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --include-infra --limit=1 --json | jq -r '.[0].id // empty')
 fi
 NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{target_branch}} --var rig_name={{rig_name}} --var binding_prefix={{binding_prefix}} --json | jq -r '.new_epic_id // empty')
 if [ -z "$NEXT" ]; then
@@ -428,7 +428,7 @@ TARGET=$(gc bd show $WORK --json | jq -r '.[0].metadata.target // "{{target_bran
      ```bash
      CURRENT_WISP=${GC_BEAD_ID:-}
      if [ -z "$CURRENT_WISP" ]; then
-       CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
+       CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --include-infra --limit=1 --json | jq -r '.[0].id // empty')
      fi
      NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{target_branch}} --var rig_name={{rig_name}} --var binding_prefix={{binding_prefix}} --json | jq -r '.new_epic_id // empty')
      if [ -z "$NEXT" ]; then
@@ -520,7 +520,7 @@ Branch: $BRANCH
 Target: $TARGET"
   CURRENT_WISP=${GC_BEAD_ID:-}
   if [ -z "$CURRENT_WISP" ]; then
-    CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
+    CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --include-infra --limit=1 --json | jq -r '.[0].id // empty')
   fi
   if [ -z "$CURRENT_WISP" ]; then
     echo "Could not resolve current wisp; not burning."
@@ -1191,8 +1191,11 @@ If the cycle ended early (conflict rejection, no work found), note
 why and what state was left.
 
 This summary is not stored separately — it lives in the wisp's
-closing reason. The next session can find it via `gc bd list --type=molecule
---status=closed --limit=5` if it needs predecessor context."""
+closing reason. The next session can find it with:
+`gc bd list --type=molecule --include-infra --status=closed --limit=5`
+if it needs predecessor context. `--include-infra` is required — wisp roots
+are ephemeral infrastructure beads and are hidden from `gc bd list` without
+it."""
 
 [[steps]]
 id = "next-iteration"
@@ -1228,7 +1231,7 @@ If auto_land = "false": skip this entirely.
 ```bash
 CURRENT_WISP=${GC_BEAD_ID:-}
 if [ -z "$CURRENT_WISP" ]; then
-  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
+  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --include-infra --limit=1 --json | jq -r '.[0].id // empty')
 fi
 NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{target_branch}} --var rig_name={{rig_name}} --var binding_prefix={{binding_prefix}} --json | jq -r '.new_epic_id // empty')
 if [ -z "$NEXT" ]; then

--- a/gastown/tests/test_gastown_pack_assets.sh
+++ b/gastown/tests/test_gastown_pack_assets.sh
@@ -311,9 +311,11 @@ test_witness_wisp_queries_pin_include_infra() {
     # --include-infra is passed: a wisp-reconcile query without it returns []
     # even when a wisp is assigned, and the witness pours a duplicate. That
     # regressed once already, so pin the flag rather than trust the comments.
-    # Deliberately witness-scoped: the refinery and deacon patrol queries
-    # still carry the bare form and are tracked separately in #252, so a
-    # pack-wide assertion would fail here instead of guarding this contract.
+    # Deliberately witness-scoped: the refinery and deacon prompt templates
+    # still carry the bare form under #266, so a pack-wide assertion would
+    # fail here instead of guarding this contract. Their formulas are no
+    # longer part of that gap -- they are pinned by the refinery and deacon
+    # guards below.
     total=$(grep -h -- '--type=molecule' "$prompt" "$formula" |
         grep -c -F 'gc bd list' || true)
     flagged=$(grep -h -- '--type=molecule' "$prompt" "$formula" |
@@ -446,9 +448,10 @@ test_boot_wisp_queries_pin_include_infra() {
     # burn never runs and each cycle pours a fresh wisp while its predecessor
     # leaks. Boot shipped with the bare form on all three sites one commit
     # after the witness fix, so scope this per-agent rather than widening the
-    # witness test: a pack-wide assertion is red either way (measured 10/21 at
-    # this commit) because the deacon and refinery sites are still bare and
-    # tracked separately in #252.
+    # witness test: a pack-wide assertion is still red at this commit
+    # (measured 18/22) because agents/refinery/prompt.template.md and
+    # agents/deacon/prompt.template.md remain bare under #266. The deacon and
+    # refinery formulas have since been fixed and carry their own guards.
     total=$(grep -h -- '--type=molecule' "$prompt" "$formula" |
         grep -c -F 'gc bd list' || true)
     flagged=$(grep -h -- '--type=molecule' "$prompt" "$formula" |
@@ -539,6 +542,65 @@ test_boot_deacon_observation_query_sees_wisps_tier() {
         [[ "$unflagged" -eq 0 ]] ||
             fail "$name deacon-observation queries must pass --include-infra ($unflagged do not)"
     done
+}
+
+test_refinery_wisp_queries_pin_include_infra() {
+    local formula total flagged
+    formula="$GASTOWN/formulas/mol-refinery-patrol.toml"
+
+    # Same contract as the witness and boot guards above, scoped to the
+    # refinery formula. The refinery resolves its current patrol wisp at every
+    # early-exit path and again at the next-iteration pour, and without
+    # --include-infra all of them resolve empty: the cycle burns nothing and
+    # pours a duplicate on top of the wisp it failed to see. Observed live --
+    # gas-city held two concurrent open mol-refinery-patrol wisps, which is
+    # this loop's own output (gastownhall/gascity-packs#252).
+    #
+    # Formula-scoped on purpose. agents/refinery/prompt.template.md still
+    # carries two bare sites, and the prompt half of #252 belongs to #266;
+    # widening this guard to the prompt would fail here on another PR's
+    # unlanded work instead of pinning what this one fixed.
+    total=$(grep -h -- '--type=molecule' "$formula" |
+        grep -c -F 'gc bd list' || true)
+    flagged=$(grep -h -- '--type=molecule' "$formula" |
+        grep -F 'gc bd list' | grep -c -- '--include-infra' || true)
+
+    # -ge, not -eq, for the reason the witness guard states: the flagged/total
+    # assertion owns the contract, so the count is a floor that catches a
+    # deleted query site rather than a cardinality pin a legitimate eighth
+    # site would break. The prose reference in patrol-summary is counted
+    # deliberately -- it is the line that tells the next session how to find
+    # its predecessor, and a bare form there teaches the blind query onward.
+    [[ "$total" -ge 7 ]] ||
+        fail "expected at least 7 refinery --type=molecule wisp queries (6 code sites + 1 prose reference), found $total"
+    [[ "$flagged" -eq "$total" ]] ||
+        fail "refinery --type=molecule wisp queries must pass --include-infra ($flagged/$total do)"
+}
+
+test_deacon_wisp_queries_pin_include_infra() {
+    local formula total flagged
+    formula="$GASTOWN/formulas/mol-deacon-patrol.toml"
+
+    # The deacon has the same defect by the same route, and no PR ever covered
+    # it: #266 took the prompts, #325 took the witness formula, and the deacon
+    # formula was left holding the bare form at its one reconciliation site.
+    # A single site is still a per-iteration leak, because it is the only
+    # thing standing between "burn the wisp I am on" and "pour a second one".
+    #
+    # Formula-scoped for the same reason as the refinery guard above:
+    # agents/deacon/prompt.template.md carries two bare sites that are #266's.
+    total=$(grep -h -- '--type=molecule' "$formula" |
+        grep -c -F 'gc bd list' || true)
+    flagged=$(grep -h -- '--type=molecule' "$formula" |
+        grep -F 'gc bd list' | grep -c -- '--include-infra' || true)
+
+    # A floor of 1 is the whole population here, so this arm is really the
+    # deletion guard: it fires if the reconciliation query is removed outright,
+    # which would take the burn with it and leak just as surely.
+    [[ "$total" -ge 1 ]] ||
+        fail "expected at least 1 deacon --type=molecule wisp query, found $total"
+    [[ "$flagged" -eq "$total" ]] ||
+        fail "deacon --type=molecule wisp queries must pass --include-infra ($flagged/$total do)"
 }
 
 test_refinery_direct_merge_is_worktree_safe_and_fail_closed() {
@@ -682,6 +744,8 @@ test_witness_handoff_recovery_is_guarded_and_fail_closed
 test_boot_wisp_queries_pin_include_infra
 test_boot_patrol_burn_resolves_current_wisp
 test_boot_deacon_observation_query_sees_wisps_tier
+test_refinery_wisp_queries_pin_include_infra
+test_deacon_wisp_queries_pin_include_infra
 test_refinery_direct_merge_is_worktree_safe_and_fail_closed
 
 echo "gastown pack asset tests passed"


### PR DESCRIPTION
Closes the formula-side half of #252.

**Rebased 2026-09-11 onto `2716505`.** This PR previously conflicted, because
#325 fixed the witness half independently while it sat. Rather than resolve the
conflict, the witness hunks have been **dropped**: see *What changed in the
rebase* below.

## Problem

Wisp roots are **ephemeral infrastructure beads**. `gc bd list` hides infra beads
unless `--include-infra` is passed, so a `--type=molecule` reconciliation query
without the flag returns `[]` regardless of how many wisps are actually open.
Every patrol iteration concludes "no wisp exists", pours a fresh one, and orphans
the wisp it was standing on — **one leaked wisp per iteration, per patrol role,
town-wide.**

## Reproduction (live rig)

The rig had 4 open wisps — 2 on the witness, 2 on the refinery — themselves the
product of this duplicate-pour loop, and all 4 invisible to the query the
formulas actually run:

```console
$ gc bd list --assignee=gas-city/gastown.witness --status=open --type=molecule --limit=0 --json | jq length
0

$ gc bd list --assignee=gas-city/gastown.witness --status=open --type=molecule --include-infra --limit=0 --json | jq length
2
```

Confirmed the hidden beads are exactly the wisps (`ephemeral=true`,
`issue_type=molecule`), and that **the flag alone is sufficient** — with
`--include-infra`, `gc bd list --type=molecule` returns the *same id set* as
`gc bd query 'ephemeral=true'`:

```console
$ gc bd query --json 'ephemeral=true' | jq -r '[.[]|select(.status=="open")]|map(.id)|sort|join(" ")'
gci-wisp-5an gci-wisp-8kq gci-wisp-bvr gci-wisp-d2g

$ gc bd list --status=open --type=molecule --include-infra --limit=0 --json | jq -r 'map(.id)|sort|join(" ")'
gci-wisp-5an gci-wisp-8kq gci-wisp-bvr gci-wisp-d2g
```

## What changed in the rebase

**The witness hunks are gone.** `8243d049` (#325, merged 2026-09-08) added
`--include-infra` to `mol-witness-patrol.toml` and to the witness prompt while
this PR was open. Re-applying either would have been a no-op at best and a
conflict at worst, so both were dropped. `mol-witness-patrol.toml` and
`gastown/agents/witness/prompt.template.md` are **untouched by this PR** — that
file is upstream's now.

**The refinery site count moved from 5 to 6.** The original PR was written
against an older main. The sites were re-measured against `2716505` rather than
re-applied by line number; a sixth `CURRENT_WISP` call site had appeared in
`mol-refinery-patrol.toml` in the interim.

**The regression test is a re-add, not a revert.** #325 rewrote
`test_gastown_pack_assets.sh`, including adding its own witness-scoped
`--include-infra` guard. This PR adds the refinery and deacon equivalents on top
of that version, in the same idiom, rather than restoring the original PR's
pack-wide assertion — which would now fail on `#266`'s unlanded prompt work.

## Changes

| File | Sites |
|---|---|
| `gastown/formulas/mol-refinery-patrol.toml` | 6 `CURRENT_WISP` reconciliation sites + 1 prose reference |
| `gastown/formulas/mol-deacon-patrol.toml` | 1 `CURRENT_WISP` reconciliation site |
| `gastown/tests/test_gastown_pack_assets.sh` | 2 new guards + 2 scope-note corrections |

The prose reference in the refinery's `patrol-summary` step is fixed as well as
the code. It is the line that tells the next session how to find its
predecessor, so a bare form there teaches the blind query onward.

The deacon formula carries the identical defect and **no PR has ever covered
it** — #266 took the prompts, #325 took the witness formula. Happy to split that
hunk out if you would rather keep this scoped to the refinery.

## Deliberately out of scope: the prompt templates

`gastown/agents/refinery/prompt.template.md` (2 sites) and
`gastown/agents/deacon/prompt.template.md` (2 sites) still carry the bare form.
Those are the prompt half of #252 and belong to **#266**, which is still open.
Fixing them here would collide with that PR, so the two new guards are
**formula-scoped**, and the existing witness and boot guards' scope notes have
been corrected — they currently claim the refinery and deacon *formulas* are the
outstanding gap, which this PR closes. Pack-wide census after this PR: 18/22
flagged, the 4 remaining being exactly #266's.

## Test

`test_refinery_wisp_queries_pin_include_infra` and
`test_deacon_wisp_queries_pin_include_infra` assert that every
`gc bd list --type=molecule` line in the respective formula carries the flag.

Verified as real regression tests — both arms, on the pre-fix tree:

```console
# main's formulas verbatim, only the new test file dropped in:
FAIL: refinery --type=molecule wisp queries must pass --include-infra (0/7 do)

# then with ONLY the refinery formula fixed, so the deacon guard is reached:
FAIL: deacon --type=molecule wisp queries must pass --include-infra (0/1 do)
```

Both pass after the fix. All **five** `gastown/tests/test_*.sh` suites pass under
`ci.yml`'s exact loop; both edited formulas parse under `tomllib`.

## Overlap with #264 — please note merge order

#264 (also mine) rewrites five of these same `CURRENT_WISP` sites in
`mol-refinery-patrol.toml` to resolve wisps via `gc bd query`. **Whichever lands
second needs a trivial rebase** — the two approaches are semantically equivalent
(id sets proven identical above), and #264's rewrite supersedes these lines
entirely if it lands. Flagging rather than resolving it here, since that is the
maintainer's call.

One correction worth flagging: #264's regression test asserts *"`gc bd list`
never returns ephemeral beads regardless of `--type`"*. That premise is wrong —
as shown above, `--include-infra` makes `gc bd list` return them exactly. #264's
fix still works, but its stated justification does not, so that assertion is
deliberately not adopted here.
