### PR TITLE
fix(checks): route molecule-member reads through gc ready, not a graph-blind collection query

### DIFF
--- a/gascity/assets/scripts/checks/design-review-approved.sh
+++ b/gascity/assets/scripts/checks/design-review-approved.sh
@@ -28,7 +28,11 @@ gmol() {   # root_id -> molecule-member JSON array
         echo "gmol: gc ready failed for status: $(tr '\n' ' ' <"$tmp/failed")" >&2
         rc=1
     fi
-    jq -s 'map(select(type=="array")) | add // [] | unique_by(.id)' "$tmp"/*.json || rc=1
+    # unique_by sorts by id, so the union comes back in bead-id order. The
+    # verdict extractors below take `| last`, which must mean "most recently
+    # updated" -- without this re-sort the gate picks a verdict by id hash and
+    # can sit on a stale `iterate` forever while a newer `done` is ignored.
+    jq -s 'map(select(type=="array")) | add // [] | unique_by(.id) | sort_by(.updated_at // "")' "$tmp"/*.json || rc=1
     rm -rf "$tmp"
     return "$rc"
 }

--- a/gascity/assets/scripts/checks/design-review-approved.sh
+++ b/gascity/assets/scripts/checks/design-review-approved.sh
@@ -3,6 +3,36 @@
 
 set -euo pipefail
 
+gmol() {   # root_id -> molecule-member JSON array
+    # `gc bd list --metadata-field` is a collection query carrying no bead id,
+    # so on a city that relocates the graph class bd has nothing to route on and
+    # refuses the read -- and the `2>/dev/null` below turned that refusal into an
+    # empty set, so this gate never saw design_review.verdict and looped until Ralph
+    # ran out of attempts.
+    #
+    # `gc ready` is the federating reader: city store, rig stores and the
+    # relocated graph store, across both tiers. It takes exactly one --status
+    # and has no --all, so the member set is the union of one leg per status.
+    # The four legs are independent reads, so run them concurrently: a check
+    # gate has a 10m budget and each `gc ready` costs ~17s on a loaded city.
+    # A leg that fails is reported on stderr and fails the function rather than
+    # contributing an empty set -- silent starvation is the bug being fixed.
+    local root="$1" tmp st rc=0
+    tmp="$(mktemp -d)" || return 1
+    for st in open in_progress blocked closed; do
+        { gc ready --metadata-field "gc.root_bead_id=$root" --status "$st" --limit 0 --json \
+            >"$tmp/$st.json" || printf '%s\n' "$st" >>"$tmp/failed"; } &
+    done
+    wait
+    if [ -s "$tmp/failed" ]; then
+        echo "gmol: gc ready failed for status: $(tr '\n' ' ' <"$tmp/failed")" >&2
+        rc=1
+    fi
+    jq -s 'map(select(type=="array")) | add // [] | unique_by(.id)' "$tmp"/*.json || rc=1
+    rm -rf "$tmp"
+    return "$rc"
+}
+
 BEAD_ID="${GC_BEAD_ID:-}"
 if [ -z "$BEAD_ID" ]; then
     echo "ERROR: GC_BEAD_ID not set" >&2
@@ -20,7 +50,7 @@ if [ -z "$ROOT_ID" ]; then
 fi
 
 VERDICT=$(
-    gc bd list --all --metadata-field "gc.root_bead_id=$ROOT_ID" --json --limit=0 2>/dev/null |
+    gmol "$ROOT_ID" |
         jq -r --arg root "$ROOT_ID" --arg attempt "$ATTEMPT" --arg scope "$SCOPE_REF" --arg step "$STEP_ID" '
             [
               .[]

--- a/gascity/assets/scripts/checks/gap-analysis-approved.sh
+++ b/gascity/assets/scripts/checks/gap-analysis-approved.sh
@@ -1,6 +1,36 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+gmol() {   # root_id -> molecule-member JSON array
+    # `gc bd list --metadata-field` is a collection query carrying no bead id,
+    # so on a city that relocates the graph class bd has nothing to route on and
+    # refuses the read -- and the `2>/dev/null` below turned that refusal into an
+    # empty set, so this gate never saw gap_analysis.verdict and looped until Ralph
+    # ran out of attempts.
+    #
+    # `gc ready` is the federating reader: city store, rig stores and the
+    # relocated graph store, across both tiers. It takes exactly one --status
+    # and has no --all, so the member set is the union of one leg per status.
+    # The four legs are independent reads, so run them concurrently: a check
+    # gate has a 10m budget and each `gc ready` costs ~17s on a loaded city.
+    # A leg that fails is reported on stderr and fails the function rather than
+    # contributing an empty set -- silent starvation is the bug being fixed.
+    local root="$1" tmp st rc=0
+    tmp="$(mktemp -d)" || return 1
+    for st in open in_progress blocked closed; do
+        { gc ready --metadata-field "gc.root_bead_id=$root" --status "$st" --limit 0 --json \
+            >"$tmp/$st.json" || printf '%s\n' "$st" >>"$tmp/failed"; } &
+    done
+    wait
+    if [ -s "$tmp/failed" ]; then
+        echo "gmol: gc ready failed for status: $(tr '\n' ' ' <"$tmp/failed")" >&2
+        rc=1
+    fi
+    jq -s 'map(select(type=="array")) | add // [] | unique_by(.id)' "$tmp"/*.json || rc=1
+    rm -rf "$tmp"
+    return "$rc"
+}
+
 ROOT_ID="${GC_BEAD_ID:-}"
 ATTEMPT="${GC_ITERATION:-}"
 
@@ -28,7 +58,7 @@ if [ -z "$PARENT_ROOT" ]; then
   PARENT_ROOT="$ROOT_ID"
 fi
 
-MATCHES="$(gc bd list --all --metadata-field "gc.root_bead_id=$PARENT_ROOT" --json --limit=0 2>/dev/null || printf '[]')"
+MATCHES="$(gmol "$PARENT_ROOT")"
 
 VERDICT="$(printf '%s\n' "$MATCHES" | jq -r --arg attempt "$ATTEMPT" '
   [

--- a/gascity/assets/scripts/checks/gap-analysis-approved.sh
+++ b/gascity/assets/scripts/checks/gap-analysis-approved.sh
@@ -26,7 +26,11 @@ gmol() {   # root_id -> molecule-member JSON array
         echo "gmol: gc ready failed for status: $(tr '\n' ' ' <"$tmp/failed")" >&2
         rc=1
     fi
-    jq -s 'map(select(type=="array")) | add // [] | unique_by(.id)' "$tmp"/*.json || rc=1
+    # unique_by sorts by id, so the union comes back in bead-id order. The
+    # verdict extractors below take `| last`, which must mean "most recently
+    # updated" -- without this re-sort the gate picks a verdict by id hash and
+    # can sit on a stale `iterate` forever while a newer `done` is ignored.
+    jq -s 'map(select(type=="array")) | add // [] | unique_by(.id) | sort_by(.updated_at // "")' "$tmp"/*.json || rc=1
     rm -rf "$tmp"
     return "$rc"
 }

--- a/gascity/assets/scripts/checks/implementation-review-approved.sh
+++ b/gascity/assets/scripts/checks/implementation-review-approved.sh
@@ -1,6 +1,36 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+gmol() {   # root_id -> molecule-member JSON array
+    # `gc bd list --metadata-field` is a collection query carrying no bead id,
+    # so on a city that relocates the graph class bd has nothing to route on and
+    # refuses the read -- and the `2>/dev/null` below turned that refusal into an
+    # empty set, so this gate never saw code_review.verdict and looped until Ralph
+    # ran out of attempts.
+    #
+    # `gc ready` is the federating reader: city store, rig stores and the
+    # relocated graph store, across both tiers. It takes exactly one --status
+    # and has no --all, so the member set is the union of one leg per status.
+    # The four legs are independent reads, so run them concurrently: a check
+    # gate has a 10m budget and each `gc ready` costs ~17s on a loaded city.
+    # A leg that fails is reported on stderr and fails the function rather than
+    # contributing an empty set -- silent starvation is the bug being fixed.
+    local root="$1" tmp st rc=0
+    tmp="$(mktemp -d)" || return 1
+    for st in open in_progress blocked closed; do
+        { gc ready --metadata-field "gc.root_bead_id=$root" --status "$st" --limit 0 --json \
+            >"$tmp/$st.json" || printf '%s\n' "$st" >>"$tmp/failed"; } &
+    done
+    wait
+    if [ -s "$tmp/failed" ]; then
+        echo "gmol: gc ready failed for status: $(tr '\n' ' ' <"$tmp/failed")" >&2
+        rc=1
+    fi
+    jq -s 'map(select(type=="array")) | add // [] | unique_by(.id)' "$tmp"/*.json || rc=1
+    rm -rf "$tmp"
+    return "$rc"
+}
+
 ROOT_ID="${GC_BEAD_ID:-}"
 ATTEMPT="${GC_ITERATION:-}"
 
@@ -37,7 +67,7 @@ if [ -z "$SCOPE_REF" ]; then
   SCOPE_REF="$(metadata_value "$ROOT_JSON" "gc.step_ref")"
 fi
 
-MATCHES="$(gc bd list --all --metadata-field "gc.root_bead_id=$PARENT_ROOT" --json --limit=0 2>/dev/null || printf '[]')"
+MATCHES="$(gmol "$PARENT_ROOT")"
 
 VERDICT="$(printf '%s\n' "$MATCHES" | jq -r --arg attempt "$ATTEMPT" '
   [

--- a/gascity/assets/scripts/checks/implementation-review-approved.sh
+++ b/gascity/assets/scripts/checks/implementation-review-approved.sh
@@ -26,7 +26,11 @@ gmol() {   # root_id -> molecule-member JSON array
         echo "gmol: gc ready failed for status: $(tr '\n' ' ' <"$tmp/failed")" >&2
         rc=1
     fi
-    jq -s 'map(select(type=="array")) | add // [] | unique_by(.id)' "$tmp"/*.json || rc=1
+    # unique_by sorts by id, so the union comes back in bead-id order. The
+    # verdict extractors below take `| last`, which must mean "most recently
+    # updated" -- without this re-sort the gate picks a verdict by id hash and
+    # can sit on a stale `iterate` forever while a newer `done` is ignored.
+    jq -s 'map(select(type=="array")) | add // [] | unique_by(.id) | sort_by(.updated_at // "")' "$tmp"/*.json || rc=1
     rm -rf "$tmp"
     return "$rc"
 }

--- a/gascity/tests/test_formula_assets.py
+++ b/gascity/tests/test_formula_assets.py
@@ -669,6 +669,66 @@ def assert_pack_or_role_route_target(
     test_case.assertTrue((pack_root / "agents" / local_agent / "agent.toml").is_file())
 
 
+def write_check_gc_stub(bin_dir: pathlib.Path, *, parent_show: bool = False) -> pathlib.Path:
+    """Write a fake `gc` for the check-script tests, and return its path.
+
+    The check gates enumerate molecule members with `gc ready` (one leg per
+    --status) rather than a metadata-filtered `gc bd list`, because a collection
+    query carries no bead id and is refused on a city that relocates the graph
+    class. The stub answers every `ready` leg from BD_LIST_JSON, so the union
+    the gate builds is the same member set the old single list call returned.
+
+    `ready` without --metadata-field is rejected: unscoped, it would return the
+    whole city and the gate could read a *different* molecule's verdict. Any
+    other verb exits 2, so a gate that starts shelling out to something new
+    fails here instead of silently reading an empty set.
+
+    A member carrying an explicit "status" is served only by that status's leg;
+    a member without one is served by every leg (the gate dedupes by id). That
+    lets a test place a bead in exactly one leg and prove the gate unions all
+    four — without disturbing the fixtures that don't model status at all.
+    """
+    show = (
+        "    if [ \"${2:-}\" = \"root\" ]; then\n"
+        "      cat \"$BD_PARENT_SHOW_JSON\"\n"
+        "    else\n"
+        "      cat \"$BD_SHOW_JSON\"\n"
+        "    fi\n"
+        if parent_show
+        else "    cat \"$BD_SHOW_JSON\"\n"
+    )
+    fake_gc = bin_dir / "gc"
+    fake_gc.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        "if [ \"${1:-}\" = \"ready\" ]; then\n"
+        "  case \" $* \" in\n"
+        "    *\" --metadata-field \"*) : ;;\n"
+        "    *) echo \"stub: gc ready without --metadata-field\" >&2; exit 2 ;;\n"
+        "  esac\n"
+        "  st=\"\"\n"
+        "  while [ \"$#\" -gt 0 ]; do\n"
+        "    if [ \"$1\" = \"--status\" ]; then st=\"${2:-}\"; break; fi\n"
+        "    shift\n"
+        "  done\n"
+        "  if [ -z \"$st\" ]; then echo \"stub: gc ready without --status\" >&2; exit 2; fi\n"
+        "  jq --arg st \"$st\" 'map(select((.status // $st) == $st))' \"$BD_LIST_JSON\"\n"
+        "  exit 0\n"
+        "fi\n"
+        "while [ \"${1:-}\" != \"bd\" ]; do shift; done\n"
+        "shift\n"
+        "case \"$1\" in\n"
+        "  version) exit 0 ;;\n"
+        "  show)\n" + show + "    ;;\n"
+        "  list) cat \"$BD_LIST_JSON\" ;;\n"
+        "  *) exit 2 ;;\n"
+        "esac\n",
+        encoding="utf-8",
+    )
+    fake_gc.chmod(0o755)
+    return fake_gc
+
+
 class FormulaAssetTests(unittest.TestCase):
     def test_expected_formula_set_is_convoy_first(self) -> None:
         root = pathlib.Path(__file__).resolve().parents[1]
@@ -4098,27 +4158,7 @@ description = "Override sink that writes the base triage report contract."
             show_path.write_text(show_json, encoding="utf-8")
             parent_show_path.write_text(parent_show_json or show_json, encoding="utf-8")
             list_path.write_text(list_json, encoding="utf-8")
-            fake_gc = bin_dir / "gc"
-            fake_gc.write_text(
-                "#!/usr/bin/env bash\n"
-                "set -euo pipefail\n"
-                "while [ \"${1:-}\" != \"bd\" ]; do shift; done\n"
-                "shift\n"
-                "case \"$1\" in\n"
-                "  version) exit 0 ;;\n"
-                "  show)\n"
-                "    if [ \"${2:-}\" = \"root\" ]; then\n"
-                "      cat \"$BD_PARENT_SHOW_JSON\"\n"
-                "    else\n"
-                "      cat \"$BD_SHOW_JSON\"\n"
-                "    fi\n"
-                "    ;;\n"
-                "  list) cat \"$BD_LIST_JSON\" ;;\n"
-                "  *) exit 2 ;;\n"
-                "esac\n",
-                encoding="utf-8",
-            )
-            fake_gc.chmod(0o755)
+            write_check_gc_stub(bin_dir, parent_show=True)
 
             env = {
                 **os.environ,
@@ -4564,6 +4604,65 @@ description = "Override sink that writes the base triage report contract."
         self.assertIn("code_review.verdict=iterate", apply_text)
         self.assertIn("code_review.report_path=<fix summary path>", apply_text)
 
+    def test_design_review_check_unions_every_status_leg(self) -> None:
+        """The verdict usually lands on a bead the review just closed.
+
+        `gc ready` takes exactly one --status, so the gate queries open,
+        in_progress, blocked and closed and unions the results. Drop any leg and
+        a verdict parked in that state disappears — which is the original bug:
+        the gate reports a member set it could not actually read, and Ralph
+        iterates until it runs out of attempts. Pin the closed leg specifically,
+        because that is where an approval comes to rest.
+        """
+        root = pathlib.Path(__file__).resolve().parents[1]
+        script = root / "assets" / "scripts" / "checks" / "design-review-approved.sh"
+
+        with tempfile.TemporaryDirectory() as td:
+            tmp = pathlib.Path(td)
+            bin_dir = tmp / "bin"
+            bin_dir.mkdir()
+            write_check_gc_stub(bin_dir)
+
+            show_json = tmp / "show.json"
+            list_json = tmp / "list.json"
+            show_json.write_text(
+                json.dumps(
+                    [{"id": "loop", "metadata": {"gc.root_bead_id": "root", "gc.attempt": "1"}}]
+                ),
+                encoding="utf-8",
+            )
+            list_json.write_text(
+                json.dumps(
+                    [
+                        {
+                            "id": "approved-and-closed",
+                            "status": "closed",
+                            "metadata": {
+                                "gc.root_bead_id": "root",
+                                "gc.attempt": "1",
+                                "gc.continuation_group": "design-review-fixes",
+                                "design_review.verdict": "done",
+                            },
+                        }
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            env = {
+                **os.environ,
+                "PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}",
+                "BD_SHOW_JSON": str(show_json),
+                "BD_LIST_JSON": str(list_json),
+                "GC_BEAD_ID": "loop",
+            }
+            result = subprocess.run(
+                [str(script)], env=env, text=True, capture_output=True, check=False
+            )
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("Design review approved", result.stdout)
+
     def test_design_review_check_scopes_verdict_to_current_loop(self) -> None:
         root = pathlib.Path(__file__).resolve().parents[1]
         script = root / "assets" / "scripts" / "checks" / "design-review-approved.sh"
@@ -4572,21 +4671,7 @@ description = "Override sink that writes the base triage report contract."
             tmp = pathlib.Path(td)
             bin_dir = tmp / "bin"
             bin_dir.mkdir()
-            fake_gc = bin_dir / "gc"
-            fake_gc.write_text(
-                "#!/usr/bin/env bash\n"
-                "set -euo pipefail\n"
-                "while [ \"${1:-}\" != \"bd\" ]; do shift; done\n"
-                "shift\n"
-                "case \"$1\" in\n"
-                "  version) exit 0 ;;\n"
-                "  show) cat \"$BD_SHOW_JSON\" ;;\n"
-                "  list) cat \"$BD_LIST_JSON\" ;;\n"
-                "  *) exit 2 ;;\n"
-                "esac\n",
-                encoding="utf-8",
-            )
-            fake_gc.chmod(0o755)
+            write_check_gc_stub(bin_dir)
 
             show_json = tmp / "show.json"
             list_json = tmp / "list.json"
@@ -4655,21 +4740,7 @@ description = "Override sink that writes the base triage report contract."
             tmp = pathlib.Path(td)
             bin_dir = tmp / "bin"
             bin_dir.mkdir()
-            fake_gc = bin_dir / "gc"
-            fake_gc.write_text(
-                "#!/usr/bin/env bash\n"
-                "set -euo pipefail\n"
-                "while [ \"${1:-}\" != \"bd\" ]; do shift; done\n"
-                "shift\n"
-                "case \"$1\" in\n"
-                "  version) exit 0 ;;\n"
-                "  show) cat \"$BD_SHOW_JSON\" ;;\n"
-                "  list) cat \"$BD_LIST_JSON\" ;;\n"
-                "  *) exit 2 ;;\n"
-                "esac\n",
-                encoding="utf-8",
-            )
-            fake_gc.chmod(0o755)
+            write_check_gc_stub(bin_dir)
 
             show_json = tmp / "show.json"
             list_json = tmp / "list.json"
@@ -4751,21 +4822,7 @@ description = "Override sink that writes the base triage report contract."
             tmp = pathlib.Path(td)
             bin_dir = tmp / "bin"
             bin_dir.mkdir()
-            fake_gc = bin_dir / "gc"
-            fake_gc.write_text(
-                "#!/usr/bin/env bash\n"
-                "set -euo pipefail\n"
-                "while [ \"${1:-}\" != \"bd\" ]; do shift; done\n"
-                "shift\n"
-                "case \"$1\" in\n"
-                "  version) exit 0 ;;\n"
-                "  show) cat \"$BD_SHOW_JSON\" ;;\n"
-                "  list) cat \"$BD_LIST_JSON\" ;;\n"
-                "  *) exit 2 ;;\n"
-                "esac\n",
-                encoding="utf-8",
-            )
-            fake_gc.chmod(0o755)
+            write_check_gc_stub(bin_dir)
 
             show_json = tmp / "show.json"
             list_json = tmp / "list.json"

--- a/gascity/tests/test_formula_assets.py
+++ b/gascity/tests/test_formula_assets.py
@@ -4604,6 +4604,44 @@ description = "Override sink that writes the base triage report contract."
         self.assertIn("code_review.verdict=iterate", apply_text)
         self.assertIn("code_review.report_path=<fix summary path>", apply_text)
 
+    def test_implementation_review_check_takes_newest_verdict_not_highest_id(self) -> None:
+        """`| last` in the verdict extractors has to mean newest, not highest id.
+
+        gmol dedupes the four status legs with `unique_by(.id)`, and jq's
+        unique_by sorts — so without a re-sort the union arrives in bead-id
+        order and this gate's `| last` picks a verdict by id hash. Here the
+        stale `iterate` sorts after the newer `done`, so an already-approved
+        review would loop until Ralph ran out of attempts: the exact symptom
+        the federating-reader fix was written to end, re-entering by ordering
+        rather than by starvation.
+        """
+        show_json = json.dumps(
+            [{"id": "loop", "metadata": {"gc.root_bead_id": "root", "gc.attempt": "1"}}]
+        )
+
+        def member(bead_id: str, updated: str, verdict: str) -> dict:
+            return {
+                "id": bead_id,
+                "updated_at": updated,
+                "metadata": {
+                    "gc.root_bead_id": "root",
+                    "gc.attempt": "1",
+                    "code_review.verdict": verdict,
+                    "code_review.report_path": f"/reports/{bead_id}.md",
+                },
+            }
+
+        # "gcg-zzz" sorts last by id but carries the OLDER verdict.
+        list_json = json.dumps(
+            [
+                member("gcg-aaa", "2026-08-13T03:00:00Z", "done"),
+                member("gcg-zzz", "2026-08-13T01:00:00Z", "iterate"),
+            ]
+        )
+        result = self._run_implementation_review_check(show_json=show_json, list_json=list_json)
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
     def test_design_review_check_unions_every_status_leg(self) -> None:
         """The verdict usually lands on a bead the review just closed.
 


### PR DESCRIPTION
## The bug

The three `gascity` review gates found their molecule members with a metadata collection query:

```sh
gc bd list --all --metadata-field "gc.root_bead_id=$ROOT" --json --limit=0 2>/dev/null
```

A metadata collection query carries **no bead id**, so on a city that relocates the graph class `bd` has nothing to route on and **refuses the read (exit 1)** rather than answering from the wrong store. Two of the three call sites also carried an explicit `|| printf '[]'`, and all three carried `2>/dev/null` — so the refusal became an **empty member set**, not an error.

The gate then never saw its verdict key and returned `iterate`, which is indistinguishable from a review that genuinely hadn't finished. The loop ran until Ralph exhausted its attempts.

| script | starved key |
|---|---|
| `design-review-approved.sh` | `design_review.verdict` |
| `gap-analysis-approved.sh` | `gap_analysis.verdict` |
| `implementation-review-approved.sh` | `code_review.verdict` |

## The fix

`gc ready` is the federating reader — city store, rig stores, and the relocated graph store, across both tiers. It takes exactly one `--status` and has no `--all`, so the member set is the union of one leg per status.

The four legs run **concurrently**. A check gate has a 10m budget and one `gc ready` costs ~17s on a loaded city; four sequential legs (~67s) inside a five-iteration poll loop would come uncomfortably close to that budget.

A leg that fails **names itself on stderr and fails the helper**, which propagates under `set -euo pipefail` to a nonzero script exit — the gate iterates instead of silently approving or silently starving. Silent starvation is the defect being fixed; the replacement must not reintroduce it.

## Verification

**Live**, against maintainer-city's relocated graph store (root `gcg-284771409692055`):

- **70 members**, all 70 carrying `gc.step_id`
- sqlite ground truth: **70** — exact match
- **17.27s** (vs ~67s for the sequential form)

**Control + negative**, with a stub `gc` on `PATH`:

| case | rc | members | stderr |
|---|---|---|---|
| control — all legs OK | 0 | 4 | *(none)* |
| negative — `closed` leg refuses | 1 | 3 | `gmol: gc ready failed for status: closed` |

Under `set -euo pipefail` the negative **propagates**: the caller aborts rather than continuing on the short set.

## Scope

Same fix already landed for the workflows-pack gates (`adopt-pr-ci-ready`, `adopt-pr-review-approved`, `code-review-approved`, `design-review-approved`) and for the gc-plan-pack copies (#309).

These three gates are **latent on maintainer-city today** — its graph store has no `design-review-fixes` continuation group and no `design_review`/`gap_analysis` verdict keys — so this closes the gap before the formula next runs rather than repairing a live stall.

The same three scripts also exist, still unfixed, in the detached-HEAD `build-methodology-packs` worktree (`f77fab4`), consumed by `paxel-city`, `paxel-city-cherry`, `maintainer-city-cherry` and `gc-methodology-smoke-city`. None of those cities is currently running; that worktree needs a rebase onto this fix.