### PR TITLE
pr-pipeline: refuse an oversized PR review before spending, non-retryably

### DIFF
--- a/pr-pipeline/README.md
+++ b/pr-pipeline/README.md
@@ -94,7 +94,13 @@ Scorecard against 11 categories (behavioral correctness, contract
 fidelity, blast radius, concurrency, error handling, security, resource
 lifecycle, release safety, test evidence, architectural consistency,
 debuggability). Pre-flags 7 recurring fixup themes. Verdict: `block`,
-`request_changes`, or `approve`.
+`request_changes`, `approve`, or `too_large`.
+
+A PR whose additions+deletions exceed `--max-diff-lines` (default 5000, `0`
+disables) is refused before any agent is started, exiting 3 and recording
+`verdict: too_large`. That refusal describes the request, not a failed run:
+retrying it unchanged cannot succeed and spends the same budget again, so
+supervising loops must not treat it as retryable.
 
 ### Run the pre-push gate
 

--- a/pr-pipeline/commands/pr/review/help.md
+++ b/pr-pipeline/commands/pr/review/help.md
@@ -31,7 +31,20 @@ Direct sling (skip this command):
 
 Output:
   Report at <repo-root>/.gc/pr-pipeline/reviews/pr-<N>.md
-  Root-bead notes record `verdict:` (block | request_changes | approve).
+  Root-bead notes record `verdict:` (block | request_changes | approve |
+  too_large). `too_large` means the PR exceeded --max-diff-lines and was
+  refused WITHOUT being reviewed; it is not a judgement about the code.
+
+Budget:
+  --max-diff-lines <n>   Refuse a PR whose additions+deletions exceed <n>,
+                         before any agent is started. Default 5000; 0 disables.
+                         Env: GC_PR_MAX_DIFF_LINES. Exits 3 on refusal.
+                         Exit 3 describes the REQUEST, not a failed run: an
+                         identical retry cannot succeed and costs the same
+                         budget again. Dead-letter it, do not retry it.
+                         The formula re-measures the fetched diff as well, so
+                         a PR that grows after the check is still refused
+                         before the diff reaches the model.
 
 Decision policy (mechanical):
   Unresolved blocker in cat 1-4   → verdict block

--- a/pr-pipeline/commands/pr/review/run.sh
+++ b/pr-pipeline/commands/pr/review/run.sh
@@ -51,6 +51,8 @@ esac
 
 RIG=""
 AGENT="polecat"
+# Keep in step with [vars.max_diff_lines] in formulas/mol-pr-review.formula.toml.
+MAX_DIFF_LINES="${GC_PR_MAX_DIFF_LINES:-5000}"
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -58,6 +60,8 @@ while [ $# -gt 0 ]; do
         --rig=*)      RIG="${1#--rig=}"; shift ;;
         --agent)      AGENT="$2"; shift 2 ;;
         --agent=*)    AGENT="${1#--agent=}"; shift ;;
+        --max-diff-lines)   MAX_DIFF_LINES="$2"; shift 2 ;;
+        --max-diff-lines=*) MAX_DIFF_LINES="${1#--max-diff-lines=}"; shift ;;
         *)
             echo "gc pr-pipeline pr review: unknown argument: $1" >&2
             exit 2
@@ -79,4 +83,53 @@ if ! command -v gc >/dev/null 2>&1; then
     exit 1
 fi
 
