### PR TITLE
fix(gastown): gate the polecat handoff on the branch having commits

### DIFF
--- a/gastown/formulas/mol-polecat-work.toml
+++ b/gastown/formulas/mol-polecat-work.toml
@@ -364,6 +364,49 @@ BODY
 This is a belt-and-suspenders check — self-review should have caught this,
 but we never push with untracked work left behind.
 
+**2b. Branch-content gate (fails closed — non-negotiable).**
+
+The branch-shape gate proves the branch is *named* right; it does not prove
+it *contains* anything. A branch created at the base tip and never committed
+to passes every other gate here: the name matches, the tree is clean, and
+`git push` of zero commits succeeds and creates the ref, so push verification
+sees origin == HEAD. The handoff is then stamped and the bead moves forward
+looking like success — a phantom handoff. Only the refinery's own
+no-work-on-branch check catches it, one gate slot later; without that check
+it merges as a no-op and the bead closes with the work undone. An idle worker
+is visible, this is not.
+
+```bash
+COMMITS_AHEAD=$(git rev-list --count "origin/{{base_branch}}..HEAD")
+if [ "$COMMITS_AHEAD" -eq 0 ]; then
+    echo "BRANCH CONTENT GATE FAILED"
+    echo "  branch:  $EXPECTED_BRANCH"
+    echo "  commits ahead of origin/{{base_branch}}: 0"
+    echo ""
+    echo "There is nothing to hand off. Do NOT push and do NOT reassign to the"
+    echo "refinery — an empty branch is a phantom handoff, not a completion."
+    echo ""
+    echo "If you HAVE done work, it is uncommitted or on another branch: go back,"
+    echo "commit it on $EXPECTED_BRANCH, and re-run submit-and-exit."
+    echo ""
+    echo "If the honest answer is that no code change is warranted (an"
+    echo "investigation that concluded 'no', a bead already satisfied by main),"
+    echo "that is a legitimate outcome — but it is reported, not handed off."
+    gc bd update "$WORK_BEAD_ID" \
+      --status=open --assignee="" \
+      --set-metadata gc.routed_to="" \
+      --set-metadata halt_reason=no_commits \
+      --notes "$(cat <<'BODY'
+Halted at submit: branch has zero commits ahead of base. No handoff stamped.
+<State what you investigated and why no code change is warranted, or what
+blocked you from producing one. A coordinator reads this to decide next steps.>
+BODY
+)"
+    gc runtime drain-ack
+    exit 1
+fi
+```
+
 **3. Push gate — FAIL CLOSED, then push:**
 
 Absent metadata is not consent. A rail expressed only in prose is enforced by

--- a/gastown/formulas/mol-polecat-work.toml
+++ b/gastown/formulas/mol-polecat-work.toml
@@ -376,36 +376,79 @@ no-work-on-branch check catches it, one gate slot later; without that check
 it merges as a no-op and the bead closes with the work undone. An idle worker
 is visible, this is not.
 
