### PR TITLE
refinery: review the diff before it lands

### DIFF
--- a/gastown/formulas/mol-refinery-patrol.toml
+++ b/gastown/formulas/mol-refinery-patrol.toml
@@ -382,9 +382,100 @@ TARGET=$(gc bd show $WORK --json | jq -r '.[0].metadata.target // "{{target_bran
 **FORBIDDEN**: Writing code to fix failures. You are a merge processor."""
 
 [[steps]]
+id = "review-diff"
+title = "Review the diff before it lands"
+needs = ["handle-failures"]
+description = """
+Quality checks prove the branch does not break the build. They do not say
+whether the change is CORRECT. This step reads the diff before it lands.
+
+Reached only when checks PASSED — a failing branch is handled by
+handle-failures and never arrives here.
+
+Read the branch, target and strategy:
+```bash
+BRANCH=$(gc bd show $WORK --json | jq -r '.[0].metadata.branch')
+TARGET=$(gc bd show $WORK --json | jq -r '.[0].metadata.target // "{{target_branch}}"')
+MERGE_STRATEGY=$(gc bd show $WORK --json | jq -r '.[0].metadata.merge_strategy // "direct"')
+git --no-pager diff --stat "origin/$TARGET...origin/$BRANCH"
+git --no-pager diff "origin/$TARGET...origin/$BRANCH"
+```
+
+Review for:
+1. **Correctness** — does it do what the bead asked? Read the bead's own
+   description and acceptance criteria; a change that builds cleanly and
+   solves the wrong problem is the expensive failure this step exists to
+   catch.
+2. **Silent failures** — swallowed errors, empty catch blocks, a fallback
+   that hides the fault it was meant to report.
+3. **Blast radius** — does it touch shared state, migrations, or config
+   that reaches beyond this bead's stated scope?
+
+## 🔴 ATTRIBUTION — read before posting anything
+
+In most installs `gh` authenticates as a HUMAN's account, not a bot. Check
+once with `gh api user --jq .login`. Whatever it prints is the name your
+review appears under.
+
+⛔ NEVER run `gh pr review --approve` or `--request-changes`. Under a human
+   account those fabricate a human sign-off that never happened — on exactly
+   the PRs whose open question is whether anyone reviewed them. An approval
+   is an attestation; you are not the attester.
+✅ Post `gh pr comment`, and BEGIN the body with a literal disclosure line:
+
+       **Automated review (refinery) — not a human approval.**
+
+Approval stays a human act. Your job is to surface findings so a human can
+approve quickly. Comments are safe because they read as claims; verdicts are
+not, because they read as testimony.
+
+## Recording the review
+
+For `mr`/`pr` strategy, post the comment on the PR:
+```bash
+gh pr comment "$PR_NUMBER" --body "$(cat <<'REVIEW'
+**Automated review (refinery) — not a human approval.**
+
+<findings, each citing file:line — or an explicit "no blocking issues found">
+REVIEW
+)"
+```
+
+For `direct` strategy there is no PR, so record the review on the work bead
+so it survives this session:
+```bash
+gc bd comment $WORK --stdin <<'REVIEW'
+Refinery pre-merge review (automated — not a human approval):
+<findings, or "no blocking issues found">
+REVIEW
+```
+
+Say "no blocking issues found" plainly when that is the answer. Do NOT
+manufacture findings to look thorough — a review that always finds something
+trains the next reader to ignore it.
+
+## Blocking is deliberately RARE
+
+**Default to NOT blocking.** Record the finding, proceed to merge-push.
+
+Block ONLY when you can state a concrete failure: the inputs, and the wrong
+output or crash they produce. "This looks fragile" is a comment, not a block.
+
+If — and only if — you can state that failure, treat it exactly as a test
+failure: do NOT merge, and follow handle-failures' rejection path to reopen
+the source bead with your reasoning in the rejection metadata.
+
+The bar is high on purpose. A refinery that blocks on suspicion starves its
+own lane, and every bead behind this one waits on a guess. A wrong merge is
+recoverable by a follow-up commit; a stalled lane is not self-healing.
+
+Close this step when the review is recorded (and posted, in mr/pr mode).
+"""
+
+[[steps]]
 id = "merge-push"
 title = "Merge and push"
-needs = ["handle-failures"]
+needs = ["review-diff"]
 description = """
 **Config: target_branch = {{target_branch}}**
 **Config: delete_merged_branches = {{delete_merged_branches}}**


### PR DESCRIPTION
## What

Adds a `review-diff` step to `mol-refinery-patrol`, between `handle-failures` and `merge-push`.

Step order becomes:

```
... run-tests -> handle-failures -> review-diff -> merge-push -> patrol-summary ...
```

It reviews exactly what is about to land, and only runs on branches whose checks already passed — a failing branch is handled by `handle-failures` and never reaches it.

## Why

The formula had **zero** review content (`grep -ic review` → 0). Quality checks prove a branch does not break the build; they say nothing about whether the change is *correct*. So every branch the refinery landed went in unreviewed by anything.

Reviews for correctness against the bead's own acceptance criteria, silent failures (swallowed errors, fallbacks that hide the fault they should report), and blast radius beyond the bead's stated scope.

## Two constraints worth reviewing closely

**1. Attribution — the step forbids `--approve`.**

In most installs `gh` authenticates as a *human's* account, not a bot. On the install this was written against, `gh api user` returns the operator's own login. An automated `gh pr review --approve` therefore fabricates a human sign-off that never happened — on exactly the PRs whose open question is whether anyone reviewed them. That is strictly worse than no review, because it *looks* like the problem was solved.

So the step forbids `--approve`/`--request-changes` and posts `gh pr comment` prefixed with a literal `**Automated review (refinery) — not a human approval.**` disclosure. Comments are safe because they read as claims; verdicts are not, because they read as testimony. Approval stays a human act.

In `direct` mode there is no PR, so the review is recorded on the work bead rather than lost with the session.

**2. Blocking is rare by design.**

The step blocks only when it can state a concrete failure — the inputs, and the wrong output or crash they produce — and otherwise records the finding and proceeds. "This looks fragile" is a comment, not a block.

The bar is high deliberately: a refinery that blocks on suspicion starves its own lane, and every bead behind it waits on a guess. A wrong merge is recoverable by a follow-up commit; a stalled lane is not self-healing. When it does block, it reuses the existing `handle-failures` rejection path rather than inventing new machinery.

If you'd rather this be advisory-only (never blocks), that is a one-paragraph edit — say so and I'll cut it.

## Validation

- TOML parses (`tomllib`), 10 step blocks.
- Dependency graph resolves, no dangling `needs`.
- Base verified byte-identical to the currently pinned pack revision (`sha:6373985…`) before editing.
- Not yet exercised against a live merge queue — the refinery this was written for has an empty queue.

## Blast radius

`mol-refinery-patrol` is machine-wide: every city sharing this pack cache gets this step on the next pin bump. That is why the blocking path is narrow. Worth a careful read from someone who runs a busy refinery.

Authored by the gas-town mayor agent on Jeremy's behalf; not a human-written patch.