### PR TITLE
docs(gastown/refinery): note mr/pr mode is GitHub-specific

### DIFF
--- a/gastown/agents/refinery/prompt.template.md
+++ b/gastown/agents/refinery/prompt.template.md
@@ -271,6 +271,16 @@ the bead when the branch has been pushed. If validation fails, record a
 durable blocked reason on the bead and escalate to mayor instead of
 closing the work.
 
+**GitHub-specific today.** `gh pr view`/`gh pr create` require a
+GitHub-hosted origin. Non-GitHub hosts (e.g. Azure DevOps Repos) are
+not yet supported: `metadata.existing_pr` suppresses the `gh pr create`
+call, but the validation step above (`gh pr view`) is also
+GitHub-only — it cannot resolve a non-GitHub PR, so a refinery on a
+non-GitHub rig will correctly fail validation and escalate to mayor
+rather than close, even for a perfectly valid PR. There is no working
+non-GitHub path today. Native support is tracked upstream:
+gascity#5260.
+
 If `metadata.existing_pr` is present while `merge_strategy` is unset or
 `direct`, treat the handoff as `mr`. An existing PR cannot be validated
 and then ignored by landing directly to the target branch.


### PR DESCRIPTION
Relates to gastownhall/gascity#5260 ("native refinery PR-creation backend over Azure DevOps Repos REST API").

## Why this is here, not in gascity

The issue asks to extend `packs/gastown/agents/refinery/prompt.template.md` — but that file doesn't live in `gastownhall/gascity`. It's pulled in as a separate module dependency, this repo, pinned via `pack.toml`/`packs.lock`.

## Scope note

The issue's actual ask — a native Azure DevOps Repos REST API merge/PR-creation backend — is a substantial addition: the real merge mechanics live in `formulas/mol-refinery-patrol.toml`'s `merge-push` step (~700 lines of bash the refinery agent itself executes, with GitHub URL parsing, `gh` CLI + REST-API fallback, PR-lookup, existing-PR validation with five failure modes, and an adversarial test suite asserting exact invariants). Building `ado-rest` properly means a parallel credential/URL/PR-lookup/PR-creation path plus new tests — a dedicated future PR, not this one, pending a maintainer signal on the design direction (new `merge_strategy` value vs. a separate `repo_provider` discriminator, per the issue's own flagged tradeoff).

Also considered just rewording the existing `existing_pr` validation paragraph to sound "provider-neutral," but backed off: `prompt.template.md` isn't documentation in the usual sense — it's literal instructions an autonomous refinery agent executes. Describing an "equivalent REST read on other hosts" with no implementation behind it risks an agent improvising an unreviewed ADO REST call in production PR/merge logic on an ADO rig.

## What this PR actually does

One paragraph in the Merge Strategy section: states `mr`/`pr` mode is GitHub-specific today, and is explicit that there is **no working non-GitHub path** — `metadata.existing_pr` suppresses the `gh pr create` call, but the validation step (`gh pr view`) is also GitHub-only, so a refinery on a non-GitHub rig will correctly fail validation and escalate to mayor rather than close, even for a perfectly valid externally-created PR. Points at gascity#5260 for native support. No instruction telling the agent to attempt anything undefined, and no claim that a non-GitHub workaround currently works — an earlier draft of this PR description said the `existing_pr` fallback "already works end-to-end on ADO rigs," which was wrong (conflated a reporter's own custom-patched setup with standard behavior); caught before merge, corrected here.

## Verification

`bash gastown/tests/test_gastown_pack_assets.sh` passes — the only shell test suite covering this pack; none of its assertions touch this section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)