### PR TITLE
feat(oversight-rig): add portable executive status skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,13 @@ Browse the tree for the current set; each pack has its own README.
 - [cass](./cass) adds a shared `cass-search` prompt fragment and Claude skill
   overlay for searching past coding-agent sessions.
 
+### Oversight packs
+
+- [oversight-rig](./oversight-rig) adds one rig-scoped project lead per rig and
+  includes an optional `city-executive-status` skill for maintaining a
+  shareable, Obsidian-compatible portfolio brief. Its status schedules are
+  examples only and remain inactive until configured by the consuming city.
+
 ### Build methodology packs
 
 Raw-framework subagents become Gas City fanouts. The vendored methodology text

--- a/oversight-rig/README.md
+++ b/oversight-rig/README.md
@@ -35,11 +35,26 @@ The project-lead writes a rollup bead labeled `severity:escalate`. A scheduled o
 - `agents/project-lead/` — the role (agent config, prompt template, and a `project-brief.template.md` to copy per rig)
 - `orders/` — `patrol-project-leads` (triage cadence) and `escalate-rollups` (deterministic delivery)
 - `assets/scripts/` — the delivery script and a rig→channel resolver
+- `skills/city-executive-status/` — an optional workflow for maintaining an Obsidian-compatible portfolio brief from project-owner updates
+
+## Optional executive status brief
+
+The `city-executive-status` skill packages the shareable workflow for requesting
+structured project-owner updates, validating them, and writing one concise
+portfolio brief. It can optionally publish a content-hash-deduplicated summary
+through a deployment-specific adapter.
+
+Importing this pack exposes the skill but does not activate its example
+schedules or write to a vault. The only active pack orders remain
+`patrol-project-leads` and `escalate-rollups`. To enable the workflow, follow the
+skill's `SKILL.md`, copy its environment and order examples into the consuming
+city, configure local paths, and verify dry-run output before scheduling writes.
 
 ## Requirements
 
 - An extmsg/slack adapter in the city for outbound delivery and inbound replies — **compose this pack with your slack pack** (e.g. `slack-full`, `slack-channel`, or `slack-mini`). This pack ships only the oversight role and its escalation machinery, not a slack bridge.
 - Optional: the project-lead's rig-scoped dispatch examples use convoy formulas (`mol-decompose`, `mol-pr-from-issue`) supplied by a workflow pack (e.g. `gastown`). The role works without them.
+- Optional: the executive-status skill needs Python 3.11 or newer. Obsidian and a publishing adapter are not required; without them it writes ordinary Markdown to a configured path.
 
 ## Install
 

--- a/oversight-rig/skills/city-executive-status/SKILL.md
+++ b/oversight-rig/skills/city-executive-status/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: city-executive-status
+description: Maintain a concise, high-level portfolio brief from structured project-owner updates, with Obsidian-compatible Markdown output and optional deduplicated publishing. Use when setting up, sharing, operating, or troubleshooting an executive-status workflow for a multi-agent city or collection of projects.
+---
+
+# City Executive Status
+
+Maintain one current portfolio brief without asking deterministic code to make
+semantic judgments. Project owners describe outcomes and risks; bundled scripts
+only request, validate, aggregate, write, and optionally publish those inputs.
+
+## Preserve the boundary
+
+- Let each project owner decide `health`, `current`, `next`, and `risk` from its
+  real project context.
+- Keep the scripts mechanical. Do not add keyword scoring, inferred health, or
+  automatic rewriting of owner statements.
+- Give every owner exactly one file named `<owner>.md`. Reject owner/filename
+  mismatches and malformed inputs.
+- Write the aggregate atomically. Preserve an existing brief when no valid
+  inputs are available.
+- Treat the vault as live production data. Preview paths and output before
+  enabling scheduled writes.
+
+## Install or share
+
+Prefer importing the containing `oversight-rig` pack in a Gas City workspace.
+The skill is inert until its configuration and example orders are copied into
+that workspace. For a standalone installation, copy this entire
+`city-executive-status/` directory into either a repository's `.claude/skills/`
+directory or the recipient's Codex skills directory. Keep the scripts,
+references, assets, tests, and `agents/openai.yaml` together.
+
+Read [references/configuration.md](references/configuration.md) when installing,
+changing paths, adding a publisher, or adapting the scheduler. Copy and edit the
+bundled environment, input, and order examples rather than inventing new formats.
+
+## Run the workflow
+
+1. Configure paths and command templates from
+   `assets/executive-status.env.example`.
+2. Copy `assets/status-input-template.md` once per owner, naming each copy
+   `<owner>.md` and setting its `owner` field to the same value.
+3. Preview update requests:
+
+   ```bash
+   python3 scripts/request_status_updates.py \
+     --agents-dir ./agents \
+     --input-dir ./executive-status/inputs \
+     --dry-run
+   ```
+
+4. Configure `EXECUTIVE_STATUS_DISPATCH_COMMAND`, then run the same command
+   without `--dry-run`. The command template is parsed without a shell and must
+   contain `{agent}` and `{message}`.
+5. Preview the aggregate:
+
+   ```bash
+   python3 scripts/executive_status_sync.py --dry-run
+   ```
+
+6. Run with `--no-publish` to update only the Markdown brief. Configure
+   `EXECUTIVE_STATUS_PUBLISH_COMMAND` only after the user explicitly authorizes
+   the external destination. Publishing is content-hash deduplicated.
+7. Stagger the request and aggregation schedules so owners have a composition
+   window. Use the examples under `assets/orders/` as starting points.
+
+## Interpret failures
+
+- A malformed input is reported by filename and makes the sync exit nonzero;
+  valid inputs are still visible with a coverage warning.
+- Zero valid inputs makes the sync fail closed without replacing the existing
+  brief.
+- A failed dispatch or publish command propagates as an error. Do not mark its
+  sentinel complete or hide it with a default value.
+- Stale inputs remain visible as `Stale`; they are not silently dropped.
+
+## Verify changes
+
+Run all unit, integration, end-to-end, package-completeness, and scrub tests:
+
+```bash
+python3 -m unittest discover -s tests -v
+```
+
+Then validate the skill structure with the `skill-creator` validator.

--- a/oversight-rig/skills/city-executive-status/agents/openai.yaml
+++ b/oversight-rig/skills/city-executive-status/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "City Executive Status"
+  short_description: "Maintain portable city and project briefs"
+  default_prompt: "Use $city-executive-status to configure and maintain a concise executive status brief for my projects."

--- a/oversight-rig/skills/city-executive-status/assets/executive-status.env.example
+++ b/oversight-rig/skills/city-executive-status/assets/executive-status.env.example
@@ -1,0 +1,18 @@
+# Copy this file into deployment configuration and replace every example value.
+EXECUTIVE_STATUS_INPUT_DIR=/path/to/vault/Projects/Executive-Status/Inputs
+EXECUTIVE_STATUS_OUTPUT=/path/to/vault/Projects/Executive-Status/Executive-Brief.md
+EXECUTIVE_STATUS_TITLE='Executive Status Brief'
+EXECUTIVE_STATUS_AGENTS_DIR=/path/to/orchestrator/agents
+EXECUTIVE_STATUS_EXPECTED_OWNERS='research-pl,platform-pl,mayor'
+EXECUTIVE_STATUS_STALE_HOURS=48
+EXECUTIVE_STATUS_DISPATCH_TIMEOUT=30
+EXECUTIVE_STATUS_PUBLISH_TIMEOUT=90
+EXECUTIVE_STATUS_MAX_PUBLISH_LENGTH=3500
+EXECUTIVE_STATUS_SENTINEL=/path/to/runtime/executive-status-summary.sha256
+EXECUTIVE_STATUS_LOG=/path/to/runtime/executive-status-sync.log
+
+# Templates are parsed without a shell. Keep each placeholder as one argument.
+EXECUTIVE_STATUS_DISPATCH_COMMAND='status-mail send {agent} --subject {subject} --message {message}'
+
+# Leave unset for vault-only operation. Configure only with explicit permission.
+EXECUTIVE_STATUS_PUBLISH_COMMAND='status-publisher --title {title} --body-file {body_file}'

--- a/oversight-rig/skills/city-executive-status/assets/orders/request-status-updates.toml
+++ b/oversight-rig/skills/city-executive-status/assets/orders/request-status-updates.toml
@@ -1,0 +1,11 @@
+# Example scheduler entry. Replace /path/to/city-executive-status with the
+# copied or materialized skill directory. Supply configuration through the
+# scheduler's service environment; keep vault paths and integration identifiers
+# out of this file.
+[order]
+description = "Twice daily: request one executive-status input from each project owner."
+trigger = "cron"
+schedule = "30 9,16 * * *"
+exec = "python3 /path/to/city-executive-status/scripts/request_status_updates.py"
+timeout = "5m"
+idempotent = true