-exec gc sling "$RIG/$AGENT" mol-pr-review --formula --var "pr=$PR"
+# --- Budget preflight -------------------------------------------------------
+# Refuse an oversized PR HERE, before `gc sling` starts an agent. This is the
+# only point in the pipeline that is genuinely pre-spend: once the sling runs,
+# a model session exists and step 1 has already read the PR metadata.
+#
+# The formula carries the same check as defence in depth for direct slings that
+# bypass this command, but the formula's copy cannot be pre-spend by
+# construction -- it executes inside the very session whose cost it is trying
+# to avoid.
+#
+# A malformed limit REFUSES rather than falling through. The earlier draft
+# interpolated this value straight into a `[` test, where a non-numeric value
+# made the test error and the oversized PR proceed -- a guard that fails open
+# on bad configuration is worse than no guard, because it reads as protection.
+case "$MAX_DIFF_LINES" in
+    ''|*[!0-9]*)
+        echo "gc pr-pipeline pr review: --max-diff-lines must be a non-negative integer (got: $MAX_DIFF_LINES)" >&2
+        exit 2
+        ;;
+esac
+
+if [ "$MAX_DIFF_LINES" -ne 0 ]; then
+    if ! PR_SIZE=$(gh pr view "$PR" --json additions,deletions,changedFiles \
+                     --jq '"\(.additions + .deletions) \(.changedFiles)"' 2>/dev/null); then
+        echo "gc pr-pipeline pr review: could not read PR size for #$PR, refusing" >&2
+        echo "  rather than reviewing on an unknown budget. An unreadable size is not zero." >&2
+        exit 1
+    fi
+    PR_LINES="${PR_SIZE%% *}"
+    PR_FILES="${PR_SIZE##* }"
+    case "$PR_LINES" in
+        ''|*[!0-9]*)
+            echo "gc pr-pipeline pr review: PR size did not parse as a number ('$PR_LINES'), refusing" >&2
+            exit 1
+            ;;
+    esac
+    if [ "$PR_LINES" -gt "$MAX_DIFF_LINES" ]; then
+        echo "gc pr-pipeline pr review: REFUSED, PR #$PR changes $PR_LINES lines across $PR_FILES files," >&2
+        echo "  over the max-diff-lines budget of $MAX_DIFF_LINES. No agent was started and no model" >&2
+        echo "  budget was spent." >&2
+        echo "" >&2
+        echo "  This describes the REQUEST, not a failed run: retrying it unchanged cannot succeed" >&2
+        echo "  and costs the same budget again. Split the PR, review a subset of paths, or raise" >&2
+        echo "  the budget deliberately with --max-diff-lines <new-limit>." >&2
+        exit 3
+    fi
+fi
+
+exec gc sling "$RIG/$AGENT" mol-pr-review --formula \
+    --var "pr=$PR" --var "max_diff_lines=$MAX_DIFF_LINES"

--- a/pr-pipeline/formulas/mol-pr-review.formula.toml
+++ b/pr-pipeline/formulas/mol-pr-review.formula.toml
@@ -26,7 +26,9 @@ writes a structured scorecard to `.gc/pr-pipeline/reviews/pr-<N>.md`.
 1. Caller slings with `--var pr=<url-or-number>`
 2. Agent works through 4 sequential steps
 3. Scorecard report written
-4. Root-bead notes record `verdict:` (block | request_changes | approve)
+4. Root-bead notes record `verdict:` (block | request_changes | approve |
+   too_large, the last meaning the PR was refused unreviewed on budget, and
+   is NOT a judgement about the code)
 5. Agent exits — no fixes are applied
 
 Apply fixes by re-iterating the development loop, not by extending this
@@ -38,7 +40,7 @@ formula.
 |-----------|--------|
 | PR does not exist | gh fails; record error, close bead |
 | PR has no diff | Note in report; verdict approve |
-| Diff is too large to fully analyze | Note coverage, finish what fits |"""
+| Diff exceeds `max_diff_lines` | REFUSE in step 1, before reading the diff. Record `verdict: too_large`, close the bead, stop. Never retry, see Budget refusal |"""
 formula = "mol-pr-review"
 version = 1
 
@@ -46,6 +48,14 @@ version = 1
 [vars.pr]
 description = "PR URL (https://github.com/owner/repo/pull/N) or bare integer in current repo"
 required = true
+
+[vars.max_diff_lines]
+description = """Refuse to review a PR whose additions+deletions exceed this,
+before spending any model budget. 0 disables the guard. Raising it is a
+deliberate act: the cost of a review scales with the diff, and the failure
+mode it prevents is an expensive LATE failure that retry loops re-spend."""
+required = false
+default = "5000"
 
 [[steps]]
 id = "intake"
