### PR TITLE
Test the five maintained packs against a running gc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,18 @@ jobs:
         run: |
           go install github.com/gastownhall/gascity/cmd/gc@latest
           GC_BIN="$(go env GOPATH)/bin/gc"
+          # oversight-rig is deliberately absent. Under the gc this step
+          # installs it reports four bd-unknown-flag findings for `gc bd list
+          # --rig`, which is valid: `gc bd` strips --rig in extractBdScopeFlags
+          # before forwarding, and the scanner validated against bare bd's
+          # manifest alone. Same upstream defect as the `pre-5220` section of
+          # tests/gastown_lint_upstream_defects.txt, fixed by gascity 7724983de
+          # and not in v1.4.1. Add oversight-rig here in the same change that
+          # deletes that section. A dev gc already reports zero for it, so
+          # pinning them would waive findings most contributors never see.
+          # Refute: gc lint oversight-rig  (0 findings on main, 4 on v1.4.1)
           for pack in gascity gascity/roles bmad compound-engineering gstack superpowers profiler \
-                      oversight-rig pr-pipeline slack-channel slack-full slack-mini; do
+                      pr-pipeline slack-channel slack-full slack-mini; do
             "$GC_BIN" lint "$pack"
           done
           GC_TEST_BIN="$GC_BIN" python3 -m pytest tests/test_gc_role_prompt_integration.py -q

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,16 +41,27 @@ jobs:
         run: python3 validate_registry.py --require-git
 
       - name: Run Python pack tests
-        run: python3 -m pytest tests contributing/tests gascity/tests discord/tests github/tests slack-full/tests slack-channel/tests pr-pipeline/tests profiler/tests -q
+        run: python3 -m pytest tests contributing/tests gascity/tests discord/tests github/tests oversight-rig/tests slack-full/tests slack-channel/tests pr-pipeline/tests profiler/tests -q
 
       - name: Lint and exercise shared role prompt composition
         run: |
           go install github.com/gastownhall/gascity/cmd/gc@latest
           GC_BIN="$(go env GOPATH)/bin/gc"
-          for pack in gascity gascity/roles bmad compound-engineering gstack superpowers profiler; do
+          for pack in gascity gascity/roles bmad compound-engineering gstack superpowers profiler \
+                      oversight-rig pr-pipeline slack-channel slack-full slack-mini; do
             "$GC_BIN" lint "$pack"
           done
           GC_TEST_BIN="$GC_BIN" python3 -m pytest tests/test_gc_role_prompt_integration.py -q
+
+      # Installed, not parsed. `gc lint` above reads each pack on its own and
+      # the per-pack suites read their own TOML; neither can say what gc does
+      # when a city loads the pack, which is where a user meets it. pr-pipeline
+      # linted clean for months while putting a deprecation warning into every
+      # importing city's `gc doctor`.
+      - name: Stand each maintained pack up against gc
+        run: |
+          GC_TEST_BIN="$(go env GOPATH)/bin/gc" \
+            python3 -m pytest tests/test_maintained_packs_live_gc.py -q
 
       # gastown is not in the lint loop above because seven of its findings are
       # defects in gc's linter rather than in the pack; see

--- a/discord/tests/test_discord_intake_common.py
+++ b/discord/tests/test_discord_intake_common.py
@@ -17,6 +17,13 @@ sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
 
 import discord_intake_common as common
 
+# GC_BIN and GC_API_BASE_URL: the assertions here expect the defaults the
+# scripts fall back to (`gc`, and the supervisor's own base URL). A Gas City
+# seat exports both, so nine of these tests fail for anyone running the suite
+# from inside a city, and pass in CI only because CI sets neither. Each setUp
+# pins the fallback rather than depending on the variables' absence.
+SEAT_ENV_OVERRIDES = ("GC_BIN", "GC_API_BASE_URL")
+
 
 class DiscordIntakeCommonTests(unittest.TestCase):
     def setUp(self) -> None:
@@ -24,6 +31,8 @@ class DiscordIntakeCommonTests(unittest.TestCase):
         self.addCleanup(self.tempdir.cleanup)
         self._old_environ = os.environ.copy()
         os.environ["GC_CITY_ROOT"] = self.tempdir.name
+        for name in SEAT_ENV_OVERRIDES:
+            os.environ.pop(name, None)
 
     def tearDown(self) -> None:
         os.environ.clear()

--- a/discord/tests/test_discord_intake_service.py
+++ b/discord/tests/test_discord_intake_service.py
@@ -58,6 +58,9 @@ class DiscordIntakeServiceTests(unittest.TestCase):
         self.addCleanup(self.tempdir.cleanup)
         self._old_environ = os.environ.copy()
         os.environ["GC_CITY_ROOT"] = self.tempdir.name
+        # See the SEAT_ENV_OVERRIDES note in test_discord_intake_common.py.
+        for name in ("GC_BIN", "GC_API_BASE_URL"):
+            os.environ.pop(name, None)
         service.LAST_REQUEST_PRUNE_AT = 0.0
         service.LAST_REQUEST_RECOVERY_AT = 0.0
 

--- a/gascity/tests/test_formula_assets.py
+++ b/gascity/tests/test_formula_assets.py
@@ -821,6 +821,11 @@ class FormulaAssetTests(unittest.TestCase):
                 **os.environ,
                 "BEADS_ACTOR": "worker",
                 "GC_AGENT": "gc.implementation-worker",
