### PR TITLE
fix(publish): forbid internal bead/REQ IDs in sanitized PR title/body

### DIFF
--- a/gascity/assets/workflows/implement/publish.md
+++ b/gascity/assets/workflows/implement/publish.md
@@ -11,3 +11,14 @@ explicit caller authorization to publish the direct implementation result, and
 use the same protected-branch, lease-safe push, sanitized PR title/body, and
 collision checks as the pack publish helper. If neither push nor open_pr is an
 explicit opt-in, close with `gc.outcome=pass` without mutating remotes.
+
+Sanitized means: the PR title and body describe the change in terms a
+reviewer with no access to gc's internal tracking would understand. Before
+opening the PR, strip or rewrite anything that only makes sense inside gc —
+bead/convoy/epic IDs (e.g. `tlp-xxxxx`, `ga-xxx`), internal requirement labels
+like `REQ-001`/`REQ-002`, workflow/formula names, and coverage tables copied
+verbatim from the implementation-summary artifact. If the target repo
+publishes its own PR conventions (e.g. a `github-conventions.md` or
+`CONTRIBUTING.md` under its docs), follow those over this default. When in
+doubt, write the body as if explaining the change to someone outside gc
+entirely.

--- a/gascity/assets/workflows/publish/open-pr.md
+++ b/gascity/assets/workflows/publish/open-pr.md
@@ -1,3 +1,11 @@
 
 If open_pr is {{open_pr}}, create a PR only after push succeeds and sanitized
 title/body from final report {{final_report}} pass policy.
+
+Before calling `gh pr create`, re-read the drafted title and body and reject
+any that still contain internal tracking artifacts: bead/convoy/epic IDs
+(e.g. `tlp-xxxxx`, `ga-xxx`), internal requirement labels like
+`REQ-001`/`REQ-002`, gc workflow/formula names, or raw coverage tables
+lifted from the implementation-summary artifact. Rewrite the title/body in
+terms an external reviewer with no gc access would understand, following the
+target repo's own PR conventions doc when one exists.

--- a/gascity/assets/workflows/publish/preflight.md
+++ b/gascity/assets/workflows/publish/preflight.md
@@ -2,3 +2,8 @@
 Validate auth, token scope, remote, branch names, PR base, collision policy,
 protected/default targets, sanitized metadata, final report {{final_report}},
 push authorization {{push}}, and open_pr authorization {{open_pr}}.
+
+Sanitized metadata means the PR title/body contain no bead/convoy/epic IDs,
+no internal requirement labels (`REQ-001`, `REQ-002`, ...), and no gc
+workflow/formula names — fail this check and require a rewrite before
+proceeding if any are present.


### PR DESCRIPTION
## Summary
- Published PRs onto target repos (e.g. eunice) were leaking gc-internal tracking artifacts — bead/convoy IDs, `REQ-001`/`REQ-002` style requirement labels, coverage tables copied from the implementation-summary — into PR titles/bodies, violating target-repo PR conventions (e.g. eunice's `apps/web/docs/ops/github-conventions.md`, which requires a plain-English, scannable top half).
- The publish/preflight prompts already said "sanitized PR title/body" but never defined what sanitized meant, so there was nothing concrete to check against.
- Defines "sanitized" explicitly in `implement/publish.md`, `publish/open-pr.md`, and `publish/preflight.md`: strip bead/convoy/epic IDs, REQ-xxx labels, and gc workflow/formula names before opening a PR, and defer to the target repo's own PR conventions doc when one exists.

## Test plan
- [ ] Run an `implement`/`do-work` flow that opens a PR against a repo with its own PR conventions doc and confirm the drafted body has no bead/REQ IDs
- [ ] Spot check an existing eunice-bound PR flow for regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)