### PR TITLE
fix(gascity): pick the implementation review verdict by owner, not by bead id

### DIFF
--- a/gascity/assets/scripts/checks/implementation-review-approved.sh
+++ b/gascity/assets/scripts/checks/implementation-review-approved.sh
@@ -103,7 +103,8 @@ MATCHES="$(gmol "$PARENT_ROOT")"
 # not to write the bare `code_review.verdict`, so a candidate carrying any
 # `code_review.*_verdict` key is a lane and is dropped -- unless dropping the
 # lanes would leave nothing, in which case every candidate is kept. Narrowing
-# may never starve the gate.
+# may never starve the gate. That fallback decides from lane beads alone, so it
+# announces itself on stderr whenever it reduces more than one candidate.
 #
 # The survivors are then reduced to one value by value, never by position: an
 # approval if any survivor carries one, otherwise the lexicographically
@@ -139,6 +140,8 @@ VERDICT_SELECTION="$(printf '%s\n' "$MATCHES" | jq -r \
   | (
       if ($owners | length) > 1 then
         "review check: \($owners | length) owner-shaped beads carry code_review.verdict at attempt \($attempt) (values: \($values | join(", "))); selected \"\($verdict)\""
+      elif ($owners | length) == 0 and ($surviving | length) > 1 then
+        "review check: no owner-shaped bead at attempt \($attempt); reduced \($surviving | length) lane candidates (values: \($values | join(", "))); selected \"\($verdict)\""
       else
         ""
       end

