### PR TITLE
fix(claim): verify the claim against the session's own identity SET, not one precomputed form

### DIFF
--- a/gascity/commands/claim/run.sh
+++ b/gascity/commands/claim/run.sh
@@ -118,6 +118,22 @@ if [ -z "$EXPECTED_ASSIGNEE" ]; then
     exit 1
 fi
 
+# The claim hook writes the OCCUPANT identity (the session bead id) for
+# unaliased pool workers and the alias for aliased ones; older binaries wrote
+# the slot-derived session name. All of these are OUR identities, so verify
+# membership in the session's own identity set instead of insisting on one
+# precomputed form -- a strict single-form compare rejected the session's own
+# claim forever after the writer moved to the occupant id (gascity ga-jrnou).
+claim_assignee_is_ours() {
+    _candidate="$1"
+    for _own in "${BEADS_ACTOR:-}" "${GC_ALIAS:-}" "${GC_SESSION_ID:-}" "${GC_SESSION_NAME:-}" "${GC_AGENT:-}"; do
+        if [ -n "$_own" ] && [ "$_candidate" = "$_own" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
 claim_file="$(mktemp)"
 show_file="$(mktemp)"
 convoy_file="$(mktemp)"
@@ -209,7 +225,7 @@ while [ "$verify_try" -lt "$max_attempts" ]; do
             printf 'CLAIM_REJECTED unexpected status for %s: %s\n' \
                 "$work_id" "$claim_status" >&2
             break
-        elif [ "$claim_assignee" != "$EXPECTED_ASSIGNEE" ]; then
+        elif ! claim_assignee_is_ours "$claim_assignee"; then
             printf 'CLAIM_REJECTED assignee mismatch for %s\n' "$work_id" >&2
             break
         elif [ -n "$EXPECTED_ROUTE" ] && [ -n "$claim_route" ] && [ "$claim_route" != "$EXPECTED_ROUTE" ]; then


### PR DESCRIPTION
## Summary

The claim protocol computed `EXPECTED_ASSIGNEE` as `BEADS_ACTOR > GC_SESSION_NAME > GC_SESSION_ID` and required strict equality at verification. `gc hook --claim` now records an unaliased pool worker's claim under its OCCUPANT identity — the session bead id (gastownhall/gascity#5663) — because the slot-derived session name is a chair shared by every occupant of the slot. The strict compare therefore rejected the session's OWN claim forever (`CLAIM_REJECTED assignee mismatch` spin, gascity `ga-jrnou`) without releasing it.

Accept the claim when the verified assignee matches ANY of the session's own identities (`BEADS_ACTOR`, `GC_ALIAS`, `GC_SESSION_ID`, `GC_SESSION_NAME`, `GC_AGENT`): correct under both hook generations and both aliased and unaliased shapes, and still rejects a claim owned by a different session.

Validated live on maintainer-city (as a hot-patch of the serving gc-plan-pack worktree): the wedged reviewer seat's next incarnation printed `CLAIMED_BEAD_ID=...` on first try and the adopt-pr pipeline proceeded through merge.

## Testing

- Behavior probe: occupant-id and chair forms accepted; a foreign assignee still rejected
- `bash -n` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)