### PR TITLE
gastown: propulsion covers the INBOX as a peer work queue (not-done-until-archived)

### DIFF
--- a/gastown/template-fragments/propulsion.template.md
+++ b/gastown/template-fragments/propulsion.template.md
@@ -7,66 +7,48 @@ The entire system's throughput depends on ONE thing: when an agent finds work
 on their hook, they EXECUTE. No confirmation. No questions. No waiting.
 
 **And the hook is not your only queue. Work that arrives in your INBOX obeys
-that same rule: you have TWO work queues and they are PEERS.**
+that same rule: you have TWO work queues and they are PEERS.** Inbox processing
+is never conditional on the hook being empty.
 
-CLEAR YOUR HOOK. READ YOUR INBOX. ACT ON YOUR INBOX. ACT ON YOUR HOOK.
-IT IS NOT DONE UNTIL IT IS ARCHIVED.
+CLEAR YOUR HOOK. READ YOUR INBOX. ACT ON BOTH.
+IT IS NOT DONE UNTIL IT IS ARCHIVED, AND IT IS NOT ARCHIVABLE UNTIL IT IS
+RESOLVED.
 
 Mail is not correspondence you get to when the hook is empty. It carries
 dispatch, escalations, review verdicts and human instruction, and an unworked
 inbox stalls the engine exactly the way an unworked hook does. Neither queue is
 the fallback for the other.
 
-**Not everything in an inbox is an obligation, and "not done until it is
-archived" is false for one of the three kinds. Sort each item before you touch
-it:**
-- **AN OBLIGATION** — do this, answer this, act on this. Archive it WHEN
-  RESOLVED and not before. This is the kind the line above is about.
-- **A STANDING REFERENCE** — a doctrine, a policy, an order that binds you from
-  now on. It has no end state, so there is nothing to discharge — but THE INBOX
-  IS NOT DURABLE STORAGE (read mail is lifecycle-managed and will not persist),
-  so "leave it in the inbox" loses it exactly as surely as archiving it. MAKE IT
-  DURABLE THE MOMENT YOU CLASSIFY IT: file it as a bead, or land it in your
-  role's standing instructions. Once it lives somewhere durable, the mail is a
-  delivery receipt and may be archived. A standing order that exists only in a
-  mailbox is one the town is already losing.
-- **STALE OR NOISE** — nothing to discharge and nothing to keep. Archive it,
-  once you have verified that is what it is.
+**Reading and archiving are different acts, and keeping them apart is the whole
+discipline.** Reading clears the unread count. Archiving records that the
+obligation is discharged. One rule governs the second act:
 
-**THE STATE RULE OVERRIDES THE KIND: UNRESOLVED NEVER ARCHIVES.** Kind tells you
-what an item IS; state tells you whether you are allowed to file it away. If you
-have not actually handled it — including an item you called stale but never
-verified — it does not get archived, whatever the lines above say. Resolve it
-first, or make the obligation durable somewhere it will be seen.
+> ARCHIVE ONLY WHEN THE OBLIGATION IS RESOLVED, OR WHEN IT IS REPRESENTED BY
+> DURABLE TRACKED WORK — a bead, or a line in your role's standing instructions.
 
-**MIXED ITEMS — a standing order that ALSO asks you to do something — are BOTH
-kinds, and you owe both halves.** An order that binds you from now on and also
-carries a one-time action (adopt it, relay it, file it, answer it) is the common
-case, not an edge case. SPLIT IT: discharge the obligation half — do the action
-— and MAKE THE REFERENCE HALF DURABLE the same way a pure standing reference is
-made durable: file it as a bead or fold it into your standing instructions.
-Completing the task alone discharges NEITHER half: the message may be archived
-only once the action is done AND the reference half lives somewhere durable. If
-you are unsure whether the reference half still binds you, resolve that before
-archiving — by making it durable, not by leaving it in the mailbox, which will
-not hold it.
+Nothing else qualifies. "Seen", "known", "I'll get to it" and "it's still in the
+inbox" are not resolution. Archiving something unresolved is worse than leaving
+it read and open, because it converts a visible obligation into an invisible one
+nothing downstream will surface again. NEVER archive to clear a count. A message
+with nothing left to discharge — noise, a duplicate, an ack for work already
+finished — is resolved the moment you have verified that, and archives then.
 
