### PR TITLE
fix(gastown): pass --include-infra on every patrol wisp lookup

### DIFF
--- a/gastown/agents/deacon/prompt.template.md
+++ b/gastown/agents/deacon/prompt.template.md
@@ -89,9 +89,9 @@ If `next-iteration` already ran, do not pour again; run `gc hook`.
 ```bash
 CURRENT_WISP=${GC_BEAD_ID:-}
 if [ -z "$CURRENT_WISP" ]; then
-  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
+  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --include-infra --limit=1 --json | jq -r '.[0].id // empty')
 fi
-ASSIGNED_WISP=$(gc bd list --assignee="$GC_AGENT" --status=open --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
+ASSIGNED_WISP=$(gc bd list --assignee="$GC_AGENT" --status=open --type=molecule --include-infra --limit=1 --json | jq -r '.[0].id // empty')
 if [ -n "$CURRENT_WISP" ] && [ -z "$ASSIGNED_WISP" ]; then
   NEXT=$(gc bd mol wisp mol-deacon-patrol --root-only --var binding_prefix={{ .BindingPrefix }} --json | jq -r '.new_epic_id // empty')
   if [ -z "$NEXT" ]; then

--- a/gastown/agents/refinery/prompt.template.md
+++ b/gastown/agents/refinery/prompt.template.md
@@ -64,12 +64,20 @@ Two rules govern your inter-wisp behavior. Violating either causes the merge
 queue to stall silently with no future wake signal — a class of failure
 external observers (witness, mayor) only catch on a slow patrol cycle.
 
+**Every wisp lookup needs `--include-infra`.** Wisps fall in the
+infrastructure visibility class, which `gc bd list` hides by default, so
+without the flag the resolver returns `[]` for a wisp `gc bd show` proves
+exists — in_progress, assigned to you. It fails inside `$(...)` without
+tripping `set -e`, so `CURRENT_WISP` reads empty, the guarded "could not
+resolve current wisp; not burning" branch fires exactly as designed, and the
+stale wisp is left assigned and orphaned. One more leaks every cycle.
+
 ### 1. ALWAYS pour the next wisp before burning the current one
 
 ```bash
 CURRENT_WISP=${GC_BEAD_ID:-}
 if [ -z "$CURRENT_WISP" ]; then
-  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
+  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --include-infra --limit=1 --json | jq -r '.[0].id // empty')
 fi
 NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{ .DefaultBranch }} --var rig_name={{ .RigName }} --var binding_prefix={{ .BindingPrefix }} --json | jq -r '.new_epic_id // empty')
 if [ -z "$NEXT" ]; then
@@ -114,7 +122,7 @@ assign the next wisp, burn the current wisp, THEN request restart**:
 ```bash
 CURRENT_WISP=${GC_BEAD_ID:-}
 if [ -z "$CURRENT_WISP" ]; then
-  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
+  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --include-infra --limit=1 --json | jq -r '.[0].id // empty')
 fi
 NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{ .DefaultBranch }} --var rig_name={{ .RigName }} --var binding_prefix={{ .BindingPrefix }} --json | jq -r '.new_epic_id // empty')
 if [ -z "$NEXT" ]; then

--- a/gastown/agents/witness/prompt.template.md
+++ b/gastown/agents/witness/prompt.template.md
@@ -160,14 +160,22 @@ fresh one while the prior wisp leaks. Wisp roots are `issue_type=molecule`;
 never filter `--type=wisp` (not a valid gc bd type — the query errors and matches
 nothing).
 
+**Every wisp lookup needs `--include-infra`.** Wisps fall in the
+infrastructure visibility class, which `gc bd list` hides by default, so
+without the flag the query returns `[]` for a wisp `gc bd show` proves
+exists. It fails inside `$(...)` without tripping `set -e`, so the resolver
+reads "no wisp", the guarded "not burning" branch fires as designed, and the
+stale wisp is left assigned and orphaned. One more leaks every cycle.
+
 ```bash
 # Step 1: Reconcile your patrol wisps to exactly one (town ledger, via gc bd).
 # Collect every open/in_progress patrol wisp assigned to you, keep one, and
 # burn the surplus so restarts never accumulate duplicates. Wisp roots are
