### PR TITLE
fix(gastown/witness): add --include-infra to bd list molecule queries (#324)

### DIFF
--- a/gastown/agents/witness/prompt.template.md
+++ b/gastown/agents/witness/prompt.template.md
@@ -166,8 +166,8 @@ nothing).
 # burn the surplus so restarts never accumulate duplicates. Wisp roots are
 # molecules — filter --type=molecule, never --type=wisp.
 WISP_IDS=$(
-  gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=0 --json | jq -r '.[].id'
-  gc bd list --assignee="$GC_AGENT" --status=open --type=molecule --limit=0 --json | jq -r '.[].id'
+  gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --include-infra --limit=0 --json | jq -r '.[].id'
+  gc bd list --assignee="$GC_AGENT" --status=open --type=molecule --include-infra --limit=0 --json | jq -r '.[].id'
 )
 WISP=$(printf '%s\n' $WISP_IDS | sed -n '1p')           # keep one (prefers in_progress)
 for extra in $(printf '%s\n' $WISP_IDS | sed '1d'); do  # burn any surplus
@@ -203,14 +203,14 @@ If `next-iteration` already ran, do not pour again; run `gc hook`.
 ```bash
 CURRENT_WISP=${GC_BEAD_ID:-}
 if [ -z "$CURRENT_WISP" ]; then
-  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
+  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --include-infra --limit=1 --json | jq -r '.[0].id // empty')
 fi
 # Reconcile queued (open) patrol wisps to exactly one. A prior cycle may have
 # poured a next wisp without burning, or a restart may have raced — keep the
 # first and burn the surplus so wisps never accumulate. Wisp roots are
 # molecules (never --type=wisp, which is not a valid gc bd type and matches
 # nothing).
-OPEN_WISPS=$(gc bd list --assignee="$GC_AGENT" --status=open --type=molecule --limit=0 --json | jq -r '.[].id')
+OPEN_WISPS=$(gc bd list --assignee="$GC_AGENT" --status=open --type=molecule --include-infra --limit=0 --json | jq -r '.[].id')
 ASSIGNED_WISP=$(printf '%s\n' $OPEN_WISPS | sed -n '1p')
 for extra in $(printf '%s\n' $OPEN_WISPS | sed '1d'); do
   gc bd mol burn "$extra" --force

--- a/gastown/agents/witness/prompt.template.md
+++ b/gastown/agents/witness/prompt.template.md
@@ -164,7 +164,10 @@ nothing).
 # Step 1: Reconcile your patrol wisps to exactly one (town ledger, via gc bd).
 # Collect every open/in_progress patrol wisp assigned to you, keep one, and
 # burn the surplus so restarts never accumulate duplicates. Wisp roots are
-# molecules — filter --type=molecule, never --type=wisp.
+# molecules — filter --type=molecule, never --type=wisp. They are also
+# ephemeral, so they live in the wisps tier that gc bd list hides without
+# --include-infra; drop that flag and these queries return [] even when a
+# wisp is assigned, and you pour a duplicate.
 WISP_IDS=$(
   gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --include-infra --limit=0 --json | jq -r '.[].id'
   gc bd list --assignee="$GC_AGENT" --status=open --type=molecule --include-infra --limit=0 --json | jq -r '.[].id'
@@ -209,7 +212,8 @@ fi
 # poured a next wisp without burning, or a restart may have raced — keep the
 # first and burn the surplus so wisps never accumulate. Wisp roots are
 # molecules (never --type=wisp, which is not a valid gc bd type and matches
-# nothing).
+# nothing), and they are ephemeral, so --include-infra is required here too —
+# gc bd list hides the wisps tier without it.
 OPEN_WISPS=$(gc bd list --assignee="$GC_AGENT" --status=open --type=molecule --include-infra --limit=0 --json | jq -r '.[].id')
 ASSIGNED_WISP=$(printf '%s\n' $OPEN_WISPS | sed -n '1p')
 for extra in $(printf '%s\n' $OPEN_WISPS | sed '1d'); do

--- a/gastown/formulas/mol-witness-patrol.toml
+++ b/gastown/formulas/mol-witness-patrol.toml
@@ -531,7 +531,7 @@ keep one open patrol wisp and burn any surplus, so wisps never accumulate.
 Wisp roots are `issue_type=molecule` (never `--type=wisp`, which is not a
 valid gc bd type and matches nothing).
 ```bash
-OPEN_WISPS=$(gc bd list --assignee="$GC_AGENT" --status=open --type=molecule --limit=0 --json | jq -r '.[].id')
+OPEN_WISPS=$(gc bd list --assignee="$GC_AGENT" --status=open --type=molecule --include-infra --limit=0 --json | jq -r '.[].id')
 NEXT=$(printf '%s\n' $OPEN_WISPS | sed -n '1p')
 for extra in $(printf '%s\n' $OPEN_WISPS | sed '1d'); do
   gc bd mol burn "$extra" --force

