### PR TITLE
fix(gastown/worktree): sync against origin/<branch> explicitly, not implicit tracking

### DIFF
--- a/gastown/assets/scripts/worktree-setup.sh
+++ b/gastown/assets/scripts/worktree-setup.sh
@@ -43,8 +43,20 @@ sync_worktree() {
     if ! git -C "$WT" remote get-url origin >/dev/null 2>&1; then
         return 0
     fi
-    git -C "$WT" fetch origin 2>/dev/null || true
-    git -C "$WT" pull --rebase 2>/dev/null || true
+    # Fetch and rebase against the origin branch of the SAME name explicitly,
+    # rather than relying on `git pull --rebase`'s implicit upstream
+    # (`branch.<name>.remote`/`.merge`). A worktree branch created via the
+    # no-start-point fallback below (no `origin/HEAD` at creation time) never
+    # gets that tracking config, so the implicit form fails with "no tracking
+    # information for the current branch" -- silently, since both git calls
+    # here are best-effort. That failure is permanent: nothing later sets the
+    # missing tracking config, so every subsequent --sync repeats it forever.
+    # Naming the branch explicitly sidesteps the missing config entirely, and
+    # is a no-op (as before) when origin has no branch of this name yet.
+    CUR_BRANCH=$(git -C "$WT" symbolic-ref --short HEAD 2>/dev/null || true)
+    [ -n "$CUR_BRANCH" ] || return 0
+    git -C "$WT" fetch origin "$CUR_BRANCH" 2>/dev/null || return 0
+    git -C "$WT" pull --rebase origin "$CUR_BRANCH" 2>/dev/null || true
 }
 
 branch_name() {

--- a/gastown/tests/test_worktree_setup_sync.sh
+++ b/gastown/tests/test_worktree_setup_sync.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+SCRIPT="$ROOT/gastown/assets/scripts/worktree-setup.sh"
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+git_c() {
+    git -c user.email=a@a.com -c user.name=a "$@"
+}
+
+# new_upstream_and_rig — a bare "upstream" repo plus a rig clone of it, with
+# one commit on main and origin/HEAD already configured (the common case:
+# the rig was cloned from an origin that already existed).
+new_upstream_and_rig() {
+    local base="$1"
+    git_c init -q --bare "$base/upstream.git"
+    git_c init -q -b main "$base/seed"
+    (cd "$base/seed" && git_c commit -q --allow-empty -m init \
+        && git_c remote add origin "$base/upstream.git" \
+        && git_c push -q origin main)
+    git_c clone -q "$base/upstream.git" "$base/rig"
+}
+
+test_sync_pulls_when_branch_lacks_origin_tracking() {
+    local base="$1"
+    local rig="$base/rig" wt="$base/wt-notrack"
+
+    # Reproduce #299's precondition directly: a worktree branch created by
+    # the no-start-point fallback (the path taken when origin/HEAD isn't
+    # configured at creation time -- e.g. a rig set up locally and given a
+    # remote afterwards) has no branch.<name>.remote/.merge config at all.
+    git_c -C "$rig" worktree add -q "$wt" -b notrack
+    if git_c -C "$wt" rev-parse --abbrev-ref --symbolic-full-name '@{u}' >/dev/null 2>&1; then
+        fail "test setup bug: notrack must have no upstream tracking configured"
+    fi
+
+    # The branch WAS pushed at some point (e.g. by a prior refinery run), and
+    # origin has since moved ahead of it -- the exact "we hit this in
+    # production" scenario from the issue.
+    git_c -C "$wt" push -q origin notrack
+    (cd "$base" && git_c clone -q "$base/upstream.git" advance \
+        && cd advance && git_c checkout -q notrack \
+        && git_c commit -q --allow-empty -m "advanced upstream" \
+        && git_c push -q origin notrack)
+    local advanced_sha
+    advanced_sha=$(git_c -C "$base/advance" rev-parse notrack)
+
+    sh "$SCRIPT" "$rig" "$wt" notrack --sync
+
+    local wt_sha
+    wt_sha=$(git_c -C "$wt" rev-parse HEAD)
+    [ "$wt_sha" = "$advanced_sha" ] ||
+        fail "sync should have pulled the advanced commit despite missing tracking config; want $advanced_sha got $wt_sha"
+}
+
+test_sync_is_noop_without_origin_counterpart() {
+    local base="$1"
+    local rig="$base/rig" wt="$base/wt-unpushed"
+
+    git_c -C "$rig" worktree add -q "$wt" -b unpushed
+    local before_sha
+    before_sha=$(git_c -C "$wt" rev-parse HEAD)
+
+    # Never pushed to origin -- nothing to sync. Must not error and must
+    # leave the worktree exactly where it was.
+    sh "$SCRIPT" "$rig" "$wt" unpushed --sync
+
+    local after_sha
+    after_sha=$(git_c -C "$wt" rev-parse HEAD)
+    [ "$after_sha" = "$before_sha" ] ||
+        fail "an unpushed branch with no origin counterpart must be left untouched, got $before_sha -> $after_sha"
+}
+
+test_sync_still_works_with_configured_tracking() {
+    local base="$1"
+    local rig="$base/rig" wt="$base/wt-tracked"
+
+    # The already-working case: a branch created from an explicit
+    # origin-tracking start point (the DEFAULT_REF path this script's own
+    # creation logic normally takes) gets real tracking config for free.
+    # The explicit fetch/pull-by-name form must keep working for it too.
+    git_c -C "$rig" worktree add -q "$wt" -b tracked refs/remotes/origin/main
+    if ! git_c -C "$wt" rev-parse --abbrev-ref --symbolic-full-name '@{u}' >/dev/null 2>&1; then
+        fail "test setup bug: tracked must have upstream tracking configured"
+    fi
+
+    git_c -C "$wt" push -q origin tracked
+    (cd "$base" && git_c clone -q "$base/upstream.git" advance2 \
+        && cd advance2 && git_c checkout -q tracked \
+        && git_c commit -q --allow-empty -m "advanced tracked" \
+        && git_c push -q origin tracked)
+    local advanced_sha
+    advanced_sha=$(git_c -C "$base/advance2" rev-parse tracked)
+
+    sh "$SCRIPT" "$rig" "$wt" tracked --sync
+
+    local wt_sha
+    wt_sha=$(git_c -C "$wt" rev-parse HEAD)
+    [ "$wt_sha" = "$advanced_sha" ] ||
+        fail "sync should still pull for a normally-tracked branch; want $advanced_sha got $wt_sha"
+}
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+new_upstream_and_rig "$tmp"
+
+test_sync_pulls_when_branch_lacks_origin_tracking "$tmp"
+test_sync_is_noop_without_origin_counterpart "$tmp"
+test_sync_still_works_with_configured_tracking "$tmp"
+
+echo "worktree-setup sync tests passed"


### PR DESCRIPTION
Fixes #299.

`sync_worktree()` ran `git pull --rebase` with no refspec, which
resolves its target via the current branch's
`branch.<name>.remote`/`.merge` config ("upstream tracking"). A worktree
branch created via this script's own no-start-point fallback — taken
whenever `origin/HEAD` isn't configured at creation time, which covers
any rig set up locally and given a remote afterwards — never gets that
config, because `git worktree add -b <branch>` with no explicit start
point doesn't set up tracking. `git pull --rebase` then fails with "no
tracking information for the current branch" on every single `--sync`
call, forever. Both the `fetch` and the `pull` are `2>/dev/null || true`,
so the failure is completely invisible — no log, no bead, no doctor
check reports it. The worktree just freezes at whatever commit it was
created at.

Reproduced the actual git behavior directly in a throwaway repo before
touching any code: `git worktree add -b <branch> refs/remotes/origin/HEAD`
(the normal creation path) does set up tracking, but
`git worktree add -b <branch>` with no start point (the fallback path)
does not.

## Fix

`sync_worktree` now fetches and rebases against the origin branch of the
*same name* explicitly (`git fetch origin "$CUR_BRANCH"` / `git pull
--rebase origin "$CUR_BRANCH"`), reading the branch name directly off
the worktree's own `HEAD` instead of depending on tracking config to
resolve it implicitly. This sidesteps the missing-config problem
entirely rather than patching the config after the fact, and preserves
existing best-effort semantics: no origin counterpart yet is still a
clean no-op, and the already-working tracked-branch case still syncs
correctly.

## Tests

No existing test covered `worktree-setup.sh`'s sync path at all, so this
adds a new file: `gastown/tests/test_worktree_setup_sync.sh`, three
subtests:

- `test_sync_pulls_when_branch_lacks_origin_tracking` — reproduces
  #299's exact production scenario (no-start-point branch, pushed once,
  origin advances) — RED against the unfixed script (confirmed via
  `git stash`), GREEN after.
- `test_sync_is_noop_without_origin_counterpart` — an unpushed branch
  with nothing to sync stays untouched and error-free.
- `test_sync_still_works_with_configured_tracking` — the normal
  already-working tracked case keeps syncing correctly (no regression).

Full `gastown/tests/test_*.sh` suite passes (two unrelated local-only
failures — missing `tomllib` on default `python3`, macOS `date` lacking
GNU's `-d` — are pre-existing environment gaps already documented by the
suite itself, not regressions from this change).

Generated with [Claude Code](https://claude.com/claude-code)
