### PR TITLE
fix(gastown): drop refinery's masked sleep_after_idle, and guard every pack against it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
                       pr-pipeline slack-channel slack-full slack-mini; do
             "$GC_BIN" lint "$pack"
           done
-          GC_TEST_BIN="$GC_BIN" python3 -m pytest tests/test_gc_role_prompt_integration.py -q
+          GC_TEST_BIN="$GC_BIN" python3 -m pytest tests/test_gc_role_prompt_integration.py tests/test_pack_composition_warnings.py -q
 
       # Installed, not parsed. `gc lint` above reads each pack on its own and
       # the per-pack suites read their own TOML; neither can say what gc does

--- a/gastown/agents/refinery/agent.toml
+++ b/gastown/agents/refinery/agent.toml
@@ -4,5 +4,4 @@ work_dir = ".gc/worktrees/{{.Rig}}/refinery"
 nudge = "Run 'gc prime' to check merge queue and begin processing."
 pre_start = ["{{.ConfigDir}}/assets/scripts/worktree-setup.sh {{.RigRoot}} {{.WorkDir}} {{.AgentBase}} --sync"]
 idle_timeout = "2h"
-sleep_after_idle = "300s"
 max_active_sessions = 1

--- a/tests/test_pack_composition_warnings.py
+++ b/tests/test_pack_composition_warnings.py
@@ -43,13 +43,39 @@ def advisory_binding(line: str) -> str | None:
     return match.group(1).rsplit("/", 1)[-1].split(".", 1)[0]
 
 
+def owning_pack(agent_toml: Path) -> Path | None:
+    """The nearest ancestor of an agent.toml that is itself a pack."""
+    for parent in agent_toml.parents:
+        if parent == REPO_ROOT.parent:
+            return None
+        if (parent / "pack.toml").is_file():
+            return parent
+    return None
+
+
 def agent_bearing_packs() -> list[str]:
-    """Pack directories that ship at least one agent definition."""
-    names = {
-        path.parents[2].name
-        for path in REPO_ROOT.glob("*/agents/*/agent.toml")
+    """Pack directories that ship at least one agent definition, REPO_ROOT-relative.
+
+    Derived from `pack.toml` presence rather than from a fixed depth. A glob of
+    `*/agents/*/agent.toml` reads as "every pack" and silently drops any pack that
+    is not a direct child of the repo root: `gascity/roles` is a pack with its own
+    `pack.toml` and twelve agents, and it was never parameterized. The nested case
+    is the one a depth-pinned pattern always misses, so key on the marker file.
+    """
+    packs = {
+        pack.relative_to(REPO_ROOT).as_posix()
+        for pack in (
+            owning_pack(path)
+            for path in REPO_ROOT.rglob("agents/*/agent.toml")
+        )
+        if pack is not None
     }
-    return sorted(names)
+    return sorted(packs)
+
+
+def binding_name(pack_path: str) -> str:
+    """The import binding for a pack path; `gascity/roles` cannot be a bare key."""
+    return pack_path.replace("/", "-")
 
 
 @dataclass(frozen=True)
@@ -103,7 +129,8 @@ def write_canary_pack(root: Path) -> Path:
     return pack_dir
 
 
-def write_city(root: Path, pack_name: str) -> Workspace:
+def write_city(root: Path, pack_path: str) -> Workspace:
+    binding = binding_name(pack_path)
     city_dir = root / "city"
     rig_dir = root / "fixture"
     gc_home = root / "gc-home"
@@ -114,7 +141,7 @@ def write_city(root: Path, pack_name: str) -> Workspace:
     home.mkdir()
 
     canary_pack = write_canary_pack(root)
-    pack_source = (REPO_ROOT / pack_name).resolve()
+    pack_source = (REPO_ROOT / pack_path).resolve()
 
     city_dir.joinpath("pack.toml").write_text(
         textwrap.dedent(
@@ -123,7 +150,7 @@ def write_city(root: Path, pack_name: str) -> Workspace:
             name = "composition-warnings"
             schema = 2
 
-            [imports.{pack_name}]
+            [imports.{binding}]
             source = {json.dumps(str(pack_source))}
 
             [imports.{CANARY_BINDING}]
@@ -173,6 +200,15 @@ def write_city(root: Path, pack_name: str) -> Workspace:
 
 
 def config_show(gc_test_bin: Path, workspace: Workspace) -> str:
+    """Run `gc config show`, refusing to return output from a failed load.
+
+    Returning `stdout + stderr` alone makes "the config loaded and named no
+    offender" indistinguishable from "the config did not load at all": a binary
+    that aborts before it reaches advisory emission prints no advisory line, and
+    every offender assertion below is a search for an absent string. The canary
+    catches most of that, but only for failures that still emit some advisories.
+    A nonzero exit is the one signal that separates the two, so read it.
+    """
     result = subprocess.run(
         [str(gc_test_bin), "config", "show"],
         cwd=workspace.rig_dir,
@@ -181,14 +217,20 @@ def config_show(gc_test_bin: Path, workspace: Workspace) -> str:
         capture_output=True,
         timeout=120,
     )
-    return result.stdout + result.stderr
+    output = result.stdout + result.stderr
+    assert result.returncode == 0, (
+        f"gc config show exited {result.returncode}; an absent advisory in this "
+        f"output is a failed load, not a clean pack. Output:\n{output}"
+    )
+    return output
 
 
-@pytest.mark.parametrize("pack_name", agent_bearing_packs())
+@pytest.mark.parametrize("pack_path", agent_bearing_packs())
 def test_pack_agents_compose_without_idle_advisory(
-    tmp_path: Path, gc_test_bin: Path, pack_name: str
+    tmp_path: Path, gc_test_bin: Path, pack_path: str
 ) -> None:
-    output = config_show(gc_test_bin, write_city(tmp_path, pack_name))
+    pack_name = binding_name(pack_path)
+    output = config_show(gc_test_bin, write_city(tmp_path, pack_path))
 
     advisories = [line for line in output.splitlines() if IDLE_ADVISORY in line]
 

--- a/tests/test_pack_composition_warnings.py
+++ b/tests/test_pack_composition_warnings.py
@@ -1,0 +1,210 @@
+"""Every agent-bearing pack must compose into a city without config advisories.
+
+A pack's own unit tests read its TOML and can tell you the file parses. They
+cannot tell you what Gas City says when it loads that file into a city, which
+is where a user meets the pack. These tests stand each pack up in an isolated
+scratch city and run the real binary.
+
+Each case also imports a fixture pack whose one agent sets both `idle_timeout`
+and `sleep_after_idle` on purpose. That canary must be reported in the same
+invocation. Without it a green result is ambiguous: a pack with no advisories
+and a binary that stopped emitting advisories look identical.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import textwrap
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+CANARY_BINDING = "idle-canary"
+CANARY_AGENT = "canary"
+IDLE_ADVISORY = "idle_timeout and sleep_after_idle are both set"
+
+# `agent "gastown.mayor"` at city scope, `agent "fixture/gastown.refinery"`
+# for a rig-scoped one. Both forms name the same pack binding.
+ADVISORY_AGENT = re.compile(r'agent "([^"]+)"')
+
+
+def advisory_binding(line: str) -> str | None:
+    """The pack binding an advisory line is about, or None if it names no agent."""
+    match = ADVISORY_AGENT.search(line)
+    if match is None:
+        return None
+    return match.group(1).rsplit("/", 1)[-1].split(".", 1)[0]
+
+
+def agent_bearing_packs() -> list[str]:
+    """Pack directories that ship at least one agent definition."""
+    names = {
+        path.parents[2].name
+        for path in REPO_ROOT.glob("*/agents/*/agent.toml")
+    }
+    return sorted(names)
+
+
+@dataclass(frozen=True)
+class Workspace:
+    city_dir: Path
+    rig_dir: Path
+    env: dict[str, str]
+
+
+@pytest.fixture(scope="session")
+def gc_test_bin() -> Path:
+    configured = os.environ.get("GC_TEST_BIN")
+    if not configured:
+        pytest.skip("set GC_TEST_BIN to run real Gas City CLI integration tests")
+
+    binary = Path(configured).expanduser().resolve()
+    if not binary.is_file() or not os.access(binary, os.X_OK):
+        pytest.fail(f"GC_TEST_BIN is not an executable file: {binary}")
+    return binary
+
+
+def write_canary_pack(root: Path) -> Path:
+    """A pack whose single agent sets both idle keys, so the check can go red."""
+    pack_dir = root / "canary-pack"
+    agent_dir = pack_dir / "agents" / CANARY_AGENT
+    agent_dir.mkdir(parents=True)
+    pack_dir.joinpath("pack.toml").write_text(
+        textwrap.dedent(
+            f"""\
+            [pack]
+            name = "{CANARY_BINDING}"
+            schema = 2
+            """
+        ),
+        encoding="utf-8",
+    )
+    agent_dir.joinpath("agent.toml").write_text(
+        textwrap.dedent(
+            """\
+            scope = "city"
+            work_dir = "."
+            idle_timeout = "1h"
+            sleep_after_idle = "60s"
+            """
+        ),
+        encoding="utf-8",
+    )
+    agent_dir.joinpath("prompt.template.md").write_text(
+        "Fixture agent. Never dispatched.\n", encoding="utf-8"
+    )
+    return pack_dir
+
+
+def write_city(root: Path, pack_name: str) -> Workspace:
+    city_dir = root / "city"
+    rig_dir = root / "fixture"
+    gc_home = root / "gc-home"
+    home = root / "home"
+    (city_dir / ".gc").mkdir(parents=True)
+    rig_dir.mkdir()
+    gc_home.mkdir()
+    home.mkdir()
+
+    canary_pack = write_canary_pack(root)
+    pack_source = (REPO_ROOT / pack_name).resolve()
+
+    city_dir.joinpath("pack.toml").write_text(
+        textwrap.dedent(
+            f"""\
+            [pack]
+            name = "composition-warnings"
+            schema = 2
+
+            [imports.{pack_name}]
+            source = {json.dumps(str(pack_source))}
+
+            [imports.{CANARY_BINDING}]
+            source = {json.dumps(str(canary_pack))}
+            """
+        ),
+        encoding="utf-8",
+    )
+    city_dir.joinpath("city.toml").write_text(
+        textwrap.dedent(
+            """\
+            [workspace]
+            provider = "codex"
+
+            [providers.codex]
+            base = "builtin:codex"
+
+            [[rigs]]
+            name = "fixture"
+            """
+        ),
+        encoding="utf-8",
+    )
+    city_dir.joinpath(".gc", "site.toml").write_text(
+        textwrap.dedent(
+            f"""\
+            workspace_name = "composition-warnings"
+
+            [[rig]]
+            name = "fixture"
+            path = {json.dumps(str(rig_dir))}
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    env = {
+        **os.environ,
+        "HOME": str(home),
+        "GC_HOME": str(gc_home),
+        "GC_CITY": str(city_dir),
+        "GC_CITY_PATH": str(city_dir),
+        "GC_CITY_ROOT": str(city_dir),
+        "GC_RIG": "fixture",
+    }
+    return Workspace(city_dir=city_dir, rig_dir=rig_dir, env=env)
+
+
+def config_show(gc_test_bin: Path, workspace: Workspace) -> str:
+    result = subprocess.run(
+        [str(gc_test_bin), "config", "show"],
+        cwd=workspace.rig_dir,
+        env=workspace.env,
+        text=True,
+        capture_output=True,
+        timeout=120,
+    )
+    return result.stdout + result.stderr
+
+
+@pytest.mark.parametrize("pack_name", agent_bearing_packs())
+def test_pack_agents_compose_without_idle_advisory(
+    tmp_path: Path, gc_test_bin: Path, pack_name: str
+) -> None:
+    output = config_show(gc_test_bin, write_city(tmp_path, pack_name))
+
+    advisories = [line for line in output.splitlines() if IDLE_ADVISORY in line]
+
+    bindings = [(advisory_binding(line), line) for line in advisories]
+
+    # The canary proves the advisory is reachable in this run, on this binary,
+    # through this fixture shape, and that the binding parse above finds it.
+    # Assert it first: without it, an empty `offenders` list is not evidence.
+    assert any(binding == CANARY_BINDING for binding, _ in bindings), (
+        f"fixture canary {CANARY_BINDING}.{CANARY_AGENT} did not surface as an "
+        f"idle advisory; this check cannot go red. Output:\n{output}"
+    )
+
+    offenders = [line for binding, line in bindings if binding == pack_name]
+    assert not offenders, (
+        f"{pack_name} sets both idle_timeout and sleep_after_idle on an agent; "
+        "idle_timeout wins and sleep_after_idle only applies when the session "
+        "survives it. Drop one:\n" + "\n".join(offenders)
+    )

--- a/tests/test_pack_composition_warnings.py
+++ b/tests/test_pack_composition_warnings.py
@@ -3,19 +3,24 @@
 A pack's own unit tests read its TOML and can tell you the file parses. They
 cannot tell you what Gas City says when it loads that file into a city, which
 is where a user meets the pack. These tests stand each pack up in an isolated
-scratch city and run the real binary.
+scratch city -- built by the shared `gc_live_city` harness, the same one
+`test_maintained_packs_live_gc.py` uses -- and run the real binary.
 
 Each case also imports a fixture pack whose one agent sets both `idle_timeout`
 and `sleep_after_idle` on purpose. That canary must be reported in the same
 invocation. Without it a green result is ambiguous: a pack with no advisories
 and a binary that stopped emitting advisories look identical.
+
+The both-keys *pairing* is the tripwire, not either key on its own, and the two
+are not alternatives. `idle_timeout` is a lifecycle stop; whether a session
+idle-sleeps is decided by a separate switch that reads `sleep_after_idle` and
+never consults `idle_timeout` at all (gc `cmd/gc/compute_awake_set.go`). Which
+key is safe to remove therefore depends on the agent -- the offender assertion
+below spells out the condition rather than saying "drop one".
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-import json
-import os
 from pathlib import Path
 import re
 import subprocess
@@ -23,14 +28,27 @@ import textwrap
 
 import pytest
 
+from gc_live_city import (
+    REPO_ROOT,
+    gc_output,
+    gc_test_bin,  # noqa: F401 -- pytest fixture, used by name
+    write_city,
+)
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
 
 CANARY_BINDING = "idle-canary"
+# The canary's declared pack name deliberately differs from its import binding,
+# mirroring `gascity/roles` (declared `gc-roles`, bound `gascity-roles`) -- the
+# one shipped pack with that mismatch and the pack this suite exists to protect.
+# `gc` attributes an advisory by import binding today, so the offender match
+# keys on CANARY_BINDING; were a future `gc` to switch to declared-name
+# attribution, the canary would surface as CANARY_DECL_NAME, the CANARY_BINDING
+# assertion below would fail, and the regression would be caught, not hidden.
+CANARY_DECL_NAME = "idle-canary-decl"
 CANARY_AGENT = "canary"
 IDLE_ADVISORY = "idle_timeout and sleep_after_idle are both set"
 
-# `agent "gastown.mayor"` at city scope, `agent "fixture/gastown.refinery"`
+# `agent "gastown.mayor"` at city scope, `agent "demo/gastown.refinery"`
 # for a rig-scoped one. Both forms name the same pack binding.
 ADVISORY_AGENT = re.compile(r'agent "([^"]+)"')
 
@@ -43,12 +61,39 @@ def advisory_binding(line: str) -> str | None:
     return match.group(1).rsplit("/", 1)[-1].split(".", 1)[0]
 
 
-def owning_pack(agent_toml: Path) -> Path | None:
-    """The nearest ancestor of an agent.toml that is itself a pack."""
+def tracked_paths() -> frozenset[Path]:
+    """Every file git tracks in this repo, as absolute paths.
+
+    Enumerating from git rather than walking the filesystem keeps the pack set
+    identical no matter where the suite is invoked from. An `rglob` descends
+    into the nested checkouts under `.gc/worktrees/`, `.claude/worktrees/` and
+    `worktrees/`, multiplying every real pack into stale copies bound under
+    mangled keys -- most of them starting with a dot, which renders
+    `[imports..gc-worktrees-...]` and fails the TOML parse, reddening the case.
+    A clean checkout collects the eight real packs; the same tree from a live
+    rig collected hundreds, and the number climbs as worktrees accumulate. No
+    fixed count is recorded here for that reason. `git ls-files` sees only this
+    repo's tracked source, so CI and a working checkout parametrize the same
+    packs. Same "tracked source, not filesystem" scan as
+    `tests/test_no_bare_bd_commands.tracked_files`.
+    """
+    result = subprocess.run(
+        ["git", "ls-files", "-z"],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+    )
+    return frozenset(
+        REPO_ROOT / path for path in result.stdout.decode().split("\0") if path
+    )
+
+
+def owning_pack(agent_toml: Path, tracked: frozenset[Path]) -> Path | None:
+    """The nearest ancestor of an agent.toml that is itself a tracked pack."""
     for parent in agent_toml.parents:
         if parent == REPO_ROOT.parent:
             return None
-        if (parent / "pack.toml").is_file():
+        if parent / "pack.toml" in tracked:
             return parent
     return None
 
@@ -59,17 +104,35 @@ def agent_bearing_packs() -> list[str]:
     Derived from `pack.toml` presence rather than from a fixed depth. A glob of
     `*/agents/*/agent.toml` reads as "every pack" and silently drops any pack that
     is not a direct child of the repo root: `gascity/roles` is a pack with its own
-    `pack.toml` and twelve agents, and it was never parameterized. The nested case
+    `pack.toml` and its own agents, and it was never parameterized. The nested case
     is the one a depth-pinned pattern always misses, so key on the marker file.
+
+    Both halves read from `git ls-files` rather than the filesystem: the agent
+    files, and the ancestor `pack.toml` that attributes each one. An untracked
+    `pack.toml` left in a parent directory would otherwise re-attribute every
+    pack beneath it -- the same invocation-dependence in a quieter form.
     """
+    tracked = tracked_paths()
+    agent_tomls = [
+        path
+        for path in tracked
+        if path.name == "agent.toml"
+        and len(path.parts) >= 3
+        and path.parts[-3] == "agents"
+    ]
     packs = {
         pack.relative_to(REPO_ROOT).as_posix()
-        for pack in (
-            owning_pack(path)
-            for path in REPO_ROOT.rglob("agents/*/agent.toml")
-        )
+        for pack in (owning_pack(path, tracked) for path in agent_tomls)
         if pack is not None
     }
+    # pytest SKIPS a test whose parameter set is empty rather than failing it, so
+    # a derivation that silently found nothing would read as "nothing to check"
+    # forever. Fail collection loudly instead.
+    assert packs, (
+        f"no tracked agents/*/agent.toml under {REPO_ROOT} resolved to a tracked "
+        "pack; pack discovery is broken, and an empty parameter set would "
+        "silently skip every assertion in this file"
+    )
     return sorted(packs)
 
 
@@ -78,35 +141,22 @@ def binding_name(pack_path: str) -> str:
     return pack_path.replace("/", "-")
 
 
-@dataclass(frozen=True)
-class Workspace:
-    city_dir: Path
-    rig_dir: Path
-    env: dict[str, str]
+def write_idle_canary_pack(root: Path) -> Path:
+    """A pack whose single agent sets both idle keys, so the check can go red.
 
-
-@pytest.fixture(scope="session")
-def gc_test_bin() -> Path:
-    configured = os.environ.get("GC_TEST_BIN")
-    if not configured:
-        pytest.skip("set GC_TEST_BIN to run real Gas City CLI integration tests")
-
-    binary = Path(configured).expanduser().resolve()
-    if not binary.is_file() or not os.access(binary, os.X_OK):
-        pytest.fail(f"GC_TEST_BIN is not an executable file: {binary}")
-    return binary
-
-
-def write_canary_pack(root: Path) -> Path:
-    """A pack whose single agent sets both idle keys, so the check can go red."""
-    pack_dir = root / "canary-pack"
+    A sibling of `gc_live_city.write_canary_pack` rather than a use of it: that
+    canary declares a deprecated formula contract and surfaces through
+    `gc doctor`, while this one has to raise an idle advisory out of
+    `gc config show`.
+    """
+    pack_dir = root / "idle-canary-pack"
     agent_dir = pack_dir / "agents" / CANARY_AGENT
     agent_dir.mkdir(parents=True)
     pack_dir.joinpath("pack.toml").write_text(
         textwrap.dedent(
             f"""\
             [pack]
-            name = "{CANARY_BINDING}"
+            name = "{CANARY_DECL_NAME}"
             schema = 2
             """
         ),
@@ -129,108 +179,26 @@ def write_canary_pack(root: Path) -> Path:
     return pack_dir
 
 
-def write_city(root: Path, pack_path: str) -> Workspace:
-    binding = binding_name(pack_path)
-    city_dir = root / "city"
-    rig_dir = root / "fixture"
-    gc_home = root / "gc-home"
-    home = root / "home"
-    (city_dir / ".gc").mkdir(parents=True)
-    rig_dir.mkdir()
-    gc_home.mkdir()
-    home.mkdir()
-
-    canary_pack = write_canary_pack(root)
-    pack_source = (REPO_ROOT / pack_path).resolve()
-
-    city_dir.joinpath("pack.toml").write_text(
-        textwrap.dedent(
-            f"""\
-            [pack]
-            name = "composition-warnings"
-            schema = 2
-
-            [imports.{binding}]
-            source = {json.dumps(str(pack_source))}
-
-            [imports.{CANARY_BINDING}]
-            source = {json.dumps(str(canary_pack))}
-            """
-        ),
-        encoding="utf-8",
-    )
-    city_dir.joinpath("city.toml").write_text(
-        textwrap.dedent(
-            """\
-            [workspace]
-            provider = "codex"
-
-            [providers.codex]
-            base = "builtin:codex"
-
-            [[rigs]]
-            name = "fixture"
-            """
-        ),
-        encoding="utf-8",
-    )
-    city_dir.joinpath(".gc", "site.toml").write_text(
-        textwrap.dedent(
-            f"""\
-            workspace_name = "composition-warnings"
-
-            [[rig]]
-            name = "fixture"
-            path = {json.dumps(str(rig_dir))}
-            """
-        ),
-        encoding="utf-8",
-    )
-
-    env = {
-        **os.environ,
-        "HOME": str(home),
-        "GC_HOME": str(gc_home),
-        "GC_CITY": str(city_dir),
-        "GC_CITY_PATH": str(city_dir),
-        "GC_CITY_ROOT": str(city_dir),
-        "GC_RIG": "fixture",
-    }
-    return Workspace(city_dir=city_dir, rig_dir=rig_dir, env=env)
-
-
-def config_show(gc_test_bin: Path, workspace: Workspace) -> str:
-    """Run `gc config show`, refusing to return output from a failed load.
-
-    Returning `stdout + stderr` alone makes "the config loaded and named no
-    offender" indistinguishable from "the config did not load at all": a binary
-    that aborts before it reaches advisory emission prints no advisory line, and
-    every offender assertion below is a search for an absent string. The canary
-    catches most of that, but only for failures that still emit some advisories.
-    A nonzero exit is the one signal that separates the two, so read it.
-    """
-    result = subprocess.run(
-        [str(gc_test_bin), "config", "show"],
-        cwd=workspace.rig_dir,
-        env=workspace.env,
-        text=True,
-        capture_output=True,
-        timeout=120,
-    )
-    output = result.stdout + result.stderr
-    assert result.returncode == 0, (
-        f"gc config show exited {result.returncode}; an absent advisory in this "
-        f"output is a failed load, not a clean pack. Output:\n{output}"
-    )
-    return output
-
-
 @pytest.mark.parametrize("pack_path", agent_bearing_packs())
 def test_pack_agents_compose_without_idle_advisory(
     tmp_path: Path, gc_test_bin: Path, pack_path: str
 ) -> None:
     pack_name = binding_name(pack_path)
-    output = config_show(gc_test_bin, write_city(tmp_path, pack_path))
+    workspace = write_city(
+        tmp_path,
+        {
+            pack_name: REPO_ROOT / pack_path,
+            CANARY_BINDING: write_idle_canary_pack(tmp_path),
+        },
+    )
+
+    # `gc_output` refuses to return the output of a nonzero exit, and that
+    # refusal is load-bearing here rather than merely tidy: every assertion
+    # below searches this string for an ABSENT advisory, and a city that failed
+    # to load emits no advisory either. The canary covers failed loads that
+    # still emit some advisories; the exit code is the only thing separating
+    # the rest from a genuinely clean pack.
+    output = gc_output(gc_test_bin, workspace, "config", "show")
 
     advisories = [line for line in output.splitlines() if IDLE_ADVISORY in line]
 
@@ -246,7 +214,12 @@ def test_pack_agents_compose_without_idle_advisory(
 
     offenders = [line for binding, line in bindings if binding == pack_name]
     assert not offenders, (
-        f"{pack_name} sets both idle_timeout and sleep_after_idle on an agent; "
-        "idle_timeout wins and sleep_after_idle only applies when the session "
-        "survives it. Drop one:\n" + "\n".join(offenders)
+        f"{pack_name} sets both idle_timeout and sleep_after_idle on an agent. "
+        "Drop sleep_after_idle when that agent is an on-demand named session "
+        "and its value matches the 300s on-demand default -- that is the case "
+        "where dropping it is behavior-preserving. Otherwise dropping it "
+        "removes idle sleep from the agent entirely, because the awake set "
+        "reads sleep_after_idle and never idle_timeout; there, idle_timeout "
+        "(a lifecycle stop, not an idle-sleep policy) is the key to "
+        "reconsider:\n" + "\n".join(offenders)
     )


### PR DESCRIPTION
Closes #165.

## The fix

`gastown/agents/refinery/agent.toml` set both `idle_timeout` and `sleep_after_idle`. Gas City reports that pairing as an advisory in every city importing the pack:

```
agent "<rig>/gastown.refinery": idle_timeout and sleep_after_idle are both set;
idle_timeout takes precedence and sleep_after_idle only applies when the session
survives the idle_timeout check
```

Refinery is the only gastown agent that sets both. Mayor, witness and deacon use `1h`; polecat, dog and refinery use `2h`; none of the others sets `sleep_after_idle`. The line arrived in a bulk embedded-pack sync (`2068e84`, #73) with no stated rationale. Dropping it is the change that makes refinery match the rest of the pack, and it removes the advisory.

## The test

`tests/test_pack_composition_warnings.py` discovers every pack that ships agent definitions, stands each one up in an isolated scratch city, and runs the real `gc config show` against it.

That structure is the point. A pack's own tests read its TOML and can tell you the file parses. They cannot tell you what Gas City says when it loads that file into a city, which is the only place a user meets this defect. So the test exercises the shipped pack directory through the shipped binary, not a copy of either.

**It goes red on the real defect.** Restoring the `sleep_after_idle` line, with nothing else changed:

```
1 failed, 7 passed        gastown
```

Removing it again:

```
8 passed
```

Verified against two `gc` builds, since the linter version skew in #330 showed a same-answer-everywhere assumption is not safe here: the released `v1.4.1` and a build from current `gascity` main give the same result in both directions.

**And it cannot go green by accident.** Each case also imports a fixture pack, written into the test's tmp dir, whose single agent sets both keys on purpose. The test asserts that canary is reported in the same invocation, before it checks the pack under test. Without that, a pack with no advisories and a binary that stopped emitting advisories are indistinguishable, and the guard would pass forever after any upstream change to the check.

That guard earned itself during development. My first offender filter matched `"gastown.` with the quote adjacent, which never fires for a rig-scoped agent because the advisory names it `"demo/gastown.refinery"`. The canary was green throughout; the A/B is what caught it. The filter now parses the quoted name and compares the binding.

## CI

Added to the existing `GC_TEST_BIN` step beside `test_gc_role_prompt_integration.py`. This touches `.github/workflows/ci.yml`, one line.

Without that, the file still gets collected by the "Run Python pack tests" step, where `GC_TEST_BIN` is unset and all cases skip. A guard that only runs on a contributor's machine is the failure this is meant to close.

## Verification

```
$ GC_TEST_BIN=<gc> python3 -m pytest tests/test_pack_composition_warnings.py -q
8 passed

$ python3 -m pytest tests contributing/tests gascity/tests discord/tests github/tests \
    slack-full/tests slack-channel/tests pr-pipeline/tests profiler/tests -q
14 failed, 1266 passed, 15 skipped
```

All 14 failures reproduce on `upstream/main` with this branch's changes stashed: 12 in `discord/tests` and `github/tests`, and 2 in `gascity/tests/test_formula_assets.py::...city_claim_command...`. None is touched by this change.
