### PR TITLE
fix: five reported pack defects, and the green suites that hid them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,14 @@ jobs:
         run: python3 validate_registry.py --require-git
 
       - name: Run Python pack tests
-        run: python3 -m pytest tests contributing/tests gascity/tests discord/tests github/tests slack-full/tests slack-channel/tests pr-pipeline/tests profiler/tests -q
+        # oversight-rig/tests existed on disk and was absent from this list, so
+        # its tests had never run in CI. The list stays explicit (pytest
+        # discovery from the root would sweep vendored and fixture trees), and
+        # tests/test_ci_covers_every_test_directory.py fails when a */tests
+        # directory holding test_*.py is missing from it. gastown/tests is
+        # deliberately absent: it holds shell tests only, run by the
+        # "Run Gastown shell tests" step below.
+        run: python3 -m pytest tests contributing/tests gascity/tests discord/tests github/tests oversight-rig/tests slack-full/tests slack-channel/tests pr-pipeline/tests profiler/tests -q
 
       - name: Lint and exercise shared role prompt composition
         run: |

--- a/bmad/formulas/bmad-build.formula.toml
+++ b/bmad/formulas/bmad-build.formula.toml
@@ -7,9 +7,11 @@ epics/stories so it matches the upstream workflow.
 """
 formula = "bmad-build"
 version = 1
-contract = "graph.v2"
 extends = ["build-base"]
 target_required = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "bmad-build"

--- a/bmad/formulas/bmad-code-review-flow.formula.toml
+++ b/bmad/formulas/bmad-code-review-flow.formula.toml
@@ -7,7 +7,9 @@ review lanes, including gap analysis, with synthesis and fix application.
 formula = "bmad-code-review-flow"
 type = "expansion"
 version = 1
-contract = "graph.v2"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/bmad/formulas/bmad-decomposition.formula.toml
+++ b/bmad/formulas/bmad-decomposition.formula.toml
@@ -3,10 +3,12 @@ BMAD implementation of the decomposition-base methodology contract.
 """
 formula = "bmad-decomposition"
 version = 1
-contract = "graph.v2"
 extends = ["decomposition-base"]
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [[steps]]
 id = "decompose"

--- a/bmad/formulas/bmad-fix-loop.formula.toml
+++ b/bmad/formulas/bmad-fix-loop.formula.toml
@@ -3,10 +3,12 @@ BMAD implementation of the fix-loop-base methodology contract.
 """
 formula = "bmad-fix-loop"
 version = 1
-contract = "graph.v2"
 extends = ["fix-loop-base"]
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_formula]

--- a/bmad/formulas/bmad-implementation.formula.toml
+++ b/bmad/formulas/bmad-implementation.formula.toml
@@ -3,10 +3,12 @@ BMAD implementation of the public implement methodology contract.
 """
 formula = "bmad-implementation"
 version = 1
-contract = "graph.v2"
 extends = ["implement"]
 target_required = true
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/bmad/formulas/bmad-planning.formula.toml
+++ b/bmad/formulas/bmad-planning.formula.toml
@@ -3,10 +3,12 @@ BMAD implementation of the planning-base methodology contract.
 """
 formula = "bmad-planning"
 version = 1
-contract = "graph.v2"
 extends = ["planning-base"]
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [[steps]]
 id = "requirements"

--- a/bmad/formulas/bmad-review.formula.toml
+++ b/bmad/formulas/bmad-review.formula.toml
@@ -3,11 +3,13 @@ BMAD implementation of the code-review-base methodology contract.
 """
 formula = "bmad-review"
 version = 1
-contract = "graph.v2"
 extends = ["code-review-base"]
 target_required = false
 internal = true
 mode = "report"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/bmad/formulas/bmad-story-development-item.formula.toml
+++ b/bmad/formulas/bmad-story-development-item.formula.toml
@@ -6,11 +6,13 @@ shared drain lifecycle and serializes item work.
 """
 formula = "bmad-story-development-item"
 version = 1
-contract = "graph.v2"
 extends = ["do-work-item"]
 target_required = true
 internal = true
 single_lane = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [[steps]]
 id = "implement-item"

--- a/bmad/formulas/bmad-story-development.formula.toml
+++ b/bmad/formulas/bmad-story-development.formula.toml
@@ -6,9 +6,11 @@ implementation and review lanes.
 """
 formula = "bmad-story-development"
 version = 1
-contract = "graph.v2"
 extends = ["do-work"]
 target_required = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [[steps]]
 id = "implement"

--- a/bmad/pack.toml
+++ b/bmad/pack.toml
@@ -2,6 +2,14 @@
 name = "bmad"
 version = "0.1.0"
 schema = 2
+# Minimum gc version. The formulas in this pack declare
+# [requires] formula_compiler, a table gc only learned to read in v1.3.0;
+# older gc parses the formula leniently and drops the declaration, so a
+# formula using graph-only constructs fails to compile and one that does
+# not silently takes the v1 path. gc parses this key today and does not
+# yet enforce it -- it is the declared floor, not a guarantee.
+requires_gc = ">=1.3.0"
+
 
 [imports.gc]
 source = "../gascity"

--- a/compound-engineering/formulas/compound-build.formula.toml
+++ b/compound-engineering/formulas/compound-build.formula.toml
@@ -7,9 +7,11 @@ is a finalize-stage behavior.
 """
 formula = "compound-build"
 version = 1
-contract = "graph.v2"
 extends = ["build-base"]
 target_required = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "compound-build"

--- a/compound-engineering/formulas/compound-code-review.formula.toml
+++ b/compound-engineering/formulas/compound-code-review.formula.toml
@@ -10,7 +10,9 @@ invoked.
 formula = "compound-code-review"
 type = "expansion"
 version = 1
-contract = "graph.v2"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/compound-engineering/formulas/compound-decomposition.formula.toml
+++ b/compound-engineering/formulas/compound-decomposition.formula.toml
@@ -3,10 +3,12 @@ Compound Engineering implementation of the decomposition-base methodology contra
 """
 formula = "compound-decomposition"
 version = 1
-contract = "graph.v2"
 extends = ["decomposition-base"]
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [[steps]]
 id = "decompose"

--- a/compound-engineering/formulas/compound-fix-loop.formula.toml
+++ b/compound-engineering/formulas/compound-fix-loop.formula.toml
@@ -3,10 +3,12 @@ Compound Engineering implementation of the fix-loop-base methodology contract.
 """
 formula = "compound-fix-loop"
 version = 1
-contract = "graph.v2"
 extends = ["fix-loop-base"]
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_formula]

--- a/compound-engineering/formulas/compound-implementation.formula.toml
+++ b/compound-engineering/formulas/compound-implementation.formula.toml
@@ -3,10 +3,12 @@ Compound Engineering implementation of the public implement methodology contract
 """
 formula = "compound-implementation"
 version = 1
-contract = "graph.v2"
 extends = ["implement"]
 target_required = true
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/compound-engineering/formulas/compound-plan-review.formula.toml
+++ b/compound-engineering/formulas/compound-plan-review.formula.toml
@@ -8,7 +8,9 @@ all execution is routed through Gas City `gc.*` agents.
 formula = "compound-plan-review"
 type = "expansion"
 version = 1
-contract = "graph.v2"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [[template]]
 id = "{target}.setup-compound-plan-review"

--- a/compound-engineering/formulas/compound-planning.formula.toml
+++ b/compound-engineering/formulas/compound-planning.formula.toml
@@ -3,10 +3,12 @@ Compound Engineering implementation of the planning-base methodology contract.
 """
 formula = "compound-planning"
 version = 1
-contract = "graph.v2"
 extends = ["planning-base"]
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [[steps]]
 id = "requirements"

--- a/compound-engineering/formulas/compound-resolution.formula.toml
+++ b/compound-engineering/formulas/compound-resolution.formula.toml
@@ -8,7 +8,9 @@ and records a single build-base finalize result.
 formula = "compound-resolution"
 type = "expansion"
 version = 1
-contract = "graph.v2"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [[template]]
 id = "{target}.inventory-artifacts"

--- a/compound-engineering/formulas/compound-review.formula.toml
+++ b/compound-engineering/formulas/compound-review.formula.toml
@@ -3,11 +3,13 @@ Compound Engineering implementation of the code-review-base methodology contract
 """
 formula = "compound-review"
 version = 1
-contract = "graph.v2"
 extends = ["code-review-base"]
 target_required = false
 internal = true
 mode = "report"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/compound-engineering/formulas/compound-work-item.formula.toml
+++ b/compound-engineering/formulas/compound-work-item.formula.toml
@@ -6,11 +6,13 @@ without creating an isolated source-anchor worktree.
 """
 formula = "compound-work-item"
 version = 1
-contract = "graph.v2"
 extends = ["do-work-item"]
 target_required = true
 internal = true
 single_lane = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/compound-engineering/formulas/compound-work.formula.toml
+++ b/compound-engineering/formulas/compound-work.formula.toml
@@ -6,9 +6,11 @@ top of Gas City's source-anchor worktree lifecycle.
 """
 formula = "compound-work"
 version = 1
-contract = "graph.v2"
 extends = ["do-work"]
 target_required = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/compound-engineering/pack.toml
+++ b/compound-engineering/pack.toml
@@ -2,6 +2,14 @@
 name = "compound-engineering"
 version = "0.1.0"
 schema = 2
+# Minimum gc version. The formulas in this pack declare
+# [requires] formula_compiler, a table gc only learned to read in v1.3.0;
+# older gc parses the formula leniently and drops the declaration, so a
+# formula using graph-only constructs fails to compile and one that does
+# not silently takes the v1 path. gc parses this key today and does not
+# yet enforce it -- it is the declared floor, not a guarantee.
+requires_gc = ">=1.3.0"
+
 
 [imports.gc]
 source = "../gascity"

--- a/discord/tests/test_discord_intake_common.py
+++ b/discord/tests/test_discord_intake_common.py
@@ -17,12 +17,72 @@ sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
 
 import discord_intake_common as common
 
+# Every environment-variable prefix this pack's modules read. setUp strips
+# these so a test never inherits the developer's live city; the guard test
+# below re-derives the variable list from the module source and fails if a
+# new read falls outside the prefixes.
+MODULE_ENV_PREFIXES = ("GC_",)
+
+
+def _env_vars_read_by(*module_paths: pathlib.Path) -> set[str]:
+    """Enumerate os.environ keys the given modules read, from their AST."""
+    import ast
+
+    def is_environ(node: ast.AST) -> bool:
+        # os.environ  |  environ (from os import environ)
+        if isinstance(node, ast.Attribute):
+            return node.attr == "environ" and isinstance(node.value, ast.Name)
+        return isinstance(node, ast.Name) and node.id == "environ"
+
+    found: set[str] = set()
+    for path in module_paths:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            # os.environ.get("X") / os.getenv("X")
+            if isinstance(node, ast.Call) and node.args:
+                func = node.func
+                if isinstance(func, ast.Attribute) and isinstance(
+                    node.args[0], ast.Constant
+                ):
+                    reads_env = (
+                        func.attr in {"get", "setdefault", "pop"}
+                        and is_environ(func.value)
+                    ) or (
+                        func.attr == "getenv"
+                        and isinstance(func.value, ast.Name)
+                        and func.value.id == "os"
+                    )
+                    value = node.args[0].value
+                    if reads_env and isinstance(value, str):
+                        found.add(value)
+            # os.environ["X"]
+            if (
+                isinstance(node, ast.Subscript)
+                and is_environ(node.value)
+                and isinstance(node.slice, ast.Constant)
+                and isinstance(node.slice.value, str)
+            ):
+                found.add(node.slice.value)
+    return found
+
 
 class DiscordIntakeCommonTests(unittest.TestCase):
     def setUp(self) -> None:
         self.tempdir = tempfile.TemporaryDirectory()
         self.addCleanup(self.tempdir.cleanup)
         self._old_environ = os.environ.copy()
+        # Clear the ambient city before pinning the fixture one. A Gas
+        # City agent seat exports GC_API_BASE_URL, GC_CITY_PATH,
+        # GC_SESSION_NAME and friends into every process it spawns, and
+        # this module reads them at a HIGHER precedence than the city.toml
+        # the fixture writes. Setting GC_CITY_ROOT alone left those in
+        # place, so 13 tests here passed in CI (where no city exists) and
+        # failed on any machine actually running Gas City — green for a
+        # reason unrelated to the code under test. Enumerated from the
+        # module source and held there by
+        # test_env_prefixes_cover_every_variable_the_module_reads.
+        for key in [k for k in os.environ if k.startswith(MODULE_ENV_PREFIXES)]:
+            del os.environ[key]
         os.environ["GC_CITY_ROOT"] = self.tempdir.name
 
     def tearDown(self) -> None:
@@ -3058,6 +3118,27 @@ class DiscordIntakeCommonTests(unittest.TestCase):
 
         request = urlopen.call_args.args[0]
         self.assertNotIn("Authorization", request.headers)
+
+    def test_env_prefixes_cover_every_variable_the_module_reads(self) -> None:
+        # Keeps MODULE_ENV_PREFIXES honest. Without this, adding a read of
+        # some FOO_BAR variable to the module would silently reintroduce
+        # the ambient-environment leak setUp exists to close, and every
+        # test here would still be green.
+        scripts = pathlib.Path(__file__).resolve().parents[1] / "scripts"
+        read = _env_vars_read_by(
+            scripts / "discord_intake_common.py",
+            scripts / "discord_intake_service.py",
+        )
+        self.assertTrue(read, "AST enumeration found no env reads at all")
+        uncovered = sorted(
+            name for name in read if not name.startswith(MODULE_ENV_PREFIXES)
+        )
+        self.assertEqual(
+            uncovered,
+            [],
+            "these variables are read by the pack but not stripped in setUp; "
+            "add their prefix to MODULE_ENV_PREFIXES",
+        )
 
 
 if __name__ == "__main__":

--- a/discord/tests/test_discord_intake_service.py
+++ b/discord/tests/test_discord_intake_service.py
@@ -57,6 +57,13 @@ class DiscordIntakeServiceTests(unittest.TestCase):
         self.tempdir = tempfile.TemporaryDirectory()
         self.addCleanup(self.tempdir.cleanup)
         self._old_environ = os.environ.copy()
+        # Strip the ambient city before pinning the fixture one — a live
+        # Gas City seat exports GC_* into every child process and this
+        # pack reads several of them ahead of the fixture's city.toml.
+        # See test_discord_intake_common.py for the full note and for
+        # the guard that keeps this prefix list covering the modules.
+        for key in [k for k in os.environ if k.startswith("GC_")]:
+            del os.environ[key]
         os.environ["GC_CITY_ROOT"] = self.tempdir.name
         service.LAST_REQUEST_PRUNE_AT = 0.0
         service.LAST_REQUEST_RECOVERY_AT = 0.0

--- a/gascity/README.md
+++ b/gascity/README.md
@@ -134,7 +134,8 @@ records the entrypoint it started from, and refuses to finalize as a pass when
 review or repair is still blocked — see "Choosing an entrypoint" above for
 which one matches the artifacts you have.
 
-Every formula in this pack uses `contract = "graph.v2"`. Targeted formulas take
+Every formula in this pack declares `[requires] formula_compiler = ">=2.0.0"`,
+the supported form of the graph-v2 contract. Targeted formulas take
 the core-injected reserved convoy target; they do not declare `issue`,
 `bead_id`, or `convoy_id` variables. `drain_policy=separate` is the standalone
 default. Use `same-session` only when preserving one shared worktree and

--- a/gascity/REQUIREMENTS.md
+++ b/gascity/REQUIREMENTS.md
@@ -105,7 +105,8 @@ top-level stages only as anchored extensions:
   delegates to the next suffix through an inherited handoff step.
 - `build-from-*` formulas are cataloged default Gas City wrappers around the
   matching continuation suffix bases.
-- All formulas use `contract = "graph.v2"` and do not redeclare reserved
+- All formulas declare `[requires] formula_compiler = ">=2.0.0"` and do not
+  redeclare reserved
   runtime variables: `issue`, `bead_id`, or `convoy_id`.
 - Raw-framework subagents are converted to Gas City fanouts, drains, or formula
   steps. The base pack must not preserve subagent functionality as opaque

--- a/gascity/formulas/REQUIREMENTS.md
+++ b/gascity/formulas/REQUIREMENTS.md
@@ -45,7 +45,9 @@ For every formula change:
 
 ## Global Invariants
 
-- Every formula uses `contract = "graph.v2"`.
+- Every formula declares `[requires] formula_compiler = ">=2.0.0"`. The
+  `contract = "graph.v2"` spelling is deprecated and warned on by `gc doctor`;
+  the two are equivalent at the compiler.
 - No formula declares reserved runtime vars `issue`, `bead_id`, or `convoy_id`.
 - Cataloged formulas are user-runnable; internal/base/helper formulas are not
   cataloged unless deliberately promoted.

--- a/gascity/formulas/build-base.formula.toml
+++ b/gascity/formulas/build-base.formula.toml
@@ -27,9 +27,11 @@ Launch inputs:
 """
 formula = "build-base"
 version = 1
-contract = "graph.v2"
 target_required = true
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [metadata.gc.methodology]
 allowed_drain_policies = ["separate", "same-session"]

--- a/gascity/formulas/build-basic-review.formula.toml
+++ b/gascity/formulas/build-basic-review.formula.toml
@@ -8,7 +8,9 @@ synthesize into one fix loop.
 formula = "build-basic-review"
 type = "expansion"
 version = 1
-contract = "graph.v2"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/gascity/formulas/build-basic.formula.toml
+++ b/gascity/formulas/build-basic.formula.toml
@@ -7,9 +7,11 @@ same full-lifecycle stage contract exposed by build-base.
 """
 formula = "build-basic"
 version = 1
-contract = "graph.v2"
 extends = ["build-base"]
 target_required = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "build-basic"

--- a/gascity/formulas/build-from-convoy-base.formula.toml
+++ b/gascity/formulas/build-from-convoy-base.formula.toml
@@ -7,10 +7,12 @@ to `build-from-review-base` through the inherited `prepare-review` step.
 """
 formula = "build-from-convoy-base"
 version = 1
-contract = "graph.v2"
 extends = ["build-from-review-base"]
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [metadata.gc.methodology]
 allowed_drain_policies = ["separate", "same-session"]

--- a/gascity/formulas/build-from-convoy.formula.toml
+++ b/gascity/formulas/build-from-convoy.formula.toml
@@ -6,9 +6,11 @@ Gas City methodology defaults.
 """
 formula = "build-from-convoy"
 version = 1
-contract = "graph.v2"
 extends = ["build-from-convoy-base"]
 target_required = false
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "build-from-convoy"

--- a/gascity/formulas/build-from-decompose-base.formula.toml
+++ b/gascity/formulas/build-from-decompose-base.formula.toml
@@ -29,10 +29,12 @@ Launch inputs:
 """
 formula = "build-from-decompose-base"
 version = 1
-contract = "graph.v2"
 extends = ["build-from-convoy-base"]
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [metadata.gc.methodology]
 allowed_drain_policies = ["separate", "same-session"]

--- a/gascity/formulas/build-from-decompose.formula.toml
+++ b/gascity/formulas/build-from-decompose.formula.toml
@@ -8,9 +8,11 @@ selectors, routes, drains, or review expansions they need.
 """
 formula = "build-from-decompose"
 version = 1
-contract = "graph.v2"
 extends = ["build-from-decompose-base"]
 target_required = false
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "build-from-decompose"

--- a/gascity/formulas/build-from-plan-base.formula.toml
+++ b/gascity/formulas/build-from-plan-base.formula.toml
@@ -7,10 +7,12 @@ implementation plan and plan-review verdict, then hands off to
 """
 formula = "build-from-plan-base"
 version = 1
-contract = "graph.v2"
 extends = ["build-from-decompose-base"]
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [metadata.gc.methodology]
 allowed_drain_policies = ["separate", "same-session"]

--- a/gascity/formulas/build-from-plan.formula.toml
+++ b/gascity/formulas/build-from-plan.formula.toml
@@ -6,9 +6,11 @@ City methodology defaults.
 """
 formula = "build-from-plan"
 version = 1
-contract = "graph.v2"
 extends = ["build-from-plan-base"]
 target_required = false
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "build-from-plan"

--- a/gascity/formulas/build-from-requirements-base.formula.toml
+++ b/gascity/formulas/build-from-requirements-base.formula.toml
@@ -7,10 +7,12 @@ inherited `prepare-plan` step.
 """
 formula = "build-from-requirements-base"
 version = 1
-contract = "graph.v2"
 extends = ["build-from-plan-base"]
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [metadata.gc.methodology]
 allowed_drain_policies = ["separate", "same-session"]

--- a/gascity/formulas/build-from-requirements.formula.toml
+++ b/gascity/formulas/build-from-requirements.formula.toml
@@ -6,9 +6,11 @@ built-in Gas City methodology defaults.
 """
 formula = "build-from-requirements"
 version = 1
-contract = "graph.v2"
 extends = ["build-from-requirements-base"]
 target_required = false
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "build-from-requirements"

--- a/gascity/formulas/build-from-review-base.formula.toml
+++ b/gascity/formulas/build-from-review-base.formula.toml
@@ -8,9 +8,11 @@ to `prepare-review` after producing implementation evidence.
 """
 formula = "build-from-review-base"
 version = 1
-contract = "graph.v2"
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [metadata.gc.methodology]
 allowed_drain_policies = ["separate", "same-session"]

--- a/gascity/formulas/build-from-review.formula.toml
+++ b/gascity/formulas/build-from-review.formula.toml
@@ -6,9 +6,11 @@ Gas City methodology defaults.
 """
 formula = "build-from-review"
 version = 1
-contract = "graph.v2"
 extends = ["build-from-review-base"]
 target_required = false
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "build-from-review"

--- a/gascity/formulas/code-review-base.formula.toml
+++ b/gascity/formulas/code-review-base.formula.toml
@@ -7,10 +7,12 @@ scoring while entrypoint adapters keep GitHub/comment lifecycle ownership.
 """
 formula = "code-review-base"
 version = 1
-contract = "graph.v2"
 target_required = false
 internal = true
 mode = "report"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.context_path]

--- a/gascity/formulas/decomposition-base.formula.toml
+++ b/gascity/formulas/decomposition-base.formula.toml
@@ -7,9 +7,11 @@ native output uses stories, cards, or another task shape.
 """
 formula = "decomposition-base"
 version = 1
-contract = "graph.v2"
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.context_path]

--- a/gascity/formulas/design-review.formula.toml
+++ b/gascity/formulas/design-review.formula.toml
@@ -8,8 +8,10 @@ graphs while preserving launch and finalization semantics.
 """
 formula = "design-review"
 version = 1
-contract = "graph.v2"
 target_required = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "design-review"

--- a/gascity/formulas/do-work-item.formula.toml
+++ b/gascity/formulas/do-work-item.formula.toml
@@ -8,11 +8,13 @@ Launch inputs:
 """
 formula = "do-work-item"
 version = 1
-contract = "graph.v2"
 extends = ["implementation-item-base"]
 target_required = true
 internal = true
 single_lane = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.context_path]

--- a/gascity/formulas/do-work.formula.toml
+++ b/gascity/formulas/do-work.formula.toml
@@ -10,9 +10,11 @@ Launch inputs:
 """
 formula = "do-work"
 version = 1
-contract = "graph.v2"
 extends = ["implementation-base"]
 target_required = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.context_path]

--- a/gascity/formulas/fix-convoy.formula.toml
+++ b/gascity/formulas/fix-convoy.formula.toml
@@ -8,9 +8,11 @@ Launch inputs:
 """
 formula = "fix-convoy"
 version = 1
-contract = "graph.v2"
 target_required = true
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.report_path]

--- a/gascity/formulas/fix-loop-base.formula.toml
+++ b/gascity/formulas/fix-loop-base.formula.toml
@@ -8,9 +8,11 @@ discipline.
 """
 formula = "fix-loop-base"
 version = 1
-contract = "graph.v2"
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.context_path]

--- a/gascity/formulas/gap-analysis.formula.toml
+++ b/gascity/formulas/gap-analysis.formula.toml
@@ -8,9 +8,11 @@ Launch inputs:
 """
 formula = "gap-analysis"
 version = 1
-contract = "graph.v2"
 target_required = false
 mode = "report"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "gap-analysis"

--- a/gascity/formulas/github-issue-fix-base.formula.toml
+++ b/gascity/formulas/github-issue-fix-base.formula.toml
@@ -27,8 +27,10 @@ Launch inputs:
 """
 formula = "github-issue-fix-base"
 version = 1
-contract = "graph.v2"
 target_required = false
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.github_issue_url]

--- a/gascity/formulas/github-issue-fix-design-review-work.formula.toml
+++ b/gascity/formulas/github-issue-fix-design-review-work.formula.toml
@@ -10,7 +10,9 @@ contract for downstream bead creation.
 formula = "github-issue-fix-design-review-work"
 type = "expansion"
 version = 1
-contract = "graph.v2"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars.mode]
 description = "Issue-fix front-half mode, recorded in artifacts."

--- a/gascity/formulas/github-issue-fix.formula.toml
+++ b/gascity/formulas/github-issue-fix.formula.toml
@@ -18,8 +18,10 @@ Launch inputs:
 formula = "github-issue-fix"
 extends = ["github-issue-fix-base"]
 version = 1
-contract = "graph.v2"
 target_required = false
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "github-issue-fix"

--- a/gascity/formulas/github-issue-triage-base.formula.toml
+++ b/gascity/formulas/github-issue-triage-base.formula.toml
@@ -17,8 +17,10 @@ Launch inputs:
 """
 formula = "github-issue-triage-base"
 version = 1
