### PR TITLE
fix: finalize idle refinery patrol wisps

### DIFF
--- a/gastown/agents/refinery/prompt.template.md
+++ b/gastown/agents/refinery/prompt.template.md
@@ -67,10 +67,7 @@ external observers (witness, mayor) only catch on a slow patrol cycle.
 ### 1. ALWAYS pour the next wisp before burning the current one
 
 ```bash
-CURRENT_WISP=${GC_BEAD_ID:-}
-if [ -z "$CURRENT_WISP" ]; then
-  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
-fi
+CURRENT_WISP=${GC_BEAD_ID:-${GC_TRIGGER_BEAD_ID:-$(gc hook current --id-only)}}
 NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{ .DefaultBranch }} --var rig_name={{ .RigName }} --var binding_prefix={{ .BindingPrefix }} --json | jq -r '.new_epic_id // empty')
 if [ -z "$NEXT" ]; then
   echo "Could not pour next refinery wisp; not burning."
@@ -112,10 +109,7 @@ shortcuts or summarizing prematurely. If context feels heavy, then **pour and
 assign the next wisp, burn the current wisp, THEN request restart**:
 
 ```bash
-CURRENT_WISP=${GC_BEAD_ID:-}
-if [ -z "$CURRENT_WISP" ]; then
-  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
-fi
+CURRENT_WISP=${GC_BEAD_ID:-${GC_TRIGGER_BEAD_ID:-$(gc hook current --id-only)}}
 NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{ .DefaultBranch }} --var rig_name={{ .RigName }} --var binding_prefix={{ .BindingPrefix }} --json | jq -r '.new_epic_id // empty')
 if [ -z "$NEXT" ]; then
   echo "Could not pour next refinery wisp; not requesting restart."

--- a/gastown/formulas/mol-refinery-patrol.toml
+++ b/gastown/formulas/mol-refinery-patrol.toml
@@ -189,15 +189,35 @@ The bead MUST have `metadata.branch`. If `metadata.target` is missing,
 use {{target_branch}} as default. Note the work bead ID and close this step.
 
 If NO work found:
+Resolve the patrol wisp for this iteration, claim it, and close it with an
+audit reason before leaving. An idle refinery has no branch-backed work to
+hold open, and leaving the root wisp open makes the next startup bypass it
+because the legacy lookup only checks `in_progress`:
+```bash
+CURRENT_WISP=${GC_BEAD_ID:-}
+if [ -z "$CURRENT_WISP" ]; then
+  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=open --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
+fi
+if [ -z "$CURRENT_WISP" ]; then
+  echo "Could not resolve current refinery wisp; preserving evidence."
+  exit 1
+fi
+if ! gc bd update "$CURRENT_WISP" --claim; then
+  echo "Could not claim current refinery wisp; preserving evidence."
+  exit 1
+fi
+if ! gc bd close "$CURRENT_WISP" --reason "Idle: no branch-backed work assigned."; then
+  echo "Could not close current refinery wisp; preserving evidence."
+  exit 1
+fi
+gc runtime drain-ack
 Write exactly:
 ```
 IDLE: no work, exiting turn.
 ```
 Then stop immediately. Do NOT sleep, call ScheduleWakeup, or use Monitor.
-The session_sleep policy will restart this session after the configured idle interval.
-When restarted, re-read formula steps — this step stays open until a work bead is found.
-
-**Do not close this step until you have a work bead with branch metadata.**"""
+New branch-backed work will wake a fresh refinery patrol through the normal
+routing path. """
 
 [[steps]]
 id = "rebase"

--- a/gastown/formulas/mol-refinery-patrol.toml
+++ b/gastown/formulas/mol-refinery-patrol.toml
@@ -117,10 +117,7 @@ If context feels heavy (multi-hour session, large recent diffs, or you notice
 yourself taking shortcuts or summarizing prematurely), pour and assign the next
 wisp, burn the current wisp, then request a restart:
 ```bash
-CURRENT_WISP=${GC_BEAD_ID:-}
-if [ -z "$CURRENT_WISP" ]; then
-  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
-fi
+CURRENT_WISP=${GC_BEAD_ID:-${GC_TRIGGER_BEAD_ID:-$(gc hook current --id-only)}}
 NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{target_branch}} --var rig_name={{rig_name}} --var binding_prefix={{binding_prefix}} --json | jq -r '.new_epic_id // empty')
 if [ -z "$NEXT" ]; then
   echo "Could not pour next refinery wisp; not requesting restart."
