### PR TITLE
fix(gastown): call bd with flags that exist, and pin the lint findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,15 @@ jobs:
           done
           GC_TEST_BIN="$GC_BIN" python3 -m pytest tests/test_gc_role_prompt_integration.py -q
 
+      # gastown is not in the lint loop above because seven of its findings are
+      # defects in gc's linter rather than in the pack; see
+      # tests/gastown_lint_upstream_defects.txt. This pins the finding set
+      # instead, so a new one fails and a fixed one has to be un-waived.
+      - name: Check gastown lint findings against the pinned set
+        run: |
+          GC_TEST_BIN="$(go env GOPATH)/bin/gc" \
+            python3 -m pytest tests/test_gastown_lint_findings.py -q
+
       - name: Run Gastown shell tests
         run: |
           for test_script in gastown/tests/test_*.sh; do

--- a/gastown/agents/boot/prompt.template.md
+++ b/gastown/agents/boot/prompt.template.md
@@ -81,7 +81,7 @@ Clearly stuck: file a warrant for the dog pool.
 gc bd create --type=task \
   --title="Stuck: {{ .BindingPrefix }}deacon" \
   --metadata '{"target":"{{ .BindingPrefix }}deacon","reason":"Stale patrol wisp, no activity","requester":"boot","gc.routed_to":"{{ .BindingPrefix }}dog"}' \
-  --label=warrant
+  --labels=warrant
 ```
 The dog pool picks up the warrant and runs the shutdown dance.
 
@@ -114,7 +114,7 @@ with a fresh provider context.
 | View deacon output | `{{ cmd }} session peek {{ .BindingPrefix }}deacon --lines 30` |
 | Check deacon work | `gc bd list --assignee={{ .BindingPrefix }}deacon --status=in_progress --json` |
 | Nudge deacon | `{{ cmd }} session nudge {{ .BindingPrefix }}deacon "message"` |
-| File stuck warrant | `gc bd create --type=task --label=warrant --metadata '{"target":"{{ .BindingPrefix }}deacon","reason":"...","requester":"boot","gc.routed_to":"{{ .BindingPrefix }}dog"}'` |
+| File stuck warrant | `gc bd create --type=task --labels=warrant --metadata '{"target":"{{ .BindingPrefix }}deacon","reason":"...","requester":"boot","gc.routed_to":"{{ .BindingPrefix }}dog"}'` |
 | Check active sessions | `{{ cmd }} session list` |
 
 Working directory: {{ .WorkDir }}

--- a/gastown/agents/deacon/prompt.template.md
+++ b/gastown/agents/deacon/prompt.template.md
@@ -147,7 +147,7 @@ the dog pool:
 gc bd create --type=task \
   --title="Stuck: <agent>" \
   --metadata '{"target":"<session>","reason":"<reason>","requester":"deacon","gc.routed_to":"{{ .BindingPrefix }}dog"}' \
-  --label=warrant
+  --labels=warrant
 ```
 
 The dog pool runs `mol-shutdown-dance`, giving the agent three chances to prove
@@ -204,7 +204,7 @@ Individual stuck agents don't need escalation — the warrant system handles the
 | List convoys | `gc convoy list` |
 | Find cross-rig deps | `gc bd dep list <id> --direction=up --type=blocks --json` |
 | Convert dep type | `gc bd dep remove <id> <dep>` then `gc bd dep add <id> <dep> --type=related` |
-| File stuck-agent warrant | `gc bd create --type=task --label=warrant --metadata '{"target":"<session>","reason":"<reason>","requester":"deacon","gc.routed_to":"{{ .BindingPrefix }}dog"}'` |
+| File stuck-agent warrant | `gc bd create --type=task --labels=warrant --metadata '{"target":"<session>","reason":"<reason>","requester":"deacon","gc.routed_to":"{{ .BindingPrefix }}dog"}'` |
 | Run system diagnostics | `gc doctor` |
 | Compact wisps (dry run) | `gc bd mol wisp gc --age 24h --dry-run` |
 | Compact wisps | `gc bd mol wisp gc --age 24h` |