-contract = "graph.v2"
 target_required = false
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.github_issue_url]

--- a/gascity/formulas/github-issue-triage.formula.toml
+++ b/gascity/formulas/github-issue-triage.formula.toml
@@ -16,8 +16,10 @@ Launch inputs:
 formula = "github-issue-triage"
 extends = ["github-issue-triage-base"]
 version = 1
-contract = "graph.v2"
 target_required = false
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "github-issue-triage"

--- a/gascity/formulas/github-pr-review.formula.toml
+++ b/gascity/formulas/github-pr-review.formula.toml
@@ -19,8 +19,10 @@ Launch inputs:
 """
 formula = "github-pr-review"
 version = 1
-contract = "graph.v2"
 target_required = false
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "github-pr-review"

--- a/gascity/formulas/implement.formula.toml
+++ b/gascity/formulas/implement.formula.toml
@@ -16,9 +16,11 @@ Launch inputs:
 """
 formula = "implement"
 version = 2
-contract = "graph.v2"
 target_required = true
 sling_container_mode = "source"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "implement"

--- a/gascity/formulas/implementation-base.formula.toml
+++ b/gascity/formulas/implementation-base.formula.toml
@@ -8,9 +8,11 @@ source-anchor close contract.
 """
 formula = "implementation-base"
 version = 1
-contract = "graph.v2"
 target_required = true
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.context_path]

--- a/gascity/formulas/implementation-item-base.formula.toml
+++ b/gascity/formulas/implementation-item-base.formula.toml
@@ -7,10 +7,12 @@ per-item procedure while keeping shared-drain sequencing stable.
 """
 formula = "implementation-item-base"
 version = 1
-contract = "graph.v2"
 target_required = true
 internal = true
 single_lane = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.context_path]

--- a/gascity/formulas/planning-base.formula.toml
+++ b/gascity/formulas/planning-base.formula.toml
@@ -8,9 +8,11 @@ artifact paths consumed by entrypoint adapters.
 """
 formula = "planning-base"
 version = 1
-contract = "graph.v2"
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.artifact_root]

--- a/gascity/formulas/publish.formula.toml
+++ b/gascity/formulas/publish.formula.toml
@@ -8,9 +8,11 @@ Launch inputs:
 """
 formula = "publish"
 version = 1
-contract = "graph.v2"
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.final_report]

--- a/gascity/formulas/review.formula.toml
+++ b/gascity/formulas/review.formula.toml
@@ -10,10 +10,12 @@ Launch inputs:
 """
 formula = "review"
 version = 1
-contract = "graph.v2"
 extends = ["code-review-base"]
 target_required = false
 mode = "report"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "review"

--- a/gascity/formulas/same-session-implement.formula.toml
+++ b/gascity/formulas/same-session-implement.formula.toml
@@ -9,9 +9,11 @@ Launch inputs:
 """
 formula = "same-session-implement"
 version = 1
-contract = "graph.v2"
 target_required = true
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.context_path]

--- a/gascity/pack.toml
+++ b/gascity/pack.toml
@@ -2,3 +2,11 @@
 name = "gascity"
 version = "0.1.0"
 schema = 2
+# Minimum gc version. The formulas in this pack declare
+# [requires] formula_compiler, a table gc only learned to read in v1.3.0;
+# older gc parses the formula leniently and drops the declaration, so a
+# formula using graph-only constructs fails to compile and one that does
+# not silently takes the v1 path. gc parses this key today and does not
+# yet enforce it -- it is the declared floor, not a guarantee.
+requires_gc = ">=1.3.0"
+

--- a/gascity/tests/test_formula_assets.py
+++ b/gascity/tests/test_formula_assets.py
@@ -499,6 +499,26 @@ def methodology_selector_defaults(expected: dict) -> dict[str, str]:
     }
 
 
+def declares_graph_v2(data: dict) -> bool:
+    """Whether a formula requires the v2 graph compiler, in either spelling.
+
+    `[requires] formula_compiler = ">=2.0.0"` is the supported form; the legacy
+    `contract = "graph.v2"` is deprecated and produces a blocking `gc doctor`
+    warning in every consuming city. They are equivalent at the compiler:
+    `directFormulaCompilerConstraints` maps the legacy field to exactly the
+    constraint the `[requires]` key produces, and `UsesGraphCompiler` reads the
+    resulting constraint set rather than the literal field.
+
+    Asserting the property rather than the spelling is deliberate. The previous
+    assertions here keyed on `contract` alone, which meant the pack's own suite
+    enforced the deprecated form and went red on the migration away from it.
+    """
+    if str(data.get("contract", "")).strip().lower() == "graph.v2":
+        return True
+    requires = data.get("requires") or {}
+    return bool(str(requires.get("formula_compiler", "")).strip())
+
+
 def load_formula(root: pathlib.Path, name: str) -> dict:
     return tomllib.loads((root / "formulas" / f"{name}.formula.toml").read_text(encoding="utf-8"))
 
@@ -537,6 +557,7 @@ def resolve_formula(root: pathlib.Path, name: str, seen: tuple[str, ...] = ()) -
         "description": data.get("description", ""),
         "version": data.get("version", 1),
         "contract": data.get("contract", ""),
+        "requires": data.get("requires", {}),
         "target_required": data.get("target_required"),
         "vars": {},
         "steps": [],
@@ -545,6 +566,8 @@ def resolve_formula(root: pathlib.Path, name: str, seen: tuple[str, ...] = ()) -
         parent_data = resolve_formula(root, parent, (*seen, name))
         if not merged["contract"]:
             merged["contract"] = parent_data.get("contract", "")
+        if not merged["requires"]:
+            merged["requires"] = parent_data.get("requires", {})
         if merged["target_required"] is None:
             merged["target_required"] = parent_data.get("target_required")
         merged["vars"].update(parent_data.get("vars", {}))
