### PR TITLE
test(gastown-lint): key the lint waiver on path and message, not line number

### DIFF
--- a/tests/gastown_lint_upstream_defects.txt
+++ b/tests/gastown_lint_upstream_defects.txt
@@ -1,7 +1,24 @@
 # `gc lint gastown` findings that are defects in gc's linter, not in this pack.
 #
-# One finding per line, as "<path relative to the pack dir>:<line>: <message>",
-# with line 0 for a pack-level diagnostic. Blank lines and `#` comments ignored.
+# One finding per OCCURRENCE, as "<path relative to the pack dir>: <message>".
+# Blank lines and `#` comments ignored.
+#
+# NO LINE NUMBERS. An entry is matched on path and message only, and a finding
+# that occurs twice is written twice -- tests/test_gastown_lint_findings.py
+# counts occurrences, so a duplicate arriving still fails. Line numbers were
+# here for one day and cost a red main the first time anyone edited a pinned
+# file: #265 collapsed the mayor prompt's four-row rig-routing table into one
+# generic row, moving the same diagnostic from lines 118-121 to lines 23 and
+# 114. Nothing about the pack or the linter changed, and CI went red on every
+# open PR in the repo. A guard whose green depends on where in a file a line
+# sits reports edits, not regressions.
+#
+# What that costs, stated so nobody re-adds them: this no longer tells you
+# WHERE to look, and a finding that moves within a file is invisible here. Both
+# are fine. The section comments below carry the gc-side cause and a refute
+# command, which is what a reader actually needs, and a moved finding is not an
+# event. What still fails: a new path, a new message, or one more occurrence of
+# an existing pair.
 #
 # `# @section: <name>` switches which set the lines below it belong to:
 #
@@ -48,11 +65,11 @@
 #         grep -n 'EffectiveMinActiveSessions' <gascity checkout>/internal/doctor/checks_named_session.go
 # ---------------------------------------------------------------------------
 # @section: universal
-pack.toml:0: named_session "mayor" targets pool-controlled agent "mayor"; remove pool settings from named-session templates or remove [[named_session]] for pool agents
-pack.toml:0: named_session "deacon" targets pool-controlled agent "deacon"; remove pool settings from named-session templates or remove [[named_session]] for pool agents
-pack.toml:0: named_session "boot" targets pool-controlled agent "boot"; remove pool settings from named-session templates or remove [[named_session]] for pool agents
-pack.toml:0: named_session "witness" targets pool-controlled agent "witness"; remove pool settings from named-session templates or remove [[named_session]] for pool agents
-pack.toml:0: named_session "refinery" targets pool-controlled agent "refinery"; remove pool settings from named-session templates or remove [[named_session]] for pool agents
+pack.toml: named_session "mayor" targets pool-controlled agent "mayor"; remove pool settings from named-session templates or remove [[named_session]] for pool agents
+pack.toml: named_session "deacon" targets pool-controlled agent "deacon"; remove pool settings from named-session templates or remove [[named_session]] for pool agents
+pack.toml: named_session "boot" targets pool-controlled agent "boot"; remove pool settings from named-session templates or remove [[named_session]] for pool agents
+pack.toml: named_session "witness" targets pool-controlled agent "witness"; remove pool settings from named-session templates or remove [[named_session]] for pool agents
+pack.toml: named_session "refinery" targets pool-controlled agent "refinery"; remove pool settings from named-session templates or remove [[named_session]] for pool agents
 
 # ---------------------------------------------------------------------------
 # 2. `mol wisp` x2: the flag manifest stops one subcommand level short
@@ -74,11 +91,11 @@ pack.toml:0: named_session "refinery" targets pool-controlled agent "refinery"; 
 # Refute: gc bd mol wisp gc --help | grep -- --age
 #         grep -n '"mol wisp"' <gascity checkout>/internal/bdflags/bdflags.go
 # ---------------------------------------------------------------------------
