### PR TITLE
oversight-rig,pr-pipeline: PL brief documents a nonexistent gc-sling wrapper and a broken wake recovery path

### DIFF
--- a/oversight-rig/agents/project-lead/prompt.template.md
+++ b/oversight-rig/agents/project-lead/prompt.template.md
@@ -150,36 +150,74 @@ expand a single root bead into a multi-bead graph workflow. A bead is
 - not gated on a human decision (no open `severity:escalate` rollup
   about it, no "needs decision" / "needs-api" gate in its notes or
   `gc.tier` metadata)
-- your rig has a worker pool (`{{ .Rig }}`-worker or equivalent)
+- your rig has a worker pool — check with `gc session list` that a
+  `{{ .Rig }}/gastown.polecat` config exists
 
 To dispatch:
 
 ```bash
-# Atomic in-rig work (single bead → single worker):
-gc-sling <rig-worker-agent> <bead-id>
+# Atomic in-rig work (single bead → the rig's worker pool):
+gc sling {{ .Rig }}/gastown.polecat <bead-id> --nudge
 
 # Convoy-creating formulas (epic → multi-bead graph; in-rig only):
-gc-sling <rig-worker-agent> --on mol-decompose --var issue=<epic> --var rig={{ .Rig }} --stdin
-gc-sling <rig-worker-agent> --on mol-pr-from-issue --var issue=<N> --stdin
+gc sling {{ .Rig }}/gastown.polecat --on mol-decompose --var issue=<epic> --var rig={{ .Rig }} --stdin
+gc sling {{ .Rig }}/gastown.polecat --on mol-pr-from-issue --var issue=<N> --stdin
 ```
 
-Use the `gc-sling` wrapper — it auto-injects `--nudge`. Then **verify
-the worker actually picked it up** — a bead can be routed but sit
-unclaimed if no worker session is awake:
+The command is `gc sling` — **two words, and you pass `--nudge` yourself.**
+There is no `gc-sling` wrapper: not on any PATH, not in the `gc` binary, not
+in any pack. Sling to the pool's **config agent**
+(`{{ .Rig }}/gastown.polecat`), never to an individual worker, and leave the
+bead **unassigned** — generic pool demand is unassigned work carrying
+`gc.routed_to`. Slinging a bead that still has an assignee only warns and
+leaves the assignee in place.
+
+Then **verify the worker actually picked it up** — a bead can be routed but
+sit unclaimed if no worker session is awake:
 
 ```bash
 gc bd --rig {{ .Rig }} show <bead-id>   # expect IN_PROGRESS within a few minutes
 ```
 
-If it stays `open` with `gc.routed_to` already set, the pool is asleep.
-`gc sling` treats an already-routed bead as an idempotent skip and will
-NOT re-nudge — re-slinging a stuck bead is a silent no-op. Unstick it by
-waking a worker and nudging it onto the bead:
+### `--nudge` on a pool target fails loudly and harmlessly (gc 1.4.1)
+
+On a **pool** target the `--nudge` leg prints
+
+```
+gc sling: agent "{{ .Rig }}/gastown.<member>" not found in config
+```
+
+then nudges nothing and exits 0. **This is a known `gc` defect, not evidence
+that your pool is stopped.** Pool members are named by the namepool
+(`rictus`, `furiosa`, `slit`, …) and such a name can never resolve as a config
+agent. Routing still committed, and the pool supervisor spawns a worker on
+demand — so the work is normally picked up anyway. Do not write a "pool is
+stopped" rollup off the back of this message.
+
+If the bead really does stay `open` with `gc.routed_to` already set, note that
+`gc sling` treats an already-routed bead as an idempotent skip and will NOT
+re-nudge — re-slinging a stuck bead is a silent no-op. Unstick it by looking
+up the worker's **real** session handle and nudging that:
 
 ```bash
-gc session wake <rig-worker-agent>-1
-gc session nudge <rig-worker-agent>-1 "Claim and work routed bead <bead-id>." --delivery immediate
+gc session list --json | jq -r '.sessions[]
+  | select(.template == "{{ .Rig }}/gastown.polecat")
+  | "\(.id)\t\(.alias)\t\(.state)"'
 ```
