### PR TITLE
feat(github): add self-contained docs pull request reviewer

### DIFF
--- a/docs/design/github-docs-proposal-authority.md
+++ b/docs/design/github-docs-proposal-authority.md
@@ -1,0 +1,174 @@
+# GitHub docs proposal authority boundary
+
+## Status
+
+Proposed implementation boundary for one upstream PR. This document describes
+the dogfood implementation on `fix/github-followup-handoff-copy`; it does not
+describe functionality available on `upstream/main`.
+
+## Outcome
+
+An opted-in pull-request docs reviewer can publish a concise GitHub Check Run
+and, only for a validated same-repository proposal, open one App-owned stacked
+documentation follow-up PR. It never writes the contributor branch, merges a
+PR, or exposes a City admin run page or rendered diff as the review surface.
+
+The original PR remains the review surface. The check either links to the
+App-owned follow-up PR or says that action is required. It must not link to an
+admin dashboard, a City run locator, or inline proposal-diff text.
+
+## Evidence base
+
+The proposed boundary is reconstructed from the dogfood branch rather than
+from a released upstream implementation:
+
+| Dogfood evidence | What it establishes |
+| --- | --- |
+| `github/scripts/github_intake_docs_patch.py` | Strict canonical review and proposal validation, including exact schemas, SHA-pinned evidence, bounded inputs, documentation-only diffs, and digest verification. |
+| `github/scripts/github_intake_docs_patch_worker.py` | The untrusted reviewer receives a sanitized assignment, no GitHub credentials, and emits no candidate when output is unavailable or invalid. |
+| `github/scripts/github_intake_docs_impact_pipeline.py` | The trusted intake boundary captures exact-head evidence, binds the candidate to the exact assignment bytes, and rejects invalid candidates before projection. |
+| `github/scripts/github_intake_docs_impact.py` | The trusted App alone may create a `gas-city/docs-…` stacked branch and follow-up PR after rechecking the PR head. |
+| `github/tests/test_github_intake_docs_{patch,patch_worker,impact_pipeline,impact}.py` | Existing dogfood regression examples for validator, worker, pipeline, and App publication boundaries. |
+
+The eventual PR must preserve the design intent but not copy the retired
+dogfood behavior that points a check to a City review page or treats that page
+as the proposal-diff UI.
+
+## Minimal self-contained upstream change
+
+Land these pieces together. None is independently useful or safe to ship in
+isolation.
+
+| Module | Responsibility |
+| --- | --- |
+| `github/scripts/github_intake_docs_patch.py` | Canonical proposal/review validator. Require exact fields; exact identity; SHA-256 of the exact UTF-8 diff; documentation-only, non-binary paths; SHA-pinned evidence; bounded claims, checks, files, and diff size. |
+| `github/scripts/github_intake_docs_patch_worker.py` | Validate the complete sanitized assignment, run the isolated reviewer with scrubbed environment, and atomically write only a fully validated candidate. Missing, timed-out, oversized, malformed, or mismatched output removes/produces no candidate. |
+| `github/scripts/github_intake_docs_impact_pipeline.py` | Fetch exact-base-to-head evidence, reject any file list that is truncated or contains a file without complete usable patch evidence, bind the outbox envelope to the raw assignment digest, and project only a canonical matching review. |
+| `github/scripts/github_intake_docs_impact.py` | Persist/project the first exact review; create a follow-up only from a validated `proposal-ready` review; recheck the current head before apply, push, and PR creation; publish only compact GitHub-native check text. |
+| `github/scripts/github_intake_service.py` and `github/scripts/github_intake_common.py` | Supply exact PR identity/evidence and narrowly scoped App API helpers plus durable idempotency records for one review and one follow-up per proposal identity. |
+| `github/agents/docs-impact-reviewer/{agent.toml,prompt.template.md}` and `github/pack.toml` | Configure the City reviewer as credential-free and instruct it to emit the exact validator-compatible contract; do not grant it GitHub write authority. |
+| `github/skills/developer-experience-techdocs/` | Vendor the reviewer methodology so the packaged agent has stable documentation-review guidance without depending on a separately installed skill. |
+| `github/tests/test_github_intake_docs_{patch,patch_worker,impact_pipeline,impact}.py` | Cover each trust boundary below. |
+| `github/README.md` | Document only the user-visible GitHub lifecycle and its limits. Do not document an admin run/diff page. |
+
+Excluded from this PR: `github_intake_docs_review_workspace.py`, any City-run
+page route, any check output that contains a rendered diff, and any UI/API for
+browsing reviewer runs. A review workspace may be reconsidered later only if
+it remains internal to the reviewer and is not a user-facing proposal surface.
+
+The pack exposes this reviewer without selecting a scheduler, queue, host, or
+credential source. An installation opts in by dispatching immutable
+assignments to `docs-impact-reviewer`, submitting valid candidates to the
+trusted bridge, and independently invoking the lifecycle one-shot intake and
+reconciliation operations. This is operational wiring owned by the
+installation, not an implied pack deployment.
+
+## Authority and data flow
+
+```text
+GitHub PR exact head
+  -> trusted intake captures complete bounded evidence
+  -> credential-free reviewer receives one immutable assignment
+  -> strict validator accepts one digest- and identity-bound candidate
+  -> trusted App publishes GitHub Check Run
+       -> same-repository proposal: App-owned `gas-city/docs-…` follow-up PR
+       -> every other result: action-required check, no branch or PR mutation
+```
+
+The proposal identity must contain repository IDs/names, PR number, base SHA,
+head SHA, head repository IDs/names, and base ref. The review identity must
+match the source identity exactly. The pipeline compares the candidate envelope
+digest with the raw assignment bytes, then compares both review identity and
+skill with that assignment. This prevents a candidate from another revision,
+PR, repository, or reviewer skill from gaining publication authority.
+
+## Fail-closed rules
+
+The following conditions stop before review projection and App mutation:
+
+- GitHub reports more changed files than the evidence collector obtained, a
+  file has no textual patch, or any patch/aggregate limit is exceeded. Do not
+  silently inspect a prefix of the file list.
+- The assignment has missing/extra fields, an incomplete proposal identity,
+  unsorted or duplicate paths, non-SHA-pinned evidence references, or evidence
+  not bound to the assignment head SHA.
+- The reviewer is absent, times out, emits malformed/oversized output, produces
+  an incomplete proposal, changes the identity or skill, or cannot pass strict
+  review/proposal validation.
+- The proposal has missing/extra fields; an unmatched diff digest; non-doc,
+  traversal, binary, symlink, or mismatched diff paths; missing claim evidence
+  or release scope; or missing/invalid check records.
+- The PR head changes before candidate projection, before patch application,
+  before pushing the bot branch, or before creating the follow-up PR.
+
+For each condition, retain no usable candidate and create no follow-up. When a
+check already exists, complete it as action-required/stale using compact GitHub
+text; never substitute an unverifiable conclusion.
+
+## Follow-up PR authority
+
+`create_followup_pull_request` is authorized only when all of these predicates
+hold after validation: the verdict is `proposal-ready`; proposal status is
+`proposed`; the proposal identity exactly matches the current PR context; the
+head repository ID and name equal the base repository; the head ref is present;
+and the remote head still equals the reviewed SHA at every mutation boundary.
+
+The App fetches the reviewed SHA into a temporary detached checkout, runs
+`git apply --check`, applies the already validated docs-only patch, creates a
+new `gas-city/docs-<pr>-<digest>` branch, and opens it with the original PR head
+as its base. It must never push to the contributor head ref, call a merge API,
+or ask the reviewer worker to do either. Any failure falls back to the compact
+action-required result without a branch mutation.
+
+### Compensating stale-source semantics
+
+The App rechecks the source PR head immediately after each terminal Check Run
+mutation and immediately after follow-up PR creation. If the source head has
+changed, the durable source run becomes `stale` with an `action_required`
+conclusion, and the App overwrites the Check with compact stale text so no
+successful conclusion remains. If a follow-up was created, the App closes only
+that PR after re-reading it and verifying its stable proposal marker, exact
+expected `gas-city/docs-…` ref, same base/head repository, and the configured
+GitHub App bot login. A marker or branch-looking name supplied by a contributor
+is not authority to adopt or close a PR. The marker is represented exactly as
+exactly one standalone `<!-- gas-city-docs-followup:<artifact-sha256> -->`
+body line; substrings, variants, and duplicate marker lines do not match. It
+never closes or modifies the
+contributor PR or branch. A failed compensating close leaves the source Check
+action-required and records the close as pending rather than widening
+authority.
+
+## Test plan for the eventual implementation
+
+1. Validator tests reject every missing/extra proposal field, incomplete
+   identity, unpinned evidence, absent claim release scope, absent check field,
+   digest mismatch, unsafe/truncated diff, and non-documentation path.
+2. Worker tests reject assignments with incomplete evidence bundles or proposal
+   identities; prove an unavailable, oversized, malformed, or mismatched
+   adapter result leaves no candidate artifact.
+3. Pipeline tests model a compare response whose page/file count or patch data
+   is incomplete and assert it does not queue/project/publish. They also prove
+   wrong assignment digest, identity, skill, or stale head never reaches the
+   App projector.
+4. App tests prove a valid same-repository result creates only an App-owned
+   branch and stacked PR; forked heads, stale heads, invalid proposals, and
+   follow-up failures create neither. Assert no command targets the author ref
+   and no merge helper/API is called.
+5. GitHub-native UX tests assert proposal-ready check output links only to the
+   stacked follow-up PR (when created), contains no inline diff, and contains
+   no City admin/run/dashboard URL. The action-required fallback gives a clear
+   next action without exposing an internal run surface.
+6. Run the focused four test modules, then the complete `github/tests`
+   discovery suite. Add a mocked GitHub integration seam only at the App API
+   boundary; validator and assignment tests use real serialization/validation.
+
+## Acceptance criteria for one upstream PR
+
+- The whole authority chain above lands atomically with its focused tests.
+- Incomplete or truncated evidence cannot produce a reviewer candidate,
+  proposal, bot branch, follow-up PR, pass conclusion, or merge action.
+- A valid same-repository proposal opens at most one App-owned docs follow-up
+  branch/PR per proposal identity; retries reuse it.
+- No code path writes the contributor branch or invokes PR merge.
+- The original GitHub PR/check is the only user-facing review surface. No admin
+  run/diff page is linked, documented, or required to act on a proposal.

--- a/github/README.md
+++ b/github/README.md
@@ -30,6 +30,23 @@ source bead and router scan succeed. Bugflow snapshots the issue and comments,
 then owns investigation, classification, implementation gates, PR review, CI,
 and final issue updates.
 
+## Pull-request documentation review
+
+The optional `Gas City / docs-impact` capability has a deployment-neutral
+[lifecycle contract](docs/docs-pr-review-lifecycle.md). Enable it only when
+the installation provides its webhook intake, City reviewer dispatch, validated
+candidate bridge, and independent reconciliation loop over shared durable run
+state. The pack does not prescribe a Compose profile, network overlay, or
+particular scheduler.
+
+The opt-in reviewer is `docs-impact-reviewer`. It reads the supplied immutable
+assignment and returns a documentation-impact decision only; it has no
+authority to change GitHub. The trusted integration validates that decision,
+derives any documentation proposal from its assigned checkout, and publishes
+the GitHub-native result. A valid same-repository proposal may become one
+App-owned follow-up pull request; every other result remains an
+action-required or successful check on the original pull request.
+
 If a dispatched workflow gets wedged and you need to retry the same issue
 before cancel/retry automation exists, release the intake lock manually:
 

--- a/github/agents/docs-impact-reviewer/agent.toml
+++ b/github/agents/docs-impact-reviewer/agent.toml
@@ -1,0 +1,3 @@
+description = "GitHub pull-request documentation impact reviewer"
+scope = "rig"
+fallback = false

--- a/github/agents/docs-impact-reviewer/prompt.template.md
+++ b/github/agents/docs-impact-reviewer/prompt.template.md
@@ -1,0 +1,43 @@
+# GitHub Pull-Request Documentation Impact Reviewer
+
+Read and apply this pack's vendored
+`skills/developer-experience-techdocs/SKILL.md` guidance. Review only the
+immutable `github-pr-docs-impact-assignment` supplied with this task. Treat its
+identity and `evidence_bundle` as the complete review record; do not fetch
+additional repository state.
+
+You have no credentials and no authority to write a branch, open or update a
+pull request, publish a check, invoke commands, or create a patch. Evaluate
+whether the supplied change needs documentation and return exactly one JSON
+object, with no Markdown fence or explanatory text:
+
+```json
+{
+  "schema_version": 1,
+  "kind": "github-pr-docs-impact-review",
+  "identity": {
+    "repository_id": "copy from assignment.identity",
+    "repository": "copy from assignment.identity",
+    "pr_number": 1,
+    "head_sha": "copy from assignment.identity",
+    "source_key": "copy from assignment.identity"
+  },
+  "agent_skill": "developer-experience-techdocs",
+  "verdict": "no-impact | docs-sufficient | docs-change-required | proposal-ready | inconclusive",
+  "rationale": "concise, evidence-based explanation",
+  "evidence": [
+    {
+      "path": "a path from evidence_bundle.files",
+      "evidence": "the matching SHA-pinned reference from evidence_bundle.files"
+    }
+  ],
+  "confidence": 0.0,
+  "proposal": null
+}
+```
+
+Copy the assignment identity exactly. Include one or more relevant,
+SHA-pinned evidence records from its evidence bundle. Use `proposal-ready`
+only when a bounded documentation follow-up is justified; the trusted builder
+derives any proposal from its assigned checkout. When the supplied evidence is
+insufficient, return `inconclusive` rather than making assumptions.

--- a/github/docs/docs-pr-review-lifecycle.md
+++ b/github/docs/docs-pr-review-lifecycle.md
@@ -1,0 +1,137 @@
+# GitHub Docs PR Review Lifecycle Contract
+
+This contract defines when a GitHub Intake installation may advertise the
+`Gas City / docs-impact` capability. It is deliberately independent of a
+container scheduler, network topology, worker implementation, or City
+deployment. A deployment that cannot satisfy every requirement below must
+leave the capability disabled.
+
+## Enablement
+
+Enable docs PR review only after one installation has all four components
+sharing durable run storage:
+
+1. **Webhook intake** accepts opted-in `pull_request` deliveries, authenticates
+   them, and creates or adopts a run before returning. It creates exactly one
+   in-progress GitHub Check Run for that run.
+2. **Reviewer dispatcher** gives a City reviewer the immutable assignment. It
+   may use any queue or City entrypoint, but must preserve the assignment
+   identity and lease recorded on the run.
+3. **Candidate bridge** accepts only a candidate validated against that exact
+   immutable assignment. The reviewer and bridge need no GitHub credentials.
+4. **Reconciler** runs independently of webhook delivery and reviewer process
+   lifetime. It scans every non-terminal run, re-dispatches expired leases,
+   and completes eligible Check Runs.
+
+The installation owns scheduling, process supervision, storage, and reviewer
+selection. Those are deployment choices, not pack configuration. The webhook,
+dispatcher, bridge, and reconciler may be one process or several, but they
+must remain independently recoverable; a successful webhook response alone is
+not enablement.
+
+## Opt-in reviewer and scheduling
+
+The pack ships the credential-free `docs-impact-reviewer` agent. A dispatcher
+may select it only for an immutable `github-pr-docs-impact-assignment`; its
+sole result is a validator-compatible documentation-impact decision. It cannot
+publish GitHub results or create a proposal. The trusted candidate bridge and
+projection boundary retain those responsibilities.
+
+Use the runtime command as one-shot work under the installation's own event
+and scheduling mechanism. For each accepted pull-request assignment, invoke:
+
+```bash
+python3 github/scripts/github_intake_docs_review_commands.py intake --once \
+  --assignment-file <assignment.json> --projection action-file \
+  --actions-file <actions.json>
+```
+
+Schedule an independent recurring invocation for recovery:
+
+```bash
+python3 github/scripts/github_intake_docs_review_commands.py reconcile --once \
+  --projection action-file --actions-file <actions.json>
+```
+
+After the reviewer result has passed the candidate bridge, invoke:
+
+```bash
+python3 github/scripts/github_intake_docs_review_commands.py \
+  candidate --once --candidate-file <candidate.json> --projection action-file \
+  --actions-file <actions.json>
+```
+
+With `action-file` projection, the command records action intents; the
+installation chooses how to consume them and how to provide the trusted
+projection adapter.
+
+## Immutable run identity
+
+Each run is keyed by the repository ID, pull-request number, and head SHA.
+The key is never reused for a later revision. Persist at least the key, Check
+Run ID or external ID, creation time, deadline, dispatch attempt, lease expiry,
+and terminal conclusion.
+
+Duplicate webhook deliveries load that same record. They do not create another
+Check Run or another independent review. A head change makes the old record
+stale: before publishing a non-stale result, the reconciler confirms that the
+current PR head still equals the stored SHA. A stale record completes only as
+stale by updating its already-created Check Run on the old SHA; it never
+publishes a candidate for the new revision.
+
+## Dispatch and recovery
+
+Intake records the run and its visible in-progress Check Run before dispatch.
+Dispatch is at-least-once: a lease prevents unnecessary parallel work, but a
+reconciler re-dispatches the same immutable assignment when that lease expires.
+It does not create a new Check Run, source identity, or revision record.
+
+Candidate delivery is also at-least-once. The bridge persists the first valid
+candidate bound to the run identity. The reconciler validates it again before
+terminal publication. A candidate with another identity is ignored. A valid
+candidate produces one terminal conclusion: `success` for `no-impact` and
+`docs-sufficient`; `action_required` for every other accepted verdict.
+
+At the deadline, a non-terminal run completes `action_required` with an
+operational reason. A candidate that arrives after that terminal transition is
+recorded only if useful for audit, and cannot reopen or overwrite the Check
+Run. This turns restart, duplicate delivery, and late work into convergence
+rather than a permanently in-progress check.
+
+## Adapter obligations
+
+Adapters execute the actions emitted by
+[`github_docs_pr_review_lifecycle.py`](../scripts/github_docs_pr_review_lifecycle.py):
+
+- `ensure_check` creates or adopts the Check Run by a durable external ID.
+- `dispatch` sends the already-persisted immutable assignment.
+- `ensure_terminal_check` completes or adopts a non-stale terminal Check Run,
+  after the current-head check.
+- `ensure_stale_check` completes or adopts the already-created stale Check Run
+  on its stored SHA. It must not require the current-head check.
+
+Persist the transitioned run before performing an external action, and make
+each action idempotent. The `ensure_*` actions are deliberately emitted again
+for persisted runs: after a crash between persistence and an external write, a
+later reconciliation adopts the existing GitHub Check Run by external ID or
+performs the missing write. The pack does not prescribe a database, queue,
+scheduler, or retry interval.
+
+The credentials that create and update Check Runs are confined to the trusted
+intake/reconciler boundary. This lifecycle contract governs only Check Run and
+dispatch state. A separate authority-gated projection capability may create a
+bot-owned follow-up branch and pull request; lifecycle itself does not
+authorize GitHub issue, comment, pull-request, branch, or deployment mutations.
+
+## Verification
+
+Run the lifecycle model tests with:
+
+```bash
+python3 -m unittest github.tests.test_docs_pr_review_lifecycle -v
+```
+
+They prove the pack-level transitions for duplicate delivery, lease recovery,
+late candidates, and once-only terminal completion. A deployment enabling the
+feature must additionally exercise its concrete adapters against a test GitHub
+Check Run and durable-store restart.

--- a/github/pack.toml
+++ b/github/pack.toml
@@ -3,6 +3,10 @@ name = "github"
 version = "0.1.0"
 schema = 2
 
+# The docs-impact reviewer is packaged as agents/docs-impact-reviewer. It is
+# deliberately opt-in: this pack declares no always-running reviewer service
+# or scheduling policy.
+
 [[service]]
 name = "github-webhook"
 kind = "proxy_process"