-agents/deacon/prompt.template.md:209: bd-unknown-flag: bd mol wisp uses unrecognized flag "--age"
-agents/deacon/prompt.template.md:210: bd-unknown-flag: bd mol wisp uses unrecognized flag "--age"
+agents/deacon/prompt.template.md: bd-unknown-flag: bd mol wisp uses unrecognized flag "--age"
+agents/deacon/prompt.template.md: bd-unknown-flag: bd mol wisp uses unrecognized flag "--age"
 
 # ---------------------------------------------------------------------------
-# 3. x22, gc <= v1.4.1 only: the scanner ran past the pipe, and did not know
+# 3. x20, gc <= v1.4.1 only: the scanner ran past the pipe, and did not know
 #    about `gc bd`'s own scope flags
 #
 # Two separate scanner defects, both fixed by gascity 7724983de ("fix(bdflags):
@@ -105,25 +122,23 @@ agents/deacon/prompt.template.md:210: bd-unknown-flag: bd mol wisp uses unrecogn
 #                                              bd is correctly rejected)
 # ---------------------------------------------------------------------------
 # @section: pre-5220
-agents/deacon/prompt.template.md:64: bd-unknown-flag: bd mol wisp uses unrecognized flag "-r"
-agents/deacon/prompt.template.md:96: bd-unknown-flag: bd mol wisp uses unrecognized flag "-r"
-agents/deacon/prompt.template.md:109: bd-unknown-flag: bd mol wisp uses unrecognized flag "-r"
-agents/mayor/prompt.template.md:118: bd-unknown-flag: bd create uses unrecognized flag "--rig"
-agents/mayor/prompt.template.md:119: bd-unknown-flag: bd create uses unrecognized flag "--rig"
-agents/mayor/prompt.template.md:120: bd-unknown-flag: bd create uses unrecognized flag "--rig"
-agents/mayor/prompt.template.md:121: bd-unknown-flag: bd create uses unrecognized flag "--rig"
-agents/polecat/prompt.template.md:316: bd-unknown-flag: bd show uses unrecognized flag "-r"
-agents/polecat/prompt.template.md:317: bd-unknown-flag: bd show uses unrecognized flag "-r"
-agents/refinery/prompt.template.md:74: bd-unknown-flag: bd mol wisp uses unrecognized flag "-r"
-agents/refinery/prompt.template.md:119: bd-unknown-flag: bd mol wisp uses unrecognized flag "-r"
-agents/refinery/prompt.template.md:180: bd-unknown-flag: bd mol wisp uses unrecognized flag "-r"
-agents/refinery/prompt.template.md:221: bd-unknown-flag: bd show uses unrecognized flag "-r"
-agents/refinery/prompt.template.md:222: bd-unknown-flag: bd show uses unrecognized flag "-r"
-agents/refinery/prompt.template.md:223: bd-unknown-flag: bd show uses unrecognized flag "-r"
-agents/refinery/prompt.template.md:224: bd-unknown-flag: bd show uses unrecognized flag "-r"
-agents/witness/prompt.template.md:182: bd-unknown-flag: bd mol wisp uses unrecognized flag "-r"
-agents/witness/prompt.template.md:219: bd-unknown-flag: bd mol wisp uses unrecognized flag "-r"
-agents/witness/prompt.template.md:232: bd-unknown-flag: bd mol wisp uses unrecognized flag "-r"
-assets/prompts/crew.template.md:120: bd-unknown-flag: bd create uses unrecognized flag "--rig"
-assets/prompts/crew.template.md:121: bd-unknown-flag: bd create uses unrecognized flag "--rig"
-assets/prompts/crew.template.md:122: bd-unknown-flag: bd create uses unrecognized flag "--city"
+agents/deacon/prompt.template.md: bd-unknown-flag: bd mol wisp uses unrecognized flag "-r"
+agents/deacon/prompt.template.md: bd-unknown-flag: bd mol wisp uses unrecognized flag "-r"
+agents/deacon/prompt.template.md: bd-unknown-flag: bd mol wisp uses unrecognized flag "-r"
+agents/mayor/prompt.template.md: bd-unknown-flag: bd create uses unrecognized flag "--rig"
+agents/mayor/prompt.template.md: bd-unknown-flag: bd create uses unrecognized flag "--rig"
+agents/polecat/prompt.template.md: bd-unknown-flag: bd show uses unrecognized flag "-r"
+agents/polecat/prompt.template.md: bd-unknown-flag: bd show uses unrecognized flag "-r"
+agents/refinery/prompt.template.md: bd-unknown-flag: bd mol wisp uses unrecognized flag "-r"
+agents/refinery/prompt.template.md: bd-unknown-flag: bd mol wisp uses unrecognized flag "-r"
+agents/refinery/prompt.template.md: bd-unknown-flag: bd mol wisp uses unrecognized flag "-r"
+agents/refinery/prompt.template.md: bd-unknown-flag: bd show uses unrecognized flag "-r"
+agents/refinery/prompt.template.md: bd-unknown-flag: bd show uses unrecognized flag "-r"
+agents/refinery/prompt.template.md: bd-unknown-flag: bd show uses unrecognized flag "-r"
+agents/refinery/prompt.template.md: bd-unknown-flag: bd show uses unrecognized flag "-r"
+agents/witness/prompt.template.md: bd-unknown-flag: bd mol wisp uses unrecognized flag "-r"
+agents/witness/prompt.template.md: bd-unknown-flag: bd mol wisp uses unrecognized flag "-r"
+agents/witness/prompt.template.md: bd-unknown-flag: bd mol wisp uses unrecognized flag "-r"
+assets/prompts/crew.template.md: bd-unknown-flag: bd create uses unrecognized flag "--rig"
+assets/prompts/crew.template.md: bd-unknown-flag: bd create uses unrecognized flag "--rig"
+assets/prompts/crew.template.md: bd-unknown-flag: bd create uses unrecognized flag "--city"

