### PR TITLE
fix(gastown/witness): complete crashed submit-and-exit handoff instead of resetting to pool

### DIFF
--- a/gastown/agents/polecat/prompt.template.md
+++ b/gastown/agents/polecat/prompt.template.md
@@ -87,7 +87,8 @@ Work beads carry structured metadata for lifecycle tracking and handoff:
 |-------|--------|------|-------------|
 | `work_dir` | polecat (branch-setup) | Early | Absolute path to git worktree |
 | `branch` | polecat (branch-setup) | Early | Source branch name |
-| `target` | polecat (submit) | Late | Target branch (default: {{ .DefaultBranch }}) |
+| `target` | caller (sling) or polecat (submit) | Mint-time or Late | Target branch (default: {{ .DefaultBranch }}). `gc sling` accepts it as a mint-time input and nothing ever unsets it, so its presence is **not** a signal that you submitted |
+| `handoff_stage` | polecat (submit step 5) | Late | `target_recorded` once submit has recorded `target`. This — not `target` — is what says submit ran to completion |
 | `existing_pr` | caller | Before dispatch | Existing PR URL to reuse instead of creating another PR |
 | `pr_url` | refinery | PR handoff | Canonical PR URL recorded after validation |
 | `rejection_reason` | refinery (on failure) | On reject | Why the merge was rejected |
@@ -96,12 +97,21 @@ Work beads carry structured metadata for lifecycle tracking and handoff:
 This enables crash recovery — the witness can find and salvage your work.
 
 **On submission:** You update `branch` (may have changed after rebase),
-set `target`, then reassign to refinery. If `existing_pr` is present, leave
-it for refinery to validate and canonicalize into `pr_url`.
+set `target` and `handoff_stage` in the same update, then reassign to
+refinery. If `existing_pr` is present, leave it for refinery to validate and
+canonicalize into `pr_url`. If you die between those two steps, the witness
+reads `handoff_stage` and completes the reassignment for you instead of
+resetting your finished work to the pool.
 
 **On rejection:** The refinery puts the bead back in the pool with
-`rejection_reason` set and the branch intact. A new polecat picks it up,
-sees the existing branch and reason, and resumes instead of redoing everything.
+`rejection_reason` set, `handoff_stage` cleared, and the branch intact. A new
+polecat picks it up, sees the existing branch and reason, and resumes instead
+of redoing everything. Your own workspace-setup clears `handoff_stage` again
+on every fresh attempt, so a stale marker never survives into new work.
+
+The formulas are the source of truth for this contract:
+`mol-polecat-work` writes the marker, `mol-refinery-patrol` and
+workspace-setup clear it, and `mol-witness-patrol` Step 3a is its only reader.
 
 Read metadata:
 ```bash

--- a/gastown/agents/refinery/prompt.template.md
+++ b/gastown/agents/refinery/prompt.template.md
@@ -230,7 +230,12 @@ Never infer a branch name. If `metadata.branch` is missing, reject the bead.
 
 On rebase conflict or test failure:
 1. Put work bead back in pool:
-   `gc bd update $WORK --status=open --assignee="" --set-metadata rejection_reason="..."`
+   `gc bd update $WORK --status=open --assignee="" --set-metadata rejection_reason="..." --unset-metadata handoff_stage`
+
+   Clearing `handoff_stage` is required, not cosmetic, and belongs in the same
+   update as the pool reset: rejection invalidates the polecat's completed
+   submit, and a bead left carrying the marker is one the witness would hand
+   straight back to you as a crash-recovery handoff.
 2. Branch handling depends on failure type:
    - Conflict: leave branch intact (polecat needs it for rebase)
    - Test failure: delete branch (polecat redoes work)

--- a/gastown/agents/witness/prompt.template.md
+++ b/gastown/agents/witness/prompt.template.md
@@ -89,7 +89,11 @@ bead metadata; do not use template-pattern or fixed-prefix matching.
 branch-setup. For each orphaned bead:
 
 1. **Branch on origin** (`metadata.branch` exists, verified on remote) ->
-   worktree disposable. Delete worktree, reset bead to pool.
+   worktree disposable. If the bead also carries
+   `metadata.handoff_stage=target_recorded`, the polecat finished submit
+   through step 5 and only the reassignment is missing: complete that handoff
+   to the refinery (formula Step 3a) rather than discarding finished work.
+   Otherwise delete worktree, reset bead to pool.
 
 2. **Worktree exists, unpushed commits** ->
    commit any remaining uncommitted work (`git add -A && git commit`),

--- a/gastown/formulas/mol-polecat-work.toml
+++ b/gastown/formulas/mol-polecat-work.toml
@@ -83,6 +83,13 @@ if [ -z "$WORK_BEAD_ID" ]; then
   gc runtime drain-ack
   exit 1
 fi
+# Clear any stale handoff marker before touching the work. A fresh attempt on
+# this bead means a prior submit-and-exit step 5 no longer describes it, and a
+# leftover marker would let the witness's Step 3a hand un-submitted work to the
+# refinery if this attempt also crashes. Unconditional on purpose: a bead can
+# arrive here carrying the marker with no rejection_reason (witness pool reset,
+# operator re-sling), so clearing only on the rejection path is not enough.
+gc bd update "$WORK_BEAD_ID" --unset-metadata handoff_stage
 ```
 
 **2. Ensure worktree exists.**
