### PR TITLE
feat(slack-mini): Socket Mode transport for ingress-free installs

### DIFF
--- a/slack-mini/CHANGELOG.md
+++ b/slack-mini/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to slack-mini are documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Socket Mode transport** (`adapter/socketmode.go`), an ingress-free
+  alternative to the public Events API listener: the adapter opens an
+  outbound WebSocket to Slack instead of receiving webhooks, so the pack
+  runs on networks that cannot accept inbound connections (corporate
+  firewalls, laptops, anywhere a tunnel is blocked).
+  - Selected by `SLACK_APP_TOKEN` (an `xapp-…` app-level token with the
+    `connections:write` scope). When set, `LISTEN_PUBLIC` is never bound
+    and `SLACK_SIGNING_SECRET` is no longer required — Socket Mode has no
+    request signatures, so the trust boundary is the app-token-authenticated
+    connection the adapter itself opens.
+  - Supervised reconnect with capped exponential backoff (1s → 30s). On
+    Slack's advance disconnect warning a replacement connection is opened
+    while the old one drains and keeps acking, so mentions are not dropped.
+  - Envelopes are acked before bridging; events from a workspace other than
+    `SLACK_WORKSPACE_ID` are dropped rather than filed under the wrong
+    account.
+  - Dialled through Go's default HTTP client, so `HTTPS_PROXY`/`NO_PROXY`
+    are honoured.
+- `manifest/app-socket.json`, the Socket Mode variant of the app manifest
+  (identical to `manifest/app.json` but with `socket_mode_enabled: true`).
+
+### Changed
+
+- The adapter now depends on `github.com/coder/websocket` v1.8.15, which
+  has no dependencies of its own. The HTTP transport is unchanged and still
+  verifies request signatures exactly as before.
+
 ## [0.1.0] — Tier 1 extraction
 
 Initial release. slack-mini is Tier 1 of the Slack pack family — the

--- a/slack-mini/CHANGELOG.md
+++ b/slack-mini/CHANGELOG.md
@@ -22,19 +22,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Supervised reconnect with capped exponential backoff (1s → 30s). On
     Slack's advance disconnect warning a replacement connection is opened
     while the old one drains and keeps acking, so mentions are not dropped.
-  - Envelopes are acked before bridging; events from a workspace other than
-    `SLACK_WORKSPACE_ID` are dropped rather than filed under the wrong
-    account.
+    Every redial is paced, including the warned one — a 1s pause fits inside
+    the ~10s warning, so an ordinary refresh still overlaps — and the delay
+    escalates only for connections that fail to last 30s, so a server that
+    accepts and immediately drops connections cannot be redialled in a
+    tight loop.
+  - Envelopes are acked before bridging.
   - Dialled through Go's default HTTP client, so `HTTPS_PROXY`/`NO_PROXY`
     are honoured.
 - `manifest/app-socket.json`, the Socket Mode variant of the app manifest
-  (identical to `manifest/app.json` but with `socket_mode_enabled: true`).
+  (`manifest/app.json` with `socket_mode_enabled: true` and its own display
+  description; nothing else differs).
 
 ### Changed
 
 - The adapter now depends on `github.com/coder/websocket` v1.8.15, which
-  has no dependencies of its own. The HTTP transport is unchanged and still
-  verifies request signatures exactly as before.
+  has no dependencies of its own.
+- Events from a workspace other than `SLACK_WORKSPACE_ID` are dropped
+  rather than filed under the wrong account. This guard sits in the shared
+  bridge, so it covers **both** transports: neither establishes which
+  workspace an event belongs to (Socket Mode has no signature, and the HTTP
+  path's HMAC proves only that Slack sent the request for this app), while
+  every bridged message is stamped with `SLACK_WORKSPACE_ID` as its account
+  id. Otherwise the HTTP transport is unchanged and still verifies request
+  signatures exactly as before.
 
 ## [0.1.0] — Tier 1 extraction
 

--- a/slack-mini/README.md
+++ b/slack-mini/README.md
@@ -21,22 +21,47 @@ multi-rig routing — those live in `slack-channel` (Tier 2) and `slack-full`
 - **Outbound:** `gc slack-mini post-message --channel C0123 --text "…"` →
   posts to a channel, optionally in a thread.
 
+## Choose a transport
+
+Inbound mentions reach the adapter one of two ways. Pick one before you
+create the app — the choice is baked into the app manifest.
+
+| | **Socket Mode** | **HTTP (Events API)** |
+| --- | --- | --- |
+| Public ingress | none | public HTTPS URL required |
+| How events arrive | outbound WebSocket the adapter opens to Slack | Slack POSTs to your Request URL |
+| Credentials | app-level token (`xapp-…`) | signing secret |
+| Manifest | [`manifest/app-socket.json`](./manifest/app-socket.json) | [`manifest/app.json`](./manifest/app.json) |
+
+**Socket Mode is the right default if you cannot expose an inbound port** —
+behind a corporate firewall, on a laptop, or anywhere a tunnel is blocked.
+It needs only outbound HTTPS to `slack.com`. Choose HTTP when you already
+have public ingress and would rather not manage another token.
+
+Everything downstream is identical: same mention handling, same bridge into
+gc, same outbound verb.
+
 ## Install in 3 minutes
 
 ### 1. Create the Slack app (1 min)
 
-Create an app from the shipped manifest at
-[`manifest/app.json`](./manifest/app.json):
+Create an app from the shipped manifest — `manifest/app-socket.json` for
+Socket Mode, `manifest/app.json` for HTTP:
 
 1. <https://api.slack.com/apps> → **Create New App** → **From a manifest**.
-2. Pick your workspace, paste `manifest/app.json`, create.
+2. Pick your workspace, paste the manifest, create.
 3. **Install to Workspace** and copy the **Bot User OAuth Token**
    (`xoxb-…`).
-4. From **Basic Information**, copy the **Signing Secret**.
+4. From **Basic Information**:
+   - **Socket Mode:** under **App-Level Tokens**, **Generate Token and
+     Scopes**, add the **`connections:write`** scope, and copy the token
+     (`xapp-…`). App-level tokens cannot be declared in a manifest, so this
+     step is manual.
+   - **HTTP:** copy the **Signing Secret**.
 
-The manifest requests only three scopes — `app_mentions:read`,
-`chat:write`, `chat:write.public` — and subscribes to the `app_mention`
-event.
+Both manifests request only three bot scopes — `app_mentions:read`,
+`chat:write`, `chat:write.public` — and subscribe to the `app_mention`
+event. They differ only in `socket_mode_enabled`.
 
 ### 2. Configure the city (1 min)
 
@@ -50,6 +75,17 @@ source = "../packs/slack-mini"
 Provide the adapter's environment (e.g. in your city service env or
 `~/.config/gc-slack-mini-adapter/env`):
 
+**Socket Mode:**
+
+```sh
+SLACK_BOT_TOKEN=xoxb-...          # from step 1
+SLACK_APP_TOKEN=xapp-...          # from step 1 — selects Socket Mode
+SLACK_WORKSPACE_ID=T0123ABCD      # your Slack team id
+GC_CITY_NAME=<your-city-name>     # the gc city to bridge into
+```
+
+**HTTP:**
+
 ```sh
 SLACK_BOT_TOKEN=xoxb-...          # from step 1
 SLACK_SIGNING_SECRET=...          # from step 1
@@ -57,14 +93,22 @@ SLACK_WORKSPACE_ID=T0123ABCD      # your Slack team id
 GC_CITY_NAME=<your-city-name>     # the gc city to bridge into
 ```
 
-That's the full required set — four variables.
+That's the full required set either way — four variables. Setting
+`SLACK_APP_TOKEN` is the whole switch: the adapter runs Socket Mode, never
+binds `LISTEN_PUBLIC`, and stops requiring `SLACK_SIGNING_SECRET` (Socket
+Mode has no request signatures to verify).
 
-### 3. Expose the events endpoint and start (1 min)
+### 3. Start (1 min)
 
