### PR TITLE
fix(gascity): scope artifact checks to owning store

### DIFF
--- a/gascity/assets/scripts/checks/build-artifact-valid.sh
+++ b/gascity/assets/scripts/checks/build-artifact-valid.sh
@@ -20,6 +20,11 @@ fail() {
   exit 1
 }
 
+retryable() {
+  echo "build-artifact-check: RETRYABLE: $*" >&2
+  exit 75
+}
+
 BEAD_ID="${GC_BEAD_ID:-}"
 [ -n "$BEAD_ID" ] || fail "GC_BEAD_ID is required"
 command -v gc >/dev/null 2>&1 || fail "gc is required on PATH"
@@ -49,7 +54,97 @@ print(value if isinstance(value, str) else "")
 ' "$2"
 }
 
-SHOW_JSON="$(gc bd show "$BEAD_ID" --json 2>/dev/null)" || fail "gc bd show $BEAD_ID failed"
+resolve_show_scope() {
+  local store_ref scope_root rig_json resolved
+
+  SHOW_COMMAND=(gc)
+  store_ref=${GC_TRIGGER_BEAD_STORE_REF:-${GC_TRIGGER_WORK_STORE_REF:-}}
+  if [ -n "${GC_CITY:-}" ]; then
+    case "$store_ref" in
+      city|city:*)
+        SHOW_COMMAND=(gc --city "$GC_CITY")
+        return 0
+        ;;
+      rig:*)
+        resolved=${store_ref#rig:}
+        case "$resolved" in
+          ''|*[!A-Za-z0-9._-]*) retryable "invalid work store ref: $store_ref" ;;
+        esac
+        SHOW_COMMAND=(gc --city "$GC_CITY" --rig "$resolved")
+        return 0
+        ;;
+      '') ;;
+      *) retryable "unsupported work store ref: $store_ref" ;;
+    esac
+  fi
+
+  # Controller checks already receive the durable Beads scope root on current
+  # runtimes. Use that exact store instead of allowing the controller cwd to
+  # select the city store for a rig-owned attempt.
+  scope_root=${GC_BEADS_SCOPE_ROOT:-${GC_RIG_ROOT:-}}
+  case "$scope_root" in
+    /*)
+      if [ -n "${GC_CITY:-}" ]; then
+        SHOW_COMMAND=(gc --city "$GC_CITY" --rig "$scope_root")
+      else
+        SHOW_COMMAND=(gc --rig "$scope_root")
+      fi
+      return 0
+      ;;
+    '') ;;
+    *) retryable "Beads scope root is not absolute: $scope_root" ;;
+  esac
+
+  [ -n "${GC_CITY:-}" ] || return 0
+  if rig_json="$(gc --city "$GC_CITY" rig list --json 2>/dev/null)"; then
+    resolved="$(printf '%s' "$rig_json" | python3 -c '
+import json
+import sys
+
+bead_id = sys.argv[1]
+prefix = bead_id.split("-", 1)[0]
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    raise SystemExit(0)
+rigs = data.get("rigs", []) if isinstance(data, dict) else []
+matches = [r for r in rigs if isinstance(r, dict) and r.get("prefix") == prefix]
+if len(matches) == 1:
+    rig = matches[0]
+    print("city" if rig.get("hq") is True else "rig:" + str(rig.get("name", "")))
+' "$BEAD_ID")"
+    case "$resolved" in
+      city) SHOW_COMMAND=(gc --city "$GC_CITY") ;;
+      rig:*) SHOW_COMMAND=(gc --city "$GC_CITY" --rig "${resolved#rig:}") ;;
+    esac
+  fi
+}
+
+show_bead_with_retry() {
+  local bead_id=$1 attempts delay attempt output
+  attempts=${GC_BUILD_ARTIFACT_SHOW_ATTEMPTS:-12}
+  delay=${GC_BUILD_ARTIFACT_SHOW_RETRY_DELAY:-1}
+  case "$attempts" in
+    ''|*[!0-9]*|0) retryable "invalid GC_BUILD_ARTIFACT_SHOW_ATTEMPTS=$attempts" ;;
+  esac
+
+  attempt=1
+  while [ "$attempt" -le "$attempts" ]; do
+    if output="$("${SHOW_COMMAND[@]}" bd show "$bead_id" --json 2>/dev/null)"; then
+      printf '%s' "$output"
+      return 0
+    fi
+    if [ "$attempt" -lt "$attempts" ]; then
+      sleep "$delay"
+    fi
+    attempt=$((attempt + 1))
+  done
+  return 75
+}
+
+resolve_show_scope
+SHOW_JSON="$(show_bead_with_retry "$BEAD_ID")" ||
+  retryable "gc bd show $BEAD_ID remained unreadable after ${GC_BUILD_ARTIFACT_SHOW_ATTEMPTS:-12} attempts; no artifact verdict was made"
 
 SCHEMA="$(metadata_value "$SHOW_JSON" "gc.build.artifact_schema")"
 PATH_KEYS="$(metadata_value "$SHOW_JSON" "gc.build.artifact_path_keys")"
@@ -59,7 +154,8 @@ PATH_KEYS="$(metadata_value "$SHOW_JSON" "gc.build.artifact_path_keys")"
 ROOT_ID="$(metadata_value "$SHOW_JSON" "gc.root_bead_id")"
 ROOT_JSON="$SHOW_JSON"
 if [ -n "$ROOT_ID" ] && [ "$ROOT_ID" != "$BEAD_ID" ]; then
-  ROOT_JSON="$(gc bd show "$ROOT_ID" --json 2>/dev/null)" || fail "gc bd show $ROOT_ID failed"
+  ROOT_JSON="$(show_bead_with_retry "$ROOT_ID")" ||
+    retryable "gc bd show $ROOT_ID remained unreadable after ${GC_BUILD_ARTIFACT_SHOW_ATTEMPTS:-12} attempts; no artifact verdict was made"
 fi
 
 ARTIFACT_PATH=""

--- a/gascity/tests/test_formula_assets.py
+++ b/gascity/tests/test_formula_assets.py
@@ -4223,11 +4223,21 @@ description = "Override sink that writes the base triage report contract."
             fake_gc.write_text(
                 "#!/usr/bin/env bash\n"
                 "set -euo pipefail\n"
+                "if [ -n \"${GC_SCOPED_SHOW_CALLS:-}\" ]; then printf '%s\\n' \"$*\" >>\"$GC_SCOPED_SHOW_CALLS\"; fi\n"
                 "while [ \"${1:-}\" != \"bd\" ]; do shift; done\n"
                 "shift\n"
                 "case \"$1\" in\n"
                 "  version) exit 0 ;;\n"
-                "  show) cat \"$BD_SHOW_DIR/$2.json\" ;;\n"
+                "  show)\n"
+                "    if [ -n \"${GC_SHOW_COUNT_FILE:-}\" ]; then\n"
+                "      count=0\n"
+                "      [ ! -f \"$GC_SHOW_COUNT_FILE\" ] || count=$(cat \"$GC_SHOW_COUNT_FILE\")\n"
+                "      count=$((count + 1))\n"
+                "      printf '%s\\n' \"$count\" >\"$GC_SHOW_COUNT_FILE\"\n"
+                "      [ \"$count\" -gt \"${GC_SHOW_FAIL_COUNT:-0}\" ] || exit 1\n"
+                "    fi\n"
+                "    cat \"$BD_SHOW_DIR/$2.json\"\n"
+                "    ;;\n"
                 "  *) exit 2 ;;\n"
                 "esac\n",
                 encoding="utf-8",
@@ -4645,6 +4655,41 @@ description = "Override sink that writes the base triage report contract."
 
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         self.assertIn("build artifact valid", result.stdout)
+
+    def test_build_artifact_check_scopes_reads_and_waits_for_close(self) -> None:
+        with tempfile.TemporaryDirectory() as artifact_dir:
+            tmp = pathlib.Path(artifact_dir)
+            artifact = tmp / "requirements.md"
+            artifact.write_text(self._valid_requirements_artifact(), encoding="utf-8")
+            calls = tmp / "calls"
+            count = tmp / "count"
+            control = (
+                '[{"id": "fc-loop", "metadata": {'
+                '"gc.root_bead_id": "fc-root", '
+                '"gc.build.artifact_schema": "gc.build.requirements.v1", '
+                '"gc.build.artifact_path_keys": "gc.build.requirements_path"}}]'
+            )
+            root_bead = (
+                '[{"id": "fc-root", "metadata": {'
+                f'"gc.build.requirements_path": "{artifact}"'
+                "}}]"
+            )
+            result = self._run_build_artifact_check(
+                {"fc-loop": control, "fc-root": root_bead},
+                "fc-loop",
+                {
+                    "GC_BEADS_SCOPE_ROOT": str(tmp),
+                    "GC_SCOPED_SHOW_CALLS": str(calls),
+                    "GC_SHOW_COUNT_FILE": str(count),
+                    "GC_SHOW_FAIL_COUNT": "6",
+                    "GC_BUILD_ARTIFACT_SHOW_RETRY_DELAY": "0",
+                },
+            )
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertGreaterEqual(int(count.read_text(encoding="utf-8")), 7)
+            call_text = calls.read_text(encoding="utf-8")
+            self.assertIn(f"--rig {tmp} bd show fc-loop --json", call_text)
+            self.assertIn(f"--rig {tmp} bd show fc-root --json", call_text)
 
     def test_build_artifact_check_resolves_relative_path_from_rig_root(self) -> None:
         with tempfile.TemporaryDirectory() as td:


### PR DESCRIPTION
## Summary

- resolve producer and workflow-root reads through the explicit trigger store or controller Beads scope root
- fall back to the unique city rig prefix when no scope projection is available
- retry close-time reads inside the existing five-minute check budget and preserve an explicit retryable no-verdict result

## Why

A rig-owned producer can close with a valid artifact while the city-level Ralph controller runs the shared check from city context. The unscoped `gc bd show` reads then fail, consume bounded repair attempts, and block every downstream build stage even though the artifact is valid.

Observed in Flow City on requirements and plan controls; the defect is in this shared pack gate and affects every formula that references it.

## Verification

- `python3 -m unittest gascity.tests.test_formula_assets` (95 tests)
- `shellcheck gascity/assets/scripts/checks/build-artifact-valid.sh`
- `git diff --check`