--- a/gastown/formulas/mol-witness-patrol.toml
+++ b/gastown/formulas/mol-witness-patrol.toml
@@ -529,7 +529,9 @@ Reuse an already-queued wisp instead of pouring a duplicate. A prior cycle
 may have poured a next wisp without burning, or a restart may have raced —
 keep one open patrol wisp and burn any surplus, so wisps never accumulate.
 Wisp roots are `issue_type=molecule` (never `--type=wisp`, which is not a
-valid gc bd type and matches nothing).
+valid gc bd type and matches nothing). They are also ephemeral, so they live
+in the wisps tier that `gc bd list` hides without `--include-infra` — drop that
+flag and this query returns `[]` even when a wisp is already queued.
 ```bash
 OPEN_WISPS=$(gc bd list --assignee="$GC_AGENT" --status=open --type=molecule --include-infra --limit=0 --json | jq -r '.[].id')
 NEXT=$(printf '%s\n' $OPEN_WISPS | sed -n '1p')

--- a/gastown/tests/test_gastown_pack_assets.sh
+++ b/gastown/tests/test_gastown_pack_assets.sh
@@ -179,6 +179,40 @@ test_review_leg_contract_forbids_synthetic_mutation() {
         fail "polecat prompt must not globally forbid review-leg close steps"
 }
 
+test_witness_wisp_queries_pin_include_infra() {
+    local prompt formula total flagged
+    prompt="$GASTOWN/agents/witness/prompt.template.md"
+    formula="$GASTOWN/formulas/mol-witness-patrol.toml"
+
+    # Wisp roots are ephemeral, so gc bd list skips the wisps tier unless
+    # --include-infra is passed: a wisp-reconcile query without it returns []
+    # even when a wisp is assigned, and the witness pours a duplicate. That
+    # regressed once already, so pin the flag rather than trust the comments.
+    # Deliberately witness-scoped: the refinery and deacon patrol queries
+    # still carry the bare form and are tracked separately in #252, so a
+    # pack-wide assertion would fail here instead of guarding this contract.
+    total=$(grep -h -- '--type=molecule' "$prompt" "$formula" |
+        grep -c -F 'gc bd list' || true)
+    flagged=$(grep -h -- '--type=molecule' "$prompt" "$formula" |
+        grep -F 'gc bd list' | grep -c -- '--include-infra' || true)
+
+    # -ge, not -eq: the flagged/total assertion below owns the contract, so an
+    # exact count only adds a cardinality pin -- and a legitimate sixth query,
+    # or a prose line that happens to name all three tokens counted above,
+    # then fails the suite with nothing wrong. Measured: -ge holds every
+    # regression mode red (flag stripped from a prompt query, from the formula
+    # query, a query site deleted, an unflagged sixth site) while dropping
+    # both false positives. A prose line carrying the query tokens but not the
+    # flag still fails -- loud, in the safe direction. Requiring --json on
+    # counted lines would silence that last one too, but it is not a
+    # substitute: it stops counting any query that does not pipe to jq, so an
+    # unflagged new site written without --json passes silently.
+    [[ "$total" -ge 5 ]] ||
+        fail "expected at least 5 witness --type=molecule wisp queries (4 prompt + 1 formula), found $total"
+    [[ "$flagged" -eq "$total" ]] ||
+        fail "witness --type=molecule wisp queries must pass --include-infra ($flagged/$total do)"
+}
+
 test_refinery_direct_merge_is_worktree_safe_and_fail_closed() {
     local formula direct_block
     formula="$GASTOWN/formulas/mol-refinery-patrol.toml"
@@ -261,6 +295,7 @@ test_composition_is_documented
 test_polecat_startup_uses_standard_hook_claim
 test_review_leg_contract_forbids_synthetic_mutation
 test_prime_prompts_are_city_generic_and_compact
+test_witness_wisp_queries_pin_include_infra
 test_refinery_direct_merge_is_worktree_safe_and_fail_closed
 
 echo "gastown pack asset tests passed"


### PR DESCRIPTION
Fixes #324.

`gc bd list --type=molecule` (without `--include-infra`) hides molecule wisps by default, so the witness startup protocol and `mol-witness-patrol`'s `next-iteration` reconcile step both see `[]` even when a wisp is actually assigned. Live impact reported: a patrol cycle poured a wisp, the next session's startup check saw nothing, poured a duplicate -- the surplus had to be burned manually. Found by the reporter's own witness in production.

**Fix:** added `--include-infra` to all 5 confirmed call sites (4 in `agents/witness/prompt.template.md` at lines 169, 170, 206, 213; 1 in `formulas/mol-witness-patrol.toml`, shifted slightly to line 534 since the issue was filed against an older `main`). Confirmed all 5 sites and line numbers against current `origin/main` before editing; also checked for an `examples/gastown/packs/gastown/` mirror copy the issue flagged as "if that copy is also shipped" -- it does not exist in this repo, so no extra site there.

**Verification:** no unit-test harness exists for prompt/formula shell content specifically, so verification was exact-match grep against the issue's report before editing (confirmed the bug pattern present), then grep-confirmed all 5 sites carry `--include-infra` after. `gastown/tests/test_gastown_pack_assets.sh` and `tests/test_no_bare_bd_commands.py` pass. Full pytest suite (`tests/`, `gastown/tests/`, `gascity/tests/`): 285 passed, 8 skipped (pre-existing), 9435 subtests, no regressions. `gastown/tests/test_witness_heartbeat_check.sh` fails, but reproduces identically on unmodified `origin/main` (GNU `date -d` vs macOS BSD `date`) -- confirmed pre-existing and unrelated.

**Flagging, not fixed here:** the same `--type=molecule` pattern (without `--include-infra`) also appears in `agents/refinery/`, `agents/deacon/`, `formulas/mol-deacon-patrol.toml`, and `formulas/mol-refinery-patrol.toml`, all on `--status=in_progress` queries. Could not get a live Dolt server running locally to confirm those hit the same infra-exclusion path this issue's `--status=open` repro demonstrated, so left untouched rather than guess. If `bd list --status=in_progress --type=molecule --json` (no `--include-infra`) on a live rig comes back empty when it shouldn't, that's the same bug hitting deacon/refinery's "am I mid-wisp" resume check too, and would be a larger follow-up fix.

---

Generated with [Claude Code](https://claude.com/claude-code)