-# molecules — filter --type=molecule, never --type=wisp.
+# molecules — filter --type=molecule, never --type=wisp — and always pass
+# --include-infra, or the query silently returns [] and nothing is burned.
 WISP_IDS=$(
-  gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=0 --json | jq -r '.[].id'
-  gc bd list --assignee="$GC_AGENT" --status=open --type=molecule --limit=0 --json | jq -r '.[].id'
+  gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --include-infra --limit=0 --json | jq -r '.[].id'
+  gc bd list --assignee="$GC_AGENT" --status=open --type=molecule --include-infra --limit=0 --json | jq -r '.[].id'
 )
 WISP=$(printf '%s\n' $WISP_IDS | sed -n '1p')           # keep one (prefers in_progress)
 for extra in $(printf '%s\n' $WISP_IDS | sed '1d'); do  # burn any surplus
@@ -203,14 +211,14 @@ If `next-iteration` already ran, do not pour again; run `gc hook`.
 ```bash
 CURRENT_WISP=${GC_BEAD_ID:-}
 if [ -z "$CURRENT_WISP" ]; then
-  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
+  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --include-infra --limit=1 --json | jq -r '.[0].id // empty')
 fi
 # Reconcile queued (open) patrol wisps to exactly one. A prior cycle may have
 # poured a next wisp without burning, or a restart may have raced — keep the
 # first and burn the surplus so wisps never accumulate. Wisp roots are
 # molecules (never --type=wisp, which is not a valid gc bd type and matches
 # nothing).
-OPEN_WISPS=$(gc bd list --assignee="$GC_AGENT" --status=open --type=molecule --limit=0 --json | jq -r '.[].id')
+OPEN_WISPS=$(gc bd list --assignee="$GC_AGENT" --status=open --type=molecule --include-infra --limit=0 --json | jq -r '.[].id')
 ASSIGNED_WISP=$(printf '%s\n' $OPEN_WISPS | sed -n '1p')
 for extra in $(printf '%s\n' $OPEN_WISPS | sed '1d'); do
   gc bd mol burn "$extra" --force

--- a/gastown/formulas/mol-deacon-patrol.toml
+++ b/gastown/formulas/mol-deacon-patrol.toml
@@ -521,7 +521,7 @@ Handle any urgent messages that arrived during patrol. Archive the rest.
 ```bash
 CURRENT_WISP=${GC_BEAD_ID:-}
 if [ -z "$CURRENT_WISP" ]; then
-  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
+  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --include-infra --limit=1 --json | jq -r '.[0].id // empty')
 fi
 
 NEXT=$(gc bd mol wisp mol-deacon-patrol --root-only --var binding_prefix='{{binding_prefix}}' --json | jq -r '.new_epic_id // empty')

--- a/gastown/formulas/mol-refinery-patrol.toml
+++ b/gastown/formulas/mol-refinery-patrol.toml
@@ -119,7 +119,7 @@ wisp, burn the current wisp, then request a restart:
 ```bash
 CURRENT_WISP=${GC_BEAD_ID:-}
 if [ -z "$CURRENT_WISP" ]; then
-  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
+  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --include-infra --limit=1 --json | jq -r '.[0].id // empty')
 fi
 NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{target_branch}} --var rig_name={{rig_name}} --var binding_prefix={{binding_prefix}} --json | jq -r '.new_epic_id // empty')
 if [ -z "$NEXT" ]; then
@@ -242,7 +242,7 @@ gc bd update $WORK \
 ```bash
 CURRENT_WISP=${GC_BEAD_ID:-}
 if [ -z "$CURRENT_WISP" ]; then
-  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
+  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --include-infra --limit=1 --json | jq -r '.[0].id // empty')
 fi
 NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{target_branch}} --var rig_name={{rig_name}} --var binding_prefix={{binding_prefix}} --json | jq -r '.new_epic_id // empty')
 if [ -z "$NEXT" ]; then
