### PR TITLE
compound-implementation: carry the coordinator steps directly instead of extending implement

### DIFF
--- a/compound-engineering/assets/workflows/compound-implementation/prepare.md
+++ b/compound-engineering/assets/workflows/compound-implementation/prepare.md
@@ -1,0 +1,33 @@
+
+Validate graph.v2 target state before side effects.
+
+This step is validation only. Do not edit source files in the launcher checkout,
+any existing worktree, or any newly created path. Do not create, modify, or commit source code. Do not run implementation or test-fix loops.
+
+Requirements:
+- identify the current claimed step bead from `CLAIMED_BEAD_ID` in the startup
+  claim output, or `$GC_BEAD_ID` if the claim output did not expose one;
+  hard-fail if neither value is present
+- read the claimed step JSON with `gc bd show "$CLAIMED_BEAD_ID" --json`, then
+  read the current workflow root id from `metadata["gc.root_bead_id"]`
+- read the current workflow root JSON with `gc bd show "$ROOT_ID" --json`
+- resolve the implementation input convoy from the current workflow root
+  metadata key `gc.input_convoy_id`
+- verify the resolved input convoy id matches rendered runtime convoy
+  `{{convoy_id}}`
+- validate that input bead is a convoy or normalized singleton convoy with
+  `gc bd show "<gc.input_convoy_id>" --json` before treating it as implementation
+  work
+- do not search repo, plan, report, artifact, session-log, or runtime files for
+  convoy ids; stale files are not graph context
+- hard-fail if metadata is missing, malformed, or ambiguous
+- fail if the target is not a convoy or normalized singleton convoy
+- reject legacy `issue`, `bead_id`, or user-supplied `convoy_id` inputs
+- validate context_path {{context_path}} with `{{pack_root}}/assets/scripts/validate_context_bundle.py` when set
+- reject drain_policy {{drain_policy}} values other than `separate` or `same-session`
+- inspect the convoy target branch, defaulting to the repo default branch
+- write a run-status artifact if summary_path {{summary_path}} or artifact root is provided
+- record push {{push}} and open_pr {{open_pr}}
+
+Close pass only after no workflow roots, drain controls, routed beads,
+worktrees, refs, or publish records have been created before validation.

--- a/compound-engineering/assets/workflows/compound-implementation/publish.md
+++ b/compound-engineering/assets/workflows/compound-implementation/publish.md
@@ -1,0 +1,13 @@
+
+If push {{push}} or open_pr {{open_pr}} are explicit opt-ins, publish only
+after the direct implementation summary has completed successfully. Resolve the
+publish report from summary_path {{summary_path}} when set; otherwise read the
+`gc.implementation.summary_path` value recorded by the summarize step in
+workflow root metadata. Fail closed if no absolute summary report path is
+available.
+
+Direct implement does not run gap-analysis or review loops. Treat this as an
+explicit caller authorization to publish the direct implementation result, and
+use the same protected-branch, lease-safe push, sanitized PR title/body, and
+collision checks as the pack publish helper. If neither push nor open_pr is an
+explicit opt-in, close with `gc.outcome=pass` without mutating remotes.

