### PR TITLE
fix(gastown/witness): re-verify liveness before delete, content-check merges past rebase/squash

### DIFF
--- a/gastown/formulas/mol-witness-patrol.toml
+++ b/gastown/formulas/mol-witness-patrol.toml
@@ -213,7 +213,13 @@ a NEW session with a different ID — the old one never comes back.
    SESSION_COUNT=$(jq -r '(.sessions // []) | length' "$SESSIONS_FILE")
    MAP_COUNT=$(printf '%s' "$LIVENESS_MAP" | jq -r 'length')
    rm -f "$SESSIONS_FILE" "$SESSION_BEADS_FILE"
+   MAP_BUILT_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
    ```
+
+   `MAP_BUILT_AT` is this snapshot's timestamp — every bead the per-bead
+   loop below reaches was read from the store *after* this instant, but
+   its own `updated_at` may be newer still if something touched it mid-cycle.
+   Step 3b uses this to catch that case before it destroys anything.
 
    **Fail safe — never orphan on an empty map.** If the map is empty while
    sessions exist, the schema has drifted again (the exact failure in
@@ -323,14 +329,44 @@ starts fresh.
 **Step 3: Verify work on main before resetting.**
 
 Before resetting the bead to pool, check if the branch was already merged
-to main (polecat finished, pushed, but crashed before closing the bead):
+to main (polecat finished, pushed, but crashed before closing the bead).
+
+**Ancestry alone is not enough.** `git merge-base --is-ancestor` only holds
+when the branch's own commit objects are literally reachable from main —
+true for a plain fast-forward or a real merge commit. It false-negatives
+whenever the refinery lands the branch by *recreating* its commits
+(rebase-then-fast-forward onto a main that has moved since the branch was
+cut, or a squash) — main then carries a new commit with a different SHA
+that contains exactly the branch's changes, and ancestry can never see
+that. This is the normal case, not an edge case: any queue with 2+ beads
+produces it as soon as a second bead lands after the first was rebased.
+A false negative here re-dispatches already-merged work.
+
 ```bash