@@ -658,6 +665,7 @@ git branch -D "$BRANCH"              # Branch is pushed; refinery owns it now
 # --append-notes, NEVER --notes — see the note under this block.
 gc bd update "$WORK_BEAD_ID" \
   --set-metadata target={{base_branch}} \
+  --set-metadata handoff_stage=target_recorded \
   --append-notes "Implemented: <brief summary>"
 ```
 Branch was recorded in workspace-setup and is already in metadata.
@@ -682,6 +690,18 @@ the very notes a bare `--notes` would have just deleted. The identity-stamped
 bead record is also the city's anchor against nudge-text spoofing, so a rail
 that silently erases it is a P1, not a formatting nit. The same rule holds
 anywhere a formula writes a note onto a bead it did not create: append.
+
+`handoff_stage=target_recorded` is the stage marker the witness's Step 3a
+uses to recognize a polecat that crashed between this step and step 6 and to
+complete the handoff instead of respinning the work. It must be written here
+and nowhere else: `target` cannot carry that meaning because `gc sling`
+accepts it as a mint-time input, nothing ever unsets it, and it survives
+refinery rejection. Every path that invalidates "step 5 completed" clears the
+marker — `workspace-setup` on each fresh attempt, and both `mol-refinery-patrol`
+rejection paths. Every branch-ready halt in the push gate above
+(`auto_push_false`, `metadata_unreadable`, `no_push_rail_unresolved`) returns
+before this step, as do the push-failure paths, so an unpushed branch never
+carries the marker.
 
 **6. Reassign to refinery:**
 ```bash

--- a/gastown/formulas/mol-refinery-patrol.toml
+++ b/gastown/formulas/mol-refinery-patrol.toml
@@ -233,9 +233,13 @@ gc workflow delete-source $WORK --apply && gc workflow reopen-source $WORK
 gc bd update $WORK \
   --status=open \
   --assignee="" \
+  --unset-metadata handoff_stage \
   --set-metadata rejection_reason="Conflicts with $TARGET at $(git rev-parse origin/$TARGET)" \
   --set-metadata gc.routed_to="${GC_RIG:+$GC_RIG/}{{binding_prefix}}polecat"
 ```
+Clearing `handoff_stage` is required, not cosmetic: rejection invalidates the
+polecat's "submit completed" marker, and leaving it set would let the witness's
+Step 3a hand this already-rejected tip straight back here on the next crash.
 4. Do NOT delete the branch (new polecat needs it for conflict resolution).
 5. Clean up temp branch: `git checkout {{target_branch}} && git branch -D temp`
 6. Pour next patrol iteration before burning:
@@ -334,9 +338,13 @@ TARGET=$(gc bd show $WORK --json | jq -r '.[0].metadata.target // "{{target_bran
      gc bd update $WORK \
        --status=open \
        --assignee="" \
+       --unset-metadata handoff_stage \
        --set-metadata rejection_reason="<failure summary>" \
        --set-metadata gc.routed_to="${GC_RIG:+$GC_RIG/}{{binding_prefix}}polecat"
      ```
+     `handoff_stage` must be cleared here too: this path also deletes the
+     remote branch, so a stale marker would point the witness's Step 3a at
+     work that no longer exists on origin.
    - Delete branch: `git push origin --delete $BRANCH`
    - Clean up: `git checkout "$TARGET" && git branch -D temp`
    - Pour next patrol iteration before burning:

