### PR TITLE
feat(slack-channel): Socket Mode transport; fix reply-current --conversation-id

### DIFF
--- a/slack-channel/CHANGELOG.md
+++ b/slack-channel/CHANGELOG.md
@@ -5,6 +5,45 @@ All notable changes to slack-channel are documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Socket Mode transport** (`adapter/socketmode.go`), an ingress-free
+  alternative to the public Events API listener: the adapter opens an
+  outbound WebSocket to Slack instead of receiving webhooks, so the pack
+  runs on networks that cannot accept inbound connections (corporate
+  firewalls, laptops, anywhere a tunnel is blocked). Ported from the
+  slack-mini (Tier 1) transport of the same name.
+  - Selected by `SLACK_APP_TOKEN` (an `xapp-…` app-level token with the
+    `connections:write` scope). When set, `LISTEN_PUBLIC` is never bound
+    and `SLACK_SIGNING_SECRET` is no longer required — Socket Mode has no
+    request signatures, so the trust boundary is the app-token-authenticated
+    connection the adapter itself opens.
+  - Envelopes are handed to `routeEvent`, so channel bindings, handle
+    aliases, the `app_mention` fallback, and per-session identity behave
+    identically to the HTTP path.
+  - Supervised reconnect with capped exponential backoff (1s → 30s), a 30s
+    keepalive ping as the liveness check, and an overlap on Slack's advance
+    disconnect warning so in-flight envelopes are still acked.
+  - Events from a workspace other than `SLACK_WORKSPACE_ID` are dropped
+    rather than filed under the wrong account or matched against another
+    workspace's channel bindings.
+  - Dialled through Go's default HTTP client, so `HTTPS_PROXY`/`NO_PROXY`
+    are honoured.
+  - **Interactivity is not carried over Socket Mode.** Tier 2 ships
+    interactivity disabled and `/slack/interactions` is an opt-in extra
+    that still needs a public URL; `interactive` envelopes are dropped with
+    an explanatory log line.
+- `manifest/app-socket.json`, the Socket Mode variant of the app manifest
+  (identical to `manifest/app.json` but with `socket_mode_enabled: true`).
+
+### Changed
+
+- The adapter now depends on `github.com/coder/websocket` v1.8.15, which
+  has no dependencies of its own. The HTTP transport is unchanged and still
+  verifies request signatures exactly as before.
+
 ## [0.1.0] — Tier 2
 
 Initial release. slack-channel is Tier 2 of the Slack pack family — the

--- a/slack-channel/CHANGELOG.md
+++ b/slack-channel/CHANGELOG.md
@@ -25,10 +25,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     identically to the HTTP path.
   - Supervised reconnect with capped exponential backoff (1s → 30s), a 30s
     keepalive ping as the liveness check, and an overlap on Slack's advance
-    disconnect warning so in-flight envelopes are still acked.
-  - Events from a workspace other than `SLACK_WORKSPACE_ID` are dropped
-    rather than filed under the wrong account or matched against another
-    workspace's channel bindings.
+    disconnect warning so in-flight envelopes are still acked. The backoff
+    floor is restored only once a connection has lasted 30s, so a server
+    that accepts a connection and drops it immediately — or the
+    connection-limit churn two adapters sharing one app token produce —
+    escalates the delay instead of redialling at the floor forever.
   - Dialled through Go's default HTTP client, so `HTTPS_PROXY`/`NO_PROXY`
     are honoured.
   - **Interactivity is not carried over Socket Mode.** Tier 2 ships
@@ -41,8 +42,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - The adapter now depends on `github.com/coder/websocket` v1.8.15, which
-  has no dependencies of its own. The HTTP transport is unchanged and still
-  verifies request signatures exactly as before.
+  has no dependencies of its own. The HTTP transport still verifies request
+  signatures exactly as before.
+- **Events carrying another workspace's `team_id` are now dropped on both
+  transports**, at the shared `routeEvent` funnel. Previously the HTTP path
+  accepted them: a request signature proves only that Slack sent the event
+  for this app, not that it came from this workspace, so an app installed
+  in a second workspace had that workspace's messages filed under
+  `SLACK_WORKSPACE_ID` and matched against this workspace's channel
+  bindings. An absent `team_id` is still accepted — Slack sends one on
+  every `event_callback`.
 
 ## [0.1.0] — Tier 2
 

--- a/slack-channel/README.md
+++ b/slack-channel/README.md
@@ -45,15 +45,42 @@ flags.
 
 ## Install
 
+## Choose a transport
+
+Inbound messages reach the adapter one of two ways. Pick one before you
+create the app — the choice is baked into the app manifest.
+
+| | **Socket Mode** | **HTTP (Events API)** |
+| --- | --- | --- |
+| Public ingress | none | public HTTPS URL required |
+| How events arrive | outbound WebSocket the adapter opens to Slack | Slack POSTs to your Request URL |
+| Credentials | app-level token (`xapp-…`) | signing secret |
+| Manifest | [`manifest/app-socket.json`](./manifest/app-socket.json) | [`manifest/app.json`](./manifest/app.json) |
+| Interactivity (opt-in) | not supported | `/slack/interactions` |
+
+**Socket Mode is the right default if you cannot expose an inbound port** —
+behind a corporate firewall, on a laptop, or anywhere a tunnel is blocked.
+It needs only outbound HTTPS to `slack.com`. Bindings, handle aliases,
+identities, and every outbound verb behave identically on both.
+
+The one thing Socket Mode cannot carry is interactivity. Tier 2 ships it
+disabled, so this only matters if you deliberately turned on
+`/slack/interactions` — that half still needs a public URL.
+
 ### 1. Create the Slack app
 
-Create an app from the shipped manifest at
-[`manifest/app.json`](./manifest/app.json):
+Create an app from the shipped manifest — `manifest/app-socket.json` for
+Socket Mode, `manifest/app.json` for HTTP:
 
 1. <https://api.slack.com/apps> → **Create New App** → **From a manifest**.
-2. Pick your workspace, paste `manifest/app.json`, create.
+2. Pick your workspace, paste the manifest, create.
 3. **Install to Workspace** and copy the **Bot User OAuth Token** (`xoxb-…`).
-4. From **Basic Information**, copy the **Signing Secret**.
+4. From **Basic Information**:
+   - **Socket Mode:** under **App-Level Tokens**, **Generate Token and
+     Scopes**, add the **`connections:write`** scope, and copy the token
+     (`xapp-…`). App-level tokens cannot be declared in a manifest, so this
+     step is manual.
+   - **HTTP:** copy the **Signing Secret**.
 
 The manifest requests the scopes Tier 2 needs: `app_mentions:read`,
 `channels:history`, `groups:history`, `im:history`, `mpim:history`,
@@ -77,22 +104,32 @@ Provide the adapter's environment:
 
 ```sh
 SLACK_BOT_TOKEN=xoxb-...          # from step 1
-SLACK_SIGNING_SECRET=...          # from step 1
+SLACK_APP_TOKEN=xapp-...          # Socket Mode only — selects the transport
+SLACK_SIGNING_SECRET=...          # HTTP only
 SLACK_WORKSPACE_ID=T0123ABCD      # your Slack team id
 GC_CITY_NAME=<your-city-name>     # the gc city to bridge into
 GC_CITY_PATH=/path/to/your/city   # on-disk city root (for the registries)
 ```
 
+Setting `SLACK_APP_TOKEN` is the whole switch: the adapter runs Socket
+Mode, never binds `LISTEN_PUBLIC`, and stops requiring
+`SLACK_SIGNING_SECRET` (Socket Mode has no request signatures to verify).
+
 `GC_CITY_PATH` is where the three registries live
 (`<GC_CITY_PATH>/.gc/slack-channel/`). Override the directory with
 `SLACK_CHANNEL_REGISTRY_DIR` if needed.
 
-### 3. Expose the events endpoint and start
+### 3. Start
 
