### PR TITLE
fix(slack): pack pin bumps can no longer strand the adapter — run.sh service entrypoint with build-on-missing

### DIFF
--- a/slack-full/.gitignore
+++ b/slack-full/.gitignore
@@ -2,9 +2,14 @@ __pycache__/
 *.pyc
 .gc/
 
-# Built adapter binary — produced by `go build` in adapter/ and read
-# in place by the [[service]] proxy_process command.
+# Built adapter binary — produced by `go build` in adapter/ (or by
+# adapter/run.sh's build-on-missing self-heal). The [[service]]
+# proxy_process command is adapter/run.sh (checked in), which rebuilds
+# this binary when a git-only pack re-materialization has wiped it, so
+# the service can't strand. A crash mid-build (SIGKILL, host loss) can
+# leave a PID-suffixed temp behind — ignore those too.
 adapter/gc-slack-adapter
+adapter/gc-slack-adapter.build.*
 
 # Built operator CLI binary — produced by `go build` in cli/ and exec'd
 # by the commands/<cmd>.sh wrappers via $GC_PACK_DIR/cli/gc-slack-cli.

--- a/slack-full/CHANGELOG.md
+++ b/slack-full/CHANGELOG.md
@@ -16,16 +16,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   pack pin bump wiped the binary and left the slack service dead until
   someone rebuilt it by hand. The service command is now
   `adapter/run.sh` (checked in, survives every materialization): it
-  sources the secrets env file (warns but continues when the file is
-  absent — the adapter fail-fasts on missing required env itself),
-  execs an existing binary untouched, and on a missing binary finds a
-  Go toolchain (PATH plus Homebrew/system fallbacks for minimal
-  supervisor environments), rebuilds from the colocated sources with
-  loud stderr logging, publishes via PID-suffixed temp file + atomic
-  `mv` (safe under concurrent supervisor restarts), and execs.
+  sources the secrets env file, execs an existing binary untouched,
+  and on a missing binary finds a Go toolchain (PATH plus
+  Homebrew/system fallbacks for minimal supervisor environments),
+  rebuilds from the colocated sources with loud stderr logging,
+  publishes via PID-suffixed temp file + atomic `mv` (safe under
+  concurrent supervisor restarts), and execs.
+
+  Env-file handling distinguishes the two cases. An absent *default*
+  (`~/.config/gc-slack-adapter/env`) warns and continues, since
+  supervised deployments legitimately inject the env another way and
+  the adapter fail-fasts on missing required keys itself. An absent
+  path you set *explicitly* in `GC_SLACK_ADAPTER_ENV` is fatal: the
+  adapter validates that credentials are present, never where they
+  came from, so continuing would boot it against whatever Slack token
+  happens to be in the ambient environment.
+
+  Because the rebuild now sits on the service startup path, it is
+  hardened for the minimal supervisor environments it targets: the
+  toolchain search also covers `/usr/bin/go` and `/bin/go` (where a
+  distro Go lands, and which a restricted PATH hides); `GOCACHE` and
+  `GOPATH` are defaulted under `TMPDIR` when HOME, `XDG_CACHE_HOME`
+  and `GOCACHE` are all unset, which `go build` otherwise rejects
+  outright; and the toolchain is checked against `go.mod`'s `go`
+  directive up front, so a too-old Go under `GOTOOLCHAIN=local` fails
+  with a named remedy instead of a raw compiler error (the default
+  `GOTOOLCHAIN=auto`, which can fetch the required toolchain itself,
+  warns and proceeds).
 
 ### Changed
 
+- **Behavior change on upgrade:** the slack service now *exits 1 at
+  startup* when `GC_SLACK_ADAPTER_ENV` is set to a path that does not
+  exist, where it previously logged one warning and started on the
+  ambient environment. Pointing the variable at a nonexistent path is
+  this pack's own established idiom for "no env file", so a unit file or
+  wrapper using it that way for the **service** will stop starting after
+  this pin bump. Audit before upgrading with
+  `grep -r GC_SLACK_ADAPTER_ENV` across your unit files and wrappers, and
+  either create the file or unset the variable to fall back to the
+  default. The strict rule is service-only: `slack_chat_*` commands
+  (`scripts/slack_intake_common.py`) still treat a missing path as "no
+  env file".
 - Renamed the pack directory from `slack-pack/` to `slack-full/` and the
   `pack.toml` name from `slack` to `slack-full` as part of the Slack pack
   tiering split (`gc-yrw`). This pack is now **Tier 3** of the Slack

--- a/slack-full/CHANGELOG.md
+++ b/slack-full/CHANGELOG.md
@@ -8,6 +8,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The `[[service]]` proxy_process command pointed straight at
+  `adapter/gc-slack-adapter`, a gitignored build artifact — but
+  `gc import install` re-materializes the pack cache git-only, so every
+  pack pin bump wiped the binary and left the slack service dead until
+  someone rebuilt it by hand. The service command is now
+  `adapter/run.sh` (checked in, survives every materialization): it
+  sources the secrets env file (warns but continues when the file is
+  absent — the adapter fail-fasts on missing required env itself),
+  execs an existing binary untouched, and on a missing binary finds a
+  Go toolchain (PATH plus Homebrew/system fallbacks for minimal
+  supervisor environments), rebuilds from the colocated sources with
+  loud stderr logging, publishes via PID-suffixed temp file + atomic
+  `mv` (safe under concurrent supervisor restarts), and execs.
+
 ### Changed
 
 - Renamed the pack directory from `slack-pack/` to `slack-full/` and the

--- a/slack-full/CONTRIBUTING.md
+++ b/slack-full/CONTRIBUTING.md
@@ -30,6 +30,12 @@ cd examples/slack-pack/adapter
 go build -o gc-slack-adapter
 ```
 
+In deployed packs you normally don't build by hand: the `[[service]]`
+command is `adapter/run.sh`, which rebuilds `gc-slack-adapter` from
+source whenever the binary is missing (build artifacts are gitignored,
+so `gc import install` re-materializes the pack cache without them —
+run.sh self-heals instead of stranding the service).
+
 Build the operator CLI with:
 
 ```bash

