### PR TITLE
fix(slack-full): build adapter on macOS — use x/sys/unix.Openat instead of Linux-only syscall.Openat

### DIFF
--- a/slack-full/adapter/confined_open.go
+++ b/slack-full/adapter/confined_open.go
@@ -5,7 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
 // openBeneath opens rel (a Clean, root-relative path containing no
@@ -14,8 +15,19 @@ import (
 // with O_NOFOLLOW set. The parent fd pins the verified directory inode,
 // so a directory swapped for a symlink mid-walk cannot redirect the
 // traversal — the userspace equivalent of openat2(RESOLVE_BENEATH),
-// which stdlib syscall does not expose (and the adapter's
-// zero-dependency go.mod keeps us from importing x/sys for).
+// which stdlib syscall does not expose.
+//
+// The syscalls come from x/sys/unix rather than stdlib syscall because
+// syscall.Openat is Linux-only: on darwin the package builds but the
+// symbol is undefined, so this file did not compile on macOS at all.
+// x/sys/unix implements Openat on both, which keeps one implementation
+// and one security contract across platforms.
+//
+// stdlib os.Root is deliberately NOT used here. It enforces "cannot
+// escape the root", which is weaker than what this function promises:
+// os.Root FOLLOWS a symlink whose target stays inside the root, and it
+// does not honour O_NOFOLLOW passed through OpenFile. Switching to it
+// would silently narrow the guarantee below.
 //
 // O_NOFOLLOW applies to every component, not just the leaf, so any
 // symlink anywhere beneath root is a hard failure (ELOOP / ENOTDIR).
@@ -33,18 +45,18 @@ func openBeneath(rootAbs, rel string) (*os.File, error) {
 			return nil, fmt.Errorf("openBeneath: invalid path component %q in %q", c, rel)
 		}
 	}
-	dirFlags := syscall.O_RDONLY | syscall.O_DIRECTORY | syscall.O_NOFOLLOW | syscall.O_CLOEXEC
-	fd, err := syscall.Open(rootAbs, dirFlags, 0)
+	dirFlags := unix.O_RDONLY | unix.O_DIRECTORY | unix.O_NOFOLLOW | unix.O_CLOEXEC
+	fd, err := unix.Open(rootAbs, dirFlags, 0)
 	if err != nil {
 		return nil, fmt.Errorf("openBeneath: open root %q: %w", rootAbs, err)
 	}
 	for i, c := range comps {
-		flags := syscall.O_RDONLY | syscall.O_NOFOLLOW | syscall.O_CLOEXEC
+		flags := unix.O_RDONLY | unix.O_NOFOLLOW | unix.O_CLOEXEC
 		if i < len(comps)-1 {
-			flags |= syscall.O_DIRECTORY
+			flags |= unix.O_DIRECTORY
 		}
-		next, err := syscall.Openat(fd, c, flags, 0)
-		syscall.Close(fd)
+		next, err := unix.Openat(fd, c, flags, 0)
+		unix.Close(fd)
 		if err != nil {
 			return nil, fmt.Errorf("openBeneath: open component %q of %q: %w", c, rel, err)
 		}

--- a/slack-full/adapter/go.mod
+++ b/slack-full/adapter/go.mod
@@ -1,3 +1,5 @@
 module github.com/sjarmak/gc-slack-adapter
 
 go 1.25.9
+
+require golang.org/x/sys v0.45.0

--- a/slack-full/adapter/go.sum
+++ b/slack-full/adapter/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
+golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=


### PR DESCRIPTION
## The problem

`slack-full/adapter` does not compile on macOS:

```
./confined_open.go:46:24: undefined: syscall.Openat
```

`syscall.Openat` is Linux-only in the Go stdlib. `openBeneath` — the symlink-safe component walk that confines inbound file uploads — has therefore never built on darwin. Confirmed in both directions on `darwin/arm64`, Go 1.26.1: `go build ./...` fails, `GOOS=linux go vet ./...` is clean.

Scope is this module alone. `slack-full/cli`, `slack-channel/adapter` and `slack-mini/adapter` all build fine on darwin.

## The fix

Swap the stdlib `syscall` calls for `golang.org/x/sys/unix`, which implements `Openat` on darwin and linux both.

The algorithm is untouched — same component-by-component walk, same `O_NOFOLLOW` on every component, same `O_DIRECTORY` on interior components, same errno. **Existing tests pass unmodified**, including `TestReadConfinedFileRejectsSymlink`'s `errors.Is(err, syscall.ELOOP)` assertion: `x/sys/unix` returns `syscall.Errno` values, so error identity is preserved.

## The trade — and please tell us if you'd rather have it the other way

This adds the module's **first dependency and first `go.sum`**. `go.mod` had no `require` block and there was no `go.sum` file at all, so the zero-dependency property was literal, not aspirational. That is the strongest argument against this patch and we want to state it plainly rather than gesture at it.

The alternative is stdlib **`os.Root`** (Go 1.24+; the `go` directive here is already 1.25.9). It keeps the module dependency-free and deletes the hand-rolled walk entirely. We did not choose it because it enforces a weaker property than this function promises. Measured on `darwin/arm64`, Go 1.26.1:

| fixture | `os.Root` | `O_NOFOLLOW` walk |
|---|---|---|
| symlink, **absolute** target | rejected — "path escapes from parent" | rejected — ELOOP |
| symlink, **relative** in-root target | **followed, file read** | rejected — ELOOP |
| control, real file | opened | opened |

`os.Root` guarantees *cannot escape the root*. This function's doc comment promises something stronger — *any symlink anywhere beneath root is a hard failure* — and `gc-cby.10` / `gpk-1ta4` filed it specifically to close a TOCTOU window. We also tried `root.OpenFile(rel, os.O_RDONLY|syscall.O_NOFOLLOW, 0)` to recover the strict behaviour: it does not work, `os.Root` does not honour that flag and still follows the relative in-root symlink.

**Worth knowing regardless of which patch you prefer:** the current test suite cannot see that difference. `TestReadConfinedFileRejectsSymlink` builds its symlink with `os.Symlink(filepath.Join(dir, "target.txt"), link)` — an *absolute* target, which `os.Root` rejects for escaping rather than for being a symlink. Change that one line to `os.Symlink("target.txt", link)` and an `os.Root` implementation opens the file and returns its contents while the current one rejects it. If you do prefer `os.Root`, that test needs a relative-target case added, and the doc comment needs rewriting — it currently asserts a property that is contingent on `Openat`.

Happy to swap this PR to the `os.Root` version if you'd rather hold the empty `go.mod`; it is a preference only you can hold.

## Testing

- `go build ./...` on darwin: **passes** (previously failed to compile)
- `GOOS=linux go vet ./...`: clean
- `go test ./...`: **entire suite passes**, no test modified

One caveat on running the suite locally on macOS: three upload-confinement tests fail under the default `TMPDIR` for a **separate, pre-existing** reason unrelated to this patch. `confinedUploadPath` (`main.go` ~1800-1819) compares an `EvalSymlinks`-resolved `realPath` against an *unresolved* root, and on macOS `/tmp` and `/var` are symlinks into `/private`, so any root beneath them fails containment. The failures all report `is outside root` and never reach `openBeneath`. With `TMPDIR` set to a canonical path the whole suite is green. We have deliberately left that out of scope here — happy to file it separately, or fold it in if you'd prefer (the fix is to resolve the root before comparing).