+The predicate is deliberately commit-count-only, measured against the
+`origin/{{base_branch}}` tip: it catches the phantom handoff — a branch with
+nothing on it — at the cheapest point, before any push. It is weaker than the
+refinery's canonical `branch_has_real_change`, which also requires a non-empty
+`git diff` against the merge-base and therefore additionally catches a net-zero
+branch (commit plus revert). That split is intentional: the refinery stays the
+backstop for net-zero work. Do not "fix" only one side of the pair.
+
+`git rev-list` failing is not the same answer as "zero commits", and neither is
+a licence to hand off: a count that is not a plain number halts under its own
+`halt_reason=content_gate_error` rather than falling through to the push. That
+is why the count is matched with `case` instead of `[ "$COMMITS_AHEAD" -eq 0 ]`,
+which evaluates false — and so fails open — on an empty value.
+
 ```bash
-COMMITS_AHEAD=$(git rev-list --count "origin/{{base_branch}}..HEAD")
-if [ "$COMMITS_AHEAD" -eq 0 ]; then
-    echo "BRANCH CONTENT GATE FAILED"
+COMMITS_AHEAD=$(git rev-list --count "origin/{{base_branch}}..HEAD" 2>/dev/null)
+HALT_REASON=""
+case "$COMMITS_AHEAD" in
+    ''|*[!0-9]*) HALT_REASON=content_gate_error ;;
+    0) HALT_REASON=no_commits ;;
+esac
+if [ -n "$HALT_REASON" ]; then
+    echo "BRANCH CONTENT GATE FAILED ($HALT_REASON)"
     echo "  branch:  $EXPECTED_BRANCH"
-    echo "  commits ahead of origin/{{base_branch}}: 0"
+    if [ "$HALT_REASON" = content_gate_error ]; then
+        echo "  commits ahead of origin/{{base_branch}}: could not be measured"
+        echo ""
+        echo "The count could not be taken (missing or corrupt origin/{{base_branch}},"
+        echo "a concurrent prune). A tool error is a suspect, not a licence to merge:"
+        echo "an unmeasurable branch is not pushed and no handoff is stamped."
+    else
+        echo "  commits ahead of origin/{{base_branch}}: 0"
+        echo ""
+        echo "There is nothing to hand off. Do NOT push and do NOT reassign to the"
+        echo "refinery — an empty branch is a phantom handoff, not a completion."
+        echo ""
+        echo "Uncommitted leftovers are not the cause: the clean-state check above"
+        echo "already committed them. Either the work is sitting on another branch,"
+        echo "or no change was produced at all."
+        echo ""
+        echo "If the honest answer is that no code change is warranted (an"
+        echo "investigation that concluded 'no', a bead already satisfied by main),"
+        echo "that is a legitimate outcome — but it is reported, not handed off."
+    fi
     echo ""
-    echo "There is nothing to hand off. Do NOT push and do NOT reassign to the"
-    echo "refinery — an empty branch is a phantom handoff, not a completion."
-    echo ""
-    echo "If you HAVE done work, it is uncommitted or on another branch: go back,"
-    echo "commit it on $EXPECTED_BRANCH, and re-run submit-and-exit."
-    echo ""
-    echo "If the honest answer is that no code change is warranted (an"
-    echo "investigation that concluded 'no', a bead already satisfied by main),"
-    echo "that is a legitimate outcome — but it is reported, not handed off."
+    echo "The bead goes back to the pool with this halt recorded; do not re-run"
+    echo "submit-and-exit from this session, whose claim is released below."
     gc bd update "$WORK_BEAD_ID" \
       --status=open --assignee="" \
       --set-metadata gc.routed_to="" \
-      --set-metadata halt_reason=no_commits \
-      --notes "$(cat <<'BODY'
-Halted at submit: branch has zero commits ahead of base. No handoff stamped.
-<State what you investigated and why no code change is warranted, or what
-blocked you from producing one. A coordinator reads this to decide next steps.>
+      --set-metadata halt_reason="$HALT_REASON" \
+      --append-notes "Halted at submit ($HALT_REASON): no handoff stamped.
+$(cat <<'BODY'
+<State what you investigated and why no code change is warranted, what blocked
+you from producing one, or — for content_gate_error — what left the branch
+unmeasurable. A coordinator reads this to decide next steps.>
 BODY
 )"
+    for ESCALATE_TARGET in mayor "${GC_RIG:+$GC_RIG/}{{binding_prefix}}witness"; do
+      gc session nudge "$ESCALATE_TARGET" "POLECAT HANDOFF HALT ($HALT_REASON): $WORK_BEAD_ID on $EXPECTED_BRANCH — no handoff stamped; bead returned to the pool open and unassigned. Needs a coordinator decision." \
+        || echo "WARNING: could not nudge $ESCALATE_TARGET about $WORK_BEAD_ID; escalate by hand."
+    done
     gc runtime drain-ack
     exit 1
 fi
 ```