+                # commands/claim/run.sh reads `${GC_TEMPLATE:-${GC_AGENT:-}}`, so
+                # a seat's exported GC_TEMPLATE outranks the GC_AGENT this test is
+                # exercising and the claim is rejected on a route mismatch. Empty
+                # falls through to GC_AGENT; the env dict cannot unset a name.
+                "GC_TEMPLATE": "",
                 "GC_PACK_DIR": str(root),
                 "GC_PACK_NAME": "gc",
                 "PATH": f"{bin_dir}:/usr/bin:/bin",
@@ -924,6 +929,7 @@ class FormulaAssetTests(unittest.TestCase):
                 **os.environ,
                 "BEADS_ACTOR": "worker",
                 "GC_AGENT": "gc.implementation-worker",
+                "GC_TEMPLATE": "",  # see the GC_TEMPLATE note above
                 "GC_PACK_DIR": str(root),
                 "GC_PACK_NAME": "gc",
                 "GC_SESSION_ID": "session-1",

--- a/github/tests/test_github_intake_service.py
+++ b/github/tests/test_github_intake_service.py
@@ -16,6 +16,13 @@ sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
 
 import github_intake_service as service
 
+# GC_BIN: the assertions below expect the literal `gc`, which is what
+# `os.environ.get("GC_BIN", "gc")` falls back to in the service. A Gas City seat
+# exports GC_BIN, so 14 of these tests fail for anyone running the suite from
+# inside a city, and pass in CI only because CI has not installed gc yet at the
+# step that runs them. Each setUp pins the fallback rather than depending on the
+# variable's absence.
+
 
 class DummyWebhookHandler:
     def __init__(self, body: bytes, headers: dict[str, str]) -> None:
@@ -42,6 +49,7 @@ class GitHubIntakeServiceTests(unittest.TestCase):
         self.addCleanup(self.tempdir.cleanup)
         self._old_environ = os.environ.copy()
         os.environ["GC_CITY_ROOT"] = self.tempdir.name
+        os.environ.pop("GC_BIN", None)  # see GC_BIN note at the top of this file
 
     def tearDown(self) -> None:
         os.environ.clear()
@@ -1592,6 +1600,7 @@ class PublishImportedIdentityTests(unittest.TestCase):
         self.addCleanup(self.tempdir.cleanup)
         self._old_environ = os.environ.copy()
         os.environ["GC_CITY_ROOT"] = self.tempdir.name
+        os.environ.pop("GC_BIN", None)  # see GC_BIN note at the top of this file
         os.environ.pop("GITHUB_INTAKE_IDENTITY_PUBLISHER", None)
         os.environ.pop("GITHUB_INTAKE_APP_IDENTITY", None)
 
@@ -1676,6 +1685,7 @@ class RenderAdminHomeTests(unittest.TestCase):
         self.addCleanup(self.tempdir.cleanup)
         self._old_environ = os.environ.copy()
         os.environ["GC_CITY_ROOT"] = self.tempdir.name
+        os.environ.pop("GC_BIN", None)  # see GC_BIN note at the top of this file
 
     def tearDown(self) -> None:
         os.environ.clear()

--- a/pr-pipeline/formulas/mol-pr-from-issue.formula.toml
+++ b/pr-pipeline/formulas/mol-pr-from-issue.formula.toml
@@ -63,13 +63,19 @@ phase = "vapor"
 # predicate (internal/formula/compile.go) is
 #   rootOnly := (!f.Pour && f.Phase == "vapor") || len(f.Steps) == 0
 # which keys only on pour and phase; the graph declaration form is never
-# consulted, so `contract = "graph.v2"` does not protect against it. Note the
-# failure is silent: RecipeHasReadySurface still returns true because RootOnly
-# itself satisfies it, so the pool sling is accepted and only the steps go
-# missing.
+# consulted, so declaring a compiler requirement does not protect against it.
+# Note the failure is silent: RecipeHasReadySurface still returns true because
+# RootOnly itself satisfies it, so the pool sling is accepted and only the
+# steps go missing.
 pour = true
 version = 1
-contract = "graph.v2"
+
+# The v2 compiler requirement, in the form gc reads today. This was
+# `contract = "graph.v2"`, which gc still honors and reports as deprecated in
+# `gc doctor` -- one `formula-requirements` warning in every city that imports
+# this pack.
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.issue_number]

--- a/pr-pipeline/tests/test_pr_pipeline_formulas.py
+++ b/pr-pipeline/tests/test_pr_pipeline_formulas.py
@@ -27,7 +27,23 @@ class MolPrFromIssueVarBindingTests(unittest.TestCase):
     def test_formula_is_present_and_well_formed(self) -> None:
         self.assertTrue(self.path.exists(), "mol-pr-from-issue must live in the pr-pipeline pack")
         self.assertEqual(self.data["formula"], "mol-pr-from-issue")