@@ -570,6 +593,7 @@ def resolve_formula_from_dirs(formula_dirs: list[pathlib.Path], name: str, seen:
         "description": data.get("description", ""),
         "version": data.get("version", 1),
         "contract": data.get("contract", ""),
+        "requires": data.get("requires", {}),
         "target_required": data.get("target_required"),
         "vars": {},
         "steps": [],
@@ -578,6 +602,8 @@ def resolve_formula_from_dirs(formula_dirs: list[pathlib.Path], name: str, seen:
         parent_data = resolve_formula_from_dirs(formula_dirs, parent, (*seen, name))
         if not merged["contract"]:
             merged["contract"] = parent_data.get("contract", "")
+        if not merged["requires"]:
+            merged["requires"] = parent_data.get("requires", {})
         if merged["target_required"] is None:
             merged["target_required"] = parent_data.get("target_required")
         merged["vars"].update(parent_data.get("vars", {}))
@@ -759,7 +785,7 @@ class FormulaAssetTests(unittest.TestCase):
             data = tomllib.loads(path.read_text(encoding="utf-8"))
             name = path.name.removesuffix(".formula.toml")
             self.assertEqual(data["formula"], name)
-            self.assertEqual(data["contract"], "graph.v2")
+            self.assertTrue(declares_graph_v2(data), f"{data.get('formula')} does not require the v2 graph compiler")
             var_names = set(data.get("vars", {}))
             self.assertNotIn("issue", var_names)
             self.assertNotIn("bead_id", var_names)
@@ -1354,7 +1380,7 @@ class FormulaAssetTests(unittest.TestCase):
             with self.subTest(formula=name):
                 data = load_formula(root, name)
                 self.assertEqual(data["formula"], name)
-                self.assertEqual(data["contract"], "graph.v2")
+                self.assertTrue(declares_graph_v2(data), f"{data.get('formula')} does not require the v2 graph compiler")
                 self.assertTrue(data["internal"])
                 self.assertNotIn("catalog", data)
                 self.assertNotIn("extends", data)
@@ -1937,7 +1963,7 @@ class FormulaAssetTests(unittest.TestCase):
         root = pathlib.Path(__file__).resolve().parents[1]
         review = load_formula(root, "build-basic-review")
         self.assertEqual(review["type"], "expansion")
-        self.assertEqual(review["contract"], "graph.v2")
+        self.assertTrue(declares_graph_v2(review), "review formula does not require the v2 graph compiler")
         self.assertEqual(
             review["vars"]["implementation_target"]["default"],
             "gc.implementation-worker",
@@ -2390,7 +2416,7 @@ class FormulaAssetTests(unittest.TestCase):
                     expansion = load_formula(pack_root, expansion_name)
                     self.assertEqual(expansion["formula"], expansion_name)
                     self.assertEqual(expansion["type"], "expansion")
-                    self.assertEqual(expansion["contract"], "graph.v2")
+                    self.assertTrue(declares_graph_v2(expansion), "expansion formula does not require the v2 graph compiler")
 
                     nodes = formula_nodes(expansion)
                     self.assertGreaterEqual(len(nodes), 4)
@@ -2417,7 +2443,7 @@ class FormulaAssetTests(unittest.TestCase):
             item_formula = load_formula(pack_root, expected["implementation_formula"])
             with self.subTest(pack=pack_name, item_formula=expected["implementation_formula"]):
                 self.assertEqual(item_formula["formula"], expected["implementation_formula"])
-                self.assertEqual(item_formula["contract"], "graph.v2")
+                self.assertTrue(declares_graph_v2(item_formula), "item formula does not require the v2 graph compiler")
                 self.assertEqual(item_formula["extends"], ["do-work"])
                 self.assertNotEqual(item_formula.get("type"), "expansion")
                 self.assertTrue(item_formula["target_required"])
@@ -2493,7 +2519,7 @@ class FormulaAssetTests(unittest.TestCase):
             shared_item_formula = load_formula(pack_root, expected["implementation_item_formula"])
             with self.subTest(pack=pack_name, item_formula=expected["implementation_item_formula"]):
                 self.assertEqual(shared_item_formula["formula"], expected["implementation_item_formula"])
-                self.assertEqual(shared_item_formula["contract"], "graph.v2")
+                self.assertTrue(declares_graph_v2(shared_item_formula), "shared item formula does not require the v2 graph compiler")
                 self.assertEqual(shared_item_formula["extends"], ["do-work-item"])
                 self.assertNotEqual(shared_item_formula.get("type"), "expansion")
                 self.assertTrue(shared_item_formula["target_required"])
@@ -3763,7 +3789,7 @@ class FormulaAssetTests(unittest.TestCase):
         for name, (url_var, optional_vars) in expected.items():
             with self.subTest(name=name):
                 data = resolve_formula(root, name)
-                self.assertEqual(data["contract"], "graph.v2")
+                self.assertTrue(declares_graph_v2(data), f"{data.get('formula')} does not require the v2 graph compiler")
                 self.assertFalse(data["target_required"])
                 self.assertTrue(data["vars"][url_var]["required"])
                 self.assertEqual(set(data["vars"]) - {url_var}, optional_vars)
@@ -3939,8 +3965,10 @@ class FormulaAssetTests(unittest.TestCase):
 formula = "github-issue-fix"
 extends = ["github-issue-fix-base"]
 version = 1
-contract = "graph.v2"
 target_required = false
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "github-issue-fix"
@@ -3960,8 +3988,10 @@ description = "Override sink that preserves the base issue-fix protocol."
 formula = "github-issue-triage"
 extends = ["github-issue-triage-base"]
 version = 1
-contract = "graph.v2"
 target_required = false
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "github-issue-triage"

--- a/gascity/tests/test_formula_assets.py
+++ b/gascity/tests/test_formula_assets.py
@@ -14,7 +14,30 @@ sys.path.insert(
     0, str(pathlib.Path(__file__).resolve().parents[2] / "scripts")
 )
 
-from formula_compiler_requirement import declares_graph_compiler  # noqa: E402
+from formula_compiler_requirement import (  # noqa: E402
+    declared_constraints,
+    declares_graph_compiler,
+    joined_constraints,
+)
+
+
+def accumulated_requires(constraints: list[str], fallback: dict) -> dict:
+    """The `requires` table gc leaves on a resolved formula.
+
+    `Resolve` collects formula_compiler constraints from the child and every
+    parent, then overwrites `merged.Requires` with the comma-joined set
+    (`setFormulaCompilerConstraints`). A resolver that instead lets the child's
+    table win drops a parent's stricter constraint, so a child declaring
+    `">=1.0.0"` under a parent declaring `">=2.0.0"` reads as v1 here and
+    compiles as graph-v2 in gc.
+
+    With no constraints anywhere gc leaves `Requires` alone, so the child's own
+    table is returned unchanged.
+    """
+    joined = joined_constraints(constraints)
+    if not joined:
+        return fallback
+    return {"formula_compiler": joined}
 
 
 # Prefixes the gascity pack's shell commands read from the environment.
@@ -571,17 +594,18 @@ def resolve_formula(root: pathlib.Path, name: str, seen: tuple[str, ...] = ()) -
         "vars": {},
         "steps": [],
     }
+    constraints = list(declared_constraints(data))
     for parent in parents:
         parent_data = resolve_formula(root, parent, (*seen, name))
+        constraints.extend(declared_constraints(parent_data))
         if not merged["contract"]:
             merged["contract"] = parent_data.get("contract", "")
-        if not merged["requires"]:
-            merged["requires"] = parent_data.get("requires", {})
         if merged["target_required"] is None:
             merged["target_required"] = parent_data.get("target_required")
         merged["vars"].update(parent_data.get("vars", {}))
         merged["steps"].extend(parent_data.get("steps", []))
 
+    merged["requires"] = accumulated_requires(constraints, merged["requires"])
     merged["vars"].update(data.get("vars", {}))
     merged["steps"] = merged_steps(merged["steps"], data.get("steps", []))
     if data.get("description"):
@@ -607,17 +631,18 @@ def resolve_formula_from_dirs(formula_dirs: list[pathlib.Path], name: str, seen:
         "vars": {},
         "steps": [],
     }
+    constraints = list(declared_constraints(data))
     for parent in parents:
         parent_data = resolve_formula_from_dirs(formula_dirs, parent, (*seen, name))
+        constraints.extend(declared_constraints(parent_data))
         if not merged["contract"]:
             merged["contract"] = parent_data.get("contract", "")
-        if not merged["requires"]:
-            merged["requires"] = parent_data.get("requires", {})
         if merged["target_required"] is None:
             merged["target_required"] = parent_data.get("target_required")
         merged["vars"].update(parent_data.get("vars", {}))
         merged["steps"].extend(parent_data.get("steps", []))
 
+    merged["requires"] = accumulated_requires(constraints, merged["requires"])
     merged["vars"].update(data.get("vars", {}))
     merged["steps"] = merged_steps(merged["steps"], data.get("steps", []))
     if data.get("description"):
@@ -5390,3 +5415,77 @@ description = "Override sink that writes the base triage report contract."
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class ExtendsConstraintAccumulationTests(unittest.TestCase):
+    """gc unions formula_compiler constraints down the extends chain.
+
+    `Resolve` in internal/formula/parser.go appends each parent's constraints
+    to the child's and then overwrites `merged.Requires` with the comma-joined
+    set. The resolvers in this file used to merge the `requires` table
+    child-wins, which reaches the opposite answer whenever a child declares its
+    own constraint over a parent's stricter one -- and every consumer of
+    `declares_graph_v2` on a resolved formula inherited that answer.
+
+    Refute the rule:
+      grep -n 'compilerConstraints = append' <gascity>/internal/formula/parser.go
+      grep -n 'func setFormulaCompilerConstraints' -A 12 \
+        <gascity>/internal/formula/requirements.go
+    """
+
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self.formulas = pathlib.Path(self.tempdir.name)
+
+    def write(self, name: str, body: str) -> None:
+        (self.formulas / f"{name}.formula.toml").write_text(body, encoding="utf-8")
+
+    def test_a_parents_constraint_survives_a_looser_child_declaration(self) -> None:
+        self.write(
+            "probe-base",
+            'formula = "probe-base"\n'
+            "[requires]\n"
+            'formula_compiler = ">=2.0.0"\n',
+        )
+        self.write(
+            "probe-child",
+            'formula = "probe-child"\n'
+            'extends = ["probe-base"]\n'
+            "[requires]\n"
+            'formula_compiler = ">=1.0.0"\n',
+        )
+        resolved = resolve_formula_from_dirs([self.formulas], "probe-child")
+        self.assertEqual(
+            resolved["requires"]["formula_compiler"],
+            ">=1.0.0, >=2.0.0",
+            "the parent's constraint was dropped; gc joins the whole chain",
+        )
+        self.assertTrue(
+            declares_graph_v2(resolved),
+            "gc compiles this as graph-v2 because the parent requires it; a "
+            "child-wins merge reports v1 and the assertions built on this "
+            "resolver go red for a reason that is not true of the formula",
+        )
+
+    def test_a_chain_declaring_nothing_keeps_an_empty_requires(self) -> None:
+        self.write("plain-base", 'formula = "plain-base"\n')
+        self.write(
+            "plain-child",
+            'formula = "plain-child"\nextends = ["plain-base"]\n',
+        )
+        resolved = resolve_formula_from_dirs([self.formulas], "plain-child")
+        self.assertEqual(resolved["requires"], {})
+        self.assertFalse(declares_graph_v2(resolved))
+
+    def test_the_deprecated_contract_key_on_a_parent_also_carries(self) -> None:
+        self.write(
+            "legacy-base",
+            'formula = "legacy-base"\ncontract = "graph.v2"\n',
+        )
+        self.write(
+            "legacy-child",
+            'formula = "legacy-child"\nextends = ["legacy-base"]\n',
+        )
+        resolved = resolve_formula_from_dirs([self.formulas], "legacy-child")
+        self.assertTrue(declares_graph_v2(resolved))

--- a/gascity/tests/test_formula_assets.py
+++ b/gascity/tests/test_formula_assets.py
@@ -17,8 +17,32 @@ sys.path.insert(
 from formula_compiler_requirement import (  # noqa: E402
     declared_constraints,
     declares_graph_compiler,
+    declares_graph_compiler_from,
     joined_constraints,
 )
+
+# Where a resolved formula carries its accumulated constraint LIST. gc keeps
+# the same list in the unexported `Formula.compilerRequirementSources` and
+# evaluates it one constraint at a time; the comma-joined
+# `Requires.FormulaCompiler` string is what gets serialised, and re-reading
+# that string as a single conjunctive constraint gives a different answer (see
+# `declares_graph_compiler_from`). This key is likewise not part of the TOML.
+CONSTRAINTS_KEY = "_compiler_constraints"
+
+
+def constraints_of(data: dict) -> list[str]:
+    """The constraint list to evaluate for `data`, resolved or straight off disk.
+
+    Known and deliberate: a diamond `extends` chain appends the shared
+    grandparent's constraint twice, here and in gc. Neither implementation
+    deduplicates, and `declaresGraphCompilerRequirement` is an OR over the list,
+    so the repeat cannot change the answer. Left as parity rather than
+    "fixed" on this side, which would make the mirror wrong in a new way.
+    """
+    accumulated = data.get(CONSTRAINTS_KEY)
+    if isinstance(accumulated, list):
+        return list(accumulated)
+    return list(declared_constraints(data))
 
 
 def accumulated_requires(constraints: list[str], fallback: dict) -> dict:
@@ -547,8 +571,11 @@ def declares_graph_v2(data: dict) -> bool:
     accepts `">=1.0.0"` and `"banana"`, neither of which selects the v2
     compiler, so it would agree with a formula that opted into nothing. The
     rule lives once, in `scripts/formula_compiler_requirement.py`.
+
+    Constraints are evaluated separately, never as one joined string, because
+    that is what `declaresGraphCompilerRequirement` does.
     """
-    return declares_graph_compiler(dict(data))
+    return declares_graph_compiler_from(constraints_of(dict(data)))
 
 
 def load_formula(root: pathlib.Path, name: str) -> dict:
@@ -597,7 +624,7 @@ def resolve_formula(root: pathlib.Path, name: str, seen: tuple[str, ...] = ()) -
     constraints = list(declared_constraints(data))
     for parent in parents:
         parent_data = resolve_formula(root, parent, (*seen, name))
-        constraints.extend(declared_constraints(parent_data))
+        constraints.extend(constraints_of(parent_data))
         if not merged["contract"]:
             merged["contract"] = parent_data.get("contract", "")
         if merged["target_required"] is None:
@@ -606,6 +633,7 @@ def resolve_formula(root: pathlib.Path, name: str, seen: tuple[str, ...] = ()) -
         merged["steps"].extend(parent_data.get("steps", []))
 
     merged["requires"] = accumulated_requires(constraints, merged["requires"])
+    merged[CONSTRAINTS_KEY] = constraints
     merged["vars"].update(data.get("vars", {}))
     merged["steps"] = merged_steps(merged["steps"], data.get("steps", []))
     if data.get("description"):
@@ -634,7 +662,7 @@ def resolve_formula_from_dirs(formula_dirs: list[pathlib.Path], name: str, seen:
     constraints = list(declared_constraints(data))
     for parent in parents:
         parent_data = resolve_formula_from_dirs(formula_dirs, parent, (*seen, name))
-        constraints.extend(declared_constraints(parent_data))
+        constraints.extend(constraints_of(parent_data))
         if not merged["contract"]:
             merged["contract"] = parent_data.get("contract", "")
         if merged["target_required"] is None:
@@ -643,6 +671,7 @@ def resolve_formula_from_dirs(formula_dirs: list[pathlib.Path], name: str, seen:
         merged["steps"].extend(parent_data.get("steps", []))
 
     merged["requires"] = accumulated_requires(constraints, merged["requires"])
+    merged[CONSTRAINTS_KEY] = constraints
     merged["vars"].update(data.get("vars", {}))
     merged["steps"] = merged_steps(merged["steps"], data.get("steps", []))
     if data.get("description"):
@@ -5413,10 +5442,6 @@ description = "Override sink that writes the base triage report contract."
         )
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 class ExtendsConstraintAccumulationTests(unittest.TestCase):
     """gc unions formula_compiler constraints down the extends chain.
 
@@ -5468,6 +5493,67 @@ class ExtendsConstraintAccumulationTests(unittest.TestCase):
             "resolver go red for a reason that is not true of the formula",
         )
 
+    def test_constraints_are_evaluated_separately_not_as_one_conjunction(self) -> None:
+        """The joined string is a serialisation; gc evaluates the LIST.
+
+        `declaresGraphCompilerRequirement` walks `compilerRequirementSources`
+        and returns true as soon as one constraint excludes 1.0.0 and admits
+        2.0.0. Here the child qualifies on its own, so gc compiles this chain
+        as graph-v2 -- while the joined `">=2.0.0, !=2.0.0"` admits neither
+        capability and reads as v1. The pair is not a conflict either: their
+        intersection above 2.0.0 is non-empty, so
+        `validateFormulaCompilerConstraintSet` accepts it.
+        """
+        self.write(
+            "split-base",
+            'formula = "split-base"\n[requires]\nformula_compiler = "!=2.0.0"\n',
+        )
+        self.write(
+            "split-child",
+            'formula = "split-child"\nextends = ["split-base"]\n'
+            '[requires]\nformula_compiler = ">=2.0.0"\n',
+        )
+        resolved = resolve_formula_from_dirs([self.formulas], "split-child")
+        self.assertEqual(
+            resolved["requires"]["formula_compiler"], ">=2.0.0, !=2.0.0"
+        )
+        self.assertFalse(
+            declares_graph_compiler(
+                {"requires": {"formula_compiler": ">=2.0.0, !=2.0.0"}}
+            ),
+            "re-reading the joined string as one constraint is the failure "
+            "mode this test exists to pin; if it starts agreeing, the "
+            "assertion below stops proving anything",
+        )
+        self.assertTrue(
+            declares_graph_v2(resolved),
+            "the child constraint alone selects the v2 compiler, so gc does "
+            "too; a resolver that only kept the joined string cannot see that",
+        )
+
+    def test_a_grandparents_constraint_is_not_flattened_by_the_middle_link(self) -> None:
+        """Depth-2: the middle formula must pass a LIST up, not its joined string."""
+        self.write(
+            "deep-base",
+            'formula = "deep-base"\n[requires]\nformula_compiler = "!=2.0.0"\n',
+        )
+        self.write(
+            "deep-mid",
+            'formula = "deep-mid"\nextends = ["deep-base"]\n'
+            '[requires]\nformula_compiler = ">=2.0.0"\n',
+        )
+        self.write(
+            "deep-child",
+            'formula = "deep-child"\nextends = ["deep-mid"]\n',
+        )
+        resolved = resolve_formula_from_dirs([self.formulas], "deep-child")
+        self.assertEqual(
+            resolved[CONSTRAINTS_KEY],
+            [">=2.0.0", "!=2.0.0"],
+            "the middle formula collapsed its chain into one string",
+        )
+        self.assertTrue(declares_graph_v2(resolved))
+
     def test_a_chain_declaring_nothing_keeps_an_empty_requires(self) -> None:
         self.write("plain-base", 'formula = "plain-base"\n')
         self.write(
@@ -5489,3 +5575,7 @@ class ExtendsConstraintAccumulationTests(unittest.TestCase):
         )
         resolved = resolve_formula_from_dirs([self.formulas], "legacy-child")
         self.assertTrue(declares_graph_v2(resolved))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gascity/tests/test_formula_assets.py
+++ b/gascity/tests/test_formula_assets.py
@@ -5,9 +5,16 @@ import os
 import pathlib
 import re
 import subprocess
+import sys
 import tempfile
 import tomllib
 import unittest
+
+sys.path.insert(
+    0, str(pathlib.Path(__file__).resolve().parents[2] / "scripts")
+)
+
+from formula_compiler_requirement import declares_graph_compiler  # noqa: E402
 
 
 # Prefixes the gascity pack's shell commands read from the environment.
@@ -512,11 +519,13 @@ def declares_graph_v2(data: dict) -> bool:
     Asserting the property rather than the spelling is deliberate. The previous
     assertions here keyed on `contract` alone, which meant the pack's own suite
     enforced the deprecated form and went red on the migration away from it.
+
+    The constraint is evaluated, not tested for non-emptiness. A presence check
+    accepts `">=1.0.0"` and `"banana"`, neither of which selects the v2
+    compiler, so it would agree with a formula that opted into nothing. The
+    rule lives once, in `scripts/formula_compiler_requirement.py`.
     """
-    if str(data.get("contract", "")).strip().lower() == "graph.v2":
-        return True
-    requires = data.get("requires") or {}
-    return bool(str(requires.get("formula_compiler", "")).strip())
+    return declares_graph_compiler(dict(data))
 
 
 def load_formula(root: pathlib.Path, name: str) -> dict:

--- a/gascity/tests/test_formula_assets.py
+++ b/gascity/tests/test_formula_assets.py
@@ -10,6 +10,26 @@ import tomllib
 import unittest
 
 
+# Prefixes the gascity pack's shell commands read from the environment.
+# The tests below run those commands as subprocesses; inheriting the
+# developer's environment wholesale let a live Gas City seat's own values
+# reach them. GC_TEMPLATE is the concrete case: commands/claim/run.sh reads
+# EXPECTED_ROUTE="${GC_TEMPLATE:-${GC_AGENT:-}}", so on a machine where a
+# seat exports GC_TEMPLATE=mayor the fixture's GC_AGENT was shadowed and the
+# claim came back CLAIM_REJECTED. In CI nothing is exported, so the suite was
+# green there and red on every real installation.
+PACK_ENV_PREFIXES = ("GC_", "BEADS_", "GASWORKS_", "BD_")
+
+
+def hermetic_env() -> dict[str, str]:
+    """os.environ minus everything the pack reads, for subprocess fixtures."""
+    return {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith(PACK_ENV_PREFIXES)
+    }
+
+
 FORMULAS = {
     "build-base",
     "build-basic",
@@ -818,7 +838,7 @@ class FormulaAssetTests(unittest.TestCase):
             )
             fake_gc.chmod(0o755)
             env = {
-                **os.environ,
+                **hermetic_env(),
                 "BEADS_ACTOR": "worker",
                 "GC_AGENT": "gc.implementation-worker",
                 "GC_PACK_DIR": str(root),
@@ -868,7 +888,7 @@ class FormulaAssetTests(unittest.TestCase):
             )
             fake_gc.chmod(0o755)
             env = {
-                **os.environ,
+                **hermetic_env(),
                 "BEADS_ACTOR": "worker",
                 "GC_PACK_DIR": str(root),
                 "GC_PACK_NAME": "gc",
@@ -921,7 +941,7 @@ class FormulaAssetTests(unittest.TestCase):
             )
             fake_observer.chmod(0o755)
             env = {
-                **os.environ,
+                **hermetic_env(),
                 "BEADS_ACTOR": "worker",
                 "GC_AGENT": "gc.implementation-worker",
                 "GC_PACK_DIR": str(root),
@@ -998,7 +1018,7 @@ class FormulaAssetTests(unittest.TestCase):
             fake_sleep.write_text("#!/bin/sh\n/bin/sleep 0.05\n", encoding="utf-8")
             fake_sleep.chmod(0o755)
             env = {
-                **os.environ,
+                **hermetic_env(),
                 "BEADS_ACTOR": "worker",
                 "GC_AGENT": "gc.implementation-worker",
                 "GC_PACK_DIR": str(root),
@@ -1036,7 +1056,7 @@ class FormulaAssetTests(unittest.TestCase):
             )
             fake_gc.chmod(0o755)
             env = {
-                **os.environ,
+                **hermetic_env(),
                 "GC_PACK_DIR": str(root),
                 "GC_PACK_NAME": "gc",
                 "GC_TEST_CALLS": str(calls),
@@ -1070,7 +1090,7 @@ class FormulaAssetTests(unittest.TestCase):
             )
             fake_gc.chmod(0o755)
             env = {
-                **os.environ,
+                **hermetic_env(),
                 "BEADS_ACTOR": "worker",
                 "GC_PACK_DIR": str(root),
                 "GC_PACK_NAME": "gc",
@@ -1103,7 +1123,7 @@ class FormulaAssetTests(unittest.TestCase):
             )
             fake_gc.chmod(0o755)
             env = {
-                **os.environ,
+                **hermetic_env(),
                 "GC_PACK_DIR": str(root),
                 "GC_PACK_NAME": "gc",
                 "GC_TEST_CALLS": str(calls),
@@ -1141,7 +1161,7 @@ class FormulaAssetTests(unittest.TestCase):
             )
             fake_gc.chmod(0o755)
             env = {
-                **os.environ,
+                **hermetic_env(),
                 "BEADS_ACTOR": "worker",
                 "GC_AGENT": "gc.implementation-worker",
                 "GC_PACK_DIR": str(root),
@@ -1188,7 +1208,7 @@ class FormulaAssetTests(unittest.TestCase):
             fake_sleep.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
             fake_sleep.chmod(0o755)
             env = {
-                **os.environ,
+                **hermetic_env(),
                 "BEADS_ACTOR": "worker",
                 "GC_AGENT": "gc.implementation-worker",
                 "GC_PACK_DIR": str(root),
@@ -1247,7 +1267,7 @@ class FormulaAssetTests(unittest.TestCase):
             fake_sleep.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
             fake_sleep.chmod(0o755)
             env = {
-                **os.environ,
+                **hermetic_env(),
                 "BEADS_ACTOR": "worker",
                 "GC_AGENT": "gc.implementation-worker",
                 "GC_PACK_DIR": str(root),
@@ -4229,7 +4249,7 @@ description = "Override sink that writes the base triage report contract."
             fake_gc.chmod(0o755)
 
             env = {
-                **os.environ,
+                **hermetic_env(),
                 "PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}",
                 "BD_SHOW_DIR": str(show_dir),
                 "GC_BEAD_ID": bead_id,
@@ -4267,7 +4287,7 @@ description = "Override sink that writes the base triage report contract."
             write_check_gc_stub(bin_dir, parent_show=True)
 
             env = {
-                **os.environ,
+                **hermetic_env(),
                 "PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}",
                 "BD_SHOW_JSON": str(show_path),
                 "BD_PARENT_SHOW_JSON": str(parent_show_path),
@@ -4921,7 +4941,7 @@ description = "Override sink that writes the base triage report contract."
             )
 
             env = {
-                **os.environ,
+                **hermetic_env(),
                 "PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}",
                 "BD_SHOW_JSON": str(show_json),
                 "BD_LIST_JSON": str(list_json),
@@ -4986,7 +5006,7 @@ description = "Override sink that writes the base triage report contract."
             )
 
             env = {
-                **os.environ,
+                **hermetic_env(),
                 "PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}",
                 "BD_SHOW_JSON": str(show_json),
                 "BD_LIST_JSON": str(list_json),
@@ -5068,7 +5088,7 @@ description = "Override sink that writes the base triage report contract."
             )
 
             env = {
-                **os.environ,
+                **hermetic_env(),
                 "PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}",
                 "BD_SHOW_JSON": str(show_json),
                 "BD_LIST_JSON": str(list_json),
@@ -5130,7 +5150,7 @@ description = "Override sink that writes the base triage report contract."
             )
 
             env = {
-                **os.environ,
+                **hermetic_env(),
                 "PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}",
                 "BD_SHOW_JSON": str(show_json),
                 "BD_LIST_JSON": str(list_json),

--- a/gastown/pack.toml
+++ b/gastown/pack.toml
@@ -19,6 +19,14 @@
 [pack]
 name = "gastown"
 schema = 2
+# Minimum gc version. The formulas in this pack declare
+# [requires] formula_compiler, a table gc only learned to read in v1.3.0;
+# older gc parses the formula leniently and drops the declaration, so a
+# formula using graph-only constructs fails to compile and one that does
+# not silently takes the v1 path. gc parses this key today and does not
+# yet enforce it -- it is the declared floor, not a guarantee.
+requires_gc = ">=1.3.0"
+
 
 [global]
 session_live = [

--- a/github/tests/test_github_intake_service.py
+++ b/github/tests/test_github_intake_service.py
@@ -16,6 +16,59 @@ sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
 
 import github_intake_service as service
 
+# Every environment-variable prefix this pack's modules read. setUp strips
+# these so a test never inherits the developer's live city; the guard test
+# in GitHubIntakeServiceTests re-derives the variable list from the module
+# source and fails if a new read falls outside the prefixes.
+# GC_*/GITHUB_INTAKE_* are the variables the pack READS; the guard test
+# below enumerates those from the module AST and fails if one escapes these
+# prefixes. GH_*/GIT_* are stripped for a second reason the guard does not
+# cover: gh_env_for_repo and push_branch_with_installation_token build their
+# subprocess environment with os.environ.copy(), so a developer's ambient
+# GH_TOKEN, GH_HOST or GIT_CONFIG_* rides into the `gh` and `git` calls these
+# tests exercise. Stripping more than the guard requires is deliberate.
+MODULE_ENV_PREFIXES = ("GC_", "GITHUB_INTAKE_", "GH_", "GIT_")
+
+
+def _env_vars_read_by(*module_paths: pathlib.Path) -> set[str]:
+    """Enumerate os.environ keys the given modules read, from their AST."""
+    import ast
+
+    def is_environ(node: ast.AST) -> bool:
+        # os.environ  |  environ (from os import environ)
+        if isinstance(node, ast.Attribute):
+            return node.attr == "environ" and isinstance(node.value, ast.Name)
+        return isinstance(node, ast.Name) and node.id == "environ"
+
+    found: set[str] = set()
+    for path in module_paths:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and node.args:
+                func = node.func
+                if isinstance(func, ast.Attribute) and isinstance(
+                    node.args[0], ast.Constant
+                ):
+                    reads_env = (
+                        func.attr in {"get", "setdefault", "pop"}
+                        and is_environ(func.value)
+                    ) or (
+                        func.attr == "getenv"
+                        and isinstance(func.value, ast.Name)
+                        and func.value.id == "os"
+                    )
+                    value = node.args[0].value
+                    if reads_env and isinstance(value, str):
+                        found.add(value)
+            if (
+                isinstance(node, ast.Subscript)
+                and is_environ(node.value)
+                and isinstance(node.slice, ast.Constant)
+                and isinstance(node.slice.value, str)
+            ):
+                found.add(node.slice.value)
+    return found
+
 
 class DummyWebhookHandler:
     def __init__(self, body: bytes, headers: dict[str, str]) -> None:
@@ -41,11 +94,40 @@ class GitHubIntakeServiceTests(unittest.TestCase):
         self.tempdir = tempfile.TemporaryDirectory()
         self.addCleanup(self.tempdir.cleanup)
         self._old_environ = os.environ.copy()
+        # Clear the ambient city before pinning the fixture one. A live
+        # Gas City seat exports GC_API_BASE_URL, GC_CITY_PATH and friends
+        # into every process it spawns, and this pack reads them ahead of
+        # the fixture's city.toml — so these tests passed in CI (no city)
+        # and failed on any machine actually running Gas City. The
+        # PublishImportedIdentityTests class below used to pop two
+        # GITHUB_INTAKE_* names by hand; the prefix sweep replaces that
+        # hand-list, and
+        # test_env_prefixes_cover_every_variable_the_module_reads keeps
+        # the prefixes covering the modules.
+        for key in [k for k in os.environ if k.startswith(MODULE_ENV_PREFIXES)]:
+            del os.environ[key]
         os.environ["GC_CITY_ROOT"] = self.tempdir.name
 
     def tearDown(self) -> None:
         os.environ.clear()
         os.environ.update(self._old_environ)
+
+    def test_env_prefixes_cover_every_variable_the_module_reads(self) -> None:
+        # Keeps MODULE_ENV_PREFIXES honest: a new read of some variable
+        # outside these prefixes would silently reintroduce the ambient
+        # leak with every test still green.
+        scripts = pathlib.Path(__file__).resolve().parents[1] / "scripts"
+        read = _env_vars_read_by(*sorted(scripts.glob("*.py")))
+        self.assertTrue(read, "AST enumeration found no env reads at all")
+        uncovered = sorted(
+            name for name in read if not name.startswith(MODULE_ENV_PREFIXES)
+        )
+        self.assertEqual(
+            uncovered,
+            [],
+            "these variables are read by the pack but not stripped in setUp; "
+            "add their prefix to MODULE_ENV_PREFIXES",
+        )
 
     def test_fix_command_behavior(self) -> None:
         behavior = service.command_behavior("fix")
@@ -1591,9 +1673,9 @@ class PublishImportedIdentityTests(unittest.TestCase):
         self.tempdir = tempfile.TemporaryDirectory()
         self.addCleanup(self.tempdir.cleanup)
         self._old_environ = os.environ.copy()
+        for key in [k for k in os.environ if k.startswith(MODULE_ENV_PREFIXES)]:
+            del os.environ[key]
         os.environ["GC_CITY_ROOT"] = self.tempdir.name
-        os.environ.pop("GITHUB_INTAKE_IDENTITY_PUBLISHER", None)
-        os.environ.pop("GITHUB_INTAKE_APP_IDENTITY", None)
 
     def tearDown(self) -> None:
         os.environ.clear()

--- a/github/tests/test_github_intake_service.py
+++ b/github/tests/test_github_intake_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ast
 import io
 import json
 import urllib.parse
@@ -20,54 +21,189 @@ import github_intake_service as service
 # these so a test never inherits the developer's live city; the guard test
 # in GitHubIntakeServiceTests re-derives the variable list from the module
 # source and fails if a new read falls outside the prefixes.
-# GC_*/GITHUB_INTAKE_* are the variables the pack READS; the guard test
-# below enumerates those from the module AST and fails if one escapes these
-# prefixes. GH_*/GIT_* are stripped for a second reason the guard does not
-# cover: gh_env_for_repo and push_branch_with_installation_token build their
-# subprocess environment with os.environ.copy(), so a developer's ambient
-# GH_TOKEN, GH_HOST or GIT_CONFIG_* rides into the `gh` and `git` calls these
-# tests exercise. Stripping more than the guard requires is deliberate.
-MODULE_ENV_PREFIXES = ("GC_", "GITHUB_INTAKE_", "GH_", "GIT_")
+# GC_*/GITHUB_* are the variables the pack READS; the guard test below
+# enumerates those from the module AST and fails if one escapes these
+# prefixes. GITHUB_ is deliberately the whole namespace rather than
+# GITHUB_INTAKE_: app_config_from_env loops over ENV_APP_FIELDS and reads
+# eleven GITHUB_APP_* / GITHUB_WEBHOOK_SECRET / GITHUB_INSTALLATION_ID names,
+# so a developer holding real GitHub App credentials in their environment had
+# them merged into the fixture config by effective_config. GH_*/GIT_* are
+# stripped for a second reason the guard does not cover: gh_env_for_repo and
+# push_branch_with_installation_token build their subprocess environment with
+# os.environ.copy(), so an ambient GH_TOKEN, GH_HOST or GIT_CONFIG_* rides
+# into the `gh` and `git` calls these tests exercise. Stripping more than the
+# guard requires is deliberate.
+MODULE_ENV_PREFIXES = ("GC_", "GITHUB_", "GH_", "GIT_")
 
 
-def _env_vars_read_by(*module_paths: pathlib.Path) -> set[str]:
-    """Enumerate os.environ keys the given modules read, from their AST."""
-    import ast
+def _is_environ(node: ast.AST) -> bool:
+    # os.environ  |  environ (from os import environ)
+    if isinstance(node, ast.Attribute):
+        return node.attr == "environ" and isinstance(node.value, ast.Name)
+    return isinstance(node, ast.Name) and node.id == "environ"
 
-    def is_environ(node: ast.AST) -> bool:
-        # os.environ  |  environ (from os import environ)
-        if isinstance(node, ast.Attribute):
-            return node.attr == "environ" and isinstance(node.value, ast.Name)
-        return isinstance(node, ast.Name) and node.id == "environ"
+
+def _reads_environ(call: ast.Call) -> bool:
+    func = call.func
+    if not isinstance(func, ast.Attribute):
+        return False
+    if func.attr in {"get", "setdefault", "pop"} and _is_environ(func.value):
+        return True
+    return (
+        func.attr == "getenv"
+        and isinstance(func.value, ast.Name)
+        and func.value.id == "os"
+    )
+
+
+def _module_level_dict_keys(tree: ast.Module) -> dict[str, list[str]]:
+    """Module-level `NAME = {"A": ...}` literals, string keys only.
+
+    A dict with any non-literal key is skipped rather than partially claimed:
+    knowing some of its keys is not knowing the set a loop over it produces.
+    """
+    mapping: dict[str, list[str]] = {}
+    for node in tree.body:
+        if not isinstance(node, ast.Assign) or not isinstance(node.value, ast.Dict):
+            continue
+        keys = [
+            key.value
+            for key in node.value.keys
+            if isinstance(key, ast.Constant) and isinstance(key.value, str)
+        ]
+        if len(keys) != len(node.value.keys):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name):
+                mapping[target.id] = keys
+    return mapping
+
+
+def _loop_variable_keys(
+    tree: ast.Module, dicts: dict[str, list[str]]
+) -> dict[str, list[str]]:
+    """Loop variables that range over a known module-level dict's keys.
+
+    Covers `for env_key, field in ENV_APP_FIELDS.items(): os.environ.get(env_key)`
+    in github_intake_common.py, which reads eleven GITHUB_APP_* / GITHUB_* names
+    that a constant-only walker cannot see.
+    """
+    bound: dict[str, list[str]] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.For):
+            continue
+        iterated = node.iter
+        source: str | None = None
+        if (
+            isinstance(iterated, ast.Call)
+            and isinstance(iterated.func, ast.Attribute)
+            and iterated.func.attr in {"items", "keys"}
+            and isinstance(iterated.func.value, ast.Name)
+        ):
+            source, kind = iterated.func.value.id, iterated.func.attr
+        elif isinstance(iterated, ast.Name):
+            source, kind = iterated.id, "keys"
+        if source is None or source not in dicts:
+            continue
+        target = node.target
+        if kind == "keys" and isinstance(target, ast.Name):
+            bound.setdefault(target.id, []).extend(dicts[source])
+        elif (
+            kind == "items"
+            and isinstance(target, ast.Tuple)
+            and target.elts
+            and isinstance(target.elts[0], ast.Name)
+        ):
+            bound.setdefault(target.elts[0].id, []).extend(dicts[source])
+    return bound
+
+
+def _parameter_keys(trees: dict[pathlib.Path, ast.Module]) -> dict[str, list[str]]:
+    """For `def f(name): os.environ.get(name)`, the constants callers pass.
+
+    Covers workspace_env_value in github_intake_common.py. Call sites are
+    collected across every module in the set, so a caller in a sibling script
+    counts.
+    """
+    call_args: dict[str, list[str]] = {}
+    for tree in trees.values():
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call) or not node.args:
+                continue
+            func = node.func
+            name = (
+                func.id
+                if isinstance(func, ast.Name)
+                else func.attr
+                if isinstance(func, ast.Attribute)
+                else None
+            )
+            if name is None:
+                continue
+            first = node.args[0]
+            if isinstance(first, ast.Constant) and isinstance(first.value, str):
+                call_args.setdefault(name, []).append(first.value)
+
+    bound: dict[str, list[str]] = {}
+    for tree in trees.values():
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            params = [arg.arg for arg in node.args.args]
+            if not params or node.name not in call_args:
+                continue
+            bound.setdefault(params[0], []).extend(call_args[node.name])
+    return bound
+
+
+def _env_vars_read_by(
+    *module_paths: pathlib.Path,
+) -> tuple[set[str], list[str]]:
+    """os.environ keys the given modules read, plus reads we could not resolve.
+
+    A key read through a variable is resolved from the two shapes this pack
+    actually uses (a loop over a module-level dict, and a function parameter
+    filled by constant call sites). Anything else is returned as unresolved
+    rather than dropped, because a read the enumeration cannot see is exactly
+    the leak the guard exists to catch.
+    """
+    trees = {
+        path: ast.parse(path.read_text(encoding="utf-8")) for path in module_paths
+    }
+
+    resolvable: dict[str, list[str]] = {}
+    for tree in trees.values():
+        for variable, keys in _loop_variable_keys(
+            tree, _module_level_dict_keys(tree)
+        ).items():
+            resolvable.setdefault(variable, []).extend(keys)
+    for variable, keys in _parameter_keys(trees).items():
+        resolvable.setdefault(variable, []).extend(keys)
 
     found: set[str] = set()
-    for path in module_paths:
-        tree = ast.parse(path.read_text(encoding="utf-8"))
+    unresolved: list[str] = []
+
+    def record(path: pathlib.Path, node: ast.AST, key: ast.expr) -> None:
+        if isinstance(key, ast.Constant):
+            if isinstance(key.value, str):
+                found.add(key.value)
+            return
+        if isinstance(key, ast.Name) and key.id in resolvable:
+            found.update(resolvable[key.id])
+            return
+        unresolved.append(
+            f"{path.name}:{getattr(node, 'lineno', '?')}: "
+            "os.environ read with a key this enumeration cannot resolve"
+        )
+
+    for path, tree in trees.items():
         for node in ast.walk(tree):
-            if isinstance(node, ast.Call) and node.args:
-                func = node.func
-                if isinstance(func, ast.Attribute) and isinstance(
-                    node.args[0], ast.Constant
-                ):
-                    reads_env = (
-                        func.attr in {"get", "setdefault", "pop"}
-                        and is_environ(func.value)
-                    ) or (
-                        func.attr == "getenv"
-                        and isinstance(func.value, ast.Name)
-                        and func.value.id == "os"
-                    )
-                    value = node.args[0].value
-                    if reads_env and isinstance(value, str):
-                        found.add(value)
-            if (
-                isinstance(node, ast.Subscript)
-                and is_environ(node.value)
-                and isinstance(node.slice, ast.Constant)
-                and isinstance(node.slice.value, str)
-            ):
-                found.add(node.slice.value)
-    return found
+            if isinstance(node, ast.Call) and node.args and _reads_environ(node):
+                record(path, node, node.args[0])
+            elif isinstance(node, ast.Subscript) and _is_environ(node.value):
+                record(path, node, node.slice)
+
+    return found, unresolved
 
 
 class DummyWebhookHandler:
@@ -117,8 +253,17 @@ class GitHubIntakeServiceTests(unittest.TestCase):
         # outside these prefixes would silently reintroduce the ambient
         # leak with every test still green.
         scripts = pathlib.Path(__file__).resolve().parents[1] / "scripts"
-        read = _env_vars_read_by(*sorted(scripts.glob("*.py")))
+        read, unresolved = _env_vars_read_by(*sorted(scripts.glob("*.py")))
         self.assertTrue(read, "AST enumeration found no env reads at all")
+        # An unresolvable read is reported before the prefix check, because a
+        # variable the walker cannot see reads as "covered" either way.
+        self.assertEqual(
+            unresolved,
+            [],
+            "these os.environ reads use a key shape the enumeration does not "
+            "model, so they are neither covered nor cleared; teach "
+            "_env_vars_read_by the shape:\n  " + "\n  ".join(unresolved),
+        )
         uncovered = sorted(
             name for name in read if not name.startswith(MODULE_ENV_PREFIXES)
         )
@@ -127,6 +272,52 @@ class GitHubIntakeServiceTests(unittest.TestCase):
             [],
             "these variables are read by the pack but not stripped in setUp; "
             "add their prefix to MODULE_ENV_PREFIXES",
+        )
+
+    def test_env_enumeration_sees_reads_made_through_a_variable(self) -> None:
+        """Mutation control for the enumeration itself.
+
+        The previous walker only recorded a key when it was a literal at the
+        call site, so `for k in SOME_DICT: os.environ.get(k)` read as no env
+        access at all. Eleven GitHub App credential variables were read that
+        way and reported as covered. Both rails are asserted here: the shapes
+        the pack uses must resolve, and a shape the walker does not model must
+        surface rather than vanish.
+        """
+        source = pathlib.Path(self.tempdir.name) / "probe_module.py"
+        source.write_text(
+            "import os\n"
+            'FIELDS = {"PROBE_LOOP_ONE": "a", "PROBE_LOOP_TWO": "b"}\n'
+            "def by_loop():\n"
+            "    for key, _field in FIELDS.items():\n"
+            "        os.environ.get(key)\n"
+            "def by_param(name):\n"
+            "    return os.environ.get(name)\n"
+            'by_param("PROBE_PARAM_ONE")\n',
+            encoding="utf-8",
+        )
+        read, unresolved = _env_vars_read_by(source)
+        self.assertEqual(unresolved, [], "these shapes are modelled and must resolve")
+        self.assertEqual(
+            read,
+            {"PROBE_LOOP_ONE", "PROBE_LOOP_TWO", "PROBE_PARAM_ONE"},
+            "a key reached through a loop variable or a parameter was dropped",
+        )
+
+        opaque = pathlib.Path(self.tempdir.name) / "probe_opaque.py"
+        opaque.write_text(
+            "import os\n"
+            "def read(prefix):\n"
+            '    return os.environ.get(prefix + "_SUFFIX")\n',
+            encoding="utf-8",
+        )
+        read, unresolved = _env_vars_read_by(opaque)
+        self.assertEqual(read, set())
+        self.assertEqual(
+            len(unresolved),
+            1,
+            "a computed env key must be reported, not silently dropped: "
+            f"{unresolved}",
         )
 
     def test_fix_command_behavior(self) -> None:

--- a/github/tests/test_github_intake_service.py
+++ b/github/tests/test_github_intake_service.py
@@ -36,24 +36,62 @@ import github_intake_service as service
 MODULE_ENV_PREFIXES = ("GC_", "GITHUB_", "GH_", "GIT_")
 
 
-def _is_environ(node: ast.AST) -> bool:
-    # os.environ  |  environ (from os import environ)
+def _is_environ(node: ast.AST, aliases: frozenset[str] = frozenset()) -> bool:
+    # os.environ  |  environ (from os import environ)  |  a copy of either
     if isinstance(node, ast.Attribute):
         return node.attr == "environ" and isinstance(node.value, ast.Name)
-    return isinstance(node, ast.Name) and node.id == "environ"
+    return isinstance(node, ast.Name) and (node.id == "environ" or node.id in aliases)
 
 
-def _reads_environ(call: ast.Call) -> bool:
+def _reads_environ(call: ast.Call, aliases: frozenset[str] = frozenset()) -> bool:
     func = call.func
     if not isinstance(func, ast.Attribute):
         return False
-    if func.attr in {"get", "setdefault", "pop"} and _is_environ(func.value):
+    # setdefault and pop touch the real environment, so they count there. On a
+    # COPY they mutate the copy and read nothing: `env.setdefault(key, value)`
+    # over a workspace dict is how both modules build a subprocess environment,
+    # and counting it reports the pack as reading keys it only writes.
+    if func.attr == "get" and _is_environ(func.value, aliases):
+        return True
+    if func.attr in {"setdefault", "pop"} and _is_environ(func.value):
         return True
     return (
         func.attr == "getenv"
         and isinstance(func.value, ast.Name)
         and func.value.id == "os"
     )
+
+
+def _environ_aliases(tree: ast.Module) -> set[str]:
+    """Names bound to a whole copy of the environment.
+
+    `env = os.environ.copy()` (which gh_env_for_repo and
+    push_branch_with_installation_token both do) makes every later `env.get(K)`
+    an environment read that a walker looking only for `os.environ` cannot see.
+    Whole-environment copies are also why MODULE_ENV_PREFIXES strips GH_ and
+    GIT_: those ride into the subprocess without being read by name at all.
+    """
+    aliases: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign) or not isinstance(node.value, ast.Call):
+            continue
+        call = node.value
+        copied = (
+            isinstance(call.func, ast.Attribute)
+            and call.func.attr == "copy"
+            and _is_environ(call.func.value)
+        ) or (
+            isinstance(call.func, ast.Name)
+            and call.func.id == "dict"
+            and len(call.args) == 1
+            and _is_environ(call.args[0])
+        )
+        if not copied:
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name):
+                aliases.add(target.id)
+    return aliases
 
 
 def _module_level_dict_keys(tree: ast.Module) -> dict[str, list[str]]:
@@ -79,8 +117,35 @@ def _module_level_dict_keys(tree: ast.Module) -> dict[str, list[str]]:
     return mapping
 
 
+def _walk_scope(scope: ast.AST):
+    """Nodes belonging to `scope`, not descending into nested functions.
+
+    Name resolution has to be per scope. Resolving by bare name across a whole
+    module set merges unrelated bindings: `split_repository`, `read_body` and
+    `main` are each defined in more than one of the guarded scripts, and every
+    one of them has a parameter called `name` somewhere, so a caller of one
+    function answered a read in another.
+    """
+    stack = list(ast.iter_child_nodes(scope))
+    while stack:
+        node = stack.pop()
+        yield node
+        # Lambdas are deliberately NOT a boundary: they are not in
+        # _function_scopes, so skipping them would drop any read inside one
+        # instead of merely resolving it in the enclosing scope.
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        stack.extend(ast.iter_child_nodes(node))
+
+
+def _function_scopes(tree: ast.Module):
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            yield node
+
+
 def _loop_variable_keys(
-    tree: ast.Module, dicts: dict[str, list[str]]
+    tree: ast.AST, dicts: dict[str, list[str]]
 ) -> dict[str, list[str]]:
     """Loop variables that range over a known module-level dict's keys.
 
@@ -89,7 +154,7 @@ def _loop_variable_keys(
     that a constant-only walker cannot see.
     """
     bound: dict[str, list[str]] = {}
-    for node in ast.walk(tree):
+    for node in _walk_scope(tree):
         if not isinstance(node, ast.For):
             continue
         iterated = node.iter
@@ -118,42 +183,74 @@ def _loop_variable_keys(
     return bound
 
 
-def _parameter_keys(trees: dict[pathlib.Path, ast.Module]) -> dict[str, list[str]]:
+def _parameter_keys(
+    trees: dict[pathlib.Path, ast.Module],
+) -> tuple[dict[str, list[str]], set[str]]:
     """For `def f(name): os.environ.get(name)`, the constants callers pass.
 
     Covers workspace_env_value in github_intake_common.py. Call sites are
     collected across every module in the set, so a caller in a sibling script
-    counts.
-    """
-    call_args: dict[str, list[str]] = {}
-    for tree in trees.values():
-        for node in ast.walk(tree):
-            if not isinstance(node, ast.Call) or not node.args:
-                continue
-            func = node.func
-            name = (
-                func.id
-                if isinstance(func, ast.Name)
-                else func.attr
-                if isinstance(func, ast.Attribute)
-                else None
-            )
-            if name is None:
-                continue
-            first = node.args[0]
-            if isinstance(first, ast.Constant) and isinstance(first.value, str):
-                call_args.setdefault(name, []).append(first.value)
+    counts. Returns the resolved names and the names that must NOT be treated
+    as resolved.
 
-    bound: dict[str, list[str]] = {}
-    for tree in trees.values():
+    Three limits, each handled rather than assumed away:
+
+    * Only a plain `f(...)` call resolves `f`'s parameters. `client.f("X")` is
+      a method on some object and says nothing about the free function, so
+      attributing it would invent a key the module never reads.
+    * Keyword arguments are read, matched to the parameter by NAME. Positional
+      arguments are matched by position. `f(name="X")` used to vanish.
+    * A call passing a non-constant poisons that parameter: it becomes
+      unresolvable rather than resolved-from-the-other-call-sites, so the read
+      surfaces as unresolved instead of being answered from a partial set.
+
+    Call sites are collected per MODULE and matched to the function defined in
+    that same module. `main`, `split_repository` and `read_body` are each
+    defined in more than one guarded script, so a set-wide bucket answered a
+    read in one module from a caller in another.
+    """
+    positional: dict[tuple[pathlib.Path, str, int], list[str]] = {}
+    keyword: dict[tuple[pathlib.Path, str, str], list[str]] = {}
+    poisoned: set[tuple[pathlib.Path, str, object]] = set()
+
+    for path, tree in trees.items():
         for node in ast.walk(tree):
-            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Name):
                 continue
+            name = node.func.id
+            for index, arg in enumerate(node.args):
+                if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                    positional.setdefault((path, name, index), []).append(arg.value)
+                else:
+                    poisoned.add((path, name, index))
+            for kw in node.keywords:
+                if kw.arg is None:  # **kwargs: we cannot say which parameter
+                    poisoned.add((path, name, "**"))
+                elif isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str):
+                    keyword.setdefault((path, name, kw.arg), []).append(kw.value.value)
+                else:
+                    poisoned.add((path, name, kw.arg))
+
+    bound: dict[tuple[pathlib.Path, str, str], list[str]] = {}
+    unresolvable: set[tuple[pathlib.Path, str, str]] = set()
+    for path, tree in trees.items():
+        for node in _function_scopes(tree):
             params = [arg.arg for arg in node.args.args]
-            if not params or node.name not in call_args:
-                continue
-            bound.setdefault(params[0], []).extend(call_args[node.name])
-    return bound
+            if params and params[0] in {"self", "cls"}:
+                continue  # a method; its callers are not resolvable by name
+            for index, param in enumerate(params):
+                keys = positional.get((path, node.name, index), []) + keyword.get(
+                    (path, node.name, param), []
+                )
+                if (
+                    (path, node.name, index) in poisoned
+                    or (path, node.name, param) in poisoned
+                    or (path, node.name, "**") in poisoned
+                ):
+                    unresolvable.add((path, node.name, param))
+                elif keys:
+                    bound.setdefault((path, node.name, param), []).extend(keys)
+    return bound, unresolvable
 
 
 def _env_vars_read_by(
@@ -163,27 +260,31 @@ def _env_vars_read_by(
 
     A key read through a variable is resolved from the two shapes this pack
     actually uses (a loop over a module-level dict, and a function parameter
-    filled by constant call sites). Anything else is returned as unresolved
-    rather than dropped, because a read the enumeration cannot see is exactly
-    the leak the guard exists to catch.
+    filled by constant call sites), plus reads made through a whole copy of the
+    environment. Anything else is returned as unresolved rather than dropped,
+    because a read the enumeration cannot see is exactly the leak the guard
+    exists to catch.
+
+    Resolution is per scope. Names are not unique across a module set, and a
+    binding borrowed from another module's function is a fabricated answer that
+    looks exactly like a real one.
     """
     trees = {
         path: ast.parse(path.read_text(encoding="utf-8")) for path in module_paths
     }
 
-    resolvable: dict[str, list[str]] = {}
-    for tree in trees.values():
-        for variable, keys in _loop_variable_keys(
-            tree, _module_level_dict_keys(tree)
-        ).items():
-            resolvable.setdefault(variable, []).extend(keys)
-    for variable, keys in _parameter_keys(trees).items():
-        resolvable.setdefault(variable, []).extend(keys)
+    aliases = frozenset().union(*(_environ_aliases(tree) for tree in trees.values()))
+    parameters, poisoned = _parameter_keys(trees)
 
     found: set[str] = set()
     unresolved: list[str] = []
 
-    def record(path: pathlib.Path, node: ast.AST, key: ast.expr) -> None:
+    def record(
+        path: pathlib.Path,
+        node: ast.AST,
+        key: ast.expr,
+        resolvable: dict[str, list[str]],
+    ) -> None:
         if isinstance(key, ast.Constant):
             if isinstance(key.value, str):
                 found.add(key.value)
@@ -197,11 +298,31 @@ def _env_vars_read_by(
         )
 
     for path, tree in trees.items():
-        for node in ast.walk(tree):
-            if isinstance(node, ast.Call) and node.args and _reads_environ(node):
-                record(path, node, node.args[0])
-            elif isinstance(node, ast.Subscript) and _is_environ(node.value):
-                record(path, node, node.slice)
+        dicts = _module_level_dict_keys(tree)
+        for scope in (tree, *_function_scopes(tree)):
+            resolvable = dict(_loop_variable_keys(scope, dicts))
+            if isinstance(scope, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                for param in (arg.arg for arg in scope.args.args):
+                    if (path, scope.name, param) in poisoned:
+                        resolvable.pop(param, None)
+                    elif (path, scope.name, param) in parameters:
+                        resolvable.setdefault(param, []).extend(
+                            parameters[(path, scope.name, param)]
+                        )
+            for node in _walk_scope(scope):
+                if (
+                    isinstance(node, ast.Call)
+                    and node.args
+                    and _reads_environ(node, aliases)
+                ):
+                    record(path, node, node.args[0], resolvable)
+                elif (
+                    isinstance(node, ast.Subscript)
+                    and _is_environ(node.value, aliases)
+                    and isinstance(node.ctx, ast.Load)
+                ):
+                    # `env[key] = value` is a write to the copy, not a read.
+                    record(path, node, node.slice, resolvable)
 
     return found, unresolved
 
@@ -318,6 +439,122 @@ class GitHubIntakeServiceTests(unittest.TestCase):
             1,
             "a computed env key must be reported, not silently dropped: "
             f"{unresolved}",
+        )
+
+    def test_env_enumeration_sees_reads_through_a_copy_of_the_environment(self) -> None:
+        """`env = os.environ.copy()` then `env.get(K)` is an environment read.
+
+        Both guarded modules make that copy to build a subprocess environment.
+        A walker matching only `os.environ` reports no read for a key taken
+        from the copy, so the prefix check clears a variable it never saw.
+        """
+        source = pathlib.Path(self.tempdir.name) / "probe_copy.py"
+        source.write_text(
+            "import os\n"
+            "def build():\n"
+            "    env = os.environ.copy()\n"
+            '    env.get("PROBE_COPY_GET")\n'
+            '    return env["PROBE_COPY_INDEX"]\n'
+            "def build_dict():\n"
+            "    other = dict(os.environ)\n"
+            '    return other.get("PROBE_DICT_GET")\n',
+            encoding="utf-8",
+        )
+        read, unresolved = _env_vars_read_by(source)
+        self.assertEqual(unresolved, [])
+        self.assertEqual(
+            read,
+            {"PROBE_COPY_GET", "PROBE_COPY_INDEX", "PROBE_DICT_GET"},
+            "a key read from a copy of the environment was dropped",
+        )
+
+    def test_parameter_resolution_handles_keywords_and_ignores_methods(self) -> None:
+        """The three ways parameter resolution used to be wrong.
+
+        A keyword call site vanished; a same-named METHOD call was attributed
+        to the free function, inventing a key the module never reads; and a
+        non-constant call site left the parameter looking fully resolved from
+        the other call sites.
+        """
+        source = pathlib.Path(self.tempdir.name) / "probe_params.py"
+        source.write_text(
+            "import os\n"
+            "def by_keyword(name):\n"
+            "    return os.environ.get(name)\n"
+            'by_keyword(name="PROBE_KEYWORD")\n'
+            "def only_a_method(name):\n"
+            "    return os.environ.get(name)\n"
+            'client.only_a_method("PROBE_NOT_OURS")\n',
+            encoding="utf-8",
+        )
+        read, unresolved = _env_vars_read_by(source)
+        self.assertIn("PROBE_KEYWORD", read, "a keyword call site was dropped")
+        self.assertNotIn(
+            "PROBE_NOT_OURS",
+            read,
+            "a method call was attributed to the free function of the same "
+            "name, inventing a key the module never reads",
+        )
+        self.assertEqual(
+            len(unresolved),
+            1,
+            "only_a_method's parameter has no resolvable call site, so its "
+            f"read must be reported unresolved: {unresolved}",
+        )
+
+        poisoned = pathlib.Path(self.tempdir.name) / "probe_poison.py"
+        poisoned.write_text(
+            "import os\n"
+            "def lookup(name):\n"
+            "    return os.environ.get(name)\n"
+            'lookup("PROBE_CONSTANT")\n'
+            "lookup(computed)\n",
+            encoding="utf-8",
+        )
+        read, unresolved = _env_vars_read_by(poisoned)
+        self.assertEqual(
+            read,
+            set(),
+            "one non-constant call site makes the parameter unknowable; "
+            "answering from the constant sites reports a partial set as whole",
+        )
+        self.assertEqual(len(unresolved), 1)
+
+    def test_a_binding_does_not_leak_between_modules_or_functions(self) -> None:
+        """Two modules define `main(name)`; only one has a constant caller.
+
+        `main`, `split_repository` and `read_body` really are each defined in
+        more than one of the guarded scripts. With call sites bucketed by bare
+        name, the caller in one module answered the read in the other, and the
+        unresolved read it should have reported disappeared.
+        """
+        directory = pathlib.Path(self.tempdir.name)
+        first = directory / "probe_scope_a.py"
+        first.write_text(
+            "import os\n"
+            "def main(name):\n"
+            "    return os.environ.get(name)\n"
+            'main("PROBE_SCOPE_A")\n',
+            encoding="utf-8",
+        )
+        second = directory / "probe_scope_b.py"
+        second.write_text(
+            "import os\n"
+            "def main(name):\n"
+            "    return os.environ.get(name)\n",
+            encoding="utf-8",
+        )
+        read, unresolved = _env_vars_read_by(first, second)
+        self.assertEqual(read, {"PROBE_SCOPE_A"})
+        self.assertEqual(
+            len(unresolved),
+            1,
+            "probe_scope_b's main has no caller at all, so its read is "
+            f"unresolved; it was answered from the other module: {unresolved}",
+        )
+        self.assertTrue(
+            any("probe_scope_b" in entry for entry in unresolved),
+            f"the unresolved read must be attributed to probe_scope_b: {unresolved}",
         )
 
     def test_fix_command_behavior(self) -> None:

--- a/gstack/formulas/gstack-build.formula.toml
+++ b/gstack/formulas/gstack-build.formula.toml
@@ -6,9 +6,11 @@ Think -> Plan -> Build -> Review -> Test -> Ship -> Reflect.
 """
 formula = "gstack-build"
 version = 1
-contract = "graph.v2"
 extends = ["build-base"]
 target_required = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "gstack-build"

--- a/gstack/formulas/gstack-code-review.formula.toml
+++ b/gstack/formulas/gstack-code-review.formula.toml
@@ -7,7 +7,9 @@ into explicit Gas City review lanes with synthesis and fix application.
 formula = "gstack-code-review"
 type = "expansion"
 version = 1
-contract = "graph.v2"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/gstack/formulas/gstack-decomposition.formula.toml
+++ b/gstack/formulas/gstack-decomposition.formula.toml
@@ -3,10 +3,12 @@ gstack implementation of the decomposition-base methodology contract.
 """
 formula = "gstack-decomposition"
 version = 1
-contract = "graph.v2"
 extends = ["decomposition-base"]
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [[steps]]
 id = "decompose"

--- a/gstack/formulas/gstack-fix-loop.formula.toml
+++ b/gstack/formulas/gstack-fix-loop.formula.toml
@@ -3,10 +3,12 @@ gstack implementation of the fix-loop-base methodology contract.
 """
 formula = "gstack-fix-loop"
 version = 1
-contract = "graph.v2"
 extends = ["fix-loop-base"]
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_formula]

--- a/gstack/formulas/gstack-implementation.formula.toml
+++ b/gstack/formulas/gstack-implementation.formula.toml
@@ -3,10 +3,12 @@ gstack implementation of the public implement methodology contract.
 """
 formula = "gstack-implementation"
 version = 1
-contract = "graph.v2"
 extends = ["implement"]
 target_required = true
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/gstack/formulas/gstack-plan-review.formula.toml
+++ b/gstack/formulas/gstack-plan-review.formula.toml
@@ -7,7 +7,9 @@ founder, design, engineering, and developer-experience lanes.
 formula = "gstack-plan-review"
 type = "expansion"
 version = 1
-contract = "graph.v2"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/gstack/formulas/gstack-planning.formula.toml
+++ b/gstack/formulas/gstack-planning.formula.toml
@@ -3,10 +3,12 @@ gstack implementation of the planning-base methodology contract.
 """
 formula = "gstack-planning"
 version = 1
-contract = "graph.v2"
 extends = ["planning-base"]
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.interaction_mode]