@@ -85,12 +95,110 @@ gh pr view <N> --repo <repo> --json \\
   changedFiles,mergeable,url,state,labels
 ```
 
+### Budget refusal, check the size BEFORE reading the diff
+
+The metadata above already carries `additions`, `deletions` and `changedFiles`.
+Compare them to `{{max_diff_lines}}` now, while nothing has been spent yet.
+
+```bash
+# Read the sizes directly rather than reusing a variable from the fetch above:
+# a guard that depends on an unset name silently computes 0 and can never fire.
+PR_LINES=$(gh pr view <N> --repo <repo> --json additions,deletions \
+             --jq '.additions + .deletions')
+PR_FILES=$(gh pr view <N> --repo <repo> --json changedFiles --jq '.changedFiles')
+case "$PR_LINES" in
+    ''|*[!0-9]*)
+        echo "Could not read PR size ('$PR_LINES'), refusing rather than"
+        echo "reviewing on an unknown budget. An unreadable size is not zero."
+        gc bd update "$ROOT_ID" --notes "verdict: too_large"
+        gc bd close "$ROOT_ID" --reason "PR size unreadable; refused without reviewing"
+        exit 0 ;;
+esac
+MAX_LINES="{{max_diff_lines}}"
+# A malformed limit REFUSES. Interpolated template text reaches `[` as shell
+# source: a non-numeric value makes the test error and the oversized PR sail
+# through. A guard that fails open on bad configuration is worse than none,
+# because it still reads as protection.
+case "$MAX_LINES" in
+    ''|*[!0-9]*)
+        echo "max_diff_lines is not a non-negative integer ('$MAX_LINES'), refusing."
+        gc bd update "$ROOT_ID" --notes "verdict: too_large"
+        gc bd close "$ROOT_ID" --reason "max_diff_lines malformed; refused without reviewing"
+        exit 0 ;;
+esac
+if [ "$MAX_LINES" -ne 0 ] && [ "$PR_LINES" -gt "$MAX_LINES" ]; then
+    # Establish the report path here rather than relying on the "Prepare the
+    # report path" block below: that runs AFTER the diff fetch, which is
+    # exactly what this guard exists to skip.
+    mkdir -p .gc/pr-pipeline/reviews
+    REPORT_PATH=".gc/pr-pipeline/reviews/pr-<N>.md"
+    cat > "$REPORT_PATH" <<EOF
+# PR #<N>, review refused
+
+## Verdict
+too_large
+
+Not reviewed. This PR changes $PR_LINES lines across $PR_FILES files,
+over the max_diff_lines budget of $MAX_LINES. No review was performed and
+no model budget was spent.
+
+This is a statement about the REQUEST, not a failed run. Retrying it
+unchanged cannot succeed and costs the same budget again. Either split the
+PR, review a subset of paths, or re-sling with a deliberately raised
+--var max_diff_lines=<new-limit>.
+EOF
+    gc bd update "$ROOT_ID" --notes "verdict: too_large
+status: refused
+refused_lines: $PR_LINES
+refused_limit: $MAX_LINES
+report_path: $REPORT_PATH"
+    gc bd close "$ROOT_ID" --reason "diff over max_diff_lines; refused before spending, do not retry unchanged"
+    exit 0
+fi
+```
+
+**Why this runs here and not as a failure mode later.** A review whose input does
+not fit spends the entire budget first and fails LAST, and that late failure is
+shaped exactly like a transient one, so callers that retry on failure re-spend
+on an input that can never fit. One maintainer traced three exhausted max
+accounts to this loop in 2026-08-22. The numbers needed to refuse are already in
+hand one step above; the only thing that made this expensive was not comparing
+them.
+
+**Exit 0 is deliberate.** The refusal is a completed decision, not an error, and
+must not present to a supervising loop as a failure to retry. The verdict
+`too_large` is distinct from `approve`, nothing was reviewed, and the report
+says so rather than implying the PR is clean.
+
 Fetch the diff:
 
 ```bash
 gh pr diff <N> --repo <repo> > /tmp/pr-<N>.diff
 gh pr view <N> --repo <repo> --json files --jq '.files[].path' > /tmp/pr-<N>.files
 ```
+
+The size check above read the PR's metadata; the fetch above read the PR's
+current head. Those are two separate reads, and a commit pushed between them
+can turn a PR that passed the budget into one that does not. So measure what
+you actually fetched, before any of it reaches the model. This is the reading
+that binds -- the diff on disk is the thing whose size costs money:
+
+```bash
+DIFF_LINES=$(wc -l < /tmp/pr-<N>.diff)
+MAX_LINES="{{max_diff_lines}}"
+if [ "$MAX_LINES" -ne 0 ] && [ "$DIFF_LINES" -gt "$MAX_LINES" ]; then
+    rm -f /tmp/pr-<N>.diff
+    gc bd update "$ROOT_ID" --notes "verdict: too_large
+status: refused
+refused_lines: $DIFF_LINES
+refused_limit: $MAX_LINES
+refused_at: post_fetch"
+    gc bd close "$ROOT_ID" --reason "diff grew past max_diff_lines between the size check and the fetch; refused before reading, do not retry unchanged"
+    exit 0
+fi
+```
+
+Do NOT read `/tmp/pr-<N>.diff` before that check has passed.
 
 Prepare the report path:
 

--- a/pr-pipeline/tests/test_pr_review_size_guard.py
+++ b/pr-pipeline/tests/test_pr_review_size_guard.py
@@ -1,0 +1,319 @@
+"""The budget refusal in mol-pr-review step 1.
+
+These tests EXECUTE the guard's shell with stubbed `gh`/`gc` rather than
+asserting on the formula's text. A text assertion here would be worth very
+little: this pack already carries a test that pinned a deprecated value by
+reading the file back to itself and passed for months while every importing
+city threw a doctor warning. The property that matters is behavioural -- does
+the guard refuse the big PR, pass the small one, and refuse to guess when the
+size cannot be read -- and only running it can answer that.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+import subprocess
+import tempfile
+import tomllib
+import unittest
+
+PACK_ROOT = pathlib.Path(__file__).resolve().parents[1]
+FORMULA = PACK_ROOT / "formulas" / "mol-pr-review.formula.toml"
+
+# Real sizes, measured 2026-08-22 on gastownhall/gascity:
+#   gh pr list --repo gastownhall/gascity --state open --limit 200 \
+#     --json number,additions,deletions,changedFiles
+PR_TOO_BIG = (113042, 432)   # #5489, the largest open PR
+PR_REPORTED = (47734, 372)   # #5255, the PR that triggered the drain report
+PR_TYPICAL = (248, 4)        # the median open PR
+
+
+def _guard_script() -> str:
+    data = tomllib.loads(FORMULA.read_text(encoding="utf-8"))
+    intake = data["steps"][0]["description"]
+    m = re.search(r"### Budget refusal.*?```bash\n(.*?)```", intake, re.S)
+    assert m, "the Budget refusal block vanished from step 1"
+    return m.group(1)
+
+
+def default_max_diff_lines() -> str:
+    """Read the shipped default rather than restating it.
+
+    A hardcoded 5000 here would keep passing after someone changed the pack's
+    default, testing a number this file invented instead of the one installers
+    actually get.
+    """
+    data = tomllib.loads(FORMULA.read_text(encoding="utf-8"))
+    return str(data["vars"]["max_diff_lines"]["default"])
+
+
+def run_guard(lines, files, max_lines=None, size_readable=True, gh_fails=False):
+    """Run the guard with stubbed gh/gc.
+
+    Returns (rc, stdout, gc-calls, report-text, gh-calls). The gh stub logs
+    every invocation and refuses anything it was not expected to be asked,
+    so "no diff was fetched" can be asserted rather than inferred from where
+    a heading sits in the source.
+    """
+    max_lines = default_max_diff_lines() if max_lines is None else max_lines
+    with tempfile.TemporaryDirectory() as td:
+        tmp = pathlib.Path(td)
+        bin_dir = tmp / "bin"
+        bin_dir.mkdir()
+        size = f"{lines}" if size_readable else "null"
+        fail = "exit 4\n" if gh_fails else ""
+        (bin_dir / "gh").write_text(
+            "#!/usr/bin/env bash\n"
+            f'echo "$*" >> "{tmp}/gh.log"\n'
+            f"{fail}"
+            "case \"$*\" in\n"
+            f'  *changedFiles*) echo {files};;\n'
+            f'  *additions*)    echo {size};;\n'
+            "  *' pr diff'*|*'pr diff '*) echo UNEXPECTED_DIFF_FETCH; exit 9;;\n"
+            "  *) echo UNEXPECTED_GH_CALL; exit 9;;\n"
+            "esac\n"
+        )
+        # `gc` records what it was asked to do so the test can assert the
+        # OUTCOME, not merely that the script exited.
+        (bin_dir / "gc").write_text(
+            "#!/usr/bin/env bash\n"
+            f'echo "$*" >> "{tmp}/gc.log"\n'
+        )
+        for f in ("gh", "gc"):
+            (bin_dir / f).chmod(0o755)
+
+        script = _guard_script()
+        script = (script.replace("<N>", "123").replace("<repo>", "o/r")
+                        .replace("{{max_diff_lines}}", max_lines))
+        # Supply ONLY what an earlier part of step 1 genuinely sets. Do NOT
+        # define REPORT_PATH here: an earlier version of this harness did, and
+        # it concealed a real defect -- the guard wrote to a variable the
+        # formula does not assign until after the diff fetch, 2,600 characters
+        # further down. A fixture that supplies state the real formula lacks
+        # tests the fixture, not the formula.
+        script = "ROOT_ID=root-1\nset -u\n" + script
+        # A later `exit 0` must be the guard's, so mark the fall-through.
+        script += '\necho REACHED_DIFF_FETCH\n'
+
+        sh = tmp / "guard.sh"
+        sh.write_text(script)
+        proc = subprocess.run(
+            ["bash", str(sh)], capture_output=True, text=True,
+            env={"PATH": f"{bin_dir}:/usr/bin:/bin", "HOME": str(tmp)}, cwd=td,
+        )
+        log = (tmp / "gc.log")
+        ghlog = (tmp / "gh.log")
+        report = (tmp / ".gc/pr-pipeline/reviews/pr-123.md")
+        return (proc.returncode, proc.stdout,
+                log.read_text() if log.exists() else "",
+                report.read_text() if report.exists() else "",
+                ghlog.read_text() if ghlog.exists() else "")
+
+
+class BudgetRefusalTests(unittest.TestCase):
+    def test_the_largest_open_pr_is_refused_before_the_diff_is_read(self):
+        rc, out, gclog, report, ghlog = run_guard(*PR_TOO_BIG)
+        self.assertEqual(rc, 0, "a refusal is a decision, not an error")
+        self.assertNotIn("REACHED_DIFF_FETCH", out,
+                         "the guard let a 113k-line PR through to the diff fetch")
+        self.assertIn("too_large", gclog)
+        self.assertIn("do not retry unchanged", gclog)
+
+    def test_the_pr_that_triggered_the_report_is_refused(self):
+        rc, out, gclog, _, ghlog = run_guard(*PR_REPORTED)
+        self.assertNotIn("REACHED_DIFF_FETCH", out)
+        self.assertIn("too_large", gclog)
+
+    def test_a_typical_pr_still_gets_reviewed(self):
+        """The green rail. Without this, refusing everything would pass."""
+        rc, out, gclog, _, ghlog = run_guard(*PR_TYPICAL)
+        self.assertIn("REACHED_DIFF_FETCH", out,
+                      "the guard blocked a median-sized PR -- it is over-firing")
+        self.assertNotIn("too_large", gclog)
+
+    def test_refusal_is_never_recorded_as_an_approval(self):
+        """A refused review must not look like a clean one downstream."""
+        _, _, gclog, report, _ = run_guard(*PR_TOO_BIG)
+        self.assertNotIn("approve", gclog)
+        self.assertIn("Not reviewed", report)
+        self.assertIn("no model budget was spent", report)
+
+    def test_an_unreadable_size_refuses_rather_than_reading_as_zero(self):
+        """Zero is the reassuring answer and would wave the PR through."""
+        rc, out, gclog, _, ghlog = run_guard(0, 0, size_readable=False)
+        self.assertNotIn("REACHED_DIFF_FETCH", out)
+        self.assertIn("unreadable", gclog)
+
+    def test_zero_disables_the_guard_deliberately(self):
+        _, out, gclog, _, _ = run_guard(*PR_TOO_BIG, max_lines="0")
+        self.assertIn("REACHED_DIFF_FETCH", out)
+        self.assertNotIn("too_large", gclog)
+
+    def test_no_diff_is_fetched_when_the_pr_is_refused(self):
+        """The claim is that nothing was spent, so prove nothing was read.
+
+        Textual ordering in the formula is not this property: it says where the
+        heading sits, not what ran. The gh stub exits non-zero on any `pr diff`
+        and logs every call, so this asserts on the invocations themselves.
+        """
+        _, _, _, _, ghlog = run_guard(*PR_TOO_BIG)
+        self.assertNotIn("pr diff", ghlog)
+        self.assertNotIn("UNEXPECTED", ghlog)
+        self.assertTrue(ghlog.strip(), "the guard never asked gh anything")
+
+    def test_a_pr_exactly_at_the_limit_is_reviewed(self):
+        """`-gt`, not `-ge`: the budget is a ceiling that may be reached."""
+        limit = int(default_max_diff_lines())
+        _, out, gclog, _, _ = run_guard(limit, 10)
+        self.assertIn("REACHED_DIFF_FETCH", out)
+        self.assertNotIn("too_large", gclog)
+
+    def test_one_line_over_the_limit_is_refused(self):
+        limit = int(default_max_diff_lines())
+        _, out, gclog, _, _ = run_guard(limit + 1, 10)
+        self.assertNotIn("REACHED_DIFF_FETCH", out)
+        self.assertIn("too_large", gclog)
+
+    def test_a_malformed_limit_refuses_instead_of_failing_open(self):
+        """The earlier draft let a non-numeric limit error the test and pass
+        the PR through -- a guard that fails open on bad config is worse than
+        no guard, because it still reads as protection."""
+        for bad in ("", "abc", "5000; rm -rf /", "-1"):
+            with self.subTest(limit=bad):
+                _, out, gclog, _, _ = run_guard(*PR_TOO_BIG, max_lines=bad)
+                self.assertNotIn("REACHED_DIFF_FETCH", out)
+                self.assertIn("too_large", gclog)
+
+    def test_a_failing_gh_refuses_rather_than_guessing(self):
+        _, out, gclog, _, _ = run_guard(*PR_TYPICAL, gh_fails=True)
+        self.assertNotIn("REACHED_DIFF_FETCH", out)
+        self.assertIn("too_large", gclog)
+
+    def test_the_guard_precedes_the_diff_fetch_in_the_source(self):
+        """Ordering is the whole point: a guard after the spend saves nothing."""
+        intake = tomllib.loads(FORMULA.read_text(encoding="utf-8"))["steps"][0]
+        text = intake["description"]
+        self.assertLess(text.index("### Budget refusal"), text.index("gh pr diff"),
+                        "the budget check must run before the diff is fetched")
+
+
+RUN_SH = PACK_ROOT / "commands" / "pr" / "review" / "run.sh"
+
+
+def _recheck_script() -> str:
+    data = tomllib.loads(FORMULA.read_text(encoding="utf-8"))
+    intake = data["steps"][0]["description"]
+    m = re.search(r"DIFF_LINES=.*?```", intake, re.S)
+    assert m, "the post-fetch recheck vanished from step 1"
+    return m.group(0)[: -3]
+
+
+class PostFetchRecheckTests(unittest.TestCase):
+    """The size check and the diff fetch are two reads of a moving target.
+
+    A commit pushed between them turns a passing PR into an oversized one, and
+    the fetched diff is the thing that actually costs money. So the fetched
+    bytes are measured before anything reads them.
+    """
+
+    def _run(self, diff_lines, max_lines=None):
+        max_lines = default_max_diff_lines() if max_lines is None else max_lines
+        with tempfile.TemporaryDirectory() as td:
+            tmp = pathlib.Path(td)
+            bin_dir = tmp / "bin"
+            bin_dir.mkdir()
+            (bin_dir / "gc").write_text(
+                "#!/usr/bin/env bash\n" + f'echo "$*" >> "{tmp}/gc.log"\n')
+            (bin_dir / "gc").chmod(0o755)
+            diff = tmp / "pr-123.diff"
+            diff.write_text("x\n" * diff_lines)
+            script = (_recheck_script().replace("<N>", "123")
+                      .replace("{{max_diff_lines}}", max_lines)
+                      .replace("/tmp/pr-123.diff", str(diff)))
+            script = "ROOT_ID=root-1\nset -u\n" + script + "\necho REACHED_REVIEW\n"
+            sh = tmp / "recheck.sh"
+            sh.write_text(script)
+            proc = subprocess.run(
+                ["bash", str(sh)], capture_output=True, text=True,
+                env={"PATH": f"{bin_dir}:/usr/bin:/bin"}, cwd=td)
+            log = tmp / "gc.log"
+            return (proc.stdout, log.read_text() if log.exists() else "",
+                    diff.exists())
+
+    def test_a_diff_that_grew_past_the_budget_is_refused_after_the_fetch(self):
+        out, gclog, diff_kept = self._run(int(default_max_diff_lines()) + 1)
+        self.assertNotIn("REACHED_REVIEW", out)
+        self.assertIn("too_large", gclog)
+        self.assertIn("post_fetch", gclog)
+        self.assertFalse(diff_kept, "the oversized diff was left on disk")
+
+    def test_a_diff_within_the_budget_proceeds(self):
+        out, gclog, _ = self._run(10)
+        self.assertIn("REACHED_REVIEW", out)
+        self.assertNotIn("too_large", gclog)
+
+
+class CommandPreflightTests(unittest.TestCase):
+    """run.sh is the only genuinely pre-spend point.
+
+    The formula's copy runs inside the session whose cost it is avoiding, so
+    the command has to refuse before `gc sling` ever starts an agent.
+    """
+
+    def _run(self, args, pr_lines=248, gh_fails=False):
+        with tempfile.TemporaryDirectory() as td:
+            tmp = pathlib.Path(td)
+            bin_dir = tmp / "bin"
+            bin_dir.mkdir()
+            (bin_dir / "gh").write_text(
+                "#!/usr/bin/env bash\n"
+                f'echo "$*" >> "{tmp}/gh.log"\n'
+                + ("exit 4\n" if gh_fails else f'echo "{pr_lines} 4"\n'))
+            (bin_dir / "gc").write_text(
+                "#!/usr/bin/env bash\n" + f'echo "$*" >> "{tmp}/gc.log"\n')
+            for f in ("gh", "gc"):
+                (bin_dir / f).chmod(0o755)
+            proc = subprocess.run(
+                ["sh", str(RUN_SH)] + args, capture_output=True, text=True,
+                env={"PATH": f"{bin_dir}:/usr/bin:/bin",
+                     "GC_PACK_DIR": str(PACK_ROOT), "GC_RIG": "r"}, cwd=td)
+            log = tmp / "gc.log"
+            return proc, log.read_text() if log.exists() else ""
+
+    def test_an_oversized_pr_is_refused_before_the_sling(self):
+        proc, gclog = self._run(["123"], pr_lines=113042)
+        self.assertEqual(proc.returncode, 3,
+                         "a budget refusal needs its own non-retryable code")
+        self.assertNotIn("sling", gclog, "an agent was started anyway")
+        self.assertIn("no model", proc.stderr)
+
+    def test_a_typical_pr_is_slung(self):
+        proc, gclog = self._run(["123"])
+        self.assertIn("sling", gclog)
+        self.assertIn("max_diff_lines=", gclog,
+                      "the limit must reach the formula too")
+
+    def test_an_unreadable_size_refuses_rather_than_slinging(self):
+        proc, gclog = self._run(["123"], gh_fails=True)
+        self.assertEqual(proc.returncode, 1)
+        self.assertNotIn("sling", gclog)
+
+    def test_a_malformed_limit_refuses_rather_than_failing_open(self):
+        proc, gclog = self._run(["123", "--max-diff-lines", "abc"])
+        self.assertEqual(proc.returncode, 2)
+        self.assertNotIn("sling", gclog)
+
+    def test_zero_disables_the_preflight_deliberately(self):
+        proc, gclog = self._run(["123", "--max-diff-lines=0"], pr_lines=113042)
+        self.assertIn("sling", gclog)
+
+    def test_the_command_default_matches_the_formula_default(self):
+        """Two copies of a number drift; this is what notices."""
+        text = RUN_SH.read_text(encoding="utf-8")
+        m = re.search(r'MAX_DIFF_LINES="\$\{GC_PR_MAX_DIFF_LINES:-(\d+)\}"', text)
+        self.assertIsNotNone(m, "the command's default is no longer readable")
+        self.assertEqual(m.group(1), default_max_diff_lines())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What this fixes

