### PR TITLE
fix(slack): reconcile binding and verify delivery

### DIFF
--- a/slack-full/README.md
+++ b/slack-full/README.md
@@ -57,7 +57,9 @@ for the full rationale.
 Implemented:
 
 - [x] `gc slack bind-dm` — bind a Slack DM channel to one named session
-- [x] `gc slack bind-room` — bind a room to multiple sessions; flags
+- [x] `gc slack bind-room` — bind a room to multiple sessions; requires
+      exactly one of `--binding-owner SESSION` / `--group-only` to
+      declare the room's binding shape; further flags
       `--enable-peer-fanout`, `--allow-untargeted-publication`,
       `--max-peer-triggered-publishes`, `--max-total-peer-deliveries`,
       `--default-handle`, `--handle HANDLE=SESSION` (creates a
@@ -295,13 +297,25 @@ reminder to the other bound sessions so they see what their peer just
 said.
 
 `--binding-owner SESSION` is what makes outbound publishes (and
-therefore `gc slack reply-current --via gc`) actually work. Without
-it, peer fanout still fires on inbound, but `/extmsg/outbound` has
-no `SessionBindingRecord` to resolve the conversation through and the
-publish is rejected. The owner must be one of the participants —
-prefer the session that "owns" the room from gc's perspective. Pass
-the gc session id (e.g. `gc-77139`) when alias resolution semantics
-matter; for stable named sessions, the alias works too.
+therefore `gc slack reply-current --via gc`) actually work: without a
+direct binding, `/extmsg/outbound` has no `SessionBindingRecord` to
+resolve the conversation through and the publish is rejected, even
+though peer fanout still fires on inbound. The owner must be one of
+the participants — prefer the session that "owns" the room from gc's
+perspective. Pass the gc session id (e.g. `gc-77139`) when alias
+resolution semantics matter; for stable named sessions, the alias
+works too.
+
+Every run must declare which of the two shapes it wants: pass
+`--binding-owner SESSION` for a room with an outbound publisher, or
+`--group-only` for a purely group-routed room. `--group-only` removes
+*every* active direct binding for the conversation — including ones
+created by other tooling — so that none can shadow the group route,
+and it prints each removed binding to stderr. Because that removal is
+destructive, it is never the default: a run with neither flag is
+rejected before any API call rather than quietly sweeping the room's
+publisher. Re-running `bind-room` on an owned room therefore has to
+name the owner again.
 
 ## Adapter as a proxy_process service
 

--- a/slack-full/adapter/SETUP.md
+++ b/slack-full/adapter/SETUP.md
@@ -70,9 +70,19 @@ curl -s https://<your-tailnet>.ts.net/healthz
    **OAuth & Permissions** →
    - Bot Token Scopes — add:
      - `chat:write` (post messages)
-     - `im:history` (read DM history for inbound replies)
+     - `im:history` (read DM history for inbound replies **and** to verify
+       outbound ones — see below)
      - `im:read` (open DM channel)
      - `users:read` (resolve display names — optional but useful)
+
+     A history scope is required for every conversation kind you bind, not
+     just DMs: `/publish` confirms each post by reading it back, so a token
+     without history for a bound channel reports every publish as
+     `Delivered:false` / `readback_auth` even though the message is visible in
+     Slack. Add `channels:history` (public channels), `groups:history`
+     (private channels) and `mpim:history` (group DMs) when you bind rooms.
+     `slack-full/schema/apps.schema.json` is the authoritative list for
+     manifest-driven installs.
    - Click **Install to Workspace** at the top, approve.
    - Copy the **Bot User OAuth Token** (`xoxb-...`) — you need it.
 

--- a/slack-full/adapter/main.go
+++ b/slack-full/adapter/main.go
@@ -21,8 +21,18 @@
 //
 //   - SLACK_WORKSPACE_ID      Slack team id (e.g. T01234567).
 //   - SLACK_BOT_TOKEN         xoxb- bot token. Must have chat:write,
-//     reactions:write, files:write, and (for
-//     identity overrides) chat:write.customize.
+//     reactions:write, files:write, (for identity
+//     overrides) chat:write.customize, and the
+//     history scopes for the conversation kinds in
+//     use — channels:history, groups:history,
+//     im:history, mpim:history. schema/apps.schema.json
+//     is the authoritative list and already requires
+//     them, so manifest-driven installs are covered;
+//     this line is what a hand-provisioned token is
+//     built from. History is not optional: /publish
+//     confirms every post by reading it back, so a
+//     token without it reports every delivery as
+//     failed (failure_kind "auth").
 //   - GC_CITY_NAME            Name of the gc city the adapter posts to
 //     (matches [workspace].name in city.toml). Used
 //     to construct /v0/city/{name}/extmsg/inbound and
@@ -895,7 +905,8 @@ type slackPostMessageResp struct {
 //
 // The bot token requires the `files:write` scope. Without it, step 1 returns
 // {ok: false, error: "missing_scope"} and the failure propagates as
-// FailureKind="permanent" with the auth error logged.
+// FailureKind="auth" with the auth error logged — both upload steps classify
+// through mapSlackError, which maps missing_scope onto gc's `auth` kind.
 
 type slackGetUploadURLResp struct {
 	OK        bool   `json:"ok"`
@@ -1468,13 +1479,13 @@ func registerAdapter(cfg config) error {
 // minutes later is not silently swallowed.
 const publishDedupTTL = 2 * time.Minute
 
-// publishDedupCache remembers delivered publish receipts keyed by the
-// caller-supplied idempotency key, so a retry after a delivered-but-
-// timed-out POST returns the original receipt instead of posting a second
-// Slack message (gpk-lbhl). Only delivered receipts are cached: a retry
-// after a genuine (non-delivered) failure must still re-attempt delivery,
-// so failures are never remembered. An empty idempotency key disables
-// dedup for that call.
+// publishDedupCache remembers publish receipts keyed by the caller-supplied
+// idempotency key, so a retry after a delivered-but-timed-out POST returns the
+// original receipt instead of posting a second Slack message (gpk-lbhl). A
+// retry after a genuine failure must still re-attempt delivery, so failures are
+// never remembered — see publishReceiptBlocksRepost for where the line falls
+// now that a write Slack accepted can still fail its readback. An empty
+// idempotency key disables dedup for that call.
 type publishDedupCache struct {
 	mu      sync.Mutex
 	entries map[string]publishDedupEntry
@@ -1513,11 +1524,35 @@ func (c *publishDedupCache) Get(key string) (publishReceipt, bool) {
 	return e.receipt, true
 }
 
-// Put records a delivered receipt under key and sweeps expired entries so
-// the map stays bounded under churn. Empty keys and non-delivered receipts
-// are ignored.
+// publishReceiptBlocksRepost reports whether a retry on the same idempotency
+// key must be answered from this receipt instead of posting again.
+//
+// A delivered receipt replays outright. The harder case is a write Slack
+// accepted — ok:true with a real ts — whose readback then failed. If the read
+// leg itself was unavailable, or the token cannot read history at all, nothing
+// is known about the message except that Slack took it, so re-posting would
+// duplicate a message that is very probably in the channel. Those receipts are
+// remembered and re-verified (replayPublishReceipt) rather than replayed as-is.
+//
+// readback_unconfirmed stays strict and is never remembered: there the read
+// path answered and the message was not in the channel, so the key must be
+// free to post again.
+func publishReceiptBlocksRepost(receipt publishReceipt) bool {
+	if receipt.Delivered {
+		return true
+	}
+	switch receipt.Metadata[receiptMetadataKeyReadback] {
+	case slackReadbackUnavailable, slackReadbackAuth:
+		return receipt.MessageID != ""
+	}
+	return false
+}
+
+// Put records a receipt a retry must not re-post (publishReceiptBlocksRepost)
+// under key and sweeps expired entries so the map stays bounded under churn.
+// Empty keys and receipts that leave the key free to post again are ignored.
 func (c *publishDedupCache) Put(key string, receipt publishReceipt) {
-	if key == "" || !receipt.Delivered {
+	if key == "" || !publishReceiptBlocksRepost(receipt) {
 		return
 	}
 	c.mu.Lock()
@@ -1529,6 +1564,18 @@ func (c *publishDedupCache) Put(key string, receipt publishReceipt) {
 			delete(c.entries, k)
 		}
 	}
+}
+
+// Delete forgets key. It is how a remembered posted-but-unconfirmed receipt is
+// released once a later readback proves the message is not in the channel: the
+// key has to be free to post again at that point.
+func (c *publishDedupCache) Delete(key string) {
+	if key == "" {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.entries, key)
 }
 
 // referenceSuffix derives the low-visibility marker embedded in outbound
@@ -1693,9 +1740,11 @@ func handlePublish(cfg config, reg *identityRegistry, userAliases *userAliasMap,
 		// and a test asserting it would have to hand-build a map the loader
 		// cannot produce, which would pin an unreachable state rather than a
 		// behavior.
+		stampedMarker := ""
 		if req.IdempotencyKey != "" && rewrittenText != "" {
 			if len(rewrittenText)+referenceMarkerOverhead <= slackMaxMessageLength {
-				post.Text += "\n\n" + referenceMarker(req.IdempotencyKey)
+				stampedMarker = referenceMarker(req.IdempotencyKey)
+				post.Text += "\n\n" + stampedMarker
 			} else {
 				// rewritten=, not text=: this is the post-rewrite length the
 				// budget was measured against, while the main publish log
@@ -1726,13 +1775,24 @@ func handlePublish(cfg config, reg *identityRegistry, userAliases *userAliasMap,
 			req.Conversation.ConversationID, len(req.Text), len(post.Text), req.ReplyToMessageID,
 			req.IdempotencyKey, identitySessionID, identityApplied, rewrittenText != req.Text)
 
-		// Idempotent replay: if this idempotency key already produced a
-		// delivered receipt, return it without re-posting. This is the
-		// chokepoint that absorbs a retry after a delivered-but-timed-out
-		// POST (gpk-lbhl) — the original Slack message stands, no duplicate.
-		if cached, ok := dedup.Get(req.IdempotencyKey); ok {
-			log.Printf("publish: dedup hit idem=%s conv=%s -> returning cached receipt (no re-post)",
-				req.IdempotencyKey, req.Conversation.ConversationID)
+		// The readback's subject: this conversation, the text actually posted,
+		// and the marker if one was stamped. messageTS is filled in once Slack
+		// answers with a ts (or, on the replay path, from the remembered
+		// receipt).
+		target := slackReadbackTarget{
+			channel:      req.Conversation.ConversationID,
+			threadTS:     req.ReplyToMessageID,
+			expectedText: post.Text,
+			marker:       stampedMarker,
+		}
+
+		// Idempotent replay: if this idempotency key already produced a receipt
+		// that must not be re-posted, answer from it. This is the chokepoint
+		// that absorbs a retry after a delivered-but-timed-out POST (gpk-lbhl)
+		// — the original Slack message stands, no duplicate.
+		if cached, ok := replayPublishReceipt(cfg.slackBotToken, dedup, req.IdempotencyKey, target); ok {
+			log.Printf("publish: dedup hit idem=%s conv=%s delivered=%t -> returning cached receipt (no re-post)",
+				req.IdempotencyKey, req.Conversation.ConversationID, cached.Delivered)
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(cached)
 			return
@@ -1785,28 +1845,21 @@ func handlePublish(cfg config, reg *identityRegistry, userAliases *userAliasMap,
 			// The truncation warning is recorded before the readback so the
 			// wire fact survives either outcome: it is what Slack reported
 			// about this write, while Delivered below is what the read API can
-			// confirm. Truncation also fails the readback's exact-text compare,
-			// so a truncated keyed publish now reports Delivered:false with
-			// FailureKind "readback_unconfirmed" *and* metadata["truncated"] —
-			// strictly more than either half could say alone.
-			if err := readBackPublishedMessage(
-				slackReadbackHTTPClient,
-				cfg.slackBotToken,
-				req.Conversation.ConversationID,
-				slackResp.TS,
-				req.ReplyToMessageID,
-				post.Text,
-			); err != nil {
-				log.Printf("slack readback failed: %v", err)
-				receipt.Delivered = false
-				receipt.FailureKind = slackReadbackFailureKind(err)
-			} else {
-				receipt.Delivered = true
-			}
+			// confirm. Truncation also fails the readback, so a truncated
+			// publish now reports Delivered:false with FailureKind "permanent"
+			// (metadata["readback"]="readback_unconfirmed") *and*
+			// metadata["truncated"] — strictly more than either half could say
+			// alone. Permanent is the honest kind there: the same oversized
+			// payload truncates identically on every retry, so re-sending it
+			// can only add another visible partial message.
+			target.messageTS = slackResp.TS
+			confirmPublishReceipt(cfg.slackBotToken, &receipt, target)
 		}
-		// Remember delivered receipts so a subsequent retry with the same
-		// idempotency key replays this receipt instead of re-posting. Put
-		// ignores empty keys and non-delivered receipts.
+		// Remember any receipt a retry must not re-post — delivered, or posted
+		// with the read leg unavailable — so a subsequent retry with the same
+		// idempotency key replays it. Put ignores empty keys and the receipts
+		// that carry no evidence Slack took the message
+		// (publishReceiptBlocksRepost).
 		dedup.Put(req.IdempotencyKey, receipt)
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(receipt)
@@ -1818,13 +1871,23 @@ func handlePublish(cfg config, reg *identityRegistry, userAliases *userAliasMap,
 // req.Conversation.ConversationID, optionally threaded under
 // req.ReplyToMessageID. The bot token requires the `files:write` scope —
 // without it, Slack returns {ok: false, error: "missing_scope"} and the
-// receipt's FailureKind is "permanent".
+// receipt's FailureKind is "auth" (mapSlackError classifies missing_scope as
+// auth, so a consumer branching retry policy on this doc must read `auth`).
 //
 // Slack's files.completeUploadExternal does NOT accept chat:write.customize
 // username/icon overrides, so file posts appear under the default bot
 // identity even when an identity record is registered for the source
 // session. This is a Slack platform limitation, not an adapter bug.
 // The identity lookup still happens for log parity with /publish.
+//
+// Delivery evidence here is weaker than /publish's, deliberately and for now:
+// /publish reads its message back and only then sets Delivered (see
+// confirmPublishReceipt), while this path still reports Delivered on Slack's
+// accepted write. The two emit the same receipt schema, so a consumer cannot
+// tell verified delivery from accepted delivery by the receipt alone — treat a
+// delivered /publish-file receipt as "Slack accepted the upload". Closing the
+// gap means reading back the completed post's ts the same way; it is not done
+// here because this change is scoped to the /publish contract.
 func handlePublishFile(cfg config, reg *identityRegistry) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
@@ -2314,8 +2377,18 @@ func postReactionMethod(client *http.Client, token, method string, req slackReac
 	return &sr, nil
 }
 
+// slackPostTimeout bounds the write leg. /publish now spends its budget on a
+// write and then a read, and gc gives the adapter 30s for the whole call, so an
+// untimed post client could burn the entire budget and leave gc to time out
+// after Slack had already accepted the message — the shape that produces a
+// duplicate on the caller's retry. See slackReadbackTiming for the arithmetic
+// the two legs share.
+const slackPostTimeout = 10 * time.Second
+
+var slackPostHTTPClient = &http.Client{Timeout: slackPostTimeout}
+
 func postToSlack(token string, req slackPostMessageReq) (*slackPostMessageResp, error) {
-	return postMessageWithClient(http.DefaultClient, token, req)
+	return postMessageWithClient(slackPostHTTPClient, token, req)
 }
 
 // postMessageWithClient is the single Slack chat.postMessage path, parameterized

--- a/slack-full/adapter/main.go
+++ b/slack-full/adapter/main.go
@@ -1759,7 +1759,6 @@ func handlePublish(cfg config, reg *identityRegistry, userAliases *userAliasMap,
 				receipt.FailureKind = "permanent"
 			}
 		default:
-			receipt.Delivered = true
 			receipt.MessageID = slackResp.TS
 			// A delivered-but-truncated message is still ok:true with a real
 			// message_id, so none of the receipt's named fields can show it. On
@@ -1782,6 +1781,27 @@ func handlePublish(cfg config, reg *identityRegistry, userAliases *userAliasMap,
 					receipt.Metadata = map[string]string{}
 				}
 				receipt.Metadata["truncated"] = "true"
+			}
+			// The truncation warning is recorded before the readback so the
+			// wire fact survives either outcome: it is what Slack reported
+			// about this write, while Delivered below is what the read API can
+			// confirm. Truncation also fails the readback's exact-text compare,
+			// so a truncated keyed publish now reports Delivered:false with
+			// FailureKind "readback_unconfirmed" *and* metadata["truncated"] —
+			// strictly more than either half could say alone.
+			if err := readBackPublishedMessage(
+				slackReadbackHTTPClient,
+				cfg.slackBotToken,
+				req.Conversation.ConversationID,
+				slackResp.TS,
+				req.ReplyToMessageID,
+				post.Text,
+			); err != nil {
+				log.Printf("slack readback failed: %v", err)
+				receipt.Delivered = false
+				receipt.FailureKind = slackReadbackFailureKind(err)
+			} else {
+				receipt.Delivered = true
 			}
 		}
 		// Remember delivered receipts so a subsequent retry with the same

--- a/slack-full/adapter/main_test.go
+++ b/slack-full/adapter/main_test.go
@@ -783,16 +783,14 @@ func TestHandlePublishDedupesOnIdempotencyKey(t *testing.T) {
 	origBase := slackAPIBase
 	t.Cleanup(func() { slackAPIBase = origBase })
 	var posts int
+	var captured slackPostMessageReq
 	ts := "1700000000.000100"
-	fakeSlack := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		if r.URL.Path == "/conversations.history" {
-			_, _ = w.Write([]byte(`{"ok":true,"messages":[{"ts":"` + ts + `","text":"hello"}]}`))
-			return
-		}
-		posts++
-		_, _ = w.Write([]byte(`{"ok":true,"channel":"C1","ts":"` + ts + `"}`))
-	}))
+	// The readback has to echo the text actually posted, not the request text:
+	// a keyed publish is stamped with the reference marker, so a fake that
+	// confirmed "hello" would report a content mismatch, leave the receipt
+	// undelivered, and take the dedup cache — which only stores delivered
+	// receipts — out of the picture entirely.
+	fakeSlack := httptest.NewServer(newFakeSlackPublishHandler(t, &captured, ts, func() { posts++ }))
 	t.Cleanup(fakeSlack.Close)
 	slackAPIBase = fakeSlack.URL
 
@@ -941,13 +939,7 @@ func TestHandlePublishAppendsReferenceMarkerWhenIdempotencyKeySet(t *testing.T) 
 	origBase := slackAPIBase
 	t.Cleanup(func() { slackAPIBase = origBase })
 	var captured slackPostMessageReq
-	fakeSlack := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
-			t.Errorf("decode Slack request: %v", err)
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"ok":true,"ts":"1.2"}`))
-	}))
+	fakeSlack := httptest.NewServer(newFakeSlackPublishHandler(t, &captured, "1.2", nil))
 	t.Cleanup(fakeSlack.Close)
 	slackAPIBase = fakeSlack.URL
 
@@ -975,13 +967,7 @@ func TestHandlePublishOmitsReferenceMarkerWhenNoIdempotencyKey(t *testing.T) {
 	origBase := slackAPIBase
 	t.Cleanup(func() { slackAPIBase = origBase })
 	var captured slackPostMessageReq
-	fakeSlack := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
-			t.Errorf("decode Slack request: %v", err)
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"ok":true,"ts":"1.2"}`))
-	}))
+	fakeSlack := httptest.NewServer(newFakeSlackPublishHandler(t, &captured, "1.2", nil))
 	t.Cleanup(fakeSlack.Close)
 	slackAPIBase = fakeSlack.URL
 
