### PR TITLE
fix(oversight): require durable execution intent

### DIFF
--- a/oversight-rig/README.md
+++ b/oversight-rig/README.md
@@ -16,15 +16,36 @@ mayor (city, unchanged) ──── plans cross-cutting work, handles escalatio
   • bounded to foo's beads      • bounded to bar's beads
   • reads foo/.gc/              • reads bar/.gc/
     project-brief.md              project-brief.md
-  • dispatches its own          • dispatches its own
-    ready work directly           ready work directly
+  • reconciles committed         • reconciles committed
+    execution intent              execution intent
 ```
 
 - **`project-lead`** (rig scope, always-on, one per rig)
   - Bounded to a single rig's beads. Reads its persona, current focus, and escalation triggers from `<rig>/.gc/project-brief.md` — each project owns its own scoping context, so it never piles onto the mayor.
-  - Triages its rig every tick and **dispatches ready, in-scope work in its own rig directly** — it does not route every dispatch through the mayor.
+  - Triages its rig every tick and **reconciles committed ready work in its own rig**. It observes existing eligible routes and controller progress but does not create a route from Beads readiness alone or treat a pool route as a concrete session identity.
   - Judges severity (info vs escalate) and writes structured rollup beads.
 - **The mayor stays unchanged** and shrinks to what is genuinely cross-cutting: planning work that spans rigs, and reacting to escalations.
+
+## Dispatch safety: READY != RUN
+
+Project Lead dispatch is intentionally narrower than Beads readiness. A plain
+ready backlog bead is not execution-authorized and must never be slung merely
+because a worker pool exists. On each tick, Project Lead uses the pack's
+read-only bounded selector:
+
+```sh
+python3 "$GC_PACK_DIR/assets/scripts/select-execution-candidates.py" --rig <rig> --json
+```
+
+Only its routed output may be monitored as committed execution intent. It
+recognizes an existing valid `gc.routed_to` in the same rig, or a Formula/run
+member whose existing root metadata resolves to a live workflow root in that
+rig. It fails closed on query, JSON, schema, route, root, or bound uncertainty.
+It does not invent or rewrite routes, infer arbitrary bead-tree intent, or add
+a committed-root marker. Pool routes remain controller scheduling demand and
+are never passed directly to session wake/nudge commands. Missing routing,
+Formula control state, or persistent routed-but-open work is surfaced instead
+of repaired by Project Lead.
 
 ## Deterministic escalation (no relay agent)
 
@@ -53,7 +74,7 @@ city, configure local paths, and verify dry-run output before scheduling writes.
 ## Requirements
 
 - An extmsg/slack adapter in the city for outbound delivery and inbound replies — **compose this pack with your slack pack** (e.g. `slack-full`, `slack-channel`, or `slack-mini`). This pack ships only the oversight role and its escalation machinery, not a slack bridge.
-- Optional: the project-lead's rig-scoped dispatch examples use convoy formulas (`mol-decompose`, `mol-pr-from-issue`) supplied by a workflow pack (e.g. `gastown`). The role works without them.
+- Optional: a workflow/formula pack (for example `gastown`) supplies the durable Formula/run metadata that Project Lead can safely reconcile. Project Lead does not initiate new convoy formulas.
 - Optional: the executive-status skill needs Python 3.11 or newer. Obsidian and a publishing adapter are not required; without them it writes ordinary Markdown to a configured path.
 
 ## Install

--- a/oversight-rig/agents/project-lead/prompt.template.md
+++ b/oversight-rig/agents/project-lead/prompt.template.md
@@ -14,9 +14,8 @@ not deliver to Slack/email. The downstream pipeline turns your rollup
 beads into messages mechanically — your job is to make the right
 judgment, in your project's voice, and write the bead.
 
-You also **dispatch ready, in-scope work in your own rig directly** —
-you no longer route every dispatch through the mayor. See
-_Rig-Scoped Dispatch_ below for the boundary.
+You reconcile durable existing execution intent in your own rig. You do not
+create new routing decisions. See _Rig-Scoped Dispatch_ below for the boundary.
 
 ## Required First Step Each Tick
 
@@ -38,9 +37,10 @@ and exit. Do not improvise a persona.
 
 You read these and nothing else:
 
-- `gc bd list --rig {{ .Rig }} --status blocked --json`
-- `gc bd list --rig {{ .Rig }} --status in_progress --json`
-- `gc bd list --rig {{ .Rig }} --label rollup --status open --json` (dedup)
+- `gc --rig "{{ .Rig }}" bd list --status blocked --json`
+- `gc --rig "{{ .Rig }}" bd list --status in_progress --json`
+- `gc --rig "{{ .Rig }}" bd list --label rollup --status open --json` (dedup)
+- `python3 "$GC_PACK_DIR/assets/scripts/select-execution-candidates.py" --rig {{ .Rig }} --json` (the only dispatch-candidate source)
 - `gc mail inbox` (human replies routed back to you, plus crew
   questions specific to your rig)
 - `{{ .RigRoot }}/.gc/project-brief.md` (your operating manual)
@@ -119,7 +119,7 @@ Before writing a `severity:escalate` rollup, list existing open
 `severity:escalate` rollup beads for your rig:
 
 ```bash