--- a/gstack/formulas/gstack-qa-review.formula.toml
+++ b/gstack/formulas/gstack-qa-review.formula.toml
@@ -7,7 +7,9 @@ and synthesis lanes.
 formula = "gstack-qa-review"
 type = "expansion"
 version = 1
-contract = "graph.v2"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/gstack/formulas/gstack-release-readiness.formula.toml
+++ b/gstack/formulas/gstack-release-readiness.formula.toml
@@ -7,7 +7,9 @@ explicit Gas City readiness lanes before the build finalize and publish stages.
 formula = "gstack-release-readiness"
 type = "expansion"
 version = 1
-contract = "graph.v2"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.review_mode]

--- a/gstack/formulas/gstack-review.formula.toml
+++ b/gstack/formulas/gstack-review.formula.toml
@@ -3,11 +3,13 @@ gstack implementation of the code-review-base methodology contract.
 """
 formula = "gstack-review"
 version = 1
-contract = "graph.v2"
 extends = ["code-review-base"]
 target_required = false
 internal = true
 mode = "report"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/gstack/formulas/gstack-work-item.formula.toml
+++ b/gstack/formulas/gstack-work-item.formula.toml
@@ -3,11 +3,13 @@ gstack single-lane implementation item formula.
 """
 formula = "gstack-work-item"
 version = 1
-contract = "graph.v2"
 extends = ["do-work-item"]
 target_required = true
 internal = true
 single_lane = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/gstack/formulas/gstack-work.formula.toml