@@ -1130,13 +1116,7 @@ func TestHandlePublishSkipsReferenceMarkerWhenItCannotFitUnderSlackCeiling(t *te
 			origBase := slackAPIBase
 			t.Cleanup(func() { slackAPIBase = origBase })
 			var captured slackPostMessageReq
-			fakeSlack := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
-					t.Errorf("decode Slack request: %v", err)
-				}
-				w.Header().Set("Content-Type", "application/json")
-				_, _ = w.Write([]byte(`{"ok":true,"ts":"1.2"}`))
-			}))
+			fakeSlack := httptest.NewServer(newFakeSlackPublishHandler(t, &captured, "1.2", nil))
 			t.Cleanup(fakeSlack.Close)
 			slackAPIBase = fakeSlack.URL
 
@@ -1229,6 +1209,18 @@ func TestHandlePublishSurfacesSlackTruncationOnTheReceipt(t *testing.T) {
 	t.Cleanup(func() { slackAPIBase = origBase })
 	fakeSlack := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/conversations.history" {
+			// What a truncated message actually reads back as: the head of the
+			// post, with the tail Slack cut off — here the whole marker. A fake
+			// that echoed the full posted text would confirm a message Slack
+			// says it did not store intact, and the readback assertion below
+			// would be measuring nothing.
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"ok":       true,
+				"messages": []map[string]string{{"ts": "1.2", "text": "hi"}},
+			})
+			return
+		}
 		// Slack's delivered-but-truncated shape: ok, a real ts, and the
 		// warning as the only signal that the tail is gone.
 		_, _ = w.Write([]byte(`{"ok":true,"ts":"1.2","response_metadata":{"warnings":["message_truncated"]}}`))
@@ -1249,9 +1241,28 @@ func TestHandlePublishSurfacesSlackTruncationOnTheReceipt(t *testing.T) {
 	if err := json.Unmarshal(rec.Body.Bytes(), &receipt); err != nil {
 		t.Fatalf("decode receipt through gc's shim: %v (body=%q)", err, rec.Body.String())
 	}
-	if !receipt.Delivered || receipt.MessageID != "1.2" {
-		t.Fatalf("receipt delivered=%t message_id=%q, want a delivered receipt with ts 1.2: truncation does not fail the publish",
-			receipt.Delivered, receipt.MessageID)
+	if receipt.MessageID != "1.2" {
+		t.Fatalf("receipt message_id = %q, want 1.2: Slack accepted the post and the ts is real whatever the readback then finds",
+			receipt.MessageID)
+	}
+	// Truncation used to leave Delivered true, because chat.postMessage's own
+	// answer was the only evidence. The readback is now the evidence, and a
+	// truncated message reads back as different text, so the delivery is
+	// reported unconfirmed. The two signals are complementary and both must
+	// survive: "truncated" says what Slack did to the write, Delivered says
+	// what the read API could confirm afterwards.
+	//
+	// "permanent" is the kind on the wire because that is gc's word for it: the
+	// same oversized payload truncates identically on every retry, so re-sending
+	// can only add another visible partial message. The adapter's finer-grained
+	// classification rides in metadata, which is the only additive channel gc
+	// forwards.
+	if receipt.Delivered || receipt.FailureKind != "permanent" {
+		t.Fatalf("receipt delivered=%t failure_kind=%q, want a permanent failure: the readback cannot find the text that was posted once Slack truncates it, and re-posting it truncates the same way",
+			receipt.Delivered, receipt.FailureKind)
+	}
+	if got := receipt.Metadata[receiptMetadataKeyReadback]; got != slackReadbackUnconfirmed {
+		t.Errorf("receipt metadata[%q] = %q, want %q", receiptMetadataKeyReadback, got, slackReadbackUnconfirmed)
 	}
 	if receipt.Metadata["truncated"] != "true" {
 		t.Errorf(`receipt metadata = %v, want metadata["truncated"]="true": Slack warned that it truncated the post, and the receipt is the only place a caller can see that its marker did not survive`,
@@ -1290,13 +1301,10 @@ func TestHandlePublishStampsThreadRepliesWhichHistoryDoesNotReturn(t *testing.T)
 	origBase := slackAPIBase
 	t.Cleanup(func() { slackAPIBase = origBase })
 	var captured slackPostMessageReq
-	fakeSlack := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
-			t.Errorf("decode Slack request: %v", err)
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"ok":true,"ts":"1699999999.000200"}`))
-	}))
+	// A threaded post is read back through conversations.replies, which is the
+	// scan-surface asymmetry this test exists to pin; the fake serves both
+	// endpoints so the readback cannot be what makes the assertions below move.
+	fakeSlack := httptest.NewServer(newFakeSlackPublishHandler(t, &captured, "1699999999.000200", nil))
 	t.Cleanup(fakeSlack.Close)
 	slackAPIBase = fakeSlack.URL
 

--- a/slack-full/adapter/main_test.go
+++ b/slack-full/adapter/main_test.go
@@ -784,10 +784,14 @@ func TestHandlePublishDedupesOnIdempotencyKey(t *testing.T) {
 	t.Cleanup(func() { slackAPIBase = origBase })
 	var posts int
 	ts := "1700000000.000100"
-	fakeSlack := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		posts++
+	fakeSlack := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"ok":true,"ts":"` + ts + `"}`))
+		if r.URL.Path == "/conversations.history" {
+			_, _ = w.Write([]byte(`{"ok":true,"messages":[{"ts":"` + ts + `","text":"hello"}]}`))
+			return
+		}
+		posts++
+		_, _ = w.Write([]byte(`{"ok":true,"channel":"C1","ts":"` + ts + `"}`))
 	}))
 	t.Cleanup(fakeSlack.Close)
 	slackAPIBase = fakeSlack.URL
