### PR TITLE
docs(gastown/crew): fix HQ bead-filing command to gc bd create --rig hq

### DIFF
--- a/gastown/assets/prompts/crew.template.md
+++ b/gastown/assets/prompts/crew.template.md
@@ -119,7 +119,7 @@ go here by default. But if you discover bugs/issues in OTHER projects:
 | This rig's code ({{ .RigName }}) | Here (default) | `gc bd create "..."` |
 | Beads CLI (beads tool) | **beads** | `gc bd create --rig beads "..."` |
 | `gc` CLI (gas city tool) | **gastown** | `gc bd create --rig gastown "..."` |
-| Cross-rig coordination | **HQ** | `gc bd create --prefix hq- "..."` |
+| Cross-rig coordination | **HQ** | `gc bd create --rig hq "..."` |
 
 **The test**: "Which repo would the fix be committed to?"
 


### PR DESCRIPTION
Fixes #308.

`crew.template.md`'s "Where to File Beads" table tells the crew agent to
file cross-rig coordination beads with `gc bd create --prefix hq- "..."`.
`bd` has no `--prefix` flag; confirmed directly with
`bd create --prefix hq- "t"` -> `Error: unknown flag: --prefix`. `gc bd`'s
own scope-flag extractor only recognizes `--city`/`--rig`, nothing else
passthrough-relevant.

The reporter deliberately didn't send a fix — two readings ("the HQ
rig's store" vs. "the bead ID prefix, needs a rewritten row entirely")
produce different commands, and didn't want to guess wrong in an
agent-executed file.

## Resolving the ambiguity

The table itself resolves it: every other row (`beads`, `gastown`) names
a real target rig in "File in" and reaches it with `gc bd create --rig
<name> "..."`. The HQ row's "File in" column already says **HQ** — a rig
name, same shape as the other two rows — so `--prefix hq-` reads as a
mis-recalled flag for what the sibling rows already express correctly
with `--rig`, not a deliberately different mechanism. Fixed to
`gc bd create --rig hq "..."`, matching the table's own established
pattern exactly (including flag placement, to stay internally consistent
with the other three rows).

## Verification

No test parses prose content in this template. Verified by: reproducing
the reported `bd create --prefix` failure directly, reading `gc bd`'s
actual flag-extraction code to confirm `--rig` is the real working flag,
and re-running the full `gastown/tests/test_*.sh` suite to confirm
nothing golden-file-asserts the old text.

Generated with [Claude Code](https://claude.com/claude-code)
