### PR TITLE
fix(gastown): attach default polecat workflow

### DIFF
--- a/gastown/README.md
+++ b/gastown/README.md
@@ -33,6 +33,36 @@ gc formula show mol-shutdown-dance
 The recipe must read warrant metadata from the claimed bead via
 `$GC_BEAD_ID` and must not declare a required `warrant_id` var.
 
+## Default Sling Formula
+
+The polecat agent ships an agent-level default sling formula, so a plain
+`gc sling <rig>/gastown.polecat "<text>"` compiles `mol-polecat-work`
+(`method = "default-on-formula"`) instead of routing a bare bead.
+
+That agent-level value outranks a city's `[agent_defaults]
+default_sling_formula`: `Agent.EffectiveDefaultSlingFormula()` returns the
+agent's own value before any inherited one, and `ApplyAgentDefaults` fills the
+city default in only for agents that set neither their own nor an inherited pack
+default. A city that deliberately routed polecat slings through its own default
+formula is therefore shadowed when it upgrades to a gastown pack carrying this
+knob.
+
+The config-level override is a per-agent patch, which assigns the agent's own
+value and so wins over the pack's:
+
+```toml
+[[patches.agent]]
+dir = "<rig>"
+name = "gastown.polecat"
+default_sling_formula = "mol-your-formula"
+```
+
+Per sling, an explicit choice still short-circuits ahead of the default:
+`--no-formula` routes a raw bead, `<formula> --formula` instantiates that formula
+instead (`--formula` is a boolean that reinterprets the positional argument), and
+`--on <formula>` attaches one to an existing bead. `[agent_defaults]` is the one
+knob that cannot override the agent's own value.
+
 ## Dog Pool
 
 Gastown owns `mol-shutdown-dance` and the dog agent that runs stuck-agent

--- a/gastown/agents/polecat/agent.toml
+++ b/gastown/agents/polecat/agent.toml
@@ -3,6 +3,7 @@ wake_mode = "fresh"
 work_dir = ".gc/worktrees/{{.Rig}}/polecats/{{.AgentBase}}"
 nudge = "Run gc hook --claim --json now; if it returns work, execute the claimed formula immediately."
 pre_start = ["{{.ConfigDir}}/assets/scripts/worktree-setup.sh {{.RigRoot}} {{.WorkDir}} {{.AgentBase}} --sync"]
+default_sling_formula = "mol-polecat-work"
 idle_timeout = "2h"
 min_active_sessions = 0
 max_active_sessions = 5

--- a/gastown/agents/polecat/agent.toml
+++ b/gastown/agents/polecat/agent.toml
@@ -3,6 +3,9 @@ wake_mode = "fresh"
 work_dir = ".gc/worktrees/{{.Rig}}/polecats/{{.AgentBase}}"
 nudge = "Run gc hook --claim --json now; if it returns work, execute the claimed formula immediately."
 pre_start = ["{{.ConfigDir}}/assets/scripts/worktree-setup.sh {{.RigRoot}} {{.WorkDir}} {{.AgentBase}} --sync"]
+# Agent-level default: outranks a city's [agent_defaults], so a city that routes
+# polecat slings elsewhere must say so in a [[patches.agent]] block. See
+# ../../README.md ("Default Sling Formula").
 default_sling_formula = "mol-polecat-work"
 idle_timeout = "2h"
 min_active_sessions = 0

--- a/gastown/tests/test_gastown_pack_assets.sh
+++ b/gastown/tests/test_gastown_pack_assets.sh
@@ -138,6 +138,8 @@ test_polecat_startup_uses_standard_hook_claim() {
 
     grep -F 'gc hook --claim --json' "$agent" >/dev/null ||
         fail "polecat nudge should call the standard hook claim path"
+    grep -F 'default_sling_formula = "mol-polecat-work"' "$agent" >/dev/null ||
+        fail "plain polecat sling must compile the implementation workflow instead of routing a bare task"
     grep -F 'gc hook --claim --json' "$prompt" >/dev/null ||
         fail "polecat prompt should call the standard hook claim path"
     grep -F 'gc hook --claim --json' "$propulsion" >/dev/null ||

--- a/tests/test_gc_role_prompt_integration.py
+++ b/tests/test_gc_role_prompt_integration.py
@@ -11,6 +11,9 @@ import pytest
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+GASCITY_CORE_SOURCE = (
+    "https://github.com/gastownhall/gascity.git//internal/bootstrap/packs/core"
+)
 
 
 @dataclass(frozen=True)
@@ -105,6 +108,79 @@ def write_prompt_workspace(
     return PromptWorkspace(city_dir=city_dir, rig_dir=rig_dir, env=env)
 
 
+def write_gastown_sling_workspace(root: Path) -> PromptWorkspace:
+    city_dir = root / "city"
+    rig_dir = root / "fixture"
+    gc_home = root / "gc-home"
+    home = root / "home"
+    (city_dir / ".gc").mkdir(parents=True)
+    rig_dir.mkdir()
+    gc_home.mkdir()
+    home.mkdir()
+
+    gastown_source = (REPO_ROOT / "gastown").resolve()
+    city_dir.joinpath("pack.toml").write_text(
+        textwrap.dedent(
+            f"""\
+            [pack]
+            name = "gastown-sling-integration"
+            schema = 2
+
+            [imports.core]
+            source = {json.dumps(GASCITY_CORE_SOURCE)}
+            """
+        ),
+        encoding="utf-8",
+    )
+    city_dir.joinpath("city.toml").write_text(
+        textwrap.dedent(
+            f"""\
+            [workspace]
+            provider = "opencode"
+
+            [providers.opencode]
+            base = "builtin:opencode"
+
+            [beads]
+            provider = "file"
+
+            [[rigs]]
+            name = "fixture"
+            prefix = "gc"
+            default_branch = "main"
+
+            [rigs.imports.gastown]
+            source = {json.dumps(str(gastown_source))}
+            """
+        ),
+        encoding="utf-8",
+    )
+    city_dir.joinpath(".gc", "site.toml").write_text(
+        textwrap.dedent(
+            f"""\
+            workspace_name = "gastown-sling-integration"
+
+            [[rig]]
+            name = "fixture"
+            path = {json.dumps(str(rig_dir))}
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    env = {
+        **os.environ,
+        "HOME": str(home),
+        "GC_HOME": str(gc_home),
+        "GC_CITY": str(city_dir),
+        "GC_CITY_PATH": str(city_dir),
+        "GC_CITY_ROOT": str(city_dir),
+        "GC_RIG": "fixture",
+        "GC_BEADS": "file",
+    }
+    return PromptWorkspace(city_dir=city_dir, rig_dir=rig_dir, env=env)
+
+
 def run_gc(
     gc_test_bin: Path,
     workspace: PromptWorkspace,
@@ -149,6 +225,34 @@ def test_city_scoped_gascity_registers_claim_command_from_rig(
     assert "Atomically claim one routed workflow bead" in result.stdout
     assert "Usage:\n  gc gc claim" in result.stdout
     assert "Gas City CLI — orchestration-builder" not in result.stdout
+
+
+def test_plain_gastown_polecat_sling_starts_default_graph_workflow(
+    tmp_path: Path, gc_test_bin: Path
+) -> None:
+    workspace = write_gastown_sling_workspace(tmp_path)
+
+    result = run_gc(
+        gc_test_bin,
+        workspace,
+        "--city",
+        str(workspace.city_dir),
+        "--rig",
+        "fixture",
+        "sling",
+        "fixture/gastown.polecat",
+        "Exercise the default polecat workflow",
+        "--json",
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["target"] == "fixture/gastown.polecat"
+    assert payload["method"] == "default-on-formula"
+    assert payload["formula"] == "mol-polecat-work"
+    assert payload["workflow_id"]
+    assert payload["bead_id"] == payload["workflow_id"]
+    assert "molecule_id" not in payload
 
 
 @pytest.mark.parametrize(

--- a/tests/test_gc_role_prompt_integration.py
+++ b/tests/test_gc_role_prompt_integration.py
@@ -35,12 +35,20 @@ def gc_test_bin() -> Path:
     return binary
 
 
-def write_prompt_workspace(
+def _write_workspace_scaffold(
     root: Path,
     *,
-    city_binding: str,
-    city_pack: Path,
+    workspace_name: str,
+    pack_toml: str,
+    city_toml: str,
+    extra_env: dict[str, str] | None = None,
 ) -> PromptWorkspace:
+    """Build the hermetic fixture city every integration fixture here shares.
+
+    Fixtures differ only in their pack.toml/city.toml contents and in env
+    deltas; the directory layout, the site.toml rig registration, and the
+    isolating env base are identical, so they live here once.
+    """
     city_dir = root / "city"
     rig_dir = root / "fixture"
     gc_home = root / "gc-home"
@@ -50,43 +58,12 @@ def write_prompt_workspace(
     gc_home.mkdir()
     home.mkdir()
 
-    roles_source = (REPO_ROOT / "gascity" / "roles").resolve()
-    city_pack = city_pack.resolve()
-    city_dir.joinpath("pack.toml").write_text(
-        textwrap.dedent(
-            f"""\
-            [pack]
-            name = "prompt-integration"
-            schema = 2
-
-            [imports.{city_binding}]
-            source = {json.dumps(str(city_pack))}
-            """
-        ),
-        encoding="utf-8",
-    )
-    city_dir.joinpath("city.toml").write_text(
-        textwrap.dedent(
-            f"""\
-            [workspace]
-            provider = "codex"
-
-            [providers.codex]
-            base = "builtin:codex"
-
-            [[rigs]]
-            name = "fixture"
-
-            [rigs.imports.gc]
-            source = {json.dumps(str(roles_source))}
-            """
-        ),
-        encoding="utf-8",
-    )
+    city_dir.joinpath("pack.toml").write_text(pack_toml, encoding="utf-8")
+    city_dir.joinpath("city.toml").write_text(city_toml, encoding="utf-8")
     city_dir.joinpath(".gc", "site.toml").write_text(
         textwrap.dedent(
             f"""\
-            workspace_name = "prompt-integration"
+            workspace_name = {json.dumps(workspace_name)}
 
             [[rig]]
             name = "fixture"
@@ -104,23 +81,56 @@ def write_prompt_workspace(
         "GC_CITY_PATH": str(city_dir),
         "GC_CITY_ROOT": str(city_dir),
         "GC_RIG": "fixture",
+        **(extra_env or {}),
     }
     return PromptWorkspace(city_dir=city_dir, rig_dir=rig_dir, env=env)
 
 
-def write_gastown_sling_workspace(root: Path) -> PromptWorkspace:
-    city_dir = root / "city"
-    rig_dir = root / "fixture"
-    gc_home = root / "gc-home"
-    home = root / "home"
-    (city_dir / ".gc").mkdir(parents=True)
-    rig_dir.mkdir()
-    gc_home.mkdir()
-    home.mkdir()
+def write_prompt_workspace(
+    root: Path,
+    *,
+    city_binding: str,
+    city_pack: Path,
+) -> PromptWorkspace:
+    roles_source = (REPO_ROOT / "gascity" / "roles").resolve()
+    city_pack = city_pack.resolve()
+    return _write_workspace_scaffold(
+        root,
+        workspace_name="prompt-integration",
+        pack_toml=textwrap.dedent(
+            f"""\
+            [pack]
+            name = "prompt-integration"
+            schema = 2
 
+            [imports.{city_binding}]
+            source = {json.dumps(str(city_pack))}
+            """
+        ),
+        city_toml=textwrap.dedent(
+            f"""\
+            [workspace]
+            provider = "codex"
+
+            [providers.codex]
+            base = "builtin:codex"
+
+            [[rigs]]
+            name = "fixture"
+
+            [rigs.imports.gc]
+            source = {json.dumps(str(roles_source))}
+            """
+        ),
+    )
+
+
+def write_gastown_sling_workspace(root: Path) -> PromptWorkspace:
     gastown_source = (REPO_ROOT / "gastown").resolve()
-    city_dir.joinpath("pack.toml").write_text(
-        textwrap.dedent(
+    return _write_workspace_scaffold(
+        root,
+        workspace_name="gastown-sling-integration",
+        pack_toml=textwrap.dedent(
             f"""\
             [pack]
             name = "gastown-sling-integration"
@@ -130,10 +140,7 @@ def write_gastown_sling_workspace(root: Path) -> PromptWorkspace:
             source = {json.dumps(GASCITY_CORE_SOURCE)}
             """
         ),
-        encoding="utf-8",
-    )
-    city_dir.joinpath("city.toml").write_text(
-        textwrap.dedent(
+        city_toml=textwrap.dedent(
             f"""\
             [workspace]
             provider = "opencode"
@@ -153,32 +160,8 @@ def write_gastown_sling_workspace(root: Path) -> PromptWorkspace:
             source = {json.dumps(str(gastown_source))}
             """
         ),
-        encoding="utf-8",
+        extra_env={"GC_BEADS": "file"},
     )
-    city_dir.joinpath(".gc", "site.toml").write_text(
-        textwrap.dedent(
-            f"""\
-            workspace_name = "gastown-sling-integration"
-
-            [[rig]]
-            name = "fixture"
-            path = {json.dumps(str(rig_dir))}
-            """
-        ),
-        encoding="utf-8",
-    )
-
-    env = {
-        **os.environ,
-        "HOME": str(home),
-        "GC_HOME": str(gc_home),
-        "GC_CITY": str(city_dir),
-        "GC_CITY_PATH": str(city_dir),
-        "GC_CITY_ROOT": str(city_dir),
-        "GC_RIG": "fixture",
-        "GC_BEADS": "file",
-    }
-    return PromptWorkspace(city_dir=city_dir, rig_dir=rig_dir, env=env)
 
 
 def run_gc(


### PR DESCRIPTION
## Summary

- Configure explicit Gastown polecats with `default_sling_formula = "mol-polecat-work"`.
- Add an asset assertion and a real-CLI integration regression proving plain sling creates the graph workflow.
- Keep explicit formula selection and `--no-formula` behavior unchanged.

Without this agent-level default, plain sling to an explicit Gastown polecat routes a bare bead, so the worker has no implementation workflow to execute. This reauthors the one required behavior from closed #251 directly on current main without its downstream integration stack.

The integration fixture uses OpenCode configuration and does not launch a provider.

## Verification

- `bash gastown/tests/test_gastown_pack_assets.sh`
- all `gastown/tests/test_*.sh`
- `go test ./...`
- real Gas City main CLI: patched result is `default-on-formula` / `mol-polecat-work`; unpatched baseline is a bare `bead`
- `git diff --check`