@@ -194,10 +191,7 @@ audit reason before leaving. An idle refinery has no branch-backed work to
 hold open, and leaving the root wisp open makes the next startup bypass it
 because the legacy lookup only checks `in_progress`:
 ```bash
-CURRENT_WISP=${GC_BEAD_ID:-}
-if [ -z "$CURRENT_WISP" ]; then
-  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=open --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
-fi
+CURRENT_WISP=${GC_BEAD_ID:-${GC_TRIGGER_BEAD_ID:-$(gc hook current --id-only)}}
 if [ -z "$CURRENT_WISP" ]; then
   echo "Could not resolve current refinery wisp; preserving evidence."
   exit 1
@@ -260,10 +254,7 @@ gc bd update $WORK \
 5. Clean up temp branch: `git checkout {{target_branch}} && git branch -D temp`
 6. Pour next patrol iteration before burning:
 ```bash
-CURRENT_WISP=${GC_BEAD_ID:-}
-if [ -z "$CURRENT_WISP" ]; then
-  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
-fi
+CURRENT_WISP=${GC_BEAD_ID:-${GC_TRIGGER_BEAD_ID:-$(gc hook current --id-only)}}
 NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{target_branch}} --var rig_name={{rig_name}} --var binding_prefix={{binding_prefix}} --json | jq -r '.new_epic_id // empty')
 if [ -z "$NEXT" ]; then
   echo "Could not pour next refinery wisp; not burning."
@@ -361,10 +352,7 @@ TARGET=$(gc bd show $WORK --json | jq -r '.[0].metadata.target // "{{target_bran
    - Clean up: `git checkout "$TARGET" && git branch -D temp`
    - Pour next patrol iteration before burning:
      ```bash
-     CURRENT_WISP=${GC_BEAD_ID:-}
-     if [ -z "$CURRENT_WISP" ]; then
-       CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
-     fi
+     CURRENT_WISP=${GC_BEAD_ID:-${GC_TRIGGER_BEAD_ID:-$(gc hook current --id-only)}}
      NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{target_branch}} --var rig_name={{rig_name}} --var binding_prefix={{binding_prefix}} --json | jq -r '.new_epic_id // empty')
      if [ -z "$NEXT" ]; then
        echo "Could not pour next refinery wisp; not burning."
@@ -453,10 +441,7 @@ Work bead: $WORK
 Existing PR: $EXISTING_PR
 Branch: $BRANCH
 Target: $TARGET"
-  CURRENT_WISP=${GC_BEAD_ID:-}
-  if [ -z "$CURRENT_WISP" ]; then
-    CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
-  fi
+  CURRENT_WISP=${GC_BEAD_ID:-${GC_TRIGGER_BEAD_ID:-$(gc hook current --id-only)}}
   if [ -z "$CURRENT_WISP" ]; then
     echo "Could not resolve current wisp; not burning."
     echo "$reason"
@@ -1161,10 +1146,7 @@ If auto_land = "false": skip this entirely.
 
 **2. Resolve the current wisp, pour next iteration, then burn this wisp:**
 ```bash
-CURRENT_WISP=${GC_BEAD_ID:-}
-if [ -z "$CURRENT_WISP" ]; then
-  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
-fi
+CURRENT_WISP=${GC_BEAD_ID:-${GC_TRIGGER_BEAD_ID:-$(gc hook current --id-only)}}
 NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{target_branch}} --var rig_name={{rig_name}} --var binding_prefix={{binding_prefix}} --json | jq -r '.new_epic_id // empty')
 if [ -z "$NEXT" ]; then
   echo "Could not pour next refinery wisp; not burning."

--- a/gastown/tests/test_gastown_pack_assets.sh
+++ b/gastown/tests/test_gastown_pack_assets.sh
@@ -237,6 +237,55 @@ PY
         fail "idle refinery exit must not close through update --status=closed"
 }
 