-The adapter listens for Slack events on public TCP (`LISTEN_PUBLIC`,
-default `0.0.0.0:8775`). Terminate TLS in front of it and give Slack a
-public URL — [Tailscale Funnel](https://tailscale.com/kb/1223/funnel) is
-the easy path:
+**Socket Mode — nothing to expose.** The adapter dials out to Slack, so
+there is no listener to publish, no TLS to terminate, and no Request URL to
+register. Start your city and `@`-mention the bot. The log line to look for
+is `socket mode: connected`.
+
+**HTTP — expose the events endpoint.** The adapter listens for Slack events
+on public TCP (`LISTEN_PUBLIC`, default `0.0.0.0:8775`). Terminate TLS in
+front of it and give Slack a public URL —
+[Tailscale Funnel](https://tailscale.com/kb/1223/funnel) is the easy path:
 
 ```sh
 tailscale funnel 8775
@@ -90,7 +134,9 @@ gc slack-mini post-message --channel C0123 \
 
 ## Build
 
-The adapter is a single Go file with no external dependencies:
+The adapter's only dependency is
+[`github.com/coder/websocket`](https://github.com/coder/websocket) (itself
+dependency-free), used for the Socket Mode transport:
 
 ```sh
 cd adapter
@@ -104,10 +150,11 @@ The built binary is git-ignored; the `[[service]]` block runs it in place.
 | Variable | Required | Default | Purpose |
 | --- | :---: | --- | --- |
 | `SLACK_BOT_TOKEN` | ✓ | — | Bot token for `chat.postMessage` and the inbound POST. |
-| `SLACK_SIGNING_SECRET` | ✓ | — | HMAC secret for verifying Slack requests. |
+| `SLACK_SIGNING_SECRET` | HTTP only | — | HMAC secret for verifying Slack requests. Required unless `SLACK_APP_TOKEN` is set. |
 | `SLACK_WORKSPACE_ID` | ✓ | — | Slack team id (the extmsg account id). |
 | `GC_CITY_NAME` | ✓ | — | gc city to bridge into. |
-| `LISTEN_PUBLIC` | | `0.0.0.0:8775` | Public bind for `/slack/events`. |
+| `SLACK_APP_TOKEN` | Socket Mode | — | App-level token (`xapp-…`) with `connections:write`. Setting it selects Socket Mode: no public listener, no signing secret. |
+| `LISTEN_PUBLIC` | | `0.0.0.0:8775` | Public bind for `/slack/events`. Not bound in Socket Mode. |
 | `LISTEN_INTERNAL` | | `127.0.0.1:8776` | TCP bind for `/post-message` when not run as a gc proxy_process (no `GC_SERVICE_SOCKET`). |
 | `REGISTER_ON_START` | | `true` | Self-register as an extmsg adapter on start. |
 | `SLACK_MINI_INBOUND_TARGET` | | `mayor` | Session handle inbound mentions address. |
@@ -117,9 +164,29 @@ The built binary is git-ignored; the `[[service]]` block runs it in place.
 `GC_SERVICE_SOCKET`, `GC_SERVICE_URL_PREFIX`, and `GC_API_BASE_URL` are
 injected by gc when the adapter runs as a `proxy_process` service.
 
+## Socket Mode notes
+
+- **Egress only.** The adapter needs outbound HTTPS to `slack.com` and a
+  WebSocket to `wss-*.slack.com`. Nothing inbound.
+- **Proxies are honoured.** The connection is dialled through Go's default
+  HTTP client, so `HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` apply — useful
+  on networks that force egress through a proxy.
+- **Reconnects are normal.** Slack recycles connections routinely and warns
+  ~10s ahead; the adapter opens a replacement while the old connection
+  drains, so mentions are not dropped. Reconnect failures back off from 1s
+  to a 30s cap.
+- **Redelivery is safe.** Every envelope is acked before bridging, and each
+  bridged message carries a `dedup_key` of `slack-<ts>`, so a redelivered
+  event does not produce a duplicate in gc.
+- **`invalid_auth` on start** almost always means the app-level token is
+  missing the `connections:write` scope, or a bot token was pasted into
+  `SLACK_APP_TOKEN`.
+
 ## Upgrading to a larger tier
 
 To gain channel bindings, per-session identity, or multi-rig routing, swap
 this pack for `slack-channel` or `slack-full`. The bot token, signing
-secret, and workspace id carry over unchanged. See the tiering memo's
+secret, and workspace id carry over unchanged — but note that Socket Mode
+is currently implemented at Tier 1 only, so the larger tiers still need
+public ingress. See the tiering memo's
 migration section.

--- a/slack-mini/README.md
+++ b/slack-mini/README.md
@@ -5,8 +5,8 @@
 session. Reply back with one verb.
 
 slack-mini is **Tier 1** of the Slack pack family — the smallest surface
-that gets a human talking to gc over Slack. It ships a single-file adapter
-and one outbound verb. No channel bindings, no per-session identity, no
+that gets a human talking to gc over Slack. It ships a small two-file
+adapter and one outbound verb. No channel bindings, no per-session identity, no
 multi-rig routing — those live in `slack-channel` (Tier 2) and `slack-full`
 (Tier 3). See the [slack-pack tiering design memo](../docs/design/slack-pack-tiering.md)
 (landing separately).
@@ -61,7 +61,8 @@ Socket Mode, `manifest/app.json` for HTTP:
 
 Both manifests request only three bot scopes — `app_mentions:read`,
 `chat:write`, `chat:write.public` — and subscribe to the `app_mention`
-event. They differ only in `socket_mode_enabled`.
+event. They differ in `socket_mode_enabled` and in the display description
+text; nothing else.
 
 ### 2. Configure the city (1 min)
 
@@ -151,7 +152,7 @@ The built binary is git-ignored; the `[[service]]` block runs it in place.
 | --- | :---: | --- | --- |
 | `SLACK_BOT_TOKEN` | ✓ | — | Bot token for `chat.postMessage` and the inbound POST. |
 | `SLACK_SIGNING_SECRET` | HTTP only | — | HMAC secret for verifying Slack requests. Required unless `SLACK_APP_TOKEN` is set. |
-| `SLACK_WORKSPACE_ID` | ✓ | — | Slack team id (the extmsg account id). |
+| `SLACK_WORKSPACE_ID` | ✓ | — | Slack team id (the extmsg account id). Also gates inbound: events carrying a different `team_id` are dropped on both transports, so a wrong value looks like a silent bot. |
 | `GC_CITY_NAME` | ✓ | — | gc city to bridge into. |
 | `SLACK_APP_TOKEN` | Socket Mode | — | App-level token (`xapp-…`) with `connections:write`. Setting it selects Socket Mode: no public listener, no signing secret. |
 | `LISTEN_PUBLIC` | | `0.0.0.0:8775` | Public bind for `/slack/events`. Not bound in Socket Mode. |
@@ -173,8 +174,11 @@ injected by gc when the adapter runs as a `proxy_process` service.
   on networks that force egress through a proxy.
 - **Reconnects are normal.** Slack recycles connections routinely and warns
   ~10s ahead; the adapter opens a replacement while the old connection
-  drains, so mentions are not dropped. Reconnect failures back off from 1s
-  to a 30s cap.
+  drains, so mentions are not dropped. Every redial is paced, from 1s up to
+  a 30s cap — a 1s pause fits well inside the warning's lead, so an ordinary
+  refresh still overlaps. The pacing only escalates for connections that die
+  before lasting 30s, which is what stops a server that accepts and
+  immediately drops connections from producing a redial loop.
 - **Redelivery is safe.** Every envelope is acked before bridging, and each
   bridged message carries a `dedup_key` of `slack-<ts>`, so a redelivered
   event does not produce a duplicate in gc.

--- a/slack-mini/adapter/go.mod
+++ b/slack-mini/adapter/go.mod
@@ -1,3 +1,5 @@
 module github.com/sjarmak/gc-slack-mini-adapter
 
 go 1.25.9
+
+require github.com/coder/websocket v1.8.15

--- a/slack-mini/adapter/go.sum
+++ b/slack-mini/adapter/go.sum
@@ -1,0 +1,2 @@
+github.com/coder/websocket v1.8.15 h1:6B2JPeOGlpff2Uz6vOEH1Vzpi0iUz20A+lPVhPHtNUA=
+github.com/coder/websocket v1.8.15/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=

--- a/slack-mini/adapter/main.go
+++ b/slack-mini/adapter/main.go
@@ -1,11 +1,16 @@
 // gc-slack-mini-adapter — the Tier-1 ("slack-mini") Slack ↔ gc bridge.
 //
-// The minimal viable Slack→mayor surface, single-file by design:
+// The minimal viable Slack→mayor surface. This file is the whole adapter
+// bar one thing: the Socket Mode transport lives in socketmode.go, kept
+// separate because it is an alternative to the HTTP receiver below rather
+// than an addition to it.
 //
-//   - Inbound: a public HTTPS receiver for the Slack Events API. Only
-//     `app_mention` is handled. Each verified mention is bridged to gc by
-//     POSTing /v0/city/{city}/extmsg/inbound, addressed to the mayor
-//     session (override with SLACK_MINI_INBOUND_TARGET).
+//   - Inbound: either a public HTTPS receiver for the Slack Events API, or —
+//     when SLACK_APP_TOKEN is set — a Socket Mode WebSocket the adapter opens
+//     outbound to Slack, which needs no public ingress at all (see
+//     socketmode.go). Only `app_mention` is handled either way. Each mention
+//     is bridged to gc by POSTing /v0/city/{city}/extmsg/inbound, addressed
+//     to the mayor session (override with SLACK_MINI_INBOUND_TARGET).
 //
 //   - Outbound: a UDS endpoint (/post-message) that posts plain text to a
 //     Slack channel via chat.postMessage using the workspace bot token.
@@ -23,9 +28,11 @@
 //	                       Not used on the inbound path (which only verifies
 //	                       the signing secret and POSTs to gc).
 //	SLACK_SIGNING_SECRET   HMAC secret for verifying Slack request signatures
-//	                       on the inbound bridge. Required at Tier 1 — there is
-//	                       no apps-registry fallback, so without it every
-//	                       inbound is rejected.
+//	                       on the HTTP inbound bridge. Required at Tier 1 when
+//	                       running the HTTP transport — there is no
+//	                       apps-registry fallback, so without it every inbound
+//	                       is rejected. Not used (and not required) in Socket
+//	                       Mode, which has no request signatures.
 //	SLACK_WORKSPACE_ID     Slack workspace (team) id; the extmsg account id.
 //	GC_CITY_NAME           gc city the adapter bridges into.
 //
@@ -39,7 +46,13 @@
 //
 // Optional env:
 //
+//	SLACK_APP_TOKEN            App-level token (xapp-...) with the
+//	                           connections:write scope. When set, the adapter
+//	                           runs Socket Mode instead of the HTTP receiver:
+//	                           LISTEN_PUBLIC is never bound and
+//	                           SLACK_SIGNING_SECRET is not required.
 //	LISTEN_PUBLIC              Public bind for /slack/events (default 0.0.0.0:8775).
+//	                           Ignored in Socket Mode.
 //	LISTEN_INTERNAL            TCP bind for the internal mux when GC_SERVICE_SOCKET
 //	                           is unset (default 127.0.0.1:8776).
 //	REGISTER_ON_START          "true" (default) self-registers as an extmsg adapter.
@@ -109,10 +122,17 @@ type config struct {
 	workspaceID         string
 	botToken            string
 	signingSecret       string
+	appToken            string
 	inboundTarget       string
 	slackAPIBase        string
 	registerOnStart     bool
 }
+
+// socketMode reports whether the adapter takes inbound over a Socket Mode
+// WebSocket instead of the public HTTP listener. The app-level token is the
+// selector: it is required for Socket Mode and useless without it, so its
+// presence is the whole contract — there is no second toggle to keep in sync.
+func (c config) socketMode() bool { return c.appToken != "" }
 
 func main() {
 	cfg, err := loadConfig()
@@ -123,8 +143,12 @@ func main() {
 	if cfg.serviceSocket != "" {
 		internalDescr = "uds:" + cfg.serviceSocket
 	}
-	log.Printf("starting gc-slack-mini-adapter public=%s internal=%s gc=%s city=%s target=%s",
-		cfg.publicListen, internalDescr, cfg.gcAPIBase, cfg.cityName, cfg.inboundTarget)
+	inboundDescr := "http:" + cfg.publicListen
+	if cfg.socketMode() {
+		inboundDescr = "socket-mode (no public listener)"
+	}
+	log.Printf("starting gc-slack-mini-adapter inbound=%s internal=%s gc=%s city=%s target=%s",
+		inboundDescr, internalDescr, cfg.gcAPIBase, cfg.cityName, cfg.inboundTarget)
 
 	publicMux := http.NewServeMux()
 	publicMux.HandleFunc("/slack/events", handleSlackEvents(cfg))
@@ -156,11 +180,27 @@ func main() {
 			cfg.provider, cfg.workspaceID, cfg.internalCallbackURL)
 	}
 
+	// Socket Mode owns the inbound path when enabled; the public listener is
+	// not merely unused but never bound, which is the point on a network that
+	// cannot accept inbound connections.
+	socketCtx, socketCancel := context.WithCancel(context.Background())
+	defer socketCancel()
+
 	errCh := make(chan error, 2)
-	go func() {
-		log.Printf("public listener serving on %s (Slack events)", cfg.publicListen)
-		errCh <- publicSrv.ListenAndServe()
-	}()
+	if cfg.socketMode() {
+		go func() {
+			// runSocketMode reconnects internally and returns only when its
+			// context is cancelled, so a return here means shutdown.
+			if err := runSocketMode(socketCtx, cfg); err != nil && !errors.Is(err, context.Canceled) {
+				errCh <- err
+			}
+		}()
+	} else {
+		go func() {
+			log.Printf("public listener serving on %s (Slack events)", cfg.publicListen)
+			errCh <- publicSrv.ListenAndServe()
+		}()
+	}
 	go func() {
 		if cfg.serviceSocket != "" {
 			log.Printf("internal listener serving on UDS %s (gc proxy_process)", cfg.serviceSocket)
@@ -187,6 +227,7 @@ func main() {
 			log.Printf("listener error: %v", err)
 		}
 	}
+	socketCancel()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	_ = publicSrv.Shutdown(ctx)
@@ -220,6 +261,7 @@ func loadConfigFromEnv(getenv func(string) string) (config, error) {
 		workspaceID:     getenv("SLACK_WORKSPACE_ID"),
 		botToken:        getenv("SLACK_BOT_TOKEN"),
 		signingSecret:   getenv("SLACK_SIGNING_SECRET"),
+		appToken:        getenv("SLACK_APP_TOKEN"),
 		inboundTarget:   envOr("SLACK_MINI_INBOUND_TARGET", defaultInboundTarget),
 		slackAPIBase:    strings.TrimRight(envOr("SLACK_API_BASE", defaultSlackAPIBase), "/"),
 		registerOnStart: envOr("REGISTER_ON_START", "true") == "true",
@@ -248,7 +290,11 @@ func loadConfigFromEnv(getenv func(string) string) (config, error) {
 	if cfg.botToken == "" {
 		missing = append(missing, "SLACK_BOT_TOKEN")
 	}
-	if cfg.signingSecret == "" {
+	// The signing secret verifies HTTP webhook signatures. Socket Mode has no
+	// request signatures — authenticity comes from the app-token-authenticated
+	// connection the adapter itself opens — so requiring it there would be
+	// demanding a credential the transport never consults.
+	if cfg.signingSecret == "" && !cfg.socketMode() {
 		missing = append(missing, "SLACK_SIGNING_SECRET")
 	}
 	if cfg.cityName == "" {
@@ -256,6 +302,12 @@ func loadConfigFromEnv(getenv func(string) string) (config, error) {
 	}
 	if len(missing) > 0 {
 		return cfg, fmt.Errorf("missing required env vars: %s", strings.Join(missing, ", "))
+	}
+	// Fail fast on the easiest Socket Mode mistake: pasting the bot token
+	// (xoxb-) into SLACK_APP_TOKEN. Slack would answer invalid_auth on every
+	// reconnect forever, which reads as a network fault rather than a typo.
+	if cfg.socketMode() && !strings.HasPrefix(cfg.appToken, "xapp-") {
+		return cfg, errors.New("SLACK_APP_TOKEN must be an app-level token (xapp-...); the bot token belongs in SLACK_BOT_TOKEN")
 	}
 	// cityName is interpolated into every /v0/city/{city}/... URL. Reject
 	// URL-significant characters so a city name cannot alter routing.

--- a/slack-mini/adapter/main.go
+++ b/slack-mini/adapter/main.go
@@ -34,6 +34,8 @@
 //	                       is rejected. Not used (and not required) in Socket
 //	                       Mode, which has no request signatures.
 //	SLACK_WORKSPACE_ID     Slack workspace (team) id; the extmsg account id.
+//	                       Also the inbound workspace filter: bridgeEvent drops
+//	                       events whose team_id differs, on both transports.
 //	GC_CITY_NAME           gc city the adapter bridges into.
 //
 // Controller-injected env (proxy_process mode):
@@ -402,6 +404,20 @@ func handleSlackEvents(cfg config) http.HandlerFunc {
 // cannot leak goroutines under sustained traffic.
 func bridgeEvent(cfg config, env slackEventEnvelope) {
 	if env.Type != "event_callback" || len(env.Event) == 0 {
+		return
+	}
+	// Drop events from another workspace. Neither transport establishes which
+	// workspace an event belongs to — Socket Mode has no signature at all, and
+	// the HTTP path's HMAC proves only that Slack sent it for this app — yet
+	// every bridged message is stamped with cfg.workspaceID as its account id
+	// below. An app installed in a second workspace would therefore file that
+	// workspace's mentions under this one. The guard sits here, at the funnel
+	// both transports feed, so neither can be missed.
+	//
+	// An absent team_id is allowed through: Slack sends one on every
+	// event_callback, so this only affects hand-built payloads.
+	if env.TeamID != "" && env.TeamID != cfg.workspaceID {
+		log.Printf("dropping event from unexpected team %s (want %s)", env.TeamID, cfg.workspaceID)
 		return
 	}
 	var msg slackMessageEvent

--- a/slack-mini/adapter/main_test.go
+++ b/slack-mini/adapter/main_test.go
@@ -331,6 +331,50 @@ func TestBridgeEventIgnoresNonMentions(t *testing.T) {
 	drop("empty after strip", slackMessageEvent{Type: "app_mention", User: "U1", Text: "<@U0BOT>", Channel: "C1", TS: "1"})
 }
 
+// TestBridgeEventWorkspaceGuard pins the workspace check at the funnel both
+// transports feed. Neither transport establishes which workspace an event
+// belongs to — Socket Mode has no signature, and the HTTP path's HMAC only
+// proves Slack sent it for this app — while every bridged message is stamped
+// with cfg.workspaceID, so an app installed twice would misfile the second
+// workspace's mentions. Guarding here means neither transport can miss it.
+func TestBridgeEventWorkspaceGuard(t *testing.T) {
+	bridged := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		bridged = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	cfg := config{gcAPIBase: srv.URL, cityName: "c", workspaceID: "T123", inboundTarget: "mayor"}
+
+	raw, err := json.Marshal(slackMessageEvent{
+		Type: "app_mention", User: "U1", Text: "<@U0BOT> hi", Channel: "C1", TS: "1",
+	})
+	if err != nil {
+		t.Fatalf("marshal event: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name     string
+		teamID   string
+		wantSent bool
+	}{
+		{"foreign workspace", "T_OTHER", false},
+		{"configured workspace", "T123", true},
+		// Slack sends team_id on every event_callback, so an absent one means a
+		// hand-built payload rather than a foreign workspace; the guard must not
+		// silently swallow those.
+		{"absent team_id", "", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			bridged = false
+			bridgeEvent(cfg, slackEventEnvelope{Type: "event_callback", TeamID: tc.teamID, Event: raw})
+			if bridged != tc.wantSent {
+				t.Errorf("bridged = %v, want %v (team_id=%q, workspace=%q)", bridged, tc.wantSent, tc.teamID, cfg.workspaceID)
+			}
+		})
+	}
+}
+
 func TestHandlePostMessage(t *testing.T) {
 	var gotBody slackPostMessageReq
 	var gotAuth string

--- a/slack-mini/adapter/socketmode.go
+++ b/slack-mini/adapter/socketmode.go
@@ -52,10 +52,15 @@ const (
 	// inside that window is better abandoned than left blocking the reader.
 	socketAckTimeout = 2 * time.Second
 
-	// socketReadTimeout is the idle watchdog. Slack pings frequently, so a
-	// read that yields nothing for this long means the connection is wedged
-	// in a way TCP has not noticed yet — drop it and redial.
-	socketReadTimeout = 90 * time.Second
+	// Liveness is checked by pinging Slack, not by bounding reads. A healthy
+	// Socket Mode connection can sit idle indefinitely — no mentions means no
+	// data messages — and Slack's own keepalive pings are answered inside the
+	// WebSocket library without ever waking a read. A read deadline would
+	// therefore tear down perfectly good connections on any quiet workspace.
+	// A ping that goes unanswered is the real signal that a connection is
+	// wedged in a way TCP has not noticed yet.
+	socketPingInterval = 30 * time.Second
+	socketPingTimeout  = 10 * time.Second
 
 	// socketOpenTimeout bounds apps.connections.open plus the WebSocket
 	// handshake. The URL Slack returns expires in ~30s.
@@ -92,6 +97,10 @@ type socketEnvelope struct {
 type socketConn interface {
 	Read(ctx context.Context) ([]byte, error)
 	Write(ctx context.Context, data []byte) error
+	// Ping sends a WebSocket ping and waits for the matching pong, which is
+	// how liveness is established on a connection that may legitimately carry
+	// no data for hours.
+	Ping(ctx context.Context) error
 	Close() error
 }
 
@@ -105,6 +114,8 @@ func (r realSocketConn) Read(ctx context.Context) ([]byte, error) {
 func (r realSocketConn) Write(ctx context.Context, data []byte) error {
 	return r.c.Write(ctx, websocket.MessageText, data)
 }
+
+func (r realSocketConn) Ping(ctx context.Context) error { return r.c.Ping(ctx) }
 
 func (r realSocketConn) Close() error {
 	// CloseNow over a handshaked close: the peer is Slack and the connection
@@ -273,27 +284,34 @@ func openSocketConnectionURL(ctx context.Context, cfg config) (string, error) {
 func pumpSocket(ctx context.Context, cfg config, conn socketConn, onWarning func()) error {
 	defer func() { _ = conn.Close() }()
 
+	// connCtx bounds this connection specifically: the keepalive cancels it
+	// when Slack stops answering pings, and the drain timer cancels it when a
+	// warned-about connection has had long enough to finish. Reads block on
+	// it with no deadline of their own — see socketPingInterval.
+	connCtx, closeConn := context.WithCancel(ctx)
+	defer closeConn()
+	go keepaliveSocket(connCtx, conn, socketPingInterval, closeConn)
+
 	// A disconnect warning arrives ~10s before Slack drops the socket. Rather
 	// than tear down immediately (which loses whatever is in flight), the
 	// caller is signalled to open a replacement while this loop keeps
 	// draining and acking on the doomed connection.
-	drainUntil := time.Time{}
+	draining := false
 
 	for {
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
-		if !drainUntil.IsZero() && time.Now().After(drainUntil) {
-			return nil
-		}
 
-		readCtx, cancel := context.WithTimeout(ctx, socketReadTimeout)
-		data, err := conn.Read(readCtx)
-		cancel()
+		data, err := conn.Read(connCtx)
 		if err != nil {
-			if !drainUntil.IsZero() {
-				// Expected: the warned-about close finally landed.
+			if draining {
+				// Expected: the warned-about close finally landed, or the
+				// drain window elapsed.
 				return nil
+			}
+			if ctx.Err() != nil {
+				return ctx.Err()
 			}
 			return err
 		}
@@ -309,8 +327,11 @@ func pumpSocket(ctx context.Context, cfg config, conn socketConn, onWarning func
 			continue
 		case "disconnect":
 			log.Printf("socket mode: disconnect requested (reason=%s), draining", env.Reason)
-			if drainUntil.IsZero() {
-				drainUntil = time.Now().Add(socketDrainGrace)
+			if !draining {
+				draining = true
+				// Bound the drain: if Slack never actually closes, this
+				// connection must not linger next to its replacement.
+				time.AfterFunc(socketDrainGrace, closeConn)
 				if onWarning != nil {
 					onWarning()
 				}
@@ -337,6 +358,34 @@ func pumpSocket(ctx context.Context, cfg config, conn socketConn, onWarning func
 	}
 }
 
+// keepaliveSocket pings Slack on a fixed interval and closes the connection
+// when a ping goes unanswered. This is the liveness check for a transport
+// whose healthy state is silence: without it, a connection dropped in a way
+// that never reaches TCP (a NAT timeout, a proxy reaping an idle tunnel)
+// would leave the adapter reading forever from a socket Slack has forgotten.
+func keepaliveSocket(ctx context.Context, conn socketConn, interval time.Duration, closeConn func()) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			pingCtx, cancel := context.WithTimeout(ctx, socketPingTimeout)
+			err := conn.Ping(pingCtx)
+			cancel()
+			if err != nil {
+				if ctx.Err() != nil {
+					return // shutting down; not a ping failure
+				}
+				log.Printf("socket mode: keepalive ping failed: %v", err)
+				closeConn()
+				return
+			}
+		}
+	}
+}
+
 // socketAck builds the ack frame for an envelope.
 func socketAck(envelopeID string) []byte {
 	// Marshal rather than concatenate: envelope ids are Slack-supplied and
@@ -354,6 +403,11 @@ func socketAck(envelopeID string) []byte {
 // larger tiers — and the payload is the same shape the HTTP listener decodes,
 // so the bridge itself is shared verbatim with the webhook path.
 func handleSocketEnvelope(cfg config, env socketEnvelope) {
+	// Log every delivery on arrival. Tier 1 subscribes to app_mention alone,
+	// so this is low volume, and without it a dropped event is indis-
+	// tinguishable from Slack never having sent one — which is exactly the
+	// question an operator debugging a silent bot needs answered.
+	log.Printf("socket mode: envelope received type=%s", env.Type)
 	if env.Type != "events_api" || len(env.Payload) == 0 {
 		return
 	}

--- a/slack-mini/adapter/socketmode.go
+++ b/slack-mini/adapter/socketmode.go
@@ -1,0 +1,380 @@
+// Socket Mode transport — the ingress-free alternative to the public
+// /slack/events listener.
+//
+// Socket Mode replaces Slack's inbound HTTP webhook with an outbound
+// WebSocket the adapter opens to Slack. Nothing listens on a public port and
+// no TLS terminator or tunnel is needed, which is the only way to run this
+// pack on a network that cannot accept inbound connections.
+//
+// The transport is selected by SLACK_APP_TOKEN: when it is set the adapter
+// runs Socket Mode and never binds LISTEN_PUBLIC; when it is empty the
+// adapter keeps the original Events-API-over-HTTP behaviour unchanged. The
+// two are alternatives, never both at once — Slack itself refuses to deliver
+// events to a Request URL while Socket Mode is enabled on the app.
+//
+// Wire protocol (https://api.slack.com/apis/socket-mode):
+//
+//  1. POST apps.connections.open with the app-level token → a single-use
+//     wss:// URL, valid for ~30s.
+//  2. Dial it. Slack sends {"type":"hello"} on success.
+//  3. Each event arrives as an envelope: {"envelope_id":…,"type":"events_api",
+//     "payload":{…}}. The payload is byte-identical to the HTTP webhook body,
+//     which is why this file reuses bridgeEvent unchanged.
+//  4. Ack every envelope with {"envelope_id":…} within 3s or Slack redelivers.
+//  5. {"type":"disconnect"} warns the connection is going away, ~10s before
+//     it closes, so a replacement can be opened before events are missed.
+//
+// Authenticity differs from the HTTP path and is worth being explicit about:
+// there is no signing secret and no HMAC. The trust boundary is the TLS
+// connection the adapter itself opened using its app-level token — an
+// attacker cannot inject envelopes without already holding that token. This
+// is Slack's designed model for Socket Mode, not a relaxation of the HTTP
+// path, which keeps verifying signatures exactly as before.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/coder/websocket"
+)
+
+const (
+	// socketAckTimeout bounds the ack write. Slack redelivers an envelope
+	// that is not acked within 3s, so a write that cannot complete well
+	// inside that window is better abandoned than left blocking the reader.
+	socketAckTimeout = 2 * time.Second
+
+	// socketReadTimeout is the idle watchdog. Slack pings frequently, so a
+	// read that yields nothing for this long means the connection is wedged
+	// in a way TCP has not noticed yet — drop it and redial.
+	socketReadTimeout = 90 * time.Second
+
+	// socketOpenTimeout bounds apps.connections.open plus the WebSocket
+	// handshake. The URL Slack returns expires in ~30s.
+	socketOpenTimeout = 30 * time.Second
+
+	// Reconnect backoff after a failed or lost connection. Reset once a
+	// connection is established (see runSocketMode).
+	socketBackoffMin = 1 * time.Second
+	socketBackoffMax = 30 * time.Second
+
+	// socketDrainGrace is how long a connection that announced a disconnect
+	// keeps reading after its replacement is live, so in-flight envelopes
+	// still get acked instead of being redelivered.
+	socketDrainGrace = 10 * time.Second
+
+	// maxSocketMessage caps a single inbound WebSocket message, mirroring
+	// maxInboundBody on the HTTP path.
+	maxSocketMessage = 1 << 20 // 1 MiB
+)
+
+// socketEnvelope is the Socket Mode frame wrapping each delivery. Payload is
+// the same JSON body the Events API would have POSTed to /slack/events.
+type socketEnvelope struct {
+	Type         string          `json:"type"`
+	EnvelopeID   string          `json:"envelope_id,omitempty"`
+	Payload      json.RawMessage `json:"payload,omitempty"`
+	Reason       string          `json:"reason,omitempty"`
+	RetryAttempt int             `json:"retry_attempt,omitempty"`
+}
+
+// socketConn is the WebSocket surface this file needs, extracted so the
+// envelope loop can be tested against a scripted connection without standing
+// up a server. realSocketConn is the only production implementation.
+type socketConn interface {
+	Read(ctx context.Context) ([]byte, error)
+	Write(ctx context.Context, data []byte) error
+	Close() error
+}
+
+type realSocketConn struct{ c *websocket.Conn }
+
+func (r realSocketConn) Read(ctx context.Context) ([]byte, error) {
+	_, data, err := r.c.Read(ctx)
+	return data, err
+}
+
+func (r realSocketConn) Write(ctx context.Context, data []byte) error {
+	return r.c.Write(ctx, websocket.MessageText, data)
+}
+
+func (r realSocketConn) Close() error {
+	// CloseNow over a handshaked close: the peer is Slack and the connection
+	// is being discarded either way, so waiting on a close reply only delays
+	// the redial.
+	return r.c.CloseNow()
+}
+
+// runSocketMode supervises the Socket Mode connection until ctx is done,
+// redialing with capped exponential backoff. It returns only when ctx is
+// cancelled; every other failure is a reconnect, because losing the socket
+// is the expected steady state (Slack recycles connections routinely) rather
+// than a fatal condition.
+func runSocketMode(ctx context.Context, cfg config) error {
+	backoff := socketBackoffMin
+	for {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		warned := make(chan struct{}, 1)
+		done, err := runSocketConnection(ctx, cfg, func() {
+			select {
+			case warned <- struct{}{}:
+			default: // already warned; one signal is enough
+			}
+		})
+		if err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			log.Printf("socket mode: connect failed: %v (retrying in %s)", err, backoff)
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(backoff):
+			}
+			if backoff *= 2; backoff > socketBackoffMax {
+				backoff = socketBackoffMax
+			}
+			continue
+		}
+		// A live connection means the backoff has served its purpose.
+		backoff = socketBackoffMin
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+
+		case <-warned:
+			// Slack warned this socket is closing, ~10s ahead. Dial the
+			// replacement now, while the old connection keeps draining and
+			// acking in its own goroutine — that overlap is the entire
+			// reason Slack sends the warning early. The drained connection
+			// closes itself; nothing here needs to wait for it.
+			log.Printf("socket mode: opening replacement connection")
+			continue
+
+		case err := <-done:
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			if err != nil {
+				log.Printf("socket mode: connection ended: %v (reconnecting in %s)", err, backoff)
+			} else {
+				log.Printf("socket mode: connection closed (reconnecting in %s)", backoff)
+			}
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(backoff):
+			}
+			if backoff *= 2; backoff > socketBackoffMax {
+				backoff = socketBackoffMax
+			}
+		}
+	}
+}
+
+// runSocketConnection dials one connection and pumps it in the background,
+// returning a channel that yields the pump's outcome. Dialing is synchronous
+// so the caller can distinguish "could not connect" (back off) from "was
+// connected and then ended" (reconnect promptly); pumping is not, so the
+// caller can react to a disconnect warning without waiting for the drain.
+// onWarning fires when Slack announces an impending close.
+func runSocketConnection(ctx context.Context, cfg config, onWarning func()) (<-chan error, error) {
+	conn, err := dialSocketMode(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+	done := make(chan error, 1)
+	go func() { done <- pumpSocket(ctx, cfg, conn, onWarning) }()
+	return done, nil
+}
+
+// dialSocketMode negotiates a connection URL and opens it.
+func dialSocketMode(ctx context.Context, cfg config) (socketConn, error) {
+	openCtx, cancel := context.WithTimeout(ctx, socketOpenTimeout)
+	defer cancel()
+
+	wsURL, err := openSocketConnectionURL(openCtx, cfg)
+	if err != nil {
+		return nil, err
+	}
+	// Dial through http.DefaultClient rather than a bare TLS dial so
+	// HTTP_PROXY/HTTPS_PROXY are honoured — the adapter is expected to run
+	// on exactly the kind of restricted network that needs an egress proxy.
+	c, _, err := websocket.Dial(openCtx, wsURL, &websocket.DialOptions{
+		HTTPClient: http.DefaultClient,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("dial socket mode: %w", err)
+	}
+	c.SetReadLimit(maxSocketMessage)
+	log.Printf("socket mode: connected")
+	return realSocketConn{c: c}, nil
+}
+
+// appsConnectionsOpenResp is the apps.connections.open reply.
+type appsConnectionsOpenResp struct {
+	OK    bool   `json:"ok"`
+	URL   string `json:"url,omitempty"`
+	Error string `json:"error,omitempty"`
+}
+
+// openSocketConnectionURL calls apps.connections.open, which is the only
+// endpoint that accepts the app-level (xapp-) token rather than the bot
+// token.
+func openSocketConnectionURL(ctx context.Context, cfg config) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, cfg.slackAPIBase+"/apps.connections.open", nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+cfg.appToken)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("apps.connections.open: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxSocketMessage))
+	if err != nil {
+		return "", fmt.Errorf("read apps.connections.open response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("apps.connections.open http %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	var out appsConnectionsOpenResp
+	if err := json.Unmarshal(body, &out); err != nil {
+		return "", fmt.Errorf("decode apps.connections.open response: %w", err)
+	}
+	if !out.OK {
+		// invalid_auth here almost always means the token is a bot token or
+		// is missing the connections:write scope; say so rather than making
+		// the operator look it up.
+		return "", fmt.Errorf("apps.connections.open: %s (app-level token needs the connections:write scope)", out.Error)
+	}
+	if out.URL == "" {
+		return "", errors.New("apps.connections.open returned no url")
+	}
+	return out.URL, nil
+}
+
+// pumpSocket reads envelopes until the connection ends, acking each one and
+// bridging events through the same path the HTTP listener uses.
+func pumpSocket(ctx context.Context, cfg config, conn socketConn, onWarning func()) error {
+	defer func() { _ = conn.Close() }()
+
+	// A disconnect warning arrives ~10s before Slack drops the socket. Rather
+	// than tear down immediately (which loses whatever is in flight), the
+	// caller is signalled to open a replacement while this loop keeps
+	// draining and acking on the doomed connection.
+	drainUntil := time.Time{}
+
+	for {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if !drainUntil.IsZero() && time.Now().After(drainUntil) {
+			return nil
+		}
+
+		readCtx, cancel := context.WithTimeout(ctx, socketReadTimeout)
+		data, err := conn.Read(readCtx)
+		cancel()
+		if err != nil {
+			if !drainUntil.IsZero() {
+				// Expected: the warned-about close finally landed.
+				return nil
+			}
+			return err
+		}
+
+		var env socketEnvelope
+		if err := json.Unmarshal(data, &env); err != nil {
+			log.Printf("socket mode: undecodable frame: %v", err)
+			continue
+		}
+
+		switch env.Type {
+		case "hello":
+			continue
+		case "disconnect":
+			log.Printf("socket mode: disconnect requested (reason=%s), draining", env.Reason)
+			if drainUntil.IsZero() {
+				drainUntil = time.Now().Add(socketDrainGrace)
+				if onWarning != nil {
+					onWarning()
+				}
+			}
+			continue
+		}
+
+		if env.EnvelopeID != "" {
+			ackCtx, ackCancel := context.WithTimeout(ctx, socketAckTimeout)
+			ackErr := conn.Write(ackCtx, socketAck(env.EnvelopeID))
+			ackCancel()
+			if ackErr != nil {
+				// Acking is what stops redelivery, so a failed ack means the
+				// connection is no longer usable — redial and let Slack
+				// redeliver rather than processing on a dead socket.
+				return fmt.Errorf("ack envelope %s: %w", env.EnvelopeID, ackErr)
+			}
+		}
+
+		// Bridge off the read loop, exactly as the HTTP path does after its
+		// ack: postInbound is bounded by gcCallTimeout, and a slow gc must
+		// not stall acks for the envelopes queued behind this one.
+		go handleSocketEnvelope(cfg, env)
+	}
+}
+
+// socketAck builds the ack frame for an envelope.
+func socketAck(envelopeID string) []byte {
+	// Marshal rather than concatenate: envelope ids are Slack-supplied and
+	// must not be able to break out of the JSON they are embedded in.
+	b, err := json.Marshal(map[string]string{"envelope_id": envelopeID})
+	if err != nil {
+		// Unreachable for a map[string]string, but never emit a malformed ack.
+		return []byte(`{}`)
+	}
+	return b
+}
+
+// handleSocketEnvelope routes one non-control envelope. Only events_api is
+// meaningful at Tier 1 — interactivity and slash commands belong to the
+// larger tiers — and the payload is the same shape the HTTP listener decodes,
+// so the bridge itself is shared verbatim with the webhook path.
+func handleSocketEnvelope(cfg config, env socketEnvelope) {
+	if env.Type != "events_api" || len(env.Payload) == 0 {
+		return
+	}
+	var payload slackEventEnvelope
+	if err := json.Unmarshal(env.Payload, &payload); err != nil {
+		log.Printf("socket mode: decode payload: %v", err)
+		return
+	}
+	// The HTTP path proves workspace identity via the signing secret. Socket
+	// Mode has no equivalent, and the adapter stamps every bridged message
+	// with cfg.workspaceID as its account id — so an event from another
+	// workspace (an app installed more than once) would be filed under the
+	// wrong account. Drop it instead.
+	if payload.TeamID != "" && payload.TeamID != cfg.workspaceID {
+		log.Printf("socket mode: dropping event from unexpected team %s (want %s)", payload.TeamID, cfg.workspaceID)
+		return
+	}
+	if env.RetryAttempt > 0 {
+		// gc dedupes on DedupKey, so a redelivery is harmless; log it because
+		// a persistent retry count means acks are not landing in time.
+		log.Printf("socket mode: redelivered envelope (attempt %d)", env.RetryAttempt)
+	}
+	bridgeEvent(cfg, payload)
+}

--- a/slack-mini/adapter/socketmode.go
+++ b/slack-mini/adapter/socketmode.go
@@ -67,9 +67,18 @@ const (
 	socketOpenTimeout = 30 * time.Second
 
 	// Reconnect backoff after a failed or lost connection. Reset once a
-	// connection is established (see runSocketMode).
+	// connection has lasted socketMinLifetime (see settleBackoff).
 	socketBackoffMin = 1 * time.Second
 	socketBackoffMax = 30 * time.Second
+
+	// socketMinLifetime is how long a connection must survive before its
+	// successor is allowed to start from socketBackoffMin again. Resetting on
+	// establishment alone lets a server that accepts a connection and drops or
+	// disowns it immediately be redialled at the floor forever; making a
+	// connection prove itself first is what escalates the delay in exactly that
+	// case. Slack recycles healthy connections on a far longer cadence, so
+	// ordinary refreshes still reset the backoff.
+	socketMinLifetime = 30 * time.Second
 
 	// socketDrainGrace is how long a connection that announced a disconnect
 	// keeps reading after its replacement is live, so in-flight envelopes
@@ -80,6 +89,38 @@ const (
 	// maxInboundBody on the HTTP path.
 	maxSocketMessage = 1 << 20 // 1 MiB
 )
+
+// socketTimings groups the connection-lifecycle timers. Production passes
+// defaultSocketTimings(); tests pass a scaled-down copy so the same code paths
+// can be driven in milliseconds.
+//
+// The seam exists because these timers are the layer no test could otherwise
+// reach: read at their call sites, they made it impossible to pin that
+// pumpSocket actually runs a keepalive, that a drain is bounded, or that
+// reconnects are paced — each of which stayed green through the mutation that
+// removed it. socketPingTimeout, socketAckTimeout and socketOpenTimeout stay
+// constants deliberately: nothing drives them, and a knob no test turns is
+// only a wider surface.
+type socketTimings struct {
+	pingInterval time.Duration
+	drainGrace   time.Duration
+	backoffMin   time.Duration
+	backoffMax   time.Duration
+	// minLifetime is how long a connection must last before its successor is
+	// allowed to start from backoffMin again.
+	minLifetime time.Duration
+}
+
+// defaultSocketTimings is the production timer set.
+func defaultSocketTimings() socketTimings {
+	return socketTimings{
+		pingInterval: socketPingInterval,
+		drainGrace:   socketDrainGrace,
+		backoffMin:   socketBackoffMin,
+		backoffMax:   socketBackoffMax,
+		minLifetime:  socketMinLifetime,
+	}
+}
 
 // socketEnvelope is the Socket Mode frame wrapping each delivery. Payload is
 // the same JSON body the Events API would have POSTed to /slack/events.
@@ -130,14 +171,21 @@ func (r realSocketConn) Close() error {
 // is the expected steady state (Slack recycles connections routinely) rather
 // than a fatal condition.
 func runSocketMode(ctx context.Context, cfg config) error {
-	backoff := socketBackoffMin
+	return runSocketModeWithTimings(ctx, cfg, defaultSocketTimings())
+}
+
+// runSocketModeWithTimings is runSocketMode with its timer set injected, so
+// the reconnect lifecycle can be driven in a test without waiting on
+// production intervals.
+func runSocketModeWithTimings(ctx context.Context, cfg config, tm socketTimings) error {
+	backoff := tm.backoffMin
 	for {
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
 
 		warned := make(chan struct{}, 1)
-		done, err := runSocketConnection(ctx, cfg, func() {
+		done, err := runSocketConnection(ctx, cfg, tm, func() {
 			select {
 			case warned <- struct{}{}:
 			default: // already warned; one signal is enough
@@ -148,50 +196,87 @@ func runSocketMode(ctx context.Context, cfg config) error {
 				return ctx.Err()
 			}
 			log.Printf("socket mode: connect failed: %v (retrying in %s)", err, backoff)
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case <-time.After(backoff):
+			if waitErr := sleepFor(ctx, backoff); waitErr != nil {
+				return waitErr
 			}
-			if backoff *= 2; backoff > socketBackoffMax {
-				backoff = socketBackoffMax
-			}
+			backoff = nextBackoff(backoff, tm)
 			continue
 		}
-		// A live connection means the backoff has served its purpose.
-		backoff = socketBackoffMin
+		connectedAt := time.Now()
 
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 
 		case <-warned:
-			// Slack warned this socket is closing, ~10s ahead. Dial the
-			// replacement now, while the old connection keeps draining and
-			// acking in its own goroutine — that overlap is the entire
-			// reason Slack sends the warning early. The drained connection
-			// closes itself; nothing here needs to wait for it.
-			log.Printf("socket mode: opening replacement connection")
+			// Slack warned this socket is closing, ~10s ahead. The replacement
+			// is dialled while the old connection keeps draining and acking in
+			// its own goroutine — that overlap is the entire reason Slack sends
+			// the warning early. The drained connection closes itself; nothing
+			// here needs to wait for it.
+			//
+			// The dial is paced all the same. A connection that lasted a normal
+			// lifetime resets the delay to backoffMin first, which fits inside
+			// the warning's ~10s lead and keeps the overlap; only a connection
+			// warned moments after it opened — the connection-limit churn two
+			// adapters sharing one app token produce — carries an escalating
+			// delay here, and that is precisely the case this path used to
+			// redial at network speed.
+			backoff = settleBackoff(backoff, time.Since(connectedAt), tm)
+			log.Printf("socket mode: opening replacement connection in %s", backoff)
+			if waitErr := sleepFor(ctx, backoff); waitErr != nil {
+				return waitErr
+			}
+			backoff = nextBackoff(backoff, tm)
 			continue
 
 		case err := <-done:
 			if ctx.Err() != nil {
 				return ctx.Err()
 			}
+			backoff = settleBackoff(backoff, time.Since(connectedAt), tm)
 			if err != nil {
 				log.Printf("socket mode: connection ended: %v (reconnecting in %s)", err, backoff)
 			} else {
 				log.Printf("socket mode: connection closed (reconnecting in %s)", backoff)
 			}
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case <-time.After(backoff):
+			if waitErr := sleepFor(ctx, backoff); waitErr != nil {
+				return waitErr
 			}
-			if backoff *= 2; backoff > socketBackoffMax {
-				backoff = socketBackoffMax
-			}
+			backoff = nextBackoff(backoff, tm)
 		}
+	}
+}
+
+// settleBackoff picks the delay before the next dial from how long the
+// connection that just ended lasted. A connection that survived
+// tm.minLifetime proved the endpoint healthy, so its successor starts from the
+// floor again; one that died sooner keeps the escalating delay, which is what
+// stops a dial-OK → instant-death cycle from redialling at the floor forever.
+func settleBackoff(backoff, lifetime time.Duration, tm socketTimings) time.Duration {
+	if lifetime >= tm.minLifetime {
+		return tm.backoffMin
+	}
+	return backoff
+}
+
+// nextBackoff doubles the reconnect delay, capped.
+func nextBackoff(backoff time.Duration, tm socketTimings) time.Duration {
+	backoff *= 2
+	if backoff > tm.backoffMax {
+		return tm.backoffMax
+	}
+	return backoff
+}
+
+// sleepFor waits for d, returning early with ctx.Err() if the context is
+// cancelled first.
+func sleepFor(ctx context.Context, d time.Duration) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(d):
+		return nil
 	}
 }
 
@@ -201,13 +286,13 @@ func runSocketMode(ctx context.Context, cfg config) error {
 // connected and then ended" (reconnect promptly); pumping is not, so the
 // caller can react to a disconnect warning without waiting for the drain.
 // onWarning fires when Slack announces an impending close.
-func runSocketConnection(ctx context.Context, cfg config, onWarning func()) (<-chan error, error) {
+func runSocketConnection(ctx context.Context, cfg config, tm socketTimings, onWarning func()) (<-chan error, error) {
 	conn, err := dialSocketMode(ctx, cfg)
 	if err != nil {
 		return nil, err
 	}
 	done := make(chan error, 1)
-	go func() { done <- pumpSocket(ctx, cfg, conn, onWarning) }()
+	go func() { done <- pumpSocket(ctx, cfg, tm, conn, onWarning) }()
 	return done, nil
 }
 
@@ -281,7 +366,7 @@ func openSocketConnectionURL(ctx context.Context, cfg config) (string, error) {
 
 // pumpSocket reads envelopes until the connection ends, acking each one and
 // bridging events through the same path the HTTP listener uses.
-func pumpSocket(ctx context.Context, cfg config, conn socketConn, onWarning func()) error {
+func pumpSocket(ctx context.Context, cfg config, tm socketTimings, conn socketConn, onWarning func()) error {
 	defer func() { _ = conn.Close() }()
 
 	// connCtx bounds this connection specifically: the keepalive cancels it
@@ -290,7 +375,7 @@ func pumpSocket(ctx context.Context, cfg config, conn socketConn, onWarning func
 	// it with no deadline of their own — see socketPingInterval.
 	connCtx, closeConn := context.WithCancel(ctx)
 	defer closeConn()
-	go keepaliveSocket(connCtx, conn, socketPingInterval, closeConn)
+	go keepaliveSocket(connCtx, conn, tm.pingInterval, closeConn)
 
 	// A disconnect warning arrives ~10s before Slack drops the socket. Rather
 	// than tear down immediately (which loses whatever is in flight), the
@@ -331,7 +416,7 @@ func pumpSocket(ctx context.Context, cfg config, conn socketConn, onWarning func
 				draining = true
 				// Bound the drain: if Slack never actually closes, this
 				// connection must not linger next to its replacement.
-				time.AfterFunc(socketDrainGrace, closeConn)
+				time.AfterFunc(tm.drainGrace, closeConn)
 				if onWarning != nil {
 					onWarning()
 				}
@@ -416,15 +501,11 @@ func handleSocketEnvelope(cfg config, env socketEnvelope) {
 		log.Printf("socket mode: decode payload: %v", err)
 		return
 	}
-	// The HTTP path proves workspace identity via the signing secret. Socket
-	// Mode has no equivalent, and the adapter stamps every bridged message
-	// with cfg.workspaceID as its account id — so an event from another
-	// workspace (an app installed more than once) would be filed under the
-	// wrong account. Drop it instead.
-	if payload.TeamID != "" && payload.TeamID != cfg.workspaceID {
-		log.Printf("socket mode: dropping event from unexpected team %s (want %s)", payload.TeamID, cfg.workspaceID)
-		return
-	}
+	// The workspace-identity check lives in bridgeEvent, shared with the HTTP
+	// path: neither transport proves which workspace an event belongs to (the
+	// HTTP signature proves it came from Slack for this app, not from this
+	// team), and both stamp cfg.workspaceID as the account id, so the guard
+	// belongs at the funnel rather than here.
 	if env.RetryAttempt > 0 {
 		// gc dedupes on DedupKey, so a redelivery is harmless; log it because
 		// a persistent retry count means acks are not landing in time.

--- a/slack-mini/adapter/socketmode_test.go
+++ b/slack-mini/adapter/socketmode_test.go
@@ -1,0 +1,534 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+)
+
+// scriptedConn is a socketConn that replays a fixed sequence of frames and
+// records everything written back, so the envelope loop can be exercised
+// without a server.
+type scriptedConn struct {
+	mu     sync.Mutex
+	frames [][]byte
+	next   int
+	writes [][]byte
+	closed bool
+	// blockAfterScript, when set, makes Read block on ctx instead of
+	// returning io.EOF once the script is exhausted — used to model a
+	// connection that stays open.
+	blockAfterScript bool
+}
+
+func (s *scriptedConn) Read(ctx context.Context) ([]byte, error) {
+	s.mu.Lock()
+	if s.next < len(s.frames) {
+		frame := s.frames[s.next]
+		s.next++
+		s.mu.Unlock()
+		return frame, nil
+	}
+	s.mu.Unlock()
+	if s.blockAfterScript {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	return nil, io.EOF
+}
+
+func (s *scriptedConn) Write(_ context.Context, data []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.writes = append(s.writes, append([]byte(nil), data...))
+	return nil
+}
+
+func (s *scriptedConn) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.closed = true
+	return nil
+}
+
+func (s *scriptedConn) written() [][]byte {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([][]byte(nil), s.writes...)
+}
+
+// gcStub stands in for the gc API, signalling each bridged inbound message.
+func gcStub(t *testing.T) (*httptest.Server, chan externalInboundMessage) {
+	t.Helper()
+	got := make(chan externalInboundMessage, 8)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var wrap struct {
+			Message externalInboundMessage `json:"message"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&wrap); err != nil {
+			t.Errorf("decode inbound: %v", err)
+		}
+		got <- wrap.Message
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, got
+}
+
+func appMentionEnvelope(t *testing.T, envelopeID, teamID, text string) []byte {
+	t.Helper()
+	event, err := json.Marshal(slackMessageEvent{
+		Type:        "app_mention",
+		User:        "U99",
+		Text:        text,
+		Channel:     "C42",
+		TS:          "1700000000.0001",
+		ChannelType: "channel",
+	})
+	if err != nil {
+		t.Fatalf("marshal event: %v", err)
+	}
+	payload, err := json.Marshal(slackEventEnvelope{
+		Type:   "event_callback",
+		TeamID: teamID,
+		Event:  event,
+	})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	frame, err := json.Marshal(socketEnvelope{
+		Type:       "events_api",
+		EnvelopeID: envelopeID,
+		Payload:    payload,
+	})
+	if err != nil {
+		t.Fatalf("marshal envelope: %v", err)
+	}
+	return frame
+}
+
+func TestConfigSocketModeSelector(t *testing.T) {
+	// Socket Mode does not consult the signing secret, so it must not be
+	// required — that is the whole point of the ingress-free path.
+	cfg, err := loadConfigFromEnv(func(key string) string {
+		switch key {
+		case "SLACK_APP_TOKEN":
+			return "xapp-1-A-abc"
+		case "SLACK_BOT_TOKEN":
+			return "xoxb-abc"
+		case "SLACK_WORKSPACE_ID":
+			return "T123"
+		case "GC_CITY_NAME":
+			return "mycity"
+		}
+		return ""
+	})
+	if err != nil {
+		t.Fatalf("socket-mode config rejected: %v", err)
+	}
+	if !cfg.socketMode() {
+		t.Error("socketMode() = false with SLACK_APP_TOKEN set")
+	}
+
+	// Without an app token the HTTP transport still demands its secret.
+	_, err = loadConfigFromEnv(func(key string) string {
+		switch key {
+		case "SLACK_BOT_TOKEN":
+			return "xoxb-abc"
+		case "SLACK_WORKSPACE_ID":
+			return "T123"
+		case "GC_CITY_NAME":
+			return "mycity"
+		}
+		return ""
+	})
+	if err == nil || !strings.Contains(err.Error(), "SLACK_SIGNING_SECRET") {
+		t.Errorf("http mode without signing secret: err = %v, want SLACK_SIGNING_SECRET required", err)
+	}
+}
+
+func TestConfigRejectsBotTokenAsAppToken(t *testing.T) {
+	_, err := loadConfigFromEnv(func(key string) string {
+		switch key {
+		case "SLACK_APP_TOKEN":
+			return "xoxb-not-an-app-token"
+		case "SLACK_BOT_TOKEN":
+			return "xoxb-abc"
+		case "SLACK_WORKSPACE_ID":
+			return "T123"
+		case "GC_CITY_NAME":
+			return "mycity"
+		}
+		return ""
+	})
+	if err == nil || !strings.Contains(err.Error(), "xapp-") {
+		t.Errorf("err = %v, want a message naming the xapp- prefix", err)
+	}
+}
+
+func TestOpenSocketConnectionURL(t *testing.T) {
+	var gotAuth, gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true,"url":"wss://wss-primary.slack.com/link/?ticket=abc"}`))
+	}))
+	defer srv.Close()
+
+	url, err := openSocketConnectionURL(context.Background(), config{
+		slackAPIBase: srv.URL,
+		appToken:     "xapp-1-A-abc",
+	})
+	if err != nil {
+		t.Fatalf("openSocketConnectionURL: %v", err)
+	}
+	if url != "wss://wss-primary.slack.com/link/?ticket=abc" {
+		t.Errorf("url = %q", url)
+	}
+	// The app-level token, not the bot token, authenticates this call.
+	if gotAuth != "Bearer xapp-1-A-abc" {
+		t.Errorf("Authorization = %q", gotAuth)
+	}
+	if gotPath != "/apps.connections.open" {
+		t.Errorf("path = %q", gotPath)
+	}
+}
+
+func TestOpenSocketConnectionURLSurfacesScopeHint(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"ok":false,"error":"invalid_auth"}`))
+	}))
+	defer srv.Close()
+
+	_, err := openSocketConnectionURL(context.Background(), config{
+		slackAPIBase: srv.URL,
+		appToken:     "xapp-1-A-abc",
+	})
+	if err == nil {
+		t.Fatal("want error on ok:false")
+	}
+	// The overwhelmingly common cause is a missing scope; the message should
+	// say so rather than leaving the operator with a bare invalid_auth.
+	if !strings.Contains(err.Error(), "invalid_auth") || !strings.Contains(err.Error(), "connections:write") {
+		t.Errorf("err = %v, want invalid_auth plus the connections:write hint", err)
+	}
+}
+
+func TestPumpSocketAcksThenBridges(t *testing.T) {
+	gc, inbound := gcStub(t)
+	cfg := config{
+		gcAPIBase:     gc.URL,
+		cityName:      "mycity",
+		provider:      "slack",
+		workspaceID:   "T123",
+		inboundTarget: "mayor",
+	}
+	conn := &scriptedConn{frames: [][]byte{
+		[]byte(`{"type":"hello","num_connections":1}`),
+		appMentionEnvelope(t, "env-1", "T123", "<@U0BOT> deploy please"),
+	}}
+
+	if err := pumpSocket(context.Background(), cfg, conn, nil); !errors.Is(err, io.EOF) {
+		t.Fatalf("pumpSocket err = %v, want io.EOF at end of script", err)
+	}
+
+	writes := conn.written()
+	if len(writes) != 1 {
+		t.Fatalf("wrote %d frames, want exactly 1 ack (hello is not acked)", len(writes))
+	}
+	var ack map[string]string
+	if err := json.Unmarshal(writes[0], &ack); err != nil {
+		t.Fatalf("ack is not JSON: %v (%s)", err, writes[0])
+	}
+	if ack["envelope_id"] != "env-1" {
+		t.Errorf("ack = %v, want envelope_id env-1", ack)
+	}
+
+	select {
+	case msg := <-inbound:
+		if msg.Text != "deploy please" {
+			t.Errorf("bridged Text = %q, want the mention stripped", msg.Text)
+		}
+		if msg.ExplicitTarget != "mayor" {
+			t.Errorf("bridged ExplicitTarget = %q", msg.ExplicitTarget)
+		}
+		if msg.DedupKey != "slack-1700000000.0001" {
+			t.Errorf("bridged DedupKey = %q", msg.DedupKey)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("event was acked but never bridged to gc")
+	}
+	if !conn.closed {
+		t.Error("pumpSocket returned without closing the connection")
+	}
+}
+
+func TestPumpSocketDrainsAfterDisconnect(t *testing.T) {
+	gc, inbound := gcStub(t)
+	cfg := config{gcAPIBase: gc.URL, cityName: "c", workspaceID: "T123", inboundTarget: "mayor"}
+	conn := &scriptedConn{frames: [][]byte{
+		[]byte(`{"type":"disconnect","reason":"refresh_requested"}`),
+		appMentionEnvelope(t, "env-2", "T123", "<@U0BOT> still here"),
+	}}
+
+	// A warned-about close is orderly, not an error: envelopes already in
+	// flight are still acked, and the supervisor reconnects without logging
+	// a failure.
+	if err := pumpSocket(context.Background(), cfg, conn, nil); err != nil {
+		t.Fatalf("pumpSocket err = %v, want nil after a disconnect warning", err)
+	}
+	if writes := conn.written(); len(writes) != 1 {
+		t.Errorf("wrote %d frames, want the in-flight envelope acked during drain", len(writes))
+	}
+	select {
+	case <-inbound:
+	case <-time.After(5 * time.Second):
+		t.Fatal("envelope received during drain was never bridged")
+	}
+}
+
+func TestPumpSocketSkipsUndecodableFrame(t *testing.T) {
+	cfg := config{gcAPIBase: "http://127.0.0.1:1", cityName: "c", workspaceID: "T123"}
+	conn := &scriptedConn{frames: [][]byte{[]byte(`{not json`)}}
+	// A malformed frame must not kill the connection — the next envelope on
+	// the same socket should still be read.
+	if err := pumpSocket(context.Background(), cfg, conn, nil); !errors.Is(err, io.EOF) {
+		t.Fatalf("pumpSocket err = %v, want the loop to continue to EOF", err)
+	}
+	if len(conn.written()) != 0 {
+		t.Error("acked an undecodable frame")
+	}
+}
+
+func TestPumpSocketStopsOnContextCancel(t *testing.T) {
+	cfg := config{gcAPIBase: "http://127.0.0.1:1", cityName: "c", workspaceID: "T123"}
+	conn := &scriptedConn{blockAfterScript: true}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- pumpSocket(ctx, cfg, conn, nil) }()
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("pumpSocket ignored context cancellation")
+	}
+}
+
+func TestHandleSocketEnvelopeDropsForeignWorkspace(t *testing.T) {
+	gc, inbound := gcStub(t)
+	cfg := config{gcAPIBase: gc.URL, cityName: "c", workspaceID: "T123", inboundTarget: "mayor"}
+
+	var env socketEnvelope
+	if err := json.Unmarshal(appMentionEnvelope(t, "env-3", "T_OTHER", "<@U0BOT> hi"), &env); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	// Every bridged message is stamped with cfg.workspaceID as its account
+	// id, so an event from another workspace would be filed under the wrong
+	// account. Socket Mode has no signature to catch it — this check does.
+	handleSocketEnvelope(cfg, env)
+
+	select {
+	case msg := <-inbound:
+		t.Fatalf("bridged an event from a foreign workspace: %+v", msg)
+	case <-time.After(250 * time.Millisecond):
+	}
+}
+
+func TestHandleSocketEnvelopeIgnoresNonEventTypes(t *testing.T) {
+	gc, inbound := gcStub(t)
+	cfg := config{gcAPIBase: gc.URL, cityName: "c", workspaceID: "T123", inboundTarget: "mayor"}
+	// Interactivity and slash commands belong to the larger tiers; Tier 1
+	// must ignore them rather than misroute them as mentions.
+	handleSocketEnvelope(cfg, socketEnvelope{Type: "interactive", EnvelopeID: "e", Payload: json.RawMessage(`{}`)})
+	select {
+	case msg := <-inbound:
+		t.Fatalf("bridged a non-events_api envelope: %+v", msg)
+	case <-time.After(250 * time.Millisecond):
+	}
+}
+
+func TestSocketAckEscapesEnvelopeID(t *testing.T) {
+	// Envelope ids are Slack-supplied; a hand-concatenated ack would let a
+	// crafted id break out of the JSON.
+	ack := socketAck(`abc","injected":"x`)
+	var decoded map[string]string
+	if err := json.Unmarshal(ack, &decoded); err != nil {
+		t.Fatalf("ack is not valid JSON: %v (%s)", err, ack)
+	}
+	if _, injected := decoded["injected"]; injected {
+		t.Errorf("envelope id escaped its field: %s", ack)
+	}
+	if decoded["envelope_id"] != `abc","injected":"x` {
+		t.Errorf("envelope_id = %q", decoded["envelope_id"])
+	}
+}
+
+// TestSocketModeEndToEnd drives the real transport: a WebSocket server stands
+// in for Slack, and the adapter negotiates, connects, acks, and bridges over
+// an actual connection rather than the scripted stub.
+func TestSocketModeEndToEnd(t *testing.T) {
+	gc, inbound := gcStub(t)
+
+	acked := make(chan string, 1)
+	wsSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			t.Errorf("accept: %v", err)
+			return
+		}
+		defer func() { _ = c.CloseNow() }()
+		ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+		defer cancel()
+
+		if err := c.Write(ctx, websocket.MessageText, []byte(`{"type":"hello"}`)); err != nil {
+			return
+		}
+		if err := c.Write(ctx, websocket.MessageText, appMentionEnvelope(t, "env-e2e", "T123", "<@U0BOT> ship it")); err != nil {
+			return
+		}
+		_, data, err := c.Read(ctx)
+		if err != nil {
+			return
+		}
+		var ack map[string]string
+		_ = json.Unmarshal(data, &ack)
+		acked <- ack["envelope_id"]
+	}))
+	defer wsSrv.Close()
+
+	// apps.connections.open hands back the test server's ws:// URL.
+	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		wsURL := "ws" + strings.TrimPrefix(wsSrv.URL, "http")
+		_, _ = w.Write([]byte(`{"ok":true,"url":"` + wsURL + `"}`))
+	}))
+	defer apiSrv.Close()
+
+	cfg := config{
+		gcAPIBase:     gc.URL,
+		cityName:      "mycity",
+		provider:      "slack",
+		workspaceID:   "T123",
+		inboundTarget: "mayor",
+		slackAPIBase:  apiSrv.URL,
+		appToken:      "xapp-1-A-abc",
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	if _, err := runSocketConnection(ctx, cfg, nil); err != nil {
+		t.Fatalf("runSocketConnection: %v", err)
+	}
+
+	select {
+	case id := <-acked:
+		if id != "env-e2e" {
+			t.Errorf("ack envelope_id = %q, want env-e2e", id)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("no ack reached the server over a real connection")
+	}
+	select {
+	case msg := <-inbound:
+		if msg.Text != "ship it" {
+			t.Errorf("bridged Text = %q", msg.Text)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("event never bridged to gc")
+	}
+}
+
+// TestRunSocketModeReconnectsAfterDisconnect exercises the supervisor over a
+// real transport: the first connection is told to go away, and the adapter
+// must dial a second one and keep bridging. Reconnect is the steady state in
+// Socket Mode — Slack recycles connections routinely — so this is the path
+// that matters most in production.
+func TestRunSocketModeReconnectsAfterDisconnect(t *testing.T) {
+	gc, inbound := gcStub(t)
+
+	var mu sync.Mutex
+	connections := 0
+	wsSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer func() { _ = c.CloseNow() }()
+		ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
+		defer cancel()
+
+		mu.Lock()
+		connections++
+		n := connections
+		mu.Unlock()
+
+		if err := c.Write(ctx, websocket.MessageText, []byte(`{"type":"hello"}`)); err != nil {
+			return
+		}
+		if n == 1 {
+			// Warn, then go away as Slack does after its grace period.
+			_ = c.Write(ctx, websocket.MessageText, []byte(`{"type":"disconnect","reason":"refresh_requested"}`))
+			return
+		}
+		// The replacement connection carries the event that must not be lost.
+		_ = c.Write(ctx, websocket.MessageText, appMentionEnvelope(t, "env-after-reconnect", "T123", "<@U0BOT> after reconnect"))
+		<-ctx.Done()
+	}))
+	defer wsSrv.Close()
+
+	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"ok":true,"url":"ws` + strings.TrimPrefix(wsSrv.URL, "http") + `"}`))
+	}))
+	defer apiSrv.Close()
+
+	cfg := config{
+		gcAPIBase:     gc.URL,
+		cityName:      "mycity",
+		workspaceID:   "T123",
+		inboundTarget: "mayor",
+		slackAPIBase:  apiSrv.URL,
+		appToken:      "xapp-1-A-abc",
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = runSocketMode(ctx, cfg) }()
+
+	select {
+	case msg := <-inbound:
+		if msg.Text != "after reconnect" {
+			t.Errorf("bridged Text = %q", msg.Text)
+		}
+	case <-time.After(20 * time.Second):
+		t.Fatal("adapter never reconnected after the disconnect")
+	}
+}
+
+func TestPumpSocketWarnsBeforeDraining(t *testing.T) {
+	gc, _ := gcStub(t)
+	cfg := config{gcAPIBase: gc.URL, cityName: "c", workspaceID: "T123", inboundTarget: "mayor"}
+	conn := &scriptedConn{frames: [][]byte{
+		[]byte(`{"type":"disconnect","reason":"warning"}`),
+		[]byte(`{"type":"disconnect","reason":"warning"}`),
+	}}
+
+	warnings := 0
+	if err := pumpSocket(context.Background(), cfg, conn, func() { warnings++ }); err != nil {
+		t.Fatalf("pumpSocket err = %v", err)
+	}
+	// The warning must fire so the supervisor can dial a replacement while
+	// this connection is still draining — that overlap is the point of
+	// Slack's early warning. A repeat warning is not a second reconnect.
+	if warnings != 1 {
+		t.Errorf("onWarning fired %d times, want exactly 1", warnings)
+	}
+}

--- a/slack-mini/adapter/socketmode_test.go
+++ b/slack-mini/adapter/socketmode_test.go
@@ -28,6 +28,9 @@ type scriptedConn struct {
 	// returning io.EOF once the script is exhausted — used to model a
 	// connection that stays open.
 	blockAfterScript bool
+	// pingErr, when set, makes Ping fail — a wedged connection.
+	pingErr error
+	pings   int
 }
 
 func (s *scriptedConn) Read(ctx context.Context) ([]byte, error) {
@@ -51,6 +54,13 @@ func (s *scriptedConn) Write(_ context.Context, data []byte) error {
 	defer s.mu.Unlock()
 	s.writes = append(s.writes, append([]byte(nil), data...))
 	return nil
+}
+
+func (s *scriptedConn) Ping(_ context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.pings++
+	return s.pingErr
 }
 
 func (s *scriptedConn) Close() error {
@@ -510,6 +520,71 @@ func TestRunSocketModeReconnectsAfterDisconnect(t *testing.T) {
 		}
 	case <-time.After(20 * time.Second):
 		t.Fatal("adapter never reconnected after the disconnect")
+	}
+}
+
+// TestPumpSocketSurvivesIdleConnection is a regression test. An earlier
+// revision bounded each Read with a 90s deadline as an idle watchdog, which
+// tore down healthy connections on any quiet workspace: Slack's keepalives
+// are WebSocket pings, answered inside the library without ever waking a
+// read, so silence is the normal state of a working connection.
+func TestPumpSocketSurvivesIdleConnection(t *testing.T) {
+	cfg := config{gcAPIBase: "http://127.0.0.1:1", cityName: "c", workspaceID: "T123"}
+	conn := &scriptedConn{blockAfterScript: true} // never sends anything
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- pumpSocket(ctx, cfg, conn, nil) }()
+
+	select {
+	case err := <-done:
+		t.Fatalf("pumpSocket gave up on an idle but healthy connection: %v", err)
+	case <-time.After(500 * time.Millisecond):
+		// Still reading, which is correct.
+	}
+}
+
+func TestKeepaliveClosesWedgedConnection(t *testing.T) {
+	conn := &scriptedConn{blockAfterScript: true, pingErr: errors.New("no pong")}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	closed := make(chan struct{})
+	var once sync.Once
+	go keepaliveSocket(ctx, conn, time.Millisecond, func() { once.Do(func() { close(closed) }) })
+
+	// A connection Slack has stopped answering must be torn down rather than
+	// read from forever — the failure mode a NAT or proxy timeout produces.
+	select {
+	case <-closed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("unanswered ping did not close the connection")
+	}
+}
+
+func TestKeepaliveStopsWithContext(t *testing.T) {
+	conn := &scriptedConn{blockAfterScript: true}
+	ctx, cancel := context.WithCancel(context.Background())
+	closedCount := 0
+	done := make(chan struct{})
+	go func() {
+		keepaliveSocket(ctx, conn, time.Millisecond, func() { closedCount++ })
+		close(done)
+	}()
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("keepalive ignored context cancellation")
+	}
+	// Healthy pings must never trip the close path.
+	if closedCount != 0 {
+		t.Errorf("closeConn called %d times on a healthy connection", closedCount)
+	}
+	if conn.pings == 0 {
+		t.Error("keepalive never pinged")
 	}
 }
 

--- a/slack-mini/adapter/socketmode_test.go
+++ b/slack-mini/adapter/socketmode_test.go
@@ -248,7 +248,7 @@ func TestPumpSocketAcksThenBridges(t *testing.T) {
 		appMentionEnvelope(t, "env-1", "T123", "<@U0BOT> deploy please"),
 	}}
 
-	if err := pumpSocket(context.Background(), cfg, conn, nil); !errors.Is(err, io.EOF) {
+	if err := pumpSocket(context.Background(), cfg, defaultSocketTimings(), conn, nil); !errors.Is(err, io.EOF) {
 		t.Fatalf("pumpSocket err = %v, want io.EOF at end of script", err)
 	}
 
@@ -294,7 +294,7 @@ func TestPumpSocketDrainsAfterDisconnect(t *testing.T) {
 	// A warned-about close is orderly, not an error: envelopes already in
 	// flight are still acked, and the supervisor reconnects without logging
 	// a failure.
-	if err := pumpSocket(context.Background(), cfg, conn, nil); err != nil {
+	if err := pumpSocket(context.Background(), cfg, defaultSocketTimings(), conn, nil); err != nil {
 		t.Fatalf("pumpSocket err = %v, want nil after a disconnect warning", err)
 	}
 	if writes := conn.written(); len(writes) != 1 {
@@ -312,7 +312,7 @@ func TestPumpSocketSkipsUndecodableFrame(t *testing.T) {
 	conn := &scriptedConn{frames: [][]byte{[]byte(`{not json`)}}
 	// A malformed frame must not kill the connection — the next envelope on
 	// the same socket should still be read.
-	if err := pumpSocket(context.Background(), cfg, conn, nil); !errors.Is(err, io.EOF) {
+	if err := pumpSocket(context.Background(), cfg, defaultSocketTimings(), conn, nil); !errors.Is(err, io.EOF) {
 		t.Fatalf("pumpSocket err = %v, want the loop to continue to EOF", err)
 	}
 	if len(conn.written()) != 0 {
@@ -325,7 +325,7 @@ func TestPumpSocketStopsOnContextCancel(t *testing.T) {
 	conn := &scriptedConn{blockAfterScript: true}
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
-	go func() { done <- pumpSocket(ctx, cfg, conn, nil) }()
+	go func() { done <- pumpSocket(ctx, cfg, defaultSocketTimings(), conn, nil) }()
 	cancel()
 	select {
 	case <-done:
@@ -342,9 +342,9 @@ func TestHandleSocketEnvelopeDropsForeignWorkspace(t *testing.T) {
 	if err := json.Unmarshal(appMentionEnvelope(t, "env-3", "T_OTHER", "<@U0BOT> hi"), &env); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	// Every bridged message is stamped with cfg.workspaceID as its account
-	// id, so an event from another workspace would be filed under the wrong
-	// account. Socket Mode has no signature to catch it — this check does.
+	// The guard itself lives in bridgeEvent, shared with the HTTP path (see
+	// TestBridgeEventWorkspaceGuard); this pins that the socket path actually
+	// reaches it, since Socket Mode has no signature to fall back on.
 	handleSocketEnvelope(cfg, env)
 
 	select {
@@ -435,7 +435,7 @@ func TestSocketModeEndToEnd(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
-	if _, err := runSocketConnection(ctx, cfg, nil); err != nil {
+	if _, err := runSocketConnection(ctx, cfg, defaultSocketTimings(), nil); err != nil {
 		t.Fatalf("runSocketConnection: %v", err)
 	}
 
@@ -535,7 +535,7 @@ func TestPumpSocketSurvivesIdleConnection(t *testing.T) {
 	defer cancel()
 
 	done := make(chan error, 1)
-	go func() { done <- pumpSocket(ctx, cfg, conn, nil) }()
+	go func() { done <- pumpSocket(ctx, cfg, defaultSocketTimings(), conn, nil) }()
 
 	select {
 	case err := <-done:
@@ -597,7 +597,7 @@ func TestPumpSocketWarnsBeforeDraining(t *testing.T) {
 	}}
 
 	warnings := 0
-	if err := pumpSocket(context.Background(), cfg, conn, func() { warnings++ }); err != nil {
+	if err := pumpSocket(context.Background(), cfg, defaultSocketTimings(), conn, func() { warnings++ }); err != nil {
 		t.Fatalf("pumpSocket err = %v", err)
 	}
 	// The warning must fire so the supervisor can dial a replacement while
@@ -605,5 +605,307 @@ func TestPumpSocketWarnsBeforeDraining(t *testing.T) {
 	// Slack's early warning. A repeat warning is not a second reconnect.
 	if warnings != 1 {
 		t.Errorf("onWarning fired %d times, want exactly 1", warnings)
+	}
+}
+
+// --- the timing layer ------------------------------------------------------
+//
+// The tests below reach the connection-lifecycle timers through socketTimings.
+// They exist because wall-clock waiting cannot express these properties: an
+// earlier idle test waited 500ms against a 90s deadline and so passed on the
+// very bug it was written for, and nothing pinned that a connection runs a
+// keepalive, that a drain is bounded, or that reconnects are paced.
+
+// deadlineProbeConn records whether the context pumpSocket reads with carries
+// a deadline. It never yields a frame, modelling a healthy but idle Slack
+// connection.
+type deadlineProbeConn struct {
+	mu       sync.Mutex
+	hasDL    bool
+	pings    int
+	readOnce chan struct{}
+}
+
+func (d *deadlineProbeConn) Read(ctx context.Context) ([]byte, error) {
+	_, ok := ctx.Deadline()
+	d.mu.Lock()
+	d.hasDL = ok
+	d.mu.Unlock()
+	select {
+	case d.readOnce <- struct{}{}:
+	default:
+	}
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func (d *deadlineProbeConn) Write(context.Context, []byte) error { return nil }
+
+func (d *deadlineProbeConn) Ping(context.Context) error {
+	d.mu.Lock()
+	d.pings++
+	d.mu.Unlock()
+	return nil
+}
+
+func (d *deadlineProbeConn) Close() error { return nil }
+
+// TestPumpSocketReadsWithoutDeadline pins the mechanism behind the idle fix:
+// an idle Socket Mode connection is healthy, so reads must block on a context
+// no timer will expire. Waiting a wall-clock interval cannot express this —
+// the deadline that caused the outage was 90s — whereas the absence of any
+// deadline is checkable in one read.
+func TestPumpSocketReadsWithoutDeadline(t *testing.T) {
+	cfg := config{gcAPIBase: "http://127.0.0.1:1", cityName: "c", workspaceID: "T123"}
+	conn := &deadlineProbeConn{readOnce: make(chan struct{}, 1)}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() { _ = pumpSocket(ctx, cfg, defaultSocketTimings(), conn, nil) }()
+
+	select {
+	case <-conn.readOnce:
+	case <-time.After(5 * time.Second):
+		t.Fatal("pumpSocket never issued a read")
+	}
+	conn.mu.Lock()
+	hasDL := conn.hasDL
+	conn.mu.Unlock()
+	if hasDL {
+		t.Fatal("pumpSocket bounded its read with a deadline; idle connections are torn down on that timer")
+	}
+}
+
+// TestPumpSocketTearsDownWedgedConnection is the other half of the liveness
+// design, and the half that needed the injectable interval: a connection Slack
+// has stopped answering must be abandoned. TestKeepaliveClosesWedgedConnection
+// calls keepaliveSocket directly, so it stays green if pumpSocket never starts
+// one; this drives the production wiring instead.
+func TestPumpSocketTearsDownWedgedConnection(t *testing.T) {
+	tm := defaultSocketTimings()
+	tm.pingInterval = time.Millisecond
+
+	cfg := config{gcAPIBase: "http://127.0.0.1:1", cityName: "c", workspaceID: "T123"}
+	// Reads block forever, as a wedged connection does: only the keepalive can
+	// end this pump.
+	conn := &scriptedConn{blockAfterScript: true, pingErr: errors.New("no pong")}
+
+	done := make(chan error, 1)
+	go func() { done <- pumpSocket(context.Background(), cfg, tm, conn, nil) }()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Error("pumpSocket reported a clean end for a wedged connection")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("pumpSocket read forever from a connection Slack had stopped answering")
+	}
+	conn.mu.Lock()
+	closed := conn.closed
+	conn.mu.Unlock()
+	if !closed {
+		t.Error("wedged connection was left open")
+	}
+}
+
+// TestPumpSocketBoundsDrain pins the drain bound. The existing drain test ends
+// because its scripted frames run out and Read returns io.EOF, so it never
+// exercises the timer; here Read never returns on its own, which leaves the
+// AfterFunc as the only way out.
+func TestPumpSocketBoundsDrain(t *testing.T) {
+	tm := defaultSocketTimings()
+	tm.drainGrace = 25 * time.Millisecond
+
+	gc, _ := gcStub(t)
+	cfg := config{gcAPIBase: gc.URL, cityName: "c", workspaceID: "T123", inboundTarget: "mayor"}
+	conn := &scriptedConn{
+		frames:           [][]byte{[]byte(`{"type":"disconnect","reason":"warning"}`)},
+		blockAfterScript: true,
+	}
+
+	start := time.Now()
+	done := make(chan error, 1)
+	go func() { done <- pumpSocket(context.Background(), cfg, tm, conn, nil) }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("drain ended with err = %v, want nil (an elapsed drain is expected, not a failure)", err)
+		}
+		if elapsed := time.Since(start); elapsed < tm.drainGrace {
+			t.Errorf("drain ended after %s, before the %s grace — in-flight envelopes lose their ack window", elapsed, tm.drainGrace)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("a warned connection whose close never landed drained past %s and would linger beside its replacement", tm.drainGrace)
+	}
+}
+
+// TestDefaultSocketTimingsMatchConstants pins the production timer set to
+// literal durations rather than to the constants it is built from. Every other
+// test in this section injects scaled-down timings, so without this pin a
+// production interval could drift — or be zeroed — with the whole suite green.
+// Changing a timer here is fine; it just has to be visible in the diff.
+func TestDefaultSocketTimingsMatchConstants(t *testing.T) {
+	want := socketTimings{
+		pingInterval: 30 * time.Second,
+		drainGrace:   10 * time.Second,
+		backoffMin:   1 * time.Second,
+		backoffMax:   30 * time.Second,
+		minLifetime:  30 * time.Second,
+	}
+	if got := defaultSocketTimings(); got != want {
+		t.Errorf("defaultSocketTimings() = %+v, want %+v", got, want)
+	}
+}
+
+func TestSettleBackoffResetsOnlyAfterMinLifetime(t *testing.T) {
+	tm := socketTimings{backoffMin: time.Second, backoffMax: 30 * time.Second, minLifetime: 30 * time.Second}
+	for _, tc := range []struct {
+		name     string
+		backoff  time.Duration
+		lifetime time.Duration
+		want     time.Duration
+	}{
+		// A connection that proved the endpoint healthy earns its successor
+		// the floor again — this is the ordinary Slack refresh.
+		{"outlived the minimum", 8 * time.Second, 30 * time.Second, time.Second},
+		{"long-lived", 30 * time.Second, time.Hour, time.Second},
+		// Dial-OK then instant death is the case a reset-on-establishment
+		// misreads as health, redialling at the floor forever.
+		{"died immediately", 8 * time.Second, 0, 8 * time.Second},
+		{"just short of the minimum", 8 * time.Second, 29 * time.Second, 8 * time.Second},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := settleBackoff(tc.backoff, tc.lifetime, tm); got != tc.want {
+				t.Errorf("settleBackoff(%s, %s) = %s, want %s", tc.backoff, tc.lifetime, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNextBackoffDoublesToCap(t *testing.T) {
+	tm := socketTimings{backoffMin: time.Second, backoffMax: 30 * time.Second}
+	for _, tc := range []struct{ in, want time.Duration }{
+		{time.Second, 2 * time.Second},
+		{8 * time.Second, 16 * time.Second},
+		{16 * time.Second, 30 * time.Second}, // 32s clamped
+		{30 * time.Second, 30 * time.Second},
+	} {
+		if got := nextBackoff(tc.in, tm); got != tc.want {
+			t.Errorf("nextBackoff(%s) = %s, want %s", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestRunSocketModePacesWarnedReconnect drives the supervisor over a real
+// transport against a server that warns every connection the moment it opens —
+// the shape two adapters sharing one app token produce as they displace each
+// other. That path used to redial at network speed, one apps.connections.open
+// plus handshake per cycle, because it was the only reconnect arm with no
+// delay and because backoff reset on every successful dial.
+func TestRunSocketModePacesWarnedReconnect(t *testing.T) {
+	tm := socketTimings{
+		backoffMin: 40 * time.Millisecond,
+		backoffMax: 5 * time.Second,
+		// No connection here reaches minLifetime, so each successor must carry
+		// the escalating delay: this is what distinguishes pacing from a reset
+		// on every dial.
+		minLifetime: time.Hour,
+		// Neither timer should fire during the test; the connections are held
+		// open by the server, not ended by a keepalive or an elapsed drain.
+		pingInterval: time.Hour,
+		drainGrace:   time.Hour,
+	}
+
+	var mu sync.Mutex
+	var dials []time.Time
+	stop := make(chan struct{})
+	dialed := make(chan struct{}, 16)
+
+	wsSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		dials = append(dials, time.Now())
+		mu.Unlock()
+		select {
+		case dialed <- struct{}{}:
+		default:
+		}
+
+		c, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer func() { _ = c.CloseNow() }()
+		ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+		defer cancel()
+
+		if err := c.Write(ctx, websocket.MessageText, []byte(`{"type":"hello"}`)); err != nil {
+			return
+		}
+		if err := c.Write(ctx, websocket.MessageText, []byte(`{"type":"disconnect","reason":"link_disabled"}`)); err != nil {
+			return
+		}
+		// Hold the connection open. If it ended here, the supervisor could take
+		// its `done` arm instead of the warned arm — both are paced now, so the
+		// test would pass without ever measuring the path it is about.
+		select {
+		case <-stop:
+		case <-ctx.Done():
+		}
+	}))
+	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"ok":true,"url":"ws` + strings.TrimPrefix(wsSrv.URL, "http") + `"}`))
+	}))
+
+	cfg := config{
+		gcAPIBase:     "http://127.0.0.1:1",
+		cityName:      "mycity",
+		workspaceID:   "T123",
+		inboundTarget: "mayor",
+		slackAPIBase:  apiSrv.URL,
+		appToken:      "xapp-1-A-abc",
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Unwind inside out: release the handlers, stop the supervisor redialling,
+	// then close the servers, so nothing touches t after this test returns.
+	defer wsSrv.Close()
+	defer apiSrv.Close()
+	defer cancel()
+	defer close(stop)
+
+	go func() { _ = runSocketModeWithTimings(ctx, cfg, tm) }()
+
+	const wantDials = 4
+	for i := 0; i < wantDials; i++ {
+		select {
+		case <-dialed:
+		case <-time.After(10 * time.Second):
+			t.Fatalf("only %d of %d dials arrived", i, wantDials)
+		}
+	}
+
+	mu.Lock()
+	got := append([]time.Time(nil), dials...)
+	mu.Unlock()
+	if len(got) < wantDials {
+		t.Fatalf("recorded %d dials, want %d", len(got), wantDials)
+	}
+
+	gaps := make([]time.Duration, 0, len(got)-1)
+	for i := 1; i < len(got); i++ {
+		gaps = append(gaps, got[i].Sub(got[i-1]))
+	}
+	for i, gap := range gaps {
+		if gap < tm.backoffMin {
+			t.Errorf("redial %d came %s after the previous one, inside the %s floor: gaps=%v", i+1, gap, tm.backoffMin, gaps)
+		}
+	}
+	// Doubling from a 40ms floor gives ~40ms, ~80ms, ~160ms. A backoff that
+	// reset on every dial would hold every gap near the floor, so requiring
+	// the last one to exceed 3x it is what pins the escalation.
+	if last := gaps[len(gaps)-1]; last < 3*tm.backoffMin {
+		t.Errorf("last redial gap %s did not escalate past 3x the %s floor: gaps=%v", last, tm.backoffMin, gaps)
 	}
 }

--- a/slack-mini/manifest/app-socket.json
+++ b/slack-mini/manifest/app-socket.json
@@ -1,0 +1,40 @@
+{
+  "display_information": {
+    "name": "gc-mayor",
+    "description": "Talk to your Gas City mayor from Slack over Socket Mode - no public URL required.",
+    "background_color": "#1f2933"
+  },
+  "features": {
+    "bot_user": {
+      "display_name": "gc-mayor",
+      "always_online": true
+    },
+    "app_home": {
+      "home_tab_enabled": false,
+      "messages_tab_enabled": true,
+      "messages_tab_read_only_enabled": false
+    }
+  },
+  "oauth_config": {
+    "scopes": {
+      "bot": [
+        "app_mentions:read",
+        "chat:write",
+        "chat:write.public"
+      ]
+    }
+  },
+  "settings": {
+    "event_subscriptions": {
+      "bot_events": [
+        "app_mention"
+      ]
+    },
+    "interactivity": {
+      "is_enabled": false
+    },
+    "org_deploy_enabled": false,
+    "socket_mode_enabled": true,
+    "token_rotation_enabled": false
+  }
+}

--- a/slack-mini/pack.toml
+++ b/slack-mini/pack.toml
@@ -7,12 +7,15 @@
 #
 # Pack-shipped binary:
 #
-#   - Adapter (./adapter/gc-slack-mini-adapter, built from adapter/main.go).
-#     A single-file Slack webhook receiver + outbound publisher. The
-#     [[service]] block below has gc supervise it as a proxy_process. It
-#     binds a Unix domain socket at $GC_SERVICE_SOCKET for /post-message +
-#     /healthz, and a public TCP port for /slack/events (the Slack Events
-#     API receiver — terminate TLS in front of it, e.g. Tailscale Funnel).
+#   - Adapter (./adapter/gc-slack-mini-adapter, built from adapter/main.go
+#     + adapter/socketmode.go). A Slack inbound receiver + outbound
+#     publisher. The [[service]] block below has gc supervise it as a
+#     proxy_process. It binds a Unix domain socket at $GC_SERVICE_SOCKET for
+#     /post-message + /healthz. Inbound arrives one of two ways, chosen by
+#     env: with SLACK_APP_TOKEN set it runs Socket Mode (an outbound
+#     WebSocket to Slack — no public port at all); otherwise it binds a
+#     public TCP port for /slack/events (the Slack Events API receiver —
+#     terminate TLS in front of it, e.g. Tailscale Funnel).
 #
 # This pack ships NO operator CLI binary: the single outbound verb is a
 # bash wrapper (commands/post-message.sh) that POSTs to the adapter through
@@ -30,17 +33,18 @@ schema = 2
 
 # proxy_process service: gc supervises the adapter as part of the city's
 # service set. The adapter binds a UDS at $GC_SERVICE_SOCKET for
-# /post-message + /healthz; gc reverse-proxies /svc/slack-mini/* to it. The
-# adapter also binds public TCP (LISTEN_PUBLIC, default 0.0.0.0:8775) for
-# /slack/events. proxy_process owns only the UDS lifecycle.
+# /post-message + /healthz; gc reverse-proxies /svc/slack-mini/* to it. In
+# HTTP mode the adapter also binds public TCP (LISTEN_PUBLIC, default
+# 0.0.0.0:8775) for /slack/events; in Socket Mode (SLACK_APP_TOKEN set) it
+# binds no public port. proxy_process owns only the UDS lifecycle either way.
 #
 # The service is named "slack-mini" (matching the pack) so it does not
 # collide with a slack-full install's "slack" service. Per the tiering
 # design, run exactly one Slack tier per city regardless.
 #
-# Secrets (SLACK_BOT_TOKEN, SLACK_SIGNING_SECRET, SLACK_WORKSPACE_ID) and
-# GC_CITY_NAME are inherited from the service environment at start. See
-# README.md "Configure".
+# Secrets (SLACK_BOT_TOKEN, SLACK_WORKSPACE_ID, plus SLACK_SIGNING_SECRET in
+# HTTP mode or SLACK_APP_TOKEN in Socket Mode) and GC_CITY_NAME are inherited
+# from the service environment at start. See README.md "Configure".
 
 [[service]]
 name = "slack-mini"


### PR DESCRIPTION
## Problem

slack-mini only takes inbound over the Slack Events API, which needs a public HTTPS Request URL — the README points at Tailscale Funnel. That rules the pack out entirely on networks that cannot accept inbound connections: corporate firewalls, laptops, anywhere a tunnel is blocked. That is the situation this change came out of.

## What this does

Adds Socket Mode as an alternative inbound transport. The adapter opens an outbound WebSocket to Slack instead of receiving webhooks, so it needs only egress to `slack.com`.

`SLACK_APP_TOKEN` (an `xapp-` app-level token with `connections:write`) is the entire switch:

- **set** → Socket Mode. `LISTEN_PUBLIC` is never bound, and `SLACK_SIGNING_SECRET` is no longer required.
- **unset** → the HTTP transport, behaving exactly as before, signature verification included.

The event payload inside a Socket Mode envelope is byte-identical to the webhook body, so `bridgeEvent` is reused verbatim — `socketmode.go` is transport only.

## Design notes

**Authenticity.** Socket Mode has no signing secret and no HMAC. The trust boundary is the app-token-authenticated connection the adapter itself opens. Because every bridged message is stamped with `SLACK_WORKSPACE_ID` as its account id, the socket path additionally drops events whose `team_id` does not match — without it, an app installed in a second workspace would be filed under the wrong account. The HTTP path is untouched and still verifies signatures.

**Reconnect is the steady state.** Slack recycles connections routinely. Failed dials back off 1s→30s. On Slack's ~10s advance disconnect warning the supervisor opens the replacement while the old connection keeps draining and acking, rather than tearing down and losing what is in flight.

**Liveness is a ping, not a read deadline.** The first cut bounded reads at 90s as an idle watchdog, which was wrong: Slack's keepalives are WebSocket pings answered inside the library without ever waking a read, and a healthy connection carries data only when someone mentions the bot. It tore down working connections every 90s. Second commit replaces it with a 30s application-level ping; a connection is dropped only when a ping goes unanswered. Both the bug and the fix are covered by tests.

**Envelopes are acked before bridging**, and bridging happens off the read loop so a slow gc cannot stall acks behind it.

## Dependency

Adds `github.com/coder/websocket` v1.8.15, which declares no requires of its own — `go.sum` stays two lines. This is the adapter's first dependency; the sibling `slack-full/cli` module already carries cobra, so pack binaries taking deps seemed established rather than novel. Happy to hand-roll RFC 6455 on stdlib instead if the maintainers prefer the adapters stay dependency-free — the `discord` pack's gateway service is precedent for that. One concrete argument for the library: it dials via `net/http`, so `HTTPS_PROXY`/`NO_PROXY` are honoured, which matters on exactly the restricted networks this feature targets.

## Manifest

One manifest cannot serve both transports (Slack refuses to deliver to a Request URL while Socket Mode is enabled), so this ships `manifest/app-socket.json` — identical to `app.json` but with `socket_mode_enabled: true`. The README now leads with a transport-choice table.

## Testing

`go vet` + `go test -race` green. 16 tests, including two that drive a real WebSocket via `websocket.Accept` rather than a stub: a full ack→bridge round trip, and one that kills the first connection and asserts the adapter reconnects and keeps bridging.

Validated against a live workspace on a network with no inbound ingress:

- `@`-mention → `envelope received` → acked → `POST /extmsg/inbound 200` → reached the target session.
- One connection held **over three hours with zero reconnects** after the keepalive fix. Before it, the same setup churned a reconnect every 90 seconds.
- HTTP mode re-checked for regressions: still binds `:8775`, still answers `/healthz`.

## Note for maintainers (not addressed here)

While testing, a delivered message sat unrouted in gc until an `extmsg` binding was created by hand. Tier 1 sets `explicit_target` and ships no bind verb (`bind-room`/`bind-dm` are Tier 2), so a stock slack-mini install can look silent even when the bridge is working. That looks like a separate gap — possibly just a docs step — and I have deliberately left it out of this PR, which is scoped to the transport.