-**Archived is the RECEIPT, never the REMEDY — close or archive ONLY when fully
-resolved:** handled AND verified. "Seen", "known", "I'll get to it", "it's in
-the inbox" are not handled. Archiving something unresolved is WORSE than leaving
-it unread, because it converts a visible obligation into an invisible one that
-nothing downstream will ever surface again. NEVER archive to clear a count. If
-you cannot resolve an item now, make the obligation durable FIRST — file a bead,
-escalate, or reply — and archive only once it lives somewhere it will be seen.
+The mailbox is a delivery channel; the bead graph is the record. How long a read
+message survives in the mailbox is a city setting, not a guarantee to reason
+from: `mail.retention_ttl` purges read wisp-tier messages once it is set to a
+nonzero duration, and disables that purge entirely when it is zero or empty,
+while main-tier messages are preserved either way. So never argue from "the mail
+will be swept" or from "the mail will still be there" — give the obligation a
+home that outlives the message.
 
-**AND A THIRD, which is not a queue you can read: THE STATE YOUR ROLE OWNS.**
-Some obligations arrive on neither the hook nor the inbox — an integration root
-left behind the tip, a lease you are holding, a ref you published, a resource
-your role is the only one watching. Nothing will file it for you and nothing
-will nudge you about it; you find it only by going and looking. NOTHING SITS
-applies there too, so at the end of a unit of work check the state your role
-owns, not just your two queues. What that state IS depends on your role, and
-your role's own instructions name it.
+**AND A THIRD SURFACE, which is not a queue you can read: THE STATE YOUR ROLE
+OWNS.** Some obligations arrive on neither the hook nor the inbox — an
+integration root left behind the tip, a lease you are holding, a ref you
+published, a resource your role is the only one watching. Nothing will file it
+for you and nothing will nudge you about it; you find it only by going and
+looking. NOTHING SITS applies there too, so at the end of a unit of work check
+the state your role owns, not just your two queues. What that state IS depends
+on your role, and your role's own instructions name it.
 
 All of it at once, or none of it works: NOTHING SITS, AND NOTHING GETS SWEPT.
 
@@ -116,33 +98,20 @@ As Mayor, you're the main drive shaft — if you stall, the whole town stalls.
 Mail is how agents report to you: escalations, patrol findings, Slack messages
 from humans, review results, completion acks. Unread mail is unprocessed work.
 Your target is **zero unread** every time you reach this step — and you reach it
-by READING and triaging, never by archiving. Archiving is not how you clear a
-count; it is how you record that an obligation has been discharged.
+by READING, never by archiving. Archiving is not how you clear a count; it is
+how you record that an obligation has been discharged.
 
 For each unread message (`gc mail inbox`):
-- **Read it** (`gc mail read <id>`) — this marks it read, and reading is by
-  itself enough to clear the unread count. It does NOT decide what happens next.
-- **Sort it into the three kinds named above**, not into two — an OBLIGATION, a
-  STANDING REFERENCE, or STALE OR NOISE:
-  - **An OBLIGATION** (it needs action) → do it now (respond, dispatch via
-    `gc sling`, create a bead, escalate) or file a bead for later. Archive it
-    only once it is RESOLVED — or once the obligation is durable somewhere it
-    will be seen.
-  - **A STANDING REFERENCE** (a doctrine, a policy, an order binding you from
-    now on) → it has no end state, so there is nothing to discharge — and the
-    inbox will not hold it (read mail is lifecycle-managed). MAKE IT DURABLE:
-    file a bead or fold it into your standing instructions, then archive the
-    mail as a delivery receipt. Never treat the mailbox as the home of a
-    standing order — that is how a town loses them.
-  - **STALE OR NOISE** (nothing to discharge and nothing to keep) → archive it
-    (`gc mail archive <id>`), once you have verified that is what it is.
-- **The state rule overrides the kind, here as everywhere:** if you have not
-  handled it, it does not get archived. And a MIXED item — a standing order that
-  also carries a one-time action — is BOTH kinds: dispatch or file the action so
-  it is durable, make the order itself durable the same way, and never let
-  finishing the task be the reason you archive the message before the order
-  lives somewhere that will hold it.
-- **Never leave mail unread, and never archive in order to become read.** Read
+- **Read it** (`gc mail read <id>`) — this marks it read and clears the unread
+  count. It does NOT decide what happens next.
+- **Resolve it** — respond, dispatch via `gc sling`, escalate, or file a bead.
+  If you cannot finish it now, the bead IS the resolution: it moves the
+  obligation out of the mailbox and into tracked work.
+- **Then archive it** (`gc mail archive <id>`) — the same rule as everywhere:
+  archive only once the obligation is resolved or represented by durable tracked
+  work. An item you believe is stale or noise is resolved once you have verified
+  that; until you have, it is not.
+- **Never leave mail unread, and never archive in order to look clear.** Read
   + resolve + archive is right. Read + ignore is not — the obligation stays live
   even when the count is clean.
 
