### PR TITLE
fix(slack-full): accidental-mrkdwn guard — approximately-tildes no longer strike through

### DIFF
--- a/slack-full/CHANGELOG.md
+++ b/slack-full/CHANGELOG.md
@@ -26,6 +26,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   commands sends the body verbatim. Pure script-side change — no
   adapter restart needed.
 
+  Two limits worth knowing. "Lone tilde" is per rendered line, so two
+  home-relative paths on one line (`rsync ~/a ~/b`) are a pairable pair
+  and both get substituted; wrap twin paths in a code span, or use
+  `--raw`, when the exact bytes matter. And `gc slack post-message` is
+  deliberately out of scope: its milestone summary, field values, and
+  rollup items are rendered as mrkdwn by the Go Block Kit renderer,
+  downstream of this Python guard, so a payload carrying
+  "~$58.5k … ~$16.5k" still strikes through (titles are `plain_text`
+  and unaffected). That surface predates this change and guarding it
+  would need a second implementation of the heuristic in Go plus a
+  `gc-slack-cli` rebuild; tracked as gp-x5bdy.
+
+  Scope is this pack only. The sibling packs `slack-channel` (same
+  `publish` / `publish-to-channel` / `reply-current` verbs) and
+  `slack-mini` (`post-message`) carry no guard, so the same `gc slack`
+  verb behaves differently depending on which pack a city installed.
+  Porting was left out deliberately to keep this change script-side
+  with no adapter rebuild; guard-port vs. documented exclusion is
+  tracked as gp-cbxzk.
+
 ### Fixed
 
 - Inbound files recorded inside Slack itself — voice clips (file subtype

--- a/slack-full/CHANGELOG.md
+++ b/slack-full/CHANGELOG.md
@@ -8,6 +8,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Accidental-mrkdwn guard on the send path (gp-o42): `gc slack
+  reply-current` (legacy and company paths), `publish`,
+  `publish-to-channel`, `upload --initial-comment`, and `delegate` now
+  neutralize tildes that would pair into unintended Slack strikethrough
+  ("~$58.5k … ~$16.5k" rendered half a runway summary struck through).
+  Slack mrkdwn has no escape sequence, so accidental delimiter tildes
+  are substituted with the visually identical U+223C TILDE OPERATOR —
+  but only on lines where a pair could actually form: lone tildes keep
+  their ASCII byte (`cd ~/repo` survives copy-paste), code spans are
+  never touched, a tilde before an optionally-signed digit/currency
+  (`~$5k`, `~-$13.5k`, `~9/2`) is never a delimiter, and deliberate
+  tight-wrapped `~word~` strikethrough still renders. `*bold*`,
+  `_italics_`, and bullets are unaffected. New `--raw` flag on all five
+  commands sends the body verbatim. Pure script-side change — no
+  adapter restart needed.
+
 ### Fixed
 
 - Inbound files recorded inside Slack itself — voice clips (file subtype

--- a/slack-full/commands/delegate/help.md
+++ b/slack-full/commands/delegate/help.md
@@ -49,3 +49,10 @@ Examples
   gc slack delegate --turn-ref gct-0123456789abcdef0123 --cancel --to riley
 
 Routes to: scripts/slack_company_outbound.py delegate
+
+Formatting guard: tildes that would accidentally pair into Slack
+strikethrough (e.g. "~$58.5k … ~$16.5k" — tilde as "approximately") are
+neutralized by default with a visually identical substitute (U+223C).
+Deliberate tight-wrapped `~word~` strikethrough, code spans, lone
+tildes, and every other formatting character pass through untouched.
+Pass --raw to send the body byte-for-byte verbatim.

--- a/slack-full/commands/delegate/help.md
+++ b/slack-full/commands/delegate/help.md
@@ -48,11 +48,13 @@ Examples
   gc slack delegate --turn-ref gct-0123456789abcdef0123 --to riley --body-file /tmp/ask.txt
   gc slack delegate --turn-ref gct-0123456789abcdef0123 --cancel --to riley
 
-Routes to: scripts/slack_company_outbound.py delegate
-
 Formatting guard: tildes that would accidentally pair into Slack
 strikethrough (e.g. "~$58.5k … ~$16.5k" — tilde as "approximately") are
 neutralized by default with a visually identical substitute (U+223C).
 Deliberate tight-wrapped `~word~` strikethrough, code spans, lone
 tildes, and every other formatting character pass through untouched.
-Pass --raw to send the body byte-for-byte verbatim.
+"Lone" counts per line, though: two home-relative paths on one line
+(`rsync ~/a ~/b`) can pair, so both are substituted — put twin paths in
+a code span, or pass --raw to send the body byte-for-byte verbatim.
+
+Routes to: scripts/slack_company_outbound.py delegate

--- a/slack-full/commands/post-message/help.md
+++ b/slack-full/commands/post-message/help.md
@@ -21,4 +21,14 @@ Examples:
 Pass --update <ts> with a previously-returned message ts to edit the
 post in place (Slack chat.update).
 
+Not covered by the formatting guard: the text send commands
+(reply-current, publish, publish-to-channel, upload --initial-comment,
+delegate) neutralize tildes that would accidentally pair into Slack
+strikethrough. post-message does not — summary, field values, and
+rollup items are rendered as mrkdwn section text by the Go Block Kit
+renderer, downstream of the Python guard, so "~$58.5k … ~$16.5k" in a
+payload still strikes through. Titles are plain_text and unaffected.
+Until gp-x5bdy decides that surface, write "approx." or wrap the
+figures in a code span when a payload carries tilde-as-approximately.
+
 Routes to: gc-slack-cli post-message

--- a/slack-full/commands/publish-to-channel/help.md
+++ b/slack-full/commands/publish-to-channel/help.md
@@ -57,3 +57,10 @@ gc slack publish-to-channel \
 
 The reply threads under the human's message and posts as your
 registered Slack identity.
+
+Formatting guard: tildes that would accidentally pair into Slack
+strikethrough (e.g. "~$58.5k … ~$16.5k" — tilde as "approximately") are
+neutralized by default with a visually identical substitute (U+223C).
+Deliberate tight-wrapped `~word~` strikethrough, code spans, lone
+tildes, and every other formatting character pass through untouched.
+Pass --raw to send the body byte-for-byte verbatim.

--- a/slack-full/commands/publish-to-channel/help.md
+++ b/slack-full/commands/publish-to-channel/help.md
@@ -63,4 +63,6 @@ strikethrough (e.g. "~$58.5k … ~$16.5k" — tilde as "approximately") are
 neutralized by default with a visually identical substitute (U+223C).
 Deliberate tight-wrapped `~word~` strikethrough, code spans, lone
 tildes, and every other formatting character pass through untouched.
-Pass --raw to send the body byte-for-byte verbatim.
+"Lone" counts per line, though: two home-relative paths on one line
+(`rsync ~/a ~/b`) can pair, so both are substituted — put twin paths in
+a code span, or pass --raw to send the body byte-for-byte verbatim.

--- a/slack-full/commands/publish/help.md
+++ b/slack-full/commands/publish/help.md
@@ -22,3 +22,10 @@ Routes through `/v0/city/<name>/extmsg/outbound` by default so peer
 fanout + transcript recording fire. Pass `--via adapter` for
 adapter-only diagnostics that bypass gc; peers in a bind-room won't
 see those.
+
+Formatting guard: tildes that would accidentally pair into Slack
+strikethrough (e.g. "~$58.5k … ~$16.5k" — tilde as "approximately") are
+neutralized by default with a visually identical substitute (U+223C).
+Deliberate tight-wrapped `~word~` strikethrough, code spans, lone
+tildes, and every other formatting character pass through untouched.
+Pass --raw to send the body byte-for-byte verbatim.

--- a/slack-full/commands/publish/help.md
+++ b/slack-full/commands/publish/help.md
@@ -28,4 +28,6 @@ strikethrough (e.g. "~$58.5k … ~$16.5k" — tilde as "approximately") are
 neutralized by default with a visually identical substitute (U+223C).
 Deliberate tight-wrapped `~word~` strikethrough, code spans, lone
 tildes, and every other formatting character pass through untouched.
-Pass --raw to send the body byte-for-byte verbatim.
+"Lone" counts per line, though: two home-relative paths on one line
+(`rsync ~/a ~/b`) can pair, so both are substituted — put twin paths in
+a code span, or pass --raw to send the body byte-for-byte verbatim.

--- a/slack-full/commands/reply-current/help.md
+++ b/slack-full/commands/reply-current/help.md
@@ -16,3 +16,10 @@ Company reminders include an immutable `turn_ref` and an exact command. Copy
 that command: `--turn-ref` binds the reply to the originating channel/thread
 even if a newer message in another channel wakes the same agent session.
 Post-rollout company turns fail closed when the flag is omitted.
+
+Formatting guard: tildes that would accidentally pair into Slack
+strikethrough (e.g. "~$58.5k … ~$16.5k" — tilde as "approximately") are
+neutralized by default with a visually identical substitute (U+223C).
+Deliberate tight-wrapped `~word~` strikethrough, code spans, lone
+tildes, and every other formatting character pass through untouched.
+Pass --raw to send the body byte-for-byte verbatim.

--- a/slack-full/commands/reply-current/help.md
+++ b/slack-full/commands/reply-current/help.md
@@ -22,4 +22,6 @@ strikethrough (e.g. "~$58.5k … ~$16.5k" — tilde as "approximately") are
 neutralized by default with a visually identical substitute (U+223C).
 Deliberate tight-wrapped `~word~` strikethrough, code spans, lone
 tildes, and every other formatting character pass through untouched.
-Pass --raw to send the body byte-for-byte verbatim.
+"Lone" counts per line, though: two home-relative paths on one line
+(`rsync ~/a ~/b`) can pair, so both are substituted — put twin paths in
+a code span, or pass --raw to send the body byte-for-byte verbatim.

--- a/slack-full/commands/upload/help.md
+++ b/slack-full/commands/upload/help.md
@@ -103,3 +103,10 @@ gc slack upload --file out/snr_plot.png \
 # cos session: post a status digest with attached CSV
 gc slack upload --file /tmp/digest.csv --title "overnight digest"
 ```
+
+Formatting guard: tildes that would accidentally pair into Slack
+strikethrough (e.g. "~$58.5k … ~$16.5k" — tilde as "approximately") are
+neutralized by default with a visually identical substitute (U+223C).
+Deliberate tight-wrapped `~word~` strikethrough, code spans, lone
+tildes, and every other formatting character pass through untouched.
+Pass --raw to send --initial-comment byte-for-byte verbatim.

--- a/slack-full/commands/upload/help.md
+++ b/slack-full/commands/upload/help.md
@@ -109,4 +109,7 @@ strikethrough (e.g. "~$58.5k … ~$16.5k" — tilde as "approximately") are
 neutralized by default with a visually identical substitute (U+223C).
 Deliberate tight-wrapped `~word~` strikethrough, code spans, lone
 tildes, and every other formatting character pass through untouched.
-Pass --raw to send --initial-comment byte-for-byte verbatim.
+"Lone" counts per line, though: two home-relative paths on one line
+(`rsync ~/a ~/b`) can pair, so both are substituted — put twin paths in
+a code span, or pass --raw to send --initial-comment byte-for-byte
+verbatim.

--- a/slack-full/scripts/slack_chat_publish.py
+++ b/slack-full/scripts/slack_chat_publish.py
@@ -28,16 +28,23 @@ import sys
 from typing import Any
 
 import slack_intake_common as common
+import slack_mrkdwn
 
 
 def _load_body(args: argparse.Namespace) -> str:
     if args.body and args.body_file:
         raise SystemExit("pass --body OR --body-file, not both")
+    body = ""
     if args.body:
-        return args.body
-    if args.body_file:
-        return pathlib.Path(args.body_file).read_text(encoding="utf-8")
-    raise SystemExit("either --body or --body-file is required")
+        body = args.body
+    elif args.body_file:
+        body = pathlib.Path(args.body_file).read_text(encoding="utf-8")
+    else:
+        raise SystemExit("either --body or --body-file is required")
+    if not getattr(args, "raw", False):
+        # gp-o42: tilde pairs render as strikethrough in Slack mrkdwn.
+        body = slack_mrkdwn.escape_accidental_mrkdwn(body)
+    return body
 
 
 def _resolve_conversation(session_id: str) -> dict[str, str]:
@@ -74,6 +81,12 @@ def main(argv: list[str]) -> int:
                         help="Caller-supplied idempotency key")
     parser.add_argument("--body", default="")
     parser.add_argument("--body-file", default="")
+    parser.add_argument(
+        "--raw", action="store_true",
+        help=("Send the body verbatim, skipping the accidental-mrkdwn guard "
+              "(by default, tildes that would pair into unintended Slack "
+              "strikethrough are neutralized; deliberate ~word~ wrapping and "
+              "code spans always pass through)."))
     parser.add_argument(
         "--via",
         choices=("gc", "adapter"),

--- a/slack-full/scripts/slack_chat_publish.py
+++ b/slack-full/scripts/slack_chat_publish.py
@@ -41,7 +41,7 @@ def _load_body(args: argparse.Namespace) -> str:
         body = pathlib.Path(args.body_file).read_text(encoding="utf-8")
     else:
         raise SystemExit("either --body or --body-file is required")
-    if not getattr(args, "raw", False):
+    if not args.raw:
         # gp-o42: tilde pairs render as strikethrough in Slack mrkdwn.
         body = slack_mrkdwn.escape_accidental_mrkdwn(body)
     return body

--- a/slack-full/scripts/slack_chat_publish_to_channel.py
+++ b/slack-full/scripts/slack_chat_publish_to_channel.py
@@ -21,16 +21,23 @@ import pathlib
 import sys
 
 import slack_intake_common as common
+import slack_mrkdwn
 
 
 def _load_body(args: argparse.Namespace) -> str:
     if args.body and args.body_file:
         raise SystemExit("pass --body OR --body-file, not both")
+    body = ""
     if args.body:
-        return args.body
-    if args.body_file:
-        return pathlib.Path(args.body_file).read_text(encoding="utf-8")
-    raise SystemExit("either --body or --body-file is required")
+        body = args.body
+    elif args.body_file:
+        body = pathlib.Path(args.body_file).read_text(encoding="utf-8")
+    else:
+        raise SystemExit("either --body or --body-file is required")
+    if not args.raw:
+        # gp-o42: tilde pairs render as strikethrough in Slack mrkdwn.
+        body = slack_mrkdwn.escape_accidental_mrkdwn(body)
+    return body
 
 
 def main(argv: list[str]) -> int:
@@ -53,6 +60,12 @@ def main(argv: list[str]) -> int:
                         help="Caller-supplied idempotency key (optional).")
     parser.add_argument("--body", default="")
     parser.add_argument("--body-file", default="")
+    parser.add_argument(
+        "--raw", action="store_true",
+        help=("Send the body verbatim, skipping the accidental-mrkdwn guard "
+              "(by default, tildes that would pair into unintended Slack "
+              "strikethrough are neutralized; deliberate ~word~ wrapping and "
+              "code spans always pass through)."))
     args = parser.parse_args(argv)
 
     body = _load_body(args)

--- a/slack-full/scripts/slack_chat_reply_current.py
+++ b/slack-full/scripts/slack_chat_reply_current.py
@@ -21,6 +21,7 @@ import sys
 from typing import Any
 
 import slack_intake_common as common
+import slack_mrkdwn
 
 
 def _derive_idempotency_key(
@@ -43,11 +44,17 @@ def _derive_idempotency_key(
 def _load_body(args: argparse.Namespace) -> str:
     if args.body and args.body_file:
         raise SystemExit("pass --body OR --body-file, not both")
+    body = ""
     if args.body:
-        return args.body
-    if args.body_file:
-        return pathlib.Path(args.body_file).read_text(encoding="utf-8")
-    raise SystemExit("either --body or --body-file is required")
+        body = args.body
+    elif args.body_file:
+        body = pathlib.Path(args.body_file).read_text(encoding="utf-8")
+    else:
+        raise SystemExit("either --body or --body-file is required")
+    if not getattr(args, "raw", False):
+        # gp-o42: tilde pairs render as strikethrough in Slack mrkdwn.
+        body = slack_mrkdwn.escape_accidental_mrkdwn(body)
+    return body
 
 
 def _slack_kind_from_channel_id(cid: str, fallback: str = "dm") -> str:
@@ -236,6 +243,12 @@ def main(argv: list[str]) -> int:
                               "the same reply dedupes instead of double-posting."))
     parser.add_argument("--body", default="")
     parser.add_argument("--body-file", default="")
+    parser.add_argument(
+        "--raw", action="store_true",
+        help=("Send the body verbatim, skipping the accidental-mrkdwn guard "
+              "(by default, tildes that would pair into unintended Slack "
+              "strikethrough are neutralized; deliberate ~word~ wrapping and "
+              "code spans always pass through)."))
     parser.add_argument(
         "--via",
         choices=("gc", "adapter"),

--- a/slack-full/scripts/slack_chat_reply_current.py
+++ b/slack-full/scripts/slack_chat_reply_current.py
@@ -51,7 +51,7 @@ def _load_body(args: argparse.Namespace) -> str:
         body = pathlib.Path(args.body_file).read_text(encoding="utf-8")
     else:
         raise SystemExit("either --body or --body-file is required")
-    if not getattr(args, "raw", False):
+    if not args.raw:
         # gp-o42: tilde pairs render as strikethrough in Slack mrkdwn.
         body = slack_mrkdwn.escape_accidental_mrkdwn(body)
     return body

--- a/slack-full/scripts/slack_chat_upload.py
+++ b/slack-full/scripts/slack_chat_upload.py
@@ -42,6 +42,7 @@ import pathlib
 import sys
 
 import slack_intake_common as common
+import slack_mrkdwn
 
 
 def _resolve_conversation(session_id: str) -> dict[str, str]:
@@ -87,6 +88,11 @@ def main(argv: list[str]) -> int:
                              "Mutually exclusive with --thread-ts.")
     parser.add_argument("--idempotency-key", default="",
                         help="Caller-supplied idempotency key for retries.")
+    parser.add_argument(
+        "--raw", action="store_true",
+        help=("Send --initial-comment verbatim, skipping the accidental-"
+              "mrkdwn guard (by default, tildes that would pair into "
+              "unintended Slack strikethrough are neutralized)."))
     parser.add_argument("--via", choices=("gc", "adapter"), default="gc",
                         help="Routing path. 'gc' (default) records the upload "
                              "in the transcript and fans out to peer sessions; "
@@ -115,6 +121,11 @@ def main(argv: list[str]) -> int:
             f"session {session_id!r} binding has no conversation_id "
             "(corrupt binding record?)")
 
+    initial_comment = args.initial_comment
+    if initial_comment and not args.raw:
+        # gp-o42: the comment renders as mrkdwn alongside the file.
+        initial_comment = slack_mrkdwn.escape_accidental_mrkdwn(initial_comment)
+
     thread_ts = args.thread_ts.strip()
     if args.thread_current:
         match = common.find_latest_inbound_message_id_for_session(session_id)
@@ -132,7 +143,7 @@ def main(argv: list[str]) -> int:
                 kind=conv["kind"],
                 file_path=str(file_path),
                 filename=args.filename,
-                initial_comment=args.initial_comment,
+                initial_comment=initial_comment,
                 thread_ts=thread_ts,
                 title=args.title,
                 idempotency_key=args.idempotency_key,
@@ -147,7 +158,7 @@ def main(argv: list[str]) -> int:
                 kind=conv["kind"],
                 file_path=str(file_path),
                 filename=args.filename,
-                initial_comment=args.initial_comment,
+                initial_comment=initial_comment,
                 thread_ts=thread_ts,
                 title=args.title,
                 idempotency_key=args.idempotency_key,

--- a/slack-full/scripts/slack_chat_upload.py
+++ b/slack-full/scripts/slack_chat_upload.py
@@ -92,7 +92,8 @@ def main(argv: list[str]) -> int:
         "--raw", action="store_true",
         help=("Send --initial-comment verbatim, skipping the accidental-"
               "mrkdwn guard (by default, tildes that would pair into "
-              "unintended Slack strikethrough are neutralized)."))
+              "unintended Slack strikethrough are neutralized; deliberate "
+              "~word~ wrapping and code spans always pass through)."))
     parser.add_argument("--via", choices=("gc", "adapter"), default="gc",
                         help="Routing path. 'gc' (default) records the upload "
                              "in the transcript and fans out to peer sessions; "

--- a/slack-full/scripts/slack_company_outbound.py
+++ b/slack-full/scripts/slack_company_outbound.py
@@ -2520,6 +2520,11 @@ def cmd_delegate(argv: list[str]) -> int:
                         help="Pin a specific turn ts when a newer wake overwrote the pointer")
     parser.add_argument("--turn-ref", default="",
                         help="Immutable turn reference from the Slack reminder")
+    parser.add_argument(
+        "--raw", action="store_true",
+        help=("Send the body verbatim, skipping the accidental-mrkdwn guard "
+              "(by default, tildes that would pair into unintended Slack "
+              "strikethrough are neutralized)."))
     args = parser.parse_args(argv)
 
     session_name = os.environ.get("GC_SESSION_NAME", "").strip()
@@ -2529,6 +2534,11 @@ def cmd_delegate(argv: list[str]) -> int:
             turn_ref=args.turn_ref)
     else:
         body = _load_body_arg(args.body, args.body_file)
+        if not args.raw:
+            # gp-o42: tilde pairs render as strikethrough in Slack mrkdwn.
+            # Local import keeps the library surface of this module stdlib-only.
+            import slack_mrkdwn
+            body = slack_mrkdwn.escape_accidental_mrkdwn(body)
         result = run_delegate(
             to=args.to, body=body, origin_ts=args.origin_ts,
             session_name=session_name, turn_ref=args.turn_ref)

--- a/slack-full/scripts/slack_company_outbound.py
+++ b/slack-full/scripts/slack_company_outbound.py
@@ -2524,7 +2524,8 @@ def cmd_delegate(argv: list[str]) -> int:
         "--raw", action="store_true",
         help=("Send the body verbatim, skipping the accidental-mrkdwn guard "
               "(by default, tildes that would pair into unintended Slack "
-              "strikethrough are neutralized)."))
+              "strikethrough are neutralized; deliberate ~word~ wrapping and "
+              "code spans always pass through)."))
     args = parser.parse_args(argv)
 
     session_name = os.environ.get("GC_SESSION_NAME", "").strip()

--- a/slack-full/scripts/slack_mrkdwn.py
+++ b/slack-full/scripts/slack_mrkdwn.py
@@ -1,0 +1,125 @@
+"""Guard outbound Slack text against accidental mrkdwn strikethrough.
+
+Slack's mrkdwn pairs tilde characters into strikethrough, and the pairing
+is looser than any documented rule: a body containing "~$58.5k … ~$16.5k"
+(tilde as "approximately") rendered half the message struck through
+(gp-o42, C0BEZ3CQK5X ts=1787203992.825369). Slack offers NO escape
+sequence for formatting characters — a backslash renders literally and
+``mrkdwn: false`` would also kill intentional *bold* and bullets — so the
+only way to make a tilde inert is to substitute a visually equivalent
+codepoint that Slack's parser does not treat as a delimiter.
+
+The guard is deliberately conservative about which bytes it touches:
+
+* Code spans (``` fences and `inline`) are never modified — Slack does
+  not format inside them, and literal bytes there must survive copy-paste.
+* A line with fewer than two tildes is never modified — strikethrough
+  needs a pair on the same line (Slack inline formatting does not cross
+  newlines), so a lone ``cd ~/repo`` keeps its ASCII byte.
+* On a line where pairing is possible, a tilde survives only as half of
+  a deliberate tight-wrapped pair (``~word~`` / ``~a few words~``): the
+  opener sits at start-of-line or after whitespace/bracket/quote and is
+  immediately followed by a plain character; the closer immediately
+  follows a plain character and is followed by end/whitespace/
+  punctuation; the span stays on one line and contains no other tilde.
+  Per the gp-o42 directive, a tilde immediately preceding a digit or a
+  currency symbol (optionally signed: ``~-$13.5k``, ``~.5``) reads as
+  "approximately" and is NEVER a delimiter, so it never opens a pair.
+* Everything else becomes U+223C TILDE OPERATOR — near-identical glyph,
+  guaranteed inert. Callers that need exact bytes end-to-end should use
+  a code span or the send commands' ``--raw`` flag.
+
+Underscores and asterisks are deliberately NOT guarded: accidental
+italics are low-harm and legible (unlike strikethrough), snake_case
+underscores are mid-word and cannot delimit anyway, and substituting
+homoglyphs into identifiers would corrupt copy-pasted commands — a worse
+papercut than the one being fixed. Revisit only with an observed repro.
+"""
+
+from __future__ import annotations
+
+import re
+
+# U+223C TILDE OPERATOR: renders near-identically to ASCII "~" in Slack's
+# message font but is never a mrkdwn delimiter.
+TILDE_SUBSTITUTE = "∼"
+
+# Fenced blocks first (may span lines), then single-line inline code.
+_CODE_SPAN_RE = re.compile(r"```.*?```|`[^`\n]+`", re.DOTALL)
+
+_CURRENCY = "$€£¥₩₹¢"  # $ € £ ¥ ₩ ₹ ¢
+_OPENER_PRECEDERS = set(" \t([{'\"")
+_CLOSER_FOLLOWERS = set(" \t.,;:!?)]}'\"")
+
+
+def _never_delimiter(line: str, i: int) -> bool:
+    """A tilde reading as "approximately": ~ before an optionally-signed
+    digit/currency/decimal (``~$58.5k``, ``~-$13.5k``, ``~9/2``, ``~.5``)."""
+    rest = line[i + 1:]
+    if rest[:1] in ("-", "+"):
+        rest = rest[1:]
+    if rest[:1] == "." and rest[1:2].isdigit():
+        return True
+    return rest[:1].isdigit() or rest[:1] in _CURRENCY
+
+
+def _is_opener(line: str, i: int) -> bool:
+    if i > 0 and line[i - 1] not in _OPENER_PRECEDERS:
+        return False
+    if i + 1 >= len(line):
+        return False
+    nxt = line[i + 1]
+    if nxt in " \t~":
+        return False
+    return not _never_delimiter(line, i)
+
+
+def _is_closer(line: str, j: int) -> bool:
+    if j == 0 or line[j - 1] in " \t~":
+        return False
+    return j + 1 >= len(line) or line[j + 1] in _CLOSER_FOLLOWERS
+
+
+def _guard_line(line: str) -> str:
+    positions = [i for i, ch in enumerate(line) if ch == "~"]
+    if len(positions) < 2:
+        # A lone tilde cannot pair, so it can never strike: keep the byte.
+        return line
+    keep: set[int] = set()
+    k = 0
+    while k < len(positions) - 1:
+        i, j = positions[k], positions[k + 1]
+        # A deliberate strikethrough is a tight-wrapped pair whose span
+        # contains no other tilde — the very next tilde must be the closer.
+        if _is_opener(line, i) and j > i + 1 and _is_closer(line, j):
+            keep.update((i, j))
+            k += 2
+        else:
+            k += 1
+    return "".join(
+        TILDE_SUBSTITUTE if ch == "~" and i not in keep else ch
+        for i, ch in enumerate(line)
+    )
+
+
+def _guard_segment(segment: str) -> str:
+    if "~" not in segment:
+        return segment
+    return "\n".join(_guard_line(ln) for ln in segment.split("\n"))
+
+
+def escape_accidental_mrkdwn(text: str) -> str:
+    """Neutralize tildes that would accidentally strike through, keeping
+    deliberate ``~word~`` strikethrough, code spans, and every other
+    formatting character (``*bold*``, bullets, ``_italics_``) untouched.
+    Idempotent: guarding already-guarded text is a no-op."""
+    if "~" not in text:
+        return text
+    out: list[str] = []
+    last = 0
+    for m in _CODE_SPAN_RE.finditer(text):
+        out.append(_guard_segment(text[last:m.start()]))
+        out.append(m.group(0))
+        last = m.end()
+    out.append(_guard_segment(text[last:]))
+    return "".join(out)

--- a/slack-full/scripts/slack_mrkdwn.py
+++ b/slack-full/scripts/slack_mrkdwn.py
@@ -12,16 +12,43 @@ codepoint that Slack's parser does not treat as a delimiter.
 The guard is deliberately conservative about which bytes it touches:
 
 * Code spans (``` fences and `inline`) are never modified — Slack does
-  not format inside them, and literal bytes there must survive copy-paste.
+  not format inside them, and literal bytes there must survive
+  copy-paste. An unterminated ``` fence is code too: Slack formats it as
+  a code block through end-of-message. Their bytes are masked, not cut
+  out, before the census below, because Slack pairs tildes *across* an
+  inline span (``~$5k (see `calc.py`) vs ~$7k`` is one pairable line).
+
+  That unterminated-fence rule rests on a premise about Slack's
+  renderer, recorded here because it is this module's ONE
+  under-substituting branch. Premise: an unmatched triple-backtick
+  renders as a code block through end-of-message. Evidence: two
+  independently executed reviewer probes (PR #337 iteration-1 review,
+  finding S4, codex + gemini), which prescribed this trailing
+  alternative under DOTALL. It has never been checked against a live
+  Slack fixture. The alternative is unanchored, so ANY triple-backtick,
+  including one mid-sentence in prose, suspends the guard for the rest
+  of the message — a line reading "type ``` then code, runway ~$58.5k
+  to ~$16.5k" passes through with both ASCII tildes intact. Every other
+  decision here fails toward substituting (worst case: a cosmetic
+  U+223C in text that was fine); this one fails the other way, toward
+  leaving a pairable ASCII tilde, which is the gp-o42 bug itself. It is
+  kept because corrupting bytes that Slack renders as code is the more
+  concrete harm and a stray unmatched fence in prose is rare. If the
+  premise is falsified, the narrowing that follows is anchoring this
+  alternative to a line-start fence. The behavior is pinned by
+  ``test_stray_midline_fence_suspends_the_guard``.
 * A line with fewer than two tildes is never modified — strikethrough
   needs a pair on the same line (Slack inline formatting does not cross
-  newlines), so a lone ``cd ~/repo`` keeps its ASCII byte.
+  newlines), so a lone ``cd ~/repo`` keeps its ASCII byte. "Lone" is per
+  rendered line: ``rsync ~/a ~/b`` puts two on one line and both are
+  substituted, so pass twin paths in a code span or use ``--raw``.
 * On a line where pairing is possible, a tilde survives only as half of
   a deliberate tight-wrapped pair (``~word~`` / ``~a few words~``): the
-  opener sits at start-of-line or after whitespace/bracket/quote and is
-  immediately followed by a plain character; the closer immediately
-  follows a plain character and is followed by end/whitespace/
-  punctuation; the span stays on one line and contains no other tilde.
+  opener sits at start-of-line or after whitespace/bracket/quote or a
+  mrkdwn delimiter (``*``/``_``) and is immediately followed by a plain
+  character; the closer immediately follows a plain character and is
+  followed by end/whitespace/punctuation; the span stays on one line
+  and contains no other tilde.
   Per the gp-o42 directive, a tilde immediately preceding a digit or a
   currency symbol (optionally signed: ``~-$13.5k``, ``~.5``) reads as
   "approximately" and is NEVER a delimiter, so it never opens a pair.
@@ -44,12 +71,25 @@ import re
 # message font but is never a mrkdwn delimiter.
 TILDE_SUBSTITUTE = "∼"
 
-# Fenced blocks first (may span lines), then single-line inline code.
-_CODE_SPAN_RE = re.compile(r"```.*?```|`[^`\n]+`", re.DOTALL)
+# Closed fenced blocks first (they may span lines), then an unterminated
+# fence — which Slack renders as a code block through end-of-message, so its
+# bytes are code as well — then single-line inline code.
+_CODE_SPAN_RE = re.compile(r"```.*?```|```.*|`[^`\n]+`", re.DOTALL)
 
-_CURRENCY = "$€£¥₩₹¢"  # $ € £ ¥ ₩ ₹ ¢
-_OPENER_PRECEDERS = set(" \t([{'\"")
-_CLOSER_FOLLOWERS = set(" \t.,;:!?)]}'\"")
+# Code-span bytes are masked one-for-one with this character before the
+# tilde census runs, so every offset still lines up with the original text.
+# It has to read as an ordinary "plain" character: not a tilde, not in either
+# boundary set below, and neither a digit nor a currency symbol — otherwise
+# masking would itself change which tildes look like deliberate delimiters.
+_MASK_CHAR = "\x00"
+
+_CURRENCY = "$€£¥₩₹¢₿"  # $ € £ ¥ ₩ ₹ ¢ ₿
+# A mrkdwn delimiter is a legitimate span boundary: Slack renders ``*~text~*``
+# as bold strikethrough, so a deliberate pair may be wrapped in one. ``\r`` is
+# a closer follower only — ``_guard_segment`` splits on ``\n``, so a CRLF body
+# leaves the ``\r`` at end of line, never before an opener.
+_OPENER_PRECEDERS = set(" \t([{'\"*_")
+_CLOSER_FOLLOWERS = set(" \t.,;:!?)]}'\"*_\r")
 
 
 def _never_delimiter(line: str, i: int) -> bool:
@@ -115,11 +155,27 @@ def escape_accidental_mrkdwn(text: str) -> str:
     Idempotent: guarding already-guarded text is a no-op."""
     if "~" not in text:
         return text
+    spans = [m.span() for m in _CODE_SPAN_RE.finditer(text)]
+    if not spans:
+        return _guard_segment(text)
+    # Slack pairs tildes across an inline code span, so the census has to see
+    # the whole rendered line. Guarding each inter-span segment separately
+    # would restart the count at every span and let a pair through. Mask the
+    # span bytes instead — keeping their newlines, and so the line boundaries
+    # — guard the masked text, then put the original bytes back. Substitution
+    # is one codepoint for one, so the guarded text is the same length as the
+    # input and the span offsets still hold.
+    masked = list(text)
+    for start, end in spans:
+        for i in range(start, end):
+            if masked[i] != "\n":
+                masked[i] = _MASK_CHAR
+    guarded = _guard_segment("".join(masked))
     out: list[str] = []
     last = 0
-    for m in _CODE_SPAN_RE.finditer(text):
-        out.append(_guard_segment(text[last:m.start()]))
-        out.append(m.group(0))
-        last = m.end()
-    out.append(_guard_segment(text[last:]))
+    for start, end in spans:
+        out.append(guarded[last:start])
+        out.append(text[start:end])
+        last = end
+    out.append(guarded[last:])
     return "".join(out)

--- a/slack-full/template-fragments/slack-v0.template.md
+++ b/slack-full/template-fragments/slack-v0.template.md
@@ -71,6 +71,14 @@ Slack already attributes every reply to your agent identity. Write the message
 directly; do not prefix the message with your name or handle.
 Do not pipe the command through filters that can hide failures.
 
+Slack mrkdwn has no escape character, so the send commands neutralize tildes
+that would pair into unintended strikethrough — the "approximately" tilde in
+"~$58.5k … ~$16.5k" struck through half a runway summary. Deliberate `~word~`
+and code spans survive untouched. Two `~/` paths on one line do pair, so wrap
+those in a code span (or pass `--raw`) when the exact bytes matter.
+`gc slack post-message` payloads are rendered downstream of this guard and are
+not protected: write "approx." there instead.
+
 ## Agent-to-agent delegation
 
 To formally hand work to one peer, visibly:

--- a/slack-full/tests/test_slack_chat_publish.py
+++ b/slack-full/tests/test_slack_chat_publish.py
@@ -325,3 +325,50 @@ def test_interpret_publish_receipt_shapes() -> None:
     delivered, kind = common.interpret_publish_receipt("not a dict")
     assert delivered is False
     assert kind == "non_dict_response"
+
+
+# --------------------------------------------------------------------------
+# Accidental-mrkdwn guard (gp-o42) — tilde pairs must not strike through.
+# --------------------------------------------------------------------------
+
+def test_publish_guards_tildes_by_default(monkeypatch) -> None:
+    pub, common = _import_modules()
+    import slack_mrkdwn
+    captured = {}
+
+    def fake_publish(**kwargs):
+        captured.update(kwargs)
+        return {"Receipt": {"Delivered": True, "MessageID": "1700.001"}}
+
+    monkeypatch.setattr(common, "publish_via_gc_outbound", fake_publish)
+    monkeypatch.setattr(
+        common, "look_up_binding",
+        lambda _sid: {"conversation_id": "C0CHAN01", "kind": "room",
+                      "scope_id": "test-city", "provider": "slack",
+                      "account_id": "T0TESTWS"})
+
+    rc = pub.main(["--session", "gc-1", "--body", "~$58.5k out, ~$16.5k left"])
+    assert rc == 0
+    assert captured["text"] == \
+        "~$58.5k out, ~$16.5k left".replace("~", slack_mrkdwn.TILDE_SUBSTITUTE)
+
+
+def test_publish_raw_flag_skips_guard(monkeypatch) -> None:
+    pub, common = _import_modules()
+    captured = {}
+
+    def fake_publish(**kwargs):
+        captured.update(kwargs)
+        return {"Receipt": {"Delivered": True, "MessageID": "1700.001"}}
+
+    monkeypatch.setattr(common, "publish_via_gc_outbound", fake_publish)
+    monkeypatch.setattr(
+        common, "look_up_binding",
+        lambda _sid: {"conversation_id": "C0CHAN01", "kind": "room",
+                      "scope_id": "test-city", "provider": "slack",
+                      "account_id": "T0TESTWS"})
+
+    rc = pub.main(["--session", "gc-1", "--raw",
+                   "--body", "~$58.5k out, ~$16.5k left"])
+    assert rc == 0
+    assert captured["text"] == "~$58.5k out, ~$16.5k left"

--- a/slack-full/tests/test_slack_chat_publish_to_channel.py
+++ b/slack-full/tests/test_slack_chat_publish_to_channel.py
@@ -131,3 +131,50 @@ def test_publish_to_channel_rejects_both_body_and_body_file() -> None:
             "--body-file", "/dev/null",
         ])
     assert "OR" in str(exc.value)
