### PR TITLE
Gastown dog and patrol formulas mis-handle a missing work-bead id under the claude provider

### DIFF
--- a/gastown/formulas/mol-deacon-patrol.toml
+++ b/gastown/formulas/mol-deacon-patrol.toml
@@ -534,7 +534,7 @@ Handle any urgent messages that arrived during patrol. Archive the rest.
 
 **3. Resolve current wisp and pour next iteration BEFORE burning:**
 ```bash
-CURRENT_WISP=${GC_BEAD_ID:-}
+CURRENT_WISP=${GC_BEAD_ID:-${GC_TRIGGER_WORK_BEAD_ID:-}}
 if [ -z "$CURRENT_WISP" ]; then
   CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
 fi

--- a/gastown/formulas/mol-deacon-patrol.toml
+++ b/gastown/formulas/mol-deacon-patrol.toml
@@ -534,6 +534,12 @@ Handle any urgent messages that arrived during patrol. Archive the rest.
 
 **3. Resolve current wisp and pour next iteration BEFORE burning:**
 ```bash
+# Preferring the spawn trigger is safe here only because the deacon is a
+# singleton with a fresh wake (agents/deacon/agent.toml: max_active_sessions = 1,
+# wake_mode = "fresh"), so one process env holds exactly one wisp and the
+# trigger cannot name a foreign molecule. Do not copy this order into a pooled
+# role, and do not keep it here if this formula ever rotates wisps in-session
+# or the deacon gains a second slot.
 CURRENT_WISP=${GC_BEAD_ID:-${GC_TRIGGER_WORK_BEAD_ID:-}}
 if [ -z "$CURRENT_WISP" ]; then
   CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')

--- a/gastown/formulas/mol-refinery-patrol.toml
+++ b/gastown/formulas/mol-refinery-patrol.toml
@@ -117,7 +117,7 @@ If context feels heavy (multi-hour session, large recent diffs, or you notice
 yourself taking shortcuts or summarizing prematurely), pour and assign the next
 wisp, burn the current wisp, then request a restart:
 ```bash
-CURRENT_WISP=${GC_BEAD_ID:-}
+CURRENT_WISP=${GC_BEAD_ID:-${GC_TRIGGER_WORK_BEAD_ID:-}}
 if [ -z "$CURRENT_WISP" ]; then
   CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
 fi
@@ -240,7 +240,7 @@ gc bd update $WORK \
 5. Clean up temp branch: `git checkout {{target_branch}} && git branch -D temp`
 6. Pour next patrol iteration before burning:
 ```bash
-CURRENT_WISP=${GC_BEAD_ID:-}
+CURRENT_WISP=${GC_BEAD_ID:-${GC_TRIGGER_WORK_BEAD_ID:-}}
 if [ -z "$CURRENT_WISP" ]; then
   CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
 fi