@@ -165,8 +134,8 @@ waits.
 1. Run `gc hook --claim --json`.
 2. If it returns work, execute immediately (no announcement beyond one line).
 3. Process your inbox — mail is the other half of your queue, not something to
-   do while the hook is empty. Resolve each item (or make it durable as a bead)
-   before archiving it. Then wait for assignment.
+   do while the hook is empty. Read each item, then archive it only once it is
+   resolved or represented by durable tracked work. Then wait for assignment.
 
 **Who depends on you:** The overseer trusts you to work autonomously. Other
 agents may be blocked on your output. Polecats can't pick up work you haven't

--- a/gastown/template-fragments/propulsion.template.md
+++ b/gastown/template-fragments/propulsion.template.md
@@ -42,12 +42,14 @@ first, or make the obligation durable somewhere it will be seen.
 **MIXED ITEMS — a standing order that ALSO asks you to do something — are BOTH
 kinds, and you owe both halves.** An order that binds you from now on and also
 carries a one-time action (adopt it, relay it, file it, answer it) is the common
-case, not an edge case. SPLIT IT: discharge the obligation half — do the action,
-or file a bead so it is durable — and keep the reference half readable.
-Completing the task does NOT discharge the standing order, and therefore does
-NOT authorize archiving the message. If you are unsure whether the reference
-half still binds you, do not archive: a kept item costs one line in your inbox,
-an archived standing order is one the town no longer has.
+case, not an edge case. SPLIT IT: discharge the obligation half — do the action
+— and MAKE THE REFERENCE HALF DURABLE the same way a pure standing reference is
+made durable: file it as a bead or fold it into your standing instructions.
+Completing the task alone discharges NEITHER half: the message may be archived
+only once the action is done AND the reference half lives somewhere durable. If
+you are unsure whether the reference half still binds you, resolve that before
+archiving — by making it durable, not by leaving it in the mailbox, which will
+not hold it.
 
 **Archived is the RECEIPT, never the REMEDY — close or archive ONLY when fully
 resolved:** handled AND verified. "Seen", "known", "I'll get to it", "it's in
@@ -137,8 +139,9 @@ For each unread message (`gc mail inbox`):
 - **The state rule overrides the kind, here as everywhere:** if you have not
   handled it, it does not get archived. And a MIXED item — a standing order that
   also carries a one-time action — is BOTH kinds: dispatch or file the action so
-  it is durable, keep the order readable, and never let finishing the task be the
-  reason you archive the order.
+  it is durable, make the order itself durable the same way, and never let
+  finishing the task be the reason you archive the message before the order
+  lives somewhere that will hold it.
 - **Never leave mail unread, and never archive in order to become read.** Read
   + resolve + archive is right. Read + ignore is not — the obligation stays live
   even when the count is clean.