+test_refinery_idle_exit_uses_the_session_bound_wisp() {
+    local formula idle_script tmp log
+    formula="$GASTOWN/formulas/mol-refinery-patrol.toml"
+    idle_script=$(python3 - "$formula" <<'PY'
+import sys
+
+text = open(sys.argv[1], encoding="utf-8").read()
+start = text.index("If NO work found:")
+start = text.index("```bash", start) + len("```bash")
+end = text.index("gc runtime drain-ack", start) + len("gc runtime drain-ack")
+print(text[start:end])
+PY
+)
+
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' RETURN
+    log="$tmp/gc.log"
+    mkdir "$tmp/bin"
+    cat >"$tmp/bin/gc" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"$GC_TEST_LOG"
+case "$*" in
+    'hook current --id-only') echo 'sl-wisp-rt8' ;;
+    'bd update sl-wisp-rt8 --claim') ;;
+    'bd close sl-wisp-rt8 --reason Idle: no branch-backed work assigned.') ;;
+    'runtime drain-ack') ;;
+    'bd list'*) echo 'unrelated-molecule' ;;
+    *) echo "unexpected gc invocation: $*" >&2; exit 1 ;;
+esac
+EOF
+    chmod +x "$tmp/bin/gc"
+
+    # GC_BEAD_ID отсутствует, а в ledger могут быть другие назначенные wisps.
+    # Для закрытия допустим только claim текущей сессии, а не произвольная молекула.
+    env -u GC_BEAD_ID -u GC_TRIGGER_BEAD_ID \
+        GC_AGENT='slovo/gastown.refinery' GC_TEST_LOG="$log" PATH="$tmp/bin:$PATH" \
+        bash -c "$idle_script"
+
+    grep -Fx 'hook current --id-only' "$log" >/dev/null ||
+        fail "idle refinery exit must resolve the current session claim"
+    ! grep -F 'bd list' "$log" >/dev/null ||
+        fail "idle refinery exit must not select an arbitrary assigned molecule"
+    grep -Fx 'bd close sl-wisp-rt8 --reason Idle: no branch-backed work assigned.' "$log" >/dev/null ||
+        fail "idle refinery exit must close only the session-bound wisp"
+    ! grep -F 'unrelated-molecule' "$log" >/dev/null ||
+        fail "idle refinery exit must preserve unrelated wisp evidence"
+}
+
 test_prime_prompts_are_city_generic_and_compact() {
     local mayor propulsion awareness
     mayor="$GASTOWN/agents/mayor/prompt.template.md"
@@ -276,5 +325,6 @@ test_review_leg_contract_forbids_synthetic_mutation
 test_prime_prompts_are_city_generic_and_compact
 test_refinery_direct_merge_is_worktree_safe_and_fail_closed
 test_refinery_idle_exit_closes_patrol_wisp
+test_refinery_idle_exit_uses_the_session_bound_wisp
 
 echo "gastown pack asset tests passed"

--- a/gastown/tests/test_gastown_pack_assets.sh
+++ b/gastown/tests/test_gastown_pack_assets.sh
@@ -216,6 +216,27 @@ if verify >= metadata:
 PY
 }
 
+test_refinery_idle_exit_closes_patrol_wisp() {
+    local formula idle_block
+    formula="$GASTOWN/formulas/mol-refinery-patrol.toml"
+    idle_block=$(python3 - "$formula" <<'PY'
+import sys
+text = open(sys.argv[1], encoding="utf-8").read()
+start = text.index('If NO work found:')
+end = text.index('[[steps]]', start)
+print(text[start:end])
+PY
+)
+    [[ "$idle_block" == *'gc bd update "$CURRENT_WISP" --claim'* ]] ||
+        fail "idle refinery exit must claim its patrol wisp before closing"
+    [[ "$idle_block" == *'gc bd close "$CURRENT_WISP" --reason "Idle: no branch-backed work assigned."'* ]] ||
+        fail "idle refinery exit must close its patrol wisp with an audit reason"
+    [[ "$idle_block" == *'gc runtime drain-ack'* ]] ||
+        fail "idle refinery exit must drain after closing its patrol wisp"
+    [[ "$idle_block" != *'--status=closed'* ]] ||
+        fail "idle refinery exit must not close through update --status=closed"
+}
+
 test_prime_prompts_are_city_generic_and_compact() {
     local mayor propulsion awareness
     mayor="$GASTOWN/agents/mayor/prompt.template.md"
@@ -254,5 +275,6 @@ test_polecat_startup_uses_standard_hook_claim
 test_review_leg_contract_forbids_synthetic_mutation
 test_prime_prompts_are_city_generic_and_compact
 test_refinery_direct_merge_is_worktree_safe_and_fail_closed
+test_refinery_idle_exit_closes_patrol_wisp
 
 echo "gastown pack asset tests passed"


### PR DESCRIPTION
Review-only fix for refinery patrol wisp accumulation.

On an idle scan, the formula now claims its current patrol wisp, closes it with an audit reason, and drains instead of leaving an open root wisp that bypasses the legacy `in_progress` startup lookup.

Includes a static pack regression test.

Verification: `bash gastown/tests/test_gastown_pack_assets.sh`

No merge, deployment, pack install, or runtime change is part of this PR.