### PR TITLE
fix(gastown): resolve the claimed bead id without assuming GC_BEAD_ID

### DIFF
--- a/gastown/formulas/mol-deacon-patrol.toml
+++ b/gastown/formulas/mol-deacon-patrol.toml
@@ -519,7 +519,7 @@ Handle any urgent messages that arrived during patrol. Archive the rest.
 
 **3. Resolve current wisp and pour next iteration BEFORE burning:**
 ```bash
-CURRENT_WISP=${GC_BEAD_ID:-}
+CURRENT_WISP="${GC_BEAD_ID:-${GC_TRIGGER_WORK_BEAD_ID:-}}"
 if [ -z "$CURRENT_WISP" ]; then
   CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
 fi

--- a/gastown/formulas/mol-refinery-patrol.toml
+++ b/gastown/formulas/mol-refinery-patrol.toml
@@ -117,7 +117,7 @@ If context feels heavy (multi-hour session, large recent diffs, or you notice
 yourself taking shortcuts or summarizing prematurely), pour and assign the next
 wisp, burn the current wisp, then request a restart:
 ```bash
-CURRENT_WISP=${GC_BEAD_ID:-}
+CURRENT_WISP="${GC_BEAD_ID:-${GC_TRIGGER_WORK_BEAD_ID:-}}"
 if [ -z "$CURRENT_WISP" ]; then
   CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
 fi
@@ -240,7 +240,7 @@ gc bd update $WORK \
 5. Clean up temp branch: `git checkout {{target_branch}} && git branch -D temp`
 6. Pour next patrol iteration before burning:
 ```bash
-CURRENT_WISP=${GC_BEAD_ID:-}
+CURRENT_WISP="${GC_BEAD_ID:-${GC_TRIGGER_WORK_BEAD_ID:-}}"
 if [ -z "$CURRENT_WISP" ]; then
   CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
 fi
@@ -341,7 +341,7 @@ TARGET=$(gc bd show $WORK --json | jq -r '.[0].metadata.target // "{{target_bran
    - Clean up: `git checkout "$TARGET" && git branch -D temp`
    - Pour next patrol iteration before burning:
      ```bash
-     CURRENT_WISP=${GC_BEAD_ID:-}
+     CURRENT_WISP="${GC_BEAD_ID:-${GC_TRIGGER_WORK_BEAD_ID:-}}"
      if [ -z "$CURRENT_WISP" ]; then
        CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
      fi
@@ -433,7 +433,7 @@ Work bead: $WORK
 Existing PR: $EXISTING_PR
 Branch: $BRANCH
 Target: $TARGET"
-  CURRENT_WISP=${GC_BEAD_ID:-}
+  CURRENT_WISP="${GC_BEAD_ID:-${GC_TRIGGER_WORK_BEAD_ID:-}}"
   if [ -z "$CURRENT_WISP" ]; then
     CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
   fi
@@ -1141,7 +1141,7 @@ If auto_land = "false": skip this entirely.
 
 **2. Resolve the current wisp, pour next iteration, then burn this wisp:**
 ```bash
-CURRENT_WISP=${GC_BEAD_ID:-}
+CURRENT_WISP="${GC_BEAD_ID:-${GC_TRIGGER_WORK_BEAD_ID:-}}"
 if [ -z "$CURRENT_WISP" ]; then
   CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
 fi

--- a/gastown/formulas/mol-shutdown-dance.toml
+++ b/gastown/formulas/mol-shutdown-dance.toml
@@ -12,25 +12,30 @@ gc bd create --type=task \
 
 The dog pool picks up the warrant and runs this formula against the
 claimed warrant bead. The claimed bead is the warrant id; use
-`$GC_BEAD_ID` for warrant verification, closure, and audit output.
+`$WORK_BEAD` — resolved in the bootstrap below — for warrant verification,
+closure, and audit output.
 Existing warrant producers provide `target`, `reason`, and `requester`
 metadata, not a separate `warrant_id`. Each warrant is one shutdown dance
 for one target. On crash, re-read formula steps and resume from context
 (check target state, attempt history).
 
-Before running command snippets in any step, load warrant metadata into quoted
-shell variables:
+Before running command snippets in any step, resolve the claimed warrant id and
+load its metadata into quoted shell variables. `$GC_BEAD_ID` is not exported by
+every provider — the claude provider exports `$GC_TRIGGER_WORK_BEAD_ID` instead
+— so read the first that is set and abort loudly when neither is, rather than
+running `gc bd close ""` against an empty id:
 
 ```bash