-git log main --oneline | grep -q "$BRANCH"
-# Or check if branch commits are reachable from main:
-git merge-base --is-ancestor origin/$BRANCH origin/main
+# Cheap first pass — catches the plain fast-forward/merge-commit case:
+if git merge-base --is-ancestor origin/$BRANCH origin/main; then
+  ON_MAIN=true
+else
+  # Rebase/squash recreates commits, so a "not an ancestor" result does
+  # NOT mean "not merged" -- fall back to a content test, scoped to the
+  # branch's own changed files, which holds regardless of how it landed.
+  MERGE_BASE=$(git merge-base origin/$BRANCH origin/main 2>/dev/null || true)
+  if [ -z "$MERGE_BASE" ]; then
+    ON_MAIN=false   # no shared history found; treat conservatively as not-yet-merged
+  else
+    CHANGED_FILES=$(git diff --name-only "$MERGE_BASE" origin/$BRANCH)
+    if [ -z "$CHANGED_FILES" ]; then
+      ON_MAIN=false   # branch introduced nothing beyond the merge-base; nothing to confirm
+    elif git diff --quiet origin/main origin/$BRANCH -- $CHANGED_FILES; then
+      ON_MAIN=true    # main's current content for exactly these files matches the branch
+    else
+      ON_MAIN=false
+    fi
+  fi
+fi
 ```
 
-If the work is already on main:
+If the work is already on main (`ON_MAIN=true`):
 - **Close the bead** (work is done, don't re-dispatch). Use `--force`: the bead
   is still assigned to the crashed polecat, so this is a cross-actor close and
   bd's close-authority guard (gastownhall/beads#3734) would otherwise refuse it:
@@ -434,9 +470,43 @@ Step 3b: the crash landed earlier than step 5, the bead was deliberately left
 branch-ready by an `auto_push=false` halt (which never writes the marker), or
 a rejection cleared it — and pool reset is the correct recovery.
 
-**Step 3b: Clean up worktree and return bead to pool.**
+**Step 3b: Re-verify liveness immediately before destroying anything.**
 
-Once the branch is canonical (on origin), the worktree is disposable:
+**This bead is about to have its worktree deleted and be reset to pool —
+the one truly destructive action in this recipe.** The liveness map built
+in Step 1 is a snapshot; an agent that spawned after it was built resolves
+to `absent` there even though it may be alive and mid-edit right now,
+minutes into the per-bead loop. Only `absent`/orphan candidates reaching
+this exact point need a fresh check — every bead classified `active`,
+`asleep`, or another do-not-touch state in Step 1 never gets here, so this
+adds one extra lookup per candidate orphan, not per bead:
+
+```bash
+FRESH_STATE=$(gc session list --state=all --json | jq -r --arg a "$ASSIGNEE" '
+  (.sessions // [])[] | select(.id == $a or .name == $a or .session_name == $a or .alias == $a or .agent_name == $a)
+  | (if (.closed // false) then "closed" else (.state // "") end)' | head -n1)
+FRESH_STATE=${FRESH_STATE:-absent}
+if [ "$FRESH_STATE" != "absent" ] && [ "$FRESH_STATE" != "closed" ] && [ "$FRESH_STATE" != "archived" ]; then
+  echo "SKIP: <bead> assignee $ASSIGNEE is now '$FRESH_STATE' -- spawned after the Step 1 snapshot. Not orphaned; leave it alone."
+  # Do not delete the worktree or reset this bead. Continue the per-bead loop.
+fi
+```
+
+Second, cheap guard: also skip if the bead itself changed after the
+Step 1 map was built — its `updated_at` (already read via `gc bd show
+<bead> --json` in Step 2) newer than `MAP_BUILT_AT` means something
+touched this bead mid-cycle and the Step 1 classification may already be
+stale:
+
+```bash
+BEAD_UPDATED_AT=$(echo "$META" | jq -r '.updated_at // empty')
+if [ -n "$BEAD_UPDATED_AT" ] && [[ "$BEAD_UPDATED_AT" > "$MAP_BUILT_AT" ]]; then
+  echo "SKIP: <bead> updated_at ($BEAD_UPDATED_AT) is newer than the liveness snapshot ($MAP_BUILT_AT) -- something touched it mid-cycle. Not destroying it on a stale classification."
+  # Do not delete the worktree or reset this bead. Continue the per-bead loop.
+fi
+```
+
+Once both fresh checks also say orphaned, the worktree is disposable:
 ```bash
 # Delete worktree if it exists
 cd <rig-root>

--- a/gastown/formulas/mol-witness-patrol.toml
+++ b/gastown/formulas/mol-witness-patrol.toml
@@ -189,47 +189,84 @@ a NEW session with a different ID — the old one never comes back.
 
    Stream both JSON blobs through temp files, never `--argjson` on argv: on a
    busy city the session `command` fields are large and overflow ARG_MAX
-   (`argument list too long: jq`). Build the map once:
+   (`argument list too long: jq`). Build the map through this function rather
+   than inline — Step 2a re-runs it per orphan candidate, and a single
+   definition is what stops the pre-destruction re-check from drifting away
+   from this classification: same two legs, same identifier forms, same
+   last-write-wins tie-break on duplicate identifiers.
    ```bash
-   SESSIONS_FILE=$(mktemp); SESSION_BEADS_FILE=$(mktemp)
-   gc session list --state=all --json > "$SESSIONS_FILE"
-   gc bd list --type=session --label=gc:session --include-infra --include-gates --all --json --limit=0 > "$SESSION_BEADS_FILE"
+   build_liveness_map() {
+     # Stamp the watermark BEFORE the snapshot. Everything touched from this
+     # instant onward is by definition not represented in the map about to be
+     # built, so the staleness guard has to measure against the START of the
+     # build, not its end. Measured on a 36-session city, the two queries plus
+     # the jq build take 2.56s — stamping last put that whole window on the
+     # wrong side of the comparison, which is the fail-open direction.
+     MAP_BUILT_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+     LIVENESS_MAP='{}'; MAP_COUNT=0; SESSION_COUNT=0; MAP_QUERY_RC=0
 
-   LIVENESS_MAP=$(jq -n --slurpfile sessions "$SESSIONS_FILE" --slurpfile session_beads "$SESSION_BEADS_FILE" '
-     def add($m; $key; $state; $closed):
-       if (($key // "") | length) == 0 then $m
-       else $m + {($key): (if $closed then "closed" else ($state // "") end)}
-       end;
-     (reduce ($sessions[0].sessions // [])[] as $s ({};
-         add(.; $s.id;         $s.state; ($s.closed // false))
-       | add(.; $s.name;       $s.state; ($s.closed // false))
-       | add(.; $s.session_name; $s.state; ($s.closed // false))
-       | add(.; $s.alias;      $s.state; ($s.closed // false))
-       | add(.; $s.agent_name; $s.state; ($s.closed // false))
-     )) as $from_sessions
-     | reduce ($session_beads[0] // [])[] as $b ($from_sessions;
-         add(.; $b.metadata.configured_named_identity; $b.metadata.state; ($b.status == "closed")))')
+     SESSIONS_FILE=$(mktemp); SESSION_BEADS_FILE=$(mktemp)
+     gc session list --state=all --json > "$SESSIONS_FILE" || MAP_QUERY_RC=1
+     gc bd list --type=session --label=gc:session --include-infra --include-gates --all --json --limit=0 > "$SESSION_BEADS_FILE" || MAP_QUERY_RC=1
 
-   SESSION_COUNT=$(jq -r '(.sessions // []) | length' "$SESSIONS_FILE")
-   MAP_COUNT=$(printf '%s' "$LIVENESS_MAP" | jq -r 'length')
-   rm -f "$SESSIONS_FILE" "$SESSION_BEADS_FILE"
-   MAP_BUILT_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+     if [ "$MAP_QUERY_RC" -eq 0 ]; then
+       LIVENESS_MAP=$(jq -n --slurpfile sessions "$SESSIONS_FILE" --slurpfile session_beads "$SESSION_BEADS_FILE" '
+         def add($m; $key; $state; $closed):
+           if (($key // "") | length) == 0 then $m
+           else $m + {($key): (if $closed then "closed" else ($state // "") end)}
+           end;
+         (reduce ($sessions[0].sessions // [])[] as $s ({};
+             add(.; $s.id;         $s.state; ($s.closed // false))
+           | add(.; $s.name;       $s.state; ($s.closed // false))
+           | add(.; $s.session_name; $s.state; ($s.closed // false))
+           | add(.; $s.alias;      $s.state; ($s.closed // false))
+           | add(.; $s.agent_name; $s.state; ($s.closed // false))
+         )) as $from_sessions
+         | reduce ($session_beads[0] // [])[] as $b ($from_sessions;
+             add(.; $b.metadata.configured_named_identity; $b.metadata.state; ($b.status == "closed")))') || MAP_QUERY_RC=1
+       SESSION_COUNT=$(jq -r '(.sessions // []) | length' "$SESSIONS_FILE" 2>/dev/null || echo 0)
+       MAP_COUNT=$(printf '%s' "$LIVENESS_MAP" | jq -r 'length' 2>/dev/null || echo 0)
+     fi
+     rm -f "$SESSIONS_FILE" "$SESSION_BEADS_FILE"
+
+     # Non-zero means "could not verify liveness" — it never means "nobody is
+     # alive". Callers must read it as a reason to leave beads alone, never as
+     # a licence to orphan them.
+     if [ "$MAP_QUERY_RC" -ne 0 ]; then return 1; fi
+     if [ "${MAP_COUNT:-0}" -eq 0 ] && [ "${SESSION_COUNT:-0}" -gt 0 ]; then return 1; fi
+     return 0
+   }
+
+   build_liveness_map; MAP_BUILD_RC=$?
+
+   # Pin the cycle's opening watermark. Step 2a rebuilds the map per candidate,
+   # which re-stamps MAP_BUILT_AT to ~now; comparing a bead against *that* would
+   # leave a guard that only ever catches a sub-second window. This is the
+   # baseline that stays fixed for the whole cycle.
+   CYCLE_MAP_BUILT_AT="$MAP_BUILT_AT"
    ```
 
-   `MAP_BUILT_AT` is this snapshot's timestamp — every bead the per-bead
-   loop below reaches was read from the store *after* this instant, but
-   its own `updated_at` may be newer still if something touched it mid-cycle.
-   Step 3b uses this to catch that case before it destroys anything.
+   `CYCLE_MAP_BUILT_AT` is the instant this cycle's first snapshot was
+   *started* — anything the map cannot know about was touched at or after it.
+   A bead whose own `updated_at` is not strictly older than that watermark was
+   changed during this cycle, by someone other than us, so its classification
+   may already be stale. Step 2a uses that to skip such a bead before anything
+   acts on it.
 
-   **Fail safe — never orphan on an empty map.** If the map is empty while
-   sessions exist, the schema has drifted again (the exact failure in
-   gc-3tn8g). An empty map resolves every assignee to `absent` and would
-   false-orphan live agents. ABORT recovery this cycle — do NOT classify any
-   bead as orphaned — escalate, then continue to `check-refinery`:
+   **Fail safe — never orphan on an unusable map.** If either query failed, or
+   the map is empty while sessions exist, the schema has drifted again (the
+   exact failure in gc-3tn8g). An empty or unbuilt map resolves every assignee
+   to `absent` and would false-orphan live agents. ABORT recovery this cycle —
+   do NOT classify any bead as orphaned — escalate, then continue to
+   `check-refinery`:
    ```bash
-   if [ "${MAP_COUNT:-0}" -eq 0 ] && [ "${SESSION_COUNT:-0}" -gt 0 ]; then
-     echo "FAIL-SAFE: empty liveness map with $SESSION_COUNT live sessions — skipping orphan recovery (treat all assignees as live)."
-     gc mail send mayor/ -s "WITNESS: orphan-recovery disabled — empty liveness map" -m "Built an empty assignee->state map from $SESSION_COUNT live sessions. gc session list --json schema likely drifted again (gc-3tn8g); skipping orphan recovery this cycle to avoid false-orphaning live agents. Re-check the recover-orphaned-beads liveness recipe."
+   if [ "${MAP_BUILD_RC:-1}" -ne 0 ]; then
+     if [ "${MAP_COUNT:-0}" -eq 0 ] && [ "${SESSION_COUNT:-0}" -gt 0 ]; then
+       echo "FAIL-SAFE: empty liveness map with $SESSION_COUNT live sessions — skipping orphan recovery (treat all assignees as live)."
+     else
+       echo "FAIL-SAFE: liveness map could not be built (gc session list / gc bd list did not both succeed) — skipping orphan recovery (treat all assignees as live)."
+     fi
+     gc mail send mayor/ -s "WITNESS: orphan-recovery disabled — liveness map unusable" -m "Could not build a usable assignee->state map (build rc=$MAP_BUILD_RC, map entries=$MAP_COUNT, live sessions=$SESSION_COUNT). Either a query failed or the gc session list --json schema drifted again (gc-3tn8g); skipping orphan recovery this cycle to avoid false-orphaning live agents. Re-check the recover-orphaned-beads liveness recipe."
      # Skip the rest of this step; proceed to check-refinery.
    fi
    ```
@@ -269,6 +306,93 @@ META=$(gc bd show <bead> --json | jq '.[0].metadata')
 WORKTREE=$(echo "$META" | jq -r '.worktree // empty')
 BRANCH=$(echo "$META" | jq -r '.branch // empty')
 ```
+
+**Step 2a: Re-verify liveness before anything acts on this bead.**
+
+Step 1's classification is a snapshot, and the per-bead loop can run for
+minutes after it. An agent that spawned in between resolves to `absent` there
+while being alive and mid-edit right now. Re-check here — **above** the
+salvage cases and all three destructive paths — rather than at any one of
+them:
+
+- Step 3 closes the bead with `gc bd close --force` and deletes its worktree
+  when the branch reads as already on main;
+- Step 3a reassigns the bead with `gc bd update --force`, runs
+  `gc workflow delete-source` and deletes its worktree, then skips Step 3b
+  entirely, so a guard placed there would never see this path;
+- Step 3b deletes the worktree and resets the bead to pool.
+
+All three use `--force`, which overrides exactly the cross-actor claim guard
+that would otherwise refuse a write against a live agent, and all three act on
+this same Step 2 snapshot. One check above them covers all three; three copies
+would drift. Salvage (Cases C and D below) is gated on the same verdict: it
+commits and pushes whatever is in the worktree, which is not something to do
+to an agent that is still editing it.
+
+Only `absent`/orphan candidates reach here — beads classified `active`,
+`asleep` or another do-not-touch state in Step 1 never enter this loop — so
+this is one extra map build per candidate orphan, not per bead.
+
+```bash
+# Fail closed by construction: the verdict starts at "do not touch" and is
+# only promoted by a check that provably succeeded. Every arm below that
+# cannot prove orphanhood leaves it false, so an unset, errored or
+# half-computed verdict skips rather than destroys.
+STILL_ORPHANED=false
+
+if [ -z "$ASSIGNEE" ]; then
+  echo "SKIP: <bead> has no assignee to re-verify — cannot confirm it is orphaned; leaving it alone this cycle."
+elif ! build_liveness_map; then
+  # Same fail-safe as Step 1's: a failed query or an empty map is "cannot
+  # verify", never "the assignee is gone". Escalate; do not fall through.
+  echo "SKIP: <bead> liveness re-check unavailable (map build rc=1) — cannot verify, leaving it alone this cycle."
+  gc mail send mayor/ -s "WITNESS: orphan re-check inconclusive for <bead>" -m "The pre-destruction liveness rebuild failed for assignee $ASSIGNEE (map entries=$MAP_COUNT, live sessions=$SESSION_COUNT). Skipped this candidate rather than acting on an unverified classification."
+else
+  # Re-read the bead itself. Two fields matter and both must be current: the
+  # assignee (a human or the controller may have handed this bead to a live
+  # agent since Step 1, which would make Step 1's $ASSIGNEE the wrong identity
+  # to resolve) and updated_at.
+  #
+  # `updated_at` is a TOP-LEVEL bead field, never a metadata key, so reading it
+  # off Step 2's $META (which is `jq '.[0].metadata'`) returned empty on every
+  # bead and this guard could never fire.
+  BEAD_JSON=$(gc bd show <bead> --json) || BEAD_JSON=""
+  FRESH_ASSIGNEE=$(printf '%s' "$BEAD_JSON" | jq -r '.[0].assignee // empty' 2>/dev/null || true)
+  FRESH_ASSIGNEE="${FRESH_ASSIGNEE:-$ASSIGNEE}"
+  BEAD_UPDATED_AT=$(printf '%s' "$BEAD_JSON" | jq -r '.[0].updated_at // empty' 2>/dev/null || true)
+
+  FRESH_STATE=$(printf '%s' "$LIVENESS_MAP" | jq -r --arg a "$FRESH_ASSIGNEE" '.[$a] // "absent"')
+
+  # Normalize away fractional seconds before comparing. The watermark is stamped
+  # whole-second by `date`, while `gc bd show` emits whole seconds for rig beads
+  # and nanoseconds for graph-resident ones; comparing those two shapes as
+  # strings inverts, because "." (0x2E) sorts before "Z" (0x5A), and it inverts
+  # toward destroying. Truncating both to whole seconds and skipping unless the
+  # bead is *strictly older* than the watermark keeps the boundary second on the
+  # safe side: a bead touched in the same second the cycle started costs one
+  # wasted cycle, which is the direction to be wrong in.
+  BEAD_UPDATED_AT="${BEAD_UPDATED_AT%%.*}"
+  case "$BEAD_UPDATED_AT" in ""|*Z) ;; *) BEAD_UPDATED_AT="${BEAD_UPDATED_AT}Z" ;; esac
+
+  if [ "$FRESH_ASSIGNEE" != "$ASSIGNEE" ]; then
+    echo "SKIP: <bead> was reassigned from $ASSIGNEE to $FRESH_ASSIGNEE since Step 1 — someone else owns it now; leave it alone."
+  elif [ "$FRESH_STATE" != "absent" ] && [ "$FRESH_STATE" != "closed" ] && [ "$FRESH_STATE" != "archived" ]; then
+    echo "SKIP: <bead> assignee $FRESH_ASSIGNEE is now '$FRESH_STATE' — spawned after the Step 1 snapshot. Not orphaned; leave it alone."
+  elif [ -z "$BEAD_UPDATED_AT" ]; then
+    echo "SKIP: <bead> updated_at could not be read — cannot confirm the classification is current; leaving it alone this cycle."
+  elif ! [[ "$BEAD_UPDATED_AT" < "$CYCLE_MAP_BUILT_AT" ]]; then
+    echo "SKIP: <bead> updated_at ($BEAD_UPDATED_AT) is not older than this cycle's liveness snapshot ($CYCLE_MAP_BUILT_AT) — something touched it mid-cycle. Not acting on a stale classification."
+  else
+    STILL_ORPHANED=true
+  fi
+fi
+```
+
+If `STILL_ORPHANED` is not `true`, skip this bead entirely and continue the
+per-bead loop — do not salvage, do not close, do not reassign, do not delete
+the worktree. Everything from here to Step 4 assumes `STILL_ORPHANED=true`
+and each destructive site re-states the check, so a step reached out of order
+still fails closed.
 
 Check the bead and worktree state, then act:
 
@@ -343,21 +467,45 @@ produces it as soon as a second bead lands after the first was rebased.
 A false negative here re-dispatches already-merged work.
 
 ```bash
+# Every check below reads *local* remote-tracking refs, while Step 2's
+# existence checks used live `ls-remote` — two freshness sources in one flow.
+# Refresh first. A failed fetch must not be read as "nothing changed": fall
+# back to not-merged, which re-dispatches (wasteful) rather than closing
+# (terminal).
+if ! git fetch -q origin main "$BRANCH"; then
+  ON_MAIN=false
 # Cheap first pass — catches the plain fast-forward/merge-commit case:
-if git merge-base --is-ancestor origin/$BRANCH origin/main; then
+elif git merge-base --is-ancestor origin/$BRANCH origin/main; then
   ON_MAIN=true
 else
   # Rebase/squash recreates commits, so a "not an ancestor" result does
   # NOT mean "not merged" -- fall back to a content test, scoped to the
-  # branch's own changed files, which holds regardless of how it landed.
+  # branch's own changed files. Bound, stated honestly: this holds while main
+  # has not itself touched those files since the landing, and while the refs
+  # above are fresh. Outside that bound it answers not-merged and the bead is
+  # re-dispatched -- the pre-PR direction, wasteful but never destructive.
   MERGE_BASE=$(git merge-base origin/$BRANCH origin/main 2>/dev/null || true)
   if [ -z "$MERGE_BASE" ]; then
     ON_MAIN=false   # no shared history found; treat conservatively as not-yet-merged
   else
-    CHANGED_FILES=$(git diff --name-only "$MERGE_BASE" origin/$BRANCH)
-    if [ -z "$CHANGED_FILES" ]; then
+    # Collect NUL-separated into a quoted array. Both halves are load-bearing:
+    # an unquoted `-- $CHANGED_FILES` word-splits, so a path containing
+    # whitespace becomes pathspecs matching nothing -- and `git diff --quiet`
+    # over pathspecs that match nothing exits 0, i.e. an UNMERGED branch reads
+    # as merged and gets force-closed with its worktree deleted. `-z` is needed
+    # as well as the quoting: without it `--name-only` C-quotes a path
+    # containing a newline, and re-reading that quoted form yields a pathspec
+    # that matches nothing in exactly the same way.
+    # `while read -d ''` rather than `mapfile -d ''`: mapfile is a bash-4
+    # builtin, and gastown/tests/test_witness_heartbeat_check.sh bans bash-4
+    # constructs outright because the fleet includes macOS on bash 3.2.
+    CHANGED=(); CHANGED_COUNT=0
+    while IFS= read -r -d '' f; do
+      CHANGED[$CHANGED_COUNT]="$f"; CHANGED_COUNT=$((CHANGED_COUNT + 1))
+    done < <(git diff --name-only -z "$MERGE_BASE" "origin/$BRANCH")
+    if [ "$CHANGED_COUNT" -eq 0 ]; then
       ON_MAIN=false   # branch introduced nothing beyond the merge-base; nothing to confirm
-    elif git diff --quiet origin/main origin/$BRANCH -- $CHANGED_FILES; then
+    elif git diff --quiet "origin/main" "origin/$BRANCH" -- "${CHANGED[@]}"; then
       ON_MAIN=true    # main's current content for exactly these files matches the branch
     else
       ON_MAIN=false
@@ -369,11 +517,16 @@ fi
 If the work is already on main (`ON_MAIN=true`):
 - **Close the bead** (work is done, don't re-dispatch). Use `--force`: the bead
   is still assigned to the crashed polecat, so this is a cross-actor close and
-  bd's close-authority guard (gastownhall/beads#3734) would otherwise refuse it:
+  bd's close-authority guard (gastownhall/beads#3734) would otherwise refuse it.
+  `--force` is also what makes this destructive against a *live* agent, so it
+  runs only on Step 2a's verdict — a terminal close on a bead whose work never
+  landed cannot be undone by the next patrol cycle:
 ```bash
-gc bd close <bead> --force
-gc mail send mayor/ -s "ORPHAN_CLOSED: <bead> already merged" \
-  -m "Branch $BRANCH already on main. Closed instead of resetting."
+if [ "$STILL_ORPHANED" = "true" ] && [ "$ON_MAIN" = "true" ]; then
+  gc bd close <bead> --force
+  gc mail send mayor/ -s "ORPHAN_CLOSED: <bead> already merged" \
+    -m "Branch $BRANCH already on main. Closed instead of resetting."
+fi
 ```
 - Clean up worktree and skip to Step 4.
 
@@ -424,7 +577,10 @@ branch-on-origin conjunct is a fail-closed backstop: there is nothing to hand
 off if the refinery's `--has-metadata-key=branch` query cannot see the work.
 
 ```bash
-if [ "$HANDOFF_STAGE" = "target_recorded" ] && [ -n "$BRANCH_ON_ORIGIN" ]; then
+# STILL_ORPHANED is re-stated here because this arm never reaches Step 3b:
+# `:455` skips straight to Step 4, so this is the one destructive path a guard
+# placed at the pool reset would miss entirely.
+if [ "$STILL_ORPHANED" = "true" ] && [ "$HANDOFF_STAGE" = "target_recorded" ] && [ -n "$BRANCH_ON_ORIGIN" ]; then
   REFINERY_TARGET="${GC_RIG:+$GC_RIG/}{{binding_prefix}}refinery"
   # --force: this is a cross-actor write against the dead polecat's live
   # in_progress claim, which bd refuses without it (the same claim guard
@@ -470,43 +626,25 @@ Step 3b: the crash landed earlier than step 5, the bead was deliberately left
 branch-ready by an `auto_push=false` halt (which never writes the marker), or
 a rejection cleared it — and pool reset is the correct recovery.
 
-**Step 3b: Re-verify liveness immediately before destroying anything.**
+**Step 3b: Clean up worktree and return bead to pool.**
 
-**This bead is about to have its worktree deleted and be reset to pool —
-the one truly destructive action in this recipe.** The liveness map built
-in Step 1 is a snapshot; an agent that spawned after it was built resolves
-to `absent` there even though it may be alive and mid-edit right now,
-minutes into the per-bead loop. Only `absent`/orphan candidates reaching
-this exact point need a fresh check — every bead classified `active`,
-`asleep`, or another do-not-touch state in Step 1 never gets here, so this
-adds one extra lookup per candidate orphan, not per bead:
+**This bead is about to have its worktree deleted and be reset to pool.**
+That is destructive, but it is *not* the only destructive action in this
+recipe, and it is the mildest of the three: Step 3 closes the bead
+terminally with `gc bd close --force`, and Step 3a reassigns it with
+`gc bd update --force` and tears down its workflow subtree before skipping
+here entirely. All three are covered by Step 2a's `STILL_ORPHANED` verdict,
+which is re-stated at each of them so a step reached out of order still fails
+closed.
 
 ```bash
-FRESH_STATE=$(gc session list --state=all --json | jq -r --arg a "$ASSIGNEE" '
-  (.sessions // [])[] | select(.id == $a or .name == $a or .session_name == $a or .alias == $a or .agent_name == $a)
-  | (if (.closed // false) then "closed" else (.state // "") end)' | head -n1)
-FRESH_STATE=${FRESH_STATE:-absent}
-if [ "$FRESH_STATE" != "absent" ] && [ "$FRESH_STATE" != "closed" ] && [ "$FRESH_STATE" != "archived" ]; then
-  echo "SKIP: <bead> assignee $ASSIGNEE is now '$FRESH_STATE' -- spawned after the Step 1 snapshot. Not orphaned; leave it alone."
-  # Do not delete the worktree or reset this bead. Continue the per-bead loop.
+if [ "$STILL_ORPHANED" != "true" ]; then
+  echo "SKIP: <bead> did not pass the Step 2a liveness re-check — not deleting its worktree or resetting it."
+  # Continue the per-bead loop; this bead is retried next cycle.
 fi
 ```
 
-Second, cheap guard: also skip if the bead itself changed after the
-Step 1 map was built — its `updated_at` (already read via `gc bd show
-<bead> --json` in Step 2) newer than `MAP_BUILT_AT` means something
-touched this bead mid-cycle and the Step 1 classification may already be
-stale:
-
-```bash
-BEAD_UPDATED_AT=$(echo "$META" | jq -r '.updated_at // empty')
-if [ -n "$BEAD_UPDATED_AT" ] && [[ "$BEAD_UPDATED_AT" > "$MAP_BUILT_AT" ]]; then
-  echo "SKIP: <bead> updated_at ($BEAD_UPDATED_AT) is newer than the liveness snapshot ($MAP_BUILT_AT) -- something touched it mid-cycle. Not destroying it on a stale classification."
-  # Do not delete the worktree or reset this bead. Continue the per-bead loop.
-fi
-```
-
-Once both fresh checks also say orphaned, the worktree is disposable:
+Once the verdict is `true`, the worktree is disposable:
 ```bash
 # Delete worktree if it exists
 cd <rig-root>

--- a/gastown/tests/test_gastown_pack_assets.sh
+++ b/gastown/tests/test_gastown_pack_assets.sh
@@ -354,10 +354,13 @@ test_witness_handoff_recovery_is_guarded_and_fail_closed() {
     # it dead code for every bead 3b has already returned to pool. A sequence
     # signature pins order, count, and cardinality together, and pins the
     # precondition (Step 3's on-main close) rather than 3a alone.
+    # Leading whitespace is tolerated because the close now sits inside the
+    # STILL_ORPHANED gate asserted below; the line is still pinned whole, so
+    # this admits indentation and nothing else.
     signature=$(awk '
-        /^gc bd close <bead> --force$/ { print "step3-close" }
-        /^\*\*Step 3a:/               { print "step3a" }
-        /^\*\*Step 3b:/               { print "step3b" }
+        /^[[:space:]]*gc bd close <bead> --force$/ { print "step3-close" }
+        /^\*\*Step 3a:/                           { print "step3a" }
+        /^\*\*Step 3b:/                           { print "step3b" }
     ' "$witness" | tr '\n' ' ')
     [[ "$signature" == "step3-close step3a step3b " ]] ||
         fail "witness recovery must run Step 3's on-main close, then Step 3a, then Step 3b (got: $signature)"
@@ -367,8 +370,10 @@ test_witness_handoff_recovery_is_guarded_and_fail_closed() {
     # it fires 3a for beads that never submitted -- shipping an already-rejected
     # or half-finished tip to a refinery whose only merge gate is tests-pass.
     block=$(awk '/^\*\*Step 3a:/{f=1} /^\*\*Step 3b:/{f=0} f' "$witness")
+    # Matched without the leading `if `: the same condition now carries the
+    # STILL_ORPHANED gate in front of it, pinned as a whole line below.
     printf '%s\n' "$block" |
-        grep -F 'if [ "$HANDOFF_STAGE" = "target_recorded" ] && [ -n "$BRANCH_ON_ORIGIN" ]; then' >/dev/null ||
+        grep -F '[ "$HANDOFF_STAGE" = "target_recorded" ] && [ -n "$BRANCH_ON_ORIGIN" ]; then' >/dev/null ||
         fail "Step 3a must key the handoff on handoff_stage and a branch that is really on origin"
     ! printf '%s\n' "$block" | grep -F '[ -n "$BEAD_TARGET" ]' >/dev/null ||
         fail "Step 3a must not treat metadata.target as a completion signal"
@@ -433,6 +438,21 @@ test_witness_handoff_recovery_is_guarded_and_fail_closed() {
     # 3b keeps its own recovery for everything that falls through.
     grep -F 'gc workflow delete-source <bead> --apply && gc workflow reopen-source <bead>' "$witness" >/dev/null ||
         fail "Step 3b must still reopen the source bead for fall-through recoveries"
+
+    # All three destructive outcomes re-state the pre-destruction verdict, and
+    # the verdict itself starts closed. Step 3a is not covered by a guard at the
+    # pool reset: its success arm skips to Step 4 and never reaches Step 3b, so
+    # each site is pinned individually rather than inferred from one of them.
+    grep -F 'STILL_ORPHANED=false' "$witness" >/dev/null ||
+        fail "the pre-destruction verdict must start closed (STILL_ORPHANED=false)"
+    local gate
+    for gate in \
+        'if [ "$STILL_ORPHANED" = "true" ] && [ "$ON_MAIN" = "true" ]; then' \
+        'if [ "$STILL_ORPHANED" = "true" ] && [ "$HANDOFF_STAGE" = "target_recorded" ] && [ -n "$BRANCH_ON_ORIGIN" ]; then' \
+        'if [ "$STILL_ORPHANED" != "true" ]; then'; do
+        grep -F -- "$gate" "$witness" >/dev/null ||
+            fail "a destructive witness recovery path is not gated on the liveness re-check: $gate"
+    done
 }
 
 test_boot_wisp_queries_pin_include_infra() {

--- a/gastown/tests/test_mol_witness_patrol_orphan_recovery.sh
+++ b/gastown/tests/test_mol_witness_patrol_orphan_recovery.sh
@@ -1,0 +1,488 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Executed coverage for `recover-orphaned-beads` in mol-witness-patrol.
+#
+# That step force-closes beads, force-reassigns them and deletes worktrees, and
+# it decides to do so from a liveness snapshot and a "did this branch land?"
+# test.  Both decisions were previously wrong in the destructive direction: an
+# unquoted pathspec made an unmerged branch read as merged, and a lookup failure
+# read as "the owner is gone".  Contract pins in
+# scripts/gascity_pack_inference_gate.py catch deletion of those guards; this
+# file catches them being kept but broken.
+#
+# The blocks are LIFTED out of the formula and executed, not transcribed.  A
+# transcription is a second copy that drifts silently from the recipe that
+# actually runs, which is the failure mode this whole area already has.
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+FORMULA="$ROOT/gastown/formulas/mol-witness-patrol.toml"
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+BIN="$tmp/bin"
+STEP1="$tmp/step1-liveness-map.sh"
+STEP2A="$tmp/step2a-verdict.sh"
+STEP3="$tmp/step3-on-main.sh"
+ERRLOG="$tmp/stderr.log"
+: >"$ERRLOG"
+
+fail() {
+    echo "FAIL: $*" >&2
+    if [ -s "$ERRLOG" ]; then
+        echo "--- captured stderr ---" >&2
+        tail -n 20 "$ERRLOG" >&2
+    fi
+    exit 1
+}
+
+# lift_block <sentinel> <dest> -- extract the fenced ```bash block containing
+# <sentinel>.  `<bead>` is the formula's placeholder for the bead id; in shell
+# it would parse as a redirect, so it is substituted mechanically.
+lift_block() {
+    local sentinel="$1" dest="$2"
+    awk -v want="$sentinel" '
+        /^[[:space:]]*```bash[[:space:]]*$/ { inblk = 1; body = ""; next }
+        inblk && /^[[:space:]]*```[[:space:]]*$/ {
+            inblk = 0
+            if (index(body, want)) { printf "%s", body; found = 1 }
+            body = ""
+            next
+        }
+        inblk { body = body $0 "\n"; next }
+        END { exit(found ? 0 : 1) }
+    ' "$FORMULA" | sed 's/<bead>/TESTBEAD/g' >"$dest" ||
+        fail "no fenced bash block in $FORMULA contains: $sentinel"
+    [ -s "$dest" ] || fail "lifted an empty block for: $sentinel"
+    bash -n "$dest" || fail "lifted block does not parse: $sentinel"
+}
+
+# Sentinels are chosen to be stable under the mutations these tests are meant
+# to catch: `STILL_ORPHANED=` rather than `STILL_ORPHANED=false`, so flipping
+# the verdict's initial value still lifts and is caught by an assertion here
+# rather than by the extraction failing.
+lift_block 'build_liveness_map() {' "$STEP1"
+lift_block 'STILL_ORPHANED=' "$STEP2A"
+lift_block 'merge-base --is-ancestor' "$STEP3"
+
+write_gc_stub() {
+    mkdir -p "$BIN"
+    cat >"$BIN/gc" <<'SH'
+#!/usr/bin/env sh
+# Match on the reconstructed command line: the repo's bare-`bd` lint only
+# accepts beads literals that read as `gc bd ...`.
+invocation="gc $*"
+case "$invocation" in
+    *"gc session list"*)
+        if [ -n "${GC_STUB_FAIL_SESSION_LIST:-}" ]; then exit 1; fi
+        cat "$GC_SESSIONS_JSON"
+        ;;
+    *"gc bd list"*) cat "$GC_SESSION_BEADS_JSON" ;;
+    *"gc bd show"*)
+        if [ -n "${GC_STUB_FAIL_BD_SHOW:-}" ]; then exit 1; fi
+        cat "$GC_BEAD_JSON"
+        ;;
+    *"gc mail send"*) : ;;
+    *) printf '{}' ;;
+esac
+SH
+    chmod +x "$BIN/gc"
+}
+
+write_gc_stub
+export PATH="$BIN:$PATH"
+export GC_SESSIONS_JSON="$tmp/sessions.json"
+export GC_SESSION_BEADS_JSON="$tmp/session-beads.json"
+export GC_BEAD_JSON="$tmp/bead.json"
+printf '[]' >"$GC_SESSION_BEADS_JSON"
+
+command -v jq >/dev/null || fail "jq is required (the recipe under test uses it)"
+
+# A roster with two live pool sessions.  Anything else resolves to `absent`.
+ROSTER_LIVE='{"sessions":[
+  {"id":"pool-1","name":"pool-1","state":"active","closed":false},
+  {"id":"pool-2","name":"pool-2","state":"active","closed":false}
+]}'
+# Sessions exist but carry no identifier the map can key on -- the gc-3tn8g
+# schema-drift shape, which yields an empty map while sessions are live.
+ROSTER_NO_IDENTIFIERS='{"sessions":[{"state":"active","closed":false}]}'
+
+set_roster() { printf '%s' "$1" >"$GC_SESSIONS_JSON"; }
+
+# run_verdict <step1-assignee> <bead-assignee> <updated-at-spec>
+#   updated-at-spec: OLD | BOUNDARY | NEWER | MISSING | <literal RFC3339>
+# Sources the shipped Step 1 and Step 2a blocks back to back, as the recipe runs
+# them, and reports the verdict.  `set +eu` because the recipe is executed by an
+# agent in a plain shell, not under strict mode -- testing it stricter than it
+# ships would measure the wrong thing.
+run_verdict() {
+    VERDICT=$(
+        set +eu
+        ASSIGNEE="$1"
+        bead_assignee="$2"
+        spec="$3"
+        # The recipe narrates its decisions on stdout; send that to the log so
+        # only the verdict is captured, and so `fail` can show the reasoning.
+        {
+            . "$STEP1"
+            case "$spec" in
+                OLD) u="2020-01-01T00:00:00Z" ;;
+                BOUNDARY) u="${CYCLE_MAP_BUILT_AT%Z}.7035126Z" ;;
+                NEWER) u="2099-01-01T00:00:00Z" ;;
+                MID_CYCLE)
+                    # A timestamp inside the cycle but before Step 2a's own
+                    # rebuild.  Sleeping first makes the two watermarks differ
+                    # by whole seconds, which is what separates "compared
+                    # against the cycle's snapshot" from "compared against the
+                    # rebuild that just happened".  GNU date, as in the sibling
+                    # heartbeat test: the recipe needs BSD portability, this
+                    # Linux-only CI test does not.
+                    u=$(date -u -d "$CYCLE_MAP_BUILT_AT + 1 second" +%Y-%m-%dT%H:%M:%SZ)
+                    sleep 2.1
+                    ;;
+                MISSING) u="" ;;
+                *) u="$spec" ;;
+            esac
+            if [ -n "$u" ]; then
+                printf '[{"id":"TESTBEAD","assignee":"%s","updated_at":"%s"}]' \
+                    "$bead_assignee" "$u" >"$GC_BEAD_JSON"
+            else
+                printf '[{"id":"TESTBEAD","assignee":"%s"}]' "$bead_assignee" >"$GC_BEAD_JSON"
+            fi
+            . "$STEP2A"
+        } >>"$ERRLOG" 2>&1
+        printf '%s' "$STILL_ORPHANED"
+    )
+}
+
+assert_verdict() {
+    local expected="$1" label="$2"
+    [ "$VERDICT" = "$expected" ] ||
+        fail "$label: expected STILL_ORPHANED=$expected, got '$VERDICT'"
+}
+
+# --- Step 2a: the pre-destruction liveness verdict -------------------------
+
+test_absent_assignee_is_still_orphaned() {
+    # Positive control.  Without it every guard below passes vacuously by
+    # never producing `true` at all, and the step would recover nothing.
+    set_roster "$ROSTER_LIVE"
+    run_verdict "pool-gone" "pool-gone" OLD
+    assert_verdict true "a genuinely absent assignee"
+}
+
+test_closed_assignee_is_still_orphaned() {
+    set_roster '{"sessions":[{"id":"pool-1","name":"pool-1","state":"active","closed":true}]}'
+    run_verdict "pool-1" "pool-1" OLD
+    assert_verdict true "an assignee whose session is closed"
+}
+
+test_live_assignee_is_not_orphaned() {
+    set_roster "$ROSTER_LIVE"
+    run_verdict "pool-1" "pool-1" OLD
+    assert_verdict false "an assignee that is alive at re-check time"
+}
+
+test_unusable_liveness_map_skips_instead_of_orphaning() {
+    # The core of the fail-open defect: a failed query must mean "cannot
+    # verify", never "the owner is gone".
+    set_roster "$ROSTER_LIVE"
+    GC_STUB_FAIL_SESSION_LIST=1 run_verdict "pool-gone" "pool-gone" OLD
+    assert_verdict false "a failed roster query"
+}
+
+test_empty_map_with_live_sessions_skips() {
+    set_roster "$ROSTER_NO_IDENTIFIERS"
+    run_verdict "pool-gone" "pool-gone" OLD
+    assert_verdict false "an empty map built while sessions are live"
+}
+
+test_missing_assignee_skips() {
+    set_roster "$ROSTER_LIVE"
+    run_verdict "" "" OLD
+    assert_verdict false "a bead with no assignee to re-verify"
+}
+
+test_unreadable_bead_skips() {
+    set_roster "$ROSTER_LIVE"
+    GC_STUB_FAIL_BD_SHOW=1 run_verdict "pool-gone" "pool-gone" OLD
+    assert_verdict false "a bead whose record could not be read"
+}
+
+test_missing_updated_at_skips() {
+    set_roster "$ROSTER_LIVE"
+    run_verdict "pool-gone" "pool-gone" MISSING
+    assert_verdict false "a bead with no readable updated_at"
+}
+
+test_bead_touched_mid_cycle_skips() {
+    set_roster "$ROSTER_LIVE"
+    run_verdict "pool-gone" "pool-gone" NEWER
+    assert_verdict false "a bead touched after the cycle's snapshot"
+}
+
+test_boundary_second_fraction_skips() {
+    # Sub-second `updated_at` inside the same second as the whole-second
+    # watermark.  Compared as raw strings this inverts -- "." sorts before "Z"
+    # -- and it inverts toward destroying, so it is pinned as its own case.
+    set_roster "$ROSTER_LIVE"
+    run_verdict "pool-gone" "pool-gone" BOUNDARY
+    assert_verdict false "a sub-second timestamp in the watermark's own second"
+}
+
+test_touch_before_the_recheck_rebuild_still_skips() {
+    # The staleness compare must use the watermark from the cycle's FIRST
+    # snapshot, not the one Step 2a's own rebuild just stamped.  Against the
+    # rebuild's watermark almost every bead reads as "older", so the guard
+    # would survive as a line of code while catching nothing.
+    set_roster "$ROSTER_LIVE"
+    run_verdict "pool-gone" "pool-gone" MID_CYCLE
+    assert_verdict false "a bead touched between the snapshot and the re-check"
+}
+
+test_reassigned_bead_skips() {
+    # Someone handed the bead to a live agent after Step 1 read it.
+    set_roster "$ROSTER_LIVE"
+    run_verdict "pool-gone" "pool-1" OLD
+    assert_verdict false "a bead reassigned since the snapshot"
+}
+
+# --- Step 3: the "did this branch land?" test -----------------------------
+
+new_repo() {
+    REPO="$tmp/repo-$1"
+    ORIGIN="$tmp/repo-$1.git"
+    git init -q --bare -b main "$ORIGIN"
+    git init -q -b main "$REPO"
+    git -C "$REPO" config user.name "Witness Patrol Test"
+    git -C "$REPO" config user.email "witness@example.invalid"
+    git -C "$REPO" remote add origin "$ORIGIN"
+    printf 'baseline\n' >"$REPO/README.md"
+    git -C "$REPO" add -A
+    git -C "$REPO" commit -q -m baseline
+    git -C "$REPO" push -q origin main
+}
+
+# commit_branch <branch> <file>...
+commit_branch() {
+    local branch="$1"
+    shift
+    git -C "$REPO" checkout -q -b "$branch" main
+    local f
+    for f in "$@"; do
+        printf 'branch work\n' >"$REPO/$f"
+    done
+    git -C "$REPO" add -A
+    git -C "$REPO" commit -q -m "work on $branch"
+    git -C "$REPO" push -q origin "$branch"
+    git -C "$REPO" checkout -q main
+}
+
+# add_branch_commit <branch> <file>
+add_branch_commit() {
+    git -C "$REPO" checkout -q "$1"
+    printf 'more work\n' >"$REPO/$2"
+    git -C "$REPO" add -A
+    git -C "$REPO" commit -q -m "more work on $1"
+    git -C "$REPO" push -q origin "$1"
+    git -C "$REPO" checkout -q main
+}
+
+advance_main() {
+    printf 'unrelated\n' >>"$REPO/README.md"
+    git -C "$REPO" add -A
+    git -C "$REPO" commit -q -m "unrelated main commit"
+    git -C "$REPO" push -q origin main
+}
+
+land_merge() {
+    git -C "$REPO" merge -q --no-ff -m "merge $1" "$1"
+    git -C "$REPO" push -q origin main
+}
+
+land_rebase() {
+    # Replays the branch's commits onto a moved main: same content, new SHAs,
+    # so ancestry can never see the landing.
+    git -C "$REPO" cherry-pick "origin/main..origin/$1" >/dev/null 2>&1 ||
+        fail "cherry-pick of $1 onto main failed"
+    git -C "$REPO" push -q origin main
+}
+
+land_squash() {
+    git -C "$REPO" merge --squash "$1" >/dev/null 2>&1
+    git -C "$REPO" commit -q -m "squashed $1"
+    git -C "$REPO" push -q origin main
+}
+
+# run_on_main <branch>
+run_on_main() {
+    ON_MAIN=$(
+        set +eu
+        cd "$REPO" || exit 1
+        BRANCH="$1"
+        ON_MAIN=
+        { . "$STEP3"; } >>"$ERRLOG" 2>&1
+        printf '%s' "$ON_MAIN"
+    )
+}
+
+assert_on_main() {
+    local expected="$1" label="$2"
+    [ "$ON_MAIN" = "$expected" ] ||
+        fail "$label: expected ON_MAIN=$expected, got '$ON_MAIN'"
+}
+
+test_merge_commit_landing_reads_as_on_main() {
+    new_repo ff
+    commit_branch feat "feature.txt"
+    land_merge feat
+    run_on_main feat
+    assert_on_main true "a branch merged with a merge commit"
+}
+
+test_rebased_landing_reads_as_on_main() {
+    new_repo rebased
+    commit_branch feat "feature.txt"
+    advance_main
+    land_rebase feat
+    run_on_main feat
+    assert_on_main true "a branch replayed onto a moved main"
+}
+
+test_squashed_landing_reads_as_on_main() {
+    new_repo squashed
+    commit_branch feat "one.txt"
+    add_branch_commit feat "two.txt"
+    advance_main
+    land_squash feat
+    run_on_main feat
+    assert_on_main true "a branch squashed onto main"
+}
+
+test_unlanded_branch_reads_as_not_on_main() {
+    new_repo unlanded
+    commit_branch feat "feature.txt"
+    advance_main
+    run_on_main feat
+    assert_on_main false "a branch that never landed"
+}
+
+test_unlanded_branch_with_space_in_path_reads_as_not_on_main() {
+    # Unquoted, this filename word-splits into pathspecs matching nothing;
+    # `git diff --quiet` over those exits 0 and the branch reads as merged.
+    new_repo space-unlanded
+    commit_branch feat "has space.txt"
+    advance_main
+    run_on_main feat
+    assert_on_main false "an unlanded branch touching a path with a space"
+}
+
+test_unlanded_branch_with_newline_in_path_reads_as_not_on_main() {
+    # Without `-z`, `--name-only` C-quotes this path; re-reading the quoted
+    # form yields a pathspec matching nothing -- the same destructive verdict
+    # by a different route, which a per-file loop over unquoted output does
+    # not fix.
+    new_repo newline-unlanded
+    commit_branch feat "$(printf 'has\nnewline.txt')"
+    advance_main
+    run_on_main feat
+    assert_on_main false "an unlanded branch touching a path with a newline"
+}
+
+test_landed_branch_with_space_in_path_reads_as_on_main() {
+    # Positive control for the two cases above: the quoting fix must not turn
+    # every awkward filename into a permanent "not merged".
+    new_repo space-landed
+    commit_branch feat "has space.txt"
+    advance_main
+    land_rebase feat
+    run_on_main feat
+    assert_on_main true "a landed branch touching a path with a space"
+}
+
+test_main_touching_the_files_after_landing_reads_as_not_on_main() {
+    # The content test's stated bound.  It answers not-merged, which
+    # re-dispatches -- wasteful, never destructive.
+    new_repo touched-after
+    commit_branch feat "feature.txt"
+    advance_main
+    land_rebase feat
+    printf 'main edited this later\n' >"$REPO/feature.txt"
+    git -C "$REPO" add -A
+    git -C "$REPO" commit -q -m "main edits the landed file"
+    git -C "$REPO" push -q origin main
+    run_on_main feat
+    assert_on_main false "main having edited the landed files afterwards"
+}
+
+test_branch_with_no_changes_reads_as_not_on_main() {
+    new_repo empty-branch
+    git -C "$REPO" checkout -q -b feat main
+    git -C "$REPO" commit -q --allow-empty -m "empty"
+    git -C "$REPO" push -q origin feat
+    git -C "$REPO" checkout -q main
+    advance_main
+    run_on_main feat
+    assert_on_main false "a branch introducing no file changes"
+}
+
+test_unreachable_remote_reads_as_not_on_main() {
+    new_repo no-remote
+    commit_branch feat "feature.txt"
+    land_merge feat
+    git -C "$REPO" remote set-url origin "$tmp/does-not-exist.git"
+    run_on_main feat
+    assert_on_main false "a failed fetch"
+}
+
+# --- The lift itself -------------------------------------------------------
+
+test_lifted_step3_block_is_the_hardened_one() {
+    # If the extraction ever grabs the wrong block, or the guard is replaced by
+    # a form that only looks right, the cases above could pass for the wrong
+    # reason.  Assert the two jointly load-bearing halves are what ran.
+    grep -qF -- 'git diff --name-only -z "$MERGE_BASE" "origin/$BRANCH"' "$STEP3" ||
+        fail "lifted Step 3 block does not collect changed paths NUL-delimited"
+    grep -qF -- '-- "${CHANGED[@]}"' "$STEP3" ||
+        fail "lifted Step 3 block does not pass changed paths as a quoted array"
+}
+
+test_lifted_blocks_use_no_bash4_only_constructs() {
+    # Same bar as gastown/tests/test_witness_heartbeat_check.sh: the fleet
+    # includes macOS on bash 3.2.  Comment lines are stripped first -- the
+    # recipe names `mapfile` in a comment explaining why it is not used.
+    local block
+    for block in "$STEP1" "$STEP2A" "$STEP3"; do
+        ! grep -v '^[[:space:]]*#' "$block" |
+            grep -nE 'declare -A|local -A|mapfile|readarray|\$\{[A-Za-z_]+\^|\$\{[A-Za-z_]+,,|&>>|\[\[ -v ' >/dev/null ||
+            fail "$(basename "$block") must stay bash 3.2 compatible"
+    done
+}
+
+test_absent_assignee_is_still_orphaned
+test_closed_assignee_is_still_orphaned
+test_live_assignee_is_not_orphaned
+test_unusable_liveness_map_skips_instead_of_orphaning
+test_empty_map_with_live_sessions_skips
+test_missing_assignee_skips
+test_unreadable_bead_skips
+test_missing_updated_at_skips
+test_bead_touched_mid_cycle_skips
+test_boundary_second_fraction_skips
+test_touch_before_the_recheck_rebuild_still_skips
+test_reassigned_bead_skips
+test_merge_commit_landing_reads_as_on_main
+test_rebased_landing_reads_as_on_main
+test_squashed_landing_reads_as_on_main
+test_unlanded_branch_reads_as_not_on_main
+test_unlanded_branch_with_space_in_path_reads_as_not_on_main
+test_unlanded_branch_with_newline_in_path_reads_as_not_on_main
+test_landed_branch_with_space_in_path_reads_as_on_main
+test_main_touching_the_files_after_landing_reads_as_not_on_main
+test_branch_with_no_changes_reads_as_not_on_main
+test_unreachable_remote_reads_as_not_on_main
+test_lifted_step3_block_is_the_hardened_one
+test_lifted_blocks_use_no_bash4_only_constructs
+
+echo "mol-witness-patrol orphan recovery tests passed"

