### PR TITLE
fix: make Gas Town lifecycle guidance owner-safe

### DIFF
--- a/gascity/template-fragments/gc-role-worker.template.md
+++ b/gascity/template-fragments/gc-role-worker.template.md
@@ -50,7 +50,7 @@ Set required metadata before closing same claimed bead:
 gc bd update "$CLAIMED_BEAD_ID" \
   --set-metadata 'gc.outcome=pass' \
   --set-metadata 'example.key=example-value'
-gc bd close "$CLAIMED_BEAD_ID"
+gc bd close "$CLAIMED_BEAD_ID" --reason 'Completed: <brief summary>.'
 ```
 
 Review findings, missing tests, or follow-up usually are output, not execution

--- a/gastown/agents/dog/prompt.template.md
+++ b/gastown/agents/dog/prompt.template.md
@@ -77,7 +77,7 @@ ample opportunity to respond even if they're in long-running operations.
 **CRITICAL**: When you finish, you MUST close your work and exit:
 
 ```bash
-gc bd close <work-bead>    # Close your assigned work
+gc bd close <work-bead> --reason "Completed: <brief summary>."    # Close your assigned work
 gc runtime drain-ack    # Signal reconciler you're done
 exit                     # Return to pool (controller recycles you)
 ```

--- a/gastown/agents/polecat/prompt.template.md
+++ b/gastown/agents/polecat/prompt.template.md
@@ -227,7 +227,7 @@ if [ "$SHOW_OK" -ne 1 ]; then
   # Never leave a claimed bead stranded in_progress on an unreadable state:
   # release it so it re-enters the pool instead of being lost.
   echo "CLAIM_RELEASED $WORK_ID unreadable after retries; returning it to the pool"
-  gc bd update "$WORK_ID" --status=open --assignee=""
+  gc bd unclaim "$WORK_ID" --if-assignee "$EXPECTED_ASSIGNEE" --reason "Claim state could not be verified."
   gc runtime drain-ack
   exit 0
 fi
@@ -341,7 +341,7 @@ gc mail send "$WITNESS_TARGET" -s "ESCALATION: Brief description [HIGH]" -m "Det
 gc mail send mayor/ -s "BLOCKED: <topic>" -m "Context"
 ```
 
-After escalating: continue if possible, otherwise `gc bd update <bead> --status=escalated && gc runtime drain-ack && exit`.
+After escalating: continue if possible, otherwise `gc bd defer <bead> --reason "Escalated: <brief reason>." && gc runtime drain-ack && exit`.
 
 ---
 

--- a/gastown/agents/refinery/prompt.template.md
+++ b/gastown/agents/refinery/prompt.template.md
@@ -229,8 +229,9 @@ Never infer a branch name. If `metadata.branch` is missing, reject the bead.
 ## Rejection Flow
 
 On rebase conflict or test failure:
-1. Put work bead back in pool:
-   `gc bd update $WORK --status=open --assignee="" --set-metadata rejection_reason="..."`
+1. Record the rejection, then put work bead back in pool:
+   `gc bd update $WORK --set-metadata rejection_reason="..."`
+   followed by `gc bd unclaim $WORK --reason "Refinery rejected: ..."`
 2. Branch handling depends on failure type:
    - Conflict: leave branch intact (polecat needs it for rebase)
    - Test failure: delete branch (polecat redoes work)