+
+The halt parks the bead `open` + unassigned + unrouted, which no dispatcher
+tier serves and which witness orphan recovery skips (it filters for beads that
+*have* an assignee). Left at that, this gate would silently displace the
+refinery's `halt_false_completion`, which escalates the same failure class to
+mayor and witness. The nudges above keep that escalation, so moving the catch
+one gate earlier does not make it quieter.
 
 **3. Push gate — FAIL CLOSED, then push:**
 

--- a/gastown/tests/test_polecat_push_gate.sh
+++ b/gastown/tests/test_polecat_push_gate.sh
@@ -165,8 +165,13 @@ if '[ -z "$WORK_JSON" ]' not in body:
     # jq prints nothing for empty input and exits 0, so a dead ledger cannot be
     # caught on jq's exit status alone.
     problems.append("no explicit guard for an empty payload from the ledger read")
-if body.count("halt_reason=") != 3:
-    problems.append("expected exactly three halt_reason writes, found %d" % body.count("halt_reason="))
+# Four halts write halt_reason in this step: the push gate's three
+# (metadata_unreadable, auto_push_false, no_push_rail_unresolved) plus the
+# branch-content gate's single write of "$HALT_REASON", which carries either
+# no_commits or content_gate_error. The count is pinned, not floored, so a
+# fifth unaccounted halt -- or a deleted one -- still reports here.
+if body.count("halt_reason=") != 4:
+    problems.append("expected exactly four halt_reason writes, found %d" % body.count("halt_reason="))
 if "ascii_downcase" not in body:
     # `False` and `no` are hand-written by humans following the mayor prompt;
     # reading them as "any other value -> explicit consent" fails open on the

--- a/scripts/gascity_pack_inference_gate.py
+++ b/scripts/gascity_pack_inference_gate.py
@@ -109,6 +109,9 @@ GASTOWN_BUILD_WORKFLOW_CONTRACTS = {
         "{{lint_command}}",
         "{{build_command}}",
         "{{test_command}}",
+        'COMMITS_AHEAD=$(git rev-list --count "origin/{{base_branch}}..HEAD" 2>/dev/null)',
+        "''|*[!0-9]*) HALT_REASON=content_gate_error ;;",
+        "0) HALT_REASON=no_commits ;;",
         "git push origin HEAD",
         "gc bd update \"$WORK_BEAD_ID\" \\",
         "--set-metadata target={{base_branch}}",
@@ -159,6 +162,55 @@ GASTOWN_BUILD_WORKFLOW_CONTRACTS = {
         "gc bd dep add",
     ),
 }