--- a/compound-engineering/assets/workflows/compound-implementation/summarize.md
+++ b/compound-engineering/assets/workflows/compound-implementation/summarize.md
@@ -1,0 +1,52 @@
+
+Write the aggregate implementation summary, including selected anchors, drain
+policy, item result classes, report paths, commit refs when available, and any
+operator recovery instructions. Direct implement does not run gap-analysis or
+review loops. Publish settings are push {{push}} and open_pr {{open_pr}}.
+
+Write to summary_path {{summary_path}} when provided; otherwise use the default
+implementation summary path for the workflow run. Update workflow root metadata
+with `gc.implementation.summary_path=<absolute path>` so the optional publish
+step has an explicit report path to consume. Write the summary as a
+`gc.build.implementation-summary.v1` artifact.
+The summary body must contain these exact schema-required `##` headings in this
+order:
+
+- `## Summary`
+- `## Intended Behavior`
+- `## Changed Files`
+- `## Verification`
+- `## Remaining Risks`
+
+Include a Markdown coverage table. The validator only recognizes a table with
+an `ID` column and a `Status` column. Use this shape:
+
+| ID | Status |
+| --- | --- |
+| REQ-001 | covered |
+
+Use mapping objects for front matter; do not use scalar shortcuts such as
+`workflow: implement`. The top-level YAML shape must be:
+
+- `schema: gc.build.implementation-summary.v1`
+- `workflow: {id: <workflow-root-id>, formula: implement}`
+- `methodology: {pack: gascity, name: implement}`
+- `producer: {formula: implement, stage: summarize, attempt: <positive integer>}`
+- `status: approved` or another schema-allowed status
+- `trace: {upstream: [...], coverage: [...]}`
+
+Trace front matter must use the validator shape exactly:
+
+- `trace.upstream[]` entries must include `path` and `hash`; do not use
+  `id`/`title`/`type` entries as the upstream shape.
+- For source anchor beads, use `path: beads/<bead-id>` and `hash: bead:<bead-id>`.
+  For changed files, item summaries, or upstream build artifacts, use
+  repo-relative paths and scheme-qualified hashes such as `sha256:<digest>` or
+  `git:<revision>`.
+- If an upstream entry lists `ids`, every listed id must appear exactly once in
+  `trace.coverage` and in the Markdown coverage table with the same status.
+- Coverage statuses are not artifact statuses. Use `covered` for satisfied
+  requirements; do not use `approved` in `trace.coverage[].status` or the
+  Markdown coverage table.
+
+Artifact validation: this step is gated by `.gc/scripts/checks/build-artifact-valid.sh`, which validates the summary recorded at `gc.implementation.summary_path` (fallback `gc.var.summary_path`) against schema `gc.build.implementation-summary.v1`. Before closing this step, read the launcher rig root from the workflow root bead's `gc.work_dir`, then run the same validator locally from that rig root with `GC_BEAD_ID=<claimed-step-id> .gc/scripts/checks/build-artifact-valid.sh`; fix every reported validation error before setting `gc.outcome=pass`. On repair attempts (`gc.attempt` greater than 1), read the validator errors from `gc.attempt_log` on the validation loop control bead (the dependent of this step bead) and repair the summary in place instead of rewriting it. Two bounded repair attempts follow the first failure; exhausting them closes this stage with `gc.outcome=fail` and machine-readable validation errors that block downstream stages. Never ask questions in headless mode; record unresolved ambiguity inside the summary.

--- a/compound-engineering/assets/workflows/compound-implementation/wait-for-drain.md
+++ b/compound-engineering/assets/workflows/compound-implementation/wait-for-drain.md
@@ -1,0 +1,13 @@
+
+Wait only on the core drain control bead and its `gc.drain_manifest.v1` rows.
+Success requires the drain control to be closed with `gc.drain_state=succeeded`
+and `gc.outcome=pass`, and every manifest row to have `status=succeeded` and
+`outcome_kind=pass` or a selected source anchor already closed with
+`gc.outcome=pass`. Failed, skipped, abandoned, or still-open manifest rows make
+implement fail and write the aggregate summary.
+
+Do not wait for or inspect downstream steps that depend on this bead, including
+summarize, workflow-finalize, or root workflow closure; those cannot progress
+until this bead closes. Do not close the input convoy head or the root workflow.
+On success, close only this wait step with `gc.outcome=pass`. Summary path
+override is {{summary_path}}.

--- a/compound-engineering/formulas/compound-implementation.formula.toml
+++ b/compound-engineering/formulas/compound-implementation.formula.toml
@@ -1,17 +1,59 @@
 description = """
 Compound Engineering implementation of the public implement methodology contract.
+
+Self-contained coordinator: this formula carries the convoy-first coordinator
+steps directly (prepare, drain, wait, summarize, publish) instead of extending
+the base `implement` formula, so deployments that have retired `implement`
+from their catalogs can still run Compound Engineering lanes. The drain lanes
+delegate to compound-work / compound-work-item, which extend do-work /
+do-work-item.
+
+Launch inputs:
+- input_convoy: {{convoy_id}}
+- context_path: {{context_path}} (empty means no extra context bundle)
+- drain_policy: {{drain_policy}}
+- implementation_target: {{implementation_target}}
+- summary_path: {{summary_path}} (empty means use the default implementation summary)
+- push: {{push}}
+- open_pr: {{open_pr}}
 """
 formula = "compound-implementation"
