### PR TITLE
fix(slack-full): reply-current inherits thread_ts from the latest threaded inbound

### DIFF
--- a/slack-full/CHANGELOG.md
+++ b/slack-full/CHANGELOG.md
@@ -8,6 +8,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `gc slack reply-current` now inherits the thread from the latest
+  inbound (gp-i62): a thread-reply inbound's transcript entry carries
+  the Slack `thread_ts` in `ReplyToMessageID`, and the reply anchors
+  there by default — including when `--conversation-id` names the same
+  conversation explicitly, which previously always posted at channel
+  level (live burns 2026-08-09, #gastown + #fundraising). An unthreaded
+  inbound keeps the channel-level reply; an explicit target naming a
+  *different* conversation never borrows the inbound's thread anchor;
+  a failed lookup degrades to channel level with a stderr warning
+  (`--via adapter` must survive a gc outage). New `--no-thread` flag
+  forces a channel-level post. `--thread-current` now anchors at the
+  thread ROOT when the latest inbound was itself a thread reply —
+  Slack threads hang off the parent ts, so anchoring at the child
+  stranded the reply. Retires the fleet-memory workaround of routing
+  threaded replies through `publish-to-channel --thread-ts`.
+
 ### Added
 
 - Accidental-mrkdwn guard on the send path (gp-o42): `gc slack

--- a/slack-full/CHANGELOG.md
+++ b/slack-full/CHANGELOG.md
@@ -25,6 +25,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Slack threads hang off the parent ts, so anchoring at the child
   stranded the reply. Retires the fleet-memory workaround of routing
   threaded replies through `publish-to-channel --thread-ts`.
+  `reply-current` now also reports the anchor it used —
+  `reply_to_message_id` in the result JSON, plus an `inheriting thread
+  <ts> from inbound <mid>` line on stderr when inheritance fires — so a
+  reply that lands in an unexpected thread can be traced to the inbound
+  that donated the anchor. The inherited anchor is the conversation's
+  newest inbound, not provably the message being answered (nothing on
+  the wire identifies which inbound woke the session); the limitation
+  and its `--reply-to` escape hatch are documented in
+  `commands/reply-current/help.md`.
+- `gc slack upload --thread-current` anchors at the thread ROOT too,
+  matching the parity its help text promises with `gc slack
+  reply-current`. It consumed a message-id-only lookup that dropped the
+  thread root, so a file uploaded in answer to a thread reply anchored
+  at the child ts and stranded outside the thread.
+- A *wedged* gc (connection accepted, then stalled) no longer crashes
+  callers whose degrade guards catch `GCAPIError`: the HTTP helper
+  wraps `TimeoutError` — raised bare out of `resp.read()`, an `OSError`
+  rather than a `URLError` — so a stalled lookup degrades like a
+  refused one instead of killing the reply with a traceback. The wrap
+  covers the stall's siblings too: a gc killed mid-response sends an
+  RST and `resp.read()` raises `ConnectionResetError`, so every
+  transport `OSError` now reaches callers in that same currency.
 
 ### Added
 

--- a/slack-full/README.md
+++ b/slack-full/README.md
@@ -65,7 +65,9 @@ Implemented:
 - [x] `gc slack reply-current` — reply to the latest Slack event in the
       current session, by default through gc's `/extmsg/outbound` so
       transcript recording + peer fanout fire (`--via adapter` keeps the
-      old direct-to-adapter path for diagnostics)
+      old direct-to-adapter path for diagnostics). A thread-reply
+      inbound is answered in its thread by default (`--no-thread`
+      forces a channel-level post)
 - [x] `gc slack publish` — publish to a session's saved binding (target
       session required, no event-scan fallback — fail-fast when the
       session has no active binding)

--- a/slack-full/commands/reply-current/help.md
+++ b/slack-full/commands/reply-current/help.md
@@ -4,11 +4,18 @@ The session's recent transcript is scanned for the most recent
 `extmsg.inbound` system-reminder. The reply is published through the
 local Slack adapter's /publish endpoint to the same conversation.
 
+When that latest inbound was a thread reply, the reply inherits its
+thread_ts and lands in the same thread — including when
+--conversation-id names the same conversation explicitly. An
+unthreaded inbound keeps the channel-level reply. Use --no-thread to
+force a channel-level post, or --reply-to <ts> to anchor elsewhere.
+
 Examples:
   gc slack reply-current --body "ack"
   gc slack reply-current --body-file /tmp/reply.txt
   gc slack reply-current --turn-ref gct-0123456789abcdef0123 --body-file /tmp/reply.txt
   gc slack reply-current --conversation-id D0B0TTS550F --body "explicit channel"
+  gc slack reply-current --body "top-level on purpose" --no-thread
 
 If the session has no inbound history, --conversation-id is required.
 

--- a/slack-full/commands/reply-current/help.md
+++ b/slack-full/commands/reply-current/help.md
@@ -9,6 +9,21 @@ thread_ts and lands in the same thread — including when
 --conversation-id names the same conversation explicitly. An
 unthreaded inbound keeps the channel-level reply. Use --no-thread to
 force a channel-level post, or --reply-to <ts> to anchor elsewhere.
+--thread-current threads under that latest inbound either way, at its
+thread root when it was a thread reply and at its own ts when it was
+not.
+
+The inherited anchor is the newest inbound in the conversation, which
+is not always the message being answered: in a shared channel, a
+threaded message from someone else that arrives between that message
+and this reply becomes the anchor, and the reply lands in their thread
+instead. Nothing on the wire identifies which inbound woke the
+session, so the command cannot tell the two apart. Pass --reply-to
+<ts> when the anchor has to be exact, or --no-thread to stay at
+channel level. When inheritance fires it prints `inheriting thread
+<ts> from inbound <mid>` on stderr and reports reply_to_message_id in
+the result JSON, so a reply that lands in an unexpected thread can be
+traced back to the inbound that donated the anchor.
 
 Examples:
   gc slack reply-current --body "ack"

--- a/slack-full/commands/upload/help.md
+++ b/slack-full/commands/upload/help.md
@@ -47,7 +47,12 @@ gc slack upload --file /tmp/raw.csv --filename results.csv --title "Run 42 metri
 - `--thread-ts TS` — Slack message ts to thread under. Mutually
   exclusive with `--thread-current`.
 - `--thread-current` — thread under the latest inbound for this
-  session, same logic as `gc slack reply-current`.
+  session, at that inbound's thread root when it was itself a thread
+  reply — same logic as `gc slack reply-current`. That anchor is the
+  conversation's newest inbound, not provably the message being
+  answered: in a busy shared channel someone else's threaded message
+  can arrive first and become the anchor. Pass `--thread-ts <ts>` when
+  the anchor has to be exact.
 - `--idempotency-key KEY` — caller-supplied idempotency key for
   retries.
 - `--via {gc,adapter}` — routing path. `gc` (default) records the

--- a/slack-full/scripts/slack_chat_reply_current.py
+++ b/slack-full/scripts/slack_chat_reply_current.py
@@ -8,6 +8,12 @@ The lookup order:
    current session, and reply to the same conversation.
 3. If neither yields a target, fall back to the session's saved
    extmsg binding.
+
+Threading: when the latest inbound routed to this session was a thread
+reply, the reply inherits its thread_ts and lands in the same thread —
+including when --conversation-id names the same conversation explicitly
+(gp-i62). --reply-to / --thread-current still override the anchor, and
+--no-thread forces a channel-level post.
 """
 
 from __future__ import annotations
@@ -232,8 +238,18 @@ def main(argv: list[str]) -> int:
         action="store_true",
         help=(
             "Thread the reply under the latest inbound message routed to "
-            "this session (resolved via gc transcript). Cannot be combined "
+            "this session (resolved via gc transcript; a thread-reply "
+            "inbound anchors at its thread root). Cannot be combined "
             "with --reply-to. If no recent inbound is found, fails fast."
+        ),
+    )
+    parser.add_argument(
+        "--no-thread",
+        action="store_true",
+        help=(
+            "Force a channel-level post even when the latest inbound was a "
+            "thread reply (by default the reply inherits that thread_ts). "
+            "Cannot be combined with --reply-to or --thread-current."
         ),
     )
     parser.add_argument("--idempotency-key", default="",
@@ -280,16 +296,43 @@ def main(argv: list[str]) -> int:
         raise SystemExit("missing slack account_id (SLACK_WORKSPACE_ID env)")
 
     reply_to = args.reply_to
+    if args.no_thread and (reply_to or args.thread_current):
+        raise SystemExit(
+            "--no-thread cannot be combined with --reply-to or --thread-current")
     if args.thread_current:
         if reply_to:
             raise SystemExit("pass --reply-to OR --thread-current, not both")
-        match = common.find_latest_inbound_message_id_for_session(session_id)
+        match = common.find_latest_inbound_thread_for_session(session_id)
         if match is None:
             raise SystemExit(
                 "no recent inbound transcript entry for this session; "
                 "cannot thread without --reply-to <ts>"
             )
-        reply_to = match[0]
+        mid, thread_root, _conv = match
+        # A thread-reply inbound anchors at its thread ROOT, not its own
+        # ts — Slack threads hang off the parent message, and a thread_ts
+        # pointing at a child strands the reply outside the conversation.
+        reply_to = thread_root or mid
+    elif not reply_to and not args.no_thread:
+        # gp-i62: a threaded inbound means the human is talking to this
+        # session IN that thread — "reply to the latest inbound" must land
+        # there, not at channel level. Inherit the inbound's thread_ts,
+        # including when --conversation-id names the conversation
+        # explicitly. Guard on conversation match so an explicit target
+        # pointing elsewhere never borrows a foreign thread anchor, and
+        # stay best-effort: no inbound / unthreaded inbound / transcript
+        # miss / gc outage (--via adapter still works then) all keep the
+        # channel-level behavior.
+        try:
+            match = common.find_latest_inbound_thread_for_session(session_id)
+        except common.GCAPIError as exc:
+            print(f"warning: thread-inheritance lookup failed, posting at "
+                  f"channel level: {exc}", file=sys.stderr)
+            match = None
+        if match is not None:
+            _mid, thread_root, inbound_conv = match
+            if thread_root and inbound_conv.get("conversation_id") == conv["conversation_id"]:
+                reply_to = thread_root
 
     idempotency_key = args.idempotency_key.strip()
     if not idempotency_key:

--- a/slack-full/scripts/slack_chat_reply_current.py
+++ b/slack-full/scripts/slack_chat_reply_current.py
@@ -9,11 +9,12 @@ The lookup order:
 3. If neither yields a target, fall back to the session's saved
    extmsg binding.
 
-Threading: when the latest inbound routed to this session was a thread
-reply, the reply inherits its thread_ts and lands in the same thread —
-including when --conversation-id names the same conversation explicitly
-(gp-i62). --reply-to / --thread-current still override the anchor, and
---no-thread forces a channel-level post.
+Threading: when the latest inbound in the conversation this session
+last heard from was a thread reply, the reply inherits its thread_ts
+and lands in the same thread — including when --conversation-id names
+the same conversation explicitly (gp-i62). --reply-to /
+--thread-current still override the anchor, and --no-thread forces a
+channel-level post.
 """
 
 from __future__ import annotations
@@ -237,10 +238,11 @@ def main(argv: list[str]) -> int:
         "--thread-current",
         action="store_true",
         help=(
-            "Thread the reply under the latest inbound message routed to "
-            "this session (resolved via gc transcript; a thread-reply "
-            "inbound anchors at its thread root). Cannot be combined "
-            "with --reply-to. If no recent inbound is found, fails fast."
+            "Thread the reply under the latest inbound message in the "
+            "conversation this session last heard from (resolved via gc "
+            "transcript; a thread-reply inbound anchors at its thread "
+            "root). Cannot be combined with --reply-to. If no recent "
+            "inbound is found, fails fast."
         ),
     )
     parser.add_argument(
@@ -330,9 +332,18 @@ def main(argv: list[str]) -> int:
                   f"channel level: {exc}", file=sys.stderr)
             match = None
         if match is not None:
-            _mid, thread_root, inbound_conv = match
+            mid, thread_root, inbound_conv = match
             if thread_root and inbound_conv.get("conversation_id") == conv["conversation_id"]:
                 reply_to = thread_root
+                # The degraded path warns, but the success path rewrites
+                # the reply target silently. Say which anchor was
+                # inherited and which inbound donated it: the lookup takes
+                # the conversation's newest inbound, not provably the one
+                # being answered (see find_latest_inbound_thread_for_session),
+                # so this line is what makes a misthreaded reply
+                # reproducible from a field report.
+                print(f"inheriting thread {thread_root} from inbound {mid}",
+                      file=sys.stderr)
 
     idempotency_key = args.idempotency_key.strip()
     if not idempotency_key:
@@ -365,6 +376,10 @@ def main(argv: list[str]) -> int:
     print(json.dumps({
         "conversation_id": conv["conversation_id"],
         "session_id": session_id,
+        # Empty for a channel-level post; the anchor is reported whether it
+        # came from --reply-to, --thread-current, or inheritance, so the
+        # thread a reply landed in is recoverable from the command output.
+        "reply_to_message_id": reply_to,
         "via": args.via,
         "result": result,
     }, indent=2))

--- a/slack-full/scripts/slack_chat_upload.py
+++ b/slack-full/scripts/slack_chat_upload.py
@@ -83,9 +83,11 @@ def main(argv: list[str]) -> int:
                         help="Slack message ts to thread under. Mutually "
                              "exclusive with --thread-current.")
     parser.add_argument("--thread-current", action="store_true",
-                        help="Thread under the latest inbound for this session "
-                             "(same logic as `gc slack reply-current`). "
-                             "Mutually exclusive with --thread-ts.")
+                        help="Thread under the latest inbound for this session, "
+                             "at that inbound's thread root when it was itself "
+                             "a thread reply (same logic as `gc slack "
+                             "reply-current`). Mutually exclusive with "
+                             "--thread-ts.")
     parser.add_argument("--idempotency-key", default="",
                         help="Caller-supplied idempotency key for retries.")
     parser.add_argument(
@@ -129,12 +131,18 @@ def main(argv: list[str]) -> int:
 
     thread_ts = args.thread_ts.strip()
     if args.thread_current:
-        match = common.find_latest_inbound_message_id_for_session(session_id)
+        match = common.find_latest_inbound_thread_for_session(session_id)
         if not match:
             raise SystemExit(
                 f"session {session_id!r} has no inbound to thread under; "
                 "pass --thread-ts <ts> explicitly or omit threading")
-        thread_ts = match[0]
+        mid, thread_root, _conv = match
+        # Same anchoring as `gc slack reply-current --thread-current`, which
+        # help.md promises: a thread-reply inbound anchors at its thread
+        # ROOT, since a thread_ts pointing at a child strands the upload
+        # outside the thread the human is reading (gp-i62). An unthreaded
+        # inbound still anchors at its own ts.
+        thread_ts = thread_root or mid
 
     try:
         if args.via == "adapter":

--- a/slack-full/scripts/slack_intake_common.py
+++ b/slack-full/scripts/slack_intake_common.py
@@ -405,14 +405,35 @@ def find_latest_inbound_message_id_for_session(
     """Find the latest inbound transcript entry routed to this session.
 
     Returns (provider_message_id, conversation_dict) on hit, or None if no
-    inbound has reached this session yet.
+    inbound has reached this session yet. Thin wrapper over
+    find_latest_inbound_thread_for_session for callers that only need the
+    message id (react/upload anchoring).
+    """
+    match = find_latest_inbound_thread_for_session(session_id)
+    if match is None:
+        return None
+    mid, _thread_root, conv = match
+    return mid, conv
+
+
+def find_latest_inbound_thread_for_session(
+    session_id: str,
+) -> tuple[str, str, dict[str, str]] | None:
+    """Find the latest inbound transcript entry routed to this session.
+
+    Returns (provider_message_id, thread_root, conversation_dict) on hit,
+    or None if no inbound has reached this session yet. thread_root is the
+    entry's ReplyToMessageID — the Slack thread_ts the adapter stamps on a
+    thread-reply inbound — or "" when the inbound was a plain channel/DM
+    message (gp-i62).
 
     The lookup chain:
       1. Find the latest extmsg.inbound event targeting this session.
       2. Read its conversation_id from the event payload.
       3. Query the transcript for that conversation newest-first
          (order=desc, gascity#3128), take the first entry whose
-         Kind=="inbound", and return its ProviderMessageID.
+         Kind=="inbound", and return its ProviderMessageID +
+         ReplyToMessageID.
 
     Two queries (event + transcript) because the inbound event payload
     intentionally does NOT carry message_id — that field lives in the
@@ -455,8 +476,11 @@ def find_latest_inbound_message_id_for_session(
         if (entry.get("Kind") or entry.get("kind")) == "inbound":
             mid = (entry.get("ProviderMessageID") or entry.get("provider_message_id") or "").strip()
             if mid:
+                thread_root = (
+                    entry.get("ReplyToMessageID") or entry.get("reply_to_message_id") or ""
+                ).strip()
                 conv = entry.get("Conversation") or entry.get("conversation") or {}
-                return mid, {
+                return mid, thread_root, {
                     "scope_id": conv.get("ScopeID") or conv.get("scope_id") or gc_city_name(),
                     "provider": conv.get("Provider") or conv.get("provider") or provider,
                     "account_id": conv.get("AccountID") or conv.get("account_id") or workspace,

--- a/slack-full/scripts/slack_intake_common.py
+++ b/slack-full/scripts/slack_intake_common.py
@@ -173,6 +173,23 @@ def _request(method: str, url: str, body: dict[str, Any] | None = None,
         raise GCAPIError(f"{method} {url} -> {exc.code}: {detail}") from exc
     except urllib.error.URLError as exc:
         raise GCAPIError(f"{method} {url} failed: {exc}") from exc
+    except TimeoutError as exc:
+        # A *wedged* gc — headers sent, body stalled — surfaces here as a
+        # bare TimeoutError out of resp.read(), not as a URLError, so
+        # callers whose degrade guards catch GCAPIError (best-effort
+        # lookups like find_latest_inbound_thread_for_session) would crash
+        # on the one outage shape they exist to survive. socket.timeout is
+        # an alias of TimeoutError on the Python versions this pack runs.
+        raise GCAPIError(f"{method} {url} timed out after {timeout}s") from exc
+    except OSError as exc:
+        # The stall's siblings: a gc that dies mid-response sends an RST and
+        # resp.read() raises ConnectionResetError, which is neither a
+        # URLError nor a TimeoutError and so escapes both arms above. Keep
+        # every transport failure in the one currency best-effort callers
+        # degrade on. This arm must stay last: URLError and TimeoutError are
+        # both OSError subclasses and would otherwise be swallowed here,
+        # losing their more specific messages.
+        raise GCAPIError(f"{method} {url} failed: {exc}") from exc
     if not raw:
         return {}
     try:
@@ -402,12 +419,14 @@ def find_latest_inbound_for_session(session_id: str) -> dict[str, Any] | None:
 def find_latest_inbound_message_id_for_session(
     session_id: str,
 ) -> tuple[str, dict[str, str]] | None:
-    """Find the latest inbound transcript entry routed to this session.
+    """Find the latest inbound in the conversation this session last heard from.
 
     Returns (provider_message_id, conversation_dict) on hit, or None if no
     inbound has reached this session yet. Thin wrapper over
     find_latest_inbound_thread_for_session for callers that only need the
-    message id (react/upload anchoring).
+    message id (react anchoring, which attaches to a specific message and
+    so wants the inbound's own ts rather than its thread root). Inherits
+    that function's anchor caveat.
     """
     match = find_latest_inbound_thread_for_session(session_id)
     if match is None:
@@ -419,7 +438,7 @@ def find_latest_inbound_message_id_for_session(
 def find_latest_inbound_thread_for_session(
     session_id: str,
 ) -> tuple[str, str, dict[str, str]] | None:
-    """Find the latest inbound transcript entry routed to this session.
+    """Find the latest inbound in the conversation this session last heard from.
 
     Returns (provider_message_id, thread_root, conversation_dict) on hit,
     or None if no inbound has reached this session yet. thread_root is the
@@ -435,10 +454,21 @@ def find_latest_inbound_thread_for_session(
          Kind=="inbound", and return its ProviderMessageID +
          ReplyToMessageID.
 
-    Two queries (event + transcript) because the inbound event payload
-    intentionally does NOT carry message_id — that field lives in the
-    transcript and is the canonical source. See engdocs/architecture/
-    api-control-plane.md for the typed-wire rationale.
+    Anchor caveat, deliberate: step 3 resolves the newest inbound of the
+    *conversation*, which is not necessarily the message that woke this
+    session. Every message in a bound room routes to the bound session and
+    is transcribed, so in a busy shared channel a threaded message that
+    lands between the one being answered and the reply becomes the anchor,
+    and the reply joins that newer thread. Binding the pick to a single
+    message would need an identity the wire does not carry: the
+    extmsg.inbound payload is {provider, conversation_id, actor,
+    target_session, target_agent} with no message id — that field lives in
+    the transcript, the canonical source (see engdocs/architecture/
+    api-control-plane.md for the typed-wire rationale), which is why this
+    is two queries — and nothing hands the command the inbound it is
+    answering. Callers that must anchor exactly pass an explicit ts;
+    reply-current exposes that as --reply-to and documents the limitation
+    in commands/reply-current/help.md.
 
     The transcript query MUST be newest-first: the endpoint's oldest-first
     default with a bounded limit hides the most recent inbound on busy

--- a/slack-full/tests/gc_mock.py
+++ b/slack-full/tests/gc_mock.py
@@ -197,17 +197,21 @@ class GcMock:
         provider_message_id: str,
         message_kind: str = "inbound",
         account_id: str = "T0TESTWS",
+        reply_to_message_id: str = "",
     ) -> None:
         """Seed a transcript entry for ``GET /extmsg/transcript`` lookups.
 
         ``message_kind`` is the transcript-row Kind ("inbound" / "outbound").
         ``--thread-current`` resolves the latest *inbound* entry for the
-        session's conversation.
+        session's conversation. ``reply_to_message_id`` mirrors the thread
+        root ts the adapter stamps on a thread-reply inbound (gp-i62);
+        empty means a plain channel/DM message.
         """
         key = (provider, conversation_id, kind)
         entry = {
             "Kind": message_kind,
             "ProviderMessageID": provider_message_id,
+            "ReplyToMessageID": reply_to_message_id,
             "Conversation": {
                 "ScopeID": self.city_name,
                 "Provider": provider,

--- a/slack-full/tests/test_inbound_event_scan.py
+++ b/slack-full/tests/test_inbound_event_scan.py
@@ -137,3 +137,46 @@ def test_truncated_scan_warns_on_stderr(
     err = capsys.readouterr().err
     assert "truncated to 0/750" in err
     assert err.count("warning: inbound event scan") == len(common._INBOUND_SCAN_WINDOWS)
+
+
+def test_thread_lookup_returns_root_for_threaded_inbound(gc_mock: "GcMock") -> None:
+    # gp-i62: the transcript entry for a thread-reply inbound carries the
+    # thread root in ReplyToMessageID (adapter stamps Slack's thread_ts
+    # there). The full event→transcript chain must surface it so
+    # reply-current can inherit the thread.
+    common = _import_common()
+    gc_mock.register_inbound_event(
+        target_session="gc-test-session", conversation_id="C0THREADED",
+    )
+    gc_mock.register_transcript_entry(
+        conversation_id="C0THREADED",
+        provider_message_id="1786291407.960839",
+        reply_to_message_id="1786250478.963679",
+    )
+
+    match = common.find_latest_inbound_thread_for_session("gc-test-session")
+
+    assert match is not None
+    mid, thread_root, conv = match
+    assert mid == "1786291407.960839"
+    assert thread_root == "1786250478.963679"
+    assert conv["conversation_id"] == "C0THREADED"
+
+
+def test_thread_lookup_returns_empty_root_for_plain_inbound(gc_mock: "GcMock") -> None:
+    common = _import_common()
+    gc_mock.register_inbound_event(
+        target_session="gc-test-session", conversation_id="C0PLAIN",
+    )
+    gc_mock.register_transcript_entry(
+        conversation_id="C0PLAIN",
+        provider_message_id="1786291407.960839",
+    )
+
+    match = common.find_latest_inbound_thread_for_session("gc-test-session")
+
+    assert match is not None
+    mid, thread_root, conv = match
+    assert mid == "1786291407.960839"
+    assert thread_root == ""
+    assert conv["conversation_id"] == "C0PLAIN"

--- a/slack-full/tests/test_slack_chat_reply_current.py
+++ b/slack-full/tests/test_slack_chat_reply_current.py
@@ -236,6 +236,249 @@ def test_reply_current_exits_nonzero_on_gc_outbound_delivered_false(
 
 
 # --------------------------------------------------------------------------
+# Thread inheritance from the latest inbound (gp-i62).
+# --------------------------------------------------------------------------
+
+
+def _inbound_conv(conversation_id: str) -> dict[str, str]:
+    return {
+        "scope_id": "test-city",
+        "provider": "slack",
+        "account_id": "T0TESTWS",
+        "conversation_id": conversation_id,
+        "kind": "room",
+    }
+
+
+def test_threaded_inbound_inherits_thread_ts(monkeypatch: pytest.MonkeyPatch) -> None:
+    """gp-i62 repro: threaded inbound + explicit --conversation-id.
+
+    Twice on 2026-08-09 an inbound carrying thread context ('in thread
+    1786250478.963679') was answered with reply-current --conversation-id,
+    and the reply landed at CHANNEL level. The reply must inherit the
+    inbound's thread root by default.
+    """
+    rc, common = _import_modules()
+    captured: dict[str, Any] = {}
+
+    def fake_request(method: str, url: str, body: dict[str, Any] | None = None,
+                     *, csrf: bool = True, timeout: float = 30.0) -> dict[str, Any]:
+        captured["body"] = body
+        return {"Receipt": {"Delivered": True}}
+
+    monkeypatch.setattr(common, "_request", fake_request)
+    monkeypatch.setattr(
+        common, "find_latest_inbound_thread_for_session",
+        lambda _sid: ("1786291407.960839", "1786250478.963679", _inbound_conv("C0GASTOWN")))
+
+    exit_code = rc.main([
+        "--session", "gc-test-session",
+        "--conversation-id", "C0GASTOWN",
+        "--body", "reply",
+    ])
+    assert exit_code == 0
+    assert captured["body"]["reply_to_message_id"] == "1786250478.963679"
+
+
+def test_unthreaded_inbound_stays_channel_level(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A plain (unthreaded) inbound keeps the channel-level reply."""
+    rc, common = _import_modules()
+    captured: dict[str, Any] = {}
+
+    def fake_request(method: str, url: str, body: dict[str, Any] | None = None,
+                     *, csrf: bool = True, timeout: float = 30.0) -> dict[str, Any]:
+        captured["body"] = body
+        return {"Receipt": {"Delivered": True}}
+
+    monkeypatch.setattr(common, "_request", fake_request)
+    monkeypatch.setattr(
+        common, "find_latest_inbound_thread_for_session",
+        lambda _sid: ("1786291407.960839", "", _inbound_conv("C0GASTOWN")))
+
+    exit_code = rc.main([
+        "--session", "gc-test-session",
+        "--conversation-id", "C0GASTOWN",
+        "--body", "reply",
+    ])
+    assert exit_code == 0
+    assert "reply_to_message_id" not in captured["body"]
+
+
+def test_thread_not_inherited_across_conversations(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An explicit --conversation-id naming a DIFFERENT conversation than the
+    latest inbound must not borrow that inbound's thread anchor — a foreign
+    thread_ts would strand the reply."""
+    rc, common = _import_modules()
+    captured: dict[str, Any] = {}
+
+    def fake_request(method: str, url: str, body: dict[str, Any] | None = None,
+                     *, csrf: bool = True, timeout: float = 30.0) -> dict[str, Any]:
+        captured["body"] = body
+        return {"Receipt": {"Delivered": True}}
+
+    monkeypatch.setattr(common, "_request", fake_request)
+    monkeypatch.setattr(
+        common, "find_latest_inbound_thread_for_session",
+        lambda _sid: ("1786291407.960839", "1786250478.963679", _inbound_conv("C0ELSEWHERE")))
+
+    exit_code = rc.main([
+        "--session", "gc-test-session",
+        "--conversation-id", "C0GASTOWN",
+        "--body", "reply",
+    ])
+    assert exit_code == 0
+    assert "reply_to_message_id" not in captured["body"]
+
+
+def test_no_thread_flag_forces_channel_level(monkeypatch: pytest.MonkeyPatch) -> None:
+    rc, common = _import_modules()
+    captured: dict[str, Any] = {}
+
+    def fake_request(method: str, url: str, body: dict[str, Any] | None = None,
+                     *, csrf: bool = True, timeout: float = 30.0) -> dict[str, Any]:
+        captured["body"] = body
+        return {"Receipt": {"Delivered": True}}
+
+    monkeypatch.setattr(common, "_request", fake_request)
+    monkeypatch.setattr(
+        common, "find_latest_inbound_thread_for_session",
+        lambda _sid: ("1786291407.960839", "1786250478.963679", _inbound_conv("C0GASTOWN")))
+
+    exit_code = rc.main([
+        "--session", "gc-test-session",
+        "--conversation-id", "C0GASTOWN",
+        "--body", "reply",
+        "--no-thread",
+    ])
+    assert exit_code == 0
+    assert "reply_to_message_id" not in captured["body"]
+
+
+def test_no_thread_rejects_reply_to_combination(monkeypatch: pytest.MonkeyPatch) -> None:
+    rc, common = _import_modules()
+    monkeypatch.setattr(common, "find_latest_inbound_for_session", lambda _sid: None)
+    monkeypatch.setattr(common, "look_up_binding", lambda _sid: None)
+    with pytest.raises(SystemExit, match="--no-thread cannot be combined"):
+        rc.main([
+            "--session", "gc-test-session",
+            "--conversation-id", "C0GASTOWN",
+            "--body", "x",
+            "--reply-to", "1700000.000100",
+            "--no-thread",
+        ])
+
+
+def test_explicit_reply_to_wins_over_inherited_thread(monkeypatch: pytest.MonkeyPatch) -> None:
+    rc, common = _import_modules()
+    captured: dict[str, Any] = {}
+
+    def fake_request(method: str, url: str, body: dict[str, Any] | None = None,
+                     *, csrf: bool = True, timeout: float = 30.0) -> dict[str, Any]:
+        captured["body"] = body
+        return {"Receipt": {"Delivered": True}}
+
+    monkeypatch.setattr(common, "_request", fake_request)
+
+    def fail_lookup(_sid: str):
+        raise AssertionError("--reply-to must not trigger the inheritance lookup")
+
+    monkeypatch.setattr(common, "find_latest_inbound_thread_for_session", fail_lookup)
+
+    exit_code = rc.main([
+        "--session", "gc-test-session",
+        "--conversation-id", "C0GASTOWN",
+        "--body", "reply",
+        "--reply-to", "1700000.000100",
+    ])
+    assert exit_code == 0
+    assert captured["body"]["reply_to_message_id"] == "1700000.000100"
+
+
+def test_thread_current_anchors_at_thread_root(monkeypatch: pytest.MonkeyPatch) -> None:
+    """--thread-current on a thread-reply inbound anchors at the ROOT ts.
+
+    Slack threads hang off the parent message; thread_ts pointing at a
+    child message strands the reply. Before gp-i62 this used the child's
+    own ts."""
+    rc, common = _import_modules()
+    captured: dict[str, Any] = {}
+
+    def fake_request(method: str, url: str, body: dict[str, Any] | None = None,
+                     *, csrf: bool = True, timeout: float = 30.0) -> dict[str, Any]:
+        captured["body"] = body
+        return {"Receipt": {"Delivered": True}}
+
+    monkeypatch.setattr(common, "_request", fake_request)
+    monkeypatch.setattr(
+        common, "find_latest_inbound_thread_for_session",
+        lambda _sid: ("1786291407.960839", "1786250478.963679", _inbound_conv("C0GASTOWN")))
+
+    exit_code = rc.main([
+        "--session", "gc-test-session",
+        "--conversation-id", "C0GASTOWN",
+        "--body", "reply",
+        "--thread-current",
+    ])
+    assert exit_code == 0
+    assert captured["body"]["reply_to_message_id"] == "1786250478.963679"
+
+
+def test_thread_current_unthreaded_uses_own_ts(monkeypatch: pytest.MonkeyPatch) -> None:
+    """--thread-current on a plain inbound threads under that message itself."""
+    rc, common = _import_modules()
+    captured: dict[str, Any] = {}
+
+    def fake_request(method: str, url: str, body: dict[str, Any] | None = None,
+                     *, csrf: bool = True, timeout: float = 30.0) -> dict[str, Any]:
+        captured["body"] = body
+        return {"Receipt": {"Delivered": True}}
+
+    monkeypatch.setattr(common, "_request", fake_request)
+    monkeypatch.setattr(
+        common, "find_latest_inbound_thread_for_session",
+        lambda _sid: ("1786291407.960839", "", _inbound_conv("C0GASTOWN")))
+
+    exit_code = rc.main([
+        "--session", "gc-test-session",
+        "--conversation-id", "C0GASTOWN",
+        "--body", "reply",
+        "--thread-current",
+    ])
+    assert exit_code == 0
+    assert captured["body"]["reply_to_message_id"] == "1786291407.960839"
+
+
+def test_inheritance_lookup_failure_degrades_to_channel_level(
+        monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture) -> None:
+    """A gc outage during the best-effort inheritance lookup must not sink
+    the reply (--via adapter works without gc) — warn and post unthreaded."""
+    rc, common = _import_modules()
+    captured: dict[str, Any] = {}
+
+    def fake_request(method: str, url: str, body: dict[str, Any] | None = None,
+                     *, csrf: bool = True, timeout: float = 30.0) -> dict[str, Any]:
+        captured["body"] = body
+        return {"delivered": True}
+
+    monkeypatch.setattr(common, "_request", fake_request)
+
+    def failing_lookup(_sid: str):
+        raise common.GCAPIError("GET /events failed: connection refused")
+
+    monkeypatch.setattr(common, "find_latest_inbound_thread_for_session", failing_lookup)
+
+    exit_code = rc.main([
+        "--session", "gc-test-session",
+        "--conversation-id", "C0GASTOWN",
+        "--body", "reply",
+        "--via", "adapter",
+    ])
+    assert exit_code == 0
+    assert "reply_to_message_id" not in captured["body"]
+    assert "thread-inheritance lookup failed" in capsys.readouterr().err
+
+
+# --------------------------------------------------------------------------
 # Company-context awareness (company rooms 2b) — additive to the legacy path.
 # --------------------------------------------------------------------------
 

--- a/slack-full/tests/test_slack_chat_reply_current.py
+++ b/slack-full/tests/test_slack_chat_reply_current.py
@@ -478,6 +478,135 @@ def test_inheritance_lookup_failure_degrades_to_channel_level(
     assert "thread-inheritance lookup failed" in capsys.readouterr().err
 
 
+def test_inheritance_lookup_timeout_degrades_to_channel_level(
+        monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture) -> None:
+    """A *wedged* gc degrades like a refused one.
+
+    A refused connection reaches the guard as GCAPIError (URLError), but a
+    gc that accepts the connection and then stalls raises a bare
+    TimeoutError out of resp.read() — an OSError, not a GCAPIError. That
+    shape used to escape the degrade guard and kill the reply with a
+    traceback, on a path that made no gc call at all before inheritance
+    existed. _request wraps it so every best-effort caller degrades.
+    """
+    rc, common = _import_modules()
+    published: dict[str, Any] = {}
+
+    def wedged_urlopen(*_args: Any, **_kwargs: Any):
+        raise TimeoutError("timed out")
+
+    # Only the lookup goes over HTTP here; publish is stubbed, so the real
+    # find_latest_inbound_thread_for_session -> _request path runs.
+    monkeypatch.setattr(common.urllib.request, "urlopen", wedged_urlopen)
+    monkeypatch.setattr(
+        common, "publish_via_adapter",
+        lambda **kwargs: published.update(kwargs) or {"delivered": True})
+
+    exit_code = rc.main([
+        "--session", "gc-test-session",
+        "--conversation-id", "C0GASTOWN",
+        "--body", "reply",
+        "--via", "adapter",
+    ])
+    assert exit_code == 0
+    assert published["reply_to_message_id"] == ""
+    assert "thread-inheritance lookup failed" in capsys.readouterr().err
+
+
+def test_request_wraps_timeout_as_gcapi_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_request turns a read timeout into GCAPIError for every caller.
+
+    urllib raises TimeoutError (an OSError, not a URLError) when the server
+    accepts the connection and then stalls, so without this wrap it slips
+    past every `except GCAPIError` degrade guard in the pack.
+    """
+    _rc, common = _import_modules()
+
+    def wedged_urlopen(*_args: Any, **_kwargs: Any):
+        raise TimeoutError("timed out")
+
+    monkeypatch.setattr(common.urllib.request, "urlopen", wedged_urlopen)
+    with pytest.raises(common.GCAPIError) as exc:
+        common._request("GET", "http://127.0.0.1:8372/v0/city/test-city/events",
+                        csrf=False)
+    assert "timed out" in str(exc.value)
+
+
+def test_inheritance_lookup_reset_degrades_to_channel_level(
+        monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture) -> None:
+    """A gc that dies mid-response degrades like one that stalls.
+
+    The stall arrives as TimeoutError, but a gc killed after the headers
+    sends an RST and resp.read() raises ConnectionResetError — neither a
+    URLError nor a TimeoutError, so it escaped both of _request's wrapping
+    arms and killed the reply with a traceback on the same best-effort path
+    the timeout wrap exists to keep alive.
+    """
+    rc, common = _import_modules()
+    published: dict[str, Any] = {}
+
+    class _ResetResponse:
+        def __enter__(self) -> "_ResetResponse":
+            return self
+
+        def __exit__(self, *_exc: Any) -> bool:
+            return False
+
+        def read(self) -> bytes:
+            raise ConnectionResetError(104, "Connection reset by peer")
+
+    # Headers arrive, then the body read is reset: the shape that reaches
+    # read() rather than urlopen(). Publish is stubbed, so the real
+    # find_latest_inbound_thread_for_session -> _request path runs.
+    monkeypatch.setattr(common.urllib.request, "urlopen",
+                        lambda *_a, **_k: _ResetResponse())
+    monkeypatch.setattr(
+        common, "publish_via_adapter",
+        lambda **kwargs: published.update(kwargs) or {"delivered": True})
+
+    exit_code = rc.main([
+        "--session", "gc-test-session",
+        "--conversation-id", "C0GASTOWN",
+        "--body", "reply",
+        "--via", "adapter",
+    ])
+    assert exit_code == 0
+    assert published["reply_to_message_id"] == ""
+    assert "thread-inheritance lookup failed" in capsys.readouterr().err
+
+
+def test_inheritance_logs_the_anchor_and_reports_it(
+        monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture) -> None:
+    """Inheriting an anchor is announced on stderr and in the result JSON.
+
+    The re-anchor is the one decision on the success path that rewrites
+    where the reply lands, and the anchor is the conversation's newest
+    inbound rather than provably the message being answered — so a reply
+    in an unexpected thread has to be traceable to the inbound that
+    donated the ts, or the report is unreproducible.
+    """
+    rc, common = _import_modules()
+
+    def fake_request(method: str, url: str, body: dict[str, Any] | None = None,
+                     *, csrf: bool = True, timeout: float = 30.0) -> dict[str, Any]:
+        return {"Receipt": {"Delivered": True}}
+
+    monkeypatch.setattr(common, "_request", fake_request)
+    monkeypatch.setattr(
+        common, "find_latest_inbound_thread_for_session",
+        lambda _sid: ("1786291407.960839", "1786250478.963679", _inbound_conv("C0GASTOWN")))
+
+    exit_code = rc.main([
+        "--session", "gc-test-session",
+        "--conversation-id", "C0GASTOWN",
+        "--body", "reply",
+    ])
+    assert exit_code == 0
+    streams = capsys.readouterr()
+    assert "inheriting thread 1786250478.963679 from inbound 1786291407.960839" in streams.err
+    assert json.loads(streams.out)["reply_to_message_id"] == "1786250478.963679"
+
+
 # --------------------------------------------------------------------------
 # Company-context awareness (company rooms 2b) — additive to the legacy path.
 # --------------------------------------------------------------------------

--- a/slack-full/tests/test_slack_chat_upload.py
+++ b/slack-full/tests/test_slack_chat_upload.py
@@ -160,19 +160,12 @@ def test_thread_ts_and_idempotency_propagate_through_gc_path(
     assert body["filename"] == "out.txt"
 
 
-def test_thread_current_unwraps_helper_tuple(
+def _upload_thread_current(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: pathlib.Path,
-) -> None:
-    """Regression for the gc-j8h live-smoke bug.
-
-    `find_latest_inbound_message_id_for_session` returns
-    `tuple[str, dict]`; the upload script must extract `match[0]`
-    rather than passing the whole tuple as `thread_ts`. Without
-    the unpack, gc rejects the request with a 422 because
-    `reply_to_message_id` arrives on the wire as a 2-element list
-    instead of a string.
-    """
+    lookup: Any,
+) -> dict[str, Any]:
+    """Run `upload --thread-current` against a stubbed thread lookup."""
     upload, common = _import_modules()
     captured: dict[str, Any] = {}
 
@@ -184,10 +177,7 @@ def test_thread_current_unwraps_helper_tuple(
     monkeypatch.setattr(common, "_request", fake_request)
     monkeypatch.setattr(common, "look_up_binding", lambda _sid: _fake_binding())
     monkeypatch.setattr(
-        common,
-        "find_latest_inbound_message_id_for_session",
-        lambda _sid: ("1777779766.848799", _fake_binding()),
-    )
+        common, "find_latest_inbound_thread_for_session", lookup)
 
     file_path = _make_file(tmp_path)
     upload.main([
@@ -195,10 +185,57 @@ def test_thread_current_unwraps_helper_tuple(
         "--session", "gc-test-session",
         "--thread-current",
     ])
-    body = captured["body"]
-    # Critical: a plain string, NOT the (msg_id, conversation) tuple.
+    return captured["body"]
+
+
+def test_thread_current_unwraps_helper_tuple(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+) -> None:
+    """Regression for the gc-j8h live-smoke bug.
+
+    The lookup returns a tuple; the upload script must extract the ts
+    rather than passing the whole tuple as `thread_ts`. Without the
+    unpack, gc rejects the request with a 422 because
+    `reply_to_message_id` arrives on the wire as a list instead of a
+    string.
+    """
+    body = _upload_thread_current(
+        monkeypatch, tmp_path,
+        lambda _sid: ("1777779766.848799", "", _fake_binding()))
+    # Critical: a plain string, NOT the lookup tuple.
     assert body["reply_to_message_id"] == "1777779766.848799"
     assert isinstance(body["reply_to_message_id"], str)
+
+
+def test_thread_current_anchors_at_thread_root(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+) -> None:
+    """`upload --thread-current` anchors at the ROOT ts of a thread-reply
+    inbound, matching `reply-current --thread-current`.
+
+    upload/help.md promises "same logic as `gc slack reply-current`". While
+    upload consumed the mid-only wrapper, a thread-reply inbound anchored
+    the upload at the child's own ts — Slack hangs threads off the parent,
+    so the file stranded outside the thread the human was reading (gp-i62)
+    and the parity claim was false.
+    """
+    body = _upload_thread_current(
+        monkeypatch, tmp_path,
+        lambda _sid: ("1786291407.960839", "1786250478.963679", _fake_binding()))
+    assert body["reply_to_message_id"] == "1786250478.963679"
+
+
+def test_thread_current_unthreaded_uses_own_ts(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+) -> None:
+    """A plain (unthreaded) inbound still anchors the upload at its own ts."""
+    body = _upload_thread_current(
+        monkeypatch, tmp_path,
+        lambda _sid: ("1786291407.960839", "", _fake_binding()))
+    assert body["reply_to_message_id"] == "1786291407.960839"
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`gc slack reply-current` — "reply to the latest inbound" — drops thread context. When the latest inbound routed to a session is a **thread reply**, the reply posts at **channel level** instead of into the thread. Reproduced live twice on 2026-08-09: the session's inbound reminder carried `Message id: 1786291407.960839 (in thread 1786250478.963679)`, the agent answered with `reply-current --conversation-id Cxxx --body-file f`, and the human found the reply in channel history while the thread contained only their own messages.

The thread root was already recorded end to end: the adapter stamps Slack's `thread_ts` into the inbound's `reply_to_message_id`, and gc surfaces it on the transcript record as `ReplyToMessageID`. `reply-current` just never read it.

## Fix

- New `slack_intake_common.find_latest_inbound_thread_for_session` returns `(provider_message_id, thread_root, conversation)` via the existing event→transcript chain. `find_latest_inbound_message_id_for_session` becomes a thin wrapper, so `react`/`upload` callers are untouched.
- `reply-current` now inherits the inbound's thread root **by default** — including when `--conversation-id` names the same conversation explicitly (the repro shape). Guards:
  - an explicit target naming a *different* conversation never borrows the thread anchor (a foreign `thread_ts` would strand the reply);
  - an unthreaded inbound keeps the channel-level reply, byte-for-byte;
  - a failed lookup degrades to channel level with a stderr warning, so `--via adapter` survives a gc outage.
- `--thread-current` now anchors at the thread **root** when the latest inbound was itself a thread reply. Slack threads hang off the parent `ts`; anchoring at a child message strands the reply (Slack API docs: "Avoid using a reply's ts value; use its parent instead").
- New `--no-thread` flag forces a channel-level post; combining it with `--reply-to`/`--thread-current` is rejected.
- The company-context path (`_maybe_company_reply`) is untouched — it already does its own thread anchoring.

## Tests

- gp-i62 repro: threaded inbound + explicit `--conversation-id` → reply carries the inbound's thread root.
- Unthreaded inbound → no `reply_to_message_id` (channel level unchanged).
- Cross-conversation guard, `--no-thread` opt-out + flag-combination rejection, `--reply-to` bypasses the lookup entirely.
- `--thread-current`: root anchoring on threaded inbound, own-ts on plain inbound.
- Lookup-failure degradation (warning + channel level, exit 0).
- Mock-backed event→transcript chain: `GcMock` transcript entries now carry `ReplyToMessageID`, and `find_latest_inbound_thread_for_session` extracts root vs `""`.

Full slack-full suite on this branch: **394 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMTmu76XFdBZRmc3MzZdcB