+++ b/gstack/formulas/gstack-work.formula.toml
@@ -3,9 +3,11 @@ gstack implementation item formula.
 """
 formula = "gstack-work"
 version = 1
-contract = "graph.v2"
 extends = ["do-work"]
 target_required = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/gstack/pack.toml
+++ b/gstack/pack.toml
@@ -2,6 +2,14 @@
 name = "gstack"
 version = "0.1.0"
 schema = 2
+# Minimum gc version. The formulas in this pack declare
+# [requires] formula_compiler, a table gc only learned to read in v1.3.0;
+# older gc parses the formula leniently and drops the declaration, so a
+# formula using graph-only constructs fails to compile and one that does
+# not silently takes the v1 path. gc parses this key today and does not
+# yet enforce it -- it is the declared floor, not a guarantee.
+requires_gc = ">=1.3.0"
+
 
 [imports.gc]
 source = "../gascity"

--- a/pr-pipeline/README.md
+++ b/pr-pipeline/README.md
@@ -41,6 +41,22 @@ would be clobbered. It defaults to halt-at-branch-ready (`auto_push`
 absent → no push, no PR); pass `--var auto_push=true` to authorize the
 eligibility-gated push.
 
+## The standard the scorecard is enforcing
+
+[`docs/testing-across-the-layer-boundary.md`](docs/testing-across-the-layer-boundary.md)
+is the reasoning behind `mol-pr-review` and `mol-pr-ship`. One sentence of it
+decides most reviews:
+
+> A fix's test must fail on the unfixed **live build** and pass on the fixed
+> live build, with the fix as the only difference.
+
+It covers the test-tier ladder (and why a bug that reproduces only against
+stubs has not been reproduced), the fidelity claim every stub owes the PR body,
+the two mutations a test has to survive, the probe-not-a-city answer for
+environment-specific bugs, and the dolt / beads / gascity / packs layer map that
+decides which layer owns a given bug. Read it before filing a bug against a
+layer you do not own.
+
 ## Scope
 
 This pack is the **author side** — planning, building, and shipping the
@@ -127,6 +143,11 @@ gc sling api-server/polecat mol-pr-start --formula --var issue=1234
 ```
 pr-pipeline/
 ├── pack.toml
+├── docs/
+│   └── testing-across-the-layer-boundary.md   the review standard, the
+│                                              test-tier ladder, and the
+│                                              dolt/beads/gascity/packs
+│                                              layer map
 ├── formulas/
 │   ├── mol-pr-start.formula.toml          6-step planner
 │   ├── mol-pr-blast-radius.formula.toml   5-step impact mapper

--- a/pr-pipeline/docs/testing-across-the-layer-boundary.md
+++ b/pr-pipeline/docs/testing-across-the-layer-boundary.md
@@ -1,0 +1,247 @@
+# Testing across the layer boundary
+
+A fix's test must fail on the unfixed **live build** and pass on the fixed live
+build, with the fix as the only difference.
+
+Everything in this document is in service of that one sentence. The common
+failure in this stack is a patch that does exactly what it says, proves it with
+a test that genuinely passes, and leaves the reporter's machine unchanged.
+
+This is the review material behind `mol-pr-review` and `mol-pr-ship`. Read it
+as the reasoning; the formulas are the checklist.
+
+---
+
+## The failure this exists to stop
+
+Two worked examples, both real bugs, both public: `gastownhall/gascity` issues
+**#5333** (`gc start` treats a supervisor reload timeout as fatal before the
+readiness check) and **#5324** (`gc supervisor stop` can report success while
+launchd remains able to restart the supervisor). Neither report, as written,
+establishes that fixing it fixes the machine it was found on.
+
+**#5333 has an executable that asserts the wrong thing.** The reproducer drives
+`registerCityWithSupervisor` directly and replaces five seams:
+`ensureSupervisorRunningHook`, `reloadSupervisorHook`, `supervisorAliveHook`,
+`waitForSupervisorCityHook`, `cityControllerURLHook`. The report says plainly
+why it had to. The real path "can regenerate or install platform supervisor
+service files before liveness checks on macOS," so the test stubbed exactly the
+boundary the bug lives on. What it proves is a claim about the stub graph: given
+a `reloadSupervisorHook` that returns 1 and writes a particular string to
+stderr, the caller now treats it as an async start. Whether the *real* macOS
+reload returns 1, and writes that string, on a genuine timeout is a separate
+claim, it is the load-bearing one, and nothing in the report establishes it. If
+the real path returns 2, or a different message, the fix is correct in the test
+and inert in the build.
+
+**#5324 asserts the right thing and has no executable.** Its stated
+postcondition is about the world, not the return value: `gc supervisor stop
+--wait` "should leave the machine supervisor durably stopped, or fail if it
+cannot prove that launchd will not restart it." That is the correct shape. Its
+reproduction is a "best-effort reproduction shape" in prose, and its evidence
+was withheld for a reason the reporter names: the logs "include machine-specific
+paths and session identifiers."
+
+Between them they name the two halves of the problem. A test can be runnable, or
+it can be about the live system. Reports keep getting accepted that are only the
+first.
+
+---
+
+## 1. Push the test to the outermost tier where the bug still reproduces
+
+| Tier | What is real | What is fake |
+|---|---|---|
+| **T1** | the installed binary, the real platform service (launchd/systemd), a real store | nothing |
+| **T2** | the real `gc` binary, real `bd`, real dolt, a throwaway city in a temp dir | the work, the repos |
+| **T3** | in-process, real collaborators wired together | the environment |
+| **T4** | in-process, seams replaced by hooks | the collaborators |
+
+Both issues above sit at T4. That is the tier where a green result carries the
+least information, and it is the tier the test hooks make easiest to reach.
+
+**If a bug reproduces only at T4, you have not reproduced the bug. You have
+reproduced a stub.** Move up until it stops reproducing. The last tier where it
+still does is where the test belongs.
+
+`test/acceptance/` and `test/qualification/` in `gastownhall/gascity` are the T2
+tier and already exist; `test/acceptance/beads_cli_contract_test.go` is the
+shape to copy. Reaching for a hook when a T2 harness exists is the specific move
+to stop.
+
+## 2. Every stub carries its fidelity claim, in the PR body
+
+For each seam the reproducer replaces, the PR states the real behavior it stands
+for and the evidence they match. "The real `reloadSupervisorHook` exits 1 and
+writes `reconcile did not finish before timeout` to stderr on macOS timeout;
+verified by `<command>`" is a reviewable sentence. Its absence is where the
+fixes-the-reproducer-not-the-build failure lives, every time.
+
+A reviewer who cannot find that sentence has found the finding.
+
+## 3. Assert the postcondition, not the report
+
+A test that checks the function returned success is testing the report. A test
+that checks launchd no longer holds a restartable job is testing the world.
+`success: true` is an exit line, not an outcome.
+
+## 4. Kill the fix, and then kill the stub
+
+Reverting the fix must turn the test red. That is necessary and it is weak: it
+shows only that the stub graph is sensitive to the change. The second mutation
+is the one that matters. Perturb each stub toward a plausible alternative real
+behavior (a different exit code, a reworded message, an extra call) and see
+whether the test still distinguishes fixed from unfixed. A test that survives
+every such perturbation is not measuring the seam it claims to.
+
+The same discipline applies to any guard you add: prove it can go red by
+removing the exact thing it exists to catch, then restore. A guard that has
+never been seen red is a guard nobody has tested.
+
+## 5. For an environment-specific bug, ship a probe, not a city
+
+Cities cannot be passed back and forth, which is usually where the conversation
+stops. Something smaller can travel: a **diagnostic the reporter runs**,
+emitting a scrubbed, machine-produced transcript with versions of `gc`,
+`bd` and dolt, the platform service state, and the exact command output at the
+failing step, with home paths, hostnames and session identifiers redacted at
+the source.
+
+That solves both halves of #5324 at once. The reporter wanted to give evidence
+and could not do so safely; a probe that scrubs by construction yields a real
+reading of a real environment and keeps their paths out of a public issue. The
+bug report then contains an observation instead of a repro shape.
+
+---
+
+## The layer map
+
+Four layers. Each row is what the layer owns, where its contract with the layer
+above is written down, and what actually enforces it.
+
+| Layer | Owns | Contract specified in | Enforced by |
+|---|---|---|---|
+| **dolt** | storage engine, SQL surface, version history | upstream | a pinned version in `deps.env` |
+| **beads** (`bd`) | work records, claim/lease/fence, `--json` wire shapes, exit codes, `schema_version` | `engdocs/design/beads-dolt-contract-redesign.md` | nothing cross-repo |
+| **gascity core** (`gc`) | cities, rigs, sessions, the supervisor, formulas, and the `bd` subprocess consumer (roughly 20 subcommands, parsed into a fixed struct, behavior keyed off exit codes and free-text error strings) | `engdocs/design/beads-gascity-contract-test-system.md` | Phase 0+1 only |
+| **packs** | agents, commands, services, formulas, skills, hooks, template fragments, composed via `pack.toml` imports | `docs/reference/specs/pack-spec.md`, `engdocs/design/packv2/` | `gc lint` on 5 of 16 registry packs |
+
+**The boundary is specified in four places and gated end to end in none.** Every
+drift incident catalogued so far lives in the gap between a written contract and
+an executed one.
+
+`engdocs/design/beads-gascity-contract-test-system.md` (Proposed, 2026-06-24)
+already diagnosed this for the `bd` to `gc` edge and catalogued **28 historical
+drift incidents**, dominated by version-gated code that CI never exercises. Its
+Phase 0+1 landed as `3f45f30aa` (gascity #3714). The cross-version matrix that
+was the actual gate did not.
+
+**Which layer owns your bug** decides where the fix goes and which repo's tests
+must move:
+
+- A wire shape, exit code or `--json` field changed under you: beads.
+- `gc` mis-parsing a shape beads still emits correctly: gascity core.
+- A workflow, prompt, formula or command behaving wrongly while `gc` behaves
+  correctly: your pack.
+- A pack needing something `gc` cannot express: a request for a new
+  declaration in core, not a special case (see below).
+
+## The interaction effect, and how not to make core bespoke
+
+A pack expresses one user's particular system. Core must serve it without
+learning about it. The test for whether a fix crossed that line:
+
+> **Does the fix add a branch that names a pack, or a capability the pack
+> declares and core validates generically?**
+
+The first is bespoke and accrues forever. The second is what `gc lint` and the
+packv2 conformance work are for: the pack *declares* its requirement, core
+*checks* the declaration, and the check is the same code for every pack. A pack
+that needs something core cannot express is a request for a new declaration, not
+a new special case.
+
+Prefer content-based discovery over hand-maintained lists on both sides. A check
+that walks every `*.json` carrying an `oauth_config` key keeps working when a
+pack adds a second manifest; a check that reads a list of paths silently skips
+it.
+
+## Where this stack currently fails its own advice
+
+Re-derived on `gastownhall/gascity-packs` 2026-08-17, from the CI lint loop and
+`registry.toml` (issue **#307** reports the same defect with a count of 10; the
+list below is 11 because `profiler`, which CI does lint, is not a registry
+pack): **11 of the 16 registry packs are never exercised against a running
+`gc`**: `cass`, `contributing`, `discord`, `gastown`, `github`, `oversight-rig`,
+`pr-pipeline`, `runtime-cloudflare`, `slack-channel`, `slack-full`,
+`slack-mini`. The five CI does lint are `bmad`, `compound-engineering`,
+`gascity`, `gstack` and `superpowers`. Several of the eleven have
+their own pytest or Go suites, which test the pack's logic against the pack's
+own fixtures. Nothing stands them up against a `gc` that has moved since the
+pack was last touched, and `registry.toml` carries no support-tier or
+last-validated-version field, so a user reading it cannot tell an exercised pack
+from an unexercised one.
+
+That is the same failure as #5333 at a different scale: a green suite that is
+about the artifact's fixtures rather than the system it runs in.
+
+A sharper instance, found in this repo's own suite on 2026-08-17: several pack
+test suites were green in CI and red on every machine actually running Gas City.
+A live agent seat exports `GC_API_BASE_URL`, `GC_TEMPLATE`, `BEADS_ACTOR` and
+others into every child process, at a higher precedence than a fixture's own
+`city.toml`. CI runners export none of them. The suites passed for a reason
+unrelated to the code under test, which is the failure this whole document is
+about, reproduced inside the tooling that is supposed to catch it. The fix is in
+`discord/tests/`, `github/tests/` and `gascity/tests/`: strip the pack's own
+environment prefixes in `setUp`, build subprocess environments from a filtered
+copy rather than `os.environ`, and add an AST guard that fails when a module
+starts reading a variable outside the stripped prefixes.
+
+---
+
+## What a reviewer asks
+
+Five questions, in order. Any "no" is the review comment.
+
+1. What tier is the test at, and does the bug reproduce at a higher one?
+2. For each stub: what real behavior does it stand for, and what verified it?
+3. Does the assertion name a state of the world, or a return value?
+4. Reverting the fix turns it red, and does perturbing each stub break the
+   discrimination?
+5. If the bug is environment-specific, is there a probe the reporter can run?
+
+---
+
+## Refuting commands
+
+Every number above is re-derivable. Resolve anchors at time of use rather than
+trusting a pinned line number.
+
+`$GASCITY` is a checkout of `gastownhall/gascity`, `$PACKS` a checkout of
+`gastownhall/gascity-packs`.
+
+```sh
+# the five stubbed seams in #5333
+gh issue view 5333 --repo gastownhall/gascity --json body \
+  | grep -oE '[a-zA-Z]+Hook = ' | sort -u
+
+# the 28 drift incidents and the design's status (still "Proposed")
+sed -n '1,40p' "$GASCITY/engdocs/design/beads-gascity-contract-test-system.md"
+
+# which packs CI actually lints against a running gc. The loop body is
+# `"$GC_BIN" lint "$pack"`, so grepping for the literal `gc lint` finds nothing.
+grep -n 'lint "\$pack"' -B4 "$PACKS/.github/workflows/ci.yml"
+
+# registry packs never exercised against a running gc. Set the second list
+# from the loop above; `profiler` appears there and is NOT a registry pack,
+# which is how the count of 10 in #307 came out one short.
+cd "$PACKS" && comm -23 \
+  <(grep -A1 '^\[\[pack\]\]' registry.toml | grep 'name =' \
+      | sed 's/.*= //' | tr -d '"' | sort) \
+  <(printf '%s\n' gascity bmad compound-engineering gstack superpowers profiler \
+      | sort)
+
+# pack maintenance recency
+cd "$PACKS" && for p in pr-pipeline slack-full slack-mini slack-channel oversight-rig; do
+  printf '%-16s %s\n' "$p" "$(git log -1 --format='%ad %s' --date=short -- "$p")"
+done
+```

--- a/pr-pipeline/formulas/mol-pr-from-issue.formula.toml
+++ b/pr-pipeline/formulas/mol-pr-from-issue.formula.toml
@@ -63,13 +63,16 @@ phase = "vapor"
 # predicate (internal/formula/compile.go) is
 #   rootOnly := (!f.Pour && f.Phase == "vapor") || len(f.Steps) == 0
 # which keys only on pour and phase; the graph declaration form is never
-# consulted, so `contract = "graph.v2"` does not protect against it. Note the
+# consulted, so declaring the graph compiler in [requires] below does not
+# protect against it. Note the
 # failure is silent: RecipeHasReadySurface still returns true because RootOnly
 # itself satisfies it, so the pool sling is accepted and only the steps go
 # missing.
 pour = true
 version = 1
-contract = "graph.v2"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.issue_number]

--- a/pr-pipeline/pack.toml
+++ b/pr-pipeline/pack.toml
@@ -44,3 +44,11 @@
 name = "pr-pipeline"
 version = "0.1.0"
 schema = 2
+# Minimum gc version. The formulas in this pack declare
+# [requires] formula_compiler, a table gc only learned to read in v1.3.0;
+# older gc parses the formula leniently and drops the declaration, so a
+# formula using graph-only constructs fails to compile and one that does
+# not silently takes the v1 path. gc parses this key today and does not
+# yet enforce it -- it is the declared floor, not a guarantee.
+requires_gc = ">=1.3.0"
+

--- a/pr-pipeline/tests/test_pr_pipeline_formulas.py
+++ b/pr-pipeline/tests/test_pr_pipeline_formulas.py
@@ -27,7 +27,14 @@ class MolPrFromIssueVarBindingTests(unittest.TestCase):
     def test_formula_is_present_and_well_formed(self) -> None:
         self.assertTrue(self.path.exists(), "mol-pr-from-issue must live in the pr-pipeline pack")
         self.assertEqual(self.data["formula"], "mol-pr-from-issue")
-        self.assertEqual(self.data["contract"], "graph.v2")
+        # The supported declaration is [requires] formula_compiler; the legacy
+        # `contract = "graph.v2"` is deprecated and warned on by `gc doctor`.
+        # Assert the requirement, not the spelling, so the pack's own suite
+        # does not enforce the deprecated form.
+        self.assertTrue(
+            str(self.data.get("requires", {}).get("formula_compiler", "")).strip(),
+            "mol-pr-from-issue must declare a formula_compiler requirement",
+        )
 
     def test_github_issue_input_is_named_issue_number(self) -> None:
         variables = self.data.get("vars", {})

--- a/pr-pipeline/tests/test_pr_pipeline_formulas.py
+++ b/pr-pipeline/tests/test_pr_pipeline_formulas.py
@@ -1,8 +1,15 @@
 from __future__ import annotations
 
 import pathlib
+import sys
 import tomllib
 import unittest
+
+sys.path.insert(
+    0, str(pathlib.Path(__file__).resolve().parents[2] / "scripts")
+)
+
+from formula_compiler_requirement import declares_graph_compiler  # noqa: E402
 
 
 PACK_ROOT = pathlib.Path(__file__).resolve().parents[1]
@@ -30,10 +37,13 @@ class MolPrFromIssueVarBindingTests(unittest.TestCase):
         # The supported declaration is [requires] formula_compiler; the legacy
         # `contract = "graph.v2"` is deprecated and warned on by `gc doctor`.
         # Assert the requirement, not the spelling, so the pack's own suite
-        # does not enforce the deprecated form.
+        # does not enforce the deprecated form -- and evaluate the constraint
+        # rather than checking the key is non-empty, since `">=1.0.0"` and a
+        # typo both survive a presence check while selecting the v1 compiler.
         self.assertTrue(
-            str(self.data.get("requires", {}).get("formula_compiler", "")).strip(),
-            "mol-pr-from-issue must declare a formula_compiler requirement",
+            declares_graph_compiler(dict(self.data)),
+            "mol-pr-from-issue must declare a formula_compiler constraint that "
+            'selects the v2 graph compiler, e.g. ">=2.0.0"',
         )
 
     def test_github_issue_input_is_named_issue_number(self) -> None:

--- a/pr-review/pack.toml
+++ b/pr-review/pack.toml
@@ -17,3 +17,11 @@
 [pack]
 name = "pr-review"
 schema = 2
+# Minimum gc version. The formulas in this pack declare
+# [requires] formula_compiler, a table gc only learned to read in v1.3.0;
+# older gc parses the formula leniently and drops the declaration, so a
+# formula using graph-only constructs fails to compile and one that does
+# not silently takes the v1 path. gc parses this key today and does not
+# yet enforce it -- it is the declared floor, not a guarantee.
+requires_gc = ">=1.3.0"
+

--- a/profiler/formulas/bench-nullop.formula.toml
+++ b/profiler/formulas/bench-nullop.formula.toml
@@ -8,7 +8,9 @@ Launch: gc sling <operator-target> bench-nullop --formula
 """
 formula = "bench-nullop"
 version = 2
-contract = "graph.v2"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "bench-nullop"

--- a/profiler/formulas/profile-analyze.formula.toml
+++ b/profiler/formulas/profile-analyze.formula.toml
@@ -12,7 +12,9 @@ Launch inputs:
 """
 formula = "profile-analyze"
 version = 2
-contract = "graph.v2"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "profile-analyze"

--- a/profiler/pack.toml
+++ b/profiler/pack.toml
@@ -2,6 +2,14 @@
 name = "profiler"
 version = "0.1.0"
 schema = 2
+# Minimum gc version. The formulas in this pack declare
+# [requires] formula_compiler, a table gc only learned to read in v1.3.0;
+# older gc parses the formula leniently and drops the declaration, so a
+# formula using graph-only constructs fails to compile and one that does
+# not silently takes the v1 path. gc parses this key today and does not
+# yet enforce it -- it is the declared floor, not a guarantee.
+requires_gc = ">=1.3.0"
+
 
 # bench-nullop routes every step to gc.run-operator, which lives in the gascity
 # pack; without this import the formula cannot resolve its run target.

--- a/scripts/formula_compiler_requirement.py
+++ b/scripts/formula_compiler_requirement.py
@@ -112,17 +112,42 @@ def _declared_constraints(formula: dict[str, Any]) -> list[str]:
     """
     constraints: list[str] = []
 
+    # Order mirrors `directFormulaCompilerConstraints`: contract, then
+    # [requires]. It does not change the outcome (the set is conjunctive) but
+    # keeps the two implementations comparable line for line.
+    contract = formula.get("contract")
+    if isinstance(contract, str) and contract.strip().lower() == "graph.v2":
+        constraints.append(">=2.0.0")
+
     requires = formula.get("requires")
     if isinstance(requires, dict):
         declared = requires.get("formula_compiler")
         if isinstance(declared, str) and declared.strip():
             constraints.append(declared.strip())
 
-    contract = formula.get("contract")
-    if isinstance(contract, str) and contract.strip().lower() == "graph.v2":
-        constraints.append(">=2.0.0")
-
     return constraints
+
+
+def declared_constraints(formula: dict[str, Any]) -> list[str]:
+    """The formula_compiler constraints one formula declares, in gc's order."""
+    return _declared_constraints(formula)
+
+
+def joined_constraints(constraints: Iterable[str]) -> str:
+    """Combine constraints the way `setFormulaCompilerConstraints` does.
+
+    gc does NOT let a child's `[requires]` replace its parents'. `Resolve`
+    accumulates `formulaCompilerConstraints` down the whole `extends` chain and
+    then overwrites `merged.Requires` with the comma-joined set, so a child
+    declaring `">=1.0.0"` over a parent declaring `">=2.0.0"` still compiles as
+    graph-v2. A resolver that merges the field child-wins reaches the opposite
+    answer. The comma is conjunctive, which `satisfies` already models.
+    """
+    return ", ".join(
+        constraint.strip()
+        for constraint in constraints
+        if isinstance(constraint, str) and constraint.strip()
+    )
 
 
 def declares_graph_compiler(formula: dict[str, Any]) -> bool:

--- a/scripts/formula_compiler_requirement.py
+++ b/scripts/formula_compiler_requirement.py
@@ -17,7 +17,10 @@ Masterminds semver, whose grammar is larger than what this repository's packs
 actually use; rather than half-implement it and silently mis-evaluate an
 unsupported form, `parse_constraint` raises `UnsupportedConstraint`. A pack that
 introduces a new constraint shape makes the guard fail loudly, which is the
-outcome we want over a guard that quietly guesses.
+outcome we want over a guard that quietly guesses. Prereleases are refused for
+that reason rather than accepted-and-truncated, and the whole expression is
+parsed before any of it is evaluated, so an unsupported group cannot be skipped
+because an earlier group already decided the answer.
 
 Refute the rule this file encodes:
 
@@ -37,8 +40,21 @@ from typing import Any, Iterable
 DEFAULT_COMPILER_CAPABILITY = (1, 0, 0)
 CURRENT_COMPILER_CAPABILITY = (2, 0, 0)
 
-_VERSION = re.compile(r"^(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:[-+].*)?$")
-_COMPARATOR = re.compile(r"^(>=|<=|!=|==|=|>|<|\^|~)?\s*(.+)$")
+# Build metadata is ignored for precedence by the semver spec and by
+# Masterminds, so it is accepted and dropped. A PRERELEASE is not: Masterminds
+# orders `1.0.0-alpha` below stable `1.0.0`, and a three-integer tuple cannot
+# represent that. Modelling it as `1.0.0` inverts `>1.0.0-alpha` (Python would
+# exclude 1.0.0 and admit 2.0.0, selecting graph-v2; Go admits 1.0.0 and does
+# not), so the form is refused rather than approximated.
+_VERSION = re.compile(r"^(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:\+[0-9A-Za-z.\-]+)?$")
+
+# One comparator clause. The version must start with a digit, so `banana` is a
+# parse failure rather than a silently-false clause, and the comparator may be
+# separated from its version by whitespace (`>= 2.0.0`), which Masterminds
+# accepts.
+_CLAUSE = re.compile(r"(>=|<=|!=|==|=|>|<|\^|~)?\s*([0-9][^\s,]*)")
+
+_SEPARATORS = ", \t"
 
 
 class UnsupportedConstraint(ValueError):
@@ -46,7 +62,18 @@ class UnsupportedConstraint(ValueError):
 
 
 def _version(text: str) -> tuple[int, int, int]:
-    match = _VERSION.match(text.strip())
+    stripped = text.strip()
+    # `_VERSION` already refuses a prerelease, so this branch changes the
+    # message and not the outcome. It is here because the message is the whole
+    # value: "not a version: '1.0.0-alpha'" reads like a typo and invites
+    # widening the regex, which is the truncating evaluator this module refuses
+    # to be. Removing this branch alone is not the regression; widening
+    # `_VERSION` to admit `-alpha` is, and `ConstraintEvaluatorTest` catches it.
+    if "-" in stripped.split("+", 1)[0]:
+        raise UnsupportedConstraint(
+            f"prerelease versions are not modelled: {text!r}"
+        )
+    match = _VERSION.match(stripped)
     if not match:
         raise UnsupportedConstraint(f"not a version: {text!r}")
     major, minor, patch = match.groups()
