### PR TITLE
fix(slack): always derive inbound attachment mime_type — Slack-native recordings carry none

### DIFF
--- a/slack-full/CHANGELOG.md
+++ b/slack-full/CHANGELOG.md
@@ -21,6 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `filetype` code → Slack-native subtype → `application/octet-stream`)
   and always serializes `mime_type` (no longer `omitempty`), so a
   payload can never again be rejected for a missing key.
+  Scope: this covers the legacy `/extmsg/inbound` delivery path. Files
+  shared in a company/multi-bot room take the company hydration path,
+  which never posts to `/extmsg/inbound` and still renders Slack's raw
+  `filetype`, so a Slack-native recording there is unchanged by this fix
+  and still lists an empty filetype.
 
 ### Changed
 

--- a/slack-full/CHANGELOG.md
+++ b/slack-full/CHANGELOG.md
@@ -8,6 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Inbound files recorded inside Slack itself — voice clips (file subtype
+  `slack_audio`) and video clips (`slack_video`) — arrive with an empty
+  `mimetype` AND `filetype`, which the adapter passed through verbatim.
+  The inbound payload then omitted `mime_type`, a REQUIRED property of
+  gc's `extmsg.ExternalAttachment`, so gc rejected the whole message
+  with 422 and the recording plus its text caption silently never
+  reached the bound session. The adapter now derives a media type for
+  every inbound file (Slack's `mimetype` → file-name extension → Slack
+  `filetype` code → Slack-native subtype → `application/octet-stream`)
+  and always serializes `mime_type` (no longer `omitempty`), so a
+  payload can never again be rejected for a missing key.
+
 ### Changed
 
 - Renamed the pack directory from `slack-pack/` to `slack-full/` and the

