### PR TITLE
fix(gascity): assert work-item dependency orientation at decomposition time

### DIFF
--- a/gascity/assets/scripts/checks/build-artifact-valid.sh
+++ b/gascity/assets/scripts/checks/build-artifact-valid.sh
@@ -97,11 +97,34 @@ for candidate in \
 done
 [ -n "$VALIDATOR" ] || fail "validate_build_artifact.py not found beside $SCRIPT_DIR or under GC_WORK_DIR"
 
-if OUTPUT="$(python3 "$VALIDATOR" --schema "$SCHEMA" --path "$ARTIFACT_PATH" 2>&1)"; then
-  echo "build artifact valid: schema=$SCHEMA path=$ARTIFACT_PATH"
-  exit 0
+if ! OUTPUT="$(python3 "$VALIDATOR" --schema "$SCHEMA" --path "$ARTIFACT_PATH" 2>&1)"; then
+  echo "build-artifact-check: schema=$SCHEMA path=$ARTIFACT_PATH failed validation" >&2
+  printf '%s\n' "$OUTPUT" >&2
+  exit 1
 fi
 
-echo "build-artifact-check: schema=$SCHEMA path=$ARTIFACT_PATH failed validation" >&2
-printf '%s\n' "$OUTPUT" >&2
-exit 1
+# Decomposition artifacts additionally bind live bead edges to the declared
+# work-item order: a sequential chain wired backwards drains back-to-front, so
+# assert edge orientation at creation time rather than at drain time.
+if [ "$SCHEMA" = "gc.build.decomposition.v1" ]; then
+  EDGE_CHECK=""
+  for candidate in \
+    ${GC_WORK_DIR:+"$GC_WORK_DIR/gascity/assets/scripts/validate_decomposition_edges.py"} \
+    "$(dirname "$VALIDATOR")/validate_decomposition_edges.py"; do
+    if [ -n "$candidate" ] && [ -f "$candidate" ]; then
+      EDGE_CHECK="$candidate"
+      break
+    fi
+  done
+  [ -n "$EDGE_CHECK" ] || fail "validate_decomposition_edges.py not found beside $VALIDATOR or under GC_WORK_DIR"
+  if EDGE_OUTPUT="$(python3 "$EDGE_CHECK" --path "$ARTIFACT_PATH" 2>&1)"; then
+    [ -n "$EDGE_OUTPUT" ] && printf '%s\n' "$EDGE_OUTPUT"
+  else
+    echo "build-artifact-check: schema=$SCHEMA path=$ARTIFACT_PATH failed dependency-orientation check" >&2
+    printf '%s\n' "$EDGE_OUTPUT" >&2
+    exit 1
+  fi
+fi
+
+echo "build artifact valid: schema=$SCHEMA path=$ARTIFACT_PATH"
+exit 0