+
+
+# --------------------------------------------------------------------------
+# Accidental-mrkdwn guard (gp-o42) — tilde pairs must not strike through.
+# --------------------------------------------------------------------------
+
+def test_publish_to_channel_guards_tildes_by_default(
+        monkeypatch: pytest.MonkeyPatch) -> None:
+    pub, common = _import_modules()
+    import slack_mrkdwn
+    captured: dict[str, Any] = {}
+
+    def fake_publish(**kwargs):
+        captured.update(kwargs)
+        return {"delivered": True, "message_id": "1700.001"}
+
+    monkeypatch.setattr(common, "publish_to_channel_via_adapter", fake_publish)
+
+    rc = pub.main([
+        "--conversation-id", "C0CHAN01",
+        "--session", "gc-1",
+        "--body", "~$58.5k out, ~$16.5k left",
+    ])
+    assert rc == 0
+    assert captured["text"] == \
+        "~$58.5k out, ~$16.5k left".replace("~", slack_mrkdwn.TILDE_SUBSTITUTE)
+
+
+def test_publish_to_channel_raw_flag_skips_guard(
+        monkeypatch: pytest.MonkeyPatch) -> None:
+    pub, common = _import_modules()
+    captured: dict[str, Any] = {}
+
+    def fake_publish(**kwargs):
+        captured.update(kwargs)
+        return {"delivered": True, "message_id": "1700.001"}
+
+    monkeypatch.setattr(common, "publish_to_channel_via_adapter", fake_publish)
+
+    rc = pub.main([
+        "--conversation-id", "C0CHAN01",
+        "--session", "gc-1",
+        "--body", "~$58.5k out, ~$16.5k left",
+        "--raw",
+    ])
+    assert rc == 0
+    assert captured["text"] == "~$58.5k out, ~$16.5k left"

