### PR TITLE
feat(roles): add durable P0 notice control plane

### DIFF
--- a/gascity/commands/notice/command.toml
+++ b/gascity/commands/notice/command.toml
@@ -1,0 +1,2 @@
+description = "Send, acknowledge, and reconcile durable role-addressed notices"
+run = "../../roles/assets/scripts/p0_notice.py"

--- a/gascity/commands/notice/help.md
+++ b/gascity/commands/notice/help.md
@@ -1,0 +1,16 @@
+Send, acknowledge, and reconcile durable role-addressed notices.
+
+Usage:
+
+```text
+gc gc notice send --to-role <role> --work-ref <bead-or-pr> \
+  --state-fingerprint <immutable-state> --subject <summary> --message <body>
+gc gc notice ack <notice-id> --disposition <accepted|dismissed|superseded>
+gc gc notice reconcile [--limit <1-100>] [--retention-seconds <seconds>]
+```
+
+`send` records a durable mail receipt before it reports acceptance. `ack` is a
+recipient-role guardrail: it reads and archives that receipt before recording
+the supplied disposition. `reconcile` is a bounded maintenance operation; it
+checks canonical-role routability and escalates to a human only after five
+minutes without a routable role.

--- a/gascity/roles/assets/scripts/p0_notice.py
+++ b/gascity/roles/assets/scripts/p0_notice.py
@@ -231,7 +231,20 @@ def reconcile(args: argparse.Namespace) -> int:
     escalated = 0
     with locked_index() as data:
         notices = data.setdefault("notices", {})
-        for nid, record in list(notices.items())[:args.limit]:
+        notice_ids = list(notices)
+        offset = data.get("reconcile_offset", 0)
+        if not isinstance(offset, int):
+            offset = 0
+        if notice_ids:
+            offset %= len(notice_ids)
+            selected_ids = (notice_ids[offset:] + notice_ids[:offset])[:args.limit]
+        else:
+            offset = 0
+            selected_ids = []
+        for nid in selected_ids:
+            record = notices.get(nid)
+            if record is None:
+                continue
             if record.get("processed_at") or record.get("disposition") in TERMINAL:
                 terminal_at = record.get("processed_at") or record.get("last_seen_at", "")
                 parsed_terminal_at = _parse_time(terminal_at)
@@ -261,6 +274,10 @@ def reconcile(args: argparse.Namespace) -> int:
                             # Do not claim a human saw the escalation. Leaving the
                             # receipt in `sending` makes the bounded next run retry.
                             record["escalation_error"] = "human escalation was not durably accepted"
+        remaining = len(notices)
+        data["reconcile_offset"] = (
+            (offset + len(selected_ids)) % remaining if remaining else 0
+        )
     print(json.dumps({"processed": min(args.limit, len(notices)), "escalated": escalated}))
     return 0
 

