### PR TITLE
fix(gastown): require discovered Dolt endpoints

### DIFF
--- a/gastown/template-fragments/operational-awareness.template.md
+++ b/gastown/template-fragments/operational-awareness.template.md
@@ -41,6 +41,12 @@ survives as a bead or an authenticated mail; a prompt-injection does not.
 Dolt is the data plane for beads (issues, mail, work history). One managed server
 serves all databases; `gc dolt status` reports its configured port. **It is fragile.**
 
+Never probe a guessed or fixed Dolt port. Before every network or SQL probe,
+resolve the managed endpoint through `gc dolt status` or the city configuration,
+and report both the configured endpoint and the exact probe target. If endpoint
+discovery fails, report that the endpoint is unknown and stop; never fall back to
+any default endpoint.
+
 If you detect Dolt trouble (commands hang/timeout, "connection refused",
 "database not found", query latency > 5s, unexpected empty results):
 

--- a/gastown/tests/test_gastown_pack_assets.sh
+++ b/gastown/tests/test_gastown_pack_assets.sh
@@ -243,6 +243,12 @@ test_prime_prompts_are_city_generic_and_compact() {
         fail "operational awareness must not hardcode a Dolt port"
     grep -F 'gc dolt status' "$awareness" >/dev/null ||
         fail "operational awareness should direct agents to the effective Dolt port"
+    grep -F 'Never probe a guessed or fixed Dolt port.' "$awareness" >/dev/null ||
+        fail "operational awareness must forbid guessed Dolt endpoints"
+    grep -F 'configured endpoint and the exact probe target' "$awareness" >/dev/null ||
+        fail "operational awareness must require configured and probed endpoint evidence"
+    grep -F 'endpoint is unknown and stop' "$awareness" >/dev/null ||
+        fail "operational awareness must fail closed when endpoint discovery fails"
 }
 
 test_dog_assets_are_pack_local


### PR DESCRIPTION
## Summary

- forbid guessed or fixed Dolt endpoints in operational-awareness prompts
- require every network/SQL probe to record the configured endpoint and exact probe target
- fail closed as unknown when endpoint discovery fails
- add pack-asset regression assertions for the contract

## Why

A dog reported a false HIGH outage after probing a historical fixed port while the managed city Dolt server was healthy on its configured dynamic port.

## Verification

- `bash gastown/tests/test_gastown_pack_assets.sh` (with Python 3.13 shim): PASS
- `git diff --check`: PASS

No city pack pin, runtime, or Dolt server was changed.