@@ -80,26 +107,48 @@ def _satisfies_one(comparator: str, bound: tuple[int, int, int],
     raise UnsupportedConstraint(f"unsupported comparator: {comparator!r}")
 
 
-def satisfies(constraint: str, candidate: tuple[int, int, int]) -> bool:
-    """Does `candidate` satisfy `constraint`? Raises on forms we do not model."""
+def parse_constraint(constraint: str) -> list[list[tuple[str, tuple[int, int, int]]]]:
+    """`constraint` as OR groups of AND clauses. Raises on forms we do not model.
+
+    The WHOLE expression is parsed before anything is evaluated. Parsing
+    lazily, group by group, made the fail-closed promise conditional on the
+    candidate version: `"<=1.0.0 || banana"` would return False for 1.0.0
+    without ever looking at `banana`, while `semver.NewConstraint` rejects the
+    entire expression. An evaluator that is only strict on some inputs is the
+    guard-agrees-with-a-typo shape this module exists to avoid.
+    """
     if not isinstance(constraint, str) or not constraint.strip():
         raise UnsupportedConstraint("empty constraint")
 
-    for group in constraint.split("||"):  # OR across groups
-        clauses = [c for c in re.split(r"[,\s]+", group.strip()) if c]
+    groups: list[list[tuple[str, tuple[int, int, int]]]] = []
+    for group in constraint.split("||"):
+        text = group.strip()
+        clauses: list[tuple[str, tuple[int, int, int]]] = []
+        position = 0
+        while position < len(text):
+            if text[position] in _SEPARATORS:
+                position += 1
+                continue
+            match = _CLAUSE.match(text, position)
+            if not match:
+                raise UnsupportedConstraint(
+                    f"not a comparator clause at offset {position} of {group!r}"
+                )
+            comparator, bound = match.groups()
+            clauses.append((comparator or "", _version(bound)))
+            position = match.end()
         if not clauses:
             raise UnsupportedConstraint(f"empty constraint group in {constraint!r}")
-        if all(_clause_holds(clause, candidate) for clause in clauses):
-            return True
-    return False
+        groups.append(clauses)
+    return groups
 
 
-def _clause_holds(clause: str, candidate: tuple[int, int, int]) -> bool:
-    match = _COMPARATOR.match(clause)
-    if not match:
-        raise UnsupportedConstraint(f"not a comparator clause: {clause!r}")
-    comparator, bound = match.groups()
-    return _satisfies_one(comparator or "", _version(bound), candidate)
+def satisfies(constraint: str, candidate: tuple[int, int, int]) -> bool:
+    """Does `candidate` satisfy `constraint`? Raises on forms we do not model."""
+    return any(
+        all(_satisfies_one(comparator, bound, candidate) for comparator, bound in group)
+        for group in parse_constraint(constraint)
+    )
 
 
 def _declared_constraints(formula: dict[str, Any]) -> list[str]:
@@ -141,7 +190,12 @@ def joined_constraints(constraints: Iterable[str]) -> str:
     then overwrites `merged.Requires` with the comma-joined set, so a child
     declaring `">=1.0.0"` over a parent declaring `">=2.0.0"` still compiles as
     graph-v2. A resolver that merges the field child-wins reaches the opposite
-    answer. The comma is conjunctive, which `satisfies` already models.
+    answer.
+
+    This is the SERIALISED form only. gc keeps the constraints separate in
+    `compilerRequirementSources` and evaluates them one at a time; re-reading
+    this joined string as a single conjunctive constraint is not equivalent.
+    Decide with `declares_graph_compiler_from(constraints)`.
     """
     return ", ".join(
         constraint.strip()
@@ -150,13 +204,36 @@ def joined_constraints(constraints: Iterable[str]) -> str:
     )
 
 
-def declares_graph_compiler(formula: dict[str, Any]) -> bool:
-    """The packs-side mirror of Gas City's `UsesGraphCompiler`."""
-    for constraint in _declared_constraints(formula):
+def declares_graph_compiler_from(constraints: Iterable[str]) -> bool:
+    """`UsesGraphCompiler` over an already-accumulated constraint LIST.
+
+    Take the list, never a joined string. `declaresGraphCompilerRequirement`
+    walks `compilerRequirementSources` and returns true as soon as ONE
+    constraint excludes 1.0.0 and admits 2.0.0; the comma-joined
+    `Requires.FormulaCompiler` string is a serialisation of that list, not the
+    thing evaluated. The two disagree: a child requiring `>=2.0.0` under a
+    parent requiring `!=2.0.0` is graph-v2 in Go (the child qualifies on its
+    own), and not graph-v2 when the pair is re-read as the single conjunctive
+    constraint `">=2.0.0, !=2.0.0"`, which admits neither 1.0.0 nor 2.0.0.
+    """
+    for constraint in constraints:
         if (not satisfies(constraint, DEFAULT_COMPILER_CAPABILITY)
                 and satisfies(constraint, CURRENT_COMPILER_CAPABILITY)):
             return True
     return False
+
+
+def declares_graph_compiler(formula: dict[str, Any]) -> bool:
+    """The packs-side mirror of Gas City's `UsesGraphCompiler`.
+
+    For a formula read straight off disk, which is what every guard in this
+    repository does. `formulaCompilerConstraints` falls back to
+    `directFormulaCompilerConstraints` when nothing has been accumulated, so
+    the unresolved case is exactly `contract` plus `[requires]` as two
+    constraints. For a RESOLVED `extends` chain use
+    `declares_graph_compiler_from` with the accumulated list.
+    """
+    return declares_graph_compiler_from(_declared_constraints(formula))
 
 
 def formulas_declaring_graph_compiler(

--- a/scripts/formula_compiler_requirement.py
+++ b/scripts/formula_compiler_requirement.py
@@ -1,0 +1,141 @@
+"""Decide whether a formula opts into the graph (v2) compiler.
+
+This mirrors `UsesGraphCompiler` in Gas City's `internal/formula/requirements.go`
+rather than approximating it. The real rule is not "a formula_compiler
+constraint is present": it is that at least one declared constraint **excludes**
+the default compiler capability 1.0.0 and **admits** the current capability
+2.0.0. `>=2.0.0` satisfies that; `>=1.0.0` does not (it admits both), and
+`>=999.0.0` does not (it admits neither).
+
+The distinction matters because the predicate routes real behaviour. A checker
+that only asks "is this key non-empty" reports graph-v2 for
+`formula_compiler = "banana"` and for a constraint that no compiler will ever
+satisfy, which is the shape where a guard agrees with a typo forever.
+
+Constraint parsing is deliberately narrow and **fails closed**. Gas City uses
+Masterminds semver, whose grammar is larger than what this repository's packs
+actually use; rather than half-implement it and silently mis-evaluate an
+unsupported form, `parse_constraint` raises `UnsupportedConstraint`. A pack that
+introduces a new constraint shape makes the guard fail loudly, which is the
+outcome we want over a guard that quietly guesses.
+
+Refute the rule this file encodes:
+
+    grep -n "declaresGraphCompilerRequirement" -A 25 \
+      <gascity checkout>/internal/formula/requirements.go
+    grep -n "FormulaCompilerCapability *=" \
+      <gascity checkout>/internal/formula/requirements.go
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Iterable
+
+
+# The two capabilities the real predicate tests every constraint against.
+DEFAULT_COMPILER_CAPABILITY = (1, 0, 0)
+CURRENT_COMPILER_CAPABILITY = (2, 0, 0)
+
+_VERSION = re.compile(r"^(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:[-+].*)?$")
+_COMPARATOR = re.compile(r"^(>=|<=|!=|==|=|>|<|\^|~)?\s*(.+)$")
+
+
+class UnsupportedConstraint(ValueError):
+    """The constraint uses a form this evaluator will not guess at."""
+
+
+def _version(text: str) -> tuple[int, int, int]:
+    match = _VERSION.match(text.strip())
+    if not match:
+        raise UnsupportedConstraint(f"not a version: {text!r}")
+    major, minor, patch = match.groups()
+    return (int(major), int(minor or 0), int(patch or 0))
+
+
+def _satisfies_one(comparator: str, bound: tuple[int, int, int],
+                   candidate: tuple[int, int, int]) -> bool:
+    if comparator in ("", "=", "=="):
+        return candidate == bound
+    if comparator == "!=":
+        return candidate != bound
+    if comparator == ">":
+        return candidate > bound
+    if comparator == ">=":
+        return candidate >= bound
+    if comparator == "<":
+        return candidate < bound
+    if comparator == "<=":
+        return candidate <= bound
+    if comparator == "^":
+        # ^1.2.3 := >=1.2.3 <2.0.0 (and ^0.x pins the minor, per semver).
+        if bound[0] > 0:
+            upper = (bound[0] + 1, 0, 0)
+        else:
+            upper = (0, bound[1] + 1, 0)
+        return bound <= candidate < upper
+    if comparator == "~":
+        # ~1.2.3 := >=1.2.3 <1.3.0
+        return bound <= candidate < (bound[0], bound[1] + 1, 0)
+    raise UnsupportedConstraint(f"unsupported comparator: {comparator!r}")
+
+
+def satisfies(constraint: str, candidate: tuple[int, int, int]) -> bool:
+    """Does `candidate` satisfy `constraint`? Raises on forms we do not model."""
+    if not isinstance(constraint, str) or not constraint.strip():
+        raise UnsupportedConstraint("empty constraint")
+
+    for group in constraint.split("||"):  # OR across groups
+        clauses = [c for c in re.split(r"[,\s]+", group.strip()) if c]
+        if not clauses:
+            raise UnsupportedConstraint(f"empty constraint group in {constraint!r}")
+        if all(_clause_holds(clause, candidate) for clause in clauses):
+            return True
+    return False
+
+
+def _clause_holds(clause: str, candidate: tuple[int, int, int]) -> bool:
+    match = _COMPARATOR.match(clause)
+    if not match:
+        raise UnsupportedConstraint(f"not a comparator clause: {clause!r}")
+    comparator, bound = match.groups()
+    return _satisfies_one(comparator or "", _version(bound), candidate)
+
+
+def _declared_constraints(formula: dict[str, Any]) -> list[str]:
+    """Every formula_compiler constraint this formula declares.
+
+    Both spellings are accepted, because the compiler accepts both: the
+    supported `[requires] formula_compiler`, and the deprecated
+    `contract = "graph.v2"`, which `directFormulaCompilerConstraints` maps to
+    exactly `>=2.0.0`.
+    """
+    constraints: list[str] = []
+
+    requires = formula.get("requires")
+    if isinstance(requires, dict):
+        declared = requires.get("formula_compiler")
+        if isinstance(declared, str) and declared.strip():
+            constraints.append(declared.strip())
+
+    contract = formula.get("contract")
+    if isinstance(contract, str) and contract.strip().lower() == "graph.v2":
+        constraints.append(">=2.0.0")
+
+    return constraints
+
+
+def declares_graph_compiler(formula: dict[str, Any]) -> bool:
+    """The packs-side mirror of Gas City's `UsesGraphCompiler`."""
+    for constraint in _declared_constraints(formula):
+        if (not satisfies(constraint, DEFAULT_COMPILER_CAPABILITY)
+                and satisfies(constraint, CURRENT_COMPILER_CAPABILITY)):
+            return True
+    return False
+
+
+def formulas_declaring_graph_compiler(
+    parsed: Iterable[tuple[str, dict[str, Any]]],
+) -> list[str]:
+    """Names of the (label, parsed-formula) pairs that opt into the v2 compiler."""
+    return [label for label, data in parsed if declares_graph_compiler(data)]

--- a/scripts/gascity_pack_inference_gate.py
+++ b/scripts/gascity_pack_inference_gate.py
@@ -28,6 +28,12 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
+# Sibling module. Resolved explicitly rather than relying on sys.path[0], which
+# is the script's directory only when this file is run as a script.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from formula_compiler_requirement import declares_graph_compiler  # noqa: E402
+
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 REVIEW_GATE = "review"
@@ -2608,13 +2614,15 @@ def declares_graph_v2_compiler(payload: Mapping[str, Any]) -> bool:
     warning per formula in every consuming city. The two are equivalent at the
     compiler, so this gate checks the requirement rather than the spelling and
     stops the packs repo enforcing the form its own doctor warns about.
+
+    The constraint is evaluated the way `UsesGraphCompiler` evaluates it, not
+    tested for non-emptiness: this gate routes real inference work, and a
+    formula declaring `">=1.0.0"` or a typo would otherwise be dispatched as a
+    graph-v2 formula that no compiler will treat as one. An unparseable
+    constraint raises rather than reading as False, so it surfaces as a gate
+    error instead of a silent non-selection.
     """
-    if str(payload.get("contract", "")).strip().lower() == "graph.v2":
-        return True
-    requires = payload.get("requires")
-    if not isinstance(requires, Mapping):
-        return False
-    return bool(str(requires.get("formula_compiler", "")).strip())
+    return declares_graph_compiler(dict(payload))
 
 
 def validate_methodology_build_formula(

--- a/scripts/gascity_pack_inference_gate.py
+++ b/scripts/gascity_pack_inference_gate.py
@@ -2592,9 +2592,29 @@ def load_methodology_formula(pack_source: Path, formula_name: str | None, missin
         return None
     if payload.get("formula") != formula_name:
         missing.append(f"{formula_name}: formula field is {payload.get('formula')!r}, want {formula_name!r}")
-    if payload.get("contract") != "graph.v2":
-        missing.append(f"{formula_name}: contract is {payload.get('contract')!r}, want 'graph.v2'")
+    if not declares_graph_v2_compiler(payload):
+        missing.append(
+            f"{formula_name}: declares no v2 graph compiler requirement; add "
+            '[requires] formula_compiler = ">=2.0.0"'
+        )
     return payload
+
+
+def declares_graph_v2_compiler(payload: Mapping[str, Any]) -> bool:
+    """Whether a formula requires the v2 graph compiler, in either spelling.
+
+    `[requires] formula_compiler = ">=2.0.0"` is the supported form. The legacy
+    `contract = "graph.v2"` is deprecated and raises one blocking `gc doctor`
+    warning per formula in every consuming city. The two are equivalent at the
+    compiler, so this gate checks the requirement rather than the spelling and
+    stops the packs repo enforcing the form its own doctor warns about.
+    """
+    if str(payload.get("contract", "")).strip().lower() == "graph.v2":
+        return True
+    requires = payload.get("requires")
+    if not isinstance(requires, Mapping):
+        return False
+    return bool(str(requires.get("formula_compiler", "")).strip())
 
 
 def validate_methodology_build_formula(

--- a/slack-full/manifest/README.md
+++ b/slack-full/manifest/README.md
@@ -13,18 +13,25 @@ Schema reference: <https://api.slack.com/reference/manifests>
 - **`display_information`** — bot name, short/long description, brand color.
 - **`features.bot_user`** — bot display name + `always_online`.
 - **`features.app_home`** — Messages tab enabled (DM intake), Home tab off.
-- **`features.slash_commands`** — empty list. Slash commands will be
-  populated by [`gc slack sync-commands`](../README.md) (gc-cby.2) once
-  that command lands. Until then, the slack-pack does not expose any
+- **`features.slash_commands`** — **omitted, not empty.** Slack's
+  manifest validator rejects an empty array here, so a manifest
+  carrying `"slash_commands": []` fails at import
+  ([gascity-packs#63](https://github.com/gastownhall/gascity-packs/issues/63)).
+  [`gc slack sync-commands`](../README.md) (gc-cby.2) creates the key
+  when it has a command to write. Until then the slack-pack exposes no
   `/gc …` shortcuts in Slack.
 - **`oauth_config.scopes.bot`** — the minimal scope set the live
   adapter (`examples/slack-pack/adapter/main.go`) requires today.
-  Each `*:history` scope pairs with the matching `message.*` event
-  subscription below — Slack rejects an install whose subscriptions
-  exceed its scopes, so the two lists must move together. The
+  Every event subscription below pairs with a scope here —
+  `app_mention` with `app_mentions:read`, each `message.*` with the
+  matching `*:history`. Slack rejects an install whose subscriptions
+  exceed its scopes, so the two lists must move together;
+  `tests/test_slack_manifest_conformance.py` checks the pairing for
+  every manifest in the repo. The
   `*:read` scopes are the exception: they back outbound API calls, not
   event delivery, so they add no `message.*` subscription (see the
   company-rooms note under "Agent identity apps").
+  - `app_mentions:read` — receive @-mentions (pairs with `app_mention`)
   - `channels:history` — read public channel messages (pairs with
     `message.channels`)
   - `channels:read` — company rooms: verify switchboard membership of

--- a/slack-full/manifest/agent-app.json
+++ b/slack-full/manifest/agent-app.json
@@ -14,8 +14,7 @@
       "home_tab_enabled": false,
       "messages_tab_enabled": true,
       "messages_tab_read_only_enabled": false
-    },
-    "slash_commands": []
+    }
   },
   "oauth_config": {
     "scopes": {

--- a/slack-full/manifest/app.json
+++ b/slack-full/manifest/app.json
@@ -14,12 +14,12 @@
       "home_tab_enabled": false,
       "messages_tab_enabled": true,
       "messages_tab_read_only_enabled": false
-    },
-    "slash_commands": []
+    }
   },
   "oauth_config": {
     "scopes": {
       "bot": [
+        "app_mentions:read",
         "channels:history",
         "channels:read",
         "chat:write",

--- a/slack-full/tests/test_manifest.py
+++ b/slack-full/tests/test_manifest.py
@@ -75,6 +75,8 @@ def test_manifest_declares_bot_scopes(manifest: dict) -> None:
     # install or silently drops the channel subscription. Lock the
     # invariant scope-by-event into this assertion.
     required = {
+        # pairs with the app_mention event subscription below
+        "app_mentions:read",
         "channels:history",
         # company rooms: verify switchboard membership of public
         # directory rooms (conversations.info / conversations.members)
@@ -138,11 +140,19 @@ def test_manifest_bot_events_unique_and_sorted(manifest: dict) -> None:
     assert events == sorted(events), "bot events must be sorted alphabetically"
 
 
-def test_manifest_slash_commands_field_present(manifest: dict) -> None:
-    # gc-cby.2 (sync-commands) needs this field to exist as a list so
-    # it can append/diff. Empty is fine today; missing is not.
+def test_manifest_omits_empty_slash_commands(manifest: dict) -> None:
+    # This test used to require features.slash_commands to exist as a
+    # list, on the theory that gc-cby.2 (sync-commands) needed
+    # something to append to. Slack's manifest validator rejects an
+    # empty array, so that shape made the manifest un-importable —
+    # reported against a real workspace in
+    # gastownhall/gascity-packs#63. sync-commands creates the key when
+    # it has a command to write; until then the key stays out.
     cmds = manifest.get("features", {}).get("slash_commands")
-    assert isinstance(cmds, list), "features.slash_commands must be a list"
+    assert cmds is None or cmds, (
+        "features.slash_commands must be omitted or non-empty; Slack "
+        "rejects an empty array at import"
+    )
 
 
 # --- Agent identity app template (manifest/agent-app.json) -----------

--- a/superpowers/formulas/superpowers-brainstorming.formula.toml
+++ b/superpowers/formulas/superpowers-brainstorming.formula.toml
@@ -9,7 +9,9 @@ and review guidance available through the provider skill directory.
 formula = "superpowers-brainstorming"
 type = "expansion"
 version = 1
-contract = "graph.v2"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.brainstorming_approval_mode]

--- a/superpowers/formulas/superpowers-build.formula.toml
+++ b/superpowers/formulas/superpowers-build.formula.toml
@@ -6,9 +6,11 @@ build-base lifecycle.
 """
 formula = "superpowers-build"
 version = 1
-contract = "graph.v2"
 extends = ["build-base"]
 target_required = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "superpowers-build"

--- a/superpowers/formulas/superpowers-code-review.formula.toml
+++ b/superpowers/formulas/superpowers-code-review.formula.toml
@@ -7,7 +7,9 @@ into explicit Gas City review, gap-analysis, and feedback-processing lanes.
 formula = "superpowers-code-review"
 type = "expansion"
 version = 1
-contract = "graph.v2"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/superpowers/formulas/superpowers-decomposition.formula.toml
+++ b/superpowers/formulas/superpowers-decomposition.formula.toml
@@ -3,10 +3,12 @@ Superpowers implementation of the decomposition-base methodology contract.
 """
 formula = "superpowers-decomposition"
 version = 1
-contract = "graph.v2"
 extends = ["decomposition-base"]
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [[steps]]
 id = "decompose"

--- a/superpowers/formulas/superpowers-development-item.formula.toml
+++ b/superpowers/formulas/superpowers-development-item.formula.toml
@@ -7,11 +7,13 @@ the task scope; this formula carries the execution process.
 """
 formula = "superpowers-development-item"
 version = 1
-contract = "graph.v2"
 extends = ["do-work-item"]
 target_required = true
 internal = true
 single_lane = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/superpowers/formulas/superpowers-development.formula.toml
+++ b/superpowers/formulas/superpowers-development.formula.toml
@@ -7,9 +7,11 @@ scope; this formula carries the execution process.
 """
 formula = "superpowers-development"
 version = 1
-contract = "graph.v2"
 extends = ["do-work"]
 target_required = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/superpowers/formulas/superpowers-fix-loop.formula.toml
+++ b/superpowers/formulas/superpowers-fix-loop.formula.toml
@@ -3,10 +3,12 @@ Superpowers implementation of the fix-loop-base methodology contract.
 """
 formula = "superpowers-fix-loop"
 version = 1
-contract = "graph.v2"
 extends = ["fix-loop-base"]
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_formula]

--- a/superpowers/formulas/superpowers-implementation.formula.toml
+++ b/superpowers/formulas/superpowers-implementation.formula.toml
@@ -3,10 +3,12 @@ Superpowers implementation of the public implement methodology contract.
 """
 formula = "superpowers-implementation"
 version = 1
-contract = "graph.v2"
 extends = ["implement"]
 target_required = true
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/superpowers/formulas/superpowers-plan-review.formula.toml
+++ b/superpowers/formulas/superpowers-plan-review.formula.toml
@@ -7,7 +7,9 @@ City-native review loop.
 formula = "superpowers-plan-review"
 type = "expansion"
 version = 1
-contract = "graph.v2"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [[template]]
 id = "{target}.setup-superpowers-plan-review"

--- a/superpowers/formulas/superpowers-planning.formula.toml
+++ b/superpowers/formulas/superpowers-planning.formula.toml
@@ -3,10 +3,12 @@ Superpowers implementation of the planning-base methodology contract.
 """
 formula = "superpowers-planning"
 version = 1
-contract = "graph.v2"
 extends = ["planning-base"]
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.brainstorming_approval_mode]

--- a/superpowers/formulas/superpowers-review.formula.toml
+++ b/superpowers/formulas/superpowers-review.formula.toml
@@ -3,11 +3,13 @@ Superpowers implementation of the code-review-base methodology contract.
 """
 formula = "superpowers-review"
 version = 1
-contract = "graph.v2"
 extends = ["code-review-base"]
 target_required = false
 internal = true
 mode = "report"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/superpowers/formulas/superpowers-task-review.formula.toml
+++ b/superpowers/formulas/superpowers-task-review.formula.toml
@@ -8,7 +8,9 @@ implementation lane applies findings; provider-native subagents are not used.
 formula = "superpowers-task-review"
 type = "expansion"
 version = 1
-contract = "graph.v2"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/superpowers/pack.toml
+++ b/superpowers/pack.toml
@@ -2,6 +2,14 @@
 name = "superpowers"
 version = "0.1.0"
 schema = 2
+# Minimum gc version. The formulas in this pack declare
+# [requires] formula_compiler, a table gc only learned to read in v1.3.0;
+# older gc parses the formula leniently and drops the declaration, so a
+# formula using graph-only constructs fails to compile and one that does
+# not silently takes the v1 path. gc parses this key today and does not
+# yet enforce it -- it is the declared floor, not a guarantee.
+requires_gc = ">=1.3.0"
+
 
 [imports.gc]
 source = "../gascity"

--- a/tests/graph_v2_formulas.txt
+++ b/tests/graph_v2_formulas.txt
@@ -1,0 +1,99 @@
+# Formulas that declare a formula_compiler constraint selecting the v2 graph
+# compiler, one repo-relative path per line. Read by
+# tests/test_formula_contract_declaration.py.
+#
+# This is a set, not a count. A count cannot tell "one declaration removed,
+# one formula added" from "nothing changed", and a formula stripped of its
+# declaration does not fail to compile -- it silently takes the v1 path.
+#
+# ADDING a formula that declares the constraint: add its line.
+# REMOVING a line: only when the formula itself is deleted or genuinely stops
+# needing the v2 compiler. Regenerating this file to make the test pass is the
+# regression the test exists to catch.
+bmad/formulas/bmad-build.formula.toml
+bmad/formulas/bmad-code-review-flow.formula.toml
+bmad/formulas/bmad-decomposition.formula.toml
+bmad/formulas/bmad-fix-loop.formula.toml
+bmad/formulas/bmad-implementation.formula.toml
+bmad/formulas/bmad-planning.formula.toml
+bmad/formulas/bmad-review.formula.toml
+bmad/formulas/bmad-story-development-item.formula.toml
+bmad/formulas/bmad-story-development.formula.toml
+compound-engineering/formulas/compound-build.formula.toml
+compound-engineering/formulas/compound-code-review.formula.toml
+compound-engineering/formulas/compound-decomposition.formula.toml
+compound-engineering/formulas/compound-fix-loop.formula.toml
+compound-engineering/formulas/compound-implementation.formula.toml
+compound-engineering/formulas/compound-plan-review.formula.toml
+compound-engineering/formulas/compound-planning.formula.toml
+compound-engineering/formulas/compound-resolution.formula.toml
+compound-engineering/formulas/compound-review.formula.toml
+compound-engineering/formulas/compound-work-item.formula.toml
+compound-engineering/formulas/compound-work.formula.toml
+gascity/formulas/build-base.formula.toml
+gascity/formulas/build-basic-review.formula.toml
+gascity/formulas/build-basic.formula.toml
+gascity/formulas/build-from-convoy-base.formula.toml
+gascity/formulas/build-from-convoy.formula.toml
+gascity/formulas/build-from-decompose-base.formula.toml
+gascity/formulas/build-from-decompose.formula.toml
+gascity/formulas/build-from-plan-base.formula.toml
+gascity/formulas/build-from-plan.formula.toml
+gascity/formulas/build-from-requirements-base.formula.toml
+gascity/formulas/build-from-requirements.formula.toml
+gascity/formulas/build-from-review-base.formula.toml
+gascity/formulas/build-from-review.formula.toml
+gascity/formulas/code-review-base.formula.toml
+gascity/formulas/decomposition-base.formula.toml
+gascity/formulas/design-review.formula.toml
+gascity/formulas/do-work-item.formula.toml
+gascity/formulas/do-work.formula.toml
+gascity/formulas/fix-convoy.formula.toml
+gascity/formulas/fix-loop-base.formula.toml
+gascity/formulas/gap-analysis.formula.toml
+gascity/formulas/github-issue-fix-base.formula.toml
+gascity/formulas/github-issue-fix-design-review-work.formula.toml
+gascity/formulas/github-issue-fix.formula.toml
+gascity/formulas/github-issue-triage-base.formula.toml
+gascity/formulas/github-issue-triage.formula.toml
+gascity/formulas/github-pr-review.formula.toml
+gascity/formulas/implement.formula.toml
+gascity/formulas/implementation-base.formula.toml
+gascity/formulas/implementation-item-base.formula.toml
+gascity/formulas/planning-base.formula.toml
+gascity/formulas/publish.formula.toml
+gascity/formulas/review.formula.toml
+gascity/formulas/same-session-implement.formula.toml
+gastown/formulas/mol-idea-to-plan.toml
+gastown/formulas/mol-polecat-work.toml
+gastown/formulas/mol-refinery-patrol.toml
+gastown/formulas/mol-review-leg.toml
+gstack/formulas/gstack-build.formula.toml
+gstack/formulas/gstack-code-review.formula.toml
+gstack/formulas/gstack-decomposition.formula.toml
+gstack/formulas/gstack-fix-loop.formula.toml
+gstack/formulas/gstack-implementation.formula.toml
+gstack/formulas/gstack-plan-review.formula.toml
+gstack/formulas/gstack-planning.formula.toml
+gstack/formulas/gstack-qa-review.formula.toml
+gstack/formulas/gstack-release-readiness.formula.toml
+gstack/formulas/gstack-review.formula.toml
+gstack/formulas/gstack-work-item.formula.toml
+gstack/formulas/gstack-work.formula.toml
+pr-pipeline/formulas/mol-pr-from-issue.formula.toml
+pr-review/formulas/mol-adopt-pr.formula.toml
+pr-review/formulas/mol-pr-iterate.formula.toml
+profiler/formulas/bench-nullop.formula.toml
+profiler/formulas/profile-analyze.formula.toml
+superpowers/formulas/superpowers-brainstorming.formula.toml
+superpowers/formulas/superpowers-build.formula.toml
+superpowers/formulas/superpowers-code-review.formula.toml
+superpowers/formulas/superpowers-decomposition.formula.toml
+superpowers/formulas/superpowers-development-item.formula.toml
+superpowers/formulas/superpowers-development.formula.toml
+superpowers/formulas/superpowers-fix-loop.formula.toml
+superpowers/formulas/superpowers-implementation.formula.toml
+superpowers/formulas/superpowers-plan-review.formula.toml
+superpowers/formulas/superpowers-planning.formula.toml
+superpowers/formulas/superpowers-review.formula.toml
+superpowers/formulas/superpowers-task-review.formula.toml

--- a/tests/test_ci_covers_every_test_directory.py
+++ b/tests/test_ci_covers_every_test_directory.py
@@ -1,0 +1,75 @@
+"""CI must run every test directory that exists in the repo.
+
+``gastown/tests`` and ``oversight-rig/tests`` were on disk and absent from
+the ``Run Python pack tests`` step's argument list, so those suites had
+never executed in CI. Nothing failed; they were simply not run, which is
+the quiet half of gastownhall/gascity-packs#307 (packs shipped without
+being exercised).
+
+The CI argument list stays explicit rather than switching to root
+discovery, because discovery would also sweep fixture and vendored trees.
+This test is what keeps an explicit list from drifting: add a pack with a
+``tests/`` directory and forget the workflow, and CI goes red here instead
+of silently skipping it.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+STEP_NAME = "Run Python pack tests"
+
+
+def _pytest_paths_from_workflow() -> list[str]:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    step = text.split(f"name: {STEP_NAME}", 1)
+    assert len(step) == 2, f"workflow has no step named {STEP_NAME!r}"
+    match = re.search(r"python3 -m pytest ([^\n]*)", step[1])
+    assert match, f"step {STEP_NAME!r} does not invoke `python3 -m pytest`"
+    return [
+        token
+        for token in match.group(1).split()
+        if not token.startswith("-")
+    ]
+
+
+def _test_directories_on_disk() -> list[str]:
+    found = []
+    for path in sorted(REPO_ROOT.glob("*/tests")):
+        if not path.is_dir() or path.name != "tests":
+            continue
+        if any(path.glob("test_*.py")):
+            found.append(f"{path.parent.name}/tests")
+    if any((REPO_ROOT / "tests").glob("test_*.py")):
+        found.append("tests")
+    return sorted(found)
+
+
+def test_discovery_found_test_directories() -> None:
+    # Control on the walk itself — an empty result would make the
+    # comparison below vacuously true.
+    on_disk = _test_directories_on_disk()
+    assert len(on_disk) >= 5, f"suspiciously few test directories: {on_disk}"
+
+
+def test_ci_runs_every_test_directory_on_disk() -> None:
+    in_ci = set(_pytest_paths_from_workflow())
+    on_disk = set(_test_directories_on_disk())
+    missing = sorted(on_disk - in_ci)
+    assert not missing, (
+        "these test directories exist but CI never runs them; add them to "
+        f"the {STEP_NAME!r} step in .github/workflows/ci.yml: {missing}"
+    )
+
+
+def test_ci_does_not_name_a_directory_that_is_gone() -> None:
+    in_ci = set(_pytest_paths_from_workflow())
+    on_disk = set(_test_directories_on_disk())
+    stale = sorted(in_ci - on_disk)
+    assert not stale, (
+        f"the {STEP_NAME!r} step names directories with no tests on disk: "
+        f"{stale}"
+    )