-        self.assertEqual(self.data["contract"], "graph.v2")
+
+    def test_v2_compiler_requirement_is_declared_in_the_form_gc_reads(self) -> None:
+        """`contract = "graph.v2"` is deprecated; `[requires]` is the live form.
+
+        This asserted the deprecated key until 2026-08-17, and passed the whole
+        time. It could not have done otherwise: it read the file's own text back
+        to itself, and gc was never involved. Meanwhile every city importing this
+        pack carried a `formula-requirements` warning from `gc doctor`. The check
+        that catches the next one of these is tests/test_reference_city.py, which
+        runs the binary; this one just pins the value that fix landed on.
+        """
+        self.assertNotIn(
+            "contract",
+            self.data,
+            "gc reports `contract = \"graph.v2\"` as deprecated in gc doctor",
+        )
+        self.assertEqual(self.data["requires"]["formula_compiler"], ">=2.0.0")
 
     def test_github_issue_input_is_named_issue_number(self) -> None:
         variables = self.data.get("vars", {})

--- a/tests/gc_live_city.py
+++ b/tests/gc_live_city.py
@@ -1,0 +1,407 @@
+"""Stand a pack up in a scratch city and ask a real `gc` binary about it.
+
+A pack's own unit tests read its TOML and confirm the file parses. `gc lint`
+reads one pack in isolation. Neither can say what Gas City does when it loads
+that file into a city, which is the only place a user meets a pack -- and the
+gap is not theoretical: every pack we maintain linted clean while `pr-pipeline`
+put a deprecation warning into `gc doctor` for every city that imported it.
+
+This module is the shared harness for tests that close that gap. It offers three
+things a caller composes:
+
+`write_city` builds a throwaway city that imports whatever packs the caller
+names, at city scope, rig scope, or both.
+
+`attributable` runs `gc doctor` twice -- once against that city, once against a
+baseline city with the same shape and no packs under test -- and returns the
+difference. A doctor run on a developer's machine reports a couple of dozen
+findings that have nothing to do with any pack (no tmux, no bead store, no git
+in the scratch rig). Hand-listing them would be a waiver set that rots.
+Subtracting a baseline cancels them without naming any of them.
+
+`write_canary_pack` is the control every caller of `attributable` owes. An empty
+delta is also what a doctor that stopped reporting produces, and what a city
+that failed to load before doctor reached the packs produces. The canary is a
+pack whose formula declares a deprecated contract on purpose, so a test can
+require the subtraction to surface a known finding through this fixture shape,
+on this binary, in this environment.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import textwrap
+import tomllib
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+CANARY_BINDING = "requirements-canary"
+BASELINE_BINDING = "delta-baseline"
+CANARY_CHECK = "formula-requirements"
+
+# `  ⚠ rig-pack-coverage — 1 rig-scoped named_session(s) not covered ...`
+DOCTOR_FINDING = re.compile(r"^\s*[⚠✗]\s+(\S+)\s+—")
+
+# Findings the delta cannot cancel, with the reason. Every other environment
+# finding cancels because both cities run on the same host in the same second;
+# these do not, so they are named rather than tolerated silently.
+UNSTABLE_CHECKS = frozenset(
+    {
+        # Host-wide processes-per-second, sampled independently in each run and
+        # compared against a fixed threshold. It moves with whatever else the
+        # machine is doing, including the other doctor run in this same test.
+        "fork-rate",
+    }
+)
+
+
+@dataclass(frozen=True)
+class Workspace:
+    city_dir: Path
+    rig_dir: Path
+    env: dict[str, str]
+
+
+@pytest.fixture(scope="session")
+def gc_test_bin() -> Path:
+    configured = os.environ.get("GC_TEST_BIN")
+    if not configured:
+        pytest.skip("set GC_TEST_BIN to run real Gas City CLI integration tests")
+
+    binary = Path(configured).expanduser().resolve()
+    if not binary.is_file() or not os.access(binary, os.X_OK):
+        pytest.fail(f"GC_TEST_BIN is not an executable file: {binary}")
+    return binary
+
+
+def read_pack_manifest(pack_dir: Path) -> dict:
+    return tomllib.loads(pack_dir.joinpath("pack.toml").read_text(encoding="utf-8"))
+
+
+def declares_a_service(pack_dir: Path) -> bool:
+    """Whether the pack ships a `[[service]]`, which pins it to city scope.
+
+    Gas City rejects a rig-scoped import carrying one outright ("[[service]] is
+    only allowed in city-scoped packs"), so a caller cannot choose the wiring
+    freely -- the pack decides it. Read from the pack rather than listed per
+    pack here, so adding a service to a pack changes how it is tested.
+    """
+    return bool(read_pack_manifest(pack_dir).get("service"))
+
+
+def declares_a_rig_scoped_session(pack_dir: Path) -> bool:
+    """Whether the pack ships a rig-scoped `[[named_session]]`.
+
+    A pack that does has to be bound per rig as well as at city scope, or
+    `gc doctor` reports `rig-pack-coverage` -- the session it declares has no
+    rig to run in. Also derived rather than listed, for the same reason.
+    """
+    return any(
+        session.get("scope") == "rig"
+        for session in read_pack_manifest(pack_dir).get("named_session", ())
+    )
+
+
+def discover_agents(pack_dir: Path) -> set[str]:
+    """The agent roles a pack ships, from `agents/<name>/agent.toml`."""
+    agents_dir = pack_dir / "agents"
+    if not agents_dir.is_dir():
+        return set()
+    return {path.parent.name for path in agents_dir.glob("*/agent.toml")}
+
+
+def discover_command_words(pack_dir: Path) -> set[tuple[str, ...]]:
+    """The command paths a pack ships, as the word tuples `gc` will register.
+
+    Pack commands are discovered by convention -- a directory under `commands/`
+    holding a `run.sh` or a `command.toml` is a leaf, and nested directories
+    become nested command words. Nothing declares them, which is what makes the
+    surface easy to lose silently: a moved directory or a renamed script drops a
+    verb with no error anywhere.
+
+    Derived rather than listed so a pack that grows a command gets it tested.
+    Callers must reject an empty result; a derivation that silently finds
+    nothing would make every assertion built on it vacuous.
+    """
+    commands_dir = pack_dir / "commands"
+    if not commands_dir.is_dir():
+        return set()
+
+    words = {
+        leaf.parent.relative_to(commands_dir).parts
+        for name in ("run.sh", "command.toml")
+        for leaf in commands_dir.rglob(name)
+    }
+    # A runner sitting directly in `commands/` names no verb. Nothing in this
+    # repo does that, and the empty tuple would silently become a `words[-1]`
+    # crash in a caller rather than a readable failure here.
+    assert () not in words, (
+        f"{pack_dir.name} has a command runner directly in commands/ rather "
+        "than in a leaf directory, so it names no verb"
+    )
+    return words
+
+
+def discover_formulas(pack_dir: Path) -> set[str]:
+    """The formula names a pack ships, from its `formulas/` directory."""
+    formulas_dir = pack_dir / "formulas"
+    if not formulas_dir.is_dir():
+        return set()
+    return {path.name.split(".", 1)[0] for path in formulas_dir.glob("*.formula.toml")}
+
+
+def write_canary_pack(root: Path) -> Path:
+    """A pack whose one formula declares the deprecated contract on purpose."""
+    pack_dir = root / "canary-pack"
+    (pack_dir / "formulas").mkdir(parents=True)
+    pack_dir.joinpath("pack.toml").write_text(
+        textwrap.dedent(
+            f"""\
+            [pack]
+            name = "{CANARY_BINDING}"
+            schema = 2
+            """
+        ),
+        encoding="utf-8",
+    )
+    pack_dir.joinpath("formulas", "mol-requirements-canary.formula.toml").write_text(
+        textwrap.dedent(
+            """\
+            description = "Fixture. Never dispatched."
+            formula = "mol-requirements-canary"
+            version = 1
+            contract = "graph.v2"
+            pour = true
+
+            [[steps]]
+            id = "noop"
+            title = "Never dispatched"
+            prompt = "Fixture step."
+            """
+        ),
+        encoding="utf-8",
+    )
+    return pack_dir
+
+
+def write_baseline_pack(root: Path) -> Path:
+    """An empty pack with the SHAPE of a real one: one agent, one order.
+
+    The baseline has to be comparable, not merely empty. Several doctor checks
+    only run once a city has something to check -- `order-firing-current` needs
+    a scheduled order, `v2-routed-to-namespace` needs a binding-qualified route
+    target -- so an empty baseline skips them, and every one of them shows up in
+    the delta as though the pack under test had caused it. It had not: an order
+    that has never fired in a city that has never started is stale in any city,
+    and a route check that cannot reach a bead store is skipped in any city.
+    Give the baseline the same shape and both cancel, without either one being
+    named in a waiver list that would then also hide a real regression.
+    """
+    pack_dir = root / "baseline-pack"
+    (pack_dir / "orders").mkdir(parents=True)
+    agent_dir = pack_dir / "agents" / "inert"
+    agent_dir.mkdir(parents=True)
+    pack_dir.joinpath("pack.toml").write_text(
+        textwrap.dedent(
+            f"""\
+            [pack]
+            name = "{BASELINE_BINDING}"
+            schema = 2
+            """
+        ),
+        encoding="utf-8",
+    )
+    pack_dir.joinpath("orders", "inert.toml").write_text(
+        textwrap.dedent(
+            """\
+            [order]
+            description = "Fixture. Never fires; exists so order checks run."
+            trigger = "cooldown"
+            interval = "15m"
+            exec = "true"
+            timeout = "30s"
+            """
+        ),
+        encoding="utf-8",
+    )
+    agent_dir.joinpath("agent.toml").write_text(
+        textwrap.dedent(
+            """\
+            scope = "rig"
+            work_dir = "."
+            """
+        ),
+        encoding="utf-8",
+    )
+    agent_dir.joinpath("prompt.template.md").write_text(
+        "Fixture agent. Never dispatched.\n", encoding="utf-8"
+    )
+    return pack_dir
+
+
+def write_city(
+    root: Path,
+    imports: dict[str, Path],
+    rig_imports: dict[str, Path] | None = None,
+) -> Workspace:
+    """A scratch city importing `imports` at city scope, `rig_imports` at rig."""
+    city_dir = root / "city"
+    rig_dir = root / "demo"
+    gc_home = root / "gc-home"
+    home = root / "home"
+    (city_dir / ".gc").mkdir(parents=True)
+    (rig_dir / ".gc").mkdir(parents=True)
+    gc_home.mkdir()
+    home.mkdir()
+
+    bindings = "".join(
+        f"\n[imports.{name}]\nsource = {json.dumps(str(path.resolve()))}\n"
+        for name, path in sorted(imports.items())
+    )
+    city_dir.joinpath("pack.toml").write_text(
+        textwrap.dedent(
+            """\
+            [pack]
+            name = "pack-under-test"
+            schema = 2
+            """
+        )
+        + bindings,
+        encoding="utf-8",
+    )
+
+    rig_bindings = "".join(
+        f"\n[rigs.imports.{name}]\nsource = {json.dumps(str(path.resolve()))}\n"
+        for name, path in sorted((rig_imports or {}).items())
+    )
+    city_dir.joinpath("city.toml").write_text(
+        textwrap.dedent(
+            """\
+            [workspace]
+            provider = "claude"
+
+            [providers.claude]
+            base = "builtin:claude"
+
+            [[rigs]]
+            name = "demo"
+            """
+        )
+        + rig_bindings,
+        encoding="utf-8",
+    )
+    city_dir.joinpath(".gc", "site.toml").write_text(
+        textwrap.dedent(
+            f"""\
+            workspace_name = "pack-under-test"
+
+            [[rig]]
+            name = "demo"
+            path = {json.dumps(str(rig_dir))}
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    brief = REPO_ROOT / "oversight-rig" / "agents" / "project-lead"
+    brief = brief / "project-brief.template.md"
+    if brief.is_file():
+        rig_dir.joinpath(".gc", "project-brief.md").write_text(
+            brief.read_text(encoding="utf-8"), encoding="utf-8"
+        )
+
+    # Strip the caller's Gas City and beads environment rather than inheriting
+    # it. `BEADS_DOLT_SERVER_PORT` in particular overrides what a city's own
+    # metadata names, so a developer running this suite inside a live city
+    # would have these scratch invocations reach that city's canonical store.
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith(("GC_", "BEADS_"))
+    }
+    env.update(
+        {
+            "HOME": str(home),
+            "GC_HOME": str(gc_home),
+            "GC_CITY": str(city_dir),
+            "GC_CITY_PATH": str(city_dir),
+            "GC_CITY_ROOT": str(city_dir),
+            "GC_RIG": "demo",
+        }
+    )
+    return Workspace(city_dir=city_dir, rig_dir=rig_dir, env=env)
+
+
+def run_gc(
+    gc_test_bin: Path, workspace: Workspace, *args: str
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [str(gc_test_bin), *args],
+        cwd=workspace.rig_dir,
+        env=workspace.env,
+        text=True,
+        capture_output=True,
+        timeout=300,
+    )
+
+
+def gc_output(gc_test_bin: Path, workspace: Workspace, *args: str) -> str:
+    """Run gc, refusing to return output from a command that failed.
+
+    Returning stdout+stderr alone makes "the command ran and listed nothing"
+    indistinguishable from "the command never got far enough to list", and
+    every presence assertion built on this is a search through the string.
+    """
+    result = run_gc(gc_test_bin, workspace, *args)
+    output = result.stdout + result.stderr
+    assert result.returncode == 0, (
+        f"gc {' '.join(args)} exited {result.returncode}; an absent name in "
+        f"this output is a failed command, not a missing surface. Output:\n{output}"
+    )
+    return output
+
+
+def doctor_findings(gc_test_bin: Path, workspace: Workspace) -> set[str]:
+    """Check names `gc doctor` reported as warning or failure.
+
+    Deliberately not asserting on the exit status: doctor exits non-zero
+    whenever anything is off, and in a scratch city with no store something
+    always is. The delta is the signal, not the code.
+    """
+    result = run_gc(gc_test_bin, workspace, "doctor")
+    output = result.stdout + result.stderr
+    findings = {
+        match.group(1)
+        for match in (DOCTOR_FINDING.match(line) for line in output.splitlines())
+        if match is not None
+    }
+    assert findings, (
+        "gc doctor named no check at all, so this run cannot contribute to a "
+        f"delta. Output:\n{output}"
+    )
+    return findings - UNSTABLE_CHECKS
+
+
+def attributable(
+    gc_test_bin: Path,
+    tmp_path: Path,
+    imports: dict[str, Path],
+    rig_imports: dict[str, Path] | None = None,
+) -> set[str]:
+    """Doctor findings these imports add to a city that would not have them."""
+    shape = {BASELINE_BINDING: write_baseline_pack(tmp_path / "shape")}
+    baseline = doctor_findings(
+        gc_test_bin, write_city(tmp_path / "baseline", shape, shape)
+    )
+    loaded = doctor_findings(
+        gc_test_bin, write_city(tmp_path / "loaded", imports, rig_imports)
+    )
+    return loaded - baseline