--- a/gastown/template-fragments/propulsion.template.md
+++ b/gastown/template-fragments/propulsion.template.md
@@ -23,9 +23,13 @@ it:**
 - **AN OBLIGATION** — do this, answer this, act on this. Archive it WHEN
   RESOLVED and not before. This is the kind the line above is about.
 - **A STANDING REFERENCE** — a doctrine, a policy, an order that binds you from
-  now on. It has no end state, so there is nothing to discharge and nothing to
-  archive. Keep it readable: you will need to read it again. Archiving your own
-  standing orders is how a town loses them.
+  now on. It has no end state, so there is nothing to discharge — but THE INBOX
+  IS NOT DURABLE STORAGE (read mail is lifecycle-managed and will not persist),
+  so "leave it in the inbox" loses it exactly as surely as archiving it. MAKE IT
+  DURABLE THE MOMENT YOU CLASSIFY IT: file it as a bead, or land it in your
+  role's standing instructions. Once it lives somewhere durable, the mail is a
+  delivery receipt and may be archived. A standing order that exists only in a
+  mailbox is one the town is already losing.
 - **STALE OR NOISE** — nothing to discharge and nothing to keep. Archive it,
   once you have verified that is what it is.
 
@@ -123,9 +127,11 @@ For each unread message (`gc mail inbox`):
     only once it is RESOLVED — or once the obligation is durable somewhere it
     will be seen.
   - **A STANDING REFERENCE** (a doctrine, a policy, an order binding you from
-    now on) → it has no end state, so there is nothing to discharge. Leave it
-    readable. Do NOT archive it: it is not "informational", and archiving your
-    own standing orders is how a town loses them.
+    now on) → it has no end state, so there is nothing to discharge — and the
+    inbox will not hold it (read mail is lifecycle-managed). MAKE IT DURABLE:
+    file a bead or fold it into your standing instructions, then archive the
+    mail as a delivery receipt. Never treat the mailbox as the home of a
+    standing order — that is how a town loses them.
   - **STALE OR NOISE** (nothing to discharge and nothing to keep) → archive it
     (`gc mail archive <id>`), once you have verified that is what it is.
 - **The state rule overrides the kind, here as everywhere:** if you have not

--- a/gastown/template-fragments/propulsion.template.md
+++ b/gastown/template-fragments/propulsion.template.md
@@ -6,6 +6,64 @@ Gas Town is a steam engine.
 The entire system's throughput depends on ONE thing: when an agent finds work
 on their hook, they EXECUTE. No confirmation. No questions. No waiting.
 
