### PR TITLE
fix(packs): resolve the default branch from the local ref, not the network

### DIFF
--- a/contributing/formulas/mol-contributing-fine-tune.formula.toml
+++ b/contributing/formulas/mol-contributing-fine-tune.formula.toml
@@ -66,7 +66,16 @@ if [ -z "$BRANCH" ] || [ "$BRANCH" = "HEAD" ]; then
     gc bd close "$ROOT_ID" --reason "no branch resolved"
     exit 1
 fi
-DEFAULT=$(git remote show origin 2>/dev/null | sed -n 's/.*HEAD branch: //p' || echo "main")
+# Resolve the default branch locally. `|| echo "main"` on the old
+# `git remote show origin` pipeline could never fire: sed exits 0 on empty
+# input, so a network failure produced DEFAULT="" and this check silently
+# fell back to the hardcoded main/master arms below.
+DEFAULT=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||')
+if [ -z "$DEFAULT" ]; then
+    git remote set-head origin --auto >/dev/null 2>&1 || true
+    DEFAULT=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||')
+fi
+[ -n "$DEFAULT" ] || DEFAULT=main
 if [ "$BRANCH" = "$DEFAULT" ] || [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then
     echo "Cannot fine-tune from default branch ($BRANCH). Create a feature branch first."
     gc bd close "$ROOT_ID" --reason "on default branch"

--- a/gascity/assets/workflows/do-work/prepare-worktree.md
+++ b/gascity/assets/workflows/do-work/prepare-worktree.md
@@ -24,9 +24,25 @@ setup only. Do not edit source files in the launcher checkout.
    `$(pwd)/worktrees/<source-anchor-id>`, based on the up-to-date remote
    default branch — never the launcher's local `HEAD`, which may be behind
    `origin`. If the path is missing:
-   - Resolve the remote default branch (do not hardcode `main`):
-     `DEFAULT_BRANCH=$(git remote show origin 2>/dev/null | sed -n 's/.*HEAD branch: //p')`.
-     If it is empty, fail closed — do not fall back to local `HEAD`.
+   - Resolve the remote default branch (do not hardcode `main`). Read the
+     local ref first, and only touch the network if it is missing:
+
+     ```sh
+     DEFAULT_BRANCH=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||')
+     if [ -z "$DEFAULT_BRANCH" ]; then
+       git remote set-head origin --auto >/dev/null 2>&1 || true
+       DEFAULT_BRANCH=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||')
+     fi
+     ```
+
+     `refs/remotes/origin/HEAD` is written by `git clone` and refreshed by
+     `git remote set-head origin --auto`. It is NOT written by `git init` plus
+     `git fetch`, which is how `actions/checkout` and several of our own
+     checkouts are built, so the refresh branch is load-bearing rather than
+     defensive. The fetch on the next line still guarantees the base is
+     current, so a stale ref costs nothing.
+
+     If it is still empty, fail closed — do not fall back to local `HEAD`.
    - Fetch it so the base is current:
      `git fetch --prune origin "$DEFAULT_BRANCH"`.
    - Create the worktree detached at the freshly fetched tip:

--- a/pr-pipeline/formulas/mol-pr-from-issue.formula.toml
+++ b/pr-pipeline/formulas/mol-pr-from-issue.formula.toml
@@ -256,7 +256,16 @@ ROOT_ID=$(gc bd mol current --json | jq -r '.molecule_id')
 REPO_ROOT=$(git rev-parse --show-toplevel)
 cd "$REPO_ROOT"
 BRANCH=$(git branch --show-current)
-DEFAULT=$(git remote show origin 2>/dev/null | sed -n 's/.*HEAD branch: //p' || echo "main")
+# Resolve the default branch locally. `|| echo "main"` on the old
+# `git remote show origin` pipeline could never fire: sed exits 0 on empty
+# input, so a network failure produced DEFAULT="" and this check silently
+# fell back to the hardcoded main/master arms below.
+DEFAULT=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||')
+if [ -z "$DEFAULT" ]; then
+    git remote set-head origin --auto >/dev/null 2>&1 || true
+    DEFAULT=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||')
+fi
+[ -n "$DEFAULT" ] || DEFAULT=main
 if [ "$BRANCH" = "$DEFAULT" ] || [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then
     gc bd update "$ROOT_ID" --set-metadata "gc.halt_chain=true" \\
       --set-metadata "summary_for_human=Cannot ship from default branch ($BRANCH). pr-start did not create a feature branch — chain stopped."

--- a/pr-pipeline/formulas/mol-pr-ship.formula.toml
+++ b/pr-pipeline/formulas/mol-pr-ship.formula.toml
@@ -69,7 +69,16 @@ if [ -z "$BRANCH" ] || [ "$BRANCH" = "HEAD" ]; then
 fi
 
 # Refuse to ship from main / default branch.
-DEFAULT=$(git remote show origin 2>/dev/null | sed -n 's/.*HEAD branch: //p' || echo "main")
+# Resolve the default branch locally. `|| echo "main"` on the old
+# `git remote show origin` pipeline could never fire: sed exits 0 on empty
+# input, so a network failure produced DEFAULT="" and this check silently
+# fell back to the hardcoded main/master arms below.
+DEFAULT=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||')
+if [ -z "$DEFAULT" ]; then
+    git remote set-head origin --auto >/dev/null 2>&1 || true
+    DEFAULT=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||')
+fi
+[ -n "$DEFAULT" ] || DEFAULT=main
 if [ "$BRANCH" = "$DEFAULT" ] || [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then
     echo "Cannot ship from default branch ($BRANCH). Create a feature branch first."
     gc bd close "$ROOT_ID" --reason "on default branch"

--- a/tests/test_default_branch_resolution.py
+++ b/tests/test_default_branch_resolution.py
@@ -1,0 +1,241 @@
+"""Run the shipped default-branch resolution against real git repositories.
+
+Four assets resolve a repository's default branch: the `prepare-worktree`
+workflow step in the `gascity` pack, and the guard that refuses to ship from
+the default branch in `contributing` and twice in `pr-pipeline`. All four used
+to do it with `git remote show origin`, which contacts the remote on every
+invocation.
+
+This test does not assert that the files contain a particular string. It pulls
+the shell out of the shipped asset and runs it under `sh` against git
+repositories built on disk, so a passing result is a statement about what the
+shipped code does, not about how it is written.
+
+The repositories here use a default branch named `trunk` on purpose. `main` is
+the answer a broken resolution reaches by accident, through the hardcoded
+fallback, so a fixture on `main` cannot tell a working resolution from a
+failing one.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+import tempfile
+import textwrap
+import tomllib
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+WORKFLOW_STEP = REPO_ROOT / "gascity/assets/workflows/do-work/prepare-worktree.md"
+FORMULAS = (
+    REPO_ROOT / "contributing/formulas/mol-contributing-fine-tune.formula.toml",
+    REPO_ROOT / "pr-pipeline/formulas/mol-pr-ship.formula.toml",
+    REPO_ROOT / "pr-pipeline/formulas/mol-pr-from-issue.formula.toml",
+)
+
+# Each asset is matched by two patterns: the shape it carries now, and the
+# shape it carried before. The legacy alternative is what makes this test an
+# A/B rather than a presence check -- reverting the fix must make these cases
+# fail on the WRONG ANSWER at the shipped site, not on "the block is missing".
+#
+# The current block starts at the local read and ends at the last line that can
+# assign the variable. Anchoring on both ends means an edit that moves either
+# one fails this test loudly rather than silently narrowing what gets run.
+FORMULA_BLOCK = (
+    re.compile(
+        r"^DEFAULT=\$\(git symbolic-ref.*?^\[ -n \"\$DEFAULT\" \] \|\| DEFAULT=main$",
+        re.MULTILINE | re.DOTALL,
+    ),
+    re.compile(r"^DEFAULT=\$\(git remote show origin.*$", re.MULTILINE),
+)
+# The fence sits inside a nested list item, so both it and its contents are
+# indented. Capture the body and dedent it rather than pinning a column count.
+# The legacy form was an inline backticked command in the same list item.
+WORKFLOW_BLOCK = (
+    re.compile(r"```sh\n(\s*DEFAULT_BRANCH=.*?)\n[ \t]*```", re.DOTALL),
+    re.compile(r"`(DEFAULT_BRANCH=\$\(git remote show origin[^`]*)`"),
+)
+
+# What the four assets replaced. Kept here as an executable control rather than
+# a comment: the `|| echo "main"` reads as a fallback and cannot fire, because
+# sed exits 0 on empty input, so a failed `git remote show` yields an empty
+# string rather than "main".
+SUPERSEDED = (
+    """DEFAULT=$(git remote show origin 2>/dev/null """
+    """| sed -n 's/.*HEAD branch: //p' || echo "main")"""
+)
+
+
+def git(*args: str, cwd: Path) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True)
+
+
+def run_snippet(snippet: str, variable: str, cwd: Path) -> str:
+    """Execute the snippet in `cwd` and return what it assigned."""
+    proc = subprocess.run(
+        ["sh", "-c", f'{snippet}\nprintf "%s" "${variable}"'],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise AssertionError(
+            f"snippet exited {proc.returncode}: {proc.stderr[:1000]}"
+        )
+    return proc.stdout.strip()
+
+
+def extract(path: Path, patterns: tuple[re.Pattern[str], ...]) -> str:
+    if path.suffix == ".toml":
+        # Read the rendered command, not the TOML source: the source carries
+        # escaping that the shell never sees.
+        haystack = "\n".join(
+            value
+            for value in walk_strings(tomllib.loads(path.read_text(encoding="utf-8")))
+        )
+    else:
+        haystack = path.read_text(encoding="utf-8")
+    for pattern in patterns:
+        match = pattern.search(haystack)
+        if match:
+            return textwrap.dedent(
+                match.group(1) if match.groups() else match.group(0)
+            )
+    raise AssertionError(
+        f"no default-branch resolution found in {path.relative_to(REPO_ROOT)}, "
+        "in either the current or the superseded shape. If the block moved, "
+        "update the anchors here; do not delete the test."
+    )
+
+
+def walk_strings(node: object) -> list[str]:
+    if isinstance(node, str):
+        return [node]
+    if isinstance(node, dict):
+        return [s for value in node.values() for s in walk_strings(value)]
+    if isinstance(node, list):
+        return [s for item in node for s in walk_strings(item)]
+    return []
+
+
+class DefaultBranchResolutionTest(unittest.TestCase):
+    """Each case builds an origin and a clone, then breaks one thing."""
+
+    def setUp(self) -> None:
+        if not shutil.which("git"):
+            self.skipTest("git is not available")
+        self.tmp = Path(tempfile.mkdtemp(prefix="default-branch-"))
+        self.addCleanup(shutil.rmtree, self.tmp, True)
+
+        self.origin = self.tmp / "origin.git"
+        seed = self.tmp / "seed"
+        seed.mkdir()
+        git("init", "--initial-branch", "trunk", cwd=seed)
+        git("config", "user.email", "test@example.invalid", cwd=seed)
+        git("config", "user.name", "test", cwd=seed)
+        (seed / "README").write_text("seed\n", encoding="utf-8")
+        git("add", "README", cwd=seed)
+        git("commit", "-m", "seed", cwd=seed)
+        git("clone", "--bare", str(seed), str(self.origin), cwd=self.tmp)
+
+        self.clone = self.tmp / "clone"
+        git("clone", str(self.origin), str(self.clone), cwd=self.tmp)
+
+    def sever_remote(self) -> None:
+        """Make origin unreachable without touching the clone's refs."""
+        (self.origin).rename(self.tmp / "origin.git.moved")
+
+    def drop_origin_head(self) -> None:
+        git("remote", "set-head", "origin", "--delete", cwd=self.clone)
+
+    # --- the shipped formulas -------------------------------------------
+
+    def formula_snippets(self) -> list[tuple[Path, str]]:
+        return [(path, extract(path, FORMULA_BLOCK)) for path in FORMULAS]
+
+    def test_formulas_resolve_the_default_branch_without_the_remote(self) -> None:
+        """The point of the change: no network call in the common case."""
+        self.sever_remote()
+        for path, snippet in self.formula_snippets():
+            with self.subTest(formula=path.name):
+                self.assertEqual(
+                    run_snippet(snippet, "DEFAULT", self.clone),
+                    "trunk",
+                    "resolution must come from refs/remotes/origin/HEAD, "
+                    "which is local",
+                )
+
+    def test_formulas_refresh_the_ref_when_a_checkout_lacks_it(self) -> None:
+        """`git init` plus `git fetch` never writes refs/remotes/origin/HEAD.
+
+        That is how actions/checkout builds a workspace, so this branch runs in
+        CI rather than being a defensive nicety.
+        """
+        self.drop_origin_head()
+        for path, snippet in self.formula_snippets():
+            with self.subTest(formula=path.name):
+                self.assertEqual(
+                    run_snippet(snippet, "DEFAULT", self.clone),
+                    "trunk",
+                )
+                # Undo the refresh so the next formula starts from the same
+                # state; otherwise only the first one exercises this path.
+                self.drop_origin_head()
+
+    def test_formulas_fall_back_only_when_both_paths_fail(self) -> None:
+        self.drop_origin_head()
+        self.sever_remote()
+        for path, snippet in self.formula_snippets():
+            with self.subTest(formula=path.name):
+                self.assertEqual(run_snippet(snippet, "DEFAULT", self.clone), "main")
+
+    def test_the_superseded_pipeline_returns_empty_not_main(self) -> None:
+        """The control, and the reason the fallback was worth replacing.
+
+        Runs the exact line the four assets used to carry. It is not a stub of
+        it. With the remote unreachable it yields an empty string, so every
+        caller that read `DEFAULT` as "main" was reading "".
+        """
+        self.sever_remote()
+        self.assertEqual(run_snippet(SUPERSEDED, "DEFAULT", self.clone), "")
+
+    def test_the_superseded_pipeline_is_gone_from_every_asset(self) -> None:
+        offenders = [
+            str(path.relative_to(REPO_ROOT))
+            for path in REPO_ROOT.rglob("*")
+            if path.is_file()
+            and path.suffix in {".toml", ".md", ".sh", ".py"}
+            and ".git/" not in str(path)
+            and path != Path(__file__)
+            and "HEAD branch: " in path.read_text(encoding="utf-8", errors="ignore")
+        ]
+        self.assertFalse(
+            offenders,
+            "these still resolve the default branch over the network:\n  "
+            + "\n  ".join(offenders),
+        )
+
+    # --- the shipped workflow step ---------------------------------------
+
+    def test_workflow_step_resolves_without_the_remote(self) -> None:
+        snippet = extract(WORKFLOW_STEP, WORKFLOW_BLOCK)
+        self.sever_remote()
+        self.assertEqual(run_snippet(snippet, "DEFAULT_BRANCH", self.clone), "trunk")
+
+    def test_workflow_step_fails_closed_rather_than_guessing(self) -> None:
+        """It has no `main` fallback, deliberately: #228 landed because basing
+        a worktree on the wrong branch is worse than refusing to make one.
+        """
+        snippet = extract(WORKFLOW_STEP, WORKFLOW_BLOCK)
+        self.drop_origin_head()
+        self.sever_remote()
+        self.assertEqual(run_snippet(snippet, "DEFAULT_BRANCH", self.clone), "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #305.

## The reported defect, and three more sites

`git remote show origin` opens a connection every time it runs, to read a value git already stores locally. The issue names the `prepare-worktree` step in the `gascity` pack. Grepping for the command finds four:

| asset | what it gates |
|---|---|
| `gascity/assets/workflows/do-work/prepare-worktree.md` | the base branch every do-work worktree is created from |
| `contributing/formulas/mol-contributing-fine-tune.formula.toml` | refuses to ship from the default branch |
| `pr-pipeline/formulas/mol-pr-ship.formula.toml` | same guard |
| `pr-pipeline/formulas/mol-pr-from-issue.formula.toml` | same guard |

## A second defect the issue does not mention

The three formulas ended the line in `|| echo "main"`. That fallback can never fire. A pipeline's exit status is its last command's, and `sed` exits 0 on empty input, so a failed `git remote show` sets `DEFAULT=""` and the fallback is skipped. Every caller that read `DEFAULT` as `main` was reading the empty string. This needs no repository to reproduce:

```console
$ X=$( (exit 3) 2>/dev/null | sed -n 's/.*HEAD branch: //p' || echo "main")
$ echo "[$X]"
[]
```

Downstream, `[ "$DEFAULT" = main ]` and `[ "$DEFAULT" = master ]` both fail, so the guard silently stops guarding.

## The fix

All four now read `refs/remotes/origin/HEAD`.

The issue calls that "worth confirming", and it is. `refs/remotes/origin/HEAD` is written by `git clone` and refreshed by `git remote set-head origin --auto`. It is **not** written by `git init` plus `git fetch`, which is how `actions/checkout` builds a workspace. Of three checkouts on the machine this was written on, one had no `origin/HEAD` at all and `git symbolic-ref` there returns `fatal: ref refs/remotes/origin/HEAD is not a symbolic ref`. So a bare swap would have failed closed on a real repository.

Each site therefore reads the ref, refreshes once if it is missing, re-reads, and only then falls back:

```sh
DEFAULT=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||')
if [ -z "$DEFAULT" ]; then
    git remote set-head origin --auto >/dev/null 2>&1 || true
    DEFAULT=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||')
fi
[ -n "$DEFAULT" ] || DEFAULT=main
```

The refresh branch is one network call in the case that needs it, against one on every run. A stale ref costs nothing at the `prepare-worktree` site because the next line fetches the branch anyway.

Failure behavior is unchanged per site and deliberate: `prepare-worktree` still fails closed with an empty value (#228 landed because basing a worktree on the wrong branch is worse than not making one), and the three formulas keep their explicit `main` fallback, which now actually runs.

## The test

`tests/test_default_branch_resolution.py` pulls the shell out of each shipped asset and runs it under `sh` against git repositories built on disk. It reads the TOML formulas through `tomllib` and the workflow step out of its fenced block, so there is no second copy of the snippet to keep in sync: edit a formula and the test runs the edit.

Fixture repositories default to a branch named `trunk`. `main` is the answer a broken resolution reaches by accident through the fallback, so a fixture on `main` cannot tell a working resolution from a failing one.

Each extractor matches the superseded shape as well as the current one, which makes this an A/B rather than a presence check. Reverting the four files and re-running:

```
4 failed, 3 passed      '' != 'trunk', '' != 'main'  -- at the shipped site
```

Restoring them, with nothing else changed:

```
7 passed
```

The two cases that pass either way are the network-reachable one, where the old command did work, and the control that runs the superseded line directly to show it yields `""` rather than `"main"`.

Cases covered: resolution with the remote directory renamed away (proves it is local), resolution via the `set-head` refresh with `origin/HEAD` deleted, the fallback with both paths broken, `prepare-worktree` failing closed instead of guessing, and a repository-wide check that no asset still shells out to `git remote show origin` for this.

## Verification

```
$ python3 -m pytest tests contributing/tests gascity/tests pr-pipeline/tests -q
2 failed, 322 passed, 8 skipped
```

The two failures are `gascity/tests/test_formula_assets.py::...city_claim_command...`, which fail identically on `upstream/main` with this branch's changes stashed. They are not touched by this change.