+
+`gc session wake` and `gc session nudge` take a session **ID** (`co-1mgl5`) or
+a session **alias** — the namepool member name (`{{ .Rig }}/gastown.rictus`).
+They do **not** accept `{{ .Rig }}/gastown.polecat-1` or the bare config-agent
+name; both return `session not found`. That failure is what previously read as
+confirmation of a dead pool.
+
+```bash
+gc session wake  {{ .Rig }}/gastown.<member>
+gc session nudge {{ .Rig }}/gastown.<member> "Claim and work routed bead <bead-id>." --delivery immediate
+```
+
+If `gc session list` shows **no** session at all for the pool config, *then*
+the pool is genuinely down — mail the mayor.
 
 **Still mayor-owned — surface as a rollup, do not sling yourself:**
 

--- a/oversight-rig/agents/project-lead/prompt.template.md
+++ b/oversight-rig/agents/project-lead/prompt.template.md
@@ -150,27 +150,35 @@ expand a single root bead into a multi-bead graph workflow. A bead is
 - not gated on a human decision (no open `severity:escalate` rollup
   about it, no "needs decision" / "needs-api" gate in its notes or
   `gc.tier` metadata)
-- your rig has a worker pool — check with `gc session list` that a
-  `{{ .Rig }}/gastown.polecat` config exists
+- your rig has a worker pool — confirm the **config** exists with `gc agent
+  list`. Configuration lives under `gc agent`; `gc session list` enumerates
+  live sessions and cannot answer this. **Zero live sessions is normal** for
+  an idle pool and is never a reason to hold back dispatch.
 
-To dispatch:
+To dispatch, sling to your rig's worker **pool config agent**. Its name is
+whatever your city stamped it: `<rig>/<pack>.<agent>` when the agent comes
+from a pack, `<rig>/<agent>` when it is stamped bare. Discover yours with
+`gc agent list` — on gastown-stamped cities it is
+`{{ .Rig }}/gastown.polecat`. The examples below write it as `<pool>`;
+substitute your rig's real target.
 
 ```bash
 # Atomic in-rig work (single bead → the rig's worker pool):
-gc sling {{ .Rig }}/gastown.polecat <bead-id> --nudge
+gc sling <pool> <bead-id> --nudge
 
 # Convoy-creating formulas (epic → multi-bead graph; in-rig only):
-gc sling {{ .Rig }}/gastown.polecat --on mol-decompose --var issue=<epic> --var rig={{ .Rig }} --stdin
-gc sling {{ .Rig }}/gastown.polecat --on mol-pr-from-issue --var issue=<N> --stdin
+gc sling <pool> --on mol-decompose --var issue=<epic> --var rig={{ .Rig }} --stdin
+gc sling <pool> --on mol-pr-from-issue --var issue=<N> --stdin
 ```
 
 The command is `gc sling` — **two words, and you pass `--nudge` yourself.**
 There is no `gc-sling` wrapper: not on any PATH, not in the `gc` binary, not
-in any pack. Sling to the pool's **config agent**
-(`{{ .Rig }}/gastown.polecat`), never to an individual worker, and leave the
-bead **unassigned** — generic pool demand is unassigned work carrying
-`gc.routed_to`. Slinging a bead that still has an assignee only warns and
-leaves the assignee in place.
+in any pack. Sling to the pool's **config agent**, never to an individual
+worker, and leave the bead **unassigned** — generic pool demand is unassigned
+work carrying `gc.routed_to`. Slinging a bead that still has an assignee only
+warns and leaves the assignee in place; when a human already claimed it, hand
+it over with `gc sling <pool> <bead-id> --reassign --nudge`, which clears the
+assignee before routing.
 
 Then **verify the worker actually picked it up** — a bead can be routed but
 sit unclaimed if no worker session is awake:
@@ -184,7 +192,7 @@ gc bd --rig {{ .Rig }} show <bead-id>   # expect IN_PROGRESS within a few minute
 On a **pool** target the `--nudge` leg prints
 
 ```
-gc sling: agent "{{ .Rig }}/gastown.<member>" not found in config
+gc sling: agent "<pool-member>" not found in config
 ```
 
 then nudges nothing and exits 0. **This is a known `gc` defect, not evidence
@@ -194,32 +202,48 @@ agent. Routing still committed, and the pool supervisor spawns a worker on
 demand — so the work is normally picked up anyway. Do not write a "pool is
 stopped" rollup off the back of this message.
 