--- a/oversight-rig/skills/city-executive-status/assets/orders/sync-status-brief.toml
+++ b/oversight-rig/skills/city-executive-status/assets/orders/sync-status-brief.toml
@@ -1,0 +1,9 @@
+# Run after a composition window following request-status-updates. Replace
+# /path/to/city-executive-status with the copied or materialized skill directory.
+[order]
+description = "Twice daily: validate owner inputs and refresh the executive brief."
+trigger = "cron"
+schedule = "10 10,17 * * *"
+exec = "python3 /path/to/city-executive-status/scripts/executive_status_sync.py"
+timeout = "3m"
+idempotent = true

--- a/oversight-rig/skills/city-executive-status/assets/status-input-template.md
+++ b/oversight-rig/skills/city-executive-status/assets/status-input-template.md
@@ -1,0 +1,14 @@
+---
+tags: [executive-status-input]
+---
+# Plain Project Name
+
+<!-- executive-status:start -->
+project: Plain Project Name
+owner: owner-handle
+updated: 2030-01-01T09:00:00+00:00
+health: on-track
+current: One plain-language sentence describing the current outcome or focus.
+next: One plain-language sentence describing the next planned outcome.
+risk: none
+<!-- executive-status:end -->

--- a/oversight-rig/skills/city-executive-status/references/configuration.md
+++ b/oversight-rig/skills/city-executive-status/references/configuration.md
@@ -1,0 +1,82 @@
+# Configuration
+
+## Data flow
+
+```text
+scheduled request
+  -> one model-authored Markdown input per owner
+  -> structural validation
+  -> deterministic portfolio brief in the vault
+  -> optional content-hash-deduplicated publisher
+```
+
+The input files are the semantic boundary. The requester supplies the exact
+schema; the aggregator never infers health or rewrites project meaning.
+
+## Environment variables
+
+| Variable | Used by | Default | Purpose |
+| --- | --- | --- | --- |
+| `EXECUTIVE_STATUS_INPUT_DIR` | both | `executive-status/inputs` | Owner input directory |
+| `EXECUTIVE_STATUS_AGENTS_DIR` | requester | unset | Discover `*-pl/agent.toml` owners |
+| `EXECUTIVE_STATUS_DISPATCH_COMMAND` | requester | unset | Shell-free command template containing `{agent}` and `{message}`; `{subject}` is optional |
+| `EXECUTIVE_STATUS_SUBJECT` | requester | `DIRECTIVE: EXECUTIVE_STATUS` | Dispatch subject |
+| `EXECUTIVE_STATUS_DISPATCH_TIMEOUT` | requester | `30` | Per-owner command timeout in seconds |
+| `EXECUTIVE_STATUS_OUTPUT` | sync | `executive-status/Executive Brief.md` | Aggregate Markdown path, normally inside the vault |
+| `EXECUTIVE_STATUS_TITLE` | sync | `Executive Status Brief` | Brief and publish-summary title |
+| `EXECUTIVE_STATUS_EXPECTED_OWNERS` | sync | unset | Comma-separated owners used for coverage reporting |
+| `EXECUTIVE_STATUS_STALE_HOURS` | sync | `48` | Age at which an input is shown as stale |
+| `EXECUTIVE_STATUS_PUBLISH_COMMAND` | sync | unset | Shell-free command template requiring `{body_file}`; `{title}` is optional |
+| `EXECUTIVE_STATUS_PUBLISH_TIMEOUT` | sync | `90` | Publisher timeout in seconds |
+| `EXECUTIVE_STATUS_MAX_PUBLISH_LENGTH` | sync | `3500` | Maximum summary length |
+| `EXECUTIVE_STATUS_SENTINEL` | sync | beside output | Last successfully published summary hash |
+| `EXECUTIVE_STATUS_LOG` | sync | beside output | Append-only audit log |
+
+Command templates are split with `shlex` and executed directly. Shell syntax,
+pipes, redirects, substitutions, and environment expansion are intentionally not
+evaluated. Use a small adapter executable when an integration needs them.
+
+## Installation
+
+1. Copy `assets/executive-status.env.example` outside the skill and set local
+   paths and command adapters.
+2. Create the configured input directory.
+3. Create one input from `assets/status-input-template.md` per expected owner.
+4. Run both scripts in dry-run mode.
+5. Run the sync with `--no-publish` and inspect the generated Markdown in the
+   vault.
+6. Configure publishing only with explicit authorization for that destination.
+7. Install the two scheduler examples, replace their placeholder script paths
+   with the copied or provider-materialized skill directory, and adjust their
+   cadence. Leave enough time between request and aggregation for agents to
+   write their inputs.
+
+## Input contract
+
+Each input must have both fences and exactly these fields:
+
+```text
+project, owner, updated, health, current, next, risk
+```
+
+`owner` must match the filename. `updated` must be an ISO-8601 timestamp with a
+timezone. Health is one of `on-track`, `at-risk`, `blocked`, or `parked`.
+Project and owner are limited to 80 characters; current, next, and risk are
+limited to 240 characters each.
+
+Inputs must be regular Markdown files no larger than 64 KiB. Symbolic links are
+rejected so an input directory cannot redirect the reader elsewhere. Raw HTML
+characters are escaped before owner content enters the brief or publish summary.
+
+Use `blocked` only when the project cannot make useful progress. Use `at-risk`
+when progress continues but an outcome is threatened. Use `parked` for deliberate
+inactivity. Keep internal work IDs, paths, branches, queue counts, and incident
+mechanics out of the brief.
+
+## Adapters
+
+For a Gas City installation, a dispatch adapter can invoke `gc mail send` with
+the `{agent}`, `{subject}`, and `{message}` arguments. A publishing adapter can
+invoke any approved channel command that accepts a Markdown file path. Keep
+platform-specific identifiers and credentials in the deployment environment,
+not in this skill.