--- a/gascity/assets/scripts/checks/implementation-review-approved.sh
+++ b/gascity/assets/scripts/checks/implementation-review-approved.sh
@@ -26,11 +26,16 @@ gmol() {   # root_id -> molecule-member JSON array
         echo "gmol: gc ready failed for status: $(tr '\n' ' ' <"$tmp/failed")" >&2
         rc=1
     fi
-    # unique_by sorts by id, so the union comes back in bead-id order. The
-    # verdict extractors below take `| last`, which must mean "most recently
-    # updated" -- without this re-sort the gate picks a verdict by id hash and
-    # can sit on a stale `iterate` forever while a newer `done` is ignored.
-    jq -s 'map(select(type=="array")) | add // [] | unique_by(.id) | sort_by(.updated_at // "")' "$tmp"/*.json || rc=1
+    # unique_by sorts by id, so the union comes back in bead-id order -- and
+    # that is the only order there is. `gc ready --json` emits no `updated_at`,
+    # so the re-sort this line used to carry compared every row equal, left the
+    # id order untouched, and still claimed to mean "most recently updated".
+    #
+    # The verdict selection below does not depend on this order: it partitions
+    # the candidates by ownership and then reduces them to one value by value,
+    # never by position. The lane-status aggregation further down does still
+    # take the id-last value per key; see the note there.
+    jq -s 'map(select(type=="array")) | add // [] | unique_by(.id)' "$tmp"/*.json || rc=1
     rm -rf "$tmp"
     return "$rc"
 }
@@ -56,6 +61,26 @@ metadata_value() {
   ' 2>/dev/null
 }
 
+# The one approval vocabulary. Both consumers read this single definition and
+# both match case-insensitively: the jq lane-status helper, which receives it
+# via --argjson, and the bash dispatch at the bottom of the file. A spelling
+# added here reaches every consumer at once.
+APPROVAL_VERDICTS=(approve approved pass done)
+APPROVAL_VERDICTS_JSON="$(printf '%s\n' "${APPROVAL_VERDICTS[@]}" \
+  | jq -Rsc 'split("\n") | map(select(. != ""))')"
+
+is_approved() {
+  local candidate known
+  candidate="$(printf '%s' "${1-}" | tr '[:upper:]' '[:lower:]')"
+  [ -n "$candidate" ] || return 1
+  for known in "${APPROVAL_VERDICTS[@]}"; do
+    if [ "$candidate" = "$known" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
 ROOT_JSON="$(gc bd show "$ROOT_ID" --json 2>/dev/null || true)"
 PARENT_ROOT="$(metadata_value "$ROOT_JSON" "gc.root_bead_id")"
 if [ -z "$PARENT_ROOT" ]; then
@@ -73,23 +98,58 @@ fi
 
 MATCHES="$(gmol "$PARENT_ROOT")"
 
-VERDICT="$(printf '%s\n' "$MATCHES" | jq -r --arg attempt "$ATTEMPT" '
+# One bead owns the loop verdict: the apply step that closes out the review.
+# Review lanes report their own `code_review.<lane>_verdict` and are contracted
+# not to write the bare `code_review.verdict`, so a candidate carrying any
+# `code_review.*_verdict` key is a lane and is dropped -- unless dropping the
+# lanes would leave nothing, in which case every candidate is kept. Narrowing
+# may never starve the gate.
+#
+# The survivors are then reduced to one value by value, never by position: an
+# approval if any survivor carries one, otherwise the lexicographically
+# smallest of the distinct non-approving values. Both are invariant under a
+# permutation of bead ids -- the property the old `| last` could not hold.
+#
+# jq emits two lines: the selected verdict, then an optional ambiguity note.
+VERDICT_SELECTION="$(printf '%s\n' "$MATCHES" | jq -r \
+  --arg attempt "$ATTEMPT" \
+  --argjson approvals "$APPROVAL_VERDICTS_JSON" '
+  def is_approval($value):
+    (($value // "") | ascii_downcase) as $v
+    | any($approvals[]; . == $v);
   [
     .[]
     | select((.metadata["gc.attempt"] // "") == $attempt)
     | select((.metadata["code_review.verdict"] // "") != "")
-    | .metadata["code_review.verdict"]
-  ] | last // ""
+    | {
+        value: .metadata["code_review.verdict"],
+        lane: (
+          [(.metadata // {}) | keys[] | select(test("^code_review\\..+_verdict$"))]
+          | length > 0
+        )
+      }
+  ] as $candidates
+  | ($candidates | map(select(.lane | not))) as $owners
+  | (if ($owners | length) > 0 then $owners else $candidates end) as $surviving
+  | ($surviving | map(.value) | unique) as $values
+  | ($values | map(select(is_approval(.)))) as $approving
+  | (
+      if ($approving | length) > 0 then $approving[0] else ($values[0] // "") end
+    ) as $verdict
+  | (
+      if ($owners | length) > 1 then
+        "review check: \($owners | length) owner-shaped beads carry code_review.verdict at attempt \($attempt) (values: \($values | join(", "))); selected \"\($verdict)\""
+      else
+        ""
+      end
+    ) as $note
+  | "\($verdict)\n\($note)"
 ' 2>/dev/null)"
-
-REPORT="$(printf '%s\n' "$MATCHES" | jq -r --arg attempt "$ATTEMPT" '
-  [
-    .[]
-    | select((.metadata["gc.attempt"] // "") == $attempt)
-    | select((.metadata["code_review.report_path"] // "") != "")
-    | .metadata["code_review.report_path"]
-  ] | last // ""
-' 2>/dev/null)"
+VERDICT="$(printf '%s\n' "$VERDICT_SELECTION" | sed -n '1p')"
+VERDICT_NOTE="$(printf '%s\n' "$VERDICT_SELECTION" | sed -n '2p')"
+if [ -n "$VERDICT_NOTE" ]; then
+  echo "$VERDICT_NOTE" >&2
+fi
 
 REVIEW_MODE="$(metadata_value "$ROOT_JSON" "gc.var.review_mode")"
 if [ -z "$REVIEW_MODE" ]; then
@@ -104,6 +164,9 @@ if [ "$REVIEW_MODE" = "report" ]; then
     REPORT_MODE_PATH="$(metadata_value "$PARENT_JSON" "gc.var.report_path")"
   fi
   if [ -z "$REPORT_MODE_PATH" ]; then
+    # This `| last` picks a report *path* out of the same id-ordered union, not
+    # a loop decision. Report mode is behavior-preserved here, so the id-order
+    # dependency is documented rather than changed.
     REPORT_MODE_PATH="$(printf '%s\n' "$MATCHES" | jq -r --arg attempt "$ATTEMPT" '
       [
         .[]
@@ -130,7 +193,8 @@ LANE_STATUS="$(printf '%s\n' "$MATCHES" | jq -r \
   --arg root "$PARENT_ROOT" \
   --arg attempt "$ATTEMPT" \
   --arg scope "$SCOPE_REF" \
-  --arg step "$STEP_ID" '
+  --arg step "$STEP_ID" \
+  --argjson approvals "$APPROVAL_VERDICTS_JSON" '
   def current_loop:
     select(.metadata["gc.root_bead_id"] == $root)
     | select(($attempt == "") or ((.metadata["gc.attempt"] // "") == $attempt))
@@ -151,9 +215,10 @@ LANE_STATUS="$(printf '%s\n' "$MATCHES" | jq -r \
           true
         end
       );
+  # Same vocabulary the bash dispatch uses, handed in via --argjson approvals.
   def approved($value):
     (($value // "") | ascii_downcase) as $v
-    | ($v == "approve" or $v == "approved" or $v == "pass" or $v == "done");
+    | any($approvals[]; . == $v);
   [
     .[]
     | current_loop
@@ -164,6 +229,9 @@ LANE_STATUS="$(printf '%s\n' "$MATCHES" | jq -r \
         simplicity: (."code_review.simplicity_verdict" // "")
       }
   ] as $rows
+  # Each key still takes the id-last non-empty value out of the id-ordered
+  # union gmol returns. That dependency is real; this change deliberately
+  # leaves the lane-status path behavior-preserving and does not repair it.
   | {
       acceptance: ([$rows[].acceptance | select(. != "")] | last // ""),
       test_evidence: ([$rows[].test_evidence | select(. != "")] | last // ""),
@@ -180,24 +248,19 @@ LANE_STATUS="$(printf '%s\n' "$MATCHES" | jq -r \
     end
 ' 2>/dev/null)"
 
-if [ "$VERDICT" != "done" ]; then
-  case "$VERDICT" in
-    approved|pass)
-      ;;
-    "")
-      if [ "$LANE_STATUS" = "approved" ]; then
-        echo "Implementation review approved from lane verdicts"
-        exit 0
-      fi
-      echo "Implementation review needs another iteration: ${LANE_STATUS:-missing verdict}"
-      exit 1
-      ;;
-    *)
-      echo "Implementation review needs another iteration: $VERDICT"
-      exit 1
-      ;;
-  esac
+if [ -z "$VERDICT" ]; then
+  if [ "$LANE_STATUS" = "approved" ]; then
+    echo "Implementation review approved from lane verdicts"
+    exit 0
+  fi
+  echo "Implementation review needs another iteration: ${LANE_STATUS:-missing verdict}"
+  exit 1
 fi
 
-echo "Implementation review approved"
-exit 0
+if is_approved "$VERDICT"; then
+  echo "Implementation review approved"
+  exit 0
+fi
+
+echo "Implementation review needs another iteration: $VERDICT"
+exit 1

--- a/gascity/assets/scripts/checks/implementation-review-approved.sh
+++ b/gascity/assets/scripts/checks/implementation-review-approved.sh
@@ -26,15 +26,21 @@ gmol() {   # root_id -> molecule-member JSON array
         echo "gmol: gc ready failed for status: $(tr '\n' ' ' <"$tmp/failed")" >&2
         rc=1
     fi
-    # unique_by sorts by id, so the union comes back in bead-id order -- and
-    # that is the only order there is. `gc ready --json` emits no `updated_at`,
-    # so the re-sort this line used to carry compared every row equal, left the
-    # id order untouched, and still claimed to mean "most recently updated".
+    # unique_by sorts by id, so the union comes back in bead-id order.
     #
-    # The verdict selection below does not depend on this order: it partitions
-    # the candidates by ownership and then reduces them to one value by value,
-    # never by position. The lane-status aggregation further down does still
-    # take the id-last value per key; see the note there.
+    # `updated_at` is `omitempty` on the reader's bead struct -- absent only on
+    # a bead never updated since it was created, which no verdict carrier can
+    # be: it got its verdict key from `gc bd update`. So the re-sort this line
+    # used to carry was live, and the `| last` it fed really did mean "most
+    # recently updated".
+    #
+    # It is gone because the verdict selection below no longer decides by
+    # position at all. It reads recency where recency is used -- narrowing to
+    # the newest `updated_at` explicitly, by value -- instead of staging it in
+    # the row order for a later `| last` to consume. That is what makes the
+    # selection invariant under a permutation of bead ids. The lane-status
+    # aggregation further down does still take the id-last value per key, and
+    # dropping the re-sort changed what that means; see the note there.
     jq -s 'map(select(type=="array")) | add // [] | unique_by(.id)' "$tmp"/*.json || rc=1
     rm -rf "$tmp"
     return "$rc"
@@ -64,17 +70,20 @@ metadata_value() {
 # The one approval vocabulary. Both consumers read this single definition and
 # both match case-insensitively: the jq lane-status helper, which receives it
 # via --argjson, and the bash dispatch at the bottom of the file. A spelling
-# added here reaches every consumer at once.
+# added here reaches every consumer at once -- in any case, because each
+# consumer downcases the entry as well as the candidate. Matching only the
+# candidate would have made a mixed-case entry silently unmatchable everywhere,
+# which is the same class of defect as the split vocabulary this replaced.
 APPROVAL_VERDICTS=(approve approved pass done)
 APPROVAL_VERDICTS_JSON="$(printf '%s\n' "${APPROVAL_VERDICTS[@]}" \
-  | jq -Rsc 'split("\n") | map(select(. != ""))')"
+  | jq -Rsc 'split("\n") | map(select(. != "")) | map(ascii_downcase)')"
 
 is_approved() {
   local candidate known
   candidate="$(printf '%s' "${1-}" | tr '[:upper:]' '[:lower:]')"
   [ -n "$candidate" ] || return 1
   for known in "${APPROVAL_VERDICTS[@]}"; do
-    if [ "$candidate" = "$known" ]; then
+    if [ "$candidate" = "${known,,}" ]; then
       return 0
     fi
   done
@@ -106,10 +115,15 @@ MATCHES="$(gmol "$PARENT_ROOT")"
 # may never starve the gate. That fallback decides from lane beads alone, so it
 # announces itself on stderr whenever it reduces more than one candidate.
 #
-# The survivors are then reduced to one value by value, never by position: an
-# approval if any survivor carries one, otherwise the lexicographically
-# smallest of the distinct non-approving values. Both are invariant under a
-# permutation of bead ids -- the property the old `| last` could not hold.
+# The survivors are then reduced to one value in two steps, neither of them
+# positional. First recency: keep only the survivors carrying the newest
+# `updated_at`, so a later pass overrules an earlier one exactly as it did
+# before this file stopped sorting the union. Then, among values recency could
+# not separate, prefer a NON-approving one. Resolving an unresolvable dispute
+# toward "approve" ships unaddressed findings; resolving it toward "iterate"
+# costs one more loop iteration in a state that should not occur anyway.
+# Both steps are invariant under a permutation of bead ids -- the property the
+# old `| last` could not hold.
 #
 # jq emits two lines: the selected verdict, then an optional ambiguity note.
 VERDICT_SELECTION="$(printf '%s\n' "$MATCHES" | jq -r \
@@ -118,12 +132,30 @@ VERDICT_SELECTION="$(printf '%s\n' "$MATCHES" | jq -r \
   def is_approval($value):
     (($value // "") | ascii_downcase) as $v
     | any($approvals[]; . == $v);
+  # Narrow to the newest rows -- but only when every row is dated. `updated_at`
+  # is omitempty, and ranking a partially dated set would silently rank the
+  # undated rows oldest, which is a guess, not a reading. Selecting by max
+  # value rather than by position keeps ties whole for the reduction below.
+  def newest($rows):
+    ($rows | map(select((.updated_at // "") != "")) | length) as $dated
+    | if $dated > 0 and $dated == ($rows | length)
+      then ($rows | map(.updated_at) | max) as $max
+        | ($rows | map(select(.updated_at == $max)))
+      else $rows
+      end;
+  # Reduce to one value, fail-closed: the lexicographically smallest distinct
+  # non-approving value if there is one, else the smallest approval.
+  def decide($rows):
+    ($rows | map(.value) | unique) as $vals
+    | ($vals | map(select(is_approval(.) | not))) as $blocking
+    | if ($blocking | length) > 0 then $blocking[0] else ($vals[0] // "") end;
   [
     .[]
     | select((.metadata["gc.attempt"] // "") == $attempt)
     | select((.metadata["code_review.verdict"] // "") != "")
     | {
         value: .metadata["code_review.verdict"],
+        updated_at: (.updated_at // ""),
         lane: (
           [(.metadata // {}) | keys[] | select(test("^code_review\\..+_verdict$"))]
           | length > 0
@@ -133,15 +165,22 @@ VERDICT_SELECTION="$(printf '%s\n' "$MATCHES" | jq -r \
   | ($candidates | map(select(.lane | not))) as $owners
   | (if ($owners | length) > 0 then $owners else $candidates end) as $surviving
   | ($surviving | map(.value) | unique) as $values
-  | ($values | map(select(is_approval(.)))) as $approving
+  | newest($surviving) as $current
+  | decide($current) as $verdict
   | (
-      if ($approving | length) > 0 then $approving[0] else ($values[0] // "") end
-    ) as $verdict
+      if (($current | map(.value) | unique | length) > 1) then
+        "fail-closed among \($current | map(.value) | unique | length) values"
+      elif (($current | length) < ($surviving | length)) then
+        "newest updated_at"
+      else
+        "unanimous"
+      end
+    ) as $basis
   | (
       if ($owners | length) > 1 then
-        "review check: \($owners | length) owner-shaped beads carry code_review.verdict at attempt \($attempt) (values: \($values | join(", "))); selected \"\($verdict)\""
+        "review check: \($owners | length) owner-shaped beads carry code_review.verdict at attempt \($attempt) (values: \($values | join(", "))); selected \"\($verdict)\" (\($basis))"
       elif ($owners | length) == 0 and ($surviving | length) > 1 then
-        "review check: no owner-shaped bead at attempt \($attempt); reduced \($surviving | length) lane candidates (values: \($values | join(", "))); selected \"\($verdict)\""
+        "review check: no owner-shaped bead at attempt \($attempt); reduced \($surviving | length) lane candidates (values: \($values | join(", "))); selected \"\($verdict)\" (\($basis))"
       else
         ""
       end
@@ -168,8 +207,11 @@ if [ "$REVIEW_MODE" = "report" ]; then
   fi
   if [ -z "$REPORT_MODE_PATH" ]; then
     # This `| last` picks a report *path* out of the same id-ordered union, not
-    # a loop decision. Report mode is behavior-preserved here, so the id-order
-    # dependency is documented rather than changed.
+    # a loop decision. Dropping the re-sort in gmol did change it -- from
+    # recency-last to id-last -- so this is a documented behavior change, not a
+    # preservation. The two orders diverge only when one attempt carries more
+    # than one row with a report path. Report mode is left unrepaired here
+    # deliberately; the residual is recorded rather than claimed away.
     REPORT_MODE_PATH="$(printf '%s\n' "$MATCHES" | jq -r --arg attempt "$ATTEMPT" '
       [
         .[]
@@ -233,8 +275,12 @@ LANE_STATUS="$(printf '%s\n' "$MATCHES" | jq -r \
       }
   ] as $rows
   # Each key still takes the id-last non-empty value out of the id-ordered
-  # union gmol returns. That dependency is real; this change deliberately
-  # leaves the lane-status path behavior-preserving and does not repair it.
+  # union gmol returns. Dropping the re-sort in gmol changed that from
+  # recency-last to id-last: a behavior change, not a preservation. The two
+  # diverge only when one attempt carries the same lane key twice, in which
+  # case this path can now report a stale value where it used to report the
+  # fresh one. That is a real residual, recorded and deliberately left
+  # unrepaired here rather than described as equivalent.
   | {
       acceptance: ([$rows[].acceptance | select(. != "")] | last // ""),
       test_evidence: ([$rows[].test_evidence | select(. != "")] | last // ""),

--- a/gascity/tests/test_formula_assets.py
+++ b/gascity/tests/test_formula_assets.py
@@ -5104,6 +5104,59 @@ description = "Override sink that writes the base triage report contract."
         self.assertIn("Implementation review approved", result.stdout)
         self.assertIn("2 owner-shaped beads carry code_review.verdict", result.stderr)
 
+    def test_implementation_review_check_notes_lane_fallback_without_owner(self) -> None:
+        """The no-starvation fallback announces itself instead of deciding in silence.
+
+        When no owner-shaped bead exists, every candidate survives narrowing and
+        the value reduction runs over lane beads -- so one lane carrying an
+        approval outvotes any number of `iterate`s. That decision is deliberate
+        (narrowing may never starve the gate) and is left unchanged here, but it
+        must not be silent: the note names the fallback, how many candidates it
+        reduced, and what it selected.
+        """
+        show_json = json.dumps(
+            [{"id": "loop", "metadata": {"gc.root_bead_id": "root", "gc.attempt": "1"}}]
+        )
+        list_json = json.dumps(
+            [
+                {
+                    "id": "gcg-aaa",
+                    "metadata": {
+                        "gc.root_bead_id": "root",
+                        "gc.attempt": "1",
+                        "code_review.verdict": "iterate",
+                        "code_review.acceptance_verdict": "iterate",
+                    },
+                },
+                {
+                    "id": "gcg-mmm",
+                    "metadata": {
+                        "gc.root_bead_id": "root",
+                        "gc.attempt": "1",
+                        "code_review.verdict": "iterate",
+                        "code_review.test_evidence_verdict": "iterate",
+                    },
+                },
+                {
+                    "id": "gcg-zzz",
+                    "metadata": {
+                        "gc.root_bead_id": "root",
+                        "gc.attempt": "1",
+                        "code_review.verdict": "approve",
+                        "code_review.simplicity_verdict": "approve",
+                    },
+                },
+            ]
+        )
+
+        result = self._run_implementation_review_check(show_json=show_json, list_json=list_json)
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("Implementation review approved", result.stdout)
+        self.assertIn("no owner-shaped bead at attempt 1", result.stderr)
+        self.assertIn("reduced 3 lane candidates", result.stderr)
+        self.assertIn('selected "approve"', result.stderr)
+
     def test_design_review_check_unions_every_status_leg(self) -> None:
         """The verdict usually lands on a bead the review just closed.
 

--- a/gascity/tests/test_formula_assets.py
+++ b/gascity/tests/test_formula_assets.py
@@ -5066,6 +5066,38 @@ description = "Override sink that writes the base triage report contract."
             self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
             self.assertIn("Implementation review approved from lane verdicts", result.stdout)
 
+        with self.subTest(shape="lane status, mixed case"):
+            # The shared vocabulary reaches the jq lane-status helper via
+            # `--argjson approvals` and is matched with `ascii_downcase`. Every
+            # other `*_verdict` fixture in this file spells the value in lower
+            # case, so a helper that hard-coded a case-sensitive list of its own
+            # would leave the suite green. Spell two lanes' approvals in mixed
+            # case to pin the case-insensitive match on this path specifically.
+            list_json = json.dumps(
+                [
+                    {
+                        "id": f"lane-{key}",
+                        "metadata": {
+                            "gc.root_bead_id": "root",
+                            "gc.attempt": "1",
+                            f"code_review.{key}_verdict": value,
+                        },
+                    }
+                    for key, value in (
+                        ("acceptance", "Approve"),
+                        ("test_evidence", "approve"),
+                        ("simplicity", "DONE"),
+                    )
+                ]
+            )
+
+            result = self._run_implementation_review_check(
+                show_json=show_json, list_json=list_json
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertIn("Implementation review approved from lane verdicts", result.stdout)
+
     def test_implementation_review_check_notes_multiple_owner_candidates(self) -> None:
         """Owner ambiguity is reported on stderr and never fails the gate.
 

--- a/gascity/tests/test_formula_assets.py
+++ b/gascity/tests/test_formula_assets.py
@@ -4845,43 +4845,264 @@ description = "Override sink that writes the base triage report contract."
         self.assertIn("code_review.verdict=iterate", apply_text)
         self.assertIn("code_review.report_path=<fix summary path>", apply_text)
 
-    def test_implementation_review_check_takes_newest_verdict_not_highest_id(self) -> None:
-        """`| last` in the verdict extractors has to mean newest, not highest id.
+    def test_implementation_review_check_takes_owner_verdict_not_highest_id(self) -> None:
+        """The owner's verdict decides the loop, and id order is irrelevant.
 
-        gmol dedupes the four status legs with `unique_by(.id)`, and jq's
-        unique_by sorts — so without a re-sort the union arrives in bead-id
-        order and this gate's `| last` picks a verdict by id hash. Here the
-        stale `iterate` sorts after the newer `done`, so an already-approved
-        review would loop until Ralph ran out of attempts: the exact symptom
-        the federating-reader fix was written to end, re-entering by ordering
-        rather than by starvation.
+        gmol dedupes the four status legs with `unique_by(.id)`, so the union
+        arrives in bead-id order and there is no recency signal to recover:
+        `gc ready --json` emits no `updated_at`. The verdict the loop acts on
+        is therefore the one written by the bead that *owns* it -- the apply
+        lane -- not whichever candidate happens to sort last. Here a review
+        lane, marked by its own `code_review.review_verdict`, carries a stale
+        `iterate` and sorts last by id; the owner's `done` must still win.
+
+        This fixture used to set `updated_at` on every row -- a field the real
+        reader never emits. That made the since-removed `sort_by(.updated_at)`
+        look load-bearing and the id-order selection look correct, so this
+        test passed for its entire life while the defect it names shipped.
         """
         show_json = json.dumps(
             [{"id": "loop", "metadata": {"gc.root_bead_id": "root", "gc.attempt": "1"}}]
         )
 
-        def member(bead_id: str, updated: str, verdict: str) -> dict:
-            return {
-                "id": bead_id,
-                "updated_at": updated,
-                "metadata": {
-                    "gc.root_bead_id": "root",
-                    "gc.attempt": "1",
-                    "code_review.verdict": verdict,
-                    "code_review.report_path": f"/reports/{bead_id}.md",
-                },
+        def member(bead_id: str, verdict: str, *, lane: bool = False) -> dict:
+            metadata = {
+                "gc.root_bead_id": "root",
+                "gc.attempt": "1",
+                "code_review.verdict": verdict,
+                "code_review.report_path": f"/reports/{bead_id}.md",
             }
+            if lane:
+                # Any `code_review.*_verdict` key marks a review lane. Every
+                # lane prompt in the packs is contracted not to write the bare
+                # `code_review.verdict` the apply lane owns.
+                metadata["code_review.review_verdict"] = verdict
+            return {"id": bead_id, "metadata": metadata}
 
-        # "gcg-zzz" sorts last by id but carries the OLDER verdict.
+        # "gcg-zzz" sorts last by id but is a review lane, not the owner.
         list_json = json.dumps(
             [
-                member("gcg-aaa", "2026-08-13T03:00:00Z", "done"),
-                member("gcg-zzz", "2026-08-13T01:00:00Z", "iterate"),
+                member("gcg-aaa", "done"),
+                member("gcg-zzz", "iterate", lane=True),
             ]
         )
         result = self._run_implementation_review_check(show_json=show_json, list_json=list_json)
 
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_implementation_review_check_is_invariant_under_id_permutation(self) -> None:
+        """Exchanging the two bead ids changes neither exit code nor stdout.
+
+        This is the property the id-ordered `| last` could not hold: the same
+        molecule, relabelled, decided the loop differently.
+        """
+        show_json = json.dumps(
+            [{"id": "loop", "metadata": {"gc.root_bead_id": "root", "gc.attempt": "1"}}]
+        )
+
+        def fixture(owner_id: str, lane_id: str) -> str:
+            return json.dumps(
+                [
+                    {
+                        "id": owner_id,
+                        "metadata": {
+                            "gc.root_bead_id": "root",
+                            "gc.attempt": "1",
+                            "code_review.verdict": "done",
+                        },
+                    },
+                    {
+                        "id": lane_id,
+                        "metadata": {
+                            "gc.root_bead_id": "root",
+                            "gc.attempt": "1",
+                            "code_review.verdict": "iterate",
+                            "code_review.review_verdict": "iterate",
+                        },
+                    },
+                ]
+            )
+
+        first = self._run_implementation_review_check(
+            show_json=show_json, list_json=fixture("gcg-aaa", "gcg-zzz")
+        )
+        second = self._run_implementation_review_check(
+            show_json=show_json, list_json=fixture("gcg-zzz", "gcg-aaa")
+        )
+
+        self.assertEqual(
+            first.returncode,
+            second.returncode,
+            f"{first.stdout}{first.stderr}||{second.stdout}{second.stderr}",
+        )
+        self.assertEqual(first.stdout, second.stdout)
+        self.assertEqual(first.returncode, 0, first.stdout + first.stderr)
+
+    def test_implementation_review_check_accepts_every_approval_spelling(self) -> None:
+        """One approval vocabulary, matched case-insensitively.
+
+        The bash dispatch and the jq lane-status helper used to carry separate
+        copies of the list, and the bash copy was missing `approve` -- a value
+        the jq copy had always treated as approval.
+        """
+        show_json = json.dumps(
+            [{"id": "loop", "metadata": {"gc.root_bead_id": "root", "gc.attempt": "1"}}]
+        )
+
+        for verdict in ("approve", "approved", "pass", "done", "Approve", "DONE"):
+            with self.subTest(verdict=verdict):
+                list_json = json.dumps(
+                    [
+                        {
+                            "id": "apply",
+                            "metadata": {
+                                "gc.root_bead_id": "root",
+                                "gc.attempt": "1",
+                                "code_review.verdict": verdict,
+                            },
+                        }
+                    ]
+                )
+
+                result = self._run_implementation_review_check(
+                    show_json=show_json, list_json=list_json
+                )
+
+                self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+                self.assertIn("Implementation review approved", result.stdout)
+
+    def test_implementation_review_check_rejects_owner_iterate_over_lane_approve(self) -> None:
+        """A lane's approval cannot outvote the owner's `iterate`.
+
+        No total order over the *values* satisfies both this case and the
+        `{done, iterate}` fix-pass case below -- they differ only in who wrote
+        each value, which is why the selection partitions by ownership.
+        """
+        show_json = json.dumps(
+            [{"id": "loop", "metadata": {"gc.root_bead_id": "root", "gc.attempt": "1"}}]
+        )
+        # The lane sorts last by id; only ownership keeps it from deciding.
+        list_json = json.dumps(
+            [
+                {
+                    "id": "aaa-apply",
+                    "metadata": {
+                        "gc.root_bead_id": "root",
+                        "gc.attempt": "1",
+                        "code_review.verdict": "iterate",
+                    },
+                },
+                {
+                    "id": "zzz-acceptance",
+                    "metadata": {
+                        "gc.root_bead_id": "root",
+                        "gc.attempt": "1",
+                        "code_review.verdict": "approve",
+                        "code_review.acceptance_verdict": "approve",
+                    },
+                },
+            ]
+        )
+
+        result = self._run_implementation_review_check(show_json=show_json, list_json=list_json)
+
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("needs another iteration: iterate", result.stdout)
+
+    def test_implementation_review_check_never_starves_a_molecule_with_a_verdict(self) -> None:
+        """Narrowing to owners may never empty the candidate set.
+
+        Two shapes reach the same conclusion. A molecule whose only verdict
+        carrier also looks like a lane has no distinguishable owner, so the
+        selection falls back to the full candidate set instead of reporting a
+        missing verdict; and a molecule with no bare verdict at all still
+        reaches the lane-status aggregation, which this change leaves intact.
+        """
+        show_json = json.dumps(
+            [{"id": "loop", "metadata": {"gc.root_bead_id": "root", "gc.attempt": "1"}}]
+        )
+
+        with self.subTest(shape="no distinguishable owner"):
+            list_json = json.dumps(
+                [
+                    {
+                        "id": "only-carrier",
+                        "metadata": {
+                            "gc.root_bead_id": "root",
+                            "gc.attempt": "1",
+                            "code_review.verdict": "done",
+                            "code_review.review_verdict": "approve",
+                        },
+                    }
+                ]
+            )
+
+            result = self._run_implementation_review_check(
+                show_json=show_json, list_json=list_json
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertNotIn("missing verdict", result.stdout)
+
+        with self.subTest(shape="lane status only"):
+            list_json = json.dumps(
+                [
+                    {
+                        "id": f"lane-{key}",
+                        "metadata": {
+                            "gc.root_bead_id": "root",
+                            "gc.attempt": "1",
+                            f"code_review.{key}_verdict": "approve",
+                        },
+                    }
+                    for key in ("acceptance", "test_evidence", "simplicity")
+                ]
+            )
+
+            result = self._run_implementation_review_check(
+                show_json=show_json, list_json=list_json
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertIn("Implementation review approved from lane verdicts", result.stdout)
+
+    def test_implementation_review_check_notes_multiple_owner_candidates(self) -> None:
+        """Owner ambiguity is reported on stderr and never fails the gate.
+
+        Two owner-shaped beads in one attempt is the fix-pass shape: an owner
+        wrote `iterate`, a later pass wrote `done`, and the terminal state is
+        approval. The note names the ambiguity for a human without turning a
+        reported state into a loop decision.
+        """
+        show_json = json.dumps(
+            [{"id": "loop", "metadata": {"gc.root_bead_id": "root", "gc.attempt": "1"}}]
+        )
+        list_json = json.dumps(
+            [
+                {
+                    "id": "gcg-aaa",
+                    "metadata": {
+                        "gc.root_bead_id": "root",
+                        "gc.attempt": "1",
+                        "code_review.verdict": "done",
+                    },
+                },
+                {
+                    "id": "gcg-zzz",
+                    "metadata": {
+                        "gc.root_bead_id": "root",
+                        "gc.attempt": "1",
+                        "code_review.verdict": "iterate",
+                    },
+                },
+            ]
+        )
+
+        result = self._run_implementation_review_check(show_json=show_json, list_json=list_json)
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("Implementation review approved", result.stdout)
+        self.assertIn("2 owner-shaped beads carry code_review.verdict", result.stderr)
 
     def test_design_review_check_unions_every_status_leg(self) -> None:
         """The verdict usually lands on a bead the review just closed.

--- a/gascity/tests/test_formula_assets.py
+++ b/gascity/tests/test_formula_assets.py
@@ -4258,9 +4258,13 @@ description = "Override sink that writes the base triage report contract."
         list_json: str,
         parent_show_json: str | None = None,
         extra_env: dict[str, str] | None = None,
+        script: pathlib.Path | None = None,
     ) -> subprocess.CompletedProcess:
+        # `script` runs a caller-supplied copy of the gate instead of the
+        # shipped one, so a test can mutate a line the fixtures cannot reach.
         root = pathlib.Path(__file__).resolve().parents[1]
-        script = root / "assets" / "scripts" / "checks" / "implementation-review-approved.sh"
+        if script is None:
+            script = root / "assets" / "scripts" / "checks" / "implementation-review-approved.sh"
 
         with tempfile.TemporaryDirectory() as td:
             tmp = pathlib.Path(td)
@@ -4849,23 +4853,23 @@ description = "Override sink that writes the base triage report contract."
         """The owner's verdict decides the loop, and id order is irrelevant.
 
         gmol dedupes the four status legs with `unique_by(.id)`, so the union
-        arrives in bead-id order and there is no recency signal to recover:
-        `gc ready --json` emits no `updated_at`. The verdict the loop acts on
-        is therefore the one written by the bead that *owns* it -- the apply
-        lane -- not whichever candidate happens to sort last. Here a review
-        lane, marked by its own `code_review.review_verdict`, carries a stale
-        `iterate` and sorts last by id; the owner's `done` must still win.
+        arrives in bead-id order. Ownership, not position, decides: the verdict
+        the loop acts on is the one written by the bead that *owns* it -- the
+        apply lane -- and a review lane's opinion never outranks it however the
+        ids or the timestamps fall. Here a review lane, marked by its own
+        `code_review.review_verdict`, carries `iterate`, sorts last by id, and
+        is also the *newer* row; the owner's `done` must still win, because the
+        lane is dropped before recency is ever consulted.
 
-        This fixture used to set `updated_at` on every row -- a field the real
-        reader never emits. That made the since-removed `sort_by(.updated_at)`
-        look load-bearing and the id-order selection look correct, so this
-        test passed for its entire life while the defect it names shipped.
+        `updated_at` is real: it is `omitempty` on the reader's bead struct,
+        absent only on a bead never updated since creation, which no verdict
+        carrier can be. The fixtures carry it because the reader emits it.
         """
         show_json = json.dumps(
             [{"id": "loop", "metadata": {"gc.root_bead_id": "root", "gc.attempt": "1"}}]
         )
 
-        def member(bead_id: str, verdict: str, *, lane: bool = False) -> dict:
+        def member(bead_id: str, verdict: str, updated: str, *, lane: bool = False) -> dict:
             metadata = {
                 "gc.root_bead_id": "root",
                 "gc.attempt": "1",
@@ -4877,13 +4881,14 @@ description = "Override sink that writes the base triage report contract."
                 # lane prompt in the packs is contracted not to write the bare
                 # `code_review.verdict` the apply lane owns.
                 metadata["code_review.review_verdict"] = verdict
-            return {"id": bead_id, "metadata": metadata}
+            return {"id": bead_id, "updated_at": updated, "metadata": metadata}
 
-        # "gcg-zzz" sorts last by id but is a review lane, not the owner.
+        # "gcg-zzz" sorts last by id AND carries the newer timestamp -- it loses
+        # on both counts to ownership alone.
         list_json = json.dumps(
             [
-                member("gcg-aaa", "done"),
-                member("gcg-zzz", "iterate", lane=True),
+                member("gcg-aaa", "done", "2026-08-13T01:00:00Z"),
+                member("gcg-zzz", "iterate", "2026-08-13T03:00:00Z", lane=True),
             ]
         )
         result = self._run_implementation_review_check(show_json=show_json, list_json=list_json)
@@ -4894,7 +4899,9 @@ description = "Override sink that writes the base triage report contract."
         """Exchanging the two bead ids changes neither exit code nor stdout.
 
         This is the property the id-ordered `| last` could not hold: the same
-        molecule, relabelled, decided the loop differently.
+        molecule, relabelled, decided the loop differently. The timestamps stay
+        attached to the *roles* while the ids are exchanged, so nothing but the
+        labelling differs between the two runs.
         """
         show_json = json.dumps(
             [{"id": "loop", "metadata": {"gc.root_bead_id": "root", "gc.attempt": "1"}}]
@@ -4905,6 +4912,7 @@ description = "Override sink that writes the base triage report contract."
                 [
                     {
                         "id": owner_id,
+                        "updated_at": "2026-08-13T01:00:00Z",
                         "metadata": {
                             "gc.root_bead_id": "root",
                             "gc.attempt": "1",
@@ -4913,6 +4921,7 @@ description = "Override sink that writes the base triage report contract."
                     },
                     {
                         "id": lane_id,
+                        "updated_at": "2026-08-13T03:00:00Z",
                         "metadata": {
                             "gc.root_bead_id": "root",
                             "gc.attempt": "1",
@@ -4955,6 +4964,7 @@ description = "Override sink that writes the base triage report contract."
                     [
                         {
                             "id": "apply",
+                            "updated_at": "2026-08-13T01:00:00Z",
                             "metadata": {
                                 "gc.root_bead_id": "root",
                                 "gc.attempt": "1",
@@ -4981,11 +4991,13 @@ description = "Override sink that writes the base triage report contract."
         show_json = json.dumps(
             [{"id": "loop", "metadata": {"gc.root_bead_id": "root", "gc.attempt": "1"}}]
         )
-        # The lane sorts last by id; only ownership keeps it from deciding.
+        # The lane sorts last by id and is the newer row; only ownership keeps
+        # it from deciding.
         list_json = json.dumps(
             [
                 {
                     "id": "aaa-apply",
+                    "updated_at": "2026-08-13T01:00:00Z",
                     "metadata": {
                         "gc.root_bead_id": "root",
                         "gc.attempt": "1",
@@ -4994,6 +5006,7 @@ description = "Override sink that writes the base triage report contract."
                 },
                 {
                     "id": "zzz-acceptance",
+                    "updated_at": "2026-08-13T03:00:00Z",
                     "metadata": {
                         "gc.root_bead_id": "root",
                         "gc.attempt": "1",
@@ -5027,6 +5040,7 @@ description = "Override sink that writes the base triage report contract."
                 [
                     {
                         "id": "only-carrier",
+                        "updated_at": "2026-08-13T01:00:00Z",
                         "metadata": {
                             "gc.root_bead_id": "root",
                             "gc.attempt": "1",
@@ -5049,6 +5063,7 @@ description = "Override sink that writes the base triage report contract."
                 [
                     {
                         "id": f"lane-{key}",
+                        "updated_at": "2026-08-13T01:00:00Z",
                         "metadata": {
                             "gc.root_bead_id": "root",
                             "gc.attempt": "1",
@@ -5077,6 +5092,7 @@ description = "Override sink that writes the base triage report contract."
                 [
                     {
                         "id": f"lane-{key}",
+                        "updated_at": "2026-08-13T01:00:00Z",
                         "metadata": {
                             "gc.root_bead_id": "root",
                             "gc.attempt": "1",
@@ -5098,53 +5114,160 @@ description = "Override sink that writes the base triage report contract."
             self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
             self.assertIn("Implementation review approved from lane verdicts", result.stdout)
 
-    def test_implementation_review_check_notes_multiple_owner_candidates(self) -> None:
-        """Owner ambiguity is reported on stderr and never fails the gate.
+    @staticmethod
+    def _owner_bead(bead_id: str, verdict: str, updated: str | None = None) -> dict:
+        bead = {
+            "id": bead_id,
+            "metadata": {
+                "gc.root_bead_id": "root",
+                "gc.attempt": "1",
+                "code_review.verdict": verdict,
+            },
+        }
+        if updated is not None:
+            bead["updated_at"] = updated
+        return bead
 
-        Two owner-shaped beads in one attempt is the fix-pass shape: an owner
-        wrote `iterate`, a later pass wrote `done`, and the terminal state is
-        approval. The note names the ambiguity for a human without turning a
-        reported state into a loop decision.
+    def test_implementation_review_check_prefers_the_newest_owner_verdict(self) -> None:
+        """Among owner-shaped beads the newest `updated_at` decides, both ways.
+
+        Two owner-shaped beads at one attempt is the re-serve-after-stamp shape,
+        and the only thing that distinguishes them is when they were written.
+        The gate must follow that in *both* directions, or it is not reading
+        recency at all: a later `done` closes the loop, and a later `iterate`
+        keeps it open. The second direction is the one that matters -- resolving
+        it toward the stale approval ships unaddressed findings.
+
+        Recency is read by value (`max`), not by row position, so exchanging the
+        two ids leaves both answers unchanged. That is asserted here rather than
+        assumed: it is what separates "reads `updated_at`" from "happens to sort
+        the way the fixture was written".
+        """
+        show_json = json.dumps(
+            [{"id": "loop", "metadata": {"gc.root_bead_id": "root", "gc.attempt": "1"}}]
+        )
+        old, new = "2026-08-13T01:00:00Z", "2026-08-13T03:00:00Z"
+
+        for label, stale, fresh, expected_code, expected_out in (
+            ("later iterate keeps the loop open", "done", "iterate", 1, "iterate"),
+            ("later done closes the loop", "iterate", "done", 0, "approved"),
+        ):
+            # Exchange the ids so the fresh row is once id-last and once
+            # id-first: neither ordering may change the decision.
+            for id_order in (("gcg-aaa", "gcg-zzz"), ("gcg-zzz", "gcg-aaa")):
+                stale_id, fresh_id = id_order
+                with self.subTest(case=label, stale_id=stale_id):
+                    list_json = json.dumps(
+                        [
+                            self._owner_bead(stale_id, stale, old),
+                            self._owner_bead(fresh_id, fresh, new),
+                        ]
+                    )
+
+                    result = self._run_implementation_review_check(
+                        show_json=show_json, list_json=list_json
+                    )
+
+                    self.assertEqual(
+                        result.returncode,
+                        expected_code,
+                        result.stdout + result.stderr,
+                    )
+                    self.assertIn(expected_out, result.stdout)
+                    self.assertIn(f'selected "{fresh}" (newest updated_at)', result.stderr)
+
+    def test_implementation_review_check_notes_multiple_owner_candidates(self) -> None:
+        """Owner ambiguity is always reported on stderr, whichever way it falls.
+
+        The note is an audit artifact -- no control flow reads it -- so its job
+        is to let a human tell a recency decision from a fail-closed one after
+        the fact. It names how many owners were seen, every value among them,
+        the selection, and the basis for it.
         """
         show_json = json.dumps(
             [{"id": "loop", "metadata": {"gc.root_bead_id": "root", "gc.attempt": "1"}}]
         )
         list_json = json.dumps(
             [
-                {
-                    "id": "gcg-aaa",
-                    "metadata": {
-                        "gc.root_bead_id": "root",
-                        "gc.attempt": "1",
-                        "code_review.verdict": "done",
-                    },
-                },
-                {
-                    "id": "gcg-zzz",
-                    "metadata": {
-                        "gc.root_bead_id": "root",
-                        "gc.attempt": "1",
-                        "code_review.verdict": "iterate",
-                    },
-                },
+                self._owner_bead("gcg-aaa", "done", "2026-08-13T01:00:00Z"),
+                self._owner_bead("gcg-zzz", "iterate", "2026-08-13T03:00:00Z"),
             ]
         )
 
         result = self._run_implementation_review_check(show_json=show_json, list_json=list_json)
 
-        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
-        self.assertIn("Implementation review approved", result.stdout)
         self.assertIn("2 owner-shaped beads carry code_review.verdict", result.stderr)
+        self.assertIn("values: done, iterate", result.stderr)
+        self.assertIn('selected "iterate" (newest updated_at)', result.stderr)
+
+    def test_implementation_review_check_fails_closed_when_owner_recency_is_unknown(self) -> None:
+        """Owners that disagree with no usable recency resolve to `iterate`.
+
+        `updated_at` is omitempty, so a set where it is missing -- or where the
+        newest rows still disagree -- carries no signal to rank on. The gate
+        then takes the non-approving value: one more loop iteration in a state
+        that should not occur is recoverable, and a silent ship is not. Ranking
+        a partly dated set instead would quietly treat "no timestamp" as
+        "oldest", which is a guess dressed as a reading, so the undated row here
+        must not be demoted into losing.
+
+        Both subtests would pass under a rule that simply preferred the
+        *approving* value, which is what base did -- hence the third assertion,
+        that the stated basis is the fail-closed one and not recency.
+        """
+        show_json = json.dumps(
+            [{"id": "loop", "metadata": {"gc.root_bead_id": "root", "gc.attempt": "1"}}]
+        )
+
+        for label, beads in (
+            (
+                "no row is dated",
+                [
+                    self._owner_bead("gcg-aaa", "done"),
+                    self._owner_bead("gcg-zzz", "iterate"),
+                ],
+            ),
+            (
+                "only one row is dated",
+                [
+                    # The dated row is the approval. If the undated row were
+                    # ranked as older, this would approve.
+                    self._owner_bead("gcg-aaa", "done", "2026-08-13T03:00:00Z"),
+                    self._owner_bead("gcg-zzz", "iterate"),
+                ],
+            ),
+            (
+                "the newest rows still disagree",
+                [
+                    self._owner_bead("gcg-aaa", "done", "2026-08-13T03:00:00Z"),
+                    self._owner_bead("gcg-zzz", "iterate", "2026-08-13T03:00:00Z"),
+                ],
+            ),
+        ):
+            with self.subTest(shape=label):
+                result = self._run_implementation_review_check(
+                    show_json=show_json, list_json=json.dumps(beads)
+                )
+
+                self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+                self.assertIn("needs another iteration: iterate", result.stdout)
+                self.assertIn('selected "iterate" (fail-closed among 2 values)', result.stderr)
 
     def test_implementation_review_check_notes_lane_fallback_without_owner(self) -> None:
-        """The no-starvation fallback announces itself instead of deciding in silence.
+        """The no-starvation fallback announces itself and reduces fail-closed.
 
         When no owner-shaped bead exists, every candidate survives narrowing and
-        the value reduction runs over lane beads -- so one lane carrying an
-        approval outvotes any number of `iterate`s. That decision is deliberate
-        (narrowing may never starve the gate) and is left unchanged here, but it
-        must not be silent: the note names the fallback, how many candidates it
-        reduced, and what it selected.
+        the value reduction runs over lane beads. Reaching this branch means the
+        gate is looking at protocol-violating data -- every lane prompt in the
+        packs is contracted not to write the bare `code_review.verdict` -- so it
+        resolves the disagreement the same way the owner path does: toward the
+        non-approving value. One lane's approval does not outvote two `iterate`s
+        just because it is spelled hopefully. The branch must also not be
+        silent: the note names the fallback, how many candidates it reduced, and
+        what it selected.
+
+        All three rows share one timestamp, so recency cannot decide and the
+        fail-closed reduction is what is under test.
         """
         show_json = json.dumps(
             [{"id": "loop", "metadata": {"gc.root_bead_id": "root", "gc.attempt": "1"}}]
@@ -5153,6 +5276,7 @@ description = "Override sink that writes the base triage report contract."
             [
                 {
                     "id": "gcg-aaa",
+                    "updated_at": "2026-08-13T01:00:00Z",
                     "metadata": {
                         "gc.root_bead_id": "root",
                         "gc.attempt": "1",
@@ -5162,6 +5286,7 @@ description = "Override sink that writes the base triage report contract."
                 },
                 {
                     "id": "gcg-mmm",
+                    "updated_at": "2026-08-13T01:00:00Z",
                     "metadata": {
                         "gc.root_bead_id": "root",
                         "gc.attempt": "1",
@@ -5171,6 +5296,7 @@ description = "Override sink that writes the base triage report contract."
                 },
                 {
                     "id": "gcg-zzz",
+                    "updated_at": "2026-08-13T01:00:00Z",
                     "metadata": {
                         "gc.root_bead_id": "root",
                         "gc.attempt": "1",
@@ -5183,11 +5309,216 @@ description = "Override sink that writes the base triage report contract."
 
         result = self._run_implementation_review_check(show_json=show_json, list_json=list_json)
 
-        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
-        self.assertIn("Implementation review approved", result.stdout)
+        self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+        self.assertIn("needs another iteration: iterate", result.stdout)
         self.assertIn("no owner-shaped bead at attempt 1", result.stderr)
         self.assertIn("reduced 3 lane candidates", result.stderr)
-        self.assertIn('selected "approve"', result.stderr)
+        self.assertIn('selected "iterate" (fail-closed among 2 values)', result.stderr)
+
+    def test_implementation_review_check_matches_a_mixed_case_vocabulary_entry(self) -> None:
+        """A vocabulary entry reaches both consumers whatever case it is written in.
+
+        `APPROVAL_VERDICTS` is the single definition the bash dispatch and the
+        jq lane-status helper both read, and the comment above it promises that
+        a spelling added there reaches every consumer at once. Every shipped
+        entry is already lowercase, so a consumer that downcased only the
+        *candidate* would leave this whole suite green while the next `Approve`
+        added to the array matched nothing anywhere. No fixture can reach that
+        line, so the test rewrites it in a copy of the gate.
+
+        The removal case is the control: it fails if the harness is running
+        anything other than the substituted array.
+        """
+        root = pathlib.Path(__file__).resolve().parents[1]
+        gate_source = (
+            root / "assets" / "scripts" / "checks" / "implementation-review-approved.sh"
+        ).read_text(encoding="utf-8")
+        vocabulary = "APPROVAL_VERDICTS=(approve approved pass done)"
+        self.assertEqual(
+            gate_source.count(vocabulary),
+            1,
+            "the vocabulary line moved; retarget this mutation before trusting it",
+        )
+
+        show_json = json.dumps(
+            [{"id": "loop", "metadata": {"gc.root_bead_id": "root", "gc.attempt": "1"}}]
+        )
+        # `approve` is the spelling under test: as an owner verdict it goes
+        # through the bash dispatch, and as three lane verdicts it goes through
+        # the jq helper, which receives the same array via --argjson.
+        owner_rows = json.dumps(
+            [self._owner_bead("gcg-aaa", "approve", "2026-08-13T01:00:00Z")]
+        )
+        lane_rows = json.dumps(
+            [
+                {
+                    "id": "gcg-aaa",
+                    "updated_at": "2026-08-13T01:00:00Z",
+                    "metadata": {
+                        "gc.root_bead_id": "root",
+                        "gc.attempt": "1",
+                        "code_review.acceptance_verdict": "approve",
+                        "code_review.test_evidence_verdict": "approve",
+                        "code_review.simplicity_verdict": "approve",
+                    },
+                }
+            ]
+        )
+
+        with tempfile.TemporaryDirectory() as td:
+            gate = pathlib.Path(td) / "implementation-review-approved.sh"
+            for label, mutation, expected_code, owner_out, lane_out in (
+                (
+                    "a mixed-case entry still matches",
+                    "APPROVAL_VERDICTS=(APPROVE approved pass done)",
+                    0,
+                    "Implementation review approved",
+                    "Implementation review approved from lane verdicts",
+                ),
+                (
+                    "an entry dropped from the array stops matching",
+                    "APPROVAL_VERDICTS=(approved pass done)",
+                    1,
+                    "needs another iteration: approve",
+                    "needs another iteration: iterate:",
+                ),
+            ):
+                gate.write_text(gate_source.replace(vocabulary, mutation), encoding="utf-8")
+                gate.chmod(0o755)
+                for consumer, list_json, expected_out in (
+                    ("bash dispatch", owner_rows, owner_out),
+                    ("jq lane status", lane_rows, lane_out),
+                ):
+                    with self.subTest(case=label, consumer=consumer):
+                        result = self._run_implementation_review_check(
+                            show_json=show_json, list_json=list_json, script=gate
+                        )
+
+                        self.assertEqual(
+                            result.returncode,
+                            expected_code,
+                            result.stdout + result.stderr,
+                        )
+                        self.assertIn(expected_out, result.stdout)
+
+    def _run_sibling_gate(
+        self, script_name: str, *, show_json: str, list_json: str
+    ) -> subprocess.CompletedProcess:
+        root = pathlib.Path(__file__).resolve().parents[1]
+        script = root / "assets" / "scripts" / "checks" / script_name
+
+        with tempfile.TemporaryDirectory() as td:
+            tmp = pathlib.Path(td)
+            bin_dir = tmp / "bin"
+            bin_dir.mkdir()
+            write_check_gc_stub(bin_dir)
+            show_path = tmp / "show.json"
+            list_path = tmp / "list.json"
+            show_path.write_text(show_json, encoding="utf-8")
+            list_path.write_text(list_json, encoding="utf-8")
+
+            env = {
+                **os.environ,
+                "PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}",
+                "BD_SHOW_JSON": str(show_path),
+                "BD_LIST_JSON": str(list_path),
+                "GC_BEAD_ID": "loop",
+                "GC_ITERATION": "1",
+            }
+            return subprocess.run(
+                [str(script)], env=env, text=True, capture_output=True, check=False
+            )
+
+    def test_gap_analysis_check_takes_the_newest_verdict_not_the_id_last_one(self) -> None:
+        """The gap-analysis gate decides by recency -- pinned before it is ported.
+
+        This PR leaves its two sibling gates alone and files the port of
+        owner/value selection as a follow-up. `gap-analysis-approved.sh` has
+        exactly one recency mechanism: the `sort_by(.updated_at // "")` inside
+        its `gmol`, staging row order for a bare `| last` at the selection site.
+        Deleting that sort while porting -- which the follow-up as first written
+        proposed -- would reduce the gate to picking a verdict by bead id.
+        Measured: with the sort removed both directions below flip, so this is
+        the fail-open the guard exists to catch.
+
+        It is a behavior test, not a text assertion, so the port stays free to
+        move the mechanism as long as the answers survive. Both directions are
+        asserted because a gate stuck on `iterate` would pass the first alone.
+        """
+        self._assert_sibling_gate_reads_recency(
+            "gap-analysis-approved.sh",
+            verdict_key="gap_analysis.verdict",
+            extra_metadata={},
+            iterate_output="Gap analysis needs another iteration: iterate",
+            approve_output="Gap analysis approved",
+        )
+
+    def test_design_review_check_takes_the_newest_verdict_not_the_id_last_one(self) -> None:
+        """The same guard for design-review, which carries recency somewhere else.
+
+        `design-review-approved.sh` re-sorts at the selection site --
+        `sort_by(.attempt, .updated_at) | last.verdict` -- so unlike its
+        gap-analysis sibling it does not depend on the sort inside its `gmol`;
+        deleting that one alone is measurably inert here. The distinction is
+        worth pinning precisely, because the tempting generalisation from this
+        file to the other is exactly wrong: the same deletion next door is a
+        fail-open. What the two gates do share is the behavior below, and that
+        is what a port has to keep.
+        """
+        self._assert_sibling_gate_reads_recency(
+            "design-review-approved.sh",
+            verdict_key="design_review.verdict",
+            # With no step or scope on the loop bead, this gate matches members
+            # by continuation group.
+            extra_metadata={"gc.continuation_group": "design-review-fixes"},
+            iterate_output="Design review needs another pass",
+            approve_output="Design review approved",
+        )
+
+    def _assert_sibling_gate_reads_recency(
+        self,
+        script_name: str,
+        *,
+        verdict_key: str,
+        extra_metadata: dict,
+        iterate_output: str,
+        approve_output: str,
+    ) -> None:
+        show_json = json.dumps(
+            [{"id": "loop", "metadata": {"gc.root_bead_id": "root", "gc.attempt": "1"}}]
+        )
+        old, new = "2026-08-13T01:00:00Z", "2026-08-13T03:00:00Z"
+
+        def member(bead_id: str, verdict: str, updated: str) -> dict:
+            return {
+                "id": bead_id,
+                "status": "closed",
+                "updated_at": updated,
+                "metadata": {
+                    "gc.root_bead_id": "root",
+                    "gc.attempt": "1",
+                    verdict_key: verdict,
+                    **extra_metadata,
+                },
+            }
+
+        for label, fresh, stale, expected_code, expected_out in (
+            ("a fresh iterate outranks a stale done", "iterate", "done", 1, iterate_output),
+            ("a fresh done outranks a stale iterate", "done", "iterate", 0, approve_output),
+        ):
+            with self.subTest(case=label, script=script_name):
+                # The fresh row is id-*first*, so selecting by id order takes
+                # the stale one. That is the arrangement a lost sort exposes.
+                list_json = json.dumps(
+                    [member("gcg-aaa", fresh, new), member("gcg-zzz", stale, old)]
+                )
+
+                result = self._run_sibling_gate(
+                    script_name, show_json=show_json, list_json=list_json
+                )
+
+                self.assertEqual(result.returncode, expected_code, result.stdout + result.stderr)
+                self.assertIn(expected_out, result.stdout)
 
     def test_design_review_check_unions_every_status_leg(self) -> None:
         """The verdict usually lands on a bead the review just closed.


### PR DESCRIPTION
`implementation-review-approved.sh` is the Ralph loop-exit gate consumed by 10 formulas across 5 packs. It could strand a finished build. Two independent defects were confirmed, either sufficient on its own.

## The defects

**1. The loop verdict was picked by position, not by owner.** `gmol()` ended in
`unique_by(.id) | sort_by(.updated_at // "")`, and the downstream `| last` consumed that row
order. That re-sort was **live**, and `| last` really did mean "most recently updated":
`updated_at` is `omitempty` on the reader's bead struct, absent only on a bead never updated
since it was created — which no verdict carrier can be, because it got its verdict key from
`gc bd update`. (Measured 56/56 rows carrying `updated_at` on this change's own review root.)

The defect is that "most recently updated" is not "the lane that owned the review". Selection
was positional and ranged over every verdict-bearing bead in the molecule, so the newest row
won even when it came from a bead that did not own the review; and on equal timestamps jq's
stable sort left bead-id order to break the tie.

**2. The file disagreed with itself about "approved".** Its own `approved()` helper
accepted `approve|approved|pass|done`, while the top-level dispatch accepted only `done`
and `approved|pass`. A lane spelling its verdict `approve` was rejected by the gate that
its own helper would have accepted.

## The repair

- Positional selection is replaced with **owner-preferring, permutation-invariant**
  selection: the verdict is chosen by the lane that owns the review, so exchanging bead
  ids in the fixture produces an identical exit code and stdout.
- Recency is read **by value where it is used**, not staged in row order: `newest()` narrows
  to the maximum `updated_at`, but only when *every* survivor is dated; a partially dated set
  is deliberately not ranked. `decide()` then reduces any remaining disagreement to the
  non-approving value, so the gate **fails closed** rather than approving on a tie.
- The approval vocabulary is defined **once, case-insensitively**, for both consumers.
- The lane-fallback path now **announces** which verdict it selected instead of deciding
  in silence, and shares `decide()` — so one bare-key approval no longer outvotes two
  `iterate`s at equal recency.

### One deliberate deviation from the filed suggestion

The source bead suggested filtering on `gc.step_id == "review.apply-review-findings"`.
That was **not** implemented: the literal string selects nothing for 7 of the 10 consuming
formulas and would have broken most consumers. The landed rule reads a contract every lane
prompt states verbatim instead.

## Evidence

| Check | Result |
| --- | --- |
| `pytest -k implementation_review -q`, test change only (red baseline) | 7 failed, 6 passed, 5 subtests |
| same, after the script repair | 10 passed, 89 deselected, 8 subtests |
| ids exchanged in the permutation fixture | identical exit code and stdout for both orderings |
| `python3 -m pytest gascity/tests -q` at the final head | 199 passed, 9461 subtests |
| `pytest -k implementation_review -q` at the final head | 14 passed, 185 deselected, 20 subtests |
| full CI matrix (`.github/workflows/ci.yml:44`, 11 suites), measured at `c690bad` | 1328 passed, 29 skipped, 9484 subtests |
| `grep -n 'sort_by(.updated_at' <repaired script>` | no match (exit 1) |

Two files change together: `gascity/assets/scripts/checks/implementation-review-approved.sh`
and `gascity/tests/test_formula_assets.py` (+809 / −60). Rollback is `git revert` of the
four commits in this branch (`ca5170d`, `8347a90`, `a463594`, `796d20c`) — reverting only the
first three would leave the selection rewrite in the tree without the fixture and comment work
it is coupled to.

## Notes for the merger

- **A parallel branch edits the same test file.** Unmerged
  `gc/ac-s362al-shared-namespace-owner-check` also touches
  `gascity/tests/test_formula_assets.py`. Near-identical sibling test blocks auto-merge with
  no conflict marker and nothing in Python catches it — whoever merges second should re-run
  `python3 -m pytest gascity/tests -q`. That branch's base also carries a pre-`56016d5` copy
  of the target script, so a merge taking that side would silently revert the
  federating-reader fix.
- **Out of scope, tracked separately — and the sibling sorts are live, not inert.** The same
  `sort_by` lives in `design-review-approved.sh:35` and `gap-analysis-approved.sh:33` (the
  latter accepts `done` only). Review measured both: deleting `gap-analysis-approved.sh`'s
  sort turns its guard red in **both** directions — against a molecule whose fresh verdict is
  `iterate` and whose id-last verdict is a stale `done`, the shipped script correctly returns
  `ITERATE(1)` and the sort-deleted script returns `APPROVE(0)`, a real fail-open.
  `design-review-approved.sh:35`'s copy is inert *at that line only*, rescued by the
  selection-site `sort_by(.attempt, .updated_at)` at `:77`; delete both and its guard goes red
  too. **The follow-up must port owner/value-based selection while keeping a recency
  tie-break — it must never merely delete the sorts.** Both siblings are verified untouched
  here and are filed as `mc-57k9j`.
- **No pack release step was performed.** Whether a version bump or registry stamp is also
  needed is a release decision outside this code change. Installed rigs keep running the
  broken gate until their next pack-cache refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BsWb1VXLXKTEPAaJKEF1dS
