### PR TITLE
fix(gastown): preserve refinery cold-slot lifecycle

### DIFF
--- a/gastown/agents/refinery/agent.toml
+++ b/gastown/agents/refinery/agent.toml
@@ -3,6 +3,5 @@ wake_mode = "fresh"
 work_dir = ".gc/worktrees/{{.Rig}}/refinery"
 nudge = "Run 'gc prime' to check merge queue and begin processing."
 pre_start = ["{{.ConfigDir}}/assets/scripts/worktree-setup.sh {{.RigRoot}} {{.WorkDir}} {{.AgentBase}} --sync"]
-idle_timeout = "2h"
 sleep_after_idle = "300s"
 max_active_sessions = 1

--- a/gastown/formulas/mol-refinery-patrol.toml
+++ b/gastown/formulas/mol-refinery-patrol.toml
@@ -1106,8 +1106,9 @@ If the cycle ended early (conflict rejection, no work found), note
 why and what state was left.
 
 This summary is not stored separately — it lives in the wisp's
-closing reason. The next session can find it via `gc bd list --type=molecule
---status=closed --limit=5` if it needs predecessor context."""
+closing reason. The next session can find it via
+`gc bd query --all --json 'ephemeral=true AND status=closed' --limit=0 | jq --arg agent "$GC_AGENT" '[.[] | select(.issue_type == "molecule" and .assignee == $agent)][:5]'`
+if it needs predecessor context."""
 
 [[steps]]
 id = "next-iteration"

--- a/gastown/tests/test_gastown_pack_assets.sh
+++ b/gastown/tests/test_gastown_pack_assets.sh
@@ -20,6 +20,20 @@ for path in sys.argv[1:]:
 PY
 }
 
+test_refinery_patrol_lifecycle_contracts() {
+    local agent="$GASTOWN/agents/refinery/agent.toml"
+    local formula="$GASTOWN/formulas/mol-refinery-patrol.toml"
+
+    parse_toml "$agent" "$formula"
+    grep -F 'sleep_after_idle = "300s"' "$agent" >/dev/null ||
+        fail "refinery should use sleep_after_idle for cold-slot cycling"
+    ! grep -F 'idle_timeout =' "$agent" >/dev/null ||
+        fail "refinery idle_timeout masks sleep_after_idle and must stay unset"
+    grep -F "gc bd query --all --json 'ephemeral=true AND status=closed' --limit=0 | jq --arg agent \"\$GC_AGENT\" '[.[] | select(.issue_type == \"molecule\" and .assignee == \$agent)][:5]'" \
+        "$formula" >/dev/null ||
+        fail "refinery predecessor lookup must filter slash-qualified assignees and molecule roots before limiting"
+}
+
 test_dog_assets_are_pack_local() {
     [[ -f "$GASTOWN/agents/dog/agent.toml" ]] || fail "missing dog agent config"
     [[ -f "$GASTOWN/agents/dog/prompt.template.md" ]] || fail "missing dog prompt"
@@ -216,6 +230,7 @@ if verify >= metadata:
 PY
 }
 
+test_refinery_patrol_lifecycle_contracts
 test_dog_assets_are_pack_local
 test_retired_dog_formulas_are_not_reintroduced
 test_shutdown_dance_contracts_are_executable


### PR DESCRIPTION
## Summary

- let `sleep_after_idle` exclusively own the refinery cold-slot policy instead of being masked by `idle_timeout`
- make predecessor-summary recovery include closed ephemeral molecule roots
- filter rig-qualified assignees with `jq` before taking the five newest matches
- add focused asset coverage for both lifecycle contracts

## Scope

This intentionally excludes current-wisp and prompt query changes already covered by open PRs #264, #266, and #278. It also excludes the formula compiler work in #257.

## Validation

- all `gastown/tests/test_*.sh` scripts passed
- `gc lint gascity` passed
- `gc lint gascity/roles` passed
- the corrected query and `jq` pipeline executed successfully with a slash-qualified agent
- `git diff --check` passed

## Native review provenance

- immutable base: `f3826035bb7de7c34621c2fdcd8620ab5a18bb08`
- immutable head: `17d622055d037325f5cfaefe30097c44f030a12a`
- command: `codex review --base f3826035bb7de7c34621c2fdcd8620ab5a18bb08` with high reasoning effort
- result: no discrete correctness issues identified

No live Pack deployment or city lifecycle action was performed.