-The adapter listens for Slack events on public TCP (`LISTEN_PUBLIC`,
-default `0.0.0.0:8775`). Terminate TLS in front of it and give Slack a
-public URL — [Tailscale Funnel](https://tailscale.com/kb/1223/funnel) is the
-easy path:
+**Socket Mode — nothing to expose.** The adapter dials out to Slack, so
+there is no listener to publish, no TLS to terminate, and no Request URL to
+register. Start your city; the log line to look for is
+`socket mode: connected`.
+
+**HTTP — expose the events endpoint.** The adapter listens for Slack events
+on public TCP (`LISTEN_PUBLIC`, default `0.0.0.0:8775`). Terminate TLS in
+front of it and give Slack a public URL —
+[Tailscale Funnel](https://tailscale.com/kb/1223/funnel) is the easy path:
 
 ```sh
 tailscale funnel 8775
@@ -160,12 +197,13 @@ The built binary is git-ignored; the `[[service]]` block runs it in place.
 | Variable | Required | Default | Purpose |
 | --- | :---: | --- | --- |
 | `SLACK_BOT_TOKEN` | ✓ | — | Bot token for `chat.postMessage` + `reactions.add`. |
-| `SLACK_SIGNING_SECRET` | ✓ | — | HMAC secret for verifying Slack requests. |
+| `SLACK_SIGNING_SECRET` | HTTP only | — | HMAC secret for verifying Slack requests. Required unless `SLACK_APP_TOKEN` is set. |
+| `SLACK_APP_TOKEN` | Socket Mode | — | App-level token (`xapp-…`) with `connections:write`. Setting it selects Socket Mode: no public listener, no signing secret. |
 | `SLACK_WORKSPACE_ID` | ✓ | — | Slack team id (extmsg account id + registry key). |
 | `GC_CITY_NAME` | ✓ | — | gc city to bridge into. |
 | `GC_CITY_PATH` | ✓* | — | City root; registry dir defaults under it. |
 | `SLACK_CHANNEL_REGISTRY_DIR` | | `<GC_CITY_PATH>/.gc/slack-channel` | Override the registry directory. |
-| `LISTEN_PUBLIC` | | `0.0.0.0:8775` | Public bind for `/slack/events` + `/slack/interactions`. |
+| `LISTEN_PUBLIC` | | `0.0.0.0:8775` | Public bind for `/slack/events` + `/slack/interactions`. Not bound in Socket Mode. |
 | `LISTEN_INTERNAL` | | `127.0.0.1:8776` | TCP bind for the verb endpoints when not a gc proxy_process. |
 | `REGISTER_ON_START` | | `true` | Self-register as an extmsg adapter on start. |
 | `SLACK_CHANNEL_INBOUND_TARGET` | | `mayor` | Fallback session for an unbound, unaliased `app_mention`. |

--- a/slack-channel/README.md
+++ b/slack-channel/README.md
@@ -45,7 +45,7 @@ flags.
 
 ## Install
 
-## Choose a transport
+### Choose a transport
 
 Inbound messages reach the adapter one of two ways. Pick one before you
 create the app — the choice is baked into the app manifest.
@@ -244,6 +244,14 @@ understanding before you install:
   it). Treat the token as a secret, scope it to one workspace, and rotate it
   by hand if it is exposed. Enable rotation in the Slack app settings if your
   deployment policy requires it.
+- **Events from another workspace are dropped, on both transports.** Neither
+  transport establishes which workspace an event came from: Socket Mode has
+  no signature at all, and an HTTP request signature proves only that Slack
+  sent the event *for this app*, not that it came *from this team*. An app
+  installed in a second workspace would otherwise have that workspace's
+  messages filed under `SLACK_WORKSPACE_ID` and matched against this
+  workspace's channel bindings, so an event whose `team_id` is set and does
+  not match is dropped with a log line. Run one workspace per install.
 - **Internal verb listener is loopback / dev-only.** When the adapter is
   *not* run as a gc `proxy_process` service (`GC_SERVICE_SOCKET` unset), the
   verb endpoints are served over plain TCP on `127.0.0.1:8776`

--- a/slack-channel/adapter/config.go
+++ b/slack-channel/adapter/config.go
@@ -62,10 +62,17 @@ type config struct {
 	workspaceID         string
 	botToken            string
 	signingSecret       string
+	appToken            string
 	inboundTarget       string
 	slackAPIBase        string
 	registerOnStart     bool
 }
+
+// socketMode reports whether the adapter takes inbound over a Socket Mode
+// WebSocket instead of the public HTTP listener. The app-level token is the
+// selector: it is required for Socket Mode and useless without it, so its
+// presence is the whole contract — there is no second toggle to keep in sync.
+func (c config) socketMode() bool { return c.appToken != "" }
 
 func (c config) channelMappingsPath() string {
 	return filepath.Join(c.registryDir, "channel_mappings.json")
@@ -102,6 +109,7 @@ func loadConfigFromEnv(getenv func(string) string) (config, error) {
 		workspaceID:     getenv("SLACK_WORKSPACE_ID"),
 		botToken:        getenv("SLACK_BOT_TOKEN"),
 		signingSecret:   getenv("SLACK_SIGNING_SECRET"),
+		appToken:        getenv("SLACK_APP_TOKEN"),
 		inboundTarget:   envOr("SLACK_CHANNEL_INBOUND_TARGET", defaultInboundTarget),
 		slackAPIBase:    strings.TrimRight(envOr("SLACK_API_BASE", defaultSlackAPIBase), "/"),
 		registerOnStart: envOr("REGISTER_ON_START", "true") == "true",
@@ -139,7 +147,11 @@ func loadConfigFromEnv(getenv func(string) string) (config, error) {
 	if cfg.botToken == "" {
 		missing = append(missing, "SLACK_BOT_TOKEN")
 	}
-	if cfg.signingSecret == "" {
+	// The signing secret verifies HTTP webhook signatures. Socket Mode has no
+	// request signatures — authenticity comes from the app-token-authenticated
+	// connection the adapter itself opens — so requiring it there would be
+	// demanding a credential the transport never consults.
+	if cfg.signingSecret == "" && !cfg.socketMode() {
 		missing = append(missing, "SLACK_SIGNING_SECRET")
 	}
 	if cfg.cityName == "" {
@@ -147,6 +159,12 @@ func loadConfigFromEnv(getenv func(string) string) (config, error) {
 	}
 	if len(missing) > 0 {
 		return cfg, fmt.Errorf("missing required env vars: %s", strings.Join(missing, ", "))
+	}
+	// Fail fast on the easiest Socket Mode mistake: pasting the bot token
+	// (xoxb-) into SLACK_APP_TOKEN. Slack would answer invalid_auth on every
+	// reconnect forever, which reads as a network fault rather than a typo.
+	if cfg.socketMode() && !strings.HasPrefix(cfg.appToken, "xapp-") {
+		return cfg, errors.New("SLACK_APP_TOKEN must be an app-level token (xapp-...); the bot token belongs in SLACK_BOT_TOKEN")
 	}
 	// Tier 2 keeps on-disk registries, so it needs a place to put them.
 	// Require either GC_CITY_PATH (the normal gc-supervised path) or an

--- a/slack-channel/adapter/go.mod
+++ b/slack-channel/adapter/go.mod
@@ -1,3 +1,5 @@
 module github.com/sjarmak/gc-slack-channel-adapter
 
 go 1.25.9
+
+require github.com/coder/websocket v1.8.15

--- a/slack-channel/adapter/go.sum
+++ b/slack-channel/adapter/go.sum
@@ -1,0 +1,2 @@
+github.com/coder/websocket v1.8.15 h1:6B2JPeOGlpff2Uz6vOEH1Vzpi0iUz20A+lPVhPHtNUA=
+github.com/coder/websocket v1.8.15/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=

--- a/slack-channel/adapter/inbound.go
+++ b/slack-channel/adapter/inbound.go
@@ -65,9 +65,10 @@ func (s *server) handleSlackEvents() http.HandlerFunc {
 //   - A plain message with no binding and no alias → dropped (Tier 2 does
 //     not firehose every channel message at the mayor).
 //
-// Bot, system, and edited messages are dropped to avoid echo loops.
+// Bot, system, and edited messages are dropped to avoid echo loops, as are
+// events carrying another workspace's team_id.
 func (s *server) routeEvent(env slackEventEnvelope) {
-	if env.Type != "event_callback" || len(env.Event) == 0 {
+	if !s.admitEvent(env) {
 		return
 	}
 	var msg slackMessageEvent
@@ -125,6 +126,40 @@ func (s *server) routeEvent(env slackEventEnvelope) {
 		}(sid, text)
 	}
 	wg.Wait()
+}
+
+// admitEvent reports whether an event envelope should be routed at all. Both
+// checks are transport-independent, which is why they live at the funnel
+// rather than in either transport.
+//
+// slack-mini keeps the same two checks inline at the top of bridgeEvent. They
+// are extracted here because Tier 2's funnel does considerably more below
+// them — bindings, aliases, the app_mention fallback, and the fan-out — and
+// the guard must not push that body past its complexity budget. Extracting
+// the admission tests rather than the routing arms keeps the diff against
+// mini's bridgeEvent readable: the guard is still the first thing either
+// funnel does.
+func (s *server) admitEvent(env slackEventEnvelope) bool {
+	if env.Type != "event_callback" || len(env.Event) == 0 {
+		return false
+	}
+	// Drop events from another workspace. Neither transport establishes which
+	// workspace an event belongs to — Socket Mode has no signature at all, and
+	// the HTTP path's HMAC proves only that Slack sent it for this app, not
+	// that it came from this team — yet every delivery below is stamped with
+	// cfg.workspaceID as its account id, and a channel id from a second
+	// workspace can collide with a binding belonging to this one. An app
+	// installed in a second workspace would therefore file that workspace's
+	// messages under this one. The guard sits here, at the funnel both
+	// transports feed, so neither can be missed.
+	//
+	// An absent team_id is allowed through: Slack sends one on every
+	// event_callback, so this only affects hand-built payloads.
+	if env.TeamID != "" && env.TeamID != s.cfg.workspaceID {
+		log.Printf("dropping event from unexpected team %s (want %s)", env.TeamID, s.cfg.workspaceID)
+		return false
+	}
+	return true
 }
 
 // deliverInbound POSTs one extmsg inbound addressed to target and records

--- a/slack-channel/adapter/inbound_test.go
+++ b/slack-channel/adapter/inbound_test.go
@@ -44,6 +44,26 @@ func newInboundCollector(t *testing.T, s *server) *inboundCollector {
 	return c
 }
 
+// count returns how many deliveries have landed so far, safely against the
+// goroutine handleSlackEvents routes in.
+func (c *inboundCollector) count() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.all)
+}
+
+// awaitCount waits up to timeout for the collector to reach want deliveries,
+// returning what it actually saw.
+func (c *inboundCollector) awaitCount(want int, timeout time.Duration) int {
+	deadline := time.Now().Add(timeout)
+	for {
+		if got := c.count(); got >= want || time.Now().After(deadline) {
+			return got
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+}
+
 func routeMessage(s *server, ev slackMessageEvent) {
 	raw, _ := json.Marshal(ev)
 	s.routeEvent(slackEventEnvelope{Type: "event_callback", Event: raw})
@@ -167,6 +187,82 @@ func TestRouteEventDrops(t *testing.T) {
 				t.Errorf("%s: expected drop, but a delivery was made", tc.name)
 			}
 		})
+	}
+}
+
+// TestRouteEventDropsForeignWorkspace pins the foreign-workspace drop at
+// routeEvent, the funnel both transports feed. Neither transport establishes
+// which workspace an event came from — Socket Mode has no signature, and the
+// HTTP path's HMAC proves only that Slack sent it for this app — so a guard on
+// one transport leaves the other open. Both arms send the same event payload;
+// the local-team arm is the control that proves a drop is the guard firing and
+// not the event simply going nowhere.
+func TestRouteEventDropsForeignWorkspace(t *testing.T) {
+	srv := newTestServer(t)
+	c := newInboundCollector(t, srv)
+
+	// The app_mention fallback delivers to the default inbound target from any
+	// unbound channel, so an un-dropped event here is always a delivery. Both
+	// arms carry the identical payload: the socket frame's payload is
+	// byte-for-byte the body Slack would have POSTed.
+	frameFor := func(teamID string) socketEnvelope {
+		var env socketEnvelope
+		if err := json.Unmarshal(appMentionEnvelope(t, "env-fw", teamID, "<@U0BOT> hi"), &env); err != nil {
+			t.Fatalf("unmarshal socket frame: %v", err)
+		}
+		return env
+	}
+
+	overSocket := func(t *testing.T, teamID string) {
+		t.Helper()
+		srv.handleSocketEnvelope(frameFor(teamID))
+	}
+
+	overHTTP := func(t *testing.T, teamID string) {
+		t.Helper()
+		body := []byte(frameFor(teamID).Payload)
+		ts := strconv.FormatInt(time.Now().Unix(), 10)
+		req := httptest.NewRequest(http.MethodPost, "/slack/events", strings.NewReader(string(body)))
+		req.Header.Set("X-Slack-Request-Timestamp", ts)
+		req.Header.Set("X-Slack-Signature", signSlack(srv.cfg.signingSecret, ts, body))
+		rec := httptest.NewRecorder()
+		srv.handleSlackEvents()(rec, req)
+		// A valid signature: Slack is satisfied, which is exactly why the
+		// signature cannot be what decides the workspace question.
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", rec.Code)
+		}
+	}
+
+	for _, tc := range []struct {
+		name string
+		send func(*testing.T, string)
+	}{
+		{"socket path", overSocket},
+		{"http path", overHTTP},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			before := c.count()
+
+			tc.send(t, "T_OTHER")
+			if got := c.awaitCount(before+1, 250*time.Millisecond); got != before {
+				t.Errorf("delivered %d event(s) from a foreign workspace", got-before)
+			}
+
+			tc.send(t, srv.cfg.workspaceID)
+			if got := c.awaitCount(before+1, 5*time.Second); got != before+1 {
+				t.Errorf("local-workspace event delivered %d times, want 1 — the guard is dropping everything", got-before)
+			}
+		})
+	}
+
+	// Slack sends team_id on every event_callback, so an absent one only
+	// occurs in hand-built payloads and must not be dropped; the rest of this
+	// file's routeEvent tests rely on it.
+	before := c.count()
+	routeMessage(srv, slackMessageEvent{Type: "app_mention", User: "U9", Text: "<@U0BOT> hi", Channel: "C9", TS: "1700.9"})
+	if got := c.count(); got != before+1 {
+		t.Errorf("absent team_id delivered %d times, want 1", got-before)
 	}
 }
 

--- a/slack-channel/adapter/main.go
+++ b/slack-channel/adapter/main.go
@@ -89,8 +89,12 @@ func main() {
 	if cfg.serviceSocket != "" {
 		internalDescr = "uds:" + cfg.serviceSocket
 	}
-	log.Printf("starting gc-slack-channel-adapter public=%s internal=%s gc=%s city=%s registry=%s target=%s",
-		cfg.publicListen, internalDescr, cfg.gcAPIBase, cfg.cityName, cfg.registryDir, cfg.inboundTarget)
+	inboundDescr := "http:" + cfg.publicListen
+	if cfg.socketMode() {
+		inboundDescr = "socket-mode (no public listener)"
+	}
+	log.Printf("starting gc-slack-channel-adapter inbound=%s internal=%s gc=%s city=%s registry=%s target=%s",
+		inboundDescr, internalDescr, cfg.gcAPIBase, cfg.cityName, cfg.registryDir, cfg.inboundTarget)
 
 	publicMux := http.NewServeMux()
 	publicMux.HandleFunc("/slack/events", srv.handleSlackEvents())
@@ -149,11 +153,27 @@ func main() {
 			cfg.provider, cfg.workspaceID, cfg.internalCallbackURL)
 	}
 
+	// Socket Mode owns the inbound path when enabled; the public listener is
+	// not merely unused but never bound, which is the point on a network that
+	// cannot accept inbound connections.
+	socketCtx, socketCancel := context.WithCancel(context.Background())
+	defer socketCancel()
+
 	errCh := make(chan error, 2)
-	go func() {
-		log.Printf("public listener serving on %s (Slack events + interactions)", cfg.publicListen)
-		errCh <- publicSrv.ListenAndServe()
-	}()
+	if cfg.socketMode() {
+		go func() {
+			// runSocketMode reconnects internally and returns only when its
+			// context is cancelled, so a return here means shutdown.
+			if err := srv.runSocketMode(socketCtx); err != nil && !errors.Is(err, context.Canceled) {
+				errCh <- err
+			}
+		}()
+	} else {
+		go func() {
+			log.Printf("public listener serving on %s (Slack events + interactions)", cfg.publicListen)
+			errCh <- publicSrv.ListenAndServe()
+		}()
+	}
 	go func() {
 		if cfg.serviceSocket != "" {
 			log.Printf("internal listener serving on UDS %s (gc proxy_process)", cfg.serviceSocket)
@@ -179,6 +199,7 @@ func main() {
 			log.Printf("listener error: %v", err)
 		}
 	}
+	socketCancel()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	_ = publicSrv.Shutdown(ctx)

--- a/slack-channel/adapter/outbound.go
+++ b/slack-channel/adapter/outbound.go
@@ -26,9 +26,17 @@ type publishToChannelRequest struct {
 }
 
 type replyCurrentRequest struct {
-	SessionID      string `json:"session_id"`
-	Body           string `json:"body"`
-	ReplyTo        string `json:"reply_to,omitempty"`
+	SessionID string `json:"session_id"`
+	Body      string `json:"body"`
+	ReplyTo   string `json:"reply_to,omitempty"`
+	// ConversationID optionally asserts which conversation the caller
+	// believes it is replying to. reply-current always targets the session's
+	// latest inbound, so this is redundant by construction — but slack-full
+	// and discord both accept the flag, and gc's injected reply instruction
+	// passes it, so rejecting it stranded Tier 2 agents with a command that
+	// looked right and failed. Validated rather than ignored: a mismatch
+	// means the agent is replying to a conversation it no longer owns.
+	ConversationID string `json:"conversation_id,omitempty"`
 	ThreadCurrent  bool   `json:"thread_current,omitempty"`
 	IdempotencyKey string `json:"idempotency_key,omitempty"`
 }
@@ -192,6 +200,16 @@ func (s *server) handleReplyCurrent() http.HandlerFunc {
 			}
 			channel = channels[0]
 			threadTS = req.ReplyTo // thread_current has no message to thread under here
+		}
+		// An asserted conversation that does not match the resolved target
+		// means the session's latest inbound moved on (or the caller copied
+		// an id from elsewhere). Failing here is the point: the alternative
+		// is a reply delivered into the wrong channel.
+		if req.ConversationID != "" && req.ConversationID != channel {
+			writeJSONError(w, http.StatusConflict, fmt.Sprintf(
+				"conversation_id %q does not match this session's current reply target %q",
+				req.ConversationID, channel))
+			return
 		}
 		// Derive a deterministic key when the caller supplied none, so a
 		// retry of the same reply dedupes instead of double-posting after a

--- a/slack-channel/adapter/outbound_test.go
+++ b/slack-channel/adapter/outbound_test.go
@@ -166,6 +166,31 @@ func TestHandleReplyCurrent(t *testing.T) {
 			t.Fatalf("status=%d", rec.Code)
 		}
 	})
+
+	// gc's injected reply instruction passes --conversation-id, and both
+	// slack-full and discord accept it. Tier 2 rejecting it left agents with
+	// a command that looked correct and failed.
+	t.Run("matching conversation_id is accepted", func(t *testing.T) {
+		rec := doJSON(srv.handleReplyCurrent(), `{"session_id":"s1","body":"ack","conversation_id":"C1"}`)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+		}
+		if last := slack.posts[len(slack.posts)-1]; last.Channel != "C1" {
+			t.Errorf("post channel = %q, want C1", last.Channel)
+		}
+	})
+
+	t.Run("mismatched conversation_id is refused", func(t *testing.T) {
+		before := len(slack.posts)
+		rec := doJSON(srv.handleReplyCurrent(), `{"session_id":"s1","body":"oops","conversation_id":"C_OTHER"}`)
+		if rec.Code != http.StatusConflict {
+			t.Fatalf("status=%d, want 409 body=%s", rec.Code, rec.Body.String())
+		}
+		// The whole point: a stale assertion must not post anywhere.
+		if len(slack.posts) != before {
+			t.Errorf("posted %d message(s) despite a conversation mismatch", len(slack.posts)-before)
+		}
+	})
 }
 
 func TestHandleReplyCurrentFallbackToBinding(t *testing.T) {

--- a/slack-channel/adapter/server.go
+++ b/slack-channel/adapter/server.go
@@ -56,6 +56,7 @@ type server struct {
 
 	httpClient *http.Client
 	now        func() time.Time
+	timings    socketTimings // Socket Mode connection-lifecycle timers; see socketmode.go
 
 	dedup *postDedupCache // idempotent-replay cache for outbound posts (gpk-bm3f)
 }
@@ -69,6 +70,7 @@ func newServer(cfg config) (*server, error) {
 		lastInbound: map[string]inboundRef{},
 		httpClient:  &http.Client{},
 		now:         func() time.Time { return time.Now() },
+		timings:     defaultSocketTimings(),
 		dedup:       newPostDedupCache(postDedupTTL),
 	}
 	if err := s.loadRegistries(); err != nil {

--- a/slack-channel/adapter/socketmode.go
+++ b/slack-channel/adapter/socketmode.go
@@ -1,0 +1,453 @@
+// Socket Mode transport — the ingress-free alternative to the public
+// /slack/events listener.
+//
+// Socket Mode replaces Slack's inbound HTTP webhook with an outbound
+// WebSocket the adapter opens to Slack. Nothing listens on a public port and
+// no TLS terminator or tunnel is needed, which is the only way to run this
+// pack on a network that cannot accept inbound connections.
+//
+// The transport is selected by SLACK_APP_TOKEN: when it is set the adapter
+// runs Socket Mode and never binds LISTEN_PUBLIC; when it is empty the
+// adapter keeps the original Events-API-over-HTTP behaviour unchanged. The
+// two are alternatives, never both at once — Slack itself refuses to deliver
+// events to a Request URL while Socket Mode is enabled on the app.
+//
+// This mirrors the slack-mini (Tier 1) transport of the same name; the only
+// substantive difference is that envelopes are handed to routeEvent, so
+// bindings, handle aliases, and identities all behave exactly as they do on
+// the HTTP path.
+//
+// Wire protocol (https://api.slack.com/apis/socket-mode):
+//
+//  1. POST apps.connections.open with the app-level token → a single-use
+//     wss:// URL, valid for ~30s.
+//  2. Dial it. Slack sends {"type":"hello"} on success.
+//  3. Each event arrives as an envelope: {"envelope_id":…,"type":"events_api",
+//     "payload":{…}}. The payload is byte-identical to the HTTP webhook body,
+//     which is why this file reuses routeEvent unchanged.
+//  4. Ack every envelope with {"envelope_id":…} within 3s or Slack redelivers.
+//  5. {"type":"disconnect"} warns the connection is going away, ~10s before
+//     it closes, so a replacement can be opened before events are missed.
+//
+// Interactivity is NOT carried over this transport. Tier 2's manifest ships
+// interactivity disabled, and /slack/interactions is an opt-in extra that
+// still requires a public URL; an operator who enables it cannot use Socket
+// Mode for that half. Envelopes of type "interactive" are dropped with a log
+// line rather than silently ignored.
+//
+// Authenticity differs from the HTTP path and is worth being explicit about:
+// there is no signing secret and no HMAC. The trust boundary is the TLS
+// connection the adapter itself opened using its app-level token — an
+// attacker cannot inject envelopes without already holding that token. This
+// is Slack's designed model for Socket Mode, not a relaxation of the HTTP
+// path, which keeps verifying signatures exactly as before.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/coder/websocket"
+)
+
+const (
+	// socketAckTimeout bounds the ack write. Slack redelivers an envelope
+	// that is not acked within 3s, so a write that cannot complete well
+	// inside that window is better abandoned than left blocking the reader.
+	socketAckTimeout = 2 * time.Second
+
+	// Liveness is checked by pinging Slack, not by bounding reads. A healthy
+	// Socket Mode connection can sit idle indefinitely — no traffic in bound
+	// channels means no data messages — and Slack's own keepalive pings are
+	// answered inside the WebSocket library without ever waking a read. A
+	// read deadline would therefore tear down perfectly good connections on
+	// any quiet workspace. A ping that goes unanswered is the real signal
+	// that a connection is wedged in a way TCP has not noticed yet.
+	socketPingInterval = 30 * time.Second
+	socketPingTimeout  = 10 * time.Second
+
+	// socketOpenTimeout bounds apps.connections.open plus the WebSocket
+	// handshake. The URL Slack returns expires in ~30s.
+	socketOpenTimeout = 30 * time.Second
+
+	// Reconnect backoff after a failed or lost connection. Reset once a
+	// connection is established (see runSocketMode).
+	socketBackoffMin = 1 * time.Second
+	socketBackoffMax = 30 * time.Second
+
+	// socketDrainGrace is how long a connection that announced a disconnect
+	// keeps reading after its replacement is live, so in-flight envelopes
+	// still get acked instead of being redelivered.
+	socketDrainGrace = 10 * time.Second
+
+	// maxSocketMessage caps a single inbound WebSocket message, mirroring
+	// maxInboundBody on the HTTP path.
+	maxSocketMessage = 1 << 20 // 1 MiB
+)
+
+// socketEnvelope is the Socket Mode frame wrapping each delivery. Payload is
+// the same JSON body the Events API would have POSTed to /slack/events.
+type socketEnvelope struct {
+	Type         string          `json:"type"`
+	EnvelopeID   string          `json:"envelope_id,omitempty"`
+	Payload      json.RawMessage `json:"payload,omitempty"`
+	Reason       string          `json:"reason,omitempty"`
+	RetryAttempt int             `json:"retry_attempt,omitempty"`
+}
+
+// socketConn is the WebSocket surface this file needs, extracted so the
+// envelope loop can be tested against a scripted connection without standing
+// up a server. realSocketConn is the only production implementation.
+type socketConn interface {
+	Read(ctx context.Context) ([]byte, error)
+	Write(ctx context.Context, data []byte) error
+	// Ping sends a WebSocket ping and waits for the matching pong, which is
+	// how liveness is established on a connection that may legitimately carry
+	// no data for hours.
+	Ping(ctx context.Context) error
+	Close() error
+}
+
+type realSocketConn struct{ c *websocket.Conn }
+
+func (r realSocketConn) Read(ctx context.Context) ([]byte, error) {
+	_, data, err := r.c.Read(ctx)
+	return data, err
+}
+
+func (r realSocketConn) Write(ctx context.Context, data []byte) error {
+	return r.c.Write(ctx, websocket.MessageText, data)
+}
+
+func (r realSocketConn) Ping(ctx context.Context) error { return r.c.Ping(ctx) }
+
+func (r realSocketConn) Close() error {
+	// CloseNow over a handshaked close: the peer is Slack and the connection
+	// is being discarded either way, so waiting on a close reply only delays
+	// the redial.
+	return r.c.CloseNow()
+}
+
+// runSocketMode supervises the Socket Mode connection until ctx is done,
+// redialing with capped exponential backoff. It returns only when ctx is
+// cancelled; every other failure is a reconnect, because losing the socket
+// is the expected steady state (Slack recycles connections routinely) rather
+// than a fatal condition.
+func (s *server) runSocketMode(ctx context.Context) error {
+	backoff := socketBackoffMin
+	for {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		warned := make(chan struct{}, 1)
+		done, err := s.runSocketConnection(ctx, func() {
+			select {
+			case warned <- struct{}{}:
+			default: // already warned; one signal is enough
+			}
+		})
+		if err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			log.Printf("socket mode: connect failed: %v (retrying in %s)", err, backoff)
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(backoff):
+			}
+			if backoff *= 2; backoff > socketBackoffMax {
+				backoff = socketBackoffMax
+			}
+			continue
+		}
+		// A live connection means the backoff has served its purpose.
+		backoff = socketBackoffMin
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+
+		case <-warned:
+			// Slack warned this socket is closing, ~10s ahead. Dial the
+			// replacement now, while the old connection keeps draining and
+			// acking in its own goroutine — that overlap is the entire
+			// reason Slack sends the warning early. The drained connection
+			// closes itself; nothing here needs to wait for it.
+			log.Printf("socket mode: opening replacement connection")
+			continue
+
+		case err := <-done:
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			if err != nil {
+				log.Printf("socket mode: connection ended: %v (reconnecting in %s)", err, backoff)
+			} else {
+				log.Printf("socket mode: connection closed (reconnecting in %s)", backoff)
+			}
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(backoff):
+			}
+			if backoff *= 2; backoff > socketBackoffMax {
+				backoff = socketBackoffMax
+			}
+		}
+	}
+}
+
+// runSocketConnection dials one connection and pumps it in the background,
+// returning a channel that yields the pump's outcome. Dialing is synchronous
+// so the caller can distinguish "could not connect" (back off) from "was
+// connected and then ended" (reconnect promptly); pumping is not, so the
+// caller can react to a disconnect warning without waiting for the drain.
+// onWarning fires when Slack announces an impending close.
+func (s *server) runSocketConnection(ctx context.Context, onWarning func()) (<-chan error, error) {
+	conn, err := dialSocketMode(ctx, s.cfg)
+	if err != nil {
+		return nil, err
+	}
+	done := make(chan error, 1)
+	go func() { done <- s.pumpSocket(ctx, conn, onWarning) }()
+	return done, nil
+}
+
+// dialSocketMode negotiates a connection URL and opens it.
+func dialSocketMode(ctx context.Context, cfg config) (socketConn, error) {
+	openCtx, cancel := context.WithTimeout(ctx, socketOpenTimeout)
+	defer cancel()
+
+	wsURL, err := openSocketConnectionURL(openCtx, cfg)
+	if err != nil {
+		return nil, err
+	}
+	// Dial through http.DefaultClient rather than a bare TLS dial so
+	// HTTP_PROXY/HTTPS_PROXY are honoured — the adapter is expected to run
+	// on exactly the kind of restricted network that needs an egress proxy.
+	c, _, err := websocket.Dial(openCtx, wsURL, &websocket.DialOptions{
+		HTTPClient: http.DefaultClient,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("dial socket mode: %w", err)
+	}
+	c.SetReadLimit(maxSocketMessage)
+	log.Printf("socket mode: connected")
+	return realSocketConn{c: c}, nil
+}
+
+// appsConnectionsOpenResp is the apps.connections.open reply.
+type appsConnectionsOpenResp struct {
+	OK    bool   `json:"ok"`
+	URL   string `json:"url,omitempty"`
+	Error string `json:"error,omitempty"`
+}
+
+// openSocketConnectionURL calls apps.connections.open, which is the only
+// endpoint that accepts the app-level (xapp-) token rather than the bot
+// token.
+func openSocketConnectionURL(ctx context.Context, cfg config) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, cfg.slackAPIBase+"/apps.connections.open", nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+cfg.appToken)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("apps.connections.open: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxSocketMessage))
+	if err != nil {
+		return "", fmt.Errorf("read apps.connections.open response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("apps.connections.open http %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	var out appsConnectionsOpenResp
+	if err := json.Unmarshal(body, &out); err != nil {
+		return "", fmt.Errorf("decode apps.connections.open response: %w", err)
+	}
+	if !out.OK {
+		// invalid_auth here almost always means the token is a bot token or
+		// is missing the connections:write scope; say so rather than making
+		// the operator look it up.
+		return "", fmt.Errorf("apps.connections.open: %s (app-level token needs the connections:write scope)", out.Error)
+	}
+	if out.URL == "" {
+		return "", errors.New("apps.connections.open returned no url")
+	}
+	return out.URL, nil
+}
+
+// pumpSocket reads envelopes until the connection ends, acking each one and
+// routing events through the same path the HTTP listener uses.
+func (s *server) pumpSocket(ctx context.Context, conn socketConn, onWarning func()) error {
+	defer func() { _ = conn.Close() }()
+
+	// connCtx bounds this connection specifically: the keepalive cancels it
+	// when Slack stops answering pings, and the drain timer cancels it when a
+	// warned-about connection has had long enough to finish. Reads block on
+	// it with no deadline of their own — see socketPingInterval.
+	connCtx, closeConn := context.WithCancel(ctx)
+	defer closeConn()
+	go keepaliveSocket(connCtx, conn, socketPingInterval, closeConn)
+
+	// A disconnect warning arrives ~10s before Slack drops the socket. Rather
+	// than tear down immediately (which loses whatever is in flight), the
+	// caller is signalled to open a replacement while this loop keeps
+	// draining and acking on the doomed connection.
+	draining := false
+
+	for {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		data, err := conn.Read(connCtx)
+		if err != nil {
+			if draining {
+				// Expected: the warned-about close finally landed, or the
+				// drain window elapsed.
+				return nil
+			}
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			return err
+		}
+
+		var env socketEnvelope
+		if err := json.Unmarshal(data, &env); err != nil {
+			log.Printf("socket mode: undecodable frame: %v", err)
+			continue
+		}
+
+		switch env.Type {
+		case "hello":
+			continue
+		case "disconnect":
+			log.Printf("socket mode: disconnect requested (reason=%s), draining", env.Reason)
+			if !draining {
+				draining = true
+				// Bound the drain: if Slack never actually closes, this
+				// connection must not linger next to its replacement.
+				time.AfterFunc(socketDrainGrace, closeConn)
+				if onWarning != nil {
+					onWarning()
+				}
+			}
+			continue
+		}
+
+		if env.EnvelopeID != "" {
+			ackCtx, ackCancel := context.WithTimeout(ctx, socketAckTimeout)
+			ackErr := conn.Write(ackCtx, socketAck(env.EnvelopeID))
+			ackCancel()
+			if ackErr != nil {
+				// Acking is what stops redelivery, so a failed ack means the
+				// connection is no longer usable — redial and let Slack
+				// redeliver rather than processing on a dead socket.
+				return fmt.Errorf("ack envelope %s: %w", env.EnvelopeID, ackErr)
+			}
+		}
+
+		// Route off the read loop, exactly as the HTTP path does after its
+		// ack: delivery fans out to every bound session and is bounded by
+		// gcCallTimeout, and a slow gc must not stall acks for the envelopes
+		// queued behind this one.
+		go s.handleSocketEnvelope(env)
+	}
+}
+
+// keepaliveSocket pings Slack on a fixed interval and closes the connection
+// when a ping goes unanswered. This is the liveness check for a transport
+// whose healthy state is silence: without it, a connection dropped in a way
+// that never reaches TCP (a NAT timeout, a proxy reaping an idle tunnel)
+// would leave the adapter reading forever from a socket Slack has forgotten.
+func keepaliveSocket(ctx context.Context, conn socketConn, interval time.Duration, closeConn func()) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			pingCtx, cancel := context.WithTimeout(ctx, socketPingTimeout)
+			err := conn.Ping(pingCtx)
+			cancel()
+			if err != nil {
+				if ctx.Err() != nil {
+					return // shutting down; not a ping failure
+				}
+				log.Printf("socket mode: keepalive ping failed: %v", err)
+				closeConn()
+				return
+			}
+		}
+	}
+}
+
+// socketAck builds the ack frame for an envelope.
+func socketAck(envelopeID string) []byte {
+	// Marshal rather than concatenate: envelope ids are Slack-supplied and
+	// must not be able to break out of the JSON they are embedded in.
+	b, err := json.Marshal(map[string]string{"envelope_id": envelopeID})
+	if err != nil {
+		// Unreachable for a map[string]string, but never emit a malformed ack.
+		return []byte(`{}`)
+	}
+	return b
+}
+
+// handleSocketEnvelope routes one non-control envelope. The payload is the
+// same shape the HTTP listener decodes, so routing — bindings, handle
+// aliases, the app_mention fallback — is shared verbatim with the webhook
+// path.
+func (s *server) handleSocketEnvelope(env socketEnvelope) {
+	// Log every delivery on arrival. Without it a dropped event is
+	// indistinguishable from Slack never having sent one — which is exactly
+	// the question an operator debugging a silent bot needs answered.
+	log.Printf("socket mode: envelope received type=%s", env.Type)
+	if env.Type == "interactive" {
+		// Tier 2 ships interactivity disabled; /slack/interactions is an
+		// opt-in extra that needs a public URL. Say so rather than dropping
+		// an operator's block-kit payload without explanation.
+		log.Printf("socket mode: interactive envelope dropped — Tier 2 does not handle interactivity over Socket Mode")
+		return
+	}
+	if env.Type != "events_api" || len(env.Payload) == 0 {
+		return
+	}
+	var payload slackEventEnvelope
+	if err := json.Unmarshal(env.Payload, &payload); err != nil {
+		log.Printf("socket mode: decode payload: %v", err)
+		return
+	}
+	// The HTTP path proves workspace identity via the signing secret. Socket
+	// Mode has no equivalent, and the adapter stamps every delivered message
+	// with cfg.workspaceID as its account id — so an event from another
+	// workspace (an app installed more than once) would be filed under the
+	// wrong account, and could match a channel binding belonging to a
+	// different workspace. Drop it instead.
+	if payload.TeamID != "" && payload.TeamID != s.cfg.workspaceID {
+		log.Printf("socket mode: dropping event from unexpected team %s (want %s)", payload.TeamID, s.cfg.workspaceID)
+		return
+	}
+	if env.RetryAttempt > 0 {
+		// Delivery is deduped downstream, so a redelivery is harmless; log it
+		// because a persistent retry count means acks are not landing in time.
+		log.Printf("socket mode: redelivered envelope (attempt %d)", env.RetryAttempt)
+	}
+	s.routeEvent(payload)
+}

--- a/slack-channel/adapter/socketmode.go
+++ b/slack-channel/adapter/socketmode.go
@@ -12,10 +12,18 @@
 // two are alternatives, never both at once — Slack itself refuses to deliver
 // events to a Request URL while Socket Mode is enabled on the app.
 //
-// This mirrors the slack-mini (Tier 1) transport of the same name; the only
-// substantive difference is that envelopes are handed to routeEvent, so
-// bindings, handle aliases, and identities all behave exactly as they do on
-// the HTTP path.
+// This mirrors the slack-mini (Tier 1) transport of the same name. Two things
+// differ. Envelopes are handed to routeEvent, so bindings, handle aliases, and
+// identities all behave exactly as they do on the HTTP path. And the
+// foreign-workspace drop lives at that shared funnel (inbound.go) rather than
+// in this file, so one check covers both transports — see the comment on the
+// guard there for why the HTTP path needs it too.
+//
+// Shape, as opposed to behaviour: the supervision loop and the envelope pump
+// are split into named arms (superviseConnection, paceRedial, pumpReadErr,
+// startDrain, ackEnvelope) that mini keeps inline on main. That split is
+// mini's own, from gascity-packs#407; this file adopts it up front so the
+// reference diff stays small once #407 lands. Everything else is a port.
 //
 // Wire protocol (https://api.slack.com/apis/socket-mode):
 //
@@ -78,9 +86,18 @@ const (
 	socketOpenTimeout = 30 * time.Second
 
 	// Reconnect backoff after a failed or lost connection. Reset once a
-	// connection is established (see runSocketMode).
+	// connection has lasted socketMinLifetime (see settleBackoff).
 	socketBackoffMin = 1 * time.Second
 	socketBackoffMax = 30 * time.Second
+
+	// socketMinLifetime is how long a connection must survive before its
+	// successor is allowed to start from socketBackoffMin again. Resetting on
+	// establishment alone lets a server that accepts a connection and drops or
+	// disowns it immediately be redialled at the floor forever; making a
+	// connection prove itself first is what escalates the delay in exactly that
+	// case. Slack recycles healthy connections on a far longer cadence, so
+	// ordinary refreshes still reset the backoff.
+	socketMinLifetime = 30 * time.Second
 
 	// socketDrainGrace is how long a connection that announced a disconnect
 	// keeps reading after its replacement is live, so in-flight envelopes
@@ -91,6 +108,44 @@ const (
 	// maxInboundBody on the HTTP path.
 	maxSocketMessage = 1 << 20 // 1 MiB
 )
+
+// socketTimings groups the connection-lifecycle timers. Production uses
+// defaultSocketTimings() (set by newServer); tests overwrite server.timings
+// with a scaled-down copy so the same code paths can be driven in
+// milliseconds.
+//
+// The seam exists because these timers are the layer no test could otherwise
+// reach: read at their call sites, they made it impossible to pin that
+// pumpSocket actually runs a keepalive, that a drain is bounded, or that
+// reconnects are paced — each of which stayed green through the mutation that
+// removed it. socketPingTimeout, socketAckTimeout and socketOpenTimeout stay
+// constants deliberately: nothing drives them, and a knob no test turns is
+// only a wider surface.
+//
+// slack-mini threads the same set as an explicit parameter because its socket
+// functions are free functions; here they are methods on server, which already
+// carries the adapter's other injected seams (httpClient, now), so the timers
+// live alongside them.
+type socketTimings struct {
+	pingInterval time.Duration
+	drainGrace   time.Duration
+	backoffMin   time.Duration
+	backoffMax   time.Duration
+	// minLifetime is how long a connection must last before its successor is
+	// allowed to start from backoffMin again.
+	minLifetime time.Duration
+}
+
+// defaultSocketTimings is the production timer set.
+func defaultSocketTimings() socketTimings {
+	return socketTimings{
+		pingInterval: socketPingInterval,
+		drainGrace:   socketDrainGrace,
+		backoffMin:   socketBackoffMin,
+		backoffMax:   socketBackoffMax,
+		minLifetime:  socketMinLifetime,
+	}
+}
 
 // socketEnvelope is the Socket Mode frame wrapping each delivery. Payload is
 // the same JSON body the Events API would have POSTed to /slack/events.
@@ -141,68 +196,127 @@ func (r realSocketConn) Close() error {
 // is the expected steady state (Slack recycles connections routinely) rather
 // than a fatal condition.
 func (s *server) runSocketMode(ctx context.Context) error {
-	backoff := socketBackoffMin
+	backoff := s.timings.backoffMin
 	for {
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
 
-		warned := make(chan struct{}, 1)
-		done, err := s.runSocketConnection(ctx, func() {
-			select {
-			case warned <- struct{}{}:
-			default: // already warned; one signal is enough
-			}
-		})
+		next, err := s.superviseConnection(ctx, backoff)
 		if err != nil {
-			if ctx.Err() != nil {
-				return ctx.Err()
-			}
-			log.Printf("socket mode: connect failed: %v (retrying in %s)", err, backoff)
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case <-time.After(backoff):
-			}
-			if backoff *= 2; backoff > socketBackoffMax {
-				backoff = socketBackoffMax
-			}
-			continue
+			return err
 		}
-		// A live connection means the backoff has served its purpose.
-		backoff = socketBackoffMin
+		backoff = next
+	}
+}
 
+// superviseConnection runs exactly one connection's lifecycle: dial it, wait
+// for it to end (or to be warned about), pace the delay before the next dial,
+// and return the backoff that dial should start from. A non-nil error means the
+// supervisor should stop — only shutdown produces one, which is what makes
+// runSocketMode's loop return solely on cancellation.
+//
+// slack-mini splits this loop into the same three parts — superviseConnection,
+// paceRedial, and the pump helpers below — in gascity-packs#407, where
+// superviseConnection is a free function taking cfg and the timer set as
+// parameters. Here it is a method, for the same reason socketTimings is a
+// field rather than a threaded parameter: channel's socket code hangs off
+// server, which already carries cfg and the other injected seams. The arms
+// themselves are line-for-line mini's, so the two files converge rather than
+// drift once that change lands.
+func (s *server) superviseConnection(ctx context.Context, backoff time.Duration) (time.Duration, error) {
+	tm := s.timings
+	warned := make(chan struct{}, 1)
+	done, err := s.runSocketConnection(ctx, func() {
 		select {
-		case <-ctx.Done():
-			return ctx.Err()
-
-		case <-warned:
-			// Slack warned this socket is closing, ~10s ahead. Dial the
-			// replacement now, while the old connection keeps draining and
-			// acking in its own goroutine — that overlap is the entire
-			// reason Slack sends the warning early. The drained connection
-			// closes itself; nothing here needs to wait for it.
-			log.Printf("socket mode: opening replacement connection")
-			continue
-
-		case err := <-done:
-			if ctx.Err() != nil {
-				return ctx.Err()
-			}
-			if err != nil {
-				log.Printf("socket mode: connection ended: %v (reconnecting in %s)", err, backoff)
-			} else {
-				log.Printf("socket mode: connection closed (reconnecting in %s)", backoff)
-			}
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case <-time.After(backoff):
-			}
-			if backoff *= 2; backoff > socketBackoffMax {
-				backoff = socketBackoffMax
-			}
+		case warned <- struct{}{}:
+		default: // already warned; one signal is enough
 		}
+	})
+	if err != nil {
+		if ctx.Err() != nil {
+			return backoff, ctx.Err()
+		}
+		log.Printf("socket mode: connect failed: %v (retrying in %s)", err, backoff)
+		return paceRedial(ctx, backoff, tm)
+	}
+	connectedAt := time.Now()
+
+	select {
+	case <-ctx.Done():
+		return backoff, ctx.Err()
+
+	case <-warned:
+		// Slack warned this socket is closing, ~10s ahead. The replacement
+		// is dialled while the old connection keeps draining and acking in
+		// its own goroutine — that overlap is the entire reason Slack sends
+		// the warning early. The drained connection closes itself; nothing
+		// here needs to wait for it.
+		//
+		// The dial is paced all the same. A connection that lasted a normal
+		// lifetime resets the delay to backoffMin first, which fits inside
+		// the warning's ~10s lead and keeps the overlap; only a connection
+		// warned moments after it opened — the connection-limit churn two
+		// adapters sharing one app token produce — carries an escalating
+		// delay here, and that is precisely the case this path used to
+		// redial at network speed.
+		backoff = settleBackoff(backoff, time.Since(connectedAt), tm)
+		log.Printf("socket mode: opening replacement connection in %s", backoff)
+		return paceRedial(ctx, backoff, tm)
+
+	case connErr := <-done:
+		if ctx.Err() != nil {
+			return backoff, ctx.Err()
+		}
+		backoff = settleBackoff(backoff, time.Since(connectedAt), tm)
+		if connErr != nil {
+			log.Printf("socket mode: connection ended: %v (reconnecting in %s)", connErr, backoff)
+		} else {
+			log.Printf("socket mode: connection closed (reconnecting in %s)", backoff)
+		}
+		return paceRedial(ctx, backoff, tm)
+	}
+}
+
+// paceRedial waits out the current delay and returns the delay the dial after
+// it should use. Shutdown during the wait is reported as an error, which stops
+// the supervisor rather than redialling into a cancelled context.
+func paceRedial(ctx context.Context, backoff time.Duration, tm socketTimings) (time.Duration, error) {
+	if waitErr := sleepFor(ctx, backoff); waitErr != nil {
+		return backoff, waitErr
+	}
+	return nextBackoff(backoff, tm), nil
+}
+
+// settleBackoff picks the delay before the next dial from how long the
+// connection that just ended lasted. A connection that survived
+// tm.minLifetime proved the endpoint healthy, so its successor starts from the
+// floor again; one that died sooner keeps the escalating delay, which is what
+// stops a dial-OK → instant-death cycle from redialling at the floor forever.
+func settleBackoff(backoff, lifetime time.Duration, tm socketTimings) time.Duration {
+	if lifetime >= tm.minLifetime {
+		return tm.backoffMin
+	}
+	return backoff
+}
+
+// nextBackoff doubles the reconnect delay, capped.
+func nextBackoff(backoff time.Duration, tm socketTimings) time.Duration {
+	backoff *= 2
+	if backoff > tm.backoffMax {
+		return tm.backoffMax
+	}
+	return backoff
+}
+
+// sleepFor waits for d, returning early with ctx.Err() if the context is
+// cancelled first.
+func sleepFor(ctx context.Context, d time.Duration) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(d):
+		return nil
 	}
 }
 
@@ -301,7 +415,7 @@ func (s *server) pumpSocket(ctx context.Context, conn socketConn, onWarning func
 	// it with no deadline of their own — see socketPingInterval.
 	connCtx, closeConn := context.WithCancel(ctx)
 	defer closeConn()
-	go keepaliveSocket(connCtx, conn, socketPingInterval, closeConn)
+	go keepaliveSocket(connCtx, conn, s.timings.pingInterval, closeConn)
 
 	// A disconnect warning arrives ~10s before Slack drops the socket. Rather
 	// than tear down immediately (which loses whatever is in flight), the
@@ -316,15 +430,7 @@ func (s *server) pumpSocket(ctx context.Context, conn socketConn, onWarning func
 
 		data, err := conn.Read(connCtx)
 		if err != nil {
-			if draining {
-				// Expected: the warned-about close finally landed, or the
-				// drain window elapsed.
-				return nil
-			}
-			if ctx.Err() != nil {
-				return ctx.Err()
-			}
-			return err
+			return pumpReadErr(ctx, err, draining)
 		}
 
 		var env socketEnvelope
@@ -340,26 +446,13 @@ func (s *server) pumpSocket(ctx context.Context, conn socketConn, onWarning func
 			log.Printf("socket mode: disconnect requested (reason=%s), draining", env.Reason)
 			if !draining {
 				draining = true
-				// Bound the drain: if Slack never actually closes, this
-				// connection must not linger next to its replacement.
-				time.AfterFunc(socketDrainGrace, closeConn)
-				if onWarning != nil {
-					onWarning()
-				}
+				startDrain(s.timings, closeConn, onWarning)
 			}
 			continue
 		}
 
-		if env.EnvelopeID != "" {
-			ackCtx, ackCancel := context.WithTimeout(ctx, socketAckTimeout)
-			ackErr := conn.Write(ackCtx, socketAck(env.EnvelopeID))
-			ackCancel()
-			if ackErr != nil {
-				// Acking is what stops redelivery, so a failed ack means the
-				// connection is no longer usable — redial and let Slack
-				// redeliver rather than processing on a dead socket.
-				return fmt.Errorf("ack envelope %s: %w", env.EnvelopeID, ackErr)
-			}
+		if ackErr := ackEnvelope(ctx, conn, env.EnvelopeID); ackErr != nil {
+			return ackErr
 		}
 
 		// Route off the read loop, exactly as the HTTP path does after its
@@ -368,6 +461,51 @@ func (s *server) pumpSocket(ctx context.Context, conn socketConn, onWarning func
 		// queued behind this one.
 		go s.handleSocketEnvelope(env)
 	}
+}
+
+// pumpReadErr maps a failed connection read to the pump's return value. A read
+// that fails while draining is the expected end of a warned-about connection,
+// not a fault; a read that fails during shutdown reports the shutdown.
+func pumpReadErr(ctx context.Context, readErr error, draining bool) error {
+	if draining {
+		// Expected: the warned-about close finally landed, or the drain
+		// window elapsed.
+		return nil
+	}
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	return readErr
+}
+
+// startDrain begins the drain of a connection Slack has announced it will
+// close: the window is bounded, and the supervisor is signalled to dial the
+// replacement that overlaps it.
+func startDrain(tm socketTimings, closeConn func(), onWarning func()) {
+	// Bound the drain: if Slack never actually closes, this connection must
+	// not linger next to its replacement.
+	time.AfterFunc(tm.drainGrace, closeConn)
+	if onWarning != nil {
+		onWarning()
+	}
+}
+
+// ackEnvelope acknowledges one envelope. Envelopes that carry no id (hello,
+// disconnect) are not acked, matching Slack's protocol.
+func ackEnvelope(ctx context.Context, conn socketConn, envelopeID string) error {
+	if envelopeID == "" {
+		return nil
+	}
+	ackCtx, ackCancel := context.WithTimeout(ctx, socketAckTimeout)
+	ackErr := conn.Write(ackCtx, socketAck(envelopeID))
+	ackCancel()
+	if ackErr != nil {
+		// Acking is what stops redelivery, so a failed ack means the
+		// connection is no longer usable — redial and let Slack redeliver
+		// rather than processing on a dead socket.
+		return fmt.Errorf("ack envelope %s: %w", envelopeID, ackErr)
+	}
+	return nil
 }
 
 // keepaliveSocket pings Slack on a fixed interval and closes the connection
@@ -412,8 +550,8 @@ func socketAck(envelopeID string) []byte {
 
 // handleSocketEnvelope routes one non-control envelope. The payload is the
 // same shape the HTTP listener decodes, so routing — bindings, handle
-// aliases, the app_mention fallback — is shared verbatim with the webhook
-// path.
+// aliases, the app_mention fallback, and the foreign-workspace drop — is
+// shared verbatim with the webhook path.
 func (s *server) handleSocketEnvelope(env socketEnvelope) {
 	// Log every delivery on arrival. Without it a dropped event is
 	// indistinguishable from Slack never having sent one — which is exactly
@@ -432,16 +570,6 @@ func (s *server) handleSocketEnvelope(env socketEnvelope) {
 	var payload slackEventEnvelope
 	if err := json.Unmarshal(env.Payload, &payload); err != nil {
 		log.Printf("socket mode: decode payload: %v", err)
-		return
-	}
-	// The HTTP path proves workspace identity via the signing secret. Socket
-	// Mode has no equivalent, and the adapter stamps every delivered message
-	// with cfg.workspaceID as its account id — so an event from another
-	// workspace (an app installed more than once) would be filed under the
-	// wrong account, and could match a channel binding belonging to a
-	// different workspace. Drop it instead.
-	if payload.TeamID != "" && payload.TeamID != s.cfg.workspaceID {
-		log.Printf("socket mode: dropping event from unexpected team %s (want %s)", payload.TeamID, s.cfg.workspaceID)
 		return
 	}
 	if env.RetryAttempt > 0 {

--- a/slack-channel/adapter/socketmode_test.go
+++ b/slack-channel/adapter/socketmode_test.go
@@ -1,0 +1,612 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+)
+
+// scriptedConn is a socketConn that replays a fixed sequence of frames and
+// records everything written back, so the envelope loop can be exercised
+// without a server.
+type scriptedConn struct {
+	mu     sync.Mutex
+	frames [][]byte
+	next   int
+	writes [][]byte
+	closed bool
+	// blockAfterScript, when set, makes Read block on ctx instead of
+	// returning io.EOF once the script is exhausted — used to model a
+	// connection that stays open.
+	blockAfterScript bool
+	// pingErr, when set, makes Ping fail — a wedged connection.
+	pingErr error
+	pings   int
+}
+
+func (s *scriptedConn) Read(ctx context.Context) ([]byte, error) {
+	s.mu.Lock()
+	if s.next < len(s.frames) {
+		frame := s.frames[s.next]
+		s.next++
+		s.mu.Unlock()
+		return frame, nil
+	}
+	s.mu.Unlock()
+	if s.blockAfterScript {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	return nil, io.EOF
+}
+
+func (s *scriptedConn) Write(_ context.Context, data []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.writes = append(s.writes, append([]byte(nil), data...))
+	return nil
+}
+
+func (s *scriptedConn) Ping(_ context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.pings++
+	return s.pingErr
+}
+
+func (s *scriptedConn) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.closed = true
+	return nil
+}
+
+func (s *scriptedConn) written() [][]byte {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([][]byte(nil), s.writes...)
+}
+
+// gcStub stands in for the gc API, signalling each bridged inbound message.
+func gcStub(t *testing.T) (*httptest.Server, chan externalInboundMessage) {
+	t.Helper()
+	got := make(chan externalInboundMessage, 8)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var wrap struct {
+			Message externalInboundMessage `json:"message"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&wrap); err != nil {
+			t.Errorf("decode inbound: %v", err)
+		}
+		got <- wrap.Message
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, got
+}
+
+func appMentionEnvelope(t *testing.T, envelopeID, teamID, text string) []byte {
+	t.Helper()
+	event, err := json.Marshal(slackMessageEvent{
+		Type:        "app_mention",
+		User:        "U99",
+		Text:        text,
+		Channel:     "C42",
+		TS:          "1700000000.0001",
+		ChannelType: "channel",
+	})
+	if err != nil {
+		t.Fatalf("marshal event: %v", err)
+	}
+	payload, err := json.Marshal(slackEventEnvelope{
+		Type:   "event_callback",
+		TeamID: teamID,
+		Event:  event,
+	})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	frame, err := json.Marshal(socketEnvelope{
+		Type:       "events_api",
+		EnvelopeID: envelopeID,
+		Payload:    payload,
+	})
+	if err != nil {
+		t.Fatalf("marshal envelope: %v", err)
+	}
+	return frame
+}
+
+func TestConfigSocketModeSelector(t *testing.T) {
+	regDir := t.TempDir()
+	// Socket Mode does not consult the signing secret, so it must not be
+	// required — that is the whole point of the ingress-free path.
+	cfg, err := loadConfigFromEnv(func(key string) string {
+		switch key {
+		case "SLACK_APP_TOKEN":
+			return "xapp-1-A-abc"
+		case "SLACK_BOT_TOKEN":
+			return "xoxb-abc"
+		case "SLACK_WORKSPACE_ID":
+			return "T123"
+		case "GC_CITY_NAME":
+			return "mycity"
+		case "SLACK_CHANNEL_REGISTRY_DIR":
+			return regDir
+		}
+		return ""
+	})
+	if err != nil {
+		t.Fatalf("socket-mode config rejected: %v", err)
+	}
+	if !cfg.socketMode() {
+		t.Error("socketMode() = false with SLACK_APP_TOKEN set")
+	}
+
+	// Without an app token the HTTP transport still demands its secret.
+	_, err = loadConfigFromEnv(func(key string) string {
+		switch key {
+		case "SLACK_BOT_TOKEN":
+			return "xoxb-abc"
+		case "SLACK_WORKSPACE_ID":
+			return "T123"
+		case "GC_CITY_NAME":
+			return "mycity"
+		case "SLACK_CHANNEL_REGISTRY_DIR":
+			return regDir
+		}
+		return ""
+	})
+	if err == nil || !strings.Contains(err.Error(), "SLACK_SIGNING_SECRET") {
+		t.Errorf("http mode without signing secret: err = %v, want SLACK_SIGNING_SECRET required", err)
+	}
+}
+
+func TestConfigRejectsBotTokenAsAppToken(t *testing.T) {
+	regDir := t.TempDir()
+	_, err := loadConfigFromEnv(func(key string) string {
+		switch key {
+		case "SLACK_APP_TOKEN":
+			return "xoxb-not-an-app-token"
+		case "SLACK_BOT_TOKEN":
+			return "xoxb-abc"
+		case "SLACK_WORKSPACE_ID":
+			return "T123"
+		case "GC_CITY_NAME":
+			return "mycity"
+		case "SLACK_CHANNEL_REGISTRY_DIR":
+			return regDir
+		}
+		return ""
+	})
+	if err == nil || !strings.Contains(err.Error(), "xapp-") {
+		t.Errorf("err = %v, want a message naming the xapp- prefix", err)
+	}
+}
+
+func TestOpenSocketConnectionURL(t *testing.T) {
+	var gotAuth, gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true,"url":"wss://wss-primary.slack.com/link/?ticket=abc"}`))
+	}))
+	defer srv.Close()
+
+	url, err := openSocketConnectionURL(context.Background(), config{
+		slackAPIBase: srv.URL,
+		appToken:     "xapp-1-A-abc",
+	})
+	if err != nil {
+		t.Fatalf("openSocketConnectionURL: %v", err)
+	}
+	if url != "wss://wss-primary.slack.com/link/?ticket=abc" {
+		t.Errorf("url = %q", url)
+	}
+	// The app-level token, not the bot token, authenticates this call.
+	if gotAuth != "Bearer xapp-1-A-abc" {
+		t.Errorf("Authorization = %q", gotAuth)
+	}
+	if gotPath != "/apps.connections.open" {
+		t.Errorf("path = %q", gotPath)
+	}
+}
+
+func TestOpenSocketConnectionURLSurfacesScopeHint(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"ok":false,"error":"invalid_auth"}`))
+	}))
+	defer srv.Close()
+
+	_, err := openSocketConnectionURL(context.Background(), config{
+		slackAPIBase: srv.URL,
+		appToken:     "xapp-1-A-abc",
+	})
+	if err == nil {
+		t.Fatal("want error on ok:false")
+	}
+	// The overwhelmingly common cause is a missing scope; the message should
+	// say so rather than leaving the operator with a bare invalid_auth.
+	if !strings.Contains(err.Error(), "invalid_auth") || !strings.Contains(err.Error(), "connections:write") {
+		t.Errorf("err = %v, want invalid_auth plus the connections:write hint", err)
+	}
+}
+
+func TestPumpSocketAcksThenBridges(t *testing.T) {
+	gc, inbound := gcStub(t)
+	srv := newTestServer(t)
+	srv.cfg.gcAPIBase = gc.URL
+	conn := &scriptedConn{frames: [][]byte{
+		[]byte(`{"type":"hello","num_connections":1}`),
+		appMentionEnvelope(t, "env-1", "T123", "<@U0BOT> deploy please"),
+	}}
+
+	if err := srv.pumpSocket(context.Background(), conn, nil); !errors.Is(err, io.EOF) {
+		t.Fatalf("pumpSocket err = %v, want io.EOF at end of script", err)
+	}
+
+	writes := conn.written()
+	if len(writes) != 1 {
+		t.Fatalf("wrote %d frames, want exactly 1 ack (hello is not acked)", len(writes))
+	}
+	var ack map[string]string
+	if err := json.Unmarshal(writes[0], &ack); err != nil {
+		t.Fatalf("ack is not JSON: %v (%s)", err, writes[0])
+	}
+	if ack["envelope_id"] != "env-1" {
+		t.Errorf("ack = %v, want envelope_id env-1", ack)
+	}
+
+	select {
+	case msg := <-inbound:
+		if msg.Text != "deploy please" {
+			t.Errorf("bridged Text = %q, want the mention stripped", msg.Text)
+		}
+		if msg.ExplicitTarget != "mayor" {
+			t.Errorf("bridged ExplicitTarget = %q", msg.ExplicitTarget)
+		}
+		// Tier 2 scopes the dedup key per delivery target, because one
+		// message fans out to every session bound to the channel.
+		if msg.DedupKey != "slack-1700000000.0001-mayor" {
+			t.Errorf("bridged DedupKey = %q", msg.DedupKey)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("event was acked but never bridged to gc")
+	}
+	if !conn.closed {
+		t.Error("pumpSocket returned without closing the connection")
+	}
+}
+
+func TestPumpSocketDrainsAfterDisconnect(t *testing.T) {
+	gc, inbound := gcStub(t)
+	srv := newTestServer(t)
+	srv.cfg.gcAPIBase = gc.URL
+	conn := &scriptedConn{frames: [][]byte{
+		[]byte(`{"type":"disconnect","reason":"refresh_requested"}`),
+		appMentionEnvelope(t, "env-2", "T123", "<@U0BOT> still here"),
+	}}
+
+	// A warned-about close is orderly, not an error: envelopes already in
+	// flight are still acked, and the supervisor reconnects without logging
+	// a failure.
+	if err := srv.pumpSocket(context.Background(), conn, nil); err != nil {
+		t.Fatalf("pumpSocket err = %v, want nil after a disconnect warning", err)
+	}
+	if writes := conn.written(); len(writes) != 1 {
+		t.Errorf("wrote %d frames, want the in-flight envelope acked during drain", len(writes))
+	}
+	select {
+	case <-inbound:
+	case <-time.After(5 * time.Second):
+		t.Fatal("envelope received during drain was never bridged")
+	}
+}
+
+func TestPumpSocketSkipsUndecodableFrame(t *testing.T) {
+	srv := newTestServer(t)
+	srv.cfg.gcAPIBase = "http://127.0.0.1:1"
+	conn := &scriptedConn{frames: [][]byte{[]byte(`{not json`)}}
+	// A malformed frame must not kill the connection — the next envelope on
+	// the same socket should still be read.
+	if err := srv.pumpSocket(context.Background(), conn, nil); !errors.Is(err, io.EOF) {
+		t.Fatalf("pumpSocket err = %v, want the loop to continue to EOF", err)
+	}
+	if len(conn.written()) != 0 {
+		t.Error("acked an undecodable frame")
+	}
+}
+
+func TestPumpSocketStopsOnContextCancel(t *testing.T) {
+	srv := newTestServer(t)
+	srv.cfg.gcAPIBase = "http://127.0.0.1:1"
+	conn := &scriptedConn{blockAfterScript: true}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- srv.pumpSocket(ctx, conn, nil) }()
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("pumpSocket ignored context cancellation")
+	}
+}
+
+func TestHandleSocketEnvelopeDropsForeignWorkspace(t *testing.T) {
+	gc, inbound := gcStub(t)
+	srv := newTestServer(t)
+	srv.cfg.gcAPIBase = gc.URL
+
+	var env socketEnvelope
+	if err := json.Unmarshal(appMentionEnvelope(t, "env-3", "T_OTHER", "<@U0BOT> hi"), &env); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	// Every bridged message is stamped with cfg.workspaceID as its account
+	// id, so an event from another workspace would be filed under the wrong
+	// account. Socket Mode has no signature to catch it — this check does.
+	srv.handleSocketEnvelope(env)
+
+	select {
+	case msg := <-inbound:
+		t.Fatalf("bridged an event from a foreign workspace: %+v", msg)
+	case <-time.After(250 * time.Millisecond):
+	}
+}
+
+func TestHandleSocketEnvelopeIgnoresNonEventTypes(t *testing.T) {
+	gc, inbound := gcStub(t)
+	srv := newTestServer(t)
+	srv.cfg.gcAPIBase = gc.URL
+	// Interactivity and slash commands belong to the larger tiers; Tier 1
+	// must ignore them rather than misroute them as mentions.
+	srv.handleSocketEnvelope(socketEnvelope{Type: "interactive", EnvelopeID: "e", Payload: json.RawMessage(`{}`)})
+	select {
+	case msg := <-inbound:
+		t.Fatalf("bridged a non-events_api envelope: %+v", msg)
+	case <-time.After(250 * time.Millisecond):
+	}
+}
+
+func TestSocketAckEscapesEnvelopeID(t *testing.T) {
+	// Envelope ids are Slack-supplied; a hand-concatenated ack would let a
+	// crafted id break out of the JSON.
+	ack := socketAck(`abc","injected":"x`)
+	var decoded map[string]string
+	if err := json.Unmarshal(ack, &decoded); err != nil {
+		t.Fatalf("ack is not valid JSON: %v (%s)", err, ack)
+	}
+	if _, injected := decoded["injected"]; injected {
+		t.Errorf("envelope id escaped its field: %s", ack)
+	}
+	if decoded["envelope_id"] != `abc","injected":"x` {
+		t.Errorf("envelope_id = %q", decoded["envelope_id"])
+	}
+}
+
+// TestSocketModeEndToEnd drives the real transport: a WebSocket server stands
+// in for Slack, and the adapter negotiates, connects, acks, and bridges over
+// an actual connection rather than the scripted stub.
+func TestSocketModeEndToEnd(t *testing.T) {
+	gc, inbound := gcStub(t)
+
+	acked := make(chan string, 1)
+	wsSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			t.Errorf("accept: %v", err)
+			return
+		}
+		defer func() { _ = c.CloseNow() }()
+		ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+		defer cancel()
+
+		if err := c.Write(ctx, websocket.MessageText, []byte(`{"type":"hello"}`)); err != nil {
+			return
+		}
+		if err := c.Write(ctx, websocket.MessageText, appMentionEnvelope(t, "env-e2e", "T123", "<@U0BOT> ship it")); err != nil {
+			return
+		}
+		_, data, err := c.Read(ctx)
+		if err != nil {
+			return
+		}
+		var ack map[string]string
+		_ = json.Unmarshal(data, &ack)
+		acked <- ack["envelope_id"]
+	}))
+	defer wsSrv.Close()
+
+	// apps.connections.open hands back the test server's ws:// URL.
+	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		wsURL := "ws" + strings.TrimPrefix(wsSrv.URL, "http")
+		_, _ = w.Write([]byte(`{"ok":true,"url":"` + wsURL + `"}`))
+	}))
+	defer apiSrv.Close()
+
+	srv := newTestServer(t)
+	srv.cfg.gcAPIBase = gc.URL
+	srv.cfg.slackAPIBase = apiSrv.URL
+	srv.cfg.appToken = "xapp-1-A-abc"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	if _, err := srv.runSocketConnection(ctx, nil); err != nil {
+		t.Fatalf("runSocketConnection: %v", err)
+	}
+
+	select {
+	case id := <-acked:
+		if id != "env-e2e" {
+			t.Errorf("ack envelope_id = %q, want env-e2e", id)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("no ack reached the server over a real connection")
+	}
+	select {
+	case msg := <-inbound:
+		if msg.Text != "ship it" {
+			t.Errorf("bridged Text = %q", msg.Text)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("event never bridged to gc")
+	}
+}
+
+// TestRunSocketModeReconnectsAfterDisconnect exercises the supervisor over a
+// real transport: the first connection is told to go away, and the adapter
+// must dial a second one and keep bridging. Reconnect is the steady state in
+// Socket Mode — Slack recycles connections routinely — so this is the path
+// that matters most in production.
+func TestRunSocketModeReconnectsAfterDisconnect(t *testing.T) {
+	gc, inbound := gcStub(t)
+
+	var mu sync.Mutex
+	connections := 0
+	wsSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer func() { _ = c.CloseNow() }()
+		ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
+		defer cancel()
+
+		mu.Lock()
+		connections++
+		n := connections
+		mu.Unlock()
+
+		if err := c.Write(ctx, websocket.MessageText, []byte(`{"type":"hello"}`)); err != nil {
+			return
+		}
+		if n == 1 {
+			// Warn, then go away as Slack does after its grace period.
+			_ = c.Write(ctx, websocket.MessageText, []byte(`{"type":"disconnect","reason":"refresh_requested"}`))
+			return
+		}
+		// The replacement connection carries the event that must not be lost.
+		_ = c.Write(ctx, websocket.MessageText, appMentionEnvelope(t, "env-after-reconnect", "T123", "<@U0BOT> after reconnect"))
+		<-ctx.Done()
+	}))
+	defer wsSrv.Close()
+
+	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"ok":true,"url":"ws` + strings.TrimPrefix(wsSrv.URL, "http") + `"}`))
+	}))
+	defer apiSrv.Close()
+
+	srv := newTestServer(t)
+	srv.cfg.gcAPIBase = gc.URL
+	srv.cfg.slackAPIBase = apiSrv.URL
+	srv.cfg.appToken = "xapp-1-A-abc"
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = srv.runSocketMode(ctx) }()
+
+	select {
+	case msg := <-inbound:
+		if msg.Text != "after reconnect" {
+			t.Errorf("bridged Text = %q", msg.Text)
+		}
+	case <-time.After(20 * time.Second):
+		t.Fatal("adapter never reconnected after the disconnect")
+	}
+}
+
+// TestPumpSocketSurvivesIdleConnection is a regression test. An earlier
+// revision bounded each Read with a 90s deadline as an idle watchdog, which
+// tore down healthy connections on any quiet workspace: Slack's keepalives
+// are WebSocket pings, answered inside the library without ever waking a
+// read, so silence is the normal state of a working connection.
+func TestPumpSocketSurvivesIdleConnection(t *testing.T) {
+	srv := newTestServer(t)
+	srv.cfg.gcAPIBase = "http://127.0.0.1:1"
+	conn := &scriptedConn{blockAfterScript: true} // never sends anything
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- srv.pumpSocket(ctx, conn, nil) }()
+
+	select {
+	case err := <-done:
+		t.Fatalf("pumpSocket gave up on an idle but healthy connection: %v", err)
+	case <-time.After(500 * time.Millisecond):
+		// Still reading, which is correct.
+	}
+}
+
+func TestKeepaliveClosesWedgedConnection(t *testing.T) {
+	conn := &scriptedConn{blockAfterScript: true, pingErr: errors.New("no pong")}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	closed := make(chan struct{})
+	var once sync.Once
+	go keepaliveSocket(ctx, conn, time.Millisecond, func() { once.Do(func() { close(closed) }) })
+
+	// A connection Slack has stopped answering must be torn down rather than
+	// read from forever — the failure mode a NAT or proxy timeout produces.
+	select {
+	case <-closed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("unanswered ping did not close the connection")
+	}
+}
+
+func TestKeepaliveStopsWithContext(t *testing.T) {
+	conn := &scriptedConn{blockAfterScript: true}
+	ctx, cancel := context.WithCancel(context.Background())
+	closedCount := 0
+	done := make(chan struct{})
+	go func() {
+		keepaliveSocket(ctx, conn, time.Millisecond, func() { closedCount++ })
+		close(done)
+	}()
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("keepalive ignored context cancellation")
+	}
+	// Healthy pings must never trip the close path.
+	if closedCount != 0 {
+		t.Errorf("closeConn called %d times on a healthy connection", closedCount)
+	}
+	if conn.pings == 0 {
+		t.Error("keepalive never pinged")
+	}
+}
+
+func TestPumpSocketWarnsBeforeDraining(t *testing.T) {
+	gc, _ := gcStub(t)
+	srv := newTestServer(t)
+	srv.cfg.gcAPIBase = gc.URL
+	conn := &scriptedConn{frames: [][]byte{
+		[]byte(`{"type":"disconnect","reason":"warning"}`),
+		[]byte(`{"type":"disconnect","reason":"warning"}`),
+	}}
+
+	warnings := 0
+	if err := srv.pumpSocket(context.Background(), conn, func() { warnings++ }); err != nil {
+		t.Fatalf("pumpSocket err = %v", err)
+	}
+	// The warning must fire so the supervisor can dial a replacement while
+	// this connection is still draining — that overlap is the point of
+	// Slack's early warning. A repeat warning is not a second reconnect.
+	if warnings != 1 {
+		t.Errorf("onWarning fired %d times, want exactly 1", warnings)
+	}
+}

--- a/slack-channel/adapter/socketmode_test.go
+++ b/slack-channel/adapter/socketmode_test.go
@@ -342,27 +342,6 @@ func TestPumpSocketStopsOnContextCancel(t *testing.T) {
 	}
 }
 
-func TestHandleSocketEnvelopeDropsForeignWorkspace(t *testing.T) {
-	gc, inbound := gcStub(t)
-	srv := newTestServer(t)
-	srv.cfg.gcAPIBase = gc.URL
-
-	var env socketEnvelope
-	if err := json.Unmarshal(appMentionEnvelope(t, "env-3", "T_OTHER", "<@U0BOT> hi"), &env); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
-	// Every bridged message is stamped with cfg.workspaceID as its account
-	// id, so an event from another workspace would be filed under the wrong
-	// account. Socket Mode has no signature to catch it — this check does.
-	srv.handleSocketEnvelope(env)
-
-	select {
-	case msg := <-inbound:
-		t.Fatalf("bridged an event from a foreign workspace: %+v", msg)
-	case <-time.After(250 * time.Millisecond):
-	}
-}
-
 func TestHandleSocketEnvelopeIgnoresNonEventTypes(t *testing.T) {
 	gc, inbound := gcStub(t)
 	srv := newTestServer(t)
@@ -547,6 +526,38 @@ func TestPumpSocketSurvivesIdleConnection(t *testing.T) {
 	}
 }
 
+// TestPumpSocketTearsDownWedgedConnection is the other half of the liveness
+// design, and the half that needed the injectable interval: a connection Slack
+// has stopped answering must be abandoned. TestKeepaliveClosesWedgedConnection
+// calls keepaliveSocket directly, so it stays green if pumpSocket never starts
+// one; this drives the production wiring instead.
+func TestPumpSocketTearsDownWedgedConnection(t *testing.T) {
+	srv := newTestServer(t)
+	srv.cfg.gcAPIBase = "http://127.0.0.1:1"
+	srv.timings.pingInterval = time.Millisecond
+	// Reads block forever, as a wedged connection does: only the keepalive can
+	// end this pump.
+	conn := &scriptedConn{blockAfterScript: true, pingErr: errors.New("no pong")}
+
+	done := make(chan error, 1)
+	go func() { done <- srv.pumpSocket(context.Background(), conn, nil) }()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Error("pumpSocket reported a clean end for a wedged connection")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("pumpSocket read forever from a connection Slack had stopped answering")
+	}
+	conn.mu.Lock()
+	closed := conn.closed
+	conn.mu.Unlock()
+	if !closed {
+		t.Error("wedged connection was left open")
+	}
+}
+
 func TestKeepaliveClosesWedgedConnection(t *testing.T) {
 	conn := &scriptedConn{blockAfterScript: true, pingErr: errors.New("no pong")}
 	ctx, cancel := context.WithCancel(context.Background())
@@ -608,5 +619,206 @@ func TestPumpSocketWarnsBeforeDraining(t *testing.T) {
 	// Slack's early warning. A repeat warning is not a second reconnect.
 	if warnings != 1 {
 		t.Errorf("onWarning fired %d times, want exactly 1", warnings)
+	}
+}
+
+// TestPumpSocketBoundsDrain pins the drain bound. The existing drain test ends
+// because its scripted frames run out and Read returns io.EOF, so it never
+// exercises the timer; here Read never returns on its own, which leaves the
+// AfterFunc as the only way out.
+func TestPumpSocketBoundsDrain(t *testing.T) {
+	gc, _ := gcStub(t)
+	srv := newTestServer(t)
+	srv.cfg.gcAPIBase = gc.URL
+	srv.timings.drainGrace = 25 * time.Millisecond
+	conn := &scriptedConn{
+		frames:           [][]byte{[]byte(`{"type":"disconnect","reason":"warning"}`)},
+		blockAfterScript: true,
+	}
+
+	start := time.Now()
+	done := make(chan error, 1)
+	go func() { done <- srv.pumpSocket(context.Background(), conn, nil) }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("drain ended with err = %v, want nil (an elapsed drain is expected, not a failure)", err)
+		}
+		if elapsed := time.Since(start); elapsed < srv.timings.drainGrace {
+			t.Errorf("drain ended after %s, before the %s grace — in-flight envelopes lose their ack window", elapsed, srv.timings.drainGrace)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("a warned connection whose close never landed drained past %s and would linger beside its replacement", srv.timings.drainGrace)
+	}
+}
+
+// TestDefaultSocketTimingsMatchConstants pins the production timer set to
+// literal durations rather than to the constants it is built from. Every other
+// test in this section injects scaled-down timings, so without this pin a
+// production interval could drift — or be zeroed — with the whole suite green.
+// Changing a timer here is fine; it just has to be visible in the diff.
+func TestDefaultSocketTimingsMatchConstants(t *testing.T) {
+	want := socketTimings{
+		pingInterval: 30 * time.Second,
+		drainGrace:   10 * time.Second,
+		backoffMin:   1 * time.Second,
+		backoffMax:   30 * time.Second,
+		minLifetime:  30 * time.Second,
+	}
+	if got := defaultSocketTimings(); got != want {
+		t.Errorf("defaultSocketTimings() = %+v, want %+v", got, want)
+	}
+	// newServer must wire the production set: a zero-valued timings field would
+	// give a 0s ping interval and an unpaced reconnect with every unit test
+	// above still green, because they all set their own.
+	if got := newTestServer(t).timings; got != want {
+		t.Errorf("newServer timings = %+v, want %+v", got, want)
+	}
+}
+
+func TestSettleBackoffResetsOnlyAfterMinLifetime(t *testing.T) {
+	tm := socketTimings{backoffMin: time.Second, backoffMax: 30 * time.Second, minLifetime: 30 * time.Second}
+	for _, tc := range []struct {
+		name     string
+		backoff  time.Duration
+		lifetime time.Duration
+		want     time.Duration
+	}{
+		// A connection that proved the endpoint healthy earns its successor
+		// the floor again — this is the ordinary Slack refresh.
+		{"outlived the minimum", 8 * time.Second, 30 * time.Second, time.Second},
+		{"long-lived", 30 * time.Second, time.Hour, time.Second},
+		// Dial-OK then instant death is the case a reset-on-establishment
+		// misreads as health, redialling at the floor forever.
+		{"died immediately", 8 * time.Second, 0, 8 * time.Second},
+		{"just short of the minimum", 8 * time.Second, 29 * time.Second, 8 * time.Second},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := settleBackoff(tc.backoff, tc.lifetime, tm); got != tc.want {
+				t.Errorf("settleBackoff(%s, %s) = %s, want %s", tc.backoff, tc.lifetime, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNextBackoffDoublesToCap(t *testing.T) {
+	tm := socketTimings{backoffMin: time.Second, backoffMax: 30 * time.Second}
+	for _, tc := range []struct{ in, want time.Duration }{
+		{time.Second, 2 * time.Second},
+		{8 * time.Second, 16 * time.Second},
+		{16 * time.Second, 30 * time.Second}, // 32s clamped
+		{30 * time.Second, 30 * time.Second},
+	} {
+		if got := nextBackoff(tc.in, tm); got != tc.want {
+			t.Errorf("nextBackoff(%s) = %s, want %s", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestRunSocketModePacesWarnedReconnect drives the supervisor over a real
+// transport against a server that warns every connection the moment it opens —
+// the shape two adapters sharing one app token produce as they displace each
+// other. That path used to redial at network speed, one apps.connections.open
+// plus handshake per cycle, because it was the only reconnect arm with no
+// delay and because backoff reset on every successful dial.
+func TestRunSocketModePacesWarnedReconnect(t *testing.T) {
+	var mu sync.Mutex
+	var dials []time.Time
+	stop := make(chan struct{})
+	dialed := make(chan struct{}, 16)
+
+	wsSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		dials = append(dials, time.Now())
+		mu.Unlock()
+		select {
+		case dialed <- struct{}{}:
+		default:
+		}
+
+		c, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer func() { _ = c.CloseNow() }()
+		ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+		defer cancel()
+
+		if err := c.Write(ctx, websocket.MessageText, []byte(`{"type":"hello"}`)); err != nil {
+			return
+		}
+		if err := c.Write(ctx, websocket.MessageText, []byte(`{"type":"disconnect","reason":"link_disabled"}`)); err != nil {
+			return
+		}
+		// Hold the connection open. If it ended here, the supervisor could take
+		// its `done` arm instead of the warned arm — both are paced now, so the
+		// test would pass without ever measuring the path it is about.
+		select {
+		case <-stop:
+		case <-ctx.Done():
+		}
+	}))
+	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"ok":true,"url":"ws` + strings.TrimPrefix(wsSrv.URL, "http") + `"}`))
+	}))
+
+	srv := newTestServer(t)
+	srv.cfg.gcAPIBase = "http://127.0.0.1:1"
+	srv.cfg.slackAPIBase = apiSrv.URL
+	srv.cfg.appToken = "xapp-1-A-abc"
+	srv.timings = socketTimings{
+		backoffMin: 40 * time.Millisecond,
+		backoffMax: 5 * time.Second,
+		// No connection here reaches minLifetime, so each successor must carry
+		// the escalating delay: this is what distinguishes pacing from a reset
+		// on every dial.
+		minLifetime: time.Hour,
+		// Neither timer should fire during the test; the connections are held
+		// open by the server, not ended by a keepalive or an elapsed drain.
+		pingInterval: time.Hour,
+		drainGrace:   time.Hour,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Unwind inside out: release the handlers, stop the supervisor redialling,
+	// then close the servers, so nothing touches t after this test returns.
+	defer wsSrv.Close()
+	defer apiSrv.Close()
+	defer cancel()
+	defer close(stop)
+
+	go func() { _ = srv.runSocketMode(ctx) }()
+
+	const wantDials = 4
+	for i := 0; i < wantDials; i++ {
+		select {
+		case <-dialed:
+		case <-time.After(10 * time.Second):
+			t.Fatalf("only %d of %d dials arrived", i, wantDials)
+		}
+	}
+
+	mu.Lock()
+	got := append([]time.Time(nil), dials...)
+	mu.Unlock()
+	if len(got) < wantDials {
+		t.Fatalf("recorded %d dials, want %d", len(got), wantDials)
+	}
+
+	gaps := make([]time.Duration, 0, len(got)-1)
+	for i := 1; i < len(got); i++ {
+		gaps = append(gaps, got[i].Sub(got[i-1]))
+	}
+	for i, gap := range gaps {
+		if gap < srv.timings.backoffMin {
+			t.Errorf("redial %d came %s after the previous one, inside the %s floor: gaps=%v", i+1, gap, srv.timings.backoffMin, gaps)
+		}
+	}
+	// Doubling from a 40ms floor gives ~40ms, ~80ms, ~160ms. A backoff that
+	// reset on every dial would hold every gap near the floor, so requiring
+	// the last one to exceed 3x it is what pins the escalation.
+	if last := gaps[len(gaps)-1]; last < 3*srv.timings.backoffMin {
+		t.Errorf("last redial gap %s did not escalate past 3x the %s floor: gaps=%v", last, srv.timings.backoffMin, gaps)
 	}
 }

