### PR TITLE
docs(do-work): resolve default branch locally first, network only as fallback

### DIFF
--- a/gascity/assets/workflows/do-work/prepare-worktree.md
+++ b/gascity/assets/workflows/do-work/prepare-worktree.md
@@ -24,9 +24,15 @@ setup only. Do not edit source files in the launcher checkout.
    `$(pwd)/worktrees/<source-anchor-id>`, based on the up-to-date remote
    default branch — never the launcher's local `HEAD`, which may be behind
    `origin`. If the path is missing:
-   - Resolve the remote default branch (do not hardcode `main`):
+   - Resolve the remote default branch (do not hardcode `main`), reading the
+     local `origin/HEAD` symref first so a normal prepare does not pay a
+     network round trip on every item:
+     `DEFAULT_BRANCH=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||')`.
+     If that is empty (no local record of the remote's default branch —
+     e.g. a repo whose `origin` was added after local setup rather than via
+     `git clone`), fall back to the network form:
      `DEFAULT_BRANCH=$(git remote show origin 2>/dev/null | sed -n 's/.*HEAD branch: //p')`.
-     If it is empty, fail closed — do not fall back to local `HEAD`.
+     If both are empty, fail closed — do not fall back to local `HEAD`.
    - Fetch it so the base is current:
      `git fetch --prune origin "$DEFAULT_BRANCH"`.
    - Create the worktree detached at the freshly fetched tip:


### PR DESCRIPTION
Fixes #305. Follow-up to #228.

`do-work`'s `prepare-worktree.md` step resolves the remote default
branch with `git remote show origin`, which contacts the remote. Every
worktree prepare pays that network round trip, and it pairs badly with
the fail-closed guard right after it: a transient network failure now
refuses dispatch entirely instead of degrading, since the network call
was the only path to a result.

## Fix

Reads `refs/remotes/origin/HEAD` locally first
(`git symbolic-ref --short refs/remotes/origin/HEAD`, strip the
`origin/` prefix) — that symref is written by a normal `git clone` and
kept current by `git remote set-head origin -a`, so the common case now
resolves at zero network cost.

On the reporter's own flagged caveat (worth confirming whether any
consumer clones with a configuration that leaves
`refs/remotes/origin/HEAD` unset): rather than assume every consumer
clones normally, kept the original network-based command as an explicit
fallback when the local read comes back empty. That's the exact same
"rig set up locally, remote added afterward" scenario `#299` reproduced
this session for a different script, so this doesn't guess it away.
Behavior is strictly a superset of the old command now: free and
identical whenever `origin/HEAD` is set (the common case), unchanged
from before when it isn't. The existing "if it is empty, fail closed"
guard is untouched and now only triggers when both reads fail.

## Verification

No test parses this workflow doc's prose. Directly reproduced: confirmed
the new local-read command produces byte-identical output to the old
network-based command against a normal clone, and confirmed it correctly
returns empty (triggering the fallback) when `origin/HEAD` is unset.
Full `gastown/tests/test_*.sh` suite passes clean.

Generated with [Claude Code](https://claude.com/claude-code)