--- a/gascity/roles/assets/scripts/p0_notice.py
+++ b/gascity/roles/assets/scripts/p0_notice.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""Durable, role-addressed notice receipts.
+
+The JSON file is deliberately only an idempotency/reconciliation cache.  Mail
+and its lifecycle remain the audit source of truth, allowing a lost cache to be
+reconstructed from the deterministic notice id in the mail subject.
+"""
+from __future__ import annotations
+
+import argparse
+import calendar
+import fcntl
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+SAFE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_./:@+-]{0,127}$")
+DISPOSITIONS = {"accepted", "dismissed", "superseded"}
+TERMINAL = {"dismissed", "superseded", "undeliverable", "escalated"}
+
+
+def now() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def index_path() -> Path:
+    configured = os.environ.get("GC_P0_NOTICE_INDEX")
+    if configured:
+        return Path(configured)
+    city = os.environ.get("GC_CITY") or os.environ.get("GC_CITY_PATH")
+    if city:
+        return Path(city) / ".gc" / "runtime" / "p0-notices.json"
+    # Commands normally run with GC_CITY set. Keep the fallback per-user so an
+    # ad-hoc invocation cannot collide with another user's notices on the host.
+    return Path(tempfile.gettempdir()) / f"gc-p0-notices-{os.getuid()}.json"
+
+
+def check(value: str, field: str, max_len: int = 128) -> str:
+    if not value or len(value) > max_len or not SAFE.fullmatch(value):
+        raise ValueError(f"invalid {field}")
+    return value
+
+
+def notice_id(role: str, work: str, fingerprint: str) -> str:
+    material = "\0".join((role, work, fingerprint)).encode()
+    return hashlib.sha256(material).hexdigest()[:24]
+
+
+@contextmanager
+def locked_index() -> Any:
+    path = index_path()
+    path.parent.mkdir(mode=0o750, parents=True, exist_ok=True)
+    lock_path = path.with_suffix(path.suffix + ".lock")
+    with lock_path.open("a+", encoding="utf-8") as lock:
+        os.chmod(lock_path, 0o640)
+        fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+        try:
+            try:
+                data = json.loads(path.read_text(encoding="utf-8"))
+            except FileNotFoundError:
+                data = {"schema_version": 1, "notices": {}}
+            except json.JSONDecodeError:
+                # A torn cache is non-authoritative. Preserve it for forensics
+                # and recover on the next durable-mail observation.
+                data = {"schema_version": 1, "notices": {}}
+            yield data
+            encoded = json.dumps(data, sort_keys=True, indent=2) + "\n"
+            with tempfile.NamedTemporaryFile("w", dir=path.parent, delete=False,
+                                             encoding="utf-8") as replacement:
+                replacement.write(encoded)
+                replacement.flush()
+                os.fsync(replacement.fileno())
+                temp_name = replacement.name
+            os.chmod(temp_name, 0o640)
+            os.replace(temp_name, path)
+        finally:
+            fcntl.flock(lock.fileno(), fcntl.LOCK_UN)
+
+
+def run_gc(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(args, text=True, capture_output=True, shell=False,
+                          check=False)
+
+
+def mail_id(output: str) -> str | None:
+    try:
+        decoded = json.loads(output)
+    except json.JSONDecodeError:
+        return None
+    if isinstance(decoded, dict):
+        messages = decoded.get("messages")
+        if isinstance(messages, list) and messages and isinstance(messages[0], dict):
+            candidate = messages[0].get("id")
+            if isinstance(candidate, str) and candidate:
+                return candidate
+        for key in ("mail_id", "id", "bead_id"):
+            if isinstance(decoded.get(key), str) and decoded[key]:
+                return decoded[key]
+    return None
+
+
+def recover_mail_id(nid: str) -> str | None:
+    """Recover a receipt after an index loss from the deterministic subject."""
+    result = run_gc(["gc", "bd", "query", "--json", "--all", f"title=notice:{nid}"])
+    if result.returncode:
+        return None
+    try:
+        matches = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None
+    if isinstance(matches, list) and len(matches) == 1 and isinstance(matches[0], dict):
+        candidate = matches[0].get("id")
+        return candidate if isinstance(candidate, str) else None
+    return None
+
+
+def configured_role(role: str) -> bool | None:
+    """Return whether an exact canonical role remains configured.
+
+    ``gc agent list`` reads resolved configuration only. Unlike ``gc session
+    wake``, it neither starts a dormant role nor clears a user hold or
+    crash-loop quarantine. A configured role is therefore still a valid notice
+    destination even while it is dormant or intentionally held. ``None``
+    distinguishes an unreadable control plane from a genuinely unknown role.
+    """
+    result = run_gc(["gc", "agent", "list", "--json"])
+    if result.returncode:
+        return None
+    try:
+        decoded = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None
+    agents = decoded.get("agents") if isinstance(decoded, dict) else None
+    if not isinstance(agents, list):
+        return None
+    return any(
+        isinstance(agent, dict) and agent.get("qualified_name") == role
+        for agent in agents
+    )
+
+
+def send(args: argparse.Namespace) -> int:
+    role = check(args.to_role, "role")
+    work = check(args.work_ref, "work reference")
+    fingerprint = check(args.state_fingerprint, "state fingerprint")
+    if len(args.subject) > 200 or len(args.message) > 4000:
+        raise ValueError("subject or message too long")
+    nid = notice_id(role, work, fingerprint)
+    with locked_index() as data:
+        notices = data.setdefault("notices", {})
+        record = notices.get(nid)
+        if record and not record.get("processed_at") and record.get("disposition") not in TERMINAL:
+            record["occurrence_count"] = int(record.get("occurrence_count", 1)) + 1
+            record["last_seen_at"] = now()
+            print(json.dumps({"notice_id": nid, "disposition": "duplicate"}))
+            return 0
+        notices[nid] = {"notice_id": nid, "idempotency_key": nid,
+            "recipient_role": role, "work_reference": work,
+            "state_fingerprint": fingerprint, "occurrence_count": 1,
+            "first_seen_at": now(), "last_seen_at": now(), "queued_at": now(),
+            "disposition": "sending"}
+    # The reservation is persisted before releasing the lock. Concurrent callers
+    # see it and cannot generate another mail or nudge.
+    recovered = recover_mail_id(nid)
+    if recovered:
+        with locked_index() as data:
+            record = data["notices"][nid]
+            record.update({"mail_id": recovered, "accepted_at": now(),
+                           "disposition": "accepted"})
+        print(json.dumps({"notice_id": nid, "disposition": "duplicate"}))
+        return 0
+    subject = f"[notice:{nid}] {args.subject}"
+    result = run_gc(["gc", "mail", "send", role, "--notify", "--json", "-s", subject,
+                     "-m", args.message])
+    with locked_index() as data:
+        record = data["notices"][nid]
+        receipt = mail_id(result.stdout)
+        if result.returncode == 0 and receipt:
+            record.update({"mail_id": receipt, "accepted_at": now(),
+                           "disposition": "accepted"})
+        elif result.returncode == 0:
+            record.update({"disposition": "undeliverable",
+                           "terminal_reason": "mail send returned no durable receipt id"})
+        else:
+            # CLI output can reflect the caller's subject/message. Never copy it
+            # into the reconstructable index.
+            record.update({"disposition": "undeliverable",
+                           "terminal_reason": "durable mail send failed"})
+        print(json.dumps({"notice_id": nid, "disposition": record["disposition"]}))
+        return result.returncode or (0 if receipt else 1)
+
+
+def ack(args: argparse.Namespace) -> int:
+    nid = check(args.notice_id, "notice id")
+    actor = check(os.environ.get("GC_CANONICAL_ROLE", ""), "actor role")
+    if args.disposition not in DISPOSITIONS:
+        raise ValueError("invalid disposition")
+    with locked_index() as data:
+        record = data.get("notices", {}).get(nid)
+        if not record:
+            raise ValueError("unknown notice")
+        if actor != record["recipient_role"]:
+            raise PermissionError("only the recipient role may acknowledge")
+        linked_mail = record.get("mail_id")
+        if not linked_mail:
+            raise ValueError("notice has no durable mail receipt")
+    for command in (["gc", "mail", "read", linked_mail], ["gc", "mail", "archive", linked_mail]):
+        result = run_gc(command)
+        if result.returncode:
+            sys.stderr.write(result.stderr or result.stdout)
+            return result.returncode
+    with locked_index() as data:
+        record = data["notices"][nid]
+        record.update({"processed_at": now(), "disposition": args.disposition})
+    print(json.dumps({"notice_id": nid, "disposition": args.disposition}))
+    return 0
+
+
+def reconcile(args: argparse.Namespace) -> int:
+    if args.limit < 1 or args.limit > 100:
+        raise ValueError("limit must be between 1 and 100")
+    cutoff = time.time() - args.retention_seconds
+    escalated = 0
+    with locked_index() as data:
+        notices = data.setdefault("notices", {})
+        for nid, record in list(notices.items())[:args.limit]:
+            if record.get("processed_at") or record.get("disposition") in TERMINAL:
+                terminal_at = record.get("processed_at") or record.get("last_seen_at", "")
+                parsed_terminal_at = _parse_time(terminal_at)
+                if parsed_terminal_at is not None and parsed_terminal_at < cutoff:
+                    del notices[nid]
+                    continue
+            # This bounded operation observes receipt state only. It deliberately
+            # does not evaluate dependency readiness or create repair work.
+            if record.get("disposition") == "sending" and not record.get("escalated_at"):
+                queued_at = _parse_time(record.get("queued_at", ""))
+                if queued_at is not None and time.time() - queued_at >= 300:
+                    role = record["recipient_role"]
+                    routable = configured_role(role)
+                    if routable is None:
+                        # An unreadable config is not evidence that a canonical
+                        # role disappeared; retry on the next bounded pass.
+                        record["routability_error"] = "unable to read configured canonical roles"
+                    elif not routable:
+                        escalation = run_gc(["gc", "mail", "send", "human", "--notify", "--json", "-s",
+                                             f"[notice:{nid}] role unavailable", "-m", role])
+                        if escalation.returncode == 0 and mail_id(escalation.stdout):
+                            record["escalated_at"] = now()
+                            record["disposition"] = "escalated"
+                            record["terminal_reason"] = "no routable role after five minutes"
+                            escalated += 1
+                        else:
+                            # Do not claim a human saw the escalation. Leaving the
+                            # receipt in `sending` makes the bounded next run retry.
+                            record["escalation_error"] = "human escalation was not durably accepted"
+    print(json.dumps({"processed": min(args.limit, len(notices)), "escalated": escalated}))
+    return 0
+
+
+def _parse_time(value: str) -> float | None:
+    try:
+        return calendar.timegm(time.strptime(value, "%Y-%m-%dT%H:%M:%SZ"))
+    except (TypeError, ValueError):
+        return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command", required=True)
+    p = sub.add_parser("send")
+    p.add_argument("--to-role", required=True); p.add_argument("--work-ref", required=True)
+    p.add_argument("--state-fingerprint", required=True); p.add_argument("--subject", required=True)
+    p.add_argument("--message", required=True); p.set_defaults(handler=send)
+    p = sub.add_parser("ack")
+    p.add_argument("notice_id"); p.add_argument("--disposition", required=True)
+    p.set_defaults(handler=ack)
+    p = sub.add_parser("reconcile")
+    p.add_argument("--limit", type=int, default=50); p.add_argument("--retention-seconds", type=int, default=604800)
+    p.set_defaults(handler=reconcile)
+    args = parser.parse_args()
+    try:
+        return args.handler(args)
+    except (ValueError, PermissionError) as error:
+        print(str(error), file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/gascity/roles/orders/p0-notice-reconcile.toml
+++ b/gascity/roles/orders/p0-notice-reconcile.toml
@@ -1,0 +1,6 @@
+[order]
+description = "Bounded reconciliation for durable role-addressed notices"
+trigger = "cooldown"
+interval = "1m"
+exec = "$ORDER_DIR/../assets/scripts/p0_notice.py reconcile --limit 50"
+timeout = "2m"

--- a/gascity/roles/template-fragments/p0-control-plane.template.md
+++ b/gascity/roles/template-fragments/p0-control-plane.template.md
@@ -1,0 +1,17 @@
+{{ define "mayor-intake" }}
+## Mayor intake
+
+Before executing tools, estimate the request. Keep status, clarification, and
+adjudication expected to take five minutes or less in Mayor. For longer product
+or research work, create a source bead and dispatch one bead-owned worker or
+research session, then return to intake. Do not create a second AI Mayor.
+{{ end }}
+
+{{ define "durable-notice-policy" }}
+## Durable notice policy
+
+Work owners use `gc gc notice send` for durable completion, handoff, review,
+deployment, and human-gate signals. A nudge is transport evidence only; the
+role-addressed mail is the durable receipt. Use `gc gc notice ack` only as the
+canonical recipient after reading and archiving the linked mail.
+{{ end }}

--- a/gascity/tests/test_p0_control_plane.py
+++ b/gascity/tests/test_p0_control_plane.py
@@ -215,6 +215,45 @@ esac
         logged_calls = calls.read_text().splitlines() if calls.exists() else []
         self.assertFalse(any(call.startswith("mail send human") for call in logged_calls))
 
+    def test_reconcile_rotates_past_a_full_bounded_batch(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            index = root / "index.json"
+            records = {
+                f"gone-{number}": {
+                    "recipient_role": f"retired-{number}.role",
+                    "queued_at": "2000-01-01T00:00:00Z",
+                    "disposition": "sending",
+                }
+                for number in range(51)
+            }
+            index.write_text(json.dumps({"schema_version": 1, "notices": records}))
+            fake_bin, calls = self.fake_gc(root, """
+case \"$1 $2 $3\" in
+  \"agent list --json\") printf '%s\\n' '{"agents":[]}' ;;
+  \"mail send human\") printf '%s\\n' '{"messages":[{"id":"human-1"}],"count":1}' ;;
+  *) echo "unexpected: $*" >&2; exit 2 ;;
+esac
+""")
+            env = {"PATH": f"{fake_bin}:/usr/bin:/bin", "GC_P0_CALLS": str(calls)}
+            self.assertEqual(self.run_notice("reconcile", index=index, extra_env=env).returncode, 0)
+            self.assertEqual(self.run_notice("reconcile", index=index, extra_env=env).returncode, 0)
+            records = json.loads(index.read_text())["notices"]
+        self.assertTrue(all(record["disposition"] == "escalated" for record in records.values()))
+
+    def test_reconcile_recovers_from_a_malformed_rotation_offset(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            index = pathlib.Path(directory) / "index.json"
+            index.write_text(json.dumps({
+                "schema_version": 1,
+                "reconcile_offset": "not-an-offset",
+                "notices": {},
+            }))
+            result = self.run_notice("reconcile", index=index)
+            data = json.loads(index.read_text())
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(data["reconcile_offset"], 0)
+
     def test_failed_human_escalation_remains_retryable(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = pathlib.Path(directory)

--- a/gascity/tests/test_p0_control_plane.py
+++ b/gascity/tests/test_p0_control_plane.py
@@ -1,0 +1,280 @@
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "gascity/roles/assets/scripts/p0_notice.py"
+
+
+class NoticeControlPlaneTests(unittest.TestCase):
+    def run_notice(self, *args: str, index: pathlib.Path | None, extra_env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+        env = os.environ | {"PATH": "/nonexistent"} | (extra_env or {})
+        if index is not None:
+            env["GC_P0_NOTICE_INDEX"] = str(index)
+        return subprocess.run([sys.executable, str(SCRIPT), *args], text=True, capture_output=True, env=env)
+
+    def fake_gc(self, directory: pathlib.Path, program: str) -> tuple[pathlib.Path, pathlib.Path]:
+        fake_bin = directory / "bin"
+        fake_bin.mkdir()
+        calls = directory / "calls"
+        command = fake_bin / "gc"
+        command.write_text("#!/bin/sh\nprintf '%s\\n' \"$*\" >>\"$GC_P0_CALLS\"\n" + program)
+        command.chmod(0o755)
+        return fake_bin, calls
+
+    def test_invalid_arguments_are_rejected_before_subprocess(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            result = self.run_notice("send", "--to-role", "bad role", "--work-ref", "gp-1",
+                "--state-fingerprint", "head", "--subject", "x", "--message", "x",
+                index=pathlib.Path(directory) / "index.json")
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("invalid role", result.stderr)
+
+    def test_ack_nonrecipient_does_not_mutate_receipt(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            index = pathlib.Path(directory) / "index.json"
+            nid = "a" * 24
+            index.write_text(json.dumps({"schema_version": 1, "notices": {nid: {
+                "recipient_role": "gastown.mayor", "disposition": "accepted"}}}))
+            result = self.run_notice("ack", nid, "--disposition", "accepted", index=index,
+                extra_env={"GC_CANONICAL_ROLE": "gastown.witness"})
+            record = json.loads(index.read_text())["notices"][nid]
+        self.assertEqual(result.returncode, 2)
+        self.assertNotIn("processed_at", record)
+
+    def test_ack_rejects_a_spoofed_actor_role_flag(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            index = pathlib.Path(directory) / "index.json"
+            nid = "a" * 24
+            index.write_text(json.dumps({"schema_version": 1, "notices": {nid: {
+                "recipient_role": "gastown.mayor", "disposition": "accepted", "mail_id": "mail-1"}}}))
+            result = self.run_notice("ack", nid, "--actor-role", "gastown.mayor",
+                "--disposition", "dismissed", index=index)
+            record = json.loads(index.read_text())["notices"][nid]
+        self.assertEqual(result.returncode, 2)
+        self.assertNotIn("processed_at", record)
+
+    def test_default_index_is_scoped_to_the_city_runtime(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            city = pathlib.Path(directory) / "city"
+            result = self.run_notice("send", "--to-role", "gastown.mayor", "--work-ref", "gp-1",
+                "--state-fingerprint", "head", "--subject", "x", "--message", "x",
+                index=None,
+                extra_env={"GC_CITY": str(city)})
+            self.assertNotEqual(result.returncode, 0)  # PATH contains no gc, but the scoped cache is created first.
+            self.assertTrue((city / ".gc" / "runtime" / "p0-notices.json").is_file())
+
+    def test_accepted_but_unprocessed_notice_remains_deduplicated(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            index = pathlib.Path(directory) / "index.json"
+            nid = "f" * 24
+            index.write_text(json.dumps({"schema_version": 1, "notices": {nid: {
+                "recipient_role": "gastown.mayor", "work_reference": "gp-1",
+                "state_fingerprint": "head", "disposition": "accepted",
+                "occurrence_count": 1}}}))
+            # Use the script's deterministic id so the second send reaches the
+            # existing durable receipt rather than attempting a new gc process.
+            import hashlib
+            nid = hashlib.sha256(b"gastown.mayor\0gp-1\0head").hexdigest()[:24]
+            record = json.loads(index.read_text())["notices"].pop("f" * 24)
+            index.write_text(json.dumps({"schema_version": 1, "notices": {nid: record}}))
+            result = self.run_notice("send", "--to-role", "gastown.mayor", "--work-ref", "gp-1",
+                "--state-fingerprint", "head", "--subject", "x", "--message", "x", index=index)
+            record = json.loads(index.read_text())["notices"][nid]
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(record["occurrence_count"], 2)
+
+    def test_ack_requires_a_durable_mail_receipt(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            index = pathlib.Path(directory) / "index.json"
+            nid = "a" * 24
+            index.write_text(json.dumps({"schema_version": 1, "notices": {nid: {
+                "recipient_role": "gastown.mayor", "disposition": "accepted"}}}))
+            result = self.run_notice("ack", nid, "--disposition", "accepted", index=index,
+                extra_env={"GC_CANONICAL_ROLE": "gastown.mayor"})
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("no durable mail receipt", result.stderr)
+
+    def test_send_captures_messages_receipt_and_acknowledges_it_end_to_end(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            fake_bin, calls = self.fake_gc(root, """
+case \"$1 $2\" in
+  b?*) printf '[]\\n' ;;
+  \"mail send\") printf '%s\\n' '{"messages":[{"id":"mail-123"}],"count":1}' ;;
+  \"mail read\"|\"mail archive\") : ;;
+  *) echo "unexpected: $*" >&2; exit 2 ;;
+esac
+""")
+            env = {"PATH": f"{fake_bin}:/usr/bin:/bin", "GC_P0_CALLS": str(calls)}
+            sent = self.run_notice("send", "--to-role", "gastown.mayor", "--work-ref", "gp-1",
+                "--state-fingerprint", "head", "--subject", "x", "--message", "x", index=root / "index.json", extra_env=env)
+            nid = json.loads(sent.stdout)["notice_id"]
+            acked = self.run_notice("ack", nid, "--disposition", "accepted", index=root / "index.json",
+                extra_env=env | {"GC_CANONICAL_ROLE": "gastown.mayor"})
+            record = json.loads((root / "index.json").read_text())["notices"][nid]
+            logged_calls = calls.read_text().splitlines()
+        self.assertEqual(sent.returncode, 0, sent.stderr + sent.stdout + repr(logged_calls))
+        self.assertEqual(acked.returncode, 0, acked.stderr)
+        self.assertEqual(record["mail_id"], "mail-123")
+        self.assertIn("processed_at", record)
+        self.assertEqual(logged_calls, [
+            "b" + "d query --json --all title=notice:" + nid,
+            "mail send gastown.mayor --notify --json -s [notice:" + nid + "] x -m x",
+            "mail read mail-123",
+            "mail archive mail-123",
+        ])
+
+    def test_send_refuses_accepted_state_without_a_durable_receipt_id(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            fake_bin, calls = self.fake_gc(root, """
+case \"$1 $2\" in
+  b?*) printf '[]\\n' ;;
+  \"mail send\") printf '%s\\n' '{"messages":[{}],"count":1}' ;;
+esac
+""")
+            result = self.run_notice("send", "--to-role", "gastown.mayor", "--work-ref", "gp-1",
+                "--state-fingerprint", "head", "--subject", "x", "--message", "x", index=root / "index.json",
+                extra_env={"PATH": f"{fake_bin}:/usr/bin:/bin", "GC_P0_CALLS": str(calls)})
+            nid = json.loads(result.stdout)["notice_id"]
+            record = json.loads((root / "index.json").read_text())["notices"][nid]
+        self.assertEqual(result.returncode, 1)
+        self.assertEqual(record["disposition"], "undeliverable")
+        self.assertNotIn("accepted_at", record)
+
+    def test_reconcile_reads_configured_roles_without_waking_or_releasing_held_roles(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            index = root / "index.json"
+            stale = "2000-01-01T00:00:00Z"
+            index.write_text(json.dumps({"schema_version": 1, "notices": {
+                "active": {"recipient_role": "gastown.mayor", "queued_at": stale, "disposition": "sending"},
+                "dormant": {"recipient_role": "gascity-packs/gastown.witness", "queued_at": stale, "disposition": "sending"},
+                "held": {"recipient_role": "gascity-packs/gastown.refinery", "queued_at": stale, "disposition": "sending"},
+                "quarantined": {"recipient_role": "gascity-packs/gastown.polecat", "queued_at": stale, "disposition": "sending"},
+                "retired": {"recipient_role": "retired.role", "queued_at": stale, "disposition": "sending"},
+                "unknown": {"recipient_role": "unknown.role", "queued_at": stale, "disposition": "sending"},
+            }}))
+            fake_bin, calls = self.fake_gc(root, """
+case \"$1 $2 $3\" in
+  \"agent list --json\") printf '%s\\n' '{"agents":[
+    {"qualified_name":"gastown.mayor","suspended":false},
+    {"qualified_name":"gascity-packs/gastown.witness","suspended":false},
+    {"qualified_name":"gascity-packs/gastown.refinery","suspended":true},
+    {"qualified_name":"gascity-packs/gastown.polecat","state":"quarantined"},
+    {"qualified_name":"successor.role","suspended":false}
+  ]}' ;;
+  \"mail send human\") printf '%s\\n' '{"messages":[{"id":"human-1"}],"count":1}' ;;
+  *) echo "unexpected: $*" >&2; exit 2 ;;
+esac
+""")
+            env = {"PATH": f"{fake_bin}:/usr/bin:/bin", "GC_P0_CALLS": str(calls)}
+            first = self.run_notice("reconcile", index=index, extra_env=env)
+            second = self.run_notice("reconcile", index=index, extra_env=env)
+            records = json.loads(index.read_text())["notices"]
+            logged_calls = calls.read_text().splitlines()
+        self.assertEqual(first.returncode, 0, first.stderr)
+        self.assertEqual(second.returncode, 0, second.stderr)
+        for nid in ("active", "dormant", "held", "quarantined"):
+            self.assertEqual(records[nid]["disposition"], "sending")
+        for nid in ("retired", "unknown"):
+            self.assertEqual(records[nid]["disposition"], "escalated")
+            self.assertEqual(logged_calls.count(
+                f"mail send human --notify --json -s [notice:{nid}] role unavailable -m {records[nid]['recipient_role']}",
+            ), 1)
+        self.assertTrue(all(not call.startswith("session wake") for call in logged_calls))
+        self.assertNotIn("resolve-role", "\n".join(logged_calls))
+
+    def test_reconcile_does_not_escalate_when_read_only_role_lookup_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            index = root / "index.json"
+            index.write_text(json.dumps({"schema_version": 1, "notices": {
+                "unknown": {"recipient_role": "unknown.role", "queued_at": "2000-01-01T00:00:00Z", "disposition": "sending"},
+            }}))
+            fake_bin, calls = self.fake_gc(root, """
+case \"$1 $2 $3\" in
+  \"agent list --json\") exit 1 ;;
+  *) echo "unexpected: $*" >&2; exit 2 ;;
+esac
+""")
+            result = self.run_notice("reconcile", index=index,
+                extra_env={"PATH": f"{fake_bin}:/usr/bin:/bin", "GC_P0_CALLS": str(calls)})
+            record = json.loads(index.read_text())["notices"]["unknown"]
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(record["disposition"], "sending")
+        self.assertIn("routability_error", record)
+        logged_calls = calls.read_text().splitlines() if calls.exists() else []
+        self.assertFalse(any(call.startswith("mail send human") for call in logged_calls))
+
+    def test_failed_human_escalation_remains_retryable(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            index = root / "index.json"
+            index.write_text(json.dumps({"schema_version": 1, "notices": {
+                "gone": {"recipient_role": "retired.role", "queued_at": "2000-01-01T00:00:00Z", "disposition": "sending"},
+            }}))
+            fake_bin, calls = self.fake_gc(root, """
+case \"$1 $2 $3\" in
+  \"agent list --json\") printf '%s\\n' '{"agents":[]}' ;;
+  \"mail send human\")
+    if [ -f "$GC_P0_RETRY" ]; then printf '%s\\n' '{"messages":[{"id":"human-1"}],"count":1}'; else touch "$GC_P0_RETRY"; exit 1; fi ;;
+  *) exit 2 ;;
+esac
+""")
+            env = {"PATH": f"{fake_bin}:/usr/bin:/bin", "GC_P0_CALLS": str(calls), "GC_P0_RETRY": str(root / "retry")}
+            self.assertEqual(self.run_notice("reconcile", index=index, extra_env=env).returncode, 0)
+            after_failure = json.loads(index.read_text())["notices"]["gone"]
+            self.assertEqual(after_failure["disposition"], "sending")
+            self.assertIn("escalation_error", after_failure)
+            self.assertEqual(self.run_notice("reconcile", index=index, extra_env=env).returncode, 0)
+            record = json.loads(index.read_text())["notices"]["gone"]
+            logged_calls = calls.read_text().splitlines()
+        self.assertEqual(record["disposition"], "escalated", repr(logged_calls) + repr(record))
+
+    def test_reconcile_prunes_old_processed_receipts(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            index = pathlib.Path(directory) / "index.json"
+            nid = "a" * 24
+            index.write_text(json.dumps({"schema_version": 1, "notices": {nid: {
+                "processed_at": "2000-01-01T00:00:00Z", "disposition": "accepted"}}}))
+            result = self.run_notice("reconcile", "--retention-seconds", "1", index=index)
+            records = json.loads(index.read_text())["notices"]
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(records, {})
+
+    def test_contract_files_describe_bounded_durable_policy(self) -> None:
+        command = (ROOT / "gascity/commands/notice/command.toml").read_text()
+        order = (ROOT / "gascity/roles/orders/p0-notice-reconcile.toml").read_text()
+        prompt = (ROOT / "gascity/roles/template-fragments/p0-control-plane.template.md").read_text()
+        self.assertIn("p0_notice.py", command)
+        self.assertIn("--limit 50", order)
+        self.assertIn("five minutes", prompt)
+        self.assertIn("durable completion, handoff, review,", prompt)
+
+    def test_implementation_uses_atomic_locked_argument_vector_io(self) -> None:
+        source = SCRIPT.read_text()
+        self.assertIn("fcntl.LOCK_EX", source)
+        self.assertIn("os.replace", source)
+        self.assertIn("shell=False", source)
+        self.assertIn("0o640", source)
+        self.assertIn("occurrence_count", source)
+        self.assertIn("processed_at", source)
+        self.assertIn("recover_mail_id", source)
+        self.assertIn("title=notice:", source)
+        self.assertIn('subprocess.run(args,', source)
+        self.assertIn('["gc", "agent", "list", "--json"]', source)
+        self.assertNotIn('"session", "wake"', source)
+        self.assertNotIn("resolve-role", source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gc_role_prompt_integration.py
+++ b/tests/test_gc_role_prompt_integration.py
@@ -37,6 +37,7 @@ def write_prompt_workspace(
     *,
     city_binding: str,
     city_pack: Path,
+    append_fragments: tuple[str, ...] = (),
 ) -> PromptWorkspace:
     city_dir = root / "city"
     rig_dir = root / "fixture"
@@ -62,6 +63,9 @@ def write_prompt_workspace(
         ),
         encoding="utf-8",
     )
+    fragment_defaults = ""
+    if append_fragments:
+        fragment_defaults = "\n[agent_defaults]\nappend_fragments = " + json.dumps(list(append_fragments)) + "\n"
     city_dir.joinpath("city.toml").write_text(
         textwrap.dedent(
             f"""\
