### PR TITLE
fix(gastown): make refinery find-work survive its own claim

### DIFF
--- a/gastown/agents/refinery/prompt.template.md
+++ b/gastown/agents/refinery/prompt.template.md
@@ -325,7 +325,7 @@ alert the witness, not `gc mail send`.
 |------------|----------------|
 | Pour next wisp | `gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{ .DefaultBranch }} --var rig_name={{ .RigName }} --var binding_prefix={{ .BindingPrefix }}` |
 | Burn current wisp | Follow Patrol Lifecycle Discipline Rule 1: pour next wisp, validate `NEXT`, assign it to `$GC_AGENT`, then burn `$CURRENT_WISP`. Never run a standalone burn. |
-| Find assigned work | `gc bd list ${GC_RIG:+--rig="$GC_RIG"} --assignee="$GC_AGENT" --status=open` |
+| Find assigned work | `gc bd list ${GC_RIG:+--rig="$GC_RIG"} --assignee="$GC_AGENT" --status=open,in_progress` — both statuses, comma-separated: a bead you already claimed is in_progress, and a query filtered to open alone can never see it again |
 | Snapshot event position | `gc events --seq` |
 | Wait for assignment | `gc events --watch --type=bead.updated --after=$SEQ` |
 | Read work metadata | `gc bd show $WORK --json \| jq '.[0].metadata'` |

--- a/gastown/formulas/mol-refinery-patrol.toml
+++ b/gastown/formulas/mol-refinery-patrol.toml
@@ -169,9 +169,9 @@ needs = ["check-inbox"]
 description = """
 **Config: event_timeout = {{event_timeout}}**
 
-Search for work beads assigned to you with branch metadata:
+Search for work beads assigned to you — unclaimed, or already claimed by you:
 ```bash
-WORK=$(gc bd list ${GC_RIG:+--rig="$GC_RIG"} --assignee=$GC_AGENT --status=open \
+WORK=$(gc bd list ${GC_RIG:+--rig="$GC_RIG"} --assignee=$GC_AGENT --status=open,in_progress \
   --exclude-type=epic --has-metadata-key=branch --limit=1 --json | jq -r '.[0].id // empty')
 ```
 
@@ -180,6 +180,26 @@ database. Without it, `gc bd list` routes to the HQ database and never
 sees rig-scoped work beads — the `assignee` field alone does not route
 by namespace. For HQ-only refineries `$GC_RIG` is empty and the flag
 expands to nothing.
+
+`--status=open,in_progress` is what makes this query survive its own claim.
+Claiming a bead moves it to `in_progress`, so a filter of `open` alone can
+never see the work this patrol just took: the bead strands in `in_progress`
+with its branch metadata intact and nothing merged, while this step truthfully
+reports an empty queue. It is a leak with a rate — one stranded bead per
+claim, in every rig running this pack (measured in a production rig: the
+stranded count went 1 -> 2 in 30 minutes, with `--status=open` returning
+nothing the whole time and the branches provably unmerged rather than lost).
+
+Both statuses stay narrowed by `--assignee=$GC_AGENT`, so this widens the
+query to *your own* claims only — it never picks up another agent's in-flight
+work. Wisp roots are `ephemeral=true` and this query does not pass
+`--include-infra`, so widening the status cannot make the refinery adopt its
+own patrol wisp. Use the comma-separated form: repeating `-s/--status`
+silently overwrites the previous value instead of unioning them.
+
+Re-finding your own claim is the intended resume path, not a duplicate: a bead
+you claimed but did not land is unfinished work, and the merge-state gate in
+merge-push already closes it as `already_merged` if a previous pass landed it.
 
 If found: read the bead metadata to confirm it has a branch:
 ```bash

--- a/scripts/gascity_pack_inference_gate.py
+++ b/scripts/gascity_pack_inference_gate.py
@@ -117,7 +117,7 @@ GASTOWN_BUILD_WORKFLOW_CONTRACTS = {
         "gc runtime drain-ack",
     ),
     "mol-refinery-patrol": (
-        "gc bd list ${GC_RIG:+--rig=\"$GC_RIG\"} --assignee=$GC_AGENT --status=open",
+        "gc bd list ${GC_RIG:+--rig=\"$GC_RIG\"} --assignee=$GC_AGENT --status=open,in_progress",
         "git rebase origin/$TARGET",
         "{{typecheck_command}}",
         "{{lint_command}}",


### PR DESCRIPTION
## The bug

`mol-refinery-patrol`'s `find-work` step queries `--status=open`, so it can never see the work it just claimed. Claiming a bead moves it to `in_progress`, which the filter excludes. The bead strands in `in_progress` with its branch metadata intact and nothing merged, while the step **truthfully reports an empty queue** and the patrol idles.

This is a leak with a rate, not a one-off: one stranded bead per claim, in every rig running this pack. Measured in a production rig, the stranded count went **1 -> 2 in 30 minutes**, with `--status=open` returning nothing the whole time and the branches provably unmerged rather than lost.

It is also silent in the worst way — the refinery looks healthy-idle and the beads look green, so nothing surfaces the backlog.

## The fix

```diff
- --assignee=$GC_AGENT --status=open
+ --assignee=$GC_AGENT --status=open,in_progress
```

The query is **already narrowed by `--assignee=$GC_AGENT`**, so this widens it to the refinery's *own* claims only — it never picks up another agent's in-flight work.

Re-finding your own claim is the intended resume path, not a duplicate merge: `merge-push`'s merge-state gate already closes a bead as `already_merged` if a previous pass landed it. To be precise about what that gate implements: it is **ancestry-based** (plus a `fork_sha` commit count), not patch-equivalence. A branch that landed externally as a squash would miss it, fall through to the diff-based false-completion guard, and halt for escalation rather than re-merging — fail-safe, but not the seamless resume an earlier draft of this line implied.

The comma-separated form is deliberate — repeating `-s/--status` silently overwrites the previous value instead of unioning them, which `gc bd list --help` calls out explicitly.

## Why the prompt changed too

`gastown/agents/refinery/prompt.template.md`'s "Find assigned work" quick-reference row taught the **same** blind query. Fixing only the formula would have left the cheat sheet teaching the bug.

## Verification

- Reproduced against a live store: `--status=open` returns empty while `--status=in_progress` returns the stranded work beads, same assignee, branch metadata intact.
- The fixed query returns a bead that `--status=open` could not see.
- **Wisp safety:** the shipped query **retains** the `--has-metadata-key=branch` filter — what follows is an extra robustness experiment, not a description of the change. Even with that filter dropped, the widened query still matched only real work beads and no patrol wisp. The verified belt is tier exclusion: wisp roots are `ephemeral=true` and this query does not pass `--include-infra`, so widening the status cannot make the refinery adopt its own wisp. (Review correction: `--has-metadata-key=branch` is not an independent second belt — no bead in the measured store carries a `branch` key at all, so that probe cannot discriminate on its own. Tier exclusion is the guard that actually holds.)
- `gastown/tests/test_gastown_pack_assets.sh` passes; `tests/test_no_bare_bd_commands.py` passes; formula TOML parses with all 9 steps intact.

## Relationship to #287

Independent — no file overlap (#287 touches the `agent.toml`s and `worktree-setup.sh`). Mergeable in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