--- a/oversight-rig/skills/city-executive-status/scripts/executive_status_sync.py
+++ b/oversight-rig/skills/city-executive-status/scripts/executive_status_sync.py
@@ -1,0 +1,544 @@
+#!/usr/bin/env python3
+"""Validate status inputs and maintain one deterministic executive brief."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import html
+import os
+import pathlib
+import re
+import shlex
+import string
+import subprocess
+import sys
+import tempfile
+from typing import NamedTuple
+
+
+START = "<!-- executive-status:start -->"
+END = "<!-- executive-status:end -->"
+HEALTH_LABELS = {
+    "on-track": "🟢 On track",
+    "at-risk": "🟠 At risk",
+    "blocked": "🔴 Blocked",
+    "parked": "⚪ Parked",
+}
+REQUIRED_FIELDS = (
+    "project",
+    "owner",
+    "updated",
+    "health",
+    "current",
+    "next",
+    "risk",
+)
+FIELD_LIMITS = {
+    "project": 80,
+    "owner": 80,
+    "current": 240,
+    "next": 240,
+    "risk": 240,
+}
+DEFAULT_STALE_AFTER = dt.timedelta(hours=48)
+DEFAULT_MAX_PUBLISH_LENGTH = 3500
+MAX_INPUT_BYTES = 64 * 1024
+PUBLISH_PLACEHOLDERS = frozenset({"body_file", "title"})
+
+
+class Status(NamedTuple):
+    project: str
+    owner: str
+    updated: dt.datetime
+    health: str
+    current: str
+    next_step: str
+    risk: str
+
+
+class SyncConfig(NamedTuple):
+    input_dir: pathlib.Path
+    output: pathlib.Path
+    title: str
+    sentinel: pathlib.Path
+    audit_log: pathlib.Path
+    publish_command: str
+    stale_after: dt.timedelta
+    max_publish_length: int
+    publish_timeout: float
+    expected_owners: set[str]
+
+
+def parse_fields(text: str) -> dict[str, str]:
+    if START not in text or END not in text:
+        raise ValueError("missing executive-status fence")
+    block = text.split(START, 1)[1].split(END, 1)[0]
+    fields: dict[str, str] = {}
+    for raw_line in block.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        if ":" not in line:
+            raise ValueError("invalid field line without a colon")
+        key, value = line.split(":", 1)
+        key = key.strip()
+        value = value.strip()
+        if key in fields:
+            raise ValueError(f"duplicate field: {key}")
+        fields[key] = value
+    return fields
+
+
+def parse_updated(value: str) -> dt.datetime:
+    try:
+        updated = dt.datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise ValueError("updated must be an ISO-8601 timestamp") from exc
+    if updated.tzinfo is None:
+        raise ValueError("updated must include a timezone")
+    return updated
+
+
+def validate_fields(fields: dict[str, str], path: pathlib.Path) -> dt.datetime:
+    for field in REQUIRED_FIELDS:
+        if not fields.get(field):
+            raise ValueError(f"missing required field: {field}")
+    unexpected = sorted(set(fields) - set(REQUIRED_FIELDS))
+    if unexpected:
+        raise ValueError(f"unexpected field(s): {', '.join(unexpected)}")
+    if fields["health"] not in HEALTH_LABELS:
+        raise ValueError("invalid health; use on-track, at-risk, blocked, or parked")
+    for field, limit in FIELD_LIMITS.items():
+        if len(fields[field]) > limit:
+            raise ValueError(f"{field} exceeds {limit} characters")
+    if path.stem != fields["owner"]:
+        raise ValueError("owner must match filename")
+    if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]*", fields["owner"]):
+        raise ValueError("owner contains unsupported characters")
+
+    return parse_updated(fields["updated"])
+
+
+def parse_status(text: str, path: pathlib.Path) -> Status:
+    fields = parse_fields(text)
+    updated = validate_fields(fields, path)
+
+    return Status(
+        project=fields["project"],
+        owner=fields["owner"],
+        updated=updated,
+        health=fields["health"],
+        current=fields["current"],
+        next_step=fields["next"],
+        risk=fields["risk"],
+    )
+
+
+def read_status_input(path: pathlib.Path) -> str:
+    if path.is_symlink():
+        raise ValueError("symbolic links are not allowed")
+    if path.stat().st_size > MAX_INPUT_BYTES:
+        raise ValueError(f"input exceeds {MAX_INPUT_BYTES} bytes")
+    return path.read_text(encoding="utf-8")
+
+
+def load_statuses(input_dir: pathlib.Path) -> tuple[list[Status], list[str]]:
+    if not input_dir.is_dir():
+        return [], [f"{input_dir}: input directory does not exist"]
+    statuses: list[Status] = []
+    errors: list[str] = []
+    seen_owners: set[str] = set()
+    for path in sorted(input_dir.glob("*.md")):
+        try:
+            status = parse_status(read_status_input(path), path)
+            if status.owner in seen_owners:
+                raise ValueError(f"duplicate owner: {status.owner}")
+            seen_owners.add(status.owner)
+            statuses.append(status)
+        except (OSError, ValueError) as exc:
+            errors.append(f"{path.name}: {exc}")
+    return statuses, errors
+
+
+def is_stale(
+    status: Status,
+    now: dt.datetime,
+    stale_after: dt.timedelta = DEFAULT_STALE_AFTER,
+) -> bool:
+    age = now.astimezone(dt.timezone.utc) - status.updated.astimezone(dt.timezone.utc)
+    return age > stale_after
+
+
+def display_health(
+    status: Status,
+    now: dt.datetime,
+    stale_after: dt.timedelta = DEFAULT_STALE_AFTER,
+) -> str:
+    return (
+        "⚪ Stale"
+        if is_stale(status, now, stale_after)
+        else HEALTH_LABELS[status.health]
+    )
+
+
+def markdown_text(value: str) -> str:
+    return html.escape(value, quote=False).replace("\n", " ")
+
+
+def markdown_cell(value: str) -> str:
+    return markdown_text(value).replace("|", "\\|")
+
+
+def stable_generated_at(statuses: list[Status]) -> str:
+    return max(status.updated for status in statuses).isoformat(timespec="minutes")
+
+
+def risks_to_watch(
+    statuses: list[Status],
+    now: dt.datetime,
+    stale_after: dt.timedelta,
+    *,
+    include_stale: bool,
+) -> list[Status]:
+    return [
+        status
+        for status in statuses
+        if status.risk.casefold() != "none"
+        and (
+            status.health in {"at-risk", "blocked"}
+            or (include_stale and is_stale(status, now, stale_after))
+        )
+        and (include_stale or not is_stale(status, now, stale_after))
+    ]
+
+
+def brief_coverage_lines(
+    reporting: int, missing: set[str], errors: list[str]
+) -> list[str]:
+    lines = [
+        "",
+        "## Reporting coverage",
+        "",
+        f"- {reporting} portfolio owners reporting.",
+    ]
+    if missing:
+        lines.append("- Awaiting first update: " + ", ".join(sorted(missing)) + ".")
+    if errors:
+        lines.append(f"- {len(errors)} malformed input(s); see the sync audit log.")
+    return lines
+
+
+def render_brief(
+    statuses: list[Status],
+    now: dt.datetime,
+    *,
+    title: str,
+    missing: set[str] | None = None,
+    errors: list[str] | None = None,
+    stale_after: dt.timedelta = DEFAULT_STALE_AFTER,
+) -> str:
+    missing = missing or set()
+    errors = errors or []
+    ordered = sorted(statuses, key=lambda item: item.project.casefold())
+    lines = [
+        "---",
+        "tags: [executive-brief]",
+        f"updated: {stable_generated_at(ordered)}",
+        "---",
+        "",
+        f"# {markdown_text(title)}",
+        "",
+        "> One portfolio view of current focus, planned work, and material risk.",
+        "",
+        "## Portfolio",
+        "",
+        "| Project | Health | Current focus | Next |",
+        "| --- | --- | --- | --- |",
+    ]
+    for status in ordered:
+        lines.append(
+            f"| {markdown_cell(status.project)} | "
+            f"{display_health(status, now, stale_after)} | "
+            f"{markdown_cell(status.current)} | "
+            f"{markdown_cell(status.next_step)} |"
+        )
+
+    risks = risks_to_watch(ordered, now, stale_after, include_stale=True)
+    lines.extend(["", "## Risks to watch", ""])
+    if risks:
+        lines.extend(
+            f"- **{markdown_text(status.project)}:** {markdown_text(status.risk)}"
+            for status in risks
+        )
+    else:
+        lines.append("- No material risks reported.")
+
+    lines.extend(brief_coverage_lines(len(ordered), missing, errors))
+    lines.append("")
+    return "\n".join(lines)
+
+
+def shorten(value: str, limit: int) -> str:
+    return value if len(value) <= limit else value[: limit - 1].rstrip() + "…"
+
+
+def health_counts(
+    statuses: list[Status], now: dt.datetime, stale_after: dt.timedelta
+) -> dict[str, int]:
+    return {
+        health: sum(
+            not is_stale(status, now, stale_after) and status.health == health
+            for status in statuses
+        )
+        for health in HEALTH_LABELS
+    }
+
+
+def summary_coverage_lines(missing: set[str], errors: list[str]) -> list[str]:
+    if not missing and not errors:
+        return []
+    lines = ["", "Reporting coverage:"]
+    if missing:
+        lines.append(f"- {len(missing)} owner(s) have not reported.")
+    if errors:
+        lines.append(f"- {len(errors)} input(s) failed validation.")
+    return lines
+
+
+def render_publish_summary(
+    statuses: list[Status],
+    now: dt.datetime,
+    *,
+    title: str,
+    missing: set[str] | None = None,
+    errors: list[str] | None = None,
+    stale_after: dt.timedelta = DEFAULT_STALE_AFTER,
+    max_length: int = DEFAULT_MAX_PUBLISH_LENGTH,
+) -> str:
+    missing = missing or set()
+    errors = errors or []
+    ordered = sorted(statuses, key=lambda item: item.project.casefold())
+    counts = health_counts(ordered, now, stale_after)
+    stale_count = sum(is_stale(status, now, stale_after) for status in ordered)
+    noun = "project" if len(ordered) == 1 else "projects"
+    lines = [
+        f"# {markdown_text(title)}",
+        "",
+        f"{len(ordered)} {noun} reporting: {counts['on-track']} on track, "
+        f"{counts['at-risk']} at risk, {counts['blocked']} blocked, "
+        f"{counts['parked']} parked, {stale_count} stale.",
+        "",
+    ]
+    for status in ordered:
+        icon = display_health(status, now, stale_after).split()[0]
+        lines.append(
+            f"- {icon} **{markdown_text(status.project)}** — "
+            f"{markdown_text(shorten(status.current, 100))}"
+        )
+    risks = risks_to_watch(ordered, now, stale_after, include_stale=False)
+    if risks:
+        lines.extend(["", "Risks to watch:"])
+        lines.extend(
+            f"- **{markdown_text(status.project)}** — "
+            f"{markdown_text(shorten(status.risk, 140))}"
+            for status in risks[:4]
+        )
+    lines.extend(summary_coverage_lines(missing, errors))
+    body = "\n".join(lines)
+    return body if len(body) <= max_length else body[: max_length - 1].rstrip() + "…"
+
+
+def write_if_changed(path: pathlib.Path, content: str) -> bool:
+    try:
+        if path.read_text(encoding="utf-8") == content:
+            return False
+    except FileNotFoundError:
+        pass
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        "w",
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        delete=False,
+        encoding="utf-8",
+    ) as handle:
+        handle.write(content)
+        temporary = pathlib.Path(handle.name)
+    temporary.replace(path)
+    return True
+
+
+def build_publish_command(
+    template: str, *, body_file: pathlib.Path, title: str
+) -> list[str]:
+    formatter = string.Formatter()
+    fields = {
+        field_name for _, field_name, _, _ in formatter.parse(template) if field_name
+    }
+    unsupported = fields - PUBLISH_PLACEHOLDERS
+    if unsupported:
+        names = ", ".join(sorted(unsupported))
+        raise ValueError(f"unsupported publish placeholder(s): {names}")
+    if "body_file" not in fields:
+        raise ValueError("publish command requires {body_file}")
+    values = {"body_file": str(body_file), "title": title}
+    return [token.format_map(values) for token in shlex.split(template)]
+
+
+def publish_summary(template: str, body: str, *, title: str, timeout: float) -> None:
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".md", delete=False, encoding="utf-8"
+    ) as handle:
+        handle.write(body)
+        body_path = pathlib.Path(handle.name)
+    try:
+        command = build_publish_command(template, body_file=body_path, title=title)
+        subprocess.run(command, timeout=timeout, check=True)
+    finally:
+        body_path.unlink(missing_ok=True)
+
+
+def expected_owners(raw: str) -> set[str]:
+    return {owner.strip() for owner in raw.split(",") if owner.strip()}
+
+
+def log(path: pathlib.Path, message: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    timestamp = dt.datetime.now().astimezone().isoformat(timespec="seconds")
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(f"{timestamp} {message}\n")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--no-publish", action="store_true")
+    return parser.parse_args()
+
+
+def load_config() -> SyncConfig:
+    input_dir = pathlib.Path(
+        os.environ.get("EXECUTIVE_STATUS_INPUT_DIR", "executive-status/inputs")
+    )
+    output = pathlib.Path(
+        os.environ.get("EXECUTIVE_STATUS_OUTPUT", "executive-status/Executive Brief.md")
+    )
+    title = os.environ.get("EXECUTIVE_STATUS_TITLE", "Executive Status Brief").strip()
+    if not title or len(title) > 120 or "\n" in title or "\r" in title:
+        raise ValueError("EXECUTIVE_STATUS_TITLE must be one line of 1-120 characters")
+    sentinel = pathlib.Path(
+        os.environ.get(
+            "EXECUTIVE_STATUS_SENTINEL", str(output.with_suffix(".summary.sha256"))
+        )
+    )
+    audit_log = pathlib.Path(
+        os.environ.get("EXECUTIVE_STATUS_LOG", str(output.with_suffix(".sync.log")))
+    )
+    publish_command = os.environ.get("EXECUTIVE_STATUS_PUBLISH_COMMAND", "")
+    stale_after = dt.timedelta(
+        hours=int(os.environ.get("EXECUTIVE_STATUS_STALE_HOURS", "48"))
+    )
+    max_length = int(
+        os.environ.get(
+            "EXECUTIVE_STATUS_MAX_PUBLISH_LENGTH",
+            str(DEFAULT_MAX_PUBLISH_LENGTH),
+        )
+    )
+    publish_timeout = float(os.environ.get("EXECUTIVE_STATUS_PUBLISH_TIMEOUT", "90"))
+    if stale_after <= dt.timedelta(0):
+        raise ValueError("EXECUTIVE_STATUS_STALE_HOURS must be positive")
+    if max_length < 200:
+        raise ValueError("EXECUTIVE_STATUS_MAX_PUBLISH_LENGTH must be at least 200")
+    if publish_timeout <= 0:
+        raise ValueError("EXECUTIVE_STATUS_PUBLISH_TIMEOUT must be positive")
+    return SyncConfig(
+        input_dir=input_dir,
+        output=output,
+        title=title,
+        sentinel=sentinel,
+        audit_log=audit_log,
+        publish_command=publish_command,
+        stale_after=stale_after,
+        max_publish_length=max_length,
+        publish_timeout=publish_timeout,
+        expected_owners=expected_owners(
+            os.environ.get("EXECUTIVE_STATUS_EXPECTED_OWNERS", "")
+        ),
+    )
+
+
+def publish_if_changed(config: SyncConfig, summary: str, *, disabled: bool) -> bool:
+    digest = hashlib.sha256(summary.encode("utf-8")).hexdigest()
+    try:
+        previous_digest = config.sentinel.read_text(encoding="utf-8").strip()
+    except FileNotFoundError:
+        previous_digest = ""
+    if disabled or not config.publish_command or digest == previous_digest:
+        return False
+    publish_summary(
+        config.publish_command,
+        summary,
+        title=config.title,
+        timeout=config.publish_timeout,
+    )
+    write_if_changed(config.sentinel, digest)
+    return True
+
+
+def run_sync(args: argparse.Namespace, config: SyncConfig) -> int:
+    statuses, errors = load_statuses(config.input_dir)
+    for error in errors:
+        print(f"ERROR: {error}", file=sys.stderr)
+        log(config.audit_log, f"input_error={error}")
+    if not statuses:
+        raise ValueError("no valid executive status inputs; preserving existing brief")
+    missing = config.expected_owners - {status.owner for status in statuses}
+    now = dt.datetime.now().astimezone()
+    brief = render_brief(
+        statuses,
+        now,
+        title=config.title,
+        missing=missing,
+        errors=errors,
+        stale_after=config.stale_after,
+    )
+    summary = render_publish_summary(
+        statuses,
+        now,
+        title=config.title,
+        missing=missing,
+        errors=errors,
+        stale_after=config.stale_after,
+        max_length=config.max_publish_length,
+    )
+    if args.dry_run:
+        print(brief)
+        print("\n--- Publish preview ---\n")
+        print(summary)
+        return 1 if errors else 0
+
+    changed = write_if_changed(config.output, brief)
+    published = publish_if_changed(config, summary, disabled=args.no_publish)
+    event = (
+        f"reporting={len(statuses)} missing={len(missing)} errors={len(errors)} "
+        f"brief_changed={str(changed).lower()} published={str(published).lower()}"
+    )
+    log(config.audit_log, event)
+    print(event)
+    return 1 if errors else 0
+
+
+def main() -> int:
+    args = parse_args()
+
+    try:
+        return run_sync(args, load_config())
+    except (OSError, ValueError, subprocess.SubprocessError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/oversight-rig/skills/city-executive-status/scripts/request_status_updates.py
+++ b/oversight-rig/skills/city-executive-status/scripts/request_status_updates.py
@@ -28,11 +28,12 @@ def build_message(agent: str, input_dir: pathlib.Path) -> str:
         "updated: ISO-8601 with timezone; "
         "health: on-track|at-risk|blocked|parked; "
         "current: current outcome or focus; next: next planned outcome; "
-        "risk: one material risk or none. Include frontmatter tag "
-        "executive-status-input. Each content field must be at most 240 "
-        "characters. Use CEO-level plain language: omit internal IDs, session "
-        "names, branches, paths, formula names, queue counts, and operational "
-        "incident detail. Write atomically and replace only your own file."
+        "risk: one material risk or none. Project and owner must be at most 80 "
+        "characters. Current, next, and risk must be at most 240 characters. "
+        "The executive-status-input frontmatter tag is recommended. Use "
+        "CEO-level plain language: omit internal IDs, session names, branches, "
+        "paths, formula names, queue counts, and operational incident detail. "
+        "Write atomically and replace only your own file."
     )
 
 

--- a/oversight-rig/skills/city-executive-status/scripts/request_status_updates.py
+++ b/oversight-rig/skills/city-executive-status/scripts/request_status_updates.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Request one structured executive-status input from each configured owner."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import pathlib
+import re
+import shlex
+import string
+import subprocess
+import sys
+
+
+SUBJECT = "DIRECTIVE: EXECUTIVE_STATUS"
+SUPPORTED_PLACEHOLDERS = frozenset({"agent", "subject", "message"})
+
+
+def build_message(agent: str, input_dir: pathlib.Path) -> str:
+    output = input_dir / f"{agent}.md"
+    return (
+        f"DIRECTIVE: EXECUTIVE_STATUS — update {output} now. "
+        "Write one block fenced by '<!-- executive-status:start -->' and "
+        "'<!-- executive-status:end -->' with exactly these one-line fields: "
+        "project: plain project name; "
+        f"owner: {agent}; "
+        "updated: ISO-8601 with timezone; "
+        "health: on-track|at-risk|blocked|parked; "
+        "current: current outcome or focus; next: next planned outcome; "
+        "risk: one material risk or none. Include frontmatter tag "
+        "executive-status-input. Each content field must be at most 240 "
+        "characters. Use CEO-level plain language: omit internal IDs, session "
+        "names, branches, paths, formula names, queue counts, and operational "
+        "incident detail. Write atomically and replace only your own file."
+    )
+
+
+def discover_agents(agents_dir: pathlib.Path) -> list[str]:
+    if not agents_dir.is_dir():
+        raise ValueError(f"agents directory does not exist: {agents_dir}")
+    return sorted(path.parent.name for path in agents_dir.glob("*-pl/agent.toml"))
+
+
+def build_dispatch_command(
+    template: str,
+    *,
+    agent: str,
+    subject: str,
+    message: str,
+) -> list[str]:
+    formatter = string.Formatter()
+    fields = {
+        field_name for _, field_name, _, _ in formatter.parse(template) if field_name
+    }
+    unsupported = fields - SUPPORTED_PLACEHOLDERS
+    if unsupported:
+        names = ", ".join(sorted(unsupported))
+        raise ValueError(f"unsupported placeholder(s): {names}")
+    if "message" not in fields or "agent" not in fields:
+        raise ValueError("dispatch command requires {agent} and {message}")
+    values = {"agent": agent, "subject": subject, "message": message}
+    return [token.format_map(values) for token in shlex.split(template)]
+
+
+def configured_agents(
+    explicit: list[str], agents_dir: pathlib.Path | None
+) -> list[str]:
+    discovered = discover_agents(agents_dir) if agents_dir else []
+    agents = sorted(set(explicit + discovered))
+    if not agents:
+        raise ValueError("no status owners configured")
+    invalid = [
+        agent
+        for agent in agents
+        if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]*", agent)
+    ]
+    if invalid:
+        raise ValueError(f"invalid agent name(s): {', '.join(invalid)}")
+    return agents
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--agent",
+        action="append",
+        default=[],
+        help="status owner to request; repeat for multiple owners",
+    )
+    parser.add_argument(
+        "--agents-dir",
+        type=pathlib.Path,
+        default=(
+            pathlib.Path(os.environ["EXECUTIVE_STATUS_AGENTS_DIR"])
+            if os.environ.get("EXECUTIVE_STATUS_AGENTS_DIR")
+            else None
+        ),
+        help="discover owners from *-pl/agent.toml directories",
+    )
+    parser.add_argument(
+        "--input-dir",
+        type=pathlib.Path,
+        default=pathlib.Path(
+            os.environ.get(
+                "EXECUTIVE_STATUS_INPUT_DIR",
+                "executive-status/inputs",
+            )
+        ),
+    )
+    parser.add_argument(
+        "--dispatch-command",
+        default=os.environ.get("EXECUTIVE_STATUS_DISPATCH_COMMAND", ""),
+        help="shell-free command template using {agent}, {subject}, and {message}",
+    )
+    parser.add_argument(
+        "--subject",
+        default=os.environ.get("EXECUTIVE_STATUS_SUBJECT", SUBJECT),
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=float(os.environ.get("EXECUTIVE_STATUS_DISPATCH_TIMEOUT", "30")),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="print each request without invoking the dispatch command",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        agents = configured_agents(args.agent, args.agents_dir)
+        if not args.dry_run and not args.dispatch_command:
+            raise ValueError("set --dispatch-command or use --dry-run")
+
+        sent = 0
+        failures = 0
+        for agent in agents:
+            message = build_message(agent, args.input_dir)
+            if args.dry_run:
+                print(f"[{agent}]\n{message}\n")
+                continue
+            command = build_dispatch_command(
+                args.dispatch_command,
+                agent=agent,
+                subject=args.subject,
+                message=message,
+            )
+            try:
+                subprocess.run(command, timeout=args.timeout, check=True)
+                sent += 1
+            except (OSError, subprocess.SubprocessError) as exc:
+                print(f"ERROR: {agent}: {exc}", file=sys.stderr)
+                failures += 1
+    except (OSError, ValueError, subprocess.SubprocessError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"owners={len(agents)} dispatched={sent} dry_run={str(args.dry_run).lower()}")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/oversight-rig/skills/city-executive-status/tests/test_end_to_end.py
+++ b/oversight-rig/skills/city-executive-status/tests/test_end_to_end.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import datetime as dt
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+SKILL_DIR = pathlib.Path(__file__).parents[1]
+SYNC = SKILL_DIR / "scripts" / "executive_status_sync.py"
+
+
+class ExecutiveStatusEndToEndTest(unittest.TestCase):
+    def test_cli_writes_brief_and_publishes_only_when_summary_changes(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = pathlib.Path(raw)
+            inputs = root / "inputs"
+            inputs.mkdir()
+            timestamp = dt.datetime.now().astimezone().isoformat(timespec="minutes")
+            (inputs / "research-pl.md").write_text(
+                "---\ntags: [executive-status-input]\n---\n"
+                "<!-- executive-status:start -->\n"
+                "project: Research\n"
+                "owner: research-pl\n"
+                f"updated: {timestamp}\n"
+                "health: on-track\n"
+                "current: The evaluation path is producing useful evidence.\n"
+                "next: Complete the larger comparison.\n"
+                "risk: none\n"
+                "<!-- executive-status:end -->\n",
+                encoding="utf-8",
+            )
+            publisher = root / "publisher.py"
+            publisher.write_text(
+                "import pathlib, sys\n"
+                "log = pathlib.Path(sys.argv[1])\n"
+                "body = pathlib.Path(sys.argv[2]).read_text(encoding='utf-8')\n"
+                "with log.open('a', encoding='utf-8') as handle:\n"
+                "    handle.write(body.replace('\\n', ' ') + '\\n')\n",
+                encoding="utf-8",
+            )
+            output = root / "vault" / "Portfolio Brief.md"
+            publish_log = root / "published.log"
+            environment = {
+                **os.environ,
+                "EXECUTIVE_STATUS_INPUT_DIR": str(inputs),
+                "EXECUTIVE_STATUS_OUTPUT": str(output),
+                "EXECUTIVE_STATUS_TITLE": "Portfolio Brief",
+                "EXECUTIVE_STATUS_SENTINEL": str(root / "summary.sha256"),
+                "EXECUTIVE_STATUS_LOG": str(root / "sync.log"),
+                "EXECUTIVE_STATUS_PUBLISH_COMMAND": (
+                    f"{sys.executable} {publisher} {publish_log} {{body_file}}"
+                ),
+            }
+
+            first = subprocess.run(
+                [sys.executable, str(SYNC)],
+                capture_output=True,
+                text=True,
+                env=environment,
+                check=False,
+            )
+            second = subprocess.run(
+                [sys.executable, str(SYNC)],
+                capture_output=True,
+                text=True,
+                env=environment,
+                check=False,
+            )
+
+            self.assertEqual(first.returncode, 0, first.stderr)
+            self.assertEqual(second.returncode, 0, second.stderr)
+            self.assertIn("# Portfolio Brief", output.read_text(encoding="utf-8"))
+            self.assertEqual(len(publish_log.read_text().splitlines()), 1)
+            self.assertIn("published=true", first.stdout)
+            self.assertIn("published=false", second.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/oversight-rig/skills/city-executive-status/tests/test_executive_status_sync.py
+++ b/oversight-rig/skills/city-executive-status/tests/test_executive_status_sync.py
@@ -1,0 +1,445 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import datetime as dt
+import importlib.util
+import io
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+
+SCRIPT = pathlib.Path(__file__).parents[1] / "scripts" / "executive_status_sync.py"
+SPEC = importlib.util.spec_from_file_location("executive_status_sync", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def status_block(
+    *,
+    project: str = "Research",
+    owner: str = "research-pl",
+    updated: str = "2026-08-07T10:00:00-04:00",
+    health: str = "on-track",
+    current: str = "Validating the new evaluation path.",
+    next_step: str = "Run the larger comparison.",
+    risk: str = "none",
+) -> str:
+    return f"""---
+tags: [executive-status-input]
+---
+# {project}
+
+<!-- executive-status:start -->
+project: {project}
+owner: {owner}
+updated: {updated}
+health: {health}
+current: {current}
+next: {next_step}
+risk: {risk}
+<!-- executive-status:end -->
+"""
+
+
+class ParseStatusTest(unittest.TestCase):
+    def test_parses_complete_status_block(self) -> None:
+        status = MODULE.parse_status(status_block(), pathlib.Path("research-pl.md"))
+
+        self.assertEqual(status.project, "Research")
+        self.assertEqual(status.owner, "research-pl")
+        self.assertEqual(status.health, "on-track")
+        self.assertEqual(status.next_step, "Run the larger comparison.")
+
+    def test_rejects_missing_required_field(self) -> None:
+        text = status_block().replace(
+            "current: Validating the new evaluation path.\n", ""
+        )
+
+        with self.assertRaisesRegex(ValueError, "missing required field: current"):
+            MODULE.parse_status(text, pathlib.Path("research-pl.md"))
+
+    def test_rejects_invalid_health_and_oversized_content(self) -> None:
+        invalid_health = status_block().replace("health: on-track", "health: great")
+        with self.assertRaisesRegex(ValueError, "invalid health"):
+            MODULE.parse_status(invalid_health, pathlib.Path("research-pl.md"))
+
+        with self.assertRaisesRegex(ValueError, "current exceeds 240 characters"):
+            MODULE.parse_status(
+                status_block(current="x" * 241), pathlib.Path("research-pl.md")
+            )
+
+    def test_rejects_filename_owner_mismatch(self) -> None:
+        with self.assertRaisesRegex(ValueError, "owner must match filename"):
+            MODULE.parse_status(status_block(), pathlib.Path("different-pl.md"))
+
+    def test_rejects_structural_and_timestamp_errors(self) -> None:
+        cases = (
+            ("no fences", "missing executive-status fence"),
+            (
+                status_block().replace("project: Research", "project Research"),
+                "invalid field line",
+            ),
+            (
+                status_block().replace("risk: none", "risk: none\nrisk: duplicate"),
+                "duplicate field",
+            ),
+            (
+                status_block().replace("risk: none", "risk: none\nextra: value"),
+                "unexpected field",
+            ),
+            (
+                status_block(owner="bad owner"),
+                "owner contains unsupported characters",
+            ),
+            (
+                status_block(updated="not-a-date"),
+                "updated must be an ISO-8601 timestamp",
+            ),
+            (
+                status_block(updated="2026-08-07T10:00:00"),
+                "updated must include a timezone",
+            ),
+        )
+        for text, message in cases:
+            owner = "bad owner" if "bad owner" in text else "research-pl"
+            with (
+                self.subTest(message=message),
+                self.assertRaisesRegex(ValueError, message),
+            ):
+                MODULE.parse_status(text, pathlib.Path(f"{owner}.md"))
+
+    def test_structural_errors_do_not_echo_input_content(self) -> None:
+        with self.assertRaises(ValueError) as raised:
+            MODULE.parse_status(
+                f"{MODULE.START}\nprivate-value-without-colon\n{MODULE.END}",
+                pathlib.Path("research-pl.md"),
+            )
+
+        self.assertNotIn("private-value", str(raised.exception))
+
+
+class RenderBriefTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.now = dt.datetime.fromisoformat("2026-08-07T12:00:00-04:00")
+
+    def test_renders_configurable_brief_and_publish_summary(self) -> None:
+        statuses = [
+            MODULE.parse_status(status_block(), pathlib.Path("research-pl.md")),
+            MODULE.parse_status(
+                status_block(
+                    project="Platform",
+                    owner="platform-pl",
+                    updated="2026-08-07T09:00:00-04:00",
+                    health="blocked",
+                    current="Delivery is paused while capacity is restored.",
+                    next_step="Resume the queued validation work.",
+                    risk="No throughput until capacity returns.",
+                ),
+                pathlib.Path("platform-pl.md"),
+            ),
+        ]
+
+        markdown = MODULE.render_brief(statuses, self.now, title="Portfolio Brief")
+        summary = MODULE.render_publish_summary(
+            statuses, self.now, title="Portfolio Brief"
+        )
+
+        self.assertIn("# Portfolio Brief", markdown)
+        self.assertIn("| Platform | 🔴 Blocked |", markdown)
+        self.assertIn("## Risks to watch", markdown)
+        self.assertNotIn("platform-pl", markdown)
+        self.assertIn("Portfolio Brief", summary)
+        self.assertIn("2 projects reporting", summary)
+        self.assertIn("🔴 **Platform**", summary)
+
+    def test_marks_old_inputs_stale_and_output_is_deterministic(self) -> None:
+        status = MODULE.parse_status(
+            status_block(updated="2026-08-04T10:00:00-04:00"),
+            pathlib.Path("research-pl.md"),
+        )
+
+        first = MODULE.render_brief([status], self.now, title="Portfolio Brief")
+        later = MODULE.render_brief(
+            [status], self.now + dt.timedelta(minutes=20), title="Portfolio Brief"
+        )
+
+        self.assertIn("⚪ Stale", first)
+        self.assertEqual(first, later)
+
+    def test_load_statuses_reports_invalid_inputs_and_duplicate_owners(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = pathlib.Path(raw)
+            (root / "research-pl.md").write_text(status_block(), encoding="utf-8")
+            (root / "invalid.md").write_text("not a status", encoding="utf-8")
+            (root / "copy.md").write_text(status_block(), encoding="utf-8")
+
+            statuses, errors = MODULE.load_statuses(root)
+
+        self.assertEqual(len(statuses), 1)
+        self.assertEqual(len(errors), 2)
+        self.assertTrue(any("invalid.md" in error for error in errors))
+        self.assertTrue(any("copy.md" in error for error in errors))
+
+    def test_load_statuses_reports_missing_directory(self) -> None:
+        statuses, errors = MODULE.load_statuses(pathlib.Path("/definitely/not/present"))
+
+        self.assertEqual(statuses, [])
+        self.assertIn("input directory does not exist", errors[0])
+
+    def test_load_statuses_rejects_symlinks_and_oversized_files(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = pathlib.Path(raw)
+            inputs = root / "inputs"
+            inputs.mkdir()
+            outside = root / "research-pl.md"
+            outside.write_text(status_block(), encoding="utf-8")
+            (inputs / "research-pl.md").symlink_to(outside)
+            (inputs / "large-pl.md").write_text(
+                "x" * (MODULE.MAX_INPUT_BYTES + 1), encoding="utf-8"
+            )
+
+            statuses, errors = MODULE.load_statuses(inputs)
+
+        self.assertEqual(statuses, [])
+        self.assertTrue(
+            any("symbolic links are not allowed" in error for error in errors)
+        )
+        self.assertTrue(any("input exceeds" in error for error in errors))
+
+    def test_render_includes_coverage_warnings_and_truncates_summary(self) -> None:
+        status = MODULE.parse_status(status_block(), pathlib.Path("research-pl.md"))
+
+        markdown = MODULE.render_brief(
+            [status],
+            self.now,
+            title="Portfolio Brief",
+            missing={"platform-pl"},
+            errors=["bad input"],
+        )
+        summary = MODULE.render_publish_summary(
+            [status],
+            self.now,
+            title="Portfolio Brief",
+            missing={"platform-pl"},
+            errors=["bad input"],
+            max_length=80,
+        )
+
+        self.assertIn("Awaiting first update: platform-pl", markdown)
+        self.assertIn("1 malformed input", markdown)
+        self.assertEqual(len(summary), 80)
+        self.assertTrue(summary.endswith("…"))
+
+    def test_render_escapes_raw_html_from_owner_fields(self) -> None:
+        status = MODULE.parse_status(
+            status_block(
+                project="<script>alert(1)</script>",
+                current="Evidence is ready & reviewed.",
+                risk="<img src=x onerror=alert(1)>",
+                health="at-risk",
+            ),
+            pathlib.Path("research-pl.md"),
+        )
+
+        markdown = MODULE.render_brief([status], self.now, title="Portfolio <Status>")
+        summary = MODULE.render_publish_summary(
+            [status], self.now, title="Portfolio <Status>"
+        )
+
+        self.assertNotIn("<script>", markdown)
+        self.assertNotIn("<img", markdown)
+        self.assertNotIn("<script>", summary)
+        self.assertIn("&lt;script&gt;", markdown)
+
+
+class PersistenceAndCommandTest(unittest.TestCase):
+    def test_write_if_changed_is_atomic_and_idempotent(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            path = pathlib.Path(raw) / "nested" / "brief.md"
+
+            first = MODULE.write_if_changed(path, "brief")
+            second = MODULE.write_if_changed(path, "brief")
+
+        self.assertTrue(first)
+        self.assertFalse(second)
+
+    def test_publish_command_validation_and_execution(self) -> None:
+        command = MODULE.build_publish_command(
+            "publisher --title {title} --body {body_file}",
+            body_file=pathlib.Path("/tmp/body.md"),
+            title="Portfolio Brief",
+        )
+        self.assertEqual(
+            command,
+            ["publisher", "--title", "Portfolio Brief", "--body", "/tmp/body.md"],
+        )
+        with self.assertRaisesRegex(ValueError, "unsupported publish placeholder"):
+            MODULE.build_publish_command(
+                "publisher {unsupported}",
+                body_file=pathlib.Path("/tmp/body.md"),
+                title="Portfolio Brief",
+            )
+        with self.assertRaisesRegex(ValueError, "requires"):
+            MODULE.build_publish_command(
+                "publisher {title}",
+                body_file=pathlib.Path("/tmp/body.md"),
+                title="Portfolio Brief",
+            )
+
+        with mock.patch.object(MODULE.subprocess, "run") as run:
+            MODULE.publish_summary(
+                "publisher {body_file}",
+                "summary",
+                title="Portfolio Brief",
+                timeout=12,
+            )
+
+        published_path = pathlib.Path(run.call_args.args[0][1])
+        self.assertFalse(published_path.exists())
+        run.assert_called_once_with(
+            ["publisher", str(published_path)], timeout=12, check=True
+        )
+
+    def test_expected_owners_and_log(self) -> None:
+        self.assertEqual(
+            MODULE.expected_owners("research-pl, platform-pl, research-pl"),
+            {"research-pl", "platform-pl"},
+        )
+        with tempfile.TemporaryDirectory() as raw:
+            path = pathlib.Path(raw) / "nested" / "sync.log"
+            MODULE.log(path, "reporting=2")
+            content = path.read_text(encoding="utf-8")
+
+        self.assertIn("reporting=2", content)
+
+
+class MainIntegrationTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = pathlib.Path(self.temporary.name)
+        self.inputs = self.root / "inputs"
+        self.inputs.mkdir()
+        (self.inputs / "research-pl.md").write_text(status_block(), encoding="utf-8")
+        self.environment = {
+            "EXECUTIVE_STATUS_INPUT_DIR": str(self.inputs),
+            "EXECUTIVE_STATUS_OUTPUT": str(self.root / "vault" / "Brief.md"),
+            "EXECUTIVE_STATUS_TITLE": "Portfolio Brief",
+            "EXECUTIVE_STATUS_EXPECTED_OWNERS": "research-pl,platform-pl",
+            "EXECUTIVE_STATUS_SENTINEL": str(self.root / "summary.sha256"),
+            "EXECUTIVE_STATUS_LOG": str(self.root / "sync.log"),
+        }
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def test_main_dry_run_and_vault_only_run(self) -> None:
+        with (
+            mock.patch.dict(os.environ, self.environment, clear=True),
+            mock.patch.object(sys, "argv", ["executive_status_sync.py", "--dry-run"]),
+            mock.patch("sys.stdout", new_callable=io.StringIO) as stdout,
+        ):
+            dry_result = MODULE.main()
+
+        self.assertEqual(dry_result, 0)
+        self.assertIn("Publish preview", stdout.getvalue())
+        self.assertFalse((self.root / "vault" / "Brief.md").exists())
+
+        with (
+            mock.patch.dict(os.environ, self.environment, clear=True),
+            mock.patch.object(
+                sys, "argv", ["executive_status_sync.py", "--no-publish"]
+            ),
+        ):
+            first = MODULE.main()
+            second = MODULE.main()
+
+        self.assertEqual(first, 0)
+        self.assertEqual(second, 0)
+        self.assertIn(
+            "Awaiting first update: platform-pl",
+            (self.root / "vault" / "Brief.md").read_text(encoding="utf-8"),
+        )
+
+    def test_main_publishes_changed_summary_and_records_sentinel(self) -> None:
+        environment = {
+            **self.environment,
+            "EXECUTIVE_STATUS_PUBLISH_COMMAND": "publisher {body_file}",
+            "EXECUTIVE_STATUS_STALE_HOURS": "72",
+            "EXECUTIVE_STATUS_MAX_PUBLISH_LENGTH": "1000",
+            "EXECUTIVE_STATUS_PUBLISH_TIMEOUT": "15",
+        }
+        with (
+            mock.patch.dict(os.environ, environment, clear=True),
+            mock.patch.object(sys, "argv", ["executive_status_sync.py"]),
+            mock.patch.object(MODULE, "publish_summary") as publish,
+        ):
+            result = MODULE.main()
+
+        self.assertEqual(result, 0)
+        publish.assert_called_once()
+        self.assertTrue((self.root / "summary.sha256").is_file())
+
+    def test_main_fails_closed_without_valid_inputs_and_surfaces_publish_errors(
+        self,
+    ) -> None:
+        empty = self.root / "empty"
+        empty.mkdir()
+        no_inputs = {**self.environment, "EXECUTIVE_STATUS_INPUT_DIR": str(empty)}
+        with (
+            mock.patch.dict(os.environ, no_inputs, clear=True),
+            mock.patch.object(sys, "argv", ["executive_status_sync.py"]),
+            mock.patch("sys.stderr", new_callable=io.StringIO) as stderr,
+        ):
+            no_input_result = MODULE.main()
+
+        self.assertEqual(no_input_result, 1)
+        self.assertIn("preserving existing brief", stderr.getvalue())
+
+        publish_environment = {
+            **self.environment,
+            "EXECUTIVE_STATUS_PUBLISH_COMMAND": "publisher {body_file}",
+        }
+        with (
+            mock.patch.dict(os.environ, publish_environment, clear=True),
+            mock.patch.object(sys, "argv", ["executive_status_sync.py"]),
+            mock.patch.object(
+                MODULE,
+                "publish_summary",
+                side_effect=subprocess.CalledProcessError(2, ["publisher"]),
+            ),
+            mock.patch("sys.stderr", new_callable=io.StringIO) as stderr,
+        ):
+            publish_result = MODULE.main()
+
+        self.assertEqual(publish_result, 1)
+        self.assertIn("returned non-zero exit status", stderr.getvalue())
+
+    def test_main_names_malformed_inputs_in_stderr_and_audit_log(self) -> None:
+        (self.inputs / "broken.md").write_text("not a status", encoding="utf-8")
+        with (
+            mock.patch.dict(os.environ, self.environment, clear=True),
+            mock.patch.object(
+                sys, "argv", ["executive_status_sync.py", "--no-publish"]
+            ),
+            mock.patch("sys.stderr", new_callable=io.StringIO) as stderr,
+        ):
+            result = MODULE.main()
+
+        self.assertEqual(result, 1)
+        self.assertIn("broken.md", stderr.getvalue())
+        self.assertIn(
+            "broken.md",
+            pathlib.Path(self.environment["EXECUTIVE_STATUS_LOG"]).read_text(
+                encoding="utf-8"
+            ),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/oversight-rig/skills/city-executive-status/tests/test_request_status_updates.py
+++ b/oversight-rig/skills/city-executive-status/tests/test_request_status_updates.py
@@ -27,6 +27,12 @@ class RequestStatusUpdatesTest(unittest.TestCase):
         self.assertIn("<!-- executive-status:start -->", message)
         self.assertIn("health: on-track|at-risk|blocked|parked", message)
         self.assertIn("owner: research-pl", message)
+        self.assertIn("Project and owner must be at most 80 characters", message)
+        self.assertIn("Current, next, and risk must be at most 240 characters", message)
+        self.assertIn(
+            "The executive-status-input frontmatter tag is recommended", message
+        )
+        self.assertNotIn("Each content field must be at most 240 characters", message)
         self.assertIn("CEO-level plain language", message)
 
     def test_discover_agents_uses_agent_directories_and_sorts_names(self) -> None:

--- a/oversight-rig/skills/city-executive-status/tests/test_request_status_updates.py
+++ b/oversight-rig/skills/city-executive-status/tests/test_request_status_updates.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import io
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+
+SCRIPT = pathlib.Path(__file__).parents[1] / "scripts" / "request_status_updates.py"
+SPEC = importlib.util.spec_from_file_location("request_status_updates", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class RequestStatusUpdatesTest(unittest.TestCase):
+    def test_build_message_carries_portable_schema_and_owner_path(self) -> None:
+        message = MODULE.build_message("research-pl", pathlib.Path("/vault/inputs"))
+
+        self.assertIn("/vault/inputs/research-pl.md", message)
+        self.assertIn("<!-- executive-status:start -->", message)
+        self.assertIn("health: on-track|at-risk|blocked|parked", message)
+        self.assertIn("owner: research-pl", message)
+        self.assertIn("CEO-level plain language", message)
+
+    def test_discover_agents_uses_agent_directories_and_sorts_names(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = pathlib.Path(raw)
+            for name in ("zeta-pl", "alpha-pl", "not-a-lead"):
+                directory = root / name
+                directory.mkdir()
+                (directory / "agent.toml").write_text("", encoding="utf-8")
+
+            agents = MODULE.discover_agents(root)
+
+        self.assertEqual(agents, ["alpha-pl", "zeta-pl"])
+
+    def test_discover_agents_rejects_missing_directory(self) -> None:
+        with self.assertRaisesRegex(ValueError, "agents directory does not exist"):
+            MODULE.discover_agents(pathlib.Path("/definitely/not/present"))
+
+    def test_build_dispatch_command_preserves_message_as_one_argument(self) -> None:
+        command = MODULE.build_dispatch_command(
+            "sender --to {agent} --subject {subject} --message {message}",
+            agent="research-pl",
+            subject="Executive update",
+            message="words with spaces and $shell syntax",
+        )
+
+        self.assertEqual(
+            command,
+            [
+                "sender",
+                "--to",
+                "research-pl",
+                "--subject",
+                "Executive update",
+                "--message",
+                "words with spaces and $shell syntax",
+            ],
+        )
+
+    def test_build_dispatch_command_rejects_unknown_placeholders(self) -> None:
+        with self.assertRaisesRegex(ValueError, "unsupported placeholder"):
+            MODULE.build_dispatch_command(
+                "sender {agent} {unknown}",
+                agent="research-pl",
+                subject="Executive update",
+                message="message",
+            )
+
+    def test_build_dispatch_command_requires_agent_and_message(self) -> None:
+        with self.assertRaisesRegex(ValueError, "requires"):
+            MODULE.build_dispatch_command(
+                "sender {subject}",
+                agent="research-pl",
+                subject="Executive update",
+                message="message",
+            )
+
+    def test_configured_agents_merges_explicit_and_discovered_owners(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = pathlib.Path(raw)
+            (root / "research-pl").mkdir()
+            (root / "research-pl" / "agent.toml").write_text("", encoding="utf-8")
+
+            agents = MODULE.configured_agents(["mayor", "research-pl"], root)
+
+        self.assertEqual(agents, ["mayor", "research-pl"])
+
+    def test_configured_agents_rejects_empty_and_path_like_names(self) -> None:
+        with self.assertRaisesRegex(ValueError, "no status owners"):
+            MODULE.configured_agents([], None)
+        with self.assertRaisesRegex(ValueError, "invalid agent"):
+            MODULE.configured_agents(["../owner"], None)
+        with self.assertRaisesRegex(ValueError, "invalid agent"):
+            MODULE.configured_agents(["bad owner"], None)
+
+    def test_main_supports_dry_run_and_shell_free_dispatch(self) -> None:
+        with (
+            mock.patch.dict(os.environ, {}, clear=True),
+            mock.patch.object(
+                sys,
+                "argv",
+                ["request_status_updates.py", "--agent", "research-pl", "--dry-run"],
+            ),
+            mock.patch("sys.stdout", new_callable=io.StringIO) as stdout,
+        ):
+            dry_result = MODULE.main()
+
+        self.assertEqual(dry_result, 0)
+        self.assertIn("owner: research-pl", stdout.getvalue())
+        self.assertIn("dispatched=0", stdout.getvalue())
+
+        with (
+            mock.patch.dict(os.environ, {}, clear=True),
+            mock.patch.object(
+                sys,
+                "argv",
+                [
+                    "request_status_updates.py",
+                    "--agent",
+                    "research-pl",
+                    "--dispatch-command",
+                    "sender {agent} {message}",
+                ],
+            ),
+            mock.patch.object(MODULE.subprocess, "run") as run,
+        ):
+            dispatch_result = MODULE.main()
+
+        self.assertEqual(dispatch_result, 0)
+        command = run.call_args.args[0]
+        self.assertEqual(command[0:2], ["sender", "research-pl"])
+        self.assertIn("owner: research-pl", command[2])
+        run.assert_called_once_with(command, timeout=30.0, check=True)
+
+    def test_main_reports_configuration_and_dispatch_errors(self) -> None:
+        with (
+            mock.patch.dict(os.environ, {}, clear=True),
+            mock.patch.object(
+                sys, "argv", ["request_status_updates.py", "--agent", "research-pl"]
+            ),
+            mock.patch("sys.stderr", new_callable=io.StringIO) as stderr,
+        ):
+            missing_command = MODULE.main()
+
+        self.assertEqual(missing_command, 1)
+        self.assertIn("set --dispatch-command", stderr.getvalue())
+
+        with (
+            mock.patch.dict(os.environ, {}, clear=True),
+            mock.patch.object(
+                sys,
+                "argv",
+                [
+                    "request_status_updates.py",
+                    "--agent",
+                    "research-pl",
+                    "--dispatch-command",
+                    "sender {agent} {message}",
+                ],
+            ),
+            mock.patch.object(
+                MODULE.subprocess,
+                "run",
+                side_effect=subprocess.CalledProcessError(2, ["sender"]),
+            ),
+            mock.patch("sys.stderr", new_callable=io.StringIO) as stderr,
+        ):
+            failed_dispatch = MODULE.main()
+
+        self.assertEqual(failed_dispatch, 1)
+        self.assertIn("returned non-zero exit status", stderr.getvalue())
+
+    def test_main_continues_after_one_owner_dispatch_fails(self) -> None:
+        with (
+            mock.patch.dict(os.environ, {}, clear=True),
+            mock.patch.object(
+                sys,
+                "argv",
+                [
+                    "request_status_updates.py",
+                    "--agent",
+                    "alpha-pl",
+                    "--agent",
+                    "zeta-pl",
+                    "--dispatch-command",
+                    "sender {agent} {message}",
+                ],
+            ),
+            mock.patch.object(
+                MODULE.subprocess,
+                "run",
+                side_effect=[subprocess.CalledProcessError(2, ["sender"]), None],
+            ) as run,
+            mock.patch("sys.stderr", new_callable=io.StringIO) as stderr,
+        ):
+            result = MODULE.main()
+
+        self.assertEqual(result, 1)
+        self.assertEqual(run.call_count, 2)
+        self.assertIn("alpha-pl", stderr.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/oversight-rig/skills/city-executive-status/tests/test_skill_package.py
+++ b/oversight-rig/skills/city-executive-status/tests/test_skill_package.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import pathlib
+import re
+import unittest
+
+
+SKILL_DIR = pathlib.Path(__file__).parents[1]
+REQUIRED_RESOURCES = (
+    "SKILL.md",
+    "agents/openai.yaml",
+    "assets/executive-status.env.example",
+    "assets/status-input-template.md",
+    "assets/orders/request-status-updates.toml",
+    "assets/orders/sync-status-brief.toml",
+    "references/configuration.md",
+    "scripts/request_status_updates.py",
+    "scripts/executive_status_sync.py",
+)
+
+
+class SkillPackageTest(unittest.TestCase):
+    def test_contains_complete_shareable_package(self) -> None:
+        missing = [
+            name for name in REQUIRED_RESOURCES if not (SKILL_DIR / name).is_file()
+        ]
+
+        self.assertEqual(missing, [])
+
+    def test_contains_no_local_identity_or_secret_placeholders(self) -> None:
+        forbidden = (
+            re.compile("/" + "home/" + r"[^/\s]+/"),
+            re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}"),
+            re.compile(r"\bC[A-Z0-9]{10}\b"),
+        )
+        offenders: list[str] = []
+        for path in SKILL_DIR.rglob("*"):
+            if (
+                not path.is_file()
+                or "__pycache__" in path.parts
+                or path == pathlib.Path(__file__)
+            ):
+                continue
+            text = path.read_text(encoding="utf-8")
+            if any(pattern.search(text) for pattern in forbidden):
+                offenders.append(str(path.relative_to(SKILL_DIR)))
+
+        self.assertEqual(offenders, [])
+
+    def test_order_examples_do_not_assume_a_provider_skill_directory(self) -> None:
+        for name in (
+            "assets/orders/request-status-updates.toml",
+            "assets/orders/sync-status-brief.toml",
+        ):
+            text = (SKILL_DIR / name).read_text(encoding="utf-8")
+            self.assertNotIn(".claude/skills", text)
+            self.assertNotIn(".agents/skills", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/oversight-rig/tests/test_optional_executive_status_skill.py
+++ b/oversight-rig/tests/test_optional_executive_status_skill.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+PACK_ROOT = Path(__file__).resolve().parents[1]
+SKILL_ROOT = PACK_ROOT / "skills" / "city-executive-status"
+
+EXPECTED_SKILL_FILES = {
+    "SKILL.md",
+    "agents/openai.yaml",
+    "assets/executive-status.env.example",
+    "assets/orders/request-status-updates.toml",
+    "assets/orders/sync-status-brief.toml",
+    "assets/status-input-template.md",
+    "references/configuration.md",
+    "scripts/executive_status_sync.py",
+    "scripts/request_status_updates.py",
+    "tests/test_end_to_end.py",
+    "tests/test_executive_status_sync.py",
+    "tests/test_request_status_updates.py",
+    "tests/test_skill_package.py",
+}
+MACHINE_HOME_PREFIX = "/".join(("", "home", ""))
+
+
+def test_pack_ships_complete_executive_status_skill() -> None:
+    packaged_files = {
+        path.relative_to(SKILL_ROOT).as_posix()
+        for path in SKILL_ROOT.rglob("*")
+        if path.is_file() and "__pycache__" not in path.parts
+    }
+
+    assert packaged_files == EXPECTED_SKILL_FILES
+
+
+def test_executive_status_examples_are_not_active_pack_orders() -> None:
+    active_orders = {path.name for path in (PACK_ROOT / "orders").glob("*.toml")}
+
+    assert active_orders == {
+        "escalate-rollups.toml",
+        "patrol-project-leads.toml",
+    }
+    assert (SKILL_ROOT / "assets/orders/request-status-updates.toml").is_file()
+    assert (SKILL_ROOT / "assets/orders/sync-status-brief.toml").is_file()
+
+
+def test_packaged_skill_contains_no_machine_specific_home_paths() -> None:
+    offending_files = []
+    for path in SKILL_ROOT.rglob("*"):
+        if (
+            path.is_file()
+            and "__pycache__" not in path.parts
+            and MACHINE_HOME_PREFIX in path.read_text(encoding="utf-8")
+        ):
+            offending_files.append(path.relative_to(SKILL_ROOT).as_posix())
+
+    assert offending_files == []


### PR DESCRIPTION
## Summary

- package an optional city-executive-status skill inside oversight-rig
- request structured project-owner updates and aggregate them into an Obsidian-compatible portfolio brief
- keep semantic health judgments with project owners while scripts handle validation, atomic writes, and optional hash-deduplicated publishing
- keep the example schedules inert until a consuming city explicitly configures them
- document pack and standalone sharing paths

## Safety

- rejects malformed, oversized, and symlinked status inputs
- escapes owner-provided HTML before rendering
- executes dispatch and publishing adapters without a shell
- preserves the existing brief when no valid inputs are available
- contains no machine-specific paths, personal identifiers, or credentials

## Test plan

- GC_TEST_BIN=/path/to/gc PYTHONDONTWRITEBYTECODE=1 pytest -q oversight-rig/tests oversight-rig/assets/scripts/test_resolve_rig_channel.py
- PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s oversight-rig/skills/city-executive-status/tests -q
- coverage report for both scripts: 96 percent total
- ruff format --check and ruff check
- skill-creator quick_validate.py
- gitleaks scan of upstream/main..HEAD