--- a/slack-full/adapter/attachment_mime.go
+++ b/slack-full/adapter/attachment_mime.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"mime"
+	"path"
+	"strings"
+)
+
+// --- inbound attachment media types ------------------------------------
+//
+// gc's extmsg.ExternalAttachment declares mime_type a REQUIRED property,
+// and Slack does not always populate one: files recorded inside Slack
+// itself — voice clips (file subtype "slack_audio", name
+// "audio_message.m4a") and video clips ("slack_video") — arrive with
+// mimetype "" AND filetype "", even from files.info. Passing Slack's
+// value through verbatim produced a payload without the key, a
+// deterministic 422 from gc, and the whole inbound message — the file
+// AND its text caption — silently never reached the bound session.
+// attachmentMIMEType therefore always derives a value; the adapter
+// never emits an attachment without one.
+
+// fallbackAttachmentMIMEType is the last-resort attachment type when
+// neither Slack nor the file name says anything usable.
+const fallbackAttachmentMIMEType = "application/octet-stream"
+
+// slackExtensionMIMETypes pins the media types Slack clients actually
+// produce, independent of the host's mime.types database (which differs
+// between macOS and Linux and lacks .m4a on some images). Consulted
+// before mime.TypeByExtension.
+var slackExtensionMIMETypes = map[string]string{
+	".m4a": "audio/mp4", ".aac": "audio/aac", ".mp3": "audio/mpeg", ".wav": "audio/wav",
+	".ogg": "audio/ogg", ".oga": "audio/ogg", ".opus": "audio/opus", ".flac": "audio/flac",
+	".mp4": "video/mp4", ".m4v": "video/mp4", ".mov": "video/quicktime", ".webm": "video/webm",
+	".png": "image/png", ".jpg": "image/jpeg", ".jpeg": "image/jpeg", ".gif": "image/gif",
+	".webp": "image/webp", ".heic": "image/heic", ".svg": "image/svg+xml",
+	".pdf": "application/pdf", ".txt": "text/plain", ".md": "text/markdown", ".csv": "text/csv",
+	".json": "application/json", ".zip": "application/zip",
+}
+
+// slackSubtypeMIMETypes maps Slack-native recording subtypes — which
+// carry no mimetype/filetype at all — to the container Slack encodes
+// them in.
+var slackSubtypeMIMETypes = map[string]string{
+	"slack_audio": "audio/mp4", // voice clips: AAC in an MP4 container (audio_message.m4a)
+	"slack_video": "video/mp4", // video clips
+}
+
+// attachmentMIMEType derives the mime_type reported to gc for an inbound
+// Slack file. Precedence: Slack's own mimetype → the file name's
+// extension (name, then title) → Slack's filetype code treated as an
+// extension → the Slack-native subtype → application/octet-stream.
+// Never returns "".
+func attachmentMIMEType(f slackFile) string {
+	if mt := strings.TrimSpace(f.MIMEType); mt != "" {
+		return mt
+	}
+	for _, name := range []string{f.Name, f.Title} {
+		if mt := mimeTypeByExtension(path.Ext(name)); mt != "" {
+			return mt
+		}
+	}
+	if ft := strings.TrimSpace(f.Filetype); ft != "" {
+		if mt := mimeTypeByExtension("." + ft); mt != "" {
+			return mt
+		}
+	}
+	if mt := slackSubtypeMIMETypes[strings.ToLower(strings.TrimSpace(f.Subtype))]; mt != "" {
+		return mt
+	}
+	return fallbackAttachmentMIMEType
+}
+
+// mimeTypeByExtension resolves a dotted extension via the pinned Slack
+// table, then the stdlib/host database with any parameters (e.g.
+// "; charset=utf-8") stripped so the value is a bare media type. ""
+// when unknown or ext is empty. Input is canonicalized to exactly one
+// leading dot, lowercased and whitespace-trimmed, so a file name with
+// trailing whitespace ("clip.M4A ") or an already-dotted filetype code
+// (".m4a" → "..m4a" at the call site) still resolves.
+func mimeTypeByExtension(ext string) string {
+	ext = strings.TrimLeft(strings.ToLower(strings.TrimSpace(ext)), ".")
+	if ext == "" {
+		return ""
+	}
+	ext = "." + ext
+	if mt, ok := slackExtensionMIMETypes[ext]; ok {
+		return mt
+	}
+	mt := mime.TypeByExtension(ext)
+	if mt == "" {
+		return ""
+	}
+	if mediaType, _, err := mime.ParseMediaType(mt); err == nil {
+		return mediaType
+	}
+	return mt
+}