-version = 1
+version = 2
 contract = "graph.v2"
-extends = ["implement"]
 target_required = true
 internal = true
+sling_container_mode = "source"
 
 [vars]
+[vars.context_path]
+description = "Optional context bundle path with name/path/description entries."
+default = ""
+
+[vars.drain_policy]
+description = "Implementation drain policy: separate or same-session."
+default = "separate"
+
 [vars.implementation_target]
 description = "Compound Engineering task implementation role."
 default = "compound-engineering.ce-work"
+
+[vars.summary_path]
+description = "Optional aggregate implementation summary path."
+default = ""
+
+[vars.push]
+description = "Set true to allow publish push after direct implementation succeeds."
+default = "false"
+
+[vars.open_pr]
+description = "Set true to allow publish PR creation after direct implementation succeeds."
+default = "false"
+
+[[steps]]
+id = "prepare"
+title = "Validate implementation convoy"
+metadata = { "gc.run_target" = "gc.run-operator" }
+description_file = "../assets/workflows/compound-implementation/prepare.md"
 
 [[steps]]
 id = "drain-separate"
@@ -42,3 +84,32 @@ member_access = "exclusive"
 
 [steps.drain.item]
 single_lane = true
+
+[[steps]]
+id = "wait-for-drain"
+title = "Wait for drain completion"
+needs = ["drain-separate", "drain-same-session"]
+metadata = { "gc.run_target" = "gc.run-operator" }
+description_file = "../assets/workflows/compound-implementation/wait-for-drain.md"
+
+[[steps]]
+id = "summarize"
+title = "Write implementation summary"
+needs = ["wait-for-drain"]
+metadata = { "gc.run_target" = "gc.run-operator", "gc.build.artifact_schema" = "gc.build.implementation-summary.v1", "gc.build.artifact_path_keys" = "gc.implementation.summary_path,gc.var.summary_path" }
+description_file = "../assets/workflows/compound-implementation/summarize.md"
+
+[steps.check]
+max_attempts = 3
+
+[steps.check.check]
+mode = "exec"
+path = ".gc/scripts/checks/build-artifact-valid.sh"
+timeout = "5m"
+
+[[steps]]
+id = "publish"
+title = "Optionally publish direct implementation"
+needs = ["summarize"]
+metadata = { "gc.run_target" = "gc.publisher" }
+description_file = "../assets/workflows/compound-implementation/publish.md"


### PR DESCRIPTION
## Problem

The compound-engineering pack is half-migrated off the base `implement` lane: `compound-work` and `compound-work-item` already extend `do-work` / `do-work-item`, but the `compound-implementation` coordinator still declares `extends = ["implement"]`.

Deployments that have retired `implement` from their catalogs cannot compile any Compound Engineering lane through it. (Context: bare `implement` defaults `push=false` / `open_pr=false`, so slung work closes `pass` with nothing published — a stranding trap that led at least one production city to tombstone the formula at the compiler gate. Any formula extending it is then refused, which currently blocks compound-engineering trials there.)

## Change

Make `compound-implementation` self-contained: inline the five inherited coordinator pieces (launch-input vars and the `prepare`, `wait-for-drain`, `summarize`, `publish` steps) verbatim from `implement`, with the step prompts copied into this pack's assets so `description_file` paths stay pack-relative. The two drain steps were already fully overridden here, so this drops the last dependency on `implement`.

Behavior is byte-identical for deployments that still ship `implement`.

## Verification

Fresh throwaway city importing this branch by sha alongside the `gascity` base pack:

- `gc formula show compound-implementation --json` — compiles, 9 steps
- `gc formula show compound-build --json` — compiles, **106 steps, unchanged** from the pre-change compile of v0.4.0
- `gc formula show compound-work / compound-work-item` — compile (7 / 5 steps)
- cached pack content confirms no `extends` remains in `compound-implementation.formula.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)