-warrant_json="$(gc bd show "$GC_BEAD_ID" --json)"
+WORK_BEAD="${GC_BEAD_ID:-${GC_TRIGGER_WORK_BEAD_ID:?no work bead id in env}}"
+warrant_json="$(gc bd show "$WORK_BEAD" --json)"
 target="$(printf '%s' "$warrant_json" | jq -r '.[0].metadata.target // empty')"
 reason="$(printf '%s' "$warrant_json" | jq -r '.[0].metadata.reason // empty')"
 requester="$(printf '%s' "$warrant_json" | jq -r '.[0].metadata.requester // "deacon"')"
 requester_endpoint="${requester%/}/"
 if [ -z "$target" ] || [ -z "$reason" ]; then
-  echo "warrant $GC_BEAD_ID is missing target or reason" >&2
-  gc bd close "$GC_BEAD_ID" --reason "MALFORMED_WARRANT: missing target or reason metadata"
-  gc session nudge "$requester_endpoint" "DOG_DONE: warrant $GC_BEAD_ID - MALFORMED_WARRANT (missing target or reason)" || true
+  echo "warrant $WORK_BEAD is missing target or reason" >&2
+  gc bd close "$WORK_BEAD" --reason "MALFORMED_WARRANT: missing target or reason metadata"
+  gc session nudge "$requester_endpoint" "DOG_DONE: warrant $WORK_BEAD - MALFORMED_WARRANT (missing target or reason)" || true
   gc runtime drain-ack
   exit 1
 fi
@@ -82,21 +87,24 @@ Entry point. Read the warrant metadata from the claimed warrant bead.
 
 **1. Read warrant details:**
 ```bash
-warrant_json="$(gc bd show "$GC_BEAD_ID" --json)"
+WORK_BEAD="${GC_BEAD_ID:-${GC_TRIGGER_WORK_BEAD_ID:?no work bead id in env}}"
+warrant_json="$(gc bd show "$WORK_BEAD" --json)"
 target="$(printf '%s' "$warrant_json" | jq -r '.[0].metadata.target // empty')"
 reason="$(printf '%s' "$warrant_json" | jq -r '.[0].metadata.reason // empty')"
 requester="$(printf '%s' "$warrant_json" | jq -r '.[0].metadata.requester // "deacon"')"
 requester_endpoint="${requester%/}/"
 if [ -z "$target" ] || [ -z "$reason" ]; then
-  echo "warrant $GC_BEAD_ID is missing target or reason" >&2
-  gc bd close "$GC_BEAD_ID" --reason "MALFORMED_WARRANT: missing target or reason metadata"
-  gc session nudge "$requester_endpoint" "DOG_DONE: warrant $GC_BEAD_ID - MALFORMED_WARRANT (missing target or reason)" || true
+  echo "warrant $WORK_BEAD is missing target or reason" >&2
+  gc bd close "$WORK_BEAD" --reason "MALFORMED_WARRANT: missing target or reason metadata"
+  gc session nudge "$requester_endpoint" "DOG_DONE: warrant $WORK_BEAD - MALFORMED_WARRANT (missing target or reason)" || true
   gc runtime drain-ack
   exit 1
 fi
 ```
 Extract: `target`, `reason`, and `requester`. The warrant id is the
-claimed work bead, `$GC_BEAD_ID`.
+claimed work bead, `$WORK_BEAD` — `$GC_BEAD_ID` when the provider exports it,
+`$GC_TRIGGER_WORK_BEAD_ID` (claude) otherwise. Re-run that one-line resolution
+at the top of every later step: shell variables do not survive between steps.
 
 A warrant missing `target` or `reason` is malformed and cannot be danced.
 The branch above is a terminal cleanup path: it closes the claimed warrant
