### PR TITLE
fix(slack-full): stamp a reference marker on keyed publishes so delivery can be read back

### DIFF
--- a/slack-full/CHANGELOG.md
+++ b/slack-full/CHANGELOG.md
@@ -100,6 +100,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Outbound publishes carrying an idempotency key are stamped with a
+  low-visibility reference marker (`_ref:<12 hex>_`) so a later reader can
+  find the exact message in Slack. The in-process dedup cache only lives
+  for its TTL and does not survive a restart, so it cannot provide durable
+  delivery evidence; the marker can. The readback contract — what a marker's
+  absence does and does not mean, and where a reader has to look — is stated
+  normatively in the `referenceMarker` doc comment in `adapter/main.go`, and
+  this entry deliberately does not restate it, so there is one place to edit.
+  Two properties worth knowing without opening the source: absence always
+  means UNKNOWN, never undelivered (all history predating this change is
+  unmarked); and a marker on a threaded reply is not reachable from
+  `conversations.history`, which does not return thread replies.
+
+  Note on Slack's ceiling, since the obvious assumption is wrong: Slack does
+  not reject text over 40,000 — it truncates from the end and still answers
+  `ok:true`. The marker is the tail of the text, so an oversized post would
+  deliver a mangled partial marker under a receipt that looks perfect. The
+  advertised `MaxMessageLength` therefore reserves the marker's 20 bytes, and
+  `handlePublish` enforces the same budget itself rather than trusting an
+  advertisement nothing in gc reads today. Over the budget the caller's text
+  is posted **unstamped** rather than trimmed: the message is the caller's,
+  the bookkeeping is ours, and an honest absence is already something the
+  contract requires readers to tolerate. When Slack reports a truncation
+  anyway, the publish receipt carries `metadata["truncated"]="true"`
+  (`dr-3msk6.3`).
 - `gc slack retry-peer-fanout` — operational recovery for peer-fanout.
   Walks recent `extmsg.peer_fanout_failed` events (added in this change
   too), filters by `--since` / `--conversation` / `--max`, deduplicates

--- a/slack-full/adapter/main.go
+++ b/slack-full/adapter/main.go
@@ -791,6 +791,19 @@ type publishReceipt struct {
 	MessageID    string          `json:"message_id,omitempty"`
 	Delivered    bool            `json:"delivered"`
 	FailureKind  string          `json:"failure_kind,omitempty"`
+	// Metadata carries out-of-band facts about a delivery that the four
+	// named fields above cannot express — currently only "truncated". gc
+	// does not decode this body into its public PublishReceipt directly: it
+	// unmarshals into a fixed intermediate shim, wirePublishReceipt
+	// (gascity internal/extmsg/http_adapter.go:140-157), whose six fields
+	// are copied across one by one in toPublishReceipt. `metadata` is one
+	// of those six and reaches PublishReceipt.Metadata; any key outside
+	// that set is silently discarded at gc's boundary, so widening this
+	// struct with a new top-level field would produce a value no gc
+	// consumer can ever observe. Measured against gc's real code, not
+	// inferred. The request side already uses this idiom
+	// (publishRequest.Metadata).
+	Metadata map[string]string `json:"metadata,omitempty"`
 }
 
 type externalActor struct {
@@ -857,6 +870,15 @@ type slackPostMessageResp struct {
 	TS      string `json:"ts,omitempty"`
 	Channel string `json:"channel,omitempty"`
 	Error   string `json:"error,omitempty"`
+	// Slack reports non-fatal problems here instead of failing the call. The
+	// one that matters to us is "message_truncated": Slack truncates text past
+	// slackMaxMessageLength rather than rejecting it, and returns ok:true, so
+	// the receipt looks perfect. handlePublish stamps the reference marker at
+	// the very end of the text, so this warning is the only wire signal that a
+	// delivered keyed message is no longer findable by its marker.
+	ResponseMetadata struct {
+		Warnings []string `json:"warnings,omitempty"`
+	} `json:"response_metadata,omitempty"`
 }
 
 // Slack files-upload-v2 API types.
@@ -1393,8 +1415,24 @@ func registerAdapter(cfg config) error {
 		Capabilities: adapterCapabilities{
 			SupportsChildConversations: false,
 			SupportsAttachments:        true,
-			// Leave room for the marker handlePublish appends after callers size
-			// keyed messages against this advertised capability.
+			// Reserve room for the marker handlePublish appends to keyed
+			// messages. Slack does not reject text over its ceiling — it
+			// truncates from the end and still answers ok:true, with a
+			// "message_truncated" warning in response_metadata — so the
+			// reservation is not overflow protection, it is what keeps the
+			// trailing marker inside the 40,000 window for callers that size
+			// against this advertised capability. Nothing in gc reads
+			// MaxMessageLength today, so handlePublish also enforces the same
+			// budget itself rather than trusting the advertisement.
+			//
+			// The reservation is uniform because a capability is advertised
+			// once per adapter while the stamp decision is per request: only
+			// keyed publishes are stamped, but there is no way to express
+			// "20 bytes less, but only when you send an idempotency key". So
+			// unkeyed publishes — the majority — also give up the 20 bytes.
+			// Harmless while no gc-side sizer exists; if one lands and the
+			// reserve is worth recovering, it needs a per-call capability,
+			// not a different constant here.
 			MaxMessageLength: slackMaxMessageLength - referenceMarkerOverhead,
 		},
 	})