--- a/gastown/formulas/mol-witness-patrol.toml
+++ b/gastown/formulas/mol-witness-patrol.toml
@@ -341,7 +341,55 @@ gc mail send mayor/ -s "ORPHAN_CLOSED: <bead> already merged" \
 ```
 - Clean up worktree and skip to Step 4.
 
-If the work is NOT on main, proceed with reset:
+If the work is NOT on main, check for a completed-but-unhanded-off submit
+before resetting to pool:
+
+**Step 3a: Was this bead already handed off to the refinery step, just not
+reassigned?** (gastownhall/gascity-packs#276)
+
+`submit-and-exit` sets `metadata.target` in its step 5, then reassigns the
+bead to the refinery in step 6 — two separate, independently-interruptible
+`gc bd update` calls. A polecat killed in that exact window (pool reclaim,
+host restart, context exhaustion) has already pushed the branch, run its
+final clean-state check, and recorded `metadata.target`; the only thing it
+never did was the reassignment itself. Resetting a bead in this state to
+pool is safe (no data is lost — `workspace-setup`'s rejection-aware resume
+picks the existing branch back up) but wasteful and confusing: a fresh
+polecat spins up just to re-run branch-shape/clean-state checks and a
+no-op push before reaching the same step 6 the witness can complete
+directly, right now, with the information already on hand.
+
+```bash
+BEAD_TARGET=$(echo "$META" | jq -r '.target // empty')
+BRANCH_READY=$(echo "$META" | jq -r '.branch_ready // empty')
+```
+
+`metadata.target` is set by exactly two places in `submit-and-exit`: step 5
+(the normal path this recovery targets) and the `auto_push=false` early
+halt, which sets `branch_ready=true` in the *same* update — an intentional
+final state, not a crash. Only treat this as a completed-but-unhanded-off
+submit when `target` is set and `branch_ready` is not:
+
+```bash
+if [ -n "$BEAD_TARGET" ] && [ "$BRANCH_READY" != "true" ]; then
+  REFINERY_TARGET="<rig>/{{binding_prefix}}refinery"
+  gc bd update <bead> --status=open --assignee="$REFINERY_TARGET" --set-metadata gc.routed_to=""
+  gc mail send mayor/ -s "ORPHAN_HANDED_OFF: <bead> completed submit, missing only reassignment" \
+    -m "Branch $BRANCH is on origin and metadata.target=$BEAD_TARGET was already recorded -- the crashed polecat had finished submit-and-exit through step 5. Completed step 6 (reassign to refinery) instead of resetting to pool."
+  gc session nudge "$REFINERY_TARGET" "Run 'gc prime' to check merge queue and begin processing." || true
+  # Worktree is disposable, same reasoning as Step 3b:
+  cd <rig-root>
+  git worktree remove <worktree-path> --force 2>/dev/null
+  rm -rf <worktree-path> 2>/dev/null  # Fallback
+  git worktree prune
+  # Skip to Step 4 -- do NOT fall through to Step 3b's pool reset.
+fi
+```
+
+If `metadata.target` is unset, or `branch_ready=true` (an intentional
+`auto_push=false` halt, not a crash), fall through to Step 3b: the crash
+landed earlier than step 5, or this bead was deliberately left branch-ready
+and pool reset is the correct recovery.
 
 **Step 3b: Clean up worktree and return bead to pool.**
 

--- a/gastown/formulas/mol-witness-patrol.toml
+++ b/gastown/formulas/mol-witness-patrol.toml
@@ -347,49 +347,92 @@ before resetting to pool:
 **Step 3a: Was this bead already handed off to the refinery step, just not
 reassigned?** (gastownhall/gascity-packs#276)
 
-`submit-and-exit` sets `metadata.target` in its step 5, then reassigns the
-bead to the refinery in step 6 — two separate, independently-interruptible
-`gc bd update` calls. A polecat killed in that exact window (pool reclaim,
-host restart, context exhaustion) has already pushed the branch, run its
-final clean-state check, and recorded `metadata.target`; the only thing it
-never did was the reassignment itself. Resetting a bead in this state to
-pool is safe (no data is lost — `workspace-setup`'s rejection-aware resume
-picks the existing branch back up) but wasteful and confusing: a fresh
-polecat spins up just to re-run branch-shape/clean-state checks and a
-no-op push before reaching the same step 6 the witness can complete
-directly, right now, with the information already on hand.
+`submit-and-exit` records `handoff_stage=target_recorded` in its step 5, then
+reassigns the bead to the refinery in step 6 — two separate,
+independently-interruptible `gc bd update` calls. A polecat killed in that
+exact window (pool reclaim, host restart, context exhaustion) has already
+pushed the branch, run its final clean-state check, and recorded the stage
+marker; the only thing it never did was the reassignment itself. Resetting a
+bead in this state to pool is safe (no data is lost — `workspace-setup`'s
+rejection-aware resume picks the existing branch back up) but wasteful and
+confusing: a fresh polecat spins up just to re-run branch-shape/clean-state
+checks and a no-op push before reaching the same step 6 the witness can
+complete directly, right now, with the information already on hand.
 
 ```bash
