### PR TITLE
fix(gastown): make Dolt diagnostics portable on macOS

### DIFF
--- a/gastown/template-fragments/operational-awareness.template.md
+++ b/gastown/template-fragments/operational-awareness.template.md
@@ -54,18 +54,50 @@ If you detect Dolt trouble (commands hang/timeout, "connection refused",
 are hard to reproduce. A blind restart destroys the evidence. Always:
 
 ```bash
+# Bound a command without depending on GNU coreutils `timeout`, which is not
+# installed by default on macOS. This mirrors Gas City's Dolt runtime helper:
+# preserve normal exit codes, return 124 at the deadline, and escalate from
+# SIGTERM to SIGKILL after a short grace period.
+run_bounded() {
+  bound_seconds="$1"
+  shift
+  if ! command -v python3 >/dev/null 2>&1; then
+    printf 'diagnostic: python3 not found; cannot run bounded command\n' >&2
+    return 124
+  fi
+  python3 - "$bound_seconds" "$@" <<'PY'
+import subprocess
+import sys
+
+limit = float(sys.argv[1])
+command = sys.argv[2:]
+process = subprocess.Popen(command)
+try:
+    process.wait(timeout=limit)
+except subprocess.TimeoutExpired:
+    process.terminate()
+    try:
+        process.wait(timeout=2)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait()
+    sys.exit(124)
+sys.exit(process.returncode)
+PY
+}
+
 # Group all four captures under one timestamp so the bundle is easy
-# to attach to the escalation note. Each timed step writes via
-# redirect (not `tee`) so timeout's exit 124 propagates to `||` and
-# the agent gets an explicit "diagnostic timed out" signal — POSIX
-# pipelines mask the upstream exit code via tee.
+# to attach to the escalation note. Each bounded step writes via redirect
+# (not `tee`) so its non-zero status propagates to `||` and the agent gets an
+# explicit "diagnostic timed out" signal — POSIX pipelines mask the upstream
+# exit code via tee.
 ts=$(date +%s)
 
 # 1. Capture live process state via SQL (non-fatal — Dolt keeps running).
 #    SHOW FULL PROCESSLIST lists active connections, the query each is
 #    running, and time-in-state. Bound the call so a wedged server can't
 #    block the diagnostic itself.
-timeout 5 gc dolt sql -q "SHOW FULL PROCESSLIST" \
+run_bounded 5 gc dolt sql -q "SHOW FULL PROCESSLIST" \
     > /tmp/dolt-hang-$ts-procs.log 2>&1 \
   || echo "(step 1 timed out or failed — see procs.log for partial output)"
 cat /tmp/dolt-hang-$ts-procs.log
@@ -86,7 +118,7 @@ cat /tmp/dolt-hang-$ts-logs.log
 #    worst-case wall time is roughly 5s + 5s × N_databases. 60s covers
 #    cities up to ~10 databases at the limit; if the timeout fires,
 #    treat it as evidence the data plane is wedged and escalate.
-timeout 60 gc dolt health --json \
+run_bounded 60 gc dolt health --json \
     > /tmp/dolt-hang-$ts-health.json 2>&1 \
   || echo "(step 3 timed out or failed — see health.json for partial output)"
 cat /tmp/dolt-hang-$ts-health.json
@@ -94,7 +126,7 @@ cat /tmp/dolt-hang-$ts-health.json
 # 4. Capture reachability + PID for the escalation note. Bound the
 #    call: `gc dolt status` probes /dev/tcp, which can stall on a
 #    server that accepts connections but never speaks MySQL.
-timeout 10 gc dolt status \
+run_bounded 10 gc dolt status \
     > /tmp/dolt-hang-$ts-status.log 2>&1 \
   || echo "(step 4 timed out or failed — see status.log for partial output)"
 cat /tmp/dolt-hang-$ts-status.log

--- a/gastown/template-fragments/operational-awareness.template.md
+++ b/gastown/template-fragments/operational-awareness.template.md
@@ -57,7 +57,15 @@ are hard to reproduce. A blind restart destroys the evidence. Always:
 # Bound a command without depending on GNU coreutils `timeout`, which is not
 # installed by default on macOS. This mirrors Gas City's Dolt runtime helper:
 # preserve normal exit codes, return 124 at the deadline, and escalate from
-# SIGTERM to SIGKILL after a short grace period.
+# SIGTERM to SIGKILL after a short grace period. The canonical full helper is
+# the dolt pack's `doctor/check-dolt/run.sh`; this variant deliberately drops
+# its `gtimeout`/`timeout` fast path so a pasted runbook takes one code path on
+# every host — the asset test pins that absence, so don't harmonize it back in.
+# Copy notes: the bound is seconds as a bare number (`run_bounded 5 ...`), not
+# GNU suffix syntax (`5s`), and the bounded command does not inherit your stdin
+# because the helper's own script arrives there — redirect input per command if
+# it needs any. The canonical helper has that same stdin limitation whenever it
+# takes its python fallback, but not when it finds a real `timeout` binary.
 run_bounded() {
   bound_seconds="$1"
   shift
@@ -69,7 +77,14 @@ run_bounded() {
 import subprocess
 import sys
 
-limit = float(sys.argv[1])
+try:
+    limit = float(sys.argv[1])
+except ValueError:
+    sys.stderr.write(
+        "diagnostic: run_bounded takes seconds as a bare number"
+        " (run_bounded 5 ...), not GNU suffix syntax (5s)\n"
+    )
+    sys.exit(124)
 command = sys.argv[2:]
 process = subprocess.Popen(command)
 try:
@@ -82,7 +97,10 @@ except subprocess.TimeoutExpired:
         process.kill()
         process.wait()
     sys.exit(124)
-sys.exit(process.returncode)
+# A child killed by a signal reports a negative returncode; surface it as the
+# shell's 128+N convention (SIGTERM -> 143) so "preserve normal exit codes"
+# holds for that class too.
+sys.exit(process.returncode if process.returncode >= 0 else 128 - process.returncode)
 PY
 }
 

--- a/gastown/tests/test_gastown_pack_assets.sh
+++ b/gastown/tests/test_gastown_pack_assets.sh
@@ -613,6 +613,24 @@ test_prime_prompts_are_city_generic_and_compact() {
         fail "operational awareness must require configured and probed endpoint evidence"
     grep -F 'endpoint is unknown and stop' "$awareness" >/dev/null ||
         fail "operational awareness must fail closed when endpoint discovery fails"
+    grep -F 'run_bounded() {' "$awareness" >/dev/null ||
+        fail "operational awareness should define a portable diagnostic timeout helper"
+    grep -F 'run_bounded 5 gc dolt sql' "$awareness" >/dev/null ||
+        fail "operational awareness should bound the process-list diagnostic"
+    grep -F 'run_bounded 60 gc dolt health --json' "$awareness" >/dev/null ||
+        fail "operational awareness should bound the health diagnostic"
+    grep -F 'run_bounded 10 gc dolt status' "$awareness" >/dev/null ||
+        fail "operational awareness should bound the status diagnostic"
+    grep -F 'python3 - "$bound_seconds" "$@"' "$awareness" >/dev/null ||
+        fail "operational awareness should use the portable Python timeout fallback"
+    grep -F 'process.wait(timeout=2)' "$awareness" >/dev/null ||
+        fail "operational awareness should grant a short SIGTERM grace period"
+    grep -F 'process.kill()' "$awareness" >/dev/null ||
+        fail "operational awareness should kill a diagnostic that ignores SIGTERM"
+    grep -F 'sys.exit(124)' "$awareness" >/dev/null ||
+        fail "operational awareness should use the conventional timeout exit status"
+    ! grep -E '(^|[[:space:]])timeout[[:space:]]+[0-9]' "$awareness" >/dev/null ||
+        fail "operational awareness must not require GNU coreutils timeout"
 }
 
 test_dog_assets_are_pack_local

--- a/gastown/tests/test_gastown_pack_assets.sh
+++ b/gastown/tests/test_gastown_pack_assets.sh
@@ -631,6 +631,41 @@ test_prime_prompts_are_city_generic_and_compact() {
         fail "operational awareness should use the conventional timeout exit status"
     ! grep -E '(^|[[:space:]])timeout[[:space:]]+[0-9]' "$awareness" >/dev/null ||
         fail "operational awareness must not require GNU coreutils timeout"
+
+    # The pins above are content-only: they cannot see a python syntax error, a
+    # dropped `shift`, or a deleted exit path inside the fenced helper. Execute
+    # the shipped helper so a functionally broken run_bounded cannot ship green.
+    # This also carries the deadline contract that `sys.exit(124)` above can no
+    # longer carry alone: that literal now appears twice (deadline and bad-bound
+    # rejection), so the presence pin is satisfied by either occurrence.
+    local helper helper_rc
+    helper="$(sed -n '/^run_bounded() {$/,/^}$/p' "$awareness")"
+    [[ -n "$helper" ]] ||
+        fail "run_bounded helper not found between 'run_bounded() {' and its closing brace"
+    [[ "$helper" != *'run_bounded 5 gc dolt sql'* ]] ||
+        fail "run_bounded helper extraction overshot its closing brace anchor"
+
+    helper_rc=0
+    ( eval "$helper"; run_bounded 5 sh -c 'exit 7' ) || helper_rc=$?
+    [[ "$helper_rc" -eq 7 ]] ||
+        fail "shipped run_bounded must pass a bounded command's exit status through (want 7, got $helper_rc)"
+
+    helper_rc=0
+    ( eval "$helper"; run_bounded 1 sleep 3 ) || helper_rc=$?
+    [[ "$helper_rc" -eq 124 ]] ||
+        fail "shipped run_bounded must return 124 when the deadline fires (want 124, got $helper_rc)"
+
+    helper_rc=0
+    ( eval "$helper"; run_bounded 5s true ) 2>/dev/null || helper_rc=$?
+    [[ "$helper_rc" -eq 124 ]] ||
+        fail "shipped run_bounded must reject a GNU-suffix bound closed with 124 (want 124, got $helper_rc)"
+
+    # A child that dies to a signal inside the bound reports a negative
+    # returncode; the helper must report the shell's 128+N (143), not 241.
+    helper_rc=0
+    ( eval "$helper"; run_bounded 5 sh -c 'kill -TERM $$; sleep 5' ) || helper_rc=$?
+    [[ "$helper_rc" -eq 143 ]] ||
+        fail "shipped run_bounded must report a signal-killed child as 128+N (want 143, got $helper_rc)"
 }
 
 test_dog_assets_are_pack_local


### PR DESCRIPTION
## Summary

- replace GNU `timeout` calls in the operational-awareness Dolt diagnostic bundle with the same Python 3 bounded-execution contract used by Gas City's Dolt runtime
- preserve normal exit codes, return 124 on timeout, and escalate SIGTERM to SIGKILL after a two-second grace period without requiring Homebrew/coreutils
- add asset assertions that prevent the non-portable dependency or hard-bound guarantees from regressing

## Verification

- `git diff --check`
- `gastown/tests/test_gastown_pack_assets.sh` (run with Python 3.12 because the macOS system Python is 3.9 and lacks `tomllib`)
- functional helper harness: a normal 30-second sleep returned 124 at 1 second; a SIGTERM-ignoring sleep returned 124 after the 2-second grace period; fast success returned 0; fast failure returned 1

This intentionally changes only the pack template. It does not alter any consuming city pin, install, or runtime.