### PR TITLE
reconcile: land the live worktree's real fixes, drop the protocol regression (ga-2pej2)

### DIFF
--- a/discord/.gitignore
+++ b/discord/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 *.pyc
+.gc/

--- a/discord/README.md
+++ b/discord/README.md
@@ -83,11 +83,64 @@ Create a Discord app in the Developer Portal, then import the app metadata and
 bot token:
 
 ```bash
-gc discord import-app \
-  --application-id 123456789012345678 \
-  --public-key 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef \
-  --bot-token "$DISCORD_BOT_TOKEN"
+bao kv get -field=bot_token internal/kv/example/agents/default/discord |
+  gc discord import-app \
+    --application-id 123456789012345678 \
+    --public-key 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef \
+    --bot-token-file /dev/stdin
 ```
+
+The command above configures the default app. Add separate chat identities
+with stable lowercase app names:
+
+```bash
+bao kv get -field=bot_token internal/kv/example/agents/ollie/discord |
+  gc discord import-app \
+    --app ollie \
+    --application-id 223456789012345678 \
+    --public-key abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789 \
+    --bot-token-file /dev/stdin \
+    --guild-allowlist 323456789012345678 \
+    --channel-allowlist 423456789012345678
+
+bao kv get -field=bot_token internal/kv/example/agents/olivia/discord |
+  gc discord import-app \
+    --app olivia \
+    --application-id 523456789012345678 \
+    --public-key 123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0 \
+    --bot-token-file /dev/stdin \
+    --guild-allowlist 323456789012345678 \
+    --channel-allowlist 423456789012345678
+```
+
+Named apps have independent policy, token files, gateway connections, chat
+bindings, ingress receipts, and health counters. The default token remains at
+`secrets/bot-token.txt`; named tokens use
+`secrets/bot-token-<app>.txt`. All token files are mode `0600`.
+Named imports authenticate the supplied token with Discord and reject it before
+any local mutation unless its bot user ID matches `--application-id`. Omitted
+allowlist flags preserve an app's existing policy during credential rotation.
+An explicitly supplied empty token or token file is an error, so a failed Bao
+read cannot silently update metadata while retaining a stale credential.
+An app name is pinned to its first `application_id`; import a replacement under
+a new app name instead of changing that identity in place. Config and token
+persistence share one lock and roll back together if the credential write
+fails.
+
+Run `gc service restart discord-gateway` after adding, removing, or rotating
+named apps and credentials.
+The gateway starts one connection per configured app and staggers Discord
+identify requests. A failed named connection reconnects independently and does
+not stop the other bots.
+
+Before rolling this pack back to a version without multi-app support, back up
+`.gc/services/discord/data/config.json` and the service secrets directory.
+Older config mutators do not understand the `apps` registry and can remove it
+when they rewrite schema-v1 config; do not run them until the multi-app config
+has been restored or intentionally retired.
+
+Named apps cover direct chat in this release. Interactions, `/gc` commands,
+workflow mappings, and launcher rooms continue to use the default app.
 
 After import, point the app's Interactions Endpoint URL at:
 
@@ -126,6 +179,32 @@ gc discord bind-room --guild-id 223456789012345678 --enable-ambient-read 3234567
 gc discord bind-room --guild-id 223456789012345678 --enable-ambient-read --allow-untargeted-ambient-delivery 323456789012345678 randy
 gc discord bind-room --guild-id 223456789012345678 --enable-peer-fanout 323456789012345678 corp--sky corp--priya
 ```
+
+Bind several bot identities to the same room by selecting an app for each
+binding:
+
+```bash
+gc discord bind-room --app ollie --guild-id 223456789012345678 323456789012345678 teams.lead
+gc discord bind-room --app olivia --guild-id 223456789012345678 323456789012345678 teams.pm
+gc discord bind-room --app sky --guild-id 223456789012345678 323456789012345678 teams.designer
+```
+
+Mentioning a bot routes only through that app's binding. An inbound receipt
+records the app, and `gc discord reply-current` automatically publishes with
+the same app and token. For an operator-controlled send, select it explicitly:
+
+```bash
+gc discord publish --app ollie --binding room:323456789012345678 --body-file ./reply.txt
+```
+
+An exact default binding remains the backward-compatible result when `--app`
+is omitted. If there is no default binding, one matching named binding can be
+resolved automatically; several named candidates are ambiguous and fail
+closed.
+
+Guild and parent-channel policy applies to both the default app and named apps.
+Room bind and publish verify Discord's actual channel scope with the selected
+bot token; `--guild-id` is a consistency hint, not an authority boundary.
 
 Launcher mode is the new room-first UX:
 
@@ -188,6 +267,11 @@ Inbound behavior in v0:
 gc discord status
 gc discord status --json
 ```
+
+Status lists the default and named apps separately, including token presence,
+gateway state, and per-app counters. The gateway endpoint also reports an
+aggregate state without letting one failed bot hide or take down healthy bots.
+Status never prints token values.
 
 ## Workflow Helper
 

--- a/discord/commands/bind-dm/help.md
+++ b/discord/commands/bind-dm/help.md
@@ -2,6 +2,8 @@ Bind a Discord DM channel to exactly one named session.
 
 Examples:
   gc discord bind-dm 123456789012345678 sky
+  gc discord bind-dm --app ollie 223456789012345678 teams.lead
 
 This stores the binding under `.gc/services/discord/data/config.json`.
 Use exact permanent session names.
+Use `--app <name>` when the DM belongs to a named bot.

--- a/discord/commands/bind-room/help.md
+++ b/discord/commands/bind-room/help.md
@@ -7,9 +7,14 @@ Examples:
   gc discord bind-room --guild-id 223456789012345678 --enable-ambient-read --allow-untargeted-ambient-delivery 123456789012345678 randy
   gc discord bind-room --guild-id 223456789012345678 --enable-peer-fanout 123456789012345678 corp--sky corp--priya
   gc discord bind-room --guild-id 223456789012345678 --enable-peer-fanout --allow-untargeted-peer-fanout 123456789012345678 corp--sky corp--priya
+  gc discord bind-room --app ollie --guild-id 223456789012345678 123456789012345678 teams.lead
+  gc discord bind-room --app olivia --guild-id 223456789012345678 123456789012345678 teams.pm
 
 This stores the binding under `.gc/services/discord/data/config.json`.
 Use exact permanent session names.
+`--app <name>` binds the room through that named bot. Multiple named apps can
+bind the same room independently; each receives and replies through its own
+Discord identity.
 Direct `bind-room` routing is mutually exclusive with `gc discord enable-room-launch`
 for the same room.
 

--- a/discord/commands/import-app/help.md
+++ b/discord/commands/import-app/help.md
@@ -1,12 +1,22 @@
 Import Discord app metadata and the bot token into the shared intake state.
 
 Example:
-  gc discord import-app \
-    --application-id 123456789012345678 \
-    --public-key 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef \
-    --bot-token "$DISCORD_BOT_TOKEN"
+  bao kv get -field=bot_token internal/kv/example/agents/default/discord |
+    gc discord import-app \
+      --application-id 123456789012345678 \
+      --public-key 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef \
+      --bot-token-file /dev/stdin
+
+Import an additional chat bot without replacing the default app:
+  bao kv get -field=bot_token internal/kv/example/agents/ollie/discord |
+    gc discord import-app \
+      --app ollie \
+      --application-id 223456789012345678 \
+      --public-key abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789 \
+      --bot-token-file /dev/stdin
 
 Optional fields:
+  --app <name>                 named chat app; omit for the default app
   --command-name <name>         slash command root, default: gc
   --bot-token-file <path>       read the bot token from a file
   --guild-allowlist <id>        allow only specific guild ids; repeatable
@@ -16,6 +26,16 @@ Optional fields:
 The public key is the Discord app's interaction verification key. The bot
 token is stored under the pack state root so the service can sync commands and
 post workflow status updates.
+
+Named apps have isolated metadata, policy, token files, gateway connections,
+and chat bindings. Slash commands and workflow mappings continue to use the
+default app. A supplied named token is verified online against its application
+ID before local config or secrets are changed. Omitted allowlist flags preserve
+existing policy. A named application ID is immutable; import a replacement
+under a new app name. Run `gc service restart discord-gateway` after adding,
+removing, or rotating named apps and credentials so the gateway starts the new
+connection.
+An explicitly supplied empty token file fails before config mutation.
 
 If you want launcher rooms or ambient-read room bindings, also enable
 `Message Content Intent` for the app in the Discord Developer Portal.

--- a/discord/commands/publish/help.md
+++ b/discord/commands/publish/help.md
@@ -9,6 +9,12 @@ Examples:
   gc discord publish --binding room:123456789012345678 --conversation-id 323456789012345678 --trigger 223456789012345678 --body "Reply in thread"
   gc discord publish --binding launch-room:123456789012345678 --source-event-kind discord_human_message --source-ingress-receipt-id in-223456789012345678 --body-file ./reply.txt
   gc discord publish --binding room:123456789012345678 --source-event-kind discord_human_message --source-ingress-receipt-id in-223456789012345678 --source-session corp--sky --body-file ./reply.txt
+  gc discord publish --app ollie --binding room:123456789012345678 --body-file ./reply.txt
+
+`--app <name>` selects a named app binding and its isolated token. If a room
+has more than one named binding and no default binding, an unqualified publish
+fails as ambiguous. `reply-current` inherits the qualified binding from the
+inbound turn and therefore replies as the same bot automatically.
 
 `--conversation-id` overrides the destination channel or thread for this send.
 Use it when the saved room binding is the parent channel but the inbound message

--- a/discord/commands/reply-current/help.md
+++ b/discord/commands/reply-current/help.md
@@ -5,6 +5,9 @@ This is the safest agent-facing Discord reply path. It resolves the latest
 `publish_binding_id`, `publish_conversation_id`, and reply threading metadata,
 then publishes the provided body back to Discord.
 
+For a named app binding, the qualified `publish_binding_id` selects the same
+app and isolated token that received the turn. No `--app` flag is needed.
+
 For launcher-backed root-room turns, the first successful `reply-current`
 automatically creates the Discord thread before posting the message. The agent
 does not need to create or target that thread manually.

--- a/discord/commands/status/help.md
+++ b/discord/commands/status/help.md
@@ -6,5 +6,6 @@ Examples:
   gc discord status --json
 
 The snapshot includes the public interactions URL, the tenant admin URL,
-redacted app configuration, workflow mappings, chat bindings, recent `/gc fix`
-requests, and recent explicit chat publishes.
+redacted default and named app configuration, per-app token presence and
+gateway health, workflow mappings, chat bindings, recent `/gc fix` requests,
+and recent explicit chat publishes. Token values are never shown.

--- a/discord/docs/multi-app-chat.md
+++ b/discord/docs/multi-app-chat.md
@@ -1,0 +1,231 @@
+# Multi-App Discord Chat
+
+## Objective
+
+Allow one Gas City Discord pack instance to host multiple Discord bot
+identities. Each identity must have isolated credentials, app-aware room and
+DM bindings, an independent gateway connection, and same-app replies. Existing
+single-app cities must continue to work without configuration or command
+changes.
+
+The immediate consumer is the Gas City Inc engineering organization: a team
+city can expose its technical lead, product manager, and design partner as
+separate Discord bots in one team channel.
+
+## Supported Surface
+
+The multi-app slice covers chat transport:
+
+- app import and credential storage;
+- room and DM bindings;
+- gateway ingress and per-app policy checks;
+- explicit publish and `reply-current`;
+- per-app gateway status.
+
+Slash-command interactions, workflow channel/rig maps, room launchers, and
+command sync continue to use the legacy/default app in this slice. Named apps
+must use explicit chat bindings. This keeps the bridge small while preserving
+the existing workflow surface unchanged.
+
+## Contract
+
+### Configuration
+
+The existing `app` and top-level `policy` remain the default app. A new `apps`
+registry holds named apps. App names are stable lowercase slugs matching
+`[a-z][a-z0-9_-]{0,31}`.
+
+```json
+{
+  "app": {
+    "application_id": "1484616391729483786",
+    "public_key": "...",
+    "command_name": "gc"
+  },
+  "policy": {
+    "guild_allowlist": ["123"],
+    "channel_allowlist": ["456"],
+    "role_allowlist": []
+  },
+  "apps": {
+    "ollie": {
+      "application_id": "1526662042302287982",
+      "public_key": "...",
+      "policy": {
+        "guild_allowlist": ["123"],
+        "channel_allowlist": ["456"],
+        "role_allowlist": []
+      }
+    }
+  }
+}
+```
+
+Bindings gain an optional `app` field. Legacy bindings without it belong to
+the default app. Named bindings are keyed by app as well as conversation so
+multiple bots can bind the same Discord channel independently.
+
+```json
+{
+  "id": "room:456@app:ollie",
+  "kind": "room",
+  "conversation_id": "456",
+  "guild_id": "123",
+  "app": "ollie",
+  "session_names": ["teams.lead"]
+}
+```
+
+### Secrets
+
+- Default app token: `secrets/bot-token.txt` (unchanged).
+- Named app token: `secrets/bot-token-<app>.txt`.
+- Every token file is mode `0600` inside the mode `0700` secrets directory.
+- Tokens never appear in config, status output, logs, exceptions, or test
+  fixtures that can be committed.
+- Unknown or invalid app names fail closed before a secret path is built.
+- A named app slug is pinned to its first application ID. Replacements use a
+  new slug; only same-identity token rotation is supported.
+
+### Commands
+
+The following optional selector is additive:
+
+```text
+gc discord import-app --app <name> ...
+gc discord bind-room --app <name> ...
+gc discord bind-dm --app <name> ...
+gc discord publish --app <name> ...
+```
+
+Omitting `--app` retains the default app's command shape, configuration, and
+binding-selection behavior when an exact default binding exists. The existing
+top-level policy remains authoritative and is enforced for default-app ingress,
+bind, and publish just as an `apps.<name>.policy` is for named apps. If no
+default binding exists, one matching named binding may be resolved
+automatically; multiple named candidates are ambiguous and require `--app`.
+`reply-current` does not need an app flag for its normal path: it inherits the
+app recorded on the current ingress turn.
+
+### Gateway and routing
+
+- The existing `discord-gateway` service starts one `GatewayWorker` per
+  configured app with a token.
+- A worker receives its app name explicitly; it never infers identity from
+  mutable global config.
+- Gateway status, queues, reconnect state, and counters are isolated per app.
+  One failed connection must not stop another.
+- Ingress receipt IDs are app-scoped for named apps so an ignored copy seen by
+  one bot cannot suppress delivery by the bot that was actually mentioned.
+- Every ingress receipt stores `app`; every publish stores `app`.
+- Binding resolution and allowlist checks always receive the worker app.
+- Room bind and publish verify Discord's actual guild and parent channel rather
+  than trusting caller-supplied binding metadata. Role allowlists remain
+  inbound-user checks.
+- `reply-current` selects the token from the ingress app and rejects missing or
+  stale app references.
+- Bot-authored Discord messages remain ignored, preventing bot loops.
+
+Adding, removing, or rotating an app or credential requires
+`gc service restart discord-gateway` so the service rebuilds its worker
+registry and reconnects with the current token. `gc reload` alone does not
+restart an unchanged gateway service.
+
+## Commands for Development
+
+From the `gascity-packs` repository root:
+
+```sh
+python3 -m unittest discover -s discord/tests -p 'test_discord_*.py'
+python3 -m unittest discord.tests.test_discord_intake_common
+python3 -m unittest discord.tests.test_discord_chat_scripts
+python3 -m unittest discord.tests.test_discord_gateway_service
+```
+
+No dependency is added; implementation uses the Python standard library and
+the existing pack helpers.
+
+## Project Structure
+
+- `discord/scripts/discord_intake_common.py`: config, secret, binding, receipt,
+  publish, policy, and status contracts.
+- `discord/scripts/discord_intake_import.py`: app import CLI.
+- `discord/scripts/discord_chat_bind.py`: app-aware binding CLI.
+- `discord/scripts/discord_chat_publish.py`: explicit app selection.
+- `discord/scripts/discord_chat_reply_current.py`: ingress-app inheritance.
+- `discord/scripts/discord_gateway_service.py`: one worker per app and app-aware
+  ingress.
+- `discord/tests/`: unit and service tests beside the existing Discord suites.
+- `discord/README.md` and command help: public usage and migration guidance.
+
+## Code Style
+
+Keep app identity explicit at boundaries and preserve empty-string default app
+semantics internally:
+
+```python
+app_name = common.validate_app_name(args.app)
+binding = common.resolve_chat_binding(
+    config,
+    kind="room",
+    conversation_id=args.conversation_id,
+    app_name=app_name,
+)
+token = common.load_bot_token(app_name)
+```
+
+Do not use process-wide mutable app identity, silently fall back from an
+unknown named app to default, or catch credential/config errors and continue
+with another token.
+
+## Testing Strategy
+
+Tests are written first and must demonstrate failure on the single-app code.
+Coverage includes:
+
+1. legacy config, token path, binding IDs, status shape, and commands;
+2. normalization and validation of named apps;
+3. token isolation and file modes;
+4. two bindings for the same room under different apps;
+5. app-scoped allowlists and ingress deduplication;
+6. same-app `reply-current` and explicit publish;
+7. independent gateway ready/failure/reconnect status;
+8. unknown and ambiguous app selectors failing closed;
+9. bot-message loop prevention with multiple connected bots.
+
+The full Discord pack test suite runs after each vertical slice. Live rollout
+then verifies every configured identity with status counters and one inbound
+and outbound message in its authorized channel.
+
+## Boundaries
+
+- Always: preserve legacy behavior, validate external/config input, isolate
+  secrets, redact errors/status, and test both happy and failure paths.
+- Ask first: changing the public interactions URL, enabling named-app slash
+  commands, changing the existing default app, or broadening Discord/OpenBao
+  permissions.
+- Never: commit or print tokens, share one token file between named apps,
+  accept ambiguous binding resolution, restart the retired Gas City Inc city,
+  or allow one app failure to terminate all gateway workers.
+
+The additive `apps` registry currently shares schema version 1 with the legacy
+config. Before rolling back to a pack version that does not understand it,
+back up the config and secrets and avoid legacy config-mutating commands, which
+would normalize the unknown registry away.
+
+## Success Criteria
+
+- A city can connect at least three named Discord bots concurrently.
+- Mentioning each bot in the same room routes only to its bound Gas City
+  session.
+- `reply-current` posts as the bot that received the turn.
+- Importing one app cannot overwrite another app's metadata or token.
+- Existing single-app fixtures and live cities require no migration.
+- Status reports each app's health and counters without exposing credentials.
+- The complete Discord test suite passes, followed by live tests with zero
+  failed or dropped messages.
+
+## Open Questions
+
+None for this slice. Named-app interactions and command sync are intentionally
+deferred until there is a consumer for them.

--- a/discord/scripts/discord_chat_bind.py
+++ b/discord/scripts/discord_chat_bind.py
@@ -23,6 +23,7 @@ def _optional_bool(enabled: bool, disabled: bool, *, enable_flag: str, disable_f
 def main(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(description="Bind a Discord conversation to one or more named sessions")
     parser.add_argument("--kind", required=True, choices=("dm", "room"), help="Binding kind")
+    parser.add_argument("--app", default="", help="Optional named app identity")
     parser.add_argument("--guild-id", default="", help="Discord guild id")
     parser.add_argument("--enable-ambient-read", action="store_true", help="Accept unmentioned messages in a bound room")
     parser.add_argument("--disable-ambient-read", action="store_true", help="Disable unmentioned room intake")
@@ -100,18 +101,70 @@ def main(argv: list[str]) -> int:
         raise SystemExit("room policy flags require --kind room")
 
     try:
+        app_name = common.validate_app_name(args.app)
+        loaded_config = common.load_config()
+        channel_metadata: dict[str, Any] | None = None
+        effective_guild_id = str(args.guild_id).strip()
+        if app_name:
+            common.resolve_app_config(loaded_config, app_name)
+        if args.kind == "room":
+            declared_policy_reason = common.outbound_policy_reason(
+                loaded_config,
+                effective_guild_id,
+                args.conversation_id,
+                app_name=app_name,
+            )
+            if declared_policy_reason == "guild_not_allowed" and effective_guild_id:
+                display_name = app_name or "default"
+                raise ValueError(f"Discord app {display_name!r} policy rejects binding: {declared_policy_reason}")
+            app_policy = common.resolve_app_policy(loaded_config, app_name)
+            has_outbound_policy = bool(
+                app_policy.get("guild_allowlist")
+                or app_policy.get("channel_allowlist")
+            )
+            if has_outbound_policy:
+                bot_token = common.load_bot_token(app_name)
+                if not bot_token:
+                    display_name = app_name or "default"
+                    raise ValueError(f"Discord bot token is not configured for app {display_name!r}")
+                channel_scope = common.describe_room_channel_scope(
+                    args.conversation_id,
+                    bot_token=bot_token,
+                )
+                actual_guild_id = str(channel_scope.get("guild_id", "")).strip()
+                if effective_guild_id and actual_guild_id and effective_guild_id != actual_guild_id:
+                    raise ValueError(
+                        f"--guild-id {effective_guild_id!r} does not match Discord channel guild {actual_guild_id!r}"
+                    )
+                effective_guild_id = actual_guild_id or effective_guild_id
+                channel_metadata = common.normalize_binding_channel_metadata(channel_scope)
+                parent_channel_id = (
+                    str(channel_scope.get("thread_parent_id", "")).strip()
+                    or args.conversation_id
+                )
+                policy_rejection = common.outbound_policy_reason(
+                    loaded_config,
+                    effective_guild_id,
+                    parent_channel_id,
+                    app_name=app_name,
+                )
+                if policy_rejection:
+                    display_name = app_name or "default"
+                    raise ValueError(f"Discord app {display_name!r} policy rejects binding: {policy_rejection}")
         config = common.set_chat_binding(
-            common.load_config(),
+            loaded_config,
             args.kind,
             args.conversation_id,
             args.session_name,
-            guild_id=args.guild_id,
+            guild_id=effective_guild_id,
+            app_name=app_name,
             policy=room_policy or None,
+            channel_metadata=channel_metadata,
         )
-    except ValueError as exc:
+    except (ValueError, common.DiscordAPIError) as exc:
         raise SystemExit(str(exc)) from exc
 
-    binding = common.resolve_chat_binding(config, common.chat_binding_id(args.kind, args.conversation_id))
+    binding = common.resolve_chat_binding(config, common.chat_binding_id(args.kind, args.conversation_id, app_name))
     print(json.dumps(binding or {}, indent=2, sort_keys=True))
     return 0
 

--- a/discord/scripts/discord_chat_publish.py
+++ b/discord/scripts/discord_chat_publish.py
@@ -41,6 +41,7 @@ def _hydrate_launch_source_context(binding: dict[str, object], source_context: d
 def main(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(description="Publish a Discord-visible message through a saved chat binding")
     parser.add_argument("--binding", required=True, help="Binding id such as room:1234567890")
+    parser.add_argument("--app", default="", help="Optional named app identity")
     parser.add_argument("--conversation-id", default="", help="Discord channel or thread id to publish into")
     parser.add_argument("--trigger", default="", help="Original Discord message id for reply threading")
     parser.add_argument("--reply-to", default="", help="Explicit Discord message id to reply to")
@@ -71,7 +72,10 @@ def main(argv: list[str]) -> int:
 
     body = _load_body(args)
     config = common.load_config()
-    binding = common.resolve_publish_route(config, args.binding)
+    try:
+        binding = common.resolve_publish_route(config, args.binding, app_name=args.app)
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
     if not binding:
         raise SystemExit(f"binding not found: {args.binding}")
 

--- a/discord/scripts/discord_chat_reply_current.py
+++ b/discord/scripts/discord_chat_reply_current.py
@@ -44,7 +44,10 @@ def main(argv: list[str]) -> int:
 
     if binding_id:
         config = common.load_config()
-        binding = common.resolve_publish_route(config, binding_id)
+        try:
+            binding = common.resolve_publish_route(config, binding_id)
+        except ValueError as exc:
+            raise SystemExit(str(exc)) from exc
         if not binding:
             raise SystemExit(f"binding not found: {binding_id}")
         source_identity: dict[str, str] = {}

--- a/discord/scripts/discord_gateway_service.py
+++ b/discord/scripts/discord_gateway_service.py
@@ -30,17 +30,27 @@ ALIAS_PATTERN = re.compile(r"(?<![A-Za-z0-9_<])@([a-z0-9][a-z0-9_-]*)", re.IGNOR
 DISCORD_RESERVED_MENTIONS = {"everyone", "here"}
 MAX_STATUS_PREVIEW = 160
 GATEWAY_WORKER_THREADS = 8
+GATEWAY_NAMED_WORKER_THREADS = 1
 GATEWAY_MAX_PENDING_MESSAGES = 128
+GATEWAY_WORKER_STOP_TIMEOUT_SECONDS = 5.0
 RECONNECT_BASE_DELAY_SECONDS = 5
 RECONNECT_MAX_DELAY_SECONDS = 60
+GATEWAY_IDENTIFY_STAGGER_SECONDS = 5.5
 PRUNE_INTERVAL_SECONDS = 60
+PENDING_RECOVERY_INTERVAL_SECONDS = 60
 HEALTH_RECONNECT_GRACE_SECONDS = 90
 GC_API_HEALTH_TTL_SECONDS = 30
 GC_API_HEALTH_PROBE_TIMEOUT_SECONDS = 3.0
 CHANNEL_INFO_TTL_SECONDS = 5 * 60
 MAX_FRAME_BYTES = 16 * 1024 * 1024
-STALE_PROCESSING_RECEIPT_SECONDS = 2 * 60
+PROCESSING_RECEIPT_STALE_MARGIN_SECONDS = 60
+STALE_PROCESSING_RECEIPT_SECONDS = (
+    common.GC_API_REQUEST_TIMEOUT_SECONDS
+    + common.GC_API_ASYNC_RESULT_TIMEOUT_SECONDS
+    + PROCESSING_RECEIPT_STALE_MARGIN_SECONDS
+)
 FAILED_RECEIPT_RETRY_SECONDS = 60
+INGRESS_DELIVERY_PROTOCOL_VERSION = 2
 WEBSOCKET_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
 
 
@@ -146,6 +156,27 @@ def bot_was_mentioned(message: dict[str, Any], bot_user_id: str) -> bool:
     return any(str(item.get("id", "")).strip() == bot_user_id for item in mentions if isinstance(item, dict))
 
 
+def configured_bot_mentions(message: dict[str, Any], config: dict[str, Any]) -> set[str]:
+    configured_bot_ids: set[str] = set()
+    for app_name in common.list_app_names(config):
+        try:
+            application_id = str(common.resolve_app_config(config, app_name).get("application_id", "")).strip()
+        except ValueError:
+            continue
+        if application_id:
+            configured_bot_ids.add(application_id)
+    mentions = message.get("mentions") or []
+    if not isinstance(mentions, list):
+        return set()
+    return {
+        mention_id
+        for item in mentions
+        if isinstance(item, dict)
+        for mention_id in [str(item.get("id", "")).strip()]
+        if mention_id in configured_bot_ids
+    }
+
+
 def websocket_accept_value(key: str) -> str:
     digest = hashlib.sha1((str(key) + WEBSOCKET_GUID).encode("utf-8")).digest()
     return base64.b64encode(digest).decode("ascii")
@@ -214,11 +245,16 @@ def casefold_lookup(values: list[str]) -> tuple[dict[str, str], set[str]]:
     return lookup, collisions
 
 
-def message_ingress_id(message: dict[str, Any]) -> str:
+def message_ingress_id(message: dict[str, Any], app_name: str = "") -> str:
     message_id = str(message.get("id", "")).strip()
     if message_id:
-        return f"in-{message_id}"
-    return f"in-{int(time.time() * 1000)}"
+        ingress_id = f"in-{message_id}"
+    else:
+        ingress_id = f"in-{int(time.time() * 1000)}"
+    normalized_app_name = common.validate_app_name(app_name)
+    if normalized_app_name:
+        return f"{ingress_id}-app-{normalized_app_name}"
+    return ingress_id
 
 
 def conversation_fields(message: dict[str, Any], channel_info: dict[str, Any]) -> tuple[str, str]:
@@ -242,7 +278,12 @@ def ingress_preview(message: dict[str, Any], bot_user_id: str) -> str:
     return summarize_body(strip_bot_mentions(str(message.get("content", "")), bot_user_id))
 
 
-def fetch_message_via_rest(channel_id: str, message_id: str) -> dict[str, Any]:
+def fetch_message_via_rest(
+    channel_id: str,
+    message_id: str,
+    *,
+    bot_token: str | None = None,
+) -> dict[str, Any]:
     normalized_channel_id = str(channel_id).strip()
     normalized_message_id = str(message_id).strip()
     if not normalized_channel_id or not normalized_message_id:
@@ -250,17 +291,22 @@ def fetch_message_via_rest(channel_id: str, message_id: str) -> dict[str, Any]:
     quoted_channel = urllib.parse.quote(normalized_channel_id)
     quoted_message = urllib.parse.quote(normalized_message_id)
     try:
-        payload = common.discord_api_request("GET", f"/channels/{quoted_channel}/messages/{quoted_message}")
+        path = f"/channels/{quoted_channel}/messages/{quoted_message}"
+        if bot_token is None:
+            payload = common.discord_api_request("GET", path)
+        else:
+            payload = common.discord_api_request("GET", path, bot_token=bot_token)
         if isinstance(payload, dict) and str(payload.get("id", "")).strip() == normalized_message_id:
             return payload
     except common.DiscordAPIError as exc:
         if int(getattr(exc, "status_code", 0) or 0) != 404:
             return {}
     try:
-        payload = common.discord_api_request(
-            "GET",
-            f"/channels/{quoted_channel}/messages?around={quoted_message}&limit=3",
-        )
+        path = f"/channels/{quoted_channel}/messages?around={quoted_message}&limit=3"
+        if bot_token is None:
+            payload = common.discord_api_request("GET", path)
+        else:
+            payload = common.discord_api_request("GET", path, bot_token=bot_token)
     except common.DiscordAPIError:
         return {}
     if isinstance(payload, list):
@@ -270,7 +316,11 @@ def fetch_message_via_rest(channel_id: str, message_id: str) -> dict[str, Any]:
     return {}
 
 
-def recover_message_for_routing(message: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
+def recover_message_for_routing(
+    message: dict[str, Any],
+    *,
+    bot_token: str | None = None,
+) -> tuple[dict[str, Any], dict[str, Any]]:
     recovered = dict(message)
     gateway_content = raw_message_content(message)
     debug = {
@@ -287,7 +337,7 @@ def recover_message_for_routing(message: dict[str, Any]) -> tuple[dict[str, Any]
     if not needs_rest:
         return recovered, debug
     debug["rest_fetch_attempted"] = True
-    fetched = fetch_message_via_rest(channel_id, message_id)
+    fetched = fetch_message_via_rest(channel_id, message_id, bot_token=bot_token)
     if not isinstance(fetched, dict) or not fetched:
         debug["content_source"] = "gateway_empty_rest_unavailable"
         return recovered, debug
@@ -500,18 +550,23 @@ def probe_gc_api_health(runtime_state: "GatewayRuntimeState") -> bool:
     return True
 
 
-def resolve_binding(config: dict[str, Any], message: dict[str, Any]) -> tuple[dict[str, Any] | None, dict[str, Any]]:
+def resolve_binding(
+    config: dict[str, Any],
+    message: dict[str, Any],
+    app_name: str = "",
+) -> tuple[dict[str, Any] | None, dict[str, Any]]:
+    normalized_app_name = common.validate_app_name(app_name)
     guild_id = str(message.get("guild_id", "")).strip()
     channel_id = str(message.get("channel_id", "")).strip()
     channel_info: dict[str, Any] = {}
-    binding_id = common.chat_binding_id("dm" if not guild_id else "room", channel_id)
+    binding_id = common.chat_binding_id("dm" if not guild_id else "room", channel_id, normalized_app_name)
     binding = common.resolve_chat_binding(config, binding_id)
     if not guild_id:
         return binding, channel_info
     if binding:
         binding = dict(binding)
         if binding_allows_ambient_read(binding):
-            cached_binding = cached_ambient_room_binding(channel_id)
+            cached_binding = cached_ambient_room_binding(channel_id, normalized_app_name)
             if cached_binding:
                 binding = cached_binding
         channel_info = binding_channel_info(binding)
@@ -525,7 +580,7 @@ def resolve_binding(config: dict[str, Any], message: dict[str, Any]) -> tuple[di
                 return binding, channel_info
         channel_type_raw = binding.get("channel_type", None)
         if channel_type_raw is None:
-            bot_token = common.load_bot_token()
+            bot_token = common.load_bot_token(normalized_app_name)
             if not bot_token:
                 return binding, {}
             try:
@@ -541,7 +596,7 @@ def resolve_binding(config: dict[str, Any], message: dict[str, Any]) -> tuple[di
             channel_type = 0
         if channel_type not in common.THREAD_CHANNEL_TYPES:
             return binding, {}
-        bot_token = common.load_bot_token()
+        bot_token = common.load_bot_token(normalized_app_name)
         if not bot_token:
             return binding, channel_info
         try:
@@ -551,7 +606,7 @@ def resolve_binding(config: dict[str, Any], message: dict[str, Any]) -> tuple[di
         binding.update(common.normalize_binding_channel_metadata(looked_up_channel_info))
         persist_binding_channel_metadata(binding)
         return binding, binding_channel_info(binding)
-    bot_token = common.load_bot_token()
+    bot_token = common.load_bot_token(normalized_app_name)
     if not bot_token:
         return None, channel_info
     try:
@@ -561,13 +616,13 @@ def resolve_binding(config: dict[str, Any], message: dict[str, Any]) -> tuple[di
             return None, {}
         raise
     if not isinstance(channel_info, dict):
-        return common.resolve_chat_binding(config, common.chat_binding_id("room", channel_id)), {}
+        return common.resolve_chat_binding(config, common.chat_binding_id("room", channel_id, normalized_app_name)), {}
     parent_id = str(channel_info.get("parent_id", "")).strip()
     if parent_id and parent_id != channel_id:
-        binding = common.resolve_chat_binding(config, common.chat_binding_id("room", parent_id))
+        binding = common.resolve_chat_binding(config, common.chat_binding_id("room", parent_id, normalized_app_name))
         if binding:
             return binding, channel_info
-    return common.resolve_chat_binding(config, common.chat_binding_id("room", channel_id)), channel_info
+    return common.resolve_chat_binding(config, common.chat_binding_id("room", channel_id, normalized_app_name)), channel_info
 
 
 def resolve_targets(
@@ -621,15 +676,24 @@ def binding_allows_untargeted_ambient_delivery(binding: dict[str, Any] | None) -
     return bool(common.binding_peer_policy(binding).get("allow_untargeted_ambient_delivery"))
 
 
-def explicit_room_binding(config: dict[str, Any], channel_id: str) -> dict[str, Any] | None:
-    return common.resolve_chat_binding(config, common.chat_binding_id("room", channel_id))
+def explicit_room_binding(
+    config: dict[str, Any],
+    channel_id: str,
+    app_name: str = "",
+) -> dict[str, Any] | None:
+    return common.resolve_chat_binding(config, common.chat_binding_id("room", channel_id, app_name))
 
 
-def bound_room_claims_message(config: dict[str, Any], channel_id: str, parent_id: str = "") -> bool:
-    if explicit_room_binding(config, channel_id):
+def bound_room_claims_message(
+    config: dict[str, Any],
+    channel_id: str,
+    parent_id: str = "",
+    app_name: str = "",
+) -> bool:
+    if explicit_room_binding(config, channel_id, app_name):
         return True
     parent = str(parent_id).strip()
-    if parent and explicit_room_binding(config, parent):
+    if parent and explicit_room_binding(config, parent, app_name):
         return True
     return False
 
@@ -646,13 +710,18 @@ def ambient_bindings_config_signature() -> tuple[int, int, int] | None:
     )
 
 
-def cached_ambient_room_binding(channel_id: str) -> dict[str, Any] | None:
+def ambient_binding_cache_key(channel_id: str, app_name: str = "") -> str:
+    return f"{common.validate_app_name(app_name)}\x00{str(channel_id).strip()}"
+
+
+def cached_ambient_room_binding(channel_id: str, app_name: str = "") -> dict[str, Any] | None:
+    cache_key = ambient_binding_cache_key(channel_id, app_name)
     config_signature = ambient_bindings_config_signature()
     with AMBIENT_ROOM_BINDINGS_CACHE_LOCK:
         if AMBIENT_ROOM_BINDINGS_CACHE.get("config_signature") == config_signature:
             bindings = AMBIENT_ROOM_BINDINGS_CACHE.get("bindings", {})
             if isinstance(bindings, dict):
-                binding = bindings.get(channel_id)
+                binding = bindings.get(cache_key)
                 return dict(binding) if isinstance(binding, dict) else None
 
     with AMBIENT_ROOM_BINDINGS_FETCH_LOCK:
@@ -661,7 +730,7 @@ def cached_ambient_room_binding(channel_id: str) -> dict[str, Any] | None:
             if AMBIENT_ROOM_BINDINGS_CACHE.get("config_signature") == config_signature:
                 bindings = AMBIENT_ROOM_BINDINGS_CACHE.get("bindings", {})
                 if isinstance(bindings, dict):
-                    binding = bindings.get(channel_id)
+                    binding = bindings.get(cache_key)
                     return dict(binding) if isinstance(binding, dict) else None
 
         bindings: dict[str, dict[str, Any]] = {}
@@ -676,12 +745,12 @@ def cached_ambient_room_binding(channel_id: str) -> dict[str, Any] | None:
                 continue
             conversation_id = str(binding.get("conversation_id", "")).strip()
             if conversation_id:
-                bindings[conversation_id] = dict(binding)
+                bindings[ambient_binding_cache_key(conversation_id, str(binding.get("app", "")))] = dict(binding)
 
         with AMBIENT_ROOM_BINDINGS_CACHE_LOCK:
             AMBIENT_ROOM_BINDINGS_CACHE["config_signature"] = config_signature
             AMBIENT_ROOM_BINDINGS_CACHE["bindings"] = bindings
-    binding = bindings.get(channel_id)
+    binding = bindings.get(cache_key)
     return dict(binding) if isinstance(binding, dict) else None
 
 
@@ -835,6 +904,337 @@ def persist_ingress_receipt(payload: dict[str, Any]) -> dict[str, Any]:
     return common.save_chat_ingress(payload)
 
 
+def ingress_delivery_status(targets: list[dict[str, Any]], fallback: str = "pending") -> str:
+    statuses = [str(target.get("status", "")).strip() for target in targets if isinstance(target, dict)]
+    if not statuses:
+        return fallback
+    if any(status in {"pending", "submitting", "awaiting_result"} for status in statuses):
+        return "pending"
+    if "delivery_unknown" in statuses:
+        return "delivery_unknown"
+    failure_count = sum(status == "failed" for status in statuses)
+    if failure_count == 0:
+        return "delivered"
+    if failure_count < len(statuses):
+        return "partial_failed"
+    return "failed"
+
+
+def persist_ingress_target_patch(
+    receipt: dict[str, Any],
+    target_index: int,
+    patch: dict[str, Any],
+) -> dict[str, Any]:
+    targets = [dict(target) for target in receipt.get("targets", []) if isinstance(target, dict)]
+    if target_index < 0 or target_index >= len(targets):
+        raise IndexError(f"ingress target index {target_index} is out of range")
+    targets[target_index].update(patch)
+    updated = {**receipt, "targets": targets}
+    updated["status"] = ingress_delivery_status(targets, str(receipt.get("status", "pending")).strip() or "pending")
+    return persist_ingress_receipt(updated)
+
+
+def ingress_delivery_protocol_version(receipt: dict[str, Any]) -> int:
+    try:
+        return int(receipt.get("delivery_protocol_version", 0) or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def ingress_routing_delivery_order(receipt: dict[str, Any]) -> str:
+    message_id = str(receipt.get("discord_message_id", "")).strip()
+    if message_id.isdigit():
+        return f"snowflake:{int(message_id):020d}"
+    return ":".join(
+        [
+            "timestamp",
+            str(receipt.get("created_at", "")).strip(),
+            message_id,
+            str(receipt.get("ingress_id", "")).strip(),
+        ]
+    )
+
+
+def apply_ingress_routing_state(receipt: dict[str, Any]) -> tuple[dict[str, Any], bool]:
+    if ingress_delivery_protocol_version(receipt) != INGRESS_DELIVERY_PROTOCOL_VERSION:
+        return receipt, False
+    if str(receipt.get("status", "")).strip() != "delivered":
+        return receipt, False
+    if str(receipt.get("route_kind", "")).strip() != "room_launch_thread":
+        return receipt, False
+    if str(receipt.get("routing_state_applied_at", "")).strip():
+        return receipt, False
+    launch_id = str(receipt.get("launch_id", "")).strip()
+    qualified_handle = str(receipt.get("qualified_handle", "")).strip()
+    if not launch_id or not qualified_handle:
+        return receipt, False
+    updated_launch = common.set_room_launch_last_addressed(
+        launch_id,
+        qualified_handle,
+        delivery_order=ingress_routing_delivery_order(receipt),
+    )
+    if not isinstance(updated_launch, dict):
+        return receipt, False
+    updated_receipt = persist_ingress_receipt(
+        {
+            **receipt,
+            "routing_state_applied_at": common.utcnow(),
+        }
+    )
+    return updated_receipt, True
+
+
+def resume_ingress_delivery(
+    receipt: dict[str, Any],
+    *,
+    cancel_event: threading.Event | None = None,
+    delivery_envelopes: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    current = dict(receipt)
+    targets = [dict(target) for target in current.get("targets", []) if isinstance(target, dict)]
+    for target_index, target in enumerate(targets):
+        if cancel_event is not None and cancel_event.is_set():
+            break
+        target_status = str(target.get("status", "")).strip()
+        if target_status == "submitting":
+            current = persist_ingress_target_patch(
+                current,
+                target_index,
+                {"status": "delivery_unknown", "reason": "missing_async_correlation"},
+            )
+            targets = [dict(item) for item in current.get("targets", []) if isinstance(item, dict)]
+            continue
+        if target_status == "pending":
+            session_name = str(target.get("session_name", "")).strip()
+            envelope = str((delivery_envelopes or {}).get(session_name, ""))
+            idempotency_key = str(target.get("idempotency_key", "")).strip()
+            intent = str(target.get("intent", "default")).strip() or "default"
+            if not session_name or not envelope:
+                current = persist_ingress_target_patch(
+                    current,
+                    target_index,
+                    {"status": "delivery_unknown", "reason": "delivery_payload_not_retained"},
+                )
+                targets = [dict(item) for item in current.get("targets", []) if isinstance(item, dict)]
+                continue
+            current = persist_ingress_target_patch(current, target_index, {"status": "submitting"})
+
+            def record_async_acceptance(accepted: dict[str, Any], index: int = target_index) -> None:
+                nonlocal current
+                current = persist_ingress_target_patch(
+                    current,
+                    index,
+                    {
+                        "status": "awaiting_result",
+                        "request_id": str(accepted.get("request_id", "")).strip(),
+                        "event_cursor": str(accepted.get("event_cursor", "")).strip(),
+                        "intent": str(accepted.get("intent", intent)).strip() or intent,
+                        "response": accepted.get("response") if isinstance(accepted.get("response"), dict) else {},
+                    },
+                )
+
+            def record_async_terminal(evidence: dict[str, Any], index: int = target_index) -> None:
+                nonlocal current
+                status = "delivered" if str(evidence.get("status", "")).strip() == "succeeded" else "failed"
+                current = persist_ingress_target_patch(
+                    current,
+                    index,
+                    {"status": status, "terminal_evidence": evidence},
+                )
+
+            try:
+                response = common.deliver_session_message(
+                    session_name,
+                    envelope,
+                    idempotency_key=idempotency_key,
+                    intent=intent,
+                    cancel_event=cancel_event,
+                    on_async_accepted=record_async_acceptance,
+                    on_async_terminal=record_async_terminal,
+                )
+            except common.GCAPIRequestCancelled as exc:
+                target_now = current["targets"][target_index]
+                status = "awaiting_result" if str(target_now.get("request_id", "")).strip() else "delivery_unknown"
+                current = persist_ingress_target_patch(
+                    current,
+                    target_index,
+                    {"status": status, "last_wait_error": str(exc)},
+                )
+                break
+            except common.GCAPIResultUnknown as exc:
+                target_now = current["targets"][target_index]
+                status = "awaiting_result" if str(target_now.get("request_id", "")).strip() else "delivery_unknown"
+                current = persist_ingress_target_patch(
+                    current,
+                    target_index,
+                    {"status": status, "last_wait_error": str(exc)},
+                )
+            except common.GCAPIRequestFailed as exc:
+                current = persist_ingress_target_patch(
+                    current,
+                    target_index,
+                    {
+                        "status": "failed",
+                        "error": str(exc),
+                        "terminal_evidence": {"status": "failed", "payload": exc.payload},
+                    },
+                )
+            except common.GCAPIError as exc:
+                current = persist_ingress_target_patch(
+                    current,
+                    target_index,
+                    {"status": "failed", "error": str(exc)},
+                )
+            else:
+                if str(current["targets"][target_index].get("status", "")).strip() != "delivered":
+                    current = persist_ingress_target_patch(
+                        current,
+                        target_index,
+                        {
+                            "status": "delivered",
+                            "response": response,
+                            "terminal_evidence": {
+                                "status": "succeeded",
+                                "source": "http",
+                                "payload": response,
+                            },
+                        },
+                    )
+            targets = [dict(item) for item in current.get("targets", []) if isinstance(item, dict)]
+            continue
+        if target_status != "awaiting_result":
+            continue
+        request_id = str(target.get("request_id", "")).strip()
+        event_cursor = str(target.get("event_cursor", "")).strip()
+        if not request_id or not event_cursor:
+            current = persist_ingress_target_patch(
+                current,
+                target_index,
+                {
+                    "status": "delivery_unknown",
+                    "reason": "missing_async_correlation",
+                },
+            )
+            continue
+        intent = str(target.get("intent", "default")).strip() or "default"
+        try:
+            terminal_payload = common.resume_session_message_delivery(
+                request_id,
+                event_cursor,
+                intent=intent,
+                timeout=common.GC_API_ASYNC_RESULT_TIMEOUT_SECONDS,
+                cancel_event=cancel_event,
+            )
+        except common.GCAPIRequestCancelled as exc:
+            current = persist_ingress_target_patch(
+                current,
+                target_index,
+                {"status": "awaiting_result", "last_wait_error": str(exc)},
+            )
+            break
+        except common.GCAPIResultUnknown as exc:
+            current = persist_ingress_target_patch(
+                current,
+                target_index,
+                {"status": "awaiting_result", "last_wait_error": str(exc)},
+            )
+        except common.GCAPIRequestFailed as exc:
+            current = persist_ingress_target_patch(
+                current,
+                target_index,
+                {
+                    "status": "failed",
+                    "error": str(exc),
+                    "terminal_evidence": {"status": "failed", "payload": exc.payload},
+                },
+            )
+        except common.GCAPIError as exc:
+            current = persist_ingress_target_patch(
+                current,
+                target_index,
+                {"status": "failed", "error": str(exc)},
+            )
+        else:
+            current = persist_ingress_target_patch(
+                current,
+                target_index,
+                {
+                    "status": "delivered",
+                    "terminal_evidence": {"status": "succeeded", "payload": terminal_payload},
+                },
+            )
+        targets = [dict(item) for item in current.get("targets", []) if isinstance(item, dict)]
+    return current
+
+
+def recover_pending_ingress_receipts(
+    *,
+    bot_user_id: str,
+    app_name: str = "",
+    cancel_event: threading.Event | None = None,
+) -> list[str]:
+    del bot_user_id
+    normalized_app_name = common.validate_app_name(app_name)
+    recovered: list[str] = []
+    for receipt in common.list_chat_ingress():
+        if cancel_event is not None and cancel_event.is_set():
+            break
+        if str(receipt.get("app", "")).strip() != normalized_app_name:
+            continue
+        receipt_status = str(receipt.get("status", "")).strip()
+        needs_routing_state = (
+            ingress_delivery_protocol_version(receipt) == INGRESS_DELIVERY_PROTOCOL_VERSION
+            and receipt_status == "delivered"
+            and str(receipt.get("route_kind", "")).strip() == "room_launch_thread"
+            and not str(receipt.get("routing_state_applied_at", "")).strip()
+        )
+        if receipt_status != "pending" and not needs_routing_state:
+            continue
+        ingress_id = str(receipt.get("ingress_id", "")).strip()
+        if not ingress_id:
+            continue
+        process_lock = ingress_process_lock(ingress_id)
+        if not process_lock.acquire(blocking=False):
+            continue
+        try:
+            latest = common.load_chat_ingress(ingress_id) or receipt
+            latest_status = str(latest.get("status", "")).strip()
+            if latest_status == "delivered":
+                _, applied = apply_ingress_routing_state(latest)
+                if applied:
+                    recovered.append(ingress_id)
+                continue
+            if latest_status != "pending":
+                continue
+            protocol_version = ingress_delivery_protocol_version(latest)
+            targets = [dict(target) for target in latest.get("targets", []) if isinstance(target, dict)]
+            if protocol_version == INGRESS_DELIVERY_PROTOCOL_VERSION and any(
+                str(target.get("status", "")).strip() in {"pending", "submitting", "awaiting_result"}
+                for target in targets
+            ):
+                latest = resume_ingress_delivery(latest, cancel_event=cancel_event)
+                latest, _ = apply_ingress_routing_state(latest)
+            elif utc_age_seconds(str(latest.get("updated_at", "")).strip()) >= STALE_PROCESSING_RECEIPT_SECONDS:
+                for target in targets:
+                    if str(target.get("status", "")).strip() in {"delivered", "failed"}:
+                        continue
+                    target["status"] = "delivery_unknown"
+                    target["reason"] = "missing_async_correlation"
+                latest = {
+                    **latest,
+                    "targets": targets,
+                    "status": "delivery_unknown",
+                    "reason": "missing_async_correlation",
+                }
+                persist_ingress_receipt(latest)
+            else:
+                continue
+            recovered.append(ingress_id)
+        finally:
+            process_lock.release()
+    return recovered
+
+
 def save_rejected_ingress_receipt(
     message: dict[str, Any],
     bot_user_id: str,
@@ -842,8 +1242,10 @@ def save_rejected_ingress_receipt(
     status: str,
     reason: str,
     message_debug: dict[str, Any] | None = None,
+    app_name: str = "",
 ) -> tuple[bool, dict[str, Any]]:
-    ingress_id = message_ingress_id(message)
+    normalized_app_name = common.validate_app_name(app_name)
+    ingress_id = message_ingress_id(message, normalized_app_name)
     return common.save_chat_ingress_if_absent(
         {
             "ingress_id": ingress_id,
@@ -858,6 +1260,7 @@ def save_rejected_ingress_receipt(
             "reason": reason,
             "message_debug": dict(message_debug or {}),
             "targets": [],
+            "app": normalized_app_name,
         }
     )
 
@@ -869,14 +1272,17 @@ def reject_ingress_before_processing(
     status: str,
     reason: str,
     message_debug: dict[str, Any] | None = None,
+    app_name: str = "",
 ) -> dict[str, Any]:
-    ingress_id = message_ingress_id(message)
+    normalized_app_name = common.validate_app_name(app_name)
+    ingress_id = message_ingress_id(message, normalized_app_name)
     claimed, receipt = save_rejected_ingress_receipt(
         message,
         bot_user_id,
         status=status,
         reason=reason,
         message_debug=message_debug,
+        app_name=normalized_app_name,
     )
     if claimed:
         return {"status": status, "reason": reason, "ingress_id": ingress_id, "receipt": receipt}
@@ -896,6 +1302,7 @@ def reject_ingress_before_processing(
                 "reason": str(receipt.get("reason", "")).strip() or "ingress_claim_unreadable",
                 "message_debug": dict(message_debug or {}),
                 "targets": [],
+                "app": normalized_app_name,
             }
         )
         return {"status": "failed_claim_conflict", "ingress_id": ingress_id, "receipt": receipt}
@@ -910,6 +1317,7 @@ def process_room_launch_message(
     bot_user_id: str,
     ingress_id: str,
     message_debug: dict[str, Any] | None = None,
+    cancel_event: threading.Event | None = None,
 ) -> dict[str, Any]:
     body = strip_bot_mentions(str(message.get("content", "")), bot_user_id)
     if not body:
@@ -1049,19 +1457,6 @@ def process_room_launch_message(
         return {"status": "failed_lookup", "ingress_id": ingress_id, "receipt": receipt}
 
     target_selector = participant_delivery_selector(launch)
-    receipt = persist_ingress_receipt(
-        {
-            **base_receipt,
-            "binding_id": str(launcher.get("id", "")).strip(),
-            "status": "pending",
-            "delivery": "targeted",
-            "route_kind": "room_launch",
-            "launch_id": launch_id,
-            "mentioned_handles": mentioned_handles,
-            "qualified_handle": qualified_handle,
-            "targets": [{"session_name": target_selector, "status": "pending"}],
-        }
-    )
     envelope = build_room_launch_envelope(
         launcher=launcher,
         launch=launch,
@@ -1070,21 +1465,34 @@ def process_room_launch_message(
         mentioned_handles=mentioned_handles,
         ingress_id=ingress_id,
     )
-    try:
-        response = common.deliver_session_message(
-            target_selector,
-            envelope,
-            idempotency_key=f"ingress:{ingress_id}:target:{target_selector}",
-        )
-    except common.GCAPIError as exc:
-        receipt["status"] = "failed"
-        receipt["targets"] = [{"session_name": target_selector, "status": "failed", "error": str(exc)}]
-        receipt = persist_ingress_receipt(receipt)
-        return {"status": "failed", "ingress_id": ingress_id, "receipt": receipt}
-    receipt["status"] = "delivered"
-    receipt["targets"] = [{"session_name": target_selector, "status": "delivered", "response": response}]
-    receipt = persist_ingress_receipt(receipt)
-    return {"status": "delivered", "ingress_id": ingress_id, "receipt": receipt}
+    idempotency_key = f"ingress:{ingress_id}:target:{target_selector}"
+    receipt = persist_ingress_receipt(
+        {
+            **base_receipt,
+            "binding_id": str(launcher.get("id", "")).strip(),
+            "status": "pending",
+            "delivery_protocol_version": INGRESS_DELIVERY_PROTOCOL_VERSION,
+            "delivery": "targeted",
+            "route_kind": "room_launch",
+            "launch_id": launch_id,
+            "mentioned_handles": mentioned_handles,
+            "qualified_handle": qualified_handle,
+            "targets": [
+                {
+                    "session_name": target_selector,
+                    "status": "pending",
+                    "intent": "default",
+                    "idempotency_key": idempotency_key,
+                }
+            ],
+        }
+    )
+    receipt = resume_ingress_delivery(
+        receipt,
+        cancel_event=cancel_event,
+        delivery_envelopes={target_selector: envelope},
+    )
+    return {"status": receipt["status"], "ingress_id": ingress_id, "receipt": receipt}
 
 
 def process_room_launch_thread_message(
@@ -1096,6 +1504,7 @@ def process_room_launch_thread_message(
     bot_user_id: str,
     ingress_id: str,
     message_debug: dict[str, Any] | None = None,
+    cancel_event: threading.Event | None = None,
 ) -> dict[str, Any]:
     refreshed_launch = common.touch_room_launch(str(launch.get("launch_id", "")).strip())
     if isinstance(refreshed_launch, dict):
@@ -1195,20 +1604,6 @@ def process_room_launch_thread_message(
         return {"status": "failed_lookup", "ingress_id": ingress_id, "receipt": receipt}
     target_selector = participant_delivery_selector(target_participant)
 
-    receipt = persist_ingress_receipt(
-        {
-            **base_receipt,
-            "binding_id": str(launcher.get("id", "")).strip(),
-            "status": "pending",
-            "delivery": "targeted",
-            "route_kind": "room_launch_thread",
-            "launch_id": str(launch.get("launch_id", "")).strip(),
-            "routing_mode": routing_mode,
-            "mentioned_handles": mentioned_handles,
-            "qualified_handle": target_handle,
-            "targets": [{"session_name": target_selector, "status": "pending"}],
-        }
-    )
     envelope = build_room_launch_thread_envelope(
         launcher=launcher,
         launch=launch,
@@ -1220,28 +1615,46 @@ def process_room_launch_thread_message(
         routing_mode=routing_mode,
         reply_to_id=reply_to_id,
     )
-    try:
-        response = common.deliver_session_message(
-            target_selector,
-            envelope,
-            idempotency_key=f"ingress:{ingress_id}:target:{target_selector}",
-        )
-    except common.GCAPIError as exc:
-        receipt["status"] = "failed"
-        receipt["targets"] = [{"session_name": target_selector, "status": "failed", "error": str(exc)}]
-        receipt = persist_ingress_receipt(receipt)
-        return {"status": "failed", "ingress_id": ingress_id, "receipt": receipt}
-    updated_launch = common.set_room_launch_last_addressed(str(launch.get("launch_id", "")).strip(), target_handle)
-    if isinstance(updated_launch, dict):
-        launch = updated_launch
-    receipt["status"] = "delivered"
-    receipt["targets"] = [{"session_name": target_selector, "status": "delivered", "response": response}]
-    receipt = persist_ingress_receipt(receipt)
-    return {"status": "delivered", "ingress_id": ingress_id, "receipt": receipt}
+    idempotency_key = f"ingress:{ingress_id}:target:{target_selector}"
+    receipt = persist_ingress_receipt(
+        {
+            **base_receipt,
+            "binding_id": str(launcher.get("id", "")).strip(),
+            "status": "pending",
+            "delivery_protocol_version": INGRESS_DELIVERY_PROTOCOL_VERSION,
+            "delivery": "targeted",
+            "route_kind": "room_launch_thread",
+            "launch_id": str(launch.get("launch_id", "")).strip(),
+            "routing_mode": routing_mode,
+            "mentioned_handles": mentioned_handles,
+            "qualified_handle": target_handle,
+            "targets": [
+                {
+                    "session_name": target_selector,
+                    "status": "pending",
+                    "intent": "default",
+                    "idempotency_key": idempotency_key,
+                }
+            ],
+        }
+    )
+    receipt = resume_ingress_delivery(
+        receipt,
+        cancel_event=cancel_event,
+        delivery_envelopes={target_selector: envelope},
+    )
+    receipt, _ = apply_ingress_routing_state(receipt)
+    return {"status": receipt["status"], "ingress_id": ingress_id, "receipt": receipt}
 
 
-def process_inbound_message(message: dict[str, Any], bot_user_id: str) -> dict[str, Any]:
-    ingress_id = message_ingress_id(message)
+def process_inbound_message(
+    message: dict[str, Any],
+    bot_user_id: str,
+    app_name: str = "",
+    cancel_event: threading.Event | None = None,
+) -> dict[str, Any]:
+    normalized_app_name = common.validate_app_name(app_name)
+    ingress_id = message_ingress_id(message, normalized_app_name)
     author = message.get("author") or {}
     if bool(author.get("bot")) or str(author.get("id", "")).strip() == bot_user_id:
         return {"status": "ignored", "reason": "bot_message", "ingress_id": ingress_id}
@@ -1251,11 +1664,19 @@ def process_inbound_message(message: dict[str, Any], bot_user_id: str) -> dict[s
     if not channel_id:
         return {"status": "ignored", "reason": "missing_channel", "ingress_id": ingress_id}
 
-    message, message_debug = recover_message_for_routing(message)
+    recovery_token = common.load_bot_token(normalized_app_name) if normalized_app_name else None
+    message, message_debug = recover_message_for_routing(message, bot_token=recovery_token)
     author = message.get("author") or {}
 
     config = common.load_config()
-    room_launchers_configured = bool(common.list_room_launchers(config)) if guild_id else False
+    mentioned_configured_bots = configured_bot_mentions(message, config) if guild_id else set()
+    if mentioned_configured_bots and str(bot_user_id).strip() not in mentioned_configured_bots:
+        return {
+            "status": "ignored",
+            "reason": "different_configured_bot_mentioned",
+            "ingress_id": ingress_id,
+        }
+    room_launchers_configured = bool(common.list_room_launchers(config)) if guild_id and not normalized_app_name else False
     mentioned_bot = bot_was_mentioned(message, bot_user_id) if guild_id else False
     preloaded_launcher: dict[str, Any] | None = None
     preloaded_launch: dict[str, Any] | None = None
@@ -1278,7 +1699,7 @@ def process_inbound_message(message: dict[str, Any], bot_user_id: str) -> dict[s
             if preloaded_launch is None:
                 preloaded_launcher = common.resolve_room_launcher(config, channel_id)
         if preloaded_launcher is None and not mentioned_bot:
-            preloaded_binding = cached_ambient_room_binding(channel_id)
+            preloaded_binding = cached_ambient_room_binding(channel_id, normalized_app_name)
             if not preloaded_binding or not binding_allows_ambient_read(preloaded_binding):
                 return {"status": "ignored", "reason": "not_mentioned", "ingress_id": ingress_id}
             preloaded_channel_info = binding_channel_info(preloaded_binding)
@@ -1292,6 +1713,7 @@ def process_inbound_message(message: dict[str, Any], bot_user_id: str) -> dict[s
                     status="ignored_untargeted",
                     reason="ambient_target_required",
                     message_debug=message_debug,
+                    app_name=normalized_app_name,
                 )
             participant_names = [str(item).strip() for item in preloaded_binding.get("session_names", []) if str(item).strip()]
             participant_lookup, participant_collisions = casefold_lookup(participant_names)
@@ -1310,6 +1732,7 @@ def process_inbound_message(message: dict[str, Any], bot_user_id: str) -> dict[s
                     status="ignored_untargeted",
                     reason="ambient_target_required",
                     message_debug=message_debug,
+                    app_name=normalized_app_name,
                 )
             preloaded_channel_type_raw = preloaded_binding.get("channel_type", 0)
             try:
@@ -1334,7 +1757,9 @@ def process_inbound_message(message: dict[str, Any], bot_user_id: str) -> dict[s
             "body_preview": preview,
             "message_debug": dict(message_debug or {}),
             "status": "processing",
+            "delivery_protocol_version": INGRESS_DELIVERY_PROTOCOL_VERSION,
             "targets": [],
+            "app": normalized_app_name,
         }
     )
     if not claimed:
@@ -1356,6 +1781,7 @@ def process_inbound_message(message: dict[str, Any], bot_user_id: str) -> dict[s
                     "status": "failed_claim_conflict",
                     "reason": str(base_receipt.get("reason", "")).strip() or "ingress_claim_unreadable",
                     "targets": [],
+                    "app": normalized_app_name,
                 }
             )
             return {"status": "failed_claim_conflict", "ingress_id": ingress_id, "receipt": receipt}
@@ -1407,6 +1833,7 @@ def process_inbound_message(message: dict[str, Any], bot_user_id: str) -> dict[s
                         "status": "processing",
                         "reason": retry_reason,
                         "targets": [],
+                        "app": normalized_app_name,
                     }
                 )
                 claimed = True
@@ -1426,7 +1853,7 @@ def process_inbound_message(message: dict[str, Any], bot_user_id: str) -> dict[s
         if launcher is None and binding is None:
             config = common.load_config()
             try:
-                binding, channel_info = resolve_binding(config, message)
+                binding, channel_info = resolve_binding(config, message, normalized_app_name)
             except common.DiscordAPIError as exc:
                 receipt = persist_ingress_receipt(
                     {
@@ -1437,6 +1864,39 @@ def process_inbound_message(message: dict[str, Any], bot_user_id: str) -> dict[s
                     }
                 )
                 return {"status": "failed_lookup", "ingress_id": ingress_id, "receipt": receipt}
+        if guild_id:
+            roles = (message.get("member") or {}).get("roles") or []
+            role_ids = [str(role_id).strip() for role_id in roles if str(role_id).strip()]
+            policy_route = launcher or binding or {}
+            policy_channel_id = (
+                str(policy_route.get("thread_parent_id", "")).strip()
+                or str(channel_info.get("parent_id", "")).strip()
+                or str(policy_route.get("conversation_id", "")).strip()
+                or channel_id
+            )
+            policy_rejection = common.policy_reason(
+                config,
+                guild_id,
+                policy_channel_id,
+                role_ids,
+                app_name=normalized_app_name,
+            )
+            if policy_rejection:
+                receipt = persist_ingress_receipt(
+                    {
+                        **base_receipt,
+                        "binding_id": str((binding or {}).get("id", "")).strip(),
+                        "status": "rejected_policy",
+                        "reason": policy_rejection,
+                        "targets": [],
+                    }
+                )
+                return {
+                    "status": "rejected_policy",
+                    "reason": policy_rejection,
+                    "ingress_id": ingress_id,
+                    "receipt": receipt,
+                }
         base_receipt.update(
             {
                 "ingress_id": ingress_id,
@@ -1458,6 +1918,7 @@ def process_inbound_message(message: dict[str, Any], bot_user_id: str) -> dict[s
                 bot_user_id=bot_user_id,
                 ingress_id=ingress_id,
                 message_debug=message_debug,
+                cancel_event=cancel_event,
             )
         if launcher:
             return process_room_launch_message(
@@ -1467,6 +1928,7 @@ def process_inbound_message(message: dict[str, Any], bot_user_id: str) -> dict[s
                 bot_user_id=bot_user_id,
                 ingress_id=ingress_id,
                 message_debug=message_debug,
+                cancel_event=cancel_event,
             )
         if not binding:
             receipt = persist_ingress_receipt(
@@ -1539,16 +2001,6 @@ def process_inbound_message(message: dict[str, Any], bot_user_id: str) -> dict[s
             )
             return {"status": "skipped_no_targets", "ingress_id": ingress_id, "receipt": receipt}
 
-        receipt = persist_ingress_receipt(
-            {
-                **base_receipt,
-                "binding_id": str(binding.get("id", "")).strip(),
-                "status": "pending",
-                "mentioned_aliases": mentioned_aliases,
-                "delivery": delivery,
-                "targets": [{"session_name": target, "status": "pending"} for target in targets],
-            }
-        )
         envelope = build_human_envelope(
             binding=binding,
             message=message,
@@ -1558,47 +2010,38 @@ def process_inbound_message(message: dict[str, Any], bot_user_id: str) -> dict[s
             delivery=delivery,
             ingress_id=ingress_id,
         )
-        updated_targets: list[dict[str, Any]] = []
-        failures = 0
-        for target in targets:
-            idempotency_key = f"ingress:{ingress_id}:target:{target}"
-            try:
-                response = common.deliver_session_message(
-                    target,
-                    envelope,
-                    idempotency_key=idempotency_key,
-                    intent="follow_up",
-                )
-                updated_targets.append(
+        receipt = persist_ingress_receipt(
+            {
+                **base_receipt,
+                "binding_id": str(binding.get("id", "")).strip(),
+                "status": "pending",
+                "delivery_protocol_version": INGRESS_DELIVERY_PROTOCOL_VERSION,
+                "mentioned_aliases": mentioned_aliases,
+                "delivery": delivery,
+                "targets": [
                     {
                         "session_name": target,
-                        "status": "delivered",
-                        "idempotency_key": idempotency_key,
-                        "response": response,
+                        "status": "pending",
+                        "intent": "follow_up",
+                        "idempotency_key": f"ingress:{ingress_id}:target:{target}",
                     }
-                )
-            except common.GCAPIError as exc:
-                failures += 1
-                updated_targets.append(
-                    {
-                        "session_name": target,
-                        "status": "failed",
-                        "idempotency_key": idempotency_key,
-                        "error": str(exc),
-                    }
-                )
-        receipt["targets"] = updated_targets
-        receipt["status"] = "delivered" if failures == 0 else ("partial_failed" if failures < len(targets) else "failed")
-        receipt["delivery"] = delivery
-        receipt["mentioned_aliases"] = mentioned_aliases
-        receipt = persist_ingress_receipt(receipt)
+                    for target in targets
+                ],
+            }
+        )
+        receipt = resume_ingress_delivery(
+            receipt,
+            cancel_event=cancel_event,
+            delivery_envelopes={target: envelope for target in targets},
+        )
         return {"status": receipt["status"], "ingress_id": ingress_id, "receipt": receipt}
     finally:
         process_lock.release()
 
 
 class GatewayRuntimeState:
-    def __init__(self) -> None:
+    def __init__(self, app_name: str = "") -> None:
+        self.app_name = common.validate_app_name(app_name)
         self._lock = threading.Lock()
         self._last_persist_monotonic = 0.0
         self._status: dict[str, Any] = {
@@ -1612,12 +2055,14 @@ class GatewayRuntimeState:
             "dropped_messages": 0,
             "message_queue_size": 0,
         }
+        if self.app_name:
+            self._status["app"] = self.app_name
         self._persist_locked(force=True)
 
     def _persist_locked(self, force: bool = False) -> None:
         now = time.monotonic()
         if force or (now - self._last_persist_monotonic) >= 1.0:
-            common.save_gateway_status(self._status)
+            common.save_gateway_status(self._status, app_name=self.app_name)
             self._last_persist_monotonic = now
 
     def snapshot(self) -> dict[str, Any]:
@@ -1800,17 +2245,31 @@ def _resolve_thread_parent(channel_id: str) -> str:
 
 
 class GatewayWorker:
-    def __init__(self, runtime_state: GatewayRuntimeState) -> None:
+    def __init__(
+        self,
+        runtime_state: GatewayRuntimeState,
+        app_name: str = "",
+        *,
+        initial_connect_delay_seconds: float = 0,
+    ) -> None:
         self.runtime_state = runtime_state
+        self.app_name = common.validate_app_name(app_name)
+        self.initial_connect_delay_seconds = max(float(initial_connect_delay_seconds), 0.0)
         self.stop_event = threading.Event()
         self._stopped = False
         self._stop_lock = threading.Lock()
         self.message_queue: queue.Queue[tuple[dict[str, Any], str] | None] = queue.Queue(maxsize=GATEWAY_MAX_PENDING_MESSAGES)
         self.worker_threads: list[threading.Thread] = []
+        self._recovery_lock = threading.Lock()
+        self.recovery_thread: threading.Thread | None = None
         self._current_ws_lock = threading.Lock()
         self._current_ws: GatewayWebSocket | None = None
-        for index in range(GATEWAY_WORKER_THREADS):
-            thread = threading.Thread(target=self.message_worker_loop, name=f"discord-gateway-worker-{index + 1}")
+        consumer_count = GATEWAY_NAMED_WORKER_THREADS if self.app_name else GATEWAY_WORKER_THREADS
+        for index in range(consumer_count):
+            worker_name = f"discord-gateway-worker-{index + 1}"
+            if self.app_name:
+                worker_name = f"{worker_name}-{self.app_name}"
+            thread = threading.Thread(target=self.message_worker_loop, name=worker_name, daemon=True)
             thread.start()
             self.worker_threads.append(thread)
 
@@ -1828,6 +2287,34 @@ class GatewayWorker:
         self.stop_event.set()
         self.close_current_ws()
 
+    def start_pending_recovery(self, bot_user_id: str) -> None:
+        with self._recovery_lock:
+            if self.recovery_thread is not None:
+                return
+
+            def recovery_loop() -> None:
+                while not self.stop_event.is_set():
+                    try:
+                        recover_pending_ingress_receipts(
+                            bot_user_id=bot_user_id,
+                            app_name=self.app_name,
+                            cancel_event=self.stop_event,
+                        )
+                    except Exception as exc:  # noqa: BLE001
+                        self.runtime_state.patch(
+                            last_recovery_error=str(exc),
+                            last_recovery_exception=traceback.format_exc(limit=20),
+                            last_recovery_at=common.utcnow(),
+                        )
+                    if self.stop_event.wait(PENDING_RECOVERY_INTERVAL_SECONDS):
+                        return
+
+            thread_name = "discord-gateway-pending-recovery"
+            if self.app_name:
+                thread_name = f"{thread_name}-{self.app_name}"
+            self.recovery_thread = threading.Thread(target=recovery_loop, name=thread_name, daemon=True)
+            self.recovery_thread.start()
+
     def stop(self) -> None:
         with self._stop_lock:
             if self._stopped:
@@ -1835,12 +2322,36 @@ class GatewayWorker:
             self._stopped = True
         self.runtime_state.patch(state="stopping", connected=False)
         self.request_stop()
+        while True:
+            try:
+                item = self.message_queue.get_nowait()
+            except queue.Empty:
+                break
+            try:
+                if item is not WORKER_QUEUE_SENTINEL:
+                    message, bot_user_id = item
+                    self.reject_message_during_shutdown(message, bot_user_id)
+            finally:
+                self.message_queue.task_done()
         for _ in self.worker_threads:
-            self.message_queue.put(WORKER_QUEUE_SENTINEL)
-        self.message_queue.join()
+            self.message_queue.put_nowait(WORKER_QUEUE_SENTINEL)
+        deadline = time.monotonic() + GATEWAY_WORKER_STOP_TIMEOUT_SECONDS
         for thread in self.worker_threads:
-            thread.join()
-        self.runtime_state.patch(state="stopped", connected=False, message_queue_size=self.message_queue.qsize())
+            thread.join(timeout=max(deadline - time.monotonic(), 0.0))
+        if self.recovery_thread is not None:
+            self.recovery_thread.join(timeout=max(deadline - time.monotonic(), 0.0))
+        alive_threads = [thread.name for thread in self.worker_threads if thread.is_alive()]
+        if self.recovery_thread is not None and self.recovery_thread.is_alive():
+            alive_threads.append(self.recovery_thread.name)
+        state = "stop_timeout" if alive_threads else "stopped"
+        patch: dict[str, Any] = {
+            "state": state,
+            "connected": False,
+            "message_queue_size": self.message_queue.qsize(),
+        }
+        if alive_threads:
+            patch["last_error"] = f"timed out stopping worker threads: {', '.join(alive_threads)}"
+        self.runtime_state.patch(**patch)
 
     def current_bot_user_id(
         self,
@@ -1848,13 +2359,24 @@ class GatewayWorker:
         ready_payload: dict[str, Any] | None = None,
         last_known_bot_user_id: str = "",
     ) -> str:
+        try:
+            app_config = common.resolve_app_config(config, self.app_name)
+        except ValueError:
+            app_config = {}
+        configured_application_id = str(app_config.get("application_id", "")).strip()
         ready_user = (ready_payload or {}).get("user") or {}
-        bot_user_id = str(ready_user.get("id", "")).strip()
-        if bot_user_id:
-            return bot_user_id
-        if last_known_bot_user_id:
-            return str(last_known_bot_user_id).strip()
-        return str((config.get("app") or {}).get("application_id", "")).strip()
+        authenticated_user_id = str(ready_user.get("id", "")).strip()
+        if not authenticated_user_id:
+            authenticated_user_id = str(last_known_bot_user_id).strip()
+        if authenticated_user_id:
+            if configured_application_id and authenticated_user_id != configured_application_id:
+                display_name = self.app_name or "default"
+                raise RuntimeError(
+                    f"Discord app {display_name!r} authenticated as user {authenticated_user_id!r}, "
+                    f"not configured application_id {configured_application_id!r}"
+                )
+            return authenticated_user_id
+        return configured_application_id
 
     def gateway_connect_url(self, url: str) -> str:
         if not url:
@@ -1866,8 +2388,11 @@ class GatewayWorker:
         query["encoding"] = "json"
         return urllib.parse.urlunparse(parsed._replace(query=urllib.parse.urlencode(query)))
 
-    def gateway_url(self) -> str:
-        payload = common.discord_api_request("GET", "/gateway/bot")
+    def gateway_url(self, bot_token: str = "") -> str:
+        if self.app_name:
+            payload = common.discord_api_request("GET", "/gateway/bot", bot_token=bot_token)
+        else:
+            payload = common.discord_api_request("GET", "/gateway/bot")
         url = str((payload or {}).get("url", "")).strip()
         if not url:
             raise RuntimeError("Discord gateway URL is missing from /gateway/bot")
@@ -1911,12 +2436,15 @@ class GatewayWorker:
                 if item is WORKER_QUEUE_SENTINEL:
                     return
                 message, bot_user_id = item
-                self.handle_gateway_message(message, bot_user_id)
+                if self.stop_event.is_set():
+                    self.reject_message_during_shutdown(message, bot_user_id)
+                else:
+                    self.handle_gateway_message(message, bot_user_id)
             finally:
                 self.message_queue.task_done()
                 self.runtime_state.patch(message_queue_size=self.message_queue.qsize())
 
-    def _record_extmsg_inbound(self, message: dict[str, Any], bot_user_id: str) -> bool:
+    def _record_extmsg_inbound(self, message: dict[str, Any], bot_user_id: str) -> bool | dict[str, Any]:
         """Normalize and post inbound Discord message to extmsg fabric.
 
         If the message contains @mentions in a room (not a thread), this also
@@ -1925,6 +2453,8 @@ class GatewayWorker:
         Returns True if the message was fully handled by extmsg (caller should
         skip legacy routing). Returns False to fall through to legacy path.
         """
+        if self.app_name:
+            return False
         try:
             author = message.get("author") or {}
             if bool(author.get("bot")) or str(author.get("id", "")).strip() == bot_user_id:
@@ -1934,12 +2464,18 @@ class GatewayWorker:
             app_id = str(config.get("app", {}).get("application_id", "")).strip()
             if not app_id:
                 return False
+            mentioned_configured_bots = configured_bot_mentions(message, config) if guild_id else set()
+            if mentioned_configured_bots and str(bot_user_id).strip() not in mentioned_configured_bots:
+                return False
 
             content = str(message.get("content", ""))
             channel_id = str(message.get("channel_id", "")).strip()
             # Discord MESSAGE_CREATE in threads doesn't include parent_id.
-            # Check channel type to detect threads (cached).
-            parent_id = _resolve_thread_parent(channel_id)
+            # Prefer verified metadata on an exact binding before a REST lookup.
+            direct_binding = common.resolve_chat_binding(config, common.chat_binding_id("room", channel_id))
+            parent_id = str((direct_binding or {}).get("thread_parent_id", "")).strip()
+            if not parent_id:
+                parent_id = _resolve_thread_parent(channel_id)
             is_thread = bool(parent_id)
 
             # Explicit room bindings take precedence over generic extmsg
@@ -1957,6 +2493,14 @@ class GatewayWorker:
                 targets = common.resolve_mention_targets(at_mentions)
                 if not targets:
                     return False
+                policy_rejection = self._reject_extmsg_policy(
+                    config,
+                    message,
+                    bot_user_id,
+                    parent_channel_id=channel_id,
+                )
+                if policy_rejection:
+                    return policy_rejection
                 group = common.launch_thread_for_mentions(
                     message, targets, guild_id, app_id,
                 )
@@ -1976,6 +2520,14 @@ class GatewayWorker:
 
             # THREAD: all messages go to transcript. Handle @mentions and NL names.
             if is_thread:
+                policy_rejection = self._reject_extmsg_policy(
+                    config,
+                    message,
+                    bot_user_id,
+                    parent_channel_id=parent_id,
+                )
+                if policy_rejection:
+                    return policy_rejection
                 # @mentions in thread = add new participants (strong signal).
                 at_mentions = common.resolve_at_mentions(content)
                 if at_mentions:
@@ -2007,17 +2559,49 @@ class GatewayWorker:
         except Exception:
             return False  # On error, fall through to legacy path.
 
+    def _reject_extmsg_policy(
+        self,
+        config: dict[str, Any],
+        message: dict[str, Any],
+        bot_user_id: str,
+        *,
+        parent_channel_id: str,
+    ) -> dict[str, Any] | None:
+        guild_id = str(message.get("guild_id", "")).strip()
+        if not guild_id:
+            return None
+        roles = (message.get("member") or {}).get("roles") or []
+        role_ids = [str(role_id).strip() for role_id in roles if str(role_id).strip()]
+        policy_rejection = common.policy_reason(config, guild_id, parent_channel_id, role_ids)
+        if not policy_rejection:
+            return None
+        return reject_ingress_before_processing(
+            message,
+            bot_user_id,
+            status="rejected_policy",
+            reason=policy_rejection,
+        )
+
     def handle_gateway_message(self, message: dict[str, Any], bot_user_id: str) -> None:
         try:
             # Try the new extmsg path first. If it handles the message
             # (e.g., creates a thread from @mentions), skip legacy routing.
-            if self._record_extmsg_inbound(message, bot_user_id):
+            extmsg_result = self._record_extmsg_inbound(message, bot_user_id)
+            if extmsg_result is True:
                 self.runtime_state.bump("routed_messages",
                     last_message_status="extmsg_routed",
                     last_message_preview=common.utcnow(),
                     last_event_at=common.utcnow())
                 return
-            outcome = process_inbound_message(message, bot_user_id)
+            if isinstance(extmsg_result, dict):
+                outcome = extmsg_result
+            else:
+                outcome = process_inbound_message(
+                    message,
+                    bot_user_id,
+                    self.app_name,
+                    cancel_event=self.stop_event,
+                )
             status = str(outcome.get("status", "")).strip()
             preview = summarize_body(str((outcome.get("receipt") or {}).get("body_preview", "")))
             if status == "duplicate":
@@ -2043,30 +2627,19 @@ class GatewayWorker:
 
     def dispatch_gateway_message(self, message: dict[str, Any], bot_user_id: str) -> None:
         if self.stop_event.is_set():
-            save_rejected_ingress_receipt(
-                message,
-                bot_user_id,
-                status="rejected_shutting_down",
-                reason="service_shutting_down",
-            )
-            self.runtime_state.bump(
-                "dropped_messages",
-                last_message_status="shutting_down",
-                last_message_preview=ingress_preview(message, bot_user_id),
-                last_event_at=common.utcnow(),
-                message_queue_size=self.message_queue.qsize(),
-            )
+            self.reject_message_during_shutdown(message, bot_user_id)
             return
         try:
             self.message_queue.put_nowait((message, bot_user_id))
             self.runtime_state.patch(message_queue_size=self.message_queue.qsize())
         except queue.Full:
-            ingress_id = message_ingress_id(message)
+            ingress_id = message_ingress_id(message, self.app_name)
             save_rejected_ingress_receipt(
                 message,
                 bot_user_id,
                 status="rejected_overloaded",
                 reason="message_queue_full",
+                app_name=self.app_name,
             )
             print(
                 f"[{common.current_service_name() or 'discord-gateway'}] dropping ingress {ingress_id}: message queue full",
@@ -2079,6 +2652,22 @@ class GatewayWorker:
                 last_event_at=common.utcnow(),
                 message_queue_size=self.message_queue.qsize(),
             )
+
+    def reject_message_during_shutdown(self, message: dict[str, Any], bot_user_id: str) -> None:
+        save_rejected_ingress_receipt(
+            message,
+            bot_user_id,
+            status="rejected_shutting_down",
+            reason="service_shutting_down",
+            app_name=self.app_name,
+        )
+        self.runtime_state.bump(
+            "dropped_messages",
+            last_message_status="shutting_down",
+            last_message_preview=ingress_preview(message, bot_user_id),
+            last_event_at=common.utcnow(),
+            message_queue_size=self.message_queue.qsize(),
+        )
 
     def prune_runtime_data(self) -> None:
         common.prune_requests()
@@ -2094,6 +2683,8 @@ class GatewayWorker:
         self.runtime_state.patch(last_prune_at=common.utcnow())
 
     def run_forever(self) -> None:
+        if self.initial_connect_delay_seconds and self.stop_event.wait(self.initial_connect_delay_seconds):
+            return
         backoff_seconds = RECONNECT_BASE_DELAY_SECONDS
         next_prune_at = 0.0
         seq: int | None = None
@@ -2103,12 +2694,16 @@ class GatewayWorker:
         while not self.stop_event.is_set():
             try:
                 now = time.monotonic()
-                if now >= next_prune_at:
+                if not self.app_name and now >= next_prune_at:
                     self.prune_runtime_data()
                     next_prune_at = now + PRUNE_INTERVAL_SECONDS
                 config = common.load_config()
-                bot_token = common.load_bot_token()
-                application_id = str((config.get("app") or {}).get("application_id", "")).strip()
+                bot_token = common.load_bot_token(self.app_name)
+                try:
+                    app_config = common.resolve_app_config(config, self.app_name)
+                except ValueError:
+                    app_config = {}
+                application_id = str(app_config.get("application_id", "")).strip()
                 if not bot_token or not application_id:
                     self.runtime_state.patch(
                         connected=False,
@@ -2119,8 +2714,13 @@ class GatewayWorker:
                         break
                     continue
 
+                self.start_pending_recovery(application_id)
                 can_resume = bool(resume_session_id and seq is not None)
-                connection_url = self.gateway_connect_url(resume_gateway_url) if can_resume and resume_gateway_url else self.gateway_url()
+                connection_url = (
+                    self.gateway_connect_url(resume_gateway_url)
+                    if can_resume and resume_gateway_url
+                    else self.gateway_url(bot_token)
+                )
                 ws = GatewayWebSocket(connection_url)
                 self.set_current_ws(ws)
                 ready_payload: dict[str, Any] | None = None
@@ -2155,7 +2755,7 @@ class GatewayWorker:
                             awaiting_heartbeat_ack = True
                             next_heartbeat_at = now + heartbeat_interval
                             self.runtime_state.patch(last_heartbeat_at=common.utcnow())
-                        if now >= next_prune_at:
+                        if not self.app_name and now >= next_prune_at:
                             self.prune_runtime_data()
                             next_prune_at = now + PRUNE_INTERVAL_SECONDS
                         if not event:
@@ -2185,11 +2785,14 @@ class GatewayWorker:
                                 )
                                 continue
                             if event_type == "RESUMED":
+                                bot_user_id = self.current_bot_user_id(config, None, last_known_bot_user_id)
+                                last_known_bot_user_id = bot_user_id
                                 awaiting_heartbeat_ack = False
                                 backoff_seconds = RECONNECT_BASE_DELAY_SECONDS
                                 self.runtime_state.patch(
                                     connected=True,
                                     state="ready",
+                                    bot_user_id=bot_user_id,
                                     last_resumed_at=common.utcnow(),
                                     last_resumed_epoch=int(time.time()),
                                     last_error="",
@@ -2233,6 +2836,33 @@ class GatewayWorker:
                 backoff_seconds = min(RECONNECT_MAX_DELAY_SECONDS, max(RECONNECT_BASE_DELAY_SECONDS, backoff_seconds * 2))
 
 
+def build_gateway_workers(config: dict[str, Any]) -> list[GatewayWorker]:
+    application_id_owners: dict[str, str] = {}
+    for app_name in common.list_app_names(config):
+        application_id = str(common.resolve_app_config(config, app_name).get("application_id", "")).strip()
+        if not application_id:
+            continue
+        display_name = app_name or "default"
+        previous_owner = application_id_owners.get(application_id)
+        if previous_owner:
+            raise ValueError(
+                f"Discord application_id {application_id!r} is configured more than once "
+                f"({previous_owner!r} and {display_name!r})"
+            )
+        application_id_owners[application_id] = display_name
+    workers: list[GatewayWorker] = []
+    for index, app_name in enumerate(common.list_app_names(config)):
+        runtime_state = GatewayRuntimeState(app_name)
+        workers.append(
+            GatewayWorker(
+                runtime_state,
+                app_name,
+                initial_connect_delay_seconds=index * GATEWAY_IDENTIFY_STAGGER_SECONDS,
+            )
+        )
+    return workers
+
+
 class GatewayHandler(BaseHTTPRequestHandler):
     server_version = "DiscordGateway/0.1"
 
@@ -2242,11 +2872,20 @@ class GatewayHandler(BaseHTTPRequestHandler):
     def do_GET(self) -> None:  # noqa: N802
         parsed = urllib.parse.urlparse(self.path)
         if parsed.path == "/healthz":
-            state = get_runtime_state().snapshot()
+            states = gateway_runtime_snapshots()
+            configured_app_names = configured_gateway_app_names(common.load_config())
             gc_api_reachable = True
-            if str(state.get("state", "")).strip() in {"ready", "reconnecting"}:
+            if any(
+                app_name in configured_app_names
+                and str(state.get("state", "")).strip() in {"ready", "reconnecting"}
+                for app_name, state in states.items()
+            ):
                 gc_api_reachable = probe_gc_api_health(get_runtime_state())
-            code = gateway_health_status_code(state, gc_api_reachable=gc_api_reachable)
+            code = aggregate_gateway_health_status_code(
+                states,
+                configured_app_names=configured_app_names,
+                gc_api_reachable=gc_api_reachable,
+            )
             self.send_response(code)
             self.end_headers()
             return
@@ -2254,12 +2893,23 @@ class GatewayHandler(BaseHTTPRequestHandler):
             text_response(self, HTTPStatus.OK, "discord gateway ready\n", "text/plain; charset=utf-8")
             return
         if parsed.path == "/v0/discord/gateway/status":
-            json_response(self, HTTPStatus.OK, get_runtime_state().snapshot())
+            states = gateway_runtime_snapshots()
+            json_response(
+                self,
+                HTTPStatus.OK,
+                gateway_status_payload(
+                    states,
+                    configured_app_names=configured_gateway_app_names(common.load_config()),
+                    gc_api_reachable=cached_gc_api_reachable(),
+                ),
+            )
             return
         json_response(self, HTTPStatus.NOT_FOUND, {"error": "not_found"})
 
 
 RUNTIME_STATE: GatewayRuntimeState | None = None
+RUNTIME_STATES_LOCK = threading.Lock()
+RUNTIME_STATES: dict[str, GatewayRuntimeState] = {}
 
 
 def get_runtime_state() -> GatewayRuntimeState:
@@ -2267,6 +2917,31 @@ def get_runtime_state() -> GatewayRuntimeState:
     if RUNTIME_STATE is None:
         RUNTIME_STATE = GatewayRuntimeState()
     return RUNTIME_STATE
+
+
+def gateway_runtime_snapshots() -> dict[str, dict[str, Any]]:
+    with RUNTIME_STATES_LOCK:
+        runtime_states = dict(RUNTIME_STATES)
+    if not runtime_states:
+        runtime_states = {"default": get_runtime_state()}
+    return {app_name: runtime_state.snapshot() for app_name, runtime_state in runtime_states.items()}
+
+
+def configured_gateway_app_names(config: dict[str, Any]) -> set[str]:
+    configured: set[str] = set()
+    for app_name in common.list_app_names(config):
+        try:
+            application_id = str(common.resolve_app_config(config, app_name).get("application_id", "")).strip()
+        except ValueError:
+            continue
+        if application_id:
+            configured.add(app_name or "default")
+    return configured
+
+
+def cached_gc_api_reachable() -> bool:
+    with GC_API_HEALTH_LOCK:
+        return bool(GC_API_HEALTH_CACHE.get("reachable", True))
 
 
 def gateway_health_status_code(state: dict[str, Any], gc_api_reachable: bool = True) -> HTTPStatus:
@@ -2284,6 +2959,95 @@ def gateway_health_status_code(state: dict[str, Any], gc_api_reachable: bool = T
     return HTTPStatus.SERVICE_UNAVAILABLE
 
 
+def aggregate_gateway_status(
+    states: dict[str, dict[str, Any]],
+    *,
+    configured_app_names: set[str],
+    gc_api_reachable: bool = True,
+) -> dict[str, Any]:
+    selected = {
+        app_name: states.get(app_name, {"state": "missing"})
+        for app_name in sorted(configured_app_names)
+    }
+    ready_apps = sum(str(state.get("state", "")).strip() == "ready" for state in selected.values())
+    reconnecting_apps = sum(str(state.get("state", "")).strip() == "reconnecting" for state in selected.values())
+    provisioning_states = {"connecting", "waiting_for_config", "starting"}
+    provisioning_apps = sum(
+        str(state.get("state", "")).strip() in provisioning_states
+        for state in selected.values()
+    )
+    operational_apps = sum(
+        gateway_health_status_code(state, gc_api_reachable=True) == HTTPStatus.NO_CONTENT
+        and str(state.get("state", "")).strip() not in provisioning_states
+        for state in selected.values()
+    )
+    configured_apps = len(selected)
+    failed_apps = configured_apps - operational_apps - provisioning_apps
+    if not gc_api_reachable and configured_apps:
+        state = "failed"
+    elif configured_apps == 0:
+        state = "waiting_for_config"
+    elif ready_apps == configured_apps:
+        state = "ready"
+    elif provisioning_apps == configured_apps:
+        state = "provisioning"
+    elif operational_apps:
+        state = "degraded"
+    else:
+        state = "failed"
+    return {
+        "state": state,
+        "configured_apps": configured_apps,
+        "ready_apps": ready_apps,
+        "reconnecting_apps": reconnecting_apps,
+        "provisioning_apps": provisioning_apps,
+        "operational_apps": operational_apps,
+        "failed_apps": failed_apps,
+        "gc_api_reachable": bool(gc_api_reachable),
+    }
+
+
+def aggregate_gateway_health_status_code(
+    states: dict[str, dict[str, Any]],
+    *,
+    configured_app_names: set[str],
+    gc_api_reachable: bool = True,
+) -> HTTPStatus:
+    aggregate = aggregate_gateway_status(
+        states,
+        configured_app_names=configured_app_names,
+        gc_api_reachable=gc_api_reachable,
+    )
+    if not gc_api_reachable and aggregate["configured_apps"]:
+        return HTTPStatus.SERVICE_UNAVAILABLE
+    if aggregate["configured_apps"] == 0:
+        return HTTPStatus.NO_CONTENT
+    if aggregate["operational_apps"]:
+        return HTTPStatus.NO_CONTENT
+    if aggregate["provisioning_apps"] == aggregate["configured_apps"]:
+        return HTTPStatus.NO_CONTENT
+    return HTTPStatus.SERVICE_UNAVAILABLE
+
+
+def gateway_status_payload(
+    states: dict[str, dict[str, Any]],
+    *,
+    configured_app_names: set[str],
+    gc_api_reachable: bool = True,
+) -> dict[str, Any]:
+    payload = dict(states.get("default", {}))
+    payload["gateway_statuses"] = {
+        app_name: dict(state)
+        for app_name, state in sorted(states.items())
+    }
+    payload["aggregate"] = aggregate_gateway_status(
+        states,
+        configured_app_names=configured_app_names,
+        gc_api_reachable=gc_api_reachable,
+    )
+    return payload
+
+
 def main() -> int:
     common.ensure_layout()
     common.prune_chat_ingress()
@@ -2295,15 +3059,29 @@ def main() -> int:
     except RuntimeError as exc:
         raise SystemExit(str(exc)) from exc
 
-    runtime_state = get_runtime_state()
-    worker = GatewayWorker(runtime_state)
-    thread = threading.Thread(target=worker.run_forever, name="discord-gateway")
-    thread.start()
+    workers = build_gateway_workers(common.load_config())
+    if not workers:
+        raise SystemExit("no Discord gateway workers were configured")
+    global RUNTIME_STATE, RUNTIME_STATES
+    RUNTIME_STATE = workers[0].runtime_state
+    with RUNTIME_STATES_LOCK:
+        RUNTIME_STATES = {
+            worker.app_name or "default": worker.runtime_state
+            for worker in workers
+        }
+    worker_threads: list[threading.Thread] = []
+    for worker in workers:
+        thread_name = "discord-gateway" if not worker.app_name else f"discord-gateway-{worker.app_name}"
+        thread = threading.Thread(target=worker.run_forever, name=thread_name)
+        thread.start()
+        worker_threads.append(thread)
+    runtime_state = workers[0].runtime_state
 
     with ThreadingUnixHTTPServer(socket_path, GatewayHandler) as server:
         def handle_shutdown(signum: int, _frame: Any) -> None:
             runtime_state.patch(last_shutdown_signal=signum, last_shutdown_at=common.utcnow())
-            worker.request_stop()
+            for worker in workers:
+                worker.request_stop()
             threading.Thread(target=server.shutdown, daemon=True).start()
 
         previous_sigint = signal.signal(signal.SIGINT, handle_shutdown)
@@ -2314,8 +3092,10 @@ def main() -> int:
         finally:
             signal.signal(signal.SIGINT, previous_sigint)
             signal.signal(signal.SIGTERM, previous_sigterm)
-            worker.stop()
-            thread.join()
+            for worker in workers:
+                worker.stop()
+            for thread in worker_threads:
+                thread.join()
     return 0
 
 

--- a/discord/scripts/discord_intake_common.py
+++ b/discord/scripts/discord_intake_common.py
@@ -13,12 +13,13 @@ import re
 import socket
 import subprocess
 import tempfile
+import threading
 import time
 import tomllib
 import urllib.error
 import urllib.parse
 import urllib.request
-from typing import Any
+from typing import Any, Callable
 
 INTERACTIONS_SERVICE_NAME = "discord-interactions"
 ADMIN_SERVICE_NAME = "discord-admin"
@@ -38,6 +39,12 @@ DEFAULT_SUPERVISOR_API_BASE = "http://127.0.0.1:8372"
 LOCAL_API_BINDS = {"", "0.0.0.0", "::", "[::]", "*"}
 DISCORD_RATE_LIMIT_RETRIES = 2
 GC_API_REQUEST_TIMEOUT_SECONDS = 20.0
+GC_API_ASYNC_RESULT_TIMEOUT_SECONDS = 4 * 60.0
+GC_EVENT_REQUEST_FAILED = "request.failed"
+GC_EVENT_SESSION_MESSAGE_SUCCEEDED = "request.result.session.message"
+GC_EVENT_SESSION_SUBMIT_SUCCEEDED = "request.result.session.submit"
+GC_OPERATION_SESSION_MESSAGE = "session.message"
+GC_OPERATION_SESSION_SUBMIT = "session.submit"
 SERVICE_SOCKET_PROBE_TIMEOUT_SECONDS = 0.2
 NON_ROUTABLE_SESSION_STATES = {"", "closed", "stopped", "orphaned", "quarantined"}
 PEER_DELIVERY_TIMEOUT_SECONDS = 10.0
@@ -56,6 +63,7 @@ ROOM_LAUNCH_READY_RESOLVE_TIMEOUT_SECONDS = 90.0
 ROOM_LAUNCH_READY_RESOLVE_DELAY_SECONDS = 0.5
 ROOM_LAUNCH_PRIMER_VERSION = 1
 AGENT_HANDLE_SEGMENT = re.compile(r"^[a-z][a-z0-9_-]{0,31}$")
+DISCORD_APP_NAME = re.compile(r"^[a-z][a-z0-9_-]{0,31}$")
 
 
 class DiscordAPIError(RuntimeError):
@@ -66,6 +74,24 @@ class DiscordAPIError(RuntimeError):
 
 class GCAPIError(RuntimeError):
     pass
+
+
+class GCAPITransportError(GCAPIError):
+    pass
+
+
+class GCAPIResultUnknown(GCAPIError):
+    pass
+
+
+class GCAPIRequestCancelled(GCAPIResultUnknown):
+    pass
+
+
+class GCAPIRequestFailed(GCAPIError):
+    def __init__(self, message: str, payload: dict[str, Any]) -> None:
+        super().__init__(message)
+        self.payload = copy.deepcopy(payload)
 
 
 def utcnow() -> str:
@@ -152,6 +178,10 @@ def config_path() -> str:
     return os.path.join(data_dir(), "config.json")
 
 
+def config_mutation_lock_path() -> str:
+    return os.path.join(locks_dir(), "config.lock")
+
+
 def secret_path(name: str) -> str:
     return os.path.join(secrets_dir(), name)
 
@@ -166,7 +196,10 @@ def published_services_dir() -> str:
     return os.path.join(root, ".gc", "services", ".published")
 
 
-def gateway_status_path() -> str:
+def gateway_status_path(app_name: str = "") -> str:
+    normalized_app_name = validate_app_name(app_name)
+    if normalized_app_name:
+        return os.path.join(data_dir(), f"gateway-status-{normalized_app_name}.json")
     return os.path.join(data_dir(), "gateway-status.json")
 
 
@@ -239,6 +272,7 @@ def default_config() -> dict[str, Any]:
         "app": {
             "command_name": COMMAND_NAME_DEFAULT,
         },
+        "apps": {},
         "policy": {
             "guild_allowlist": [],
             "channel_allowlist": [],
@@ -322,6 +356,29 @@ def normalize_config(raw: dict[str, Any] | None) -> dict[str, Any]:
             "channel_allowlist": _normalize_allowlist(policy.get("channel_allowlist")),
             "role_allowlist": _normalize_allowlist(policy.get("role_allowlist")),
         }
+    apps = raw.get("apps")
+    if isinstance(apps, dict):
+        normalized_apps: dict[str, Any] = {}
+        for raw_name, raw_app in apps.items():
+            if not isinstance(raw_app, dict):
+                continue
+            try:
+                app_name = validate_app_name(raw_name, allow_default=False)
+            except ValueError:
+                continue
+            app_policy = raw_app.get("policy") if isinstance(raw_app.get("policy"), dict) else {}
+            normalized_apps[app_name] = {
+                "application_id": str(raw_app.get("application_id", "")).strip(),
+                "public_key": str(raw_app.get("public_key", "")).strip(),
+                "command_name": str(raw_app.get("command_name", COMMAND_NAME_DEFAULT)).strip()
+                or COMMAND_NAME_DEFAULT,
+                "policy": {
+                    "guild_allowlist": _normalize_allowlist(app_policy.get("guild_allowlist")),
+                    "channel_allowlist": _normalize_allowlist(app_policy.get("channel_allowlist")),
+                    "role_allowlist": _normalize_allowlist(app_policy.get("role_allowlist")),
+                },
+            }
+        config["apps"] = normalized_apps
     chat = raw.get("chat")
     if isinstance(chat, dict):
         normalized_bindings: dict[str, Any] = {}
@@ -341,7 +398,11 @@ def normalize_config(raw: dict[str, Any] | None) -> dict[str, Any]:
                 normalized_session_names = dedupe_session_names(session_names)
                 if kind == "dm" and len(normalized_session_names) != 1:
                     continue
-                binding_id = chat_binding_id(kind, conversation_id)
+                try:
+                    app_name = validate_app_name(value.get("app", ""))
+                except ValueError:
+                    continue
+                binding_id = chat_binding_id(kind, conversation_id, app_name)
                 normalized_bindings[binding_id] = {
                     "id": binding_id,
                     "kind": kind,
@@ -349,6 +410,8 @@ def normalize_config(raw: dict[str, Any] | None) -> dict[str, Any]:
                     "guild_id": str(value.get("guild_id", "")).strip(),
                     "session_names": normalized_session_names,
                 }
+                if app_name:
+                    normalized_bindings[binding_id]["app"] = app_name
                 channel_metadata = normalize_binding_channel_metadata(value)
                 if channel_metadata:
                     normalized_bindings[binding_id].update(channel_metadata)
@@ -551,7 +614,20 @@ def binding_peer_policy(binding: dict[str, Any]) -> dict[str, Any]:
 def redact_config(config: dict[str, Any]) -> dict[str, Any]:
     redacted = normalize_config(config)
     redacted["app"]["bot_token_present"] = bool(load_bot_token())
+    for app_name, app in redacted.get("apps", {}).items():
+        app["bot_token_present"] = bool(load_bot_token(app_name))
     return redacted
+
+
+def validate_app_name(value: Any, *, allow_default: bool = True) -> str:
+    normalized = str(value or "").strip()
+    if not normalized and allow_default:
+        return ""
+    if normalized == "default":
+        raise ValueError("app name 'default' is reserved for the legacy default app")
+    if not DISCORD_APP_NAME.fullmatch(normalized):
+        raise ValueError("app name must match [a-z][a-z0-9_-]{0,31}")
+    return normalized
 
 
 def validate_application_id(value: str) -> str:
@@ -576,40 +652,155 @@ def validate_public_key(value: str) -> str:
     return normalized
 
 
-def import_app_config(config: dict[str, Any], app_fields: dict[str, Any]) -> dict[str, Any]:
+def import_app_config(
+    config: dict[str, Any],
+    app_fields: dict[str, Any],
+    *,
+    app_name: str = "",
+    bot_token: str | None = None,
+) -> dict[str, Any]:
+    normalized_app_name = validate_app_name(app_name)
+    normalized_bot_token: str | None = None
+    if bot_token is not None:
+        normalized_bot_token = str(bot_token).strip()
+        if not normalized_bot_token:
+            raise ValueError("bot token is empty")
+    with advisory_lock(config_mutation_lock_path()):
+        current = load_config() if os.path.exists(config_path()) else normalize_config(config)
+        previous_bot_token = load_bot_token(normalized_app_name) if normalized_bot_token is not None else ""
+        existing_app = current.get("apps", {}).get(normalized_app_name) if normalized_app_name else None
+        requested_application_id = validate_application_id(
+            app_fields.get("application_id", app_fields.get("app_id", ""))
+        )
+        existing_application_id = (
+            str(existing_app.get("application_id", "")).strip()
+            if isinstance(existing_app, dict)
+            else ""
+        )
+        existing_named_bot_token = load_bot_token(normalized_app_name) if normalized_app_name else ""
+        if existing_named_bot_token and (not isinstance(existing_app, dict) or not existing_application_id):
+            raise ValueError(
+                f"orphan bot token for Discord app {normalized_app_name!r} has no pinned application_id; "
+                "remove it explicitly or import the replacement under a new app name"
+            )
+        if (
+            normalized_app_name
+            and existing_application_id
+            and requested_application_id
+            and requested_application_id != existing_application_id
+        ):
+            raise ValueError(
+                f"Discord app {normalized_app_name!r} cannot change application_id; "
+                "import the replacement under a new app name"
+            )
+        updated = _import_app_config_locked(current, app_fields, app_name=normalized_app_name)
+        if normalized_bot_token is None:
+            return updated
+        try:
+            save_bot_token(normalized_bot_token, app_name=normalized_app_name)
+        except OSError:
+            save_config(current)
+            if previous_bot_token:
+                save_bot_token(previous_bot_token, app_name=normalized_app_name)
+            else:
+                try:
+                    os.remove(secret_path(bot_token_secret_name(normalized_app_name)))
+                except FileNotFoundError:
+                    pass
+            raise
+        return updated
+
+
+def _import_app_config_locked(
+    config: dict[str, Any],
+    app_fields: dict[str, Any],
+    *,
+    app_name: str = "",
+) -> dict[str, Any]:
     cfg = normalize_config(config)
-    app = cfg.setdefault("app", {})
+    normalized_app_name = validate_app_name(app_name)
+    if normalized_app_name:
+        app = cfg.setdefault("apps", {}).setdefault(normalized_app_name, {})
+        policy = app.setdefault("policy", {})
+    else:
+        app = cfg.setdefault("app", {})
+        policy = cfg.setdefault("policy", {})
     application_id = validate_application_id(app_fields.get("application_id", app_fields.get("app_id", "")))
     public_key = validate_public_key(app_fields.get("public_key", ""))
     if application_id:
+        for existing_app_name in list_app_names(cfg):
+            if existing_app_name == normalized_app_name:
+                continue
+            existing_application_id = str(resolve_app_config(cfg, existing_app_name).get("application_id", "")).strip()
+            if existing_application_id == application_id:
+                display_name = existing_app_name or "default"
+                raise ValueError(f"application_id is already configured for app {display_name!r}")
         app["application_id"] = application_id
     if public_key:
         app["public_key"] = public_key
     command_name = str(app_fields.get("command_name", app.get("command_name", COMMAND_NAME_DEFAULT))).strip()
     app["command_name"] = command_name or COMMAND_NAME_DEFAULT
 
-    policy = cfg.setdefault("policy", {})
     for key in ("guild_allowlist", "channel_allowlist", "role_allowlist"):
         if key in app_fields:
             policy[key] = _normalize_allowlist(app_fields.get(key))
     return save_config(cfg)
 
 
-def save_bot_token(token: str) -> None:
+def resolve_app_config(config: dict[str, Any], app_name: str = "") -> dict[str, Any]:
+    cfg = normalize_config(config)
+    normalized_app_name = validate_app_name(app_name)
+    if not normalized_app_name:
+        return cfg["app"]
+    app = cfg.get("apps", {}).get(normalized_app_name)
+    if not isinstance(app, dict):
+        raise ValueError(f"unknown Discord app {normalized_app_name!r}")
+    return app
+
+
+def resolve_app_policy(config: dict[str, Any], app_name: str = "") -> dict[str, Any]:
+    cfg = normalize_config(config)
+    normalized_app_name = validate_app_name(app_name)
+    if not normalized_app_name:
+        return cfg["policy"]
+    app = cfg.get("apps", {}).get(normalized_app_name)
+    if not isinstance(app, dict):
+        raise ValueError(f"unknown Discord app {normalized_app_name!r}")
+    return app["policy"]
+
+
+def list_app_names(config: dict[str, Any]) -> list[str]:
+    cfg = normalize_config(config)
+    names = sorted(cfg.get("apps", {}))
+    return [""] + names
+
+
+def bot_token_secret_name(app_name: str = "") -> str:
+    normalized_app_name = validate_app_name(app_name)
+    if not normalized_app_name:
+        return "bot-token.txt"
+    return f"bot-token-{normalized_app_name}.txt"
+
+
+def save_bot_token(token: str, app_name: str = "") -> None:
     ensure_layout()
-    atomic_write_text(secret_path("bot-token.txt"), token.strip() + "\n", mode=0o600)
+    atomic_write_text(secret_path(bot_token_secret_name(app_name)), token.strip() + "\n", mode=0o600)
 
 
-def load_bot_token() -> str:
-    return read_text(secret_path("bot-token.txt")).strip()
+def load_bot_token(app_name: str = "") -> str:
+    return read_text(secret_path(bot_token_secret_name(app_name))).strip()
 
 
 def normalize_channel_key(guild_id: str, channel_id: str) -> str:
     return f"{str(guild_id).strip()}/{str(channel_id).strip()}"
 
 
-def chat_binding_id(kind: str, conversation_id: str) -> str:
-    return f"{str(kind).strip().lower()}:{str(conversation_id).strip()}"
+def chat_binding_id(kind: str, conversation_id: str, app_name: str = "") -> str:
+    binding_id = f"{str(kind).strip().lower()}:{str(conversation_id).strip()}"
+    normalized_app_name = validate_app_name(app_name)
+    if normalized_app_name:
+        return f"{binding_id}@app:{normalized_app_name}"
+    return binding_id
 
 
 def set_chat_binding(
@@ -619,6 +810,32 @@ def set_chat_binding(
     session_names: list[str],
     guild_id: str = "",
     *,
+    app_name: str = "",
+    policy: dict[str, Any] | None = None,
+    channel_metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    with advisory_lock(config_mutation_lock_path()):
+        current = load_config() if os.path.exists(config_path()) else normalize_config(config)
+        return _set_chat_binding_locked(
+            current,
+            kind,
+            conversation_id,
+            session_names,
+            guild_id,
+            app_name=app_name,
+            policy=policy,
+            channel_metadata=channel_metadata,
+        )
+
+
+def _set_chat_binding_locked(
+    config: dict[str, Any],
+    kind: str,
+    conversation_id: str,
+    session_names: list[str],
+    guild_id: str = "",
+    *,
+    app_name: str = "",
     policy: dict[str, Any] | None = None,
     channel_metadata: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
@@ -634,9 +851,10 @@ def set_chat_binding(
     if normalized_kind == "dm" and len(normalized_session_names) != 1:
         raise ValueError("DM bindings require exactly one session name")
 
+    normalized_app_name = validate_app_name(app_name)
     cfg = normalize_config(config)
-    binding_id = chat_binding_id(normalized_kind, normalized_conversation)
-    if normalized_kind == "room" and resolve_room_launcher(cfg, normalized_conversation):
+    binding_id = chat_binding_id(normalized_kind, normalized_conversation, normalized_app_name)
+    if not normalized_app_name and normalized_kind == "room" and resolve_room_launcher(cfg, normalized_conversation):
         raise ValueError("room launch is already enabled for that conversation")
     existing = resolve_chat_binding(cfg, binding_id) or {}
     raw_room_policy = copy.deepcopy(existing.get("policy")) if isinstance(existing.get("policy"), dict) else {}
@@ -664,6 +882,8 @@ def set_chat_binding(
         "guild_id": str(guild_id).strip(),
         "session_names": normalized_session_names,
     }
+    if normalized_app_name:
+        binding["app"] = normalized_app_name
     if normalized_kind == "room":
         if raw_channel_metadata:
             binding.update(raw_channel_metadata)
@@ -673,6 +893,27 @@ def set_chat_binding(
 
 
 def set_room_launcher(
+    config: dict[str, Any],
+    guild_id: str,
+    conversation_id: str,
+    *,
+    response_mode: str = "mention_only",
+    default_qualified_handle: str = "",
+    policy: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    with advisory_lock(config_mutation_lock_path()):
+        current = load_config() if os.path.exists(config_path()) else normalize_config(config)
+        return _set_room_launcher_locked(
+            current,
+            guild_id,
+            conversation_id,
+            response_mode=response_mode,
+            default_qualified_handle=default_qualified_handle,
+            policy=policy,
+        )
+
+
+def _set_room_launcher_locked(
     config: dict[str, Any],
     guild_id: str,
     conversation_id: str,
@@ -735,14 +976,24 @@ def list_room_launchers(config: dict[str, Any]) -> list[dict[str, Any]]:
     return sorted(launchers.values(), key=lambda item: (str(item.get("kind", "")), str(item.get("conversation_id", ""))))
 
 
-def describe_room_channel_metadata(conversation_id: str, *, bot_token: str = "") -> dict[str, Any]:
-    token = str(bot_token).strip() or load_bot_token()
+def describe_room_channel_scope(conversation_id: str, *, bot_token: str | None = None) -> dict[str, Any]:
+    token = load_bot_token() if bot_token is None else str(bot_token).strip()
     if not token:
         return {}
     info = discord_api_request("GET", f"/channels/{urllib.parse.quote(str(conversation_id).strip())}", bot_token=token)
     if not isinstance(info, dict):
         return {}
-    return normalize_binding_channel_metadata(info)
+    scope = normalize_binding_channel_metadata(info)
+    guild_id = str(info.get("guild_id", "")).strip()
+    if guild_id:
+        scope["guild_id"] = guild_id
+    return scope
+
+
+def describe_room_channel_metadata(conversation_id: str, *, bot_token: str | None = None) -> dict[str, Any]:
+    return normalize_binding_channel_metadata(
+        describe_room_channel_scope(conversation_id, bot_token=bot_token)
+    )
 
 
 def channel_metadata_cache_path(conversation_id: str) -> str:
@@ -773,14 +1024,53 @@ def resolve_chat_binding(config: dict[str, Any], binding_id: str) -> dict[str, A
 
 def list_chat_bindings(config: dict[str, Any]) -> list[dict[str, Any]]:
     bindings = normalize_config(config).get("chat", {}).get("bindings", {})
-    return sorted(bindings.values(), key=lambda item: (str(item.get("kind", "")), str(item.get("conversation_id", ""))))
+    return sorted(
+        bindings.values(),
+        key=lambda item: (
+            str(item.get("kind", "")),
+            str(item.get("conversation_id", "")),
+            str(item.get("app", "")),
+        ),
+    )
 
 
-def resolve_publish_route(config: dict[str, Any], route_id: str) -> dict[str, Any] | None:
-    binding = resolve_chat_binding(config, route_id)
-    if binding:
-        return binding
+def resolve_publish_route(
+    config: dict[str, Any],
+    route_id: str,
+    *,
+    app_name: str = "",
+) -> dict[str, Any] | None:
     route = str(route_id).strip()
+    normalized_app_name = validate_app_name(app_name)
+    if normalized_app_name:
+        resolve_app_config(config, normalized_app_name)
+        if "@app:" in route:
+            expected_suffix = f"@app:{normalized_app_name}"
+            if not route.endswith(expected_suffix):
+                raise ValueError("--app does not match the binding app")
+        elif route.startswith(("dm:", "room:")):
+            route = f"{route}@app:{normalized_app_name}"
+        else:
+            raise ValueError("named apps support only room and DM bindings")
+    binding = resolve_chat_binding(config, route)
+    if binding:
+        binding_app_name = validate_app_name(binding.get("app", ""))
+        if binding_app_name:
+            resolve_app_config(config, binding_app_name)
+        return binding
+    if not normalized_app_name and route.startswith(("dm:", "room:")) and "@app:" not in route:
+        candidates = [
+            item
+            for item in list_chat_bindings(config)
+            if str(item.get("id", "")).partition("@app:")[0] == route
+        ]
+        if len(candidates) == 1:
+            candidate_app_name = validate_app_name(candidates[0].get("app", ""))
+            if candidate_app_name:
+                resolve_app_config(config, candidate_app_name)
+            return candidates[0]
+        if len(candidates) > 1:
+            raise ValueError(f"binding {route!r} is ambiguous; select one with --app")
     if route.startswith("launch-room:"):
         launcher = resolve_room_launcher(config, route.removeprefix("launch-room:"))
         if launcher:
@@ -793,6 +1083,18 @@ def resolve_publish_route(config: dict[str, Any], route_id: str) -> dict[str, An
 
 
 def set_channel_mapping(
+    config: dict[str, Any],
+    guild_id: str,
+    channel_id: str,
+    target: str,
+    fix_formula: str | None,
+) -> dict[str, Any]:
+    with advisory_lock(config_mutation_lock_path()):
+        current = load_config() if os.path.exists(config_path()) else normalize_config(config)
+        return _set_channel_mapping_locked(current, guild_id, channel_id, target, fix_formula)
+
+
+def _set_channel_mapping_locked(
     config: dict[str, Any],
     guild_id: str,
     channel_id: str,
@@ -826,6 +1128,18 @@ def normalize_rig_key(guild_id: str, rig_name: str) -> str:
 
 
 def set_rig_mapping(
+    config: dict[str, Any],
+    guild_id: str,
+    rig_name: str,
+    target: str,
+    fix_formula: str | None,
+) -> dict[str, Any]:
+    with advisory_lock(config_mutation_lock_path()):
+        current = load_config() if os.path.exists(config_path()) else normalize_config(config)
+        return _set_rig_mapping_locked(current, guild_id, rig_name, target, fix_formula)
+
+
+def _set_rig_mapping_locked(
     config: dict[str, Any],
     guild_id: str,
     rig_name: str,
@@ -1176,17 +1490,17 @@ def list_recent_requests(limit: int = 20) -> list[dict[str, Any]]:
     return entries[:limit]
 
 
-def save_gateway_status(payload: dict[str, Any]) -> dict[str, Any]:
+def save_gateway_status(payload: dict[str, Any], app_name: str = "") -> dict[str, Any]:
     ensure_layout()
     body = copy.deepcopy(payload)
     body["updated_at"] = utcnow()
-    atomic_write_json(gateway_status_path(), body)
+    atomic_write_json(gateway_status_path(app_name), body)
     return body
 
 
-def load_gateway_status() -> dict[str, Any]:
+def load_gateway_status(app_name: str = "") -> dict[str, Any]:
     ensure_layout()
-    payload = read_json(gateway_status_path(), {}, allow_invalid=True)
+    payload = read_json(gateway_status_path(app_name), {}, allow_invalid=True)
     if isinstance(payload, dict):
         return payload
     return {}
@@ -1413,9 +1727,15 @@ def touch_room_launch(launch_id: str, *, activity_at: str = "") -> dict[str, Any
         return save_room_launch(body)
 
 
-def set_room_launch_last_addressed(launch_id: str, qualified_handle: str) -> dict[str, Any] | None:
+def set_room_launch_last_addressed(
+    launch_id: str,
+    qualified_handle: str,
+    *,
+    delivery_order: str = "",
+) -> dict[str, Any] | None:
     normalized_launch_id = str(launch_id).strip()
     normalized_handle = str(qualified_handle).strip()
+    normalized_delivery_order = str(delivery_order).strip()
     if not normalized_launch_id or not normalized_handle:
         return None
     with advisory_lock(room_launch_lock_path(normalized_launch_id)):
@@ -1424,8 +1744,15 @@ def set_room_launch_last_addressed(launch_id: str, qualified_handle: str) -> dic
             return None
         if normalized_handle not in room_launch_participants(current):
             return current
+        current_delivery_order = str(current.get("last_addressed_delivery_order", "")).strip()
+        if current_delivery_order and (
+            not normalized_delivery_order or normalized_delivery_order <= current_delivery_order
+        ):
+            return current
         body = copy.deepcopy(current)
         body["last_addressed_qualified_handle"] = normalized_handle
+        if normalized_delivery_order:
+            body["last_addressed_delivery_order"] = normalized_delivery_order
         return save_room_launch(body)
 
 
@@ -1701,6 +2028,17 @@ def list_recent_chat_ingress(limit: int = 20) -> list[dict[str, Any]]:
     return entries[:limit]
 
 
+def list_chat_ingress() -> list[dict[str, Any]]:
+    ensure_layout()
+    entries: list[dict[str, Any]] = []
+    for path in pathlib.Path(chat_ingress_dir()).glob("*.json"):
+        data = read_json(str(path), allow_invalid=True)
+        if isinstance(data, dict):
+            entries.append(data)
+    entries.sort(key=lambda item: item.get("created_at", ""))
+    return entries
+
+
 def prune_chat_ingress() -> None:
     ensure_layout()
     _prune_dir(chat_ingress_dir(), CHAT_INGRESS_RETENTION_SECONDS)
@@ -1804,12 +2142,17 @@ def interactions_url() -> str:
 
 def build_status_snapshot(limit: int = 20) -> dict[str, Any]:
     config = load_config()
+    gateway_statuses = {
+        app_name or "default": redact_gateway_status(load_gateway_status(app_name))
+        for app_name in list_app_names(config)
+    }
     return {
         "service_name": current_service_name(),
         "admin_url": admin_url(),
         "interactions_url": interactions_url(),
         "config": redact_config(config),
         "gateway_status": redact_gateway_status(load_gateway_status()),
+        "gateway_statuses": gateway_statuses,
         "recent_requests": [redact_request_record(item) for item in list_recent_requests(limit=limit)],
         "chat_bindings": list_chat_bindings(config),
         "chat_launchers": list_room_launchers(config),
@@ -1900,7 +2243,7 @@ def discord_api_request(
         "Accept": "application/json",
         "User-Agent": "gas-city-discord/0.1",
     }
-    token = bot_token or load_bot_token()
+    token = load_bot_token() if bot_token is None else bot_token
     if token:
         headers["Authorization"] = f"Bot {token}"
     if payload is not None:
@@ -2084,31 +2427,33 @@ def gc_api_base_url() -> str:
     return f"http://{bind}:{port}"
 
 
-def gc_api_request(
+def gc_api_url(path: str) -> str:
+    base_url = gc_api_base_url()
+    if path.startswith("http://") or path.startswith("https://"):
+        return path
+    # Skip scope discovery if the caller provided an explicit base URL
+    # (it already includes the scope prefix). Strip /v0/ from path
+    # since the base URL already contains the scoped root.
+    override = str(os.environ.get("GC_API_BASE_URL", "")).strip()
+    if override:
+        normalized_path = "/" + path[len("/v0/") :] if path.startswith("/v0/") else path
+    else:
+        city_cfg = load_city_toml()
+        scope_prefix = discover_supervisor_gc_api_scope(city_cfg)
+        normalized_path = path
+        if scope_prefix and path.startswith("/v0/"):
+            normalized_path = scope_prefix + "/" + path[len("/v0/") :]
+    return urllib.parse.urljoin(base_url.rstrip("/") + "/", normalized_path.lstrip("/"))
+
+
+def gc_api_request_with_status(
     method: str,
     path: str,
     payload: Any = None,
     headers: dict[str, str] | None = None,
     timeout: float = GC_API_REQUEST_TIMEOUT_SECONDS,
-) -> Any:
-    base_url = gc_api_base_url()
-    if path.startswith("http://") or path.startswith("https://"):
-        url = path
-    else:
-        # Skip scope discovery if the caller provided an explicit base URL
-        # (it already includes the scope prefix). Strip /v0/ from path
-        # since the base URL already contains the scoped root.
-        override = str(os.environ.get("GC_API_BASE_URL", "")).strip()
-        if override:
-            # Explicit base URL already includes scope; strip /v0/ prefix.
-            normalized_path = "/" + path[len("/v0/"):] if path.startswith("/v0/") else path
-        else:
-            city_cfg = load_city_toml()
-            scope_prefix = discover_supervisor_gc_api_scope(city_cfg)
-            normalized_path = path
-            if scope_prefix and path.startswith("/v0/"):
-                normalized_path = scope_prefix + "/" + path[len("/v0/") :]
-        url = urllib.parse.urljoin(base_url.rstrip("/") + "/", normalized_path.lstrip("/"))
+) -> tuple[int, Any]:
+    url = gc_api_url(path)
     body = None
     request_headers = {
         "Accept": "application/json",
@@ -2124,22 +2469,170 @@ def gc_api_request(
     try:
         with urllib.request.urlopen(request, timeout=timeout) as response:
             raw = response.read()
+            status_code = getattr(response, "status", None)
+            if not isinstance(status_code, int):
+                getcode = getattr(response, "getcode", None)
+                candidate = getcode() if callable(getcode) else None
+                status_code = candidate if isinstance(candidate, int) else 200
     except urllib.error.HTTPError as exc:
         raw = exc.read()
         message = raw.decode("utf-8", errors="replace")
         raise GCAPIError(f"{method.upper()} {url} failed with {exc.code}: {message}") from exc
     except urllib.error.URLError as exc:
-        raise GCAPIError(f"{method.upper()} {url} failed: {exc}") from exc
+        raise GCAPITransportError(f"{method.upper()} {url} failed: {exc}") from exc
     except TimeoutError as exc:
-        raise GCAPIError(f"{method.upper()} {url} timed out") from exc
+        raise GCAPITransportError(f"{method.upper()} {url} timed out") from exc
     except OSError as exc:
-        raise GCAPIError(f"{method.upper()} {url} failed: {exc}") from exc
+        raise GCAPITransportError(f"{method.upper()} {url} failed: {exc}") from exc
     if not raw:
-        return {}
+        return status_code, {}
     try:
-        return json.loads(raw.decode("utf-8"))
+        return status_code, json.loads(raw.decode("utf-8"))
     except json.JSONDecodeError as exc:
         raise GCAPIError(f"{method.upper()} {url} returned invalid JSON") from exc
+
+
+def gc_api_request(
+    method: str,
+    path: str,
+    payload: Any = None,
+    headers: dict[str, str] | None = None,
+    timeout: float = GC_API_REQUEST_TIMEOUT_SECONDS,
+) -> Any:
+    _, response_payload = gc_api_request_with_status(
+        method,
+        path,
+        payload=payload,
+        headers=headers,
+        timeout=timeout,
+    )
+    return response_payload
+
+
+def wait_for_gc_request_result(
+    request_id: str,
+    *,
+    event_cursor: str,
+    success_type: str,
+    failure_operation: str,
+    timeout: float = GC_API_ASYNC_RESULT_TIMEOUT_SECONDS,
+    cancel_event: threading.Event | None = None,
+) -> dict[str, Any]:
+    normalized_request_id = str(request_id).strip()
+    if not normalized_request_id:
+        raise GCAPIError("gc async request did not include request_id")
+    cursor = str(event_cursor).strip() or "0"
+    query = urllib.parse.urlencode({"after_seq": cursor})
+    url = gc_api_url(f"/v0/events/stream?{query}")
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "text/event-stream",
+            "User-Agent": "gas-city-discord/0.1",
+            "X-GC-Request": "true",
+        },
+        method="GET",
+    )
+    data_lines: list[str] = []
+    deadline = time.monotonic() + max(float(timeout), 0.0)
+    if cancel_event is not None and cancel_event.is_set():
+        raise GCAPIRequestCancelled(f"waiting for gc request {normalized_request_id} was cancelled")
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            stream_done = threading.Event()
+            cancel_watcher: threading.Thread | None = None
+            if cancel_event is not None:
+                def close_stream_on_cancel() -> None:
+                    while not stream_done.wait(0.05):
+                        if cancel_event.is_set():
+                            close = getattr(response, "close", None)
+                            if callable(close):
+                                try:
+                                    close()
+                                except (OSError, ValueError):
+                                    pass
+                            return
+
+                cancel_watcher = threading.Thread(
+                    target=close_stream_on_cancel,
+                    name=f"gc-request-cancel-{normalized_request_id}",
+                    daemon=True,
+                )
+                cancel_watcher.start()
+            try:
+                for raw_line in response:
+                    if cancel_event is not None and cancel_event.is_set():
+                        raise GCAPIRequestCancelled(f"waiting for gc request {normalized_request_id} was cancelled")
+                    if time.monotonic() >= deadline:
+                        raise GCAPIResultUnknown(f"GET {url} timed out before request {normalized_request_id} completed")
+                    if isinstance(raw_line, bytes):
+                        try:
+                            line = raw_line.decode("utf-8")
+                        except UnicodeDecodeError as exc:
+                            raise GCAPIResultUnknown("gc event stream returned invalid UTF-8 before request completed") from exc
+                    else:
+                        line = str(raw_line)
+                    line = line.rstrip("\r\n")
+                    if line.startswith("data:"):
+                        data_lines.append(line.removeprefix("data:").lstrip())
+                        continue
+                    if line or not data_lines:
+                        continue
+                    try:
+                        envelope = json.loads("\n".join(data_lines))
+                    except json.JSONDecodeError as exc:
+                        raise GCAPIResultUnknown("gc event stream returned invalid JSON before request completed") from exc
+                    finally:
+                        data_lines = []
+                    if not isinstance(envelope, dict):
+                        continue
+                    event_type = str(envelope.get("type", "")).strip()
+                    payload = envelope.get("payload")
+                    if not isinstance(payload, dict):
+                        continue
+                    if str(payload.get("request_id", "")).strip() != normalized_request_id:
+                        continue
+                    if event_type == success_type:
+                        return payload
+                    if event_type != GC_EVENT_REQUEST_FAILED:
+                        continue
+                    if str(payload.get("operation", "")).strip() != failure_operation:
+                        continue
+                    error_code = str(payload.get("error_code", "")).strip() or "request_failed"
+                    error_message = str(payload.get("error_message", "")).strip() or "asynchronous request failed"
+                    raise GCAPIRequestFailed(
+                        f"{failure_operation} failed: {error_code}: {error_message}",
+                        payload,
+                    )
+            finally:
+                stream_done.set()
+                if cancel_watcher is not None:
+                    cancel_watcher.join(timeout=0.2)
+    except urllib.error.HTTPError as exc:
+        if cancel_event is not None and cancel_event.is_set():
+            raise GCAPIRequestCancelled(f"waiting for gc request {normalized_request_id} was cancelled") from exc
+        raw = exc.read()
+        message = raw.decode("utf-8", errors="replace")
+        raise GCAPIResultUnknown(f"GET {url} failed with {exc.code} before request completed: {message}") from exc
+    except urllib.error.URLError as exc:
+        if cancel_event is not None and cancel_event.is_set():
+            raise GCAPIRequestCancelled(f"waiting for gc request {normalized_request_id} was cancelled") from exc
+        raise GCAPIResultUnknown(f"GET {url} failed before request completed: {exc}") from exc
+    except TimeoutError as exc:
+        if cancel_event is not None and cancel_event.is_set():
+            raise GCAPIRequestCancelled(f"waiting for gc request {normalized_request_id} was cancelled") from exc
+        raise GCAPIResultUnknown(f"GET {url} timed out before request completed") from exc
+    except OSError as exc:
+        if cancel_event is not None and cancel_event.is_set():
+            raise GCAPIRequestCancelled(f"waiting for gc request {normalized_request_id} was cancelled") from exc
+        raise GCAPIResultUnknown(f"GET {url} failed before request completed: {exc}") from exc
+    except ValueError as exc:
+        if cancel_event is not None and cancel_event.is_set():
+            raise GCAPIRequestCancelled(f"waiting for gc request {normalized_request_id} was cancelled") from exc
+        raise GCAPIResultUnknown(f"GET {url} closed before request completed: {exc}") from exc
+    if cancel_event is not None and cancel_event.is_set():
+        raise GCAPIRequestCancelled(f"waiting for gc request {normalized_request_id} was cancelled")
+    raise GCAPIResultUnknown(f"gc event stream closed before request {normalized_request_id} completed")
 
 
 def load_session_transcript_raw(session_selector: str, tail: int = 20) -> list[dict[str, Any]]:
@@ -2224,6 +2717,24 @@ def _chat_ingress_target_matches_selector(target: dict[str, Any], selector: str)
                 str(response.get("session_alias", "")).strip(),
             }
         )
+    terminal_evidence = target.get("terminal_evidence")
+    if isinstance(terminal_evidence, dict):
+        candidates.update(
+            {
+                str(terminal_evidence.get("session_name", "")).strip(),
+                str(terminal_evidence.get("session_id", "")).strip(),
+                str(terminal_evidence.get("session_alias", "")).strip(),
+            }
+        )
+        terminal_payload = terminal_evidence.get("payload")
+        if isinstance(terminal_payload, dict):
+            candidates.update(
+                {
+                    str(terminal_payload.get("session_name", "")).strip(),
+                    str(terminal_payload.get("session_id", "")).strip(),
+                    str(terminal_payload.get("session_alias", "")).strip(),
+                }
+            )
     return wanted in {candidate for candidate in candidates if candidate}
 
 
@@ -4166,7 +4677,12 @@ def record_room_launch_message_target(
         return save_room_launch(body)
 
 
-def resolve_publish_conversation_id(binding: dict[str, Any], requested_conversation_id: str) -> str:
+def resolve_publish_conversation_id(
+    binding: dict[str, Any],
+    requested_conversation_id: str,
+    *,
+    bot_token: str | None = None,
+) -> str:
     binding_conversation_id = str(binding.get("conversation_id", "")).strip()
     requested = str(requested_conversation_id).strip()
     if not requested or requested == binding_conversation_id:
@@ -4174,7 +4690,11 @@ def resolve_publish_conversation_id(binding: dict[str, Any], requested_conversat
     if str(binding.get("kind", "")).strip() == "dm":
         raise ValueError("--conversation-id cannot override a DM binding")
     try:
-        channel_info = discord_api_request("GET", f"/channels/{urllib.parse.quote(requested)}")
+        channel_info = discord_api_request(
+            "GET",
+            f"/channels/{urllib.parse.quote(requested)}",
+            bot_token=bot_token,
+        )
     except DiscordAPIError as exc:
         raise ValueError(f"failed to validate --conversation-id: {exc}") from exc
     parent_id = str((channel_info or {}).get("parent_id", "")).strip()
@@ -4190,12 +4710,17 @@ def resolve_publish_destination(
     trigger_id: str = "",
     reply_to_message_id: str = "",
     source_context: dict[str, str] | None = None,
+    bot_token: str | None = None,
 ) -> tuple[str, str, dict[str, Any] | None]:
     reply_target = str(reply_to_message_id).strip() or str(trigger_id).strip()
     source_meta = derive_publish_source_metadata(source_context)
     launch_id = str(source_meta.get("launch_id", "")).strip()
     if str(binding.get("publish_route_kind", "")).strip() != "room_launch" or not launch_id:
-        conversation_id = resolve_publish_conversation_id(binding, requested_conversation_id)
+        conversation_id = resolve_publish_conversation_id(
+            binding,
+            requested_conversation_id,
+            bot_token=bot_token,
+        )
         return conversation_id, reply_target, None
     current = load_room_launch(launch_id)
     if not current:
@@ -4224,12 +4749,13 @@ def _peer_delivery_needs_attention(record: dict[str, Any]) -> bool:
         return False
     phase = str(peer_delivery.get("phase", "")).strip()
     status = str(peer_delivery.get("status", "")).strip()
-    if phase == "peer_fanout_partial_failure":
+    if phase in {"peer_fanout_in_progress", "peer_fanout_partial_failure"}:
         return True
     if status.startswith("failed_"):
         return True
     return any(
-        str(entry.get("status", "")).strip() in {"failed_retryable", "failed_permanent", "delivery_unknown"}
+        str(entry.get("status", "")).strip()
+        in {"pending", "in_progress", "awaiting_result", "failed_retryable", "failed_permanent", "delivery_unknown"}
         for entry in peer_delivery.get("targets", [])
         if isinstance(entry, dict)
     )
@@ -4248,7 +4774,7 @@ def _finalize_peer_delivery(record: dict[str, Any]) -> dict[str, Any]:
         if isinstance(entry, dict)
     }
     status = str(peer_delivery.get("status", "")).strip()
-    if {"pending", "in_progress"} & terminal_statuses:
+    if {"pending", "in_progress", "awaiting_result"} & terminal_statuses:
         peer_delivery["phase"] = "peer_fanout_in_progress"
     elif status.startswith("failed_"):
         peer_delivery["phase"] = "peer_fanout_partial_failure"
@@ -4293,11 +4819,59 @@ def _update_target_in_progress(
                 "idempotency_key": idempotency_key,
                 "attempt_count": attempt_count,
                 "attempted_at": utcnow(),
+                "request_id": "",
+                "event_cursor": "",
+                "response": {},
+                "terminal_evidence": {},
+                "reason": "",
             },
         )
         current["peer_delivery"] = peer_delivery
         current = _save_chat_publish_record(current)
         return current, attempt_count
+
+
+def _patch_peer_delivery_target(
+    *,
+    publish_id: str,
+    fallback_record: dict[str, Any],
+    session_name: str,
+    patch: dict[str, Any],
+    expected_request_id: str = "",
+) -> dict[str, Any]:
+    with advisory_lock(_safe_lock_name("chat-publish", publish_id)):
+        current = load_chat_publish(publish_id) or copy.deepcopy(fallback_record)
+        peer_delivery = _peer_delivery_payload(current)
+        target_entry = next(
+            (item for item in peer_delivery.get("targets", []) if str(item.get("session_name", "")).strip() == session_name),
+            None,
+        )
+        if expected_request_id and str((target_entry or {}).get("request_id", "")).strip() != expected_request_id:
+            return current
+        _update_peer_target(peer_delivery, session_name, patch)
+        current["peer_delivery"] = peer_delivery
+        return _save_chat_publish_record(current)
+
+
+def _record_peer_async_acceptance(
+    *,
+    publish_id: str,
+    fallback_record: dict[str, Any],
+    session_name: str,
+    accepted: dict[str, Any],
+) -> dict[str, Any]:
+    return _patch_peer_delivery_target(
+        publish_id=publish_id,
+        fallback_record=fallback_record,
+        session_name=session_name,
+        patch={
+            "status": "awaiting_result",
+            "request_id": str(accepted.get("request_id", "")).strip(),
+            "event_cursor": str(accepted.get("event_cursor", "")).strip(),
+            "intent": str(accepted.get("intent", "default")).strip() or "default",
+            "response": accepted.get("response") if isinstance(accepted.get("response"), dict) else {},
+        },
+    )
 
 
 def _update_target_delivery_result(
@@ -4564,13 +5138,61 @@ def _apply_peer_fanout(
             idempotency_key=idempotency_key,
             launch=launch_record,
         )
+
+        def record_async_acceptance(accepted: dict[str, Any], session_name: str = target_key) -> None:
+            nonlocal current
+            current = _record_peer_async_acceptance(
+                publish_id=publish_id,
+                fallback_record=current,
+                session_name=session_name,
+                accepted=accepted,
+            )
+
+        def record_async_terminal(evidence: dict[str, Any], session_name: str = target_key) -> None:
+            nonlocal current
+            request_id = str(
+                next(
+                    (
+                        item.get("request_id", "")
+                        for item in _peer_delivery_payload(current).get("targets", [])
+                        if str(item.get("session_name", "")).strip() == session_name
+                    ),
+                    "",
+                )
+            ).strip()
+            terminal_status = "delivered" if str(evidence.get("status", "")).strip() == "succeeded" else "failed_retryable"
+            current = _patch_peer_delivery_target(
+                publish_id=publish_id,
+                fallback_record=current,
+                session_name=session_name,
+                expected_request_id=request_id,
+                patch={"status": terminal_status, "terminal_evidence": evidence},
+            )
+
         try:
             response = deliver_session_message(
                 delivery_selector,
                 envelope,
                 idempotency_key=idempotency_key,
                 timeout=PEER_DELIVERY_TIMEOUT_SECONDS,
+                async_timeout=PEER_DELIVERY_TIMEOUT_SECONDS,
+                on_async_accepted=record_async_acceptance,
+                on_async_terminal=record_async_terminal,
             )
+        except GCAPIResultUnknown as exc:
+            peer_delivery = _peer_delivery_payload(current)
+            target_entry = next(
+                (item for item in peer_delivery.get("targets", []) if str(item.get("session_name", "")).strip() == target_key),
+                {},
+            )
+            target_status = "awaiting_result" if str(target_entry.get("request_id", "")).strip() else "delivery_unknown"
+            current = _patch_peer_delivery_target(
+                publish_id=publish_id,
+                fallback_record=current,
+                session_name=target_key,
+                patch={"status": target_status, "reason": str(exc)},
+            )
+            continue
         except GCAPIError as exc:
             current = _update_target_delivery_result(
                 publish_id=publish_id,
@@ -4613,6 +5235,7 @@ def retry_peer_fanout(
     if launch_id:
         launch_record = load_room_launch(launch_id)
     retry_targets: list[tuple[str, str, str, str, list[str], str, str, str]] = []
+    resume_targets: list[tuple[str, str, str, str]] = []
     with advisory_lock(_safe_lock_name("chat-publish", publish_id)):
         current = load_chat_publish(publish_id) or record
         current, changed = _promote_stale_in_progress_targets(current)
@@ -4639,7 +5262,17 @@ def retry_peer_fanout(
                     target_selector = resolved_name
             if selected and session_name not in selected:
                 continue
-            if str(entry.get("status", "")).strip() not in eligible:
+            entry_status = str(entry.get("status", "")).strip()
+            request_id = str(entry.get("request_id", "")).strip()
+            event_cursor = str(entry.get("event_cursor", "")).strip()
+            intent = str(entry.get("intent", "default")).strip() or "default"
+            if entry_status == "awaiting_result" or (
+                include_unknown and entry_status == "delivery_unknown" and request_id and event_cursor
+            ):
+                if request_id and event_cursor:
+                    resume_targets.append((session_name, request_id, event_cursor, intent))
+                continue
+            if entry_status not in eligible:
                 continue
             idempotency_key = str(entry.get("idempotency_key", "")).strip()
             if not idempotency_key:
@@ -4656,6 +5289,11 @@ def retry_peer_fanout(
                     "idempotency_key": idempotency_key,
                     "delivery_selector": target_selector,
                     "attempts": attempts,
+                    "request_id": "",
+                    "event_cursor": "",
+                    "response": {},
+                    "terminal_evidence": {},
+                    "reason": "",
                 },
             )
             retry_targets.append(
@@ -4673,6 +5311,55 @@ def retry_peer_fanout(
         current["peer_delivery"] = peer_delivery
         current = _save_chat_publish_record(current)
 
+    for session_name, request_id, event_cursor, intent in resume_targets:
+        try:
+            terminal_payload = resume_session_message_delivery(
+                request_id,
+                event_cursor,
+                intent=intent,
+                timeout=PEER_DELIVERY_TIMEOUT_SECONDS,
+            )
+        except GCAPIResultUnknown as exc:
+            current = _patch_peer_delivery_target(
+                publish_id=publish_id,
+                fallback_record=current,
+                session_name=session_name,
+                expected_request_id=request_id,
+                patch={"status": "awaiting_result", "reason": str(exc)},
+            )
+        except GCAPIRequestFailed as exc:
+            current = _patch_peer_delivery_target(
+                publish_id=publish_id,
+                fallback_record=current,
+                session_name=session_name,
+                expected_request_id=request_id,
+                patch={
+                    "status": "failed_retryable",
+                    "reason": str(exc),
+                    "terminal_evidence": {"status": "failed", "payload": exc.payload},
+                },
+            )
+        except GCAPIError as exc:
+            current = _patch_peer_delivery_target(
+                publish_id=publish_id,
+                fallback_record=current,
+                session_name=session_name,
+                expected_request_id=request_id,
+                patch={"status": "failed_retryable", "reason": str(exc)},
+            )
+        else:
+            current = _patch_peer_delivery_target(
+                publish_id=publish_id,
+                fallback_record=current,
+                session_name=session_name,
+                expected_request_id=request_id,
+                patch={
+                    "status": "delivered",
+                    "delivered_at": utcnow(),
+                    "terminal_evidence": {"status": "succeeded", "payload": terminal_payload},
+                },
+            )
+
     for session_name, target_selector, idempotency_key, delivery, mentioned_session_names, root_ingress_receipt_id, source_session_name, source_session_id in retry_targets:
         envelope = _build_peer_envelope(
             binding=binding,
@@ -4686,13 +5373,61 @@ def retry_peer_fanout(
             idempotency_key=idempotency_key,
             launch=launch_record,
         )
+
+        def record_retry_async_acceptance(accepted: dict[str, Any], retry_session_name: str = session_name) -> None:
+            nonlocal current
+            current = _record_peer_async_acceptance(
+                publish_id=publish_id,
+                fallback_record=current,
+                session_name=retry_session_name,
+                accepted=accepted,
+            )
+
+        def record_retry_async_terminal(evidence: dict[str, Any], retry_session_name: str = session_name) -> None:
+            nonlocal current
+            peer_delivery = _peer_delivery_payload(current)
+            target_entry = next(
+                (
+                    item
+                    for item in peer_delivery.get("targets", [])
+                    if str(item.get("session_name", "")).strip() == retry_session_name
+                ),
+                {},
+            )
+            request_id = str(target_entry.get("request_id", "")).strip()
+            terminal_status = "delivered" if str(evidence.get("status", "")).strip() == "succeeded" else "failed_retryable"
+            current = _patch_peer_delivery_target(
+                publish_id=publish_id,
+                fallback_record=current,
+                session_name=retry_session_name,
+                expected_request_id=request_id,
+                patch={"status": terminal_status, "terminal_evidence": evidence},
+            )
+
         try:
             response = deliver_session_message(
                 target_selector,
                 envelope,
                 idempotency_key=idempotency_key,
                 timeout=PEER_DELIVERY_TIMEOUT_SECONDS,
+                async_timeout=PEER_DELIVERY_TIMEOUT_SECONDS,
+                on_async_accepted=record_retry_async_acceptance,
+                on_async_terminal=record_retry_async_terminal,
             )
+        except GCAPIResultUnknown as exc:
+            peer_delivery = _peer_delivery_payload(current)
+            target_entry = next(
+                (item for item in peer_delivery.get("targets", []) if str(item.get("session_name", "")).strip() == session_name),
+                {},
+            )
+            target_status = "awaiting_result" if str(target_entry.get("request_id", "")).strip() else "delivery_unknown"
+            current = _patch_peer_delivery_target(
+                publish_id=publish_id,
+                fallback_record=current,
+                session_name=session_name,
+                patch={"status": target_status, "reason": str(exc)},
+            )
+            continue
         except GCAPIError as exc:
             current = _update_target_delivery_result(
                 publish_id=publish_id,
@@ -4727,20 +5462,63 @@ def publish_binding_message(
     source_session_name: str = "",
     source_session_id: str = "",
 ) -> dict[str, Any]:
+    app_name = validate_app_name(binding.get("app", ""))
+    bot_token: str | None = None
+    if app_name:
+        bot_token = load_bot_token(app_name)
+        if not bot_token:
+            raise DiscordAPIError(f"Discord bot token is not configured for app {app_name!r}")
+    if str(binding.get("kind", "")).strip() == "room":
+        config = load_config()
+        policy = resolve_app_policy(config, app_name)
+        has_outbound_policy = bool(
+            _normalize_allowlist(policy.get("guild_allowlist"))
+            or _normalize_allowlist(policy.get("channel_allowlist"))
+        )
+        if has_outbound_policy:
+            policy_token = bot_token or load_bot_token()
+            if not policy_token:
+                display_name = app_name or "default"
+                raise DiscordAPIError(f"Discord bot token is not configured for app {display_name!r}")
+            binding_conversation_id = str(binding.get("conversation_id", "")).strip()
+            channel_scope = describe_room_channel_scope(binding_conversation_id, bot_token=policy_token)
+            actual_guild_id = str(channel_scope.get("guild_id", "")).strip()
+            parent_channel_id = (
+                str(channel_scope.get("thread_parent_id", "")).strip()
+                or binding_conversation_id
+            )
+            policy_rejection = outbound_policy_reason(
+                config,
+                actual_guild_id,
+                parent_channel_id,
+                app_name=app_name,
+            )
+            if policy_rejection:
+                display_name = app_name or "default"
+                raise ValueError(f"Discord app {display_name!r} policy rejects publish: {policy_rejection}")
     conversation_id, reply_target, launch = resolve_publish_destination(
         binding,
         requested_conversation_id=requested_conversation_id,
         trigger_id=trigger_id,
         reply_to_message_id=reply_to_message_id,
         source_context=source_context,
+        bot_token=bot_token,
     )
     if not conversation_id:
         raise ValueError("binding is missing a destination conversation_id")
-    response = post_channel_message(
-        conversation_id,
-        body,
-        reply_to_message_id=reply_target,
-    )
+    if app_name:
+        response = post_channel_message(
+            conversation_id,
+            body,
+            reply_to_message_id=reply_target,
+            bot_token=bot_token,
+        )
+    else:
+        response = post_channel_message(
+            conversation_id,
+            body,
+            reply_to_message_id=reply_target,
+        )
     remote_message_id = str((response or {}).get("id", "")).strip()
     if not remote_message_id:
         raise DiscordAPIError("discord publish returned no message id")
@@ -4772,6 +5550,7 @@ def publish_binding_message(
             "binding_id": str(binding.get("id", "")).strip(),
             "binding_kind": str(binding.get("kind", "")).strip(),
             "binding_conversation_id": str(binding.get("conversation_id", "")).strip(),
+            "app": app_name,
             "conversation_id": conversation_id,
             "guild_id": str(binding.get("guild_id", "")).strip(),
             "trigger_id": str(trigger_id).strip(),
@@ -4804,6 +5583,31 @@ def publish_binding_message(
     return {"binding": binding, "record": record, "response": response}
 
 
+def resume_session_message_delivery(
+    request_id: str,
+    event_cursor: str,
+    *,
+    intent: str = "default",
+    timeout: float = GC_API_ASYNC_RESULT_TIMEOUT_SECONDS,
+    cancel_event: threading.Event | None = None,
+) -> dict[str, Any]:
+    normalized_intent = str(intent or "default").strip() or "default"
+    if normalized_intent == "default":
+        success_type = GC_EVENT_SESSION_MESSAGE_SUCCEEDED
+        failure_operation = GC_OPERATION_SESSION_MESSAGE
+    else:
+        success_type = GC_EVENT_SESSION_SUBMIT_SUCCEEDED
+        failure_operation = GC_OPERATION_SESSION_SUBMIT
+    return wait_for_gc_request_result(
+        request_id,
+        event_cursor=event_cursor,
+        success_type=success_type,
+        failure_operation=failure_operation,
+        timeout=timeout,
+        cancel_event=cancel_event,
+    )
+
+
 def deliver_session_message(
     session_name: str,
     message: str,
@@ -4811,7 +5615,13 @@ def deliver_session_message(
     timeout: float = GC_API_REQUEST_TIMEOUT_SECONDS,
     *,
     intent: str = "default",
+    async_timeout: float = GC_API_ASYNC_RESULT_TIMEOUT_SECONDS,
+    cancel_event: threading.Event | None = None,
+    on_async_accepted: Callable[[dict[str, Any]], None] | None = None,
+    on_async_terminal: Callable[[dict[str, Any]], None] | None = None,
 ) -> dict[str, Any]:
+    if cancel_event is not None and cancel_event.is_set():
+        raise GCAPIRequestCancelled("session delivery was cancelled before submission")
     headers: dict[str, str] = {}
     key = str(idempotency_key).strip()
     if key:
@@ -4822,15 +5632,49 @@ def deliver_session_message(
     if normalized_intent != "default":
         path = f"/v0/session/{urllib.parse.quote(str(session_name).strip(), safe='')}/submit"
         payload_body["intent"] = normalized_intent
-    payload = gc_api_request(
-        "POST",
-        path,
-        payload=payload_body,
-        headers=headers,
-        timeout=timeout,
-    )
+    try:
+        status_code, payload = gc_api_request_with_status(
+            "POST",
+            path,
+            payload=payload_body,
+            headers=headers,
+            timeout=timeout,
+        )
+    except GCAPITransportError as exc:
+        raise GCAPIResultUnknown(f"session delivery outcome is unknown: {exc}") from exc
     if not isinstance(payload, dict):
+        if status_code == 202:
+            raise GCAPIResultUnknown("gc async HTTP 202 response requires request_id and event_cursor")
         return {}
+    if status_code != 202:
+        return payload
+    request_id = str(payload.get("request_id", "")).strip()
+    event_cursor = str(payload.get("event_cursor", "")).strip()
+    if not request_id or not event_cursor:
+        raise GCAPIResultUnknown("gc async HTTP 202 response requires request_id and event_cursor")
+    accepted_request = {
+        "http_status": status_code,
+        "request_id": request_id,
+        "event_cursor": event_cursor,
+        "intent": normalized_intent,
+        "response": payload,
+    }
+    if on_async_accepted is not None:
+        on_async_accepted(accepted_request)
+    try:
+        terminal_payload = resume_session_message_delivery(
+            request_id,
+            event_cursor=event_cursor,
+            intent=normalized_intent,
+            timeout=async_timeout,
+            cancel_event=cancel_event,
+        )
+    except GCAPIRequestFailed as exc:
+        if on_async_terminal is not None:
+            on_async_terminal({"status": "failed", "payload": exc.payload})
+        raise
+    if on_async_terminal is not None:
+        on_async_terminal({"status": "succeeded", "payload": terminal_payload})
     return payload
 
 
@@ -4884,7 +5728,13 @@ def sync_guild_commands(config: dict[str, Any], guild_id: str) -> Any:
     )
 
 
-def post_channel_message(channel_id: str, body: str, reply_to_message_id: str = "") -> Any:
+def post_channel_message(
+    channel_id: str,
+    body: str,
+    reply_to_message_id: str = "",
+    *,
+    bot_token: str | None = None,
+) -> Any:
     payload: dict[str, Any] = {
         "content": body,
         "allowed_mentions": {"parse": ["users"]},
@@ -4896,11 +5746,10 @@ def post_channel_message(channel_id: str, body: str, reply_to_message_id: str = 
             "message_id": reply_to_message_id,
             "fail_if_not_exists": False,
         }
-    return discord_api_request(
-        "POST",
-        f"/channels/{urllib.parse.quote(str(channel_id))}/messages",
-        payload=payload,
-    )
+    path = f"/channels/{urllib.parse.quote(str(channel_id))}/messages"
+    if bot_token is None:
+        return discord_api_request("POST", path, payload=payload)
+    return discord_api_request("POST", path, payload=payload, bot_token=bot_token)
 
 
 def discord_jump_url(guild_id: str, conversation_id: str) -> str:
@@ -4911,9 +5760,15 @@ def discord_jump_url(guild_id: str, conversation_id: str) -> str:
     return f"https://discord.com/channels/{guild_id}/{conversation_id}"
 
 
-def policy_reason(config: dict[str, Any], guild_id: str, parent_channel_id: str, role_ids: list[str]) -> str:
-    normalized = normalize_config(config)
-    policy = normalized.get("policy", {})
+def policy_reason(
+    config: dict[str, Any],
+    guild_id: str,
+    parent_channel_id: str,
+    role_ids: list[str],
+    *,
+    app_name: str = "",
+) -> str:
+    policy = resolve_app_policy(config, app_name)
     guild_allowlist = set(_normalize_allowlist(policy.get("guild_allowlist")))
     channel_allowlist = set(_normalize_allowlist(policy.get("channel_allowlist")))
     role_allowlist = set(_normalize_allowlist(policy.get("role_allowlist")))
@@ -4923,4 +5778,21 @@ def policy_reason(config: dict[str, Any], guild_id: str, parent_channel_id: str,
         return "channel_not_allowed"
     if role_allowlist and not role_allowlist.intersection(set(role_ids)):
         return "role_not_allowed"
+    return ""
+
+
+def outbound_policy_reason(
+    config: dict[str, Any],
+    guild_id: str,
+    parent_channel_id: str,
+    *,
+    app_name: str = "",
+) -> str:
+    policy = resolve_app_policy(config, app_name)
+    guild_allowlist = set(_normalize_allowlist(policy.get("guild_allowlist")))
+    channel_allowlist = set(_normalize_allowlist(policy.get("channel_allowlist")))
+    if guild_allowlist and str(guild_id).strip() not in guild_allowlist:
+        return "guild_not_allowed"
+    if channel_allowlist and str(parent_channel_id).strip() not in channel_allowlist:
+        return "channel_not_allowed"
     return ""

--- a/discord/scripts/discord_intake_import.py
+++ b/discord/scripts/discord_intake_import.py
@@ -13,38 +13,71 @@ import discord_intake_common as common
 def _read_optional_file(path: str | None) -> str:
     if not path:
         return ""
-    return pathlib.Path(path).read_text(encoding="utf-8").strip()
+    try:
+        value = pathlib.Path(path).read_text(encoding="utf-8").strip()
+    except OSError as exc:
+        raise ValueError(f"could not read bot token file {path!r}: {exc.strerror or 'I/O error'}") from exc
+    if not value:
+        raise ValueError("bot token file is empty")
+    return value
 
 
 def main(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(description="Import Discord app metadata into the Discord pack")
+    parser.add_argument("--app", default="", help="Optional named app identity")
     parser.add_argument("--application-id", required=True, help="Discord application id")
     parser.add_argument("--public-key", required=True, help="Discord interaction public key (hex)")
     parser.add_argument("--command-name", default=common.COMMAND_NAME_DEFAULT, help="Slash command root name")
-    parser.add_argument("--bot-token", default="", help="Discord bot token")
-    parser.add_argument("--bot-token-file", default="", help="Read the Discord bot token from a file")
-    parser.add_argument("--guild-allowlist", action="append", default=[], help="Optional allowed guild id")
-    parser.add_argument("--channel-allowlist", action="append", default=[], help="Optional allowed parent channel id")
-    parser.add_argument("--role-allowlist", action="append", default=[], help="Optional allowed Discord role id")
+    token_group = parser.add_mutually_exclusive_group()
+    token_group.add_argument("--bot-token", default=None, help="Discord bot token")
+    token_group.add_argument("--bot-token-file", default=None, help="Read the Discord bot token from a file")
+    parser.add_argument("--guild-allowlist", action="append", default=None, help="Optional allowed guild id")
+    parser.add_argument("--channel-allowlist", action="append", default=None, help="Optional allowed parent channel id")
+    parser.add_argument("--role-allowlist", action="append", default=None, help="Optional allowed Discord role id")
     args = parser.parse_args(argv)
 
-    bot_token = args.bot_token.strip() or _read_optional_file(args.bot_token_file)
+    app_name = ""
     try:
+        app_name = common.validate_app_name(args.app)
+        if args.bot_token_file is not None:
+            bot_token = _read_optional_file(args.bot_token_file)
+        elif args.bot_token is not None:
+            bot_token = str(args.bot_token).strip()
+            if not bot_token:
+                raise ValueError("bot token is empty")
+        else:
+            bot_token = ""
+        requested_application_id = common.validate_application_id(args.application_id)
+        if app_name and bot_token:
+            current_user = common.discord_api_request("GET", "/users/@me", bot_token=bot_token)
+            authenticated_user_id = str(current_user.get("id", "")).strip() if isinstance(current_user, dict) else ""
+            if authenticated_user_id != requested_application_id:
+                raise ValueError(
+                    f"Discord app {app_name!r} token authenticated as user {authenticated_user_id or '<unknown>'!r}, "
+                    f"not configured application_id {requested_application_id!r}"
+                )
+        app_fields = {
+            "application_id": args.application_id,
+            "public_key": args.public_key,
+            "command_name": args.command_name,
+        }
+        for field_name in ("guild_allowlist", "channel_allowlist", "role_allowlist"):
+            value = getattr(args, field_name)
+            if value is not None:
+                app_fields[field_name] = value
         config = common.import_app_config(
             common.load_config(),
-            {
-                "application_id": args.application_id,
-                "public_key": args.public_key,
-                "command_name": args.command_name,
-                "guild_allowlist": args.guild_allowlist,
-                "channel_allowlist": args.channel_allowlist,
-                "role_allowlist": args.role_allowlist,
-            },
+            app_fields,
+            app_name=app_name,
+            bot_token=bot_token or None,
         )
+    except common.DiscordAPIError as exc:
+        status = f" (HTTP {exc.status_code})" if exc.status_code is not None else ""
+        raise SystemExit(f"failed to authenticate Discord bot token for app {app_name!r}{status}") from exc
     except ValueError as exc:
         raise SystemExit(str(exc)) from exc
-    if bot_token:
-        common.save_bot_token(bot_token)
+    except OSError as exc:
+        raise SystemExit(f"failed to save Discord app credentials: {exc}") from exc
     print(json.dumps(common.redact_config(config), indent=2, sort_keys=True))
     return 0
 

--- a/discord/scripts/discord_intake_status.py
+++ b/discord/scripts/discord_intake_status.py
@@ -18,6 +18,7 @@ def render_text(snapshot: dict[str, object]) -> str:
     ingress = snapshot.get("recent_chat_ingress", [])
     publishes = snapshot.get("recent_chat_publishes", [])
     launches = snapshot.get("recent_room_launches", [])
+    gateway_statuses = snapshot.get("gateway_statuses", {})
     lines = [
         "Discord",
         f"  interactions_url: {snapshot.get('interactions_url') or '(not published yet)'}",
@@ -33,8 +34,27 @@ def render_text(snapshot: dict[str, object]) -> str:
         f"  chat_ingress:     {len(ingress)}",
         f"  chat_publishes:   {len(publishes)}",
         "",
-        "Recent Requests:",
+        "Apps:",
     ]
+    app_config = ((config or {}).get("app") or {})
+    named_apps = ((config or {}).get("apps") or {})
+    app_rows = [("default", app_config)] + sorted(named_apps.items())
+    for app_name, item in app_rows:
+        app_gateway = (gateway_statuses or {}).get(app_name, {})
+        lines.append(
+            "  - {app} application_id={application_id} token={token} gateway={gateway} "
+            "routed={routed} ignored={ignored} failed={failed} dropped={dropped}".format(
+                app=app_name,
+                application_id=item.get("application_id", "") or "-",
+                token="present" if item.get("bot_token_present") else "missing",
+                gateway=app_gateway.get("state", "") or "(unknown)",
+                routed=int(app_gateway.get("routed_messages", 0) or 0),
+                ignored=int(app_gateway.get("ignored_messages", 0) or 0),
+                failed=int(app_gateway.get("failed_messages", 0) or 0),
+                dropped=int(app_gateway.get("dropped_messages", 0) or 0),
+            )
+        )
+    lines.extend(["", "Recent Requests:"])
     if not requests:
         lines.append("  (none)")
     else:
@@ -55,8 +75,9 @@ def render_text(snapshot: dict[str, object]) -> str:
     else:
         for item in bindings:
             lines.append(
-                "  - {binding_id} kind={kind} conversation={conversation_id} sessions={sessions}".format(
+                "  - {binding_id} app={app} kind={kind} conversation={conversation_id} sessions={sessions}".format(
                     binding_id=item.get("id", ""),
+                    app=item.get("app", "") or "default",
                     kind=item.get("kind", ""),
                     conversation_id=item.get("conversation_id", ""),
                     sessions=",".join(item.get("session_names", [])),

--- a/discord/tests/test_discord_gateway_service.py
+++ b/discord/tests/test_discord_gateway_service.py
@@ -219,6 +219,78 @@ class DiscordGatewayServiceTests(unittest.TestCase):
         self.assertEqual(lead_receipt["binding_id"], "room:22@app:ollie")
         self.assertEqual(pm_receipt["binding_id"], "room:22@app:olivia")
 
+    def test_named_app_async_submit_failure_cannot_leave_delivered_receipt(self) -> None:
+        config = common.import_app_config(
+            common.load_config(),
+            {"application_id": "999", "public_key": "ab" * 32},
+            app_name="ollie",
+        )
+        common.set_chat_binding(
+            config,
+            "room",
+            "22",
+            ["teams.lead"],
+            guild_id="1",
+            app_name="ollie",
+            channel_metadata={"channel_type": 0},
+        )
+        message = {
+            "id": "async-failure-203",
+            "guild_id": "1",
+            "channel_id": "22",
+            "content": "<@999> please investigate",
+            "mentions": [{"id": "999"}],
+            "author": {"id": "u-2", "username": "alice"},
+        }
+        accepted_response = mock.MagicMock()
+        accepted_response.__enter__.return_value = mock.Mock(
+            read=mock.Mock(
+                return_value=b'{"status":"accepted","request_id":"req-submit","event_cursor":"41"}'
+            )
+        )
+        accepted_response.__enter__.return_value.status = 202
+        accepted_response.__exit__.return_value = False
+        failed_stream = mock.MagicMock()
+        failed_stream.__enter__.return_value = iter(
+            [
+                b"event: request.failed\n",
+                b'data: {"type":"request.failed","payload":{"request_id":"req-other-app","operation":"session.submit","error_code":"submit_failed","error_message":"other app failed"}}\n',
+                b"\n",
+                b"event: request.failed\n",
+                b'data: {"type":"request.failed","payload":{"request_id":"req-submit","operation":"session.submit","error_code":"submit_failed","error_message":"session disappeared"}}\n',
+                b"\n",
+            ]
+        )
+        failed_stream.__exit__.return_value = False
+
+        with mock.patch.dict(
+            os.environ,
+            {"GC_API_BASE_URL": "http://gc.test/v0/city/test"},
+        ), mock.patch.object(
+            common,
+            "session_index_by_name",
+            return_value={"teams.lead": {"session_name": "teams.lead", "state": "active"}},
+        ), mock.patch.object(
+            common.urllib.request,
+            "urlopen",
+            side_effect=[accepted_response, failed_stream],
+        ) as urlopen:
+            outcome = gateway_service.process_inbound_message(message, bot_user_id="999", app_name="ollie")
+
+        self.assertEqual(outcome["status"], "failed")
+        self.assertEqual(len(urlopen.call_args_list), 2)
+        self.assertEqual(
+            urlopen.call_args_list[1].args[0].full_url,
+            "http://gc.test/v0/city/test/events/stream?after_seq=41",
+        )
+        receipt = common.load_chat_ingress("in-async-failure-203-app-ollie")
+        self.assertEqual(receipt["app"], "ollie")
+        self.assertEqual(receipt["status"], "failed")
+        self.assertEqual(receipt["targets"][0]["status"], "failed")
+        self.assertIn("session.submit failed: submit_failed: session disappeared", receipt["targets"][0]["error"])
+        self.assertEqual(receipt["targets"][0]["terminal_evidence"]["status"], "failed")
+        self.assertEqual(receipt["targets"][0]["terminal_evidence"]["payload"]["error_code"], "submit_failed")
+
     def test_named_app_gateway_policy_is_evaluated_independently(self) -> None:
         config = common.import_app_config(
             common.load_config(),
@@ -2313,6 +2385,260 @@ class DiscordGatewayServiceTests(unittest.TestCase):
         self.assertEqual(outcome["status"], "delivered")
         deliver_session_message.assert_called_once()
 
+    def test_process_inbound_message_persists_async_correlation_when_result_is_unknown(self) -> None:
+        common.set_chat_binding(common.load_config(), "dm", "55", ["sky"])
+        message = {
+            "id": "917",
+            "channel_id": "55",
+            "content": "hello from discord",
+            "author": {"id": "u-17", "username": "alice"},
+        }
+
+        def unknown_after_acceptance(*args: object, **kwargs: object) -> dict[str, object]:
+            kwargs["on_async_accepted"](
+                {
+                    "http_status": 202,
+                    "request_id": "req-17",
+                    "event_cursor": "42",
+                    "intent": "follow_up",
+                    "response": {"status": "accepted", "request_id": "req-17", "event_cursor": "42"},
+                }
+            )
+            raise common.GCAPIResultUnknown("event stream closed")
+
+        with mock.patch.object(common, "session_index_by_name", return_value={"sky": {"session_name": "sky", "state": "active"}}), mock.patch.object(
+            common,
+            "deliver_session_message",
+            side_effect=unknown_after_acceptance,
+        ):
+            outcome = gateway_service.process_inbound_message(message, bot_user_id="999")
+
+        self.assertEqual(outcome["status"], "pending")
+        receipt = common.load_chat_ingress("in-917")
+        assert receipt is not None
+        self.assertEqual(receipt["delivery_protocol_version"], 2)
+        self.assertEqual(receipt["targets"][0]["status"], "awaiting_result")
+        self.assertEqual(receipt["targets"][0]["request_id"], "req-17")
+        self.assertEqual(receipt["targets"][0]["event_cursor"], "42")
+
+    def test_recover_pending_ingress_resumes_original_async_request_without_posting(self) -> None:
+        common.atomic_write_json(
+            common.chat_ingress_path("in-919-app-ollie"),
+            {
+                "ingress_id": "in-919-app-ollie",
+                "app": "ollie",
+                "status": "pending",
+                "delivery_protocol_version": 2,
+                "targets": [
+                    {
+                        "session_name": "teams.lead",
+                        "status": "awaiting_result",
+                        "request_id": "req-19",
+                        "event_cursor": "51",
+                        "intent": "follow_up",
+                        "response": {"status": "accepted", "request_id": "req-19", "event_cursor": "51"},
+                    }
+                ],
+                "created_at": "2000-01-01T00:00:00Z",
+                "updated_at": "2000-01-01T00:00:00Z",
+            },
+        )
+        terminal = {"request_id": "req-19", "session_id": "session-19", "queued": True}
+
+        with mock.patch.object(
+            common,
+            "resume_session_message_delivery",
+            return_value=terminal,
+        ) as resume_session_message_delivery, mock.patch.object(
+            common,
+            "deliver_session_message",
+        ) as deliver_session_message:
+            recovered = gateway_service.recover_pending_ingress_receipts(
+                bot_user_id="999",
+                app_name="ollie",
+                cancel_event=threading.Event(),
+            )
+
+        self.assertEqual(recovered, ["in-919-app-ollie"])
+        deliver_session_message.assert_not_called()
+        resume_session_message_delivery.assert_called_once_with(
+            "req-19",
+            "51",
+            intent="follow_up",
+            timeout=common.GC_API_ASYNC_RESULT_TIMEOUT_SECONDS,
+            cancel_event=mock.ANY,
+        )
+        receipt = common.load_chat_ingress("in-919-app-ollie")
+        assert receipt is not None
+        self.assertEqual(receipt["status"], "delivered")
+        self.assertEqual(receipt["targets"][0]["status"], "delivered")
+        self.assertEqual(receipt["targets"][0]["terminal_evidence"], {"status": "succeeded", "payload": terminal})
+
+    def test_recover_pending_ingress_does_not_retain_or_repost_pre_submission_body(self) -> None:
+        common.atomic_write_json(
+            common.chat_ingress_path("in-921-app-ollie"),
+            {
+                "ingress_id": "in-921-app-ollie",
+                "app": "ollie",
+                "status": "pending",
+                "delivery_protocol_version": 2,
+                "targets": [
+                    {
+                        "session_name": "teams.lead",
+                        "status": "pending",
+                        "intent": "follow_up",
+                        "idempotency_key": "ingress:in-921-app-ollie:target:teams.lead",
+                    }
+                ],
+                "created_at": "2000-01-01T00:00:00Z",
+                "updated_at": "2000-01-01T00:00:00Z",
+            },
+        )
+
+        with mock.patch.object(
+            common,
+            "deliver_session_message",
+            return_value={"status": "accepted"},
+        ) as deliver_session_message:
+            recovered = gateway_service.recover_pending_ingress_receipts(
+                bot_user_id="999",
+                app_name="ollie",
+                cancel_event=threading.Event(),
+            )
+
+        self.assertEqual(recovered, ["in-921-app-ollie"])
+        deliver_session_message.assert_not_called()
+        receipt = common.load_chat_ingress("in-921-app-ollie")
+        assert receipt is not None
+        self.assertEqual(receipt["status"], "delivery_unknown")
+        self.assertEqual(receipt["targets"][0]["status"], "delivery_unknown")
+        self.assertEqual(receipt["targets"][0]["reason"], "delivery_payload_not_retained")
+        self.assertNotIn("envelope", receipt["targets"][0])
+
+    def test_recover_pending_ingress_quarantines_legacy_receipt_without_async_correlation(self) -> None:
+        common.atomic_write_json(
+            common.chat_ingress_path("in-920-app-ollie"),
+            {
+                "ingress_id": "in-920-app-ollie",
+                "app": "ollie",
+                "status": "pending",
+                "targets": [{"session_name": "teams.lead", "status": "pending"}],
+                "created_at": "2000-01-01T00:00:00Z",
+                "updated_at": "2000-01-01T00:00:00Z",
+            },
+        )
+
+        with mock.patch.object(common, "resume_session_message_delivery") as resume_session_message_delivery, mock.patch.object(
+            common,
+            "deliver_session_message",
+        ) as deliver_session_message:
+            recovered = gateway_service.recover_pending_ingress_receipts(
+                bot_user_id="999",
+                app_name="ollie",
+                cancel_event=threading.Event(),
+            )
+
+        self.assertEqual(recovered, ["in-920-app-ollie"])
+        resume_session_message_delivery.assert_not_called()
+        deliver_session_message.assert_not_called()
+        receipt = common.load_chat_ingress("in-920-app-ollie")
+        assert receipt is not None
+        self.assertEqual(receipt["status"], "delivery_unknown")
+        self.assertEqual(receipt["targets"][0]["status"], "delivery_unknown")
+        self.assertEqual(receipt["targets"][0]["reason"], "missing_async_correlation")
+
+    def test_recovery_applies_missing_room_launch_thread_routing_side_effect(self) -> None:
+        common.atomic_write_json(
+            common.chat_ingress_path("in-922-app-ollie"),
+            {
+                "ingress_id": "in-922-app-ollie",
+                "app": "ollie",
+                "status": "delivered",
+                "delivery_protocol_version": 2,
+                "route_kind": "room_launch_thread",
+                "launch_id": "room-launch:thread-922",
+                "qualified_handle": "corp/priya",
+                "targets": [{"session_name": "teams.priya", "status": "delivered"}],
+                "created_at": "2000-01-01T00:00:00Z",
+                "updated_at": "2000-01-01T00:00:00Z",
+            },
+        )
+
+        with mock.patch.object(
+            common,
+            "set_room_launch_last_addressed",
+            return_value={"launch_id": "room-launch:thread-922"},
+        ) as set_room_launch_last_addressed:
+            recovered = gateway_service.recover_pending_ingress_receipts(
+                bot_user_id="999",
+                app_name="ollie",
+                cancel_event=threading.Event(),
+            )
+
+        self.assertEqual(recovered, ["in-922-app-ollie"])
+        set_room_launch_last_addressed.assert_called_once_with(
+            "room-launch:thread-922",
+            "corp/priya",
+            delivery_order=mock.ANY,
+        )
+        receipt = common.load_chat_ingress("in-922-app-ollie")
+        assert receipt is not None
+        self.assertTrue(receipt["routing_state_applied_at"])
+
+    def test_recovery_does_not_replay_routing_state_for_legacy_delivered_receipt(self) -> None:
+        common.atomic_write_json(
+            common.chat_ingress_path("in-923-app-ollie"),
+            {
+                "ingress_id": "in-923-app-ollie",
+                "app": "ollie",
+                "status": "delivered",
+                "route_kind": "room_launch_thread",
+                "launch_id": "room-launch:thread-923",
+                "qualified_handle": "corp/priya",
+                "targets": [{"session_name": "teams.priya", "status": "delivered"}],
+                "created_at": "2000-01-01T00:00:00Z",
+                "updated_at": "2000-01-01T00:00:00Z",
+            },
+        )
+
+        with mock.patch.object(common, "set_room_launch_last_addressed") as set_room_launch_last_addressed:
+            recovered = gateway_service.recover_pending_ingress_receipts(
+                bot_user_id="999",
+                app_name="ollie",
+                cancel_event=threading.Event(),
+            )
+
+        self.assertEqual(recovered, [])
+        set_room_launch_last_addressed.assert_not_called()
+
+    def test_process_inbound_message_keeps_fresh_pending_receipt_as_duplicate(self) -> None:
+        common.set_chat_binding(common.load_config(), "dm", "55", ["sky"])
+        now = common.utcnow()
+        common.atomic_write_json(
+            common.chat_ingress_path("in-918"),
+            {
+                "ingress_id": "in-918",
+                "status": "pending",
+                "created_at": now,
+                "updated_at": now,
+            },
+        )
+        message = {
+            "id": "918",
+            "channel_id": "55",
+            "content": "hello from discord",
+            "author": {"id": "u-18", "username": "alice"},
+        }
+
+        with mock.patch.object(common, "deliver_session_message") as deliver_session_message:
+            outcome = gateway_service.process_inbound_message(message, bot_user_id="999")
+
+        self.assertEqual(outcome["status"], "duplicate")
+        deliver_session_message.assert_not_called()
+        receipt = common.load_chat_ingress("in-918")
+        assert receipt is not None
+        self.assertEqual(receipt["status"], "pending")
+
     def test_process_inbound_message_records_unreadable_claim_conflict(self) -> None:
         path = common.chat_ingress_path("in-910")
         pathlib.Path(path).parent.mkdir(parents=True, exist_ok=True)
@@ -2604,19 +2930,83 @@ class DiscordGatewayServiceTests(unittest.TestCase):
         self.assertIs(lock_a, gateway_service.channel_info_fetch_lock("222"))
         self.assertIsNot(lock_a, lock_b)
 
-    def test_worker_stop_drains_queued_messages_before_exit(self) -> None:
+    def test_worker_stop_rejects_queued_messages_before_exit(self) -> None:
         runtime_state = gateway_service.GatewayRuntimeState()
-        worker = gateway_service.GatewayWorker(runtime_state)
+        with mock.patch.object(gateway_service, "GATEWAY_WORKER_THREADS", 1):
+            worker = gateway_service.GatewayWorker(runtime_state)
         self.addCleanup(lambda: worker.stop() if not worker.stop_event.is_set() else None)
 
         handled: list[str] = []
-        with mock.patch.object(worker, "handle_gateway_message", side_effect=lambda message, bot_user_id: handled.append(str(message.get("id", "")))):
+        active_started = threading.Event()
+
+        def handle_until_stopped(message: dict[str, object], bot_user_id: str) -> None:
+            del bot_user_id
+            handled.append(str(message.get("id", "")))
+            active_started.set()
+            worker.stop_event.wait(timeout=1)
+
+        with mock.patch.object(worker, "handle_gateway_message", side_effect=handle_until_stopped):
+            worker.dispatch_gateway_message({"id": "1000", "channel_id": "55", "author": {"id": "u-1000"}}, "999")
+            self.assertTrue(active_started.wait(timeout=1))
             worker.dispatch_gateway_message({"id": "1001", "channel_id": "55", "author": {"id": "u-1001"}}, "999")
             worker.stop()
 
-        self.assertEqual(handled, ["1001"])
+        self.assertEqual(handled, ["1000"])
         self.assertTrue(worker.stop_event.is_set())
         self.assertTrue(all(not thread.is_alive() for thread in worker.worker_threads))
+        receipt = common.load_chat_ingress("in-1001")
+        assert receipt is not None
+        self.assertEqual(receipt["status"], "rejected_shutting_down")
+        self.assertEqual(receipt["reason"], "service_shutting_down")
+
+    def test_named_worker_starts_app_scoped_pending_recovery(self) -> None:
+        runtime_state = gateway_service.GatewayRuntimeState("ollie")
+        with mock.patch.object(gateway_service, "GATEWAY_NAMED_WORKER_THREADS", 0):
+            worker = gateway_service.GatewayWorker(runtime_state, "ollie")
+        self.addCleanup(worker.stop)
+        recovered = threading.Event()
+
+        def recover_once(**kwargs: object) -> list[str]:
+            recovered.set()
+            worker.stop_event.set()
+            return []
+
+        with mock.patch.object(
+            gateway_service,
+            "recover_pending_ingress_receipts",
+            side_effect=recover_once,
+        ) as recover_pending_ingress_receipts:
+            worker.start_pending_recovery("999")
+            self.assertTrue(recovered.wait(timeout=1))
+            assert worker.recovery_thread is not None
+            worker.recovery_thread.join(timeout=1)
+
+        recover_pending_ingress_receipts.assert_called_once_with(
+            bot_user_id="999",
+            app_name="ollie",
+            cancel_event=worker.stop_event,
+        )
+
+    def test_handle_gateway_message_passes_worker_stop_event_to_delivery(self) -> None:
+        runtime_state = gateway_service.GatewayRuntimeState("ollie")
+        with mock.patch.object(gateway_service, "GATEWAY_NAMED_WORKER_THREADS", 0):
+            worker = gateway_service.GatewayWorker(runtime_state, "ollie")
+        self.addCleanup(worker.stop)
+        message = {"id": "1003", "channel_id": "55", "author": {"id": "u-1003"}}
+
+        with mock.patch.object(worker, "_record_extmsg_inbound", return_value=False), mock.patch.object(
+            gateway_service,
+            "process_inbound_message",
+            return_value={"status": "duplicate", "receipt": {}},
+        ) as process_inbound_message:
+            worker.handle_gateway_message(message, "999")
+
+        process_inbound_message.assert_called_once_with(
+            message,
+            "999",
+            "ollie",
+            cancel_event=worker.stop_event,
+        )
 
     def test_dispatch_gateway_message_persists_shutting_down_receipt(self) -> None:
         runtime_state = gateway_service.GatewayRuntimeState()
@@ -2643,6 +3033,38 @@ class DiscordGatewayServiceTests(unittest.TestCase):
         self.assertTrue(worker.stop_event.is_set())
         self.assertTrue(all(not thread.is_alive() for thread in worker.worker_threads))
 
+    def test_worker_stop_is_bounded_when_consumer_ignores_cancellation(self) -> None:
+        runtime_state = gateway_service.GatewayRuntimeState()
+        with mock.patch.object(gateway_service, "GATEWAY_WORKER_THREADS", 1):
+            worker = gateway_service.GatewayWorker(runtime_state)
+        entered = threading.Event()
+        release = threading.Event()
+
+        def block_delivery(message: dict[str, object], bot_user_id: str) -> None:
+            del message, bot_user_id
+            entered.set()
+            release.wait(timeout=2)
+
+        with mock.patch.object(worker, "handle_gateway_message", side_effect=block_delivery), mock.patch.object(
+            gateway_service,
+            "GATEWAY_WORKER_STOP_TIMEOUT_SECONDS",
+            0.05,
+        ):
+            worker.dispatch_gateway_message({"id": "1004", "channel_id": "55", "author": {"id": "u-1004"}}, "999")
+            self.assertTrue(entered.wait(timeout=1))
+            stop_thread = threading.Thread(target=worker.stop)
+            stop_thread.start()
+            stop_thread.join(timeout=0.25)
+            returned_before_release = not stop_thread.is_alive()
+            release.set()
+            stop_thread.join(timeout=1)
+
+        self.assertTrue(returned_before_release)
+        self.assertEqual(runtime_state.snapshot()["state"], "stop_timeout")
+        self.assertTrue(all(thread.daemon for thread in worker.worker_threads))
+        for thread in worker.worker_threads:
+            thread.join(timeout=1)
+
     def test_utc_age_seconds_uses_utc_epoch_conversion(self) -> None:
         if not hasattr(time, "tzset"):
             self.skipTest("tzset not available on this platform")
@@ -2664,6 +3086,17 @@ class DiscordGatewayServiceTests(unittest.TestCase):
 
         self.assertGreaterEqual(age, gateway_service.STALE_PROCESSING_RECEIPT_SECONDS)
         self.assertLess(age, gateway_service.STALE_PROCESSING_RECEIPT_SECONDS + 30)
+
+    def test_processing_receipt_staleness_exceeds_max_async_delivery_wait(self) -> None:
+        max_delivery_wait = (
+            common.GC_API_REQUEST_TIMEOUT_SECONDS
+            + common.GC_API_ASYNC_RESULT_TIMEOUT_SECONDS
+        )
+
+        self.assertGreaterEqual(
+            gateway_service.STALE_PROCESSING_RECEIPT_SECONDS - max_delivery_wait,
+            60,
+        )
 
     def test_gateway_connect_url_preserves_resume_host_and_adds_required_query_params(self) -> None:
         worker = object.__new__(gateway_service.GatewayWorker)
@@ -2811,6 +3244,113 @@ class DiscordGatewayServiceTests(unittest.TestCase):
             ),
             gateway_service.HTTPStatus.NO_CONTENT,
         )
+
+    def test_reconnecting_named_worker_does_not_stop_ready_default_worker(self) -> None:
+        config = common.import_app_config(
+            common.load_config(),
+            {"application_id": "111"},
+            bot_token="default-test-token",
+        )
+        config = common.import_app_config(
+            config,
+            {"application_id": "222"},
+            app_name="ollie",
+            bot_token="ollie-test-token",
+        )
+
+        with mock.patch.object(gateway_service, "GATEWAY_WORKER_THREADS", 0), mock.patch.object(
+            gateway_service,
+            "GATEWAY_NAMED_WORKER_THREADS",
+            0,
+        ), mock.patch.object(gateway_service, "GATEWAY_IDENTIFY_STAGGER_SECONDS", 0):
+            workers = gateway_service.build_gateway_workers(config)
+        workers_by_app = {worker.app_name: worker for worker in workers}
+        default_worker = workers_by_app[""]
+        named_worker = workers_by_app["ollie"]
+
+        ready_frames = iter(
+            [
+                {"op": 10, "d": {"heartbeat_interval": 60_000}},
+                {
+                    "op": 0,
+                    "t": "READY",
+                    "s": 1,
+                    "d": {"user": {"id": "111"}, "session_id": "default-session"},
+                },
+            ]
+        )
+        ready_closed = threading.Event()
+
+        def receive_ready_frame(timeout: float | None = None) -> dict[str, object]:
+            del timeout
+            try:
+                return next(ready_frames)
+            except StopIteration:
+                ready_closed.wait()
+                raise gateway_service.WebSocketClosed("websocket closed")
+
+        ready_websocket = mock.Mock()
+        ready_websocket.recv_event.side_effect = receive_ready_frame
+        ready_websocket.close.side_effect = ready_closed.set
+
+        named_attempts = 0
+        named_retried = threading.Event()
+
+        def fail_named_gateway_url(_bot_token: str = "") -> str:
+            nonlocal named_attempts
+            named_attempts += 1
+            if named_attempts >= 2:
+                named_retried.set()
+            raise RuntimeError("named gateway unavailable")
+
+        top_level_threads = [
+            threading.Thread(target=default_worker.run_forever, name="discord-gateway-test-default"),
+            threading.Thread(target=named_worker.run_forever, name="discord-gateway-test-ollie"),
+        ]
+        with mock.patch.object(default_worker, "gateway_url", return_value="wss://ready.example"), mock.patch.object(
+            named_worker,
+            "gateway_url",
+            side_effect=fail_named_gateway_url,
+        ), mock.patch.object(default_worker, "prune_runtime_data"), mock.patch.object(
+            gateway_service,
+            "GatewayWebSocket",
+            return_value=ready_websocket,
+        ), mock.patch.object(gateway_service, "RECONNECT_BASE_DELAY_SECONDS", 0.01), mock.patch.object(
+            gateway_service,
+            "RECONNECT_MAX_DELAY_SECONDS",
+            0.01,
+        ), mock.patch.object(gateway_service.random, "uniform", return_value=1.0):
+            try:
+                for thread in top_level_threads:
+                    thread.start()
+
+                self.assertTrue(named_retried.wait(2.0), "named gateway did not retry")
+                deadline = time.monotonic() + 2.0
+                while True:
+                    default_state = default_worker.runtime_state.snapshot()
+                    named_state = named_worker.runtime_state.snapshot()
+                    if default_state["state"] == "ready" and named_state["state"] == "reconnecting":
+                        break
+                    if time.monotonic() >= deadline:
+                        self.fail(f"gateway states did not converge: default={default_state}, named={named_state}")
+                    time.sleep(0.01)
+
+                self.assertTrue(top_level_threads[0].is_alive())
+                self.assertTrue(top_level_threads[1].is_alive())
+                self.assertFalse(default_worker.stop_event.is_set())
+                self.assertFalse(named_worker.stop_event.is_set())
+                self.assertTrue(default_state["connected"])
+                self.assertIn("named gateway unavailable", named_state["last_error"])
+            finally:
+                for worker in workers:
+                    worker.request_stop()
+                for thread in top_level_threads:
+                    if thread.ident is not None:
+                        thread.join(timeout=2.0)
+                for worker in workers:
+                    worker.stop()
+
+        self.assertTrue(all(not thread.is_alive() for thread in top_level_threads))
 
     def test_aggregate_health_fails_when_all_configured_apps_are_stale(self) -> None:
         states = {

--- a/discord/tests/test_discord_gateway_service.py
+++ b/discord/tests/test_discord_gateway_service.py
@@ -22,6 +22,7 @@ class DiscordGatewayServiceTests(unittest.TestCase):
         self.tempdir = tempfile.TemporaryDirectory()
         self.addCleanup(self.tempdir.cleanup)
         self._old_environ = os.environ.copy()
+        self.addCleanup(self._restore_environment)
         os.environ["GC_CITY_ROOT"] = self.tempdir.name
         gateway_service.CHANNEL_INFO_CACHE.clear()
         gateway_service.CHANNEL_INFO_FETCH_LOCKS.clear()
@@ -32,7 +33,7 @@ class DiscordGatewayServiceTests(unittest.TestCase):
         gateway_service.AMBIENT_ROOM_BINDINGS_CACHE["config_signature"] = None
         gateway_service.AMBIENT_ROOM_BINDINGS_CACHE["bindings"] = {}
 
-    def tearDown(self) -> None:
+    def _restore_environment(self) -> None:
         os.environ.clear()
         os.environ.update(self._old_environ)
 
@@ -48,6 +49,53 @@ class DiscordGatewayServiceTests(unittest.TestCase):
 
     def test_gateway_requests_message_content_intent(self) -> None:
         self.assertTrue(gateway_service.GATEWAY_INTENTS & (1 << 15))
+
+    def test_build_gateway_workers_creates_one_worker_per_configured_app(self) -> None:
+        config = common.import_app_config(
+            common.load_config(),
+            {"application_id": "111", "public_key": "ab" * 32},
+        )
+        config = common.import_app_config(
+            config,
+            {"application_id": "222", "public_key": "cd" * 32},
+            app_name="ollie",
+        )
+        config = common.import_app_config(
+            config,
+            {"application_id": "333", "public_key": "ef" * 32},
+            app_name="olivia",
+        )
+
+        with mock.patch.object(gateway_service, "GATEWAY_WORKER_THREADS", 0):
+            workers = gateway_service.build_gateway_workers(config)
+        self.addCleanup(lambda: [worker.stop() for worker in workers])
+
+        self.assertEqual(workers[0].app_name, "")
+        self.assertEqual({worker.app_name for worker in workers[1:]}, {"ollie", "olivia"})
+        bot_ids = {worker.app_name: worker.current_bot_user_id(config) for worker in workers}
+        self.assertEqual(bot_ids, {"": "111", "ollie": "222", "olivia": "333"})
+        delays = [worker.initial_connect_delay_seconds for worker in workers]
+        self.assertEqual(delays[0], 0)
+        self.assertEqual(delays[1:], [
+            gateway_service.GATEWAY_IDENTIFY_STAGGER_SECONDS,
+            gateway_service.GATEWAY_IDENTIFY_STAGGER_SECONDS * 2,
+        ])
+
+    def test_build_gateway_workers_rejects_duplicate_application_ids_from_config(self) -> None:
+        config = common.normalize_config(
+            {
+                "app": {"application_id": "111", "public_key": "ab" * 32},
+                "apps": {
+                    "ollie": {
+                        "application_id": "111",
+                        "public_key": "cd" * 32,
+                    }
+                },
+            }
+        )
+
+        with self.assertRaisesRegex(ValueError, "application_id.*more than once"):
+            gateway_service.build_gateway_workers(config)
 
     def test_display_name_from_message_skips_none_strings(self) -> None:
         message = {
@@ -79,7 +127,9 @@ class DiscordGatewayServiceTests(unittest.TestCase):
         self.assertIn("kind: discord_human_message", envelope)
         self.assertIn('untrusted_body_json: "hello from discord"', envelope)
         self.assertIn("reply_tool: gc discord reply-current --conversation-id 55 --reply-to 101 --body-file <path>", envelope)
-        self.assertEqual(common.load_chat_ingress("in-101")["status"], "delivered")
+        receipt = common.load_chat_ingress("in-101")
+        self.assertEqual(receipt["status"], "delivered")
+        self.assertEqual(receipt["app"], "")
 
     def test_process_inbound_room_message_targets_only_named_alias(self) -> None:
         common.set_chat_binding(common.load_config(), "room", "22", ["sky", "lawrence"], guild_id="1")
@@ -109,6 +159,551 @@ class DiscordGatewayServiceTests(unittest.TestCase):
         receipt = common.load_chat_ingress("in-202")
         self.assertEqual(receipt["delivery"], "targeted")
         self.assertEqual(receipt["mentioned_aliases"], ["sky"])
+
+    def test_named_apps_route_the_same_discord_message_independently(self) -> None:
+        config = common.import_app_config(
+            common.load_config(),
+            {"application_id": "999", "public_key": "ab" * 32},
+            app_name="ollie",
+        )
+        config = common.import_app_config(
+            config,
+            {"application_id": "998", "public_key": "cd" * 32},
+            app_name="olivia",
+        )
+        config = common.set_chat_binding(
+            config,
+            "room",
+            "22",
+            ["teams.lead"],
+            guild_id="1",
+            app_name="ollie",
+            channel_metadata={"channel_type": 0},
+        )
+        common.set_chat_binding(
+            config,
+            "room",
+            "22",
+            ["teams.pm"],
+            guild_id="1",
+            app_name="olivia",
+            channel_metadata={"channel_type": 0},
+        )
+        message = {
+            "id": "multi-202",
+            "guild_id": "1",
+            "channel_id": "22",
+            "content": "<@999> <@998> please coordinate",
+            "mentions": [{"id": "999"}, {"id": "998"}],
+            "author": {"id": "u-2", "username": "alice"},
+        }
+
+        with mock.patch.object(
+            common,
+            "session_index_by_name",
+            return_value={
+                "teams.lead": {"session_name": "teams.lead", "state": "active"},
+                "teams.pm": {"session_name": "teams.pm", "state": "active"},
+            },
+        ), mock.patch.object(common, "deliver_session_message", return_value={"status": "accepted"}) as deliver:
+            lead_outcome = gateway_service.process_inbound_message(message, bot_user_id="999", app_name="ollie")
+            pm_outcome = gateway_service.process_inbound_message(message, bot_user_id="998", app_name="olivia")
+
+        self.assertEqual(lead_outcome["status"], "delivered")
+        self.assertEqual(pm_outcome["status"], "delivered")
+        self.assertEqual([call.args[0] for call in deliver.call_args_list], ["teams.lead", "teams.pm"])
+        lead_receipt = common.load_chat_ingress("in-multi-202-app-ollie")
+        pm_receipt = common.load_chat_ingress("in-multi-202-app-olivia")
+        self.assertEqual(lead_receipt["app"], "ollie")
+        self.assertEqual(pm_receipt["app"], "olivia")
+        self.assertEqual(lead_receipt["binding_id"], "room:22@app:ollie")
+        self.assertEqual(pm_receipt["binding_id"], "room:22@app:olivia")
+
+    def test_named_app_gateway_policy_is_evaluated_independently(self) -> None:
+        config = common.import_app_config(
+            common.load_config(),
+            {
+                "application_id": "999",
+                "public_key": "ab" * 32,
+                "guild_allowlist": ["allowed-guild"],
+                "channel_allowlist": ["22"],
+            },
+            app_name="ollie",
+        )
+        common.set_chat_binding(
+            config,
+            "room",
+            "22",
+            ["teams.lead"],
+            guild_id="blocked-guild",
+            app_name="ollie",
+            channel_metadata={"channel_type": 0},
+        )
+        message = {
+            "id": "policy-203",
+            "guild_id": "blocked-guild",
+            "channel_id": "22",
+            "content": "<@999> hello",
+            "mentions": [{"id": "999"}],
+            "author": {"id": "u-2", "username": "alice"},
+        }
+
+        with mock.patch.object(common, "deliver_session_message") as deliver:
+            outcome = gateway_service.process_inbound_message(message, bot_user_id="999", app_name="ollie")
+
+        self.assertEqual(outcome["status"], "rejected_policy")
+        self.assertEqual(outcome["reason"], "guild_not_allowed")
+        self.assertEqual(common.load_chat_ingress("in-policy-203-app-ollie")["app"], "ollie")
+        deliver.assert_not_called()
+
+    def test_default_app_gateway_chat_uses_the_top_level_policy(self) -> None:
+        config = common.import_app_config(
+            common.load_config(),
+            {
+                "application_id": "999",
+                "public_key": "ab" * 32,
+                "guild_allowlist": ["allowed-guild"],
+                "channel_allowlist": ["22"],
+            },
+        )
+        common.set_chat_binding(
+            config,
+            "room",
+            "22",
+            ["teams.lead"],
+            guild_id="blocked-guild",
+            channel_metadata={"channel_type": 0},
+        )
+        message = {
+            "id": "default-policy-203",
+            "guild_id": "blocked-guild",
+            "channel_id": "22",
+            "content": "<@999> hello",
+            "mentions": [{"id": "999"}],
+            "author": {"id": "u-2", "username": "alice"},
+        }
+
+        with mock.patch.object(common, "deliver_session_message") as deliver:
+            outcome = gateway_service.process_inbound_message(message, bot_user_id="999")
+
+        self.assertEqual(outcome["status"], "rejected_policy")
+        self.assertEqual(outcome["reason"], "guild_not_allowed")
+        self.assertEqual(common.load_chat_ingress("in-default-policy-203")["app"], "")
+        deliver.assert_not_called()
+
+    def test_named_app_rest_recovery_uses_its_own_token(self) -> None:
+        named_token = "ollie-test-token"
+        config = common.import_app_config(
+            common.load_config(),
+            {"application_id": "999", "public_key": "ab" * 32},
+            app_name="ollie",
+            bot_token=named_token,
+        )
+        common.set_chat_binding(
+            config,
+            "room",
+            "22",
+            ["teams.lead"],
+            guild_id="1",
+            app_name="ollie",
+            channel_metadata={"channel_type": 0},
+        )
+        message = {
+            "id": "recovery-204",
+            "guild_id": "1",
+            "channel_id": "22",
+            "content": "",
+            "mentions": [{"id": "999"}],
+            "author": {"id": "u-2", "username": "alice"},
+        }
+
+        with mock.patch.object(
+            common,
+            "discord_api_request",
+            return_value={**message, "content": "<@999> recovered body"},
+        ) as discord_api_request, mock.patch.object(
+            common,
+            "session_index_by_name",
+            return_value={"teams.lead": {"session_name": "teams.lead", "state": "active"}},
+        ), mock.patch.object(common, "deliver_session_message", return_value={"status": "accepted"}):
+            outcome = gateway_service.process_inbound_message(message, bot_user_id="999", app_name="ollie")
+
+        self.assertEqual(outcome["status"], "delivered")
+        self.assertEqual(discord_api_request.call_args.kwargs["bot_token"], named_token)
+
+    def test_named_app_binding_takes_precedence_over_default_room_launcher(self) -> None:
+        config = common.set_room_launcher(common.load_config(), "1", "22")
+        config = common.import_app_config(
+            config,
+            {"application_id": "999", "public_key": "ab" * 32},
+            app_name="ollie",
+        )
+        common.set_chat_binding(
+            config,
+            "room",
+            "22",
+            ["teams.lead"],
+            guild_id="1",
+            app_name="ollie",
+            channel_metadata={"channel_type": 0},
+        )
+        message = {
+            "id": "launcher-isolation-205",
+            "guild_id": "1",
+            "channel_id": "22",
+            "content": "<@999> use the direct binding",
+            "mentions": [{"id": "999"}],
+            "author": {"id": "u-2", "username": "alice"},
+        }
+
+        with mock.patch.object(
+            common,
+            "session_index_by_name",
+            return_value={"teams.lead": {"session_name": "teams.lead", "state": "active"}},
+        ), mock.patch.object(common, "deliver_session_message", return_value={"status": "accepted"}) as deliver:
+            outcome = gateway_service.process_inbound_message(message, bot_user_id="999", app_name="ollie")
+
+        self.assertEqual(outcome["status"], "delivered")
+        self.assertEqual(deliver.call_args.args[0], "teams.lead")
+        self.assertEqual(outcome["receipt"]["binding_id"], "room:22@app:ollie")
+
+    def test_named_app_channel_policy_accepts_thread_under_allowed_parent(self) -> None:
+        config = common.import_app_config(
+            common.load_config(),
+            {
+                "application_id": "999",
+                "public_key": "ab" * 32,
+                "guild_allowlist": ["1"],
+                "channel_allowlist": ["22"],
+            },
+            app_name="ollie",
+            bot_token="ollie-test-token",
+        )
+        common.set_chat_binding(
+            config,
+            "room",
+            "22",
+            ["teams.lead"],
+            guild_id="1",
+            app_name="ollie",
+            channel_metadata={"channel_type": 0},
+        )
+        message = {
+            "id": "thread-policy-206",
+            "guild_id": "1",
+            "channel_id": "222",
+            "content": "<@999> thread follow-up",
+            "mentions": [{"id": "999"}],
+            "author": {"id": "u-2", "username": "alice"},
+        }
+
+        with mock.patch.object(
+            common,
+            "discord_api_request",
+            return_value={"id": "222", "parent_id": "22", "type": 11},
+        ), mock.patch.object(
+            common,
+            "session_index_by_name",
+            return_value={"teams.lead": {"session_name": "teams.lead", "state": "active"}},
+        ), mock.patch.object(common, "deliver_session_message", return_value={"status": "accepted"}):
+            outcome = gateway_service.process_inbound_message(message, bot_user_id="999", app_name="ollie")
+
+        self.assertEqual(outcome["status"], "delivered")
+        self.assertEqual(outcome["receipt"]["binding_id"], "room:22@app:ollie")
+
+    def test_named_app_channel_policy_accepts_a_direct_thread_binding_under_allowed_parent(self) -> None:
+        config = common.import_app_config(
+            common.load_config(),
+            {
+                "application_id": "999",
+                "public_key": "ab" * 32,
+                "guild_allowlist": ["1"],
+                "channel_allowlist": ["22"],
+            },
+            app_name="ollie",
+        )
+        common.set_chat_binding(
+            config,
+            "room",
+            "222",
+            ["teams.lead"],
+            guild_id="1",
+            app_name="ollie",
+            channel_metadata={"channel_type": 11, "thread_parent_id": "22"},
+        )
+        message = {
+            "id": "direct-thread-policy-206",
+            "guild_id": "1",
+            "channel_id": "222",
+            "content": "<@999> direct thread follow-up",
+            "mentions": [{"id": "999"}],
+            "author": {"id": "u-2", "username": "alice"},
+        }
+
+        with mock.patch.object(
+            common,
+            "session_index_by_name",
+            return_value={"teams.lead": {"session_name": "teams.lead", "state": "active"}},
+        ), mock.patch.object(common, "deliver_session_message", return_value={"status": "accepted"}):
+            outcome = gateway_service.process_inbound_message(message, bot_user_id="999", app_name="ollie")
+
+        self.assertEqual(outcome["status"], "delivered")
+        self.assertEqual(outcome["receipt"]["binding_id"], "room:222@app:ollie")
+
+    def test_default_gateway_policy_rejects_before_extmsg_routing(self) -> None:
+        common.import_app_config(
+            common.load_config(),
+            {
+                "application_id": "999",
+                "public_key": "ab" * 32,
+                "guild_allowlist": ["1"],
+                "channel_allowlist": ["22"],
+            },
+        )
+        runtime_state = gateway_service.GatewayRuntimeState()
+        with mock.patch.object(gateway_service, "GATEWAY_WORKER_THREADS", 0):
+            worker = gateway_service.GatewayWorker(runtime_state)
+        self.addCleanup(worker.stop)
+        message = {
+            "id": "extmsg-policy-207",
+            "guild_id": "1",
+            "channel_id": "33",
+            "content": "@sky hello",
+            "author": {"id": "u-2", "username": "alice"},
+        }
+
+        with mock.patch.object(gateway_service, "_resolve_thread_parent", return_value=""), mock.patch.object(
+            common,
+            "resolve_at_mentions",
+            return_value=["sky"],
+        ) as resolve_at_mentions, mock.patch.object(
+            common,
+            "resolve_mention_targets",
+            return_value=[{"mention": "sky"}],
+        ), mock.patch.object(common, "launch_thread_for_mentions") as launch_thread_for_mentions:
+            worker.handle_gateway_message(message, bot_user_id="999")
+
+        resolve_at_mentions.assert_called_once_with("@sky hello")
+        launch_thread_for_mentions.assert_not_called()
+        receipt = common.load_chat_ingress("in-extmsg-policy-207")
+        self.assertEqual(receipt["status"], "rejected_policy")
+        self.assertEqual(receipt["reason"], "channel_not_allowed")
+        self.assertEqual(receipt["app"], "")
+
+    def test_default_gateway_policy_does_not_turn_bot_messages_into_failures(self) -> None:
+        common.import_app_config(
+            common.load_config(),
+            {
+                "application_id": "999",
+                "public_key": "ab" * 32,
+                "guild_allowlist": ["1"],
+                "channel_allowlist": ["22"],
+            },
+        )
+        worker = self._new_gateway_worker()
+        message = {
+            "id": "extmsg-bot-policy-208",
+            "guild_id": "1",
+            "channel_id": "33",
+            "content": "automated",
+            "author": {"id": "other-bot", "username": "robot", "bot": True},
+        }
+
+        worker.handle_gateway_message(message, bot_user_id="999")
+
+        self.assertIsNone(common.load_chat_ingress("in-extmsg-bot-policy-208"))
+        self.assertEqual(worker.runtime_state.snapshot()["ignored_messages"], 1)
+
+    def test_default_gateway_policy_does_not_persist_irrelevant_unmentioned_messages(self) -> None:
+        common.import_app_config(
+            common.load_config(),
+            {
+                "application_id": "999",
+                "public_key": "ab" * 32,
+                "guild_allowlist": ["1"],
+                "channel_allowlist": ["22"],
+            },
+        )
+        worker = self._new_gateway_worker()
+        message = {
+            "id": "extmsg-unmentioned-policy-209",
+            "guild_id": "1",
+            "channel_id": "33",
+            "content": "ordinary chatter",
+            "author": {"id": "u-2", "username": "alice"},
+        }
+
+        with mock.patch.object(gateway_service, "_resolve_thread_parent", return_value=""):
+            worker.handle_gateway_message(message, bot_user_id="999")
+
+        self.assertIsNone(common.load_chat_ingress("in-extmsg-unmentioned-policy-209"))
+        self.assertEqual(worker.runtime_state.snapshot()["ignored_messages"], 1)
+
+    def test_extmsg_prefers_a_direct_bindings_stored_thread_parent(self) -> None:
+        self._configure_discord_app()
+        common.set_chat_binding(
+            common.load_config(),
+            "room",
+            "222",
+            ["randy"],
+            guild_id="1",
+            channel_metadata={"channel_type": 11, "thread_parent_id": "22"},
+        )
+        worker = self._new_gateway_worker()
+        message = {
+            "id": "stored-thread-parent-210",
+            "guild_id": "1",
+            "channel_id": "222",
+            "content": "@randy still there?",
+            "author": {"id": "u-2", "username": "alice"},
+        }
+
+        with mock.patch.object(gateway_service, "_resolve_thread_parent") as resolve_thread_parent:
+            handled = worker._record_extmsg_inbound(message, bot_user_id="999")
+
+        self.assertFalse(handled)
+        resolve_thread_parent.assert_not_called()
+
+    def test_default_extmsg_ignores_a_thread_message_aimed_only_at_a_named_bot(self) -> None:
+        config = common.import_app_config(
+            common.load_config(),
+            {"application_id": "111", "public_key": "ab" * 32},
+        )
+        common.import_app_config(
+            config,
+            {"application_id": "222", "public_key": "cd" * 32},
+            app_name="ollie",
+        )
+        worker = self._new_gateway_worker()
+        message = {
+            "id": "named-only-thread-211",
+            "guild_id": "1",
+            "channel_id": "2222",
+            "content": "<@222> can you handle this?",
+            "mentions": [{"id": "222"}],
+            "author": {"id": "u-2", "username": "alice"},
+        }
+
+        with mock.patch.object(gateway_service, "_resolve_thread_parent", return_value="22"), mock.patch.object(
+            common,
+            "resolve_at_mentions",
+            return_value=[],
+        ), mock.patch.object(common, "resolve_nl_agent_mentions", return_value=[]), mock.patch.object(
+            common,
+            "normalize_to_extmsg_message",
+            return_value={"id": "normalized"},
+        ), mock.patch.object(common, "deliver_to_extmsg") as deliver_to_extmsg:
+            handled = worker._record_extmsg_inbound(message, bot_user_id="111")
+
+        self.assertFalse(handled)
+        deliver_to_extmsg.assert_not_called()
+
+    def test_named_ambient_binding_cache_cannot_substitute_default_binding(self) -> None:
+        config = common.set_chat_binding(
+            common.load_config(),
+            "room",
+            "22",
+            ["legacy.session"],
+            guild_id="1",
+            policy={"ambient_read_enabled": True, "allow_untargeted_ambient_delivery": True},
+            channel_metadata={"channel_type": 0},
+        )
+        config = common.import_app_config(
+            config,
+            {"application_id": "999", "public_key": "ab" * 32},
+            app_name="ollie",
+        )
+        common.set_chat_binding(
+            config,
+            "room",
+            "22",
+            ["teams.lead"],
+            guild_id="1",
+            app_name="ollie",
+            policy={"ambient_read_enabled": True, "allow_untargeted_ambient_delivery": True},
+            channel_metadata={"channel_type": 0},
+        )
+        message = {
+            "id": "ambient-cache-207",
+            "guild_id": "1",
+            "channel_id": "22",
+            "content": "<@999> route to Ollie",
+            "mentions": [{"id": "999"}],
+            "author": {"id": "u-2", "username": "alice"},
+        }
+
+        with mock.patch.object(
+            common,
+            "session_index_by_name",
+            return_value={
+                "legacy.session": {"session_name": "legacy.session", "state": "active"},
+                "teams.lead": {"session_name": "teams.lead", "state": "active"},
+            },
+        ), mock.patch.object(common, "deliver_session_message", return_value={"status": "accepted"}) as deliver:
+            outcome = gateway_service.process_inbound_message(message, bot_user_id="999", app_name="ollie")
+
+        self.assertEqual(outcome["status"], "delivered")
+        self.assertEqual(deliver.call_args.args[0], "teams.lead")
+        self.assertEqual(outcome["receipt"]["binding_id"], "room:22@app:ollie")
+
+    def test_sticky_named_binding_ignores_message_for_another_configured_bot(self) -> None:
+        config = common.import_app_config(
+            common.load_config(),
+            {"application_id": "999", "public_key": "ab" * 32},
+            app_name="ollie",
+        )
+        config = common.import_app_config(
+            config,
+            {"application_id": "998", "public_key": "cd" * 32},
+            app_name="olivia",
+        )
+        config = common.set_chat_binding(
+            config,
+            "room",
+            "22",
+            ["teams.lead"],
+            guild_id="1",
+            app_name="ollie",
+            policy={"ambient_read_enabled": True, "allow_untargeted_ambient_delivery": True},
+            channel_metadata={"channel_type": 0},
+        )
+        common.set_chat_binding(
+            config,
+            "room",
+            "22",
+            ["teams.pm"],
+            guild_id="1",
+            app_name="olivia",
+            policy={"ambient_read_enabled": True, "allow_untargeted_ambient_delivery": True},
+            channel_metadata={"channel_type": 0},
+        )
+        message = {
+            "id": "other-bot-208",
+            "guild_id": "1",
+            "channel_id": "22",
+            "content": "<@999> Ollie only",
+            "mentions": [{"id": "999"}],
+            "author": {"id": "u-2", "username": "alice"},
+        }
+
+        with mock.patch.object(
+            common,
+            "session_index_by_name",
+            return_value={
+                "teams.lead": {"session_name": "teams.lead", "state": "active"},
+                "teams.pm": {"session_name": "teams.pm", "state": "active"},
+            },
+        ), mock.patch.object(common, "deliver_session_message", return_value={"status": "accepted"}) as deliver:
+            lead_outcome = gateway_service.process_inbound_message(message, bot_user_id="999", app_name="ollie")
+            pm_outcome = gateway_service.process_inbound_message(message, bot_user_id="998", app_name="olivia")
+
+        self.assertEqual(lead_outcome["status"], "delivered")
+        self.assertEqual(pm_outcome, {
+            "status": "ignored",
+            "reason": "different_configured_bot_mentioned",
+            "ingress_id": "in-other-bot-208-app-olivia",
+        })
+        self.assertEqual([call.args[0] for call in deliver.call_args_list], ["teams.lead"])
 
     def test_process_inbound_room_message_matches_session_names_case_insensitively(self) -> None:
         common.set_chat_binding(common.load_config(), "room", "22", ["Sky"], guild_id="1")
@@ -1738,6 +2333,7 @@ class DiscordGatewayServiceTests(unittest.TestCase):
         assert receipt is not None
         self.assertEqual(receipt["status"], "failed_claim_conflict")
         self.assertEqual(receipt["reason"], "ingress_claim_unreadable")
+        self.assertEqual(receipt["app"], "")
 
     def test_failed_claim_conflict_receipt_retries_after_backoff(self) -> None:
         common.set_chat_binding(common.load_config(), "dm", "55", ["sky"])
@@ -1769,6 +2365,7 @@ class DiscordGatewayServiceTests(unittest.TestCase):
         receipt = common.load_chat_ingress("in-915")
         assert receipt is not None
         self.assertEqual(receipt["reason"], "retry_after_failed_claim_conflict")
+        self.assertEqual(receipt["app"], "")
 
     def test_rejected_shutting_down_receipt_retries_immediately(self) -> None:
         common.set_chat_binding(common.load_config(), "dm", "55", ["sky"])
@@ -2092,15 +2689,49 @@ class DiscordGatewayServiceTests(unittest.TestCase):
 
     def test_current_bot_user_id_prefers_last_known_id_after_resume(self) -> None:
         worker = object.__new__(gateway_service.GatewayWorker)
+        worker.app_name = ""
 
         bot_user_id = gateway_service.GatewayWorker.current_bot_user_id(
             worker,
-            {"app": {"application_id": "app-1"}},
+            {"app": {"application_id": "bot-9"}},
             None,
             "bot-9",
         )
 
         self.assertEqual(bot_user_id, "bot-9")
+
+    def test_named_gateway_rejects_resumed_identity_mismatched_to_configured_app(self) -> None:
+        config = common.import_app_config(
+            common.load_config(),
+            {"application_id": "222", "public_key": "ab" * 32},
+            app_name="ollie",
+        )
+        worker = object.__new__(gateway_service.GatewayWorker)
+        worker.app_name = "ollie"
+
+        with self.assertRaisesRegex(RuntimeError, "authenticated as.*configured application_id"):
+            gateway_service.GatewayWorker.current_bot_user_id(
+                worker,
+                config,
+                None,
+                "999",
+            )
+
+    def test_named_gateway_rejects_ready_identity_mismatched_to_configured_app(self) -> None:
+        config = common.import_app_config(
+            common.load_config(),
+            {"application_id": "222", "public_key": "ab" * 32},
+            app_name="ollie",
+        )
+        worker = object.__new__(gateway_service.GatewayWorker)
+        worker.app_name = "ollie"
+
+        with self.assertRaisesRegex(RuntimeError, "authenticated as.*configured application_id"):
+            gateway_service.GatewayWorker.current_bot_user_id(
+                worker,
+                config,
+                {"user": {"id": "999"}},
+            )
 
     def test_gateway_health_status_code_requires_gc_api_when_ready(self) -> None:
         self.assertEqual(
@@ -2131,6 +2762,132 @@ class DiscordGatewayServiceTests(unittest.TestCase):
             gateway_service.gateway_health_status_code(state, gc_api_reachable=True),
             gateway_service.HTTPStatus.NO_CONTENT,
         )
+
+    def test_gateway_status_payload_preserves_legacy_default_fields_and_exposes_all_apps(self) -> None:
+        states = {
+            "default": {"state": "stopped", "routed_messages": 4},
+            "ollie": {"state": "ready", "routed_messages": 7},
+        }
+
+        payload = gateway_service.gateway_status_payload(
+            states,
+            configured_app_names={"default", "ollie"},
+            gc_api_reachable=True,
+        )
+
+        self.assertEqual(payload["state"], "stopped")
+        self.assertEqual(payload["routed_messages"], 4)
+        self.assertEqual(payload["gateway_statuses"], states)
+        self.assertEqual(payload["aggregate"]["state"], "degraded")
+        self.assertEqual(payload["aggregate"]["configured_apps"], 2)
+        self.assertEqual(payload["aggregate"]["ready_apps"], 1)
+
+    def test_aggregate_health_is_available_when_default_fails_but_named_app_is_ready(self) -> None:
+        states = {
+            "default": {"state": "stopped"},
+            "ollie": {"state": "ready"},
+        }
+
+        self.assertEqual(
+            gateway_service.aggregate_gateway_health_status_code(
+                states,
+                configured_app_names={"default", "ollie"},
+                gc_api_reachable=True,
+            ),
+            gateway_service.HTTPStatus.NO_CONTENT,
+        )
+
+    def test_aggregate_health_is_available_when_named_app_fails_but_default_is_ready(self) -> None:
+        states = {
+            "default": {"state": "ready"},
+            "ollie": {"state": "stopped"},
+        }
+
+        self.assertEqual(
+            gateway_service.aggregate_gateway_health_status_code(
+                states,
+                configured_app_names={"default", "ollie"},
+                gc_api_reachable=True,
+            ),
+            gateway_service.HTTPStatus.NO_CONTENT,
+        )
+
+    def test_aggregate_health_fails_when_all_configured_apps_are_stale(self) -> None:
+        states = {
+            "default": {"state": "reconnecting", "last_ready_epoch": 1},
+            "ollie": {"state": "stopped"},
+        }
+
+        self.assertEqual(
+            gateway_service.aggregate_gateway_health_status_code(
+                states,
+                configured_app_names={"default", "ollie"},
+                gc_api_reachable=True,
+            ),
+            gateway_service.HTTPStatus.SERVICE_UNAVAILABLE,
+        )
+
+    def test_aggregate_health_requires_shared_gc_api(self) -> None:
+        states = {
+            "default": {"state": "ready"},
+            "ollie": {"state": "ready"},
+        }
+
+        self.assertEqual(
+            gateway_service.aggregate_gateway_health_status_code(
+                states,
+                configured_app_names={"default", "ollie"},
+                gc_api_reachable=False,
+            ),
+            gateway_service.HTTPStatus.SERVICE_UNAVAILABLE,
+        )
+
+    def test_aggregate_status_ignores_an_unconfigured_default_worker(self) -> None:
+        states = {
+            "default": {"state": "waiting_for_config"},
+            "ollie": {"state": "ready"},
+        }
+
+        aggregate = gateway_service.aggregate_gateway_status(
+            states,
+            configured_app_names={"ollie"},
+            gc_api_reachable=True,
+        )
+
+        self.assertEqual(aggregate["state"], "ready")
+        self.assertEqual(aggregate["configured_apps"], 1)
+        self.assertEqual(aggregate["ready_apps"], 1)
+
+    def test_aggregate_health_allows_all_apps_to_provision(self) -> None:
+        states = {
+            "default": {"state": "starting"},
+            "ollie": {"state": "waiting_for_config"},
+        }
+
+        self.assertEqual(
+            gateway_service.aggregate_gateway_health_status_code(
+                states,
+                configured_app_names={"default", "ollie"},
+                gc_api_reachable=True,
+            ),
+            gateway_service.HTTPStatus.NO_CONTENT,
+        )
+
+    def test_named_gateway_uses_one_consumer_while_default_keeps_legacy_pool(self) -> None:
+        default_state = gateway_service.GatewayRuntimeState()
+        named_state = gateway_service.GatewayRuntimeState("ollie")
+        with mock.patch.object(gateway_service, "GATEWAY_WORKER_THREADS", 3), mock.patch.object(
+            gateway_service,
+            "GATEWAY_NAMED_WORKER_THREADS",
+            1,
+        ):
+            default_worker = gateway_service.GatewayWorker(default_state)
+            named_worker = gateway_service.GatewayWorker(named_state, "ollie")
+        self.addCleanup(default_worker.stop)
+        self.addCleanup(named_worker.stop)
+
+        self.assertEqual(len(default_worker.worker_threads), 3)
+        self.assertEqual(len(named_worker.worker_threads), 1)
 
     def test_gateway_websocket_recv_event_reassembles_fragmented_text_frames(self) -> None:
         ws = object.__new__(gateway_service.GatewayWebSocket)

--- a/discord/tests/test_discord_intake_common.py
+++ b/discord/tests/test_discord_intake_common.py
@@ -1033,11 +1033,7 @@ class DiscordIntakeCommonTests(unittest.TestCase):
         self.assertEqual(urlopen.call_args_list[-1].args[0].full_url, "http://127.0.0.1:8372/v0/city/gc/sessions")
 
     def test_deliver_session_message_uses_messages_endpoint_for_default_intent(self) -> None:
-        with mock.patch.object(
-            common,
-            "gc_api_request_with_status",
-            return_value=(200, {"status": "accepted"}),
-        ) as gc_api_request:
+        with mock.patch.object(common, "gc_api_request_with_status", return_value=(200, {"status": "accepted"})) as gc_api_request:
             payload = common.deliver_session_message("corp--sky", "hello", idempotency_key="ingress:1")
 
         self.assertEqual(payload, {"status": "accepted"})
@@ -1050,11 +1046,7 @@ class DiscordIntakeCommonTests(unittest.TestCase):
         )
 
     def test_deliver_session_message_uses_submit_endpoint_for_follow_up_intent(self) -> None:
-        with mock.patch.object(
-            common,
-            "gc_api_request_with_status",
-            return_value=(200, {"status": "accepted"}),
-        ) as gc_api_request:
+        with mock.patch.object(common, "gc_api_request_with_status", return_value=(200, {"status": "accepted"})) as gc_api_request:
             payload = common.deliver_session_message(
                 "corp--sky",
                 "hello again",
@@ -1070,6 +1062,340 @@ class DiscordIntakeCommonTests(unittest.TestCase):
             headers={"Idempotency-Key": "ingress:2"},
             timeout=common.GC_API_REQUEST_TIMEOUT_SECONDS,
         )
+
+    def test_deliver_session_message_preserves_accepted_payload_after_async_success(self) -> None:
+        accepted = {"status": "accepted", "request_id": "req-submit", "event_cursor": "42"}
+        accepted_response = mock.MagicMock()
+        accepted_response.status = 202
+        accepted_response.__enter__.return_value = mock.Mock(
+            read=mock.Mock(
+                return_value=b'{"status":"accepted","request_id":"req-submit","event_cursor":"42"}'
+            )
+        )
+        accepted_response.__enter__.return_value.status = 202
+        accepted_response.__exit__.return_value = False
+        succeeded_stream = mock.MagicMock()
+        succeeded_stream.__enter__.return_value = iter(
+            [
+                b"event: request.result.session.submit\n",
+                b'data: {"type":"request.result.session.submit","payload":{"request_id":"req-submit","session_id":"session-1","queued":true,"intent":"follow_up"}}\n',
+                b"\n",
+            ]
+        )
+        succeeded_stream.__exit__.return_value = False
+
+        with mock.patch.dict(
+            os.environ,
+            {"GC_API_BASE_URL": "http://gc.test/v0/city/test"},
+        ), mock.patch.object(
+            common.urllib.request,
+            "urlopen",
+            side_effect=[accepted_response, succeeded_stream],
+        ) as urlopen:
+            payload = common.deliver_session_message(
+                "corp--sky",
+                "hello again",
+                idempotency_key="ingress:3",
+                intent="follow_up",
+            )
+
+        self.assertEqual(payload, accepted)
+        self.assertEqual(common.GC_API_ASYNC_RESULT_TIMEOUT_SECONDS, 4 * 60)
+        self.assertEqual(len(urlopen.call_args_list), 2)
+        self.assertEqual(
+            urlopen.call_args_list[1].args[0].full_url,
+            "http://gc.test/v0/city/test/events/stream?after_seq=42",
+        )
+        self.assertEqual(
+            urlopen.call_args_list[0].kwargs["timeout"],
+            common.GC_API_REQUEST_TIMEOUT_SECONDS,
+        )
+        self.assertEqual(
+            urlopen.call_args_list[1].kwargs["timeout"],
+            common.GC_API_ASYNC_RESULT_TIMEOUT_SECONDS,
+        )
+
+    def test_deliver_session_message_rejects_malformed_async_accepted_response(self) -> None:
+        accepted_response = mock.MagicMock()
+        accepted_response.status = 202
+        accepted_response.__enter__.return_value = mock.Mock(
+            read=mock.Mock(return_value=b'{"status":"accepted"}')
+        )
+        accepted_response.__enter__.return_value.status = 202
+        accepted_response.__exit__.return_value = False
+
+        with mock.patch.dict(
+            os.environ,
+            {"GC_API_BASE_URL": "http://gc.test/v0/city/test"},
+        ), mock.patch.object(
+            common.urllib.request,
+            "urlopen",
+            return_value=accepted_response,
+        ):
+            on_async_accepted = mock.Mock()
+            with self.assertRaisesRegex(common.GCAPIError, "request_id.*event_cursor"):
+                common.deliver_session_message(
+                    "corp--sky",
+                    "hello again",
+                    idempotency_key="ingress:malformed",
+                    intent="follow_up",
+                    on_async_accepted=on_async_accepted,
+                )
+
+        on_async_accepted.assert_not_called()
+
+    def test_deliver_session_message_rejects_async_response_without_event_cursor(self) -> None:
+        on_async_accepted = mock.Mock()
+        with mock.patch.object(
+            common,
+            "gc_api_request_with_status",
+            return_value=(202, {"status": "accepted", "request_id": "req-no-cursor"}),
+        ), mock.patch.object(common, "resume_session_message_delivery") as resume_session_message_delivery:
+            with self.assertRaisesRegex(common.GCAPIError, "request_id.*event_cursor"):
+                common.deliver_session_message(
+                    "corp--sky",
+                    "hello again",
+                    intent="follow_up",
+                    on_async_accepted=on_async_accepted,
+                )
+
+        on_async_accepted.assert_not_called()
+        resume_session_message_delivery.assert_not_called()
+
+    def test_deliver_session_message_accepts_zero_event_cursor(self) -> None:
+        accepted = {"status": "accepted", "request_id": "req-zero", "event_cursor": "0"}
+        with mock.patch.object(
+            common,
+            "gc_api_request_with_status",
+            return_value=(202, accepted),
+        ), mock.patch.object(
+            common,
+            "resume_session_message_delivery",
+            return_value={"request_id": "req-zero", "session_id": "session-zero"},
+        ) as resume_session_message_delivery:
+            payload = common.deliver_session_message("corp--sky", "hello again", intent="follow_up")
+
+        self.assertEqual(payload, accepted)
+        resume_session_message_delivery.assert_called_once_with(
+            "req-zero",
+            event_cursor="0",
+            intent="follow_up",
+            timeout=common.GC_API_ASYNC_RESULT_TIMEOUT_SECONDS,
+            cancel_event=None,
+        )
+
+    def test_deliver_session_message_allows_legacy_synchronous_response_without_async_metadata(self) -> None:
+        accepted_response = mock.MagicMock()
+        accepted_response.status = 200
+        accepted_response.__enter__.return_value = mock.Mock(
+            read=mock.Mock(return_value=b'{"status":"accepted","request_id":"legacy-request"}')
+        )
+        accepted_response.__enter__.return_value.status = 200
+        accepted_response.__exit__.return_value = False
+
+        with mock.patch.dict(
+            os.environ,
+            {"GC_API_BASE_URL": "http://gc.test/v0/city/test"},
+        ), mock.patch.object(
+            common.urllib.request,
+            "urlopen",
+            return_value=accepted_response,
+        ) as urlopen, mock.patch.object(common, "resume_session_message_delivery") as resume_session_message_delivery:
+            payload = common.deliver_session_message(
+                "corp--sky",
+                "hello again",
+                idempotency_key="ingress:legacy",
+                intent="follow_up",
+            )
+
+        self.assertEqual(payload, {"status": "accepted", "request_id": "legacy-request"})
+        self.assertEqual(len(urlopen.call_args_list), 1)
+        resume_session_message_delivery.assert_not_called()
+
+    def test_deliver_session_message_persists_async_acceptance_before_waiting(self) -> None:
+        accepted_response = mock.MagicMock()
+        accepted_response.status = 202
+        accepted_response.__enter__.return_value = mock.Mock(
+            read=mock.Mock(
+                return_value=b'{"status":"accepted","request_id":"req-submit","event_cursor":"42"}'
+            )
+        )
+        accepted_response.__enter__.return_value.status = 202
+        accepted_response.__exit__.return_value = False
+        persisted: list[dict[str, object]] = []
+
+        def assert_persisted_before_wait(*args: object, **kwargs: object) -> dict[str, object]:
+            self.assertEqual(persisted[0]["request_id"], "req-submit")
+            self.assertEqual(persisted[0]["event_cursor"], "42")
+            return {"request_id": "req-submit", "session_id": "session-1"}
+
+        with mock.patch.dict(
+            os.environ,
+            {"GC_API_BASE_URL": "http://gc.test/v0/city/test"},
+        ), mock.patch.object(
+            common.urllib.request,
+            "urlopen",
+            return_value=accepted_response,
+        ), mock.patch.object(
+            common,
+            "wait_for_gc_request_result",
+            side_effect=assert_persisted_before_wait,
+        ):
+            common.deliver_session_message(
+                "corp--sky",
+                "hello again",
+                idempotency_key="ingress:persist-first",
+                intent="follow_up",
+                on_async_accepted=persisted.append,
+            )
+
+        self.assertEqual(len(persisted), 1)
+
+    def test_deliver_session_message_does_not_open_sse_when_acceptance_persistence_fails(self) -> None:
+        accepted = {"status": "accepted", "request_id": "req-submit", "event_cursor": "42"}
+
+        with mock.patch.object(
+            common,
+            "gc_api_request_with_status",
+            return_value=(202, accepted),
+        ), mock.patch.object(
+            common,
+            "resume_session_message_delivery",
+        ) as resume_session_message_delivery:
+            with self.assertRaisesRegex(OSError, "receipt write failed"):
+                common.deliver_session_message(
+                    "corp--sky",
+                    "hello again",
+                    intent="follow_up",
+                    on_async_accepted=mock.Mock(side_effect=OSError("receipt write failed")),
+                )
+
+        resume_session_message_delivery.assert_not_called()
+
+    def test_deliver_session_message_reports_terminal_success_evidence(self) -> None:
+        accepted = {"status": "accepted", "request_id": "req-submit", "event_cursor": "42"}
+        terminal = {"request_id": "req-submit", "session_id": "session-1", "queued": True}
+        evidence: list[dict[str, object]] = []
+
+        with mock.patch.object(
+            common,
+            "gc_api_request_with_status",
+            return_value=(202, accepted),
+        ), mock.patch.object(
+            common,
+            "resume_session_message_delivery",
+            return_value=terminal,
+        ):
+            payload = common.deliver_session_message(
+                "corp--sky",
+                "hello again",
+                idempotency_key="ingress:terminal",
+                intent="follow_up",
+                on_async_terminal=evidence.append,
+            )
+
+        self.assertEqual(payload, accepted)
+        self.assertEqual(evidence, [{"status": "succeeded", "payload": terminal}])
+
+    def test_resume_session_message_delivery_waits_without_resubmitting(self) -> None:
+        cancel_event = threading.Event()
+        terminal = {"request_id": "req-submit", "session_id": "session-1", "queued": True}
+
+        with mock.patch.object(
+            common,
+            "wait_for_gc_request_result",
+            return_value=terminal,
+        ) as wait_for_gc_request_result, mock.patch.object(
+            common,
+            "gc_api_request_with_status",
+        ) as gc_api_request_with_status:
+            result = common.resume_session_message_delivery(
+                "req-submit",
+                "42",
+                intent="follow_up",
+                timeout=12,
+                cancel_event=cancel_event,
+            )
+
+        self.assertEqual(result, terminal)
+        gc_api_request_with_status.assert_not_called()
+        wait_for_gc_request_result.assert_called_once_with(
+            "req-submit",
+            event_cursor="42",
+            success_type=common.GC_EVENT_SESSION_SUBMIT_SUCCEEDED,
+            failure_operation=common.GC_OPERATION_SESSION_SUBMIT,
+            timeout=12,
+            cancel_event=cancel_event,
+        )
+
+    def test_wait_for_gc_request_result_cancellation_closes_open_stream(self) -> None:
+        entered = threading.Event()
+        closed = threading.Event()
+        cancel_event = threading.Event()
+        errors: list[BaseException] = []
+
+        class BlockingStream:
+            def __enter__(self) -> "BlockingStream":
+                return self
+
+            def __exit__(self, *args: object) -> None:
+                self.close()
+
+            def __iter__(self) -> "BlockingStream":
+                return self
+
+            def __next__(self) -> bytes:
+                entered.set()
+                closed.wait(timeout=2)
+                raise StopIteration
+
+            def close(self) -> None:
+                closed.set()
+
+        def wait_for_result() -> None:
+            try:
+                common.wait_for_gc_request_result(
+                    "req-submit",
+                    event_cursor="42",
+                    success_type=common.GC_EVENT_SESSION_SUBMIT_SUCCEEDED,
+                    failure_operation=common.GC_OPERATION_SESSION_SUBMIT,
+                    timeout=60,
+                    cancel_event=cancel_event,
+                )
+            except BaseException as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        with mock.patch.dict(
+            os.environ,
+            {"GC_API_BASE_URL": "http://gc.test/v0/city/test"},
+        ), mock.patch.object(common.urllib.request, "urlopen", return_value=BlockingStream()):
+            waiter = threading.Thread(target=wait_for_result)
+            waiter.start()
+            self.assertTrue(entered.wait(timeout=1))
+            cancel_event.set()
+            waiter.join(timeout=1)
+
+        self.assertFalse(waiter.is_alive())
+        self.assertTrue(closed.is_set())
+        self.assertEqual(len(errors), 1)
+        self.assertIsInstance(errors[0], common.GCAPIRequestCancelled)
+
+    def test_wait_for_gc_request_result_eof_is_recoverable_uncertainty(self) -> None:
+        closed_stream = mock.MagicMock()
+        closed_stream.__enter__.return_value = iter([])
+        closed_stream.__exit__.return_value = False
+
+        with mock.patch.dict(
+            os.environ,
+            {"GC_API_BASE_URL": "http://gc.test/v0/city/test"},
+        ), mock.patch.object(common.urllib.request, "urlopen", return_value=closed_stream):
+            with self.assertRaisesRegex(common.GCAPIResultUnknown, "closed before request"):
+                common.wait_for_gc_request_result(
+                    "req-submit",
+                    event_cursor="42",
+                    success_type=common.GC_EVENT_SESSION_SUBMIT_SUCCEEDED,
+                    failure_operation=common.GC_OPERATION_SESSION_SUBMIT,
+                )
 
     def test_gc_api_base_url_rejects_disabled_port(self) -> None:
         pathlib.Path(self.tempdir.name, "city.toml").write_text('[api]\nport = 0\n', encoding="utf-8")
@@ -1221,6 +1547,43 @@ class DiscordIntakeCommonTests(unittest.TestCase):
         self.assertEqual(fields["publish_conversation_id"], "22")
         self.assertEqual(fields["publish_trigger_id"], "new-msg")
         self.assertEqual(fields["publish_reply_to_discord_message_id"], "new-msg")
+
+    def test_find_latest_discord_reply_context_matches_async_terminal_session_id(self) -> None:
+        common.save_chat_ingress(
+            {
+                "ingress_id": "in-async",
+                "binding_id": "room:22@app:riley",
+                "conversation_id": "22",
+                "discord_message_id": "async-msg",
+                "created_at": "2026-07-15T02:24:01Z",
+                "status": "delivered",
+                "targets": [
+                    {
+                        "session_name": "employees.corp--riley",
+                        "status": "delivered",
+                        "response": {
+                            "status": "accepted",
+                            "request_id": "req-async",
+                        },
+                        "terminal_evidence": {
+                            "status": "succeeded",
+                            "payload": {
+                                "request_id": "req-async",
+                                "session_id": "mc-wisp-n2val",
+                                "queued": True,
+                            },
+                        },
+                    }
+                ],
+            }
+        )
+
+        with mock.patch.object(common, "gc_api_request", return_value={"messages": []}):
+            fields = common.find_latest_discord_reply_context("mc-wisp-n2val", tail=5)
+
+        self.assertEqual(fields["ingress_receipt_id"], "in-async")
+        self.assertEqual(fields["publish_binding_id"], "room:22@app:riley")
+        self.assertEqual(fields["publish_reply_to_discord_message_id"], "async-msg")
 
     def test_extract_peer_session_mentions_ignores_urls_and_code(self) -> None:
         mentions = common.extract_peer_session_mentions(
@@ -1391,6 +1754,42 @@ class DiscordIntakeCommonTests(unittest.TestCase):
 
         assert touched is not None
         self.assertTrue(str(touched.get("last_activity_at", "")).strip())
+
+    def test_set_room_launch_last_addressed_ignores_older_delivery_order(self) -> None:
+        common.save_room_launch(
+            {
+                "launch_id": "room-launch:ordered",
+                "launcher_id": "launch-room:22",
+                "guild_id": "1",
+                "conversation_id": "22",
+                "root_message_id": "ordered",
+                "qualified_handle": "corp/sky",
+                "session_alias": "dc-123-sky",
+                "thread_id": "222",
+                "participants": {
+                    "corp/priya": {
+                        "qualified_handle": "corp/priya",
+                        "session_alias": "dc-123-priya",
+                    }
+                },
+            }
+        )
+
+        common.set_room_launch_last_addressed(
+            "room-launch:ordered",
+            "corp/priya",
+            delivery_order="snowflake:00000000000000000200",
+        )
+        common.set_room_launch_last_addressed(
+            "room-launch:ordered",
+            "corp/sky",
+            delivery_order="snowflake:00000000000000000100",
+        )
+
+        launch = common.load_room_launch("room-launch:ordered")
+        assert launch is not None
+        self.assertEqual(launch["last_addressed_qualified_handle"], "corp/priya")
+        self.assertEqual(launch["last_addressed_delivery_order"], "snowflake:00000000000000000200")
 
     def test_prune_room_launches_keeps_recent_thread_routes(self) -> None:
         common.save_room_launch(
@@ -2142,6 +2541,41 @@ class DiscordIntakeCommonTests(unittest.TestCase):
         self.assertEqual(common._count_root_peer_triggered_publishes("room:22", "in-1", "corp--sky"), 2)
         self.assertEqual(common._count_root_peer_deliveries_from_index("room:22", "in-1"), 3)
 
+    def _save_peer_retry_record(self, publish_id: str, target: dict[str, object]) -> None:
+        common.set_chat_binding(
+            common.load_config(),
+            "room",
+            "22",
+            ["corp--sky", "corp--priya"],
+            guild_id="1",
+            policy={"peer_fanout_enabled": True},
+        )
+        common.save_chat_publish(
+            {
+                "publish_id": publish_id,
+                "binding_id": "room:22",
+                "binding_kind": "room",
+                "binding_conversation_id": "22",
+                "conversation_id": "22",
+                "guild_id": "1",
+                "source_session_name": "corp--sky",
+                "source_session_id": "gc-sky",
+                "source_event_kind": "discord_human_message",
+                "root_ingress_receipt_id": f"in-{publish_id}",
+                "body": "@corp--priya hello",
+                "remote_message_id": f"msg-{publish_id}",
+                "peer_delivery": {
+                    "phase": "peer_fanout_partial_failure",
+                    "status": "partial_failure",
+                    "delivery": "targeted",
+                    "mentioned_session_names": ["corp--priya"],
+                    "frozen_targets": ["corp--priya"],
+                    "targets": [target],
+                    "budget_snapshot": {},
+                },
+            }
+        )
+
     def test_retry_peer_fanout_redrives_failed_target_without_reposting(self) -> None:
         common.set_chat_binding(
             common.load_config(),
@@ -2195,6 +2629,219 @@ class DiscordIntakeCommonTests(unittest.TestCase):
         self.assertEqual(record["peer_delivery"]["status"], "delivered")
         post_channel_message.assert_not_called()
         deliver_session_message.assert_called_once()
+        self.assertEqual(
+            deliver_session_message.call_args.kwargs["async_timeout"],
+            common.PEER_DELIVERY_TIMEOUT_SECONDS,
+        )
+
+    def test_retry_peer_fanout_preserves_async_correlation_when_result_is_unknown(self) -> None:
+        common.set_chat_binding(
+            common.load_config(),
+            "room",
+            "22",
+            ["corp--sky", "corp--priya"],
+            guild_id="1",
+            policy={"peer_fanout_enabled": True},
+        )
+        common.save_chat_publish(
+            {
+                "publish_id": "discord-publish-unknown",
+                "binding_id": "room:22",
+                "binding_kind": "room",
+                "binding_conversation_id": "22",
+                "conversation_id": "22",
+                "guild_id": "1",
+                "source_session_name": "corp--sky",
+                "source_session_id": "gc-sky",
+                "source_event_kind": "discord_human_message",
+                "root_ingress_receipt_id": "in-unknown",
+                "body": "@corp--priya hello",
+                "remote_message_id": "msg-unknown",
+                "peer_delivery": {
+                    "phase": "peer_fanout_partial_failure",
+                    "status": "partial_failure",
+                    "delivery": "targeted",
+                    "mentioned_session_names": ["corp--priya"],
+                    "frozen_targets": ["corp--priya"],
+                    "targets": [
+                        {
+                            "session_name": "corp--priya",
+                            "status": "failed_retryable",
+                            "attempt_count": 1,
+                            "attempts": [],
+                        }
+                    ],
+                    "budget_snapshot": {},
+                },
+            }
+        )
+
+        def unknown_after_acceptance(*args: object, **kwargs: object) -> dict[str, object]:
+            kwargs["on_async_accepted"](
+                {
+                    "http_status": 202,
+                    "request_id": "req-peer-unknown",
+                    "event_cursor": "71",
+                    "intent": "default",
+                    "response": {
+                        "status": "accepted",
+                        "request_id": "req-peer-unknown",
+                        "event_cursor": "71",
+                    },
+                }
+            )
+            raise common.GCAPIResultUnknown("peer result stream closed")
+
+        with mock.patch.object(
+            common,
+            "deliver_session_message",
+            side_effect=unknown_after_acceptance,
+        ) as deliver_session_message:
+            record = common.retry_peer_fanout("discord-publish-unknown")
+
+        target = record["peer_delivery"]["targets"][0]
+        self.assertEqual(record["peer_delivery"]["phase"], "peer_fanout_in_progress")
+        self.assertEqual(target["status"], "awaiting_result")
+        self.assertEqual(target["request_id"], "req-peer-unknown")
+        self.assertEqual(target["event_cursor"], "71")
+        self.assertEqual(
+            deliver_session_message.call_args.kwargs["async_timeout"],
+            common.PEER_DELIVERY_TIMEOUT_SECONDS,
+        )
+
+    def test_retry_peer_fanout_explicitly_redrives_uncorrelated_unknown(self) -> None:
+        self._save_peer_retry_record(
+            "discord-publish-explicit-unknown",
+            {
+                "session_name": "corp--priya",
+                "delivery_selector": "corp--priya",
+                "status": "delivery_unknown",
+                "attempt_count": 1,
+                "attempts": [],
+            },
+        )
+
+        with mock.patch.object(
+            common,
+            "deliver_session_message",
+            return_value={"status": "accepted"},
+        ) as deliver_session_message:
+            record = common.retry_peer_fanout(
+                "discord-publish-explicit-unknown",
+                include_unknown=True,
+            )
+
+        deliver_session_message.assert_called_once()
+        self.assertEqual(record["peer_delivery"]["targets"][0]["status"], "delivered")
+
+    def test_retry_peer_fanout_clears_stale_async_ref_before_new_post(self) -> None:
+        self._save_peer_retry_record(
+            "discord-publish-stale-ref",
+            {
+                "session_name": "corp--priya",
+                "delivery_selector": "corp--priya",
+                "status": "failed_retryable",
+                "attempt_count": 1,
+                "request_id": "req-old",
+                "event_cursor": "81",
+                "response": {"status": "accepted", "request_id": "req-old", "event_cursor": "81"},
+                "terminal_evidence": {"status": "failed"},
+                "attempts": [],
+            },
+        )
+
+        with mock.patch.object(
+            common,
+            "deliver_session_message",
+            side_effect=common.GCAPIResultUnknown("new POST outcome unknown"),
+        ) as deliver_session_message, mock.patch.object(
+            common,
+            "resume_session_message_delivery",
+        ) as resume_session_message_delivery:
+            record = common.retry_peer_fanout("discord-publish-stale-ref")
+
+        deliver_session_message.assert_called_once()
+        resume_session_message_delivery.assert_not_called()
+        target = record["peer_delivery"]["targets"][0]
+        self.assertEqual(target["status"], "delivery_unknown")
+        self.assertEqual(target["request_id"], "")
+        self.assertEqual(target["event_cursor"], "")
+        self.assertEqual(target["terminal_evidence"], {})
+
+    def test_peer_in_progress_staleness_exceeds_post_and_result_waits(self) -> None:
+        self.assertGreater(
+            common.PEER_IN_PROGRESS_STALE_SECONDS,
+            common.PEER_DELIVERY_TIMEOUT_SECONDS * 2,
+        )
+
+    def test_retry_peer_fanout_resumes_awaiting_result_without_resubmitting(self) -> None:
+        common.set_chat_binding(
+            common.load_config(),
+            "room",
+            "22",
+            ["corp--sky", "corp--priya"],
+            guild_id="1",
+            policy={"peer_fanout_enabled": True},
+        )
+        common.save_chat_publish(
+            {
+                "publish_id": "discord-publish-awaiting",
+                "binding_id": "room:22",
+                "binding_kind": "room",
+                "binding_conversation_id": "22",
+                "conversation_id": "22",
+                "guild_id": "1",
+                "source_session_name": "corp--sky",
+                "source_session_id": "gc-sky",
+                "source_event_kind": "discord_human_message",
+                "root_ingress_receipt_id": "in-awaiting",
+                "body": "@corp--priya hello",
+                "remote_message_id": "msg-awaiting",
+                "peer_delivery": {
+                    "phase": "peer_fanout_in_progress",
+                    "status": "",
+                    "delivery": "targeted",
+                    "mentioned_session_names": ["corp--priya"],
+                    "frozen_targets": ["corp--priya"],
+                    "targets": [
+                        {
+                            "session_name": "corp--priya",
+                            "delivery_selector": "corp--priya",
+                            "status": "awaiting_result",
+                            "attempt_count": 1,
+                            "request_id": "req-peer",
+                            "event_cursor": "61",
+                            "intent": "default",
+                            "response": {"status": "accepted", "request_id": "req-peer", "event_cursor": "61"},
+                            "attempts": [],
+                        }
+                    ],
+                    "budget_snapshot": {},
+                },
+            }
+        )
+        terminal = {"request_id": "req-peer", "session_id": "gc-priya"}
+
+        with mock.patch.object(
+            common,
+            "resume_session_message_delivery",
+            return_value=terminal,
+        ) as resume_session_message_delivery, mock.patch.object(
+            common,
+            "deliver_session_message",
+        ) as deliver_session_message:
+            record = common.retry_peer_fanout("discord-publish-awaiting")
+
+        deliver_session_message.assert_not_called()
+        resume_session_message_delivery.assert_called_once_with(
+            "req-peer",
+            "61",
+            intent="default",
+            timeout=common.PEER_DELIVERY_TIMEOUT_SECONDS,
+        )
+        target = record["peer_delivery"]["targets"][0]
+        self.assertEqual(target["status"], "delivered")
+        self.assertEqual(target["terminal_evidence"], {"status": "succeeded", "payload": terminal})
 
     def test_retry_peer_fanout_room_launch_preserves_launch_context(self) -> None:
         common.set_room_launcher(common.load_config(), "1", "22")

--- a/discord/tests/test_discord_intake_common.py
+++ b/discord/tests/test_discord_intake_common.py
@@ -75,6 +75,395 @@ class DiscordIntakeCommonTests(unittest.TestCase):
                 },
             )
 
+    def test_named_app_import_preserves_default_app_and_isolates_policy(self) -> None:
+        config = common.import_app_config(
+            common.load_config(),
+            {
+                "application_id": "123",
+                "public_key": "ab" * 32,
+                "guild_allowlist": ["default-guild"],
+            },
+        )
+
+        config = common.import_app_config(
+            config,
+            {
+                "application_id": "456",
+                "public_key": "cd" * 32,
+                "guild_allowlist": ["ollie-guild"],
+                "channel_allowlist": ["ollie-channel"],
+            },
+            app_name="ollie",
+        )
+
+        self.assertEqual(config["app"]["application_id"], "123")
+        self.assertEqual(config["policy"]["guild_allowlist"], ["default-guild"])
+        self.assertEqual(config["apps"]["ollie"]["application_id"], "456")
+        self.assertEqual(config["apps"]["ollie"]["policy"]["guild_allowlist"], ["ollie-guild"])
+        self.assertEqual(config["apps"]["ollie"]["policy"]["channel_allowlist"], ["ollie-channel"])
+
+    def test_import_app_config_rejects_named_id_change_even_with_a_new_token(self) -> None:
+        config = common.import_app_config(
+            common.load_config(),
+            {"application_id": "456", "public_key": "cd" * 32},
+            app_name="ollie",
+        )
+        common.save_bot_token("existing-credential", app_name="ollie")
+
+        with self.assertRaisesRegex(ValueError, "cannot change.*application_id"):
+            common.import_app_config(
+                config,
+                {"application_id": "789", "public_key": "ef" * 32},
+                app_name="ollie",
+                bot_token="replacement-credential",
+            )
+
+        self.assertEqual(common.resolve_app_config(common.load_config(), "ollie")["application_id"], "456")
+        self.assertEqual(common.load_bot_token("ollie"), "existing-credential")
+
+    def test_import_app_config_rejects_empty_id_partial_app_with_an_existing_token(self) -> None:
+        common.save_config(
+            {
+                "apps": {
+                    "ollie": {
+                        "public_key": "cd" * 32,
+                    }
+                }
+            }
+        )
+        common.save_bot_token("orphan-credential", app_name="ollie")
+
+        with self.assertRaisesRegex(ValueError, "orphan bot token.*new app name"):
+            common.import_app_config(
+                common.load_config(),
+                {"application_id": "456", "public_key": "cd" * 32},
+                app_name="ollie",
+            )
+
+        self.assertEqual(common.resolve_app_config(common.load_config(), "ollie")["application_id"], "")
+        self.assertEqual(common.load_bot_token("ollie"), "orphan-credential")
+
+    def test_new_named_identity_rejects_orphan_token_even_when_a_token_is_supplied(self) -> None:
+        common.save_bot_token("orphan-credential", app_name="ollie")
+
+        with self.assertRaisesRegex(ValueError, "orphan bot token.*new app name"):
+            common.import_app_config(
+                common.load_config(),
+                {"application_id": "456", "public_key": "cd" * 32},
+                app_name="ollie",
+                bot_token="replacement-credential",
+            )
+
+        self.assertEqual(common.load_config()["apps"], {})
+        self.assertEqual(common.load_bot_token("ollie"), "orphan-credential")
+
+    def test_named_app_import_rejects_unsafe_app_name(self) -> None:
+        with self.assertRaisesRegex(ValueError, "app name"):
+            common.import_app_config(
+                common.load_config(),
+                {
+                    "application_id": "456",
+                    "public_key": "cd" * 32,
+                },
+                app_name="../ollie",
+            )
+
+    def test_named_app_import_rejects_reserved_default_name(self) -> None:
+        with self.assertRaisesRegex(ValueError, "reserved"):
+            common.import_app_config(
+                common.load_config(),
+                {
+                    "application_id": "456",
+                    "public_key": "cd" * 32,
+                },
+                app_name="default",
+            )
+
+    def test_config_normalization_drops_empty_named_app_key(self) -> None:
+        config = common.normalize_config(
+            {
+                "apps": {
+                    "": {
+                        "application_id": "456",
+                        "public_key": "cd" * 32,
+                    }
+                }
+            }
+        )
+
+        self.assertEqual(config["apps"], {})
+
+    def test_named_app_import_rejects_duplicate_application_id(self) -> None:
+        config = common.import_app_config(
+            common.load_config(),
+            {
+                "application_id": "456",
+                "public_key": "ab" * 32,
+            },
+        )
+
+        with self.assertRaisesRegex(ValueError, "application_id.*already configured"):
+            common.import_app_config(
+                config,
+                {
+                    "application_id": "456",
+                    "public_key": "cd" * 32,
+                },
+                app_name="ollie",
+            )
+
+    def test_concurrent_named_app_imports_preserve_both_apps(self) -> None:
+        stale_config = common.load_config()
+        start = threading.Barrier(2)
+        errors: list[BaseException] = []
+
+        def import_named(app_name: str, application_id: str, public_key_byte: str) -> None:
+            try:
+                start.wait(timeout=2)
+                common.import_app_config(
+                    stale_config,
+                    {
+                        "application_id": application_id,
+                        "public_key": public_key_byte * 32,
+                    },
+                    app_name=app_name,
+                )
+            except BaseException as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        threads = [
+            threading.Thread(target=import_named, args=("ollie", "456", "ab")),
+            threading.Thread(target=import_named, args=("olivia", "789", "cd")),
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=3)
+
+        self.assertEqual(errors, [])
+        self.assertTrue(all(not thread.is_alive() for thread in threads))
+        self.assertEqual(set(common.load_config()["apps"]), {"ollie", "olivia"})
+
+    def test_concurrent_metadata_import_cannot_split_a_rotated_named_identity(self) -> None:
+        stale_config = common.import_app_config(
+            common.load_config(),
+            {"application_id": "456", "public_key": "ab" * 32},
+            app_name="ollie",
+        )
+        common.save_bot_token("old-credential", app_name="ollie")
+        rotation_holds_lock = threading.Event()
+        release_rotation = threading.Event()
+        errors: list[BaseException] = []
+        original_save_bot_token = common.save_bot_token
+
+        def blocking_save_bot_token(token: str, app_name: str = "") -> None:
+            if token == "new-credential":
+                rotation_holds_lock.set()
+                if not release_rotation.wait(timeout=2):
+                    raise TimeoutError("timed out waiting to release credential rotation")
+            original_save_bot_token(token, app_name=app_name)
+
+        def rotate_identity() -> None:
+            try:
+                common.import_app_config(
+                    stale_config,
+                    {"application_id": "456", "public_key": "cd" * 32},
+                    app_name="ollie",
+                    bot_token="new-credential",
+                )
+            except BaseException as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        def write_stale_metadata() -> None:
+            try:
+                common.import_app_config(
+                    stale_config,
+                    {"application_id": "456", "public_key": "ef" * 32},
+                    app_name="ollie",
+                )
+            except BaseException as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        with mock.patch.object(common, "save_bot_token", side_effect=blocking_save_bot_token):
+            rotation_thread = threading.Thread(target=rotate_identity)
+            rotation_thread.start()
+            self.assertTrue(rotation_holds_lock.wait(timeout=2))
+            metadata_thread = threading.Thread(target=write_stale_metadata)
+            metadata_thread.start()
+            release_rotation.set()
+            rotation_thread.join(timeout=3)
+            metadata_thread.join(timeout=3)
+
+        self.assertFalse(rotation_thread.is_alive())
+        self.assertFalse(metadata_thread.is_alive())
+        self.assertEqual(errors, [])
+        app = common.resolve_app_config(common.load_config(), "ollie")
+        self.assertEqual(app["application_id"], "456")
+        self.assertEqual(app["public_key"], "ef" * 32)
+        self.assertEqual(common.load_bot_token("ollie"), "new-credential")
+
+    def test_concurrent_named_bindings_preserve_both_bindings(self) -> None:
+        config = common.import_app_config(
+            common.load_config(),
+            {"application_id": "456", "public_key": "ab" * 32},
+            app_name="ollie",
+        )
+        common.import_app_config(
+            config,
+            {"application_id": "789", "public_key": "cd" * 32},
+            app_name="olivia",
+        )
+        stale_config = common.load_config()
+        start = threading.Barrier(2)
+        errors: list[BaseException] = []
+
+        def bind_named(app_name: str, session_name: str) -> None:
+            try:
+                start.wait(timeout=2)
+                common.set_chat_binding(
+                    stale_config,
+                    "room",
+                    "22",
+                    [session_name],
+                    guild_id="1",
+                    app_name=app_name,
+                )
+            except BaseException as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        threads = [
+            threading.Thread(target=bind_named, args=("ollie", "teams.lead")),
+            threading.Thread(target=bind_named, args=("olivia", "teams.pm")),
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=3)
+
+        self.assertEqual(errors, [])
+        self.assertTrue(all(not thread.is_alive() for thread in threads))
+        binding_ids = {item["id"] for item in common.list_chat_bindings(common.load_config())}
+        self.assertEqual(binding_ids, {"room:22@app:ollie", "room:22@app:olivia"})
+
+    def test_room_launcher_mutation_reloads_config_and_preserves_a_concurrent_app_import(self) -> None:
+        stale_config = common.load_config()
+        common.import_app_config(
+            stale_config,
+            {"application_id": "456", "public_key": "ab" * 32},
+            app_name="ollie",
+        )
+
+        common.set_room_launcher(stale_config, "1", "22")
+
+        config = common.load_config()
+        self.assertIn("ollie", config["apps"])
+        self.assertIsNotNone(common.resolve_room_launcher(config, "22"))
+
+    def test_channel_mapping_mutation_reloads_config_and_preserves_a_concurrent_app_import(self) -> None:
+        stale_config = common.load_config()
+        common.import_app_config(
+            stale_config,
+            {"application_id": "456", "public_key": "ab" * 32},
+            app_name="ollie",
+        )
+
+        common.set_channel_mapping(stale_config, "1", "22", "product/polecat", None)
+
+        config = common.load_config()
+        self.assertIn("ollie", config["apps"])
+        self.assertIn("1/22", config["channels"])
+
+    def test_rig_mapping_mutation_reloads_config_and_preserves_a_concurrent_app_import(self) -> None:
+        stale_config = common.load_config()
+        common.import_app_config(
+            stale_config,
+            {"application_id": "456", "public_key": "ab" * 32},
+            app_name="ollie",
+        )
+
+        common.set_rig_mapping(stale_config, "1", "product", "product/polecat", None)
+
+        config = common.load_config()
+        self.assertIn("ollie", config["apps"])
+        self.assertIn("1/product", config["rigs"])
+
+    def test_named_app_tokens_are_isolated_and_mode_0600(self) -> None:
+        common.save_bot_token("default-token")
+        common.save_bot_token("ollie-token", app_name="ollie")
+        common.save_bot_token("olivia-token", app_name="olivia")
+
+        self.assertEqual(common.load_bot_token(), "default-token")
+        self.assertEqual(common.load_bot_token("ollie"), "ollie-token")
+        self.assertEqual(common.load_bot_token("olivia"), "olivia-token")
+        self.assertEqual(
+            pathlib.Path(common.secret_path("bot-token-ollie.txt")).stat().st_mode & 0o777,
+            0o600,
+        )
+        self.assertEqual(
+            pathlib.Path(common.secret_path("bot-token-olivia.txt")).stat().st_mode & 0o777,
+            0o600,
+        )
+
+    def test_redacted_config_reports_named_token_presence_without_token_value(self) -> None:
+        config = common.import_app_config(
+            common.load_config(),
+            {
+                "application_id": "456",
+                "public_key": "cd" * 32,
+            },
+            app_name="ollie",
+        )
+        common.save_bot_token("ollie-token", app_name="ollie")
+
+        redacted = common.redact_config(config)
+
+        self.assertTrue(redacted["apps"]["ollie"]["bot_token_present"])
+        self.assertNotIn("bot_token", redacted["apps"]["ollie"])
+
+    def test_app_config_and_policy_resolution_fail_closed_for_unknown_name(self) -> None:
+        config = common.import_app_config(
+            common.load_config(),
+            {
+                "application_id": "456",
+                "public_key": "cd" * 32,
+                "guild_allowlist": ["1"],
+                "channel_allowlist": ["22"],
+            },
+            app_name="ollie",
+        )
+
+        self.assertEqual(common.resolve_app_config(config, "ollie")["application_id"], "456")
+        self.assertEqual(common.resolve_app_policy(config, "ollie")["channel_allowlist"], ["22"])
+        with self.assertRaisesRegex(ValueError, "unknown Discord app"):
+            common.resolve_app_config(config, "olivia")
+        with self.assertRaisesRegex(ValueError, "unknown Discord app"):
+            common.resolve_app_policy(config, "olivia")
+
+    def test_gateway_status_is_isolated_per_named_app_and_keeps_legacy_projection(self) -> None:
+        config = common.import_app_config(
+            common.load_config(),
+            {
+                "application_id": "123",
+                "public_key": "ab" * 32,
+            },
+        )
+        common.import_app_config(
+            config,
+            {
+                "application_id": "456",
+                "public_key": "cd" * 32,
+            },
+            app_name="ollie",
+        )
+        common.save_gateway_status({"state": "ready", "bot_user_id": "123"})
+        common.save_gateway_status({"state": "waiting_for_config"}, app_name="ollie")
+
+        snapshot = common.build_status_snapshot(limit=1)
+
+        self.assertEqual(snapshot["gateway_status"]["bot_user_id"], "123")
+        self.assertEqual(snapshot["gateway_statuses"]["default"]["bot_user_id"], "123")
+        self.assertEqual(snapshot["gateway_statuses"]["ollie"]["state"], "waiting_for_config")
+
     def test_shared_discord_prompt_requires_bold_speaker_prefix(self) -> None:
         fragment = (
             pathlib.Path(__file__).resolve().parents[1] / "template-fragments" / "discord-v0.template.md"
@@ -117,6 +506,69 @@ class DiscordIntakeCommonTests(unittest.TestCase):
         self.assertEqual(binding["guild_id"], "1")
         self.assertEqual(binding["session_names"], ["sky", "lawrence"])
         self.assertEqual(binding["policy"], common.default_room_peer_policy())
+
+    def test_named_apps_can_bind_the_same_room_independently(self) -> None:
+        config = common.set_chat_binding(
+            common.load_config(),
+            "room",
+            "22",
+            ["teams.lead"],
+            guild_id="1",
+            app_name="ollie",
+        )
+        config = common.set_chat_binding(
+            config,
+            "room",
+            "22",
+            ["teams.pm"],
+            guild_id="1",
+            app_name="olivia",
+        )
+
+        lead = common.resolve_chat_binding(config, "room:22@app:ollie")
+        product = common.resolve_chat_binding(config, "room:22@app:olivia")
+
+        self.assertEqual(lead["app"], "ollie")
+        self.assertEqual(lead["session_names"], ["teams.lead"])
+        self.assertEqual(product["app"], "olivia")
+        self.assertEqual(product["session_names"], ["teams.pm"])
+        self.assertEqual(len(common.list_chat_bindings(config)), 2)
+
+    def test_legacy_and_named_binding_can_share_a_room(self) -> None:
+        config = common.set_chat_binding(
+            common.load_config(),
+            "room",
+            "22",
+            ["legacy"],
+            guild_id="1",
+        )
+        config = common.set_chat_binding(
+            config,
+            "room",
+            "22",
+            ["teams.lead"],
+            guild_id="1",
+            app_name="ollie",
+        )
+
+        legacy = common.resolve_chat_binding(config, "room:22")
+        named = common.resolve_chat_binding(config, "room:22@app:ollie")
+
+        self.assertNotIn("app", legacy)
+        self.assertEqual(named["app"], "ollie")
+
+    def test_publish_route_rejects_binding_for_unknown_named_app(self) -> None:
+        config = common.set_chat_binding(
+            common.load_config(),
+            "room",
+            "22",
+            ["teams.lead"],
+            guild_id="1",
+            app_name="ghost",
+        )
+
+        with self.assertRaisesRegex(ValueError, "unknown Discord app"):
+            common.resolve_publish_route(config, "room:22@app:ghost")
 
     def test_set_chat_binding_deduplicates_participants_case_insensitively(self) -> None:
         config = common.set_chat_binding(common.load_config(), "room", "22", ["sky", "Sky", "lawrence"], guild_id="1")
@@ -316,6 +768,15 @@ class DiscordIntakeCommonTests(unittest.TestCase):
             metadata = common.describe_room_channel_metadata("22", bot_token="bot-token")
 
         self.assertEqual(metadata, {"channel_type": 0})
+
+    def test_describe_room_channel_scope_does_not_fall_back_from_an_explicit_empty_token(self) -> None:
+        common.save_bot_token("default-token")
+
+        with mock.patch.object(common, "discord_api_request") as discord_api_request:
+            scope = common.describe_room_channel_scope("22", bot_token="")
+
+        self.assertEqual(scope, {})
+        discord_api_request.assert_not_called()
 
     def test_save_channel_metadata_cache_round_trips_normalized_metadata(self) -> None:
         metadata = common.save_channel_metadata_cache("22", {"type": 11, "parent_id": "7"})
@@ -572,7 +1033,11 @@ class DiscordIntakeCommonTests(unittest.TestCase):
         self.assertEqual(urlopen.call_args_list[-1].args[0].full_url, "http://127.0.0.1:8372/v0/city/gc/sessions")
 
     def test_deliver_session_message_uses_messages_endpoint_for_default_intent(self) -> None:
-        with mock.patch.object(common, "gc_api_request", return_value={"status": "accepted"}) as gc_api_request:
+        with mock.patch.object(
+            common,
+            "gc_api_request_with_status",
+            return_value=(200, {"status": "accepted"}),
+        ) as gc_api_request:
             payload = common.deliver_session_message("corp--sky", "hello", idempotency_key="ingress:1")
 
         self.assertEqual(payload, {"status": "accepted"})
@@ -585,7 +1050,11 @@ class DiscordIntakeCommonTests(unittest.TestCase):
         )
 
     def test_deliver_session_message_uses_submit_endpoint_for_follow_up_intent(self) -> None:
-        with mock.patch.object(common, "gc_api_request", return_value={"status": "accepted"}) as gc_api_request:
+        with mock.patch.object(
+            common,
+            "gc_api_request_with_status",
+            return_value=(200, {"status": "accepted"}),
+        ) as gc_api_request:
             payload = common.deliver_session_message(
                 "corp--sky",
                 "hello again",
@@ -1930,6 +2399,18 @@ class DiscordIntakeCommonTests(unittest.TestCase):
         self.assertEqual(payload, {"ok": True})
         self.assertEqual(urlopen.call_count, 2)
         sleep.assert_called_once_with(0.0)
+
+    def test_discord_api_request_explicit_empty_token_never_falls_back_to_default(self) -> None:
+        common.save_bot_token("default-test-token")
+        success = mock.Mock()
+        success.__enter__ = mock.Mock(return_value=mock.Mock(read=mock.Mock(return_value=b'{}')))
+        success.__exit__ = mock.Mock(return_value=False)
+
+        with mock.patch.object(common.urllib.request, "urlopen", return_value=success) as urlopen:
+            common.discord_api_request("GET", "/channels/1", bot_token="")
+
+        request = urlopen.call_args.args[0]
+        self.assertNotIn("Authorization", request.headers)
 
 
 if __name__ == "__main__":

--- a/discord/tests/test_discord_multibot_cli_contract.py
+++ b/discord/tests/test_discord_multibot_cli_contract.py
@@ -1,0 +1,675 @@
+from __future__ import annotations
+
+import io
+import json
+import os
+import pathlib
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from unittest import mock
+
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+
+import discord_chat_bind as bind_script
+import discord_chat_publish as publish_script
+import discord_chat_reply_current as reply_current_script
+import discord_intake_common as common
+import discord_intake_import as import_script
+import discord_intake_status as status_script
+
+
+class DiscordMultiBotCLIContractTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self._old_environ = os.environ.copy()
+        os.environ["GC_CITY_ROOT"] = self.tempdir.name
+
+    def tearDown(self) -> None:
+        os.environ.clear()
+        os.environ.update(self._old_environ)
+
+    def _import_named_app(self, app_name: str, application_id: str, public_key_byte: str) -> None:
+        common.import_app_config(
+            common.load_config(),
+            {
+                "application_id": application_id,
+                "public_key": public_key_byte * 32,
+            },
+            app_name=app_name,
+        )
+
+    def test_import_app_selector_preserves_legacy_default_app_and_token(self) -> None:
+        default_credential = "default-test-credential"
+        named_credential = "ollie-test-credential"
+
+        with redirect_stdout(io.StringIO()):
+            legacy_code = import_script.main(
+                [
+                    "--application-id",
+                    "123",
+                    "--public-key",
+                    "ab" * 32,
+                    "--bot-token",
+                    default_credential,
+                ]
+            )
+
+        stdout = io.StringIO()
+        with mock.patch.object(common, "discord_api_request", return_value={"id": "456"}), redirect_stdout(stdout):
+            named_code = import_script.main(
+                [
+                    "--app",
+                    "ollie",
+                    "--application-id",
+                    "456",
+                    "--public-key",
+                    "cd" * 32,
+                    "--bot-token",
+                    named_credential,
+                    "--guild-allowlist",
+                    "guild-ollie",
+                ]
+            )
+
+        self.assertEqual(legacy_code, 0)
+        self.assertEqual(named_code, 0)
+        config = common.load_config()
+        self.assertEqual(config["app"]["application_id"], "123")
+        self.assertEqual(config["apps"]["ollie"]["application_id"], "456")
+        self.assertEqual(config["apps"]["ollie"]["policy"]["guild_allowlist"], ["guild-ollie"])
+        self.assertEqual(common.load_bot_token(), default_credential)
+        self.assertEqual(common.load_bot_token("ollie"), named_credential)
+        rendered = stdout.getvalue()
+        self.assertNotIn(default_credential, rendered)
+        self.assertNotIn(named_credential, rendered)
+        self.assertTrue(json.loads(rendered)["apps"]["ollie"]["bot_token_present"])
+
+    def test_named_import_rejects_token_for_a_different_application_without_mutation(self) -> None:
+        with mock.patch.object(common, "discord_api_request", return_value={"id": "999"}):
+            with self.assertRaisesRegex(SystemExit, "authenticated as.*application_id"):
+                import_script.main(
+                    [
+                        "--app",
+                        "ollie",
+                        "--application-id",
+                        "456",
+                        "--public-key",
+                        "cd" * 32,
+                        "--bot-token",
+                        "wrong-app-token",
+                    ]
+                )
+
+        self.assertEqual(common.load_config()["apps"], {})
+        self.assertEqual(common.load_bot_token("ollie"), "")
+
+    def test_named_import_reports_authentication_failure_without_leaking_or_mutating(self) -> None:
+        credential = "must-not-appear"
+        api_error = common.DiscordAPIError(
+            f"GET /users/@me rejected {credential}",
+            status_code=401,
+        )
+
+        with mock.patch.object(common, "discord_api_request", side_effect=api_error):
+            with self.assertRaises(SystemExit) as raised:
+                import_script.main(
+                    [
+                        "--app",
+                        "ollie",
+                        "--application-id",
+                        "456",
+                        "--public-key",
+                        "cd" * 32,
+                        "--bot-token",
+                        credential,
+                    ]
+                )
+
+        message = str(raised.exception)
+        self.assertIn("failed to authenticate Discord bot token", message)
+        self.assertIn("HTTP 401", message)
+        self.assertNotIn(credential, message)
+        self.assertEqual(common.load_config()["apps"], {})
+        self.assertEqual(common.load_bot_token("ollie"), "")
+
+    def test_named_token_rotation_preserves_existing_policy(self) -> None:
+        with mock.patch.object(common, "discord_api_request", return_value={"id": "456"}), redirect_stdout(io.StringIO()):
+            import_script.main(
+                [
+                    "--app",
+                    "ollie",
+                    "--application-id",
+                    "456",
+                    "--public-key",
+                    "cd" * 32,
+                    "--bot-token",
+                    "first-credential",
+                    "--guild-allowlist",
+                    "1",
+                    "--channel-allowlist",
+                    "22",
+                    "--role-allowlist",
+                    "7",
+                ]
+            )
+            import_script.main(
+                [
+                    "--app",
+                    "ollie",
+                    "--application-id",
+                    "456",
+                    "--public-key",
+                    "cd" * 32,
+                    "--bot-token",
+                    "rotated-credential",
+                ]
+            )
+
+        policy = common.resolve_app_policy(common.load_config(), "ollie")
+        self.assertEqual(policy["guild_allowlist"], ["1"])
+        self.assertEqual(policy["channel_allowlist"], ["22"])
+        self.assertEqual(policy["role_allowlist"], ["7"])
+        self.assertEqual(common.load_bot_token("ollie"), "rotated-credential")
+
+    def test_explicit_empty_named_token_file_fails_without_mutating_existing_identity(self) -> None:
+        self._import_named_app("ollie", "456", "cd")
+        common.save_bot_token("existing-credential", app_name="ollie")
+        empty_token_file = pathlib.Path(self.tempdir.name) / "empty-token"
+        empty_token_file.write_text("", encoding="utf-8")
+
+        with self.assertRaisesRegex(SystemExit, "bot token file is empty"):
+            import_script.main(
+                [
+                    "--app",
+                    "ollie",
+                    "--application-id",
+                    "789",
+                    "--public-key",
+                    "ef" * 32,
+                    "--bot-token-file",
+                    str(empty_token_file),
+                ]
+            )
+
+        app = common.resolve_app_config(common.load_config(), "ollie")
+        self.assertEqual(app["application_id"], "456")
+        self.assertEqual(common.load_bot_token("ollie"), "existing-credential")
+
+    def test_named_import_rejects_application_id_change_even_with_a_matching_token(self) -> None:
+        self._import_named_app("ollie", "456", "cd")
+        common.save_bot_token("existing-credential", app_name="ollie")
+
+        with mock.patch.object(common, "discord_api_request", return_value={"id": "789"}):
+            with self.assertRaisesRegex(SystemExit, "cannot change.*application_id"):
+                import_script.main(
+                    [
+                        "--app",
+                        "ollie",
+                        "--application-id",
+                        "789",
+                        "--public-key",
+                        "ef" * 32,
+                        "--bot-token",
+                        "replacement-credential",
+                    ]
+                )
+
+        app = common.resolve_app_config(common.load_config(), "ollie")
+        self.assertEqual(app["application_id"], "456")
+        self.assertEqual(common.load_bot_token("ollie"), "existing-credential")
+
+    def test_named_import_rejects_an_orphan_token_file_without_reusing_the_slug(self) -> None:
+        common.save_bot_token("orphan-credential", app_name="ollie")
+
+        with self.assertRaisesRegex(SystemExit, "orphan bot token.*new app name"):
+            import_script.main(
+                [
+                    "--app",
+                    "ollie",
+                    "--application-id",
+                    "456",
+                    "--public-key",
+                    "cd" * 32,
+                ]
+            )
+
+        self.assertEqual(common.load_config()["apps"], {})
+        self.assertEqual(common.load_bot_token("ollie"), "orphan-credential")
+
+    def test_named_import_rolls_back_config_when_token_persistence_fails(self) -> None:
+        self._import_named_app("ollie", "456", "cd")
+        common.save_bot_token("existing-credential", app_name="ollie")
+
+        with mock.patch.object(common, "discord_api_request", return_value={"id": "456"}), mock.patch.object(
+            common,
+            "save_bot_token",
+            side_effect=[OSError("simulated disk full"), None],
+        ):
+            with self.assertRaisesRegex(SystemExit, "failed to save Discord app credentials"):
+                import_script.main(
+                    [
+                        "--app",
+                        "ollie",
+                        "--application-id",
+                        "456",
+                        "--public-key",
+                        "ef" * 32,
+                        "--bot-token",
+                        "replacement-credential",
+                    ]
+                )
+
+        app = common.resolve_app_config(common.load_config(), "ollie")
+        self.assertEqual(app["application_id"], "456")
+        self.assertEqual(app["public_key"], "cd" * 32)
+        self.assertEqual(common.load_bot_token("ollie"), "existing-credential")
+
+    def test_bind_selector_keeps_default_and_named_room_bindings_independent(self) -> None:
+        self._import_named_app("ollie", "456", "cd")
+
+        with redirect_stdout(io.StringIO()):
+            legacy_code = bind_script.main(["--kind", "room", "--guild-id", "1", "22", "legacy.session"])
+            named_code = bind_script.main(
+                [
+                    "--kind",
+                    "room",
+                    "--app",
+                    "ollie",
+                    "--guild-id",
+                    "1",
+                    "22",
+                    "teams.lead",
+                ]
+            )
+
+        self.assertEqual(legacy_code, 0)
+        self.assertEqual(named_code, 0)
+        config = common.load_config()
+        legacy = common.resolve_chat_binding(config, "room:22")
+        named = common.resolve_chat_binding(config, "room:22@app:ollie")
+        self.assertEqual(legacy["session_names"], ["legacy.session"])
+        self.assertNotIn("app", legacy)
+        self.assertEqual(named["session_names"], ["teams.lead"])
+        self.assertEqual(named["app"], "ollie")
+
+    def test_bind_selector_creates_named_dm_binding(self) -> None:
+        self._import_named_app("ollie", "456", "cd")
+
+        stdout = io.StringIO()
+        with redirect_stdout(stdout):
+            code = bind_script.main(["--kind", "dm", "--app", "ollie", "55", "teams.lead"])
+
+        self.assertEqual(code, 0)
+        binding = common.resolve_chat_binding(common.load_config(), "dm:55@app:ollie")
+        self.assertEqual(binding["id"], "dm:55@app:ollie")
+        self.assertEqual(binding["app"], "ollie")
+        self.assertEqual(json.loads(stdout.getvalue())["session_names"], ["teams.lead"])
+
+    def test_named_bind_rejects_a_guild_outside_its_policy_without_mutation(self) -> None:
+        common.import_app_config(
+            common.load_config(),
+            {
+                "application_id": "456",
+                "public_key": "cd" * 32,
+                "guild_allowlist": ["1"],
+                "channel_allowlist": ["22"],
+            },
+            app_name="ollie",
+        )
+
+        with mock.patch.object(common, "discord_api_request") as discord_api_request:
+            with self.assertRaisesRegex(SystemExit, "guild_not_allowed"):
+                bind_script.main(
+                    ["--kind", "room", "--app", "ollie", "--guild-id", "9", "22", "teams.lead"]
+                )
+
+        discord_api_request.assert_not_called()
+        self.assertIsNone(common.resolve_chat_binding(common.load_config(), "room:22@app:ollie"))
+
+    def test_named_bind_accepts_a_thread_under_its_allowed_parent(self) -> None:
+        named_credential = "ollie-test-credential"
+        common.import_app_config(
+            common.load_config(),
+            {
+                "application_id": "456",
+                "public_key": "cd" * 32,
+                "guild_allowlist": ["1"],
+                "channel_allowlist": ["22"],
+            },
+            app_name="ollie",
+        )
+        common.save_bot_token(named_credential, app_name="ollie")
+
+        with mock.patch.object(
+            common,
+            "discord_api_request",
+            return_value={"id": "222", "guild_id": "1", "type": 11, "parent_id": "22"},
+        ) as discord_api_request, redirect_stdout(io.StringIO()):
+            code = bind_script.main(
+                ["--kind", "room", "--app", "ollie", "--guild-id", "1", "222", "teams.lead"]
+            )
+
+        self.assertEqual(code, 0)
+        discord_api_request.assert_called_once_with(
+            "GET",
+            "/channels/222",
+            bot_token=named_credential,
+        )
+        binding = common.resolve_chat_binding(common.load_config(), "room:222@app:ollie")
+        assert binding is not None
+        self.assertEqual(binding["thread_parent_id"], "22")
+
+    def test_named_bind_rejects_a_forged_guild_id_using_discord_channel_scope(self) -> None:
+        named_credential = "ollie-test-credential"
+        common.import_app_config(
+            common.load_config(),
+            {
+                "application_id": "456",
+                "public_key": "cd" * 32,
+                "guild_allowlist": ["1"],
+            },
+            app_name="ollie",
+        )
+        common.save_bot_token(named_credential, app_name="ollie")
+
+        with mock.patch.object(
+            common,
+            "discord_api_request",
+            return_value={"id": "33", "guild_id": "9", "type": 0},
+        ) as discord_api_request:
+            with self.assertRaisesRegex(SystemExit, "guild"):
+                bind_script.main(
+                    ["--kind", "room", "--app", "ollie", "--guild-id", "1", "33", "teams.lead"]
+                )
+
+        discord_api_request.assert_called_once_with("GET", "/channels/33", bot_token=named_credential)
+        self.assertIsNone(common.resolve_chat_binding(common.load_config(), "room:33@app:ollie"))
+
+    def test_default_bind_verifies_channel_scope_when_top_level_policy_is_restricted(self) -> None:
+        default_credential = "default-test-credential"
+        common.import_app_config(
+            common.load_config(),
+            {
+                "application_id": "123",
+                "public_key": "ab" * 32,
+                "guild_allowlist": ["1"],
+                "channel_allowlist": ["22"],
+            },
+        )
+        common.save_bot_token(default_credential)
+
+        with mock.patch.object(
+            common,
+            "discord_api_request",
+            return_value={"id": "22", "guild_id": "1", "type": 0},
+        ) as discord_api_request, redirect_stdout(io.StringIO()):
+            code = bind_script.main(["--kind", "room", "22", "teams.lead"])
+
+        self.assertEqual(code, 0)
+        discord_api_request.assert_called_once_with("GET", "/channels/22", bot_token=default_credential)
+        binding = common.resolve_chat_binding(common.load_config(), "room:22")
+        assert binding is not None
+        self.assertEqual(binding["guild_id"], "1")
+
+    def test_publish_selector_uses_named_binding_and_named_app_credential(self) -> None:
+        default_credential = "default-test-credential"
+        named_credential = "ollie-test-credential"
+        common.save_bot_token(default_credential)
+        self._import_named_app("ollie", "456", "cd")
+        common.save_bot_token(named_credential, app_name="ollie")
+        common.set_chat_binding(common.load_config(), "room", "22", ["legacy.session"], guild_id="1")
+        common.set_chat_binding(
+            common.load_config(),
+            "room",
+            "22",
+            ["teams.lead"],
+            guild_id="1",
+            app_name="ollie",
+        )
+        effective_credentials: list[str] = []
+
+        def fake_discord_api_request(
+            method: str,
+            path: str,
+            payload: object = None,
+            bot_token: str | None = None,
+        ) -> dict[str, str]:
+            del method, path, payload
+            effective_credentials.append(bot_token or common.load_bot_token())
+            return {"id": f"msg-{len(effective_credentials)}"}
+
+        with mock.patch.object(common, "discord_api_request", side_effect=fake_discord_api_request):
+            with redirect_stdout(io.StringIO()):
+                legacy_code = publish_script.main(["--binding", "room:22", "--body", "legacy hello"])
+                named_code = publish_script.main(
+                    ["--binding", "room:22", "--app", "ollie", "--body", "named hello"]
+                )
+
+        self.assertEqual(legacy_code, 0)
+        self.assertEqual(named_code, 0)
+        self.assertEqual(effective_credentials, [default_credential, named_credential])
+        publishes = sorted(common.list_recent_chat_publishes(limit=5), key=lambda item: item["remote_message_id"])
+        self.assertEqual(publishes[0]["binding_id"], "room:22")
+        self.assertEqual(publishes[0].get("app", ""), "")
+        self.assertEqual(publishes[1]["binding_id"], "room:22@app:ollie")
+        self.assertEqual(publishes[1]["app"], "ollie")
+
+    def test_publish_without_selector_rejects_ambiguous_named_bindings(self) -> None:
+        self._import_named_app("ollie", "456", "cd")
+        self._import_named_app("olivia", "789", "ef")
+        common.set_chat_binding(
+            common.load_config(),
+            "room",
+            "22",
+            ["teams.lead"],
+            guild_id="1",
+            app_name="ollie",
+        )
+        common.set_chat_binding(
+            common.load_config(),
+            "room",
+            "22",
+            ["teams.pm"],
+            guild_id="1",
+            app_name="olivia",
+        )
+
+        with self.assertRaisesRegex(SystemExit, r"(?i)ambiguous.*--app"):
+            publish_script.main(["--binding", "room:22", "--body", "must choose"])
+
+    def test_named_publish_rejects_a_binding_outside_its_channel_policy(self) -> None:
+        common.import_app_config(
+            common.load_config(),
+            {
+                "application_id": "456",
+                "public_key": "cd" * 32,
+                "guild_allowlist": ["1"],
+                "channel_allowlist": ["22"],
+            },
+            app_name="ollie",
+        )
+        common.save_bot_token("ollie-test-credential", app_name="ollie")
+        common.set_chat_binding(
+            common.load_config(),
+            "room",
+            "33",
+            ["teams.lead"],
+            guild_id="1",
+            app_name="ollie",
+            channel_metadata={"channel_type": 0},
+        )
+
+        with mock.patch.object(
+            common,
+            "discord_api_request",
+            return_value={"id": "33", "guild_id": "1", "type": 0},
+        ) as discord_api_request:
+            with self.assertRaisesRegex(SystemExit, "channel_not_allowed"):
+                publish_script.main(
+                    ["--binding", "room:33", "--app", "ollie", "--body", "must not publish"]
+                )
+
+        discord_api_request.assert_called_once_with(
+            "GET",
+            "/channels/33",
+            bot_token="ollie-test-credential",
+        )
+
+    def test_default_publish_enforces_top_level_channel_policy_against_discord_scope(self) -> None:
+        default_credential = "default-test-credential"
+        common.import_app_config(
+            common.load_config(),
+            {
+                "application_id": "123",
+                "public_key": "ab" * 32,
+                "guild_allowlist": ["1"],
+                "channel_allowlist": ["22"],
+            },
+        )
+        common.save_bot_token(default_credential)
+        common.set_chat_binding(
+            common.load_config(),
+            "room",
+            "33",
+            ["teams.lead"],
+            guild_id="1",
+            channel_metadata={"channel_type": 0},
+        )
+
+        with mock.patch.object(
+            common,
+            "discord_api_request",
+            return_value={"id": "33", "guild_id": "1", "type": 0},
+        ) as discord_api_request:
+            with self.assertRaisesRegex(SystemExit, "channel_not_allowed"):
+                publish_script.main(["--binding", "room:33", "--body", "must not publish"])
+
+        discord_api_request.assert_called_once_with("GET", "/channels/33", bot_token=default_credential)
+
+    def test_reply_current_inherits_the_named_app_from_ingress_binding(self) -> None:
+        named_credential = "ollie-test-credential"
+        self._import_named_app("ollie", "456", "cd")
+        common.save_bot_token(named_credential, app_name="ollie")
+        common.set_chat_binding(
+            common.load_config(),
+            "room",
+            "22",
+            ["teams.lead"],
+            guild_id="1",
+            app_name="ollie",
+        )
+        discord_calls: list[tuple[str, str, str]] = []
+
+        def fake_discord_api_request(
+            method: str,
+            path: str,
+            payload: object = None,
+            bot_token: str | None = None,
+        ) -> dict[str, str]:
+            del payload
+            discord_calls.append((method, path, bot_token or ""))
+            if method == "GET":
+                return {"id": "222", "parent_id": "22"}
+            return {"id": "reply-1"}
+
+        with mock.patch.object(
+            common,
+            "find_latest_discord_reply_context",
+            return_value={
+                "kind": "discord_human_message",
+                "ingress_receipt_id": "in-202-app-ollie",
+                "publish_binding_id": "room:22@app:ollie",
+                "publish_conversation_id": "222",
+                "publish_trigger_id": "202",
+                "publish_reply_to_discord_message_id": "202",
+            },
+        ), mock.patch.object(common, "discord_api_request", side_effect=fake_discord_api_request):
+            with redirect_stdout(io.StringIO()):
+                code = reply_current_script.main(["--body", "same bot reply"])
+
+        self.assertEqual(code, 0)
+        self.assertEqual(
+            discord_calls,
+            [
+                ("GET", "/channels/222", named_credential),
+                ("POST", "/channels/222/messages", named_credential),
+            ],
+        )
+        record = common.list_recent_chat_publishes(limit=1)[0]
+        self.assertEqual(record["app"], "ollie")
+        self.assertEqual(record["binding_id"], "room:22@app:ollie")
+        self.assertEqual(record["conversation_id"], "222")
+
+    def test_reply_current_rejects_a_stale_named_app_without_calling_discord(self) -> None:
+        self._import_named_app("ollie", "456", "cd")
+        common.set_chat_binding(
+            common.load_config(),
+            "room",
+            "22",
+            ["teams.lead"],
+            guild_id="1",
+            app_name="ollie",
+        )
+        config = common.load_config()
+        del config["apps"]["ollie"]
+        common.save_config(config)
+
+        with mock.patch.object(
+            common,
+            "find_latest_discord_reply_context",
+            return_value={
+                "kind": "discord_human_message",
+                "publish_binding_id": "room:22@app:ollie",
+                "publish_conversation_id": "22",
+                "publish_reply_to_discord_message_id": "202",
+            },
+        ), mock.patch.object(common, "discord_api_request") as discord_api_request:
+            with self.assertRaisesRegex(SystemExit, "unknown Discord app 'ollie'"):
+                reply_current_script.main(["--body", "must not publish"])
+
+        discord_api_request.assert_not_called()
+
+    def test_status_text_exposes_default_and_named_app_health_without_credentials(self) -> None:
+        default_credential = "default-test-credential"
+        named_credential = "ollie-test-credential"
+        common.import_app_config(
+            common.load_config(),
+            {"application_id": "123", "public_key": "ab" * 32},
+        )
+        self._import_named_app("ollie", "456", "cd")
+        self._import_named_app("olivia", "789", "ef")
+        common.save_bot_token(default_credential)
+        common.save_bot_token(named_credential, app_name="ollie")
+        common.save_gateway_status({"state": "ready", "routed_messages": 4, "failed_messages": 1})
+        common.save_gateway_status({"state": "reconnecting", "ignored_messages": 2}, app_name="ollie")
+        common.save_gateway_status({"state": "failed", "dropped_messages": 3}, app_name="olivia")
+
+        stdout = io.StringIO()
+        with redirect_stdout(stdout):
+            code = status_script.main([])
+
+        self.assertEqual(code, 0)
+        rendered = stdout.getvalue()
+        self.assertIn("Apps:", rendered)
+        self.assertIn("default", rendered)
+        self.assertIn("ollie", rendered)
+        self.assertIn("olivia", rendered)
+        self.assertIn("ready", rendered)
+        self.assertIn("reconnecting", rendered)
+        self.assertIn("failed", rendered)
+        self.assertIn("present", rendered)
+        self.assertIn("missing", rendered)
+        self.assertIn("routed=4", rendered)
+        self.assertIn("ignored=2", rendered)
+        self.assertIn("failed=1", rendered)
+        self.assertIn("dropped=3", rendered)
+        self.assertNotIn(default_credential, rendered)
+        self.assertNotIn(named_credential, rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gascity/assets/scripts/checks/build-artifact-valid.sh
+++ b/gascity/assets/scripts/checks/build-artifact-valid.sh
@@ -24,6 +24,7 @@ BEAD_ID="${GC_BEAD_ID:-}"
 [ -n "$BEAD_ID" ] || fail "GC_BEAD_ID is required"
 command -v gc >/dev/null 2>&1 || fail "gc is required on PATH"
 command -v python3 >/dev/null 2>&1 || fail "python3 is required on PATH"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 metadata_value() {
   # metadata_value <json> <key> -> prints metadata[key] or empty
@@ -79,13 +80,30 @@ done
 case "$ARTIFACT_PATH" in
   /*) ;;
   *)
-    [ -n "${GC_WORK_DIR:-}" ] || fail "artifact path $ARTIFACT_PATH from $RESOLVED_KEY is relative and GC_WORK_DIR is unset"
-    ARTIFACT_PATH="$GC_WORK_DIR/$ARTIFACT_PATH"
+    # Formula artifact paths are rig-relative. A producer runs in a disposable
+    # per-bead worktree, so GC_WORK_DIR points at the wrong place whenever the
+    # runtime provides the durable rig root. Controller checks use
+    # GC_BEADS_SCOPE_ROOT on some runtimes, while agent sessions use
+    # GC_RIG_ROOT. Older controllers supply neither but execute the installed
+    # check from <rig>/.gc/scripts/checks, which is another durable root
+    # signal. Do not use that fallback for a source-tree script.
+    ARTIFACT_ROOT="${GC_RIG_ROOT:-${GC_BEADS_SCOPE_ROOT:-${GC_DIR:-}}}"
+    if [ -z "$ARTIFACT_ROOT" ]; then
+      INSTALLED_RIG_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+      if [ -d "$INSTALLED_RIG_ROOT/.gc" ]; then
+        ARTIFACT_ROOT="$INSTALLED_RIG_ROOT"
+      fi
+    fi
+    if [ -n "$ARTIFACT_ROOT" ]; then
+      ARTIFACT_PATH="$ARTIFACT_ROOT/$ARTIFACT_PATH"
+    else
+      [ -n "${GC_WORK_DIR:-}" ] || fail "artifact path $ARTIFACT_PATH from $RESOLVED_KEY is relative and no rig-root environment is set"
+      ARTIFACT_PATH="$GC_WORK_DIR/$ARTIFACT_PATH"
+    fi
     ;;
 esac
 [ -f "$ARTIFACT_PATH" ] || fail "artifact $ARTIFACT_PATH from $RESOLVED_KEY does not exist"
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 VALIDATOR=""
 for candidate in \
   ${GC_WORK_DIR:+"$GC_WORK_DIR/gascity/assets/scripts/validate_build_artifact.py"} \

--- a/gascity/assets/workflows/build-base/plan-review.md
+++ b/gascity/assets/workflows/build-base/plan-review.md
@@ -3,3 +3,8 @@ This is the `build-base` plan-review stage. Treat it as a virtual contract that 
 Review the plan for traceability to requirements, feasibility, missing edge cases, and implementation readiness. If changes are required, update or route the plan before closing this stage.
 
 Close this step only when the plan is approved or the blocking issues are recorded in the step summary.
+
+Before closing this step, set the claimed step outcome with
+`gc bd update "<claimed-step-id>" --set-metadata "gc.outcome=pass"`, then close
+with `gc bd close "<claimed-step-id>" --reason "<concise reason>"`. Do not pass
+`--metadata` or `--set-metadata` to `gc bd close`.

--- a/gascity/assets/workflows/build-basic-review/{target}.acceptance-review.md
+++ b/gascity/assets/workflows/build-basic-review/{target}.acceptance-review.md
@@ -12,6 +12,19 @@ mark acceptance as `iterate` merely because the root checkout is unchanged when
 the recorded source anchor/worktree implements the requested behavior and its
 proof commands pass.
 
+Before inspecting files or running tests, read `gc.build.code_review_context_path`
+from the workflow root bead and use its `## Implementation Worktrees` section as
+the authority for code under review. `gc.work_dir` is the launcher rig root, not
+the implementation worktree. Do not inspect or edit the launcher checkout when
+deciding whether the implementation passes. Resolve every relative source path
+and proof command from the review context against the listed implementation
+worktree, run `cd "$WORKTREE"`, and verify `pwd -P` equals that worktree before
+executing commands. If the context is missing a usable implementation worktree,
+write an iterate finding against review setup instead of reviewing the launcher
+checkout.
+
+Contract: `gc.work_dir` is the launcher rig root, not the implementation worktree.
+
 Write findings under the build artifact root. Required findings must include
 the relevant requirement or task reference plus the file, command, or artifact
 that proves the issue.

--- a/gascity/assets/workflows/build-basic-review/{target}.apply-review-findings.md
+++ b/gascity/assets/workflows/build-basic-review/{target}.apply-review-findings.md
@@ -13,6 +13,21 @@ anchor. If the only reported issue is "implementation exists in the worktree but
 not the root checkout" and the source anchor/worktree passes the requirements,
 record a no-op fix summary and set `code_review.verdict=done`.
 
+Before editing or running proof commands, read `gc.build.code_review_context_path`
+from the workflow root bead and use its `## Implementation Worktrees` section as
+the authority for writable code. `gc.work_dir` is the launcher rig root, not the
+implementation worktree. Do not inspect or edit the launcher checkout. Select
+the implementation worktree for each finding from the source anchor/worktree
+recorded in the review context, run `cd "$WORKTREE"`, and verify `pwd -P` equals
+that worktree before making changes. Resolve all relative paths in synthesis
+findings against the selected worktree. If a required fix cannot be tied to an
+implementation worktree, write an iterate summary explaining the missing
+worktree evidence and do not patch the launcher root. If multiple worktrees are
+listed and a finding is ambiguous, leave it as iterate until the owning worktree
+is explicit.
+
+Contract: `gc.work_dir` is the launcher rig root, not the implementation worktree.
+
 Set `code_review.verdict=done` only when acceptance, test evidence, and
 simplicity all approve after this pass. Set `code_review.verdict=iterate` when
 required fixes remain.

--- a/gascity/assets/workflows/build-basic-review/{target}.setup-build-basic-review.md
+++ b/gascity/assets/workflows/build-basic-review/{target}.setup-build-basic-review.md
@@ -12,6 +12,37 @@ launcher rig root may remain unchanged until an explicit publish step; do not
 present an unchanged root checkout as a review failure when the source
 anchor/worktree contains the verified implementation.
 
+The review context must anchor every relative source path to the real
+implementation worktree, not the launcher checkout. Read the launcher rig root
+from the workflow root bead's `gc.work_dir`; this path is only the factory
+launcher root and is not the code under review. Resolve implementation source
+anchors from the implementation summary `trace.upstream` entries whose paths are
+`beads/<source-anchor-id>`. For each source anchor, run
+`gc bd show "<source-anchor-id>" --json`, handle both an object and a one-element
+list, and read `metadata.work_dir`. Verify every `work_dir` is an absolute
+existing git worktree and is different from the launcher root. If metadata is
+missing but `<launcher-root>/worktrees/<source-anchor-id>` exists and is a git
+worktree, record that recovered worktree and include a setup warning in the
+context. If no implementation worktree can be resolved, close this setup bead
+with `gc.outcome=fail` and record the missing source-anchor/worktree evidence.
+
+The context body must include an `## Implementation Worktrees` section before
+the artifact excerpts. For each source anchor include:
+
+- source anchor id
+- absolute implementation worktree path
+- launcher root path for contrast
+- changed files and proof commands from the item or aggregate implementation
+  summary
+
+When writing artifact excerpts, append the actual file contents with commands
+such as `cat "$REQUIREMENTS_PATH"` outside any quoted heredoc. Do not write
+literal command substitutions such as `$(cat ...)` or `$(date ...)` into the
+review context. Before closing this setup bead, verify the generated context
+does not contain literal shell substitutions, for example with
+`rg -n '\$\((cat|date)' "$CONTEXT_PATH"`; any match is a setup failure to repair
+before setting `gc.outcome=pass`.
+
 This starter factory intentionally uses only three review lanes so new users can
 see fanout/fanin without a large reviewer roster.
 

--- a/gascity/assets/workflows/build-basic-review/{target}.simplicity-review.md
+++ b/gascity/assets/workflows/build-basic-review/{target}.simplicity-review.md
@@ -5,6 +5,16 @@ unnecessary abstractions, accidental broad changes, and obvious future
 maintenance risk. Keep this lane beginner-friendly: flag only concrete issues
 that a new factory user can understand and act on.
 
+Before inspecting files, read `gc.build.code_review_context_path` from the
+workflow root bead and use its `## Implementation Worktrees` section as the
+authority for code under review. `gc.work_dir` is the launcher rig root, not the
+implementation worktree. Do not inspect or edit the launcher checkout. Resolve
+relative file paths against the listed implementation worktree, run
+`cd "$WORKTREE"`, and verify `pwd -P` equals that worktree before running any
+command.
+
+Contract: `gc.work_dir` is the launcher rig root, not the implementation worktree.
+
 Write findings under the build artifact root. Required findings must be tied to
 specific changed files or artifacts and must explain the smallest useful fix.
 

--- a/gascity/assets/workflows/build-basic-review/{target}.synthesize-review.md
+++ b/gascity/assets/workflows/build-basic-review/{target}.synthesize-review.md
@@ -4,6 +4,16 @@ Read the acceptance, test evidence, and simplicity review reports. Deduplicate
 findings, preserve the source review lane for each finding, and classify each
 item as required fix, missing evidence, or residual risk.
 
+Also read `gc.build.code_review_context_path` from the workflow root bead. When
+you carry a finding forward, include the source anchor and implementation
+worktree from the context's `## Implementation Worktrees` section. If a finding
+cites only a relative filename, resolve that filename relative to the
+implementation worktree, never the launcher checkout. Required fixes must be
+specific enough for the fix lane to act without guessing which worktree owns the
+file.
+
+Contract: `gc.work_dir` is the launcher rig root, not the implementation worktree.
+
 Write one starter review synthesis under the build artifact root. The synthesis
 must be short enough for a first-time factory user to scan, but concrete enough
 for the fix lane to act without another planning pass.
@@ -14,4 +24,3 @@ Close with `gc.outcome=pass`,
 
 Do not invoke provider-native subagents. Synthesis happens in this Gas City
 fan-in lane.
-

--- a/gascity/assets/workflows/build-basic-review/{target}.test-evidence-review.md
+++ b/gascity/assets/workflows/build-basic-review/{target}.test-evidence-review.md
@@ -5,6 +5,17 @@ command, proof command, changed files, and remaining risks. Verify that the
 commands actually cover the acceptance criteria claimed by the requirements and
 plan.
 
+Before evaluating proof, read `gc.build.code_review_context_path` from the
+workflow root bead and use its `## Implementation Worktrees` section as the
+authority for where commands must run. `gc.work_dir` is the launcher rig root,
+not the implementation worktree. Do not run evidence commands from the launcher
+checkout. Resolve relative command paths against the listed implementation
+worktree, run `cd "$WORKTREE"`, and verify `pwd -P` equals that worktree before
+executing proof commands. If the context is missing a usable implementation
+worktree, write an iterate finding against review setup.
+
+Contract: `gc.work_dir` is the launcher rig root, not the implementation worktree.
+
 Write concrete findings under the build artifact root. Distinguish missing
 proof from real product defects so the fix lane can either run the missing
 command or change code.

--- a/gascity/assets/workflows/build-basic/decompose.md
+++ b/gascity/assets/workflows/build-basic/decompose.md
@@ -55,7 +55,9 @@ work units. Do not reuse the source or launch convoy from `gc.var.convoy_id`.
 Use the convoy creation flow exactly:
 
 1. Create each work item with `gc bd create ...` and capture the returned work-item
-   bead IDs.
+   bead IDs. Do not use `gc bd create --root-bead`; `--root-bead` is not a
+   create flag. Attach the workflow root relationship with metadata such as
+   `gc.root_bead_id=<workflow-root-id>`.
 2. Create and link the implementation convoy in one command:
    `gc convoy create <name> <work-item-id...> --json`.
 3. Parse `<implementation-convoy-id>` from that JSON response, then verify the

--- a/gascity/assets/workflows/build-basic/plan-review.md
+++ b/gascity/assets/workflows/build-basic/plan-review.md
@@ -14,3 +14,8 @@ If you write a plan-readiness note, record it on the workflow root as
 `gc.build.plan_review_report_path=<path>`. Do not write or overwrite
 `gc.build.review_report_path`; that key is reserved for the later
 build-basic implementation review artifact.
+
+Before closing this step, set the claimed step outcome with
+`gc bd update "<claimed-step-id>" --set-metadata "gc.outcome=pass"`, then close
+with `gc bd close "<claimed-step-id>" --reason "<concise reason>"`. Do not pass
+`--metadata` or `--set-metadata` to `gc bd close`.

--- a/gascity/assets/workflows/do-work/close-source-anchor.md
+++ b/gascity/assets/workflows/do-work/close-source-anchor.md
@@ -5,6 +5,12 @@ summary evidence are present in that worktree. Write per-item summary to
 `gc.implementation.summary_path` from the preceding implementation step when it
 is present; otherwise use `{{artifact_root}}/task-<source-anchor-id>-summary.md`.
 
+When reading beads with `gc bd show --json`, handle both an object and a
+one-element list before reading metadata. `gc.work_dir` is the launcher rig
+root, not the implementation worktree. If the source anchor `work_dir` is
+missing, equals the launcher root, or points at a worktree without the
+implementation commit, fail this step instead of closing the source anchor.
+
 On success, close only `<source-anchor-id>` with `gc.outcome=pass`. Include the
 verified commit and summary path in the source-anchor close reason. Read the
 source anchor back with `gc bd show <source-anchor-id> --json` and verify

--- a/gascity/assets/workflows/do-work/prepare-worktree.md
+++ b/gascity/assets/workflows/do-work/prepare-worktree.md
@@ -3,11 +3,14 @@ Resolve and publish the isolated worktree for this item. This is infrastructure
 setup only. Do not edit source files in the launcher checkout.
 
 1. Read current step bead metadata and get `gc.root_bead_id`; hard-fail if it is
-   missing. Read that do-work root with `gc bd show <root-bead-id> --json`.
+   missing. Read that do-work root with `gc bd show <root-bead-id> --json`. If
+   `gc bd show --json` returns a one-element list, unwrap the first element before
+   reading metadata.
 2. Resolve `<source-anchor-id>` from the do-work root:
    - read root metadata `gc.input_convoy_id`; hard-fail if it is missing
    - verify `gc.input_convoy_id` matches rendered runtime convoy `{{convoy_id}}`
-   - read that input convoy with `gc bd show <input-convoy-id> --json`
+   - read that input convoy with `gc bd show <input-convoy-id> --json`; unwrap a
+     one-element list response before reading metadata
    - if input convoy metadata has `gc.synthetic_kind=drain-unit-convoy`, use
      input convoy metadata `gc.drain_member_id`
    - do not use the synthetic drain-unit convoy id as `<source-anchor-id>`;

--- a/gascity/assets/workflows/review/write-report.md
+++ b/gascity/assets/workflows/review/write-report.md
@@ -10,3 +10,26 @@ and reason recorded in the report. The interaction posture is
 `{{interaction_mode}}`.
 
 Artifact validation: this step is gated by `.gc/scripts/checks/build-artifact-valid.sh`, which validates the report recorded at `gc.build.review_report_path` (fallback `gc.var.report_path`) against schema `gc.build.review.v1`. On repair attempts (`gc.attempt` greater than 1), read the validator errors from `gc.attempt_log` on the validation loop control bead (the dependent of this step bead) and repair the report in place instead of rewriting it. Two bounded repair attempts follow the first failure; exhausting them closes this stage with `gc.outcome=fail` and machine-readable validation errors that block downstream stages. Never ask questions in headless mode; record unresolved ambiguity inside the report.
+
+## Required artifact location
+
+`{{report_path}}` is relative to the durable rig root, not the current
+per-bead worktree. Read the rig root from `$GC_RIG_ROOT` and write the report
+to `$GC_RIG_ROOT/{{report_path}}`; do not write it under the current directory
+or `$GC_WORK_DIR`. The inference gate reads the artifact from that durable
+location after this disposable worktree is removed.
+
+Before closing, resolve the workflow-root id from the claimed bead's
+`gc.root_bead_id`, then record the rig-relative path on that root:
+
+```bash
+gc bd update "<workflow-root-id>" \
+  --set-metadata 'gc.build.review_report_path={{report_path}}'
+```
+
+From `$GC_RIG_ROOT`, run the artifact validator with the claimed bead id. Fix
+any error before setting `gc.outcome=pass`:
+
+```bash
+GC_BEAD_ID=<claimed-step-id> .gc/scripts/checks/build-artifact-valid.sh
+```

--- a/gascity/tests/test_formula_assets.py
+++ b/gascity/tests/test_formula_assets.py
@@ -1908,6 +1908,7 @@ class FormulaAssetTests(unittest.TestCase):
             "Do not create an empty convoy",
             "Do not call `gc convoy add` for newly-created beads",
             "Do not call `gc bd show <implementation-convoy-id>`",
+            "Do not use `gc bd create --root-bead`",
         ):
             with self.subTest(step="decompose", fragment=fragment):
                 self.assertIn(fragment, decompose_description)
@@ -1970,6 +1971,9 @@ class FormulaAssetTests(unittest.TestCase):
             "not to the launcher rig root",
             "normalized `gc.build.review.v1` artifact with `status: approved`",
             "Do not invoke provider-native subagents",
+            "Implementation Worktrees",
+            "`gc.work_dir` is the launcher rig root, not the implementation worktree",
+            "Do not inspect or edit the launcher checkout",
         ):
             with self.subTest(fragment=fragment):
                 self.assertIn(fragment, asset_text)
@@ -2125,6 +2129,68 @@ class FormulaAssetTests(unittest.TestCase):
                 with self.subTest(asset=relative_path, fragment=fragment):
                     self.assertIn(fragment, text)
 
+    def test_build_basic_review_context_is_worktree_anchored(self) -> None:
+        root = pathlib.Path(__file__).resolve().parents[1]
+        workflow_dir = root / "assets" / "workflows" / "build-basic-review"
+        setup = (workflow_dir / "{target}.setup-build-basic-review.md").read_text(
+            encoding="utf-8"
+        )
+        acceptance = (workflow_dir / "{target}.acceptance-review.md").read_text(
+            encoding="utf-8"
+        )
+        test_evidence = (workflow_dir / "{target}.test-evidence-review.md").read_text(
+            encoding="utf-8"
+        )
+        simplicity = (workflow_dir / "{target}.simplicity-review.md").read_text(
+            encoding="utf-8"
+        )
+        synthesize = (workflow_dir / "{target}.synthesize-review.md").read_text(
+            encoding="utf-8"
+        )
+        apply = (workflow_dir / "{target}.apply-review-findings.md").read_text(
+            encoding="utf-8"
+        )
+
+        for fragment in (
+            "gc.build.code_review_context_path",
+            "Implementation Worktrees",
+            "metadata.work_dir",
+            "Do not write\nliteral command substitutions",
+            r"rg -n '\$\((cat|date)'",
+        ):
+            with self.subTest(asset="setup", fragment=fragment):
+                self.assertIn(fragment, setup)
+
+        for asset_name, text in (
+            ("acceptance", acceptance),
+            ("test-evidence", test_evidence),
+            ("simplicity", simplicity),
+            ("synthesize", synthesize),
+            ("apply", apply),
+        ):
+            with self.subTest(asset=asset_name, fragment="context path"):
+                self.assertIn("gc.build.code_review_context_path", text)
+            with self.subTest(asset=asset_name, fragment="worktree section"):
+                self.assertIn("Implementation Worktrees", text)
+            with self.subTest(asset=asset_name, fragment="launcher root"):
+                self.assertIn(
+                    "`gc.work_dir` is the launcher rig root, not the implementation worktree",
+                    text,
+                )
+
+        for asset_name, text in (
+            ("acceptance", acceptance),
+            ("test-evidence", test_evidence),
+            ("simplicity", simplicity),
+            ("apply", apply),
+        ):
+            with self.subTest(asset=asset_name, fragment="cd worktree"):
+                self.assertIn('cd "$WORKTREE"', text)
+            with self.subTest(asset=asset_name, fragment="pwd verification"):
+                self.assertIn("pwd -P", text)
+
+        self.assertIn("do not patch the launcher root", apply)
+        self.assertIn("source anchor and implementation\nworktree", synthesize)
     def test_build_artifact_prompts_use_set_metadata_for_paths(self) -> None:
         root = pathlib.Path(__file__).resolve().parents[1]
         path_contracts = {
@@ -3569,6 +3635,9 @@ class FormulaAssetTests(unittest.TestCase):
         for fragment in (
             "Read `work_dir` from the source anchor",
             "close only `<source-anchor-id>`",
+            "handle both an object and a",
+            "`gc.work_dir` is the launcher rig",
+            "points at a worktree without the",
             "gc bd show <source-anchor-id> --json",
             "status=closed",
             "gc.outcome=pass",

--- a/gascity/tests/test_formula_assets.py
+++ b/gascity/tests/test_formula_assets.py
@@ -4188,9 +4188,22 @@ description = "Override sink that writes the base triage report contract."
         beads_by_id: dict[str, str],
         bead_id: str,
         extra_env: dict[str, str] | None = None,
+        script_root: pathlib.Path | None = None,
     ) -> subprocess.CompletedProcess:
         root = pathlib.Path(__file__).resolve().parents[1]
         script = root / "assets" / "scripts" / "checks" / "build-artifact-valid.sh"
+
+        if script_root is not None:
+            installed_check_dir = script_root / ".gc" / "scripts" / "checks"
+            installed_check_dir.mkdir(parents=True)
+            installed_script = installed_check_dir / script.name
+            installed_script.write_text(script.read_text(encoding="utf-8"), encoding="utf-8")
+            installed_script.chmod(0o755)
+            validator = root / "assets" / "scripts" / "validate_build_artifact.py"
+            (installed_check_dir.parent / validator.name).write_text(
+                validator.read_text(encoding="utf-8"), encoding="utf-8"
+            )
+            script = installed_script
 
         with tempfile.TemporaryDirectory() as td:
             tmp = pathlib.Path(td)
@@ -4627,6 +4640,118 @@ description = "Override sink that writes the base triage report contract."
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         self.assertIn("build artifact valid", result.stdout)
 
+    def test_build_artifact_check_resolves_relative_path_from_rig_root(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = pathlib.Path(td)
+            rig_root = tmp / "rig"
+            artifact = rig_root / ".gc" / "inference-gate" / "requirements.md"
+            artifact.parent.mkdir(parents=True)
+            artifact.write_text(self._valid_requirements_artifact(), encoding="utf-8")
+            per_bead_worktree = tmp / "per-bead-worktree"
+            per_bead_worktree.mkdir()
+
+            control = (
+                '[{"id": "loop", "metadata": {'
+                '"gc.root_bead_id": "root", '
+                '"gc.build.artifact_schema": "gc.build.requirements.v1", '
+                '"gc.build.artifact_path_keys": "gc.build.requirements_path"}}]'
+            )
+            root_bead = (
+                '[{"id": "root", "metadata": {'
+                '"gc.build.requirements_path": ".gc/inference-gate/requirements.md"'
+                '}}]'
+            )
+            result = self._run_build_artifact_check(
+                {"loop": control, "root": root_bead},
+                "loop",
+                extra_env={
+                    "GC_RIG_ROOT": str(rig_root),
+                    "GC_WORK_DIR": str(per_bead_worktree),
+                },
+            )
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn(str(artifact), result.stdout)
+
+    def test_build_artifact_check_uses_beads_scope_root_when_rig_root_is_unset(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = pathlib.Path(td)
+            rig_root = tmp / "rig"
+            artifact = rig_root / ".gc" / "inference-gate" / "requirements.md"
+            artifact.parent.mkdir(parents=True)
+            artifact.write_text(self._valid_requirements_artifact(), encoding="utf-8")
+            per_bead_worktree = tmp / "per-bead-worktree"
+            per_bead_worktree.mkdir()
+
+            control = (
+                '[{"id": "loop", "metadata": {'
+                '"gc.root_bead_id": "root", '
+                '"gc.build.artifact_schema": "gc.build.requirements.v1", '
+                '"gc.build.artifact_path_keys": "gc.build.requirements_path"}}]'
+            )
+            root_bead = (
+                '[{"id": "root", "metadata": {'
+                '"gc.build.requirements_path": ".gc/inference-gate/requirements.md"'
+                '}}]'
+            )
+            result = self._run_build_artifact_check(
+                {"loop": control, "root": root_bead},
+                "loop",
+                extra_env={
+                    "GC_RIG_ROOT": "",
+                    "GC_BEADS_SCOPE_ROOT": str(rig_root),
+                    "GC_WORK_DIR": str(per_bead_worktree),
+                },
+            )
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn(str(artifact), result.stdout)
+
+    def test_build_artifact_check_derives_rig_root_from_installed_script_when_env_is_unset(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = pathlib.Path(td)
+            rig_root = tmp / "rig"
+            artifact = rig_root / ".gc" / "inference-gate" / "requirements.md"
+            artifact.parent.mkdir(parents=True)
+            artifact.write_text(self._valid_requirements_artifact(), encoding="utf-8")
+            per_bead_worktree = tmp / "per-bead-worktree"
+            per_bead_worktree.mkdir()
+            source_root = pathlib.Path(__file__).resolve().parents[1]
+            validator = source_root / "assets" / "scripts" / "validate_build_artifact.py"
+            worktree_validator = per_bead_worktree / "gascity" / "assets" / "scripts" / validator.name
+            worktree_validator.parent.mkdir(parents=True)
+            worktree_validator.write_text(validator.read_text(encoding="utf-8"), encoding="utf-8")
+            for schema in (source_root / "schemas" / "build").glob("*.yaml"):
+                destination = per_bead_worktree / "gascity" / "schemas" / "build" / schema.name
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                destination.write_text(schema.read_text(encoding="utf-8"), encoding="utf-8")
+
+            control = (
+                '[{"id": "loop", "metadata": {'
+                '"gc.root_bead_id": "root", '
+                '"gc.build.artifact_schema": "gc.build.requirements.v1", '
+                '"gc.build.artifact_path_keys": "gc.build.requirements_path"}}]'
+            )
+            root_bead = (
+                '[{"id": "root", "metadata": {'
+                '"gc.build.requirements_path": ".gc/inference-gate/requirements.md"'
+                '}}]'
+            )
+            result = self._run_build_artifact_check(
+                {"loop": control, "root": root_bead},
+                "loop",
+                extra_env={
+                    "GC_RIG_ROOT": "",
+                    "GC_BEADS_SCOPE_ROOT": "",
+                    "GC_DIR": "",
+                    "GC_WORK_DIR": str(per_bead_worktree),
+                },
+                script_root=rig_root,
+            )
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn(str(artifact), result.stdout)
+
     def test_build_artifact_check_blocks_invalid_artifact_with_repair_context(self) -> None:
         with tempfile.TemporaryDirectory() as artifact_dir:
             artifact = pathlib.Path(artifact_dir) / "requirements.md"
@@ -4668,6 +4793,21 @@ description = "Override sink that writes the base triage report contract."
         self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
         self.assertIn("no artifact path recorded", result.stderr)
         self.assertIn("gc.build.requirements_path,gc.var.requirements_path", result.stderr)
+
+    def test_review_report_prompt_writes_to_the_rig_root(self) -> None:
+        root = pathlib.Path(__file__).resolve().parents[1]
+        prompt = (root / "assets" / "workflows" / "review" / "write-report.md").read_text(
+            encoding="utf-8"
+        )
+
+        for fragment in (
+            "GC_RIG_ROOT",
+            "per-bead worktree",
+            "gc.build.review_report_path={{report_path}}",
+            "or `$GC_WORK_DIR`",
+        ):
+            with self.subTest(fragment=fragment):
+                self.assertIn(fragment, prompt)
 
     def test_bmad_story_development_emits_base_check_verdict(self) -> None:
         gascity_root = pathlib.Path(__file__).resolve().parents[1]
@@ -5109,6 +5249,9 @@ description = "Override sink that writes the base triage report contract."
         self.assertIn("gc.build.code_review_report_path", setup)
         self.assertIn("gc.build.gap_analysis_report_path", setup)
         self.assertIn("gc.build.review_fix_summary_path", setup)
+        self.assertIn("implementation_convoy_id: not provided", setup)
+        self.assertIn("Do not invent an external convoy", setup)
+        self.assertIn("per-bead worktree", setup)
 
         self.assertIn("code_review.review_verdict", request)
         self.assertIn("code_review.review_report_path", request)
@@ -5135,12 +5278,28 @@ description = "Override sink that writes the base triage report contract."
         self.assertNotIn("code_review.verdict=done", gap)
         self.assertNotIn("code_review.report_path=<", gap)
 
+        for reviewer_name, reviewer in (("request", request), ("gap", gap)):
+            with self.subTest(reviewer=reviewer_name):
+                self.assertIn("Initial-review baseline", reviewer)
+                self.assertIn("highest numeric `gc.attempt`", reviewer)
+                self.assertIn("gc.build.review_fix_summary_path", reviewer)
+                self.assertIn("fixed implementation worktree", reviewer)
+                self.assertIn("must not issue an `iterate` verdict merely", reviewer)
+
+        self.assertIn("may be intentionally absent", gap)
+        self.assertIn("must not by itself cause `iterate`", gap)
+        self.assertIn("implementation_convoy_id: not provided", gap)
+
         self.assertIn("code_review.verdict=done|iterate", process)
         self.assertIn("code_review.report_path=<review fix summary path>", process)
         self.assertIn("Use `covered` for resolved\nfindings", process)
         self.assertIn("Include `rationale: <why this id is not covered>`", process)
         self.assertIn("gc.build.code_review_status=approved", process)
         self.assertIn("gc.build.code_review_status=draft", process)
+        self.assertIn("non-blocking for this standalone review", process)
+        self.assertIn("implementation_convoy_id: not provided", process)
+        self.assertIn("must not self-approve its own remediation", process)
+        self.assertIn("next attempt must independently re-review", process)
 
         self.assertIn("gc.build.code_review_status=approved", finalize)
         self.assertIn("gc.build.code_review_approved_at", finalize)

--- a/gascity/tests/test_formula_assets.py
+++ b/gascity/tests/test_formula_assets.py
@@ -2928,6 +2928,30 @@ class FormulaAssetTests(unittest.TestCase):
                     all(group == "superpowers-task-{{issue}}" for group in continuation_groups)
                 )
 
+    def test_superpowers_finalizer_materializes_canonical_build_summary(self) -> None:
+        packs_root = pathlib.Path(__file__).resolve().parents[2]
+        pack_root = packs_root / "superpowers"
+        build = load_formula(pack_root, "superpowers-build")
+        finalize_step = {step["id"]: step for step in build["steps"]}["finalize"]
+        finalize = (
+            pack_root / "assets" / "workflows" / "superpowers-build" / "finalize.md"
+        ).read_text(encoding="utf-8")
+
+        self.assertEqual(finalize_step["metadata"]["gc.run_target"], "superpowers.finisher")
+        for fragment in (
+            "materialize the canonical",
+            "gc.build.implementation_summary_path",
+            "implementation-summary.md",
+            "{{artifact_root}}",
+            "gc.build.implementation-summary.v1",
+            "gc.implementation.summary_path",
+            "source anchors",
+            "gc bd update",
+            "Do not create the final report",
+        ):
+            with self.subTest(fragment=fragment):
+                self.assertIn(fragment, finalize)
+
     def test_superpowers_development_converts_subagent_reviews_to_fanout(self) -> None:
         packs_root = pathlib.Path(__file__).resolve().parents[2]
         pack_root = packs_root / "superpowers"

--- a/superpowers/assets/workflows/superpowers-build/finalize.md
+++ b/superpowers/assets/workflows/superpowers-build/finalize.md
@@ -1,6 +1,40 @@
 Use the assigned Superpowers branch-finalization skill materialized for this agent.
 
-Before closing, confirm the final artifact paths, test evidence, and publish readiness. Record the build-base finalize outcome on the workflow root bead.
+Before writing the final report or closing this lane, materialize the canonical
+implementation summary in the build artifact root. The workflow root must record
+an absolute, existing path as
+`gc.build.implementation_summary_path`, normally
+`{{artifact_root}}/implementation-summary.md`. A per-item summary inside an
+implementation worktree is not sufficient because that worktree is disposable.
+
+Read the closed implementation source anchors and their recorded per-item
+`gc.implementation.summary_path` values. If the root already points to a valid
+`gc.build.implementation-summary.v1` artifact at the canonical path, preserve
+it. Otherwise synthesize `implementation-summary.md` from those source anchors,
+their summary paths, commits, changed files, verification evidence, and
+remaining risks. The result must be Markdown with YAML front matter, use mapping
+objects for `workflow`, `methodology`, `producer`, and `trace`, and declare:
+
+- `schema: gc.build.implementation-summary.v1`
+- the running Superpowers build workflow id and `formula: superpowers-build`
+- `methodology: {pack: superpowers, name: superpowers-build}`
+- a non-empty `trace.upstream` and matching `trace.coverage`
+
+Its body must contain the exact `##` headings `Summary`, `Intended Behavior`,
+`Changed Files`, `Verification`, and `Remaining Risks`, plus a Markdown coverage
+table with `ID` and `Status` columns. Record the canonical absolute path before
+writing the final report:
+
+```sh
+gc bd update "<workflow-root-id>" \
+  --set-metadata "gc.build.implementation_summary_path=<absolute path>"
+```
+
+Do not create the final report or set `gc.outcome=pass` until the canonical
+implementation summary exists and validates as
+`gc.build.implementation-summary.v1`. Then confirm the final artifact paths,
+test evidence, review state, residual risks, and publish readiness. Record the
+build-base finalize outcome on the workflow root bead.
 
 Do not invoke provider-native subagents or upstream plugin runtime commands.
 

--- a/superpowers/assets/workflows/superpowers-code-review/{target}.gap-analysis-review.md
+++ b/superpowers/assets/workflows/superpowers-code-review/{target}.gap-analysis-review.md
@@ -8,6 +8,37 @@ the plan, and test claims that were not proven by commands or artifacts.
 Write concrete findings that the feedback-processing lane can resolve in one
 pass with file, artifact, command, or requirement references.
 
+## Retry-aware evidence
+
+The subject diff and implementation summary describe the **Initial-review
+baseline**. They preserve the original change for traceability, so they may
+continue to show a defect after a repair pass. Before issuing a verdict, inspect
+the current attempt and its repair evidence:
+
+1. List closed lanes for this workflow root with `gc.step_id=write-report.process-code-review`, then select the highest numeric `gc.attempt` that is lower than this lane's attempt.
+2. If that prior process lane has `code_review.verdict=iterate`, read the
+   review-fix summary at workflow-root metadata
+   `gc.build.review_fix_summary_path`.
+3. Verify the claimed resolution against the fixed implementation worktree or
+   commit recorded in that summary, including its relevant test evidence.
+
+The static initial subject alone is not evidence that a finding remains open.
+On a retry, you must not issue an `iterate` verdict merely because the
+Initial-review baseline still contains the original vulnerable code. Return
+`iterate` only for a finding that remains in the fixed implementation or whose
+claimed resolution cannot be verified.
+
+## Standalone-review scope
+
+This review workflow may be invoked directly against a diff rather than from a
+full build workflow. In that case the requirements, plan, and decomposition
+paths may be intentionally absent. Apply this rule only when the context says
+`implementation_convoy_id: not provided` as well as marking the three upstream
+paths not provided. Their absence must not by itself cause `iterate`: record it
+as unavailable context, not as a required implementation finding. When a
+convoy or any upstream input is declared, return `iterate` for a missing
+required artifact or evidence of a concrete failure or mismatch.
+
 Read the code-review context from workflow root metadata
 `gc.build.code_review_context_path`. Write the gap-analysis report to workflow
 root metadata path `gc.build.gap_analysis_report_path`, which should be

--- a/superpowers/assets/workflows/superpowers-code-review/{target}.process-code-review.md
+++ b/superpowers/assets/workflows/superpowers-code-review/{target}.process-code-review.md
@@ -28,9 +28,23 @@ only; the rationale belongs in YAML front matter.
 
 If both review lanes approve, perform a no-op pass, update workflow root
 metadata with `gc.build.code_review_status=approved`, and close with
-`code_review.verdict=done`. If required fixes remain after processing, update
+`code_review.verdict=done`.
+
+If either review lane returns `iterate`, process its required findings and
+write the repair evidence. Even when the repair and focused tests pass, update
 workflow root metadata with `gc.build.code_review_status=draft` and close with
-`code_review.verdict=iterate`.
+`code_review.verdict=iterate`: the next attempt must independently re-review
+the repaired implementation. This lane must not self-approve its own remediation.
+Only a later attempt whose reviewer lanes both approve may close
+with `code_review.verdict=done`.
+
+An independently invoked review may have no requirements, plan, or
+decomposition artifact. When the review context marks those inputs as not
+provided and says `implementation_convoy_id: not provided`, record the absence
+in the fix summary as non-blocking for this standalone review; it does not make
+a required code finding remain open. Set `iterate` only for unresolved findings
+in the reviewed implementation, a required artifact that is missing or invalid,
+or a claimed resolution that cannot be verified.
 
 Always close with `gc.outcome=pass`, `code_review.verdict=done|iterate`,
 `code_review.report_path=<review fix summary path>`, and

--- a/superpowers/assets/workflows/superpowers-code-review/{target}.request-code-review.md
+++ b/superpowers/assets/workflows/superpowers-code-review/{target}.request-code-review.md
@@ -5,6 +5,26 @@ test evidence. Write an implementation-review report with pass/fail verdict and
 actionable findings. Required fixes must be specific enough for the processing
 step to resolve them directly.
 
+## Retry-aware evidence
+
+The subject diff and implementation summary describe the **Initial-review
+baseline**. They preserve the original change for traceability, so they may
+continue to show a defect after a repair pass. Before issuing a verdict, inspect
+the current attempt and its repair evidence:
+
+1. List closed lanes for this workflow root with `gc.step_id=write-report.process-code-review`, then select the highest numeric `gc.attempt` that is lower than this lane's attempt.
+2. If that prior process lane has `code_review.verdict=iterate`, read the
+   review-fix summary at workflow-root metadata
+   `gc.build.review_fix_summary_path`.
+3. Verify the claimed resolution against the fixed implementation worktree or
+   commit recorded in that summary, including its relevant test evidence.
+
+The static initial subject alone is not evidence that a finding remains open.
+On a retry, you must not issue an `iterate` verdict merely because the
+Initial-review baseline still contains the original vulnerable code. Return
+`iterate` only for a finding that remains in the fixed implementation or whose
+claimed resolution cannot be verified.
+
 Read the code-review context from workflow root metadata
 `gc.build.code_review_context_path`. Write the implementation review report to
 workflow root metadata path `gc.build.code_review_report_path`, which should be

--- a/superpowers/assets/workflows/superpowers-code-review/{target}.setup-superpowers-code-review.md
+++ b/superpowers/assets/workflows/superpowers-code-review/{target}.setup-superpowers-code-review.md
@@ -9,11 +9,24 @@ the completed drain manifest. Use these exact handoff paths:
 - gap-analysis report: `<artifact_root>/gap-analysis-report.md`
 - review fix summary: `<artifact_root>/review-fix-summary.md`
 
+`<artifact_root>` is relative to the rig repository root. Create and write
+these files there, and record the same rig-relative paths in root metadata. Do
+not use a per-bead worktree as the artifact root: that worktree is disposable
+and inaccessible to later review and finalization lanes.
+
 Write the compact context file to the code-review context path. The context
 file must include the workflow root id, source bead id, implementation convoy
 id, implemented member bead ids, task summary paths, commit hashes, changed
 files, requirements path, plan path, decomposition path, and the exact report
 paths above.
+
+For a direct, standalone review (no implementation convoy, drain manifest,
+requirements, plan, or decomposition is available), write the literal context
+field `implementation_convoy_id: not provided` and mark each unavailable
+upstream path `not provided`. Do not invent an external convoy or infer a full
+build workflow from the review subject alone. Those markers distinguish
+standalone review scope from a build-derived review whose required artifacts are
+missing.
 
 Update workflow root metadata before closing:
 


### PR DESCRIPTION
Reconciles two months of uncommitted working-tree drift in the fleet's live pack source (bead ga-2pej2). The live checkout had been carrying ~4 uncommitted edit waves (69 modified + 13 untracked files) over a branch 155 commits behind main — including a June-14 wave that silently regressed every role prompt to the pre-CLAIM_JSON hook protocol with the in-tool-call claim poll loop (the aggravator behind this week's claim-orphaning incidents, ga-fylee/ga-4qdfn).

Method: verbatim rescue snapshot (`rescue/worktree-20260814`, pushed) → three-agent wave-by-wave triage vs the old HEAD (28 DROP / 50 KEEP, diff-evidenced) → three-way re-validation of every keep against main → this branch, from `origin/main`:

- `68ff798` — superpowers build summary artifact requirement (novel vs main; note: main's `summarize-implementation` step is the structural answer to the same problem — this prose is idempotent alongside it, reviewers may drop it)
- `5443a07` — June asset guards: build-basic-review lanes anchored to the implementation worktree, outcome-close footers, one-element-list guards
- `0ebccbb` — the discord multibot slice: restores origin-pushed `feat/discord-multibot-bridge` content (committed-but-unmerged work found live in the tree), tests taken at the tip the scripts shipped with (`4e0b3d2`)
- `e537461` — July artifact gates: rig-root artifact resolution, retry-aware review evidence, no-self-approval rule

Dropped: the 20-file protocol regression (never committed anywhere; HEAD was always correct), 11 conflict paths where main evolved the same code further (incl. the initial-review adapter contract — reasons on ga-2pej2), runtime residue dirs. One salvageable follow-up flagged: the authoritative-lane selection block from the skipped `{target}.md` region.

Gates: full pack suite green per-commit (1249 passed + 9462 subtests; registry, gc lint ×7, role-prompt integration, shell suites, go/slack/runtime-cloudflare).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