@@ -341,7 +341,7 @@ TARGET=$(gc bd show $WORK --json | jq -r '.[0].metadata.target // "{{target_bran
    - Clean up: `git checkout "$TARGET" && git branch -D temp`
    - Pour next patrol iteration before burning:
      ```bash
-     CURRENT_WISP=${GC_BEAD_ID:-}
+     CURRENT_WISP=${GC_BEAD_ID:-${GC_TRIGGER_WORK_BEAD_ID:-}}
      if [ -z "$CURRENT_WISP" ]; then
        CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
      fi
@@ -433,7 +433,7 @@ Work bead: $WORK
 Existing PR: $EXISTING_PR
 Branch: $BRANCH
 Target: $TARGET"
-  CURRENT_WISP=${GC_BEAD_ID:-}
+  CURRENT_WISP=${GC_BEAD_ID:-${GC_TRIGGER_WORK_BEAD_ID:-}}
   if [ -z "$CURRENT_WISP" ]; then
     CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
   fi
@@ -1141,7 +1141,7 @@ If auto_land = "false": skip this entirely.
 
 **2. Resolve the current wisp, pour next iteration, then burn this wisp:**
 ```bash
-CURRENT_WISP=${GC_BEAD_ID:-}
+CURRENT_WISP=${GC_BEAD_ID:-${GC_TRIGGER_WORK_BEAD_ID:-}}
 if [ -z "$CURRENT_WISP" ]; then
   CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
 fi

--- a/gastown/formulas/mol-refinery-patrol.toml
+++ b/gastown/formulas/mol-refinery-patrol.toml
@@ -117,7 +117,7 @@ If context feels heavy (multi-hour session, large recent diffs, or you notice
 yourself taking shortcuts or summarizing prematurely), pour and assign the next
 wisp, burn the current wisp, then request a restart:
 ```bash
-CURRENT_WISP=${GC_BEAD_ID:-${GC_TRIGGER_WORK_BEAD_ID:-}}
+CURRENT_WISP=${GC_BEAD_ID:-}
 if [ -z "$CURRENT_WISP" ]; then
   CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
 fi
@@ -240,7 +240,7 @@ gc bd update $WORK \
 5. Clean up temp branch: `git checkout {{target_branch}} && git branch -D temp`
 6. Pour next patrol iteration before burning:
 ```bash
-CURRENT_WISP=${GC_BEAD_ID:-${GC_TRIGGER_WORK_BEAD_ID:-}}
+CURRENT_WISP=${GC_BEAD_ID:-}
 if [ -z "$CURRENT_WISP" ]; then
   CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
 fi
@@ -341,7 +341,7 @@ TARGET=$(gc bd show $WORK --json | jq -r '.[0].metadata.target // "{{target_bran
    - Clean up: `git checkout "$TARGET" && git branch -D temp`
    - Pour next patrol iteration before burning:
      ```bash
-     CURRENT_WISP=${GC_BEAD_ID:-${GC_TRIGGER_WORK_BEAD_ID:-}}
+     CURRENT_WISP=${GC_BEAD_ID:-}
      if [ -z "$CURRENT_WISP" ]; then
        CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
      fi
@@ -433,7 +433,7 @@ Work bead: $WORK
 Existing PR: $EXISTING_PR
 Branch: $BRANCH
 Target: $TARGET"
-  CURRENT_WISP=${GC_BEAD_ID:-${GC_TRIGGER_WORK_BEAD_ID:-}}
+  CURRENT_WISP=${GC_BEAD_ID:-}
   if [ -z "$CURRENT_WISP" ]; then
     CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
   fi
@@ -1141,7 +1141,7 @@ If auto_land = "false": skip this entirely.
 
 **2. Resolve the current wisp, pour next iteration, then burn this wisp:**
 ```bash
-CURRENT_WISP=${GC_BEAD_ID:-${GC_TRIGGER_WORK_BEAD_ID:-}}
+CURRENT_WISP=${GC_BEAD_ID:-}
 if [ -z "$CURRENT_WISP" ]; then
   CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
 fi

--- a/gastown/formulas/mol-shutdown-dance.toml
+++ b/gastown/formulas/mol-shutdown-dance.toml
@@ -13,6 +13,9 @@ gc bd create --type=task \
 The dog pool picks up the warrant and runs this formula against the
 claimed warrant bead. The claimed bead is the warrant id; use
 `$GC_BEAD_ID` for warrant verification, closure, and audit output.
+Some providers export the claimed bead id only as `GC_TRIGGER_WORK_BEAD_ID`
+(never `GC_BEAD_ID`), so every snippet block below first normalizes the id
+with a fallback that fails loudly when neither variable is set.
 Existing warrant producers provide `target`, `reason`, and `requester`
 metadata, not a separate `warrant_id`. Each warrant is one shutdown dance
 for one target. On crash, re-read formula steps and resume from context
@@ -22,6 +25,7 @@ Before running command snippets in any step, load warrant metadata into quoted
 shell variables:
 
 ```bash
+GC_BEAD_ID="${GC_BEAD_ID:-${GC_TRIGGER_WORK_BEAD_ID:?no work bead id in env}}"
 warrant_json="$(gc bd show "$GC_BEAD_ID" --json)"
 target="$(printf '%s' "$warrant_json" | jq -r '.[0].metadata.target // empty')"
 reason="$(printf '%s' "$warrant_json" | jq -r '.[0].metadata.reason // empty')"
@@ -82,6 +86,7 @@ Entry point. Read the warrant metadata from the claimed warrant bead.
 
 **1. Read warrant details:**
 ```bash
+GC_BEAD_ID="${GC_BEAD_ID:-${GC_TRIGGER_WORK_BEAD_ID:?no work bead id in env}}"
 warrant_json="$(gc bd show "$GC_BEAD_ID" --json)"
 target="$(printf '%s' "$warrant_json" | jq -r '.[0].metadata.target // empty')"
 reason="$(printf '%s' "$warrant_json" | jq -r '.[0].metadata.reason // empty')"

--- a/gastown/formulas/mol-shutdown-dance.toml
+++ b/gastown/formulas/mol-shutdown-dance.toml
@@ -13,9 +13,19 @@ gc bd create --type=task \
 The dog pool picks up the warrant and runs this formula against the
 claimed warrant bead. The claimed bead is the warrant id; use
 `$GC_BEAD_ID` for warrant verification, closure, and audit output.
-Some providers export the claimed bead id only as `GC_TRIGGER_WORK_BEAD_ID`
-(never `GC_BEAD_ID`), so every snippet block below first normalizes the id
-with a fallback that fails loudly when neither variable is set.
+Some providers never export `GC_BEAD_ID`; there the id arrives as
+`GC_TRIGGER_WORK_BEAD_ID`, the bead that triggered this session. The trigger
+variable is fixed at spawn and is not advanced by `gc hook --claim`, so in a
+pool it can name a bead this session never claimed. This dance belongs to the
+warrant this session claimed, so the two warrant-metadata blocks — the preamble
+below and step 1 of `receive-warrant` — resolve the claim with
+`gc hook current --id-only` **first**, fall back to the trigger only when
+nothing is claimed, and fail loudly when neither is available. Order matters:
+appending the resolver after the trigger instead is inert, because
+`${A:-${B:-$(C)}}` never evaluates `$(C)` while `B` is non-empty, and a stale
+trigger would still win. Later blocks reuse the normalized value, so re-run the
+preamble first in any fresh shell: `$GC_BEAD_ID`, `$target`, `$reason`,
+`$requester`, and `$requester_endpoint` do not survive across shells.
 Existing warrant producers provide `target`, `reason`, and `requester`
 metadata, not a separate `warrant_id`. Each warrant is one shutdown dance
 for one target. On crash, re-read formula steps and resume from context
@@ -25,6 +35,7 @@ Before running command snippets in any step, load warrant metadata into quoted
 shell variables:
 
 ```bash
+GC_BEAD_ID="${GC_BEAD_ID:-$(gc hook current --id-only 2>/dev/null)}"
 GC_BEAD_ID="${GC_BEAD_ID:-${GC_TRIGGER_WORK_BEAD_ID:?no work bead id in env}}"
 warrant_json="$(gc bd show "$GC_BEAD_ID" --json)"
 target="$(printf '%s' "$warrant_json" | jq -r '.[0].metadata.target // empty')"
@@ -86,6 +97,7 @@ Entry point. Read the warrant metadata from the claimed warrant bead.
 
 **1. Read warrant details:**
 ```bash
+GC_BEAD_ID="${GC_BEAD_ID:-$(gc hook current --id-only 2>/dev/null)}"
 GC_BEAD_ID="${GC_BEAD_ID:-${GC_TRIGGER_WORK_BEAD_ID:?no work bead id in env}}"
 warrant_json="$(gc bd show "$GC_BEAD_ID" --json)"
 target="$(printf '%s' "$warrant_json" | jq -r '.[0].metadata.target // empty')"

--- a/gastown/tests/test_gastown_pack_assets.sh
+++ b/gastown/tests/test_gastown_pack_assets.sh
@@ -111,6 +111,129 @@ test_shutdown_dance_lifecycle_and_audit_contracts() {
         fail "dog prompt DOG_DONE guidance should use the normalized requester endpoint"
 }
 
+# Five role-surfaces resolve a work bead from the environment, by deliberately
+# different rules, and the differences are load-bearing. Two properties decide
+# which form is safe -- NOT "pooled vs singleton": the refinery and the deacon
+# carry identical max_active_sessions = 1 + wake_mode = "fresh" pins, so pooling
+# cannot tell them apart. What differs is (a) whether more than one session
+# shares the env, and (b) whether the role rotates wisps IN-SESSION, which makes
+# a spawn-fixed trigger go stale mid-loop:
+#   shutdown dance (dog pool, max_active_sessions = 3) - resolve the CLAIM
+#     first. The spawn trigger is fixed at wake and is not advanced by
+#     `gc hook --claim`, so under contention it names a bead this session never
+#     claimed - and the dance closes whatever it resolves.
+#   deacon patrol formula (singleton, wake_mode = "fresh", pours the next wisp
+#     then EXITS the turn) - may prefer the trigger: one process env holds
+#     exactly one wisp for its whole life.
+#   refinery patrol formula (singleton too, but re-reads the formula steps
+#     in-session after burning) - bare ${GC_BEAD_ID:-} plus a live assignee
+#     query, never the trigger: the wisp advances while the trigger does not.
+#   refinery / witness / deacon prompt templates - bare ${GC_BEAD_ID:-} plus the
+#     same live query. Exempt from the trigger rule by form, not by luck: a bare
+#     resolution backed by the assignee query cannot mis-select on any role, so
+#     it stays correct even on the singletons. Pinned below so the exemption is
+#     gated rather than conventional.
+# Pin the discriminator, and the rotation property it rests on, so the forms
+# cannot silently converge on the permissive one.
+test_work_bead_resolution_discriminator_is_pinned() {
+    local dance="$GASTOWN/formulas/mol-shutdown-dance.toml"
+    local deacon="$GASTOWN/formulas/mol-deacon-patrol.toml"
+    local refinery="$GASTOWN/formulas/mol-refinery-patrol.toml"
+    local refinery_prompt="$GASTOWN/agents/refinery/prompt.template.md"
+
+    local claim_first='GC_BEAD_ID="${GC_BEAD_ID:-$(gc hook current --id-only 2>/dev/null)}"'
+    local trigger_fallback='GC_BEAD_ID="${GC_BEAD_ID:-${GC_TRIGGER_WORK_BEAD_ID:?no work bead id in env}}"'
+
+    # Order-sensitive by construction: presence greps alone would stay green on
+    # a reordering. Record both forms in file order and require claim-then-
+    # trigger at exactly the two normalization sites the formula prose names.
+    local dance_order
+    dance_order="$(awk -v claim="$claim_first" -v trig="$trigger_fallback" '
+        index($0, claim) { printf "C"; next }
+        index($0, trig)  { printf "T" }
+    ' "$dance")"
+    [[ "$dance_order" == "CTCT" ]] ||
+        fail "shutdown dance must resolve the claimed warrant before the spawn trigger at exactly the two normalization sites (preamble and receive-warrant step 1); got '$dance_order'"
+
+    # Nesting the resolver inside the trigger fallback is inert: ${A:-${B:-$(C)}}
+    # never evaluates $(C) while B is non-empty, so a stale trigger still wins
+    # and the dance closes a foreign bead.
+    ! grep -F 'GC_TRIGGER_WORK_BEAD_ID:-$(gc hook current' "$dance" >/dev/null ||
+        fail "shutdown dance must not nest the claim resolver inside the trigger fallback; that form is inert whenever the trigger is set"
+
+    # The signature above matches two exact literals, so it is blind to a
+    # NOVEL-form trigger resolution added to a third block (a bare
+    # ${GC_TRIGGER_WORK_BEAD_ID:-} matches neither literal and leaves the
+    # signature at CTCT). Bound the references instead of only their shape, so a
+    # new one has to be added consciously rather than silently.
+    local dance_trigger_refs
+    dance_trigger_refs="$(grep -cF 'GC_TRIGGER_WORK_BEAD_ID' "$dance" || true)"
+    [[ "$dance_trigger_refs" -eq 3 ]] ||
+        fail "shutdown dance must carry exactly 3 GC_TRIGGER_WORK_BEAD_ID references (the prose paragraph plus the two fallback lines); got $dance_trigger_refs. A new one is a new resolution site: update the prose contract and this pin together."
+
+    local deacon_trigger
+    deacon_trigger="$(grep -cF 'CURRENT_WISP=${GC_BEAD_ID:-${GC_TRIGGER_WORK_BEAD_ID:-}}' "$deacon" || true)"
+    [[ "$deacon_trigger" -eq 1 ]] ||
+        fail "deacon patrol should keep exactly one trigger-preferring wisp resolution; got $deacon_trigger"
+    grep -F 'max_active_sessions = 1' "$GASTOWN/agents/deacon/agent.toml" >/dev/null ||
+        fail "the deacon's trigger-first wisp resolution is safe only while the deacon is a singleton; agent.toml no longer pins max_active_sessions = 1"
+    grep -F 'wake_mode = "fresh"' "$GASTOWN/agents/deacon/agent.toml" >/dev/null ||
+        fail "the deacon's trigger-first wisp resolution is safe only on a fresh wake; agent.toml no longer pins wake_mode"
+
+    # The third precondition lives in the formula, not in agent.toml, so neither
+    # pin above can ever catch its loss: the deacon pours the successor, burns
+    # this wisp, and EXITS the turn, so one process env holds exactly one wisp
+    # for its whole life and the restarted session gets a fresh trigger. An
+    # in-session loop here revives the stale-trigger failure with both config
+    # pins still green.
+    grep -F 'IDLE: no work, exiting turn.' "$deacon" >/dev/null ||
+        fail "the deacon's trigger-first wisp resolution is safe only while each iteration ends by exiting the turn; mol-deacon-patrol.toml no longer emits the IDLE exit signal"
+    grep -F 'the restarted session resumes from it' "$deacon" >/dev/null ||
+        fail "the deacon's trigger-first wisp resolution is safe only while the successor wisp is resumed by a RESTARTED session (fresh trigger); mol-deacon-patrol.toml no longer hands the successor to a restarted session"
+    ! grep -F 're-read formula steps to begin' "$deacon" >/dev/null ||
+        fail "the deacon now rotates wisps in-session like the refinery, so its spawn trigger goes stale mid-loop; mol-deacon-patrol.toml must drop the trigger-preferring resolution for the bare \${GC_BEAD_ID:-} plus live assignee query"
+
+    # The refinery's opposite rule rests on the opposite property, so pin that
+    # too rather than leaving it asserted only in a comment: it re-reads the
+    # formula steps in-session after burning, advancing the wisp while the
+    # spawn-fixed trigger stays put.
+    grep -F 're-read formula steps to begin' "$refinery" >/dev/null ||
+        fail "the refinery no longer rotates wisps in-session; that rotation is the recorded reason it must never resolve a wisp from the spawn trigger, so re-derive the per-role rule and this discriminator before relaxing either form"
+
+    # Every environment-resolved wisp assignment in the refinery must be the
+    # bare query-backed form. Comparing the two counts catches conversion in
+    # either direction without freezing the number of call sites.
+    local path env_assignments bare_assignments
+    for path in "$refinery" "$refinery_prompt"; do
+        ! grep -F 'GC_TRIGGER_WORK_BEAD_ID' "$path" >/dev/null ||
+            fail "the refinery rotates wisps in-session, so a spawn-fixed trigger goes stale mid-loop; it must resolve every wisp from \$GC_BEAD_ID plus the live assignee query, never the trigger: $path"
+        env_assignments="$(grep -cF 'CURRENT_WISP=${GC_BEAD_ID' "$path" || true)"
+        bare_assignments="$(grep -cF 'CURRENT_WISP=${GC_BEAD_ID:-}' "$path" || true)"
+        [[ "$env_assignments" -ge 1 ]] ||
+            fail "refinery should resolve its current wisp from \$GC_BEAD_ID: $path"
+        [[ "$env_assignments" -eq "$bare_assignments" ]] ||
+            fail "every refinery wisp resolution must be the bare \${GC_BEAD_ID:-} form backed by the live assignee query ($bare_assignments of $env_assignments): $path"
+    done
+
+    # The remaining two surfaces of the census in the header comment. They are
+    # correct today by form -- bare plus the live query cannot mis-select on a
+    # singleton -- so gate that exemption instead of leaving it to convention: a
+    # harmonization edit that copies the deacon formula's trigger-preferring
+    # line into either template goes red here rather than passing silently.
+    local template
+    for template in "$GASTOWN/agents/witness/prompt.template.md" \
+                    "$GASTOWN/agents/deacon/prompt.template.md"; do
+        ! grep -F 'GC_TRIGGER_WORK_BEAD_ID' "$template" >/dev/null ||
+            fail "singleton prompt templates stay exempt from the per-role trigger rules by using the bare \${GC_BEAD_ID:-} form; they must not resolve a wisp from the spawn trigger: $template"
+        env_assignments="$(grep -cF 'CURRENT_WISP=${GC_BEAD_ID' "$template" || true)"
+        bare_assignments="$(grep -cF 'CURRENT_WISP=${GC_BEAD_ID:-}' "$template" || true)"
+        [[ "$env_assignments" -ge 1 ]] ||
+            fail "prompt template should resolve its current wisp from \$GC_BEAD_ID: $template"
+        [[ "$env_assignments" -eq "$bare_assignments" ]] ||
+            fail "every prompt-template wisp resolution must be the bare \${GC_BEAD_ID:-} form backed by the live assignee query ($bare_assignments of $env_assignments): $template"
+    done
+}
+
 test_composition_is_documented() {
     # The retired maintenance pack is gone: the runtime composes the builtin
     # core pack via explicit city.toml includes, and gastown owns the only
@@ -291,6 +414,7 @@ test_dog_assets_are_pack_local
 test_retired_dog_formulas_are_not_reintroduced
 test_shutdown_dance_contracts_are_executable
 test_shutdown_dance_lifecycle_and_audit_contracts
+test_work_bead_resolution_discriminator_is_pinned
 test_composition_is_documented
 test_polecat_startup_uses_standard_hook_claim
 test_review_leg_contract_forbids_synthetic_mutation


### PR DESCRIPTION
Three gastown formulas mis-handle a missing work-bead id: the shutdown-dance (the "due process" flow that decides whether to kill a stuck agent) silently operated on an *empty* warrant id, and the patrol formulas fell back to a database query that can pick the wrong item when an agent has several in flight. This change makes the dance resolve the warrant it actually claimed and fail loudly when it cannot, and lets the deacon patrol use the spawn trigger under an explicitly recorded safety precondition.

### Root cause

- Some providers never export `GC_BEAD_ID`. There the id arrives as `GC_TRIGGER_WORK_BEAD_ID` — **the bead that triggered the session, fixed at spawn**. It is *not* advanced by `gc hook --claim`, so in a pool it can name a bead this session never claimed.
- The shutdown-dance snippets used the id unguarded and without strict shell mode, so it expanded to empty — warrant verification and closure ran against an empty id, risking a warrant being misread or mis-closed.
- Naively preferring the trigger is not a safe fix for the dance: under dog-pool contention it would read and **close the wrong bead**. The dance belongs to the warrant *this session claimed*.
- The deacon patrol guarded the id but then always fell through to a "first in-progress molecule" lookup, which is ambiguous when more than one is assigned.

### Fix

- **Shutdown-dance:** normalize the id at the two id-establishing sites (the preamble block and `receive-warrant` step 1) by resolving the session's **claim first**, falling back to the trigger only when nothing is claimed, and aborting loudly when neither exists:
  ```bash
  GC_BEAD_ID="${GC_BEAD_ID:-$(gc hook current --id-only 2>/dev/null)}"
  GC_BEAD_ID="${GC_BEAD_ID:-${GC_TRIGGER_WORK_BEAD_ID:?no work bead id in env}}"
  ```
  Order matters: appending the resolver *after* the trigger instead is inert, because `${A:-${B:-$(C)}}` never evaluates `$(C)` while `B` is non-empty, so a stale trigger would still win.
- **Deacon patrol:** prefer the trigger before the lookup query. This is safe *only* because the deacon is a singleton with a fresh wake (`max_active_sessions = 1`, `wake_mode = "fresh"`), so one process env holds exactly one wisp. That precondition is recorded in the formula and pinned by tests.
- **Refinery patrol:** deliberately **not** changed. It rotates wisps in-session, so a spawn-fixed trigger goes stale mid-loop; the bare `${GC_BEAD_ID:-}` plus live assignee query is the only form that tracks the rotation.

### Tests

`gastown/tests/test_gastown_pack_assets.sh` gains a discriminator test that pins the resolution *form and order* per role: an order-sensitive signature over the dance's two normalization sites, a count pin on the deacon's trigger preference, a negative grep rejecting the inert nested form, and `agent.toml` pins on the deacon's singleton/fresh-wake preconditions. It is registered unconditionally at the runner and executed by CI (`.github/workflows/ci.yml` loops every `gastown/tests/test_*.sh`). All three TOML files parse cleanly; registry validation passes.

---

<details>
<summary>Machine detail</summary>

> **Maintainer note:** this section was rewritten during adoption review. The originally-proposed approach (prefer `GC_TRIGGER_WORK_BEAD_ID` everywhere, including 5 refinery sites) was found to introduce a wrong-bead-close hazard under pool contention and to break the refinery's in-session wisp rotation. The refinery changes were reverted and the dance was changed to claim-first ordering. The description above reflects what actually ships.

**Changed files** (head `354ba3a`, branch `fix/ga-oyp60-gc-bead-id-fallback`, 3 files +148/−1)
- `gastown/formulas/mol-shutdown-dance.toml` (+17) — claim-first normalization at the preamble snippet block and the `receive-warrant` step-1 block (the two id-establishing sites; all later snippets rely on the preamble's "run before any snippet" contract, same as `$target`/`$reason`/`$requester`, so a fresh shell must re-run the preamble). Prose documents the tiebreak order, the fresh-shell rule, and why the appended-resolver form is inert.
- `gastown/formulas/mol-deacon-patrol.toml` (+8/−1) — 1 site: `CURRENT_WISP=${GC_BEAD_ID:-}` → `CURRENT_WISP=${GC_BEAD_ID:-${GC_TRIGGER_WORK_BEAD_ID:-}}`, with the singleton/fresh-wake/no-in-session-rotation preconditions recorded inline.
- `gastown/tests/test_gastown_pack_assets.sh` (+124) — the per-role resolution discriminator described above.
- `gastown/formulas/mol-refinery-patrol.toml` — **not touched** (byte-identical to base).

**Approach / blast radius**
Per-formula resolution rules (provider-agnostic) rather than changing the claude provider to export `GC_BEAD_ID`. Providers that export `GC_BEAD_ID` are unaffected — it wins the chain on every path. The deacon keeps the existing `gc bd list` query as the final fallback, so behavior under providers exporting neither variable is unchanged. The dance change converts a silent empty-id expansion into either a correct claimed-warrant id or a loud abort. No agent config, prompt template, or sibling formula is modified.

**Verification**
- Resolution matrix over the dance form (claimed + foreign trigger → claimed bead; agreement → same bead; nothing claimed → trigger fallback preserves the original provider fix; neither → `:?` aborts non-zero; exported `GC_BEAD_ID` wins untouched).
- Discriminator mutation coverage: reordering a site, the nested form, an added trigger-preferring deacon line, converting a refinery site, and flipping the deacon to two slots each turn the suite red; the restored tree is green.
- `python3 -c "import tomllib; tomllib.load(...)"` on all three formulas → OK; `python3 validate_registry.py registry.toml` → ok; `go test .` → ok; full `gastown` asset suite green at head.

**Post-merge verification**
- Next shutdown-dance run under a provider that does not export `GC_BEAD_ID`: the dog's transcript should show `gc bd show <real-warrant-id>` (the id this session claimed) in the receive-warrant step, and warrants should close with reasons naming the actual claimed warrant bead. Signal: no empty-id invocations and no `MALFORMED_WARRANT` closes against empty ids.
- Next deacon patrol burn-and-repour: `CURRENT_WISP` should resolve directly. Signal: the deacon stops invoking the `gc bd list --assignee=... --limit=1` fallback query on the resolve step when the trigger env is present.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