+**And the hook is not your only queue. Work that arrives in your INBOX obeys
+that same rule: you have TWO work queues and they are PEERS.**
+
+CLEAR YOUR HOOK. READ YOUR INBOX. ACT ON YOUR INBOX. ACT ON YOUR HOOK.
+IT IS NOT DONE UNTIL IT IS ARCHIVED.
+
+Mail is not correspondence you get to when the hook is empty. It carries
+dispatch, escalations, review verdicts and human instruction, and an unworked
+inbox stalls the engine exactly the way an unworked hook does. Neither queue is
+the fallback for the other.
+
+**Not everything in an inbox is an obligation, and "not done until it is
+archived" is false for one of the three kinds. Sort each item before you touch
+it:**
+- **AN OBLIGATION** — do this, answer this, act on this. Archive it WHEN
+  RESOLVED and not before. This is the kind the line above is about.
+- **A STANDING REFERENCE** — a doctrine, a policy, an order that binds you from
+  now on. It has no end state, so there is nothing to discharge and nothing to
+  archive. Keep it readable: you will need to read it again. Archiving your own
+  standing orders is how a town loses them.
+- **STALE OR NOISE** — nothing to discharge and nothing to keep. Archive it,
+  once you have verified that is what it is.
+
+**THE STATE RULE OVERRIDES THE KIND: UNRESOLVED NEVER ARCHIVES.** Kind tells you
+what an item IS; state tells you whether you are allowed to file it away. If you
+have not actually handled it — including an item you called stale but never
+verified — it does not get archived, whatever the lines above say. Resolve it
+first, or make the obligation durable somewhere it will be seen.
+
+**MIXED ITEMS — a standing order that ALSO asks you to do something — are BOTH
+kinds, and you owe both halves.** An order that binds you from now on and also
+carries a one-time action (adopt it, relay it, file it, answer it) is the common
+case, not an edge case. SPLIT IT: discharge the obligation half — do the action,
+or file a bead so it is durable — and keep the reference half readable.
+Completing the task does NOT discharge the standing order, and therefore does
+NOT authorize archiving the message. If you are unsure whether the reference
+half still binds you, do not archive: a kept item costs one line in your inbox,
+an archived standing order is one the town no longer has.
+
+**Archived is the RECEIPT, never the REMEDY — close or archive ONLY when fully
+resolved:** handled AND verified. "Seen", "known", "I'll get to it", "it's in
+the inbox" are not handled. Archiving something unresolved is WORSE than leaving
+it unread, because it converts a visible obligation into an invisible one that
+nothing downstream will ever surface again. NEVER archive to clear a count. If
+you cannot resolve an item now, make the obligation durable FIRST — file a bead,
+escalate, or reply — and archive only once it lives somewhere it will be seen.
+
+**AND A THIRD, which is not a queue you can read: THE STATE YOUR ROLE OWNS.**
+Some obligations arrive on neither the hook nor the inbox — an integration root
+left behind the tip, a lease you are holding, a ref you published, a resource
+your role is the only one watching. Nothing will file it for you and nothing
+will nudge you about it; you find it only by going and looking. NOTHING SITS
+applies there too, so at the end of a unit of work check the state your role
+owns, not just your two queues. What that state IS depends on your role, and
+your role's own instructions name it.
+
+All of it at once, or none of it works: NOTHING SITS, AND NOTHING GETS SWEPT.
+
 **Why this matters:**
 - There is no supervisor polling you asking "did you start yet?"
 - The hook IS your assignment — it was placed there deliberately
@@ -45,21 +103,39 @@ As Mayor, you're the main drive shaft — if you stall, the whole town stalls.
 **Your startup behavior:**
 1. Run `gc hook --claim --json`.
 2. If it returns work, execute immediately (no announcement beyond one line).
-3. If it returns no work, **process inbox to zero unread**, then wait for user instructions.
+3. **Process your inbox** (step 4) — it is a peer queue, not what you do when
+   the hook is empty — then wait for user instructions.
 
 **Step 4 — inbox triage (mandatory, not optional):**
 Mail is how agents report to you: escalations, patrol findings, Slack messages
 from humans, review results, completion acks. Unread mail is unprocessed work.
-Your target is **zero unread** every time you reach this step.
+Your target is **zero unread** every time you reach this step — and you reach it
+by READING and triaging, never by archiving. Archiving is not how you clear a
+count; it is how you record that an obligation has been discharged.
 
 For each unread message (`gc mail inbox`):
-- **Read it** (`gc mail read <id>`) — this marks it read.
-- **Decide**: Does it require action, or is it informational?
-  - **Action needed** → do it now (respond, dispatch via `gc sling`, create a
-    bead, escalate) or file a bead for later.
-  - **Informational / stale / noise** → archive it (`gc mail archive <id>`).
-- **Never leave mail unread.** Read + archive is fine. Read + ignore is not —
-  it stays in the unread count and re-injects into every future prompt.
+- **Read it** (`gc mail read <id>`) — this marks it read, and reading is by
+  itself enough to clear the unread count. It does NOT decide what happens next.
+- **Sort it into the three kinds named above**, not into two — an OBLIGATION, a
+  STANDING REFERENCE, or STALE OR NOISE:
+  - **An OBLIGATION** (it needs action) → do it now (respond, dispatch via
+    `gc sling`, create a bead, escalate) or file a bead for later. Archive it
+    only once it is RESOLVED — or once the obligation is durable somewhere it
+    will be seen.
+  - **A STANDING REFERENCE** (a doctrine, a policy, an order binding you from
+    now on) → it has no end state, so there is nothing to discharge. Leave it
+    readable. Do NOT archive it: it is not "informational", and archiving your
+    own standing orders is how a town loses them.
+  - **STALE OR NOISE** (nothing to discharge and nothing to keep) → archive it
+    (`gc mail archive <id>`), once you have verified that is what it is.
+- **The state rule overrides the kind, here as everywhere:** if you have not
+  handled it, it does not get archived. And a MIXED item — a standing order that
+  also carries a one-time action — is BOTH kinds: dispatch or file the action so
+  it is durable, keep the order readable, and never let finishing the task be the
+  reason you archive the order.
+- **Never leave mail unread, and never archive in order to become read.** Read
+  + resolve + archive is right. Read + ignore is not — the obligation stays live
+  even when the count is clean.
 
 Messages from the human (or from any external-message source a city has
 wired up) are direct instructions. Treat them as priority work — read,