--- a/gascity/assets/scripts/validate_decomposition_edges.py
+++ b/gascity/assets/scripts/validate_decomposition_edges.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""Verify decomposition work-item dependency edge orientation.
+
+A decomposition artifact (gc.build.decomposition.v1) that declares its work
+items in a machine-readable dependency table binds the live bead graph to that
+declaration: each work item's bead must depend on the beads of the work items
+it declares under Depends On, and no earlier work item's bead may depend on a
+later one's. This is the creation-time orientation assert for the recurring
+failure where a sequential chain is wired backwards (`gc bd dep add` read
+temporally, "1 before 2", instead of as "dependent needs prerequisite") and
+the convoy drains the chain back-to-front.
+
+The dependency table lives in the artifact body (conventionally under the
+Work Items section) and is any Markdown table whose header row includes ID,
+Bead, and Depends On columns:
+
+| ID | Bead | Depends On |
+| --- | --- | --- |
+| WI-1 | gc-aaa111 | - |
+| WI-2 | gc-bbb222 | WI-1 |
+
+Rows are the intended execution order, so every Depends On entry must
+reference an earlier row (comma-separated for several, `-` or empty for
+none). The table must not carry a Status column: the build-artifact validator
+reads any ID/Status table as the coverage matrix.
+
+Artifacts with no dependency table skip live verification (methodology packs
+that produce the same schema without bead-level tables stay valid); declaring
+the table opts the artifact into strict orientation checking.
+
+Exit status: 0 when the declaration is absent or fully consistent with the
+live graph, 1 with machine-readable `decomposition-edge-check:` lines on
+stderr otherwise. Requires `gc` for live edge reads unless --skip-live.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from validate_build_artifact import clean_table_cell, is_separator_row, split_table_row
+
+# Mirrors gascity's beads.readyBlockingDependencyTypes: only these edge types
+# hold a bead out of Ready(), so only these express execution ordering.
+READY_BLOCKING_TYPES = {"blocks", "waits-for", "conditional-blocks"}
+CHECK_PREFIX = "decomposition-edge-check"
+
+
+class EdgeCheckError(Exception):
+    pass
+
+
+@dataclass(frozen=True)
+class WorkItemRow:
+    item_id: str
+    bead_id: str
+    depends_on: tuple[str, ...]
+
+
+def normalize_header_cell(cell: str) -> str:
+    return " ".join(clean_table_cell(cell).lower().replace("_", " ").replace("-", " ").split())
+
+
+def parse_depends_cell(raw: str) -> tuple[str, ...]:
+    cleaned = clean_table_cell(raw)
+    if cleaned in {"", "-", "none"}:
+        return ()
+    parts = [clean_table_cell(part) for part in cleaned.split(",")]
+    return tuple(part for part in parts if part and part != "-")
+
+
+def parse_work_item_tables(body: str) -> list[WorkItemRow]:
+    rows: list[WorkItemRow] = []
+    lines = body.splitlines()
+    index = 0
+    while index < len(lines):
+        cells = split_table_row(lines[index])
+        header = [normalize_header_cell(cell) for cell in cells]
+        if not header or "id" not in header or "bead" not in header or "depends on" not in header:
+            index += 1
+            continue
+        if "status" in header:
+            raise EdgeCheckError(
+                "work-item dependency table must not carry a Status column; "
+                "the build-artifact validator reads any ID/Status table as the coverage matrix"
+            )
+        id_index = header.index("id")
+        bead_index = header.index("bead")
+        depends_index = header.index("depends on")
+        index += 1
+        if index < len(lines) and is_separator_row(lines[index]):
+            index += 1
+        while index < len(lines):
+            row = split_table_row(lines[index])
+            if not row or len(row) <= max(id_index, bead_index, depends_index):
+                break
+            item_id = clean_table_cell(row[id_index])
+            bead_id = clean_table_cell(row[bead_index])
+            if item_id:
+                rows.append(
+                    WorkItemRow(
+                        item_id=item_id,
+                        bead_id="" if bead_id == "-" else bead_id,
+                        depends_on=parse_depends_cell(row[depends_index]),
+                    )
+                )
+            index += 1
+    return rows
+
+
+def validate_declaration(rows: list[WorkItemRow]) -> list[str]:
+    errors: list[str] = []
+    position: dict[str, int] = {}
+    beads_seen: dict[str, str] = {}
+    for index, row in enumerate(rows):
+        if row.item_id in position:
+            errors.append(f"duplicate work item id {row.item_id!r} in dependency table")
+            continue
+        position[row.item_id] = index
+        if not row.bead_id:
+            errors.append(f"work item {row.item_id} has no bead id in the dependency table")
+            continue
+        if row.bead_id in beads_seen:
+            errors.append(
+                f"work items {beads_seen[row.bead_id]} and {row.item_id} share bead id {row.bead_id}"
+            )
+            continue
+        beads_seen[row.bead_id] = row.item_id
+    for index, row in enumerate(rows):
+        for dep in row.depends_on:
+            if dep == row.item_id:
+                errors.append(f"work item {row.item_id} declares a dependency on itself")
+                continue
+            if dep not in position:
+                errors.append(f"work item {row.item_id} depends on unknown work item {dep!r}")
+                continue
+            if position[dep] >= index:
+                errors.append(
+                    f"work item {row.item_id} depends on {dep}, which is declared later: "
+                    "the table must list work items in execution order and every "
+                    "Depends On entry must reference an earlier row"
+                )
+    return errors
+
+
+def parse_dep_list_output(output: str) -> list[dict[str, str]]:
+    start = output.find("[")
+    if start < 0:
+        return []
+    try:
+        data, _ = json.JSONDecoder().raw_decode(output[start:])
+    except json.JSONDecodeError as exc:
+        raise EdgeCheckError(f"gc bd dep list output was not JSON: {exc}") from exc
+    if not isinstance(data, list):
+        return []
+    deps: list[dict[str, str]] = []
+    for raw in data:
+        if not isinstance(raw, dict):
+            continue
+        depends_on = str(raw.get("depends_on_id") or raw.get("id") or "").strip()
+        dep_type = str(raw.get("type") or raw.get("dependency_type") or "").strip() or "blocks"
+        if depends_on:
+            deps.append({"depends_on_id": depends_on, "type": dep_type})
+    return deps
+
+
+def live_blocking_deps(gc_bin: str, bead_id: str) -> set[str]:
+    cmd = [gc_bin, "bd", "dep", "list", bead_id, "--json"]
+    proc = subprocess.run(cmd, text=True, capture_output=True, check=False)
+    if proc.returncode != 0:
+        stderr = proc.stderr.strip()
+        raise EdgeCheckError(f"gc bd dep list {bead_id} failed ({proc.returncode}): {stderr}")
+    return {
+        dep["depends_on_id"]
+        for dep in parse_dep_list_output(proc.stdout)
+        if dep["type"] in READY_BLOCKING_TYPES
+    }
+
+
+def validate_live_edges(rows: list[WorkItemRow], gc_bin: str) -> list[str]:
+    errors: list[str] = []
+    bead_by_item = {row.item_id: row.bead_id for row in rows}
+    deps_by_bead: dict[str, set[str]] = {}
+    for row in rows:
+        try:
+            deps_by_bead[row.bead_id] = live_blocking_deps(gc_bin, row.bead_id)
+        except EdgeCheckError as exc:
+            errors.append(str(exc))
+    if errors:
+        return errors
+    for row in rows:
+        for dep in row.depends_on:
+            prerequisite = bead_by_item[dep]
+            if prerequisite not in deps_by_bead[row.bead_id]:
+                errors.append(
+                    f"missing declared edge: {row.item_id} ({row.bead_id}) must depend on "
+                    f"{dep} ({prerequisite}); fix: gc bd dep add {row.bead_id} {prerequisite}"
+                )
+    for earlier_index, earlier in enumerate(rows):
+        for later in rows[earlier_index + 1 :]:
+            if later.bead_id in deps_by_bead[earlier.bead_id]:
+                errors.append(
+                    f"inverted edge: {earlier.item_id} ({earlier.bead_id}) depends on "
+                    f"{later.item_id} ({later.bead_id}), which is declared later in execution "
+                    f"order; fix: gc bd dep remove {earlier.bead_id} {later.bead_id}"
+                )
+    return errors
+
+
+def check_artifact(path: Path, gc_bin: str, skip_live: bool) -> tuple[int, str]:
+    text = path.read_text(encoding="utf-8")
+    rows = parse_work_item_tables(text)
+    if not rows:
+        return 0, "decomposition edge check: no work-item dependency table declared; skipping edge verification"
+    errors = validate_declaration(rows)
+    if not errors and not skip_live:
+        errors = validate_live_edges(rows, gc_bin)
+    if errors:
+        for error in errors:
+            print(f"{CHECK_PREFIX}: {error}", file=sys.stderr)
+        return 1, ""
+    declared_edges = sum(len(row.depends_on) for row in rows)
+    scope = "declaration only" if skip_live else "declaration and live edges"
+    return 0, f"decomposition edges valid: {len(rows)} work items, {declared_edges} declared edges ({scope})"
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Verify decomposition work-item dependency edge orientation")
+    parser.add_argument("--path", required=True, type=Path, help="Decomposition artifact markdown path")
+    parser.add_argument("--gc-bin", default="gc", help="gc binary used for live edge reads (default: gc)")
+    parser.add_argument(
+        "--skip-live",
+        action="store_true",
+        help="Only validate the declared table (no gc bead reads)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv if argv is not None else sys.argv[1:])
+    try:
+        status, message = check_artifact(args.path, args.gc_bin, args.skip_live)
+    except (OSError, UnicodeDecodeError, EdgeCheckError) as exc:
+        print(f"{CHECK_PREFIX}: {exc}", file=sys.stderr)
+        return 1
+    if message:
+        print(message)
+    return status
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/gascity/assets/workflows/build-basic/decompose.md
+++ b/gascity/assets/workflows/build-basic/decompose.md
@@ -49,6 +49,25 @@ Include the required schema sections:
 - Implementation Convoy
 - Work Items
 
+The Work Items section must include a machine-readable dependency table with
+ID, Bead, and Depends On columns, one row per work item, rows in intended
+execution order:
+
+| ID | Bead | Depends On |
+| --- | --- | --- |
+| WI-1 | <WI-1-bead-id> | - |
+| WI-2 | <WI-2-bead-id> | WI-1 |
+
+- Every Depends On entry must reference an EARLIER row's ID; use commas for
+  several prerequisites and `-` for none.
+- Do not add a Status column to this table; the validator reads any table with
+  ID and Status columns as the coverage matrix.
+- The validation gate verifies live bead edges against this table: each row's
+  bead must depend on the beads of its Depends On entries, and no earlier
+  row's bead may depend on a later row's bead. Orientation failures name the
+  exact `gc bd dep add` / `gc bd dep remove` repair commands; repair the
+  EDGES with those commands, not just the artifact text.
+
 Create work-item beads first, then create a new implementation convoy for those
 work units. Do not reuse the source or launch convoy from `gc.var.convoy_id`.
 
@@ -64,6 +83,24 @@ Use the convoy creation flow exactly:
 Do not create an empty convoy. Do not call `gc convoy add` for newly-created beads.
 The freshly-created IDs may not be visible to that path yet. Do not call `gc bd show <implementation-convoy-id>`.
 Convoy IDs are not bd issue IDs.
+
+Wire work-item dependencies immediately after creating the convoy, exactly as
+declared in the dependency table:
+
+- The command is `gc bd dep add <dependent> <prerequisite>`: the FIRST
+  argument is the work item that must WAIT, the SECOND is what it waits for.
+  Read it as "<dependent> depends on <prerequisite>".
+- For the declared order WI-1 then WI-2 (WI-2 depends on WI-1):
+  - RIGHT: `gc bd dep add <WI-2-bead> <WI-1-bead>` (WI-2 needs WI-1)
+  - WRONG: `gc bd dep add <WI-1-bead> <WI-2-bead>` — that is the temporal
+    misreading ("WI-1 comes before WI-2"); it makes WI-1 wait on WI-2, and a
+    chain wired this way drains back-to-front.
+- For a strict sequential chain, run one command per consecutive pair, always
+  naming the LATER work item first.
+- Self-check before closing: the first work item must show no blocking
+  dependencies in `gc bd dep list <WI-1-bead> --json`, every later work item
+  must list exactly its declared prerequisites, and for a strict chain only
+  the first of the new work items may be ready.
 
 Record the decomposition output on the workflow root bead with
 `gc bd update "<workflow-root-id>" --set-metadata "gc.build.decomposition_path=<absolute path>"`.

--- a/gascity/assets/workflows/build-from-decompose-base/decompose.md
+++ b/gascity/assets/workflows/build-from-decompose-base/decompose.md
@@ -6,6 +6,8 @@ Create or adopt an implementation convoy for the work units. The convoy must con
 
 Write the decomposition artifact to `{{decomposition_path}}` when supplied; otherwise write it under `{{artifact_root}}` as the default decomposition artifact. The decomposition must include work item IDs, requirement and plan traceability, expected files or formula assets, verification expectations, dependencies, skipped work, and blocked work with rationale.
 
+Declare work-item dependencies in a machine-readable table with ID, Bead, and Depends On columns (rows in intended execution order; every Depends On entry references an earlier row; no Status column), and wire the live edges to match: `gc bd dep add <dependent> <prerequisite>` — the first argument WAITS, the second is what it waits for. Never wire a declared sequence temporally (`gc bd dep add <earlier> <later>` is inverted and drains back-to-front). The validation gate verifies live edge orientation against the declared table and fails with the exact `gc bd dep add`/`gc bd dep remove` repair commands; repair the edges, not just the artifact text.
+
 Record the implementation convoy ID on the workflow root bead as both:
 
 - `gc.input_convoy_id=<implementation-convoy-id>` for the drain contract.

--- a/gascity/assets/workflows/decomposition-base/decompose.md
+++ b/gascity/assets/workflows/decomposition-base/decompose.md
@@ -8,4 +8,14 @@ metadata as `gc.build.decomposition_path` before closing. The output must still
 be an implementation convoy that downstream implementation formulas can drain
 without knowing the planning methodology.
 
+Dependency orientation contract: wire ordering edges as
+`gc bd dep add <dependent> <prerequisite>` — the first argument WAITS, the
+second is what it waits for (predecessor blocks successor; successor depends
+on predecessor). Never wire a declared sequence temporally
+(`gc bd dep add <earlier> <later>` is inverted and drains back-to-front).
+When the artifact declares work items with an ID/Bead/Depends On table (rows
+in execution order, Depends On referencing earlier rows only, no Status
+column), the validation gate verifies the live edges against that declaration
+and fails with the exact `gc bd dep add`/`gc bd dep remove` repair commands.
+
 Artifact validation: this step is gated by `.gc/scripts/checks/build-artifact-valid.sh`, which validates the artifact recorded at `gc.build.decomposition_path` (fallback `gc.var.decomposition_path`) against schema `gc.build.decomposition.v1`. On repair attempts (`gc.attempt` greater than 1), read the validator errors from `gc.attempt_log` on the validation loop control bead (the dependent of this step bead) and repair the artifact in place instead of rewriting it. Two bounded repair attempts follow the first failure; exhausting them closes this stage with `gc.outcome=fail` and machine-readable validation errors that block downstream stages. Never ask questions in headless mode; record unresolved ambiguity inside the artifact.

--- a/gascity/tests/test_validate_decomposition_edges.py
+++ b/gascity/tests/test_validate_decomposition_edges.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import os
+import pathlib
+import stat
+import sys
+import tempfile
+import textwrap
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "assets" / "scripts"))
+
+import validate_build_artifact as build_artifact
+import validate_decomposition_edges as edges
+
+FAKE_GC_SOURCE = textwrap.dedent(
+    """\
+    #!/usr/bin/env python3
+    import json
+    import os
+    import sys
+
+    with open(os.environ["FAKE_GC_DEPS"], encoding="utf-8") as handle:
+        deps_by_bead = json.load(handle)
+
+    if sys.argv[1:4] != ["bd", "dep", "list"] or "--json" not in sys.argv:
+        sys.stderr.write("fake gc: unsupported invocation: %r\\n" % (sys.argv[1:],))
+        raise SystemExit(2)
+
+    bead = sys.argv[4]
+    if bead not in deps_by_bead:
+        sys.stderr.write("no issue found matching %s\\n" % bead)
+        raise SystemExit(1)
+    print(json.dumps(deps_by_bead[bead]))
+    """
+)
+
+
+def dependency_table(rows: list[tuple[str, str, str]]) -> str:
+    lines = [
+        "## Work Items",
+        "",
+        "| ID | Bead | Depends On |",
+        "| --- | --- | --- |",
+    ]
+    lines.extend(f"| {item_id} | {bead} | {depends} |" for item_id, bead, depends in rows)
+    return "\n".join(lines) + "\n"
+
+
+class EdgeCheckTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = pathlib.Path(self.tmp.name)
+
+    def write_artifact(self, body: str) -> pathlib.Path:
+        path = self.root / "decomposition.md"
+        path.write_text(body, encoding="utf-8")
+        return path
+
+    def write_fake_gc(self, deps_by_bead: dict[str, list[dict[str, str]]]) -> pathlib.Path:
+        deps_path = self.root / "deps.json"
+        deps_path.write_text(json.dumps(deps_by_bead), encoding="utf-8")
+        gc_path = self.root / "gc"
+        gc_path.write_text(FAKE_GC_SOURCE, encoding="utf-8")
+        gc_path.chmod(gc_path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        os.environ["FAKE_GC_DEPS"] = str(deps_path)
+        self.addCleanup(os.environ.pop, "FAKE_GC_DEPS", None)
+        return gc_path
+
+    def run_main(self, argv: list[str]) -> tuple[int, str, str]:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+            status = edges.main(argv)
+        return status, stdout.getvalue(), stderr.getvalue()
+
+    def test_skips_artifact_without_dependency_table(self) -> None:
+        path = self.write_artifact("## Work Items\n\nProse only, no table.\n")
+        status, stdout, stderr = self.run_main(["--path", str(path)])
+        self.assertEqual(status, 0)
+        self.assertIn("skipping edge verification", stdout)
+        self.assertEqual(stderr, "")
+
+    def test_rejects_forward_reference_in_declaration(self) -> None:
+        path = self.write_artifact(
+            dependency_table(
+                [
+                    ("WI-1", "gc-aaa111", "WI-2"),
+                    ("WI-2", "gc-bbb222", "-"),
+                ]
+            )
+        )
+        status, _, stderr = self.run_main(["--path", str(path), "--skip-live"])
+        self.assertEqual(status, 1)
+        self.assertIn("declared later", stderr)
+        self.assertIn("execution order", stderr)
+
+    def test_rejects_status_column_in_dependency_table(self) -> None:
+        path = self.write_artifact(
+            "## Work Items\n\n"
+            "| ID | Bead | Depends On | Status |\n"
+            "| --- | --- | --- | --- |\n"
+            "| WI-1 | gc-aaa111 | - | open |\n"
+        )
+        status, _, stderr = self.run_main(["--path", str(path), "--skip-live"])
+        self.assertEqual(status, 1)
+        self.assertIn("must not carry a Status column", stderr)
+
+    def test_correct_chain_passes_live_verification(self) -> None:
+        path = self.write_artifact(
+            dependency_table(
+                [
+                    ("WI-1", "gc-aaa111", "-"),
+                    ("WI-2", "gc-bbb222", "WI-1"),
+                    ("WI-3", "gc-ccc333", "WI-2"),
+                ]
+            )
+        )
+        gc_path = self.write_fake_gc(
+            {
+                "gc-aaa111": [],
+                "gc-bbb222": [{"depends_on_id": "gc-aaa111", "type": "blocks"}],
+                "gc-ccc333": [{"depends_on_id": "gc-bbb222", "type": "blocks"}],
+            }
+        )
+        status, stdout, stderr = self.run_main(["--path", str(path), "--gc-bin", str(gc_path)])
+        self.assertEqual(status, 0, stderr)
+        self.assertIn("3 work items, 2 declared edges", stdout)
+
+    def test_inverted_chain_fails_with_repair_commands(self) -> None:
+        # The observed ac-9egumo shape: the declared chain WI-1 -> WI-2 -> WI-3
+        # was wired backwards (each EARLIER item depends on its successor).
+        path = self.write_artifact(
+            dependency_table(
+                [
+                    ("WI-1", "gc-aaa111", "-"),
+                    ("WI-2", "gc-bbb222", "WI-1"),
+                    ("WI-3", "gc-ccc333", "WI-2"),
+                ]
+            )
+        )
+        gc_path = self.write_fake_gc(
+            {
+                "gc-aaa111": [{"depends_on_id": "gc-bbb222", "type": "blocks"}],
+                "gc-bbb222": [{"depends_on_id": "gc-ccc333", "type": "blocks"}],
+                "gc-ccc333": [],
+            }
+        )
+        status, _, stderr = self.run_main(["--path", str(path), "--gc-bin", str(gc_path)])
+        self.assertEqual(status, 1)
+        self.assertIn("missing declared edge", stderr)
+        self.assertIn("inverted edge", stderr)
+        self.assertIn("gc bd dep add gc-bbb222 gc-aaa111", stderr)
+        self.assertIn("gc bd dep remove gc-aaa111 gc-bbb222", stderr)
+
+    def test_missing_bead_fails(self) -> None:
+        path = self.write_artifact(
+            dependency_table(
+                [
+                    ("WI-1", "gc-aaa111", "-"),
+                    ("WI-2", "gc-missing", "WI-1"),
+                ]
+            )
+        )
+        gc_path = self.write_fake_gc({"gc-aaa111": []})
+        status, _, stderr = self.run_main(["--path", str(path), "--gc-bin", str(gc_path)])
+        self.assertEqual(status, 1)
+        self.assertIn("gc bd dep list gc-missing failed", stderr)
+
+    def test_non_blocking_dependency_types_are_ignored(self) -> None:
+        path = self.write_artifact(
+            dependency_table(
+                [
+                    ("WI-1", "gc-aaa111", "-"),
+                    ("WI-2", "gc-bbb222", "WI-1"),
+                ]
+            )
+        )
+        gc_path = self.write_fake_gc(
+            {
+                # The declared edge exists; the earlier item also carries a
+                # non-blocking edge onto the later one, which must not count
+                # as an inversion.
+                "gc-aaa111": [{"depends_on_id": "gc-bbb222", "type": "related"}],
+                "gc-bbb222": [{"depends_on_id": "gc-aaa111", "type": "waits-for"}],
+            }
+        )
+        status, stdout, stderr = self.run_main(["--path", str(path), "--gc-bin", str(gc_path)])
+        self.assertEqual(status, 0, stderr)
+        self.assertIn("2 work items, 1 declared edges", stdout)
+
+    def test_dependency_table_does_not_pollute_coverage_matrix(self) -> None:
+        body = (
+            "## Coverage\n\n"
+            "| ID | Status |\n"
+            "| --- | --- |\n"
+            "| REQ-001 | covered |\n\n"
+            + dependency_table(
+                [
+                    ("WI-1", "gc-aaa111", "-"),
+                    ("WI-2", "gc-bbb222", "WI-1"),
+                ]
+            )
+        )
+        coverage = build_artifact.parse_markdown_coverage(body)
+        self.assertEqual(coverage, {"REQ-001": "covered"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

A decomposition step that declares a strict sequential chain of work items can materialize every dependency edge inverted. The failure mode: `gc bd dep add <a> <b>` gets read temporally ("a comes before b") instead of by its actual contract ("a depends on b"), so each EARLIER work item ends up depending on its successor and the implementation convoy drains the chain back-to-front.

Observed twice in a production Gas City deployment running `build-basic`:

- A 6-item chain (WI-1 → … → WI-6, "each depends on its predecessor" per the artifact) came out complete but fully inverted: WI-1 depended on WI-2, … WI-5 on WI-6, and WI-6 had no dependencies at all. The plan-wide verification sweep (WI-6) drained FIRST at index 0/6 with nothing to verify, exhausted its 3-attempt budget, closed `gc.outcome=fail` / blocked-precondition, and filed a duplicate follow-up bead. The work item owning a live data re-pull ran LAST, so its consumers priced from a stale snapshot — harmless only because the re-pull happened to show zero drift.
- A second run's 4-item drain executed in exact reverse of declared dependency order — same inversion.

The `[steps.check]` gate validates only the artifact (schema / front matter / coverage); nothing asserts that the created edges match the declared order. The gascity pack's decompose instructions never mention dependency wiring at all — while the older gastown pack prompts carry an explicit WRONG/RIGHT warning about this exact argument-order trap (`gc bd n phase2 phase1`, not `phase1 phase2`), so this is a known failure mode that the newer pack lost.

## Fix

Creation-time assertion, per the incident analysis: assert edge orientation when materializing a declared sequence — not at drain time, and not by adding more edges.

- **Instructions** (`build-basic`, `decomposition-base`, `build-from-decompose-base` decompose steps): spell the command contract — first argument WAITS, second is what it waits for — with a RIGHT/WRONG pair, require one `gc bd dep add` per consecutive pair for chains (later item named first), and require a machine-readable dependency table in the Work Items section (`| ID | Bead | Depends On |`, rows in execution order).
- **New `gascity/assets/scripts/validate_decomposition_edges.py`**: verifies the declaration (Depends On may only reference earlier rows — a forward reference means the table is not in execution order) and the live graph via `gc bd dep list --json` (each bead depends on its declared prerequisites; no earlier bead depends on a later one through a ready-blocking type: `blocks` / `waits-for` / `conditional-blocks`, mirroring gascity's `readyBlockingDependencyTypes`). Failures print the exact `gc bd dep add` / `gc bd dep remove` repair commands so the bounded repair loop can rewire deterministically instead of guessing from prose.
- **`build-artifact-valid.sh`**: after schema validation passes, runs the edge check for `gc.build.decomposition.v1` artifacts.

## Compatibility

- Artifacts that declare no dependency table (methodology packs with other task shapes, e.g. superpowers) skip live verification and validate exactly as before; declaring the table opts the artifact into strict orientation checking.
- The dependency table deliberately has no Status column: `validate_build_artifact.py` treats any ID/Status table as the coverage matrix, and both the new instructions and the edge checker guard against that collision.
- Schema `gc.build.decomposition.v1` is untouched.

## Testing

- `python3 -m pytest gascity/tests -q` — 184 passed, including 8 new tests: table parsing/skip behavior, forward-reference rejection, Status-column rejection, correct chain passes live verification, the observed inverted-chain shape fails with the right repair commands, missing bead fails, non-blocking dep types ignored, coverage-matrix non-interference.
- Full CI pytest sweep (`tests contributing/tests gascity/tests discord/tests github/tests slack-full/tests slack-channel/tests pr-pipeline/tests profiler/tests`): 1179 passed, 8 pre-existing skips.
- `bash -n` on the modified check script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
