### PR TITLE
fix(gastown): bound status-line refreshes by process group, not by timeout(1)

### DIFF
--- a/gastown/assets/scripts/status-line.sh
+++ b/gastown/assets/scripts/status-line.sh
@@ -7,7 +7,7 @@
 # Counts are cached with a short TTL so tmux's frequent refresh does not query
 # Beads on every render across every agent. TTL override:
 # GC_STATUSLINE_TTL (seconds). Cache directory override:
-# GC_STATUSLINE_CACHE_DIR.
+# GC_STATUSLINE_CACHE_DIR. Bound override: GC_STATUSLINE_BOUND (seconds).
 
 agent="$1"
 city="${2:-${GC_CITY:-${GT_ROOT:-${GC_DIR:-}}}}"
@@ -17,12 +17,62 @@ if [ -n "$city" ] && [ -d "$city" ]; then
     cd "$city" 2>/dev/null || true
 fi
 
+bound_secs="${GC_STATUSLINE_BOUND:-2}"
+case "$bound_secs" in ''|*[!0-9]*) bound_secs=2 ;; esac
+
+# Poll finely where sleep takes a fraction, so the common case — a command that
+# answers promptly — is not padded out to a whole second on every refresh.
+if sleep 0.1 2>/dev/null; then
+    poll_int=0.1
+    poll_max=$((bound_secs * 10))
+else
+    poll_int=1
+    poll_max="$bound_secs"
+fi
+
+# One scratch dir per invocation, cleaned on any ordinary exit, so bounded
+# output never accumulates in TMPDIR.
+rb_dir=$(mktemp -d "${TMPDIR:-/tmp}/gc-statusline-rb.XXXXXX" 2>/dev/null) || rb_dir=
+[ -n "$rb_dir" ] && trap 'rm -rf "$rb_dir" 2>/dev/null' EXIT HUP INT TERM
+
+# Bound a command in wall-clock time and in process-group scope.
+#
+# Two failure modes this must survive, both observed on the fleet:
+#   1. timeout(1) ships with GNU coreutils and is absent on macOS, so a
+#      timeout-only bound degrades silently to no bound at all.
+#   2. Work the command backgrounds outlives a bound placed on the direct
+#      child. It also inherits our stdout, so a caller reading through a pipe
+#      blocks long after the bound expired while the child orphans to init.
+#
+# The command therefore runs in its own process group (set -m) writing to a
+# file rather than to the caller's pipe, and the whole group is signalled on
+# expiry — and swept even after a clean exit, because a command can return
+# promptly and still leave backgrounded work behind.
 run_bounded() {
-    if command -v timeout >/dev/null 2>&1; then
-        timeout 2s "$@"
-    else
-        "$@"
+    [ -n "$rb_dir" ] || return 0
+    _rb_out="$rb_dir/out"
+    : > "$_rb_out" 2>/dev/null || return 0
+
+    set -m 2>/dev/null
+    "$@" >"$_rb_out" 2>/dev/null &
+    _rb_pid=$!
+    set +m 2>/dev/null
+
+    _rb_polls=0
+    while [ "$_rb_polls" -lt "$poll_max" ] && kill -0 "$_rb_pid" 2>/dev/null; do
+        sleep "$poll_int"
+        _rb_polls=$((_rb_polls + 1))
+    done
+
+    if kill -0 "$_rb_pid" 2>/dev/null; then
+        kill -TERM -- "-$_rb_pid" 2>/dev/null
+        sleep "$poll_int"
+        kill -KILL -- "-$_rb_pid" 2>/dev/null
     fi
+    wait "$_rb_pid" 2>/dev/null
+    kill -KILL -- "-$_rb_pid" 2>/dev/null
+
+    cat "$_rb_out" 2>/dev/null
 }
 
 json_array_count() {

--- a/gastown/tests/test_gastown_theme_scripts.sh
+++ b/gastown/tests/test_gastown_theme_scripts.sh
@@ -34,6 +34,78 @@ SH
     chmod +x "$bin/gc"
 }
 