--- a/slack-full/adapter/attachment_mime_test.go
+++ b/slack-full/adapter/attachment_mime_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Slack voice clips (file subtype "slack_audio") arrive with an EMPTY
+// mimetype AND filetype — files.info reports mimetype "" filetype ""
+// subtype "slack_audio" name "audio_message.m4a" for them. gc's
+// extmsg.ExternalAttachment declares mime_type as a required property,
+// so the adapter must always derive one rather than pass Slack's value
+// through verbatim.
+func TestAttachmentMIMETypeDerivation(t *testing.T) {
+	cases := []struct {
+		name string
+		file slackFile
+		want string
+	}{
+		{"slack mimetype wins over extension", slackFile{Name: "x.bin", MIMEType: "image/png"}, "image/png"},
+		{"slack mimetype is trimmed", slackFile{Name: "x.m4a", MIMEType: " audio/mp4 "}, "audio/mp4"},
+		{"slack mimetype passes through in its own case", slackFile{Name: "x.m4a", MIMEType: "IMAGE/PNG"}, "IMAGE/PNG"},
+		{"voice clip by .m4a extension", slackFile{Name: "audio_message.m4a", Subtype: "slack_audio"}, "audio/mp4"},
+		{"extension is case-insensitive", slackFile{Name: "CLIP.M4A"}, "audio/mp4"},
+		{"trailing whitespace in name still resolves", slackFile{Name: "clip.M4A "}, "audio/mp4"},
+		{"title used when name empty", slackFile{Title: "memo.mp3"}, "audio/mpeg"},
+		{"title used when name extension unknown", slackFile{Name: "blob.zzzunknown", Title: "memo.mp3"}, "audio/mpeg"},
+		{"slack filetype code used when no extension", slackFile{Name: "noext", Filetype: "m4a"}, "audio/mp4"},
+		{"already-dotted filetype code still resolves", slackFile{Name: "noext", Filetype: ".m4a"}, "audio/mp4"},
+		{"subtype used when filetype unknown", slackFile{Name: "noext", Filetype: "zzzunknown", Subtype: "slack_audio"}, "audio/mp4"},
+		{"slack_audio subtype when nothing else", slackFile{Name: "noext", Subtype: "slack_audio"}, "audio/mp4"},
+		{"slack_video subtype when nothing else", slackFile{Name: "noext", Subtype: "slack_video"}, "video/mp4"},
+		{"stdlib table, charset parameter stripped", slackFile{Name: "style.css"}, "text/css"},
+		{"unknown extension falls back to octet-stream", slackFile{Name: "blob.zzzunknown"}, "application/octet-stream"},
+		{"no hints at all falls back to octet-stream", slackFile{ID: "F1"}, "application/octet-stream"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := attachmentMIMEType(tc.file); got != tc.want {
+				t.Fatalf("attachmentMIMEType(%+v) = %q, want %q", tc.file, got, tc.want)
+			}
+		})
+	}
+}
+
+// The downloaded attachment record carries the derived type, not
+// Slack's empty string — this is the exact shape that made gc 422 the
+// whole inbound message.
+func TestDownloadSlackFilesDerivesMIMETypeForVoiceClip(t *testing.T) {
+	testAllowAnyURL(t)
+	slackStub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("AAC-BYTES"))
+	}))
+	t.Cleanup(slackStub.Close)
+
+	cfg := config{
+		slackBotToken:    "xoxb-test",
+		inboundFileStore: filepath.Join(t.TempDir(), "inbound"),
+	}
+	files := []slackFile{{
+		ID:         "F1VOICE",
+		Name:       "audio_message.m4a",
+		Title:      "audio_message.m4a",
+		URLPrivate: slackStub.URL + "/files/F1VOICE",
+		MIMEType:   "",
+		Filetype:   "",
+		Subtype:    "slack_audio",
+	}}
+	got := downloadSlackFiles(cfg, "C123", "1234.5678", files)
+	if len(got) != 1 {
+		t.Fatalf("got %d attachments, want 1", len(got))
+	}
+	if got[0].MIMEType != "audio/mp4" {
+		t.Fatalf("attachment mime_type = %q, want audio/mp4", got[0].MIMEType)
+	}
+}
+
+// mime_type mirrors a REQUIRED property on the gc side: it must be
+// serialized even when empty so a payload can never be rejected for a
+// missing key (an empty string is at worst a degraded value, never a
+// 422).
+func TestExternalAttachmentAlwaysSerializesMIMEType(t *testing.T) {
+	raw, err := json.Marshal(externalAttachment{ProviderID: "F1", URL: "file:///tmp/x"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(raw), `"mime_type":""`) {
+		t.Fatalf("mime_type must always be present, got %s", raw)
+	}
+}

--- a/slack-full/adapter/main.go
+++ b/slack-full/adapter/main.go
@@ -807,7 +807,12 @@ type externalActor struct {
 type externalAttachment struct {
 	ProviderID string `json:"provider_id"`
 	URL        string `json:"url"`
-	MIMEType   string `json:"mime_type,omitempty"`
+	// mime_type is REQUIRED on the gc side (extmsg.ExternalAttachment):
+	// omitting the key gets the whole inbound message rejected with 422,
+	// so it is deliberately NOT omitempty. Producers derive a non-empty
+	// value via attachmentMIMEType; an empty string here is at worst a
+	// degraded value, never a missing required key.
+	MIMEType string `json:"mime_type"`
 }
 
 type externalInboundMessage struct {
@@ -1036,7 +1041,12 @@ type slackFile struct {
 	URLPrivateDownload string `json:"url_private_download,omitempty"`
 	MIMEType           string `json:"mimetype,omitempty"`
 	Filetype           string `json:"filetype,omitempty"`
-	Size               int    `json:"size,omitempty"`
+	// Subtype is set for recordings made inside Slack ("slack_audio"
+	// voice clips, "slack_video" video clips), which carry NO
+	// mimetype/filetype — the only hint attachmentMIMEType has for an
+	// extension-less one.
+	Subtype string `json:"subtype,omitempty"`
+	Size    int    `json:"size,omitempty"`
 }
 
 type slackMessageEvent struct {
@@ -2686,7 +2696,10 @@ func downloadSlackFiles(cfg config, channel, ts string, files []slackFile) []ext
 		out = append(out, externalAttachment{
 			ProviderID: f.ID,
 			URL:        "file://" + dest,
-			MIMEType:   f.MIMEType,
+			// Never f.MIMEType verbatim: Slack-native recordings (voice
+			// clips, video clips) carry an empty mimetype, and gc requires
+			// the field — see attachmentMIMEType.
+			MIMEType: attachmentMIMEType(f),
 		})
 	}
 	return out


### PR DESCRIPTION
## Symptom

A Slack **voice clip** (or video clip) posted into a mapped channel never reaches the bound gc session — and neither does its text caption. The adapter logs `inbound POST failed: 422 ...` and drops the message on the floor. In our fork, whose inbound pipeline retries instead of dropping, the same root cause was worse: one founder voice memo wedged a production channel's inbound delivery for ~34 hours until a human intervened. Either way, the trigger is any file recorded *inside* Slack.

## Root cause

Files recorded natively in Slack — voice clips (file subtype `slack_audio`, name `audio_message.m4a`) and video clips (`slack_video`) — arrive with an **empty `mimetype` AND empty `filetype`**; `files.info` confirms Slack simply never sets one for these. `downloadSlackFiles` passed that empty value through verbatim into `externalAttachment.MIMEType`, which is tagged `omitempty`, so the inbound payload omitted the `mime_type` key entirely. gc's `extmsg.ExternalAttachment` declares `mime_type` **required**, so gc deterministically answers 422 and the whole `externalInboundMessage` — attachments and text alike — is rejected.

## Fix

- New `attachmentMIMEType(f slackFile)` derives a media type for every inbound file, precedence: Slack's own `mimetype` → the file name's extension (a pinned table of the types Slack clients actually produce, then the host's `mime.TypeByExtension` with parameters stripped) → the Slack `filetype` code treated as an extension → the Slack-native subtype (`slack_audio`/`slack_video` → `audio/mp4`/`video/mp4`) → `application/octet-stream`. It never returns `""`.
- `externalAttachment.MIMEType` drops `omitempty`: the key is always serialized, so a payload can never again be rejected for a missing required key (an empty string would be at worst a degraded value, never a 422).
- `slackFile` gains the `Subtype` field — the only hint Slack provides on its native recordings.

## How verified

- Table test over the derivation precedence, including the fall-through boundaries (unknown name extension → title, unknown filetype → subtype) and canonicalization edges (trailing whitespace in the name, already-dotted filetype codes, case-insensitivity).
- A voice-clip download test reproducing the exact incident shape (`mimetype:"", filetype:"", subtype:"slack_audio"`) and asserting the wire record carries `audio/mp4`.
- A serialization guard asserting `mime_type` is present in the JSON even when empty.
- `gofmt`/`go vet` clean; the full adapter suite passes (run on linux/amd64, Go 1.25).
- The same fix (same derivation table and precedence) has been running in production in our fork since 2026-08-27 after three rounds of adversarial review there; this PR ports the transport-agnostic root-cause half, leaving out the fork-specific retry/dead-letter machinery that doesn't apply to this codebase's drop-on-error inbound path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