--- a/github/scripts/github_docs_pr_review_lifecycle.py
+++ b/github/scripts/github_docs_pr_review_lifecycle.py
@@ -1,0 +1,129 @@
+"""Deployment-neutral state transitions for GitHub docs PR review.
+
+Deployments persist :class:`DocsReviewRun` and perform the returned actions.
+This module deliberately has no GitHub, process, queue, or scheduler client.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+SUCCESS_VERDICTS = frozenset({"no-impact", "docs-sufficient"})
+
+
+@dataclass(frozen=True)
+class Candidate:
+    """A validated candidate bound to the immutable review identity."""
+
+    identity: str
+    verdict: str
+
+
+@dataclass(frozen=True)
+class DocsReviewRun:
+    """Persisted state for exactly one repository, PR, and head revision."""
+
+    identity: str
+    state: str
+    created_at: float
+    deadline_at: float
+    lease_until: float
+    attempt: int
+    conclusion: str | None = None
+
+
+@dataclass(frozen=True)
+class Transition:
+    """The new durable state and idempotent adapter actions to perform."""
+
+    run: DocsReviewRun
+    actions: tuple[str, ...]
+
+
+def begin(
+    identity: str,
+    *,
+    now: float,
+    existing: DocsReviewRun | None = None,
+    lease_seconds: float = 300,
+    deadline_seconds: float = 1800,
+) -> Transition:
+    """Create one visible run and dispatch it once; duplicate delivery converges."""
+    if existing is not None:
+        if existing.identity != identity:
+            raise ValueError("existing run identity differs from delivery identity")
+        action = "ensure_stale_check" if existing.state == "stale" else "ensure_terminal_check" if existing.state == "terminal" else "ensure_check"
+        return Transition(existing, (action,))
+    if not identity:
+        raise ValueError("review identity is required")
+    if lease_seconds <= 0 or deadline_seconds <= 0:
+        raise ValueError("lease and deadline must be positive")
+    return Transition(
+        DocsReviewRun(
+            identity=identity,
+            state="dispatched",
+            created_at=now,
+            deadline_at=now + deadline_seconds,
+            lease_until=now + lease_seconds,
+            attempt=1,
+        ),
+        ("ensure_check", "dispatch"),
+    )
+
+
+def reconcile(
+    run: DocsReviewRun,
+    *,
+    now: float,
+    head_is_current: bool,
+    candidate: Candidate | None = None,
+    lease_seconds: float = 300,
+) -> Transition:
+    """Advance a run at most once, safely after duplicate work or restart."""
+    if run.state == "stale":
+        return Transition(run, ("ensure_stale_check",))
+    if run.state == "terminal":
+        return Transition(run, ("ensure_terminal_check",))
+    if not head_is_current:
+        return Transition(
+            _terminal(run, "stale"),
+            ("ensure_stale_check",),
+        )
+    if now >= run.deadline_at:
+        return Transition(
+            _terminal(run, "action_required"),
+            ("ensure_terminal_check",),
+        )
+    if candidate is not None and candidate.identity == run.identity:
+        conclusion = "success" if candidate.verdict in SUCCESS_VERDICTS else "action_required"
+        return Transition(_terminal(run, conclusion), ("ensure_terminal_check",))
+    if now >= run.lease_until:
+        if lease_seconds <= 0:
+            raise ValueError("lease must be positive")
+        return Transition(
+            DocsReviewRun(
+                identity=run.identity,
+                state="dispatched",
+                created_at=run.created_at,
+                deadline_at=run.deadline_at,
+                lease_until=now + lease_seconds,
+                attempt=run.attempt + 1,
+            ),
+            ("dispatch",),
+        )
+    # A persisted in-progress run may have crashed before its Check Run write.
+    # Re-emitting this idempotent action lets an adapter adopt or create it.
+    return Transition(run, ("ensure_check",))
+
+
+def _terminal(run: DocsReviewRun, conclusion: str) -> DocsReviewRun:
+    return DocsReviewRun(
+        identity=run.identity,
+        state="stale" if conclusion == "stale" else "terminal",
+        created_at=run.created_at,
+        deadline_at=run.deadline_at,
+        lease_until=run.lease_until,
+        attempt=run.attempt,
+        conclusion=conclusion,
+    )

--- a/github/scripts/github_intake_common.py
+++ b/github/scripts/github_intake_common.py
@@ -84,6 +84,11 @@ def address_results_dir() -> str:
     return os.path.join(data_dir(), "address-results")
 
 
+def docs_review_runs_dir() -> str:
+    """Shared durable state location for the optional docs-impact runtime."""
+    return os.path.join(data_dir(), "docs-review-runs")
+
+
 def config_path() -> str:
     return os.path.join(data_dir(), "config.json")
 
@@ -1123,6 +1128,87 @@ def github_api_request(
     raise GitHubAPIError(f"{method.upper()} {url} returned non-object JSON")
 
 
+def github_api_list_request(
+    method: str,
+    path: str,
+    *,
+    bearer_token: str | None = None,
+) -> list[dict[str, Any]]:
+    """Read a GitHub list endpoint without weakening object-only API callers."""
+    if path.startswith("http://") or path.startswith("https://"):
+        url = path
+    else:
+        url = urllib.parse.urljoin(GITHUB_API_BASE.rstrip("/") + "/", path.lstrip("/"))
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "gas-city-github/0.1",
+        "X-GitHub-Api-Version": GITHUB_API_VERSION,
+    }
+    if bearer_token:
+        headers["Authorization"] = f"Bearer {bearer_token}"
+    request = urllib.request.Request(url, headers=headers, method=method.upper())
+    try:
+        with urllib.request.urlopen(request, timeout=20) as response:
+            data = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        raise GitHubAPIError(f"{method.upper()} {url} failed with {exc.code}: {exc.read().decode('utf-8', errors='replace')}") from exc
+    except urllib.error.URLError as exc:
+        raise GitHubAPIError(f"{method.upper()} {url} failed: {exc}") from exc
+    if not isinstance(data, list) or not all(isinstance(item, dict) for item in data):
+        raise GitHubAPIError(f"{method.upper()} {url} returned non-list JSON")
+    return data
+
+
+def github_api_paginated_list_request(
+    method: str,
+    path: str,
+    *,
+    bearer_token: str | None = None,
+    per_page: int = 100,
+) -> list[dict[str, Any]]:
+    """Read every page of a bounded GitHub list endpoint before deciding."""
+    if per_page <= 0 or per_page > 100:
+        raise ValueError("per_page must be between 1 and 100")
+    result: list[dict[str, Any]] = []
+    page = 1
+    while True:
+        separator = "&" if "?" in path else "?"
+        values = github_api_list_request(
+            method, f"{path}{separator}per_page={per_page}&page={page}", bearer_token=bearer_token,
+        )
+        result.extend(values)
+        if len(values) < per_page:
+            return result
+        page += 1
+
+
+def github_api_paginated_object_list_request(
+    method: str,
+    path: str,
+    field: str,
+    *,
+    bearer_token: str | None = None,
+    per_page: int = 100,
+) -> list[dict[str, Any]]:
+    """Read every page of an object-wrapped GitHub list (for Check Runs)."""
+    if per_page <= 0 or per_page > 100:
+        raise ValueError("per_page must be between 1 and 100")
+    result: list[dict[str, Any]] = []
+    page = 1
+    while True:
+        separator = "&" if "?" in path else "?"
+        response = github_api_request(
+            method, f"{path}{separator}per_page={per_page}&page={page}", bearer_token=bearer_token,
+        )
+        values = response.get(field)
+        if not isinstance(values, list) or not all(isinstance(value, dict) for value in values):
+            raise GitHubAPIError(f"{method.upper()} {path} returned invalid {field}")
+        result.extend(values)
+        if len(values) < per_page:
+            return result
+        page += 1
+
+
 def exchange_manifest_code(code: str) -> dict[str, Any]:
     return github_api_request("POST", f"/app-manifests/{urllib.parse.quote(code)}/conversions")
 
@@ -1246,6 +1332,36 @@ def create_pull_request(
     )
 
 
+def get_pull_request(app_cfg: dict[str, Any], installation_id: str, owner: str, repo: str, number: int) -> dict[str, Any]:
+    """Read the current PR facts using an installation token."""
+    token = create_installation_token(app_cfg, installation_id)
+    return github_api_request("GET", f"/repos/{urllib.parse.quote(owner)}/{urllib.parse.quote(repo)}/pulls/{number}", bearer_token=token)
+
+
+def create_check_run(app_cfg: dict[str, Any], installation_id: str, owner: str, repo: str, head_sha: str, external_id: str, status: str, conclusion: str | None, output: dict[str, str]) -> dict[str, Any]:
+    token = create_installation_token(app_cfg, installation_id)
+    payload: dict[str, Any] = {"name": "Gas City / docs-impact", "head_sha": head_sha, "external_id": external_id, "status": status, "output": output}
+    if conclusion is not None:
+        payload["conclusion"] = conclusion
+    return github_api_request("POST", f"/repos/{urllib.parse.quote(owner)}/{urllib.parse.quote(repo)}/check-runs", payload=payload, bearer_token=token)
+
+
+def update_check_run(app_cfg: dict[str, Any], installation_id: str, owner: str, repo: str, check_id: str, conclusion: str, output: dict[str, str]) -> dict[str, Any]:
+    token = create_installation_token(app_cfg, installation_id)
+    return github_api_request("PATCH", f"/repos/{urllib.parse.quote(owner)}/{urllib.parse.quote(repo)}/check-runs/{urllib.parse.quote(check_id)}", payload={"status": "completed", "conclusion": conclusion, "output": output}, bearer_token=token)
+
+
+def find_check_run(app_cfg: dict[str, Any], installation_id: str, owner: str, repo: str, head_sha: str, external_id: str) -> dict[str, Any] | None:
+    token = create_installation_token(app_cfg, installation_id)
+    checks = github_api_paginated_object_list_request(
+        "GET", f"/repos/{urllib.parse.quote(owner)}/{urllib.parse.quote(repo)}/commits/{urllib.parse.quote(head_sha)}/check-runs", "check_runs", bearer_token=token,
+    )
+    for check in checks:
+        if isinstance(check, dict) and str(check.get("external_id", "")) == external_id:
+            return check
+    return None
+
+
 def repository_git_url(repository_full_name: str) -> str:
     return f"{github_web_base().rstrip('/')}/{repository_full_name}.git"
 
@@ -1256,6 +1372,7 @@ def git_push_branch(
     repository_full_name: str,
     branch: str,
     ref: str = "HEAD",
+    cwd: str | None = None,
 ) -> dict[str, Any]:
     token = create_installation_token(app_cfg, installation_id)
     basic_auth = base64.b64encode(f"x-access-token:{token}".encode("utf-8")).decode("ascii")
@@ -1271,6 +1388,7 @@ def git_push_branch(
         text=True,
         check=False,
         env=env,
+        cwd=cwd,
     )
     if result.returncode != 0:
         stderr = result.stderr.strip()

--- a/github/scripts/github_intake_docs_candidate_builder.py
+++ b/github/scripts/github_intake_docs_candidate_builder.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Build a canonical docs proposal from a Git worktree, never an agent diff."""
+
+from __future__ import annotations
+
+import hashlib
+import pathlib
+import subprocess
+from typing import Any
+
+import github_intake_docs_patch as docs_patch
+import github_intake_docs_patch_worker as worker
+
+
+def _git(repository: pathlib.Path, *args: str) -> bytes:
+    result = subprocess.run(
+        ["git", "-C", str(repository), *args], capture_output=True, check=False
+    )
+    if result.returncode:
+        raise ValueError(result.stderr.decode("utf-8", "replace").strip() or "git could not derive the proposal")
+    return result.stdout
+
+
+def _changed_paths(diff: str) -> list[str]:
+    paths: set[str] = set()
+    for old_path, new_path in docs_patch.DIFF_PATH_PATTERN.findall(diff):
+        if old_path != "/dev/null":
+            paths.add(docs_patch._validate_path(old_path))
+        if new_path != "/dev/null":
+            paths.add(docs_patch._validate_path(new_path))
+    if not paths:
+        raise ValueError("git produced no unified documentation paths")
+    return sorted(paths)
+
+
+def _file_digest(repository: pathlib.Path, path: str) -> str:
+    candidate = repository / path
+    if candidate.is_file():
+        content = candidate.read_bytes()
+    else:
+        content = _git(repository, "show", f"HEAD:{path}")
+    return hashlib.sha256(content).hexdigest()
+
+
+def build_candidate(
+    raw_assignment: bytes,
+    repository: pathlib.Path,
+    *,
+    generated_at: str,
+    claims: list[dict[str, str]],
+    checks: list[dict[str, str]],
+    review: dict[str, Any],
+) -> dict[str, Any]:
+    """Derive the only accepted patch from Git and bind it to raw assignment bytes."""
+    assignment = worker.load_assignment_bytes(raw_assignment)
+    repository = pathlib.Path(repository)
+    actual_head = _git(repository, "rev-parse", "HEAD").decode("ascii").strip()
+    if actual_head != assignment["evidence_bundle"]["proposal_identity"]["head_sha"]:
+        raise ValueError("checkout HEAD does not match assigned proposal head SHA")
+    diff_bytes = _git(repository, "diff", "--no-ext-diff", "--full-index", "--binary", "HEAD", "--")
+    try:
+        diff = diff_bytes.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ValueError("git produced a non-text documentation diff") from exc
+    paths = _changed_paths(diff)
+    identity = assignment["evidence_bundle"]["proposal_identity"]
+    artifact = docs_patch.validate_artifact({
+        "schema_version": docs_patch.SCHEMA_VERSION,
+        "status": "proposed",
+        "generated_at": generated_at,
+        "identity": identity,
+        "patch_sha256": hashlib.sha256(diff_bytes).hexdigest(),
+        "diff": diff,
+        "files": [{"path": path, "sha256": _file_digest(repository, path)} for path in paths],
+        "claims": claims,
+        "checks": checks,
+    })
+    envelope = {
+        "schema_version": docs_patch.SCHEMA_VERSION,
+        "snapshot_sha256": hashlib.sha256(raw_assignment).hexdigest(),
+        "artifact": artifact,
+    }
+    review = docs_patch.validate_review_decision(review)
+    if review["identity"] != assignment["identity"] or review["agent_skill"] != assignment["agent_skill"]:
+        raise ValueError("review is not a proposal-free assignment-bound proposal-ready result")
+    final_review = dict(review)
+    final_review.pop("review_sha256", None)
+    final_review["proposal"] = artifact
+    return worker.validate_final_candidate(raw_assignment, {"schema_version": docs_patch.SCHEMA_VERSION, "snapshot_sha256": envelope["snapshot_sha256"], "artifact": docs_patch.validate_agent_review(final_review)})

--- a/github/scripts/github_intake_docs_impact.py
+++ b/github/scripts/github_intake_docs_impact.py
@@ -1,0 +1,402 @@
+"""Safe GitHub-native projection for a validated docs-impact review.
+
+This module deliberately owns no reviewer work.  It turns the first accepted,
+revision-bound candidate into a compact Check Run and (only where GitHub still
+proves the source branch belongs to the base repository) an App-owned stacked
+documentation follow-up.
+"""
+
+from __future__ import annotations
+
+import copy
+import base64
+import os
+import pathlib
+import subprocess
+import tempfile
+from typing import Any, Callable, Protocol
+
+import github_intake_common as common
+import github_intake_docs_patch as docs_patch
+
+
+def _text(value: Any) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _pull_identity(pull_request: dict[str, Any]) -> dict[str, Any] | None:
+    """Extract exactly the mutable GitHub facts that authorize a follow-up."""
+    try:
+        head, base = pull_request["head"], pull_request["base"]
+        head_repo, base_repo = head["repo"], base["repo"]
+        number = pull_request["number"]
+        if type(number) is not int or number <= 0:
+            return None
+        result = {
+            "repository_id": str(base_repo["id"]),
+            "repository": _text(base_repo["full_name"]),
+            "pr_number": number,
+            "base_sha": _text(base["sha"]).lower(),
+            "head_sha": _text(head["sha"]).lower(),
+            "head_repository_id": str(head_repo["id"]),
+            "head_repository": _text(head_repo["full_name"]),
+            "base_ref": _text(base["ref"]),
+            "head_ref": _text(head["ref"]),
+        }
+    except (KeyError, TypeError):
+        return None
+    return result if all(result.values()) else None
+
+
+def followup_pr_plan(pull_request: dict[str, Any], review: dict[str, Any]) -> dict[str, str] | None:
+    """Return the only branch/PR mutation an accepted review can authorize."""
+    try:
+        validated = docs_patch.validate_agent_review(review)
+    except (TypeError, ValueError):
+        return None
+    current = _pull_identity(pull_request) if isinstance(pull_request, dict) else None
+    proposal = validated.get("proposal")
+    if current is None or validated["verdict"] != "proposal-ready" or not isinstance(proposal, dict):
+        return None
+    proposal_identity = proposal["identity"]
+    if any(proposal_identity[key] != current[key] for key in proposal_identity):
+        return None
+    if current["head_repository_id"] != current["repository_id"] or current["head_repository"] != current["repository"]:
+        return None
+    digest = _text(proposal.get("patch_sha256"))
+    if len(digest) != 64:
+        return None
+    return {
+        "repository": current["repository"],
+        "branch": f"gas-city/docs-{current['pr_number']}-{digest[:12]}",
+        "base": current["head_ref"],
+        "head_sha": current["head_sha"],
+    }
+
+
+def compact_check_output(review: dict[str, Any], followup: dict[str, Any] | None = None) -> dict[str, str]:
+    """Render the original PR's entire user-facing result without a diff/UI."""
+    verdict = _text(review.get("verdict")) if isinstance(review, dict) else ""
+    if verdict == "proposal-ready":
+        url = _text((followup or {}).get("url"))
+        number = _text((followup or {}).get("number"))
+        if url.startswith("https://") and number.isdigit():
+            return {
+                "title": "Documentation impact: follow-up ready",
+                "summary": f"A documentation follow-up is ready: [PR #{number}]({url}). Review that PR, then merge it into this PR branch.",
+            }
+        return {
+            "title": "Documentation impact: action required",
+            "summary": "A documentation proposal was validated, but a safe App-owned follow-up PR could not be confirmed. Create or update the documentation on this pull request branch.",
+        }
+    if verdict in {"no-impact", "docs-sufficient"}:
+        return {"title": "Documentation impact: complete", "summary": "Documentation review completed; no follow-up is required."}
+    return {"title": "Documentation impact: action required", "summary": "Documentation review needs author action on this pull request."}
+
+
+class ProjectionGateway(Protocol):
+    """The sole seam for GitHub/App effects; implementations must never merge."""
+
+    def pull_request(self, run: dict[str, Any]) -> dict[str, Any]: ...
+    def find_followup(self, repository: str, branch: str, marker: str) -> dict[str, str] | None: ...
+    def branch_exists(self, repository: str, branch: str) -> bool: ...
+    def branch_matches(self, repository: str, branch: str, marker: str, commit_sha: str = "") -> bool: ...
+    def create_branch(self, repository: str, branch: str, head_sha: str, review: dict[str, Any], marker: str, before_push: Callable[[str], None]) -> str: ...
+    def create_followup(self, repository: str, branch: str, base: str, marker: str, review: dict[str, Any]) -> dict[str, str]: ...
+    def close_followup(self, repository: str, number: str, branch: str, marker: str) -> None: ...
+    def ensure_check(self, run: dict[str, Any], conclusion: str, output: dict[str, str]) -> None: ...
+
+
+class AppProjection:
+    """Runtime adapter that makes one durable, App-owned follow-up per proposal.
+
+    The follow-up record is written before every remote mutation.  A retry
+    therefore adopts a branch or PR by its stable proposal marker instead of
+    issuing another author-branch write or another pull request.
+    """
+
+    def __init__(self, store: Any, gateway: ProjectionGateway) -> None:
+        self.store = store
+        self.gateway = gateway
+
+    def head_is_current(self, run: dict[str, Any]) -> bool:
+        try:
+            current = _pull_identity(self.gateway.pull_request(copy.deepcopy(run)))
+            expected = run["assignment"]["identity"]["head_sha"]
+            return current is not None and current["head_sha"] == expected
+        except (KeyError, TypeError, ValueError):
+            return False
+
+    def perform(self, action: str, run: dict[str, Any]) -> None:
+        if action == "dispatch":
+            return
+        review = ((run.get("candidate") or {}).get("artifact"))
+        if action == "ensure_check":
+            self.gateway.ensure_check(run, "in_progress", {
+                "title": "Documentation impact: reviewing",
+                "summary": "Documentation review is in progress for this pull request revision.",
+            })
+            return
+        if action == "ensure_stale_check":
+            self.gateway.ensure_check(run, "action_required", {
+                "title": "Documentation impact: stale revision",
+                "summary": "This review was invalidated because the pull request revision is no longer current.",
+            })
+            return
+        if action != "ensure_terminal_check":
+            raise ValueError(f"unknown docs impact projection action: {action}")
+        followup = None
+        conclusion = str(run.get("conclusion") or "action_required")
+        if isinstance(review, dict) and review.get("verdict") == "proposal-ready":
+            try:
+                followup = self._reconcile_followup(run, review)
+            except Exception:  # noqa: BLE001 - projection failures must complete the visible Check
+                # Intent is already durable before every branch/PR mutation.
+                # Never leave the visible Check in progress when a retryable
+                # projection operation fails or discovers a stale head.
+                conclusion = "action_required"
+                prior = run.get("followup") if isinstance(run.get("followup"), dict) else {}
+                self._save_intent(run, {**prior, "state": "action-required"})
+        if not self.head_is_current(run):
+            self._mark_stale(run)
+            self.gateway.ensure_check(run, "action_required", {
+                "title": "Documentation impact: stale revision",
+                "summary": "This review was invalidated because the pull request revision is no longer current.",
+            })
+            return
+        self.gateway.ensure_check(run, conclusion, compact_check_output(review if isinstance(review, dict) else {}, followup))
+        # The terminal Check itself is a mutation boundary. If the source head
+        # moved after it, compensate by closing only our marker-verified
+        # stacked PR and overwrite the Check with stale/action-required.
+        if not self.head_is_current(run):
+            self._mark_stale(run)
+            self.gateway.ensure_check(run, "action_required", {
+                "title": "Documentation impact: stale revision",
+                "summary": "This review was invalidated because the pull request revision is no longer current.",
+            })
+
+    def _save_intent(self, run: dict[str, Any], value: dict[str, Any]) -> None:
+        run["followup"] = value
+        self.store.save(run)
+
+    def _mark_stale(self, run: dict[str, Any]) -> None:
+        """Compensate a source-head race without touching contributor resources."""
+        followup = run.get("followup") if isinstance(run.get("followup"), dict) else {}
+        number, marker, repository, branch = _text(followup.get("number")), _text(followup.get("marker")), _text(followup.get("repository")), _text(followup.get("branch"))
+        if number and marker and repository and branch and followup.get("state") != "closed":
+            try:
+                self.gateway.close_followup(repository, number, branch, marker)
+                followup = {**followup, "state": "closed"}
+            except Exception:  # noqa: BLE001 - stale Check must still win if compensation is unavailable
+                followup = {**followup, "state": "close-pending"}
+        run["state"] = "stale"
+        run["conclusion"] = "action_required"
+        if followup:
+            run["followup"] = followup
+        self.store.save(run)
+
+    def _reconcile_followup(self, run: dict[str, Any], review: dict[str, Any]) -> dict[str, str] | None:
+        current = self.gateway.pull_request(copy.deepcopy(run))
+        plan = followup_pr_plan(current, review)
+        if plan is None:
+            return None
+        # The candidate was validated at intake; validating again here gives
+        # the marker its canonical artifact digest even if a caller supplied
+        # the digest-free wire representation.
+        proposal = docs_patch.validate_agent_review(review)["proposal"]
+        if proposal is None:
+            return None
+        marker = f"gas-city-docs-followup:{proposal['artifact_sha256']}"
+        existing = self.gateway.find_followup(plan["repository"], plan["branch"], marker)
+        if existing is not None:
+            result = {"state": "created", **plan, "marker": marker, **existing}
+            self._save_intent(run, result)
+            return existing
+        prior = run.get("followup") if isinstance(run.get("followup"), dict) else {}
+        if self.gateway.branch_exists(plan["repository"], plan["branch"]):
+            expected_commit = _text(prior.get("commit_sha"))
+            if not expected_commit or not self.gateway.branch_matches(plan["repository"], plan["branch"], marker, expected_commit):
+                return None
+        else:
+            self._save_intent(run, {"state": "branch-intent", **plan, "marker": marker})
+            def persist_commit(commit_sha: str) -> None:
+                if len(commit_sha) != 40:
+                    raise ValueError("prepared App branch commit is invalid")
+                self._save_intent(run, {"state": "branch-intent", **plan, "marker": marker, "commit_sha": commit_sha})
+            commit_sha = self.gateway.create_branch(plan["repository"], plan["branch"], plan["head_sha"], review, marker, persist_commit)
+            self._save_intent(run, {"state": "branch-created", **plan, "marker": marker, "commit_sha": commit_sha})
+        persisted_followup = run.get("followup") if isinstance(run.get("followup"), dict) else {}
+        if not self.gateway.branch_matches(plan["repository"], plan["branch"], marker, _text(persisted_followup.get("commit_sha"))):
+            return None
+        # The branch push and PR creation are separate mutation boundaries.
+        # A changed contributor revision leaves the App-owned branch inert and
+        # projects action-required instead of stacking onto the wrong ref.
+        if followup_pr_plan(self.gateway.pull_request(copy.deepcopy(run)), review) is None:
+            self._save_intent(run, {"state": "branch-created", **plan, "marker": marker, "commit_sha": _text(persisted_followup.get("commit_sha"))})
+            return None
+        self._save_intent(run, {"state": "pr-intent", **plan, "marker": marker, "commit_sha": _text(persisted_followup.get("commit_sha")), **({"recovered": True} if prior else {})})
+        created = self.gateway.create_followup(plan["repository"], plan["branch"], plan["base"], marker, review)
+        if not (_text(created.get("url")).startswith("https://") and _text(created.get("number")).isdigit()):
+            raise ValueError("App-created follow-up pull request lacks URL or number")
+        self._save_intent(run, {"state": "created", **plan, "marker": marker, **created})
+        if not self.head_is_current(run):
+            self._mark_stale(run)
+            return None
+        return created
+
+
+class GitHubAppProjectionGateway:
+    """Concrete App-only gateway; all mutations target a ``gas-city/docs-`` ref."""
+
+    def __init__(self, app_config: dict[str, Any], installation_id: str) -> None:
+        self.app_config = app_config
+        self.installation_id = installation_id
+
+    def _owner_repo(self, repository: str) -> tuple[str, str]:
+        owner, repo = repository.split("/", 1)
+        if not owner or not repo:
+            raise ValueError("repository must be owner/name")
+        return owner, repo
+
+    def pull_request(self, run: dict[str, Any]) -> dict[str, Any]:
+        identity = run["assignment"]["identity"]
+        owner, repo = self._owner_repo(identity["repository"])
+        return common.get_pull_request(self.app_config, self.installation_id, owner, repo, int(identity["pr_number"]))
+
+    def _owns_followup(self, pull: dict[str, Any], repository: str, branch: str, marker: str) -> bool:
+        """Require GitHub's App identity, not forgeable marker/ref text alone."""
+        bot_login = common.app_bot_login(self.app_config)
+        if not bot_login:
+            return False
+        head = pull.get("head") if isinstance(pull.get("head"), dict) else {}
+        base = pull.get("base") if isinstance(pull.get("base"), dict) else {}
+        head_repo = head.get("repo") if isinstance(head.get("repo"), dict) else {}
+        base_repo = base.get("repo") if isinstance(base.get("repo"), dict) else {}
+        head_user = head.get("user") if isinstance(head.get("user"), dict) else {}
+        return (
+            _text(pull.get("body")).splitlines().count(f"<!-- {marker} -->") == 1
+            and _text(head.get("ref")) == branch
+            and _text(head_repo.get("full_name")) == repository
+            and _text(base_repo.get("full_name")) == repository
+            and _text(head_user.get("login")) == bot_login
+        )
+
+    def find_followup(self, repository: str, branch: str, marker: str) -> dict[str, str] | None:
+        owner, repo = self._owner_repo(repository)
+        token = common.create_installation_token(self.app_config, self.installation_id)
+        response = common.github_api_paginated_list_request("GET", f"/repos/{owner}/{repo}/pulls?state=all&head={owner}:{branch}", bearer_token=token)
+        for item in response:
+            if isinstance(item, dict) and self._owns_followup(item, repository, branch, marker):
+                return {"number": str(item.get("number", "")), "url": str(item.get("html_url", ""))}
+        return None
+
+    def branch_exists(self, repository: str, branch: str) -> bool:
+        owner, repo = self._owner_repo(repository)
+        token = common.create_installation_token(self.app_config, self.installation_id)
+        try:
+            common.github_api_request("GET", f"/repos/{owner}/{repo}/git/ref/heads/{branch}", bearer_token=token)
+        except common.GitHubAPIError as exc:
+            if " 404:" in str(exc):
+                return False
+            raise
+        return True
+
+    def branch_matches(self, repository: str, branch: str, marker: str, commit_sha: str = "") -> bool:
+        owner, repo = self._owner_repo(repository)
+        token = common.create_installation_token(self.app_config, self.installation_id)
+        try:
+            ref = common.github_api_request("GET", f"/repos/{owner}/{repo}/git/ref/heads/{branch}", bearer_token=token)
+            sha = str(((ref.get("object") or {}).get("sha", "")))
+            if commit_sha and sha != commit_sha:
+                return False
+            commit = common.github_api_request("GET", f"/repos/{owner}/{repo}/git/commits/{sha}", bearer_token=token)
+        except common.GitHubAPIError:
+            return False
+        return marker in str(((commit.get("message") or "")))
+
+    @staticmethod
+    def _git(cwd: pathlib.Path, *args: str, env: dict[str, str] | None = None) -> None:
+        result = subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True, check=False, env=env)
+        if result.returncode:
+            raise common.GitHubAPIError(result.stderr.strip() or "git operation failed")
+
+    def create_branch(self, repository: str, branch: str, head_sha: str, review: dict[str, Any], marker: str, before_push: Callable[[str], None]) -> str:
+        if not branch.startswith("gas-city/docs-"):
+            raise ValueError("follow-up branch is not App-owned")
+        validated = docs_patch.validate_agent_review(review)
+        proposal = validated["proposal"]
+        if proposal is None:
+            raise ValueError("follow-up requires a validated proposal")
+        token = common.create_installation_token(self.app_config, self.installation_id)
+        basic_auth = base64.b64encode(f"x-access-token:{token}".encode("utf-8")).decode("ascii")
+        git_env = os.environ.copy()
+        git_env.update({"GIT_TERMINAL_PROMPT": "0", "GIT_CONFIG_COUNT": "1", "GIT_CONFIG_KEY_0": f"http.{common.github_web_base().rstrip('/')}/.extraheader", "GIT_CONFIG_VALUE_0": f"AUTHORIZATION: basic {basic_auth}"})
+        with tempfile.TemporaryDirectory(prefix="gas-city-docs-") as temporary:
+            checkout = pathlib.Path(temporary)
+            self._git(checkout, "init", "--quiet", env=git_env)
+            self._git(checkout, "remote", "add", "origin", common.repository_git_url(repository), env=git_env)
+            self._git(checkout, "fetch", "--depth", "1", "origin", head_sha, env=git_env)
+            self._git(checkout, "checkout", "--detach", "--quiet", "FETCH_HEAD", env=git_env)
+            patch = checkout / "proposal.patch"
+            patch.write_text(proposal["diff"], encoding="utf-8")
+            self._git(checkout, "apply", "--check", str(patch), env=git_env)
+            self._git(checkout, "apply", str(patch), env=git_env)
+            patch.unlink()
+            self._git(checkout, "checkout", "-b", branch, env=git_env)
+            self._git(checkout, "config", "user.name", "Gas City", env=git_env)
+            self._git(checkout, "config", "user.email", "gas-city[bot]@users.noreply.github.com", env=git_env)
+            self._git(checkout, "add", "--", *[item["path"] for item in proposal["files"]], env=git_env)
+            self._git(checkout, "commit", "--quiet", "-m", f"docs: address PR #{proposal['identity']['pr_number']} review", "-m", marker, env=git_env)
+            prepared = subprocess.run(["git", "rev-parse", "HEAD"], cwd=checkout, capture_output=True, text=True, check=True, env=git_env).stdout.strip()
+            before_push(prepared)
+            owner, repo = self._owner_repo(repository)
+            current = common.get_pull_request(self.app_config, self.installation_id, owner, repo, int(proposal["identity"]["pr_number"]))
+            if followup_pr_plan(current, validated) is None:
+                raise common.GitHubAPIError("pull request changed before App branch push")
+            common.git_push_branch(self.app_config, self.installation_id, repository, branch, cwd=str(checkout))
+            return prepared
+
+    def create_followup(self, repository: str, branch: str, base: str, marker: str, review: dict[str, Any]) -> dict[str, str]:
+        owner, repo = self._owner_repo(repository)
+        validated = docs_patch.validate_agent_review(review)
+        proposal = validated.get("proposal")
+        if proposal is None:
+            raise common.GitHubAPIError("follow-up requires a validated proposal")
+        current = common.get_pull_request(self.app_config, self.installation_id, owner, repo, int(proposal["identity"]["pr_number"]))
+        if followup_pr_plan(current, validated) is None:
+            raise common.GitHubAPIError("pull request changed before follow-up PR creation")
+        created = common.create_pull_request(self.app_config, self.installation_id, owner, repo, "docs: documentation follow-up", branch, base, f"Documentation follow-up generated from a validated proposal.\n\n<!-- {marker} -->")
+        return {"number": str(created.get("number", "")), "url": str(created.get("html_url", ""))}
+
+    def close_followup(self, repository: str, number: str, branch: str, marker: str) -> None:
+        owner, repo = self._owner_repo(repository)
+        token = common.create_installation_token(self.app_config, self.installation_id)
+        pull = common.github_api_request("GET", f"/repos/{owner}/{repo}/pulls/{number}", bearer_token=token)
+        head = pull.get("head") if isinstance(pull.get("head"), dict) else {}
+        if not self._owns_followup(pull, repository, branch, marker):
+            raise common.GitHubAPIError("refusing to close a follow-up not owned by this App marker")
+        common.github_api_request("PATCH", f"/repos/{owner}/{repo}/pulls/{number}", payload={"state": "closed"}, bearer_token=token)
+
+    def ensure_check(self, run: dict[str, Any], conclusion: str, output: dict[str, str]) -> None:
+        identity = run["assignment"]["identity"]
+        owner, repo = self._owner_repo(identity["repository"])
+        if conclusion != "in_progress":
+            current = common.get_pull_request(self.app_config, self.installation_id, owner, repo, int(identity["pr_number"]))
+            current_identity = _pull_identity(current)
+            if current_identity is None or current_identity["head_sha"] != identity["head_sha"]:
+                conclusion = "action_required"
+                output = {
+                    "title": "Documentation impact: stale revision",
+                    "summary": "This review was invalidated because the pull request revision is no longer current.",
+                }
+        external_id = str(run["external_id"])
+        existing = common.find_check_run(self.app_config, self.installation_id, owner, repo, identity["head_sha"], external_id)
+        if conclusion == "in_progress":
+            if existing is None:
+                run["check"] = common.create_check_run(self.app_config, self.installation_id, owner, repo, identity["head_sha"], external_id, "in_progress", None, output)
+            return
+        if existing is None:
+            created = common.create_check_run(self.app_config, self.installation_id, owner, repo, identity["head_sha"], external_id, "completed", conclusion, output)
+        else:
+            created = common.update_check_run(self.app_config, self.installation_id, owner, repo, str(existing["id"]), conclusion, output)
+        run["check"] = created