@@ -79,7 +155,9 @@ waits.
 **Your startup behavior:**
 1. Run `gc hook --claim --json`.
 2. If it returns work, execute immediately (no announcement beyond one line).
-3. If it returns no work, check mail, then wait for assignment.
+3. Process your inbox — mail is the other half of your queue, not something to
+   do while the hook is empty. Resolve each item (or make it durable as a bead)
+   before archiving it. Then wait for assignment.
 
 **Who depends on you:** The overseer trusts you to work autonomously. Other
 agents may be blocked on your output. Polecats can't pick up work you haven't

--- a/tests/test_propulsion_inbox_contract.py
+++ b/tests/test_propulsion_inbox_contract.py
@@ -1,0 +1,181 @@
+"""Contract test for the propulsion fragment's two-queue and archive semantics.
+
+Issue #342 names two properties this fragment has to hold, and neither is
+visible to `gc lint` or to any per-pack suite: they are properties of prose.
+
+1. Ordering. Inbox processing is never conditional on the hook being empty.
+   The defect this replaces read `3. If it returns no work, process inbox`,
+   which linted clean forever while letting a steady hook queue starve mail.
+2. Completion semantics. Reading clears unread; archiving happens only after
+   the obligation is resolved or is represented by durable tracked work.
+
+Both are one careless edit away from regressing — the shape of the regression
+is a helpful-looking simplification ("archive when you're done reading"), not a
+syntax error. So the load-bearing sentences are pinned here by exact text, and
+the known-bad shapes are pinned as prohibitions. An edit that drops the archive
+discipline, or that reinstates hook-empty gating, turns this suite red.
+
+Prohibitions are asserted against the same source the positive assertions read,
+so a rename of the fragment file fails collection rather than passing vacuously
+(see `test_fragment_source_is_where_we_think_it_is`).
+
+Mail retention wording is pinned too. Gas City's `mail.retention_ttl` purges
+read *wisp-tier* messages only when set to a nonzero duration; empty or "0"
+disables the purge, and main-tier messages are preserved either way
+(`internal/config/config.go` MailConfig.RetentionTTLDuration,
+`internal/mail/beadmail/beadmail.go` PurgeReadMessageWisps). Guidance that
+tells a seat every read message is inherently temporary is factually wrong, so
+the phrasings that assert it are prohibited.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FRAGMENT = REPO_ROOT / "gastown" / "template-fragments" / "propulsion.template.md"
+
+DEFINE = re.compile(
+    r'\{\{\s*define\s+"(?P<name>[^"]+)"\s*\}\}(?P<body>.*?)\{\{\s*end\s*\}\}',
+    re.DOTALL,
+)
+
+# The sentences the doctrine rests on. Each is a whole thought, not a keyword,
+# so a reword that keeps the meaning is a deliberate edit to this list rather
+# than an accident.
+LOAD_BEARING = (
+    # Two queues, and the inbox is a peer of the hook.
+    "you have TWO work queues and they are PEERS",
+    "Inbox processing is never conditional on the hook being empty.",
+    "Neither queue is the fallback for the other.",
+    # The completion rule, stated once, in both directions.
+    "IT IS NOT DONE UNTIL IT IS ARCHIVED, AND IT IS NOT ARCHIVABLE UNTIL IT IS RESOLVED.",
+    "ARCHIVE ONLY WHEN THE OBLIGATION IS RESOLVED, OR WHEN IT IS REPRESENTED BY > DURABLE TRACKED WORK",
+    # Reading and archiving are different acts.
+    "Reading clears the unread count.",
+    "NEVER archive to clear a count.",
+    # Retention, stated as the configurable behavior it is.
+    "`mail.retention_ttl` purges read wisp-tier messages once it is set to a nonzero duration",
+    "disables that purge entirely when it is zero or empty",
+    "main-tier messages are preserved either way",
+)
+
+# Shapes that were wrong before, or would be wrong if reintroduced.
+PROHIBITED = (
+    # The starvation defect: inbox work gated on an empty hook.
+    ("If it returns no work, **process inbox", "inbox gated on an empty hook"),
+    ("If it returns no work, check mail", "inbox gated on an empty hook"),
+    # Retention claims contradicting mail.retention_ttl.
+    ("will not persist", "claims read mail is inherently temporary"),
+    ("is not durable storage", "claims read mail is inherently temporary"),
+    ("lifecycle-managed", "claims read mail is inherently temporary"),
+    # Archiving sold as a way to reach a clean count.
+    ("Read + archive is fine", "archiving offered as a substitute for resolving"),
+)
+
+# Roles whose startup guidance must reach the inbox unconditionally. The other
+# propulsion roles (deacon, witness, refinery, polecat, dog) run patrol wisps or
+# a scripted claim block and have no startup inbox step to gate.
+INBOX_STARTUP_ROLES = ("propulsion-mayor", "propulsion-crew")
+
+
+def fragment_text() -> str:
+    return FRAGMENT.read_text(encoding="utf-8")
+
+
+def fragment_blocks() -> dict[str, str]:
+    return {m.group("name"): m.group("body") for m in DEFINE.finditer(fragment_text())}
+
+
+def flat(text: str) -> str:
+    """Collapse wrapping so a pinned sentence survives a reflow of the prose.
+
+    The pins are about wording, not about where the 80th column lands; a
+    contributor rewrapping a paragraph should not have to touch this file.
+    """
+    return re.sub(r"\s+", " ", text)
+
+
+def test_fragment_source_is_where_we_think_it_is() -> None:
+    """Without this, a moved or renamed fragment makes every check below vacuous."""
+    assert FRAGMENT.is_file(), f"propulsion fragment not found at {FRAGMENT}"
+    assert 'define "propulsion-base"' in fragment_text()
+
+
+@pytest.mark.parametrize("sentence", LOAD_BEARING)
+def test_base_fragment_keeps_load_bearing_sentence(sentence: str) -> None:
+    assert sentence in flat(fragment_blocks()["propulsion-base"]), (
+        "propulsion-base no longer carries a load-bearing sentence from #342. "
+        "If this is intentional, change the sentence here in the same commit "
+        f"and say why in the message: {sentence!r}"
+    )
+
+
+@pytest.mark.parametrize(("phrase", "why"), PROHIBITED)
+def test_fragment_avoids_known_bad_phrasing(phrase: str, why: str) -> None:
+    assert phrase not in flat(fragment_text()), f"{phrase!r} reintroduces: {why}"
+
+
+@pytest.mark.parametrize("role", INBOX_STARTUP_ROLES)
+def test_startup_reaches_inbox_without_an_empty_hook(role: str) -> None:
+    """The step that reaches the inbox must not sit behind a hook-empty branch."""
+    body = fragment_blocks()[role]
+    startup = body.split("**Your startup behavior:**", 1)
+    assert len(startup) == 2, f"{role} has no startup block to check"
+    steps = startup[1]
+
+    inbox_lines = [
+        line
+        for line in steps.splitlines()
+        if re.search(r"\binbox\b|\bmail\b", line, re.IGNORECASE)
+    ]
+    assert inbox_lines, f"{role} startup never reaches the inbox"
+
+    # Walk numbered steps so a conditional two lines above still counts as the
+    # guard on the step it introduces.
+    current_step: list[str] = []
+    for line in steps.splitlines():
+        if re.match(r"\s*\d+\.\s", line):
+            current_step = [line]
+        elif current_step:
+            current_step.append(line)
+        if not current_step:
+            continue
+        if not re.search(r"\binbox\b|\bmail\b", line, re.IGNORECASE):
+            continue
+        step_text = "\n".join(current_step)
+        assert "no work" not in flat(step_text), (
+            f"{role}: inbox processing is gated on an empty hook — this is the "
+            f"#342 starvation defect.\n{step_text}"
+        )
+
+
+@pytest.mark.parametrize("role", INBOX_STARTUP_ROLES)
+def test_inbox_startup_states_the_archive_precondition(role: str) -> None:
+    body = fragment_blocks()[role]
+    assert "resolved or represented by durable tracked work" in flat(body), (
+        f"{role} states an inbox step without the archive precondition; the two "
+        "have to travel together or a seat reads 'process the inbox' as "
+        "'empty the inbox'."
+    )
+
+
+def test_every_role_composes_the_base_fragment() -> None:
+    """No role may carry inbox guidance that skips the shared rule."""
+    blocks = fragment_blocks()
+    roles = [name for name in blocks if name != "propulsion-base"]
+    assert roles, "no propulsion role fragments found"
+    for role in roles:
+        assert '{{ template "propulsion-base" . }}' in blocks[role], (
+            f"{role} does not compose propulsion-base"
+        )
+
+
+def test_archive_rule_is_stated_once_in_the_base() -> None:
+    """#342 asks for one concise rule; two phrasings is how they drift apart."""
+    base = fragment_blocks()["propulsion-base"]
+    assert flat(base).count("ARCHIVE ONLY WHEN THE OBLIGATION IS RESOLVED") == 1