--- a/scripts/gascity_pack_inference_gate.py
+++ b/scripts/gascity_pack_inference_gate.py
@@ -145,6 +145,43 @@ GASTOWN_BUILD_WORKFLOW_CONTRACTS = {
         "gc session nudge <rig>/{{binding_prefix}}refinery",
         "--labels=warrant",
         "\"gc.routed_to\":\"{{binding_prefix}}dog\"",
+        # recover-orphaned-beads destroys work: it force-closes beads, force-
+        # reassigns them, and deletes worktrees. Every guard standing between a
+        # stale classification and one of those is pinned below, because the
+        # formula is prose and a guard can be dropped in an edit that still
+        # reads as a sensible recipe. Companion executed coverage lives in
+        # gastown/tests/test_mol_witness_patrol_on_main.sh, which lifts the
+        # Step 3 decision block out of this file and runs it.
+        #
+        # One shared liveness-map builder, so Step 1's classification and the
+        # pre-destruction re-check cannot drift apart, and a build failure
+        # returns non-zero rather than an empty map that reads as "all absent".
+        "build_liveness_map() {",
+        "MAP_BUILT_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+        'CYCLE_MAP_BUILT_AT="$MAP_BUILT_AT"',
+        # The pre-destruction verdict: starts false, is only promoted by a check
+        # that provably succeeded, and an unusable map skips instead of orphaning.
+        "STILL_ORPHANED=false",
+        "elif ! build_liveness_map; then",
+        # updated_at is a top-level bead field; read off .metadata it is always
+        # empty and the staleness guard silently never fires. Fractional seconds
+        # must be truncated before the compare, and the compare must be strictly
+        # older, so the boundary second falls on the skip side.
+        "jq -r '.[0].updated_at // empty'",
+        'BEAD_UPDATED_AT="${BEAD_UPDATED_AT%%.*}"',
+        'elif ! [[ "$BEAD_UPDATED_AT" < "$CYCLE_MAP_BUILT_AT" ]]; then',
+        # The rebase/squash content test. `-z` plus the quoted array are jointly
+        # load-bearing: drop either and a path with whitespace or a newline
+        # becomes a pathspec matching nothing, `git diff --quiet` exits 0, and an
+        # unmerged branch reads as merged and is force-closed.
+        'done < <(git diff --name-only -z "$MERGE_BASE" "origin/$BRANCH")',
+        'elif git diff --quiet "origin/main" "origin/$BRANCH" -- "${CHANGED[@]}"; then',
+        # All three destructive sites re-state the verdict. Step 3a is not
+        # redundant with Step 3b: it skips to Step 4, so a guard placed only at
+        # the pool reset would never cover it.
+        'if [ "$STILL_ORPHANED" = "true" ] && [ "$ON_MAIN" = "true" ]; then',
+        'if [ "$STILL_ORPHANED" = "true" ] && [ "$HANDOFF_STAGE" = "target_recorded" ] && [ -n "$BRANCH_ON_ORIGIN" ]; then',
+        'if [ "$STILL_ORPHANED" != "true" ]; then',
     ),
     "mol-deacon-patrol": (
         "Work-layer health",

--- a/tests/test_gascity_pack_inference_gate.py
+++ b/tests/test_gascity_pack_inference_gate.py
@@ -1481,6 +1481,71 @@ def test_gastown_build_workflow_contract_covers_orchestration_roles() -> None:
     assert "gc bd dep add" in contracts["mol-idea-to-plan"]
 
 
+# Guards standing between a stale orphan classification and one of the witness's
+# three destructive outcomes (force-close, force-reassign, worktree deletion).
+# Each must be pinned in the gate contract AND occur exactly once in the formula.
+WITNESS_ORPHAN_GUARD_PINS = (
+    # One shared map builder that reports failure instead of returning an empty
+    # map, and a cycle-scoped watermark the per-candidate rebuild cannot reset.
+    "build_liveness_map() {",
+    "MAP_BUILT_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+    'CYCLE_MAP_BUILT_AT="$MAP_BUILT_AT"',
+    "elif ! build_liveness_map; then",
+    # Fail-closed pre-destruction verdict.
+    "STILL_ORPHANED=false",
+    # Staleness guard: top-level field path, truncated fraction, strict compare.
+    "jq -r '.[0].updated_at // empty'",
+    'BEAD_UPDATED_AT="${BEAD_UPDATED_AT%%.*}"',
+    'elif ! [[ "$BEAD_UPDATED_AT" < "$CYCLE_MAP_BUILT_AT" ]]; then',
+    # Content test: -z and the quoted array are jointly load-bearing.
+    'done < <(git diff --name-only -z "$MERGE_BASE" "origin/$BRANCH")',
+    'elif git diff --quiet "origin/main" "origin/$BRANCH" -- "${CHANGED[@]}"; then',
+    # All three destructive sites re-state the verdict.  Step 3a skips to Step
+    # 4, so a guard placed only at the pool reset would never cover it.
+    'if [ "$STILL_ORPHANED" = "true" ] && [ "$ON_MAIN" = "true" ]; then',
+    'if [ "$STILL_ORPHANED" = "true" ] && [ "$HANDOFF_STAGE" = "target_recorded" ]'
+    ' && [ -n "$BRANCH_ON_ORIGIN" ]; then',
+    'if [ "$STILL_ORPHANED" != "true" ]; then',
+)
+
+
+def test_gastown_witness_patrol_pins_orphan_recovery_guards() -> None:
+    """Every guard on the witness's destructive paths must stay pinned.
+
+    ``recover-orphaned-beads`` force-closes beads, force-reassigns them and
+    deletes worktrees.  The formula is prose, so a guard can be removed by an
+    edit that still reads as a sensible recipe; without a pin per guard the
+    gate stays green while the recipe goes back to destroying live work.
+    Asserting the fragments here means deleting a pin fails as loudly as
+    deleting the guard it protects.
+    """
+    witness = gascity_pack_inference_gate.GASTOWN_BUILD_WORKFLOW_CONTRACTS["mol-witness-patrol"]
+
+    for fragment in WITNESS_ORPHAN_GUARD_PINS:
+        assert fragment in witness, f"unpinned witness orphan-recovery guard: {fragment!r}"
+
+
+def test_gastown_witness_patrol_guard_pins_are_present_in_the_formula() -> None:
+    """The pins must actually match the shipped formula.
+
+    A pin that matches nothing is dead — it can never fail, so it protects
+    nothing.  A guard pin that matches more than once can also be satisfied by
+    narration left behind after the guard itself is deleted, so those are held
+    to exactly one occurrence.  Both failure modes leave the gate green, so
+    check the raw formula text the gate actually reads.
+    """
+    spec = gascity_pack_inference_gate.PACK_SPECS["gastown"]
+    formula = spec.source / "formulas" / "mol-witness-patrol.toml"
+    text = formula.read_text(encoding="utf-8")
+
+    for fragment in gascity_pack_inference_gate.GASTOWN_BUILD_WORKFLOW_CONTRACTS["mol-witness-patrol"]:
+        assert fragment in text, f"dead pin, matches nothing in {formula}: {fragment!r}"
+
+    for fragment in WITNESS_ORPHAN_GUARD_PINS:
+        count = text.count(fragment)
+        assert count == 1, f"{fragment!r} occurs {count} times in {formula}, want exactly 1"
+
+
 def test_build_basic_work_item_targets_code_and_pytest() -> None:
     text = gascity_pack_inference_gate.build_basic_work_item()
 


### PR DESCRIPTION
Fixes #286.

Two independent defects in `mol-witness-patrol.toml`'s
`recover-orphaned-beads` step, both caught live during patrol, both fail
in the silent-destructive direction: the witness logs a normal-looking
recovery while destroying or duplicating real work. This is a shared,
pinned pack — a local patch would be reverted on the next sync, so it
needs a real fix here.

**Defect 1 (high, destructive).** The assignee->state liveness map is
built once per patrol cycle, then consulted for the rest of the per-bead
loop. A polecat that spawns *after* the map is built resolves as
`absent`, which the classification rules treat as orphaned — so a live
agent minutes into real work can have its worktree deleted and its bead
reset to pool out from under it. The existing fail-safe only guards an
*empty* map, not a map that's simply one entry stale.

**Defect 2 (medium, duplicative).** The merge check
(`git merge-base --is-ancestor origin/$BRANCH origin/main`) only holds
when the branch's own commit objects are literally reachable from main —
true for a fast-forward or a real merge commit, but false whenever the
refinery lands the branch by *recreating* its commits (rebase onto a
main that moved since the branch was cut, or a squash). That's the
normal case once a queue has 2+ beads, not an edge case. A false
negative here re-dispatches already-merged work — wasted at best, a
confused re-implementation or conflicting revert at worst.

Confirmed both defects still reproduce verbatim against current
`origin/main` (not just the issue's pinned sha — this file has moved 3
commits since that pin; checked each one's actual diff, none touch this
step's logic). For Defect 2, independently reproduced the false-negative
in a throwaway git repo before writing the fix: a branch rebased onto a
main that had already diverged, then landed, correctly shows
`is-ancestor=false` even though its content is fully on main.

## Fix

- **Defect 1**: Step 3b (the one truly destructive point — right before
  worktree deletion + pool reset) now re-verifies the specific candidate
  orphan's liveness with a fresh single-lookup query immediately before
  acting, plus a second guard comparing the bead's own `updated_at`
  against the Step 1 map's build timestamp (`MAP_BUILT_AT`, newly
  captured). Only candidates that already survived Step 1's orphan
  classification pay the extra lookup.
- **Defect 2**: keeps the ancestor check as a cheap first pass, falls
  back to a content test scoped to the branch's own changed files when
  ancestry says no — holds for fast-forward, merge, rebase, and squash
  alike, since it compares tree content instead of commit-object
  reachability.

Fixed both in one commit — same step, same failure shape, and Defect 1's
fix sits directly downstream of Defect 2's `ON_MAIN` determination in the
same Step 3/3b flow.

## Verification

No test suite exercises this file's prose/recipe semantics — only
`test_gastown_pack_assets.sh`'s TOML-parse/structural checks apply,
which pass. In place of RED/GREEN: reproduced Defect 2's false-negative
and the fix's correction in a throwaway repo (plus confirmed no false
positive on a genuinely unmerged branch), `bash -n` on all three new
embedded bash blocks, verified the fresh-liveness jq query against both
a live and an absent assignee, re-ran the full `gastown/tests/test_*.sh`
suite.

Generated with [Claude Code](https://claude.com/claude-code)