--- a/tests/test_formula_contract_declaration.py
+++ b/tests/test_formula_contract_declaration.py
@@ -17,12 +17,13 @@ Both rails are asserted. `test_no_deprecated_contract_declaration` is the deny
 check; `test_the_guard_has_something_to_check` is its discovery control, so a
 glob that stops matching cannot turn this file into a vacuous pass.
 
-The replacement floor is counted by **parsing** each formula and evaluating the
+The replacement set is derived by **parsing** each formula and evaluating the
 declared constraint the way the compiler does, not by grepping for the text
 `formula_compiler =`. A text match counts the key inside a comment, inside a
-formula's prose description, and when its value is `""` or `"banana"` — so the
-floor could hold at 87 while none of the 87 actually opted into the v2 compiler.
-The rule itself lives in `scripts/formula_compiler_requirement.py`.
+formula's prose description, and when its value is `""` or `"banana"`, so a
+grep-based check would agree with 87 formulas that opted into nothing. The rule
+itself lives in `scripts/formula_compiler_requirement.py`, and the expected set
+in `tests/graph_v2_formulas.txt`.
 """
 
 from __future__ import annotations
@@ -39,6 +40,8 @@ sys.path.insert(0, str(REPO_ROOT / "scripts"))
 from formula_compiler_requirement import (  # noqa: E402
     UnsupportedConstraint,
     declares_graph_compiler,
+    declares_graph_compiler_from,
+    satisfies,
 )
 
 DEPRECATED = re.compile(r'^\s*contract\s*=\s*"graph\.v2"', re.MULTILINE)
@@ -46,10 +49,19 @@ DEPRECATED = re.compile(r'^\s*contract\s*=\s*"graph\.v2"', re.MULTILINE)
 # Below this, the enumeration has broken rather than the repo having shrunk.
 MINIMUM_FORMULAS = 50
 
-# 87 formulas declare a formula_compiler requirement that actually selects the
-# v2 compiler, as of 2026-08-17. Refute with:
-#   grep -rl 'formula_compiler' */formulas | wc -l
-MINIMUM_DECLARING = 87
+# The formulas that declare a constraint selecting the v2 compiler, as a SET.
+# A floor on the count cannot separate "one declaration removed, one formula
+# added" from "nothing changed", so the identities are pinned instead.
+DECLARING_FIXTURE = REPO_ROOT / "tests" / "graph_v2_formulas.txt"
+
+
+def expected_declaring() -> set[str]:
+    """The pinned set, from the fixture file."""
+    return {
+        line.strip()
+        for line in DECLARING_FIXTURE.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.startswith("#")
+    }
 
 
 def formula_files() -> list[pathlib.Path]:
@@ -92,9 +104,12 @@ class FormulaContractDeclarationTest(unittest.TestCase):
         A graph-v2 formula stripped of both forms does not fail to compile. It
         silently takes the v1 path (`isGraphWorkflow` returns false and
         `compile` skips the graph stages), losing graph validation and the
-        `gc.formula_contract` bead stamp with no error anywhere. This floor is
-        the cheapest guard against that regression: it cannot rise by accident,
-        and a drop means a declaration went away rather than being converted.
+        `gc.formula_contract` bead stamp with no error anywhere.
+
+        Named formulas, not a count. A floor of 87 holds while one formula
+        loses its declaration and an unrelated one gains it, which is the
+        realistic shape of the regression: a migration touches many files and
+        misses one. The fixture makes the miss a named diff.
         """
         declaring = []
         unparseable = []
@@ -118,14 +133,23 @@ class FormulaContractDeclarationTest(unittest.TestCase):
             "scripts/formula_compiler_requirement.py the constraint form:\n  "
             + "\n  ".join(unparseable),
         )