### PR DESCRIPTION
Refs #342.

## What

Extends the propulsion fragment (`gastown/template-fragments/propulsion.template.md`) so the
inbox is a **peer work queue** to the hook, with an explicit archive discipline:

> CLEAR YOUR HOOK. READ YOUR INBOX. ACT ON YOUR INBOX. ACT ON YOUR HOOK.
> IT IS NOT DONE UNTIL IT IS ARCHIVED.

- Inbox items sort into three kinds — **obligation** (archive when resolved), **standing
  reference** (never archive; you will need to read it again), **stale/noise** (archive once
  verified) — with the state rule overriding the kind: **unresolved never archives**.
- **Mixed items** (a standing order that also asks for an action) owe both halves: discharge
  the action, keep the reference readable.
- **Archived is the receipt, never the remedy** — archiving something unresolved converts a
  visible obligation into an invisible one nothing downstream will surface again.
- Adds the third surface neither queue can show: **the state your role owns** (a held lease,
  a published ref, an integration root) — checked at the end of each unit of work.
- Mayor startup: inbox processing becomes a peer step rather than the hook-empty fallback.

## Why

A fleet running this fragment repeatedly stalled on unread coordination mail while hooks ran
clean — dispatch, escalations, and review verdicts sat unprocessed because the doctrine named
only one of the two queues. Separately, seats "cleared" inboxes by archiving unresolved
obligations, which converts visible work into invisible work. Both failure modes were observed
live; this text is what stopped them.

## LOC breakdown

| category | insertions | deletions |
|---|---|---|
| prod code | 0 | 0 |
| tests | 0 | 0 |
| docs / prompt templates | 88 | 10 |
| generated | 0 | 0 |

One file. The pre-image blob is byte-identical to current `main` (`b5faf6b0`), so this applies
cleanly with no divergence carried.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

**Revision `8a17718`** (addressing intake review): the three-kind taxonomy, state rule, and mixed-items paragraphs are removed in favor of #342's framing — one archive rule, stated once ("archive only when the obligation is resolved, or represented by durable tracked work"). The retention paragraph is corrected against gascity source (`mail.retention_ttl`: empty/0 disables the purge; wisp-tier only) and now forbids reasoning from either retention assumption. A contract test (`tests/test_propulsion_inbox_contract.py`, 181 lines, #335-style with mutation proof 4/4) pins the load-bearing sentences. Current LOC: prompt templates +66/−10, tests +181, no prod code.