--- a/slack-channel/commands/reply-current.sh
+++ b/slack-channel/commands/reply-current.sh
@@ -10,6 +10,7 @@ thread_current="false"
 body=""
 body_file=""
 idempotency_key=""
+conversation_id=""
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -22,6 +23,8 @@ while [ $# -gt 0 ]; do
     --body=*)           body="${1#*=}"; shift ;;
     --body-file)        body_file="$2"; shift 2 ;;
     --body-file=*)      body_file="${1#*=}"; shift ;;
+    --conversation-id)  conversation_id="$2"; shift 2 ;;
+    --conversation-id=*) conversation_id="${1#*=}"; shift ;;
     --idempotency-key)  idempotency_key="$2"; shift 2 ;;
     --idempotency-key=*) idempotency_key="${1#*=}"; shift ;;
     -h|--help)          sc_help reply-current ;;
@@ -41,8 +44,10 @@ req=$(jq -n \
   --arg body "$text" \
   --arg reply_to "$reply_to" \
   --arg idem "$idempotency_key" \
+  --arg conversation "$conversation_id" \
   --argjson thread_current "$thread_current" \
   '{session_id: $session, body: $body, thread_current: $thread_current}
    + (if $reply_to == "" then {} else {reply_to: $reply_to} end)
-   + (if $idem == "" then {} else {idempotency_key: $idem} end)')
+   + (if $idem == "" then {} else {idempotency_key: $idem} end)
+   + (if $conversation == "" then {} else {conversation_id: $conversation} end)')
 sc_call POST reply-current "$req"

--- a/slack-channel/commands/reply-current/help.md
+++ b/slack-channel/commands/reply-current/help.md
@@ -15,6 +15,7 @@ Usage:
   gc slack-channel reply-current [--session <id>]
                                  (--body <text> | --body-file <path>)
                                  [--thread-current | --reply-to <ts>]
+                                 [--conversation-id <id>]
                                  [--idempotency-key <key>]
 
 Flags:
@@ -23,6 +24,13 @@ Flags:
   --body-file       Read the message body from a file (must be a regular file).
   --thread-current  Thread under the latest inbound message. Mutually
                     exclusive with --reply-to.
+  --conversation-id Assert which conversation the reply is for. Optional and
+                    redundant — the target is always the session's latest
+                    inbound — but if given it must match, so a stale reply
+                    fails loudly instead of landing in the wrong channel.
+                    Accepted for parity with slack-full and discord, whose
+                    reply-current take the same flag; gc's injected reply
+                    instruction passes it.
   --reply-to        Slack message ts to thread under.
   --idempotency-key Caller-supplied key to dedupe retries. When omitted, the
                     adapter derives a deterministic key from the resolved

--- a/slack-channel/commands/reply-current/help.md
+++ b/slack-channel/commands/reply-current/help.md
@@ -25,12 +25,16 @@ Flags:
   --thread-current  Thread under the latest inbound message. Mutually
                     exclusive with --reply-to.
   --conversation-id Assert which conversation the reply is for. Optional and
-                    redundant — the target is always the session's latest
-                    inbound — but if given it must match, so a stale reply
-                    fails loudly instead of landing in the wrong channel.
-                    Accepted for parity with slack-full and discord, whose
-                    reply-current take the same flag; gc's injected reply
-                    instruction passes it.
+                    redundant — the target is the session's current reply
+                    target (its latest inbound, or its single channel
+                    binding before any inbound) — but if given it must
+                    match, so a stale reply fails loudly instead of landing
+                    in the wrong channel.
+                    Same flag name as slack-full and discord, but not the
+                    same semantics: there it retargets the reply to that
+                    conversation, here it only asserts the one already
+                    resolved. Accepted so gc's injected reply instruction,
+                    which passes it, works across tiers.
   --reply-to        Slack message ts to thread under.
   --idempotency-key Caller-supplied key to dedupe retries. When omitted, the
                     adapter derives a deterministic key from the resolved

--- a/slack-channel/manifest/app-socket.json
+++ b/slack-channel/manifest/app-socket.json
@@ -1,0 +1,51 @@
+{
+  "display_information": {
+    "name": "gc-channel",
+    "description": "Bridge Slack channels and DMs to your Gas City sessions over Socket Mode - no public URL required.",
+    "background_color": "#1f2933",
+    "long_description": "slack-channel (Tier 2) bridges human Slack conversations to Gas City sessions. Bind a channel or DM to one or more gc sessions and every message there is delivered to them; address a session from any channel with '@handle'. Per-session display-name and avatar overrides use chat:write.customize so each bound session appears under its own identity. See https://github.com/gastownhall/gascity-packs/tree/main/slack-channel for setup."
+  },
+  "features": {
+    "bot_user": {
+      "display_name": "gc-channel",
+      "always_online": true
+    },
+    "app_home": {
+      "home_tab_enabled": false,
+      "messages_tab_enabled": true,
+      "messages_tab_read_only_enabled": false
+    }
+  },
+  "oauth_config": {
+    "scopes": {
+      "bot": [
+        "app_mentions:read",
+        "channels:history",
+        "chat:write",
+        "chat:write.customize",
+        "chat:write.public",
+        "groups:history",
+        "im:history",
+        "mpim:history",
+        "reactions:write"
+      ]
+    }
+  },
+  "settings": {
+    "event_subscriptions": {
+      "bot_events": [
+        "app_mention",
+        "message.channels",
+        "message.groups",
+        "message.im",
+        "message.mpim"
+      ]
+    },
+    "interactivity": {
+      "is_enabled": false
+    },
+    "org_deploy_enabled": false,
+    "socket_mode_enabled": true,
+    "token_rotation_enabled": false
+  }
+}

--- a/slack-channel/pack.toml
+++ b/slack-channel/pack.toml
@@ -14,9 +14,12 @@
 #     also owns three on-disk registries under
 #     <GC_CITY_PATH>/.gc/slack-channel/. The [[service]] block below has gc
 #     supervise it as a proxy_process: it binds a Unix domain socket at
-#     $GC_SERVICE_SOCKET for the verb endpoints + /healthz, and a public TCP
-#     port for /slack/events + /slack/interactions (terminate TLS in front
-#     of it, e.g. Tailscale Funnel).
+#     $GC_SERVICE_SOCKET for the verb endpoints + /healthz. Inbound arrives
+#     one of two ways, chosen by env: with SLACK_APP_TOKEN set it runs
+#     Socket Mode (an outbound WebSocket to Slack — no public port at all);
+#     otherwise it binds a public TCP port for /slack/events +
+#     /slack/interactions (terminate TLS in front of it, e.g. Tailscale
+#     Funnel).
 #
 # This pack ships NO operator CLI binary: every verb is a bash wrapper
 # (commands/<verb>.sh) that POSTs to the adapter through gc's
@@ -33,10 +36,11 @@ schema = 2
 
 # proxy_process service: gc supervises the adapter as part of the city's
 # service set. The adapter binds a UDS at $GC_SERVICE_SOCKET for the verb
-# endpoints + /healthz; gc reverse-proxies /svc/slack-channel/* to it. The
-# adapter also binds public TCP (LISTEN_PUBLIC, default 0.0.0.0:8775) for
-# /slack/events + /slack/interactions. proxy_process owns only the UDS
-# lifecycle.
+# endpoints + /healthz; gc reverse-proxies /svc/slack-channel/* to it. In
+# HTTP mode the adapter also binds public TCP (LISTEN_PUBLIC, default
+# 0.0.0.0:8775) for /slack/events + /slack/interactions; in Socket Mode
+# (SLACK_APP_TOKEN set) it binds no public port. proxy_process owns only
+# the UDS lifecycle either way.
 #
 # The service is named "slack-channel" (matching the pack) so it does not
 # collide with a slack-mini or slack-full install. Per the tiering design,

--- a/slack-channel/pack.toml
+++ b/slack-channel/pack.toml
@@ -46,9 +46,9 @@ schema = 2
 # collide with a slack-mini or slack-full install. Per the tiering design,
 # run exactly one Slack tier per city regardless.
 #
-# Secrets (SLACK_BOT_TOKEN, SLACK_SIGNING_SECRET, SLACK_WORKSPACE_ID),
-# GC_CITY_NAME, and GC_CITY_PATH are inherited from the service environment
-# at start. See README.md "Configure".
+# Secrets (SLACK_BOT_TOKEN, SLACK_SIGNING_SECRET, SLACK_APP_TOKEN,
+# SLACK_WORKSPACE_ID), GC_CITY_NAME, and GC_CITY_PATH are inherited from the
+# service environment at start. See README.md "Configure".
 
 [[service]]
 name = "slack-channel"


### PR DESCRIPTION
Two commits. The first ports the Socket Mode transport from #283 (slack-mini) to Tier 2; the second fixes a reply-path bug that is independent of it.

Both are running live against a real workspace on a network with no inbound ingress — see Testing.

## 1. Socket Mode transport

Same problem as #283: the adapter only took inbound over the Events API, which needs a public HTTPS Request URL, so the pack could not run anywhere that cannot accept inbound connections.

`SLACK_APP_TOKEN` (an `xapp-` app-level token with `connections:write`) selects it. When set, `LISTEN_PUBLIC` is never bound and `SLACK_SIGNING_SECRET` is not required; when unset, the HTTP transport behaves exactly as before, signature verification included.

Envelopes are handed to `routeEvent` — the same place the HTTP handler hands off — so channel bindings, handle aliases, the `app_mention` fallback, and per-session identity are shared verbatim rather than reimplemented.

Design carried over from #283: envelopes acked before routing; routing off the read loop so a slow gc cannot stall acks; supervised reconnect backing off 1s→30s; a 30s keepalive ping as the liveness check (a read deadline is wrong here — Slack's keepalives are pings answered inside the library, so silence is the healthy state); and an overlap on Slack's advance disconnect warning so the replacement is dialled while the old connection drains.

Two Tier 2 specifics:

- **Workspace filtering matters more here.** Tier 2 stamps `SLACK_WORKSPACE_ID` as the account id *and* keys channel bindings on it, so a stray workspace's event could otherwise match a binding that is not its own. Events with a mismatched `team_id` are dropped.
- **Interactivity is not carried.** Tier 2 ships interactivity disabled and `/slack/interactions` is an opt-in extra that still needs a public URL, so `interactive` envelopes are dropped with an explanatory log line. Documented in the README's transport table.

Adds `github.com/coder/websocket` v1.8.15 (no dependencies of its own), matching #283. The same offer stands: happy to hand-roll RFC 6455 on stdlib instead if maintainers prefer the adapters stay dependency-free — though the library dials via `net/http`, so `HTTPS_PROXY`/`NO_PROXY` are honoured, which matters on exactly the networks this targets.

## 2. reply-current now accepts --conversation-id

gc's injected reply instruction tells an agent to run:

```
gc slack-channel reply-current --conversation-id <id> --body-file <path>
```

Tier 2 did not accept `--conversation-id`, so the command gc advertises failed. `slack-full` and `discord` both take the flag — Tier 2 was the outlier.

Found the hard way: a mayor agent in a live city hit it, worked out the correct invocation itself, and filed the divergence — after four sessions had concluded Slack was simply down. (Related gc-side issue: gastownhall/gascity#5166, where the injected command's namespace is derived from the provider name. Not addressed here.)

The flag is validated rather than ignored. `reply-current` targets the session's current reply target (its latest inbound, or its single channel binding before any inbound), so a supplied id is redundant by construction — but a mismatch means the caller believes it is answering a conversation the session no longer owns, and silently posting into the current target would put the reply in the wrong channel. A mismatch is 409 naming both ids, and posts nothing.

## Testing

`go vet` + `go test -race` green across the whole Tier 2 suite. New tests: the transport's envelope loop, ack-before-route, drain-on-disconnect, idle-connection regression, keepalive closing a wedged connection, a real-WebSocket round trip via `websocket.Accept`, a reconnect-after-disconnect, and both `--conversation-id` paths (matching accepted; mismatched refused without posting).

Live, gc-supervised, on a network with no inbound ingress:

- `slack-channel` service reaches `ready`, Socket Mode connects, registers through gc's reverse proxy.
- A plain channel message with no `@`-mention is delivered to the bound session — Tier 2's defining behaviour, over the socket.
- One connection held **over three hours with zero reconnects**. Before the keepalive fix (see #283) the same setup churned a reconnect every 90 seconds.
- HTTP mode re-checked for regressions: still binds `:8775`, still answers `/healthz`.

## Note for maintainers

The README lists `GC_API_BASE_URL` among the vars "injected by gc when the adapter runs as a `proxy_process` service". It is not injected, and neither are `GC_CITY_NAME` or `GC_CITY_PATH` — a supervised adapter cannot discover its own city or API endpoint, and defaults to `:9443`. I have left the docs alone here to keep this PR to the transport plus the flag fix, but happy to correct that in either this PR or a follow-up. Raised on gastownhall/gascity#5166 as well.