`mol-pr-review` already fetches `additions`, `deletions` and `changedFiles` in
step 1, and uses them for nothing but a `**Stats**` line in step 4. The only
size handling was a Failure Modes row reading "finish what fits", which spends
the whole budget before deciding it could not finish.

That combination is what makes an oversized PR expensive rather than merely
slow. The review burns the budget and then fails *last*, and a supervising
retry loop cannot tell "this can never succeed" from "this timed out", so it
re-spends at full price on every attempt. One maintainer reported three Max
accounts drained this way.

The important part of this change is not the threshold. It is that a refusal
is a **distinct, non-retryable outcome**:

- `pr review` exits **3**, a code no other path uses, and refuses before
  `gc sling` starts an agent.
- The formula records verdict **`too_large`**, distinct from `approve`,
  `request_changes` and `block`. It is a statement about the request, not a
  judgement about the code.
- The bead is **closed**, not left failed, so nothing re-queues it.

## Where the checks are, and why there are three

| Where | When it runs | What it protects |
|---|---|---|
| `commands/pr/review/run.sh` | before `gc sling` | the only genuinely pre-spend point, no session exists yet |
| formula step 1, before the diff fetch | inside the session | direct slings that bypass the command |
| formula step 1, after the diff fetch | inside the session | the diff that was actually fetched |