@@ -1498,8 +1536,14 @@ func (c *publishDedupCache) Put(key string, receipt publishReceipt) {
 // history. The in-process publishDedupCache only survives publishDedupTTL and
 // process restarts, so it cannot provide durable delivery evidence.
 //
-// This must agree with gas-city's messaging_state_reconciler.py:
-// "dr-3msk6.3-test-vector" maps to "50e90a583c36".
+// The digest is a forward contract with the gas-city delivery-state
+// reconciler tracked as dr-3msk6.3, which has not landed:
+// messaging_state_reconciler.py exists at no ref in that repo yet, so this
+// side is currently the only one pinning the format. When the Python reader
+// lands it must embed this same vector verbatim — "dr-3msk6.3-test-vector"
+// maps to "50e90a583c36" — and cite it back by repo, path, and commit. Until
+// then TestReferenceSuffixMatchesCrossLanguageTestVector is the sole
+// executable guard of the agreement.
 func referenceSuffix(idempotencyKey string) string {
 	digest := sha256.Sum256([]byte(idempotencyKey))
 	return hex.EncodeToString(digest[:])[:12]
@@ -1514,8 +1558,47 @@ const (
 )
 
 // referenceMarker is appended to outbound text when an idempotency key is
-// present. Slack message metadata would be preferable, but requires app scopes
-// the adapter does not have.
+// present and the marker is both meaningful and survivable. Slack message
+// metadata would be preferable, but requires app scopes the adapter does not
+// have.
+//
+// Readback contract, for whatever reads these markers back. This comment is
+// the normative statement of the scheme; the CHANGELOG entry and the stamp
+// guard in handlePublish point here rather than restating it, so there is one
+// place to edit when the contract changes:
+//
+//   - Marker absence means UNKNOWN, never undelivered. Everything posted
+//     before this change is unmarked; keyed publishes with empty text are not
+//     stamped; text that cannot fit the marker under Slack's ceiling is posted
+//     unstamped (see handlePublish); and keyed file publishes are outside the
+//     contract entirely — handlePublishFile ignores IdempotencyKey and uploads
+//     without a marker, so a reader sweeping "all keyed outbound" will not
+//     find file deliveries.
+//   - The scan surface is not conversations.history alone. A keyed publish
+//     carrying reply_to_message_id is posted with thread_ts, and history does
+//     not return thread replies — the adapter reads its own threads back
+//     through conversations.replies for exactly this reason (thread_context.go,
+//     company_hydration.go). The one Slack shape that would put a reply in
+//     history is a thread_broadcast copy, and this adapter never sets
+//     reply_broadcast (docs/company-rooms.md, "reply_broadcast is never set"),
+//     so no threaded delivery is reachable from history here. A reader
+//     sweeping history alone therefore finds no marker for any threaded
+//     delivery and, by the rule above, must call that UNKNOWN rather than
+//     undelivered; to resolve those it must walk conversations.replies for
+//     each parent whose reply_count is non-zero.
+//     TestHandlePublishStampsThreadRepliesWhichHistoryDoesNotReturn pins the
+//     thread_ts half of this — the half that lives in this repo.
+//   - A delivered message can still lose its marker after the fact: Slack
+//     truncates text past its ceiling from the end and answers ok:true. The
+//     stamp guard makes that unreachable for stamped messages, and the
+//     publish receipt reports metadata["truncated"]="true" when Slack warns,
+//     so a reader that keeps receipts can tell this case apart from an
+//     unstamped post instead of inferring it.
+//   - The scheme is slack-full-only. The slack-channel sibling accepts keyed
+//     publishes and even derives a key when the caller omits one, but stamps
+//     nothing; slack-mini has no idempotency surface at all. A reader must not
+//     expect markers from either. Porting the marker to slack-channel is
+//     deliberate follow-up work, not an oversight here.
 func referenceMarker(idempotencyKey string) string {
 	return "_ref:" + referenceSuffix(idempotencyKey) + "_"
 }
@@ -1569,8 +1652,60 @@ func handlePublish(cfg config, reg *identityRegistry, userAliases *userAliasMap,
 			Text:     rewrittenText,
 			ThreadTS: req.ReplyToMessageID,
 		}
-		if req.IdempotencyKey != "" {
-			post.Text += "\n\n" + referenceMarker(req.IdempotencyKey)
+		// Stamp only when the marker is both meaningful and survivable.
+		//
+		// Empty text: a keyed publish carrying no text failed loudly at base —
+		// Slack answers no_text, the receipt is Delivered:false with
+		// FailureKind "permanent". Stamping unconditionally posts a
+		// marker-only message, which Slack accepts, converting that visible
+		// failure into Delivered:true plus a real MessageID for a payload that
+		// delivered nothing — and dedup then caches that receipt, so a
+		// legitimate retry on the same key replays "delivered" instead of
+		// re-posting. `gc slack publish --idempotency-key K --body-file <empty
+		// file>` arrives here with exactly that shape, because _load_body
+		// tests the truthiness of the path, not the file contents.
+		//
+		// Over the ceiling: Slack truncates text past slackMaxMessageLength
+		// from the end rather than rejecting it, and the marker is the tail of
+		// the string, so stamping an oversized message delivers a mangled
+		// partial marker that matches nothing on readback. Skipping keeps the
+		// caller's text whole (trimming it to make room would trade their
+		// content for our bookkeeping) and leaves an honest absence, which the
+		// readback contract already requires readers to treat as unknown. That
+		// contract is stated normatively on referenceMarker; this comment only
+		// covers why the stamp is skipped, so the two cannot drift apart.
+		//
+		// Both are measured on rewrittenText because that is what is actually
+		// posted: the alias rewrite can expand @handle into <@U…>, so a caller
+		// that sized itself to the advertised capability can still land over
+		// the budget here. len is bytes while Slack counts characters; for
+		// multibyte text that over-counts, which can only make this skip a
+		// marker that would have fit, never stamp one that will not.
+		//
+		// Only the fit check has a reachable input distinguishing rewrittenText
+		// from req.Text, and the alias-rewrite case in
+		// TestHandlePublishSkipsReferenceMarkerWhenItCannotFitUnderSlackCeiling
+		// pins it. The emptiness check cannot be told apart the same way today:
+		// rewrite returns text unchanged when it is empty, and parseUserAliasMap
+		// rejects any target slackMentionFor does not recognize, so no loadable
+		// alias map can rewrite non-empty text to "". rewrittenText is still the
+		// right operand — it is what gets posted — but that half is defensive,
+		// and a test asserting it would have to hand-build a map the loader
+		// cannot produce, which would pin an unreachable state rather than a
+		// behavior.
+		if req.IdempotencyKey != "" && rewrittenText != "" {
+			if len(rewrittenText)+referenceMarkerOverhead <= slackMaxMessageLength {
+				post.Text += "\n\n" + referenceMarker(req.IdempotencyKey)
+			} else {
+				// rewritten=, not text=: this is the post-rewrite length the
+				// budget was measured against, while the main publish log
+				// below reports the request length under text=. Two adjacent
+				// lines of one request carrying the same label with different
+				// quantities is what makes a grep on text= ambiguous.
+				log.Printf("publish: rewritten=%dch leaves no room for the reference marker (ceiling=%d overhead=%d) idem=%s conv=%s -> posting unstamped; this delivery is not readable back",
+					len(rewrittenText), slackMaxMessageLength, referenceMarkerOverhead,
+					req.IdempotencyKey, req.Conversation.ConversationID)
+			}
 		}
 		identityApplied := ""
 		if reg != nil {
@@ -1581,8 +1716,14 @@ func handlePublish(cfg config, reg *identityRegistry, userAliases *userAliasMap,
 				identityApplied = rec.Username
 			}
 		}
-		log.Printf("publish: conv=%s text=%dch reply_to=%s idem=%s session=%s as=%q mentions_rewritten=%t",
-			req.Conversation.ConversationID, len(req.Text), req.ReplyToMessageID,
+		// text= is the request as received; posted= is what actually reaches
+		// Slack, after the alias rewrite and the marker stamp. They diverge by
+		// the marker on a keyed publish and by the rewrite otherwise, and
+		// posted= is the number that matters at Slack's ceiling — logging only
+		// the pre-stamp length is what would make a length-related outcome
+		// look inexplicable from the logs.
+		log.Printf("publish: conv=%s text=%dch posted=%dch reply_to=%s idem=%s session=%s as=%q mentions_rewritten=%t",
+			req.Conversation.ConversationID, len(req.Text), len(post.Text), req.ReplyToMessageID,
 			req.IdempotencyKey, identitySessionID, identityApplied, rewrittenText != req.Text)
 
 		// Idempotent replay: if this idempotency key already produced a
@@ -1620,6 +1761,28 @@ func handlePublish(cfg config, reg *identityRegistry, userAliases *userAliasMap,
 		default:
 			receipt.Delivered = true
 			receipt.MessageID = slackResp.TS
+			// A delivered-but-truncated message is still ok:true with a real
+			// message_id, so none of the receipt's named fields can show it. On
+			// a keyed publish the marker is the tail of the text, so truncation
+			// is precisely the case where delivery succeeded but readback will
+			// not find it. Log it for the operator and put it on the receipt
+			// for the caller: a log line cannot be observed by the reconciler
+			// this scheme exists to serve, and it is the caller — not this
+			// process — that knows whether the message was keyed. Routed
+			// through metadata because that is the only additive channel gc
+			// actually carries through; see publishReceipt.Metadata.
+			for _, warning := range slackResp.ResponseMetadata.Warnings {
+				if warning != "message_truncated" {
+					continue
+				}
+				log.Printf("publish: slack truncated the posted text (posted=%dch ceiling=%d) idem=%s conv=%s ts=%s -> any reference marker did not survive",
+					len(post.Text), slackMaxMessageLength, req.IdempotencyKey,
+					req.Conversation.ConversationID, slackResp.TS)
+				if receipt.Metadata == nil {
+					receipt.Metadata = map[string]string{}
+				}
+				receipt.Metadata["truncated"] = "true"
+			}
 		}
 		// Remember delivered receipts so a subsequent retry with the same
 		// idempotency key replays this receipt instead of re-posting. Put

--- a/slack-full/adapter/main.go
+++ b/slack-full/adapter/main.go
@@ -1393,7 +1393,9 @@ func registerAdapter(cfg config) error {
 		Capabilities: adapterCapabilities{
 			SupportsChildConversations: false,
 			SupportsAttachments:        true,
-			MaxMessageLength:           40000, // Slack's chat.postMessage limit
+			// Leave room for the marker handlePublish appends after callers size
+			// keyed messages against this advertised capability.
+			MaxMessageLength: slackMaxMessageLength - referenceMarkerOverhead,
 		},
 	})
 	// PathEscape cityName so URL-significant characters cannot alter
@@ -1502,6 +1504,14 @@ func referenceSuffix(idempotencyKey string) string {
 	digest := sha256.Sum256([]byte(idempotencyKey))
 	return hex.EncodeToString(digest[:])[:12]
 }
+
+const (
+	// slackMaxMessageLength is Slack's chat.postMessage ceiling.
+	slackMaxMessageLength = 40000
+	// referenceMarkerOverhead is the two-newline separator plus the fixed-width
+	// marker appended by handlePublish for keyed messages.
+	referenceMarkerOverhead = 2 + len("_ref:") + 12 + len("_")
+)
 
 // referenceMarker is appended to outbound text when an idempotency key is
 // present. Slack message metadata would be preferable, but requires app scopes

--- a/slack-full/adapter/main.go
+++ b/slack-full/adapter/main.go
@@ -1491,6 +1491,25 @@ func (c *publishDedupCache) Put(key string, receipt publishReceipt) {
 	}
 }
 
+// referenceSuffix derives the low-visibility marker embedded in outbound
+// publish text so a later reader can find the exact message in Slack channel
+// history. The in-process publishDedupCache only survives publishDedupTTL and
+// process restarts, so it cannot provide durable delivery evidence.
+//
+// This must agree with gas-city's messaging_state_reconciler.py:
+// "dr-3msk6.3-test-vector" maps to "50e90a583c36".
+func referenceSuffix(idempotencyKey string) string {
+	digest := sha256.Sum256([]byte(idempotencyKey))
+	return hex.EncodeToString(digest[:])[:12]
+}
+
+// referenceMarker is appended to outbound text when an idempotency key is
+// present. Slack message metadata would be preferable, but requires app scopes
+// the adapter does not have.
+func referenceMarker(idempotencyKey string) string {
+	return "_ref:" + referenceSuffix(idempotencyKey) + "_"
+}
+
 func handlePublish(cfg config, reg *identityRegistry, userAliases *userAliasMap, dedup *publishDedupCache) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
@@ -1539,6 +1558,9 @@ func handlePublish(cfg config, reg *identityRegistry, userAliases *userAliasMap,
 			Channel:  req.Conversation.ConversationID,
 			Text:     rewrittenText,
 			ThreadTS: req.ReplyToMessageID,
+		}
+		if req.IdempotencyKey != "" {
+			post.Text += "\n\n" + referenceMarker(req.IdempotencyKey)
 		}
 		identityApplied := ""
 		if reg != nil {

--- a/slack-full/adapter/main_test.go
+++ b/slack-full/adapter/main_test.go
@@ -810,14 +810,18 @@ func TestHandlePublishDedupesOnIdempotencyKey(t *testing.T) {
 	}
 	second := publish()
 	if second.Code != http.StatusOK {
-		t.Fatalf("retry status = %d, want 200 (body=%q)", second.Code, second.Body.String())
+		t.Fatalf("first retry status = %d, want 200 (body=%q)", second.Code, second.Body.String())
+	}
+	third := publish()
+	if third.Code != http.StatusOK {
+		t.Fatalf("second retry status = %d, want 200 (body=%q)", third.Code, third.Body.String())
 	}
 
 	if posts != 1 {
 		t.Fatalf("Slack chat.postMessage called %d times, want 1 (retry must not re-post)", posts)
 	}
-	// Both responses must carry the same delivered receipt + message id.
-	for _, rec := range []*httptest.ResponseRecorder{first, second} {
+	// All responses must carry the same delivered receipt + message id.
+	for _, rec := range []*httptest.ResponseRecorder{first, second, third} {
 		var got publishReceipt
 		if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
 			t.Fatalf("decode receipt %q: %v", rec.Body.String(), err)
@@ -825,6 +829,14 @@ func TestHandlePublishDedupesOnIdempotencyKey(t *testing.T) {
 		if !got.Delivered || got.MessageID != ts {
 			t.Errorf("receipt = %+v, want delivered with message_id %q", got, ts)
 		}
+	}
+
+	// Dedup is scoped to the caller-supplied key, not the conversation or text.
+	distinctBody := strings.Replace(body, `"idempotency_key":"k-1"`, `"idempotency_key":"k-2"`, 1)
+	req := httptest.NewRequest(http.MethodPost, "/publish", strings.NewReader(distinctBody))
+	handler(httptest.NewRecorder(), req)
+	if posts != 2 {
+		t.Fatalf("Slack chat.postMessage called %d times after a distinct idempotency key, want 2", posts)
 	}
 }
 
@@ -888,6 +900,94 @@ func TestPublishDedupCache(t *testing.T) {
 	clock = clock.Add(2*time.Minute + time.Second)
 	if _, ok := c.Get("k"); ok {
 		t.Error("entry should have expired past its TTL")
+	}
+}
+
+// TestReferenceSuffixMatchesCrossLanguageTestVector asserts the same
+// (key, suffix) pair as gas-city's messaging state reconciler.
+func TestReferenceSuffixMatchesCrossLanguageTestVector(t *testing.T) {
+	const key = "dr-3msk6.3-test-vector"
+	const want = "50e90a583c36"
+	if got := referenceSuffix(key); got != want {
+		t.Errorf("referenceSuffix(%q) = %q, want %q (must match the Python-side test vector)", key, got, want)
+	}
+}
+
+func TestReferenceSuffixIsDeterministicAndKeySensitive(t *testing.T) {
+	if referenceSuffix("a") != referenceSuffix("a") {
+		t.Error(`referenceSuffix("a") produced different output on two calls; want deterministic`)
+	}
+	if referenceSuffix("a") == referenceSuffix("b") {
+		t.Error(`referenceSuffix("a") == referenceSuffix("b"); want distinct keys to derive distinct suffixes`)
+	}
+}
+
+// TestHandlePublishAppendsReferenceMarkerWhenIdempotencyKeySet verifies that
+// a keyed publish can be located later in Slack channel history.
+func TestHandlePublishAppendsReferenceMarkerWhenIdempotencyKeySet(t *testing.T) {
+	reg, err := newIdentityRegistry(filepath.Join(t.TempDir(), "id.json"))
+	if err != nil {
+		t.Fatalf("newIdentityRegistry: %v", err)
+	}
+
+	origBase := slackAPIBase
+	t.Cleanup(func() { slackAPIBase = origBase })
+	var captured slackPostMessageReq
+	fakeSlack := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode Slack request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true,"ts":"1.2"}`))
+	}))
+	t.Cleanup(fakeSlack.Close)
+	slackAPIBase = fakeSlack.URL
+
+	cfg := config{slackBotToken: "xoxb-test"}
+	body := `{"session_id":"gc-pl-1","conversation":{"conversation_id":"C1"},"text":"hello","idempotency_key":"dr-3msk6.3-test-vector"}`
+	req := httptest.NewRequest(http.MethodPost, "/publish", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	handlePublish(cfg, reg, nil, newPublishDedupCache(publishDedupTTL))(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body=%q)", rec.Code, rec.Body.String())
+	}
+	const wantText = "hello\n\n_ref:50e90a583c36_"
+	if captured.Text != wantText {
+		t.Errorf("posted text = %q, want %q", captured.Text, wantText)
+	}
+}
+
+func TestHandlePublishOmitsReferenceMarkerWhenNoIdempotencyKey(t *testing.T) {
+	reg, err := newIdentityRegistry(filepath.Join(t.TempDir(), "id.json"))
+	if err != nil {
+		t.Fatalf("newIdentityRegistry: %v", err)
+	}
+
+	origBase := slackAPIBase
+	t.Cleanup(func() { slackAPIBase = origBase })
+	var captured slackPostMessageReq
+	fakeSlack := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode Slack request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true,"ts":"1.2"}`))
+	}))
+	t.Cleanup(fakeSlack.Close)
+	slackAPIBase = fakeSlack.URL
+
+	cfg := config{slackBotToken: "xoxb-test"}
+	body := `{"session_id":"gc-pl-1","conversation":{"conversation_id":"C1"},"text":"hello"}`
+	req := httptest.NewRequest(http.MethodPost, "/publish", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	handlePublish(cfg, reg, nil, newPublishDedupCache(publishDedupTTL))(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body=%q)", rec.Code, rec.Body.String())
+	}
+	if captured.Text != "hello" {
+		t.Errorf("posted text = %q, want %q (no marker without an idempotency key)", captured.Text, "hello")
 	}
 }
 

