### PR TITLE
test(intake): honor configured gc binary

### DIFF
--- a/discord/tests/test_discord_intake_service.py
+++ b/discord/tests/test_discord_intake_service.py
@@ -58,6 +58,7 @@ class DiscordIntakeServiceTests(unittest.TestCase):
         self.addCleanup(self.tempdir.cleanup)
         self._old_environ = os.environ.copy()
         os.environ["GC_CITY_ROOT"] = self.tempdir.name
+        self.gc_bin = os.environ.get("GC_BIN", "gc")
         service.LAST_REQUEST_PRUNE_AT = 0.0
         service.LAST_REQUEST_RECOVERY_AT = 0.0
 
@@ -331,7 +332,7 @@ class DiscordIntakeServiceTests(unittest.TestCase):
         self.assertEqual(outcome["bead_id"], "bd-1")
         self.assertTrue(outcome["bead_closed"])
         commands = [call.args[0] for call in run_subprocess.call_args_list]
-        prefix = ["gc", "--city", self.tempdir.name, "--rig", "product", "bd"]
+        prefix = [self.gc_bin, "--city", self.tempdir.name, "--rig", "product", "bd"]
         self.assertEqual(
             commands[0],
             prefix + ["update", "bd-1", "--set-metadata", "close_reason=discord:bead_update_failed"],

--- a/github/tests/test_github_intake_service.py
+++ b/github/tests/test_github_intake_service.py
@@ -42,6 +42,7 @@ class GitHubIntakeServiceTests(unittest.TestCase):
         self.addCleanup(self.tempdir.cleanup)
         self._old_environ = os.environ.copy()
         os.environ["GC_CITY_ROOT"] = self.tempdir.name
+        self.gc_bin = os.environ.get("GC_BIN", "gc")
 
     def tearDown(self) -> None:
         os.environ.clear()
@@ -887,7 +888,7 @@ GITHUB_INTAKE_APP_IDENTITY = "mayor"
         self.assertEqual(
             commands[2][:8],
             [
-                "gc",
+                self.gc_bin,
                 "--city",
                 self.tempdir.name,
                 "--rig",
@@ -907,7 +908,7 @@ GITHUB_INTAKE_APP_IDENTITY = "mayor"
         self.assertEqual(commands[2][-1], "--json")
         self.assertEqual(
             commands[3][:8],
-            ["gc", "--rig", "github-owner-repo", "sling", "--json", "github-owner-repo/mayor", "ga-launch", "--force"],
+            [self.gc_bin, "--rig", "github-owner-repo", "sling", "--json", "github-owner-repo/mayor", "ga-launch", "--force"],
         )
         self.assertIn("--var", commands[3])
         sling_vars = {
@@ -920,7 +921,7 @@ GITHUB_INTAKE_APP_IDENTITY = "mayor"
         self.assertEqual(sling_vars["github_app_installation_id"], "profile-installation")
         self.assertEqual(sling_vars["github_app_identity"], "mayor")
         self.assertEqual(sling_vars["acknowledgement_requested"], "true")
-        city_prefix = ["gc", "--city", self.tempdir.name, "bd"]
+        city_prefix = [self.gc_bin, "--city", self.tempdir.name, "bd"]
         self.assertEqual(commands[1][0:6], city_prefix + ["update", "ga-src1"])
         self.assertEqual(commands[4][0:6], city_prefix + ["update", "ga-src1"])
         self.assertEqual(
@@ -983,7 +984,7 @@ GITHUB_INTAKE_APP_IDENTITY = "mayor"
         self.assertEqual(outcome["workflow_root_id"], "ga-root")
         run_subprocess.assert_called_once_with(
             [
-                "gc",
+                self.gc_bin,
                 "--city",
                 self.tempdir.name,
                 "bd",
@@ -1271,7 +1272,7 @@ GITHUB_INTAKE_APP_IDENTITY = "mayor"
         self.assertEqual(outcome["bead_id"], "bd-1")
         self.assertTrue(outcome["bead_closed"])
         commands = [call.args[0] for call in run_subprocess.call_args_list]
-        prefix = ["gc", "--city", self.tempdir.name, "--rig", "product", "bd"]
+        prefix = [self.gc_bin, "--city", self.tempdir.name, "--rig", "product", "bd"]
         self.assertEqual(
             commands[0],
             prefix + ["update", "bd-1", "--set-metadata", "close_reason=github:bead_update_failed"],
@@ -1319,8 +1320,8 @@ GITHUB_INTAKE_APP_IDENTITY = "mayor"
         self.assertEqual(outcome["bead_id"], "mc-source")
         self.assertEqual(outcome["workflow_root_id"], "ga-root")
         commands = [call.args[0] for call in run_subprocess.call_args_list]
-        self.assertEqual(commands[0], ["gc", "workflows", "bugflow", "create", "https://github.com/owner/repo/issues/42"])
-        self.assertEqual(commands[1], ["gc", "workflows", "bugflow", "router-scan"])
+        self.assertEqual(commands[0], [self.gc_bin, "workflows", "bugflow", "create", "https://github.com/owner/repo/issues/42"])
+        self.assertEqual(commands[1], [self.gc_bin, "workflows", "bugflow", "router-scan"])
         self.assertEqual(run_subprocess.call_args_list[0].kwargs["env"]["GH_TOKEN"], "token-123")
         self.assertEqual(run_subprocess.call_args_list[1].kwargs["env"]["GH_TOKEN"], "token-123")
 
@@ -1413,7 +1414,7 @@ GITHUB_INTAKE_APP_IDENTITY = "mayor"
 
         self.assertTrue(closed)
         commands = [call.args[0] for call in run_subprocess.call_args_list]
-        prefix = ["gc", "--city", self.tempdir.name, "bd"]
+        prefix = [self.gc_bin, "--city", self.tempdir.name, "bd"]
         self.assertEqual(
             commands[0],
             prefix + ["update", "bd-1", "--set-metadata", "close_reason=github:dispatch_failed"],


### PR DESCRIPTION
## Summary

Discord and GitHub intake services already resolve the CLI executable through `GC_BIN`. Update their subprocess argv expectations to use the same configured value instead of hardcoding `gc`.

This is a test-only contract correction. It does not change production dispatch, providers, configuration, or lifecycle behavior.

## Validation

- both intake service suites with the default environment: 102 passed
- both intake service suites with `GC_BIN=/opt/gc/bin/gc`: 102 passed
- `git diff --check f3826035bb7de7c34621c2fdcd8620ab5a18bb08..5a380455217c547e438feba0777db5b6f915dd16`: passed

## Immutable review provenance

- base: `f3826035bb7de7c34621c2fdcd8620ab5a18bb08`
- head: `5a380455217c547e438feba0777db5b6f915dd16`
- native Codex review: no introduced correctness issues
- local artifact: `/home/pranay/wd/gas-city/.gc/runtime/reviews/gcp-auo-pr-review-f3826035-5a380455.txt`

Tracking: `gcp-auo`