+# Every external command status-line.sh reaches for. The bound probes below run
+# with a PATH holding only these, so the helper can be exercised on a host where
+# timeout(1) does not exist. A tool missing here does not fail the run cleanly —
+# it breaks the cache path and quietly changes what is under test — so resolve
+# them all up front and fail loudly instead.
+STATUS_LINE_PROBE_TOOLS=(sh sleep mktemp cat rm awk stat jq tr cksum date)
+
+write_bounded_probe_bin() {
+    local bin="$1" tool resolved
+    mkdir -p "$bin"
+    for tool in "${STATUS_LINE_PROBE_TOOLS[@]}"; do
+        resolved=$(command -v "$tool" 2>/dev/null) ||
+            fail "status-line bound probe needs $tool on PATH"
+        ln -sf "$resolved" "$bin/$tool"
+    done
+}
+
+# Stub gc whose behaviour is chosen by mode: hang stands in for a query wedged
+# on a lock, background for one that returns promptly but leaves work running.
+write_bounded_probe_gc() {
+    local bin="$1" mode="$2" sleeper="$3"
+
+    cat >"$sleeper" <<'SH'
+#!/usr/bin/env sh
+sleep 60
+SH
+    chmod +x "$sleeper"
+
+    cat >"$bin/gc" <<SH
+#!/usr/bin/env sh
+case "$mode" in
+    hang)       "$sleeper" ;;
+    background) "$sleeper" & ;;
+esac
+printf '[]\n'
+SH
+    chmod +x "$bin/gc"
+}
+
+# Run status-line.sh detached from this suite's stdio and wait up to cap
+# seconds. A wedged run outlives the call, and anything it still holds would
+# keep the caller's pipe open — the very failure under test, turned on the
+# runner.
+run_status_line_watchdog() {
+    local run="$1" cap="$2" bin="$3" city="$4" waited=0
+    (
+        PATH="$bin" GC_STATUSLINE_CACHE_DIR="$run/cache" GC_STATUSLINE_TTL=0 \
+            GC_STATUSLINE_BOUND=1 "$SCRIPTS/status-line.sh" alpha "$city" \
+            >"$run/out" 2>/dev/null
+        : >"$run/done"
+    ) >/dev/null 2>&1 &
+    while [[ ! -f "$run/done" && "$waited" -lt "$cap" ]]; do
+        sleep 1
+        waited=$((waited + 1))
+    done
+    [[ -f "$run/done" ]]
+}
+
+# Reap only our own marked probes, by exact pid — never a broad pattern kill.
+# pgrep exits non-zero when nothing matches, which is the expected case here, so
+# neither helper may let that status escape into the suite's errexit.
+reap_marked() {
+    local marker="$1" pid
+    for pid in $(pgrep -f "$marker" 2>/dev/null || true); do
+        kill -KILL "$pid" 2>/dev/null || true
+    done
+}
+
+marked_survivors() {
+    pgrep -f "$1" 2>/dev/null | grep -c . || true
+}
+
 test_status_line_counts_with_bounded_gc_commands_and_cache() {
     local tmp city bin cache log output
     tmp=$(mktemp -d)
@@ -185,6 +257,56 @@ SH
     [[ "$output" == "alpha" ]] || fail "expected read mail to be omitted, got: $output"
 }
 
+test_status_line_bounds_a_hanging_query_without_timeout_binary() {
+    local tmp bin city run marker
+    tmp=$(mktemp -d)
+    bin="$tmp/bin"
+    city="$tmp/city"
+    run="$tmp/run"
+    marker="statusline_bound_hang_$$"
+    mkdir -p "$city" "$run"
+
+    write_bounded_probe_bin "$bin"
+    # Positive control: the probe bin is the whole PATH for the run below, so
+    # timeout(1) is reachable only if it was linked in. Assert it was not — if
+    # it ever is, this case silently degrades into "timeout did the bounding"
+    # and stops covering the platforms that ship no coreutils.
+    [[ ! -e "$bin/timeout" ]] ||
+        fail "probe PATH still resolves timeout(1); the no-timeout case would be vacuous"
+    write_bounded_probe_gc "$bin" hang "$tmp/$marker.sh"
+
+    if ! run_status_line_watchdog "$run" 20 "$bin" "$city"; then
+        reap_marked "$marker"
+        fail "hanging query was never bounded where timeout(1) is absent"
+    fi
+    reap_marked "$marker"
+}
+
+test_status_line_reaps_work_the_query_leaves_behind() {
+    local tmp bin city run marker survivors wedged=0
+    tmp=$(mktemp -d)
+    bin="$tmp/bin"
+    city="$tmp/city"
+    run="$tmp/run"
+    marker="statusline_bound_bg_$$"
+    mkdir -p "$city" "$run"
+
+    write_bounded_probe_bin "$bin"
+    write_bounded_probe_gc "$bin" background "$tmp/$marker.sh"
+
+    # A bound on the direct child alone leaves the backgrounded grandchild
+    # running, and that grandchild inherits stdout — so the refresh both leaks
+    # a process and blocks the caller reading through the pipe.
+    run_status_line_watchdog "$run" 20 "$bin" "$city" || wedged=1
+    survivors=$(marked_survivors "$marker")
+    reap_marked "$marker"
+
+    [[ "$wedged" -eq 0 ]] ||
+        fail "refresh never completed — caller wedged by a grandchild holding stdout"
+    [[ "$survivors" -eq 0 ]] ||
+        fail "backgrounded work survived the bound ($survivors still running)"
+}
+
 test_tmux_theme_passes_city_path_to_status_helper() {
     local tmp bin log city
     tmp=$(mktemp -d)
@@ -210,6 +332,8 @@ test_status_line_cache_is_city_scoped
 test_status_line_falls_back_to_agent_only_on_query_failure
 test_status_line_counts_ready_work_not_queued_nudges
 test_status_line_uses_unread_mail_check_semantics
+test_status_line_bounds_a_hanging_query_without_timeout_binary
+test_status_line_reaps_work_the_query_leaves_behind
 test_tmux_theme_passes_city_path_to_status_helper
 
 echo "gastown theme script tests passed"


### PR DESCRIPTION
## Summary

`gastown/assets/scripts/status-line.sh` runs on every tmux status refresh for
every agent, so an unbounded query is paid on the refresh schedule by the whole
fleet. `run_bounded` had two ways to apply no bound at all:

1. **`timeout(1)` is not portable.** It ships with GNU coreutils and is absent
   on macOS (no `gtimeout` either), so `command -v timeout || run unbounded`
   failed open and applied *no* bound. Measured on a macOS fleet host: a 6s `gc`
   stretched a single status refresh to 12-13s, on every render, for every
   agent.
2. **A bound on the direct child does not cover what that child backgrounds.**
   The grandchild also inherits stdout, so a caller reading through a command
   substitution blocks long after the bound expired while the grandchild orphans
   to init. This one bites on Linux too, where `timeout` *is* present — the
   bound applies to `gc` and the backgrounded work sails past it.

`run_bounded` now runs the command in its own process group (`set -m`) writing
to a file rather than to the caller's pipe, polls for the bound, and signals the
whole group on expiry — sweeping it after a clean exit too, since a command can
return promptly and still leave work behind. The bound is `GC_STATUSLINE_BOUND`
seconds (default 2, preserving the previous `timeout 2s` behaviour), and scratch
is removed on any ordinary exit so refreshes do not litter `TMPDIR`.

## Relationship to #207

#207 (`hotfix/statusline-single-flight`, open since 2026-07-15) touches the same
function and I do not want to talk over it. Two honest differences:

- #207 fixes failure mode 1 by shelling out to `perl`, which leaves failure mode
  2 in place: `perl` forks and `TERM`s the direct child, so work that child
  backgrounded still survives and still holds the inherited stdout.
- #207 also carries a **single-flight cache lock**, which this PR does not
  touch. That is a genuinely separate improvement and is worth landing on its
  own merits.

These two changes are complementary, not competing. If maintainers prefer, I am
happy to rebase this on top of #207 (the process-group `run_bounded` replaces
the `perl` branch cleanly and the lock is untouched), or to hold this until #207
lands. Please just say which order you want.