@@ -106,7 +114,7 @@ still `in_progress` — that leaks the warrant and wedges this pool slot.
 
 **2. Verify the warrant bead exists and is not closed:**
 ```bash
-gc bd show "$GC_BEAD_ID" --json | jq '.[0].status'
+gc bd show "$WORK_BEAD" --json | jq '.[0].status'
 ```
 Both `open` and `in_progress` are valid warrant states — a claimed
 warrant is normally already `in_progress`. Only `closed` stops the
@@ -120,7 +128,7 @@ attempt any step or bead updates against the closed warrant. Run
 gc session peek "$target" --lines 1
 ```
 If target session doesn't exist (already dead):
-- Close warrant: `gc bd close "$GC_BEAD_ID" --reason "Target already dead"`
+- Close warrant: `gc bd close "$WORK_BEAD" --reason "Target already dead"`
 - Nudge requester: `gc session nudge "$requester_endpoint" "DOG_DONE: $target - already dead"`
 - Run `gc runtime drain-ack`, then exit
 
@@ -136,7 +144,7 @@ First attempt to contact the stuck agent. Give it 60 seconds.
 **1. Send health check via nudge:**
 ```bash
 gc session nudge "$target" "[DOG] HEALTH CHECK: Respond ALIVE within 60s or face termination.
-Warrant: $GC_BEAD_ID
+Warrant: $WORK_BEAD
 Reason: $reason
 Filed by: $requester
 Attempt: 1/3"
@@ -158,7 +166,7 @@ generated). Use judgment — explicit "ALIVE" is definitive, but active
 output also indicates the agent is functioning.
 
 **4. If ALIVE or active:**
-- Close warrant: `gc bd close "$GC_BEAD_ID" --reason "Session responded at attempt 1"`
+- Close warrant: `gc bd close "$WORK_BEAD" --reason "Session responded at attempt 1"`
 - Nudge requester: `gc session nudge "$requester_endpoint" "DOG_DONE: $target - PARDONED after attempt 1"`
 - Run `gc runtime drain-ack`, then exit
 
@@ -175,7 +183,7 @@ got no response.
 **1. Send health check:**
 ```bash
 gc session nudge "$target" "[DOG] HEALTH CHECK: Respond ALIVE within 120s or face termination.
-Warrant: $GC_BEAD_ID
+Warrant: $WORK_BEAD
 Reason: $reason
 Filed by: $requester
 Attempt: 2/3"
@@ -194,7 +202,7 @@ gc session peek "$target" --lines 50
 Same evaluation as attempt 1: ALIVE keyword or active output.
 
 **4. If ALIVE or active:**
-- Close warrant: `gc bd close "$GC_BEAD_ID" --reason "Session responded at attempt 2"`
+- Close warrant: `gc bd close "$WORK_BEAD" --reason "Session responded at attempt 2"`
 - Nudge requester: `gc session nudge "$requester_endpoint" "DOG_DONE: $target - PARDONED after attempt 2"`
 - Run `gc runtime drain-ack`, then exit
 
@@ -211,7 +219,7 @@ respond in 4 minutes after 3 attempts, it's genuinely stuck.
 **1. Send health check:**
 ```bash
 gc session nudge "$target" "[DOG] HEALTH CHECK: FINAL WARNING. Respond ALIVE within 240s.
-Warrant: $GC_BEAD_ID
+Warrant: $WORK_BEAD
 Reason: $reason
 Filed by: $requester
 Attempt: 3/3 — session will be terminated if no response"
@@ -228,7 +236,7 @@ gc session peek "$target" --lines 50
 ```
 
 **4. If ALIVE or active:**
-- Close warrant: `gc bd close "$GC_BEAD_ID" --reason "Session responded at attempt 3"`
+- Close warrant: `gc bd close "$WORK_BEAD" --reason "Session responded at attempt 3"`
 - Nudge requester: `gc session nudge "$requester_endpoint" "DOG_DONE: $target - PARDONED after attempt 3"`
 - Run `gc runtime drain-ack`, then exit
 
@@ -277,7 +285,7 @@ spent. If either signal shows movement inside it, the target is progressing —
 PARDON it instead of killing. A polecat inside a full test suite is not dead:
 ```bash
 if [ "$progress" != "none" ]; then