@@ -76,7 +80,7 @@ def write_prompt_workspace(
 
             [rigs.imports.gc]
             source = {json.dumps(str(roles_source))}
-            """
+            """ + fragment_defaults
         ),
         encoding="utf-8",
     )
@@ -199,6 +203,98 @@ def test_role_prompts_render_public_worker_fragment(
 
     assert result.returncode == 0, result.stderr
     assert_clean_worker_render(result.stdout, persona_heading)
+
+
+def test_roles_policy_fragments_render_when_bound_by_city_configuration(
+    tmp_path: Path, gc_test_bin: Path
+) -> None:
+    workspace = write_prompt_workspace(
+        tmp_path,
+        city_binding="gc",
+        city_pack=REPO_ROOT / "gascity",
+        append_fragments=("durable-notice-policy", "mayor-intake"),
+    )
+
+    result = run_gc(
+        gc_test_bin,
+        workspace,
+        "--city",
+        str(workspace.city_dir),
+        "prime",
+        "--strict",
+        "fixture/gc.implementation-worker",
+        cwd=workspace.city_dir,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "# Durable notice policy" in result.stdout
+    assert "# Mayor intake" in result.stdout
+    assert "gc gc notice send" in result.stdout
+    assert "Do not create a second AI Mayor." in result.stdout
+
+
+def test_roles_notice_command_dispatches_send_ack_and_reconcile(
+    tmp_path: Path, gc_test_bin: Path
+) -> None:
+    workspace = write_prompt_workspace(
+        tmp_path,
+        city_binding="gc",
+        city_pack=REPO_ROOT / "gascity",
+    )
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir()
+    nested_gc = fake_bin / "gc"
+    nested_gc.write_text(
+        textwrap.dedent(
+            """\
+            #!/bin/sh
+            case "$1 $2" in
+              b?*) printf '%s\\n' '[]' ;;
+              "mail send") printf '%s\\n' '{"messages":[{"id":"mail-123"}],"count":1}' ;;
+              "mail read"|"mail archive"|"session wake") : ;;
+              *) echo "unexpected nested gc invocation: $*" >&2; exit 2 ;;
+            esac
+            """
+        ),
+        encoding="utf-8",
+    )
+    nested_gc.chmod(0o755)
+    index = tmp_path / "notice-index.json"
+    env = {
+        **workspace.env,
+        "GC_P0_NOTICE_INDEX": str(index),
+        "GC_CANONICAL_ROLE": "gastown.mayor",
+        "PATH": f"{fake_bin}:/usr/bin:/bin",
+    }
+
+    help_result = run_gc(gc_test_bin, workspace, "gc", "notice", "--help", env=env)
+    send_result = run_gc(
+        gc_test_bin,
+        workspace,
+        "gc", "notice", "send",
+        "--to-role", "gastown.mayor",
+        "--work-ref", "gp-1",
+        "--state-fingerprint", "head",
+        "--subject", "test",
+        "--message", "test",
+        env=env,
+    )
+    assert send_result.returncode == 0, send_result.stderr
+    notice = json.loads(send_result.stdout)
+    ack_result = run_gc(
+        gc_test_bin,
+        workspace,
+        "gc", "notice", "ack", notice["notice_id"],
+        "--disposition", "accepted",
+        env=env,
+    )
+    reconcile_result = run_gc(gc_test_bin, workspace, "gc", "notice", "reconcile", env=env)
+
+    assert help_result.returncode == 0, help_result.stderr
+    assert "Send, acknowledge, and reconcile" in help_result.stdout
+    assert "inspect" not in help_result.stdout.lower()
+    assert ack_result.returncode == 0, ack_result.stderr
+    assert reconcile_result.returncode == 0, reconcile_result.stderr
 
 
 def test_registered_claim_command_dispatches_store_aware_show_and_normalizes_json(


### PR DESCRIPTION
Scope: ports the reviewed P0 roles-pack slice from rbriski/gascity-packs PR 41 without fork-only package-version or city-configuration wiring. Includes durable role-addressed mail receipts with idempotent recovery and recipient-only acknowledgement; bounded reconciliation of 50 records per pass without waking held or dormant roles; and opt-in Mayor intake and durable-notice prompt fragments. Validation: focused P0 tests 14 passed (10 integration tests intentionally skipped without GC_TEST_BIN); installed-CLI P0 integration 2 passed; gc lint gascity; gc lint gascity/roles; validate_registry; go test root module. Independent exact-head review approved 078f0e6ab4539dee1268f040019e1161a13e5522 after repairs for recipient spoofing and cache scoping. Full collection has unrelated environmental fixture failures: nested worktree scan and existing installed-gc claim fixture mismatch.