--- a/tests/gc_live_city.py
+++ b/tests/gc_live_city.py
@@ -325,11 +325,23 @@ def write_city(
     env = {
         key: value
         for key, value in os.environ.items()
-        if not key.startswith(("GC_", "BEADS_"))
+        if not key.startswith(("GC_", "BEADS_", "XDG_"))
     }
     env.update(
         {
             "HOME": str(home),
+            # Pinning HOME is not enough. Pack code that resolves config the
+            # portable way reads `${XDG_CONFIG_HOME:-$HOME/.config}`, and a set
+            # XDG_CONFIG_HOME beats the pinned HOME, so the scratch city reads
+            # the developer's real dotfiles. Caught by CI, not locally:
+            # `slack-full`'s doctor/check-env.sh found this operator's
+            # ~/.config/gc-slack-adapter/env and passed here, while a clean
+            # runner with no such file reported `slack-full:env`. Redirect the
+            # whole XDG set, since data/state/cache override HOME identically.
+            "XDG_CONFIG_HOME": str(home / ".config"),
+            "XDG_DATA_HOME": str(home / ".local" / "share"),
+            "XDG_STATE_HOME": str(home / ".local" / "state"),
+            "XDG_CACHE_HOME": str(home / ".cache"),
             "GC_HOME": str(gc_home),
             "GC_CITY": str(city_dir),
             "GC_CITY_PATH": str(city_dir),

--- a/tests/test_maintained_packs_live_gc.py
+++ b/tests/test_maintained_packs_live_gc.py
@@ -1,0 +1,215 @@
+"""Every pack we maintain, stood up in a city and asked about by a real `gc`.
+
+These five are the packs users actually install, and the ones we have committed
+to keeping working. Each is imported on its own here, because each is imported
+on its own by a user -- nobody installs "the maintained set". The whole point of
+running them separately is that a break in one is attributed to that one.
+
+What each pack gets:
+
+* its declared surfaces, derived from its own directory rather than listed here,
+  resolved through a running `gc` in a city that imports it;
+* a `gc doctor` delta against a baseline city, asserted by set EQUALITY against
+  what that pack is currently expected to add. Equality rather than emptiness
+  because a legitimate finding exists (an adapter binary a pack cannot ship
+  built), and equality rather than `assertFalse` on new items because a finding
+  that DISAPPEARS is also news: it means either the pack stopped declaring
+  something or `gc` stopped checking it.
+
+The control lives in `test_the_doctor_delta_can_surface_a_finding` and every
+delta assertion here depends on it. An empty or unchanged delta is also what a
+doctor that stopped reporting produces.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from gc_live_city import (
+    CANARY_BINDING,
+    CANARY_CHECK,
+    REPO_ROOT,
+    attributable,
+    declares_a_rig_scoped_session,
+    declares_a_service,
+    discover_agents,
+    discover_command_words,
+    discover_formulas,
+    gc_output,
+    gc_test_bin,  # noqa: F401 -- pytest fixture, used by name
+    write_canary_pack,
+    write_city,
+)
+
+
+# The packs this city owns the maintenance of. Adding a pack here is the whole
+# cost of bringing it under live-gc coverage; everything below derives from the
+# pack's own contents.
+MAINTAINED_PACKS = (
+    "oversight-rig",
+    "pr-pipeline",
+    "slack-channel",
+    "slack-full",
+    "slack-mini",
+)
+
+# Doctor findings each pack is currently expected to add to a city, with the
+# reason it is legitimate. An entry here is a claim that a user installing the
+# pack meets this message and that we have decided it is correct for them to.
+# Anything not written down is a regression, and removing an entry without
+# removing its cause is caught too, because the assertion is equality.
+EXPECTED_DOCTOR_DELTA: dict[str, frozenset[str]] = {
+    "oversight-rig": frozenset(),
+    "pr-pipeline": frozenset(),
+    "slack-channel": frozenset(),
+    # The pack ships its Slack adapter as source and its own doctor check
+    # reports the binary as not yet built. That is the correct message for a
+    # fresh install -- the user builds it during setup -- and it is the only
+    # finding any of these five adds today. `slack-channel` and `slack-mini`
+    # ship the same unbuilt adapter and no check that notices, which is why
+    # their entries are empty rather than matching.
+    "slack-full": frozenset({"slack-full:binaries"}),
+    "slack-mini": frozenset(),
+}
+
+
+def pack_dir(pack: str) -> Path:
+    return REPO_ROOT / pack
+
+
+def wiring(pack: str) -> tuple[dict[str, Path], dict[str, Path]]:
+    """City-scope and rig-scope bindings for one pack, as its manifest requires.
+
+    Not a choice. A pack declaring a `[[service]]` is rejected at rig scope, and
+    a pack declaring a rig-scoped `[[named_session]]` leaves `rig-pack-coverage`
+    reported unless it is bound per rig. Both are read from the pack, so a pack
+    that changes its manifest changes how this suite installs it.
+    """
+    directory = pack_dir(pack)
+    has_service = declares_a_service(directory)
+    needs_rig = declares_a_rig_scoped_session(directory)
+
+    assert not (has_service and needs_rig), (
+        f"{pack} declares both a [[service]] (city scope only) and a rig-scoped "
+        "[[named_session]] (needs a rig binding). There is no wiring that "
+        "satisfies both, so this suite cannot describe how to install it."
+    )
+
+    return {pack: directory}, ({pack: directory} if needs_rig else {})
+
+
+@pytest.fixture(scope="session")
+def canary_delta(tmp_path_factory, gc_test_bin: Path) -> frozenset[str]:  # noqa: F811
+    """The control, run once: a pack that earns a finding on purpose.
+
+    Every delta assertion in this file is a statement about a subtraction. If
+    the subtraction cannot surface anything -- because doctor stopped reporting,
+    because the fixture city fails to load before doctor reaches its packs,
+    because the binary changed its output shape -- then every one of those
+    statements holds vacuously and this suite goes green having measured
+    nothing. This fixture is what makes the greens mean something.
+    """
+    root = tmp_path_factory.mktemp("canary")
+    canary = write_canary_pack(root / "fixture")
+    return frozenset(attributable(gc_test_bin, root / "city", {CANARY_BINDING: canary}))
+
+
+def test_the_doctor_delta_can_surface_a_finding(canary_delta: frozenset[str]) -> None:
+    assert CANARY_CHECK in canary_delta, (
+        'a pack whose formula declares the deprecated `contract = "graph.v2"` '
+        f"did not add {CANARY_CHECK!r} to the doctor delta, so every delta "
+        f"asserted in this file proves nothing. Delta was: {sorted(canary_delta)}"
+    )
+
+
+@pytest.mark.parametrize("pack", MAINTAINED_PACKS)
+def test_pack_adds_only_the_doctor_findings_we_have_accepted(
+    pack: str, tmp_path: Path, gc_test_bin: Path, canary_delta: frozenset[str]  # noqa: F811
+) -> None:
+    imports, rig_imports = wiring(pack)
+    found = attributable(gc_test_bin, tmp_path, imports, rig_imports)
+    expected = EXPECTED_DOCTOR_DELTA[pack]
+
+    assert found == expected, (
+        f"installing {pack} changes what gc doctor reports, against what this "
+        f"suite records as accepted.\n"
+        f"  new (a user installing {pack} now meets this): {sorted(found - expected)}\n"
+        f"  gone (recorded as expected, no longer reported): {sorted(expected - found)}\n"
+        f"Run `gc doctor` in a city importing {pack} to read the messages. A new "
+        f"finding is a defect in the pack unless it is deliberate, in which case "
+        f"it goes in EXPECTED_DOCTOR_DELTA with the reason. A finding that went "
+        f"away is fixed work: delete the entry in the same change."
+    )
+
+
+@pytest.mark.parametrize("pack", MAINTAINED_PACKS)
+def test_pack_registers_the_command_verbs_it_ships(
+    pack: str, tmp_path: Path, gc_test_bin: Path  # noqa: F811
+) -> None:
+    """Pack commands are discovered by convention, so nothing declares them.
+
+    That makes the surface easy to lose silently: a moved directory or a renamed
+    leaf script drops a verb with no error anywhere. `gc <pack> ... --help` is
+    where a user would notice, so it is where this asserts.
+    """
+    leaves = discover_command_words(pack_dir(pack))
+    if not leaves:
+        pytest.skip(f"{pack} ships no commands")
+
+    imports, rig_imports = wiring(pack)
+    workspace = write_city(tmp_path, imports, rig_imports)
+
+    # One `--help` per level of nesting: pr-pipeline puts its leaves under `pr`,
+    # the slack packs put theirs directly under the pack.
+    by_parent: dict[tuple[str, ...], set[str]] = {}
+    for words in leaves:
+        by_parent.setdefault(words[:-1], set()).add(words[-1])
+
+    for parent, expected in sorted(by_parent.items()):
+        listed = set(gc_output(gc_test_bin, workspace, pack, *parent, "--help").split())
+        missing = expected - listed
+        assert not missing, (
+            f"gc {pack} {' '.join(parent)} --help did not offer verbs the pack "
+            f"ships: " + ", ".join(sorted(missing))
+        )
+
+
+@pytest.mark.parametrize("pack", MAINTAINED_PACKS)
+def test_pack_formulas_resolve_through_a_city(
+    pack: str, tmp_path: Path, gc_test_bin: Path  # noqa: F811
+) -> None:
+    expected = discover_formulas(pack_dir(pack))
+    if not expected:
+        pytest.skip(f"{pack} ships no formulas")
+
+    imports, rig_imports = wiring(pack)
+    workspace = write_city(tmp_path, imports, rig_imports)
+    listed = set(gc_output(gc_test_bin, workspace, "formula", "list").split())
+
+    missing = expected - listed
+    assert not missing, (
+        f"formulas {pack} ships did not resolve in a city that imports it: "
+        + ", ".join(sorted(missing))
+    )
+
+
+@pytest.mark.parametrize("pack", MAINTAINED_PACKS)
+def test_pack_agents_resolve_through_a_city(
+    pack: str, tmp_path: Path, gc_test_bin: Path  # noqa: F811
+) -> None:
+    expected = discover_agents(pack_dir(pack))
+    if not expected:
+        pytest.skip(f"{pack} ships no agents")
+
+    imports, rig_imports = wiring(pack)
+    workspace = write_city(tmp_path, imports, rig_imports)
+    listed = gc_output(gc_test_bin, workspace, "agent", "list")
+
+    missing = {name for name in expected if name not in listed}
+    assert not missing, (
+        f"agent roles {pack} ships did not resolve in a city that imports it: "
+        + ", ".join(sorted(missing))
+        + f"\nOutput:\n{listed}"
+    )

--- a/tests/test_maintained_packs_live_gc.py
+++ b/tests/test_maintained_packs_live_gc.py
@@ -64,14 +64,33 @@ EXPECTED_DOCTOR_DELTA: dict[str, frozenset[str]] = {
     "oversight-rig": frozenset(),
     "pr-pipeline": frozenset(),
     "slack-channel": frozenset(),
-    # The pack ships its Slack adapter as source and its own doctor check
-    # reports the binary as not yet built. That is the correct message for a
-    # fresh install -- the user builds it during setup -- and it is the only
-    # finding any of these five adds today. `slack-channel` and `slack-mini`
-    # ship the same unbuilt adapter and no check that notices, which is why
-    # their entries are empty rather than matching.
-    "slack-full": frozenset({"slack-full:binaries"}),
+    # Both of these are the correct messages for a fresh install, and both come
+    # from checks only `slack-full` ships. `binaries`: the pack ships its Slack
+    # adapter as source, and the user builds it during setup. `env`: the
+    # adapter's credentials live in a config file the user writes during setup,
+    # and it does not exist yet. `slack-channel` and `slack-mini` ship the same
+    # unbuilt adapter and no check that notices, which is why their entries are
+    # empty rather than matching.
+    "slack-full": frozenset({"slack-full:binaries", "slack-full:env"}),
     "slack-mini": frozenset(),
+}
+
+# Findings whose presence is a property of the machine, not of the pack. These
+# are set aside before the equality above and PRINTED whenever they are, so a
+# run always shows what it stopped asserting on -- a silent subtraction and a
+# check that stopped reporting read identically.
+#
+# Keep this set as small as the evidence forces. It is not a waiver list: the
+# bar is that no import of the pack can decide the outcome, so the equality
+# assertion could not be green on every machine at once.
+HOST_DEPENDENT: dict[str, frozenset[str]] = {
+    # slack-full/doctor/check-funnel.sh inspects the host's Tailscale Funnel
+    # rules. With tailscale absent it prints a note and exits 0; with tailscale
+    # present and no rule forwarding to the adapter port it exits 2. Both are
+    # correct messages for the machine they ran on, and neither is caused by
+    # importing the pack -- a developer's laptop and a CI runner cannot both
+    # satisfy one recorded value.
+    "slack-full": frozenset({"slack-full:funnel"}),
 }
 
 
@@ -131,6 +150,14 @@ def test_pack_adds_only_the_doctor_findings_we_have_accepted(
     imports, rig_imports = wiring(pack)
     found = attributable(gc_test_bin, tmp_path, imports, rig_imports)
     expected = EXPECTED_DOCTOR_DELTA[pack]
+
+    host = HOST_DEPENDENT.get(pack, frozenset())
+    for check in sorted(found & host):
+        print(
+            f"[host-dependent] {check} reported on this machine and is not "
+            f"asserted on; see HOST_DEPENDENT in {Path(__file__).name}"
+        )
+    found -= host
 
     assert found == expected, (
         f"installing {pack} changes what gc doctor reports, against what this "


### PR DESCRIPTION
`gc lint` reads each pack on its own, and the per-pack suites read their own TOML. Neither says what happens when a city loads the pack, which is where a user meets it.

`pr-pipeline` linted clean for months while putting a `formula-requirements` deprecation warning into every importing city's `gc doctor`. `mol-pr-from-issue.formula.toml` still declared `contract = "graph.v2"`, and the test covering it asserted that by reading the file's own text back to itself, with `gc` never involved.

## What this adds

`tests/gc_live_city.py` builds a scratch city, imports one pack into it, and runs the real binary through `GC_TEST_BIN`.

`tests/test_maintained_packs_live_gc.py` stands up `oversight-rig`, `pr-pipeline`, `slack-channel`, `slack-full` and `slack-mini`, each on its own, and checks four things per pack:

- `gc doctor` reports nothing the pack did not cause
- every command verb the pack ships is registered (`gc <pack> ... --help`)
- every formula resolves (`gc formula list`)
- every agent resolves (`gc agent list`)

Each pack is imported alone so a finding names one pack. They cannot all share a city anyway: the three Slack packs declare `[[service]]`, which gc rejects in a rig-scoped import, and `oversight-rig` declares a rig-scoped `[[named_session]]` that needs a rig binding.

## Reading gc doctor

A scratch city reports a couple of dozen findings that belong to the environment, so the doctor reading is a set difference against a baseline city of the same shape. The baseline is not empty: several checks only run once a city has something to check, so an empty baseline surfaces them as findings the pack did not cause. It carries one inert order and one inert agent.

The delta is asserted by set equality rather than emptiness, so a finding that disappears fails too and fixed work cannot leave a stale allowance behind.

One entry is non-empty. `slack-full` ships its adapter as source and its own doctor check reports the binary as not yet built, which is the right message on a fresh install. `slack-channel` and `slack-mini` ship the same unbuilt adapter and no check that notices it, which is why their entries are empty rather than matching.

## Proving the tests can fail

Reverting the `mol-pr-from-issue` fix turns `pr-pipeline` red with the delta exactly `{formula-requirements}`, and green with the fix back. That is the property this PR exists for, written as a command.

A command leaf gc will not register (a `command.toml` naming no runner) turns the surface test red. Two other mutations stayed green and should have: renaming a leaf, and dropping `help.md` from a leaf that has `run.sh`. gc registers the second, and both sides of the first derive from disk.

Every delta assertion rests on the canary pack in `write_canary_pack`, which earns a `formula-requirements` finding on purpose. Without it, an empty delta and a doctor that stopped reporting are the same reading.

## Also in this branch

`95b1fe2` pins the seat environment three pack suites silently depended on. `write_city` strips `GC_*` and `BEADS_*` from the inherited environment, so running the suite inside a live city cannot reach that city's store.

## Test plan

```
go install github.com/gastownhall/gascity/cmd/gc@latest
GC_TEST_BIN="$(go env GOPATH)/bin/gc" python3 -m pytest tests/test_maintained_packs_live_gc.py -q
```

12 passed, 9 skipped. The skips are packs that ship no formulas, agents, or commands. CI runs this as a new step after the lint loop.