-gc bd list --rig {{ .Rig }} --label rollup --label severity:escalate --status open --json
+gc --rig "{{ .Rig }}" bd list --label rollup --label severity:escalate --status open --json
 ```
 
 If any of them have a `ref:<id>` matching one of your source beads,
@@ -141,57 +141,53 @@ otherwise. When you receive one:
 
 ## Rig-Scoped Dispatch (your rig only)
 
-You may dispatch **ready** work in your own rig directly, including
-convoy-creating formulas (`mol-decompose`, `mol-pr-from-issue`) that
-expand a single root bead into a multi-bead graph workflow. A bead is
-*ready* to sling when ALL of these hold:
+**READY != RUN.** Beads readiness is only a scheduling prerequisite. A plain
+open, unblocked backlog bead is not execution-authorized, even when a worker
+pool exists. Never run an unrestricted `gc bd list --ready` scan to select work.
 
-- status `open`, not `blocked`, and every `depends-on` bead is closed
-- not gated on a human decision (no open `severity:escalate` rollup
-  about it, no "needs decision" / "needs-api" gate in its notes or
-  `gc.tier` metadata)
-- your rig has a worker pool (`{{ .Rig }}`-worker or equivalent)
+Run the bounded, read-only selector from _Your Inputs_. It is the only
+dispatch-candidate source. It fails closed on query, JSON, schema, root, route,
+or bound uncertainty. It returns only existing durable intent:
 
-To dispatch:
+1. a valid existing `gc.routed_to` for this rig, or
+2. a Formula/run member whose existing `gc.root_bead_id` and store reference
+   resolve to a live valid workflow root in this rig.
 
-```bash
-# Atomic in-rig work (single bead → single worker):
-gc-sling <rig-worker-agent> <bead-id>
+A returned route is already the authoritative scheduling decision. Do not
+invoke `gc-sling` to choose a worker for it. Do not invent, select, overwrite,
+normalize, or repair a route. Do not infer execution intent from an arbitrary
+bead tree, a title, a label, or a custom ACTIVE/COMMITTED marker. Formula
+control steps remain controller-owned. A Formula member without its existing
+route/control state is an anomaly to surface, not permission to choose a
+worker.
 
-# Convoy-creating formulas (epic → multi-bead graph; in-rig only):
-gc-sling <rig-worker-agent> --on mol-decompose --var issue=<epic> --var rig={{ .Rig }} --stdin
-gc-sling <rig-worker-agent> --on mol-pr-from-issue --var issue=<N> --stdin
-```
-
-Use the `gc-sling` wrapper — it auto-injects `--nudge`. Then **verify
-the worker actually picked it up** — a bead can be routed but sit
-unclaimed if no worker session is awake:
+For an eligible candidate, first verify its existing route actually picked it
+up:
 
 ```bash
