### PR TITLE
feat(roles): feature-refiner and quality-judge intake-lane role agents

### DIFF
--- a/gascity/roles/agents/feature-refiner/agent.toml
+++ b/gascity/roles/agents/feature-refiner/agent.toml
@@ -1,0 +1,3 @@
+description = "Intake compile worker: anchors-only template compilation for mol-feature-refine (never invents decisions; decision-waits on gaps)"
+scope = "rig"
+fallback = true

--- a/gascity/roles/agents/feature-refiner/prompt.template.md
+++ b/gascity/roles/agents/feature-refiner/prompt.template.md
@@ -1,0 +1,1 @@
+{{ template "gc-role-worker" . }}

--- a/gascity/roles/agents/quality-judge/agent.toml
+++ b/gascity/roles/agents/quality-judge/agent.toml
@@ -1,0 +1,3 @@
+description = "Quality-gate judgment worker: fixed-prompt rubric evaluation for mol-ac-quality-gate (validated verdicts; uncertainty fails the gate)"
+scope = "rig"
+fallback = true

--- a/gascity/roles/agents/quality-judge/prompt.template.md
+++ b/gascity/roles/agents/quality-judge/prompt.template.md
@@ -1,0 +1,1 @@
+{{ template "gc-role-worker" . }}

--- a/gascity/tests/test_formula_assets.py
+++ b/gascity/tests/test_formula_assets.py
@@ -49,6 +49,7 @@ FORMULAS = {
 
 ROLE_AGENTS = {
     "design-author",
+    "feature-refiner",
     "design-implementation-reviewer",
     "design-test-risk-reviewer",
     "gap-analyst",
@@ -56,6 +57,7 @@ ROLE_AGENTS = {
     "implementation-worker",
     "issue-triager",
     "publisher",
+    "quality-judge",
     "requirements-planner",
     "review-synthesizer",
     "run-operator",


### PR DESCRIPTION
Two new role agents in the gc roles pack for the dark-intake pipeline that lives in the workflows pack (mol-feature-refine + mol-ac-quality-gate, workflows#42–#45). The workflows repo's CI guard correctly refused shipping roles there (workflows#46, closed) — this is their proper home. Standard GC role-worker prompt; per-role charters. First consumer: substrate, for the BTS wave live slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)