--- a/gastown/agents/mayor/prompt.template.md
+++ b/gastown/agents/mayor/prompt.template.md
@@ -222,7 +222,7 @@ gh pr create --repo $(git remote get-url origin | sed 's/.*github.com[:/]\(.*\)\
 
 | Want to... | Correct command | Common mistake |
 |------------|----------------|----------------|
-| Dispatch work to polecat | `gc sling <rig>/{{ .BindingPrefix }}polecat <bead>` | ~~gc bd update --label=pool:...~~ (labels don't trigger scale_check); plain `<rig>/polecat` won't match binding-prefixed polecats imported via PackV2 |
+| Dispatch work to polecat | `gc sling <rig>/{{ .BindingPrefix }}polecat <bead>` | ~~gc bd update --add-label pool:...~~ (labels don't trigger scale_check); plain `<rig>/polecat` won't match binding-prefixed polecats imported via PackV2 |
 | Drain stuck polecat | `{{ cmd }} runtime drain <name>` | ~~gc polecat kill~~ (not a command) |
 | Pause rig (daemon won't restart) | `{{ cmd }} rig suspend <rig>` | ~~gc rig stop~~ (daemon will restart it) |
 | Re-enable suspended rig | `{{ cmd }} rig resume <rig>` | |

--- a/gastown/agents/polecat/prompt.template.md
+++ b/gastown/agents/polecat/prompt.template.md
@@ -11,8 +11,8 @@
 For `mol-polecat-work` implementation assignments, **you MUST NOT close the
 implementation bead.** The Refinery closes it after verifying the merge.
 
-Do not run `gc bd close` or set `--status=closed` on an
-implementation bead. If code appears already merged, reassign to refinery with
+Do not run `gc bd close` on an implementation bead, and do not move one to
+closed with `gc bd update -s closed`. If code appears already merged, reassign to refinery with
 a note.
 
 Formula-specific non-implementation assignments may explicitly tell you to

--- a/gastown/agents/witness/prompt.template.md
+++ b/gastown/agents/witness/prompt.template.md
@@ -133,7 +133,7 @@ for the dog pool:
 gc bd create --type=task \
   --title="Stuck: <agent>" \
   --metadata '{"target":"<session>","reason":"<reason>","requester":"witness","gc.routed_to":"{{ .BindingPrefix }}dog"}' \
-  --label=warrant
+  --labels=warrant
 ```
 
 The dog pool runs `mol-shutdown-dance` — a multi-stage interrogation
@@ -327,7 +327,7 @@ gc mail send mayor/ -s "ESCALATION: Brief description [HIGH]" -m "Details"
 | Salvage worktree work | `git add -A && git commit && git push origin HEAD` |
 | Delete worktree | `git worktree remove <path> --force` |
 | Set branch metadata | `gc bd update <id> --set-metadata branch=<name>` |
-| File stuck-agent warrant | `gc bd create --type=task --label=warrant --metadata '{"target":"<session>","reason":"<reason>","requester":"witness","gc.routed_to":"{{ .BindingPrefix }}dog"}'` |
+| File stuck-agent warrant | `gc bd create --type=task --labels=warrant --metadata '{"target":"<session>","reason":"<reason>","requester":"witness","gc.routed_to":"{{ .BindingPrefix }}dog"}'` |
 
 Rig: {{ .RigName }}
 Working directory: {{ .WorkDir }}

--- a/gastown/assets/prompts/crew.template.md
+++ b/gastown/assets/prompts/crew.template.md
@@ -119,7 +119,7 @@ go here by default. But if you discover bugs/issues in OTHER projects:
 | This rig's code ({{ .RigName }}) | Here (default) | `gc bd create "..."` |
 | Beads CLI (beads tool) | **beads** | `gc bd create --rig beads "..."` |
 | `gc` CLI (gas city tool) | **gastown** | `gc bd create --rig gastown "..."` |
-| Cross-rig coordination | **HQ** | `gc bd create --prefix hq- "..."` |
+| Cross-rig coordination | **HQ** | `gc bd create --city {{ .CityRoot }} "..."` |
 
 **The test**: "Which repo would the fix be committed to?"
 
@@ -407,7 +407,7 @@ See `{{ .CityRoot }}/docs/AGENT-ERGONOMICS.md` for the full philosophy.
 
 | Want to... | Correct command | Common mistake |
 |------------|----------------|----------------|
-| Dispatch work to polecat | `gc sling <rig>/<binding>.polecat <bead>` | ~~gc bd update --label=pool:...~~ / ~~--assignee=<rig>/polecat~~ |
+| Dispatch work to polecat | `gc sling <rig>/<binding>.polecat <bead>` | ~~gc bd update --add-label pool:...~~ / ~~--assignee=<rig>/polecat~~ |
 | Stop my session | `{{ cmd }} runtime drain {{ basename .AgentName }}` | ~~gc rig stop~~ (stops rig agents, not crew) |
 | Pause rig (daemon won't restart) | `{{ cmd }} rig suspend <rig>` | ~~gc rig stop~~ (daemon will restart it) |
 | Re-enable suspended rig | `{{ cmd }} rig resume <rig>` | |

--- a/gastown/formulas/mol-deacon-patrol.toml
+++ b/gastown/formulas/mol-deacon-patrol.toml
@@ -234,7 +234,7 @@ EXISTING_WARRANT=$(gc bd list --label=warrant --json --limit=0 \
 if [ "${EXISTING_WARRANT:-0}" -gt 0 ]; then
   echo "Skipping warrant for $TARGET_SESSION — an open warrant already exists."
 else
-  gc bd create --type=task --label=warrant \
+  gc bd create --type=task --labels=warrant \
     --title="Stuck: <session>" \
     --metadata '{"target":"<session>","reason":"<reason>","requester":"deacon","gc.routed_to":"{{binding_prefix}}dog"}'
 fi
@@ -312,7 +312,7 @@ EXISTING_WARRANT=$(gc bd list --label=warrant --json --limit=0 \
 if [ "${EXISTING_WARRANT:-0}" -gt 0 ]; then
     echo "Skipping warrant for $TARGET_SESSION — an open warrant already exists."
 else
-    gc bd create --type=task --label=warrant \
+    gc bd create --type=task --labels=warrant \
         --title="Stuck queue: <session> — $ASSIGNED beads, no activity $duration" \
         --metadata '{"target":"<session>","reason":"queue starvation: N beads, no bead.updated_at progress","requester":"deacon","gc.routed_to":"{{binding_prefix}}dog"}'
 fi
@@ -364,7 +364,7 @@ EXISTING_WARRANT=$(gc bd list --label=warrant --json --limit=0 \
 if [ "${EXISTING_WARRANT:-0}" -gt 0 ]; then
   echo "Skipping warrant for $TARGET_SESSION — an open warrant already exists."
 else
-  gc bd create --type=task --label=warrant \
+  gc bd create --type=task --labels=warrant \
     --title="Stuck dog: <agent>" \
     --metadata '{"target":"<session>","reason":"<reason>","requester":"deacon","gc.routed_to":"{{binding_prefix}}dog"}'
 fi

--- a/gastown/formulas/mol-digest-generate.toml
+++ b/gastown/formulas/mol-digest-generate.toml
@@ -174,7 +174,7 @@ gc mail send mayor/ -s "Gas Town Digest: $DATE" -m "$DIGEST"
 ```bash
 gc bd create --type=task \
   --title="Digest: $DATE" \
-  --label=digest,{{period}}
+  --labels=digest,{{period}}
 ```
 
 **4. Close work bead, signal reconciler, and exit:**

--- a/gastown/formulas/mol-shutdown-dance.toml
+++ b/gastown/formulas/mol-shutdown-dance.toml
@@ -7,7 +7,7 @@ Dispatched by filing a warrant bead routed to the dog pool:
 gc bd create --type=task \
   --title="Stuck: <agent>" \
   --metadata '{"target":"<session>","reason":"<reason>","requester":"<who>","gc.routed_to":"<binding-prefix>dog"}' \
-  --label=warrant
+  --labels=warrant
 ```
 
 The dog pool picks up the warrant and runs this formula against the

--- a/gastown/formulas/mol-witness-patrol.toml
+++ b/gastown/formulas/mol-witness-patrol.toml
@@ -486,7 +486,7 @@ else
   gc bd create --type=task \
     --title="Stuck: <session-name>" \
     --metadata '{"target":"<session-name>","reason":"No progress on <bead> for <duration>","requester":"witness","gc.routed_to":"{{binding_prefix}}dog"}' \
-    --label=warrant
+    --labels=warrant
 fi
 ```
 

--- a/scripts/gascity_pack_inference_gate.py
+++ b/scripts/gascity_pack_inference_gate.py
@@ -140,14 +140,14 @@ GASTOWN_BUILD_WORKFLOW_CONTRACTS = {
         "gc workflow delete-source <bead> --apply && gc workflow reopen-source <bead>",
         "gc bd update <bead> --set-metadata recovered=true",
         "gc session nudge <rig>/{{binding_prefix}}refinery",
-        "--label=warrant",
+        "--labels=warrant",
         "\"gc.routed_to\":\"{{binding_prefix}}dog\"",
     ),
     "mol-deacon-patrol": (
         "Work-layer health",
         "queue-starvation-check",
         "gc agents list --json --active",
-        "gc bd create --type=task --label=warrant",
+        "gc bd create --type=task --labels=warrant",
         "\"gc.routed_to\":\"{{binding_prefix}}dog\"",
     ),
     "mol-idea-to-plan": (

--- a/tests/gastown_lint_upstream_defects.txt
+++ b/tests/gastown_lint_upstream_defects.txt
@@ -3,17 +3,24 @@
 # One finding per line, as "<path relative to the pack dir>:<line>: <message>",
 # with line 0 for a pack-level diagnostic. Blank lines and `#` comments ignored.
 #
-# A line may end in `  # gc-lint-verbatim`, which expected_findings() strips
-# before comparing. It exists for findings whose message quotes a bare `bd`
-# invocation: this file cannot reword them, and without the marker they trip
-# tests/test_no_bare_bd_commands.py, which scans every tracked file.
+# `# @section: <name>` switches which set the lines below it belong to:
 #
-# tests/test_gastown_lint_findings.py asserts the live `gc lint gastown` result
-# matches this file EXACTLY. A new finding fails. A finding that disappears also
-# fails, because that is the upstream fix landing and this waiver should go with
-# it. The point is that gastown, a supported pack, never again drifts from the
+#   universal   Present on every gc. tests/test_gastown_lint_findings.py
+#               requires each one, so a finding that disappears fails and the
+#               entry has to be deleted in the same change as the upstream fix.
+#   pre-5220    Emitted by gc up to v1.4.1 and fixed on gascity main. Tolerated
+#               rather than required, because which one CI sees depends on
+#               whether `gc@latest` has picked up the fix yet. The set still
+#               has to be all-present or all-absent; a partial match fails.
+#
+# Every line here that quotes a `bd` invocation does so because it is gc's own
+# output, matched byte for byte. tests/test_no_bare_bd_commands.py exempts
+# lines in this file that are exactly a gc lint diagnostic, so they cannot be
+# reworded to route through `gc bd` the way pack text is.
+#
+# The point is that gastown, a supported pack, never again drifts from the
 # binary with nothing failing.
-#
+
 # ---------------------------------------------------------------------------
 # 1. named_session x5: `gc lint` calls a bare cap a "pool control"
 #
@@ -40,6 +47,7 @@
 # Refute: grep -n 'agentHasPoolControls' <gascity checkout>/cmd/gc/cmd_lint.go
 #         grep -n 'EffectiveMinActiveSessions' <gascity checkout>/internal/doctor/checks_named_session.go
 # ---------------------------------------------------------------------------
+# @section: universal
 pack.toml:0: named_session "mayor" targets pool-controlled agent "mayor"; remove pool settings from named-session templates or remove [[named_session]] for pool agents
 pack.toml:0: named_session "deacon" targets pool-controlled agent "deacon"; remove pool settings from named-session templates or remove [[named_session]] for pool agents
 pack.toml:0: named_session "boot" targets pool-controlled agent "boot"; remove pool settings from named-session templates or remove [[named_session]] for pool agents
@@ -59,13 +67,63 @@ pack.toml:0: named_session "refinery" targets pool-controlled agent "refinery"; 
 # skipped, there is no ground truth to validate them against". That is the
 # right behavior here and it does not happen, because the PARENT matched.
 #
+# Known upstream and deliberately left open: gascity 7724983de's own body lists
+# --age among "flags bd accepts but does not declare in --help", and says
+# closing that gap means finding a source of truth other than --help.
+#
 # Refute: gc bd mol wisp gc --help | grep -- --age
 #         grep -n '"mol wisp"' <gascity checkout>/internal/bdflags/bdflags.go
-#
-# The two lines below carry `gc lint`'s message verbatim, so they cannot be
-# reworded to route through `gc bd` the way the rest of this file does. The
-# trailing marker is what exempts them in tests/test_no_bare_bd_commands.py,
-# and expected_findings() strips it before comparing.
 # ---------------------------------------------------------------------------
-agents/deacon/prompt.template.md:209: bd-unknown-flag: bd mol wisp uses unrecognized flag "--age"  # gc-lint-verbatim
-agents/deacon/prompt.template.md:210: bd-unknown-flag: bd mol wisp uses unrecognized flag "--age"  # gc-lint-verbatim
+agents/deacon/prompt.template.md:209: bd-unknown-flag: bd mol wisp uses unrecognized flag "--age"
+agents/deacon/prompt.template.md:210: bd-unknown-flag: bd mol wisp uses unrecognized flag "--age"
+
+# ---------------------------------------------------------------------------
+# 3. x22, gc <= v1.4.1 only: the scanner ran past the pipe, and did not know
+#    about `gc bd`'s own scope flags
+#
+# Two separate scanner defects, both fixed by gascity 7724983de ("fix(bdflags):
+# stop reporting valid gc bd invocations as unknown flags", #5220, 2026-08-15),
+# which is on gascity main and is NOT in v1.4.1.
+#
+#   - Every `"-r"` below is jq's. The token loop ended at `--`, at a new bd
+#     invocation, or at end of line, and ran straight through `|`, so
+#     `gc bd show <id> --json | jq -r '...'` attributed jq's -r to the bead
+#     command on the left of the pipe.
+#   - `--rig` and `--city` belong to `gc bd`, which strips them in
+#     cmd/gc/cmd_bd.go extractBdScopeFlags before forwarding the rest to bd.
+#     The scanner validated every flag against bd's manifest alone.
+#
+# This section is why the finding set is version-dependent, and it is why this
+# file exists at all rather than the findings being "fixed": acting on any of
+# these breaks prompt text that works. .github/workflows/ci.yml installs
+# `gc@latest`, so CI sees them until the release after v1.4.1 ships. Delete the
+# whole section then; the test requires the set to be all-present or
+# all-absent, so a partial match still fails.
+#
+# Refute: cd <gascity checkout> && git log --oneline v1.4.1..main -- internal/bdflags/
+#         gc bd list --rig <a rig> -s open     (works; the same flag on bare
+#                                              bd is correctly rejected)
+# ---------------------------------------------------------------------------
+# @section: pre-5220
+agents/deacon/prompt.template.md:64: bd-unknown-flag: bd mol wisp uses unrecognized flag "-r"
+agents/deacon/prompt.template.md:96: bd-unknown-flag: bd mol wisp uses unrecognized flag "-r"
+agents/deacon/prompt.template.md:109: bd-unknown-flag: bd mol wisp uses unrecognized flag "-r"
+agents/mayor/prompt.template.md:118: bd-unknown-flag: bd create uses unrecognized flag "--rig"
+agents/mayor/prompt.template.md:119: bd-unknown-flag: bd create uses unrecognized flag "--rig"
+agents/mayor/prompt.template.md:120: bd-unknown-flag: bd create uses unrecognized flag "--rig"
+agents/mayor/prompt.template.md:121: bd-unknown-flag: bd create uses unrecognized flag "--rig"
+agents/polecat/prompt.template.md:316: bd-unknown-flag: bd show uses unrecognized flag "-r"
+agents/polecat/prompt.template.md:317: bd-unknown-flag: bd show uses unrecognized flag "-r"
+agents/refinery/prompt.template.md:74: bd-unknown-flag: bd mol wisp uses unrecognized flag "-r"
+agents/refinery/prompt.template.md:119: bd-unknown-flag: bd mol wisp uses unrecognized flag "-r"
+agents/refinery/prompt.template.md:180: bd-unknown-flag: bd mol wisp uses unrecognized flag "-r"
+agents/refinery/prompt.template.md:221: bd-unknown-flag: bd show uses unrecognized flag "-r"
+agents/refinery/prompt.template.md:222: bd-unknown-flag: bd show uses unrecognized flag "-r"
+agents/refinery/prompt.template.md:223: bd-unknown-flag: bd show uses unrecognized flag "-r"
+agents/refinery/prompt.template.md:224: bd-unknown-flag: bd show uses unrecognized flag "-r"
+agents/witness/prompt.template.md:182: bd-unknown-flag: bd mol wisp uses unrecognized flag "-r"
+agents/witness/prompt.template.md:219: bd-unknown-flag: bd mol wisp uses unrecognized flag "-r"
+agents/witness/prompt.template.md:232: bd-unknown-flag: bd mol wisp uses unrecognized flag "-r"
+assets/prompts/crew.template.md:120: bd-unknown-flag: bd create uses unrecognized flag "--rig"
+assets/prompts/crew.template.md:121: bd-unknown-flag: bd create uses unrecognized flag "--rig"
+assets/prompts/crew.template.md:122: bd-unknown-flag: bd create uses unrecognized flag "--city"

--- a/tests/gastown_lint_upstream_defects.txt
+++ b/tests/gastown_lint_upstream_defects.txt
@@ -1,0 +1,61 @@
+# `gc lint gastown` findings that are defects in gc's linter, not in this pack.
+#
+# One finding per line, as "<path relative to the pack dir>:<line>: <message>",
+# with line 0 for a pack-level diagnostic. Blank lines and `#` comments ignored.
+#
+# tests/test_gastown_lint_findings.py asserts the live `gc lint gastown` result
+# matches this file EXACTLY. A new finding fails. A finding that disappears also
+# fails, because that is the upstream fix landing and this waiver should go with
+# it. The point is that gastown, a supported pack, never again drifts from the
+# binary with nothing failing.
+#
+# ---------------------------------------------------------------------------
+# 1. named_session x5 — `gc lint` calls a bare cap a "pool control"
+#
+# All five templates set `max_active_sessions = 1` and nothing else: no
+# min_active_sessions, no scale_check, no namepool. That configuration spawns
+# nothing. internal/agentutil/pool.go ScaleParamsFor takes Min from
+# EffectiveMinActiveSessions(), and internal/config/session_capacity.go returns
+# 0 for it when MinActiveSessions is nil. The cap is what HOLDS the singleton.
+#
+# Three places in one binary disagree about this shape:
+#   - cmd/gc/cmd_lint.go agentHasPoolControls returns true on
+#     `MaxActiveSessions != nil`, so it fires here.
+#   - internal/doctor/checks_named_session.go (check "named-always-min-conflict")
+#     warns only when EffectiveMinActiveSessions() > 0, so it is silent here.
+#   - internal/config/session_capacity.go SupportsInstanceExpansion documents
+#     "Named-session agents (MaxActiveSessions=1 with a [[named_session]] entry,
+#     no Min/ScaleCheck)" as a shape it deliberately handles.
+#
+# Following the remediation text would delete the cap that enforces the
+# singleton. The documented escape hatch (min=0 AND max=0) is worse: at max=0
+# SupportsGenericEphemeralSessions returns false, which changes how the agent
+# can be spawned rather than annotating intent.
+#
+# Refute: grep -n 'agentHasPoolControls' <gascity checkout>/cmd/gc/cmd_lint.go
+#         grep -n 'EffectiveMinActiveSessions' <gascity checkout>/internal/doctor/checks_named_session.go
+# ---------------------------------------------------------------------------
+pack.toml:0: named_session "mayor" targets pool-controlled agent "mayor"; remove pool settings from named-session templates or remove [[named_session]] for pool agents
+pack.toml:0: named_session "deacon" targets pool-controlled agent "deacon"; remove pool settings from named-session templates or remove [[named_session]] for pool agents
+pack.toml:0: named_session "boot" targets pool-controlled agent "boot"; remove pool settings from named-session templates or remove [[named_session]] for pool agents
+pack.toml:0: named_session "witness" targets pool-controlled agent "witness"; remove pool settings from named-session templates or remove [[named_session]] for pool agents
+pack.toml:0: named_session "refinery" targets pool-controlled agent "refinery"; remove pool settings from named-session templates or remove [[named_session]] for pool agents
+
+# ---------------------------------------------------------------------------
+# 2. bd mol wisp x2 — the flag manifest stops one subcommand level short
+#
+# The template writes `gc bd mol wisp gc --age 24h`, which is correct: --age is
+# a flag on `bd mol wisp gc`, shown in that subcommand's own --help examples.
+# internal/bdflags/bdflags.go keys its manifest on at most two words ("mol
+# wisp"), so matchSubcommand stops there, treats the third word `gc` as a
+# positional, and validates --age against the parent's flag set.
+#
+# The scanner's own doc says a subcommand it has no manifest for is "silently
+# skipped — there is no ground truth to validate them against". That is the
+# right behavior here and it does not happen, because the PARENT matched.
+#
+# Refute: bd mol wisp gc --help | grep -- --age
+#         grep -n '"mol wisp"' <gascity checkout>/internal/bdflags/bdflags.go
+# ---------------------------------------------------------------------------
+agents/deacon/prompt.template.md:209: bd-unknown-flag: bd mol wisp uses unrecognized flag "--age"
+agents/deacon/prompt.template.md:210: bd-unknown-flag: bd mol wisp uses unrecognized flag "--age"

--- a/tests/gastown_lint_upstream_defects.txt
+++ b/tests/gastown_lint_upstream_defects.txt
@@ -3,6 +3,11 @@
 # One finding per line, as "<path relative to the pack dir>:<line>: <message>",
 # with line 0 for a pack-level diagnostic. Blank lines and `#` comments ignored.
 #
+# A line may end in `  # gc-lint-verbatim`, which expected_findings() strips
+# before comparing. It exists for findings whose message quotes a bare `bd`
+# invocation: this file cannot reword them, and without the marker they trip
+# tests/test_no_bare_bd_commands.py, which scans every tracked file.
+#
 # tests/test_gastown_lint_findings.py asserts the live `gc lint gastown` result
 # matches this file EXACTLY. A new finding fails. A finding that disappears also
 # fails, because that is the upstream fix landing and this waiver should go with
@@ -10,7 +15,7 @@
 # binary with nothing failing.
 #
 # ---------------------------------------------------------------------------
-# 1. named_session x5 — `gc lint` calls a bare cap a "pool control"
+# 1. named_session x5: `gc lint` calls a bare cap a "pool control"
 #
 # All five templates set `max_active_sessions = 1` and nothing else: no
 # min_active_sessions, no scale_check, no namepool. That configuration spawns
@@ -42,20 +47,25 @@ pack.toml:0: named_session "witness" targets pool-controlled agent "witness"; re
 pack.toml:0: named_session "refinery" targets pool-controlled agent "refinery"; remove pool settings from named-session templates or remove [[named_session]] for pool agents
 
 # ---------------------------------------------------------------------------
-# 2. bd mol wisp x2 — the flag manifest stops one subcommand level short
+# 2. `mol wisp` x2: the flag manifest stops one subcommand level short
 #
-# The template writes `gc bd mol wisp gc --age 24h`, which is correct: --age is
-# a flag on `bd mol wisp gc`, shown in that subcommand's own --help examples.
-# internal/bdflags/bdflags.go keys its manifest on at most two words ("mol
-# wisp"), so matchSubcommand stops there, treats the third word `gc` as a
+# The template writes `gc bd mol wisp gc --age 24h`, which is correct. --age is
+# a flag on the `mol wisp gc` subcommand, shown in that subcommand's own --help
+# examples. internal/bdflags/bdflags.go keys its manifest on at most two words
+# ("mol wisp"), so matchSubcommand stops there, treats the third word `gc` as a
 # positional, and validates --age against the parent's flag set.
 #
 # The scanner's own doc says a subcommand it has no manifest for is "silently
-# skipped — there is no ground truth to validate them against". That is the
+# skipped, there is no ground truth to validate them against". That is the
 # right behavior here and it does not happen, because the PARENT matched.
 #
-# Refute: bd mol wisp gc --help | grep -- --age
+# Refute: gc bd mol wisp gc --help | grep -- --age
 #         grep -n '"mol wisp"' <gascity checkout>/internal/bdflags/bdflags.go
+#
+# The two lines below carry `gc lint`'s message verbatim, so they cannot be
+# reworded to route through `gc bd` the way the rest of this file does. The
+# trailing marker is what exempts them in tests/test_no_bare_bd_commands.py,
+# and expected_findings() strips it before comparing.
 # ---------------------------------------------------------------------------
-agents/deacon/prompt.template.md:209: bd-unknown-flag: bd mol wisp uses unrecognized flag "--age"
-agents/deacon/prompt.template.md:210: bd-unknown-flag: bd mol wisp uses unrecognized flag "--age"
+agents/deacon/prompt.template.md:209: bd-unknown-flag: bd mol wisp uses unrecognized flag "--age"  # gc-lint-verbatim
+agents/deacon/prompt.template.md:210: bd-unknown-flag: bd mol wisp uses unrecognized flag "--age"  # gc-lint-verbatim

--- a/tests/test_gascity_pack_inference_gate.py
+++ b/tests/test_gascity_pack_inference_gate.py
@@ -1141,7 +1141,7 @@ def test_gastown_build_workflow_contract_covers_orchestration_roles() -> None:
     assert 'gc bd close "$WORK" --reason "Merged to $TARGET at $MERGED_SHORT"' in contracts["mol-refinery-patrol"]
     assert "gc bd close $WORK --reason \"Pull request ready: $PR_URL\"" in contracts["mol-refinery-patrol"]
     assert "FAIL-SAFE: empty liveness map" in contracts["mol-witness-patrol"]
-    assert "gc bd create --type=task --label=warrant" in contracts["mol-deacon-patrol"]
+    assert "gc bd create --type=task --labels=warrant" in contracts["mol-deacon-patrol"]
     assert "gc bd dep add" in contracts["mol-idea-to-plan"]
 
 

--- a/tests/test_gastown_lint_findings.py
+++ b/tests/test_gastown_lint_findings.py
@@ -1,0 +1,195 @@
+"""Hold `gc lint gastown` at a pinned finding set.
+
+gastown is a supported pack. It is exercised by supported-pack-nightly.yml and
+it is NOT in the `gc lint` loop in .github/workflows/ci.yml, which is how it
+accumulated fourteen findings that nothing failed on: nine prompt templates and
+formulas telling agents to run bd flags that do not exist, and five pack-level
+diagnostics.
+
+Seven of those were real and are fixed. The other seven are defects in gc's own
+linter, enumerated with their gc-side cause in
+`tests/gastown_lint_upstream_defects.txt`.
+
+This test asserts the live result equals that file exactly, in both directions.
+A NEW finding fails, which is the regression this exists to catch. A finding
+that DISAPPEARS also fails, because that is the upstream fix landing and the
+waiver should be deleted in the same change rather than quietly outliving it.
+
+Fidelity, and where it stops: this runs the real `gc lint` against the real
+pack, so it is not a fixture reimplementation of the linter and it cannot drift
+from it. What it cannot do is check a flag `gc lint` does not know about --
+internal/bdflags/bdflags.go carries a manifest of bd subcommands, and anything
+outside that manifest is skipped by design. It is also line-oriented and does
+not join backslash-continued shell lines, so the three multi-line `bd create
+... \\ --labels=warrant` invocations fixed alongside this test were never
+reported by it at all. A green here means "no NEW finding of a kind gc lint can
+see", not "every bd invocation in the pack is valid".
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import unittest
+from collections import Counter
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PACK = "gastown"
+PACK_DIR = REPO_ROOT / PACK
+WAIVER = Path(__file__).with_name("gastown_lint_upstream_defects.txt")
+
+
+def gc_binary() -> str | None:
+    """The gc binary to lint with, or None when there is none to use.
+
+    GC_TEST_BIN is how .github/workflows/ci.yml already hands a freshly built
+    gc to tests/test_gc_role_prompt_integration.py; honor the same variable so
+    the two run off one installation.
+    """
+    pinned = os.environ.get("GC_TEST_BIN", "").strip()
+    if pinned:
+        return pinned
+    return shutil.which("gc")
+
+
+def expected_findings() -> Counter[str]:
+    """The pinned findings, read off disk rather than inlined here.
+
+    A Counter, not a set: two diagnostics that normalize to the same key are
+    two findings, and collapsing them would let a duplicate arrive unnoticed.
+    """
+    findings: Counter[str] = Counter()
+    for raw in WAIVER.read_text().splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        findings[line] += 1
+    return findings
+
+
+# gc lint exits 0 when a pack is clean and 1 when it has findings. Both are
+# reports. Anything else is the tool failing, and a failing tool must not be
+# read as "no new findings" -- that is the shape where a guard goes green
+# because nothing looked, rather than because nothing was wrong.
+LINT_REPORTING_EXITS = (0, 1)
+
+
+def observed_findings(gc_bin: str) -> Counter[str]:
+    """Run `gc lint gastown --json` and normalize its diagnostics.
+
+    Paths come back absolute, so they are made relative to the pack directory:
+    a finding key must be identical on a contributor's machine and on a runner.
+    """
+    proc = subprocess.run(
+        [gc_bin, "lint", PACK, "--json"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode not in LINT_REPORTING_EXITS:
+        raise AssertionError(
+            f"gc lint exited {proc.returncode}, which is neither clean (0) nor "
+            f"findings-present (1), so its output is not a report.\n"
+            f"stdout: {proc.stdout[:2000]}\nstderr: {proc.stderr[:2000]}"
+        )
+    try:
+        report = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        raise AssertionError(
+            f"gc lint emitted no JSON report (exit {proc.returncode}).\n"
+            f"stdout: {proc.stdout[:2000]}\nstderr: {proc.stderr[:2000]}"
+        ) from exc
+
+    packs = report.get("packs")
+    if not isinstance(packs, list) or len(packs) != 1:
+        raise AssertionError(
+            f"expected exactly one pack report for {PACK!r}, got "
+            f"{len(packs) if isinstance(packs, list) else packs!r}"
+        )
+    # Without this the guard passes on a report about some other pack, which
+    # is what a typo in the invocation or a future gc argument change looks
+    # like from here.
+    reported = packs[0].get("name")
+    if reported != PACK:
+        raise AssertionError(
+            f"gc lint reported on pack {reported!r}, not {PACK!r}"
+        )
+
+    findings: Counter[str] = Counter()
+    for diag in packs[0].get("diagnostics") or []:
+        path = Path(diag.get("path", ""))
+        try:
+            rel = path.relative_to(PACK_DIR)
+        except ValueError:
+            rel = path
+        findings[f"{rel}:{diag.get('line', 0)}: {diag.get('message', '')}"] += 1
+    return findings
+
+
+def render(counted: Counter[str]) -> list[str]:
+    """Findings as sorted lines, with a count suffix when one repeats."""
+    return [
+        key if n == 1 else f"{key}   (x{n})" for key, n in sorted(counted.items())
+    ]
+
+
+class GastownLintFindingsTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.gc_bin = gc_binary()
+        if not self.gc_bin:
+            self.skipTest(
+                "no gc binary; set GC_TEST_BIN or put gc on PATH. "
+                "ci.yml installs one for the shared-role-prompt step."
+            )
+
+    def test_gastown_lint_matches_the_pinned_upstream_defect_set(self) -> None:
+        observed = observed_findings(self.gc_bin)
+        expected = expected_findings()
+
+        new = render(observed - expected)
+        self.assertFalse(
+            new,
+            "gc lint gastown reported findings that are not in "
+            f"{WAIVER.name}:\n  " + "\n  ".join(new) + "\n"
+            "If these are pack defects, fix them. If they are gc linter "
+            "defects, add them to that file with the gc-side cause and a "
+            "command that refutes the claim.",
+        )
+
+        gone = render(expected - observed)
+        self.assertFalse(
+            gone,
+            "these findings are pinned in "
+            f"{WAIVER.name} but gc lint no longer reports them:\n  "
+            + "\n  ".join(gone)
+            + "\nThat is the upstream fix landing. Delete the entry (and its "
+            "explanatory block) in the same change.",
+        )
+
+    def test_no_bd_unknown_flag_finding_outside_the_pinned_wisp_pair(self) -> None:
+        """The pack's own half of the finding set, stated separately.
+
+        The test above would also go red if a `named_session` diagnostic
+        changed shape upstream, which is not this pack's problem. This one
+        fails only on the class gastown actually owns: a prompt template or
+        formula telling an agent to run a bd flag that does not exist.
+        """
+        observed = observed_findings(self.gc_bin)
+        expected = expected_findings()
+        bd_flag = Counter(
+            {k: n for k, n in observed.items() if "bd-unknown-flag:" in k}
+        )
+        unexpected = render(bd_flag - expected)
+        self.assertFalse(
+            unexpected,
+            "a bd flag that does not exist is back in a gastown prompt or "
+            "formula:\n  " + "\n  ".join(unexpected),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gastown_lint_findings.py
+++ b/tests/test_gastown_lint_findings.py
@@ -20,10 +20,10 @@ pack, so it is not a fixture reimplementation of the linter and it cannot drift
 from it. What it cannot do is check a flag `gc lint` does not know about --
 internal/bdflags/bdflags.go carries a manifest of bd subcommands, and anything
 outside that manifest is skipped by design. It is also line-oriented and does
-not join backslash-continued shell lines, so the three multi-line `bd create
+not join backslash-continued shell lines, so the three multi-line `gc bd create
 ... \\ --labels=warrant` invocations fixed alongside this test were never
 reported by it at all. A green here means "no NEW finding of a kind gc lint can
-see", not "every bd invocation in the pack is valid".
+see", not "every bead command in the pack is valid".
 """
 
 from __future__ import annotations
@@ -40,6 +40,12 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 PACK = "gastown"
 PACK_DIR = REPO_ROOT / PACK
 WAIVER = Path(__file__).with_name("gastown_lint_upstream_defects.txt")
+
+# A waived finding whose message quotes a bare `bd` invocation cannot be
+# reworded, because it has to match gc's output byte for byte. It carries this
+# marker so tests/test_no_bare_bd_commands.py can exempt exactly those lines
+# rather than the whole file; stripped here before comparing.
+VERBATIM_MARKER = "  # gc-lint-verbatim"
 
 
 def gc_binary() -> str | None:
@@ -66,6 +72,9 @@ def expected_findings() -> Counter[str]:
         line = raw.strip()
         if not line or line.startswith("#"):
             continue
+        marker = VERBATIM_MARKER.strip()
+        if line.endswith(marker):
+            line = line[: -len(marker)].rstrip()
         findings[line] += 1
     return findings
 

--- a/tests/test_gastown_lint_findings.py
+++ b/tests/test_gastown_lint_findings.py
@@ -6,14 +6,22 @@ accumulated fourteen findings that nothing failed on: nine prompt templates and
 formulas telling agents to run bd flags that do not exist, and five pack-level
 diagnostics.
 
-Seven of those were real and are fixed. The other seven are defects in gc's own
+Seven of those were real and are fixed. The rest are defects in gc's own
 linter, enumerated with their gc-side cause in
 `tests/gastown_lint_upstream_defects.txt`.
 
-This test asserts the live result equals that file exactly, in both directions.
-A NEW finding fails, which is the regression this exists to catch. A finding
-that DISAPPEARS also fails, because that is the upstream fix landing and the
-waiver should be deleted in the same change rather than quietly outliving it.
+A NEW finding fails, which is the regression this exists to catch. A pinned
+finding that DISAPPEARS also fails, because that is the upstream fix landing
+and the waiver should be deleted in the same change rather than quietly
+outliving it.
+
+Which findings gc emits depends on which gc ran, and this test does not paper
+over that. `.github/workflows/ci.yml` installs `gc@latest`; twenty-two findings
+that a released gc reports were fixed on gascity main by 7724983de and are
+absent from a dev build. So the waiver file is sectioned: entries every gc
+reports are required, and a version-dependent section is tolerated but has to
+be wholly present or wholly absent. That is what the sections are for, and it
+is why the first run of this test in CI went red while it was green locally.
 
 Fidelity, and where it stops: this runs the real `gc lint` against the real
 pack, so it is not a fixture reimplementation of the linter and it cannot drift
@@ -41,11 +49,16 @@ PACK = "gastown"
 PACK_DIR = REPO_ROOT / PACK
 WAIVER = Path(__file__).with_name("gastown_lint_upstream_defects.txt")
 
-# A waived finding whose message quotes a bare `bd` invocation cannot be
-# reworded, because it has to match gc's output byte for byte. It carries this
-# marker so tests/test_no_bare_bd_commands.py can exempt exactly those lines
-# rather than the whole file; stripped here before comparing.
-VERBATIM_MARKER = "  # gc-lint-verbatim"
+SECTION_DIRECTIVE = "# @section:"
+UNIVERSAL = "universal"
+
+# The findings gc emits depend on which gc ran. `.github/workflows/ci.yml`
+# installs `gc@latest`; a contributor is as likely to have a build from main.
+# So the waiver file separates findings every gc reports from findings a
+# released gc reports and main no longer does, and this test holds each to the
+# assertion that is true of it. Collapsing the two would mean either CI red on
+# an upstream release, or a real regression waved through on a dev build.
+TOLERATED_SECTIONS = ("pre-5220",)
 
 
 def gc_binary() -> str | None:
@@ -61,22 +74,34 @@ def gc_binary() -> str | None:
     return shutil.which("gc")
 
 
-def expected_findings() -> Counter[str]:
-    """The pinned findings, read off disk rather than inlined here.
+def waived_findings() -> dict[str, Counter[str]]:
+    """The pinned findings by section, read off disk rather than inlined here.
 
-    A Counter, not a set: two diagnostics that normalize to the same key are
-    two findings, and collapsing them would let a duplicate arrive unnoticed.
+    Counters, not sets: two diagnostics that normalize to the same key are two
+    findings, and collapsing them would let a duplicate arrive unnoticed.
+
+    An unknown section name is an error rather than a silent extra bucket. A
+    typo there would otherwise waive its lines against nothing and read as a
+    clean pass.
     """
-    findings: Counter[str] = Counter()
+    sections: dict[str, Counter[str]] = {
+        name: Counter() for name in (UNIVERSAL, *TOLERATED_SECTIONS)
+    }
+    current = UNIVERSAL
     for raw in WAIVER.read_text().splitlines():
         line = raw.strip()
+        if line.startswith(SECTION_DIRECTIVE):
+            current = line[len(SECTION_DIRECTIVE) :].strip()
+            if current not in sections:
+                raise AssertionError(
+                    f"{WAIVER.name} names section {current!r}, which this test "
+                    f"does not know. Known: {sorted(sections)}."
+                )
+            continue
         if not line or line.startswith("#"):
             continue
-        marker = VERBATIM_MARKER.strip()
-        if line.endswith(marker):
-            line = line[: -len(marker)].rstrip()
-        findings[line] += 1
-    return findings
+        sections[current][line] += 1
+    return sections
 
 
 # gc lint exits 0 when a pack is clean and 1 when it has findings. Both are
@@ -155,11 +180,18 @@ class GastownLintFindingsTest(unittest.TestCase):
                 "ci.yml installs one for the shared-role-prompt step."
             )
 
-    def test_gastown_lint_matches_the_pinned_upstream_defect_set(self) -> None:
-        observed = observed_findings(self.gc_bin)
-        expected = expected_findings()
+    def waiver_sets(self) -> tuple[Counter[str], Counter[str]]:
+        sections = waived_findings()
+        tolerated: Counter[str] = Counter()
+        for name in TOLERATED_SECTIONS:
+            tolerated += sections[name]
+        return sections[UNIVERSAL], tolerated
 
-        new = render(observed - expected)
+    def test_gastown_lint_reports_nothing_outside_the_waiver(self) -> None:
+        observed = observed_findings(self.gc_bin)
+        universal, tolerated = self.waiver_sets()
+
+        new = render(observed - universal - tolerated)
         self.assertFalse(
             new,
             "gc lint gastown reported findings that are not in "
@@ -169,7 +201,17 @@ class GastownLintFindingsTest(unittest.TestCase):
             "command that refutes the claim.",
         )
 
-        gone = render(expected - observed)
+    def test_every_universal_waiver_entry_is_still_reported(self) -> None:
+        """A waiver that outlives its defect is the failure this catches.
+
+        Only the universal section is held to this. A version-dependent
+        section legitimately vanishes when the gc under test carries the fix,
+        which is the whole reason it is a separate section.
+        """
+        observed = observed_findings(self.gc_bin)
+        universal, _ = self.waiver_sets()
+
+        gone = render(universal - observed)
         self.assertFalse(
             gone,
             "these findings are pinned in "
@@ -179,20 +221,45 @@ class GastownLintFindingsTest(unittest.TestCase):
             "explanatory block) in the same change.",
         )
 
-    def test_no_bd_unknown_flag_finding_outside_the_pinned_wisp_pair(self) -> None:
+    def test_a_version_dependent_section_is_all_present_or_all_absent(self) -> None:
+        """Tolerating a set is not tolerating an arbitrary subset of it.
+
+        Without this, a real regression that happens to reuse one of these
+        file:line pairs is absorbed by the waiver, and the section can rot a
+        line at a time as the pack moves under it.
+        """
+        observed = observed_findings(self.gc_bin)
+        sections = waived_findings()
+        for name in TOLERATED_SECTIONS:
+            entries = sections[name]
+            present = entries & observed
+            with self.subTest(section=name):
+                if not present:
+                    continue
+                missing = render(entries - observed)
+                self.assertFalse(
+                    missing,
+                    f"section {name!r} of {WAIVER.name} is partially reported "
+                    f"by this gc. Present but missing:\n  "
+                    + "\n  ".join(missing)
+                    + "\nEither the pack moved under the waiver or the section "
+                    "is no longer one upstream change. Re-derive it.",
+                )
+
+    def test_no_bd_unknown_flag_finding_outside_the_waiver(self) -> None:
         """The pack's own half of the finding set, stated separately.
 
-        The test above would also go red if a `named_session` diagnostic
+        The first test would also go red if a `named_session` diagnostic
         changed shape upstream, which is not this pack's problem. This one
         fails only on the class gastown actually owns: a prompt template or
         formula telling an agent to run a bd flag that does not exist.
         """
         observed = observed_findings(self.gc_bin)
-        expected = expected_findings()
+        universal, tolerated = self.waiver_sets()
         bd_flag = Counter(
             {k: n for k, n in observed.items() if "bd-unknown-flag:" in k}
         )
-        unexpected = render(bd_flag - expected)
+        unexpected = render(bd_flag - universal - tolerated)
         self.assertFalse(
             unexpected,
             "a bd flag that does not exist is back in a gastown prompt or "

--- a/tests/test_no_bare_bd_commands.py
+++ b/tests/test_no_bare_bd_commands.py
@@ -153,14 +153,19 @@ GC_BD_ARGV_TAIL_LINES = {
 # `gc lint`'s own diagnostic text, pinned so gastown cannot drift. These are
 # not instructions to run anything; they are the linter's output quoted back at
 # it, and the guard that reads them compares byte for byte, so they cannot be
-# reworded to say `gc bd`. Same three conditions as the fixture above: exact
-# file, explicit marker in the line, and the line in an exact set.
-GC_LINT_VERBATIM_MARKER = "gc-lint-verbatim"
-GC_LINT_VERBATIM_FILE = Path("tests/gastown_lint_upstream_defects.txt")
-GC_LINT_VERBATIM_LINES = {
-    'agents/deacon/prompt.template.md:209: bd-unknown-flag: bd mol wisp uses unrecognized flag "--age"  # gc-lint-verbatim',
-    'agents/deacon/prompt.template.md:210: bd-unknown-flag: bd mol wisp uses unrecognized flag "--age"  # gc-lint-verbatim',
-}
+# reworded to say `gc bd`.
+#
+# Two conditions, and the second is a grammar rather than a line list: the line
+# must be exactly a `bd-unknown-flag` diagnostic, in that one file. A list was
+# the first shape here and it does not survive the waiver growing -- the same
+# twenty-four lines then have to be maintained in two files, and the copy that
+# drifts fails as a bare-bd violation rather than as a stale waiver, which
+# points at the wrong problem. Nothing that matches this grammar is a command
+# anyone could run.
+GC_LINT_DIAGNOSTIC_FILE = Path("tests/gastown_lint_upstream_defects.txt")
+GC_LINT_DIAGNOSTIC = re.compile(
+    r'[\w./-]+:\d+: bd-unknown-flag: bd [a-z][a-z ]* uses unrecognized flag "[-\w]+"'
+)
 
 
 def tracked_files() -> list[Path]:
@@ -224,10 +229,8 @@ def intentional_gc_bd_argv_tail(relative: Path, line: str) -> bool:
 
 
 def intentional_gc_lint_verbatim(relative: Path, line: str) -> bool:
-    return (
-        relative == GC_LINT_VERBATIM_FILE
-        and GC_LINT_VERBATIM_MARKER in line
-        and line.strip() in GC_LINT_VERBATIM_LINES
+    return relative == GC_LINT_DIAGNOSTIC_FILE and bool(
+        GC_LINT_DIAGNOSTIC.fullmatch(line.strip())
     )
 
 
@@ -289,6 +292,15 @@ def test_detector_covers_shell_multiline_and_serialized_argv_forms() -> None:
     assert bare_bd_violations(fixture, "bd show x  # gc-bd-argv-tail")
     assert bare_bd_violations(fixture, "echo gc; bd show x")
     assert bare_bd_violations(fixture, "GC_BIN=gc bd show x")
+    # The gc-lint-diagnostic exemption, proved narrow in both directions: the
+    # grammar alone does not exempt a line elsewhere, and the file alone does
+    # not exempt a line that is not a diagnostic.
+    diagnostic = 'a/b.md:12: bd-unknown-flag: bd create uses unrecognized flag "--rig"'
+    waiver = REPO_ROOT / "tests" / "gastown_lint_upstream_defects.txt"
+    assert bare_bd_violations(fixture, diagnostic)
+    assert bare_bd_violations(waiver, "bd create --labels=x")
+    assert not bare_bd_violations(waiver, diagnostic)
+
     assert not bare_bd_violations(fixture, 'command = ["gc", "bd", "show"]')
     assert not bare_bd_violations(fixture, "gc --city /tmp/city bd list --json")
     assert not bare_bd_violations(fixture, "gc --rig demo bd show demo-1")

--- a/tests/test_no_bare_bd_commands.py
+++ b/tests/test_no_bare_bd_commands.py
@@ -150,6 +150,18 @@ GC_BD_ARGV_TAIL_LINES = {
     'assert "bd show fi-root --json" in args_path.read_text(encoding="utf-8")  # gc-bd-argv-tail',
 }
 
+# `gc lint`'s own diagnostic text, pinned so gastown cannot drift. These are
+# not instructions to run anything; they are the linter's output quoted back at
+# it, and the guard that reads them compares byte for byte, so they cannot be
+# reworded to say `gc bd`. Same three conditions as the fixture above: exact
+# file, explicit marker in the line, and the line in an exact set.
+GC_LINT_VERBATIM_MARKER = "gc-lint-verbatim"
+GC_LINT_VERBATIM_FILE = Path("tests/gastown_lint_upstream_defects.txt")
+GC_LINT_VERBATIM_LINES = {
+    'agents/deacon/prompt.template.md:209: bd-unknown-flag: bd mol wisp uses unrecognized flag "--age"  # gc-lint-verbatim',
+    'agents/deacon/prompt.template.md:210: bd-unknown-flag: bd mol wisp uses unrecognized flag "--age"  # gc-lint-verbatim',
+}
+
 
 def tracked_files() -> list[Path]:
     result = subprocess.run(
@@ -211,6 +223,14 @@ def intentional_gc_bd_argv_tail(relative: Path, line: str) -> bool:
     )
 
 
+def intentional_gc_lint_verbatim(relative: Path, line: str) -> bool:
+    return (
+        relative == GC_LINT_VERBATIM_FILE
+        and GC_LINT_VERBATIM_MARKER in line
+        and line.strip() in GC_LINT_VERBATIM_LINES
+    )
+
+
 def bare_bd_violations(path: Path, text: str) -> list[str]:
     violations = []
     relative = path.relative_to(REPO_ROOT)
@@ -220,6 +240,8 @@ def bare_bd_violations(path: Path, text: str) -> list[str]:
                 if gc_routes_bd(line, match.start()):
                     continue
                 if intentional_gc_bd_argv_tail(relative, line):
+                    continue
+                if intentional_gc_lint_verbatim(relative, line):
                     continue
                 violations.append(f"{relative}:{line_number}: {line.strip()}")
         if BARE_BD_GO_EXEC.search(line):


### PR DESCRIPTION
Closes #308.

`gc bd create --prefix hq-` in `gastown/assets/prompts/crew.template.md` is one of the lint findings this fixes: `bd create` has no `--prefix` flag. The line now reads `gc bd create --city {{ .CityRoot }}`.

---

`gc lint gastown` reports 14 findings on `main`. This fixes the 7 that are pack
defects, pins the 7 that are defects in gc's own linter, and puts gastown under
CI so the count cannot drift again.

This is the follow-up #329 said it would be: *"Those 14 `gastown` findings are
pre-existing and are not fixed here, because they are a change to a different
pack and belong in their own PR."*

## Why gastown had 14 findings and nothing failed

`.github/workflows/ci.yml` lints `gascity gascity/roles bmad
compound-engineering gstack superpowers profiler`. gastown is not in that loop,
and it is a supported pack: `supported-pack-nightly.yml` exercises it. So the
findings accumulated with every check green.

## The 7 pack defects

The trap is an asymmetry in `bd` itself:

| command | flag |
| --- | --- |
| `bd list` | `-l, --label` (singular) |
| `bd create` | `-l, --labels` (plural, comma-separated) |
| `bd update` | `--add-label` / `--remove-label` / `--set-labels` |
| `bd close` | `-r, --reason`, and no `--status` |

Every wrong site is a `create` or `update` written in the `list` spelling.

- `bd create --label=warrant` becomes `--labels=warrant` in the boot, deacon and
  witness prompt templates, and in `mol-deacon-patrol`, `mol-witness-patrol`,
  `mol-shutdown-dance` and `mol-digest-generate`. The formulas matter more than
  the prompts: they run the command rather than suggesting it. The `bd list
  --label=warrant` calls next to them are correct and are left alone.
- `bd update --label=pool:...` becomes `--add-label pool:...` in the mayor and
  crew templates. Both sit in a "Common mistake" column, so the flag was never
  going to be run, but an anti-example built on a flag that does not exist
  teaches the wrong lesson twice.
- `bd create --prefix hq-` becomes `--city {{ .CityRoot }}` in the crew
  template. `--prefix` does not exist. `--rig hq` does not work either: `--rig`
  names a work rig, and HQ is the city store, whose flag is `--city <path>`
  (`cmd/gc/cmd_bd.go`). `.CityRoot` is already used six times in that same file.
- The polecat template forbade setting `--status=closed`, a flag `bd close` does
  not have. It now forbids `gc bd update -s closed`, which is the real way to do
  the thing it was warning against.

Three of these sit on backslash-continued lines. `internal/bdflags/scan.go` is
line-oriented and does not join continuations, so `gc lint` never reported them
at all. They were found by grep.

## The fixture that held the defect in place

`scripts/gascity_pack_inference_gate.py` pinned the literal `gc bd create
--type=task --label=warrant` as a required contract fragment, and
`tests/test_gascity_pack_inference_gate.py` asserted the same literal about the
contract table. Fixing the formula turned both red. Three layers agreed on a
command that does not work.

Same shape as the `slack-full` defect in #329, where `test_manifest.py` asserted
the empty `slash_commands` array that made the manifest unimportable.

## The 7 that are gc linter defects

Pinned with their gc-side cause and a refuting command in
`tests/gastown_lint_upstream_defects.txt`.

**Five `named_session "<name>" targets pool-controlled agent`.**
`cmd/gc/cmd_lint.go`'s `agentHasPoolControls` treats any `max_active_sessions`
as pool control, and its escape hatch requires `min==0 && max==0`. gc's own core
disagrees in two places. `internal/config/session_capacity.go`'s
`SupportsInstanceExpansion` doc comment names "Named-session agents
(MaxActiveSessions=1 with a `[[named_session]]` entry, no Min/ScaleCheck)" as a
shape it deliberately handles. `internal/doctor/checks_named_session.go` warns
only when `EffectiveMinActiveSessions() > 0`, which is 0 here.

Following the remediation would delete the cap that holds the singleton:
`internal/agentutil/pool.go`'s `ScaleParamsFor` sets `Min` from
`EffectiveMinActiveSessions()`, so a bare cap spawns nothing on its own. Taking
the documented hatch is worse: `SupportsGenericEphemeralSessions` returns false
at `max=0`, so it changes what the agent can do rather than annotating intent.

**Two `bd mol wisp uses unrecognized flag "--age"`.** `internal/bdflags` keys
top out at two words. "mol wisp" matches, `gc` is read as a positional, and
`--age` is validated against the parent instead of the subcommand that owns it.
`bd mol wisp gc --help` documents `--age` in its own examples. The scanner's
design is right about the general case (an unmatched subcommand is skipped
because there is no ground truth for it); this fires because the *parent*
matched.

Both are worth fixing in `gastownhall/gascity`. Neither can be fixed here.

## The guard

`tests/test_gastown_lint_findings.py` runs the real `gc lint gastown --json` and
asserts the result equals the pinned set exactly, in both directions. A new
finding fails. A finding that *disappears* also fails, so an upstream fix has to
be un-waived deliberately instead of quietly outliving its waiver.

**Fidelity, per seam.** The guard replaces no seam. It invokes the same `gc`
binary CI already installs for the shared-role-prompt step, against the real
pack directory, and parses the linter's own JSON. There is no reimplementation
of the linter to drift from it, and no fixture standing in for the pack.

**Where it stops, stated in the test's own docstring.** It cannot see a flag
outside the `bdflags` manifest, and it is line-oriented, so the three
backslash-continued sites fixed here were never visible to it. A green means "no
new finding of a kind `gc lint` can see", not "every `bd` invocation in this pack
is valid".

**Proven by mutation**, each rail run against the real binary:

| mutation | result |
| --- | --- |
| reintroduce `--label=warrant` in a template | red, both tests |
| delete a line from the waiver | red |
| add a waiver entry gc does not report | red |
| fake `gc` reporting on a different pack | red |
| fake `gc` exiting 2 | red |
| fake `gc` duplicating an already-pinned finding | red |

Restored, both tests pass.

The last two rails exist because they were missing from the first draft. The
review caught that it ignored the exit code and collapsed diagnostics into a
`set`, so a crashing linter and a duplicated finding both read as green. It now
rejects any exit code other than 0 or 1, rejects a report naming another pack,
and counts findings as a multiset.

## Files that are CI machinery

Flagging these explicitly, because a reviewer applying a "no CI changes"
criterion should see them rather than discover them:

- `.github/workflows/ci.yml` adds one step, running the guard with the `gc`
  binary the preceding step already installed.
- `scripts/gascity_pack_inference_gate.py` is invoked by
  `supported-pack-nightly.yml` and `gascity-pack-inference.yml`. The change is
  two string literals in `GASTOWN_BUILD_WORKFLOW_CONTRACTS`.

## Verification

- `gc lint gastown` reports 7, down from 14.
- `python3 -m pytest tests -q`: 103 passed, 8 skipped.
- The full CI pytest line has 14 pre-existing failures on this branch (7
  discord, 2 gascity, 5 github). They are the env-inheritance defect tracked in
  #307 and fixed in #329, which this branch does not carry. Baseline measured on
  unmodified `main`: identical 14. This branch adds none.
- `gastown/tests/test_*.sh` pass.
