### PR TITLE
fix(checks): read molecule members through the federating reader

### DIFF
--- a/gascity/assets/scripts/checks/design-review-approved.sh
+++ b/gascity/assets/scripts/checks/design-review-approved.sh
@@ -3,6 +3,37 @@
 
 set -euo pipefail
 
+gmol() {   # root_id -> molecule-member JSON array; nonzero if any status leg failed
+    # A metadata collection query carries no bead id for bd to route on, so on a
+    # city that relocates the graph class `gc bd list --metadata-field` refuses
+    # (exit 1) rather than answer from the wrong store -- and swallowing that
+    # refusal turned it into an empty member set, so this gate never saw its
+    # verdict and looped until ralph exhausted its attempts.
+    #
+    # `gc ready` is the federating reader: city store, rig stores and the
+    # relocated graph store, across both tiers. It takes exactly one --status
+    # and has no --all, so the member set is the union of one leg per status.
+    # The four legs are independent reads and run concurrently: a check gate has
+    # a 10m budget and each `gc ready` costs ~17s on a loaded city.
+    #
+    # A leg that fails is reported on stderr and fails the function rather than
+    # contributing an empty set -- silent starvation is the bug being fixed.
+    local root="$1" tmp st rc=0
+    tmp="$(mktemp -d)" || return 1
+    for st in open in_progress blocked closed; do
+        { gc ready --metadata-field "gc.root_bead_id=$root" --status "$st" --limit 0 --json \
+            >"$tmp/$st.json" || printf '%s\n' "$st" >>"$tmp/failed"; } &
+    done
+    wait
+    if [ -s "$tmp/failed" ]; then
+        echo "gmol: gc ready failed for status: $(tr '\n' ' ' <"$tmp/failed")" >&2
+        rc=1
+    fi
+    jq -s 'map(select(type=="array")) | add // [] | unique_by(.id)' "$tmp"/*.json || rc=1
+    rm -rf "$tmp"
+    return "$rc"
+}
+
 BEAD_ID="${GC_BEAD_ID:-}"
 if [ -z "$BEAD_ID" ]; then
     echo "ERROR: GC_BEAD_ID not set" >&2
@@ -18,7 +49,7 @@ if [ -z "$ROOT_ID" ]; then
 fi
 
 VERDICT=$(
-    gc bd list --all --metadata-field "gc.root_bead_id=$ROOT_ID" --json --limit=0 2>/dev/null |
+    gmol "$ROOT_ID" |
         jq -r --arg root "$ROOT_ID" --arg attempt "$ATTEMPT" '
             [
               .[]

--- a/gascity/assets/scripts/checks/design-review-approved.sh
+++ b/gascity/assets/scripts/checks/design-review-approved.sh
@@ -29,7 +29,11 @@ gmol() {   # root_id -> molecule-member JSON array; nonzero if any status leg fa
         echo "gmol: gc ready failed for status: $(tr '\n' ' ' <"$tmp/failed")" >&2
         rc=1
     fi
-    jq -s 'map(select(type=="array")) | add // [] | unique_by(.id)' "$tmp"/*.json || rc=1
+    # unique_by sorts by id, so the union comes back in bead-id order. The
+    # verdict extractors below take `| last`, which must mean "most recently
+    # updated" -- without this re-sort the gate picks a verdict by id hash and
+    # can sit on a stale `iterate` forever while a newer `done` is ignored.
+    jq -s 'map(select(type=="array")) | add // [] | unique_by(.id) | sort_by(.updated_at // "")' "$tmp"/*.json || rc=1
     rm -rf "$tmp"
     return "$rc"
 }

--- a/gascity/assets/scripts/checks/gap-analysis-approved.sh
+++ b/gascity/assets/scripts/checks/gap-analysis-approved.sh
@@ -27,7 +27,11 @@ gmol() {   # root_id -> molecule-member JSON array; nonzero if any status leg fa
         echo "gmol: gc ready failed for status: $(tr '\n' ' ' <"$tmp/failed")" >&2
         rc=1
     fi
-    jq -s 'map(select(type=="array")) | add // [] | unique_by(.id)' "$tmp"/*.json || rc=1
+    # unique_by sorts by id, so the union comes back in bead-id order. The
+    # verdict extractors below take `| last`, which must mean "most recently
+    # updated" -- without this re-sort the gate picks a verdict by id hash and
+    # can sit on a stale `iterate` forever while a newer `done` is ignored.
+    jq -s 'map(select(type=="array")) | add // [] | unique_by(.id) | sort_by(.updated_at // "")' "$tmp"/*.json || rc=1
     rm -rf "$tmp"
     return "$rc"
 }

--- a/gascity/assets/scripts/checks/gap-analysis-approved.sh
+++ b/gascity/assets/scripts/checks/gap-analysis-approved.sh
@@ -1,6 +1,37 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+gmol() {   # root_id -> molecule-member JSON array; nonzero if any status leg failed
+    # A metadata collection query carries no bead id for bd to route on, so on a
+    # city that relocates the graph class `gc bd list --metadata-field` refuses
+    # (exit 1) rather than answer from the wrong store -- and swallowing that
+    # refusal turned it into an empty member set, so this gate never saw its
+    # verdict and looped until ralph exhausted its attempts.
+    #
+    # `gc ready` is the federating reader: city store, rig stores and the
+    # relocated graph store, across both tiers. It takes exactly one --status
+    # and has no --all, so the member set is the union of one leg per status.
+    # The four legs are independent reads and run concurrently: a check gate has
+    # a 10m budget and each `gc ready` costs ~17s on a loaded city.
+    #
+    # A leg that fails is reported on stderr and fails the function rather than
+    # contributing an empty set -- silent starvation is the bug being fixed.
+    local root="$1" tmp st rc=0
+    tmp="$(mktemp -d)" || return 1
+    for st in open in_progress blocked closed; do
+        { gc ready --metadata-field "gc.root_bead_id=$root" --status "$st" --limit 0 --json \
+            >"$tmp/$st.json" || printf '%s\n' "$st" >>"$tmp/failed"; } &
+    done
+    wait
+    if [ -s "$tmp/failed" ]; then
+        echo "gmol: gc ready failed for status: $(tr '\n' ' ' <"$tmp/failed")" >&2
+        rc=1
+    fi
+    jq -s 'map(select(type=="array")) | add // [] | unique_by(.id)' "$tmp"/*.json || rc=1
+    rm -rf "$tmp"
+    return "$rc"
+}
+
 ROOT_ID="${GC_BEAD_ID:-}"
 ATTEMPT="${GC_ITERATION:-}"
 
@@ -28,7 +59,7 @@ if [ -z "$PARENT_ROOT" ]; then
   PARENT_ROOT="$ROOT_ID"
 fi
 
-MATCHES="$(gc bd list --all --metadata-field "gc.root_bead_id=$PARENT_ROOT" --json --limit=0 2>/dev/null || printf '[]')"
+MATCHES="$(gmol "$PARENT_ROOT")"
 
 VERDICT="$(printf '%s\n' "$MATCHES" | jq -r --arg attempt "$ATTEMPT" '
   [

--- a/gascity/assets/scripts/checks/implementation-review-approved.sh
+++ b/gascity/assets/scripts/checks/implementation-review-approved.sh
@@ -27,7 +27,11 @@ gmol() {   # root_id -> molecule-member JSON array; nonzero if any status leg fa
         echo "gmol: gc ready failed for status: $(tr '\n' ' ' <"$tmp/failed")" >&2
         rc=1
     fi
-    jq -s 'map(select(type=="array")) | add // [] | unique_by(.id)' "$tmp"/*.json || rc=1
+    # unique_by sorts by id, so the union comes back in bead-id order. The
+    # verdict extractors below take `| last`, which must mean "most recently
+    # updated" -- without this re-sort the gate picks a verdict by id hash and
+    # can sit on a stale `iterate` forever while a newer `done` is ignored.
+    jq -s 'map(select(type=="array")) | add // [] | unique_by(.id) | sort_by(.updated_at // "")' "$tmp"/*.json || rc=1
     rm -rf "$tmp"
     return "$rc"
 }

--- a/gascity/assets/scripts/checks/implementation-review-approved.sh
+++ b/gascity/assets/scripts/checks/implementation-review-approved.sh
@@ -1,6 +1,37 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+gmol() {   # root_id -> molecule-member JSON array; nonzero if any status leg failed
+    # A metadata collection query carries no bead id for bd to route on, so on a
+    # city that relocates the graph class `gc bd list --metadata-field` refuses
+    # (exit 1) rather than answer from the wrong store -- and swallowing that
+    # refusal turned it into an empty member set, so this gate never saw its
+    # verdict and looped until ralph exhausted its attempts.
+    #
+    # `gc ready` is the federating reader: city store, rig stores and the
+    # relocated graph store, across both tiers. It takes exactly one --status
+    # and has no --all, so the member set is the union of one leg per status.
+    # The four legs are independent reads and run concurrently: a check gate has
+    # a 10m budget and each `gc ready` costs ~17s on a loaded city.
+    #
+    # A leg that fails is reported on stderr and fails the function rather than
+    # contributing an empty set -- silent starvation is the bug being fixed.
+    local root="$1" tmp st rc=0
+    tmp="$(mktemp -d)" || return 1
+    for st in open in_progress blocked closed; do
+        { gc ready --metadata-field "gc.root_bead_id=$root" --status "$st" --limit 0 --json \
+            >"$tmp/$st.json" || printf '%s\n' "$st" >>"$tmp/failed"; } &
+    done
+    wait
+    if [ -s "$tmp/failed" ]; then
+        echo "gmol: gc ready failed for status: $(tr '\n' ' ' <"$tmp/failed")" >&2
+        rc=1
+    fi
+    jq -s 'map(select(type=="array")) | add // [] | unique_by(.id)' "$tmp"/*.json || rc=1
+    rm -rf "$tmp"
+    return "$rc"
+}
+
 ROOT_ID="${GC_BEAD_ID:-}"
 ATTEMPT="${GC_ITERATION:-}"
 
@@ -28,7 +59,7 @@ if [ -z "$PARENT_ROOT" ]; then
   PARENT_ROOT="$ROOT_ID"
 fi
 
-MATCHES="$(gc bd list --all --metadata-field "gc.root_bead_id=$PARENT_ROOT" --json --limit=0 2>/dev/null || printf '[]')"
+MATCHES="$(gmol "$PARENT_ROOT")"
 
 VERDICT="$(printf '%s\n' "$MATCHES" | jq -r --arg attempt "$ATTEMPT" '
   [


### PR DESCRIPTION
## Problem

All three gc-plan-pack Ralph gates resolved a molecule's members with:

```sh
gc bd list --all --metadata-field "gc.root_bead_id=$ROOT" --json --limit=0 2>/dev/null
```

A metadata **collection** query carries no bead id for bd to route on, so on a
city that relocates the graph class the query is refused (exit 1) rather than
answered from the wrong store. Every call site swallowed the refusal —
`2>/dev/null`, and in two of them an explicit `|| printf '[]'` — turning it into
an empty member set. The gate then never found its verdict and looped until
ralph exhausted its attempts.

| script | starved metadata key |
| --- | --- |
| `design-review-approved.sh` | `design_review.verdict` |
| `gap-analysis-approved.sh` | `gap_analysis.verdict` |
| `implementation-review-approved.sh` | `code_review.verdict` |

## Fix

`gc ready` is the federating reader: city store, rig stores and the relocated
graph store, across both tiers. It takes exactly one `--status` and has no
`--all`, so the member set is the union of one leg per status.

The four legs are independent reads and run **concurrently** — a check gate has
a 10m budget and each `gc ready` costs ~17s on a loaded city.

A leg that fails is now **reported on stderr and fails the helper** instead of
contributing an empty set. Silent starvation is the bug being fixed, so the
replacement must not reintroduce it.

Mirrors the same fix in the workflows pack (gastownhall/workflows `5e05dd68a`),
which covers the adopt-pr and code/design review gates.

## Verification

Against maintainer-city's relocated graph store, root `gcg-284771409692055`:

```
70 members in 17.0s     (sqlite ground truth: 70)
```

Each script then run end-to-end against a stub `gc`, **with a passing control**:

```
design-review-approved.sh         CONTROL: "Design review approved"          rc=0
                                  NEGATIVE: gmol: gc ready failed for status: closed   rc=1
gap-analysis-approved.sh          CONTROL: "Gap analysis approved"           rc=0
                                  NEGATIVE: gmol: gc ready failed for status: closed   rc=1
implementation-review-approved.sh CONTROL: "Implementation review approved"  rc=0
                                  NEGATIVE: gmol: gc ready failed for status: closed   rc=1
```

The control and the negative fail differently, so the probe distinguishes a
real refusal from a script that merely finds no verdict.

## Scope note

These three gates are **latent** on maintainer-city today — its graph store
shows no `design-review-fixes` continuation group and no
`design_review`/`gap_analysis` verdicts, only the two adopt-pr checks. This
closes the gap before the formula next runs rather than repairing a live stall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)