The formula's copies cannot be pre-spend by construction: they execute inside
the very session whose cost they are avoiding. That is why the command carries
the real gate and the formula carries defence in depth for direct slings.

The third check exists because the size read and the diff fetch are two reads
of a moving target. A commit pushed between them turns a passing PR into an
oversized one, and the fetched diff is the thing that actually costs money, so
its lines are counted on disk before anything reads them.

## Failure directions this deliberately does not take

- **An unreadable size is not zero.** Zero is the reassuring answer and would
  wave through exactly the largest PRs. Both an unparseable size and a failing
  `gh` refuse.
- **A malformed limit refuses.** An earlier draft interpolated the limit
  straight into `[ ... ]`, where a non-numeric value made the test error and
  the oversized PR proceed. A guard that fails open on bad configuration is
  worse than no guard, because it still reads as protection.
- **`0` disables the guard**, deliberately and explicitly.

## Threshold

`max_diff_lines` defaults to **5000** (additions + deletions). Measured against
the 200 most recent open PRs on `gastownhall/gascity`: median 248 lines, 188
pass, 12 refuse. The largest is 113,042 lines across 432 files.

Set per invocation with `--max-diff-lines <n>`, or per city with
`GC_PR_MAX_DIFF_LINES`.

## Tests

`pr-pipeline/tests/test_pr_review_size_guard.py`, 20 cases. They **execute**
the guard's shell against stubbed `gh`/`gc` rather than reading the TOML back
to itself, this pack already carries a test that pinned a deprecated value
that way and passed for months while every importing city threw a `gc doctor`
warning.

The `gh` stub logs every call and exits non-zero on anything it was not
expected to be asked, including `pr diff`. So "nothing was read" is asserted
from the invocations, not inferred from where a heading sits in the source.
The harness reads the default from the formula rather than restating it, and
supplies only the variables step 1 genuinely sets, an earlier version injected
`REPORT_PATH` and concealed a real defect where the guard wrote to a name the
formula does not assign until 2,600 characters further down.

Each guard was mutated to confirm the tests can go red, and each mutation kills
a disjoint set:

| Mutation | Kills |
|---|---|
| remove the pre-fetch guard | refusal + no-diff-fetched cases |
| `-gt` → `-ge` | the at-the-limit case only |
| remove the post-fetch recheck | both post-fetch cases only |
| drop `exit 3` from `run.sh` | the command preflight refusal only |
| drop the guard's `REPORT_PATH` | "refusal is never recorded as an approval" |

`gc lint pr-pipeline` passes, and the pack passes the live-`gc` harness
(`GC_TEST_BIN` set, real binary): 3 passed, 1 skipped (pr-pipeline ships no
agents).