-  gc bd close "$GC_BEAD_ID" --reason "PARDONED: $target showed work progress within the interrogation window ($progress)"
+  gc bd close "$WORK_BEAD" --reason "PARDONED: $target showed work progress within the interrogation window ($progress)"
   gc session nudge "$requester_endpoint" "DOG_DONE: $target - PARDONED (progress within interrogation window; likely inside one long tool call)"
   gc runtime drain-ack
   exit 0
@@ -313,7 +321,7 @@ state captured in step 1.
 
 **4. If the kill succeeded, record the execution on the warrant:**
 ```bash
-gc bd close "$GC_BEAD_ID" --reason "Executed after 3 failed attempts (420s total)"
+gc bd close "$WORK_BEAD" --reason "Executed after 3 failed attempts (420s total)"
 ```
 
 **5. If the kill did not take effect** (the session still shows the
@@ -324,8 +332,8 @@ mayor and close the warrant with the failure on the audit record:
 gc mail send mayor/ -s "EXECUTE_FAILED: $target" \
   -m "session kill didn't take effect. Agent may need manual intervention.
 Requester: $requester
-Warrant: $GC_BEAD_ID"
-gc bd close "$GC_BEAD_ID" --reason "EXECUTE_FAILED: kill did not take effect, escalated to mayor"
+Warrant: $WORK_BEAD"
+gc bd close "$WORK_BEAD" --reason "EXECUTE_FAILED: kill did not take effect, escalated to mayor"
 ```
 
 Close this step, proceed to epitaph. Carry the outcome (EXECUTED or
@@ -343,7 +351,7 @@ Final step. Create audit record and exit.
 If the kill took effect (warrant closed as Executed):
 ```bash
 gc session nudge "$requester_endpoint" "DOG_DONE: $target - EXECUTED after 3 failed attempts.
-Warrant: $GC_BEAD_ID
+Warrant: $WORK_BEAD
 Target: $target
 Reason: $reason
 Outcome: EXECUTED after 3 attempts (60s + 120s + 240s = 420s)
@@ -353,7 +361,7 @@ Action: session killed, reconciler will restart"
 If the kill did not take effect (warrant closed as EXECUTE_FAILED):
 ```bash
 gc session nudge "$requester_endpoint" "DOG_DONE: $target - EXECUTE_FAILED (escalated).
-Warrant: $GC_BEAD_ID
+Warrant: $WORK_BEAD
 Target: $target
 Reason: $reason
 Outcome: EXECUTE_FAILED after 3 attempts (60s + 120s + 240s = 420s)

--- a/gastown/tests/test_gastown_pack_assets.sh
+++ b/gastown/tests/test_gastown_pack_assets.sh
@@ -49,9 +49,9 @@ test_shutdown_dance_contracts_are_executable() {
 
     ! grep -F '[vars.warrant_id]' "$formula" >/dev/null ||
         fail "warrant_id should be the claimed work bead, not a required formula var"
-    grep -F 'gc bd show "$GC_BEAD_ID"' "$formula" >/dev/null ||
+    grep -F 'gc bd show "$WORK_BEAD"' "$formula" >/dev/null ||
         fail "shutdown dance should inspect the claimed warrant bead"
-    grep -F 'gc bd close "$GC_BEAD_ID"' "$formula" >/dev/null ||
+    grep -F 'gc bd close "$WORK_BEAD"' "$formula" >/dev/null ||
         fail "shutdown dance should close the claimed warrant bead"
     ! grep -F '<wisp-id>' "$formula" >/dev/null ||
         fail "shutdown dance should not contain raw wisp placeholders"
@@ -85,7 +85,7 @@ test_shutdown_dance_lifecycle_and_audit_contracts() {
         fail "every early-exit path and the epitaph should end with gc runtime drain-ack"
     local malformed_branches malformed_closes malformed_drains
     malformed_branches="$(grep -c 'is missing target or reason' "$formula" || true)"
-    malformed_closes="$(grep -A4 'is missing target or reason' "$formula" | grep -cF 'gc bd close "$GC_BEAD_ID"' || true)"
+    malformed_closes="$(grep -A4 'is missing target or reason' "$formula" | grep -cF 'gc bd close "$WORK_BEAD"' || true)"
     malformed_drains="$(grep -A4 'is missing target or reason' "$formula" | grep -cF 'gc runtime drain-ack' || true)"
     [[ "$malformed_branches" -ge 1 ]] ||
         fail "shutdown dance should validate warrant target/reason metadata"
@@ -109,6 +109,41 @@ test_shutdown_dance_lifecycle_and_audit_contracts() {
         fail "dog prompt should notify the warrant's requester, not a hardcoded deacon endpoint"
     grep -F 'gc session nudge "$requester_endpoint"' "$prompt" >/dev/null ||
         fail "dog prompt DOG_DONE guidance should use the normalized requester endpoint"
+}
+
+# The claude provider never exports GC_BEAD_ID — it exports GC_TRIGGER_BEAD_ID
+# and GC_TRIGGER_WORK_BEAD_ID (ga-oyp60, porting gastownhall/gascity#4693). Every
+# formula that needs the claimed bead id must therefore read GC_BEAD_ID first, so
+# providers that do export it keep working, and fall back to
+# GC_TRIGGER_WORK_BEAD_ID instead of acting on an empty id.
+test_formulas_resolve_bead_id_without_gc_bead_id() {
+    local dance="$GASTOWN/formulas/mol-shutdown-dance.toml"
+    local patrol file
+
+    # The dance has no other source for the warrant id, and `gc bd close ""`
+    # fuzzy-matches an unrelated bead, so an unresolvable id must hard-abort.
+    # Both bootstrap blocks (preamble + receive-warrant) need the resolution:
+    # shell variables do not survive between steps.
+    [[ "$(grep -cF 'WORK_BEAD="${GC_BEAD_ID:-${GC_TRIGGER_WORK_BEAD_ID:?no work bead id in env}}"' "$dance")" -ge 2 ]] ||
+        fail "every shutdown dance bootstrap block should resolve WORK_BEAD from GC_BEAD_ID or GC_TRIGGER_WORK_BEAD_ID"
+    ! grep -E 'gc (bd|session|runtime|mail) [^|]*\$GC_BEAD_ID' "$dance" >/dev/null ||
+        fail "shutdown dance commands should use the resolved WORK_BEAD, not a bare GC_BEAD_ID"
+
+    # The patrols already degrade to a `gc bd list` lookup, and that path ends in
+    # `gc runtime drain-ack`. A `:?` rung would abort the shell before reaching
+    # either, leaking the wisp — so the env fallback is soft here, and sits ahead
+    # of the query, which picks by --limit=1 and can choose the wrong molecule.
+    for patrol in mol-refinery-patrol mol-deacon-patrol; do
+        file="$GASTOWN/formulas/$patrol.toml"
+        grep -F 'CURRENT_WISP="${GC_BEAD_ID:-${GC_TRIGGER_WORK_BEAD_ID:-}}"' "$file" >/dev/null ||
+            fail "$patrol should resolve the current wisp from GC_BEAD_ID or GC_TRIGGER_WORK_BEAD_ID"
+        ! grep -F 'CURRENT_WISP=${GC_BEAD_ID:-}' "$file" >/dev/null ||
+            fail "$patrol should not read GC_BEAD_ID without the GC_TRIGGER_WORK_BEAD_ID fallback"
+        ! grep -F 'CURRENT_WISP="${GC_BEAD_ID:-${GC_TRIGGER_WORK_BEAD_ID:?' "$file" >/dev/null ||
+            fail "$patrol wisp resolution must stay soft; a hard abort skips the gc bd list fallback and drain-ack"
+        [[ "$(grep -cF 'CURRENT_WISP="${GC_BEAD_ID' "$file")" -eq "$(grep -cF 'CURRENT_WISP=$(gc bd list' "$file")" ]] ||
+            fail "$patrol should keep one gc bd list fallback for every wisp resolution"
+    done
 }
 
 test_composition_is_documented() {
@@ -220,6 +255,7 @@ test_dog_assets_are_pack_local
 test_retired_dog_formulas_are_not_reintroduced
 test_shutdown_dance_contracts_are_executable
 test_shutdown_dance_lifecycle_and_audit_contracts
+test_formulas_resolve_bead_id_without_gc_bead_id
 test_composition_is_documented
 test_polecat_startup_uses_standard_hook_claim
 test_review_leg_contract_forbids_synthetic_mutation


### PR DESCRIPTION
> ⚠️ **Opened as DRAFT — the hosted test gate never ran.** GitHub Actions had a major outage on 2026-08-06, so there is no CI run for this branch and the gate verdict is `skipped`, not `pass`. This is **not** a diff-introduced failure: local adjudication against the true merge-base found nothing new (evidence below). Opening this PR itself triggers `ci.yml` on `pull_request → main`, so the real suite runs on its own once Actions recovers — `gh pr ready` once it is green.
>
> Note for whoever picks this up: the workflow lane names `test.yml`, which does not exist in this repo, and the real `ci.yml` has no `workflow_dispatch` trigger — there is no run to kick off by hand.

## What changed

The claude provider does not export `GC_BEAD_ID` — it exports `GC_TRIGGER_BEAD_ID` and `GC_TRIGGER_WORK_BEAD_ID`. Three gastown formulas still read `GC_BEAD_ID`, so on that provider they were acting on an **empty id**. Ports the fallback pattern from gastownhall/gascity#4693, with the rung kind chosen per site:

- **`mol-shutdown-dance` (hard rung)** — every command took the warrant id straight from `$GC_BEAD_ID` with no fallback, so an unset var meant `gc bd close ""`, which fuzzy-matches an unrelated bead. Both bootstrap blocks now resolve `WORK_BEAD` and abort before any `bd` write if the id is unresolvable.
- **`mol-refinery-patrol` (5 sites) + `mol-deacon-patrol` (1 site) (soft rung)** — these already degraded to a `gc bd list --type=molecule --limit=1` lookup. The env rung goes ahead of that query as a soft default, because a hard abort would skip both that fallback and the `gc runtime drain-ack` behind it, leaking the wisp.
- **`test_gastown_pack_assets.sh`** — updated the assertions that pinned the old literals (including the `-A4` malformed-warrant window, which would have silently counted 0), plus a new `test_formulas_resolve_bead_id_without_gc_bead_id` locking in the rung kind at each site.

Scope is prompt/formula + test assets only: no schema, auth, billing, env config, DB routing, or CI workflow file is touched.

## How it was tested

Adjudicated locally against the **true merge-base** — the branch is exactly one commit (806e0d0) on top of origin/main 0b95742:

| Check | Result |
| --- | --- |
| gastown shell tests @ origin/main (baseline) | 4/4 PASS |
| gastown shell tests @ 806e0d0 | 4/4 PASS (identical set) |
| `go test .` (root embed) @ HEAD | PASS |
| `validate_registry.py --require-git` @ HEAD | PASS |
| tomllib parse of all 3 changed formulas | PASS |
| Non-vacuity: new test vs origin/main formulas | FAILS (rc=1) — the added test really guards the change |

New (baseline-absent **and** diff-attributable) failures: **none**.

Both automated review lanes returned **minor-gaps — advisory only, non-blocking**; their full reports are below, and the follow-ups they name (four agent prompt templates still carrying the old literal) are out of scope for this diff.

Closes gp-e02

<sub>`gp-e02` is the synthetic input convoy the workflow resolved to; the substantive tracked item is **gp-9sj**, already closed with commit 806e0d0.</sub>

---

## CI gate

⚠️ **Test gate SKIPPED — no failure attributable to this diff** (raw suite: `not_run_actions_outage`). Run: `none` — GitHub Actions major outage, 2026-08-06. Opened as DRAFT because the gate is *unknown*, not because it failed.

```
DRAFT REASON: CI gate skipped: GitHub Actions major outage 2026-08-06. This is
NOT a diff-introduced failure — no failure is attributable to this diff.
Disregard any "this diff introduced test failures" banner: the hosted gate never
ran. Outage: githubstatus.com "Incident with Actions", impact critical,
Actions+Pages major_outage, still investigating at 18:11Z. Per mayor guidance on
gp-wr9, Actions runs were neither dispatched nor awaited.

STRUCTURAL FINDING (independent of the outage): this lane's ci_workflow var is
"test.yml", which does not exist in gascity-packs. The real workflow is ci.yml,
and it has NO workflow_dispatch trigger (pull_request/push on main only). The
bead's `gh workflow run test.yml` step is unexecutable on this rig and will break
every future pr-work run here. Needs a formula/var fix.

LOCAL ADJUDICATION (mirrors ci.yml; branch vs TRUE merge-base). The branch is
exactly one commit (806e0d0) on origin/main 0b95742, so origin/main IS the
merge-base — a stronger baseline than the bead's <=24h sampled run.
  BASELINE origin/main : 4/4 gastown shell tests PASS
  HEAD     806e0d0     : 4/4 gastown shell tests PASS (identical set)
  Also PASS at HEAD: `go test .` (root embed), `validate_registry.py
  --require-git`, tomllib parse of all 3 changed formulas.
  Non-vacuity check: the NEW test_gastown_pack_assets.sh FAILS (rc=1) against
  origin/main's formulas and passes against this diff's — the added test really
  guards the change.
  => NEW (baseline-absent AND diff-attributable) = EMPTY.

NOT RUN (declared, not silently skipped): pytest suites (pytest absent; bead
forbids installing), gc lint + role-prompt integration, the 4 Go module suites
(zero Go in diff), CodeQL, RPP conformance.

PUSH: origin (gastownhall) denied write to figgeous; pushed to the fork instead.
PR head must be `figgeous:pr-work/gp-9sj-806e0d0`, base gastownhall main.

GATE DEFERRED, NOT WAIVED: ci.yml triggers on pull_request->main, so opening the
PR will itself run the real suite once Actions recovers.
```

## Automated review — correctness + tests

```
VERDICT: minor-gaps — right shape, but the fallback variable is not the claimed bead, and the new test is a text contract that cannot see that.

CORRECTNESS
• GC_TRIGGER_WORK_BEAD_ID is a session-LAUNCH constant, not the claimed bead. gascity
  bakes it once from info.TriggerBeadID into the launch env (cmd/gc/session_lifecycle_parallel.go:1189,
  cmd/gc/build_desired_state.go:3249); a running process's env cannot track later claims or re-points.
  Live proof from the session writing this review (GC_PROVIDER=claude, pool worker):
  GC_TRIGGER_WORK_BEAD_ID=gp-6te while `gc hook --claim --json` returned gp-dtf — and gp-6te is
  assigned to a DIFFERENT agent (implementation-reviewer-2). So the fallback can be set-and-wrong,
  which `:?` does not catch: it guards unset, never wrong.
• Consequence for mol-shutdown-dance: `gc bd close "$WORK_BEAD"` can close a real-but-wrong warrant —
  arguably worse than the `gc bd close ""` fuzzy match it replaces, because it cannot fail loudly.
  Bites when a dog session takes a SECOND warrant in its lifetime (agents/dog/agent.toml:
  max_active_sessions=3, idle_timeout=2h).
  NOT VERIFIED: whether wake_mode="fresh" re-execs the provider process (re-resolving the env) before
  each warrant — internal/config/config.go:3412 says "start a new provider session on every wake".
  If it does, first-warrant dances are fine and only second-claim/re-point paths are exposed.
  Worth confirming before merge; it decides this bullet's severity.
• Patrols — the rung ORDERING is the wrong trade, independent of the above. The env rung now sits
  AHEAD of `gc bd list --status=in_progress --type=molecule --limit=1`. These are looping agents
  (pour next wisp, then burn current). On iteration 2+ a session-lifetime constant is
  DETERMINISTICALLY the stale first wisp, whereas the query it preempts is only POSSIBLY wrong
  (--limit=1). The commit justifies the order by that query's imprecision; for a looping agent the
  trade inverts. Suggest keeping the query first and using the env var only as its fallback.
• Nit: GC_BEAD_ID is exported nowhere in /home/thomas-o-neill/gascity or /home/thomas-o-neill/gastown,
  so the first rung is dead on every provider in this tree, not just claude (a provider outside the
  tree could still export it).

TESTS
• GOOD: test_formulas_resolve_bead_id_without_gc_bead_id is a genuine regression guard — verified it
  FAILS against the origin/main formulas and PASSES on this branch (ran it isolated against both
  trees). The -A4 malformed-warrant window now counts >=1 instead of silently 0.
• GAP: it is a literal-grep contract test only. Nothing asserts the SEMANTICS — that the resolved id
  equals the claimed bead — so the finding above is invisible to it. Cheap behavioural test: assert
  GC_TRIGGER_WORK_BEAD_ID == the id from `gc hook --claim --json`. It would fail today.
• GAP: `! grep -E 'gc (bd|session|runtime|mail) [^|]*\$GC_BEAD_ID'` is line-anchored and
  command-prefixed, so it misses $GC_BEAD_ID on CONTINUATION lines of multi-line nudge bodies —
  probed and confirmed missed. That is the exact shape of 6 of the sites this diff fixed
  (`Warrant: $GC_BEAD_ID`), i.e. the regression it most needs to guard is the one it cannot see.
• GAP (scope): agents/dog/prompt.template.md:54 still tells the dog to "Use $GC_BEAD_ID as the
  warrant id" — the agent prompt now contradicts the formula that same agent runs. Also unfixed and
  still carrying the exact literal this diff removed: refinery/prompt.template.md:70,115;
  deacon/prompt.template.md:90; witness/prompt.template.md:204. The new test globs only the two
  patrol formulas, so none of these are guarded.

Advisory only. No source touched; worktree clean. Suite `gastown/tests/test_gastown_pack_assets.sh` passes on the branch.
```

## Automated review — guardrails + risk

```
VERDICT: minor-gaps — no guardrail path touched, and the fix itself is sound; but
it is rolled out only to the formulas, leaving byte-identical siblings unpatched.
Advisory only; nothing here should block the PR.

SCOPE / GUARDRAIL EXPOSURE
- Diff is prompt + test assets only: gastown/formulas/{mol-shutdown-dance,
  mol-refinery-patrol,mol-deacon-patrol}.toml and gastown/tests/
  test_gastown_pack_assets.sh. No schema/migration, auth, billing, env config, DB
  pool routing, or CI workflow file is touched. No secrets, no tenant scoping, no
  unvalidated input. The `:?` message leaks only an env var NAME, not a value.
- Premise verified empirically from a live claude-provider session: GC_BEAD_ID is
  NOT exported, GC_TRIGGER_WORK_BEAD_ID is. The bug being fixed is real, not
  theoretical, and it is currently firing on every claude-provider agent.

HIGHEST-BLAST-RADIUS PATH — mol-shutdown-dance is the dog, which KILLS sessions
- Reassuring, and worth stating plainly: the kill target is still derived from
  warrant `target` metadata, which this diff does not touch. The empty-id hazard
  is confined to bead closure and nudge text and can never select the wrong
  session to kill. That bound is why this reads minor-gaps rather than risky.
- Replacing `gc bd close "$GC_BEAD_ID"` (empty -> bd fuzzy-matches an unrelated
  bead) with a hard abort is the right trade on a destructive path.
- Residual: the `:?` abort fires before any drain-ack, so an unresolvable id
  leaves the warrant in_progress and wedges the dog pool slot — the exact leak
  the formula's own text warns about ~15 lines further down. Consider degrading
  that branch to echo + `gc runtime drain-ack` + escalate, so the worst case is a
  drained slot rather than a stuck one.

INCOMPLETE ROLLOUT — pre-existing, NOT introduced by this diff
These were already broken; the diff fixes their twins and leaves them inconsistent.
- gastown/agents/dog/prompt.template.md:54 still tells the dog "Use `$GC_BEAD_ID`
  as the warrant id", while the formula it names now uses WORK_BEAD. The dog
  receives contradictory guidance for the same warrant. Highest-value follow-up.
- The identical `CURRENT_WISP=${GC_BEAD_ID:-}` snippet survives in
  agents/deacon:90, agents/refinery:70,115, agents/witness:204. Under the claude
  provider these ALWAYS fall through to `gc bd list --limit=1`, which this diff's
  own test comment notes "can choose the wrong molecule" — so the wrong wisp can
  be burned. No worse than before, but the fleet is now half-fixed.
- The new test only globs $GASTOWN/formulas/, so nothing guards those four prompt
  templates against the same regression.

MINOR / OUT OF SCOPE
- gastown/assets/scripts/checks/*-approved.sh read GC_BEAD_ID but abort loudly
  when unset, and docs invoke them with an inline GC_BEAD_ID= — fail-safe.

Suggested follow-up: extend the same resolution to the four agent prompt
templates. gastown pack asset tests pass locally on this branch.
```