--- a/slack-full/adapter/main_test.go
+++ b/slack-full/adapter/main_test.go
@@ -991,6 +991,61 @@ func TestHandlePublishOmitsReferenceMarkerWhenNoIdempotencyKey(t *testing.T) {
 	}
 }
 
+func TestReferenceMarkerOverheadMatchesActualAppend(t *testing.T) {
+	appended := "\n\n" + referenceMarker("any-key-of-any-length-at-all")
+	if len(appended) != referenceMarkerOverhead {
+		t.Fatalf("referenceMarkerOverhead = %d, but handlePublish appends %d bytes (%q)",
+			referenceMarkerOverhead, len(appended), appended)
+	}
+	short := "\n\n" + referenceMarker("k")
+	if len(short) != len(appended) {
+		t.Fatalf("marker length varies with key length: %d vs %d", len(short), len(appended))
+	}
+}
+
+func TestAdvertisedMaxMessageLengthLeavesRoomForMarker(t *testing.T) {
+	advertised := slackMaxMessageLength - referenceMarkerOverhead
+	stamped := advertised + len("\n\n"+referenceMarker("dr-3msk6.3-test-vector"))
+	if stamped > slackMaxMessageLength {
+		t.Fatalf("a message at the advertised limit (%d) is %d after stamping, over Slack's %d ceiling",
+			advertised, stamped, slackMaxMessageLength)
+	}
+}
+
+func TestRegisterAdapterAdvertisesMarkerSafeMaxMessageLength(t *testing.T) {
+	requestCh := make(chan adapterRegisterRequest, 1)
+	gcStub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var got adapterRegisterRequest
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Errorf("decode registration request: %v", err)
+		} else {
+			requestCh <- got
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(gcStub.Close)
+
+	cfg := config{
+		gcAPIBase: gcStub.URL,
+		cityName:  "test-city",
+		provider:  "slack",
+		accountID: "T0",
+	}
+	if err := registerAdapter(cfg); err != nil {
+		t.Fatalf("registerAdapter: %v", err)
+	}
+
+	select {
+	case got := <-requestCh:
+		want := slackMaxMessageLength - referenceMarkerOverhead
+		if got.Capabilities.MaxMessageLength != want {
+			t.Fatalf("registered MaxMessageLength = %d, want %d", got.Capabilities.MaxMessageLength, want)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("registerAdapter did not POST registration within 2s")
+	}
+}
+
 func TestParseHandlePrefix(t *testing.T) {
 	const prefix = "@oversight."
 	cases := []struct {

--- a/slack-full/adapter/main_test.go
+++ b/slack-full/adapter/main_test.go
@@ -991,6 +991,335 @@ func TestHandlePublishOmitsReferenceMarkerWhenNoIdempotencyKey(t *testing.T) {
 	}
 }
 
+// TestHandlePublishOmitsReferenceMarkerForEmptyText pins the regression the
+// marker would otherwise introduce. A keyed publish carrying no text fails
+// loudly at Slack (no_text -> permanent). Stamping unconditionally turns it
+// into a marker-only message Slack accepts, so the receipt claims Delivered
+// for a payload that delivered nothing — and dedup caches that receipt, so a
+// legitimate retry replays the lie instead of re-posting.
+func TestHandlePublishOmitsReferenceMarkerForEmptyText(t *testing.T) {
+	reg, err := newIdentityRegistry(filepath.Join(t.TempDir(), "id.json"))
+	if err != nil {
+		t.Fatalf("newIdentityRegistry: %v", err)
+	}
+
+	origBase := slackAPIBase
+	t.Cleanup(func() { slackAPIBase = origBase })
+	var captured slackPostMessageReq
+	fakeSlack := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode Slack request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		// Emulate Slack rather than accepting anything: a blank message is
+		// rejected. Without this the test could not tell "posted nothing"
+		// apart from "posted a marker-only message".
+		if captured.Text == "" {
+			_, _ = w.Write([]byte(`{"ok":false,"error":"no_text"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"ok":true,"ts":"1.2"}`))
+	}))
+	t.Cleanup(fakeSlack.Close)
+	slackAPIBase = fakeSlack.URL
+
+	cfg := config{slackBotToken: "xoxb-test"}
+	body := `{"session_id":"gc-pl-1","conversation":{"conversation_id":"C1"},"text":"","idempotency_key":"dr-3msk6.3-test-vector"}`
+	req := httptest.NewRequest(http.MethodPost, "/publish", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	handlePublish(cfg, reg, nil, newPublishDedupCache(publishDedupTTL))(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body=%q)", rec.Code, rec.Body.String())
+	}
+	if captured.Text != "" {
+		t.Errorf("posted text = %q, want %q: an empty keyed publish must not become a marker-only post", captured.Text, "")
+	}
+	var receipt publishReceipt
+	if err := json.Unmarshal(rec.Body.Bytes(), &receipt); err != nil {
+		t.Fatalf("decode receipt: %v (body=%q)", err, rec.Body.String())
+	}
+	if receipt.Delivered {
+		t.Errorf("receipt.Delivered = true for an empty-text keyed publish (message_id=%q); want false, nothing was delivered",
+			receipt.MessageID)
+	}
+	if receipt.FailureKind != "permanent" {
+		t.Errorf("receipt.FailureKind = %q, want %q: the base failure must stay visible", receipt.FailureKind, "permanent")
+	}
+}
+
+// TestHandlePublishSkipsReferenceMarkerWhenItCannotFitUnderSlackCeiling pins
+// the truncation boundary. Slack truncates text past its ceiling from the end
+// and still answers ok:true, and the marker is the tail of the text — so
+// stamping past the budget would deliver a mangled partial marker that matches
+// nothing on readback, with a receipt that looks perfect. Skipping keeps the
+// caller's text whole and leaves an honest absence instead.
+func TestHandlePublishSkipsReferenceMarkerWhenItCannotFitUnderSlackCeiling(t *testing.T) {
+	const key = "dr-3msk6.3-test-vector"
+	marker := "\n\n" + referenceMarker(key)
+
+	// atCapability is the largest request text that still leaves room for the
+	// marker — the value registerAdapter advertises.
+	const atCapability = slackMaxMessageLength - referenceMarkerOverhead
+	// The rewrite case sizes itself to atCapability too, so the pre-rewrite
+	// text fits the budget and the post-rewrite text does not.
+	rewriteHead := strings.Repeat("x", atCapability-len(" @bob"))
+
+	cases := []struct {
+		name string
+		// aliases is nil everywhere but the rewrite case, matching an install
+		// that has not curated slack-user-aliases.json.
+		aliases *userAliasMap
+		text    string
+		// wantBody is the caller's content as it must reach Slack, ahead of any
+		// marker: the request text, or its rewrite. Spelled out rather than
+		// computed by calling rewrite() so a mutation to the rewrite cannot
+		// move this expectation along with the behavior it is checking.
+		wantBody   string
+		wantMarker bool
+	}{
+		{
+			name:       "at the advertised capability",
+			text:       strings.Repeat("x", atCapability),
+			wantBody:   strings.Repeat("x", atCapability),
+			wantMarker: true,
+		},
+		{
+			name:       "one byte over the advertised capability",
+			text:       strings.Repeat("x", atCapability+1),
+			wantBody:   strings.Repeat("x", atCapability+1),
+			wantMarker: false,
+		},
+		{
+			name:       "at slack's raw ceiling",
+			text:       strings.Repeat("x", slackMaxMessageLength),
+			wantBody:   strings.Repeat("x", slackMaxMessageLength),
+			wantMarker: false,
+		},
+		{
+			// The budget has to be measured on what is posted, not on what was
+			// requested. This text sits exactly at the advertised capability,
+			// so a fit check reading len(req.Text) stamps it — but "@bob" (4
+			// bytes) rewrites to "<@U012ABCDEF>" (13), and the stamped result
+			// would reach Slack at 40009 bytes, past the ceiling, where the
+			// marker is exactly what gets truncated away. Every other case
+			// passes nil aliases, which makes rewrittenText == req.Text, so
+			// this is the only row that can tell the two operands apart.
+			name:       "at the advertised capability but over it after the alias rewrite",
+			aliases:    &userAliasMap{byHandle: map[string]string{"bob": "<@U012ABCDEF>"}},
+			text:       rewriteHead + " @bob",
+			wantBody:   rewriteHead + " <@U012ABCDEF>",
+			wantMarker: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reg, err := newIdentityRegistry(filepath.Join(t.TempDir(), "id.json"))
+			if err != nil {
+				t.Fatalf("newIdentityRegistry: %v", err)
+			}
+
+			origBase := slackAPIBase
+			t.Cleanup(func() { slackAPIBase = origBase })
+			var captured slackPostMessageReq
+			fakeSlack := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+					t.Errorf("decode Slack request: %v", err)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"ok":true,"ts":"1.2"}`))
+			}))
+			t.Cleanup(fakeSlack.Close)
+			slackAPIBase = fakeSlack.URL
+
+			body, err := json.Marshal(publishRequest{
+				SessionID:      "gc-pl-1",
+				Conversation:   conversationRef{ConversationID: "C1"},
+				Text:           tc.text,
+				IdempotencyKey: key,
+			})
+			if err != nil {
+				t.Fatalf("marshal publish request: %v", err)
+			}
+			req := httptest.NewRequest(http.MethodPost, "/publish", bytes.NewReader(body))
+			rec := httptest.NewRecorder()
+			cfg := config{slackBotToken: "xoxb-test"}
+			handlePublish(cfg, reg, tc.aliases, newPublishDedupCache(publishDedupTTL))(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200 (body=%q)", rec.Code, rec.Body.String())
+			}
+			gotMarker := strings.HasSuffix(captured.Text, marker)
+			if gotMarker != tc.wantMarker {
+				t.Errorf("request text of %d bytes: marker stamped = %t, want %t (posted %d bytes)",
+					len(tc.text), gotMarker, tc.wantMarker, len(captured.Text))
+			}
+			// The caller's content is never trimmed to make room, whichever
+			// way the stamp decision went. On the rewrite case this also
+			// catches a rewrite that silently failed to apply, which would
+			// otherwise leave the row measuring nothing.
+			if !strings.HasPrefix(captured.Text, tc.wantBody) {
+				t.Errorf("request text of %d bytes: posted text does not start with the caller's content (%d bytes posted, %d expected ahead of any marker); want it preserved verbatim",
+					len(tc.text), len(captured.Text), len(tc.wantBody))
+			}
+			if len(captured.Text) > slackMaxMessageLength {
+				t.Errorf("request text of %d bytes: posted %d bytes, over Slack's %d ceiling — the marker would be truncated away",
+					len(tc.text), len(captured.Text), slackMaxMessageLength)
+			}
+		})
+	}
+}
+
+// TestSlackPostMessageRespParsesTruncationWarning pins the response_metadata
+// tags. Slack signals a delivered-but-truncated message only here, with
+// ok:true, so a wrong tag would silently discard the one wire signal that a
+// keyed delivery lost its marker.
+func TestSlackPostMessageRespParsesTruncationWarning(t *testing.T) {
+	const body = `{"ok":true,"ts":"1.2","response_metadata":{"warnings":["message_truncated"]}}`
+	var resp slackPostMessageResp
+	if err := json.Unmarshal([]byte(body), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !resp.OK || resp.TS != "1.2" {
+		t.Fatalf("resp ok=%t ts=%q, want ok with ts 1.2", resp.OK, resp.TS)
+	}
+	got := resp.ResponseMetadata.Warnings
+	if len(got) != 1 || got[0] != "message_truncated" {
+		t.Errorf("ResponseMetadata.Warnings = %#v, want [message_truncated]", got)
+	}
+}
+
+// gcWirePublishReceipt restates, with gc's own tags, the four keys of gc's
+// wirePublishReceipt (gascity internal/extmsg/http_adapter.go:140-157) that
+// this test reasons about. gc unmarshals the /publish response body into that
+// fixed six-field shim and copies its fields one by one into the public
+// PublishReceipt; every key outside the six is discarded at gc's boundary. The
+// two omitted here — `conversation` and `retry_after` — cross the same way and
+// are not at issue. Decoding into the adapter's own publishReceipt instead
+// would prove nothing about that boundary: both sides would share one set of
+// tags, so a rename or a differently-shaped field would stay green while gc
+// silently dropped the value.
+type gcWirePublishReceipt struct {
+	MessageID   string            `json:"message_id,omitempty"`
+	Delivered   bool              `json:"delivered"`
+	FailureKind string            `json:"failure_kind,omitempty"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
+}
+
+// TestHandlePublishSurfacesSlackTruncationOnTheReceipt witnesses the diagnosis
+// signal end to end. TestSlackPostMessageRespParsesTruncationWarning covers
+// only the decode of Slack's warning; nothing pinned what the adapter then does
+// with it, and a log line is not observable by the reconciler this marker
+// scheme exists to serve.
+func TestHandlePublishSurfacesSlackTruncationOnTheReceipt(t *testing.T) {
+	reg, err := newIdentityRegistry(filepath.Join(t.TempDir(), "id.json"))
+	if err != nil {
+		t.Fatalf("newIdentityRegistry: %v", err)
+	}
+
+	origBase := slackAPIBase
+	t.Cleanup(func() { slackAPIBase = origBase })
+	fakeSlack := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Slack's delivered-but-truncated shape: ok, a real ts, and the
+		// warning as the only signal that the tail is gone.
+		_, _ = w.Write([]byte(`{"ok":true,"ts":"1.2","response_metadata":{"warnings":["message_truncated"]}}`))
+	}))
+	t.Cleanup(fakeSlack.Close)
+	slackAPIBase = fakeSlack.URL
+
+	body := `{"session_id":"gc-pl-1","conversation":{"conversation_id":"C1"},"text":"hi","idempotency_key":"dr-3msk6.3-test-vector"}`
+	req := httptest.NewRequest(http.MethodPost, "/publish", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	cfg := config{slackBotToken: "xoxb-test"}
+	handlePublish(cfg, reg, nil, newPublishDedupCache(publishDedupTTL))(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body=%q)", rec.Code, rec.Body.String())
+	}
+	var receipt gcWirePublishReceipt
+	if err := json.Unmarshal(rec.Body.Bytes(), &receipt); err != nil {
+		t.Fatalf("decode receipt through gc's shim: %v (body=%q)", err, rec.Body.String())
+	}
+	if !receipt.Delivered || receipt.MessageID != "1.2" {
+		t.Fatalf("receipt delivered=%t message_id=%q, want a delivered receipt with ts 1.2: truncation does not fail the publish",
+			receipt.Delivered, receipt.MessageID)
+	}
+	if receipt.Metadata["truncated"] != "true" {
+		t.Errorf(`receipt metadata = %v, want metadata["truncated"]="true": Slack warned that it truncated the post, and the receipt is the only place a caller can see that its marker did not survive`,
+			receipt.Metadata)
+	}
+
+	// The signal must travel by the one route gc carries. A top-level
+	// "truncated" key decodes cleanly on this side and is then dropped by gc's
+	// shim, which is a wire-contract change that buys nothing.
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(rec.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("decode receipt as raw json: %v", err)
+	}
+	if _, ok := raw["truncated"]; ok {
+		t.Errorf("receipt body carries a top-level \"truncated\" key (%q); gc decodes /publish into a fixed shim that has no such field, so it is invisible there — report truncation under metadata instead",
+			rec.Body.String())
+	}
+}
+
+// TestHandlePublishStampsThreadRepliesWhichHistoryDoesNotReturn pins the half
+// of the readback contract's scan-surface rule that lives in this repo: a keyed
+// publish answering another message is posted into a thread, and Slack's
+// conversations.history does not return thread replies. A reader sweeping
+// history alone therefore cannot see this marker — the contract on
+// referenceMarker tells it to walk conversations.replies as well, and that
+// instruction is only correct while this stays true.
+func TestHandlePublishStampsThreadRepliesWhichHistoryDoesNotReturn(t *testing.T) {
+	const key = "dr-3msk6.3-test-vector"
+	const parentTS = "1699999999.000100"
+
+	reg, err := newIdentityRegistry(filepath.Join(t.TempDir(), "id.json"))
+	if err != nil {
+		t.Fatalf("newIdentityRegistry: %v", err)
+	}
+
+	origBase := slackAPIBase
+	t.Cleanup(func() { slackAPIBase = origBase })
+	var captured slackPostMessageReq
+	fakeSlack := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode Slack request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true,"ts":"1699999999.000200"}`))
+	}))
+	t.Cleanup(fakeSlack.Close)
+	slackAPIBase = fakeSlack.URL
+
+	body, err := json.Marshal(publishRequest{
+		SessionID:        "gc-pl-1",
+		Conversation:     conversationRef{ConversationID: "C1"},
+		Text:             "threaded reply",
+		ReplyToMessageID: parentTS,
+		IdempotencyKey:   key,
+	})
+	if err != nil {
+		t.Fatalf("marshal publish request: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/publish", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	cfg := config{slackBotToken: "xoxb-test"}
+	handlePublish(cfg, reg, nil, newPublishDedupCache(publishDedupTTL))(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body=%q)", rec.Code, rec.Body.String())
+	}
+	if captured.ThreadTS != parentTS {
+		t.Errorf("posted thread_ts = %q, want %q: reply_to_message_id must post into the thread, which is what puts the marker outside conversations.history",
+			captured.ThreadTS, parentTS)
+	}
+	if !strings.HasSuffix(captured.Text, "\n\n"+referenceMarker(key)) {
+		t.Errorf("posted text = %q, want it to end with the reference marker: a threaded keyed delivery is stamped like any other, so the contract's replies-sweep instruction has something to find",
+			captured.Text)
+	}
+}
+
 func TestReferenceMarkerOverheadMatchesActualAppend(t *testing.T) {
 	appended := "\n\n" + referenceMarker("any-key-of-any-length-at-all")
 	if len(appended) != referenceMarkerOverhead {


### PR DESCRIPTION
## What this fixes

When the adapter posts to Slack, nothing afterwards can confirm the message
landed. `publishDedupCache` is in-process, so it holds a receipt for
`publishDedupTTL` and loses everything on restart, and a sweep that wants to
verify delivery has no way to find a specific message in channel history.

This stamps a short reference marker on outbound publishes that carry an
idempotency key, so a later reader can locate that exact message in Slack
itself:

```
_ref:50e90a583c36_
```

The marker is the first 12 hex characters of the SHA-256 of the idempotency
key, appended after a blank line. Messages with no idempotency key are
unchanged.

## Why not message metadata

Slack's message metadata would be the right home for this, but it requires app
scopes the adapter does not request. Text is what we can write with the scopes
an installed slack-full app already has.

## The second commit

Appending the marker makes an outbound message longer than the caller sized it,
so `registerAdapter` now advertises `40000 - 20 = 39980` as
`MaxMessageLength`. Callers that respect the advertised capability then produce
a post that still fits after stamping.

Two consequences worth stating rather than leaving to be discovered:

- Unkeyed messages get no marker but are still advertised the reduced ceiling.
  That costs 20 characters out of 40,000 and keeps one number for callers to
  reason about, which seemed better than a conditional limit.
- A caller that ignores the advertised capability can still hand us text that
  does not leave room for the marker. Slack **truncates** an over-length
  `chat.postMessage` from the end rather than rejecting it, so a blind append
  there would deliver the message with the marker silently cut off — the one
  failure mode this change exists to prevent, since a reader would then find no
  marker on a message that was in fact delivered. The reservation exists so
  well-behaved callers never reach that band; the third commit handles the
  callers that do.

## The third commit (maintainer adoption fixup)

Applied during maintainer review, on top of the contributor commits:

- The marker is no longer stamped when the text is empty. A keyed publish with
  empty text previously took the stamping path and returned `Delivered: true`
  for a message Slack never accepted, which also poisoned the dedup cache.
  Empty text now flows the base `no_text` → `permanent` path.
- The marker is no longer stamped when it would not fit
  (`len(rewrittenText)+referenceMarkerOverhead > slackMaxMessageLength`). The
  caller's text is posted unstamped and a line is logged; caller content is
  never trimmed to make room for the marker.
- Slack's truncation warning (`ResponseMetadata`) is parsed and logged, so a
  delivered-but-truncated message is visible rather than silent.
- `referenceSuffix`'s doc comment states the reader-side reconciler has not
  landed yet, instead of describing the agreement in the present tense.

Marker absence therefore reads as *unknown*, never as *undelivered*.

## Cross-system contract

`referenceSuffix` has to agree with the reader on the other side. The doc
comment pins the agreement with a test vector
(`dr-3msk6.3-test-vector` maps to `50e90a583c36`) so a future change to the
digest or the truncation width fails loudly rather than silently producing
markers nobody can find.

## Testing

`go build ./...`, `go vet ./...`, `go test -count=1 ./...` and
`go test -race ./...` all pass in `slack-full/adapter`.

The new tests were checked against mutations rather than only run green. Each
mutation below was applied to the production code, the suite was run, and the
file was restored and re-verified by checksum:

| mutation | expected red | result |
| --- | --- | --- |
| marker separator `"\n\n"` to `"\n"` | marker test | `TestHandlePublishAppendsReferenceMarkerWhenIdempotencyKeySet` failed |
| advertised max back to `slackMaxMessageLength` | capability test | `TestRegisterAdapterAdvertisesMarkerSafeMaxMessageLength` failed, got 40000 want 39980 |
| dedup `Get` returns `false` | dedup test | `TestHandlePublishDedupesOnIdempotencyKey` failed, Slack called 3x not 1x |
| append guard forced false | marker test | `TestHandlePublishAppendsReferenceMarkerWhenIdempotencyKeySet` failed |
| append guard forced true | omission test | `TestHandlePublishOmitsReferenceMarkerWhenNoIdempotencyKey` failed |

The last two cover the guard in both directions, so "marker present when keyed"
and "marker absent when unkeyed" are each independently asserted.

The maintainer fixup's two new guards were mutation-checked the same way during
review: dropping `&& rewrittenText != ""` reddens
`TestHandlePublishOmitsReferenceMarkerForEmptyText`, and forcing the fit check
true reddens the two ceiling subtests while the at-capability case stays green.

## Scope

Three files: `slack-full/adapter/main.go`, `slack-full/adapter/main_test.go`,
and `slack-full/CHANGELOG.md`. No change to routing, threading, credentials, or
the dedup cache's own behaviour, which was already present upstream.
