### PR TITLE
Add Mattermost chat gateway pack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         run: python3 validate_registry.py --require-git
 
       - name: Run Python pack tests
-        run: python3 -m pytest tests contributing/tests gascity/tests discord/tests github/tests slack-full/tests slack-channel/tests pr-pipeline/tests profiler/tests -q
+        run: python3 -m pytest tests contributing/tests gascity/tests discord/tests github/tests mattermost/tests slack-full/tests slack-channel/tests pr-pipeline/tests profiler/tests -q
 
       - name: Lint and exercise shared role prompt composition
         run: |

--- a/mattermost/commands/bind-dm.sh
+++ b/mattermost/commands/bind-dm.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -eu
+
+if [ -z "${GC_CITY_PATH:-}" ] || [ -z "${GC_PACK_DIR:-}" ]; then
+  echo "gc mattermost bind-dm: missing Gas City pack context" >&2
+  exit 1
+fi
+
+exec python3 "$GC_PACK_DIR/scripts/mattermost_chat_bind.py" --kind dm "$@"

--- a/mattermost/commands/bind-dm/command.toml
+++ b/mattermost/commands/bind-dm/command.toml
@@ -1,0 +1,2 @@
+description = 'Bind a Mattermost DM channel to one named session'
+run = '../bind-dm.sh'

--- a/mattermost/commands/bind-dm/help.md
+++ b/mattermost/commands/bind-dm/help.md
@@ -1,0 +1,11 @@
+Bind a Mattermost DM channel to exactly one named session.
+
+Examples:
+  gc mattermost bind-dm 9h5j7k1m3n5p7r9t1v3x5z7b9c sky
+
+This stores the binding under `.gc/services/mattermost/data/config.json`.
+Use exact permanent session names.
+
+The DM channel id is the Mattermost channel id of the direct-message channel
+between the bot account and the human, not the human's user id. The bot
+account must already be a member of that DM channel.

--- a/mattermost/commands/bind-room.sh
+++ b/mattermost/commands/bind-room.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -eu
+
+if [ -z "${GC_CITY_PATH:-}" ] || [ -z "${GC_PACK_DIR:-}" ]; then
+  echo "gc mattermost bind-room: missing Gas City pack context" >&2
+  exit 1
+fi
+
+exec python3 "$GC_PACK_DIR/scripts/mattermost_chat_bind.py" --kind room "$@"

--- a/mattermost/commands/bind-room/command.toml
+++ b/mattermost/commands/bind-room/command.toml
@@ -1,0 +1,2 @@
+description = 'Bind a Mattermost channel or thread to named sessions'
+run = '../bind-room.sh'

--- a/mattermost/commands/bind-room/help.md
+++ b/mattermost/commands/bind-room/help.md
@@ -1,0 +1,50 @@
+Bind a Mattermost channel or thread to one or more named sessions.
+
+Examples:
+  gc mattermost bind-room 9h5j7k1m3n5p7r9t1v3x5z7b9c sky lawrence
+  gc mattermost bind-room --team-id 7k3m9x2c5n8b1v4z6q0r2s4t6w 9h5j7k1m3n5p7r9t1v3x5z7b9c sky lawrence
+  gc mattermost bind-room --team-id 7k3m9x2c5n8b1v4z6q0r2s4t6w --enable-ambient-read 9h5j7k1m3n5p7r9t1v3x5z7b9c sky lawrence
+  gc mattermost bind-room --team-id 7k3m9x2c5n8b1v4z6q0r2s4t6w --enable-ambient-read --allow-untargeted-ambient-delivery 9h5j7k1m3n5p7r9t1v3x5z7b9c randy
+  gc mattermost bind-room --team-id 7k3m9x2c5n8b1v4z6q0r2s4t6w --enable-peer-fanout 9h5j7k1m3n5p7r9t1v3x5z7b9c corp--sky corp--priya
+  gc mattermost bind-room --team-id 7k3m9x2c5n8b1v4z6q0r2s4t6w --enable-peer-fanout --allow-untargeted-peer-fanout 9h5j7k1m3n5p7r9t1v3x5z7b9c corp--sky corp--priya
+
+This stores the binding under `.gc/services/mattermost/data/config.json`.
+Use exact permanent session names.
+Direct `bind-room` routing is mutually exclusive with
+`gc mattermost enable-room-launch` for the same room.
+
+A Mattermost thread is not a separate channel. To bind a single thread rather
+than a whole channel, pass the channel id plus the thread's root post id:
+
+  gc mattermost bind-room --root-id 2a4b6c8d0e2f4g6h8i0j2k4m6n 9h5j7k1m3n5p7r9t1v3x5z7b9c sky
+
+Ambient read is disabled by default. When enabled, messages in this bound
+channel or bound thread no longer need to mention the bot, but they still must
+explicitly target one or more `@session_name` values to route. Posts in a
+thread inherit the parent channel binding but still require a bot mention
+unless the thread root itself is also bound. Ambient-read bindings remain
+targeted-only even when the bot is mentioned directly, unless
+`--allow-untargeted-ambient-delivery` is enabled on an ambient-read room with
+exactly one bound session. In that sticky single-agent mode, every visible
+message routes to the one bound session, including messages that contain a
+non-exact shorthand mention.
+
+Ambient read consumes unmentioned channel messages. Mattermost delivers those
+posts over the WebSocket gateway only for channels the bot account has joined,
+so add the bot to the channel before enabling ambient read. Private channels
+additionally require an explicit invite.
+
+Peer fanout is disabled by default. When enabled, the bridge can reinject one
+session's room publish to other bound sessions as `mattermost_peer_publication`
+events without re-reading bot posts from Mattermost.
+
+Peer-fanout-enabled room bindings require lowercase canonical session names.
+Useful flags:
+
+- `--enable-ambient-read` / `--disable-ambient-read`
+- `--allow-untargeted-ambient-delivery` / `--disallow-untargeted-ambient-delivery`
+- `--enable-peer-fanout` / `--disable-peer-fanout`
+- `--allow-untargeted-peer-fanout` / `--disallow-untargeted-peer-fanout`
+- `--max-peer-triggered-publishes-per-root N`
+- `--max-total-peer-deliveries-per-root N`
+- `--max-peer-triggered-publishes-per-session-per-minute N`

--- a/mattermost/commands/enable-room-launch.sh
+++ b/mattermost/commands/enable-room-launch.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -eu
+
+if [ -z "${GC_CITY_PATH:-}" ] || [ -z "${GC_PACK_DIR:-}" ]; then
+  echo "gc mattermost enable-room-launch: missing Gas City pack context" >&2
+  exit 1
+fi
+
+exec python3 "$GC_PACK_DIR/scripts/mattermost_room_launch.py" "$@"

--- a/mattermost/commands/enable-room-launch/command.toml
+++ b/mattermost/commands/enable-room-launch/command.toml
@@ -1,0 +1,2 @@
+description = 'Enable launcher mode for a Mattermost root channel'
+run = '../enable-room-launch.sh'

--- a/mattermost/commands/enable-room-launch/help.md
+++ b/mattermost/commands/enable-room-launch/help.md
@@ -1,0 +1,32 @@
+Enable launcher mode for a Mattermost root channel.
+
+Usage:
+  gc mattermost enable-room-launch --team-id 7k3m9x2c5n8b1v4z6q0r2s4t6w 9h5j7k1m3n5p7r9t1v3x5z7b9c
+  gc mattermost enable-room-launch --team-id 7k3m9x2c5n8b1v4z6q0r2s4t6w --response-mode respond_all --default-handle corp/sky 9h5j7k1m3n5p7r9t1v3x5z7b9c
+
+Launcher-mode channels are different from direct `bind-room` channels:
+
+- `@@handle` in the root channel launches a thread-scoped session for that agent
+- the first agent reply creates the visible thread by replying to the launching
+  post; Mattermost threads live inside the same channel and are keyed by the
+  root post id, so there is no separate thread channel to bind or join
+- follow-up posts in that managed thread continue to the same session
+- `@@handle` inside the managed thread retargets the conversation to another agent
+- replying to an agent-authored post inside the managed thread implicitly targets that agent
+- unmentioned follow-ups inside the managed thread continue to the last agent the human addressed there
+- human-visible replies inside the managed thread are also forwarded to the other participating thread agents as peer input
+- include `@@rig/alias` in an agent reply if it should only fan out to a specific peer; untargeted replies to peer publications do not fan out
+- direct `bind-room` and launcher mode are mutually exclusive for one channel
+
+Launcher mode reads unmentioned channel messages. The bot account must be a
+member of the root channel so the WebSocket gateway receives `posted` events
+for it, otherwise `@@handle` traffic will not route.
+
+`mention_only` is the safe default. `respond_all` requires `--default-handle`
+and routes root-level unmentioned posts to that one handle, except root-level
+replies, which still require an explicit `@@handle`.
+
+Launcher rooms default to peer fanout enabled for managed threads. Use
+`--disable-peer-fanout` to turn that off, or
+`--disallow-untargeted-peer-fanout` to require explicit `@@rig/alias` peer
+targeting inside the thread.

--- a/mattermost/commands/import-app.sh
+++ b/mattermost/commands/import-app.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -eu
+
+if [ -z "${GC_CITY_PATH:-}" ] || [ -z "${GC_PACK_DIR:-}" ]; then
+  echo "gc mattermost import-app: missing Gas City pack context" >&2
+  exit 1
+fi
+
+exec python3 "$GC_PACK_DIR/scripts/mattermost_intake_import.py" "$@"

--- a/mattermost/commands/import-app/command.toml
+++ b/mattermost/commands/import-app/command.toml
@@ -1,0 +1,2 @@
+description = 'Import Mattermost server metadata and bot credentials into the pack state'
+run = '../import-app.sh'

--- a/mattermost/commands/import-app/help.md
+++ b/mattermost/commands/import-app/help.md
@@ -1,0 +1,31 @@
+Import Mattermost server metadata and the bot token into the shared intake
+state.
+
+Example:
+  gc mattermost import-app \
+    --server-url https://mattermost.example.com \
+    --bot-token "$MATTERMOST_BOT_TOKEN" \
+    --verification-token 1a2b3c4d5e6f7g8h9i0j1k2l3m
+
+Optional fields:
+  --command-name <name>            slash command root, default: gc
+  --bot-token-file <path>          read the bot token from a file
+  --verification-token-file <path> read the verification token from a file
+  --team-allowlist <id>            allow only specific team ids; repeatable
+  --channel-allowlist <id>         allow only specific channel ids; repeatable
+  --role-allowlist <role>          allow only specific Mattermost role names,
+                                   e.g. `system_admin` or `team_admin`; repeatable
+
+The bot token is a personal access token for a Mattermost bot account, created
+under System Console -> Integrations -> Bot Accounts. It is stored under the
+pack state root so the service can register slash commands and post workflow
+status updates.
+
+The verification token is the token Mattermost issues when a slash command or
+interactive integration is created. Inbound slash-command and interactive
+callbacks are authenticated by comparing that shared token, so there is no
+signature key to import.
+
+If you want launcher rooms or ambient-read room bindings, add the bot account
+to each channel you intend to read. Mattermost only streams posts for channels
+the bot is a member of.

--- a/mattermost/commands/map-channel.sh
+++ b/mattermost/commands/map-channel.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -eu
+
+if [ -z "${GC_CITY_PATH:-}" ] || [ -z "${GC_PACK_DIR:-}" ]; then
+  echo "gc mattermost map-channel: missing Gas City pack context" >&2
+  exit 1
+fi
+
+exec python3 "$GC_PACK_DIR/scripts/mattermost_intake_map_channel.py" "$@"

--- a/mattermost/commands/map-channel/command.toml
+++ b/mattermost/commands/map-channel/command.toml
@@ -1,0 +1,2 @@
+description = 'Map a Mattermost channel to a slash-command dispatch target'
+run = '../map-channel.sh'

--- a/mattermost/commands/map-channel/help.md
+++ b/mattermost/commands/map-channel/help.md
@@ -1,0 +1,17 @@
+Map a Mattermost channel to a workflow dispatch target.
+
+Example:
+  gc mattermost map-channel 7k3m9x2c5n8b1v4z6q0r2s4t6w 9h5j7k1m3n5p7r9t1v3x5z7b9c product/polecat \
+    --fix-formula mol-mattermost-fix-issue
+
+Arguments:
+  <team_id>     Mattermost team id
+  <channel_id>  Mattermost channel id
+  <target>      rig/pool sling target
+                `mol-mattermost-fix-issue` requires a `rig/polecat` target
+
+Flags:
+  --fix-formula <name>  formula to use for `/gc fix`, default: mol-mattermost-fix-issue
+
+Thread replies inherit the mapping from their channel, because a Mattermost
+thread is just a set of posts sharing a root post id inside that same channel.

--- a/mattermost/commands/map-rig.sh
+++ b/mattermost/commands/map-rig.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -eu
+
+if [ -z "${GC_CITY_PATH:-}" ] || [ -z "${GC_PACK_DIR:-}" ]; then
+  echo "gc mattermost map-rig: missing Gas City pack context" >&2
+  exit 1
+fi
+
+exec python3 "$GC_PACK_DIR/scripts/mattermost_intake_map_rig.py" "$@"

--- a/mattermost/commands/map-rig/command.toml
+++ b/mattermost/commands/map-rig/command.toml
@@ -1,0 +1,2 @@
+description = 'Map a Mattermost team rig name to a slash-command dispatch target'
+run = '../map-rig.sh'

--- a/mattermost/commands/map-rig/help.md
+++ b/mattermost/commands/map-rig/help.md
@@ -1,0 +1,18 @@
+Map a Mattermost team rig name to a workflow dispatch target.
+
+Example:
+  gc mattermost map-rig 7k3m9x2c5n8b1v4z6q0r2s4t6w mission-control mission-control/polecat \
+    --fix-formula mol-mattermost-fix-issue
+
+Arguments:
+  <team_id>     Mattermost team id
+  <rig_name>    Rig name as used in /gc fix <rig>
+  <target>      rig/pool sling target
+                `mol-mattermost-fix-issue` requires a `rig/polecat` target
+
+Flags:
+  --fix-formula <name>  formula to use for `/gc fix`, default: mol-mattermost-fix-issue
+
+Users type `/gc fix mission-control "summary"` in any channel. The rig
+parameter routes the request to the configured target regardless of which
+channel the command is invoked from.

--- a/mattermost/commands/post-message.sh
+++ b/mattermost/commands/post-message.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -eu
+
+if [ -z "${GC_CITY_PATH:-}" ] || [ -z "${GC_PACK_DIR:-}" ]; then
+  echo "gc mattermost post-message: missing Gas City pack context" >&2
+  exit 1
+fi
+
+exec python3 "$GC_PACK_DIR/scripts/mattermost_intake_post_message.py" "$@"

--- a/mattermost/commands/post-message/command.toml
+++ b/mattermost/commands/post-message/command.toml
@@ -1,0 +1,2 @@
+description = 'Post a Mattermost status update for a request or channel'
+run = '../post-message.sh'

--- a/mattermost/commands/post-message/help.md
+++ b/mattermost/commands/post-message/help.md
@@ -1,0 +1,20 @@
+Post a Mattermost message using the workspace bot token.
+
+Examples:
+  gc mattermost post-message --request-id mm-123-fix --body "Started work"
+  gc mattermost post-message --channel-id 9h5j7k1m3n5p7r9t1v3x5z7b9c --body-file ./message.txt
+  gc mattermost post-message --channel-id 9h5j7k1m3n5p7r9t1v3x5z7b9c --root-id 2a4b6c8d0e2f4g6h8i0j2k4m6n --body "Update"
+
+Flags:
+  --request-id <id>     load the target channel from a saved intake request
+  --channel-id <id>     channel id if no request id is provided
+  --root-id <id>        optional thread root post id to reply under
+  --body <text>         inline message body
+  --body-file <path>    read the message body from a file
+
+`--root-id` posts into an existing thread. The channel id stays the same for
+threaded and unthreaded posts; Mattermost threading is entirely a property of
+the root post id.
+
+Use `--request-id` from formulas so the message lands back in the original
+conversation.

--- a/mattermost/commands/publish.sh
+++ b/mattermost/commands/publish.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -eu
+
+if [ -z "${GC_CITY_PATH:-}" ] || [ -z "${GC_PACK_DIR:-}" ]; then
+  echo "gc mattermost publish: missing Gas City pack context" >&2
+  exit 1
+fi
+
+exec python3 "$GC_PACK_DIR/scripts/mattermost_chat_publish.py" "$@"

--- a/mattermost/commands/publish/command.toml
+++ b/mattermost/commands/publish/command.toml
@@ -1,0 +1,2 @@
+description = 'Publish a Mattermost-visible message through a saved chat binding'
+run = '../publish.sh'

--- a/mattermost/commands/publish/help.md
+++ b/mattermost/commands/publish/help.md
@@ -1,0 +1,40 @@
+Publish a human-visible Mattermost message through a saved chat binding.
+
+For agent replies to the current Mattermost turn, prefer:
+  gc mattermost reply-current --body-file ./reply.txt
+
+Examples:
+  gc mattermost publish --binding room:9h5j7k1m3n5p7r9t1v3x5z7b9c --body "hello humans"
+  gc mattermost publish --binding room:9h5j7k1m3n5p7r9t1v3x5z7b9c --trigger 5s7t9u1v3w5x7y9z1a3b5c7d9e --body-file ./reply.txt
+  gc mattermost publish --binding room:9h5j7k1m3n5p7r9t1v3x5z7b9c --conversation-id 4f6g8h0j2k4m6n8p0q2r4s6t8u --trigger 5s7t9u1v3w5x7y9z1a3b5c7d9e --body "Reply in another channel"
+  gc mattermost publish --binding launch-room:9h5j7k1m3n5p7r9t1v3x5z7b9c --source-event-kind mattermost_human_message --source-ingress-receipt-id in-5s7t9u1v3w5x7y9z1a3b5c7d9e --body-file ./reply.txt
+  gc mattermost publish --binding room:9h5j7k1m3n5p7r9t1v3x5z7b9c --source-event-kind mattermost_human_message --source-ingress-receipt-id in-5s7t9u1v3w5x7y9z1a3b5c7d9e --source-session corp--sky --body-file ./reply.txt
+
+`--conversation-id` overrides the destination channel for this send. Use it
+when the saved binding points at a different channel than the one the inbound
+message arrived from.
+
+`--root-id` overrides the thread root post id for this send. `--reply-to`
+overrides the post id used as the reply target. If neither is given, `--trigger`
+is used as the reply target when present, and the resulting post joins that
+post's thread.
+
+Direct `publish` is primarily for operator-controlled sends or cross-binding
+publishes. Peer fanout only participates when you also supply source metadata
+such as `--source-event-kind` plus `--source-ingress-receipt-id` or
+`--root-ingress-receipt-id`. For agent replies to the latest Mattermost turn,
+prefer `gc mattermost reply-current --body-file ...`.
+
+Launcher-backed replies normally should use `reply-current`, not direct
+`publish`. When source context includes a room-launch id, the bridge will start
+the managed thread on first publish by replying to the launching post, and then
+post subsequent messages under that same root post id.
+
+For multi-line or generated content, prefer `--body-file` over inline `--body`.
+Do not pipe publish output through filters that can hide failures. Treat a
+publish as successful only when the returned JSON contains `record.remote_message_id`.
+
+If the command exits with status `2`, the Mattermost post succeeded but peer
+fanout for other bound sessions was partial or needs operator attention.
+Inspect `record.peer_delivery` and use `gc mattermost retry-peer-fanout` if
+needed.

--- a/mattermost/commands/react.sh
+++ b/mattermost/commands/react.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -eu
+
+if [ -z "${GC_CITY_PATH:-}" ] || [ -z "${GC_PACK_DIR:-}" ]; then
+  echo "gc mattermost react: missing Gas City pack context" >&2
+  exit 1
+fi
+
+exec python3 "$GC_PACK_DIR/scripts/mattermost_chat_react.py" "$@"

--- a/mattermost/commands/react/command.toml
+++ b/mattermost/commands/react/command.toml
@@ -1,0 +1,2 @@
+description = 'Add an emoji reaction to the latest inbound Mattermost post for this session'
+run = '../react.sh'

--- a/mattermost/commands/react/help.md
+++ b/mattermost/commands/react/help.md
@@ -1,0 +1,68 @@
+# gc mattermost react
+
+Add an emoji reaction to a Mattermost post — typically the latest
+inbound post routed to the current session, used as a "got it,
+working on a reply" receipt for human posters.
+
+## Usage
+
+```
+gc mattermost react [--emoji NAME] [--session SID]
+gc mattermost react --conversation-id 9h5j7k1m3n5p7r9t1v3x5z7b9c --message-id 5s7t9u1v3w5x7y9z1a3b5c7d9e [--emoji NAME]
+```
+
+## Default mode
+
+With no arguments, the command:
+
+1. Resolves the current session id from `GC_SESSION_ID`.
+2. Queries `gc /v0/city/<city>/extmsg/transcript` for the latest
+   inbound post routed to that session.
+3. POSTs to the local Mattermost adapter `/react` with the post's
+   channel id + post id and the chosen emoji.
+4. The adapter calls Mattermost `POST /api/v4/reactions` with
+   `{user_id, post_id, emoji_name}`.
+
+## Explicit mode
+
+If you already know the channel id and post id, pass them directly.
+Both flags must be set together.
+
+## Flags
+
+- `--emoji NAME` — Mattermost `emoji_name`. Plain name, no colons:
+  `thumbsup`, not `:thumbsup:`. Surrounding colons are stripped if
+  you pass them. Default: `eyes`.
+- `--session SID` — override the session id (otherwise auto-resolved).
+- `--conversation-id <channel_id>` — explicit channel id (requires `--message-id`).
+- `--message-id <post_id>` — explicit post id (requires `--conversation-id`).
+- `--current` — explicit "use the latest inbound" mode (the default).
+
+Reacting to a post inside a thread needs only that post's id. The
+thread root post id is irrelevant to reactions.
+
+## Failure modes
+
+- No recent inbound for this session → exit 1, message tells you to
+  pass explicit flags.
+- Mattermost returns HTTP 404 for an unknown post or a channel the bot
+  cannot see → receipt `delivered=false`, `failure_kind=not_found`.
+- The bot account is not a member of the channel → HTTP 403, receipt
+  `delivered=false`, `failure_kind=auth`.
+- Re-adding a reaction the bot already added is a no-op on the
+  Mattermost side and is treated as success.
+
+## Examples
+
+```bash
+# After a system-reminder in a rig channel:
+gc mattermost react --emoji eyes
+
+# Acknowledge with a different emoji:
+gc mattermost react --emoji thinking_face
+
+# React to a specific post (e.g. from a debug script):
+gc mattermost react --conversation-id 9h5j7k1m3n5p7r9t1v3x5z7b9c \
+                    --message-id 5s7t9u1v3w5x7y9z1a3b5c7d9e \
+                    --emoji white_check_mark
+```

--- a/mattermost/commands/release-workflow.sh
+++ b/mattermost/commands/release-workflow.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -eu
+
+if [ -z "${GC_CITY_PATH:-}" ] || [ -z "${GC_PACK_DIR:-}" ]; then
+  echo "gc mattermost release-workflow: missing Gas City pack context" >&2
+  exit 1
+fi
+
+exec python3 "$GC_PACK_DIR/scripts/mattermost_intake_release_workflow.py" "$@"

--- a/mattermost/commands/release-workflow/command.toml
+++ b/mattermost/commands/release-workflow/command.toml
@@ -1,0 +1,2 @@
+description = 'Release a stuck workflow lock so the same Mattermost conversation can be retried'
+run = '../release-workflow.sh'

--- a/mattermost/commands/release-workflow/help.md
+++ b/mattermost/commands/release-workflow/help.md
@@ -1,0 +1,18 @@
+Release a stuck workflow lock for a Mattermost conversation.
+
+This is an operator recovery command. It does not touch the bead; it only
+clears the intake-side workflow lock so `/gc fix` can be accepted again for the
+same channel or thread.
+
+Example:
+  gc mattermost release-workflow 7k3m9x2c5n8b1v4z6q0r2s4t6w 9h5j7k1m3n5p7r9t1v3x5z7b9c
+  gc mattermost release-workflow --request-id mm-interaction-fix
+
+Arguments:
+  <team_id>          Mattermost team id
+  <conversation_id>  Channel id, or channel id plus thread root post id, used
+                     for the workflow key
+
+Flags:
+  --request-id <id> Release the workflow key recorded on an existing request
+  --command <name>  slash command to unlock, default: fix

--- a/mattermost/commands/reply-current.sh
+++ b/mattermost/commands/reply-current.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -eu
+
+if [ -z "${GC_CITY_PATH:-}" ] || [ -z "${GC_PACK_DIR:-}" ]; then
+  echo "gc mattermost reply-current: missing Gas City pack context" >&2
+  exit 1
+fi
+
+exec python3 "$GC_PACK_DIR/scripts/mattermost_chat_reply_current.py" "$@"

--- a/mattermost/commands/reply-current/command.toml
+++ b/mattermost/commands/reply-current/command.toml
@@ -1,0 +1,2 @@
+description = 'Reply to the latest Mattermost event seen by the current session'
+run = '../reply-current.sh'

--- a/mattermost/commands/reply-current/help.md
+++ b/mattermost/commands/reply-current/help.md
@@ -1,0 +1,31 @@
+Reply to the latest Mattermost event seen by the current session.
+
+This is the safest agent-facing Mattermost reply path. It resolves the latest
+`<mattermost-event>` from the current session transcript, reuses its
+`publish_binding_id`, `publish_conversation_id`, and reply threading metadata,
+then publishes the provided body back to Mattermost.
+
+For launcher-backed root-channel turns, the first successful `reply-current`
+starts the thread by replying to the launching post, and later replies reuse
+that root post id. The agent does not need to create or target a thread
+manually; Mattermost threads are just posts sharing a root post id in the same
+channel.
+
+Examples:
+  gc mattermost reply-current --body-file ./reply.txt
+  gc mattermost reply-current --session corp--sky --body-file ./reply.txt
+
+Prefer `--body-file` for agent replies. It avoids fragile shell quoting and
+makes multi-line responses safe.
+
+If you use `--session`, the override is treated as the source session identity
+for peer-fanout attribution as well as transcript lookup.
+
+In peer-fanout-enabled rooms, replying to a `mattermost_peer_publication` with
+an exact `@session_name` mention can route that publication to another bound
+session. Untargeted peer-triggered replies stay human-visible only.
+
+If the command exits with status `2`, the Mattermost reply was posted but peer
+fanout was only partially delivered. Inspect `record.peer_delivery` and ask an
+operator to run `gc mattermost retry-peer-fanout <publish-id>` if repair is
+needed.

--- a/mattermost/commands/retry-peer-fanout.sh
+++ b/mattermost/commands/retry-peer-fanout.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -eu
+
+if [ -z "${GC_CITY_PATH:-}" ] || [ -z "${GC_PACK_DIR:-}" ]; then
+  echo "gc mattermost retry-peer-fanout: missing Gas City pack context" >&2
+  exit 1
+fi
+
+exec python3 "$GC_PACK_DIR/scripts/mattermost_chat_retry_peer_fanout.py" "$@"

--- a/mattermost/commands/retry-peer-fanout/command.toml
+++ b/mattermost/commands/retry-peer-fanout/command.toml
@@ -1,0 +1,2 @@
+description = 'Retry failed peer fanout targets for a saved room publish without reposting to Mattermost'
+run = '../retry-peer-fanout.sh'

--- a/mattermost/commands/retry-peer-fanout/help.md
+++ b/mattermost/commands/retry-peer-fanout/help.md
@@ -1,0 +1,15 @@
+Retry failed peer fanout deliveries for a saved room publish without reposting
+the Mattermost message.
+
+Examples:
+  gc mattermost retry-peer-fanout mattermost-publish-123
+  gc mattermost retry-peer-fanout --include-unknown mattermost-publish-123
+  gc mattermost retry-peer-fanout --target corp--priya --target corp--eve mattermost-publish-123
+
+This command only re-drives saved peer targets from the publish record. It does
+not repost to Mattermost and it reuses the same deterministic idempotency keys.
+It is an operator repair path and intentionally does not re-apply peer-fanout
+budget limits.
+
+Use `--include-unknown` only after checking the target session transcript. A
+`delivery_unknown` target may already have received the peer envelope.

--- a/mattermost/commands/status.sh
+++ b/mattermost/commands/status.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -eu
+
+if [ -z "${GC_CITY_PATH:-}" ] || [ -z "${GC_PACK_DIR:-}" ]; then
+  echo "gc mattermost status: missing Gas City pack context" >&2
+  exit 1
+fi
+
+exec python3 "$GC_PACK_DIR/scripts/mattermost_intake_status.py" "$@"

--- a/mattermost/commands/status/command.toml
+++ b/mattermost/commands/status/command.toml
@@ -1,0 +1,2 @@
+description = 'Show Mattermost provider status, URLs, mappings, bindings, and recent activity'
+run = '../status.sh'

--- a/mattermost/commands/status/help.md
+++ b/mattermost/commands/status/help.md
@@ -1,0 +1,11 @@
+Show the current Mattermost configuration, published URLs, workflow mappings,
+chat bindings, and recent activity.
+
+Examples:
+  gc mattermost status
+  gc mattermost status --json
+
+The snapshot includes the public callback URL registered with Mattermost slash
+commands, the tenant admin URL, redacted server configuration (server URL, bot
+account, redacted bot and verification tokens), workflow mappings, chat
+bindings, recent `/gc fix` requests, and recent explicit chat publishes.

--- a/mattermost/commands/sync-commands.sh
+++ b/mattermost/commands/sync-commands.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -eu
+
+if [ -z "${GC_CITY_PATH:-}" ] || [ -z "${GC_PACK_DIR:-}" ]; then
+  echo "gc mattermost sync-commands: missing Gas City pack context" >&2
+  exit 1
+fi
+
+exec python3 "$GC_PACK_DIR/scripts/mattermost_intake_sync_commands.py" "$@"

--- a/mattermost/commands/sync-commands/command.toml
+++ b/mattermost/commands/sync-commands/command.toml
@@ -1,0 +1,2 @@
+description = 'Register team-scoped /gc slash commands with Mattermost'
+run = '../sync-commands.sh'

--- a/mattermost/commands/sync-commands/help.md
+++ b/mattermost/commands/sync-commands/help.md
@@ -1,0 +1,24 @@
+Register or replace the team-scoped `/gc` slash command for one or more
+Mattermost teams.
+
+Examples:
+  gc mattermost sync-commands 7k3m9x2c5n8b1v4z6q0r2s4t6w
+  gc mattermost sync-commands 7k3m9x2c5n8b1v4z6q0r2s4t6w 3d5f7g9h1j3k5m7n9p1q3r5s7t
+
+Arguments:
+  <team_id>...   one or more Mattermost team ids
+
+Registration uses the Mattermost integrations API (`/api/v4/commands`) with the
+bot token, so that account needs the `manage_slash_commands` permission on each
+team. Existing `/gc` commands owned by the pack are updated in place; the
+verification token recorded by `gc mattermost import-app` is reused so inbound
+callbacks keep validating.
+
+The command payload is intentionally small in this slice:
+
+- `/gc fix <summary>` opens an interactive dialog for summary and additional
+  context using the `trigger_id` from the slash-command callback
+- the raw trailing text is also accepted as a fallback `prompt` for clients
+  that cannot render the dialog
+- role, team, and channel policy is enforced by the workspace service after
+  Mattermost delivers the slash command

--- a/mattermost/commands/upload.sh
+++ b/mattermost/commands/upload.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -eu
+
+if [ -z "${GC_CITY_PATH:-}" ] || [ -z "${GC_PACK_DIR:-}" ]; then
+  echo "gc mattermost upload: missing Gas City pack context" >&2
+  exit 1
+fi
+
+exec python3 "$GC_PACK_DIR/scripts/mattermost_chat_upload.py" "$@"

--- a/mattermost/commands/upload/command.toml
+++ b/mattermost/commands/upload/command.toml
@@ -1,0 +1,2 @@
+description = 'Upload a local file into a session bound Mattermost channel'
+run = '../upload.sh'

--- a/mattermost/commands/upload/help.md
+++ b/mattermost/commands/upload/help.md
@@ -1,0 +1,107 @@
+# gc mattermost upload
+
+Upload a local file to the Mattermost channel a session is bound to.
+By default the upload is routed through gc, mirroring the text-reply
+contract: gc records the upload in the conversation transcript and
+fans out a peer notification to other sessions bound to the same
+room. Pass `--via adapter` to fall back to the direct-to-adapter path
+for diagnostics.
+
+Either way the local adapter handles Mattermost's two-step upload
+protocol (`POST /api/v4/files?channel_id=...&filename=...` to get a
+`file_id`, then `POST /api/v4/posts` with that id in `file_ids`).
+
+Use this instead of describing a file in text — Mattermost renders the
+attachment inline (image preview, code preview, etc.) and keeps it
+discoverable in the channel's file search.
+
+## Usage
+
+```
+# Plain upload into the bound channel, no thread
+gc mattermost upload --file ./out/plot.png
+
+# With a comment that acts as the message body
+gc mattermost upload --file ./out/plot.png --initial-comment "latest run, n=512"
+
+# Threaded under the most recent inbound (parallels reply-current)
+gc mattermost upload --file ./out/plot.png --thread-current
+
+# Threaded under a specific thread root post
+gc mattermost upload --file ./out/plot.png --root-id 2a4b6c8d0e2f4g6h8i0j2k4m6n
+```
+
+## Flags
+
+- `--file PATH` — local file to upload (required).
+- `--session SID` — session id whose binding to upload into. Defaults
+  to `$GC_SESSION_ID`.
+- `--filename NAME` — override the uploaded filename (defaults to
+  `basename(--file)`). This is the `filename` query parameter on the
+  file upload call and is what Mattermost displays.
+- `--initial-comment TEXT` — post message text sent alongside the
+  attachment. This is the `message` field of the created post.
+- `--root-id <post_id>` — thread root post id to attach under.
+  Mutually exclusive with `--thread-current`.
+- `--thread-current` — attach under the thread of the latest inbound
+  for this session, same logic as `gc mattermost reply-current`.
+- `--idempotency-key KEY` — caller-supplied idempotency key for
+  retries.
+- `--via {gc,adapter}` — routing path. `gc` (default) records the
+  upload in the transcript and fans out to peer sessions; `adapter`
+  bypasses gc for diagnostics only.
+
+## Required Mattermost access
+
+The bot account needs the `upload_file` permission and must be a
+member of the destination channel. Without membership the file call
+returns HTTP 403 and the adapter returns
+`{delivered: false, failure_kind: "auth", error: "forbidden"}` and
+prints the receipt — no exception is raised. Steps to grant:
+
+1. System Console -> Integrations -> Bot Accounts, confirm the bot is
+   active.
+2. Add the bot to the target team and channel.
+3. For private channels, invite the bot explicitly.
+
+There is no OAuth-scope reinstall step; the next
+`gc mattermost upload` picks up the new membership immediately.
+
+## Identity caveat
+
+Files post under the bot account's identity. Mattermost's per-post
+`override_username`/`override_icon_url` props only apply when the
+server has `EnablePostUsernameOverride` turned on, and they are not
+applied to the file attachment metadata itself. If per-session
+identity matters more than the inline preview, post the file with
+`gc mattermost upload` and follow up with `gc mattermost reply-current`
+containing the explanatory text — that reply carries the per-session
+identity.
+
+## How it works
+
+1. Resolves the session's active extmsg binding to find the target
+   channel id.
+2. **`--via gc` (default)** — POSTs the file metadata to
+   `/v0/city/{city}/extmsg/outbound-file`. gc verifies the binding,
+   hands off to the adapter via the FileTransportAdapter interface,
+   appends an outbound transcript entry, and emits an
+   `extmsg.outbound` event so peer sessions receive a nudge.
+3. **`--via adapter`** — POSTs `{session_id, conversation, file_path,
+   filename, initial_comment, root_id}` directly to the adapter's
+   `/publish-file` endpoint. No transcript record, no peer fanout.
+4. Either way, the adapter uploads the bytes, creates the post with
+   the returned `file_ids`, and returns a receipt with
+   `{delivered, file_id, failure_kind, error}`.
+
+## Examples
+
+```bash
+# PL session: upload a generated plot threaded under the human's request
+gc mattermost upload --file out/snr_plot.png \
+                     --initial-comment "snr vs t for 50 inj/rec runs" \
+                     --thread-current
+
+# cos session: post a status digest with attached CSV
+gc mattermost upload --file /tmp/digest.csv --initial-comment "overnight digest"
+```

--- a/mattermost/docs/known-issues.md
+++ b/mattermost/docs/known-issues.md
@@ -1,0 +1,157 @@
+# Known issues / operational gotchas
+
+Findings from standing this pack up for real on a production Gas City
+host — its first genuine live deployment (dot-wau, 2026-08-09/11).
+Every pack command (`import-app`, `bind-room`, `publish`, the gateway
+service) worked correctly against real Mattermost traffic; nothing here
+required a code change to the pack itself. Organized by where the
+problem actually lives, since that matters for anyone triaging a
+similar deployment.
+
+## Real gaps in this pack (worth fixing or at least flagging in review)
+
+### No CLI to remove a chat binding
+
+Once created via `bind-room`, there's no `gc mattermost unbind` /
+`remove-binding` command. If you bind the wrong channel, the only fix
+is a direct edit of the city's
+`.gc/services/mattermost/data/config.json`: load the JSON, pop the
+stale key out of `.chat.bindings`, write back atomically
+(temp file + rename) — same shape as the pack's own `atomic_write_json`
+helper. Binding-discovery logic that picks the first `kind == "room"`
+entry (e.g. a caller mirroring `deploy.sh`'s `mm_binding()` pattern)
+will otherwise nondeterministically pick a stale binding left behind
+by an earlier mistake. A first-class unbind command would remove the
+need for this workaround entirely.
+
+### `bind-room` doesn't check channel membership before binding
+
+A bot token that authenticates successfully isn't necessarily a bot
+that's a *member* of the channel you're binding — Mattermost channel
+membership is separate from token validity, and `bind-room` happily
+creates a binding for a channel the bot can't actually post to.
+`gc mattermost publish` against such a binding fails with an HTTP 403
+from Mattermost at *publish* time, not at bind time — by which point
+you've already told yourself the setup succeeded. A pre-flight
+`GET /api/v4/channels/<id>/members/me` check inside `bind-room` (warn
+or fail loud if the bot isn't a member) would surface this immediately
+instead of on the first real message.
+
+### Workspace-name mismatch silently falls back to the wrong API port
+
+`gc_api_base_url()` / `discover_supervisor_gc_api_scope()` resolve the
+city's local control API by looking up the city's `workspace_name`
+(from `.gc/site.toml` / `city.toml`) against the supervisor's live
+`/v0/cities` list. If that name doesn't match anything currently
+registered (e.g. `.gc/site.toml` has a stale name left over from a
+prior registration), discovery just returns empty and the code falls
+through to the **legacy, pre-supervisor** default port (9443) instead
+of the real supervisor port (8372) — with no error, no warning. Every
+subsequent `gc-api` call from the gateway then fails with a generic
+connection-refused, which looks exactly like a networking problem and
+gives zero hint that the actual issue is a name mismatch. This one
+cost real debugging time. Concretely:
+
+```
+$ curl http://127.0.0.1:8372/v0/cities
+{"items":[{"name":"phosphorus-city", ...}]}   # what's actually registered
+
+$ cat .gc/site.toml
+workspace_name = "dotfiles"                    # what the pack was looking for — no match
+```
+
+**Suggested fix:** when `discover_supervisor_gc_api_scope()` gets a
+non-empty `/v0/cities` response but finds no matching name, log (or
+surface via `gc mattermost status`) something like `city
+"<workspace_name>" not found among registered cities: [<names>]` —
+even just at debug level — instead of silently changing which port
+gets used.
+
+## Bugs in the `gc` binary itself (`gastownhall/gascity` — a different repo, not this pack)
+
+### `gc import add` mis-parses branch names containing `/`
+
+The GitHub tree-URL form (`https://github.com/<org>/<repo>/tree/<ref>/<path>`)
+is ambiguous when `<ref>` itself contains a slash — e.g. a branch named
+`feat/mattermost-pack`. The import parser splits on the first `/`
+after `tree/`, so `.../tree/feat/mattermost-pack/mattermost` gets read
+as ref=`feat`, path=`mattermost-pack/mattermost`, which doesn't exist,
+and the import fails with a "missing pack.toml" error naming that
+wrong path.
+
+**Workaround:** use the `.git//<subpath>` form with an explicit
+`--version sha:<commit>` instead, which has no ambiguity:
+
+```bash
+gc import add "https://github.com/<org>/<repo>.git//mattermost" \
+  --version "sha:<commit>" --name mattermost
+```
+
+## Environment/deployment pitfalls (config and host state, not code)
+
+### The bot can publish long before it can listen
+
+`gc mattermost publish --binding <id> --body-file <path>` is a
+stateless one-shot REST call — it works as soon as `import-app` has
+stored a valid bot token, independent of whether the city's own
+controller/supervisor has fully started. **Actually receiving and
+responding to messages (DMs, @-mentions) is a different story** — that
+needs the `mattermost-gateway` / `mattermost-interactions` `[[service]]`
+processes running, which only happens once the city's controller
+finishes initializing. If that controller is stuck (see the two causes
+below), `gc mattermost publish` still works fine, `gc service list`
+shows the gateway as `config` only (no live URL, no process), and
+messaging the bot gets total silence. `gc status` reporting
+`Controller: supervisor-managed (PID <n>, init failed)` is the first
+thing to check.
+
+Two concrete things that can wedge a controller's init on a host also
+running `bd`/beads:
+
+1. **`bd`/`dolt` not installed / not on PATH** — `gc register`'s beads
+   lifecycle step fails outright (`dolt: command not found`), and the
+   controller keeps retrying and failing on the supervisor's timer.
+2. **`bd` beads-store schema skew** — if the Dolt database has been
+   migrated ahead of what the installed `bd`/`gc` binaries understand
+   (`schema version mismatch: database is at vNN, binary knows up to
+   vMM`), `gc`'s internal `bd` subprocess calls fail silently and the
+   session reconciler can never progress ANY session bead past
+   `start-pending` — not just mattermost-related ones. Fixed live via
+   `BD_IGNORE_SCHEMA_SKEW=1` in the environment of the process that
+   spawns sessions (a systemd drop-in + actually cycling the daemon,
+   since env changes don't reach an already-running detached process).
+   This is a generic `gc`/`beads` compatibility issue, not mattermost-
+   pack-specific, but it manifests identically to gateway/session
+   problems and is easy to misattribute.
+
+### `gc`/`beads`/`dolt` version coupling
+
+`gc` links against a specific `beads` version at build time. If the
+standalone `bd`/`dolt` binaries on a host drift from what that build
+expects, `gc` can silently fall back to a much slower fork-per-op `bd`
+subprocess path instead of its native in-process store — documented
+elsewhere in this fleet as the direct cause of a multi-hour Dolt
+connection-storm incident on a different host. Known-good pairing
+referenced at that time: `gascity 1.4.0 ↔ beads 1.1.0 ↔ dolt 2.2.3`;
+nixpkgs' own `dolt`/`beads` packages were noted as mismatched versions
+at the time of writing. Before installing/upgrading any one of the
+three, check what the others actually need — don't bump in isolation.
+
+### Bot identity: use the host's own dedicated bot, not an unrelated one
+
+If your fleet already has a bot-per-purpose convention (e.g. one bot
+per host/city, separate from bots used for other automation's own
+status pings), **use the dedicated one** for `import-app`. Using the
+wrong (but valid) token is exactly how the channel-membership gap above
+gets discovered the hard way — the bot authenticates fine, and the
+403 only shows up at publish time.
+
+## Positive finding: the pack is model/provider-agnostic on the receiving end
+
+Wired a Gas City session's `start_command` to run `codex` against
+OpenRouter (a free-tier NVIDIA Nemotron model, non-Claude, no OAuth
+login) instead of the default Claude provider, purely to validate
+routing without needing interactive auth on a headless host. The
+mattermost-v0 prompt fragment + gateway routing worked identically —
+the pack has no hidden dependency on which agent/provider is behind
+the session it's routing to.

--- a/mattermost/doctor/bd/doctor.toml
+++ b/mattermost/doctor/bd/doctor.toml
@@ -1,0 +1,2 @@
+description = 'gc bd is available for Mattermost bead lifecycle commands'
+run = '../check-bd.sh'

--- a/mattermost/doctor/check-bd.sh
+++ b/mattermost/doctor/check-bd.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if ! command -v gc >/dev/null 2>&1 || ! gc bd version >/dev/null 2>&1; then
+  echo "gc bd unavailable"
+  echo "Install or expose gc with a working bd backend so the mattermost pack can manage fix-workflow beads."
+  exit 2
+fi
+
+echo "gc bd available"

--- a/mattermost/doctor/check-gc.sh
+++ b/mattermost/doctor/check-gc.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if ! command -v gc >/dev/null 2>&1; then
+  echo "gc CLI not found"
+  echo "Install or expose the gc binary so the mattermost pack can dispatch formulas."
+  exit 2
+fi
+
+echo "gc CLI available"

--- a/mattermost/doctor/check-git.sh
+++ b/mattermost/doctor/check-git.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if ! command -v git >/dev/null 2>&1; then
+  echo "git not found"
+  echo "Install or expose git so the mattermost pack can create and clean worktrees."
+  exit 2
+fi
+
+echo "git available"

--- a/mattermost/doctor/check-jq.sh
+++ b/mattermost/doctor/check-jq.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq not found"
+  echo "Install or expose jq so the mattermost pack can read workflow metadata."
+  exit 2
+fi
+
+echo "jq available"

--- a/mattermost/doctor/check-openssl.sh
+++ b/mattermost/doctor/check-openssl.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if ! command -v openssl >/dev/null 2>&1; then
+  echo "openssl not found"
+  echo "Install openssl so the mattermost pack can verify inbound tokens and webhook payloads."
+  exit 2
+fi
+
+openssl version | awk 'NR==1 { print $0 " available" }'

--- a/mattermost/doctor/check-python.sh
+++ b/mattermost/doctor/check-python.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -eu
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "python3 not found"
+  echo "Install Python 3.11 or newer to run the mattermost services."
+  exit 2
+fi
+
+python3 - <<'PY'
+import sys
+if sys.version_info < (3, 11):
+    print(f"python3 is {sys.version.split()[0]}; need 3.11+")
+    print("Install Python 3.11 or newer to run the mattermost services.")
+    raise SystemExit(2)
+print(f"python3 {sys.version.split()[0]} available")
+PY

--- a/mattermost/doctor/gc/doctor.toml
+++ b/mattermost/doctor/gc/doctor.toml
@@ -1,0 +1,2 @@
+description = 'gc CLI is available for Mattermost workflow dispatch'
+run = '../check-gc.sh'

--- a/mattermost/doctor/git/doctor.toml
+++ b/mattermost/doctor/git/doctor.toml
@@ -1,0 +1,2 @@
+description = 'git is available for Mattermost workflow worktree management'
+run = '../check-git.sh'

--- a/mattermost/doctor/jq/doctor.toml
+++ b/mattermost/doctor/jq/doctor.toml
@@ -1,0 +1,2 @@
+description = 'jq is available for Mattermost workflow metadata extraction'
+run = '../check-jq.sh'

--- a/mattermost/doctor/openssl/doctor.toml
+++ b/mattermost/doctor/openssl/doctor.toml
@@ -1,0 +1,2 @@
+description = 'openssl is available for the mattermost pack token and webhook verification'
+run = '../check-openssl.sh'

--- a/mattermost/doctor/python/doctor.toml
+++ b/mattermost/doctor/python/doctor.toml
@@ -1,0 +1,2 @@
+description = 'python3 3.11+ is available for the Mattermost services'
+run = '../check-python.sh'

--- a/mattermost/formulas/mol-mattermost-fix-issue.formula.toml
+++ b/mattermost/formulas/mol-mattermost-fix-issue.formula.toml
@@ -1,0 +1,336 @@
+description = """
+Mattermost-driven bugfix workflow for a GC worker session.
+
+This workflow is attached to a newly created rig bead for `/gc fix` requests
+accepted through the Mattermost pack. The intake service creates the bead,
+records the source Mattermost context, and slings it to the mapped worker
+target with this formula attached.
+
+The workflow is intentionally Mattermost-first:
+1. understand the bug and post a "work started" message back to Mattermost
+2. write or update tests first so the bug is reproduced
+3. implement the fix until the focused tests pass
+4. run a quality pass on the changed area
+5. post a completion message back to Mattermost with the current branch and bead
+6. release the intake workflow lock for that conversation
+"""
+formula = "mol-mattermost-fix-issue"
+version = 1
+
+[vars]
+[vars.issue]
+description = "The work bead id created for this Mattermost request"
+required = true
+
+[vars.mattermost_request_id]
+description = "Stable request id from the Mattermost pack service"
+required = true
+
+[vars.mattermost_team_id]
+description = "Mattermost team id"
+required = true
+
+[vars.mattermost_channel_id]
+description = "Mattermost channel id"
+required = true
+
+[vars.mattermost_root_id]
+description = "Mattermost thread root post id if the request originated in a thread"
+default = ""
+
+[vars.mattermost_conversation_id]
+description = "Mattermost conversation id used for idempotency"
+required = true
+
+[vars.mattermost_permalink_b64]
+description = "Base64-encoded Mattermost post permalink for safe interpolation into shell snippets"
+default = ""
+
+[vars.mattermost_requester_b64]
+description = "Base64-encoded Mattermost requester display name for safe interpolation into shell snippets"
+default = ""
+
+[vars.mattermost_summary_b64]
+description = "Base64-encoded Mattermost summary for safe interpolation into shell snippets"
+default = ""
+
+[vars.mattermost_context_b64]
+description = "Base64-encoded Mattermost context markdown for safe interpolation into shell snippets"
+default = ""
+
+[[steps]]
+id = "load-context"
+title = "Load context and announce work start"
+description = """
+Prime the session, understand the assignment, and post the first Mattermost
+message when work begins.
+
+**1. Prime the session:**
+```bash
+gc prime
+gc bd prime
+```
+
+**2. Inspect the bead and source context:**
+```bash
+gc bd show {{issue}}
+gc bd show {{issue}} --json | jq '.metadata'
+```
+
+Read the bead notes carefully. They contain:
+- the source Mattermost requester and conversation ids
+- the summary from the `/gc fix` interactive dialog
+- the additional freeform context supplied by the operator
+
+**3. Post the "work started" Mattermost message exactly once:**
+```bash
+STARTED=$(gc bd show {{issue}} --json | jq -r '.metadata.mattermost_fix_started_message_id // empty')
+if [ -z "$STARTED" ]; then
+  REQUESTER=$(python3 - <<'PY'
+import base64
+print(base64.b64decode("{{mattermost_requester_b64}}").decode("utf-8"))
+PY
+)
+  PERMALINK=$(python3 - <<'PY'
+import base64
+print(base64.b64decode("{{mattermost_permalink_b64}}").decode("utf-8"))
+PY
+)
+  BODY=$(mktemp)
+  cat >"$BODY" <<EOF
+Started work from Mattermost.
+
+- Bead: `{{issue}}`
+- Requested by: ${REQUESTER:-unknown}
+- Source: ${PERMALINK:-}
+
+I will follow up here again when the workflow is complete.
+EOF
+  MESSAGE_JSON=$(gc mattermost post-message --request-id {{mattermost_request_id}} --body-file "$BODY")
+  MESSAGE_ID=$(printf '%s' "$MESSAGE_JSON" | jq -r '.id // empty')
+  if [ -n "$MESSAGE_ID" ]; then
+    gc bd update {{issue}} --set-metadata mattermost_fix_started_message_id="$MESSAGE_ID"
+  fi
+  rm -f "$BODY"
+fi
+```
+
+**Exit criteria:** You understand the bug and the start message is posted or
+already recorded on the bead metadata."""
+
+[[steps]]
+id = "workspace-setup"
+title = "Set up worktree and fix branch"
+needs = ["load-context"]
+description = """
+Create or resume an isolated git worktree and a deterministic fix branch.
+
+**1. Fetch latest refs:**
+```bash
+git fetch --prune origin
+```
+
+**2. Reuse or create the bead-scoped worktree:**
+```bash
+WORKTREE=$(gc bd show {{issue}} --json | jq -r '.metadata.work_dir // empty')
+if [ -n "$WORKTREE" ] && [ -d "$WORKTREE" ]; then
+  cd "$WORKTREE"
+else
+  WORKTREE_ROOT="$(pwd)/.gc/worktrees"
+  mkdir -p "$WORKTREE_ROOT"
+  WORKTREE_PATH="$WORKTREE_ROOT/{{issue}}"
+  git worktree add "$WORKTREE_PATH" --detach origin/$(git remote show origin | sed -n '/HEAD branch/s/.*: //p')
+  cd "$WORKTREE_PATH"
+  gc bd update {{issue}} --set-metadata work_dir="$WORKTREE_PATH"
+fi
+```
+
+**3. Reuse or create the branch:**
+```bash
+BRANCH=$(gc bd show {{issue}} --json | jq -r '.metadata.branch // empty')
+if [ -n "$BRANCH" ]; then
+  git checkout "$BRANCH" 2>/dev/null || git checkout -b "$BRANCH"
+else
+  BRANCH="fix-mattermost-{{issue}}"
+  git checkout -b "$BRANCH"
+  gc bd update {{issue}} --set-metadata branch="$BRANCH"
+fi
+```
+
+**4. Verify a clean starting point:**
+```bash
+git status
+```
+
+**Exit criteria:** You are in a clean worktree on the recorded fix branch and
+the bead metadata reflects the active worktree and branch."""
+
+[[steps]]
+id = "understand-bug"
+title = "Understand the bug before writing code"
+needs = ["workspace-setup"]
+description = """
+Take a read-first pass so you understand the problem before changing code.
+
+**1. Re-read the bead notes and identify the likely files:**
+- inspect implementation files
+- inspect existing test coverage around the bug
+- identify the smallest reproducible failing behavior
+
+**2. Record the working theory in bead notes:**
+```bash
+CURRENT_NOTES=$(gc bd show {{issue}} --json | jq -r '.notes // empty')
+NOTES_FILE=$(mktemp)
+cat >"$NOTES_FILE" <<EOF
+$CURRENT_NOTES
+
+## Bug Understanding
+
+### Hypothesis
+- <what is broken and why>
+
+### Relevant files
+- <file>: <reason>
+
+### Test plan
+- <the failing test you will write first>
+EOF
+gc bd update {{issue}} --notes "$(cat "$NOTES_FILE")"
+rm -f "$NOTES_FILE"
+```
+
+**Exit criteria:** You can explain the bug clearly and you know which failing
+test will prove the fix."""
+
+[[steps]]
+id = "write-tests-first"
+title = "Write or update tests first"
+needs = ["understand-bug"]
+description = """
+Follow TDD. Capture the bug in tests before you change implementation logic.
+
+**1. Add or update the smallest regression test that proves the bug.**
+
+**2. Run the focused test target and confirm it fails for the right reason.**
+
+**3. If the code change is behavioral, do not proceed until you have a failing
+test or a clear explanation in bead notes for why a test is not appropriate.**
+
+**Exit criteria:** You have a failing test or an explicit, defensible reason
+recorded on the bead for why the change is non-behavioral."""
+
+[[steps]]
+id = "implement-fix"
+title = "Implement until the tests pass"
+needs = ["write-tests-first"]
+description = """
+Make the minimum implementation change that turns the failing test green.
+
+**1. Edit only the files needed for the bugfix.**
+
+**2. Re-run the focused test target until it passes.**
+
+**3. Run any nearby fast validation needed to ensure the fix did not regress
+the changed area.**
+
+**4. Update bead notes with the actual fix and validation command.**
+
+**Exit criteria:** The new regression test passes and you can explain the
+implementation change clearly."""
+
+[[steps]]
+id = "wrap-up"
+title = "Post completion update and release the workflow lock"
+needs = ["implement-fix"]
+description = """
+Summarize the work back to Mattermost, then release the conversation lock so
+the same thread can be used again later.
+
+**1. Capture the branch and validation summary:**
+```bash
+BRANCH=$(gc bd show {{issue}} --json | jq -r '.metadata.branch // empty')
+WORKTREE=$(gc bd show {{issue}} --json | jq -r '.metadata.work_dir // empty')
+```
+
+**2. Attempt the completion message:**
+```bash
+BODY=$(mktemp)
+cat >"$BODY" <<EOF
+Mattermost `/gc fix` workflow finished.
+
+- Bead: `{{issue}}`
+- Branch: `${BRANCH:-unknown}`
+- Worktree: `${WORKTREE:-unknown}`
+
+Please inspect the bead notes and local branch for the resulting patch.
+EOF
+POST_STATUS=0
+gc mattermost post-message --request-id {{mattermost_request_id}} --body-file "$BODY" || POST_STATUS=$?
+rm -f "$BODY"
+```
+
+**3. Release the intake workflow lock and finish cleanup even if the final
+Mattermost callback failed:**
+```bash
+if [ "$POST_STATUS" -ne 0 ]; then
+  echo "warning: failed to post Mattermost completion update" >&2
+fi
+RELEASE_WORKFLOW=1
+gc_mattermost_fix_cleanup() {
+  if [ "${RELEASE_WORKFLOW:-1}" -eq 1 ]; then
+    gc mattermost release-workflow --request-id {{mattermost_request_id}} >/dev/null 2>&1 || true
+  fi
+}
+trap gc_mattermost_fix_cleanup EXIT
+if command -v gt >/dev/null 2>&1; then
+  if ! gc bd ready {{issue}}; then
+    echo "error: failed to ready bead {{issue}} before gt done" >&2
+    RELEASE_WORKFLOW=0
+    exit 1
+  fi
+  if ! gt done; then
+    echo "error: gt done failed" >&2
+    RELEASE_WORKFLOW=0
+    exit 1
+  fi
+else
+  if [ -n "$WORKTREE" ] && [ -d "$WORKTREE" ]; then
+    GIT_COMMON_DIR=$(git -C "$WORKTREE" rev-parse --git-common-dir)
+    case "$GIT_COMMON_DIR" in
+      /*) ;;
+      *) GIT_COMMON_DIR="$WORKTREE/$GIT_COMMON_DIR" ;;
+    esac
+    CLEANUP_CWD=$(dirname "$GIT_COMMON_DIR")
+    if ! cd "$CLEANUP_CWD"; then
+      echo "error: failed to enter cleanup directory $CLEANUP_CWD" >&2
+      RELEASE_WORKFLOW=0
+      exit 1
+    fi
+    if ! git --git-dir="$GIT_COMMON_DIR" worktree remove "$WORKTREE" --force; then
+      echo "error: failed to remove worktree $WORKTREE" >&2
+      RELEASE_WORKFLOW=0
+      exit 1
+    fi
+    if ! gc bd update {{issue}} --unset-metadata work_dir; then
+      echo "error: failed to clear work_dir metadata for {{issue}}" >&2
+      RELEASE_WORKFLOW=0
+      exit 1
+    fi
+  fi
+  if ! gc bd ready {{issue}}; then
+    echo "error: failed to ready bead {{issue}}" >&2
+    RELEASE_WORKFLOW=0
+    exit 1
+  fi
+  if ! gc bd close {{issue}}; then
+    echo "error: failed to close bead {{issue}}" >&2
+    RELEASE_WORKFLOW=0
+    exit 1
+  fi
+fi
+```
+
+**Exit criteria:** Mattermost has the completion update, the workflow lock is
+released, and the session or bead has been finished through the local runtime's
+normal completion path. If the callback fails, the workflow still unlocks the
+conversation and surfaces the warning in the formula output."""

--- a/mattermost/pack.toml
+++ b/mattermost/pack.toml
@@ -1,0 +1,42 @@
+[pack]
+name = "mattermost"
+version = "0.1.0"
+schema = 2
+
+[[service]]
+name = "mattermost-interactions"
+kind = "proxy_process"
+state_root = ".gc/services/mattermost"
+
+[service.publication]
+visibility = "public"
+hostname = "mattermost"
+
+[service.process]
+command = ["python3", "-u", "scripts/mattermost_intake_service.py"]
+health_path = "/healthz"
+
+[[service]]
+name = "mattermost-admin"
+kind = "proxy_process"
+state_root = ".gc/services/mattermost"
+
+[service.publication]
+visibility = "tenant"
+hostname = "mattermost-admin"
+
+[service.process]
+command = ["python3", "-u", "scripts/mattermost_intake_service.py"]
+health_path = "/healthz"
+
+[[service]]
+name = "mattermost-gateway"
+kind = "proxy_process"
+state_root = ".gc/services/mattermost"
+
+[service.publication]
+visibility = "private"
+
+[service.process]
+command = ["python3", "-u", "scripts/mattermost_gateway_service.py"]
+health_path = "/healthz"

--- a/mattermost/scripts/mattermost_chat_bind.py
+++ b/mattermost/scripts/mattermost_chat_bind.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Any
+
+import mattermost_intake_common as common
+
+
+def _optional_bool(enabled: bool, disabled: bool, *, enable_flag: str, disable_flag: str) -> bool | None:
+    if enabled and disabled:
+        raise SystemExit(f"choose only one of {enable_flag} or {disable_flag}")
+    if enabled:
+        return True
+    if disabled:
+        return False
+    return None
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Bind a Mattermost conversation to one or more named sessions")
+    parser.add_argument("--kind", required=True, choices=("dm", "room"), help="Binding kind")
+    parser.add_argument("--team-id", default="", help="Mattermost team id")
+    parser.add_argument(
+        "--root-id",
+        default="",
+        help="Bind a single thread inside the channel instead of the whole channel",
+    )
+    parser.add_argument("--enable-ambient-read", action="store_true", help="Accept unmentioned messages in a bound room")
+    parser.add_argument("--disable-ambient-read", action="store_true", help="Disable unmentioned room intake")
+    parser.add_argument(
+        "--allow-untargeted-ambient-delivery",
+        action="store_true",
+        help="For a single-session ambient room, route untargeted messages to that bound session",
+    )
+    parser.add_argument(
+        "--disallow-untargeted-ambient-delivery",
+        action="store_true",
+        help="Require explicit @session_name targeting for ambient room messages",
+    )
+    parser.add_argument("--enable-peer-fanout", action="store_true", help="Enable peer fanout for bound room publishes")
+    parser.add_argument("--disable-peer-fanout", action="store_true", help="Disable peer fanout for bound room publishes")
+    parser.add_argument(
+        "--allow-untargeted-peer-fanout",
+        action="store_true",
+        help="Allow untargeted peer fanout inside a peer-enabled room",
+    )
+    parser.add_argument(
+        "--disallow-untargeted-peer-fanout",
+        action="store_true",
+        help="Require explicit peer targets for peer fanout",
+    )
+    parser.add_argument("--max-peer-triggered-publishes-per-root", type=int, default=None)
+    parser.add_argument("--max-total-peer-deliveries-per-root", type=int, default=None)
+    parser.add_argument("--max-peer-triggered-publishes-per-session-per-minute", type=int, default=None)
+    parser.add_argument("conversation_id", help="Mattermost channel id (DM channels are channels too)")
+    parser.add_argument("session_name", nargs="+", help="Gas City session name(s)")
+    args = parser.parse_args(argv)
+
+    ambient_read = _optional_bool(
+        args.enable_ambient_read,
+        args.disable_ambient_read,
+        enable_flag="--enable-ambient-read",
+        disable_flag="--disable-ambient-read",
+    )
+    untargeted_ambient_delivery = _optional_bool(
+        args.allow_untargeted_ambient_delivery,
+        args.disallow_untargeted_ambient_delivery,
+        enable_flag="--allow-untargeted-ambient-delivery",
+        disable_flag="--disallow-untargeted-ambient-delivery",
+    )
+    peer_fanout = _optional_bool(
+        args.enable_peer_fanout,
+        args.disable_peer_fanout,
+        enable_flag="--enable-peer-fanout",
+        disable_flag="--disable-peer-fanout",
+    )
+    untargeted_peer_fanout = _optional_bool(
+        args.allow_untargeted_peer_fanout,
+        args.disallow_untargeted_peer_fanout,
+        enable_flag="--allow-untargeted-peer-fanout",
+        disable_flag="--disallow-untargeted-peer-fanout",
+    )
+
+    room_policy: dict[str, Any] = {}
+    if ambient_read is not None:
+        room_policy["ambient_read_enabled"] = ambient_read
+    if untargeted_ambient_delivery is not None:
+        room_policy["allow_untargeted_ambient_delivery"] = untargeted_ambient_delivery
+    if peer_fanout is not None:
+        room_policy["peer_fanout_enabled"] = peer_fanout
+    if untargeted_peer_fanout is not None:
+        room_policy["allow_untargeted_peer_fanout"] = untargeted_peer_fanout
+    if args.max_peer_triggered_publishes_per_root is not None:
+        room_policy["max_peer_triggered_publishes_per_root"] = args.max_peer_triggered_publishes_per_root
+    if args.max_total_peer_deliveries_per_root is not None:
+        room_policy["max_total_peer_deliveries_per_root"] = args.max_total_peer_deliveries_per_root
+    if args.max_peer_triggered_publishes_per_session_per_minute is not None:
+        room_policy["max_peer_triggered_publishes_per_session_per_minute"] = args.max_peer_triggered_publishes_per_session_per_minute
+
+    if args.kind != "room" and room_policy:
+        raise SystemExit("room policy flags require --kind room")
+
+    root_id = str(args.root_id).strip()
+    if root_id and args.kind != "room":
+        raise SystemExit("--root-id requires --kind room")
+    # A Mattermost thread is not its own channel, so a thread binding is keyed
+    # by the channel id plus the thread root post id.
+    conversation_id = common.mattermost_conversation_key(args.conversation_id, root_id)
+
+    try:
+        config = common.set_chat_binding(
+            common.load_config(),
+            args.kind,
+            conversation_id,
+            args.session_name,
+            team_id=args.team_id,
+            policy=room_policy or None,
+        )
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
+
+    binding = common.resolve_chat_binding(config, common.chat_binding_id(args.kind, conversation_id))
+    print(json.dumps(binding or {}, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/mattermost/scripts/mattermost_chat_bind.py
+++ b/mattermost/scripts/mattermost_chat_bind.py
@@ -56,6 +56,16 @@ def main(argv: list[str]) -> int:
     parser.add_argument("--max-peer-triggered-publishes-per-root", type=int, default=None)
     parser.add_argument("--max-total-peer-deliveries-per-root", type=int, default=None)
     parser.add_argument("--max-peer-triggered-publishes-per-session-per-minute", type=int, default=None)
+    parser.add_argument(
+        "--enable-thread-replies",
+        action="store_true",
+        help="Reply-current threads replies under the message being answered (default)",
+    )
+    parser.add_argument(
+        "--disable-thread-replies",
+        action="store_true",
+        help="Force reply-current to post flat, top-level messages instead of threading. Valid for --kind room or dm.",
+    )
     parser.add_argument("conversation_id", help="Mattermost channel id (DM channels are channels too)")
     parser.add_argument("session_name", nargs="+", help="Gas City session name(s)")
     args = parser.parse_args(argv)
@@ -85,6 +95,13 @@ def main(argv: list[str]) -> int:
         disable_flag="--disallow-untargeted-peer-fanout",
     )
 
+    thread_replies = _optional_bool(
+        args.enable_thread_replies,
+        args.disable_thread_replies,
+        enable_flag="--enable-thread-replies",
+        disable_flag="--disable-thread-replies",
+    )
+
     room_policy: dict[str, Any] = {}
     if ambient_read is not None:
         room_policy["ambient_read_enabled"] = ambient_read
@@ -103,6 +120,11 @@ def main(argv: list[str]) -> int:
 
     if args.kind != "room" and room_policy:
         raise SystemExit("room policy flags require --kind room")
+
+    # thread_replies applies to any binding kind (unlike the room-only peer
+    # policy above), so it's merged in after the room-only guard.
+    if thread_replies is not None:
+        room_policy["thread_replies"] = thread_replies
 
     root_id = str(args.root_id).strip()
     if root_id and args.kind != "room":

--- a/mattermost/scripts/mattermost_chat_publish.py
+++ b/mattermost/scripts/mattermost_chat_publish.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+
+import mattermost_intake_common as common
+
+
+def _load_body(args: argparse.Namespace) -> str:
+    if args.body:
+        return args.body
+    if args.body_file:
+        return pathlib.Path(args.body_file).read_text(encoding="utf-8")
+    raise SystemExit("either --body or --body-file is required")
+
+
+def _hydrate_launch_source_context(binding: dict[str, object], source_context: dict[str, str]) -> dict[str, str]:
+    if str(binding.get("publish_route_kind", "")).strip() != "room_launch":
+        return source_context
+    if str(source_context.get("launch_id", "")).strip():
+        return source_context
+    ingress_id = str(source_context.get("ingress_receipt_id", "")).strip()
+    if not ingress_id:
+        raise SystemExit("launch-room publish requires --source-ingress-receipt-id")
+    receipt = common.load_chat_ingress(ingress_id)
+    if not receipt:
+        raise SystemExit(f"source ingress receipt not found: {ingress_id}")
+    launch_id = str(receipt.get("launch_id", "")).strip()
+    if not launch_id:
+        raise SystemExit(f"source ingress receipt has no launch_id: {ingress_id}")
+    hydrated = dict(source_context)
+    hydrated["launch_id"] = launch_id
+    hydrated.setdefault("root_ingress_receipt_id", ingress_id)
+    return hydrated
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Publish a Mattermost-visible message through a saved chat binding")
+    parser.add_argument("--binding", required=True, help="Binding id such as room:9h5j7k1m3n5p7r9t1v3x5z7b9c")
+    parser.add_argument("--conversation-id", default="", help="Mattermost channel id to publish into")
+    parser.add_argument("--trigger", default="", help="Original Mattermost post id for reply threading")
+    parser.add_argument("--root-id", default="", help="Thread root post id to publish under")
+    parser.add_argument("--reply-to", default="", help="Explicit Mattermost post id to reply to")
+    parser.add_argument(
+        "--source-event-kind",
+        default="",
+        choices=("", common.HUMAN_MESSAGE_EVENT_KIND, common.PEER_PUBLICATION_EVENT_KIND),
+        help="Optional source event kind for source attribution",
+    )
+    parser.add_argument(
+        "--source-ingress-receipt-id",
+        default="",
+        help="Ingress receipt id for the source Mattermost event",
+    )
+    parser.add_argument(
+        "--root-ingress-receipt-id",
+        default="",
+        help="Root ingress receipt id for the source Mattermost event",
+    )
+    parser.add_argument(
+        "--source-session",
+        default="",
+        help="Optional exact session name or id to attribute this publish to instead of the current session env",
+    )
+    parser.add_argument("--body", default="", help="Inline message body")
+    parser.add_argument("--body-file", default="", help="Read the message body from a file")
+    args = parser.parse_args(argv)
+
+    body = _load_body(args)
+    config = common.load_config()
+    binding = common.resolve_publish_route(config, args.binding)
+    if not binding:
+        raise SystemExit(f"binding not found: {args.binding}")
+
+    source_context: dict[str, str] = {}
+    if args.source_event_kind:
+        source_context["kind"] = args.source_event_kind
+    if args.source_ingress_receipt_id:
+        source_context["ingress_receipt_id"] = args.source_ingress_receipt_id
+    if args.root_ingress_receipt_id:
+        source_context["root_ingress_receipt_id"] = args.root_ingress_receipt_id
+    source_context = _hydrate_launch_source_context(binding, source_context)
+
+    source_identity: dict[str, str] = {}
+    try:
+        if args.source_session:
+            source_identity = common.resolve_session_identity(args.source_session)
+    except common.GCAPIError as exc:
+        raise SystemExit(str(exc)) from exc
+
+    # Mattermost threads are keyed by the root post id, and it rejects a
+    # root_id that points at a reply, so the reply target is normalized to its
+    # thread root downstream.
+    reply_target = str(args.root_id).strip() or str(args.reply_to).strip()
+
+    try:
+        payload = common.publish_binding_message(
+            binding,
+            body,
+            requested_conversation_id=args.conversation_id,
+            trigger_id=args.trigger,
+            reply_to_message_id=reply_target,
+            source_context=source_context or None,
+            source_session_name=str(source_identity.get("session_name", "")).strip(),
+            source_session_id=str(source_identity.get("session_id", "")).strip(),
+        )
+    except (ValueError, common.MattermostAPIError) as exc:
+        raise SystemExit(str(exc)) from exc
+
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return common.peer_delivery_exit_code(payload.get("record", {}))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/mattermost/scripts/mattermost_chat_react.py
+++ b/mattermost/scripts/mattermost_chat_react.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+import mattermost_intake_common as common
+
+DEFAULT_EMOJI = "eyes"
+DEFAULT_TRANSCRIPT_TAIL = 40
+
+
+def _failure_kind(exc: common.MattermostAPIError) -> str:
+    status = getattr(exc, "status_code", None)
+    if status == 404:
+        return "not_found"
+    if status in (401, 403):
+        return "auth"
+    if status == 429:
+        return "rate_limited"
+    if status == 400:
+        return "invalid_request"
+    return "error"
+
+
+def _resolve_target(args: argparse.Namespace) -> tuple[str, str, str, dict[str, str]]:
+    """Return (mode, conversation_id, post_id, source_context)."""
+    conversation_id = str(args.conversation_id).strip()
+    post_id = str(args.message_id).strip()
+    if conversation_id or post_id:
+        if args.current:
+            raise SystemExit("--current cannot be combined with --conversation-id/--message-id")
+        if not (conversation_id and post_id):
+            raise SystemExit("--conversation-id and --message-id must be passed together")
+        return "explicit", conversation_id, post_id, {}
+
+    try:
+        context = common.find_latest_mattermost_reply_context(args.session, tail=DEFAULT_TRANSCRIPT_TAIL)
+    except common.GCAPIError as exc:
+        raise SystemExit(
+            f"{exc}; pass --conversation-id <channel_id> --message-id <post_id> to react to a specific post"
+        ) from exc
+
+    post_id = str(context.get("mattermost_post_id", "")).strip() or str(context.get("publish_trigger_id", "")).strip()
+    conversation_id = str(context.get("publish_conversation_id", "")).strip()
+    if not post_id:
+        raise SystemExit(
+            "latest mattermost event has no post id; pass --conversation-id and --message-id explicitly"
+        )
+    return "current", conversation_id, post_id, context
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Add an emoji reaction to the latest inbound Mattermost post for this session"
+    )
+    parser.add_argument("--emoji", default=DEFAULT_EMOJI, help="Mattermost emoji_name, no colons (default: eyes)")
+    parser.add_argument("--session", default="", help="Override session selector")
+    parser.add_argument("--conversation-id", default="", help="Explicit Mattermost channel id (requires --message-id)")
+    parser.add_argument("--message-id", default="", help="Explicit Mattermost post id (requires --conversation-id)")
+    parser.add_argument("--current", action="store_true", help="React to the latest inbound post (the default)")
+    args = parser.parse_args(argv)
+
+    emoji_name = common.normalize_emoji_name(args.emoji)
+    if not emoji_name:
+        raise SystemExit("--emoji must be a non-empty emoji name such as eyes")
+
+    mode, conversation_id, post_id, context = _resolve_target(args)
+    session_selector = str(args.session).strip() or common.current_session_selector()
+
+    receipt: dict[str, object] = {
+        "delivered": False,
+        "mode": mode,
+        "emoji": emoji_name,
+        "conversation_id": conversation_id,
+        "post_id": post_id,
+        "session_selector": session_selector,
+        "binding_id": str(context.get("publish_binding_id", "")).strip(),
+        "user_id": "",
+        "failure_kind": "",
+        "error": "",
+    }
+
+    try:
+        bot_user_id = common.resolve_bot_user_id()
+        if not bot_user_id:
+            raise common.MattermostAPIError("could not resolve the bot user id from GET /users/me")
+        receipt["user_id"] = bot_user_id
+        # Re-adding a reaction the bot already owns is a no-op server side.
+        response = common.add_message_reaction(post_id, emoji_name, user_id=bot_user_id)
+    except common.MattermostAPIError as exc:
+        receipt["failure_kind"] = _failure_kind(exc)
+        receipt["error"] = str(exc)
+        print(json.dumps(receipt, indent=2, sort_keys=True))
+        return 1
+
+    receipt["delivered"] = True
+    receipt["reaction"] = response
+    print(json.dumps(receipt, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/mattermost/scripts/mattermost_chat_reply_current.py
+++ b/mattermost/scripts/mattermost_chat_reply_current.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pathlib
+import sys
+
+import mattermost_intake_common as common
+
+
+def _load_body(args: argparse.Namespace) -> str:
+    if args.body:
+        return args.body
+    if args.body_file:
+        return pathlib.Path(args.body_file).read_text(encoding="utf-8")
+    raise SystemExit("either --body or --body-file is required")
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Reply to the latest Mattermost event seen by the current session")
+    parser.add_argument("--session", default="", help="Override session selector")
+    parser.add_argument("--tail", type=int, default=40, help="Transcript messages to search for Mattermost context")
+    parser.add_argument("--conversation-id", default="", help="Mattermost channel id to reply in")
+    parser.add_argument("--root-id", default="", help="Mattermost thread root post id to reply under")
+    parser.add_argument("--reply-to", default="", help="Mattermost post id to reply to")
+    parser.add_argument("--body", default="", help="Inline message body")
+    parser.add_argument("--body-file", default="", help="Read the message body from a file")
+    args = parser.parse_args(argv)
+
+    body = _load_body(args)
+    context: dict[str, str] = {}
+    try:
+        context = common.find_latest_mattermost_reply_context(args.session, tail=max(1, args.tail))
+    except common.GCAPIError as exc:
+        if not str(args.conversation_id).strip():
+            raise SystemExit(str(exc)) from exc
+        context = {}
+
+    requested_conversation_id = str(args.conversation_id).strip() or str(context.get("publish_conversation_id", "")).strip()
+    root_post_id = (
+        str(args.root_id).strip()
+        or str(args.reply_to).strip()
+        or str(context.get("publish_root_post_id", "")).strip()
+    )
+    binding_id = str(context.get("publish_binding_id", "")).strip()
+
+    if binding_id:
+        config = common.load_config()
+        binding = common.resolve_publish_route(config, binding_id)
+        if not binding:
+            raise SystemExit(f"binding not found: {binding_id}")
+        source_identity: dict[str, str] = {}
+        try:
+            if args.session:
+                source_identity = common.resolve_session_identity(args.session)
+        except common.GCAPIError as exc:
+            raise SystemExit(str(exc)) from exc
+        try:
+            payload = common.publish_binding_message(
+                binding,
+                body,
+                requested_conversation_id=requested_conversation_id,
+                trigger_id=str(context.get("publish_trigger_id", "")).strip(),
+                reply_to_message_id=root_post_id,
+                source_context=context or None,
+                source_session_name=str(source_identity.get("session_name", "")).strip(),
+                source_session_id=str(source_identity.get("session_id", "")).strip(),
+            )
+        except (ValueError, common.MattermostAPIError) as exc:
+            raise SystemExit(str(exc)) from exc
+        source_meta = common.derive_publish_source_metadata(context)
+        payload["reply_context"] = {
+            "session_selector": str(args.session).strip() or common.current_session_selector(),
+            "binding_id": binding_id,
+            "source_event_kind": str(source_meta.get("source_event_kind", "")).strip(),
+            "root_ingress_receipt_id": str(source_meta.get("root_ingress_receipt_id", "")).strip(),
+            "publish_conversation_id": requested_conversation_id,
+            "publish_trigger_id": str(context.get("publish_trigger_id", "")).strip(),
+            "publish_root_post_id": str(payload.get("record", {}).get("root_post_id", "")).strip() or root_post_id,
+            "source_session_name": str(source_identity.get("session_name", "")).strip()
+            or str(os.environ.get("GC_SESSION_NAME", "")).strip(),
+            "source_session_id": str(source_identity.get("session_id", "")).strip()
+            or str(os.environ.get("GC_SESSION_ID", "")).strip(),
+        }
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return common.peer_delivery_exit_code(payload.get("record", {}))
+
+    conversation_id = requested_conversation_id
+    if not conversation_id:
+        raise SystemExit("latest mattermost event is missing publish_conversation_id")
+    try:
+        # Mattermost rejects a root_id that points at a reply, so walk the
+        # reply target up to its thread root before posting.
+        resolved_root_id = common.resolve_thread_root_id(conversation_id, root_post_id) if root_post_id else ""
+        response = common.post_channel_message(
+            conversation_id,
+            body,
+            root_id=resolved_root_id,
+        )
+    except common.MattermostAPIError as exc:
+        raise SystemExit(str(exc)) from exc
+
+    remote_message_id = str((response or {}).get("id", "")).strip()
+    if not remote_message_id:
+        raise SystemExit("mattermost publish returned no post id")
+
+    result = {
+        "record": {
+            "remote_message_id": remote_message_id,
+            "conversation_id": conversation_id,
+            "root_post_id": resolved_root_id,
+        },
+        "response": response,
+        "reply_context": {
+            "session_selector": str(args.session).strip() or common.current_session_selector(),
+            "binding_id": binding_id,
+            "publish_conversation_id": conversation_id,
+            "publish_root_post_id": resolved_root_id,
+            "source_session_name": str(os.environ.get("GC_SESSION_NAME", "")).strip(),
+            "source_session_id": str(os.environ.get("GC_SESSION_ID", "")).strip(),
+        },
+    }
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/mattermost/scripts/mattermost_chat_retry_peer_fanout.py
+++ b/mattermost/scripts/mattermost_chat_retry_peer_fanout.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+import mattermost_intake_common as common
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Retry peer fanout for a previously published Mattermost room message")
+    parser.add_argument("--include-unknown", action="store_true", help="Also retry targets currently marked delivery_unknown")
+    parser.add_argument("--target", action="append", default=[], help="Retry only the named session target (repeatable)")
+    parser.add_argument("publish_id", help="Saved publish id to redrive")
+    args = parser.parse_args(argv)
+
+    try:
+        record = common.retry_peer_fanout(
+            args.publish_id,
+            include_unknown=args.include_unknown,
+            target_session_names=args.target,
+        )
+    except (ValueError, common.GCAPIError) as exc:
+        raise SystemExit(str(exc)) from exc
+
+    print(json.dumps(record, indent=2, sort_keys=True))
+    return common.peer_delivery_exit_code(record)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/mattermost/scripts/mattermost_chat_upload.py
+++ b/mattermost/scripts/mattermost_chat_upload.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import pathlib
+import sys
+from typing import Any
+
+import mattermost_intake_common as common
+
+DEFAULT_TRANSCRIPT_TAIL = 40
+VIA_GC = "gc"
+VIA_ADAPTER = "adapter"
+
+
+def _failure_kind(exc: common.MattermostAPIError) -> str:
+    status = getattr(exc, "status_code", None)
+    if status == 404:
+        return "not_found"
+    if status in (401, 403):
+        return "auth"
+    if status == 429:
+        return "rate_limited"
+    if status == 413:
+        return "too_large"
+    if status == 400:
+        return "invalid_request"
+    return "error"
+
+
+def _idempotency_dir() -> str:
+    return os.path.join(common.data_dir(), "upload-idempotency")
+
+
+def _idempotency_path(key: str) -> str:
+    digest = hashlib.sha256(key.encode("utf-8")).hexdigest()[:32]
+    return os.path.join(_idempotency_dir(), f"upload-{digest}.json")
+
+
+def _load_idempotent_receipt(key: str) -> tuple[dict[str, Any], int]:
+    """Return the cached (receipt, exit_code) for an idempotency key."""
+    if not key:
+        return {}, 0
+    cached = common.read_json(_idempotency_path(key), default=None, allow_invalid=True)
+    if isinstance(cached, dict) and cached.get("receipt"):
+        receipt = cached.get("receipt")
+        if not isinstance(receipt, dict):
+            return {}, 0
+        try:
+            exit_code = int(cached.get("exit_code", 0))
+        except (TypeError, ValueError):
+            exit_code = 0
+        return receipt, exit_code
+    return {}, 0
+
+
+def _save_idempotent_receipt(key: str, receipt: dict[str, Any], exit_code: int) -> None:
+    if not key:
+        return
+    os.makedirs(_idempotency_dir(), exist_ok=True)
+    common.atomic_write_json(
+        _idempotency_path(key),
+        {
+            "idempotency_key": key,
+            "saved_at": common.utcnow(),
+            "exit_code": int(exit_code),
+            "receipt": receipt,
+        },
+    )
+
+
+def _read_file(path: str) -> bytes:
+    candidate = pathlib.Path(path).expanduser()
+    if not candidate.exists():
+        raise SystemExit(f"file not found: {path}")
+    if not candidate.is_file():
+        raise SystemExit(f"not a regular file: {path}")
+    try:
+        return candidate.read_bytes()
+    except OSError as exc:
+        raise SystemExit(f"cannot read {path}: {exc}") from exc
+
+
+def _resolve_binding(session_selector: str) -> tuple[dict[str, Any], dict[str, str]]:
+    try:
+        context = common.find_latest_mattermost_reply_context(session_selector, tail=DEFAULT_TRANSCRIPT_TAIL)
+    except common.GCAPIError as exc:
+        raise SystemExit(f"{exc}; bind this session with `gc mattermost bind-room` or `gc mattermost bind-dm` first") from exc
+    binding_id = str(context.get("publish_binding_id", "")).strip()
+    if not binding_id:
+        raise SystemExit("latest mattermost event has no publish_binding_id")
+    binding = common.resolve_publish_route(common.load_config(), binding_id)
+    if not binding:
+        raise SystemExit(f"binding not found: {binding_id}")
+    return binding, context
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Upload a local file into a session bound Mattermost channel")
+    parser.add_argument("--file", required=True, help="Local file to upload")
+    parser.add_argument("--session", default="", help="Session id whose binding to upload into")
+    parser.add_argument("--filename", default="", help="Override the uploaded filename (defaults to basename of --file)")
+    parser.add_argument("--initial-comment", default="", help="Post message text sent alongside the attachment")
+    parser.add_argument("--root-id", default="", help="Thread root post id to attach under")
+    parser.add_argument(
+        "--thread-current",
+        action="store_true",
+        help="Attach under the thread of the latest inbound for this session",
+    )
+    parser.add_argument("--idempotency-key", default="", help="Caller supplied idempotency key for retries")
+    parser.add_argument(
+        "--via",
+        default=VIA_GC,
+        choices=(VIA_GC, VIA_ADAPTER),
+        help="Routing path: gc records the upload and fans out to peers; adapter bypasses gc for diagnostics",
+    )
+    args = parser.parse_args(argv)
+
+    root_id = str(args.root_id).strip()
+    if root_id and args.thread_current:
+        raise SystemExit("--root-id and --thread-current are mutually exclusive")
+
+    content = _read_file(args.file)
+    filename = str(args.filename).strip() or os.path.basename(str(args.file).rstrip("/")) or "upload.bin"
+    message = str(args.initial_comment)
+    idempotency_key = str(args.idempotency_key).strip()
+    session_selector = str(args.session).strip() or common.current_session_selector()
+
+    cached_receipt, cached_exit_code = _load_idempotent_receipt(idempotency_key)
+    if cached_receipt:
+        replay = dict(cached_receipt)
+        replay["idempotent_replay"] = True
+        print(json.dumps(replay, indent=2, sort_keys=True))
+        # Replaying a partially-delivered upload must not read as a clean success.
+        return cached_exit_code if replay.get("delivered") else 1
+
+    binding, context = _resolve_binding(str(args.session).strip())
+
+    source_context: dict[str, str] = dict(context)
+    trigger_id = ""
+    if args.thread_current:
+        trigger_id = str(context.get("publish_trigger_id", "")).strip()
+    else:
+        # A plain upload posts at channel level; drop the inbound threading hints
+        # but keep launch/attribution metadata so room launches still route.
+        source_context.pop("publish_root_post_id", None)
+        source_context.pop("publish_trigger_id", None)
+
+    try:
+        conversation_id, root_post_id, _launch = common.resolve_publish_destination(
+            binding,
+            trigger_id=trigger_id,
+            reply_to_message_id=root_id,
+            source_context=source_context,
+        )
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
+    except common.MattermostAPIError as exc:
+        raise SystemExit(str(exc)) from exc
+    if not conversation_id:
+        raise SystemExit("binding is missing a destination conversation_id")
+
+    source_identity: dict[str, str] = {}
+    if str(args.session).strip():
+        try:
+            source_identity = common.resolve_session_identity(str(args.session).strip())
+        except common.GCAPIError as exc:
+            raise SystemExit(str(exc)) from exc
+
+    receipt: dict[str, Any] = {
+        "delivered": False,
+        "via": str(args.via),
+        "file_id": "",
+        "file_ids": [],
+        "filename": filename,
+        "size_bytes": len(content),
+        "conversation_id": conversation_id,
+        "root_id": root_post_id,
+        "post_id": "",
+        "binding_id": str(binding.get("id", "")).strip(),
+        "session_selector": session_selector,
+        "idempotency_key": idempotency_key,
+        "failure_kind": "",
+        "error": "",
+    }
+
+    try:
+        uploaded = common.mattermost_upload_request(
+            "/files",
+            [("channel_id", conversation_id)],
+            [("files", filename, content)],
+        )
+        file_infos = (uploaded or {}).get("file_infos")
+        file_ids = [
+            str(item.get("id", "")).strip()
+            for item in (file_infos if isinstance(file_infos, list) else [])
+            if isinstance(item, dict) and str(item.get("id", "")).strip()
+        ]
+        if not file_ids:
+            raise common.MattermostAPIError("mattermost upload returned no file id")
+        receipt["file_ids"] = file_ids
+        receipt["file_id"] = file_ids[0]
+
+        if str(args.via) == VIA_ADAPTER:
+            response = common.post_channel_message(
+                conversation_id,
+                message,
+                root_id=root_post_id,
+                file_ids=file_ids,
+            )
+            payload: dict[str, Any] = {"response": response}
+            exit_code = 0
+        else:
+            payload = common.publish_binding_message(
+                binding,
+                message,
+                trigger_id=trigger_id,
+                reply_to_message_id=root_id,
+                source_context=source_context or None,
+                source_session_name=str(source_identity.get("session_name", "")).strip(),
+                source_session_id=str(source_identity.get("session_id", "")).strip(),
+                file_ids=file_ids,
+            )
+            response = payload.get("response") or {}
+            receipt["record"] = payload.get("record", {})
+            exit_code = common.peer_delivery_exit_code(payload.get("record", {}))
+    except (ValueError, common.MattermostAPIError) as exc:
+        if isinstance(exc, common.MattermostAPIError):
+            receipt["failure_kind"] = _failure_kind(exc)
+        else:
+            receipt["failure_kind"] = "invalid_request"
+        receipt["error"] = str(exc)
+        # Failures are not cached: a retry with the same key must try again.
+        print(json.dumps(receipt, indent=2, sort_keys=True))
+        return 1
+
+    receipt["delivered"] = True
+    receipt["post_id"] = str((response or {}).get("id", "")).strip()
+    receipt["response"] = response
+    _save_idempotent_receipt(idempotency_key, receipt, exit_code)
+    print(json.dumps(receipt, indent=2, sort_keys=True))
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/mattermost/scripts/mattermost_gateway_service.py
+++ b/mattermost/scripts/mattermost_gateway_service.py
@@ -1,0 +1,2465 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import base64
+import calendar
+import hashlib
+import json
+import os
+import queue
+import random
+import re
+import signal
+import socket
+import socketserver
+import ssl
+import struct
+import threading
+import time
+import traceback
+import urllib.parse
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler
+from typing import Any
+
+import mattermost_intake_common as common
+
+ALIAS_PATTERN = re.compile(r"(?<![A-Za-z0-9_@])@([a-z0-9][a-z0-9_-]*)", re.IGNORECASE)
+RESERVED_MENTION_PATTERN = re.compile(
+    r"(?<![A-Za-z0-9_@.\-])@(" + "|".join(sorted(re.escape(item) for item in common.MATTERMOST_RESERVED_MENTIONS)) + r")(?![A-Za-z0-9_.\-])",
+    re.IGNORECASE,
+)
+MAX_STATUS_PREVIEW = 160
+GATEWAY_WORKER_THREADS = 8
+GATEWAY_MAX_PENDING_MESSAGES = 128
+RECONNECT_BASE_DELAY_SECONDS = 5
+RECONNECT_MAX_DELAY_SECONDS = 60
+PRUNE_INTERVAL_SECONDS = 60
+HEALTH_RECONNECT_GRACE_SECONDS = 90
+GC_API_HEALTH_TTL_SECONDS = 30
+GC_API_HEALTH_PROBE_TIMEOUT_SECONDS = 3.0
+CHANNEL_INFO_TTL_SECONDS = 5 * 60
+BOT_IDENTITY_TTL_SECONDS = 10 * 60
+MAX_FRAME_BYTES = 16 * 1024 * 1024
+STALE_PROCESSING_RECEIPT_SECONDS = 2 * 60
+FAILED_RECEIPT_RETRY_SECONDS = 60
+WEBSOCKET_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+# Mattermost pings connected clients on a 60s cadence and treats 65s of silence
+# as a dead connection (model.PingTimeoutBufferSeconds == 5). Mirror that here
+# and drive our own ping so a half-open socket is detected in bounded time.
+WEBSOCKET_PING_INTERVAL_SECONDS = 30.0
+WEBSOCKET_SILENCE_TIMEOUT_SECONDS = 65.0
+WEBSOCKET_AUTH_TIMEOUT_SECONDS = 20.0
+AUTHENTICATION_CHALLENGE_ACTION = "authentication_challenge"
+# Close codes the Mattermost reference webapp client reports back to the server
+# via ?disconnect_err_code= on the next connect (webapp/platform/client).
+CLIENT_PING_TIMEOUT_CLOSE_CODE = 4000
+CLIENT_SEQUENCE_MISMATCH_CLOSE_CODE = 4001
+
+
+class WebSocketClosed(RuntimeError):
+    pass
+
+
+class GatewayFrameTimeout(RuntimeError):
+    pass
+
+
+class ThreadingUnixHTTPServer(socketserver.ThreadingMixIn, socketserver.UnixStreamServer):
+    daemon_threads = True
+
+
+CHANNEL_INFO_CACHE_LOCK = threading.Lock()
+CHANNEL_INFO_FETCH_LOCKS_LOCK = threading.Lock()
+CHANNEL_INFO_FETCH_LOCKS: dict[str, threading.Lock] = {}
+CHANNEL_INFO_CACHE: dict[str, tuple[float, dict[str, Any]]] = {}
+AMBIENT_ROOM_BINDINGS_CACHE_LOCK = threading.Lock()
+AMBIENT_ROOM_BINDINGS_FETCH_LOCK = threading.Lock()
+AMBIENT_ROOM_BINDINGS_CACHE: dict[str, Any] = {"config_signature": None, "bindings": {}}
+STALE_RECLAIM_LOCKS_LOCK = threading.Lock()
+STALE_RECLAIM_LOCKS: dict[str, threading.Lock] = {}
+INGRESS_PROCESS_LOCKS_LOCK = threading.Lock()
+INGRESS_PROCESS_LOCKS: dict[str, threading.Lock] = {}
+GC_API_HEALTH_LOCK = threading.Lock()
+GC_API_HEALTH_CACHE = {"checked_at": 0.0, "reachable": True}
+BOT_IDENTITY_LOCK = threading.Lock()
+BOT_IDENTITY_CACHE: dict[str, Any] = {"fetched_at": 0.0, "user_id": "", "username": ""}
+WORKER_QUEUE_SENTINEL: tuple[dict[str, Any], str, str] | None = None
+
+
+def participant_delivery_selector(participant: dict[str, Any]) -> str:
+    for key in ("session_name", "session_id", "session_alias"):
+        value = str((participant or {}).get(key, "")).strip()
+        if value:
+            return value
+    return ""
+
+
+def json_response(handler: BaseHTTPRequestHandler, status: int, payload: dict[str, Any]) -> None:
+    body = json.dumps(payload, indent=2, sort_keys=True).encode("utf-8") + b"\n"
+    handler.send_response(status)
+    handler.send_header("Content-Type", "application/json")
+    handler.send_header("Content-Length", str(len(body)))
+    handler.end_headers()
+    handler.wfile.write(body)
+
+
+def text_response(handler: BaseHTTPRequestHandler, status: int, body: str, content_type: str) -> None:
+    payload = body.encode("utf-8")
+    handler.send_response(status)
+    handler.send_header("Content-Type", content_type)
+    handler.send_header("Content-Length", str(len(payload)))
+    handler.end_headers()
+    handler.wfile.write(payload)
+
+
+def summarize_body(value: str, limit: int = MAX_STATUS_PREVIEW) -> str:
+    normalized = " ".join(str(value).split())
+    if len(normalized) <= limit:
+        return normalized
+    return normalized[:limit].rstrip() + "..."
+
+
+def parse_event_mentions(event_data: dict[str, Any]) -> list[str]:
+    # Mattermost sends data.mentions as a JSON-encoded array of user ids.
+    raw = (event_data or {}).get("mentions")
+    if isinstance(raw, list):
+        items: Any = raw
+    elif isinstance(raw, str) and raw.strip():
+        try:
+            items = json.loads(raw)
+        except json.JSONDecodeError:
+            return []
+    else:
+        return []
+    if not isinstance(items, list):
+        return []
+    seen: set[str] = set()
+    mentions: list[str] = []
+    for item in items:
+        value = str(item).strip()
+        if value and value not in seen:
+            seen.add(value)
+            mentions.append(value)
+    return mentions
+
+
+def normalize_posted_event(event: dict[str, Any]) -> dict[str, Any]:
+    """Flatten a Mattermost `posted` websocket event into one routable post dict.
+
+    Mattermost splits the information Discord packs into a single MESSAGE_CREATE
+    payload across `data.post` (a JSON-encoded string), sibling `data` keys, and
+    `broadcast`. Everything downstream expects one dict, so merge them here.
+    """
+    raw_data = (event or {}).get("data")
+    data: dict[str, Any] = raw_data if isinstance(raw_data, dict) else {}
+    raw_broadcast = (event or {}).get("broadcast")
+    broadcast: dict[str, Any] = raw_broadcast if isinstance(raw_broadcast, dict) else {}
+    post = common.parse_websocket_post(data)
+    if not isinstance(post, dict) or not post:
+        return {}
+    normalized = dict(post)
+    normalized["channel_id"] = str(post.get("channel_id", "") or broadcast.get("channel_id", "")).strip()
+    normalized["root_id"] = str(post.get("root_id", "")).strip()
+    normalized["team_id"] = str(data.get("team_id", "") or broadcast.get("team_id", "")).strip()
+    normalized["channel_type"] = str(data.get("channel_type", "")).strip().upper()
+    normalized["channel_name"] = str(data.get("channel_name", "")).strip()
+    normalized["channel_display_name"] = str(data.get("channel_display_name", "")).strip()
+    sender_name = str(data.get("sender_name", "")).strip().lstrip("@")
+    normalized["sender_name"] = sender_name
+    normalized["from_username"] = sender_name
+    normalized["mentions"] = parse_event_mentions(data)
+    return normalized
+
+
+def display_name_from_message(post: dict[str, Any]) -> str:
+    raw_props = post.get("props")
+    props: dict[str, Any] = raw_props if isinstance(raw_props, dict) else {}
+    candidates: list[str] = []
+    for raw in (
+        props.get("override_username"),
+        post.get("from_username"),
+        post.get("sender_name"),
+    ):
+        if raw is None:
+            continue
+        value = str(raw).strip().lstrip("@")
+        if value:
+            candidates.append(value)
+    for value in candidates:
+        normalized = " ".join(value.replace("\r", " ").replace("\n", " ").split())
+        if normalized:
+            return normalized
+    return "mattermost-user"
+
+
+def raw_message_content(post: dict[str, Any]) -> str:
+    value = post.get("message", "")
+    if isinstance(value, str):
+        return value
+    if value is None:
+        return ""
+    return str(value)
+
+
+def bot_mention_pattern(bot_username: str) -> re.Pattern[str] | None:
+    normalized = str(bot_username).strip().lstrip("@")
+    if not normalized:
+        return None
+    # Mattermost mentions are literal `@username` text, not `<@id>` markup, so
+    # detection needs the bot's username and username-safe boundaries.
+    return re.compile(
+        rf"(?<![A-Za-z0-9_@.\-])@{re.escape(normalized)}(?![A-Za-z0-9_.\-])",
+        re.IGNORECASE,
+    )
+
+
+def bot_was_mentioned(post: dict[str, Any], bot_user_id: str, bot_username: str = "") -> bool:
+    content = raw_message_content(post)
+    pattern = bot_mention_pattern(bot_username)
+    if pattern is not None and pattern.search(content):
+        return True
+    normalized_bot_user_id = str(bot_user_id).strip()
+    mentions = post.get("mentions")
+    if not normalized_bot_user_id or not isinstance(mentions, list):
+        return False
+    if not any(str(item).strip() == normalized_bot_user_id for item in mentions):
+        return False
+    # Mattermost's `mentions` key only ever carries the receiving user's own id
+    # (app/web_broadcast_hooks.go), and it is populated for @all / @channel /
+    # @here just as it is for a direct @username. Discord's mention array
+    # excludes @everyone, so keep that behaviour: a broadcast mention alone is
+    # not an address to this bot.
+    if RESERVED_MENTION_PATTERN.search(content):
+        return False
+    return True
+
+
+def websocket_accept_value(key: str) -> str:
+    digest = hashlib.sha1((str(key) + WEBSOCKET_GUID).encode("utf-8")).digest()
+    return base64.b64encode(digest).decode("ascii")
+
+
+def validate_websocket_handshake(header_blob: str, key: str) -> None:
+    lines = header_blob.splitlines()
+    status_line = lines[0] if lines else ""
+    if "101" not in status_line:
+        raise RuntimeError(f"websocket handshake failed: {status_line}")
+    headers: dict[str, str] = {}
+    for line in lines[1:]:
+        if ":" not in line:
+            continue
+        name, value = line.split(":", 1)
+        headers[name.strip().lower()] = value.strip()
+    if headers.get("upgrade", "").lower() != "websocket":
+        raise RuntimeError("websocket handshake missing Upgrade: websocket")
+    connection_tokens = {token.strip().lower() for token in headers.get("connection", "").split(",") if token.strip()}
+    if "upgrade" not in connection_tokens:
+        raise RuntimeError("websocket handshake missing Connection: Upgrade")
+    accept_value = headers.get("sec-websocket-accept", "")
+    if accept_value != websocket_accept_value(key):
+        raise RuntimeError("websocket handshake returned an unexpected Sec-WebSocket-Accept")
+
+
+def strip_bot_mentions(content: str, bot_username: str) -> str:
+    pattern = bot_mention_pattern(bot_username)
+    if pattern is None:
+        return " ".join(str(content).split())
+    stripped = pattern.sub(" ", str(content))
+    return " ".join(stripped.split())
+
+
+def extract_alias_mentions(content: str) -> list[str]:
+    seen: set[str] = set()
+    aliases: list[str] = []
+    for match in ALIAS_PATTERN.finditer(content):
+        alias = str(match.group(1) or "").strip().lower()
+        if alias and alias not in seen and alias not in common.MATTERMOST_RESERVED_MENTIONS:
+            seen.add(alias)
+            aliases.append(alias)
+    return aliases
+
+
+def referenced_post_id(post: dict[str, Any]) -> str:
+    """Best-effort analogue of Discord's `message_reference.message_id`.
+
+    Mattermost has no per-post reply reference: replying inside a thread only
+    sets `root_id`, which is already the thread identity. Integrations that do
+    carry a finer-grained reply target put it in `props`, so honour that and
+    otherwise report "no explicit reply target".
+    """
+    props = post.get("props")
+    if not isinstance(props, dict):
+        return ""
+    for key in ("reply_to_post_id", "in_reply_to_id"):
+        value = str(props.get(key, "")).strip()
+        if value:
+            return value
+    return ""
+
+
+def casefold_lookup(values: list[str]) -> tuple[dict[str, str], set[str]]:
+    lookup: dict[str, str] = {}
+    collisions: set[str] = set()
+    for value in values:
+        normalized = str(value).strip()
+        if not normalized:
+            continue
+        key = normalized.casefold()
+        existing = lookup.get(key)
+        if existing and existing != normalized:
+            collisions.add(key)
+            continue
+        lookup[key] = normalized
+    return lookup, collisions
+
+
+def message_ingress_id(post: dict[str, Any]) -> str:
+    post_id = str(post.get("id", "")).strip()
+    if post_id:
+        return f"in-{post_id}"
+    return f"in-{int(time.time() * 1000)}"
+
+
+def message_root_post_id(post: dict[str, Any]) -> str:
+    return common.post_thread_root_id(post)
+
+
+def conversation_fields(post: dict[str, Any]) -> tuple[str, str]:
+    team_id = str(post.get("team_id", "")).strip()
+    channel_id = str(post.get("channel_id", "")).strip()
+    root_id = str(post.get("root_id", "")).strip()
+    conversation_key = common.mattermost_conversation_key(channel_id, root_id)
+    if not team_id:
+        return f"dm:{channel_id}", conversation_key
+    if root_id:
+        return f"team:{team_id} channel:{channel_id} thread:{root_id}", conversation_key
+    return f"team:{team_id} channel:{channel_id}", conversation_key
+
+
+def ingress_preview(post: dict[str, Any], bot_username: str) -> str:
+    return summarize_body(strip_bot_mentions(raw_message_content(post), bot_username))
+
+
+def fetch_post_via_rest(post_id: str) -> dict[str, Any]:
+    normalized_post_id = str(post_id).strip()
+    if not normalized_post_id:
+        return {}
+    try:
+        payload = common.mattermost_api_request("GET", f"/posts/{urllib.parse.quote(normalized_post_id)}")
+    except common.MattermostAPIError:
+        return {}
+    if isinstance(payload, dict) and str(payload.get("id", "")).strip() == normalized_post_id:
+        return payload
+    return {}
+
+
+def recover_message_for_routing(post: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
+    recovered = dict(post)
+    gateway_content = raw_message_content(post)
+    debug = {
+        "gateway_content_length": len(gateway_content),
+        "rest_content_length": 0,
+        "content_source": "gateway",
+        "rest_fetch_attempted": False,
+        "rest_fetch_succeeded": False,
+    }
+    team_id = str(post.get("team_id", "")).strip()
+    channel_id = str(post.get("channel_id", "")).strip()
+    post_id = str(post.get("id", "")).strip()
+    needs_rest = bool(team_id and channel_id and post_id and not gateway_content.strip())
+    if not needs_rest:
+        return recovered, debug
+    debug["rest_fetch_attempted"] = True
+    fetched = fetch_post_via_rest(post_id)
+    if not isinstance(fetched, dict) or not fetched:
+        debug["content_source"] = "gateway_empty_rest_unavailable"
+        return recovered, debug
+    fetched_content = raw_message_content(fetched)
+    debug["rest_content_length"] = len(fetched_content)
+    debug["rest_fetch_succeeded"] = True
+    if fetched_content:
+        recovered["message"] = fetched_content
+        debug["content_source"] = "rest_fallback"
+    else:
+        debug["content_source"] = "gateway_empty_rest_empty"
+    for key in ("root_id", "props", "file_ids", "metadata"):
+        current = recovered.get(key)
+        if current in (None, "", [], {}):
+            fetched_value = fetched.get(key)
+            if fetched_value not in (None, "", [], {}):
+                recovered[key] = fetched_value
+    if display_name_from_message(recovered) == "mattermost-user":
+        fetched_user_id = str(fetched.get("user_id", "")).strip()
+        if fetched_user_id and not str(recovered.get("user_id", "")).strip():
+            recovered["user_id"] = fetched_user_id
+        author_username = lookup_username(str(recovered.get("user_id", "")).strip())
+        if author_username:
+            recovered["from_username"] = author_username
+            recovered["sender_name"] = author_username
+    return recovered, debug
+
+
+def lookup_username(user_id: str) -> str:
+    normalized_user_id = str(user_id).strip()
+    if not normalized_user_id:
+        return ""
+    try:
+        payload = common.describe_user(normalized_user_id)
+    except common.MattermostAPIError:
+        return ""
+    if not isinstance(payload, dict):
+        return ""
+    return str(payload.get("username", "")).strip()
+
+
+def empty_body_reason(post: dict[str, Any], message_debug: dict[str, Any] | None = None) -> str:
+    raw_content = raw_message_content(post)
+    if raw_content.strip():
+        return "empty_after_bot_mention_strip"
+    if str(post.get("team_id", "")).strip():
+        debug = message_debug or {}
+        source = str(debug.get("content_source", "")).strip()
+        if source in {"gateway_empty_rest_unavailable", "gateway_empty_rest_empty", "gateway"}:
+            return "message_content_unavailable"
+    return "empty_message_content"
+
+
+def utc_age_seconds(value: str) -> float:
+    normalized = str(value).strip()
+    if not normalized:
+        return float("inf")
+    try:
+        parsed = time.strptime(normalized, "%Y-%m-%dT%H:%M:%SZ")
+    except ValueError:
+        return float("inf")
+    return max(time.time() - calendar.timegm(parsed), 0.0)
+
+
+def normalize_channel_info(info: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(info, dict):
+        return {}
+    normalized = dict(info)
+    channel_type = str(normalized.get("channel_type", normalized.get("type", ""))).strip().upper()
+    if channel_type in common.MATTERMOST_CHANNEL_TYPES:
+        normalized["type"] = channel_type
+        normalized["channel_type"] = channel_type
+    return normalized
+
+
+def binding_channel_info(binding: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(binding, dict):
+        return {}
+    return common.normalize_binding_channel_metadata(binding)
+
+
+def persist_binding_channel_metadata(binding: dict[str, Any]) -> None:
+    if str(binding.get("kind", "")).strip() != "room":
+        return
+    channel_metadata = common.normalize_binding_channel_metadata(binding)
+    if not channel_metadata:
+        return
+    conversation_id = str(binding.get("conversation_id", "")).strip()
+    if not conversation_id:
+        return
+    try:
+        common.save_channel_metadata_cache(conversation_id, channel_metadata)
+    except (ValueError, OSError, json.JSONDecodeError):
+        return
+
+
+def load_channel_info(channel_id: str, bot_token: str) -> dict[str, Any]:
+    now = time.monotonic()
+    with CHANNEL_INFO_CACHE_LOCK:
+        cached = CHANNEL_INFO_CACHE.get(channel_id)
+        if cached and cached[0] > now:
+            return dict(cached[1])
+    # Serialize cache fills so a burst of uncached channel lookups does not fan
+    # out into concurrent Mattermost API reads for the same class of metadata.
+    with channel_info_fetch_lock(channel_id):
+        now = time.monotonic()
+        with CHANNEL_INFO_CACHE_LOCK:
+            cached = CHANNEL_INFO_CACHE.get(channel_id)
+            if cached and cached[0] > now:
+                return dict(cached[1])
+        info = common.describe_channel(channel_id, bot_token=bot_token)
+        if isinstance(info, dict) and info:
+            info = normalize_channel_info(info)
+            with CHANNEL_INFO_CACHE_LOCK:
+                CHANNEL_INFO_CACHE[channel_id] = (now + CHANNEL_INFO_TTL_SECONDS, dict(info))
+            return dict(info)
+    return {}
+
+
+def load_bot_identity(config: dict[str, Any] | None = None, *, force: bool = False) -> tuple[str, str]:
+    """Resolve (bot_user_id, bot_username) from GET /users/me, cached.
+
+    Mattermost mention text carries usernames rather than ids, so the gateway
+    needs both halves of the bot identity to detect and strip self-mentions.
+    """
+    now = time.monotonic()
+    with BOT_IDENTITY_LOCK:
+        fetched_at = float(BOT_IDENTITY_CACHE.get("fetched_at", 0.0) or 0.0)
+        cached_user_id = str(BOT_IDENTITY_CACHE.get("user_id", "")).strip()
+        cached_username = str(BOT_IDENTITY_CACHE.get("username", "")).strip()
+        if not force and cached_user_id and fetched_at and (now - fetched_at) < BOT_IDENTITY_TTL_SECONDS:
+            return cached_user_id, cached_username
+    user_id = ""
+    username = ""
+    try:
+        payload = common.mattermost_api_request("GET", "/users/me")
+    except common.MattermostAPIError:
+        payload = {}
+    if isinstance(payload, dict):
+        user_id = str(payload.get("id", "")).strip()
+        username = str(payload.get("username", "")).strip()
+    if not user_id:
+        cfg = config if isinstance(config, dict) else {}
+        user_id = str((cfg.get("app") or {}).get("bot_user_id", "")).strip()
+    if not user_id and not username:
+        with BOT_IDENTITY_LOCK:
+            return (
+                str(BOT_IDENTITY_CACHE.get("user_id", "")).strip(),
+                str(BOT_IDENTITY_CACHE.get("username", "")).strip(),
+            )
+    with BOT_IDENTITY_LOCK:
+        BOT_IDENTITY_CACHE["fetched_at"] = now
+        if user_id:
+            BOT_IDENTITY_CACHE["user_id"] = user_id
+        if username:
+            BOT_IDENTITY_CACHE["username"] = username
+        return (
+            str(BOT_IDENTITY_CACHE.get("user_id", "")).strip(),
+            str(BOT_IDENTITY_CACHE.get("username", "")).strip(),
+        )
+
+
+def stale_reclaim_lock(ingress_id: str) -> threading.Lock:
+    with STALE_RECLAIM_LOCKS_LOCK:
+        lock = STALE_RECLAIM_LOCKS.get(ingress_id)
+        if lock is None:
+            lock = threading.Lock()
+            STALE_RECLAIM_LOCKS[ingress_id] = lock
+        return lock
+
+
+def channel_info_fetch_lock(channel_id: str) -> threading.Lock:
+    with CHANNEL_INFO_FETCH_LOCKS_LOCK:
+        lock = CHANNEL_INFO_FETCH_LOCKS.get(channel_id)
+        if lock is None:
+            lock = threading.Lock()
+            CHANNEL_INFO_FETCH_LOCKS[channel_id] = lock
+        return lock
+
+
+def ingress_process_lock(ingress_id: str) -> threading.Lock:
+    with INGRESS_PROCESS_LOCKS_LOCK:
+        lock = INGRESS_PROCESS_LOCKS.get(ingress_id)
+        if lock is None:
+            lock = threading.Lock()
+            INGRESS_PROCESS_LOCKS[ingress_id] = lock
+        return lock
+
+
+def prune_channel_info_cache() -> None:
+    now = time.monotonic()
+    with CHANNEL_INFO_CACHE_LOCK:
+        expired = [key for key, (expires_at, _) in CHANNEL_INFO_CACHE.items() if expires_at <= now]
+        for key in expired:
+            del CHANNEL_INFO_CACHE[key]
+
+
+def prune_channel_info_fetch_locks() -> None:
+    with CHANNEL_INFO_CACHE_LOCK:
+        cached_keys = set(CHANNEL_INFO_CACHE.keys())
+    with CHANNEL_INFO_FETCH_LOCKS_LOCK:
+        expired = [key for key, lock in CHANNEL_INFO_FETCH_LOCKS.items() if not lock.locked() and key not in cached_keys]
+        for key in expired:
+            del CHANNEL_INFO_FETCH_LOCKS[key]
+
+
+def prune_stale_reclaim_locks() -> None:
+    with STALE_RECLAIM_LOCKS_LOCK:
+        expired = [key for key, lock in STALE_RECLAIM_LOCKS.items() if not lock.locked() and common.load_chat_ingress(key) is None]
+        for key in expired:
+            del STALE_RECLAIM_LOCKS[key]
+
+
+def prune_ingress_process_locks() -> None:
+    with INGRESS_PROCESS_LOCKS_LOCK:
+        expired = [key for key, lock in INGRESS_PROCESS_LOCKS.items() if not lock.locked() and common.load_chat_ingress(key) is None]
+        for key in expired:
+            del INGRESS_PROCESS_LOCKS[key]
+
+
+def probe_gc_api_health(runtime_state: "GatewayRuntimeState") -> bool:
+    now = time.monotonic()
+    with GC_API_HEALTH_LOCK:
+        checked_at = float(GC_API_HEALTH_CACHE.get("checked_at", 0.0) or 0.0)
+        if checked_at and (now - checked_at) < GC_API_HEALTH_TTL_SECONDS:
+            return bool(GC_API_HEALTH_CACHE.get("reachable", True))
+    try:
+        common.gc_api_request(
+            "GET",
+            "/v0/sessions?limit=1&state=all",
+            timeout=GC_API_HEALTH_PROBE_TIMEOUT_SECONDS,
+        )
+    except common.GCAPIError as exc:
+        with GC_API_HEALTH_LOCK:
+            GC_API_HEALTH_CACHE["checked_at"] = now
+            GC_API_HEALTH_CACHE["reachable"] = False
+        runtime_state.patch(last_gc_api_error=str(exc), last_gc_api_error_at=common.utcnow())
+        return False
+    with GC_API_HEALTH_LOCK:
+        GC_API_HEALTH_CACHE["checked_at"] = now
+        GC_API_HEALTH_CACHE["reachable"] = True
+    runtime_state.patch(last_gc_api_error="", last_gc_api_ok_at=common.utcnow())
+    return True
+
+
+def resolve_binding(config: dict[str, Any], post: dict[str, Any]) -> tuple[dict[str, Any] | None, dict[str, Any]]:
+    """Resolve the chat binding that owns this post.
+
+    Mattermost threads live inside their parent channel (they are just posts
+    sharing a root_id), so unlike Discord there is no parent channel to walk up
+    to: the channel id in the event is always the binding key.
+    """
+    team_id = str(post.get("team_id", "")).strip()
+    channel_id = str(post.get("channel_id", "")).strip()
+    channel_type = str(post.get("channel_type", "")).strip().upper()
+    channel_info: dict[str, Any] = {}
+    if not channel_type:
+        bot_token = common.load_bot_token()
+        if bot_token:
+            try:
+                channel_info = load_channel_info(channel_id, bot_token)
+            except common.MattermostAPIError as exc:
+                if int(getattr(exc, "status_code", 0) or 0) == 404:
+                    return None, {}
+                raise
+            channel_type = str(channel_info.get("type", channel_info.get("channel_type", ""))).strip().upper()
+            if not team_id:
+                team_id = str(channel_info.get("team_id", "")).strip()
+    is_direct = channel_type in common.DIRECT_CHANNEL_TYPES or (not channel_type and not team_id)
+    binding_id = common.chat_binding_id("dm" if is_direct else "room", channel_id)
+    binding = common.resolve_chat_binding(config, binding_id)
+    if is_direct:
+        return binding, channel_info
+    if not binding:
+        return None, channel_info
+    binding = dict(binding)
+    if binding_allows_ambient_read(binding):
+        cached_binding = cached_ambient_room_binding(channel_id)
+        if cached_binding:
+            binding = cached_binding
+    channel_metadata = binding_channel_info(binding)
+    if channel_metadata.get("channel_type"):
+        return binding, channel_metadata
+    cached_channel_metadata = common.load_channel_metadata_cache(channel_id)
+    if cached_channel_metadata:
+        binding.update(cached_channel_metadata)
+        channel_metadata = binding_channel_info(binding)
+        if channel_metadata.get("channel_type"):
+            return binding, channel_metadata
+    bot_token = common.load_bot_token()
+    if not bot_token:
+        return binding, channel_metadata
+    try:
+        looked_up_channel_info = load_channel_info(channel_id, bot_token)
+    except common.MattermostAPIError:
+        return binding, channel_metadata
+    binding.update(common.normalize_binding_channel_metadata(looked_up_channel_info))
+    persist_binding_channel_metadata(binding)
+    return binding, binding_channel_info(binding)
+
+
+def resolve_targets(
+    binding: dict[str, Any],
+    mentioned_aliases: list[str],
+    *,
+    require_targeted_aliases: bool = False,
+) -> tuple[list[str], str, str]:
+    # Bound room selectors are authoritative. Delivery materializes named
+    # sessions on first reference via the core /v0/session/{selector}/messages API.
+    participants = [str(item).strip() for item in binding.get("session_names", []) if str(item).strip()]
+    participant_lookup, participant_collisions = casefold_lookup(participants)
+    if mentioned_aliases:
+        for alias in mentioned_aliases:
+            key = alias.casefold()
+            if key in participant_collisions:
+                return [], "targeted", f"ambiguous_alias:{alias}"
+            participant_name = participant_lookup.get(key)
+            if not participant_name:
+                return [], "targeted", f"unknown_alias:{alias}"
+        targets: list[str] = []
+        for alias in mentioned_aliases:
+            participant_name = participant_lookup.get(alias.casefold())
+            if not participant_name:
+                return [], "targeted", f"unknown_alias:{alias}"
+            targets.append(participant_name)
+        return targets, "targeted", ""
+
+    if require_targeted_aliases:
+        return [], "targeted", "target_required"
+
+    return participants, "broadcast", ""
+
+
+def binding_allows_ambient_read(binding: dict[str, Any] | None) -> bool:
+    if not isinstance(binding, dict):
+        return False
+    if str(binding.get("kind", "")).strip() != "room":
+        return False
+    return bool(common.binding_peer_policy(binding).get("ambient_read_enabled"))
+
+
+def binding_allows_untargeted_ambient_delivery(binding: dict[str, Any] | None) -> bool:
+    if not binding_allows_ambient_read(binding):
+        return False
+    if not isinstance(binding, dict):
+        return False
+    participants = [str(item).strip() for item in binding.get("session_names", []) if str(item).strip()]
+    if len(participants) != 1:
+        return False
+    return bool(common.binding_peer_policy(binding).get("allow_untargeted_ambient_delivery"))
+
+
+def explicit_room_binding(config: dict[str, Any], channel_id: str) -> dict[str, Any] | None:
+    return common.resolve_chat_binding(config, common.chat_binding_id("room", channel_id))
+
+
+def bound_room_claims_message(config: dict[str, Any], channel_id: str) -> bool:
+    # Mattermost threads share their channel with the room, so the channel
+    # binding covers both the root posts and every threaded reply.
+    return bool(explicit_room_binding(config, channel_id))
+
+
+def ambient_bindings_config_signature() -> tuple[int, int, int] | None:
+    try:
+        stat_result = os.stat(common.config_path())
+    except OSError:
+        return None
+    return (
+        int(getattr(stat_result, "st_mtime_ns", 0)),
+        int(getattr(stat_result, "st_size", 0)),
+        int(getattr(stat_result, "st_ino", 0)),
+    )
+
+
+def cached_ambient_room_binding(channel_id: str) -> dict[str, Any] | None:
+    config_signature = ambient_bindings_config_signature()
+    with AMBIENT_ROOM_BINDINGS_CACHE_LOCK:
+        if AMBIENT_ROOM_BINDINGS_CACHE.get("config_signature") == config_signature:
+            bindings = AMBIENT_ROOM_BINDINGS_CACHE.get("bindings", {})
+            if isinstance(bindings, dict):
+                binding = bindings.get(channel_id)
+                return dict(binding) if isinstance(binding, dict) else None
+
+    with AMBIENT_ROOM_BINDINGS_FETCH_LOCK:
+        config_signature = ambient_bindings_config_signature()
+        with AMBIENT_ROOM_BINDINGS_CACHE_LOCK:
+            if AMBIENT_ROOM_BINDINGS_CACHE.get("config_signature") == config_signature:
+                bindings = AMBIENT_ROOM_BINDINGS_CACHE.get("bindings", {})
+                if isinstance(bindings, dict):
+                    binding = bindings.get(channel_id)
+                    return dict(binding) if isinstance(binding, dict) else None
+
+        bindings: dict[str, dict[str, Any]] = {}
+        try:
+            config = common.load_config()
+        except (OSError, ValueError, json.JSONDecodeError):
+            config = {}
+        for binding in common.list_chat_bindings(config):
+            if str(binding.get("kind", "")).strip() != "room":
+                continue
+            if not binding_allows_ambient_read(binding):
+                continue
+            conversation_id = str(binding.get("conversation_id", "")).strip()
+            if conversation_id:
+                bindings[conversation_id] = dict(binding)
+
+        with AMBIENT_ROOM_BINDINGS_CACHE_LOCK:
+            AMBIENT_ROOM_BINDINGS_CACHE["config_signature"] = config_signature
+            AMBIENT_ROOM_BINDINGS_CACHE["bindings"] = bindings
+    binding = bindings.get(channel_id)
+    return dict(binding) if isinstance(binding, dict) else None
+
+
+def build_human_envelope(
+    *,
+    binding: dict[str, Any],
+    post: dict[str, Any],
+    body: str,
+    mentioned_aliases: list[str],
+    delivery: str,
+    ingress_id: str,
+) -> str:
+    conversation_value, conversation_key = conversation_fields(post)
+    binding_id = str(binding.get("id", "")).strip()
+    team_id = str(post.get("team_id", "")).strip()
+    channel_id = str(post.get("channel_id", "")).strip()
+    post_id = str(post.get("id", "")).strip()
+    root_post_id = message_root_post_id(post)
+    lines = [
+        f"<{common.EVENT_TAG}>",
+        "version: 1",
+        f"kind: {common.HUMAN_MESSAGE_EVENT_KIND}",
+        f"binding_id: {binding_id}",
+        f"ingress_receipt_id: {ingress_id}",
+        f"conversation: {conversation_value}",
+        f"conversation_key: {conversation_key}",
+        f"team_id: {team_id}",
+        f"channel_id: {channel_id}",
+        f"root_id: {root_post_id}",
+        f"mattermost_post_id: {post_id}",
+        f"from_display: {display_name_from_message(post)}",
+        f"from_username: {str(post.get('from_username', '')).strip()}",
+        f"from_user_id: {str(post.get('user_id', '')).strip()}",
+        f"delivery: {delivery}",
+        f"mentioned_aliases_json: {json.dumps(mentioned_aliases)}",
+        f"untrusted_body_json: {json.dumps(body)}",
+        f"publish_binding_id: {binding_id}",
+        f"publish_conversation_id: {channel_id}",
+        f"publish_trigger_id: {post_id}",
+        f"publish_root_post_id: {root_post_id}",
+        "normal_output_visibility: internal_only",
+        "reply_contract: explicit_publish_required",
+        f"reply_tool: gc mattermost reply-current --conversation-id {channel_id} --root-id {root_post_id} --body-file <path>",
+        "reply_success_signal: record.remote_message_id",
+        "reply_turn_requirement: if you intend to answer, do not end the turn without a successful reply-current",
+        f"</{common.EVENT_TAG}>",
+    ]
+    return "\n".join(lines)
+
+
+def build_room_launch_envelope(
+    *,
+    launcher: dict[str, Any],
+    launch: dict[str, Any],
+    post: dict[str, Any],
+    body: str,
+    mentioned_handles: list[str],
+    ingress_id: str,
+) -> str:
+    team_id = str(post.get("team_id", "")).strip()
+    channel_id = str(post.get("channel_id", "")).strip()
+    post_id = str(post.get("id", "")).strip()
+    root_post_id = message_root_post_id(post)
+    lines = [
+        f"<{common.EVENT_TAG}>",
+        "version: 1",
+        f"kind: {common.HUMAN_MESSAGE_EVENT_KIND}",
+        f"binding_id: {str(launcher.get('id', '')).strip()}",
+        f"ingress_receipt_id: {ingress_id}",
+        f"conversation: team:{team_id} channel:{channel_id}",
+        f"conversation_key: {common.mattermost_conversation_key(channel_id, root_post_id)}",
+        f"team_id: {team_id}",
+        f"channel_id: {channel_id}",
+        f"root_id: {root_post_id}",
+        f"mattermost_post_id: {post_id}",
+        f"from_display: {display_name_from_message(post)}",
+        f"from_username: {str(post.get('from_username', '')).strip()}",
+        f"from_user_id: {str(post.get('user_id', '')).strip()}",
+        "delivery: targeted",
+        f"mentioned_handles_json: {json.dumps(mentioned_handles)}",
+        f"launch_id: {str(launch.get('launch_id', '')).strip()}",
+        "launch_surface_kind: room",
+        f"launch_qualified_handle: {str(launch.get('qualified_handle', '')).strip()}",
+        f"launch_session_alias: {str(launch.get('session_alias', '')).strip()}",
+        f"launch_session_name: {str(launch.get('session_name', '')).strip()}",
+        f"thread_participants_json: {json.dumps(common.room_launch_participant_summaries(launch))}",
+        f"untrusted_body_json: {json.dumps(body)}",
+        f"publish_binding_id: {str(launcher.get('id', '')).strip()}",
+        f"publish_conversation_id: {channel_id}",
+        f"publish_trigger_id: {post_id}",
+        f"publish_root_post_id: {root_post_id}",
+        f"publish_launch_id: {str(launch.get('launch_id', '')).strip()}",
+        "normal_output_visibility: internal_only",
+        "reply_contract: explicit_publish_required",
+        "reply_tool: gc mattermost reply-current --body-file <path>",
+        "reply_success_signal: record.remote_message_id",
+        "reply_turn_requirement: if you intend to answer, do not end the turn without a successful reply-current",
+        "peer_targeting_rule: include @@rig/alias in the Mattermost reply if you want another launcher participant to receive it as peer input",
+        f"</{common.EVENT_TAG}>",
+    ]
+    return "\n".join(lines)
+
+
+def build_room_launch_thread_envelope(
+    *,
+    launcher: dict[str, Any],
+    launch: dict[str, Any],
+    target_participant: dict[str, Any],
+    post: dict[str, Any],
+    body: str,
+    mentioned_handles: list[str],
+    ingress_id: str,
+    routing_mode: str,
+    reply_to_id: str,
+) -> str:
+    team_id = str(post.get("team_id", "")).strip()
+    channel_id = str(post.get("channel_id", "")).strip()
+    post_id = str(post.get("id", "")).strip()
+    root_post_id = message_root_post_id(post)
+    target_qualified_handle = str(target_participant.get("qualified_handle", "")).strip() or str(launch.get("qualified_handle", "")).strip()
+    target_session_alias = str(target_participant.get("session_alias", "")).strip() or str(launch.get("session_alias", "")).strip()
+    target_session_name = str(target_participant.get("session_name", "")).strip()
+    lines = [
+        f"<{common.EVENT_TAG}>",
+        "version: 1",
+        f"kind: {common.HUMAN_MESSAGE_EVENT_KIND}",
+        f"binding_id: {str(launcher.get('id', '')).strip()}",
+        f"ingress_receipt_id: {ingress_id}",
+        f"conversation: team:{team_id} channel:{channel_id} thread:{root_post_id}",
+        f"conversation_key: {common.mattermost_conversation_key(channel_id, root_post_id)}",
+        f"team_id: {team_id}",
+        f"channel_id: {channel_id}",
+        f"root_id: {root_post_id}",
+        f"mattermost_post_id: {post_id}",
+        f"from_display: {display_name_from_message(post)}",
+        f"from_username: {str(post.get('from_username', '')).strip()}",
+        f"from_user_id: {str(post.get('user_id', '')).strip()}",
+        "delivery: targeted",
+        f"routing_mode: {routing_mode}",
+        f"reply_to_mattermost_post_id: {reply_to_id}",
+        f"mentioned_handles_json: {json.dumps(mentioned_handles)}",
+        f"launch_id: {str(launch.get('launch_id', '')).strip()}",
+        "launch_surface_kind: room",
+        f"launch_root_qualified_handle: {str(launch.get('qualified_handle', '')).strip()}",
+        f"launch_root_session_alias: {str(launch.get('session_alias', '')).strip()}",
+        f"launch_qualified_handle: {target_qualified_handle}",
+        f"launch_session_alias: {target_session_alias}",
+        f"launch_session_name: {target_session_name}",
+        f"thread_participants_json: {json.dumps(common.room_launch_participant_summaries(launch))}",
+        f"untrusted_body_json: {json.dumps(body)}",
+        f"publish_binding_id: {str(launcher.get('id', '')).strip()}",
+        f"publish_conversation_id: {channel_id}",
+        f"publish_trigger_id: {post_id}",
+        f"publish_root_post_id: {root_post_id}",
+        f"publish_launch_id: {str(launch.get('launch_id', '')).strip()}",
+        "normal_output_visibility: internal_only",
+        "reply_contract: explicit_publish_required",
+        "reply_tool: gc mattermost reply-current --body-file <path>",
+        "reply_success_signal: record.remote_message_id",
+        "reply_turn_requirement: if you intend to answer, do not end the turn without a successful reply-current",
+        "peer_targeting_rule: include @@rig/alias in the Mattermost reply if you want another launcher participant to receive it as peer input",
+        f"</{common.EVENT_TAG}>",
+    ]
+    return "\n".join(lines)
+
+
+def persist_ingress_receipt(payload: dict[str, Any]) -> dict[str, Any]:
+    return common.save_chat_ingress(payload)
+
+
+def base_receipt_identity(post: dict[str, Any], bot_username: str) -> dict[str, Any]:
+    return {
+        "mattermost_post_id": str(post.get("id", "")).strip(),
+        "team_id": str(post.get("team_id", "")).strip(),
+        "conversation_id": str(post.get("channel_id", "")).strip(),
+        "root_post_id": message_root_post_id(post),
+        "from_user_id": str(post.get("user_id", "")).strip(),
+        "from_display": display_name_from_message(post),
+        "body_preview": ingress_preview(post, bot_username),
+    }
+
+
+def save_rejected_ingress_receipt(
+    post: dict[str, Any],
+    bot_username: str,
+    *,
+    status: str,
+    reason: str,
+    message_debug: dict[str, Any] | None = None,
+) -> tuple[bool, dict[str, Any]]:
+    ingress_id = message_ingress_id(post)
+    return common.save_chat_ingress_if_absent(
+        {
+            "ingress_id": ingress_id,
+            **base_receipt_identity(post, bot_username),
+            "binding_id": "",
+            "status": status,
+            "reason": reason,
+            "message_debug": dict(message_debug or {}),
+            "targets": [],
+        }
+    )
+
+
+def reject_ingress_before_processing(
+    post: dict[str, Any],
+    bot_username: str,
+    *,
+    status: str,
+    reason: str,
+    message_debug: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    ingress_id = message_ingress_id(post)
+    claimed, receipt = save_rejected_ingress_receipt(
+        post,
+        bot_username,
+        status=status,
+        reason=reason,
+        message_debug=message_debug,
+    )
+    if claimed:
+        return {"status": status, "reason": reason, "ingress_id": ingress_id, "receipt": receipt}
+    if str(receipt.get("status", "")).strip() == "claim_conflict_unreadable":
+        receipt = persist_ingress_receipt(
+            {
+                **receipt,
+                "ingress_id": ingress_id,
+                **base_receipt_identity(post, bot_username),
+                "binding_id": "",
+                "status": "failed_claim_conflict",
+                "reason": str(receipt.get("reason", "")).strip() or "ingress_claim_unreadable",
+                "message_debug": dict(message_debug or {}),
+                "targets": [],
+            }
+        )
+        return {"status": "failed_claim_conflict", "ingress_id": ingress_id, "receipt": receipt}
+    return {"status": "duplicate", "ingress_id": ingress_id, "receipt": receipt}
+
+
+def process_room_launch_message(
+    *,
+    base_receipt: dict[str, Any],
+    launcher: dict[str, Any],
+    post: dict[str, Any],
+    bot_username: str,
+    ingress_id: str,
+    message_debug: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    body = strip_bot_mentions(raw_message_content(post), bot_username)
+    if not body:
+        receipt = persist_ingress_receipt(
+            {
+                **base_receipt,
+                "binding_id": str(launcher.get("id", "")).strip(),
+                "status": "ignored_empty",
+                "reason": empty_body_reason(post, message_debug),
+                "message_debug": dict(message_debug or {}),
+                "targets": [],
+            }
+        )
+        return {"status": "ignored_empty", "ingress_id": ingress_id, "receipt": receipt}
+
+    mentioned_handles = common.extract_agent_handles(body)
+    response_mode = str(launcher.get("response_mode", "mention_only")).strip() or "mention_only"
+    reply_to_id = referenced_post_id(post)
+    if len(mentioned_handles) > 1:
+        receipt = persist_ingress_receipt(
+            {
+                **base_receipt,
+                "binding_id": str(launcher.get("id", "")).strip(),
+                "status": "rejected_targeting",
+                "reason": "multiple_handles_not_supported",
+                "mentioned_handles": mentioned_handles,
+                "targets": [],
+            }
+        )
+        return {"status": "rejected_targeting", "ingress_id": ingress_id, "receipt": receipt}
+
+    requested_handle = mentioned_handles[0] if mentioned_handles else ""
+    used_default_handle = False
+    if not requested_handle:
+        if response_mode != "respond_all":
+            receipt = persist_ingress_receipt(
+                {
+                    **base_receipt,
+                    "binding_id": str(launcher.get("id", "")).strip(),
+                    "status": "ignored_untargeted",
+                    "reason": "launch_handle_required",
+                    "targets": [],
+                }
+            )
+            return {"status": "ignored_untargeted", "ingress_id": ingress_id, "receipt": receipt}
+        if reply_to_id:
+            receipt = persist_ingress_receipt(
+                {
+                    **base_receipt,
+                    "binding_id": str(launcher.get("id", "")).strip(),
+                    "status": "ignored_untargeted",
+                    "reason": "respond_all_root_reply_requires_handle",
+                    "targets": [],
+                }
+            )
+            return {"status": "ignored_untargeted", "ingress_id": ingress_id, "receipt": receipt}
+        requested_handle = str(launcher.get("default_qualified_handle", "")).strip()
+        if not requested_handle:
+            receipt = persist_ingress_receipt(
+                {
+                    **base_receipt,
+                    "binding_id": str(launcher.get("id", "")).strip(),
+                    "status": "ignored_untargeted",
+                    "reason": "launch_handle_required",
+                    "targets": [],
+                }
+            )
+            return {"status": "ignored_untargeted", "ingress_id": ingress_id, "receipt": receipt}
+        used_default_handle = True
+
+    if used_default_handle:
+        qualified_handle, resolve_error = requested_handle, ""
+    else:
+        try:
+            qualified_handle, resolve_error = common.resolve_agent_handle(requested_handle)
+        except common.GCAPIError as exc:
+            receipt = persist_ingress_receipt(
+                {
+                    **base_receipt,
+                    "binding_id": str(launcher.get("id", "")).strip(),
+                    "status": "failed_lookup",
+                    "reason": str(exc),
+                    "targets": [],
+                }
+            )
+            return {"status": "failed_lookup", "ingress_id": ingress_id, "receipt": receipt}
+    if resolve_error:
+        receipt = persist_ingress_receipt(
+            {
+                **base_receipt,
+                "binding_id": str(launcher.get("id", "")).strip(),
+                "status": "rejected_targeting",
+                "reason": resolve_error,
+                "mentioned_handles": mentioned_handles,
+                "targets": [],
+            }
+        )
+        return {"status": "rejected_targeting", "ingress_id": ingress_id, "receipt": receipt}
+
+    root_post_id = str(post.get("id", "")).strip()
+    launch_id = common.room_launch_record_id(root_post_id)
+    existing_launch = common.load_room_launch(launch_id) or {}
+    launch = common.save_room_launch(
+        {
+            **existing_launch,
+            "launch_id": launch_id,
+            "state": str(existing_launch.get("state", "")).strip() or "pending_thread",
+            "launcher_id": str(launcher.get("id", "")).strip(),
+            "team_id": str(post.get("team_id", "")).strip(),
+            "conversation_id": str(post.get("channel_id", "")).strip(),
+            "root_post_id": root_post_id,
+            "qualified_handle": qualified_handle,
+            "session_alias": str(existing_launch.get("session_alias", "")).strip()
+            or common.room_launch_session_alias(
+                str(post.get("team_id", "")).strip(),
+                str(post.get("channel_id", "")).strip(),
+                root_post_id,
+                qualified_handle,
+            ),
+            "from_user_id": str(post.get("user_id", "")).strip(),
+            "from_display": display_name_from_message(post),
+            "body_preview": ingress_preview(post, bot_username),
+        }
+    )
+    try:
+        launch = common.ensure_room_launch_session(launch)
+    except (ValueError, common.GCAPIError) as exc:
+        receipt = persist_ingress_receipt(
+            {
+                **base_receipt,
+                "binding_id": str(launcher.get("id", "")).strip(),
+                "status": "failed_lookup",
+                "reason": str(exc),
+                "mentioned_handles": mentioned_handles,
+                "targets": [],
+            }
+        )
+        return {"status": "failed_lookup", "ingress_id": ingress_id, "receipt": receipt}
+
+    target_selector = participant_delivery_selector(launch)
+    receipt = persist_ingress_receipt(
+        {
+            **base_receipt,
+            "binding_id": str(launcher.get("id", "")).strip(),
+            "status": "pending",
+            "delivery": "targeted",
+            "route_kind": "room_launch",
+            "launch_id": launch_id,
+            "mentioned_handles": mentioned_handles,
+            "qualified_handle": qualified_handle,
+            "targets": [{"session_name": target_selector, "status": "pending"}],
+        }
+    )
+    envelope = build_room_launch_envelope(
+        launcher=launcher,
+        launch=launch,
+        post=post,
+        body=body,
+        mentioned_handles=mentioned_handles,
+        ingress_id=ingress_id,
+    )
+    try:
+        response = common.deliver_session_message(
+            target_selector,
+            envelope,
+            idempotency_key=f"ingress:{ingress_id}:target:{target_selector}",
+        )
+    except common.GCAPIError as exc:
+        receipt["status"] = "failed"
+        receipt["targets"] = [{"session_name": target_selector, "status": "failed", "error": str(exc)}]
+        receipt = persist_ingress_receipt(receipt)
+        return {"status": "failed", "ingress_id": ingress_id, "receipt": receipt}
+    receipt["status"] = "delivered"
+    receipt["targets"] = [{"session_name": target_selector, "status": "delivered", "response": response}]
+    receipt = persist_ingress_receipt(receipt)
+    return {"status": "delivered", "ingress_id": ingress_id, "receipt": receipt}
+
+
+def process_room_launch_thread_message(
+    *,
+    base_receipt: dict[str, Any],
+    launcher: dict[str, Any],
+    launch: dict[str, Any],
+    post: dict[str, Any],
+    bot_username: str,
+    ingress_id: str,
+    message_debug: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    refreshed_launch = common.touch_room_launch(str(launch.get("launch_id", "")).strip())
+    if isinstance(refreshed_launch, dict):
+        launch = refreshed_launch
+    body = strip_bot_mentions(raw_message_content(post), bot_username)
+    if not body:
+        receipt = persist_ingress_receipt(
+            {
+                **base_receipt,
+                "binding_id": str(launcher.get("id", "")).strip(),
+                "status": "ignored_empty",
+                "reason": empty_body_reason(post, message_debug),
+                "message_debug": dict(message_debug or {}),
+                "targets": [],
+            }
+        )
+        return {"status": "ignored_empty", "ingress_id": ingress_id, "receipt": receipt}
+    mentioned_handles = common.extract_agent_handles(body)
+    reply_to_id = referenced_post_id(post)
+    if len(mentioned_handles) > 1:
+        receipt = persist_ingress_receipt(
+            {
+                **base_receipt,
+                "binding_id": str(launcher.get("id", "")).strip(),
+                "status": "rejected_targeting",
+                "reason": "multiple_handles_not_supported",
+                "mentioned_handles": mentioned_handles,
+                "targets": [],
+            }
+        )
+        return {"status": "rejected_targeting", "ingress_id": ingress_id, "receipt": receipt}
+    target_handle = ""
+    routing_mode = ""
+    if mentioned_handles:
+        try:
+            qualified_handle, resolve_error = common.resolve_agent_handle(mentioned_handles[0])
+        except common.GCAPIError as exc:
+            receipt = persist_ingress_receipt(
+                {
+                    **base_receipt,
+                    "binding_id": str(launcher.get("id", "")).strip(),
+                    "status": "failed_lookup",
+                    "reason": str(exc),
+                    "targets": [],
+                }
+            )
+            return {"status": "failed_lookup", "ingress_id": ingress_id, "receipt": receipt}
+        if resolve_error:
+            receipt = persist_ingress_receipt(
+                {
+                    **base_receipt,
+                    "binding_id": str(launcher.get("id", "")).strip(),
+                    "status": "rejected_targeting",
+                    "reason": resolve_error,
+                    "mentioned_handles": mentioned_handles,
+                    "targets": [],
+                }
+            )
+            return {"status": "rejected_targeting", "ingress_id": ingress_id, "receipt": receipt}
+        target_handle = qualified_handle
+        routing_mode = "explicit_handle"
+    if not target_handle and reply_to_id:
+        target_handle = common.room_launch_message_target_handle(launch, reply_to_id)
+        if target_handle:
+            routing_mode = "reply_to"
+    if not target_handle:
+        target_handle = str(launch.get("last_addressed_qualified_handle", "")).strip()
+        if target_handle:
+            routing_mode = "last_addressed"
+    if not target_handle:
+        target_handle = str(launch.get("qualified_handle", "")).strip()
+        if target_handle:
+            routing_mode = "launch_default"
+    if not target_handle:
+        receipt = persist_ingress_receipt(
+            {
+                **base_receipt,
+                "binding_id": str(launcher.get("id", "")).strip(),
+                "status": "failed_lookup",
+                "reason": "missing_thread_target",
+                "targets": [],
+            }
+        )
+        return {"status": "failed_lookup", "ingress_id": ingress_id, "receipt": receipt}
+    try:
+        launch, target_participant = common.ensure_room_launch_session_for_handle(launch, target_handle)
+    except (ValueError, common.GCAPIError) as exc:
+        receipt = persist_ingress_receipt(
+            {
+                **base_receipt,
+                "binding_id": str(launcher.get("id", "")).strip(),
+                "status": "failed_lookup",
+                "reason": str(exc),
+                "targets": [],
+            }
+        )
+        return {"status": "failed_lookup", "ingress_id": ingress_id, "receipt": receipt}
+    target_selector = participant_delivery_selector(target_participant)
+
+    receipt = persist_ingress_receipt(
+        {
+            **base_receipt,
+            "binding_id": str(launcher.get("id", "")).strip(),
+            "status": "pending",
+            "delivery": "targeted",
+            "route_kind": "room_launch_thread",
+            "launch_id": str(launch.get("launch_id", "")).strip(),
+            "routing_mode": routing_mode,
+            "mentioned_handles": mentioned_handles,
+            "qualified_handle": target_handle,
+            "targets": [{"session_name": target_selector, "status": "pending"}],
+        }
+    )
+    envelope = build_room_launch_thread_envelope(
+        launcher=launcher,
+        launch=launch,
+        target_participant=target_participant,
+        post=post,
+        body=body,
+        mentioned_handles=mentioned_handles,
+        ingress_id=ingress_id,
+        routing_mode=routing_mode,
+        reply_to_id=reply_to_id,
+    )
+    try:
+        response = common.deliver_session_message(
+            target_selector,
+            envelope,
+            idempotency_key=f"ingress:{ingress_id}:target:{target_selector}",
+        )
+    except common.GCAPIError as exc:
+        receipt["status"] = "failed"
+        receipt["targets"] = [{"session_name": target_selector, "status": "failed", "error": str(exc)}]
+        receipt = persist_ingress_receipt(receipt)
+        return {"status": "failed", "ingress_id": ingress_id, "receipt": receipt}
+    updated_launch = common.set_room_launch_last_addressed(str(launch.get("launch_id", "")).strip(), target_handle)
+    if isinstance(updated_launch, dict):
+        launch = updated_launch
+    receipt["status"] = "delivered"
+    receipt["targets"] = [{"session_name": target_selector, "status": "delivered", "response": response}]
+    receipt = persist_ingress_receipt(receipt)
+    return {"status": "delivered", "ingress_id": ingress_id, "receipt": receipt}
+
+
+def process_inbound_message(post: dict[str, Any], bot_user_id: str, bot_username: str) -> dict[str, Any]:
+    ingress_id = message_ingress_id(post)
+    if common.post_is_from_bot(post, bot_user_id) or common.post_is_system(post):
+        return {"status": "ignored", "reason": "bot_message", "ingress_id": ingress_id}
+
+    team_id = str(post.get("team_id", "")).strip()
+    channel_id = str(post.get("channel_id", "")).strip()
+    root_id = str(post.get("root_id", "")).strip()
+    if not channel_id:
+        return {"status": "ignored", "reason": "missing_channel", "ingress_id": ingress_id}
+
+    post, message_debug = recover_message_for_routing(post)
+    root_id = str(post.get("root_id", "")).strip()
+
+    config = common.load_config()
+    room_launchers_configured = bool(common.list_room_launchers(config)) if team_id else False
+    mentioned_bot = bot_was_mentioned(post, bot_user_id, bot_username) if team_id else False
+    preloaded_launcher: dict[str, Any] | None = None
+    preloaded_launch: dict[str, Any] | None = None
+    preloaded_binding: dict[str, Any] | None = None
+    preloaded_body: str | None = None
+    preloaded_aliases: list[str] | None = None
+    if team_id:
+        if room_launchers_configured:
+            if root_id:
+                # A Mattermost thread is identified by the root post id, so the
+                # launch record id is derived from root_id rather than from a
+                # separate thread channel id the way Discord does it.
+                launch = common.load_room_launch(common.room_launch_record_id(root_id))
+                if launch and str(launch.get("root_post_id", "")).strip() == root_id:
+                    launcher_id = str(launch.get("launcher_id", "")).strip()
+                    launcher_conversation_id = launcher_id.removeprefix("launch-room:")
+                    preloaded_launcher = common.resolve_room_launcher(config, launcher_conversation_id)
+                    if preloaded_launcher:
+                        preloaded_launch = launch
+            elif not root_id:
+                preloaded_launcher = common.resolve_room_launcher(config, channel_id)
+        if preloaded_launcher is None and not mentioned_bot:
+            preloaded_binding = cached_ambient_room_binding(channel_id)
+            if not preloaded_binding or not binding_allows_ambient_read(preloaded_binding):
+                return {"status": "ignored", "reason": "not_mentioned", "ingress_id": ingress_id}
+            preloaded_body = strip_bot_mentions(raw_message_content(post), bot_username)
+            preloaded_aliases = extract_alias_mentions(preloaded_body)
+            sticky_single_session_delivery = binding_allows_untargeted_ambient_delivery(preloaded_binding)
+            if not preloaded_aliases and not sticky_single_session_delivery:
+                return reject_ingress_before_processing(
+                    post,
+                    bot_username,
+                    status="ignored_untargeted",
+                    reason="ambient_target_required",
+                    message_debug=message_debug,
+                )
+            participant_names = [str(item).strip() for item in preloaded_binding.get("session_names", []) if str(item).strip()]
+            participant_lookup, participant_collisions = casefold_lookup(participant_names)
+            has_valid_preloaded_alias = False
+            for alias in preloaded_aliases:
+                key = alias.casefold()
+                if key in participant_collisions:
+                    continue
+                if participant_lookup.get(key):
+                    has_valid_preloaded_alias = True
+                    break
+            if preloaded_aliases and not has_valid_preloaded_alias and not sticky_single_session_delivery:
+                return reject_ingress_before_processing(
+                    post,
+                    bot_username,
+                    status="ignored_untargeted",
+                    reason="ambient_target_required",
+                    message_debug=message_debug,
+                )
+
+    preview = ingress_preview(post, bot_username)
+    identity = base_receipt_identity(post, bot_username)
+    claimed, base_receipt = common.save_chat_ingress_if_absent(
+        {
+            "ingress_id": ingress_id,
+            **identity,
+            "binding_id": "",
+            "message_debug": dict(message_debug or {}),
+            "status": "processing",
+            "targets": [],
+        }
+    )
+    if not claimed:
+        receipt_status = str(base_receipt.get("status", "")).strip()
+        receipt_age = utc_age_seconds(str(base_receipt.get("updated_at", "")).strip())
+        if receipt_status == "claim_conflict_unreadable":
+            receipt = persist_ingress_receipt(
+                {
+                    **base_receipt,
+                    "ingress_id": ingress_id,
+                    **identity,
+                    "binding_id": "",
+                    "message_debug": dict(message_debug or {}),
+                    "status": "failed_claim_conflict",
+                    "reason": str(base_receipt.get("reason", "")).strip() or "ingress_claim_unreadable",
+                    "targets": [],
+                }
+            )
+            return {"status": "failed_claim_conflict", "ingress_id": ingress_id, "receipt": receipt}
+        if receipt_status in {"processing", "failed", "partial_failed", "failed_lookup", "failed_claim_conflict", "rejected_shutting_down"} and (
+            (receipt_status == "processing" and receipt_age >= STALE_PROCESSING_RECEIPT_SECONDS)
+            or (
+                receipt_status in {"failed", "partial_failed", "failed_lookup", "failed_claim_conflict"}
+                and receipt_age >= FAILED_RECEIPT_RETRY_SECONDS
+            )
+            or receipt_status == "rejected_shutting_down"
+        ):
+            reclaim_lock = stale_reclaim_lock(ingress_id)
+            if not reclaim_lock.acquire(blocking=False):
+                return {"status": "duplicate", "ingress_id": ingress_id, "receipt": base_receipt}
+            try:
+                latest_receipt = common.load_chat_ingress(ingress_id) or base_receipt
+                latest_status = str(latest_receipt.get("status", "")).strip()
+                latest_age = utc_age_seconds(str(latest_receipt.get("updated_at", "")).strip())
+                if not (
+                    (latest_status == "processing" and latest_age >= STALE_PROCESSING_RECEIPT_SECONDS)
+                    or (
+                        latest_status in {"failed", "partial_failed", "failed_lookup", "failed_claim_conflict"}
+                        and latest_age >= FAILED_RECEIPT_RETRY_SECONDS
+                    )
+                    or latest_status == "rejected_shutting_down"
+                ):
+                    return {"status": "duplicate", "ingress_id": ingress_id, "receipt": latest_receipt}
+                retry_reason = "stale_processing_reclaimed"
+                if latest_status in {"failed", "partial_failed", "failed_lookup"}:
+                    retry_reason = "retry_after_failed_delivery"
+                if latest_status == "failed_lookup":
+                    retry_reason = "retry_after_failed_lookup"
+                if latest_status == "failed_claim_conflict":
+                    retry_reason = "retry_after_failed_claim_conflict"
+                if latest_status == "rejected_shutting_down":
+                    retry_reason = "retry_after_shutdown"
+                base_receipt = persist_ingress_receipt(
+                    {
+                        **latest_receipt,
+                        "ingress_id": ingress_id,
+                        **identity,
+                        "binding_id": "",
+                        "message_debug": dict(message_debug or {}),
+                        "status": "processing",
+                        "reason": retry_reason,
+                        "targets": [],
+                    }
+                )
+                claimed = True
+            finally:
+                reclaim_lock.release()
+        else:
+            return {"status": "duplicate", "ingress_id": ingress_id, "receipt": base_receipt}
+
+    process_lock = ingress_process_lock(ingress_id)
+    if not process_lock.acquire(blocking=False):
+        return {"status": "duplicate", "ingress_id": ingress_id, "receipt": common.load_chat_ingress(ingress_id) or base_receipt}
+    try:
+        launcher = preloaded_launcher
+        launch = preloaded_launch
+        binding = preloaded_binding
+        if launcher is None and binding is None:
+            config = common.load_config()
+            try:
+                binding, _channel_info = resolve_binding(config, post)
+            except common.MattermostAPIError as exc:
+                receipt = persist_ingress_receipt(
+                    {
+                        **base_receipt,
+                        "status": "failed_lookup",
+                        "reason": str(exc),
+                        "targets": [],
+                    }
+                )
+                return {"status": "failed_lookup", "ingress_id": ingress_id, "receipt": receipt}
+        base_receipt.update(
+            {
+                "ingress_id": ingress_id,
+                **identity,
+                "binding_id": str((launcher or binding or {}).get("id", "")).strip(),
+                "body_preview": preview,
+            }
+        )
+        if launcher and launch:
+            return process_room_launch_thread_message(
+                base_receipt=base_receipt,
+                launcher=launcher,
+                launch=launch,
+                post=post,
+                bot_username=bot_username,
+                ingress_id=ingress_id,
+                message_debug=message_debug,
+            )
+        if launcher:
+            return process_room_launch_message(
+                base_receipt=base_receipt,
+                launcher=launcher,
+                post=post,
+                bot_username=bot_username,
+                ingress_id=ingress_id,
+                message_debug=message_debug,
+            )
+        if not binding:
+            receipt = persist_ingress_receipt(
+                {
+                    **base_receipt,
+                    "status": "rejected_unbound",
+                    "reason": "binding_not_found",
+                    "targets": [],
+                }
+            )
+            return {"status": "rejected_unbound", "ingress_id": ingress_id, "receipt": receipt}
+
+        body = preloaded_body if preloaded_body is not None else strip_bot_mentions(raw_message_content(post), bot_username)
+        if not body:
+            receipt = persist_ingress_receipt(
+                {
+                    **base_receipt,
+                    "binding_id": str(binding.get("id", "")).strip(),
+                    "status": "ignored_empty",
+                    "reason": empty_body_reason(post, message_debug),
+                    "message_debug": dict(message_debug or {}),
+                    "targets": [],
+                }
+            )
+            return {"status": "ignored_empty", "ingress_id": ingress_id, "receipt": receipt}
+
+        mentioned_aliases = preloaded_aliases if preloaded_aliases is not None else extract_alias_mentions(body)
+        target_aliases = [] if binding_allows_untargeted_ambient_delivery(binding) else mentioned_aliases
+        targets, delivery, resolve_error = resolve_targets(
+            binding,
+            target_aliases,
+            require_targeted_aliases=bool(
+                binding_allows_ambient_read(binding) and team_id and not binding_allows_untargeted_ambient_delivery(binding)
+            ),
+        )
+        if resolve_error:
+            if resolve_error == "target_required":
+                receipt = persist_ingress_receipt(
+                    {
+                        **base_receipt,
+                        "binding_id": str(binding.get("id", "")).strip(),
+                        "status": "ignored_untargeted",
+                        "reason": "ambient_target_required",
+                        "mentioned_aliases": mentioned_aliases,
+                        "targets": [],
+                    }
+                )
+                return {"status": "ignored_untargeted", "ingress_id": ingress_id, "receipt": receipt}
+            receipt = persist_ingress_receipt(
+                {
+                    **base_receipt,
+                    "binding_id": str(binding.get("id", "")).strip(),
+                    "status": "rejected_targeting",
+                    "reason": resolve_error,
+                    "mentioned_aliases": mentioned_aliases,
+                    "targets": [],
+                }
+            )
+            return {"status": "rejected_targeting", "ingress_id": ingress_id, "receipt": receipt}
+        if not targets:
+            receipt = persist_ingress_receipt(
+                {
+                    **base_receipt,
+                    "binding_id": str(binding.get("id", "")).strip(),
+                    "status": "skipped_no_targets",
+                    "reason": "no_targets",
+                    "mentioned_aliases": mentioned_aliases,
+                    "targets": [],
+                }
+            )
+            return {"status": "skipped_no_targets", "ingress_id": ingress_id, "receipt": receipt}
+
+        receipt = persist_ingress_receipt(
+            {
+                **base_receipt,
+                "binding_id": str(binding.get("id", "")).strip(),
+                "status": "pending",
+                "mentioned_aliases": mentioned_aliases,
+                "delivery": delivery,
+                "targets": [{"session_name": target, "status": "pending"} for target in targets],
+            }
+        )
+        envelope = build_human_envelope(
+            binding=binding,
+            post=post,
+            body=body,
+            mentioned_aliases=mentioned_aliases,
+            delivery=delivery,
+            ingress_id=ingress_id,
+        )
+        updated_targets: list[dict[str, Any]] = []
+        failures = 0
+        for target in targets:
+            idempotency_key = f"ingress:{ingress_id}:target:{target}"
+            try:
+                response = common.deliver_session_message(
+                    target,
+                    envelope,
+                    idempotency_key=idempotency_key,
+                    intent="follow_up",
+                )
+                updated_targets.append(
+                    {
+                        "session_name": target,
+                        "status": "delivered",
+                        "idempotency_key": idempotency_key,
+                        "response": response,
+                    }
+                )
+            except common.GCAPIError as exc:
+                failures += 1
+                updated_targets.append(
+                    {
+                        "session_name": target,
+                        "status": "failed",
+                        "idempotency_key": idempotency_key,
+                        "error": str(exc),
+                    }
+                )
+        receipt["targets"] = updated_targets
+        receipt["status"] = "delivered" if failures == 0 else ("partial_failed" if failures < len(targets) else "failed")
+        receipt["delivery"] = delivery
+        receipt["mentioned_aliases"] = mentioned_aliases
+        receipt = persist_ingress_receipt(receipt)
+        return {"status": receipt["status"], "ingress_id": ingress_id, "receipt": receipt}
+    finally:
+        process_lock.release()
+
+
+class GatewayRuntimeState:
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._last_persist_monotonic = 0.0
+        self._status: dict[str, Any] = {
+            "service": common.GATEWAY_SERVICE_NAME,
+            "connected": False,
+            "state": "starting",
+            "routed_messages": 0,
+            "duplicate_messages": 0,
+            "ignored_messages": 0,
+            "failed_messages": 0,
+            "dropped_messages": 0,
+            "message_queue_size": 0,
+        }
+        self._persist_locked(force=True)
+
+    def _persist_locked(self, force: bool = False) -> None:
+        now = time.monotonic()
+        if force or (now - self._last_persist_monotonic) >= 1.0:
+            common.save_gateway_status(self._status)
+            self._last_persist_monotonic = now
+
+    def snapshot(self) -> dict[str, Any]:
+        with self._lock:
+            return dict(self._status)
+
+    def patch(self, **values: Any) -> None:
+        with self._lock:
+            self._status.update(values)
+            force = bool({"state", "connected", "last_error", "last_disconnect_at", "last_ready_at", "last_resumed_at"} & set(values))
+            self._persist_locked(force=force)
+
+    def bump(self, field: str, delta: int = 1, **values: Any) -> None:
+        with self._lock:
+            self._status[field] = int(self._status.get(field, 0) or 0) + delta
+            self._status.update(values)
+            force = bool({"state", "connected", "last_error", "last_disconnect_at", "last_ready_at", "last_resumed_at"} & set(values))
+            self._persist_locked(force=force)
+
+
+class GatewayWebSocket:
+    def __init__(self, url: str, headers: dict[str, str] | None = None) -> None:
+        self.url = url
+        self._recv_buffer = bytearray()
+        self.last_frame_at = time.monotonic()
+        self._closed = False
+        self.sock = self._connect(url, headers or {})
+        self._send_lock = threading.Lock()
+
+    def _connect(self, url: str, extra_headers: dict[str, str]) -> socket.socket:
+        parsed = urllib.parse.urlparse(url)
+        host = parsed.hostname or ""
+        if not host:
+            raise RuntimeError(f"gateway URL missing hostname: {url}")
+        port = parsed.port or (443 if parsed.scheme == "wss" else 80)
+        path = parsed.path or "/"
+        if parsed.query:
+            path += "?" + parsed.query
+
+        raw_sock = socket.create_connection((host, port), timeout=20)
+        if parsed.scheme == "wss":
+            context = ssl.create_default_context()
+            sock = context.wrap_socket(raw_sock, server_hostname=host)
+        else:
+            sock = raw_sock
+        sock.settimeout(20)
+
+        key = base64.b64encode(os.urandom(16)).decode("ascii")
+        header_lines = [
+            f"GET {path} HTTP/1.1",
+            f"Host: {host}:{port}",
+            "Upgrade: websocket",
+            "Connection: Upgrade",
+            f"Sec-WebSocket-Key: {key}",
+            "Sec-WebSocket-Version: 13",
+        ]
+        for name, value in extra_headers.items():
+            normalized_name = str(name).strip()
+            normalized_value = " ".join(str(value).split())
+            if normalized_name and normalized_value:
+                header_lines.append(f"{normalized_name}: {normalized_value}")
+        request = "\r\n".join(header_lines) + "\r\n\r\n"
+        sock.sendall(request.encode("utf-8"))
+        response = b""
+        while b"\r\n\r\n" not in response:
+            chunk = sock.recv(4096)
+            if not chunk:
+                raise RuntimeError("websocket handshake closed early")
+            response += chunk
+        header_bytes, remainder = response.split(b"\r\n\r\n", 1)
+        self._recv_buffer.extend(remainder)
+        header_blob = header_bytes.decode("utf-8", errors="replace")
+        validate_websocket_handshake(header_blob, key)
+        self.last_frame_at = time.monotonic()
+        return sock
+
+    def close(self, code: int = 1000, reason: str = "") -> None:
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            payload = b""
+            if int(code or 0):
+                payload = struct.pack("!H", int(code)) + str(reason).encode("utf-8")[:123]
+            self.send_frame(0x8, payload)
+        except Exception:  # noqa: BLE001
+            pass
+        try:
+            self.sock.close()
+        except OSError:
+            return
+
+    def read_exact(self, length: int, timeout: float | None = None) -> bytes:
+        if timeout is not None:
+            self.sock.settimeout(timeout)
+        data = bytearray()
+        if self._recv_buffer:
+            take = min(length, len(self._recv_buffer))
+            data.extend(self._recv_buffer[:take])
+            del self._recv_buffer[:take]
+        while len(data) < length:
+            chunk = self.sock.recv(length - len(data))
+            if not chunk:
+                raise WebSocketClosed("socket closed")
+            data.extend(chunk)
+        return bytes(data)
+
+    def read_frame(self, timeout: float | None = None) -> tuple[bool, int, bytes]:
+        try:
+            head = self.read_exact(2, timeout=timeout)
+        except TimeoutError as exc:
+            raise GatewayFrameTimeout("timed out waiting for gateway frame header") from exc
+        fin = bool(head[0] & 0x80)
+        opcode = head[0] & 0x0F
+        masked = (head[1] & 0x80) != 0
+        length = head[1] & 0x7F
+        try:
+            if length == 126:
+                length = struct.unpack("!H", self.read_exact(2, timeout=20.0))[0]
+            elif length == 127:
+                length = struct.unpack("!Q", self.read_exact(8, timeout=20.0))[0]
+            if length > MAX_FRAME_BYTES:
+                raise WebSocketClosed(f"gateway frame too large: {length}")
+            mask = self.read_exact(4, timeout=20.0) if masked else b""
+            payload = self.read_exact(length, timeout=20.0) if length else b""
+        except TimeoutError as exc:
+            raise WebSocketClosed("timed out while reading gateway frame payload") from exc
+        if masked and mask:
+            payload = bytes(byte ^ mask[index % 4] for index, byte in enumerate(payload))
+        self.last_frame_at = time.monotonic()
+        return fin, opcode, payload
+
+    def send_frame(self, opcode: int, payload: bytes) -> None:
+        length = len(payload)
+        first = 0x80 | (opcode & 0x0F)
+        if length < 126:
+            header = bytes([first, 0x80 | length])
+        elif length < (1 << 16):
+            header = bytes([first, 0x80 | 126]) + struct.pack("!H", length)
+        else:
+            header = bytes([first, 0x80 | 127]) + struct.pack("!Q", length)
+        mask = os.urandom(4)
+        masked_payload = bytes(byte ^ mask[index % 4] for index, byte in enumerate(payload))
+        with self._send_lock:
+            self.sock.sendall(header + mask + masked_payload)
+
+    def send_json(self, payload: dict[str, Any]) -> None:
+        self.send_frame(0x1, json.dumps(payload, separators=(",", ":")).encode("utf-8"))
+
+    def send_ping(self, payload: bytes = b"gc") -> None:
+        self.send_frame(0x9, payload)
+
+    def recv_event(self, timeout: float | None = None) -> dict[str, Any] | None:
+        fragments: list[bytes] = []
+        while True:
+            fin, opcode, payload = self.read_frame(timeout=timeout if not fragments else 20.0)
+            if opcode == 0x1:
+                if fin:
+                    return json.loads(payload.decode("utf-8"))
+                fragments = [payload]
+                continue
+            if opcode == 0x0:
+                if not fragments:
+                    raise WebSocketClosed("unexpected continuation frame")
+                fragments.append(payload)
+                if sum(len(part) for part in fragments) > MAX_FRAME_BYTES:
+                    raise WebSocketClosed("gateway message too large")
+                if fin:
+                    return json.loads(b"".join(fragments).decode("utf-8"))
+                continue
+            if opcode == 0x8:
+                raise WebSocketClosed("gateway requested close")
+            if opcode == 0x9:
+                self.send_frame(0xA, payload)
+                continue
+            if opcode == 0xA:
+                return None
+            raise WebSocketClosed(f"unsupported websocket opcode: {opcode}")
+
+
+class GatewayWorker:
+    def __init__(self, runtime_state: GatewayRuntimeState) -> None:
+        self.runtime_state = runtime_state
+        self.stop_event = threading.Event()
+        self._stopped = False
+        self._stop_lock = threading.Lock()
+        self.message_queue: queue.Queue[tuple[dict[str, Any], str, str] | None] = queue.Queue(maxsize=GATEWAY_MAX_PENDING_MESSAGES)
+        self.worker_threads: list[threading.Thread] = []
+        self._current_ws_lock = threading.Lock()
+        self._current_ws: GatewayWebSocket | None = None
+        for index in range(GATEWAY_WORKER_THREADS):
+            thread = threading.Thread(target=self.message_worker_loop, name=f"mattermost-gateway-worker-{index + 1}")
+            thread.start()
+            self.worker_threads.append(thread)
+
+    def set_current_ws(self, ws: GatewayWebSocket | None) -> None:
+        with self._current_ws_lock:
+            self._current_ws = ws
+
+    def close_current_ws(self) -> None:
+        with self._current_ws_lock:
+            ws = self._current_ws
+        if ws is not None:
+            ws.close()
+
+    def request_stop(self) -> None:
+        self.stop_event.set()
+        self.close_current_ws()
+
+    def stop(self) -> None:
+        with self._stop_lock:
+            if self._stopped:
+                return
+            self._stopped = True
+        self.runtime_state.patch(state="stopping", connected=False)
+        self.request_stop()
+        for _ in self.worker_threads:
+            self.message_queue.put(WORKER_QUEUE_SENTINEL)
+        self.message_queue.join()
+        for thread in self.worker_threads:
+            thread.join()
+        self.runtime_state.patch(state="stopped", connected=False, message_queue_size=self.message_queue.qsize())
+
+    def current_bot_identity(
+        self,
+        config: dict[str, Any],
+        last_known: tuple[str, str] = ("", ""),
+    ) -> tuple[str, str]:
+        bot_user_id, bot_username = load_bot_identity(config)
+        if bot_user_id or bot_username:
+            return bot_user_id, bot_username
+        last_user_id, last_username = last_known
+        if last_user_id or last_username:
+            return str(last_user_id).strip(), str(last_username).strip()
+        return str((config.get("app") or {}).get("bot_user_id", "")).strip(), ""
+
+    def gateway_connect_url(
+        self,
+        connection_id: str = "",
+        next_sequence: int | None = None,
+        disconnect_err_code: int = 0,
+    ) -> str:
+        base_url = common.mattermost_websocket_url()
+        if not base_url:
+            raise RuntimeError("Mattermost websocket URL is missing")
+        normalized_connection_id = str(connection_id).strip()
+        parsed = urllib.parse.urlparse(base_url)
+        query = dict(urllib.parse.parse_qsl(parsed.query, keep_blank_values=True))
+        # Mattermost's reliable-websocket reconnect: replay everything the
+        # server buffered from `sequence_number` onward for this connection.
+        if normalized_connection_id and next_sequence is not None:
+            query["connection_id"] = normalized_connection_id
+            query["sequence_number"] = str(max(int(next_sequence), 0))
+        if int(disconnect_err_code or 0):
+            query["disconnect_err_code"] = str(int(disconnect_err_code))
+        if not query:
+            return base_url
+        return urllib.parse.urlunparse(parsed._replace(query=urllib.parse.urlencode(query)))
+
+    def authenticate(self, ws: GatewayWebSocket, token: str, request_seq: int) -> None:
+        ws.send_json(
+            {
+                "seq": int(request_seq),
+                "action": AUTHENTICATION_CHALLENGE_ACTION,
+                "data": {"token": token},
+            }
+        )
+
+    def message_worker_loop(self) -> None:
+        while True:
+            try:
+                item = self.message_queue.get(timeout=0.5)
+            except queue.Empty:
+                continue
+            try:
+                if item is WORKER_QUEUE_SENTINEL:
+                    return
+                post, bot_user_id, bot_username = item
+                self.handle_gateway_message(post, bot_user_id, bot_username)
+            finally:
+                self.message_queue.task_done()
+                self.runtime_state.patch(message_queue_size=self.message_queue.qsize())
+
+    def _record_extmsg_inbound(self, post: dict[str, Any], bot_user_id: str, bot_username: str) -> bool:
+        """Normalize and post an inbound Mattermost post to the extmsg fabric.
+
+        If the post @mentions agents in a room (not a thread), this also starts
+        the thread and session setup — the room is a launchpad.
+
+        Returns True if the post was fully handled by extmsg (caller should
+        skip legacy routing). Returns False to fall through to legacy path.
+        """
+        try:
+            if common.post_is_from_bot(post, bot_user_id) or common.post_is_system(post):
+                return False
+            team_id = str(post.get("team_id", "")).strip()
+            config = common.load_config()
+            if not bot_user_id:
+                bot_user_id = str(config.get("app", {}).get("bot_user_id", "")).strip()
+            if not bot_user_id:
+                return False
+
+            content = raw_message_content(post)
+            channel_id = str(post.get("channel_id", "")).strip()
+            # Mattermost threads live inside the channel, keyed by root_id, so
+            # thread detection is a field read rather than a channel lookup.
+            root_id = str(post.get("root_id", "")).strip()
+            is_thread = bool(root_id)
+
+            # Explicit room bindings take precedence over generic extmsg
+            # mention/thread launching. This keeps sticky bound rooms, and
+            # their inherited thread routing, from spawning new sessions.
+            if team_id and channel_id and bound_room_claims_message(config, channel_id):
+                return False
+
+            # ROOM: @mentions required to launch a new thread.
+            # NL mentions in the room are ignored (no accidental threads).
+            if team_id and channel_id and not is_thread:
+                at_mentions = self._agent_at_mentions(content, bot_username)
+                if not at_mentions:
+                    return False  # No @mentions in room — fall through to legacy.
+                targets = common.resolve_mention_targets(at_mentions)
+                if not targets:
+                    return False
+                group = common.launch_thread_for_mentions(post, targets, team_id, bot_user_id)
+                if group:
+                    root_conversation = group.get("root_conversation") if isinstance(group, dict) else None
+                    thread_root_id = str((root_conversation or {}).get("thread_root_id", "")).strip()
+                    if thread_root_id:
+                        participants = [{"handle": t.get("mention", "")} for t in targets]
+                        normalized = common.normalize_to_extmsg_message(
+                            {**post, "root_id": thread_root_id},
+                            team_id,
+                            bot_user_id,
+                            participants,
+                        )
+                        common.deliver_to_extmsg(normalized, bot_user_id)
+                    return True
+                return False
+
+            # THREAD: all messages go to transcript. Handle @mentions and NL names.
+            # Only team channels take this path. Mattermost DMs support threads
+            # too (root_id is set), but a DM belongs to its `dm:` binding, so
+            # swallowing DM thread replies here would strand them.
+            if team_id and is_thread:
+                # @mentions in thread = add new participants (strong signal).
+                at_mentions = self._agent_at_mentions(content, bot_username)
+                if at_mentions:
+                    targets = common.resolve_mention_targets(at_mentions)
+                    if targets:
+                        print(f"[extmsg] thread @mentions: adding {[t.get('mention','') for t in targets]}", flush=True)
+                        common.add_participants_to_thread(
+                            root_id, channel_id, targets, team_id, bot_user_id, content,
+                        )
+
+                # NL mentions in thread = set explicit_target (attention signal).
+                nl_mentions = common.resolve_nl_agent_mentions(content)
+
+                normalized = common.normalize_to_extmsg_message(post, team_id, bot_user_id)
+                # Set explicit_target from @mention or NL match.
+                if at_mentions:
+                    normalized["explicit_target"] = at_mentions[0]
+                elif nl_mentions:
+                    normalized["explicit_target"] = nl_mentions[0]
+
+                common.deliver_to_extmsg(normalized, bot_user_id)
+                return True
+
+            return False
+        except Exception:  # noqa: BLE001
+            return False  # On error, fall through to legacy path.
+
+    @staticmethod
+    def _agent_at_mentions(content: str, bot_username: str) -> list[str]:
+        # Mattermost mention text is literal `@username`, so the bot's own
+        # mention shows up in the body and must not be treated as a target.
+        normalized_bot_username = str(bot_username).strip().lstrip("@").casefold()
+        return [
+            mention
+            for mention in common.resolve_at_mentions(content)
+            if mention.strip().casefold() != normalized_bot_username
+        ]
+
+    def handle_gateway_message(self, post: dict[str, Any], bot_user_id: str, bot_username: str) -> None:
+        try:
+            # Try the new extmsg path first. If it handles the message
+            # (e.g., creates a thread from @mentions), skip legacy routing.
+            if self._record_extmsg_inbound(post, bot_user_id, bot_username):
+                self.runtime_state.bump("routed_messages",
+                    last_message_status="extmsg_routed",
+                    last_message_preview=common.utcnow(),
+                    last_event_at=common.utcnow())
+                return
+            outcome = process_inbound_message(post, bot_user_id, bot_username)
+            status = str(outcome.get("status", "")).strip()
+            preview = summarize_body(str((outcome.get("receipt") or {}).get("body_preview", "")))
+            if status == "duplicate":
+                self.runtime_state.bump("duplicate_messages", last_message_status=status, last_message_preview=preview, last_event_at=common.utcnow())
+                return
+            if status.startswith("ignored"):
+                self.runtime_state.bump("ignored_messages", last_message_status=status, last_message_preview=preview, last_event_at=common.utcnow())
+                return
+            if status in {"delivered", "partial_failed"}:
+                self.runtime_state.bump("routed_messages", last_message_status=status, last_message_preview=preview, last_event_at=common.utcnow())
+                return
+            self.runtime_state.bump("failed_messages", last_message_status=status or "failed", last_message_preview=preview, last_event_at=common.utcnow())
+        except Exception as exc:  # noqa: BLE001
+            preview = ingress_preview(post, bot_username)
+            self.runtime_state.bump(
+                "failed_messages",
+                last_message_status="exception",
+                last_message_preview=preview,
+                last_error=str(exc),
+                last_exception=traceback.format_exc(limit=20),
+                last_event_at=common.utcnow(),
+            )
+
+    def dispatch_gateway_message(self, post: dict[str, Any], bot_user_id: str, bot_username: str) -> None:
+        if self.stop_event.is_set():
+            save_rejected_ingress_receipt(
+                post,
+                bot_username,
+                status="rejected_shutting_down",
+                reason="service_shutting_down",
+            )
+            self.runtime_state.bump(
+                "dropped_messages",
+                last_message_status="shutting_down",
+                last_message_preview=ingress_preview(post, bot_username),
+                last_event_at=common.utcnow(),
+                message_queue_size=self.message_queue.qsize(),
+            )
+            return
+        try:
+            self.message_queue.put_nowait((post, bot_user_id, bot_username))
+            self.runtime_state.patch(message_queue_size=self.message_queue.qsize())
+        except queue.Full:
+            ingress_id = message_ingress_id(post)
+            save_rejected_ingress_receipt(
+                post,
+                bot_username,
+                status="rejected_overloaded",
+                reason="message_queue_full",
+            )
+            print(
+                f"[{common.current_service_name() or 'mattermost-gateway'}] dropping ingress {ingress_id}: message queue full",
+                flush=True,
+            )
+            self.runtime_state.bump(
+                "dropped_messages",
+                last_message_status="queue_full",
+                last_message_preview=ingress_preview(post, bot_username),
+                last_event_at=common.utcnow(),
+                message_queue_size=self.message_queue.qsize(),
+            )
+
+    def prune_runtime_data(self) -> None:
+        common.prune_requests()
+        common.prune_receipts()
+        common.prune_pending_modals()
+        common.prune_chat_ingress()
+        common.prune_chat_publishes()
+        common.prune_room_launches()
+        prune_channel_info_cache()
+        prune_channel_info_fetch_locks()
+        prune_stale_reclaim_locks()
+        prune_ingress_process_locks()
+        self.runtime_state.patch(last_prune_at=common.utcnow())
+
+    def run_forever(self) -> None:
+        backoff_seconds = RECONNECT_BASE_DELAY_SECONDS
+        next_prune_at = 0.0
+        # `next_server_sequence` is the seq the server is expected to send next,
+        # mirroring the reference webapp client's `serverSequence`.
+        next_server_sequence = 0
+        connection_id = ""
+        disconnect_err_code = 0
+        last_known_identity: tuple[str, str] = ("", "")
+        while not self.stop_event.is_set():
+            try:
+                now = time.monotonic()
+                if now >= next_prune_at:
+                    self.prune_runtime_data()
+                    next_prune_at = now + PRUNE_INTERVAL_SECONDS
+                config = common.load_config()
+                bot_token = common.load_bot_token()
+                site_url = common.mattermost_site_url()
+                if not bot_token or not site_url:
+                    self.runtime_state.patch(
+                        connected=False,
+                        state="waiting_for_config",
+                        last_error="mattermost site_url or bot token is not configured",
+                    )
+                    if self.stop_event.wait(RECONNECT_BASE_DELAY_SECONDS):
+                        break
+                    continue
+
+                can_resume = bool(connection_id)
+                requested_connection_id = connection_id
+                connection_url = self.gateway_connect_url(
+                    connection_id if can_resume else "",
+                    next_server_sequence if can_resume else None,
+                    disconnect_err_code,
+                )
+                disconnect_err_code = 0
+                # Mattermost accepts either an Authorization header on the
+                # upgrade (what the reliable Go client does) or an
+                # `authentication_challenge` action once connected. Send both
+                # so the handshake works against every supported deployment,
+                # and accept readiness from `hello` or the challenge's OK reply.
+                ws = GatewayWebSocket(connection_url, headers={"Authorization": f"Bearer {bot_token}"})
+                self.set_current_ws(ws)
+                authenticated = False
+                auth_request_seq = 1
+                self.runtime_state.patch(connected=False, state="connecting", last_error="", resume_attempt=can_resume)
+
+                try:
+                    self.authenticate(ws, bot_token, auth_request_seq)
+                    auth_deadline = time.monotonic() + WEBSOCKET_AUTH_TIMEOUT_SECONDS
+                    next_ping_at = time.monotonic() + WEBSOCKET_PING_INTERVAL_SECONDS
+
+                    while not self.stop_event.is_set():
+                        now = time.monotonic()
+                        timeout = max(0.1, min(next_ping_at, auth_deadline if not authenticated else next_ping_at) - now)
+                        try:
+                            event = ws.recv_event(timeout=timeout)
+                        except GatewayFrameTimeout:
+                            event = None
+                        now = time.monotonic()
+                        if not authenticated and now >= auth_deadline:
+                            raise RuntimeError("mattermost gateway authentication timed out")
+                        if now >= next_ping_at:
+                            ws.send_ping()
+                            next_ping_at = now + WEBSOCKET_PING_INTERVAL_SECONDS
+                            self.runtime_state.patch(last_ping_at=common.utcnow())
+                        if (now - ws.last_frame_at) > WEBSOCKET_SILENCE_TIMEOUT_SECONDS:
+                            disconnect_err_code = CLIENT_PING_TIMEOUT_CLOSE_CODE
+                            ws.close(CLIENT_PING_TIMEOUT_CLOSE_CODE)
+                            raise RuntimeError("mattermost gateway websocket went silent")
+                        if now >= next_prune_at:
+                            self.prune_runtime_data()
+                            next_prune_at = now + PRUNE_INTERVAL_SECONDS
+                        if not isinstance(event, dict):
+                            continue
+
+                        event_type = str(event.get("event", "")).strip()
+                        if "event" in event:
+                            try:
+                                observed_sequence = int(event.get("seq", 0) or 0)
+                            except (TypeError, ValueError):
+                                observed_sequence = next_server_sequence
+                            # `hello` re-establishes the sequence baseline. A
+                            # server that could not replay our buffered queue
+                            # answers with a fresh connection_id and restarts
+                            # seq at 0 — that is a resync, not a gap, so it must
+                            # be accepted before the gap check below.
+                            if event_type != "hello" and observed_sequence != next_server_sequence:
+                                # A gap means the server's dead queue could not
+                                # replay everything; the reference client drops
+                                # the socket with 4001 and resyncs from scratch.
+                                expected_sequence = next_server_sequence
+                                connection_id = ""
+                                next_server_sequence = 0
+                                disconnect_err_code = CLIENT_SEQUENCE_MISMATCH_CLOSE_CODE
+                                ws.close(CLIENT_SEQUENCE_MISMATCH_CLOSE_CODE)
+                                raise RuntimeError(
+                                    f"mattermost gateway sequence mismatch: expected {expected_sequence}, got {observed_sequence}"
+                                )
+                            next_server_sequence = observed_sequence + 1
+                            self.runtime_state.patch(last_sequence=observed_sequence)
+
+                        status = str(event.get("status", "")).strip()
+                        if status and "event" not in event:
+                            # WebSocketResponse: {"status", "seq_reply", "data", "error"}
+                            try:
+                                seq_reply = int(event.get("seq_reply", 0) or 0)
+                            except (TypeError, ValueError):
+                                seq_reply = 0
+                            if seq_reply == auth_request_seq:
+                                if status.upper() != "OK":
+                                    raise RuntimeError(f"mattermost gateway rejected authentication: {event.get('error')!r}")
+                                if not authenticated:
+                                    authenticated = True
+                                    backoff_seconds = RECONNECT_BASE_DELAY_SECONDS
+                                    self.runtime_state.patch(
+                                        connected=True,
+                                        state="ready",
+                                        last_ready_at=common.utcnow(),
+                                        last_ready_epoch=int(time.time()),
+                                        last_error="",
+                                    )
+                            continue
+
+                        raw_data = event.get("data")
+                        data: dict[str, Any] = raw_data if isinstance(raw_data, dict) else {}
+                        raw_broadcast = event.get("broadcast")
+                        broadcast: dict[str, Any] = raw_broadcast if isinstance(raw_broadcast, dict) else {}
+                        if event_type == "hello":
+                            hello_connection_id = (
+                                str(data.get("connection_id", "")).strip()
+                                or str(broadcast.get("connection_id", "")).strip()
+                            )
+                            # A different connection_id than the one we asked to
+                            # resume means the server could not replay; the
+                            # sequence cursor was already rebased off this
+                            # `hello` above, so only the status differs.
+                            resumed = bool(
+                                requested_connection_id
+                                and hello_connection_id
+                                and hello_connection_id == requested_connection_id
+                            )
+                            connection_id = hello_connection_id or connection_id
+                            bot_user_id, bot_username = self.current_bot_identity(config, last_known_identity)
+                            last_known_identity = (bot_user_id, bot_username)
+                            authenticated = True
+                            backoff_seconds = RECONNECT_BASE_DELAY_SECONDS
+                            self.runtime_state.patch(
+                                connected=True,
+                                state="ready",
+                                bot_user_id=bot_user_id,
+                                bot_username=bot_username,
+                                connection_id=connection_id,
+                                resumed_connection=resumed,
+                                server_version=str(data.get("server_version", "")).strip(),
+                                last_ready_at=common.utcnow(),
+                                last_ready_epoch=int(time.time()),
+                                last_error="",
+                            )
+                            if resumed:
+                                self.runtime_state.patch(
+                                    last_resumed_at=common.utcnow(),
+                                    last_resumed_epoch=int(time.time()),
+                                )
+                            continue
+                        if event_type == "posted":
+                            post = normalize_posted_event(event)
+                            if not post:
+                                continue
+                            bot_user_id, bot_username = self.current_bot_identity(config, last_known_identity)
+                            last_known_identity = (bot_user_id, bot_username)
+                            self.dispatch_gateway_message(post, bot_user_id, bot_username)
+                            continue
+                finally:
+                    self.set_current_ws(None)
+                    ws.close()
+            except Exception as exc:  # noqa: BLE001
+                if self.stop_event.is_set():
+                    break
+                if isinstance(exc, common.MattermostAPIError) and int(getattr(exc, "status_code", 0) or 0) in {401, 403}:
+                    # A rejected token invalidates any buffered server queue.
+                    connection_id = ""
+                    next_server_sequence = 0
+                sleep_seconds = min(RECONNECT_MAX_DELAY_SECONDS, backoff_seconds * random.uniform(0.8, 1.2))
+                self.runtime_state.patch(
+                    connected=False,
+                    state="reconnecting",
+                    last_error=str(exc),
+                    last_exception=traceback.format_exc(limit=20),
+                    last_disconnect_at=common.utcnow(),
+                    next_retry_delay_seconds=round(sleep_seconds, 2),
+                )
+                if self.stop_event.wait(sleep_seconds):
+                    break
+                backoff_seconds = min(RECONNECT_MAX_DELAY_SECONDS, max(RECONNECT_BASE_DELAY_SECONDS, backoff_seconds * 2))
+
+
+class GatewayHandler(BaseHTTPRequestHandler):
+    server_version = "MattermostGateway/0.1"
+
+    def log_message(self, fmt: str, *args: Any) -> None:
+        print(f"[{common.current_service_name() or 'mattermost-gateway'}] {fmt % args}")
+
+    def do_GET(self) -> None:  # noqa: N802
+        parsed = urllib.parse.urlparse(self.path)
+        if parsed.path == "/healthz":
+            state = get_runtime_state().snapshot()
+            gc_api_reachable = True
+            if str(state.get("state", "")).strip() in {"ready", "reconnecting"}:
+                gc_api_reachable = probe_gc_api_health(get_runtime_state())
+            code = gateway_health_status_code(state, gc_api_reachable=gc_api_reachable)
+            self.send_response(code)
+            self.end_headers()
+            return
+        if parsed.path in {"", "/"}:
+            text_response(self, HTTPStatus.OK, "mattermost gateway ready\n", "text/plain; charset=utf-8")
+            return
+        if parsed.path == "/v0/mattermost/gateway/status":
+            json_response(self, HTTPStatus.OK, get_runtime_state().snapshot())
+            return
+        json_response(self, HTTPStatus.NOT_FOUND, {"error": "not_found"})
+
+
+RUNTIME_STATE: GatewayRuntimeState | None = None
+
+
+def get_runtime_state() -> GatewayRuntimeState:
+    global RUNTIME_STATE
+    if RUNTIME_STATE is None:
+        RUNTIME_STATE = GatewayRuntimeState()
+    return RUNTIME_STATE
+
+
+def gateway_health_status_code(state: dict[str, Any], gc_api_reachable: bool = True) -> HTTPStatus:
+    status = str(state.get("state", "")).strip()
+    if status in {"connecting", "waiting_for_config", "starting"}:
+        return HTTPStatus.NO_CONTENT
+    if status == "ready":
+        return HTTPStatus.NO_CONTENT if gc_api_reachable else HTTPStatus.SERVICE_UNAVAILABLE
+    if status == "reconnecting":
+        last_ready_epoch = int(state.get("last_ready_epoch", 0) or 0)
+        last_resumed_epoch = int(state.get("last_resumed_epoch", 0) or 0)
+        fresh_epoch = max(last_ready_epoch, last_resumed_epoch)
+        if fresh_epoch and (time.time() - fresh_epoch) <= HEALTH_RECONNECT_GRACE_SECONDS:
+            return HTTPStatus.NO_CONTENT if gc_api_reachable else HTTPStatus.SERVICE_UNAVAILABLE
+    return HTTPStatus.SERVICE_UNAVAILABLE
+
+
+def main() -> int:
+    common.ensure_layout()
+    common.prune_chat_ingress()
+    common.prune_chat_publishes()
+    common.prune_room_launches()
+    socket_path = os.environ.get("GC_SERVICE_SOCKET", "")
+    try:
+        common.prepare_service_socket(socket_path)
+    except RuntimeError as exc:
+        raise SystemExit(str(exc)) from exc
+
+    runtime_state = get_runtime_state()
+    worker = GatewayWorker(runtime_state)
+    thread = threading.Thread(target=worker.run_forever, name="mattermost-gateway")
+    thread.start()
+
+    with ThreadingUnixHTTPServer(socket_path, GatewayHandler) as server:
+        def handle_shutdown(signum: int, _frame: Any) -> None:
+            runtime_state.patch(last_shutdown_signal=signum, last_shutdown_at=common.utcnow())
+            worker.request_stop()
+            threading.Thread(target=server.shutdown, daemon=True).start()
+
+        previous_sigint = signal.signal(signal.SIGINT, handle_shutdown)
+        previous_sigterm = signal.signal(signal.SIGTERM, handle_shutdown)
+        print(f"[{common.current_service_name() or 'mattermost-gateway'}] listening on {socket_path}")
+        try:
+            server.serve_forever()
+        finally:
+            signal.signal(signal.SIGINT, previous_sigint)
+            signal.signal(signal.SIGTERM, previous_sigterm)
+            worker.stop()
+            thread.join()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/mattermost/scripts/mattermost_gateway_service.py
+++ b/mattermost/scripts/mattermost_gateway_service.py
@@ -801,6 +801,15 @@ def build_human_envelope(
     channel_id = str(post.get("channel_id", "")).strip()
     post_id = str(post.get("id", "")).strip()
     root_post_id = message_root_post_id(post)
+    # A binding can opt out of threading (bind-room/bind-dm
+    # --disable-thread-replies) to force flat, top-level replies instead of
+    # threading under the message being answered.
+    thread_replies = common.binding_peer_policy(binding).get("thread_replies", True)
+    reply_root_arg = f" --root-id {root_post_id}" if (thread_replies and root_post_id) else ""
+    reply_tool_line = f"reply_tool: gc mattermost reply-current --conversation-id {channel_id}{reply_root_arg} --body-file <path>"
+    if not thread_replies:
+        reply_tool_line += " (this binding posts flat — do NOT pass --root-id yourself)"
+    publish_root_post_id = root_post_id if thread_replies else ""
     lines = [
         f"<{common.EVENT_TAG}>",
         "version: 1",
@@ -822,10 +831,10 @@ def build_human_envelope(
         f"publish_binding_id: {binding_id}",
         f"publish_conversation_id: {channel_id}",
         f"publish_trigger_id: {post_id}",
-        f"publish_root_post_id: {root_post_id}",
+        f"publish_root_post_id: {publish_root_post_id}",
         "normal_output_visibility: internal_only",
         "reply_contract: explicit_publish_required",
-        f"reply_tool: gc mattermost reply-current --conversation-id {channel_id} --root-id {root_post_id} --body-file <path>",
+        reply_tool_line,
         "reply_success_signal: record.remote_message_id",
         "reply_turn_requirement: if you intend to answer, do not end the turn without a successful reply-current",
         f"</{common.EVENT_TAG}>",

--- a/mattermost/scripts/mattermost_intake_common.py
+++ b/mattermost/scripts/mattermost_intake_common.py
@@ -1,0 +1,5313 @@
+from __future__ import annotations
+
+import calendar
+import contextlib
+import copy
+import fcntl
+import hashlib
+import hmac
+import json
+import mimetypes
+import os
+import pathlib
+import re
+import socket
+import tempfile
+import time
+import tomllib
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+INTERACTIONS_SERVICE_NAME = "mattermost-interactions"
+ADMIN_SERVICE_NAME = "mattermost-admin"
+GATEWAY_SERVICE_NAME = "mattermost-gateway"
+SCHEMA_VERSION = 1
+MATTERMOST_API_PREFIX = "/api/v4"
+REQUEST_RETENTION_SECONDS = 24 * 60 * 60
+PENDING_MODAL_RETENTION_SECONDS = 15 * 60
+CHAT_INGRESS_RETENTION_SECONDS = 7 * 24 * 60 * 60
+CHAT_PUBLISH_RETENTION_SECONDS = 7 * 24 * 60 * 60
+ROOM_LAUNCH_RETENTION_SECONDS = 90 * 24 * 60 * 60
+COMMAND_NAME_DEFAULT = "gc"
+FIX_FORMULA_DEFAULT = "mol-mattermost-fix-issue"
+DEFAULT_GC_API_PORT = 9443
+DEFAULT_SUPERVISOR_API_BASE = "http://127.0.0.1:8372"
+LOCAL_API_BINDS = {"", "0.0.0.0", "::", "[::]", "*"}
+MATTERMOST_RATE_LIMIT_RETRIES = 2
+MATTERMOST_REQUEST_TIMEOUT_SECONDS = 20.0
+GC_API_REQUEST_TIMEOUT_SECONDS = 20.0
+SERVICE_SOCKET_PROBE_TIMEOUT_SECONDS = 0.2
+NON_ROUTABLE_SESSION_STATES = {"", "closed", "stopped", "orphaned", "quarantined"}
+PEER_DELIVERY_TIMEOUT_SECONDS = 10.0
+PEER_IN_PROGRESS_STALE_SECONDS = 30.0
+PEER_ROOT_WINDOW_SECONDS = 60.0
+CANONICAL_PEER_SESSION_NAME = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+URL_PATTERN = re.compile(r"https?://\S+")
+MATTERMOST_RESERVED_MENTIONS = {"all", "channel", "here"}
+MATTERMOST_ID = re.compile(r"^[a-z0-9]{26}$")
+CHANNEL_TYPE_OPEN = "O"
+CHANNEL_TYPE_PRIVATE = "P"
+CHANNEL_TYPE_DIRECT = "D"
+CHANNEL_TYPE_GROUP = "G"
+MATTERMOST_CHANNEL_TYPES = {CHANNEL_TYPE_OPEN, CHANNEL_TYPE_PRIVATE, CHANNEL_TYPE_DIRECT, CHANNEL_TYPE_GROUP}
+DIRECT_CHANNEL_TYPES = {CHANNEL_TYPE_DIRECT, CHANNEL_TYPE_GROUP}
+CHANNEL_ADMIN_ROLE = "channel_admin"
+CHANNEL_USER_ROLE = "channel_user"
+COMMAND_ROUTE_PATH = "/mattermost/command"
+DIALOG_ROUTE_PATH = "/mattermost/dialog"
+ACTION_ROUTE_PATH = "/mattermost/action"
+DIALOG_STATE_VERSION = "v1"
+DIALOG_STATE_TTL_SECONDS = PENDING_MODAL_RETENTION_SECONDS
+ROOM_LAUNCH_RESPONSE_MODES = {"mention_only", "respond_all"}
+ROOM_LAUNCH_ALIAS_SLUG_MAX = 24
+ROOM_LAUNCH_MESSAGE_TARGET_LIMIT = 64
+ROOM_LAUNCH_IDENTITY_RESOLVE_TIMEOUT_SECONDS = 30.0
+ROOM_LAUNCH_IDENTITY_RESOLVE_DELAY_SECONDS = 0.25
+ROOM_LAUNCH_READY_RESOLVE_TIMEOUT_SECONDS = 90.0
+ROOM_LAUNCH_READY_RESOLVE_DELAY_SECONDS = 0.5
+ROOM_LAUNCH_PRIMER_VERSION = 1
+AGENT_HANDLE_SEGMENT = re.compile(r"^[a-z][a-z0-9_-]{0,31}$")
+HUMAN_MESSAGE_EVENT_KIND = "mattermost_human_message"
+PEER_PUBLICATION_EVENT_KIND = "mattermost_peer_publication"
+EVENT_TAG = "mattermost-event"
+
+
+class MattermostAPIError(RuntimeError):
+    def __init__(self, message: str, *, status_code: int | None = None) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class GCAPIError(RuntimeError):
+    pass
+
+
+def utcnow() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def city_root() -> str:
+    return os.environ.get("GC_CITY_ROOT") or os.environ.get("GC_CITY_PATH", "")
+
+
+def city_name() -> str:
+    root = city_root()
+    if not root:
+        return "workspace"
+    return pathlib.Path(root).name
+
+
+def current_service_name() -> str:
+    return os.environ.get("GC_SERVICE_NAME", "")
+
+
+def state_root() -> str:
+    value = os.environ.get("GC_SERVICE_STATE_ROOT")
+    if value:
+        return value
+    root = city_root()
+    if not root:
+        return ".gc/services/mattermost"
+    return os.path.join(root, ".gc", "services", "mattermost")
+
+
+def secrets_dir() -> str:
+    value = os.environ.get("GC_SERVICE_SECRETS_DIR")
+    if value:
+        return value
+    return os.path.join(state_root(), "secrets")
+
+
+def data_dir() -> str:
+    return os.path.join(state_root(), "data")
+
+
+def requests_dir() -> str:
+    return os.path.join(data_dir(), "requests")
+
+
+def receipts_dir() -> str:
+    return os.path.join(data_dir(), "receipts")
+
+
+def workflows_dir() -> str:
+    return os.path.join(data_dir(), "workflows")
+
+
+def pending_modals_dir() -> str:
+    return os.path.join(data_dir(), "pending-modals")
+
+
+def chat_publishes_dir() -> str:
+    return os.path.join(data_dir(), "chat-publishes")
+
+
+def chat_ingress_dir() -> str:
+    return os.path.join(data_dir(), "chat-ingress")
+
+
+def room_launches_dir() -> str:
+    return os.path.join(data_dir(), "chat-launches")
+
+
+def channel_metadata_cache_dir() -> str:
+    return os.path.join(data_dir(), "channel-metadata")
+
+
+def peer_root_budget_dir() -> str:
+    return os.path.join(data_dir(), "peer-root-budgets")
+
+
+def locks_dir() -> str:
+    return os.path.join(data_dir(), "locks")
+
+
+def config_path() -> str:
+    return os.path.join(data_dir(), "config.json")
+
+
+def secret_path(name: str) -> str:
+    return os.path.join(secrets_dir(), name)
+
+
+def published_services_dir() -> str:
+    value = os.environ.get("GC_PUBLISHED_SERVICES_DIR")
+    if value:
+        return value
+    root = city_root()
+    if not root:
+        return ".gc/services/.published"
+    return os.path.join(root, ".gc", "services", ".published")
+
+
+def gateway_status_path() -> str:
+    return os.path.join(data_dir(), "gateway-status.json")
+
+
+def ensure_layout() -> None:
+    for path in (
+        data_dir(),
+        requests_dir(),
+        receipts_dir(),
+        workflows_dir(),
+        pending_modals_dir(),
+        chat_publishes_dir(),
+        chat_ingress_dir(),
+        room_launches_dir(),
+        channel_metadata_cache_dir(),
+        peer_root_budget_dir(),
+        locks_dir(),
+        secrets_dir(),
+    ):
+        os.makedirs(path, exist_ok=True)
+    os.chmod(secrets_dir(), 0o700)
+
+
+def atomic_write_json(path: str, payload: dict[str, Any], mode: int = 0o640) -> None:
+    parent = os.path.dirname(path)
+    os.makedirs(parent, exist_ok=True)
+    data = json.dumps(payload, indent=2, sort_keys=True).encode("utf-8") + b"\n"
+    with tempfile.NamedTemporaryFile(dir=parent, delete=False) as handle:
+        handle.write(data)
+        handle.flush()
+        os.fchmod(handle.fileno(), mode)
+        temp_path = handle.name
+    os.replace(temp_path, path)
+
+
+def atomic_write_text(path: str, body: str, mode: int = 0o600) -> None:
+    parent = os.path.dirname(path)
+    os.makedirs(parent, exist_ok=True)
+    data = body.encode("utf-8")
+    with tempfile.NamedTemporaryFile(dir=parent, delete=False) as handle:
+        handle.write(data)
+        handle.flush()
+        os.fchmod(handle.fileno(), mode)
+        temp_path = handle.name
+    os.replace(temp_path, path)
+
+
+def read_json(path: str, default: Any = None, *, allow_invalid: bool = False) -> Any:
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            return json.load(handle)
+    except FileNotFoundError:
+        return default
+    except json.JSONDecodeError:
+        if allow_invalid:
+            return default
+        raise
+
+
+def read_text(path: str, default: str = "") -> str:
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            return handle.read()
+    except FileNotFoundError:
+        return default
+
+
+def default_config() -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "app": {
+            "command_name": COMMAND_NAME_DEFAULT,
+        },
+        "policy": {
+            "team_allowlist": [],
+            "channel_allowlist": [],
+            "channel_role_allowlist": [],
+        },
+        "channels": {},
+        "rigs": {},
+        "chat": {
+            "bindings": {},
+            "launchers": {},
+        },
+    }
+
+
+def _normalize_allowlist(values: Any) -> list[str]:
+    if not isinstance(values, list):
+        return []
+    return [str(value).strip() for value in values if str(value).strip()]
+
+
+def dedupe_session_names(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    session_names: list[str] = []
+    for value in values:
+        normalized = str(value).strip()
+        if not normalized:
+            continue
+        key = normalized.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        session_names.append(normalized)
+    return session_names
+
+
+def room_launch_surface_id(conversation_id: str) -> str:
+    return f"launch-room:{str(conversation_id).strip()}"
+
+
+def mattermost_conversation_key(channel_id: str, root_id: str = "") -> str:
+    channel = str(channel_id).strip()
+    root = str(root_id).strip()
+    if root and root != channel:
+        return f"{channel}/{root}"
+    return channel
+
+
+def mattermost_conversation_parts(conversation_id: str) -> tuple[str, str]:
+    """Inverse of mattermost_conversation_key: split a possibly thread-scoped
+    conversation id ("<channel_id>/<root_id>") back into its parts. A bare
+    channel id (no "/") splits to (channel_id, "")."""
+    raw = str(conversation_id).strip()
+    channel, sep, root = raw.partition("/")
+    return channel, (root if sep else "")
+
+
+def normalize_room_launch_response_mode(value: Any) -> str:
+    normalized = str(value).strip().lower() or "mention_only"
+    if normalized not in ROOM_LAUNCH_RESPONSE_MODES:
+        return "mention_only"
+    return normalized
+
+
+def normalize_binding_channel_metadata(value: dict[str, Any] | None = None) -> dict[str, Any]:
+    raw = value if isinstance(value, dict) else {}
+    normalized: dict[str, Any] = {}
+    bare_type = str(raw.get("type", "")).strip().upper()
+    # Only treat bare Mattermost channel-object keys as metadata when the
+    # payload actually is a channel object; bindings carry their own team_id.
+    is_channel_object = bare_type in MATTERMOST_CHANNEL_TYPES
+    channel_type = str(raw.get("channel_type", bare_type if is_channel_object else "")).strip().upper()
+    if channel_type in MATTERMOST_CHANNEL_TYPES:
+        normalized["channel_type"] = channel_type
+    team_id = str(raw.get("channel_team_id", raw.get("team_id", "") if is_channel_object else "")).strip()
+    if team_id:
+        normalized["channel_team_id"] = team_id
+    name = str(raw.get("channel_name", raw.get("name", "") if is_channel_object else "")).strip()
+    if name:
+        normalized["channel_name"] = name
+    display_name = str(raw.get("channel_display_name", raw.get("display_name", "") if is_channel_object else "")).strip()
+    if display_name:
+        normalized["channel_display_name"] = display_name
+    return normalized
+
+
+def binding_is_direct(binding: dict[str, Any]) -> bool:
+    if str(binding.get("kind", "")).strip() == "dm":
+        return True
+    return str(binding.get("channel_type", "")).strip().upper() in DIRECT_CHANNEL_TYPES
+
+
+def normalize_config(raw: dict[str, Any] | None) -> dict[str, Any]:
+    config = default_config()
+    if not raw:
+        return config
+    if isinstance(raw.get("app"), dict):
+        app = copy.deepcopy(raw["app"])
+        command_name = str(app.get("command_name", COMMAND_NAME_DEFAULT)).strip() or COMMAND_NAME_DEFAULT
+        config["app"] = {
+            "site_url": str(app.get("site_url", "")).strip().rstrip("/"),
+            "team_id": str(app.get("team_id", "")).strip(),
+            "bot_user_id": str(app.get("bot_user_id", "")).strip(),
+            "command_id": str(app.get("command_id", "")).strip(),
+            "command_name": command_name,
+        }
+    if isinstance(raw.get("policy"), dict):
+        policy = raw["policy"]
+        config["policy"] = {
+            "team_allowlist": _normalize_allowlist(policy.get("team_allowlist")),
+            "channel_allowlist": _normalize_allowlist(policy.get("channel_allowlist")),
+            "channel_role_allowlist": _normalize_allowlist(policy.get("channel_role_allowlist")),
+        }
+    chat = raw.get("chat")
+    if isinstance(chat, dict):
+        normalized_bindings: dict[str, Any] = {}
+        normalized_launchers: dict[str, Any] = {}
+        bindings = chat.get("bindings")
+        if isinstance(bindings, dict):
+            for key, value in bindings.items():
+                if not isinstance(value, dict):
+                    continue
+                kind = str(value.get("kind", "")).strip().lower()
+                conversation_id = str(value.get("conversation_id", "")).strip()
+                if kind not in {"dm", "room"} or not conversation_id:
+                    continue
+                session_names = value.get("session_names")
+                if not isinstance(session_names, list):
+                    session_names = []
+                normalized_session_names = dedupe_session_names(session_names)
+                if kind == "dm" and len(normalized_session_names) != 1:
+                    continue
+                binding_id = chat_binding_id(kind, conversation_id)
+                binding_channel_id = str(value.get("channel_id", "")).strip()
+                binding_root_id = str(value.get("root_id", "")).strip()
+                if not binding_channel_id:
+                    binding_channel_id, binding_root_id = mattermost_conversation_parts(conversation_id)
+                normalized_bindings[binding_id] = {
+                    "id": binding_id,
+                    "kind": kind,
+                    "conversation_id": conversation_id,
+                    "channel_id": binding_channel_id,
+                    "root_id": binding_root_id,
+                    "team_id": str(value.get("team_id", "")).strip(),
+                    "session_names": normalized_session_names,
+                }
+                channel_metadata = normalize_binding_channel_metadata(value)
+                if channel_metadata:
+                    normalized_bindings[binding_id].update(channel_metadata)
+                if kind == "room":
+                    normalized_bindings[binding_id]["policy"] = normalize_room_peer_policy(value.get("policy"))
+        launchers = chat.get("launchers")
+        if isinstance(launchers, dict):
+            for key, value in launchers.items():
+                if not isinstance(value, dict):
+                    continue
+                kind = str(value.get("kind", "")).strip().lower()
+                conversation_id = str(value.get("conversation_id", "")).strip()
+                team_id = str(value.get("team_id", "")).strip()
+                if kind != "room" or not conversation_id or not team_id:
+                    continue
+                launcher_id = room_launch_surface_id(conversation_id)
+                response_mode = normalize_room_launch_response_mode(value.get("response_mode"))
+                default_handle = _normalize_agent_handle(value.get("default_qualified_handle", ""))
+                if default_handle and "/" not in default_handle:
+                    default_handle = ""
+                if response_mode == "respond_all" and not default_handle:
+                    response_mode = "mention_only"
+                normalized_launchers[launcher_id] = {
+                    "id": launcher_id,
+                    "kind": "room",
+                    "conversation_id": conversation_id,
+                    "team_id": team_id,
+                    "response_mode": response_mode,
+                    "default_qualified_handle": default_handle,
+                }
+                if isinstance(value.get("policy"), dict):
+                    normalized_launchers[launcher_id]["policy"] = normalize_room_launch_peer_policy(value.get("policy"))
+        config["chat"] = {
+            "bindings": normalized_bindings,
+            "launchers": normalized_launchers,
+        }
+    channels = raw.get("channels")
+    if isinstance(channels, dict):
+        normalized_channels: dict[str, Any] = {}
+        for key, value in channels.items():
+            if not isinstance(value, dict):
+                continue
+            team_id = str(value.get("team_id", "")).strip()
+            channel_id = str(value.get("channel_id", "")).strip()
+            target = str(value.get("target", "")).strip()
+            if not team_id or not channel_id or not target:
+                continue
+            commands = value.get("commands")
+            if not isinstance(commands, dict):
+                commands = {}
+            fix_cfg = commands.get("fix")
+            if not isinstance(fix_cfg, dict):
+                fix_cfg = {}
+            fix_formula = str(fix_cfg.get("formula", FIX_FORMULA_DEFAULT)).strip() or FIX_FORMULA_DEFAULT
+            normalized_channels[str(key)] = {
+                "team_id": team_id,
+                "channel_id": channel_id,
+                "target": target,
+                "commands": {
+                    "fix": {
+                        "formula": fix_formula,
+                    }
+                },
+            }
+        config["channels"] = normalized_channels
+    rigs = raw.get("rigs")
+    if isinstance(rigs, dict):
+        normalized_rigs: dict[str, Any] = {}
+        for key, value in rigs.items():
+            if not isinstance(value, dict):
+                continue
+            team_id = str(value.get("team_id", "")).strip()
+            rig_name = str(value.get("rig_name", "")).strip()
+            target = str(value.get("target", "")).strip()
+            if not team_id or not rig_name or not target:
+                continue
+            commands = value.get("commands")
+            if not isinstance(commands, dict):
+                commands = {}
+            fix_cfg = commands.get("fix")
+            if not isinstance(fix_cfg, dict):
+                fix_cfg = {}
+            fix_formula = str(fix_cfg.get("formula", FIX_FORMULA_DEFAULT)).strip() or FIX_FORMULA_DEFAULT
+            normalized_rigs[str(key)] = {
+                "team_id": team_id,
+                "rig_name": rig_name,
+                "target": target,
+                "commands": {
+                    "fix": {
+                        "formula": fix_formula,
+                    }
+                },
+            }
+        config["rigs"] = normalized_rigs
+    config["schema_version"] = SCHEMA_VERSION
+    return config
+
+
+def load_config() -> dict[str, Any]:
+    ensure_layout()
+    return normalize_config(read_json(config_path(), {}))
+
+
+def save_config(config: dict[str, Any]) -> dict[str, Any]:
+    ensure_layout()
+    normalized = normalize_config(config)
+    atomic_write_json(config_path(), normalized)
+    return normalized
+
+
+def canonical_peer_session_name(name: str) -> str:
+    normalized = str(name).strip()
+    if normalized and CANONICAL_PEER_SESSION_NAME.fullmatch(normalized):
+        return normalized
+    return ""
+
+
+def _coerce_bool(value: Any, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return default
+    text = str(value).strip().lower()
+    if text in {"1", "true", "yes", "on", "enabled"}:
+        return True
+    if text in {"0", "false", "no", "off", "disabled"}:
+        return False
+    return default
+
+
+def default_room_peer_policy() -> dict[str, Any]:
+    return {
+        "ambient_read_enabled": False,
+        "allow_untargeted_ambient_delivery": False,
+        "peer_fanout_enabled": False,
+        "allow_untargeted_peer_fanout": False,
+        "max_peer_triggered_publishes_per_root": 1,
+        "max_total_peer_deliveries_per_root": 8,
+        "max_peer_triggered_publishes_per_session_per_minute": 5,
+    }
+
+
+def default_room_launch_peer_policy() -> dict[str, Any]:
+    defaults = default_room_peer_policy()
+    defaults["peer_fanout_enabled"] = True
+    defaults["allow_untargeted_peer_fanout"] = True
+    return defaults
+
+
+def _normalize_peer_policy(policy: dict[str, Any] | None, defaults: dict[str, Any]) -> dict[str, Any]:
+    raw = policy if isinstance(policy, dict) else {}
+    return {
+        "ambient_read_enabled": _coerce_bool(raw.get("ambient_read_enabled"), defaults["ambient_read_enabled"]),
+        "allow_untargeted_ambient_delivery": _coerce_bool(
+            raw.get("allow_untargeted_ambient_delivery"), defaults["allow_untargeted_ambient_delivery"]
+        ),
+        "peer_fanout_enabled": _coerce_bool(raw.get("peer_fanout_enabled"), defaults["peer_fanout_enabled"]),
+        "allow_untargeted_peer_fanout": _coerce_bool(
+            raw.get("allow_untargeted_peer_fanout"), defaults["allow_untargeted_peer_fanout"]
+        ),
+        "max_peer_triggered_publishes_per_root": max(
+            0, int(raw.get("max_peer_triggered_publishes_per_root", defaults["max_peer_triggered_publishes_per_root"]) or 0)
+        ),
+        "max_total_peer_deliveries_per_root": max(
+            0, int(raw.get("max_total_peer_deliveries_per_root", defaults["max_total_peer_deliveries_per_root"]) or 0)
+        ),
+        "max_peer_triggered_publishes_per_session_per_minute": max(
+            0,
+            int(
+                raw.get(
+                    "max_peer_triggered_publishes_per_session_per_minute",
+                    defaults["max_peer_triggered_publishes_per_session_per_minute"],
+                )
+                or 0
+            ),
+        ),
+    }
+
+
+def normalize_room_peer_policy(policy: dict[str, Any] | None = None) -> dict[str, Any]:
+    return _normalize_peer_policy(policy, default_room_peer_policy())
+
+
+def normalize_room_launch_peer_policy(policy: dict[str, Any] | None = None) -> dict[str, Any]:
+    return _normalize_peer_policy(policy, default_room_launch_peer_policy())
+
+
+def binding_peer_policy(binding: dict[str, Any]) -> dict[str, Any]:
+    if str(binding.get("kind", "")).strip() != "room":
+        return default_room_peer_policy()
+    if str(binding.get("publish_route_kind", "")).strip() == "room_launch" or str(binding.get("id", "")).strip().startswith(
+        "launch-room:"
+    ):
+        if not isinstance(binding.get("policy"), dict):
+            return default_room_peer_policy()
+        return normalize_room_launch_peer_policy(binding.get("policy"))
+    return normalize_room_peer_policy(binding.get("policy"))
+
+
+def redact_config(config: dict[str, Any]) -> dict[str, Any]:
+    redacted = normalize_config(config)
+    redacted["app"]["bot_token_present"] = bool(load_bot_token())
+    redacted["app"]["command_token_present"] = bool(load_command_token())
+    redacted["app"]["dialog_secret_present"] = bool(load_dialog_secret())
+    return redacted
+
+
+def validate_mattermost_id(value: str, field: str = "id") -> str:
+    normalized = str(value).strip()
+    if not normalized:
+        return ""
+    if not MATTERMOST_ID.fullmatch(normalized):
+        raise ValueError(f"{field} must be a 26-character Mattermost id")
+    return normalized
+
+
+def validate_team_id(value: str) -> str:
+    return validate_mattermost_id(value, "team_id")
+
+
+def validate_bot_user_id(value: str) -> str:
+    return validate_mattermost_id(value, "bot_user_id")
+
+
+def validate_command_token(value: str) -> str:
+    return validate_mattermost_id(value, "command_token")
+
+
+def validate_site_url(value: str) -> str:
+    normalized = str(value).strip().rstrip("/")
+    if not normalized:
+        return ""
+    parsed = urllib.parse.urlparse(normalized)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ValueError("site_url must be an http(s) URL")
+    return normalized
+
+
+def import_app_config(config: dict[str, Any], app_fields: dict[str, Any]) -> dict[str, Any]:
+    cfg = normalize_config(config)
+    app = cfg.setdefault("app", {})
+    site_url = validate_site_url(app_fields.get("site_url", app_fields.get("url", "")))
+    team_id = validate_team_id(app_fields.get("team_id", ""))
+    bot_user_id = validate_bot_user_id(app_fields.get("bot_user_id", app_fields.get("bot_id", "")))
+    command_id = validate_mattermost_id(app_fields.get("command_id", ""), "command_id")
+    if site_url:
+        app["site_url"] = site_url
+    if team_id:
+        app["team_id"] = team_id
+    if bot_user_id:
+        app["bot_user_id"] = bot_user_id
+    if command_id:
+        app["command_id"] = command_id
+    command_name = str(app_fields.get("command_name", app.get("command_name", COMMAND_NAME_DEFAULT))).strip()
+    app["command_name"] = command_name.lstrip("/") or COMMAND_NAME_DEFAULT
+
+    policy = cfg.setdefault("policy", {})
+    for key in ("team_allowlist", "channel_allowlist", "channel_role_allowlist"):
+        if key in app_fields:
+            policy[key] = _normalize_allowlist(app_fields.get(key))
+    return save_config(cfg)
+
+
+def save_bot_token(token: str) -> None:
+    ensure_layout()
+    atomic_write_text(secret_path("bot-token.txt"), token.strip() + "\n", mode=0o600)
+
+
+def load_bot_token() -> str:
+    return read_text(secret_path("bot-token.txt")).strip()
+
+
+def save_command_token(token: str) -> None:
+    ensure_layout()
+    atomic_write_text(secret_path("command-token.txt"), token.strip() + "\n", mode=0o600)
+
+
+def load_command_token() -> str:
+    return read_text(secret_path("command-token.txt")).strip()
+
+
+def verify_command_token(presented_token: str) -> bool:
+    expected = load_command_token()
+    presented = str(presented_token or "").strip()
+    if not expected or not presented:
+        return False
+    return hmac.compare_digest(expected, presented)
+
+
+def _new_secret_hex(size: int = 32) -> str:
+    return hashlib.sha256(os.urandom(size) + str(time.time_ns()).encode("utf-8")).hexdigest()
+
+
+def save_dialog_secret(secret: str) -> None:
+    ensure_layout()
+    atomic_write_text(secret_path("dialog-secret.txt"), secret.strip() + "\n", mode=0o600)
+
+
+def load_dialog_secret() -> str:
+    return read_text(secret_path("dialog-secret.txt")).strip()
+
+
+def ensure_dialog_secret() -> str:
+    current = load_dialog_secret()
+    if current:
+        return current
+    with advisory_lock(_safe_lock_name("dialog-secret", "singleton")):
+        current = load_dialog_secret()
+        if current:
+            return current
+        current = _new_secret_hex()
+        save_dialog_secret(current)
+    return current
+
+
+def dialog_route_token() -> str:
+    # Path-segment bearer for our own dialog/action routes; derived from the
+    # dialog secret so rotating one rotates both.
+    return hashlib.sha256(("route:" + ensure_dialog_secret()).encode("utf-8")).hexdigest()[:32]
+
+
+def verify_dialog_route_token(presented_token: str) -> bool:
+    presented = str(presented_token or "").strip()
+    if not presented:
+        return False
+    return hmac.compare_digest(dialog_route_token(), presented)
+
+
+def _dialog_state_signature(secret: str, payload: str) -> str:
+    return hmac.new(secret.encode("utf-8"), payload.encode("utf-8"), hashlib.sha256).hexdigest()
+
+
+def mint_dialog_state(nonce: str, *, ttl_seconds: float = DIALOG_STATE_TTL_SECONDS) -> str:
+    normalized_nonce = str(nonce).strip()
+    if not normalized_nonce or ":" in normalized_nonce:
+        raise ValueError("dialog nonce must be non-empty and must not contain ':'")
+    expires_at = int(time.time() + max(1.0, float(ttl_seconds)))
+    payload = f"{DIALOG_STATE_VERSION}:{normalized_nonce}:{expires_at}"
+    return f"{payload}:{_dialog_state_signature(ensure_dialog_secret(), payload)}"
+
+
+def verify_dialog_state(state: str) -> str:
+    parts = str(state or "").strip().split(":")
+    if len(parts) != 4:
+        return ""
+    version, nonce, expires_raw, signature = parts
+    if version != DIALOG_STATE_VERSION or not nonce or not signature:
+        return ""
+    try:
+        expires_at = int(expires_raw)
+    except ValueError:
+        return ""
+    if expires_at < time.time():
+        return ""
+    secret = load_dialog_secret()
+    if not secret:
+        return ""
+    expected = _dialog_state_signature(secret, f"{version}:{nonce}:{expires_raw}")
+    if not hmac.compare_digest(expected, signature):
+        return ""
+    return nonce
+
+
+def command_callback_url() -> str:
+    base = interactions_url().rstrip("/")
+    if not base:
+        return ""
+    return f"{base}{COMMAND_ROUTE_PATH}"
+
+
+def dialog_callback_url() -> str:
+    base = interactions_url().rstrip("/")
+    if not base:
+        return ""
+    return f"{base}{DIALOG_ROUTE_PATH}/{dialog_route_token()}"
+
+
+def action_callback_url() -> str:
+    base = interactions_url().rstrip("/")
+    if not base:
+        return ""
+    return f"{base}{ACTION_ROUTE_PATH}/{dialog_route_token()}"
+
+
+def normalize_channel_key(team_id: str, channel_id: str) -> str:
+    return f"{str(team_id).strip()}/{str(channel_id).strip()}"
+
+
+def chat_binding_id(kind: str, conversation_id: str) -> str:
+    return f"{str(kind).strip().lower()}:{str(conversation_id).strip()}"
+
+
+def set_chat_binding(
+    config: dict[str, Any],
+    kind: str,
+    conversation_id: str,
+    session_names: list[str],
+    team_id: str = "",
+    *,
+    policy: dict[str, Any] | None = None,
+    channel_metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    normalized_kind = str(kind).strip().lower()
+    if normalized_kind not in {"dm", "room"}:
+        raise ValueError("kind must be dm or room")
+    normalized_conversation = str(conversation_id).strip()
+    if not normalized_conversation:
+        raise ValueError("conversation_id is required")
+    normalized_session_names = dedupe_session_names(session_names)
+    if not normalized_session_names:
+        raise ValueError("at least one session name is required")
+    if normalized_kind == "dm" and len(normalized_session_names) != 1:
+        raise ValueError("DM bindings require exactly one session name")
+
+    cfg = normalize_config(config)
+    binding_id = chat_binding_id(normalized_kind, normalized_conversation)
+    if normalized_kind == "room" and resolve_room_launcher(cfg, normalized_conversation):
+        raise ValueError("room launch is already enabled for that conversation")
+    existing = resolve_chat_binding(cfg, binding_id) or {}
+    raw_room_policy = copy.deepcopy(existing.get("policy")) if isinstance(existing.get("policy"), dict) else {}
+    raw_channel_metadata = normalize_binding_channel_metadata(existing)
+    if isinstance(channel_metadata, dict):
+        raw_channel_metadata.update(normalize_binding_channel_metadata(channel_metadata))
+    if isinstance(policy, dict):
+        raw_room_policy.update(copy.deepcopy(policy))
+    room_policy = normalize_room_peer_policy(raw_room_policy)
+    if normalized_kind == "room" and room_policy.get("peer_fanout_enabled"):
+        invalid = [name for name in normalized_session_names if canonical_peer_session_name(name) != name]
+        if invalid:
+            raise ValueError("peer-fanout-enabled room bindings require lowercase canonical session names")
+    if normalized_kind == "room" and room_policy.get("allow_untargeted_ambient_delivery"):
+        if not room_policy.get("ambient_read_enabled"):
+            raise ValueError("untargeted ambient delivery requires ambient read to be enabled")
+        if len(normalized_session_names) != 1:
+            raise ValueError("untargeted ambient delivery requires exactly one session name")
+    cfg.setdefault("chat", {})
+    cfg["chat"].setdefault("bindings", {})
+    binding_channel_id, binding_root_id = mattermost_conversation_parts(normalized_conversation)
+    binding: dict[str, Any] = {
+        "id": binding_id,
+        "kind": normalized_kind,
+        "conversation_id": normalized_conversation,
+        "channel_id": binding_channel_id,
+        "root_id": binding_root_id,
+        "team_id": str(team_id).strip(),
+        "session_names": normalized_session_names,
+    }
+    if normalized_kind == "room":
+        if raw_channel_metadata:
+            binding.update(raw_channel_metadata)
+        binding["policy"] = room_policy
+    cfg["chat"]["bindings"][binding_id] = binding
+    return save_config(cfg)
+
+
+def set_room_launcher(
+    config: dict[str, Any],
+    team_id: str,
+    conversation_id: str,
+    *,
+    response_mode: str = "mention_only",
+    default_qualified_handle: str = "",
+    policy: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    normalized_conversation = str(conversation_id).strip()
+    normalized_team_id = str(team_id).strip()
+    if not normalized_team_id:
+        raise ValueError("team_id is required")
+    if not normalized_conversation:
+        raise ValueError("conversation_id is required")
+    normalized_response_mode = normalize_room_launch_response_mode(response_mode)
+    normalized_default_handle = _normalize_agent_handle(default_qualified_handle)
+    if str(default_qualified_handle).strip() and (not normalized_default_handle or "/" not in normalized_default_handle):
+        raise ValueError("default_qualified_handle must use qualified rig/alias syntax")
+    if normalized_response_mode == "respond_all" and not normalized_default_handle:
+        raise ValueError("respond_all room launchers require --default-handle")
+
+    cfg = normalize_config(config)
+    binding_id = chat_binding_id("room", normalized_conversation)
+    existing_binding = resolve_chat_binding(cfg, binding_id)
+    if existing_binding:
+        raise ValueError("room launch cannot be enabled on a directly bound room")
+    cfg.setdefault("chat", {})
+    cfg["chat"].setdefault("launchers", {})
+    launcher_id = room_launch_surface_id(normalized_conversation)
+    existing_launcher = resolve_room_launcher(cfg, normalized_conversation) or {}
+    existing_has_policy = isinstance(existing_launcher.get("policy"), dict)
+    has_policy = existing_has_policy or not existing_launcher
+    raw_policy = copy.deepcopy(existing_launcher.get("policy")) if existing_has_policy else {}
+    if not existing_launcher:
+        raw_policy = default_room_launch_peer_policy()
+    if isinstance(policy, dict) and policy:
+        has_policy = True
+        raw_policy.update(copy.deepcopy(policy))
+    launcher: dict[str, Any] = {
+        "id": launcher_id,
+        "kind": "room",
+        "team_id": normalized_team_id,
+        "conversation_id": normalized_conversation,
+        "response_mode": normalized_response_mode,
+        "default_qualified_handle": normalized_default_handle,
+    }
+    if has_policy:
+        launcher["policy"] = normalize_room_launch_peer_policy(raw_policy)
+    cfg["chat"]["launchers"][launcher_id] = launcher
+    return save_config(cfg)
+
+
+def resolve_room_launcher(config: dict[str, Any], conversation_id: str) -> dict[str, Any] | None:
+    launchers = normalize_config(config).get("chat", {}).get("launchers", {})
+    return launchers.get(room_launch_surface_id(conversation_id))
+
+
+def list_room_launchers(config: dict[str, Any]) -> list[dict[str, Any]]:
+    launchers = normalize_config(config).get("chat", {}).get("launchers", {})
+    return sorted(launchers.values(), key=lambda item: (str(item.get("kind", "")), str(item.get("conversation_id", ""))))
+
+
+def describe_channel(channel_id: str, *, bot_token: str = "") -> dict[str, Any]:
+    info = mattermost_api_request(
+        "GET",
+        f"/channels/{urllib.parse.quote(str(channel_id).strip())}",
+        bot_token=str(bot_token).strip() or None,
+    )
+    if not isinstance(info, dict):
+        return {}
+    return info
+
+
+def describe_room_channel_metadata(conversation_id: str, *, bot_token: str = "") -> dict[str, Any]:
+    token = str(bot_token).strip() or load_bot_token()
+    if not token:
+        return {}
+    info = describe_channel(conversation_id, bot_token=token)
+    if not info:
+        return {}
+    return normalize_binding_channel_metadata(info)
+
+
+def channel_metadata_cache_path(conversation_id: str) -> str:
+    return os.path.join(channel_metadata_cache_dir(), f"{safe_storage_id(str(conversation_id).strip(), 'channel-metadata')}.json")
+
+
+def load_channel_metadata_cache(conversation_id: str) -> dict[str, Any]:
+    ensure_layout()
+    data = read_json(channel_metadata_cache_path(conversation_id), allow_invalid=True)
+    if not isinstance(data, dict):
+        return {}
+    return normalize_binding_channel_metadata(data)
+
+
+def save_channel_metadata_cache(conversation_id: str, metadata: dict[str, Any] | None) -> dict[str, Any]:
+    ensure_layout()
+    normalized = normalize_binding_channel_metadata(metadata)
+    if not normalized:
+        return {}
+    atomic_write_json(channel_metadata_cache_path(conversation_id), normalized)
+    return normalized
+
+
+def resolve_chat_binding(config: dict[str, Any], binding_id: str) -> dict[str, Any] | None:
+    bindings = normalize_config(config).get("chat", {}).get("bindings", {})
+    return bindings.get(str(binding_id).strip())
+
+
+def list_chat_bindings(config: dict[str, Any]) -> list[dict[str, Any]]:
+    bindings = normalize_config(config).get("chat", {}).get("bindings", {})
+    return sorted(bindings.values(), key=lambda item: (str(item.get("kind", "")), str(item.get("conversation_id", ""))))
+
+
+def resolve_publish_route(config: dict[str, Any], route_id: str) -> dict[str, Any] | None:
+    binding = resolve_chat_binding(config, route_id)
+    if binding:
+        return binding
+    route = str(route_id).strip()
+    if route.startswith("launch-room:"):
+        launcher = resolve_room_launcher(config, route.removeprefix("launch-room:"))
+        if launcher:
+            payload = dict(launcher)
+            payload["publish_route_kind"] = "room_launch"
+            payload["kind"] = "room"
+            payload.setdefault("session_names", [])
+            return payload
+    return None
+
+
+def set_channel_mapping(
+    config: dict[str, Any],
+    team_id: str,
+    channel_id: str,
+    target: str,
+    fix_formula: str | None,
+) -> dict[str, Any]:
+    cfg = normalize_config(config)
+    formula = str(fix_formula or FIX_FORMULA_DEFAULT).strip() or FIX_FORMULA_DEFAULT
+    normalized_target = validate_fix_dispatch_target(target, formula)
+    key = normalize_channel_key(team_id, channel_id)
+    cfg["channels"][key] = {
+        "team_id": str(team_id).strip(),
+        "channel_id": str(channel_id).strip(),
+        "target": normalized_target,
+        "commands": {
+            "fix": {
+                "formula": formula,
+            }
+        },
+    }
+    return save_config(cfg)
+
+
+def resolve_channel_mapping(config: dict[str, Any], team_id: str, channel_id: str) -> dict[str, Any] | None:
+    channels = normalize_config(config).get("channels", {})
+    return channels.get(normalize_channel_key(team_id, channel_id))
+
+
+def normalize_rig_key(team_id: str, rig_name: str) -> str:
+    return f"{str(team_id).strip()}/{str(rig_name).strip()}"
+
+
+def set_rig_mapping(
+    config: dict[str, Any],
+    team_id: str,
+    rig_name: str,
+    target: str,
+    fix_formula: str | None,
+) -> dict[str, Any]:
+    cfg = normalize_config(config)
+    formula = str(fix_formula or FIX_FORMULA_DEFAULT).strip() or FIX_FORMULA_DEFAULT
+    normalized_target = validate_fix_dispatch_target(target, formula)
+    key = normalize_rig_key(team_id, rig_name)
+    cfg["rigs"][key] = {
+        "team_id": str(team_id).strip(),
+        "rig_name": str(rig_name).strip(),
+        "target": normalized_target,
+        "commands": {
+            "fix": {
+                "formula": formula,
+            }
+        },
+    }
+    return save_config(cfg)
+
+
+def resolve_rig_mapping(config: dict[str, Any], team_id: str, rig_name: str) -> dict[str, Any] | None:
+    rigs = normalize_config(config).get("rigs", {})
+    return rigs.get(normalize_rig_key(team_id, rig_name))
+
+
+def load_channel_context(
+    config: dict[str, Any],
+    team_id: str,
+    channel_id: str,
+    root_id_hint: str = "",
+) -> dict[str, Any]:
+    normalized_team_id = str(team_id).strip()
+    normalized_channel_id = str(channel_id).strip()
+    root_id = str(root_id_hint).strip()
+    mapping = resolve_channel_mapping(config, normalized_team_id, normalized_channel_id)
+    if mapping:
+        return {
+            "team_id": normalized_team_id,
+            "channel_id": normalized_channel_id,
+            "root_id": root_id,
+            "mapping": mapping,
+            "channel_info": {},
+        }
+    channel_info: dict[str, Any] = {}
+    bot_token = load_bot_token()
+    if bot_token:
+        try:
+            channel_info = describe_channel(normalized_channel_id, bot_token=bot_token)
+        except MattermostAPIError as exc:
+            if exc.status_code != 404:
+                return {
+                    "team_id": normalized_team_id,
+                    "channel_id": normalized_channel_id,
+                    "root_id": root_id,
+                    "mapping": {},
+                    "channel_info": {},
+                    "lookup_error": str(exc),
+                }
+    # DM/GM channels carry an empty team_id, and an inbound event can name a
+    # different team than the channel actually belongs to.
+    resolved_team_id = str(channel_info.get("team_id", "")).strip()
+    if resolved_team_id and resolved_team_id != normalized_team_id:
+        mapping = resolve_channel_mapping(config, resolved_team_id, normalized_channel_id)
+        if mapping:
+            return {
+                "team_id": resolved_team_id,
+                "channel_id": normalized_channel_id,
+                "root_id": root_id,
+                "mapping": mapping,
+                "channel_info": channel_info,
+            }
+    return {
+        "team_id": resolved_team_id or normalized_team_id,
+        "channel_id": normalized_channel_id,
+        "root_id": root_id,
+        "mapping": mapping or None,
+        "channel_info": channel_info,
+    }
+
+
+def safe_storage_id(value: str, prefix: str) -> str:
+    value = value.strip()
+    if value and all(ch.isalnum() or ch in ("-", "_", ":") for ch in value):
+        return value
+    digest = hashlib.sha256(value.encode("utf-8")).hexdigest()[:24]
+    return f"{prefix}-{digest}"
+
+
+def build_request_id(interaction_id: str, command: str) -> str:
+    safe_command = "".join(ch for ch in command.lower() if ch.isalnum() or ch in ("-", "_")) or "command"
+    return f"mm-{safe_storage_id(interaction_id, 'interaction')}-{safe_command}"
+
+
+def build_workflow_key(team_id: str, conversation_id: str, command: str) -> str:
+    safe_command = "".join(ch for ch in command.lower() if ch.isalnum() or ch in ("-", "_")) or "command"
+    return f"mm:team:{team_id}:conversation:{conversation_id}:{safe_command}"
+
+
+def request_path(request_id: str) -> str:
+    return os.path.join(requests_dir(), f"{safe_storage_id(request_id, 'request')}.json")
+
+
+def receipt_path(interaction_id: str) -> str:
+    return os.path.join(receipts_dir(), f"{safe_storage_id(interaction_id, 'receipt')}.json")
+
+
+def workflow_path(workflow_key: str) -> str:
+    return os.path.join(workflows_dir(), f"{safe_storage_id(workflow_key, 'workflow')}.json")
+
+
+def pending_modal_path(nonce: str) -> str:
+    return os.path.join(pending_modals_dir(), f"{safe_storage_id(nonce, 'modal')}.json")
+
+
+def chat_publish_path(publish_id: str) -> str:
+    return os.path.join(chat_publishes_dir(), f"{safe_storage_id(publish_id, 'chat-publish')}.json")
+
+
+def chat_ingress_path(ingress_id: str) -> str:
+    return os.path.join(chat_ingress_dir(), f"{safe_storage_id(ingress_id, 'chat-ingress')}.json")
+
+
+def room_launch_path(launch_id: str) -> str:
+    return os.path.join(room_launches_dir(), f"{safe_storage_id(launch_id, 'room-launch')}.json")
+
+
+def room_launch_record_id(root_post_id: str) -> str:
+    return f"room-launch:{str(root_post_id).strip()}"
+
+
+def room_launch_lock_path(launch_id: str) -> str:
+    return _safe_lock_name("room-launch", str(launch_id).strip())
+
+
+def load_request(request_id: str) -> dict[str, Any] | None:
+    data = read_json(request_path(request_id), allow_invalid=True)
+    if isinstance(data, dict):
+        return data
+    return None
+
+
+def save_request(payload: dict[str, Any]) -> dict[str, Any]:
+    ensure_layout()
+    body = copy.deepcopy(payload)
+    body["updated_at"] = utcnow()
+    atomic_write_json(request_path(body["request_id"]), body)
+    return body
+
+
+def load_interaction_receipt(interaction_id: str) -> dict[str, Any] | None:
+    data = read_json(receipt_path(interaction_id), allow_invalid=True)
+    if isinstance(data, dict):
+        return data
+    return None
+
+
+def save_interaction_receipt(interaction_id: str, payload: dict[str, Any]) -> bool:
+    ensure_layout()
+    path = receipt_path(interaction_id)
+    body = copy.deepcopy(payload)
+    body["interaction_id"] = interaction_id
+    body.setdefault("created_at", utcnow())
+    data = json.dumps(body, indent=2, sort_keys=True).encode("utf-8") + b"\n"
+    try:
+        fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o640)
+    except FileExistsError:
+        return False
+    with os.fdopen(fd, "wb") as handle:
+        handle.write(data)
+    return True
+
+
+def replace_interaction_receipt(interaction_id: str, payload: dict[str, Any]) -> dict[str, Any]:
+    ensure_layout()
+    existing = load_interaction_receipt(interaction_id) or {}
+    body = copy.deepcopy(payload)
+    body["interaction_id"] = interaction_id
+    body.setdefault("created_at", str(existing.get("created_at", "")).strip() or utcnow())
+    atomic_write_json(receipt_path(interaction_id), body)
+    return body
+
+
+def load_workflow_link(workflow_key: str) -> dict[str, Any] | None:
+    data = read_json(workflow_path(workflow_key), allow_invalid=True)
+    if isinstance(data, dict):
+        return data
+    return None
+
+
+def save_workflow_link(workflow_key: str, request_id: str) -> dict[str, Any]:
+    ensure_layout()
+    payload = {
+        "workflow_key": workflow_key,
+        "request_id": request_id,
+        "created_at": utcnow(),
+    }
+    atomic_write_json(workflow_path(workflow_key), payload)
+    return payload
+
+
+def remove_workflow_link(workflow_key: str) -> None:
+    try:
+        os.remove(workflow_path(workflow_key))
+    except FileNotFoundError:
+        return
+
+
+def remove_workflow_link_if_request(workflow_key: str, request_id: str) -> bool:
+    current = load_workflow_link(workflow_key)
+    if not current:
+        return False
+    if str(current.get("request_id", "")) != request_id:
+        return False
+    remove_workflow_link(workflow_key)
+    return True
+
+
+def remove_workflow_links_for_request(request_id: str) -> list[str]:
+    released: list[str] = []
+    for path in pathlib.Path(workflows_dir()).glob("*.json"):
+        payload = read_json(str(path), {}, allow_invalid=True)
+        if not isinstance(payload, dict):
+            continue
+        workflow_key = str(payload.get("workflow_key", "")).strip()
+        if not workflow_key or str(payload.get("request_id", "")).strip() != str(request_id).strip():
+            continue
+        remove_workflow_link(workflow_key)
+        released.append(workflow_key)
+    return released
+
+
+def save_pending_modal(payload: dict[str, Any]) -> dict[str, Any]:
+    ensure_layout()
+    body = copy.deepcopy(payload)
+    body.setdefault("created_at", utcnow())
+    atomic_write_json(pending_modal_path(str(body["nonce"])), body)
+    return body
+
+
+def load_pending_modal(nonce: str) -> dict[str, Any] | None:
+    data = read_json(pending_modal_path(nonce), allow_invalid=True)
+    if isinstance(data, dict):
+        return data
+    return None
+
+
+def remove_pending_modal(nonce: str) -> None:
+    try:
+        os.remove(pending_modal_path(nonce))
+    except FileNotFoundError:
+        return
+
+
+def consume_pending_modal(state: str) -> dict[str, Any] | None:
+    # Dialog submits carry no signature of their own, so the nonce is only
+    # trusted after the HMAC in `state` verifies, and it is single-use.
+    nonce = verify_dialog_state(state)
+    if not nonce:
+        return None
+    record = load_pending_modal(nonce)
+    if not record:
+        return None
+    remove_pending_modal(nonce)
+    return record
+
+
+def _prune_dir(path: str, max_age_seconds: int) -> None:
+    now = time.time()
+    for entry in pathlib.Path(path).glob("*.json"):
+        try:
+            age = now - entry.stat().st_mtime
+        except FileNotFoundError:
+            continue
+        if age > max_age_seconds:
+            try:
+                entry.unlink()
+            except FileNotFoundError:
+                continue
+
+
+def prune_receipts() -> None:
+    ensure_layout()
+    _prune_dir(receipts_dir(), REQUEST_RETENTION_SECONDS)
+
+
+def active_workflow_request_ids() -> set[str]:
+    ensure_layout()
+    request_ids: set[str] = set()
+    for path in pathlib.Path(workflows_dir()).glob("*.json"):
+        payload = read_json(str(path), {}, allow_invalid=True)
+        if not isinstance(payload, dict):
+            continue
+        request_id = str(payload.get("request_id", "")).strip()
+        if request_id:
+            request_ids.add(request_id)
+    return request_ids
+
+
+def prune_requests() -> None:
+    ensure_layout()
+    now = time.time()
+    active_request_ids = active_workflow_request_ids()
+    for entry in pathlib.Path(requests_dir()).glob("*.json"):
+        payload = read_json(str(entry), allow_invalid=True)
+        if isinstance(payload, dict) and str(payload.get("request_id", "")).strip() in active_request_ids:
+            continue
+        try:
+            age = now - entry.stat().st_mtime
+        except FileNotFoundError:
+            continue
+        if age > REQUEST_RETENTION_SECONDS:
+            try:
+                entry.unlink()
+            except FileNotFoundError:
+                continue
+
+
+def prune_pending_modals() -> None:
+    ensure_layout()
+    _prune_dir(pending_modals_dir(), PENDING_MODAL_RETENTION_SECONDS)
+
+
+def list_recent_requests(limit: int = 20) -> list[dict[str, Any]]:
+    ensure_layout()
+    entries: list[dict[str, Any]] = []
+    paths = sorted(
+        pathlib.Path(requests_dir()).glob("*.json"),
+        key=lambda path: path.stat().st_mtime,
+        reverse=True,
+    )[:limit]
+    for path in paths:
+        data = read_json(str(path), allow_invalid=True)
+        if isinstance(data, dict):
+            entries.append(data)
+    entries.sort(key=lambda item: item.get("created_at", ""), reverse=True)
+    return entries[:limit]
+
+
+def save_gateway_status(payload: dict[str, Any]) -> dict[str, Any]:
+    ensure_layout()
+    body = copy.deepcopy(payload)
+    body["updated_at"] = utcnow()
+    atomic_write_json(gateway_status_path(), body)
+    return body
+
+
+def load_gateway_status() -> dict[str, Any]:
+    ensure_layout()
+    payload = read_json(gateway_status_path(), {}, allow_invalid=True)
+    if isinstance(payload, dict):
+        return payload
+    return {}
+
+
+def save_chat_publish(payload: dict[str, Any]) -> dict[str, Any]:
+    ensure_layout()
+    body = copy.deepcopy(payload)
+    publish_id = str(body.get("publish_id", "")).strip()
+    if not publish_id:
+        publish_id = f"mattermost-publish-{int(time.time() * 1000)}-{hashlib.sha256(os.urandom(16)).hexdigest()[:8]}"
+        body["publish_id"] = publish_id
+    body.setdefault("created_at", utcnow())
+    atomic_write_json(chat_publish_path(publish_id), body)
+    _update_peer_root_budget_index(body)
+    return body
+
+
+def load_room_launch(launch_id: str) -> dict[str, Any] | None:
+    data = read_json(room_launch_path(launch_id), allow_invalid=True)
+    if isinstance(data, dict):
+        return normalize_room_launch_record(data)
+    return None
+
+
+def normalize_room_launch_record(payload: dict[str, Any]) -> dict[str, Any]:
+    body = copy.deepcopy(payload)
+    participants: dict[str, dict[str, Any]] = {}
+    raw_participants = body.get("participants")
+    if isinstance(raw_participants, dict):
+        for key, raw in raw_participants.items():
+            item = copy.deepcopy(raw) if isinstance(raw, dict) else {}
+            qualified_handle = str(item.get("qualified_handle", "")).strip() or str(key).strip()
+            if not qualified_handle:
+                continue
+            participants[qualified_handle] = {
+                **item,
+                "qualified_handle": qualified_handle,
+                "session_alias": str(item.get("session_alias", "")).strip(),
+                "session_id": str(item.get("session_id", "")).strip(),
+                "session_name": str(item.get("session_name", "")).strip(),
+            }
+    primary_handle = str(body.get("qualified_handle", "")).strip()
+    if primary_handle:
+        participant = copy.deepcopy(participants.get(primary_handle, {}))
+        participant["qualified_handle"] = primary_handle
+        for field in ("session_alias", "session_id", "session_name"):
+            top_level = str(body.get(field, "")).strip()
+            participant[field] = top_level or str(participant.get(field, "")).strip()
+        participants[primary_handle] = participant
+    body["participants"] = participants
+    message_targets: dict[str, str] = {}
+    raw_message_targets = body.get("message_targets")
+    if isinstance(raw_message_targets, dict):
+        for message_id, qualified_handle in raw_message_targets.items():
+            normalized_message_id = str(message_id).strip()
+            normalized_handle = str(qualified_handle).strip()
+            if normalized_message_id and normalized_handle:
+                message_targets[normalized_message_id] = normalized_handle
+    root_post_id = str(body.get("root_post_id", "")).strip()
+    if primary_handle and root_post_id and root_post_id not in message_targets:
+        message_targets[root_post_id] = primary_handle
+    if message_targets:
+        body["message_targets"] = message_targets
+    else:
+        body.pop("message_targets", None)
+    target_order = [str(item).strip() for item in body.get("message_target_order", []) if str(item).strip()]
+    if root_post_id and root_post_id in message_targets and root_post_id not in target_order:
+        target_order.insert(0, root_post_id)
+    if target_order:
+        body["message_target_order"] = target_order
+    else:
+        body.pop("message_target_order", None)
+    if primary_handle and primary_handle in participants:
+        participant = participants[primary_handle]
+        body["session_alias"] = str(participant.get("session_alias", "")).strip()
+        body["session_id"] = str(participant.get("session_id", "")).strip()
+        body["session_name"] = str(participant.get("session_name", "")).strip()
+    cursor = str(body.get("last_addressed_qualified_handle", "")).strip()
+    if cursor:
+        body["last_addressed_qualified_handle"] = cursor
+    elif primary_handle:
+        body["last_addressed_qualified_handle"] = primary_handle
+    return body
+
+
+def room_launch_participants(payload: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    body = normalize_room_launch_record(payload)
+    raw = body.get("participants")
+    if isinstance(raw, dict):
+        return copy.deepcopy(raw)
+    return {}
+
+
+def room_launch_participant(payload: dict[str, Any], qualified_handle: str) -> dict[str, Any]:
+    return copy.deepcopy(room_launch_participants(payload).get(str(qualified_handle).strip(), {}))
+
+
+def room_launch_participant_summaries(payload: dict[str, Any]) -> list[dict[str, str]]:
+    summaries: list[dict[str, str]] = []
+    for qualified_handle, participant in room_launch_participants(payload).items():
+        summaries.append(
+            {
+                "qualified_handle": qualified_handle,
+                "session_alias": str(participant.get("session_alias", "")).strip(),
+                "session_name": str(participant.get("session_name", "")).strip(),
+            }
+        )
+    summaries.sort(key=lambda item: item["qualified_handle"])
+    return summaries
+
+
+def room_launch_participant_handle_lookup(payload: dict[str, Any]) -> dict[str, str]:
+    lookup: dict[str, str] = {}
+    for qualified_handle, participant in room_launch_participants(payload).items():
+        selector = room_launch_participant_delivery_selector(participant)
+        if qualified_handle and selector:
+            lookup[qualified_handle] = selector
+    return lookup
+
+
+def room_launch_participant_session_lookup(payload: dict[str, Any]) -> dict[str, str]:
+    lookup: dict[str, str] = {}
+    for participant in room_launch_participants(payload).values():
+        selector = room_launch_participant_delivery_selector(participant)
+        session_name = str(participant.get("session_name", "")).strip()
+        if session_name and selector:
+            lookup[session_name] = selector
+    return lookup
+
+
+def room_launch_participant_delivery_targets(payload: dict[str, Any]) -> list[str]:
+    targets: list[str] = []
+    seen: set[str] = set()
+    for participant in room_launch_participants(payload).values():
+        selector = room_launch_participant_delivery_selector(participant)
+        if not selector or selector in seen:
+            continue
+        seen.add(selector)
+        targets.append(selector)
+    return targets
+
+
+def room_launch_participant_handle_for_session(payload: dict[str, Any], *, session_name: str = "", session_id: str = "") -> str:
+    for qualified_handle, participant in room_launch_participants(payload).items():
+        if _room_launch_participant_matches_session(
+            participant,
+            session_name=session_name,
+            session_id=session_id,
+        ):
+            return qualified_handle
+    return ""
+
+
+def resolve_room_launch_target_selector(launch: dict[str, Any], target_selector: str) -> tuple[str, dict[str, Any], dict[str, str]]:
+    normalized_target = str(target_selector).strip()
+    if not normalized_target:
+        return "", {}, {}
+    participant_handle = room_launch_participant_handle_for_session(
+        launch,
+        session_name=normalized_target,
+        session_id=normalized_target,
+    )
+    participant = room_launch_participant(launch, participant_handle)
+    try:
+        sessions = list_city_sessions(state="all")
+    except GCAPIError:
+        sessions = []
+    resolved_selector, identity = resolve_routable_session_candidate_from_sessions(
+        sessions,
+        participant.get("session_name", ""),
+        participant.get("delivery_selector", ""),
+        participant.get("session_alias", ""),
+        participant.get("session_id", ""),
+        normalized_target,
+    )
+    if resolved_selector:
+        return resolved_selector, participant, identity
+    local_selector = (
+        str(participant.get("session_alias", "")).strip()
+        or str(participant.get("delivery_selector", "")).strip()
+        or str(participant.get("session_name", "")).strip()
+        or str(participant.get("session_id", "")).strip()
+        or normalized_target
+    )
+    return local_selector, participant, {}
+
+
+def room_launch_message_target_handle(payload: dict[str, Any], remote_message_id: str) -> str:
+    body = normalize_room_launch_record(payload)
+    message_id = str(remote_message_id).strip()
+    if not message_id:
+        return ""
+    handle = str(body.get("message_targets", {}).get(message_id, "")).strip()
+    if not handle:
+        return ""
+    if handle not in room_launch_participants(body):
+        return ""
+    return handle
+
+
+def save_room_launch(payload: dict[str, Any]) -> dict[str, Any]:
+    ensure_layout()
+    body = normalize_room_launch_record(payload)
+    launch_id = str(body.get("launch_id", "")).strip()
+    if not launch_id:
+        raise ValueError("launch_id is required")
+    body.setdefault("created_at", utcnow())
+    body["updated_at"] = utcnow()
+    atomic_write_json(room_launch_path(launch_id), body)
+    return body
+
+
+def touch_room_launch(launch_id: str, *, activity_at: str = "") -> dict[str, Any] | None:
+    normalized_launch_id = str(launch_id).strip()
+    if not normalized_launch_id:
+        return None
+    with advisory_lock(room_launch_lock_path(normalized_launch_id)):
+        current = load_room_launch(normalized_launch_id)
+        if not isinstance(current, dict):
+            return None
+        body = copy.deepcopy(current)
+        body["last_activity_at"] = str(activity_at).strip() or utcnow()
+        return save_room_launch(body)
+
+
+def set_room_launch_last_addressed(launch_id: str, qualified_handle: str) -> dict[str, Any] | None:
+    normalized_launch_id = str(launch_id).strip()
+    normalized_handle = str(qualified_handle).strip()
+    if not normalized_launch_id or not normalized_handle:
+        return None
+    with advisory_lock(room_launch_lock_path(normalized_launch_id)):
+        current = load_room_launch(normalized_launch_id)
+        if not isinstance(current, dict):
+            return None
+        if normalized_handle not in room_launch_participants(current):
+            return current
+        body = copy.deepcopy(current)
+        body["last_addressed_qualified_handle"] = normalized_handle
+        return save_room_launch(body)
+
+
+def list_room_launches(limit: int = 50) -> list[dict[str, Any]]:
+    ensure_layout()
+    entries: list[dict[str, Any]] = []
+    paths = sorted(
+        pathlib.Path(room_launches_dir()).glob("*.json"),
+        key=lambda path: path.stat().st_mtime,
+        reverse=True,
+    )[:limit]
+    for path in paths:
+        data = read_json(str(path), allow_invalid=True)
+        if isinstance(data, dict):
+            entries.append(data)
+    entries.sort(key=lambda item: item.get("created_at", ""), reverse=True)
+    return entries[:limit]
+
+
+def load_chat_publish(publish_id: str) -> dict[str, Any] | None:
+    data = read_json(chat_publish_path(publish_id), allow_invalid=True)
+    if isinstance(data, dict):
+        return data
+    return None
+
+
+def iter_chat_publishes() -> list[dict[str, Any]]:
+    ensure_layout()
+    items: list[dict[str, Any]] = []
+    for path in pathlib.Path(chat_publishes_dir()).glob("*.json"):
+        data = read_json(str(path), allow_invalid=True)
+        if isinstance(data, dict):
+            items.append(data)
+    return items
+
+
+def list_recent_chat_publishes(limit: int = 20) -> list[dict[str, Any]]:
+    ensure_layout()
+    entries: list[dict[str, Any]] = []
+    paths = sorted(
+        pathlib.Path(chat_publishes_dir()).glob("*.json"),
+        key=lambda path: path.stat().st_mtime,
+        reverse=True,
+    )[:limit]
+    for path in paths:
+        data = read_json(str(path), allow_invalid=True)
+        if isinstance(data, dict):
+            entries.append(data)
+    entries.sort(key=lambda item: item.get("created_at", ""), reverse=True)
+    return entries[:limit]
+
+
+def iter_chat_publishes_since(since_epoch: float) -> list[dict[str, Any]]:
+    ensure_layout()
+    items: list[dict[str, Any]] = []
+    for path in pathlib.Path(chat_publishes_dir()).glob("*.json"):
+        try:
+            stat_result = path.stat()
+        except OSError:
+            continue
+        if stat_result.st_mtime < since_epoch:
+            continue
+        data = read_json(str(path), allow_invalid=True)
+        if isinstance(data, dict):
+            items.append(data)
+    return items
+
+
+def _safe_lock_name(prefix: str, key: str) -> str:
+    digest = hashlib.sha256(str(key).encode("utf-8")).hexdigest()[:16]
+    return os.path.join(locks_dir(), f"{prefix}-{digest}.lock")
+
+
+def peer_root_budget_path(binding_id: str, root_ingress_receipt_id: str) -> str:
+    safe_key = safe_storage_id(f"{binding_id}:{root_ingress_receipt_id}", "peer-root-budget")
+    return os.path.join(peer_root_budget_dir(), f"{safe_key}.json")
+
+
+@contextlib.contextmanager
+def advisory_lock(path: str):
+    ensure_layout()
+    handle = open(path, "a+", encoding="utf-8")
+    try:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        yield handle
+    finally:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        handle.close()
+
+
+def parse_utc_timestamp(value: str) -> float | None:
+    text = str(value).strip()
+    if not text:
+        return None
+    try:
+        parsed = time.strptime(text, "%Y-%m-%dT%H:%M:%SZ")
+    except ValueError:
+        return None
+    return float(calendar.timegm(parsed))
+
+
+def _normalize_peer_root_budget_index(index: dict[str, Any] | None, *, binding_id: str, root_ingress_receipt_id: str) -> dict[str, Any]:
+    payload = copy.deepcopy(index) if isinstance(index, dict) else {}
+    entries = payload.get("entries")
+    normalized_entries: dict[str, dict[str, Any]] = {}
+    if isinstance(entries, dict):
+        for publish_id, item in entries.items():
+            if not isinstance(item, dict):
+                continue
+            normalized_entries[str(publish_id).strip()] = {
+                "publish_id": str(item.get("publish_id", publish_id)).strip(),
+                "created_at": str(item.get("created_at", "")).strip(),
+                "source_session_name": str(item.get("source_session_name", "")).strip(),
+                "source_event_kind": str(item.get("source_event_kind", "")).strip(),
+                "frozen_target_count": max(0, int(item.get("frozen_target_count", 0) or 0)),
+            }
+    payload["binding_id"] = binding_id
+    payload["root_ingress_receipt_id"] = root_ingress_receipt_id
+    payload["entries"] = normalized_entries
+    return payload
+
+
+def load_peer_root_budget_index(binding_id: str, root_ingress_receipt_id: str) -> dict[str, Any]:
+    if not binding_id or not root_ingress_receipt_id:
+        return _normalize_peer_root_budget_index({}, binding_id=binding_id, root_ingress_receipt_id=root_ingress_receipt_id)
+    payload = read_json(peer_root_budget_path(binding_id, root_ingress_receipt_id), {}, allow_invalid=True)
+    if not isinstance(payload, dict):
+        payload = {}
+    return _normalize_peer_root_budget_index(payload, binding_id=binding_id, root_ingress_receipt_id=root_ingress_receipt_id)
+
+
+def _prune_peer_root_budget_index(index: dict[str, Any]) -> dict[str, Any]:
+    payload = copy.deepcopy(index)
+    cutoff = time.time() - CHAT_PUBLISH_RETENTION_SECONDS
+    entries = payload.get("entries")
+    if not isinstance(entries, dict):
+        payload["entries"] = {}
+        return payload
+    for publish_id, item in list(entries.items()):
+        created_at = ""
+        if isinstance(item, dict):
+            created_at = str(item.get("created_at", "")).strip()
+        created_epoch = parse_utc_timestamp(created_at)
+        if created_epoch is not None and created_epoch < cutoff:
+            entries.pop(publish_id, None)
+    payload["entries"] = entries
+    return payload
+
+
+def save_peer_root_budget_index(index: dict[str, Any]) -> dict[str, Any]:
+    payload = _prune_peer_root_budget_index(index)
+    binding_id = str(payload.get("binding_id", "")).strip()
+    root_ingress_receipt_id = str(payload.get("root_ingress_receipt_id", "")).strip()
+    if not binding_id or not root_ingress_receipt_id:
+        return payload
+    atomic_write_json(peer_root_budget_path(binding_id, root_ingress_receipt_id), payload)
+    return payload
+
+
+def _update_peer_root_budget_index(record: dict[str, Any]) -> None:
+    binding_id = str(record.get("binding_id", "")).strip()
+    root_ingress_receipt_id = str(record.get("root_ingress_receipt_id", "")).strip()
+    publish_id = str(record.get("publish_id", "")).strip()
+    if not binding_id or not root_ingress_receipt_id or not publish_id:
+        return
+    lock_path = _safe_lock_name("peer-root-index", f"{binding_id}:{root_ingress_receipt_id}")
+    with advisory_lock(lock_path):
+        index = load_peer_root_budget_index(binding_id, root_ingress_receipt_id)
+        entries = index.setdefault("entries", {})
+        peer_delivery = record.get("peer_delivery")
+        frozen_targets: list[str] = []
+        if isinstance(peer_delivery, dict):
+            frozen = peer_delivery.get("frozen_targets")
+            if isinstance(frozen, list):
+                frozen_targets = [str(item).strip() for item in frozen if str(item).strip()]
+        entries[publish_id] = {
+            "publish_id": publish_id,
+            "created_at": str(record.get("created_at", "")).strip(),
+            "source_session_name": str(record.get("source_session_name", "")).strip(),
+            "source_event_kind": str(record.get("source_event_kind", "")).strip(),
+            "frozen_target_count": len(frozen_targets),
+        }
+        save_peer_root_budget_index(index)
+
+
+def load_chat_ingress(ingress_id: str) -> dict[str, Any] | None:
+    data = read_json(chat_ingress_path(ingress_id), allow_invalid=True)
+    if isinstance(data, dict):
+        return data
+    return None
+
+
+def save_chat_ingress(payload: dict[str, Any]) -> dict[str, Any]:
+    ensure_layout()
+    body = copy.deepcopy(payload)
+    ingress_id = str(body.get("ingress_id", "")).strip()
+    if not ingress_id:
+        ingress_id = f"mattermost-ingress-{int(time.time() * 1000)}"
+        body["ingress_id"] = ingress_id
+    body["updated_at"] = utcnow()
+    body.setdefault("created_at", body["updated_at"])
+    atomic_write_json(chat_ingress_path(ingress_id), body)
+    return body
+
+
+def save_chat_ingress_if_absent(payload: dict[str, Any]) -> tuple[bool, dict[str, Any]]:
+    ensure_layout()
+    body = copy.deepcopy(payload)
+    ingress_id = str(body.get("ingress_id", "")).strip()
+    if not ingress_id:
+        ingress_id = f"mattermost-ingress-{int(time.time() * 1000)}"
+        body["ingress_id"] = ingress_id
+    body["updated_at"] = utcnow()
+    body.setdefault("created_at", body["updated_at"])
+    path = chat_ingress_path(ingress_id)
+    data = json.dumps(body, indent=2, sort_keys=True).encode("utf-8") + b"\n"
+    try:
+        fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o640)
+    except FileExistsError:
+        for _ in range(20):
+            try:
+                existing = load_chat_ingress(ingress_id)
+            except json.JSONDecodeError:
+                existing = None
+            if existing:
+                return False, existing
+            time.sleep(0.01)
+        updated_at = utcnow()
+        try:
+            stat_result = os.stat(path)
+        except OSError:
+            pass
+        else:
+            updated_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(stat_result.st_mtime))
+        return False, {
+            "ingress_id": ingress_id,
+            "status": "claim_conflict_unreadable",
+            "reason": "ingress_claim_unreadable",
+            "created_at": updated_at,
+            "updated_at": updated_at,
+        }
+    with os.fdopen(fd, "wb") as handle:
+        handle.write(data)
+    return True, body
+
+
+def validate_fix_dispatch_target(target: str, fix_formula: str) -> str:
+    normalized_target = str(target).strip()
+    if not normalized_target:
+        raise ValueError("target must be a rig/pool sling target")
+    rig, separator, pool = normalized_target.partition("/")
+    if not separator or not rig.strip() or not pool.strip():
+        raise ValueError("target must be a rig/pool sling target")
+    formula = str(fix_formula or FIX_FORMULA_DEFAULT).strip() or FIX_FORMULA_DEFAULT
+    if formula == FIX_FORMULA_DEFAULT and pool.strip() != "polecat":
+        raise ValueError(f"{FIX_FORMULA_DEFAULT} requires a rig/polecat sling target")
+    return f"{rig.strip()}/{pool.strip()}"
+
+
+def list_recent_chat_ingress(limit: int = 20) -> list[dict[str, Any]]:
+    ensure_layout()
+    entries: list[dict[str, Any]] = []
+    paths = sorted(
+        pathlib.Path(chat_ingress_dir()).glob("*.json"),
+        key=lambda path: path.stat().st_mtime,
+        reverse=True,
+    )[:limit]
+    for path in paths:
+        data = read_json(str(path), allow_invalid=True)
+        if isinstance(data, dict):
+            entries.append(data)
+    entries.sort(key=lambda item: item.get("created_at", ""), reverse=True)
+    return entries[:limit]
+
+
+def prune_chat_ingress() -> None:
+    ensure_layout()
+    _prune_dir(chat_ingress_dir(), CHAT_INGRESS_RETENTION_SECONDS)
+
+
+def prune_chat_publishes() -> None:
+    ensure_layout()
+    _prune_dir(chat_publishes_dir(), CHAT_PUBLISH_RETENTION_SECONDS)
+
+
+def prune_room_launches() -> None:
+    ensure_layout()
+    _prune_dir(room_launches_dir(), ROOM_LAUNCH_RETENTION_SECONDS)
+
+
+def redact_chat_ingress_record(payload: dict[str, Any]) -> dict[str, Any]:
+    body = copy.deepcopy(payload)
+    for field in ("from_display", "from_username", "from_user_id", "body_preview"):
+        if body.get(field):
+            body[field] = "[redacted]"
+    return body
+
+
+def redact_chat_publish_record(payload: dict[str, Any]) -> dict[str, Any]:
+    body = copy.deepcopy(payload)
+    if body.get("body"):
+        body["body"] = "[redacted]"
+    return body
+
+
+def redact_room_launch_record(payload: dict[str, Any]) -> dict[str, Any]:
+    body = copy.deepcopy(payload)
+    for field in ("from_display", "from_username", "from_user_id", "body_preview"):
+        if body.get(field):
+            body[field] = "[redacted]"
+    return body
+
+
+def redact_request_record(payload: dict[str, Any]) -> dict[str, Any]:
+    body = copy.deepcopy(payload)
+    for field in (
+        "summary",
+        "prompt",
+        "context_markdown",
+        "invoking_user_display_name",
+        "invoking_user_id",
+        "error_message",
+        "traceback",
+        "dispatch_stdout",
+        "dispatch_stderr",
+    ):
+        if body.get(field):
+            body[field] = "[redacted]"
+    return body
+
+
+def redact_gateway_status(payload: dict[str, Any]) -> dict[str, Any]:
+    body = copy.deepcopy(payload)
+    for field in ("last_message_preview", "last_error", "last_exception"):
+        if body.get(field):
+            body[field] = "[redacted]"
+    return body
+
+
+def published_service_snapshot(service_name: str) -> dict[str, Any]:
+    path = os.path.join(published_services_dir(), f"{service_name}.json")
+    snapshot = read_json(path, {}, allow_invalid=True)
+    if isinstance(snapshot, dict):
+        return snapshot
+    return {}
+
+
+def published_service_url(service_name: str) -> str:
+    if service_name == current_service_name():
+        current_url = os.environ.get("GC_SERVICE_PUBLIC_URL", "")
+        if current_url:
+            return current_url
+    snapshot = published_service_snapshot(service_name)
+    current_url = snapshot.get("current_url")
+    if isinstance(current_url, str):
+        return current_url
+    return ""
+
+
+def admin_url() -> str:
+    return published_service_url(ADMIN_SERVICE_NAME)
+
+
+def interactions_url() -> str:
+    return published_service_url(INTERACTIONS_SERVICE_NAME)
+
+
+def build_status_snapshot(limit: int = 20) -> dict[str, Any]:
+    config = load_config()
+    return {
+        "service_name": current_service_name(),
+        "admin_url": admin_url(),
+        "interactions_url": interactions_url(),
+        "config": redact_config(config),
+        "gateway_status": redact_gateway_status(load_gateway_status()),
+        "recent_requests": [redact_request_record(item) for item in list_recent_requests(limit=limit)],
+        "chat_bindings": list_chat_bindings(config),
+        "chat_launchers": list_room_launchers(config),
+        "recent_chat_ingress": [redact_chat_ingress_record(item) for item in list_recent_chat_ingress(limit=limit)],
+        "recent_chat_publishes": [redact_chat_publish_record(item) for item in list_recent_chat_publishes(limit=limit)],
+        "recent_room_launches": [redact_room_launch_record(item) for item in list_room_launches(limit=limit)],
+    }
+
+
+def mattermost_site_url() -> str:
+    value = str(os.environ.get("GC_MATTERMOST_URL", "")).strip()
+    if value:
+        return value.rstrip("/")
+    payload = read_json(config_path(), {}, allow_invalid=True)
+    app = payload.get("app") if isinstance(payload, dict) else None
+    if isinstance(app, dict):
+        return str(app.get("site_url", "")).strip().rstrip("/")
+    return ""
+
+
+def mattermost_api_base() -> str:
+    override = str(os.environ.get("GC_MATTERMOST_API_BASE", "")).strip()
+    if override:
+        return override.rstrip("/")
+    site_url = mattermost_site_url()
+    if not site_url:
+        raise MattermostAPIError("Mattermost site_url is not configured")
+    return site_url + MATTERMOST_API_PREFIX
+
+
+def mattermost_websocket_url() -> str:
+    override = str(os.environ.get("GC_MATTERMOST_WS_URL", "")).strip()
+    if override:
+        return override
+    site_url = mattermost_site_url()
+    if not site_url:
+        raise MattermostAPIError("Mattermost site_url is not configured")
+    parsed = urllib.parse.urlparse(site_url)
+    scheme = "wss" if parsed.scheme == "https" else "ws"
+    return urllib.parse.urlunparse((scheme, parsed.netloc, parsed.path.rstrip("/") + MATTERMOST_API_PREFIX + "/websocket", "", "", ""))
+
+
+def mattermost_retry_after_seconds(exc: urllib.error.HTTPError) -> float:
+    headers = exc.headers if exc.headers else {}
+    header_value = headers.get("Retry-After", "") if headers else ""
+    try:
+        if header_value:
+            return max(float(header_value), 0.0)
+    except ValueError:
+        pass
+    reset_value = headers.get("X-RateLimit-Reset", "") if headers else ""
+    try:
+        if reset_value:
+            # Mattermost reports the epoch second at which the window resets;
+            # tolerate deployments that send a plain delta instead.
+            reset = float(reset_value)
+            delta = reset - time.time() if reset > 10_000_000 else reset
+            return min(max(delta, 0.0), 60.0)
+    except ValueError:
+        pass
+    return 1.0
+
+
+def _mattermost_request(
+    method: str,
+    url: str,
+    *,
+    body: bytes | None,
+    headers: dict[str, str],
+    timeout: float,
+) -> bytes:
+    request = urllib.request.Request(url, data=body, headers=headers, method=method.upper())
+    raw = b""
+    for attempt in range(MATTERMOST_RATE_LIMIT_RETRIES + 1):
+        try:
+            with urllib.request.urlopen(request, timeout=timeout) as response:
+                raw = response.read()
+            break
+        except urllib.error.HTTPError as exc:
+            raw = exc.read()
+            if exc.code == 429 and attempt < MATTERMOST_RATE_LIMIT_RETRIES:
+                time.sleep(mattermost_retry_after_seconds(exc))
+                continue
+            message = raw.decode("utf-8", errors="replace")
+            raise MattermostAPIError(f"{method.upper()} {url} failed with {exc.code}: {message}", status_code=exc.code) from exc
+        except urllib.error.URLError as exc:
+            raise MattermostAPIError(f"{method.upper()} {url} failed: {exc}") from exc
+    return raw
+
+
+def mattermost_api_request(
+    method: str,
+    path: str,
+    payload: Any = None,
+    bot_token: str | None = None,
+    *,
+    timeout: float = MATTERMOST_REQUEST_TIMEOUT_SECONDS,
+) -> Any:
+    if path.startswith("http://") or path.startswith("https://"):
+        url = path
+    else:
+        url = urllib.parse.urljoin(mattermost_api_base().rstrip("/") + "/", path.lstrip("/"))
+    body = None
+    headers = {
+        "Accept": "application/json",
+        "User-Agent": "gas-city-mattermost/0.1",
+    }
+    token = bot_token or load_bot_token()
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    if payload is not None:
+        body = json.dumps(payload).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    raw = _mattermost_request(method, url, body=body, headers=headers, timeout=timeout)
+    if not raw:
+        return {}
+    try:
+        return json.loads(raw.decode("utf-8"))
+    except json.JSONDecodeError as exc:
+        raise MattermostAPIError(f"{method.upper()} {url} returned invalid JSON") from exc
+
+
+def _encode_multipart(fields: list[tuple[str, str]], files: list[tuple[str, str, bytes]]) -> tuple[bytes, str]:
+    boundary = "----gascity" + hashlib.sha256(os.urandom(16)).hexdigest()[:24]
+    chunks: list[bytes] = []
+    for name, value in fields:
+        chunks.append(f"--{boundary}\r\n".encode("utf-8"))
+        chunks.append(f'Content-Disposition: form-data; name="{name}"\r\n\r\n'.encode("utf-8"))
+        chunks.append(str(value).encode("utf-8") + b"\r\n")
+    for name, filename, content in files:
+        content_type = mimetypes.guess_type(filename)[0] or "application/octet-stream"
+        chunks.append(f"--{boundary}\r\n".encode("utf-8"))
+        chunks.append(
+            f'Content-Disposition: form-data; name="{name}"; filename="{os.path.basename(filename)}"\r\n'.encode("utf-8")
+        )
+        chunks.append(f"Content-Type: {content_type}\r\n\r\n".encode("utf-8"))
+        chunks.append(content + b"\r\n")
+    chunks.append(f"--{boundary}--\r\n".encode("utf-8"))
+    return b"".join(chunks), f"multipart/form-data; boundary={boundary}"
+
+
+def mattermost_upload_request(path: str, fields: list[tuple[str, str]], files: list[tuple[str, str, bytes]], *, bot_token: str | None = None) -> Any:
+    url = urllib.parse.urljoin(mattermost_api_base().rstrip("/") + "/", path.lstrip("/"))
+    body, content_type = _encode_multipart(fields, files)
+    headers = {
+        "Accept": "application/json",
+        "User-Agent": "gas-city-mattermost/0.1",
+        "Content-Type": content_type,
+    }
+    token = bot_token or load_bot_token()
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    raw = _mattermost_request("POST", url, body=body, headers=headers, timeout=max(MATTERMOST_REQUEST_TIMEOUT_SECONDS, 60.0))
+    if not raw:
+        return {}
+    try:
+        return json.loads(raw.decode("utf-8"))
+    except json.JSONDecodeError as exc:
+        raise MattermostAPIError(f"POST {url} returned invalid JSON") from exc
+
+
+def city_toml_path() -> str:
+    root = city_root()
+    if not root:
+        return "city.toml"
+    return os.path.join(root, "city.toml")
+
+
+def load_city_toml() -> dict[str, Any]:
+    path = city_toml_path()
+    try:
+        with open(path, "rb") as handle:
+            payload = tomllib.load(handle)
+    except FileNotFoundError as exc:
+        raise GCAPIError(f"city.toml not found at {path}") from exc
+    except tomllib.TOMLDecodeError as exc:
+        raise GCAPIError(f"invalid city.toml: {exc}") from exc
+    if isinstance(payload, dict):
+        return payload
+    raise GCAPIError("city.toml did not parse to an object")
+
+
+def normalize_gc_api_bind(value: Any) -> str:
+    bind = str(value or "").strip()
+    if bind in {"", "0.0.0.0", "*"}:
+        return "127.0.0.1"
+    if bind in {"::", "[::]", "::1", "[::1]"}:
+        return "[::1]"
+    return bind or "127.0.0.1"
+
+
+_supervisor_scope_cache: dict[str, tuple[float, str]] = {}  # workspace_name → (timestamp, scope)
+_SCOPE_CACHE_TTL = 60.0  # seconds
+
+
+def resolved_workspace_name(city_cfg: dict[str, Any]) -> str:
+    """Resolve the city's runtime workspace name.
+
+    Precedence mirrors gc itself: declared city.toml workspace.name, then the
+    machine-local site binding (.gc/site.toml workspace_name), then the city
+    directory basename. gc init no longer writes workspace.name to city.toml,
+    so deployments commonly only carry the site binding.
+    """
+    workspace_cfg = city_cfg.get("workspace") or {}
+    if isinstance(workspace_cfg, dict):
+        name = str(workspace_cfg.get("name", "")).strip()
+        if name:
+            return name
+    root = city_root()
+    if not root:
+        return ""
+    site_path = os.path.join(root, ".gc", "site.toml")
+    try:
+        with open(site_path, "rb") as handle:
+            site_cfg = tomllib.load(handle)
+    except (OSError, tomllib.TOMLDecodeError):
+        site_cfg = {}
+    if isinstance(site_cfg, dict):
+        name = str(site_cfg.get("workspace_name", "")).strip()
+        if name:
+            return name
+    return pathlib.Path(root).name
+
+
+def discover_supervisor_gc_api_scope(city_cfg: dict[str, Any]) -> str:
+    """Discover the supervisor API scope prefix for the city.
+
+    Caches the result for 60 seconds to avoid hitting the supervisor
+    on every API call.
+    """
+    workspace_name = resolved_workspace_name(city_cfg)
+    cache_key = workspace_name or "__default__"
+    now = time.monotonic()
+    if cache_key in _supervisor_scope_cache:
+        cached_at, cached_scope = _supervisor_scope_cache[cache_key]
+        if now - cached_at < _SCOPE_CACHE_TTL:
+            return cached_scope
+    scope = _discover_supervisor_gc_api_scope_uncached(city_cfg)
+    if scope:  # Only cache successful discovery; retry on next call if empty.
+        _supervisor_scope_cache[cache_key] = (now, scope)
+    return scope
+
+
+def _discover_supervisor_gc_api_scope_uncached(city_cfg: dict[str, Any]) -> str:
+    workspace_name = resolved_workspace_name(city_cfg)
+    request = urllib.request.Request(
+        DEFAULT_SUPERVISOR_API_BASE + "/v0/cities",
+        headers={
+            "Accept": "application/json",
+            "User-Agent": "gas-city-mattermost/0.1",
+            "X-GC-Request": "true",
+        },
+        method="GET",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=1.0) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except (urllib.error.URLError, urllib.error.HTTPError, json.JSONDecodeError):
+        return ""
+    items = payload.get("items")
+    if not isinstance(items, list):
+        return ""
+    if workspace_name:
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            if str(item.get("name", "")).strip() != workspace_name:
+                continue
+            if item.get("running") is False:
+                return ""
+            return f"/v0/city/{urllib.parse.quote(workspace_name)}"
+    return ""
+
+
+def gc_api_base_url() -> str:
+    override = str(os.environ.get("GC_API_BASE_URL", "")).strip()
+    if override:
+        return override.rstrip("/")
+    city_cfg = load_city_toml()
+    if discover_supervisor_gc_api_scope(city_cfg):
+        return DEFAULT_SUPERVISOR_API_BASE
+    api_cfg = city_cfg.get("api") or {}
+    if not isinstance(api_cfg, dict):
+        api_cfg = {}
+    port_value = api_cfg.get("port", DEFAULT_GC_API_PORT)
+    if port_value in (None, ""):
+        port_value = DEFAULT_GC_API_PORT
+    port = int(port_value)
+    if port <= 0:
+        raise GCAPIError("gc api is disabled (api.port = 0)")
+    bind = normalize_gc_api_bind(api_cfg.get("bind", "127.0.0.1"))
+    return f"http://{bind}:{port}"
+
+
+def gc_api_request(
+    method: str,
+    path: str,
+    payload: Any = None,
+    headers: dict[str, str] | None = None,
+    timeout: float = GC_API_REQUEST_TIMEOUT_SECONDS,
+) -> Any:
+    base_url = gc_api_base_url()
+    if path.startswith("http://") or path.startswith("https://"):
+        url = path
+    else:
+        # Skip scope discovery if the caller provided an explicit base URL
+        # (it already includes the scope prefix). Strip /v0/ from path
+        # since the base URL already contains the scoped root.
+        override = str(os.environ.get("GC_API_BASE_URL", "")).strip()
+        if override:
+            normalized_path = "/" + path[len("/v0/"):] if path.startswith("/v0/") else path
+        else:
+            city_cfg = load_city_toml()
+            scope_prefix = discover_supervisor_gc_api_scope(city_cfg)
+            normalized_path = path
+            if scope_prefix and path.startswith("/v0/"):
+                normalized_path = scope_prefix + "/" + path[len("/v0/") :]
+        url = urllib.parse.urljoin(base_url.rstrip("/") + "/", normalized_path.lstrip("/"))
+    body = None
+    request_headers = {
+        "Accept": "application/json",
+        "User-Agent": "gas-city-mattermost/0.1",
+        "X-GC-Request": "true",
+    }
+    if headers:
+        request_headers.update(headers)
+    if payload is not None:
+        body = json.dumps(payload).encode("utf-8")
+        request_headers["Content-Type"] = "application/json"
+    request = urllib.request.Request(url, data=body, headers=request_headers, method=method.upper())
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            raw = response.read()
+    except urllib.error.HTTPError as exc:
+        raw = exc.read()
+        message = raw.decode("utf-8", errors="replace")
+        raise GCAPIError(f"{method.upper()} {url} failed with {exc.code}: {message}") from exc
+    except urllib.error.URLError as exc:
+        raise GCAPIError(f"{method.upper()} {url} failed: {exc}") from exc
+    except TimeoutError as exc:
+        raise GCAPIError(f"{method.upper()} {url} timed out") from exc
+    except OSError as exc:
+        raise GCAPIError(f"{method.upper()} {url} failed: {exc}") from exc
+    if not raw:
+        return {}
+    try:
+        return json.loads(raw.decode("utf-8"))
+    except json.JSONDecodeError as exc:
+        raise GCAPIError(f"{method.upper()} {url} returned invalid JSON") from exc
+
+
+def load_session_transcript_raw(session_selector: str, tail: int = 20) -> list[dict[str, Any]]:
+    selector = str(session_selector).strip()
+    if not selector:
+        raise GCAPIError("session selector is required")
+    payload = gc_api_request(
+        "GET",
+        f"/v0/session/{urllib.parse.quote(selector, safe='')}/transcript?format=raw&tail={max(0, int(tail))}",
+    )
+    messages = payload.get("messages") if isinstance(payload, dict) else None
+    if not isinstance(messages, list):
+        return []
+    return [item for item in messages if isinstance(item, dict)]
+
+
+def current_session_selector() -> str:
+    for key in ("GC_SESSION_ID", "GC_SESSION_NAME", "GC_ALIAS"):
+        value = str(os.environ.get(key, "")).strip()
+        if value:
+            return value
+    return ""
+
+
+def _raw_user_message_text(entry: dict[str, Any]) -> str:
+    if str(entry.get("type", "")).strip() != "user":
+        return ""
+    message = entry.get("message")
+    if not isinstance(message, dict):
+        return ""
+    content = message.get("content")
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+    parts: list[str] = []
+    for item in content:
+        if isinstance(item, str):
+            parts.append(item)
+            continue
+        if not isinstance(item, dict):
+            continue
+        if str(item.get("type", "")).strip() == "text":
+            parts.append(str(item.get("text", "")))
+    return "".join(parts)
+
+
+def _extract_mattermost_event_fields(text: str) -> dict[str, str]:
+    body = str(text)
+    start = body.find(f"<{EVENT_TAG}>")
+    end = body.find(f"</{EVENT_TAG}>")
+    if start < 0 or end < 0 or end <= start:
+        return {}
+    inner = body[start + len(f"<{EVENT_TAG}>") : end]
+    fields: dict[str, str] = {}
+    for raw_line in inner.splitlines():
+        line = raw_line.strip()
+        if not line or ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        fields[key.strip()] = value.strip()
+    return fields
+
+
+def _chat_ingress_target_matches_selector(target: dict[str, Any], selector: str) -> bool:
+    wanted = str(selector).strip()
+    if not wanted:
+        return False
+    candidates = {
+        str(target.get("session_name", "")).strip(),
+        str(target.get("session_id", "")).strip(),
+        str(target.get("session_alias", "")).strip(),
+        str(target.get("id", "")).strip(),
+    }
+    response = target.get("response")
+    if isinstance(response, dict):
+        candidates.update(
+            {
+                str(response.get("id", "")).strip(),
+                str(response.get("session_name", "")).strip(),
+                str(response.get("session_id", "")).strip(),
+                str(response.get("session_alias", "")).strip(),
+            }
+        )
+    return wanted in {candidate for candidate in candidates if candidate}
+
+
+def _chat_ingress_delivered_to_selector(record: dict[str, Any], selector: str) -> bool:
+    targets = record.get("targets")
+    if not isinstance(targets, list):
+        return False
+    for target in targets:
+        if not isinstance(target, dict):
+            continue
+        if str(target.get("status", "")).strip() != "delivered":
+            continue
+        if _chat_ingress_target_matches_selector(target, selector):
+            return True
+    return False
+
+
+def _chat_ingress_reply_context(record: dict[str, Any]) -> dict[str, str]:
+    ingress_id = str(record.get("ingress_id", "")).strip()
+    binding_id = str(record.get("binding_id", "")).strip()
+    conversation_id = str(record.get("conversation_id", "")).strip()
+    post_id = str(record.get("mattermost_post_id", "")).strip()
+    if not (ingress_id and binding_id and conversation_id and post_id):
+        return {}
+    root_post_id = str(record.get("root_post_id", "")).strip() or post_id
+    fields = {
+        "kind": HUMAN_MESSAGE_EVENT_KIND,
+        "binding_id": binding_id,
+        "ingress_receipt_id": ingress_id,
+        "mattermost_post_id": post_id,
+        "publish_binding_id": binding_id,
+        "publish_conversation_id": conversation_id,
+        "publish_trigger_id": post_id,
+        "publish_root_post_id": root_post_id,
+    }
+    for key in ("team_id", "delivery", "route_kind", "launch_id", "qualified_handle", "routing_mode"):
+        value = str(record.get(key, "")).strip()
+        if value:
+            fields[key] = value
+    if fields.get("launch_id"):
+        fields["publish_launch_id"] = fields["launch_id"]
+    return fields
+
+
+def find_latest_delivered_chat_ingress_reply_context(session_selector: str, limit: int = 40) -> dict[str, str]:
+    selector = str(session_selector).strip()
+    if not selector:
+        return {}
+    for record in list_recent_chat_ingress(limit=max(1, int(limit))):
+        if str(record.get("status", "")).strip() not in {"delivered", "partial_failed"}:
+            continue
+        if not _chat_ingress_delivered_to_selector(record, selector):
+            continue
+        fields = _chat_ingress_reply_context(record)
+        if fields.get("publish_binding_id"):
+            return fields
+    return {}
+
+
+def find_latest_mattermost_reply_context(session_selector: str = "", tail: int = 40) -> dict[str, str]:
+    selector = str(session_selector).strip() or current_session_selector()
+    if not selector:
+        raise GCAPIError("GC_SESSION_ID or GC_SESSION_NAME is required")
+    try:
+        transcript_entries = load_session_transcript_raw(selector, tail=tail)
+    except GCAPIError as exc:
+        fields = find_latest_delivered_chat_ingress_reply_context(selector, limit=tail)
+        if fields:
+            return fields
+        raise exc
+    for entry in reversed(transcript_entries):
+        fields = _extract_mattermost_event_fields(_raw_user_message_text(entry))
+        if fields.get("publish_binding_id"):
+            return fields
+    fields = find_latest_delivered_chat_ingress_reply_context(selector, limit=tail)
+    if fields:
+        return fields
+    raise GCAPIError(f"no recent mattermost event with publish metadata found for {selector}")
+
+
+def parse_websocket_post(event_data: dict[str, Any]) -> dict[str, Any]:
+    # Mattermost sends data.post as a JSON-encoded string, not an object.
+    raw = (event_data or {}).get("post")
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, str) and raw.strip():
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError:
+            return {}
+        if isinstance(parsed, dict):
+            return parsed
+    return {}
+
+
+def post_is_from_bot(post: dict[str, Any], bot_user_id: str = "") -> bool:
+    if str(post.get("user_id", "")).strip() and str(post.get("user_id", "")).strip() == str(bot_user_id).strip():
+        return True
+    props = post.get("props")
+    if isinstance(props, dict) and str(props.get("from_bot", "")).strip().lower() == "true":
+        return True
+    return False
+
+
+def post_is_system(post: dict[str, Any]) -> bool:
+    return str(post.get("type", "")).strip().startswith("system_")
+
+
+def post_thread_root_id(post: dict[str, Any]) -> str:
+    root_id = str(post.get("root_id", "")).strip()
+    return root_id or str(post.get("id", "")).strip()
+
+
+def normalize_to_extmsg_message(
+    mattermost_event: dict[str, Any],
+    team_id: str,
+    bot_user_id: str,
+    participants: list[dict[str, str]] | None = None,
+) -> dict[str, Any]:
+    """Normalize a Mattermost `posted` websocket event to an extmsg ExternalInboundMessage."""
+    raw_data = mattermost_event.get("data")
+    data: dict[str, Any] = raw_data if isinstance(raw_data, dict) else mattermost_event
+    post = parse_websocket_post(data) or (mattermost_event if "message" in mattermost_event else {})
+    raw_broadcast = mattermost_event.get("broadcast")
+    broadcast: dict[str, Any] = raw_broadcast if isinstance(raw_broadcast, dict) else {}
+    channel_id = str(post.get("channel_id", "") or broadcast.get("channel_id", "")).strip()
+    root_id = str(post.get("root_id", "")).strip()
+    content = str(post.get("message", ""))
+    channel_type = str(data.get("channel_type", "")).strip().upper()
+    sender_name = str(data.get("sender_name", "")).strip().lstrip("@")
+
+    if channel_type in DIRECT_CHANNEL_TYPES:
+        kind = "dm"
+    elif root_id:
+        kind = "thread"
+    else:
+        kind = "room"
+
+    explicit_target = ""
+    if participants:
+        explicit_target = _fuzzy_match_handle(content, participants)
+
+    resolved_team_id = str(team_id or data.get("team_id", "") or broadcast.get("team_id", "")).strip()
+
+    return {
+        "provider_message_id": str(post.get("id", "")),
+        "conversation": {
+            "scope_id": resolved_team_id or "global",
+            "provider": "mattermost",
+            "account_id": str(bot_user_id or "").strip(),
+            "conversation_id": channel_id,
+            "parent_conversation_id": "",
+            "thread_root_id": root_id,
+            "conversation_key": mattermost_conversation_key(channel_id, root_id),
+            "kind": kind,
+        },
+        "actor": {
+            "id": str(post.get("user_id", "")),
+            "display_name": sender_name,
+            "is_bot": post_is_from_bot(post, bot_user_id),
+        },
+        "text": content,
+        "explicit_target": explicit_target,
+        "reply_to_message_id": root_id,
+        "received_at": utcnow(),
+    }
+
+
+def _fuzzy_match_handle(
+    text: str,
+    participants: list[dict[str, str]],
+) -> str:
+    """Match participant handles in natural language text.
+
+    Looks for participant names/handles mentioned naturally in the message
+    (e.g., "hey worker, can you fix this?" matches handle "worker").
+    Returns the first matching handle, or empty string if none found.
+    """
+    lower_text = text.lower()
+    for p in participants:
+        handle = str(p.get("handle", "")).strip().lower()
+        if not handle:
+            continue
+        short = handle.rsplit("/", 1)[-1] if "/" in handle else handle
+        for name in (short, handle):
+            if not name:
+                continue
+            idx = lower_text.find(name)
+            if idx < 0:
+                continue
+            before_ok = idx == 0 or not lower_text[idx - 1].isalnum()
+            after_idx = idx + len(name)
+            after_ok = after_idx >= len(lower_text) or not lower_text[after_idx].isalnum()
+            if before_ok and after_ok:
+                return handle
+    return ""
+
+
+def deliver_to_extmsg(
+    message: dict[str, Any],
+    bot_user_id: str,
+) -> dict[str, Any]:
+    """Post a normalized message to the extmsg inbound API."""
+    return gc_api_request("POST", "/v0/extmsg/inbound", {"message": message})
+
+
+def resolve_at_mentions(text: str) -> list[str]:
+    """Extract @mentions from message text.
+
+    Mattermost renders mentions as bare `@username` in the message body, so
+    the raw text is the only source.
+    """
+    return [
+        mention
+        for mention in re.findall(r"@([a-zA-Z][a-zA-Z0-9_./-]*)", text)
+        if mention.lower() not in MATTERMOST_RESERVED_MENTIONS
+    ]
+
+
+def resolve_nl_agent_mentions(text: str) -> list[str]:
+    """Find agent names mentioned naturally in text (without @ prefix)."""
+    lower_text = text.lower()
+    agents = list_city_agents()
+    found: list[str] = []
+    seen: set[str] = set()
+    for a in agents:
+        qname = str(a.get("name", "")).strip().lower()
+        if not qname:
+            continue
+        base = qname.rsplit("/", 1)[-1] if "/" in qname else qname
+        if base in seen or not base:
+            continue
+        idx = lower_text.find(base)
+        if idx < 0:
+            continue
+        before_ok = idx == 0 or not lower_text[idx - 1].isalnum()
+        after_idx = idx + len(base)
+        after_ok = after_idx >= len(lower_text) or not lower_text[after_idx].isalnum()
+        if before_ok and after_ok:
+            found.append(base)
+            seen.add(base)
+    return found
+
+
+def resolve_mention_targets(mentions: list[str]) -> list[dict[str, Any]]:
+    """Resolve @mention names to session/template targets.
+
+    Resolution order for each mention:
+    1. Agent template with matching name → {"kind": "template", "template": str, "agent": {...}}
+    2. Managed session with matching alias/name → {"kind": "session", "session": {...}}
+    3. Unresolved → skipped
+    """
+    if not mentions:
+        return []
+    sessions = list_city_sessions(state="all")
+    agents = list_city_agents()
+
+    session_by_alias: dict[str, dict[str, Any]] = {}
+    for s in sessions:
+        alias = str(s.get("alias", "")).strip().lower()
+        if alias:
+            session_by_alias[alias] = s
+        name = str(s.get("session_name", s.get("name", ""))).strip().lower()
+        if name:
+            session_by_alias[name] = s
+
+    agent_by_name: dict[str, dict[str, Any]] = {}
+    for a in agents:
+        qname = str(a.get("name", "")).strip().lower()
+        if qname:
+            agent_by_name[qname] = a
+            base = qname.rsplit("/", 1)[-1] if "/" in qname else qname
+            if base not in agent_by_name:
+                agent_by_name[base] = a
+        template = str(a.get("template", "")).strip().lower()
+        if template and template not in agent_by_name:
+            agent_by_name[template] = a
+
+    targets = []
+    seen: set[str] = set()
+    for mention in mentions:
+        key = mention.strip().lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        if key in agent_by_name:
+            agent = agent_by_name[key]
+            targets.append({"kind": "template", "template": str(agent.get("name", "")), "agent": agent, "mention": mention})
+            continue
+        if key in session_by_alias:
+            targets.append({"kind": "session", "session": session_by_alias[key], "mention": mention})
+            continue
+    return targets
+
+
+def _create_session_from_template(template_name: str, alias: str, initial_message: str = "") -> str:
+    """Create a session from an agent template via the sessions API."""
+    payload: dict[str, Any] = {
+        "template": template_name,
+        "name": template_name,
+        "kind": "agent",
+        "options": {
+            "permission_mode": "unrestricted",
+            "effort": "max",
+        },
+    }
+    if initial_message:
+        payload["message"] = initial_message
+    else:
+        payload["async"] = True
+    session = gc_api_request("POST", "/v0/sessions", payload, timeout=60.0)
+    session_name = str(session.get("session_name", "") or session.get("name", "")).strip()
+    if not session_name:
+        raise RuntimeError(f"session creation returned no session_name for {template_name}")
+    return session_name
+
+
+def _build_mattermost_prompt_fragment(handle: str) -> str:
+    """Build the Mattermost conversation prompt fragment for an agent."""
+    return f"""<system-context>
+You are in a shared Mattermost thread with humans and other agents.
+Your agent handle is "{handle}". When someone mentions "{handle}" (or @{handle}),
+they are likely addressing you.
+
+## How this thread works
+
+A Mattermost thread is not a separate channel — it is a set of posts in the
+same channel that share a root post id. Everyone in this thread sees every
+message, humans and agents alike. When you reply, your message is visible to
+all participants.
+
+## When to respond
+
+- **You are named directly** ("{handle}, fix the tests" or "@{handle}"): You
+  should definitely respond. This is a strong signal the message is for you.
+- **@{handle} in thread**: This is the strongest signal — the human expects a
+  response from you specifically.
+- **Multiple agents named** ("{handle}, priya, work together"): All named agents
+  should respond.
+- **No one is named, but you have relevant info**: Respond if you can genuinely
+  add value. If someone else already handled it, stay silent. Silence is fine.
+- **A peer agent says something relevant to your work**: You may respond, but
+  do not pile on.
+- **A peer says something not relevant to you**: Read for context, move on.
+
+The key test: **does this message need MY input?** If yes, respond. If maybe,
+use judgment. If no, listen.
+
+## Replying to Mattermost
+
+Normal assistant output stays private to the session. Do not assume a human on
+Mattermost can see it.
+
+If the event includes `reply_contract: explicit_publish_required`, follow that
+contract literally: plain assistant output does not go back to Mattermost.
+
+To send a human-visible reply, write the body to a file and run the command
+shown in the `reply_tool` field of the mattermost-event. Example:
+  gc mattermost reply-current --conversation-id <channel_id> --root-id <post_id> --body-file <path>
+
+**Always prefix your Mattermost messages with your handle in bold** so humans
+and other agents know who is speaking. Example: if your handle is "sky", start
+every reply with "**sky:** " followed by your message. Other agents should use
+@sky to address you directly.
+
+Do not put long replies inline in --body. Use --body-file.
+Only claim success after the command returns JSON with a non-empty
+record.remote_message_id.
+
+## Addressing others
+
+When addressing a specific peer agent, use @name for clarity (e.g., "@priya can
+you look at the test failures?"). This helps the routing layer.
+
+When you need a response from a human, mention them by their Mattermost
+username: `@` followed by the `from_username` value in the mattermost-event.
+Mattermost mentions are plain text — there is no id-wrapping syntax. Do not
+assume humans are watching the thread.
+</system-context>"""
+
+
+def _build_thread_launch_envelope(
+    *,
+    mattermost_post: dict[str, Any],
+    root_id: str,
+    channel_id: str,
+    team_id: str,
+    handle: str,
+    content: str,
+) -> str:
+    """Build a mattermost-event envelope with prompt fragment for a thread-launch message."""
+    post_id = str(mattermost_post.get("id", ""))
+    from_username = str(mattermost_post.get("from_username", "")).strip()
+    from_user_id = str(mattermost_post.get("user_id", "")).strip()
+    prompt = _build_mattermost_prompt_fragment(handle)
+    lines = [
+        prompt,
+        "",
+        f"<{EVENT_TAG}>",
+        "version: 1",
+        f"kind: {HUMAN_MESSAGE_EVENT_KIND}",
+        f"team_id: {team_id}",
+        f"conversation: mattermost/{team_id}/{channel_id}",
+        f"conversation_key: {mattermost_conversation_key(channel_id, root_id)}",
+        f"channel_id: {channel_id}",
+        f"root_id: {root_id}",
+        f"mattermost_post_id: {post_id}",
+        f"from_display: {from_username}",
+        f"from_username: {from_username}",
+        f"from_user_id: {from_user_id}",
+        "delivery: targeted",
+        f"target_handle: {handle}",
+        f"untrusted_body_json: {json.dumps(content)}",
+        f"publish_binding_id: extmsg:thread:{mattermost_conversation_key(channel_id, root_id)}",
+        f"publish_conversation_id: {channel_id}",
+        f"publish_trigger_id: {post_id}",
+        f"publish_root_post_id: {root_id}",
+        "normal_output_visibility: internal_only",
+        "reply_contract: explicit_publish_required",
+        f"reply_tool: gc mattermost reply-current --conversation-id {channel_id} --root-id {root_id} --body-file <path>",
+        "reply_success_signal: record.remote_message_id",
+        "reply_turn_requirement: if you intend to answer, do not end the turn without a successful reply-current",
+        f"</{EVENT_TAG}>",
+    ]
+    return "\n".join(lines)
+
+
+def launch_thread_for_mentions(
+    mattermost_post: dict[str, Any],
+    targets: list[dict[str, Any]],
+    team_id: str,
+    bot_user_id: str,
+) -> dict[str, Any] | None:
+    """Set up an extmsg group for a Mattermost thread rooted at the mentioning post.
+
+    Mattermost threads need no server-side creation: the thread exists as soon
+    as something replies with root_id set, so the root post id is the thread
+    identity and there is nothing to POST here.
+    """
+    channel_id = str(mattermost_post.get("channel_id", ""))
+    post_id = str(mattermost_post.get("id", ""))
+    content = str(mattermost_post.get("message", ""))
+    if not channel_id or not post_id or not targets:
+        return None
+
+    root_id = post_thread_root_id(mattermost_post)
+
+    thread_conversation = {
+        "scope_id": team_id or "global",
+        "provider": "mattermost",
+        "account_id": str(bot_user_id or "").strip(),
+        "conversation_id": channel_id,
+        "parent_conversation_id": "",
+        "thread_root_id": root_id,
+        "conversation_key": mattermost_conversation_key(channel_id, root_id),
+        "kind": "thread",
+    }
+
+    first_handle = ""
+    for t in targets:
+        if t["kind"] == "session":
+            first_handle = str(t["session"].get("alias", "") or t["session"].get("name", ""))
+            break
+        if t["kind"] == "template":
+            first_handle = str(t["agent"].get("name", "")).rsplit("/", 1)[-1]
+            break
+
+    print(f"[extmsg] thread root {root_id} in {channel_id}, creating group...", flush=True)
+    try:
+        group = gc_api_request("POST", "/v0/extmsg/groups", {
+            "root_conversation": thread_conversation,
+            "mode": "launcher",
+            "default_handle": first_handle,
+            "metadata": {"team_id": team_id, "source_channel_id": channel_id, "source_message_id": post_id},
+        })
+    except GCAPIError as exc:
+        print(f"[extmsg] group creation failed: {exc}", flush=True)
+        return None
+
+    group_id = str(group.get("id", ""))
+
+    def _create_participant(target: dict[str, Any]) -> tuple[str, str] | None:
+        if target["kind"] == "session":
+            sid = str(target["session"].get("name", ""))
+            handle = str(target["session"].get("alias", "") or sid)
+            return (sid, handle) if sid else None
+        if target["kind"] == "template":
+            template_name = str(target["template"])
+            handle = template_name.rsplit("/", 1)[-1] if "/" in template_name else template_name
+            envelope = _build_thread_launch_envelope(
+                mattermost_post=mattermost_post,
+                root_id=root_id,
+                channel_id=channel_id,
+                team_id=team_id,
+                handle=handle,
+                content=content,
+            )
+            try:
+                sid = _create_session_from_template(template_name, handle, initial_message=envelope)
+                print(f"[extmsg] session {sid} created from {template_name}", flush=True)
+                return (sid, handle)
+            except (GCAPIError, RuntimeError) as exc:
+                print(f"[extmsg] session creation failed for {template_name}: {exc}", flush=True)
+                return None
+        return None
+
+    # Create sessions sequentially to avoid parallel prompt resolution races.
+    participants: list[tuple[str, str]] = []
+    for t in targets:
+        result = _create_participant(t)
+        if result:
+            participants.append(result)
+
+    for session_id, handle in participants:
+        try:
+            gc_api_request("POST", "/v0/extmsg/groups/participants", {
+                "group_id": group_id,
+                "handle": handle,
+                "session_id": session_id,
+                "public": True,
+            })
+        except GCAPIError:
+            pass
+        try:
+            gc_api_request("POST", "/v0/extmsg/bindings", {
+                "conversation": thread_conversation,
+                "session_id": session_id,
+            })
+        except GCAPIError:
+            pass
+        try:
+            gc_api_request("POST", "/v0/extmsg/transcript/membership", {
+                "conversation": thread_conversation,
+                "session_id": session_id,
+            })
+        except GCAPIError:
+            pass
+
+    return group
+
+
+def add_participants_to_thread(
+    root_id: str,
+    channel_id: str,
+    targets: list[dict[str, Any]],
+    team_id: str,
+    bot_user_id: str,
+    content: str = "",
+) -> None:
+    """Add new agent participants to an existing (channel_id, root_id) thread."""
+    conversation_key = mattermost_conversation_key(channel_id, root_id)
+    thread_conversation = {
+        "scope_id": team_id or "global",
+        "provider": "mattermost",
+        "account_id": str(bot_user_id or "").strip(),
+        "conversation_id": channel_id,
+        "parent_conversation_id": "",
+        "thread_root_id": root_id,
+        "conversation_key": conversation_key,
+        "kind": "thread",
+    }
+
+    query = urllib.parse.urlencode(
+        {
+            "scope_id": team_id,
+            "provider": "mattermost",
+            "account_id": bot_user_id,
+            "conversation_id": channel_id,
+            "thread_root_id": root_id,
+            "kind": "thread",
+        }
+    )
+    try:
+        group = gc_api_request("GET", f"/v0/extmsg/groups?{query}")
+        group_id = str(group.get("id", ""))
+    except GCAPIError:
+        try:
+            group = gc_api_request("POST", "/v0/extmsg/groups", {
+                "root_conversation": thread_conversation,
+                "mode": "launcher",
+                "default_handle": "",
+            })
+            group_id = str(group.get("id", ""))
+        except GCAPIError as exc:
+            print(f"[extmsg] group creation failed for thread {conversation_key}: {exc}", flush=True)
+            return
+
+    existing_sessions: set[str] = set()
+    try:
+        sessions = list_city_sessions(state="all")
+        for s in sessions:
+            sid = str(s.get("session_name", s.get("name", "")))
+            try:
+                bindings = gc_api_request("GET", f"/v0/extmsg/bindings?session_id={sid}")
+                for b in (bindings.get("items") or []):
+                    conversation = b.get("conversation", {})
+                    if str(conversation.get("conversation_id", "")) != channel_id:
+                        continue
+                    bound_root = str(conversation.get("thread_root_id", "")).strip()
+                    if bound_root and bound_root != root_id:
+                        continue
+                    existing_sessions.add(str(s.get("template", "")))
+                    break
+            except GCAPIError:
+                pass
+    except GCAPIError:
+        pass
+
+    for target in targets:
+        session_id = ""
+        handle = ""
+        if target["kind"] == "session":
+            session_id = str(target["session"].get("session_name", target["session"].get("name", "")))
+            handle = str(target["session"].get("alias", "") or session_id)
+        elif target["kind"] == "template":
+            template_name = str(target["template"])
+            handle = template_name.rsplit("/", 1)[-1] if "/" in template_name else template_name
+            if template_name in existing_sessions:
+                print(f"[extmsg] {handle} already in thread {conversation_key}, skipping", flush=True)
+                continue
+            envelope = _build_thread_launch_envelope(
+                mattermost_post={"id": "", "message": content, "channel_id": channel_id},
+                root_id=root_id,
+                channel_id=channel_id,
+                team_id=team_id,
+                handle=handle,
+                content=content,
+            )
+            try:
+                session_id = _create_session_from_template(
+                    template_name, handle, initial_message=envelope,
+                )
+                print(f"[extmsg] added {handle} to thread {conversation_key} as {session_id}", flush=True)
+            except (GCAPIError, RuntimeError) as exc:
+                print(f"[extmsg] failed to add {handle}: {exc}", flush=True)
+                continue
+
+        if not session_id or not handle:
+            continue
+
+        try:
+            gc_api_request("POST", "/v0/extmsg/groups/participants", {
+                "group_id": group_id,
+                "handle": handle,
+                "session_id": session_id,
+                "public": True,
+            })
+        except GCAPIError:
+            pass
+
+        try:
+            gc_api_request("POST", "/v0/extmsg/bindings", {
+                "conversation": thread_conversation,
+                "session_id": session_id,
+            })
+        except GCAPIError:
+            pass
+
+        try:
+            gc_api_request("POST", "/v0/extmsg/transcript/membership", {
+                "conversation": thread_conversation,
+                "session_id": session_id,
+            })
+        except GCAPIError:
+            pass
+
+
+def list_city_sessions(state: str = "all") -> list[dict[str, Any]]:
+    suffix = ""
+    normalized_state = str(state).strip()
+    if normalized_state:
+        suffix = "?state=" + urllib.parse.quote(normalized_state)
+    payload = gc_api_request("GET", "/v0/sessions" + suffix)
+    items = payload.get("items") if isinstance(payload, dict) else None
+    if not isinstance(items, list):
+        return []
+    return [item for item in items if isinstance(item, dict)]
+
+
+def list_city_agents() -> list[dict[str, Any]]:
+    config_payload = gc_api_request("GET", "/v0/config")
+    if isinstance(config_payload, dict):
+        agents = config_payload.get("agents")
+        if isinstance(agents, list) and agents:
+            return [item for item in agents if isinstance(item, dict)]
+    payload = gc_api_request("GET", "/v0/agents")
+    items = payload.get("items") if isinstance(payload, dict) else None
+    if not isinstance(items, list):
+        return []
+    return [item for item in items if isinstance(item, dict)]
+
+
+def _agent_base_handle(qualified_handle: str) -> str:
+    normalized = str(qualified_handle).strip().lower()
+    if not normalized:
+        return ""
+    return normalized.rsplit("/", 1)[-1]
+
+
+def _normalize_agent_handle(handle: str) -> str:
+    normalized = str(handle).strip().lower()
+    if not normalized:
+        return ""
+    parts = normalized.split("/")
+    if len(parts) > 2:
+        return ""
+    if any(not AGENT_HANDLE_SEGMENT.fullmatch(part) for part in parts):
+        return ""
+    return normalized
+
+
+def resolve_agent_handle(handle: str) -> tuple[str, str]:
+    normalized = _normalize_agent_handle(handle)
+    if not normalized:
+        return "", "malformed_handle"
+    qualified_lookup: dict[str, dict[str, Any]] = {}
+    bare_lookup: dict[str, list[str]] = {}
+    for item in list_city_agents():
+        qualified_name = _normalize_agent_handle(item.get("name", ""))
+        if not qualified_name:
+            continue
+        qualified_lookup[qualified_name] = item
+        base_handle = _agent_base_handle(qualified_name)
+        bare_lookup.setdefault(base_handle, []).append(qualified_name)
+    if "/" in normalized:
+        if normalized in qualified_lookup:
+            return normalized, ""
+        return "", "unknown_handle"
+    matches = bare_lookup.get(normalized, [])
+    if len(matches) == 1:
+        return matches[0], ""
+    if len(matches) > 1:
+        return "", "ambiguous_handle"
+    return "", "unknown_handle"
+
+
+def service_socket_is_active(socket_path: str, timeout: float = SERVICE_SOCKET_PROBE_TIMEOUT_SECONDS) -> bool:
+    path = str(socket_path).strip()
+    if not path or not os.path.exists(path):
+        return False
+    probe = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    probe.settimeout(timeout)
+    try:
+        probe.connect(path)
+    except OSError:
+        return False
+    finally:
+        probe.close()
+    return True
+
+
+def prepare_service_socket(socket_path: str) -> None:
+    path = str(socket_path).strip()
+    if not path:
+        raise RuntimeError("GC_SERVICE_SOCKET is required")
+    if service_socket_is_active(path):
+        raise RuntimeError(f"refusing to replace active service socket: {path}")
+    try:
+        os.remove(path)
+    except FileNotFoundError:
+        pass
+
+
+def session_index_by_name(state: str = "all") -> dict[str, dict[str, Any]]:
+    index: dict[str, dict[str, Any]] = {}
+    for item in list_city_sessions(state=state):
+        session_name = str(item.get("session_name", "")).strip()
+        if session_name:
+            existing = index.get(session_name)
+            if existing is None or _session_record_preference(item) > _session_record_preference(existing):
+                index[session_name] = item
+    return index
+
+
+def session_index_by_alias(state: str = "all") -> dict[str, dict[str, Any]]:
+    index: dict[str, dict[str, Any]] = {}
+    for item in list_city_sessions(state=state):
+        alias = str(item.get("alias", "")).strip()
+        if alias:
+            existing = index.get(alias)
+            if existing is None or _session_record_preference(item) > _session_record_preference(existing):
+                index[alias] = item
+    return index
+
+
+def resolve_session_identity(session_selector: str) -> dict[str, str]:
+    selector = str(session_selector).strip()
+    if not selector:
+        return {}
+    session_by_alias = session_index_by_alias(state="all").get(selector)
+    if session_by_alias:
+        return {
+            "session_name": str(session_by_alias.get("session_name", "")).strip(),
+            "session_id": str(session_by_alias.get("id", "")).strip(),
+            "alias": str(session_by_alias.get("alias", "")).strip(),
+        }
+    session_by_name = session_index_by_name(state="all").get(selector)
+    if session_by_name:
+        return {
+            "session_name": str(session_by_name.get("session_name", "")).strip(),
+            "session_id": str(session_by_name.get("id", "")).strip(),
+            "alias": str(session_by_name.get("alias", "")).strip(),
+        }
+    for item in list_city_sessions(state="all"):
+        session_id = str(item.get("id", "")).strip()
+        if session_id != selector:
+            continue
+        return {
+            "session_name": str(item.get("session_name", "")).strip(),
+            "session_id": session_id,
+            "alias": str(item.get("alias", "")).strip(),
+        }
+    raise GCAPIError(f"session not found: {selector}")
+
+
+def resolve_routable_session_identity(session_selector: str) -> dict[str, str]:
+    return resolve_routable_session_identity_from_sessions(list_city_sessions(state="all"), session_selector)
+
+
+def _session_identity_fields(item: dict[str, Any]) -> dict[str, str]:
+    return {
+        "session_name": str(item.get("session_name", "")).strip(),
+        "session_id": str(item.get("id", "")).strip(),
+        "alias": str(item.get("alias", "")).strip(),
+    }
+
+
+def resolve_routable_session_identity_from_sessions(sessions: list[dict[str, Any]], session_selector: str) -> dict[str, str]:
+    selector = str(session_selector).strip()
+    if not selector:
+        return {}
+    alias_match: dict[str, Any] | None = None
+    name_match: dict[str, Any] | None = None
+    id_match: dict[str, Any] | None = None
+    for item in sessions:
+        if not session_record_routable(item):
+            continue
+        if str(item.get("alias", "")).strip() == selector and (
+            alias_match is None or _session_record_preference(item) > _session_record_preference(alias_match)
+        ):
+            alias_match = item
+        if str(item.get("session_name", "")).strip() == selector and (
+            name_match is None or _session_record_preference(item) > _session_record_preference(name_match)
+        ):
+            name_match = item
+        if str(item.get("id", "")).strip() == selector and (
+            id_match is None or _session_record_preference(item) > _session_record_preference(id_match)
+        ):
+            id_match = item
+    chosen = alias_match or name_match or id_match
+    if not chosen:
+        return {}
+    return _session_identity_fields(chosen)
+
+
+def resolve_routable_session_candidate_from_sessions(
+    sessions: list[dict[str, Any]], *selectors: str
+) -> tuple[str, dict[str, str]]:
+    seen: set[str] = set()
+    for selector in selectors:
+        normalized = str(selector).strip()
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        identity = resolve_routable_session_identity_from_sessions(sessions, normalized)
+        if identity:
+            return normalized, identity
+    return "", {}
+
+
+def resolve_routable_session_identity_eventually(*selectors: str) -> dict[str, str]:
+    _matched_selector, identity = resolve_routable_session_candidate_eventually(*selectors)
+    return identity
+
+
+def resolve_routable_session_candidate_eventually(*selectors: str) -> tuple[str, dict[str, str]]:
+    candidates: list[str] = []
+    seen: set[str] = set()
+    for selector in selectors:
+        normalized = str(selector).strip()
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        candidates.append(normalized)
+    if not candidates:
+        return "", {}
+    deadline = time.monotonic() + ROOM_LAUNCH_IDENTITY_RESOLVE_TIMEOUT_SECONDS
+    while True:
+        sessions = list_city_sessions(state="all")
+        matched_selector, identity = resolve_routable_session_candidate_from_sessions(sessions, *candidates)
+        if identity:
+            return matched_selector, identity
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return "", {}
+        time.sleep(min(ROOM_LAUNCH_IDENTITY_RESOLVE_DELAY_SECONDS, remaining))
+
+
+def session_record_ready(item: dict[str, Any] | None) -> bool:
+    if not session_record_routable(item):
+        return False
+    if str(item.get("state", "")).strip() != "active":
+        return False
+    return bool(item.get("running"))
+
+
+def resolve_ready_session_identity_from_sessions(sessions: list[dict[str, Any]], session_selector: str) -> dict[str, str]:
+    selector = str(session_selector).strip()
+    if not selector:
+        return {}
+    alias_match: dict[str, Any] | None = None
+    name_match: dict[str, Any] | None = None
+    id_match: dict[str, Any] | None = None
+    for item in sessions:
+        if not session_record_ready(item):
+            continue
+        if str(item.get("alias", "")).strip() == selector and (
+            alias_match is None or _session_record_preference(item) > _session_record_preference(alias_match)
+        ):
+            alias_match = item
+        if str(item.get("session_name", "")).strip() == selector and (
+            name_match is None or _session_record_preference(item) > _session_record_preference(name_match)
+        ):
+            name_match = item
+        if str(item.get("id", "")).strip() == selector and (
+            id_match is None or _session_record_preference(item) > _session_record_preference(id_match)
+        ):
+            id_match = item
+    chosen = alias_match or name_match or id_match
+    if not chosen:
+        return {}
+    return _session_identity_fields(chosen)
+
+
+def resolve_ready_session_candidate_from_sessions(
+    sessions: list[dict[str, Any]], *selectors: str
+) -> tuple[str, dict[str, str]]:
+    seen: set[str] = set()
+    for selector in selectors:
+        normalized = str(selector).strip()
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        identity = resolve_ready_session_identity_from_sessions(sessions, normalized)
+        if identity:
+            return normalized, identity
+    return "", {}
+
+
+def resolve_ready_session_candidate_eventually(*selectors: str) -> tuple[str, dict[str, str]]:
+    candidates: list[str] = []
+    seen: set[str] = set()
+    for selector in selectors:
+        normalized = str(selector).strip()
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        candidates.append(normalized)
+    if not candidates:
+        return "", {}
+    deadline = time.monotonic() + ROOM_LAUNCH_READY_RESOLVE_TIMEOUT_SECONDS
+    while True:
+        sessions = list_city_sessions(state="all")
+        matched_selector, identity = resolve_ready_session_candidate_from_sessions(sessions, *candidates)
+        if identity:
+            return matched_selector, identity
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return "", {}
+        time.sleep(min(ROOM_LAUNCH_READY_RESOLVE_DELAY_SECONDS, remaining))
+
+
+def resolve_routable_session_record(session_selector: str) -> dict[str, Any] | None:
+    selector = str(session_selector).strip()
+    if not selector:
+        return None
+    by_name = session_index_by_name(state="all").get(selector)
+    if session_record_routable(by_name):
+        return by_name
+    by_alias = session_index_by_alias(state="all").get(selector)
+    if session_record_routable(by_alias):
+        return by_alias
+    for item in list_city_sessions(state="all"):
+        if str(item.get("id", "")).strip() == selector and session_record_routable(item):
+            return item
+    return None
+
+
+def _session_record_preference(item: dict[str, Any]) -> tuple[int, int, int, str]:
+    state = str(item.get("state", "")).strip()
+    return (
+        0 if state in NON_ROUTABLE_SESSION_STATES else 1,
+        1 if item.get("running") is True else 0,
+        1 if item.get("attached") is True else 0,
+        str(item.get("created_at", "")).strip(),
+    )
+
+
+def session_record_routable(item: dict[str, Any] | None) -> bool:
+    if not isinstance(item, dict):
+        return False
+    return str(item.get("state", "")).strip() not in NON_ROUTABLE_SESSION_STATES
+
+
+def _room_launch_alias_slug(qualified_handle: str) -> str:
+    normalized = str(qualified_handle).strip().lower().replace("/", "-")
+    filtered = "".join(ch for ch in normalized if ch.isalnum() or ch in {"-", "_"})
+    filtered = filtered.strip("-_")
+    if not filtered:
+        filtered = "agent"
+    return filtered[:ROOM_LAUNCH_ALIAS_SLUG_MAX]
+
+
+def room_launch_session_alias(team_id: str, conversation_id: str, root_post_id: str, qualified_handle: str) -> str:
+    digest_input = f"{str(team_id).strip()}:{str(conversation_id).strip()}:{str(root_post_id).strip()}:{str(qualified_handle).strip().lower()}"
+    digest = hashlib.sha256(digest_input.encode("utf-8")).hexdigest()[:12]
+    slug = _room_launch_alias_slug(qualified_handle)
+    alias = f"mm-{digest}-{slug}" if slug else f"mm-{digest}"
+    return alias[:63].rstrip("-_")
+
+
+def room_launch_thread_name(qualified_handle: str, source_display: str = "") -> str:
+    handle_label = str(qualified_handle).strip().rsplit("/", 1)[-1] or "agent"
+    display = " ".join(str(source_display).strip().split())
+    if display:
+        value = f"{handle_label} - {display}"
+    else:
+        value = handle_label
+    return value[:100].strip() or handle_label
+
+
+def create_agent_session(
+    qualified_handle: str,
+    *,
+    alias: str,
+    title: str,
+    initial_message: str = "",
+    idempotency_key: str = "",
+) -> dict[str, Any]:
+    if str(initial_message).strip():
+        raise ValueError("initial_message is not supported for async launcher session creation")
+    headers: dict[str, str] = {}
+    if idempotency_key:
+        headers["Idempotency-Key"] = idempotency_key
+    payload = gc_api_request(
+        "POST",
+        "/v0/sessions",
+        payload={
+            "kind": "agent",
+            "name": str(qualified_handle).strip(),
+            "alias": str(alias).strip(),
+            "title": str(title).strip(),
+            "async": True,
+        },
+        headers=headers,
+    )
+    if not isinstance(payload, dict):
+        return {}
+    return payload
+
+
+def room_launch_participant_delivery_selector(participant: dict[str, Any]) -> str:
+    for key in ("session_name", "session_id", "session_alias", "delivery_selector"):
+        value = str((participant or {}).get(key, "")).strip()
+        if value:
+            return value
+    return ""
+
+
+def room_launch_primer_message(
+    launch: dict[str, Any],
+    participant: dict[str, Any],
+    *,
+    extra_message: str = "",
+    peer_fanout_enabled: bool = True,
+) -> str:
+    qualified_handle = str(participant.get("qualified_handle", "")).strip() or str(launch.get("qualified_handle", "")).strip()
+    session_name = str(participant.get("session_name", "")).strip()
+    lines = [
+        "<mattermost-launch-primer>",
+        "This is transport guidance for a Mattermost launcher-backed session.",
+        "Do not answer this primer directly.",
+        f"Your routed handle for this conversation is: {qualified_handle}",
+    ]
+    if session_name:
+        lines.append(f"Your current session_name is: {session_name}")
+    lines.extend(
+        [
+            "Normal assistant text is private and invisible to Mattermost humans.",
+            "If you want a human-visible reply, you MUST:",
+            "1. Write the reply body to a file.",
+            "2. Run `gc mattermost reply-current --body-file <path>`.",
+            "3. Only treat the Mattermost reply as sent after the command returns JSON with a non-empty `record.remote_message_id`.",
+            "Replies are posted into the launch thread: same channel as the root post, with root_id set to the launch root post id.",
+            "Do not end a turn with plain assistant prose if you intend the human to see a reply.",
+            "If you decide not to answer, stay silent instead of pretending the reply was sent.",
+        ]
+    )
+    if peer_fanout_enabled:
+        lines.extend(
+            [
+                "In launcher-managed threads, human-visible replies are also forwarded to the other participating launcher sessions as peer input.",
+                "Include `@@rig/alias` in the Mattermost reply if you want to target a specific thread participant; untargeted replies to peer publications do not fan out.",
+            ]
+        )
+    extra = str(extra_message).strip()
+    if extra:
+        lines.extend(
+            [
+                "",
+                "Additional launch guidance:",
+                extra,
+            ]
+        )
+    lines.append("</mattermost-launch-primer>")
+    return "\n".join(lines)
+
+
+def room_launch_primer_idempotency_key(launch_id: str, qualified_handle: str) -> str:
+    return f"{str(launch_id).strip()}:primer:{str(qualified_handle).strip()}:v{ROOM_LAUNCH_PRIMER_VERSION}"
+
+
+def room_launch_participant_primer_identity(participant: dict[str, Any]) -> str:
+    for key in ("session_id", "session_name", "session_alias"):
+        value = str((participant or {}).get(key, "")).strip()
+        if value:
+            return value
+    return ""
+
+
+def room_launch_participant_needs_primer(participant: dict[str, Any]) -> bool:
+    try:
+        current_version = int(str(participant.get("primer_version", "")).strip() or "0")
+    except ValueError:
+        current_version = 0
+    if current_version < ROOM_LAUNCH_PRIMER_VERSION:
+        return True
+    current_identity = room_launch_participant_primer_identity(participant)
+    if not current_identity:
+        return False
+    return str(participant.get("primer_identity", "")).strip() != current_identity
+
+
+def prime_room_launch_participant(
+    launch: dict[str, Any],
+    participant: dict[str, Any],
+    *,
+    extra_message: str = "",
+) -> dict[str, Any]:
+    qualified_handle = str(participant.get("qualified_handle", "")).strip()
+    if not qualified_handle:
+        raise ValueError("launch participant is missing qualified_handle")
+    selector = room_launch_participant_delivery_selector(participant)
+    if not selector:
+        raise GCAPIError(f"launch participant {qualified_handle!r} is not routable yet")
+    launcher = resolve_room_launcher(load_config(), str(launch.get("conversation_id", "")).strip()) or {}
+    peer_fanout_enabled = bool(binding_peer_policy(launcher).get("peer_fanout_enabled"))
+    deliver_session_message(
+        selector,
+        room_launch_primer_message(
+            launch,
+            participant,
+            extra_message=extra_message,
+            peer_fanout_enabled=peer_fanout_enabled,
+        ),
+        idempotency_key=room_launch_primer_idempotency_key(str(launch.get("launch_id", "")).strip(), qualified_handle),
+    )
+    body = copy.deepcopy(participant)
+    body["primer_version"] = ROOM_LAUNCH_PRIMER_VERSION
+    body["primer_identity"] = room_launch_participant_primer_identity(participant)
+    body["primed_at"] = utcnow()
+    return body
+
+
+def _sync_launch_participant(
+    current: dict[str, Any],
+    normalized_handle: str,
+    participant: dict[str, Any],
+) -> dict[str, Any]:
+    participants = room_launch_participants(current)
+    participants[normalized_handle] = participant
+    current["participants"] = participants
+    if not str(current.get("qualified_handle", "")).strip():
+        current["qualified_handle"] = normalized_handle
+    if str(current.get("qualified_handle", "")).strip() == normalized_handle:
+        current["session_alias"] = str(participant.get("session_alias", "")).strip()
+        current["session_id"] = str(participant.get("session_id", "")).strip()
+        current["session_name"] = str(participant.get("session_name", "")).strip()
+    if not str(current.get("last_addressed_qualified_handle", "")).strip():
+        current["last_addressed_qualified_handle"] = normalized_handle
+    return current
+
+
+def _room_launch_participant_matches_session(participant: dict[str, Any], *, session_name: str = "", session_id: str = "") -> bool:
+    normalized_session_name = str(session_name).strip()
+    normalized_session_id = str(session_id).strip()
+    if normalized_session_id and str(participant.get("session_id", "")).strip() == normalized_session_id:
+        return True
+    if normalized_session_name and normalized_session_name in {
+        str(participant.get("session_name", "")).strip(),
+        str(participant.get("session_alias", "")).strip(),
+        str(participant.get("delivery_selector", "")).strip(),
+    }:
+        return True
+    return False
+
+
+def ensure_room_launch_session_for_handle(
+    launch: dict[str, Any],
+    qualified_handle: str,
+    *,
+    title: str = "",
+    initial_message: str = "",
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    launch_id = str(launch.get("launch_id", "")).strip()
+    normalized_handle = str(qualified_handle).strip()
+    if not launch_id or not normalized_handle:
+        raise ValueError("launch is missing required session fields")
+    with advisory_lock(room_launch_lock_path(launch_id)):
+        current = load_room_launch(launch_id) or normalize_room_launch_record(dict(launch))
+        current = normalize_room_launch_record(current)
+        participants = room_launch_participants(current)
+        participant = copy.deepcopy(participants.get(normalized_handle, {}))
+        created_new = False
+        session_alias = (
+            str(participant.get("session_alias", "")).strip()
+            or room_launch_session_alias(
+                str(current.get("team_id", "")).strip(),
+                str(current.get("conversation_id", "")).strip(),
+                str(current.get("root_post_id", "")).strip(),
+                normalized_handle,
+            )
+        )
+        existing = None
+        if str(participant.get("session_name", "")).strip():
+            existing_by_name = session_index_by_name(state="all").get(str(participant.get("session_name", "")).strip())
+            if session_record_routable(existing_by_name):
+                existing = existing_by_name
+        if not session_record_routable(existing):
+            existing_by_alias = session_index_by_alias(state="all").get(session_alias)
+            if session_record_routable(existing_by_alias):
+                existing = existing_by_alias
+        if session_record_routable(existing):
+            participant["session_alias"] = str(existing.get("alias", "")).strip() or session_alias
+            participant["session_id"] = str(existing.get("id", "")).strip()
+            participant["session_name"] = str(existing.get("session_name", "")).strip()
+        else:
+            created_new = True
+            created = create_agent_session(
+                normalized_handle,
+                alias=session_alias,
+                title=title or room_launch_thread_name(normalized_handle, str(current.get("from_display", "")).strip()),
+                initial_message=initial_message,
+                idempotency_key=f"{launch_id}:create-session:{normalized_handle}",
+            )
+            participant["session_alias"] = str(created.get("alias", "")).strip() or session_alias
+            participant["session_id"] = str(created.get("id", "")).strip()
+            participant["session_name"] = str(created.get("session_name", "")).strip()
+        created_identity = {
+            "alias": str(participant.get("session_alias", "")).strip(),
+            "session_id": str(participant.get("session_id", "")).strip(),
+            "session_name": str(participant.get("session_name", "")).strip(),
+        }
+        selector_snapshot, hydrated = resolve_routable_session_candidate_from_sessions(
+            list_city_sessions(state="all"),
+            participant.get("session_name", ""),
+            participant.get("session_id", ""),
+            participant.get("delivery_selector", ""),
+            participant.get("session_alias", ""),
+        )
+        if created_new and not selector_snapshot:
+            created_selector = str(created_identity.get("session_name", "")).strip() or str(created_identity.get("session_id", "")).strip()
+            if created_selector:
+                selector_snapshot = created_selector
+                hydrated = created_identity
+        if created_new and not selector_snapshot:
+            selector_snapshot, hydrated = resolve_routable_session_candidate_eventually(
+                participant.get("session_name", ""),
+                participant.get("delivery_selector", ""),
+                participant.get("session_alias", ""),
+                participant.get("session_id", ""),
+            )
+        if hydrated:
+            participant["session_alias"] = str(hydrated.get("alias", "")).strip() or str(participant.get("session_alias", "")).strip()
+            participant["session_id"] = str(hydrated.get("session_id", "")).strip() or str(participant.get("session_id", "")).strip()
+            participant["session_name"] = str(hydrated.get("session_name", "")).strip() or str(participant.get("session_name", "")).strip()
+        if created_new and not selector_snapshot:
+            raise GCAPIError(f"created launch session is not routable yet: {participant['session_alias'] or normalized_handle}")
+        participant["delivery_selector"] = (
+            str(participant.get("session_name", "")).strip()
+            or str(participant.get("session_id", "")).strip()
+            or str(participant.get("session_alias", "")).strip()
+            or selector_snapshot
+        )
+        participant["qualified_handle"] = normalized_handle
+        current = _sync_launch_participant(current, normalized_handle, participant)
+        current = save_room_launch(current)
+        if created_new:
+            _ready_selector, ready_identity = resolve_ready_session_candidate_from_sessions(
+                list_city_sessions(state="all"),
+                participant.get("session_name", ""),
+                participant.get("session_id", ""),
+                participant.get("session_alias", ""),
+                participant.get("delivery_selector", ""),
+            )
+            if not ready_identity:
+                ready_selector = str(created_identity.get("session_name", "")).strip() or str(created_identity.get("session_id", "")).strip()
+                if ready_selector:
+                    _ready_selector = ready_selector
+                    ready_identity = created_identity
+            if not ready_identity:
+                _ready_selector, ready_identity = resolve_ready_session_candidate_eventually(
+                    participant.get("session_name", ""),
+                    participant.get("session_id", ""),
+                    participant.get("session_alias", ""),
+                    participant.get("delivery_selector", ""),
+                )
+            if not ready_identity:
+                raise GCAPIError(f"created launch session is not ready yet: {participant['session_alias'] or normalized_handle}")
+            participant["session_alias"] = str(ready_identity.get("alias", "")).strip() or str(participant.get("session_alias", "")).strip()
+            participant["session_id"] = str(ready_identity.get("session_id", "")).strip() or str(participant.get("session_id", "")).strip()
+            participant["session_name"] = str(ready_identity.get("session_name", "")).strip() or str(participant.get("session_name", "")).strip()
+            participant["delivery_selector"] = (
+                str(participant.get("session_name", "")).strip()
+                or str(participant.get("session_id", "")).strip()
+                or str(participant.get("session_alias", "")).strip()
+            )
+            current = _sync_launch_participant(current, normalized_handle, participant)
+            current = save_room_launch(current)
+        if room_launch_participant_needs_primer(participant):
+            try:
+                participant = prime_room_launch_participant(
+                    current,
+                    participant,
+                    extra_message=initial_message,
+                )
+            except Exception as exc:  # noqa: BLE001
+                participant["primer_error"] = str(exc)
+                participant["primer_last_failed_at"] = utcnow()
+            else:
+                participant.pop("primer_error", None)
+                participant.pop("primer_last_failed_at", None)
+            current = _sync_launch_participant(current, normalized_handle, participant)
+            current = save_room_launch(current)
+        return current, copy.deepcopy(participant)
+
+
+def ensure_room_launch_session(
+    launch: dict[str, Any],
+    *,
+    title: str = "",
+    initial_message: str = "",
+) -> dict[str, Any]:
+    qualified_handle = str(launch.get("qualified_handle", "")).strip()
+    current, _participant = ensure_room_launch_session_for_handle(
+        launch,
+        qualified_handle,
+        title=title,
+        initial_message=initial_message,
+    )
+    return current
+
+
+def derive_publish_source_metadata(source_context: dict[str, str] | None = None) -> dict[str, str]:
+    fields = source_context if isinstance(source_context, dict) else {}
+    source_kind = str(fields.get("kind", "")).strip()
+    ingress_id = str(fields.get("ingress_receipt_id", "")).strip()
+    root_ingress_id = str(fields.get("root_ingress_receipt_id", "")).strip()
+    if source_kind == HUMAN_MESSAGE_EVENT_KIND and ingress_id:
+        root_ingress_id = ingress_id
+    return {
+        "source_event_kind": source_kind,
+        "ingress_receipt_id": ingress_id,
+        "root_ingress_receipt_id": root_ingress_id,
+        "publish_binding_id": str(fields.get("publish_binding_id", "")).strip(),
+        "publish_trigger_id": str(fields.get("publish_trigger_id", "")).strip(),
+        "publish_root_post_id": str(fields.get("publish_root_post_id", "")).strip(),
+        "launch_id": str(fields.get("launch_id", "")).strip() or str(fields.get("publish_launch_id", "")).strip(),
+    }
+
+
+def _derive_publish_source_metadata(source_context: dict[str, str] | None = None) -> dict[str, str]:
+    return derive_publish_source_metadata(source_context)
+
+
+def _strip_inline_code(text: str) -> str:
+    out: list[str] = []
+    i = 0
+    while i < len(text):
+        ch = text[i]
+        if ch == "`":
+            j = i
+            while j < len(text) and text[j] == "`":
+                j += 1
+            ticks = text[i:j]
+            close = text.find(ticks, j)
+            out.extend(" " * len(ticks))
+            if close < 0:
+                i = j
+                continue
+            out.extend(" " * (close - j))
+            out.extend(" " * len(ticks))
+            i = close + len(ticks)
+            continue
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+
+def _peer_routing_visible_text(body: str) -> str:
+    lines: list[str] = []
+    in_fence = False
+    for raw_line in str(body).splitlines():
+        line = raw_line
+        stripped = line.lstrip()
+        if stripped.startswith("```"):
+            in_fence = not in_fence
+            lines.append("")
+            continue
+        if in_fence:
+            lines.append("")
+            continue
+        if stripped.startswith(">"):
+            lines.append("")
+            continue
+        visible = URL_PATTERN.sub(" ", _strip_inline_code(line))
+        lines.append(visible)
+    return "\n".join(lines)
+
+
+def extract_peer_session_mentions(body: str) -> list[str]:
+    text = _peer_routing_visible_text(body)
+    mentions: list[str] = []
+    seen: set[str] = set()
+    i = 0
+    while i < len(text):
+        if text[i] != "@":
+            i += 1
+            continue
+        prev = text[i - 1] if i > 0 else ""
+        if prev and (prev.isalnum() or prev in {"_", "@"}):
+            i += 1
+            continue
+        j = i + 1
+        if j >= len(text) or not text[j].isdigit() and not ("a" <= text[j] <= "z"):
+            i += 1
+            continue
+        while j < len(text) and (text[j].isdigit() or ("a" <= text[j] <= "z") or text[j] in {"_", "-"}):
+            j += 1
+        token = text[i + 1 : j]
+        if token and token not in MATTERMOST_RESERVED_MENTIONS and canonical_peer_session_name(token) == token and token not in seen:
+            seen.add(token)
+            mentions.append(token)
+        i = j
+    return mentions
+
+
+def extract_agent_handles(body: str) -> list[str]:
+    text = _peer_routing_visible_text(body)
+    handles: list[str] = []
+    seen: set[str] = set()
+    i = 0
+    while i < len(text):
+        if text[i : i + 2] != "@@":
+            i += 1
+            continue
+        prev = text[i - 1] if i > 0 else ""
+        if prev and (prev.isalnum() or prev in {"_", "@"}):
+            i += 1
+            continue
+        j = i + 2
+        parts: list[str] = []
+        while len(parts) < 2:
+            start = j
+            while j < len(text):
+                lower = text[j].lower()
+                if ("a" <= lower <= "z") or text[j].isdigit() or text[j] in {"_", "-"}:
+                    j += 1
+                    continue
+                break
+            part = text[start:j]
+            if not part:
+                break
+            parts.append(part)
+            if j < len(text) and text[j] == "/" and len(parts) == 1:
+                j += 1
+                continue
+            break
+        candidate = "/".join(parts)
+        normalized = _normalize_agent_handle(candidate)
+        if normalized and normalized not in seen:
+            seen.add(normalized)
+            handles.append(normalized)
+        i = max(i + 2, j)
+    return handles
+
+
+def _binding_session_lookup(binding: dict[str, Any], *, launch: dict[str, Any] | None = None) -> dict[str, str]:
+    if launch and str(binding.get("publish_route_kind", "")).strip() == "room_launch":
+        return room_launch_participant_session_lookup(launch)
+    lookup: dict[str, str] = {}
+    for name in binding.get("session_names", []):
+        session_name = str(name).strip()
+        if session_name:
+            lookup[session_name] = session_name
+    return lookup
+
+
+def _peer_delivery_payload(record: dict[str, Any]) -> dict[str, Any]:
+    payload = record.get("peer_delivery")
+    if isinstance(payload, dict):
+        return copy.deepcopy(payload)
+    return {
+        "phase": "mattermost_posted",
+        "status": "",
+        "delivery": "",
+        "mentioned_session_names": [],
+        "frozen_targets": [],
+        "targets": [],
+        "budget_snapshot": {},
+    }
+
+
+def _save_chat_publish_record(record: dict[str, Any]) -> dict[str, Any]:
+    return save_chat_publish(record)
+
+
+def _update_peer_target(peer_delivery: dict[str, Any], session_name: str, patch: dict[str, Any]) -> None:
+    targets = peer_delivery.setdefault("targets", [])
+    for entry in targets:
+        if str(entry.get("session_name", "")).strip() == session_name:
+            entry.update(copy.deepcopy(patch))
+            return
+    item = {"session_name": session_name}
+    item.update(copy.deepcopy(patch))
+    targets.append(item)
+
+
+def _rename_peer_target(peer_delivery: dict[str, Any], old_session_name: str, new_session_name: str) -> None:
+    old_name = str(old_session_name).strip()
+    new_name = str(new_session_name).strip()
+    if not old_name or not new_name or old_name == new_name:
+        return
+    targets = peer_delivery.setdefault("targets", [])
+    old_entry = next((entry for entry in targets if str(entry.get("session_name", "")).strip() == old_name), None)
+    new_entry = next((entry for entry in targets if str(entry.get("session_name", "")).strip() == new_name), None)
+    if old_entry and not new_entry:
+        old_entry["session_name"] = new_name
+    elif old_entry and new_entry:
+        for key, value in old_entry.items():
+            if key == "session_name":
+                continue
+            new_entry.setdefault(key, value)
+        targets.remove(old_entry)
+    for key in ("mentioned_session_names", "frozen_targets"):
+        values = []
+        seen: set[str] = set()
+        for item in peer_delivery.get(key, []):
+            normalized = new_name if str(item).strip() == old_name else str(item).strip()
+            if not normalized or normalized in seen:
+                continue
+            seen.add(normalized)
+            values.append(normalized)
+        peer_delivery[key] = values
+
+
+def _peer_attempt(session_name: str, status: str, reason: str = "", response: dict[str, Any] | None = None) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "at": utcnow(),
+        "status": status,
+    }
+    if reason:
+        payload["reason"] = reason
+    if response:
+        payload["response"] = response
+    payload["session_name"] = session_name
+    return payload
+
+
+def _count_matching_publishes(
+    *,
+    binding_id: str,
+    root_ingress_receipt_id: str,
+    source_session_name: str = "",
+    source_event_kind: str = "",
+    since_epoch: float | None = None,
+    exclude_publish_id: str = "",
+    records: list[dict[str, Any]] | None = None,
+) -> int:
+    total = 0
+    publish_records = records if records is not None else iter_chat_publishes()
+    for record in publish_records:
+        if exclude_publish_id and str(record.get("publish_id", "")).strip() == exclude_publish_id:
+            continue
+        if str(record.get("binding_id", "")).strip() != binding_id:
+            continue
+        if root_ingress_receipt_id and str(record.get("root_ingress_receipt_id", "")).strip() != root_ingress_receipt_id:
+            continue
+        if source_session_name and str(record.get("source_session_name", "")).strip() != source_session_name:
+            continue
+        if source_event_kind and str(record.get("source_event_kind", "")).strip() != source_event_kind:
+            continue
+        if since_epoch is not None:
+            created = parse_utc_timestamp(str(record.get("created_at", "")).strip())
+            if created is None or created < since_epoch:
+                continue
+        total += 1
+    return total
+
+
+def _count_root_peer_deliveries(binding_id: str, root_ingress_receipt_id: str, records: list[dict[str, Any]] | None = None) -> int:
+    total = 0
+    publish_records = records if records is not None else iter_chat_publishes()
+    for record in publish_records:
+        if str(record.get("binding_id", "")).strip() != binding_id:
+            continue
+        if str(record.get("root_ingress_receipt_id", "")).strip() != root_ingress_receipt_id:
+            continue
+        peer_delivery = record.get("peer_delivery")
+        if not isinstance(peer_delivery, dict):
+            continue
+        frozen = peer_delivery.get("frozen_targets")
+        if isinstance(frozen, list):
+            total += len([item for item in frozen if str(item).strip()])
+    return total
+
+
+def _count_root_peer_triggered_publishes(
+    binding_id: str,
+    root_ingress_receipt_id: str,
+    source_session_name: str,
+    *,
+    exclude_publish_id: str = "",
+) -> int:
+    index = load_peer_root_budget_index(binding_id, root_ingress_receipt_id)
+    total = 0
+    for publish_id, item in index.get("entries", {}).items():
+        if exclude_publish_id and publish_id == exclude_publish_id:
+            continue
+        if not isinstance(item, dict):
+            continue
+        if str(item.get("source_session_name", "")).strip() != source_session_name:
+            continue
+        if str(item.get("source_event_kind", "")).strip() != PEER_PUBLICATION_EVENT_KIND:
+            continue
+        total += 1
+    return total
+
+
+def _count_root_peer_deliveries_from_index(binding_id: str, root_ingress_receipt_id: str) -> int:
+    index = load_peer_root_budget_index(binding_id, root_ingress_receipt_id)
+    total = 0
+    for item in index.get("entries", {}).values():
+        if not isinstance(item, dict):
+            continue
+        total += max(0, int(item.get("frozen_target_count", 0) or 0))
+    return total
+
+
+def _resolve_peer_targets(
+    binding: dict[str, Any],
+    *,
+    body: str,
+    source_session_name: str,
+    source_session_id: str,
+    source_event_kind: str,
+    launch: dict[str, Any] | None = None,
+) -> tuple[list[str], str, str, list[str]]:
+    policy = binding_peer_policy(binding)
+    session_lookup = _binding_session_lookup(binding, launch=launch)
+    handle_lookup = room_launch_participant_handle_lookup(launch) if launch else {}
+    delivery_targets = room_launch_participant_delivery_targets(launch) if launch else []
+    source_delivery_selector = source_session_name
+    if launch:
+        source_handle = room_launch_participant_handle_for_session(
+            launch,
+            session_name=source_session_name,
+            session_id=source_session_id,
+        )
+        if source_handle:
+            source_delivery_selector = room_launch_participant_delivery_selector(
+                room_launch_participant(launch, source_handle)
+            )
+    if handle_lookup:
+        handles = extract_agent_handles(body)
+        if handles:
+            if any(handle not in handle_lookup for handle in handles):
+                return [], "targeted", "failed_targeting_unknown_handle", handles
+            resolved_mentions: list[str] = []
+            targets: list[str] = []
+            seen: set[str] = set()
+            for handle in handles:
+                selector = str(handle_lookup.get(handle, "")).strip()
+                if not selector:
+                    continue
+                resolved_mentions.append(selector)
+                if selector == source_delivery_selector or selector in seen:
+                    continue
+                seen.add(selector)
+                targets.append(selector)
+            if not targets:
+                return [], "targeted", "failed_targeting_self_only", resolved_mentions
+            return targets, "targeted", "", resolved_mentions
+    mentions = extract_peer_session_mentions(body)
+    if mentions:
+        if any(name not in session_lookup for name in mentions):
+            return [], "targeted", "failed_targeting_unknown_session", mentions
+        targets = [str(session_lookup.get(name, "")).strip() for name in mentions]
+        targets = [name for name in targets if name and name != source_delivery_selector]
+        if not targets:
+            return [], "targeted", "failed_targeting_self_only", mentions
+        return targets, "targeted", "", mentions
+    if source_event_kind == PEER_PUBLICATION_EVENT_KIND:
+        return [], "untargeted", "skipped_peer_target_required", []
+    if not policy.get("allow_untargeted_peer_fanout"):
+        return [], "untargeted", "skipped_policy_untargeted_disabled", []
+    if delivery_targets:
+        targets = [name for name in delivery_targets if name != source_delivery_selector]
+    else:
+        targets = [name for name in session_lookup if name != source_session_name]
+    if not targets:
+        return [], "untargeted", "skipped_no_peer_targets", []
+    return targets, "untargeted", "", []
+
+
+def _build_peer_envelope(
+    *,
+    binding: dict[str, Any],
+    record: dict[str, Any],
+    source_session_name: str,
+    source_session_id: str,
+    target_session_name: str,
+    delivery: str,
+    mentioned_session_names: list[str],
+    root_ingress_receipt_id: str,
+    idempotency_key: str,
+    launch: dict[str, Any] | None = None,
+) -> str:
+    launch_id = str((launch or {}).get("launch_id", "")).strip()
+    target_delivery_selector, target_participant, target_identity = resolve_room_launch_target_selector(
+        launch or {},
+        target_session_name,
+    )
+    target_delivery_selector = target_delivery_selector or str(target_session_name).strip()
+    source_qualified_handle = room_launch_participant_handle_for_session(
+        launch or {},
+        session_name=source_session_name,
+        session_id=source_session_id,
+    )
+    target_qualified_handle = str(target_participant.get("qualified_handle", "")).strip()
+    if not target_qualified_handle and target_identity:
+        target_qualified_handle = room_launch_participant_handle_for_session(
+            launch or {},
+            session_name=str(target_identity.get("session_name", "")).strip(),
+            session_id=str(target_identity.get("session_id", "")).strip(),
+        )
+    if not target_qualified_handle and target_delivery_selector:
+        target_qualified_handle = room_launch_participant_handle_for_session(
+            launch or {},
+            session_name=target_delivery_selector,
+        )
+    target_participant = target_participant or room_launch_participant(launch or {}, target_qualified_handle)
+    target_session_label = str(target_participant.get("session_name", "")).strip() or target_delivery_selector
+    team_id = str(binding.get("team_id", "")).strip()
+    channel_id = str(record.get("conversation_id", "")).strip()
+    root_post_id = str(record.get("root_post_id", "")).strip() or str(record.get("remote_message_id", "")).strip()
+    conversation_label = (
+        f"team:{team_id} channel:{channel_id}" if team_id else f"dm:{channel_id}"
+    )
+    lines = [
+        f"<{EVENT_TAG}>",
+        "version: 1",
+        f"kind: {PEER_PUBLICATION_EVENT_KIND}",
+        f"binding_id: {str(binding.get('id', '')).strip()}",
+        f"ingress_receipt_id: peer:{str(record.get('publish_id', '')).strip()}:target:{target_session_name}",
+        f"conversation: {conversation_label}",
+        f"conversation_key: {mattermost_conversation_key(channel_id, root_post_id)}",
+        f"team_id: {team_id}",
+        f"channel_id: {channel_id}",
+        f"root_id: {root_post_id}",
+        f"mattermost_post_id: {str(record.get('remote_message_id', '')).strip()}",
+        f"source_session_name: {source_session_name}",
+        f"source_session_id: {source_session_id}",
+        "source_kind: peer_session",
+        f"target_session_name: {target_session_label}",
+        f"publish_id: {str(record.get('publish_id', '')).strip()}",
+        f"root_ingress_receipt_id: {root_ingress_receipt_id}",
+        f"publish_binding_id: {str(binding.get('id', '')).strip()}",
+        f"publish_conversation_id: {channel_id}",
+        f"publish_trigger_id: {str(record.get('remote_message_id', '')).strip()}",
+        f"publish_root_post_id: {root_post_id}",
+        f"publish_launch_id: {launch_id}",
+        f"delivery_idempotency_key: {idempotency_key}",
+        f"delivery: {delivery}",
+        f"mentioned_session_names_json: {json.dumps(mentioned_session_names)}",
+        f"untrusted_body_json: {json.dumps(str(record.get('body', '')))}",
+        f"created_at: {str(record.get('created_at', '')).strip()}",
+        "normal_output_visibility: internal_only",
+        "reply_contract: explicit_publish_required",
+        "hop: 1",
+        "max_hop: 1",
+    ]
+    if launch_id:
+        lines.extend(
+            [
+                f"launch_id: {launch_id}",
+                "launch_surface_kind: room",
+                f"launch_root_qualified_handle: {str((launch or {}).get('qualified_handle', '')).strip()}",
+                f"launch_root_session_alias: {str((launch or {}).get('session_alias', '')).strip()}",
+                f"launch_qualified_handle: {target_qualified_handle}",
+                f"launch_session_alias: {str(target_participant.get('session_alias', '')).strip()}",
+                f"launch_session_name: {target_session_label}",
+                f"source_qualified_handle: {source_qualified_handle}",
+                f"thread_participants_json: {json.dumps(room_launch_participant_summaries(launch or {}))}",
+            ]
+        )
+    lines.append(f"</{EVENT_TAG}>")
+    return "\n".join(lines)
+
+
+def _promote_stale_in_progress_targets(record: dict[str, Any]) -> tuple[dict[str, Any], bool]:
+    body = copy.deepcopy(record)
+    peer_delivery = _peer_delivery_payload(body)
+    changed = False
+    now = time.time()
+    for entry in peer_delivery.get("targets", []):
+        if str(entry.get("status", "")).strip() != "in_progress":
+            continue
+        attempted_at = parse_utc_timestamp(str(entry.get("attempted_at", "")).strip())
+        if attempted_at is None or now - attempted_at < PEER_IN_PROGRESS_STALE_SECONDS:
+            continue
+        entry["status"] = "delivery_unknown"
+        entry.setdefault("reason", "stale_in_progress")
+        changed = True
+    if changed:
+        body["peer_delivery"] = peer_delivery
+    return body, changed
+
+
+def ensure_room_launch_thread(binding: dict[str, Any], launch_id: str) -> tuple[dict[str, Any], bool]:
+    """Mark the launch thread ready.
+
+    Mattermost has no thread object to create: the thread is defined by posts
+    carrying root_id == root_post_id in the launch channel, so this only
+    promotes the launch record to active on first use.
+    """
+    normalized_launch_id = str(launch_id).strip()
+    if not normalized_launch_id:
+        raise ValueError("launch_id is required")
+    with advisory_lock(room_launch_lock_path(normalized_launch_id)):
+        current = load_room_launch(normalized_launch_id)
+        if not current:
+            raise ValueError(f"launch not found: {normalized_launch_id}")
+        channel_id = str(binding.get("conversation_id", "")).strip() or str(current.get("conversation_id", "")).strip()
+        root_post_id = str(current.get("root_post_id", "")).strip()
+        if not channel_id or not root_post_id:
+            raise ValueError("launch is missing thread routing metadata")
+        if str(current.get("state", "")).strip() == "active":
+            return current, False
+        current["conversation_id"] = channel_id
+        current["state"] = "active"
+        current = save_room_launch(current)
+        return current, True
+
+
+def record_room_launch_message_target(
+    launch_id: str,
+    remote_message_id: str,
+    *,
+    source_session_name: str = "",
+    source_session_id: str = "",
+) -> dict[str, Any] | None:
+    normalized_launch_id = str(launch_id).strip()
+    normalized_remote_message_id = str(remote_message_id).strip()
+    if not normalized_launch_id or not normalized_remote_message_id:
+        return None
+    with advisory_lock(room_launch_lock_path(normalized_launch_id)):
+        current = load_room_launch(normalized_launch_id)
+        if not current:
+            return None
+        current = normalize_room_launch_record(current)
+        matched_handle = ""
+        for qualified_handle, participant in room_launch_participants(current).items():
+            if _room_launch_participant_matches_session(
+                participant,
+                session_name=source_session_name,
+                session_id=source_session_id,
+            ):
+                matched_handle = qualified_handle
+                break
+        if not matched_handle:
+            return current
+        body = copy.deepcopy(current)
+        message_targets = {
+            str(message_id).strip(): str(qualified_handle).strip()
+            for message_id, qualified_handle in body.get("message_targets", {}).items()
+            if str(message_id).strip() and str(qualified_handle).strip()
+        }
+        target_order = [str(item).strip() for item in body.get("message_target_order", []) if str(item).strip()]
+        message_targets[normalized_remote_message_id] = matched_handle
+        target_order = [item for item in target_order if item != normalized_remote_message_id]
+        target_order.append(normalized_remote_message_id)
+        while len(target_order) > ROOM_LAUNCH_MESSAGE_TARGET_LIMIT:
+            evicted = target_order.pop(0)
+            message_targets.pop(evicted, None)
+        body["message_targets"] = {
+            message_id: message_targets[message_id]
+            for message_id in target_order
+            if message_id in message_targets
+        }
+        body["message_target_order"] = target_order
+        return save_room_launch(body)
+
+
+def resolve_thread_root_id(channel_id: str, post_id: str, *, bot_token: str = "") -> str:
+    """Resolve a post id to the root id of its thread.
+
+    Mattermost rejects a root_id that points at a reply, so a caller replying
+    to an arbitrary post must walk up to the thread root first.
+    """
+    normalized_post_id = str(post_id).strip()
+    if not normalized_post_id:
+        return ""
+    try:
+        post = mattermost_api_request(
+            "GET",
+            f"/posts/{urllib.parse.quote(normalized_post_id)}",
+            bot_token=str(bot_token).strip() or None,
+        )
+    except MattermostAPIError:
+        return normalized_post_id
+    if not isinstance(post, dict):
+        return normalized_post_id
+    post_channel_id = str(post.get("channel_id", "")).strip()
+    if str(channel_id).strip() and post_channel_id and post_channel_id != str(channel_id).strip():
+        return ""
+    return post_thread_root_id(post)
+
+
+def resolve_publish_channel_id(binding: dict[str, Any], requested_conversation_id: str) -> str:
+    """Return the real Mattermost channel_id a binding posts into.
+
+    A binding's conversation_id may be thread-scoped ("<channel_id>/<root_id>",
+    see mattermost_conversation_key) — that composite is the binding's lookup
+    identity, not a literal API channel id, so it must never be handed to
+    post_channel_message() directly. --conversation-id overrides are compared
+    against the binding's real channel_id (what operators pass), not the
+    composite.
+    """
+    binding_channel_id = str(binding.get("channel_id", "")).strip()
+    if not binding_channel_id:
+        binding_channel_id, _binding_root_id = mattermost_conversation_parts(
+            str(binding.get("conversation_id", "")).strip()
+        )
+    requested = str(requested_conversation_id).strip()
+    if not requested or requested == binding_channel_id:
+        return binding_channel_id
+    if str(binding.get("kind", "")).strip() == "dm":
+        raise ValueError("--conversation-id cannot override a DM binding")
+    # Mattermost threads live inside their channel, so a bound room admits no
+    # other channel id.
+    raise ValueError("--conversation-id must match the bound channel")
+
+
+def resolve_publish_destination(
+    binding: dict[str, Any],
+    *,
+    requested_conversation_id: str = "",
+    trigger_id: str = "",
+    reply_to_message_id: str = "",
+    source_context: dict[str, str] | None = None,
+) -> tuple[str, str, dict[str, Any] | None]:
+    source_meta = derive_publish_source_metadata(source_context)
+    reply_target = (
+        str(reply_to_message_id).strip()
+        or str(source_meta.get("publish_root_post_id", "")).strip()
+        or str(trigger_id).strip()
+    )
+    launch_id = str(source_meta.get("launch_id", "")).strip()
+    if str(binding.get("publish_route_kind", "")).strip() != "room_launch" or not launch_id:
+        conversation_id = resolve_publish_channel_id(binding, requested_conversation_id)
+        binding_root_id = str(binding.get("root_id", "")).strip()
+        if not binding_root_id:
+            _channel_part, binding_root_id = mattermost_conversation_parts(
+                str(binding.get("conversation_id", "")).strip()
+            )
+        # A thread-scoped binding (bind-room --root-id) can only ever post
+        # into its own bound thread — it does not admit a different reply
+        # target, unlike a whole-channel binding which threads off whatever
+        # message it's replying to.
+        if binding_root_id:
+            root_post_id = binding_root_id
+        else:
+            root_post_id = resolve_thread_root_id(conversation_id, reply_target) if reply_target else ""
+        return conversation_id, root_post_id, None
+    current = load_room_launch(launch_id)
+    if not current:
+        raise ValueError(f"launch not found: {launch_id}")
+    binding_conversation_id = str(binding.get("conversation_id", "")).strip()
+    requested = str(requested_conversation_id).strip()
+    if requested and requested != binding_conversation_id:
+        raise ValueError("--conversation-id must match the launch channel for this room launch")
+    if str(current.get("state", "")).strip() != "active":
+        current, _promoted = ensure_room_launch_thread(binding, launch_id)
+    conversation_id = str(current.get("conversation_id", "")).strip() or binding_conversation_id
+    root_post_id = str(current.get("root_post_id", "")).strip()
+    if not conversation_id or not root_post_id:
+        raise ValueError("room launch is missing channel/root routing metadata")
+    return conversation_id, root_post_id, current
+
+
+def _peer_delivery_needs_attention(record: dict[str, Any]) -> bool:
+    peer_delivery = record.get("peer_delivery")
+    if not isinstance(peer_delivery, dict):
+        return False
+    phase = str(peer_delivery.get("phase", "")).strip()
+    status = str(peer_delivery.get("status", "")).strip()
+    if phase == "peer_fanout_partial_failure":
+        return True
+    if status.startswith("failed_"):
+        return True
+    return any(
+        str(entry.get("status", "")).strip() in {"failed_retryable", "failed_permanent", "delivery_unknown"}
+        for entry in peer_delivery.get("targets", [])
+        if isinstance(entry, dict)
+    )
+
+
+def peer_delivery_exit_code(record: dict[str, Any]) -> int:
+    return 2 if _peer_delivery_needs_attention(record) else 0
+
+
+def _finalize_peer_delivery(record: dict[str, Any]) -> dict[str, Any]:
+    body = copy.deepcopy(record)
+    peer_delivery = _peer_delivery_payload(body)
+    terminal_statuses = {
+        str(entry.get("status", "")).strip()
+        for entry in peer_delivery.get("targets", [])
+        if isinstance(entry, dict)
+    }
+    status = str(peer_delivery.get("status", "")).strip()
+    if {"pending", "in_progress"} & terminal_statuses:
+        peer_delivery["phase"] = "peer_fanout_in_progress"
+    elif status.startswith("failed_"):
+        peer_delivery["phase"] = "peer_fanout_partial_failure"
+    elif {"failed_retryable", "failed_permanent", "delivery_unknown"} & terminal_statuses:
+        peer_delivery["phase"] = "peer_fanout_partial_failure"
+        peer_delivery["status"] = "partial_failure"
+    elif terminal_statuses:
+        peer_delivery["phase"] = "peer_fanout_complete"
+        if "delivered" in terminal_statuses:
+            peer_delivery["status"] = "delivered"
+        elif not status or status == "partial_failure":
+            peer_delivery["status"] = "delivered"
+    elif not status:
+        peer_delivery["phase"] = "peer_fanout_complete"
+        peer_delivery["status"] = "skipped_no_peer_targets"
+    body["peer_delivery"] = peer_delivery
+    return body
+
+
+def _update_target_in_progress(
+    *,
+    publish_id: str,
+    fallback_record: dict[str, Any],
+    session_name: str,
+    idempotency_key: str,
+) -> tuple[dict[str, Any], int]:
+    with advisory_lock(_safe_lock_name("chat-publish", publish_id)):
+        current = load_chat_publish(publish_id) or copy.deepcopy(fallback_record)
+        peer_delivery = _peer_delivery_payload(current)
+        target_entry = next(
+            (item for item in peer_delivery.get("targets", []) if str(item.get("session_name", "")).strip() == session_name),
+            None,
+        )
+        if target_entry and str(target_entry.get("status", "")).strip() == "delivered":
+            return current, int(target_entry.get("attempt_count", 0) or 0)
+        attempt_count = int((target_entry or {}).get("attempt_count", 0) or 0) + 1
+        _update_peer_target(
+            peer_delivery,
+            session_name,
+            {
+                "status": "in_progress",
+                "idempotency_key": idempotency_key,
+                "attempt_count": attempt_count,
+                "attempted_at": utcnow(),
+            },
+        )
+        current["peer_delivery"] = peer_delivery
+        current = _save_chat_publish_record(current)
+        return current, attempt_count
+
+
+def _update_target_delivery_result(
+    *,
+    publish_id: str,
+    fallback_record: dict[str, Any],
+    session_name: str,
+    response: dict[str, Any] | None = None,
+    error: str = "",
+) -> dict[str, Any]:
+    with advisory_lock(_safe_lock_name("chat-publish", publish_id)):
+        current = load_chat_publish(publish_id) or copy.deepcopy(fallback_record)
+        peer_delivery = _peer_delivery_payload(current)
+        target_entry = next(
+            (item for item in peer_delivery.get("targets", []) if str(item.get("session_name", "")).strip() == session_name),
+            None,
+        )
+        attempts = list((target_entry or {}).get("attempts", []))
+        if error:
+            attempts.append(_peer_attempt(session_name, "failed_retryable", error))
+            _update_peer_target(
+                peer_delivery,
+                session_name,
+                {
+                    "status": "failed_retryable",
+                    "reason": error,
+                    "attempts": attempts,
+                },
+            )
+        else:
+            attempts.append(_peer_attempt(session_name, "delivered", response=response or {}))
+            _update_peer_target(
+                peer_delivery,
+                session_name,
+                {
+                    "status": "delivered",
+                    "delivered_at": utcnow(),
+                    "response": response or {},
+                    "attempts": attempts,
+                },
+            )
+        current["peer_delivery"] = peer_delivery
+        return _save_chat_publish_record(current)
+
+
+def _apply_peer_fanout(
+    record: dict[str, Any],
+    binding: dict[str, Any],
+    *,
+    source_context: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    if str(binding.get("kind", "")).strip() != "room":
+        return record
+
+    binding_id = str(binding.get("id", "")).strip()
+    publish_id = str(record.get("publish_id", "")).strip()
+    source_session_name = str(record.get("source_session_name", "")).strip()
+    source_session_id = str(record.get("source_session_id", "")).strip()
+    policy = binding_peer_policy(binding)
+    source_meta = _derive_publish_source_metadata(source_context)
+    root_ingress_receipt_id = source_meta.get("root_ingress_receipt_id", "")
+    launch_record = None
+    if str(binding.get("publish_route_kind", "")).strip() == "room_launch":
+        launch_id = str(source_meta.get("launch_id", "")).strip() or str(record.get("launch_id", "")).strip()
+        if launch_id:
+            launch_record = load_room_launch(launch_id) or {}
+    source_delivery_selector = source_session_name
+    budget_lock_key = f"{binding_id}:{root_ingress_receipt_id or publish_id}"
+    delivery_targets: list[tuple[str, str]] = []
+    delivery_mode = ""
+    delivery_mentions: list[str] = []
+    with advisory_lock(_safe_lock_name("peer-budget", budget_lock_key)):
+        with advisory_lock(_safe_lock_name("chat-publish", publish_id)):
+            current = load_chat_publish(publish_id) or copy.deepcopy(record)
+            current, stale_changed = _promote_stale_in_progress_targets(current)
+            if stale_changed:
+                current = _save_chat_publish_record(current)
+            peer_delivery = _peer_delivery_payload(current)
+            peer_delivery.setdefault("delivery", "")
+            peer_delivery.setdefault("mentioned_session_names", [])
+            peer_delivery.setdefault("frozen_targets", [])
+            peer_delivery.setdefault("targets", [])
+            peer_delivery.setdefault("budget_snapshot", {})
+            current["source_event_kind"] = source_meta.get("source_event_kind", "")
+            current["root_ingress_receipt_id"] = root_ingress_receipt_id
+
+            if not policy.get("peer_fanout_enabled"):
+                peer_delivery["phase"] = "peer_fanout_complete"
+                peer_delivery["status"] = "skipped_policy_disabled"
+                current["peer_delivery"] = peer_delivery
+                return _save_chat_publish_record(current)
+            if not root_ingress_receipt_id:
+                peer_delivery["phase"] = "peer_fanout_complete"
+                peer_delivery["status"] = "skipped_missing_root_context"
+                current["peer_delivery"] = peer_delivery
+                return _save_chat_publish_record(current)
+            session_lookup = _binding_session_lookup(binding, launch=launch_record)
+            if str(binding.get("publish_route_kind", "")).strip() == "room_launch" and launch_record:
+                source_handle = room_launch_participant_handle_for_session(
+                    launch_record,
+                    session_name=source_session_name,
+                    session_id=source_session_id,
+                )
+                if not source_handle:
+                    current_selector = current_session_selector()
+                    if current_selector:
+                        source_handle = room_launch_participant_handle_for_session(
+                            launch_record,
+                            session_name=current_selector,
+                            session_id=current_selector,
+                        )
+                if not source_handle:
+                    peer_delivery["phase"] = "peer_fanout_complete"
+                    peer_delivery["status"] = "skipped_source_not_thread_participant"
+                    current["peer_delivery"] = peer_delivery
+                    return _save_chat_publish_record(current)
+                source_participant = room_launch_participant(launch_record, source_handle)
+                source_delivery_selector = room_launch_participant_delivery_selector(source_participant)
+                source_session_name = (
+                    source_session_name
+                    or str(source_participant.get("session_name", "")).strip()
+                    or source_delivery_selector
+                )
+                source_session_id = source_session_id or str(source_participant.get("session_id", "")).strip()
+                current["source_session_name"] = source_session_name
+                current["source_session_id"] = source_session_id
+                current["source_qualified_handle"] = source_handle
+                current = _save_chat_publish_record(current)
+            if not source_session_name or (not source_delivery_selector and source_session_name not in session_lookup):
+                peer_delivery["phase"] = "peer_fanout_partial_failure"
+                peer_delivery["status"] = "failed_source_not_bound"
+                current["peer_delivery"] = peer_delivery
+                return _save_chat_publish_record(current)
+            if source_delivery_selector and not launch_record and source_delivery_selector not in session_lookup.values():
+                peer_delivery["phase"] = "peer_fanout_partial_failure"
+                peer_delivery["status"] = "failed_source_not_bound"
+                current["peer_delivery"] = peer_delivery
+                return _save_chat_publish_record(current)
+
+            now = time.time()
+            if source_meta.get("source_event_kind") == PEER_PUBLICATION_EVENT_KIND:
+                per_root_count = _count_root_peer_triggered_publishes(
+                    binding_id,
+                    root_ingress_receipt_id,
+                    source_session_name,
+                    exclude_publish_id=publish_id,
+                )
+                if per_root_count >= int(policy.get("max_peer_triggered_publishes_per_root", 0) or 0):
+                    peer_delivery["phase"] = "peer_fanout_complete"
+                    peer_delivery["status"] = "skipped_budget_exhausted"
+                    peer_delivery["budget_snapshot"] = {"peer_triggered_publishes_per_root": per_root_count}
+                    current["peer_delivery"] = peer_delivery
+                    return _save_chat_publish_record(current)
+                recent_publish_records = iter_chat_publishes_since(now - PEER_ROOT_WINDOW_SECONDS)
+                minute_count = _count_matching_publishes(
+                    binding_id=binding_id,
+                    root_ingress_receipt_id="",
+                    source_session_name=source_session_name,
+                    source_event_kind=PEER_PUBLICATION_EVENT_KIND,
+                    since_epoch=now - PEER_ROOT_WINDOW_SECONDS,
+                    exclude_publish_id=publish_id,
+                    records=recent_publish_records,
+                )
+                if minute_count >= int(policy.get("max_peer_triggered_publishes_per_session_per_minute", 0) or 0):
+                    peer_delivery["phase"] = "peer_fanout_complete"
+                    peer_delivery["status"] = "skipped_rate_limited"
+                    peer_delivery["budget_snapshot"] = {"peer_triggered_publishes_per_session_per_minute": minute_count}
+                    current["peer_delivery"] = peer_delivery
+                    return _save_chat_publish_record(current)
+
+            targets, delivery, resolve_reason, mentions = _resolve_peer_targets(
+                binding,
+                body=str(current.get("body", "")),
+                source_session_name=source_session_name,
+                source_session_id=source_session_id,
+                source_event_kind=source_meta.get("source_event_kind", ""),
+                launch=launch_record,
+            )
+            peer_delivery["delivery"] = delivery
+            peer_delivery["mentioned_session_names"] = mentions
+            if resolve_reason:
+                peer_delivery["phase"] = "peer_fanout_partial_failure" if resolve_reason.startswith("failed_") else "peer_fanout_complete"
+                peer_delivery["status"] = resolve_reason
+                current["peer_delivery"] = peer_delivery
+                return _save_chat_publish_record(current)
+
+            # Peer delivery also targets the configured selectors directly so
+            # sleeping or reserved named sessions still receive the publication.
+            resolved_targets: list[tuple[str, str]] = []
+            for session_name in targets:
+                target_key = str(session_name).strip()
+                if not target_key:
+                    continue
+                delivery_selector = target_key
+                if launch_record:
+                    resolved_target_selector, participant, _identity = resolve_room_launch_target_selector(launch_record, target_key)
+                    delivery_selector = (
+                        str(resolved_target_selector).strip()
+                        or str((participant or {}).get("delivery_selector", "")).strip()
+                        or str((participant or {}).get("session_name", "")).strip()
+                        or str((participant or {}).get("session_id", "")).strip()
+                        or str((participant or {}).get("session_alias", "")).strip()
+                        or target_key
+                    )
+                resolved_targets.append((target_key, delivery_selector))
+
+            if not resolved_targets:
+                peer_delivery["phase"] = "peer_fanout_complete"
+                peer_delivery["status"] = "skipped_no_peer_targets"
+                current["peer_delivery"] = peer_delivery
+                return _save_chat_publish_record(current)
+
+            total_peer_deliveries = _count_root_peer_deliveries_from_index(binding_id, root_ingress_receipt_id)
+            projected = total_peer_deliveries + len(resolved_targets)
+            peer_delivery["budget_snapshot"] = {
+                "root_ingress_receipt_id": root_ingress_receipt_id,
+                "existing_peer_deliveries_for_root": total_peer_deliveries,
+                "projected_peer_deliveries_for_root": projected,
+            }
+            max_total = int(policy.get("max_total_peer_deliveries_per_root", 0) or 0)
+            if max_total and projected > max_total:
+                peer_delivery["phase"] = "peer_fanout_complete"
+                peer_delivery["status"] = "skipped_budget_exhausted"
+                current["peer_delivery"] = peer_delivery
+                return _save_chat_publish_record(current)
+
+            peer_delivery["frozen_targets"] = [delivery_selector for _target_key, delivery_selector in resolved_targets]
+            peer_delivery["phase"] = "peer_fanout_in_progress"
+            for target_key, delivery_selector in resolved_targets:
+                _update_peer_target(
+                    peer_delivery,
+                    target_key,
+                    {
+                        "status": "pending",
+                        "attempt_count": 0,
+                        "attempted_at": "",
+                        "delivery_selector": delivery_selector,
+                        "attempts": [],
+                    },
+                )
+            current["peer_delivery"] = peer_delivery
+            current = _save_chat_publish_record(current)
+            delivery_targets = list(resolved_targets)
+            delivery_mode = delivery
+            delivery_mentions = list(mentions)
+
+    for target_key, delivery_selector in delivery_targets:
+        idempotency_key = f"peer_publish:{publish_id}:binding:{binding_id}:target:{target_key}"
+        current, _ = _update_target_in_progress(
+            publish_id=publish_id,
+            fallback_record=current,
+            session_name=target_key,
+            idempotency_key=idempotency_key,
+        )
+        envelope = _build_peer_envelope(
+            binding=binding,
+            record=current,
+            source_session_name=source_session_name,
+            source_session_id=source_session_id,
+            target_session_name=delivery_selector,
+            delivery=delivery_mode,
+            mentioned_session_names=delivery_mentions,
+            root_ingress_receipt_id=root_ingress_receipt_id,
+            idempotency_key=idempotency_key,
+            launch=launch_record,
+        )
+        try:
+            response = deliver_session_message(
+                delivery_selector,
+                envelope,
+                idempotency_key=idempotency_key,
+                timeout=PEER_DELIVERY_TIMEOUT_SECONDS,
+            )
+        except GCAPIError as exc:
+            current = _update_target_delivery_result(
+                publish_id=publish_id,
+                fallback_record=current,
+                session_name=target_key,
+                error=str(exc),
+            )
+            continue
+        current = _update_target_delivery_result(
+            publish_id=publish_id,
+            fallback_record=current,
+            session_name=target_key,
+            response=response,
+        )
+
+    with advisory_lock(_safe_lock_name("chat-publish", publish_id)):
+        current = load_chat_publish(publish_id) or current
+        current, stale_changed = _promote_stale_in_progress_targets(current)
+        if stale_changed:
+            current = _save_chat_publish_record(current)
+        current = _finalize_peer_delivery(current)
+        return _save_chat_publish_record(current)
+
+
+def retry_peer_fanout(
+    publish_id: str,
+    *,
+    include_unknown: bool = False,
+    target_session_names: list[str] | None = None,
+) -> dict[str, Any]:
+    record = load_chat_publish(publish_id)
+    if not record:
+        raise ValueError(f"publish not found: {publish_id}")
+    binding_id = str(record.get("binding_id", "")).strip()
+    binding = resolve_publish_route(load_config(), binding_id)
+    if not binding:
+        raise ValueError(f"binding not found: {binding_id}")
+    launch_record = None
+    launch_id = str(record.get("launch_id", "")).strip()
+    if launch_id:
+        launch_record = load_room_launch(launch_id)
+    retry_targets: list[tuple[str, str, str, str, list[str], str, str, str]] = []
+    with advisory_lock(_safe_lock_name("chat-publish", publish_id)):
+        current = load_chat_publish(publish_id) or record
+        current, changed = _promote_stale_in_progress_targets(current)
+        if changed:
+            current = _save_chat_publish_record(current)
+        peer_delivery = _peer_delivery_payload(current)
+        eligible = {"failed_retryable"}
+        if include_unknown:
+            eligible.add("delivery_unknown")
+        selected = {str(item).strip() for item in (target_session_names or []) if str(item).strip()}
+        delivery = str(peer_delivery.get("delivery", "")).strip() or "targeted"
+        mentioned_session_names = [str(item).strip() for item in peer_delivery.get("mentioned_session_names", []) if str(item).strip()]
+        root_ingress_receipt_id = str(current.get("root_ingress_receipt_id", "")).strip()
+        source_session_name = str(current.get("source_session_name", "")).strip()
+        source_session_id = str(current.get("source_session_id", "")).strip()
+        for entry in peer_delivery.get("targets", []):
+            if not isinstance(entry, dict):
+                continue
+            session_name = str(entry.get("session_name", "")).strip()
+            target_selector = str(entry.get("delivery_selector", "")).strip() or session_name
+            if launch_record:
+                resolved_name, _participant, _identity = resolve_room_launch_target_selector(launch_record, session_name)
+                if resolved_name:
+                    target_selector = resolved_name
+            if selected and session_name not in selected:
+                continue
+            if str(entry.get("status", "")).strip() not in eligible:
+                continue
+            idempotency_key = str(entry.get("idempotency_key", "")).strip()
+            if not idempotency_key:
+                idempotency_key = f"peer_publish:{publish_id}:binding:{binding_id}:target:{session_name}"
+            attempts = list(entry.get("attempts", []))
+            attempts.append(_peer_attempt(session_name, "retrying"))
+            _update_peer_target(
+                peer_delivery,
+                session_name,
+                {
+                    "status": "in_progress",
+                    "attempt_count": int(entry.get("attempt_count", 0) or 0) + 1,
+                    "attempted_at": utcnow(),
+                    "idempotency_key": idempotency_key,
+                    "delivery_selector": target_selector,
+                    "attempts": attempts,
+                },
+            )
+            retry_targets.append(
+                (
+                    session_name,
+                    target_selector,
+                    idempotency_key,
+                    delivery,
+                    mentioned_session_names,
+                    root_ingress_receipt_id,
+                    source_session_name,
+                    source_session_id,
+                )
+            )
+        current["peer_delivery"] = peer_delivery
+        current = _save_chat_publish_record(current)
+
+    for session_name, target_selector, idempotency_key, delivery, mentioned_session_names, root_ingress_receipt_id, source_session_name, source_session_id in retry_targets:
+        envelope = _build_peer_envelope(
+            binding=binding,
+            record=current,
+            source_session_name=source_session_name,
+            source_session_id=source_session_id,
+            target_session_name=target_selector,
+            delivery=delivery,
+            mentioned_session_names=mentioned_session_names,
+            root_ingress_receipt_id=root_ingress_receipt_id,
+            idempotency_key=idempotency_key,
+            launch=launch_record,
+        )
+        try:
+            response = deliver_session_message(
+                target_selector,
+                envelope,
+                idempotency_key=idempotency_key,
+                timeout=PEER_DELIVERY_TIMEOUT_SECONDS,
+            )
+        except GCAPIError as exc:
+            current = _update_target_delivery_result(
+                publish_id=publish_id,
+                fallback_record=current,
+                session_name=session_name,
+                error=str(exc),
+            )
+            continue
+        current = _update_target_delivery_result(
+            publish_id=publish_id,
+            fallback_record=current,
+            session_name=session_name,
+            response=response,
+        )
+    with advisory_lock(_safe_lock_name("chat-publish", publish_id)):
+        current = load_chat_publish(publish_id) or current
+        current, changed = _promote_stale_in_progress_targets(current)
+        if changed:
+            current = _save_chat_publish_record(current)
+        current = _finalize_peer_delivery(current)
+        return _save_chat_publish_record(current)
+
+
+def publish_binding_message(
+    binding: dict[str, Any],
+    body: str,
+    *,
+    requested_conversation_id: str = "",
+    trigger_id: str = "",
+    reply_to_message_id: str = "",
+    source_context: dict[str, str] | None = None,
+    source_session_name: str = "",
+    source_session_id: str = "",
+    file_ids: list[str] | None = None,
+) -> dict[str, Any]:
+    conversation_id, root_post_id, launch = resolve_publish_destination(
+        binding,
+        requested_conversation_id=requested_conversation_id,
+        trigger_id=trigger_id,
+        reply_to_message_id=reply_to_message_id,
+        source_context=source_context,
+    )
+    if not conversation_id:
+        raise ValueError("binding is missing a destination conversation_id")
+    response = post_channel_message(
+        conversation_id,
+        body,
+        root_id=root_post_id,
+        file_ids=file_ids,
+    )
+    remote_message_id = str((response or {}).get("id", "")).strip()
+    if not remote_message_id:
+        raise MattermostAPIError("mattermost publish returned no post id")
+    source_meta = _derive_publish_source_metadata(source_context)
+    resolved_source_identity: dict[str, str] = {}
+    source_selector = str(source_session_name).strip() or str(source_session_id).strip() or current_session_selector()
+    if source_selector and (not str(source_session_name).strip() or not str(source_session_id).strip()):
+        try:
+            resolved_source_identity = resolve_session_identity(source_selector)
+        except GCAPIError:
+            resolved_source_identity = {}
+    effective_source_session_name = (
+        str(source_session_name).strip()
+        or str(resolved_source_identity.get("session_name", "")).strip()
+        or str(os.environ.get("GC_SESSION_NAME", "")).strip()
+    )
+    effective_source_session_id = (
+        str(source_session_id).strip()
+        or str(resolved_source_identity.get("session_id", "")).strip()
+        or str(os.environ.get("GC_SESSION_ID", "")).strip()
+    )
+    effective_source_qualified_handle = room_launch_participant_handle_for_session(
+        launch or {},
+        session_name=effective_source_session_name,
+        session_id=effective_source_session_id,
+    )
+    record = save_chat_publish(
+        {
+            "binding_id": str(binding.get("id", "")).strip(),
+            "binding_kind": str(binding.get("kind", "")).strip(),
+            "binding_conversation_id": str(binding.get("conversation_id", "")).strip(),
+            "conversation_id": conversation_id,
+            "team_id": str(binding.get("team_id", "")).strip(),
+            "trigger_id": str(trigger_id).strip(),
+            "root_post_id": root_post_id,
+            "source_session_id": effective_source_session_id,
+            "source_session_name": effective_source_session_name,
+            "source_qualified_handle": effective_source_qualified_handle,
+            "source_event_kind": source_meta.get("source_event_kind", ""),
+            "root_ingress_receipt_id": source_meta.get("root_ingress_receipt_id", ""),
+            "launch_id": source_meta.get("launch_id", ""),
+            "launch_root_post_id": str((launch or {}).get("root_post_id", "")).strip(),
+            "body": body,
+            "remote_message_id": remote_message_id,
+        }
+    )
+    launch_record = launch
+    if launch_record is None and str(source_meta.get("launch_id", "")).strip():
+        launch_record = load_room_launch(str(source_meta.get("launch_id", "")).strip())
+    launch_root_post_id = str((launch_record or {}).get("root_post_id", "")).strip()
+    launch_record_id = str((launch_record or {}).get("launch_id", "")).strip() or str(source_meta.get("launch_id", "")).strip()
+    if launch_record_id and launch_root_post_id and root_post_id == launch_root_post_id:
+        record_room_launch_message_target(
+            launch_record_id,
+            remote_message_id,
+            source_session_name=effective_source_session_name,
+            source_session_id=effective_source_session_id,
+        )
+    # Peer notification is now handled by the extmsg outbound orchestrator
+    # via transcript membership — no pack-side fanout needed.
+    return {"binding": binding, "record": record, "response": response}
+
+
+def deliver_session_message(
+    session_name: str,
+    message: str,
+    idempotency_key: str = "",
+    timeout: float = GC_API_REQUEST_TIMEOUT_SECONDS,
+    *,
+    intent: str = "default",
+) -> dict[str, Any]:
+    headers: dict[str, str] = {}
+    key = str(idempotency_key).strip()
+    if key:
+        headers["Idempotency-Key"] = key
+    normalized_intent = str(intent or "default").strip() or "default"
+    path = f"/v0/session/{urllib.parse.quote(str(session_name).strip(), safe='')}/messages"
+    payload_body: dict[str, Any] = {"message": message}
+    if normalized_intent != "default":
+        path = f"/v0/session/{urllib.parse.quote(str(session_name).strip(), safe='')}/submit"
+        payload_body["intent"] = normalized_intent
+    payload = gc_api_request(
+        "POST",
+        path,
+        payload=payload_body,
+        headers=headers,
+        timeout=timeout,
+    )
+    if not isinstance(payload, dict):
+        return {}
+    return payload
+
+
+def command_name(config: dict[str, Any]) -> str:
+    return str(normalize_config(config).get("app", {}).get("command_name", COMMAND_NAME_DEFAULT)).strip() or COMMAND_NAME_DEFAULT
+
+
+def build_command_payload(command_name_value: str, team_id: str, url: str = "") -> dict[str, Any]:
+    return {
+        "team_id": str(team_id).strip(),
+        "trigger": str(command_name_value).strip().lstrip("/") or COMMAND_NAME_DEFAULT,
+        "method": "P",
+        "url": str(url).strip() or command_callback_url(),
+        "display_name": "GC",
+        "description": "GC workspace actions",
+        "auto_complete": True,
+        "auto_complete_desc": "Create a GC fix workflow",
+        "auto_complete_hint": "fix [rig] [prompt]",
+        "username": "gc",
+    }
+
+
+def list_team_commands(team_id: str, *, custom_only: bool = True) -> list[dict[str, Any]]:
+    # custom_only=true is required for the response to carry command tokens;
+    # the default listing path sanitizes them away.
+    query = urllib.parse.urlencode({"team_id": str(team_id).strip(), "custom_only": "true" if custom_only else "false"})
+    payload = mattermost_api_request("GET", f"/commands?{query}")
+    if not isinstance(payload, list):
+        return []
+    return [item for item in payload if isinstance(item, dict)]
+
+
+def sync_team_commands(config: dict[str, Any], team_id: str, *, url: str = "") -> Any:
+    cfg = normalize_config(config)
+    normalized_team_id = str(team_id).strip() or str(cfg.get("app", {}).get("team_id", "")).strip()
+    if not normalized_team_id:
+        raise MattermostAPIError("Mattermost team_id is not configured")
+    callback_url = str(url).strip() or command_callback_url()
+    if not callback_url:
+        raise MattermostAPIError("interactions service URL is not published yet")
+    trigger = command_name(cfg)
+    payload = build_command_payload(trigger, normalized_team_id, callback_url)
+    existing = next(
+        (item for item in list_team_commands(normalized_team_id) if str(item.get("trigger", "")).strip() == trigger),
+        None,
+    )
+    if existing:
+        body = dict(existing)
+        body.update(payload)
+        command = mattermost_api_request("PUT", f"/commands/{urllib.parse.quote(str(existing.get('id', '')))}", payload=body)
+    else:
+        command = mattermost_api_request("POST", "/commands", payload=payload)
+    if isinstance(command, dict):
+        token = str(command.get("token", "")).strip()
+        if token:
+            save_command_token(token)
+        command_id = str(command.get("id", "")).strip()
+        if command_id:
+            cfg.setdefault("app", {})["command_id"] = command_id
+            cfg["app"]["team_id"] = normalized_team_id
+            save_config(cfg)
+    return command
+
+
+def regenerate_command_token(command_id: str) -> str:
+    payload = mattermost_api_request("PUT", f"/commands/{urllib.parse.quote(str(command_id).strip())}/regen_token")
+    token = str((payload or {}).get("token", "")).strip()
+    if token:
+        save_command_token(token)
+    return token
+
+
+def post_channel_message(
+    channel_id: str,
+    body: str,
+    root_id: str = "",
+    *,
+    file_ids: list[str] | None = None,
+    props: dict[str, Any] | None = None,
+) -> Any:
+    payload: dict[str, Any] = {
+        "channel_id": str(channel_id).strip(),
+        "message": body,
+    }
+    normalized_root_id = str(root_id).strip()
+    if normalized_root_id:
+        payload["root_id"] = normalized_root_id
+    normalized_file_ids = [str(item).strip() for item in (file_ids or []) if str(item).strip()]
+    if normalized_file_ids:
+        # Mattermost rejects posts carrying more than 5 attachments.
+        payload["file_ids"] = normalized_file_ids[:5]
+    if isinstance(props, dict) and props:
+        payload["props"] = props
+    return mattermost_api_request("POST", "/posts", payload=payload)
+
+
+def create_direct_channel(user_id: str, other_user_id: str) -> dict[str, Any]:
+    payload = mattermost_api_request("POST", "/channels/direct", payload=[str(user_id).strip(), str(other_user_id).strip()])
+    if isinstance(payload, dict):
+        return payload
+    return {}
+
+
+def create_group_channel(user_ids: list[str]) -> dict[str, Any]:
+    normalized = [str(item).strip() for item in user_ids if str(item).strip()]
+    payload = mattermost_api_request("POST", "/channels/group", payload=normalized)
+    if isinstance(payload, dict):
+        return payload
+    return {}
+
+
+def resolve_bot_user_id(config: dict[str, Any] | None = None) -> str:
+    cfg = normalize_config(config) if config is not None else load_config()
+    configured = str(cfg.get("app", {}).get("bot_user_id", "")).strip()
+    if configured:
+        return configured
+    me = mattermost_api_request("GET", "/users/me")
+    if isinstance(me, dict):
+        return str(me.get("id", "")).strip()
+    return ""
+
+
+def describe_user(user_id: str) -> dict[str, Any]:
+    payload = mattermost_api_request("GET", f"/users/{urllib.parse.quote(str(user_id).strip())}")
+    if isinstance(payload, dict):
+        return payload
+    return {}
+
+
+def describe_channel_member(channel_id: str, user_id: str) -> dict[str, Any]:
+    try:
+        payload = mattermost_api_request(
+            "GET",
+            f"/channels/{urllib.parse.quote(str(channel_id).strip())}/members/{urllib.parse.quote(str(user_id).strip())}",
+        )
+    except MattermostAPIError as exc:
+        if exc.status_code == 404:
+            return {}
+        raise
+    if isinstance(payload, dict):
+        return payload
+    return {}
+
+
+def channel_member_roles(channel_id: str, user_id: str) -> list[str]:
+    member = describe_channel_member(channel_id, user_id)
+    if not member:
+        return []
+    return [role for role in str(member.get("roles", "")).split() if role]
+
+
+def describe_team_member(team_id: str, user_id: str) -> dict[str, Any]:
+    try:
+        payload = mattermost_api_request(
+            "GET",
+            f"/teams/{urllib.parse.quote(str(team_id).strip())}/members/{urllib.parse.quote(str(user_id).strip())}",
+        )
+    except MattermostAPIError as exc:
+        if exc.status_code == 404:
+            return {}
+        raise
+    if isinstance(payload, dict):
+        return payload
+    return {}
+
+
+def normalize_emoji_name(value: str) -> str:
+    return str(value).strip().strip(":").strip()
+
+
+def add_message_reaction(post_id: str, emoji_name: str, *, user_id: str = "") -> dict[str, Any]:
+    actor_id = str(user_id).strip() or resolve_bot_user_id()
+    if not actor_id:
+        raise MattermostAPIError("bot user id is required to react")
+    payload = mattermost_api_request(
+        "POST",
+        "/reactions",
+        payload={
+            "user_id": actor_id,
+            "post_id": str(post_id).strip(),
+            "emoji_name": normalize_emoji_name(emoji_name),
+        },
+    )
+    if isinstance(payload, dict):
+        return payload
+    return {}
+
+
+def remove_message_reaction(post_id: str, emoji_name: str, *, user_id: str = "") -> bool:
+    actor_id = str(user_id).strip() or resolve_bot_user_id()
+    if not actor_id:
+        raise MattermostAPIError("bot user id is required to remove a reaction")
+    mattermost_api_request(
+        "DELETE",
+        "/users/{user}/posts/{post}/reactions/{emoji}".format(
+            user=urllib.parse.quote(actor_id),
+            post=urllib.parse.quote(str(post_id).strip()),
+            emoji=urllib.parse.quote(normalize_emoji_name(emoji_name)),
+        ),
+    )
+    return True
+
+
+def upload_files(channel_id: str, paths: list[str]) -> list[dict[str, Any]]:
+    normalized_channel_id = str(channel_id).strip()
+    if not normalized_channel_id:
+        raise ValueError("channel_id is required")
+    file_infos: list[dict[str, Any]] = []
+    for path in paths:
+        with open(path, "rb") as handle:
+            content = handle.read()
+        payload = mattermost_upload_request(
+            "/files",
+            [("channel_id", normalized_channel_id)],
+            [("files", str(path), content)],
+        )
+        infos = (payload or {}).get("file_infos")
+        if isinstance(infos, list):
+            file_infos.extend([item for item in infos if isinstance(item, dict)])
+    return file_infos
+
+
+def upload_and_post_files(channel_id: str, paths: list[str], body: str = "", *, root_id: str = "") -> Any:
+    file_infos = upload_files(channel_id, paths)
+    file_ids = [str(item.get("id", "")).strip() for item in file_infos if str(item.get("id", "")).strip()]
+    return post_channel_message(channel_id, body, root_id=root_id, file_ids=file_ids)
+
+
+def mattermost_permalink(team_name: str, post_id: str) -> str:
+    site_url = mattermost_site_url()
+    team = str(team_name).strip()
+    post = str(post_id).strip()
+    if not site_url or not team or not post:
+        return ""
+    return f"{site_url}/{urllib.parse.quote(team)}/pl/{urllib.parse.quote(post)}"
+
+
+def mattermost_channel_url(team_name: str, channel_name: str) -> str:
+    site_url = mattermost_site_url()
+    team = str(team_name).strip()
+    channel = str(channel_name).strip()
+    if not site_url or not team or not channel:
+        return ""
+    return f"{site_url}/{urllib.parse.quote(team)}/channels/{urllib.parse.quote(channel)}"
+
+
+def policy_reason(config: dict[str, Any], team_id: str, channel_id: str, channel_roles: list[str] | str | None = None) -> str:
+    normalized = normalize_config(config)
+    policy = normalized.get("policy", {})
+    team_allowlist = set(_normalize_allowlist(policy.get("team_allowlist")))
+    channel_allowlist = set(_normalize_allowlist(policy.get("channel_allowlist")))
+    role_allowlist = set(_normalize_allowlist(policy.get("channel_role_allowlist")))
+    if team_allowlist and team_id not in team_allowlist:
+        return "team_not_allowed"
+    if channel_allowlist and channel_id not in channel_allowlist:
+        return "channel_not_allowed"
+    if role_allowlist:
+        if isinstance(channel_roles, str):
+            roles = {role for role in channel_roles.split() if role}
+        else:
+            roles = {str(role).strip() for role in (channel_roles or []) if str(role).strip()}
+        if not roles:
+            return "channel_membership_required"
+        if not role_allowlist.intersection(roles):
+            return "channel_role_not_allowed"
+    return ""

--- a/mattermost/scripts/mattermost_intake_common.py
+++ b/mattermost/scripts/mattermost_intake_common.py
@@ -405,6 +405,11 @@ def normalize_config(raw: dict[str, Any] | None) -> dict[str, Any]:
                     normalized_bindings[binding_id].update(channel_metadata)
                 if kind == "room":
                     normalized_bindings[binding_id]["policy"] = normalize_room_peer_policy(value.get("policy"))
+                elif isinstance(value.get("policy"), dict) and value.get("policy"):
+                    # Non-room bindings don't carry the full room peer-policy
+                    # surface, but a simple override (e.g. thread_replies)
+                    # applies to any kind and must survive normalization too.
+                    normalized_bindings[binding_id]["policy"] = normalize_room_peer_policy(value.get("policy"))
         launchers = chat.get("launchers")
         if isinstance(launchers, dict):
             for key, value in launchers.items():
@@ -539,6 +544,10 @@ def default_room_peer_policy() -> dict[str, Any]:
         "max_peer_triggered_publishes_per_root": 1,
         "max_total_peer_deliveries_per_root": 8,
         "max_peer_triggered_publishes_per_session_per_minute": 5,
+        # Default True preserves existing behavior (replies thread under the
+        # message they're answering). Set False via bind-room/bind-dm
+        # --disable-thread-replies to force flat, top-level replies instead.
+        "thread_replies": True,
     }
 
 
@@ -560,6 +569,7 @@ def _normalize_peer_policy(policy: dict[str, Any] | None, defaults: dict[str, An
         "allow_untargeted_peer_fanout": _coerce_bool(
             raw.get("allow_untargeted_peer_fanout"), defaults["allow_untargeted_peer_fanout"]
         ),
+        "thread_replies": _coerce_bool(raw.get("thread_replies"), defaults.get("thread_replies", True)),
         "max_peer_triggered_publishes_per_root": max(
             0, int(raw.get("max_peer_triggered_publishes_per_root", defaults["max_peer_triggered_publishes_per_root"]) or 0)
         ),
@@ -589,7 +599,10 @@ def normalize_room_launch_peer_policy(policy: dict[str, Any] | None = None) -> d
 
 def binding_peer_policy(binding: dict[str, Any]) -> dict[str, Any]:
     if str(binding.get("kind", "")).strip() != "room":
-        return default_room_peer_policy()
+        # DM (and any future non-room) bindings only ever carry a minimal
+        # override subset (e.g. thread_replies) via set_chat_binding, but
+        # still deserve to have it respected rather than silently dropped.
+        return normalize_room_peer_policy(binding.get("policy"))
     if str(binding.get("publish_route_kind", "")).strip() == "room_launch" or str(binding.get("id", "")).strip().startswith(
         "launch-room:"
     ):
@@ -850,6 +863,11 @@ def set_chat_binding(
     if normalized_kind == "room":
         if raw_channel_metadata:
             binding.update(raw_channel_metadata)
+        binding["policy"] = room_policy
+    elif isinstance(policy, dict) and policy:
+        # Non-room bindings don't carry the full room peer-policy surface
+        # (ambient read / peer fanout are room-only concepts), but a simple
+        # override like thread_replies applies to any binding kind.
         binding["policy"] = room_policy
     cfg["chat"]["bindings"][binding_id] = binding
     return save_config(cfg)
@@ -4411,6 +4429,8 @@ def resolve_publish_destination(
         # message it's replying to.
         if binding_root_id:
             root_post_id = binding_root_id
+        elif not binding_peer_policy(binding).get("thread_replies", True):
+            root_post_id = ""
         else:
             root_post_id = resolve_thread_root_id(conversation_id, reply_target) if reply_target else ""
         return conversation_id, root_post_id, None

--- a/mattermost/scripts/mattermost_intake_import.py
+++ b/mattermost/scripts/mattermost_intake_import.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+
+import mattermost_intake_common as common
+
+
+def _read_optional_file(path: str | None) -> str:
+    if not path:
+        return ""
+    return pathlib.Path(path).read_text(encoding="utf-8").strip()
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Import Mattermost server metadata into the Mattermost pack")
+    parser.add_argument("--server-url", required=True, help="Mattermost server base URL, e.g. https://mattermost.example.com")
+    parser.add_argument("--command-name", default=common.COMMAND_NAME_DEFAULT, help="Slash command root name")
+    parser.add_argument("--bot-token", default="", help="Mattermost bot personal access token")
+    parser.add_argument("--bot-token-file", default="", help="Read the Mattermost bot token from a file")
+    parser.add_argument("--verification-token", default="", help="Slash command verification token")
+    parser.add_argument("--verification-token-file", default="", help="Read the verification token from a file")
+    parser.add_argument("--team-allowlist", action="append", default=[], help="Optional allowed team id")
+    parser.add_argument("--channel-allowlist", action="append", default=[], help="Optional allowed channel id")
+    parser.add_argument("--role-allowlist", action="append", default=[], help="Optional allowed Mattermost role name")
+    args = parser.parse_args(argv)
+
+    bot_token = args.bot_token.strip() or _read_optional_file(args.bot_token_file)
+    verification_token = args.verification_token.strip() or _read_optional_file(args.verification_token_file)
+    try:
+        if verification_token:
+            verification_token = common.validate_command_token(verification_token)
+        config = common.import_app_config(
+            common.load_config(),
+            {
+                "site_url": args.server_url,
+                "command_name": args.command_name,
+                "team_allowlist": args.team_allowlist,
+                "channel_allowlist": args.channel_allowlist,
+                "channel_role_allowlist": args.role_allowlist,
+            },
+        )
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
+    if bot_token:
+        common.save_bot_token(bot_token)
+    if verification_token:
+        common.save_command_token(verification_token)
+    print(json.dumps(common.redact_config(config), indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/mattermost/scripts/mattermost_intake_map_channel.py
+++ b/mattermost/scripts/mattermost_intake_map_channel.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+import mattermost_intake_common as common
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Map a Mattermost channel to a workflow target")
+    parser.add_argument("team_id", help="Mattermost team id")
+    parser.add_argument("channel_id", help="Mattermost channel id")
+    parser.add_argument("target", help="gc sling target, usually rig/pool")
+    parser.add_argument("--fix-formula", default=common.FIX_FORMULA_DEFAULT, help="Formula for /gc fix")
+    args = parser.parse_args(argv)
+
+    try:
+        config = common.set_channel_mapping(
+            common.load_config(),
+            args.team_id,
+            args.channel_id,
+            args.target,
+            args.fix_formula,
+        )
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
+    key = common.normalize_channel_key(args.team_id, args.channel_id)
+    print(json.dumps(config["channels"][key], indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/mattermost/scripts/mattermost_intake_map_rig.py
+++ b/mattermost/scripts/mattermost_intake_map_rig.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+import mattermost_intake_common as common
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Map a Mattermost team rig name to a workflow target")
+    parser.add_argument("team_id", help="Mattermost team id")
+    parser.add_argument("rig_name", help="Rig name used in /gc fix <rig>")
+    parser.add_argument("target", help="gc sling target, usually rig/pool")
+    parser.add_argument("--fix-formula", default=common.FIX_FORMULA_DEFAULT, help="Formula for /gc fix")
+    args = parser.parse_args(argv)
+
+    try:
+        config = common.set_rig_mapping(
+            common.load_config(),
+            args.team_id,
+            args.rig_name,
+            args.target,
+            args.fix_formula,
+        )
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
+    key = common.normalize_rig_key(args.team_id, args.rig_name)
+    print(json.dumps(config["rigs"][key], indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/mattermost/scripts/mattermost_intake_post_message.py
+++ b/mattermost/scripts/mattermost_intake_post_message.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+
+import mattermost_intake_common as common
+
+
+def _load_body(args: argparse.Namespace) -> str:
+    if args.body:
+        return args.body
+    if args.body_file:
+        return pathlib.Path(args.body_file).read_text(encoding="utf-8")
+    raise SystemExit("either --body or --body-file is required")
+
+
+def _resolve_target(args: argparse.Namespace) -> tuple[str, str]:
+    if args.request_id:
+        request = common.load_request(args.request_id)
+        if not request:
+            raise SystemExit(f"request not found: {args.request_id}")
+        channel_id = str(request.get("channel_id", "")).strip() or str(request.get("conversation_id", "")).strip()
+        if not channel_id:
+            raise SystemExit(f"request has no message target: {args.request_id}")
+        root_id = args.root_id.strip() or str(request.get("root_id", "")).strip()
+        return channel_id, root_id
+    if args.channel_id:
+        return args.channel_id, args.root_id.strip()
+    raise SystemExit("either --request-id or --channel-id is required")
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Post a message using the Mattermost workspace bot")
+    parser.add_argument("--request-id", default="", help="Saved request id to route back to the original conversation")
+    parser.add_argument("--channel-id", default="", help="Mattermost channel id")
+    parser.add_argument("--root-id", default="", help="Mattermost thread root post id")
+    parser.add_argument("--body", default="", help="Inline message body")
+    parser.add_argument("--body-file", default="", help="Read the message body from a file")
+    args = parser.parse_args(argv)
+
+    target_channel, root_id = _resolve_target(args)
+    body = _load_body(args)
+    try:
+        response = common.post_channel_message(target_channel, body, root_id)
+    except common.MattermostAPIError as exc:
+        raise SystemExit(str(exc)) from exc
+    print(json.dumps(response, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/mattermost/scripts/mattermost_intake_release_workflow.py
+++ b/mattermost/scripts/mattermost_intake_release_workflow.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+
+import mattermost_intake_common as common
+
+
+def workflow_key_from_args(args: argparse.Namespace) -> tuple[str, str]:
+    if args.request_id:
+        request = common.load_request(args.request_id)
+        if not request:
+            raise SystemExit(f"request not found: {args.request_id}")
+        workflow_key = str(request.get("workflow_key", "")).strip()
+        if not workflow_key:
+            raise SystemExit(f"request has no workflow key: {args.request_id}")
+        return workflow_key, str(request.get("request_id", "")).strip()
+    if not args.team_id or not args.conversation_id:
+        raise SystemExit("either --request-id or <team_id> <conversation_id> is required")
+    workflow_key = common.build_workflow_key(args.team_id, args.conversation_id, args.command)
+    linked = common.load_workflow_link(workflow_key) or {}
+    return workflow_key, str(linked.get("request_id", "")).strip()
+
+
+def release_matching_workflows(workflow_prefix: str) -> tuple[bool, list[str]]:
+    released_keys: list[str] = []
+    for path in pathlib.Path(common.workflows_dir()).glob("*.json"):
+        payload = common.read_json(str(path), {}, allow_invalid=True)
+        if not isinstance(payload, dict):
+            continue
+        workflow_key = str(payload.get("workflow_key", "")).strip()
+        if workflow_key != workflow_prefix and not workflow_key.startswith(workflow_prefix + ":rig:"):
+            continue
+        common.remove_workflow_link(workflow_key)
+        released_keys.append(workflow_key)
+    return bool(released_keys), released_keys
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Release a stuck Mattermost workflow lock")
+    parser.add_argument("team_id", nargs="?", help="Mattermost team id")
+    parser.add_argument("conversation_id", nargs="?", help="Mattermost conversation id (channel or channel plus thread root)")
+    parser.add_argument("--request-id", default="", help="Release the workflow key recorded on an existing request")
+    parser.add_argument("--command", default="fix", help="Slash command name, default: fix")
+    args = parser.parse_args(argv)
+
+    workflow_key, request_id = workflow_key_from_args(args)
+    exit_code = 0
+    if request_id:
+        released_ok = common.remove_workflow_link_if_request(workflow_key, request_id)
+        if not released_ok:
+            exit_code = 1
+    else:
+        released_ok, released_keys = release_matching_workflows(workflow_key)
+
+    released = {
+        "workflow_key": workflow_key,
+        "released": released_ok,
+    }
+    if not request_id:
+        released["released_keys"] = released_keys if released_ok else []
+    if request_id and released_ok:
+        request = common.load_request(request_id)
+        if request:
+            request["workflow_released_at"] = common.utcnow()
+            common.save_request(request)
+            released["request_id"] = request_id
+    print(json.dumps(released, indent=2, sort_keys=True))
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/mattermost/scripts/mattermost_intake_service.py
+++ b/mattermost/scripts/mattermost_intake_service.py
@@ -1,0 +1,1687 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import base64
+import calendar
+import html
+import json
+import os
+import pathlib
+import secrets
+import socketserver
+import subprocess
+import threading
+import time
+import traceback
+import urllib.parse
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler
+from typing import Any
+
+import mattermost_intake_common as common
+
+PROCESSING_LOCK = threading.Lock()
+ACCEPTANCE_LOCK = threading.Lock()
+DIALOG_SUBMIT_LOCK = threading.Lock()
+REQUEST_PRUNE_LOCK = threading.Lock()
+REQUEST_RECOVERY_LOCK = threading.Lock()
+PROCESSING_REQUESTS: set[str] = set()
+MAX_REQUEST_BYTES = 64 * 1024
+DISPATCHING_RECOVERY_GRACE_SECONDS = 10 * 60
+REQUEST_PRUNE_INTERVAL_SECONDS = 60
+REQUEST_RECOVERY_INTERVAL_SECONDS = 60
+DISPATCH_SUBPROCESS_TIMEOUT_SECONDS = 5 * 60
+LAST_REQUEST_PRUNE_AT = 0.0
+LAST_REQUEST_RECOVERY_AT = 0.0
+
+FIX_DIALOG_CALLBACK_ID = "gc_fix"
+FIX_DIALOG_TITLE = "GC Fix Request"
+# Mattermost caps dialog element display names at 24 characters and textarea
+# defaults/placeholders at 3000; see model/integration_action.go.
+FIX_SUMMARY_MIN_LENGTH = 4
+FIX_SUMMARY_MAX_LENGTH = 120
+FIX_CONTEXT_MAX_LENGTH = 3000
+
+
+class ThreadingUnixHTTPServer(socketserver.ThreadingMixIn, socketserver.UnixStreamServer):
+    daemon_threads = True
+
+
+class DispatchSubprocessTimeout(RuntimeError):
+    def __init__(self, command: list[str], timeout_seconds: float) -> None:
+        self.command = list(command)
+        self.timeout_seconds = timeout_seconds
+        super().__init__(f"command timed out after {timeout_seconds:g}s: {' '.join(self.command)}")
+
+
+def json_response(handler: BaseHTTPRequestHandler, status: int, payload: dict[str, Any]) -> None:
+    body = json.dumps(payload, indent=2, sort_keys=True).encode("utf-8") + b"\n"
+    handler.send_response(status)
+    handler.send_header("Content-Type", "application/json")
+    handler.send_header("Content-Length", str(len(body)))
+    handler.end_headers()
+    handler.wfile.write(body)
+
+
+def text_response(handler: BaseHTTPRequestHandler, status: int, body: str, content_type: str) -> None:
+    payload = body.encode("utf-8")
+    handler.send_response(status)
+    handler.send_header("Content-Type", content_type)
+    handler.send_header("Content-Length", str(len(payload)))
+    handler.end_headers()
+    handler.wfile.write(payload)
+
+
+def interaction_response(handler: BaseHTTPRequestHandler, payload: dict[str, Any]) -> None:
+    body = json.dumps(payload).encode("utf-8")
+    handler.send_response(HTTPStatus.OK)
+    handler.send_header("Content-Type", "application/json")
+    handler.send_header("Content-Length", str(len(body)))
+    handler.end_headers()
+    handler.wfile.write(body)
+
+
+def command_behavior(command: str) -> dict[str, Any]:
+    if command != "fix":
+        return {}
+    return {"workflow_scope": "conversation"}
+
+
+def trim_output(value: str, limit: int = 1200) -> str:
+    value = value.strip()
+    if len(value) <= limit:
+        return value
+    return value[:limit].rstrip() + "..."
+
+
+def human_reason(code: str) -> str:
+    mapping = {
+        "command_not_supported": "this Mattermost slice only supports /gc fix",
+        "channel_mapping_missing": "no channel mapping exists for this conversation",
+        "rig_mapping_missing": "no rig mapping exists for that rig in this team",
+        "command_not_configured": "this channel does not configure that /gc command",
+        "team_required": "Mattermost /gc fix is only accepted inside a team channel",
+        "team_not_allowed": "this team is not allowed to dispatch /gc fix",
+        "channel_not_allowed": "this channel is not allowed to dispatch /gc fix",
+        "channel_membership_required": "you must be a member of this channel to dispatch /gc fix",
+        "channel_role_not_allowed": "you do not have a Mattermost channel role that is allowed to dispatch /gc fix",
+        "mattermost_app_not_configured": "the Mattermost app is not fully configured in this workspace",
+        "bead_create_failed": "the workflow bead could not be created",
+        "bead_update_failed": "the workflow bead could not be initialized",
+        "gc_not_available": "the gc CLI is not available in this runtime",
+        "dispatch_timeout": "workflow dispatch timed out before it could finish",
+        "invalid_dispatch_target": "the configured target is not a rig-scoped sling target",
+        "rig_workdir_missing": "the rig is not routed to a local workspace directory",
+        "mattermost_lookup_failed": "Mattermost metadata lookup failed; retry in a moment",
+        "dialog_open_failed": "the /gc fix dialog could not be opened; retry in a moment",
+        "dialog_expired": "that dialog submission has expired; run /gc fix again",
+        "bad_dialog_context": "that dialog submission does not match the original slash command",
+        "summary_required": "a short summary is required before the workflow can start",
+        "internal_error": "an internal error occurred while starting the workflow",
+        "service_restarted_before_dispatch": "the Mattermost worker restarted before the workflow could be started",
+        "service_restarted_during_dispatch": "the Mattermost worker restarted during workflow dispatch",
+    }
+    return mapping.get(code, code or "unknown_error")
+
+
+def utc_age_seconds(value: str) -> float:
+    normalized = str(value).strip()
+    if not normalized:
+        return float("inf")
+    try:
+        parsed = time.strptime(normalized, "%Y-%m-%dT%H:%M:%SZ")
+    except ValueError:
+        return float("inf")
+    return max(time.time() - calendar.timegm(parsed), 0.0)
+
+
+def should_run_request_recovery() -> bool:
+    service_name = str(common.current_service_name() or "").strip()
+    return service_name in {"", common.INTERACTIONS_SERVICE_NAME}
+
+
+def maybe_prune_request_state() -> bool:
+    global LAST_REQUEST_PRUNE_AT
+    now = time.monotonic()
+    with REQUEST_PRUNE_LOCK:
+        if LAST_REQUEST_PRUNE_AT and (now - LAST_REQUEST_PRUNE_AT) < REQUEST_PRUNE_INTERVAL_SECONDS:
+            return False
+        LAST_REQUEST_PRUNE_AT = now
+    common.prune_requests()
+    common.prune_receipts()
+    common.prune_pending_modals()
+    return True
+
+
+def maybe_recover_request_state() -> bool:
+    global LAST_REQUEST_RECOVERY_AT
+    if not should_run_request_recovery():
+        return False
+    now = time.monotonic()
+    with REQUEST_RECOVERY_LOCK:
+        if LAST_REQUEST_RECOVERY_AT and (now - LAST_REQUEST_RECOVERY_AT) < REQUEST_RECOVERY_INTERVAL_SECONDS:
+            return False
+        LAST_REQUEST_RECOVERY_AT = now
+    recover_incomplete_requests()
+    return True
+
+
+def request_summary(request: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "request_id": request.get("request_id"),
+        "workflow_key": request.get("workflow_key", ""),
+        "status": request.get("status"),
+        "command": request.get("command"),
+        "team_id": request.get("team_id"),
+        "conversation_id": request.get("conversation_id"),
+        "bead_id": request.get("bead_id", ""),
+        "dispatch_target": request.get("dispatch_target", ""),
+        "dispatch_formula": request.get("dispatch_formula", ""),
+        "reason": request.get("reason", ""),
+    }
+
+
+def build_message_response(content: str, ephemeral: bool) -> dict[str, Any]:
+    # Mattermost slash-command responses are CommandResponse objects; the
+    # `response_type` field decides whether the post is user-only or public.
+    return {
+        "response_type": "ephemeral" if ephemeral else "in_channel",
+        "text": content,
+    }
+
+
+def build_dialog_ok_response() -> dict[str, Any]:
+    # An empty SubmitDialogResponse closes the dialog without an error banner.
+    return {}
+
+
+def build_dialog_error_response(reason: str, field: str = "") -> dict[str, Any]:
+    message = human_reason(reason)
+    if field:
+        return {"errors": {field: message}}
+    return {"error": message}
+
+
+def build_fix_dialog(state: str) -> dict[str, Any]:
+    return {
+        "callback_id": FIX_DIALOG_CALLBACK_ID,
+        "title": FIX_DIALOG_TITLE,
+        "introduction_text": "Describe the bug you want a GC worker session to fix.",
+        "submit_label": "Start workflow",
+        "notify_on_cancel": False,
+        "state": state,
+        "elements": [
+            {
+                "display_name": "Short summary",
+                "name": "summary",
+                "type": "text",
+                "subtype": "text",
+                "min_length": FIX_SUMMARY_MIN_LENGTH,
+                "max_length": FIX_SUMMARY_MAX_LENGTH,
+                "optional": False,
+                "placeholder": "What is broken?",
+            },
+            {
+                "display_name": "Additional context",
+                "name": "context",
+                "type": "textarea",
+                "max_length": FIX_CONTEXT_MAX_LENGTH,
+                "optional": True,
+                "placeholder": "Reproduction steps, links, logs, anything else useful.",
+            },
+        ],
+    }
+
+
+def open_fix_dialog(trigger_id: str, state: str) -> None:
+    """Open the /gc fix dialog. `trigger_id` is short lived, so call this first."""
+    url = common.dialog_callback_url()
+    if not url:
+        raise common.MattermostAPIError("interactions service URL is not published yet")
+    common.mattermost_api_request(
+        "POST",
+        "/actions/dialogs/open",
+        payload={
+            "trigger_id": str(trigger_id).strip(),
+            "url": url,
+            "dialog": build_fix_dialog(state),
+        },
+    )
+
+
+def build_acceptance_response(request: dict[str, Any]) -> dict[str, Any]:
+    return build_message_response(build_acceptance_message(request), ephemeral=False)
+
+
+def build_acceptance_message(request: dict[str, Any]) -> str:
+    summary = str(request.get("summary", "")).strip()
+    return "\n".join(
+        part
+        for part in (
+            "Accepted /gc fix for this conversation.",
+            f"Request: `{request.get('request_id', '')}`" if request.get("request_id") else "",
+            f"Summary: {summary}" if summary else "",
+        )
+        if part
+    )
+
+
+def build_duplicate_message(existing: dict[str, Any]) -> str:
+    content = "\n".join(
+        part
+        for part in (
+            "A /gc fix workflow is already active for this conversation.",
+            f"Request: `{existing.get('request_id', '')}`" if existing.get("request_id") else "",
+            f"Status: `{existing.get('status', '')}`" if existing.get("status") else "",
+            f"Bead: `{existing.get('bead_id', '')}`" if existing.get("bead_id") else "",
+        )
+        if part
+    )
+    return content or "A workflow is already active for this conversation."
+
+
+def build_duplicate_response(existing: dict[str, Any]) -> dict[str, Any]:
+    return build_message_response(build_duplicate_message(existing), ephemeral=True)
+
+
+def receipt_payload(response: dict[str, Any], response_kind: str = "", request_id: str = "") -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "response": response,
+    }
+    if response_kind:
+        payload["response_kind"] = response_kind
+    if request_id:
+        payload["request_id"] = request_id
+    return payload
+
+
+def prompt_to_summary_context(prompt: str) -> tuple[str, str]:
+    prompt = prompt.strip()
+    if not prompt:
+        return "", ""
+    lines = [line.strip() for line in prompt.splitlines()]
+    summary = next((line for line in lines if line), "")[:FIX_SUMMARY_MAX_LENGTH]
+    return summary, prompt
+
+
+def normalize_command_invocation(form: dict[str, str]) -> dict[str, str]:
+    """Normalize a Mattermost slash-command callback into a stable shape.
+
+    Mattermost POSTs `application/x-www-form-urlencoded` with token, team_id,
+    team_domain, channel_id, channel_name, root_id, user_id, user_name,
+    command, text, trigger_id and response_url.
+    """
+    return {
+        "surface": "command",
+        "team_id": str(form.get("team_id", "")).strip(),
+        "team_domain": str(form.get("team_domain", "")).strip(),
+        "channel_id": str(form.get("channel_id", "")).strip(),
+        "channel_name": str(form.get("channel_name", "")).strip(),
+        "root_id": str(form.get("root_id", "")).strip(),
+        "user_id": str(form.get("user_id", "")).strip(),
+        "user_name": str(form.get("user_name", "")).strip(),
+        "command": str(form.get("command", "")).strip(),
+        "text": str(form.get("text", "")).strip(),
+        "trigger_id": str(form.get("trigger_id", "")).strip(),
+        "response_url": str(form.get("response_url", "")).strip(),
+    }
+
+
+def normalize_dialog_invocation(payload: dict[str, Any], pending: dict[str, Any]) -> dict[str, str]:
+    """Normalize a `dialog_submission` payload, back-filled from the pending record.
+
+    Dialog submissions only carry type, callback_id, state, user_id, channel_id,
+    team_id, submission, file_ids and cancelled — the channel/team display names
+    and the thread root come from the slash command that opened the dialog.
+    """
+    return {
+        "surface": "dialog",
+        "team_id": str(payload.get("team_id", "")).strip() or str(pending.get("team_id", "")).strip(),
+        "team_domain": str(pending.get("team_domain", "")).strip(),
+        "channel_id": str(payload.get("channel_id", "")).strip() or str(pending.get("channel_id", "")).strip(),
+        "channel_name": str(pending.get("channel_name", "")).strip(),
+        "root_id": str(pending.get("root_id", "")).strip(),
+        "user_id": str(payload.get("user_id", "")).strip() or str(pending.get("user_id", "")).strip(),
+        "user_name": str(pending.get("user_name", "")).strip(),
+        "command": str(pending.get("command_trigger", "")).strip(),
+        "text": "",
+        "trigger_id": "",
+        "response_url": "",
+    }
+
+
+def _strip_rig_flag(token: str) -> str:
+    for prefix in ("--rig=", "-rig=", "rig=", "rig:"):
+        if token.startswith(prefix):
+            return token[len(prefix) :].strip()
+    return ""
+
+
+def _split_leading_token(text: str) -> tuple[str, str]:
+    """Peel one whitespace-delimited token off the front, keeping the tail verbatim.
+
+    The tail has to survive intact: `prompt_to_summary_context` derives the bead
+    summary from the prompt's first line, so collapsing newlines here would make
+    every multi-line `/gc fix` prompt a single 120-character summary.
+    """
+    stripped = text.lstrip()
+    index = 0
+    while index < len(stripped) and not stripped[index].isspace():
+        index += 1
+    return stripped[:index], stripped[index:]
+
+
+def parse_command_text(
+    config: dict[str, Any],
+    invocation: dict[str, str],
+    command_name_value: str,
+) -> dict[str, str]:
+    """Parse `/gc fix [rig] [prompt]` out of the slash-command `text` field.
+
+    Mattermost slash commands carry a single freeform `text` string rather than
+    Discord's typed option tree, so the subcommand and optional rig are parsed
+    positionally. A leading bare token only counts as a rig when it resolves to
+    a configured rig mapping; otherwise it stays part of the prompt.
+    """
+    trigger = str(invocation.get("command", "")).strip().lstrip("/")
+    if trigger and trigger != str(command_name_value).strip().lstrip("/"):
+        return {}
+    command_token, remainder = _split_leading_token(str(invocation.get("text", "")))
+    if not command_token:
+        return {"command": "", "prompt": "", "rig": ""}
+    command = command_token.lower()
+    rig = ""
+    next_token, after_next = _split_leading_token(remainder)
+    if next_token:
+        flag_value = _strip_rig_flag(next_token)
+        if flag_value:
+            rig = flag_value
+            remainder = after_next
+        elif next_token in {"--rig", "-rig"}:
+            rig_token, after_rig = _split_leading_token(after_next)
+            if rig_token:
+                rig = rig_token
+                remainder = after_rig
+        elif common.resolve_rig_mapping(config, str(invocation.get("team_id", "")).strip(), next_token):
+            rig = next_token
+            remainder = after_next
+    return {
+        "command": command,
+        "prompt": remainder.strip(),
+        "rig": rig,
+    }
+
+
+def extract_dialog_fields(payload: dict[str, Any]) -> dict[str, str]:
+    submission = payload.get("submission") or {}
+    if not isinstance(submission, dict):
+        return {}
+    fields: dict[str, str] = {}
+    for key, value in submission.items():
+        name = str(key).strip()
+        if not name:
+            continue
+        fields[name] = "" if value is None else str(value)
+    return fields
+
+
+def display_name(invocation: dict[str, str]) -> str:
+    return str(invocation.get("user_name", "")).strip()
+
+
+def channel_roles(config: dict[str, Any], channel_id: str, user_id: str) -> list[str]:
+    """Fetch the invoking user's channel roles, but only when policy needs them."""
+    policy = common.normalize_config(config).get("policy", {})
+    if not policy.get("channel_role_allowlist"):
+        return []
+    if not channel_id or not user_id:
+        return []
+    try:
+        return common.channel_member_roles(channel_id, user_id)
+    except common.MattermostAPIError:
+        return []
+
+
+def run_subprocess(command: list[str], cwd: str) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(
+            command,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=DISPATCH_SUBPROCESS_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise DispatchSubprocessTimeout(command, DISPATCH_SUBPROCESS_TIMEOUT_SECONDS) from exc
+
+
+def rig_from_target(target: str) -> str:
+    if "/" not in target:
+        return ""
+    rig, _, _ = target.partition("/")
+    return rig.strip()
+
+
+def gc_bd_command(city_root: str, *args: str, rig: str = "") -> list[str]:
+    command = [os.environ.get("GC_BIN", "gc")]
+    if city_root not in {"", "."}:
+        command.extend(["--city", city_root])
+    if rig:
+        command.extend(["--rig", rig])
+    command.append("bd")
+    command.extend(args)
+    return command
+
+
+def rig_workdir(rig: str) -> str:
+    """Resolve a rig's working directory from .beads/routes.jsonl."""
+    root = common.city_root() or "."
+    root_abs = os.path.realpath(root)
+    routes_path = os.path.join(root, ".beads", "routes.jsonl")
+    try:
+        with open(routes_path) as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                entry = json.loads(line)
+                path = str(entry.get("path", ""))
+                if path == rig:
+                    if os.path.isabs(path):
+                        candidate = os.path.abspath(path)
+                    else:
+                        candidate = os.path.abspath(os.path.normpath(os.path.join(root_abs, path)))
+                    resolved = os.path.realpath(candidate)
+                    if resolved == root_abs or resolved.startswith(root_abs + os.sep):
+                        if os.path.isdir(resolved):
+                            return resolved
+    except (OSError, json.JSONDecodeError):
+        pass
+    return ""
+
+
+def extract_json_output(raw: str) -> dict[str, Any]:
+    raw = raw.strip()
+    if not raw:
+        return {}
+    for line in raw.splitlines():
+        candidate = line.strip()
+        if not candidate:
+            continue
+        try:
+            payload = json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            return payload
+        if isinstance(payload, list) and payload and isinstance(payload[0], dict):
+            return payload[0]
+    for left, right in (("{", "}"), ("[", "]")):
+        start = raw.find(left)
+        end = raw.rfind(right)
+        if start == -1 or end == -1 or end < start:
+            continue
+        try:
+            payload = json.loads(raw[start : end + 1])
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            return payload
+        if isinstance(payload, list) and payload and isinstance(payload[0], dict):
+            return payload[0]
+    return {}
+
+
+def load_bead_snapshot(bead_id: str, rig: str = "") -> dict[str, Any]:
+    normalized_bead_id = str(bead_id).strip()
+    if not normalized_bead_id:
+        return {}
+    city_root = common.city_root() or "."
+    bd_cwd = rig_workdir(rig) or city_root
+    try:
+        result = run_subprocess(
+            gc_bd_command(city_root, "show", normalized_bead_id, "--json", rig=rig),
+            bd_cwd,
+        )
+    except (DispatchSubprocessTimeout, FileNotFoundError):
+        return {}
+    if result.returncode != 0:
+        return {}
+    return extract_json_output(result.stdout)
+
+
+def dispatch_recovery_state(payload: dict[str, Any]) -> str:
+    bead_id = str(payload.get("bead_id", "")).strip()
+    if not bead_id:
+        return "inactive"
+    bead = load_bead_snapshot(bead_id, rig_from_target(str(payload.get("dispatch_target", ""))))
+    if not bead:
+        return "unknown"
+    status = str(bead.get("status", "")).strip().lower()
+    assignee = str(bead.get("assignee", "")).strip()
+    parent_id = str(bead.get("parent_id", "") or bead.get("parent", "") or bead.get("parentID", "")).strip()
+    metadata = bead.get("metadata") or {}
+    if not isinstance(metadata, dict):
+        metadata = {}
+    workflow_id = str(metadata.get("workflow_id", "")).strip()
+    close_reason = str(metadata.get("close_reason", "")).strip()
+
+    if status == "closed":
+        if close_reason.startswith("mattermost:"):
+            return "inactive"
+        return "active"
+    if assignee or parent_id or workflow_id:
+        return "active"
+    if status in {"", "open"}:
+        return "inactive"
+    return "unknown"
+
+
+def build_fix_bead_title(request: dict[str, Any]) -> str:
+    summary = str(request.get("summary", "")).strip() or "Mattermost fix request"
+    return f"Fix Mattermost request: {summary}"[:180]
+
+
+def build_fix_bead_notes(request: dict[str, Any]) -> str:
+    lines = [
+        "## Mattermost Source",
+        "",
+        f"- Team: {request.get('team_id', '')}",
+        f"- Channel: {request.get('channel_id', '')}",
+        f"- Thread Root: {request.get('root_id', '') or '(none)'}",
+        f"- Conversation: {request.get('conversation_id', '')}",
+        f"- Permalink: {request.get('permalink', '')}",
+        f"- Request ID: {request.get('request_id', '')}",
+        f"- Requested By: {request.get('invoking_user_display_name', '')} ({request.get('invoking_user_id', '')})",
+        "",
+        "## Summary",
+        "",
+        str(request.get("summary", "")).strip() or "(none)",
+        "",
+        "## Additional Context",
+        "",
+        str(request.get("context_markdown", "")).strip() or "(none)",
+    ]
+    return "\n".join(lines)
+
+
+def base64_var(value: Any) -> str:
+    return base64.b64encode(str(value or "").encode("utf-8")).decode("ascii")
+
+
+def create_fix_bead(request: dict[str, Any], target: str) -> dict[str, Any]:
+    rig = rig_from_target(target)
+    if not rig:
+        return {"status": "dispatch_failed", "reason": "invalid_dispatch_target"}
+    city_root = common.city_root() or "."
+    bd_cwd = rig_workdir(rig)
+    if not bd_cwd:
+        return {"status": "dispatch_failed", "reason": "rig_workdir_missing"}
+    create_command = gc_bd_command(
+        city_root,
+        "create",
+        "--json",
+        build_fix_bead_title(request),
+        "-t",
+        "task",
+        rig=rig,
+    )
+    try:
+        create_result = run_subprocess(create_command, bd_cwd)
+    except FileNotFoundError:
+        return {"status": "dispatch_failed", "reason": "bead_create_failed", "dispatch_stderr": "gc not available"}
+    except DispatchSubprocessTimeout as exc:
+        return {
+            "status": "dispatch_failed",
+            "reason": "dispatch_timeout",
+            "dispatch_command": exc.command,
+            "dispatch_timeout_seconds": exc.timeout_seconds,
+        }
+    if create_result.returncode != 0:
+        return {
+            "status": "dispatch_failed",
+            "reason": "bead_create_failed",
+            "dispatch_stdout": trim_output(create_result.stdout),
+            "dispatch_stderr": trim_output(create_result.stderr),
+        }
+    created = extract_json_output(create_result.stdout)
+    bead_id = str(created.get("id", "")).strip()
+    if not bead_id:
+        return {
+            "status": "dispatch_failed",
+            "reason": "bead_create_failed",
+            "dispatch_stdout": trim_output(create_result.stdout),
+            "dispatch_stderr": trim_output(create_result.stderr),
+        }
+    request["bead_id"] = bead_id
+    request["status"] = "bead_created"
+    common.save_request(request)
+
+    update_command = gc_bd_command(city_root, "update", bead_id, "--notes", build_fix_bead_notes(request), rig=rig)
+    metadata = {
+        "mattermost_request_id": str(request.get("request_id", "")),
+        "mattermost_team_id": str(request.get("team_id", "")),
+        "mattermost_channel_id": str(request.get("channel_id", "")),
+        "mattermost_root_id": str(request.get("root_id", "")),
+        "mattermost_conversation_id": str(request.get("conversation_id", "")),
+        "mattermost_summary": str(request.get("summary", "")),
+    }
+    for key, value in metadata.items():
+        if value:
+            update_command.extend(["--set-metadata", f"{key}={value}"])
+    try:
+        update_result = run_subprocess(update_command, bd_cwd)
+    except FileNotFoundError:
+        return {
+            "status": "dispatch_failed",
+            "reason": "bead_update_failed",
+            "bead_id": bead_id,
+            "dispatch_stderr": "gc not available",
+        }
+    except DispatchSubprocessTimeout as exc:
+        return {
+            "status": "dispatch_failed",
+            "reason": "dispatch_timeout",
+            "bead_id": bead_id,
+            "dispatch_command": exc.command,
+            "dispatch_timeout_seconds": exc.timeout_seconds,
+        }
+    if update_result.returncode != 0:
+        return {
+            "status": "dispatch_failed",
+            "reason": "bead_update_failed",
+            "bead_id": bead_id,
+            "dispatch_stdout": trim_output(update_result.stdout),
+            "dispatch_stderr": trim_output(update_result.stderr),
+        }
+    return {"bead_id": bead_id}
+
+
+def build_fix_vars(request: dict[str, Any], bead_id: str) -> dict[str, str]:
+    return {
+        "issue": bead_id,
+        "mattermost_request_id": str(request.get("request_id", "")),
+        "mattermost_team_id": str(request.get("team_id", "")),
+        "mattermost_channel_id": str(request.get("channel_id", "")),
+        "mattermost_root_id": str(request.get("root_id", "")),
+        "mattermost_conversation_id": str(request.get("conversation_id", "")),
+        "mattermost_permalink_b64": base64_var(request.get("permalink", "")),
+        "mattermost_requester_b64": base64_var(request.get("invoking_user_display_name", "")),
+        "mattermost_summary_b64": base64_var(request.get("summary", "")),
+        "mattermost_context_b64": base64_var(request.get("context_markdown", "")),
+    }
+
+
+def close_failed_bead(bead_id: str, reason: str, rig: str = "") -> bool:
+    bead_id = bead_id.strip()
+    if not bead_id:
+        return True
+    city_root = common.city_root() or "."
+    if rig:
+        bd_cwd = rig_workdir(rig)
+        if not bd_cwd:
+            return False
+    else:
+        bd_cwd = city_root
+    try:
+        # Prefer closing a failed bead even if we could not persist the close_reason metadata.
+        run_subprocess(
+            gc_bd_command(
+                city_root,
+                "update",
+                bead_id,
+                "--set-metadata",
+                f"close_reason=mattermost:{reason or 'dispatch_failed'}",
+                rig=rig,
+            ),
+            bd_cwd,
+        )
+        run_subprocess(gc_bd_command(city_root, "ready", bead_id, rig=rig), bd_cwd)
+        result = run_subprocess(gc_bd_command(city_root, "close", bead_id, rig=rig), bd_cwd)
+    except (DispatchSubprocessTimeout, FileNotFoundError):
+        return False
+    return result.returncode == 0
+
+
+def run_fix_dispatch(request: dict[str, Any]) -> dict[str, Any]:
+    formula = str(request.get("dispatch_formula", "")).strip()
+    target = str(request.get("dispatch_target", "")).strip()
+    if not formula or not target:
+        return {"status": "ignored", "reason": "command_not_configured"}
+    try:
+        target = common.validate_fix_dispatch_target(target, formula)
+    except ValueError:
+        return {"status": "dispatch_failed", "reason": "invalid_dispatch_target"}
+
+    rig = rig_from_target(target)
+    bead_outcome = create_fix_bead(request, target)
+    if bead_outcome.get("status") == "dispatch_failed":
+        cleanup_ok = close_failed_bead(str(bead_outcome.get("bead_id", "")), str(bead_outcome.get("reason", "")), rig)
+        if cleanup_ok:
+            bead_outcome["bead_closed"] = True
+        else:
+            bead_outcome["cleanup_failed"] = True
+        return bead_outcome
+    if "bead_id" not in bead_outcome:
+        return bead_outcome
+    bead_id = str(bead_outcome["bead_id"])
+    request["bead_id"] = bead_id
+
+    gc_bin = os.environ.get("GC_BIN", "gc")
+    command = [gc_bin, "sling", target, bead_id, "--on", formula]
+    for key, value in build_fix_vars(request, bead_id).items():
+        if value:
+            command.extend(["--var", f"{key}={value}"])
+    request["status"] = "dispatching"
+    request["dispatch_started_at"] = common.utcnow()
+    common.save_request(request)
+    try:
+        result = run_subprocess(command, common.city_root() or ".")
+    except FileNotFoundError:
+        cleanup_ok = close_failed_bead(bead_id, "gc_not_available", rig)
+        outcome = {"status": "dispatch_failed", "reason": "gc_not_available", "bead_id": bead_id}
+        if cleanup_ok:
+            outcome["bead_closed"] = True
+        else:
+            outcome["cleanup_failed"] = True
+        return outcome
+    except DispatchSubprocessTimeout as exc:
+        recovery_state = dispatch_recovery_state(
+            {
+                "bead_id": bead_id,
+                "dispatch_target": target,
+            }
+        )
+        outcome: dict[str, Any] = {
+            "bead_id": bead_id,
+            "dispatch_command": exc.command,
+            "dispatch_timeout_seconds": exc.timeout_seconds,
+        }
+        if recovery_state == "active":
+            outcome["status"] = "dispatched"
+            outcome["dispatch_completed_at"] = common.utcnow()
+            outcome["dispatch_recovery_reason"] = "dispatch_timeout_but_bead_already_routed"
+        elif recovery_state == "unknown":
+            outcome["status"] = "dispatching"
+            outcome["dispatch_recovery_reason"] = "dispatch_timeout_state_unavailable"
+            outcome["dispatch_timeout_at"] = common.utcnow()
+        else:
+            cleanup_ok = close_failed_bead(bead_id, "dispatch_timeout", rig)
+            outcome["status"] = "dispatch_failed"
+            outcome["reason"] = "dispatch_timeout"
+            if cleanup_ok:
+                outcome["bead_closed"] = True
+            else:
+                outcome["cleanup_failed"] = True
+        request.update(outcome)
+        common.save_request(request)
+        return outcome
+    outcome = {
+        "bead_id": bead_id,
+        "dispatch_target": target,
+        "dispatch_formula": formula,
+        "dispatch_command": command,
+        "dispatch_exit_code": result.returncode,
+        "dispatch_stdout": trim_output(result.stdout),
+        "dispatch_stderr": trim_output(result.stderr),
+    }
+    if result.returncode == 0:
+        outcome["status"] = "dispatched"
+        outcome["dispatch_completed_at"] = common.utcnow()
+    else:
+        outcome["status"] = "dispatch_failed"
+        outcome["reason"] = "dispatch_failed"
+        if close_failed_bead(bead_id, "dispatch_failed", rig):
+            outcome["bead_closed"] = True
+        else:
+            outcome["cleanup_failed"] = True
+    request.update(outcome)
+    common.save_request(request)
+    return outcome
+
+
+def process_request(request_id: str) -> None:
+    request: dict[str, Any] | None = None
+    workflow_key_hint = ""
+    try:
+        request = common.load_request(request_id)
+        if not request:
+            return
+        workflow_key_hint = str(request.get("workflow_key", ""))
+        if str(request.get("status", "")).strip() == "received":
+            request["status"] = "processing"
+            common.save_request(request)
+        behavior = command_behavior(str(request.get("command", "")))
+        if not behavior:
+            request["status"] = "ignored"
+            request["reason"] = "command_not_supported"
+        else:
+            outcome = run_fix_dispatch(request)
+            request.update(outcome)
+            if request.get("status") in {"dispatch_failed", "internal_error"}:
+                maybe_notify_dispatch_failure(request)
+        common.save_request(request)
+    except Exception as exc:  # noqa: BLE001
+        payload = request or common.load_request(request_id) or {"request_id": request_id}
+        bead_id = str(payload.get("bead_id", ""))
+        rig = rig_from_target(str(payload.get("dispatch_target", "")))
+        if bead_id and not payload.get("bead_closed"):
+            if close_failed_bead(bead_id, "internal_error", rig):
+                payload["bead_closed"] = True
+            else:
+                payload["cleanup_failed"] = True
+        payload["status"] = "internal_error"
+        payload["reason"] = "internal_error"
+        payload["error_message"] = str(exc)
+        payload["traceback"] = traceback.format_exc(limit=20)
+        maybe_notify_dispatch_failure(payload)
+        common.save_request(payload)
+        request = payload
+    finally:
+        if request:
+            workflow_key = str(request.get("workflow_key", "")) or workflow_key_hint
+            if (
+                workflow_key
+                and request.get("status") in {"ignored", "dispatch_failed", "internal_error"}
+                and not request.get("cleanup_failed")
+            ):
+                with ACCEPTANCE_LOCK:
+                    common.remove_workflow_link_if_request(workflow_key, request_id)
+        elif request_id:
+            with ACCEPTANCE_LOCK:
+                common.remove_workflow_links_for_request(request_id)
+        with PROCESSING_LOCK:
+            PROCESSING_REQUESTS.discard(request_id)
+
+
+def enqueue_request(request_id: str) -> None:
+    with PROCESSING_LOCK:
+        if request_id in PROCESSING_REQUESTS:
+            return
+        PROCESSING_REQUESTS.add(request_id)
+    thread = threading.Thread(target=process_request, args=(request_id,), daemon=True)
+    thread.start()
+
+
+def recover_incomplete_requests() -> int:
+    recovered = 0
+    for path in pathlib.Path(common.requests_dir()).glob("*.json"):
+        payload = common.read_json(str(path), allow_invalid=True)
+        if not isinstance(payload, dict):
+            continue
+        status = str(payload.get("status", "")).strip()
+        recovery_reason = "service_restarted_before_dispatch"
+        if status in {"received", "processing", "bead_created"}:
+            pass
+        elif status == "dispatching":
+            if utc_age_seconds(str(payload.get("dispatch_started_at", "")).strip()) < DISPATCHING_RECOVERY_GRACE_SECONDS:
+                continue
+            recovery_state = dispatch_recovery_state(payload)
+            if recovery_state == "active":
+                payload["status"] = "dispatched"
+                payload["dispatch_recovered_at"] = common.utcnow()
+                payload["dispatch_recovery_reason"] = "bead_already_routed"
+                common.save_request(payload)
+                continue
+            if recovery_state == "unknown":
+                payload["dispatch_recovery_deferred_at"] = common.utcnow()
+                payload["dispatch_recovery_reason"] = "bead_state_unavailable"
+                common.save_request(payload)
+                continue
+            recovery_reason = "service_restarted_during_dispatch"
+        else:
+            continue
+        bead_id = str(payload.get("bead_id", "")).strip()
+        rig = rig_from_target(str(payload.get("dispatch_target", "")))
+        if bead_id and not payload.get("bead_closed"):
+            if close_failed_bead(bead_id, recovery_reason, rig):
+                payload["bead_closed"] = True
+            else:
+                payload["cleanup_failed"] = True
+        payload["status"] = "internal_error"
+        payload["reason"] = recovery_reason
+        payload["recovered_at"] = common.utcnow()
+        maybe_notify_dispatch_failure(payload)
+        common.save_request(payload)
+        workflow_key = str(payload.get("workflow_key", "")).strip()
+        request_id = str(payload.get("request_id", "")).strip()
+        if workflow_key and request_id and not payload.get("cleanup_failed"):
+            common.remove_workflow_link_if_request(workflow_key, request_id)
+        recovered += 1
+    return recovered
+
+
+def reserve_request(request: dict[str, Any], behavior: dict[str, Any], interaction_id: str) -> dict[str, Any] | None:
+    with ACCEPTANCE_LOCK:
+        existing_receipt = common.load_interaction_receipt(interaction_id)
+        if existing_receipt:
+            request_id = str(existing_receipt.get("request_id", "")).strip()
+            if request_id:
+                return common.load_request(request_id) or {"request_id": request_id}
+            return {"request_id": "", "status": "duplicate"}
+        existing = common.load_request(request["request_id"])
+        if existing:
+            common.save_interaction_receipt(
+                interaction_id,
+                {"request_id": str(existing.get("request_id", "")), "response_kind": "duplicate"},
+            )
+            return existing
+        workflow_key = str(request.get("workflow_key", ""))
+        if behavior.get("workflow_scope") == "conversation" and workflow_key:
+            workflow_link = common.load_workflow_link(workflow_key)
+            if workflow_link:
+                existing_request_id = str(workflow_link.get("request_id", ""))
+                existing_request = common.load_request(existing_request_id) or {
+                    "request_id": existing_request_id,
+                    "workflow_key": workflow_key,
+                    "status": "duplicate",
+                    "command": request.get("command", ""),
+                    "team_id": request.get("team_id", ""),
+                    "conversation_id": request.get("conversation_id", ""),
+                }
+                common.save_interaction_receipt(
+                    interaction_id,
+                    {"request_id": existing_request_id, "response_kind": "duplicate"},
+                )
+                return existing_request
+        common.save_request(request)
+        if behavior.get("workflow_scope") == "conversation" and workflow_key:
+            common.save_workflow_link(workflow_key, request["request_id"])
+        common.save_interaction_receipt(
+            interaction_id,
+            {"request_id": request["request_id"], "response_kind": "accepted"},
+        )
+    return None
+
+
+def render_admin_home() -> str:
+    snapshot = common.build_status_snapshot(limit=20)
+    config = snapshot["config"]
+    app_cfg = config.get("app", {})
+    command_name_value = str(app_cfg.get("command_name", common.COMMAND_NAME_DEFAULT))
+    team_id = str(app_cfg.get("team_id", ""))
+    payload_preview = json.dumps(
+        common.build_command_payload(command_name_value, team_id, common.command_callback_url()),
+        indent=2,
+        sort_keys=True,
+    )
+    command_url = common.command_callback_url() or "(publish mattermost-interactions first)"
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Mattermost Admin</title>
+  <style>
+    body {{ font-family: ui-monospace, SFMono-Regular, Menlo, monospace; margin: 2rem; line-height: 1.45; }}
+    pre {{ background: #f5f5f5; padding: 1rem; overflow-x: auto; }}
+    code {{ background: #f5f5f5; padding: 0.1rem 0.25rem; }}
+  </style>
+</head>
+<body>
+  <h1>Mattermost</h1>
+  <p>Interactions URL: <code>{html.escape(str(snapshot.get('interactions_url') or '(not published yet)'))}</code></p>
+  <p>Admin URL: <code>{html.escape(str(snapshot.get('admin_url') or '(not published yet)'))}</code></p>
+  <h2>Setup</h2>
+  <p>Import the Mattermost site URL, bot token, and slash-command verification token with <code>gc mattermost import-app ...</code>.</p>
+  <p>Then point the Mattermost slash command Request URL at <code>{html.escape(command_url)}</code>.</p>
+  <p>The interactive-dialog callback URL carries a secret path token and is registered automatically when the dialog is opened; it is not shown here.</p>
+  <h2>Command Sync Payload</h2>
+  <pre>{html.escape(payload_preview)}</pre>
+  <h2>Config</h2>
+  <pre>{html.escape(json.dumps(config, indent=2, sort_keys=True))}</pre>
+  <h2>Recent Requests</h2>
+  <pre>{html.escape(json.dumps(snapshot.get('recent_requests', []), indent=2, sort_keys=True))}</pre>
+  <h2>Chat Bindings</h2>
+  <pre>{html.escape(json.dumps(snapshot.get('chat_bindings', []), indent=2, sort_keys=True))}</pre>
+  <h2>Chat Launchers</h2>
+  <pre>{html.escape(json.dumps(snapshot.get('chat_launchers', []), indent=2, sort_keys=True))}</pre>
+  <h2>Gateway Status</h2>
+  <pre>{html.escape(json.dumps(snapshot.get('gateway_status', {}), indent=2, sort_keys=True))}</pre>
+  <h2>Recent Chat Ingress</h2>
+  <pre>{html.escape(json.dumps(snapshot.get('recent_chat_ingress', []), indent=2, sort_keys=True))}</pre>
+  <h2>Recent Chat Publishes</h2>
+  <pre>{html.escape(json.dumps(snapshot.get('recent_chat_publishes', []), indent=2, sort_keys=True))}</pre>
+  <h2>Recent Room Launches</h2>
+  <pre>{html.escape(json.dumps(snapshot.get('recent_room_launches', []), indent=2, sort_keys=True))}</pre>
+</body>
+</html>
+"""
+
+
+def build_request(
+    invocation: dict[str, str],
+    summary: str,
+    context_markdown: str,
+    channel_context: dict[str, Any],
+    interaction_id: str,
+    mapping: dict[str, Any] | None = None,
+    rig_name: str = "",
+) -> dict[str, Any]:
+    team_id = str(channel_context.get("team_id", "")).strip() or str(invocation.get("team_id", "")).strip()
+    channel_id = str(channel_context.get("channel_id", "")).strip() or str(invocation.get("channel_id", "")).strip()
+    root_id = str(channel_context.get("root_id", "")).strip() or str(invocation.get("root_id", "")).strip()
+    conversation_id = common.mattermost_conversation_key(channel_id, root_id)
+    resolved_mapping: dict[str, Any] = mapping if mapping is not None else (channel_context.get("mapping") or {})
+    request_id = common.build_request_id(interaction_id, "fix")
+    workflow_key = common.build_workflow_key(team_id, conversation_id, "fix")
+    return {
+        "request_id": request_id,
+        "workflow_key": workflow_key,
+        "status": "received",
+        "command": "fix",
+        "created_at": common.utcnow(),
+        "updated_at": common.utcnow(),
+        "interaction_id": interaction_id,
+        "team_id": team_id,
+        "team_domain": str(invocation.get("team_domain", "")).strip(),
+        "channel_id": channel_id,
+        "channel_name": str(invocation.get("channel_name", "")).strip(),
+        "root_id": root_id,
+        "conversation_id": conversation_id,
+        "invoking_user_id": str(invocation.get("user_id", "")).strip(),
+        "invoking_user_display_name": display_name(invocation),
+        "summary": summary.strip(),
+        "context_markdown": context_markdown.strip(),
+        "permalink": common.mattermost_channel_url(
+            str(invocation.get("team_domain", "")).strip(),
+            str(invocation.get("channel_name", "")).strip(),
+        ),
+        "rig_name": rig_name,
+        "dispatch_target": str(resolved_mapping.get("target", "")),
+        "dispatch_formula": str((((resolved_mapping.get("commands") or {}).get("fix") or {}).get("formula", common.FIX_FORMULA_DEFAULT))),
+    }
+
+
+def replay_response_from_receipt(receipt: dict[str, Any], surface: str = "command") -> dict[str, Any]:
+    stored_response = receipt.get("response")
+    if isinstance(stored_response, dict):
+        return stored_response
+    response_kind = str(receipt.get("response_kind", "")).strip()
+    if surface == "dialog":
+        return build_dialog_ok_response()
+    if response_kind == "dialog":
+        # The slash command already opened a dialog for this invocation.
+        return {}
+    request_id = str(receipt.get("request_id", "")).strip()
+    request = common.load_request(request_id) if request_id else {}
+    if response_kind == "accepted":
+        return build_acceptance_response(request or {"request_id": request_id})
+    return build_duplicate_response(request or {"request_id": request_id, "status": "duplicate"})
+
+
+def build_dispatch_failure_message(request: dict[str, Any]) -> str:
+    request_id = str(request.get("request_id", "")).strip()
+    bead_id = str(request.get("bead_id", "")).strip()
+    status = str(request.get("status", "")).strip()
+    reason = str(request.get("reason", "")).strip()
+    lines = [
+        "Mattermost `/gc fix` could not be started.",
+        f"Request: `{request_id}`" if request_id else "",
+        f"Status: `{status}`" if status else "",
+        f"Reason: {human_reason(reason)}" if reason else "",
+        f"Bead: `{bead_id}`" if bead_id else "",
+    ]
+    return "\n".join(line for line in lines if line)
+
+
+def maybe_notify_dispatch_failure(request: dict[str, Any]) -> dict[str, Any]:
+    if request.get("failure_notified_at"):
+        return request
+    target_channel = str(request.get("channel_id", "")).strip()
+    if not target_channel:
+        return request
+    try:
+        response = common.post_channel_message(
+            target_channel,
+            build_dispatch_failure_message(request),
+            root_id=str(request.get("root_id", "")).strip(),
+        )
+    except common.MattermostAPIError as exc:
+        request["failure_notification_error"] = str(exc)
+        return request
+    request["failure_notified_at"] = common.utcnow()
+    message_id = str((response or {}).get("id", "")).strip() if isinstance(response, dict) else ""
+    if message_id:
+        request["failure_message_id"] = message_id
+    return request
+
+
+def post_conversation_message(invocation: dict[str, str], content: str) -> str:
+    """Post back into the conversation.
+
+    A `dialog_submission` response body cannot carry post content, so dialog
+    acceptances and duplicate notices are delivered with the bot token instead.
+    """
+    channel_id = str(invocation.get("channel_id", "")).strip()
+    if not channel_id or not content:
+        return ""
+    try:
+        response = common.post_channel_message(channel_id, content, root_id=str(invocation.get("root_id", "")).strip())
+    except common.MattermostAPIError:
+        return ""
+    if isinstance(response, dict):
+        return str(response.get("id", "")).strip()
+    return ""
+
+
+def finalize_dialog_origin_receipt(
+    origin_interaction_id: str,
+    receipt: dict[str, Any],
+) -> None:
+    """Rewrite the slash-command receipt once its dialog has been submitted.
+
+    The stored body is deliberately dropped: a replayed slash command must be
+    answered with a CommandResponse, not with the dialog-submission response.
+    """
+    origin_interaction_id = origin_interaction_id.strip()
+    if not origin_interaction_id:
+        return
+    payload = {
+        "response_kind": str(receipt.get("response_kind", "")) or "accepted",
+    }
+    request_id = str(receipt.get("request_id", "")).strip()
+    if request_id:
+        payload["request_id"] = request_id
+    common.replace_interaction_receipt(origin_interaction_id, payload)
+
+
+def persist_interaction_receipt(
+    interaction_id: str,
+    receipt: dict[str, Any],
+) -> None:
+    interaction_id = interaction_id.strip()
+    if not interaction_id:
+        return
+    payload = dict(receipt)
+    common.save_interaction_receipt(interaction_id, payload)
+
+
+def accept_fix_request(
+    invocation: dict[str, str],
+    summary: str,
+    context_markdown: str,
+    interaction_id: str,
+    rig_name: str = "",
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Validate and reserve a /gc fix request.
+
+    Returns (outcome, receipt) where outcome is a surface-neutral record:
+      {"kind": "message"|"accepted"|"duplicate", "content": str, "request": {...}}
+    """
+    config = common.load_config()
+    team_id = str(invocation.get("team_id", "")).strip()
+    if not team_id:
+        return refusal_outcome("team_required")
+    if not common.load_bot_token():
+        return refusal_outcome("mattermost_app_not_configured")
+
+    # Resolve dispatch target: rig mapping takes priority, channel mapping as fallback.
+    mapping: dict[str, Any] | None = None
+    channel_id = str(invocation.get("channel_id", "")).strip()
+    root_id = str(invocation.get("root_id", "")).strip()
+    if rig_name and not root_id:
+        channel_context: dict[str, Any] = {
+            "team_id": team_id,
+            "channel_id": channel_id,
+            "root_id": "",
+            "mapping": {},
+            "channel_info": {},
+        }
+    else:
+        channel_context = common.load_channel_context(config, team_id, channel_id, root_id)
+    if channel_context.get("lookup_error") and (not rig_name or root_id):
+        return refusal_outcome("mattermost_lookup_failed")
+    effective_team_id = str(channel_context.get("team_id", "")).strip() or team_id
+    if rig_name:
+        mapping = common.resolve_rig_mapping(config, effective_team_id, rig_name)
+        if not mapping:
+            return refusal_outcome("rig_mapping_missing")
+    else:
+        mapping = channel_context.get("mapping") or {}
+        if not mapping:
+            return refusal_outcome("channel_mapping_missing")
+
+    reason = common.policy_reason(
+        config,
+        effective_team_id,
+        str(channel_context.get("channel_id", "")).strip() or channel_id,
+        channel_roles(config, channel_id, str(invocation.get("user_id", "")).strip()),
+    )
+    if reason:
+        return refusal_outcome(reason)
+    summary = summary.strip()
+    context_markdown = context_markdown.strip()
+    if not summary and context_markdown:
+        summary, context_markdown = prompt_to_summary_context(context_markdown)
+    if not summary:
+        return refusal_outcome("summary_required", field="summary")
+    request = build_request(
+        invocation,
+        summary,
+        context_markdown,
+        channel_context,
+        interaction_id,
+        mapping,
+        rig_name=rig_name,
+    )
+    behavior = command_behavior("fix")
+    if not behavior:
+        return refusal_outcome("command_not_supported")
+    existing = reserve_request(request, behavior, interaction_id)
+    if existing:
+        outcome = {
+            "kind": "duplicate",
+            "content": build_duplicate_message(existing),
+            "request": existing,
+        }
+        return outcome, receipt_payload(
+            {},
+            response_kind="duplicate",
+            request_id=str(existing.get("request_id", "")).strip(),
+        )
+    enqueue_request(request["request_id"])
+    outcome = {
+        "kind": "accepted",
+        "content": build_acceptance_message(request),
+        "request": request,
+    }
+    return outcome, receipt_payload({}, response_kind="accepted", request_id=request["request_id"])
+
+
+def refusal_outcome(reason: str, field: str = "") -> tuple[dict[str, Any], dict[str, Any]]:
+    outcome = {
+        "kind": "message",
+        "reason": reason,
+        "field": field,
+        "content": human_reason(reason),
+        "request": {},
+    }
+    return outcome, receipt_payload({}, response_kind="message")
+
+
+def command_response_for_outcome(outcome: dict[str, Any]) -> dict[str, Any]:
+    kind = str(outcome.get("kind", "message"))
+    content = str(outcome.get("content", ""))
+    if kind == "accepted":
+        return build_message_response(content, ephemeral=False)
+    return build_message_response(content, ephemeral=True)
+
+
+def dialog_response_for_outcome(outcome: dict[str, Any], invocation: dict[str, str]) -> dict[str, Any]:
+    kind = str(outcome.get("kind", "message"))
+    if kind == "message":
+        return build_dialog_error_response(str(outcome.get("reason", "")), str(outcome.get("field", "")))
+    post_conversation_message(invocation, str(outcome.get("content", "")))
+    return build_dialog_ok_response()
+
+
+class IntakeHandler(BaseHTTPRequestHandler):
+    server_version = "MattermostIntake/0.1"
+
+    def log_message(self, fmt: str, *args: Any) -> None:
+        print(f"[{common.current_service_name() or 'mattermost'}] {fmt % args}")
+
+    def _parsed(self) -> urllib.parse.ParseResult:
+        return urllib.parse.urlparse(self.path)
+
+    def _read_json_body(self) -> dict[str, Any]:
+        length = int(self.headers.get("Content-Length", "0"))
+        data = self.rfile.read(length) if length > 0 else b"{}"
+        if not data:
+            return {}
+        parsed = json.loads(data.decode("utf-8"))
+        if isinstance(parsed, dict):
+            return parsed
+        raise ValueError("request body must be a JSON object")
+
+    def _read_body(self) -> bytes | None:
+        length = int(self.headers.get("Content-Length", "0"))
+        if length > MAX_REQUEST_BYTES:
+            return None
+        return self.rfile.read(length) if length > 0 else b""
+
+    def do_GET(self) -> None:  # noqa: N802
+        parsed = self._parsed()
+        service_name = common.current_service_name()
+        if parsed.path == "/healthz":
+            self.send_response(HTTPStatus.NO_CONTENT)
+            self.end_headers()
+            return
+        if service_name == common.ADMIN_SERVICE_NAME:
+            self._do_admin_get(parsed)
+            return
+        self._do_interactions_get(parsed)
+
+    def do_POST(self) -> None:  # noqa: N802
+        parsed = self._parsed()
+        service_name = common.current_service_name()
+        if service_name == common.ADMIN_SERVICE_NAME:
+            self._do_admin_post(parsed)
+            return
+        self._do_interactions_post(parsed)
+
+    def _do_admin_get(self, parsed: urllib.parse.ParseResult) -> None:
+        if parsed.path == "/":
+            text_response(self, HTTPStatus.OK, render_admin_home(), "text/html; charset=utf-8")
+            return
+        if parsed.path == "/v0/mattermost/status":
+            json_response(self, HTTPStatus.OK, common.build_status_snapshot(limit=20))
+            return
+        if parsed.path == "/v0/mattermost/requests":
+            json_response(self, HTTPStatus.OK, {"requests": common.list_recent_requests(limit=50)})
+            return
+        json_response(self, HTTPStatus.NOT_FOUND, {"error": "not_found"})
+
+    def _do_admin_post(self, parsed: urllib.parse.ParseResult) -> None:
+        try:
+            body = self._read_json_body()
+        except Exception as exc:  # noqa: BLE001
+            json_response(self, HTTPStatus.BAD_REQUEST, {"error": str(exc)})
+            return
+        if parsed.path == "/v0/mattermost/app/import":
+            try:
+                config = common.import_app_config(common.load_config(), body)
+            except ValueError as exc:
+                json_response(self, HTTPStatus.BAD_REQUEST, {"error": str(exc)})
+                return
+            json_response(self, HTTPStatus.OK, {"config": common.redact_config(config)})
+            return
+        if parsed.path == "/v0/mattermost/bot-token/import":
+            token = str(body.get("bot_token", "")).strip()
+            if not token:
+                json_response(self, HTTPStatus.BAD_REQUEST, {"error": "bot_token is required"})
+                return
+            common.save_bot_token(token)
+            json_response(self, HTTPStatus.OK, {"status": "ok"})
+            return
+        if parsed.path == "/v0/mattermost/command-token/import":
+            # Mattermost authenticates inbound slash commands with the shared
+            # verification token issued when the command is created.
+            token = str(body.get("command_token", body.get("verification_token", ""))).strip()
+            if not token:
+                json_response(self, HTTPStatus.BAD_REQUEST, {"error": "command_token is required"})
+                return
+            try:
+                common.validate_command_token(token)
+            except ValueError as exc:
+                json_response(self, HTTPStatus.BAD_REQUEST, {"error": str(exc)})
+                return
+            common.save_command_token(token)
+            json_response(self, HTTPStatus.OK, {"status": "ok"})
+            return
+        if parsed.path == "/v0/mattermost/commands/sync":
+            team_ids = body.get("team_ids")
+            if not isinstance(team_ids, list):
+                team_id = str(body.get("team_id", "")).strip()
+                team_ids = [team_id] if team_id else []
+            if not team_ids:
+                json_response(self, HTTPStatus.BAD_REQUEST, {"error": "team_id or team_ids is required"})
+                return
+            config = common.load_config()
+            results: dict[str, Any] = {}
+            had_errors = False
+            for team_id in team_ids:
+                try:
+                    results[str(team_id)] = {
+                        "status": "ok",
+                        "command": common.sync_team_commands(config, str(team_id)),
+                    }
+                except common.MattermostAPIError as exc:
+                    had_errors = True
+                    results[str(team_id)] = {
+                        "status": "error",
+                        "error": str(exc),
+                    }
+            json_response(self, HTTPStatus.BAD_GATEWAY if had_errors else HTTPStatus.OK, {"teams": results})
+            return
+        json_response(self, HTTPStatus.NOT_FOUND, {"error": "not_found"})
+
+    def _do_interactions_get(self, parsed: urllib.parse.ParseResult) -> None:
+        if parsed.path == "/":
+            json_response(
+                self,
+                HTTPStatus.OK,
+                {
+                    "service": common.current_service_name(),
+                    "status": "ok",
+                    "interactions_url": common.interactions_url(),
+                },
+            )
+            return
+        json_response(self, HTTPStatus.NOT_FOUND, {"error": "not_found"})
+
+    def _do_interactions_post(self, parsed: urllib.parse.ParseResult) -> None:
+        path = parsed.path.rstrip("/") or "/"
+        if path == common.COMMAND_ROUTE_PATH:
+            self._handle_slash_command()
+            return
+        if path.startswith(common.DIALOG_ROUTE_PATH + "/"):
+            self._handle_dialog_submission(path[len(common.DIALOG_ROUTE_PATH) + 1 :])
+            return
+        if path.startswith(common.ACTION_ROUTE_PATH + "/"):
+            self._handle_message_action(path[len(common.ACTION_ROUTE_PATH) + 1 :])
+            return
+        json_response(self, HTTPStatus.NOT_FOUND, {"error": "not_found"})
+
+    def _handle_slash_command(self) -> None:
+        body = self._read_body()
+        if body is None:
+            json_response(self, HTTPStatus.REQUEST_ENTITY_TOO_LARGE, {"error": "request_too_large"})
+            return
+        content_type = str(self.headers.get("Content-Type", "")).split(";")[0].strip().lower()
+        try:
+            if content_type == "application/json":
+                decoded = json.loads(body.decode("utf-8") or "{}")
+                if not isinstance(decoded, dict):
+                    raise ValueError("request body must be an object")
+                form = {str(key): "" if value is None else str(value) for key, value in decoded.items()}
+            else:
+                parsed_form = urllib.parse.parse_qs(body.decode("utf-8"), keep_blank_values=True)
+                form = {key: (values[0] if values else "") for key, values in parsed_form.items()}
+        except (UnicodeDecodeError, ValueError, json.JSONDecodeError) as exc:
+            json_response(self, HTTPStatus.BAD_REQUEST, {"error": f"invalid slash command payload: {exc}"})
+            return
+
+        if not common.load_command_token():
+            json_response(self, HTTPStatus.SERVICE_UNAVAILABLE, {"error": "mattermost command token is not configured"})
+            return
+        if not common.verify_command_token(str(form.get("token", ""))):
+            json_response(self, HTTPStatus.UNAUTHORIZED, {"error": "invalid_command_token"})
+            return
+
+        maybe_prune_request_state()
+        maybe_recover_request_state()
+
+        config = common.load_config()
+        invocation = normalize_command_invocation(form)
+        interaction_id = command_interaction_id(invocation)
+
+        existing_receipt = common.load_interaction_receipt(interaction_id) if interaction_id else None
+        if existing_receipt:
+            interaction_response(self, replay_response_from_receipt(existing_receipt, surface="command"))
+            return
+
+        if not invocation["team_id"]:
+            response = build_message_response(human_reason("team_required"), ephemeral=True)
+            persist_interaction_receipt(interaction_id, receipt_payload(response, response_kind="message"))
+            interaction_response(self, response)
+            return
+
+        parsed_command = parse_command_text(config, invocation, common.command_name(config))
+        command = str(parsed_command.get("command", "")).strip()
+        if command != "fix":
+            response = build_message_response(human_reason("command_not_supported"), ephemeral=True)
+            persist_interaction_receipt(interaction_id, receipt_payload(response, response_kind="message"))
+            interaction_response(self, response)
+            return
+
+        rig_name = str(parsed_command.get("rig", "")).strip()
+        prompt = str(parsed_command.get("prompt", "")).strip()
+        if prompt:
+            summary, context_markdown = prompt_to_summary_context(prompt)
+            outcome, receipt = accept_fix_request(invocation, summary, context_markdown, interaction_id, rig_name=rig_name)
+            response = command_response_for_outcome(outcome)
+            receipt = dict(receipt)
+            receipt["response"] = response
+            persist_interaction_receipt(interaction_id, receipt)
+            interaction_response(self, response)
+            return
+
+        # No inline prompt: open the interactive dialog. The trigger_id is
+        # short lived (Mattermost expires it after OutgoingIntegrationRequestsTimeout
+        # seconds), so the dialog is opened before any other work.
+        trigger_id = invocation["trigger_id"]
+        if not trigger_id:
+            response = build_message_response(human_reason("dialog_open_failed"), ephemeral=True)
+            persist_interaction_receipt(interaction_id, receipt_payload(response, response_kind="message"))
+            interaction_response(self, response)
+            return
+        nonce = secrets.token_hex(12)
+        common.save_pending_modal(
+            {
+                "nonce": nonce,
+                "team_id": invocation["team_id"],
+                "team_domain": invocation["team_domain"],
+                "channel_id": invocation["channel_id"],
+                "channel_name": invocation["channel_name"],
+                "root_id": invocation["root_id"],
+                "user_id": invocation["user_id"],
+                "user_name": invocation["user_name"],
+                "interaction_id": interaction_id,
+                "command": "fix",
+                "command_trigger": invocation["command"],
+                "rig_name": rig_name,
+            }
+        )
+        try:
+            open_fix_dialog(trigger_id, common.mint_dialog_state(nonce))
+        except (common.MattermostAPIError, ValueError) as exc:
+            common.remove_pending_modal(nonce)
+            self.log_message("dialog open failed: %s", exc)
+            response = build_message_response(human_reason("dialog_open_failed"), ephemeral=True)
+            persist_interaction_receipt(interaction_id, receipt_payload(response, response_kind="message"))
+            interaction_response(self, response)
+            return
+        common.save_interaction_receipt(
+            interaction_id,
+            {"response_kind": "dialog", "dialog_nonce": nonce, "command_name": common.command_name(config)},
+        )
+        # Mattermost renders the dialog itself; an empty response keeps the
+        # channel clean while the operator fills it in.
+        interaction_response(self, {})
+
+    def _handle_dialog_submission(self, route_token: str) -> None:
+        if not common.verify_dialog_route_token(route_token):
+            json_response(self, HTTPStatus.UNAUTHORIZED, {"error": "invalid_dialog_route_token"})
+            return
+        body = self._read_body()
+        if body is None:
+            json_response(self, HTTPStatus.REQUEST_ENTITY_TOO_LARGE, {"error": "request_too_large"})
+            return
+        try:
+            payload = json.loads(body.decode("utf-8") or "{}")
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            json_response(self, HTTPStatus.BAD_REQUEST, {"error": f"invalid JSON payload: {exc}"})
+            return
+        if not isinstance(payload, dict):
+            json_response(self, HTTPStatus.BAD_REQUEST, {"error": "request body must be an object"})
+            return
+
+        maybe_prune_request_state()
+        maybe_recover_request_state()
+
+        if str(payload.get("type", "")).strip() not in {"", "dialog_submission"}:
+            interaction_response(self, build_dialog_error_response("command_not_supported"))
+            return
+
+        state = str(payload.get("state", "")).strip()
+        nonce = common.verify_dialog_state(state)
+        interaction_id = dialog_interaction_id(nonce)
+
+        with DIALOG_SUBMIT_LOCK:
+            existing_receipt = common.load_interaction_receipt(interaction_id) if interaction_id else None
+            if existing_receipt:
+                interaction_response(self, replay_response_from_receipt(existing_receipt, surface="dialog"))
+                return
+            # `consume_pending_modal` re-verifies the HMAC state and is single use.
+            pending = common.consume_pending_modal(state) if state else None
+            if not nonce or not pending:
+                interaction_response(self, build_dialog_error_response("dialog_expired"))
+                return
+            if bool(payload.get("cancelled")):
+                interaction_response(self, build_dialog_ok_response())
+                return
+            invocation = normalize_dialog_invocation(payload, pending)
+            if str(pending.get("team_id", "")) and str(payload.get("team_id", "")).strip():
+                if str(pending.get("team_id", "")) != str(payload.get("team_id", "")).strip():
+                    interaction_response(self, build_dialog_error_response("bad_dialog_context"))
+                    return
+            if str(pending.get("channel_id", "")) != str(payload.get("channel_id", "")).strip():
+                interaction_response(self, build_dialog_error_response("bad_dialog_context"))
+                return
+            expected_user = str(pending.get("user_id", "")).strip()
+            actual_user = str(payload.get("user_id", "")).strip()
+            if expected_user and expected_user != actual_user:
+                interaction_response(self, build_dialog_error_response("bad_dialog_context"))
+                return
+            fields = extract_dialog_fields(payload)
+            summary = str(fields.get("summary", "")).strip()
+            context_markdown = str(fields.get("context", "")).strip()
+            rig_name = str(pending.get("rig_name", "")).strip()
+            outcome, receipt = accept_fix_request(invocation, summary, context_markdown, interaction_id, rig_name=rig_name)
+            response = dialog_response_for_outcome(outcome, invocation)
+            receipt = dict(receipt)
+            receipt["response"] = response
+            persist_interaction_receipt(interaction_id, receipt)
+            if outcome.get("kind") != "message":
+                finalize_dialog_origin_receipt(str(pending.get("interaction_id", "")), receipt)
+        interaction_response(self, response)
+
+    def _handle_message_action(self, route_token: str) -> None:
+        if not common.verify_dialog_route_token(route_token):
+            json_response(self, HTTPStatus.UNAUTHORIZED, {"error": "invalid_dialog_route_token"})
+            return
+        if self._read_body() is None:
+            json_response(self, HTTPStatus.REQUEST_ENTITY_TOO_LARGE, {"error": "request_too_large"})
+            return
+        interaction_response(self, {"ephemeral_text": "Unsupported Mattermost interactive action."})
+
+
+def command_interaction_id(invocation: dict[str, str]) -> str:
+    """Stable idempotency key for one slash-command invocation.
+
+    Mattermost slash commands carry no interaction id, but `trigger_id` is
+    minted per invocation, so it stands in for Discord's `interaction.id`.
+    """
+    trigger_id = str(invocation.get("trigger_id", "")).strip()
+    if trigger_id:
+        return common.safe_storage_id(f"mm-command:{trigger_id}", "command")
+    return common.safe_storage_id(f"mm-command:{secrets.token_hex(16)}", "command")
+
+
+def dialog_interaction_id(nonce: str) -> str:
+    normalized = str(nonce).strip()
+    if not normalized:
+        return ""
+    return common.safe_storage_id(f"mm-dialog:{normalized}", "dialog")
+
+
+def main() -> int:
+    common.ensure_layout()
+    if should_run_request_recovery():
+        recover_incomplete_requests()
+    socket_path = os.environ.get("GC_SERVICE_SOCKET")
+    try:
+        common.prepare_service_socket(socket_path or "")
+    except RuntimeError as exc:
+        raise SystemExit(str(exc)) from exc
+    with ThreadingUnixHTTPServer(socket_path, IntakeHandler) as server:
+        print(f"[{common.current_service_name() or 'mattermost'}] listening on {socket_path}")
+        server.serve_forever()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/mattermost/scripts/mattermost_intake_status.py
+++ b/mattermost/scripts/mattermost_intake_status.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+import mattermost_intake_common as common
+
+
+def render_text(snapshot: dict[str, object]) -> str:
+    config = snapshot.get("config", {})
+    app = ((config or {}).get("app") or {})
+    gateway = snapshot.get("gateway_status", {})
+    requests = snapshot.get("recent_requests", [])
+    bindings = snapshot.get("chat_bindings", [])
+    launchers = snapshot.get("chat_launchers", [])
+    ingress = snapshot.get("recent_chat_ingress", [])
+    publishes = snapshot.get("recent_chat_publishes", [])
+    launches = snapshot.get("recent_room_launches", [])
+    lines = [
+        "Mattermost",
+        f"  interactions_url:   {snapshot.get('interactions_url') or '(not published yet)'}",
+        f"  admin_url:          {snapshot.get('admin_url') or '(not published yet)'}",
+        f"  server_url:         {app.get('site_url') or '(not imported yet)'}",
+        f"  team_id:            {app.get('team_id') or '-'}",
+        f"  bot_user_id:        {app.get('bot_user_id') or '-'}",
+        f"  command_name:       {app.get('command_name', common.COMMAND_NAME_DEFAULT)}",
+        f"  command_id:         {app.get('command_id') or '-'}",
+        f"  bot_token:          {'present' if app.get('bot_token_present') else 'missing'}",
+        f"  verification_token: {'present' if app.get('command_token_present') else 'missing'}",
+        f"  gateway_state:      {((gateway or {}).get('state') or '(unknown)')}",
+        f"  gateway_error:      {((gateway or {}).get('last_error') or '-')}",
+        f"  channel_mappings:   {len(((config or {}).get('channels') or {}))}",
+        f"  rig_mappings:       {len(((config or {}).get('rigs') or {}))}",
+        f"  chat_bindings:      {len(bindings)}",
+        f"  chat_launchers:     {len(launchers)}",
+        f"  chat_ingress:       {len(ingress)}",
+        f"  chat_publishes:     {len(publishes)}",
+        "",
+        "Recent Requests:",
+    ]
+    if not requests:
+        lines.append("  (none)")
+    else:
+        for item in requests:
+            lines.append(
+                "  - {request_id} {status} team={team_id} conversation={conversation_id} bead={bead_id}".format(
+                    request_id=item.get("request_id", ""),
+                    status=item.get("status", ""),
+                    team_id=item.get("team_id", ""),
+                    conversation_id=item.get("conversation_id", ""),
+                    bead_id=item.get("bead_id", ""),
+                )
+            )
+    lines.append("")
+    lines.append("Chat Bindings:")
+    if not bindings:
+        lines.append("  (none)")
+    else:
+        for item in bindings:
+            lines.append(
+                "  - {binding_id} kind={kind} conversation={conversation_id} sessions={sessions}".format(
+                    binding_id=item.get("id", ""),
+                    kind=item.get("kind", ""),
+                    conversation_id=item.get("conversation_id", ""),
+                    sessions=",".join(item.get("session_names", [])),
+                )
+            )
+    lines.append("")
+    lines.append("Chat Launchers:")
+    if not launchers:
+        lines.append("  (none)")
+    else:
+        for item in launchers:
+            lines.append(
+                "  - {launcher_id} room={conversation_id} mode={mode} default={default}".format(
+                    launcher_id=item.get("id", ""),
+                    conversation_id=item.get("conversation_id", ""),
+                    mode=item.get("response_mode", ""),
+                    default=item.get("default_qualified_handle", "") or "-",
+                )
+            )
+    lines.append("")
+    lines.append("Recent Chat Ingress:")
+    if not ingress:
+        lines.append("  (none)")
+    else:
+        for item in ingress:
+            lines.append(
+                "  - {ingress_id} binding={binding_id} status={status} from={from_display} preview={preview}".format(
+                    ingress_id=item.get("ingress_id", ""),
+                    binding_id=item.get("binding_id", ""),
+                    status=item.get("status", ""),
+                    from_display=item.get("from_display", ""),
+                    preview=item.get("body_preview", ""),
+                )
+            )
+    lines.append("")
+    lines.append("Recent Chat Publishes:")
+    if not publishes:
+        lines.append("  (none)")
+    else:
+        for item in publishes:
+            lines.append(
+                "  - {publish_id} binding={binding_id} session={session_name} remote={remote_message_id}".format(
+                    publish_id=item.get("publish_id", ""),
+                    binding_id=item.get("binding_id", ""),
+                    session_name=item.get("source_session_name", ""),
+                    remote_message_id=item.get("remote_message_id", ""),
+                )
+            )
+    lines.append("")
+    lines.append("Recent Room Launches:")
+    if not launches:
+        lines.append("  (none)")
+    else:
+        for item in launches:
+            lines.append(
+                "  - {launch_id} room={conversation_id} handle={qualified_handle} root={root_id}".format(
+                    launch_id=item.get("launch_id", ""),
+                    conversation_id=item.get("conversation_id", ""),
+                    qualified_handle=item.get("qualified_handle", ""),
+                    root_id=item.get("root_post_id", "") or "(pending)",
+                )
+            )
+    return "\n".join(lines)
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Show Mattermost provider status")
+    parser.add_argument("--json", action="store_true", help="Print JSON instead of text")
+    parser.add_argument("--limit", type=int, default=20, help="Number of recent requests to show")
+    args = parser.parse_args(argv)
+
+    snapshot = common.build_status_snapshot(limit=max(1, args.limit))
+    if args.json:
+        print(json.dumps(snapshot, indent=2, sort_keys=True))
+    else:
+        print(render_text(snapshot))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/mattermost/scripts/mattermost_intake_sync_commands.py
+++ b/mattermost/scripts/mattermost_intake_sync_commands.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+import mattermost_intake_common as common
+
+
+def _redact_command(command: object) -> object:
+    if not isinstance(command, dict):
+        return command
+    body = dict(command)
+    if body.get("token"):
+        body["token"] = "[redacted]"
+    return body
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Register team-scoped Mattermost slash commands")
+    parser.add_argument("team_id", nargs="+", help="One or more Mattermost team ids")
+    args = parser.parse_args(argv)
+
+    config = common.load_config()
+    results: dict[str, object] = {}
+    had_errors = False
+    for team_id in args.team_id:
+        try:
+            results[team_id] = {
+                "status": "ok",
+                "command": _redact_command(common.sync_team_commands(config, team_id)),
+            }
+        except common.MattermostAPIError as exc:
+            had_errors = True
+            results[team_id] = {
+                "status": "error",
+                "error": str(exc),
+            }
+    print(json.dumps({"teams": results}, indent=2, sort_keys=True))
+    return 1 if had_errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/mattermost/scripts/mattermost_room_launch.py
+++ b/mattermost/scripts/mattermost_room_launch.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Any
+
+import mattermost_intake_common as common
+
+
+def _optional_bool(enabled: bool, disabled: bool, *, enable_flag: str, disable_flag: str) -> bool | None:
+    if enabled and disabled:
+        raise SystemExit(f"choose only one of {enable_flag} or {disable_flag}")
+    if enabled:
+        return True
+    if disabled:
+        return False
+    return None
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Enable launcher mode for a Mattermost root room")
+    parser.add_argument("--team-id", required=True, help="Mattermost team id")
+    parser.add_argument(
+        "--response-mode",
+        default="mention_only",
+        choices=("mention_only", "respond_all"),
+        help="How root-room messages are routed",
+    )
+    parser.add_argument(
+        "--default-handle",
+        default="",
+        help="Qualified rig/alias handle used for respond_all rooms",
+    )
+    parser.add_argument("--enable-peer-fanout", action="store_true", help="Enable peer fanout in managed threads")
+    parser.add_argument("--disable-peer-fanout", action="store_true", help="Disable peer fanout in managed threads")
+    parser.add_argument(
+        "--allow-untargeted-peer-fanout",
+        action="store_true",
+        help="Allow untargeted peer fanout inside managed threads",
+    )
+    parser.add_argument(
+        "--disallow-untargeted-peer-fanout",
+        action="store_true",
+        help="Require explicit @@rig/alias peer targeting in managed threads",
+    )
+    parser.add_argument("conversation_id", help="Mattermost channel id for the root room")
+    args = parser.parse_args(argv)
+
+    default_handle = str(args.default_handle).strip().lower()
+    if default_handle:
+        try:
+            qualified_handle, resolve_error = common.resolve_agent_handle(default_handle)
+        except common.GCAPIError as exc:
+            raise SystemExit(str(exc)) from exc
+        if resolve_error:
+            raise SystemExit(resolve_error)
+        default_handle = qualified_handle
+
+    peer_fanout = _optional_bool(
+        args.enable_peer_fanout,
+        args.disable_peer_fanout,
+        enable_flag="--enable-peer-fanout",
+        disable_flag="--disable-peer-fanout",
+    )
+    untargeted_peer_fanout = _optional_bool(
+        args.allow_untargeted_peer_fanout,
+        args.disallow_untargeted_peer_fanout,
+        enable_flag="--allow-untargeted-peer-fanout",
+        disable_flag="--disallow-untargeted-peer-fanout",
+    )
+
+    policy: dict[str, Any] = {}
+    if peer_fanout is not None:
+        policy["peer_fanout_enabled"] = peer_fanout
+    if untargeted_peer_fanout is not None:
+        policy["allow_untargeted_peer_fanout"] = untargeted_peer_fanout
+
+    try:
+        config = common.set_room_launcher(
+            common.load_config(),
+            args.team_id,
+            args.conversation_id,
+            response_mode=args.response_mode,
+            default_qualified_handle=default_handle,
+            policy=policy or None,
+        )
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
+
+    launcher = common.resolve_room_launcher(config, args.conversation_id)
+    print(json.dumps(launcher or {}, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/mattermost/template-fragments/mattermost-v0.template.md
+++ b/mattermost/template-fragments/mattermost-v0.template.md
@@ -1,0 +1,68 @@
+{{ define "mattermost-v0" -}}
+You are in a shared Mattermost thread with humans and other agents.
+{{- if .TemplateName }}
+You were created from the **{{ .TemplateName }}** template. When someone mentions
+"{{ .TemplateName }}" (or @{{ .TemplateName }}), they are likely addressing you.
+{{- end }}
+
+## How this thread works
+
+A Mattermost thread is not its own channel. It is the set of posts that share a
+root post id inside one channel, so everyone with access to that channel sees
+every message — humans and agents alike. There is no private channel. When you
+reply via `gc mattermost reply-current`, your message is visible to all
+participants.
+
+## When to respond
+
+- **You are named directly** ("sky, fix the tests" or "@sky"): You should
+  definitely respond. This is a strong signal the message is for you.
+- **Multiple agents named** ("sky, priya, work together"): All named agents
+  should respond. Coordinate via the thread — you can see each other's messages.
+- **No one is named, but you have relevant info**: Respond if you can genuinely
+  add value. If another agent already handled it or you have nothing to add,
+  stay silent. Silence is fine.
+- **A peer agent says something relevant to your work**: You may respond. This
+  is a shared workspace. But do not pile on — if the conversation is between a
+  human and another agent, let them finish unless you have something important.
+- **A peer agent says something not relevant to you**: Read it for context,
+  move on. Do not echo, summarize, or acknowledge.
+
+The key test: **does this message need MY input?** If yes, respond. If maybe,
+use judgment. If no, listen.
+
+## Replying to Mattermost
+
+Normal assistant output stays private to the session. Do not assume a human on
+Mattermost can see it.
+
+If the event includes `reply_contract: explicit_publish_required`, follow that
+contract literally: plain assistant output does not go back to Mattermost.
+
+To send a human-visible reply, write the body to a file and run:
+```
+gc mattermost reply-current --body-file <path>
+```
+
+Always prefix your Mattermost messages with your handle in bold so humans and
+other agents can tell who is speaking. Example: if your handle is `randy`,
+start replies with `**randy:** `.
+
+Do not put long replies inline in `--body`. Use `--body-file`.
+Do not pipe the command through filters that can hide failures.
+Only claim success after the command returns JSON with a non-empty
+`record.remote_message_id`.
+
+## Agent-to-agent communication
+
+When addressing a specific peer, use `@name` for clarity (e.g., "@priya can
+you look at the test failures?"). This makes it unambiguous who you are
+talking to and helps the routing layer.
+
+## Thread creation
+
+Threads start automatically when a human `@@handle`-mentions an agent in a
+launcher room: the first agent reply is posted as a reply to that message, and
+the resulting root post id becomes the thread. Do not try to start or retarget
+threads yourself — `reply-current` already carries the correct root post id.
+{{- end }}

--- a/mattermost/tests/test_mattermost_chat_react_upload.py
+++ b/mattermost/tests/test_mattermost_chat_react_upload.py
@@ -1,0 +1,751 @@
+from __future__ import annotations
+
+import io
+import json
+import pathlib
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from unittest import mock
+
+import os
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+
+import mattermost_chat_react as react_script
+import mattermost_chat_upload as upload_script
+import mattermost_intake_common as common
+
+
+CHANNEL = "9h5j7k1m3n5p7r9t1v3x5z7b9c"
+POST = "5s7t9u1v3w5x7y9z1a3b5c7d9e"
+ROOT_POST = "2a4b6c8d0e2f4g6h8i0j2k4m6n"
+TEAM = "7k3m9x2c5n8b1v4z6q0r2s4t6w"
+BOT_USER = "3c5e7g9i1k3m5o7q9s1u3w5y7a"
+
+
+def _reply_context(**overrides: str) -> dict[str, str]:
+    """The shape find_latest_mattermost_reply_context() returns."""
+    context = {
+        "kind": common.HUMAN_MESSAGE_EVENT_KIND,
+        "binding_id": f"room:{CHANNEL}",
+        "ingress_receipt_id": "in-1",
+        "mattermost_post_id": POST,
+        "publish_binding_id": f"room:{CHANNEL}",
+        "publish_conversation_id": CHANNEL,
+        "publish_trigger_id": POST,
+        "publish_root_post_id": ROOT_POST,
+        "team_id": TEAM,
+    }
+    context.update(overrides)
+    return context
+
+
+class MattermostScriptTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self._old_environ = os.environ.copy()
+        os.environ["GC_CITY_ROOT"] = self.tempdir.name
+        for key in ("GC_SESSION_ID", "GC_SESSION_NAME", "GC_ALIAS"):
+            os.environ.pop(key, None)
+        os.environ["GC_SESSION_NAME"] = "sky"
+
+    def tearDown(self) -> None:
+        os.environ.clear()
+        os.environ.update(self._old_environ)
+
+    def _tempfile(self, name: str, content: bytes = b"hello bytes") -> pathlib.Path:
+        path = pathlib.Path(self.tempdir.name) / name
+        path.write_bytes(content)
+        return path
+
+
+# ----------------------------------------------------------------------
+# gc mattermost react
+# ----------------------------------------------------------------------
+
+
+class MattermostChatReactTests(MattermostScriptTestCase):
+    def test_explicit_target_adds_reaction(self) -> None:
+        with mock.patch.object(common, "resolve_bot_user_id", return_value=BOT_USER), mock.patch.object(
+            common, "add_message_reaction", return_value={"user_id": BOT_USER, "post_id": POST, "emoji_name": "eyes"}
+        ) as add_message_reaction, mock.patch.object(
+            common, "find_latest_mattermost_reply_context"
+        ) as find_context:
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                code = react_script.main(["--conversation-id", CHANNEL, "--message-id", POST])
+
+        self.assertEqual(code, 0)
+        find_context.assert_not_called()
+        add_message_reaction.assert_called_once_with(POST, "eyes", user_id=BOT_USER)
+        receipt = json.loads(stdout.getvalue())
+        self.assertTrue(receipt["delivered"])
+        self.assertEqual(receipt["mode"], "explicit")
+        self.assertEqual(receipt["emoji"], "eyes")
+        self.assertEqual(receipt["conversation_id"], CHANNEL)
+        self.assertEqual(receipt["post_id"], POST)
+        self.assertEqual(receipt["user_id"], BOT_USER)
+        self.assertEqual(receipt["binding_id"], "")
+        self.assertEqual(receipt["failure_kind"], "")
+        self.assertEqual(receipt["error"], "")
+
+    def test_current_mode_uses_latest_inbound_post(self) -> None:
+        with mock.patch.object(
+            common, "find_latest_mattermost_reply_context", return_value=_reply_context()
+        ) as find_context, mock.patch.object(
+            common, "resolve_bot_user_id", return_value=BOT_USER
+        ), mock.patch.object(common, "add_message_reaction", return_value={"emoji_name": "eyes"}) as add_reaction:
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                code = react_script.main([])
+
+        self.assertEqual(code, 0)
+        find_context.assert_called_once_with("", tail=react_script.DEFAULT_TRANSCRIPT_TAIL)
+        add_reaction.assert_called_once_with(POST, "eyes", user_id=BOT_USER)
+        receipt = json.loads(stdout.getvalue())
+        self.assertEqual(receipt["mode"], "current")
+        self.assertEqual(receipt["conversation_id"], CHANNEL)
+        self.assertEqual(receipt["binding_id"], f"room:{CHANNEL}")
+        self.assertEqual(receipt["session_selector"], "sky")
+
+    def test_current_mode_honours_session_override(self) -> None:
+        with mock.patch.object(
+            common, "find_latest_mattermost_reply_context", return_value=_reply_context()
+        ) as find_context, mock.patch.object(
+            common, "resolve_bot_user_id", return_value=BOT_USER
+        ), mock.patch.object(common, "add_message_reaction", return_value={}):
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                code = react_script.main(["--session", "corp--priya"])
+
+        self.assertEqual(code, 0)
+        find_context.assert_called_once_with("corp--priya", tail=react_script.DEFAULT_TRANSCRIPT_TAIL)
+        self.assertEqual(json.loads(stdout.getvalue())["session_selector"], "corp--priya")
+
+    def test_current_mode_falls_back_to_publish_trigger_id(self) -> None:
+        context = _reply_context()
+        context.pop("mattermost_post_id")
+        context["publish_trigger_id"] = "fallback-post"
+
+        with mock.patch.object(
+            common, "find_latest_mattermost_reply_context", return_value=context
+        ), mock.patch.object(common, "resolve_bot_user_id", return_value=BOT_USER), mock.patch.object(
+            common, "add_message_reaction", return_value={}
+        ) as add_reaction:
+            with redirect_stdout(io.StringIO()):
+                code = react_script.main([])
+
+        self.assertEqual(code, 0)
+        add_reaction.assert_called_once_with("fallback-post", "eyes", user_id=BOT_USER)
+
+    def test_current_flag_is_the_explicit_default_mode(self) -> None:
+        with mock.patch.object(
+            common, "find_latest_mattermost_reply_context", return_value=_reply_context()
+        ), mock.patch.object(common, "resolve_bot_user_id", return_value=BOT_USER), mock.patch.object(
+            common, "add_message_reaction", return_value={}
+        ):
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                code = react_script.main(["--current"])
+
+        self.assertEqual(code, 0)
+        self.assertEqual(json.loads(stdout.getvalue())["mode"], "current")
+
+    # -- emoji normalization ------------------------------------------------
+
+    def test_emoji_colons_are_stripped(self) -> None:
+        for raw, expected in ((":thumbsup:", "thumbsup"), ("  white_check_mark  ", "white_check_mark"), (": eyes :", "eyes")):
+            with self.subTest(raw=raw):
+                with mock.patch.object(common, "resolve_bot_user_id", return_value=BOT_USER), mock.patch.object(
+                    common, "add_message_reaction", return_value={}
+                ) as add_reaction:
+                    stdout = io.StringIO()
+                    with redirect_stdout(stdout):
+                        code = react_script.main(
+                            ["--conversation-id", CHANNEL, "--message-id", POST, "--emoji", raw]
+                        )
+
+                self.assertEqual(code, 0)
+                add_reaction.assert_called_once_with(POST, expected, user_id=BOT_USER)
+                self.assertEqual(json.loads(stdout.getvalue())["emoji"], expected)
+
+    def test_default_emoji_is_eyes(self) -> None:
+        self.assertEqual(react_script.DEFAULT_EMOJI, "eyes")
+
+    def test_blank_emoji_is_rejected(self) -> None:
+        for raw in ("", "   ", "::", ":  :"):
+            with self.subTest(raw=raw):
+                with self.assertRaises(SystemExit) as exc:
+                    react_script.main(["--conversation-id", CHANNEL, "--message-id", POST, "--emoji", raw])
+                self.assertEqual(str(exc.exception), "--emoji must be a non-empty emoji name such as eyes")
+
+    # -- argument validation ------------------------------------------------
+
+    def test_conversation_id_without_message_id_is_rejected(self) -> None:
+        with self.assertRaises(SystemExit) as exc:
+            react_script.main(["--conversation-id", CHANNEL])
+
+        self.assertEqual(str(exc.exception), "--conversation-id and --message-id must be passed together")
+
+    def test_message_id_without_conversation_id_is_rejected(self) -> None:
+        with self.assertRaises(SystemExit) as exc:
+            react_script.main(["--message-id", POST])
+
+        self.assertEqual(str(exc.exception), "--conversation-id and --message-id must be passed together")
+
+    def test_current_cannot_be_combined_with_explicit_target(self) -> None:
+        with self.assertRaises(SystemExit) as exc:
+            react_script.main(["--current", "--conversation-id", CHANNEL, "--message-id", POST])
+
+        self.assertEqual(str(exc.exception), "--current cannot be combined with --conversation-id/--message-id")
+
+    def test_missing_transcript_context_suggests_explicit_flags(self) -> None:
+        with mock.patch.object(
+            common,
+            "find_latest_mattermost_reply_context",
+            side_effect=common.GCAPIError("no recent mattermost event with publish metadata found for sky"),
+        ):
+            with self.assertRaises(SystemExit) as exc:
+                react_script.main([])
+
+        self.assertEqual(
+            str(exc.exception),
+            "no recent mattermost event with publish metadata found for sky; "
+            "pass --conversation-id <channel_id> --message-id <post_id> to react to a specific post",
+        )
+
+    def test_context_without_a_post_id_is_rejected(self) -> None:
+        context = _reply_context()
+        context.pop("mattermost_post_id")
+        context["publish_trigger_id"] = ""
+
+        with mock.patch.object(common, "find_latest_mattermost_reply_context", return_value=context):
+            with self.assertRaises(SystemExit) as exc:
+                react_script.main([])
+
+        self.assertEqual(
+            str(exc.exception),
+            "latest mattermost event has no post id; pass --conversation-id and --message-id explicitly",
+        )
+
+    # -- REST failure modes -------------------------------------------------
+
+    def test_reaction_failures_map_to_failure_kinds(self) -> None:
+        cases = (
+            (404, "not_found"),
+            (401, "auth"),
+            (403, "auth"),
+            (429, "rate_limited"),
+            (400, "invalid_request"),
+            (500, "error"),
+            (None, "error"),
+        )
+        for status, expected in cases:
+            with self.subTest(status=status):
+                error = common.MattermostAPIError("boom", status_code=status)
+                with mock.patch.object(common, "resolve_bot_user_id", return_value=BOT_USER), mock.patch.object(
+                    common, "add_message_reaction", side_effect=error
+                ):
+                    stdout = io.StringIO()
+                    with redirect_stdout(stdout):
+                        code = react_script.main(["--conversation-id", CHANNEL, "--message-id", POST])
+
+                self.assertEqual(code, 1)
+                receipt = json.loads(stdout.getvalue())
+                self.assertFalse(receipt["delivered"])
+                self.assertEqual(receipt["failure_kind"], expected)
+                self.assertEqual(receipt["error"], "boom")
+                self.assertNotIn("reaction", receipt)
+
+    def test_unresolvable_bot_user_id_returns_a_failure_receipt(self) -> None:
+        with mock.patch.object(common, "resolve_bot_user_id", return_value=""), mock.patch.object(
+            common, "add_message_reaction"
+        ) as add_reaction:
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                code = react_script.main(["--conversation-id", CHANNEL, "--message-id", POST])
+
+        self.assertEqual(code, 1)
+        add_reaction.assert_not_called()
+        receipt = json.loads(stdout.getvalue())
+        self.assertFalse(receipt["delivered"])
+        self.assertEqual(receipt["failure_kind"], "error")
+        self.assertEqual(receipt["error"], "could not resolve the bot user id from GET /users/me")
+
+    def test_unconfigured_site_url_returns_a_failure_receipt(self) -> None:
+        # resolve_bot_user_id() reaches the HTTP layer, which raises before any
+        # request is made when site_url is unset.
+        stdout = io.StringIO()
+        with redirect_stdout(stdout):
+            code = react_script.main(["--conversation-id", CHANNEL, "--message-id", POST])
+
+        self.assertEqual(code, 1)
+        receipt = json.loads(stdout.getvalue())
+        self.assertFalse(receipt["delivered"])
+        self.assertEqual(receipt["failure_kind"], "error")
+        self.assertEqual(receipt["error"], "Mattermost site_url is not configured")
+
+
+# ----------------------------------------------------------------------
+# gc mattermost upload
+# ----------------------------------------------------------------------
+
+
+class MattermostChatUploadTests(MattermostScriptTestCase):
+    def _bind_room(self, *, root_id: str = "") -> dict[str, object]:
+        conversation_id = common.mattermost_conversation_key(CHANNEL, root_id)
+        common.set_chat_binding(common.load_config(), "room", conversation_id, ["sky"], team_id=TEAM)
+        binding = common.resolve_chat_binding(
+            common.load_config(), common.chat_binding_id("room", conversation_id)
+        )
+        assert binding is not None
+        return binding
+
+    # -- argument validation ------------------------------------------------
+
+    def test_root_id_and_thread_current_are_mutually_exclusive(self) -> None:
+        path = self._tempfile("plot.png")
+        with self.assertRaises(SystemExit) as exc:
+            upload_script.main(["--file", str(path), "--root-id", ROOT_POST, "--thread-current"])
+
+        self.assertEqual(str(exc.exception), "--root-id and --thread-current are mutually exclusive")
+
+    def test_file_is_required(self) -> None:
+        with self.assertRaises(SystemExit) as exc, redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
+            upload_script.main([])
+
+        # argparse exits with status 2 for a missing required flag.
+        self.assertEqual(exc.exception.code, 2)
+
+    def test_via_only_accepts_gc_or_adapter(self) -> None:
+        path = self._tempfile("plot.png")
+        with self.assertRaises(SystemExit) as exc, redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
+            upload_script.main(["--file", str(path), "--via", "smoke-signal"])
+
+        self.assertEqual(exc.exception.code, 2)
+
+    def test_missing_file_is_rejected(self) -> None:
+        missing = str(pathlib.Path(self.tempdir.name) / "nope.png")
+        with self.assertRaises(SystemExit) as exc:
+            upload_script.main(["--file", missing])
+
+        self.assertEqual(str(exc.exception), f"file not found: {missing}")
+
+    def test_directory_is_rejected(self) -> None:
+        with self.assertRaises(SystemExit) as exc:
+            upload_script.main(["--file", self.tempdir.name])
+
+        self.assertEqual(str(exc.exception), f"not a regular file: {self.tempdir.name}")
+
+    def test_missing_transcript_context_suggests_binding(self) -> None:
+        path = self._tempfile("plot.png")
+        with mock.patch.object(
+            common, "find_latest_mattermost_reply_context", side_effect=common.GCAPIError("no recent event")
+        ):
+            with self.assertRaises(SystemExit) as exc:
+                upload_script.main(["--file", str(path)])
+
+        self.assertEqual(
+            str(exc.exception),
+            "no recent event; bind this session with `gc mattermost bind-room` or `gc mattermost bind-dm` first",
+        )
+
+    def test_context_without_binding_id_is_rejected(self) -> None:
+        path = self._tempfile("plot.png")
+        context = _reply_context(publish_binding_id="")
+        with mock.patch.object(common, "find_latest_mattermost_reply_context", return_value=context):
+            with self.assertRaises(SystemExit) as exc:
+                upload_script.main(["--file", str(path)])
+
+        self.assertEqual(str(exc.exception), "latest mattermost event has no publish_binding_id")
+
+    def test_unknown_binding_is_rejected(self) -> None:
+        path = self._tempfile("plot.png")
+        with mock.patch.object(common, "find_latest_mattermost_reply_context", return_value=_reply_context()):
+            with self.assertRaises(SystemExit) as exc:
+                upload_script.main(["--file", str(path)])
+
+        self.assertEqual(str(exc.exception), f"binding not found: room:{CHANNEL}")
+
+    # -- happy paths --------------------------------------------------------
+
+    def test_plain_upload_posts_at_channel_level(self) -> None:
+        self._bind_room()
+        path = self._tempfile("plot.png", b"\x89PNG payload")
+
+        with mock.patch.object(
+            common, "find_latest_mattermost_reply_context", return_value=_reply_context()
+        ), mock.patch.object(common, "mattermost_api_request") as api_request, mock.patch.object(
+            common, "mattermost_upload_request", return_value={"file_infos": [{"id": "file-1"}]}
+        ) as upload_request, mock.patch.object(
+            common, "post_channel_message", return_value={"id": "post-1"}
+        ) as post_channel_message:
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                code = upload_script.main(["--file", str(path), "--initial-comment", "latest run"])
+
+        self.assertEqual(code, 0)
+        upload_request.assert_called_once_with(
+            "/files", [("channel_id", CHANNEL)], [("files", "plot.png", b"\x89PNG payload")]
+        )
+        post_channel_message.assert_called_once_with(CHANNEL, "latest run", root_id="", file_ids=["file-1"])
+        # A plain upload drops the inbound threading hints, so no thread-root walk.
+        api_request.assert_not_called()
+
+        receipt = json.loads(stdout.getvalue())
+        self.assertTrue(receipt["delivered"])
+        self.assertEqual(receipt["via"], "gc")
+        self.assertEqual(receipt["file_id"], "file-1")
+        self.assertEqual(receipt["file_ids"], ["file-1"])
+        self.assertEqual(receipt["filename"], "plot.png")
+        self.assertEqual(receipt["size_bytes"], len(b"\x89PNG payload"))
+        self.assertEqual(receipt["conversation_id"], CHANNEL)
+        self.assertEqual(receipt["root_id"], "")
+        self.assertEqual(receipt["post_id"], "post-1")
+        self.assertEqual(receipt["binding_id"], f"room:{CHANNEL}")
+        self.assertEqual(receipt["failure_kind"], "")
+        self.assertEqual(receipt["record"]["remote_message_id"], "post-1")
+
+        # --via gc records the upload as a publish.
+        recent = common.list_recent_chat_publishes(limit=5)
+        self.assertEqual(len(recent), 1)
+        self.assertEqual(recent[0]["remote_message_id"], "post-1")
+
+    def test_thread_current_attaches_under_the_inbound_thread_root(self) -> None:
+        self._bind_room()
+        path = self._tempfile("plot.png")
+
+        with mock.patch.object(
+            common, "find_latest_mattermost_reply_context", return_value=_reply_context()
+        ), mock.patch.object(
+            common,
+            "mattermost_api_request",
+            return_value={"id": ROOT_POST, "channel_id": CHANNEL, "root_id": ""},
+        ) as api_request, mock.patch.object(
+            common, "mattermost_upload_request", return_value={"file_infos": [{"id": "file-2"}]}
+        ), mock.patch.object(common, "post_channel_message", return_value={"id": "post-2"}) as post_channel_message:
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                code = upload_script.main(["--file", str(path), "--thread-current"])
+
+        self.assertEqual(code, 0)
+        api_request.assert_called_with("GET", f"/posts/{ROOT_POST}", bot_token=None)
+        post_channel_message.assert_called_once_with(CHANNEL, "", root_id=ROOT_POST, file_ids=["file-2"])
+        self.assertEqual(json.loads(stdout.getvalue())["root_id"], ROOT_POST)
+
+    def test_explicit_root_id_attaches_under_that_thread(self) -> None:
+        self._bind_room()
+        path = self._tempfile("plot.png")
+
+        with mock.patch.object(
+            common, "find_latest_mattermost_reply_context", return_value=_reply_context()
+        ), mock.patch.object(
+            common,
+            "mattermost_api_request",
+            return_value={"id": "reply-42", "channel_id": CHANNEL, "root_id": "root-42"},
+        ), mock.patch.object(
+            common, "mattermost_upload_request", return_value={"file_infos": [{"id": "file-3"}]}
+        ), mock.patch.object(common, "post_channel_message", return_value={"id": "post-3"}) as post_channel_message:
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                code = upload_script.main(["--file", str(path), "--root-id", "reply-42"])
+
+        self.assertEqual(code, 0)
+        post_channel_message.assert_called_once_with(CHANNEL, "", root_id="root-42", file_ids=["file-3"])
+        self.assertEqual(json.loads(stdout.getvalue())["root_id"], "root-42")
+
+    def test_thread_scoped_binding_pins_the_bound_root(self) -> None:
+        self._bind_room(root_id=ROOT_POST)
+        path = self._tempfile("plot.png")
+        context = _reply_context(publish_binding_id=f"room:{CHANNEL}/{ROOT_POST}")
+
+        with mock.patch.object(
+            common, "find_latest_mattermost_reply_context", return_value=context
+        ), mock.patch.object(common, "mattermost_api_request") as api_request, mock.patch.object(
+            common, "mattermost_upload_request", return_value={"file_infos": [{"id": "file-4"}]}
+        ) as upload_request, mock.patch.object(
+            common, "post_channel_message", return_value={"id": "post-4"}
+        ) as post_channel_message:
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                code = upload_script.main(["--file", str(path)])
+
+        self.assertEqual(code, 0)
+        # The composite "channel/root" binding key must never reach the REST API.
+        upload_request.assert_called_once_with(
+            "/files", [("channel_id", CHANNEL)], [("files", "plot.png", b"hello bytes")]
+        )
+        post_channel_message.assert_called_once_with(CHANNEL, "", root_id=ROOT_POST, file_ids=["file-4"])
+        api_request.assert_not_called()
+        self.assertEqual(json.loads(stdout.getvalue())["conversation_id"], CHANNEL)
+
+    def test_filename_override_and_basename_default(self) -> None:
+        self._bind_room()
+        path = self._tempfile("digest.csv", b"a,b\n")
+
+        with mock.patch.object(
+            common, "find_latest_mattermost_reply_context", return_value=_reply_context()
+        ), mock.patch.object(
+            common, "mattermost_upload_request", return_value={"file_infos": [{"id": "file-5"}]}
+        ) as upload_request, mock.patch.object(common, "post_channel_message", return_value={"id": "post-5"}):
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                code = upload_script.main(["--file", str(path), "--filename", "overnight-digest.csv"])
+
+        self.assertEqual(code, 0)
+        upload_request.assert_called_once_with(
+            "/files", [("channel_id", CHANNEL)], [("files", "overnight-digest.csv", b"a,b\n")]
+        )
+        self.assertEqual(json.loads(stdout.getvalue())["filename"], "overnight-digest.csv")
+
+    def test_via_adapter_bypasses_the_publish_record(self) -> None:
+        self._bind_room()
+        path = self._tempfile("plot.png")
+
+        with mock.patch.object(
+            common, "find_latest_mattermost_reply_context", return_value=_reply_context()
+        ), mock.patch.object(
+            common, "mattermost_upload_request", return_value={"file_infos": [{"id": "file-6"}]}
+        ), mock.patch.object(
+            common, "post_channel_message", return_value={"id": "post-6"}
+        ) as post_channel_message, mock.patch.object(
+            common, "publish_binding_message"
+        ) as publish_binding_message:
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                code = upload_script.main(["--file", str(path), "--via", "adapter", "--initial-comment", "diag"])
+
+        self.assertEqual(code, 0)
+        publish_binding_message.assert_not_called()
+        post_channel_message.assert_called_once_with(CHANNEL, "diag", root_id="", file_ids=["file-6"])
+        receipt = json.loads(stdout.getvalue())
+        self.assertEqual(receipt["via"], "adapter")
+        self.assertEqual(receipt["post_id"], "post-6")
+        self.assertNotIn("record", receipt)
+        self.assertEqual(common.list_recent_chat_publishes(limit=5), [])
+
+    def test_multiple_file_infos_are_all_attached(self) -> None:
+        self._bind_room()
+        path = self._tempfile("plot.png")
+
+        with mock.patch.object(
+            common, "find_latest_mattermost_reply_context", return_value=_reply_context()
+        ), mock.patch.object(
+            common,
+            "mattermost_upload_request",
+            return_value={"file_infos": [{"id": "file-a"}, {"id": ""}, {"id": "file-b"}, "junk"]},
+        ), mock.patch.object(common, "post_channel_message", return_value={"id": "post-7"}) as post_channel_message:
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                code = upload_script.main(["--file", str(path)])
+
+        self.assertEqual(code, 0)
+        post_channel_message.assert_called_once_with(CHANNEL, "", root_id="", file_ids=["file-a", "file-b"])
+        receipt = json.loads(stdout.getvalue())
+        self.assertEqual(receipt["file_ids"], ["file-a", "file-b"])
+        self.assertEqual(receipt["file_id"], "file-a")
+
+    def test_peer_delivery_attention_propagates_exit_code_two(self) -> None:
+        self._bind_room()
+        path = self._tempfile("plot.png")
+
+        with mock.patch.object(
+            common, "find_latest_mattermost_reply_context", return_value=_reply_context()
+        ), mock.patch.object(
+            common, "mattermost_upload_request", return_value={"file_infos": [{"id": "file-8"}]}
+        ), mock.patch.object(
+            common,
+            "publish_binding_message",
+            return_value={
+                "record": {
+                    "remote_message_id": "post-8",
+                    "peer_delivery": {"phase": "peer_fanout_partial_failure", "status": "partial_failure"},
+                },
+                "response": {"id": "post-8"},
+            },
+        ):
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                code = upload_script.main(["--file", str(path)])
+
+        self.assertEqual(code, 2)
+        self.assertTrue(json.loads(stdout.getvalue())["delivered"])
+
+    # -- REST failure modes -------------------------------------------------
+
+    def test_upload_without_a_file_id_returns_a_failure_receipt(self) -> None:
+        self._bind_room()
+        path = self._tempfile("plot.png")
+
+        with mock.patch.object(
+            common, "find_latest_mattermost_reply_context", return_value=_reply_context()
+        ), mock.patch.object(
+            common, "mattermost_upload_request", return_value={"file_infos": []}
+        ), mock.patch.object(common, "post_channel_message") as post_channel_message:
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                code = upload_script.main(["--file", str(path)])
+
+        self.assertEqual(code, 1)
+        post_channel_message.assert_not_called()
+        receipt = json.loads(stdout.getvalue())
+        self.assertFalse(receipt["delivered"])
+        self.assertEqual(receipt["failure_kind"], "error")
+        self.assertEqual(receipt["error"], "mattermost upload returned no file id")
+
+    def test_upload_failures_map_to_failure_kinds(self) -> None:
+        cases = (
+            (404, "not_found"),
+            (401, "auth"),
+            (403, "auth"),
+            (429, "rate_limited"),
+            (413, "too_large"),
+            (400, "invalid_request"),
+            (500, "error"),
+            (None, "error"),
+        )
+        for status, expected in cases:
+            with self.subTest(status=status):
+                self.setUp()
+                self._bind_room()
+                path = self._tempfile("plot.png")
+                error = common.MattermostAPIError("boom", status_code=status)
+                with mock.patch.object(
+                    common, "find_latest_mattermost_reply_context", return_value=_reply_context()
+                ), mock.patch.object(common, "mattermost_upload_request", side_effect=error):
+                    stdout = io.StringIO()
+                    with redirect_stdout(stdout):
+                        code = upload_script.main(["--file", str(path)])
+
+                self.assertEqual(code, 1)
+                receipt = json.loads(stdout.getvalue())
+                self.assertFalse(receipt["delivered"])
+                self.assertEqual(receipt["failure_kind"], expected)
+                self.assertEqual(receipt["error"], "boom")
+
+    def test_post_creation_failure_still_reports_the_uploaded_file_id(self) -> None:
+        self._bind_room()
+        path = self._tempfile("plot.png")
+
+        with mock.patch.object(
+            common, "find_latest_mattermost_reply_context", return_value=_reply_context()
+        ), mock.patch.object(
+            common, "mattermost_upload_request", return_value={"file_infos": [{"id": "file-9"}]}
+        ), mock.patch.object(
+            common, "post_channel_message", side_effect=common.MattermostAPIError("forbidden", status_code=403)
+        ):
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                code = upload_script.main(["--file", str(path)])
+
+        self.assertEqual(code, 1)
+        receipt = json.loads(stdout.getvalue())
+        self.assertFalse(receipt["delivered"])
+        self.assertEqual(receipt["file_id"], "file-9")
+        self.assertEqual(receipt["failure_kind"], "auth")
+
+    # -- idempotency --------------------------------------------------------
+
+    def test_idempotency_key_replays_the_saved_receipt(self) -> None:
+        self._bind_room()
+        path = self._tempfile("plot.png")
+
+        with mock.patch.object(
+            common, "find_latest_mattermost_reply_context", return_value=_reply_context()
+        ), mock.patch.object(
+            common, "mattermost_upload_request", return_value={"file_infos": [{"id": "file-10"}]}
+        ) as upload_request, mock.patch.object(common, "post_channel_message", return_value={"id": "post-10"}):
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                first = upload_script.main(["--file", str(path), "--idempotency-key", "up-1"])
+
+            self.assertEqual(first, 0)
+            self.assertEqual(upload_request.call_count, 1)
+            self.assertNotIn("idempotent_replay", json.loads(stdout.getvalue()))
+
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                second = upload_script.main(["--file", str(path), "--idempotency-key", "up-1"])
+
+        self.assertEqual(second, 0)
+        # The replay must not re-upload the bytes or create a second post.
+        self.assertEqual(upload_request.call_count, 1)
+        replay = json.loads(stdout.getvalue())
+        self.assertTrue(replay["idempotent_replay"])
+        self.assertEqual(replay["post_id"], "post-10")
+        self.assertEqual(len(common.list_recent_chat_publishes(limit=5)), 1)
+
+    def test_failed_uploads_are_not_cached(self) -> None:
+        self._bind_room()
+        path = self._tempfile("plot.png")
+
+        with mock.patch.object(
+            common, "find_latest_mattermost_reply_context", return_value=_reply_context()
+        ), mock.patch.object(
+            common, "mattermost_upload_request", side_effect=common.MattermostAPIError("boom", status_code=500)
+        ):
+            with redirect_stdout(io.StringIO()):
+                self.assertEqual(upload_script.main(["--file", str(path), "--idempotency-key", "up-2"]), 1)
+
+        with mock.patch.object(
+            common, "find_latest_mattermost_reply_context", return_value=_reply_context()
+        ), mock.patch.object(
+            common, "mattermost_upload_request", return_value={"file_infos": [{"id": "file-11"}]}
+        ) as upload_request, mock.patch.object(common, "post_channel_message", return_value={"id": "post-11"}):
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                code = upload_script.main(["--file", str(path), "--idempotency-key", "up-2"])
+
+        self.assertEqual(code, 0)
+        upload_request.assert_called_once()
+        self.assertNotIn("idempotent_replay", json.loads(stdout.getvalue()))
+
+    def test_replay_preserves_the_original_exit_code(self) -> None:
+        self._bind_room()
+        path = self._tempfile("plot.png")
+        partial = {
+            "record": {
+                "remote_message_id": "post-12",
+                "peer_delivery": {"phase": "peer_fanout_partial_failure", "status": "partial_failure"},
+            },
+            "response": {"id": "post-12"},
+        }
+
+        with mock.patch.object(
+            common, "find_latest_mattermost_reply_context", return_value=_reply_context()
+        ), mock.patch.object(
+            common, "mattermost_upload_request", return_value={"file_infos": [{"id": "file-12"}]}
+        ), mock.patch.object(common, "publish_binding_message", return_value=partial):
+            with redirect_stdout(io.StringIO()):
+                self.assertEqual(upload_script.main(["--file", str(path), "--idempotency-key", "up-3"]), 2)
+
+        stdout = io.StringIO()
+        with redirect_stdout(stdout):
+            replay_code = upload_script.main(["--file", str(path), "--idempotency-key", "up-3"])
+
+        # A replay of a partially-delivered upload must not read as a clean success.
+        self.assertEqual(replay_code, 2)
+        self.assertTrue(json.loads(stdout.getvalue())["idempotent_replay"])
+
+    def test_uploads_without_a_key_are_never_cached(self) -> None:
+        self._bind_room()
+        path = self._tempfile("plot.png")
+
+        with mock.patch.object(
+            common, "find_latest_mattermost_reply_context", return_value=_reply_context()
+        ), mock.patch.object(
+            common, "mattermost_upload_request", return_value={"file_infos": [{"id": "file-13"}]}
+        ) as upload_request, mock.patch.object(common, "post_channel_message", return_value={"id": "post-13"}):
+            for _ in range(2):
+                with redirect_stdout(io.StringIO()):
+                    self.assertEqual(upload_script.main(["--file", str(path)]), 0)
+
+        self.assertEqual(upload_request.call_count, 2)
+        self.assertFalse(os.path.isdir(upload_script._idempotency_dir()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mattermost/tests/test_mattermost_chat_scripts.py
+++ b/mattermost/tests/test_mattermost_chat_scripts.py
@@ -1,0 +1,1061 @@
+from __future__ import annotations
+
+import io
+import json
+import pathlib
+import tempfile
+import tomllib
+import unittest
+from contextlib import redirect_stdout
+from unittest import mock
+
+import os
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+
+import mattermost_chat_bind as bind_script
+import mattermost_chat_publish as publish_script
+import mattermost_chat_reply_current as reply_current_script
+import mattermost_chat_retry_peer_fanout as retry_peer_fanout_script
+import mattermost_room_launch as room_launch_script
+import mattermost_intake_common as common
+
+
+CHANNEL = "9h5j7k1m3n5p7r9t1v3x5z7b9c"
+OTHER_CHANNEL = "1a2b3c4d5e6f7g8h9i0j1k2l3m"
+TEAM = "7k3m9x2c5n8b1v4z6q0r2s4t6w"
+ROOT_POST = "2a4b6c8d0e2f4g6h8i0j2k4m6n"
+
+
+def _post(post_id: str, channel_id: str, root_id: str = "") -> dict[str, str]:
+    """Shape of a Mattermost GET /posts/<id> response."""
+    return {"id": post_id, "channel_id": channel_id, "root_id": root_id}
+
+
+class MattermostChatScriptTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self._old_environ = os.environ.copy()
+        os.environ["GC_CITY_ROOT"] = self.tempdir.name
+        # The publish path resolves the acting session from the environment;
+        # keep every test explicit about which session (if any) is acting.
+        for key in ("GC_SESSION_ID", "GC_SESSION_NAME", "GC_ALIAS"):
+            os.environ.pop(key, None)
+
+    def tearDown(self) -> None:
+        os.environ.clear()
+        os.environ.update(self._old_environ)
+
+    # ------------------------------------------------------------------
+    # pack wiring
+    # ------------------------------------------------------------------
+
+    def test_pack_commands_reference_existing_files(self) -> None:
+        pack_dir = pathlib.Path(__file__).resolve().parents[1]
+        manifest = tomllib.loads((pack_dir / "pack.toml").read_text(encoding="utf-8"))
+        schema = int(manifest.get("pack", {}).get("schema", 1))
+
+        if schema >= 2:
+            command_dirs = sorted(path for path in (pack_dir / "commands").iterdir() if path.is_dir())
+            self.assertTrue(command_dirs, "expected pack v2 command directories")
+            for command_dir in command_dirs:
+                command_manifest = tomllib.loads((command_dir / "command.toml").read_text(encoding="utf-8"))
+                run_path = (command_dir / str(command_manifest.get("run", "")).strip()).resolve()
+                help_path = command_dir / "help.md"
+                self.assertTrue(run_path.is_file(), f"missing command script for {command_dir.name}: {run_path}")
+                self.assertTrue(help_path.is_file(), f"missing help text for {command_dir.name}: {help_path}")
+            return
+
+        for command in manifest.get("commands", []):
+            script_path = pack_dir / str(command.get("script", "")).strip()
+            help_path = pack_dir / str(command.get("long_description", "")).strip()
+            self.assertTrue(script_path.is_file(), f"missing command script for {command.get('name')}: {script_path}")
+            self.assertTrue(help_path.is_file(), f"missing help text for {command.get('name')}: {help_path}")
+
+    # ------------------------------------------------------------------
+    # publish
+    # ------------------------------------------------------------------
+
+    def test_publish_uses_binding_target_and_saves_record(self) -> None:
+        common.set_chat_binding(common.load_config(), "room", CHANNEL, ["sky"], team_id=TEAM)
+
+        with mock.patch.object(
+            common, "mattermost_api_request", return_value=_post("orig-9", CHANNEL)
+        ), mock.patch.object(common, "post_channel_message", return_value={"id": "msg-1"}) as post_channel_message:
+            with redirect_stdout(io.StringIO()):
+                code = publish_script.main(
+                    ["--binding", f"room:{CHANNEL}", "--trigger", "orig-9", "--body", "hello humans"]
+                )
+
+        self.assertEqual(code, 0)
+        post_channel_message.assert_called_once_with(CHANNEL, "hello humans", root_id="orig-9", file_ids=None)
+        recent = common.list_recent_chat_publishes(limit=5)
+        self.assertEqual(len(recent), 1)
+        self.assertEqual(recent[0]["binding_id"], f"room:{CHANNEL}")
+        self.assertEqual(recent[0]["remote_message_id"], "msg-1")
+        self.assertEqual(recent[0]["conversation_id"], CHANNEL)
+
+    def test_publish_walks_reply_target_up_to_its_thread_root(self) -> None:
+        """Mattermost rejects a root_id that points at a reply."""
+        common.set_chat_binding(common.load_config(), "room", CHANNEL, ["sky"], team_id=TEAM)
+
+        with mock.patch.object(
+            common, "mattermost_api_request", return_value=_post("reply-9", CHANNEL, root_id=ROOT_POST)
+        ) as api_request, mock.patch.object(
+            common, "post_channel_message", return_value={"id": "msg-2"}
+        ) as post_channel_message:
+            with redirect_stdout(io.StringIO()):
+                code = publish_script.main(
+                    ["--binding", f"room:{CHANNEL}", "--reply-to", "reply-9", "--body", "thread reply"]
+                )
+
+        self.assertEqual(code, 0)
+        api_request.assert_called_once_with("GET", "/posts/reply-9", bot_token=None)
+        post_channel_message.assert_called_once_with(CHANNEL, "thread reply", root_id=ROOT_POST, file_ids=None)
+        recent = common.list_recent_chat_publishes(limit=5)
+        self.assertEqual(recent[0]["root_post_id"], ROOT_POST)
+
+    def test_publish_allows_conversation_override_matching_the_bound_channel(self) -> None:
+        common.set_chat_binding(common.load_config(), "room", CHANNEL, ["sky"], team_id=TEAM)
+
+        with mock.patch.object(common, "post_channel_message", return_value={"id": "msg-3"}) as post_channel_message:
+            with redirect_stdout(io.StringIO()):
+                code = publish_script.main(
+                    ["--binding", f"room:{CHANNEL}", "--conversation-id", CHANNEL, "--body", "same channel"]
+                )
+
+        self.assertEqual(code, 0)
+        post_channel_message.assert_called_once_with(CHANNEL, "same channel", root_id="", file_ids=None)
+
+    def test_publish_rejects_cross_channel_override(self) -> None:
+        common.set_chat_binding(common.load_config(), "room", CHANNEL, ["sky"], team_id=TEAM)
+
+        with self.assertRaises(SystemExit) as exc:
+            publish_script.main(
+                ["--binding", f"room:{CHANNEL}", "--conversation-id", OTHER_CHANNEL, "--body", "nope"]
+            )
+
+        self.assertEqual(str(exc.exception), "--conversation-id must match the bound channel")
+
+    def test_publish_rejects_conversation_override_on_a_dm_binding(self) -> None:
+        common.set_chat_binding(common.load_config(), "dm", CHANNEL, ["sky"])
+
+        with self.assertRaises(SystemExit) as exc:
+            publish_script.main(["--binding", f"dm:{CHANNEL}", "--conversation-id", OTHER_CHANNEL, "--body", "nope"])
+
+        self.assertEqual(str(exc.exception), "--conversation-id cannot override a DM binding")
+
+    def test_publish_rejects_unknown_binding(self) -> None:
+        with self.assertRaises(SystemExit) as exc:
+            publish_script.main(["--binding", f"room:{CHANNEL}", "--body", "nope"])
+
+        self.assertEqual(str(exc.exception), f"binding not found: room:{CHANNEL}")
+
+    def test_publish_rejects_missing_remote_message_id(self) -> None:
+        common.set_chat_binding(common.load_config(), "room", CHANNEL, ["sky"], team_id=TEAM)
+
+        with mock.patch.object(common, "post_channel_message", return_value={}):
+            with self.assertRaises(SystemExit) as exc:
+                publish_script.main(["--binding", f"room:{CHANNEL}", "--body", "hello humans"])
+
+        self.assertEqual(str(exc.exception), "mattermost publish returned no post id")
+
+    def test_publish_requires_a_body(self) -> None:
+        common.set_chat_binding(common.load_config(), "room", CHANNEL, ["sky"], team_id=TEAM)
+
+        with self.assertRaises(SystemExit) as exc:
+            publish_script.main(["--binding", f"room:{CHANNEL}"])
+
+        self.assertEqual(str(exc.exception), "either --body or --body-file is required")
+
+    def test_publish_returns_exit_code_two_for_partial_peer_fanout(self) -> None:
+        common.set_chat_binding(common.load_config(), "room", CHANNEL, ["corp--sky"], team_id=TEAM)
+
+        with mock.patch.object(
+            common,
+            "publish_binding_message",
+            return_value={
+                "binding": {"id": f"room:{CHANNEL}"},
+                "record": {
+                    "remote_message_id": "msg-1",
+                    "peer_delivery": {
+                        "phase": "peer_fanout_partial_failure",
+                        "status": "partial_failure",
+                    },
+                },
+                "response": {"id": "msg-1"},
+            },
+        ):
+            with redirect_stdout(io.StringIO()):
+                code = publish_script.main(["--binding", f"room:{CHANNEL}", "--body", "hello humans"])
+
+        self.assertEqual(code, 2)
+
+    def test_publish_with_source_context_and_session_saves_source_metadata(self) -> None:
+        common.set_chat_binding(
+            common.load_config(),
+            "room",
+            CHANNEL,
+            ["corp--sky", "corp--priya"],
+            team_id=TEAM,
+            policy={"peer_fanout_enabled": True},
+        )
+
+        with mock.patch.object(common, "post_channel_message", return_value={"id": "msg-1"}), mock.patch.object(
+            common,
+            "resolve_session_identity",
+            return_value={"session_name": "corp--sky", "session_id": "gc-sky"},
+        ), mock.patch.object(common, "deliver_session_message") as deliver_session_message:
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                code = publish_script.main(
+                    [
+                        "--binding",
+                        f"room:{CHANNEL}",
+                        "--source-event-kind",
+                        common.HUMAN_MESSAGE_EVENT_KIND,
+                        "--source-ingress-receipt-id",
+                        "in-1",
+                        "--source-session",
+                        "corp--sky",
+                        "--body",
+                        "@corp--priya hello",
+                    ]
+                )
+
+        self.assertEqual(code, 0)
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(payload["record"]["source_session_name"], "corp--sky")
+        self.assertEqual(payload["record"]["source_session_id"], "gc-sky")
+        self.assertEqual(payload["record"]["source_event_kind"], common.HUMAN_MESSAGE_EVENT_KIND)
+        self.assertEqual(payload["record"]["root_ingress_receipt_id"], "in-1")
+        # Peer notification moved to the extmsg outbound orchestrator; the pack
+        # must not fan out on its own any more.
+        deliver_session_message.assert_not_called()
+
+    def test_publish_reports_unresolvable_source_session(self) -> None:
+        common.set_chat_binding(common.load_config(), "room", CHANNEL, ["sky"], team_id=TEAM)
+
+        with mock.patch.object(
+            common, "resolve_session_identity", side_effect=common.GCAPIError("session not found: ghost")
+        ):
+            with self.assertRaises(SystemExit) as exc:
+                publish_script.main(
+                    ["--binding", f"room:{CHANNEL}", "--source-session", "ghost", "--body", "hello"]
+                )
+
+        self.assertEqual(str(exc.exception), "session not found: ghost")
+
+    def test_plain_publish_without_source_context_stays_successful_in_peer_room(self) -> None:
+        common.set_chat_binding(
+            common.load_config(),
+            "room",
+            CHANNEL,
+            ["corp--sky", "corp--priya"],
+            team_id=TEAM,
+            policy={"peer_fanout_enabled": True},
+        )
+
+        with mock.patch.object(common, "post_channel_message", return_value={"id": "msg-1"}), mock.patch.object(
+            common, "deliver_session_message"
+        ) as deliver_session_message:
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                code = publish_script.main(["--binding", f"room:{CHANNEL}", "--body", "hello humans"])
+
+        self.assertEqual(code, 0)
+        payload = json.loads(stdout.getvalue())
+        self.assertNotIn("peer_delivery", payload["record"])
+        deliver_session_message.assert_not_called()
+
+    # ------------------------------------------------------------------
+    # thread-scoped (bind-room --root-id) bindings, end to end
+    # ------------------------------------------------------------------
+
+    def test_bind_room_root_id_creates_thread_scoped_binding(self) -> None:
+        stdout = io.StringIO()
+        with redirect_stdout(stdout):
+            code = bind_script.main(
+                ["--kind", "room", "--team-id", TEAM, "--root-id", ROOT_POST, CHANNEL, "sky"]
+            )
+
+        self.assertEqual(code, 0)
+        binding_id = f"room:{CHANNEL}/{ROOT_POST}"
+        binding = common.resolve_chat_binding(common.load_config(), binding_id)
+        self.assertIsNotNone(binding)
+        assert binding is not None
+        self.assertEqual(binding["conversation_id"], f"{CHANNEL}/{ROOT_POST}")
+        self.assertEqual(binding["channel_id"], CHANNEL)
+        self.assertEqual(binding["root_id"], ROOT_POST)
+        self.assertEqual(json.loads(stdout.getvalue())["id"], binding_id)
+        # The whole-channel binding id must stay distinct and unbound.
+        self.assertIsNone(common.resolve_chat_binding(common.load_config(), f"room:{CHANNEL}"))
+
+    def test_thread_scoped_binding_publishes_to_real_channel_with_pinned_root(self) -> None:
+        with redirect_stdout(io.StringIO()):
+            self.assertEqual(
+                bind_script.main(["--kind", "room", "--team-id", TEAM, "--root-id", ROOT_POST, CHANNEL, "sky"]),
+                0,
+            )
+
+        with mock.patch.object(common, "mattermost_api_request") as api_request, mock.patch.object(
+            common, "post_channel_message", return_value={"id": "msg-thread"}
+        ) as post_channel_message:
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                code = publish_script.main(
+                    ["--binding", f"room:{CHANNEL}/{ROOT_POST}", "--body", "into the bound thread"]
+                )
+
+        self.assertEqual(code, 0)
+        # The composite "channel/root" key is the binding identity, never an API
+        # channel id — the post has to go to the real channel with the pinned root.
+        post_channel_message.assert_called_once_with(
+            CHANNEL, "into the bound thread", root_id=ROOT_POST, file_ids=None
+        )
+        api_request.assert_not_called()
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(payload["record"]["conversation_id"], CHANNEL)
+        self.assertEqual(payload["record"]["root_post_id"], ROOT_POST)
+        self.assertEqual(payload["record"]["binding_conversation_id"], f"{CHANNEL}/{ROOT_POST}")
+
+    def test_thread_scoped_binding_ignores_a_foreign_reply_target(self) -> None:
+        with redirect_stdout(io.StringIO()):
+            bind_script.main(["--kind", "room", "--team-id", TEAM, "--root-id", ROOT_POST, CHANNEL, "sky"])
+
+        with mock.patch.object(common, "mattermost_api_request") as api_request, mock.patch.object(
+            common, "post_channel_message", return_value={"id": "msg-thread"}
+        ) as post_channel_message:
+            with redirect_stdout(io.StringIO()):
+                code = publish_script.main(
+                    [
+                        "--binding",
+                        f"room:{CHANNEL}/{ROOT_POST}",
+                        "--reply-to",
+                        "some-other-post",
+                        "--trigger",
+                        "another-post",
+                        "--body",
+                        "stays pinned",
+                    ]
+                )
+
+        self.assertEqual(code, 0)
+        post_channel_message.assert_called_once_with(CHANNEL, "stays pinned", root_id=ROOT_POST, file_ids=None)
+        api_request.assert_not_called()
+
+    def test_thread_scoped_binding_accepts_the_bare_channel_id_override(self) -> None:
+        with redirect_stdout(io.StringIO()):
+            bind_script.main(["--kind", "room", "--team-id", TEAM, "--root-id", ROOT_POST, CHANNEL, "sky"])
+
+        with mock.patch.object(
+            common, "post_channel_message", return_value={"id": "msg-thread"}
+        ) as post_channel_message:
+            with redirect_stdout(io.StringIO()):
+                code = publish_script.main(
+                    [
+                        "--binding",
+                        f"room:{CHANNEL}/{ROOT_POST}",
+                        "--conversation-id",
+                        CHANNEL,
+                        "--body",
+                        "explicit channel",
+                    ]
+                )
+
+        self.assertEqual(code, 0)
+        post_channel_message.assert_called_once_with(CHANNEL, "explicit channel", root_id=ROOT_POST, file_ids=None)
+
+    def test_whole_channel_binding_resolves_root_id_dynamically(self) -> None:
+        with redirect_stdout(io.StringIO()):
+            bind_script.main(["--kind", "room", "--team-id", TEAM, CHANNEL, "sky"])
+
+        with mock.patch.object(
+            common, "mattermost_api_request", return_value=_post("reply-77", CHANNEL, root_id="root-77")
+        ) as api_request, mock.patch.object(
+            common, "post_channel_message", return_value={"id": "msg-dyn"}
+        ) as post_channel_message:
+            with redirect_stdout(io.StringIO()):
+                code = publish_script.main(
+                    ["--binding", f"room:{CHANNEL}", "--root-id", "reply-77", "--body", "dynamic"]
+                )
+
+        self.assertEqual(code, 0)
+        api_request.assert_called_once_with("GET", "/posts/reply-77", bot_token=None)
+        post_channel_message.assert_called_once_with(CHANNEL, "dynamic", root_id="root-77", file_ids=None)
+
+    def test_whole_channel_binding_posts_at_channel_level_without_a_reply_target(self) -> None:
+        with redirect_stdout(io.StringIO()):
+            bind_script.main(["--kind", "room", "--team-id", TEAM, CHANNEL, "sky"])
+
+        with mock.patch.object(common, "mattermost_api_request") as api_request, mock.patch.object(
+            common, "post_channel_message", return_value={"id": "msg-flat"}
+        ) as post_channel_message:
+            with redirect_stdout(io.StringIO()):
+                code = publish_script.main(["--binding", f"room:{CHANNEL}", "--body", "channel level"])
+
+        self.assertEqual(code, 0)
+        post_channel_message.assert_called_once_with(CHANNEL, "channel level", root_id="", file_ids=None)
+        api_request.assert_not_called()
+
+    # ------------------------------------------------------------------
+    # reply-current
+    # ------------------------------------------------------------------
+
+    def test_reply_current_uses_latest_mattermost_context(self) -> None:
+        common.set_chat_binding(common.load_config(), "dm", CHANNEL, ["sky"])
+        os.environ["GC_SESSION_NAME"] = "sky"
+        body_file = pathlib.Path(self.tempdir.name) / "reply.txt"
+        body_file.write_text("safe reply", encoding="utf-8")
+
+        with mock.patch.object(
+            common,
+            "find_latest_mattermost_reply_context",
+            return_value={
+                "publish_binding_id": f"dm:{CHANNEL}",
+                "publish_conversation_id": CHANNEL,
+                "publish_trigger_id": "orig-22",
+                "publish_root_post_id": "orig-22",
+            },
+        ), mock.patch.object(
+            common, "mattermost_api_request", return_value=_post("orig-22", CHANNEL)
+        ), mock.patch.object(
+            common, "post_channel_message", return_value={"id": "msg-22"}
+        ) as post_channel_message:
+            with redirect_stdout(io.StringIO()):
+                code = reply_current_script.main(["--body-file", str(body_file)])
+
+        self.assertEqual(code, 0)
+        post_channel_message.assert_called_once_with(CHANNEL, "safe reply", root_id="orig-22", file_ids=None)
+        recent = common.list_recent_chat_publishes(limit=5)
+        self.assertEqual(recent[0]["binding_id"], f"dm:{CHANNEL}")
+        self.assertEqual(recent[0]["remote_message_id"], "msg-22")
+
+    def test_reply_current_replies_into_a_thread_scoped_binding(self) -> None:
+        with redirect_stdout(io.StringIO()):
+            bind_script.main(["--kind", "room", "--team-id", TEAM, "--root-id", ROOT_POST, CHANNEL, "sky"])
+        os.environ["GC_SESSION_NAME"] = "sky"
+
+        with mock.patch.object(
+            common,
+            "find_latest_mattermost_reply_context",
+            return_value={
+                "publish_binding_id": f"room:{CHANNEL}/{ROOT_POST}",
+                "publish_conversation_id": CHANNEL,
+                "publish_trigger_id": "human-post-1",
+                "publish_root_post_id": ROOT_POST,
+            },
+        ), mock.patch.object(common, "mattermost_api_request") as api_request, mock.patch.object(
+            common, "post_channel_message", return_value={"id": "msg-33"}
+        ) as post_channel_message:
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                code = reply_current_script.main(["--body", "threaded reply"])
+
+        self.assertEqual(code, 0)
+        post_channel_message.assert_called_once_with(CHANNEL, "threaded reply", root_id=ROOT_POST, file_ids=None)
+        api_request.assert_not_called()
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(payload["reply_context"]["publish_root_post_id"], ROOT_POST)
+
+    def test_reply_current_passes_source_context_through_publish(self) -> None:
+        common.set_chat_binding(
+            common.load_config(),
+            "room",
+            CHANNEL,
+            ["corp--sky", "corp--priya"],
+            team_id=TEAM,
+            policy={"peer_fanout_enabled": True},
+        )
+        os.environ["GC_SESSION_NAME"] = "corp--sky"
+        body_file = pathlib.Path(self.tempdir.name) / "reply.txt"
+        body_file.write_text("@corp--priya safe reply", encoding="utf-8")
+
+        with mock.patch.object(
+            common,
+            "find_latest_mattermost_reply_context",
+            return_value={
+                "kind": common.PEER_PUBLICATION_EVENT_KIND,
+                "publish_binding_id": f"room:{CHANNEL}",
+                "publish_conversation_id": CHANNEL,
+                "publish_trigger_id": "orig-22",
+                "publish_root_post_id": "orig-22",
+                "root_ingress_receipt_id": "in-1",
+            },
+        ), mock.patch.object(
+            common, "mattermost_api_request", return_value=_post("orig-22", CHANNEL)
+        ), mock.patch.object(
+            common, "post_channel_message", return_value={"id": "msg-22"}
+        ), mock.patch.object(
+            common, "resolve_session_identity", side_effect=common.GCAPIError("offline")
+        ), mock.patch.object(
+            common, "deliver_session_message"
+        ) as deliver_session_message:
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                code = reply_current_script.main(["--body-file", str(body_file)])
+
+        self.assertEqual(code, 0)
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(payload["reply_context"]["source_event_kind"], common.PEER_PUBLICATION_EVENT_KIND)
+        self.assertEqual(payload["reply_context"]["root_ingress_receipt_id"], "in-1")
+        self.assertEqual(payload["record"]["source_event_kind"], common.PEER_PUBLICATION_EVENT_KIND)
+        self.assertNotIn("peer_delivery", payload["record"])
+        deliver_session_message.assert_not_called()
+
+    def test_reply_current_session_override_sets_source_identity(self) -> None:
+        common.set_chat_binding(
+            common.load_config(),
+            "room",
+            CHANNEL,
+            ["corp--sky", "corp--priya"],
+            team_id=TEAM,
+            policy={"peer_fanout_enabled": True},
+        )
+        os.environ["GC_SESSION_NAME"] = "corp--else"
+        os.environ["GC_SESSION_ID"] = "gc-else"
+        body_file = pathlib.Path(self.tempdir.name) / "reply.txt"
+        body_file.write_text("@corp--priya safe reply", encoding="utf-8")
+
+        with mock.patch.object(
+            common,
+            "find_latest_mattermost_reply_context",
+            return_value={
+                "kind": common.PEER_PUBLICATION_EVENT_KIND,
+                "publish_binding_id": f"room:{CHANNEL}",
+                "publish_conversation_id": CHANNEL,
+                "publish_trigger_id": "orig-22",
+                "publish_root_post_id": "orig-22",
+                "root_ingress_receipt_id": "in-1",
+            },
+        ), mock.patch.object(
+            common, "mattermost_api_request", return_value=_post("orig-22", CHANNEL)
+        ), mock.patch.object(
+            common, "post_channel_message", return_value={"id": "msg-22"}
+        ), mock.patch.object(
+            common,
+            "resolve_session_identity",
+            return_value={"session_name": "corp--sky", "session_id": "gc-sky"},
+        ):
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                code = reply_current_script.main(["--session", "corp--sky", "--body-file", str(body_file)])
+
+        self.assertEqual(code, 0)
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(payload["record"]["source_session_name"], "corp--sky")
+        self.assertEqual(payload["record"]["source_session_id"], "gc-sky")
+        self.assertEqual(payload["reply_context"]["source_session_name"], "corp--sky")
+
+    def test_reply_current_reply_context_falls_back_to_current_session_env(self) -> None:
+        common.set_chat_binding(common.load_config(), "dm", CHANNEL, ["sky"])
+        os.environ["GC_SESSION_NAME"] = "sky"
+        os.environ["GC_SESSION_ID"] = "gc-sky"
+        body_file = pathlib.Path(self.tempdir.name) / "reply.txt"
+        body_file.write_text("safe reply", encoding="utf-8")
+
+        with mock.patch.object(
+            common,
+            "find_latest_mattermost_reply_context",
+            return_value={
+                "kind": common.HUMAN_MESSAGE_EVENT_KIND,
+                "ingress_receipt_id": "in-22",
+                "publish_binding_id": f"dm:{CHANNEL}",
+                "publish_conversation_id": CHANNEL,
+                "publish_trigger_id": "orig-22",
+                "publish_root_post_id": "orig-22",
+            },
+        ), mock.patch.object(
+            common, "mattermost_api_request", return_value=_post("orig-22", CHANNEL)
+        ), mock.patch.object(common, "post_channel_message", return_value={"id": "msg-22"}):
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                code = reply_current_script.main(["--body-file", str(body_file)])
+
+        self.assertEqual(code, 0)
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(payload["reply_context"]["source_session_name"], "sky")
+        self.assertEqual(payload["reply_context"]["source_session_id"], "gc-sky")
+
+    def test_reply_current_without_binding_posts_directly(self) -> None:
+        os.environ["GC_SESSION_NAME"] = "sky"
+
+        with mock.patch.object(
+            common,
+            "find_latest_mattermost_reply_context",
+            side_effect=common.GCAPIError("no recent mattermost event"),
+        ), mock.patch.object(
+            common, "mattermost_api_request", return_value=_post("reply-5", CHANNEL, root_id="root-5")
+        ), mock.patch.object(
+            common, "post_channel_message", return_value={"id": "msg-direct"}
+        ) as post_channel_message:
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                code = reply_current_script.main(
+                    ["--conversation-id", CHANNEL, "--reply-to", "reply-5", "--body", "direct"]
+                )
+
+        self.assertEqual(code, 0)
+        post_channel_message.assert_called_once_with(CHANNEL, "direct", root_id="root-5")
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(payload["record"]["conversation_id"], CHANNEL)
+        self.assertEqual(payload["record"]["root_post_id"], "root-5")
+
+    def test_reply_current_without_context_or_conversation_id_fails(self) -> None:
+        os.environ["GC_SESSION_NAME"] = "sky"
+
+        with mock.patch.object(
+            common,
+            "find_latest_mattermost_reply_context",
+            side_effect=common.GCAPIError("no recent mattermost event with publish metadata found for sky"),
+        ):
+            with self.assertRaises(SystemExit) as exc:
+                reply_current_script.main(["--body", "orphan"])
+
+        self.assertEqual(str(exc.exception), "no recent mattermost event with publish metadata found for sky")
+
+    def test_reply_current_requires_a_body(self) -> None:
+        with self.assertRaises(SystemExit) as exc:
+            reply_current_script.main([])
+
+        self.assertEqual(str(exc.exception), "either --body or --body-file is required")
+
+    # ------------------------------------------------------------------
+    # room launch routing
+    # ------------------------------------------------------------------
+
+    def test_reply_current_uses_launch_route(self) -> None:
+        common.set_room_launcher(common.load_config(), TEAM, CHANNEL)
+        common.save_room_launch(
+            {
+                "launch_id": "room-launch:orig-22",
+                "launcher_id": f"launch-room:{CHANNEL}",
+                "team_id": TEAM,
+                "conversation_id": CHANNEL,
+                "root_post_id": "orig-22",
+                "qualified_handle": "corp/sky",
+                "session_alias": "mm-123-sky",
+            }
+        )
+        os.environ["GC_SESSION_NAME"] = "mm-runtime"
+        body_file = pathlib.Path(self.tempdir.name) / "reply-launch.txt"
+        body_file.write_text("safe reply", encoding="utf-8")
+
+        with mock.patch.object(
+            common,
+            "find_latest_mattermost_reply_context",
+            return_value={
+                "kind": common.HUMAN_MESSAGE_EVENT_KIND,
+                "ingress_receipt_id": "in-22",
+                "publish_binding_id": f"launch-room:{CHANNEL}",
+                "publish_conversation_id": CHANNEL,
+                "publish_trigger_id": "orig-22",
+                "publish_launch_id": "room-launch:orig-22",
+            },
+        ), mock.patch.object(
+            common, "post_channel_message", return_value={"id": "msg-22"}
+        ) as post_channel_message:
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                code = reply_current_script.main(["--body-file", str(body_file)])
+
+        self.assertEqual(code, 0)
+        post_channel_message.assert_called_once_with(CHANNEL, "safe reply", root_id="orig-22", file_ids=None)
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(payload["record"]["conversation_id"], CHANNEL)
+        self.assertEqual(payload["record"]["root_post_id"], "orig-22")
+        self.assertEqual(payload["record"]["launch_id"], "room-launch:orig-22")
+        # First use promotes the launch record to active.
+        self.assertEqual(str(common.load_room_launch("room-launch:orig-22").get("state", "")), "active")
+
+    def test_publish_launch_route_hydrates_launch_id_from_source_ingress(self) -> None:
+        common.set_room_launcher(common.load_config(), TEAM, CHANNEL)
+        common.save_room_launch(
+            {
+                "launch_id": "room-launch:orig-29",
+                "launcher_id": f"launch-room:{CHANNEL}",
+                "team_id": TEAM,
+                "conversation_id": CHANNEL,
+                "root_post_id": "orig-29",
+                "qualified_handle": "corp/sky",
+                "session_alias": "mm-123-sky",
+            }
+        )
+        common.save_chat_ingress({"ingress_id": "in-29", "launch_id": "room-launch:orig-29", "status": "delivered"})
+
+        with mock.patch.object(
+            common, "post_channel_message", return_value={"id": "msg-29"}
+        ) as post_channel_message:
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                code = publish_script.main(
+                    [
+                        "--binding",
+                        f"launch-room:{CHANNEL}",
+                        "--source-event-kind",
+                        common.HUMAN_MESSAGE_EVENT_KIND,
+                        "--source-ingress-receipt-id",
+                        "in-29",
+                        "--body",
+                        "hello launcher",
+                    ]
+                )
+
+        self.assertEqual(code, 0)
+        post_channel_message.assert_called_once_with(CHANNEL, "hello launcher", root_id="orig-29", file_ids=None)
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(payload["record"]["launch_id"], "room-launch:orig-29")
+        self.assertEqual(payload["record"]["conversation_id"], CHANNEL)
+        self.assertEqual(payload["record"]["root_post_id"], "orig-29")
+
+    def test_publish_launch_route_requires_source_ingress_receipt(self) -> None:
+        common.set_room_launcher(common.load_config(), TEAM, CHANNEL)
+
+        with self.assertRaises(SystemExit) as exc:
+            publish_script.main(["--binding", f"launch-room:{CHANNEL}", "--body", "hello launcher"])
+
+        self.assertEqual(str(exc.exception), "launch-room publish requires --source-ingress-receipt-id")
+
+    def test_publish_launch_route_rejects_unknown_source_ingress_receipt(self) -> None:
+        common.set_room_launcher(common.load_config(), TEAM, CHANNEL)
+
+        with self.assertRaises(SystemExit) as exc:
+            publish_script.main(
+                [
+                    "--binding",
+                    f"launch-room:{CHANNEL}",
+                    "--source-ingress-receipt-id",
+                    "in-missing",
+                    "--body",
+                    "hello launcher",
+                ]
+            )
+
+        self.assertEqual(str(exc.exception), "source ingress receipt not found: in-missing")
+
+    # ------------------------------------------------------------------
+    # bind
+    # ------------------------------------------------------------------
+
+    def test_bind_script_creates_room_binding(self) -> None:
+        stdout = io.StringIO()
+        with mock.patch.object(
+            common, "describe_room_channel_metadata"
+        ) as describe_room_channel_metadata, redirect_stdout(stdout):
+            code = bind_script.main(["--kind", "room", "--team-id", TEAM, CHANNEL, "sky", "lawrence"])
+
+        self.assertEqual(code, 0)
+        describe_room_channel_metadata.assert_not_called()
+        binding = common.resolve_chat_binding(common.load_config(), f"room:{CHANNEL}")
+        self.assertIsNotNone(binding)
+        assert binding is not None
+        self.assertEqual(binding["session_names"], ["sky", "lawrence"])
+        self.assertEqual(binding["team_id"], TEAM)
+        self.assertEqual(binding["channel_id"], CHANNEL)
+        self.assertEqual(binding["root_id"], "")
+
+    def test_bind_script_creates_dm_binding_from_a_plain_channel_id(self) -> None:
+        stdout = io.StringIO()
+        with redirect_stdout(stdout):
+            code = bind_script.main(["--kind", "dm", CHANNEL, "sky"])
+
+        self.assertEqual(code, 0)
+        binding = common.resolve_chat_binding(common.load_config(), f"dm:{CHANNEL}")
+        assert binding is not None
+        self.assertEqual(binding["conversation_id"], CHANNEL)
+        self.assertEqual(binding["channel_id"], CHANNEL)
+        self.assertEqual(binding["session_names"], ["sky"])
+
+    def test_bind_script_persists_peer_fanout_policy(self) -> None:
+        stdout = io.StringIO()
+        with redirect_stdout(stdout):
+            code = bind_script.main(
+                [
+                    "--kind",
+                    "room",
+                    "--team-id",
+                    TEAM,
+                    "--enable-ambient-read",
+                    "--enable-peer-fanout",
+                    "--allow-untargeted-peer-fanout",
+                    "--max-peer-triggered-publishes-per-root",
+                    "2",
+                    "--max-total-peer-deliveries-per-root",
+                    "9",
+                    "--max-peer-triggered-publishes-per-session-per-minute",
+                    "7",
+                    CHANNEL,
+                    "corp--sky",
+                    "corp--priya",
+                ]
+            )
+
+        self.assertEqual(code, 0)
+        binding = common.resolve_chat_binding(common.load_config(), f"room:{CHANNEL}")
+        assert binding is not None
+        self.assertTrue(binding["policy"]["ambient_read_enabled"])
+        self.assertTrue(binding["policy"]["peer_fanout_enabled"])
+        self.assertTrue(binding["policy"]["allow_untargeted_peer_fanout"])
+        self.assertEqual(binding["policy"]["max_peer_triggered_publishes_per_root"], 2)
+        self.assertEqual(binding["policy"]["max_total_peer_deliveries_per_root"], 9)
+        self.assertEqual(binding["policy"]["max_peer_triggered_publishes_per_session_per_minute"], 7)
+
+    def test_bind_script_persists_untargeted_ambient_delivery_policy(self) -> None:
+        stdout = io.StringIO()
+        with redirect_stdout(stdout):
+            code = bind_script.main(
+                [
+                    "--kind",
+                    "room",
+                    "--team-id",
+                    TEAM,
+                    "--enable-ambient-read",
+                    "--allow-untargeted-ambient-delivery",
+                    CHANNEL,
+                    "randy",
+                ]
+            )
+
+        self.assertEqual(code, 0)
+        binding = common.resolve_chat_binding(common.load_config(), f"room:{CHANNEL}")
+        assert binding is not None
+        self.assertTrue(binding["policy"]["ambient_read_enabled"])
+        self.assertTrue(binding["policy"]["allow_untargeted_ambient_delivery"])
+
+    def test_bind_script_disable_ambient_read_updates_existing_room_binding(self) -> None:
+        common.set_chat_binding(
+            common.load_config(),
+            "room",
+            CHANNEL,
+            ["sky", "lawrence"],
+            team_id=TEAM,
+            policy={"ambient_read_enabled": True},
+        )
+
+        stdout = io.StringIO()
+        with redirect_stdout(stdout):
+            code = bind_script.main(
+                ["--kind", "room", "--team-id", TEAM, "--disable-ambient-read", CHANNEL, "sky", "lawrence"]
+            )
+
+        self.assertEqual(code, 0)
+        binding = common.resolve_chat_binding(common.load_config(), f"room:{CHANNEL}")
+        assert binding is not None
+        self.assertFalse(binding["policy"]["ambient_read_enabled"])
+
+    def test_bind_script_rejects_conflicting_ambient_read_flags(self) -> None:
+        with self.assertRaises(SystemExit) as exc:
+            bind_script.main(
+                ["--kind", "room", "--enable-ambient-read", "--disable-ambient-read", CHANNEL, "sky"]
+            )
+
+        self.assertEqual(str(exc.exception), "choose only one of --enable-ambient-read or --disable-ambient-read")
+
+    def test_bind_script_rejects_conflicting_untargeted_ambient_delivery_flags(self) -> None:
+        with self.assertRaises(SystemExit) as exc:
+            bind_script.main(
+                [
+                    "--kind",
+                    "room",
+                    "--allow-untargeted-ambient-delivery",
+                    "--disallow-untargeted-ambient-delivery",
+                    CHANNEL,
+                    "randy",
+                ]
+            )
+
+        self.assertEqual(
+            str(exc.exception),
+            "choose only one of --allow-untargeted-ambient-delivery or --disallow-untargeted-ambient-delivery",
+        )
+
+    def test_bind_script_rejects_room_policy_flags_on_a_dm(self) -> None:
+        with self.assertRaises(SystemExit) as exc:
+            bind_script.main(["--kind", "dm", "--enable-ambient-read", CHANNEL, "sky"])
+
+        self.assertEqual(str(exc.exception), "room policy flags require --kind room")
+
+    def test_bind_script_rejects_root_id_on_a_dm(self) -> None:
+        with self.assertRaises(SystemExit) as exc:
+            bind_script.main(["--kind", "dm", "--root-id", ROOT_POST, CHANNEL, "sky"])
+
+        self.assertEqual(str(exc.exception), "--root-id requires --kind room")
+
+    def test_bind_script_rejects_invalid_dm_fanout_cleanly(self) -> None:
+        with self.assertRaises(SystemExit) as exc:
+            bind_script.main(["--kind", "dm", CHANNEL, "sky", "lawrence"])
+
+        self.assertEqual(str(exc.exception), "DM bindings require exactly one session name")
+
+    def test_bind_script_rejects_a_room_that_already_has_room_launch(self) -> None:
+        common.set_room_launcher(common.load_config(), TEAM, CHANNEL)
+
+        with self.assertRaises(SystemExit) as exc:
+            bind_script.main(["--kind", "room", "--team-id", TEAM, CHANNEL, "sky"])
+
+        self.assertEqual(str(exc.exception), "room launch is already enabled for that conversation")
+
+    # ------------------------------------------------------------------
+    # enable-room-launch
+    # ------------------------------------------------------------------
+
+    def test_enable_room_launch_script_creates_launcher(self) -> None:
+        stdout = io.StringIO()
+        with redirect_stdout(stdout):
+            code = room_launch_script.main(["--team-id", TEAM, CHANNEL])
+
+        self.assertEqual(code, 0)
+        launcher = common.resolve_room_launcher(common.load_config(), CHANNEL)
+        self.assertIsNotNone(launcher)
+        assert launcher is not None
+        self.assertEqual(launcher["response_mode"], "mention_only")
+        self.assertEqual(launcher["team_id"], TEAM)
+        self.assertTrue(launcher["policy"]["peer_fanout_enabled"])
+        self.assertTrue(launcher["policy"]["allow_untargeted_peer_fanout"])
+
+    def test_enable_room_launch_script_can_disable_peer_fanout(self) -> None:
+        stdout = io.StringIO()
+        with redirect_stdout(stdout):
+            code = room_launch_script.main(
+                ["--team-id", TEAM, "--disable-peer-fanout", "--disallow-untargeted-peer-fanout", CHANNEL]
+            )
+
+        self.assertEqual(code, 0)
+        launcher = common.resolve_room_launcher(common.load_config(), CHANNEL)
+        self.assertIsNotNone(launcher)
+        assert launcher is not None
+        self.assertFalse(launcher["policy"]["peer_fanout_enabled"])
+        self.assertFalse(launcher["policy"]["allow_untargeted_peer_fanout"])
+
+    def test_enable_room_launch_preserves_legacy_launcher_without_policy_flags(self) -> None:
+        common.save_config(
+            common.normalize_config(
+                {
+                    "chat": {
+                        "launchers": {
+                            f"launch-room:{CHANNEL}": {
+                                "id": f"launch-room:{CHANNEL}",
+                                "kind": "room",
+                                "team_id": TEAM,
+                                "conversation_id": CHANNEL,
+                                "response_mode": "mention_only",
+                            }
+                        }
+                    }
+                }
+            )
+        )
+
+        with redirect_stdout(io.StringIO()):
+            code = room_launch_script.main(["--team-id", TEAM, CHANNEL])
+
+        self.assertEqual(code, 0)
+        launcher = common.resolve_room_launcher(common.load_config(), CHANNEL)
+        self.assertIsNotNone(launcher)
+        assert launcher is not None
+        self.assertNotIn("policy", launcher)
+
+    def test_enable_room_launch_rejects_a_directly_bound_room(self) -> None:
+        common.set_chat_binding(common.load_config(), "room", CHANNEL, ["sky"], team_id=TEAM)
+
+        with self.assertRaises(SystemExit) as exc:
+            room_launch_script.main(["--team-id", TEAM, CHANNEL])
+
+        self.assertEqual(str(exc.exception), "room launch cannot be enabled on a directly bound room")
+
+    def test_enable_room_launch_respond_all_requires_default_handle(self) -> None:
+        with self.assertRaises(SystemExit) as exc:
+            room_launch_script.main(["--team-id", TEAM, "--response-mode", "respond_all", CHANNEL])
+
+        self.assertEqual(str(exc.exception), "respond_all room launchers require --default-handle")
+
+    # ------------------------------------------------------------------
+    # retry-peer-fanout
+    # ------------------------------------------------------------------
+
+    def _partial_failure_publish(self, publish_id: str, binding_id: str) -> dict[str, object]:
+        return {
+            "publish_id": publish_id,
+            "binding_id": binding_id,
+            "binding_kind": "room",
+            "binding_conversation_id": CHANNEL,
+            "conversation_id": CHANNEL,
+            "team_id": TEAM,
+            "source_session_name": "corp--sky",
+            "source_session_id": "gc-1",
+            "source_event_kind": common.HUMAN_MESSAGE_EVENT_KIND,
+            "root_ingress_receipt_id": "in-1",
+            "body": "@corp--priya hello",
+            "remote_message_id": "msg-1",
+            "root_post_id": "orig-1",
+            "peer_delivery": {
+                "phase": "peer_fanout_partial_failure",
+                "status": "partial_failure",
+                "delivery": "targeted",
+                "mentioned_session_names": ["corp--priya"],
+                "frozen_targets": ["corp--priya"],
+                "targets": [
+                    {
+                        "session_name": "corp--priya",
+                        "status": "failed_retryable",
+                        "attempt_count": 1,
+                        "idempotency_key": f"peer_publish:{publish_id}:binding:{binding_id}:target:corp--priya",
+                        "attempts": [],
+                    }
+                ],
+                "budget_snapshot": {},
+            },
+        }
+
+    def test_retry_peer_fanout_script_retries_saved_publish(self) -> None:
+        common.set_chat_binding(
+            common.load_config(),
+            "room",
+            CHANNEL,
+            ["corp--sky", "corp--priya"],
+            team_id=TEAM,
+            policy={"peer_fanout_enabled": True},
+        )
+        common.save_chat_publish(self._partial_failure_publish("mattermost-publish-1", f"room:{CHANNEL}"))
+
+        with mock.patch.object(
+            common, "deliver_session_message", return_value={"status": "accepted", "id": "gc-1"}
+        ) as deliver_session_message:
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                code = retry_peer_fanout_script.main(["mattermost-publish-1"])
+
+        self.assertEqual(code, 0)
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(payload["peer_delivery"]["status"], "delivered")
+        deliver_session_message.assert_called_once()
+        envelope = deliver_session_message.call_args.args[1]
+        self.assertIn(f"channel_id: {CHANNEL}", envelope)
+        self.assertIn(f"team_id: {TEAM}", envelope)
+
+    def test_retry_peer_fanout_script_accepts_launch_room_binding(self) -> None:
+        common.set_room_launcher(common.load_config(), TEAM, CHANNEL)
+        common.save_chat_publish(
+            self._partial_failure_publish("mattermost-publish-launch", f"launch-room:{CHANNEL}")
+        )
+
+        with mock.patch.object(common, "deliver_session_message", return_value={"status": "accepted", "id": "gc-1"}):
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                code = retry_peer_fanout_script.main(["mattermost-publish-launch"])
+
+        self.assertEqual(code, 0)
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(payload["peer_delivery"]["status"], "delivered")
+
+    def test_retry_peer_fanout_script_reports_unknown_publish(self) -> None:
+        with self.assertRaises(SystemExit) as exc:
+            retry_peer_fanout_script.main(["mattermost-publish-missing"])
+
+        self.assertEqual(str(exc.exception), "publish not found: mattermost-publish-missing")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mattermost/tests/test_mattermost_doctor_scripts.py
+++ b/mattermost/tests/test_mattermost_doctor_scripts.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import pathlib
+import shutil
+import subprocess
+import tempfile
+import tomllib
+import unittest
+from typing import NamedTuple
+
+import os
+
+
+class DoctorCheck(NamedTuple):
+    name: str
+    script: str
+    tool: str
+    probe: tuple[str, ...] | None
+    failure_marker: str
+
+
+DOCTOR_CHECKS = (
+    DoctorCheck("bd", "check-bd.sh", "gc", ("gc", "bd", "version"), "gc bd unavailable"),
+    DoctorCheck("gc", "check-gc.sh", "gc", None, "gc CLI not found"),
+    DoctorCheck("git", "check-git.sh", "git", None, "git not found"),
+    DoctorCheck("jq", "check-jq.sh", "jq", None, "jq not found"),
+    DoctorCheck("openssl", "check-openssl.sh", "openssl", None, "openssl not found"),
+    DoctorCheck("python", "check-python.sh", "python3", None, "python3 not found"),
+)
+
+
+class MattermostDoctorScriptTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self._old_environ = os.environ.copy()
+        os.environ["GC_CITY_ROOT"] = self.tempdir.name
+        self.doctor_dir = pathlib.Path(__file__).resolve().parents[1] / "doctor"
+        self.bd_doctor = self.doctor_dir / "bd" / "doctor.toml"
+
+    def tearDown(self) -> None:
+        os.environ.clear()
+        os.environ.update(self._old_environ)
+
+    def _empty_path_env(self) -> dict[str, str]:
+        empty_bin = pathlib.Path(self.tempdir.name, "empty-bin")
+        empty_bin.mkdir(parents=True, exist_ok=True)
+        env = os.environ.copy()
+        env["PATH"] = str(empty_bin)
+        return env
+
+    def test_every_doctor_toml_points_at_an_executable_check_script(self) -> None:
+        for check in DOCTOR_CHECKS:
+            with self.subTest(check=check.name):
+                toml_path = self.doctor_dir / check.name / "doctor.toml"
+                self.assertTrue(toml_path.is_file())
+                with toml_path.open("rb") as handle:
+                    doctor = tomllib.load(handle)
+                self.assertEqual(doctor["run"], f"../{check.script}")
+                script = (toml_path.parent / doctor["run"]).resolve()
+                self.assertTrue(script.is_file())
+                self.assertTrue(os.access(script, os.X_OK))
+
+    def test_doctor_descriptions_reference_the_mattermost_pack(self) -> None:
+        for check in DOCTOR_CHECKS:
+            with self.subTest(check=check.name):
+                toml_path = self.doctor_dir / check.name / "doctor.toml"
+                with toml_path.open("rb") as handle:
+                    doctor = tomllib.load(handle)
+                self.assertIn("mattermost", doctor["description"].lower())
+                self.assertNotIn("discord", doctor["description"].lower())
+
+    def test_checks_fail_with_guidance_when_the_tool_is_missing(self) -> None:
+        env = self._empty_path_env()
+        for check in DOCTOR_CHECKS:
+            with self.subTest(check=check.name):
+                result = subprocess.run(
+                    [str(self.doctor_dir / check.script)],
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                    env=env,
+                )
+
+                self.assertEqual(result.returncode, 2)
+                self.assertIn(check.failure_marker, result.stdout)
+                self.assertIn("Install", result.stdout)
+
+    def test_checks_pass_when_the_tool_is_available(self) -> None:
+        for check in DOCTOR_CHECKS:
+            with self.subTest(check=check.name):
+                if shutil.which(check.tool) is None:
+                    self.skipTest(f"{check.tool} is not installed")
+                if check.probe is not None:
+                    probed = subprocess.run(list(check.probe), capture_output=True, text=True, check=False)
+                    if probed.returncode != 0:
+                        self.skipTest(f"{' '.join(check.probe)} is unavailable")
+                result = subprocess.run(
+                    [str(self.doctor_dir / check.script)],
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+
+                self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+                self.assertIn("available", result.stdout)
+
+    def test_bd_doctor_describes_the_store_aware_gc_wrapper(self) -> None:
+        with self.bd_doctor.open("rb") as handle:
+            doctor = tomllib.load(handle)
+
+        self.assertIn("gc bd", doctor["description"])
+        self.assertNotIn("bd CLI", doctor["description"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mattermost/tests/test_mattermost_gateway_service.py
+++ b/mattermost/tests/test_mattermost_gateway_service.py
@@ -351,6 +351,37 @@ class MattermostGatewayServiceTests(unittest.TestCase):
         self.assertIn(f"conversation: dm:{DM_CHANNEL}", envelope)
         self.assertEqual(common.load_chat_ingress(f"in-{post_id}")["status"], "delivered")
 
+    def test_process_inbound_dm_routes_flat_when_thread_replies_disabled(self) -> None:
+        common.set_chat_binding(
+            common.load_config(),
+            "dm",
+            DM_CHANNEL,
+            ["sky"],
+            policy={"thread_replies": False},
+        )
+        post_id = mm_id("post101b")
+        post = make_post(post_id, channel_id=DM_CHANNEL, message="hello from mattermost")
+
+        with mock.patch.object(
+            common, "session_index_by_name", return_value={"sky": {"session_name": "sky", "state": "suspended"}}
+        ), mock.patch.object(
+            common,
+            "deliver_session_message",
+            return_value={"status": "accepted", "id": "gc-1"},
+        ) as deliver_session_message:
+            outcome = self._process(post)
+
+        self.assertEqual(outcome["status"], "delivered")
+        deliver_session_message.assert_called_once()
+        envelope = deliver_session_message.call_args.args[1]
+        reply_tool_line = next(line for line in envelope.splitlines() if line.startswith("reply_tool:"))
+        self.assertEqual(
+            reply_tool_line,
+            f"reply_tool: gc mattermost reply-current --conversation-id {DM_CHANNEL} --body-file <path> "
+            "(this binding posts flat — do NOT pass --root-id yourself)",
+        )
+        self.assertIn("publish_root_post_id: \n", envelope)
+
     def test_process_inbound_room_message_targets_only_named_alias(self) -> None:
         common.set_chat_binding(common.load_config(), "room", ROOM_CHANNEL, ["sky", "lawrence"], TEAM_ID)
         post_id = mm_id("post202")

--- a/mattermost/tests/test_mattermost_gateway_service.py
+++ b/mattermost/tests/test_mattermost_gateway_service.py
@@ -1,0 +1,2746 @@
+from __future__ import annotations
+
+import json
+import pathlib
+import re
+import struct
+import tempfile
+import threading
+import time
+import unittest
+from typing import Any
+from unittest import mock
+
+import os
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+
+import mattermost_gateway_service as gateway_service
+import mattermost_intake_common as common
+
+
+def mm_id(label: str) -> str:
+    """Build a deterministic, syntactically valid 26-char Mattermost id."""
+    normalized = re.sub(r"[^a-z0-9]", "", str(label).lower())
+    return (normalized + "0" * 26)[:26]
+
+
+TEAM_ID = mm_id("team1")
+ROOM_CHANNEL = mm_id("room22")
+OTHER_CHANNEL = mm_id("room23")
+DM_CHANNEL = mm_id("dm55")
+ROOT_POST = mm_id("root222")
+BOT_USER_ID = mm_id("bot999")
+BOT_USERNAME = "gcbot"
+
+
+def make_post(
+    post_id: str,
+    *,
+    channel_id: str,
+    message: str = "",
+    team_id: str = "",
+    root_id: str = "",
+    user_id: str = "",
+    from_username: str = "alice",
+    channel_type: str = "",
+    mentions: list[str] | None = None,
+    props: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a post shaped like `normalize_posted_event` output."""
+    post: dict[str, Any] = {
+        "id": post_id,
+        "channel_id": channel_id,
+        "root_id": root_id,
+        "team_id": team_id,
+        "message": message,
+        "user_id": user_id or mm_id(f"user{post_id}"),
+        "channel_type": channel_type,
+        "mentions": list(mentions or []),
+    }
+    if from_username is not None:
+        post["from_username"] = from_username
+        post["sender_name"] = from_username
+    if props is not None:
+        post["props"] = props
+    return post
+
+
+class _ScriptedWebSocket:
+    """Stand-in for GatewayWebSocket driven by a scripted list of events."""
+
+    def __init__(self, events: list[Any], stop_event: threading.Event, url: str = "", headers: dict[str, str] | None = None) -> None:
+        self._events = list(events)
+        self._stop_event = stop_event
+        self.url = url
+        self.headers = dict(headers or {})
+        self.sent: list[dict[str, Any]] = []
+        self.pings = 0
+        self.closed_codes: list[int] = []
+        self.last_frame_at = time.monotonic()
+
+    def send_json(self, payload: dict[str, Any]) -> None:
+        self.sent.append(payload)
+
+    def send_ping(self, payload: bytes = b"gc") -> None:
+        self.pings += 1
+
+    def close(self, code: int = 1000, reason: str = "") -> None:
+        self.closed_codes.append(int(code))
+
+    def recv_event(self, timeout: float | None = None) -> Any:
+        self.last_frame_at = time.monotonic()
+        if self._events:
+            item = self._events.pop(0)
+            if isinstance(item, BaseException):
+                raise item
+            return item
+        self._stop_event.set()
+        return None
+
+
+class _HandshakeSocket:
+    """Minimal socket double that completes a websocket upgrade."""
+
+    def __init__(self) -> None:
+        self.sent = bytearray()
+        self._response = b""
+
+    def sendall(self, data: bytes) -> None:
+        self.sent.extend(data)
+        blob = bytes(self.sent)
+        if b"\r\n\r\n" in blob and not self._response:
+            text = blob.decode("utf-8", errors="replace")
+            key = ""
+            for line in text.split("\r\n"):
+                if line.lower().startswith("sec-websocket-key:"):
+                    key = line.split(":", 1)[1].strip()
+            accept = gateway_service.websocket_accept_value(key)
+            self._response = (
+                "HTTP/1.1 101 Switching Protocols\r\n"
+                "Upgrade: websocket\r\n"
+                "Connection: Upgrade\r\n"
+                f"Sec-WebSocket-Accept: {accept}\r\n\r\n"
+            ).encode("utf-8")
+
+    def recv(self, length: int) -> bytes:
+        chunk = self._response[:length]
+        self._response = self._response[length:]
+        return chunk
+
+    def settimeout(self, timeout: float | None) -> None:
+        return None
+
+    def close(self) -> None:
+        return None
+
+    def request_text(self) -> str:
+        return bytes(self.sent).decode("utf-8", errors="replace")
+
+
+class MattermostGatewayServiceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self._old_environ = os.environ.copy()
+        os.environ["GC_CITY_ROOT"] = self.tempdir.name
+        gateway_service.CHANNEL_INFO_CACHE.clear()
+        gateway_service.CHANNEL_INFO_FETCH_LOCKS.clear()
+        gateway_service.STALE_RECLAIM_LOCKS.clear()
+        gateway_service.INGRESS_PROCESS_LOCKS.clear()
+        gateway_service.GC_API_HEALTH_CACHE["checked_at"] = 0.0
+        gateway_service.GC_API_HEALTH_CACHE["reachable"] = True
+        gateway_service.AMBIENT_ROOM_BINDINGS_CACHE["config_signature"] = None
+        gateway_service.AMBIENT_ROOM_BINDINGS_CACHE["bindings"] = {}
+        gateway_service.BOT_IDENTITY_CACHE["fetched_at"] = 0.0
+        gateway_service.BOT_IDENTITY_CACHE["user_id"] = ""
+        gateway_service.BOT_IDENTITY_CACHE["username"] = ""
+
+    def tearDown(self) -> None:
+        os.environ.clear()
+        os.environ.update(self._old_environ)
+
+    def _new_gateway_worker(self) -> gateway_service.GatewayWorker:
+        runtime_state = gateway_service.GatewayRuntimeState()
+        with mock.patch.object(gateway_service, "GATEWAY_WORKER_THREADS", 0):
+            worker = gateway_service.GatewayWorker(runtime_state)
+        self.addCleanup(worker.stop)
+        return worker
+
+    def _process(self, post: dict[str, Any]) -> dict[str, Any]:
+        return gateway_service.process_inbound_message(post, BOT_USER_ID, BOT_USERNAME)
+
+    # ------------------------------------------------------------------
+    # Websocket envelope / protocol shape
+    # ------------------------------------------------------------------
+
+    def test_normalize_posted_event_decodes_json_encoded_post_string(self) -> None:
+        post_id = mm_id("post100")
+        event = {
+            "event": "posted",
+            "data": {
+                "post": json.dumps(
+                    {
+                        "id": post_id,
+                        "channel_id": ROOM_CHANNEL,
+                        "root_id": "",
+                        "message": "hello there",
+                        "user_id": mm_id("user100"),
+                    }
+                ),
+                "team_id": TEAM_ID,
+                "channel_type": "o",
+                "channel_name": "town-square",
+                "channel_display_name": "Town Square",
+                "sender_name": "@alice",
+                "mentions": json.dumps([BOT_USER_ID]),
+            },
+            "broadcast": {"channel_id": ROOM_CHANNEL, "team_id": TEAM_ID},
+            "seq": 7,
+        }
+
+        post = gateway_service.normalize_posted_event(event)
+
+        self.assertEqual(post["id"], post_id)
+        self.assertEqual(post["channel_id"], ROOM_CHANNEL)
+        self.assertEqual(post["team_id"], TEAM_ID)
+        self.assertEqual(post["channel_type"], "O")
+        self.assertEqual(post["channel_name"], "town-square")
+        self.assertEqual(post["channel_display_name"], "Town Square")
+        self.assertEqual(post["sender_name"], "alice")
+        self.assertEqual(post["from_username"], "alice")
+        self.assertEqual(post["mentions"], [BOT_USER_ID])
+        self.assertEqual(post["message"], "hello there")
+
+    def test_normalize_posted_event_falls_back_to_broadcast_ids(self) -> None:
+        post_id = mm_id("post101")
+        event = {
+            "event": "posted",
+            "data": {"post": json.dumps({"id": post_id, "message": "hi"})},
+            "broadcast": {"channel_id": ROOM_CHANNEL, "team_id": TEAM_ID},
+        }
+
+        post = gateway_service.normalize_posted_event(event)
+
+        self.assertEqual(post["channel_id"], ROOM_CHANNEL)
+        self.assertEqual(post["team_id"], TEAM_ID)
+
+    def test_normalize_posted_event_returns_empty_for_unusable_payloads(self) -> None:
+        self.assertEqual(gateway_service.normalize_posted_event({}), {})
+        self.assertEqual(gateway_service.normalize_posted_event({"data": {"post": "not json"}}), {})
+        self.assertEqual(gateway_service.normalize_posted_event({"data": {"post": "[]"}}), {})
+        self.assertEqual(gateway_service.normalize_posted_event({"data": "nope"}), {})
+
+    def test_parse_event_mentions_accepts_json_string_and_list(self) -> None:
+        self.assertEqual(gateway_service.parse_event_mentions({"mentions": json.dumps([BOT_USER_ID])}), [BOT_USER_ID])
+        self.assertEqual(gateway_service.parse_event_mentions({"mentions": [BOT_USER_ID, BOT_USER_ID]}), [BOT_USER_ID])
+        self.assertEqual(gateway_service.parse_event_mentions({"mentions": "{bad"}), [])
+        self.assertEqual(gateway_service.parse_event_mentions({}), [])
+
+    def test_bot_mention_pattern_requires_username_boundaries(self) -> None:
+        pattern = gateway_service.bot_mention_pattern(BOT_USERNAME)
+        assert pattern is not None
+        self.assertTrue(pattern.search(f"hey @{BOT_USERNAME} please look"))
+        self.assertTrue(pattern.search(f"@{BOT_USERNAME}"))
+        self.assertTrue(pattern.search(f"@{BOT_USERNAME}, hello"))
+        self.assertIsNone(pattern.search(f"@{BOT_USERNAME}x"))
+        self.assertIsNone(pattern.search(f"@{BOT_USERNAME}.deploy"))
+        self.assertIsNone(pattern.search(f"mail@{BOT_USERNAME}"))
+        self.assertIsNone(gateway_service.bot_mention_pattern("  "))
+
+    def test_bot_was_mentioned_matches_literal_username(self) -> None:
+        post = {"message": f"@{BOT_USERNAME} can you check", "mentions": []}
+        self.assertTrue(gateway_service.bot_was_mentioned(post, BOT_USER_ID, BOT_USERNAME))
+
+    def test_bot_was_mentioned_accepts_mentions_array_without_username_text(self) -> None:
+        post = {"message": "can you check this", "mentions": [BOT_USER_ID]}
+        self.assertTrue(gateway_service.bot_was_mentioned(post, BOT_USER_ID, BOT_USERNAME))
+
+    def test_bot_was_mentioned_ignores_bare_broadcast_mentions(self) -> None:
+        for reserved in ("@channel", "@all", "@here"):
+            post = {"message": f"{reserved} standup in five", "mentions": [BOT_USER_ID]}
+            self.assertFalse(
+                gateway_service.bot_was_mentioned(post, BOT_USER_ID, BOT_USERNAME),
+                msg=f"{reserved} alone must not wake the bot",
+            )
+
+    def test_bot_was_mentioned_wakes_when_broadcast_and_username_both_present(self) -> None:
+        post = {"message": f"@channel and @{BOT_USERNAME} please look", "mentions": [BOT_USER_ID]}
+        self.assertTrue(gateway_service.bot_was_mentioned(post, BOT_USER_ID, BOT_USERNAME))
+
+    def test_bot_was_mentioned_ignores_unrelated_mentions(self) -> None:
+        post = {"message": "hey team", "mentions": [mm_id("someoneelse")]}
+        self.assertFalse(gateway_service.bot_was_mentioned(post, BOT_USER_ID, BOT_USERNAME))
+
+    def test_strip_bot_mentions_removes_only_the_bot_username(self) -> None:
+        stripped = gateway_service.strip_bot_mentions(f"@{BOT_USERNAME} @sky please check", BOT_USERNAME)
+        self.assertEqual(stripped, "@sky please check")
+
+    def test_extract_alias_mentions_skips_reserved_mentions(self) -> None:
+        self.assertEqual(gateway_service.extract_alias_mentions("@sky @channel @all @here @lawrence"), ["sky", "lawrence"])
+
+    def test_display_name_from_message_skips_none_strings(self) -> None:
+        post = {"props": {"override_username": None}, "from_username": None, "sender_name": None}
+        self.assertEqual(gateway_service.display_name_from_message(post), "mattermost-user")
+
+    def test_display_name_from_message_prefers_override_username(self) -> None:
+        post = {"props": {"override_username": "@webhook-bot"}, "from_username": "alice"}
+        self.assertEqual(gateway_service.display_name_from_message(post), "webhook-bot")
+
+    def test_message_root_post_id_uses_flat_root_threading(self) -> None:
+        reply = {"id": mm_id("post300"), "root_id": ROOT_POST}
+        root = {"id": ROOT_POST, "root_id": ""}
+        self.assertEqual(gateway_service.message_root_post_id(reply), ROOT_POST)
+        self.assertEqual(gateway_service.message_root_post_id(root), ROOT_POST)
+
+    def test_conversation_fields_distinguish_dm_room_and_thread(self) -> None:
+        dm_post = make_post(mm_id("post310"), channel_id=DM_CHANNEL)
+        room_post = make_post(mm_id("post311"), channel_id=ROOM_CHANNEL, team_id=TEAM_ID)
+        thread_post = make_post(mm_id("post312"), channel_id=ROOM_CHANNEL, team_id=TEAM_ID, root_id=ROOT_POST)
+
+        self.assertEqual(gateway_service.conversation_fields(dm_post), (f"dm:{DM_CHANNEL}", DM_CHANNEL))
+        self.assertEqual(gateway_service.conversation_fields(room_post), (f"team:{TEAM_ID} channel:{ROOM_CHANNEL}", ROOM_CHANNEL))
+        self.assertEqual(
+            gateway_service.conversation_fields(thread_post),
+            (f"team:{TEAM_ID} channel:{ROOM_CHANNEL} thread:{ROOT_POST}", f"{ROOM_CHANNEL}/{ROOT_POST}"),
+        )
+
+    def test_referenced_post_id_reads_props_reply_target(self) -> None:
+        target = mm_id("post320")
+        self.assertEqual(gateway_service.referenced_post_id({"props": {"reply_to_post_id": target}}), target)
+        self.assertEqual(gateway_service.referenced_post_id({"props": {"in_reply_to_id": target}}), target)
+        self.assertEqual(gateway_service.referenced_post_id({"root_id": ROOT_POST}), "")
+        self.assertEqual(gateway_service.referenced_post_id({}), "")
+
+    def test_bound_room_claims_message_covers_threads_in_the_same_channel(self) -> None:
+        common.set_chat_binding(common.load_config(), "room", ROOM_CHANNEL, ["sky"], TEAM_ID)
+        config = common.load_config()
+
+        self.assertTrue(gateway_service.bound_room_claims_message(config, ROOM_CHANNEL))
+        self.assertFalse(gateway_service.bound_room_claims_message(config, OTHER_CHANNEL))
+
+    # ------------------------------------------------------------------
+    # Binding resolution and direct routing
+    # ------------------------------------------------------------------
+
+    def test_process_inbound_dm_routes_to_bound_session(self) -> None:
+        common.set_chat_binding(common.load_config(), "dm", DM_CHANNEL, ["sky"])
+        post_id = mm_id("post101")
+        post = make_post(post_id, channel_id=DM_CHANNEL, message="hello from mattermost")
+
+        with mock.patch.object(
+            common, "session_index_by_name", return_value={"sky": {"session_name": "sky", "state": "suspended"}}
+        ), mock.patch.object(
+            common,
+            "deliver_session_message",
+            return_value={"status": "accepted", "id": "gc-1"},
+        ) as deliver_session_message:
+            outcome = self._process(post)
+
+        self.assertEqual(outcome["status"], "delivered")
+        deliver_session_message.assert_called_once()
+        self.assertEqual(deliver_session_message.call_args.args[0], "sky")
+        envelope = deliver_session_message.call_args.args[1]
+        self.assertIn("kind: mattermost_human_message", envelope)
+        self.assertIn('untrusted_body_json: "hello from mattermost"', envelope)
+        self.assertIn(
+            f"reply_tool: gc mattermost reply-current --conversation-id {DM_CHANNEL} --root-id {post_id} --body-file <path>",
+            envelope,
+        )
+        self.assertIn(f"conversation: dm:{DM_CHANNEL}", envelope)
+        self.assertEqual(common.load_chat_ingress(f"in-{post_id}")["status"], "delivered")
+
+    def test_process_inbound_room_message_targets_only_named_alias(self) -> None:
+        common.set_chat_binding(common.load_config(), "room", ROOM_CHANNEL, ["sky", "lawrence"], TEAM_ID)
+        post_id = mm_id("post202")
+        post = make_post(
+            post_id,
+            channel_id=ROOM_CHANNEL,
+            team_id=TEAM_ID,
+            channel_type="O",
+            message=f"@{BOT_USERNAME} @Sky please check the shard",
+            mentions=[BOT_USER_ID],
+        )
+
+        with mock.patch.object(
+            common,
+            "session_index_by_name",
+            return_value={
+                "sky": {"session_name": "sky", "state": "active"},
+                "lawrence": {"session_name": "lawrence", "state": "active"},
+            },
+        ), mock.patch.object(common, "deliver_session_message", return_value={"status": "accepted"}) as deliver_session_message:
+            outcome = self._process(post)
+
+        self.assertEqual(outcome["status"], "delivered")
+        deliver_session_message.assert_called_once()
+        self.assertEqual(deliver_session_message.call_args.args[0], "sky")
+        receipt = common.load_chat_ingress(f"in-{post_id}")
+        self.assertEqual(receipt["delivery"], "targeted")
+        self.assertEqual(receipt["mentioned_aliases"], ["sky"])
+
+    def test_process_inbound_room_message_matches_session_names_case_insensitively(self) -> None:
+        common.set_chat_binding(common.load_config(), "room", ROOM_CHANNEL, ["Sky"], TEAM_ID)
+        post = make_post(
+            mm_id("post207"),
+            channel_id=ROOM_CHANNEL,
+            team_id=TEAM_ID,
+            channel_type="O",
+            message=f"@{BOT_USERNAME} @sky please check the shard",
+            mentions=[BOT_USER_ID],
+        )
+
+        with mock.patch.object(
+            common, "session_index_by_name", return_value={"Sky": {"session_name": "Sky", "state": "active"}}
+        ), mock.patch.object(common, "deliver_session_message", return_value={"status": "accepted"}) as deliver_session_message:
+            outcome = self._process(post)
+
+        self.assertEqual(outcome["status"], "delivered")
+        deliver_session_message.assert_called_once()
+        self.assertEqual(deliver_session_message.call_args.args[0], "Sky")
+
+    def test_process_inbound_room_message_broadcasts_to_all_bound_selectors(self) -> None:
+        common.set_chat_binding(common.load_config(), "room", ROOM_CHANNEL, ["sky", "lawrence"], TEAM_ID)
+        post = make_post(
+            mm_id("post214"),
+            channel_id=ROOM_CHANNEL,
+            team_id=TEAM_ID,
+            channel_type="O",
+            message=f"@{BOT_USERNAME} please investigate",
+            mentions=[BOT_USER_ID],
+        )
+
+        with mock.patch.object(common, "deliver_session_message", return_value={"status": "accepted"}) as deliver_session_message:
+            outcome = self._process(post)
+
+        self.assertEqual(outcome["status"], "delivered")
+        self.assertEqual(deliver_session_message.call_count, 2)
+        self.assertEqual(deliver_session_message.call_args_list[0].args[0], "sky")
+        self.assertEqual(deliver_session_message.call_args_list[1].args[0], "lawrence")
+
+    def test_process_inbound_room_message_rejects_unknown_alias(self) -> None:
+        common.set_chat_binding(common.load_config(), "room", ROOM_CHANNEL, ["sky", "lawrence"], TEAM_ID)
+        post_id = mm_id("post303")
+        post = make_post(
+            post_id,
+            channel_id=ROOM_CHANNEL,
+            team_id=TEAM_ID,
+            channel_type="O",
+            message=f"@{BOT_USERNAME} @ghost please check the shard",
+            mentions=[BOT_USER_ID],
+        )
+
+        with mock.patch.object(
+            common,
+            "session_index_by_name",
+            return_value={
+                "sky": {"session_name": "sky", "state": "active"},
+                "lawrence": {"session_name": "lawrence", "state": "active"},
+            },
+        ), mock.patch.object(common, "deliver_session_message") as deliver_session_message:
+            outcome = self._process(post)
+
+        self.assertEqual(outcome["status"], "rejected_targeting")
+        deliver_session_message.assert_not_called()
+        self.assertEqual(common.load_chat_ingress(f"in-{post_id}")["reason"], "unknown_alias:ghost")
+
+    def test_resolve_targets_reports_alias_collisions_and_unknown_aliases(self) -> None:
+        binding = {"id": f"room:{ROOM_CHANNEL}", "kind": "room", "session_names": ["Sky", "sky", "lawrence"]}
+
+        self.assertEqual(gateway_service.resolve_targets(binding, ["sky"]), ([], "targeted", "ambiguous_alias:sky"))
+        self.assertEqual(gateway_service.resolve_targets(binding, ["ghost"]), ([], "targeted", "unknown_alias:ghost"))
+        self.assertEqual(gateway_service.resolve_targets(binding, ["Lawrence"]), (["lawrence"], "targeted", ""))
+        self.assertEqual(
+            gateway_service.resolve_targets(binding, []),
+            (["Sky", "sky", "lawrence"], "broadcast", ""),
+        )
+        self.assertEqual(
+            gateway_service.resolve_targets(binding, [], require_targeted_aliases=True),
+            ([], "targeted", "target_required"),
+        )
+
+    def test_process_inbound_message_dedupes_existing_ingress(self) -> None:
+        post_id = mm_id("post404")
+        common.save_chat_ingress({"ingress_id": f"in-{post_id}", "status": "delivered"})
+        post = make_post(post_id, channel_id=DM_CHANNEL, message="hello from mattermost")
+
+        with mock.patch.object(common, "deliver_session_message") as deliver_session_message:
+            outcome = self._process(post)
+
+        self.assertEqual(outcome["status"], "duplicate")
+        deliver_session_message.assert_not_called()
+
+    def test_process_inbound_room_message_ignores_non_mentions(self) -> None:
+        common.set_chat_binding(common.load_config(), "room", ROOM_CHANNEL, ["sky", "lawrence"], TEAM_ID)
+        post = make_post(
+            mm_id("post505"),
+            channel_id=ROOM_CHANNEL,
+            team_id=TEAM_ID,
+            channel_type="O",
+            message="just chatting here",
+        )
+
+        with mock.patch.object(common, "deliver_session_message") as deliver_session_message:
+            outcome = self._process(post)
+
+        self.assertEqual(outcome["status"], "ignored")
+        self.assertEqual(outcome["reason"], "not_mentioned")
+        deliver_session_message.assert_not_called()
+
+    def test_process_inbound_room_message_ignores_bare_broadcast_mention(self) -> None:
+        common.set_chat_binding(common.load_config(), "room", ROOM_CHANNEL, ["sky"], TEAM_ID)
+        post = make_post(
+            mm_id("post505b"),
+            channel_id=ROOM_CHANNEL,
+            team_id=TEAM_ID,
+            channel_type="O",
+            message="@channel standup time",
+            mentions=[BOT_USER_ID],
+        )
+
+        with mock.patch.object(common, "deliver_session_message") as deliver_session_message:
+            outcome = self._process(post)
+
+        self.assertEqual(outcome["status"], "ignored")
+        self.assertEqual(outcome["reason"], "not_mentioned")
+        deliver_session_message.assert_not_called()
+
+    def test_process_inbound_room_message_ignores_mentions_array_for_aliases(self) -> None:
+        common.set_chat_binding(common.load_config(), "room", ROOM_CHANNEL, ["sky", "lawrence"], TEAM_ID)
+        post_id = mm_id("post606")
+        post = make_post(
+            post_id,
+            channel_id=ROOM_CHANNEL,
+            team_id=TEAM_ID,
+            channel_type="O",
+            message=f"@{BOT_USERNAME} please investigate",
+            mentions=[BOT_USER_ID, mm_id("otheruser")],
+        )
+
+        with mock.patch.object(
+            common,
+            "session_index_by_name",
+            return_value={
+                "sky": {"session_name": "sky", "state": "active"},
+                "lawrence": {"session_name": "lawrence", "state": "active"},
+            },
+        ), mock.patch.object(common, "deliver_session_message", return_value={"status": "accepted"}) as deliver_session_message:
+            outcome = self._process(post)
+
+        self.assertEqual(outcome["status"], "delivered")
+        self.assertEqual(deliver_session_message.call_count, 2)
+        receipt = common.load_chat_ingress(f"in-{post_id}")
+        self.assertEqual(receipt["delivery"], "broadcast")
+        self.assertEqual(receipt["mentioned_aliases"], [])
+
+    def test_process_inbound_room_message_treats_reserved_mentions_as_broadcast(self) -> None:
+        common.set_chat_binding(common.load_config(), "room", ROOM_CHANNEL, ["sky", "lawrence"], TEAM_ID)
+        post_id = mm_id("post607")
+        post = make_post(
+            post_id,
+            channel_id=ROOM_CHANNEL,
+            team_id=TEAM_ID,
+            channel_type="O",
+            message=f"@{BOT_USERNAME} @channel please look at this",
+            mentions=[BOT_USER_ID],
+        )
+
+        with mock.patch.object(
+            common,
+            "session_index_by_name",
+            return_value={
+                "sky": {"session_name": "sky", "state": "active"},
+                "lawrence": {"session_name": "lawrence", "state": "active"},
+            },
+        ), mock.patch.object(common, "deliver_session_message", return_value={"status": "accepted"}) as deliver_session_message:
+            outcome = self._process(post)
+
+        self.assertEqual(outcome["status"], "delivered")
+        self.assertEqual(deliver_session_message.call_count, 2)
+        receipt = common.load_chat_ingress(f"in-{post_id}")
+        self.assertEqual(receipt["delivery"], "broadcast")
+        self.assertEqual(receipt["mentioned_aliases"], [])
+
+    def test_process_inbound_room_message_records_partial_failed_delivery(self) -> None:
+        common.set_chat_binding(common.load_config(), "room", ROOM_CHANNEL, ["sky", "lawrence"], TEAM_ID)
+        post_id = mm_id("post707")
+        post = make_post(
+            post_id,
+            channel_id=ROOM_CHANNEL,
+            team_id=TEAM_ID,
+            channel_type="O",
+            message=f"@{BOT_USERNAME} please investigate",
+            mentions=[BOT_USER_ID],
+        )
+
+        with mock.patch.object(
+            common,
+            "session_index_by_name",
+            return_value={
+                "sky": {"session_name": "sky", "state": "active"},
+                "lawrence": {"session_name": "lawrence", "state": "active"},
+            },
+        ), mock.patch.object(
+            common,
+            "deliver_session_message",
+            side_effect=[{"status": "accepted"}, common.GCAPIError("boom")],
+        ):
+            outcome = self._process(post)
+
+        self.assertEqual(outcome["status"], "partial_failed")
+        receipt = common.load_chat_ingress(f"in-{post_id}")
+        self.assertEqual(receipt["status"], "partial_failed")
+        self.assertEqual(receipt["targets"][0]["status"], "delivered")
+        self.assertEqual(receipt["targets"][1]["status"], "failed")
+
+    def test_process_inbound_unbound_room_message_records_rejected_unbound(self) -> None:
+        post_id = mm_id("post708")
+        post = make_post(
+            post_id,
+            channel_id=ROOM_CHANNEL,
+            team_id=TEAM_ID,
+            channel_type="O",
+            message=f"@{BOT_USERNAME} anyone home?",
+            mentions=[BOT_USER_ID],
+        )
+
+        with mock.patch.object(common, "deliver_session_message") as deliver_session_message:
+            outcome = self._process(post)
+
+        self.assertEqual(outcome["status"], "rejected_unbound")
+        deliver_session_message.assert_not_called()
+        self.assertEqual(common.load_chat_ingress(f"in-{post_id}")["reason"], "binding_not_found")
+
+    def test_process_inbound_ignores_bot_and_system_posts(self) -> None:
+        common.set_chat_binding(common.load_config(), "dm", DM_CHANNEL, ["sky"])
+        bot_post = make_post(mm_id("post709"), channel_id=DM_CHANNEL, message="hi", user_id=BOT_USER_ID)
+        system_post = make_post(mm_id("post710"), channel_id=DM_CHANNEL, message="hi")
+        system_post["type"] = "system_join_channel"
+
+        with mock.patch.object(common, "deliver_session_message") as deliver_session_message:
+            self.assertEqual(self._process(bot_post)["reason"], "bot_message")
+            self.assertEqual(self._process(system_post)["reason"], "bot_message")
+
+        deliver_session_message.assert_not_called()
+
+    def test_process_inbound_ignores_post_without_channel(self) -> None:
+        post = make_post(mm_id("post711"), channel_id="", message="hi")
+
+        outcome = self._process(post)
+
+        self.assertEqual(outcome["status"], "ignored")
+        self.assertEqual(outcome["reason"], "missing_channel")
+
+    # ------------------------------------------------------------------
+    # Ambient rooms
+    # ------------------------------------------------------------------
+
+    def test_process_inbound_ambient_room_message_routes_targeted_alias_without_bot_mention(self) -> None:
+        common.set_chat_binding(
+            common.load_config(),
+            "room",
+            ROOM_CHANNEL,
+            ["sky", "lawrence"],
+            TEAM_ID,
+            policy={"ambient_read_enabled": True},
+        )
+        post_id = mm_id("post506")
+        post = make_post(
+            post_id,
+            channel_id=ROOM_CHANNEL,
+            team_id=TEAM_ID,
+            channel_type="O",
+            message="@Sky please check the shard",
+        )
+
+        with mock.patch.object(
+            common,
+            "session_index_by_name",
+            return_value={
+                "sky": {"session_name": "sky", "state": "active"},
+                "lawrence": {"session_name": "lawrence", "state": "active"},
+            },
+        ), mock.patch.object(common, "deliver_session_message", return_value={"status": "accepted"}) as deliver_session_message:
+            outcome = self._process(post)
+
+        self.assertEqual(outcome["status"], "delivered")
+        deliver_session_message.assert_called_once()
+        self.assertEqual(deliver_session_message.call_args.args[0], "sky")
+        receipt = common.load_chat_ingress(f"in-{post_id}")
+        self.assertEqual(receipt["delivery"], "targeted")
+        self.assertEqual(receipt["mentioned_aliases"], ["sky"])
+
+    def test_process_inbound_ambient_thread_message_derives_thread_from_root_id(self) -> None:
+        common.set_chat_binding(
+            common.load_config(),
+            "room",
+            ROOM_CHANNEL,
+            ["sky"],
+            TEAM_ID,
+            policy={"ambient_read_enabled": True},
+        )
+        common.save_bot_token("bot-token")
+        post = make_post(
+            mm_id("post506b"),
+            channel_id=ROOM_CHANNEL,
+            team_id=TEAM_ID,
+            root_id=ROOT_POST,
+            message="@sky please check the shard",
+        )
+
+        with mock.patch.object(common, "describe_channel") as describe_channel, mock.patch.object(
+            common, "session_index_by_name", return_value={"sky": {"session_name": "sky", "state": "active"}}
+        ), mock.patch.object(common, "deliver_session_message", return_value={"status": "accepted"}) as deliver_session_message:
+            outcome = self._process(post)
+
+        self.assertEqual(outcome["status"], "delivered")
+        describe_channel.assert_not_called()
+        envelope = deliver_session_message.call_args.args[1]
+        self.assertIn(f"conversation: team:{TEAM_ID} channel:{ROOM_CHANNEL} thread:{ROOT_POST}", envelope)
+        self.assertIn(f"conversation_key: {ROOM_CHANNEL}/{ROOT_POST}", envelope)
+        self.assertIn(f"publish_conversation_id: {ROOM_CHANNEL}", envelope)
+        self.assertIn(f"publish_root_post_id: {ROOT_POST}", envelope)
+
+    def test_process_inbound_bot_mentioned_thread_uses_binding_channel_metadata(self) -> None:
+        common.set_chat_binding(
+            common.load_config(),
+            "room",
+            ROOM_CHANNEL,
+            ["sky"],
+            TEAM_ID,
+            channel_metadata={"channel_type": "O"},
+        )
+        common.save_bot_token("bot-token")
+        post = make_post(
+            mm_id("post506c"),
+            channel_id=ROOM_CHANNEL,
+            team_id=TEAM_ID,
+            root_id=ROOT_POST,
+            channel_type="O",
+            message=f"@{BOT_USERNAME} @sky please check the shard",
+            mentions=[BOT_USER_ID],
+        )
+
+        with mock.patch.object(common, "describe_channel") as describe_channel, mock.patch.object(
+            common, "session_index_by_name", return_value={"sky": {"session_name": "sky", "state": "active"}}
+        ), mock.patch.object(common, "deliver_session_message", return_value={"status": "accepted"}) as deliver_session_message:
+            outcome = self._process(post)
+
+        self.assertEqual(outcome["status"], "delivered")
+        describe_channel.assert_not_called()
+        envelope = deliver_session_message.call_args.args[1]
+        self.assertIn(f"binding_id: room:{ROOM_CHANNEL}", envelope)
+        self.assertIn(f"conversation: team:{TEAM_ID} channel:{ROOM_CHANNEL} thread:{ROOT_POST}", envelope)
+
+    def test_process_inbound_bot_mentioned_thread_missing_metadata_falls_back_to_lookup(self) -> None:
+        common.set_chat_binding(common.load_config(), "room", ROOM_CHANNEL, ["sky"], TEAM_ID)
+        common.save_bot_token("bot-token")
+        post = make_post(
+            mm_id("post506d"),
+            channel_id=ROOM_CHANNEL,
+            team_id=TEAM_ID,
+            root_id=ROOT_POST,
+            channel_type="O",
+            message=f"@{BOT_USERNAME} @sky please check the shard",
+            mentions=[BOT_USER_ID],
+        )
+
+        with mock.patch.object(
+            common,
+            "describe_channel",
+            return_value={"id": ROOM_CHANNEL, "type": "O", "team_id": TEAM_ID},
+        ) as describe_channel, mock.patch.object(
+            common, "session_index_by_name", return_value={"sky": {"session_name": "sky", "state": "active"}}
+        ), mock.patch.object(common, "deliver_session_message", return_value={"status": "accepted"}) as deliver_session_message:
+            outcome = self._process(post)
+
+        self.assertEqual(outcome["status"], "delivered")
+        describe_channel.assert_called_once()
+        envelope = deliver_session_message.call_args.args[1]
+        self.assertIn(f"conversation: team:{TEAM_ID} channel:{ROOM_CHANNEL} thread:{ROOT_POST}", envelope)
+
+    def test_process_inbound_room_message_marks_lookup_failure_as_retryable(self) -> None:
+        common.save_bot_token("bot-token")
+        post_id = mm_id("post213")
+        post = make_post(
+            post_id,
+            channel_id=ROOM_CHANNEL,
+            team_id=TEAM_ID,
+            root_id=ROOT_POST,
+            message=f"@{BOT_USERNAME} can you take a look?",
+            mentions=[BOT_USER_ID],
+        )
+
+        with mock.patch.object(
+            common, "describe_channel", side_effect=common.MattermostAPIError("GET channel failed", status_code=500)
+        ), mock.patch.object(common, "deliver_session_message") as deliver_session_message:
+            outcome = self._process(post)
+
+        self.assertEqual(outcome["status"], "failed_lookup")
+        deliver_session_message.assert_not_called()
+        self.assertEqual(common.load_chat_ingress(f"in-{post_id}")["status"], "failed_lookup")
+
+    def test_process_inbound_ambient_room_message_ignores_untargeted_body(self) -> None:
+        common.set_chat_binding(
+            common.load_config(),
+            "room",
+            ROOM_CHANNEL,
+            ["sky", "lawrence"],
+            TEAM_ID,
+            policy={"ambient_read_enabled": True},
+        )
+        post_id = mm_id("post507")
+        post = make_post(post_id, channel_id=ROOM_CHANNEL, team_id=TEAM_ID, channel_type="O", message="just chatting here")
+
+        with mock.patch.object(common, "session_index_by_name") as session_index_by_name, mock.patch.object(
+            common, "deliver_session_message"
+        ) as deliver_session_message:
+            outcome = self._process(post)
+
+        self.assertEqual(outcome["status"], "ignored_untargeted")
+        session_index_by_name.assert_not_called()
+        deliver_session_message.assert_not_called()
+        receipt = common.load_chat_ingress(f"in-{post_id}")
+        self.assertEqual(receipt["status"], "ignored_untargeted")
+        self.assertEqual(receipt["reason"], "ambient_target_required")
+
+    def test_process_inbound_ambient_room_message_routes_untargeted_single_session_when_enabled(self) -> None:
+        common.set_chat_binding(
+            common.load_config(),
+            "room",
+            ROOM_CHANNEL,
+            ["randy"],
+            TEAM_ID,
+            policy={"ambient_read_enabled": True, "allow_untargeted_ambient_delivery": True},
+        )
+        post_id = mm_id("post507single")
+        post = make_post(
+            post_id, channel_id=ROOM_CHANNEL, team_id=TEAM_ID, channel_type="O", message="what changed since yesterday?"
+        )
+
+        with mock.patch.object(common, "deliver_session_message", return_value={"status": "accepted"}) as deliver_session_message:
+            outcome = self._process(post)
+
+        self.assertEqual(outcome["status"], "delivered")
+        deliver_session_message.assert_called_once()
+        self.assertEqual(deliver_session_message.call_args.args[0], "randy")
+        receipt = common.load_chat_ingress(f"in-{post_id}")
+        self.assertEqual(receipt["status"], "delivered")
+        self.assertEqual(receipt["delivery"], "broadcast")
+
+    def test_process_inbound_ambient_room_message_routes_unknown_alias_to_sticky_single_session(self) -> None:
+        common.set_chat_binding(
+            common.load_config(),
+            "room",
+            ROOM_CHANNEL,
+            ["deacon__deacon"],
+            TEAM_ID,
+            policy={"ambient_read_enabled": True, "allow_untargeted_ambient_delivery": True},
+        )
+        post_id = mm_id("post507sticky")
+        post = make_post(
+            post_id,
+            channel_id=ROOM_CHANNEL,
+            team_id=TEAM_ID,
+            channel_type="O",
+            message="@deacon: can you check the dashboard deploy?",
+        )
+
+        with mock.patch.object(common, "deliver_session_message", return_value={"status": "accepted"}) as deliver_session_message:
+            outcome = self._process(post)
+
+        self.assertEqual(outcome["status"], "delivered")
+        deliver_session_message.assert_called_once()
+        self.assertEqual(deliver_session_message.call_args.args[0], "deacon__deacon")
+        receipt = common.load_chat_ingress(f"in-{post_id}")
+        self.assertEqual(receipt["status"], "delivered")
+        self.assertEqual(receipt["delivery"], "broadcast")
+        self.assertEqual(receipt["mentioned_aliases"], ["deacon"])
+
+    def test_process_inbound_ambient_room_message_ignores_unknown_alias_with_receipt(self) -> None:
+        common.set_chat_binding(
+            common.load_config(),
+            "room",
+            ROOM_CHANNEL,
+            ["sky", "lawrence"],
+            TEAM_ID,
+            policy={"ambient_read_enabled": True},
+        )
+        post_id = mm_id("post507a")
+        post = make_post(
+            post_id, channel_id=ROOM_CHANNEL, team_id=TEAM_ID, channel_type="O", message="@ghost please check the shard"
+        )
+
+        with mock.patch.object(common, "session_index_by_name") as session_index_by_name, mock.patch.object(
+            common, "deliver_session_message"
+        ) as deliver_session_message:
+            outcome = self._process(post)
+
+        self.assertEqual(outcome["status"], "ignored_untargeted")
+        session_index_by_name.assert_not_called()
+        deliver_session_message.assert_not_called()
+        receipt = common.load_chat_ingress(f"in-{post_id}")
+        self.assertEqual(receipt["status"], "ignored_untargeted")
+        self.assertEqual(receipt["reason"], "ambient_target_required")
+
+    def test_process_inbound_ambient_room_message_dedupes_replayed_unknown_alias_after_binding_changes(self) -> None:
+        common.set_chat_binding(
+            common.load_config(),
+            "room",
+            ROOM_CHANNEL,
+            ["sky", "lawrence"],
+            TEAM_ID,
+            policy={"ambient_read_enabled": True},
+        )
+        post = make_post(
+            mm_id("post507aa"), channel_id=ROOM_CHANNEL, team_id=TEAM_ID, channel_type="O", message="@ghost please check"
+        )
+
+        with mock.patch.object(common, "session_index_by_name") as session_index_by_name, mock.patch.object(
+            common, "deliver_session_message"
+        ) as deliver_session_message:
+            first_outcome = self._process(post)
+
+        self.assertEqual(first_outcome["status"], "ignored_untargeted")
+        session_index_by_name.assert_not_called()
+        deliver_session_message.assert_not_called()
+
+        common.set_chat_binding(
+            common.load_config(),
+            "room",
+            ROOM_CHANNEL,
+            ["sky", "lawrence", "ghost"],
+            TEAM_ID,
+            policy={"ambient_read_enabled": True},
+        )
+
+        with mock.patch.object(common, "session_index_by_name") as session_index_by_name, mock.patch.object(
+            common, "deliver_session_message"
+        ) as deliver_session_message:
+            replay_outcome = self._process(post)
+
+        self.assertEqual(replay_outcome["status"], "duplicate")
+        session_index_by_name.assert_not_called()
+        deliver_session_message.assert_not_called()
+
+    def test_process_inbound_ambient_room_message_preserves_unknown_alias_rejection_when_mixed(self) -> None:
+        common.set_chat_binding(
+            common.load_config(),
+            "room",
+            ROOM_CHANNEL,
+            ["sky", "lawrence"],
+            TEAM_ID,
+            policy={"ambient_read_enabled": True},
+        )
+        post_id = mm_id("post507b")
+        post = make_post(
+            post_id, channel_id=ROOM_CHANNEL, team_id=TEAM_ID, channel_type="O", message="@sky @ghost please check the shard"
+        )
+
+        with mock.patch.object(
+            common,
+            "session_index_by_name",
+            return_value={
+                "sky": {"session_name": "sky", "state": "active"},
+                "lawrence": {"session_name": "lawrence", "state": "active"},
+            },
+        ), mock.patch.object(common, "deliver_session_message") as deliver_session_message:
+            outcome = self._process(post)
+
+        self.assertEqual(outcome["status"], "rejected_targeting")
+        deliver_session_message.assert_not_called()
+        self.assertEqual(common.load_chat_ingress(f"in-{post_id}")["reason"], "unknown_alias:ghost")
+
+    def test_process_inbound_ambient_room_message_still_requires_target_when_bot_mentioned(self) -> None:
+        common.set_chat_binding(
+            common.load_config(),
+            "room",
+            ROOM_CHANNEL,
+            ["sky", "lawrence"],
+            TEAM_ID,
+            policy={"ambient_read_enabled": True},
+        )
+        post_id = mm_id("post508")
+        post = make_post(
+            post_id,
+            channel_id=ROOM_CHANNEL,
+            team_id=TEAM_ID,
+            channel_type="O",
+            message=f"@{BOT_USERNAME} please check the shard",
+            mentions=[BOT_USER_ID],
+        )
+
+        with mock.patch.object(
+            common,
+            "session_index_by_name",
+            return_value={
+                "sky": {"session_name": "sky", "state": "active"},
+                "lawrence": {"session_name": "lawrence", "state": "active"},
+            },
+        ), mock.patch.object(common, "deliver_session_message") as deliver_session_message:
+            outcome = self._process(post)
+
+        self.assertEqual(outcome["status"], "ignored_untargeted")
+        deliver_session_message.assert_not_called()
+        self.assertEqual(common.load_chat_ingress(f"in-{post_id}")["reason"], "ambient_target_required")
+
+    def test_process_inbound_bot_mentioned_ambient_room_routes_untargeted_single_session_when_enabled(self) -> None:
+        common.set_chat_binding(
+            common.load_config(),
+            "room",
+            ROOM_CHANNEL,
+            ["randy"],
+            TEAM_ID,
+            policy={"ambient_read_enabled": True, "allow_untargeted_ambient_delivery": True},
+        )
+        post_id = mm_id("post508single")
+        post = make_post(
+            post_id,
+            channel_id=ROOM_CHANNEL,
+            team_id=TEAM_ID,
+            channel_type="O",
+            message=f"@{BOT_USERNAME} what changed since yesterday?",
+            mentions=[BOT_USER_ID],
+        )
+
+        with mock.patch.object(
+            common, "session_index_by_name", return_value={"randy": {"session_name": "randy", "state": "active"}}
+        ), mock.patch.object(common, "deliver_session_message", return_value={"status": "accepted"}) as deliver_session_message:
+            outcome = self._process(post)
+
+        self.assertEqual(outcome["status"], "delivered")
+        deliver_session_message.assert_called_once()
+        self.assertEqual(deliver_session_message.call_args.args[0], "randy")
+        self.assertEqual(common.load_chat_ingress(f"in-{post_id}")["status"], "delivered")
+
+    def test_process_inbound_bot_mentioned_ambient_room_delivers_to_unmaterialized_named_selector(self) -> None:
+        common.set_chat_binding(
+            common.load_config(),
+            "room",
+            ROOM_CHANNEL,
+            ["employees.corp--alex"],
+            TEAM_ID,
+            policy={"ambient_read_enabled": True, "allow_untargeted_ambient_delivery": True},
+        )
+        post_id = mm_id("post508unmat")
+        post = make_post(
+            post_id,
+            channel_id=ROOM_CHANNEL,
+            team_id=TEAM_ID,
+            channel_type="O",
+            message=f"@{BOT_USERNAME} are you there?",
+            mentions=[BOT_USER_ID],
+        )
+
+        with mock.patch.object(common, "deliver_session_message", return_value={"status": "accepted"}) as deliver_session_message:
+            outcome = self._process(post)
+
+        self.assertEqual(outcome["status"], "delivered")
+        deliver_session_message.assert_called_once()
+        self.assertEqual(deliver_session_message.call_args.args[0], "employees.corp--alex")
+        self.assertEqual(common.load_chat_ingress(f"in-{post_id}")["status"], "delivered")
+
+    def test_process_inbound_bot_mentioned_ambient_thread_still_requires_target(self) -> None:
+        common.set_chat_binding(
+            common.load_config(),
+            "room",
+            ROOM_CHANNEL,
+            ["sky", "lawrence"],
+            TEAM_ID,
+            policy={"ambient_read_enabled": True},
+        )
+        post_id = mm_id("post508b")
+        post = make_post(
+            post_id,
+            channel_id=ROOM_CHANNEL,
+            team_id=TEAM_ID,
+            root_id=ROOT_POST,
+            channel_type="O",
+            message=f"@{BOT_USERNAME} please check the shard",
+            mentions=[BOT_USER_ID],
+        )
+
+        with mock.patch.object(
+            common,
+            "session_index_by_name",
+            return_value={
+                "sky": {"session_name": "sky", "state": "active"},
+                "lawrence": {"session_name": "lawrence", "state": "active"},
+            },
+        ), mock.patch.object(common, "deliver_session_message") as deliver_session_message:
+            outcome = self._process(post)
+
+        self.assertEqual(outcome["status"], "ignored_untargeted")
+        deliver_session_message.assert_not_called()
+        self.assertEqual(common.load_chat_ingress(f"in-{post_id}")["reason"], "ambient_target_required")
+
+    def test_process_inbound_unmentioned_unbound_channel_does_not_probe_channel_info(self) -> None:
+        common.set_chat_binding(
+            common.load_config(),
+            "room",
+            ROOM_CHANNEL,
+            ["sky", "lawrence"],
+            TEAM_ID,
+            policy={"ambient_read_enabled": True},
+        )
+        common.save_bot_token("bot-token")
+        post = make_post(
+            mm_id("post509"), channel_id=OTHER_CHANNEL, team_id=TEAM_ID, message="@sky please check the shard"
+        )
+
+        with mock.patch.object(common, "describe_channel") as describe_channel, mock.patch.object(
+            common, "deliver_session_message"
+        ) as deliver_session_message:
+            outcome = self._process(post)
+
+        self.assertEqual(outcome["status"], "ignored")
+        self.assertEqual(outcome["reason"], "not_mentioned")
+        describe_channel.assert_not_called()
+        deliver_session_message.assert_not_called()
+
+    # ------------------------------------------------------------------
+    # Channel metadata caching
+    # ------------------------------------------------------------------
+
+    def test_process_inbound_bound_room_message_does_not_fetch_channel_info_when_metadata_is_known(self) -> None:
+        common.set_chat_binding(
+            common.load_config(),
+            "room",
+            ROOM_CHANNEL,
+            ["sky"],
+            TEAM_ID,
+            channel_metadata={"channel_type": "O"},
+        )
+        common.save_bot_token("bot-token")
+        post = make_post(
+            mm_id("post507bb"),
+            channel_id=ROOM_CHANNEL,
+            team_id=TEAM_ID,
+            channel_type="O",
+            message=f"@{BOT_USERNAME} @sky please check the shard",
+            mentions=[BOT_USER_ID],
+        )
+
+        with mock.patch.object(common, "describe_channel") as describe_channel, mock.patch.object(
+            common, "session_index_by_name", return_value={"sky": {"session_name": "sky", "state": "active"}}
+        ), mock.patch.object(common, "deliver_session_message", return_value={"status": "accepted"}) as deliver_session_message:
+            outcome = self._process(post)
+
+        self.assertEqual(outcome["status"], "delivered")
+        describe_channel.assert_not_called()
+        deliver_session_message.assert_called_once()
+
+    def test_process_inbound_legacy_main_room_binding_survives_lookup_failure(self) -> None:
+        common.set_chat_binding(common.load_config(), "room", ROOM_CHANNEL, ["sky"], TEAM_ID)
+        common.save_bot_token("bot-token")
+        post = make_post(
+            mm_id("post507c"),
+            channel_id=ROOM_CHANNEL,
+            team_id=TEAM_ID,
+            channel_type="O",
+            message=f"@{BOT_USERNAME} @sky please check the shard",
+            mentions=[BOT_USER_ID],
+        )
+
+        with mock.patch.object(
+            common, "describe_channel", side_effect=common.MattermostAPIError("GET failed", status_code=500)
+        ), mock.patch.object(
+            common, "session_index_by_name", return_value={"sky": {"session_name": "sky", "state": "active"}}
+        ), mock.patch.object(common, "deliver_session_message", return_value={"status": "accepted"}) as deliver_session_message:
+            outcome = self._process(post)
+
+        self.assertEqual(outcome["status"], "delivered")
+        deliver_session_message.assert_called_once()
+
+    def test_process_inbound_legacy_main_room_binding_caches_metadata_after_successful_lookup(self) -> None:
+        common.set_chat_binding(common.load_config(), "room", ROOM_CHANNEL, ["sky"], TEAM_ID)
+        common.save_bot_token("bot-token")
+        first_post = make_post(
+            mm_id("post507d"),
+            channel_id=ROOM_CHANNEL,
+            team_id=TEAM_ID,
+            channel_type="O",
+            message=f"@{BOT_USERNAME} @sky please check the shard",
+            mentions=[BOT_USER_ID],
+        )
+        second_post = make_post(
+            mm_id("post507e"),
+            channel_id=ROOM_CHANNEL,
+            team_id=TEAM_ID,
+            channel_type="O",
+            message=f"@{BOT_USERNAME} @sky please check the shard again",
+            mentions=[BOT_USER_ID],
+        )
+
+        with mock.patch.object(
+            common, "describe_channel", return_value={"id": ROOM_CHANNEL, "type": "O", "team_id": TEAM_ID}
+        ) as describe_channel, mock.patch.object(
+            common, "session_index_by_name", return_value={"sky": {"session_name": "sky", "state": "active"}}
+        ), mock.patch.object(common, "deliver_session_message", return_value={"status": "accepted"}) as deliver_session_message:
+            first_outcome = self._process(first_post)
+
+        self.assertEqual(first_outcome["status"], "delivered")
+        describe_channel.assert_called_once()
+        deliver_session_message.assert_called_once()
+        binding = common.resolve_chat_binding(common.load_config(), common.chat_binding_id("room", ROOM_CHANNEL))
+        assert binding is not None
+        self.assertNotIn("channel_type", binding)
+        self.assertEqual(
+            common.load_channel_metadata_cache(ROOM_CHANNEL),
+            {"channel_type": "O", "channel_team_id": TEAM_ID},
+        )
+
+        gateway_service.CHANNEL_INFO_CACHE.clear()
+
+        with mock.patch.object(common, "describe_channel") as describe_channel, mock.patch.object(
+            common, "session_index_by_name", return_value={"sky": {"session_name": "sky", "state": "active"}}
+        ), mock.patch.object(common, "deliver_session_message", return_value={"status": "accepted"}) as deliver_session_message:
+            second_outcome = self._process(second_post)
+
+        self.assertEqual(second_outcome["status"], "delivered")
+        describe_channel.assert_not_called()
+        deliver_session_message.assert_called_once()
+
+    def test_persist_binding_channel_metadata_writes_runtime_cache_without_rewriting_binding(self) -> None:
+        common.set_chat_binding(
+            common.load_config(),
+            "room",
+            ROOM_CHANNEL,
+            ["sky"],
+            TEAM_ID,
+            policy={"ambient_read_enabled": True},
+        )
+        stale_binding = common.resolve_chat_binding(common.load_config(), common.chat_binding_id("room", ROOM_CHANNEL))
+        assert stale_binding is not None
+        common.set_chat_binding(
+            common.load_config(),
+            "room",
+            ROOM_CHANNEL,
+            ["sky", "lawrence"],
+            TEAM_ID,
+            policy={"ambient_read_enabled": True, "peer_fanout_enabled": True},
+        )
+
+        gateway_service.persist_binding_channel_metadata({**stale_binding, "channel_type": "O"})
+
+        binding = common.resolve_chat_binding(common.load_config(), common.chat_binding_id("room", ROOM_CHANNEL))
+        assert binding is not None
+        self.assertEqual(binding["session_names"], ["sky", "lawrence"])
+        self.assertNotIn("channel_type", binding)
+        self.assertTrue(common.binding_peer_policy(binding)["peer_fanout_enabled"])
+        self.assertEqual(common.load_channel_metadata_cache(ROOM_CHANNEL), {"channel_type": "O"})
+
+    # ------------------------------------------------------------------
+    # Room launch surfaces
+    # ------------------------------------------------------------------
+
+    def _save_room_launch(self, **overrides: Any) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "launch_id": f"room-launch:{ROOT_POST}",
+            "launcher_id": f"launch-room:{ROOM_CHANNEL}",
+            "team_id": TEAM_ID,
+            "conversation_id": ROOM_CHANNEL,
+            "root_post_id": ROOT_POST,
+            "qualified_handle": "corp/sky",
+            "session_alias": "mm-123-sky",
+            "session_name": "mm-sky",
+            "participants": {
+                "corp/sky": {
+                    "qualified_handle": "corp/sky",
+                    "session_alias": "mm-123-sky",
+                    "session_name": "mm-sky",
+                    "session_id": "gc-sky",
+                }
+            },
+            "state": "active",
+        }
+        payload.update(overrides)
+        return common.save_room_launch(payload)
+
+    def test_process_inbound_room_launch_routes_handle_without_bot_mention(self) -> None:
+        common.set_room_launcher(common.load_config(), TEAM_ID, ROOM_CHANNEL)
+        post_id = mm_id("post208")
+        post = make_post(
+            post_id, channel_id=ROOM_CHANNEL, team_id=TEAM_ID, channel_type="O", message="@@sky please help"
+        )
+
+        with mock.patch.object(common, "resolve_agent_handle", return_value=("corp/sky", "")), mock.patch.object(
+            common,
+            "ensure_room_launch_session",
+            return_value={
+                "launch_id": f"room-launch:{post_id}",
+                "qualified_handle": "corp/sky",
+                "session_alias": "mm-123-sky",
+                "session_name": "s-gc-123",
+                "session_id": "gc-123",
+            },
+        ), mock.patch.object(common, "deliver_session_message", return_value={"status": "accepted"}) as deliver_session_message:
+            outcome = self._process(post)
+
+        self.assertEqual(outcome["status"], "delivered")
+        deliver_session_message.assert_called_once()
+        self.assertEqual(deliver_session_message.call_args.args[0], "s-gc-123")
+        envelope = deliver_session_message.call_args.args[1]
+        self.assertIn(f"binding_id: launch-room:{ROOM_CHANNEL}", envelope)
+        self.assertIn(f"launch_id: room-launch:{post_id}", envelope)
+        self.assertIn("launch_session_alias: mm-123-sky", envelope)
+        self.assertIn("reply_tool: gc mattermost reply-current --body-file <path>", envelope)
+        self.assertIn(
+            "reply_turn_requirement: if you intend to answer, do not end the turn without a successful reply-current",
+            envelope,
+        )
+        self.assertIn(
+            "peer_targeting_rule: include @@rig/alias in the Mattermost reply if you want another launcher participant to receive it as peer input",
+            envelope,
+        )
+        receipt = common.load_chat_ingress(f"in-{post_id}")
+        assert receipt is not None
+        self.assertEqual(receipt["launch_id"], f"room-launch:{post_id}")
+
+    def test_process_inbound_room_launch_recovers_empty_team_content_via_rest(self) -> None:
+        common.set_room_launcher(common.load_config(), TEAM_ID, ROOM_CHANNEL)
+        post_id = mm_id("post208b")
+        user_id = mm_id("user208b")
+        post = make_post(
+            post_id,
+            channel_id=ROOM_CHANNEL,
+            team_id=TEAM_ID,
+            channel_type="O",
+            message="",
+            user_id=user_id,
+            from_username="",
+        )
+
+        with mock.patch.object(
+            common,
+            "mattermost_api_request",
+            return_value={
+                "id": post_id,
+                "channel_id": ROOM_CHANNEL,
+                "message": "@@corp/sky please help",
+                "user_id": user_id,
+            },
+        ) as mattermost_api_request, mock.patch.object(
+            common, "describe_user", return_value={"username": "alice"}
+        ), mock.patch.object(common, "resolve_agent_handle", return_value=("corp/sky", "")), mock.patch.object(
+            common,
+            "ensure_room_launch_session",
+            return_value={
+                "launch_id": f"room-launch:{post_id}",
+                "qualified_handle": "corp/sky",
+                "session_alias": "mm-123-sky",
+                "session_name": "s-gc-123",
+                "session_id": "gc-123",
+            },
+        ), mock.patch.object(common, "deliver_session_message", return_value={"status": "accepted"}) as deliver_session_message:
+            outcome = self._process(post)
+
+        self.assertEqual(outcome["status"], "delivered")
+        mattermost_api_request.assert_called_once_with("GET", f"/posts/{post_id}")
+        deliver_session_message.assert_called_once()
+        self.assertEqual(deliver_session_message.call_args.args[0], "s-gc-123")
+        envelope = deliver_session_message.call_args.args[1]
+        self.assertIn('untrusted_body_json: "@@corp/sky please help"', envelope)
+        receipt = common.load_chat_ingress(f"in-{post_id}")
+        assert receipt is not None
+        self.assertEqual(receipt["body_preview"], "@@corp/sky please help")
+        self.assertEqual(receipt["from_display"], "alice")
+        self.assertEqual((receipt.get("message_debug") or {}).get("content_source"), "rest_fallback")
+
+    def test_process_inbound_room_launch_marks_team_empty_content_unavailable(self) -> None:
+        common.set_room_launcher(common.load_config(), TEAM_ID, ROOM_CHANNEL)
+        post_id = mm_id("post208c")
+        post = make_post(post_id, channel_id=ROOM_CHANNEL, team_id=TEAM_ID, channel_type="O", message="")
+
+        with mock.patch.object(common, "mattermost_api_request", return_value=[]), mock.patch.object(
+            common, "deliver_session_message"
+        ) as deliver_session_message:
+            outcome = self._process(post)
+
+        self.assertEqual(outcome["status"], "ignored_empty")
+        deliver_session_message.assert_not_called()
+        receipt = common.load_chat_ingress(f"in-{post_id}")
+        assert receipt is not None
+        self.assertEqual(receipt["reason"], "message_content_unavailable")
+        self.assertEqual((receipt.get("message_debug") or {}).get("content_source"), "gateway_empty_rest_unavailable")
+
+    def test_process_inbound_room_launch_thread_routes_follow_up_without_bot_mention(self) -> None:
+        common.set_room_launcher(common.load_config(), TEAM_ID, ROOM_CHANNEL)
+        self._save_room_launch(
+            participants={
+                "corp/sky": {
+                    "qualified_handle": "corp/sky",
+                    "session_alias": "mm-123-sky",
+                    "session_name": "mm-123-sky",
+                    "primer_version": common.ROOM_LAUNCH_PRIMER_VERSION,
+                    "primed_at": "2026-03-22T00:00:00Z",
+                }
+            },
+            session_name="mm-123-sky",
+        )
+        post_id = mm_id("post209")
+        post = make_post(
+            post_id,
+            channel_id=ROOM_CHANNEL,
+            team_id=TEAM_ID,
+            root_id=ROOT_POST,
+            channel_type="O",
+            message="follow up",
+        )
+
+        with mock.patch.object(
+            common,
+            "ensure_room_launch_session_for_handle",
+            return_value=(
+                common.load_room_launch(f"room-launch:{ROOT_POST}") or {},
+                {
+                    "qualified_handle": "corp/sky",
+                    "session_alias": "mm-123-sky",
+                    "session_name": "mm-123-sky",
+                    "session_id": "gc-sky",
+                },
+            ),
+        ), mock.patch.object(common, "deliver_session_message", return_value={"status": "accepted"}) as deliver_session_message:
+            outcome = self._process(post)
+
+        self.assertEqual(outcome["status"], "delivered")
+        deliver_session_message.assert_called_once()
+        self.assertEqual(deliver_session_message.call_args.args[0], "mm-123-sky")
+        envelope = deliver_session_message.call_args.args[1]
+        self.assertIn(f"conversation: team:{TEAM_ID} channel:{ROOM_CHANNEL} thread:{ROOT_POST}", envelope)
+        self.assertIn(f"publish_conversation_id: {ROOM_CHANNEL}", envelope)
+        self.assertIn(f"publish_root_post_id: {ROOT_POST}", envelope)
+        self.assertTrue(str(common.load_room_launch(f"room-launch:{ROOT_POST}").get("last_activity_at", "")).strip())
+
+    def test_process_inbound_room_launch_rejects_ambiguous_handle(self) -> None:
+        common.set_room_launcher(common.load_config(), TEAM_ID, ROOM_CHANNEL)
+        post_id = mm_id("post210")
+        post = make_post(
+            post_id, channel_id=ROOM_CHANNEL, team_id=TEAM_ID, channel_type="O", message="@@sky please help"
+        )
+
+        with mock.patch.object(common, "resolve_agent_handle", return_value=("", "ambiguous_handle")), mock.patch.object(
+            common, "deliver_session_message"
+        ) as deliver_session_message:
+            outcome = self._process(post)
+
+        self.assertEqual(outcome["status"], "rejected_targeting")
+        deliver_session_message.assert_not_called()
+        self.assertEqual(common.load_chat_ingress(f"in-{post_id}")["reason"], "ambiguous_handle")
+
+    def test_process_inbound_room_launch_rejects_multiple_handles(self) -> None:
+        common.set_room_launcher(common.load_config(), TEAM_ID, ROOM_CHANNEL)
+        post_id = mm_id("post210a")
+        post = make_post(
+            post_id, channel_id=ROOM_CHANNEL, team_id=TEAM_ID, channel_type="O", message="@@corp/sky @@corp/alex help"
+        )
+
+        with mock.patch.object(common, "deliver_session_message") as deliver_session_message:
+            outcome = self._process(post)
+
+        self.assertEqual(outcome["status"], "rejected_targeting")
+        deliver_session_message.assert_not_called()
+        self.assertEqual(common.load_chat_ingress(f"in-{post_id}")["reason"], "multiple_handles_not_supported")
+
+    def test_process_inbound_room_launch_ignores_untargeted_mention_only_post(self) -> None:
+        common.set_room_launcher(common.load_config(), TEAM_ID, ROOM_CHANNEL)
+        post_id = mm_id("post210d")
+        post = make_post(post_id, channel_id=ROOM_CHANNEL, team_id=TEAM_ID, channel_type="O", message="please help")
+
+        with mock.patch.object(common, "deliver_session_message") as deliver_session_message:
+            outcome = self._process(post)
+
+        self.assertEqual(outcome["status"], "ignored_untargeted")
+        deliver_session_message.assert_not_called()
+        self.assertEqual(common.load_chat_ingress(f"in-{post_id}")["reason"], "launch_handle_required")
+
+    def test_process_inbound_room_launch_respond_all_uses_default_handle(self) -> None:
+        common.set_room_launcher(
+            common.load_config(),
+            TEAM_ID,
+            ROOM_CHANNEL,
+            response_mode="respond_all",
+            default_qualified_handle="corp/sky",
+        )
+        post_id = mm_id("post210b")
+        post = make_post(post_id, channel_id=ROOM_CHANNEL, team_id=TEAM_ID, channel_type="O", message="please help")
+
+        with mock.patch.object(
+            common,
+            "ensure_room_launch_session",
+            return_value={
+                "launch_id": f"room-launch:{post_id}",
+                "qualified_handle": "corp/sky",
+                "session_alias": "mm-123-sky",
+                "session_name": "mm-123-sky",
+            },
+        ), mock.patch.object(common, "deliver_session_message", return_value={"status": "accepted"}) as deliver_session_message:
+            outcome = self._process(post)
+
+        self.assertEqual(outcome["status"], "delivered")
+        deliver_session_message.assert_called_once()
+        self.assertIn("launch_qualified_handle: corp/sky", deliver_session_message.call_args.args[1])
+
+    def test_process_inbound_room_launch_respond_all_honors_mixed_case_explicit_handle(self) -> None:
+        common.set_room_launcher(
+            common.load_config(),
+            TEAM_ID,
+            ROOM_CHANNEL,
+            response_mode="respond_all",
+            default_qualified_handle="corp/default",
+        )
+        post_id = mm_id("post210c")
+        post = make_post(
+            post_id, channel_id=ROOM_CHANNEL, team_id=TEAM_ID, channel_type="O", message="@@Sky please help"
+        )
+
+        with mock.patch.object(common, "resolve_agent_handle", return_value=("corp/sky", "")), mock.patch.object(
+            common,
+            "ensure_room_launch_session",
+            return_value={
+                "launch_id": f"room-launch:{post_id}",
+                "qualified_handle": "corp/sky",
+                "session_alias": "mm-123-sky",
+                "session_name": "mm-123-sky",
+            },
+        ), mock.patch.object(common, "deliver_session_message", return_value={"status": "accepted"}) as deliver_session_message:
+            outcome = self._process(post)
+
+        self.assertEqual(outcome["status"], "delivered")
+        envelope = deliver_session_message.call_args.args[1]
+        self.assertIn("launch_qualified_handle: corp/sky", envelope)
+        self.assertNotIn("launch_qualified_handle: corp/default", envelope)
+
+    def test_process_inbound_room_launch_thread_retargets_to_new_handle(self) -> None:
+        common.set_room_launcher(common.load_config(), TEAM_ID, ROOM_CHANNEL)
+        self._save_room_launch()
+        post_id = mm_id("post211")
+        post = make_post(
+            post_id,
+            channel_id=ROOM_CHANNEL,
+            team_id=TEAM_ID,
+            root_id=ROOT_POST,
+            channel_type="O",
+            message="@@alex please join",
+        )
+
+        with mock.patch.object(common, "resolve_agent_handle", return_value=("corp/alex", "")), mock.patch.object(
+            common,
+            "ensure_room_launch_session_for_handle",
+            return_value=(
+                {
+                    **(common.load_room_launch(f"room-launch:{ROOT_POST}") or {}),
+                    "participants": {
+                        "corp/sky": {
+                            "qualified_handle": "corp/sky",
+                            "session_alias": "mm-123-sky",
+                            "session_name": "mm-sky",
+                            "session_id": "gc-sky",
+                        },
+                        "corp/alex": {
+                            "qualified_handle": "corp/alex",
+                            "session_alias": "mm-456-alex",
+                            "session_name": "mm-alex",
+                            "session_id": "gc-alex",
+                        },
+                    },
+                },
+                {
+                    "qualified_handle": "corp/alex",
+                    "session_alias": "mm-456-alex",
+                    "session_name": "mm-alex",
+                    "session_id": "gc-alex",
+                },
+            ),
+        ), mock.patch.object(common, "set_room_launch_last_addressed"), mock.patch.object(
+            common, "deliver_session_message", return_value={"status": "accepted"}
+        ) as deliver_session_message:
+            outcome = self._process(post)
+
+        self.assertEqual(outcome["status"], "delivered")
+        deliver_session_message.assert_called_once()
+        self.assertEqual(deliver_session_message.call_args.args[0], "mm-alex")
+        envelope = deliver_session_message.call_args.args[1]
+        self.assertIn("launch_qualified_handle: corp/alex", envelope)
+        self.assertIn('thread_participants_json: [{"qualified_handle": "corp/alex"', envelope)
+        self.assertIn("reply_success_signal: record.remote_message_id", envelope)
+        self.assertIn(
+            "peer_targeting_rule: include @@rig/alias in the Mattermost reply if you want another launcher participant to receive it as peer input",
+            envelope,
+        )
+        receipt = common.load_chat_ingress(f"in-{post_id}")
+        assert receipt is not None
+        self.assertEqual(receipt["routing_mode"], "explicit_handle")
+        self.assertEqual(receipt["qualified_handle"], "corp/alex")
+
+    def test_process_inbound_room_launch_thread_reply_targets_matching_agent_publish(self) -> None:
+        common.set_room_launcher(common.load_config(), TEAM_ID, ROOM_CHANNEL)
+        agent_post_id = mm_id("postagent1")
+        self._save_room_launch(
+            participants={
+                "corp/sky": {
+                    "qualified_handle": "corp/sky",
+                    "session_alias": "mm-123-sky",
+                    "session_name": "mm-sky",
+                    "session_id": "gc-sky",
+                },
+                "corp/alex": {
+                    "qualified_handle": "corp/alex",
+                    "session_alias": "mm-456-alex",
+                    "session_name": "mm-alex",
+                    "session_id": "gc-alex",
+                },
+            },
+            message_targets={agent_post_id: "corp/alex"},
+        )
+        post_id = mm_id("post212a")
+        post = make_post(
+            post_id,
+            channel_id=ROOM_CHANNEL,
+            team_id=TEAM_ID,
+            root_id=ROOT_POST,
+            channel_type="O",
+            message="what do you think?",
+            props={"reply_to_post_id": agent_post_id},
+        )
+
+        with mock.patch.object(
+            common,
+            "ensure_room_launch_session_for_handle",
+            return_value=(
+                common.load_room_launch(f"room-launch:{ROOT_POST}") or {},
+                {
+                    "qualified_handle": "corp/alex",
+                    "session_alias": "mm-456-alex",
+                    "session_name": "mm-alex",
+                    "session_id": "gc-alex",
+                },
+            ),
+        ), mock.patch.object(common, "set_room_launch_last_addressed"), mock.patch.object(
+            common, "deliver_session_message", return_value={"status": "accepted"}
+        ) as deliver_session_message:
+            outcome = self._process(post)
+
+        self.assertEqual(outcome["status"], "delivered")
+        self.assertEqual(deliver_session_message.call_args.args[0], "mm-alex")
+        receipt = common.load_chat_ingress(f"in-{post_id}")
+        assert receipt is not None
+        self.assertEqual(receipt["routing_mode"], "reply_to")
+        self.assertIn(f"reply_to_mattermost_post_id: {agent_post_id}", deliver_session_message.call_args.args[1])
+
+    def test_process_inbound_room_launch_thread_uses_last_addressed_fallback(self) -> None:
+        common.set_room_launcher(common.load_config(), TEAM_ID, ROOM_CHANNEL)
+        self._save_room_launch(
+            last_addressed_qualified_handle="corp/alex",
+            participants={
+                "corp/sky": {
+                    "qualified_handle": "corp/sky",
+                    "session_alias": "mm-123-sky",
+                    "session_name": "mm-sky",
+                    "session_id": "gc-sky",
+                },
+                "corp/alex": {
+                    "qualified_handle": "corp/alex",
+                    "session_alias": "mm-456-alex",
+                    "session_name": "mm-alex",
+                    "session_id": "gc-alex",
+                },
+            },
+        )
+        post_id = mm_id("post212b")
+        post = make_post(
+            post_id,
+            channel_id=ROOM_CHANNEL,
+            team_id=TEAM_ID,
+            root_id=ROOT_POST,
+            channel_type="O",
+            message="keep going",
+        )
+
+        with mock.patch.object(
+            common,
+            "ensure_room_launch_session_for_handle",
+            return_value=(
+                common.load_room_launch(f"room-launch:{ROOT_POST}") or {},
+                {
+                    "qualified_handle": "corp/alex",
+                    "session_alias": "mm-456-alex",
+                    "session_name": "mm-alex",
+                    "session_id": "gc-alex",
+                },
+            ),
+        ), mock.patch.object(common, "set_room_launch_last_addressed"), mock.patch.object(
+            common, "deliver_session_message", return_value={"status": "accepted"}
+        ) as deliver_session_message:
+            outcome = self._process(post)
+
+        self.assertEqual(outcome["status"], "delivered")
+        self.assertEqual(deliver_session_message.call_args.args[0], "mm-alex")
+        receipt = common.load_chat_ingress(f"in-{post_id}")
+        assert receipt is not None
+        self.assertEqual(receipt["routing_mode"], "last_addressed")
+
+    def test_process_inbound_room_launch_thread_ignores_reply_under_unknown_root(self) -> None:
+        common.set_room_launcher(common.load_config(), TEAM_ID, ROOM_CHANNEL)
+        post_id = mm_id("post212c")
+        post = make_post(
+            post_id,
+            channel_id=ROOM_CHANNEL,
+            team_id=TEAM_ID,
+            root_id=mm_id("unknownroot"),
+            channel_type="O",
+            message="anyone there?",
+        )
+
+        with mock.patch.object(common, "deliver_session_message") as deliver_session_message:
+            outcome = self._process(post)
+
+        self.assertEqual(outcome["status"], "ignored")
+        self.assertEqual(outcome["reason"], "not_mentioned")
+        deliver_session_message.assert_not_called()
+
+    # ------------------------------------------------------------------
+    # extmsg fabric interplay
+    # ------------------------------------------------------------------
+
+    def test_record_extmsg_inbound_skips_bound_room_mentions(self) -> None:
+        common.set_chat_binding(
+            common.load_config(),
+            "room",
+            ROOM_CHANNEL,
+            ["randy"],
+            TEAM_ID,
+            policy={"ambient_read_enabled": True, "allow_untargeted_ambient_delivery": True},
+        )
+        worker = self._new_gateway_worker()
+        post = make_post(
+            mm_id("post207a"), channel_id=ROOM_CHANNEL, team_id=TEAM_ID, channel_type="O", message="@randy what changed?"
+        )
+
+        with mock.patch.object(common, "resolve_at_mentions", return_value=["randy"]) as resolve_at_mentions, mock.patch.object(
+            common, "resolve_mention_targets"
+        ) as resolve_mention_targets, mock.patch.object(common, "launch_thread_for_mentions") as launch_thread_for_mentions:
+            handled = worker._record_extmsg_inbound(post, BOT_USER_ID, BOT_USERNAME)
+
+        self.assertFalse(handled)
+        resolve_at_mentions.assert_not_called()
+        resolve_mention_targets.assert_not_called()
+        launch_thread_for_mentions.assert_not_called()
+
+    def test_record_extmsg_inbound_skips_thread_when_channel_is_bound(self) -> None:
+        common.set_chat_binding(common.load_config(), "room", ROOM_CHANNEL, ["randy"], TEAM_ID)
+        worker = self._new_gateway_worker()
+        post = make_post(
+            mm_id("post207b"),
+            channel_id=ROOM_CHANNEL,
+            team_id=TEAM_ID,
+            root_id=ROOT_POST,
+            channel_type="O",
+            message="@randy still there?",
+        )
+
+        with mock.patch.object(common, "deliver_to_extmsg") as deliver_to_extmsg, mock.patch.object(
+            common, "normalize_to_extmsg_message"
+        ) as normalize_to_extmsg_message:
+            handled = worker._record_extmsg_inbound(post, BOT_USER_ID, BOT_USERNAME)
+
+        self.assertFalse(handled)
+        normalize_to_extmsg_message.assert_not_called()
+        deliver_to_extmsg.assert_not_called()
+
+    def test_record_extmsg_inbound_leaves_dm_thread_replies_to_the_dm_binding(self) -> None:
+        common.set_chat_binding(common.load_config(), "dm", DM_CHANNEL, ["sky"])
+        worker = self._new_gateway_worker()
+        post = make_post(
+            mm_id("post207c"),
+            channel_id=DM_CHANNEL,
+            root_id=ROOT_POST,
+            channel_type="D",
+            message="following up in the thread",
+        )
+
+        with mock.patch.object(common, "deliver_to_extmsg") as deliver_to_extmsg, mock.patch.object(
+            common, "normalize_to_extmsg_message"
+        ) as normalize_to_extmsg_message, mock.patch.object(common, "resolve_nl_agent_mentions") as resolve_nl_agent_mentions:
+            handled = worker._record_extmsg_inbound(post, BOT_USER_ID, BOT_USERNAME)
+
+        self.assertFalse(handled)
+        normalize_to_extmsg_message.assert_not_called()
+        deliver_to_extmsg.assert_not_called()
+        resolve_nl_agent_mentions.assert_not_called()
+
+    def test_handle_gateway_message_routes_dm_thread_reply_to_bound_session(self) -> None:
+        common.set_chat_binding(common.load_config(), "dm", DM_CHANNEL, ["sky"])
+        worker = self._new_gateway_worker()
+        post_id = mm_id("post207d")
+        post = make_post(
+            post_id, channel_id=DM_CHANNEL, root_id=ROOT_POST, channel_type="D", message="following up in the thread"
+        )
+
+        with mock.patch.object(
+            common, "session_index_by_name", return_value={"sky": {"session_name": "sky", "state": "active"}}
+        ), mock.patch.object(common, "deliver_session_message", return_value={"status": "accepted"}) as deliver_session_message:
+            worker.handle_gateway_message(post, BOT_USER_ID, BOT_USERNAME)
+
+        deliver_session_message.assert_called_once()
+        self.assertEqual(deliver_session_message.call_args.args[0], "sky")
+        receipt = common.load_chat_ingress(f"in-{post_id}")
+        assert receipt is not None
+        self.assertEqual(receipt["binding_id"], f"dm:{DM_CHANNEL}")
+        self.assertEqual(receipt["status"], "delivered")
+        self.assertIn(f"root_id: {ROOT_POST}", deliver_session_message.call_args.args[1])
+
+    def test_agent_at_mentions_drops_the_bots_own_username(self) -> None:
+        mentions = gateway_service.GatewayWorker._agent_at_mentions(
+            f"@{BOT_USERNAME} please ask @randy and @sky", BOT_USERNAME
+        )
+
+        self.assertEqual(mentions, ["randy", "sky"])
+
+    def test_handle_gateway_message_prefers_bound_room_over_extmsg_thread_launch(self) -> None:
+        common.set_chat_binding(
+            common.load_config(),
+            "room",
+            ROOM_CHANNEL,
+            ["randy"],
+            TEAM_ID,
+            policy={"ambient_read_enabled": True, "allow_untargeted_ambient_delivery": True},
+        )
+        worker = self._new_gateway_worker()
+        post_id = mm_id("post207aa")
+        post = make_post(
+            post_id, channel_id=ROOM_CHANNEL, team_id=TEAM_ID, channel_type="O", message="@randy what changed?"
+        )
+
+        with mock.patch.object(common, "launch_thread_for_mentions") as launch_thread_for_mentions, mock.patch.object(
+            common, "session_index_by_name", return_value={"randy": {"session_name": "randy", "state": "active"}}
+        ), mock.patch.object(common, "deliver_session_message", return_value={"status": "accepted"}) as deliver_session_message:
+            worker.handle_gateway_message(post, BOT_USER_ID, BOT_USERNAME)
+
+        launch_thread_for_mentions.assert_not_called()
+        deliver_session_message.assert_called_once()
+        self.assertEqual(deliver_session_message.call_args.args[0], "randy")
+        receipt = common.load_chat_ingress(f"in-{post_id}")
+        assert receipt is not None
+        self.assertEqual(receipt["binding_id"], f"room:{ROOM_CHANNEL}")
+        self.assertEqual(receipt["status"], "delivered")
+
+    # ------------------------------------------------------------------
+    # Ingress receipt lifecycle
+    # ------------------------------------------------------------------
+
+    def _stale_receipt(self, ingress_id: str, status: str) -> None:
+        common.atomic_write_json(
+            common.chat_ingress_path(ingress_id),
+            {
+                "ingress_id": ingress_id,
+                "status": status,
+                "created_at": "2000-01-01T00:00:00Z",
+                "updated_at": "2000-01-01T00:00:00Z",
+            },
+        )
+
+    def _dm_post(self, post_id: str) -> dict[str, Any]:
+        return make_post(post_id, channel_id=DM_CHANNEL, message="hello from mattermost")
+
+    def test_process_inbound_message_reclaims_stale_processing_receipt(self) -> None:
+        common.set_chat_binding(common.load_config(), "dm", DM_CHANNEL, ["sky"])
+        post_id = mm_id("post909")
+        self._stale_receipt(f"in-{post_id}", "processing")
+
+        with mock.patch.object(
+            common, "session_index_by_name", return_value={"sky": {"session_name": "sky", "state": "active"}}
+        ), mock.patch.object(
+            common, "deliver_session_message", return_value={"status": "accepted", "id": "gc-9"}
+        ) as deliver_session_message:
+            outcome = self._process(self._dm_post(post_id))
+
+        self.assertEqual(outcome["status"], "delivered")
+        deliver_session_message.assert_called_once()
+
+    def test_process_inbound_message_records_unreadable_claim_conflict(self) -> None:
+        post_id = mm_id("post910")
+        path = common.chat_ingress_path(f"in-{post_id}")
+        pathlib.Path(path).parent.mkdir(parents=True, exist_ok=True)
+        pathlib.Path(path).write_text("", encoding="utf-8")
+
+        with mock.patch.object(common, "deliver_session_message") as deliver_session_message:
+            outcome = self._process(self._dm_post(post_id))
+
+        self.assertEqual(outcome["status"], "failed_claim_conflict")
+        deliver_session_message.assert_not_called()
+        receipt = common.load_chat_ingress(f"in-{post_id}")
+        assert receipt is not None
+        self.assertEqual(receipt["status"], "failed_claim_conflict")
+        self.assertEqual(receipt["reason"], "ingress_claim_unreadable")
+
+    def test_failed_claim_conflict_receipt_retries_after_backoff(self) -> None:
+        common.set_chat_binding(common.load_config(), "dm", DM_CHANNEL, ["sky"])
+        post_id = mm_id("post915")
+        self._stale_receipt(f"in-{post_id}", "failed_claim_conflict")
+
+        with mock.patch.object(
+            common, "session_index_by_name", return_value={"sky": {"session_name": "sky", "state": "active"}}
+        ), mock.patch.object(
+            common, "deliver_session_message", return_value={"status": "accepted", "id": "gc-15"}
+        ) as deliver_session_message:
+            outcome = self._process(self._dm_post(post_id))
+
+        self.assertEqual(outcome["status"], "delivered")
+        deliver_session_message.assert_called_once()
+        self.assertEqual(common.load_chat_ingress(f"in-{post_id}")["reason"], "retry_after_failed_claim_conflict")
+
+    def test_rejected_shutting_down_receipt_retries_immediately(self) -> None:
+        common.set_chat_binding(common.load_config(), "dm", DM_CHANNEL, ["sky"])
+        post_id = mm_id("post916")
+        self._stale_receipt(f"in-{post_id}", "rejected_shutting_down")
+
+        with mock.patch.object(
+            common, "session_index_by_name", return_value={"sky": {"session_name": "sky", "state": "active"}}
+        ), mock.patch.object(
+            common, "deliver_session_message", return_value={"status": "accepted", "id": "gc-16"}
+        ) as deliver_session_message:
+            outcome = self._process(self._dm_post(post_id))
+
+        self.assertEqual(outcome["status"], "delivered")
+        deliver_session_message.assert_called_once()
+        self.assertEqual(common.load_chat_ingress(f"in-{post_id}")["reason"], "retry_after_shutdown")
+
+    def test_failed_receipt_retries_after_backoff(self) -> None:
+        common.set_chat_binding(common.load_config(), "dm", DM_CHANNEL, ["sky"])
+        post_id = mm_id("post913")
+        self._stale_receipt(f"in-{post_id}", "failed")
+
+        with mock.patch.object(
+            common, "session_index_by_name", return_value={"sky": {"session_name": "sky", "state": "active"}}
+        ), mock.patch.object(
+            common, "deliver_session_message", return_value={"status": "accepted", "id": "gc-13"}
+        ) as deliver_session_message:
+            outcome = self._process(self._dm_post(post_id))
+
+        self.assertEqual(outcome["status"], "delivered")
+        deliver_session_message.assert_called_once()
+
+    def test_failed_lookup_receipt_retries_after_backoff(self) -> None:
+        common.set_chat_binding(common.load_config(), "dm", DM_CHANNEL, ["sky"])
+        post_id = mm_id("post914")
+        self._stale_receipt(f"in-{post_id}", "failed_lookup")
+
+        with mock.patch.object(
+            common, "session_index_by_name", return_value={"sky": {"session_name": "sky", "state": "active"}}
+        ), mock.patch.object(
+            common, "deliver_session_message", return_value={"status": "accepted", "id": "gc-14"}
+        ) as deliver_session_message:
+            outcome = self._process(self._dm_post(post_id))
+
+        self.assertEqual(outcome["status"], "delivered")
+        deliver_session_message.assert_called_once()
+        self.assertEqual(common.load_chat_ingress(f"in-{post_id}")["reason"], "retry_after_failed_lookup")
+
+    def test_stale_reclaim_lock_allows_only_one_delivery(self) -> None:
+        common.set_chat_binding(common.load_config(), "dm", DM_CHANNEL, ["sky"])
+        post_id = mm_id("post911")
+        self._stale_receipt(f"in-{post_id}", "processing")
+        post = self._dm_post(post_id)
+        barrier = threading.Barrier(2)
+        release = threading.Event()
+        started = threading.Event()
+        outcomes: list[str] = []
+
+        def fake_deliver(*args: object, **kwargs: object) -> dict[str, object]:
+            started.set()
+            release.wait(timeout=1)
+            return {"status": "accepted", "id": "gc-11"}
+
+        def worker() -> None:
+            barrier.wait()
+            outcome = gateway_service.process_inbound_message(post, BOT_USER_ID, BOT_USERNAME)
+            outcomes.append(str(outcome.get("status", "")))
+
+        with mock.patch.object(
+            common, "session_index_by_name", return_value={"sky": {"session_name": "sky", "state": "active"}}
+        ), mock.patch.object(common, "deliver_session_message", side_effect=fake_deliver) as deliver_session_message:
+            thread_a = threading.Thread(target=worker)
+            thread_b = threading.Thread(target=worker)
+            thread_a.start()
+            thread_b.start()
+            self.assertTrue(started.wait(timeout=1))
+            release.set()
+            thread_a.join()
+            thread_b.join()
+
+        self.assertEqual(deliver_session_message.call_count, 1)
+        self.assertEqual(sorted(outcomes), ["delivered", "duplicate"])
+
+    def test_stale_reclaim_defers_when_original_processor_lock_is_held(self) -> None:
+        common.set_chat_binding(common.load_config(), "dm", DM_CHANNEL, ["sky"])
+        post_id = mm_id("post912")
+        self._stale_receipt(f"in-{post_id}", "processing")
+        process_lock = gateway_service.ingress_process_lock(f"in-{post_id}")
+        process_lock.acquire()
+        self.addCleanup(lambda: process_lock.locked() and process_lock.release())
+
+        with mock.patch.object(
+            common, "session_index_by_name", return_value={"sky": {"session_name": "sky", "state": "active"}}
+        ), mock.patch.object(
+            common, "deliver_session_message", return_value={"status": "accepted", "id": "gc-12"}
+        ) as deliver_session_message:
+            outcome = self._process(self._dm_post(post_id))
+
+        self.assertEqual(outcome["status"], "duplicate")
+        deliver_session_message.assert_not_called()
+
+    # ------------------------------------------------------------------
+    # Ambient binding cache
+    # ------------------------------------------------------------------
+
+    def test_cached_ambient_room_binding_reuses_cached_config_between_messages(self) -> None:
+        common.set_chat_binding(
+            common.load_config(), "room", ROOM_CHANNEL, ["sky"], TEAM_ID, policy={"ambient_read_enabled": True}
+        )
+
+        with mock.patch.object(common, "load_config", wraps=common.load_config) as load_config:
+            first = gateway_service.cached_ambient_room_binding(ROOM_CHANNEL)
+            second = gateway_service.cached_ambient_room_binding(ROOM_CHANNEL)
+
+        self.assertIsNotNone(first)
+        self.assertEqual(first, second)
+        self.assertEqual(load_config.call_count, 1)
+
+    def test_cached_ambient_room_binding_serializes_cache_refill(self) -> None:
+        common.set_chat_binding(
+            common.load_config(), "room", ROOM_CHANNEL, ["sky"], TEAM_ID, policy={"ambient_read_enabled": True}
+        )
+
+        release = threading.Event()
+        started = threading.Event()
+        load_count = 0
+        real_load_config = common.load_config
+
+        def blocking_load_config() -> dict[str, object]:
+            nonlocal load_count
+            load_count += 1
+            started.set()
+            release.wait(timeout=2)
+            return real_load_config()
+
+        def worker() -> None:
+            gateway_service.cached_ambient_room_binding(ROOM_CHANNEL)
+
+        with mock.patch.object(common, "load_config", side_effect=blocking_load_config):
+            thread_a = threading.Thread(target=worker)
+            thread_b = threading.Thread(target=worker)
+            thread_a.start()
+            thread_b.start()
+            started.wait(timeout=2)
+            time.sleep(0.05)
+            release.set()
+            thread_a.join()
+            thread_b.join()
+
+        self.assertEqual(load_count, 1)
+
+    def test_cached_ambient_room_binding_refreshes_on_signature_change(self) -> None:
+        binding_id = f"room:{ROOM_CHANNEL}"
+        config_one = {
+            "chat": {
+                "bindings": {
+                    binding_id: {
+                        "id": binding_id,
+                        "kind": "room",
+                        "conversation_id": ROOM_CHANNEL,
+                        "team_id": TEAM_ID,
+                        "session_names": ["sky"],
+                        "policy": {"ambient_read_enabled": True},
+                    }
+                }
+            }
+        }
+        config_two = {
+            "chat": {
+                "bindings": {
+                    binding_id: {
+                        "id": binding_id,
+                        "kind": "room",
+                        "conversation_id": ROOM_CHANNEL,
+                        "team_id": TEAM_ID,
+                        "session_names": ["lawrence"],
+                        "policy": {"ambient_read_enabled": True},
+                    }
+                }
+            }
+        }
+
+        stat_one = mock.Mock(st_mtime_ns=100, st_size=1000, st_ino=1)
+        stat_two = mock.Mock(st_mtime_ns=100, st_size=1000, st_ino=2)
+
+        with mock.patch.object(gateway_service.os, "stat", side_effect=[stat_one, stat_one, stat_two, stat_two]), mock.patch.object(
+            common,
+            "load_config",
+            side_effect=[common.normalize_config(config_one), common.normalize_config(config_two)],
+        ) as load_config:
+            first = gateway_service.cached_ambient_room_binding(ROOM_CHANNEL)
+            second = gateway_service.cached_ambient_room_binding(ROOM_CHANNEL)
+
+        assert first is not None
+        assert second is not None
+        self.assertEqual(first["session_names"], ["sky"])
+        self.assertEqual(second["session_names"], ["lawrence"])
+        self.assertEqual(load_config.call_count, 2)
+
+    def test_cached_ambient_room_binding_skips_lookup_for_persisted_channel_metadata(self) -> None:
+        common.set_chat_binding(
+            common.load_config(),
+            "room",
+            ROOM_CHANNEL,
+            ["sky"],
+            TEAM_ID,
+            policy={"ambient_read_enabled": True},
+            channel_metadata={"channel_type": "O"},
+        )
+
+        with mock.patch.object(common, "describe_channel") as describe_channel:
+            binding = gateway_service.cached_ambient_room_binding(ROOM_CHANNEL)
+
+        assert binding is not None
+        self.assertEqual(binding["channel_type"], "O")
+        describe_channel.assert_not_called()
+
+    def test_cached_ambient_room_binding_ignores_invalid_config(self) -> None:
+        common.ensure_layout()
+        pathlib.Path(common.config_path()).write_text("{not valid json", encoding="utf-8")
+
+        self.assertIsNone(gateway_service.cached_ambient_room_binding(ROOM_CHANNEL))
+
+    def test_cached_ambient_room_binding_ignores_non_ambient_bindings(self) -> None:
+        common.set_chat_binding(common.load_config(), "room", ROOM_CHANNEL, ["sky"], TEAM_ID)
+
+        self.assertIsNone(gateway_service.cached_ambient_room_binding(ROOM_CHANNEL))
+
+    # ------------------------------------------------------------------
+    # Channel info cache primitives
+    # ------------------------------------------------------------------
+
+    def test_process_inbound_messages_cache_channel_lookup(self) -> None:
+        common.set_chat_binding(common.load_config(), "room", ROOM_CHANNEL, ["sky"], TEAM_ID)
+        common.save_bot_token("bot-token")
+        base = {
+            "channel_id": ROOM_CHANNEL,
+            "team_id": TEAM_ID,
+            "message": f"@{BOT_USERNAME} please check",
+            "mentions": [BOT_USER_ID],
+        }
+
+        with mock.patch.object(
+            common, "describe_channel", return_value={"id": ROOM_CHANNEL, "type": "O", "team_id": TEAM_ID}
+        ) as describe_channel, mock.patch.object(
+            common, "session_index_by_name", return_value={"sky": {"session_name": "sky", "state": "active"}}
+        ), mock.patch.object(common, "deliver_session_message", return_value={"status": "accepted"}):
+            outcome_1 = self._process(make_post(mm_id("post801"), **base))
+            outcome_2 = self._process(make_post(mm_id("post802"), **base))
+
+        self.assertEqual(outcome_1["status"], "delivered")
+        self.assertEqual(outcome_2["status"], "delivered")
+        describe_channel.assert_called_once()
+
+    def test_load_channel_info_serializes_cache_fill(self) -> None:
+        entered = threading.Event()
+        release = threading.Event()
+        calls: list[str] = []
+        results: list[dict[str, object]] = []
+
+        def fake_describe(channel_id: str, *, bot_token: str = "") -> dict[str, object]:
+            calls.append(channel_id)
+            entered.set()
+            release.wait(timeout=1)
+            return {"id": ROOM_CHANNEL, "type": "O"}
+
+        def worker() -> None:
+            results.append(gateway_service.load_channel_info(ROOM_CHANNEL, "bot-token"))
+
+        with mock.patch.object(common, "describe_channel", side_effect=fake_describe):
+            thread_a = threading.Thread(target=worker)
+            thread_b = threading.Thread(target=worker)
+            thread_a.start()
+            thread_b.start()
+            self.assertTrue(entered.wait(timeout=1))
+            release.set()
+            thread_a.join()
+            thread_b.join()
+
+        self.assertEqual(calls, [ROOM_CHANNEL])
+        self.assertEqual(
+            results,
+            [
+                {"id": ROOM_CHANNEL, "type": "O", "channel_type": "O"},
+                {"id": ROOM_CHANNEL, "type": "O", "channel_type": "O"},
+            ],
+        )
+
+    def test_load_channel_info_normalizes_channel_type(self) -> None:
+        with mock.patch.object(common, "describe_channel", return_value={"id": DM_CHANNEL, "type": "d"}):
+            info = gateway_service.load_channel_info(DM_CHANNEL, "bot-token")
+
+        self.assertEqual(info, {"id": DM_CHANNEL, "type": "D", "channel_type": "D"})
+
+    def test_normalize_channel_info_ignores_unknown_types(self) -> None:
+        self.assertEqual(
+            gateway_service.normalize_channel_info({"id": ROOM_CHANNEL, "type": "Z"}), {"id": ROOM_CHANNEL, "type": "Z"}
+        )
+        self.assertEqual(gateway_service.normalize_channel_info(None), {})
+
+    def test_channel_info_fetch_lock_is_scoped_per_channel(self) -> None:
+        lock_a = gateway_service.channel_info_fetch_lock(ROOM_CHANNEL)
+        lock_b = gateway_service.channel_info_fetch_lock(OTHER_CHANNEL)
+
+        self.assertIs(lock_a, gateway_service.channel_info_fetch_lock(ROOM_CHANNEL))
+        self.assertIsNot(lock_a, lock_b)
+
+    def test_resolve_binding_treats_direct_channel_type_as_dm(self) -> None:
+        common.set_chat_binding(common.load_config(), "dm", DM_CHANNEL, ["sky"])
+        post = make_post(mm_id("post803"), channel_id=DM_CHANNEL, channel_type="D", message="hi")
+
+        binding, _channel_info = gateway_service.resolve_binding(common.load_config(), post)
+
+        assert binding is not None
+        self.assertEqual(binding["id"], f"dm:{DM_CHANNEL}")
+
+    def test_resolve_binding_returns_none_for_missing_channel_lookup(self) -> None:
+        common.save_bot_token("bot-token")
+        post = make_post(mm_id("post804"), channel_id=OTHER_CHANNEL, team_id=TEAM_ID, message="hi")
+
+        with mock.patch.object(
+            common, "describe_channel", side_effect=common.MattermostAPIError("gone", status_code=404)
+        ):
+            binding, channel_info = gateway_service.resolve_binding(common.load_config(), post)
+
+        self.assertIsNone(binding)
+        self.assertEqual(channel_info, {})
+
+    # ------------------------------------------------------------------
+    # Worker lifecycle
+    # ------------------------------------------------------------------
+
+    def test_worker_stop_drains_queued_messages_before_exit(self) -> None:
+        runtime_state = gateway_service.GatewayRuntimeState()
+        worker = gateway_service.GatewayWorker(runtime_state)
+        self.addCleanup(lambda: worker.stop() if not worker.stop_event.is_set() else None)
+
+        handled: list[str] = []
+        with mock.patch.object(
+            worker,
+            "handle_gateway_message",
+            side_effect=lambda post, bot_user_id, bot_username: handled.append(str(post.get("id", ""))),
+        ):
+            worker.dispatch_gateway_message(
+                make_post(mm_id("post1001"), channel_id=DM_CHANNEL, message="hi"), BOT_USER_ID, BOT_USERNAME
+            )
+            worker.stop()
+
+        self.assertEqual(handled, [mm_id("post1001")])
+        self.assertTrue(worker.stop_event.is_set())
+        self.assertTrue(all(not thread.is_alive() for thread in worker.worker_threads))
+
+    def test_dispatch_gateway_message_persists_shutting_down_receipt(self) -> None:
+        runtime_state = gateway_service.GatewayRuntimeState()
+        worker = gateway_service.GatewayWorker(runtime_state)
+        self.addCleanup(worker.stop)
+        worker.request_stop()
+        post_id = mm_id("post1002")
+
+        worker.dispatch_gateway_message(
+            make_post(post_id, channel_id=DM_CHANNEL, message="hi"), BOT_USER_ID, BOT_USERNAME
+        )
+
+        receipt = common.load_chat_ingress(f"in-{post_id}")
+        assert receipt is not None
+        self.assertEqual(receipt["status"], "rejected_shutting_down")
+        self.assertEqual(receipt["reason"], "service_shutting_down")
+
+    def test_worker_stop_returns_when_worker_pool_is_idle(self) -> None:
+        runtime_state = gateway_service.GatewayRuntimeState()
+        worker = gateway_service.GatewayWorker(runtime_state)
+
+        stop_thread = threading.Thread(target=worker.stop)
+        stop_thread.start()
+        stop_thread.join(timeout=5)
+
+        self.assertFalse(stop_thread.is_alive())
+        self.assertTrue(worker.stop_event.is_set())
+        self.assertTrue(all(not thread.is_alive() for thread in worker.worker_threads))
+
+    def test_utc_age_seconds_uses_utc_epoch_conversion(self) -> None:
+        if not hasattr(time, "tzset"):
+            self.skipTest("tzset not available on this platform")
+        previous_tz = os.environ.get("TZ")
+        try:
+            os.environ["TZ"] = "Etc/GMT+8"
+            time.tzset()
+            stamp = time.strftime(
+                "%Y-%m-%dT%H:%M:%SZ",
+                time.gmtime(time.time() - gateway_service.STALE_PROCESSING_RECEIPT_SECONDS - 5),
+            )
+            age = gateway_service.utc_age_seconds(stamp)
+        finally:
+            if previous_tz is None:
+                os.environ.pop("TZ", None)
+            else:
+                os.environ["TZ"] = previous_tz
+            time.tzset()
+
+        self.assertGreaterEqual(age, gateway_service.STALE_PROCESSING_RECEIPT_SECONDS)
+        self.assertLess(age, gateway_service.STALE_PROCESSING_RECEIPT_SECONDS + 30)
+
+    def test_probe_gc_api_health_caches_recent_result(self) -> None:
+        runtime_state = gateway_service.GatewayRuntimeState()
+
+        with mock.patch.object(common, "gc_api_request", return_value={"items": []}) as gc_api_request:
+            self.assertTrue(gateway_service.probe_gc_api_health(runtime_state))
+            self.assertTrue(gateway_service.probe_gc_api_health(runtime_state))
+
+        gc_api_request.assert_called_once()
+        self.assertEqual(
+            gc_api_request.call_args.kwargs["timeout"],
+            gateway_service.GC_API_HEALTH_PROBE_TIMEOUT_SECONDS,
+        )
+
+    def test_gateway_health_status_code_requires_gc_api_when_ready(self) -> None:
+        self.assertEqual(
+            gateway_service.gateway_health_status_code({"state": "ready"}, gc_api_reachable=False),
+            gateway_service.HTTPStatus.SERVICE_UNAVAILABLE,
+        )
+        self.assertEqual(
+            gateway_service.gateway_health_status_code({"state": "ready"}, gc_api_reachable=True),
+            gateway_service.HTTPStatus.NO_CONTENT,
+        )
+
+    def test_gateway_health_status_code_honors_reconnect_grace_window(self) -> None:
+        state = {"state": "reconnecting", "last_ready_epoch": int(time.time())}
+
+        self.assertEqual(
+            gateway_service.gateway_health_status_code(state, gc_api_reachable=True),
+            gateway_service.HTTPStatus.NO_CONTENT,
+        )
+
+    def test_gateway_health_status_code_honors_resume_grace_window(self) -> None:
+        state = {"state": "reconnecting", "last_ready_epoch": 1, "last_resumed_epoch": int(time.time())}
+
+        self.assertEqual(
+            gateway_service.gateway_health_status_code(state, gc_api_reachable=True),
+            gateway_service.HTTPStatus.NO_CONTENT,
+        )
+
+    def test_gateway_health_status_code_fails_stale_reconnect(self) -> None:
+        state = {"state": "reconnecting", "last_ready_epoch": 1, "last_resumed_epoch": 1}
+
+        self.assertEqual(
+            gateway_service.gateway_health_status_code(state, gc_api_reachable=True),
+            gateway_service.HTTPStatus.SERVICE_UNAVAILABLE,
+        )
+
+    # ------------------------------------------------------------------
+    # Websocket transport
+    # ------------------------------------------------------------------
+
+    def test_gateway_websocket_recv_event_reassembles_fragmented_text_frames(self) -> None:
+        ws = object.__new__(gateway_service.GatewayWebSocket)
+        frames = iter(
+            [
+                (False, 0x1, b'{"event":"posted",'),
+                (True, 0x0, b'"seq":3}'),
+            ]
+        )
+        ws.read_frame = lambda timeout=None: next(frames)  # type: ignore[attr-defined]
+        ws.send_frame = mock.Mock()
+
+        event = gateway_service.GatewayWebSocket.recv_event(ws, timeout=1.0)
+
+        self.assertEqual(event, {"event": "posted", "seq": 3})
+
+    def test_gateway_websocket_recv_event_answers_ping_with_pong(self) -> None:
+        ws = object.__new__(gateway_service.GatewayWebSocket)
+        frames = iter(
+            [
+                (True, 0x9, b"keepalive"),
+                (True, 0x1, b'{"event":"hello"}'),
+            ]
+        )
+        ws.read_frame = lambda timeout=None: next(frames)  # type: ignore[attr-defined]
+        ws.send_frame = mock.Mock()
+
+        event = gateway_service.GatewayWebSocket.recv_event(ws, timeout=1.0)
+
+        self.assertEqual(event, {"event": "hello"})
+        ws.send_frame.assert_called_once_with(0xA, b"keepalive")
+
+    def test_gateway_websocket_read_frame_rejects_oversized_payloads(self) -> None:
+        ws = object.__new__(gateway_service.GatewayWebSocket)
+        parts = iter(
+            [
+                bytes([0x81, 0x7F]),
+                struct.pack("!Q", gateway_service.MAX_FRAME_BYTES + 1),
+            ]
+        )
+        ws.read_exact = lambda length, timeout=None: next(parts)  # type: ignore[attr-defined]
+
+        with self.assertRaises(gateway_service.WebSocketClosed):
+            gateway_service.GatewayWebSocket.read_frame(ws)
+
+    def test_validate_websocket_handshake_rejects_bad_accept_header(self) -> None:
+        key = "dGhlIHNhbXBsZSBub25jZQ=="
+        header_blob = "\r\n".join(
+            [
+                "HTTP/1.1 101 Switching Protocols",
+                "Upgrade: websocket",
+                "Connection: Upgrade",
+                "Sec-WebSocket-Accept: bad-value",
+            ]
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "Sec-WebSocket-Accept"):
+            gateway_service.validate_websocket_handshake(header_blob, key)
+
+    def test_validate_websocket_handshake_accepts_valid_upgrade(self) -> None:
+        key = "dGhlIHNhbXBsZSBub25jZQ=="
+        header_blob = "\r\n".join(
+            [
+                "HTTP/1.1 101 Switching Protocols",
+                "Upgrade: websocket",
+                "Connection: keep-alive, Upgrade",
+                f"Sec-WebSocket-Accept: {gateway_service.websocket_accept_value(key)}",
+            ]
+        )
+
+        gateway_service.validate_websocket_handshake(header_blob, key)
+
+    def test_gateway_websocket_handshake_sends_bearer_authorization_header(self) -> None:
+        fake_socket = _HandshakeSocket()
+
+        with mock.patch.object(gateway_service.socket, "create_connection", return_value=fake_socket):
+            ws = gateway_service.GatewayWebSocket(
+                "ws://mattermost.example/api/v4/websocket",
+                headers={"Authorization": "Bearer bot-token"},
+            )
+
+        request = fake_socket.request_text()
+        self.assertIn("GET /api/v4/websocket HTTP/1.1", request)
+        self.assertIn("Upgrade: websocket", request)
+        self.assertIn("Authorization: Bearer bot-token", request)
+        self.assertIs(ws.sock, fake_socket)
+
+    # ------------------------------------------------------------------
+    # Connect URL, authentication and event dispatch
+    # ------------------------------------------------------------------
+
+    def test_gateway_connect_url_without_resume_keeps_base_url(self) -> None:
+        worker = object.__new__(gateway_service.GatewayWorker)
+
+        with mock.patch.object(common, "mattermost_websocket_url", return_value="wss://mm.example/api/v4/websocket"):
+            url = gateway_service.GatewayWorker.gateway_connect_url(worker)
+
+        self.assertEqual(url, "wss://mm.example/api/v4/websocket")
+
+    def test_gateway_connect_url_adds_reliable_reconnect_params(self) -> None:
+        worker = object.__new__(gateway_service.GatewayWorker)
+
+        with mock.patch.object(common, "mattermost_websocket_url", return_value="wss://mm.example/api/v4/websocket"):
+            url = gateway_service.GatewayWorker.gateway_connect_url(worker, "conn-1", 7, 4000)
+
+        self.assertIn("connection_id=conn-1", url)
+        self.assertIn("sequence_number=7", url)
+        self.assertIn("disconnect_err_code=4000", url)
+
+    def test_gateway_connect_url_clamps_negative_sequence(self) -> None:
+        worker = object.__new__(gateway_service.GatewayWorker)
+
+        with mock.patch.object(common, "mattermost_websocket_url", return_value="wss://mm.example/api/v4/websocket"):
+            url = gateway_service.GatewayWorker.gateway_connect_url(worker, "conn-1", -5)
+
+        self.assertIn("sequence_number=0", url)
+
+    def test_gateway_connect_url_requires_configured_websocket_url(self) -> None:
+        worker = object.__new__(gateway_service.GatewayWorker)
+
+        with mock.patch.object(common, "mattermost_websocket_url", return_value=""):
+            with self.assertRaisesRegex(RuntimeError, "websocket URL is missing"):
+                gateway_service.GatewayWorker.gateway_connect_url(worker)
+
+    def test_authenticate_sends_authentication_challenge_frame(self) -> None:
+        worker = object.__new__(gateway_service.GatewayWorker)
+        ws = _ScriptedWebSocket([], threading.Event())
+
+        gateway_service.GatewayWorker.authenticate(worker, ws, "bot-token", 1)
+
+        self.assertEqual(
+            ws.sent,
+            [{"seq": 1, "action": gateway_service.AUTHENTICATION_CHALLENGE_ACTION, "data": {"token": "bot-token"}}],
+        )
+
+    def test_current_bot_identity_prefers_last_known_after_resume(self) -> None:
+        worker = object.__new__(gateway_service.GatewayWorker)
+
+        with mock.patch.object(gateway_service, "load_bot_identity", return_value=("", "")):
+            identity = gateway_service.GatewayWorker.current_bot_identity(
+                worker, {"app": {"bot_user_id": "config-bot"}}, (BOT_USER_ID, BOT_USERNAME)
+            )
+
+        self.assertEqual(identity, (BOT_USER_ID, BOT_USERNAME))
+
+    def test_current_bot_identity_falls_back_to_config_bot_user_id(self) -> None:
+        worker = object.__new__(gateway_service.GatewayWorker)
+
+        with mock.patch.object(gateway_service, "load_bot_identity", return_value=("", "")):
+            identity = gateway_service.GatewayWorker.current_bot_identity(worker, {"app": {"bot_user_id": "config-bot"}})
+
+        self.assertEqual(identity, ("config-bot", ""))
+
+    def test_load_bot_identity_reads_users_me_and_caches(self) -> None:
+        with mock.patch.object(
+            common, "mattermost_api_request", return_value={"id": BOT_USER_ID, "username": BOT_USERNAME}
+        ) as mattermost_api_request:
+            first = gateway_service.load_bot_identity()
+            second = gateway_service.load_bot_identity()
+
+        self.assertEqual(first, (BOT_USER_ID, BOT_USERNAME))
+        self.assertEqual(second, (BOT_USER_ID, BOT_USERNAME))
+        mattermost_api_request.assert_called_once_with("GET", "/users/me")
+
+    def test_load_bot_identity_falls_back_to_config_when_api_fails(self) -> None:
+        with mock.patch.object(
+            common, "mattermost_api_request", side_effect=common.MattermostAPIError("boom", status_code=500)
+        ):
+            identity = gateway_service.load_bot_identity({"app": {"bot_user_id": BOT_USER_ID}})
+
+        self.assertEqual(identity, (BOT_USER_ID, ""))
+
+    def _drive_run_forever(
+        self, worker: gateway_service.GatewayWorker, scripts: list[list[Any]]
+    ) -> tuple[list[_ScriptedWebSocket], list[dict[str, Any]]]:
+        remaining = list(scripts)
+        created: list[_ScriptedWebSocket] = []
+        patches: list[dict[str, Any]] = []
+        real_patch = worker.runtime_state.patch
+
+        def recording_patch(**values: Any) -> None:
+            patches.append(dict(values))
+            real_patch(**values)
+
+        worker.runtime_state.patch = recording_patch  # type: ignore[method-assign]
+        self.addCleanup(lambda: setattr(worker.runtime_state, "patch", real_patch))
+
+        def factory(url: str, headers: dict[str, str] | None = None) -> _ScriptedWebSocket:
+            events = remaining.pop(0) if remaining else []
+            ws = _ScriptedWebSocket(events, worker.stop_event, url, headers)
+            created.append(ws)
+            return ws
+
+        with mock.patch.object(gateway_service, "GatewayWebSocket", side_effect=factory), mock.patch.object(
+            gateway_service, "RECONNECT_BASE_DELAY_SECONDS", 0.01
+        ), mock.patch.object(
+            gateway_service, "load_bot_identity", return_value=(BOT_USER_ID, BOT_USERNAME)
+        ), mock.patch.object(common, "load_bot_token", return_value="bot-token"), mock.patch.object(
+            common, "mattermost_site_url", return_value="https://mm.example"
+        ), mock.patch.object(
+            common, "mattermost_websocket_url", return_value="wss://mm.example/api/v4/websocket"
+        ):
+            worker.run_forever()
+        return created, patches
+
+    def test_run_forever_marks_ready_on_hello_event(self) -> None:
+        worker = self._new_gateway_worker()
+
+        created, _patches = self._drive_run_forever(
+            worker,
+            [[{"event": "hello", "data": {"connection_id": "conn-1", "server_version": "9.5.0"}, "seq": 0}]],
+        )
+
+        state = worker.runtime_state.snapshot()
+        self.assertTrue(state["connected"])
+        self.assertEqual(state["state"], "ready")
+        self.assertEqual(state["connection_id"], "conn-1")
+        self.assertEqual(state["bot_user_id"], BOT_USER_ID)
+        self.assertEqual(state["bot_username"], BOT_USERNAME)
+        self.assertEqual(state["server_version"], "9.5.0")
+        self.assertFalse(state["resumed_connection"])
+        self.assertEqual(
+            created[0].sent,
+            [{"seq": 1, "action": gateway_service.AUTHENTICATION_CHALLENGE_ACTION, "data": {"token": "bot-token"}}],
+        )
+        self.assertEqual(created[0].headers.get("Authorization"), "Bearer bot-token")
+
+    def test_run_forever_marks_ready_on_authentication_challenge_reply(self) -> None:
+        worker = self._new_gateway_worker()
+
+        self._drive_run_forever(worker, [[{"status": "OK", "seq_reply": 1, "data": {}}]])
+
+        state = worker.runtime_state.snapshot()
+        self.assertTrue(state["connected"])
+        self.assertEqual(state["state"], "ready")
+
+    def test_run_forever_raises_when_authentication_is_rejected(self) -> None:
+        worker = self._new_gateway_worker()
+
+        _created, patches = self._drive_run_forever(
+            worker, [[{"status": "FAIL", "seq_reply": 1, "error": {"id": "api.unauthorized"}}]]
+        )
+
+        errors = [str(item.get("last_error", "")) for item in patches]
+        self.assertTrue(any("rejected authentication" in error for error in errors), msg=errors)
+        self.assertTrue(any(str(item.get("state", "")) == "reconnecting" for item in patches))
+
+    def test_run_forever_dispatches_posted_events(self) -> None:
+        worker = self._new_gateway_worker()
+        post_id = mm_id("post1100")
+        posted = {
+            "event": "posted",
+            "data": {
+                "post": json.dumps({"id": post_id, "channel_id": ROOM_CHANNEL, "message": "hello"}),
+                "team_id": TEAM_ID,
+                "channel_type": "O",
+                "sender_name": "@alice",
+            },
+            "broadcast": {"channel_id": ROOM_CHANNEL},
+            "seq": 1,
+        }
+
+        with mock.patch.object(worker, "dispatch_gateway_message") as dispatch_gateway_message:
+            self._drive_run_forever(
+                worker,
+                [[{"event": "hello", "data": {"connection_id": "conn-1"}, "seq": 0}, posted]],
+            )
+
+        dispatch_gateway_message.assert_called_once()
+        dispatched_post = dispatch_gateway_message.call_args.args[0]
+        self.assertEqual(dispatched_post["id"], post_id)
+        self.assertEqual(dispatched_post["channel_id"], ROOM_CHANNEL)
+        self.assertEqual(dispatched_post["team_id"], TEAM_ID)
+        self.assertEqual(dispatch_gateway_message.call_args.args[1], BOT_USER_ID)
+        self.assertEqual(dispatch_gateway_message.call_args.args[2], BOT_USERNAME)
+
+    def test_run_forever_ignores_non_posted_events(self) -> None:
+        worker = self._new_gateway_worker()
+
+        with mock.patch.object(worker, "dispatch_gateway_message") as dispatch_gateway_message:
+            self._drive_run_forever(
+                worker,
+                [
+                    [
+                        {"event": "hello", "data": {"connection_id": "conn-1"}, "seq": 0},
+                        {"event": "reaction_added", "data": {"reaction": "{}"}, "seq": 1},
+                        {"event": "typing", "data": {}, "seq": 2},
+                    ]
+                ],
+            )
+
+        dispatch_gateway_message.assert_not_called()
+        self.assertEqual(worker.runtime_state.snapshot()["last_sequence"], 2)
+
+    def test_run_forever_drops_socket_on_sequence_gap(self) -> None:
+        worker = self._new_gateway_worker()
+
+        created, patches = self._drive_run_forever(
+            worker,
+            [
+                [
+                    {"event": "hello", "data": {"connection_id": "conn-1"}, "seq": 0},
+                    {"event": "posted", "data": {}, "seq": 9},
+                ],
+                [],
+            ],
+        )
+
+        self.assertIn(gateway_service.CLIENT_SEQUENCE_MISMATCH_CLOSE_CODE, created[0].closed_codes)
+        errors = [str(item.get("last_error", "")) for item in patches]
+        self.assertTrue(any("sequence mismatch" in error for error in errors), msg=errors)
+        self.assertTrue(any(str(item.get("state", "")) == "reconnecting" for item in patches))
+        self.assertIn("disconnect_err_code=4001", created[1].url)
+
+    def test_run_forever_marks_resumed_connection_when_server_replays(self) -> None:
+        worker = self._new_gateway_worker()
+
+        created, _patches = self._drive_run_forever(
+            worker,
+            [
+                [
+                    {"event": "hello", "data": {"connection_id": "conn-1"}, "seq": 0},
+                    {"event": "posted", "data": {}, "seq": 9},
+                ],
+                [{"event": "hello", "data": {"connection_id": "conn-2"}, "seq": 0}],
+            ],
+        )
+
+        self.assertEqual(len(created), 2)
+        state = worker.runtime_state.snapshot()
+        self.assertEqual(state["connection_id"], "conn-2")
+        self.assertFalse(state["resumed_connection"])
+
+    def test_run_forever_resumes_with_connection_id_and_sequence_cursor(self) -> None:
+        worker = self._new_gateway_worker()
+
+        created, _patches = self._drive_run_forever(
+            worker,
+            [
+                [
+                    {"event": "hello", "data": {"connection_id": "conn-1"}, "seq": 0},
+                    {"event": "typing", "data": {}, "seq": 1},
+                    gateway_service.WebSocketClosed("socket closed"),
+                ],
+                [{"event": "hello", "data": {"connection_id": "conn-1"}, "seq": 2}],
+            ],
+        )
+
+        self.assertEqual(len(created), 2)
+        self.assertIn("connection_id=conn-1", created[1].url)
+        self.assertIn("sequence_number=2", created[1].url)
+        state = worker.runtime_state.snapshot()
+        self.assertTrue(state["resumed_connection"])
+        self.assertTrue(str(state.get("last_resumed_at", "")).strip())
+
+    def test_run_forever_clears_sequence_cursor_when_server_cannot_replay(self) -> None:
+        worker = self._new_gateway_worker()
+
+        created, _patches = self._drive_run_forever(
+            worker,
+            [
+                [
+                    {"event": "hello", "data": {"connection_id": "conn-1"}, "seq": 0},
+                    {"event": "typing", "data": {}, "seq": 1},
+                    gateway_service.WebSocketClosed("socket closed"),
+                ],
+                [
+                    {"event": "hello", "data": {"connection_id": "conn-9"}, "seq": 0},
+                    {"event": "typing", "data": {}, "seq": 1},
+                ],
+            ],
+        )
+
+        # The server restarting at seq 0 under a new connection_id is a resync,
+        # not a gap: it must not force a second 4001 teardown.
+        self.assertEqual(len(created), 2)
+        self.assertEqual(created[1].closed_codes, [1000])
+        self.assertIn("connection_id=conn-1", created[1].url)
+        state = worker.runtime_state.snapshot()
+        self.assertFalse(state["resumed_connection"])
+        self.assertEqual(state["connection_id"], "conn-9")
+        self.assertEqual(state["last_sequence"], 1)
+
+    def test_run_forever_waits_for_config_when_token_is_missing(self) -> None:
+        worker = self._new_gateway_worker()
+
+        def stop_after_first_wait(timeout: float | None = None) -> bool:
+            worker.stop_event.set()
+            return True
+
+        with mock.patch.object(common, "load_bot_token", return_value=""), mock.patch.object(
+            common, "mattermost_site_url", return_value=""
+        ), mock.patch.object(worker.stop_event, "wait", side_effect=stop_after_first_wait):
+            worker.run_forever()
+
+        state = worker.runtime_state.snapshot()
+        self.assertEqual(state["state"], "waiting_for_config")
+        self.assertFalse(state["connected"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mattermost/tests/test_mattermost_intake_common.py
+++ b/mattermost/tests/test_mattermost_intake_common.py
@@ -1,0 +1,2530 @@
+from __future__ import annotations
+
+import io
+import json
+import pathlib
+import socket
+import tempfile
+import threading
+import time
+import urllib.error
+import unittest
+from unittest import mock
+
+import os
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+
+import mattermost_intake_common as common
+
+
+def mmid(seed: str) -> str:
+    """Build a deterministic 26-char Mattermost-style id from a short seed."""
+    base = "".join(ch for ch in str(seed).lower() if ch.isalnum())
+    if not base:
+        base = "x"
+    return (base * 26)[:26]
+
+
+TEAM_ID = mmid("team")
+OTHER_TEAM_ID = mmid("otherteam")
+CHANNEL_ID = mmid("chan")
+OTHER_CHANNEL_ID = mmid("chan2")
+BOT_USER_ID = mmid("bot")
+COMMAND_ID = mmid("cmd")
+COMMAND_TOKEN = mmid("tok")
+ROOT_POST_ID = mmid("root")
+REPLY_POST_ID = mmid("reply")
+
+
+class MattermostIntakeCommonTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self._old_environ = os.environ.copy()
+        for key in list(os.environ):
+            if key.startswith("GC_") or key.startswith("MATTERMOST_"):
+                os.environ.pop(key, None)
+        os.environ["GC_CITY_ROOT"] = self.tempdir.name
+        common._supervisor_scope_cache.clear()
+        self.addCleanup(common._supervisor_scope_cache.clear)
+
+    def tearDown(self) -> None:
+        os.environ.clear()
+        os.environ.update(self._old_environ)
+
+    # ------------------------------------------------------------------
+    # slash command payloads
+    # ------------------------------------------------------------------
+
+    def test_build_command_payload_registers_gc_trigger(self) -> None:
+        payload = common.build_command_payload("gc", TEAM_ID, "https://interactions.test/mattermost/command")
+
+        self.assertEqual(payload["trigger"], "gc")
+        self.assertEqual(payload["team_id"], TEAM_ID)
+        self.assertEqual(payload["method"], "P")
+        self.assertEqual(payload["url"], "https://interactions.test/mattermost/command")
+        self.assertTrue(payload["auto_complete"])
+        self.assertIn("fix", payload["auto_complete_hint"])
+
+    def test_build_command_payload_strips_leading_slash_and_defaults_trigger(self) -> None:
+        payload = common.build_command_payload("/gc", TEAM_ID)
+        self.assertEqual(payload["trigger"], "gc")
+
+        blank = common.build_command_payload("   ", TEAM_ID)
+        self.assertEqual(blank["trigger"], common.COMMAND_NAME_DEFAULT)
+
+    def test_import_app_config_redacts_secret_presence(self) -> None:
+        config = common.import_app_config(
+            common.load_config(),
+            {
+                "site_url": "https://mattermost.test/",
+                "team_id": TEAM_ID,
+                "bot_user_id": BOT_USER_ID,
+                "command_id": COMMAND_ID,
+                "command_name": "gc",
+                "team_allowlist": [TEAM_ID],
+            },
+        )
+        common.save_bot_token("mattermost-bot-token")
+        common.save_command_token(COMMAND_TOKEN)
+
+        redacted = common.redact_config(config)
+
+        self.assertEqual(redacted["app"]["site_url"], "https://mattermost.test")
+        self.assertEqual(redacted["app"]["team_id"], TEAM_ID)
+        self.assertEqual(redacted["app"]["bot_user_id"], BOT_USER_ID)
+        self.assertEqual(redacted["app"]["command_id"], COMMAND_ID)
+        self.assertTrue(redacted["app"]["bot_token_present"])
+        self.assertTrue(redacted["app"]["command_token_present"])
+        self.assertEqual(redacted["policy"]["team_allowlist"], [TEAM_ID])
+
+    def test_import_app_config_rejects_invalid_team_id(self) -> None:
+        with self.assertRaisesRegex(ValueError, "team_id must be a 26-character Mattermost id"):
+            common.import_app_config(common.load_config(), {"team_id": "not-a-mattermost-id"})
+
+    def test_import_app_config_rejects_invalid_site_url(self) -> None:
+        with self.assertRaisesRegex(ValueError, "site_url must be an http"):
+            common.import_app_config(common.load_config(), {"site_url": "ftp://mattermost.test"})
+
+    def test_shared_mattermost_prompt_requires_bold_speaker_prefix(self) -> None:
+        fragment = (
+            pathlib.Path(__file__).resolve().parents[1] / "template-fragments" / "mattermost-v0.template.md"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("Always prefix your Mattermost messages with your handle in bold", fragment)
+        self.assertIn("**randy:**", fragment)
+
+    # ------------------------------------------------------------------
+    # conversation keys (channel_id [+ root_id])
+    # ------------------------------------------------------------------
+
+    def test_mattermost_conversation_key_returns_bare_channel_without_root(self) -> None:
+        self.assertEqual(common.mattermost_conversation_key(CHANNEL_ID), CHANNEL_ID)
+        self.assertEqual(common.mattermost_conversation_key(CHANNEL_ID, ""), CHANNEL_ID)
+        self.assertEqual(common.mattermost_conversation_key(f"  {CHANNEL_ID}  ", "  "), CHANNEL_ID)
+
+    def test_mattermost_conversation_key_collapses_root_equal_to_channel(self) -> None:
+        self.assertEqual(common.mattermost_conversation_key(CHANNEL_ID, CHANNEL_ID), CHANNEL_ID)
+
+    def test_mattermost_conversation_key_composes_thread_scoped_id(self) -> None:
+        self.assertEqual(
+            common.mattermost_conversation_key(CHANNEL_ID, ROOT_POST_ID),
+            f"{CHANNEL_ID}/{ROOT_POST_ID}",
+        )
+
+    def test_mattermost_conversation_parts_splits_thread_scoped_id(self) -> None:
+        self.assertEqual(
+            common.mattermost_conversation_parts(f"{CHANNEL_ID}/{ROOT_POST_ID}"),
+            (CHANNEL_ID, ROOT_POST_ID),
+        )
+
+    def test_mattermost_conversation_parts_handles_bare_and_empty_ids(self) -> None:
+        self.assertEqual(common.mattermost_conversation_parts(CHANNEL_ID), (CHANNEL_ID, ""))
+        self.assertEqual(common.mattermost_conversation_parts(""), ("", ""))
+        self.assertEqual(common.mattermost_conversation_parts(f"  {CHANNEL_ID}  "), (CHANNEL_ID, ""))
+
+    def test_mattermost_conversation_parts_round_trips_conversation_key(self) -> None:
+        for channel_id, root_id in ((CHANNEL_ID, ""), (CHANNEL_ID, ROOT_POST_ID)):
+            key = common.mattermost_conversation_key(channel_id, root_id)
+            self.assertEqual(common.mattermost_conversation_parts(key), (channel_id, root_id))
+
+    def test_room_launch_surface_id_prefixes_conversation(self) -> None:
+        self.assertEqual(common.room_launch_surface_id(CHANNEL_ID), f"launch-room:{CHANNEL_ID}")
+
+    def test_storage_paths_hash_thread_scoped_ids_instead_of_nesting_directories(self) -> None:
+        conversation_id = common.mattermost_conversation_key(CHANNEL_ID, ROOT_POST_ID)
+        binding_id = common.chat_binding_id("room", conversation_id)
+
+        cache_path = common.channel_metadata_cache_path(conversation_id)
+        budget_path = common.peer_root_budget_path(binding_id, "in-1")
+
+        self.assertEqual(os.path.dirname(cache_path), common.channel_metadata_cache_dir())
+        self.assertEqual(os.path.dirname(budget_path), common.peer_root_budget_dir())
+        self.assertNotIn("/", os.path.basename(cache_path).removesuffix(".json"))
+        self.assertNotIn("/", os.path.basename(budget_path).removesuffix(".json"))
+
+    # ------------------------------------------------------------------
+    # channel + rig mappings
+    # ------------------------------------------------------------------
+
+    def test_set_channel_mapping_persists_fix_formula(self) -> None:
+        config = common.set_channel_mapping(
+            common.load_config(), TEAM_ID, CHANNEL_ID, "product/polecat", "mol-mattermost-fix-issue"
+        )
+
+        mapping = common.resolve_channel_mapping(config, TEAM_ID, CHANNEL_ID)
+
+        self.assertIsNotNone(mapping)
+        assert mapping is not None
+        self.assertEqual(mapping["target"], "product/polecat")
+        self.assertEqual(mapping["commands"]["fix"]["formula"], "mol-mattermost-fix-issue")
+
+    def test_set_channel_mapping_rejects_non_polecat_target_for_default_formula(self) -> None:
+        with self.assertRaisesRegex(ValueError, "requires a rig/polecat sling target"):
+            common.set_channel_mapping(
+                common.load_config(), TEAM_ID, CHANNEL_ID, "product/witness", common.FIX_FORMULA_DEFAULT
+            )
+
+    def test_set_channel_mapping_allows_non_polecat_target_for_custom_formula(self) -> None:
+        config = common.set_channel_mapping(
+            common.load_config(), TEAM_ID, CHANNEL_ID, "product/witness", "custom-fix-formula"
+        )
+
+        mapping = common.resolve_channel_mapping(config, TEAM_ID, CHANNEL_ID)
+
+        assert mapping is not None
+        self.assertEqual(mapping["target"], "product/witness")
+        self.assertEqual(mapping["commands"]["fix"]["formula"], "custom-fix-formula")
+
+    def test_set_rig_mapping_persists_fix_formula(self) -> None:
+        config = common.set_rig_mapping(
+            common.load_config(), TEAM_ID, "mission-control", "mission-control/polecat", "mol-mattermost-fix-issue"
+        )
+
+        mapping = common.resolve_rig_mapping(config, TEAM_ID, "mission-control")
+
+        assert mapping is not None
+        self.assertEqual(mapping["target"], "mission-control/polecat")
+        self.assertEqual(mapping["rig_name"], "mission-control")
+        self.assertEqual(mapping["commands"]["fix"]["formula"], "mol-mattermost-fix-issue")
+
+    def test_normalize_config_preserves_distinct_mixed_case_rig_entries(self) -> None:
+        config = common.normalize_config(
+            {
+                "rigs": {
+                    f"{TEAM_ID}/Mission-Control": {
+                        "team_id": TEAM_ID,
+                        "rig_name": "Mission-Control",
+                        "target": "mission-control/polecat",
+                        "commands": {"fix": {"formula": "mol-mattermost-fix-issue"}},
+                    },
+                    f"{TEAM_ID}/mission-control": {
+                        "team_id": TEAM_ID,
+                        "rig_name": "mission-control",
+                        "target": "product/polecat",
+                        "commands": {"fix": {"formula": "mol-mattermost-fix-issue"}},
+                    },
+                }
+            }
+        )
+
+        self.assertIn(f"{TEAM_ID}/Mission-Control", config["rigs"])
+        self.assertIn(f"{TEAM_ID}/mission-control", config["rigs"])
+        self.assertEqual(config["rigs"][f"{TEAM_ID}/Mission-Control"]["target"], "mission-control/polecat")
+        self.assertEqual(config["rigs"][f"{TEAM_ID}/mission-control"]["target"], "product/polecat")
+
+    # ------------------------------------------------------------------
+    # chat bindings
+    # ------------------------------------------------------------------
+
+    def test_set_chat_binding_persists_room_binding(self) -> None:
+        config = common.set_chat_binding(common.load_config(), "room", CHANNEL_ID, ["sky", "lawrence"], TEAM_ID)
+
+        binding = common.resolve_chat_binding(config, f"room:{CHANNEL_ID}")
+
+        assert binding is not None
+        self.assertEqual(binding["team_id"], TEAM_ID)
+        self.assertEqual(binding["channel_id"], CHANNEL_ID)
+        self.assertEqual(binding["root_id"], "")
+        self.assertEqual(binding["session_names"], ["sky", "lawrence"])
+        self.assertEqual(binding["policy"], common.default_room_peer_policy())
+
+    def test_set_chat_binding_deduplicates_participants_case_insensitively(self) -> None:
+        config = common.set_chat_binding(common.load_config(), "room", CHANNEL_ID, ["sky", "Sky", "lawrence"], TEAM_ID)
+
+        binding = common.resolve_chat_binding(config, f"room:{CHANNEL_ID}")
+
+        assert binding is not None
+        self.assertEqual(binding["session_names"], ["sky", "lawrence"])
+
+    def test_set_chat_binding_rejects_dm_fanout(self) -> None:
+        with self.assertRaisesRegex(ValueError, "exactly one session name"):
+            common.set_chat_binding(common.load_config(), "dm", CHANNEL_ID, ["sky", "lawrence"])
+
+    def test_set_chat_binding_rejects_unknown_kind(self) -> None:
+        with self.assertRaisesRegex(ValueError, "kind must be dm or room"):
+            common.set_chat_binding(common.load_config(), "thread", CHANNEL_ID, ["sky"])
+
+    def test_set_chat_binding_persists_room_peer_policy(self) -> None:
+        config = common.set_chat_binding(
+            common.load_config(),
+            "room",
+            CHANNEL_ID,
+            ["corp--sky", "corp--priya"],
+            TEAM_ID,
+            policy={
+                "ambient_read_enabled": True,
+                "peer_fanout_enabled": True,
+                "allow_untargeted_peer_fanout": True,
+                "max_peer_triggered_publishes_per_root": 2,
+                "max_total_peer_deliveries_per_root": 9,
+                "max_peer_triggered_publishes_per_session_per_minute": 7,
+            },
+        )
+
+        binding = common.resolve_chat_binding(config, f"room:{CHANNEL_ID}")
+
+        assert binding is not None
+        self.assertTrue(binding["policy"]["ambient_read_enabled"])
+        self.assertTrue(binding["policy"]["peer_fanout_enabled"])
+        self.assertTrue(binding["policy"]["allow_untargeted_peer_fanout"])
+        self.assertEqual(binding["policy"]["max_peer_triggered_publishes_per_root"], 2)
+        self.assertEqual(binding["policy"]["max_total_peer_deliveries_per_root"], 9)
+        self.assertEqual(binding["policy"]["max_peer_triggered_publishes_per_session_per_minute"], 7)
+
+    def test_set_chat_binding_persists_untargeted_ambient_delivery_policy(self) -> None:
+        config = common.set_chat_binding(
+            common.load_config(),
+            "room",
+            CHANNEL_ID,
+            ["randy"],
+            TEAM_ID,
+            policy={"ambient_read_enabled": True, "allow_untargeted_ambient_delivery": True},
+        )
+
+        binding = common.resolve_chat_binding(config, f"room:{CHANNEL_ID}")
+
+        assert binding is not None
+        self.assertTrue(binding["policy"]["ambient_read_enabled"])
+        self.assertTrue(binding["policy"]["allow_untargeted_ambient_delivery"])
+
+    def test_set_chat_binding_rejects_untargeted_ambient_delivery_without_ambient_read(self) -> None:
+        with self.assertRaisesRegex(ValueError, "requires ambient read to be enabled"):
+            common.set_chat_binding(
+                common.load_config(),
+                "room",
+                CHANNEL_ID,
+                ["randy"],
+                TEAM_ID,
+                policy={"allow_untargeted_ambient_delivery": True},
+            )
+
+    def test_set_chat_binding_rejects_untargeted_ambient_delivery_for_multi_session_room(self) -> None:
+        with self.assertRaisesRegex(ValueError, "requires exactly one session name"):
+            common.set_chat_binding(
+                common.load_config(),
+                "room",
+                CHANNEL_ID,
+                ["randy", "wendy"],
+                TEAM_ID,
+                policy={"ambient_read_enabled": True, "allow_untargeted_ambient_delivery": True},
+            )
+
+    def test_set_chat_binding_persists_room_channel_metadata(self) -> None:
+        config = common.set_chat_binding(
+            common.load_config(),
+            "room",
+            CHANNEL_ID,
+            ["sky"],
+            TEAM_ID,
+            channel_metadata={
+                "channel_type": "P",
+                "channel_team_id": TEAM_ID,
+                "channel_name": "eng-private",
+                "channel_display_name": "Eng Private",
+            },
+        )
+
+        binding = common.resolve_chat_binding(config, f"room:{CHANNEL_ID}")
+
+        assert binding is not None
+        self.assertEqual(binding["channel_type"], "P")
+        self.assertEqual(binding["channel_team_id"], TEAM_ID)
+        self.assertEqual(binding["channel_name"], "eng-private")
+        self.assertEqual(binding["channel_display_name"], "Eng Private")
+
+    def test_set_chat_binding_merges_existing_room_peer_policy(self) -> None:
+        config = common.set_chat_binding(
+            common.load_config(),
+            "room",
+            CHANNEL_ID,
+            ["corp--sky", "corp--priya"],
+            TEAM_ID,
+            policy={"ambient_read_enabled": True, "peer_fanout_enabled": True, "allow_untargeted_peer_fanout": True},
+        )
+        config = common.set_chat_binding(
+            config,
+            "room",
+            CHANNEL_ID,
+            ["corp--sky", "corp--priya"],
+            TEAM_ID,
+            policy={"allow_untargeted_peer_fanout": False},
+        )
+
+        binding = common.resolve_chat_binding(config, f"room:{CHANNEL_ID}")
+
+        assert binding is not None
+        self.assertTrue(binding["policy"]["ambient_read_enabled"])
+        self.assertTrue(binding["policy"]["peer_fanout_enabled"])
+        self.assertFalse(binding["policy"]["allow_untargeted_peer_fanout"])
+
+    def test_set_chat_binding_rejects_noncanonical_names_when_peer_fanout_enabled(self) -> None:
+        with self.assertRaisesRegex(ValueError, "lowercase canonical session names"):
+            common.set_chat_binding(
+                common.load_config(),
+                "room",
+                CHANNEL_ID,
+                ["Corp--Sky", "corp--priya"],
+                TEAM_ID,
+                policy={"peer_fanout_enabled": True},
+            )
+
+    def test_binding_is_direct_detects_dm_kind_and_direct_channel_types(self) -> None:
+        self.assertTrue(common.binding_is_direct({"kind": "dm"}))
+        self.assertTrue(common.binding_is_direct({"kind": "room", "channel_type": "D"}))
+        self.assertTrue(common.binding_is_direct({"kind": "room", "channel_type": "G"}))
+        self.assertFalse(common.binding_is_direct({"kind": "room", "channel_type": "O"}))
+
+    def test_list_chat_bindings_sorts_by_kind_and_conversation(self) -> None:
+        config = common.set_chat_binding(common.load_config(), "room", CHANNEL_ID, ["sky"], TEAM_ID)
+        config = common.set_chat_binding(config, "dm", OTHER_CHANNEL_ID, ["priya"], TEAM_ID)
+
+        bindings = common.list_chat_bindings(config)
+
+        self.assertEqual([item["id"] for item in bindings], [f"dm:{OTHER_CHANNEL_ID}", f"room:{CHANNEL_ID}"])
+
+    # ------------------------------------------------------------------
+    # thread-scoped bindings (bind-room --root-id)
+    # ------------------------------------------------------------------
+
+    def test_set_chat_binding_splits_thread_scoped_conversation_id(self) -> None:
+        conversation_id = common.mattermost_conversation_key(CHANNEL_ID, ROOT_POST_ID)
+        config = common.set_chat_binding(common.load_config(), "room", conversation_id, ["corp--sky"], TEAM_ID)
+
+        binding = common.resolve_chat_binding(config, f"room:{conversation_id}")
+
+        assert binding is not None
+        self.assertEqual(binding["conversation_id"], conversation_id)
+        self.assertEqual(binding["channel_id"], CHANNEL_ID)
+        self.assertEqual(binding["root_id"], ROOT_POST_ID)
+
+    def test_thread_scoped_binding_survives_save_normalize_load_round_trip(self) -> None:
+        conversation_id = common.mattermost_conversation_key(CHANNEL_ID, ROOT_POST_ID)
+        common.set_chat_binding(common.load_config(), "room", conversation_id, ["corp--sky"], TEAM_ID)
+
+        # Round trip through disk: load_config() re-normalizes whatever was saved.
+        reloaded = common.load_config()
+        binding = common.resolve_chat_binding(reloaded, f"room:{conversation_id}")
+
+        assert binding is not None
+        self.assertEqual(binding["conversation_id"], conversation_id)
+        self.assertEqual(binding["channel_id"], CHANNEL_ID)
+        self.assertEqual(binding["root_id"], ROOT_POST_ID)
+
+        # And a second save/load cycle must not drift.
+        resaved = common.save_config(reloaded)
+        again = common.resolve_chat_binding(common.load_config(), f"room:{conversation_id}")
+        assert again is not None
+        self.assertEqual(again["channel_id"], CHANNEL_ID)
+        self.assertEqual(again["root_id"], ROOT_POST_ID)
+        self.assertEqual(resaved["chat"]["bindings"][f"room:{conversation_id}"]["root_id"], ROOT_POST_ID)
+
+    def test_normalize_config_derives_channel_and_root_for_legacy_bindings(self) -> None:
+        conversation_id = common.mattermost_conversation_key(CHANNEL_ID, ROOT_POST_ID)
+        config = common.normalize_config(
+            {
+                "chat": {
+                    "bindings": {
+                        f"room:{conversation_id}": {
+                            "id": f"room:{conversation_id}",
+                            "kind": "room",
+                            "conversation_id": conversation_id,
+                            "team_id": TEAM_ID,
+                            "session_names": ["corp--sky"],
+                        }
+                    }
+                }
+            }
+        )
+
+        binding = config["chat"]["bindings"][f"room:{conversation_id}"]
+        self.assertEqual(binding["channel_id"], CHANNEL_ID)
+        self.assertEqual(binding["root_id"], ROOT_POST_ID)
+
+    def test_normalize_config_preserves_explicit_binding_channel_id(self) -> None:
+        config = common.normalize_config(
+            {
+                "chat": {
+                    "bindings": {
+                        f"room:{CHANNEL_ID}": {
+                            "id": f"room:{CHANNEL_ID}",
+                            "kind": "room",
+                            "conversation_id": CHANNEL_ID,
+                            "channel_id": CHANNEL_ID,
+                            "root_id": ROOT_POST_ID,
+                            "team_id": TEAM_ID,
+                            "session_names": ["corp--sky"],
+                        }
+                    }
+                }
+            }
+        )
+
+        binding = config["chat"]["bindings"][f"room:{CHANNEL_ID}"]
+        self.assertEqual(binding["channel_id"], CHANNEL_ID)
+        self.assertEqual(binding["root_id"], ROOT_POST_ID)
+
+    def test_resolve_publish_channel_id_returns_channel_for_thread_scoped_binding(self) -> None:
+        conversation_id = common.mattermost_conversation_key(CHANNEL_ID, ROOT_POST_ID)
+        common.set_chat_binding(common.load_config(), "room", conversation_id, ["corp--sky"], TEAM_ID)
+        binding = common.resolve_chat_binding(common.load_config(), f"room:{conversation_id}")
+        assert binding is not None
+
+        self.assertEqual(common.resolve_publish_channel_id(binding, ""), CHANNEL_ID)
+        self.assertEqual(common.resolve_publish_channel_id(binding, CHANNEL_ID), CHANNEL_ID)
+
+    def test_resolve_publish_channel_id_rejects_composite_conversation_override(self) -> None:
+        conversation_id = common.mattermost_conversation_key(CHANNEL_ID, ROOT_POST_ID)
+        common.set_chat_binding(common.load_config(), "room", conversation_id, ["corp--sky"], TEAM_ID)
+        binding = common.resolve_chat_binding(common.load_config(), f"room:{conversation_id}")
+        assert binding is not None
+
+        with self.assertRaisesRegex(ValueError, "must match the bound channel"):
+            common.resolve_publish_channel_id(binding, conversation_id)
+
+    def test_resolve_publish_channel_id_rejects_dm_override(self) -> None:
+        common.set_chat_binding(common.load_config(), "dm", CHANNEL_ID, ["sky"], TEAM_ID)
+        binding = common.resolve_chat_binding(common.load_config(), f"dm:{CHANNEL_ID}")
+        assert binding is not None
+
+        with self.assertRaisesRegex(ValueError, "cannot override a DM binding"):
+            common.resolve_publish_channel_id(binding, OTHER_CHANNEL_ID)
+
+    def test_resolve_publish_channel_id_falls_back_to_conversation_parts(self) -> None:
+        binding = {
+            "id": f"room:{CHANNEL_ID}/{ROOT_POST_ID}",
+            "kind": "room",
+            "conversation_id": f"{CHANNEL_ID}/{ROOT_POST_ID}",
+        }
+
+        self.assertEqual(common.resolve_publish_channel_id(binding, ""), CHANNEL_ID)
+
+    def test_resolve_publish_destination_pins_thread_scoped_binding_root(self) -> None:
+        conversation_id = common.mattermost_conversation_key(CHANNEL_ID, ROOT_POST_ID)
+        common.set_chat_binding(common.load_config(), "room", conversation_id, ["corp--sky"], TEAM_ID)
+        binding = common.resolve_chat_binding(common.load_config(), f"room:{conversation_id}")
+        assert binding is not None
+
+        with mock.patch.object(common, "resolve_thread_root_id") as resolve_thread_root_id:
+            channel_id, root_post_id, launch = common.resolve_publish_destination(
+                binding,
+                reply_to_message_id=REPLY_POST_ID,
+            )
+
+        self.assertEqual(channel_id, CHANNEL_ID)
+        self.assertEqual(root_post_id, ROOT_POST_ID)
+        self.assertIsNone(launch)
+        resolve_thread_root_id.assert_not_called()
+
+    def test_publish_binding_message_thread_scoped_binding_posts_to_real_channel(self) -> None:
+        conversation_id = common.mattermost_conversation_key(CHANNEL_ID, ROOT_POST_ID)
+        common.set_chat_binding(common.load_config(), "room", conversation_id, ["corp--sky"], TEAM_ID)
+        binding = common.resolve_chat_binding(common.load_config(), f"room:{conversation_id}")
+        assert binding is not None
+
+        with mock.patch.object(common, "post_channel_message", return_value={"id": "post-1"}) as post_channel_message:
+            payload = common.publish_binding_message(binding, "hello humans", trigger_id=REPLY_POST_ID)
+
+        post_channel_message.assert_called_once_with(
+            CHANNEL_ID,
+            "hello humans",
+            root_id=ROOT_POST_ID,
+            file_ids=None,
+        )
+        self.assertEqual(payload["record"]["conversation_id"], CHANNEL_ID)
+        self.assertEqual(payload["record"]["root_post_id"], ROOT_POST_ID)
+        self.assertEqual(payload["record"]["binding_conversation_id"], conversation_id)
+
+    def test_publish_binding_message_thread_scoped_binding_accepts_real_channel_override(self) -> None:
+        conversation_id = common.mattermost_conversation_key(CHANNEL_ID, ROOT_POST_ID)
+        common.set_chat_binding(common.load_config(), "room", conversation_id, ["corp--sky"], TEAM_ID)
+        binding = common.resolve_chat_binding(common.load_config(), f"room:{conversation_id}")
+        assert binding is not None
+
+        with mock.patch.object(common, "post_channel_message", return_value={"id": "post-2"}) as post_channel_message:
+            common.publish_binding_message(binding, "hi", requested_conversation_id=CHANNEL_ID)
+
+        post_channel_message.assert_called_once_with(CHANNEL_ID, "hi", root_id=ROOT_POST_ID, file_ids=None)
+
+    def test_publish_binding_message_thread_scoped_binding_rejects_composite_override(self) -> None:
+        conversation_id = common.mattermost_conversation_key(CHANNEL_ID, ROOT_POST_ID)
+        common.set_chat_binding(common.load_config(), "room", conversation_id, ["corp--sky"], TEAM_ID)
+        binding = common.resolve_chat_binding(common.load_config(), f"room:{conversation_id}")
+        assert binding is not None
+
+        with mock.patch.object(common, "post_channel_message") as post_channel_message:
+            with self.assertRaisesRegex(ValueError, "must match the bound channel"):
+                common.publish_binding_message(binding, "hi", requested_conversation_id=conversation_id)
+
+        post_channel_message.assert_not_called()
+
+    def test_publish_binding_message_whole_channel_binding_resolves_root_from_reply_target(self) -> None:
+        common.set_chat_binding(common.load_config(), "room", CHANNEL_ID, ["corp--sky"], TEAM_ID)
+        binding = common.resolve_chat_binding(common.load_config(), f"room:{CHANNEL_ID}")
+        assert binding is not None
+
+        with mock.patch.object(common, "post_channel_message", return_value={"id": "post-3"}) as post_channel_message, mock.patch.object(
+            common,
+            "mattermost_api_request",
+            return_value={"id": REPLY_POST_ID, "channel_id": CHANNEL_ID, "root_id": ROOT_POST_ID},
+        ) as mattermost_api_request:
+            common.publish_binding_message(binding, "threaded reply", reply_to_message_id=REPLY_POST_ID)
+
+        mattermost_api_request.assert_called_once()
+        post_channel_message.assert_called_once_with(
+            CHANNEL_ID,
+            "threaded reply",
+            root_id=ROOT_POST_ID,
+            file_ids=None,
+        )
+
+    def test_publish_binding_message_whole_channel_binding_posts_unthreaded_without_reply_target(self) -> None:
+        common.set_chat_binding(common.load_config(), "room", CHANNEL_ID, ["corp--sky"], TEAM_ID)
+        binding = common.resolve_chat_binding(common.load_config(), f"room:{CHANNEL_ID}")
+        assert binding is not None
+
+        with mock.patch.object(common, "post_channel_message", return_value={"id": "post-4"}) as post_channel_message:
+            common.publish_binding_message(binding, "channel note")
+
+        post_channel_message.assert_called_once_with(CHANNEL_ID, "channel note", root_id="", file_ids=None)
+
+    def test_resolve_thread_root_id_walks_reply_to_thread_root(self) -> None:
+        with mock.patch.object(
+            common,
+            "mattermost_api_request",
+            return_value={"id": REPLY_POST_ID, "channel_id": CHANNEL_ID, "root_id": ROOT_POST_ID},
+        ):
+            self.assertEqual(common.resolve_thread_root_id(CHANNEL_ID, REPLY_POST_ID), ROOT_POST_ID)
+
+    def test_resolve_thread_root_id_returns_post_id_for_root_post(self) -> None:
+        with mock.patch.object(
+            common,
+            "mattermost_api_request",
+            return_value={"id": ROOT_POST_ID, "channel_id": CHANNEL_ID, "root_id": ""},
+        ):
+            self.assertEqual(common.resolve_thread_root_id(CHANNEL_ID, ROOT_POST_ID), ROOT_POST_ID)
+
+    def test_resolve_thread_root_id_rejects_cross_channel_post(self) -> None:
+        with mock.patch.object(
+            common,
+            "mattermost_api_request",
+            return_value={"id": REPLY_POST_ID, "channel_id": OTHER_CHANNEL_ID, "root_id": ROOT_POST_ID},
+        ):
+            self.assertEqual(common.resolve_thread_root_id(CHANNEL_ID, REPLY_POST_ID), "")
+
+    def test_resolve_thread_root_id_falls_back_to_post_id_on_api_error(self) -> None:
+        with mock.patch.object(
+            common,
+            "mattermost_api_request",
+            side_effect=common.MattermostAPIError("GET failed", status_code=500),
+        ):
+            self.assertEqual(common.resolve_thread_root_id(CHANNEL_ID, REPLY_POST_ID), REPLY_POST_ID)
+
+    # ------------------------------------------------------------------
+    # room launchers
+    # ------------------------------------------------------------------
+
+    def test_set_room_launcher_persists_room_launcher(self) -> None:
+        config = common.set_room_launcher(common.load_config(), TEAM_ID, CHANNEL_ID)
+
+        launcher = common.resolve_room_launcher(config, CHANNEL_ID)
+
+        assert launcher is not None
+        self.assertEqual(launcher["id"], f"launch-room:{CHANNEL_ID}")
+        self.assertEqual(launcher["response_mode"], "mention_only")
+        self.assertTrue(launcher["policy"]["peer_fanout_enabled"])
+        self.assertTrue(launcher["policy"]["allow_untargeted_peer_fanout"])
+
+    def test_set_room_launcher_can_disable_peer_fanout_policy(self) -> None:
+        config = common.set_room_launcher(
+            common.load_config(),
+            TEAM_ID,
+            CHANNEL_ID,
+            policy={"peer_fanout_enabled": False, "allow_untargeted_peer_fanout": False},
+        )
+
+        launcher = common.resolve_room_launcher(config, CHANNEL_ID)
+
+        assert launcher is not None
+        self.assertFalse(launcher["policy"]["peer_fanout_enabled"])
+        self.assertFalse(launcher["policy"]["allow_untargeted_peer_fanout"])
+
+    def test_set_chat_binding_rejects_room_with_launcher(self) -> None:
+        config = common.set_room_launcher(common.load_config(), TEAM_ID, CHANNEL_ID)
+
+        with self.assertRaisesRegex(ValueError, "room launch is already enabled"):
+            common.set_chat_binding(config, "room", CHANNEL_ID, ["sky"], TEAM_ID)
+
+    def test_set_room_launcher_rejects_direct_binding_conflict(self) -> None:
+        config = common.set_chat_binding(common.load_config(), "room", CHANNEL_ID, ["sky"], TEAM_ID)
+
+        with self.assertRaisesRegex(ValueError, "directly bound room"):
+            common.set_room_launcher(config, TEAM_ID, CHANNEL_ID)
+
+    def test_set_room_launcher_rejects_unqualified_default_handle(self) -> None:
+        with self.assertRaisesRegex(ValueError, "qualified rig/alias syntax"):
+            common.set_room_launcher(
+                common.load_config(),
+                TEAM_ID,
+                CHANNEL_ID,
+                response_mode="respond_all",
+                default_qualified_handle="sky",
+            )
+
+    def test_set_room_launcher_requires_team_id(self) -> None:
+        with self.assertRaisesRegex(ValueError, "team_id is required"):
+            common.set_room_launcher(common.load_config(), "", CHANNEL_ID)
+
+    def test_resolve_publish_route_returns_launcher_as_room_route(self) -> None:
+        config = common.set_room_launcher(common.load_config(), TEAM_ID, CHANNEL_ID)
+
+        route = common.resolve_publish_route(config, f"launch-room:{CHANNEL_ID}")
+
+        assert route is not None
+        self.assertEqual(route["publish_route_kind"], "room_launch")
+        self.assertEqual(route["kind"], "room")
+        self.assertEqual(route["session_names"], [])
+
+    # ------------------------------------------------------------------
+    # channel metadata
+    # ------------------------------------------------------------------
+
+    def test_normalize_binding_channel_metadata_reads_channel_objects(self) -> None:
+        metadata = common.normalize_binding_channel_metadata(
+            {
+                "id": CHANNEL_ID,
+                "type": "O",
+                "team_id": TEAM_ID,
+                "name": "town-square",
+                "display_name": "Town Square",
+            }
+        )
+
+        self.assertEqual(
+            metadata,
+            {
+                "channel_type": "O",
+                "channel_team_id": TEAM_ID,
+                "channel_name": "town-square",
+                "channel_display_name": "Town Square",
+            },
+        )
+
+    def test_normalize_binding_channel_metadata_ignores_binding_team_id(self) -> None:
+        metadata = common.normalize_binding_channel_metadata(
+            {"kind": "room", "team_id": TEAM_ID, "conversation_id": CHANNEL_ID}
+        )
+
+        self.assertEqual(metadata, {})
+
+    def test_describe_room_channel_metadata_normalizes_channel(self) -> None:
+        with mock.patch.object(common, "load_bot_token", return_value="bot-token"), mock.patch.object(
+            common,
+            "mattermost_api_request",
+            return_value={"id": CHANNEL_ID, "type": "P", "team_id": TEAM_ID, "name": "eng", "display_name": "Eng"},
+        ):
+            metadata = common.describe_room_channel_metadata(CHANNEL_ID, bot_token="bot-token")
+
+        self.assertEqual(
+            metadata,
+            {
+                "channel_type": "P",
+                "channel_team_id": TEAM_ID,
+                "channel_name": "eng",
+                "channel_display_name": "Eng",
+            },
+        )
+
+    def test_describe_room_channel_metadata_returns_empty_without_token(self) -> None:
+        with mock.patch.object(common, "load_bot_token", return_value=""), mock.patch.object(
+            common, "mattermost_api_request"
+        ) as mattermost_api_request:
+            self.assertEqual(common.describe_room_channel_metadata(CHANNEL_ID), {})
+
+        mattermost_api_request.assert_not_called()
+
+    def test_save_channel_metadata_cache_round_trips_normalized_metadata(self) -> None:
+        metadata = common.save_channel_metadata_cache(
+            CHANNEL_ID, {"id": CHANNEL_ID, "type": "O", "team_id": TEAM_ID, "name": "town-square"}
+        )
+
+        expected = {"channel_type": "O", "channel_team_id": TEAM_ID, "channel_name": "town-square"}
+        self.assertEqual(metadata, expected)
+        self.assertEqual(common.load_channel_metadata_cache(CHANNEL_ID), expected)
+
+    def test_load_channel_metadata_cache_ignores_invalid_payload(self) -> None:
+        common.ensure_layout()
+        pathlib.Path(common.channel_metadata_cache_path(CHANNEL_ID)).write_text("{not valid json", encoding="utf-8")
+
+        self.assertEqual(common.load_channel_metadata_cache(CHANNEL_ID), {})
+
+    # ------------------------------------------------------------------
+    # channel context
+    # ------------------------------------------------------------------
+
+    def test_load_channel_context_uses_direct_mapping_without_api_lookup(self) -> None:
+        config = common.set_channel_mapping(
+            common.load_config(), TEAM_ID, CHANNEL_ID, "product/polecat", "mol-mattermost-fix-issue"
+        )
+
+        with mock.patch.object(common, "mattermost_api_request") as mattermost_api_request:
+            context = common.load_channel_context(config, TEAM_ID, CHANNEL_ID, ROOT_POST_ID)
+
+        self.assertEqual(context["channel_id"], CHANNEL_ID)
+        self.assertEqual(context["root_id"], ROOT_POST_ID)
+        self.assertEqual(context["mapping"]["target"], "product/polecat")
+        mattermost_api_request.assert_not_called()
+
+    def test_load_channel_context_remaps_to_channel_owning_team(self) -> None:
+        config = common.set_channel_mapping(
+            common.load_config(), TEAM_ID, CHANNEL_ID, "product/polecat", "mol-mattermost-fix-issue"
+        )
+
+        with mock.patch.object(common, "load_bot_token", return_value="bot-token"), mock.patch.object(
+            common,
+            "mattermost_api_request",
+            return_value={"id": CHANNEL_ID, "team_id": TEAM_ID, "type": "O"},
+        ):
+            context = common.load_channel_context(config, OTHER_TEAM_ID, CHANNEL_ID)
+
+        self.assertEqual(context["team_id"], TEAM_ID)
+        self.assertEqual(context["mapping"]["target"], "product/polecat")
+
+    def test_load_channel_context_surfaces_non_404_lookup_errors(self) -> None:
+        config = common.set_channel_mapping(
+            common.load_config(), TEAM_ID, CHANNEL_ID, "product/polecat", "mol-mattermost-fix-issue"
+        )
+
+        with mock.patch.object(common, "load_bot_token", return_value="bot-token"), mock.patch.object(
+            common,
+            "mattermost_api_request",
+            side_effect=common.MattermostAPIError("GET failed", status_code=500),
+        ):
+            context = common.load_channel_context(config, OTHER_TEAM_ID, CHANNEL_ID)
+
+        self.assertEqual(context["lookup_error"], "GET failed")
+
+    def test_load_channel_context_tolerates_missing_channel(self) -> None:
+        config = common.load_config()
+
+        with mock.patch.object(common, "load_bot_token", return_value="bot-token"), mock.patch.object(
+            common,
+            "mattermost_api_request",
+            side_effect=common.MattermostAPIError("not found", status_code=404),
+        ):
+            context = common.load_channel_context(config, TEAM_ID, CHANNEL_ID)
+
+        self.assertIsNone(context["mapping"])
+        self.assertNotIn("lookup_error", context)
+
+    # ------------------------------------------------------------------
+    # slash command sync + tokens
+    # ------------------------------------------------------------------
+
+    def test_sync_team_commands_creates_command_and_stores_token(self) -> None:
+        config = common.import_app_config(common.load_config(), {"site_url": "https://mattermost.test", "team_id": TEAM_ID})
+
+        with mock.patch.object(common, "list_team_commands", return_value=[]), mock.patch.object(
+            common,
+            "mattermost_api_request",
+            return_value={"id": COMMAND_ID, "token": COMMAND_TOKEN, "trigger": "gc"},
+        ) as mattermost_api_request:
+            command = common.sync_team_commands(config, TEAM_ID, url="https://interactions.test/mattermost/command")
+
+        self.assertEqual(command["id"], COMMAND_ID)
+        self.assertEqual(mattermost_api_request.call_args.args[0], "POST")
+        self.assertEqual(mattermost_api_request.call_args.args[1], "/commands")
+        payload = mattermost_api_request.call_args.kwargs["payload"]
+        self.assertEqual(payload["trigger"], "gc")
+        self.assertEqual(payload["team_id"], TEAM_ID)
+        self.assertEqual(common.load_command_token(), COMMAND_TOKEN)
+        self.assertEqual(common.load_config()["app"]["command_id"], COMMAND_ID)
+
+    def test_sync_team_commands_updates_existing_command(self) -> None:
+        config = common.import_app_config(common.load_config(), {"site_url": "https://mattermost.test", "team_id": TEAM_ID})
+
+        with mock.patch.object(
+            common, "list_team_commands", return_value=[{"id": COMMAND_ID, "trigger": "gc", "team_id": TEAM_ID}]
+        ), mock.patch.object(
+            common,
+            "mattermost_api_request",
+            return_value={"id": COMMAND_ID, "token": COMMAND_TOKEN, "trigger": "gc"},
+        ) as mattermost_api_request:
+            common.sync_team_commands(config, TEAM_ID, url="https://interactions.test/mattermost/command")
+
+        self.assertEqual(mattermost_api_request.call_args.args[0], "PUT")
+        self.assertEqual(mattermost_api_request.call_args.args[1], f"/commands/{COMMAND_ID}")
+
+    def test_sync_team_commands_requires_callback_url(self) -> None:
+        config = common.import_app_config(common.load_config(), {"site_url": "https://mattermost.test", "team_id": TEAM_ID})
+
+        with self.assertRaisesRegex(common.MattermostAPIError, "interactions service URL is not published"):
+            common.sync_team_commands(config, TEAM_ID)
+
+    def test_verify_command_token_matches_saved_token(self) -> None:
+        common.save_command_token(COMMAND_TOKEN)
+
+        self.assertTrue(common.verify_command_token(COMMAND_TOKEN))
+        self.assertFalse(common.verify_command_token(mmid("other")))
+        self.assertFalse(common.verify_command_token(""))
+
+    def test_verify_command_token_is_false_without_saved_token(self) -> None:
+        self.assertFalse(common.verify_command_token(COMMAND_TOKEN))
+
+    def test_regenerate_command_token_persists_new_token(self) -> None:
+        new_token = mmid("newtoken")
+        with mock.patch.object(common, "mattermost_api_request", return_value={"token": new_token}):
+            self.assertEqual(common.regenerate_command_token(COMMAND_ID), new_token)
+
+        self.assertEqual(common.load_command_token(), new_token)
+
+    # ------------------------------------------------------------------
+    # dialog state signing
+    # ------------------------------------------------------------------
+
+    def test_dialog_state_round_trips_nonce(self) -> None:
+        state = common.mint_dialog_state("nonce-1")
+
+        self.assertEqual(common.verify_dialog_state(state), "nonce-1")
+
+    def test_dialog_state_rejects_tampered_signature(self) -> None:
+        state = common.mint_dialog_state("nonce-1")
+        version, nonce, expires, _signature = state.split(":")
+
+        self.assertEqual(common.verify_dialog_state(f"{version}:{nonce}:{expires}:deadbeef"), "")
+
+    def test_dialog_state_rejects_expired_state(self) -> None:
+        state = common.mint_dialog_state("nonce-1", ttl_seconds=1)
+
+        with mock.patch.object(common.time, "time", return_value=time.time() + 3600):
+            self.assertEqual(common.verify_dialog_state(state), "")
+
+    def test_mint_dialog_state_rejects_colon_in_nonce(self) -> None:
+        with self.assertRaisesRegex(ValueError, "must not contain"):
+            common.mint_dialog_state("bad:nonce")
+
+    def test_dialog_route_token_is_stable_and_verifiable(self) -> None:
+        token = common.dialog_route_token()
+
+        self.assertEqual(token, common.dialog_route_token())
+        self.assertTrue(common.verify_dialog_route_token(token))
+        self.assertFalse(common.verify_dialog_route_token("nope"))
+
+    # ------------------------------------------------------------------
+    # requests / receipts / workflow links
+    # ------------------------------------------------------------------
+
+    def test_save_interaction_receipt_is_unique(self) -> None:
+        first = common.save_interaction_receipt("abc", {"response_kind": "accepted", "request_id": "mm-1"})
+        second = common.save_interaction_receipt("abc", {"response_kind": "accepted", "request_id": "mm-1"})
+
+        self.assertTrue(first)
+        self.assertFalse(second)
+        self.assertEqual(common.load_interaction_receipt("abc")["request_id"], "mm-1")
+
+    def test_replace_interaction_receipt_overwrites_existing_payload(self) -> None:
+        common.save_interaction_receipt("abc", {"response_kind": "dialog", "modal_nonce": "nonce-1"})
+
+        common.replace_interaction_receipt("abc", {"response_kind": "accepted", "request_id": "mm-1"})
+
+        receipt = common.load_interaction_receipt("abc")
+        self.assertEqual(receipt["response_kind"], "accepted")
+        self.assertEqual(receipt["request_id"], "mm-1")
+
+    def test_load_interaction_receipt_ignores_invalid_json(self) -> None:
+        pathlib.Path(common.receipt_path("broken")).parent.mkdir(parents=True, exist_ok=True)
+        pathlib.Path(common.receipt_path("broken")).write_text("{", encoding="utf-8")
+
+        self.assertIsNone(common.load_interaction_receipt("broken"))
+
+    def test_load_request_ignores_invalid_json(self) -> None:
+        pathlib.Path(common.request_path("broken")).parent.mkdir(parents=True, exist_ok=True)
+        pathlib.Path(common.request_path("broken")).write_text("{", encoding="utf-8")
+
+        self.assertIsNone(common.load_request("broken"))
+
+    def test_build_request_id_and_workflow_key_use_mattermost_prefixes(self) -> None:
+        self.assertTrue(common.build_request_id("interaction-1", "fix").startswith("mm-"))
+        self.assertEqual(
+            common.build_workflow_key(TEAM_ID, CHANNEL_ID, "fix"),
+            f"mm:team:{TEAM_ID}:conversation:{CHANNEL_ID}:fix",
+        )
+
+    def test_list_recent_requests_skips_invalid_json_files(self) -> None:
+        common.save_request({"request_id": "mm-valid"})
+        pathlib.Path(common.request_path("mm-bad")).write_text("{", encoding="utf-8")
+
+        requests = common.list_recent_requests(limit=5)
+
+        self.assertEqual([item["request_id"] for item in requests], ["mm-valid"])
+
+    def test_prune_requests_removes_expired_records(self) -> None:
+        common.save_request({"request_id": "mm-old"})
+        path = common.request_path("mm-old")
+        expired = time.time() - common.REQUEST_RETENTION_SECONDS - 10
+        os.utime(path, (expired, expired))
+
+        common.prune_requests()
+
+        self.assertEqual(common.list_recent_requests(limit=5), [])
+
+    def test_prune_requests_keeps_records_with_active_workflow_links(self) -> None:
+        common.save_request({"request_id": "mm-active"})
+        common.save_workflow_link(common.build_workflow_key(TEAM_ID, CHANNEL_ID, "fix"), "mm-active")
+        path = common.request_path("mm-active")
+        expired = time.time() - common.REQUEST_RETENTION_SECONDS - 10
+        os.utime(path, (expired, expired))
+
+        common.prune_requests()
+
+        self.assertIsNotNone(common.load_request("mm-active"))
+
+    def test_remove_workflow_link_if_request_only_removes_matching_owner(self) -> None:
+        key = common.build_workflow_key(TEAM_ID, CHANNEL_ID, "fix")
+        common.save_workflow_link(key, "mm-1")
+
+        self.assertFalse(common.remove_workflow_link_if_request(key, "mm-2"))
+        self.assertTrue(common.remove_workflow_link_if_request(key, "mm-1"))
+        self.assertIsNone(common.load_workflow_link(key))
+
+    def test_pending_modal_round_trips_through_dialog_state(self) -> None:
+        common.save_pending_modal({"nonce": "nonce-9", "command": "fix"})
+        state = common.mint_dialog_state("nonce-9")
+
+        payload = common.consume_pending_modal(state)
+
+        assert payload is not None
+        self.assertEqual(payload["command"], "fix")
+        self.assertIsNone(common.load_pending_modal("nonce-9"))
+
+    # ------------------------------------------------------------------
+    # gc api plumbing
+    # ------------------------------------------------------------------
+
+    def _no_supervisor(self):
+        return mock.patch.object(
+            common.urllib.request, "urlopen", side_effect=urllib.error.URLError("no supervisor")
+        )
+
+    def test_gc_api_base_url_uses_city_toml_bind_and_port(self) -> None:
+        pathlib.Path(self.tempdir.name, "city.toml").write_text('[api]\nbind = "0.0.0.0"\nport = 9555\n', encoding="utf-8")
+
+        with self._no_supervisor():
+            self.assertEqual(common.gc_api_base_url(), "http://127.0.0.1:9555")
+
+    def test_gc_api_base_url_uses_ipv6_loopback_for_unspecified_ipv6_bind(self) -> None:
+        pathlib.Path(self.tempdir.name, "city.toml").write_text('[api]\nbind = "::"\nport = 9555\n', encoding="utf-8")
+
+        with self._no_supervisor():
+            self.assertEqual(common.gc_api_base_url(), "http://[::1]:9555")
+
+    def test_gc_api_base_url_honors_env_override(self) -> None:
+        pathlib.Path(self.tempdir.name, "city.toml").write_text('[api]\nbind = "0.0.0.0"\nport = 9555\n', encoding="utf-8")
+        os.environ["GC_API_BASE_URL"] = "http://override.test:1234/"
+
+        self.assertEqual(common.gc_api_base_url(), "http://override.test:1234")
+
+    def test_gc_api_base_url_prefers_supervisor_api_when_available(self) -> None:
+        pathlib.Path(self.tempdir.name, "city.toml").write_text(
+            '[workspace]\nname = "gc"\n[api]\nbind = "0.0.0.0"\nport = 9555\n',
+            encoding="utf-8",
+        )
+        response = mock.Mock()
+        response.__enter__ = mock.Mock(
+            return_value=mock.Mock(read=mock.Mock(return_value=b'{"items":[{"name":"gc","running":true}]}'))
+        )
+        response.__exit__ = mock.Mock(return_value=False)
+
+        with mock.patch.object(common.urllib.request, "urlopen", return_value=response) as urlopen:
+            self.assertEqual(common.gc_api_base_url(), "http://127.0.0.1:8372")
+
+        self.assertEqual(urlopen.call_count, 1)
+
+    def test_gc_api_base_url_uses_site_workspace_name_when_city_toml_omits_name(self) -> None:
+        pathlib.Path(self.tempdir.name, "city.toml").write_text(
+            "[workspace]\nmax_active_sessions = 5\n",
+            encoding="utf-8",
+        )
+        site_dir = pathlib.Path(self.tempdir.name, ".gc")
+        site_dir.mkdir()
+        (site_dir / "site.toml").write_text('workspace_name = "gc"\n', encoding="utf-8")
+        common._supervisor_scope_cache.clear()
+        response = mock.Mock()
+        response.__enter__ = mock.Mock(
+            return_value=mock.Mock(read=mock.Mock(return_value=b'{"items":[{"name":"gc","running":true}]}'))
+        )
+        response.__exit__ = mock.Mock(return_value=False)
+
+        with mock.patch.object(common.urllib.request, "urlopen", return_value=response):
+            self.assertEqual(common.gc_api_base_url(), "http://127.0.0.1:8372")
+
+    def test_gc_api_base_url_falls_back_to_city_dir_basename_when_no_declared_name(self) -> None:
+        pathlib.Path(self.tempdir.name, "city.toml").write_text("", encoding="utf-8")
+        common._supervisor_scope_cache.clear()
+        basename = pathlib.Path(self.tempdir.name).name
+        body = ('{"items":[{"name":"%s","running":true}]}' % basename).encode("utf-8")
+        response = mock.Mock()
+        response.__enter__ = mock.Mock(return_value=mock.Mock(read=mock.Mock(return_value=body)))
+        response.__exit__ = mock.Mock(return_value=False)
+
+        with mock.patch.object(common.urllib.request, "urlopen", return_value=response):
+            self.assertEqual(common.gc_api_base_url(), "http://127.0.0.1:8372")
+
+    def test_gc_api_base_url_falls_back_when_supervisor_city_missing(self) -> None:
+        pathlib.Path(self.tempdir.name, "city.toml").write_text(
+            '[workspace]\nname = "gc"\n[api]\nbind = "0.0.0.0"\nport = 9555\n',
+            encoding="utf-8",
+        )
+        response = mock.Mock()
+        response.__enter__ = mock.Mock(
+            return_value=mock.Mock(read=mock.Mock(return_value=b'{"items":[{"name":"other-city","running":true}]}'))
+        )
+        response.__exit__ = mock.Mock(return_value=False)
+
+        with mock.patch.object(common.urllib.request, "urlopen", return_value=response):
+            self.assertEqual(common.gc_api_base_url(), "http://127.0.0.1:9555")
+
+    def test_gc_api_request_routes_through_supervisor_city_scope(self) -> None:
+        pathlib.Path(self.tempdir.name, "city.toml").write_text(
+            '[workspace]\nname = "gc"\n[api]\nbind = "0.0.0.0"\nport = 9555\n',
+            encoding="utf-8",
+        )
+        common._supervisor_scope_cache.clear()
+        cities = mock.Mock()
+        cities.__enter__ = mock.Mock(
+            return_value=mock.Mock(read=mock.Mock(return_value=b'{"items":[{"name":"gc","running":true}]}'))
+        )
+        cities.__exit__ = mock.Mock(return_value=False)
+        sessions = mock.Mock()
+        sessions.__enter__ = mock.Mock(return_value=mock.Mock(read=mock.Mock(return_value=b'{"items": []}')))
+        sessions.__exit__ = mock.Mock(return_value=False)
+
+        with mock.patch.object(common.urllib.request, "urlopen", side_effect=[cities, sessions]) as urlopen:
+            payload = common.gc_api_request("GET", "/v0/sessions")
+
+        self.assertEqual(payload, {"items": []})
+        self.assertEqual(urlopen.call_args_list[-1].args[0].full_url, "http://127.0.0.1:8372/v0/city/gc/sessions")
+
+    def test_gc_api_base_url_rejects_disabled_port(self) -> None:
+        pathlib.Path(self.tempdir.name, "city.toml").write_text("[api]\nport = 0\n", encoding="utf-8")
+
+        with self._no_supervisor():
+            with self.assertRaisesRegex(common.GCAPIError, "gc api is disabled"):
+                common.gc_api_base_url()
+
+    def test_deliver_session_message_uses_messages_endpoint_for_default_intent(self) -> None:
+        with mock.patch.object(common, "gc_api_request", return_value={"status": "accepted"}) as gc_api_request:
+            payload = common.deliver_session_message("corp--sky", "hello", idempotency_key="ingress:1")
+
+        self.assertEqual(payload, {"status": "accepted"})
+        gc_api_request.assert_called_once_with(
+            "POST",
+            "/v0/session/corp--sky/messages",
+            payload={"message": "hello"},
+            headers={"Idempotency-Key": "ingress:1"},
+            timeout=common.GC_API_REQUEST_TIMEOUT_SECONDS,
+        )
+
+    def test_deliver_session_message_uses_submit_endpoint_for_follow_up_intent(self) -> None:
+        with mock.patch.object(common, "gc_api_request", return_value={"status": "accepted"}) as gc_api_request:
+            payload = common.deliver_session_message(
+                "corp--sky",
+                "hello again",
+                idempotency_key="ingress:2",
+                intent="follow_up",
+            )
+
+        self.assertEqual(payload, {"status": "accepted"})
+        gc_api_request.assert_called_once_with(
+            "POST",
+            "/v0/session/corp--sky/submit",
+            payload={"message": "hello again", "intent": "follow_up"},
+            headers={"Idempotency-Key": "ingress:2"},
+            timeout=common.GC_API_REQUEST_TIMEOUT_SECONDS,
+        )
+
+    # ------------------------------------------------------------------
+    # service sockets
+    # ------------------------------------------------------------------
+
+    def test_prepare_service_socket_rejects_active_listener(self) -> None:
+        socket_path = pathlib.Path(self.tempdir.name, "mattermost.sock")
+        listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        listener.bind(str(socket_path))
+        listener.listen(1)
+        self.addCleanup(listener.close)
+        self.addCleanup(lambda: socket_path.exists() and socket_path.unlink())
+
+        with self.assertRaisesRegex(RuntimeError, "refusing to replace active service socket"):
+            common.prepare_service_socket(str(socket_path))
+
+    def test_prepare_service_socket_removes_stale_socket_file(self) -> None:
+        socket_path = pathlib.Path(self.tempdir.name, "mattermost-stale.sock")
+        listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        listener.bind(str(socket_path))
+        listener.listen(1)
+        listener.close()
+        self.addCleanup(lambda: socket_path.exists() and socket_path.unlink())
+
+        common.prepare_service_socket(str(socket_path))
+
+        self.assertFalse(socket_path.exists())
+
+    # ------------------------------------------------------------------
+    # publish + ingress records
+    # ------------------------------------------------------------------
+
+    def test_save_chat_publish_lists_recent_records(self) -> None:
+        common.save_chat_publish({"publish_id": "pub-1", "binding_id": f"room:{CHANNEL_ID}"})
+
+        recent = common.list_recent_chat_publishes(limit=5)
+
+        self.assertEqual(len(recent), 1)
+        self.assertEqual(recent[0]["publish_id"], "pub-1")
+
+    def test_prune_chat_publishes_removes_expired_records(self) -> None:
+        common.save_chat_publish({"publish_id": "pub-old", "binding_id": f"room:{CHANNEL_ID}"})
+        path = common.chat_publish_path("pub-old")
+        expired = time.time() - common.CHAT_PUBLISH_RETENTION_SECONDS - 10
+        os.utime(path, (expired, expired))
+
+        common.prune_chat_publishes()
+
+        self.assertEqual(common.list_recent_chat_publishes(limit=5), [])
+
+    def test_save_chat_ingress_if_absent_only_claims_once(self) -> None:
+        payload = {"ingress_id": "in-claim", "status": "processing"}
+        barrier = threading.Barrier(2)
+        results: list[tuple[bool, dict[str, object]]] = []
+
+        def claim() -> None:
+            barrier.wait()
+            results.append(common.save_chat_ingress_if_absent(payload))
+
+        threads = [threading.Thread(target=claim), threading.Thread(target=claim)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        self.assertEqual(sum(1 for created, _ in results if created), 1)
+        self.assertEqual(sum(1 for created, _ in results if not created), 1)
+
+    def test_save_chat_ingress_if_absent_marks_unreadable_claim_conflict(self) -> None:
+        path = common.chat_ingress_path("in-broken")
+        pathlib.Path(path).parent.mkdir(parents=True, exist_ok=True)
+        pathlib.Path(path).write_text("", encoding="utf-8")
+
+        created, receipt = common.save_chat_ingress_if_absent({"ingress_id": "in-broken", "status": "processing"})
+
+        self.assertFalse(created)
+        self.assertEqual(receipt["status"], "claim_conflict_unreadable")
+        self.assertEqual(receipt["reason"], "ingress_claim_unreadable")
+
+    def test_build_status_snapshot_redacts_chat_content(self) -> None:
+        common.save_request(
+            {
+                "request_id": "mm-1",
+                "summary": "secret bug",
+                "context_markdown": "trace here",
+                "invoking_user_display_name": "alice",
+                "error_message": "boom",
+                "traceback": "stack",
+            }
+        )
+        common.save_gateway_status({"last_message_preview": "peek", "last_error": "boom"})
+        common.save_chat_ingress(
+            {
+                "ingress_id": "in-1",
+                "from_display": "alice",
+                "from_username": "alice",
+                "from_user_id": "u-1",
+                "body_preview": "super secret body",
+                "status": "delivered",
+            }
+        )
+        common.save_chat_publish({"publish_id": "pub-1", "binding_id": f"room:{CHANNEL_ID}", "body": "internal reply"})
+
+        snapshot = common.build_status_snapshot(limit=5)
+
+        self.assertEqual(snapshot["recent_requests"][0]["summary"], "[redacted]")
+        self.assertEqual(snapshot["recent_requests"][0]["context_markdown"], "[redacted]")
+        self.assertEqual(snapshot["recent_requests"][0]["invoking_user_display_name"], "[redacted]")
+        self.assertEqual(snapshot["recent_requests"][0]["error_message"], "[redacted]")
+        self.assertEqual(snapshot["recent_requests"][0]["traceback"], "[redacted]")
+        self.assertEqual(snapshot["gateway_status"]["last_message_preview"], "[redacted]")
+        self.assertEqual(snapshot["gateway_status"]["last_error"], "[redacted]")
+        self.assertEqual(snapshot["recent_chat_ingress"][0]["from_display"], "[redacted]")
+        self.assertEqual(snapshot["recent_chat_ingress"][0]["from_username"], "[redacted]")
+        self.assertEqual(snapshot["recent_chat_ingress"][0]["from_user_id"], "[redacted]")
+        self.assertEqual(snapshot["recent_chat_ingress"][0]["body_preview"], "[redacted]")
+        self.assertEqual(snapshot["recent_chat_publishes"][0]["body"], "[redacted]")
+
+    # ------------------------------------------------------------------
+    # session identity
+    # ------------------------------------------------------------------
+
+    def test_session_index_by_name_prefers_routable_duplicate(self) -> None:
+        with mock.patch.object(
+            common,
+            "list_city_sessions",
+            return_value=[
+                {"session_name": "corp--sky", "state": "awake", "running": False, "created_at": "2026-03-18T07:55:10Z"},
+                {"session_name": "corp--sky", "state": "", "running": False, "created_at": "2026-03-17T05:10:53Z"},
+            ],
+        ):
+            index = common.session_index_by_name()
+
+        self.assertEqual(index["corp--sky"]["state"], "awake")
+        self.assertEqual(index["corp--sky"]["created_at"], "2026-03-18T07:55:10Z")
+
+    def test_session_index_by_name_prefers_running_duplicate(self) -> None:
+        with mock.patch.object(
+            common,
+            "list_city_sessions",
+            return_value=[
+                {"session_name": "corp--sky", "state": "awake", "running": False, "created_at": "2026-03-18T07:55:10Z"},
+                {"session_name": "corp--sky", "state": "active", "running": True, "created_at": "2026-03-18T07:55:10Z"},
+            ],
+        ):
+            index = common.session_index_by_name()
+
+        self.assertEqual(index["corp--sky"]["state"], "active")
+        self.assertTrue(index["corp--sky"]["running"])
+
+    def test_resolve_session_identity_prefers_routable_named_session(self) -> None:
+        with mock.patch.object(
+            common,
+            "list_city_sessions",
+            return_value=[
+                {"id": "gc-old", "session_name": "corp--sky", "state": "", "running": False, "created_at": "2026-03-18T00:00:00Z"},
+                {"id": "gc-new", "session_name": "corp--sky", "state": "active", "running": True, "created_at": "2026-03-19T00:00:00Z"},
+            ],
+        ):
+            identity = common.resolve_session_identity("corp--sky")
+
+        self.assertEqual(identity["session_name"], "corp--sky")
+        self.assertEqual(identity["session_id"], "gc-new")
+
+    def test_current_session_selector_falls_back_to_gc_alias(self) -> None:
+        os.environ.pop("GC_SESSION_ID", None)
+        os.environ.pop("GC_SESSION_NAME", None)
+        os.environ["GC_ALIAS"] = "mm-123-sky"
+
+        self.assertEqual(common.current_session_selector(), "mm-123-sky")
+
+    # ------------------------------------------------------------------
+    # reply context discovery
+    # ------------------------------------------------------------------
+
+    def test_find_latest_mattermost_reply_context_uses_latest_event(self) -> None:
+        with mock.patch.object(
+            common,
+            "gc_api_request",
+            return_value={
+                "messages": [
+                    {
+                        "type": "user",
+                        "message": {
+                            "content": "<mattermost-event>\npublish_binding_id: dm:1\npublish_trigger_id: older\n</mattermost-event>"
+                        },
+                    },
+                    {
+                        "type": "user",
+                        "message": {
+                            "content": (
+                                "<mattermost-event>\n"
+                                f"publish_binding_id: room:{CHANNEL_ID}\n"
+                                f"publish_conversation_id: {CHANNEL_ID}\n"
+                                "publish_trigger_id: newer\n"
+                                f"publish_root_post_id: {ROOT_POST_ID}\n"
+                                "</mattermost-event>"
+                            )
+                        },
+                    },
+                ]
+            },
+        ) as gc_api_request:
+            fields = common.find_latest_mattermost_reply_context("corp--sky", tail=5)
+
+        gc_api_request.assert_called_once()
+        self.assertEqual(fields["publish_binding_id"], f"room:{CHANNEL_ID}")
+        self.assertEqual(fields["publish_conversation_id"], CHANNEL_ID)
+        self.assertEqual(fields["publish_trigger_id"], "newer")
+        self.assertEqual(fields["publish_root_post_id"], ROOT_POST_ID)
+
+    def test_find_latest_mattermost_reply_context_falls_back_to_delivered_ingress(self) -> None:
+        common.save_chat_ingress(
+            {
+                "ingress_id": "in-older",
+                "binding_id": "room:old",
+                "conversation_id": "old",
+                "mattermost_post_id": "old-post",
+                "created_at": "2026-04-20T22:35:00Z",
+                "status": "delivered",
+                "targets": [
+                    {
+                        "session_name": "wendy__wendy",
+                        "status": "delivered",
+                        "response": {"id": "mc-ayq6xi"},
+                    }
+                ],
+            }
+        )
+        common.save_chat_ingress(
+            {
+                "ingress_id": "in-newer",
+                "binding_id": f"room:{CHANNEL_ID}",
+                "conversation_id": CHANNEL_ID,
+                "mattermost_post_id": REPLY_POST_ID,
+                "root_post_id": ROOT_POST_ID,
+                "team_id": TEAM_ID,
+                "created_at": "2026-04-20T22:36:00Z",
+                "status": "delivered",
+                "targets": [
+                    {
+                        "session_name": "wendy__wendy",
+                        "status": "delivered",
+                        "response": {"id": "mc-ayq6xi"},
+                    }
+                ],
+            }
+        )
+
+        with mock.patch.object(common, "gc_api_request", return_value={"messages": []}):
+            fields = common.find_latest_mattermost_reply_context("mc-ayq6xi", tail=5)
+
+        self.assertEqual(fields["kind"], common.HUMAN_MESSAGE_EVENT_KIND)
+        self.assertEqual(fields["ingress_receipt_id"], "in-newer")
+        self.assertEqual(fields["publish_binding_id"], f"room:{CHANNEL_ID}")
+        self.assertEqual(fields["publish_conversation_id"], CHANNEL_ID)
+        self.assertEqual(fields["publish_trigger_id"], REPLY_POST_ID)
+        self.assertEqual(fields["publish_root_post_id"], ROOT_POST_ID)
+
+    def test_find_latest_mattermost_reply_context_defaults_root_post_to_trigger(self) -> None:
+        common.save_chat_ingress(
+            {
+                "ingress_id": "in-root",
+                "binding_id": f"room:{CHANNEL_ID}",
+                "conversation_id": CHANNEL_ID,
+                "mattermost_post_id": ROOT_POST_ID,
+                "created_at": "2026-04-20T22:36:00Z",
+                "status": "delivered",
+                "targets": [{"session_name": "corp--sky", "status": "delivered", "response": {"id": "gc-sky"}}],
+            }
+        )
+
+        with mock.patch.object(common, "gc_api_request", return_value={"messages": []}):
+            fields = common.find_latest_mattermost_reply_context("gc-sky", tail=5)
+
+        self.assertEqual(fields["publish_root_post_id"], ROOT_POST_ID)
+
+    # ------------------------------------------------------------------
+    # mention parsing
+    # ------------------------------------------------------------------
+
+    def test_extract_peer_session_mentions_ignores_urls_and_code(self) -> None:
+        mentions = common.extract_peer_session_mentions(
+            "\n".join(
+                [
+                    "Talk to @corp--priya please",
+                    "Ignore https://example.test/@corp--eve here",
+                    "`@corp--lawrence` stays code",
+                    "> @corp--eve is quoted",
+                    "@channel should not route",
+                ]
+            )
+        )
+
+        self.assertEqual(mentions, ["corp--priya"])
+
+    def test_extract_peer_session_mentions_ignores_double_backtick_code_spans(self) -> None:
+        mentions = common.extract_peer_session_mentions("Talk to ``@corp--priya`` later")
+
+        self.assertEqual(mentions, [])
+
+    def test_extract_peer_session_mentions_ignores_fenced_code_blocks(self) -> None:
+        mentions = common.extract_peer_session_mentions("```\n@corp--priya\n```\nnothing here")
+
+        self.assertEqual(mentions, [])
+
+    def test_extract_peer_session_mentions_ignores_reserved_mentions(self) -> None:
+        mentions = common.extract_peer_session_mentions("@here @all @channel @corp--priya")
+
+        self.assertEqual(mentions, ["corp--priya"])
+
+    def test_extract_agent_handles_finds_bare_and_qualified_handles(self) -> None:
+        handles = common.extract_agent_handles("hello @@sky and @@corp/priya")
+
+        self.assertEqual(handles, ["sky", "corp/priya"])
+
+    def test_extract_agent_handles_is_case_insensitive(self) -> None:
+        handles = common.extract_agent_handles("hello @@Sky and @@Corp/Priya")
+
+        self.assertEqual(handles, ["sky", "corp/priya"])
+
+    def test_resolve_at_mentions_skips_reserved_names(self) -> None:
+        self.assertEqual(common.resolve_at_mentions("@alice hi @bob @channel @here"), ["alice", "bob"])
+
+    # ------------------------------------------------------------------
+    # websocket post normalization
+    # ------------------------------------------------------------------
+
+    def test_parse_websocket_post_decodes_json_encoded_post(self) -> None:
+        post = {"id": REPLY_POST_ID, "channel_id": CHANNEL_ID, "message": "hi"}
+
+        self.assertEqual(common.parse_websocket_post({"post": json.dumps(post)}), post)
+        self.assertEqual(common.parse_websocket_post({"post": post}), post)
+        self.assertEqual(common.parse_websocket_post({"post": "{not json"}), {})
+        self.assertEqual(common.parse_websocket_post({}), {})
+
+    def test_post_is_from_bot_matches_user_id_or_props(self) -> None:
+        self.assertTrue(common.post_is_from_bot({"user_id": BOT_USER_ID}, BOT_USER_ID))
+        self.assertTrue(common.post_is_from_bot({"user_id": "u-1", "props": {"from_bot": "true"}}, BOT_USER_ID))
+        self.assertFalse(common.post_is_from_bot({"user_id": "u-1"}, BOT_USER_ID))
+
+    def test_post_is_system_detects_system_messages(self) -> None:
+        self.assertTrue(common.post_is_system({"type": "system_join_channel"}))
+        self.assertFalse(common.post_is_system({"type": ""}))
+
+    def test_post_thread_root_id_falls_back_to_post_id(self) -> None:
+        self.assertEqual(common.post_thread_root_id({"id": ROOT_POST_ID, "root_id": ""}), ROOT_POST_ID)
+        self.assertEqual(common.post_thread_root_id({"id": REPLY_POST_ID, "root_id": ROOT_POST_ID}), ROOT_POST_ID)
+
+    def test_normalize_to_extmsg_message_marks_thread_and_conversation_key(self) -> None:
+        event = {
+            "event": "posted",
+            "data": {
+                "post": json.dumps(
+                    {
+                        "id": REPLY_POST_ID,
+                        "channel_id": CHANNEL_ID,
+                        "root_id": ROOT_POST_ID,
+                        "user_id": "u-1",
+                        "message": "hello there",
+                    }
+                ),
+                "channel_type": "O",
+                "sender_name": "@alice",
+            },
+            "broadcast": {"channel_id": CHANNEL_ID},
+        }
+
+        message = common.normalize_to_extmsg_message(event, TEAM_ID, BOT_USER_ID)
+
+        self.assertEqual(message["provider_message_id"], REPLY_POST_ID)
+        self.assertEqual(message["conversation"]["provider"], "mattermost")
+        self.assertEqual(message["conversation"]["scope_id"], TEAM_ID)
+        self.assertEqual(message["conversation"]["conversation_id"], CHANNEL_ID)
+        self.assertEqual(message["conversation"]["thread_root_id"], ROOT_POST_ID)
+        self.assertEqual(message["conversation"]["conversation_key"], f"{CHANNEL_ID}/{ROOT_POST_ID}")
+        self.assertEqual(message["conversation"]["kind"], "thread")
+        self.assertEqual(message["actor"]["display_name"], "alice")
+        self.assertFalse(message["actor"]["is_bot"])
+        self.assertEqual(message["text"], "hello there")
+
+    def test_normalize_to_extmsg_message_marks_direct_channels_as_dm(self) -> None:
+        event = {
+            "data": {
+                "post": json.dumps({"id": REPLY_POST_ID, "channel_id": CHANNEL_ID, "user_id": "u-1", "message": "hey"}),
+                "channel_type": "D",
+                "sender_name": "alice",
+            }
+        }
+
+        message = common.normalize_to_extmsg_message(event, "", BOT_USER_ID)
+
+        self.assertEqual(message["conversation"]["kind"], "dm")
+        self.assertEqual(message["conversation"]["scope_id"], "global")
+        self.assertEqual(message["conversation"]["conversation_key"], CHANNEL_ID)
+
+    # ------------------------------------------------------------------
+    # posting
+    # ------------------------------------------------------------------
+
+    def test_post_channel_message_sets_root_id_for_thread_replies(self) -> None:
+        with mock.patch.object(common, "mattermost_api_request", return_value={"id": "post-1"}) as mattermost_api_request:
+            response = common.post_channel_message(CHANNEL_ID, "hello", root_id=ROOT_POST_ID)
+
+        self.assertEqual(response["id"], "post-1")
+        payload = mattermost_api_request.call_args.kwargs["payload"]
+        self.assertEqual(payload["channel_id"], CHANNEL_ID)
+        self.assertEqual(payload["message"], "hello")
+        self.assertEqual(payload["root_id"], ROOT_POST_ID)
+
+    def test_post_channel_message_omits_empty_root_id(self) -> None:
+        with mock.patch.object(common, "mattermost_api_request", return_value={"id": "post-1"}) as mattermost_api_request:
+            common.post_channel_message(CHANNEL_ID, "hello")
+
+        self.assertNotIn("root_id", mattermost_api_request.call_args.kwargs["payload"])
+
+    def test_post_channel_message_caps_attachments_at_five(self) -> None:
+        with mock.patch.object(common, "mattermost_api_request", return_value={"id": "post-1"}) as mattermost_api_request:
+            common.post_channel_message(CHANNEL_ID, "files", file_ids=[f"f{index}" for index in range(8)])
+
+        self.assertEqual(len(mattermost_api_request.call_args.kwargs["payload"]["file_ids"]), 5)
+
+    def test_mattermost_permalink_and_channel_url_require_site_url(self) -> None:
+        self.assertEqual(common.mattermost_permalink("eng", REPLY_POST_ID), "")
+
+        os.environ["GC_MATTERMOST_URL"] = "https://mattermost.test/"
+
+        self.assertEqual(
+            common.mattermost_permalink("eng", REPLY_POST_ID),
+            f"https://mattermost.test/eng/pl/{REPLY_POST_ID}",
+        )
+        self.assertEqual(
+            common.mattermost_channel_url("eng", "town-square"),
+            "https://mattermost.test/eng/channels/town-square",
+        )
+        self.assertEqual(common.mattermost_permalink("", REPLY_POST_ID), "")
+
+    # ------------------------------------------------------------------
+    # publish_binding_message
+    # ------------------------------------------------------------------
+
+    def test_publish_binding_message_requires_remote_post_id(self) -> None:
+        common.set_chat_binding(common.load_config(), "dm", CHANNEL_ID, ["sky"])
+        binding = common.resolve_chat_binding(common.load_config(), f"dm:{CHANNEL_ID}")
+        assert binding is not None
+
+        with mock.patch.object(common, "post_channel_message", return_value={}):
+            with self.assertRaisesRegex(common.MattermostAPIError, "returned no post id"):
+                common.publish_binding_message(binding, "hello humans", trigger_id=ROOT_POST_ID)
+
+    def test_publish_binding_message_room_launch_activates_thread_on_first_publish(self) -> None:
+        config = common.set_room_launcher(common.load_config(), TEAM_ID, CHANNEL_ID)
+        route = common.resolve_publish_route(config, f"launch-room:{CHANNEL_ID}")
+        assert route is not None
+        common.save_room_launch(
+            {
+                "launch_id": f"room-launch:{ROOT_POST_ID}",
+                "launcher_id": f"launch-room:{CHANNEL_ID}",
+                "team_id": TEAM_ID,
+                "conversation_id": CHANNEL_ID,
+                "root_post_id": ROOT_POST_ID,
+                "qualified_handle": "corp/sky",
+                "session_alias": "mm-123-sky",
+            }
+        )
+
+        with mock.patch.object(common, "post_channel_message", return_value={"id": "post-1"}) as post_channel_message:
+            payload = common.publish_binding_message(
+                route,
+                "hello humans",
+                trigger_id=ROOT_POST_ID,
+                source_context={
+                    "kind": common.HUMAN_MESSAGE_EVENT_KIND,
+                    "publish_launch_id": f"room-launch:{ROOT_POST_ID}",
+                },
+            )
+
+        post_channel_message.assert_called_once_with(
+            CHANNEL_ID,
+            "hello humans",
+            root_id=ROOT_POST_ID,
+            file_ids=None,
+        )
+        self.assertEqual(payload["record"]["conversation_id"], CHANNEL_ID)
+        self.assertEqual(payload["record"]["root_post_id"], ROOT_POST_ID)
+        self.assertEqual(payload["record"]["launch_id"], f"room-launch:{ROOT_POST_ID}")
+        launch = common.load_room_launch(f"room-launch:{ROOT_POST_ID}")
+        assert launch is not None
+        self.assertEqual(launch["state"], "active")
+
+    def test_publish_binding_message_records_room_launch_message_target(self) -> None:
+        config = common.set_room_launcher(common.load_config(), TEAM_ID, CHANNEL_ID)
+        route = common.resolve_publish_route(config, f"launch-room:{CHANNEL_ID}")
+        assert route is not None
+        common.save_room_launch(
+            {
+                "launch_id": "room-launch:target",
+                "launcher_id": f"launch-room:{CHANNEL_ID}",
+                "team_id": TEAM_ID,
+                "conversation_id": CHANNEL_ID,
+                "root_post_id": ROOT_POST_ID,
+                "qualified_handle": "corp/sky",
+                "session_alias": "mm-123-sky",
+                "session_name": "mm-sky",
+                "state": "active",
+                "participants": {
+                    "corp/sky": {
+                        "qualified_handle": "corp/sky",
+                        "session_alias": "mm-123-sky",
+                        "session_name": "mm-sky",
+                        "session_id": "gc-sky",
+                    }
+                },
+            }
+        )
+
+        with mock.patch.object(common, "post_channel_message", return_value={"id": "post-launch"}):
+            payload = common.publish_binding_message(
+                route,
+                "hello humans",
+                source_context={
+                    "kind": common.HUMAN_MESSAGE_EVENT_KIND,
+                    "publish_launch_id": "room-launch:target",
+                },
+                source_session_name="mm-sky",
+                source_session_id="gc-sky",
+            )
+
+        self.assertEqual(payload["record"]["remote_message_id"], "post-launch")
+        self.assertEqual(payload["record"]["source_qualified_handle"], "corp/sky")
+        launch = common.load_room_launch("room-launch:target")
+        assert launch is not None
+        self.assertEqual(launch["message_targets"]["post-launch"], "corp/sky")
+
+    def test_publish_binding_message_room_launch_rejects_foreign_conversation_override(self) -> None:
+        config = common.set_room_launcher(common.load_config(), TEAM_ID, CHANNEL_ID)
+        route = common.resolve_publish_route(config, f"launch-room:{CHANNEL_ID}")
+        assert route is not None
+        common.save_room_launch(
+            {
+                "launch_id": "room-launch:foreign",
+                "launcher_id": f"launch-room:{CHANNEL_ID}",
+                "team_id": TEAM_ID,
+                "conversation_id": CHANNEL_ID,
+                "root_post_id": ROOT_POST_ID,
+                "qualified_handle": "corp/sky",
+                "state": "active",
+            }
+        )
+
+        with mock.patch.object(common, "post_channel_message") as post_channel_message:
+            with self.assertRaisesRegex(ValueError, "must match the launch channel"):
+                common.publish_binding_message(
+                    route,
+                    "hello",
+                    requested_conversation_id=OTHER_CHANNEL_ID,
+                    source_context={"kind": common.HUMAN_MESSAGE_EVENT_KIND, "publish_launch_id": "room-launch:foreign"},
+                )
+
+        post_channel_message.assert_not_called()
+
+    def test_publish_binding_message_does_not_record_target_for_non_launch_binding(self) -> None:
+        common.set_chat_binding(common.load_config(), "room", CHANNEL_ID, ["corp--sky"], TEAM_ID)
+        binding = common.resolve_chat_binding(common.load_config(), f"room:{CHANNEL_ID}")
+        assert binding is not None
+        common.save_room_launch(
+            {
+                "launch_id": "room-launch:untouched",
+                "launcher_id": f"launch-room:{CHANNEL_ID}",
+                "team_id": TEAM_ID,
+                "conversation_id": CHANNEL_ID,
+                "root_post_id": ROOT_POST_ID,
+                "qualified_handle": "corp/sky",
+                "session_alias": "mm-123-sky",
+                "session_name": "mm-sky",
+                "state": "active",
+                "participants": {
+                    "corp/sky": {
+                        "qualified_handle": "corp/sky",
+                        "session_alias": "mm-123-sky",
+                        "session_name": "mm-sky",
+                        "session_id": "gc-sky",
+                    }
+                },
+            }
+        )
+
+        with mock.patch.object(common, "post_channel_message", return_value={"id": "post-root"}):
+            common.publish_binding_message(
+                binding,
+                "root-room note",
+                source_context={"kind": common.HUMAN_MESSAGE_EVENT_KIND, "publish_launch_id": "room-launch:untouched"},
+                source_session_name="mm-sky",
+                source_session_id="gc-sky",
+            )
+
+        launch = common.load_room_launch("room-launch:untouched")
+        assert launch is not None
+        self.assertEqual(launch["message_targets"], {ROOT_POST_ID: "corp/sky"})
+
+    def test_publish_binding_message_does_not_fan_out_to_peers(self) -> None:
+        common.set_chat_binding(
+            common.load_config(),
+            "room",
+            CHANNEL_ID,
+            ["corp--sky", "corp--priya"],
+            TEAM_ID,
+            policy={"peer_fanout_enabled": True},
+        )
+        binding = common.resolve_chat_binding(common.load_config(), f"room:{CHANNEL_ID}")
+        assert binding is not None
+        os.environ["GC_SESSION_NAME"] = "corp--sky"
+        os.environ["GC_SESSION_ID"] = "gc-sky"
+
+        with mock.patch.object(common, "post_channel_message", return_value={"id": "post-1"}), mock.patch.object(
+            common, "deliver_session_message"
+        ) as deliver_session_message:
+            payload = common.publish_binding_message(
+                binding,
+                "@corp--priya hello",
+                trigger_id=ROOT_POST_ID,
+                source_context={
+                    "kind": common.HUMAN_MESSAGE_EVENT_KIND,
+                    "ingress_receipt_id": "in-9",
+                    "publish_binding_id": f"room:{CHANNEL_ID}",
+                    "publish_conversation_id": CHANNEL_ID,
+                    "publish_trigger_id": ROOT_POST_ID,
+                    "publish_root_post_id": ROOT_POST_ID,
+                },
+            )
+
+        record = payload["record"]
+        self.assertEqual(record["source_event_kind"], common.HUMAN_MESSAGE_EVENT_KIND)
+        self.assertEqual(record["root_ingress_receipt_id"], "in-9")
+        self.assertEqual(record["source_session_name"], "corp--sky")
+        self.assertEqual(record["source_session_id"], "gc-sky")
+        self.assertNotIn("peer_delivery", record)
+        deliver_session_message.assert_not_called()
+
+    def test_publish_binding_message_uses_source_root_post_hint(self) -> None:
+        common.set_chat_binding(common.load_config(), "room", CHANNEL_ID, ["corp--sky"], TEAM_ID)
+        binding = common.resolve_chat_binding(common.load_config(), f"room:{CHANNEL_ID}")
+        assert binding is not None
+
+        with mock.patch.object(common, "post_channel_message", return_value={"id": "post-1"}) as post_channel_message, mock.patch.object(
+            common,
+            "mattermost_api_request",
+            return_value={"id": ROOT_POST_ID, "channel_id": CHANNEL_ID, "root_id": ""},
+        ):
+            common.publish_binding_message(
+                binding,
+                "hello",
+                source_context={
+                    "kind": common.HUMAN_MESSAGE_EVENT_KIND,
+                    "publish_root_post_id": ROOT_POST_ID,
+                },
+            )
+
+        post_channel_message.assert_called_once_with(CHANNEL_ID, "hello", root_id=ROOT_POST_ID, file_ids=None)
+
+    def test_publish_binding_message_resolves_source_name_from_id_only_env(self) -> None:
+        common.set_chat_binding(common.load_config(), "room", CHANNEL_ID, ["corp--sky", "corp--priya"], TEAM_ID)
+        binding = common.resolve_chat_binding(common.load_config(), f"room:{CHANNEL_ID}")
+        assert binding is not None
+        os.environ.pop("GC_SESSION_NAME", None)
+        os.environ["GC_SESSION_ID"] = "gc-sky"
+
+        with mock.patch.object(common, "post_channel_message", return_value={"id": "post-1"}), mock.patch.object(
+            common,
+            "list_city_sessions",
+            return_value=[
+                {"id": "gc-sky", "session_name": "corp--sky", "state": "active", "running": True, "created_at": "2026-03-21T00:00:00Z"},
+                {"id": "gc-priya", "session_name": "corp--priya", "state": "active", "running": True, "created_at": "2026-03-21T00:00:00Z"},
+            ],
+        ):
+            payload = common.publish_binding_message(binding, "hello", trigger_id=ROOT_POST_ID)
+
+        self.assertEqual(payload["record"]["source_session_name"], "corp--sky")
+        self.assertEqual(payload["record"]["source_session_id"], "gc-sky")
+
+    # ------------------------------------------------------------------
+    # room launch records
+    # ------------------------------------------------------------------
+
+    def test_normalize_room_launch_record_seeds_root_message_target(self) -> None:
+        launch = common.save_room_launch(
+            {
+                "launch_id": "room-launch:seed",
+                "team_id": TEAM_ID,
+                "conversation_id": CHANNEL_ID,
+                "root_post_id": ROOT_POST_ID,
+                "qualified_handle": "corp/sky",
+                "session_alias": "mm-123-sky",
+            }
+        )
+
+        self.assertEqual(launch["message_targets"], {ROOT_POST_ID: "corp/sky"})
+        self.assertEqual(launch["message_target_order"], [ROOT_POST_ID])
+        self.assertEqual(launch["last_addressed_qualified_handle"], "corp/sky")
+        self.assertEqual(common.room_launch_message_target_handle(launch, ROOT_POST_ID), "corp/sky")
+
+    def test_ensure_room_launch_thread_promotes_state_once(self) -> None:
+        config = common.set_room_launcher(common.load_config(), TEAM_ID, CHANNEL_ID)
+        binding = common.resolve_publish_route(config, f"launch-room:{CHANNEL_ID}")
+        assert binding is not None
+        common.save_room_launch(
+            {
+                "launch_id": "room-launch:promote",
+                "team_id": TEAM_ID,
+                "conversation_id": CHANNEL_ID,
+                "root_post_id": ROOT_POST_ID,
+                "qualified_handle": "corp/sky",
+            }
+        )
+
+        current, promoted = common.ensure_room_launch_thread(binding, "room-launch:promote")
+        self.assertTrue(promoted)
+        self.assertEqual(current["state"], "active")
+
+        current, promoted = common.ensure_room_launch_thread(binding, "room-launch:promote")
+        self.assertFalse(promoted)
+
+    def test_ensure_room_launch_thread_requires_routing_metadata(self) -> None:
+        config = common.set_room_launcher(common.load_config(), TEAM_ID, CHANNEL_ID)
+        binding = common.resolve_publish_route(config, f"launch-room:{CHANNEL_ID}")
+        assert binding is not None
+        common.save_room_launch(
+            {
+                "launch_id": "room-launch:incomplete",
+                "team_id": TEAM_ID,
+                "conversation_id": CHANNEL_ID,
+                "qualified_handle": "corp/sky",
+            }
+        )
+
+        with self.assertRaisesRegex(ValueError, "missing thread routing metadata"):
+            common.ensure_room_launch_thread(binding, "room-launch:incomplete")
+
+    def test_touch_room_launch_sets_last_activity_at(self) -> None:
+        common.save_room_launch(
+            {
+                "launch_id": "room-launch:activity",
+                "launcher_id": f"launch-room:{CHANNEL_ID}",
+                "team_id": TEAM_ID,
+                "conversation_id": CHANNEL_ID,
+                "root_post_id": ROOT_POST_ID,
+                "qualified_handle": "corp/sky",
+                "session_alias": "mm-123-sky",
+            }
+        )
+
+        touched = common.touch_room_launch("room-launch:activity")
+
+        assert touched is not None
+        self.assertTrue(str(touched.get("last_activity_at", "")).strip())
+
+    def test_set_room_launch_last_addressed_requires_known_participant(self) -> None:
+        common.save_room_launch(
+            {
+                "launch_id": "room-launch:cursor",
+                "team_id": TEAM_ID,
+                "conversation_id": CHANNEL_ID,
+                "root_post_id": ROOT_POST_ID,
+                "qualified_handle": "corp/sky",
+                "participants": {
+                    "corp/sky": {"qualified_handle": "corp/sky", "session_name": "mm-sky"},
+                    "corp/priya": {"qualified_handle": "corp/priya", "session_name": "mm-priya"},
+                },
+            }
+        )
+
+        updated = common.set_room_launch_last_addressed("room-launch:cursor", "corp/priya")
+        assert updated is not None
+        self.assertEqual(updated["last_addressed_qualified_handle"], "corp/priya")
+
+        unchanged = common.set_room_launch_last_addressed("room-launch:cursor", "corp/nobody")
+        assert unchanged is not None
+        self.assertEqual(unchanged["last_addressed_qualified_handle"], "corp/priya")
+
+    def test_prune_room_launches_keeps_recent_thread_routes(self) -> None:
+        common.save_room_launch(
+            {
+                "launch_id": "room-launch:recent",
+                "launcher_id": f"launch-room:{CHANNEL_ID}",
+                "team_id": TEAM_ID,
+                "conversation_id": CHANNEL_ID,
+                "root_post_id": ROOT_POST_ID,
+                "qualified_handle": "corp/sky",
+                "session_alias": "mm-123-sky",
+            }
+        )
+        path = common.room_launch_path("room-launch:recent")
+        aged_but_recent = time.time() - common.CHAT_INGRESS_RETENTION_SECONDS - 10
+        os.utime(path, (aged_but_recent, aged_but_recent))
+
+        common.prune_room_launches()
+
+        self.assertIsNotNone(common.load_room_launch("room-launch:recent"))
+
+    def test_room_launch_session_alias_is_deterministic_and_prefixed(self) -> None:
+        alias = common.room_launch_session_alias(TEAM_ID, CHANNEL_ID, ROOT_POST_ID, "corp/sky")
+
+        self.assertTrue(alias.startswith("mm-"))
+        self.assertTrue(alias.endswith("corp-sky"))
+        self.assertEqual(alias, common.room_launch_session_alias(TEAM_ID, CHANNEL_ID, ROOT_POST_ID, "Corp/Sky"))
+
+    # ------------------------------------------------------------------
+    # room launch sessions
+    # ------------------------------------------------------------------
+
+    def test_ensure_room_launch_session_recreates_non_routable_alias_match(self) -> None:
+        launch = {
+            "launch_id": "room-launch:revive",
+            "qualified_handle": "corp/sky",
+            "session_alias": "mm-123-sky",
+            "from_display": "alice",
+        }
+
+        with mock.patch.object(
+            common,
+            "list_city_sessions",
+            return_value=[
+                {
+                    "id": "gc-old",
+                    "alias": "mm-123-sky",
+                    "session_name": "mm-old-sky",
+                    "state": "closed",
+                    "running": False,
+                    "created_at": "2026-03-20T00:00:00Z",
+                }
+            ],
+        ), mock.patch.object(
+            common,
+            "create_agent_session",
+            return_value={"id": "gc-new", "session_name": "mm-new-sky", "alias": "mm-123-sky"},
+        ) as create_agent_session, mock.patch.object(
+            common,
+            "deliver_session_message",
+            return_value={"status": "accepted", "id": "gc-new"},
+        ):
+            current = common.ensure_room_launch_session(launch)
+
+        create_agent_session.assert_called_once()
+        self.assertEqual(current["session_id"], "gc-new")
+        self.assertEqual(current["session_name"], "mm-new-sky")
+
+    def test_ensure_room_launch_session_hydrates_routable_identity_after_create(self) -> None:
+        launch = {
+            "launch_id": "room-launch:hydrate",
+            "qualified_handle": "corp/sky",
+            "session_alias": "mm-123-sky",
+            "from_display": "alice",
+        }
+
+        sessions_first: list[dict[str, object]] = [
+            {
+                "id": "gc-old",
+                "alias": "mm-123-sky",
+                "session_name": "mm-old-sky",
+                "state": "closed",
+                "running": False,
+                "created_at": "2026-03-20T00:00:00Z",
+            }
+        ]
+        sessions_second: list[dict[str, object]] = [
+            {
+                "id": "gc-new",
+                "alias": "mm-123-sky",
+                "session_name": "mm-new-sky",
+                "state": "active",
+                "running": True,
+                "created_at": "2026-03-22T00:00:00Z",
+            }
+        ]
+        calls = {"count": 0}
+
+        def list_sessions(*, state: str = "all") -> list[dict[str, object]]:
+            self.assertEqual(state, "all")
+            calls["count"] += 1
+            if calls["count"] < 4:
+                return sessions_first
+            return sessions_second
+
+        with mock.patch.object(common, "list_city_sessions", side_effect=list_sessions), mock.patch.object(
+            common,
+            "create_agent_session",
+            return_value={"alias": "mm-123-sky"},
+        ) as create_agent_session, mock.patch.object(
+            common,
+            "deliver_session_message",
+            return_value={"status": "accepted", "id": "gc-new"},
+        ), mock.patch.object(common.time, "sleep"):
+            current = common.ensure_room_launch_session(launch)
+
+        create_agent_session.assert_called_once()
+        self.assertEqual(current["session_id"], "gc-new")
+        self.assertEqual(current["session_name"], "mm-new-sky")
+
+    def test_ensure_room_launch_session_hydrates_routable_identity_after_longer_async_delay(self) -> None:
+        launch = {
+            "launch_id": "room-launch:slow-hydrate",
+            "qualified_handle": "corp/maya",
+            "session_alias": "mm-123-maya",
+            "from_display": "alice",
+        }
+
+        calls = {"count": 0}
+
+        def list_sessions(*, state: str = "all") -> list[dict[str, object]]:
+            self.assertEqual(state, "all")
+            calls["count"] += 1
+            if calls["count"] < 25:
+                return []
+            return [
+                {
+                    "id": "gc-maya",
+                    "alias": "mm-123-maya",
+                    "session_name": "s-gc-maya",
+                    "state": "active",
+                    "running": True,
+                    "created_at": "2026-03-23T00:00:00Z",
+                }
+            ]
+
+        with mock.patch.object(common, "list_city_sessions", side_effect=list_sessions), mock.patch.object(
+            common,
+            "create_agent_session",
+            return_value={"alias": "mm-123-maya"},
+        ) as create_agent_session, mock.patch.object(
+            common,
+            "deliver_session_message",
+            return_value={"status": "accepted", "id": "gc-maya"},
+        ), mock.patch.object(common.time, "sleep"):
+            current = common.ensure_room_launch_session(launch)
+
+        create_agent_session.assert_called_once()
+        self.assertGreaterEqual(calls["count"], 25)
+        self.assertEqual(current["session_id"], "gc-maya")
+        self.assertEqual(current["session_name"], "s-gc-maya")
+
+    def test_ensure_room_launch_session_primes_new_session_before_first_human_turn(self) -> None:
+        launch = {
+            "launch_id": "room-launch:prime",
+            "qualified_handle": "corp/sky",
+            "session_alias": "mm-123-sky",
+            "from_display": "alice",
+        }
+
+        with mock.patch.object(common, "list_city_sessions", return_value=[]), mock.patch.object(
+            common,
+            "create_agent_session",
+            return_value={"id": "gc-new", "session_name": "mm-new-sky", "alias": "mm-123-sky"},
+        ), mock.patch.object(
+            common,
+            "deliver_session_message",
+            return_value={"status": "accepted", "id": "gc-new"},
+        ) as deliver_session_message:
+            current = common.ensure_room_launch_session(launch)
+
+        deliver_session_message.assert_called_once()
+        self.assertEqual(deliver_session_message.call_args.args[0], "mm-new-sky")
+        primer_message = deliver_session_message.call_args.args[1]
+        self.assertIn("<mattermost-launch-primer>", primer_message)
+        self.assertIn("gc mattermost reply-current --body-file <path>", primer_message)
+        self.assertEqual(
+            deliver_session_message.call_args.kwargs["idempotency_key"],
+            "room-launch:prime:primer:corp/sky:v1",
+        )
+        participant = current["participants"]["corp/sky"]
+        self.assertEqual(participant["primer_version"], common.ROOM_LAUNCH_PRIMER_VERSION)
+        self.assertTrue(str(participant.get("primed_at", "")).strip())
+
+    def test_ensure_room_launch_session_raises_when_created_identity_never_becomes_routable(self) -> None:
+        launch = {
+            "launch_id": "room-launch:stuck",
+            "qualified_handle": "corp/sky",
+            "session_alias": "mm-123-sky",
+            "from_display": "alice",
+        }
+
+        with mock.patch.object(common, "list_city_sessions", return_value=[]), mock.patch.object(
+            common,
+            "create_agent_session",
+            return_value={"alias": "mm-123-sky"},
+        ), mock.patch.object(common.time, "sleep"), mock.patch.object(
+            common, "ROOM_LAUNCH_IDENTITY_RESOLVE_TIMEOUT_SECONDS", 0.01
+        ):
+            with self.assertRaisesRegex(common.GCAPIError, "created launch session is not routable yet"):
+                common.ensure_room_launch_session(launch)
+
+    def test_ensure_room_launch_session_for_handle_creates_secondary_participant(self) -> None:
+        common.save_room_launch(
+            {
+                "launch_id": "room-launch:thread-join",
+                "launcher_id": f"launch-room:{CHANNEL_ID}",
+                "team_id": TEAM_ID,
+                "conversation_id": CHANNEL_ID,
+                "root_post_id": ROOT_POST_ID,
+                "qualified_handle": "corp/sky",
+                "session_alias": "mm-123-sky",
+                "session_name": "mm-sky",
+            }
+        )
+
+        with mock.patch.object(common, "list_city_sessions", return_value=[]), mock.patch.object(
+            common,
+            "create_agent_session",
+            return_value={"id": "gc-alex", "session_name": "mm-alex", "alias": "mm-456-alex"},
+        ) as create_agent_session, mock.patch.object(
+            common,
+            "deliver_session_message",
+            return_value={"status": "accepted", "id": "gc-alex"},
+        ):
+            current, participant = common.ensure_room_launch_session_for_handle(
+                common.load_room_launch("room-launch:thread-join") or {},
+                "corp/alex",
+            )
+
+        create_agent_session.assert_called_once()
+        self.assertEqual(participant["session_name"], "mm-alex")
+        self.assertEqual(current["participants"]["corp/alex"]["session_alias"], "mm-456-alex")
+        self.assertEqual(current["qualified_handle"], "corp/sky")
+
+    def test_ensure_room_launch_session_for_handle_does_not_reprime_current_participant(self) -> None:
+        common.save_room_launch(
+            {
+                "launch_id": "room-launch:no-reprime",
+                "launcher_id": f"launch-room:{CHANNEL_ID}",
+                "team_id": TEAM_ID,
+                "conversation_id": CHANNEL_ID,
+                "root_post_id": ROOT_POST_ID,
+                "qualified_handle": "corp/sky",
+                "participants": {
+                    "corp/sky": {
+                        "qualified_handle": "corp/sky",
+                        "session_alias": "mm-123-sky",
+                        "session_name": "mm-sky",
+                        "session_id": "gc-sky",
+                        "primer_version": common.ROOM_LAUNCH_PRIMER_VERSION,
+                        "primer_identity": "gc-sky",
+                        "primed_at": "2026-03-22T00:00:00Z",
+                    }
+                },
+                "session_alias": "mm-123-sky",
+                "session_name": "mm-sky",
+                "session_id": "gc-sky",
+            }
+        )
+
+        with mock.patch.object(
+            common,
+            "list_city_sessions",
+            return_value=[
+                {
+                    "id": "gc-sky",
+                    "alias": "mm-123-sky",
+                    "session_name": "mm-sky",
+                    "state": "active",
+                    "running": True,
+                    "created_at": "2026-03-22T00:00:00Z",
+                }
+            ],
+        ), mock.patch.object(common, "deliver_session_message") as deliver_session_message:
+            current, participant = common.ensure_room_launch_session_for_handle(
+                common.load_room_launch("room-launch:no-reprime") or {},
+                "corp/sky",
+            )
+
+        deliver_session_message.assert_not_called()
+        self.assertEqual(participant["primer_version"], common.ROOM_LAUNCH_PRIMER_VERSION)
+        self.assertEqual(current["participants"]["corp/sky"]["primed_at"], "2026-03-22T00:00:00Z")
+
+    def test_room_launch_primer_message_mentions_peer_fanout_only_when_enabled(self) -> None:
+        launch = {"launch_id": "room-launch:primer", "qualified_handle": "corp/sky", "conversation_id": CHANNEL_ID}
+        participant = {"qualified_handle": "corp/sky", "session_name": "mm-sky"}
+
+        enabled = common.room_launch_primer_message(launch, participant, peer_fanout_enabled=True)
+        disabled = common.room_launch_primer_message(launch, participant, peer_fanout_enabled=False)
+
+        self.assertIn("@@rig/alias", enabled)
+        self.assertNotIn("@@rig/alias", disabled)
+        self.assertIn("root_id set to the launch root post id", disabled)
+
+    # ------------------------------------------------------------------
+    # peer budgets + retry
+    # ------------------------------------------------------------------
+
+    def test_peer_root_budget_index_tracks_root_counts(self) -> None:
+        now = common.utcnow()
+        common.save_chat_publish(
+            {
+                "publish_id": "mattermost-publish-1",
+                "binding_id": f"room:{CHANNEL_ID}",
+                "root_ingress_receipt_id": "in-1",
+                "source_session_name": "corp--sky",
+                "source_event_kind": common.PEER_PUBLICATION_EVENT_KIND,
+                "created_at": now,
+                "peer_delivery": {"frozen_targets": ["corp--priya", "corp--eve"]},
+            }
+        )
+        common.save_chat_publish(
+            {
+                "publish_id": "mattermost-publish-2",
+                "binding_id": f"room:{CHANNEL_ID}",
+                "root_ingress_receipt_id": "in-1",
+                "source_session_name": "corp--sky",
+                "source_event_kind": common.PEER_PUBLICATION_EVENT_KIND,
+                "created_at": now,
+                "peer_delivery": {"frozen_targets": ["corp--lawrence"]},
+            }
+        )
+
+        self.assertEqual(common._count_root_peer_triggered_publishes(f"room:{CHANNEL_ID}", "in-1", "corp--sky"), 2)
+        self.assertEqual(common._count_root_peer_deliveries_from_index(f"room:{CHANNEL_ID}", "in-1"), 3)
+
+    def test_retry_peer_fanout_redrives_failed_target_without_reposting(self) -> None:
+        common.set_chat_binding(
+            common.load_config(),
+            "room",
+            CHANNEL_ID,
+            ["corp--sky", "corp--priya"],
+            TEAM_ID,
+            policy={"peer_fanout_enabled": True},
+        )
+        common.save_chat_publish(
+            {
+                "publish_id": "mattermost-publish-1",
+                "binding_id": f"room:{CHANNEL_ID}",
+                "binding_kind": "room",
+                "binding_conversation_id": CHANNEL_ID,
+                "conversation_id": CHANNEL_ID,
+                "team_id": TEAM_ID,
+                "source_session_name": "corp--sky",
+                "source_session_id": "gc-sky",
+                "source_event_kind": common.HUMAN_MESSAGE_EVENT_KIND,
+                "root_ingress_receipt_id": "in-9",
+                "body": "@corp--priya hello",
+                "remote_message_id": "post-1",
+                "root_post_id": ROOT_POST_ID,
+                "peer_delivery": {
+                    "phase": "peer_fanout_partial_failure",
+                    "status": "partial_failure",
+                    "delivery": "targeted",
+                    "mentioned_session_names": ["corp--priya"],
+                    "frozen_targets": ["corp--priya"],
+                    "targets": [
+                        {
+                            "session_name": "corp--priya",
+                            "status": "failed_retryable",
+                            "attempt_count": 1,
+                            "idempotency_key": f"peer_publish:mattermost-publish-1:binding:room:{CHANNEL_ID}:target:corp--priya",
+                            "attempts": [],
+                        }
+                    ],
+                    "budget_snapshot": {},
+                },
+            }
+        )
+
+        with mock.patch.object(
+            common,
+            "deliver_session_message",
+            return_value={"status": "accepted", "id": "gc-priya"},
+        ) as deliver_session_message, mock.patch.object(common, "post_channel_message") as post_channel_message:
+            record = common.retry_peer_fanout("mattermost-publish-1")
+
+        self.assertEqual(record["peer_delivery"]["status"], "delivered")
+        post_channel_message.assert_not_called()
+        deliver_session_message.assert_called_once()
+        envelope = deliver_session_message.call_args.args[1]
+        self.assertIn(f"channel_id: {CHANNEL_ID}", envelope)
+        self.assertIn(f"root_id: {ROOT_POST_ID}", envelope)
+        self.assertIn(f"conversation_key: {CHANNEL_ID}/{ROOT_POST_ID}", envelope)
+
+    def test_retry_peer_fanout_room_launch_preserves_launch_context(self) -> None:
+        common.set_room_launcher(common.load_config(), TEAM_ID, CHANNEL_ID)
+        common.save_room_launch(
+            {
+                "launch_id": "room-launch:retry",
+                "team_id": TEAM_ID,
+                "conversation_id": CHANNEL_ID,
+                "root_post_id": ROOT_POST_ID,
+                "qualified_handle": "corp/sky",
+                "session_alias": "mm-thread-corp-sky",
+                "session_id": "gc-sky",
+                "session_name": "",
+                "participants": {
+                    "corp/sky": {
+                        "qualified_handle": "corp/sky",
+                        "session_alias": "mm-thread-corp-sky",
+                        "session_id": "gc-sky",
+                        "session_name": "",
+                    },
+                    "corp/priya": {
+                        "qualified_handle": "corp/priya",
+                        "session_alias": "mm-thread-corp-priya",
+                        "session_id": "gc-priya",
+                        "session_name": "s-gc-priya",
+                    },
+                },
+                "state": "active",
+            }
+        )
+        common.save_chat_publish(
+            {
+                "publish_id": "mattermost-publish-launch",
+                "binding_id": f"launch-room:{CHANNEL_ID}",
+                "binding_kind": "room",
+                "binding_conversation_id": CHANNEL_ID,
+                "conversation_id": CHANNEL_ID,
+                "team_id": TEAM_ID,
+                "source_session_name": "",
+                "source_session_id": "gc-sky",
+                "source_event_kind": common.HUMAN_MESSAGE_EVENT_KIND,
+                "root_ingress_receipt_id": "in-77",
+                "launch_id": "room-launch:retry",
+                "body": "@@corp/priya hello",
+                "remote_message_id": "post-77",
+                "root_post_id": ROOT_POST_ID,
+                "peer_delivery": {
+                    "phase": "peer_fanout_partial_failure",
+                    "status": "partial_failure",
+                    "delivery": "targeted",
+                    "mentioned_session_names": ["s-gc-priya"],
+                    "frozen_targets": ["s-gc-priya"],
+                    "targets": [
+                        {
+                            "session_name": "s-gc-priya",
+                            "status": "failed_retryable",
+                            "attempt_count": 1,
+                            "idempotency_key": f"peer_publish:mattermost-publish-launch:binding:launch-room:{CHANNEL_ID}:target:s-gc-priya",
+                            "attempts": [],
+                        }
+                    ],
+                    "budget_snapshot": {},
+                },
+            }
+        )
+
+        with mock.patch.object(common, "list_city_sessions", return_value=[]), mock.patch.object(
+            common,
+            "deliver_session_message",
+            return_value={"status": "accepted", "id": "gc-priya"},
+        ) as deliver_session_message, mock.patch.object(common, "post_channel_message") as post_channel_message:
+            record = common.retry_peer_fanout("mattermost-publish-launch")
+
+        self.assertEqual(record["peer_delivery"]["status"], "delivered")
+        post_channel_message.assert_not_called()
+        deliver_session_message.assert_called_once()
+        envelope = deliver_session_message.call_args.args[1]
+        self.assertIn("publish_launch_id: room-launch:retry", envelope)
+        self.assertIn("launch_id: room-launch:retry", envelope)
+        self.assertIn("launch_qualified_handle: corp/priya", envelope)
+        self.assertIn("thread_participants_json:", envelope)
+
+    def test_retry_peer_fanout_requires_known_publish(self) -> None:
+        with self.assertRaisesRegex(ValueError, "publish not found"):
+            common.retry_peer_fanout("mattermost-publish-missing")
+
+    def test_peer_delivery_exit_code_flags_partial_failures(self) -> None:
+        healthy = {"peer_delivery": {"phase": "peer_fanout_complete", "status": "delivered", "targets": []}}
+        broken = {
+            "peer_delivery": {
+                "phase": "peer_fanout_partial_failure",
+                "status": "partial_failure",
+                "targets": [{"session_name": "corp--priya", "status": "failed_retryable"}],
+            }
+        }
+
+        self.assertEqual(common.peer_delivery_exit_code(healthy), 0)
+        self.assertEqual(common.peer_delivery_exit_code(broken), 2)
+
+    # ------------------------------------------------------------------
+    # mattermost http plumbing
+    # ------------------------------------------------------------------
+
+    def test_mattermost_api_request_retries_after_rate_limit(self) -> None:
+        os.environ["GC_MATTERMOST_URL"] = "https://mattermost.test"
+        rate_limited = urllib.error.HTTPError(
+            "https://mattermost.test/api/v4/channels/1",
+            429,
+            "Too Many Requests",
+            {"Retry-After": "0"},
+            io.BytesIO(b'{"id": "api.context.rate_limit"}'),
+        )
+        success = mock.Mock()
+        success.__enter__ = mock.Mock(return_value=mock.Mock(read=mock.Mock(return_value=b'{"ok": true}')))
+        success.__exit__ = mock.Mock(return_value=False)
+
+        with mock.patch.object(
+            common.urllib.request, "urlopen", side_effect=[rate_limited, success]
+        ) as urlopen, mock.patch.object(common.time, "sleep") as sleep:
+            payload = common.mattermost_api_request("GET", "/channels/1", bot_token="token")
+
+        self.assertEqual(payload, {"ok": True})
+        self.assertEqual(urlopen.call_count, 2)
+        sleep.assert_called_once_with(0.0)
+
+    def test_mattermost_api_request_raises_with_status_code(self) -> None:
+        os.environ["GC_MATTERMOST_URL"] = "https://mattermost.test"
+        not_found = urllib.error.HTTPError(
+            "https://mattermost.test/api/v4/channels/1",
+            404,
+            "Not Found",
+            {},
+            io.BytesIO(b'{"message": "missing"}'),
+        )
+
+        with mock.patch.object(common.urllib.request, "urlopen", side_effect=not_found):
+            with self.assertRaises(common.MattermostAPIError) as caught:
+                common.mattermost_api_request("GET", "/channels/1", bot_token="token")
+
+        self.assertEqual(caught.exception.status_code, 404)
+
+    def test_mattermost_api_base_requires_site_url(self) -> None:
+        with self.assertRaisesRegex(common.MattermostAPIError, "site_url is not configured"):
+            common.mattermost_api_base()
+
+    def test_mattermost_websocket_url_upgrades_scheme(self) -> None:
+        os.environ["GC_MATTERMOST_URL"] = "https://mattermost.test"
+        self.assertEqual(common.mattermost_websocket_url(), "wss://mattermost.test/api/v4/websocket")
+
+        os.environ["GC_MATTERMOST_URL"] = "http://mattermost.test"
+        self.assertEqual(common.mattermost_websocket_url(), "ws://mattermost.test/api/v4/websocket")
+
+    def test_mattermost_retry_after_seconds_prefers_retry_after_header(self) -> None:
+        exc = urllib.error.HTTPError("https://mattermost.test", 429, "rate", {"Retry-After": "2.5"}, io.BytesIO(b""))
+        self.assertEqual(common.mattermost_retry_after_seconds(exc), 2.5)
+
+    def test_mattermost_retry_after_seconds_falls_back_to_rate_limit_reset(self) -> None:
+        exc = urllib.error.HTTPError("https://mattermost.test", 429, "rate", {"X-RateLimit-Reset": "3"}, io.BytesIO(b""))
+        self.assertEqual(common.mattermost_retry_after_seconds(exc), 3.0)
+
+    def test_mattermost_retry_after_seconds_defaults_to_one_second(self) -> None:
+        exc = urllib.error.HTTPError("https://mattermost.test", 429, "rate", {}, io.BytesIO(b""))
+        self.assertEqual(common.mattermost_retry_after_seconds(exc), 1.0)
+
+    # ------------------------------------------------------------------
+    # policy gates
+    # ------------------------------------------------------------------
+
+    def test_policy_reason_enforces_team_channel_and_role_allowlists(self) -> None:
+        config = common.import_app_config(
+            common.load_config(),
+            {
+                "site_url": "https://mattermost.test",
+                "team_allowlist": [TEAM_ID],
+                "channel_allowlist": [CHANNEL_ID],
+                "channel_role_allowlist": [common.CHANNEL_ADMIN_ROLE],
+            },
+        )
+
+        self.assertEqual(common.policy_reason(config, TEAM_ID, CHANNEL_ID, "channel_user channel_admin"), "")
+        self.assertEqual(common.policy_reason(config, OTHER_TEAM_ID, CHANNEL_ID, ["channel_admin"]), "team_not_allowed")
+        self.assertEqual(common.policy_reason(config, TEAM_ID, OTHER_CHANNEL_ID, ["channel_admin"]), "channel_not_allowed")
+        self.assertEqual(common.policy_reason(config, TEAM_ID, CHANNEL_ID, ["channel_user"]), "channel_role_not_allowed")
+        self.assertEqual(common.policy_reason(config, TEAM_ID, CHANNEL_ID, []), "channel_membership_required")
+
+    def test_policy_reason_allows_everything_without_allowlists(self) -> None:
+        self.assertEqual(common.policy_reason(common.load_config(), TEAM_ID, CHANNEL_ID, []), "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mattermost/tests/test_mattermost_intake_common.py
+++ b/mattermost/tests/test_mattermost_intake_common.py
@@ -538,6 +538,102 @@ class MattermostIntakeCommonTests(unittest.TestCase):
         self.assertIsNone(launch)
         resolve_thread_root_id.assert_not_called()
 
+    def test_default_room_peer_policy_threads_by_default(self) -> None:
+        self.assertTrue(common.default_room_peer_policy()["thread_replies"])
+        self.assertTrue(common.normalize_room_peer_policy(None)["thread_replies"])
+        self.assertTrue(common.normalize_room_peer_policy({})["thread_replies"])
+
+    def test_resolve_publish_destination_room_binding_threads_by_default(self) -> None:
+        common.set_chat_binding(common.load_config(), "room", CHANNEL_ID, ["corp--sky"], TEAM_ID)
+        binding = common.resolve_chat_binding(common.load_config(), f"room:{CHANNEL_ID}")
+        assert binding is not None
+
+        with mock.patch.object(common, "resolve_thread_root_id", return_value=ROOT_POST_ID) as resolve_thread_root_id:
+            channel_id, root_post_id, launch = common.resolve_publish_destination(
+                binding,
+                reply_to_message_id=REPLY_POST_ID,
+            )
+
+        self.assertEqual(channel_id, CHANNEL_ID)
+        self.assertEqual(root_post_id, ROOT_POST_ID)
+        self.assertIsNone(launch)
+        resolve_thread_root_id.assert_called_once_with(CHANNEL_ID, REPLY_POST_ID)
+
+    def test_resolve_publish_destination_room_binding_forces_flat_reply_when_thread_replies_disabled(self) -> None:
+        common.set_chat_binding(
+            common.load_config(),
+            "room",
+            CHANNEL_ID,
+            ["corp--sky"],
+            TEAM_ID,
+            policy={"thread_replies": False},
+        )
+        binding = common.resolve_chat_binding(common.load_config(), f"room:{CHANNEL_ID}")
+        assert binding is not None
+
+        with mock.patch.object(common, "resolve_thread_root_id") as resolve_thread_root_id:
+            channel_id, root_post_id, launch = common.resolve_publish_destination(
+                binding,
+                reply_to_message_id=REPLY_POST_ID,
+            )
+
+        self.assertEqual(channel_id, CHANNEL_ID)
+        self.assertEqual(root_post_id, "")
+        self.assertIsNone(launch)
+        resolve_thread_root_id.assert_not_called()
+
+    def test_set_chat_binding_dm_kind_omits_policy_key_when_not_overridden(self) -> None:
+        common.set_chat_binding(common.load_config(), "dm", CHANNEL_ID, ["sky"], TEAM_ID)
+        binding = common.resolve_chat_binding(common.load_config(), f"dm:{CHANNEL_ID}")
+        assert binding is not None
+
+        self.assertNotIn("policy", binding)
+
+    def test_binding_peer_policy_respects_dm_stored_policy(self) -> None:
+        common.set_chat_binding(
+            common.load_config(),
+            "dm",
+            CHANNEL_ID,
+            ["sky"],
+            TEAM_ID,
+            policy={"thread_replies": False},
+        )
+        binding = common.resolve_chat_binding(common.load_config(), f"dm:{CHANNEL_ID}")
+        assert binding is not None
+
+        self.assertIn("policy", binding)
+        self.assertFalse(common.binding_peer_policy(binding)["thread_replies"])
+
+    def test_binding_peer_policy_dm_without_override_still_threads(self) -> None:
+        common.set_chat_binding(common.load_config(), "dm", CHANNEL_ID, ["sky"], TEAM_ID)
+        binding = common.resolve_chat_binding(common.load_config(), f"dm:{CHANNEL_ID}")
+        assert binding is not None
+
+        self.assertTrue(common.binding_peer_policy(binding)["thread_replies"])
+
+    def test_resolve_publish_destination_dm_binding_forces_flat_reply_when_thread_replies_disabled(self) -> None:
+        common.set_chat_binding(
+            common.load_config(),
+            "dm",
+            CHANNEL_ID,
+            ["sky"],
+            TEAM_ID,
+            policy={"thread_replies": False},
+        )
+        binding = common.resolve_chat_binding(common.load_config(), f"dm:{CHANNEL_ID}")
+        assert binding is not None
+
+        with mock.patch.object(common, "resolve_thread_root_id") as resolve_thread_root_id:
+            channel_id, root_post_id, launch = common.resolve_publish_destination(
+                binding,
+                reply_to_message_id=REPLY_POST_ID,
+            )
+
+        self.assertEqual(channel_id, CHANNEL_ID)
+        self.assertEqual(root_post_id, "")
+        self.assertIsNone(launch)
+        resolve_thread_root_id.assert_not_called()
+
     def test_publish_binding_message_thread_scoped_binding_posts_to_real_channel(self) -> None:
         conversation_id = common.mattermost_conversation_key(CHANNEL_ID, ROOT_POST_ID)
         common.set_chat_binding(common.load_config(), "room", conversation_id, ["corp--sky"], TEAM_ID)

--- a/mattermost/tests/test_mattermost_intake_service.py
+++ b/mattermost/tests/test_mattermost_intake_service.py
@@ -1,0 +1,1952 @@
+from __future__ import annotations
+
+import base64
+import errno
+import json
+import pathlib
+import socket
+import tempfile
+import threading
+import time
+import unittest
+import urllib.parse
+from unittest import mock
+
+import os
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+
+import mattermost_intake_common as common
+import mattermost_intake_service as service
+
+# Mattermost ids are 26-character lowercase alphanumerics; `validate_mattermost_id`
+# rejects anything else, so the fixtures below have to be shaped like real ids.
+TEAM_ID = "team0000000000000000000000"
+OTHER_TEAM_ID = "team1111111111111111111111"
+CHANNEL_ID = "chan0000000000000000000000"
+OTHER_CHANNEL_ID = "chan1111111111111111111111"
+ROOT_ID = "root0000000000000000000000"
+USER_ID = "user0000000000000000000000"
+BOT_USER_ID = "bot00000000000000000000000"
+COMMAND_TOKEN = "tok00000000000000000000000"
+SITE_URL = "https://mattermost.example.com"
+
+
+def unix_http_request(
+    socket_path: str,
+    method: str,
+    path: str,
+    *,
+    body: bytes = b"",
+    headers: dict[str, str] | None = None,
+) -> tuple[int, bytes]:
+    request_headers = {
+        "Host": "localhost",
+        "Connection": "close",
+        "Content-Length": str(len(body)),
+    }
+    if headers:
+        request_headers.update(headers)
+    request_lines = [f"{method} {path} HTTP/1.1", *[f"{key}: {value}" for key, value in request_headers.items()], "", ""]
+    payload = "\r\n".join(request_lines).encode("utf-8") + body
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+        client.connect(socket_path)
+        client.sendall(payload)
+        try:
+            client.shutdown(socket.SHUT_WR)
+        except OSError as exc:
+            # Routes that answer without draining the request body (404, 401)
+            # can close first; macOS then reports ENOTCONN on shutdown.
+            if exc.errno not in {errno.ENOTCONN, errno.EPIPE}:
+                raise
+        chunks: list[bytes] = []
+        while True:
+            chunk = client.recv(4096)
+            if not chunk:
+                break
+            chunks.append(chunk)
+    raw = b"".join(chunks)
+    head, _, response_body = raw.partition(b"\r\n\r\n")
+    status_line = head.splitlines()[0].decode("utf-8")
+    return int(status_line.split()[1]), response_body
+
+
+class MattermostIntakeServiceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self._old_environ = os.environ.copy()
+        for key in (
+            "GC_SERVICE_NAME",
+            "GC_SERVICE_STATE_ROOT",
+            "GC_SERVICE_SECRETS_DIR",
+            "GC_SERVICE_PUBLIC_URL",
+            "GC_SERVICE_SOCKET",
+            "GC_MATTERMOST_URL",
+            "GC_MATTERMOST_API_BASE",
+            "GC_BIN",
+            "GC_CITY_PATH",
+        ):
+            os.environ.pop(key, None)
+        os.environ["GC_CITY_ROOT"] = self.tempdir.name
+        service.LAST_REQUEST_PRUNE_AT = 0.0
+        service.LAST_REQUEST_RECOVERY_AT = 0.0
+        service.PROCESSING_REQUESTS.clear()
+
+    def tearDown(self) -> None:
+        os.environ.clear()
+        os.environ.update(self._old_environ)
+        service.LAST_REQUEST_PRUNE_AT = 0.0
+        service.LAST_REQUEST_RECOVERY_AT = 0.0
+        service.PROCESSING_REQUESTS.clear()
+
+    # ------------------------------------------------------------------
+    # helpers
+    # ------------------------------------------------------------------
+
+    def write_rig_route(self, rig: str) -> None:
+        beads_dir = pathlib.Path(self.tempdir.name, ".beads")
+        beads_dir.mkdir(parents=True, exist_ok=True)
+        pathlib.Path(self.tempdir.name, rig).mkdir(parents=True, exist_ok=True)
+        pathlib.Path(beads_dir, "routes.jsonl").write_text(f'{{"path":"{rig}"}}\n', encoding="utf-8")
+
+    def import_app(self, **overrides: object) -> dict[str, object]:
+        fields: dict[str, object] = {
+            "site_url": SITE_URL,
+            "team_id": TEAM_ID,
+            "bot_user_id": BOT_USER_ID,
+            "command_name": "gc",
+        }
+        fields.update(overrides)
+        return common.import_app_config(common.load_config(), fields)
+
+    def command_form(self, **overrides: str) -> dict[str, str]:
+        form = {
+            "token": COMMAND_TOKEN,
+            "team_id": TEAM_ID,
+            "team_domain": "acme",
+            "channel_id": CHANNEL_ID,
+            "channel_name": "town-square",
+            "root_id": "",
+            "user_id": USER_ID,
+            "user_name": "alice",
+            "command": "/gc",
+            "text": "",
+            "trigger_id": "trigger-1",
+            "response_url": "https://mattermost.example.com/hooks/commands/response",
+        }
+        form.update(overrides)
+        return form
+
+    def command_invocation(self, **overrides: str) -> dict[str, str]:
+        return service.normalize_command_invocation(self.command_form(**overrides))
+
+    def channel_context(self, **overrides: object) -> dict[str, object]:
+        context: dict[str, object] = {
+            "team_id": TEAM_ID,
+            "channel_id": CHANNEL_ID,
+            "root_id": "",
+            "mapping": {},
+            "channel_info": {},
+        }
+        context.update(overrides)
+        return context
+
+    def start_interactions_server(self) -> str:
+        socket_path = pathlib.Path(self.tempdir.name, "mm-intake.sock")
+        os.environ["GC_SERVICE_NAME"] = common.INTERACTIONS_SERVICE_NAME
+        server = service.ThreadingUnixHTTPServer(str(socket_path), service.IntakeHandler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+
+        def stop() -> None:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=1)
+
+        self.addCleanup(stop)
+        deadline = time.time() + 1.0
+        while not socket_path.exists():
+            if time.time() >= deadline:
+                break
+            time.sleep(0.01)
+        return str(socket_path)
+
+    # ------------------------------------------------------------------
+    # command / dialog parsing
+    # ------------------------------------------------------------------
+
+    def test_fix_command_behavior(self) -> None:
+        behavior = service.command_behavior("fix")
+
+        self.assertEqual(behavior["workflow_scope"], "conversation")
+
+    def test_unknown_command_has_no_behavior(self) -> None:
+        self.assertEqual(service.command_behavior("ship"), {})
+
+    def test_normalize_command_invocation_reads_form_fields(self) -> None:
+        invocation = service.normalize_command_invocation(self.command_form(text="  fix crash  "))
+
+        self.assertEqual(invocation["surface"], "command")
+        self.assertEqual(invocation["team_id"], TEAM_ID)
+        self.assertEqual(invocation["channel_id"], CHANNEL_ID)
+        self.assertEqual(invocation["user_id"], USER_ID)
+        self.assertEqual(invocation["command"], "/gc")
+        self.assertEqual(invocation["text"], "fix crash")
+        self.assertEqual(invocation["trigger_id"], "trigger-1")
+
+    def test_parse_command_text_reads_prompt(self) -> None:
+        config = self.import_app()
+        invocation = self.command_invocation(text="fix crash on startup when x is unset")
+
+        parsed = service.parse_command_text(config, invocation, common.command_name(config))
+
+        self.assertEqual(parsed["command"], "fix")
+        self.assertIn("crash on startup", parsed["prompt"])
+        self.assertEqual(parsed["rig"], "")
+
+    def test_parse_command_text_ignores_foreign_trigger(self) -> None:
+        config = self.import_app()
+        invocation = self.command_invocation(command="/other", text="fix crash on startup")
+
+        self.assertEqual(service.parse_command_text(config, invocation, common.command_name(config)), {})
+
+    def test_parse_command_text_extracts_bare_rig_token(self) -> None:
+        config = self.import_app()
+        config = common.set_rig_mapping(config, TEAM_ID, "mission-control", "mission-control/polecat", common.FIX_FORMULA_DEFAULT)
+        invocation = self.command_invocation(text="fix mission-control crash on startup")
+
+        parsed = service.parse_command_text(config, invocation, common.command_name(config))
+
+        self.assertEqual(parsed["command"], "fix")
+        self.assertEqual(parsed["rig"], "mission-control")
+        self.assertEqual(parsed["prompt"], "crash on startup")
+
+    def test_parse_command_text_keeps_unmapped_leading_token_in_prompt(self) -> None:
+        config = self.import_app()
+        invocation = self.command_invocation(text="fix mission-control crash on startup")
+
+        parsed = service.parse_command_text(config, invocation, common.command_name(config))
+
+        self.assertEqual(parsed["rig"], "")
+        self.assertEqual(parsed["prompt"], "mission-control crash on startup")
+
+    def test_parse_command_text_extracts_rig_flag_forms(self) -> None:
+        config = self.import_app()
+        invocation = self.command_invocation(text="fix --rig=mission-control crash on startup")
+        parsed = service.parse_command_text(config, invocation, common.command_name(config))
+        self.assertEqual(parsed["rig"], "mission-control")
+        self.assertEqual(parsed["prompt"], "crash on startup")
+
+        invocation = self.command_invocation(text="fix --rig mission-control crash on startup")
+        parsed = service.parse_command_text(config, invocation, common.command_name(config))
+        self.assertEqual(parsed["rig"], "mission-control")
+        self.assertEqual(parsed["prompt"], "crash on startup")
+
+    def test_parse_command_text_preserves_newlines_in_prompt(self) -> None:
+        # `prompt_to_summary_context` derives the summary from the prompt's first
+        # line, so the parser must not flatten a multi-line slash-command text.
+        config = self.import_app()
+        invocation = self.command_invocation(text="fix crash on startup\nwhen x is unset\n\nrepro: unset X")
+
+        parsed = service.parse_command_text(config, invocation, common.command_name(config))
+
+        self.assertEqual(parsed["command"], "fix")
+        self.assertEqual(parsed["prompt"], "crash on startup\nwhen x is unset\n\nrepro: unset X")
+        summary, context_markdown = service.prompt_to_summary_context(parsed["prompt"])
+        self.assertEqual(summary, "crash on startup")
+        self.assertIn("repro: unset X", context_markdown)
+
+    def test_parse_command_text_preserves_newlines_after_rig_token(self) -> None:
+        config = self.import_app()
+        config = common.set_rig_mapping(config, TEAM_ID, "mission-control", "mission-control/polecat", common.FIX_FORMULA_DEFAULT)
+        invocation = self.command_invocation(text="fix mission-control crash on startup\nwhen x is unset")
+
+        parsed = service.parse_command_text(config, invocation, common.command_name(config))
+
+        self.assertEqual(parsed["rig"], "mission-control")
+        self.assertEqual(parsed["prompt"], "crash on startup\nwhen x is unset")
+
+    def test_parse_command_text_keeps_dangling_rig_flag_in_prompt(self) -> None:
+        config = self.import_app()
+        invocation = self.command_invocation(text="fix --rig")
+
+        parsed = service.parse_command_text(config, invocation, common.command_name(config))
+
+        self.assertEqual(parsed["rig"], "")
+        self.assertEqual(parsed["prompt"], "--rig")
+
+    def test_parse_command_text_returns_empty_prompt_for_bare_subcommand(self) -> None:
+        config = self.import_app()
+
+        parsed = service.parse_command_text(config, self.command_invocation(text="fix"), common.command_name(config))
+
+        self.assertEqual(parsed["command"], "fix")
+        self.assertEqual(parsed["prompt"], "")
+        self.assertEqual(parsed["rig"], "")
+
+    def test_extract_dialog_fields_reads_summary_and_context(self) -> None:
+        payload = {
+            "type": "dialog_submission",
+            "callback_id": service.FIX_DIALOG_CALLBACK_ID,
+            "state": "state-token",
+            "user_id": USER_ID,
+            "channel_id": CHANNEL_ID,
+            "team_id": TEAM_ID,
+            "submission": {"summary": "Crash on boot", "context": "unset env X"},
+            "cancelled": False,
+        }
+
+        fields = service.extract_dialog_fields(payload)
+
+        self.assertEqual(fields["summary"], "Crash on boot")
+        self.assertEqual(fields["context"], "unset env X")
+
+    def test_extract_dialog_fields_tolerates_missing_submission(self) -> None:
+        self.assertEqual(service.extract_dialog_fields({"type": "dialog_submission"}), {})
+        self.assertEqual(service.extract_dialog_fields({"submission": "nope"}), {})
+        self.assertEqual(service.extract_dialog_fields({"submission": {"context": None}}), {"context": ""})
+
+    def test_normalize_dialog_invocation_backfills_from_pending_record(self) -> None:
+        payload = {
+            "type": "dialog_submission",
+            "state": "state-token",
+            "user_id": USER_ID,
+            "channel_id": CHANNEL_ID,
+            "team_id": TEAM_ID,
+            "submission": {"summary": "Crash"},
+        }
+        pending = {
+            "nonce": "nonce-1",
+            "team_id": TEAM_ID,
+            "team_domain": "acme",
+            "channel_id": CHANNEL_ID,
+            "channel_name": "town-square",
+            "root_id": ROOT_ID,
+            "user_id": USER_ID,
+            "user_name": "alice",
+            "command_trigger": "/gc",
+        }
+
+        invocation = service.normalize_dialog_invocation(payload, pending)
+
+        self.assertEqual(invocation["surface"], "dialog")
+        self.assertEqual(invocation["team_id"], TEAM_ID)
+        self.assertEqual(invocation["channel_id"], CHANNEL_ID)
+        self.assertEqual(invocation["root_id"], ROOT_ID)
+        self.assertEqual(invocation["team_domain"], "acme")
+        self.assertEqual(invocation["channel_name"], "town-square")
+        self.assertEqual(invocation["user_name"], "alice")
+        self.assertEqual(invocation["command"], "/gc")
+
+    def test_build_message_response_uses_mattermost_response_type(self) -> None:
+        self.assertEqual(
+            service.build_message_response("hello", ephemeral=True),
+            {"response_type": "ephemeral", "text": "hello"},
+        )
+        self.assertEqual(
+            service.build_message_response("hello", ephemeral=False),
+            {"response_type": "in_channel", "text": "hello"},
+        )
+
+    def test_build_dialog_error_response_targets_field_when_given(self) -> None:
+        self.assertEqual(
+            service.build_dialog_error_response("summary_required", "summary"),
+            {"errors": {"summary": service.human_reason("summary_required")}},
+        )
+        self.assertEqual(
+            service.build_dialog_error_response("dialog_expired"),
+            {"error": service.human_reason("dialog_expired")},
+        )
+        self.assertEqual(service.build_dialog_ok_response(), {})
+
+    def test_build_fix_dialog_declares_summary_and_context_elements(self) -> None:
+        dialog = service.build_fix_dialog("state-token")
+
+        self.assertEqual(dialog["callback_id"], service.FIX_DIALOG_CALLBACK_ID)
+        self.assertEqual(dialog["state"], "state-token")
+        names = [element["name"] for element in dialog["elements"]]
+        self.assertEqual(names, ["summary", "context"])
+        self.assertLessEqual(max(len(element["display_name"]) for element in dialog["elements"]), 24)
+
+    # ------------------------------------------------------------------
+    # bead payload construction
+    # ------------------------------------------------------------------
+
+    def test_build_fix_bead_notes_includes_mattermost_context(self) -> None:
+        request = {
+            "team_id": TEAM_ID,
+            "channel_id": CHANNEL_ID,
+            "root_id": ROOT_ID,
+            "conversation_id": f"{CHANNEL_ID}/{ROOT_ID}",
+            "permalink": f"{SITE_URL}/acme/channels/town-square",
+            "request_id": "mm-1-fix",
+            "invoking_user_display_name": "alice",
+            "invoking_user_id": USER_ID,
+            "summary": "Crash on startup",
+            "context_markdown": "repro: unset X",
+        }
+
+        notes = service.build_fix_bead_notes(request)
+
+        self.assertIn("## Mattermost Source", notes)
+        self.assertIn("Crash on startup", notes)
+        self.assertIn("repro: unset X", notes)
+        self.assertIn(f"{SITE_URL}/acme/channels/town-square", notes)
+        self.assertIn(ROOT_ID, notes)
+
+    def test_build_fix_bead_title_is_bounded(self) -> None:
+        title = service.build_fix_bead_title({"summary": "x" * 400})
+
+        self.assertTrue(title.startswith("Fix Mattermost request: "))
+        self.assertLessEqual(len(title), 180)
+
+    def test_build_fix_vars_encodes_prompt_sensitive_fields(self) -> None:
+        request = {
+            "request_id": "mm-1-fix",
+            "team_id": TEAM_ID,
+            "channel_id": CHANNEL_ID,
+            "root_id": ROOT_ID,
+            "conversation_id": f"{CHANNEL_ID}/{ROOT_ID}",
+            "permalink": f"{SITE_URL}/acme/channels/town-square",
+            "invoking_user_display_name": "alice `review this`",
+            "summary": "Crash on startup",
+            "context_markdown": "unset env X",
+        }
+
+        variables = service.build_fix_vars(request, "bd-1")
+
+        self.assertNotIn("mattermost_requester", variables)
+        self.assertNotIn("mattermost_permalink", variables)
+        self.assertNotIn("mattermost_summary", variables)
+        self.assertNotIn("mattermost_context", variables)
+        self.assertEqual(variables["issue"], "bd-1")
+        self.assertEqual(variables["mattermost_team_id"], TEAM_ID)
+        self.assertEqual(variables["mattermost_root_id"], ROOT_ID)
+        self.assertEqual(
+            base64.b64decode(variables["mattermost_requester_b64"]).decode("utf-8"),
+            "alice `review this`",
+        )
+        self.assertEqual(
+            base64.b64decode(variables["mattermost_permalink_b64"]).decode("utf-8"),
+            f"{SITE_URL}/acme/channels/town-square",
+        )
+        self.assertEqual(
+            base64.b64decode(variables["mattermost_summary_b64"]).decode("utf-8"),
+            "Crash on startup",
+        )
+        self.assertEqual(
+            base64.b64decode(variables["mattermost_context_b64"]).decode("utf-8"),
+            "unset env X",
+        )
+
+    def test_build_request_uses_mattermost_field_names(self) -> None:
+        self.import_app()
+        invocation = self.command_invocation(root_id=ROOT_ID)
+        mapping = {"target": "product/polecat", "commands": {"fix": {"formula": common.FIX_FORMULA_DEFAULT}}}
+
+        request = service.build_request(
+            invocation,
+            "Crash on startup",
+            "unset env X",
+            self.channel_context(root_id=ROOT_ID),
+            "interaction-1",
+            mapping,
+        )
+
+        self.assertEqual(request["team_id"], TEAM_ID)
+        self.assertEqual(request["channel_id"], CHANNEL_ID)
+        self.assertEqual(request["root_id"], ROOT_ID)
+        self.assertEqual(request["conversation_id"], f"{CHANNEL_ID}/{ROOT_ID}")
+        self.assertEqual(
+            request["workflow_key"],
+            f"mm:team:{TEAM_ID}:conversation:{CHANNEL_ID}/{ROOT_ID}:fix",
+        )
+        self.assertEqual(request["request_id"], common.build_request_id("interaction-1", "fix"))
+        self.assertEqual(request["status"], "received")
+        self.assertEqual(request["command"], "fix")
+        self.assertEqual(request["dispatch_target"], "product/polecat")
+        self.assertEqual(request["dispatch_formula"], common.FIX_FORMULA_DEFAULT)
+        self.assertEqual(request["invoking_user_id"], USER_ID)
+        self.assertEqual(request["invoking_user_display_name"], "alice")
+        self.assertEqual(request["permalink"], f"{SITE_URL}/acme/channels/town-square")
+        # Discord's guild/thread/jump_url names must not leak into the record.
+        for legacy in ("guild_id", "thread_id", "jump_url"):
+            self.assertNotIn(legacy, request)
+
+    def test_build_request_without_thread_root_uses_bare_channel_conversation(self) -> None:
+        self.import_app()
+        invocation = self.command_invocation()
+
+        request = service.build_request(
+            invocation,
+            "Crash",
+            "",
+            self.channel_context(),
+            "interaction-2",
+            {"target": "product/polecat"},
+        )
+
+        self.assertEqual(request["root_id"], "")
+        self.assertEqual(request["conversation_id"], CHANNEL_ID)
+        self.assertEqual(request["workflow_key"], f"mm:team:{TEAM_ID}:conversation:{CHANNEL_ID}:fix")
+
+    # ------------------------------------------------------------------
+    # reservation / dedupe
+    # ------------------------------------------------------------------
+
+    def test_reserve_request_deduplicates_conversation_workflow(self) -> None:
+        behavior = service.command_behavior("fix")
+        workflow_key = common.build_workflow_key(TEAM_ID, CHANNEL_ID, "fix")
+        first = {
+            "request_id": "mm-1-fix",
+            "workflow_key": workflow_key,
+            "command": "fix",
+            "team_id": TEAM_ID,
+            "conversation_id": CHANNEL_ID,
+        }
+        second = {
+            "request_id": "mm-2-fix",
+            "workflow_key": workflow_key,
+            "command": "fix",
+            "team_id": TEAM_ID,
+            "conversation_id": CHANNEL_ID,
+        }
+
+        self.assertIsNone(service.reserve_request(first, behavior, "interaction-1"))
+        duplicate = service.reserve_request(second, behavior, "interaction-2")
+
+        self.assertIsNotNone(duplicate)
+        assert duplicate is not None
+        self.assertEqual(duplicate["request_id"], "mm-1-fix")
+
+    def test_reserve_request_rejects_distinct_rig_workflows_in_same_conversation(self) -> None:
+        behavior = service.command_behavior("fix")
+        workflow_key = common.build_workflow_key(TEAM_ID, CHANNEL_ID, "fix")
+        first = {
+            "request_id": "mm-rig-1",
+            "workflow_key": workflow_key,
+            "command": "fix",
+            "team_id": TEAM_ID,
+            "conversation_id": CHANNEL_ID,
+            "rig_name": "mission-control",
+        }
+        second = {
+            "request_id": "mm-rig-2",
+            "workflow_key": workflow_key,
+            "command": "fix",
+            "team_id": TEAM_ID,
+            "conversation_id": CHANNEL_ID,
+            "rig_name": "product",
+        }
+
+        self.assertIsNone(service.reserve_request(first, behavior, "interaction-rig-1"))
+        duplicate = service.reserve_request(second, behavior, "interaction-rig-2")
+        self.assertIsNotNone(duplicate)
+        assert duplicate is not None
+        self.assertEqual(duplicate["request_id"], "mm-rig-1")
+
+    def test_reserve_request_replays_existing_interaction_receipt(self) -> None:
+        behavior = service.command_behavior("fix")
+        request = {
+            "request_id": "mm-replay-1",
+            "workflow_key": common.build_workflow_key(TEAM_ID, CHANNEL_ID, "fix"),
+            "command": "fix",
+            "team_id": TEAM_ID,
+            "conversation_id": CHANNEL_ID,
+        }
+
+        self.assertIsNone(service.reserve_request(dict(request), behavior, "interaction-replay"))
+        replayed = service.reserve_request(dict(request), behavior, "interaction-replay")
+
+        self.assertIsNotNone(replayed)
+        assert replayed is not None
+        self.assertEqual(replayed["request_id"], "mm-replay-1")
+
+    # ------------------------------------------------------------------
+    # accept_fix_request
+    # ------------------------------------------------------------------
+
+    def test_accept_fix_request_saves_and_enqueues_new_request(self) -> None:
+        self.import_app()
+        common.set_channel_mapping(common.load_config(), TEAM_ID, CHANNEL_ID, "product/polecat", common.FIX_FORMULA_DEFAULT)
+        common.save_bot_token("bot-token")
+        invocation = self.command_invocation()
+
+        with mock.patch.object(service, "enqueue_request") as enqueue_request:
+            outcome, receipt = service.accept_fix_request(invocation, "Crash on startup", "unset env X", "interaction-1")
+
+        self.assertEqual(outcome["kind"], "accepted")
+        self.assertIn("Accepted /gc fix", outcome["content"])
+        self.assertEqual(receipt["response_kind"], "accepted")
+        self.assertEqual(
+            service.command_response_for_outcome(outcome),
+            {"response_type": "in_channel", "text": outcome["content"]},
+        )
+        request = common.list_recent_requests(limit=1)[0]
+        self.assertEqual(request["summary"], "Crash on startup")
+        self.assertEqual(request["context_markdown"], "unset env X")
+        self.assertEqual(request["dispatch_target"], "product/polecat")
+        self.assertEqual(request["conversation_id"], CHANNEL_ID)
+        enqueue_request.assert_called_once()
+
+    def test_accept_fix_request_rejects_when_bot_token_missing(self) -> None:
+        self.import_app()
+        common.set_channel_mapping(common.load_config(), TEAM_ID, CHANNEL_ID, "product/polecat", common.FIX_FORMULA_DEFAULT)
+        invocation = self.command_invocation()
+
+        outcome, receipt = service.accept_fix_request(invocation, "Crash on startup", "unset env X", "interaction-1")
+
+        self.assertEqual(outcome["kind"], "message")
+        self.assertEqual(outcome["reason"], "mattermost_app_not_configured")
+        self.assertIn("not fully configured", outcome["content"])
+        self.assertEqual(receipt["response_kind"], "message")
+        self.assertEqual(
+            service.command_response_for_outcome(outcome),
+            {"response_type": "ephemeral", "text": outcome["content"]},
+        )
+        self.assertEqual(common.list_recent_requests(limit=20), [])
+
+    def test_accept_fix_request_requires_team_scope(self) -> None:
+        self.import_app()
+        common.save_bot_token("bot-token")
+        invocation = self.command_invocation(team_id="")
+
+        outcome, receipt = service.accept_fix_request(invocation, "Crash", "", "interaction-dm")
+
+        self.assertEqual(outcome["reason"], "team_required")
+        self.assertEqual(receipt["response_kind"], "message")
+
+    def test_accept_fix_request_rejects_unmapped_channel(self) -> None:
+        self.import_app()
+        common.save_bot_token("bot-token")
+        invocation = self.command_invocation()
+
+        with mock.patch.object(common, "load_channel_context", return_value=self.channel_context()):
+            outcome, _receipt = service.accept_fix_request(invocation, "Crash", "", "interaction-unmapped")
+
+        self.assertEqual(outcome["reason"], "channel_mapping_missing")
+
+    def test_accept_fix_request_requires_summary(self) -> None:
+        self.import_app()
+        common.set_channel_mapping(common.load_config(), TEAM_ID, CHANNEL_ID, "product/polecat", common.FIX_FORMULA_DEFAULT)
+        common.save_bot_token("bot-token")
+        invocation = self.command_invocation()
+
+        outcome, _receipt = service.accept_fix_request(invocation, "", "", "interaction-empty")
+
+        self.assertEqual(outcome["reason"], "summary_required")
+        self.assertEqual(outcome["field"], "summary")
+        self.assertEqual(
+            service.dialog_response_for_outcome(outcome, invocation),
+            {"errors": {"summary": service.human_reason("summary_required")}},
+        )
+
+    def test_accept_fix_request_derives_summary_from_context_only_submission(self) -> None:
+        self.import_app()
+        common.set_channel_mapping(common.load_config(), TEAM_ID, CHANNEL_ID, "product/polecat", common.FIX_FORMULA_DEFAULT)
+        common.save_bot_token("bot-token")
+        invocation = self.command_invocation()
+
+        with mock.patch.object(service, "enqueue_request"):
+            outcome, _receipt = service.accept_fix_request(
+                invocation, "", "crash on startup\nwhen x is unset", "interaction-derived"
+            )
+
+        self.assertEqual(outcome["kind"], "accepted")
+        request = common.list_recent_requests(limit=1)[0]
+        self.assertEqual(request["summary"], "crash on startup")
+        self.assertIn("when x is unset", request["context_markdown"])
+
+    def test_accept_fix_request_rejects_disallowed_channel_by_policy(self) -> None:
+        self.import_app(channel_allowlist=[OTHER_CHANNEL_ID])
+        common.set_channel_mapping(common.load_config(), TEAM_ID, CHANNEL_ID, "product/polecat", common.FIX_FORMULA_DEFAULT)
+        common.save_bot_token("bot-token")
+        invocation = self.command_invocation()
+
+        outcome, _receipt = service.accept_fix_request(invocation, "Crash", "", "interaction-policy")
+
+        self.assertEqual(outcome["reason"], "channel_not_allowed")
+
+    def test_accept_fix_request_routes_via_rig_mapping(self) -> None:
+        self.import_app()
+        common.set_rig_mapping(
+            common.load_config(), TEAM_ID, "mission-control", "mission-control/polecat", common.FIX_FORMULA_DEFAULT
+        )
+        common.save_bot_token("bot-token")
+        invocation = self.command_invocation(channel_id=OTHER_CHANNEL_ID)
+
+        with mock.patch.object(service, "enqueue_request") as enqueue_request:
+            outcome, _receipt = service.accept_fix_request(
+                invocation, "Crash on startup", "unset env X", "interaction-2", rig_name="mission-control"
+            )
+
+        self.assertEqual(outcome["kind"], "accepted")
+        self.assertIn("Accepted /gc fix", outcome["content"])
+        request = common.list_recent_requests(limit=1)[0]
+        self.assertEqual(request["dispatch_target"], "mission-control/polecat")
+        self.assertEqual(request["rig_name"], "mission-control")
+        self.assertEqual(request["workflow_key"], f"mm:team:{TEAM_ID}:conversation:{OTHER_CHANNEL_ID}:fix")
+        enqueue_request.assert_called_once()
+
+    def test_accept_fix_request_rig_routing_skips_channel_lookup_outside_threads(self) -> None:
+        self.import_app()
+        common.set_rig_mapping(
+            common.load_config(), TEAM_ID, "mission-control", "mission-control/polecat", common.FIX_FORMULA_DEFAULT
+        )
+        common.save_bot_token("bot-token")
+        invocation = self.command_invocation(channel_id=OTHER_CHANNEL_ID)
+
+        with mock.patch.object(service, "enqueue_request"), mock.patch.object(
+            common, "load_channel_context"
+        ) as load_channel_context:
+            outcome, _receipt = service.accept_fix_request(
+                invocation, "Crash", "", "interaction-no-lookup", rig_name="mission-control"
+            )
+
+        self.assertEqual(outcome["kind"], "accepted")
+        load_channel_context.assert_not_called()
+
+    def test_accept_fix_request_routes_threaded_rig_mapping_with_channel_context(self) -> None:
+        self.import_app(channel_allowlist=[CHANNEL_ID])
+        common.set_rig_mapping(
+            common.load_config(), TEAM_ID, "mission-control", "mission-control/polecat", common.FIX_FORMULA_DEFAULT
+        )
+        common.save_bot_token("bot-token")
+        invocation = self.command_invocation(root_id=ROOT_ID)
+
+        with mock.patch.object(service, "enqueue_request") as enqueue_request, mock.patch.object(
+            common,
+            "load_channel_context",
+            return_value=self.channel_context(root_id=ROOT_ID),
+        ):
+            outcome, _receipt = service.accept_fix_request(
+                invocation, "Crash on startup", "unset env X", "interaction-thread", rig_name="mission-control"
+            )
+
+        self.assertEqual(outcome["kind"], "accepted")
+        request = common.list_recent_requests(limit=1)[0]
+        self.assertEqual(request["channel_id"], CHANNEL_ID)
+        self.assertEqual(request["root_id"], ROOT_ID)
+        self.assertEqual(request["conversation_id"], f"{CHANNEL_ID}/{ROOT_ID}")
+        self.assertEqual(request["dispatch_target"], "mission-control/polecat")
+        enqueue_request.assert_called_once()
+
+    def test_accept_fix_request_rejects_unknown_rig(self) -> None:
+        self.import_app()
+        common.save_bot_token("bot-token")
+        invocation = self.command_invocation(channel_id=OTHER_CHANNEL_ID)
+
+        outcome, _receipt = service.accept_fix_request(
+            invocation, "Crash", "", "interaction-3", rig_name="nonexistent"
+        )
+
+        self.assertEqual(outcome["reason"], "rig_mapping_missing")
+        self.assertIn("no rig mapping", outcome["content"])
+
+    def test_accept_fix_request_surfaces_channel_lookup_failure(self) -> None:
+        self.import_app()
+        common.save_bot_token("bot-token")
+        invocation = self.command_invocation(channel_id=OTHER_CHANNEL_ID)
+
+        with mock.patch.object(
+            common,
+            "load_channel_context",
+            return_value={"mapping": {}, "lookup_error": "GET failed"},
+        ):
+            outcome, receipt = service.accept_fix_request(invocation, "Crash", "", "interaction-lookup-1")
+
+        self.assertEqual(outcome["reason"], "mattermost_lookup_failed")
+        self.assertIn("lookup failed", outcome["content"].lower())
+        self.assertEqual(receipt["response_kind"], "message")
+
+    def test_accept_fix_request_rejects_rig_mapping_when_thread_lookup_fails(self) -> None:
+        self.import_app()
+        common.set_rig_mapping(
+            common.load_config(), TEAM_ID, "mission-control", "mission-control/polecat", common.FIX_FORMULA_DEFAULT
+        )
+        common.save_bot_token("bot-token")
+        invocation = self.command_invocation(root_id=ROOT_ID)
+
+        with mock.patch.object(
+            common,
+            "load_channel_context",
+            return_value={"mapping": {}, "lookup_error": "GET failed"},
+        ):
+            outcome, receipt = service.accept_fix_request(
+                invocation, "Crash", "", "interaction-lookup-2", rig_name="mission-control"
+            )
+
+        self.assertEqual(outcome["reason"], "mattermost_lookup_failed")
+        self.assertIn("lookup failed", outcome["content"].lower())
+        self.assertEqual(receipt["response_kind"], "message")
+
+    def test_accept_fix_request_returns_duplicate_outcome(self) -> None:
+        self.import_app()
+        common.set_channel_mapping(common.load_config(), TEAM_ID, CHANNEL_ID, "product/polecat", common.FIX_FORMULA_DEFAULT)
+        common.save_bot_token("bot-token")
+        invocation = self.command_invocation()
+
+        with mock.patch.object(service, "enqueue_request"):
+            service.accept_fix_request(invocation, "Crash on startup", "", "interaction-dup-1")
+            outcome, receipt = service.accept_fix_request(invocation, "Crash again", "", "interaction-dup-2")
+
+        self.assertEqual(outcome["kind"], "duplicate")
+        self.assertIn("already active", outcome["content"])
+        self.assertEqual(receipt["response_kind"], "duplicate")
+        self.assertEqual(
+            service.command_response_for_outcome(outcome),
+            {"response_type": "ephemeral", "text": outcome["content"]},
+        )
+
+    def test_dialog_response_for_outcome_posts_acceptance_into_conversation(self) -> None:
+        invocation = self.command_invocation(root_id=ROOT_ID)
+        outcome = {"kind": "accepted", "content": "Accepted /gc fix for this conversation.", "request": {}}
+
+        with mock.patch.object(common, "post_channel_message", return_value={"id": "post-1"}) as post_channel_message:
+            response = service.dialog_response_for_outcome(outcome, invocation)
+
+        self.assertEqual(response, {})
+        post_channel_message.assert_called_once()
+        self.assertEqual(post_channel_message.call_args.args[0], CHANNEL_ID)
+        self.assertEqual(post_channel_message.call_args.kwargs["root_id"], ROOT_ID)
+
+    # ------------------------------------------------------------------
+    # admin surface
+    # ------------------------------------------------------------------
+
+    def test_render_admin_home_includes_launcher_sections(self) -> None:
+        self.import_app()
+        common.set_room_launcher(common.load_config(), TEAM_ID, CHANNEL_ID)
+        common.save_room_launch(
+            {
+                "launch_id": f"room-launch:{CHANNEL_ID}",
+                "launcher_id": common.room_launch_surface_id(CHANNEL_ID),
+                "team_id": TEAM_ID,
+                "conversation_id": CHANNEL_ID,
+                "root_post_id": ROOT_ID,
+                "qualified_handle": "corp/sky",
+                "session_alias": "mm-123-sky",
+            }
+        )
+
+        html_body = service.render_admin_home()
+
+        self.assertIn("Chat Launchers", html_body)
+        self.assertIn("Recent Room Launches", html_body)
+        self.assertIn("Command Sync Payload", html_body)
+        self.assertIn("corp/sky", html_body)
+
+    # ------------------------------------------------------------------
+    # bead creation / dispatch
+    # ------------------------------------------------------------------
+
+    def test_create_fix_bead_parses_json_after_cli_noise(self) -> None:
+        self.write_rig_route("product")
+        request = {
+            "summary": "Crash on startup",
+            "dispatch_target": "product/polecat",
+            "team_id": TEAM_ID,
+            "channel_id": CHANNEL_ID,
+            "root_id": "",
+            "conversation_id": CHANNEL_ID,
+            "permalink": f"{SITE_URL}/acme/channels/town-square",
+            "request_id": "mm-1-fix",
+            "invoking_user_display_name": "alice",
+            "invoking_user_id": USER_ID,
+            "context_markdown": "unset env X",
+        }
+
+        with mock.patch.object(
+            service,
+            "run_subprocess",
+            side_effect=[
+                mock.Mock(returncode=0, stdout='warning: something\n{"id":"bd-1"}\n', stderr=""),
+                mock.Mock(returncode=0, stdout="", stderr=""),
+            ],
+        ):
+            outcome = service.create_fix_bead(request, "product/polecat")
+
+        self.assertEqual(outcome["bead_id"], "bd-1")
+
+    def test_create_fix_bead_stamps_mattermost_metadata(self) -> None:
+        self.write_rig_route("product")
+        request = {
+            "summary": "Crash on startup",
+            "dispatch_target": "product/polecat",
+            "team_id": TEAM_ID,
+            "channel_id": CHANNEL_ID,
+            "root_id": ROOT_ID,
+            "conversation_id": f"{CHANNEL_ID}/{ROOT_ID}",
+            "request_id": "mm-meta-fix",
+        }
+
+        with mock.patch.object(
+            service,
+            "run_subprocess",
+            side_effect=[
+                mock.Mock(returncode=0, stdout='{"id":"bd-9"}\n', stderr=""),
+                mock.Mock(returncode=0, stdout="", stderr=""),
+            ],
+        ) as run_subprocess:
+            outcome = service.create_fix_bead(request, "product/polecat")
+
+        self.assertEqual(outcome["bead_id"], "bd-9")
+        update_command = run_subprocess.call_args_list[1].args[0]
+        self.assertIn("mattermost_request_id=mm-meta-fix", update_command)
+        self.assertIn(f"mattermost_team_id={TEAM_ID}", update_command)
+        self.assertIn(f"mattermost_channel_id={CHANNEL_ID}", update_command)
+        self.assertIn(f"mattermost_root_id={ROOT_ID}", update_command)
+        self.assertIn(f"mattermost_conversation_id={CHANNEL_ID}/{ROOT_ID}", update_command)
+
+    def test_create_fix_bead_returns_dispatch_timeout_when_bd_create_hangs(self) -> None:
+        self.write_rig_route("product")
+        request = {
+            "summary": "Crash on startup",
+            "dispatch_target": "product/polecat",
+        }
+
+        with mock.patch.object(
+            service,
+            "run_subprocess",
+            side_effect=service.DispatchSubprocessTimeout(
+                ["gc", "--city", self.tempdir.name, "--rig", "product", "bd", "create"],
+                service.DISPATCH_SUBPROCESS_TIMEOUT_SECONDS,
+            ),
+        ):
+            outcome = service.create_fix_bead(request, "product/polecat")
+
+        self.assertEqual(outcome["status"], "dispatch_failed")
+        self.assertEqual(outcome["reason"], "dispatch_timeout")
+        self.assertEqual(
+            outcome["dispatch_command"],
+            ["gc", "--city", self.tempdir.name, "--rig", "product", "bd", "create"],
+        )
+
+    def test_create_fix_bead_fails_closed_when_rig_workdir_is_missing(self) -> None:
+        request = {
+            "request_id": "mm-route-missing",
+            "summary": "Crash on startup",
+        }
+
+        with mock.patch.object(service, "run_subprocess") as run_subprocess:
+            outcome = service.create_fix_bead(request, "mission-control/polecat")
+
+        self.assertEqual(outcome["status"], "dispatch_failed")
+        self.assertEqual(outcome["reason"], "rig_workdir_missing")
+        run_subprocess.assert_not_called()
+
+    def test_create_fix_bead_rejects_non_rig_scoped_target(self) -> None:
+        with mock.patch.object(service, "run_subprocess") as run_subprocess:
+            outcome = service.create_fix_bead({"summary": "Crash"}, "polecat")
+
+        self.assertEqual(outcome["reason"], "invalid_dispatch_target")
+        run_subprocess.assert_not_called()
+
+    def test_run_fix_dispatch_returns_bead_init_failure_without_slinging(self) -> None:
+        self.write_rig_route("product")
+        request = {
+            "summary": "Crash on startup",
+            "dispatch_target": "product/polecat",
+            "dispatch_formula": common.FIX_FORMULA_DEFAULT,
+        }
+
+        with mock.patch.object(
+            service,
+            "create_fix_bead",
+            return_value={"status": "dispatch_failed", "reason": "bead_update_failed", "bead_id": "bd-1"},
+        ), mock.patch.object(
+            service,
+            "run_subprocess",
+            side_effect=[mock.Mock(returncode=0), mock.Mock(returncode=0), mock.Mock(returncode=0)],
+        ) as run_subprocess:
+            outcome = service.run_fix_dispatch(request)
+
+        self.assertEqual(outcome["status"], "dispatch_failed")
+        self.assertEqual(outcome["bead_id"], "bd-1")
+        self.assertTrue(outcome["bead_closed"])
+        commands = [call.args[0] for call in run_subprocess.call_args_list]
+        prefix = ["gc", "--city", self.tempdir.name, "--rig", "product", "bd"]
+        self.assertEqual(
+            commands[0],
+            prefix + ["update", "bd-1", "--set-metadata", "close_reason=mattermost:bead_update_failed"],
+        )
+        self.assertEqual(commands[1], prefix + ["ready", "bd-1"])
+        self.assertEqual(commands[2], prefix + ["close", "bd-1"])
+
+    def test_run_fix_dispatch_ignores_unconfigured_command(self) -> None:
+        outcome = service.run_fix_dispatch({"summary": "Crash"})
+
+        self.assertEqual(outcome["status"], "ignored")
+        self.assertEqual(outcome["reason"], "command_not_configured")
+
+    def test_run_fix_dispatch_slings_with_encoded_vars(self) -> None:
+        request = {
+            "request_id": "mm-sling-1",
+            "summary": "Crash on startup",
+            "dispatch_target": "product/polecat",
+            "dispatch_formula": common.FIX_FORMULA_DEFAULT,
+            "team_id": TEAM_ID,
+            "channel_id": CHANNEL_ID,
+            "root_id": ROOT_ID,
+            "conversation_id": f"{CHANNEL_ID}/{ROOT_ID}",
+        }
+
+        with mock.patch.object(service, "create_fix_bead", return_value={"bead_id": "bd-5"}), mock.patch.object(
+            service,
+            "run_subprocess",
+            return_value=mock.Mock(returncode=0, stdout="", stderr=""),
+        ) as run_subprocess:
+            outcome = service.run_fix_dispatch(request)
+
+        self.assertEqual(outcome["status"], "dispatched")
+        command = run_subprocess.call_args.args[0]
+        self.assertEqual(command[:5], ["gc", "sling", "product/polecat", "bd-5", "--on"])
+        self.assertEqual(command[5], common.FIX_FORMULA_DEFAULT)
+        self.assertIn("issue=bd-5", command)
+        self.assertIn(f"mattermost_root_id={ROOT_ID}", command)
+
+    def test_run_fix_dispatch_returns_dispatch_timeout_when_gc_sling_hangs(self) -> None:
+        request = {
+            "request_id": "mm-timeout-1",
+            "summary": "Crash on startup",
+            "dispatch_target": "product/polecat",
+            "dispatch_formula": common.FIX_FORMULA_DEFAULT,
+        }
+
+        with mock.patch.object(service, "create_fix_bead", return_value={"bead_id": "bd-1"}), mock.patch.object(
+            service,
+            "run_subprocess",
+            side_effect=service.DispatchSubprocessTimeout(["gc", "sling", "product/polecat", "bd-1"], 300),
+        ), mock.patch.object(service, "dispatch_recovery_state", return_value="inactive"), mock.patch.object(
+            service,
+            "close_failed_bead",
+            return_value=True,
+        ) as close_failed_bead:
+            outcome = service.run_fix_dispatch(request)
+
+        self.assertEqual(outcome["status"], "dispatch_failed")
+        self.assertEqual(outcome["reason"], "dispatch_timeout")
+        self.assertTrue(outcome["bead_closed"])
+        close_failed_bead.assert_called_once_with("bd-1", "dispatch_timeout", "product")
+
+    def test_run_fix_dispatch_converges_timeout_to_dispatched_when_bead_is_active(self) -> None:
+        request = {
+            "request_id": "mm-timeout-2",
+            "summary": "Crash on startup",
+            "dispatch_target": "product/polecat",
+            "dispatch_formula": common.FIX_FORMULA_DEFAULT,
+        }
+
+        with mock.patch.object(service, "create_fix_bead", return_value={"bead_id": "bd-2"}), mock.patch.object(
+            service,
+            "run_subprocess",
+            side_effect=service.DispatchSubprocessTimeout(["gc", "sling", "product/polecat", "bd-2"], 300),
+        ), mock.patch.object(service, "dispatch_recovery_state", return_value="active"), mock.patch.object(
+            service,
+            "close_failed_bead",
+        ) as close_failed_bead:
+            outcome = service.run_fix_dispatch(request)
+
+        self.assertEqual(outcome["status"], "dispatched")
+        self.assertEqual(outcome["dispatch_recovery_reason"], "dispatch_timeout_but_bead_already_routed")
+        close_failed_bead.assert_not_called()
+
+    def test_run_fix_dispatch_leaves_timeout_in_dispatching_when_bead_state_is_unknown(self) -> None:
+        request = {
+            "request_id": "mm-timeout-3",
+            "summary": "Crash on startup",
+            "dispatch_target": "product/polecat",
+            "dispatch_formula": common.FIX_FORMULA_DEFAULT,
+        }
+
+        with mock.patch.object(service, "create_fix_bead", return_value={"bead_id": "bd-3"}), mock.patch.object(
+            service,
+            "run_subprocess",
+            side_effect=service.DispatchSubprocessTimeout(["gc", "sling", "product/polecat", "bd-3"], 300),
+        ), mock.patch.object(service, "dispatch_recovery_state", return_value="unknown"), mock.patch.object(
+            service,
+            "close_failed_bead",
+        ) as close_failed_bead:
+            outcome = service.run_fix_dispatch(request)
+
+        self.assertEqual(outcome["status"], "dispatching")
+        self.assertEqual(outcome["dispatch_recovery_reason"], "dispatch_timeout_state_unavailable")
+        self.assertIn("dispatch_timeout_at", outcome)
+        close_failed_bead.assert_not_called()
+
+    # ------------------------------------------------------------------
+    # process_request
+    # ------------------------------------------------------------------
+
+    def test_process_request_releases_workflow_link_after_dispatch_failure(self) -> None:
+        workflow_key = common.build_workflow_key(TEAM_ID, CHANNEL_ID, "fix")
+        request = {
+            "request_id": "mm-3-fix",
+            "workflow_key": workflow_key,
+            "command": "fix",
+            "summary": "Crash on startup",
+            "dispatch_target": "product/polecat",
+            "dispatch_formula": common.FIX_FORMULA_DEFAULT,
+        }
+        common.save_request(request)
+        common.save_workflow_link(workflow_key, request["request_id"])
+
+        with mock.patch.object(
+            service,
+            "run_fix_dispatch",
+            return_value={"status": "dispatch_failed", "reason": "dispatch_failed", "bead_id": "bd-1"},
+        ):
+            service.process_request(request["request_id"])
+
+        saved = common.load_request(request["request_id"])
+        assert saved is not None
+        self.assertEqual(saved["status"], "dispatch_failed")
+        self.assertIsNone(common.load_workflow_link(workflow_key))
+
+    def test_process_request_posts_failure_followup_for_async_dispatch_failure(self) -> None:
+        common.save_bot_token("bot-token")
+        request = {
+            "request_id": "mm-4-fix",
+            "workflow_key": common.build_workflow_key(TEAM_ID, f"{CHANNEL_ID}/{ROOT_ID}", "fix"),
+            "command": "fix",
+            "summary": "Crash on startup",
+            "channel_id": CHANNEL_ID,
+            "root_id": ROOT_ID,
+            "dispatch_target": "product/polecat",
+            "dispatch_formula": common.FIX_FORMULA_DEFAULT,
+        }
+        common.save_request(request)
+
+        with mock.patch.object(
+            service,
+            "run_fix_dispatch",
+            return_value={"status": "dispatch_failed", "reason": "dispatch_failed", "bead_id": "bd-1"},
+        ), mock.patch.object(
+            common,
+            "post_channel_message",
+            return_value={"id": "post-1"},
+        ) as post_channel_message:
+            service.process_request(request["request_id"])
+
+        saved = common.load_request(request["request_id"])
+        assert saved is not None
+        self.assertEqual(saved["failure_message_id"], "post-1")
+        post_channel_message.assert_called_once()
+        self.assertEqual(post_channel_message.call_args.args[0], CHANNEL_ID)
+        self.assertEqual(post_channel_message.call_args.kwargs["root_id"], ROOT_ID)
+        self.assertIn("could not be started", post_channel_message.call_args.args[1])
+
+    def test_process_request_releases_workflow_link_when_request_file_is_missing(self) -> None:
+        workflow_key = common.build_workflow_key(TEAM_ID, CHANNEL_ID, "fix")
+        common.save_workflow_link(workflow_key, "mm-missing")
+
+        with mock.patch.object(common, "load_request", return_value=None):
+            service.process_request("mm-missing")
+
+        self.assertIsNone(common.load_workflow_link(workflow_key))
+
+    def test_process_request_sanitizes_internal_error_followup(self) -> None:
+        common.save_bot_token("bot-token")
+        request = {
+            "request_id": "mm-5-fix",
+            "workflow_key": common.build_workflow_key(TEAM_ID, CHANNEL_ID, "fix"),
+            "command": "fix",
+            "summary": "Crash on startup",
+            "channel_id": CHANNEL_ID,
+            "dispatch_target": "product/polecat",
+            "dispatch_formula": common.FIX_FORMULA_DEFAULT,
+        }
+        common.save_request(request)
+
+        with mock.patch.object(service, "run_fix_dispatch", side_effect=RuntimeError("leak this path")), mock.patch.object(
+            common,
+            "post_channel_message",
+            return_value={"id": "post-2"},
+        ) as post_channel_message:
+            service.process_request(request["request_id"])
+
+        saved = common.load_request(request["request_id"])
+        assert saved is not None
+        self.assertEqual(saved["reason"], "internal_error")
+        self.assertEqual(saved["error_message"], "leak this path")
+        self.assertIn("internal error occurred", post_channel_message.call_args.args[1])
+        self.assertNotIn("leak this path", post_channel_message.call_args.args[1])
+
+    def test_process_request_ignores_unsupported_command(self) -> None:
+        workflow_key = common.build_workflow_key(TEAM_ID, CHANNEL_ID, "ship")
+        request = {
+            "request_id": "mm-6-ship",
+            "workflow_key": workflow_key,
+            "command": "ship",
+            "status": "received",
+        }
+        common.save_request(request)
+        common.save_workflow_link(workflow_key, request["request_id"])
+
+        service.process_request(request["request_id"])
+
+        saved = common.load_request(request["request_id"])
+        assert saved is not None
+        self.assertEqual(saved["status"], "ignored")
+        self.assertEqual(saved["reason"], "command_not_supported")
+        self.assertIsNone(common.load_workflow_link(workflow_key))
+
+    # ------------------------------------------------------------------
+    # rig routing helpers
+    # ------------------------------------------------------------------
+
+    def test_rig_from_target_requires_pool_scope(self) -> None:
+        self.assertEqual(service.rig_from_target("product/polecat"), "product")
+        self.assertEqual(service.rig_from_target("polecat"), "")
+
+    def test_gc_bd_command_includes_city_and_rig_scope(self) -> None:
+        self.assertEqual(
+            service.gc_bd_command(self.tempdir.name, "show", "bd-1", "--json", rig="product"),
+            ["gc", "--city", self.tempdir.name, "--rig", "product", "bd", "show", "bd-1", "--json"],
+        )
+        self.assertEqual(service.gc_bd_command(".", "ready", "bd-1"), ["gc", "bd", "ready", "bd-1"])
+
+    def test_rig_workdir_resolves_routed_directory(self) -> None:
+        self.write_rig_route("product")
+
+        self.assertEqual(
+            service.rig_workdir("product"),
+            os.path.realpath(os.path.join(self.tempdir.name, "product")),
+        )
+
+    def test_rig_workdir_rejects_paths_outside_city_root(self) -> None:
+        beads_dir = pathlib.Path(self.tempdir.name, ".beads")
+        beads_dir.mkdir(parents=True, exist_ok=True)
+        pathlib.Path(beads_dir, "routes.jsonl").write_text('{"path":"../../tmp"}\n', encoding="utf-8")
+
+        self.assertEqual(service.rig_workdir("../../tmp"), "")
+
+    def test_rig_workdir_rejects_symlink_target_outside_city_root(self) -> None:
+        beads_dir = pathlib.Path(self.tempdir.name, ".beads")
+        beads_dir.mkdir(parents=True, exist_ok=True)
+        outside_dir = pathlib.Path(self.tempdir.name).parent / "mattermost-outside-rig"
+        outside_dir.mkdir(parents=True, exist_ok=True)
+        self.addCleanup(lambda: outside_dir.exists() and outside_dir.rmdir())
+        rig_link = pathlib.Path(self.tempdir.name, "product")
+        rig_link.symlink_to(outside_dir, target_is_directory=True)
+        pathlib.Path(beads_dir, "routes.jsonl").write_text('{"path":"product"}\n', encoding="utf-8")
+
+        self.assertEqual(service.rig_workdir("product"), "")
+
+    def test_extract_json_output_ignores_warning_braces_before_payload(self) -> None:
+        payload = service.extract_json_output('warning: field {name} missing\n{"id":"bd-1"}\n')
+
+        self.assertEqual(payload["id"], "bd-1")
+
+    def test_extract_json_output_returns_empty_for_non_json(self) -> None:
+        self.assertEqual(service.extract_json_output("no json here"), {})
+        self.assertEqual(service.extract_json_output(""), {})
+
+    # ------------------------------------------------------------------
+    # recovery
+    # ------------------------------------------------------------------
+
+    def test_recover_incomplete_requests_marks_request_failed_and_releases_workflow(self) -> None:
+        workflow_key = common.build_workflow_key(TEAM_ID, CHANNEL_ID, "fix")
+        request = {
+            "request_id": "mm-recover-1",
+            "workflow_key": workflow_key,
+            "status": "received",
+            "command": "fix",
+            "dispatch_target": "mission-control/polecat",
+            "channel_id": CHANNEL_ID,
+            "conversation_id": CHANNEL_ID,
+        }
+        common.save_request(request)
+        common.save_workflow_link(workflow_key, request["request_id"])
+
+        with mock.patch.object(service, "maybe_notify_dispatch_failure", side_effect=lambda payload: payload) as notify_failure:
+            recovered = service.recover_incomplete_requests()
+
+        self.assertEqual(recovered, 1)
+        saved = common.load_request(request["request_id"])
+        assert saved is not None
+        self.assertEqual(saved["status"], "internal_error")
+        self.assertEqual(saved["reason"], "service_restarted_before_dispatch")
+        self.assertIsNone(common.load_workflow_link(workflow_key))
+        notify_failure.assert_called_once()
+
+    def test_recover_incomplete_requests_closes_persisted_bead(self) -> None:
+        workflow_key = common.build_workflow_key(TEAM_ID, OTHER_CHANNEL_ID, "fix")
+        request = {
+            "request_id": "mm-recover-2",
+            "workflow_key": workflow_key,
+            "status": "bead_created",
+            "command": "fix",
+            "bead_id": "bd-10",
+            "dispatch_target": "mission-control/polecat",
+        }
+        common.save_request(request)
+        common.save_workflow_link(workflow_key, request["request_id"])
+
+        with mock.patch.object(service, "close_failed_bead", return_value=True) as close_failed_bead, mock.patch.object(
+            service,
+            "maybe_notify_dispatch_failure",
+            side_effect=lambda payload: payload,
+        ):
+            recovered = service.recover_incomplete_requests()
+
+        self.assertEqual(recovered, 1)
+        close_failed_bead.assert_called_once_with("bd-10", "service_restarted_before_dispatch", "mission-control")
+        saved = common.load_request(request["request_id"])
+        assert saved is not None
+        self.assertTrue(saved["bead_closed"])
+
+    def test_recover_incomplete_requests_preserves_workflow_lock_when_cleanup_fails(self) -> None:
+        workflow_key = common.build_workflow_key(TEAM_ID, OTHER_CHANNEL_ID, "fix")
+        request = {
+            "request_id": "mm-recover-3",
+            "workflow_key": workflow_key,
+            "status": "bead_created",
+            "command": "fix",
+            "bead_id": "bd-11",
+            "dispatch_target": "mission-control/polecat",
+        }
+        common.save_request(request)
+        common.save_workflow_link(workflow_key, request["request_id"])
+
+        with mock.patch.object(service, "close_failed_bead", return_value=False), mock.patch.object(
+            service,
+            "maybe_notify_dispatch_failure",
+            side_effect=lambda payload: payload,
+        ):
+            recovered = service.recover_incomplete_requests()
+
+        self.assertEqual(recovered, 1)
+        self.assertIsNotNone(common.load_workflow_link(workflow_key))
+
+    def test_recover_incomplete_requests_skips_recent_dispatching_request(self) -> None:
+        workflow_key = common.build_workflow_key(TEAM_ID, CHANNEL_ID, "fix")
+        request = {
+            "request_id": "mm-recover-4",
+            "workflow_key": workflow_key,
+            "status": "dispatching",
+            "dispatch_started_at": common.utcnow(),
+            "command": "fix",
+            "bead_id": "bd-12",
+            "dispatch_target": "mission-control/polecat",
+        }
+        common.save_request(request)
+        common.save_workflow_link(workflow_key, request["request_id"])
+
+        with mock.patch.object(service, "maybe_notify_dispatch_failure", side_effect=lambda payload: payload) as notify_failure:
+            recovered = service.recover_incomplete_requests()
+
+        self.assertEqual(recovered, 0)
+        self.assertIsNotNone(common.load_workflow_link(workflow_key))
+        notify_failure.assert_not_called()
+
+    def test_recover_incomplete_requests_reclaims_stale_dispatching_request(self) -> None:
+        workflow_key = common.build_workflow_key(TEAM_ID, CHANNEL_ID, "fix")
+        request = {
+            "request_id": "mm-recover-5",
+            "workflow_key": workflow_key,
+            "status": "dispatching",
+            "dispatch_started_at": "2000-01-01T00:00:00Z",
+            "command": "fix",
+            "bead_id": "bd-13",
+            "dispatch_target": "mission-control/polecat",
+        }
+        common.save_request(request)
+        common.save_workflow_link(workflow_key, request["request_id"])
+
+        with mock.patch.object(service, "dispatch_recovery_state", return_value="inactive"), mock.patch.object(
+            service, "close_failed_bead", return_value=True
+        ) as close_failed_bead, mock.patch.object(
+            service,
+            "maybe_notify_dispatch_failure",
+            side_effect=lambda payload: payload,
+        ):
+            recovered = service.recover_incomplete_requests()
+
+        self.assertEqual(recovered, 1)
+        close_failed_bead.assert_called_once_with("bd-13", "service_restarted_during_dispatch", "mission-control")
+        saved = common.load_request(request["request_id"])
+        assert saved is not None
+        self.assertEqual(saved["reason"], "service_restarted_during_dispatch")
+
+    def test_recover_incomplete_requests_marks_dispatched_when_bead_is_already_routed(self) -> None:
+        workflow_key = common.build_workflow_key(TEAM_ID, CHANNEL_ID, "fix")
+        request = {
+            "request_id": "mm-recover-6",
+            "workflow_key": workflow_key,
+            "status": "dispatching",
+            "dispatch_started_at": "2000-01-01T00:00:00Z",
+            "command": "fix",
+            "bead_id": "bd-14",
+            "dispatch_target": "mission-control/polecat",
+        }
+        common.save_request(request)
+        common.save_workflow_link(workflow_key, request["request_id"])
+
+        with mock.patch.object(service, "dispatch_recovery_state", return_value="active"), mock.patch.object(
+            service, "close_failed_bead"
+        ) as close_failed_bead, mock.patch.object(
+            service,
+            "maybe_notify_dispatch_failure",
+            side_effect=lambda payload: payload,
+        ) as notify_failure:
+            recovered = service.recover_incomplete_requests()
+
+        self.assertEqual(recovered, 0)
+        close_failed_bead.assert_not_called()
+        notify_failure.assert_not_called()
+        saved = common.load_request(request["request_id"])
+        assert saved is not None
+        self.assertEqual(saved["status"], "dispatched")
+        self.assertEqual(saved["dispatch_recovery_reason"], "bead_already_routed")
+        self.assertIsNotNone(common.load_workflow_link(workflow_key))
+
+    def test_recover_incomplete_requests_defers_when_bead_state_is_unavailable(self) -> None:
+        workflow_key = common.build_workflow_key(TEAM_ID, CHANNEL_ID, "fix")
+        request = {
+            "request_id": "mm-recover-7",
+            "workflow_key": workflow_key,
+            "status": "dispatching",
+            "dispatch_started_at": "2000-01-01T00:00:00Z",
+            "command": "fix",
+            "bead_id": "bd-15",
+            "dispatch_target": "mission-control/polecat",
+        }
+        common.save_request(request)
+        common.save_workflow_link(workflow_key, request["request_id"])
+
+        with mock.patch.object(service, "dispatch_recovery_state", return_value="unknown"), mock.patch.object(
+            service, "close_failed_bead"
+        ) as close_failed_bead, mock.patch.object(
+            service,
+            "maybe_notify_dispatch_failure",
+            side_effect=lambda payload: payload,
+        ) as notify_failure:
+            recovered = service.recover_incomplete_requests()
+
+        self.assertEqual(recovered, 0)
+        close_failed_bead.assert_not_called()
+        notify_failure.assert_not_called()
+        saved = common.load_request(request["request_id"])
+        assert saved is not None
+        self.assertEqual(saved["status"], "dispatching")
+        self.assertEqual(saved["dispatch_recovery_reason"], "bead_state_unavailable")
+        self.assertIsNotNone(common.load_workflow_link(workflow_key))
+
+    # ------------------------------------------------------------------
+    # dispatch_recovery_state
+    # ------------------------------------------------------------------
+
+    def test_dispatch_recovery_state_treats_assigned_bead_as_active(self) -> None:
+        self.write_rig_route("mission-control")
+        request = {
+            "bead_id": "bd-21",
+            "dispatch_target": "mission-control/polecat",
+        }
+
+        with mock.patch.object(
+            service,
+            "run_subprocess",
+            return_value=mock.Mock(
+                returncode=0,
+                stdout='{"id":"bd-21","status":"open","assignee":"mission-control/polecat","metadata":{"workflow_id":"gc-2"}}\n',
+                stderr="",
+            ),
+        ):
+            state = service.dispatch_recovery_state(request)
+
+        self.assertEqual(state, "active")
+
+    def test_dispatch_recovery_state_treats_open_unassigned_bead_as_inactive(self) -> None:
+        self.write_rig_route("mission-control")
+        request = {
+            "bead_id": "bd-22",
+            "dispatch_target": "mission-control/polecat",
+        }
+
+        with mock.patch.object(
+            service,
+            "run_subprocess",
+            return_value=mock.Mock(
+                returncode=0,
+                stdout='{"id":"bd-22","status":"open","assignee":"","metadata":{}}\n',
+                stderr="",
+            ),
+        ):
+            state = service.dispatch_recovery_state(request)
+
+        self.assertEqual(state, "inactive")
+
+    def test_dispatch_recovery_state_treats_closed_failed_bead_as_inactive(self) -> None:
+        self.write_rig_route("mission-control")
+        request = {
+            "bead_id": "bd-23",
+            "dispatch_target": "mission-control/polecat",
+        }
+
+        with mock.patch.object(
+            service,
+            "run_subprocess",
+            return_value=mock.Mock(
+                returncode=0,
+                stdout='{"id":"bd-23","status":"closed","metadata":{"close_reason":"mattermost:dispatch_failed"}}\n',
+                stderr="",
+            ),
+        ):
+            state = service.dispatch_recovery_state(request)
+
+        self.assertEqual(state, "inactive")
+
+    def test_dispatch_recovery_state_treats_closed_bead_without_failure_reason_as_active(self) -> None:
+        self.write_rig_route("mission-control")
+        request = {
+            "bead_id": "bd-24",
+            "dispatch_target": "mission-control/polecat",
+        }
+
+        with mock.patch.object(
+            service,
+            "run_subprocess",
+            return_value=mock.Mock(
+                returncode=0,
+                stdout='{"id":"bd-24","status":"closed","metadata":{}}\n',
+                stderr="",
+            ),
+        ):
+            state = service.dispatch_recovery_state(request)
+
+        self.assertEqual(state, "active")
+
+    def test_dispatch_recovery_state_is_unknown_when_bead_cannot_be_read(self) -> None:
+        self.write_rig_route("mission-control")
+        request = {
+            "bead_id": "bd-25",
+            "dispatch_target": "mission-control/polecat",
+        }
+
+        with mock.patch.object(service, "run_subprocess", return_value=mock.Mock(returncode=1, stdout="", stderr="boom")):
+            self.assertEqual(service.dispatch_recovery_state(request), "unknown")
+
+    def test_dispatch_recovery_state_is_inactive_without_bead_id(self) -> None:
+        self.assertEqual(service.dispatch_recovery_state({}), "inactive")
+
+    # ------------------------------------------------------------------
+    # rate limiting / service scoping
+    # ------------------------------------------------------------------
+
+    def test_maybe_prune_request_state_rate_limits_repeated_calls(self) -> None:
+        with mock.patch.object(common, "prune_requests") as prune_requests, mock.patch.object(
+            common, "prune_receipts"
+        ) as prune_receipts, mock.patch.object(common, "prune_pending_modals") as prune_pending_modals, mock.patch(
+            "mattermost_intake_service.time.monotonic",
+            side_effect=[100.0, 100.5, 161.0],
+        ):
+            self.assertTrue(service.maybe_prune_request_state())
+            self.assertFalse(service.maybe_prune_request_state())
+            self.assertTrue(service.maybe_prune_request_state())
+
+        self.assertEqual(prune_requests.call_count, 2)
+        self.assertEqual(prune_receipts.call_count, 2)
+        self.assertEqual(prune_pending_modals.call_count, 2)
+
+    def test_maybe_recover_request_state_rate_limits_repeated_calls(self) -> None:
+        os.environ["GC_SERVICE_NAME"] = common.INTERACTIONS_SERVICE_NAME
+
+        with mock.patch.object(service, "recover_incomplete_requests", return_value=0) as recover_incomplete_requests, mock.patch(
+            "mattermost_intake_service.time.monotonic",
+            side_effect=[200.0, 200.5, 261.0],
+        ):
+            self.assertTrue(service.maybe_recover_request_state())
+            self.assertFalse(service.maybe_recover_request_state())
+            self.assertTrue(service.maybe_recover_request_state())
+
+        self.assertEqual(recover_incomplete_requests.call_count, 2)
+
+    def test_maybe_recover_request_state_skips_non_interactions_service(self) -> None:
+        os.environ["GC_SERVICE_NAME"] = common.ADMIN_SERVICE_NAME
+
+        with mock.patch.object(service, "recover_incomplete_requests") as recover_incomplete_requests:
+            self.assertFalse(service.maybe_recover_request_state())
+
+        recover_incomplete_requests.assert_not_called()
+
+    def test_should_run_request_recovery_only_for_interactions_service(self) -> None:
+        with mock.patch.object(common, "current_service_name", return_value=common.ADMIN_SERVICE_NAME):
+            self.assertFalse(service.should_run_request_recovery())
+        with mock.patch.object(common, "current_service_name", return_value=common.INTERACTIONS_SERVICE_NAME):
+            self.assertTrue(service.should_run_request_recovery())
+
+    def test_utc_age_seconds_handles_missing_and_malformed_values(self) -> None:
+        self.assertEqual(service.utc_age_seconds(""), float("inf"))
+        self.assertEqual(service.utc_age_seconds("not-a-timestamp"), float("inf"))
+        self.assertLess(service.utc_age_seconds(common.utcnow()), 60)
+
+    # ------------------------------------------------------------------
+    # receipts / replay
+    # ------------------------------------------------------------------
+
+    def test_command_interaction_id_is_stable_per_trigger(self) -> None:
+        first = service.command_interaction_id({"trigger_id": "trigger-1"})
+        second = service.command_interaction_id({"trigger_id": "trigger-1"})
+
+        self.assertEqual(first, second)
+        self.assertTrue(first.startswith("mm-command:"))
+        self.assertNotEqual(service.command_interaction_id({}), service.command_interaction_id({}))
+
+    def test_dialog_interaction_id_requires_a_nonce(self) -> None:
+        self.assertEqual(service.dialog_interaction_id(""), "")
+        self.assertEqual(service.dialog_interaction_id("nonce-1"), "mm-dialog:nonce-1")
+
+    def test_finalize_dialog_origin_receipt_replaces_stale_dialog_replay(self) -> None:
+        common.save_interaction_receipt("slash-1", {"response_kind": "dialog", "dialog_nonce": "nonce-1"})
+        receipt = {"response_kind": "accepted", "request_id": "mm-1", "response": {}}
+
+        service.finalize_dialog_origin_receipt("slash-1", receipt)
+
+        saved = common.load_interaction_receipt("slash-1")
+        assert saved is not None
+        self.assertEqual(saved["response_kind"], "accepted")
+        # The dialog-submission body must not be replayed to a slash command.
+        self.assertNotIn("response", saved)
+        replayed = service.replay_response_from_receipt(saved, surface="command")
+        self.assertEqual(replayed["response_type"], "in_channel")
+        self.assertIn("Accepted /gc fix", replayed["text"])
+        self.assertIn("mm-1", replayed["text"])
+
+    def test_persist_interaction_receipt_makes_dialog_submit_replay_safe(self) -> None:
+        response = service.build_dialog_ok_response()
+        receipt = {"response_kind": "accepted", "request_id": "mm-2", "response": response}
+
+        service.persist_interaction_receipt("mm-dialog:nonce-2", receipt)
+
+        saved = common.load_interaction_receipt("mm-dialog:nonce-2")
+        assert saved is not None
+        self.assertEqual(saved["response_kind"], "accepted")
+        self.assertEqual(service.replay_response_from_receipt(saved, surface="dialog"), response)
+
+    def test_persist_interaction_receipt_saves_prompt_path_response(self) -> None:
+        response = service.build_message_response("team only", ephemeral=True)
+        receipt = service.receipt_payload(response, response_kind="message")
+
+        service.persist_interaction_receipt("interaction-1", receipt)
+
+        saved = common.load_interaction_receipt("interaction-1")
+        assert saved is not None
+        self.assertEqual(saved["response_kind"], "message")
+        self.assertEqual(service.replay_response_from_receipt(saved), response)
+
+    def test_replay_response_from_receipt_rebuilds_duplicate_notice(self) -> None:
+        receipt = {"response_kind": "duplicate", "request_id": "mm-dup"}
+
+        replayed = service.replay_response_from_receipt(receipt, surface="command")
+
+        self.assertEqual(replayed["response_type"], "ephemeral")
+        self.assertIn("already active", replayed["text"])
+
+    def test_replay_response_from_receipt_returns_empty_body_for_dialog_surface(self) -> None:
+        receipt = {"response_kind": "dialog", "dialog_nonce": "nonce-3"}
+
+        self.assertEqual(service.replay_response_from_receipt(receipt, surface="command"), {})
+        self.assertEqual(service.replay_response_from_receipt(receipt, surface="dialog"), {})
+
+    # ------------------------------------------------------------------
+    # HTTP surface
+    # ------------------------------------------------------------------
+
+    def test_slash_command_handler_rejects_invalid_command_token(self) -> None:
+        self.import_app()
+        common.save_command_token(COMMAND_TOKEN)
+        socket_path = self.start_interactions_server()
+        body = urllib.parse.urlencode(self.command_form(token="wrong-token", text="fix crash")).encode("utf-8")
+
+        status, response_body = unix_http_request(
+            socket_path,
+            "POST",
+            common.COMMAND_ROUTE_PATH,
+            body=body,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+
+        self.assertEqual(status, 401)
+        self.assertEqual(json.loads(response_body.decode("utf-8"))["error"], "invalid_command_token")
+
+    def test_slash_command_handler_requires_configured_command_token(self) -> None:
+        self.import_app()
+        socket_path = self.start_interactions_server()
+        body = urllib.parse.urlencode(self.command_form(text="fix crash")).encode("utf-8")
+
+        status, _response_body = unix_http_request(
+            socket_path,
+            "POST",
+            common.COMMAND_ROUTE_PATH,
+            body=body,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+
+        self.assertEqual(status, 503)
+
+    def test_slash_command_handler_answers_form_encoded_callback_over_http(self) -> None:
+        self.import_app()
+        common.save_command_token(COMMAND_TOKEN)
+        socket_path = self.start_interactions_server()
+        body = urllib.parse.urlencode(self.command_form(text="")).encode("utf-8")
+
+        status, response_body = unix_http_request(
+            socket_path,
+            "POST",
+            common.COMMAND_ROUTE_PATH,
+            body=body,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+
+        self.assertEqual(status, 200)
+        payload = json.loads(response_body.decode("utf-8"))
+        self.assertEqual(payload["response_type"], "ephemeral")
+        self.assertEqual(payload["text"], service.human_reason("command_not_supported"))
+
+    def test_slash_command_handler_replays_receipt_for_repeated_trigger(self) -> None:
+        self.import_app()
+        common.save_command_token(COMMAND_TOKEN)
+        socket_path = self.start_interactions_server()
+        body = urllib.parse.urlencode(self.command_form(text="")).encode("utf-8")
+        headers = {"Content-Type": "application/x-www-form-urlencoded"}
+
+        first_status, first_body = unix_http_request(socket_path, "POST", common.COMMAND_ROUTE_PATH, body=body, headers=headers)
+        second_status, second_body = unix_http_request(socket_path, "POST", common.COMMAND_ROUTE_PATH, body=body, headers=headers)
+
+        self.assertEqual(first_status, 200)
+        self.assertEqual(second_status, 200)
+        self.assertEqual(json.loads(first_body.decode("utf-8")), json.loads(second_body.decode("utf-8")))
+
+    def test_dialog_handler_rejects_unsigned_route_token(self) -> None:
+        self.import_app()
+        socket_path = self.start_interactions_server()
+        body = json.dumps({"type": "dialog_submission", "state": "nope"}).encode("utf-8")
+
+        status, response_body = unix_http_request(
+            socket_path,
+            "POST",
+            f"{common.DIALOG_ROUTE_PATH}/not-a-real-token",
+            body=body,
+            headers={"Content-Type": "application/json"},
+        )
+
+        self.assertEqual(status, 401)
+        self.assertEqual(json.loads(response_body.decode("utf-8"))["error"], "invalid_dialog_route_token")
+
+    def test_dialog_handler_rejects_expired_dialog_state(self) -> None:
+        self.import_app()
+        socket_path = self.start_interactions_server()
+        route_token = common.dialog_route_token()
+        body = json.dumps(
+            {
+                "type": "dialog_submission",
+                "callback_id": service.FIX_DIALOG_CALLBACK_ID,
+                "state": "stale-state",
+                "user_id": USER_ID,
+                "channel_id": CHANNEL_ID,
+                "team_id": TEAM_ID,
+                "submission": {"summary": "Crash"},
+            }
+        ).encode("utf-8")
+
+        status, response_body = unix_http_request(
+            socket_path,
+            "POST",
+            f"{common.DIALOG_ROUTE_PATH}/{route_token}",
+            body=body,
+            headers={"Content-Type": "application/json"},
+        )
+
+        self.assertEqual(status, 200)
+        self.assertEqual(
+            json.loads(response_body.decode("utf-8")),
+            {"error": service.human_reason("dialog_expired")},
+        )
+
+    def test_dialog_handler_accepts_submission_and_dispatches_request(self) -> None:
+        self.import_app()
+        common.set_channel_mapping(common.load_config(), TEAM_ID, CHANNEL_ID, "product/polecat", common.FIX_FORMULA_DEFAULT)
+        common.save_bot_token("bot-token")
+        socket_path = self.start_interactions_server()
+        route_token = common.dialog_route_token()
+        nonce = "nonce-accept-1"
+        common.save_pending_modal(
+            {
+                "nonce": nonce,
+                "team_id": TEAM_ID,
+                "team_domain": "acme",
+                "channel_id": CHANNEL_ID,
+                "channel_name": "town-square",
+                "root_id": "",
+                "user_id": USER_ID,
+                "user_name": "alice",
+                "interaction_id": "mm-command:trigger-1",
+                "command": "fix",
+                "command_trigger": "/gc",
+                "rig_name": "",
+            }
+        )
+        body = json.dumps(
+            {
+                "type": "dialog_submission",
+                "callback_id": service.FIX_DIALOG_CALLBACK_ID,
+                "state": common.mint_dialog_state(nonce),
+                "user_id": USER_ID,
+                "channel_id": CHANNEL_ID,
+                "team_id": TEAM_ID,
+                "submission": {"summary": "Crash on startup", "context": "unset env X"},
+                "cancelled": False,
+            }
+        ).encode("utf-8")
+
+        with mock.patch.object(service, "enqueue_request") as enqueue_request, mock.patch.object(
+            common, "post_channel_message", return_value={"id": "post-9"}
+        ) as post_channel_message:
+            status, response_body = unix_http_request(
+                socket_path,
+                "POST",
+                f"{common.DIALOG_ROUTE_PATH}/{route_token}",
+                body=body,
+                headers={"Content-Type": "application/json"},
+            )
+
+        self.assertEqual(status, 200)
+        self.assertEqual(json.loads(response_body.decode("utf-8")), {})
+        enqueue_request.assert_called_once()
+        post_channel_message.assert_called_once()
+        request = common.list_recent_requests(limit=1)[0]
+        self.assertEqual(request["summary"], "Crash on startup")
+        self.assertEqual(request["dispatch_target"], "product/polecat")
+        # The originating slash-command receipt is rewritten so a replay is safe.
+        origin = common.load_interaction_receipt("mm-command:trigger-1")
+        assert origin is not None
+        self.assertEqual(origin["response_kind"], "accepted")
+
+    def test_dialog_handler_accepts_cancellation_without_dispatching(self) -> None:
+        self.import_app()
+        socket_path = self.start_interactions_server()
+        route_token = common.dialog_route_token()
+        nonce = "nonce-cancel-1"
+        common.save_pending_modal(
+            {
+                "nonce": nonce,
+                "team_id": TEAM_ID,
+                "channel_id": CHANNEL_ID,
+                "user_id": USER_ID,
+                "interaction_id": "mm-command:trigger-cancel",
+                "command": "fix",
+            }
+        )
+        body = json.dumps(
+            {
+                "type": "dialog_submission",
+                "state": common.mint_dialog_state(nonce),
+                "user_id": USER_ID,
+                "channel_id": CHANNEL_ID,
+                "team_id": TEAM_ID,
+                "submission": {},
+                "cancelled": True,
+            }
+        ).encode("utf-8")
+
+        with mock.patch.object(service, "enqueue_request") as enqueue_request:
+            status, response_body = unix_http_request(
+                socket_path,
+                "POST",
+                f"{common.DIALOG_ROUTE_PATH}/{route_token}",
+                body=body,
+                headers={"Content-Type": "application/json"},
+            )
+
+        self.assertEqual(status, 200)
+        self.assertEqual(json.loads(response_body.decode("utf-8")), {})
+        enqueue_request.assert_not_called()
+        self.assertEqual(common.list_recent_requests(limit=20), [])
+
+    def test_dialog_handler_rejects_mismatched_channel_context(self) -> None:
+        self.import_app()
+        socket_path = self.start_interactions_server()
+        route_token = common.dialog_route_token()
+        nonce = "nonce-mismatch-1"
+        common.save_pending_modal(
+            {
+                "nonce": nonce,
+                "team_id": TEAM_ID,
+                "channel_id": CHANNEL_ID,
+                "user_id": USER_ID,
+                "interaction_id": "mm-command:trigger-mismatch",
+                "command": "fix",
+            }
+        )
+        body = json.dumps(
+            {
+                "type": "dialog_submission",
+                "state": common.mint_dialog_state(nonce),
+                "user_id": USER_ID,
+                "channel_id": OTHER_CHANNEL_ID,
+                "team_id": TEAM_ID,
+                "submission": {"summary": "Crash"},
+            }
+        ).encode("utf-8")
+
+        status, response_body = unix_http_request(
+            socket_path,
+            "POST",
+            f"{common.DIALOG_ROUTE_PATH}/{route_token}",
+            body=body,
+            headers={"Content-Type": "application/json"},
+        )
+
+        self.assertEqual(status, 200)
+        self.assertEqual(
+            json.loads(response_body.decode("utf-8")),
+            {"error": service.human_reason("bad_dialog_context")},
+        )
+
+    def test_message_action_route_reports_unsupported_action(self) -> None:
+        self.import_app()
+        socket_path = self.start_interactions_server()
+        route_token = common.dialog_route_token()
+
+        status, response_body = unix_http_request(
+            socket_path,
+            "POST",
+            f"{common.ACTION_ROUTE_PATH}/{route_token}",
+            body=json.dumps({"user_id": USER_ID}).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+        )
+
+        self.assertEqual(status, 200)
+        self.assertIn("Unsupported", json.loads(response_body.decode("utf-8"))["ephemeral_text"])
+
+    def test_interactions_healthz_and_root(self) -> None:
+        socket_path = self.start_interactions_server()
+
+        status, _body = unix_http_request(socket_path, "GET", "/healthz")
+        self.assertEqual(status, 204)
+
+        status, body = unix_http_request(socket_path, "GET", "/")
+        self.assertEqual(status, 200)
+        self.assertEqual(json.loads(body.decode("utf-8"))["service"], common.INTERACTIONS_SERVICE_NAME)
+
+    def test_unknown_interactions_route_is_not_found(self) -> None:
+        socket_path = self.start_interactions_server()
+
+        status, body = unix_http_request(
+            socket_path,
+            "POST",
+            "/mattermost/nope",
+            body=b"{}",
+            headers={"Content-Type": "application/json"},
+        )
+
+        self.assertEqual(status, 404)
+        self.assertEqual(json.loads(body.decode("utf-8"))["error"], "not_found")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mattermost/tests/test_mattermost_release_workflow.py
+++ b/mattermost/tests/test_mattermost_release_workflow.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import io
+import json
+import pathlib
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+
+import os
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+
+import mattermost_intake_common as common
+import mattermost_intake_release_workflow as release_script
+
+
+class MattermostReleaseWorkflowTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self._old_environ = os.environ.copy()
+        os.environ["GC_CITY_ROOT"] = self.tempdir.name
+
+    def tearDown(self) -> None:
+        os.environ.clear()
+        os.environ.update(self._old_environ)
+
+    def test_release_workflow_by_request_id_only_releases_matching_link(self) -> None:
+        workflow_key = "mm:team:1:conversation:22:fix"
+        common.save_request({"request_id": "mm-old", "workflow_key": workflow_key})
+        common.save_request({"request_id": "mm-new", "workflow_key": workflow_key})
+        common.save_workflow_link(workflow_key, "mm-new")
+
+        stdout = io.StringIO()
+        with redirect_stdout(stdout):
+            code = release_script.main(["--request-id", "mm-old"])
+
+        self.assertEqual(code, 1)
+        payload = json.loads(stdout.getvalue())
+        self.assertFalse(payload["released"])
+        current = common.load_workflow_link(workflow_key)
+        self.assertIsNotNone(current)
+        assert current is not None
+        self.assertEqual(current["request_id"], "mm-new")
+
+    def test_release_workflow_by_request_id_releases_matching_link(self) -> None:
+        workflow_key = "mm:team:1:conversation:23:fix"
+        common.save_request({"request_id": "mm-23", "workflow_key": workflow_key})
+        common.save_workflow_link(workflow_key, "mm-23")
+
+        stdout = io.StringIO()
+        with redirect_stdout(stdout):
+            code = release_script.main(["--request-id", "mm-23"])
+
+        self.assertEqual(code, 0)
+        payload = json.loads(stdout.getvalue())
+        self.assertTrue(payload["released"])
+        self.assertEqual(payload["request_id"], "mm-23")
+        self.assertIsNone(common.load_workflow_link(workflow_key))
+        request = common.load_request("mm-23")
+        self.assertIsNotNone(request)
+        assert request is not None
+        self.assertIn("workflow_released_at", request)
+
+    def test_release_workflow_by_conversation_releases_rig_scoped_locks(self) -> None:
+        workflow_key = "mm:team:1:conversation:24:fix:rig:mission-control"
+        common.save_workflow_link(workflow_key, "mm-rig-24")
+
+        stdout = io.StringIO()
+        with redirect_stdout(stdout):
+            code = release_script.main(["1", "24"])
+
+        self.assertEqual(code, 0)
+        payload = json.loads(stdout.getvalue())
+        self.assertTrue(payload["released"])
+        self.assertEqual(payload["released_keys"], [workflow_key])
+        self.assertIsNone(common.load_workflow_link(workflow_key))
+
+    def test_release_workflow_by_conversation_skips_invalid_json_files(self) -> None:
+        workflow_key = "mm:team:1:conversation:25:fix:rig:mission-control"
+        common.save_workflow_link(workflow_key, "mm-rig-25")
+        pathlib.Path(common.workflows_dir(), "broken.json").write_text("{not-json", encoding="utf-8")
+
+        stdout = io.StringIO()
+        with redirect_stdout(stdout):
+            code = release_script.main(["1", "25"])
+
+        self.assertEqual(code, 0)
+        payload = json.loads(stdout.getvalue())
+        self.assertTrue(payload["released"])
+        self.assertEqual(payload["released_keys"], [workflow_key])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Ports the `discord` pack's architecture to Mattermost's REST v4 + WebSocket API: gateway/intake services, chat bind/publish/reply/react/upload commands, room-launch support, doctor checks, formulas, and prompt template.
- `react` and `upload` have no discord equivalent — designed fresh against Mattermost's reactions/files REST endpoints.
- Fixes a real bug found during test porting: `bind-room --root-id` bindings stored `channel_id`+`root_id` as one composite string that was then sent to `POST /posts` as a literal (invalid) `channel_id`. Bindings now carry `channel_id`/`root_id` as explicit fields, verified with a save/normalize/load round-trip test **and live against a real server (see below)**.
- Adds `mattermost/tests` (494 tests, ported from discord's suite plus new coverage for react/upload) and wires `mattermost/tests` into `.github/workflows/ci.yml`'s pytest invocation, which omitted it.

## Test plan
- [x] `py_compile` clean on all 16 scripts + 7 test files
- [x] `python3 -m pytest mattermost/tests -q` — 494 passed, 1 skipped
- [x] Full CI pytest line (`tests contributing/tests gascity/tests discord/tests github/tests mattermost/tests slack-full/tests slack-channel/tests pr-pipeline/tests profiler/tests`) run locally in a clean venv — 1665 passed, 9 skipped, no regressions
- [x] `validate_registry.py` — ok
- [x] **Live smoke test against a real Mattermost server** (v11.9.0) — created a disposable bot account + token via `mmctl`, ran the actual shipped scripts (not mocks) against it, then fully cleaned up (token revoked, channel archived, temp admin deleted, bot disabled):
  - `mattermost_intake_import.py` — real config import against the live site URL
  - `mattermost_chat_bind.py` + `mattermost_chat_publish.py` — real whole-channel post, real threaded reply (`--reply-to`), and critically **the thread-binding fix**: `bind-room --root-id` followed by publish correctly posted to the real `channel_id` with the pinned `root_id`, not the broken composite string the old code would have sent
  - `mattermost_chat_react.py` — real reaction added to a real post
  - `mattermost_intake_common.upload_and_post_files` — real multipart file upload, attached to a real post
  - `mattermost_gateway_service.GatewayWebSocket` — real WebSocket connect + TLS + auth handshake to mattermost, received a real `hello` event, then received a real `posted` event (matching post ID) triggered by a concurrent REST post
  - `bot_was_mentioned` — verified live against real posts: a bare `@channel` does not count as a mention; `@channel` + an explicit `@<botusername>` does