## Safety

- No new dependency: the helper uses only POSIX shell job control plus tools the
  script already relied on. It no longer needs `timeout(1)` at all.
- Signals are scoped to the process group of the command this script itself
  started (`kill -- -$pid`); nothing else on the host is targeted.
- Bound output goes to a per-invocation `mktemp -d` scratch removed on `EXIT`,
  `HUP`, `INT`, `TERM`.
- Rendering is unchanged: counts, cache semantics, city scoping, and the
  always-exit-0 contract all still hold (existing cases cover this).
- Sub-second polling where `sleep 0.1` is supported, so the common fast case is
  not padded out to a whole second on every render.

## Test plan

Two cases added to the existing `gastown/tests/test_gastown_theme_scripts.sh`
(already the home of the status-line coverage, and already run by CI's
`for test_script in gastown/tests/test_*.sh` step):

- `test_status_line_bounds_a_hanging_query_without_timeout_binary` — runs the
  script against a hanging `gc` on a PATH sandbox that deliberately omits
  `timeout(1)`, reproducing the macOS case deterministically on any host. It
  carries a **positive control** asserting the sandbox really does hide
  `timeout`, so the case cannot quietly degrade into "timeout did the bounding".
- `test_status_line_reaps_work_the_query_leaves_behind` — a `gc` that backgrounds
  a long-lived child and returns promptly; asserts both that nothing survives the
  bound and that the refresh is not wedged by the inherited stdout. This one
  fails on the old helper regardless of platform.

Both were confirmed to fail before the fix and pass after (not merely to pass):

```
# new cases vs the pre-fix status-line.sh
test_status_line_bounds_a_hanging_query_without_timeout_binary -> FAIL: hanging query was never bounded where timeout(1) is absent
test_status_line_reaps_work_the_query_leaves_behind            -> FAIL: refresh never completed — caller wedged by a grandchild holding stdout

# whole suite vs the patched status-line.sh
$ bash gastown/tests/test_gastown_theme_scripts.sh; echo $?
gastown theme script tests passed
0
```

Also run:

- `shellcheck -s sh gastown/assets/scripts/status-line.sh` — clean.
- `shellcheck gastown/tests/test_gastown_theme_scripts.sh` — clean.
- The other `gastown/tests/test_*.sh` scripts pass unchanged.
  (`test_witness_heartbeat_check.sh` fails on macOS both before and after this
  change — it uses GNU `date -d` — so it is untouched and unrelated here; it
  passes on CI's ubuntu runner.)

File mode stays `100755`, so the pack content hash keeps the perm the release
tooling derives for `.sh`.

This same change has been running in a production city since 2026-08-09.