-        self.assertGreaterEqual(
-            len(declaring),
-            MINIMUM_DECLARING,
-            f"only {len(declaring)} formulas declare a formula_compiler "
-            f"requirement that selects the v2 compiler, down from the floor of "
-            f"{MINIMUM_DECLARING}; a declaration was removed rather than "
-            "converted. Raise this floor deliberately when formulas are added, "
-            "never to make it pass.",
+        found = {str(path.relative_to(REPO_ROOT)) for path in declaring}
+        expected = expected_declaring()
+        self.assertEqual(
+            sorted(expected - found),
+            [],
+            "these formulas are pinned in tests/graph_v2_formulas.txt as "
+            "requiring the v2 graph compiler and no longer declare it, so they "
+            "now compile down the v1 path with no error anywhere. Restore the "
+            "declaration; edit the fixture only when the formula was deleted "
+            "or genuinely stopped needing v2.",
+        )
+        self.assertEqual(
+            sorted(found - expected),
+            [],
+            "these formulas declare the v2 compiler and are not in "
+            "tests/graph_v2_formulas.txt. Add them, so the next removal is a "
+            "named diff rather than a count that still adds up.",
         )
 
     def test_the_count_rejects_a_constraint_that_selects_nothing(self) -> None:
@@ -146,6 +170,49 @@ class FormulaContractDeclarationTest(unittest.TestCase):
         self.assertTrue(declares_graph_compiler({"contract": "graph.v2"}))
         with self.assertRaises(UnsupportedConstraint):
             declares_graph_compiler({"requires": {"formula_compiler": "banana"}})
+
+
+class ConstraintEvaluatorTest(unittest.TestCase):
+    """The evaluator's own edges, where it can disagree with Masterminds.
+
+    Each of these is a way a hand-written mirror silently returns the opposite
+    answer to the Go it mirrors. They live here rather than in a comment
+    because the divergence is invisible in the packs' real formulas, which all
+    declare plain `">=2.0.0"` -- the guard would stay green through every one.
+    """
+
+    def test_a_prerelease_bound_is_refused_not_truncated(self) -> None:
+        # Dropping `-alpha` makes `>1.0.0-alpha` exclude 1.0.0 and admit 2.0.0,
+        # so the truncating version reports graph-v2. Masterminds orders
+        # stable 1.0.0 ABOVE 1.0.0-alpha, admits it, and reports v1.
+        with self.assertRaises(UnsupportedConstraint):
+            satisfies(">1.0.0-alpha", (1, 0, 0))
+        # Build metadata does not affect precedence and is accepted.
+        self.assertTrue(satisfies(">=2.0.0+build.7", (2, 0, 0)))
+
+    def test_an_unsupported_group_is_refused_even_when_an_earlier_one_answers(self) -> None:
+        # `semver.NewConstraint` rejects the whole expression. An evaluator
+        # that stops at the first satisfied group is strict only for the
+        # candidate versions that happen to reach the bad group.
+        with self.assertRaises(UnsupportedConstraint):
+            satisfies("<=1.0.0 || banana", (1, 0, 0))
+        self.assertTrue(satisfies(">=2.0.0 || >=3.0.0", (2, 0, 0)))
+
+    def test_whitespace_between_comparator_and_version_is_accepted(self) -> None:
+        # Masterminds accepts it, so refusing it would fail a valid pack.
+        self.assertTrue(satisfies(">= 2.0.0", (2, 0, 0)))
+        self.assertFalse(satisfies(">= 2.0.0", (1, 0, 0)))
+
+    def test_accumulated_constraints_are_evaluated_one_at_a_time(self) -> None:
+        # `declaresGraphCompilerRequirement` walks the constraint list and
+        # returns true on the first that qualifies. The comma-joined
+        # serialisation is conjunctive and reaches the opposite answer.
+        self.assertTrue(declares_graph_compiler_from([">=2.0.0", "!=2.0.0"]))
+        self.assertFalse(
+            declares_graph_compiler({"requires": {"formula_compiler": ">=2.0.0, !=2.0.0"}}),
+            "the joined form is the wrong thing to evaluate; if it starts "
+            "agreeing, the assertion above stops distinguishing anything",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_formula_contract_declaration.py
+++ b/tests/test_formula_contract_declaration.py
@@ -1,0 +1,101 @@
+"""No shipped formula may declare the deprecated `contract = "graph.v2"`.
+
+`gc doctor`'s formula-requirements check emits one blocking warning per formula
+that still carries it, in every city that imports the pack. The supported
+declaration is:
+
+    [requires]
+    formula_compiler = ">=2.0.0"
+
+The two forms are equivalent at the compiler. `directFormulaCompilerConstraints`
+in gascity core maps `contract = "graph.v2"` to exactly the constraint the
+`[requires]` key produces, and every consumer of the graph-v2 contract keys off
+the resulting constraint set rather than the literal field, so the bead stamp
+`gc.formula_contract=graph.v2` is unaffected by the migration.
+
+Both rails are asserted. `test_no_deprecated_contract_declaration` is the deny
+check; `test_the_guard_has_something_to_check` is its discovery control, so a
+glob that stops matching cannot turn this file into a vacuous pass.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+DEPRECATED = re.compile(r'^\s*contract\s*=\s*"graph\.v2"', re.MULTILINE)
+REQUIRES_CONSTRAINT = re.compile(r'^\s*formula_compiler\s*=', re.MULTILINE)
+
+# Below this, the enumeration has broken rather than the repo having shrunk.
+MINIMUM_FORMULAS = 50
+
+# 87 formulas declare a formula_compiler requirement as of 2026-08-17, after the
+# migration off the deprecated key. Refute with:
+#   grep -rl 'formula_compiler' */formulas | wc -l
+MINIMUM_DECLARING = 87
+
+
+def formula_files() -> list[pathlib.Path]:
+    """Every shipped formula definition, from the tree rather than a list."""
+    return sorted(
+        path
+        for path in REPO_ROOT.glob("*/formulas/**/*.toml")
+        if "__pycache__" not in path.parts
+    )
+
+
+class FormulaContractDeclarationTest(unittest.TestCase):
+    def test_the_guard_has_something_to_check(self) -> None:
+        found = formula_files()
+        self.assertGreaterEqual(
+            len(found),
+            MINIMUM_FORMULAS,
+            f"only {len(found)} formula files found under {REPO_ROOT}; the "
+            "enumeration is broken, so the deny check below would pass "
+            "vacuously",
+        )
+
+    def test_no_deprecated_contract_declaration(self) -> None:
+        offenders = [
+            str(path.relative_to(REPO_ROOT))
+            for path in formula_files()
+            if DEPRECATED.search(path.read_text(encoding="utf-8"))
+        ]
+        self.assertEqual(
+            offenders,
+            [],
+            "these formulas declare the deprecated contract key; replace each "
+            'with a [requires] table carrying formula_compiler = ">=2.0.0": '
+            + ", ".join(offenders),
+        )
+
+    def test_the_declaration_was_replaced_and_not_merely_deleted(self) -> None:
+        """The deny check alone would accept deleting the declaration.
+
+        A graph-v2 formula stripped of both forms does not fail to compile. It
+        silently takes the v1 path (`isGraphWorkflow` returns false and
+        `compile` skips the graph stages), losing graph validation and the
+        `gc.formula_contract` bead stamp with no error anywhere. This floor is
+        the cheapest guard against that regression: it cannot rise by accident,
+        and a drop means a declaration went away rather than being converted.
+        """
+        declaring = [
+            path
+            for path in formula_files()
+            if REQUIRES_CONSTRAINT.search(path.read_text(encoding="utf-8"))
+        ]
+        self.assertGreaterEqual(
+            len(declaring),
+            MINIMUM_DECLARING,
+            f"only {len(declaring)} formulas declare a formula_compiler "
+            f"requirement, down from the floor of {MINIMUM_DECLARING}; a "
+            "declaration was removed rather than converted. Raise this floor "
+            "deliberately when formulas are added, never to make it pass.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_formula_contract_declaration.py
+++ b/tests/test_formula_contract_declaration.py
@@ -16,24 +16,38 @@ the resulting constraint set rather than the literal field, so the bead stamp
 Both rails are asserted. `test_no_deprecated_contract_declaration` is the deny
 check; `test_the_guard_has_something_to_check` is its discovery control, so a
 glob that stops matching cannot turn this file into a vacuous pass.
+
+The replacement floor is counted by **parsing** each formula and evaluating the
+declared constraint the way the compiler does, not by grepping for the text
+`formula_compiler =`. A text match counts the key inside a comment, inside a
+formula's prose description, and when its value is `""` or `"banana"` — so the
+floor could hold at 87 while none of the 87 actually opted into the v2 compiler.
+The rule itself lives in `scripts/formula_compiler_requirement.py`.
 """
 
 from __future__ import annotations
 
 import pathlib
 import re
+import sys
+import tomllib
 import unittest
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from formula_compiler_requirement import (  # noqa: E402
+    UnsupportedConstraint,
+    declares_graph_compiler,
+)
 
 DEPRECATED = re.compile(r'^\s*contract\s*=\s*"graph\.v2"', re.MULTILINE)
-REQUIRES_CONSTRAINT = re.compile(r'^\s*formula_compiler\s*=', re.MULTILINE)
 
 # Below this, the enumeration has broken rather than the repo having shrunk.
 MINIMUM_FORMULAS = 50
 
-# 87 formulas declare a formula_compiler requirement as of 2026-08-17, after the
-# migration off the deprecated key. Refute with:
+# 87 formulas declare a formula_compiler requirement that actually selects the
+# v2 compiler, as of 2026-08-17. Refute with:
 #   grep -rl 'formula_compiler' */formulas | wc -l
 MINIMUM_DECLARING = 87
 
@@ -82,19 +96,56 @@ class FormulaContractDeclarationTest(unittest.TestCase):
         the cheapest guard against that regression: it cannot rise by accident,
         and a drop means a declaration went away rather than being converted.
         """
-        declaring = [
-            path
-            for path in formula_files()
-            if REQUIRES_CONSTRAINT.search(path.read_text(encoding="utf-8"))
-        ]
+        declaring = []
+        unparseable = []
+        for path in formula_files():
+            try:
+                data = tomllib.loads(path.read_text(encoding="utf-8"))
+            except tomllib.TOMLDecodeError as exc:
+                unparseable.append(f"{path.relative_to(REPO_ROOT)}: {exc}")
+                continue
+            try:
+                if declares_graph_compiler(data):
+                    declaring.append(path)
+            except UnsupportedConstraint as exc:
+                unparseable.append(f"{path.relative_to(REPO_ROOT)}: {exc}")
+
+        self.assertEqual(
+            unparseable,
+            [],
+            "these formulas could not be evaluated, so they are neither "
+            "counted nor cleared; fix the file or teach "
+            "scripts/formula_compiler_requirement.py the constraint form:\n  "
+            + "\n  ".join(unparseable),
+        )
         self.assertGreaterEqual(
             len(declaring),
             MINIMUM_DECLARING,
             f"only {len(declaring)} formulas declare a formula_compiler "
-            f"requirement, down from the floor of {MINIMUM_DECLARING}; a "
-            "declaration was removed rather than converted. Raise this floor "
-            "deliberately when formulas are added, never to make it pass.",
+            f"requirement that selects the v2 compiler, down from the floor of "
+            f"{MINIMUM_DECLARING}; a declaration was removed rather than "
+            "converted. Raise this floor deliberately when formulas are added, "
+            "never to make it pass.",
         )
+
+    def test_the_count_rejects_a_constraint_that_selects_nothing(self) -> None:
+        """Mutation control for the counter itself.
+
+        A text-matching version of the check above counts every one of these,
+        which is how a floor of 87 can hold over 87 formulas that opted into
+        nothing. The predicate must separate them.
+        """
+        selects = {"formula_compiler": ">=2.0.0"}
+        for rejected in (">=1.0.0", ">=999.0.0", "", "   ", "^1.0.0"):
+            self.assertFalse(
+                declares_graph_compiler({"requires": {"formula_compiler": rejected}}),
+                f"{rejected!r} does not select the v2 compiler, but the "
+                "predicate accepted it",
+            )
+        self.assertTrue(declares_graph_compiler({"requires": selects}))
+        self.assertTrue(declares_graph_compiler({"contract": "graph.v2"}))
+        with self.assertRaises(UnsupportedConstraint):
+            declares_graph_compiler({"requires": {"formula_compiler": "banana"}})
 
 
 if __name__ == "__main__":

--- a/tests/test_pack_gc_version_floor.py
+++ b/tests/test_pack_gc_version_floor.py
@@ -1,0 +1,105 @@
+"""A pack whose formulas need gc v1.3.0 must say so in `pack.toml`.
+
+`[requires] formula_compiler` is the supported way for a formula to declare
+the graph (v2) compiler, and gc only learned to read that table in v1.3.0
+(`Requires *Requirements` first appears in `internal/formula/types.go` at that
+tag). Older gc parses formula TOML leniently, so the table is not an error
+there: it is dropped. A formula using graph-only constructs then fails to
+compile, and a formula that does not use them silently takes the v1 path.
+
+`requires_gc` in `[pack]` is where that floor is declared. Be precise about
+what it buys: gc parses the key into `config.Pack.RequiresGC` and copies it
+through `gc init`, and **nothing compares it against the running version**.
+Refute with:
+
+    grep -rn 'RequiresGC' --include=*.go <gascity checkout>/internal <gascity checkout>/cmd
+
+So this test enforces a coupling inside the packs repo rather than claiming a
+guarantee gc provides. The declaration is honest, greppable, and already in
+the schema; it starts working the day a consumer lands, and until then it is
+documentation in the place designed to hold it.
+
+The pairing is what matters: a pack that adds a `formula_compiler` constraint
+and forgets the floor ships formulas that quietly degrade on older gc, which
+is exactly the regression the migration to `[requires]` introduced.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+import tomllib
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from formula_compiler_requirement import declares_graph_compiler  # noqa: E402
+
+# The gc release that first reads `[requires]` in a formula. Refute with:
+#   git -C <gascity checkout> show v1.3.0:internal/formula/types.go \
+#     | grep -n 'Requires \*Requirements'
+REQUIRED_FLOOR = ">=1.3.0"
+
+# Below this, the pack enumeration has broken rather than the repo having
+# shrunk, and every assertion below would pass over an empty set.
+MINIMUM_PACKS = 10
+
+
+def packs() -> list[pathlib.Path]:
+    """Every pack in the repo, from the tree rather than a hand-list."""
+    return sorted(
+        path.parent
+        for path in REPO_ROOT.glob("*/pack.toml")
+        if "__pycache__" not in path.parts
+    )
+
+
+def formulas_of(pack: pathlib.Path) -> list[pathlib.Path]:
+    return sorted((pack / "formulas").glob("**/*.toml"))
+
+
+class PackGCVersionFloorTest(unittest.TestCase):
+    def test_the_guard_has_packs_to_check(self) -> None:
+        found = packs()
+        self.assertGreaterEqual(
+            len(found),
+            MINIMUM_PACKS,
+            f"only {len(found)} packs found under {REPO_ROOT}; the enumeration "
+            "is broken, so the assertions below would pass vacuously",
+        )
+
+    def test_every_pack_needing_the_v2_compiler_declares_the_floor(self) -> None:
+        missing = []
+        declaring = []
+        for pack in packs():
+            needs_v2 = False
+            for formula in formulas_of(pack):
+                try:
+                    data = tomllib.loads(formula.read_text(encoding="utf-8"))
+                except tomllib.TOMLDecodeError:
+                    continue
+                if declares_graph_compiler(data):
+                    needs_v2 = True
+                    break
+            if not needs_v2:
+                continue
+            declaring.append(pack.name)
+            manifest = tomllib.loads((pack / "pack.toml").read_text(encoding="utf-8"))
+            floor = str(manifest.get("pack", {}).get("requires_gc", "")).strip()
+            if floor != REQUIRED_FLOOR:
+                missing.append(f"{pack.name}: requires_gc = {floor!r}")
+
+        self.assertTrue(
+            declaring,
+            "no pack was found to need the v2 compiler; the formula scan is "
+            "broken, since the repo ships dozens that declare it",
+        )
+        self.assertEqual(
+            missing,
+            [],
+            "these packs ship formulas requiring the v2 graph compiler but do "
+            f"not declare requires_gc = {REQUIRED_FLOOR!r} in [pack], so they "
+            "install cleanly onto a gc that drops the declaration:\n  "
+            + "\n  ".join(missing),
+        )

--- a/tests/test_pack_gc_version_floor.py
+++ b/tests/test_pack_gc_version_floor.py
@@ -34,12 +34,23 @@ import unittest
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
-from formula_compiler_requirement import declares_graph_compiler  # noqa: E402
+from formula_compiler_requirement import (  # noqa: E402
+    UnsupportedConstraint,
+    declares_graph_compiler,
+    satisfies,
+)
 
 # The gc release that first reads `[requires]` in a formula. Refute with:
 #   git -C <gascity checkout> show v1.3.0:internal/formula/types.go \
 #     | grep -n 'Requires \*Requirements'
-REQUIRED_FLOOR = ">=1.3.0"
+SUGGESTED_FLOOR = ">=1.3.0"
+
+# The property, not the spelling: the declared constraint must admit no gc older
+# than 1.3.0, and must admit something. `">=1.4.0"` is a legitimately stricter
+# answer for a pack that needs a later feature, and an equality match against
+# SUGGESTED_FLOOR would reject it while accepting nothing better.
+TOO_OLD = ((0, 9, 0), (1, 0, 0), (1, 2, 0), (1, 2, 99))
+NEW_ENOUGH = ((1, 3, 0), (1, 4, 0), (1, 9, 9), (2, 0, 0), (99, 0, 0))
 
 # Below this, the pack enumeration has broken rather than the repo having
 # shrunk, and every assertion below would pass over an empty set.
@@ -57,6 +68,23 @@ def packs() -> list[pathlib.Path]:
 
 def formulas_of(pack: pathlib.Path) -> list[pathlib.Path]:
     return sorted((pack / "formulas").glob("**/*.toml"))
+
+
+def _floor_defect(floor: str) -> str:
+    """Why `floor` fails to exclude every gc that drops `[requires]`, or ""."""
+    if not floor:
+        return "absent"
+    try:
+        admitted_old = [v for v in TOO_OLD if satisfies(floor, v)]
+        admitted_new = [v for v in NEW_ENOUGH if satisfies(floor, v)]
+    except UnsupportedConstraint as exc:
+        return f"unparseable: {exc}"
+    if admitted_old:
+        oldest = ".".join(str(part) for part in admitted_old[0])
+        return f"admits gc {oldest}, which drops the declaration"
+    if not admitted_new:
+        return "admits no gc version at all"
+    return ""
 
 
 class PackGCVersionFloorTest(unittest.TestCase):
@@ -87,8 +115,9 @@ class PackGCVersionFloorTest(unittest.TestCase):
             declaring.append(pack.name)
             manifest = tomllib.loads((pack / "pack.toml").read_text(encoding="utf-8"))
             floor = str(manifest.get("pack", {}).get("requires_gc", "")).strip()
-            if floor != REQUIRED_FLOOR:
-                missing.append(f"{pack.name}: requires_gc = {floor!r}")
+            reason = _floor_defect(floor)
+            if reason:
+                missing.append(f"{pack.name}: requires_gc = {floor!r} ({reason})")
 
         self.assertTrue(
             declaring,
@@ -98,8 +127,27 @@ class PackGCVersionFloorTest(unittest.TestCase):
         self.assertEqual(
             missing,
             [],
-            "these packs ship formulas requiring the v2 graph compiler but do "
-            f"not declare requires_gc = {REQUIRED_FLOOR!r} in [pack], so they "
-            "install cleanly onto a gc that drops the declaration:\n  "
+            "these packs ship formulas requiring the v2 graph compiler but "
+            "their [pack] requires_gc does not exclude every gc that drops the "
+            f"declaration, so they install cleanly onto one. {SUGGESTED_FLOOR!r} "
+            "is the minimum; a stricter constraint is fine:\n  "
             + "\n  ".join(missing),
         )
+
+    def test_the_floor_check_rejects_a_constraint_that_lets_old_gc_in(self) -> None:
+        """Mutation control for `_floor_defect` itself.
+
+        An equality match against `">=1.3.0"` passes the first row of this
+        table and fails all four of the others, which is the wrong shape: the
+        question is what the constraint ADMITS, not how it is spelled.
+        """
+        self.assertEqual(_floor_defect(">=1.3.0"), "")
+        self.assertEqual(_floor_defect(">=1.4.0"), "")
+        self.assertEqual(_floor_defect(">1.2.99"), "")
+        for rejected in (">=1.2.0", ">=1.0.0", "", ">=1.3.0, <1.2.0", "banana"):
+            self.assertNotEqual(
+                _floor_defect(rejected),
+                "",
+                f"{rejected!r} does not establish the floor, but the check "
+                "accepted it",
+            )

--- a/tests/test_registry_packs_are_in_a_release_tag.py
+++ b/tests/test_registry_packs_are_in_a_release_tag.py
@@ -64,15 +64,41 @@ def release_tags() -> list[str]:
 
 def registry_pack_paths() -> dict[str, str]:
     """Registered pack name -> its directory in this repository."""
-    data = tomllib.loads(REGISTRY.read_text(encoding="utf-8"))
+    paths, _ = _registry_entries()
+    return paths
+
+
+def unresolvable_registry_entries() -> list[str]:
+    """Registered packs whose source this parser cannot turn into a directory.
+
+    Dropping them silently is the failure this returns instead: an entry the
+    regex does not match is simply absent from the map, so it is never checked
+    against a tag, and the discovery control's `>= 16` still holds from the
+    entries that did parse. A new pack spelled differently would be exactly the
+    unreleased pack this file exists to catch.
+    """
+    _, unresolvable = _registry_entries()
+    return unresolvable
+
+
+def _registry_entries(text: str | None = None) -> tuple[dict[str, str], list[str]]:
+    if text is None:
+        text = REGISTRY.read_text(encoding="utf-8")
+    data = tomllib.loads(text)
     paths: dict[str, str] = {}
-    for pack in data.get("pack", []):
+    unresolvable: list[str] = []
+    for index, pack in enumerate(data.get("pack", [])):
         name = pack.get("name")
         source = pack.get("source", "")
+        if not name:
+            unresolvable.append(f"[[pack]] #{index} has no name")
+            continue
         match = SOURCE_PATH.search(source)
-        if name and match:
-            paths[name] = match.group("path")
-    return paths
+        if not match:
+            unresolvable.append(f"{name}: source {source!r} has no /tree/<ref>/<path>")
+            continue
+        paths[name] = match.group("path")
+    return paths, unresolvable
 
 
 def packs_absent_from(tag: str) -> list[str]:
@@ -97,6 +123,13 @@ def test_the_registry_and_the_tags_are_both_readable() -> None:
     the check would report a clean repository precisely when it could see
     nothing at all.
     """
+    unresolvable = unresolvable_registry_entries()
+    assert not unresolvable, (
+        "these registry entries yielded no pack directory, so they are checked "
+        "against no tag at all and the count below still passes without "
+        "them:\n  " + "\n  ".join(unresolvable)
+    )
+
     packs = registry_pack_paths()
     assert len(packs) >= 16, (
         f"registry.toml yielded only {len(packs)} packs with a resolvable "
@@ -111,6 +144,24 @@ def test_the_registry_and_the_tags_are_both_readable() -> None:
         "`git fetch --tags`. This test fails rather than skips, because a "
         "tagless checkout cannot tell a released pack from an unreleased one."
     )
+
+
+def test_an_entry_the_parser_cannot_read_is_reported_not_dropped() -> None:
+    """Mutation control for the discovery guard above.
+
+    A source spelled any other way used to leave the entry out of the map
+    entirely: never checked against a tag, and invisible in the count. The
+    unreleased pack this file exists to catch is exactly the newly added one,
+    which is exactly the one most likely to be spelled differently.
+    """
+    paths, unresolvable = _registry_entries(
+        '[[pack]]\nname = "good"\n'
+        'source = "https://example.test/org/repo/tree/main/good"\n'
+        '[[pack]]\nname = "odd"\nsource = "https://example.test/org/repo/good"\n'
+    )
+    assert paths == {"good": "good"}
+    assert len(unresolvable) == 1, unresolvable
+    assert "odd" in unresolvable[0], unresolvable
 
 
 def test_every_registered_pack_exists_in_the_newest_release_tag() -> None:

--- a/tests/test_registry_packs_are_in_a_release_tag.py
+++ b/tests/test_registry_packs_are_in_a_release_tag.py
@@ -1,0 +1,145 @@
+"""Every registered pack must exist inside a published release tag (#137).
+
+The failure this guards against is the one three separate users reported, and
+it is silent on our side: `gc import add <repo-url>//<pack>` with no version
+constraint resolves against this repository's **git tags**, not against
+`registry.toml`. When a pack is added to `main` and no newer tag is cut, the
+resolver checks out the newest existing tag, finds no `<pack>/pack.toml` there,
+fails validation, and then deletes the cache directory it names in the error.
+The user sees `cached pack ... is missing pack.toml at <path that no longer
+exists>` and has no way to tell that the pack simply is not in any release.
+
+Nothing in this repository noticed. `superpowers`, `contributing`,
+`gascity/roles`, `pr-pipeline`, `oversight-rig`, `bmad`, `compound-engineering`
+and `runtime-cloudflare` were all registered and installable-looking while
+being absent from every tag, for weeks. `v0.4.0` (2026-07-24) closed that gap;
+this test is what keeps the next pack from reopening it.
+
+The check is deliberately against the real tree and the real tags rather than a
+fixture. A fixture-based version of this test would have passed on every day
+the repository was broken.
+
+Refute the current state with:
+
+    git tag -l 'v*' | sort -V | tail -1
+    git cat-file -e "$(git tag -l 'v*' | sort -V | tail -1):superpowers/pack.toml"
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import subprocess
+import tomllib
+
+import pytest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+REGISTRY = REPO_ROOT / "registry.toml"
+
+# A release tag, as this repository cuts them: v0.2.0, v0.3.0, v0.4.0.
+# Non-release tags exist (backup/*, pr109-head, keep-*) and must not be
+# mistaken for releases.
+RELEASE_TAG = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
+
+# The pack's directory is the path segment after /tree/<ref>/ in its source URL.
+SOURCE_PATH = re.compile(r"/tree/[^/]+/(?P<path>.+?)/?$")
+
+
+def _git(*args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(REPO_ROOT), *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+
+
+def release_tags() -> list[str]:
+    """Release tags, oldest first by version rather than by string."""
+    tags = [t for t in _git("tag", "-l").split() if RELEASE_TAG.match(t)]
+    return sorted(tags, key=lambda t: tuple(int(g) for g in RELEASE_TAG.match(t).groups()))
+
+
+def registry_pack_paths() -> dict[str, str]:
+    """Registered pack name -> its directory in this repository."""
+    data = tomllib.loads(REGISTRY.read_text(encoding="utf-8"))
+    paths: dict[str, str] = {}
+    for pack in data.get("pack", []):
+        name = pack.get("name")
+        source = pack.get("source", "")
+        match = SOURCE_PATH.search(source)
+        if name and match:
+            paths[name] = match.group("path")
+    return paths
+
+
+def packs_absent_from(tag: str) -> list[str]:
+    """Registered packs whose pack.toml does not exist at `tag`."""
+    absent = []
+    for name, path in sorted(registry_pack_paths().items()):
+        blob = f"{tag}:{path}/pack.toml"
+        exists = subprocess.run(
+            ["git", "-C", str(REPO_ROOT), "cat-file", "-e", blob],
+            capture_output=True,
+        )
+        if exists.returncode != 0:
+            absent.append(f"{name} ({path}/pack.toml absent at {tag})")
+    return absent
+
+
+def test_the_registry_and_the_tags_are_both_readable() -> None:
+    """Discovery control: neither input may be silently empty.
+
+    Without this, a shallow clone with no tags, or a registry the parser
+    returned nothing for, would make every assertion below vacuously true —
+    the check would report a clean repository precisely when it could see
+    nothing at all.
+    """
+    packs = registry_pack_paths()
+    assert len(packs) >= 16, (
+        f"registry.toml yielded only {len(packs)} packs with a resolvable "
+        "directory; the registry parse has broken rather than the repository "
+        "having shrunk"
+    )
+
+    tags = release_tags()
+    assert tags, (
+        "no vX.Y.Z release tags are visible. In CI this means the checkout did "
+        "not fetch tags (actions/checkout needs fetch-depth: 0); locally, run "
+        "`git fetch --tags`. This test fails rather than skips, because a "
+        "tagless checkout cannot tell a released pack from an unreleased one."
+    )
+
+
+def test_every_registered_pack_exists_in_the_newest_release_tag() -> None:
+    """The property users depend on: a registered pack is importable by tag."""
+    newest = release_tags()[-1]
+    absent = packs_absent_from(newest)
+    assert not absent, (
+        f"{len(absent)} registered pack(s) are absent from the newest release "
+        f"tag {newest}, so `gc import add <url>//<pack>` with no version "
+        "constraint fails for them with a misleading 'missing pack.toml' "
+        "error (gastownhall/gascity-packs#137). Cut a release tag that "
+        "includes them:\n  " + "\n  ".join(absent)
+    )
+
+
+def test_the_check_detects_a_tag_that_really_is_missing_packs() -> None:
+    """Mutation control: the assertion above can go red.
+
+    v0.3.0 is a real tag that predates eight registered packs. If
+    `packs_absent_from` reports it as clean, the detector is broken and the
+    green above means nothing.
+    """
+    tags = release_tags()
+    if "v0.3.0" not in tags:
+        pytest.skip("v0.3.0 is not in this checkout; no known-bad tag to test against")
+
+    absent = packs_absent_from("v0.3.0")
+    assert len(absent) >= 8, (
+        "v0.3.0 predates at least eight registered packs, so the detector must "
+        f"report them missing; it reported {len(absent)}. The detector, not the "
+        "repository, is what changed."
+    )

--- a/tests/test_slack_manifest_conformance.py
+++ b/tests/test_slack_manifest_conformance.py
@@ -1,0 +1,155 @@
+"""Slack-manifest conformance, applied to every Slack manifest in the repo.
+
+Reported by a user in gastownhall/gascity-packs#63: importing
+``slack-full/manifest/app.json`` into a real workspace failed Slack's
+manifest validator on two counts, and the pack's own test suite was
+green the whole time. The pack-local tests asserted the manifest's
+*shape*; Slack rejects on *rules the shape satisfies*. This file
+encodes the rules, and it runs against every manifest in the repo
+rather than the one pack that happened to get reported, because the
+same two mistakes were sitting in a second manifest nobody had tried
+to import yet (``slack-full/manifest/agent-app.json``).
+
+Discovery is by content, not by a hand-maintained path list: any
+``*.json`` under the repo carrying an ``oauth_config`` key is a Slack
+manifest and is checked. A new pack that ships one is covered on the
+day it lands, with no edit here.
+
+Rules, each with the Slack behaviour it stands in for:
+
+  * ``features.slash_commands`` must be absent or non-empty. Slack's
+    validator rejects ``[]`` outright ("must NOT have fewer than 1
+    items"), so the empty-list-as-placeholder idiom fails at import.
+  * every subscribed ``bot_events`` entry carries its required
+    ``oauth_config.scopes.bot`` scope. Slack refuses to install an app
+    whose event subscriptions exceed its granted scopes.
+  * every subscribed event is one this file knows the scope rule for.
+    Without this the previous rule would silently pass on any event
+    added later, which is the shape of a guard that can never go red.
+
+Schema reference: https://api.slack.com/reference/manifests
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+# Slack's event -> required-bot-scope table, for the events our packs
+# subscribe to. Adding an event subscription to any manifest without
+# adding its row here fails test_every_subscribed_event_has_a_known_scope_rule,
+# which is deliberate: an unmapped event would otherwise make the
+# scope check vacuously true for that event.
+EVENT_REQUIRED_SCOPE = {
+    "app_mention": "app_mentions:read",
+    "message.channels": "channels:history",
+    "message.groups": "groups:history",
+    "message.im": "im:history",
+    "message.mpim": "mpim:history",
+}
+
+
+def _slack_manifests() -> list[pathlib.Path]:
+    found = []
+    for path in sorted(REPO_ROOT.rglob("*.json")):
+        if "node_modules" in path.parts or ".git" in path.parts:
+            continue
+        try:
+            with path.open("r", encoding="utf-8") as fh:
+                doc = json.load(fh)
+        except (json.JSONDecodeError, UnicodeDecodeError, OSError):
+            continue
+        if isinstance(doc, dict) and "oauth_config" in doc:
+            found.append(path)
+    return found
+
+
+MANIFESTS = _slack_manifests()
+
+
+def _rel(path: pathlib.Path) -> str:
+    return str(path.relative_to(REPO_ROOT))
+
+
+def test_discovery_found_the_known_manifests() -> None:
+    # Control on the discovery step itself: if the walk silently
+    # stopped matching, every rule below would pass on an empty set.
+    names = {_rel(p) for p in MANIFESTS}
+    expected = {
+        "slack-channel/manifest/app.json",
+        "slack-full/manifest/agent-app.json",
+        "slack-full/manifest/app.json",
+        "slack-mini/manifest/app.json",
+    }
+    missing = expected - names
+    assert not missing, f"manifest discovery missed: {sorted(missing)}"
+
+
+@pytest.fixture(scope="module", params=MANIFESTS, ids=_rel)
+def manifest_path(request: pytest.FixtureRequest) -> pathlib.Path:
+    return request.param
+
+
+@pytest.fixture(scope="module")
+def manifest(manifest_path: pathlib.Path) -> dict:
+    with manifest_path.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def test_slash_commands_absent_or_non_empty(
+    manifest: dict, manifest_path: pathlib.Path
+) -> None:
+    features = manifest.get("features", {})
+    if "slash_commands" not in features:
+        return
+    cmds = features["slash_commands"]
+    assert isinstance(cmds, list), (
+        f"{_rel(manifest_path)}: features.slash_commands must be a list"
+    )
+    assert cmds, (
+        f"{_rel(manifest_path)}: features.slash_commands is an empty array; "
+        "Slack's manifest validator rejects it. Omit the key until there is "
+        "a command to declare (gastownhall/gascity-packs#63)."
+    )
+
+
+def test_every_subscribed_event_has_a_known_scope_rule(
+    manifest: dict, manifest_path: pathlib.Path
+) -> None:
+    events = (
+        manifest.get("settings", {})
+        .get("event_subscriptions", {})
+        .get("bot_events", [])
+    )
+    unmapped = sorted(set(events) - set(EVENT_REQUIRED_SCOPE))
+    assert not unmapped, (
+        f"{_rel(manifest_path)}: no scope rule known for {unmapped}. Add the "
+        "event -> required-scope row to EVENT_REQUIRED_SCOPE in this file, or "
+        "the scope check below passes vacuously for it."
+    )
+
+
+def test_subscribed_events_have_their_required_scopes(
+    manifest: dict, manifest_path: pathlib.Path
+) -> None:
+    events = (
+        manifest.get("settings", {})
+        .get("event_subscriptions", {})
+        .get("bot_events", [])
+    )
+    scopes = set(manifest.get("oauth_config", {}).get("scopes", {}).get("bot", []))
+    missing = {
+        EVENT_REQUIRED_SCOPE[event]: event
+        for event in events
+        if event in EVENT_REQUIRED_SCOPE
+        and EVENT_REQUIRED_SCOPE[event] not in scopes
+    }
+    assert not missing, (
+        f"{_rel(manifest_path)}: bot_events subscribed without their required "
+        "bot scope — Slack refuses the install. Missing "
+        + ", ".join(f"{scope} (for {event})" for scope, event in sorted(missing.items()))
+    )


### PR DESCRIPTION
Closes #263.

The `GC_TEMPLATE`/`commands/claim/run.sh` mismatch this fixes is the cause of the two `test_formula_assets.py::...city_claim_command...` failures reported there.

---

Five user-reported defects in the shipped packs, and the reason each one's
test suite stayed green while the pack was broken.

Closes #63. Addresses #167. Addresses #307.

Issue #137 is already resolved by the v0.4.0 release; its guard here is regression coverage, not the original fix.

## What was broken

**#63, slack-full.** A user migrating to `slack-full` could not import
`manifest/app.json`. Slack rejected it on two rules: `features.slash_commands`
was `[]` (Slack requires the key absent or non-empty), and the manifest
subscribed to `app_mention` without declaring `app_mentions:read`. The pack's
own `test_manifest.py` asserted `slash_commands` had to exist as a list, so the
test held the defect in place. `manifest/agent-app.json` carried the same empty
array and was not in the report because nobody had tried to import it yet.

**#167, deprecated contract key.** 81 formulas declared
`contract = "graph.v2"`, which raises one blocking `gc doctor` warning per
formula in every consuming city. Measured against a city importing eleven packs
and 97 formulas: 79 warnings before, 0 after. This is a rename, not a behavior
change. `directFormulaCompilerConstraints` maps the legacy field to exactly the
constraint `[requires] formula_compiler = ">=2.0.0"` produces, and consumers key
off `UsesGraphCompiler` over the resulting constraint set rather than the
literal field, so the `gc.formula_contract=graph.v2` bead stamp is untouched.

**#137, registered packs absent from every release tag.** `gc import add
<repo-url>//<pack>` with no version constraint resolves against this
repository's git tags, not `registry.toml`. A pack added to `main` with no newer
tag cut resolves to the newest existing tag, finds no `pack.toml`, fails
validation, and deletes the cache directory it names in the error. The user sees
`cached pack ... is missing pack.toml at <path that no longer exists>`. Eight
registered packs were in that state for weeks. `v0.4.0` closed the gap; the new
test is what keeps the next pack from reopening it.

**The migration to `[requires]` created a version floor nobody declared.** gc
only learned to read that table in v1.3.0 (`Requires *Requirements` first
appears in `internal/formula/types.go` at that tag, and is absent at v1.2.1).
Older gc parses formula TOML leniently, so the table is not rejected there, it
is dropped: a formula using graph-only constructs then fails to compile, and one
that does not silently takes the v1 path, losing graph validation and the bead
stamp. Nine packs now declare `requires_gc = ">=1.3.0"`.

**Be precise about what `requires_gc` buys, because the key looks stronger than
it is.** gc parses it into `config.Pack.RequiresGC` and copies it through `gc
init`, and nothing compares it against the running version:

    grep -rn 'RequiresGC' --include=*.go <gascity checkout>/internal <gascity checkout>/cmd

Every hit is a declaration, a round-trip test, or a copy. So the key is
accurate, greppable, and in the slot designed to hold it, and it starts working
the day a consumer lands. It is not a guarantee gc enforces today. The new test
says that in its docstring rather than implying otherwise. What is enforced is
the coupling inside this repo: a pack shipping a formula that selects the v2
compiler without declaring the floor fails.

**#307, partial: the suites were green for a reason unrelated to the code.**
Running the CI pytest line on a machine with a real Gas City installed produced
14 failures; on a clean CI runner the same line is green. A live Gas City seat
exports `GC_API_BASE_URL`, `GC_TEMPLATE`, `GC_CITY_PATH` and friends into every
process it spawns, and the packs read those ahead of the fixture's own
`city.toml`. Each `setUp` now strips the prefixes its pack reads before pinning
the fixture. `oversight-rig/tests` existed on disk and was missing from the CI
pytest step, so it had never run; added, with a test that keeps the explicit
list in step with the tree.

## Why the tests are evidence about a live build

Each guard below replaces one seam, and each replacement is stated with what it
can and cannot tell you. The standard is in
`pr-pipeline/docs/testing-across-the-layer-boundary.md`, added in this branch:
a fix's test fails on the unfixed live build and passes on the fixed one, with
the fix as the only difference.

| Guard | Seam replaced | Fidelity, and where it stops |
|---|---|---|
| `test_slack_manifest_conformance.py` | none. Reads the real shipped manifests from the tree, discovered by content (any `*.json` with an `oauth_config` key) rather than a path list | The rules are transcribed from the behavior a user's failed import exhibited, not from Slack's published validator. A rule Slack enforces and this file does not is invisible here |
| `test_registry_packs_are_in_a_release_tag.py` | none. Real `registry.toml`, real `git tag`, real `git cat-file -e` against the tag | A fixture version of this test would have passed on every day the repository was broken. It needs tags fetched, so it fails rather than skips on a tagless checkout |
| `test_formula_contract_declaration.py`, `test_pack_gc_version_floor.py` | `UsesGraphCompiler`, reimplemented in `scripts/formula_compiler_requirement.py` | Mirrors `declaresGraphCompilerRequirement`: a walk over the constraint list, true on the first constraint that excludes capability 1.0.0 and admits 2.0.0. Not a Masterminds semver implementation. Forms it does not model raise rather than evaluate, so a new constraint shape fails loudly. Prereleases are refused, not truncated, because a three-integer tuple cannot order `1.0.0-alpha` below `1.0.0` |
| env-prefix guard in `github/tests`, `discord/tests`, `gascity/tests` | "run the module and see what it reads", replaced by an AST enumeration over the guarded modules | Re-derives the variable names from the module ASTs at test time. A hand-list is what drifted the first time. Keys it cannot resolve to a literal are reported, not dropped, so an unresolvable read fails the guard instead of shrinking it |

Verified against the live binary rather than only the fixtures:

- 34 formulas compiled through the real `gc` binary against a throwaway city,
  before and after the #167 migration. 34 identical, 0 differing, 0 failures.
- `gc doctor` on a city importing eleven packs and 97 formulas: 79 blocking
  warnings before, 0 after, with the discovery control that reverting one file
  turns it red again.
- `gc lint` on all nine packs is unchanged by this branch. Eight report ok.
  `gastown` reports the same 14 findings on `upstream/main` and on this branch
  (five `named_session` targets a pool-controlled agent, nine `bd-unknown-flag`
  hits in prompt templates), none mentioning `requires_gc`. Commit 723e950's
  message says eleven; that count was wrong, and 14 is the measurement on both
  trees. Refute with `gc lint gastown | wc -l` from each.

Those 14 `gastown` findings are pre-existing and are not fixed here, because
they are a change to a different pack and belong in their own PR. `gastown` is
in `supported-pack-nightly.yml`, so this is not the uncovered-pack case in
#307, it is a supported pack drifting from the binary with nothing failing.

**Correction, added after this PR was opened.** The paragraph above originally
said all nine `bd-unknown-flag` findings "are real". That was asserted from the
flag list, not measured per finding, and it is wrong. Working through them one
by one in #330:

- Four are real flag errors at real invocation sites. `bd create` takes `-l,
  --labels`, not `--label`; `bd create` has no `--prefix`.
- Three are the linter flagging a documented anti-example: two strikethrough
  cells in a "Common mistake" column, and one line of prose forbidding a flag.
  Those are still worth fixing, because an anti-example built on a flag that
  does not exist teaches the wrong lesson twice, but they were never going to
  be run.
- Two are a defect in the linter, not the pack. `internal/bdflags` keys top out
  at two words, so `bd mol wisp gc --age` matches "mol wisp", reads `gc` as a
  positional, and validates `--age` against the parent instead of the
  subcommand that owns it. `bd mol wisp gc --help` documents `--age` in its own
  examples.

The five `named_session` findings are also linter defects, for a separate
reason set out in #330 and in `tests/gastown_lint_upstream_defects.txt`.

#330 fixes the seven that are pack defects and pins the seven that are not.

## Test plan

    python3 -m pytest -q            # 1372 passed, 8 skipped

Every guard added here is proven in both directions rather than asserted to
work. Red on each of these mutations, green again on restore:

- strip the `[requires]` declaration from a pinned formula
- drop a line from `tests/graph_v2_formulas.txt`
- widen the version regex to truncate prereleases
- evaluate the comma-joined constraint string instead of the list
- restore the OR short-circuit in the constraint parser
- weaken a pack's `requires_gc` to `">=1.2.0"` (and it stays green on
  `">=1.4.0"`, which is a legitimately stricter answer)
- revert either Slack manifest
- drop `GC_` or `GITHUB_INTAKE_` from a suite's strip list
- blind the environ-alias tracker, or bucket AST call sites by the first module

`test_formula_contract_declaration.py` pins the declaring formulas as a set in
`tests/graph_v2_formulas.txt` rather than a floor on the count. A count holds
while one formula loses its declaration and an unrelated one gains it, which is
the realistic shape of the regression: a migration touches many files and misses
one.

## Known and deliberate

A diamond `extends` chain appends the shared grandparent's constraint twice,
here and in gc. Neither deduplicates, and the predicate is an OR over the list,
so the repeat cannot change the answer. Left as parity rather than fixed on this
side, which would make the mirror wrong in a new way.