@@ -850,10 +854,14 @@ func TestHandlePublishNoDedupWithoutKey(t *testing.T) {
 	origBase := slackAPIBase
 	t.Cleanup(func() { slackAPIBase = origBase })
 	var posts int
-	fakeSlack := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		posts++
+	fakeSlack := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"ok":true,"ts":"1.2"}`))
+		if r.URL.Path == "/conversations.history" {
+			_, _ = w.Write([]byte(`{"ok":true,"messages":[{"ts":"1.2","text":"hi"}]}`))
+			return
+		}
+		posts++
+		_, _ = w.Write([]byte(`{"ok":true,"channel":"C1","ts":"1.2"}`))
 	}))
 	t.Cleanup(fakeSlack.Close)
 	slackAPIBase = fakeSlack.URL

--- a/slack-full/adapter/publish_readback.go
+++ b/slack-full/adapter/publish_readback.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+const slackReadbackResponseLimit = 1 << 20
+
+const (
+	slackReadbackUnconfirmed = "readback_unconfirmed"
+	slackReadbackUnavailable = "readback_unavailable"
+)
+
+var slackReadbackHTTPClient = &http.Client{Timeout: 15 * time.Second}
+
+type slackReadbackMessage struct {
+	TS   string `json:"ts"`
+	Text string `json:"text"`
+}
+
+type slackReadbackResponse struct {
+	OK       bool                   `json:"ok"`
+	Messages []slackReadbackMessage `json:"messages"`
+	Error    string                 `json:"error"`
+}
+
+type slackReadbackError struct {
+	kind string
+	err  error
+}
+
+func (e *slackReadbackError) Error() string { return e.err.Error() }
+
+func (e *slackReadbackError) Unwrap() error { return e.err }
+
+func unavailableReadback(format string, args ...any) error {
+	return &slackReadbackError{kind: slackReadbackUnavailable, err: fmt.Errorf(format, args...)}
+}
+
+func unconfirmedReadback(format string, args ...any) error {
+	return &slackReadbackError{kind: slackReadbackUnconfirmed, err: fmt.Errorf(format, args...)}
+}
+
+func slackReadbackFailureKind(err error) string {
+	if typed, ok := err.(*slackReadbackError); ok {
+		return typed.kind
+	}
+	return slackReadbackUnavailable
+}
+
+// readBackPublishedMessage verifies a post through Slack's read API rather
+// than trusting chat.postMessage's write response as delivery evidence.
+func readBackPublishedMessage(
+	client *http.Client,
+	token string,
+	channel string,
+	messageTS string,
+	threadTS string,
+	expectedText string,
+) error {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	request, err := newSlackReadbackRequest(token, channel, messageTS, threadTS)
+	if err != nil {
+		return unavailableReadback("build Slack readback: %w", err)
+	}
+	response, err := client.Do(request)
+	if err != nil {
+		return unavailableReadback("Slack readback request: %w", err)
+	}
+	defer response.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(response.Body, slackReadbackResponseLimit+1))
+	if err != nil {
+		return unavailableReadback("read Slack readback response: %w", err)
+	}
+	if len(body) > slackReadbackResponseLimit {
+		return unavailableReadback("Slack readback response exceeds %d bytes", slackReadbackResponseLimit)
+	}
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		return unavailableReadback("Slack readback HTTP %d: %s", response.StatusCode, clipBodyForLog(body))
+	}
+
+	var result slackReadbackResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return unavailableReadback("decode Slack readback response: %w", err)
+	}
+	if !result.OK {
+		return unavailableReadback("Slack readback rejected: %s", result.Error)
+	}
+	for _, message := range result.Messages {
+		if message.TS != messageTS {
+			continue
+		}
+		if message.Text != expectedText {
+			return unconfirmedReadback("Slack readback content mismatch for message %s", messageTS)
+		}
+		return nil
+	}
+	return unconfirmedReadback("Slack message %s not present in channel %s readback", messageTS, channel)
+}
+
+func newSlackReadbackRequest(token, channel, messageTS, threadTS string) (*http.Request, error) {
+	if token == "" || channel == "" || messageTS == "" {
+		return nil, fmt.Errorf("Slack readback requires token, channel, and message ts")
+	}
+	query := url.Values{
+		"channel":   {channel},
+		"oldest":    {messageTS},
+		"latest":    {messageTS},
+		"inclusive": {"true"},
+		"limit":     {"1"},
+	}
+	method := "conversations.history"
+	if threadTS != "" {
+		method = "conversations.replies"
+		query.Set("ts", threadTS)
+		// Slack includes the thread parent in conversations.replies even when
+		// the time range selects a reply. Leave room for that parent and the
+		// exact posted reply; the timestamp/content match below remains exact.
+		query.Set("limit", "2")
+	}
+	request, err := http.NewRequest(http.MethodGet, slackAPIBase+"/"+method+"?"+query.Encode(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("build Slack readback request: %w", err)
+	}
+	request.Header.Set("Authorization", "Bearer "+token)
+	return request, nil
+}

--- a/slack-full/adapter/publish_readback.go
+++ b/slack-full/adapter/publish_readback.go
@@ -4,19 +4,85 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"net/url"
+	"regexp"
+	"strings"
 	"time"
 )
 
 const slackReadbackResponseLimit = 1 << 20
 
+// Readback classifications. These are the adapter's own vocabulary and never
+// reach the wire on their own: slackReadbackReceiptFailure maps them onto gc's
+// closed PublishFailureKind set and carries the value here as receipt metadata
+// instead. See that function for why.
 const (
 	slackReadbackUnconfirmed = "readback_unconfirmed"
 	slackReadbackUnavailable = "readback_unavailable"
+	slackReadbackAuth        = "readback_auth"
 )
 
-var slackReadbackHTTPClient = &http.Client{Timeout: 15 * time.Second}
+// gc's PublishFailureKind vocabulary, as far as this file needs it
+// (gascity internal/extmsg/types.go: unsupported|transient|rate_limited|
+// permanent|auth|not_found). Named here so the mapping below reads as a
+// mapping rather than as bare strings.
+const (
+	publishFailureTransient = "transient"
+	publishFailurePermanent = "permanent"
+	publishFailureAuth      = "auth"
+)
+
+// receiptMetadataKeyReadback carries the readback classification that
+// PublishFailureKind cannot express. Metadata is the only additive channel gc
+// actually forwards (see publishReceipt.Metadata), so it is where the detail
+// the closed enum would drop has to live.
+const receiptMetadataKeyReadback = "readback"
+
+// slackReadbackTiming bounds what the readback can cost the caller. gc gives
+// the adapter a 30s budget per call (gascity internal/extmsg/http_adapter.go),
+// and /publish now spends it on a write plus a read: the worst case here is
+// slackPostTimeout + attempts*clientTimeout + (attempts-1)*delay =
+// 10 + 3*4 + 2*0.2 = 22.4s, which leaves headroom inside that budget instead
+// of racing it. TestSlackReadbackTimingDefaults pins these numbers.
+type slackReadbackTiming struct {
+	// attempts is the total number of readback GETs, not the number of
+	// retries after the first.
+	attempts int
+	// delay separates those attempts.
+	delay time.Duration
+	// clientTimeout bounds one GET.
+	clientTimeout time.Duration
+}
+
+// slackReadbackTimings is a var so tests can shorten the window; production
+// code never assigns it.
+var slackReadbackTimings = slackReadbackTiming{
+	attempts:      3,
+	delay:         200 * time.Millisecond,
+	clientTimeout: 4 * time.Second,
+}
+
+var slackReadbackHTTPClient = &http.Client{Timeout: slackReadbackTimings.clientTimeout}
+
+// slackReadbackTarget names the message a readback must find and the evidence
+// it must find it by.
+type slackReadbackTarget struct {
+	// channel and messageTS identify the posted message.
+	channel   string
+	messageTS string
+	// threadTS is set when the message was posted as a thread reply, which
+	// conversations.history does not return.
+	threadTS string
+	// expectedText is what was posted, after the alias rewrite and the
+	// marker stamp — not the caller's original request text.
+	expectedText string
+	// marker is the reference marker stamped on this publish, or "" when the
+	// publish is unkeyed or the stamp was skipped. See the compare in
+	// matchReadbackMessage for how the two arms differ.
+	marker string
+}
 
 type slackReadbackMessage struct {
 	TS   string `json:"ts"`
@@ -31,19 +97,20 @@ type slackReadbackResponse struct {
 
 type slackReadbackError struct {
 	kind string
-	err  error
+	// retryable marks the failures a bounded re-check can plausibly clear:
+	// a transport blip, and a message Slack has accepted but not yet
+	// indexed. A content mismatch and an auth rejection are answers, not
+	// blips, and re-asking cannot change either.
+	retryable bool
+	err       error
 }
 
 func (e *slackReadbackError) Error() string { return e.err.Error() }
 
 func (e *slackReadbackError) Unwrap() error { return e.err }
 
-func unavailableReadback(format string, args ...any) error {
-	return &slackReadbackError{kind: slackReadbackUnavailable, err: fmt.Errorf(format, args...)}
-}
-
-func unconfirmedReadback(format string, args ...any) error {
-	return &slackReadbackError{kind: slackReadbackUnconfirmed, err: fmt.Errorf(format, args...)}
+func readbackFailure(kind string, retryable bool, format string, args ...any) error {
+	return &slackReadbackError{kind: kind, retryable: retryable, err: fmt.Errorf(format, args...)}
 }
 
 func slackReadbackFailureKind(err error) string {
@@ -53,57 +120,245 @@ func slackReadbackFailureKind(err error) string {
 	return slackReadbackUnavailable
 }
 
+func slackReadbackIsRetryable(err error) bool {
+	typed, ok := err.(*slackReadbackError)
+	return ok && typed.retryable
+}
+
+// slackReadbackReceiptFailure maps a readback failure onto gc's
+// PublishFailureKind vocabulary and returns the adapter-level detail to record
+// under receiptMetadataKeyReadback.
+//
+// gc's PublishFailureKind is a closed, documented set. Because it is a string
+// typedef, an adapter-invented value deserializes silently and every consumer
+// written against the documented enum falls through its default arm — the
+// receipt would carry a kind no retry policy can read. So the wire gets a value
+// from gc's vocabulary and the metadata carries which readback outcome produced
+// it, which is strictly more than an unknown enum value would have told anyone:
+//
+//   - unconfirmed → permanent. The read path answered and the message was not
+//     there (or was different text). Re-posting the identical payload cannot
+//     change that; the truncation path is the clearest case, since an oversized
+//     body truncates the same way every time.
+//   - unavailable → transient. The read leg failed, so nothing is known about
+//     the message; retrying is the right response and is safe because
+//     handlePublish caches this receipt for re-verification rather than
+//     re-posting (see publishReceiptBlocksRepost).
+//   - auth      → auth. A token missing history scope is a configuration
+//     fault, and gc's vocabulary already has the word for it.
+func slackReadbackReceiptFailure(err error) (kind, detail string) {
+	detail = slackReadbackFailureKind(err)
+	switch detail {
+	case slackReadbackUnconfirmed:
+		return publishFailurePermanent, detail
+	case slackReadbackAuth:
+		return publishFailureAuth, detail
+	default:
+		return publishFailureTransient, detail
+	}
+}
+
+// slackEntityUnescape reverses the three entities Slack escapes when it stores
+// message text. Replacer scans the input once and does not re-scan what it
+// substitutes, so "&amp;lt;" unescapes to "&lt;" rather than collapsing two
+// levels into "<".
+var slackEntityUnescape = strings.NewReplacer("&lt;", "<", "&gt;", ">", "&amp;", "&")
+
+// slackAngleSpan matches a well-formed <...> span, which is the shape Slack
+// wraps an auto-linked URL in.
+var slackAngleSpan = regexp.MustCompile(`<([^<>]*)>`)
+
+// slackNormalizeText folds the transformations Slack applies between
+// chat.postMessage and conversations.history: it entity-escapes `&`, `<` and
+// `>` in the stored text, and auto-links bare URLs into `<url>` spans.
+//
+// It is applied to BOTH sides of the compare, never to one. Normalizing only
+// the expected text would require predicting Slack's output exactly — the
+// auto-link shape in particular is not something this repo can pin — whereas
+// folding both sides only requires that the fold be the same on each, which is
+// checkable here. The fold is deliberately lossy in exactly the way Slack is
+// lossy: two texts that differ only by escaping or link markup compare equal,
+// because Slack cannot tell an operator which of the two it stored either.
+// Divergence that survives the fold is still reported unconfirmed.
+func slackNormalizeText(text string) string {
+	return slackAngleSpan.ReplaceAllString(slackEntityUnescape.Replace(text), "$1")
+}
+
 // readBackPublishedMessage verifies a post through Slack's read API rather
 // than trusting chat.postMessage's write response as delivery evidence.
-func readBackPublishedMessage(
-	client *http.Client,
-	token string,
-	channel string,
-	messageTS string,
-	threadTS string,
-	expectedText string,
-) error {
+//
+// Retryable failures get a bounded re-check: conversations.history offers no
+// read-your-writes guarantee, so a message Slack has accepted can be missing
+// from the very next read purely because indexing has not caught up. Reporting
+// that first empty read as "confirmed absent" would be a false negative on the
+// delivery-evidence contract, and the caller's response to it is to post again.
+func readBackPublishedMessage(client *http.Client, token string, target slackReadbackTarget) error {
+	attempts := slackReadbackTimings.attempts
+	if attempts < 1 {
+		attempts = 1
+	}
+	var err error
+	for attempt := 1; ; attempt++ {
+		err = readBackPublishedMessageOnce(client, token, target)
+		if err == nil {
+			return nil
+		}
+		if attempt >= attempts || !slackReadbackIsRetryable(err) {
+			return err
+		}
+		time.Sleep(slackReadbackTimings.delay)
+	}
+}
+
+func readBackPublishedMessageOnce(client *http.Client, token string, target slackReadbackTarget) error {
 	if client == nil {
 		client = http.DefaultClient
 	}
-	request, err := newSlackReadbackRequest(token, channel, messageTS, threadTS)
+	request, err := newSlackReadbackRequest(token, target.channel, target.messageTS, target.threadTS)
 	if err != nil {
-		return unavailableReadback("build Slack readback: %w", err)
+		// A malformed request is this process's own fault and re-issuing it
+		// produces the same error, so it is not retryable.
+		return readbackFailure(slackReadbackUnavailable, false, "build Slack readback: %w", err)
 	}
 	response, err := client.Do(request)
 	if err != nil {
-		return unavailableReadback("Slack readback request: %w", err)
+		return readbackFailure(slackReadbackUnavailable, true, "Slack readback request: %w", err)
 	}
 	defer response.Body.Close()
 
 	body, err := io.ReadAll(io.LimitReader(response.Body, slackReadbackResponseLimit+1))
 	if err != nil {
-		return unavailableReadback("read Slack readback response: %w", err)
+		return readbackFailure(slackReadbackUnavailable, true, "read Slack readback response: %w", err)
 	}
 	if len(body) > slackReadbackResponseLimit {
-		return unavailableReadback("Slack readback response exceeds %d bytes", slackReadbackResponseLimit)
+		return readbackFailure(slackReadbackUnavailable, false, "Slack readback response exceeds %d bytes", slackReadbackResponseLimit)
 	}
 	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
-		return unavailableReadback("Slack readback HTTP %d: %s", response.StatusCode, clipBodyForLog(body))
+		return readbackFailure(slackReadbackUnavailable, true, "Slack readback HTTP %d: %s", response.StatusCode, clipBodyForLog(body))
 	}
 
 	var result slackReadbackResponse
 	if err := json.Unmarshal(body, &result); err != nil {
-		return unavailableReadback("decode Slack readback response: %w", err)
+		return readbackFailure(slackReadbackUnavailable, false, "decode Slack readback response: %w", err)
 	}
 	if !result.OK {
-		return unavailableReadback("Slack readback rejected: %s", result.Error)
+		// An auth-class rejection is a configuration fault, not an instrument
+		// blip: the same token will be refused on every re-check, and a caller
+		// that reads the kind should be told to fix the token rather than to
+		// retry. /publish-file already classifies these through mapSlackError;
+		// this arm keeps the readback leg consistent with it.
+		switch result.Error {
+		case "invalid_auth", "not_authed", "token_revoked", "missing_scope":
+			return readbackFailure(slackReadbackAuth, false, "Slack readback rejected: %s", result.Error)
+		}
+		return readbackFailure(slackReadbackUnavailable, true, "Slack readback rejected: %s", result.Error)
 	}
 	for _, message := range result.Messages {
-		if message.TS != messageTS {
+		if message.TS != target.messageTS {
 			continue
 		}
-		if message.Text != expectedText {
-			return unconfirmedReadback("Slack readback content mismatch for message %s", messageTS)
-		}
-		return nil
+		return matchReadbackMessage(message, target)
 	}
-	return unconfirmedReadback("Slack message %s not present in channel %s readback", messageTS, channel)
+	return readbackFailure(slackReadbackUnconfirmed, true,
+		"Slack message %s not present in channel %s readback", target.messageTS, target.channel)
+}
+
+// matchReadbackMessage decides whether the message Slack stored at this ts is
+// the message that was posted.
+//
+// It cannot be a byte compare against what was posted. Slack canonicalizes text
+// at ingestion, so a delivered message containing `&`, `<`, `>` or a bare URL
+// reads back as different bytes than were sent — and agent traffic through this
+// adapter is mostly PR links, dashboards and shell snippets, so that is the
+// common shape, not a corner. A byte compare therefore reports Delivered:false
+// for messages that are sitting in the channel, and because a non-delivered
+// receipt is not cached (publishReceiptBlocksRepost), the caller's retry
+// re-posts and fails the same deterministic way.
+//
+// Two arms, because neither covers the other:
+//
+//   - Keyed publishes carry the reference marker as the tail of the posted
+//     text. Its characters (`_`, `:`, hex) are outside Slack's escape set and
+//     it is not link-shaped, so it survives ingestion verbatim; a tail match on
+//     it identifies this exact publish by its idempotency key without depending
+//     on any model of Slack's canonicalization. Truncation cannot smuggle a
+//     message past this arm, because Slack truncates from the end — the marker
+//     is the first thing to go — and handlePublish skips the stamp entirely for
+//     text that could not fit under the ceiling with it.
+//   - Everything else — unkeyed publishes, and keyed ones whose stamp was
+//     skipped — is compared on text folded through slackNormalizeText.
+func matchReadbackMessage(message slackReadbackMessage, target slackReadbackTarget) error {
+	if target.marker != "" {
+		if strings.HasSuffix(message.Text, target.marker) {
+			return nil
+		}
+		return readbackFailure(slackReadbackUnconfirmed, false,
+			"Slack readback missing reference marker for message %s", target.messageTS)
+	}
+	if slackNormalizeText(message.Text) != slackNormalizeText(target.expectedText) {
+		return readbackFailure(slackReadbackUnconfirmed, false,
+			"Slack readback content mismatch for message %s", target.messageTS)
+	}
+	return nil
+}
+
+// confirmPublishReceipt runs the readback for a write Slack accepted and
+// records what it proved on the receipt. It is the only place Delivered is set
+// for a successful post: chat.postMessage's own answer is not delivery
+// evidence, which is the premise this whole path exists to enforce.
+func confirmPublishReceipt(token string, receipt *publishReceipt, target slackReadbackTarget) {
+	err := readBackPublishedMessage(slackReadbackHTTPClient, token, target)
+	if err == nil {
+		receipt.Delivered = true
+		receipt.FailureKind = ""
+		// A re-verified receipt must not keep the detail from the read that
+		// failed, or a caller would see a delivered receipt still blaming the
+		// readback.
+		delete(receipt.Metadata, receiptMetadataKeyReadback)
+		return
+	}
+	log.Printf("slack readback failed: %v", err)
+	kind, detail := slackReadbackReceiptFailure(err)
+	receipt.Delivered = false
+	receipt.FailureKind = kind
+	if receipt.Metadata == nil {
+		receipt.Metadata = map[string]string{}
+	}
+	receipt.Metadata[receiptMetadataKeyReadback] = detail
+}
+
+// replayPublishReceipt answers a retry on an idempotency key that already
+// produced a receipt, without posting to Slack again.
+//
+// A delivered receipt is returned as it stands. A posted-but-unconfirmed one —
+// a write Slack accepted whose read leg was unavailable — is re-verified
+// instead: the message very probably exists, so the one thing this must not do
+// is post it a second time. Only a readback that positively reports the message
+// absent releases the key, and then by returning ok=false so the caller's
+// normal post path runs.
+func replayPublishReceipt(
+	token string,
+	dedup *publishDedupCache,
+	key string,
+	target slackReadbackTarget,
+) (publishReceipt, bool) {
+	cached, ok := dedup.Get(key)
+	if !ok {
+		return publishReceipt{}, false
+	}
+	if cached.Delivered {
+		return cached, true
+	}
+	target.messageTS = cached.MessageID
+	confirmPublishReceipt(token, &cached, target)
+	if !cached.Delivered && cached.Metadata[receiptMetadataKeyReadback] == slackReadbackUnconfirmed {
+		log.Printf("publish: dedup re-verify idem=%s ts=%s -> Slack does not have the message; releasing the key",
+			key, cached.MessageID)
+		dedup.Delete(key)
+		return publishReceipt{}, false
+	}
+	dedup.Put(key, cached)
+	return cached, true
 }
 
 func newSlackReadbackRequest(token, channel, messageTS, threadTS string) (*http.Request, error) {
@@ -123,7 +378,7 @@ func newSlackReadbackRequest(token, channel, messageTS, threadTS string) (*http.
 		query.Set("ts", threadTS)
 		// Slack includes the thread parent in conversations.replies even when
 		// the time range selects a reply. Leave room for that parent and the
-		// exact posted reply; the timestamp/content match below remains exact.
+		// exact posted reply; the timestamp match above remains exact.
 		query.Set("limit", "2")
 	}
 	request, err := http.NewRequest(http.MethodGet, slackAPIBase+"/"+method+"?"+query.Encode(), nil)

--- a/slack-full/adapter/publish_readback_test.go
+++ b/slack-full/adapter/publish_readback_test.go
@@ -1,0 +1,269 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return fn(request)
+}
+
+func TestReadBackPublishedMessageFromChannelHistory(t *testing.T) {
+	newSlackReadbackServer(t, "/conversations.history", func(query url.Values) {
+		assertSlackReadbackQuery(t, query, "C123", "1700.001", "1")
+	}, `{"ok":true,"messages":[{"ts":"1700.001","text":"exact body"}]}`)
+
+	if err := readBackPublishedMessage(
+		nil, "xoxb-test", "C123", "1700.001", "", "exact body",
+	); err != nil {
+		t.Fatalf("readBackPublishedMessage: %v", err)
+	}
+}
+
+func TestReadBackPublishedThreadReplyUsesConversationReplies(t *testing.T) {
+	server := newSlackReadbackServer(t, "/conversations.replies", func(query url.Values) {
+		assertSlackReadbackQuery(t, query, "C123", "1700.002", "2")
+		if got := query.Get("ts"); got != "1699.001" {
+			t.Errorf("thread ts = %q, want 1699.001", got)
+		}
+	}, `{"ok":true,"messages":[{"ts":"1699.001","text":"parent"},{"ts":"1700.002","thread_ts":"1699.001","text":"reply"}]}`)
+
+	if err := readBackPublishedMessage(
+		server.Client(), "xoxb-test", "C123", "1700.002", "1699.001", "reply",
+	); err != nil {
+		t.Fatalf("readBackPublishedMessage: %v", err)
+	}
+}
+
+func TestReadBackPublishedMessageFailsClosed(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   int
+		response string
+		want     string
+	}{
+		{name: "message absent", status: http.StatusOK, response: `{"ok":true,"messages":[]}`, want: "not present"},
+		{name: "content mismatch", status: http.StatusOK, response: `{"ok":true,"messages":[{"ts":"1700.001","text":"mutated"}]}`, want: "content mismatch"},
+		{name: "Slack rejection", status: http.StatusOK, response: `{"ok":false,"error":"missing_scope"}`, want: "missing_scope"},
+		{name: "transport status", status: http.StatusTooManyRequests, response: `rate limited`, want: "HTTP 429"},
+		{name: "malformed response", status: http.StatusOK, response: `{`, want: "decode"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(test.status)
+				_, _ = w.Write([]byte(test.response))
+			}))
+			t.Cleanup(server.Close)
+
+			originalBase := slackAPIBase
+			slackAPIBase = server.URL
+			t.Cleanup(func() { slackAPIBase = originalBase })
+
+			err := readBackPublishedMessage(
+				server.Client(), "xoxb-test", "C123", "1700.001", "", "exact body",
+			)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("error = %v, want substring %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestReadBackPublishedMessageBoundsAndClassifiesInstrumentFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(strings.Repeat("x", slackReadbackResponseLimit+1)))
+	}))
+	t.Cleanup(server.Close)
+	originalBase := slackAPIBase
+	slackAPIBase = server.URL
+	t.Cleanup(func() { slackAPIBase = originalBase })
+
+	err := readBackPublishedMessage(
+		server.Client(), "xoxb-test", "C123", "1700.001", "", "exact body",
+	)
+	if err == nil || !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("oversize error = %v, want bounded-response failure", err)
+	}
+	if got := slackReadbackFailureKind(err); got != slackReadbackUnavailable {
+		t.Fatalf("failure kind = %q, want %q", got, slackReadbackUnavailable)
+	}
+
+	transportErr := errors.New("transport unavailable")
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, transportErr
+	})}
+	err = readBackPublishedMessage(
+		client, "xoxb-test", "C123", "1700.001", "", "exact body",
+	)
+	if !errors.Is(err, transportErr) {
+		t.Fatalf("transport error = %v, want wrapped sentinel", err)
+	}
+	if got := slackReadbackFailureKind(errors.New("unknown")); got != slackReadbackUnavailable {
+		t.Fatalf("fallback failure kind = %q, want %q", got, slackReadbackUnavailable)
+	}
+}
+
+func TestNewSlackReadbackRequestRejectsMissingIdentity(t *testing.T) {
+	for _, args := range [][4]string{
+		{"", "C123", "1700.001", ""},
+		{"xoxb-test", "", "1700.001", ""},
+		{"xoxb-test", "C123", "", ""},
+	} {
+		if _, err := newSlackReadbackRequest(args[0], args[1], args[2], args[3]); err == nil {
+			t.Fatalf("newSlackReadbackRequest%q succeeded, want error", args)
+		}
+	}
+}
+
+func TestHandlePublishRequiresExactSlackReadback(t *testing.T) {
+	tests := []struct {
+		name          string
+		history       string
+		wantDelivered bool
+		wantFailure   string
+	}{
+		{
+			name:          "exact message is delivered",
+			history:       `{"ok":true,"messages":[{"ts":"1700.001","text":"hello"}]}`,
+			wantDelivered: true,
+		},
+		{
+			name:        "missing message fails loudly",
+			history:     `{"ok":true,"messages":[]}`,
+			wantFailure: "readback_unconfirmed",
+		},
+		{
+			name:        "broken read path is distinct from absent acknowledgement",
+			history:     `{"ok":false,"error":"missing_scope"}`,
+			wantFailure: "readback_unavailable",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch r.URL.Path {
+				case "/chat.postMessage":
+					_, _ = w.Write([]byte(`{"ok":true,"channel":"C123","ts":"1700.001"}`))
+				case "/conversations.history":
+					_, _ = w.Write([]byte(test.history))
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			t.Cleanup(server.Close)
+
+			originalBase := slackAPIBase
+			slackAPIBase = server.URL
+			t.Cleanup(func() { slackAPIBase = originalBase })
+
+			req := httptest.NewRequest(http.MethodPost, "/publish", strings.NewReader(
+				`{"session_id":"gc-1","conversation":{"conversation_id":"C123","kind":"room"},"text":"hello"}`,
+			))
+			recorder := httptest.NewRecorder()
+			handlePublish(config{slackBotToken: "xoxb-test"}, nil, nil, newPublishDedupCache(publishDedupTTL))(recorder, req)
+
+			var receipt publishReceipt
+			if err := json.Unmarshal(recorder.Body.Bytes(), &receipt); err != nil {
+				t.Fatalf("decode receipt %q: %v", recorder.Body.String(), err)
+			}
+			if receipt.Delivered != test.wantDelivered || receipt.FailureKind != test.wantFailure {
+				t.Fatalf("receipt = %+v, want delivered=%v failure=%q", receipt, test.wantDelivered, test.wantFailure)
+			}
+		})
+	}
+}
+
+func TestHandlePublishReadsBackTheRewrittenSlackContent(t *testing.T) {
+	var posted slackPostMessageReq
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/chat.postMessage":
+			if err := json.NewDecoder(r.Body).Decode(&posted); err != nil {
+				t.Errorf("decode post: %v", err)
+			}
+			_, _ = w.Write([]byte(`{"ok":true,"channel":"C123","ts":"1700.001"}`))
+		case "/conversations.history":
+			response := map[string]any{
+				"ok":       true,
+				"messages": []map[string]string{{"ts": "1700.001", "text": posted.Text}},
+			}
+			_ = json.NewEncoder(w).Encode(response)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	originalBase := slackAPIBase
+	slackAPIBase = server.URL
+	t.Cleanup(func() { slackAPIBase = originalBase })
+	aliases := newUserAliasMapForTest(t, map[string]string{"mayor": "U123ABC"})
+	req := httptest.NewRequest(http.MethodPost, "/publish", strings.NewReader(
+		`{"session_id":"gc-1","conversation":{"conversation_id":"C123","kind":"room"},"text":"hello @mayor"}`,
+	))
+	recorder := httptest.NewRecorder()
+	handlePublish(config{slackBotToken: "xoxb-test"}, nil, aliases, newPublishDedupCache(publishDedupTTL))(recorder, req)
+
+	var receipt publishReceipt
+	if err := json.Unmarshal(recorder.Body.Bytes(), &receipt); err != nil {
+		t.Fatalf("decode receipt %q: %v", recorder.Body.String(), err)
+	}
+	if !receipt.Delivered {
+		t.Fatalf("receipt = %+v, want delivered", receipt)
+	}
+	if posted.Text != "hello <@U123ABC>" {
+		t.Fatalf("posted text = %q, want rewritten mention", posted.Text)
+	}
+}
+
+func newSlackReadbackServer(
+	t *testing.T,
+	wantPath string,
+	checkQuery func(url.Values),
+	response string,
+) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != wantPath {
+			t.Errorf("path = %q, want %q", r.URL.Path, wantPath)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer xoxb-test" {
+			t.Errorf("authorization = %q, want bearer token", got)
+		}
+		checkQuery(r.URL.Query())
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(response))
+	}))
+	t.Cleanup(server.Close)
+
+	originalBase := slackAPIBase
+	slackAPIBase = server.URL
+	t.Cleanup(func() { slackAPIBase = originalBase })
+	return server
+}
+
+func assertSlackReadbackQuery(t *testing.T, query url.Values, channel, messageTS, limit string) {
+	t.Helper()
+	for key, want := range map[string]string{
+		"channel":   channel,
+		"oldest":    messageTS,
+		"latest":    messageTS,
+		"inclusive": "true",
+		"limit":     limit,
+	} {
+		if got := query.Get(key); got != want {
+			t.Errorf("%s = %q, want %q", key, got, want)
+		}
+	}
+}

--- a/slack-full/adapter/publish_readback_test.go
+++ b/slack-full/adapter/publish_readback_test.go
@@ -6,8 +6,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"regexp"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 type roundTripFunc func(*http.Request) (*http.Response, error)
@@ -16,14 +19,110 @@ func (fn roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error)
 	return fn(request)
 }
 
+// readbackTarget builds the common top-level-post target so each test names
+// only what it is actually varying.
+func readbackTarget(expectedText string) slackReadbackTarget {
+	return slackReadbackTarget{channel: "C123", messageTS: "1700.001", expectedText: expectedText}
+}
+
+// fastReadbackTimings collapses the bounded re-check window for tests that
+// exercise a retryable failure. Without it every such test pays the production
+// window (3 attempts, 200ms apart) to prove something that does not depend on
+// the wall clock. Tests that assert on the retry *behavior* set their own
+// values; this only removes the wait.
+func fastReadbackTimings(t *testing.T) {
+	t.Helper()
+	original := slackReadbackTimings
+	slackReadbackTimings.delay = 0
+	t.Cleanup(func() { slackReadbackTimings = original })
+}
+
+// TestSlackReadbackTimingDefaults pins the production window in literals.
+//
+// The retry loop and the two HTTP clients are only safe because their worst
+// case fits inside the 30s budget gc gives an adapter call, and that argument
+// is arithmetic over these numbers: slackPostTimeout + attempts*clientTimeout +
+// (attempts-1)*delay. A test that recomputed the bound from the same constants
+// would agree with any values at all, including ones that blow the budget — so
+// the numbers are written out here, and a change to them has to be argued for
+// against this comment rather than absorbed silently.
+func TestSlackReadbackTimingDefaults(t *testing.T) {
+	if slackReadbackTimings.attempts != 3 {
+		t.Errorf("readback attempts = %d, want 3", slackReadbackTimings.attempts)
+	}
+	if slackReadbackTimings.delay != 200*time.Millisecond {
+		t.Errorf("readback delay = %v, want 200ms", slackReadbackTimings.delay)
+	}
+	if slackReadbackTimings.clientTimeout != 4*time.Second {
+		t.Errorf("readback client timeout = %v, want 4s", slackReadbackTimings.clientTimeout)
+	}
+	if slackReadbackHTTPClient.Timeout != 4*time.Second {
+		t.Errorf("readback http client timeout = %v, want 4s", slackReadbackHTTPClient.Timeout)
+	}
+	if slackPostTimeout != 10*time.Second {
+		t.Errorf("post timeout = %v, want 10s", slackPostTimeout)
+	}
+	if slackPostHTTPClient.Timeout != slackPostTimeout {
+		t.Errorf("post http client timeout = %v, want %v", slackPostHTTPClient.Timeout, slackPostTimeout)
+	}
+	worst := slackPostTimeout +
+		time.Duration(slackReadbackTimings.attempts)*slackReadbackTimings.clientTimeout +
+		time.Duration(slackReadbackTimings.attempts-1)*slackReadbackTimings.delay
+	if worst >= 30*time.Second {
+		t.Fatalf("worst-case /publish cost = %v, want under gc's 30s adapter budget", worst)
+	}
+}
+
+// TestSlackReadbackReceiptFailureMapsOntoGCVocabulary pins the wire contract.
+//
+// gc's PublishFailureKind is a closed set, but it is a string typedef, so an
+// adapter-invented kind deserializes without error and every consumer written
+// against the documented enum silently takes its default arm. The bug that
+// causes is invisible from this side — nothing here would fail — so the mapping
+// is pinned against the literal gc vocabulary instead, and the adapter's own
+// classification is asserted to survive in metadata rather than on the wire.
+func TestSlackReadbackReceiptFailureMapsOntoGCVocabulary(t *testing.T) {
+	gcVocabulary := map[string]bool{
+		"unsupported": true, "transient": true, "rate_limited": true,
+		"permanent": true, "auth": true, "not_found": true,
+	}
+	tests := []struct {
+		readback string
+		wantKind string
+	}{
+		{slackReadbackUnconfirmed, "permanent"},
+		{slackReadbackUnavailable, "transient"},
+		{slackReadbackAuth, "auth"},
+	}
+	for _, test := range tests {
+		t.Run(test.readback, func(t *testing.T) {
+			kind, detail := slackReadbackReceiptFailure(
+				readbackFailure(test.readback, false, "readback failed"))
+			if kind != test.wantKind {
+				t.Errorf("failure kind = %q, want %q", kind, test.wantKind)
+			}
+			if !gcVocabulary[kind] {
+				t.Errorf("failure kind %q is outside gc's PublishFailureKind set %v", kind, gcVocabulary)
+			}
+			if detail != test.readback {
+				t.Errorf("metadata detail = %q, want %q: the closed enum cannot carry it, so metadata must",
+					detail, test.readback)
+			}
+		})
+	}
+	// An untyped error is the "we do not know" case and must not claim more
+	// than transient.
+	if kind, detail := slackReadbackReceiptFailure(errors.New("unknown")); kind != "transient" || detail != slackReadbackUnavailable {
+		t.Errorf("untyped error mapped to (%q, %q), want (transient, %q)", kind, detail, slackReadbackUnavailable)
+	}
+}
+
 func TestReadBackPublishedMessageFromChannelHistory(t *testing.T) {
 	newSlackReadbackServer(t, "/conversations.history", func(query url.Values) {
 		assertSlackReadbackQuery(t, query, "C123", "1700.001", "1")
 	}, `{"ok":true,"messages":[{"ts":"1700.001","text":"exact body"}]}`)
 
-	if err := readBackPublishedMessage(
-		nil, "xoxb-test", "C123", "1700.001", "", "exact body",
-	); err != nil {
+	if err := readBackPublishedMessage(nil, "xoxb-test", readbackTarget("exact body")); err != nil {
 		t.Fatalf("readBackPublishedMessage: %v", err)
 	}
 }
@@ -36,25 +135,219 @@ func TestReadBackPublishedThreadReplyUsesConversationReplies(t *testing.T) {
 		}
 	}, `{"ok":true,"messages":[{"ts":"1699.001","text":"parent"},{"ts":"1700.002","thread_ts":"1699.001","text":"reply"}]}`)
 
-	if err := readBackPublishedMessage(
-		server.Client(), "xoxb-test", "C123", "1700.002", "1699.001", "reply",
-	); err != nil {
+	target := slackReadbackTarget{
+		channel: "C123", messageTS: "1700.002", threadTS: "1699.001", expectedText: "reply",
+	}
+	if err := readBackPublishedMessage(server.Client(), "xoxb-test", target); err != nil {
 		t.Fatalf("readBackPublishedMessage: %v", err)
 	}
 }
 
+// TestReadBackPublishedMessageAcceptsSlackCanonicalizedText is F1's regression
+// control, and the case the original readback got wrong.
+//
+// Slack does not store what you post: it entity-escapes `&`, `<` and `>` and
+// auto-links bare URLs into `<url>` spans. Agent traffic through this adapter is
+// mostly PR links, dashboards and shell snippets, so that is the common shape,
+// not a corner — and a byte compare against the posted text reports every one of
+// those delivered messages as unconfirmed. The negative arm is what stops the
+// fix from degrading into "accept anything": a genuinely different body still
+// fails.
+func TestReadBackPublishedMessageAcceptsSlackCanonicalizedText(t *testing.T) {
+	posted := "R&D update: see https://github.com/o/r/pull/313 <not a tag>"
+	// entityLiteral is text that already contains an entity-shaped substring
+	// when it is posted. It is the one payload class on which the shipped
+	// both-sides fold and its mirror image (folding an entity-escaped expected
+	// side instead) disagree, so without this row the suite is green under
+	// either, and the fold's semantics here are an accident rather than a
+	// decision. See the row's comment for what the outcome means.
+	entityLiteral := "docs say &amp; is the escape"
+	tests := []struct {
+		name string
+		// postedText overrides the shared posted text for rows whose subject
+		// is the payload rather than the stored form; "" means use posted.
+		postedText string
+		stored     string
+		wantErr    bool
+	}{
+		{name: "slack canonicalization", stored: slackCanonicalizeForTest(posted)},
+		{name: "verbatim echo", stored: posted},
+		{name: "different body", stored: "R&D update: see something else entirely", wantErr: true},
+		{
+			name:    "truncated body",
+			stored:  slackCanonicalizeForTest("R&D update: see https://github.com/o/r/pull/313"),
+			wantErr: true,
+		},
+		{
+			// Entity-literal text under the fake's escape model reads back
+			// UNCONFIRMED, and that is the shipped behaviour, pinned here so it
+			// cannot flip silently in either direction.
+			//
+			// The fake escapes unconditionally (canonicalizePlainTextForTest),
+			// so it stores "&amp;amp;" for the "&amp;" posted here; the fold's
+			// single-pass unescape then takes the stored side to "&amp;" and
+			// the posted side to "&", which differ. Slack's documented contract
+			// is the weaker one — senders are told to escape `&`, and only the
+			// listed characters are decoded for display, which is self-defeating
+			// if the platform re-escaped a valid entity — so under real Slack
+			// this same payload is expected to confirm. The uncertainty is about
+			// the fake, not about the matcher: do NOT "fix" matchReadbackMessage
+			// to make this row confirm. Escaping the expected side instead is an
+			// exact inversion, not an improvement — it would confirm this class
+			// and start rejecting escaped-URL query strings (?a=1&amp;b=2),
+			// which is the more common shape and the one Slack's docs describe.
+			name:       "entity-literal payload under the fake's stricter escape",
+			postedText: entityLiteral,
+			stored:     slackCanonicalizeForTest(entityLiteral),
+			wantErr:    true,
+		},
+	}
+	if slackCanonicalizeForTest(posted) == posted {
+		t.Fatalf("the fake Slack stored %q unchanged; it models the identity function, which is the blind spot this test exists to close",
+			posted)
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			postedText := test.postedText
+			if postedText == "" {
+				postedText = posted
+			}
+			newSlackReadbackServer(t, "/conversations.history", func(url.Values) {}, mustJSON(t, map[string]any{
+				"ok":       true,
+				"messages": []map[string]string{{"ts": "1700.001", "text": test.stored}},
+			}))
+			err := readBackPublishedMessage(nil, "xoxb-test", readbackTarget(postedText))
+			if (err != nil) != test.wantErr {
+				t.Fatalf("readBackPublishedMessage = %v, wantErr %v (posted %q, stored %q)", err, test.wantErr, postedText, test.stored)
+			}
+		})
+	}
+}
+
+// TestReadBackPublishedMessageMatchesKeyedPublishByReferenceMarker covers the
+// other arm: a keyed publish carries the reference marker as its tail, whose
+// characters are outside Slack's escape set and are not link-shaped, so a tail
+// match identifies this exact publish without depending on any model of Slack's
+// canonicalization at all. The negative arm pins that the marker is load-bearing
+// — a message at the right ts without it is not this publish.
+func TestReadBackPublishedMessageMatchesKeyedPublishByReferenceMarker(t *testing.T) {
+	const marker = "_ref:50e90a583c12_"
+	posted := "shipping the fix\n\n" + marker
+	tests := []struct {
+		name    string
+		stored  string
+		wantErr bool
+	}{
+		{name: "marker survives canonicalization", stored: slackCanonicalizeForTest("R&D <b> ship\n\n" + marker)},
+		{name: "marker absent", stored: "shipping the fix", wantErr: true},
+		{name: "marker truncated away", stored: "shipping the fix\n\n_ref:50e9", wantErr: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			newSlackReadbackServer(t, "/conversations.history", func(url.Values) {}, mustJSON(t, map[string]any{
+				"ok":       true,
+				"messages": []map[string]string{{"ts": "1700.001", "text": test.stored}},
+			}))
+			target := readbackTarget(posted)
+			target.marker = marker
+			err := readBackPublishedMessage(nil, "xoxb-test", target)
+			if (err != nil) != test.wantErr {
+				t.Fatalf("readBackPublishedMessage = %v, wantErr %v (stored %q)", err, test.wantErr, test.stored)
+			}
+		})
+	}
+}
+
+// TestReadBackPublishedMessageRetriesWhileSlackIndexes pins F5's window.
+//
+// conversations.history offers no read-your-writes guarantee, so a message Slack
+// has accepted can be missing from the very next read purely because indexing
+// has not caught up. Calling that first empty read "confirmed absent" is a false
+// negative whose consequence is a second copy of the message in the channel.
+func TestReadBackPublishedMessageRetriesWhileSlackIndexes(t *testing.T) {
+	fastReadbackTimings(t)
+	var reads atomic.Int32
+	newDynamicSlackReadbackServer(t, func(w http.ResponseWriter) {
+		if reads.Add(1) < 3 {
+			_, _ = w.Write([]byte(`{"ok":true,"messages":[]}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"ok":true,"messages":[{"ts":"1700.001","text":"exact body"}]}`))
+	})
+
+	if err := readBackPublishedMessage(nil, "xoxb-test", readbackTarget("exact body")); err != nil {
+		t.Fatalf("readBackPublishedMessage: %v, want the later read to confirm it", err)
+	}
+	if got := reads.Load(); got != 3 {
+		t.Fatalf("readback GETs = %d, want 3 (the message appeared on the third)", got)
+	}
+}
+
+// TestReadBackPublishedMessageStopsRetryingWhatRetryingCannotFix is the control
+// for the test above: the bounded window must not be spent re-asking a question
+// that already has an answer. A content mismatch and an auth rejection are
+// answers.
+func TestReadBackPublishedMessageStopsRetryingWhatRetryingCannotFix(t *testing.T) {
+	fastReadbackTimings(t)
+	tests := []struct {
+		name     string
+		response string
+	}{
+		{name: "content mismatch", response: `{"ok":true,"messages":[{"ts":"1700.001","text":"mutated"}]}`},
+		{name: "auth rejection", response: `{"ok":false,"error":"missing_scope"}`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var reads atomic.Int32
+			newDynamicSlackReadbackServer(t, func(w http.ResponseWriter) {
+				reads.Add(1)
+				_, _ = w.Write([]byte(test.response))
+			})
+
+			if err := readBackPublishedMessage(nil, "xoxb-test", readbackTarget("exact body")); err == nil {
+				t.Fatal("readBackPublishedMessage succeeded, want failure")
+			}
+			if got := reads.Load(); got != 1 {
+				t.Fatalf("readback GETs = %d, want 1: re-asking cannot change this answer", got)
+			}
+		})
+	}
+}
+
 func TestReadBackPublishedMessageFailsClosed(t *testing.T) {
+	fastReadbackTimings(t)
 	tests := []struct {
 		name     string
 		status   int
 		response string
 		want     string
+		wantKind string
 	}{
-		{name: "message absent", status: http.StatusOK, response: `{"ok":true,"messages":[]}`, want: "not present"},
-		{name: "content mismatch", status: http.StatusOK, response: `{"ok":true,"messages":[{"ts":"1700.001","text":"mutated"}]}`, want: "content mismatch"},
-		{name: "Slack rejection", status: http.StatusOK, response: `{"ok":false,"error":"missing_scope"}`, want: "missing_scope"},
-		{name: "transport status", status: http.StatusTooManyRequests, response: `rate limited`, want: "HTTP 429"},
-		{name: "malformed response", status: http.StatusOK, response: `{`, want: "decode"},
+		{
+			name: "message absent", status: http.StatusOK, response: `{"ok":true,"messages":[]}`,
+			want: "not present", wantKind: slackReadbackUnconfirmed,
+		},
+		{
+			name:   "content mismatch",
+			status: http.StatusOK, response: `{"ok":true,"messages":[{"ts":"1700.001","text":"mutated"}]}`,
+			want: "content mismatch", wantKind: slackReadbackUnconfirmed,
+		},
+		{
+			name: "Slack auth rejection", status: http.StatusOK, response: `{"ok":false,"error":"missing_scope"}`,
+			want: "missing_scope", wantKind: slackReadbackAuth,
+		},
+		{
+			name: "Slack non-auth rejection", status: http.StatusOK, response: `{"ok":false,"error":"ratelimited"}`,
+			want: "ratelimited", wantKind: slackReadbackUnavailable,
+		},
+		{
+			name: "transport status", status: http.StatusTooManyRequests, response: `rate limited`,
+			want: "HTTP 429", wantKind: slackReadbackUnavailable,
+		},
+		{
+			name: "malformed response", status: http.StatusOK, response: `{`,
+			want: "decode", wantKind: slackReadbackUnavailable,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -68,17 +361,19 @@ func TestReadBackPublishedMessageFailsClosed(t *testing.T) {
 			slackAPIBase = server.URL
 			t.Cleanup(func() { slackAPIBase = originalBase })
 
-			err := readBackPublishedMessage(
-				server.Client(), "xoxb-test", "C123", "1700.001", "", "exact body",
-			)
+			err := readBackPublishedMessage(server.Client(), "xoxb-test", readbackTarget("exact body"))
 			if err == nil || !strings.Contains(err.Error(), test.want) {
 				t.Fatalf("error = %v, want substring %q", err, test.want)
+			}
+			if got := slackReadbackFailureKind(err); got != test.wantKind {
+				t.Fatalf("failure kind = %q, want %q", got, test.wantKind)
 			}
 		})
 	}
 }
 
 func TestReadBackPublishedMessageBoundsAndClassifiesInstrumentFailure(t *testing.T) {
+	fastReadbackTimings(t)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte(strings.Repeat("x", slackReadbackResponseLimit+1)))
 	}))
@@ -87,9 +382,7 @@ func TestReadBackPublishedMessageBoundsAndClassifiesInstrumentFailure(t *testing
 	slackAPIBase = server.URL
 	t.Cleanup(func() { slackAPIBase = originalBase })
 
-	err := readBackPublishedMessage(
-		server.Client(), "xoxb-test", "C123", "1700.001", "", "exact body",
-	)
+	err := readBackPublishedMessage(server.Client(), "xoxb-test", readbackTarget("exact body"))
 	if err == nil || !strings.Contains(err.Error(), "exceeds") {
 		t.Fatalf("oversize error = %v, want bounded-response failure", err)
 	}
@@ -101,9 +394,7 @@ func TestReadBackPublishedMessageBoundsAndClassifiesInstrumentFailure(t *testing
 	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
 		return nil, transportErr
 	})}
-	err = readBackPublishedMessage(
-		client, "xoxb-test", "C123", "1700.001", "", "exact body",
-	)
+	err = readBackPublishedMessage(client, "xoxb-test", readbackTarget("exact body"))
 	if !errors.Is(err, transportErr) {
 		t.Fatalf("transport error = %v, want wrapped sentinel", err)
 	}
@@ -125,11 +416,13 @@ func TestNewSlackReadbackRequestRejectsMissingIdentity(t *testing.T) {
 }
 
 func TestHandlePublishRequiresExactSlackReadback(t *testing.T) {
+	fastReadbackTimings(t)
 	tests := []struct {
 		name          string
 		history       string
 		wantDelivered bool
 		wantFailure   string
+		wantReadback  string
 	}{
 		{
 			name:          "exact message is delivered",
@@ -137,14 +430,30 @@ func TestHandlePublishRequiresExactSlackReadback(t *testing.T) {
 			wantDelivered: true,
 		},
 		{
-			name:        "missing message fails loudly",
-			history:     `{"ok":true,"messages":[]}`,
-			wantFailure: "readback_unconfirmed",
+			// The read path answered and the message was not there. Re-posting
+			// the identical payload cannot change that, so the kind a caller's
+			// retry policy reads is permanent — with the adapter's own
+			// classification alongside it, since gc's enum cannot say it.
+			name:         "missing message fails loudly",
+			history:      `{"ok":true,"messages":[]}`,
+			wantFailure:  "permanent",
+			wantReadback: slackReadbackUnconfirmed,
 		},
 		{
-			name:        "broken read path is distinct from absent acknowledgement",
-			history:     `{"ok":false,"error":"missing_scope"}`,
-			wantFailure: "readback_unavailable",
+			// A token that cannot read history is a provisioning fault, and
+			// gc's vocabulary already has the word for it. Distinguishing this
+			// from the case above is the point: one says "fix the token", the
+			// other says "the message is not there".
+			name:         "broken read path is distinct from absent acknowledgement",
+			history:      `{"ok":false,"error":"missing_scope"}`,
+			wantFailure:  "auth",
+			wantReadback: slackReadbackAuth,
+		},
+		{
+			name:         "unavailable read path is retryable",
+			history:      `{"ok":false,"error":"internal_error"}`,
+			wantFailure:  "transient",
+			wantReadback: slackReadbackUnavailable,
 		},
 	}
 	for _, test := range tests {
@@ -179,7 +488,117 @@ func TestHandlePublishRequiresExactSlackReadback(t *testing.T) {
 			if receipt.Delivered != test.wantDelivered || receipt.FailureKind != test.wantFailure {
 				t.Fatalf("receipt = %+v, want delivered=%v failure=%q", receipt, test.wantDelivered, test.wantFailure)
 			}
+			if got := receipt.Metadata[receiptMetadataKeyReadback]; got != test.wantReadback {
+				t.Fatalf("receipt metadata[%q] = %q, want %q", receiptMetadataKeyReadback, got, test.wantReadback)
+			}
 		})
+	}
+}
+
+// TestHandlePublishReplaysPostedButUnconfirmedReceipt is F2's control on the
+// side where the message is probably in Slack.
+//
+// A write Slack accepted whose read leg then failed leaves the adapter knowing
+// only that Slack took the message. Refusing to remember that receipt hands the
+// caller's retry to the post path, which duplicates a message that is very
+// probably in the channel — the exact duplicate the dedup chokepoint exists to
+// absorb. So the receipt is remembered and the retry re-verifies by readback
+// instead of re-posting; here the second read succeeds, and the caller gets a
+// delivered receipt for the message it already sent.
+func TestHandlePublishReplaysPostedButUnconfirmedReceipt(t *testing.T) {
+	fastReadbackTimings(t)
+	var posts, reads atomic.Int32
+	var captured slackPostMessageReq
+	fake := newFakeSlackPublishHandler(t, &captured, "1700.001", func() { posts.Add(1) })
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The first publish's read leg is down end to end (every attempt in the
+		// bounded window), so nothing is known about the message except that
+		// Slack accepted the write. It comes back up before the retry.
+		if strings.HasPrefix(r.URL.Path, "/conversations.") &&
+			reads.Add(1) <= int32(slackReadbackTimings.attempts) {
+			w.WriteHeader(http.StatusBadGateway)
+			return
+		}
+		fake(w, r)
+	}))
+	t.Cleanup(server.Close)
+	originalBase := slackAPIBase
+	slackAPIBase = server.URL
+	t.Cleanup(func() { slackAPIBase = originalBase })
+
+	handler := handlePublish(config{slackBotToken: "xoxb-test"}, nil, nil, newPublishDedupCache(publishDedupTTL))
+	publish := func() publishReceipt {
+		t.Helper()
+		body := `{"session_id":"gc-1","conversation":{"conversation_id":"C123","kind":"room"},"text":"hello","idempotency_key":"k-1"}`
+		recorder := httptest.NewRecorder()
+		handler(recorder, httptest.NewRequest(http.MethodPost, "/publish", strings.NewReader(body)))
+		var receipt publishReceipt
+		if err := json.Unmarshal(recorder.Body.Bytes(), &receipt); err != nil {
+			t.Fatalf("decode receipt %q: %v", recorder.Body.String(), err)
+		}
+		return receipt
+	}
+
+	first := publish()
+	if first.Delivered || first.MessageID != "1700.001" {
+		t.Fatalf("first receipt = %+v, want undelivered with the real ts Slack answered", first)
+	}
+
+	second := publish()
+	if !second.Delivered || second.MessageID != "1700.001" {
+		t.Fatalf("retry receipt = %+v, want the re-verified message marked delivered", second)
+	}
+	if got := posts.Load(); got != 1 {
+		t.Fatalf("chat.postMessage called %d times, want 1: the retry must re-verify, not re-post", got)
+	}
+	if second.Metadata[receiptMetadataKeyReadback] != "" {
+		t.Errorf("re-verified receipt still blames the readback: metadata = %v", second.Metadata)
+	}
+}
+
+// TestHandlePublishReleasesTheKeyWhenSlackDoesNotHaveTheMessage is the other
+// side of F2, and the reason the remembered receipt is not simply replayed. If
+// the re-verification positively reports the message absent, the key must be
+// released so the caller's retry actually posts — remembering it forever would
+// turn one lost message into permanent silence on that key.
+func TestHandlePublishReleasesTheKeyWhenSlackDoesNotHaveTheMessage(t *testing.T) {
+	fastReadbackTimings(t)
+	var posts, reads atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.HasPrefix(r.URL.Path, "/conversations.") {
+			// First publish: the read leg is down, so the receipt is
+			// remembered. Afterwards the read works and reports the message
+			// absent, which releases the key.
+			if reads.Add(1) <= int32(slackReadbackTimings.attempts) {
+				w.WriteHeader(http.StatusBadGateway)
+				return
+			}
+			_, _ = w.Write([]byte(`{"ok":true,"messages":[]}`))
+			return
+		}
+		posts.Add(1)
+		_, _ = w.Write([]byte(`{"ok":true,"channel":"C123","ts":"1700.001"}`))
+	}))
+	t.Cleanup(server.Close)
+	originalBase := slackAPIBase
+	slackAPIBase = server.URL
+	t.Cleanup(func() { slackAPIBase = originalBase })
+
+	handler := handlePublish(config{slackBotToken: "xoxb-test"}, nil, nil, newPublishDedupCache(publishDedupTTL))
+	publish := func() {
+		t.Helper()
+		body := `{"session_id":"gc-1","conversation":{"conversation_id":"C123","kind":"room"},"text":"hello","idempotency_key":"k-1"}`
+		handler(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/publish", strings.NewReader(body)))
+	}
+
+	publish()
+	if got := posts.Load(); got != 1 {
+		t.Fatalf("chat.postMessage called %d times on the first publish, want 1", got)
+	}
+	publish()
+	if got := posts.Load(); got != 2 {
+		t.Fatalf("chat.postMessage called %d times, want 2: a readback that proves the message absent must free the key", got)
 	}
 }
 
@@ -196,7 +615,7 @@ func TestHandlePublishReadsBackTheRewrittenSlackContent(t *testing.T) {
 		case "/conversations.history":
 			response := map[string]any{
 				"ok":       true,
-				"messages": []map[string]string{{"ts": "1700.001", "text": posted.Text}},
+				"messages": []map[string]string{{"ts": "1700.001", "text": slackCanonicalizeForTest(posted.Text)}},
 			}
 			_ = json.NewEncoder(w).Encode(response)
 		default:
@@ -227,6 +646,50 @@ func TestHandlePublishReadsBackTheRewrittenSlackContent(t *testing.T) {
 	}
 }
 
+// TestHandlePublishDeliversTextSlackCanonicalizes is F1 end to end: an ordinary
+// unkeyed publish whose body carries an ampersand, a bare URL and angle
+// brackets. This is what most agent traffic through this adapter looks like —
+// PR links, dashboards, shell snippets — and under a byte-compare readback every
+// one of these messages lands in Slack and is reported Delivered:false.
+//
+// The downstream consequence is what makes it a regression rather than a
+// cosmetic mislabel: a non-delivered receipt was not cached, and gc's outbound
+// path returns before the transcript append, so the authoritative transcript
+// omits messages a human can see in the channel while the caller's retry posts
+// them again.
+func TestHandlePublishDeliversTextSlackCanonicalizes(t *testing.T) {
+	fastReadbackTimings(t)
+	const text = "R&D: ship https://github.com/o/r/pull/313 <today>"
+	var captured slackPostMessageReq
+	server := httptest.NewServer(newFakeSlackPublishHandler(t, &captured, "1700.001", nil))
+	t.Cleanup(server.Close)
+	originalBase := slackAPIBase
+	slackAPIBase = server.URL
+	t.Cleanup(func() { slackAPIBase = originalBase })
+
+	body := mustJSON(t, map[string]any{
+		"session_id":   "gc-1",
+		"conversation": map[string]string{"conversation_id": "C123", "kind": "room"},
+		"text":         text,
+	})
+	recorder := httptest.NewRecorder()
+	handlePublish(config{slackBotToken: "xoxb-test"}, nil, nil, newPublishDedupCache(publishDedupTTL))(
+		recorder, httptest.NewRequest(http.MethodPost, "/publish", strings.NewReader(body)))
+
+	var receipt publishReceipt
+	if err := json.Unmarshal(recorder.Body.Bytes(), &receipt); err != nil {
+		t.Fatalf("decode receipt %q: %v", recorder.Body.String(), err)
+	}
+	if !receipt.Delivered {
+		t.Fatalf("receipt = %+v, want delivered: Slack stored this message, it is just not stored byte-for-byte",
+			receipt)
+	}
+	if stored := slackCanonicalizeForTest(captured.Text); stored == captured.Text {
+		t.Fatalf("fake stored the posted text unchanged (%q); the test proves nothing about canonicalization",
+			stored)
+	}
+}
+
 func newSlackReadbackServer(
 	t *testing.T,
 	wantPath string,
@@ -251,6 +714,112 @@ func newSlackReadbackServer(
 	slackAPIBase = server.URL
 	t.Cleanup(func() { slackAPIBase = originalBase })
 	return server
+}
+
+// newDynamicSlackReadbackServer is newSlackReadbackServer for tests whose
+// subject is the sequence of reads rather than one answer.
+func newDynamicSlackReadbackServer(t *testing.T, respond func(http.ResponseWriter)) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		respond(w)
+	}))
+	t.Cleanup(server.Close)
+
+	originalBase := slackAPIBase
+	slackAPIBase = server.URL
+	t.Cleanup(func() { slackAPIBase = originalBase })
+	return server
+}
+
+func mustJSON(t *testing.T, value any) string {
+	t.Helper()
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("marshal fake response: %v", err)
+	}
+	return string(encoded)
+}
+
+// testSlackBareURL matches the URL shape Slack auto-links. `|` is excluded
+// because it is Slack's own label separator inside a link span.
+var testSlackBareURL = regexp.MustCompile(`https?://[^\s<>|]+`)
+
+// slackCanonicalizeForTest models what Slack does to message text between
+// chat.postMessage and conversations.history: it entity-escapes `&`, `<` and
+// `>`, and auto-links bare URLs into `<url>` spans. Markup spans Slack itself
+// produced (`<@U…>`, `<#C…>`, `<url|label>`) are passed through, which is why
+// the escape runs on the text between spans rather than over the whole string.
+//
+// This exists because every publish fake in this package used to echo the
+// posted text back verbatim, which models a Slack that stores exactly what it
+// is given. No such Slack exists, and the suite's agreement with that fiction
+// is what let a byte-compare readback gate ship: the fakes could not produce
+// the input that breaks it. It is deliberately an approximation — the point is
+// that it is not the identity function.
+func slackCanonicalizeForTest(text string) string {
+	var out strings.Builder
+	last := 0
+	for _, span := range slackAngleSpan.FindAllStringIndex(text, -1) {
+		out.WriteString(canonicalizePlainTextForTest(text[last:span[0]]))
+		out.WriteString(text[span[0]:span[1]])
+		last = span[1]
+	}
+	out.WriteString(canonicalizePlainTextForTest(text[last:]))
+	return out.String()
+}
+
+// canonicalizePlainTextForTest escapes UNCONDITIONALLY: it does not ask whether
+// the `&` it is escaping already begins a valid entity, so it takes a posted
+// "&amp;" to "&amp;amp;". That models a *stricter* Slack than the documented
+// one — Slack tells senders to escape `&` themselves and promises that only the
+// listed characters are decoded for display, a rule that is self-defeating if
+// the platform then escaped the escape. The approximation is deliberate and
+// safe for every other row (nothing else in the suite posts entity-shaped
+// text), but it is the reason the entity-literal row in
+// TestReadBackPublishedMessageAcceptsSlackCanonicalizedText pins an unconfirmed
+// outcome that real Slack is expected to confirm. Read that row before treating
+// this function as evidence about the platform.
+func canonicalizePlainTextForTest(text string) string {
+	escaped := strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;").Replace(text)
+	return testSlackBareURL.ReplaceAllString(escaped, "<$0>")
+}
+
+// newFakeSlackPublishHandler is a fake Slack for tests whose subject is what
+// handlePublish POSTS, not whether the readback works. It records the
+// chat.postMessage into captured, then answers the readback that handlePublish
+// now performs by serving that text at ts — canonicalized the way Slack
+// canonicalizes it — on conversations.history for a top-level post and
+// conversations.replies for a threaded one.
+//
+// Without this a fake that answers every path with a post response fails the
+// readback two ways at once: the GET carries no body, so a handler that decodes
+// unconditionally reports EOF, and the reply parses as zero messages, so the
+// receipt comes back Delivered:false. Either one would make an assertion about
+// the posted text measure the readback instead of its own subject.
+//
+// onPost, when non-nil, runs on the post path only, so a caller counting posts
+// counts writes and not readbacks.
+func newFakeSlackPublishHandler(t *testing.T, captured *slackPostMessageReq, ts string, onPost func()) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/conversations.history", "/conversations.replies":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"ok":       true,
+				"messages": []map[string]string{{"ts": ts, "text": slackCanonicalizeForTest(captured.Text)}},
+			})
+		default:
+			if err := json.NewDecoder(r.Body).Decode(captured); err != nil {
+				t.Errorf("decode Slack request: %v", err)
+			}
+			if onPost != nil {
+				onPost()
+			}
+			_, _ = w.Write([]byte(`{"ok":true,"channel":"C1","ts":"` + ts + `"}`))
+		}
+	}
 }
 
 func assertSlackReadbackQuery(t *testing.T, query url.Values, channel, messageTS, limit string) {

--- a/slack-full/commands/bind-room/help.md
+++ b/slack-full/commands/bind-room/help.md
@@ -38,7 +38,15 @@ Underlying calls
 
 1. POST /v0/city/<name>/extmsg/groups   (mode=launcher; with fanout policy if any flag set)
 2. POST /v0/city/<name>/extmsg/participants for each session
+3. Reconcile gc's authoritative direct-binding table so it cannot shadow the
+   group: POST /extmsg/unbind for a group-only room, or POST /extmsg/bind with
+   `replace=true` when `--binding-owner` is set.
+
+Omitting `--binding-owner` declares the room group-only and removes any direct
+binding, including one created separately. Pass the owner on every re-run that
+must preserve outbound publication.
 
 The pack records the binding under
 `.gc/services/slack/data/config.json` so other slack-pack commands can
-resolve the room without re-querying gc.
+resolve the room without re-querying gc. The local record is written only after
+the authoritative reconciliation succeeds.

--- a/slack-full/commands/bind-room/help.md
+++ b/slack-full/commands/bind-room/help.md
@@ -11,15 +11,26 @@ conversation while a human watches.
 Examples
 --------
 
-Plain ambient binding (every session sees inbound, default-routed to
-the first session for explicit-target resolution):
+Every run must declare who owns the room's direct binding — either
+`--binding-owner SESSION` or `--group-only`. See "Binding authority" below.
 
-  gc slack bind-room C0123ROOM01 oversight-rig.mayor geo/oversight-rig.project-lead
+Group-routed room (every session sees inbound, default-routed to the
+first session for explicit-target resolution; no direct binding):
+
+  gc slack bind-room C0123ROOM01 oversight-rig.mayor geo/oversight-rig.project-lead \
+      --group-only
+
+Room with an outbound publisher (the shape oversight-rig uses):
+
+  gc slack bind-room C0123ROOM01 \
+      oversight-rig.mayor geo/oversight-rig.project-lead \
+      --binding-owner gc-77139
 
 Enable peer-fanout policy with caps (governs peer-triggered publishes):
 
   gc slack bind-room C0123ROOM01 \
       oversight-rig.mayor geo/oversight-rig.project-lead \
+      --group-only \
       --enable-peer-fanout \
       --allow-untargeted-publication \
       --max-peer-triggered-publishes 8 \
@@ -29,6 +40,7 @@ Override participant handles (used by `@@handle` routing):
 
   gc slack bind-room C0123ROOM01 \
       oversight-rig.mayor geo/oversight-rig.project-lead \
+      --group-only \
       --default-handle mayor \
       --handle mayor=oversight-rig.mayor \
       --handle geo-pl=geo/oversight-rig.project-lead
@@ -39,12 +51,27 @@ Underlying calls
 1. POST /v0/city/<name>/extmsg/groups   (mode=launcher; with fanout policy if any flag set)
 2. POST /v0/city/<name>/extmsg/participants for each session
 3. Reconcile gc's authoritative direct-binding table so it cannot shadow the
-   group: POST /extmsg/unbind for a group-only room, or POST /extmsg/bind with
-   `replace=true` when `--binding-owner` is set.
+   group: POST /extmsg/unbind for a `--group-only` room, or POST /extmsg/bind
+   with `replace=true` when `--binding-owner` is set.
 
-Omitting `--binding-owner` declares the room group-only and removes any direct
-binding, including one created separately. Pass the owner on every re-run that
-must preserve outbound publication.
+Binding authority
+-----------------
+
+gc resolves an inbound message against a direct binding *before* the group
+route, so a stale direct binding silently shadows the group. Step 3 makes the
+binding table agree with the topology you declare — and because that step
+writes authoritative state, exactly one of these is required on every run:
+
+  --binding-owner SESSION   keep (or hand over) the room's outbound publisher.
+                            Any other direct binding for the room is replaced.
+  --group-only              declare the room group-routed. Removes EVERY active
+                            direct binding for the conversation — including one
+                            created by other tooling or another operator.
+
+Passing neither is an error, not a default: `--group-only`'s sweep is
+destructive, and an operator who forgets `--binding-owner` on a re-run would
+otherwise sever the room's outbound publishing without being told. The removed
+bindings are printed to stderr and returned as `unbound_bindings`.
 
 The pack records the binding under
 `.gc/services/slack/data/config.json` so other slack-pack commands can

--- a/slack-full/scripts/slack_chat_bind_room.py
+++ b/slack-full/scripts/slack_chat_bind_room.py
@@ -198,6 +198,30 @@ def build_participants(
     return out
 
 
+def reconcile_authoritative_binding(
+    conversation: dict[str, str], binding_owner: str
+) -> dict[str, Any] | None:
+    """Make extmsg's direct-binding table agree with the room topology.
+
+    Inbound resolution consults a direct binding before its group route. A
+    group-only room must therefore have no direct binding, while a room with a
+    publisher owner must replace any stale direct binding with that owner.
+    """
+    try:
+        if binding_owner:
+            return common.gc_post(
+                "/extmsg/bind",
+                {
+                    "session_id": binding_owner,
+                    "conversation": conversation,
+                    "replace": True,
+                },
+            )
+        return common.gc_post("/extmsg/unbind", {"conversation": conversation})
+    except common.GCAPIError as exc:
+        raise SystemExit(f"reconcile authoritative binding: {exc}") from exc
+
+
 def main(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(
         description="Bind a Slack room/channel to one or more named gc sessions",
@@ -231,9 +255,10 @@ def main(argv: list[str]) -> int:
     parser.add_argument("--binding-owner", default="",
                         metavar="SESSION",
                         help="Also bind this session to the conversation as the publisher "
-                             "for /extmsg/outbound. Required to make outbound publishes "
-                             "work; without it, peer-fanout still fires but publishes need "
-                             "a separate /extmsg/bind call. Should refer semantically to one "
+                             "for /extmsg/outbound. Required on every bind-room run that must "
+                             "preserve outbound publishing; omitting it declares a group-only "
+                             "room and removes any direct binding that would shadow the group. "
+                             "Should refer semantically to one "
                              "of the participants. Pass the gc-id (e.g. gc-77139) when the "
                              "binding will be looked up by gc-id (e.g. resolve_rig_channel.py); "
                              "pass the participant alias when the rest of the system reads "
@@ -283,15 +308,7 @@ def main(argv: list[str]) -> int:
             raise SystemExit(f"upsert participant {handle}={session}: {exc}") from exc
         participant_records.append(res)
 
-    binding_record: dict[str, Any] | None = None
-    if binding_owner:
-        try:
-            binding_record = common.gc_post(
-                "/extmsg/bind",
-                {"session_id": binding_owner, "conversation": conv},
-            )
-        except common.GCAPIError as exc:
-            raise SystemExit(f"bind {binding_owner}: {exc}") from exc
+    binding_record = reconcile_authoritative_binding(conv, binding_owner)
 
     cfg = common.load_pack_config()
     cfg.setdefault("bindings", {})

--- a/slack-full/scripts/slack_chat_bind_room.py
+++ b/slack-full/scripts/slack_chat_bind_room.py
@@ -198,18 +198,97 @@ def build_participants(
     return out
 
 
+def _recorded_binding_owner(binding_key: str) -> str:
+    """Best-effort read of the owner this pack last recorded for the room.
+
+    Only used to make the fail-closed error below name a session instead of
+    saying "something may be bound". gc has no conversation-scoped binding
+    read — ``GET /extmsg/bindings`` is keyed by ``session_id`` and
+    ``resolveActiveBinding`` is internal — so the local record is the only
+    owner name available to this script, and it is a hint, not authority: it
+    can be stale, and a binding created by other tooling never appears in it.
+    Every failure mode here (no city path, corrupt state, unreadable state,
+    absent record) degrades to "unknown owner", never to a wrong answer or an
+    abort. OSError is caught alongside GCAPIError because load_pack_config
+    only wraps json.JSONDecodeError, so a config.json that exists but cannot
+    be read raises straight through it — and a hint that cannot be produced
+    must never turn the curated refusal into a traceback.
+    """
+    try:
+        cfg = common.load_pack_config()
+    except (common.GCAPIError, OSError):
+        return ""
+    if not isinstance(cfg, dict):
+        return ""
+    record = (cfg.get("bindings") or {}).get(binding_key) or {}
+    if not isinstance(record, dict):
+        return ""
+    return str(record.get("binding_owner") or "")
+
+
+def resolve_binding_authority(args: argparse.Namespace, binding_key: str) -> str:
+    """Return the declared binding owner, or "" for an explicit group-only room.
+
+    Fails closed. Reconciliation writes gc's authoritative direct-binding
+    table, and the group-only arm is destructive: ``/extmsg/unbind`` with a
+    conversation-only body matches *every* active direct binding for the room
+    (gc ``binding_service.go``'s empty filter), including bindings this pack
+    never created. That is the right thing to do when an operator declares the
+    room group-only and the wrong thing to do by default, so it may not be
+    reachable by *omitting* a flag — an operator who forgets ``--binding-owner``
+    on a re-run would silently sever the room's outbound publishing.
+
+    So exactly one of ``--binding-owner`` / ``--group-only`` is required. The
+    check runs before any API call, so a rejected invocation has mutated
+    nothing.
+    """
+    binding_owner = args.binding_owner.strip()
+    if binding_owner and args.group_only:
+        raise SystemExit(
+            "--binding-owner and --group-only are mutually exclusive: "
+            "--binding-owner names the session that keeps the direct binding, "
+            "--group-only removes it")
+    if binding_owner:
+        return binding_owner
+    if args.group_only:
+        return ""
+    recorded = _recorded_binding_owner(binding_key)
+    owner_note = (
+        f"this pack last recorded {recorded!r} as the owner of {binding_key}; "
+        if recorded
+        else ""
+    )
+    raise SystemExit(
+        "refusing to reconcile the direct binding without an explicit "
+        "declaration: pass --binding-owner SESSION to keep (or hand over) the "
+        "room's outbound publisher, or --group-only to declare the room "
+        "group-routed and remove every active direct binding for it. "
+        f"{owner_note}"
+        "--group-only removes bindings created by other tooling too, so it is "
+        "never assumed")
+
+
 def reconcile_authoritative_binding(
     conversation: dict[str, str], binding_owner: str
-) -> dict[str, Any] | None:
+) -> dict[str, Any]:
     """Make extmsg's direct-binding table agree with the room topology.
 
     Inbound resolution consults a direct binding before its group route. A
     group-only room must therefore have no direct binding, while a room with a
     publisher owner must replace any stale direct binding with that owner.
+
+    Returns a normalized record of what was reconciled::
+
+        {"action": "bind"|"unbind", "binding": {...}|None, "unbound": [...]}
+
+    The two API responses have different shapes — ``/extmsg/bind`` answers with
+    the binding it created, ``/extmsg/unbind`` with ``{"unbound": [...]}`` — and
+    flattening one into a field named for the other is how the removed bindings
+    stopped being legible to the operator who removed them.
     """
     try:
         if binding_owner:
-            return common.gc_post(
+            binding = common.gc_post(
                 "/extmsg/bind",
                 {
                     "session_id": binding_owner,
@@ -217,9 +296,27 @@ def reconcile_authoritative_binding(
                     "replace": True,
                 },
             )
-        return common.gc_post("/extmsg/unbind", {"conversation": conversation})
+            return {"action": "bind", "binding": binding or None, "unbound": []}
+        response = common.gc_post("/extmsg/unbind", {"conversation": conversation})
+        unbound = (response or {}).get("unbound") or []
+        return {"action": "unbind", "binding": None, "unbound": unbound}
     except common.GCAPIError as exc:
         raise SystemExit(f"reconcile authoritative binding: {exc}") from exc
+
+
+def report_unbound(unbound: list[Any]) -> None:
+    """Tell the operator which direct bindings the group-only sweep removed.
+
+    A removal nobody can see is a removal nobody can undo: the sweep can take
+    out a binding another pack or operator created, and until now the API's
+    answer was dropped on the floor.
+    """
+    for record in unbound:
+        if isinstance(record, dict):
+            detail = f"{record.get('SessionID') or '?'} (binding {record.get('ID') or '?'})"
+        else:
+            detail = str(record)
+        sys.stderr.write(f"unbound direct binding: {detail}\n")
 
 
 def main(argv: list[str]) -> int:
@@ -254,25 +351,36 @@ def main(argv: list[str]) -> int:
                              "is composing its own protocol delivery.")
     parser.add_argument("--binding-owner", default="",
                         metavar="SESSION",
-                        help="Also bind this session to the conversation as the publisher "
-                             "for /extmsg/outbound. Required on every bind-room run that must "
-                             "preserve outbound publishing; omitting it declares a group-only "
-                             "room and removes any direct binding that would shadow the group. "
-                             "Should refer semantically to one "
+                        help="Bind this session to the conversation as the publisher "
+                             "for /extmsg/outbound, replacing any stale direct binding. "
+                             "Required on every bind-room run that must preserve outbound "
+                             "publishing; pass --group-only instead to declare the room "
+                             "group-routed. Should refer semantically to one "
                              "of the participants. Pass the gc-id (e.g. gc-77139) when the "
                              "binding will be looked up by gc-id (e.g. resolve_rig_channel.py); "
                              "pass the participant alias when the rest of the system reads "
                              "the binding by alias. The script does NOT cross-check the owner "
                              "against the participant list — this is intentional so gc-ids "
                              "can be used alongside alias-based participants.")
+    parser.add_argument("--group-only", action="store_true",
+                        help="Declare the room purely group-routed: remove EVERY active "
+                             "direct binding for the conversation so none can shadow the "
+                             "group route, including bindings created by other tooling. "
+                             "Mutually exclusive with --binding-owner; one of the two is "
+                             "required, because this removal is destructive and must not be "
+                             "reachable by forgetting a flag.")
     args = parser.parse_args(argv)
+
+    binding_key = f"{args.kind}:{args.conversation_id}"
+    # Before any API call: a rejected declaration must not have created a
+    # group, upserted a participant, or touched the binding table.
+    binding_owner = resolve_binding_authority(args, binding_key)
 
     workspace_id = _slack_workspace_id()
     city = common.gc_city_name()
     overrides = _parse_handle_overrides(args.handle)
     participants = build_participants(args.session_names, overrides, args.default_handle)
     default_handle = args.default_handle or participants[0][0]
-    binding_owner = args.binding_owner.strip()
     conv = build_conversation_ref(
         conversation_id=args.conversation_id,
         kind=args.kind,
@@ -308,11 +416,11 @@ def main(argv: list[str]) -> int:
             raise SystemExit(f"upsert participant {handle}={session}: {exc}") from exc
         participant_records.append(res)
 
-    binding_record = reconcile_authoritative_binding(conv, binding_owner)
+    reconciled = reconcile_authoritative_binding(conv, binding_owner)
+    report_unbound(reconciled["unbound"])
 
     cfg = common.load_pack_config()
     cfg.setdefault("bindings", {})
-    binding_key = f"{args.kind}:{args.conversation_id}"
     cfg["bindings"][binding_key] = {
         "kind": args.kind,
         "conversation": conv,
@@ -323,7 +431,7 @@ def main(argv: list[str]) -> int:
             {"handle": h, "session_name": s} for h, s in participants
         ],
         "binding_owner": binding_owner or None,
-        "binding_record": (binding_record or {}).get("ID", "") or None,
+        "binding_record": (reconciled["binding"] or {}).get("ID", "") or None,
     }
     common.save_pack_config(cfg)
 
@@ -346,7 +454,8 @@ def main(argv: list[str]) -> int:
         "fanout_policy": fanout_policy,
         "participants": participant_records,
         "binding_owner": binding_owner or None,
-        "binding_record": binding_record,
+        "binding_record": reconciled["binding"],
+        "unbound_bindings": reconciled["unbound"],
         "protocol_nudge": {
             "delivered_to": nudged,
             "failures": nudge_failures,

--- a/slack-full/tests/test_slack_chat_bind_room.py
+++ b/slack-full/tests/test_slack_chat_bind_room.py
@@ -7,6 +7,7 @@ end-to-end via gc events in the slack-pack README's verification recipe.
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import pathlib
 import sys
@@ -187,6 +188,8 @@ def test_main_round_trip_with_fake_gc(monkeypatch: pytest.MonkeyPatch, capsys: p
             return {"ID": "group-xyz", "FanoutPolicy": body.get("fanout_policy") or {}}
         if path == "/extmsg/participants":
             return {"ID": "p-" + body["handle"], "Handle": body["handle"], "SessionID": body["session_id"]}
+        if path == "/extmsg/unbind":
+            return {"unbound": [{"ID": "binding-old", "SessionID": "gc-stale"}]}
         raise AssertionError(f"unexpected path {path}")
 
     monkeypatch.setattr(common, "gc_post", fake_post)
@@ -199,8 +202,19 @@ def test_main_round_trip_with_fake_gc(monkeypatch: pytest.MonkeyPatch, capsys: p
     ])
     assert rc == 0
     paths = [c[0] for c in calls]
-    # No --binding-owner: bind-room only creates the group + N participants.
-    assert paths == ["/extmsg/groups", "/extmsg/participants", "/extmsg/participants"]
+    assert paths == [
+        "/extmsg/groups",
+        "/extmsg/participants",
+        "/extmsg/participants",
+        "/extmsg/unbind",
+    ]
+    assert calls[-1][1] == {"conversation": {
+        "scope_id": "test-city",
+        "provider": "slack",
+        "account_id": "T0TESTWS",
+        "conversation_id": "C0123ROOM01",
+        "kind": "room",
+    }}
 
     group_body = calls[0][1]
     assert group_body["root_conversation"]["kind"] == "room"
@@ -223,8 +237,7 @@ def test_main_round_trip_with_fake_gc(monkeypatch: pytest.MonkeyPatch, capsys: p
 
     cfg_path = pathlib.Path(os.environ["GC_CITY_PATH"]) / ".gc/services/slack/data/config.json"
     assert cfg_path.exists()
-    import json as _json
-    saved = _json.loads(cfg_path.read_text())
+    saved = json.loads(cfg_path.read_text())
     binding = saved["bindings"]["room:C0123ROOM01"]
     assert binding["group_id"] == "group-xyz"
     assert binding["default_handle"] == "mayor"
@@ -234,8 +247,12 @@ def test_main_round_trip_with_fake_gc(monkeypatch: pytest.MonkeyPatch, capsys: p
     ]
 
     out = capsys.readouterr().out
-    assert "binding_key" in out
-    assert "group-xyz" in out
+    result = json.loads(out)
+    assert result["binding_key"] == "room:C0123ROOM01"
+    assert result["group_id"] == "group-xyz"
+    assert result["binding_record"] == {
+        "unbound": [{"ID": "binding-old", "SessionID": "gc-stale"}],
+    }
 
 
 def test_main_with_binding_owner_emits_extmsg_bind(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture):
@@ -275,6 +292,7 @@ def test_main_with_binding_owner_emits_extmsg_bind(monkeypatch: pytest.MonkeyPat
     ]
     bind_body = calls[-1][1]
     assert bind_body["session_id"] == "gc-77139"
+    assert bind_body["replace"] is True
     assert bind_body["conversation"] == {
         "scope_id": "test-city",
         "provider": "slack",
@@ -327,5 +345,32 @@ def test_binding_owner_can_be_separate_gcid_when_participants_are_aliases(monkey
     assert bind_call[1]["session_id"] == "gc-77139"
 
 
-# Module-level json import for the test above.
-import json  # noqa: E402
+@pytest.mark.parametrize("binding_owner", ["", "gc-77139"])
+def test_binding_reconciliation_failure_does_not_persist_or_report_success(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture,
+    binding_owner: str,
+):
+    mod = _import_module()
+    common = sys.modules["slack_intake_common"]
+
+    def fake_post(path: str, body: dict):
+        if path == "/extmsg/groups":
+            return {"ID": "group-xyz"}
+        if path == "/extmsg/participants":
+            return {"ID": "p-" + body["handle"]}
+        if path in {"/extmsg/bind", "/extmsg/unbind"}:
+            raise common.GCAPIError("authoritative binding store unavailable")
+        raise AssertionError(f"unexpected path {path}")
+
+    monkeypatch.setattr(common, "gc_post", fake_post)
+    args = ["C0123ROOM01", "gc-77139", "--no-protocol-nudge"]
+    if binding_owner:
+        args.extend(["--binding-owner", binding_owner])
+
+    with pytest.raises(SystemExit, match="authoritative binding store unavailable"):
+        mod.main(args)
+
+    cfg_path = pathlib.Path(os.environ["GC_CITY_PATH"]) / ".gc/services/slack/data/config.json"
+    assert not cfg_path.exists()
+    assert capsys.readouterr().out == ""

--- a/slack-full/tests/test_slack_chat_bind_room.py
+++ b/slack-full/tests/test_slack_chat_bind_room.py
@@ -197,6 +197,7 @@ def test_main_round_trip_with_fake_gc(monkeypatch: pytest.MonkeyPatch, capsys: p
     rc = mod.main([
         "C0123ROOM01",
         "oversight-rig.mayor", "geo/oversight-rig.project-lead",
+        "--group-only",
         "--enable-peer-fanout",
         "--max-peer-triggered-publishes", "5",
     ])
@@ -246,13 +247,132 @@ def test_main_round_trip_with_fake_gc(monkeypatch: pytest.MonkeyPatch, capsys: p
         "oversight-rig.mayor", "geo/oversight-rig.project-lead",
     ]
 
-    out = capsys.readouterr().out
-    result = json.loads(out)
+    captured = capsys.readouterr()
+    result = json.loads(captured.out)
     assert result["binding_key"] == "room:C0123ROOM01"
     assert result["group_id"] == "group-xyz"
-    assert result["binding_record"] == {
-        "unbound": [{"ID": "binding-old", "SessionID": "gc-stale"}],
-    }
+    # A group-only run creates no binding, so there is no binding record — the
+    # bindings it *removed* are the thing the operator needs to see, and they
+    # get their own field instead of being stuffed into the one named for the
+    # other outcome.
+    assert result["binding_record"] is None
+    assert result["unbound_bindings"] == [{"ID": "binding-old", "SessionID": "gc-stale"}]
+    # ...and a removal nobody can see is a removal nobody can undo. The sweep
+    # can take out a binding another pack or operator created.
+    assert "gc-stale" in captured.err
+    assert "binding-old" in captured.err
+
+
+def test_main_requires_an_explicit_binding_authority_before_any_api_call(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+):
+    """Neither flag is an error, and it is raised before anything is mutated.
+
+    The group-only reconcile unbinds *every* active direct binding for the room.
+    Reaching that by omitting a flag means an operator who forgets
+    ``--binding-owner`` on a re-run silently severs the room's outbound
+    publishing — so the destructive path has to be declared, not defaulted into.
+    """
+    mod = _import_module()
+    common = sys.modules["slack_intake_common"]
+
+    def fake_post(path: str, body: dict):
+        raise AssertionError(f"no API call may be made: {path}")
+
+    monkeypatch.setattr(common, "gc_post", fake_post)
+
+    with pytest.raises(SystemExit, match="--binding-owner"):
+        mod.main(["C0123ROOM01", "oversight-rig.mayor"])
+
+    cfg_path = pathlib.Path(os.environ["GC_CITY_PATH"]) / ".gc/services/slack/data/config.json"
+    assert not cfg_path.exists()
+    assert capsys.readouterr().out == ""
+
+
+def test_main_rejects_binding_owner_together_with_group_only(monkeypatch: pytest.MonkeyPatch):
+    """The two flags declare opposite topologies; accepting both would hide which won."""
+    mod = _import_module()
+    common = sys.modules["slack_intake_common"]
+    monkeypatch.setattr(
+        common, "gc_post",
+        lambda path, body: (_ for _ in ()).throw(AssertionError(f"no API call may be made: {path}")),
+    )
+
+    with pytest.raises(SystemExit, match="mutually exclusive"):
+        mod.main(["C0123ROOM01", "oversight-rig.mayor",
+                  "--binding-owner", "gc-77139", "--group-only"])
+
+
+def test_fail_closed_error_names_the_owner_this_pack_recorded(monkeypatch: pytest.MonkeyPatch):
+    """The error names the session at risk when the local record knows one.
+
+    gc has no conversation-scoped binding read — ``GET /extmsg/bindings`` is
+    keyed by session_id — so the pack's own record is the only owner name
+    available. It is a hint, not authority, and its absence must not soften the
+    refusal (covered by the fail-closed test above, which runs with no record).
+    """
+    mod = _import_module()
+    common = sys.modules["slack_intake_common"]
+    common.save_pack_config({
+        "version": 1,
+        "bindings": {"room:C0123ROOM01": {"binding_owner": "gc-77139"}},
+    })
+    monkeypatch.setattr(
+        common, "gc_post",
+        lambda path, body: (_ for _ in ()).throw(AssertionError(f"no API call may be made: {path}")),
+    )
+
+    with pytest.raises(SystemExit, match="gc-77139"):
+        mod.main(["C0123ROOM01", "oversight-rig.mayor"])
+
+
+def test_fail_closed_survives_corrupt_local_state(monkeypatch: pytest.MonkeyPatch):
+    """Corrupt pack state degrades the hint, never the refusal.
+
+    Corrupt is the JSON-level failure: the bytes are readable and do not parse,
+    which ``load_pack_config`` converts into ``GCAPIError``. The unreadable
+    case below is a different arm and reaches the hint as ``OSError``.
+    """
+    mod = _import_module()
+    common = sys.modules["slack_intake_common"]
+    state = common.pack_state_dir()
+    state.mkdir(parents=True, exist_ok=True)
+    (state / "config.json").write_text("{not json", encoding="utf-8")
+    monkeypatch.setattr(
+        common, "gc_post",
+        lambda path, body: (_ for _ in ()).throw(AssertionError(f"no API call may be made: {path}")),
+    )
+
+    with pytest.raises(SystemExit, match="--group-only"):
+        mod.main(["C0123ROOM01", "oversight-rig.mayor"])
+
+
+def test_fail_closed_survives_unreadable_local_state(monkeypatch: pytest.MonkeyPatch):
+    """State that exists but cannot be read degrades the hint, never the refusal.
+
+    ``load_pack_config`` wraps only ``json.JSONDecodeError``, so ``read_text``'s
+    ``OSError`` propagates past it and would surface as a traceback instead of
+    the curated refusal naming ``--binding-owner``/``--group-only``.
+
+    The unreadable file is a *directory* at the config path rather than a
+    chmod-000 file: ``path.exists()`` is still true so the early-return is not
+    taken, ``read_text`` raises ``IsADirectoryError`` (an ``OSError``), and
+    unlike a permission bit this reproduces for every uid — a chmod-000 file is
+    readable by root, which would make the test vacuous wherever the suite runs
+    privileged.
+    """
+    mod = _import_module()
+    common = sys.modules["slack_intake_common"]
+    state = common.pack_state_dir()
+    state.mkdir(parents=True, exist_ok=True)
+    (state / "config.json").mkdir()
+    monkeypatch.setattr(
+        common, "gc_post",
+        lambda path, body: (_ for _ in ()).throw(AssertionError(f"no API call may be made: {path}")),
+    )
+
+    with pytest.raises(SystemExit, match="--group-only"):
+        mod.main(["C0123ROOM01", "oversight-rig.mayor"])
 
 
 def test_main_with_binding_owner_emits_extmsg_bind(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture):
@@ -307,6 +427,10 @@ def test_main_with_binding_owner_emits_extmsg_bind(monkeypatch: pytest.MonkeyPat
     binding = saved["bindings"]["room:C0123ROOM01"]
     assert binding["binding_owner"] == "gc-77139"
     assert binding["binding_record"] == "binding-1"
+
+    result = json.loads(capsys.readouterr().out)
+    assert result["binding_record"] == {"ID": "binding-1", "SessionID": "gc-77139"}
+    assert result["unbound_bindings"] == []
 
 
 def test_binding_owner_can_be_separate_gcid_when_participants_are_aliases(monkeypatch: pytest.MonkeyPatch):
@@ -365,8 +489,7 @@ def test_binding_reconciliation_failure_does_not_persist_or_report_success(
 
     monkeypatch.setattr(common, "gc_post", fake_post)
     args = ["C0123ROOM01", "gc-77139", "--no-protocol-nudge"]
-    if binding_owner:
-        args.extend(["--binding-owner", binding_owner])
+    args.extend(["--binding-owner", binding_owner] if binding_owner else ["--group-only"])
 
     with pytest.raises(SystemExit, match="authoritative binding store unavailable"):
         mod.main(args)


### PR DESCRIPTION
## Summary

- reconcile `bind-room` with gc's authoritative direct-binding table before writing the pack-local record
- replace a stale direct binding when `--binding-owner` is supplied
- remove a direct binding for group-only rooms so it cannot shadow the group route
- fail before saving local configuration when authoritative reconciliation fails
- document that callers must repeat `--binding-owner` when outbound publication must remain enabled
- treat `chat.postMessage` as write acceptance, not delivery evidence
- read the exact timestamp and posted content back from the intended channel or thread before returning `delivered=true`
- distinguish a valid read with no matching acknowledgement from an unavailable read path

## Why

The pack-local Slack binding and gc's extmsg binding table can disagree. Inbound resolution consults the direct binding first, so a stale record can route a human message to an inactive session even though the visible room group is correct. The command now updates the surface the resolver actually reads and saves its local receipt only after that succeeds.

Outbound publication also treated Slack's successful write response as proof that the intended channel contained the message. The adapter now uses the returned timestamp to read the exact content back through Slack's history API. Missing or mismatched content fails as `readback_unconfirmed`; transport, auth/scope, HTTP, or schema failures fail separately as `readback_unavailable`.

## Verification

- `go test ./... -count=1`, `go test -race ./... -count=1`, `go vet ./...`, and `go build ./...` in `slack-full/adapter`
- `python3 -m pytest -q slack-full/tests/test_slack_chat_publish_to_channel.py slack-full/tests/test_slack_chat_bind_room.py` — 24 passed
- tests cover replacement, group-only unbind, authoritative failure, save ordering, root and threaded readback, exact content, read-path failure classification, response bounds, rewritten mentions, and idempotency
- independent cross-family review `gc-803204` passed after active mutation testing
