### PR TITLE
fix(gastown): stop the deacon paging CRITICAL for a city with no Dolt data plane

### DIFF
--- a/gastown/formulas/mol-deacon-patrol.toml
+++ b/gastown/formulas/mol-deacon-patrol.toml
@@ -393,6 +393,7 @@ gc dolt health --json
 ```
 
 Parse the JSON output (HealthReport schema):
+- `applicable`: false when this city has no Dolt data plane at all
 - `server`: running, reachable, pid, port, latency_ms
 - `databases[]`: name, commits, open_beads
 - `backups`: dolt_freshness, dolt_age_seconds, dolt_stale
@@ -404,7 +405,25 @@ state is signalled in-band. Key decisions off `server.reachable`, not
 `server.running` — a process can hold the port while its goroutines
 are wedged (the latter is what first prompted this check to exist).
 
-**Step 2: Evaluate thresholds**
+**Step 1a: Check applicability BEFORE any threshold.**
+
+A city whose bead ledger is on another backend (MySQL, Postgres) has no
+managed Dolt runtime, so there is no data plane to report on. That city
+reports `applicable: false` with a `reason`, and its remaining fields are
+zero-valued placeholders — `server.reachable` is `false` because no Dolt
+server exists, NOT because one is down. Evaluating the table below on such
+a payload escalates a CRITICAL that no one can act on, every patrol cycle.
+
+```bash
+gc dolt health --json | jq -r 'if .applicable == false then "skip: " + .reason else "evaluate" end'
+```
+
+If it reports `skip`, log `Dolt health: not applicable (<reason>)` and move
+on to the next step. Do NOT escalate and do NOT nudge a dog. An older
+`gc dolt health` omits the field entirely; a payload without `applicable`
+is evaluated normally, exactly as before.
+
+**Step 2: Evaluate thresholds** (only when `applicable` is not false)
 
 | Signal | Threshold | Meaning |
 |--------|-----------|---------|


### PR DESCRIPTION
## Problem

`mol-deacon-patrol`'s dolt-health step evaluates its threshold table unconditionally, and the first row escalates **CRITICAL to the mayor** on `server.reachable == false`.

A city whose bead ledger lives on another backend (MySQL, Postgres) has no managed Dolt runtime at all — there is no data plane to report on, and there never will be. On such a city `gc dolt health --json` reports `applicable: false` with a reason, and the remaining fields are zero-valued placeholders: `server.reachable` is `false` because **no Dolt server exists**, not because one is down. Evaluating the table on that payload pages an unactionable CRITICAL every patrol cycle.

## Change

One step description in `gastown/formulas/mol-deacon-patrol.toml`: check `applicable` before the threshold table, and when it is false, log `Dolt health: not applicable (<reason>)` and move on — no escalation, no dog nudge. The `applicable` field is added to the documented payload shape, and the Step 2 heading now states the precondition.

## Backward compatible — safe to land in either order

An older `gc dolt health` omits the field entirely. `jq` yields `null`, `null == false` is false, so a payload without `applicable` is evaluated exactly as it is today. This can land before or after the producer half.

## Pairs with the gascity-side fix

Tracked as gas-e05. Before that fix, `gc dolt health` on a non-Dolt city exited **78 with no payload at all** (it dies while sourcing `runtime.sh`, which resolves the port at source time), so this step could not distinguish "Dolt is not in use here" from "healthy" from "the check itself is broken" — commit bloat, stale backups, zombie servers and orphan databases went unreported with no signal that monitoring had gone blind. The producer now emits a well-formed report and exits 0; this is the consumer half that reads it.

Verified on the MySQL city that filed the bug: `gc dolt health --json` went from exit 78 with no payload to exit 0 with `applicable: false`, `reason: "city beads backend is mysql; no managed Dolt runtime to probe"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)