--- a/slack-full/README.md
+++ b/slack-full/README.md
@@ -474,10 +474,15 @@ GC_CITY_NAME=<your-city-name>
 ### Cutover sequence
 
 ```
-# 1. Build the adapter binary in place (source colocated with the pack)
+# 1. Build the adapter binary in place (source colocated with the pack).
+#    Optional: the [[service]] command is adapter/run.sh, which rebuilds
+#    gc-slack-adapter itself when the binary is missing (e.g. after
+#    `gc import install` re-materialized the pack cache git-only).
 ( cd slack-full/adapter && go build -o gc-slack-adapter )
 
-# 2. Source the secrets so the supervisor inherits them
+# 2. Source the secrets so the supervisor inherits them.
+#    Optional: run.sh sources this same file itself at service start
+#    (override the path with GC_SLACK_ADAPTER_ENV).
 set -a; source "${XDG_CONFIG_HOME:-$HOME/.config}/gc-slack-adapter/env"; set +a
 
 # 3. Stop any manually-managed adapter that may still be running

--- a/slack-full/README.md
+++ b/slack-full/README.md
@@ -482,7 +482,9 @@ GC_CITY_NAME=<your-city-name>
 
 # 2. Source the secrets so the supervisor inherits them.
 #    Optional: run.sh sources this same file itself at service start
-#    (override the path with GC_SLACK_ADAPTER_ENV).
+#    (override the path with GC_SLACK_ADAPTER_ENV — if you set it, the
+#    file must exist: run.sh refuses to start on ambient credentials
+#    rather than post to whatever workspace is in the environment).
 set -a; source "${XDG_CONFIG_HOME:-$HOME/.config}/gc-slack-adapter/env"; set +a
 
 # 3. Stop any manually-managed adapter that may still be running

--- a/slack-full/adapter/run.sh
+++ b/slack-full/adapter/run.sh
@@ -16,7 +16,9 @@
 #
 # Reads secrets from a sourced env file. Default location:
 #   ~/.config/gc-slack-adapter/env
-# Override via GC_SLACK_ADAPTER_ENV.
+# Override via GC_SLACK_ADAPTER_ENV. A missing default is a warning; a
+# GC_SLACK_ADAPTER_ENV you set explicitly must exist or startup fails
+# (see the env-file block below for why).
 #
 # Required env keys (in the file):
 #   SLACK_WORKSPACE_ID      # T... id, find via Slack admin or auth.test API
@@ -38,23 +40,71 @@ set -euo pipefail
 
 log() { echo "gc-slack-adapter run.sh: $*" >&2; }
 
+# Zero-padded sort key for a dotted version, so 1.9 vs 1.25 compares
+# numerically. Deliberately not `sort -V`: this script runs under BSD
+# userlands (launchd) where that flag is not guaranteed.
+version_key() {
+  local trimmed major minor patch rest
+  trimmed="${1%%[!0-9.]*}"
+  IFS=. read -r major minor patch rest <<<"$trimmed"
+  printf '%05d%05d%05d\n' \
+    "$((10#0${major:-0}))" "$((10#0${minor:-0}))" "$((10#0${patch:-0}))"
+}
+
 bin_dir="$(cd "$(dirname "$0")" && pwd)"
 
+# A defaulted env-file path and one the operator named explicitly are
+# different cases and must not fail the same way. A missing default is
+# ordinary — supervised deployments often inject the env another way.
+# A missing GC_SLACK_ADAPTER_ENV is operator error, and continuing is
+# unsafe: the adapter validates that its required keys are *present*,
+# never where they came from, so it would boot against whatever Slack
+# credentials happen to be in the ambient environment (a decommissioned
+# workspace's token in a stale unit file, say) instead of exiting.
+#
+# SCOPE: this strict rule is service-only. scripts/slack_intake_common.py
+# reads the same GC_SLACK_ADAPTER_ENV for the `slack_chat_*` commands and
+# treats a missing path as "no env file" (this pack's own suites use that
+# idiom), so it stays lenient there. Tightening the command path is a
+# separate change — do not assume the variable means the same thing on
+# both sides.
+#
 # ${HOME:-} / ${XDG_CONFIG_HOME:-}: supervisor environments may not set
 # HOME, and set -u must not abort startup over a default we only need
 # when GC_SLACK_ADAPTER_ENV is unset. Honors XDG_CONFIG_HOME like the
-# README's manual-sourcing instructions do.
-env_file="${GC_SLACK_ADAPTER_ENV:-${XDG_CONFIG_HOME:-${HOME:-}/.config}/gc-slack-adapter/env}"
-if [[ -f "$env_file" ]]; then
+# README's manual-sourcing instructions do. With neither set, there is no
+# usable default at all: the path would degenerate to the root-owned
+# /.config/gc-slack-adapter/env, which the operator being handed it
+# cannot create. Leave it empty so no message can offer that path.
+if [[ -n "${XDG_CONFIG_HOME:-}" || -n "${HOME:-}" ]]; then
+  default_env_file="${XDG_CONFIG_HOME:-${HOME:-}/.config}/gc-slack-adapter/env"
+else
+  default_env_file=""
+fi
+env_file="${GC_SLACK_ADAPTER_ENV:-$default_env_file}"
+if [[ -n "$env_file" && -f "$env_file" ]]; then
   set -a
   # shellcheck source=/dev/null
   source "$env_file"
   set +a
+elif [[ -n "${GC_SLACK_ADAPTER_ENV:-}" ]]; then
+  log "ERROR: GC_SLACK_ADAPTER_ENV=$env_file does not exist — refusing to start on ambient credentials"
+  if [[ -n "$default_env_file" ]]; then
+    log "manual fix: create $env_file, or unset GC_SLACK_ADAPTER_ENV to fall back to $default_env_file"
+  else
+    log "manual fix: create $env_file (unsetting GC_SLACK_ADAPTER_ENV would not help: no HOME or XDG_CONFIG_HOME is set, so there is no default env file path)"
+  fi
+  exit 1
 else
   # Not fatal: supervised deployments may inject env another way, and
   # the adapter validates its required keys at startup with a precise
   # error.
-  log "WARNING: env file not found at $env_file — continuing with the inherited environment (adapter exits at startup if SLACK_WORKSPACE_ID / SLACK_BOT_TOKEN / GC_CITY_NAME are unset)"
+  if [[ -n "$default_env_file" ]]; then
+    log "WARNING: env file not found at $env_file"
+  else
+    log "WARNING: env file not found — no HOME or XDG_CONFIG_HOME is set, so there is no default env file path to read"
+  fi
+  log "continuing with the inherited environment (adapter exits at startup if SLACK_WORKSPACE_ID / SLACK_BOT_TOKEN / GC_CITY_NAME are unset)"
 fi
 
 adapter_bin="$bin_dir/gc-slack-adapter"
@@ -67,26 +117,84 @@ fi
 # Self-heal: rebuild the binary from the sources in this directory.
 log "binary missing at $adapter_bin — rebuilding from source (pack cache was likely re-materialized git-only by 'gc import install')"
 
-go_bin=""
-if command -v go >/dev/null 2>&1; then
-  go_bin="$(command -v go)"
-  # command -v can return a relative path (relative PATH entry), which
-  # would stop resolving once the build cd's into $bin_dir — pin it to
-  # an absolute path now.
+# `type -P` and not `command -v`: it forces a PATH search, so a shell
+# function, alias or builtin named `go` cannot shadow the lookup. That is
+# reachable here — an exported function propagates into this script, and
+# the env file sourced above is arbitrary shell. `command -v` returns the
+# bare name `go` for a function, which the normalization below would turn
+# into a nonexistent <cwd>/go while suppressing the fallback search, so a
+# real installed Go would go unfound behind a confusing build error.
+go_bin="$(type -P go 2>/dev/null || true)"
+if [[ -n "$go_bin" ]]; then
+  # Still can be a relative path (a relative PATH entry), which would
+  # stop resolving once the build cd's into $bin_dir — pin it to an
+  # absolute path now.
   if [[ "$go_bin" != /* ]]; then
     go_bin="$(cd "$(dirname "$go_bin")" && pwd)/$(basename "$go_bin")"
   fi
 else
   # Supervisor environments (launchd, systemd) often carry a minimal
-  # PATH. ${HOME:-} keeps set -u happy when HOME is unset.
-  for cand in /opt/homebrew/bin/go /usr/local/go/bin/go /usr/local/bin/go "${HOME:-}/go/bin/go"; do
+  # PATH — frequently one without /usr/bin at all, which hides a distro
+  # Go (`apt install golang-go`, `dnf install golang`) from `command -v`
+  # even though it is installed. ${HOME:-} keeps set -u happy when HOME
+  # is unset.
+  for cand in /opt/homebrew/bin/go /usr/local/go/bin/go /usr/local/bin/go \
+              /usr/bin/go /bin/go "${HOME:-}/go/bin/go"; do
     if [[ -x "$cand" ]]; then go_bin="$cand"; break; fi
   done
 fi
 if [[ -z "$go_bin" ]]; then
-  log "ERROR: no Go toolchain found (checked PATH, /opt/homebrew/bin, /usr/local/go/bin, /usr/local/bin, ~/go/bin)"
+  log "ERROR: no Go toolchain found (checked PATH, /opt/homebrew/bin, /usr/local/go/bin, /usr/local/bin, /usr/bin, /bin, ~/go/bin)"
   log "manual fix: cd $bin_dir && go build -o gc-slack-adapter ."
   exit 1
+fi
+
+# Check the toolchain against go.mod's `go` directive before building.
+# That directive is an exact patch floor, and CI installs precisely it
+# (ci.yml uses go-version-file), so CI can never surface a too-old
+# toolchain — the first host to hit it is a production supervisor, and
+# it deserves a named remedy rather than a raw compiler error. Only
+# hard-fail where Go cannot resolve this itself: GOTOOLCHAIN=local pins
+# it to what we found, whereas the default (auto) legitimately fetches
+# the required toolchain, and refusing that would strand hosts that
+# build fine today. An unparseable version on either side skips the
+# check — the compiler is still the backstop.
+go_version="$("$go_bin" version 2>/dev/null || echo 'version unknown')"
+need_go="$(sed -n 's/^go[[:space:]]\{1,\}\([0-9][0-9.]*\).*/\1/p' "$bin_dir/go.mod" 2>/dev/null | head -n1)"
+have_go="$(printf '%s\n' "$go_version" | sed -n 's/^go version go\([0-9][0-9.]*\).*/\1/p')"
+go_too_old=0
+if [[ -n "$need_go" && -n "$have_go" ]] &&
+   (( 10#$(version_key "$have_go") < 10#$(version_key "$need_go") )); then
+  go_too_old=1
+  if [[ "${GOTOOLCHAIN:-auto}" == "local" ]]; then
+    log "ERROR: need Go >= $need_go, found $have_go at $go_bin (GOTOOLCHAIN=local pins this toolchain)"
+    log "manual fix: install Go >= $need_go, unset GOTOOLCHAIN, or prebuild: cd $bin_dir && go build -o gc-slack-adapter ."
+    exit 1
+  fi
+  log "WARNING: $go_bin is $have_go but go.mod needs >= $need_go — Go will try to fetch the required toolchain (needs network and a writable module cache)"
+fi
+
+# go build REQUIRES a build cache and can only locate one through
+# GOCACHE, XDG_CACHE_HOME, or HOME. All three can be unset under
+# launchd/systemd — the same reason ${HOME:-} is guarded above — and the
+# build then dies with "build cache is required, but could not be
+# located". Fill only that gap: when Go can find a cache on its own,
+# leave it alone so rebuilds keep sharing the normal one.
+if [[ -z "${GOCACHE:-}" && -z "${XDG_CACHE_HOME:-}" && -z "${HOME:-}" ]]; then
+  export GOCACHE="${TMPDIR:-/tmp}/gc-slack-adapter-gocache"
+  log "no HOME / XDG_CACHE_HOME / GOCACHE in the environment — building with GOCACHE=$GOCACHE"
+fi
+
+# GOPATH is the same problem one layer down, but it answers a different
+# question and so needs its own guard: the module cache is located via
+# GOMODCACHE or GOPATH, and GOPATH derives from HOME *alone*. Gating it
+# on the build-cache condition above would strand exactly the operator
+# who partially remediates by exporting GOCACHE after reading the
+# previous error — HOME still unset, so the toolchain fetch dies on
+# "module cache not found: neither GOMODCACHE nor GOPATH is set".
+if [[ -z "${GOPATH:-}" && -z "${GOMODCACHE:-}" && -z "${HOME:-}" ]]; then
+  export GOPATH="${TMPDIR:-/tmp}/gc-slack-adapter-gopath"
+  log "no HOME / GOMODCACHE / GOPATH in the environment — building with GOPATH=$GOPATH"
 fi
 
 # Build to a PID-suffixed temp file and mv into place: concurrent
@@ -94,9 +202,12 @@ fi
 # nothing ever execs a half-written binary.
 tmp_bin="$adapter_bin.build.$$"
 trap 'rm -f "$tmp_bin"' EXIT
-log "building with $go_bin ($("$go_bin" version 2>/dev/null || echo 'version unknown'))"
+log "building with $go_bin ($go_version)"
 if ! (cd "$bin_dir" && "$go_bin" build -o "$tmp_bin" .); then
   log "ERROR: go build failed (compiler output above) — service cannot start"
+  if (( go_too_old )); then
+    log "likely cause: $go_bin is $have_go but go.mod needs >= $need_go — install Go >= $need_go or prebuild the binary"
+  fi
   log "manual fix: cd $bin_dir && go build -o gc-slack-adapter ."
   exit 1
 fi

--- a/slack-full/adapter/run.sh
+++ b/slack-full/adapter/run.sh
@@ -1,6 +1,18 @@
 #!/usr/bin/env bash
 #
-# run.sh — start the gc-slack-adapter in foreground.
+# run.sh — entrypoint for the gc-slack-adapter. This is the pack's
+# [[service]] proxy_process command, and it also works run by hand in a
+# dev checkout.
+#
+# WHY THE SERVICE COMMAND IS A SCRIPT, NOT THE BINARY: the adapter
+# binary is a gitignored build artifact, but `gc import install`
+# re-materializes the pack cache GIT-ONLY. When the service command
+# points straight at the binary, every pack pin bump wipes it and
+# strands the service until a human rebuilds by hand. This script is
+# checked in, so it survives every materialization — and when the
+# binary is missing it rebuilds it from the sources sitting next to it
+# before exec'ing (self-heal, loud logs, idempotent: an existing binary
+# is exec'd directly with no build).
 #
 # Reads secrets from a sourced env file. Default location:
 #   ~/.config/gc-slack-adapter/env
@@ -24,22 +36,71 @@
 
 set -euo pipefail
 
-env_file="${GC_SLACK_ADAPTER_ENV:-$HOME/.config/gc-slack-adapter/env}"
-if [[ ! -f "$env_file" ]]; then
-  cat <<EOF >&2
-gc-slack-adapter: env file not found at $env_file
-Create it with at minimum:
+log() { echo "gc-slack-adapter run.sh: $*" >&2; }
 
-  SLACK_WORKSPACE_ID=T01234567
-  SLACK_BOT_TOKEN=xoxb-...
-  SLACK_SIGNING_SECRET=...
+bin_dir="$(cd "$(dirname "$0")" && pwd)"
 
-EOF
+# ${HOME:-} / ${XDG_CONFIG_HOME:-}: supervisor environments may not set
+# HOME, and set -u must not abort startup over a default we only need
+# when GC_SLACK_ADAPTER_ENV is unset. Honors XDG_CONFIG_HOME like the
+# README's manual-sourcing instructions do.
+env_file="${GC_SLACK_ADAPTER_ENV:-${XDG_CONFIG_HOME:-${HOME:-}/.config}/gc-slack-adapter/env}"
+if [[ -f "$env_file" ]]; then
+  set -a
+  # shellcheck source=/dev/null
+  source "$env_file"
+  set +a
+else
+  # Not fatal: supervised deployments may inject env another way, and
+  # the adapter validates its required keys at startup with a precise
+  # error.
+  log "WARNING: env file not found at $env_file — continuing with the inherited environment (adapter exits at startup if SLACK_WORKSPACE_ID / SLACK_BOT_TOKEN / GC_CITY_NAME are unset)"
+fi
+
+adapter_bin="$bin_dir/gc-slack-adapter"
+
+# Fast path (idempotent): a previously built binary — exec, no build.
+if [[ -x "$adapter_bin" ]]; then
+  exec "$adapter_bin" "$@"
+fi
+
+# Self-heal: rebuild the binary from the sources in this directory.
+log "binary missing at $adapter_bin — rebuilding from source (pack cache was likely re-materialized git-only by 'gc import install')"
+
+go_bin=""
+if command -v go >/dev/null 2>&1; then
+  go_bin="$(command -v go)"
+  # command -v can return a relative path (relative PATH entry), which
+  # would stop resolving once the build cd's into $bin_dir — pin it to
+  # an absolute path now.
+  if [[ "$go_bin" != /* ]]; then
+    go_bin="$(cd "$(dirname "$go_bin")" && pwd)/$(basename "$go_bin")"
+  fi
+else
+  # Supervisor environments (launchd, systemd) often carry a minimal
+  # PATH. ${HOME:-} keeps set -u happy when HOME is unset.
+  for cand in /opt/homebrew/bin/go /usr/local/go/bin/go /usr/local/bin/go "${HOME:-}/go/bin/go"; do
+    if [[ -x "$cand" ]]; then go_bin="$cand"; break; fi
+  done
+fi
+if [[ -z "$go_bin" ]]; then
+  log "ERROR: no Go toolchain found (checked PATH, /opt/homebrew/bin, /usr/local/go/bin, /usr/local/bin, ~/go/bin)"
+  log "manual fix: cd $bin_dir && go build -o gc-slack-adapter ."
   exit 1
 fi
 
-# shellcheck disable=SC1090
-set -a; source "$env_file"; set +a
-
-bin_dir="$(cd "$(dirname "$0")" && pwd)"
-exec "$bin_dir/gc-slack-adapter"
+# Build to a PID-suffixed temp file and mv into place: concurrent
+# supervisor restarts each build their own copy, the mv is atomic, and
+# nothing ever execs a half-written binary.
+tmp_bin="$adapter_bin.build.$$"
+trap 'rm -f "$tmp_bin"' EXIT
+log "building with $go_bin ($("$go_bin" version 2>/dev/null || echo 'version unknown'))"
+if ! (cd "$bin_dir" && "$go_bin" build -o "$tmp_bin" .); then
+  log "ERROR: go build failed (compiler output above) — service cannot start"
+  log "manual fix: cd $bin_dir && go build -o gc-slack-adapter ."
+  exit 1
+fi
+mv -f "$tmp_bin" "$adapter_bin"
+trap - EXIT
+log "rebuilt $adapter_bin OK — starting adapter"
+exec "$adapter_bin" "$@"

--- a/slack-full/pack.toml
+++ b/slack-full/pack.toml
@@ -2,9 +2,11 @@
 #
 # Pack-shipped binaries:
 #
-# - Adapter (./adapter/gc-slack-adapter, built from adapter/main.go).
-#   Public-facing Slack webhook receiver + outbound publisher. The
-#   [[service]] block below has gc supervise it as a proxy_process.
+# - Adapter (./adapter/gc-slack-adapter, built from the Go module in
+#   adapter/). Public-facing Slack webhook receiver + outbound
+#   publisher. The [[service]] block below has gc supervise it as a
+#   proxy_process via adapter/run.sh, which rebuilds the binary on
+#   missing so git-only pack re-materializations can't strand it.
 #
 # - Operator CLI (./cli/gc-slack-cli, built from cli/main.go +
 #   cli/cmd/). Backs the `gc slack <cmd>` verb surface (import-app,
@@ -28,9 +30,14 @@ schema = 2
 # /slack/events (Tailscale Funnel terminates there); proxy_process
 # accepts that — the controller only owns the UDS lifecycle.
 #
-# Secrets (SLACK_BOT_TOKEN, SLACK_SIGNING_SECRET, SLACK_WORKSPACE_ID)
-# stay in ~/.config/gc-slack-adapter/env and are inherited via
-# os.Environ() at start time. See README.md "Secrets".
+# The command is adapter/run.sh, NOT the binary: the binary is a
+# gitignored build artifact and `gc import install` re-materializes
+# the pack cache git-only, so a command pointing at the binary strands
+# the service on every pin bump. run.sh is checked in, sources the
+# secrets env file (~/.config/gc-slack-adapter/env, see README.md
+# "Secrets" — SLACK_BOT_TOKEN, SLACK_SIGNING_SECRET,
+# SLACK_WORKSPACE_ID), rebuilds adapter/gc-slack-adapter from source
+# when it is missing, and execs it.
 #
 # [[service]] block re-enabled 2026-05-03 afternoon: gc-cdf shipped
 # the URL-prefix fix so GC_SERVICE_URL_PREFIX now resolves to
@@ -45,5 +52,5 @@ kind = "proxy_process"
 visibility = "private"
 
 [service.process]
-command = ["./adapter/gc-slack-adapter"]
+command = ["./adapter/run.sh"]
 health_path = "/healthz"

--- a/slack-full/tests/test_adapter_run_sh.py
+++ b/slack-full/tests/test_adapter_run_sh.py
@@ -1,0 +1,224 @@
+"""Behavioral tests for adapter/run.sh — the [[service]] entrypoint.
+
+run.sh is the pack's defense against pin-bump outages: the adapter
+binary is a gitignored build artifact, and ``gc import install``
+re-materializes the pack cache git-only, so a service command pointing
+straight at the binary dies on every pin bump. run.sh is checked in and
+rebuilds the binary on missing before exec'ing it.
+
+These tests run the real script in a temp dir that mimics a fresh
+git-only materialization, with a stub ``go`` toolchain on PATH so they
+are fast and hermetic (no real compile, no network):
+
+  * missing binary -> exactly one ``go build`` -> built binary exec'd,
+  * existing gc-slack-adapter -> exec'd directly, no build (idempotency),
+  * env file is sourced and reaches the adapter process,
+  * missing env file warns but still starts,
+  * pack.toml keeps pointing the service at a checked-in command.
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import shutil
+import subprocess
+
+import pytest
+
+PACK_DIR = pathlib.Path(__file__).resolve().parent.parent
+RUN_SH = PACK_DIR / "adapter" / "run.sh"
+
+GO_STUB = """#!/usr/bin/env bash
+# Stub Go toolchain: records every invocation (with its cwd, so tests
+# can pin WHERE the build ran), and on `build` writes an executable at
+# the -o target that prints a marker instead of compiling.
+echo "go $* cwd=$PWD" >> "$GO_STUB_LOG"
+if [ "$1" = "version" ]; then
+  echo "go version go0.0-stub"
+  exit 0
+fi
+if [ "$1" = "build" ]; then
+  out=""
+  prev=""
+  for a in "$@"; do
+    [ "$prev" = "-o" ] && out="$a"
+    prev="$a"
+  done
+  [ -n "$out" ] || { echo "go stub: no -o target" >&2; exit 2; }
+  printf '%s\\n' '#!/usr/bin/env bash' \\
+    'echo "STUB_ADAPTER_RAN pwd=$PWD MARKER_VAR=${MARKER_VAR:-unset}"' > "$out"
+  chmod +x "$out"
+  exit 0
+fi
+echo "go stub: unexpected invocation: $*" >&2
+exit 2
+"""
+
+
+@pytest.fixture()
+def harness(tmp_path: pathlib.Path):
+    """Adapter dir holding only run.sh (a git-only materialization) plus
+    a stub `go` prepended to PATH."""
+    adapter = tmp_path / "adapter"
+    adapter.mkdir()
+    shutil.copy(RUN_SH, adapter / "run.sh")
+    (adapter / "run.sh").chmod(0o755)
+
+    stub_bin = tmp_path / "stubbin"
+    stub_bin.mkdir()
+    go = stub_bin / "go"
+    go.write_text(GO_STUB)
+    go.chmod(0o755)
+
+    go_log = tmp_path / "go-invocations.log"
+
+    def run(
+        env_file: pathlib.Path | None = None,
+        extra_env: dict | None = None,
+        drop_env: list[str] | None = None,
+    ):
+        env = dict(os.environ)
+        env["PATH"] = f"{stub_bin}:{env['PATH']}"
+        env["GO_STUB_LOG"] = str(go_log)
+        env["GC_SLACK_ADAPTER_ENV"] = str(env_file or tmp_path / "no-such-env")
+        env.update(extra_env or {})
+        for key in drop_env or []:
+            env.pop(key, None)
+        return subprocess.run(
+            [str(adapter / "run.sh")],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=30,
+        )
+
+    def go_invocations() -> list[str]:
+        if not go_log.exists():
+            return []
+        return [l for l in go_log.read_text().splitlines() if l.startswith("go build")]
+
+    return adapter, run, go_invocations
+
+
+def test_missing_binary_is_rebuilt_and_execd(harness):
+    adapter, run, go_invocations = harness
+    proc = run()
+    assert proc.returncode == 0, proc.stderr
+    assert "STUB_ADAPTER_RAN" in proc.stdout
+    # Loud logging: the self-heal explains itself on stderr.
+    assert "rebuilding from source" in proc.stderr
+    assert "gc import install" in proc.stderr
+    # Exactly one build, of the package (".") FROM the adapter dir —
+    # the colocated sources, not whatever cwd the supervisor used.
+    builds = go_invocations()
+    assert len(builds) == 1, builds
+    assert " . cwd=" in builds[0], builds[0]
+    build_cwd = builds[0].split(" cwd=", 1)[1]
+    assert pathlib.Path(build_cwd).resolve() == adapter.resolve(), builds[0]
+    # Binary published atomically at its canonical path, no temp left.
+    assert (adapter / "gc-slack-adapter").exists()
+    assert not list(adapter.glob("gc-slack-adapter.build.*"))
+
+
+def test_existing_binary_skips_build(harness):
+    adapter, run, go_invocations = harness
+    prebuilt = adapter / "gc-slack-adapter"
+    prebuilt.write_text("#!/usr/bin/env bash\necho PREBUILT_RAN\n")
+    prebuilt.chmod(0o755)
+    proc = run()
+    assert proc.returncode == 0, proc.stderr
+    assert "PREBUILT_RAN" in proc.stdout
+    assert go_invocations() == []
+
+
+def test_self_heal_is_idempotent_across_restarts(harness):
+    adapter, run, go_invocations = harness
+    first = run()
+    second = run()
+    assert first.returncode == 0 and second.returncode == 0
+    assert "STUB_ADAPTER_RAN" in second.stdout
+    # Only the first start built; the restart exec'd the existing binary.
+    assert len(go_invocations()) == 1
+
+
+def test_env_file_is_sourced_into_adapter_env(harness):
+    adapter, run, go_invocations = harness
+    env_file = adapter.parent / "envfile"
+    env_file.write_text("MARKER_VAR=from-env-file\n")
+    proc = run(env_file=env_file)
+    assert proc.returncode == 0, proc.stderr
+    assert "MARKER_VAR=from-env-file" in proc.stdout
+    # And no missing-env-file warning when the file exists.
+    assert "env file not found" not in proc.stderr
+
+
+def test_missing_env_file_warns_but_still_starts(harness):
+    adapter, run, go_invocations = harness
+    proc = run()
+    assert proc.returncode == 0, proc.stderr
+    assert "env file not found" in proc.stderr
+    assert "STUB_ADAPTER_RAN" in proc.stdout
+
+
+def test_starts_without_home_set(harness):
+    """Supervisor environments may not set HOME; under `set -u` an
+    unguarded $HOME would abort before the fast path ever ran."""
+    adapter, run, go_invocations = harness
+    proc = run(drop_env=["HOME", "XDG_CONFIG_HOME", "GC_SLACK_ADAPTER_ENV"])
+    assert proc.returncode == 0, proc.stderr
+    assert "STUB_ADAPTER_RAN" in proc.stdout
+
+
+def test_stale_build_temp_is_ignored(harness):
+    """A crash mid-build (SIGKILL, host loss) can leave a PID-suffixed
+    temp behind; it must never be exec'd, and a fresh start must still
+    build and run the real binary."""
+    adapter, run, go_invocations = harness
+    stale = adapter / "gc-slack-adapter.build.99999"
+    stale.write_text("#!/usr/bin/env bash\necho STALE_TEMP_RAN\n")
+    stale.chmod(0o755)
+    proc = run()
+    assert proc.returncode == 0, proc.stderr
+    assert "STALE_TEMP_RAN" not in proc.stdout
+    assert "STUB_ADAPTER_RAN" in proc.stdout
+    assert len(go_invocations()) == 1
+
+
+def test_pack_service_command_is_the_checked_in_run_sh():
+    """The [[service]] command must stay a checked-in path — pointing it
+    back at the gitignored binary reintroduces the stranded-service
+    outage on the next pin bump."""
+    try:
+        import tomllib
+    except ModuleNotFoundError:  # pragma: no cover - py<3.11
+        pytest.skip("tomllib unavailable")
+    with open(PACK_DIR / "pack.toml", "rb") as fh:
+        pack = tomllib.load(fh)
+    services = {s["name"]: s for s in pack.get("service", [])}
+    assert "slack" in services, "slack [[service]] block missing from pack.toml"
+    command = services["slack"]["process"]["command"]
+    assert command == ["./adapter/run.sh"], command
+    rel = pathlib.Path(command[0])
+    target = PACK_DIR / rel
+    assert target.exists() and os.access(target, os.X_OK)
+    # Not gitignored (check-ignore: 1 = not ignored; 0 = ignored;
+    # anything else = git itself failed and proves nothing):
+    ignored = subprocess.run(
+        ["git", "check-ignore", str(rel)],
+        cwd=PACK_DIR,
+        capture_output=True,
+        text=True,
+    )
+    assert ignored.returncode == 1, (
+        f"{rel}: git check-ignore exited {ignored.returncode} "
+        f"(0 means gitignored — service would strand): {ignored.stderr}"
+    )
+    # And actually tracked, so a materialization really ships it:
+    tracked = subprocess.run(
+        ["git", "ls-files", "--error-unmatch", str(rel)],
+        cwd=PACK_DIR,
+        capture_output=True,
+        text=True,
+    )
+    assert tracked.returncode == 0, f"{rel} is not tracked by git: {tracked.stderr}"

--- a/slack-full/tests/test_adapter_run_sh.py
+++ b/slack-full/tests/test_adapter_run_sh.py
@@ -13,8 +13,19 @@ are fast and hermetic (no real compile, no network):
   * missing binary -> exactly one ``go build`` -> built binary exec'd,
   * existing gc-slack-adapter -> exec'd directly, no build (idempotency),
   * env file is sourced and reaches the adapter process,
-  * missing env file warns but still starts,
+  * a missing *defaulted* env file warns but still starts, while a
+    missing *explicitly configured* one is fatal (starting on ambient
+    credentials would post to whatever workspace is in the environment),
+  * the self-heal's failure paths exit 1 and publish nothing: no Go new
+    enough for go.mod under ``GOTOOLCHAIN=local``, and ``go build``
+    failing,
+  * the self-heal survives the minimal supervisor environment it
+    targets (no HOME) by supplying a build cache,
   * pack.toml keeps pointing the service at a checked-in command.
+
+The harness owns HOME/XDG_CONFIG_HOME so the *defaulted* env-file path
+resolves somewhere hermetic and absent, rather than reading the
+developer's real ``~/.config/gc-slack-adapter/env``.
 """
 
 from __future__ import annotations
@@ -28,17 +39,26 @@ import pytest
 
 PACK_DIR = pathlib.Path(__file__).resolve().parent.parent
 RUN_SH = PACK_DIR / "adapter" / "run.sh"
+GO_MOD = PACK_DIR / "adapter" / "go.mod"
 
 GO_STUB = """#!/usr/bin/env bash
 # Stub Go toolchain: records every invocation (with its cwd, so tests
 # can pin WHERE the build ran), and on `build` writes an executable at
-# the -o target that prints a marker instead of compiling.
+# the -o target that prints a marker instead of compiling. Two knobs let
+# tests drive run.sh's failure paths: GO_STUB_VERSION (what `go version`
+# reports, defaulting high enough to satisfy any go.mod directive) and
+# GO_STUB_BUILD_FAILS (make `build` exit non-zero).
 echo "go $* cwd=$PWD" >> "$GO_STUB_LOG"
 if [ "$1" = "version" ]; then
-  echo "go version go0.0-stub"
+  echo "go version go${GO_STUB_VERSION:-99.0.0} stub/stub"
   exit 0
 fi
 if [ "$1" = "build" ]; then
+  echo "buildenv GOCACHE=${GOCACHE:-unset} GOPATH=${GOPATH:-unset}" >> "$GO_STUB_LOG"
+  if [ -n "${GO_STUB_BUILD_FAILS:-}" ]; then
+    echo "go stub: simulated compile failure" >&2
+    exit 1
+  fi
   out=""
   prev=""
   for a in "$@"; do
@@ -56,20 +76,36 @@ exit 2
 """
 
 
+def required_go_version() -> str:
+    """The `go` directive run.sh asserts the toolchain against."""
+    for line in GO_MOD.read_text().splitlines():
+        if line.startswith("go "):
+            return line.split(None, 1)[1].strip()
+    raise AssertionError(f"no `go` directive in {GO_MOD}")
+
+
 @pytest.fixture()
 def harness(tmp_path: pathlib.Path):
-    """Adapter dir holding only run.sh (a git-only materialization) plus
-    a stub `go` prepended to PATH."""
+    """Adapter dir holding what a git-only materialization ships —
+    run.sh and go.mod, no binary — plus a stub `go` on PATH."""
     adapter = tmp_path / "adapter"
     adapter.mkdir()
     shutil.copy(RUN_SH, adapter / "run.sh")
     (adapter / "run.sh").chmod(0o755)
+    # run.sh reads go.mod's `go` directive to assert the toolchain, and a
+    # real materialization always ships it, so the harness must too.
+    shutil.copy(GO_MOD, adapter / "go.mod")
 
     stub_bin = tmp_path / "stubbin"
     stub_bin.mkdir()
     go = stub_bin / "go"
     go.write_text(GO_STUB)
     go.chmod(0o755)
+
+    # A HOME the tests own: the defaulted env-file path must resolve
+    # somewhere hermetic and absent, never the developer's real one.
+    fake_home = tmp_path / "home"
+    (fake_home / ".config").mkdir(parents=True)
 
     go_log = tmp_path / "go-invocations.log"
 
@@ -81,7 +117,13 @@ def harness(tmp_path: pathlib.Path):
         env = dict(os.environ)
         env["PATH"] = f"{stub_bin}:{env['PATH']}"
         env["GO_STUB_LOG"] = str(go_log)
-        env["GC_SLACK_ADAPTER_ENV"] = str(env_file or tmp_path / "no-such-env")
+        env["HOME"] = str(fake_home)
+        env["XDG_CONFIG_HOME"] = str(fake_home / ".config")
+        # An explicitly set but missing GC_SLACK_ADAPTER_ENV is fatal by
+        # design, so the "no env file" baseline is the defaulted path.
+        env.pop("GC_SLACK_ADAPTER_ENV", None)
+        if env_file is not None:
+            env["GC_SLACK_ADAPTER_ENV"] = str(env_file)
         env.update(extra_env or {})
         for key in drop_env or []:
             env.pop(key, None)
@@ -98,11 +140,16 @@ def harness(tmp_path: pathlib.Path):
             return []
         return [l for l in go_log.read_text().splitlines() if l.startswith("go build")]
 
-    return adapter, run, go_invocations
+    def build_environments() -> list[str]:
+        if not go_log.exists():
+            return []
+        return [l for l in go_log.read_text().splitlines() if l.startswith("buildenv ")]
+
+    return adapter, run, go_invocations, build_environments
 
 
 def test_missing_binary_is_rebuilt_and_execd(harness):
-    adapter, run, go_invocations = harness
+    adapter, run, go_invocations, _ = harness
     proc = run()
     assert proc.returncode == 0, proc.stderr
     assert "STUB_ADAPTER_RAN" in proc.stdout
@@ -122,7 +169,7 @@ def test_missing_binary_is_rebuilt_and_execd(harness):
 
 
 def test_existing_binary_skips_build(harness):
-    adapter, run, go_invocations = harness
+    adapter, run, go_invocations, _ = harness
     prebuilt = adapter / "gc-slack-adapter"
     prebuilt.write_text("#!/usr/bin/env bash\necho PREBUILT_RAN\n")
     prebuilt.chmod(0o755)
@@ -133,7 +180,7 @@ def test_existing_binary_skips_build(harness):
 
 
 def test_self_heal_is_idempotent_across_restarts(harness):
-    adapter, run, go_invocations = harness
+    adapter, run, go_invocations, _ = harness
     first = run()
     second = run()
     assert first.returncode == 0 and second.returncode == 0
@@ -143,7 +190,7 @@ def test_self_heal_is_idempotent_across_restarts(harness):
 
 
 def test_env_file_is_sourced_into_adapter_env(harness):
-    adapter, run, go_invocations = harness
+    adapter, run, go_invocations, _ = harness
     env_file = adapter.parent / "envfile"
     env_file.write_text("MARKER_VAR=from-env-file\n")
     proc = run(env_file=env_file)
@@ -153,28 +200,195 @@ def test_env_file_is_sourced_into_adapter_env(harness):
     assert "env file not found" not in proc.stderr
 
 
-def test_missing_env_file_warns_but_still_starts(harness):
-    adapter, run, go_invocations = harness
+def test_missing_default_env_file_warns_but_still_starts(harness):
+    """Nothing was configured, so the absent default is ordinary:
+    supervised deployments legitimately inject the env another way, and
+    the adapter itself rejects a missing required key."""
+    adapter, run, go_invocations, _ = harness
     proc = run()
     assert proc.returncode == 0, proc.stderr
     assert "env file not found" in proc.stderr
     assert "STUB_ADAPTER_RAN" in proc.stdout
 
 
-def test_starts_without_home_set(harness):
-    """Supervisor environments may not set HOME; under `set -u` an
-    unguarded $HOME would abort before the fast path ever ran."""
-    adapter, run, go_invocations = harness
-    proc = run(drop_env=["HOME", "XDG_CONFIG_HOME", "GC_SLACK_ADAPTER_ENV"])
+def test_explicit_missing_env_file_is_fatal(harness):
+    """An operator-named GC_SLACK_ADAPTER_ENV that does not exist must
+    stop startup. The adapter validates that credentials are *present*,
+    never where they came from, so continuing would boot it against
+    whatever Slack token is in the ambient environment — a
+    wrong-workspace start, silently, behind one warning line."""
+    adapter, run, go_invocations, _ = harness
+    missing = adapter.parent / "no-such-env"
+    proc = run(env_file=missing)
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+    assert f"GC_SLACK_ADAPTER_ENV={missing} does not exist" in proc.stderr
+    assert "ambient credentials" in proc.stderr
+    # Nothing started, and the failure came before any build.
+    assert "STUB_ADAPTER_RAN" not in proc.stdout
+    assert go_invocations() == []
+
+
+def test_explicit_env_file_is_still_fatal_when_a_binary_exists(harness):
+    """The check must precede the exec fast path — otherwise the common
+    case (binary already built) skips it entirely."""
+    adapter, run, go_invocations, _ = harness
+    prebuilt = adapter / "gc-slack-adapter"
+    prebuilt.write_text("#!/usr/bin/env bash\necho PREBUILT_RAN\n")
+    prebuilt.chmod(0o755)
+    proc = run(env_file=adapter.parent / "no-such-env")
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+    assert "PREBUILT_RAN" not in proc.stdout
+
+
+def test_self_heal_builds_when_home_is_unset(harness):
+    """Supervisor environments may not set HOME. Under `set -u` an
+    unguarded $HOME aborts before the fast path — and `go build` then
+    fails a second way, because it can only locate a build cache via
+    GOCACHE, XDG_CACHE_HOME, or HOME. Assert the *build* survives, not
+    merely the shell."""
+    adapter, run, go_invocations, build_environments = harness
+    proc = run(
+        drop_env=[
+            "HOME",
+            "XDG_CONFIG_HOME",
+            "XDG_CACHE_HOME",
+            "GOCACHE",
+            "GOPATH",
+            # GOMODCACHE too: it is the other way Go can locate a module
+            # cache, so leaving the developer's own exported value in
+            # place would stop this test simulating the bare supervisor
+            # environment it is named for.
+            "GOMODCACHE",
+            "GC_SLACK_ADAPTER_ENV",
+        ]
+    )
     assert proc.returncode == 0, proc.stderr
     assert "STUB_ADAPTER_RAN" in proc.stdout
+    assert len(go_invocations()) == 1, go_invocations()
+    # The build was handed a usable cache and module path rather than
+    # inheriting neither, which is what actually fails on such a host.
+    tmp = os.environ.get("TMPDIR", "/tmp").rstrip("/")
+    assert build_environments() == [
+        f"buildenv GOCACHE={tmp}/gc-slack-adapter-gocache "
+        f"GOPATH={tmp}/gc-slack-adapter-gopath"
+    ], build_environments()
+    assert (adapter / "gc-slack-adapter").exists()
+
+
+@pytest.mark.parametrize("cache_var", ["XDG_CACHE_HOME", "GOCACHE"])
+def test_gopath_is_defaulted_whenever_home_is_unset(harness, tmp_path, cache_var):
+    """GOPATH must not be gated on the build-cache condition: the module
+    cache is located via GOMODCACHE or GOPATH, and GOPATH derives from
+    HOME *alone*. The operator who partially remediates — reads the cache
+    error, exports GOCACHE, leaves HOME unset — would otherwise still
+    lose a toolchain fetch to ``module cache not found: neither
+    GOMODCACHE nor GOPATH is set``, the same stranding this self-heal
+    exists to remove. An already-usable cache is left alone."""
+    adapter, run, go_invocations, build_environments = harness
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    drop = [
+        "HOME",
+        "XDG_CONFIG_HOME",
+        "XDG_CACHE_HOME",
+        "GOCACHE",
+        "GOPATH",
+        "GOMODCACHE",
+        "GC_SLACK_ADAPTER_ENV",
+    ]
+    drop.remove(cache_var)  # extra_env is applied before drop_env
+    proc = run(extra_env={cache_var: str(cache_dir)}, drop_env=drop)
+    assert proc.returncode == 0, proc.stderr
+    assert "STUB_ADAPTER_RAN" in proc.stdout
+    assert len(go_invocations()) == 1, go_invocations()
+    tmp = os.environ.get("TMPDIR", "/tmp").rstrip("/")
+    expected_gocache = str(cache_dir) if cache_var == "GOCACHE" else "unset"
+    assert build_environments() == [
+        f"buildenv GOCACHE={expected_gocache} "
+        f"GOPATH={tmp}/gc-slack-adapter-gopath"
+    ], build_environments()
+
+
+def test_no_default_env_file_path_is_never_advertised(harness):
+    """With neither HOME nor XDG_CONFIG_HOME set — the supervisor
+    environment this script targets — the "default" env file path
+    degenerates to the root-owned /.config/gc-slack-adapter/env. Never
+    print it: it reads as a remedy, and it is one the operator cannot
+    carry out."""
+    adapter, run, go_invocations, _ = harness
+    proc = run(drop_env=["HOME", "XDG_CONFIG_HOME", "GC_SLACK_ADAPTER_ENV"])
+    assert proc.returncode == 0, proc.stderr
+    assert "/.config/gc-slack-adapter/env" not in proc.stderr, proc.stderr
+    assert "no default env file path" in proc.stderr
+    # Still only a warning: the adapter fail-fasts on a missing key itself.
+    assert "STUB_ADAPTER_RAN" in proc.stdout
+
+
+def test_shell_function_named_go_does_not_shadow_the_toolchain(harness):
+    """``command -v go`` returns the bare name ``go`` for a shell
+    function, which the relative-path normalization turns into a
+    nonexistent <cwd>/go while suppressing the absolute-path fallback —
+    so a real installed Go goes unfound. Exported functions do propagate
+    into this script, and the env file it sources is arbitrary shell, so
+    the lookup must force a PATH search."""
+    adapter, run, go_invocations, _ = harness
+    env_file = adapter.parent / "envfile-with-function"
+    env_file.write_text("go() { echo 'shadowed go was called' >&2; return 127; }\n")
+    proc = run(env_file=env_file)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "shadowed go was called" not in proc.stderr
+    assert "no Go toolchain found" not in proc.stderr
+    # The stub on PATH built it, not the function and not a bogus ./go.
+    assert len(go_invocations()) == 1, go_invocations()
+    assert "STUB_ADAPTER_RAN" in proc.stdout
+
+
+def test_toolchain_older_than_go_mod_is_rejected_when_pinned(harness):
+    """GOTOOLCHAIN=local means Go cannot upgrade itself, so a toolchain
+    below go.mod's directive can never build: say so with a remedy
+    instead of leaking a raw compiler error."""
+    adapter, run, go_invocations, _ = harness
+    proc = run(extra_env={"GO_STUB_VERSION": "1.0.0", "GOTOOLCHAIN": "local"})
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+    assert f"need Go >= {required_go_version()}, found 1.0.0" in proc.stderr
+    assert "GOTOOLCHAIN=local" in proc.stderr
+    # Refused before building, and nothing was published.
+    assert go_invocations() == []
+    assert not (adapter / "gc-slack-adapter").exists()
+    assert not list(adapter.glob("gc-slack-adapter.build.*"))
+
+
+def test_toolchain_older_than_go_mod_still_builds_when_downloadable(harness):
+    """Under the default GOTOOLCHAIN=auto, Go fetches the required
+    toolchain itself. Warn, but do not refuse — hosts that build fine
+    today must keep building."""
+    adapter, run, go_invocations, _ = harness
+    proc = run(extra_env={"GO_STUB_VERSION": "1.0.0"}, drop_env=["GOTOOLCHAIN"])
+    assert proc.returncode == 0, proc.stderr
+    assert f"go.mod needs >= {required_go_version()}" in proc.stderr
+    assert "STUB_ADAPTER_RAN" in proc.stdout
+    assert len(go_invocations()) == 1, go_invocations()
+
+
+def test_go_build_failure_exits_1_and_publishes_nothing(harness):
+    """The other operational failure path: a real compile error must
+    exit non-zero with the manual-fix hint, leave no half-built binary
+    at the canonical path, and clean up its temp."""
+    adapter, run, go_invocations, _ = harness
+    proc = run(extra_env={"GO_STUB_BUILD_FAILS": "1"})
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+    assert "go build failed" in proc.stderr
+    assert "manual fix: cd " in proc.stderr
+    assert "STUB_ADAPTER_RAN" not in proc.stdout
+    assert not (adapter / "gc-slack-adapter").exists()
+    assert not list(adapter.glob("gc-slack-adapter.build.*"))
 
 
 def test_stale_build_temp_is_ignored(harness):
     """A crash mid-build (SIGKILL, host loss) can leave a PID-suffixed
     temp behind; it must never be exec'd, and a fresh start must still
     build and run the real binary."""
-    adapter, run, go_invocations = harness
+    adapter, run, go_invocations, _ = harness
     stale = adapter / "gc-slack-adapter.build.99999"
     stale.write_text("#!/usr/bin/env bash\necho STALE_TEMP_RAN\n")
     stale.chmod(0o755)


### PR DESCRIPTION
## Symptom

After a pack pin bump (`gc import install`), `gc service list` shows the `slack` service dead and it never comes back on its own. Nothing is wrong with the pack contents — the service command's target simply no longer exists. We were bitten by this twice in production before fixing it at the root.

## Root cause

The `[[service]]` proxy_process command points straight at `./adapter/gc-slack-adapter`, which is a **gitignored build artifact**. `gc import install` re-materializes the pack cache **git-only**, so every pin bump wipes the binary and leaves the supervisor exec'ing a path that isn't there, until a human notices and rebuilds by hand.

## Fix

The service command becomes `./adapter/run.sh`, which is checked in and therefore survives every materialization:

- **Fast path (idempotent):** an existing executable `adapter/gc-slack-adapter` is exec'd directly — no build, no behavior change for a healthy deployment or a dev checkout.
- **Self-heal:** when the binary is missing, run.sh says so loudly on stderr, finds a Go toolchain (PATH first, then Homebrew/system fallbacks for the minimal PATH of supervisor environments like launchd/systemd), and rebuilds from the sources sitting next to it. The build goes to a PID-suffixed temp file and is published with an atomic rename, so concurrent supervisor restarts can't exec a half-written binary.
- **Env sourcing moves into the entrypoint:** run.sh sources `~/.config/gc-slack-adapter/env` (override: `GC_SLACK_ADAPTER_ENV`) as before, but a missing env file is now a loud warning rather than a hard exit — supervised deployments may inject env another way, and the adapter already fail-fasts at startup with a precise `missing required env vars:` error.

`pack.toml`, `.gitignore`, README and CONTRIBUTING are updated to describe the new scheme.

## How verified

- New hermetic pytest suite (`slack-full/tests/test_adapter_run_sh.py`, runs in this repo's existing CI pytest step): a stub `go` toolchain on PATH records invocations and fakes the build, covering build-on-missing (exactly one build, binary published, no temp files left), exec-without-build when the binary exists, idempotency across restarts, env-file sourcing reaching the adapter process, the missing-env-file warning, HOME-unset startup (supervisors may not set HOME), a stale mid-build temp file being ignored, and a guard that `pack.toml` keeps pointing the service at a checked-in, non-gitignored command (so this outage class can't be silently reintroduced).
- Full `slack-full/tests` suite passes (391 tests); `shellcheck` clean; registry validation passes.
- The same entrypoint design has been running in production in our fork since 2026-08-21 and has survived multiple pin bumps since, including rebuild-from-cold on a supervisor with a minimal PATH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