-gc bd --rig {{ .Rig }} show <bead-id>   # expect IN_PROGRESS within a few minutes
+gc --rig "{{ .Rig }}" bd show <candidate-id>   # expect IN_PROGRESS within a few minutes
 ```
 
-If it stays `open` with `gc.routed_to` already set, the pool is asleep.
-`gc sling` treats an already-routed bead as an idempotent skip and will
-NOT re-nudge — re-slinging a stuck bead is a silent no-op. Unstick it by
-waking a worker and nudging it onto the bead:
+If it remains open, do not pass the returned pool route to `gc session wake`
+or `gc session nudge`. A persisted route expresses controller scheduling demand;
+it is not guaranteed to be a concrete session identity, especially when the
+pool is at scale zero or uses instance suffixes. Let the controller reconcile
+that demand. After a bounded observation interval, surface the still-open
+candidate and its unchanged route in a structured rollup for the mayor. Never
+guess a session name, add an instance suffix, or re-sling the bead.
 
-```bash
-gc session wake <rig-worker-agent>-1
-gc session nudge <rig-worker-agent>-1 "Claim and work routed bead <bead-id>." --delivery immediate
-```
+**Still mayor-owned - surface as a rollup, do not route yourself:**
 
-**Still mayor-owned — surface as a rollup, do not sling yourself:**
+- Cross-rig routing remains mayor-owned - any work that touches another rig's
+  worktree, beads, or worker pool. In-rig Formula/run ownership does not grant
+  authority to create a new route.
+- Worker-pool allocation or persistent routed-but-open demand - surface it to
+  the mayor without selecting a worker or guessing a session.
+- City-level orders (`gc order run …`) - mayor-only.
+- Anything gated on a human decision - surface it `severity:escalate` first;
+  act only after the human answers and a valid route already exists.
 
-- **Cross-rig routing remains mayor-owned** — any work that touches another
-  rig's worktree, beads, or worker pool. In-rig convoys are yours; cross-rig
-  convoys are mayor's.
-- Worker-pool allocation — if your rig has no pool, mail the mayor
-- City-level orders (`gc order run …`) — mayor-only
-- Anything gated on a human decision — surface it `severity:escalate`
-  first; sling only after the human answers
-
-You may NOT push, open, edit, or merge PRs — even for work you dispatch.
+You may NOT push, open, edit, or merge PRs, even for work you monitor.
 Polecats write code on branches and HALT at branch-ready; mayor publishes
 externally. This preserves the polecat-publish-authority rule end-to-end.
 
@@ -199,10 +195,10 @@ externally. This preserves the polecat-publish-authority rule end-to-end.
 
 - Read or write code.
 - Look at beads from other rigs (cross-rig work is mayor-owned).
-- Sling cross-rig or human-gated work — surface those, don't dispatch them.
-  In-rig convoys ARE yours; cross-rig convoys are NOT.
-- Push, open, edit, or merge PRs — even for work you sling. Mayor publishes
-  per-action after human approval.
+- Sling cross-rig or human-gated work. Surface those instead. Do not create
+  an in-rig route for an uncommitted bead either.
+- Push, open, edit, or merge PRs. Mayor publishes per-action after human
+  approval.
 - Decide for the human (you surface decisions, you don't make them).
 - Skip the brief. If it's missing, you don't have the context to do
   this job — escalate the missing-brief itself.

--- a/oversight-rig/assets/scripts/select-execution-candidates.py
+++ b/oversight-rig/assets/scripts/select-execution-candidates.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""Safely select Project Lead candidates with existing durable execution intent.
+
+The selector is read-only. It uses bounded public ``gc ready`` and ``gc bd list/show`` queries
+and returns only each candidate's ID, classification, and exact existing route.
+READY is a prerequisite for scheduling, not permission to run backlog work.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+DEFAULT_MAX_ROWS = 50
+COMMAND_TIMEOUT_SECONDS = 10
+MAX_OUTPUT_BYTES = 1_000_000
+MAX_JSON_DEPTH = 32
+IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+ROUTE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*(?:/[A-Za-z0-9][A-Za-z0-9._-]*)+$")
+LIVE_ROOT_STATUSES = {"open", "in_progress"}
+KNOWN_STATUSES = LIVE_ROOT_STATUSES | {"blocked", "deferred", "closed"}
+RUN_CHAIN_KEYS = ("workflow_id", "molecule_id", "gc.root_bead_id")
+INTENT_METADATA_KEYS = ("gc.routed_to", *RUN_CHAIN_KEYS)
+
+
+class SelectorError(RuntimeError):
+    """A query or payload cannot safely authorize dispatch."""
+
+
+def valid_identifier(value: Any) -> str | None:
+    return value if isinstance(value, str) and IDENTIFIER_RE.fullmatch(value) else None
+
+
+def reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise SelectorError(f"duplicate JSON key {key!r}")
+        result[key] = value
+    return result
+
+
+def check_json_depth(value: Any, depth: int = 0) -> None:
+    if depth > MAX_JSON_DEPTH:
+        raise SelectorError("JSON exceeds maximum nesting depth")
+    if isinstance(value, Mapping):
+        for child in value.values():
+            check_json_depth(child, depth + 1)
+    elif isinstance(value, list):
+        for child in value:
+            check_json_depth(child, depth + 1)
+
+
+def command_json(*args: str) -> list[dict[str, Any]]:
+    """Run one bounded public read-only gc query and validate its JSON."""
+    command = ["gc", *args] if args and args[0] == "ready" else ["gc", "bd", *args]
+    try:
+        result = subprocess.run(
+            command,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=COMMAND_TIMEOUT_SECONDS,
+        )
+    except (OSError, UnicodeError, subprocess.TimeoutExpired) as exc:
+        raise SelectorError(f"could not run gc query safely: {exc}") from exc
+    if (
+        len(result.stdout.encode()) > MAX_OUTPUT_BYTES
+        or len(result.stderr.encode()) > MAX_OUTPUT_BYTES
+    ):
+        raise SelectorError("gc query output exceeded selector bound")
+    if result.returncode:
+        raise SelectorError(f"{' '.join(command)} failed")
+    try:
+        payload = json.loads(
+            result.stdout,
+            object_pairs_hook=reject_duplicate_keys,
+            parse_constant=lambda value: (_ for _ in ()).throw(
+                SelectorError(f"invalid JSON constant {value}")
+            ),
+        )
+    except (json.JSONDecodeError, UnicodeError) as exc:
+        raise SelectorError("gc query returned malformed JSON") from exc
+    check_json_depth(payload)
+    if isinstance(payload, dict):
+        if not args or args[0] != "show":
+            raise SelectorError("gc query returned an unexpected JSON schema")
+        payload = [payload]
+    if not isinstance(payload, list) or not all(
+        isinstance(item, dict) for item in payload
+    ):
+        raise SelectorError("gc query returned an unexpected JSON schema")
+    return payload
+
+
+def metadata(bead: Mapping[str, Any]) -> Mapping[str, Any]:
+    value = bead.get("metadata", {})
+    if not isinstance(value, Mapping):
+        raise SelectorError("bead metadata is not an object")
+    return value
+
+
+def nonempty_string(value: Any) -> str | None:
+    if not isinstance(value, str) or not value or value.strip() != value:
+        return None
+    return value
+
+
+def validate_bead(bead: Mapping[str, Any]) -> None:
+    if valid_identifier(bead.get("id")) is None:
+        raise SelectorError("bead has no valid id")
+    if bead.get("status") not in KNOWN_STATUSES:
+        raise SelectorError("bead has an invalid status")
+    metadata(bead)
+    for field in ("notes", "description"):
+        value = bead.get(field)
+        if value is not None and not isinstance(value, str):
+            raise SelectorError(f"bead {field} is not text")
+
+
+def bare_route_is_proven_local(
+    bead: Mapping[str, Any], route: str, rig: str
+) -> bool:
+    bead_id = valid_identifier(bead.get("id"))
+    assert bead_id is not None  # validate_bead ran first
+    try:
+        rows = command_json("show", "--rig", rig, bead_id, "--json")
+    except SelectorError:
+        return False
+    if len(rows) != 1:
+        return False
+    local = rows[0]
+    validate_bead(local)
+    return (
+        local.get("id") == bead_id
+        and local.get("status") == bead.get("status")
+        and metadata(local).get("gc.routed_to") == route
+    )
+
+
+def existing_route(bead: Mapping[str, Any], rig: str) -> str | None:
+    bead_metadata = metadata(bead)
+    if "gc.routed_to" not in bead_metadata:
+        return None
+    raw_route = bead_metadata["gc.routed_to"]
+    if raw_route == "":
+        return None
+    route = nonempty_string(raw_route)
+    if route is None:
+        raise SelectorError("bead has an invalid gc.routed_to")
+    if valid_identifier(route) is not None:
+        return route if bare_route_is_proven_local(bead, route, rig) else None
+    if route.startswith(f"{rig}/") and ROUTE_RE.fullmatch(route):
+        return route
+    raise SelectorError("bead has an invalid or foreign gc.routed_to")
+
+
+def is_human_gated(bead: Mapping[str, Any], escalate_refs: set[str]) -> bool:
+    bead_id = valid_identifier(bead.get("id"))
+    assert bead_id is not None  # validate_bead ran first
+    if bead_id in escalate_refs:
+        return True
+    tier = metadata(bead).get("gc.tier", "")
+    if tier is not None and not isinstance(tier, str):
+        raise SelectorError("gc.tier is not text")
+    route = metadata(bead).get("gc.routed_to")
+    if route == "human":
+        return True
+    text = " ".join(
+        (bead.get("notes") or "", bead.get("description") or "", tier or "")
+    ).lower()
+    return "needs decision" in text or "needs-api" in text
+
+
+def valid_live_formula_root(root: Mapping[str, Any], root_id: str, rig: str) -> bool:
+    validate_bead(root)
+    if root.get("id") != root_id or root.get("status") not in LIVE_ROOT_STATUSES:
+        return False
+    root_metadata = metadata(root)
+    root_store = root_metadata.get("gc.root_store_ref")
+    if root_store is not None and root_store != f"rig:{rig}":
+        return False
+    graph_workflow = (
+        root_metadata.get("gc.kind") == "workflow"
+        or root_metadata.get("gc.formula_contract") == "graph.v2"
+    )
+    legacy_formula = (
+        root.get("issue_type") == "molecule" or root_metadata.get("gc.kind") == "wisp"
+    )
+    return graph_workflow or legacy_formula
+
+
+def formula_root_id(bead: Mapping[str, Any], rig: str) -> str | None:
+    """Resolve the documented run-chain fields without arbitrary-tree inference."""
+    bead_metadata = metadata(bead)
+    present = [key for key in RUN_CHAIN_KEYS if key in bead_metadata]
+    if not present:
+        return None
+    values = [valid_identifier(bead_metadata[key]) for key in present]
+    if any(value is None for value in values) or len(set(values)) != 1:
+        raise SelectorError(
+            "formula member has ambiguous or malformed run-chain metadata"
+        )
+    store = bead_metadata.get("gc.root_store_ref")
+    if store is not None and store != f"rig:{rig}":
+        raise SelectorError("formula member has a foreign root store")
+    return values[0]
+
+
+def has_live_formula_intent(bead: Mapping[str, Any], rig: str) -> bool:
+    root_id = formula_root_id(bead, rig)
+    if root_id is None:
+        return False
+    roots = command_json("show", "--rig", rig, root_id, "--json")
+    if len(roots) != 1:
+        raise SelectorError("root lookup did not return exactly one bead")
+    return valid_live_formula_root(roots[0], root_id, rig)
+
+
+def select(rig: str, max_rows: int) -> dict[str, Any]:
+    """Return a safe candidate/anomaly envelope. Uncertainty raises ``SelectorError``."""
+    if valid_identifier(rig) is None or max_rows < 1:
+        raise SelectorError("invalid selector arguments")
+    # ``ready`` delegates dependency and deferred/blocked handling to Beads.
+    # Query only durable-intent metadata keys so unrelated backlog cannot exhaust
+    # the safety bound. Each public query remains independently bounded; the
+    # deduplicated union is bounded again before any scheduling decision.
+    ready_by_id: dict[str, dict[str, Any]] = {}
+    for intent_key in INTENT_METADATA_KEYS:
+        rows = command_json(
+            "ready",
+            "--rig",
+            rig,
+            "--metadata-field",
+            intent_key,
+            "--json",
+            "--limit",
+            str(max_rows + 1),
+        )
+        if len(rows) > max_rows:
+            raise SelectorError("public query exceeded selector row bound")
+        query_ids: set[str] = set()
+        for bead in rows:
+            validate_bead(bead)
+            bead_id = bead["id"]
+            if bead_id in query_ids:
+                raise SelectorError("ready query returned a duplicate bead id")
+            query_ids.add(bead_id)
+            prior = ready_by_id.get(bead_id)
+            if prior is not None and prior != bead:
+                raise SelectorError("ready queries returned conflicting bead data")
+            ready_by_id[bead_id] = bead
+    if len(ready_by_id) > max_rows:
+        raise SelectorError("public query exceeded selector row bound")
+    ready = list(ready_by_id.values())
+    escalates = command_json(
+        "list",
+        "--rig",
+        rig,
+        "--label",
+        "rollup",
+        "--label",
+        "severity:escalate",
+        "--status",
+        "open",
+        "--json",
+        "--limit",
+        str(max_rows + 1),
+    )
+    if len(escalates) > max_rows:
+        raise SelectorError("public query exceeded selector row bound")
+    escalate_refs: set[str] = set()
+    seen_rollup_ids: set[str] = set()
+    for rollup in escalates:
+        validate_bead(rollup)
+        rollup_id = rollup["id"]
+        if rollup_id in seen_rollup_ids:
+            raise SelectorError("rollup query returned a duplicate bead id")
+        seen_rollup_ids.add(rollup_id)
+        labels = rollup.get("labels")
+        if not isinstance(labels, list) or not all(
+            isinstance(label, str) for label in labels
+        ):
+            raise SelectorError("rollup labels are not an array of strings")
+        for label in labels:
+            if label.startswith("ref:"):
+                reference = valid_identifier(label[4:])
+                if reference is None:
+                    raise SelectorError("rollup has a malformed ref label")
+                escalate_refs.add(reference)
+
+    candidates: list[dict[str, str]] = []
+    anomalies: list[dict[str, str]] = []
+    seen_ids: set[str] = set()
+    for bead in ready:
+        validate_bead(bead)
+        bead_id = bead["id"]
+        if bead_id in seen_ids:
+            raise SelectorError("ready query returned a duplicate bead id")
+        seen_ids.add(bead_id)
+        if bead.get("status") != "open" or is_human_gated(bead, escalate_refs):
+            continue
+        route = existing_route(bead, rig)
+        formula_declared = any(key in metadata(bead) for key in RUN_CHAIN_KEYS)
+        formula_member = has_live_formula_intent(bead, rig)
+        if formula_declared and not formula_member:
+            continue
+        # A formula member without an existing route is controller-owned
+        # anomalous state. Recognizing its root never authorizes choosing a
+        # worker route, so it is deliberately not returned as a candidate.
+        if route is None:
+            if formula_member:
+                anomalies.append(
+                    {"id": bead_id, "reason": "live-formula-missing-route"}
+                )
+            continue
+        candidates.append(
+            {
+                "id": bead_id,
+                "classification": "formula-routed" if formula_member else "routed",
+                "route": route,
+            }
+        )
+    return {"schema_version": 1, "candidates": candidates, "anomalies": anomalies}
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--rig", required=True)
+    parser.add_argument("--max-rows", type=int, default=DEFAULT_MAX_ROWS)
+    parser.add_argument("--json", action="store_true", help="required output format")
+    args = parser.parse_args(argv)
+    if not args.json:
+        return 2
+    try:
+        print(json.dumps(select(args.rig, args.max_rows), sort_keys=True))
+    except SelectorError as exc:
+        print(f"execution candidate selection failed closed: {exc}", file=sys.stderr)
+        print(
+            json.dumps(
+                {"schema_version": 1, "candidates": [], "anomalies": []}, sort_keys=True
+            )
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/oversight-rig/pack.toml
+++ b/oversight-rig/pack.toml
@@ -8,9 +8,10 @@
 #       triggers from <rig>/.gc/project-brief.md (each project owns its
 #       own brief, so scoping context stays local instead of piling onto
 #       the mayor).
-#     • Triages its rig every tick and dispatches ready, in-scope work in
-#       its own rig directly — it does not route every dispatch through
-#       the mayor.
+#     • Triages its rig every tick and reconciles committed ready work in
+#       its own rig. It observes existing eligible routes and controller
+#       progress but never creates routing from readiness alone or treats
+#       a pool route as a concrete session identity.
 #     • Judges severity (info vs escalate) and writes structured rollup
 #       beads with explicit labels.
 #
@@ -43,8 +44,8 @@
 #   │  │ • reads foo/.gc/       │  │ • reads bar/.gc/       │          │
 #   │  │   project-brief.md     │  │   project-brief.md     │          │
 #   │  │ • bounded to foo's     │  │ • bounded to bar's     │          │
-#   │  │   beads; dispatches    │  │   beads; dispatches    │          │
-#   │  │   its own ready work   │  │   its own ready work   │          │
+#   │  │   beads; reconciles   │  │   beads; reconciles   │          │
+#   │  │   committed intent     │  │   committed intent     │          │
 #   │  │ + your existing rig    │  │ + your existing rig    │          │
 #   │  │   agents (witness etc) │  │   agents               │          │
 #   │  └────────────────────────┘  └────────────────────────┘          │
@@ -62,10 +63,9 @@
 # slack-channel, or slack-mini). This pack ships only the oversight role and
 # its escalation machinery, not a slack bridge.
 #
-# Optional: the project-lead's rig-scoped dispatch examples use convoy
-# formulas (mol-decompose, mol-pr-from-issue) supplied by a workflow/formula
-# pack (e.g. gastown). The oversight role works without them — it just won't
-# offer those particular dispatch shortcuts.
+# Optional: a workflow/formula pack (for example gastown) supplies the
+# durable Formula/run metadata Project Lead can reconcile. Project Lead does
+# not initiate new formulas or route uncommitted work.
 #
 # To install in an existing city:
 #   1. Add the pack to city.toml (and stamp a project-lead per rig).

--- a/oversight-rig/tests/test_execution_candidates.py
+++ b/oversight-rig/tests/test_execution_candidates.py
@@ -1,0 +1,522 @@
+"""Tests for the Project Lead's durable execution-intent selector."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+BD_TAIL = ["b" + "d"]
+SCRIPT = (
+    Path(__file__).parents[1] / "assets" / "scripts" / "select-execution-candidates.py"
+)
+spec = importlib.util.spec_from_file_location("execution_candidates", SCRIPT)
+assert spec and spec.loader
+selector = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(selector)
+
+RIG = "alpha"
+
+
+def bead(
+    bead_id: str,
+    *,
+    status: str = "open",
+    metadata: dict[str, Any] | None = None,
+    notes: str = "",
+    description: str = "",
+    labels: list[str] | None = None,
+) -> dict[str, Any]:
+    return {
+        "id": bead_id,
+        "status": status,
+        "metadata": metadata or {},
+        "notes": notes,
+        "description": description,
+        "labels": labels or [],
+    }
+
+
+def root(
+    root_id: str = "root-1",
+    *,
+    status: str = "in_progress",
+    rig: str = RIG,
+    metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    defaults = {
+        "gc.root_store_ref": f"rig:{rig}",
+        "gc.kind": "workflow",
+        "gc.formula_name": "mol-example",
+        "gc.formula_contract": "graph.v2",
+    }
+    if metadata:
+        defaults.update(metadata)
+    return bead(root_id, status=status, metadata=defaults)
+
+
+def fake_queries(
+    monkeypatch: pytest.MonkeyPatch,
+    ready: list[dict[str, Any]],
+    rollups: list[dict[str, Any]] | None = None,
+    roots: dict[str, list[dict[str, Any]]] | None = None,
+) -> list[tuple[str, ...]]:
+    calls: list[tuple[str, ...]] = []
+    roots = roots or {}
+
+    def query(*args: str) -> list[dict[str, Any]]:
+        calls.append(args)
+        if args[0] == "ready":
+            key = args[args.index("--metadata-field") + 1]
+            return [item for item in ready if key in item.get("metadata", {})]
+        if args[0] == "list":
+            return rollups or []
+        assert args[0] == "show"
+        assert args[1:3] == ("--rig", RIG)
+        return roots[args[3]]
+
+    monkeypatch.setattr(selector, "command_json", query)
+    return calls
+
+
+def test_plain_ready_backlog_is_excluded(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = fake_queries(monkeypatch, [bead("backlog")])
+    assert selector.select(RIG, 7)["candidates"] == []
+    assert calls[0] == (
+        "ready",
+        "--rig",
+        RIG,
+        "--metadata-field",
+        "gc.routed_to",
+        "--json",
+        "--limit",
+        "8",
+    )
+    assert all(call[0] in {"ready", "list", "show"} for call in calls)
+
+
+def test_large_uncommitted_backlog_does_not_exhaust_intent_bound(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    backlog = [bead(f"backlog-{index}") for index in range(100)]
+    routed = bead("routed", metadata={"gc.routed_to": "alpha/polecat"})
+    fake_queries(monkeypatch, [*backlog, routed])
+    assert selector.select(RIG, 1)["candidates"] == [
+        {"id": "routed", "classification": "routed", "route": "alpha/polecat"}
+    ]
+
+
+def test_existing_valid_route_is_preserved_as_candidate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    routed = bead("routed", metadata={"gc.routed_to": "alpha/polecat"})
+    fake_queries(monkeypatch, [routed])
+    assert selector.select(RIG, 7)["candidates"] == [
+        {"id": "routed", "classification": "routed", "route": "alpha/polecat"}
+    ]
+
+
+def test_existing_rig_local_route_is_preserved_as_candidate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    routed = bead("warrant", metadata={"gc.routed_to": "gastown.dog"})
+    fake_queries(monkeypatch, [routed], roots={"warrant": [routed]})
+    assert selector.select(RIG, 7)["candidates"] == [
+        {"id": "warrant", "classification": "routed", "route": "gastown.dog"}
+    ]
+
+
+def test_unproven_bare_route_from_federated_ready_is_excluded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    foreign = bead("foreign", metadata={"gc.routed_to": "beta.worker"})
+    fake_queries(monkeypatch, [foreign], roots={"foreign": []})
+    assert selector.select(RIG, 7)["candidates"] == []
+
+
+def test_cleared_route_is_absent_without_suppressing_other_candidates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cleared = bead("direct-handoff", metadata={"gc.routed_to": ""})
+    routed = bead("routed", metadata={"gc.routed_to": "alpha/polecat"})
+    fake_queries(monkeypatch, [cleared, routed])
+    assert selector.select(RIG, 7)["candidates"] == [
+        {"id": "routed", "classification": "routed", "route": "alpha/polecat"}
+    ]
+
+
+@pytest.mark.parametrize(
+    "route", ["beta/polecat", "alpha/", " alpha/polecat", "alpha/pole cat"]
+)
+def test_invalid_or_foreign_routes_are_excluded(
+    monkeypatch: pytest.MonkeyPatch, route: str
+) -> None:
+    fake_queries(monkeypatch, [bead("bad-route", metadata={"gc.routed_to": route})])
+    with pytest.raises(selector.SelectorError):
+        selector.select(RIG, 7)
+
+
+def test_live_formula_member_is_candidate(monkeypatch: pytest.MonkeyPatch) -> None:
+    member = bead(
+        "step",
+        metadata={
+            "gc.root_bead_id": "root-1",
+            "gc.root_store_ref": "rig:alpha",
+            "gc.routed_to": "alpha/core.control-dispatcher",
+        },
+    )
+    fake_queries(monkeypatch, [member], roots={"root-1": [root()]})
+    assert selector.select(RIG, 7)["candidates"] == [
+        {
+            "id": "step",
+            "classification": "formula-routed",
+            "route": "alpha/core.control-dispatcher",
+        }
+    ]
+
+
+def test_formula_member_without_existing_route_is_not_dispatched(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    member = bead(
+        "step", metadata={"gc.root_bead_id": "root-1", "gc.root_store_ref": "rig:alpha"}
+    )
+    fake_queries(monkeypatch, [member], roots={"root-1": [root()]})
+    outcome = selector.select(RIG, 7)
+    assert outcome["candidates"] == []
+    assert outcome["anomalies"] == [
+        {"id": "step", "reason": "live-formula-missing-route"}
+    ]
+
+
+@pytest.mark.parametrize(
+    "roots",
+    [
+        {"root-1": [root(status="closed")]},
+        {"root-1": []},
+        {"root-1": [root(rig="beta")]},
+        {"root-1": [root(metadata={"gc.kind": "task", "gc.formula_contract": ""})]},
+        {"root-1": [root(), root()]},
+    ],
+)
+def test_invalid_or_closed_formula_roots_fail_closed(
+    monkeypatch: pytest.MonkeyPatch, roots: dict[str, list[dict[str, Any]]]
+) -> None:
+    member = bead(
+        "step",
+        metadata={
+            "gc.root_bead_id": "root-1",
+            "gc.root_store_ref": "rig:alpha",
+            "gc.routed_to": "alpha/polecat",
+        },
+    )
+    fake_queries(monkeypatch, [member], roots=roots)
+    if len(roots["root-1"]) != 1:
+        with pytest.raises(selector.SelectorError):
+            selector.select(RIG, 7)
+    else:
+        assert selector.select(RIG, 7)["candidates"] == []
+
+
+@pytest.mark.parametrize(
+    "candidate,rollups",
+    [
+        (
+            bead(
+                "blocked", status="blocked", metadata={"gc.routed_to": "alpha/polecat"}
+            ),
+            [],
+        ),
+        (
+            bead(
+                "deferred",
+                status="deferred",
+                metadata={"gc.routed_to": "alpha/polecat"},
+            ),
+            [],
+        ),
+        (
+            bead(
+                "human-note",
+                metadata={"gc.routed_to": "alpha/polecat"},
+                notes="needs decision from owner",
+            ),
+            [],
+        ),
+        (
+            bead(
+                "human-description",
+                metadata={"gc.routed_to": "alpha/polecat"},
+                description="Blocked: needs-api from owner",
+            ),
+            [],
+        ),
+        (
+            bead(
+                "human-tier",
+                metadata={"gc.routed_to": "alpha/polecat", "gc.tier": "needs-api"},
+            ),
+            [],
+        ),
+        (
+            bead("escalated", metadata={"gc.routed_to": "alpha/polecat"}),
+            [bead("rollup", labels=["rollup", "severity:escalate", "ref:escalated"])],
+        ),
+        (
+            bead("human-route", metadata={"gc.routed_to": "human"}),
+            [],
+        ),
+    ],
+)
+def test_non_dispatchable_or_human_gated_work_is_excluded(
+    monkeypatch: pytest.MonkeyPatch,
+    candidate: dict[str, Any],
+    rollups: list[dict[str, Any]],
+) -> None:
+    fake_queries(monkeypatch, [candidate], rollups=rollups)
+    assert selector.select(RIG, 7)["candidates"] == []
+
+
+def test_malformed_metadata_in_intent_query_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    malformed = {"id": "bad", "status": "open", "metadata": []}
+
+    def query(*args: str) -> list[dict[str, Any]]:
+        return [malformed] if args[0] == "ready" else []
+
+    monkeypatch.setattr(selector, "command_json", query)
+    with pytest.raises(selector.SelectorError):
+        selector.select(RIG, 7)
+
+
+def test_query_failure_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fails(*_args: str) -> list[dict[str, Any]]:
+        raise selector.SelectorError("query failed")
+
+    monkeypatch.setattr(selector, "command_json", fails)
+    with pytest.raises(selector.SelectorError):
+        selector.select(RIG, 7)
+
+
+def test_foreign_root_reference_is_excluded_without_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = fake_queries(
+        monkeypatch,
+        [
+            bead(
+                "foreign",
+                metadata={"gc.root_bead_id": "root-1", "gc.root_store_ref": "rig:beta"},
+            )
+        ],
+    )
+    with pytest.raises(selector.SelectorError):
+        selector.select(RIG, 7)
+    assert all(call[0] != "show" for call in calls)
+
+
+def test_escalation_rollup_overflow_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rollups = [
+        bead("rollup-1", labels=["rollup", "severity:escalate", "ref:one"]),
+        bead("rollup-2", labels=["rollup", "severity:escalate", "ref:two"]),
+    ]
+    fake_queries(monkeypatch, [], rollups=rollups)
+    with pytest.raises(selector.SelectorError):
+        selector.select(RIG, 1)
+
+
+def test_row_bound_and_duplicate_candidate_ids_fail_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    route = {"gc.routed_to": "alpha/polecat"}
+    fake_queries(monkeypatch, [bead("one", metadata=route), bead("two", metadata=route)])
+    with pytest.raises(selector.SelectorError):
+        selector.select(RIG, 1)
+
+    fake_queries(
+        monkeypatch,
+        [bead("same", metadata=route), bead("same", metadata=route)],
+    )
+    with pytest.raises(selector.SelectorError):
+        selector.select(RIG, 7)
+
+
+def test_bd_show_object_json_is_normalized(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    shown = root()
+    completed = subprocess.CompletedProcess(
+        ["gc"], 0, stdout=json.dumps(shown), stderr=""
+    )
+    monkeypatch.setattr(selector.subprocess, "run", lambda *_args, **_kwargs: completed)
+    assert selector.command_json("show", "--rig", RIG, "root-1", "--json") == [shown]
+
+
+def test_non_show_object_json_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    completed = subprocess.CompletedProcess(
+        ["gc"], 0, stdout=json.dumps(bead("unexpected")), stderr=""
+    )
+    monkeypatch.setattr(selector.subprocess, "run", lambda *_args, **_kwargs: completed)
+    with pytest.raises(selector.SelectorError):
+        selector.command_json("ready", "--rig", RIG, "--json")
+
+
+def test_malformed_json_and_timeout_fail_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    malformed = subprocess.CompletedProcess(["gc"], 0, stdout="{", stderr="")
+    monkeypatch.setattr(selector.subprocess, "run", lambda *_args, **_kwargs: malformed)
+    with pytest.raises(selector.SelectorError):
+        selector.command_json("ready", "--rig", RIG, "--json")
+
+    def timeout(*_args: Any, **_kwargs: Any) -> None:
+        raise subprocess.TimeoutExpired("gc", 10)
+
+    monkeypatch.setattr(selector.subprocess, "run", timeout)
+    with pytest.raises(selector.SelectorError):
+        selector.command_json("ready", "--rig", RIG, "--json")
+
+
+def test_conflicting_run_chain_metadata_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    member = bead(
+        "step",
+        metadata={
+            "workflow_id": "root-a",
+            "gc.root_bead_id": "root-b",
+            "gc.routed_to": "alpha/polecat",
+        },
+    )
+    fake_queries(monkeypatch, [member])
+    with pytest.raises(selector.SelectorError):
+        selector.select(RIG, 7)
+
+
+def test_arbitrary_tree_metadata_does_not_establish_intent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    descendant = bead(
+        "child", metadata={"parent_id": "root-1", "gc.parent_bead_id": "root-1"}
+    )
+    fake_queries(monkeypatch, [descendant])
+    assert selector.select(RIG, 7)["candidates"] == []
+
+
+def write_fake_gc(
+    tmp_path: Path,
+    ready: list[dict[str, Any]],
+    rollups: list[dict[str, Any]],
+    roots: dict[str, list[dict[str, Any]]],
+) -> Path:
+    fixture = tmp_path / "fixture.json"
+    fixture.write_text(json.dumps({"ready": ready, "rollups": rollups, "roots": roots}))
+    fake = tmp_path / "gc"
+    fake.write_text(
+        "#!/usr/bin/env python3\n"
+        "import json, os, pathlib, sys\n"
+        "args = sys.argv[1:]\n"
+        "pathlib.Path(os.environ['GC_FAKE_CALLS']).open('a').write(json.dumps(args) + '\\n')\n"
+        "data = json.loads(pathlib.Path(os.environ['GC_FAKE_FIXTURE']).read_text())\n"
+        "if args[0] == 'ready':\n"
+        "    key = args[args.index('--metadata-field') + 1]\n"
+        "    print(json.dumps([item for item in data['ready'] if key in item.get('metadata', {})]))\n"
+        "elif args[:2] == ['b' + 'd', 'list']: print(json.dumps(data['rollups']))\n"
+        "elif args[:2] == ['b' + 'd', 'show']: print(json.dumps(data['roots'].get(args[4], [])))\n"
+        "else: sys.exit(8)\n"
+    )
+    fake.chmod(0o755)
+    return fixture
+
+
+def test_cli_uses_only_bounded_readonly_gc_queries(tmp_path: Path) -> None:
+    ready = [bead("routed", metadata={"gc.routed_to": "alpha/polecat"})]
+    fixture = write_fake_gc(tmp_path, ready, [], {})
+    calls_file = tmp_path / "calls.jsonl"
+    env = {
+        **os.environ,
+        "PATH": f"{tmp_path}:{os.environ['PATH']}",
+        "GC_FAKE_FIXTURE": str(fixture),
+        "GC_FAKE_CALLS": str(calls_file),
+    }
+    completed = subprocess.run(
+        ["python3", str(SCRIPT), "--rig", RIG, "--json", "--max-rows", "7"],
+        text=True,
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+    assert completed.returncode == 0
+    assert json.loads(completed.stdout) == {
+        "schema_version": 1,
+        "candidates": [
+            {"id": "routed", "classification": "routed", "route": "alpha/polecat"}
+        ],
+        "anomalies": [],
+    }
+    calls = [json.loads(line) for line in calls_file.read_text().splitlines()]
+    expected_ready_calls = [
+        [
+            "ready",
+            "--rig",
+            RIG,
+            "--metadata-field",
+            key,
+            "--json",
+            "--limit",
+            "8",
+        ]
+        for key in selector.INTENT_METADATA_KEYS
+    ]
+    assert calls == [
+        *expected_ready_calls,
+        [
+            *BD_TAIL,
+            "list",
+            "--rig",
+            RIG,
+            "--label",
+            "rollup",
+            "--label",
+            "severity:escalate",
+            "--status",
+            "open",
+            "--json",
+            "--limit",
+            "8",
+        ],
+    ]
+    assert all(
+        call[0] == "ready" or call[:2] in [[*BD_TAIL, "list"], [*BD_TAIL, "show"]]
+        for call in calls
+    )
+
+
+def test_cli_command_failure_returns_an_empty_safe_envelope(tmp_path: Path) -> None:
+    fake = tmp_path / "gc"
+    fake.write_text("#!/bin/sh\nexit 1\n")
+    fake.chmod(0o755)
+    env = {**os.environ, "PATH": f"{tmp_path}:{os.environ['PATH']}"}
+    completed = subprocess.run(
+        ["python3", str(SCRIPT), "--rig", RIG, "--json"],
+        text=True,
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+    assert completed.returncode == 1
+    assert json.loads(completed.stdout) == {
+        "schema_version": 1,
+        "candidates": [],
+        "anomalies": [],
+    }

--- a/oversight-rig/tests/test_project_lead_dispatch_contract.py
+++ b/oversight-rig/tests/test_project_lead_dispatch_contract.py
@@ -1,0 +1,55 @@
+"""Static safety contract for Project Lead execution-intent reconciliation."""
+
+from pathlib import Path
+
+PACK_ROOT = Path(__file__).resolve().parents[1]
+PROMPT = (PACK_ROOT / "agents" / "project-lead" / "prompt.template.md").read_text()
+README = (PACK_ROOT / "README.md").read_text()
+PACK = (PACK_ROOT / "pack.toml").read_text()
+
+
+def normalized(text: str) -> str:
+    return " ".join(text.split())
+
+
+def test_project_lead_uses_the_selector_as_its_only_candidate_source() -> None:
+    prompt = normalized(PROMPT)
+    assert "select-execution-candidates.py" in prompt
+    assert "READY != RUN" in prompt
+    assert "plain open, unblocked backlog bead is not execution-authorized" in prompt
+    assert "Never run an unrestricted `gc bd list --ready` scan" in prompt
+    assert "Do not invoke `gc-sling`" in prompt
+
+
+def test_prompt_forbids_route_invention_and_keeps_formula_control_owned() -> None:
+    prompt = normalized(PROMPT)
+    for phrase in (
+        "Do not invent, select, overwrite, normalize, or repair a route.",
+        "Formula control steps remain controller-owned.",
+        "without its existing route/control state is an anomaly to surface",
+        "custom ACTIVE/COMMITTED marker",
+        "arbitrary bead tree",
+    ):
+        assert phrase in prompt
+
+
+def test_documentation_describes_reconciliation_not_ready_dispatch() -> None:
+    readme = normalized(README)
+    pack = normalized(PACK)
+    assert "Dispatch safety: READY != RUN" in readme
+    assert "does not invent or rewrite routes" in readme
+    assert "reconciles committed ready work" in readme
+    assert "reconciles committed ready work" in pack
+    assert "dispatches ready, in-scope work" not in pack
+
+
+def test_pool_routes_are_not_treated_as_concrete_sessions() -> None:
+    prompt = normalized(PROMPT)
+    readme = normalized(README)
+    assert "do not pass the returned pool route to `gc session wake`" in prompt
+    assert "or `gc session nudge`" in prompt
+    assert "Let the controller reconcile that demand." in prompt
+    assert "Never guess a session name, add an instance suffix" in prompt
+    assert "Pool routes remain controller scheduling demand" in readme
+    assert "gc session wake <exact-existing-route>" not in PROMPT
+    assert "gc session nudge <exact-existing-route>" not in PROMPT


### PR DESCRIPTION
## Summary

- enforce `READY != RUN` for `oversight-rig` Project Lead automation
- select only ready work with durable existing GC intent: a persisted route or verified live Formula/run membership with existing controller routing
- keep selection deterministic, bounded, read-only, rig-scoped, and fail closed without inventing or rewriting routes
- treat pool routes as controller scheduling demand rather than guessed concrete session identities

## Safety contract

Plain backlog, arbitrary bead trees, labels, priority, and project-brief prose remain inert. Formula members missing an existing route are surfaced as anomalies. Human-gated, foreign, malformed, ambiguous, truncated, and invalid-root state cannot authorize dispatch.

The selector uses public `gc ready` and `gc bd list/show` surfaces. Federated ready results are filtered by durable-intent metadata; bare routes require an explicit same-rig `show` proof before acceptance.

PR #267 is independent and complementary: it changes patrol order scope, while this PR changes Project Lead dispatch authority.

## Validation

- `uv run --with pytest pytest -q oversight-rig/tests tests/test_no_bare_bd_commands.py` - 45 passed
- `gc lint oversight-rig` - passed
- `python3 validate_registry.py registry.toml` - passed
- live read-only `gc ready` and bounded escalation-list query shapes - passed
- `git diff --check f3826035bb7de7c34621c2fdcd8620ab5a18bb08..f7e758770eadf568e0a1d8319a7e0c113a84abcc` - passed

## Immutable review provenance

- base: `f3826035bb7de7c34621c2fdcd8620ab5a18bb08`
- head: `f7e758770eadf568e0a1d8319a7e0c113a84abcc`
- native Codex review: no discrete actionable correctness issues
- local artifact: `/home/pranay/wd/gas-city/.gc/runtime/reviews/gcp-z3i-pr-review-f3826035-f7e75877.txt`

Tracking: `gcp-z3i`