--- a/github/scripts/github_intake_docs_patch.py
+++ b/github/scripts/github_intake_docs_patch.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+"""Validate and canonically serialize revision-bound documentation patch proposals."""
+
+from __future__ import annotations
+
+import copy
+import datetime as dt
+import hashlib
+import json
+import pathlib
+import re
+from typing import Any
+
+SCHEMA_VERSION = 1
+MAX_DIFF_BYTES = 64 * 1024
+MAX_FILES = 32
+MAX_CLAIMS = 64
+MAX_CHECKS = 16
+MAX_EVIDENCE = 64
+
+DOCUMENTATION_PREFIXES = ("docs/", "doc/", "documentation/")
+DOCUMENTATION_FILENAMES = {"readme.md", "changelog.md", "contributing.md"}
+SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+GIT_SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+DIFF_PATH_PATTERN = re.compile(r"^diff --git a/(.+) b/(.+)$", re.MULTILINE)
+GITLINK_MODE_PATTERN = re.compile(r"^(?:new|old) (?:file )?mode 160000$|^index [0-9a-f]+\.\.[0-9a-f]+ 160000$", re.MULTILINE)
+RFC3339_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$")
+ROOT_FIELDS = {
+    "schema_version", "status", "generated_at", "identity", "patch_sha256", "diff", "files", "claims", "checks",
+}
+IDENTITY_FIELDS = {
+    "repository_id", "repository", "pr_number", "base_sha", "head_sha", "head_repository_id", "head_repository", "base_ref",
+}
+FILE_FIELDS = {"path", "sha256"}
+CLAIM_FIELDS = {"claim", "evidence", "release_scope"}
+CHECK_FIELDS = {"command", "status", "explanation"}
+ROOT_FIELDS_WITH_DIGEST = ROOT_FIELDS | {"artifact_sha256"}
+
+REVIEW_FIELDS = {
+    "schema_version", "kind", "identity", "agent_skill", "verdict", "rationale", "evidence", "confidence", "proposal",
+}
+REVIEW_FIELDS_WITH_DIGEST = REVIEW_FIELDS | {"review_sha256"}
+REVIEW_IDENTITY_FIELDS = {"repository_id", "repository", "pr_number", "head_sha", "source_key"}
+REVIEW_EVIDENCE_FIELDS = {"path", "evidence"}
+REVIEW_VERDICTS = {"no-impact", "docs-sufficient", "docs-change-required", "proposal-ready", "inconclusive"}
+
+
+def canonical_json(value: dict[str, Any]) -> str:
+    """Render JSON deterministically for storage, digesting, and safe projection."""
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def _expect_object(value: Any, field: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{field} must be an object")
+    return value
+
+
+def _expect_fields(value: dict[str, Any], expected: set[str], field: str) -> None:
+    actual = set(value)
+    if actual != expected:
+        missing = sorted(expected - actual)
+        unknown = sorted(actual - expected)
+        raise ValueError(f"{field} fields invalid; missing={missing}, unexpected={unknown}")
+
+
+def _text(value: Any, field: str, limit: int = 4096) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field} must be a non-empty string")
+    if len(value) > limit:
+        raise ValueError(f"{field} is too long")
+    return value
+
+
+def _validate_path(path: str) -> str:
+    if "\\" in path or path.startswith("/") or path in {".", ".."}:
+        raise ValueError(f"unsafe documentation path: {path!r}")
+    parts = pathlib.PurePosixPath(path).parts
+    if not parts or any(part in {"", ".", ".."} for part in parts):
+        raise ValueError(f"unsafe documentation path: {path!r}")
+    lowered = path.lower()
+    if not lowered.startswith(DOCUMENTATION_PREFIXES) and pathlib.PurePosixPath(lowered).name not in DOCUMENTATION_FILENAMES:
+        raise ValueError(f"non-documentation path: {path!r}")
+    return path
+
+
+def _validate_identity(identity: Any) -> dict[str, Any]:
+    identity = _expect_object(identity, "identity")
+    _expect_fields(identity, IDENTITY_FIELDS, "identity")
+    normalized = copy.deepcopy(identity)
+    for field in ("repository_id", "repository", "head_repository_id", "head_repository", "base_ref"):
+        normalized[field] = _text(normalized[field], f"identity.{field}", 256)
+    if type(normalized["pr_number"]) is not int or normalized["pr_number"] <= 0:
+        raise ValueError("identity.pr_number must be a positive integer")
+    for field in ("base_sha", "head_sha"):
+        value = _text(normalized[field], f"identity.{field}", 40).lower()
+        if not GIT_SHA_PATTERN.fullmatch(value):
+            raise ValueError(f"identity.{field} must be a 40-character lowercase Git SHA")
+        normalized[field] = value
+    return normalized
+
+
+def _validate_diff(diff: Any, patch_sha256: str, files: list[dict[str, Any]]) -> str:
+    diff = _text(diff, "diff", MAX_DIFF_BYTES * 2)
+    if len(diff.encode("utf-8")) > MAX_DIFF_BYTES:
+        raise ValueError("diff is too large")
+    if "\x00" in diff or "GIT binary patch" in diff or "Binary files " in diff:
+        raise ValueError("binary diff is not allowed")
+    if "new file mode 120000" in diff or "old mode 120000" in diff:
+        raise ValueError("symlink diff is not allowed")
+    if GITLINK_MODE_PATTERN.search(diff):
+        raise ValueError("gitlink diff is not allowed")
+    actual = hashlib.sha256(diff.encode("utf-8")).hexdigest()
+    if actual != patch_sha256:
+        raise ValueError("patch_sha256 does not match diff")
+    diff_paths: set[str] = set()
+    for old_path, new_path in DIFF_PATH_PATTERN.findall(diff):
+        if old_path != "/dev/null":
+            diff_paths.add(_validate_path(old_path))
+        if new_path != "/dev/null":
+            diff_paths.add(_validate_path(new_path))
+    if not diff_paths:
+        raise ValueError("diff must contain a unified documentation patch")
+    file_paths = {file["path"] for file in files}
+    if diff_paths != file_paths:
+        raise ValueError("diff paths must exactly match files paths")
+    for line in diff.splitlines():
+        if line.startswith("--- "):
+            path = line.removeprefix("--- ")
+            if path != "/dev/null":
+                if not path.startswith("a/"):
+                    raise ValueError(f"unsafe unified diff path: {path!r}")
+                path = _validate_path(path.removeprefix("a/"))
+                if path not in file_paths:
+                    raise ValueError("unified diff paths must exactly match files paths")
+        elif line.startswith("+++ "):
+            path = line.removeprefix("+++ ")
+            if path != "/dev/null":
+                if not path.startswith("b/"):
+                    raise ValueError(f"unsafe unified diff path: {path!r}")
+                path = _validate_path(path.removeprefix("b/"))
+                if path not in file_paths:
+                    raise ValueError("unified diff paths must exactly match files paths")
+    return diff
+
+
+def _validate_files(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list) or not value or len(value) > MAX_FILES:
+        raise ValueError("files must be a non-empty bounded list")
+    files: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for index, item in enumerate(value):
+        item = _expect_object(item, f"files[{index}]")
+        _expect_fields(item, FILE_FIELDS, f"files[{index}]")
+        path = _validate_path(_text(item["path"], f"files[{index}].path", 1024))
+        digest = _text(item["sha256"], f"files[{index}].sha256", 64).lower()
+        if not SHA256_PATTERN.fullmatch(digest):
+            raise ValueError(f"files[{index}].sha256 must be a SHA-256 digest")
+        if path in seen:
+            raise ValueError("files paths must be unique")
+        seen.add(path)
+        files.append({"path": path, "sha256": digest})
+    return sorted(files, key=lambda item: item["path"])
+
+
+def _validate_claims(value: Any) -> list[dict[str, str]]:
+    if not isinstance(value, list) or not value or len(value) > MAX_CLAIMS:
+        raise ValueError("claims must be a non-empty bounded list")
+    claims: list[dict[str, str]] = []
+    for index, item in enumerate(value):
+        item = _expect_object(item, f"claims[{index}]")
+        _expect_fields(item, CLAIM_FIELDS, f"claims[{index}]")
+        evidence = _text(item["evidence"], f"claims[{index}].evidence", 2048)
+        if not (evidence.startswith("github://") or evidence.startswith("https://") or evidence.startswith("git:")):
+            raise ValueError(f"claims[{index}].evidence must be an immutable evidence reference")
+        git_sha = re.search(r"\b[0-9a-f]{40}\b", evidence)
+        if evidence.startswith("git:") and git_sha is None:
+            raise ValueError(f"claims[{index}].evidence must pin a commit SHA")
+        if not evidence.startswith("git:") and re.search(r"/(?:blob|commit)/[0-9a-f]{40}(?:/|$)", evidence) is None:
+            raise ValueError(f"claims[{index}].evidence must pin a commit SHA")
+        claims.append({
+            "claim": _text(item["claim"], f"claims[{index}].claim", 4096),
+            "evidence": evidence,
+            "release_scope": _text(item["release_scope"], f"claims[{index}].release_scope", 512),
+        })
+    return sorted(claims, key=lambda item: (item["claim"], item["evidence"], item["release_scope"]))
+
+
+def _validate_checks(value: Any) -> list[dict[str, str]]:
+    if not isinstance(value, list) or not value or len(value) > MAX_CHECKS:
+        raise ValueError("checks must be a non-empty bounded list")
+    checks: list[dict[str, str]] = []
+    for index, item in enumerate(value):
+        item = _expect_object(item, f"checks[{index}]")
+        _expect_fields(item, CHECK_FIELDS, f"checks[{index}]")
+        status = _text(item["status"], f"checks[{index}].status", 16)
+        if status not in {"passed", "failed", "unavailable"}:
+            raise ValueError(f"checks[{index}].status must be passed, failed, or unavailable")
+        checks.append({
+            "command": _text(item["command"], f"checks[{index}].command", 2048),
+            "status": status,
+            "explanation": _text(item["explanation"], f"checks[{index}].explanation", 4096),
+        })
+    return sorted(checks, key=lambda item: (item["command"], item["status"], item["explanation"]))
+
+
+def validate_artifact(value: dict[str, Any]) -> dict[str, Any]:
+    """Return a canonical artifact or raise ValueError for unsafe input."""
+    value = _expect_object(value, "artifact")
+    if set(value) != ROOT_FIELDS and set(value) != ROOT_FIELDS_WITH_DIGEST:
+        _expect_fields(value, ROOT_FIELDS, "artifact")
+    if type(value["schema_version"]) is not int or value["schema_version"] != SCHEMA_VERSION:
+        raise ValueError(f"schema_version must be {SCHEMA_VERSION}")
+    if value["status"] not in {"proposed", "unavailable", "unsafe"}:
+        raise ValueError("status must be proposed, unavailable, or unsafe")
+    generated_at = _text(value["generated_at"], "generated_at", 64)
+    if RFC3339_PATTERN.fullmatch(generated_at) is None:
+        raise ValueError("generated_at must be RFC3339 with a timezone")
+    try:
+        parsed_time = dt.datetime.fromisoformat(generated_at.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError("generated_at must be RFC3339") from exc
+    if parsed_time.tzinfo is None or parsed_time.utcoffset() is None:
+        raise ValueError("generated_at must be RFC3339 with a timezone")
+    patch_sha256 = _text(value["patch_sha256"], "patch_sha256", 64).lower()
+    if not SHA256_PATTERN.fullmatch(patch_sha256):
+        raise ValueError("patch_sha256 must be a SHA-256 digest")
+    files = _validate_files(value["files"])
+    artifact = {
+        "schema_version": SCHEMA_VERSION,
+        "status": value["status"],
+        "generated_at": generated_at,
+        "identity": _validate_identity(value["identity"]),
+        "patch_sha256": patch_sha256,
+        "diff": _validate_diff(value["diff"], patch_sha256, files),
+        "files": files,
+        "claims": _validate_claims(value["claims"]),
+        "checks": _validate_checks(value["checks"]),
+    }
+    artifact_sha256 = hashlib.sha256(canonical_json(artifact).encode("utf-8")).hexdigest()
+    supplied_digest = value.get("artifact_sha256")
+    if supplied_digest is not None:
+        supplied_digest = _text(supplied_digest, "artifact_sha256", 64).lower()
+        if not SHA256_PATTERN.fullmatch(supplied_digest) or supplied_digest != artifact_sha256:
+            raise ValueError("artifact_sha256 does not match canonical artifact")
+    artifact["artifact_sha256"] = artifact_sha256
+    return artifact
+
+
+def _validate_review_identity(value: Any) -> dict[str, Any]:
+    identity = _expect_object(value, "identity")
+    _expect_fields(identity, REVIEW_IDENTITY_FIELDS, "identity")
+    normalized = {
+        "repository_id": _text(identity["repository_id"], "identity.repository_id", 256),
+        "repository": _text(identity["repository"], "identity.repository", 256),
+        "pr_number": identity["pr_number"],
+        "head_sha": _text(identity["head_sha"], "identity.head_sha", 40).lower(),
+        "source_key": _text(identity["source_key"], "identity.source_key", 256),
+    }
+    if isinstance(normalized["pr_number"], bool) or not isinstance(normalized["pr_number"], int) or normalized["pr_number"] <= 0:
+        raise ValueError("identity.pr_number must be a positive integer")
+    if GIT_SHA_PATTERN.fullmatch(normalized["head_sha"]) is None:
+        raise ValueError("identity.head_sha must be a 40-character lowercase Git SHA")
+    expected_source = f"github-pr:{normalized['repository_id']}:{normalized['pr_number']}:{normalized['head_sha']}"
+    if normalized["source_key"] != expected_source:
+        raise ValueError("identity.source_key does not match review identity")
+    return normalized
+
+
+def _validate_review_evidence(value: Any) -> list[dict[str, str]]:
+    if not isinstance(value, list) or not value or len(value) > MAX_EVIDENCE:
+        raise ValueError("evidence must be a non-empty bounded list")
+    result: list[dict[str, str]] = []
+    for index, item in enumerate(value):
+        item = _expect_object(item, f"evidence[{index}]")
+        _expect_fields(item, REVIEW_EVIDENCE_FIELDS, f"evidence[{index}]")
+        path = _text(item["path"], f"evidence[{index}].path", 1024)
+        if "\\" in path or path.startswith("/") or any(part in {"", ".", ".."} for part in pathlib.PurePosixPath(path).parts):
+            raise ValueError(f"evidence[{index}].path is unsafe")
+        evidence = _text(item["evidence"], f"evidence[{index}].evidence", 2048)
+        if not (evidence.startswith("github://") or evidence.startswith("https://") or evidence.startswith("git:")):
+            raise ValueError(f"evidence[{index}].evidence must be an immutable evidence reference")
+        if evidence.startswith("git:"):
+            pinned = re.search(r"\b[0-9a-f]{40}\b", evidence)
+        else:
+            pinned = re.search(r"/(?:blob|commit)/[0-9a-f]{40}(?:/|$)", evidence)
+        if pinned is None:
+            raise ValueError(f"evidence[{index}].evidence must pin a commit SHA")
+        result.append({"path": path, "evidence": evidence})
+    return sorted(result, key=lambda item: (item["path"], item["evidence"]))
+
+
+def validate_agent_review(document: dict[str, Any]) -> dict[str, Any]:
+    """Return a canonical, revision-bound City TechDocs review or reject it."""
+    document = _expect_object(document, "review")
+    if set(document) != REVIEW_FIELDS and set(document) != REVIEW_FIELDS_WITH_DIGEST:
+        _expect_fields(document, REVIEW_FIELDS, "review")
+    if type(document["schema_version"]) is not int or document["schema_version"] != SCHEMA_VERSION:
+        raise ValueError(f"schema_version must be {SCHEMA_VERSION}")
+    if document["kind"] != "github-pr-docs-impact-review":
+        raise ValueError("kind must be github-pr-docs-impact-review")
+    verdict = _text(document["verdict"], "verdict", 64)
+    if verdict not in REVIEW_VERDICTS:
+        raise ValueError("unknown verdict")
+    rationale = _text(document["rationale"], "rationale", 4096)
+    skill = _text(document["agent_skill"], "agent_skill", 256)
+    if skill != "developer-experience-techdocs":
+        raise ValueError("agent_skill must be developer-experience-techdocs")
+    confidence = document["confidence"]
+    if isinstance(confidence, bool) or not isinstance(confidence, (int, float)) or not 0 <= confidence <= 1:
+        raise ValueError("confidence must be a number between 0 and 1")
+    proposal = document["proposal"]
+    if verdict == "proposal-ready" and proposal is None:
+        raise ValueError("proposal-ready requires a complete proposal")
+    if verdict != "proposal-ready" and proposal is not None:
+        raise ValueError("proposal is only allowed for proposal-ready verdict")
+    normalized_proposal = validate_artifact(proposal) if proposal is not None else None
+    if normalized_proposal is not None:
+        proposal_identity = normalized_proposal["identity"]
+        review_identity = document["identity"]
+        if normalized_proposal["status"] != "proposed":
+            raise ValueError("proposal must have proposed status")
+        for field in ("repository_id", "repository", "pr_number", "head_sha"):
+            if proposal_identity[field] != review_identity[field]:
+                raise ValueError("proposal identity does not match review identity")
+    review = {
+        "schema_version": SCHEMA_VERSION,
+        "kind": document["kind"],
+        "identity": _validate_review_identity(document["identity"]),
+        "agent_skill": skill,
+        "verdict": verdict,
+        "rationale": rationale,
+        "evidence": _validate_review_evidence(document["evidence"]),
+        "confidence": confidence,
+        "proposal": normalized_proposal,
+    }
+    digest = hashlib.sha256(canonical_json(review).encode("utf-8")).hexdigest()
+    supplied = document.get("review_sha256")
+    if supplied is not None and (_text(supplied, "review_sha256", 64).lower() != digest):
+        raise ValueError("review_sha256 does not match canonical review")
+    review["review_sha256"] = digest
+    return review
+
+
+def validate_review_decision(document: dict[str, Any]) -> dict[str, Any]:
+    """Validate a reviewer decision before the trusted builder derives its proposal."""
+    document = _expect_object(document, "review")
+    if set(document) != REVIEW_FIELDS:
+        _expect_fields(document, REVIEW_FIELDS, "review")
+    if type(document["schema_version"]) is not int or document["schema_version"] != SCHEMA_VERSION:
+        raise ValueError(f"schema_version must be {SCHEMA_VERSION}")
+    if document["kind"] != "github-pr-docs-impact-review" or document["proposal"] is not None:
+        raise ValueError("review decision must have no proposal")
+    verdict = _text(document["verdict"], "verdict", 64)
+    if verdict not in REVIEW_VERDICTS:
+        raise ValueError("unknown verdict")
+    confidence = document["confidence"]
+    if isinstance(confidence, bool) or not isinstance(confidence, (int, float)) or not 0 <= confidence <= 1:
+        raise ValueError("confidence must be a number between 0 and 1")
+    return {"schema_version": SCHEMA_VERSION, "kind": document["kind"], "identity": _validate_review_identity(document["identity"]), "agent_skill": _text(document["agent_skill"], "agent_skill", 256), "verdict": verdict, "rationale": _text(document["rationale"], "rationale", 4096), "evidence": _validate_review_evidence(document["evidence"]), "confidence": confidence, "proposal": None}

--- a/github/scripts/github_intake_docs_patch_worker.py
+++ b/github/scripts/github_intake_docs_patch_worker.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""Run a configured City TechDocs adapter for one sanitized assignment.
+
+The worker has no GitHub client and does not derive a documentation verdict.
+It gives the configured adapter only canonical assignment JSON on stdin and the
+vendored TechDocs skill directory, then emits a revision-bound review candidate
+only after strict validation. An unavailable or incomplete adapter emits none.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import pathlib
+import re
+import shlex
+import subprocess
+import sys
+import tempfile
+from typing import Any
+
+import github_intake_docs_patch as docs_patch
+
+ASSIGNMENT_SCHEMA_VERSION = 1
+ASSIGNMENT_FIELDS = {"schema_version", "kind", "identity", "agent_skill", "evidence_bundle"}
+ASSIGNMENT_IDENTITY_FIELDS = {"repository_id", "repository", "pr_number", "head_sha", "source_key"}
+AGENT_SKILL = "developer-experience-techdocs"
+SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+MAX_ADAPTER_OUTPUT_BYTES = 1_048_576
+MAX_EVIDENCE_PATCH_BYTES = 64 * 1024
+MAX_EVIDENCE_TOTAL_BYTES = 256 * 1024
+FORBIDDEN_CREDENTIAL_ENV = (
+    "GH_TOKEN",
+    "GITHUB_TOKEN",
+    "GITHUB_APP_ID",
+    "GITHUB_WEBHOOK_SECRET",
+    "GITHUB_APP_PRIVATE_KEY_PEM",
+)
+
+
+def _required_text(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value or value.strip() != value:
+        raise ValueError(f"{field} must be non-empty canonical text")
+    return value
+
+
+def validate_assignment(value: Any) -> dict[str, Any]:
+    """Return one canonical, revision-bound City TechDocs assignment."""
+    if not isinstance(value, dict) or set(value) != ASSIGNMENT_FIELDS:
+        raise ValueError("assignment must contain only the documented sanitized fields")
+    if type(value["schema_version"]) is not int or value["schema_version"] != ASSIGNMENT_SCHEMA_VERSION:
+        raise ValueError(f"assignment schema_version must be {ASSIGNMENT_SCHEMA_VERSION}")
+    if value["kind"] != "github-pr-docs-impact-assignment":
+        raise ValueError("assignment kind must be github-pr-docs-impact-assignment")
+    if value["agent_skill"] != AGENT_SKILL:
+        raise ValueError(f"assignment agent_skill must be {AGENT_SKILL}")
+    identity = value["identity"]
+    if not isinstance(identity, dict) or set(identity) != ASSIGNMENT_IDENTITY_FIELDS:
+        raise ValueError("assignment identity must be exact and revision-bound")
+    repository_id = _required_text(identity["repository_id"], "identity.repository_id")
+    repository = _required_text(identity["repository"], "identity.repository")
+    pr_number = identity["pr_number"]
+    if type(pr_number) is not int or pr_number <= 0:
+        raise ValueError("identity.pr_number must be a positive integer")
+    head_sha = _required_text(identity["head_sha"], "identity.head_sha").lower()
+    if SHA_PATTERN.fullmatch(head_sha) is None:
+        raise ValueError("identity.head_sha must be a lowercase 40-character SHA")
+    source_key = _required_text(identity["source_key"], "identity.source_key")
+    if source_key != f"github-pr:{repository_id}:{pr_number}:{head_sha}":
+        raise ValueError("identity.source_key does not match assignment identity")
+    evidence_bundle = value["evidence_bundle"]
+    if (
+        not isinstance(evidence_bundle, dict)
+        or set(evidence_bundle) != {"head_sha", "files", "proposal_identity"}
+        or _required_text(evidence_bundle["head_sha"], "evidence_bundle.head_sha") != head_sha
+        or not isinstance(evidence_bundle["files"], list)
+        or not evidence_bundle["files"]
+        or len(evidence_bundle["files"]) > 100
+    ):
+        raise ValueError("evidence_bundle must be bounded and bound to the assignment SHA")
+    try:
+        proposal_identity = docs_patch._validate_identity(evidence_bundle["proposal_identity"])
+    except ValueError as exc:
+        raise ValueError("evidence_bundle proposal identity must be complete and valid") from exc
+    for field, expected in (("repository_id", repository_id), ("repository", repository), ("pr_number", pr_number), ("head_sha", head_sha)):
+        if proposal_identity[field] != expected:
+            raise ValueError("evidence_bundle proposal identity must exactly match assignment identity")
+    files: list[dict[str, str]] = []
+    total_evidence_bytes = 0
+    for item in evidence_bundle["files"]:
+        if not isinstance(item, dict) or set(item) != {"path", "reference", "patch"}:
+            raise ValueError("evidence_bundle files must have exact fields")
+        path = _required_text(item["path"], "evidence_bundle.files.path")
+        reference = _required_text(item["reference"], "evidence_bundle.files.reference")
+        patch = item["patch"]
+        if not isinstance(patch, str) or not patch:
+            raise ValueError("evidence_bundle.files.patch must be non-empty text")
+        patch_bytes = len(patch.encode("utf-8"))
+        if patch_bytes > MAX_EVIDENCE_PATCH_BYTES:
+            raise ValueError("evidence_bundle.files.patch is too large")
+        total_evidence_bytes += sum(len(text.encode("utf-8")) for text in (path, reference, patch))
+        if total_evidence_bytes > MAX_EVIDENCE_TOTAL_BYTES:
+            raise ValueError("evidence_bundle total evidence is too large")
+        if reference != f"github://{repository}/blob/{head_sha}/{path}":
+            raise ValueError("evidence bundle reference must be immutable and SHA-pinned")
+        files.append({"path": path, "reference": reference, "patch": patch})
+    if [item["path"] for item in files] != sorted({item["path"] for item in files}):
+        raise ValueError("evidence bundle paths must be sorted and unique")
+    return {
+        "schema_version": ASSIGNMENT_SCHEMA_VERSION,
+        "kind": "github-pr-docs-impact-assignment",
+        "identity": {
+            "repository_id": repository_id,
+            "repository": repository,
+            "pr_number": pr_number,
+            "head_sha": head_sha,
+            "source_key": source_key,
+        },
+        "agent_skill": AGENT_SKILL,
+        "evidence_bundle": {"head_sha": head_sha, "files": files, "proposal_identity": proposal_identity},
+    }
+
+
+def load_assignment_bytes(raw: bytes) -> dict[str, Any]:
+    try:
+        value = json.loads(raw)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"could not read sanitized assignment: {exc}") from exc
+    return validate_assignment(value)
+
+
+def load_assignment(assignment_file: pathlib.Path) -> dict[str, Any]:
+    try:
+        return load_assignment_bytes(assignment_file.read_bytes())
+    except OSError as exc:
+        raise ValueError(f"could not read sanitized assignment: {exc}") from exc
+
+
+def _adapter_argv(adapter_command: str) -> list[str] | None:
+    if not adapter_command.strip():
+        return None
+    try:
+        argv = shlex.split(adapter_command)
+    except ValueError:
+        return None
+    if not argv or any(argument == "--skill-dir" or argument.startswith("--skill-dir=") for argument in argv):
+        return None
+    return argv
+
+
+def _adapter_environment() -> dict[str, str]:
+    """Supply runtime basics but no caller state, credentials, or City identity."""
+    return {
+        "HOME": "/tmp",
+        "PATH": os.defpath,
+        "LANG": "C.UTF-8",
+        "LC_ALL": "C.UTF-8",
+        "PYTHONNOUSERSITE": "1",
+    }
+
+
+def run_adapter(
+    assignment: dict[str, Any],
+    adapter_command: str,
+    skill_dir: pathlib.Path,
+    timeout_seconds: float = 300.0,
+) -> dict[str, Any] | None:
+    """Return a completed adapter review, or None without inventing a result."""
+    argv = _adapter_argv(adapter_command)
+    if argv is None or timeout_seconds <= 0 or not (skill_dir / "SKILL.md").is_file():
+        return None
+    payload = docs_patch.canonical_json(assignment) + "\n"
+    try:
+        with tempfile.TemporaryDirectory(prefix="city-techdocs-adapter-") as work_dir:
+            result = subprocess.run(
+                [*argv, "--skill-dir", str(skill_dir)],
+                input=payload,
+                text=True,
+                capture_output=True,
+                env=_adapter_environment(),
+                cwd=work_dir,
+                timeout=timeout_seconds,
+                check=False,
+            )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0 or not result.stdout or len(result.stdout.encode("utf-8")) > MAX_ADAPTER_OUTPUT_BYTES:
+        return None
+    try:
+        candidate = json.loads(result.stdout)
+        review = docs_patch.validate_review_decision(candidate)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return None
+    if review["identity"] != assignment["identity"] or review["agent_skill"] != assignment["agent_skill"]:
+        return None
+    if review["proposal"] is not None:
+        return None
+    return review
+
+
+def review_assignment_bytes(
+    raw: bytes,
+    adapter_command: str,
+    skill_dir: pathlib.Path,
+    timeout_seconds: float = 300.0,
+) -> dict[str, Any] | None:
+    assignment = load_assignment_bytes(raw)
+    return run_adapter(assignment, adapter_command, skill_dir, timeout_seconds)
+
+
+def validate_final_candidate(raw_assignment: bytes, candidate: dict[str, Any]) -> dict[str, Any]:
+    """Accept only the final review envelope produced after trusted Git derivation."""
+    assignment = load_assignment_bytes(raw_assignment)
+    if not isinstance(candidate, dict) or set(candidate) != {"schema_version", "snapshot_sha256", "artifact"} or type(candidate["schema_version"]) is not int or candidate["schema_version"] != 1 or candidate["snapshot_sha256"] != hashlib.sha256(raw_assignment).hexdigest():
+        raise ValueError("candidate must be one final assignment-bound envelope")
+    review = docs_patch.validate_agent_review(candidate["artifact"])
+    if review["identity"] != assignment["identity"] or review["agent_skill"] != assignment["agent_skill"]:
+        raise ValueError("candidate does not match assignment")
+    if review["verdict"] == "proposal-ready" and (review["proposal"] is None or review["proposal"]["identity"] != assignment["evidence_bundle"]["proposal_identity"]):
+        raise ValueError("candidate proposal identity does not exactly match assignment")
+    return {"schema_version": 1, "snapshot_sha256": candidate["snapshot_sha256"], "artifact": review}
+
+
+def write_artifact(artifact_file: pathlib.Path, candidate: dict[str, Any]) -> None:
+    """Atomically place only a canonical candidate envelope in the isolated outbox."""
+    artifact_file.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    payload = docs_patch.canonical_json(candidate) + "\n"
+    descriptor, temporary_name = tempfile.mkstemp(prefix=".docs-review-", suffix=".tmp", dir=artifact_file.parent)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_name, artifact_file)
+    except Exception:
+        try:
+            os.unlink(temporary_name)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def remove_artifact(artifact_file: pathlib.Path) -> None:
+    try:
+        artifact_file.unlink()
+    except FileNotFoundError:
+        pass
+
+
+def reject_credentials() -> None:
+    leaked = [name for name in FORBIDDEN_CREDENTIAL_ENV if os.environ.get(name)]
+    if leaked:
+        raise ValueError(f"worker must not receive GitHub credentials: {', '.join(leaked)}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--assignment-file",
+        default=os.environ.get("GC_TECHDOCS_ASSIGNMENT_FILE", os.environ.get("GC_TECHDOCS_SNAPSHOT_FILE", "")),
+    )
+    parser.add_argument("--artifact-file", default=os.environ.get("GC_TECHDOCS_ARTIFACT_FILE", ""))
+    parser.add_argument("--adapter-command", default=os.environ.get("GC_TECHDOCS_ADAPTER_COMMAND", ""))
+    parser.add_argument("--skill-dir", default=os.environ.get("GC_TECHDOCS_SKILL_DIR", ""))
+    parser.add_argument("--workspace", default=os.environ.get("GC_TECHDOCS_WORKSPACE", ""))
+    parser.add_argument("--generated-at", default=os.environ.get("GC_TECHDOCS_GENERATED_AT", ""))
+    parser.add_argument("--claims-json", default=os.environ.get("GC_TECHDOCS_CLAIMS_JSON", "[]"))
+    parser.add_argument("--checks-json", default=os.environ.get("GC_TECHDOCS_CHECKS_JSON", "[]"))
+    parser.add_argument(
+        "--adapter-timeout-seconds",
+        type=float,
+        default=float(os.environ.get("GC_TECHDOCS_ADAPTER_TIMEOUT_SECONDS", "300")),
+    )
+    args = parser.parse_args()
+    if not args.assignment_file or not args.artifact_file:
+        parser.error("--assignment-file and --artifact-file are required")
+    artifact_file = pathlib.Path(args.artifact_file)
+    try:
+        remove_artifact(artifact_file)
+        reject_credentials()
+        raw_assignment = pathlib.Path(args.assignment_file).read_bytes()
+        review = review_assignment_bytes(
+            raw_assignment,
+            args.adapter_command,
+            pathlib.Path(args.skill_dir),
+            args.adapter_timeout_seconds,
+        )
+        if review is None:
+            print(docs_patch.canonical_json({"status": "unavailable"}))
+            return 0
+        if review["verdict"] != "proposal-ready":
+            candidate = validate_final_candidate(raw_assignment, {"schema_version": 1, "snapshot_sha256": hashlib.sha256(raw_assignment).hexdigest(), "artifact": review})
+        elif not args.workspace or not args.generated_at:
+            print(docs_patch.canonical_json({"status": "unavailable"}))
+            return 0
+        else:
+            import github_intake_docs_candidate_builder as builder
+            candidate = builder.build_candidate(raw_assignment, pathlib.Path(args.workspace), generated_at=args.generated_at, claims=json.loads(args.claims_json), checks=json.loads(args.checks_json), review=review)
+        write_artifact(artifact_file, candidate)
+    except (OSError, ValueError) as exc:
+        parser.error(str(exc))
+    print(docs_patch.canonical_json({"review_sha256": candidate["artifact"]["review_sha256"], "status": "completed"}))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/github/scripts/github_intake_docs_review_commands.py
+++ b/github/scripts/github_intake_docs_review_commands.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Run one deployment-neutral docs-impact lifecycle operation.
+
+The commands write action intents to a file instead of selecting a scheduler,
+queue, City target, or GitHub provider.  A deployment consumes that file with
+its own adapter and invokes these commands again to converge after a restart.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pathlib
+import sys
+import time
+from typing import Any
+
+import github_intake_common as common
+import github_intake_docs_impact as impact
+import github_intake_docs_review_runtime as runtime
+
+
+class ActionFileAdapter:
+    def __init__(self, actions_file: pathlib.Path, head_is_current: bool) -> None:
+        self.actions_file = actions_file
+        self._head_is_current = head_is_current
+
+    def head_is_current(self, run: dict[str, Any]) -> bool:
+        return self._head_is_current
+
+    def perform(self, action: str, run: dict[str, Any]) -> None:
+        self.actions_file.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        document = common.read_json(str(self.actions_file), {"actions": []})
+        if not isinstance(document, dict) or not isinstance(document.get("actions"), list):
+            raise ValueError("actions file must contain an actions list")
+        document["actions"].append({"action": action, "identity": run["identity"], "external_id": run["external_id"], "assignment": run["assignment"] if action == "dispatch" else None})
+        common.atomic_write_json(str(self.actions_file), document)
+
+
+def _load(path: str) -> dict[str, Any]:
+    value = json.loads(pathlib.Path(path).read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError("input must be a JSON object")
+    return value
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("operation", choices=("intake", "candidate", "reconcile"))
+    parser.add_argument("--once", action="store_true", required=True)
+    parser.add_argument("--store", default=common.docs_review_runs_dir())
+    parser.add_argument("--actions-file")
+    parser.add_argument("--projection", choices=("github", "action-file"), default="github")
+    parser.add_argument("--installation-id", default=os.environ.get("GITHUB_INSTALLATION_ID", ""))
+    parser.add_argument("--assignment-file")
+    parser.add_argument("--candidate-file")
+    parser.add_argument("--head-is-current", choices=("true", "false"), default="true")
+    parser.add_argument("--now", type=float, default=None)
+    args = parser.parse_args()
+    now = time.time() if args.now is None else args.now
+    store = runtime.FileDocsReviewStore(args.store)
+    if args.projection == "github":
+        config = common.load_effective_config()
+        installation_id = args.installation_id or str((config.get("app") or {}).get("installation_id", ""))
+        if not installation_id:
+            parser.error("GitHub projection requires --installation-id or configured app installation_id")
+        adapter = impact.AppProjection(store, impact.GitHubAppProjectionGateway(config.get("app") or {}, installation_id))
+    else:
+        if not args.actions_file:
+            parser.error("action-file projection requires --actions-file")
+        adapter = ActionFileAdapter(pathlib.Path(args.actions_file), args.head_is_current == "true")
+    try:
+        if args.operation == "intake":
+            if not args.assignment_file:
+                parser.error("intake requires --assignment-file")
+            result = runtime.intake_delivery(store, _load(args.assignment_file), adapter, now=now)
+        elif args.operation == "candidate":
+            if not args.candidate_file:
+                parser.error("candidate requires --candidate-file")
+            result = runtime.accept_candidate(store, _load(args.candidate_file), adapter, now=now)
+        else:
+            result = {"runs": runtime.reconcile_pending(store, adapter, now=now)}
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        parser.error(str(exc))
+    print(json.dumps(result, sort_keys=True, separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/github/scripts/github_intake_docs_review_runtime.py
+++ b/github/scripts/github_intake_docs_review_runtime.py
@@ -1,0 +1,287 @@
+"""Durable, deployment-neutral runtime for the docs-impact lifecycle.
+
+This module owns only files and lifecycle transitions.  A deployment provides
+an adapter whose ``perform(action, run)`` method performs the recorded action
+and whose ``head_is_current(run)`` method reads the current pull-request head.
+"""
+
+from __future__ import annotations
+
+import copy
+import base64
+import hashlib
+import json
+import os
+import pathlib
+import tempfile
+from contextlib import contextmanager
+from typing import Any, Protocol
+
+import fcntl
+
+import github_intake_docs_patch_worker as worker
+from github_docs_pr_review_lifecycle import Candidate, DocsReviewRun, Transition, begin, reconcile
+
+
+class DocsReviewAdapter(Protocol):
+    def head_is_current(self, run: dict[str, Any]) -> bool: ...
+    def perform(self, action: str, run: dict[str, Any]) -> None: ...
+
+
+class FileDocsReviewStore:
+    """A small atomic-json store suitable for one deployment's shared volume."""
+
+    def __init__(self, root: pathlib.Path | str) -> None:
+        self.root = pathlib.Path(root)
+        self.runs_dir = self.root / "runs"
+        self.candidates_dir = self.root / "candidates"
+
+    @staticmethod
+    def _name(identity: str) -> str:
+        return hashlib.sha256(identity.encode("utf-8")).hexdigest() + ".json"
+
+    def _path(self, identity: str) -> pathlib.Path:
+        return self.runs_dir / self._name(identity)
+
+    @contextmanager
+    def lock(self, identity: str):
+        """Serialize all read-transition-write operations for one immutable run."""
+        self.runs_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+        lock_path = self.runs_dir / f"{self._name(identity)}.lock"
+        with lock_path.open("a+", encoding="utf-8") as handle:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+    def load(self, identity: str) -> dict[str, Any] | None:
+        try:
+            value = json.loads(self._path(identity).read_text(encoding="utf-8"))
+        except FileNotFoundError:
+            return None
+        if not isinstance(value, dict) or value.get("identity") != identity:
+            raise ValueError("stored docs review run is invalid")
+        return value
+
+    def save(self, run: dict[str, Any]) -> dict[str, Any]:
+        identity = str(run.get("identity", ""))
+        if not identity:
+            raise ValueError("stored docs review run requires identity")
+        self.runs_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+        path = self._path(identity)
+        with tempfile.NamedTemporaryFile(mode="w", encoding="utf-8", dir=self.runs_dir, delete=False) as handle:
+            handle.write(json.dumps(run, sort_keys=True, separators=(",", ":")) + "\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+            temporary = pathlib.Path(handle.name)
+        temporary.replace(path)
+        return run
+
+    def list_runs(self) -> list[dict[str, Any]]:
+        if not self.runs_dir.exists():
+            return []
+        result = []
+        for path in sorted(self.runs_dir.glob("*.json")):
+            value = json.loads(path.read_text(encoding="utf-8"))
+            if not isinstance(value, dict):
+                raise ValueError("stored docs review run is invalid")
+            result.append(value)
+        return result
+
+    def audit_candidate(self, identity: str, envelope: dict[str, Any], now: float) -> None:
+        self.candidates_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+        digest = hashlib.sha256(json.dumps(envelope, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+        path = self.candidates_dir / f"{self._name(identity)[:-5]}-{digest}.json"
+        if not path.exists():
+            path.write_text(json.dumps({"received_at": now, "candidate": envelope}, sort_keys=True, separators=(",", ":")) + "\n", encoding="utf-8")
+
+
+def assignment_from_paginated_evidence(delivery: dict[str, Any], pages: list[list[dict[str, Any]]]) -> dict[str, Any]:
+    """Construct a Task-1 assignment only from complete text patches on all pages."""
+    required = ("repository_id", "repository", "pr_number", "head_sha", "base_sha", "base_ref")
+    if not isinstance(delivery, dict) or any(key not in delivery for key in required):
+        raise ValueError("delivery lacks immutable pull-request identity")
+    repository_id, repository = str(delivery["repository_id"]), str(delivery["repository"])
+    pr_number = delivery["pr_number"]
+    head_sha, base_sha, base_ref = str(delivery["head_sha"]).lower(), str(delivery["base_sha"]).lower(), str(delivery["base_ref"])
+    if not repository_id or not repository or type(pr_number) is not int or pr_number <= 0:
+        raise ValueError("delivery lacks immutable pull-request identity")
+    files: list[dict[str, str]] = []
+    for page in pages:
+        if not isinstance(page, list):
+            raise ValueError("evidence page must be a list")
+        for changed in page:
+            if not isinstance(changed, dict):
+                raise ValueError("evidence file must be an object")
+            path, patch = changed.get("filename"), changed.get("patch")
+            if (not isinstance(path, str) or not path or not isinstance(patch, str) or not patch
+                    or changed.get("truncated") is True or "Binary files" in patch or "GIT binary patch" in patch):
+                raise ValueError("evidence requires a complete text patch")
+            files.append({"path": path, "reference": f"github://{repository}/blob/{head_sha}/{path}", "patch": patch})
+    if not files:
+        raise ValueError("evidence requires at least one complete text patch")
+    files.sort(key=lambda item: item["path"])
+    if len({item["path"] for item in files}) != len(files):
+        raise ValueError("evidence paths must be unique")
+    identity = {"repository_id": repository_id, "repository": repository, "pr_number": pr_number, "head_sha": head_sha, "source_key": f"github-pr:{repository_id}:{pr_number}:{head_sha}"}
+    assignment = {"schema_version": 1, "kind": "github-pr-docs-impact-assignment", "identity": identity, "agent_skill": "developer-experience-techdocs", "evidence_bundle": {"head_sha": head_sha, "files": files, "proposal_identity": {"repository_id": repository_id, "repository": repository, "pr_number": pr_number, "base_sha": base_sha, "head_sha": head_sha, "head_repository_id": str(delivery.get("head_repository_id", repository_id)), "head_repository": str(delivery.get("head_repository", repository)), "base_ref": base_ref}}}
+    return worker.validate_assignment(assignment)
+
+
+def _model(record: dict[str, Any]) -> DocsReviewRun:
+    return DocsReviewRun(**{key: record.get(key) for key in ("identity", "state", "created_at", "deadline_at", "lease_until", "attempt", "conclusion")})
+
+
+def _record(transition: Transition, assignment: dict[str, Any], assignment_bytes: bytes, prior: dict[str, Any] | None = None) -> dict[str, Any]:
+    run = transition.run
+    pending_actions = list(transition.actions)
+    if prior and prior.get("state") == run.state and prior.get("pending_actions"):
+        pending_actions = list(prior["pending_actions"])
+    result = {"identity": run.identity, "state": run.state, "created_at": run.created_at, "deadline_at": run.deadline_at, "lease_until": run.lease_until, "attempt": run.attempt, "conclusion": run.conclusion, "assignment": assignment, "assignment_bytes": base64.b64encode(assignment_bytes).decode("ascii"), "external_id": f"docs-impact:{run.identity}", "pending_actions": pending_actions}
+    if prior and "candidate" in prior:
+        result["candidate"] = prior["candidate"]
+    # Projection state is durable intent/result evidence.  The generic runtime
+    # does not interpret it, but must not discard it while reconciling the
+    # lifecycle around an App crash or restart.
+    if prior:
+        for key in ("followup", "check"):
+            if key in prior:
+                result[key] = copy.deepcopy(prior[key])
+    return result
+
+
+def _perform(store: FileDocsReviewStore, adapter: DocsReviewAdapter, record: dict[str, Any]) -> None:
+    """Perform actions after their durable intent has been written, one at a time."""
+    while record["pending_actions"]:
+        action = record["pending_actions"][0]
+        action_record = copy.deepcopy(record)
+        adapter.perform(action, action_record)
+        # A trusted projection may durably attach its own intent/result record
+        # while performing an action. Keep that state when acknowledging the
+        # lifecycle action; otherwise this final save could erase crash
+        # recovery evidence written immediately before a remote mutation.
+        for key in ("followup", "check"):
+            if key in action_record:
+                record[key] = action_record[key]
+        for key in ("state", "conclusion"):
+            if key in action_record:
+                record[key] = action_record[key]
+        record["pending_actions"] = record["pending_actions"][1:]
+        store.save(record)
+
+
+def _normalize_assignment(value: dict[str, Any] | bytes) -> tuple[dict[str, Any], bytes]:
+    if isinstance(value, bytes):
+        return worker.load_assignment_bytes(value), value
+    assignment = worker.validate_assignment(value)
+    return assignment, json.dumps(assignment, sort_keys=True, separators=(",", ":")).encode()
+
+
+def _assignment_bytes(record: dict[str, Any]) -> bytes:
+    encoded = record.get("assignment_bytes")
+    if not isinstance(encoded, str):
+        raise ValueError("stored docs review run lacks original assignment bytes")
+    return base64.b64decode(encoded, validate=True)
+
+
+def _proven_assignment_bytes(record: dict[str, Any]) -> bytes:
+    """Prove byte evidence and persisted normalized assignment are identical."""
+    raw = _assignment_bytes(record)
+    from_bytes = worker.load_assignment_bytes(raw)
+    persisted = worker.validate_assignment(record.get("assignment"))
+    canonical_bytes = json.dumps(from_bytes, sort_keys=True, separators=(",", ":"))
+    canonical_persisted = json.dumps(persisted, sort_keys=True, separators=(",", ":"))
+    if canonical_bytes != canonical_persisted:
+        raise ValueError("assignment proof does not match persisted immutable evidence")
+    return raw
+
+
+def _legacy_record(record: dict[str, Any]) -> dict[str, Any]:
+    """Fail closed when an old record cannot prove its immutable assignment."""
+    failed = copy.deepcopy(record)
+    failed["state"] = "terminal"
+    failed["conclusion"] = "action_required"
+    failed["pending_actions"] = ["ensure_terminal_check"]
+    failed["operational_reason"] = "legacy immutable assignment proof is unavailable or mismatched"
+    return failed
+
+
+def _has_assignment_bytes(record: dict[str, Any]) -> bool:
+    try:
+        _proven_assignment_bytes(record)
+    except (ValueError, TypeError):
+        return False
+    return True
+
+
+def intake_delivery(store: FileDocsReviewStore, assignment: dict[str, Any] | bytes, adapter: DocsReviewAdapter, *, now: float, lease_seconds: float = 300, deadline_seconds: float = 1800, perform_actions: bool = True) -> dict[str, Any]:
+    assignment, assignment_bytes = _normalize_assignment(assignment)
+    identity = assignment["identity"]["source_key"]
+    with store.lock(identity):
+        prior = store.load(identity)
+        if prior is not None and not _has_assignment_bytes(prior):
+            record = _legacy_record(prior)
+            store.save(record)
+            if perform_actions:
+                _perform(store, adapter, record)
+            return record
+        if prior is not None and prior["assignment"] != assignment:
+            raise ValueError("different assignment for existing immutable review identity")
+        transition = begin(identity, now=now, existing=_model(prior) if prior else None, lease_seconds=lease_seconds, deadline_seconds=deadline_seconds)
+        record = _record(transition, assignment, _proven_assignment_bytes(prior) if prior else assignment_bytes, prior)
+        store.save(record)
+        if perform_actions:
+            _perform(store, adapter, record)
+        return record
+
+
+def accept_candidate(store: FileDocsReviewStore, envelope: dict[str, Any], adapter: DocsReviewAdapter, *, now: float) -> dict[str, Any]:
+    identity = str(((envelope.get("artifact") or {}).get("identity") or {}).get("source_key", ""))
+    with store.lock(identity):
+        record = store.load(identity)
+        if record is None:
+            return {"accepted": False, "reason": "unknown run"}
+        if not _has_assignment_bytes(record):
+            record = _legacy_record(record)
+            store.save(record)
+            _perform(store, adapter, record)
+            return {"accepted": False, "reason": "legacy record cannot validate candidate"}
+        normalized = worker.validate_final_candidate(_proven_assignment_bytes(record), envelope)
+        store.audit_candidate(identity, normalized, now)
+        if record["state"] in {"terminal", "stale"} or "candidate" in record:
+            transition = reconcile(_model(record), now=now, head_is_current=adapter.head_is_current(copy.deepcopy(record)))
+            record = _record(transition, record["assignment"], _proven_assignment_bytes(record), record)
+            store.save(record)
+            _perform(store, adapter, record)
+            return {"accepted": False, "reason": "terminal or duplicate"}
+        record["candidate"] = normalized
+        transition = reconcile(_model(record), now=now, head_is_current=adapter.head_is_current(copy.deepcopy(record)), candidate=Candidate(identity=identity, verdict=normalized["artifact"]["verdict"]))
+        record = _record(transition, record["assignment"], _proven_assignment_bytes(record), record)
+        store.save(record)
+        _perform(store, adapter, record)
+        return {"accepted": True, "run": record}
+
+
+def reconcile_pending(store: FileDocsReviewStore, adapter: DocsReviewAdapter, *, now: float, lease_seconds: float = 300) -> list[dict[str, Any]]:
+    reconciled: list[dict[str, Any]] = []
+    for listed in store.list_runs():
+        identity = listed["identity"]
+        with store.lock(identity):
+            prior = store.load(identity)
+            if prior is None:
+                continue
+            if not _has_assignment_bytes(prior):
+                record = _legacy_record(prior)
+                store.save(record)
+                _perform(store, adapter, record)
+                reconciled.append(record)
+                continue
+            candidate = prior.get("candidate")
+            value = Candidate(identity=prior["identity"], verdict=candidate["artifact"]["verdict"]) if candidate and prior["state"] not in {"terminal", "stale"} else None
+            transition = reconcile(_model(prior), now=now, head_is_current=adapter.head_is_current(copy.deepcopy(prior)), candidate=value, lease_seconds=lease_seconds)
+            record = _record(transition, prior["assignment"], _proven_assignment_bytes(prior), prior)
+            store.save(record)
+            _perform(store, adapter, record)
+            reconciled.append(record)
+    return reconciled

--- a/github/skills/developer-experience-techdocs/SKILL.md
+++ b/github/skills/developer-experience-techdocs/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: developer-experience-techdocs
+description: Create, edit, review, or audit developer-facing technical documentation. Use when documentation must explain APIs, CLIs, SDKs, integrations, configuration, troubleshooting, or developer workflows with verified claims and repository-native docs-as-code checks.
+---
+
+# Developer-experience technical documentation
+
+Write documentation that lets a developer complete a real task with confidence. Treat both developers and agents as readers: make the outcome, evidence, prerequisites, and next action easy to find without unstated context.
+
+## Choose the workflow
+
+- For a new page or substantial rewrite, read [page workflows](references/page-workflows.md).
+- For a focused edit, read the targeted-edit workflow in [page workflows](references/page-workflows.md).
+- For a review or audit, read the review workflow there.
+- When an audit finding may require a tracker issue, read [finding triage](references/finding-triage.md).
+- Before finalizing any documentation change, read [evidence and verification](references/evidence-and-verification.md).
+- For terminology, voice, structure, accessibility, or prose quality, read [editorial standard](references/editorial-standard.md).
+
+## Non-negotiable rules
+
+- Verify technical claims before writing them. Do not rely on training data for repository behavior.
+- Treat an issue, support thread, design, or request as evidence of a reader problem, not evidence that a behavior shipped.
+- Use exact public names for APIs, commands, flags, defaults, limits, and diagnostic surfaces.
+- If a claim cannot be verified, omit it or report the missing evidence or owner. Do not leave verification markers in completed docs.
+- Write for one primary reader task. Lead with the outcome and the supported happy path, then cover alternatives and failure modes that affect that task.
+- Preserve existing routes, anchors, terminology, and strong prose unless changing them solves a verified reader problem.
+- State unsupported boundaries directly. Do not present proposed, branch-only, or inferred behavior as released.
+- Classify every issue created from a documentation finding with exactly one controlled-vocabulary tag. Do not add severity labels.
+
+## Finish every change
+
+1. Re-read every changed page in full.
+2. Verify each new claim, command, example, default, and limitation against evidence.
+3. Search for affected links, terminology, and contradictory instructions.
+4. Discover and run the host repository's actual documentation checks.
+5. Report which checks passed and which verification could not be performed.

--- a/github/skills/developer-experience-techdocs/references/editorial-standard.md
+++ b/github/skills/developer-experience-techdocs/references/editorial-standard.md
@@ -1,0 +1,34 @@
+# Editorial standard
+
+## Apply style in the right order
+
+Follow the target project's terminology, information architecture, and style guidance first. Use the Google developer documentation style guide when project guidance is silent. Prefer clarity and consistent reader experience over mechanical rule-following.
+
+## Write for action and retrieval
+
+- Address the reader as `you` and use imperative verbs for procedures.
+- Prefer active voice, present tense, concrete nouns, and consistent public terms.
+- Use sentence-case headings unless the project convention differs.
+- Start sections with the answer or outcome; use a descriptive heading that names the task or concept.
+- Use descriptive link text. Do not use "click here" or make a reader infer where a link leads.
+- Repeat the full noun in key instructions instead of relying on ambiguous pronouns.
+- Use code formatting for literal commands, identifiers, flags, and values.
+
+## Write for a global and accessible audience
+
+- Prefer plain, direct language over idiom, metaphor, and unexplained jargon.
+- Use parallel structure in comparable lists and procedures.
+- Describe interface elements and non-text content accessibly; do not use images of code or terminal output as the only instruction.
+- Explain surprising link behavior, downloads, or context switches.
+
+## Avoid predictable documentation failures
+
+- Do not use promotional claims, filler, rhetorical questions, or generic reassurance.
+- Do not fabricate examples, outcomes, reactions, precision, or product opinions to sound natural.
+- Do not call a task easy, simple, quick, or obvious.
+- Do not use `we` unless naming a deliberate team action.
+- Do not hide limitations or uncertain release scope behind vague wording.
+
+## Primary reference
+
+- [Google developer documentation style guide](https://developers.google.com/style)

--- a/github/skills/developer-experience-techdocs/references/evidence-and-verification.md
+++ b/github/skills/developer-experience-techdocs/references/evidence-and-verification.md
@@ -1,0 +1,45 @@
+# Evidence and verification
+
+## Establish the evidence base
+
+Use this hierarchy, stopping when the claim is established:
+
+1. Current implementation, public types, and tests.
+2. Current CLI help, command implementation, and configuration schema.
+3. Existing published documentation and examples.
+4. Release notes, changelog, and the latest released artifact.
+5. Accepted design documents only as intent, never as shipped behavior.
+6. Issues, support reports, or conversations only to understand the reader problem.
+
+For docs-only changes, compare the branch with the latest public release before describing availability. For docs shipped alongside code, state that the documentation depends on the accompanying change.
+
+## Keep a claim ledger while working
+
+For each material claim, record the claim, its evidence, and release scope. Material claims include commands, flags, parameters, defaults, permissions, limits, compatibility, error behavior, and prerequisites. Remove claims that do not have support.
+
+Verify examples by running them when practical. Verify a CLI command from `--help` and the command implementation. Verify an API example from exported types and tests. Never repair an example by guessing an argument or output.
+
+## Run repository-native documentation checks
+
+Inspect the repository before selecting checks:
+
+- Read contributor documentation and docs-specific instructions.
+- Inspect package scripts, build configuration, and CI workflows.
+- Search for documentation build, link, lint, spelling, formatting, snippet, or example-validation commands.
+
+Run the relevant commands for changed documentation. If no dedicated documentation check exists, run the closest available repository validation and say that no docs-specific check was available. Do not add a toolchain merely to complete a documentation edit.
+
+## Final verification record
+
+In the handoff, state:
+
+- Claims verified and their evidence class.
+- Commands or examples exercised.
+- Documentation checks run and their results.
+- Any unavailable evidence, unrun check, or release-scope limitation.
+
+## Primary references
+
+- [Eve technical-writing workflow](https://github.com/vercel/eve/blob/main/.agents/skills/technical-writing/SKILL.md)
+- [Write the Docs: docs as code](https://www.writethedocs.org/guide/docs-as-code/)
+- [Write the Docs: testing documentation](https://www.writethedocs.org/guide/tools/testing/)

--- a/github/skills/developer-experience-techdocs/references/finding-triage.md
+++ b/github/skills/developer-experience-techdocs/references/finding-triage.md
@@ -1,0 +1,38 @@
+# Finding triage
+
+Use this workflow during a documentation audit or grooming pass when a verified finding needs follow-up beyond the current change. A direct documentation edit should not also create a duplicate issue unless the remaining work is independently actionable.
+
+## Controlled vocabulary
+
+Attach exactly one of these tags to every issue created from a documentation finding:
+
+| Tag | Verified state | Default action |
+| --- | --- | --- |
+| `documentation-gap` | Behavior exists but is not documented. | Create or expand documentation. |
+| `documentation-enhancement` | Behavior exists and is documented, but the reader task remains poorly served. | Improve the existing documentation. |
+| `capability-gap` | A real reader task is blocked because a needed capability does not exist and has no supported path. | Create a product or feature-gap issue. |
+| `documented-non-goal` | The capability does not exist and documentation explicitly excludes it with actionable guidance. | Do not create an issue by default. |
+| `documentation-defect` | Documentation claims support that verified behavior lacks. | Create a defect issue; correct documentation or implementation. |
+
+These tags describe disposition, not priority. Do not add a severity label or infer a severity value. If the repository requires a severity field, follow that repository rule without inventing an additional label.
+
+## Verify before classifying
+
+Classify only after verifying implementation, tests, CLI help, public types, and relevant documentation. Absence of documentation alone does not establish a `capability-gap`; there must be evidence of a blocked reader job and no supported alternative.
+
+If documentation says a capability is intentionally unsupported, classify it as `documented-non-goal`. If documentation says a capability is supported but implementation contradicts it, classify it as `documentation-defect`.
+
+## Create issues
+
+Before creating issues, discover the repository's tracker and confirm that the exact controlled-vocabulary tag exists. If a required tag is unavailable and you are not authorized to manage tracker labels, report the blocker instead of creating an untagged issue.
+
+Create one issue for each independently actionable, verified finding. Include:
+
+- The controlled-vocabulary tag and no severity label.
+- The reader job and observed impact.
+- The precise contrary evidence: implementation, test, CLI help, public type, or current documentation.
+- The expected outcome and acceptance signal.
+- For `capability-gap`, the attempted supported paths and why none works.
+- For `documentation-defect`, the inaccurate claim and whether documentation or implementation should change.
+
+Do not file an issue for an inference, a hypothetical feature, or a missing page without a blocked reader job. Link related issues rather than combining distinct reader jobs or fixes.

--- a/github/skills/developer-experience-techdocs/references/page-workflows.md
+++ b/github/skills/developer-experience-techdocs/references/page-workflows.md
@@ -1,0 +1,44 @@
+# Page workflows
+
+## New page or rewrite
+
+1. Identify the reader's job, prior knowledge, starting state, and success signal.
+2. Decide whether an existing page already owns that job. Prefer a focused addition over a duplicate guide.
+3. Gather evidence before outlining.
+4. Lead with what the reader can accomplish and the prerequisites.
+5. Show the supported happy path in executable order. Include imports, context, and expected outcomes where they prevent ambiguity.
+6. Add alternatives, constraints, and troubleshooting only where they change the reader's next action.
+7. Link related material descriptively, but include the critical fact locally so a retrieved section still works alone.
+
+Use one page for one primary job. Split a page when its reader goal, prerequisite set, or success signal changes.
+
+## Targeted edit
+
+1. Read the page and its local navigation context in full.
+2. Identify the reader problem and the exact claim or task step that needs change.
+3. Verify the changed claim against current evidence.
+4. Make the minimum effective edit. Preserve supported nuance, useful examples, anchors, and routes.
+5. Search for duplicate wording, dependent examples, and links affected by the change.
+
+Do not rewrite clear prose merely to impose a personal preference.
+
+## Review or audit
+
+Review in this order:
+
+1. Reader task: Can the intended reader identify the outcome, prerequisites, and success condition?
+2. Accuracy: Does each material technical claim have current evidence?
+3. Procedure: Are steps ordered, supported, and complete enough to execute?
+4. Boundaries: Are unsupported cases, limitations, and release scope clear?
+5. Retrieval: Can each section stand alone with precise nouns and descriptive links?
+6. Maintenance: Are terms, links, routes, examples, and docs checks consistent with the repository?
+
+Report findings with the reader impact, evidence, and a concrete next check. Do not present unverified inferences as defects.
+
+## Troubleshooting
+
+Use a symptom, a verified cause, and a next action. Avoid generic advice such as retrying, checking configuration, or contacting support unless the repository documents the condition and action.
+
+## Primary reference
+
+- [Eve technical-writing workflow](https://github.com/vercel/eve/blob/main/.agents/skills/technical-writing/SKILL.md)

--- a/github/tests/test_docs_pr_review_lifecycle.py
+++ b/github/tests/test_docs_pr_review_lifecycle.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import unittest
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+
+from github_docs_pr_review_lifecycle import (
+    Candidate,
+    begin,
+    reconcile,
+)
+
+
+class DocsPrReviewLifecycleTests(unittest.TestCase):
+    def test_duplicate_delivery_reuses_one_visible_run(self) -> None:
+        first = begin("42:7:head-a", now=100)
+        duplicate = begin("42:7:head-a", existing=first.run, now=101)
+
+        self.assertEqual(first.actions, ("ensure_check", "dispatch"))
+        self.assertEqual(duplicate.run, first.run)
+        self.assertEqual(duplicate.actions, ("ensure_check",))
+
+
+    def test_recovery_redispatches_an_expired_lease_without_another_check(self) -> None:
+        started = begin("42:7:head-a", now=100, lease_seconds=30)
+
+        recovered = reconcile(started.run, now=131, head_is_current=True)
+
+        self.assertEqual(recovered.run.attempt, 2)
+        self.assertEqual(recovered.run.state, "dispatched")
+        self.assertEqual(recovered.actions, ("dispatch",))
+
+
+    def test_late_candidate_does_not_reopen_an_expired_run(self) -> None:
+        started = begin("42:7:head-a", now=100, lease_seconds=30, deadline_seconds=60)
+        expired = reconcile(started.run, now=161, head_is_current=True)
+
+        late = reconcile(
+            expired.run,
+            now=162,
+            head_is_current=True,
+            candidate=Candidate(identity="42:7:head-a", verdict="docs-sufficient"),
+        )
+
+        self.assertEqual(expired.run.state, "terminal")
+        self.assertEqual(expired.run.conclusion, "action_required")
+        self.assertEqual(expired.actions, ("ensure_terminal_check",))
+        self.assertEqual(late.run, expired.run)
+        self.assertEqual(late.actions, ("ensure_terminal_check",))
+
+
+    def test_matching_candidate_completes_the_original_run_once(self) -> None:
+        started = begin("42:7:head-a", now=100)
+
+        completed = reconcile(
+            started.run,
+            now=101,
+            head_is_current=True,
+            candidate=Candidate(identity="42:7:head-a", verdict="no-impact"),
+        )
+        duplicate = reconcile(
+            completed.run,
+            now=102,
+            head_is_current=True,
+            candidate=Candidate(identity="42:7:head-a", verdict="no-impact"),
+        )
+
+        self.assertEqual(completed.run.state, "terminal")
+        self.assertEqual(completed.run.conclusion, "success")
+        self.assertEqual(completed.actions, ("ensure_terminal_check",))
+        self.assertEqual(duplicate.run, completed.run)
+        self.assertEqual(duplicate.actions, ("ensure_terminal_check",))
+
+    def test_changed_head_marks_the_old_run_stale_without_dispatching(self) -> None:
+        started = begin("42:7:head-a", now=100)
+
+        stale = reconcile(started.run, now=101, head_is_current=False)
+
+        self.assertEqual(stale.run.state, "stale")
+        self.assertEqual(stale.run.conclusion, "stale")
+        self.assertEqual(stale.actions, ("ensure_stale_check",))
+
+    def test_reconcile_reensures_a_waiting_visible_check_after_restart(self) -> None:
+        started = begin("42:7:head-a", now=100)
+
+        recovered = reconcile(started.run, now=101, head_is_current=True)
+
+        self.assertEqual(recovered.run, started.run)
+        self.assertEqual(recovered.actions, ("ensure_check",))

--- a/github/tests/test_github_intake_common.py
+++ b/github/tests/test_github_intake_common.py
@@ -7,6 +7,7 @@ import os
 import pathlib
 import tempfile
 import unittest
+from unittest import mock
 
 import sys
 
@@ -705,6 +706,18 @@ class GitHubIntakePublishIdentityTests(unittest.TestCase):
 
         self.assertEqual(result["status"], "error")
         self.assertIn("must match", result["detail"])
+
+    def test_find_check_run_follows_next_page_to_reuse_external_id(self) -> None:
+        first = {"check_runs": [{"id": str(number), "external_id": "other"} for number in range(100)]}
+        second = {"check_runs": [{"id": "99", "external_id": "docs-impact:target"}]}
+        with mock.patch.object(common, "create_installation_token", return_value="token"), mock.patch.object(
+            common, "github_api_request", side_effect=[first, second],
+        ) as requested:
+            found = common.find_check_run({}, "1", "allenday", "demo", "a" * 40, "docs-impact:target")
+
+        self.assertEqual(found, second["check_runs"][0])
+        self.assertEqual(requested.call_count, 2)
+        self.assertIn("page=2", requested.call_args_list[1].args[1])
 
 
 

--- a/github/tests/test_github_intake_docs_candidate_builder.py
+++ b/github/tests/test_github_intake_docs_candidate_builder.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+
+import github_intake_docs_candidate_builder as builder
+
+
+SHA = "a" * 40
+
+
+def assignment(head_sha: str = SHA) -> dict[str, object]:
+    return {"schema_version": 1, "kind": "github-pr-docs-impact-assignment", "identity": {"repository_id": "17", "repository": "allenday/demo", "pr_number": 9, "head_sha": head_sha, "source_key": f"github-pr:17:9:{head_sha}"}, "agent_skill": "developer-experience-techdocs", "evidence_bundle": {"head_sha": head_sha, "proposal_identity": {"repository_id": "17", "repository": "allenday/demo", "pr_number": 9, "base_sha": "b" * 40, "head_sha": head_sha, "head_repository_id": "17", "head_repository": "allenday/demo", "base_ref": "main"}, "files": [{"path": "docs/guide.md", "reference": f"github://allenday/demo/blob/{head_sha}/docs/guide.md", "patch": "@@ -1 +1 @@\n-old\n+new\n"}]}}
+
+
+def decision(head_sha: str) -> dict[str, object]:
+    source = assignment(head_sha)
+    return {"schema_version": 1, "kind": "github-pr-docs-impact-review", "identity": source["identity"], "agent_skill": source["agent_skill"], "verdict": "proposal-ready", "rationale": "Ready for a generated proposal.", "evidence": [{"path": "docs/guide.md", "evidence": f"github://allenday/demo/blob/{head_sha}/docs/guide.md"}], "confidence": 0.9, "proposal": None}
+
+
+class CandidateBuilderTests(unittest.TestCase):
+    def test_proposal_ready_review_receives_only_git_derived_proposal(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo = pathlib.Path(temp_dir)
+            subprocess.run(["git", "init", "--quiet", str(repo)], check=True)
+            (repo / "docs").mkdir()
+            (repo / "docs" / "guide.md").write_text("Old guidance.\n", encoding="utf-8")
+            subprocess.run(["git", "-C", str(repo), "add", "."], check=True)
+            subprocess.run(["git", "-C", str(repo), "-c", "user.name=test", "-c", "user.email=test@example.invalid", "commit", "--quiet", "-m", "base"], check=True)
+            head = subprocess.run(["git", "-C", str(repo), "rev-parse", "HEAD"], text=True, capture_output=True, check=True).stdout.strip()
+            (repo / "docs" / "guide.md").write_text("New guidance.\n", encoding="utf-8")
+            source = assignment(head)
+            review = {"schema_version": 1, "kind": "github-pr-docs-impact-review", "identity": source["identity"], "agent_skill": source["agent_skill"], "verdict": "proposal-ready", "rationale": "Ready for a generated proposal.", "evidence": [{"path": "docs/guide.md", "evidence": f"github://allenday/demo/blob/{head}/docs/guide.md"}], "confidence": 0.9, "proposal": None}
+            candidate = builder.build_candidate(json.dumps(source).encode(), repo, generated_at="2026-08-31T12:00:00Z", claims=[{"claim": "A claim.", "evidence": f"github://allenday/demo/blob/{head}/docs/guide.md", "release_scope": "unreleased"}], checks=[{"command": "true", "status": "passed", "explanation": "ok"}], review=review)
+            self.assertEqual(candidate["artifact"]["verdict"], "proposal-ready")
+            self.assertIn("diff --git", candidate["artifact"]["proposal"]["diff"])
+
+    def test_build_candidate_derives_a_docs_only_git_diff_and_binds_raw_assignment_digest(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo = pathlib.Path(temp_dir)
+            subprocess.run(["git", "init", "--quiet", str(repo)], check=True)
+            (repo / "docs").mkdir()
+            (repo / "docs" / "guide.md").write_text("Old guidance.\n", encoding="utf-8")
+            subprocess.run(["git", "-C", str(repo), "add", "."], check=True)
+            subprocess.run(["git", "-C", str(repo), "-c", "user.name=test", "-c", "user.email=test@example.invalid", "commit", "--quiet", "-m", "base"], check=True)
+            (repo / "docs" / "guide.md").write_text("New guidance.\n", encoding="utf-8")
+            head = subprocess.run(["git", "-C", str(repo), "rev-parse", "HEAD"], text=True, capture_output=True, check=True).stdout.strip()
+            raw = json.dumps(assignment(head), separators=(",", ":")).encode()
+            envelope = builder.build_candidate(raw, repo, generated_at="2026-08-31T12:00:00Z", claims=[{"claim": "The guide documents the workflow.", "evidence": f"github://allenday/demo/blob/{head}/docs/guide.md", "release_scope": "unreleased"}], checks=[{"command": "make docs-check", "status": "passed", "explanation": "Documentation checks passed."}], review=decision(head))
+            self.assertEqual(envelope["artifact"]["kind"], "github-pr-docs-impact-review")
+            self.assertEqual(envelope["snapshot_sha256"], hashlib.sha256(raw).hexdigest())
+            self.assertIn("diff --git a/docs/guide.md b/docs/guide.md", envelope["artifact"]["proposal"]["diff"])
+            self.assertEqual(envelope["artifact"]["proposal"]["files"], [{"path": "docs/guide.md", "sha256": envelope["artifact"]["proposal"]["files"][0]["sha256"]}])
+
+    def test_builder_rejects_a_checkout_whose_head_is_not_the_assigned_sha(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo = pathlib.Path(temp_dir)
+            subprocess.run(["git", "init", "--quiet", str(repo)], check=True)
+            (repo / "docs").mkdir()
+            (repo / "docs" / "guide.md").write_text("Old guidance.\n", encoding="utf-8")
+            subprocess.run(["git", "-C", str(repo), "add", "."], check=True)
+            subprocess.run(["git", "-C", str(repo), "-c", "user.name=test", "-c", "user.email=test@example.invalid", "commit", "--quiet", "-m", "base"], check=True)
+            with self.assertRaisesRegex(ValueError, "HEAD"):
+                builder.build_candidate(json.dumps(assignment()).encode(), repo, generated_at="2026-08-31T12:00:00Z", claims=[{"claim": "A claim.", "evidence": f"github://allenday/demo/blob/{SHA}/docs/guide.md", "release_scope": "unreleased"}], checks=[{"command": "true", "status": "passed", "explanation": "ok"}], review=decision(SHA))
+
+    def test_build_candidate_rejects_a_non_documentation_git_change(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo = pathlib.Path(temp_dir)
+            subprocess.run(["git", "init", "--quiet", str(repo)], check=True)
+            (repo / "app.py").write_text("before\n", encoding="utf-8")
+            subprocess.run(["git", "-C", str(repo), "add", "."], check=True)
+            subprocess.run(["git", "-C", str(repo), "-c", "user.name=test", "-c", "user.email=test@example.invalid", "commit", "--quiet", "-m", "base"], check=True)
+            (repo / "app.py").write_text("after\n", encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "documentation path"):
+                head = subprocess.run(["git", "-C", str(repo), "rev-parse", "HEAD"], text=True, capture_output=True, check=True).stdout.strip()
+                builder.build_candidate(json.dumps(assignment(head)).encode(), repo, generated_at="2026-08-31T12:00:00Z", claims=[{"claim": "A claim.", "evidence": f"github://allenday/demo/blob/{head}/docs/guide.md", "release_scope": "unreleased"}], checks=[{"command": "true", "status": "passed", "explanation": "ok"}], review=decision(head))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/github/tests/test_github_intake_docs_impact.py
+++ b/github/tests/test_github_intake_docs_impact.py
@@ -1,0 +1,343 @@
+from __future__ import annotations
+
+import pathlib
+import sys
+import unittest
+import hashlib
+import json
+import tempfile
+from unittest import mock
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+
+import github_intake_docs_impact as impact
+import github_intake_docs_review_runtime as runtime
+
+
+SHA = "a" * 40
+
+
+def review() -> dict[str, object]:
+    diff = """diff --git a/docs/guide.md b/docs/guide.md
+index 1111111..2222222 100644
+--- a/docs/guide.md
++++ b/docs/guide.md
+@@ -1 +1 @@
+-Old guidance.
++New guidance.
+"""
+    proposal = {
+        "schema_version": 1, "status": "proposed", "generated_at": "2026-08-31T12:00:00Z",
+        "identity": {"repository_id": "17", "repository": "allenday/demo", "pr_number": 9, "base_sha": "b" * 40, "head_sha": SHA, "head_repository_id": "17", "head_repository": "allenday/demo", "base_ref": "main"},
+        "patch_sha256": hashlib.sha256(diff.encode()).hexdigest(), "diff": diff,
+        "files": [{"path": "docs/guide.md", "sha256": "c" * 64}],
+        "claims": [{"claim": "The guide documents the workflow.", "evidence": f"github://allenday/demo/blob/{SHA}/README.md", "release_scope": "unreleased"}],
+        "checks": [{"command": "make docs-check", "status": "passed", "explanation": "Documentation checks passed."}],
+    }
+    return {"schema_version": 1, "kind": "github-pr-docs-impact-review", "identity": {"repository_id": "17", "repository": "allenday/demo", "pr_number": 9, "head_sha": SHA, "source_key": f"github-pr:17:9:{SHA}"}, "agent_skill": "developer-experience-techdocs", "verdict": "proposal-ready", "rationale": "A bounded documentation patch is ready.", "evidence": [{"path": "docs/guide.md", "evidence": f"github://allenday/demo/blob/{SHA}/docs/guide.md"}], "confidence": 0.9, "proposal": proposal}
+
+
+def pull_request(*, head_repository: str = "allenday/demo", head_repository_id: str = "17", head_ref: str = "feature/docs", head_sha: str = SHA) -> dict[str, object]:
+    return {
+        "number": 9,
+        "head": {"sha": head_sha, "ref": head_ref, "repo": {"id": head_repository_id, "full_name": head_repository}},
+        "base": {"sha": "b" * 40, "ref": "main", "repo": {"id": "17", "full_name": "allenday/demo"}},
+    }
+
+
+class DocsImpactProjectionTests(unittest.TestCase):
+    def test_valid_same_repository_review_gets_an_app_owned_stacked_plan(self) -> None:
+        plan = impact.followup_pr_plan(pull_request(), review())
+
+        self.assertEqual(plan, {
+            "repository": "allenday/demo",
+            "branch": "gas-city/docs-9-" + review()["proposal"]["patch_sha256"][:12],
+            "base": "feature/docs",
+            "head_sha": SHA,
+        })
+
+    def test_fork_wrong_identity_or_stale_review_cannot_get_a_followup_plan(self) -> None:
+        wrong_identity = review()
+        wrong_identity["proposal"]["identity"]["base_ref"] = "release"
+        for current, candidate in (
+            (pull_request(head_repository="fork/demo", head_repository_id="99"), review()),
+            (pull_request(), wrong_identity),
+            (pull_request(head_sha="c" * 40), review()),
+        ):
+            with self.subTest(current=current):
+                self.assertIsNone(impact.followup_pr_plan(current, candidate))
+
+    def test_compact_check_never_contains_a_diff_or_internal_dashboard_link(self) -> None:
+        output = impact.compact_check_output(review(), {"url": "https://github.com/allenday/demo/pull/10", "number": "10"})
+
+        self.assertEqual(output["title"], "Documentation impact: follow-up ready")
+        self.assertIn("#10", output["summary"])
+        self.assertNotIn("diff --git", output["summary"])
+        self.assertNotIn("dashboard", output["summary"].lower())
+        self.assertNotIn("gas-city", output["summary"].lower())
+
+    def test_followup_gateway_finds_a_marker_on_a_later_page(self) -> None:
+        gateway = impact.GitHubAppProjectionGateway({"slug": "gas-city"}, "1")
+        pages = [
+            [{"number": 1, "html_url": "https://github.com/allenday/demo/pull/1", "body": "other"}],
+            [{"number": 10, "html_url": "https://github.com/allenday/demo/pull/10", "body": "<!-- marker -->", "head": {"ref": "gas-city/docs-9-deadbeef", "repo": {"full_name": "allenday/demo"}, "user": {"login": "gas-city[bot]"}}, "base": {"repo": {"full_name": "allenday/demo"}}}],
+        ]
+        with mock.patch.object(impact.common, "create_installation_token", return_value="token"), mock.patch.object(impact.common, "github_api_paginated_list_request", return_value=[item for page in pages for item in page]) as listed:
+            found = gateway.find_followup("allenday/demo", "gas-city/docs-9-deadbeef", "marker")
+
+        self.assertEqual(found, {"number": "10", "url": "https://github.com/allenday/demo/pull/10"})
+        self.assertTrue(listed.called)
+
+    def test_forged_contributor_marker_and_prefix_is_never_adopted_or_closed(self) -> None:
+        gateway = impact.GitHubAppProjectionGateway({"slug": "gas-city"}, "1")
+        forged = {
+            "number": 10, "html_url": "https://github.com/allenday/demo/pull/10", "body": "<!-- marker -->",
+            "head": {"ref": "gas-city/docs-9-deadbeef", "repo": {"full_name": "allenday/demo"}, "user": {"login": "contributor"}},
+            "base": {"repo": {"full_name": "allenday/demo"}},
+        }
+        with mock.patch.object(impact.common, "create_installation_token", return_value="token"), mock.patch.object(impact.common, "github_api_paginated_list_request", return_value=[forged]):
+            self.assertIsNone(gateway.find_followup("allenday/demo", "gas-city/docs-9-deadbeef", "marker"))
+        with mock.patch.object(impact.common, "create_installation_token", return_value="token"), mock.patch.object(impact.common, "github_api_request", return_value=forged) as requested:
+            with self.assertRaisesRegex(impact.common.GitHubAPIError, "owned"):
+                gateway.close_followup("allenday/demo", "10", "gas-city/docs-9-deadbeef", "marker")
+
+        self.assertEqual(requested.call_count, 1)
+
+    def test_bot_followup_with_wrong_branch_or_marker_substring_is_never_owned(self) -> None:
+        gateway = impact.GitHubAppProjectionGateway({"slug": "gas-city"}, "1")
+        expected_branch = "gas-city/docs-9-deadbeef"
+        def pull(*, branch: str, body: str) -> dict[str, object]:
+            return {
+                "number": 10, "html_url": "https://github.com/allenday/demo/pull/10", "body": body,
+                "head": {"ref": branch, "repo": {"full_name": "allenday/demo"}, "user": {"login": "gas-city[bot]"}},
+                "base": {"repo": {"full_name": "allenday/demo"}},
+            }
+        wrong_branch = pull(branch="gas-city/docs-9-other", body="<!-- marker -->")
+        substring = pull(branch=expected_branch, body="<!-- marker-extra -->")
+        with mock.patch.object(impact.common, "create_installation_token", return_value="token"), mock.patch.object(impact.common, "github_api_paginated_list_request", side_effect=[[wrong_branch], [substring]]):
+            self.assertIsNone(gateway.find_followup("allenday/demo", expected_branch, "marker"))
+            self.assertIsNone(gateway.find_followup("allenday/demo", expected_branch, "marker"))
+        with mock.patch.object(impact.common, "create_installation_token", return_value="token"), mock.patch.object(impact.common, "github_api_request", return_value=wrong_branch) as requested:
+            with self.assertRaisesRegex(impact.common.GitHubAPIError, "owned"):
+                gateway.close_followup("allenday/demo", "10", expected_branch, "marker")
+        self.assertEqual(requested.call_count, 1)
+
+    def test_wrong_repo_duplicate_or_substring_marker_never_authorizes_adoption_or_close(self) -> None:
+        gateway = impact.GitHubAppProjectionGateway({"slug": "gas-city"}, "1")
+        branch, marker = "gas-city/docs-9-deadbeef", "marker"
+        def pull(*, repository: str = "allenday/demo", body: str = "<!-- marker -->") -> dict[str, object]:
+            return {"number": 10, "html_url": "https://github.com/allenday/demo/pull/10", "body": body, "head": {"ref": branch, "repo": {"full_name": repository}, "user": {"login": "gas-city[bot]"}}, "base": {"repo": {"full_name": "allenday/demo"}}}
+        cases = (pull(repository="fork/demo"), pull(body="<!-- marker -->\n<!-- marker -->"), pull(body="<!-- marker-extra -->"))
+        with mock.patch.object(impact.common, "create_installation_token", return_value="token"), mock.patch.object(impact.common, "github_api_paginated_list_request", side_effect=[[case] for case in cases]):
+            for _ in cases:
+                self.assertIsNone(gateway.find_followup("allenday/demo", branch, marker))
+        with mock.patch.object(impact.common, "create_installation_token", return_value="token"), mock.patch.object(impact.common, "github_api_request", return_value=cases[-1]) as requested:
+            with self.assertRaisesRegex(impact.common.GitHubAPIError, "owned"):
+                gateway.close_followup("allenday/demo", "10", branch, marker)
+        self.assertEqual(requested.call_count, 1)
+
+    def test_paginated_discovery_reads_the_second_page_before_deciding(self) -> None:
+        first = [{"number": number} for number in range(100)]
+        second = [{"number": 10, "html_url": "https://github.com/allenday/demo/pull/10", "body": "<!-- marker -->"}]
+        with mock.patch.object(impact.common, "github_api_list_request", side_effect=[first, second]) as listed:
+            values = impact.common.github_api_paginated_list_request("GET", "/repos/allenday/demo/pulls?state=all", bearer_token="token")
+
+        self.assertEqual(values[-1]["number"], 10)
+        self.assertEqual(listed.call_count, 2)
+
+    def test_later_page_check_is_updated_without_a_duplicate_post(self) -> None:
+        gateway = impact.GitHubAppProjectionGateway({}, "1")
+        run = {"external_id": "docs-impact:run", "assignment": {"identity": review()["identity"]}}
+        output = {"title": "Documentation impact: action required", "summary": "Act."}
+        with mock.patch.object(impact.common, "get_pull_request", return_value=pull_request()), mock.patch.object(impact.common, "find_check_run", return_value={"id": "99", "external_id": "docs-impact:run"}), mock.patch.object(impact.common, "update_check_run", return_value={"id": "99"}) as updated, mock.patch.object(impact.common, "create_check_run", side_effect=AssertionError("must not create a duplicate Check Run")):
+            gateway.ensure_check(run, "action_required", output)
+
+        updated.assert_called_once()
+
+    def test_terminal_check_race_is_rendered_stale_without_creating_followup(self) -> None:
+        class Gateway:
+            def __init__(self) -> None: self.calls = 0; self.check = None
+            def pull_request(self, run: dict[str, object]) -> dict[str, object]:
+                self.calls += 1
+                return pull_request() if self.calls == 1 else pull_request(head_sha="c" * 40)
+            def find_followup(self, *args: object) -> dict[str, str]: return {"number": "10", "url": "https://github.com/allenday/demo/pull/10"}
+            def branch_exists(self, *args: object) -> bool: raise AssertionError("must not create followup")
+            def branch_matches(self, *args: object) -> bool: raise AssertionError("must not create followup")
+            def create_branch(self, *args: object) -> str: raise AssertionError("must not create followup")
+            def create_followup(self, *args: object) -> dict[str, str]: raise AssertionError("must not create followup")
+            def ensure_check(self, run: dict[str, object], conclusion: str, output: dict[str, str]) -> None: self.check = (conclusion, output)
+
+        with tempfile.TemporaryDirectory() as directory:
+            gateway = Gateway()
+            run = {"identity": "run", "external_id": "docs-impact:run", "conclusion": "action_required", "assignment": {"identity": review()["identity"]}, "candidate": {"artifact": review()}}
+            impact.AppProjection(runtime.FileDocsReviewStore(directory), gateway).perform("ensure_terminal_check", run)
+
+        self.assertEqual(gateway.check[0], "action_required")
+        self.assertEqual(gateway.check[1]["title"], "Documentation impact: stale revision")
+
+    def test_concrete_gateway_rechecks_head_before_followup_post(self) -> None:
+        gateway = impact.GitHubAppProjectionGateway({}, "1")
+        with mock.patch.object(impact.common, "get_pull_request", return_value=pull_request(head_sha="c" * 40)), mock.patch.object(impact.common, "create_pull_request", side_effect=AssertionError("must not POST a stale followup")):
+            with self.assertRaisesRegex(impact.common.GitHubAPIError, "changed"):
+                gateway.create_followup("allenday/demo", "gas-city/docs-9-deadbeef", "feature/docs", "marker", review())
+
+    def test_source_race_after_terminal_check_closes_only_the_marker_followup(self) -> None:
+        class Gateway:
+            def __init__(self) -> None: self.head_reads = 0; self.closed: list[tuple[str, str, str]] = []; self.checks: list[dict[str, str]] = []
+            def pull_request(self, run: dict[str, object]) -> dict[str, object]:
+                self.head_reads += 1
+                return pull_request() if self.head_reads < 3 else pull_request(head_sha="c" * 40)
+            def find_followup(self, *args: object) -> dict[str, str]: return {"number": "10", "url": "https://github.com/allenday/demo/pull/10"}
+            def branch_exists(self, *args: object) -> bool: raise AssertionError("existing PR must be reused")
+            def branch_matches(self, *args: object) -> bool: raise AssertionError("existing PR must be reused")
+            def create_branch(self, *args: object) -> str: raise AssertionError("existing PR must be reused")
+            def create_followup(self, *args: object) -> dict[str, str]: raise AssertionError("existing PR must be reused")
+            def close_followup(self, repository: str, number: str, branch: str, marker: str) -> None: self.closed.append((repository, number, marker))
+            def ensure_check(self, run: dict[str, object], conclusion: str, output: dict[str, str]) -> None: self.checks.append(output)
+
+        with tempfile.TemporaryDirectory() as directory:
+            gateway = Gateway()
+            run = {"identity": "run", "external_id": "docs-impact:run", "conclusion": "action_required", "assignment": {"identity": review()["identity"]}, "candidate": {"artifact": review()}}
+            impact.AppProjection(runtime.FileDocsReviewStore(directory), gateway).perform("ensure_terminal_check", run)
+
+        self.assertEqual(run["state"], "stale")
+        self.assertEqual(run["conclusion"], "action_required")
+        self.assertEqual([number for _, number, _ in gateway.closed], ["10"])
+        self.assertEqual(gateway.checks[-1]["title"], "Documentation impact: stale revision")
+
+    def test_source_race_after_pr_creation_closes_that_followup(self) -> None:
+        class Gateway:
+            def __init__(self) -> None: self.head_reads = 0; self.closed: list[str] = []
+            def pull_request(self, run: dict[str, object]) -> dict[str, object]:
+                self.head_reads += 1
+                return pull_request() if self.head_reads < 3 else pull_request(head_sha="c" * 40)
+            def find_followup(self, *args: object) -> None: return None
+            def branch_exists(self, *args: object) -> bool: return True
+            def branch_matches(self, *args: object) -> bool: return True
+            def create_branch(self, *args: object) -> str: raise AssertionError("must reuse branch")
+            def create_followup(self, *args: object) -> dict[str, str]: return {"number": "10", "url": "https://github.com/allenday/demo/pull/10"}
+            def close_followup(self, repository: str, number: str, branch: str, marker: str) -> None: self.closed.append(number)
+            def ensure_check(self, run: dict[str, object], conclusion: str, output: dict[str, str]) -> None: pass
+
+        with tempfile.TemporaryDirectory() as directory:
+            gateway = Gateway()
+            run = {"identity": "run", "external_id": "docs-impact:run", "conclusion": "action_required", "assignment": {"identity": review()["identity"]}, "candidate": {"artifact": review()}, "followup": {"state": "branch-created", "commit_sha": "d" * 40}}
+            impact.AppProjection(runtime.FileDocsReviewStore(directory), gateway).perform("ensure_terminal_check", run)
+
+        self.assertEqual(run["state"], "stale")
+        self.assertEqual(gateway.closed, ["10"])
+
+    def test_followup_failure_completes_action_required_check_instead_of_escaping(self) -> None:
+        class FailingGateway:
+            def pull_request(self, run: dict[str, object]) -> dict[str, object]:
+                return pull_request()
+            def find_followup(self, *args: object) -> None: return None
+            def branch_exists(self, *args: object) -> bool: return False
+            def branch_matches(self, *args: object) -> bool: return False
+            def create_branch(self, *args: object) -> str: raise RuntimeError("stale at push")
+            def create_followup(self, *args: object) -> dict[str, str]: raise AssertionError("unreachable")
+            def ensure_check(self, run: dict[str, object], conclusion: str, output: dict[str, str]) -> None:
+                self.check = (conclusion, output)
+
+        with tempfile.TemporaryDirectory() as directory:
+            gateway = FailingGateway()
+            adapter = impact.AppProjection(runtime.FileDocsReviewStore(directory), gateway)
+            run = {"identity": "run", "external_id": "docs-impact:run", "conclusion": "action_required", "assignment": {"identity": review()["identity"]}, "candidate": {"artifact": review()}}
+
+            adapter.perform("ensure_terminal_check", run)
+
+        self.assertEqual(gateway.check[0], "action_required")
+        self.assertEqual(gateway.check[1]["title"], "Documentation impact: action required")
+
+    def test_pr_timeout_is_terminal_then_retry_reuses_the_created_followup(self) -> None:
+        class Gateway:
+            def __init__(self) -> None:
+                self.created: list[dict[str, str]] = []
+                self.create_calls = 0
+                self.checks: list[str] = []
+            def pull_request(self, run: dict[str, object]) -> dict[str, object]: return pull_request()
+            def find_followup(self, repository: str, branch: str, marker: str) -> dict[str, str] | None:
+                return next((item for item in self.created if item["marker"] == marker), None)
+            def branch_exists(self, *args: object) -> bool: return True
+            def branch_matches(self, *args: object) -> bool: return True
+            def create_branch(self, *args: object) -> str: raise AssertionError("must reuse existing App branch")
+            def create_followup(self, repository: str, branch: str, base: str, marker: str, review: dict[str, object]) -> dict[str, str]:
+                self.create_calls += 1
+                created = {"number": "10", "url": "https://github.com/allenday/demo/pull/10", "marker": marker}
+                self.created.append(created)
+                raise RuntimeError("request timed out after GitHub created the PR")
+            def ensure_check(self, run: dict[str, object], conclusion: str, output: dict[str, str]) -> None: self.checks.append(conclusion)
+
+        with tempfile.TemporaryDirectory() as directory:
+            gateway = Gateway()
+            adapter = impact.AppProjection(runtime.FileDocsReviewStore(directory), gateway)
+            run = {"identity": "run", "external_id": "docs-impact:run", "conclusion": "action_required", "assignment": {"identity": review()["identity"]}, "candidate": {"artifact": review()}, "followup": {"state": "branch-created", "commit_sha": "d" * 40}}
+            adapter.perform("ensure_terminal_check", run)
+            adapter.perform("ensure_terminal_check", run)
+
+        self.assertEqual(gateway.create_calls, 1)
+        self.assertEqual(gateway.checks, ["action_required", "action_required"])
+
+    def test_retry_adopts_a_branch_created_before_a_crash_and_opens_one_followup(self) -> None:
+        class Gateway:
+            def __init__(self) -> None:
+                self.branch_created = False
+                self.branches: list[str] = []
+                self.crash_after_branch = True
+                self.pull_requests: list[dict[str, str]] = []
+                self.checks: list[dict[str, object]] = []
+
+            def pull_request(self, run: dict[str, object]) -> dict[str, object]:
+                return pull_request()
+
+            def find_followup(self, repository: str, branch: str, marker: str) -> dict[str, str] | None:
+                return next((item for item in self.pull_requests if item["marker"] == marker), None)
+
+            def branch_exists(self, repository: str, branch: str) -> bool:
+                return self.branch_created
+
+            def branch_matches(self, repository: str, branch: str, marker: str, commit_sha: str = "") -> bool:
+                return self.branch_created
+
+            def create_branch(self, repository: str, branch: str, head_sha: str, review: dict[str, object], marker: str, before_push: object) -> str:
+                self.branch_created = True
+                self.branches.append(branch)
+                before_push("d" * 40)
+                if self.crash_after_branch:
+                    self.crash_after_branch = False
+                    raise RuntimeError("simulated crash after branch creation")
+                return "d" * 40
+
+            def create_followup(self, repository: str, branch: str, base: str, marker: str, review: dict[str, object]) -> dict[str, str]:
+                created = {"number": "10", "url": "https://github.com/allenday/demo/pull/10", "marker": marker}
+                self.pull_requests.append(created)
+                return created
+
+            def ensure_check(self, run: dict[str, object], conclusion: str, output: dict[str, str]) -> None:
+                self.checks.append({"conclusion": conclusion, "output": output})
+
+        with tempfile.TemporaryDirectory() as directory:
+            store = runtime.FileDocsReviewStore(directory)
+            gateway = Gateway()
+            adapter = impact.AppProjection(store, gateway)
+            assignment = {"schema_version": 1, "kind": "github-pr-docs-impact-assignment", "identity": review()["identity"], "agent_skill": "developer-experience-techdocs", "evidence_bundle": {"head_sha": SHA, "proposal_identity": review()["proposal"]["identity"], "files": [{"path": "docs/guide.md", "reference": f"github://allenday/demo/blob/{SHA}/docs/guide.md", "patch": "@@ -1 +1 @@\n-old\n+new\n"}]}}
+            runtime.intake_delivery(store, assignment, adapter, now=100)
+            envelope = {"schema_version": 1, "snapshot_sha256": hashlib.sha256(json.dumps(assignment, sort_keys=True, separators=(",", ":")).encode()).hexdigest(), "artifact": review()}
+
+            accepted = runtime.accept_candidate(store, envelope, adapter, now=101)
+            self.assertTrue(accepted["accepted"])
+            persisted = store.load(str(review()["identity"]["source_key"]))
+            self.assertEqual(persisted["followup"]["state"], "action-required")
+            self.assertEqual(persisted["followup"]["commit_sha"], "d" * 40)
+
+            runtime.reconcile_pending(store, adapter, now=102)
+            runtime.reconcile_pending(store, adapter, now=103)
+
+            self.assertEqual(len(gateway.pull_requests), 1)
+            self.assertEqual(gateway.branches, ["gas-city/docs-9-" + review()["proposal"]["patch_sha256"][:12]])
+            self.assertEqual(store.load(str(review()["identity"]["source_key"]))["followup"]["state"], "created")
+            self.assertEqual(gateway.checks[-1]["conclusion"], "action_required")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/github/tests/test_github_intake_docs_patch.py
+++ b/github/tests/test_github_intake_docs_patch.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import pathlib
+import sys
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+
+import github_intake_docs_patch as docs_patch
+
+
+SHA = "a" * 40
+BASE = "b" * 40
+DIFF = """diff --git a/docs/guide.md b/docs/guide.md
+index 1111111..2222222 100644
+--- a/docs/guide.md
++++ b/docs/guide.md
+@@ -1 +1 @@
+-Old guidance.
++New guidance.
+"""
+
+
+def proposal() -> dict[str, object]:
+    return {"schema_version": 1, "status": "proposed", "generated_at": "2026-08-31T12:00:00Z", "identity": {"repository_id": "17", "repository": "allenday/demo", "pr_number": 9, "base_sha": BASE, "head_sha": SHA, "head_repository_id": "17", "head_repository": "allenday/demo", "base_ref": "main"}, "patch_sha256": hashlib.sha256(DIFF.encode()).hexdigest(), "diff": DIFF, "files": [{"path": "docs/guide.md", "sha256": "c" * 64}], "claims": [{"claim": "The guide documents the workflow.", "evidence": f"github://allenday/demo/blob/{SHA}/README.md", "release_scope": "unreleased"}], "checks": [{"command": "make docs-check", "status": "passed", "explanation": "Documentation checks passed."}]}
+
+
+def review() -> dict[str, object]:
+    return {"schema_version": 1, "kind": "github-pr-docs-impact-review", "identity": {"repository_id": "17", "repository": "allenday/demo", "pr_number": 9, "head_sha": SHA, "source_key": f"github-pr:17:9:{SHA}"}, "agent_skill": "developer-experience-techdocs", "verdict": "proposal-ready", "rationale": "A bounded documentation patch is ready.", "evidence": [{"path": "docs/guide.md", "evidence": f"github://allenday/demo/blob/{SHA}/docs/guide.md"}], "confidence": 0.9, "proposal": proposal()}
+
+
+class DocsPatchTests(unittest.TestCase):
+    def test_review_decision_accepts_every_non_proposal_verdict(self) -> None:
+        for verdict in ("no-impact", "docs-sufficient", "docs-change-required", "inconclusive"):
+            with self.subTest(verdict=verdict):
+                value = review()
+                value["verdict"] = verdict
+                value["proposal"] = None
+                self.assertEqual(docs_patch.validate_review_decision(value)["verdict"], verdict)
+    def test_proposal_ready_requires_a_complete_proposal(self) -> None:
+        value = review()
+        value["proposal"] = None
+        with self.assertRaisesRegex(ValueError, "proposal-ready"):
+            docs_patch.validate_agent_review(value)
+
+    def test_review_rejects_proposal_identity_that_is_not_exactly_the_review_source(self) -> None:
+        value = review()
+        value["proposal"]["identity"]["repository"] = "allenday/other"
+        with self.assertRaisesRegex(ValueError, "proposal identity"):
+            docs_patch.validate_agent_review(value)
+
+    def test_review_digest_covers_canonical_proposal(self) -> None:
+        validated = docs_patch.validate_agent_review(review())
+        changed = copy.deepcopy(validated)
+        changed["proposal"]["claims"][0]["claim"] = "Changed after validation."
+        changed["proposal"].pop("artifact_sha256")
+        with self.assertRaisesRegex(ValueError, "review_sha256"):
+            docs_patch.validate_agent_review(changed)
+
+    def test_artifact_rejects_gitlink_and_boolean_integral_fields(self) -> None:
+        gitlink = proposal()
+        gitlink["diff"] = DIFF.replace("index 1111111..2222222 100644", "new file mode 160000\nindex 1111111..2222222 160000")
+        gitlink["patch_sha256"] = hashlib.sha256(gitlink["diff"].encode()).hexdigest()
+        with self.assertRaisesRegex(ValueError, "gitlink"):
+            docs_patch.validate_artifact(gitlink)
+        for field, value in (("schema_version", True), ("pr_number", True)):
+            malformed = proposal()
+            if field == "schema_version":
+                malformed[field] = value
+            else:
+                malformed["identity"][field] = value
+            with self.subTest(field=field), self.assertRaises(ValueError):
+                docs_patch.validate_artifact(malformed)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/github/tests/test_github_intake_docs_patch_worker.py
+++ b/github/tests/test_github_intake_docs_patch_worker.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import json
+import pathlib
+import subprocess
+import sys
+import tempfile
+import shlex
+import textwrap
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+
+import github_intake_docs_patch_worker as worker
+
+
+SHA = "a" * 40
+
+
+def assignment() -> dict[str, object]:
+    return {"schema_version": 1, "kind": "github-pr-docs-impact-assignment", "identity": {"repository_id": "17", "repository": "allenday/demo", "pr_number": 9, "head_sha": SHA, "source_key": f"github-pr:17:9:{SHA}"}, "agent_skill": "developer-experience-techdocs", "evidence_bundle": {"head_sha": SHA, "proposal_identity": {"repository_id": "17", "repository": "allenday/demo", "pr_number": 9, "base_sha": "b" * 40, "head_sha": SHA, "head_repository_id": "17", "head_repository": "allenday/demo", "base_ref": "main"}, "files": [{"path": "docs/guide.md", "reference": f"github://allenday/demo/blob/{SHA}/docs/guide.md", "patch": "@@ -1 +1 @@\n-old\n+new\n"}]}}
+
+
+class DocsPatchWorkerTests(unittest.TestCase):
+    def test_worker_cli_writes_and_reports_a_normal_final_candidate(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = pathlib.Path(temp_dir)
+            raw = json.dumps(assignment()).encode()
+            assignment_file, artifact = root / "assignment.json", root / "artifact.json"
+            assignment_file.write_bytes(raw)
+            skill = root / "skill"; skill.mkdir(); (skill / "SKILL.md").write_text("skill", encoding="utf-8")
+            adapter = root / "adapter.py"
+            adapter.write_text(textwrap.dedent("""\
+                import json, sys
+                assignment = json.load(sys.stdin)
+                h = assignment['identity']['head_sha']
+                json.dump({'schema_version': 1, 'kind': 'github-pr-docs-impact-review', 'identity': assignment['identity'], 'agent_skill': assignment['agent_skill'], 'verdict': 'docs-sufficient', 'rationale': 'Sufficient.', 'evidence': [{'path': 'docs/guide.md', 'evidence': 'github://' + assignment['identity']['repository'] + '/blob/' + h + '/docs/guide.md'}], 'confidence': 0.9, 'proposal': None}, sys.stdout)
+            """), encoding="utf-8")
+            result = subprocess.run([sys.executable, str(pathlib.Path(worker.__file__)), "--assignment-file", str(assignment_file), "--artifact-file", str(artifact), "--adapter-command", shlex.join([sys.executable, str(adapter)]), "--skill-dir", str(skill)], text=True, capture_output=True, check=False)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            candidate = json.loads(artifact.read_text(encoding="utf-8"))
+            self.assertEqual(candidate["artifact"]["verdict"], "docs-sufficient")
+            self.assertEqual(json.loads(result.stdout)["review_sha256"], candidate["artifact"]["review_sha256"])
+    def test_final_candidate_accepts_canonical_non_proposal_reviews(self) -> None:
+        from github.tests.test_github_intake_docs_patch import review
+        raw = json.dumps(assignment()).encode()
+        for verdict in ("no-impact", "docs-sufficient", "docs-change-required", "inconclusive"):
+            with self.subTest(verdict=verdict):
+                value = review()
+                value["verdict"] = verdict
+                value["proposal"] = None
+                self.assertEqual(worker.validate_final_candidate(raw, {"schema_version": 1, "snapshot_sha256": __import__("hashlib").sha256(raw).hexdigest(), "artifact": value})["artifact"]["verdict"], verdict)
+    def test_final_candidate_rejects_every_proposal_only_identity_mismatch(self) -> None:
+        from github.tests.test_github_intake_docs_patch import review
+        raw = json.dumps(assignment()).encode()
+        for field, value in (("base_sha", "c" * 40), ("head_repository_id", "18"), ("head_repository", "allenday/other"), ("base_ref", "release")):
+            with self.subTest(field=field):
+                candidate = review()
+                candidate["proposal"]["identity"][field] = value
+                with self.assertRaisesRegex(ValueError, "proposal identity"):
+                    worker.validate_final_candidate(raw, {"schema_version": 1, "snapshot_sha256": __import__("hashlib").sha256(raw).hexdigest(), "artifact": candidate})
+
+    def test_adapter_environment_strips_caller_and_github_credentials(self) -> None:
+        environment = worker._adapter_environment()
+        self.assertNotIn("GITHUB_TOKEN", environment)
+        self.assertNotIn("GH_TOKEN", environment)
+        self.assertEqual(set(environment), {"HOME", "PATH", "LANG", "LC_ALL", "PYTHONNOUSERSITE"})
+
+    def test_assignment_bytes_keep_exact_identity_and_skill_binding(self) -> None:
+        raw = json.dumps(assignment(), separators=(",", ":")).encode()
+        validated = worker.load_assignment_bytes(raw)
+        self.assertEqual(validated["identity"], assignment()["identity"])
+        self.assertEqual(validated["agent_skill"], "developer-experience-techdocs")
+
+    def test_assignment_rejects_proposal_identity_for_another_revision(self) -> None:
+        value = assignment()
+        value["evidence_bundle"]["proposal_identity"]["head_sha"] = "c" * 40
+        with self.assertRaisesRegex(ValueError, "proposal identity"):
+            worker.validate_assignment(value)
+
+    def test_assignment_rejects_every_mismatched_proposal_identity_field(self) -> None:
+        for field, value in (("repository_id", "18"), ("repository", "allenday/other"), ("pr_number", 10), ("head_sha", "c" * 40)):
+            with self.subTest(field=field):
+                value_to_check = assignment()
+                value_to_check["evidence_bundle"]["proposal_identity"][field] = value
+                with self.assertRaisesRegex(ValueError, "proposal identity"):
+                    worker.validate_assignment(value_to_check)
+
+    def test_assignment_rejects_an_unexpected_reviewer_skill(self) -> None:
+        value = assignment()
+        value["agent_skill"] = "other-skill"
+        with self.assertRaisesRegex(ValueError, "agent_skill"):
+            worker.load_assignment_bytes(json.dumps(value).encode())
+
+    def test_credential_error_removes_a_stale_artifact_before_exit(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = pathlib.Path(temp_dir)
+            assignment_file = root / "assignment.json"
+            artifact_file = root / "artifact.json"
+            assignment_file.write_text(json.dumps(assignment()), encoding="utf-8")
+            artifact_file.write_text('{"stale":true}', encoding="utf-8")
+            result = subprocess.run([sys.executable, str(pathlib.Path(worker.__file__)), "--assignment-file", str(assignment_file), "--artifact-file", str(artifact_file)], env={"GITHUB_TOKEN": "present", "PATH": "/usr/bin:/bin"}, text=True, capture_output=True, check=False)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertFalse(artifact_file.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/github/tests/test_github_intake_docs_review_runtime.py
+++ b/github/tests/test_github_intake_docs_review_runtime.py
@@ -1,0 +1,285 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import multiprocessing
+import pathlib
+import sys
+import tempfile
+import threading
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+
+import github_intake_docs_review_runtime as runtime
+
+
+SHA = "a" * 40
+
+
+def assignment(head_sha: str = SHA) -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "kind": "github-pr-docs-impact-assignment",
+        "identity": {
+            "repository_id": "17",
+            "repository": "example/docs",
+            "pr_number": 9,
+            "head_sha": head_sha,
+            "source_key": f"github-pr:17:9:{head_sha}",
+        },
+        "agent_skill": "developer-experience-techdocs",
+        "evidence_bundle": {
+            "head_sha": head_sha,
+            "proposal_identity": {
+                "repository_id": "17", "repository": "example/docs", "pr_number": 9,
+                "base_sha": "b" * 40, "head_sha": head_sha,
+                "head_repository_id": "17", "head_repository": "example/docs", "base_ref": "main",
+            },
+            "files": [{
+                "path": "docs/guide.md",
+                "reference": f"github://example/docs/blob/{head_sha}/docs/guide.md",
+                "patch": "@@ -1 +1 @@\n-old\n+new\n",
+            }],
+        },
+    }
+
+
+def candidate(source: dict[str, object], verdict: str = "no-impact") -> dict[str, object]:
+    raw = json.dumps(source, sort_keys=True, separators=(",", ":")).encode()
+    identity = source["identity"]
+    artifact = {
+        "schema_version": 1, "kind": "github-pr-docs-impact-review", "identity": identity,
+        "agent_skill": "developer-experience-techdocs", "verdict": verdict,
+        "rationale": "The documentation is sufficient.",
+        "evidence": [{"path": "docs/guide.md", "evidence": f"github://example/docs/blob/{identity['head_sha']}/docs/guide.md"}],
+        "confidence": 0.9, "proposal": None,
+    }
+    return {"schema_version": 1, "snapshot_sha256": hashlib.sha256(raw).hexdigest(), "artifact": artifact}
+
+
+class RecordingAdapter:
+    def __init__(self, current: bool = True) -> None:
+        self.current = current
+        self.actions: list[tuple[str, str]] = []
+
+    def head_is_current(self, run: dict[str, object]) -> bool:
+        return self.current
+
+    def perform(self, action: str, run: dict[str, object]) -> None:
+        self.actions.append((action, str(run["identity"])))
+
+
+class NoopAdapter:
+    def head_is_current(self, run: dict[str, object]) -> bool:
+        return True
+
+    def perform(self, action: str, run: dict[str, object]) -> None:
+        return None
+
+
+def submit_from_process(root: str, envelope: dict[str, object], queue: multiprocessing.Queue) -> None:
+    response = runtime.accept_candidate(runtime.FileDocsReviewStore(root), envelope, NoopAdapter(), now=101)
+    queue.put(response["accepted"])
+
+
+class DocsReviewRuntimeTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self.store = runtime.FileDocsReviewStore(pathlib.Path(self.tempdir.name))
+        self.adapter = RecordingAdapter()
+
+    def test_duplicate_delivery_reuses_persisted_run_and_only_reensures_check(self) -> None:
+        source = assignment()
+        first = runtime.intake_delivery(self.store, source, self.adapter, now=100)
+        duplicate = runtime.intake_delivery(self.store, source, self.adapter, now=101)
+
+        self.assertEqual(first["identity"], duplicate["identity"])
+        self.assertEqual(first["attempt"], 1)
+        self.assertEqual(self.adapter.actions, [("ensure_check", first["identity"]), ("dispatch", first["identity"]), ("ensure_check", first["identity"])])
+
+    def test_duplicate_intake_keeps_the_original_bytes_and_pending_dispatch(self) -> None:
+        source = assignment()
+        raw = json.dumps(source, separators=(",", ":")).encode()
+        first = runtime.intake_delivery(self.store, raw, self.adapter, now=100, perform_actions=False)
+
+        duplicate = runtime.intake_delivery(self.store, source, self.adapter, now=101, perform_actions=False)
+
+        self.assertEqual(duplicate["assignment_bytes"], first["assignment_bytes"])
+        self.assertEqual(duplicate["pending_actions"], ["ensure_check", "dispatch"])
+
+    def test_duplicate_intake_rejects_a_different_assignment_for_the_same_identity(self) -> None:
+        source = assignment()
+        runtime.intake_delivery(self.store, source, self.adapter, now=100)
+        different = assignment()
+        different["evidence_bundle"]["files"][0]["patch"] = "@@ -1 +1 @@\n-old\n+different\n"
+
+        with self.assertRaisesRegex(ValueError, "different assignment"):
+            runtime.intake_delivery(self.store, different, self.adapter, now=101)
+
+    def test_complete_paginated_evidence_becomes_a_sorted_assignment(self) -> None:
+        delivery = {"repository_id": "17", "repository": "example/docs", "pr_number": 9, "head_sha": SHA, "base_sha": "b" * 40, "base_ref": "main"}
+        pages = [
+            [{"filename": "README.md", "patch": "@@ -1 +1 @@\n-old\n+new\n"}],
+            [{"filename": "docs/guide.md", "patch": "@@ -1 +1 @@\n-old\n+new\n"}],
+        ]
+
+        built = runtime.assignment_from_paginated_evidence(delivery, pages)
+
+        self.assertEqual([item["path"] for item in built["evidence_bundle"]["files"]], ["README.md", "docs/guide.md"])
+        self.assertEqual(built["identity"]["source_key"], f"github-pr:17:9:{SHA}")
+
+    def test_missing_binary_or_truncated_evidence_is_rejected_before_dispatch(self) -> None:
+        delivery = {"repository_id": "17", "repository": "example/docs", "pr_number": 9, "head_sha": SHA, "base_sha": "b" * 40, "base_ref": "main"}
+        for item in ({"filename": "docs/a.md"}, {"filename": "docs/a.md", "patch": "Binary files differ"}, {"filename": "docs/a.md", "patch": "@@ -1 +1 @@\n-old\n+new\n", "truncated": True}):
+            with self.subTest(item=item):
+                with self.assertRaisesRegex(ValueError, "complete text patch"):
+                    runtime.assignment_from_paginated_evidence(delivery, [[item]])
+
+    def test_reconcile_recovers_persisted_dispatch_after_a_crash(self) -> None:
+        source = assignment()
+        run = runtime.intake_delivery(self.store, source, self.adapter, now=100, perform_actions=False)
+
+        runtime.reconcile_pending(self.store, self.adapter, now=101)
+
+        self.assertEqual(self.adapter.actions, [("ensure_check", run["identity"]), ("dispatch", run["identity"])])
+
+    def test_expired_lease_redispatches_without_another_check(self) -> None:
+        run = runtime.intake_delivery(self.store, assignment(), self.adapter, now=100, lease_seconds=30)
+        self.adapter.actions.clear()
+
+        runtime.reconcile_pending(self.store, self.adapter, now=131, lease_seconds=30)
+
+        self.assertEqual(self.adapter.actions, [("dispatch", run["identity"])])
+        self.assertEqual(self.store.load(run["identity"])["attempt"], 2)
+
+    def test_stale_head_completes_only_the_stale_check(self) -> None:
+        run = runtime.intake_delivery(self.store, assignment(), self.adapter, now=100)
+        self.adapter.actions.clear()
+        self.adapter.current = False
+
+        runtime.reconcile_pending(self.store, self.adapter, now=101)
+
+        self.assertEqual(self.store.load(run["identity"])["state"], "stale")
+        self.assertEqual(self.adapter.actions, [("ensure_stale_check", run["identity"])])
+
+    def test_stale_reconciliation_replaces_obsolete_pending_dispatch(self) -> None:
+        run = runtime.intake_delivery(self.store, assignment(), self.adapter, now=100, perform_actions=False)
+        self.adapter.current = False
+
+        runtime.reconcile_pending(self.store, self.adapter, now=101)
+
+        self.assertEqual(self.adapter.actions, [("ensure_stale_check", run["identity"])])
+
+    def test_late_candidate_is_audited_but_cannot_reopen_deadline_terminal_run(self) -> None:
+        source = assignment()
+        run = runtime.intake_delivery(self.store, source, self.adapter, now=100, deadline_seconds=60)
+        runtime.reconcile_pending(self.store, self.adapter, now=160)
+        self.adapter.actions.clear()
+
+        accepted = runtime.accept_candidate(self.store, candidate(source), self.adapter, now=161)
+
+        self.assertFalse(accepted["accepted"])
+        self.assertEqual(self.store.load(run["identity"])["conclusion"], "action_required")
+        self.assertEqual(self.adapter.actions, [("ensure_terminal_check", run["identity"])])
+
+    def test_deadline_completes_an_operational_failure_once(self) -> None:
+        run = runtime.intake_delivery(self.store, assignment(), self.adapter, now=100, deadline_seconds=60)
+        self.adapter.actions.clear()
+
+        runtime.reconcile_pending(self.store, self.adapter, now=160)
+        runtime.reconcile_pending(self.store, self.adapter, now=161)
+
+        self.assertEqual(self.store.load(run["identity"])["conclusion"], "action_required")
+        self.assertEqual(self.adapter.actions, [("ensure_terminal_check", run["identity"]), ("ensure_terminal_check", run["identity"])])
+
+    def test_concurrent_valid_candidates_allow_only_one_terminal_winner(self) -> None:
+        source = assignment()
+        self.store = runtime.FileDocsReviewStore(pathlib.Path(self.tempdir.name))
+        runtime.intake_delivery(self.store, source, self.adapter, now=100)
+        contenders = [candidate(source, "no-impact"), candidate(source, "inconclusive")]
+        barrier = threading.Barrier(2)
+        results: list[tuple[str, bool]] = []
+
+        def submit(envelope: dict[str, object]) -> None:
+            barrier.wait()
+            response = runtime.accept_candidate(self.store, envelope, self.adapter, now=101)
+            results.append((str(envelope["artifact"]["verdict"]), bool(response["accepted"])))
+
+        threads = [threading.Thread(target=submit, args=(envelope,)) for envelope in contenders]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        winners = [verdict for verdict, accepted in results if accepted]
+        self.assertEqual(len(winners), 1)
+        stored = self.store.load(str(source["identity"]["source_key"]))
+        self.assertEqual(stored["candidate"]["artifact"]["verdict"], winners[0])
+
+    def test_processes_serialise_candidate_acceptance_for_one_run(self) -> None:
+        source = assignment()
+        runtime.intake_delivery(self.store, source, self.adapter, now=100)
+        queue: multiprocessing.Queue = multiprocessing.Queue()
+        processes = [multiprocessing.Process(target=submit_from_process, args=(self.tempdir.name, envelope, queue)) for envelope in (candidate(source, "no-impact"), candidate(source, "inconclusive"))]
+        for process in processes:
+            process.start()
+        for process in processes:
+            process.join()
+
+        self.assertEqual([process.exitcode for process in processes], [0, 0])
+        self.assertEqual(sorted([queue.get(), queue.get()]), [False, True])
+
+    def test_legacy_record_without_assignment_bytes_fails_closed_and_does_not_stop_scan(self) -> None:
+        legacy_source = assignment()
+        legacy = runtime.intake_delivery(self.store, legacy_source, self.adapter, now=100)
+        legacy_record = self.store.load(legacy["identity"])
+        legacy_record.pop("assignment_bytes")
+        self.store.save(legacy_record)
+        current_source = assignment("c" * 40)
+        current = runtime.intake_delivery(self.store, current_source, self.adapter, now=100)
+        self.adapter.actions.clear()
+
+        reconciled = runtime.reconcile_pending(self.store, self.adapter, now=101)
+
+        failed_closed = self.store.load(legacy["identity"])
+        self.assertEqual(failed_closed["state"], "terminal")
+        self.assertEqual(failed_closed["conclusion"], "action_required")
+        self.assertIn("legacy", failed_closed["operational_reason"])
+        self.assertEqual(failed_closed["assignment"], legacy_source)
+        self.assertIn(current["identity"], [record["identity"] for record in reconciled])
+
+    def test_duplicate_intake_and_candidate_for_legacy_record_fail_closed(self) -> None:
+        source = assignment()
+        run = runtime.intake_delivery(self.store, source, self.adapter, now=100)
+        legacy_record = self.store.load(run["identity"])
+        legacy_record.pop("assignment_bytes")
+        self.store.save(legacy_record)
+
+        duplicate = runtime.intake_delivery(self.store, source, self.adapter, now=101)
+        received = runtime.accept_candidate(self.store, candidate(source), self.adapter, now=102)
+
+        self.assertEqual(duplicate["state"], "terminal")
+        self.assertFalse(received["accepted"])
+        self.assertEqual(self.store.load(run["identity"])["conclusion"], "action_required")
+
+    def test_mismatched_valid_assignment_bytes_fail_closed_before_candidate_b(self) -> None:
+        source_a = assignment()
+        source_b = assignment()
+        source_b["evidence_bundle"]["files"][0]["patch"] = "@@ -1 +1 @@\n-old\n+evidence-b\n"
+        run = runtime.intake_delivery(self.store, source_a, self.adapter, now=100)
+        record = self.store.load(run["identity"])
+        record["assignment"] = source_b
+        self.store.save(record)
+
+        received = runtime.accept_candidate(self.store, candidate(source_b), self.adapter, now=101)
+
+        failed_closed = self.store.load(run["identity"])
+        self.assertFalse(received["accepted"])
+        self.assertEqual(failed_closed["conclusion"], "action_required")
+        self.assertIn("proof", failed_closed["operational_reason"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/github/tests/test_github_intake_docs_reviewer_prompt.py
+++ b/github/tests/test_github_intake_docs_reviewer_prompt.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import pathlib
+import tomllib
+import unittest
+
+
+GITHUB_ROOT = pathlib.Path(__file__).resolve().parents[1]
+AGENT_ROOT = GITHUB_ROOT / "agents" / "docs-impact-reviewer"
+
+
+class DocsImpactReviewerPackageTests(unittest.TestCase):
+    def test_agent_is_a_credential_free_techdocs_reviewer(self) -> None:
+        metadata = tomllib.loads((AGENT_ROOT / "agent.toml").read_text(encoding="utf-8"))
+
+        self.assertEqual(metadata["description"], "GitHub pull-request documentation impact reviewer")
+        self.assertEqual(metadata["scope"], "rig")
+        self.assertFalse(metadata["fallback"])
+
+    def test_prompt_returns_only_a_validator_compatible_review_decision(self) -> None:
+        prompt = (AGENT_ROOT / "prompt.template.md").read_text(encoding="utf-8")
+
+        self.assertIn("github-pr-docs-impact-review", prompt)
+        self.assertIn('"agent_skill": "developer-experience-techdocs"', prompt)
+        self.assertIn('"proposal": null', prompt)
+        self.assertIn("evidence_bundle", prompt)
+        self.assertIn("developer-experience-techdocs/SKILL.md", prompt)
+
+    def test_reviewer_metadata_and_prompt_remain_deployment_neutral_and_credential_free(self) -> None:
+        artifacts = [
+            AGENT_ROOT / "agent.toml",
+            AGENT_ROOT / "prompt.template.md",
+        ]
+        content = "\n".join(path.read_text(encoding="utf-8").lower() for path in artifacts)
+
+        for forbidden in (
+            "github_token",
+            "github_app_private_key",
+            "provider",
+            "docker compose",
+            "tailnet",
+            "dashboard",
+            "manual diff",
+            "git diff",
+            "localhost",
+            "/root/",
+        ):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, content)
+
+    def test_vendored_techdocs_skill_is_available_to_the_reviewer(self) -> None:
+        skill = GITHUB_ROOT / "skills" / "developer-experience-techdocs" / "SKILL.md"
+
+        self.assertTrue(skill.is_file())
+        self.assertIn("Developer-experience technical documentation", skill.read_text(encoding="utf-8"))
+
+    def test_rendered_prompt_is_assignment_only_and_non_mutating(self) -> None:
+        rendered = (AGENT_ROOT / "prompt.template.md").read_text(encoding="utf-8")
+
+        self.assertNotIn("{{", rendered)
+        for forbidden in (
+            "gc ",
+            "bead",
+            "runtime ack",
+            "worktree",
+            "local workspace",
+            "manual diff",
+            "git diff",
+        ):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, rendered.lower())
+
+    def test_candidate_documentation_uses_an_executable_neutral_projection(self) -> None:
+        lifecycle = (GITHUB_ROOT / "docs" / "docs-pr-review-lifecycle.md").read_text(encoding="utf-8")
+
+        self.assertIn(
+            "candidate --once --candidate-file <candidate.json> --projection action-file \\\n  --actions-file <actions.json>",
+            lifecycle,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds an opt-in, self-contained GitHub PR documentation reviewer. It records durable review runs, dispatches a credential-free reviewer, reconciles retries/stale revisions, and creates at most one App-owned stacked documentation follow-up PR.

The GitHub PR remains the review surface. The pack includes no Compose, Tailnet, dashboard, provider, or local deployment wiring.

Refs #17
Refs #18

## Verification

- `python3 -m unittest discover -s github/tests -p "test_*.py"` (174 passed)
- `git diff --check`

Bootstrap remediation remains intentionally separate (#19).