+HANDOFF_STAGE=$(echo "$META" | jq -r '.handoff_stage // empty')
 BEAD_TARGET=$(echo "$META" | jq -r '.target // empty')
-BRANCH_READY=$(echo "$META" | jq -r '.branch_ready // empty')
+BRANCH_ON_ORIGIN=""
+# Query the fully-qualified ref. ls-remote patterns match ref *tails*, so the
+# bare "$BRANCH" form stays truthy for a branch that is NOT on origin whenever
+# a tail-colliding ref outlives it (say an archive/polecat/<id> convention):
+# measured on git 2.43, deleting refs/heads/polecat/tst-1 still returns
+# refs/heads/nested/polecat/tst-1 for the pattern, and 0 lines for the
+# refs/heads/ form. Keep the -n guard too: an unset BRANCH must never be
+# mistaken for a live branch.
+[ -n "$BRANCH" ] && BRANCH_ON_ORIGIN=$(git ls-remote --heads origin "refs/heads/$BRANCH" 2>/dev/null)
 ```
 
-`metadata.target` is set by exactly two places in `submit-and-exit`: step 5
-(the normal path this recovery targets) and the `auto_push=false` early
-halt, which sets `branch_ready=true` in the *same* update — an intentional
-final state, not a crash. Only treat this as a completed-but-unhanded-off
-submit when `target` is set and `branch_ready` is not:
+Key this recovery on `handoff_stage`, **not** on `metadata.target`. `target`
+is not a completion signal: `gc sling` accepts it as a documented mint-time
+input (`mol-polecat-work.toml` workspace-setup resolves `base_branch` from
+`metadata.target` first), nothing in the tree ever unsets it, and it survives
+both `mol-refinery-patrol` rejection paths — so beads that never reached step 5
+already carry it, and keying on it hands already-rejected or never-submitted
+work back to a refinery whose only merge gate is tests-pass.
+`handoff_stage=target_recorded` is written in exactly one place
+(`submit-and-exit` step 5) and cleared in three (`workspace-setup` on every
+fresh attempt, and both refinery rejection paths), so its presence means this
+bead genuinely completed step 5 and nothing has since invalidated that. The
+branch-on-origin conjunct is a fail-closed backstop: there is nothing to hand
+off if the refinery's `--has-metadata-key=branch` query cannot see the work.
 
 ```bash