--- a/gastown/formulas/mol-polecat-work.toml
+++ b/gastown/formulas/mol-polecat-work.toml
@@ -363,8 +363,8 @@ AUTO_PUSH=$(gc bd show "$WORK_BEAD_ID" --json | jq -r '.[0].metadata | if has("a
 if [ "$AUTO_PUSH" = "false" ]; then
   echo "auto_push=false: halting at branch-ready (no push, no refinery handoff)"
   BRANCH=$(git branch --show-current)
+  gc bd unclaim "$WORK_BEAD_ID" --reason "auto_push=false: branch ready for external review"
   gc bd update "$WORK_BEAD_ID" \
-    --status=open --assignee="" \
     --set-metadata branch="$BRANCH" \
     --set-metadata target={{base_branch}} \
     --set-metadata branch_ready=true \

--- a/gastown/formulas/mol-polecat-work.toml
+++ b/gastown/formulas/mol-polecat-work.toml
@@ -427,7 +427,8 @@ the PR is open and matches the branch, base, and origin repository.
 **6. Reassign to refinery:**
 ```bash
 REFINERY_TARGET="${GC_RIG:+$GC_RIG/}{{binding_prefix}}refinery"
-gc bd update "$WORK_BEAD_ID" --status=open --assignee="$REFINERY_TARGET" --set-metadata gc.routed_to=""
+gc bd unclaim "$WORK_BEAD_ID" --reason "Submitted to refinery for merge review."
+gc bd update "$WORK_BEAD_ID" --assignee="$REFINERY_TARGET" --set-metadata gc.routed_to=""
 ```
 
 `${GC_RIG:+$GC_RIG/}{{binding_prefix}}refinery` resolves to

--- a/gastown/formulas/mol-refinery-patrol.toml
+++ b/gastown/formulas/mol-refinery-patrol.toml
@@ -230,9 +230,8 @@ gc workflow delete-source $WORK --apply && gc workflow reopen-source $WORK
 ```
 3. Put the work bead back in the pool with rejection metadata:
 ```bash
+gc bd unclaim $WORK --reason "Rebase conflicts with $TARGET; returning branch to the polecat pool."
 gc bd update $WORK \
-  --status=open \
-  --assignee="" \
   --set-metadata rejection_reason="Conflicts with $TARGET at $(git rev-parse origin/$TARGET)" \
   --set-metadata gc.routed_to="${GC_RIG:+$GC_RIG/}{{binding_prefix}}polecat"
 ```
@@ -331,9 +330,8 @@ TARGET=$(gc bd show $WORK --json | jq -r '.[0].metadata.target // "{{target_bran
      ```
    - Put the work bead back in the pool with rejection metadata:
      ```bash
+     gc bd unclaim $WORK --reason "Branch regression; returning branch to the polecat pool."
      gc bd update $WORK \
-       --status=open \
-       --assignee="" \
        --set-metadata rejection_reason="<failure summary>" \
        --set-metadata gc.routed_to="${GC_RIG:+$GC_RIG/}{{binding_prefix}}polecat"
      ```
@@ -503,9 +501,9 @@ halt_false_completion() {
   # polecat) instead of masking it.
   fc_branch="$1"
   fc_base="$2"
+  gc bd unclaim $WORK --reason "False completion suspected; deferred for human review."
+  gc bd defer $WORK --reason "False completion suspected; branch $fc_branch has no verified change versus $fc_base."
   gc bd update $WORK \
-    --status=blocked \
-    --assignee="" \
     --set-metadata merge_result=refused_false_completion \
     --set-metadata gc.routed_to=human \
     --set-metadata false_completion_suspected="branch $fc_branch no verified change vs $fc_base; refused merge-close"

--- a/gastown/formulas/mol-review-leg.toml
+++ b/gastown/formulas/mol-review-leg.toml
@@ -140,7 +140,9 @@ EOF
 
 **3. Close the bead and drain:**
 ```bash
-gc bd update "$WORK_BEAD_ID" --status=closed
+# Review legs close the convoy's controller-owned work bead rather than the
+# reviewer wisp, so this explicit controller path is the only cross-owner close.
+gc bd close "$WORK_BEAD_ID" --force --reason "Review leg $LEG completed for $PHASE."
 gc runtime drain-ack
 ```
 

--- a/gastown/formulas/mol-witness-patrol.toml
+++ b/gastown/formulas/mol-witness-patrol.toml
@@ -335,7 +335,7 @@ If the work is already on main:
   is still assigned to the crashed polecat, so this is a cross-actor close and
   bd's close-authority guard (gastownhall/beads#3734) would otherwise refuse it:
 ```bash
-gc bd close <bead> --force
+gc bd close <bead> --force --reason "Recovered orphan already merged to main."
 gc mail send mayor/ -s "ORPHAN_CLOSED: <bead> already merged" \
   -m "Branch $BRANCH already on main. Closed instead of resetting."
 ```

--- a/gastown/tests/test_gastown_pack_assets.sh
+++ b/gastown/tests/test_gastown_pack_assets.sh
@@ -153,20 +153,25 @@ test_polecat_startup_uses_standard_hook_claim() {
 }
 
 test_lifecycle_assets_require_dedicated_transitions_and_reasoned_closes() {
-    python3 - "$GASTOWN" "$ROOT/gascity/template-fragments" <<'PY' || fail "lifecycle asset scan found prohibited command"
+    scan_lifecycle_assets "$GASTOWN" "$ROOT/gascity/template-fragments" || fail "lifecycle asset scan found prohibited command"
+}
+
+scan_lifecycle_assets() {
+    python3 - "$@" <<'PY'
 import pathlib
 import re
 import sys
 
 roots = [pathlib.Path(arg) for arg in sys.argv[1:]]
-status_update = re.compile(r"\bgc\s+bd\s+update\b[^\r\n]*--status(?:=|\s+)")
-close = re.compile(r"\bgc\s+bd\s+close\s+(?:[\"'$<]|[A-Za-z_])")
+status_update = re.compile(r"\bgc[ \t]+bd(?:[ \t]+--[A-Za-z][A-Za-z0-9_-]*(?:=[^ \t]+|[ \t]+(?:\"[^\"]*\"|'[^']*'|[^ \t]+))?)*[ \t]+update\b[^\r\n]*--status(?:=|[ \t]+)")
+close = re.compile(r"\bgc[ \t]+bd(?:[ \t]+--[A-Za-z][A-Za-z0-9_-]*(?:=[^ \t]+|[ \t]+(?:\"[^\"]*\"|'[^']*'|[^ \t]+))?)*[ \t]+close\s+(?:[\"'$<]|[A-Za-z_])")
 errors = []
 for root in roots:
     for path in root.rglob("*"):
         if not path.is_file() or path.suffix not in {".toml", ".md"}:
             continue
-        for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        body = re.sub(r"\\\r?\n[ \t]*", " ", path.read_text(encoding="utf-8"))
+        for number, line in enumerate(body.splitlines(), 1):
             if status_update.search(line):
                 errors.append(f"{path}:{number}: use a dedicated lifecycle verb instead of gc bd update --status")
             if close.search(line) and "--reason" not in line:
@@ -174,6 +179,20 @@ for root in roots:
 if errors:
     raise SystemExit("\n".join(errors))
 PY
+}
+
+test_lifecycle_asset_scanner_rejects_wrapped_and_flagged_bypasses() {
+    local fixture
+    fixture=$(mktemp -d)
+    trap 'rm -rf "$fixture"' RETURN
+    printf '%s\n' 'gc bd update "$ID" \' '  --status closed' > "$fixture/wrapped.toml"
+    if scan_lifecycle_assets "$fixture" >/dev/null 2>&1; then
+        fail "lifecycle scanner must reject a wrapped gc bd update --status"
+    fi
+    printf 'gc bd --actor worker close "$ID"\n' > "$fixture/flagged.toml"
+    if scan_lifecycle_assets "$fixture" >/dev/null 2>&1; then
+        fail "lifecycle scanner must reject gc bd flags before a bare close"
+    fi
 }
 
 test_review_leg_contract_forbids_synthetic_mutation() {
@@ -276,6 +295,7 @@ test_shutdown_dance_lifecycle_and_audit_contracts
 test_composition_is_documented
 test_polecat_startup_uses_standard_hook_claim
 test_lifecycle_assets_require_dedicated_transitions_and_reasoned_closes
+test_lifecycle_asset_scanner_rejects_wrapped_and_flagged_bypasses
 test_review_leg_contract_forbids_synthetic_mutation
 test_prime_prompts_are_city_generic_and_compact
 test_refinery_direct_merge_is_worktree_safe_and_fail_closed

--- a/gastown/tests/test_gastown_pack_assets.sh
+++ b/gastown/tests/test_gastown_pack_assets.sh
@@ -152,6 +152,30 @@ test_polecat_startup_uses_standard_hook_claim() {
         fail "polecat propulsion fragment must not regress to an unclaimed hook/work-query choice"
 }
 
+test_lifecycle_assets_require_dedicated_transitions_and_reasoned_closes() {
+    python3 - "$GASTOWN" "$ROOT/gascity/template-fragments" <<'PY' || fail "lifecycle asset scan found prohibited command"
+import pathlib
+import re
+import sys
+
+roots = [pathlib.Path(arg) for arg in sys.argv[1:]]
+status_update = re.compile(r"\bgc\s+bd\s+update\b[^\r\n]*--status(?:=|\s+)")
+close = re.compile(r"\bgc\s+bd\s+close\s+(?:[\"'$<]|[A-Za-z_])")
+errors = []
+for root in roots:
+    for path in root.rglob("*"):
+        if not path.is_file() or path.suffix not in {".toml", ".md"}:
+            continue
+        for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            if status_update.search(line):
+                errors.append(f"{path}:{number}: use a dedicated lifecycle verb instead of gc bd update --status")
+            if close.search(line) and "--reason" not in line:
+                errors.append(f"{path}:{number}: gc bd close requires --reason")
+if errors:
+    raise SystemExit("\n".join(errors))
+PY
+}
+
 test_review_leg_contract_forbids_synthetic_mutation() {
     local formula prompt
     formula="$GASTOWN/formulas/mol-review-leg.toml"
@@ -251,6 +275,7 @@ test_shutdown_dance_contracts_are_executable
 test_shutdown_dance_lifecycle_and_audit_contracts
 test_composition_is_documented
 test_polecat_startup_uses_standard_hook_claim
+test_lifecycle_assets_require_dedicated_transitions_and_reasoned_closes
 test_review_leg_contract_forbids_synthetic_mutation
 test_prime_prompts_are_city_generic_and_compact
 test_refinery_direct_merge_is_worktree_safe_and_fail_closed


### PR DESCRIPTION
Removes worker-facing lifecycle uses of `gc bd update --status` and bare `gc bd close` from Gas Town formulas/prompts. Uses `unclaim`/`defer` for nonterminal moves, reasoned closes everywhere, and retains an explicit `--force` path only for documented controller-owned orphan recovery/review closure. Adds an asset scan regression.\n\nValidation: `bash gastown/tests/test_gastown_pack_assets.sh`; lifecycle static scan; `git diff --check`.