+# Position pins for the polecat branch-content gate, checked in submit-and-exit's
+# parsed order. The gate only prevents a phantom handoff where it stands: after
+# the clean-state check has committed any leftovers (so it cannot fire on work
+# that merely had not been committed yet) and before the push that would create
+# the ref and let the handoff be stamped.
+POLECAT_BRANCH_CONTENT_GATE_ORDER = (
+    ("clean-state commit", 'git commit -m "chore: capture remaining work ($WORK_BEAD_ID)"'),
+    ("branch-content count", 'COMMITS_AHEAD=$(git rev-list --count "origin/{{base_branch}}..HEAD" 2>/dev/null)'),
+    ("branch push", "git push origin HEAD"),
+)
+# Required between the count and the push. `git rev-list` failing must halt on
+# its own reason instead of falling through to the push, and the halt must
+# escalate: it parks the bead open, unassigned and unrouted, which no dispatcher
+# tier serves and witness orphan recovery skips, and it pre-empts the refinery's
+# `halt_false_completion`, which does nudge mayor and witness.
+POLECAT_BRANCH_CONTENT_GATE_HALT_PATH = (
+    ("unmeasurable-count arm", "''|*[!0-9]*) HALT_REASON=content_gate_error ;;"),
+    ("empty-branch arm", "0) HALT_REASON=no_commits ;;"),
+    # The two arms above are containment checks, so they pin arm *presence*
+    # only. `case` takes the first match, so a catch-all inserted ahead of
+    # either arm routes past it with both arms still literally present -- and
+    # one placed between them kills `no_commits`, the phantom handoff this gate
+    # exists to catch, while `content_gate_error` keeps working and the gate
+    # still looks alive. Pin the dispatch as one block so arm *order* is fixed
+    # too, and keep the trailing `esac\nif` so nothing can be inserted between
+    # deciding to halt and halting.
+    (
+        "case dispatch",
+        'case "$COMMITS_AHEAD" in\n'
+        "    ''|*[!0-9]*) HALT_REASON=content_gate_error ;;\n"
+        "    0) HALT_REASON=no_commits ;;\n"
+        'esac\nif [ -n "$HALT_REASON" ]; then',
+    ),
+    # Subsumed by the dispatch pin above (which ends with these same two
+    # lines), and kept deliberately: it names the adjacency specifically when
+    # that is what drifted, instead of reporting the whole dispatch as missing.
+    ("halt guard", 'esac\nif [ -n "$HALT_REASON" ]; then'),
+    ("halt_reason stamp", '--set-metadata halt_reason="$HALT_REASON"'),
+    ("mayor and witness escalation", 'for ESCALATE_TARGET in mayor "${GC_RIG:+$GC_RIG/}{{binding_prefix}}witness"; do'),
+    ("escalation nudge", 'gc session nudge "$ESCALATE_TARGET"'),
+    # Anchored to the escalation loop's `done`, which occurs only in this gate.
+    # The checked window runs to the push, so it also spans the auto_push=false
+    # halt further down: a bare "gc runtime drain-ack" fragment is satisfied by
+    # that sibling's copy, and stayed green with this gate's own copy deleted.
+    # The same anchor pins the `exit 1` -- without it the fence ends rc=0 and
+    # the agent walks on to the push it just refused, having already released
+    # the bead.
+    ("halt exit", "    done\n    gc runtime drain-ack\n    exit 1"),
+)
 METHODOLOGY_FLOW_CONTRACTS = {
     "superpowers": {
         "review_expansion": "superpowers-code-review",
@@ -2822,6 +2874,55 @@ def validate_gastown_orchestration_contract(pack_source: Path) -> None:
                 missing.append(f"{formula_name}: missing contract fragment {fragment!r}")
     if missing:
         raise GateError("Gastown orchestration contract drifted:\n" + "\n".join(f"- {item}" for item in missing))
+    validate_polecat_branch_content_gate(pack_source)
+
+
+def validate_polecat_branch_content_gate(pack_source: Path) -> None:
+    """Pin the branch-content gate's position and its halt path, not just its text.
+
+    The fragment pins above are substring containment over the whole file, so
+    they catch deletion and nothing else: a gate moved below `git push origin
+    HEAD`, or a halt path that quietly drops its escalation, keeps every pinned
+    fragment while gating nothing. Parse the step instead and require that the
+    commit count is taken after the clean-state commit and before the push, and
+    that everything between the count and the push still fails closed on an
+    unmeasurable branch and still escalates the halt.
+    """
+    problems: list[str] = []
+    path = pack_source / "formulas" / "mol-polecat-work.toml"
+    if not path.is_file():
+        raise GateError(f"mol-polecat-work: missing formula file {path}")
+    try:
+        payload = tomllib.loads(path.read_text(encoding="utf-8"))
+    except tomllib.TOMLDecodeError as exc:
+        raise GateError(f"mol-polecat-work: invalid TOML: {exc}") from exc
+
+    steps = [step for step in list_dicts(payload.get("steps")) if step.get("id") == "submit-and-exit"]
+    if len(steps) != 1:
+        raise GateError(f"mol-polecat-work: expected exactly one submit-and-exit step, found {len(steps)}")
+    description = str(steps[0].get("description") or "")
+
+    ordered = [(label, description.find(fragment)) for label, fragment in POLECAT_BRANCH_CONTENT_GATE_ORDER]
+    for label, index in ordered:
+        if index < 0:
+            problems.append(f"submit-and-exit is missing the {label}")
+    if not problems:
+        indexes = [index for _, index in ordered]
+        if indexes != sorted(indexes):
+            found = " then ".join(label for label, _ in sorted(ordered, key=lambda item: item[1]))
+            problems.append(
+                "the branch-content gate must run after the clean-state commit and before the push; found "
+                + found
+            )
+        else:
+            gate_block = description[indexes[1] : indexes[2]]
+            for label, fragment in POLECAT_BRANCH_CONTENT_GATE_HALT_PATH:
+                if fragment not in gate_block:
+                    problems.append(f"the branch-content gate halt path is missing the {label}")
+    if problems:
+        raise GateError(
+            "Gastown polecat branch-content gate drifted:\n" + "\n".join(f"- {item}" for item in problems)
+        )
 
 
 def stop_city(gc_bin: str, workspace: GateWorkspace, *, env: Mapping[str, str]) -> None:

--- a/tests/test_gascity_pack_inference_gate.py
+++ b/tests/test_gascity_pack_inference_gate.py
@@ -1084,6 +1084,151 @@ def test_validate_gastown_orchestration_contract_rejects_missing_refinery_false_
         gascity_pack_inference_gate.validate_gastown_orchestration_contract(tmp_path / "gastown")
 
 
+def gastown_formulas_copy(tmp_path: Path) -> Path:
+    pack_source = tmp_path / "gastown"
+    shutil.copytree(
+        gascity_pack_inference_gate.PACK_SPECS["gastown"].source / "formulas",
+        pack_source / "formulas",
+    )
+    return pack_source
+
+
+def test_validate_polecat_branch_content_gate_accepts_current_pack() -> None:
+    gascity_pack_inference_gate.validate_polecat_branch_content_gate(
+        gascity_pack_inference_gate.PACK_SPECS["gastown"].source
+    )
+
+
+def test_validate_polecat_branch_content_gate_rejects_gate_moved_after_the_push(tmp_path) -> None:
+    pack_source = gastown_formulas_copy(tmp_path)
+    path = pack_source / "formulas" / "mol-polecat-work.toml"
+    text = path.read_text(encoding="utf-8")
+    start = text.index("**2b. Branch-content gate")
+    # Anchored on the step-3 heading PREFIX, not its title: the title is prose
+    # and has been reworded once already ("Push your branch" -> "Push gate --
+    # FAIL CLOSED, then push"), which silently turned this slice into a
+    # ValueError rather than a failed assertion.
+    end = text.index("**3. ", start)
+    gate = text[start:end]
+    remainder = text[:start] + text[end:]
+    push_line = "git push origin HEAD\n"
+    anchor = remainder.index(push_line) + len(push_line)
+    path.write_text(remainder[:anchor] + gate + remainder[anchor:], encoding="utf-8")
+
+    # A relocated gate is invisible to the fragment pins: they are containment
+    # checks over the whole file, so every one of them still passes on a gate
+    # that now runs after the push it was supposed to prevent.
+    relocated = path.read_text(encoding="utf-8")
+    for fragment in gascity_pack_inference_gate.GASTOWN_BUILD_WORKFLOW_CONTRACTS["mol-polecat-work"]:
+        assert fragment in relocated
+
+    with pytest.raises(gascity_pack_inference_gate.GateError, match="before the push"):
+        gascity_pack_inference_gate.validate_polecat_branch_content_gate(pack_source)
+
+
+@pytest.mark.parametrize(
+    ("original", "replacement", "expected"),
+    [
+        pytest.param(
+            "''|*[!0-9]*) HALT_REASON=content_gate_error ;;",
+            "",
+            "unmeasurable-count arm",
+            id="deleted-fail-closed-arm",
+        ),
+        pytest.param(
+            "0) HALT_REASON=no_commits ;;",
+            "1) HALT_REASON=no_commits ;;",
+            "empty-branch arm",
+            id="inverted-empty-branch-arm",
+        ),
+        pytest.param(
+            'esac\nif [ -n "$HALT_REASON" ]; then',
+            'esac\nHALT_REASON=""\nif [ -n "$HALT_REASON" ]; then',
+            "halt guard",
+            id="disarmed-between-decision-and-halt",
+        ),
+        pytest.param(
+            'for ESCALATE_TARGET in mayor "${GC_RIG:+$GC_RIG/}{{binding_prefix}}witness"; do',
+            'for ESCALATE_TARGET in mayor; do',
+            "mayor and witness escalation",
+            id="dropped-witness-escalation",
+        ),
+        # `case` takes the first match, so a catch-all ahead of an arm disarms
+        # it while leaving the arm itself -- and every other fragment -- in
+        # place. Both positions are probed: ahead of the fail-closed arm
+        # (disarms both reasons) and between the arms, which kills only
+        # `no_commits` and is the likeliest accidental edit of the two, since
+        # an explicit default arm is harmless written *after* arm 2.
+        pytest.param(
+            "    ''|*[!0-9]*) HALT_REASON=content_gate_error ;;",
+            '    *) HALT_REASON="" ;;\n'
+            "    ''|*[!0-9]*) HALT_REASON=content_gate_error ;;",
+            "case dispatch",
+            id="catch-all-arm-ahead-of-the-fail-closed-arm",
+        ),
+        pytest.param(
+            "    0) HALT_REASON=no_commits ;;",
+            '    *) HALT_REASON="" ;;\n    0) HALT_REASON=no_commits ;;',
+            "case dispatch",
+            id="catch-all-arm-between-the-two-arms",
+        ),
+        pytest.param(
+            'case "$COMMITS_AHEAD" in',
+            'case "x$COMMITS_AHEAD" in',
+            "case dispatch",
+            id="dispatch-subject-that-can-never-match",
+        ),
+        # Without `exit 1` the fence ends rc=0, so the agent goes on to the
+        # step-3 push gate and pushes a branch this gate just declared unfit,
+        # after the halt has already released the bead.
+        pytest.param(
+            "    done\n    gc runtime drain-ack\n    exit 1",
+            "    done\n    gc runtime drain-ack",
+            "halt exit",
+            id="deleted-halt-exit",
+        ),
+    ],
+)
+def test_validate_polecat_branch_content_gate_rejects_disarmed_halt_path(
+    tmp_path, original, replacement, expected
+) -> None:
+    pack_source = gastown_formulas_copy(tmp_path)
+    path = pack_source / "formulas" / "mol-polecat-work.toml"
+    text = path.read_text(encoding="utf-8")
+    assert text.count(original) == 1
+    path.write_text(text.replace(original, replacement), encoding="utf-8")
+
+    with pytest.raises(gascity_pack_inference_gate.GateError, match=expected):
+        gascity_pack_inference_gate.validate_polecat_branch_content_gate(pack_source)
+
+
+def test_validate_polecat_branch_content_gate_rejects_deleting_the_gates_own_drain_ack(
+    tmp_path,
+) -> None:
+    """The halt-path window ends at the push, so it spans the next halt too.
+
+    An unanchored ``gc runtime drain-ack`` fragment is therefore satisfied by
+    the auto_push=false halt's own copy, and deleting the branch-content gate's
+    drain-ack left the validator green. The fragment is anchored to the
+    escalation loop's ``done`` instead, which occurs only in this gate.
+    """
+    pack_source = gastown_formulas_copy(tmp_path)
+    path = pack_source / "formulas" / "mol-polecat-work.toml"
+    text = path.read_text(encoding="utf-8")
+    original = "    done\n    gc runtime drain-ack\n    exit 1"
+    assert text.count(original) == 1
+    mutated = text.replace(original, "    done\n    exit 1")
+    path.write_text(mutated, encoding="utf-8")
+
+    # The precondition that makes the rejection below meaningful: the bare
+    # fragment is still present elsewhere in the checked window, so a
+    # containment check on it alone cannot tell the two halts apart.
+    assert "gc runtime drain-ack" in mutated
+
+    with pytest.raises(gascity_pack_inference_gate.GateError, match="halt exit"):
+        gascity_pack_inference_gate.validate_polecat_branch_content_gate(pack_source)
+
+
 def test_validate_methodology_flow_contracts_accept_current_packs() -> None:
     for pack_name in gascity_pack_inference_gate.METHODOLOGY_PACKS:
         gascity_pack_inference_gate.validate_methodology_flow_contract(
@@ -1137,6 +1282,12 @@ def test_gastown_build_workflow_contract_covers_orchestration_roles() -> None:
         "mol-idea-to-plan",
     }
     assert "gc session wake \"$REFINERY_TARGET\"" in contracts["mol-polecat-work"]
+    assert (
+        'COMMITS_AHEAD=$(git rev-list --count "origin/{{base_branch}}..HEAD" 2>/dev/null)'
+        in contracts["mol-polecat-work"]
+    )
+    assert "''|*[!0-9]*) HALT_REASON=content_gate_error ;;" in contracts["mol-polecat-work"]
+    assert "0) HALT_REASON=no_commits ;;" in contracts["mol-polecat-work"]
     assert 'git worktree add --detach "$MERGE_WT" "origin/$TARGET"' in contracts["mol-refinery-patrol"]
     assert 'gc bd close "$WORK" --reason "Merged to $TARGET at $MERGED_SHORT"' in contracts["mol-refinery-patrol"]
     assert "gc bd close $WORK --reason \"Pull request ready: $PR_URL\"" in contracts["mol-refinery-patrol"]


### PR DESCRIPTION
## Problem: a polecat can stamp a refinery handoff having produced nothing

`mol-polecat-work`'s `submit-and-exit` step has a branch-**shape** gate, a clean-state check, a push gate and a push-verification. **None of them detect an empty branch.** On a branch created at the base tip and never committed to, every gate passes:

| gate | on an empty branch |
|---|---|
| branch-shape gate | passes — the branch *is* named `polecat/<bead-id>` |
| final clean-state verification | passes — no commits means a clean tree |
| `git push origin HEAD` | **succeeds**, and creates the ref at the base tip |
| push verification (`git ls-remote` == local HEAD) | passes — the ref exists and matches |

So the bead is reassigned to the refinery and moves forward through the pipeline **looking like success**.

Observed in the wild: `metadata.branch=polecat/<id>` existed on origin pointing at a *former main tip*, with `git log origin/main..origin/polecat/<id>` empty and an empty diff. The only thing that caught it was the refinery's own no-work-on-branch check — one gate slot later, after the handoff had already been stamped and a merge-queue slot consumed. **Without that downstream check it merges as a no-op and the bead closes with the work undone.**

This is worse than a worker that simply idles: an idle worker is *visible* (the bead sits unclaimed and a coordinator notices), whereas a phantom handoff advances the bead into a state that reads as completion.

Reproduced minimally:

```
$ git checkout -b polecat/sys-xxxxx origin/main
$ git rev-list --count origin/main..HEAD   # 0
$ git status --porcelain | wc -l           # 0
$ git push origin HEAD                     # succeeds, ref created
$ git ls-remote origin refs/heads/polecat/sys-xxxxx   # == local HEAD
```

## Change

Add a **branch-content gate** before the push: require at least one commit ahead of `origin/{{base_branch}}`. Zero commits is not a handoff.

The gate deliberately does **not** merely abort. "No code change is warranted" is a legitimate outcome for an investigation bead, and if the only modeled exit is a handoff, an agent that reaches that conclusion has nowhere honest to go — which is a plausible way a phantom handoff gets produced in the first place. So the gate returns the bead open and unassigned with `halt_reason=no_commits`, clears `gc.routed_to`, and requires notes stating what was investigated and why no change is warranted. The conclusion gets *reported* instead of laundered into a merge.

The `verify` step already told the agent that `git log origin/<base>..HEAD` "must show your commits" — that was advice in prose. This makes it a gate that fails closed.

## Validation

- TOML parses; all 11 bash blocks in `submit-and-exit` pass `bash -n`.
- Predicate exercised against a scratch repo reproducing the phantom preconditions above: `rev-list --count` is `0` for the empty branch and `1` once a commit exists, while every pre-existing gate passes in both cases.