-if [ -n "$BEAD_TARGET" ] && [ "$BRANCH_READY" != "true" ]; then
-  REFINERY_TARGET="<rig>/{{binding_prefix}}refinery"
-  gc bd update <bead> --status=open --assignee="$REFINERY_TARGET" --set-metadata gc.routed_to=""
-  gc mail send mayor/ -s "ORPHAN_HANDED_OFF: <bead> completed submit, missing only reassignment" \
-    -m "Branch $BRANCH is on origin and metadata.target=$BEAD_TARGET was already recorded -- the crashed polecat had finished submit-and-exit through step 5. Completed step 6 (reassign to refinery) instead of resetting to pool."
-  gc session nudge "$REFINERY_TARGET" "Run 'gc prime' to check merge queue and begin processing." || true
-  # Worktree is disposable, same reasoning as Step 3b:
-  cd <rig-root>
-  git worktree remove <worktree-path> --force 2>/dev/null
-  rm -rf <worktree-path> 2>/dev/null  # Fallback
-  git worktree prune
-  # Skip to Step 4 -- do NOT fall through to Step 3b's pool reset.
+if [ "$HANDOFF_STAGE" = "target_recorded" ] && [ -n "$BRANCH_ON_ORIGIN" ]; then
+  REFINERY_TARGET="${GC_RIG:+$GC_RIG/}{{binding_prefix}}refinery"
+  # --force: this is a cross-actor write against the dead polecat's live
+  # in_progress claim, which bd refuses without it (the same claim guard
+  # Step 3's close cites, gastownhall/beads#3734). Step 6 needs no --force
+  # only because the polecat runs it as the bead's own actor.
+  if gc bd update <bead> --status=open --assignee="$REFINERY_TARGET" \
+       --set-metadata gc.routed_to="" --force; then
+    # Close the crashed polecat's workflow subtree, as Step 3b does. Only the
+    # delete-source half: reopen-source would clear the assignee just set.
+    # Ordered after the reassignment so the failure arm mutates nothing, and
+    # before the wake/nudge so the refinery is never signalled mid-cleanup.
+    # Best-effort, like the wake/nudge below: the reassignment has already
+    # succeeded by the time this runs, so a failure here leaves inert step
+    # beads behind, never an unhandled handoff, and the mail stays truthful.
+    gc workflow delete-source <bead> --apply || true
+    gc mail send mayor/ -s "ORPHAN_HANDED_OFF: <bead> completed submit, missing only reassignment" \
+      -m "Branch $BRANCH is on origin and handoff_stage=target_recorded was already set (target=$BEAD_TARGET) -- the crashed polecat had finished submit-and-exit through step 5. Completed step 6 (reassign to refinery) instead of resetting to pool."
+    # Wake before nudge, exactly as submit-and-exit step 7: the refinery is
+    # an on_demand session with a 2h idle timeout, and nudge alone leaves a
+    # stopped one asleep with the handoff unprocessed.
+    gc session wake "$REFINERY_TARGET" || true
+    gc session nudge "$REFINERY_TARGET" "Run 'gc prime' to check merge queue and begin processing." || true
+    # Worktree is disposable, same reasoning as Step 3b:
+    cd <rig-root>
+    git worktree remove <worktree-path> --force 2>/dev/null
+    rm -rf <worktree-path> 2>/dev/null  # Fallback
+    git worktree prune
+    # Skip to Step 4 -- do NOT fall through to Step 3b's pool reset.
+  else
+    # The reassignment did not happen, and nothing above it mutated anything.
+    # Never mail ORPHAN_HANDED_OFF and never remove the worktree on this path:
+    # claiming a handoff that failed would strand the bead in_progress under a
+    # dead assignee with its worktree gone, and the next patrol would
+    # re-orphan it every cycle. Fall through to Step 3b, which sees exactly
+    # the state it would have seen without Step 3a, and recovers to pool.
+    echo "Step 3a: reassignment of <bead> failed; falling through to Step 3b."
+  fi
 fi
 ```
 
-If `metadata.target` is unset, or `branch_ready=true` (an intentional
-`auto_push=false` halt, not a crash), fall through to Step 3b: the crash
-landed earlier than step 5, or this bead was deliberately left branch-ready
-and pool reset is the correct recovery.
+If `handoff_stage` is unset or the branch is not on origin, fall through to
+Step 3b: the crash landed earlier than step 5, the bead was deliberately left
+branch-ready by an `auto_push=false` halt (which never writes the marker), or
+a rejection cleared it — and pool reset is the correct recovery.
 
 **Step 3b: Clean up worktree and return bead to pool.**
 

--- a/gastown/tests/test_gastown_pack_assets.sh
+++ b/gastown/tests/test_gastown_pack_assets.sh
@@ -336,6 +336,105 @@ test_witness_wisp_queries_pin_include_infra() {
         fail "witness --type=molecule wisp queries must pass --include-infra ($flagged/$total do)"
 }
 
+test_witness_handoff_recovery_is_guarded_and_fail_closed() {
+    local witness polecat refinery block signature writers
+
+    witness="$GASTOWN/formulas/mol-witness-patrol.toml"
+    polecat="$GASTOWN/formulas/mol-polecat-work.toml"
+    refinery="$GASTOWN/formulas/mol-refinery-patrol.toml"
+    parse_toml "$witness" "$polecat" "$refinery"
+
+    # Witness Step 3a completes the refinery handoff for a polecat that died
+    # between submit-and-exit steps 5 and 6 (gastownhall/gascity-packs#276).
+    # It mutates a bead assigned to a dead actor and then deletes its worktree,
+    # so every property below is one that an edit can silently invert while the
+    # formula still parses and the rest of this suite stays green.
+
+    # Placement. A presence-only grep survives moving 3a after 3b, which makes
+    # it dead code for every bead 3b has already returned to pool. A sequence
+    # signature pins order, count, and cardinality together, and pins the
+    # precondition (Step 3's on-main close) rather than 3a alone.
+    signature=$(awk '
+        /^gc bd close <bead> --force$/ { print "step3-close" }
+        /^\*\*Step 3a:/               { print "step3a" }
+        /^\*\*Step 3b:/               { print "step3b" }
+    ' "$witness" | tr '\n' ' ')
+    [[ "$signature" == "step3-close step3a step3b " ]] ||
+        fail "witness recovery must run Step 3's on-main close, then Step 3a, then Step 3b (got: $signature)"
+
+    # Discriminator. metadata.target is a mint-time sling input that nothing
+    # ever unsets and that survives both refinery rejection paths, so keying on
+    # it fires 3a for beads that never submitted -- shipping an already-rejected
+    # or half-finished tip to a refinery whose only merge gate is tests-pass.
+    block=$(awk '/^\*\*Step 3a:/{f=1} /^\*\*Step 3b:/{f=0} f' "$witness")
+    printf '%s\n' "$block" |
+        grep -F 'if [ "$HANDOFF_STAGE" = "target_recorded" ] && [ -n "$BRANCH_ON_ORIGIN" ]; then' >/dev/null ||
+        fail "Step 3a must key the handoff on handoff_stage and a branch that is really on origin"
+    ! printf '%s\n' "$block" | grep -F '[ -n "$BEAD_TARGET" ]' >/dev/null ||
+        fail "Step 3a must not treat metadata.target as a completion signal"
+    # Both halves of the backstop, in one pin. ls-remote patterns match ref
+    # tails, so the bare "$BRANCH" form is truthy for a branch that is not on
+    # origin whenever a tail-colliding ref (archive/polecat/<id>) survives it;
+    # the fully-qualified form measures the property the message below names.
+    printf '%s\n' "$block" |
+        grep -F '[ -n "$BRANCH" ] && BRANCH_ON_ORIGIN=$(git ls-remote --heads origin "refs/heads/$BRANCH"' >/dev/null ||
+        fail "Step 3a must guard the empty branch and query the fully-qualified ref: ls-remote patterns match ref tails"
+
+    # The claim guard and the fail-closed arm. bd refuses a cross-actor
+    # --assignee write against the dead polecat's live in_progress claim
+    # without --force; unchecked, the witness would then mail success, delete
+    # the worktree, and skip the 3b reset that used to recover the bead.
+    printf '%s\n' "$block" | grep -F -- '--set-metadata gc.routed_to="" --force' >/dev/null ||
+        fail "Step 3a's cross-actor reassignment must pass --force"
+    # Failure policy, pinned separately from the ordering signature below so a
+    # change to either reports as itself. delete-source runs after the
+    # reassignment has already succeeded, so it is best-effort like the
+    # wake/nudge: leaving it bare invites a future editor to read it as
+    # load-bearing and abort a handoff that in fact completed.
+    printf '%s\n' "$block" |
+        grep -F 'gc workflow delete-source <bead> --apply || true' >/dev/null ||
+        fail "Step 3a's subtree cleanup must state its best-effort failure policy (|| true), as the wake/nudge do"
+    printf '%s\n' "$block" |
+        grep -F 'REFINERY_TARGET="${GC_RIG:+$GC_RIG/}{{binding_prefix}}refinery"' >/dev/null ||
+        fail "Step 3a must use submit-and-exit step 6's conditional rig prefix for the assignee write"
+
+    # Ordering inside the block, again as a signature: the reassignment's exit
+    # status is the if condition, the subtree cleanup and the success mail,
+    # wake, nudge, and worktree removal all sit inside the success arm ahead of
+    # a real else, and the subtree cleanup precedes the signal so the refinery
+    # is never woken mid-cleanup. Substring pins alone stay green if the mail
+    # is hoisted above the if or the else is dropped -- and every statement
+    # ordered after the if is a statement the failure arm cannot reach, which
+    # is what makes falling through to Step 3b a true no-op.
+    signature=$(printf '%s\n' "$block" | awk '
+        /^  if gc bd update <bead> /                  { print "guarded-update" }
+        /^    gc workflow delete-source <bead> --apply/ { print "delete-source" }
+        /gc mail send mayor\/ -s "ORPHAN_HANDED_OFF/  { print "mail" }
+        /gc session wake "\$REFINERY_TARGET"/         { print "wake" }
+        /gc session nudge "\$REFINERY_TARGET"/        { print "nudge" }
+        /git worktree remove <worktree-path> --force/ { print "worktree-remove" }
+        /^  else$/                                    { print "else" }
+    ' | tr '\n' ' ')
+    [[ "$signature" == "guarded-update delete-source mail wake nudge worktree-remove else " ]] ||
+        fail "Step 3a must check the reassignment's exit status first, then delete the subtree and mail/wake/nudge/clean up in the success arm, and fall through in an else (got: $signature)"
+
+    # The marker contract spans three formulas: one writer, three clearers.
+    # Losing any clearer silently restores the stale-marker over-trigger that
+    # keying on handoff_stage exists to prevent.
+    writers=$(cat "$polecat" "$witness" "$refinery" |
+        grep -c -F -- '--set-metadata handoff_stage=target_recorded' || true)
+    [[ "$writers" -eq 1 ]] ||
+        fail "handoff_stage must be written only by submit-and-exit step 5 (found $writers writers)"
+    grep -F 'gc bd update "$WORK_BEAD_ID" --unset-metadata handoff_stage' "$polecat" >/dev/null ||
+        fail "workspace-setup must clear a stale handoff_stage on every fresh attempt"
+    [[ $(grep -c -F -- '--unset-metadata handoff_stage' "$refinery") -eq 2 ]] ||
+        fail "both refinery rejection paths must clear handoff_stage"
+
+    # 3b keeps its own recovery for everything that falls through.
+    grep -F 'gc workflow delete-source <bead> --apply && gc workflow reopen-source <bead>' "$witness" >/dev/null ||
+        fail "Step 3b must still reopen the source bead for fall-through recoveries"
+}
+
 test_refinery_direct_merge_is_worktree_safe_and_fail_closed() {
     local formula direct_block
     formula="$GASTOWN/formulas/mol-refinery-patrol.toml"
@@ -420,6 +519,7 @@ test_polecat_startup_uses_standard_hook_claim
 test_review_leg_contract_forbids_synthetic_mutation
 test_prime_prompts_are_city_generic_and_compact
 test_witness_wisp_queries_pin_include_infra
+test_witness_handoff_recovery_is_guarded_and_fail_closed
 test_refinery_direct_merge_is_worktree_safe_and_fail_closed
 
 echo "gastown pack asset tests passed"


### PR DESCRIPTION
Fixes #276.

`mol-polecat-work.toml`'s `submit-and-exit` step records
`metadata.target` (step 5) and reassigns the bead to the refinery
(step 6) as two separate, independently interruptible `gc bd update`
calls. A polecat killed in that exact window has already pushed the
branch and run its final clean-state check — everything is done except
the handoff. The reporter hit this for real on four beads in one day and
spent hours of git-reflog/reconciler-trace archaeology confirming
nothing was actually lost.

## Why this wasn't data loss but was still worth fixing

The witness's existing orphan-recovery logic (Case A: branch on origin
-> not yet on main -> Step 3b reset to pool) already handles this
correctly in the sense that no work is lost — `workspace-setup`'s
rejection-aware resume picks the existing branch back up when a new
polecat gets the reopened bead. But it's wasteful (a fresh polecat spins
up just to re-run checks and a no-op push to reach the same step 6) and,
per the reporter, expensive to *diagnose* — the state looks alarming
(open/unassigned, work "gone") even though it isn't.

## Fix

New Step 3a in `gastown/formulas/mol-witness-patrol.toml`, between
Step 3's "not on main" branch and Step 3b's pool reset. When it fires,
the witness completes the handoff directly — the same reassignment
submit-and-exit's own step 6 would have run, the same wake+nudge as its
step 7, the same worktree cleanup Step 3b already does for the identical
reason (the branch is canonical on origin). Otherwise it falls through to
the existing Step 3b reset, unchanged.

**The discriminator is an explicit stage marker, not `target`.** Step 5
now writes `handoff_stage=target_recorded` in the same `gc bd update`
that records `target`, and Step 3a fires only on
`handoff_stage = target_recorded` **and** a live branch on origin.

`target` cannot carry this signal: `gc sling` accepts it as a documented
mint-time input (`workspace-setup` resolves `base_branch` from
`metadata.target` first), nothing in the tree ever unsets it, and it
survives both `mol-refinery-patrol` rejection paths. Beads that never
reached step 5 already carry it, so keying on `target` would hand
never-submitted or already-rejected work to a refinery whose only merge
gate is tests-pass.

`handoff_stage` is a single-purpose marker with a deliberately narrow
contract — **one writer, three clearers**:

| | Site |
|---|---|
| Written | `mol-polecat-work` `submit-and-exit` step 5 (with `target`, one update) |
| Cleared | `mol-polecat-work` `workspace-setup`, on every fresh attempt |
| Cleared | `mol-refinery-patrol`, both rejection paths |

So its presence means the bead genuinely completed step 5 *and* nothing
has since invalidated that. Every branch-ready halt in the push gate
(`auto_push_false`, `metadata_unreadable`, `no_push_rail_unresolved`)
returns before step 5, as do the push-failure paths, so an unpushed
branch never carries the marker. The branch-on-origin conjunct is a
fail-closed backstop — there is nothing to hand off if the refinery's
`--has-metadata-key=branch` query cannot see the work — and it queries
the fully-qualified `refs/heads/$BRANCH`, because `ls-remote` patterns
match ref *tails* and the bare form stays truthy when a tail-colliding
ref outlives the branch.

The reassignment is a **checked `--force` write**: `--force` because this
is a cross-actor write against the dead polecat's still-live
`in_progress` claim, which `bd` refuses otherwise (the same claim guard
Step 3's close cites, gastownhall/beads#3734); checked because the
success arm is the only path that may report success. On failure nothing
above it has mutated anything, so it falls through to Step 3b rather
than mailing `ORPHAN_HANDED_OFF` and removing the worktree — claiming a
handoff that did not happen would strand the bead `in_progress` under a
dead assignee with its worktree gone.

**Root-cause honesty**: true atomicity across push/update/reassign isn't
achievable in bash against an unpredictable kill point — this doesn't
pretend otherwise. It closes the gap from the other side: make the
witness recognize and complete the one specific interrupted state that's
unambiguously safe to complete, rather than trying to prevent the
interruption. The rest of the crash window (before step 5 runs) is
already covered correctly by the existing path this fix doesn't touch.

## Verification

**New static property test** — `gastown/tests/test_gastown_pack_assets.sh`
(+100 lines), in the pack's established style. It pins the parts of this
contract that silently rot if a later edit moves them:

- **Marker census across the three formulas**: exactly *one* writer of
  `--set-metadata handoff_stage=target_recorded`, the `workspace-setup`
  `--unset-metadata handoff_stage`, and exactly *two* refinery clearers.
  Cardinality, not just presence — a second writer reds the suite.
- **Step 3a's position and call order**: a line-anchored sequence
  signature (`guarded-update delete-source mail wake nudge
  worktree-remove else`) asserting 3a sits between Step 3's on-main close
  and Step 3b, that the mail/wake/nudge/cleanup are all *inside* the
  success arm, and that 3b still follows for fall-through states.
- **The discriminator and the exact-ref `ls-remote` form** as literals.

The test was validated by mutation, not just by passing. Each arm was
run against an isolated copy with a green control before and after:

| Mutant | Class | Suite |
|---|---|---|
| Revert the discriminator to the `target`/`branch_ready` form | inversion | **red** |
| Drop `--force` from the reassignment | deletion | **red** |
| Drop one refinery clearer | cardinality | **red** |
| Add a second marker writer | **addition** | **red** |
| Swap the success/failure arms; move 3a after 3b; hoist the mail out of the success arm | ordering | **red** |
| Demote the discriminator to a comment and substitute `if true` | narration | *green* |

The last row is a known and disclosed limit: `grep -F` pins certify that
a literal is present in the file, not that it is live in the executed
block, so commenting a pinned line out keeps them green. The
line-anchored *sequence* pins do not share that blind spot (a comment
breaks the anchor). Closing it properly needs a harness that extracts
and *executes* the block against a stubbed `gc`, which is filed as its
own hardening item rather than papered over with more substring pins.

**Behavior of the block** was checked by execution too: the failure arm
mutates nothing (update-fails → 0 `delete-source`, 0 mail, 0 wake), and
a live `ls-remote` experiment on git 2.43.0 reproduces the ref-tail
behavior the exact-ref form exists to avoid — deleting
`refs/heads/polecat/tst-1` still returns
`refs/heads/nested/polecat/tst-1` for the bare pattern, and 0 lines for
the `refs/heads/` form.

**Suites**: all `gastown/tests/test_*.sh` pass, plus
`tests/test_gascity_pack_inference_gate.py` and
`gascity/tests/test_formula_assets.py`. Note that
`test_formula_assets.py` globs `*.formula.toml` and so does **not** cover
`gastown/formulas/*.toml` — the live consumer for this pack's formulas is
the pack asset suite above, which is why the new pins live there.

Re-verified after rebasing onto current `main`, which independently
rewrote the same `submit-and-exit` step (#273); the two changes are
additive at the same anchor and both sides' pins were confirmed still
live on the merged text.

Touches the same file as #286 (PR #320) but a non-overlapping section —
new Step 3a here vs. Step 3b/3's ancestor+content check there.

Generated with [Claude Code](https://claude.com/claude-code)