--- a/tests/test_gastown_lint_findings.py
+++ b/tests/test_gastown_lint_findings.py
@@ -117,13 +117,19 @@ def observed_findings(gc_bin: str) -> Counter[str]:
     Paths come back absolute, so they are made relative to the pack directory:
     a finding key must be identical on a contributor's machine and on a runner.
 
-    The line number is deliberately NOT part of the key. It was, for one day,
-    and #265 moved the mayor prompt's rig-routing table without changing a
-    single diagnostic -- same file, same message, same count of two of them
-    where the table had four -- and every open PR in the repo inherited a red
-    main. A guard keyed on position reports edits. What is left still fails on
-    a new path, a new message, or an extra occurrence, because these are
-    Counters: three identical waiver lines waive exactly three findings.
+    The line number is deliberately NOT part of the key. It was, for one day.
+    #265 rewrote the mayor prompt's rig-routing table -- four rows collapsed
+    into one generic row, so the same unknown-flag diagnostic for `--rig`
+    moved from lines 118-121 to lines 23 and 114, four occurrences down to two.
+    Under a line-keyed waiver that read as two brand-new findings plus a
+    partially-reported version section, and every open PR in the repo
+    inherited a red main.
+
+    A guard keyed on position reports edits. Keyed on path and message it
+    reports findings, and the count is still load-bearing, because these are
+    Counters: three identical waiver lines waive exactly three findings and a
+    fourth fails. What survives: a new path, a new message, an extra
+    occurrence. What no longer fails: the same finding at a different line.
     """
     proc = subprocess.run(
         [gc_bin, "lint", PACK, "--json"],
@@ -161,8 +167,20 @@ def observed_findings(gc_bin: str) -> Counter[str]:
             f"gc lint reported on pack {reported!r}, not {PACK!r}"
         )
 
+    return findings_from_pack_report(packs[0])
+
+
+def findings_from_pack_report(pack_report: dict) -> Counter[str]:
+    """Normalize one pack's diagnostics into the keyed, counted form.
+
+    Split out from the subprocess call so the normalization has tests that do
+    not need a gc on PATH. Which gc is installed decides which sections of the
+    waiver are even reachable -- a post-5220 build emits none of `pre-5220` --
+    so without this the largest section of the waiver is exercised by no test
+    a contributor can run.
+    """
     findings: Counter[str] = Counter()
-    for diag in packs[0].get("diagnostics") or []:
+    for diag in pack_report.get("diagnostics") or []:
         path = Path(diag.get("path", ""))
         try:
             rel = path.relative_to(PACK_DIR)
@@ -277,3 +295,106 @@ class GastownLintFindingsTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class WaiverKeyingTest(unittest.TestCase):
+    """The keying properties, over synthetic reports, with no gc required.
+
+    The tests above can only see what the installed gc emits, and a post-5220
+    build emits none of the `pre-5220` section -- so on a contributor's machine
+    the twenty entries that broke main are read by nothing. These build the
+    report instead of running for it.
+
+    The synthetic reports are DERIVED FROM the waiver rather than restating it.
+    Restating it would put the same twenty lines in two files, where the copy
+    that drifts fails as the wrong thing. What is under test here is not which
+    findings are waived; it is that a report of exactly the waived pairs passes
+    at any line numbers, and that one more or one fewer does not.
+    """
+
+    def pack_report(self, keys: Counter[str], first_line: int = 1) -> dict:
+        """A gc-shaped pack report for these path/message pairs.
+
+        Line numbers ascend and are otherwise arbitrary, which is the point:
+        nothing downstream may depend on them. Paths are made absolute the way
+        gc emits them, so the relative-path step is exercised too.
+        """
+        diagnostics = []
+        line = first_line
+        for key, count in sorted(keys.items()):
+            rel, _, message = key.partition(": ")
+            for _ in range(count):
+                diagnostics.append(
+                    {
+                        "severity": "error",
+                        "path": str(PACK_DIR / rel),
+                        "line": line,
+                        "message": message,
+                    }
+                )
+                line += 7
+        return {"name": PACK, "ok": False, "diagnostics": diagnostics}
+
+    def all_waived(self) -> Counter[str]:
+        sections = waived_findings()
+        total: Counter[str] = Counter()
+        for entries in sections.values():
+            total += entries
+        return total
+
+    def test_the_same_findings_at_different_lines_are_the_same_findings(self) -> None:
+        """The regression that produced this file. Two line-disjoint reports of
+        the same diagnostics must be indistinguishable."""
+        waived = self.all_waived()
+        low = findings_from_pack_report(self.pack_report(waived, first_line=1))
+        high = findings_from_pack_report(self.pack_report(waived, first_line=9000))
+        self.assertEqual(low, high)
+        self.assertEqual(low, waived)
+        self.assertFalse(low - waived)
+
+    def test_repeated_pairs_keep_their_count(self) -> None:
+        """Dropping the line number must not collapse duplicates into one.
+
+        The mayor prompt legitimately carries the identical diagnostic twice
+        and the refinery prompt carries one four times, so a set here would
+        waive an unbounded number of them.
+        """
+        waived = self.all_waived()
+        repeated = {key: n for key, n in waived.items() if n > 1}
+        self.assertTrue(
+            repeated, "no waived pair repeats; this test is no longer meaningful"
+        )
+        observed = findings_from_pack_report(self.pack_report(waived))
+        for key, n in repeated.items():
+            self.assertEqual(observed[key], n, key)
+
+    def test_one_more_occurrence_of_a_waived_pair_is_a_new_finding(self) -> None:
+        """What replaces line sensitivity. A fourth of something waived three
+        times has to survive subtraction."""
+        waived = self.all_waived()
+        target = max(waived, key=lambda k: (waived[k], k))
+        extra = Counter(waived)
+        extra[target] += 1
+        observed = findings_from_pack_report(self.pack_report(extra))
+        self.assertEqual((observed - waived), Counter({target: 1}))
+
+    def test_a_tolerated_section_reported_short_by_one_is_partial(self) -> None:
+        """The all-present-or-all-absent rule, exercised without a v1.4.1 gc."""
+        sections = waived_findings()
+        for name in TOLERATED_SECTIONS:
+            entries = sections[name]
+            with self.subTest(section=name):
+                self.assertTrue(entries, f"section {name} is empty")
+                # One OCCURRENCE, not one key: `del` here would withhold all
+                # three of the deacon entry at once, which is a differently
+                # shaped failure and renders with a count suffix.
+                short = Counter(entries)
+                dropped = sorted(short)[0]
+                short[dropped] -= 1
+                observed = findings_from_pack_report(
+                    self.pack_report(sections[UNIVERSAL] + short)
+                )
+                self.assertTrue(
+                    entries & observed, "the section must be partially present"
+                )
+                self.assertEqual(render(entries - observed), [dropped])

--- a/tests/test_gastown_lint_findings.py
+++ b/tests/test_gastown_lint_findings.py
@@ -116,6 +116,14 @@ def observed_findings(gc_bin: str) -> Counter[str]:
 
     Paths come back absolute, so they are made relative to the pack directory:
     a finding key must be identical on a contributor's machine and on a runner.
+
+    The line number is deliberately NOT part of the key. It was, for one day,
+    and #265 moved the mayor prompt's rig-routing table without changing a
+    single diagnostic -- same file, same message, same count of two of them
+    where the table had four -- and every open PR in the repo inherited a red
+    main. A guard keyed on position reports edits. What is left still fails on
+    a new path, a new message, or an extra occurrence, because these are
+    Counters: three identical waiver lines waive exactly three findings.
     """
     proc = subprocess.run(
         [gc_bin, "lint", PACK, "--json"],
@@ -160,7 +168,7 @@ def observed_findings(gc_bin: str) -> Counter[str]:
             rel = path.relative_to(PACK_DIR)
         except ValueError:
             rel = path
-        findings[f"{rel}:{diag.get('line', 0)}: {diag.get('message', '')}"] += 1
+        findings[f"{rel}: {diag.get('message', '')}"] += 1
     return findings
 
 
@@ -225,8 +233,8 @@ class GastownLintFindingsTest(unittest.TestCase):
         """Tolerating a set is not tolerating an arbitrary subset of it.
 
         Without this, a real regression that happens to reuse one of these
-        file:line pairs is absorbed by the waiver, and the section can rot a
-        line at a time as the pack moves under it.
+        path/message pairs is absorbed by the waiver, and the section can rot
+        an entry at a time as the pack moves under it.
         """
         observed = observed_findings(self.gc_bin)
         sections = waived_findings()

--- a/tests/test_gastown_lint_findings.py
+++ b/tests/test_gastown_lint_findings.py
@@ -197,6 +197,29 @@ def render(counted: Counter[str]) -> list[str]:
     ]
 
 