--- a/slack-full/tests/test_slack_chat_reply_current.py
+++ b/slack-full/tests/test_slack_chat_reply_current.py
@@ -816,3 +816,109 @@ def test_kind_room_does_not_hijack_non_company_session(
     rc_code = rc.main(["--conversation-id", "C0LEGACY", "--kind", "room", "--body", "hi"])
     assert rc_code == 0
     assert seen["kind"] == "room"  # honored as the legacy conversation kind
+
+
+# --------------------------------------------------------------------------
+# Accidental-mrkdwn guard (gp-o42) — tilde pairs must not strike through.
+# --------------------------------------------------------------------------
+
+_RUNWAY_LINE = "• Total out: ~$58.5k → *~$16.5k left on Sep 30* from a $75k start."
+
+
+def test_body_tildes_are_guarded_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    rc, common = _import_modules()
+    import slack_mrkdwn
+    captured: dict[str, Any] = {}
+
+    def fake_request(method, url, body=None, *, csrf=True, timeout=30.0):
+        captured["body"] = body
+        return {"Receipt": {"Delivered": True, "MessageID": "1700000.000100"}}
+
+    monkeypatch.setattr(common, "_request", fake_request)
+    monkeypatch.setattr(common, "find_latest_inbound_for_session", lambda _sid: None)
+    monkeypatch.setattr(common, "find_latest_inbound_thread_for_session",
+                        lambda _sid: None, raising=False)
+    monkeypatch.setattr(common, "look_up_binding", lambda _sid: None)
+
+    exit_code = rc.main([
+        "--session", "gc-test-session",
+        "--conversation-id", "C0BEZ3CQK5X",
+        "--body", _RUNWAY_LINE,
+    ])
+    assert exit_code == 0
+    text = captured["body"]["text"]
+    assert "~" not in text  # no pairable ASCII tildes reach Slack
+    assert text == _RUNWAY_LINE.replace("~", slack_mrkdwn.TILDE_SUBSTITUTE)
+
+
+def test_raw_flag_skips_the_mrkdwn_guard(monkeypatch: pytest.MonkeyPatch) -> None:
+    rc, common = _import_modules()
+    captured: dict[str, Any] = {}
+
+    def fake_request(method, url, body=None, *, csrf=True, timeout=30.0):
+        captured["body"] = body
+        return {"Receipt": {"Delivered": True, "MessageID": "1700000.000100"}}
+
+    monkeypatch.setattr(common, "_request", fake_request)
+    monkeypatch.setattr(common, "find_latest_inbound_for_session", lambda _sid: None)
+    monkeypatch.setattr(common, "find_latest_inbound_thread_for_session",
+                        lambda _sid: None, raising=False)
+    monkeypatch.setattr(common, "look_up_binding", lambda _sid: None)
+
+    exit_code = rc.main([
+        "--session", "gc-test-session",
+        "--conversation-id", "C0BEZ3CQK5X",
+        "--body", _RUNWAY_LINE,
+        "--raw",
+    ])
+    assert exit_code == 0
+    assert captured["body"]["text"] == _RUNWAY_LINE
+
+
+def test_company_path_guards_tildes_too(
+        monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path) -> None:
+    # Acceptance case: the mayor's reply-current diverts into the company
+    # path; the exact runway body must land with zero pairable tildes and
+    # intentional *bold* intact — no caller changes.
+    rc, _common = _import_modules()
+    import slack_mrkdwn
+    outbound = _import_outbound()
+    _setup_company(outbound, tmp_path)
+    _write_turn(outbound, session="ollie-main", kind="ambient", agent="ollie",
+                ts="1700000000.000300")
+    monkeypatch.setenv("GC_SESSION_NAME", "ollie-main")
+
+    captured: list = []
+
+    def fake_post(method, token, payload, *, api_base, timeout):
+        captured.append({"token": token, "payload": payload})
+        return 200, {}, {"ok": True, "ts": "1700000000.000900"}
+    monkeypatch.setattr(outbound, "_slack_web_post", fake_post)
+
+    rc_code = rc.main(["--body", _RUNWAY_LINE])
+    assert rc_code == 0
+    text = captured[0]["payload"]["text"]
+    assert "~" not in text
+    assert "*" in text  # bold delimiters untouched
+    assert slack_mrkdwn.TILDE_SUBSTITUTE in text
+
+
+def test_company_path_raw_flag_passes_tildes(
+        monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path) -> None:
+    rc, _common = _import_modules()
+    outbound = _import_outbound()
+    _setup_company(outbound, tmp_path)
+    _write_turn(outbound, session="ollie-main", kind="ambient", agent="ollie",
+                ts="1700000000.000300")
+    monkeypatch.setenv("GC_SESSION_NAME", "ollie-main")
+
+    captured: list = []
+
+    def fake_post(method, token, payload, *, api_base, timeout):
+        captured.append({"token": token, "payload": payload})
+        return 200, {}, {"ok": True, "ts": "1700000000.000900"}
+    monkeypatch.setattr(outbound, "_slack_web_post", fake_post)
+
+    rc_code = rc.main(["--body", _RUNWAY_LINE, "--raw"])
+    assert rc_code == 0
+    assert captured[0]["payload"]["text"] == _RUNWAY_LINE

--- a/slack-full/tests/test_slack_chat_upload.py
+++ b/slack-full/tests/test_slack_chat_upload.py
@@ -199,3 +199,82 @@ def test_thread_current_unwraps_helper_tuple(
     # Critical: a plain string, NOT the (msg_id, conversation) tuple.
     assert body["reply_to_message_id"] == "1777779766.848799"
     assert isinstance(body["reply_to_message_id"], str)
+
+
+# --------------------------------------------------------------------------
+# Accidental-mrkdwn guard (gp-o42) — --initial-comment renders as mrkdwn
+# beside the file, so tilde pairs would strike it through.
+# --------------------------------------------------------------------------
+
+_RUNWAY_LINE = "• Total out: ~$58.5k → *~$16.5k left on Sep 30* from a $75k start."
+
+
+def _capture_upload(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    upload, common = _import_modules()
+    captured: dict[str, Any] = {}
+
+    def fake_request(method: str, url: str, body: dict[str, Any] | None = None,
+                     *, csrf: bool = True, timeout: float = 30.0) -> dict[str, Any]:
+        captured["body"] = body
+        return {"Receipt": {"Delivered": True, "FileID": "F7"}}
+
+    monkeypatch.setattr(common, "_request", fake_request)
+    monkeypatch.setattr(common, "look_up_binding", lambda _sid: _fake_binding())
+    captured["upload"] = upload
+    return captured
+
+
+def test_initial_comment_is_guarded_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+) -> None:
+    import slack_mrkdwn  # type: ignore
+    captured = _capture_upload(monkeypatch)
+
+    exit_code = captured["upload"].main([
+        "--file", str(_make_file(tmp_path)),
+        "--session", "gc-test-session",
+        "--initial-comment", _RUNWAY_LINE,
+    ])
+    assert exit_code == 0
+    comment = captured["body"]["initial_comment"]
+    assert "~" not in comment  # no pairable ASCII tilde reaches Slack
+    assert comment == _RUNWAY_LINE.replace("~", slack_mrkdwn.TILDE_SUBSTITUTE)
+
+
+def test_initial_comment_raw_flag_skips_the_guard(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+) -> None:
+    captured = _capture_upload(monkeypatch)
+
+    exit_code = captured["upload"].main([
+        "--file", str(_make_file(tmp_path)),
+        "--session", "gc-test-session",
+        "--initial-comment", _RUNWAY_LINE,
+        "--raw",
+    ])
+    assert exit_code == 0
+    assert captured["body"]["initial_comment"] == _RUNWAY_LINE
+
+
+def test_via_adapter_branch_is_guarded_too(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+) -> None:
+    # Upload guards inline in main() rather than in a shared body loader,
+    # and both --via branches read the one guarded variable. Pin the
+    # adapter branch as well so a future refactor cannot guard only the
+    # default path while the suite stays green.
+    import slack_mrkdwn  # type: ignore
+    captured = _capture_upload(monkeypatch)
+
+    exit_code = captured["upload"].main([
+        "--file", str(_make_file(tmp_path)),
+        "--session", "gc-test-session",
+        "--via", "adapter",
+        "--initial-comment", _RUNWAY_LINE,
+    ])
+    assert exit_code == 0
+    assert captured["body"]["initial_comment"] == \
+        _RUNWAY_LINE.replace("~", slack_mrkdwn.TILDE_SUBSTITUTE)

--- a/slack-full/tests/test_slack_company_outbound.py
+++ b/slack-full/tests/test_slack_company_outbound.py
@@ -1612,3 +1612,60 @@ def test_mpim_pointer_golden_fixture_parses_if_present(env) -> None:
     assert parsed["room"] == ""  # empty room permitted for kind mpim
     assert parsed["owner_app_id"]
     assert "delegation_key" not in json.loads(fx.read_text())  # mpim turns are keyless
+
+
+# --------------------------------------------------------------------------
+# 17. Accidental-mrkdwn guard (gp-o42) on the delegate verb — the body is
+#     posted as mrkdwn, so tilde pairs would strike it through.
+# --------------------------------------------------------------------------
+
+_RUNWAY_LINE = "• Total out: ~$58.5k → *~$16.5k left on Sep 30* from a $75k start."
+
+
+def _capture_delegate(env, monkeypatch: pytest.MonkeyPatch) -> dict:
+    """Fake ``run_delegate`` so the test pins exactly the CLI plumbing:
+    argv → body load → guard → the body the delegation actually posts."""
+    captured: dict = {}
+
+    def fake_run_delegate(**kwargs):
+        captured.update(kwargs)
+        return {"status": "posted", "posted_ts": "1700000000.000900"}
+
+    monkeypatch.setattr(env, "run_delegate", fake_run_delegate)
+    monkeypatch.setenv("GC_SESSION_NAME", "ollie-main")
+    return captured
+
+
+def test_delegate_body_is_guarded_by_default(
+        env, monkeypatch: pytest.MonkeyPatch) -> None:
+    import slack_mrkdwn  # type: ignore
+    captured = _capture_delegate(env, monkeypatch)
+
+    assert env.cmd_delegate(["--to", "riley", "--body", _RUNWAY_LINE]) == 0
+    assert "~" not in captured["body"]  # no pairable ASCII tilde reaches Slack
+    assert captured["body"] == \
+        _RUNWAY_LINE.replace("~", slack_mrkdwn.TILDE_SUBSTITUTE)
+
+
+def test_delegate_raw_flag_skips_the_guard(
+        env, monkeypatch: pytest.MonkeyPatch) -> None:
+    captured = _capture_delegate(env, monkeypatch)
+
+    assert env.cmd_delegate(
+        ["--to", "riley", "--body", _RUNWAY_LINE, "--raw"]) == 0
+    assert captured["body"] == _RUNWAY_LINE
+
+
+def test_delegate_body_file_is_guarded_too(
+        env, monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path) -> None:
+    # --body-file is the documented shape in the agent prompt fragment, and
+    # it loads through the same _load_body_arg the guard sits after.
+    import slack_mrkdwn  # type: ignore
+    captured = _capture_delegate(env, monkeypatch)
+    body_file = tmp_path / "delegation.md"
+    body_file.write_text(_RUNWAY_LINE, encoding="utf-8")
+
+    assert env.cmd_delegate(
+        ["--to", "riley", "--body-file", str(body_file)]) == 0
+    assert captured["body"] == \
+        _RUNWAY_LINE.replace("~", slack_mrkdwn.TILDE_SUBSTITUTE)

--- a/slack-full/tests/test_slack_mrkdwn.py
+++ b/slack-full/tests/test_slack_mrkdwn.py
@@ -1,0 +1,118 @@
+"""Tests for the accidental-mrkdwn guard (gp-o42).
+
+The repro: the mayor's runway summary in C0BEZ3CQK5X (ts=1787203992.825369)
+contained "~$58.5k → *~$16.5k …*" — tildes meaning "approximately" — and
+Slack's mrkdwn paired them into strikethrough across half the message.
+Slack has no escape sequence for formatting characters, so the guard
+substitutes U+223C TILDE OPERATOR for any tilde that could pair
+accidentally, while leaving deliberate ~word~ strikethrough, code spans,
+lone tildes, and all other formatting untouched.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+PACK_DIR = pathlib.Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = PACK_DIR / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import slack_mrkdwn  # noqa: E402
+
+guard = slack_mrkdwn.escape_accidental_mrkdwn
+SUB = slack_mrkdwn.TILDE_SUBSTITUTE
+
+
+# The line that actually struck through in the wild (verbatim).
+REPRO_LINE = "• Total out: ~$58.5k → *~$16.5k left on Sep 30* from a $75k start."
+
+# A fuller reconstruction of the affected message body.
+REPRO_BODY = "\n".join([
+    "Math first (Aug 20 → Sep 30 = 41 days ≈ 1.35 months):",
+    "• Founders $15k/mo + Anthropic $5k/mo + JP WeWork $1.1k/mo = $21.1k/mo × 1.35 ≈ $28.5k",
+    "• China team: $30k one-time (covers them to 9/30)",
+    REPRO_LINE,
+    "",
+    "If your $75k doesn't already include that wire, landing it puts you at *~$93.5k on Sep 30*.",
+    "1. *Your final $30k draw* — the no-wire branch goes NEGATIVE (~-$13.5k).",
+    "4. Small: 1Password needs a card by ~9/2; Shenzhen trip hotels.",
+    "The China team needs re-funding (~$22k/mo at the current rate), so all-in run-rate becomes ~$43k/mo.",
+])
+
+
+def test_repro_line_has_no_pairable_tildes() -> None:
+    out = guard(REPRO_LINE)
+    assert "~" not in out  # both approximately-tildes neutralized
+    assert out == REPRO_LINE.replace("~", SUB)
+    # Intentional bold on the same line is untouched.
+    assert "*~$16.5k left on Sep 30*".replace("~", SUB) in out
+
+
+def test_repro_body_no_line_can_strike() -> None:
+    out = guard(REPRO_BODY)
+    # No line retains two ASCII tildes, so Slack can never pair one.
+    assert all(line.count("~") < 2 for line in out.splitlines())
+    # Nothing else changed: restoring the tildes reproduces the input.
+    assert out.replace(SUB, "~") == REPRO_BODY
+
+
+def test_lone_tilde_lines_keep_their_ascii_byte() -> None:
+    for text in (
+        "the no-wire branch goes NEGATIVE (~-$13.5k). This is the number.",
+        "1Password needs a card by ~9/2 at the latest",
+        "cd ~/repo and run make",
+        "runway ends ~October",
+    ):
+        assert guard(text) == text
+
+
+def test_deliberate_strikethrough_is_preserved() -> None:
+    assert guard("that idea is ~dead~ revived") == "that idea is ~dead~ revived"
+    assert guard("~all of this~ was wrong") == "~all of this~ was wrong"
+    # Two deliberate strikes on one line both survive.
+    assert guard("~old~ new and ~stale~ fresh") == "~old~ new and ~stale~ fresh"
+
+
+def test_approximately_tilde_never_opens_a_pair() -> None:
+    # Currency, signed, decimal, and plain-digit forms (two per line so
+    # pairing is possible and the guard must engage).
+    assert guard("~$58.5k out, ~$16.5k left") == \
+        f"{SUB}$58.5k out, {SUB}$16.5k left"
+    assert guard("~-$13.5k versus ~+$2k") == f"{SUB}-$13.5k versus {SUB}+$2k"
+    assert guard("~.5 days or ~2 weeks") == f"{SUB}.5 days or {SUB}2 weeks"
+    assert guard("~5k€ and ~£3k") == f"{SUB}5k€ and {SUB}£3k"
+
+
+def test_accidental_pair_with_deliberate_neighbor() -> None:
+    # The approximately-tilde is neutralized; the deliberate pair stands.
+    assert guard("~$5k budget, ~overspent~ fixed") == \
+        f"{SUB}$5k budget, ~overspent~ fixed"
+
+
+def test_code_spans_are_untouched() -> None:
+    inline = "run `diff ~/a ~/b` then `x ~ y`"
+    assert guard(inline) == inline
+    fenced = "before ~$1 and ~$2\n```\n~$58.5k ~$16.5k\ncd ~/repo\n```\nafter"
+    out = guard(fenced)
+    assert "```\n~$58.5k ~$16.5k\ncd ~/repo\n```" in out
+    assert out.startswith(f"before {SUB}$1 and {SUB}$2")
+
+
+def test_other_formatting_is_untouched() -> None:
+    text = "*bold* _italic_ `code` • bullet\n> quote with snake_case_name"
+    assert guard(text) == text
+
+
+def test_idempotent_and_cheap_on_tilde_free_text() -> None:
+    text = "plain message, *bold*, no tildes"
+    assert guard(text) is text
+    once = guard(REPRO_BODY)
+    assert guard(once) == once
+
+
+def test_unclosed_fence_still_guards_outside_text() -> None:
+    text = "~$1 vs ~$2\n```unterminated\n~$3 ~$4"
+    out = guard(text)
+    # The unclosed fence is not a code span; everything is guarded.
+    assert out.splitlines()[0] == f"{SUB}$1 vs {SUB}$2"

--- a/slack-full/tests/test_slack_mrkdwn.py
+++ b/slack-full/tests/test_slack_mrkdwn.py
@@ -111,8 +111,103 @@ def test_idempotent_and_cheap_on_tilde_free_text() -> None:
     assert guard(once) == once
 
 
-def test_unclosed_fence_still_guards_outside_text() -> None:
+def test_unclosed_fence_is_code_and_outside_text_is_still_guarded() -> None:
     text = "~$1 vs ~$2\n```unterminated\n~$3 ~$4"
     out = guard(text)
-    # The unclosed fence is not a code span; everything is guarded.
+    # Prose before the fence still pairs, so it is guarded.
     assert out.splitlines()[0] == f"{SUB}$1 vs {SUB}$2"
+    # Slack renders an unterminated fence as a code block through
+    # end-of-message, so those bytes must survive copy-paste verbatim.
+    assert out.endswith("```unterminated\n~$3 ~$4")
+
+
+def test_stray_midline_fence_suspends_the_guard() -> None:
+    """Pin the guard's one under-substituting branch, deliberately.
+
+    The unterminated-fence alternative is unanchored, so a triple
+    backtick anywhere — including mid-sentence in ordinary prose —
+    reads as "code through end-of-message" and passes the remainder
+    through untouched. That is the module's only branch that fails
+    toward leaving a pairable ASCII tilde (i.e. toward the gp-o42 bug)
+    rather than toward substituting; see the premise recorded in the
+    module docstring. This test documents the current decision, so
+    anchoring the alternative to a line-start fence has to be a
+    deliberate change rather than a silent one.
+    """
+    stray = "type ``` then code, runway ~$58.5k to ~$16.5k"
+    assert guard(stray) == stray
+
+    # Control: the identical line without the stray fence IS guarded.
+    # Without this, the assertion above would also pass if the tildes
+    # had simply stopped being pairable for some unrelated reason.
+    control = stray.replace("``` ", "")
+    assert guard(control) == control.replace("~$", f"{SUB}$")
+
+    # The suspension runs to end-of-text, across later lines too.
+    spanning = "use ``` for code\n\nbudget ~$5k vs ~$7k"
+    assert guard(spanning) == spanning
+
+
+def test_code_span_does_not_reset_the_tilde_census() -> None:
+    """A code span between two accidental tildes must not hide the pair.
+
+    Slack applies emphasis *around* inline code, so the two tildes are on
+    one rendered line and pair — guarding each inter-span segment on its
+    own counted one tilde per segment and let both through.
+    """
+    spanned = "budget ~$5k (see `calc.py`) vs ~$7k"
+    assert guard(spanned) == f"budget {SUB}$5k (see `calc.py`) vs {SUB}$7k"
+    # Control: the identical line without the span was always guarded.
+    assert guard("budget ~$5k vs ~$7k") == f"budget {SUB}$5k vs {SUB}$7k"
+    # A single-line fence segments the same way.
+    assert guard("~$1 ```x``` ~$2") == f"{SUB}$1 ```x``` {SUB}$2"
+    # The routine agent shape from the report.
+    assert guard("bump `MAX_RETRIES` to ~5 and `TIMEOUT` to ~30") == \
+        f"bump `MAX_RETRIES` to {SUB}5 and `TIMEOUT` to {SUB}30"
+    # The span's own bytes are still returned untouched.
+    assert "`calc.py`" in guard(spanned)
+
+
+def test_deliberate_pair_survives_beside_and_inside_formatting() -> None:
+    # A code span on the same line does not disturb a real pair.
+    assert guard("run `x` ~word~ done") == "run `x` ~word~ done"
+    # Slack renders these as bold/italic strikethrough: the formatting
+    # delimiter is a legitimate span boundary, not a stray character.
+    assert guard("verdict: *~cancelled~* moving on") == \
+        "verdict: *~cancelled~* moving on"
+    assert guard("verdict: _~cancelled~_ moving on") == \
+        "verdict: _~cancelled~_ moving on"
+
+
+def test_crlf_body_keeps_a_deliberate_pair() -> None:
+    # --body-file bodies can arrive CRLF-terminated; the \r trails the
+    # closer, so it has to count as a closer follower.
+    assert guard("that is ~wrong~\r\nnext line") == "that is ~wrong~\r\nnext line"
+
+
+def test_bitcoin_sign_reads_as_approximately() -> None:
+    assert guard("~₿0.5 then ~₿0.7") == f"{SUB}₿0.5 then {SUB}₿0.7"
+    # The shape that bites: if ₿ were missing from the currency set, this
+    # first tilde would read as an opener, pair with the tilde after
+    # "today", and Slack would strike the whole clause through.
+    assert guard("~₿0.5 today~ and more") == f"{SUB}₿0.5 today{SUB} and more"
+
+
+def test_twin_home_paths_on_one_line_are_substituted() -> None:
+    """The documented limit of the "lone tilde survives" promise.
+
+    "Lone" is per rendered line: two home-relative paths on one line are
+    a pairable pair, and substituting is the fail-safe direction (Slack
+    would strike the text through otherwise). Copy-paste fidelity there
+    needs a code span or --raw — the docs say so; this pins the behavior
+    so changing it stays a decision.
+    """
+    assert guard("rsync -a ~/src ~/dst") == f"rsync -a {SUB}/src {SUB}/dst"
+    assert guard("rsync -a `~/src ~/dst`") == "rsync -a `~/src ~/dst`"
+
+
+def test_tilde_substitute_is_exactly_one_codepoint() -> None:
+    # U+223C TILDE OPERATOR, and single-width: the guard masks code spans
+    # in place and restores them by offset, which needs a 1:1 substitution.
+    assert SUB == "∼"
+    assert len(SUB) == 1


### PR DESCRIPTION
## Problem

Slack mrkdwn pairs tilde characters into strikethrough, and its pairing is looser than any documented rule. An agent posting a finance summary containing `~$58.5k … ~$16.5k` (tilde as "approximately") had half the message rendered struck through. Slack offers **no escape sequence** for formatting characters — a backslash renders literally, and `mrkdwn: false` would also kill intentional `*bold*` and bullets — so callers cannot protect themselves.

## Fix

A new shared module, `scripts/slack_mrkdwn.py`, guards outbound text at the pack-command send path. All five text-sending commands — `reply-current` (both the legacy extmsg path and the company-token path), `publish`, `publish-to-channel`, `upload --initial-comment`, and `delegate` — pass the body through `escape_accidental_mrkdwn()`, which substitutes U+223C TILDE OPERATOR (visually near-identical, never a delimiter) for any tilde that could pair accidentally.

The guard is deliberately conservative about which bytes it touches:

- **Code spans** (``` fences and `inline`) never have their bytes modified — literal text there must survive copy-paste. They are *masked* rather than cut out before the tilde census runs, because Slack pairs tildes **across** an inline span: ``~$5k (see `calc.py`) vs ~$7k`` is one pairable line and both tildes are substituted.
- **Lines with fewer than two tildes are never modified** — strikethrough needs a same-line pair, so a lone `cd ~/repo` keeps its ASCII byte. "Lone" counts per rendered line, so two home-relative paths on one line (`rsync ~/a ~/b`) can pair and both are substituted — put twin paths in a code span or use `--raw`.
- **`~` before an optionally-signed digit/currency** (`~$5k`, `~-$13.5k`, `~9/2`, `~.5`, `~₿0.5`) reads as "approximately" and is never treated as a delimiter.
- **Deliberate tight-wrapped strikethrough** (`~word~`, `~a few words~`) still renders, including when wrapped in mrkdwn delimiters (`*~cancelled~*`, `_~cancelled~_`); `*bold*`, `_italics_`, and bullets are untouched.
- **Idempotent**, length-preserving, and a new `--raw` flag on every affected command sends the body byte-for-byte verbatim.

### Design notes

- Guarding in the Go adapter instead was considered and rejected: a raw-bypass would need a new field plumbed through gc's extmsg outbound API, and the command layer is the shared choke point for every caller shape — including the company-token path, which posts straight to `chat.postMessage` without touching the adapter.
- Underscore/asterisk pairs are deliberately not guarded: accidental italics are legible (unlike strikethrough), snake_case underscores are mid-word and cannot delimit, and homoglyph-substituting identifiers would corrupt copy-pasted commands — a worse papercut than the one being fixed.
- `post-message` is **out of scope**: it renders agent text through the Block Kit path in the Go adapter, so guarding it needs a second implementation of the heuristic plus a `gc-slack-cli` rebuild. The exclusion is documented in `commands/post-message/help.md`, the CHANGELOG, and the agent-facing template fragment, and tracked as `gp-x5bdy`.
- An **unmatched** ` ``` ` is treated as a code block through end-of-message, so it suspends the guard for the remainder. That is the module's one under-substituting branch; the premise it rests on, and the reason it is kept, are recorded in the module docstring and pinned by a test.

## Tests

`python -m pytest slack-full/tests` on this branch: **431 passed.** New coverage (31 new test functions):

- `tests/test_slack_mrkdwn.py` — 17 unit tests on the guard, including the verbatim repro line, the cross-code-span census, deliberate-strikethrough preservation, mrkdwn-delimiter boundaries, CRLF, signed/currency forms, idempotency, closed and unclosed fences, and the mid-line stray-fence shape.
- CLI plumbing tests in the `reply-current` (legacy + company paths, `--raw`), `publish`, `publish-to-channel`, `upload`, and `delegate` suites asserting guarded text reaches the transport and `--raw` bypasses.

Pure script-side change — no adapter rebuild or service restart needed.

---

_Maintainer note: this description was refreshed during adoption to match the final reviewed patch. The original submission's design and prose are the contributor's; the bullets above were updated where the review/fix loop changed behavior (cross-span tilde census, `*`/`_` boundaries, per-line twin-path rule, `post-message` exclusion, unmatched-fence premise) and where the test counts moved._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