@@ -343,7 +343,7 @@ TARGET=$(gc bd show $WORK --json | jq -r '.[0].metadata.target // "{{target_bran
      ```bash
      CURRENT_WISP=${GC_BEAD_ID:-}
      if [ -z "$CURRENT_WISP" ]; then
-       CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
+       CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --include-infra --limit=1 --json | jq -r '.[0].id // empty')
      fi
      NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{target_branch}} --var rig_name={{rig_name}} --var binding_prefix={{binding_prefix}} --json | jq -r '.new_epic_id // empty')
      if [ -z "$NEXT" ]; then
@@ -435,7 +435,7 @@ Branch: $BRANCH
 Target: $TARGET"
   CURRENT_WISP=${GC_BEAD_ID:-}
   if [ -z "$CURRENT_WISP" ]; then
-    CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
+    CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --include-infra --limit=1 --json | jq -r '.[0].id // empty')
   fi
   if [ -z "$CURRENT_WISP" ]; then
     echo "Could not resolve current wisp; not burning."
@@ -1107,7 +1107,7 @@ why and what state was left.
 
 This summary is not stored separately — it lives in the wisp's
 closing reason. The next session can find it via `gc bd list --type=molecule
---status=closed --limit=5` if it needs predecessor context."""
+--include-infra --status=closed --limit=5` if it needs predecessor context."""
 
 [[steps]]
 id = "next-iteration"
@@ -1143,7 +1143,7 @@ If auto_land = "false": skip this entirely.
 ```bash
 CURRENT_WISP=${GC_BEAD_ID:-}
 if [ -z "$CURRENT_WISP" ]; then
-  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
+  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --include-infra --limit=1 --json | jq -r '.[0].id // empty')
 fi
 NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{target_branch}} --var rig_name={{rig_name}} --var binding_prefix={{binding_prefix}} --json | jq -r '.new_epic_id // empty')
 if [ -z "$NEXT" ]; then

--- a/gastown/formulas/mol-witness-patrol.toml
+++ b/gastown/formulas/mol-witness-patrol.toml
@@ -529,9 +529,12 @@ Reuse an already-queued wisp instead of pouring a duplicate. A prior cycle
 may have poured a next wisp without burning, or a restart may have raced —
 keep one open patrol wisp and burn any surplus, so wisps never accumulate.
 Wisp roots are `issue_type=molecule` (never `--type=wisp`, which is not a
-valid gc bd type and matches nothing).
+valid gc bd type and matches nothing), and every wisp lookup needs
+`--include-infra` — wisps fall in the infrastructure visibility class that
+`gc bd list` hides by default, so without the flag the query returns `[]`
+for wisps that exist and the surplus is left orphaned instead of burned.
 ```bash
-OPEN_WISPS=$(gc bd list --assignee="$GC_AGENT" --status=open --type=molecule --limit=0 --json | jq -r '.[].id')
+OPEN_WISPS=$(gc bd list --assignee="$GC_AGENT" --status=open --type=molecule --include-infra --limit=0 --json | jq -r '.[].id')
 NEXT=$(printf '%s\n' $OPEN_WISPS | sed -n '1p')
 for extra in $(printf '%s\n' $OPEN_WISPS | sed '1d'); do
   gc bd mol burn "$extra" --force

--- a/gastown/tests/test_wisp_resolvers.sh
+++ b/gastown/tests/test_wisp_resolvers.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Guards the wisp-resolver contract for every gastown patrol agent.
+#
+# Patrol wisps fall in the infrastructure visibility class, which `gc bd list`
+# hides by default. A resolver without `--include-infra` returns `[]` for a
+# wisp that `gc bd show` proves exists — in_progress and assigned to the very
+# agent asking. Worse, it fails inside `$(...)` without tripping `set -e`: the
+# resolver reads "no wisp", the guarded "not burning" branch fires as
+# designed, and the stale wisp is left assigned and orphaned. One more leaks
+# every patrol cycle, silently, until an operator runs the query by hand.
+#
+# `--type=wisp` is a separate, older bug: not a valid gc bd issue type at all,
+# so the command errors and matches nothing.
+#
+# This test fails if any patrol prompt or formula resolves a wisp without
+# `--include-infra`, or regresses to `--type=wisp`.
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+
+FILES=(
+    "gastown/formulas/mol-refinery-patrol.toml"
+    "gastown/formulas/mol-deacon-patrol.toml"
+    "gastown/formulas/mol-witness-patrol.toml"
+    "gastown/agents/refinery/prompt.template.md"
+    "gastown/agents/deacon/prompt.template.md"
+    "gastown/agents/witness/prompt.template.md"
+)
+
+failures=0
+
+fail() {
+    echo "FAIL: $*" >&2
+    failures=$((failures + 1))
+}
+
+for rel in "${FILES[@]}"; do
+    path="$ROOT/$rel"
+
+    # Only real invocations count, never the prose that warns against these
+    # forms: a resolver line always runs `gc bd list` and ends in `--json`.
+
+    # 1. No gc bd list may filter --type=wisp: not a valid issue type, so it
+    #    errors and matches nothing.
+    while IFS= read -r line; do
+        [ -n "$line" ] || continue
+        fail "$rel: gc bd list filters --type=wisp, which is not a valid issue type: $line"
+    done < <(grep -n 'gc bd list' "$path" | grep -- '--type=wisp' || true)
+
+    # 2. Every wisp resolver (a gc bd list filtering --type=molecule) must pass
+    #    --include-infra, or it silently returns [] and the wisp is orphaned.
+    while IFS= read -r line; do
+        [ -n "$line" ] || continue
+        fail "$rel: wisp resolver omits --include-infra (returns [] for wisps that exist): $line"
+    done < <(grep -n 'gc bd list' "$path" | grep -- '--type=molecule' | grep -- '--json' | grep -v -- '--include-infra' || true)
+
+    # 3. Each patrol file must still resolve wisps the working way — catches a
+    #    wholesale deletion that would make rules 1 and 2 vacuously pass.
+    if ! grep -q -- '--type=molecule --include-infra' "$path"; then
+        fail "$rel: no '--type=molecule --include-infra' wisp resolver found"
+    fi
+done
+
+if [ "$failures" -ne 0 ]; then
+    echo "$failures wisp-resolver check(s) failed" >&2
+    exit 1
+fi
+
+echo "PASS: wisp resolvers pass --include-infra in ${#FILES[@]} files"


### PR DESCRIPTION
## The bug

Every gastown patrol agent (refinery, witness, deacon) resolves its own wisp with a lookup that cannot see it:

```bash
CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
```

Wisps fall in the **infrastructure visibility class**, which `gc bd list` hides by default. Reproduced against a live rig:

```
$ gc bd show gci-wisp-agu --json | jq '.[0] | {id,issue_type,status,assignee,ephemeral}'
{ "id": "gci-wisp-agu", "issue_type": "molecule", "status": "in_progress",
  "assignee": "gas-city/gastown.refinery", "ephemeral": true }

$ gc bd list --assignee="gas-city/gastown.refinery" --status=in_progress --type=molecule --limit=5 --json
[]

$ gc bd list --assignee="gas-city/gastown.refinery" --status=in_progress --type=molecule --include-infra --limit=5 --json
gci-wisp-agu
```

`--include-infra` output matches `gc bd query "ephemeral=true AND …"` exactly, across `in_progress` and `open`, for both the refinery and the witness.

## Why it is silent, and therefore dangerous

The lookup runs inside `$(...)` without pipefail, so `set -e` never sees it. `CURRENT_WISP` comes back empty, the guarded `"could not resolve current wisp; not burning"` branch fires **exactly as designed**, and the stale wisp is left assigned and orphaned instead of burned. One more leaks every cycle.

Measured on that rig before this change, the refinery held three wisps (one `in_progress`, two `open`) — including one a prior session had explicitly confirmed as its clean anchor and which still went unburned. At least the sixth documented recurrence since 2026-06-12; sb-app logged 13+, and two leaked June gate-sweep wisps sat invisible to a default `gc bd list` for eight weeks of triage. It is only ever caught when an operator runs the query by hand instead of trusting the formula.

## Why the previous fix did not fix it

An earlier pass swapped these calls from `--type=wisp` to `--type=molecule`. That fixed a real bug — `wisp` is not a valid gc bd issue type, so the command errored — but not this one, and it made the resolver *look* correct: `--type=molecule` is valid, it matches the wisp's actual type, and it still returns `[]` because the visibility filter runs first.

## The fix

All 15 resolver sites now pass `--include-infra`, plus the predecessor lookup in the refinery `patrol-summary` prose:

```bash
CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --include-infra --limit=1 --json | jq -r '.[0].id // empty')
```

The work-bead queries in the same files are deliberately untouched — only lookups filtering `--type=molecule` are wisp resolvers.

## Test

New `gastown/tests/test_wisp_resolvers.sh`, picked up by the existing "Run Gastown shell tests" CI step. It fails if any patrol prompt or formula resolves a wisp without `--include-infra`, or regresses to `--type=wisp`. It matches invocations only (a resolver line runs `gc bd list` and ends in `--json`), never the prose that warns against those forms.

Negative proof: dropping the flag from a single site fails the test; restoring it passes.

## Verification

- `gastown/tests/*.sh` — 5/5 pass (including the new one)
- `python3 validate_registry.py --require-git` — ok
- `go test .` (root embed module) — ok
- `tests/test_no_bare_bd_commands.py` — both tests pass
- All `gastown/formulas/*.toml` parse under `tomllib`
- End-to-end: the rendered `next-iteration` snippet, executed under `set -euo pipefail` with `GC_AGENT` set to a live refinery, resolves `CURRENT_WISP=[gci-wisp-agu]` — the wisp the unflagged form could not see

## Downstream note

`gascity`'s `examples/gastown/gastown_test.go` asserts the **old** strings verbatim (`TestWitnessStartupAndNoIdleReconcileWisps`, and the no-idle order check in the prompt-render table). Those assertions read pack content through the `gascity-packs` Go module, so they will not break until someone bumps the pin — but they must be updated in the same pin bump. Flagging so it is not discovered as a surprise CI failure.

Refs: gci-853, gci-byp

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UxBWmhHRfH5vfqeuhqvu5q