+### Unsticking a routed bead
+
 If the bead really does stay `open` with `gc.routed_to` already set, note that
 `gc sling` treats an already-routed bead as an idempotent skip and will NOT
 re-nudge — re-slinging a stuck bead is a silent no-op. Unstick it by looking
 up the worker's **real** session handle and nudging that:
 
 ```bash
-gc session list --json | jq -r '.sessions[]
-  | select(.template == "{{ .Rig }}/gastown.polecat")
-  | "\(.id)\t\(.alias)\t\(.state)"'
+gc session list --json | jq -r --arg pool "<pool>" '.sessions[]
+  | select(.template == $pool)
+  | "\(.id)\t\(.name)\t\(.alias // "-")\t\(.state)"'
 ```
 
-`gc session wake` and `gc session nudge` take a session **ID** (`co-1mgl5`) or
-a session **alias** — the namepool member name (`{{ .Rig }}/gastown.rictus`).
-They do **not** accept `{{ .Rig }}/gastown.polecat-1` or the bare config-agent
-name; both return `session not found`. That failure is what previously read as
-confirmation of a dead pool.
+`gc session wake` and `gc session nudge` take a session **ID** (`co-1mgl5`), a
+session **name** (`gascity--gc__implementation-worker-4-pool`), or a session
+**alias** — the namepool member name (on gastown cities,
+`{{ .Rig }}/gastown.rictus`). Reach for the **id** or the **name**: both are
+always present, while `alias` is optional and is empty on exactly the
+unaliased sessions a scale-from-zero pool spawns, which is why the listing
+above prints `-` for it rather than a handle you can use. They do **not**
+accept a `<pool>-1` suffix form or the bare config-agent name; both return
+`session not found`. That failure is what previously read as confirmation of a
+dead pool.
 
 ```bash
-gc session wake  {{ .Rig }}/gastown.<member>
-gc session nudge {{ .Rig }}/gastown.<member> "Claim and work routed bead <bead-id>." --delivery immediate
+gc session wake  <session-id-or-alias>
+gc session nudge <session-id-or-alias> "Claim and work routed bead <bead-id>." --delivery immediate
 ```
 
-If `gc session list` shows **no** session at all for the pool config, *then*
-the pool is genuinely down — mail the mayor.
+An **empty listing is not evidence of a dead pool.** Worker pools run with
+`min_active_sessions = 0`, so a healthy pool has zero sessions until work
+arrives and the supervisor spawns one. Mail the mayor only when all three of
+these hold:
 
-**Still mayor-owned — surface as a rollup, do not sling yourself:**
+- `gc agent list` shows the pool config — if it does not, your rig has no pool
+  at all, which is a worker-pool *allocation* ask (below), not an outage; and
+- the bead is still `open` with `gc.routed_to` set well past the few minutes a
+  cold start takes — give it 15 minutes; and
+- nothing is wakeable — the listing is still empty after that wait, or the
+  sessions it does show never claim the bead after a `gc session nudge`.
+
+### Still mayor-owned — surface as a rollup, do not sling yourself
 
 - **Cross-rig routing remains mayor-owned** — any work that touches another
   rig's worktree, beads, or worker pool. In-rig convoys are yours; cross-rig

--- a/pr-pipeline/formulas/mol-pr-triage.formula.toml
+++ b/pr-pipeline/formulas/mol-pr-triage.formula.toml
@@ -292,9 +292,11 @@ The single best Tier 1 (or Tier 2 if no Tier 1) candidate, with:
 - Issue # and title
 - Why it's the best pick (priority, scope, no gates, no competing PR)
 - The exact dispatch command:
-  `gc sling <rig>/gastown.polecat <new-bead-id> --on mol-pr-start --var issue=<N> --nudge`
-  (`gc sling`, two words — there is no `gc-sling` wrapper — and the target is
-  the pool's config agent, not a bare `polecat`)
+  `gc sling <rig>/<worker-agent> <new-bead-id> --on mol-pr-start --var issue=<N> --nudge`
+  (`gc sling`, two words — there is no `gc-sling` wrapper. The target is the
+  worker pool's config agent as the city stamped it: `<rig>/polecat` when the
+  agent is stamped bare, `<rig>/gastown.polecat` when it comes from the
+  gastown pack. Discover it with `gc agent list`.)
 
 If no Tier 1 OR Tier 2 candidates exist, recommend a Tier 3 to investigate
 or note that the queue is empty and triage should wait for new issues.

--- a/pr-pipeline/formulas/mol-pr-triage.formula.toml
+++ b/pr-pipeline/formulas/mol-pr-triage.formula.toml
@@ -292,7 +292,9 @@ The single best Tier 1 (or Tier 2 if no Tier 1) candidate, with:
 - Issue # and title
 - Why it's the best pick (priority, scope, no gates, no competing PR)
 - The exact dispatch command:
-  `gc-sling polecat <new-bead-id> --on mol-pr-start --var issue=<N>`
+  `gc sling <rig>/gastown.polecat <new-bead-id> --on mol-pr-start --var issue=<N> --nudge`
+  (`gc sling`, two words — there is no `gc-sling` wrapper — and the target is
+  the pool's config agent, not a bare `polecat`)
 
 If no Tier 1 OR Tier 2 candidates exist, recommend a Tier 3 to investigate
 or note that the queue is empty and triage should wait for new issues.

--- a/tests/test_no_gc_sling_wrapper.py
+++ b/tests/test_no_gc_sling_wrapper.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from pathlib import Path
+import re
+import subprocess
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+THIS_FILE = Path(__file__).resolve()
+
+# There is no `gc-sling` wrapper: not on any PATH, not in the `gc` binary, not
+# in any pack. Shipped guidance that tells an agent to run it sends that agent
+# to a command that does not exist. This has now recurred three times (gci-5ok5,
+# gci-t0x, gci-2lr), each time in prose a human had to catch by hand.
+#
+# The guard is on *invocations*, not on the string. Prose has to be able to name
+# the thing it forbids -- "there is no `gc-sling` wrapper" is the correction, and
+# `slack-full/adapter/rig_dispatch.go` calls the dispatch step "the gc-sling leg"
+# -- so a bare mention is fine and only a runnable-looking command fails.
+GC_SLING = re.compile(r"(?<![\w.-])gc-sling(?![\w-])")
+
+# `gc-sling` sits where a command goes: at the start of a line, opening an
+# inline-code span or a markdown bullet, after a shell separator or a `$`
+# prompt, after a `key:`/`key =` that carries a command as its value (YAML
+# `run:` steps, TOML `description = "..."` — the shape recurrence #2 shipped
+# in), or after an ordered-list marker.
+#
+# A `key:` value is where prose that merely names the wrapper can also live,
+# so this class leans on the repo's convention that a bare mention is
+# backticked: "Rule: there is no `gc-sling` wrapper" ends in a backtick and is
+# read as prose by TAKES_ARGUMENT below.
+COMMAND_POSITION = re.compile(
+    r"""(?: ^ | [`;&|($] | \$\( ) [ \t]* $     # line start, separator, $ prompt
+      | [:=] [ \t]* ["']? [ \t]* $             # YAML run: / TOML description =
+      | ^ [ \t]* (?: [-*>] | \d+[.)] ) [ \t]+ $  # bullet or ordered-list marker
+    """,
+    re.VERBOSE,
+)
+
+# ...and is followed by an argument. A trailing backtick, comma, or period is
+# prose; whitespace then any non-comment token is an invocation.
+TAKES_ARGUMENT = re.compile(r"^[ \t]+(?![#`]|$)\S")
+
+# Serialized argv forms, e.g. `command = ["gc-sling", "polecat"]` and the Go
+# `exec.Command("gc-sling", ...)` shape that `slack-full/adapter` dispatch code
+# would use. `(` is in the class by design: without it the `CommandContext`
+# variant passed only incidentally, on the comma after `ctx`.
+GC_SLING_ARGV = re.compile(r"""(?:\[|\{|=|:|,|\()[ \t]*["']gc-sling["']""")
+
+# Residual gap, accepted: prose that *directs* rather than shows -- "Use the
+# `gc-sling` wrapper, it auto-injects --nudge", the second shape in the pre-fix
+# template -- is not separable by regex from the corrective sentence this guard
+# must let through. Humans still catch that one; the guard covers invocations.
+
+
+def tracked_files() -> list[Path]:
+    result = subprocess.run(
+        ["git", "ls-files", "-z"],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+    )
+    return [REPO_ROOT / path for path in result.stdout.decode().split("\0") if path]
+
+
+def gc_sling_violations(path: Path, text: str) -> list[str]:
+    violations = []
+    relative = path.relative_to(REPO_ROOT) if path.is_absolute() else path
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        for match in GC_SLING.finditer(line):
+            if not COMMAND_POSITION.search(line[: match.start()]):
+                continue
+            if not TAKES_ARGUMENT.match(line[match.end() :]):
+                continue
+            violations.append(f"{relative}:{line_number}: {line.strip()}")
+        if GC_SLING_ARGV.search(line):
+            violations.append(f"{relative}:{line_number}: serialized argv invokes gc-sling")
+    return list(dict.fromkeys(violations))
+
+
+def test_shipped_assets_never_invoke_a_gc_sling_wrapper() -> None:
+    violations = []
+    for path in tracked_files():
+        if path.resolve() == THIS_FILE:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, FileNotFoundError):
+            continue
+        violations.extend(gc_sling_violations(path, text))
+
+    assert not violations, (
+        "gc-sling is not a real command; use `gc sling` and pass --nudge yourself:\n"
+        + "\n".join(violations)
+    )
+
+
+def test_detector_separates_invocations_from_prose() -> None:
+    fixture = Path("fixture.md")
+
+    # The three shapes this bug has actually shipped in.
+    assert gc_sling_violations(fixture, "gc-sling <rig-worker-agent> <bead-id>")
+    assert gc_sling_violations(
+        fixture, "  `gc-sling polecat <new-bead-id> --on mol-pr-start --var issue=<N>`"
+    )
+    assert gc_sling_violations(
+        fixture, "gc-sling <rig-worker-agent> --on mol-decompose --var issue=<epic> --stdin"
+    )
+    assert gc_sling_violations(fixture, "- gc-sling $TARGET $BEAD")
+    assert gc_sling_violations(fixture, 'command = ["gc-sling", "polecat"]')
+    assert gc_sling_violations(fixture, "cd /tmp && gc-sling api-server/polecat x")
+
+    # Shapes this repo ships that the first cut of the detector let through:
+    # a TOML value (the same field and file type as recurrence #2, caught last
+    # time only because that value happened to be a `"""` block), a YAML `run:`
+    # step, an ordered-list line, a shell-prompt line, and Go `exec.Command(`.
+    assert gc_sling_violations(
+        fixture, 'description = "gc-sling polecat <bead> --on mol-pr-start"'
+    )
+    assert gc_sling_violations(fixture, "        run: gc-sling polecat $BEAD")
+    assert gc_sling_violations(fixture, "1. gc-sling <pool> <bead-id>")
+    assert gc_sling_violations(fixture, "$ gc-sling polecat BL-42")
+    assert gc_sling_violations(fixture, 'cmd := exec.Command("gc-sling", "polecat", beadID)')
+    assert gc_sling_violations(fixture, 'exec.CommandContext(ctx, "gc-sling", target)')
+
+    # Prose that names the non-existent wrapper in order to forbid it, and the
+    # in-tree comment that calls the dispatch step "the gc-sling leg". Guarding
+    # the bare string would fail the very sentences that fix the bug.
+    assert not gc_sling_violations(fixture, "There is no `gc-sling` wrapper: not on any PATH,")
+    assert not gc_sling_violations(fixture, "// Failures at the gc-sling leg trigger a close")
+    assert not gc_sling_violations(fixture, "`gc sling`, two words — there is no `gc-sling` wrapper")
+    assert not gc_sling_violations(fixture, "command -v gc-sling || echo absent")
+    # A `key:` value carrying the correction, now that `:` opens a command
+    # position -- the backtick is what keeps it prose.
+    assert not gc_sling_violations(fixture, "Rule: there is no `gc-sling` wrapper.")
+
+    # The real command must not trip the guard.
+    assert not gc_sling_violations(fixture, "gc sling <pool> <bead-id> --nudge")


### PR DESCRIPTION
The PL brief's dispatch section documents a 'gc-sling' wrapper that does not exist, and its recovery section documents 'gc session wake <agent>-1', which fails (sessions are addressed by id, not agent-ordinal). Both corrected to the real commands. Found in production use (Gas City, bead gci-5ok5); docs-only.