+def partial_sections(observed: Counter[str]) -> dict[str, list[str]]:
+    """Tolerated sections this report carries only part of, section to missing.
+
+    The all-present-or-all-absent rule itself, as a function, so the test that
+    runs a real gc and the tests that build a synthetic report go through the
+    same code. Stated twice it would be two rules, and the synthetic copy would
+    keep passing against itself long after the live one moved.
+
+    A section absent in full is not partial -- that is a gc carrying the
+    upstream fix, which is the entire reason the section is separate.
+    """
+    sections = waived_findings()
+    partial: dict[str, list[str]] = {}
+    for name in TOLERATED_SECTIONS:
+        entries = sections[name]
+        if not (entries & observed):
+            continue
+        missing = render(entries - observed)
+        if missing:
+            partial[name] = missing
+    return partial
+
+
 class GastownLintFindingsTest(unittest.TestCase):
     def setUp(self) -> None:
         self.gc_bin = gc_binary()
@@ -254,22 +277,15 @@ class GastownLintFindingsTest(unittest.TestCase):
         path/message pairs is absorbed by the waiver, and the section can rot
         an entry at a time as the pack moves under it.
         """
-        observed = observed_findings(self.gc_bin)
-        sections = waived_findings()
-        for name in TOLERATED_SECTIONS:
-            entries = sections[name]
-            present = entries & observed
+        partial = partial_sections(observed_findings(self.gc_bin))
+        for name, missing in partial.items():
             with self.subTest(section=name):
-                if not present:
-                    continue
-                missing = render(entries - observed)
-                self.assertFalse(
-                    missing,
+                self.fail(
                     f"section {name!r} of {WAIVER.name} is partially reported "
                     f"by this gc. Present but missing:\n  "
                     + "\n  ".join(missing)
                     + "\nEither the pack moved under the waiver or the section "
-                    "is no longer one upstream change. Re-derive it.",
+                    "is no longer one upstream change. Re-derive it."
                 )
 
     def test_no_bd_unknown_flag_finding_outside_the_waiver(self) -> None:
@@ -291,10 +307,6 @@ class GastownLintFindingsTest(unittest.TestCase):
             "a bd flag that does not exist is back in a gastown prompt or "
             "formula:\n  " + "\n  ".join(unexpected),
         )
-
-
-if __name__ == "__main__":
-    unittest.main()
 
 
 class WaiverKeyingTest(unittest.TestCase):
@@ -397,4 +409,14 @@ class WaiverKeyingTest(unittest.TestCase):
                 self.assertTrue(
                     entries & observed, "the section must be partially present"
                 )
-                self.assertEqual(render(entries - observed), [dropped])
+                self.assertEqual(partial_sections(observed), {name: [dropped]})
+
+
+# Placed after every class so that `python tests/test_gastown_lint_findings.py`
+# runs all of them. It sat above WaiverKeyingTest for one commit, and unittest
+# collects by module namespace at call time, so the four keying tests were
+# silently excluded from every direct run -- green, and green about nothing.
+# pytest imports the whole module and was unaffected, which is exactly why
+# nobody would have noticed.
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gastown_lint_findings.py
+++ b/tests/test_gastown_lint_findings.py
@@ -322,6 +322,18 @@ class WaiverKeyingTest(unittest.TestCase):
     that drifts fails as the wrong thing. What is under test here is not which
     findings are waived; it is that a report of exactly the waived pairs passes
     at any line numbers, and that one more or one fewer does not.
+
+    KNOWN GAP, left open deliberately. "One fewer" is exercised through
+    `partial_sections`, which covers the tolerated sections only. The universal
+    section's all-present rule lives in
+    `test_every_universal_waiver_entry_is_still_reported`, which needs a real
+    gc, so on a machine without one that rule is unexercised. It is not the
+    rule that broke main -- a universal entry going missing means the upstream
+    linter fixed something, which is loud and expected, where a tolerated
+    section rotting one entry at a time is silent. Raised by the cross-family
+    review at head d40a901 and recorded rather than fixed, because closing it
+    means a second synthetic path for a rule the live test already covers in
+    CI.
     """
 
     def pack_report(self, keys: Counter[str], first_line: int = 1) -> dict:

--- a/tests/test_no_bare_bd_commands.py
+++ b/tests/test_no_bare_bd_commands.py
@@ -162,9 +162,14 @@ GC_BD_ARGV_TAIL_LINES = {
 # drifts fails as a bare-bd violation rather than as a stale waiver, which
 # points at the wrong problem. Nothing that matches this grammar is a command
 # anyone could run.
+#
+# The line number is optional because the waiver stopped carrying one: it is
+# keyed on path and message so that moving a diagnostic within a file is not a
+# CI failure. Both forms stay matchable, since gc lint's raw output still
+# carries the number and gets pasted here before it is trimmed.
 GC_LINT_DIAGNOSTIC_FILE = Path("tests/gastown_lint_upstream_defects.txt")
 GC_LINT_DIAGNOSTIC = re.compile(
-    r'[\w./-]+:\d+: bd-unknown-flag: bd [a-z][a-z ]* uses unrecognized flag "[-\w]+"'
+    r'[\w./-]+:(?:\d+:)? bd-unknown-flag: bd [a-z][a-z ]* uses unrecognized flag "[-\w]+"'
 )
 
 
@@ -296,10 +301,16 @@ def test_detector_covers_shell_multiline_and_serialized_argv_forms() -> None:
     # grammar alone does not exempt a line elsewhere, and the file alone does
     # not exempt a line that is not a diagnostic.
     diagnostic = 'a/b.md:12: bd-unknown-flag: bd create uses unrecognized flag "--rig"'
+    lineless = 'a/b.md: bd-unknown-flag: bd create uses unrecognized flag "--rig"'
     waiver = REPO_ROOT / "tests" / "gastown_lint_upstream_defects.txt"
     assert bare_bd_violations(fixture, diagnostic)
+    assert bare_bd_violations(fixture, lineless)
     assert bare_bd_violations(waiver, "bd create --labels=x")
     assert not bare_bd_violations(waiver, diagnostic)
+    # The form the waiver actually uses now. Without this the exemption could
+    # regress to line-numbers-only and every waiver entry would read as a bare
+    # bd command, which is a failure about the wrong file.
+    assert not bare_bd_violations(waiver, lineless)
 
     assert not bare_bd_violations(fixture, 'command = ["gc", "bd", "show"]')
     assert not bare_bd_violations(fixture, "gc --city /tmp/city bd list --json")


### PR DESCRIPTION
`main` has been red since `4d0211e5` and every open PR in this repo inherits the failure.

Nothing about the pack or the linter changed. #265 collapsed the mayor prompt's four-row rig-routing table into one generic row. That moved the same `bd create --rig` diagnostic from lines 118-121 to lines 23 and 114, and dropped its count from four to two. `tests/gastown_lint_upstream_defects.txt` pinned `file:line` pairs, so the guard read a pure content move as two new findings plus a partially-reported version section.

## The change

The finding key is now path and message. Occurrences are counted, so three identical waiver lines waive exactly three findings and a fourth still fails.

Given up, deliberately: the waiver no longer says where to look, and a finding that moves within a file is invisible. The section comments already carry the gc-side cause and a refute command, which is what a reader actually needs, and a moved finding is not an event. Still caught: a new path, a new message, one more occurrence of an existing pair.

`tests/test_no_bare_bd_commands.py` moves with it. Its exemption grammar required `:<line>:`, so without the same change every waiver entry quoting a `bd` invocation would start reading as a bare `bd` command — a failure about the wrong file. The line number is optional there now, asserted in both directions.

## Test plan

A post-5220 local `gc` emits none of the `pre-5220` section, so running the suite locally goes green without ever reading the part that broke. Everything below runs against a stub `gc` reporting what v1.4.1 reports for this tree: the universal seven copied from a real run, and the twenty `pre-5220` entries at the line numbers CI itself reported at `4d0211e5`.

| Mutation | Expected | Result |
| --- | --- | --- |
| pre-fix test + pre-fix waiver, simulated v1.4.1 | red | reproduces all three named CI failures |
| post-fix, same simulated output | green | 4 passed |
| post-fix + a third `--rig` in the mayor prompt | red | 2 failed |
| post-fix + one `pre-5220` entry withheld | red | all-or-nothing subtest fails |
| post-fix + a waived finding moved, count unchanged | green | 4 passed |

Full suite on this branch with the real `gc`: 112 passed, 8 skipped.

Refute the diagnosis: `git log --oneline -3 upstream/main -- gastown/agents/mayor/prompt.template.md`, then `git show 4d0211e^:gastown/agents/mayor/prompt.template.md | grep -n -- --rig` against `grep -n -- --rig gastown/agents/mayor/prompt.template.md`.