### PR TITLE
feat(github): add GitHub-native Beads work sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Stand each maintained pack up against gc
         run: |
           GC_TEST_BIN="$(go env GOPATH)/bin/gc" \
-            python3 -m pytest tests/test_maintained_packs_live_gc.py -q
+            python3 -m pytest tests/test_maintained_packs_live_gc.py github/tests/test_github_work_sync_order.py -q
 
       # gastown is not in the lint loop above because seven of its findings are
       # defects in gc's linter rather than in the pack; see

--- a/github/README.md
+++ b/github/README.md
@@ -83,11 +83,11 @@ gc order history work-sync --rig product
 
 Provide these non-secret runtime settings to the controller/order environment:
 
-- `GC_AGENT_PLATFORM_BIN`: absolute path to the Agent Platform CLI.
-- `GC_AGENT_PLATFORM_ROOT`: absolute path to the canonical fleet-contract root.
+- `GC_WORK_SYNC_POLICY_BIN`: absolute path to the work-sync policy provider executable.
+- `GC_WORK_SYNC_POLICY_ROOT`: absolute path to the policy contract root.
 - `GC_GITHUB_WORK_SYNC_DRY_RUN=1`: optional additional read-only guard.
 
-The runner reads `agent-platform --json work-sync runtime-contract` and uses
+The runner reads the configured provider’s `--json work-sync runtime-contract` and uses
 the pure `work-sync plan` command. The canonical contract's
 `live_mutations = false` always forces dry-run, even if the environment flag
 is absent. Dry-run performs authenticated reads and reports planned operation
@@ -96,8 +96,7 @@ GitHub App identity resolver/routing configuration as ingress; periodic runs
 mint short-lived installation tokens through the existing intake helpers.
 Do not configure a PAT or widen the intake App to delivery permissions.
 
-The runtime owns Issues/Projects v2 projection, reconciliation and receipts;
-Agent Platform supplies policy and a pure plan, not another worker or store.
+The runtime owns Issues/Projects v2 projection, reconciliation and receipts; the configured provider supplies policy and a pure plan, not another worker or store.
 It reads the exact Rig via native `gc beads snapshot` and applies incoming
 changes through whole-row `gc beads update-cas`. A native snapshot/CAS-capable
 Gas City build is required; comment imports additionally require transactional

--- a/github/README.md
+++ b/github/README.md
@@ -45,6 +45,89 @@ gc github release-workflow owner/repo 42
 source = "../packs/github"
 ```
 
+## Bidirectional Work Sync
+
+Work sync is opt-in per Rig. The City-level `github` import owns ingress,
+credentials and the existing GitHub service data directory; it deliberately
+does **not** register a City-wide work-sync order. Import the service-free
+`github/work-sync` subpack on each participating Rig:
+
+```toml
+# city.toml
+[[rigs]]
+name = "product"
+
+[rigs.imports.github_work_sync]
+source = "../packs/github/work-sync"
+```
+
+Bind that Rig's repository path in `.gc/site.toml`, as for any native Rig.
+For remote imports, use
+`https://github.com/gastownhall/gascity-packs.git//github/work-sync`, run
+`gc import install`, and pin ingress and work-sync to the **same accepted
+repository commit** in `packs.lock`. The subpack reuses
+`github/scripts/github_work_sync.py` and the intake helpers from that checkout;
+it does not copy credentials, start a second service, or import the City-only
+service pack into a Rig.
+
+The one `work-sync` order uses Gas City's existing five-minute cooldown,
+tracking and history. Two importing Rigs get independent scoped instances.
+Webhook actions with `route_from_repo = true` invoke this same order. Always
+select the exact Rig for a manual run:
+
+```sh
+gc order list
+gc order run work-sync --rig product
+gc order history work-sync --rig product
+```
+
+Provide these non-secret runtime settings to the controller/order environment:
+
+- `GC_AGENT_PLATFORM_BIN`: absolute path to the Agent Platform CLI.
+- `GC_AGENT_PLATFORM_ROOT`: absolute path to the canonical fleet-contract root.
+- `GC_GITHUB_WORK_SYNC_DRY_RUN=1`: optional additional read-only guard.
+
+The runner reads `agent-platform --json work-sync runtime-contract` and uses
+the pure `work-sync plan` command. The canonical contract's
+`live_mutations = false` always forces dry-run, even if the environment flag
+is absent. Dry-run performs authenticated reads and reports planned operation
+counts, but does not apply Beads or GitHub changes. Supply the same supported
+GitHub App identity resolver/routing configuration as ingress; periodic runs
+mint short-lived installation tokens through the existing intake helpers.
+Do not configure a PAT or widen the intake App to delivery permissions.
+
+The runtime owns Issues/Projects v2 projection, reconciliation and receipts;
+Agent Platform supplies policy and a pure plan, not another worker or store.
+It reads the exact Rig via native `gc beads snapshot` and applies incoming
+changes through whole-row `gc beads update-cas`. A native snapshot/CAS-capable
+Gas City build is required; comment imports additionally require transactional
+comment support in the selected Beads provider. Unsupported capabilities,
+unknown/mismatched routes, schema drift, identity collisions and concurrent
+edits fail closed. There is no direct database fallback. The experimental
+Beads proxied-server mode is not required.
+
+Stable node IDs bind Issues and Projects items to Beads; replay receipts stay
+under the target City's existing `.gc/services/github/data` root. Cross-City
+webhook dispatch must not inherit the ingress City's receipt location.
+Writes require readback, ambiguous
+transport outcomes are reconciled before retry, and conflicts prevent unsafe
+overwrite. A successful reconciliation requires a final zero-operation plan.
+Receipts distinguish the projected Bead revision from the revision proven by
+an incoming CAS; importing a request does not imply it was projected back.
+Output exposes counts and reason codes, not issue bodies or credentials.
+
+Run the native composition regression against a candidate Gas City binary:
+
+```sh
+GC_TEST_BIN=/absolute/path/to/gc \
+  python3 -m unittest discover -s github/tests -p test_github_work_sync_order.py -v
+```
+
+It imports the actual packs into two temporary file-store Rigs, checks that
+ingress creates no Rig-less reconciler, and exercises real order dispatch,
+per-Rig history and cooldown. Only the external Python runner is substituted;
+the test starts no supervisor and contacts neither GitHub nor a live store.
+
 ## Publication
 
 This pack expects helper-backed published services. After the workspace starts,

--- a/github/README.md
+++ b/github/README.md
@@ -105,6 +105,10 @@ unknown/mismatched routes, schema drift, identity collisions and concurrent
 edits fail closed. There is no direct database fallback. The experimental
 Beads proxied-server mode is not required.
 
+The runtime accepts exactly one current managed-block contract from the policy
+provider. A legacy or unknown marker fails before planning or writing; the Pack
+does not contain a compatibility migration writer.
+
 Stable node IDs bind Issues and Projects items to Beads; replay receipts stay
 under the target City's existing `.gc/services/github/data` root. Cross-City
 webhook dispatch must not inherit the ingress City's receipt location.

--- a/github/README.md
+++ b/github/README.md
@@ -56,6 +56,13 @@ This pack expects helper-backed published services. After the workspace starts,
 Open the tenant-visible `github-admin` URL to register the GitHub App from the
 hosted manifest helper.
 
+The generated intake manifest follows the least-privilege work-sync contour:
+repository metadata read, Issues write, Pull requests read (required for the
+subscribed webhook), organization Projects write, and organization Issue Types
+and Issue Fields read. It does not request Contents, Actions, Administration,
+or Workflows. Branch push and PR creation therefore require a separately
+scoped delivery identity instead of broadening the organization intake App.
+
 ## Bugflow Routing
 
 `/gc fix` now uses the workflows-pack bugflow router. Configure repository
@@ -99,6 +106,28 @@ name = "pr-review-request"
 github_app_token_env = "GH_TOKEN"
 ```
 
+For organization ingress that owns repositories in more than one registered
+City, declare the exact owning City and Rig once in the repo topology and opt
+the action into topology routing:
+
+```toml
+[[repo]]
+full_name = "owner/repo"
+city = "product-city"
+rig = "product"
+
+[[rule.action]]
+type = "order"
+name = "work-sync"
+route_from_repo = true
+```
+
+That action runs as
+`gc --city product-city order run work-sync --rig product`. Unknown repositories
+and incomplete City/Rig mappings fail closed before a subprocess starts; there
+is no fallback queue or repository-local work store. Rules without
+`route_from_repo = true` retain their existing local-City behavior.
+
 Rules ignore events sent by the configured GitHub App bot by default. Set
 `allow_self = true` on a rule when bot-authored label changes are intentional
 triggers, such as a GitHub Action adding `status/needs-triage`.
@@ -123,6 +152,7 @@ version = 1
 
 [[repo]]
 full_name = "owner/repo"
+city = "product-city"
 rig = "product"
 authorized_users = ["alice", "bob"]
 installation_id = "123456"

--- a/github/commands/create-pr/help.md
+++ b/github/commands/create-pr/help.md
@@ -1,8 +1,10 @@
-Create a pull request using the workspace-owned GitHub App installation.
+Create a pull request using a workspace-owned GitHub App installation. Prefer
+a separately scoped delivery identity; the least-privilege intake App has only
+Pull requests read permission.
 
 Example:
   gc github create-pr owner/repo \
-    --installation-id 123456 \
+    --github-app-identity delivery \
     --base main \
     --head fix-42 \
     --title "fix: correct widget behavior" \
@@ -12,7 +14,8 @@ Arguments:
   <repository> owner/repo
 
 Flags:
-  --installation-id <id>    GitHub App installation id
+  --github-app-identity <id> separately scoped delivery App identity
+  --installation-id <id>    override the identity's installation id
   --base <branch>           base branch for the PR
   --head <branch>           head branch for the PR
   --title <text>            PR title

--- a/github/commands/push-branch/help.md
+++ b/github/commands/push-branch/help.md
@@ -1,15 +1,17 @@
 Push the current git HEAD to a named GitHub branch using the workspace-owned
-GitHub App installation.
+GitHub App installation. Prefer a separately scoped delivery identity; the
+least-privilege intake App does not have Contents write permission.
 
 Example:
   gc github push-branch owner/repo \
-    --installation-id 123456 \
+    --github-app-identity delivery \
     --branch fix-42
 
 Arguments:
   <repository> owner/repo
 
 Flags:
-  --installation-id <id>    GitHub App installation id
+  --github-app-identity <id> separately scoped delivery App identity
+  --installation-id <id>    override the identity's installation id
   --branch <name>           branch name to create or update
   --ref <spec>              source ref to push (default: HEAD)

--- a/github/scripts/github_intake_common.py
+++ b/github/scripts/github_intake_common.py
@@ -259,6 +259,26 @@ def validate_github_app_identity(value: str, field: str = "github_app_identity")
     return identity
 
 
+def github_app_config_for_identity(identity: str = "") -> dict[str, Any]:
+    """Resolve a named App identity, or fall back to the intake App config.
+
+    Delivery commands use this boundary so their broader repository write
+    permissions can live on a separate App without widening the intake App.
+    """
+    identity = validate_github_app_identity(identity)
+    if identity:
+        # Imported lazily to keep the common module usable by the service that
+        # implements the resolver protocol.
+        import github_intake_service as service
+
+        return service.load_profile_github_app(identity)
+    config = load_effective_config()
+    app_cfg = config.get("app", {})
+    if isinstance(app_cfg, dict):
+        return app_cfg
+    return {}
+
+
 def publish_identity(
     app_fields: dict[str, Any],
     identity: str = "",
@@ -336,6 +356,32 @@ def github_repo_dispatch_rig(repository_full_name: str, rules_config: dict[str, 
         if rig:
             return rig
     return fallback
+
+
+def github_repo_dispatch_route(
+    repository_full_name: str,
+    rules_config: dict[str, Any] | None = None,
+) -> dict[str, str]:
+    """Return the exact owning City/Rig pair for a configured repository.
+
+    Cross-City webhook dispatch must never fall back to a derived local Rig:
+    an unknown or incomplete topology record fails closed instead.
+    """
+    repo_key = normalize_repo_key(repository_full_name)
+    if not repo_key:
+        return {}
+    repos = (rules_config if rules_config is not None else load_rules()).get("repos") or []
+    for repo in repos:
+        if not isinstance(repo, dict):
+            continue
+        if normalize_repo_key(str(repo.get("full_name", ""))) != repo_key:
+            continue
+        city = str(repo.get("city", "")).strip()
+        rig = str(repo.get("rig", "")).strip()
+        if city and rig:
+            return {"city": city, "rig": rig}
+        return {}
+    return {}
 
 
 def _set_command_formula(commands: dict[str, Any], name: str, formula: str | None) -> dict[str, Any]:
@@ -461,9 +507,12 @@ def build_manifest() -> dict[str, Any]:
         "description": "Workspace-hosted GitHub comment and event intake for Gas City",
         "public": False,
         "default_permissions": {
-            "contents": "write",
             "issues": "write",
-            "pull_requests": "write",
+            "metadata": "read",
+            "pull_requests": "read",
+            "organization_projects": "write",
+            "issue_types": "read",
+            "issue_fields": "read",
         },
         "default_events": [
             "issue_comment",
@@ -568,12 +617,16 @@ def normalize_repo_addresses(raw_repo: dict[str, Any], index: int) -> dict[str, 
     configured_rig = str(raw_repo.get("rig", "")).strip()
     if configured_rig and "/" in configured_rig:
         raise ValueError(f"repo {full_name!r}: rig must be a local rig name, not a target")
+    city = str(raw_repo.get("city", "")).strip()
+    if city and not configured_rig:
+        raise ValueError(f"repo {full_name!r}: city requires an explicit rig")
     rig = configured_rig or github_rig
     raw_addresses = raw_repo.get("address") or []
     if not isinstance(raw_addresses, list):
         raise ValueError(f"repo {full_name!r}: address must be an array of tables")
     return {
         "full_name": full_name,
+        "city": city,
         "github_rig": github_rig,
         "rig": rig,
         "authorized_users": _normalized_unique_strings(raw_repo.get("authorized_users")),

--- a/github/scripts/github_intake_common.py
+++ b/github/scripts/github_intake_common.py
@@ -16,6 +16,7 @@ import tomllib
 import urllib.error
 import urllib.parse
 import urllib.request
+from datetime import datetime
 from typing import Any
 
 WEBHOOK_SERVICE_NAME = "github-webhook"
@@ -1134,12 +1135,49 @@ def github_web_base() -> str:
     return urllib.parse.urlunparse((parsed.scheme or "https", host, path.rstrip("/"), "", "", "")).rstrip("/")
 
 
+def github_https_origin(value: str) -> str:
+    """Validate the work-sync API boundary before signing or sending credentials."""
+    message = "GitHub API URL must be an HTTPS origin"
+    if (
+        not isinstance(value, str)
+        or "?" in value or "#" in value
+        or any(char.isspace() or ord(char) < 32 or ord(char) == 127 for char in value)
+    ):
+        raise ValueError(message)
+    try:
+        parsed = urllib.parse.urlsplit(value)
+        port = parsed.port
+        valid = (
+            parsed.scheme == "https" and bool(parsed.hostname)
+            and parsed.username is None and parsed.password is None
+            and parsed.path in {"", "/"} and not parsed.query and not parsed.fragment
+            and (port is None or port > 0) and not parsed.netloc.endswith(":")
+        )
+    except ValueError:
+        raise ValueError(message) from None
+    if not valid:
+        raise ValueError(message)
+    return value.rstrip("/")
+
+
+class _NoGitHubRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        # Even same-origin redirects are not an accepted auth/write destination.
+        raise urllib.error.HTTPError(req.full_url, code, "GitHub redirect rejected", headers, fp)
+
+
+def github_no_redirect_urlopen(request: urllib.request.Request, *, timeout: float):
+    return urllib.request.build_opener(_NoGitHubRedirect()).open(request, timeout=timeout)
+
+
 def github_api_request(
     method: str,
     path: str,
     payload: dict[str, Any] | None = None,
     headers: dict[str, str] | None = None,
     bearer_token: str | None = None,
+    *,
+    allow_redirects: bool = True,
 ) -> dict[str, Any]:
     if path.startswith("http://") or path.startswith("https://"):
         url = path
@@ -1160,13 +1198,19 @@ def github_api_request(
         request_headers["Content-Type"] = "application/json"
     request = urllib.request.Request(url, data=body, headers=request_headers, method=method.upper())
     try:
-        with urllib.request.urlopen(request, timeout=20) as response:
+        open_request = urllib.request.urlopen if allow_redirects else github_no_redirect_urlopen
+        with open_request(request, timeout=20) as response:
             raw = response.read()
     except urllib.error.HTTPError as exc:
+        if not allow_redirects:
+            exc.close()
+            raise GitHubAPIError("GitHub scoped request failed") from None
         raw = exc.read()
         message = raw.decode("utf-8", errors="replace")
         raise GitHubAPIError(f"{method.upper()} {url} failed with {exc.code}: {message}") from exc
     except urllib.error.URLError as exc:
+        if not allow_redirects:
+            raise GitHubAPIError("GitHub scoped request failed") from None
         raise GitHubAPIError(f"{method.upper()} {url} failed: {exc}") from exc
     if not raw:
         return {}
@@ -1224,17 +1268,81 @@ def build_app_jwt(app_cfg: dict[str, Any]) -> str:
     return f"{signing_input.decode('ascii')}.{_base64url(signature)}"
 
 
-def create_installation_token(app_cfg: dict[str, Any], installation_id: str) -> str:
+def create_installation_token(
+    app_cfg: dict[str, Any],
+    installation_id: str,
+    *,
+    repository_full_name: str | None = None,
+    permissions: dict[str, str] | None = None,
+) -> str:
+    """Mint an installation token, proving exact scope when a consumer requests it."""
+    scoped = repository_full_name is not None or permissions is not None
+    request: dict[str, Any] = {}
+    requested_permissions: dict[str, str] = {}
+    if scoped:
+        github_https_origin(GITHUB_API_BASE)
+        if (
+            not isinstance(repository_full_name, str)
+            or not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repository_full_name)
+            or not isinstance(permissions, dict)
+            or not permissions
+            or any(
+                not isinstance(key, str)
+                or not re.fullmatch(r"[a-z][a-z0-9_]*", key)
+                or value not in ("read", "write", "none")
+                for key, value in permissions.items()
+            )
+        ):
+            raise GitHubAPIError("GitHub installation token scope is invalid")
+        requested_permissions = {key: value for key, value in permissions.items() if value != "none"}
+        if not requested_permissions:
+            raise GitHubAPIError("GitHub installation token permissions are empty")
+        request["payload"] = {
+            "repositories": [repository_full_name.split("/", 1)[1]],
+            "permissions": requested_permissions,
+        }
+        request["allow_redirects"] = False
     jwt_token = build_app_jwt(app_cfg)
     response = github_api_request(
         "POST",
         f"/app/installations/{installation_id}/access_tokens",
         bearer_token=jwt_token,
+        **request,
     )
-    token = response.get("token")
-    if not token:
+    token = response.get("token") if isinstance(response, dict) else None
+    if not isinstance(token, str) or not token:
         raise GitHubAPIError("GitHub installation token response did not include a token")
-    return str(token)
+    if scoped:
+        effective_permissions = response.get("permissions")
+        expected_permissions = {"metadata": "read", **requested_permissions}
+        if not isinstance(effective_permissions, dict) or {
+            key: value for key, value in effective_permissions.items() if value != "none"
+        } != expected_permissions:
+            raise GitHubAPIError("GitHub installation token permission readback mismatch")
+        try:
+            expires = datetime.fromisoformat(response["expires_at"].replace("Z", "+00:00"))
+            remaining = expires.timestamp() - time.time() if expires.tzinfo is not None else -1
+        except (KeyError, AttributeError, TypeError, ValueError, OverflowError):
+            remaining = -1
+        if not 0 < remaining <= 3600:
+            raise GitHubAPIError("GitHub installation token expiry readback is invalid")
+        readback = github_api_request(
+            "GET", "/installation/repositories?per_page=100", bearer_token=token,
+            allow_redirects=False,
+        )
+        repositories = readback.get("repositories") if isinstance(readback, dict) else None
+        total = readback.get("total_count") if isinstance(readback, dict) else None
+        if (
+            type(total) is not int
+            or total != 1
+            or not isinstance(repositories, list)
+            or len(repositories) != 1
+            or not isinstance(repositories[0], dict)
+            or not isinstance(repositories[0].get("full_name"), str)
+            or repositories[0]["full_name"].lower() != repository_full_name.lower()
+        ):
+            raise GitHubAPIError("GitHub installation token repository readback mismatch")
+    return token
 
 
 def repository_permission(

--- a/github/scripts/github_intake_create_pr.py
+++ b/github/scripts/github_intake_create_pr.py
@@ -25,7 +25,12 @@ def read_body(args: argparse.Namespace) -> str:
 def main() -> int:
     parser = argparse.ArgumentParser(description="Create a pull request via the workspace GitHub App")
     parser.add_argument("repository", help="owner/repo")
-    parser.add_argument("--installation-id", required=True, help="GitHub App installation id")
+    parser.add_argument("--installation-id", default="", help="GitHub App installation id")
+    parser.add_argument(
+        "--github-app-identity",
+        default="",
+        help="separately scoped delivery GitHub App identity",
+    )
     parser.add_argument("--base", required=True, help="base branch")
     parser.add_argument("--head", required=True, help="head branch")
     parser.add_argument("--title", required=True, help="PR title")
@@ -34,14 +39,19 @@ def main() -> int:
     group.add_argument("--body-file", default="", help="path to a markdown file")
     args = parser.parse_args()
 
-    config = common.load_config()
-    app_cfg = config.get("app", {})
+    try:
+        app_cfg = common.github_app_config_for_identity(args.github_app_identity)
+    except (RuntimeError, ValueError) as exc:
+        raise SystemExit(str(exc)) from exc
     if not isinstance(app_cfg, dict) or not app_cfg.get("app_id") or not app_cfg.get("private_key_pem"):
         raise SystemExit("GitHub App configuration is incomplete")
+    installation_id = str(args.installation_id or app_cfg.get("installation_id", "")).strip()
+    if not installation_id:
+        raise SystemExit("GitHub App installation id is required")
     owner, repo = split_repository(args.repository)
     pull_request = common.create_pull_request(
         app_cfg,
-        args.installation_id,
+        installation_id,
         owner,
         repo,
         args.title,

--- a/github/scripts/github_intake_push_branch.py
+++ b/github/scripts/github_intake_push_branch.py
@@ -11,18 +11,28 @@ import github_intake_common as common
 def main() -> int:
     parser = argparse.ArgumentParser(description="Push a branch via the workspace GitHub App")
     parser.add_argument("repository", help="owner/repo")
-    parser.add_argument("--installation-id", required=True, help="GitHub App installation id")
+    parser.add_argument("--installation-id", default="", help="GitHub App installation id")
+    parser.add_argument(
+        "--github-app-identity",
+        default="",
+        help="separately scoped delivery GitHub App identity",
+    )
     parser.add_argument("--branch", required=True, help="branch name to create or update")
     parser.add_argument("--ref", default="HEAD", help="source ref to push")
     args = parser.parse_args()
 
-    config = common.load_config()
-    app_cfg = config.get("app", {})
+    try:
+        app_cfg = common.github_app_config_for_identity(args.github_app_identity)
+    except (RuntimeError, ValueError) as exc:
+        raise SystemExit(str(exc)) from exc
     if not isinstance(app_cfg, dict) or not app_cfg.get("app_id") or not app_cfg.get("private_key_pem"):
         raise SystemExit("GitHub App configuration is incomplete")
+    installation_id = str(args.installation_id or app_cfg.get("installation_id", "")).strip()
+    if not installation_id:
+        raise SystemExit("GitHub App installation id is required")
     result = common.git_push_branch(
         app_cfg,
-        args.installation_id,
+        installation_id,
         args.repository,
         args.branch,
         ref=args.ref,

--- a/github/scripts/github_intake_service.py
+++ b/github/scripts/github_intake_service.py
@@ -1471,14 +1471,39 @@ def execute_rule_action(
     payload: dict[str, Any],
     payload_file: str,
     app_cfg: dict[str, Any],
+    rules_config: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     started = common.utcnow()
     action_type = str(action.get("type", "")).strip()
+    dispatch_route: dict[str, str] = {}
     if action_type == "order":
-        command = ["gc", "order", "run", render_template(str(action.get("name", "")), payload)]
-        rig = str(action.get("rig", "")).strip()
-        if rig:
-            command.extend(["--rig", render_template(rig, payload)])
+        order_name = render_template(str(action.get("name", "")), payload)
+        if bool(action.get("route_from_repo")):
+            repository = str((payload.get("repository") or {}).get("full_name", ""))
+            dispatch_route = common.github_repo_dispatch_route(repository, rules_config)
+            if not dispatch_route:
+                return {
+                    "type": action_type,
+                    "status": "failed",
+                    "reason": "repository_route_not_configured",
+                    "started_at": started,
+                    "finished_at": common.utcnow(),
+                }
+            command = [
+                "gc",
+                "--city",
+                dispatch_route["city"],
+                "order",
+                "run",
+                order_name,
+                "--rig",
+                dispatch_route["rig"],
+            ]
+        else:
+            command = ["gc", "order", "run", order_name]
+            rig = str(action.get("rig", "")).strip()
+            if rig:
+                command.extend(["--rig", render_template(rig, payload)])
     elif action_type == "command":
         raw_command = action.get("command") or []
         if not isinstance(raw_command, list) or not raw_command:
@@ -1501,6 +1526,9 @@ def execute_rule_action(
 
     try:
         env, token_env = action_env(action, event, delivery_id, payload, payload_file, app_cfg)
+        if dispatch_route:
+            env["GC_GITHUB_DISPATCH_CITY"] = dispatch_route["city"]
+            env["GC_GITHUB_DISPATCH_RIG"] = dispatch_route["rig"]
         result = run_subprocess(command, common.city_root() or ".", env=env)
     except Exception as exc:  # noqa: BLE001
         return {
@@ -1565,7 +1593,16 @@ def process_event_rules(event: str, delivery_id: str, payload: dict[str, Any], a
             "actions": [],
         }
         for index, action in enumerate(rule.get("action") or []):
-            outcome = execute_rule_action(rule, action, event, delivery_id, payload, payload_file, app_cfg)
+            outcome = execute_rule_action(
+                rule,
+                action,
+                event,
+                delivery_id,
+                payload,
+                payload_file,
+                app_cfg,
+                rules_config,
+            )
             outcome["index"] = index
             result["actions"].append(outcome)
             if outcome.get("status") != "success":

--- a/github/scripts/github_work_sync.py
+++ b/github/scripts/github_work_sync.py
@@ -1,0 +1,3775 @@
+#!/usr/bin/env python3
+"""Fail-closed runtime adapter for Agent Platform GitHub work-sync plans.
+
+The Agent Platform binary owns pure planning. This module owns only the Gas City
+runtime boundary: private snapshot/plan files, exact-store Beads CAS calls, and
+GitHub writes with bounded retry plus mandatory readback.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import copy
+import fcntl
+import hashlib
+import json
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+import uuid
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime
+from typing import Any, Callable
+
+
+_WORK_SYNC_TOKEN_ENV = "GC_GITHUB_WORK_SYNC_TOKEN"
+
+
+def runtime_environment(
+    environ: dict[str, str] | os._Environ[str],
+    contract: dict[str, object],
+) -> dict[str, str]:
+    route = contract.get("route") if isinstance(contract, dict) else None
+    organization = contract.get("organization") if isinstance(contract, dict) else None
+    if not isinstance(route, dict) or not isinstance(organization, str) or not organization:
+        raise RuntimeError("canonical work-sync route is unavailable")
+    repository = route.get("repository")
+    rig = environ.get("GC_RIG", "").strip()
+    city = (
+        environ.get("GC_CITY_PATH", "").strip()
+        or environ.get("GC_CITY_ROOT", "").strip()
+    )
+    platform_bin = environ.get("GC_AGENT_PLATFORM_BIN", "").strip()
+    platform_root = environ.get("GC_AGENT_PLATFORM_ROOT", "").strip()
+    full_name = environ.get("GC_GITHUB_REPO", "").strip().lower()
+    dispatch_city = environ.get("GC_GITHUB_DISPATCH_CITY", "").strip()
+    dispatch_rig = environ.get("GC_GITHUB_DISPATCH_RIG", "").strip()
+    expected_full_name = organization + "/" + str(repository)
+    if (
+        not isinstance(repository, str)
+        or not repository
+        or route.get("rig") != repository
+        or rig != route.get("rig")
+        or not city
+        or not os.path.isabs(city)
+        or not os.path.isabs(platform_bin)
+        or not os.path.isabs(platform_root)
+        or (full_name and full_name != expected_full_name)
+        or (dispatch_city and dispatch_city != route.get("city"))
+        or (dispatch_rig and dispatch_rig != route.get("rig"))
+    ):
+        raise RuntimeError("work-sync execution environment route mismatch")
+    delivery_id = environ.get("GC_GITHUB_DELIVERY_ID", "").strip()
+    if not delivery_id:
+        delivery_id = "reconciliation:" + str(uuid.uuid4())
+    return {
+        "repository": repository,
+        "repository_full_name": expected_full_name,
+        "rig": rig,
+        "city": city,
+        "agent_platform_bin": platform_bin,
+        "platform_root": platform_root,
+        "delivery_id": delivery_id,
+        "payload_file": environ.get("GC_GITHUB_EVENT_PAYLOAD_FILE", "").strip(),
+    }
+
+
+@contextlib.contextmanager
+def installation_token_context(
+    *,
+    repository_full_name: str,
+    token_env: str,
+    common: object,
+) -> object:
+    if os.environ.get(token_env):
+        yield
+        return
+    rules = common.load_rules()
+    repos = rules.get("repos") if isinstance(rules, dict) else None
+    matches = [
+        repo
+        for repo in repos or []
+        if isinstance(repo, dict)
+        and str(repo.get("full_name", "")).lower() == repository_full_name.lower()
+    ]
+    if len(matches) != 1:
+        raise RuntimeError("work-sync installation route is missing or ambiguous")
+    installation_id = str(matches[0].get("installation_id", "")).strip()
+    if not installation_id.isdigit() or int(installation_id) <= 0:
+        raise RuntimeError("work-sync installation identity is unavailable")
+    app_config = common.github_app_config_for_identity()
+    token = common.create_installation_token(app_config, installation_id)
+    if not isinstance(token, str) or not token:
+        raise RuntimeError("work-sync installation token could not be minted")
+    os.environ[token_env] = token
+    try:
+        yield
+    finally:
+        os.environ.pop(token_env, None)
+
+
+_VIEWER_QUERY = """
+query WorkSyncViewer {
+  viewer { id }
+}
+""".strip()
+
+
+def runtime_event(
+    environment: dict[str, str],
+    contract: dict[str, object],
+    transport: object,
+) -> tuple[dict[str, object], str]:
+    response = transport.graphql(_VIEWER_QUERY, {})
+    data = response.get("data") if isinstance(response, dict) else None
+    viewer = data.get("viewer") if isinstance(data, dict) else None
+    actor_node_id = viewer.get("id") if isinstance(viewer, dict) else None
+    if not isinstance(actor_node_id, str) or not actor_node_id:
+        raise RuntimeError("GitHub projection actor identity is unavailable")
+    origin = "github-human"
+    payload_file = environment.get("payload_file", "")
+    if payload_file:
+        if (
+            not os.path.isabs(payload_file)
+            or not os.path.isfile(payload_file)
+            or os.path.islink(payload_file)
+        ):
+            raise RuntimeError("GitHub webhook payload file is invalid")
+        try:
+            with open(payload_file, "r", encoding="utf-8") as source:
+                payload = json.load(source)
+        except (OSError, TypeError, ValueError) as exc:
+            raise RuntimeError("GitHub webhook payload readback failed") from exc
+        repository = payload.get("repository") if isinstance(payload, dict) else None
+        sender = payload.get("sender") if isinstance(payload, dict) else None
+        sender_node_id = sender.get("node_id") if isinstance(sender, dict) else None
+        if (
+            not isinstance(repository, dict)
+            or repository.get("full_name") != environment.get("repository_full_name")
+            or not isinstance(sender_node_id, str)
+            or not sender_node_id
+        ):
+            raise RuntimeError("GitHub webhook stable route is invalid")
+        if sender_node_id == actor_node_id:
+            origin = str(contract.get("projection_writer", ""))
+    if origin not in {"github-human", contract.get("projection_writer")}:
+        raise RuntimeError("GitHub webhook origin is outside the contract")
+    return {
+        "delivery_id": environment["delivery_id"],
+        "origin": origin,
+    }, actor_node_id
+
+
+class TransientTransportError(RuntimeError):
+    """The transport proves the failed attempt did not commit."""
+
+
+class AmbiguousTransportError(RuntimeError):
+    """The transport cannot prove whether the attempted write committed."""
+
+
+class GitHubHTTPTransport:
+    """Versioned GitHub REST/GraphQL transport with no retained credential."""
+
+    def __init__(
+        self,
+        *,
+        token_env: str,
+        api_url: str = "https://api.github.com",
+        timeout: float = 30.0,
+        urlopen: Callable[..., object] = urllib.request.urlopen,
+    ) -> None:
+        if not token_env or not isinstance(token_env, str):
+            raise ValueError("GitHub installation token environment is required")
+        parsed = urllib.parse.urlparse(api_url)
+        if parsed.scheme != "https" or not parsed.netloc or parsed.path not in {"", "/"}:
+            raise ValueError("GitHub API URL must be an HTTPS origin")
+        if timeout <= 0:
+            raise ValueError("GitHub transport timeout must be positive")
+        self.token_env = token_env
+        self.api_url = api_url.rstrip("/")
+        self.timeout = timeout
+        self.urlopen = urlopen
+
+    @staticmethod
+    def _is_write(method: str) -> bool:
+        return method not in {"GET", "HEAD", "OPTIONS"}
+
+    @staticmethod
+    def _rate_limited(status: int, headers: object) -> bool:
+        if status == 429:
+            return True
+        if status != 403 or headers is None:
+            return False
+        get = getattr(headers, "get", None)
+        if not callable(get):
+            return False
+        return bool(get("Retry-After")) or get("X-RateLimit-Remaining") == "0"
+
+    def _raise_transport_failure(
+        self,
+        method: str,
+        *,
+        status: int | None = None,
+        headers: object = None,
+    ) -> None:
+        if status is not None and self._rate_limited(status, headers):
+            raise TransientTransportError("GitHub rate limit rejected the request")
+        if status is not None and status < 500:
+            raise RuntimeError("GitHub request was rejected")
+        if self._is_write(method):
+            raise AmbiguousTransportError(
+                "GitHub write transport outcome is ambiguous"
+            )
+        raise TransientTransportError("GitHub read transport failed")
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        payload: object = None,
+        *,
+        graphql_write: bool = False,
+    ) -> object:
+        method = method.upper()
+        if not path.startswith("/") or path.startswith("//"):
+            raise ValueError("GitHub request path must be absolute")
+        token = os.environ.get(self.token_env, "")
+        if not token:
+            raise RuntimeError("GitHub installation token is unavailable")
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "Authorization": "Bearer " + token,
+            "User-Agent": "gascity-github-work-sync",
+            "X-GitHub-Api-Version": "2026-03-10",
+        }
+        data = None
+        if payload is not None:
+            try:
+                data = json.dumps(
+                    payload,
+                    ensure_ascii=True,
+                    separators=(",", ":"),
+                ).encode("utf-8")
+            except (TypeError, ValueError) as exc:
+                raise ValueError("GitHub request payload must be JSON") from exc
+            headers["Content-Type"] = "application/json"
+        request = urllib.request.Request(
+            self.api_url + path,
+            data=data,
+            headers=headers,
+            method=method,
+        )
+        effective_method = "POST" if graphql_write else method
+        try:
+            with self.urlopen(request, timeout=self.timeout) as response:
+                status = int(getattr(response, "status", 200))
+                if status < 200 or status >= 300:
+                    self._raise_transport_failure(
+                        effective_method,
+                        status=status,
+                        headers=getattr(response, "headers", None),
+                    )
+                raw = response.read()
+        except urllib.error.HTTPError as exc:
+            self._raise_transport_failure(
+                effective_method,
+                status=exc.code,
+                headers=exc.headers,
+            )
+        except (urllib.error.URLError, TimeoutError, OSError):
+            self._raise_transport_failure(effective_method)
+        if not raw:
+            return {}
+        try:
+            result = json.loads(raw.decode("utf-8"))
+        except (UnicodeDecodeError, TypeError, ValueError) as exc:
+            raise RuntimeError("GitHub response was not valid JSON") from exc
+        if not isinstance(result, (dict, list)):
+            raise RuntimeError("GitHub response JSON has an unsupported shape")
+        return result
+
+    def rest(self, method: str, path: str, payload: object = None) -> object:
+        """Call a version-pinned GitHub REST endpoint."""
+        return self._request(method, path, payload)
+
+    def graphql(self, query: str, variables: dict[str, object]) -> object:
+        """Call GitHub GraphQL and classify mutation errors as ambiguous."""
+        if not isinstance(query, str) or not query.strip() or not isinstance(variables, dict):
+            raise ValueError("GitHub GraphQL query and variables are required")
+        is_mutation = query.lstrip().startswith("mutation")
+        result = self._request(
+            "POST",
+            "/graphql",
+            {"query": query, "variables": variables},
+            graphql_write=is_mutation,
+        )
+        if isinstance(result, dict) and result.get("errors"):
+            if is_mutation:
+                raise AmbiguousTransportError(
+                    "GitHub GraphQL mutation outcome is ambiguous"
+                )
+            raise RuntimeError("GitHub GraphQL query failed")
+        return result
+
+
+def _private_json(path: str, value: object) -> None:
+    descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+        json.dump(value, handle, ensure_ascii=False, sort_keys=True)
+        handle.write("\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+
+
+_RECEIPT_FIELDS = {
+    "schema_version",
+    "bead_id",
+    "repository",
+    "store_ref",
+    "bead_revision",
+    "github_updated_at",
+    "project_field_hash",
+    "projection_hash",
+    "delivery_id",
+    "imported_comment_ids",
+}
+
+
+def _valid_pending_push(value: object) -> bool:
+    return bool(
+        isinstance(value, dict)
+        and set(value) == {"kind", "before_hash", "after_hash"}
+        and value.get("kind") == "github-write"
+        and _sha256(value.get("before_hash"))
+        and _sha256(value.get("after_hash"))
+    )
+
+
+def _unique_comment_ids(value: object) -> bool:
+    return (
+        isinstance(value, list)
+        and all(isinstance(item, str) and item for item in value)
+        and len(value) == len(set(value))
+    )
+
+
+def _valid_pending_pull(value: object) -> bool:
+    if not isinstance(value, dict) or set(value) != {
+        "kind", "field_hashes", "before_comment_ids", "after_comment_ids", "base",
+    } or value.get("kind") != "beads-cas":
+        return False
+    fields = value.get("field_hashes")
+    before, after = value.get("before_comment_ids"), value.get("after_comment_ids")
+    return bool(
+        isinstance(fields, dict)
+        and _valid_convergence_base(value.get("base"))
+        and set(fields).issubset({"title", "description", "status", "priority", "type"})
+        and all(_sha256(digest) for digest in fields.values())
+        and _unique_comment_ids(before) and _unique_comment_ids(after)
+        and set(before).issubset(after)
+        and (fields or set(after) != set(before))
+    )
+
+
+def _valid_pending_creation(value: object) -> bool:
+    return bool(
+        isinstance(value, dict)
+        and set(value) == {"kind", "operation_hash", "projection_hash"}
+        and value.get("kind") == "create-projection"
+        and _sha256(value.get("operation_hash"))
+        and _sha256(value.get("projection_hash"))
+    )
+
+
+_STABLE_GITHUB_ID_FIELDS = (
+    "repository_id", "issue_node_id", "issue_number", "project_node_id", "project_item_id",
+)
+
+
+def _valid_pending_binding(value: object) -> bool:
+    if not isinstance(value, dict) or set(value) != {
+        "kind", "before_revision", "stable_identity",
+    } or value.get("kind") != "bind-bead":
+        return False
+    revision = value.get("before_revision")
+    identity = value.get("stable_identity")
+    return bool(
+        isinstance(revision, int) and not isinstance(revision, bool) and revision != 0
+        and isinstance(identity, dict) and set(identity) == set(_STABLE_GITHUB_ID_FIELDS)
+        and isinstance(identity.get("repository_id"), int)
+        and not isinstance(identity["repository_id"], bool) and identity["repository_id"] > 0
+        and isinstance(identity.get("issue_number"), int)
+        and not isinstance(identity["issue_number"], bool) and identity["issue_number"] > 0
+        and all(isinstance(identity.get(field), str) and identity[field]
+                for field in ("issue_node_id", "project_node_id", "project_item_id"))
+    )
+
+
+def _pending_binding(revision: int, binding: dict[str, object]) -> dict[str, object]:
+    return {
+        "kind": "bind-bead", "before_revision": revision,
+        "stable_identity": {field: binding[field] for field in _STABLE_GITHUB_ID_FIELDS},
+    }
+
+
+def _pending_creation(item: dict[str, object]) -> dict[str, object]:
+    value = item.get("value")
+    issue = value.get("issue") if isinstance(value, dict) else None
+    projection_hash = issue.get("projection_hash") if isinstance(issue, dict) else None
+    if not _sha256(projection_hash):
+        raise ValueError("create projection hash is invalid")
+    return {
+        "kind": "create-projection",
+        "operation_hash": hashlib.sha256(json.dumps(
+            item, ensure_ascii=False, sort_keys=True, separators=(",", ":"),
+        ).encode("utf-8")).hexdigest(),
+        "projection_hash": projection_hash,
+    }
+
+
+def _valid_convergence_base(value: object) -> bool:
+    return bool(
+        isinstance(value, dict) and set(value) == {
+            "bead_revision", "github_updated_at", "project_field_hash", "projection_hash", "delivery_id",
+        }
+        and isinstance(value.get("bead_revision"), int)
+        and not isinstance(value["bead_revision"], bool) and value["bead_revision"] != 0
+        and _sha256(value.get("project_field_hash")) and _sha256(value.get("projection_hash"))
+        and all(isinstance(value.get(field), str) and value[field] for field in ("github_updated_at", "delivery_id"))
+    )
+
+
+def _pending_pull(patch: dict[str, object], binding: dict[str, object], base: object) -> dict[str, object]:
+    if not _valid_convergence_base(base):
+        raise ValueError("pull requires a proved convergence base")
+    before = binding["imported_comment_ids"]
+    return {
+        "kind": "beads-cas",
+        "base": dict(base),
+        "field_hashes": {
+            field: hashlib.sha256(json.dumps(
+                value, ensure_ascii=False, sort_keys=True, separators=(",", ":"),
+            ).encode("utf-8")).hexdigest()
+            for field, value in patch.items() if field != "comments"
+        },
+        "before_comment_ids": list(before),
+        "after_comment_ids": sorted(set(before) | {
+            comment["external_id"] for comment in patch.get("comments", [])
+        }),
+    }
+
+
+class WorkSyncReceiptStore:
+    """Mutable convergence bases inside the existing GitHub Pack data root."""
+
+    def __init__(
+        self,
+        *,
+        repository: str,
+        store_ref: str,
+        data_root: str | None = None,
+    ) -> None:
+        if (
+            not isinstance(repository, str)
+            or not repository
+            or "/" in repository
+            or not isinstance(store_ref, str)
+            or not store_ref.startswith("rig:")
+            or "/" in store_ref
+        ):
+            raise ValueError("receipt store requires an exact repository and Rig store")
+        self.repository = repository
+        self.store_ref = store_ref
+        if data_root is None:
+            import github_intake_common as common
+
+            data_root = common.data_dir()
+        self.root = os.path.join(data_root, "work-sync-receipts")
+
+    def _path(self, bead_id: str) -> str:
+        if not isinstance(bead_id, str) or not bead_id:
+            raise ValueError("receipt bead identity is required")
+        digest = hashlib.sha256(
+            json.dumps(
+                [bead_id, self.repository, self.store_ref],
+                ensure_ascii=True,
+                separators=(",", ":"),
+            ).encode("ascii")
+        ).hexdigest()
+        return os.path.join(self.root, digest + ".json")
+
+    def _validate(
+        self,
+        payload: object,
+        *,
+        bead_id: str,
+        repository: str,
+        store_ref: str,
+    ) -> dict[str, object]:
+        creation_fields = {
+            "schema_version", "bead_id", "repository", "store_ref", "bead_revision", "pending",
+        }
+        if isinstance(payload, dict) and set(payload) == creation_fields:
+            if (
+                payload.get("schema_version") == 1
+                and payload.get("bead_id") == bead_id
+                and payload.get("repository") == repository
+                and payload.get("store_ref") == store_ref
+                and isinstance(payload.get("bead_revision"), int)
+                and not isinstance(payload["bead_revision"], bool)
+                and payload["bead_revision"] != 0
+                and _valid_pending_creation(payload.get("pending"))
+            ):
+                return dict(payload)
+            raise RuntimeError("work-sync creation receipt is malformed or belongs to another identity")
+        if (
+            not isinstance(payload, dict)
+            or not _RECEIPT_FIELDS.issubset(payload)
+            or set(payload) - _RECEIPT_FIELDS - {"applied_bead_revision", "pending"}
+            or ("pending" in payload and not (
+                _valid_pending_push(payload["pending"]) or _valid_pending_pull(payload["pending"])
+                or _valid_pending_binding(payload["pending"])
+            ))
+            or payload.get("schema_version") != 1
+            or payload.get("bead_id") != bead_id
+            or payload.get("repository") != repository
+            or payload.get("store_ref") != store_ref
+            or not isinstance(payload.get("bead_revision"), int)
+            or isinstance(payload["bead_revision"], bool)
+            or payload["bead_revision"] == 0
+            or not isinstance(payload.get("applied_bead_revision", payload["bead_revision"]), int)
+            or isinstance(payload.get("applied_bead_revision"), bool)
+            or payload.get("applied_bead_revision", payload["bead_revision"]) == 0
+            or not isinstance(payload.get("github_updated_at"), str)
+            or not payload["github_updated_at"]
+            or not _sha256(payload.get("project_field_hash"))
+            or not _sha256(payload.get("projection_hash"))
+            or not isinstance(payload.get("delivery_id"), str)
+            or not payload["delivery_id"]
+            or not isinstance(payload.get("imported_comment_ids"), list)
+            or any(
+                not isinstance(item, str) or not item
+                for item in payload["imported_comment_ids"]
+            )
+            or len(payload["imported_comment_ids"])
+            != len(set(payload["imported_comment_ids"]))
+        ):
+            raise RuntimeError("work-sync receipt is malformed or belongs to another identity")
+        return dict(payload)
+
+    def load(self, bead_id: str, repository: str, store_ref: str) -> object:
+        if repository != self.repository or store_ref != self.store_ref:
+            raise RuntimeError("work-sync receipt route mismatch")
+        path = self._path(bead_id)
+        try:
+            with open(path, "r", encoding="utf-8") as source:
+                payload = json.load(source)
+        except FileNotFoundError:
+            return None
+        except (OSError, TypeError, ValueError) as exc:
+            raise RuntimeError("work-sync receipt read failed") from exc
+        return self._validate(
+            payload,
+            bead_id=bead_id,
+            repository=repository,
+            store_ref=store_ref,
+        )
+
+    def save(
+        self,
+        identity: dict[str, object],
+        bead_revision: int,
+        binding: dict[str, object],
+        *,
+        applied_bead_revision: int | None = None,
+        pending: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        if (
+            not isinstance(identity, dict)
+            or identity.get("repository") != self.repository
+            or not isinstance(identity.get("bead_id"), str)
+            or not identity["bead_id"]
+        ):
+            raise ValueError("receipt identity is outside the configured route")
+        normalized = _normalized_binding(
+            binding,
+            identity,
+            allow_unbound=not _stable_identity(identity),
+        )
+        payload = {
+            "schema_version": 1,
+            "bead_id": identity["bead_id"],
+            "repository": self.repository,
+            "store_ref": self.store_ref,
+            "bead_revision": bead_revision,
+            "github_updated_at": normalized["github_updated_at"],
+            "project_field_hash": normalized["project_field_hash"],
+            "projection_hash": normalized["projection_hash"],
+            "delivery_id": normalized["delivery_id"],
+            "imported_comment_ids": list(normalized["imported_comment_ids"]),
+        }
+        if applied_bead_revision is not None:
+            payload["applied_bead_revision"] = applied_bead_revision
+        if pending is not None:
+            payload["pending"] = dict(pending)
+        receipt = self._validate(
+            payload,
+            bead_id=str(identity["bead_id"]),
+            repository=self.repository,
+            store_ref=self.store_ref,
+        )
+        return self._persist(str(identity["bead_id"]), receipt)
+
+    def _persist(
+        self, bead_id: str, receipt: dict[str, object],
+    ) -> dict[str, object]:
+        path = self._path(bead_id)
+        os.makedirs(self.root, mode=0o750, exist_ok=True)
+        lock_path = path + ".lock"
+        descriptor = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
+        try:
+            fcntl.flock(descriptor, fcntl.LOCK_EX)
+            temporary = tempfile.NamedTemporaryFile(
+                dir=self.root,
+                prefix=".work-sync-receipt-",
+                delete=False,
+            )
+            temporary_path = temporary.name
+            try:
+                with temporary:
+                    temporary.write(
+                        json.dumps(
+                            receipt,
+                            ensure_ascii=False,
+                            indent=2,
+                            sort_keys=True,
+                        ).encode("utf-8")
+                        + b"\n"
+                    )
+                    temporary.flush()
+                    os.fchmod(temporary.fileno(), 0o600)
+                    os.fsync(temporary.fileno())
+                os.replace(temporary_path, path)
+                directory = os.open(self.root, os.O_RDONLY)
+                try:
+                    os.fsync(directory)
+                finally:
+                    os.close(directory)
+            finally:
+                try:
+                    os.unlink(temporary_path)
+                except FileNotFoundError:
+                    pass
+        finally:
+            fcntl.flock(descriptor, fcntl.LOCK_UN)
+            os.close(descriptor)
+        return receipt
+
+    def begin(
+        self, identity: dict[str, object], bead_revision: int,
+        binding: dict[str, object], pending: dict[str, object],
+    ) -> dict[str, object]:
+        """Persist content-free intent before the external side effect."""
+        return self.save(identity, bead_revision, binding, pending=pending)
+
+    def begin_creation(
+        self, identity: dict[str, object], bead_revision: int, pending: dict[str, object],
+    ) -> dict[str, object]:
+        if (
+            not isinstance(identity, dict)
+            or identity.get("repository") != self.repository
+            or not isinstance(identity.get("bead_id"), str)
+            or not identity["bead_id"]
+        ):
+            raise ValueError("creation receipt identity is outside the configured route")
+        payload = self._validate({
+            "schema_version": 1,
+            "bead_id": identity["bead_id"],
+            "repository": self.repository,
+            "store_ref": self.store_ref,
+            "bead_revision": bead_revision,
+            "pending": dict(pending),
+        }, bead_id=str(identity["bead_id"]), repository=self.repository, store_ref=self.store_ref)
+        return self._persist(str(identity["bead_id"]), payload)
+
+    def begin_binding(
+        self, identity: dict[str, object], bead_revision: int,
+        binding: dict[str, object], pending: dict[str, object],
+    ) -> dict[str, object]:
+        if not _valid_pending_binding(pending):
+            raise ValueError("binding receipt intent is invalid")
+        return self.save(identity, bead_revision, binding, pending=pending)
+
+
+class BeadsSnapshotReader:
+    """Capture one exact Gas City store without exposing private row content."""
+
+    def __init__(
+        self,
+        *,
+        city: str,
+        rig: str,
+        repository: str,
+        gc_bin: str = "gc",
+        run: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+        load_receipt: Callable[[str, str, str], object] | None = None,
+    ) -> None:
+        if not city or not rig or "/" in rig or not repository or "/" in repository:
+            raise ValueError("exact City, local Rig, and repository are required")
+        self.city = city
+        self.rig = rig
+        self.repository = repository
+        self.gc_bin = gc_bin
+        self.run = run
+        self.load_receipt = load_receipt or (lambda _bead_id, _repository, _store_ref: None)
+
+    def read(self) -> list[dict[str, object]]:
+        command = [
+            self.gc_bin,
+            "--city",
+            self.city,
+            "beads",
+            "snapshot",
+            "--store-ref=rig:" + self.rig,
+            "--json",
+        ]
+        try:
+            result = self.run(
+                command,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        except OSError as exc:
+            raise RuntimeError("gc beads snapshot failed") from exc
+        if result.returncode != 0:
+            raise RuntimeError("gc beads snapshot failed")
+        try:
+            payload = json.loads(result.stdout)
+        except (TypeError, ValueError) as exc:
+            raise RuntimeError("gc beads snapshot returned malformed JSON") from exc
+        expected_ref = "rig:" + self.rig
+        if (
+            not isinstance(payload, dict)
+            or payload.get("schema_version") != "1"
+            or payload.get("ok") is not True
+            or payload.get("store_ref") != expected_ref
+            or not isinstance(payload.get("beads"), list)
+        ):
+            raise RuntimeError("gc beads snapshot did not prove the exact store")
+        records: list[dict[str, object]] = []
+        for raw in payload["beads"]:
+            if not isinstance(raw, dict):
+                raise RuntimeError("gc beads snapshot returned a malformed row")
+            issue = dict(raw)
+            dependencies = issue.pop("dependencies", None)
+            count = issue.get("dependency_count")
+            if (
+                not isinstance(dependencies, list)
+                or not isinstance(count, int)
+                or isinstance(count, bool)
+                or count != len(dependencies)
+                or any(not isinstance(item, dict) for item in dependencies)
+            ):
+                raise RuntimeError("gc beads snapshot returned incomplete dependencies")
+            records.append(
+                {
+                    "repository": self.repository,
+                    "issue": issue,
+                    "dependencies": dependencies,
+                    "receipt": self.load_receipt(
+                        str(issue.get("id", "")),
+                        self.repository,
+                        expected_ref,
+                    ),
+                }
+            )
+        return records
+
+
+class ContractRunner:
+    """Read one canonical repository contract through the Agent Platform CLI."""
+
+    def __init__(
+        self,
+        run: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+    ) -> None:
+        self.run = run
+
+    def read(
+        self,
+        *,
+        repository: str,
+        agent_platform_bin: str,
+        platform_root: str,
+    ) -> dict[str, object]:
+        if (
+            not isinstance(repository, str)
+            or not repository
+            or "/" in repository
+            or not os.path.isabs(agent_platform_bin)
+            or not os.path.isabs(platform_root)
+        ):
+            raise ValueError("exact repository, planner binary, and platform root are required")
+        with tempfile.TemporaryDirectory(prefix="github-work-sync-contract-") as tempdir:
+            os.chmod(tempdir, 0o700)
+            output_path = os.path.join(tempdir, "runtime-contract.json")
+            command = [
+                agent_platform_bin,
+                "--json",
+                "work-sync",
+                "runtime-contract",
+                "--repository",
+                repository,
+                "--output",
+                output_path,
+                "--platform-root",
+                platform_root,
+            ]
+            result = self.run(
+                command,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if result.returncode != 0:
+                raise RuntimeError("work-sync runtime contract failed")
+            if not os.path.isfile(output_path) or os.path.islink(output_path):
+                raise RuntimeError("work-sync runtime contract is not a regular file")
+            if os.stat(output_path).st_mode & 0o777 != 0o600:
+                raise RuntimeError("work-sync runtime contract must have mode 0600")
+            try:
+                with open(output_path, "r", encoding="utf-8") as source:
+                    contract = json.load(source)
+            except (OSError, TypeError, ValueError) as exc:
+                raise RuntimeError("work-sync runtime contract is malformed") from exc
+        route = contract.get("route") if isinstance(contract, dict) else None
+        if not isinstance(route, dict) or route.get("repository") != repository:
+            raise RuntimeError("work-sync runtime contract route mismatch")
+        return contract
+
+
+_BOUND_PROJECT_ITEM_QUERY = """
+query WorkSyncProjectItem($item: ID!) {
+  node(id: $item) {
+    ... on ProjectV2Item {
+      id
+      isArchived
+      project { id }
+      content {
+        ... on Issue {
+          id
+          number
+          repository { id nameWithOwner }
+        }
+      }
+      fieldValues(first: 100) {
+        nodes {
+          ... on ProjectV2ItemFieldSingleSelectValue {
+            name
+            field { ... on ProjectV2FieldCommon { name } }
+          }
+          ... on ProjectV2ItemFieldTextValue {
+            text
+            field { ... on ProjectV2FieldCommon { name } }
+          }
+        }
+      }
+    }
+  }
+}
+""".strip()
+
+_PROJECT_ITEMS_QUERY = """
+query WorkSyncProjectItems($project: ID!, $after: String) {
+  node(id: $project) {
+    ... on ProjectV2 {
+      id
+      items(first: 100, after: $after) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id
+          isArchived
+          project { id }
+          content {
+            ... on Issue {
+              id
+              number
+              repository { id nameWithOwner }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+""".strip()
+
+
+class GitHubSnapshotReader:
+    """Re-read effective Issue, comments, and ProjectV2 item before planning."""
+
+    def __init__(
+        self,
+        *,
+        organization: str,
+        repository: str,
+        transport: object,
+        projection_actor_node_id: str,
+        max_pages: int = 100,
+    ) -> None:
+        if (
+            not organization
+            or "/" in organization
+            or not repository
+            or "/" in repository
+            or not projection_actor_node_id
+            or not isinstance(max_pages, int)
+            or isinstance(max_pages, bool)
+            or max_pages <= 0
+            or max_pages > 100
+        ):
+            raise ValueError("invalid GitHub snapshot routing or pagination policy")
+        self.organization = organization
+        self.repository = repository
+        self.transport = transport
+        self.projection_actor_node_id = projection_actor_node_id
+        self.max_pages = max_pages
+
+    def _base_path(self) -> str:
+        return "/repos/{0}/{1}".format(
+            urllib.parse.quote(self.organization, safe=""),
+            urllib.parse.quote(self.repository, safe=""),
+        )
+
+    def _comments(self, issue_number: int) -> list[dict[str, object]]:
+        comments: list[dict[str, object]] = []
+        for page in range(1, self.max_pages + 1):
+            rows = self.transport.rest(
+                "GET",
+                self._base_path()
+                + "/issues/{0}/comments?per_page=100&page={1}".format(
+                    issue_number, page
+                ),
+            )
+            if not isinstance(rows, list) or any(not isinstance(row, dict) for row in rows):
+                raise RuntimeError("GitHub comment readback is malformed")
+            for row in rows:
+                user = row.get("user")
+                comments.append(
+                    {
+                        "node_id": row.get("node_id"),
+                        "body": row.get("body"),
+                        "created_at": row.get("created_at"),
+                        "user": {
+                            "node_id": user.get("node_id")
+                            if isinstance(user, dict)
+                            else None
+                        },
+                    }
+                )
+            if len(rows) < 100:
+                return comments
+        raise RuntimeError("GitHub comment pagination exceeded the bounded policy")
+
+    def projection_candidates(self) -> list[dict[str, object]]:
+        """Enumerate every Issue in the exact repository for absence proof."""
+        candidates: list[dict[str, object]] = []
+        for page in range(1, self.max_pages + 1):
+            rows = self.transport.rest(
+                "GET",
+                self._base_path()
+                + "/issues?state=all&per_page=100&page={0}".format(page),
+            )
+            if not isinstance(rows, list) or any(not isinstance(row, dict) for row in rows):
+                raise RuntimeError("GitHub Issue reconciliation page is malformed")
+            for row in rows:
+                if "pull_request" in row:
+                    continue
+                body = row.get("body")
+                if (
+                    not isinstance(row.get("node_id"), str)
+                    or not row["node_id"]
+                    or not isinstance(row.get("number"), int)
+                    or isinstance(row["number"], bool)
+                    or row["number"] <= 0
+                    or "body" not in row
+                    or (body is not None and not isinstance(body, str))
+                ):
+                    raise RuntimeError("GitHub Issue reconciliation identity is malformed")
+                candidates.append(
+                    {
+                        "node_id": row["node_id"],
+                        "number": row["number"],
+                        "body": "" if body is None else body,
+                    }
+                )
+            if len(rows) < 100:
+                return candidates
+        raise RuntimeError("GitHub Issue reconciliation exceeded the bounded policy")
+
+    def _project_items(
+        self,
+        project_title: str,
+        project_id: str,
+    ) -> list[tuple[str, dict[str, object]]]:
+        result: list[tuple[str, dict[str, object]]] = []
+        after: str | None = None
+        for _page in range(self.max_pages):
+            response = self.transport.graphql(
+                _PROJECT_ITEMS_QUERY,
+                {"project": project_id, "after": after},
+            )
+            data = response.get("data") if isinstance(response, dict) else None
+            project = data.get("node") if isinstance(data, dict) else None
+            items = project.get("items") if isinstance(project, dict) else None
+            nodes = items.get("nodes") if isinstance(items, dict) else None
+            page_info = items.get("pageInfo") if isinstance(items, dict) else None
+            if (
+                not isinstance(project, dict)
+                or project.get("id") != project_id
+                or not isinstance(nodes, list)
+                or any(not isinstance(item, dict) for item in nodes)
+                or not isinstance(page_info, dict)
+                or not isinstance(page_info.get("hasNextPage"), bool)
+            ):
+                raise RuntimeError("GitHub Project item inventory is malformed")
+            result.extend((project_title, item) for item in nodes)
+            if not page_info["hasNextPage"]:
+                return result
+            after = page_info.get("endCursor")
+            if not isinstance(after, str) or not after:
+                raise RuntimeError("GitHub Project item pagination cursor is missing")
+        raise RuntimeError("GitHub Project item pagination exceeded the bounded policy")
+
+    def reconciliation_records(
+        self,
+        *,
+        projects: dict[str, object],
+        managed_blocks: list[dict[str, object]],
+        owning_project: str,
+        cross_city_project: str,
+        cross_city_bead_types: list[str],
+        event: dict[str, object],
+    ) -> list[dict[str, object]]:
+        """Inventory the whole managed Issue/Project surface for one repository."""
+        expected_titles = {owning_project, cross_city_project}
+        if (
+            not isinstance(projects, dict)
+            or set(projects) != expected_titles
+            or not isinstance(managed_blocks, list)
+            or not managed_blocks
+            or not isinstance(cross_city_bead_types, list)
+            or not cross_city_bead_types
+            or len(cross_city_bead_types) != len(set(cross_city_bead_types))
+            or any(not isinstance(value, str) or not value for value in cross_city_bead_types)
+            or not isinstance(event, dict)
+        ):
+            raise ValueError("GitHub reconciliation contract is malformed")
+        project_ids: dict[str, str] = {}
+        for title, config in projects.items():
+            project_id = config.get("project_node_id") if isinstance(config, dict) else None
+            if not isinstance(project_id, str) or not project_id:
+                raise ValueError("GitHub reconciliation Project identity is missing")
+            project_ids[str(title)] = project_id
+
+        candidates = self.projection_candidates()
+        managed_by_node: dict[str, tuple[dict[str, object], dict[str, object]]] = {}
+        numbers: set[int] = set()
+        for candidate in candidates:
+            node_id = candidate.get("node_id") if isinstance(candidate, dict) else None
+            number = candidate.get("number") if isinstance(candidate, dict) else None
+            body = candidate.get("body") if isinstance(candidate, dict) else None
+            if (
+                not isinstance(node_id, str)
+                or not node_id
+                or not isinstance(number, int)
+                or isinstance(number, bool)
+                or number <= 0
+                or not isinstance(body, str)
+                or node_id in managed_by_node
+                or number in numbers
+            ):
+                raise RuntimeError("GitHub Issue inventory identity is ambiguous")
+            has_marker = any(
+                str(block.get(marker, "")) in body
+                for block in managed_blocks
+                for marker in ("start_marker", "end_marker")
+                if isinstance(block, dict) and block.get(marker)
+            )
+            if not has_marker:
+                continue
+            managed, _projection_hash = _parse_managed_projection(
+                body,
+                None,
+                managed_blocks,
+            )
+            managed_by_node[node_id] = (candidate, managed)
+            numbers.add(number)
+
+        items_by_issue: dict[str, list[tuple[str, dict[str, object]]]] = {}
+        seen_item_ids: set[str] = set()
+        expected_full_name = self.organization + "/" + self.repository
+        for title in sorted(project_ids):
+            for project_title, item in self._project_items(title, project_ids[title]):
+                item_id = item.get("id")
+                project = item.get("project")
+                content = item.get("content")
+                if not isinstance(content, dict):
+                    continue
+                repository = content.get("repository")
+                full_name = repository.get("nameWithOwner") if isinstance(repository, dict) else None
+                if full_name != expected_full_name:
+                    continue
+                node_id = content.get("id")
+                number = content.get("number")
+                if (
+                    not isinstance(item_id, str)
+                    or not item_id
+                    or item_id in seen_item_ids
+                    or not isinstance(project, dict)
+                    or project.get("id") != project_ids[project_title]
+                    or not isinstance(node_id, str)
+                    or not node_id
+                    or not isinstance(number, int)
+                    or isinstance(number, bool)
+                    or number <= 0
+                ):
+                    raise RuntimeError("GitHub Project item stable identity is ambiguous")
+                seen_item_ids.add(item_id)
+                if node_id not in managed_by_node:
+                    continue
+                candidate = managed_by_node[node_id][0]
+                if candidate.get("number") != number:
+                    raise RuntimeError("GitHub Project item Issue identity mismatches inventory")
+                items_by_issue.setdefault(node_id, []).append((project_title, item))
+
+        records: list[dict[str, object]] = []
+        cross_types = set(cross_city_bead_types)
+        for node_id, (candidate, managed) in sorted(
+            managed_by_node.items(),
+            key=lambda item: int(item[1][0]["number"]),
+        ):
+            matches = items_by_issue.get(node_id, [])
+            expected_project = (
+                cross_city_project
+                if managed.get("bead_type") in cross_types
+                else owning_project
+            )
+            if not matches:
+                raise RuntimeError("managed GitHub Issue is unprojected")
+            if len(matches) != 1 or matches[0][0] != expected_project:
+                raise RuntimeError("managed GitHub Issue Project route is ambiguous")
+            project_title, item = matches[0]
+            records.append(
+                self.read_bound(
+                    issue_number=int(candidate["number"]),
+                    project_node_id=project_ids[project_title],
+                    project_item_id=str(item["id"]),
+                    event=event,
+                    project_config=projects[project_title],
+                    bead_id=str(managed["bead_id"]),
+                )
+            )
+        return records
+
+    def read_bound(
+        self,
+        *,
+        issue_number: int,
+        project_node_id: str,
+        project_item_id: str,
+        event: dict[str, object],
+        project_config: dict[str, object] | None = None,
+        bead_id: str | None = None,
+    ) -> dict[str, object]:
+        if (
+            not isinstance(issue_number, int)
+            or isinstance(issue_number, bool)
+            or issue_number <= 0
+            or not project_node_id
+            or not project_item_id
+            or not isinstance(event, dict)
+            or ((project_config is None) != (bead_id is None))
+        ):
+            raise ValueError("bound GitHub identity and event are required")
+        repository = self.transport.rest("GET", self._base_path())
+        issue = self.transport.rest(
+            "GET", self._base_path() + "/issues/" + str(issue_number)
+        )
+        comments = self._comments(issue_number)
+        project_response = self.transport.graphql(
+            _BOUND_PROJECT_ITEM_QUERY,
+            {"item": project_item_id},
+        )
+        if (
+            not isinstance(repository, dict)
+            or not isinstance(issue, dict)
+            or not isinstance(project_response, dict)
+            or project_response.get("errors")
+        ):
+            raise RuntimeError("GitHub effective readback is malformed")
+        data = project_response.get("data")
+        item = data.get("node") if isinstance(data, dict) else None
+        project = item.get("project") if isinstance(item, dict) else None
+        content = item.get("content") if isinstance(item, dict) else None
+        repo_id = repository.get("id")
+        # GraphQL id is the REST node_id, not the numeric REST database id.
+        repo_node_id = repository.get("node_id")
+        full_name = repository.get("full_name")
+        expected_full_name = self.organization + "/" + self.repository
+        if (
+            not isinstance(repo_id, int)
+            or isinstance(repo_id, bool)
+            or repo_id <= 0
+            or not isinstance(repo_node_id, str)
+            or not repo_node_id
+            or not isinstance(item, dict)
+            or item.get("id") != project_item_id
+            or not isinstance(project, dict)
+            or project.get("id") != project_node_id
+            or not isinstance(content, dict)
+            or content.get("id") != issue.get("node_id")
+            or content.get("number") != issue_number
+            or not isinstance(content.get("repository"), dict)
+            or content["repository"].get("id") != repo_node_id
+            or content["repository"].get("nameWithOwner") != expected_full_name
+            or full_name != expected_full_name
+        ):
+            raise RuntimeError("GitHub Project item stable identity mismatch")
+
+        field_values = item.get("fieldValues")
+        nodes = field_values.get("nodes") if isinstance(field_values, dict) else None
+        if not isinstance(nodes, list):
+            raise RuntimeError("GitHub Project field readback is malformed")
+        names = {
+            "Status": "status",
+            "Priority": "priority",
+            "Bead type": "bead_type",
+            "Lifecycle phase": "lifecycle_phase",
+        }
+        normalized_fields: dict[str, str] = {}
+        route_values: dict[str, str] = {}
+        route_names = {
+            "Bead ID": "bead_id",
+            "City": "city",
+            "Risk tier": "risk_tier",
+            "Delivery profile": "delivery_profile",
+            "Data class": "data_class",
+        }
+        for node in nodes:
+            if not isinstance(node, dict):
+                raise RuntimeError("GitHub Project field readback is malformed")
+            field = node.get("field")
+            source_name = field.get("name") if isinstance(field, dict) else None
+            target_name = names.get(source_name)
+            route_name = route_names.get(source_name)
+            if target_name is None and route_name is None:
+                continue
+            value = node.get("text") if route_name == "bead_id" else node.get("name")
+            destination = normalized_fields if target_name is not None else route_values
+            destination_name = target_name if target_name is not None else route_name
+            assert destination_name is not None
+            if (
+                not isinstance(value, str)
+                or not value
+                or destination_name in destination
+            ):
+                raise RuntimeError("GitHub Project field readback is ambiguous")
+            destination[destination_name] = value
+        issue_type = issue.get("type")
+        issue_type_name = issue_type.get("name") if isinstance(issue_type, dict) else None
+        if set(normalized_fields) != set(names.values()) or not isinstance(issue_type_name, str) or not issue_type_name:
+            raise RuntimeError("GitHub Project field readback is incomplete")
+        normalized_fields["issue_type"] = issue_type_name
+        if project_config is not None:
+            expected_static = project_config.get("static_fields")
+            if (
+                not isinstance(bead_id, str)
+                or not bead_id
+                or route_values.get("bead_id") != bead_id
+            ):
+                raise RuntimeError("GitHub Project Bead ID readback mismatches")
+            if (
+                not isinstance(expected_static, dict)
+                or set(expected_static) != _STATIC_PROJECT_FIELDS
+                or {
+                    field: route_values.get(field)
+                    for field in _STATIC_PROJECT_FIELDS
+                }
+                != expected_static
+            ):
+                raise RuntimeError("GitHub Project static field readback drifts")
+
+        raw_issue = {
+            key: issue.get(key)
+            for key in ("node_id", "number", "updated_at", "state", "title", "body")
+        }
+        return {
+            "repository": {"id": repo_id, "full_name": full_name},
+            "issue": raw_issue,
+            "comments": comments,
+            "project": {
+                "project_node_id": project_node_id,
+                "project_item_id": project_item_id,
+                "archived": item.get("isArchived"),
+                "fields": normalized_fields,
+            },
+            "event": dict(event),
+            "projection_actor_node_id": self.projection_actor_node_id,
+        }
+
+
+_ADD_PROJECT_ITEM_MUTATION = """
+mutation WorkSyncAddProjectItem($project: ID!, $content: ID!) {
+  addProjectV2ItemById(input: {projectId: $project, contentId: $content}) {
+    item { id }
+  }
+}
+""".strip()
+
+_UPDATE_PROJECT_FIELD_MUTATION = """
+mutation WorkSyncUpdateProjectField(
+  $project: ID!, $item: ID!, $field: ID!, $option: String!
+) {
+  updateProjectV2ItemFieldValue(input: {
+    projectId: $project,
+    itemId: $item,
+    fieldId: $field,
+    value: {singleSelectOptionId: $option}
+  }) {
+    projectV2Item { id }
+  }
+}
+""".strip()
+
+_UPDATE_PROJECT_TEXT_FIELD_MUTATION = """
+mutation WorkSyncUpdateProjectTextField(
+  $project: ID!, $item: ID!, $field: ID!, $text: String!
+) {
+  updateProjectV2ItemFieldValue(input: {
+    projectId: $project,
+    itemId: $item,
+    fieldId: $field,
+    value: {text: $text}
+  }) {
+    projectV2Item { id }
+  }
+}
+""".strip()
+
+_UNARCHIVE_PROJECT_ITEM_MUTATION = """
+mutation WorkSyncUnarchiveProjectItem($project: ID!, $item: ID!) {
+  unarchiveProjectV2Item(input: {projectId: $project, itemId: $item}) {
+    item { id }
+  }
+}
+""".strip()
+
+_PROJECT_FIELDS = {"status", "priority", "bead_type", "lifecycle_phase"}
+_EFFECTIVE_PROJECT_FIELDS = _PROJECT_FIELDS | {"issue_type"}
+_STATIC_PROJECT_FIELDS = {"city", "risk_tier", "delivery_profile", "data_class"}
+_SELECT_PROJECT_FIELDS = _PROJECT_FIELDS | _STATIC_PROJECT_FIELDS
+_ALL_PROJECT_FIELDS = _SELECT_PROJECT_FIELDS | {"bead_id"}
+
+_PROJECT_SCHEMA_QUERY = """
+query WorkSyncProjectSchema($organization: String!, $after: String) {
+  organization(login: $organization) {
+    projectsV2(first: 100, after: $after) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        id
+        title
+        fields(first: 100) {
+          nodes {
+            ... on ProjectV2Field {
+              id
+              name
+              dataType
+            }
+            ... on ProjectV2SingleSelectField {
+              id
+              name
+              dataType
+              options { id name }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+""".strip()
+
+
+class GitHubProjectSchemaReader:
+    """Resolve exact Project, field, and option node IDs from GraphQL."""
+
+    def __init__(
+        self,
+        *,
+        organization: str,
+        transport: object,
+        max_pages: int = 100,
+    ) -> None:
+        if (
+            not isinstance(organization, str)
+            or not organization
+            or "/" in organization
+            or not isinstance(max_pages, int)
+            or isinstance(max_pages, bool)
+            or max_pages <= 0
+            or max_pages > 100
+        ):
+            raise ValueError("invalid GitHub Project schema route")
+        self.organization = organization
+        self.transport = transport
+        self.max_pages = max_pages
+
+    @staticmethod
+    def _validate_desired(
+        desired: object,
+    ) -> dict[str, dict[str, list[str]]]:
+        if not isinstance(desired, dict) or not desired:
+            raise ValueError("desired GitHub Project schemas are required")
+        normalized: dict[str, dict[str, list[str]]] = {}
+        for title, raw in desired.items():
+            if (
+                not isinstance(title, str)
+                or not title
+                or not isinstance(raw, dict)
+                or set(raw) != _PROJECT_FIELDS
+            ):
+                raise ValueError("desired GitHub Project schema is malformed")
+            fields: dict[str, list[str]] = {}
+            for field, values in raw.items():
+                if (
+                    not isinstance(values, list)
+                    or not values
+                    or len(values) != len(set(values))
+                    or any(not isinstance(value, str) or not value for value in values)
+                ):
+                    raise ValueError("desired GitHub Project options are malformed")
+                fields[str(field)] = list(values)
+            normalized[title] = fields
+        return normalized
+
+    @staticmethod
+    def _project_config(
+        node: dict[str, object],
+        desired: dict[str, list[str]],
+    ) -> dict[str, object]:
+        project_id = node.get("id")
+        fields_wrapper = node.get("fields")
+        nodes = fields_wrapper.get("nodes") if isinstance(fields_wrapper, dict) else None
+        if (
+            not isinstance(project_id, str)
+            or not project_id
+            or not isinstance(nodes, list)
+            or any(not isinstance(field, dict) for field in nodes)
+        ):
+            raise RuntimeError("GitHub Project schema readback is malformed")
+        display_names = {
+            "status": "Status",
+            "priority": "Priority",
+            "bead_type": "Bead type",
+            "lifecycle_phase": "Lifecycle phase",
+        }
+        field_ids: dict[str, str] = {}
+        option_ids: dict[str, dict[str, str]] = {}
+        for target, display in display_names.items():
+            matches = [field for field in nodes if field.get("name") == display]
+            if len(matches) != 1:
+                raise RuntimeError("GitHub Project field schema is missing or ambiguous")
+            field = matches[0]
+            field_id = field.get("id")
+            options = field.get("options")
+            if (
+                not isinstance(field_id, str)
+                or not field_id
+                or not isinstance(options, list)
+                or any(not isinstance(option, dict) for option in options)
+            ):
+                raise RuntimeError("GitHub Project field readback is malformed")
+            by_name: dict[str, str] = {}
+            for option in options:
+                name = option.get("name")
+                option_id = option.get("id")
+                if (
+                    not isinstance(name, str)
+                    or not name
+                    or name in by_name
+                    or not isinstance(option_id, str)
+                    or not option_id
+                ):
+                    raise RuntimeError("GitHub Project option schema is ambiguous")
+                by_name[name] = option_id
+            if set(by_name) != set(desired[target]):
+                raise RuntimeError("GitHub Project option schema drifts from the contract")
+            field_ids[target] = field_id
+            option_ids[target] = {
+                value: by_name[value]
+                for value in desired[target]
+            }
+        return {
+            "project_node_id": project_id,
+            "field_ids": field_ids,
+            "option_ids": option_ids,
+        }
+
+    def read(
+        self,
+        desired: dict[str, dict[str, list[str]]],
+    ) -> dict[str, dict[str, object]]:
+        """Read all pages so duplicate titles cannot silently bind."""
+        expected = self._validate_desired(desired)
+        matches: dict[str, list[dict[str, object]]] = {
+            title: [] for title in expected
+        }
+        after: str | None = None
+        for _page in range(self.max_pages):
+            response = self.transport.graphql(
+                _PROJECT_SCHEMA_QUERY,
+                {"organization": self.organization, "after": after},
+            )
+            data = response.get("data") if isinstance(response, dict) else None
+            organization = data.get("organization") if isinstance(data, dict) else None
+            projects = (
+                organization.get("projectsV2")
+                if isinstance(organization, dict)
+                else None
+            )
+            nodes = projects.get("nodes") if isinstance(projects, dict) else None
+            page_info = (
+                projects.get("pageInfo") if isinstance(projects, dict) else None
+            )
+            if (
+                not isinstance(nodes, list)
+                or any(not isinstance(node, dict) for node in nodes)
+                or not isinstance(page_info, dict)
+                or not isinstance(page_info.get("hasNextPage"), bool)
+            ):
+                raise RuntimeError("GitHub Project pagination readback is malformed")
+            for node in nodes:
+                title = node.get("title")
+                if isinstance(title, str) and title in matches:
+                    matches[title].append(node)
+            if not page_info["hasNextPage"]:
+                break
+            after = page_info.get("endCursor")
+            if not isinstance(after, str) or not after:
+                raise RuntimeError("GitHub Project pagination cursor is missing")
+        else:
+            raise RuntimeError("GitHub Project pagination exceeded the bounded policy")
+        result: dict[str, dict[str, object]] = {}
+        for title, nodes in matches.items():
+            if len(nodes) != 1:
+                raise RuntimeError("GitHub Project title is missing or ambiguous")
+            result[title] = self._project_config(nodes[0], expected[title])
+        return result
+
+    def read_contract(
+        self,
+        contract: dict[str, object],
+    ) -> dict[str, dict[str, object]]:
+        """Resolve the full canonical Project schema for all routed Projects."""
+        expected_keys = {
+            "schema_version",
+            "organization",
+            "route",
+            "projects",
+            "project_schema",
+            "managed_blocks",
+            "projection_writer",
+            "live_mutations",
+            "cross_city_project",
+            "cross_city_bead_types",
+            "max_pages_per_run",
+            "max_identical_attempts",
+        }
+        projects = contract.get("projects") if isinstance(contract, dict) else None
+        schema = contract.get("project_schema") if isinstance(contract, dict) else None
+        if (
+            not isinstance(contract, dict)
+            or set(contract) != expected_keys
+            or contract.get("schema_version") != "1"
+            or contract.get("organization") != self.organization
+            or not isinstance(projects, dict)
+            or not projects
+            or not isinstance(schema, dict)
+            or set(schema) != {"required_fields", "single_select_options"}
+        ):
+            raise ValueError("canonical GitHub runtime contract is malformed")
+        required = schema.get("required_fields")
+        options = schema.get("single_select_options")
+        display_to_key = {
+            "Status": "status",
+            "Priority": "priority",
+            "Bead ID": "bead_id",
+            "Bead type": "bead_type",
+            "Lifecycle phase": "lifecycle_phase",
+            "City": "city",
+            "Risk tier": "risk_tier",
+            "Delivery profile": "delivery_profile",
+            "Data class": "data_class",
+        }
+        if (
+            not isinstance(required, list)
+            or required != list(display_to_key)
+            or not isinstance(options, dict)
+            or set(options) != set(display_to_key) - {"Bead ID"}
+        ):
+            raise ValueError("canonical GitHub Project field contract is malformed")
+        normalized_options: dict[str, list[str]] = {}
+        for name, values in options.items():
+            if (
+                not isinstance(values, list)
+                or not values
+                or len(values) != len(set(values))
+                or any(not isinstance(value, str) or not value for value in values)
+            ):
+                raise ValueError("canonical GitHub Project options are malformed")
+            normalized_options[str(name)] = list(values)
+
+        project_nodes = self._read_project_nodes(set(projects))
+        result: dict[str, dict[str, object]] = {}
+        static_display = {"City", "Risk tier", "Delivery profile", "Data class"}
+        for title, raw_project in projects.items():
+            if (
+                not isinstance(title, str)
+                or not title
+                or not isinstance(raw_project, dict)
+                or set(raw_project) != {"static_fields"}
+                or not isinstance(raw_project.get("static_fields"), dict)
+                or set(raw_project["static_fields"]) != static_display
+            ):
+                raise ValueError("canonical GitHub Project route is malformed")
+            nodes = project_nodes.get(title, [])
+            if len(nodes) != 1:
+                raise RuntimeError("GitHub Project title is missing or ambiguous")
+            result[title] = self._contract_project_config(
+                nodes[0],
+                display_to_key=display_to_key,
+                options=normalized_options,
+                static_fields=raw_project["static_fields"],
+            )
+        return result
+
+    def _read_project_nodes(
+        self,
+        titles: set[str],
+    ) -> dict[str, list[dict[str, object]]]:
+        matches: dict[str, list[dict[str, object]]] = {
+            title: [] for title in titles
+        }
+        after: str | None = None
+        for _page in range(self.max_pages):
+            response = self.transport.graphql(
+                _PROJECT_SCHEMA_QUERY,
+                {"organization": self.organization, "after": after},
+            )
+            data = response.get("data") if isinstance(response, dict) else None
+            organization = data.get("organization") if isinstance(data, dict) else None
+            projects = organization.get("projectsV2") if isinstance(organization, dict) else None
+            nodes = projects.get("nodes") if isinstance(projects, dict) else None
+            page_info = projects.get("pageInfo") if isinstance(projects, dict) else None
+            if (
+                not isinstance(nodes, list)
+                or any(not isinstance(node, dict) for node in nodes)
+                or not isinstance(page_info, dict)
+                or not isinstance(page_info.get("hasNextPage"), bool)
+            ):
+                raise RuntimeError("GitHub Project pagination readback is malformed")
+            for node in nodes:
+                title = node.get("title")
+                if isinstance(title, str) and title in matches:
+                    matches[title].append(node)
+            if not page_info["hasNextPage"]:
+                return matches
+            after = page_info.get("endCursor")
+            if not isinstance(after, str) or not after:
+                raise RuntimeError("GitHub Project pagination cursor is missing")
+        raise RuntimeError("GitHub Project pagination exceeded the bounded policy")
+
+    @staticmethod
+    def _contract_project_config(
+        node: dict[str, object],
+        *,
+        display_to_key: dict[str, str],
+        options: dict[str, list[str]],
+        static_fields: dict[str, object],
+    ) -> dict[str, object]:
+        project_id = node.get("id")
+        wrapper = node.get("fields")
+        nodes = wrapper.get("nodes") if isinstance(wrapper, dict) else None
+        if (
+            not isinstance(project_id, str)
+            or not project_id
+            or not isinstance(nodes, list)
+            or any(not isinstance(field, dict) for field in nodes)
+        ):
+            raise RuntimeError("GitHub Project schema readback is malformed")
+        field_ids: dict[str, str] = {}
+        option_ids: dict[str, dict[str, str]] = {}
+        for display, key in display_to_key.items():
+            matches = [field for field in nodes if field.get("name") == display]
+            if len(matches) != 1:
+                raise RuntimeError("GitHub Project field schema is missing or ambiguous")
+            field = matches[0]
+            field_id = field.get("id")
+            expected_type = "TEXT" if display == "Bead ID" else "SINGLE_SELECT"
+            if (
+                not isinstance(field_id, str)
+                or not field_id
+                or field.get("dataType") != expected_type
+            ):
+                raise RuntimeError("GitHub Project field type drifts from the contract")
+            field_ids[key] = field_id
+            if display == "Bead ID":
+                continue
+            raw_options = field.get("options")
+            if not isinstance(raw_options, list) or any(
+                not isinstance(option, dict) for option in raw_options
+            ):
+                raise RuntimeError("GitHub Project option readback is malformed")
+            by_name: dict[str, str] = {}
+            for option in raw_options:
+                name = option.get("name")
+                option_id = option.get("id")
+                if (
+                    not isinstance(name, str)
+                    or not name
+                    or name in by_name
+                    or not isinstance(option_id, str)
+                    or not option_id
+                ):
+                    raise RuntimeError("GitHub Project option schema is ambiguous")
+                by_name[name] = option_id
+            if set(by_name) != set(options[display]):
+                raise RuntimeError("GitHub Project option schema drifts from the contract")
+            option_ids[key] = {
+                value: by_name[value]
+                for value in options[display]
+            }
+        normalized_static: dict[str, str] = {}
+        for display, value in static_fields.items():
+            key = display_to_key[display]
+            if not isinstance(value, str) or value not in option_ids[key]:
+                raise ValueError("GitHub Project static field is outside the contract")
+            normalized_static[key] = value
+        return {
+            "project_node_id": project_id,
+            "field_ids": field_ids,
+            "option_ids": option_ids,
+            "static_fields": normalized_static,
+        }
+
+
+class GitHubProjectionWriter:
+    """Apply planner operations through native Issues and Projects v2 APIs."""
+
+    def __init__(
+        self,
+        *,
+        organization: str,
+        repository: str,
+        transport: object,
+        snapshot_reader: object,
+        projects: dict[str, object],
+        managed_blocks: list[dict[str, object]],
+        event: dict[str, object],
+    ) -> None:
+        if (
+            not isinstance(organization, str)
+            or not organization
+            or "/" in organization
+            or not isinstance(repository, str)
+            or not repository
+            or "/" in repository
+            or not isinstance(event, dict)
+            or not isinstance(event.get("delivery_id"), str)
+            or not event["delivery_id"]
+        ):
+            raise ValueError("exact GitHub route and delivery event are required")
+        self.organization = organization
+        self.repository = repository
+        self.transport = transport
+        self.snapshot_reader = snapshot_reader
+        self.event = dict(event)
+        self.projects = self._validate_projects(projects)
+        self.managed_blocks = self._validate_managed_blocks(managed_blocks)
+        self._pending: dict[str, dict[str, object]] = {}
+        self._imported_comment_ids: dict[str, list[str]] = {}
+        self._verified: dict[str, dict[str, object]] = {}
+        self._expected_readback: dict[str, tuple[dict[str, object], bool]] = {}
+
+    @staticmethod
+    def _validate_projects(
+        projects: object,
+    ) -> dict[str, dict[str, object]]:
+        if not isinstance(projects, dict) or not projects:
+            raise ValueError("at least one exact GitHub Project route is required")
+        normalized: dict[str, dict[str, object]] = {}
+        project_ids: set[str] = set()
+        for name, raw in projects.items():
+            if (
+                not isinstance(name, str)
+                or not name
+                or not isinstance(raw, dict)
+                or set(raw)
+                != {"project_node_id", "field_ids", "option_ids", "static_fields"}
+            ):
+                raise ValueError("GitHub Project route is malformed")
+            project_id = raw.get("project_node_id")
+            field_ids = raw.get("field_ids")
+            option_ids = raw.get("option_ids")
+            static_fields = raw.get("static_fields")
+            if (
+                not isinstance(project_id, str)
+                or not project_id
+                or project_id in project_ids
+                or not isinstance(field_ids, dict)
+                or set(field_ids) != _ALL_PROJECT_FIELDS
+                or any(not isinstance(value, str) or not value for value in field_ids.values())
+                or len(set(field_ids.values())) != len(field_ids)
+                or not isinstance(option_ids, dict)
+                or set(option_ids) != _SELECT_PROJECT_FIELDS
+                or not isinstance(static_fields, dict)
+                or set(static_fields) != _STATIC_PROJECT_FIELDS
+            ):
+                raise ValueError("GitHub Project IDs must be complete and unique")
+            copied_options: dict[str, dict[str, str]] = {}
+            for field in sorted(_SELECT_PROJECT_FIELDS):
+                options = option_ids.get(field)
+                if (
+                    not isinstance(options, dict)
+                    or not options
+                    or any(
+                        not isinstance(option, str)
+                        or not option
+                        or not isinstance(option_id, str)
+                        or not option_id
+                        for option, option_id in options.items()
+                    )
+                ):
+                    raise ValueError("GitHub Project option IDs must be explicit")
+                copied_options[field] = dict(options)
+            if any(
+                not isinstance(value, str)
+                or not value
+                or value not in copied_options[field]
+                for field, value in static_fields.items()
+            ):
+                raise ValueError("GitHub Project static fields must use exact options")
+            normalized[name] = {
+                "project_node_id": project_id,
+                "field_ids": dict(field_ids),
+                "option_ids": copied_options,
+                "static_fields": dict(static_fields),
+            }
+            project_ids.add(project_id)
+        return normalized
+
+    @staticmethod
+    def _validate_managed_blocks(
+        managed_blocks: object,
+    ) -> list[dict[str, object]]:
+        if not isinstance(managed_blocks, list) or not managed_blocks:
+            raise ValueError("managed block contracts are required")
+        normalized: list[dict[str, object]] = []
+        versions: set[int] = set()
+        markers: set[str] = set()
+        for raw in managed_blocks:
+            if (
+                not isinstance(raw, dict)
+                or set(raw) != {
+                    "schema_version",
+                    "start_marker",
+                    "end_marker",
+                    "fields",
+                }
+                or not isinstance(raw.get("schema_version"), int)
+                or isinstance(raw["schema_version"], bool)
+                or raw["schema_version"] <= 0
+                or raw["schema_version"] in versions
+                or not isinstance(raw.get("start_marker"), str)
+                or not raw["start_marker"]
+                or not isinstance(raw.get("end_marker"), str)
+                or not raw["end_marker"]
+                or raw["start_marker"] == raw["end_marker"]
+                or raw["start_marker"] in markers
+                or raw["end_marker"] in markers
+                or not isinstance(raw.get("fields"), list)
+                or len(raw["fields"]) != len(set(raw["fields"]))
+                or set(raw["fields"])
+                < {"bead_id", "projection_hash"}
+            ):
+                raise ValueError("managed block contract is malformed")
+            normalized.append(
+                {
+                    "schema_version": raw["schema_version"],
+                    "start_marker": raw["start_marker"],
+                    "end_marker": raw["end_marker"],
+                    "fields": list(raw["fields"]),
+                }
+            )
+            versions.add(raw["schema_version"])
+            markers.update({raw["start_marker"], raw["end_marker"]})
+        return normalized
+
+    def _base_path(self) -> str:
+        return "/repos/{0}/{1}".format(
+            urllib.parse.quote(self.organization, safe=""),
+            urllib.parse.quote(self.repository, safe=""),
+        )
+
+    def _project_by_id(self, project_id: object) -> dict[str, object]:
+        matches = [
+            project
+            for project in self.projects.values()
+            if project["project_node_id"] == project_id
+        ]
+        if len(matches) != 1:
+            raise ValueError("GitHub Project stable identity is outside the route")
+        return matches[0]
+
+    def _effective_identity(
+        self,
+        identity: dict[str, object],
+        *,
+        require_bound: bool = True,
+    ) -> dict[str, object]:
+        if (
+            not isinstance(identity, dict)
+            or identity.get("repository") != self.repository
+            or not isinstance(identity.get("bead_id"), str)
+            or not identity["bead_id"]
+        ):
+            raise ValueError("GitHub identity is outside the configured route")
+        effective = dict(identity)
+        effective.update(self._pending.get(str(identity["bead_id"]), {}))
+        if require_bound and not _stable_identity(effective):
+            raise ValueError("GitHub stable identity is incomplete")
+        return effective
+
+    @staticmethod
+    def _graphql_node(
+        response: object,
+        operation: str,
+        field: str,
+    ) -> dict[str, object]:
+        data = response.get("data") if isinstance(response, dict) else None
+        payload = data.get(operation) if isinstance(data, dict) else None
+        node = payload.get(field) if isinstance(payload, dict) else None
+        if not isinstance(node, dict) or not isinstance(node.get("id"), str) or not node["id"]:
+            raise RuntimeError("GitHub GraphQL mutation readback is malformed")
+        return node
+
+    def _set_project_field(
+        self,
+        project: dict[str, object],
+        item_id: str,
+        field: str,
+        value: str,
+    ) -> None:
+        field_ids = project["field_ids"]
+        option_ids = project["option_ids"]
+        assert isinstance(field_ids, dict) and isinstance(option_ids, dict)
+        options = option_ids.get(field)
+        if not isinstance(options, dict) or value not in options:
+            raise ValueError("GitHub Project option is not present in exact config")
+        response = self.transport.graphql(
+            _UPDATE_PROJECT_FIELD_MUTATION,
+            {
+                "project": project["project_node_id"],
+                "item": item_id,
+                "field": field_ids[field],
+                "option": options[value],
+            },
+        )
+        node = self._graphql_node(
+            response,
+            "updateProjectV2ItemFieldValue",
+            "projectV2Item",
+        )
+        if node["id"] != item_id:
+            raise RuntimeError("GitHub Project field mutation changed item identity")
+
+    def _set_project_text(
+        self,
+        project: dict[str, object],
+        item_id: str,
+        field: str,
+        value: str,
+    ) -> None:
+        field_ids = project["field_ids"]
+        assert isinstance(field_ids, dict)
+        if field != "bead_id" or not isinstance(value, str) or not value:
+            raise ValueError("GitHub Project text field value is invalid")
+        response = self.transport.graphql(
+            _UPDATE_PROJECT_TEXT_FIELD_MUTATION,
+            {
+                "project": project["project_node_id"],
+                "item": item_id,
+                "field": field_ids[field],
+                "text": value,
+            },
+        )
+        node = self._graphql_node(
+            response,
+            "updateProjectV2ItemFieldValue",
+            "projectV2Item",
+        )
+        if node["id"] != item_id:
+            raise RuntimeError("GitHub Project text mutation changed item identity")
+
+    def _create(self, identity: dict[str, object], item: dict[str, object]) -> None:
+        value = item.get("value")
+        route = value.get("route") if isinstance(value, dict) else None
+        issue = value.get("issue") if isinstance(value, dict) else None
+        if (
+            not isinstance(route, dict)
+            or route.get("repository") != self.repository
+            or not isinstance(route.get("project"), str)
+            or route["project"] not in self.projects
+            or not isinstance(issue, dict)
+        ):
+            raise ValueError("create projection route is not exact")
+        project = self.projects[str(route["project"])]
+        bead_id = str(identity["bead_id"])
+        pending = self._pending.setdefault(bead_id, {})
+        if not isinstance(pending.get("issue_node_id"), str):
+            response = self.transport.rest(
+                "POST",
+                self._base_path() + "/issues",
+                {
+                    "title": issue.get("title"),
+                    "body": issue.get("body"),
+                    "type": issue.get("issue_type"),
+                },
+            )
+            if not isinstance(response, dict):
+                raise RuntimeError("GitHub Issue create readback is malformed")
+            issue_node_id = response.get("node_id")
+            issue_number = response.get("number")
+            expected_url = "https://github.com/{0}/{1}/issues/{2}".format(
+                self.organization,
+                self.repository,
+                issue_number,
+            )
+            if (
+                not isinstance(issue_node_id, str)
+                or not issue_node_id
+                or not isinstance(issue_number, int)
+                or isinstance(issue_number, bool)
+                or issue_number <= 0
+                or response.get("html_url") != expected_url
+            ):
+                raise RuntimeError("GitHub Issue create stable identity is malformed")
+            pending.update(
+                {
+                    "issue_node_id": issue_node_id,
+                    "issue_number": issue_number,
+                    "project_node_id": project["project_node_id"],
+                }
+            )
+        if not isinstance(pending.get("project_item_id"), str):
+            response = self.transport.graphql(
+                _ADD_PROJECT_ITEM_MUTATION,
+                {
+                    "project": project["project_node_id"],
+                    "content": pending["issue_node_id"],
+                },
+            )
+            node = self._graphql_node(response, "addProjectV2ItemById", "item")
+            pending["project_item_id"] = node["id"]
+        project_fields = issue.get("project")
+        if not isinstance(project_fields, dict) or set(project_fields) != _EFFECTIVE_PROJECT_FIELDS:
+            raise ValueError("create projection Project fields are incomplete")
+        for field in sorted(_PROJECT_FIELDS):
+            value_for_field = project_fields[field]
+            if not isinstance(value_for_field, str) or not value_for_field:
+                raise ValueError("create projection Project field is invalid")
+            self._set_project_field(
+                project,
+                str(pending["project_item_id"]),
+                field,
+                value_for_field,
+            )
+        self._set_project_text(
+            project,
+            str(pending["project_item_id"]),
+            "bead_id",
+            bead_id,
+        )
+        static_fields = project["static_fields"]
+        assert isinstance(static_fields, dict)
+        for field in sorted(_STATIC_PROJECT_FIELDS):
+            self._set_project_field(
+                project,
+                str(pending["project_item_id"]),
+                field,
+                str(static_fields[field]),
+            )
+        if issue.get("issue_state") == "closed":
+            self.transport.rest(
+                "PATCH",
+                self._base_path() + "/issues/" + str(pending["issue_number"]),
+                {"state": "closed"},
+            )
+
+    def apply(self, identity: dict[str, object], item: dict[str, object]) -> None:
+        """Apply exactly one validated planner operation."""
+        if not isinstance(item, dict):
+            raise ValueError("GitHub operation must be an object")
+        kind = item.get("kind")
+        field = item.get("field")
+        value = item.get("value")
+        if kind == "create-projection":
+            self._effective_identity(identity, require_bound=False)
+            self._create(identity, item)
+            return
+        effective = self._effective_identity(identity)
+        bead_id = str(identity["bead_id"])
+        verified = self._verified.get(bead_id)
+        if verified is not None:
+            current = self._concurrency_state(self._snapshot(identity))
+            if current != verified:
+                raise ValueError("GitHub changed since the last verified operation")
+            self._expected_readback[bead_id] = self._next_state(verified, item)
+        issue_path = self._base_path() + "/issues/" + str(effective["issue_number"])
+        project = self._project_by_id(effective["project_node_id"])
+        if kind in {"replace-managed-block", "migrate-managed-block"} and field == "projection":
+            if not isinstance(value, dict) or not isinstance(value.get("body"), str):
+                raise ValueError("GitHub body operation is malformed")
+            if kind == "migrate-managed-block":
+                snapshot = self._snapshot(identity)
+                issue = snapshot.get("issue")
+                if not isinstance(issue, dict):
+                    raise ValueError("GitHub migration precondition is incomplete")
+                _managed, current_hash = self._managed_projection(
+                    issue.get("body"),
+                    str(identity["bead_id"]),
+                )
+                if current_hash != value.get("expected_legacy_projection_hash"):
+                    raise ValueError("GitHub migration precondition changed")
+            self.transport.rest("PATCH", issue_path, {"body": value["body"]})
+            return
+        if kind == "update-project-field" and field in _PROJECT_FIELDS:
+            if not isinstance(value, str) or not value:
+                raise ValueError("GitHub Project field value is invalid")
+            self._set_project_field(
+                project,
+                str(effective["project_item_id"]),
+                str(field),
+                value,
+            )
+            return
+        if kind == "update-issue-type" and field == "issue_type":
+            self.transport.rest("PATCH", issue_path, {"type": value})
+            return
+        if kind == "update-issue-state" and field == "issue_state":
+            self.transport.rest("PATCH", issue_path, {"state": value})
+            return
+        if kind == "restore-project-item" and field == "project_archived" and value is False:
+            response = self.transport.graphql(
+                _UNARCHIVE_PROJECT_ITEM_MUTATION,
+                {
+                    "project": effective["project_node_id"],
+                    "item": effective["project_item_id"],
+                },
+            )
+            node = self._graphql_node(response, "unarchiveProjectV2Item", "item")
+            if node["id"] != effective["project_item_id"]:
+                raise RuntimeError("GitHub Project restore changed item identity")
+            return
+        raise ValueError("unsupported GitHub projection operation")
+
+    def _snapshot(self, identity: dict[str, object]) -> dict[str, object]:
+        effective = self._effective_identity(identity, require_bound=False)
+        if (
+            not isinstance(effective.get("issue_number"), int)
+            or isinstance(effective["issue_number"], bool)
+            or effective["issue_number"] <= 0
+            or not isinstance(effective.get("project_node_id"), str)
+            or not effective["project_node_id"]
+            or not isinstance(effective.get("project_item_id"), str)
+            or not effective["project_item_id"]
+        ):
+            raise ValueError("GitHub readback identity is incomplete")
+        snapshot = self.snapshot_reader.read_bound(
+            issue_number=effective["issue_number"],
+            project_node_id=effective["project_node_id"],
+            project_item_id=effective["project_item_id"],
+            event=self.event,
+            project_config=self._project_by_id(effective["project_node_id"]),
+            bead_id=str(identity["bead_id"]),
+        )
+        if not isinstance(snapshot, dict):
+            raise RuntimeError("GitHub effective readback is not an object")
+        return snapshot
+
+    def _readback_matches(
+        self,
+        snapshot: dict[str, object],
+        identity: dict[str, object],
+        item: dict[str, object],
+    ) -> bool:
+        issue = snapshot.get("issue")
+        project = snapshot.get("project")
+        if not isinstance(issue, dict) or not isinstance(project, dict):
+            raise RuntimeError("GitHub effective readback is incomplete")
+        fields = project.get("fields")
+        if not isinstance(fields, dict):
+            raise RuntimeError("GitHub effective Project readback is incomplete")
+        kind = item.get("kind")
+        field = item.get("field")
+        value = item.get("value")
+        if kind == "create-projection":
+            desired = value.get("issue") if isinstance(value, dict) else None
+            try:
+                _managed, actual_hash = self._managed_projection(
+                    issue.get("body"),
+                    str(identity["bead_id"]),
+                )
+            except ValueError:
+                return False
+            return bool(
+                isinstance(desired, dict)
+                and issue.get("title") == desired.get("title")
+                and issue.get("body") == desired.get("body")
+                and issue.get("state") == desired.get("issue_state")
+                and fields == desired.get("project")
+                and project.get("archived") is False
+                and actual_hash == desired.get("projection_hash")
+            )
+        if kind in {"replace-managed-block", "migrate-managed-block"}:
+            if not isinstance(value, dict) or issue.get("body") != value.get("body"):
+                return False
+            try:
+                _managed, actual_hash = self._managed_projection(
+                    issue.get("body"),
+                    str(identity["bead_id"]),
+                )
+            except ValueError:
+                return False
+            return actual_hash == value.get("projection_hash")
+        if kind == "update-project-field":
+            return fields.get(field) == value
+        if kind == "update-issue-type":
+            return fields.get("issue_type") == value
+        if kind == "update-issue-state":
+            return issue.get("state") == value
+        if kind == "restore-project-item":
+            return project.get("archived") is False
+        raise ValueError("unsupported GitHub projection readback")
+
+    def readback(
+        self,
+        identity: dict[str, object],
+        item: dict[str, object],
+    ) -> bool | None:
+        """Prove the operation against effective REST and GraphQL state."""
+        try:
+            snapshot = self._snapshot(identity)
+        except (TransientTransportError, AmbiguousTransportError):
+            return None
+        except (AttributeError, RuntimeError, TypeError, ValueError):
+            return None
+        if not self._readback_matches(snapshot, identity, item):
+            return False
+        bead_id = str(identity["bead_id"])
+        expected_readback = self._expected_readback.get(bead_id)
+        if expected_readback is not None:
+            actual = self._concurrency_state(snapshot)
+            expected, issue_write = copy.deepcopy(expected_readback)
+            if issue_write:
+                # GitHub chooses this timestamp for our own Issue mutation.
+                # Every other field, including comments and Project fields,
+                # must match the last verified state plus exactly our write.
+                expected["issue"]["updated_at"] = actual["issue"]["updated_at"]
+            if actual != expected:
+                return False
+            self._verified[bead_id] = actual
+            self._expected_readback.pop(bead_id, None)
+        return True
+
+    @staticmethod
+    def _concurrency_state(snapshot: dict[str, object]) -> dict[str, object]:
+        # Delivery metadata is supplied locally, not remote mutable state.
+        return copy.deepcopy({key: value for key, value in snapshot.items() if key != "event"})
+
+    @staticmethod
+    def _next_state(state: dict[str, object], item: dict[str, object]) -> tuple[dict[str, object], bool]:
+        expected = copy.deepcopy(state)
+        kind, field, value = item.get("kind"), item.get("field"), item.get("value")
+        issue_write = kind in {
+            "replace-managed-block", "migrate-managed-block", "update-issue-type", "update-issue-state",
+        }
+        if kind in {"replace-managed-block", "migrate-managed-block"} and isinstance(value, dict):
+            expected["issue"]["body"] = value.get("body")
+        elif kind == "update-issue-state":
+            expected["issue"]["state"] = value
+        elif kind in {"update-project-field", "update-issue-type"}:
+            expected["project"]["fields"][field] = value
+        elif kind == "restore-project-item":
+            expected["project"]["archived"] = False
+        else:
+            raise ValueError("unsupported pending GitHub write")
+        return expected, issue_write
+
+    @classmethod
+    def _recovery_hash(cls, snapshot: dict[str, object]) -> str:
+        value = cls._concurrency_state(snapshot)
+        value["issue"].pop("updated_at", None)
+        return hashlib.sha256(json.dumps(
+            value, ensure_ascii=False, sort_keys=True, separators=(",", ":"),
+        ).encode("utf-8")).hexdigest()
+
+    def pending_write(self, identity: dict[str, object], item: dict[str, object]) -> dict[str, object]:
+        verified = self._verified.get(str(identity["bead_id"]))
+        if verified is None:
+            raise ValueError("pending write requires a verified GitHub base")
+        expected, _ = self._next_state(verified, item)
+        return {
+            "kind": "github-write", "before_hash": self._recovery_hash(verified),
+            "after_hash": self._recovery_hash(expected),
+        }
+
+    def _managed_projection(
+        self,
+        body: object,
+        bead_id: str | None,
+    ) -> tuple[dict[str, object], str]:
+        return _parse_managed_projection(body, bead_id, self.managed_blocks)
+
+    def _snapshot_fingerprint(
+        self,
+        snapshot: dict[str, object],
+        bead_id: str,
+    ) -> dict[str, str]:
+        issue = snapshot.get("issue")
+        project = snapshot.get("project")
+        if not isinstance(issue, dict) or not isinstance(project, dict):
+            raise ValueError("GitHub effective readback is incomplete")
+        managed, projection_hash = self._managed_projection(
+            issue.get("body"),
+            bead_id,
+        )
+        fields = project.get("fields")
+        issue_state = issue.get("state")
+        archived = project.get("archived")
+        if (
+            not isinstance(fields, dict)
+            or set(fields) != _EFFECTIVE_PROJECT_FIELDS
+            or any(not isinstance(value, str) or not value for value in fields.values())
+            or issue_state not in {"open", "closed"}
+            or not isinstance(archived, bool)
+            or not isinstance(issue.get("updated_at"), str)
+            or not issue["updated_at"]
+        ):
+            raise ValueError("GitHub effective machine fields are incomplete")
+        hash_fields = (
+            _EFFECTIVE_PROJECT_FIELDS
+            if "bead_type" in managed
+            else {"status", "priority", "issue_type", "lifecycle_phase"}
+        )
+        encoded_fields = json.dumps(
+            {
+                **{field: fields[field] for field in sorted(hash_fields)},
+                "issue_state": issue_state,
+                "project_archived": archived,
+            },
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        return {
+            "github_updated_at": str(issue["updated_at"]),
+            "project_field_hash": hashlib.sha256(encoded_fields).hexdigest(),
+            "projection_hash": projection_hash,
+        }
+
+    def preflight(
+        self,
+        identity: dict[str, object],
+        precondition: dict[str, object],
+    ) -> bool | None:
+        """Re-read the exact GitHub base immediately before any mutation."""
+        if precondition == {"projection_absent": True}:
+            self._effective_identity(identity, require_bound=False)
+            try:
+                candidates = self.snapshot_reader.projection_candidates()
+            except (AttributeError, RuntimeError, TypeError, ValueError):
+                return None
+            if not isinstance(candidates, list):
+                return None
+            matches = 0
+            try:
+                for candidate in candidates:
+                    if not isinstance(candidate, dict):
+                        return None
+                    body = candidate.get("body")
+                    if not isinstance(body, str):
+                        return None
+                    if not any(
+                        str(contract["start_marker"]) in body
+                        or str(contract["end_marker"]) in body
+                        for contract in self.managed_blocks
+                    ):
+                        continue
+                    managed, _projection_hash = self._managed_projection(
+                        body,
+                        None,
+                    )
+                    if managed["bead_id"] == identity["bead_id"]:
+                        matches += 1
+            except ValueError:
+                return None
+            return matches == 0
+        if not _valid_github_precondition(
+            precondition,
+            projection_absent=False,
+        ):
+            raise ValueError("GitHub execution precondition is malformed")
+        try:
+            snapshot = self._snapshot(identity)
+            current = self._snapshot_fingerprint(
+                snapshot,
+                str(identity["bead_id"]),
+            )
+        except (RuntimeError, TypeError, ValueError):
+            return None
+        if current != precondition:
+            return False
+        self._verified[str(identity["bead_id"])] = self._concurrency_state(snapshot)
+        return True
+
+    def binding(self, identity: dict[str, object]) -> dict[str, object]:
+        """Build a closed convergence receipt from effective GitHub state."""
+        self._effective_identity(identity, require_bound=False)
+        snapshot = self._snapshot(identity)
+        verified = self._verified.get(str(identity["bead_id"]))
+        if verified is not None and self._concurrency_state(snapshot) != verified:
+            raise ValueError("GitHub changed before convergence receipt readback")
+        repository = snapshot.get("repository")
+        issue = snapshot.get("issue")
+        project = snapshot.get("project")
+        event = snapshot.get("event")
+        if (
+            not isinstance(repository, dict)
+            or repository.get("full_name")
+            != self.organization + "/" + self.repository
+            or not isinstance(repository.get("id"), int)
+            or isinstance(repository["id"], bool)
+            or repository["id"] <= 0
+            or not isinstance(issue, dict)
+            or not isinstance(project, dict)
+            or not isinstance(event, dict)
+        ):
+            raise ValueError("GitHub binding readback is incomplete")
+        fingerprint = self._snapshot_fingerprint(
+            snapshot,
+            str(identity["bead_id"]),
+        )
+        delivery_id = event.get("delivery_id")
+        imported = self._imported_comment_ids.get(
+            str(identity["bead_id"]),
+            event.get("imported_comment_ids", []),
+        )
+        if (
+            not isinstance(delivery_id, str)
+            or not delivery_id
+            or not isinstance(imported, list)
+            or any(not isinstance(comment, str) or not comment for comment in imported)
+            or len(imported) != len(set(imported))
+        ):
+            raise ValueError("GitHub delivery receipt identity is invalid")
+        binding = {
+            "external_ref": "https://github.com/{0}/{1}/issues/{2}".format(
+                self.organization,
+                self.repository,
+                issue.get("number"),
+            ),
+            "repository_id": repository["id"],
+            "issue_node_id": issue.get("node_id"),
+            "issue_number": issue.get("number"),
+            "project_node_id": project.get("project_node_id"),
+            "project_item_id": project.get("project_item_id"),
+            "github_updated_at": fingerprint["github_updated_at"],
+            "project_field_hash": fingerprint["project_field_hash"],
+            "projection_hash": fingerprint["projection_hash"],
+            "delivery_id": delivery_id,
+            "imported_comment_ids": list(imported),
+        }
+        self._pending[str(identity["bead_id"])] = {
+            field: binding[field]
+            for field in (
+                "repository_id",
+                "issue_node_id",
+                "issue_number",
+                "project_node_id",
+                "project_item_id",
+            )
+        }
+        return binding
+
+    def set_imported_comment_ids(
+        self,
+        identity: dict[str, object],
+        imported_comment_ids: list[str],
+    ) -> None:
+        bead_id = identity.get("bead_id") if isinstance(identity, dict) else None
+        if (
+            not isinstance(bead_id, str)
+            or not bead_id
+            or not isinstance(imported_comment_ids, list)
+            or any(not isinstance(item, str) or not item for item in imported_comment_ids)
+            or len(imported_comment_ids) != len(set(imported_comment_ids))
+        ):
+            raise ValueError("GitHub imported comment receipt is invalid")
+        self._imported_comment_ids[bead_id] = list(imported_comment_ids)
+
+
+class PlannerRunner:
+    def __init__(self, run: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run) -> None:
+        self.run = run
+
+    def plan(
+        self,
+        snapshots: dict[str, object],
+        *,
+        agent_platform_bin: str,
+        platform_root: str,
+    ) -> dict[str, object]:
+        if set(snapshots) != {"beads", "issues"}:
+            raise ValueError("snapshots must contain exactly beads and issues")
+        if not os.path.isabs(agent_platform_bin) or not os.path.isabs(platform_root):
+            raise ValueError("planner binary and platform root must be absolute")
+        with tempfile.TemporaryDirectory(prefix="github-work-sync-") as tempdir:
+            os.chmod(tempdir, 0o700)
+            input_path = os.path.join(tempdir, "snapshots.json")
+            output_path = os.path.join(tempdir, "execution-plan.json")
+            _private_json(input_path, snapshots)
+            command = [
+                agent_platform_bin,
+                "--json",
+                "work-sync",
+                "plan",
+                "--input",
+                input_path,
+                "--output",
+                output_path,
+                "--platform-root",
+                platform_root,
+            ]
+            result = self.run(
+                command,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if result.returncode != 0:
+                detail = (result.stderr or result.stdout or "planner failed").strip()
+                raise RuntimeError("work-sync planner failed: " + detail[:1000])
+            if not os.path.isfile(output_path) or os.path.islink(output_path):
+                raise RuntimeError("work-sync planner did not create a regular execution plan")
+            if os.stat(output_path).st_mode & 0o777 != 0o600:
+                raise RuntimeError("work-sync execution plan must have mode 0600")
+            with open(output_path, "r", encoding="utf-8") as source:
+                plan = json.load(source)
+        if not isinstance(plan, dict):
+            raise RuntimeError("work-sync planner returned a non-object plan")
+        return plan
+
+
+class WorkSyncReconciler:
+    """Run bounded plan/apply/readback cycles on one exact repository route."""
+
+    def __init__(
+        self,
+        *,
+        contract: dict[str, object],
+        projects: dict[str, object],
+        event: dict[str, object],
+        beads_reader: object,
+        github_reader: object,
+        planner: object,
+        beads_cas: object,
+        github_writer: object,
+        receipt_store: object,
+        agent_platform_bin: str,
+        platform_root: str,
+        apply_plan: Callable[..., dict[str, object]] | None = None,
+    ) -> None:
+        route = contract.get("route") if isinstance(contract, dict) else None
+        if (
+            not isinstance(route, dict)
+            or not isinstance(route.get("repository"), str)
+            or not route["repository"]
+            or not isinstance(route.get("owning_project"), str)
+            or not route["owning_project"]
+            or not isinstance(contract.get("managed_blocks"), list)
+            or not isinstance(contract.get("cross_city_project"), str)
+            or not contract["cross_city_project"]
+            or not isinstance(contract.get("cross_city_bead_types"), list)
+            or not contract["cross_city_bead_types"]
+            or not isinstance(contract.get("max_identical_attempts"), int)
+            or isinstance(contract["max_identical_attempts"], bool)
+            or contract["max_identical_attempts"] <= 0
+            or contract["max_identical_attempts"] > 2
+            or not isinstance(contract.get("live_mutations"), bool)
+            or not isinstance(projects, dict)
+            or not isinstance(event, dict)
+            or not isinstance(event.get("delivery_id"), str)
+            or not event["delivery_id"]
+            or event.get("origin")
+            not in {"github-human", contract.get("projection_writer")}
+            or not os.path.isabs(agent_platform_bin)
+            or not os.path.isabs(platform_root)
+        ):
+            raise ValueError("work-sync reconciler contract is malformed")
+        self.contract = contract
+        self.projects = projects
+        self.event = dict(event)
+        self.beads_reader = beads_reader
+        self.github_reader = github_reader
+        self.planner = planner
+        self.beads_cas = beads_cas
+        self.github_writer = github_writer
+        self.receipt_store = receipt_store
+        self.agent_platform_bin = agent_platform_bin
+        self.platform_root = platform_root
+        self.apply_plan = apply_plan or apply_execution_plan
+
+    def _plan(self) -> dict[str, object]:
+        beads = self.beads_reader.read()
+        issues = self.github_reader.reconciliation_records(
+            projects=self.projects,
+            managed_blocks=self.contract["managed_blocks"],
+            owning_project=self.contract["route"]["owning_project"],
+            cross_city_project=self.contract["cross_city_project"],
+            cross_city_bead_types=self.contract["cross_city_bead_types"],
+            event=self.event,
+        )
+        if not isinstance(beads, list) or not isinstance(issues, list):
+            raise RuntimeError("work-sync snapshot readers returned malformed data")
+        self._prepare_issues(beads, issues)
+        plan = self.planner.plan(
+            {"beads": beads, "issues": issues},
+            agent_platform_bin=self.agent_platform_bin,
+            platform_root=self.platform_root,
+        )
+        if not isinstance(plan, dict):
+            raise RuntimeError("work-sync planner returned malformed data")
+        return plan
+
+    def _prepare_issues(
+        self,
+        beads: list[dict[str, object]],
+        issues: list[dict[str, object]],
+    ) -> None:
+        bead_by_id: dict[str, dict[str, object]] = {}
+        duplicate_beads: set[str] = set()
+        for record in beads:
+            raw = record.get("issue") if isinstance(record, dict) else None
+            bead_id = raw.get("id") if isinstance(raw, dict) else None
+            if not isinstance(bead_id, str) or not bead_id:
+                continue
+            if bead_id in bead_by_id:
+                duplicate_beads.add(bead_id)
+            bead_by_id[bead_id] = record
+
+        for record in issues:
+            raw_issue = record.get("issue") if isinstance(record, dict) else None
+            body = raw_issue.get("body") if isinstance(raw_issue, dict) else None
+            managed, projection_hash = _parse_managed_projection(
+                body,
+                None,
+                self.contract["managed_blocks"],
+            )
+            bead_id = str(managed["bead_id"])
+            bead_record = bead_by_id.get(bead_id)
+            if (
+                self.event["origin"] == self.contract["projection_writer"]
+                and bead_record is not None
+                and bead_id not in duplicate_beads
+            ):
+                raw_bead = bead_record.get("issue")
+                revision = raw_bead.get("revision") if isinstance(raw_bead, dict) else None
+                event = record.get("event")
+                if isinstance(event, dict) and isinstance(revision, int) and not isinstance(revision, bool):
+                    event["bead_revision"] = revision
+                    event["projection_hash"] = projection_hash
+
+            if bead_record is None or bead_id in duplicate_beads:
+                continue
+            receipt = bead_record.get("receipt")
+            if isinstance(receipt, dict) and "imported_comment_ids" in receipt:
+                imported = receipt.get("imported_comment_ids")
+                try:
+                    self.github_writer.set_imported_comment_ids(
+                        {"bead_id": bead_id}, imported
+                    )
+                except (AttributeError, TypeError, ValueError) as exc:
+                    raise RuntimeError("work-sync imported comment receipt is invalid") from exc
+            if not isinstance(receipt, dict) or receipt.get("delivery_id") != self.event["delivery_id"]:
+                continue
+            if _valid_pending_push(receipt.get("pending")) or _valid_pending_pull(receipt.get("pending")):
+                # The pure planner verifies exact before/after snapshot hashes
+                # and the target Bead revision before allowing resume writes.
+                continue
+            raw_bead = bead_record.get("issue")
+            revision = raw_bead.get("revision") if isinstance(raw_bead, dict) else None
+            try:
+                fingerprint = self.github_writer._snapshot_fingerprint(record, bead_id)
+            except (AttributeError, RuntimeError, TypeError, ValueError) as exc:
+                raise RuntimeError("work-sync delivery replay conflict") from exc
+            if (
+                receipt.get("applied_bead_revision", receipt.get("bead_revision")) != revision
+                or any(
+                    receipt.get(field) != fingerprint.get(field)
+                    for field in (
+                        "github_updated_at",
+                        "project_field_hash",
+                        "projection_hash",
+                    )
+                )
+            ):
+                raise RuntimeError("work-sync delivery replay conflict")
+
+    @staticmethod
+    def _terminal(plan: dict[str, object]) -> bool:
+        counts = plan.get("counts")
+        plans = plan.get("plans")
+        return bool(
+            plan.get("status") == "green"
+            and plan.get("execution_safe") is True
+            and isinstance(counts, dict)
+            and counts.get("operations") == 0
+            and isinstance(plans, list)
+            and all(
+                isinstance(item, dict)
+                and item.get("state") == "green"
+                and item.get("execution_safe") is True
+                and item.get("operations") == []
+                for item in plans
+            )
+        )
+
+    @staticmethod
+    def _public_counts(plan: dict[str, object]) -> dict[str, object]:
+        counts = plan.get("counts")
+        if not isinstance(counts, dict):
+            return {}
+        return {
+            key: counts[key]
+            for key in (
+                "beads",
+                "issues",
+                "plans",
+                "operations",
+                "duplicates",
+                "orphans",
+            )
+            if key in counts
+        }
+
+    def run(self, *, dry_run: bool = False) -> dict[str, object]:
+        if not dry_run and self.contract["live_mutations"] is not True:
+            raise RuntimeError("canonical work-sync live mutations are disabled")
+        plan = self._plan()
+        if dry_run:
+            result = self.apply_plan(
+                plan,
+                self.beads_cas,
+                self.github_writer,
+                self.receipt_store,
+                dry_run=True,
+            )
+            return {
+                **result,
+                "terminal_readback": False,
+                "counts": self._public_counts(plan),
+            }
+
+        attempts = 0
+        max_attempts = int(self.contract["max_identical_attempts"])
+        while attempts < max_attempts:
+            if self._terminal(plan):
+                return {
+                    "status": "green",
+                    "terminal_readback": True,
+                    "attempts": attempts,
+                    "counts": self._public_counts(plan),
+                }
+            attempts += 1
+            result = self.apply_plan(
+                plan,
+                self.beads_cas,
+                self.github_writer,
+                self.receipt_store,
+            )
+            if result.get("status") not in {"green", "replan_required"}:
+                return {
+                    **result,
+                    "terminal_readback": False,
+                    "attempts": attempts,
+                    "counts": self._public_counts(plan),
+                }
+            plan = self._plan()
+
+        if self._terminal(plan):
+            return {
+                "status": "green",
+                "terminal_readback": True,
+                "attempts": attempts,
+                "counts": self._public_counts(plan),
+            }
+        return {
+            "status": "unknown",
+            "reason": "bounded_reconciliation_not_converged",
+            "terminal_readback": False,
+            "attempts": attempts,
+            "counts": self._public_counts(plan),
+        }
+
+
+def _stable_identity(identity: object, *, allow_unbound: bool = False) -> bool:
+    if not isinstance(identity, dict):
+        return False
+    if not isinstance(identity.get("bead_id"), str) or not identity["bead_id"]:
+        return False
+    if not isinstance(identity.get("repository"), str) or not identity["repository"]:
+        return False
+    if allow_unbound:
+        return True
+    text_fields = ("issue_node_id", "project_node_id", "project_item_id")
+    if any(not isinstance(identity.get(field), str) or not identity[field] for field in text_fields):
+        return False
+    if not isinstance(identity.get("repository_id"), int) or isinstance(identity["repository_id"], bool):
+        return False
+    if not isinstance(identity.get("issue_number"), int) or isinstance(identity["issue_number"], bool):
+        return False
+    return identity["repository_id"] > 0 and identity["issue_number"] > 0
+
+
+def _operation_lists(plan: dict[str, object]) -> tuple[list[dict[str, object]], list[dict[str, object]]]:
+    pull: list[dict[str, object]] = []
+    push: list[dict[str, object]] = []
+    raw = plan.get("operations")
+    if not isinstance(raw, list):
+        raise ValueError("plan operations must be an array")
+    for item in raw:
+        if not isinstance(item, dict):
+            raise ValueError("plan operation must be an object")
+        direction = item.get("direction")
+        if direction == "github-to-beads":
+            pull.append(item)
+        elif direction == "beads-to-github":
+            push.append(item)
+        else:
+            raise ValueError("unknown work-sync operation direction")
+    return pull, push
+
+
+def _pull_patch(operations: list[dict[str, object]]) -> tuple[int, dict[str, object]]:
+    expected: int | None = None
+    patch: dict[str, object] = {}
+    for item in operations:
+        revision = item.get("expected_revision")
+        if not isinstance(revision, int) or isinstance(revision, bool) or revision == 0:
+            raise ValueError("operation expected_revision must be a nonzero integer")
+        if expected is None:
+            expected = revision
+        elif expected != revision:
+            raise ValueError("one plan cannot mix Beads revisions")
+        kind = item.get("kind")
+        field = item.get("field")
+        value = item.get("value")
+        if kind == "append-comment" and field == "comments" and isinstance(value, dict):
+            node_id = value.get("node_id")
+            body = value.get("body")
+            created_at = value.get("created_at")
+            if (
+                not isinstance(node_id, str)
+                or not node_id
+                or not isinstance(body, str)
+                or not body.strip()
+                or not _rfc3339_timestamp(created_at)
+            ):
+                raise ValueError("comment import requires node_id/body/created_at")
+            comments = patch.setdefault("comments", [])
+            if not isinstance(comments, list):
+                raise ValueError("comment patch collides with another field")
+            if any(
+                isinstance(comment, dict)
+                and comment.get("external_id") == node_id
+                for comment in comments
+            ):
+                raise ValueError("duplicate comment import identity")
+            comments.append({
+                "external_id": node_id,
+                "body": body,
+                "created_at": created_at,
+            })
+            continue
+        if kind == "update-field" and field in {"title", "description"} and isinstance(value, str):
+            patch[str(field)] = value
+            continue
+        if kind == "transition-request" and field == "status" and isinstance(value, str):
+            patch["status"] = value
+            continue
+        if kind == "transition-request" and field == "priority" and isinstance(value, int):
+            patch["priority"] = value
+            continue
+        if kind == "transition-request" and field == "bead_type" and isinstance(value, str):
+            patch["type"] = value
+            continue
+        raise ValueError("unsupported github-to-beads operation")
+    if expected is None or not patch:
+        raise ValueError("empty github-to-beads patch")
+    return expected, patch
+
+
+def _rfc3339_timestamp(value: object) -> bool:
+    if not isinstance(value, str) or not value:
+        return False
+    normalized = value[:-1] + "+00:00" if value.endswith("Z") else value
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return False
+    return parsed.tzinfo is not None
+
+
+_BINDING_FIELDS = {
+    "external_ref",
+    "repository_id",
+    "issue_node_id",
+    "issue_number",
+    "project_node_id",
+    "project_item_id",
+    "github_updated_at",
+    "project_field_hash",
+    "projection_hash",
+    "delivery_id",
+    "imported_comment_ids",
+}
+
+
+def _sha256(value: object) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) == 64
+        and all(character in "0123456789abcdef" for character in value)
+    )
+
+
+def _parse_managed_projection(
+    body: object,
+    bead_id: str | None,
+    managed_blocks: list[dict[str, object]],
+) -> tuple[dict[str, object], str]:
+    if not isinstance(body, str):
+        raise ValueError("GitHub Issue managed body is not text")
+    matches: list[dict[str, object]] = []
+    for contract in managed_blocks:
+        if not isinstance(contract, dict):
+            raise ValueError("GitHub Issue managed block contract is malformed")
+        start = str(contract.get("start_marker", ""))
+        end = str(contract.get("end_marker", ""))
+        fields = contract.get("fields")
+        if (
+            not start
+            or not end
+            or start == end
+            or not isinstance(fields, list)
+            or len(fields) != len(set(fields))
+        ):
+            raise ValueError("GitHub Issue managed block contract is malformed")
+        start_count = body.count(start)
+        end_count = body.count(end)
+        if start_count == 0 and end_count == 0:
+            continue
+        if start_count != 1 or end_count != 1:
+            raise ValueError("GitHub Issue managed block markers are ambiguous")
+        start_index = body.index(start) + len(start)
+        end_index = body.index(end, start_index)
+        try:
+            managed = json.loads(body[start_index:end_index].strip())
+        except (TypeError, ValueError) as exc:
+            raise ValueError("GitHub Issue managed block JSON is malformed") from exc
+        if (
+            not isinstance(managed, dict)
+            or set(managed) != set(fields)
+            or (bead_id is not None and managed.get("bead_id") != bead_id)
+            or not isinstance(managed.get("bead_id"), str)
+            or not managed["bead_id"]
+            or not _sha256(managed.get("projection_hash"))
+        ):
+            raise ValueError("GitHub Issue managed block identity is invalid")
+        payload = {
+            field: managed[field]
+            for field in managed
+            if field not in {"bead_id", "projection_hash"}
+        }
+        encoded = json.dumps(
+            payload,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        if hashlib.sha256(encoded).hexdigest() != managed["projection_hash"]:
+            raise ValueError("GitHub Issue managed projection hash mismatches")
+        matches.append(managed)
+    if len(matches) != 1:
+        raise ValueError("GitHub Issue requires exactly one managed block")
+    return matches[0], str(matches[0]["projection_hash"])
+
+
+def _normalized_binding(
+    binding: object,
+    identity: dict[str, object],
+    *,
+    allow_unbound: bool = False,
+) -> dict[str, object]:
+    if not isinstance(binding, dict) or set(binding) != _BINDING_FIELDS:
+        raise ValueError("GitHub readback binding must match the closed receipt schema")
+    external_ref = binding.get("external_ref")
+    if not isinstance(external_ref, str) or not external_ref.startswith("https://github.com/"):
+        raise ValueError("GitHub readback binding lacks canonical external_ref")
+    integer_fields = ("repository_id", "issue_number")
+    if any(
+        not isinstance(binding.get(field), int)
+        or isinstance(binding[field], bool)
+        or binding[field] <= 0
+        for field in integer_fields
+    ):
+        raise ValueError("GitHub readback numeric identity is invalid")
+    text_fields = (
+        "issue_node_id",
+        "project_node_id",
+        "project_item_id",
+        "github_updated_at",
+        "delivery_id",
+    )
+    if any(
+        not isinstance(binding.get(field), str) or not binding[field]
+        for field in text_fields
+    ):
+        raise ValueError("GitHub readback text identity is invalid")
+    if not _sha256(binding.get("project_field_hash")) or not _sha256(
+        binding.get("projection_hash")
+    ):
+        raise ValueError("GitHub readback hashes are invalid")
+    imported = binding.get("imported_comment_ids")
+    if (
+        not isinstance(imported, list)
+        or any(not isinstance(item, str) or not item for item in imported)
+        or len(imported) != len(set(imported))
+    ):
+        raise ValueError("GitHub imported comment identity is invalid")
+    if not allow_unbound:
+        for field in (
+            "repository_id",
+            "issue_node_id",
+            "issue_number",
+            "project_node_id",
+            "project_item_id",
+        ):
+            if identity.get(field) != binding[field]:
+                raise ValueError("GitHub readback stable identity mismatch")
+    return dict(binding)
+
+
+def _stable_binding_patch(binding: dict[str, object]) -> dict[str, object]:
+    return {
+        "external_ref": binding["external_ref"],
+        "metadata": {
+            "github.repository_id": str(binding["repository_id"]),
+            "github.issue_node_id": str(binding["issue_node_id"]),
+            "github.issue_number": str(binding["issue_number"]),
+            "github.project_node_id": str(binding["project_node_id"]),
+            "github.project_item_id": str(binding["project_item_id"]),
+        },
+    }
+
+
+def _save_receipt(
+    receipt_store: object,
+    identity: dict[str, object],
+    bead_revision: int,
+    binding: dict[str, object],
+    *,
+    applied_bead_revision: int | None = None,
+) -> None:
+    if (
+        not isinstance(bead_revision, int)
+        or isinstance(bead_revision, bool)
+        or bead_revision == 0
+    ):
+        raise ValueError("Bead receipt revision must be a nonzero integer")
+    if applied_bead_revision is None:
+        receipt_store.save(identity, bead_revision, binding)
+    else:
+        receipt_store.save(
+            identity, bead_revision, binding,
+            applied_bead_revision=applied_bead_revision,
+        )
+
+
+def _valid_push_operation(item: dict[str, object]) -> bool:
+    kind = item.get("kind")
+    field = item.get("field")
+    value = item.get("value")
+    if kind == "create-projection" and field == "projection":
+        if not isinstance(value, dict) or set(value) != {"route", "issue"}:
+            return False
+        route = value.get("route")
+        issue = value.get("issue")
+        if not isinstance(route, dict) or not isinstance(issue, dict):
+            return False
+        return (
+            set(issue)
+            == {
+                "title",
+                "body",
+                "issue_type",
+                "issue_state",
+                "project",
+                "projection_hash",
+            }
+            and all(
+                isinstance(issue.get(name), str) and issue[name]
+                for name in ("title", "body", "issue_type")
+            )
+            and issue.get("issue_state") in {"open", "closed"}
+            and isinstance(issue.get("project"), dict)
+            and _sha256(issue.get("projection_hash"))
+        )
+    if kind == "bind-existing-projection" and field == "identity":
+        return (
+            isinstance(value, dict)
+            and set(value) == {"projection_hash"}
+            and _sha256(value.get("projection_hash"))
+        )
+    if kind == "replace-managed-block" and field == "projection":
+        return (
+            isinstance(value, dict)
+            and set(value) == {"body", "projection_hash"}
+            and isinstance(value.get("body"), str)
+            and _sha256(value.get("projection_hash"))
+        )
+    if kind == "migrate-managed-block" and field == "projection":
+        return (
+            isinstance(value, dict)
+            and isinstance(value.get("body"), str)
+            and _sha256(value.get("projection_hash"))
+            and _sha256(value.get("expected_legacy_projection_hash"))
+            and value.get("readback_after_write") is True
+        )
+    if kind == "update-project-field":
+        return field in {"status", "priority", "bead_type", "lifecycle_phase"} and isinstance(value, str) and bool(value)
+    if kind == "update-issue-type":
+        return field == "issue_type" and isinstance(value, str) and bool(value)
+    if kind == "update-issue-state":
+        return field == "issue_state" and value in {"open", "closed"}
+    if kind == "restore-project-item":
+        return field == "project_archived" and value is False
+    if kind == "refresh-binding" and field == "identity":
+        return (
+            isinstance(value, dict)
+            and set(value)
+            == {
+                "bead_revision",
+                "github_updated_at",
+                "project_field_hash",
+                "projection_hash",
+            }
+            and isinstance(value.get("bead_revision"), int)
+            and not isinstance(value["bead_revision"], bool)
+            and value["bead_revision"] != 0
+            and isinstance(value.get("github_updated_at"), str)
+            and bool(value["github_updated_at"])
+            and _sha256(value.get("project_field_hash"))
+            and _sha256(value.get("projection_hash"))
+        )
+    return False
+
+
+def _valid_github_precondition(
+    precondition: object,
+    *,
+    projection_absent: bool,
+) -> bool:
+    if projection_absent:
+        return precondition == {"projection_absent": True}
+    return bool(
+        isinstance(precondition, dict)
+        and set(precondition)
+        == {
+            "github_updated_at",
+            "project_field_hash",
+            "projection_hash",
+        }
+        and isinstance(precondition.get("github_updated_at"), str)
+        and precondition["github_updated_at"]
+        and _sha256(precondition.get("project_field_hash"))
+        and _sha256(precondition.get("projection_hash"))
+    )
+
+
+def _execution_allowed(execution: dict[str, object], plans: object) -> bool:
+    if execution.get("execution_safe") is not True or not isinstance(plans, list):
+        return False
+    status = execution.get("status")
+    if status not in {"green", "red"}:
+        return False
+    if status == "red":
+        reasons = execution.get("reason_codes")
+        if (
+            not isinstance(reasons, list)
+            or not reasons
+            or not set(reasons).issubset(
+                {"missing-github-projection", "orphan-bead"}
+            )
+        ):
+            return False
+    for plan in plans:
+        if not isinstance(plan, dict) or plan.get("execution_safe") is not True:
+            return False
+        state = plan.get("state")
+        operations = plan.get("operations")
+        if not isinstance(operations, list):
+            return False
+        if (
+            state == "green"
+            and not operations
+            and plan.get("reason_codes") == ["internal-bead-not-projected"]
+            and _valid_github_precondition(
+                plan.get("github_precondition"), projection_absent=True,
+            )
+        ):
+            continue
+        creates = bool(operations) and all(
+            isinstance(item, dict) and item.get("kind") == "create-projection"
+            for item in operations
+        )
+        if not _valid_github_precondition(
+            plan.get("github_precondition"),
+            projection_absent=creates,
+        ):
+            return False
+        if state == "green":
+            continue
+        if (
+            state != "red"
+            or plan.get("reason_codes") != ["missing-github-projection"]
+            or not operations
+            or any(
+                not isinstance(item, dict)
+                or item.get("kind") != "create-projection"
+                for item in operations
+            )
+        ):
+            return False
+    return True
+
+
+def _apply_github_with_readback(
+    github: object,
+    identity: dict[str, object],
+    item: dict[str, object],
+) -> str:
+    for attempt in range(2):
+        try:
+            github.apply(identity, item)
+        except AmbiguousTransportError:
+            readback = github.readback(identity, item)
+            if readback is True:
+                return "applied"
+            if readback is None:
+                return "unknown"
+            if attempt == 0:
+                continue
+            return "failed"
+        except TransientTransportError:
+            if attempt == 0:
+                continue
+            return "failed"
+        except (RuntimeError, ValueError):
+            return "failed"
+        readback = github.readback(identity, item)
+        if readback is True:
+            return "applied"
+        if readback is None:
+            return "unknown"
+        return "failed"
+    return "failed"
+
+
+def apply_execution_plan(
+    execution: dict[str, object],
+    beads_cas: object,
+    github: object,
+    receipt_store: object,
+    *,
+    dry_run: bool = False,
+) -> dict[str, object]:
+    """Apply one planner result without last-write-wins or blind retries."""
+    if not isinstance(execution, dict):
+        return {"status": "red", "reason": "malformed_execution_plan"}
+    plans = execution.get("plans")
+    if not _execution_allowed(execution, plans):
+        return {"status": "red", "reason": "planner_not_execution_safe"}
+    assert isinstance(plans, list)
+    if dry_run:
+        return {
+            "status": "dry_run",
+            "planned_operations": sum(
+                len(plan.get("operations", []))
+                for plan in plans
+                if isinstance(plan, dict) and isinstance(plan.get("operations"), list)
+            ),
+        }
+
+    applied = 0
+    for plan in plans:
+        assert isinstance(plan, dict)
+        try:
+            pull, push = _operation_lists(plan)
+        except ValueError:
+            return {"status": "red", "reason": "malformed_execution_plan"}
+        if not pull and not push:
+            continue
+        identity = plan.get("identity")
+        allow_unbound = bool(push) and all(item.get("kind") == "create-projection" for item in push)
+        if not _stable_identity(identity, allow_unbound=allow_unbound):
+            return {"status": "red", "reason": "invalid_stable_identity"}
+        assert isinstance(identity, dict)
+        if allow_unbound:
+            # A newly created Issue cannot have any previously imported comment
+            # identities. Do not inherit delivery metadata from another event.
+            github.set_imported_comment_ids(identity, [])
+        elif "imported_comment_ids" in identity:
+            imported = identity["imported_comment_ids"]
+            if not _unique_comment_ids(imported):
+                return {"status": "red", "reason": "invalid_imported_comment_identity"}
+            github.set_imported_comment_ids(identity, imported)
+
+        try:
+            preflight = github.preflight(
+                identity,
+                plan["github_precondition"],
+            )
+        except (AttributeError, RuntimeError, TypeError, ValueError):
+            return {"status": "unknown", "reason": "github_precondition_unproven"}
+        if preflight is None:
+            return {"status": "unknown", "reason": "github_precondition_unproven"}
+        if preflight is not True:
+            return {"status": "red", "reason": "github_precondition_changed"}
+
+        if pull:
+            try:
+                expected_revision, patch = _pull_patch(pull)
+            except RuntimeError as exc:
+                return {"status": "red", "reason": str(exc)}
+            except ValueError:
+                return {"status": "red", "reason": "unsupported_beads_operation"}
+            try:
+                binding = _normalized_binding(github.binding(identity), identity)
+                receipt_store.begin(identity, expected_revision, binding, _pending_pull(
+                    patch, binding, plan.get("beads_convergence_base"),
+                ))
+            except (AttributeError, OSError, RuntimeError, TypeError, ValueError):
+                return {"status": "unknown", "reason": "pending_cas_persistence_unproven"}
+            outcome = beads_cas.apply(str(identity["bead_id"]), expected_revision, patch)
+            if not isinstance(outcome, dict) or outcome.get("outcome") == "conflict":
+                return {"status": "red", "reason": "beads_revision_conflict"}
+            if outcome.get("outcome") not in {"updated", "already_applied"}:
+                return {"status": "unknown", "reason": "beads_cas_unproven"}
+            comments = patch.get("comments")
+            if isinstance(comments, list):
+                imported = outcome.get("imported_comment_ids")
+                requested = {
+                    item.get("external_id")
+                    for item in comments
+                    if isinstance(item, dict)
+                }
+                if (
+                    not isinstance(imported, list)
+                    or any(not isinstance(item, str) or not item for item in imported)
+                    or len(imported) != len(set(imported))
+                    or not requested.issubset(set(imported))
+                ):
+                    return {"status": "unknown", "reason": "beads_comment_readback_unproven"}
+                try:
+                    github.set_imported_comment_ids(identity, imported)
+                except (AttributeError, TypeError, ValueError):
+                    return {"status": "unknown", "reason": "github_comment_receipt_unproven"}
+            applied += len(pull)
+            try:
+                binding = _normalized_binding(github.binding(identity), identity)
+                revision = outcome.get("revision")
+                if not isinstance(revision, int) or isinstance(revision, bool) or revision == 0:
+                    raise ValueError("Beads CAS revision is unproven")
+                # Machine-field requests (or a concurrent outgoing change)
+                # still need an export. Human-only imports do not alter the
+                # managed projection and can advance its convergence base.
+                receipt_revision = (
+                    expected_revision if push or set(patch) & {"status", "priority", "type"}
+                    else revision
+                )
+                _save_receipt(
+                    receipt_store, identity, receipt_revision, binding,
+                    applied_bead_revision=revision,
+                )
+            except (AttributeError, OSError, TypeError, ValueError):
+                return {"status": "unknown", "reason": "receipt_readback_unproven"}
+            if push:
+                return {
+                    "status": "replan_required",
+                    "reason": "beads_revision_advanced",
+                    "applied_operations": applied,
+                }
+
+        if push:
+            revisions = {item.get("expected_revision") for item in push}
+            if len(revisions) != 1:
+                return {"status": "red", "reason": "mixed_expected_revisions"}
+            expected_revision = next(iter(revisions))
+            if not isinstance(expected_revision, int) or isinstance(expected_revision, bool) or expected_revision == 0:
+                return {"status": "red", "reason": "invalid_expected_revision"}
+            if any(not _valid_push_operation(item) for item in push):
+                return {"status": "red", "reason": "unsupported_github_operation"}
+            refresh = [item for item in push if item.get("kind") == "refresh-binding"]
+            bind_existing = [item for item in push if item.get("kind") == "bind-existing-projection"]
+            if (refresh or bind_existing) and len(push) != 1:
+                return {"status": "red", "reason": "mixed_refresh_operation"}
+            for item in (push if not refresh and not bind_existing else []):
+                if allow_unbound:
+                    try:
+                        receipt_store.begin_creation(
+                            identity, expected_revision, _pending_creation(item),
+                        )
+                    except (AttributeError, OSError, RuntimeError, TypeError, ValueError):
+                        return {"status": "unknown", "reason": "pending_creation_persistence_unproven"}
+                if not allow_unbound:
+                    try:
+                        binding = _normalized_binding(github.binding(identity), identity)
+                        pending = github.pending_write(identity, item)
+                        receipt_store.begin(identity, expected_revision, binding, pending)
+                    except (AttributeError, OSError, RuntimeError, TypeError, ValueError):
+                        return {"status": "unknown", "reason": "pending_write_persistence_unproven"}
+                outcome = _apply_github_with_readback(github, identity, item)
+                if outcome == "unknown":
+                    return {"status": "unknown", "reason": "github_readback_unknown"}
+                if outcome != "applied":
+                    return {"status": "red", "reason": "github_write_failed"}
+                applied += 1
+            try:
+                binding = _normalized_binding(
+                    github.binding(identity),
+                    identity,
+                    allow_unbound=allow_unbound,
+                )
+            except (AttributeError, TypeError, ValueError):
+                return {"status": "unknown", "reason": "github_binding_readback_invalid"}
+            if refresh:
+                expected = refresh[0]["value"]
+                assert isinstance(expected, dict)
+                if any(
+                    expected[field] != binding[field]
+                    for field in (
+                        "github_updated_at",
+                        "project_field_hash",
+                        "projection_hash",
+                    )
+                ) or expected["bead_revision"] != expected_revision:
+                    return {"status": "unknown", "reason": "refresh_readback_mismatch"}
+                receipt_revision = expected_revision
+            elif bind_existing or allow_unbound:
+                if bind_existing:
+                    value = bind_existing[0]["value"]
+                    assert isinstance(value, dict)
+                    if binding["projection_hash"] != value["projection_hash"]:
+                        return {"status": "red", "reason": "pending_creation_projection_changed"}
+                try:
+                    receipt_store.begin_binding(
+                        identity, expected_revision, binding,
+                        _pending_binding(expected_revision, binding),
+                    )
+                except (AttributeError, OSError, RuntimeError, TypeError, ValueError):
+                    return {"status": "unknown", "reason": "pending_binding_persistence_unproven"}
+                outcome = beads_cas.apply(
+                    str(identity["bead_id"]), expected_revision,
+                    _stable_binding_patch(binding),
+                )
+                if not isinstance(outcome, dict) or outcome.get("outcome") == "conflict":
+                    return {"status": "red", "reason": "binding_revision_conflict"}
+                if outcome.get("outcome") not in {"updated", "already_applied"}:
+                    return {"status": "unknown", "reason": "binding_cas_unproven"}
+                receipt_revision = outcome.get("revision")
+            else:
+                receipt_revision = expected_revision
+            try:
+                _save_receipt(
+                    receipt_store,
+                    identity,
+                    receipt_revision,
+                    binding,
+                )
+            except (AttributeError, OSError, TypeError, ValueError):
+                return {"status": "unknown", "reason": "receipt_persistence_unproven"}
+
+    return {"status": "green", "applied_operations": applied}
+
+
+class BeadsCAS:
+    """Exact-store adapter over `gc beads update-cas`; content stays on stdin."""
+
+    def __init__(
+        self,
+        *,
+        city: str,
+        rig: str,
+        gc_bin: str = "gc",
+        run: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+    ) -> None:
+        if not city or not rig or "/" in rig:
+            raise ValueError("exact City and local Rig are required")
+        self.city = city
+        self.rig = rig
+        self.gc_bin = gc_bin
+        self.run = run
+
+    def apply(self, bead_id: str, expected_revision: int, patch: dict[str, object]) -> dict[str, object]:
+        command = [
+            self.gc_bin,
+            "--city",
+            self.city,
+            "beads",
+            "update-cas",
+            bead_id,
+            "--store-ref=rig:" + self.rig,
+            "--expected-revision=" + str(expected_revision),
+            "--request-file=-",
+            "--json",
+        ]
+        result = self.run(
+            command,
+            input=json.dumps(patch, ensure_ascii=False, sort_keys=True) + "\n",
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            raise RuntimeError("gc beads update-cas failed")
+        try:
+            payload = json.loads(result.stdout)
+        except (TypeError, ValueError) as exc:
+            raise RuntimeError("gc beads update-cas returned malformed JSON") from exc
+        if (
+            not isinstance(payload, dict)
+            or payload.get("schema_version") != "1"
+            or payload.get("ok") is not True
+            or payload.get("bead_id") != bead_id
+            or payload.get("store_ref") != "rig:" + self.rig
+            or payload.get("expected_revision") != expected_revision
+            or payload.get("outcome") not in {"updated", "already_applied", "conflict"}
+            or not isinstance(payload.get("revision"), int)
+            or isinstance(payload["revision"], bool)
+            or payload["revision"] == 0
+        ):
+            raise RuntimeError("gc beads update-cas returned non-object JSON")
+        comments = patch.get("comments")
+        if isinstance(comments, list) and payload["outcome"] != "conflict":
+            payload["imported_comment_ids"] = self._comment_receipt_readback(
+                bead_id=bead_id,
+                revision=int(payload["revision"]),
+                comments=comments,
+            )
+        return payload
+
+    def _comment_receipt_readback(
+        self,
+        *,
+        bead_id: str,
+        revision: int,
+        comments: list[object],
+    ) -> list[str]:
+        command = [
+            self.gc_bin,
+            "--city",
+            self.city,
+            "beads",
+            "snapshot",
+            "--store-ref=rig:" + self.rig,
+            "--json",
+        ]
+        result = self.run(
+            command,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            raise RuntimeError("gc beads snapshot failed after comment CAS")
+        try:
+            payload = json.loads(result.stdout)
+        except (TypeError, ValueError) as exc:
+            raise RuntimeError("gc beads snapshot returned malformed JSON") from exc
+        rows = payload.get("beads") if isinstance(payload, dict) else None
+        if (
+            not isinstance(payload, dict)
+            or payload.get("schema_version") != "1"
+            or payload.get("ok") is not True
+            or payload.get("store_ref") != "rig:" + self.rig
+            or not isinstance(rows, list)
+        ):
+            raise RuntimeError("gc beads snapshot did not prove comment CAS route")
+        matches = [row for row in rows if isinstance(row, dict) and row.get("id") == bead_id]
+        if len(matches) != 1 or matches[0].get("revision") != revision:
+            raise RuntimeError("gc beads snapshot did not prove comment CAS revision")
+        metadata = matches[0].get("metadata")
+        raw_ids = metadata.get("github.imported_comment_ids") if isinstance(metadata, dict) else None
+        try:
+            imported = json.loads(raw_ids) if isinstance(raw_ids, str) else None
+        except ValueError as exc:
+            raise RuntimeError("gc beads comment receipt is malformed") from exc
+        requested = {
+            item.get("external_id")
+            for item in comments
+            if isinstance(item, dict)
+        }
+        if (
+            not isinstance(imported, list)
+            or any(not isinstance(item, str) or not item for item in imported)
+            or len(imported) != len(set(imported))
+            or not requested.issubset(set(imported))
+        ):
+            raise RuntimeError("gc beads comment receipt readback is incomplete")
+        return list(imported)
+
+
+def execute_runtime_from_environment(*, dry_run: bool = False) -> dict[str, object]:
+    rig = os.environ.get("GC_RIG", "").strip()
+    platform_bin = os.environ.get("GC_AGENT_PLATFORM_BIN", "").strip()
+    platform_root = os.environ.get("GC_AGENT_PLATFORM_ROOT", "").strip()
+    if (
+        not rig
+        or "/" in rig
+        or not os.path.isabs(platform_bin)
+        or not os.path.isabs(platform_root)
+    ):
+        raise RuntimeError("work-sync canonical runtime inputs are unavailable")
+    contract = ContractRunner().read(
+        repository=rig,
+        agent_platform_bin=platform_bin,
+        platform_root=platform_root,
+    )
+    environment = runtime_environment(os.environ, contract)
+
+    import github_intake_common as common
+
+    with installation_token_context(
+        repository_full_name=environment["repository_full_name"],
+        token_env=_WORK_SYNC_TOKEN_ENV,
+        common=common,
+    ):
+        transport = GitHubHTTPTransport(
+            token_env=_WORK_SYNC_TOKEN_ENV,
+            api_url=os.environ.get("GC_GITHUB_API_BASE", "https://api.github.com"),
+        )
+        event, actor_node_id = runtime_event(environment, contract, transport)
+        max_pages = contract.get("max_pages_per_run")
+        if (
+            not isinstance(max_pages, int)
+            or isinstance(max_pages, bool)
+            or max_pages <= 0
+            or max_pages > 100
+        ):
+            raise RuntimeError("work-sync pagination contract is invalid")
+        projects = GitHubProjectSchemaReader(
+            organization=str(contract["organization"]),
+            transport=transport,
+            max_pages=max_pages,
+        ).read_contract(contract)
+        receipt_store = WorkSyncReceiptStore(
+            repository=environment["repository"],
+            store_ref="rig:" + environment["rig"],
+            # Cross-City dispatch inherits the ingress service environment.
+            # Reconciliation and webhook execution must share the target
+            # City's existing GitHub Pack state, not the ingress City's root.
+            data_root=os.path.join(environment["city"], ".gc", "services", "github", "data"),
+        )
+        beads_reader = BeadsSnapshotReader(
+            city=environment["city"],
+            rig=environment["rig"],
+            repository=environment["repository"],
+            load_receipt=receipt_store.load,
+        )
+        github_reader = GitHubSnapshotReader(
+            organization=str(contract["organization"]),
+            repository=environment["repository"],
+            transport=transport,
+            projection_actor_node_id=actor_node_id,
+            max_pages=max_pages,
+        )
+        github_writer = GitHubProjectionWriter(
+            organization=str(contract["organization"]),
+            repository=environment["repository"],
+            transport=transport,
+            snapshot_reader=github_reader,
+            projects=projects,
+            managed_blocks=contract["managed_blocks"],
+            event=event,
+        )
+        return WorkSyncReconciler(
+            contract=contract,
+            projects=projects,
+            event=event,
+            beads_reader=beads_reader,
+            github_reader=github_reader,
+            planner=PlannerRunner(),
+            beads_cas=BeadsCAS(
+                city=environment["city"],
+                rig=environment["rig"],
+            ),
+            github_writer=github_writer,
+            receipt_store=receipt_store,
+            agent_platform_bin=environment["agent_platform_bin"],
+            platform_root=environment["platform_root"],
+        ).run(dry_run=dry_run or contract["live_mutations"] is not True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="github-work-sync")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args(argv)
+    dry_run = args.dry_run or os.environ.get("GC_GITHUB_WORK_SYNC_DRY_RUN") == "1"
+    try:
+        result = execute_runtime_from_environment(dry_run=dry_run)
+    except (OSError, RuntimeError, TypeError, ValueError):
+        result = {
+            "status": "unknown",
+            "reason": "runtime_failed",
+            "terminal_readback": False,
+        }
+    print(json.dumps(result, ensure_ascii=True, sort_keys=True))
+    if result.get("status") in {"green", "dry_run"}:
+        return 0
+    if result.get("status") == "red":
+        return 2
+    return 3
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/github/scripts/github_work_sync.py
+++ b/github/scripts/github_work_sync.py
@@ -1060,7 +1060,7 @@ class GitHubSnapshotReader:
         self,
         *,
         projects: dict[str, object],
-        managed_blocks: list[dict[str, object]],
+        managed_block: dict[str, object],
         owning_project: str,
         cross_city_project: str,
         cross_city_bead_types: list[str],
@@ -1071,8 +1071,7 @@ class GitHubSnapshotReader:
         if (
             not isinstance(projects, dict)
             or set(projects) != expected_titles
-            or not isinstance(managed_blocks, list)
-            or not managed_blocks
+            or not isinstance(managed_block, dict)
             or not isinstance(cross_city_bead_types, list)
             or not cross_city_bead_types
             or len(cross_city_bead_types) != len(set(cross_city_bead_types))
@@ -1105,18 +1104,13 @@ class GitHubSnapshotReader:
                 or number in numbers
             ):
                 raise RuntimeError("GitHub Issue inventory identity is ambiguous")
-            has_marker = any(
-                str(block.get(marker, "")) in body
-                for block in managed_blocks
-                for marker in ("start_marker", "end_marker")
-                if isinstance(block, dict) and block.get(marker)
-            )
+            has_marker = "<!-- opsime-space:managed:" in body
             if not has_marker:
                 continue
             managed, _projection_hash = _parse_managed_projection(
                 body,
                 None,
-                managed_blocks,
+                managed_block,
             )
             managed_by_node[node_id] = (candidate, managed)
             numbers.add(number)
@@ -1593,7 +1587,7 @@ class GitHubProjectSchemaReader:
             "route",
             "projects",
             "project_schema",
-            "managed_blocks",
+            "managed_block",
             "projection_writer",
             "token_permissions",
             "live_mutations",
@@ -1791,7 +1785,7 @@ class GitHubProjectionWriter:
         transport: object,
         snapshot_reader: object,
         projects: dict[str, object],
-        managed_blocks: list[dict[str, object]],
+        managed_block: dict[str, object],
         event: dict[str, object],
     ) -> None:
         if (
@@ -1812,7 +1806,7 @@ class GitHubProjectionWriter:
         self.snapshot_reader = snapshot_reader
         self.event = dict(event)
         self.projects = self._validate_projects(projects)
-        self.managed_blocks = self._validate_managed_blocks(managed_blocks)
+        self.managed_block = self._validate_managed_block(managed_block)
         self._pending: dict[str, dict[str, object]] = {}
         self._imported_comment_ids: dict[str, list[str]] = {}
         self._verified: dict[str, dict[str, object]] = {}
@@ -1886,51 +1880,36 @@ class GitHubProjectionWriter:
         return normalized
 
     @staticmethod
-    def _validate_managed_blocks(
-        managed_blocks: object,
-    ) -> list[dict[str, object]]:
-        if not isinstance(managed_blocks, list) or not managed_blocks:
-            raise ValueError("managed block contracts are required")
-        normalized: list[dict[str, object]] = []
-        versions: set[int] = set()
-        markers: set[str] = set()
-        for raw in managed_blocks:
-            if (
-                not isinstance(raw, dict)
-                or set(raw) != {
-                    "schema_version",
-                    "start_marker",
-                    "end_marker",
-                    "fields",
-                }
-                or not isinstance(raw.get("schema_version"), int)
-                or isinstance(raw["schema_version"], bool)
-                or raw["schema_version"] <= 0
-                or raw["schema_version"] in versions
-                or not isinstance(raw.get("start_marker"), str)
-                or not raw["start_marker"]
-                or not isinstance(raw.get("end_marker"), str)
-                or not raw["end_marker"]
-                or raw["start_marker"] == raw["end_marker"]
-                or raw["start_marker"] in markers
-                or raw["end_marker"] in markers
-                or not isinstance(raw.get("fields"), list)
-                or len(raw["fields"]) != len(set(raw["fields"]))
-                or set(raw["fields"])
-                < {"bead_id", "projection_hash"}
-            ):
-                raise ValueError("managed block contract is malformed")
-            normalized.append(
-                {
-                    "schema_version": raw["schema_version"],
-                    "start_marker": raw["start_marker"],
-                    "end_marker": raw["end_marker"],
-                    "fields": list(raw["fields"]),
-                }
-            )
-            versions.add(raw["schema_version"])
-            markers.update({raw["start_marker"], raw["end_marker"]})
-        return normalized
+    def _validate_managed_block(
+        raw: object,
+    ) -> dict[str, object]:
+        if (
+            not isinstance(raw, dict)
+            or set(raw) != {
+                "schema_version",
+                "start_marker",
+                "end_marker",
+                "fields",
+            }
+            or not isinstance(raw.get("schema_version"), int)
+            or isinstance(raw["schema_version"], bool)
+            or raw["schema_version"] <= 0
+            or not isinstance(raw.get("start_marker"), str)
+            or not raw["start_marker"]
+            or not isinstance(raw.get("end_marker"), str)
+            or not raw["end_marker"]
+            or raw["start_marker"] == raw["end_marker"]
+            or not isinstance(raw.get("fields"), list)
+            or len(raw["fields"]) != len(set(raw["fields"]))
+            or set(raw["fields"]) < {"bead_id", "projection_hash"}
+        ):
+            raise ValueError("managed block contract is malformed")
+        return {
+            "schema_version": raw["schema_version"],
+            "start_marker": raw["start_marker"],
+            "end_marker": raw["end_marker"],
+            "fields": list(raw["fields"]),
+        }
 
     def _base_path(self) -> str:
         return "/repos/{0}/{1}".format(
@@ -2154,20 +2133,9 @@ class GitHubProjectionWriter:
             self._expected_readback[bead_id] = self._next_state(verified, item)
         issue_path = self._base_path() + "/issues/" + str(effective["issue_number"])
         project = self._project_by_id(effective["project_node_id"])
-        if kind in {"replace-managed-block", "migrate-managed-block"} and field == "projection":
+        if kind == "replace-managed-block" and field == "projection":
             if not isinstance(value, dict) or not isinstance(value.get("body"), str):
                 raise ValueError("GitHub body operation is malformed")
-            if kind == "migrate-managed-block":
-                snapshot = self._snapshot(identity)
-                issue = snapshot.get("issue")
-                if not isinstance(issue, dict):
-                    raise ValueError("GitHub migration precondition is incomplete")
-                _managed, current_hash = self._managed_projection(
-                    issue.get("body"),
-                    str(identity["bead_id"]),
-                )
-                if current_hash != value.get("expected_legacy_projection_hash"):
-                    raise ValueError("GitHub migration precondition changed")
             self.transport.rest("PATCH", issue_path, {"body": value["body"]})
             return
         if kind == "update-project-field" and field in _PROJECT_FIELDS:
@@ -2258,7 +2226,7 @@ class GitHubProjectionWriter:
                 and project.get("archived") is False
                 and actual_hash == desired.get("projection_hash")
             )
-        if kind in {"replace-managed-block", "migrate-managed-block"}:
+        if kind == "replace-managed-block":
             if not isinstance(value, dict) or issue.get("body") != value.get("body"):
                 return False
             try:
@@ -2319,9 +2287,9 @@ class GitHubProjectionWriter:
         expected = copy.deepcopy(state)
         kind, field, value = item.get("kind"), item.get("field"), item.get("value")
         issue_write = kind in {
-            "replace-managed-block", "migrate-managed-block", "update-issue-type", "update-issue-state",
+            "replace-managed-block", "update-issue-type", "update-issue-state",
         }
-        if kind in {"replace-managed-block", "migrate-managed-block"} and isinstance(value, dict):
+        if kind == "replace-managed-block" and isinstance(value, dict):
             expected["issue"]["body"] = value.get("body")
         elif kind == "update-issue-state":
             expected["issue"]["state"] = value
@@ -2356,7 +2324,7 @@ class GitHubProjectionWriter:
         body: object,
         bead_id: str | None,
     ) -> tuple[dict[str, object], str]:
-        return _parse_managed_projection(body, bead_id, self.managed_blocks)
+        return _parse_managed_projection(body, bead_id, self.managed_block)
 
     def _snapshot_fingerprint(
         self,
@@ -2427,11 +2395,7 @@ class GitHubProjectionWriter:
                     body = candidate.get("body")
                     if not isinstance(body, str):
                         return None
-                    if not any(
-                        str(contract["start_marker"]) in body
-                        or str(contract["end_marker"]) in body
-                        for contract in self.managed_blocks
-                    ):
+                    if "<!-- opsime-space:managed:" not in body:
                         continue
                     managed, _projection_hash = self._managed_projection(
                         body,
@@ -2624,7 +2588,7 @@ class WorkSyncReconciler:
             or not route["repository"]
             or not isinstance(route.get("owning_project"), str)
             or not route["owning_project"]
-            or not isinstance(contract.get("managed_blocks"), list)
+            or not isinstance(contract.get("managed_block"), dict)
             or not isinstance(contract.get("cross_city_project"), str)
             or not contract["cross_city_project"]
             or not isinstance(contract.get("cross_city_bead_types"), list)
@@ -2661,7 +2625,7 @@ class WorkSyncReconciler:
         beads = self.beads_reader.read()
         issues = self.github_reader.reconciliation_records(
             projects=self.projects,
-            managed_blocks=self.contract["managed_blocks"],
+            managed_block=self.contract["managed_block"],
             owning_project=self.contract["route"]["owning_project"],
             cross_city_project=self.contract["cross_city_project"],
             cross_city_bead_types=self.contract["cross_city_bead_types"],
@@ -2701,7 +2665,7 @@ class WorkSyncReconciler:
             managed, projection_hash = _parse_managed_projection(
                 body,
                 None,
-                self.contract["managed_blocks"],
+                self.contract["managed_block"],
             )
             bead_id = str(managed["bead_id"])
             bead_record = bead_by_id.get(bead_id)
@@ -2984,63 +2948,56 @@ def _sha256(value: object) -> bool:
 def _parse_managed_projection(
     body: object,
     bead_id: str | None,
-    managed_blocks: list[dict[str, object]],
+    managed_block: dict[str, object],
 ) -> tuple[dict[str, object], str]:
     if not isinstance(body, str):
         raise ValueError("GitHub Issue managed body is not text")
-    matches: list[dict[str, object]] = []
-    for contract in managed_blocks:
-        if not isinstance(contract, dict):
-            raise ValueError("GitHub Issue managed block contract is malformed")
-        start = str(contract.get("start_marker", ""))
-        end = str(contract.get("end_marker", ""))
-        fields = contract.get("fields")
-        if (
-            not start
-            or not end
-            or start == end
-            or not isinstance(fields, list)
-            or len(fields) != len(set(fields))
-        ):
-            raise ValueError("GitHub Issue managed block contract is malformed")
-        start_count = body.count(start)
-        end_count = body.count(end)
-        if start_count == 0 and end_count == 0:
-            continue
-        if start_count != 1 or end_count != 1:
-            raise ValueError("GitHub Issue managed block markers are ambiguous")
-        start_index = body.index(start) + len(start)
-        end_index = body.index(end, start_index)
-        try:
-            managed = json.loads(body[start_index:end_index].strip())
-        except (TypeError, ValueError) as exc:
-            raise ValueError("GitHub Issue managed block JSON is malformed") from exc
-        if (
-            not isinstance(managed, dict)
-            or set(managed) != set(fields)
-            or (bead_id is not None and managed.get("bead_id") != bead_id)
-            or not isinstance(managed.get("bead_id"), str)
-            or not managed["bead_id"]
-            or not _sha256(managed.get("projection_hash"))
-        ):
-            raise ValueError("GitHub Issue managed block identity is invalid")
-        payload = {
-            field: managed[field]
-            for field in managed
-            if field not in {"bead_id", "projection_hash"}
-        }
-        encoded = json.dumps(
-            payload,
-            ensure_ascii=False,
-            sort_keys=True,
-            separators=(",", ":"),
-        ).encode("utf-8")
-        if hashlib.sha256(encoded).hexdigest() != managed["projection_hash"]:
-            raise ValueError("GitHub Issue managed projection hash mismatches")
-        matches.append(managed)
-    if len(matches) != 1:
+    if not isinstance(managed_block, dict):
+        raise ValueError("GitHub Issue managed block contract is malformed")
+    start = str(managed_block.get("start_marker", ""))
+    end = str(managed_block.get("end_marker", ""))
+    fields = managed_block.get("fields")
+    if (
+        not start
+        or not end
+        or start == end
+        or not isinstance(fields, list)
+        or len(fields) != len(set(fields))
+    ):
+        raise ValueError("GitHub Issue managed block contract is malformed")
+    if "<!-- opsime-space:managed:" in body and start not in body and end not in body:
+        raise ValueError("GitHub Issue non-current managed block is forbidden")
+    if body.count(start) != 1 or body.count(end) != 1:
         raise ValueError("GitHub Issue requires exactly one managed block")
-    return matches[0], str(matches[0]["projection_hash"])
+    start_index = body.index(start) + len(start)
+    end_index = body.index(end, start_index)
+    try:
+        managed = json.loads(body[start_index:end_index].strip())
+    except (TypeError, ValueError) as exc:
+        raise ValueError("GitHub Issue managed block JSON is malformed") from exc
+    if (
+        not isinstance(managed, dict)
+        or set(managed) != set(fields)
+        or (bead_id is not None and managed.get("bead_id") != bead_id)
+        or not isinstance(managed.get("bead_id"), str)
+        or not managed["bead_id"]
+        or not _sha256(managed.get("projection_hash"))
+    ):
+        raise ValueError("GitHub Issue managed block identity is invalid")
+    payload = {
+        field: managed[field]
+        for field in managed
+        if field not in {"bead_id", "projection_hash"}
+    }
+    encoded = json.dumps(
+        payload,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    if hashlib.sha256(encoded).hexdigest() != managed["projection_hash"]:
+        raise ValueError("GitHub Issue managed projection hash mismatches")
+    return managed, str(managed["projection_hash"])
 
 
 def _normalized_binding(
@@ -3175,14 +3132,6 @@ def _valid_push_operation(item: dict[str, object]) -> bool:
             and set(value) == {"body", "projection_hash"}
             and isinstance(value.get("body"), str)
             and _sha256(value.get("projection_hash"))
-        )
-    if kind == "migrate-managed-block" and field == "projection":
-        return (
-            isinstance(value, dict)
-            and isinstance(value.get("body"), str)
-            and _sha256(value.get("projection_hash"))
-            and _sha256(value.get("expected_legacy_projection_hash"))
-            and value.get("readback_after_write") is True
         )
     if kind == "update-project-field":
         return field in {"status", "priority", "bead_type", "lifecycle_phase"} and isinstance(value, str) and bool(value)
@@ -3739,7 +3688,7 @@ def execute_runtime_from_environment(*, dry_run: bool = False) -> dict[str, obje
             transport=transport,
             snapshot_reader=github_reader,
             projects=projects,
-            managed_blocks=contract["managed_blocks"],
+            managed_block=contract["managed_block"],
             event=event,
         )
         return WorkSyncReconciler(

--- a/github/scripts/github_work_sync.py
+++ b/github/scripts/github_work_sync.py
@@ -85,10 +85,10 @@ def installation_token_context(
     repository_full_name: str,
     token_env: str,
     common: object,
+    permissions: dict[str, str] | None = None,
 ) -> object:
-    if os.environ.get(token_env):
-        yield
-        return
+    # An ambient token is not evidence of its repository/permission scope.
+    previous_token = os.environ.get(token_env)
     rules = common.load_rules()
     repos = rules.get("repos") if isinstance(rules, dict) else None
     matches = [
@@ -103,14 +103,22 @@ def installation_token_context(
     if not installation_id.isdigit() or int(installation_id) <= 0:
         raise RuntimeError("work-sync installation identity is unavailable")
     app_config = common.github_app_config_for_identity()
-    token = common.create_installation_token(app_config, installation_id)
+    token = common.create_installation_token(
+        app_config,
+        installation_id,
+        repository_full_name=repository_full_name,
+        permissions=permissions,
+    )
     if not isinstance(token, str) or not token:
         raise RuntimeError("work-sync installation token could not be minted")
     os.environ[token_env] = token
     try:
         yield
     finally:
-        os.environ.pop(token_env, None)
+        if previous_token is None:
+            os.environ.pop(token_env, None)
+        else:
+            os.environ[token_env] = previous_token
 
 
 _VIEWER_QUERY = """
@@ -182,19 +190,19 @@ class GitHubHTTPTransport:
         token_env: str,
         api_url: str = "https://api.github.com",
         timeout: float = 30.0,
-        urlopen: Callable[..., object] = urllib.request.urlopen,
+        urlopen: Callable[..., object] | None = None,
     ) -> None:
+        import github_intake_common as common
+
         if not token_env or not isinstance(token_env, str):
             raise ValueError("GitHub installation token environment is required")
-        parsed = urllib.parse.urlparse(api_url)
-        if parsed.scheme != "https" or not parsed.netloc or parsed.path not in {"", "/"}:
-            raise ValueError("GitHub API URL must be an HTTPS origin")
+        api_url = common.github_https_origin(api_url)
         if timeout <= 0:
             raise ValueError("GitHub transport timeout must be positive")
         self.token_env = token_env
         self.api_url = api_url.rstrip("/")
         self.timeout = timeout
-        self.urlopen = urlopen
+        self.urlopen = urlopen if urlopen is not None else common.github_no_redirect_urlopen
 
     @staticmethod
     def _is_write(method: str) -> bool:
@@ -1587,6 +1595,7 @@ class GitHubProjectSchemaReader:
             "project_schema",
             "managed_blocks",
             "projection_writer",
+            "token_permissions",
             "live_mutations",
             "cross_city_project",
             "cross_city_bead_types",
@@ -3683,6 +3692,7 @@ def execute_runtime_from_environment(*, dry_run: bool = False) -> dict[str, obje
         repository_full_name=environment["repository_full_name"],
         token_env=_WORK_SYNC_TOKEN_ENV,
         common=common,
+        permissions=contract.get("token_permissions"),
     ):
         transport = GitHubHTTPTransport(
             token_env=_WORK_SYNC_TOKEN_ENV,

--- a/github/scripts/github_work_sync.py
+++ b/github/scripts/github_work_sync.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
-"""Fail-closed runtime adapter for Agent Platform GitHub work-sync plans.
+"""Fail-closed runtime adapter for external GitHub work-sync policy plans.
 
-The Agent Platform binary owns pure planning. This module owns only the Gas City
+The configured policy provider owns pure planning. This module owns only the Gas City
 runtime boundary: private snapshot/plan files, exact-store Beads CAS calls, and
 GitHub writes with bounded retry plus mandatory readback.
 """
@@ -44,8 +44,8 @@ def runtime_environment(
         environ.get("GC_CITY_PATH", "").strip()
         or environ.get("GC_CITY_ROOT", "").strip()
     )
-    platform_bin = environ.get("GC_AGENT_PLATFORM_BIN", "").strip()
-    platform_root = environ.get("GC_AGENT_PLATFORM_ROOT", "").strip()
+    policy_bin = environ.get("GC_WORK_SYNC_POLICY_BIN", "").strip()
+    policy_root = environ.get("GC_WORK_SYNC_POLICY_ROOT", "").strip()
     full_name = environ.get("GC_GITHUB_REPO", "").strip().lower()
     dispatch_city = environ.get("GC_GITHUB_DISPATCH_CITY", "").strip()
     dispatch_rig = environ.get("GC_GITHUB_DISPATCH_RIG", "").strip()
@@ -57,8 +57,8 @@ def runtime_environment(
         or rig != route.get("rig")
         or not city
         or not os.path.isabs(city)
-        or not os.path.isabs(platform_bin)
-        or not os.path.isabs(platform_root)
+        or not os.path.isabs(policy_bin)
+        or not os.path.isabs(policy_root)
         or (full_name and full_name != expected_full_name)
         or (dispatch_city and dispatch_city != route.get("city"))
         or (dispatch_rig and dispatch_rig != route.get("rig"))
@@ -72,8 +72,8 @@ def runtime_environment(
         "repository_full_name": expected_full_name,
         "rig": rig,
         "city": city,
-        "agent_platform_bin": platform_bin,
-        "platform_root": platform_root,
+        "policy_bin": policy_bin,
+        "policy_root": policy_root,
         "delivery_id": delivery_id,
         "payload_file": environ.get("GC_GITHUB_EVENT_PAYLOAD_FILE", "").strip(),
     }
@@ -802,7 +802,7 @@ class BeadsSnapshotReader:
 
 
 class ContractRunner:
-    """Read one canonical repository contract through the Agent Platform CLI."""
+    """Read one canonical repository contract through the work-sync policy provider."""
 
     def __init__(
         self,
@@ -814,22 +814,22 @@ class ContractRunner:
         self,
         *,
         repository: str,
-        agent_platform_bin: str,
-        platform_root: str,
+        policy_bin: str,
+        policy_root: str,
     ) -> dict[str, object]:
         if (
             not isinstance(repository, str)
             or not repository
             or "/" in repository
-            or not os.path.isabs(agent_platform_bin)
-            or not os.path.isabs(platform_root)
+            or not os.path.isabs(policy_bin)
+            or not os.path.isabs(policy_root)
         ):
-            raise ValueError("exact repository, planner binary, and platform root are required")
+            raise ValueError("exact repository, planner binary, and policy root are required")
         with tempfile.TemporaryDirectory(prefix="github-work-sync-contract-") as tempdir:
             os.chmod(tempdir, 0o700)
             output_path = os.path.join(tempdir, "runtime-contract.json")
             command = [
-                agent_platform_bin,
+                policy_bin,
                 "--json",
                 "work-sync",
                 "runtime-contract",
@@ -838,7 +838,7 @@ class ContractRunner:
                 "--output",
                 output_path,
                 "--platform-root",
-                platform_root,
+                policy_root,
             ]
             result = self.run(
                 command,
@@ -2554,12 +2554,12 @@ class PlannerRunner:
         self,
         snapshots: dict[str, object],
         *,
-        agent_platform_bin: str,
-        platform_root: str,
+        policy_bin: str,
+        policy_root: str,
     ) -> dict[str, object]:
         if set(snapshots) != {"beads", "issues"}:
             raise ValueError("snapshots must contain exactly beads and issues")
-        if not os.path.isabs(agent_platform_bin) or not os.path.isabs(platform_root):
+        if not os.path.isabs(policy_bin) or not os.path.isabs(policy_root):
             raise ValueError("planner binary and platform root must be absolute")
         with tempfile.TemporaryDirectory(prefix="github-work-sync-") as tempdir:
             os.chmod(tempdir, 0o700)
@@ -2567,7 +2567,7 @@ class PlannerRunner:
             output_path = os.path.join(tempdir, "execution-plan.json")
             _private_json(input_path, snapshots)
             command = [
-                agent_platform_bin,
+                policy_bin,
                 "--json",
                 "work-sync",
                 "plan",
@@ -2576,7 +2576,7 @@ class PlannerRunner:
                 "--output",
                 output_path,
                 "--platform-root",
-                platform_root,
+                policy_root,
             ]
             result = self.run(
                 command,
@@ -2613,8 +2613,8 @@ class WorkSyncReconciler:
         beads_cas: object,
         github_writer: object,
         receipt_store: object,
-        agent_platform_bin: str,
-        platform_root: str,
+        policy_bin: str,
+        policy_root: str,
         apply_plan: Callable[..., dict[str, object]] | None = None,
     ) -> None:
         route = contract.get("route") if isinstance(contract, dict) else None
@@ -2640,8 +2640,8 @@ class WorkSyncReconciler:
             or not event["delivery_id"]
             or event.get("origin")
             not in {"github-human", contract.get("projection_writer")}
-            or not os.path.isabs(agent_platform_bin)
-            or not os.path.isabs(platform_root)
+            or not os.path.isabs(policy_bin)
+            or not os.path.isabs(policy_root)
         ):
             raise ValueError("work-sync reconciler contract is malformed")
         self.contract = contract
@@ -2653,8 +2653,8 @@ class WorkSyncReconciler:
         self.beads_cas = beads_cas
         self.github_writer = github_writer
         self.receipt_store = receipt_store
-        self.agent_platform_bin = agent_platform_bin
-        self.platform_root = platform_root
+        self.policy_bin = policy_bin
+        self.policy_root = policy_root
         self.apply_plan = apply_plan or apply_execution_plan
 
     def _plan(self) -> dict[str, object]:
@@ -2672,8 +2672,8 @@ class WorkSyncReconciler:
         self._prepare_issues(beads, issues)
         plan = self.planner.plan(
             {"beads": beads, "issues": issues},
-            agent_platform_bin=self.agent_platform_bin,
-            platform_root=self.platform_root,
+            policy_bin=self.policy_bin,
+            policy_root=self.policy_root,
         )
         if not isinstance(plan, dict):
             raise RuntimeError("work-sync planner returned malformed data")
@@ -3670,19 +3670,19 @@ class BeadsCAS:
 
 def execute_runtime_from_environment(*, dry_run: bool = False) -> dict[str, object]:
     rig = os.environ.get("GC_RIG", "").strip()
-    platform_bin = os.environ.get("GC_AGENT_PLATFORM_BIN", "").strip()
-    platform_root = os.environ.get("GC_AGENT_PLATFORM_ROOT", "").strip()
+    policy_bin = os.environ.get("GC_WORK_SYNC_POLICY_BIN", "").strip()
+    policy_root = os.environ.get("GC_WORK_SYNC_POLICY_ROOT", "").strip()
     if (
         not rig
         or "/" in rig
-        or not os.path.isabs(platform_bin)
-        or not os.path.isabs(platform_root)
+        or not os.path.isabs(policy_bin)
+        or not os.path.isabs(policy_root)
     ):
         raise RuntimeError("work-sync canonical runtime inputs are unavailable")
     contract = ContractRunner().read(
         repository=rig,
-        agent_platform_bin=platform_bin,
-        platform_root=platform_root,
+        policy_bin=policy_bin,
+        policy_root=policy_root,
     )
     environment = runtime_environment(os.environ, contract)
 
@@ -3755,8 +3755,8 @@ def execute_runtime_from_environment(*, dry_run: bool = False) -> dict[str, obje
             ),
             github_writer=github_writer,
             receipt_store=receipt_store,
-            agent_platform_bin=environment["agent_platform_bin"],
-            platform_root=environment["platform_root"],
+            policy_bin=environment["policy_bin"],
+            policy_root=environment["policy_root"],
         ).run(dry_run=dry_run or contract["live_mutations"] is not True)
 
 

--- a/github/tests/test_github_delivery_commands.py
+++ b/github/tests/test_github_delivery_commands.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import io
+import pathlib
+import sys
+import unittest
+from unittest import mock
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+
+import github_intake_create_pr as create_pr
+import github_intake_push_branch as push_branch
+
+
+class GitHubDeliveryCommandTests(unittest.TestCase):
+    def test_push_branch_resolves_separate_delivery_identity(self) -> None:
+        app = {"app_id": "delivery-app", "private_key_pem": "pem", "installation_id": "77"}
+        argv = [
+            "github_intake_push_branch.py",
+            "owner/repo",
+            "--github-app-identity",
+            "delivery",
+            "--branch",
+            "fix-42",
+        ]
+
+        with mock.patch.object(sys, "argv", argv), mock.patch.object(
+            push_branch.common,
+            "github_app_config_for_identity",
+            return_value=app,
+        ) as resolve_app, mock.patch.object(
+            push_branch.common,
+            "git_push_branch",
+            return_value={"status": "pushed"},
+        ) as git_push_branch, mock.patch("sys.stdout", new_callable=io.StringIO):
+            self.assertEqual(push_branch.main(), 0)
+
+        resolve_app.assert_called_once_with("delivery")
+        git_push_branch.assert_called_once_with(app, "77", "owner/repo", "fix-42", ref="HEAD")
+
+    def test_create_pr_resolves_separate_delivery_identity(self) -> None:
+        app = {"app_id": "delivery-app", "private_key_pem": "pem", "installation_id": "88"}
+        argv = [
+            "github_intake_create_pr.py",
+            "owner/repo",
+            "--github-app-identity",
+            "delivery",
+            "--base",
+            "main",
+            "--head",
+            "fix-42",
+            "--title",
+            "fix: widget",
+        ]
+
+        with mock.patch.object(sys, "argv", argv), mock.patch.object(
+            create_pr.common,
+            "github_app_config_for_identity",
+            return_value=app,
+        ) as resolve_app, mock.patch.object(
+            create_pr.common,
+            "create_pull_request",
+            return_value={"number": 42},
+        ) as create_pull_request, mock.patch("sys.stdout", new_callable=io.StringIO):
+            self.assertEqual(create_pr.main(), 0)
+
+        resolve_app.assert_called_once_with("delivery")
+        create_pull_request.assert_called_once_with(
+            app,
+            "88",
+            "owner",
+            "repo",
+            "fix: widget",
+            "fix-42",
+            "main",
+            "",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/github/tests/test_github_intake_common.py
+++ b/github/tests/test_github_intake_common.py
@@ -62,8 +62,17 @@ class GitHubIntakeCommonTests(unittest.TestCase):
         self.assertIn("issue_comment", manifest["default_events"])
         self.assertIn("issues", manifest["default_events"])
         self.assertIn("pull_request", manifest["default_events"])
-        self.assertEqual(manifest["default_permissions"]["contents"], "write")
-        self.assertEqual(manifest["default_permissions"]["pull_requests"], "write")
+        self.assertEqual(
+            manifest["default_permissions"],
+            {
+                "issues": "write",
+                "metadata": "read",
+                "pull_requests": "read",
+                "organization_projects": "write",
+                "issue_types": "read",
+                "issue_fields": "read",
+            },
+        )
 
     def test_effective_config_merges_github_app_env_secrets(self) -> None:
         os.environ["GITHUB_APP_ID"] = "123"
@@ -176,6 +185,7 @@ version = 1
 
 [[repo]]
 full_name = "Owner/Repo"
+city = "product-city"
 rig = "product"
 authorized_users = ["Alice"]
 
@@ -191,10 +201,27 @@ formula = "github-addressed-message"
 
         repo = rules["repos"][0]
         self.assertEqual(repo["full_name"], "owner/repo")
+        self.assertEqual(repo["city"], "product-city")
         self.assertEqual(repo["github_rig"], "github-owner-repo")
         self.assertEqual(repo["rig"], "product")
         self.assertEqual(repo["addresses"][0]["target"], "product/mayor")
         self.assertEqual(common.github_repo_dispatch_rig("Owner/Repo", rules), "product")
+        self.assertEqual(
+            common.github_repo_dispatch_route("Owner/Repo", rules),
+            {"city": "product-city", "rig": "product"},
+        )
+
+    def test_github_repo_dispatch_route_requires_exact_city_and_rig_mapping(self) -> None:
+        rules = {
+            "repos": [
+                {"full_name": "owner/missing-city", "city": "", "rig": "product"},
+                {"full_name": "owner/missing-rig", "city": "product-city", "rig": ""},
+            ]
+        }
+
+        self.assertEqual(common.github_repo_dispatch_route("owner/unknown", rules), {})
+        self.assertEqual(common.github_repo_dispatch_route("owner/missing-city", rules), {})
+        self.assertEqual(common.github_repo_dispatch_route("owner/missing-rig", rules), {})
 
     def test_load_rules_rejects_path_like_github_app_identity(self) -> None:
         rules_dir = pathlib.Path(self.tempdir.name) / "config" / "github-intake"
@@ -268,6 +295,23 @@ formula = "github-addressed-message"
         )
 
         with self.assertRaisesRegex(ValueError, "rig must be a local rig name"):
+            common.load_rules()
+
+    def test_load_rules_rejects_city_route_without_explicit_rig(self) -> None:
+        rules_dir = pathlib.Path(self.tempdir.name) / "config" / "github-intake"
+        rules_dir.mkdir(parents=True)
+        (rules_dir / "rules.toml").write_text(
+            """
+version = 1
+
+[[repo]]
+full_name = "owner/repo"
+city = "product-city"
+""",
+            encoding="utf-8",
+        )
+
+        with self.assertRaisesRegex(ValueError, "city requires an explicit rig"):
             common.load_rules()
 
     def test_extract_addressed_comment_requests_repo_scoped_matches(self) -> None:

--- a/github/tests/test_github_intake_service.py
+++ b/github/tests/test_github_intake_service.py
@@ -174,6 +174,66 @@ class GitHubIntakeServiceTests(unittest.TestCase):
         self.assertEqual(env["GH_TOKEN"], "token-123")
         self.assertTrue(outcome["github_app_token_injected"])
 
+    def test_order_action_routes_exact_repository_to_owning_city_and_rig(self) -> None:
+        payload = {
+            "repository": {"full_name": "Owner/Repo"},
+            "issue": {"number": 42, "html_url": "https://github.com/owner/repo/issues/42"},
+        }
+        rules = {
+            "repos": [
+                {
+                    "full_name": "owner/repo",
+                    "city": "product-city",
+                    "rig": "product",
+                }
+            ]
+        }
+        action = {"type": "order", "name": "work-sync", "route_from_repo": True}
+        completed = mock.Mock(returncode=0, stdout="ok\n", stderr="")
+
+        with mock.patch.object(service, "run_subprocess", return_value=completed) as run_subprocess:
+            outcome = service.execute_rule_action(
+                {"id": "rule"},
+                action,
+                "issues",
+                "delivery-1",
+                payload,
+                "/tmp/payload.json",
+                {},
+                rules,
+            )
+
+        self.assertEqual(outcome["status"], "success")
+        command, cwd = run_subprocess.call_args.args[:2]
+        env = run_subprocess.call_args.kwargs["env"]
+        self.assertEqual(
+            command,
+            ["gc", "--city", "product-city", "order", "run", "work-sync", "--rig", "product"],
+        )
+        self.assertEqual(cwd, self.tempdir.name)
+        self.assertEqual(env["GC_GITHUB_DISPATCH_CITY"], "product-city")
+        self.assertEqual(env["GC_GITHUB_DISPATCH_RIG"], "product")
+
+    def test_order_action_repo_route_fails_closed_without_exact_mapping(self) -> None:
+        payload = {"repository": {"full_name": "owner/unknown"}}
+        action = {"type": "order", "name": "work-sync", "route_from_repo": True}
+
+        with mock.patch.object(service, "run_subprocess") as run_subprocess:
+            outcome = service.execute_rule_action(
+                {"id": "rule"},
+                action,
+                "issues",
+                "delivery-1",
+                payload,
+                "/tmp/payload.json",
+                {},
+                {"repos": []},
+            )
+
+        self.assertEqual(outcome["status"], "failed")
+        self.assertEqual(outcome["reason"], "repository_route_not_configured")
+        run_subprocess.assert_not_called()
+
     def test_process_event_rules_executes_matching_order_rule_and_persists_result(self) -> None:
         rules_dir = pathlib.Path(self.tempdir.name) / "config" / "github-intake"
         rules_dir.mkdir(parents=True)

--- a/github/tests/test_github_work_sync_auth.py
+++ b/github/tests/test_github_work_sync_auth.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import copy
+import contextlib
+import email.message
+import io
+import json
+import os
+import pathlib
+import sys
+import time
+import unittest
+import urllib.request
+import urllib.response
+from unittest import mock
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+import github_intake_common as common
+import github_work_sync as work_sync
+
+
+class WorkSyncTokenScopeTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.permissions = {"metadata": "read", "issues": "write", "organization_projects": "write"}
+        self.response = {
+            "token": "synthetic-installation-token",
+            "expires_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(time.time() + 3500)),
+            "permissions": dict(self.permissions),
+            "repository_selection": "selected",
+        }
+        self.repositories = {"total_count": 1, "repositories": [{"full_name": "owner/product"}]}
+        self.calls = []
+
+    def request(self, method, path, **kwargs):
+        self.calls.append((method, path, kwargs))
+        if method == "POST":
+            return copy.deepcopy(self.response)
+        self.assertEqual((method, path), ("GET", "/installation/repositories?per_page=100"))
+        return copy.deepcopy(self.repositories)
+
+    def context(self):
+        return work_sync.installation_token_context(
+            repository_full_name="owner/product",
+            token_env="WORK_SYNC_SCOPE_TEST_TOKEN",
+            common=common,
+            permissions=self.permissions,
+        )
+
+    def patches(self, *, mock_http=True):
+        stack = contextlib.ExitStack()
+        stack.enter_context(mock.patch.dict(os.environ, {}, clear=True))
+        stack.enter_context(mock.patch.object(common, "load_rules", return_value={"repos": [
+            {"full_name": "owner/product", "installation_id": "123"},
+        ]}))
+        stack.enter_context(mock.patch.object(common, "github_app_config_for_identity", return_value={"app_id": "1"}))
+        stack.enter_context(mock.patch.object(common, "build_app_jwt", return_value="synthetic-jwt"))
+        if mock_http:
+            stack.enter_context(mock.patch.object(common, "github_api_request", side_effect=self.request))
+        return stack
+
+    def test_invalid_api_origin_fails_before_signing_or_network(self):
+        for origin in (
+            "http://api.example.invalid", "https:///missing-host",
+            "https://user:pass@api.example.invalid", "https://api.example.invalid/path",
+            "https://api.example.invalid?query=1", "https://api.example.invalid#fragment",
+            "https://api.example.invalid?", "https://api.example.invalid#",
+            "https://api.example.invalid:bad", "https://api.example.invalid:99999",
+            " https://api.example.invalid", "https://api.example.invalid\n",
+        ):
+            with self.subTest(origin=origin), self.patches(), mock.patch.object(common, "GITHUB_API_BASE", origin):
+                with self.assertRaisesRegex((RuntimeError, ValueError), "HTTPS origin"):
+                    with self.context():
+                        self.fail("invalid API origin was accepted")
+                common.build_app_jwt.assert_not_called()
+                common.github_api_request.assert_not_called()
+
+    @contextlib.contextmanager
+    def offline_http(self, *, redirect_at=0, destination="", status=302):
+        """Keep the real urllib opener/redirect chain, replacing only network I/O."""
+        requests = []
+
+        def respond(_handler, request):
+            requests.append(request)
+            headers = email.message.Message()
+            code = 200
+            if len(requests) == redirect_at:
+                headers["Location"] = destination
+                code = status
+            data = self.response if request.full_url.endswith("access_tokens") else self.repositories
+            response = urllib.response.addinfourl(
+                io.BytesIO(json.dumps(data).encode()), headers, request.full_url, code,
+            )
+            response.msg = "Found" if code != 200 else "OK"
+            return response
+
+        with mock.patch.object(urllib.request, "_opener", None), \
+             mock.patch.object(urllib.request.HTTPSHandler, "https_open", respond), \
+             mock.patch.object(urllib.request.HTTPHandler, "http_open", respond):
+            yield requests
+
+    def test_scoped_auth_never_follows_redirects_with_credentials(self):
+        for redirect_at in (1, 2):
+            for destination in (
+                "https://other.example.invalid/access_tokens",
+                "http://api.example.invalid/access_tokens",
+                "https://api.example.invalid/access_tokens",
+            ):
+                for status in (301, 302, 303, 307, 308):
+                    with self.subTest(step=redirect_at, destination=destination, status=status), \
+                         self.patches(mock_http=False), \
+                         mock.patch.object(common, "GITHUB_API_BASE", "https://api.example.invalid"), \
+                         self.offline_http(redirect_at=redirect_at, destination=destination, status=status) as requests:
+                        with self.assertRaises(RuntimeError):
+                            with self.context():
+                                self.fail("redirected token was accepted")
+                        self.assertEqual(len(requests), redirect_at, "credential-bearing redirect escaped")
+                        self.assertNotIn("WORK_SYNC_SCOPE_TEST_TOKEN", os.environ)
+
+    def test_scoped_auth_uses_real_https_helper_without_redirects(self):
+        with self.patches(mock_http=False), \
+             mock.patch.object(common, "GITHUB_API_BASE", "https://api.example.invalid:8443/"), \
+             self.offline_http() as requests:
+            with self.context():
+                self.assertEqual(len(requests), 2)
+                self.assertEqual(requests[0].full_url, "https://api.example.invalid:8443/app/installations/123/access_tokens")
+                self.assertEqual(requests[1].full_url, "https://api.example.invalid:8443/installation/repositories?per_page=100")
+
+    def test_work_sync_transport_rejects_invalid_origin(self):
+        for origin in (
+            "https://user:pass@api.example.invalid", "https://api.example.invalid?query=1",
+            "https://api.example.invalid#fragment", "https://api.example.invalid:bad",
+            "https://api.example.invalid?", "https://api.example.invalid#",
+        ):
+            with self.subTest(origin=origin), self.assertRaisesRegex(ValueError, "HTTPS origin"):
+                work_sync.GitHubHTTPTransport(token_env="WORK_SYNC_SCOPE_TEST_TOKEN", api_url=origin)
+
+    def test_work_sync_transport_never_redirects_scoped_token(self):
+        for method in ("GET", "POST", "PATCH"):
+            for destination in ("https://other.example.invalid/collect", "http://api.example.invalid/collect"):
+                with self.subTest(method=method, destination=destination), \
+                     self.patches(mock_http=False), \
+                     self.offline_http(redirect_at=1, destination=destination) as requests:
+                    os.environ["WORK_SYNC_SCOPE_TEST_TOKEN"] = "synthetic-installation-token"
+                    transport = work_sync.GitHubHTTPTransport(
+                        token_env="WORK_SYNC_SCOPE_TEST_TOKEN", api_url="https://api.example.invalid",
+                    )
+                    with self.assertRaises(RuntimeError):
+                        transport.rest(method, "/repos/owner/product")
+                    self.assertEqual(len(requests), 1, "credential-bearing redirect escaped")
+
+    def test_mint_has_exact_scope_and_effective_readback_before_token_use(self):
+        with self.patches():
+            with self.context():
+                self.assertEqual(len(self.calls), 2)
+                self.assertEqual(self.calls[0][2].get("payload"), {
+                    "repositories": ["product"], "permissions": self.permissions,
+                })
+                self.assertEqual(os.environ["WORK_SYNC_SCOPE_TEST_TOKEN"], "synthetic-installation-token")
+            self.assertNotIn("WORK_SYNC_SCOPE_TEST_TOKEN", os.environ)
+
+    def test_ambient_token_is_not_reused_as_scope_proof(self):
+        with self.patches():
+            os.environ["WORK_SYNC_SCOPE_TEST_TOKEN"] = "unproven-ambient-token"
+            with self.context():
+                self.assertEqual(len(self.calls), 2)
+                self.assertEqual(os.environ["WORK_SYNC_SCOPE_TEST_TOKEN"], "synthetic-installation-token")
+            self.assertEqual(os.environ["WORK_SYNC_SCOPE_TEST_TOKEN"], "unproven-ambient-token")
+
+    def test_malformed_or_broader_token_is_never_exposed(self):
+        cases = [
+            {"permissions": {**self.permissions, "contents": "write"}},
+            {"permissions": {"issues": "read"}},
+            {"permissions": None},
+            {"token": {"private": "not-a-token"}},
+            {"token": ""},
+            {"expires_at": "invalid"},
+            {"expires_at": "2000-01-01T00:00:00Z"},
+            {"expires_at": "2100-01-01T00:00:00Z"},
+        ]
+        original = copy.deepcopy(self.response)
+        for delta in cases:
+            with self.subTest(delta=delta), self.patches():
+                self.response = {**original, **delta}
+                with self.assertRaisesRegex(RuntimeError, "token"):
+                    with self.context():
+                        self.fail("unverified token was exposed")
+                self.assertNotIn("WORK_SYNC_SCOPE_TEST_TOKEN", os.environ)
+
+    def test_wrong_extra_or_incomplete_repository_readback_is_rejected(self):
+        for data in (
+            {"total_count": 1, "repositories": [{"full_name": "other/product"}]},
+            {"total_count": 2, "repositories": [{"full_name": "owner/product"}]},
+            {"total_count": 2, "repositories": [{"full_name": "owner/product"}, {"full_name": "owner/other"}]},
+            {"total_count": True, "repositories": [{"full_name": "owner/product"}]},
+            {},
+        ):
+            with self.subTest(data=data), self.patches():
+                self.repositories = data
+                with self.assertRaisesRegex(RuntimeError, "token"):
+                    with self.context():
+                        self.fail("wrong-scope token was exposed")
+
+    def test_invalid_requested_scope_fails_before_jwt_or_network(self):
+        for permissions in (None, {}, {"issues": "admin"}, {"issues": True}):
+            with self.subTest(permissions=permissions), self.patches():
+                self.permissions = permissions
+                with self.assertRaisesRegex(RuntimeError, "token"):
+                    with self.context():
+                        self.fail("invalid requested scope was accepted")
+                common.build_app_jwt.assert_not_called()
+                common.github_api_request.assert_not_called()
+
+    def test_exception_restores_ambient_environment_without_leaking_minted_token(self):
+        with self.patches():
+            os.environ["WORK_SYNC_SCOPE_TEST_TOKEN"] = "unproven-ambient-token"
+            with self.assertRaisesRegex(RuntimeError, "consumer failed"):
+                with self.context():
+                    raise RuntimeError("consumer failed")
+            self.assertEqual(os.environ["WORK_SYNC_SCOPE_TEST_TOKEN"], "unproven-ambient-token")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/github/tests/test_github_work_sync_order.py
+++ b/github/tests/test_github_work_sync_order.py
@@ -1,0 +1,163 @@
+"""Exercise real Gas City import/discovery/dispatch in isolated file-store Rigs.
+
+Set GC_TEST_BIN to the candidate gc binary. No supervisor, GitHub call, user
+registry, or live Beads server is involved. Only the external Python runner is
+replaced, so the actual shipped order, shell wrapper and gc routing are tested.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import shlex
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+GITHUB_PACK = Path(__file__).resolve().parents[1]
+
+
+@unittest.skipUnless(os.environ.get("GC_TEST_BIN"), "set GC_TEST_BIN for native order tests")
+class NativeWorkSyncOrderTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.binary = Path(os.environ["GC_TEST_BIN"]).resolve()
+        self.assertTrue(self.binary.is_file() and os.access(self.binary, os.X_OK))
+        temp = tempfile.TemporaryDirectory(prefix="github-order-test-")
+        self.addCleanup(temp.cleanup)
+        self.root = Path(temp.name).resolve()
+        self.city = self.root / "city"
+        (self.city / ".gc").mkdir(parents=True)
+        self.rigs = {name: self.root / name for name in ("alpha", "beta")}
+        for path in self.rigs.values():
+            (path / ".gc").mkdir(parents=True)
+        # Same empty scope-local file-store layout as native gc init. This is
+        # only the fixture provider, never a production work-sync store.
+        self.city.joinpath(".gc", "file-beads-layout").write_text(
+            "scope-local-v1\n", encoding="utf-8",
+        )
+        for path in (self.city, *self.rigs.values()):
+            path.joinpath(".gc", "beads.json").write_text(
+                '{"seq":0,"beads":[]}\n', encoding="utf-8",
+            )
+        self.city.joinpath("pack.toml").write_text(
+            '[pack]\nname = "work-sync-fixture"\nschema = 2\n'
+            '[imports.github]\nsource = ' + json.dumps(str(GITHUB_PACK)) + '\n',
+            encoding="utf-8",
+        )
+        self.city.joinpath(".gc", "site.toml").write_text(
+            'workspace_name = "work-sync-fixture"\nworkspace_prefix = "ws"\n' + "".join(
+                f'[[rig]]\nname = "{name}"\npath = {json.dumps(str(path))}\n'
+                for name, path in self.rigs.items()
+            ), encoding="utf-8",
+        )
+        # Allowlist only non-secret process settings. Never inherit GC/BEADS
+        # server routing, GitHub tokens, resolver commands, or live API URLs.
+        self.env = {
+            "PATH": os.defpath,
+            "GC_HOME": str(self.root / "gc-home"),
+            "GC_CITY": str(self.city),
+            "GC_CITY_PATH": str(self.city),
+            "GC_CITY_ROOT": str(self.city),
+            "GC_BEADS": "file",
+            "XDG_CONFIG_HOME": str(self.root / "config"),
+            "XDG_CACHE_HOME": str(self.root / "cache"),
+            "XDG_DATA_HOME": str(self.root / "data"),
+            "XDG_STATE_HOME": str(self.root / "state"),
+        }
+
+    def configure(self, *, rig_imports: bool) -> None:
+        content = '[workspace]\n[beads]\nprovider = "file"\n'
+        for name in self.rigs:
+            content += f'[[rigs]]\nname = "{name}"\nprefix = "{name}"\n'
+            if rig_imports:
+                content += '[rigs.imports.github_work_sync]\nsource = '
+                content += json.dumps(str(GITHUB_PACK / "work-sync")) + '\n'
+        self.city.joinpath("city.toml").write_text(content, encoding="utf-8")
+
+    def gc(self, *args: str, expected_code: int = 0) -> subprocess.CompletedProcess[str]:
+        result = subprocess.run(
+            [str(self.binary), *args], cwd=self.city, env=self.env,
+            text=True, capture_output=True, timeout=45,
+        )
+        self.assertEqual(result.returncode, expected_code, result.stdout + result.stderr)
+        return result
+
+    def work_sync_orders(self) -> list[dict]:
+        result = json.loads(self.gc("order", "list", "--json").stdout)
+        return [order for order in result["orders"] if order["name"] == "work-sync"]
+
+    def test_city_ingress_does_not_register_a_rigless_reconciler(self) -> None:
+        self.configure(rig_imports=False)
+        self.assertEqual(self.work_sync_orders(), [])
+
+    def test_each_opted_in_rig_gets_exactly_one_order(self) -> None:
+        self.configure(rig_imports=True)
+        orders = self.work_sync_orders()
+        self.assertEqual(len(orders), 2, orders)
+        self.assertEqual(
+            {order["scoped_name"] for order in orders},
+            {f"work-sync:rig:{name}" for name in self.rigs},
+        )
+        for order in orders:
+            self.assertEqual(order["type"], "exec")
+            self.assertEqual(order["trigger"], "cooldown")
+            self.assertEqual(order["interval"], "5m")
+
+    def test_dispatch_routes_and_tracks_each_rig_independently(self) -> None:
+        self.configure(rig_imports=True)
+        runner_dir = self.root / "runner"
+        runner_dir.mkdir()
+        runner = runner_dir / "python3"
+        script = runner_dir / "runner.py"
+        script.write_text(
+            "import json, os, sys\n"
+            "print(json.dumps({'argv': sys.argv[1:], 'cwd': os.getcwd(), 'env': {"
+            "key: os.environ.get(key) for key in "
+            "['GC_RIG', 'GC_RIG_ROOT', 'GC_CITY_PATH', 'GC_STORE_ROOT', 'GC_STORE_SCOPE', 'GC_SERVICE_STATE_ROOT']}}))\n",
+            encoding="utf-8",
+        )
+        runner.write_text(
+            "#!/bin/sh\nexec " + shlex.quote(sys.executable) + " "
+            + shlex.quote(str(script)) + ' "$@"\n', encoding="utf-8",
+        )
+        runner.chmod(0o755)
+        self.env["PATH"] = str(runner_dir) + os.pathsep + os.defpath
+        self.env["GC_GITHUB_WORK_SYNC_DRY_RUN"] = "1"
+        ingress_state = str(self.root / "other-city" / ".gc/services/github")
+        self.env["GC_SERVICE_STATE_ROOT"] = ingress_state
+        completed: set[str] = set()
+        for name, rig in self.rigs.items():
+            with self.subTest(rig=name):
+                result = self.gc("order", "run", "work-sync", "--rig", name)
+                output = json.loads(result.stdout.splitlines()[0])
+                self.assertEqual(output["argv"], [str(GITHUB_PACK / "scripts/github_work_sync.py"), "--dry-run"])
+                self.assertEqual(output["cwd"], str(rig))
+                self.assertEqual(Path(output["env"]["GC_CITY_PATH"]).resolve(), self.city)
+                output["env"]["GC_CITY_PATH"] = str(self.city)
+                self.assertEqual(output["env"], {
+                    "GC_RIG": name, "GC_RIG_ROOT": str(rig),
+                    "GC_CITY_PATH": str(self.city), "GC_STORE_ROOT": str(rig),
+                    "GC_STORE_SCOPE": "rig",
+                    "GC_SERVICE_STATE_ROOT": ingress_state,
+                })
+                completed.add(name)
+                for other in self.rigs:
+                    history = json.loads(self.gc(
+                        "order", "history", "work-sync", "--rig", other, "--json",
+                    ).stdout)
+                    self.assertEqual(history["summary"]["total"], int(other in completed))
+                    for entry in history["entries"]:
+                        self.assertEqual(entry["order"], "work-sync")
+                        self.assertEqual(entry["rig"], other)
+                due = json.loads(self.gc("order", "check", "--json").stdout)
+                scoped = {row["rig"]: row["due"] for row in due["orders"]
+                          if row["name"] == "work-sync"}
+                self.assertEqual(scoped, {other: other not in completed for other in self.rigs})
+        self.gc("order", "run", "work-sync", "--rig", "unknown", expected_code=1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/github/tests/test_github_work_sync_runtime.py
+++ b/github/tests/test_github_work_sync_runtime.py
@@ -286,6 +286,7 @@ def canonical_runtime_contract() -> dict[str, object]:
     return {
         "schema_version": "1",
         "organization": "opsime-space",
+        "token_permissions": {"metadata": "read", "issues": "write", "organization_projects": "write"},
         "route": {
             "repository": "product",
             "rig": "product",
@@ -521,6 +522,9 @@ class GitHubWorkSyncRuntimeTests(unittest.TestCase):
                 stack.enter_context(mock.patch.object(
                     work_sync.ContractRunner, "read", return_value=contract,
                 ))
+                auth = stack.enter_context(mock.patch.object(
+                    work_sync, "installation_token_context", return_value=contextlib.nullcontext(),
+                ))
                 stack.enter_context(mock.patch.object(
                     work_sync, "runtime_event",
                     return_value=({"delivery_id": "delivery-1", "origin": "github-human"}, "BOT_1"),
@@ -538,6 +542,7 @@ class GitHubWorkSyncRuntimeTests(unittest.TestCase):
 
                 work_sync.execute_runtime_from_environment(dry_run=requested_dry_run)
 
+                self.assertEqual(auth.call_args.kwargs["permissions"], contract["token_permissions"])
                 run.assert_called_once_with(dry_run=expected_dry_run)
                 receipts.assert_called_once_with(
                     repository="product", store_ref="rig:product",
@@ -653,7 +658,7 @@ class GitHubWorkSyncRuntimeTests(unittest.TestCase):
                 "GC_GITHUB_REPO": "opsime-space/other",
             }, canonical_runtime_contract())
 
-    def test_installation_token_context_uses_injected_token_or_mints_without_retaining(self) -> None:
+    def test_installation_token_context_remints_and_restores_the_caller_environment(self) -> None:
         token_env = "WORK_SYNC_TEST_TOKEN"
         old = os.environ.pop(token_env, None)
         self.addCleanup(
@@ -668,16 +673,19 @@ class GitHubWorkSyncRuntimeTests(unittest.TestCase):
         }]}
         common.github_app_config_for_identity.return_value = {"app_id": "1"}
         common.create_installation_token.return_value = "minted-token"
+        permissions = {"metadata": "read", "issues": "write"}
 
         with work_sync.installation_token_context(
             repository_full_name="opsime-space/product",
             token_env=token_env,
             common=common,
+            permissions=permissions,
         ):
             self.assertEqual(os.environ[token_env], "minted-token")
         self.assertNotIn(token_env, os.environ)
         common.create_installation_token.assert_called_once_with(
-            {"app_id": "1"}, "123"
+            {"app_id": "1"}, "123",
+            repository_full_name="opsime-space/product", permissions=permissions,
         )
 
         os.environ[token_env] = "injected-token"
@@ -686,10 +694,14 @@ class GitHubWorkSyncRuntimeTests(unittest.TestCase):
             repository_full_name="opsime-space/product",
             token_env=token_env,
             common=common,
+            permissions=permissions,
         ):
-            self.assertEqual(os.environ[token_env], "injected-token")
+            self.assertEqual(os.environ[token_env], "minted-token")
         self.assertEqual(os.environ[token_env], "injected-token")
-        common.create_installation_token.assert_not_called()
+        common.create_installation_token.assert_called_once_with(
+            {"app_id": "1"}, "123",
+            repository_full_name="opsime-space/product", permissions=permissions,
+        )
 
     def test_work_sync_uses_existing_rig_scoped_order_engine(self) -> None:
         root = pathlib.Path(__file__).resolve().parents[1]

--- a/github/tests/test_github_work_sync_runtime.py
+++ b/github/tests/test_github_work_sync_runtime.py
@@ -1,0 +1,2192 @@
+from __future__ import annotations
+
+import json
+import hashlib
+import contextlib
+import io
+import os
+import pathlib
+import subprocess
+import stat
+import sys
+import tempfile
+import unittest
+import urllib.error
+from unittest import mock
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+
+import github_work_sync as work_sync
+
+
+def operation(direction: str, kind: str, field: str, value: object, revision: int = 5) -> dict[str, object]:
+    return {
+        "direction": direction,
+        "kind": kind,
+        "field": field,
+        "value": value,
+        "expected_revision": revision,
+    }
+
+
+def execution_plan(
+    *operations: dict[str, object],
+    status: str = "green",
+    execution_safe: bool | None = None,
+) -> dict[str, object]:
+    if execution_safe is None:
+        execution_safe = status == "green"
+    return {
+        "status": status,
+        "execution_safe": execution_safe,
+        "counts": {
+            "beads": 1,
+            "issues": 1,
+            "plans": 1,
+            "operations": len(operations),
+            "duplicates": 0,
+            "orphans": 0,
+        },
+        "reason_codes": [],
+        "plans": [
+            {
+                "state": status,
+                "execution_safe": execution_safe,
+                "reason_codes": [],
+                "identity": {
+                    "bead_id": "ga-1",
+                    "repository": "product",
+                    "repository_id": 123,
+                    "issue_node_id": "I_1",
+                    "issue_number": 42,
+                    "project_node_id": "P_1",
+                    "project_item_id": "PI_1",
+                },
+                "github_precondition": {
+                    "github_updated_at": "2026-09-02T10:00:00Z",
+                    "project_field_hash": "b" * 64,
+                    "projection_hash": "a" * 64,
+                },
+                "beads_convergence_base": {
+                    "bead_revision": 5,
+                    "github_updated_at": "2026-09-02T10:00:00Z",
+                    "project_field_hash": "b" * 64,
+                    "projection_hash": "a" * 64,
+                    "delivery_id": "delivery-1",
+                },
+                "operations": list(operations),
+            }
+        ],
+    }
+
+
+def converged_execution_plan() -> dict[str, object]:
+    return execution_plan()
+
+
+class FakeCAS:
+    def __init__(self, outcome: str = "updated") -> None:
+        self.outcome = outcome
+        self.calls: list[dict[str, object]] = []
+
+    def apply(self, bead_id: str, expected_revision: int, patch: dict[str, object]) -> dict[str, object]:
+        self.calls.append(
+            {
+                "bead_id": bead_id,
+                "expected_revision": expected_revision,
+                "patch": patch,
+            }
+        )
+        result: dict[str, object] = {"outcome": self.outcome, "revision": 6}
+        comments = patch.get("comments")
+        if isinstance(comments, list):
+            result["imported_comment_ids"] = [
+                item["external_id"] for item in comments if isinstance(item, dict)
+            ]
+        return result
+
+
+class FakeGitHub:
+    def __init__(self) -> None:
+        self.apply_calls: list[dict[str, object]] = []
+        self.readback_calls: list[dict[str, object]] = []
+        self.failures: list[BaseException] = []
+        self.readback_result: bool | None = True
+        self.binding_calls: list[dict[str, object]] = []
+        self.preflight_calls: list[dict[str, object]] = []
+        self.preflight_result: bool | None = True
+        self.imported_comment_ids: list[str] = []
+
+    def preflight(
+        self,
+        identity: dict[str, object],
+        precondition: dict[str, object],
+    ) -> bool | None:
+        self.preflight_calls.append({
+            "identity": dict(identity),
+            "precondition": dict(precondition),
+        })
+        return self.preflight_result
+
+    def apply(self, identity: dict[str, object], item: dict[str, object]) -> None:
+        self.apply_calls.append(item)
+        if self.failures:
+            raise self.failures.pop(0)
+
+    def readback(self, identity: dict[str, object], item: dict[str, object]) -> bool | None:
+        self.readback_calls.append(item)
+        return self.readback_result
+
+    def binding(self, identity: dict[str, object]) -> dict[str, object]:
+        self.binding_calls.append(dict(identity))
+        return {
+            "external_ref": "https://github.com/owner/product/issues/42",
+            "repository_id": 123,
+            "issue_node_id": "I_1",
+            "issue_number": 42,
+            "project_node_id": "P_1",
+            "project_item_id": "PI_1",
+            "github_updated_at": "2026-09-02T10:00:00Z",
+            "project_field_hash": "b" * 64,
+            "projection_hash": "a" * 64,
+            "delivery_id": "delivery-1",
+            "imported_comment_ids": list(self.imported_comment_ids),
+        }
+
+    def set_imported_comment_ids(
+        self, identity: dict[str, object], imported_comment_ids: list[str]
+    ) -> None:
+        self.imported_comment_ids = list(imported_comment_ids)
+
+    def pending_write(self, identity: dict[str, object], item: dict[str, object]) -> dict[str, object]:
+        return {"kind": "github-write", "before_hash": "c" * 64, "after_hash": "d" * 64}
+
+
+class FakeReceiptStore:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+        self.pending: list[dict[str, object]] = []
+        self.creation_pending: list[dict[str, object]] = []
+
+    def begin(self, identity: dict[str, object], bead_revision: int, binding: dict[str, object], pending: dict[str, object]) -> None:
+        self.pending.append(dict(pending))
+
+    def begin_creation(self, identity: dict[str, object], bead_revision: int, pending: dict[str, object]) -> None:
+        self.creation_pending.append(dict(pending))
+
+    def begin_binding(self, identity: dict[str, object], bead_revision: int, binding: dict[str, object], pending: dict[str, object]) -> None:
+        self.pending.append(dict(pending))
+
+    def save(
+        self,
+        identity: dict[str, object],
+        bead_revision: int,
+        binding: dict[str, object],
+        *,
+        applied_bead_revision: int | None = None,
+    ) -> dict[str, object]:
+        call = {
+            "identity": dict(identity),
+            "bead_revision": bead_revision,
+            "binding": dict(binding),
+        }
+        if applied_bead_revision is not None:
+            call["applied_bead_revision"] = applied_bead_revision
+        self.calls.append(call)
+        return call
+
+
+class SequencedReader:
+    def __init__(self, values: list[object]) -> None:
+        self.values = list(values)
+        self.calls = 0
+
+    def read(self) -> object:
+        self.calls += 1
+        if not self.values:
+            raise AssertionError("unexpected reader call")
+        return self.values.pop(0)
+
+
+class SequencedGitHubReader:
+    def __init__(self, values: list[object]) -> None:
+        self.values = list(values)
+        self.calls: list[dict[str, object]] = []
+
+    def reconciliation_records(self, **kwargs: object) -> object:
+        self.calls.append(dict(kwargs))
+        if not self.values:
+            raise AssertionError("unexpected GitHub reader call")
+        return self.values.pop(0)
+
+
+class SequencedPlanner:
+    def __init__(self, values: list[dict[str, object]]) -> None:
+        self.values = list(values)
+        self.calls: list[dict[str, object]] = []
+
+    def plan(self, snapshots: dict[str, object], **kwargs: object) -> dict[str, object]:
+        self.calls.append({"snapshots": snapshots, **kwargs})
+        if not self.values:
+            raise AssertionError("unexpected planner call")
+        return self.values.pop(0)
+
+
+class FakeHTTPResponse:
+    def __init__(self, payload: object, status: int = 200) -> None:
+        self.payload = json.dumps(payload).encode("utf-8")
+        self.status = status
+
+    def __enter__(self) -> "FakeHTTPResponse":
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return self.payload
+
+
+def managed_projection_body(bead_id: str = "ga-1") -> tuple[str, str]:
+    machine = {
+        "acceptance": "acceptance",
+        "status": "Todo",
+        "priority": "High",
+        "bead_type": "feature",
+        "issue_type": "Feature",
+        "dependencies": [],
+        "lifecycle_phase": "development",
+        "evidence": {},
+    }
+    encoded = json.dumps(
+        machine,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    projection_hash = hashlib.sha256(encoded).hexdigest()
+    managed = {"bead_id": bead_id, **machine, "projection_hash": projection_hash}
+    body = "human\n<!-- opsime-space:managed:v2:start -->\n{0}\n<!-- opsime-space:managed:v2:end -->".format(
+        json.dumps(managed, ensure_ascii=False, sort_keys=True, indent=2)
+    )
+    return body, projection_hash
+
+
+def canonical_runtime_contract() -> dict[str, object]:
+    options = {
+        "Status": ["Todo", "Done"],
+        "Priority": ["High"],
+        "Bead type": ["feature"],
+        "Lifecycle phase": ["development"],
+        "City": ["product-city"],
+        "Risk tier": ["standard"],
+        "Delivery profile": ["product"],
+        "Data class": ["internal"],
+    }
+    return {
+        "schema_version": "1",
+        "organization": "opsime-space",
+        "route": {
+            "repository": "product",
+            "rig": "product",
+            "city": "product-city",
+            "owning_project": "Product",
+            "risk_tier": "standard",
+            "delivery_profile": "product",
+            "data_class": "internal",
+        },
+        "projects": {
+            "Product": {
+                "static_fields": {
+                    "City": "product-city",
+                    "Risk tier": "standard",
+                    "Delivery profile": "product",
+                    "Data class": "internal",
+                }
+            },
+            "opsime-space": {
+                "static_fields": {
+                    "City": "product-city",
+                    "Risk tier": "standard",
+                    "Delivery profile": "product",
+                    "Data class": "internal",
+                }
+            },
+        },
+        "project_schema": {
+            "required_fields": [
+                "Status", "Priority", "Bead ID", "Bead type",
+                "Lifecycle phase", "City", "Risk tier",
+                "Delivery profile", "Data class",
+            ],
+            "single_select_options": options,
+        },
+        "managed_blocks": [{
+            "schema_version": 2,
+            "start_marker": "<!-- opsime-space:managed:v2:start -->",
+            "end_marker": "<!-- opsime-space:managed:v2:end -->",
+            "fields": [
+                "bead_id", "acceptance", "status", "priority",
+                "bead_type", "issue_type", "dependencies",
+                "lifecycle_phase", "evidence", "projection_hash",
+            ],
+        }],
+        "projection_writer": "gascity-github-intake",
+        "live_mutations": False,
+        "cross_city_project": "opsime-space",
+        "cross_city_bead_types": ["epic"],
+        "max_pages_per_run": 100,
+        "max_identical_attempts": 2,
+    }
+
+
+def resolved_project_routes() -> dict[str, object]:
+    field_ids = {
+        "status": "F_STATUS",
+        "priority": "F_PRIORITY",
+        "bead_id": "F_BEAD_ID",
+        "bead_type": "F_BEAD_TYPE",
+        "lifecycle_phase": "F_PHASE",
+        "city": "F_CITY",
+        "risk_tier": "F_RISK",
+        "delivery_profile": "F_DELIVERY",
+        "data_class": "F_DATA",
+    }
+    option_ids = {
+        "status": {"Todo": "O_TODO", "Done": "O_DONE"},
+        "priority": {"High": "O_HIGH"},
+        "bead_type": {"feature": "O_FEATURE", "epic": "O_EPIC"},
+        "lifecycle_phase": {"development": "O_DEVELOPMENT"},
+        "city": {"product-city": "O_CITY"},
+        "risk_tier": {"standard": "O_STANDARD"},
+        "delivery_profile": {"product": "O_PRODUCT"},
+        "data_class": {"internal": "O_INTERNAL"},
+    }
+    static = {
+        "city": "product-city",
+        "risk_tier": "standard",
+        "delivery_profile": "product",
+        "data_class": "internal",
+    }
+    return {
+        "Product": {
+            "project_node_id": "P_1",
+            "field_ids": dict(field_ids),
+            "option_ids": json.loads(json.dumps(option_ids)),
+            "static_fields": dict(static),
+        },
+        "opsime-space": {
+            "project_node_id": "P_CROSS",
+            "field_ids": {key: value + "_CROSS" for key, value in field_ids.items()},
+            "option_ids": json.loads(json.dumps(option_ids)),
+            "static_fields": dict(static),
+        },
+    }
+
+
+class FakeProjectionTransport:
+    def __init__(self) -> None:
+        self.rest_calls: list[tuple[str, str, object]] = []
+        self.graphql_calls: list[tuple[str, dict[str, object]]] = []
+
+    def rest(self, method: str, path: str, payload: object = None) -> object:
+        self.rest_calls.append((method, path, payload))
+        if method == "POST" and path.endswith("/issues"):
+            return {
+                "id": 456,
+                "node_id": "I_1",
+                "number": 42,
+                "html_url": "https://github.com/opsime-space/product/issues/42",
+                "updated_at": "2026-09-02T10:00:00Z",
+            }
+        return {"node_id": "I_1", "number": 42}
+
+    def graphql(self, query: str, variables: dict[str, object]) -> object:
+        self.graphql_calls.append((query, variables))
+        if "addProjectV2ItemById" in query:
+            return {"data": {"addProjectV2ItemById": {"item": {"id": "PI_1"}}}}
+        if "updateProjectV2ItemFieldValue" in query:
+            return {"data": {"updateProjectV2ItemFieldValue": {"projectV2Item": {"id": "PI_1"}}}}
+        if "unarchiveProjectV2Item" in query:
+            return {"data": {"unarchiveProjectV2Item": {"item": {"id": "PI_1"}}}}
+        raise AssertionError(query)
+
+
+class FakeEffectiveSnapshotReader:
+    def __init__(self, body: str) -> None:
+        self.body = body
+        self.calls: list[dict[str, object]] = []
+        self.absent = True
+
+    def projection_candidates(self) -> list[dict[str, object]]:
+        self.calls.append({"projection_candidates": True})
+        if self.absent:
+            return []
+        return [{"node_id": "I_existing", "number": 99, "body": self.body}]
+
+    def read_bound(self, **kwargs: object) -> dict[str, object]:
+        self.calls.append(dict(kwargs))
+        return {
+            "repository": {
+                "id": 123,
+                "full_name": "opsime-space/product",
+            },
+            "issue": {
+                "node_id": "I_1",
+                "number": 42,
+                "updated_at": "2026-09-02T10:00:00Z",
+                "state": "open",
+                "title": "private title",
+                "body": self.body,
+            },
+            "comments": [],
+            "project": {
+                "project_node_id": "P_1",
+                "project_item_id": "PI_1",
+                "archived": False,
+                "fields": {
+                    "status": "Todo",
+                    "priority": "High",
+                    "bead_type": "feature",
+                    "issue_type": "Feature",
+                    "lifecycle_phase": "development",
+                },
+            },
+            "event": {
+                "delivery_id": "delivery-1",
+                "origin": "github-human",
+            },
+            "projection_actor_node_id": "BOT_1",
+        }
+
+
+class FakeProjectSchemaTransport:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, object]]] = []
+        self.nodes: list[dict[str, object]] = [{
+            "id": "P_1",
+            "title": "Product",
+            "fields": {
+                "nodes": [
+                    {"id": "F_STATUS", "name": "Status", "options": [
+                        {"id": "O_TODO", "name": "Todo"},
+                        {"id": "O_DONE", "name": "Done"},
+                    ]},
+                    {"id": "F_PRIORITY", "name": "Priority", "options": [
+                        {"id": "O_HIGH", "name": "High"},
+                    ]},
+                    {"id": "F_BEAD_TYPE", "name": "Bead type", "options": [
+                        {"id": "O_FEATURE", "name": "feature"},
+                    ]},
+                    {"id": "F_PHASE", "name": "Lifecycle phase", "options": [
+                        {"id": "O_DEVELOPMENT", "name": "development"},
+                    ]},
+                ]
+            },
+        }]
+
+    def graphql(self, query: str, variables: dict[str, object]) -> object:
+        self.calls.append((query, variables))
+        return {
+            "data": {
+                "organization": {
+                    "projectsV2": {
+                        "pageInfo": {"hasNextPage": False, "endCursor": None},
+                        "nodes": self.nodes,
+                    }
+                }
+            }
+        }
+
+
+class GitHubWorkSyncRuntimeTests(unittest.TestCase):
+    def test_runtime_uses_canonical_live_switch_and_explicit_dry_run(self) -> None:
+        for live, requested_dry_run, expected_dry_run in (
+            (False, False, True),
+            (False, True, True),
+            (True, False, False),
+            (True, True, True),
+        ):
+            with self.subTest(live=live, dry_run=requested_dry_run), contextlib.ExitStack() as stack:
+                contract = canonical_runtime_contract()
+                contract["live_mutations"] = live
+                stack.enter_context(mock.patch.dict(os.environ, {
+                    "GC_RIG": "product",
+                    "GC_CITY_PATH": "/city/product-city",
+                    "GC_SERVICE_STATE_ROOT": "/city/ingress/.gc/services/github",
+                    "GC_AGENT_PLATFORM_BIN": "/opt/bin/agent-platform",
+                    "GC_AGENT_PLATFORM_ROOT": "/opt/agent-platform",
+                    "GC_GITHUB_WORK_SYNC_TOKEN": "synthetic-test-token",
+                }, clear=True))
+                stack.enter_context(mock.patch.object(
+                    work_sync.ContractRunner, "read", return_value=contract,
+                ))
+                stack.enter_context(mock.patch.object(
+                    work_sync, "runtime_event",
+                    return_value=({"delivery_id": "delivery-1", "origin": "github-human"}, "BOT_1"),
+                ))
+                stack.enter_context(mock.patch.object(
+                    work_sync.GitHubProjectSchemaReader, "read_contract",
+                    return_value=resolved_project_routes(),
+                ))
+                run = stack.enter_context(mock.patch.object(
+                    work_sync.WorkSyncReconciler, "run", return_value={"status": "dry_run"},
+                ))
+                receipts = stack.enter_context(mock.patch.object(
+                    work_sync, "WorkSyncReceiptStore", wraps=work_sync.WorkSyncReceiptStore,
+                ))
+
+                work_sync.execute_runtime_from_environment(dry_run=requested_dry_run)
+
+                run.assert_called_once_with(dry_run=expected_dry_run)
+                receipts.assert_called_once_with(
+                    repository="product", store_ref="rig:product",
+                    data_root="/city/product-city/.gc/services/github/data",
+                )
+
+    def test_runtime_event_classifies_projection_actor_by_node_id_not_login(self) -> None:
+        contract = canonical_runtime_contract()
+        with tempfile.TemporaryDirectory() as tempdir:
+            payload = pathlib.Path(tempdir) / "payload.json"
+            payload.write_text(json.dumps({
+                "repository": {"full_name": "opsime-space/product"},
+                "sender": {"node_id": "BOT_1", "login": "renamed-bot"},
+            }), encoding="utf-8")
+            transport = mock.Mock()
+            transport.graphql.return_value = {
+                "data": {"viewer": {"id": "BOT_1"}}
+            }
+
+            event, actor = work_sync.runtime_event(
+                {
+                    "repository_full_name": "opsime-space/product",
+                    "delivery_id": "delivery-1",
+                    "payload_file": str(payload),
+                },
+                contract,
+                transport,
+            )
+
+        self.assertEqual(actor, "BOT_1")
+        self.assertEqual(event, {
+            "delivery_id": "delivery-1",
+            "origin": "gascity-github-intake",
+        })
+        self.assertIn("WorkSyncViewer", transport.graphql.call_args.args[0])
+
+    def test_reconciler_duplicate_delivery_fails_closed_when_receipt_base_changed(self) -> None:
+        contract = canonical_runtime_contract()
+        contract["live_mutations"] = True
+        receipt = {
+            "delivery_id": "delivery-1",
+            "bead_revision": 5,
+            "github_updated_at": "2026-09-02T10:00:00Z",
+            "project_field_hash": "b" * 64,
+            "projection_hash": "a" * 64,
+        }
+        beads = [{"issue": {"id": "ga-1", "revision": 5}, "receipt": receipt}]
+        issue = {
+            "issue": {"body": managed_projection_body()[0]},
+            "project": {},
+            "event": {"delivery_id": "delivery-1", "origin": "github-human"},
+        }
+        writer = mock.Mock()
+        writer._snapshot_fingerprint.return_value = {
+            "github_updated_at": "2026-09-02T10:01:00Z",
+            "project_field_hash": "b" * 64,
+            "projection_hash": "a" * 64,
+        }
+
+        with self.assertRaisesRegex(RuntimeError, "replay conflict"):
+            work_sync.WorkSyncReconciler(
+                contract=contract,
+                projects=resolved_project_routes(),
+                event={"delivery_id": "delivery-1", "origin": "github-human"},
+                beads_reader=SequencedReader([beads]),
+                github_reader=SequencedGitHubReader([[issue]]),
+                planner=SequencedPlanner([converged_execution_plan()]),
+                beads_cas=FakeCAS(),
+                github_writer=writer,
+                receipt_store=FakeReceiptStore(),
+                agent_platform_bin="/opt/bin/agent-platform",
+                platform_root="/opt/agent-platform",
+            ).run()
+
+    def test_main_emits_only_content_free_runtime_result(self) -> None:
+        stdout = io.StringIO()
+        with mock.patch.object(
+            work_sync,
+            "execute_runtime_from_environment",
+            return_value={
+                "status": "green",
+                "terminal_readback": True,
+                "attempts": 1,
+                "counts": {"beads": 3, "issues": 3, "operations": 0},
+            },
+        ), contextlib.redirect_stdout(stdout):
+            code = work_sync.main([])
+
+        self.assertEqual(code, 0)
+        self.assertEqual(json.loads(stdout.getvalue())["status"], "green")
+        self.assertNotIn("body", stdout.getvalue())
+    def test_runtime_environment_requires_exact_city_rig_repository_and_platform_paths(self) -> None:
+        environment = work_sync.runtime_environment({
+            "GC_RIG": "product",
+            "GC_CITY_PATH": "/city/product-city",
+            "GC_AGENT_PLATFORM_BIN": "/opt/bin/agent-platform",
+            "GC_AGENT_PLATFORM_ROOT": "/opt/agent-platform",
+            "GC_GITHUB_REPO": "opsime-space/product",
+            "GC_GITHUB_DELIVERY_ID": "delivery-1",
+        }, canonical_runtime_contract())
+
+        self.assertEqual(environment["rig"], "product")
+        self.assertEqual(environment["repository"], "product")
+        self.assertEqual(environment["city"], "/city/product-city")
+        self.assertEqual(environment["delivery_id"], "delivery-1")
+
+        with self.assertRaisesRegex(RuntimeError, "route"):
+            work_sync.runtime_environment({
+                "GC_RIG": "other",
+                "GC_CITY_PATH": "/city/product-city",
+                "GC_AGENT_PLATFORM_BIN": "/opt/bin/agent-platform",
+                "GC_AGENT_PLATFORM_ROOT": "/opt/agent-platform",
+                "GC_GITHUB_REPO": "opsime-space/other",
+            }, canonical_runtime_contract())
+
+    def test_installation_token_context_uses_injected_token_or_mints_without_retaining(self) -> None:
+        token_env = "WORK_SYNC_TEST_TOKEN"
+        old = os.environ.pop(token_env, None)
+        self.addCleanup(
+            lambda: os.environ.__setitem__(token_env, old)
+            if old is not None
+            else os.environ.pop(token_env, None)
+        )
+        common = mock.Mock()
+        common.load_rules.return_value = {"repos": [{
+            "full_name": "opsime-space/product",
+            "installation_id": "123",
+        }]}
+        common.github_app_config_for_identity.return_value = {"app_id": "1"}
+        common.create_installation_token.return_value = "minted-token"
+
+        with work_sync.installation_token_context(
+            repository_full_name="opsime-space/product",
+            token_env=token_env,
+            common=common,
+        ):
+            self.assertEqual(os.environ[token_env], "minted-token")
+        self.assertNotIn(token_env, os.environ)
+        common.create_installation_token.assert_called_once_with(
+            {"app_id": "1"}, "123"
+        )
+
+        os.environ[token_env] = "injected-token"
+        common.reset_mock()
+        with work_sync.installation_token_context(
+            repository_full_name="opsime-space/product",
+            token_env=token_env,
+            common=common,
+        ):
+            self.assertEqual(os.environ[token_env], "injected-token")
+        self.assertEqual(os.environ[token_env], "injected-token")
+        common.create_installation_token.assert_not_called()
+
+    def test_work_sync_uses_existing_rig_scoped_order_engine(self) -> None:
+        root = pathlib.Path(__file__).resolve().parents[1]
+        self.assertFalse((root / "orders" / "work-sync.toml").exists())
+        order = (root / "work-sync" / "orders" / "work-sync.toml").read_text(encoding="utf-8")
+        script = (root / "work-sync" / "orders" / "scripts" / "work-sync.sh").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn('trigger = "cooldown"', order)
+        self.assertIn('interval = "5m"', order)
+        self.assertIn('"$ORDER_DIR/scripts/work-sync.sh"', order)
+        self.assertNotIn('scope = "city"', order)
+        self.assertIn('python3 "$pack_root/scripts/github_work_sync.py"', script)
+        self.assertNotIn("cron", order.lower())
+    def test_reconciler_requires_terminal_zero_operation_readback(self) -> None:
+        contract = canonical_runtime_contract()
+        contract["live_mutations"] = True
+        beads = SequencedReader([[{"issue": {"id": "ga-1"}}], [{"issue": {"id": "ga-1"}}]])
+        github = SequencedGitHubReader([[], []])
+        planned = execution_plan(operation(
+            "beads-to-github",
+            "replace-managed-block",
+            "projection",
+            {"body": "private", "projection_hash": "a" * 64},
+        ))
+        planner = SequencedPlanner([planned, converged_execution_plan()])
+        apply_calls: list[dict[str, object]] = []
+
+        result = work_sync.WorkSyncReconciler(
+            contract=contract,
+            projects=resolved_project_routes(),
+            event={"delivery_id": "delivery-1", "origin": "github-human"},
+            beads_reader=beads,
+            github_reader=github,
+            planner=planner,
+            beads_cas=FakeCAS(),
+            github_writer=FakeGitHub(),
+            receipt_store=FakeReceiptStore(),
+            agent_platform_bin="/opt/bin/agent-platform",
+            platform_root="/opt/agent-platform",
+            apply_plan=lambda plan, *_args, **_kwargs: (
+                apply_calls.append(plan) or {"status": "green", "applied_operations": 1}
+            ),
+        ).run()
+
+        self.assertEqual(result["status"], "green")
+        self.assertIs(result["terminal_readback"], True)
+        self.assertEqual(len(apply_calls), 1)
+        self.assertEqual(beads.calls, 2)
+        self.assertEqual(len(github.calls), 2)
+        self.assertEqual(len(planner.calls), 2)
+
+    def test_reconciler_bounds_bidirectional_replan_to_contract_attempts(self) -> None:
+        contract = canonical_runtime_contract()
+        contract["live_mutations"] = True
+        contract["max_identical_attempts"] = 2
+        pull_then_push = execution_plan(
+            operation("github-to-beads", "update-field", "title", "human"),
+            operation(
+                "beads-to-github", "replace-managed-block", "projection",
+                {"body": "private", "projection_hash": "a" * 64},
+            ),
+        )
+        push = execution_plan(operation(
+            "beads-to-github", "replace-managed-block", "projection",
+            {"body": "private", "projection_hash": "a" * 64},
+        ))
+        planner = SequencedPlanner([pull_then_push, push, converged_execution_plan()])
+        outcomes = [
+            {"status": "replan_required", "reason": "beads_revision_advanced"},
+            {"status": "green", "applied_operations": 1},
+        ]
+
+        result = work_sync.WorkSyncReconciler(
+            contract=contract,
+            projects=resolved_project_routes(),
+            event={"delivery_id": "delivery-1", "origin": "github-human"},
+            beads_reader=SequencedReader([[], [], []]),
+            github_reader=SequencedGitHubReader([[], [], []]),
+            planner=planner,
+            beads_cas=FakeCAS(),
+            github_writer=FakeGitHub(),
+            receipt_store=FakeReceiptStore(),
+            agent_platform_bin="/opt/bin/agent-platform",
+            platform_root="/opt/agent-platform",
+            apply_plan=lambda *_args, **_kwargs: outcomes.pop(0),
+        ).run()
+
+        self.assertEqual(result["status"], "green")
+        self.assertEqual(result["attempts"], 2)
+        self.assertEqual(len(planner.calls), 3)
+
+    def test_reconciler_refuses_mutation_while_canonical_live_switch_is_false(self) -> None:
+        with self.assertRaisesRegex(RuntimeError, "live mutations"):
+            work_sync.WorkSyncReconciler(
+                contract=canonical_runtime_contract(),
+                projects=resolved_project_routes(),
+                event={"delivery_id": "delivery-1", "origin": "github-human"},
+                beads_reader=SequencedReader([[]]),
+                github_reader=SequencedGitHubReader([[]]),
+                planner=SequencedPlanner([converged_execution_plan()]),
+                beads_cas=FakeCAS(),
+                github_writer=FakeGitHub(),
+                receipt_store=FakeReceiptStore(),
+                agent_platform_bin="/opt/bin/agent-platform",
+                platform_root="/opt/agent-platform",
+            ).run()
+
+    def test_reconciler_allows_canonical_false_only_for_dry_run(self) -> None:
+        planned = execution_plan(operation(
+            "beads-to-github", "replace-managed-block", "projection",
+            {"body": "private", "projection_hash": "a" * 64},
+        ))
+        calls: list[bool] = []
+        result = work_sync.WorkSyncReconciler(
+            contract=canonical_runtime_contract(),
+            projects=resolved_project_routes(),
+            event={"delivery_id": "delivery-1", "origin": "github-human"},
+            beads_reader=SequencedReader([[]]),
+            github_reader=SequencedGitHubReader([[]]),
+            planner=SequencedPlanner([planned]),
+            beads_cas=FakeCAS(),
+            github_writer=FakeGitHub(),
+            receipt_store=FakeReceiptStore(),
+            agent_platform_bin="/opt/bin/agent-platform",
+            platform_root="/opt/agent-platform",
+            apply_plan=lambda _plan, *_args, **kwargs: (
+                calls.append(bool(kwargs.get("dry_run"))) or {"status": "dry_run"}
+            ),
+        ).run(dry_run=True)
+
+        self.assertEqual(result["status"], "dry_run")
+        self.assertEqual(calls, [True])
+    def test_contract_runner_uses_private_output_and_exact_repository(self) -> None:
+        observed: dict[str, object] = {}
+
+        def run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+            observed["command"] = command
+            output = command[command.index("--output") + 1]
+            observed["output_parent_mode"] = os.stat(os.path.dirname(output)).st_mode & 0o777
+            pathlib.Path(output).write_text(
+                json.dumps(canonical_runtime_contract()),
+                encoding="utf-8",
+            )
+            os.chmod(output, 0o600)
+            return subprocess.CompletedProcess(command, 0, '{"status":"ok"}\n', "")
+
+        result = work_sync.ContractRunner(run=run).read(
+            repository="product",
+            agent_platform_bin="/opt/bin/agent-platform",
+            platform_root="/opt/agent-platform",
+        )
+
+        self.assertEqual(result["route"]["repository"], "product")
+        self.assertEqual(observed["output_parent_mode"], 0o700)
+        self.assertEqual(
+            observed["command"],
+            [
+                "/opt/bin/agent-platform", "--json", "work-sync",
+                "runtime-contract", "--repository", "product",
+                "--output", observed["command"][7],
+                "--platform-root", "/opt/agent-platform",
+            ],
+        )
+
+    def test_project_schema_reader_resolves_full_contract_including_text_and_static_fields(self) -> None:
+        transport = FakeProjectSchemaTransport()
+        transport.nodes[0]["fields"]["nodes"].extend([
+            {"id": "F_BEAD_ID", "name": "Bead ID", "dataType": "TEXT"},
+            {"id": "F_CITY", "name": "City", "dataType": "SINGLE_SELECT", "options": [
+                {"id": "O_CITY", "name": "product-city"},
+            ]},
+            {"id": "F_RISK", "name": "Risk tier", "dataType": "SINGLE_SELECT", "options": [
+                {"id": "O_STANDARD", "name": "standard"},
+            ]},
+            {"id": "F_DELIVERY", "name": "Delivery profile", "dataType": "SINGLE_SELECT", "options": [
+                {"id": "O_PRODUCT", "name": "product"},
+            ]},
+            {"id": "F_DATA", "name": "Data class", "dataType": "SINGLE_SELECT", "options": [
+                {"id": "O_INTERNAL", "name": "internal"},
+            ]},
+        ])
+        for node in transport.nodes[0]["fields"]["nodes"]:
+            node.setdefault("dataType", "SINGLE_SELECT")
+        cross = json.loads(json.dumps(transport.nodes[0]))
+        cross["id"] = "P_CROSS"
+        cross["title"] = "opsime-space"
+        transport.nodes.append(cross)
+
+        result = work_sync.GitHubProjectSchemaReader(
+            organization="opsime-space",
+            transport=transport,
+        ).read_contract(canonical_runtime_contract())
+
+        product = result["Product"]
+        self.assertEqual(product["project_node_id"], "P_1")
+        self.assertEqual(product["field_ids"]["bead_id"], "F_BEAD_ID")
+        self.assertEqual(product["option_ids"]["city"], {"product-city": "O_CITY"})
+        self.assertEqual(
+            product["static_fields"],
+            {
+                "city": "product-city",
+                "risk_tier": "standard",
+                "delivery_profile": "product",
+                "data_class": "internal",
+            },
+        )
+
+    def test_beads_snapshot_reader_loads_existing_receipt_for_every_bead(self) -> None:
+        calls: list[tuple[str, str, str]] = []
+
+        def run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+            return subprocess.CompletedProcess(command, 0, json.dumps({
+                "schema_version": "1",
+                "ok": True,
+                "store_ref": "rig:product",
+                "beads": [{
+                    "id": "ga-1",
+                    "title": "title",
+                    "description": "body",
+                    "acceptance_criteria": "acceptance",
+                    "issue_type": "feature",
+                    "status": "open",
+                    "priority": 1,
+                    "revision": 5,
+                    "dependency_count": 0,
+                    "dependencies": [],
+                    "metadata": {"lifecycle_phase": "development"},
+                }],
+            }), "")
+
+        reader = work_sync.BeadsSnapshotReader(
+            city="product-city",
+            rig="product",
+            repository="product",
+            run=run,
+            load_receipt=lambda bead_id, repository, store_ref: (
+                calls.append((bead_id, repository, store_ref)) or {"receipt": True}
+            ),
+        )
+
+        records = reader.read()
+
+        self.assertEqual(calls, [("ga-1", "product", "rig:product")])
+        self.assertEqual(records[0]["receipt"], {"receipt": True})
+    def test_http_transport_uses_env_token_versioned_rest_and_graphql_without_retaining_secret(self) -> None:
+        requests: list[object] = []
+        old = os.environ.get("WORK_SYNC_TEST_TOKEN")
+        os.environ["WORK_SYNC_TEST_TOKEN"] = "short-lived-installation-token"
+        self.addCleanup(
+            lambda: (
+                os.environ.__setitem__("WORK_SYNC_TEST_TOKEN", old)
+                if old is not None
+                else os.environ.pop("WORK_SYNC_TEST_TOKEN", None)
+            )
+        )
+
+        def open_request(request: object, *, timeout: float) -> FakeHTTPResponse:
+            requests.append((request, timeout))
+            return FakeHTTPResponse({"data": {"ok": True}})
+
+        transport = work_sync.GitHubHTTPTransport(
+            token_env="WORK_SYNC_TEST_TOKEN",
+            urlopen=open_request,
+        )
+
+        self.assertEqual(
+            transport.rest("PATCH", "/repos/opsime-space/product/issues/42", {"state": "closed"}),
+            {"data": {"ok": True}},
+        )
+        self.assertEqual(
+            transport.graphql("query X { viewer { id } }", {"x": 1}),
+            {"data": {"ok": True}},
+        )
+        first = requests[0][0]
+        self.assertEqual(first.full_url, "https://api.github.com/repos/opsime-space/product/issues/42")
+        self.assertEqual(first.get_method(), "PATCH")
+        self.assertEqual(first.headers["X-github-api-version"], "2026-03-10")
+        self.assertEqual(first.headers["Authorization"], "Bearer short-lived-installation-token")
+        self.assertEqual(requests[1][0].full_url, "https://api.github.com/graphql")
+        self.assertNotIn("short-lived-installation-token", repr(transport))
+
+    def test_http_transport_classifies_read_failure_as_transient_and_write_failure_as_ambiguous(self) -> None:
+        old = os.environ.get("WORK_SYNC_TEST_TOKEN")
+        os.environ["WORK_SYNC_TEST_TOKEN"] = "short-lived-installation-token"
+        self.addCleanup(
+            lambda: (
+                os.environ.__setitem__("WORK_SYNC_TEST_TOKEN", old)
+                if old is not None
+                else os.environ.pop("WORK_SYNC_TEST_TOKEN", None)
+            )
+        )
+
+        def fail(_request: object, *, timeout: float) -> FakeHTTPResponse:
+            raise urllib.error.URLError("private transport detail")
+
+        transport = work_sync.GitHubHTTPTransport(
+            token_env="WORK_SYNC_TEST_TOKEN",
+            urlopen=fail,
+        )
+        with self.assertRaises(work_sync.TransientTransportError) as read_error:
+            transport.rest("GET", "/repos/opsime-space/product")
+        with self.assertRaises(work_sync.AmbiguousTransportError) as write_error:
+            transport.rest("PATCH", "/repos/opsime-space/product/issues/42", {"state": "closed"})
+        self.assertNotIn("private transport detail", str(read_error.exception))
+        self.assertNotIn("private transport detail", str(write_error.exception))
+
+    def test_projection_writer_creates_issue_adds_project_then_sets_fields_and_reads_effective_binding(self) -> None:
+        body, projection_hash = managed_projection_body()
+        transport = FakeProjectionTransport()
+        snapshot = FakeEffectiveSnapshotReader(body)
+        writer = work_sync.GitHubProjectionWriter(
+            organization="opsime-space",
+            repository="product",
+            transport=transport,
+            snapshot_reader=snapshot,
+            event={"delivery_id": "delivery-1", "origin": "github-human"},
+            projects={"Product": resolved_project_routes()["Product"]},
+            managed_blocks=[{
+                "schema_version": 2,
+                "start_marker": "<!-- opsime-space:managed:v2:start -->",
+                "end_marker": "<!-- opsime-space:managed:v2:end -->",
+                "fields": [
+                    "bead_id", "acceptance", "status", "priority",
+                    "bead_type", "issue_type", "dependencies",
+                    "lifecycle_phase", "evidence", "projection_hash",
+                ],
+            }],
+        )
+        identity = {"bead_id": "ga-1", "repository": "product"}
+        item = operation(
+            "beads-to-github",
+            "create-projection",
+            "projection",
+            {
+                "route": {"repository": "product", "project": "Product"},
+                "issue": {
+                    "title": "private title",
+                    "body": body,
+                    "issue_type": "Feature",
+                    "issue_state": "open",
+                    "project": {
+                        "status": "Todo",
+                        "priority": "High",
+                        "bead_type": "feature",
+                        "issue_type": "Feature",
+                        "lifecycle_phase": "development",
+                    },
+                    "projection_hash": projection_hash,
+                },
+            },
+        )
+
+        writer.apply(identity, item)
+
+        self.assertEqual(
+            transport.rest_calls[0],
+            (
+                "POST",
+                "/repos/opsime-space/product/issues",
+                {"title": "private title", "body": body, "type": "Feature"},
+            ),
+        )
+        self.assertIn("addProjectV2ItemById", transport.graphql_calls[0][0])
+        self.assertEqual(len(transport.graphql_calls), 10)
+        text_calls = [
+            variables
+            for query, variables in transport.graphql_calls
+            if "$text: String!" in query
+        ]
+        self.assertEqual(text_calls, [{
+            "project": "P_1",
+            "item": "PI_1",
+            "field": "F_BEAD_ID",
+            "text": "ga-1",
+        }])
+        self.assertTrue(writer.readback(identity, item))
+        binding = writer.binding(identity)
+        self.assertEqual(
+            {key: binding[key] for key in (
+                "repository_id", "issue_node_id", "issue_number",
+                "project_node_id", "project_item_id", "projection_hash",
+            )},
+            {
+                "repository_id": 123,
+                "issue_node_id": "I_1",
+                "issue_number": 42,
+                "project_node_id": "P_1",
+                "project_item_id": "PI_1",
+                "projection_hash": projection_hash,
+            },
+        )
+        self.assertEqual(binding["delivery_id"], "delivery-1")
+        self.assertEqual(binding["imported_comment_ids"], [])
+
+    def test_projection_writer_maps_bound_issue_project_and_restore_operations(self) -> None:
+        body, _projection_hash = managed_projection_body()
+        transport = FakeProjectionTransport()
+        writer = work_sync.GitHubProjectionWriter(
+            organization="opsime-space",
+            repository="product",
+            transport=transport,
+            snapshot_reader=FakeEffectiveSnapshotReader(body),
+            event={"delivery_id": "delivery-1", "origin": "github-human"},
+            projects={"Product": resolved_project_routes()["Product"]},
+            managed_blocks=[{
+                "schema_version": 2,
+                "start_marker": "<!-- opsime-space:managed:v2:start -->",
+                "end_marker": "<!-- opsime-space:managed:v2:end -->",
+                "fields": [
+                    "bead_id", "acceptance", "status", "priority",
+                    "bead_type", "issue_type", "dependencies",
+                    "lifecycle_phase", "evidence", "projection_hash",
+                ],
+            }],
+        )
+        identity = execution_plan()["plans"][0]["identity"]
+        operations = [
+            operation("beads-to-github", "replace-managed-block", "projection", {"body": body, "projection_hash": "a" * 64}),
+            operation("beads-to-github", "update-project-field", "status", "Done"),
+            operation("beads-to-github", "update-issue-type", "issue_type", "Feature"),
+            operation("beads-to-github", "update-issue-state", "issue_state", "closed"),
+            operation("beads-to-github", "restore-project-item", "project_archived", False),
+        ]
+
+        for item in operations:
+            writer.apply(identity, item)
+
+        self.assertIn(
+            ("PATCH", "/repos/opsime-space/product/issues/42", {"body": body}),
+            transport.rest_calls,
+        )
+        self.assertIn(
+            ("PATCH", "/repos/opsime-space/product/issues/42", {"type": "Feature"}),
+            transport.rest_calls,
+        )
+        self.assertIn(
+            ("PATCH", "/repos/opsime-space/product/issues/42", {"state": "closed"}),
+            transport.rest_calls,
+        )
+        self.assertTrue(any("updateProjectV2ItemFieldValue" in call[0] for call in transport.graphql_calls))
+        self.assertTrue(any("unarchiveProjectV2Item" in call[0] for call in transport.graphql_calls))
+
+    def test_project_schema_reader_resolves_exact_field_and_option_ids_from_graphql(self) -> None:
+        transport = FakeProjectSchemaTransport()
+
+        result = work_sync.GitHubProjectSchemaReader(
+            organization="opsime-space",
+            transport=transport,
+        ).read({
+            "Product": {
+                "status": ["Todo", "Done"],
+                "priority": ["High"],
+                "bead_type": ["feature"],
+                "lifecycle_phase": ["development"],
+            }
+        })
+
+        self.assertEqual(result["Product"]["project_node_id"], "P_1")
+        self.assertEqual(result["Product"]["field_ids"]["status"], "F_STATUS")
+        self.assertEqual(
+            result["Product"]["option_ids"]["status"],
+            {"Todo": "O_TODO", "Done": "O_DONE"},
+        )
+        self.assertEqual(transport.calls[0][1]["organization"], "opsime-space")
+
+    def test_project_schema_reader_fails_closed_on_duplicate_project_title(self) -> None:
+        transport = FakeProjectSchemaTransport()
+        transport.nodes.append(dict(transport.nodes[0]))
+
+        with self.assertRaisesRegex(RuntimeError, "ambiguous"):
+            work_sync.GitHubProjectSchemaReader(
+                organization="opsime-space",
+                transport=transport,
+            ).read({
+                "Product": {
+                    "status": ["Todo", "Done"],
+                    "priority": ["High"],
+                    "bead_type": ["feature"],
+                    "lifecycle_phase": ["development"],
+                }
+            })
+
+    def test_projection_writer_preflight_uses_effective_hashes_and_absence_scan(self) -> None:
+        body, projection_hash = managed_projection_body()
+        snapshot = FakeEffectiveSnapshotReader(body)
+        writer = work_sync.GitHubProjectionWriter(
+            organization="opsime-space",
+            repository="product",
+            transport=FakeProjectionTransport(),
+            snapshot_reader=snapshot,
+            event={"delivery_id": "delivery-1", "origin": "github-human"},
+            projects={"Product": resolved_project_routes()["Product"]},
+            managed_blocks=[{
+                "schema_version": 2,
+                "start_marker": "<!-- opsime-space:managed:v2:start -->",
+                "end_marker": "<!-- opsime-space:managed:v2:end -->",
+                "fields": [
+                    "bead_id", "acceptance", "status", "priority",
+                    "bead_type", "issue_type", "dependencies",
+                    "lifecycle_phase", "evidence", "projection_hash",
+                ],
+            }],
+        )
+        identity = execution_plan()["plans"][0]["identity"]
+        binding = writer.binding(identity)
+
+        self.assertTrue(writer.preflight(identity, {
+            "github_updated_at": binding["github_updated_at"],
+            "project_field_hash": binding["project_field_hash"],
+            "projection_hash": projection_hash,
+        }))
+        unbound = {"bead_id": "ga-1", "repository": "product"}
+        self.assertTrue(writer.preflight(unbound, {"projection_absent": True}))
+        snapshot.absent = False
+        self.assertFalse(writer.preflight(unbound, {"projection_absent": True}))
+
+    def test_receipt_store_reuses_existing_pack_state_and_round_trips_closed_schema(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            store = work_sync.WorkSyncReceiptStore(
+                repository="product",
+                store_ref="rig:product",
+                data_root=tempdir,
+            )
+            identity = {
+                "bead_id": "ga-1",
+                "repository": "product",
+                "repository_id": 123,
+                "issue_node_id": "I_1",
+                "issue_number": 42,
+                "project_node_id": "P_1",
+                "project_item_id": "PI_1",
+            }
+            binding = FakeGitHub().binding(identity)
+
+            receipt = store.save(identity, 5, binding)
+
+            self.assertEqual(
+                set(receipt),
+                {
+                    "schema_version",
+                    "bead_id",
+                    "repository",
+                    "store_ref",
+                    "bead_revision",
+                    "github_updated_at",
+                    "project_field_hash",
+                    "projection_hash",
+                    "delivery_id",
+                    "imported_comment_ids",
+                },
+            )
+            self.assertNotIn("external_ref", receipt)
+            self.assertEqual(store.load("ga-1", "product", "rig:product"), receipt)
+            files = list(pathlib.Path(tempdir, "work-sync-receipts").glob("*.json"))
+            self.assertEqual(len(files), 1)
+            self.assertEqual(os.stat(files[0]).st_mode & 0o777, 0o600)
+
+            files[0].write_text(
+                json.dumps({**receipt, "repository": "other"}),
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(RuntimeError, "receipt"):
+                store.load("ga-1", "product", "rig:product")
+
+    def test_receipt_replace_is_fsynced_through_the_parent_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            store = work_sync.WorkSyncReceiptStore(
+                repository="product", store_ref="rig:product", data_root=tempdir,
+            )
+            identity = execution_plan()["plans"][0]["identity"]
+            binding = FakeGitHub().binding(identity)
+            synced: list[str] = []
+            real_fsync = os.fsync
+
+            def observed_fsync(descriptor: int) -> None:
+                synced.append("directory" if stat.S_ISDIR(os.fstat(descriptor).st_mode) else "file")
+                real_fsync(descriptor)
+
+            with mock.patch.object(work_sync.os, "fsync", side_effect=observed_fsync):
+                store.save(identity, 5, binding)
+
+            self.assertEqual(synced[-2:], ["file", "directory"])
+
+    def test_creation_intent_round_trips_without_private_projection_content(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            store = work_sync.WorkSyncReceiptStore(
+                repository="product", store_ref="rig:product", data_root=tempdir,
+            )
+            identity = {"bead_id": "ga-1", "repository": "product"}
+            pending = {
+                "kind": "create-projection",
+                "operation_hash": "a" * 64,
+                "projection_hash": "b" * 64,
+            }
+
+            receipt = store.begin_creation(identity, 5, pending)
+
+            self.assertEqual(
+                store.load("ga-1", "product", "rig:product"), receipt,
+            )
+            self.assertEqual(set(receipt), {
+                "schema_version", "bead_id", "repository", "store_ref", "bead_revision", "pending",
+            })
+            self.assertNotIn("title", json.dumps(receipt))
+
+    def test_beads_snapshot_reader_uses_one_exact_store_and_raw_records(self) -> None:
+        observed: dict[str, object] = {}
+
+        def run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+            observed["command"] = command
+            observed["kwargs"] = kwargs
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                json.dumps(
+                    {
+                        "schema_version": "1",
+                        "ok": True,
+                        "store_ref": "rig:product",
+                        "beads": [
+                            {
+                                "id": "ga-1",
+                                "title": "private title",
+                                "description": "private body",
+                                "acceptance_criteria": "acceptance",
+                                "issue_type": "feature",
+                                "status": "open",
+                                "priority": 1,
+                                "revision": -17,
+                                "dependency_count": 1,
+                                "dependencies": [
+                                    {"id": "ga-0", "dependency_type": "blocks"}
+                                ],
+                                "metadata": {"lifecycle_phase": "development"},
+                            }
+                        ],
+                    }
+                ),
+                "",
+            )
+
+        records = work_sync.BeadsSnapshotReader(
+            city="product-city",
+            rig="product",
+            repository="product",
+            run=run,
+        ).read()
+
+        self.assertEqual(
+            observed["command"],
+            [
+                "gc",
+                "--city",
+                "product-city",
+                "beads",
+                "snapshot",
+                "--store-ref=rig:product",
+                "--json",
+            ],
+        )
+        self.assertTrue(observed["kwargs"]["capture_output"])
+        self.assertEqual(records[0]["repository"], "product")
+        self.assertIsNone(records[0]["receipt"])
+        self.assertEqual(records[0]["issue"]["revision"], -17)
+        self.assertNotIn("dependencies", records[0]["issue"])
+        self.assertEqual(
+            records[0]["dependencies"],
+            [{"id": "ga-0", "dependency_type": "blocks"}],
+        )
+
+    def test_beads_snapshot_reader_rejects_wrong_store_without_leaking_content(self) -> None:
+        def run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                json.dumps(
+                    {
+                        "schema_version": "1",
+                        "ok": True,
+                        "store_ref": "rig:other",
+                        "beads": [{"title": "private title"}],
+                    }
+                ),
+                "",
+            )
+
+        with self.assertRaisesRegex(RuntimeError, "exact store") as raised:
+            work_sync.BeadsSnapshotReader(
+                city="product-city",
+                rig="product",
+                repository="product",
+                run=run,
+            ).read()
+
+        self.assertNotIn("private title", str(raised.exception))
+
+    def test_github_snapshot_reader_uses_effective_rest_and_graphql_readback(self) -> None:
+        transport = FakeGitHubReadTransport()
+        reader = work_sync.GitHubSnapshotReader(
+            organization="opsime-space",
+            repository="product",
+            transport=transport,
+            projection_actor_node_id="BOT_1",
+        )
+
+        record = reader.read_bound(
+            issue_number=42,
+            project_node_id="P_1",
+            project_item_id="PI_1",
+            event={"delivery_id": "delivery-1", "origin": "github-human"},
+        )
+
+        self.assertEqual(
+            [call[1] for call in transport.rest_calls],
+            [
+                "/repos/opsime-space/product",
+                "/repos/opsime-space/product/issues/42",
+                "/repos/opsime-space/product/issues/42/comments?per_page=100&page=1",
+            ],
+        )
+        self.assertEqual(transport.graphql_calls[0][1], {"item": "PI_1"})
+        self.assertEqual(record["repository"]["id"], 123)
+        self.assertEqual(record["issue"]["node_id"], "I_1")
+        self.assertEqual(record["comments"][0]["body"], "private human comment")
+        self.assertEqual(record["project"]["project_node_id"], "P_1")
+        self.assertEqual(
+            record["project"]["fields"],
+            {
+                "status": "Todo",
+                "priority": "High",
+                "bead_type": "feature",
+                "issue_type": "Feature",
+                "lifecycle_phase": "development",
+            },
+        )
+        self.assertEqual(record["projection_actor_node_id"], "BOT_1")
+
+    def test_github_snapshot_reader_fails_closed_on_project_identity_mismatch(self) -> None:
+        transport = FakeGitHubReadTransport()
+        transport.project_item["content"]["number"] = 99
+
+        with self.assertRaisesRegex(RuntimeError, "stable identity"):
+            work_sync.GitHubSnapshotReader(
+                organization="opsime-space",
+                repository="product",
+                transport=transport,
+                projection_actor_node_id="BOT_1",
+            ).read_bound(
+                issue_number=42,
+                project_node_id="P_1",
+                project_item_id="PI_1",
+                event={"delivery_id": "delivery-1", "origin": "github-human"},
+            )
+
+    def test_github_snapshot_reader_compares_repository_node_ids_without_coercion(self) -> None:
+        for rest_node, graphql_node, database_id in (
+            (None, None, 123), ("", "", 123), (123, 123, 123),
+            ("R_1", "R_other", 123), ("R_1", 123, 123),
+            ("R_1", "R_1", None), ("R_1", "R_1", True),
+            ("R_1", "R_1", 0), ("R_1", "R_1", "123"),
+        ):
+            with self.subTest(rest_node=rest_node, graphql_node=graphql_node, database_id=database_id):
+                transport = FakeGitHubReadTransport()
+                transport.repository["id"] = database_id
+                transport.repository["node_id"] = rest_node
+                transport.project_item["content"]["repository"]["id"] = graphql_node
+                with self.assertRaisesRegex(RuntimeError, "stable identity"):
+                    work_sync.GitHubSnapshotReader(
+                        organization="opsime-space", repository="product",
+                        transport=transport, projection_actor_node_id="BOT_1",
+                    ).read_bound(
+                        issue_number=42, project_node_id="P_1", project_item_id="PI_1",
+                        event={"delivery_id": "delivery-1", "origin": "github-human"},
+                    )
+
+    def test_github_snapshot_reader_enumerates_exact_repository_issues_for_absence_proof(self) -> None:
+        transport = FakeGitHubReadTransport()
+        reader = work_sync.GitHubSnapshotReader(
+            organization="opsime-space",
+            repository="product",
+            transport=transport,
+            projection_actor_node_id="BOT_1",
+        )
+
+        candidates = reader.projection_candidates()
+
+        self.assertEqual(candidates, [{
+            "node_id": "I_1",
+            "number": 42,
+            "body": "private body",
+        }])
+        self.assertEqual(
+            transport.rest_calls[-1][1],
+            "/repos/opsime-space/product/issues?state=all&per_page=100&page=1",
+        )
+
+    def test_reconciliation_accepts_null_body_for_unmanaged_issue(self) -> None:
+        transport = FakeGitHubReadTransport()
+        transport.issue_body = None
+        reader = work_sync.GitHubSnapshotReader(
+            organization="opsime-space", repository="product",
+            transport=transport, projection_actor_node_id="BOT_1",
+        )
+        self.assertEqual(reader.projection_candidates(), [{
+            "node_id": "I_1", "number": 42, "body": "",
+        }])
+
+    def test_reconciliation_rejects_non_text_non_null_issue_body(self) -> None:
+        for body in (False, 123, [], {}):
+            with self.subTest(body=body):
+                transport = FakeGitHubReadTransport()
+                transport.issue_body = body
+                with self.assertRaisesRegex(RuntimeError, "identity is malformed"):
+                    work_sync.GitHubSnapshotReader(
+                        organization="opsime-space", repository="product",
+                        transport=transport, projection_actor_node_id="BOT_1",
+                    ).projection_candidates()
+
+    def test_reconciliation_records_inventory_all_managed_issues_and_relevant_project_items(self) -> None:
+        body, _projection_hash = managed_projection_body()
+        transport = FakeGitHubReadTransport()
+        transport.issue_body = body
+        reader = work_sync.GitHubSnapshotReader(
+            organization="opsime-space",
+            repository="product",
+            transport=transport,
+            projection_actor_node_id="BOT_1",
+        )
+
+        records = reader.reconciliation_records(
+            projects=resolved_project_routes(),
+            managed_blocks=canonical_runtime_contract()["managed_blocks"],
+            owning_project="Product",
+            cross_city_project="opsime-space",
+            cross_city_bead_types=["epic"],
+            event={"delivery_id": "delivery-1", "origin": "github-human"},
+        )
+
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0]["issue"]["node_id"], "I_1")
+        self.assertEqual(records[0]["project"]["project_item_id"], "PI_1")
+        self.assertEqual(
+            [variables["project"] for query, variables in transport.graphql_calls if "WorkSyncProjectItems" in query],
+            ["P_1", "P_CROSS"],
+        )
+
+    def test_reconciliation_records_fail_closed_for_managed_issue_without_project_item(self) -> None:
+        body, _projection_hash = managed_projection_body()
+        transport = FakeGitHubReadTransport()
+        transport.issue_body = body
+        transport.project_items = {"P_1": [], "P_CROSS": []}
+
+        with self.assertRaisesRegex(RuntimeError, "unprojected"):
+            work_sync.GitHubSnapshotReader(
+                organization="opsime-space",
+                repository="product",
+                transport=transport,
+                projection_actor_node_id="BOT_1",
+            ).reconciliation_records(
+                projects=resolved_project_routes(),
+                managed_blocks=canonical_runtime_contract()["managed_blocks"],
+                owning_project="Product",
+                cross_city_project="opsime-space",
+                cross_city_bead_types=["epic"],
+                event={"delivery_id": "delivery-1", "origin": "github-human"},
+            )
+
+    def test_reconciliation_records_fail_closed_for_wrong_or_duplicate_project_route(self) -> None:
+        body, _projection_hash = managed_projection_body()
+        transport = FakeGitHubReadTransport()
+        transport.issue_body = body
+        duplicate = json.loads(json.dumps(transport.project_items["P_1"][0]))
+        duplicate["id"] = "PI_CROSS"
+        duplicate["project"] = {"id": "P_CROSS"}
+        transport.project_items["P_CROSS"] = [duplicate]
+
+        with self.assertRaisesRegex(RuntimeError, "route"):
+            work_sync.GitHubSnapshotReader(
+                organization="opsime-space",
+                repository="product",
+                transport=transport,
+                projection_actor_node_id="BOT_1",
+            ).reconciliation_records(
+                projects=resolved_project_routes(),
+                managed_blocks=canonical_runtime_contract()["managed_blocks"],
+                owning_project="Product",
+                cross_city_project="opsime-space",
+                cross_city_bead_types=["epic"],
+                event={"delivery_id": "delivery-1", "origin": "github-human"},
+            )
+
+    def test_reconciliation_records_fail_closed_for_static_field_or_bead_id_drift(self) -> None:
+        body, _projection_hash = managed_projection_body()
+        for field_name, replacement, reason in (
+            ("City", "other-city", "static"),
+            ("Bead ID", "other-bead", "Bead ID"),
+        ):
+            with self.subTest(field=field_name):
+                transport = FakeGitHubReadTransport()
+                transport.issue_body = body
+                for node in transport.project_item["fieldValues"]["nodes"]:
+                    if node["field"]["name"] == field_name:
+                        if "name" in node:
+                            node["name"] = replacement
+                        else:
+                            node["text"] = replacement
+
+                with self.assertRaisesRegex(RuntimeError, reason):
+                    work_sync.GitHubSnapshotReader(
+                        organization="opsime-space",
+                        repository="product",
+                        transport=transport,
+                        projection_actor_node_id="BOT_1",
+                    ).reconciliation_records(
+                        projects=resolved_project_routes(),
+                        managed_blocks=canonical_runtime_contract()["managed_blocks"],
+                        owning_project="Product",
+                        cross_city_project="opsime-space",
+                        cross_city_bead_types=["epic"],
+                        event={"delivery_id": "delivery-1", "origin": "github-human"},
+                    )
+
+    def test_github_snapshot_reader_bounds_comment_pagination(self) -> None:
+        transport = FakeGitHubReadTransport()
+        transport.comments = [
+            {"node_id": "IC_" + str(index), "body": "body", "user": {"node_id": "U_1"}}
+            for index in range(100)
+        ]
+        with self.assertRaisesRegex(RuntimeError, "pagination"):
+            work_sync.GitHubSnapshotReader(
+                organization="opsime-space",
+                repository="product",
+                transport=transport,
+                projection_actor_node_id="BOT_1",
+                max_pages=2,
+            ).read_bound(
+                issue_number=42,
+                project_node_id="P_1",
+                project_item_id="PI_1",
+                event={"delivery_id": "delivery-1", "origin": "github-human"},
+            )
+
+    def test_planner_uses_private_files_and_does_not_put_content_in_argv(self) -> None:
+        observed: dict[str, object] = {}
+
+        def run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+            observed["command"] = command
+            observed["input_mode"] = os.stat(command[command.index("--input") + 1]).st_mode & 0o777
+            output = command[command.index("--output") + 1]
+            observed["output_parent_mode"] = os.stat(os.path.dirname(output)).st_mode & 0o777
+            pathlib.Path(output).write_text(json.dumps(execution_plan()), encoding="utf-8")
+            os.chmod(output, 0o600)
+            return subprocess.CompletedProcess(command, 0, '{"status":"green"}\n', "")
+
+        snapshots = {"beads": [{"title": "private title"}], "issues": []}
+        result = work_sync.PlannerRunner(run=run).plan(
+            snapshots,
+            agent_platform_bin="/opt/bin/agent-platform",
+            platform_root="/opt/agent-platform",
+        )
+
+        self.assertEqual(result["status"], "green")
+        self.assertNotIn("private title", " ".join(observed["command"]))
+        self.assertEqual(observed["input_mode"], 0o600)
+        self.assertEqual(observed["output_parent_mode"], 0o700)
+
+    def test_pull_groups_human_fields_and_transition_into_one_beads_cas(self) -> None:
+        cas = FakeCAS()
+        github = FakeGitHub()
+        receipts = FakeReceiptStore()
+        plan = execution_plan(
+            operation("github-to-beads", "update-field", "title", "new title"),
+            operation("github-to-beads", "update-field", "description", "new body"),
+            operation("github-to-beads", "transition-request", "status", "in_progress"),
+        )
+
+        result = work_sync.apply_execution_plan(plan, cas, github, receipts)
+
+        self.assertEqual(result["status"], "green")
+        self.assertEqual(
+            cas.calls,
+            [{
+                "bead_id": "ga-1",
+                "expected_revision": 5,
+                "patch": {"title": "new title", "description": "new body", "status": "in_progress"},
+            }],
+        )
+        self.assertEqual(github.apply_calls, [])
+        self.assertEqual(receipts.calls[0]["bead_revision"], 5)
+        self.assertEqual(receipts.calls[0]["applied_bead_revision"], 6)
+
+    def test_internal_zero_operation_plan_does_not_block_projected_work(self) -> None:
+        cas, github, receipts = FakeCAS(), FakeGitHub(), FakeReceiptStore()
+        plan = execution_plan(operation("github-to-beads", "update-field", "title", "human title"))
+        plan["plans"].append({
+            "state": "green", "execution_safe": True,
+            "reason_codes": ["internal-bead-not-projected"],
+            "identity": {"bead_id": "internal-1", "repository": "product"},
+            "operations": [], "github_precondition": {"projection_absent": True},
+        })
+        result = work_sync.apply_execution_plan(plan, cas, github, receipts)
+        self.assertEqual(result["status"], "green")
+        self.assertEqual(len(cas.calls), 1)
+        self.assertEqual(cas.calls[0]["bead_id"], "ga-1")
+
+    def test_internal_skipped_plan_cannot_smuggle_a_mutation(self) -> None:
+        cas, github, receipts = FakeCAS(), FakeGitHub(), FakeReceiptStore()
+        plan = execution_plan(operation("github-to-beads", "update-field", "title", "human title"))
+        plan["plans"][0]["reason_codes"] = ["internal-bead-not-projected"]
+        plan["plans"][0]["github_precondition"] = {"projection_absent": True}
+        result = work_sync.apply_execution_plan(plan, cas, github, receipts)
+        self.assertEqual(result["status"], "red")
+        self.assertEqual(cas.calls, [])
+        self.assertEqual(github.apply_calls, [])
+
+    def test_push_requires_github_readback_then_persists_pack_receipt_without_bead_write(self) -> None:
+        cas = FakeCAS()
+        github = FakeGitHub()
+        receipts = FakeReceiptStore()
+        plan = execution_plan(
+            operation(
+                "beads-to-github",
+                "replace-managed-block",
+                "projection",
+                {"body": "private body", "projection_hash": "a" * 64},
+            ),
+        )
+
+        result = work_sync.apply_execution_plan(plan, cas, github, receipts)
+
+        self.assertEqual(result["status"], "green")
+        self.assertEqual(len(github.apply_calls), 1)
+        self.assertEqual(len(github.readback_calls), 1)
+        self.assertEqual(cas.calls, [])
+        self.assertEqual(receipts.calls[0]["bead_revision"], 5)
+        self.assertEqual(receipts.calls[0]["binding"]["projection_hash"], "a" * 64)
+
+    def test_bidirectional_plan_applies_beads_cas_and_requires_replan_before_github_write(self) -> None:
+        cas = FakeCAS()
+        github = FakeGitHub()
+        receipts = FakeReceiptStore()
+        plan = execution_plan(
+            operation("github-to-beads", "update-field", "title", "human title"),
+            operation(
+                "beads-to-github",
+                "replace-managed-block",
+                "projection",
+                {"body": "private", "projection_hash": "a" * 64},
+            ),
+        )
+
+        result = work_sync.apply_execution_plan(plan, cas, github, receipts)
+
+        self.assertEqual(result["status"], "replan_required")
+        self.assertEqual(len(cas.calls), 1)
+        self.assertEqual(github.apply_calls, [])
+        self.assertEqual(len(receipts.calls), 1)
+        self.assertEqual(receipts.calls[0]["bead_revision"], 5)
+
+    def test_dry_run_performs_no_mutations(self) -> None:
+        cas = FakeCAS()
+        github = FakeGitHub()
+        receipts = FakeReceiptStore()
+        plan = execution_plan(
+            operation("github-to-beads", "update-field", "title", "human title"),
+            operation(
+                "beads-to-github",
+                "replace-managed-block",
+                "projection",
+                {"body": "private", "projection_hash": "a" * 64},
+            ),
+        )
+
+        result = work_sync.apply_execution_plan(
+            plan, cas, github, receipts, dry_run=True
+        )
+
+        self.assertEqual(result["status"], "dry_run")
+        self.assertEqual(cas.calls, [])
+        self.assertEqual(github.apply_calls, [])
+
+    def test_transient_github_failure_retries_once_and_reads_back(self) -> None:
+        cas = FakeCAS()
+        github = FakeGitHub()
+        receipts = FakeReceiptStore()
+        github.failures = [work_sync.TransientTransportError("reset")]
+        plan = execution_plan(
+            operation(
+                "beads-to-github",
+                "replace-managed-block",
+                "projection",
+                {"body": "private", "projection_hash": "a" * 64},
+            ),
+        )
+
+        result = work_sync.apply_execution_plan(plan, cas, github, receipts)
+
+        self.assertEqual(result["status"], "green")
+        self.assertEqual(len(github.apply_calls), 2)
+        self.assertEqual(len(github.readback_calls), 1)
+
+    def test_ambiguous_github_commit_uses_readback_without_duplicate_write(self) -> None:
+        cas = FakeCAS()
+        github = FakeGitHub()
+        receipts = FakeReceiptStore()
+        github.failures = [work_sync.AmbiguousTransportError("timeout")]
+        plan = execution_plan(
+            operation(
+                "beads-to-github",
+                "replace-managed-block",
+                "projection",
+                {"body": "private", "projection_hash": "a" * 64},
+            ),
+        )
+
+        result = work_sync.apply_execution_plan(plan, cas, github, receipts)
+
+        self.assertEqual(result["status"], "green")
+        self.assertEqual(len(github.apply_calls), 1)
+        self.assertEqual(len(github.readback_calls), 1)
+
+    def test_beads_conflict_stops_without_github_write(self) -> None:
+        cas = FakeCAS(outcome="conflict")
+        github = FakeGitHub()
+        plan = execution_plan(
+            operation("github-to-beads", "update-field", "title", "human title"),
+        )
+
+        result = work_sync.apply_execution_plan(
+            plan, cas, github, FakeReceiptStore()
+        )
+
+        self.assertEqual(result["status"], "red")
+        self.assertEqual(result["reason"], "beads_revision_conflict")
+        self.assertEqual(github.apply_calls, [])
+
+    def test_changed_github_precondition_stops_before_beads_or_github_mutation(self) -> None:
+        cas = FakeCAS()
+        github = FakeGitHub()
+        github.preflight_result = False
+        plan = execution_plan(
+            operation("github-to-beads", "update-field", "title", "human title"),
+        )
+
+        result = work_sync.apply_execution_plan(
+            plan, cas, github, FakeReceiptStore()
+        )
+
+        self.assertEqual(result, {
+            "status": "red",
+            "reason": "github_precondition_changed",
+        })
+        self.assertEqual(cas.calls, [])
+        self.assertEqual(github.apply_calls, [])
+
+    def test_missing_stable_identity_fails_closed_before_mutation(self) -> None:
+        cas = FakeCAS()
+        github = FakeGitHub()
+        plan = execution_plan(operation(
+            "beads-to-github",
+            "replace-managed-block",
+            "projection",
+            {"body": "private", "projection_hash": "a" * 64},
+        ))
+        del plan["plans"][0]["identity"]["issue_node_id"]
+
+        result = work_sync.apply_execution_plan(
+            plan, cas, github, FakeReceiptStore()
+        )
+
+        self.assertEqual(result["status"], "red")
+        self.assertEqual(result["reason"], "invalid_stable_identity")
+        self.assertEqual(cas.calls, [])
+        self.assertEqual(github.apply_calls, [])
+
+    def test_comment_import_uses_one_atomic_beads_cas_and_persists_exact_receipt(self) -> None:
+        cas = FakeCAS()
+        github = FakeGitHub()
+        receipts = FakeReceiptStore()
+        plan = execution_plan(
+            operation(
+                "github-to-beads",
+                "append-comment",
+                "comments",
+                {
+                    "node_id": "IC_1",
+                    "body": "human comment",
+                    "created_at": "2026-09-02T12:34:56Z",
+                },
+            )
+        )
+
+        result = work_sync.apply_execution_plan(
+            plan, cas, github, receipts
+        )
+
+        self.assertEqual(result["status"], "green")
+        self.assertEqual(cas.calls[0]["patch"], {
+            "comments": [{
+                "external_id": "IC_1",
+                "body": "human comment",
+                "created_at": "2026-09-02T12:34:56Z",
+            }]
+        })
+        self.assertEqual(github.imported_comment_ids, ["IC_1"])
+        self.assertEqual(
+            receipts.calls[0]["binding"]["imported_comment_ids"], ["IC_1"]
+        )
+
+    def test_beads_cas_comment_apply_reads_back_authoritative_receipt(self) -> None:
+        calls: list[dict[str, object]] = []
+
+        def run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+            calls.append({"command": list(command), "kwargs": dict(kwargs)})
+            if "update-cas" in command:
+                return subprocess.CompletedProcess(command, 0, json.dumps({
+                    "schema_version": "1",
+                    "ok": True,
+                    "bead_id": "ga-1",
+                    "store_ref": "rig:product",
+                    "outcome": "updated",
+                    "expected_revision": 5,
+                    "revision": 6,
+                }))
+            return subprocess.CompletedProcess(command, 0, json.dumps({
+                "schema_version": "1",
+                "ok": True,
+                "store_ref": "rig:product",
+                "beads": [{
+                    "id": "ga-1",
+                    "revision": 6,
+                    "metadata": {
+                        "github.imported_comment_ids": json.dumps(["IC_old", "IC_1"]),
+                    },
+                }],
+            }))
+
+        outcome = work_sync.BeadsCAS(
+            city="/city", rig="product", gc_bin="/bin/gc", run=run
+        ).apply("ga-1", 5, {
+            "comments": [{
+                "external_id": "IC_1",
+                "body": "private human comment",
+                "created_at": "2026-09-02T12:34:56Z",
+            }]
+        })
+
+        self.assertEqual(outcome["imported_comment_ids"], ["IC_old", "IC_1"])
+        self.assertIn("update-cas", calls[0]["command"])
+        self.assertIn("snapshot", calls[1]["command"])
+        self.assertIn("private human comment", calls[0]["kwargs"]["input"])
+
+    def test_safe_red_missing_projection_creates_then_cas_binds_stable_identity(self) -> None:
+        cas = FakeCAS()
+        github = FakeGitHub()
+        receipts = FakeReceiptStore()
+        plan = execution_plan(
+            operation(
+                "beads-to-github",
+                "create-projection",
+                "projection",
+                {
+                    "route": {"repository": "product", "project": "Product"},
+                    "issue": {
+                        "title": "private title",
+                        "body": "private body",
+                        "issue_type": "Feature",
+                        "issue_state": "open",
+                        "project": {
+                            "status": "Todo",
+                            "priority": "High",
+                            "bead_type": "feature",
+                            "issue_type": "Feature",
+                            "lifecycle_phase": "development",
+                        },
+                        "projection_hash": "a" * 64,
+                    },
+                },
+            ),
+            status="red",
+            execution_safe=True,
+        )
+        plan["reason_codes"] = ["missing-github-projection", "orphan-bead"]
+        child = plan["plans"][0]
+        child["reason_codes"] = ["missing-github-projection"]
+        for field in (
+            "repository_id",
+            "issue_node_id",
+            "issue_number",
+            "project_node_id",
+            "project_item_id",
+        ):
+            del child["identity"][field]
+        child["github_precondition"] = {"projection_absent": True}
+
+        result = work_sync.apply_execution_plan(plan, cas, github, receipts)
+
+        self.assertEqual(result["status"], "green")
+        self.assertEqual(len(github.apply_calls), 1)
+        self.assertEqual(len(cas.calls), 1)
+        self.assertEqual(cas.calls[0]["expected_revision"], 5)
+        self.assertEqual(
+            cas.calls[0]["patch"],
+            {
+                "external_ref": "https://github.com/owner/product/issues/42",
+                "metadata": {
+                    "github.repository_id": "123",
+                    "github.issue_node_id": "I_1",
+                    "github.issue_number": "42",
+                    "github.project_node_id": "P_1",
+                    "github.project_item_id": "PI_1",
+                },
+            },
+        )
+        self.assertEqual(receipts.calls[0]["bead_revision"], 6)
+        self.assertEqual(receipts.creation_pending[0]["kind"], "create-projection")
+        self.assertEqual(
+            set(receipts.creation_pending[0]),
+            {"kind", "operation_hash", "projection_hash"},
+        )
+        self.assertNotIn("private", json.dumps(receipts.creation_pending[0]))
+        self.assertEqual(len(receipts.pending), 1)
+        self.assertEqual(
+            receipts.pending[0],
+            {
+                "kind": "bind-bead",
+                "before_revision": 5,
+                "stable_identity": {
+                    "repository_id": 123,
+                    "issue_node_id": "I_1",
+                    "issue_number": 42,
+                    "project_node_id": "P_1",
+                    "project_item_id": "PI_1",
+                },
+            },
+        )
+
+        cas, github, receipts = FakeCAS(), FakeGitHub(), FakeReceiptStore()
+        def reject_creation(*args: object, **kwargs: object) -> None:
+            raise OSError("synthetic creation receipt failure")
+        receipts.begin_creation = reject_creation
+        failed = work_sync.apply_execution_plan(plan, cas, github, receipts)
+        self.assertEqual(failed["reason"], "pending_creation_persistence_unproven")
+        self.assertEqual(github.apply_calls, [])
+        self.assertEqual(cas.calls, [])
+
+        cas, github, receipts = FakeCAS(), FakeGitHub(), FakeReceiptStore()
+        def reject_binding(*args: object, **kwargs: object) -> None:
+            raise OSError("synthetic binding receipt failure")
+        receipts.begin_binding = reject_binding
+        failed = work_sync.apply_execution_plan(plan, cas, github, receipts)
+        self.assertEqual(failed["reason"], "pending_binding_persistence_unproven")
+        self.assertEqual(len(github.apply_calls), 1)
+        self.assertEqual(cas.calls, [])
+
+    def test_proved_existing_projection_binds_bead_without_rewriting_github(self) -> None:
+        cas, github, receipts = FakeCAS(), FakeGitHub(), FakeReceiptStore()
+        plan = execution_plan(operation(
+            "beads-to-github", "bind-existing-projection", "identity",
+            {"projection_hash": "a" * 64},
+        ))
+
+        result = work_sync.apply_execution_plan(plan, cas, github, receipts)
+
+        self.assertEqual(result["status"], "green", result)
+        self.assertEqual(github.apply_calls, [])
+        self.assertEqual(len(cas.calls), 1)
+        self.assertEqual(cas.calls[0]["patch"]["metadata"]["github.issue_node_id"], "I_1")
+        self.assertEqual(receipts.calls[0]["bead_revision"], 6)
+
+    def test_red_conflict_cannot_execute_even_if_flag_is_forged(self) -> None:
+        plan = execution_plan(status="red", execution_safe=True)
+        plan["reason_codes"] = ["concurrent-machine-field-change"]
+        plan["plans"][0]["reason_codes"] = ["concurrent-machine-field-change"]
+
+        result = work_sync.apply_execution_plan(
+            plan, FakeCAS(), FakeGitHub(), FakeReceiptStore()
+        )
+
+        self.assertEqual(result, {
+            "status": "red",
+            "reason": "planner_not_execution_safe",
+        })
+
+    def test_refresh_binding_updates_receipt_without_github_or_beads_write(self) -> None:
+        cas = FakeCAS()
+        github = FakeGitHub()
+        receipts = FakeReceiptStore()
+        plan = execution_plan(operation(
+            "beads-to-github",
+            "refresh-binding",
+            "identity",
+            {
+                "bead_revision": 5,
+                "github_updated_at": "2026-09-02T10:00:00Z",
+                "project_field_hash": "b" * 64,
+                "projection_hash": "a" * 64,
+            },
+        ))
+
+        result = work_sync.apply_execution_plan(plan, cas, github, receipts)
+
+        self.assertEqual(result["status"], "green")
+        self.assertEqual(github.apply_calls, [])
+        self.assertEqual(cas.calls, [])
+        self.assertEqual(receipts.calls[0]["bead_revision"], 5)
+
+
+class FakeGitHubReadTransport:
+    def __init__(self) -> None:
+        self.rest_calls: list[tuple[str, str, object]] = []
+        self.graphql_calls: list[tuple[str, dict[str, object]]] = []
+        self.comments = [
+            {
+                "node_id": "IC_1",
+                "body": "private human comment",
+                "created_at": "2026-09-02T12:34:56Z",
+                "user": {"node_id": "U_1"},
+            }
+        ]
+        self.issue_body = "private body"
+        self.repository = {"id": 123, "node_id": "R_1", "full_name": "opsime-space/product"}
+        self.project_item: dict[str, object] = {
+            "id": "PI_1",
+            "isArchived": False,
+            "project": {"id": "P_1"},
+            "content": {
+                "id": "I_1",
+                "number": 42,
+                "repository": {"id": "R_1", "nameWithOwner": "opsime-space/product"},
+            },
+            "fieldValues": {
+                "nodes": [
+                    {"name": "Todo", "field": {"name": "Status"}},
+                    {"name": "High", "field": {"name": "Priority"}},
+                    {"name": "feature", "field": {"name": "Bead type"}},
+                    {"name": "development", "field": {"name": "Lifecycle phase"}},
+                    {"text": "ga-1", "field": {"name": "Bead ID"}},
+                    {"name": "product-city", "field": {"name": "City"}},
+                    {"name": "standard", "field": {"name": "Risk tier"}},
+                    {"name": "product", "field": {"name": "Delivery profile"}},
+                    {"name": "internal", "field": {"name": "Data class"}},
+                ]
+            },
+        }
+        self.project_items: dict[str, list[dict[str, object]]] = {
+            "P_1": [self.project_item],
+            "P_CROSS": [],
+        }
+
+    def rest(self, method: str, path: str, payload: object = None) -> object:
+        self.rest_calls.append((method, path, payload))
+        if path == "/repos/opsime-space/product/issues?state=all&per_page=100&page=1":
+            return [
+                {"node_id": "I_1", "number": 42, "body": self.issue_body},
+                {
+                    "node_id": "PR_1",
+                    "number": 43,
+                    "body": "pull request",
+                    "pull_request": {},
+                },
+            ]
+        if path == "/repos/opsime-space/product":
+            return dict(self.repository)
+        if path == "/repos/opsime-space/product/issues/42":
+            return {
+                "node_id": "I_1",
+                "number": 42,
+                "updated_at": "2026-09-02T10:00:00Z",
+                "state": "open",
+                "title": "private title",
+                "body": self.issue_body,
+                "type": {"name": "Feature"},
+            }
+        if "/comments?" in path:
+            return list(self.comments)
+        raise AssertionError(path)
+
+    def graphql(self, query: str, variables: dict[str, object]) -> dict[str, object]:
+        self.graphql_calls.append((query, variables))
+        if "WorkSyncProjectItems" in query:
+            project = str(variables["project"])
+            return {
+                "data": {
+                    "node": {
+                        "id": project,
+                        "items": {
+                            "pageInfo": {"hasNextPage": False, "endCursor": None},
+                            "nodes": self.project_items.get(project, []),
+                        },
+                    }
+                }
+            }
+        return {"data": {"node": self.project_item}}
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/github/tests/test_github_work_sync_runtime.py
+++ b/github/tests/test_github_work_sync_runtime.py
@@ -322,7 +322,7 @@ def canonical_runtime_contract() -> dict[str, object]:
             ],
             "single_select_options": options,
         },
-        "managed_blocks": [{
+        "managed_block": {
             "schema_version": 2,
             "start_marker": "<!-- opsime-space:managed:v2:start -->",
             "end_marker": "<!-- opsime-space:managed:v2:end -->",
@@ -331,7 +331,7 @@ def canonical_runtime_contract() -> dict[str, object]:
                 "bead_type", "issue_type", "dependencies",
                 "lifecycle_phase", "evidence", "projection_hash",
             ],
-        }],
+        },
         "projection_writer": "gascity-github-intake",
         "live_mutations": False,
         "cross_city_project": "opsime-space",
@@ -1021,16 +1021,7 @@ class GitHubWorkSyncRuntimeTests(unittest.TestCase):
             snapshot_reader=snapshot,
             event={"delivery_id": "delivery-1", "origin": "github-human"},
             projects={"Product": resolved_project_routes()["Product"]},
-            managed_blocks=[{
-                "schema_version": 2,
-                "start_marker": "<!-- opsime-space:managed:v2:start -->",
-                "end_marker": "<!-- opsime-space:managed:v2:end -->",
-                "fields": [
-                    "bead_id", "acceptance", "status", "priority",
-                    "bead_type", "issue_type", "dependencies",
-                    "lifecycle_phase", "evidence", "projection_hash",
-                ],
-            }],
+            managed_block=canonical_runtime_contract()["managed_block"],
         )
         identity = {"bead_id": "ga-1", "repository": "product"}
         item = operation(
@@ -1108,16 +1099,7 @@ class GitHubWorkSyncRuntimeTests(unittest.TestCase):
             snapshot_reader=FakeEffectiveSnapshotReader(body),
             event={"delivery_id": "delivery-1", "origin": "github-human"},
             projects={"Product": resolved_project_routes()["Product"]},
-            managed_blocks=[{
-                "schema_version": 2,
-                "start_marker": "<!-- opsime-space:managed:v2:start -->",
-                "end_marker": "<!-- opsime-space:managed:v2:end -->",
-                "fields": [
-                    "bead_id", "acceptance", "status", "priority",
-                    "bead_type", "issue_type", "dependencies",
-                    "lifecycle_phase", "evidence", "projection_hash",
-                ],
-            }],
+            managed_block=canonical_runtime_contract()["managed_block"],
         )
         identity = execution_plan()["plans"][0]["identity"]
         operations = [
@@ -1196,16 +1178,7 @@ class GitHubWorkSyncRuntimeTests(unittest.TestCase):
             snapshot_reader=snapshot,
             event={"delivery_id": "delivery-1", "origin": "github-human"},
             projects={"Product": resolved_project_routes()["Product"]},
-            managed_blocks=[{
-                "schema_version": 2,
-                "start_marker": "<!-- opsime-space:managed:v2:start -->",
-                "end_marker": "<!-- opsime-space:managed:v2:end -->",
-                "fields": [
-                    "bead_id", "acceptance", "status", "priority",
-                    "bead_type", "issue_type", "dependencies",
-                    "lifecycle_phase", "evidence", "projection_hash",
-                ],
-            }],
+            managed_block=canonical_runtime_contract()["managed_block"],
         )
         identity = execution_plan()["plans"][0]["identity"]
         binding = writer.binding(identity)
@@ -1535,7 +1508,7 @@ class GitHubWorkSyncRuntimeTests(unittest.TestCase):
 
         records = reader.reconciliation_records(
             projects=resolved_project_routes(),
-            managed_blocks=canonical_runtime_contract()["managed_blocks"],
+            managed_block=canonical_runtime_contract()["managed_block"],
             owning_project="Product",
             cross_city_project="opsime-space",
             cross_city_bead_types=["epic"],
@@ -1549,6 +1522,28 @@ class GitHubWorkSyncRuntimeTests(unittest.TestCase):
             [variables["project"] for query, variables in transport.graphql_calls if "WorkSyncProjectItems" in query],
             ["P_1", "P_CROSS"],
         )
+
+    def test_reconciliation_rejects_non_current_managed_block_without_write(self) -> None:
+        transport = FakeGitHubReadTransport()
+        transport.issue_body = (
+            "private body\n<!-- opsime-space:managed:v1:start -->\n{}\n"
+            "<!-- opsime-space:managed:v1:end -->"
+        )
+
+        with self.assertRaisesRegex(ValueError, "non-current"):
+            work_sync.GitHubSnapshotReader(
+                organization="opsime-space",
+                repository="product",
+                transport=transport,
+                projection_actor_node_id="BOT_1",
+            ).reconciliation_records(
+                projects=resolved_project_routes(),
+                managed_block=canonical_runtime_contract()["managed_block"],
+                owning_project="Product",
+                cross_city_project="opsime-space",
+                cross_city_bead_types=["epic"],
+                event={"delivery_id": "delivery-1", "origin": "github-human"},
+            )
 
     def test_reconciliation_records_fail_closed_for_managed_issue_without_project_item(self) -> None:
         body, _projection_hash = managed_projection_body()
@@ -1564,7 +1559,7 @@ class GitHubWorkSyncRuntimeTests(unittest.TestCase):
                 projection_actor_node_id="BOT_1",
             ).reconciliation_records(
                 projects=resolved_project_routes(),
-                managed_blocks=canonical_runtime_contract()["managed_blocks"],
+                managed_block=canonical_runtime_contract()["managed_block"],
                 owning_project="Product",
                 cross_city_project="opsime-space",
                 cross_city_bead_types=["epic"],
@@ -1588,7 +1583,7 @@ class GitHubWorkSyncRuntimeTests(unittest.TestCase):
                 projection_actor_node_id="BOT_1",
             ).reconciliation_records(
                 projects=resolved_project_routes(),
-                managed_blocks=canonical_runtime_contract()["managed_blocks"],
+                managed_block=canonical_runtime_contract()["managed_block"],
                 owning_project="Product",
                 cross_city_project="opsime-space",
                 cross_city_bead_types=["epic"],
@@ -1619,7 +1614,7 @@ class GitHubWorkSyncRuntimeTests(unittest.TestCase):
                         projection_actor_node_id="BOT_1",
                     ).reconciliation_records(
                         projects=resolved_project_routes(),
-                        managed_blocks=canonical_runtime_contract()["managed_blocks"],
+                        managed_block=canonical_runtime_contract()["managed_block"],
                         owning_project="Product",
                         cross_city_project="opsime-space",
                         cross_city_bead_types=["epic"],

--- a/github/tests/test_github_work_sync_runtime.py
+++ b/github/tests/test_github_work_sync_runtime.py
@@ -515,8 +515,8 @@ class GitHubWorkSyncRuntimeTests(unittest.TestCase):
                     "GC_RIG": "product",
                     "GC_CITY_PATH": "/city/product-city",
                     "GC_SERVICE_STATE_ROOT": "/city/ingress/.gc/services/github",
-                    "GC_AGENT_PLATFORM_BIN": "/opt/bin/agent-platform",
-                    "GC_AGENT_PLATFORM_ROOT": "/opt/agent-platform",
+                    "GC_WORK_SYNC_POLICY_BIN": "/opt/bin/agent-platform",
+                    "GC_WORK_SYNC_POLICY_ROOT": "/opt/agent-platform",
                     "GC_GITHUB_WORK_SYNC_TOKEN": "synthetic-test-token",
                 }, clear=True))
                 stack.enter_context(mock.patch.object(
@@ -613,8 +613,8 @@ class GitHubWorkSyncRuntimeTests(unittest.TestCase):
                 beads_cas=FakeCAS(),
                 github_writer=writer,
                 receipt_store=FakeReceiptStore(),
-                agent_platform_bin="/opt/bin/agent-platform",
-                platform_root="/opt/agent-platform",
+                policy_bin="/opt/bin/agent-platform",
+                policy_root="/opt/agent-platform",
             ).run()
 
     def test_main_emits_only_content_free_runtime_result(self) -> None:
@@ -638,8 +638,8 @@ class GitHubWorkSyncRuntimeTests(unittest.TestCase):
         environment = work_sync.runtime_environment({
             "GC_RIG": "product",
             "GC_CITY_PATH": "/city/product-city",
-            "GC_AGENT_PLATFORM_BIN": "/opt/bin/agent-platform",
-            "GC_AGENT_PLATFORM_ROOT": "/opt/agent-platform",
+            "GC_WORK_SYNC_POLICY_BIN": "/opt/bin/agent-platform",
+            "GC_WORK_SYNC_POLICY_ROOT": "/opt/agent-platform",
             "GC_GITHUB_REPO": "opsime-space/product",
             "GC_GITHUB_DELIVERY_ID": "delivery-1",
         }, canonical_runtime_contract())
@@ -653,8 +653,8 @@ class GitHubWorkSyncRuntimeTests(unittest.TestCase):
             work_sync.runtime_environment({
                 "GC_RIG": "other",
                 "GC_CITY_PATH": "/city/product-city",
-                "GC_AGENT_PLATFORM_BIN": "/opt/bin/agent-platform",
-                "GC_AGENT_PLATFORM_ROOT": "/opt/agent-platform",
+                "GC_WORK_SYNC_POLICY_BIN": "/opt/bin/agent-platform",
+                "GC_WORK_SYNC_POLICY_ROOT": "/opt/agent-platform",
                 "GC_GITHUB_REPO": "opsime-space/other",
             }, canonical_runtime_contract())
 
@@ -741,8 +741,8 @@ class GitHubWorkSyncRuntimeTests(unittest.TestCase):
             beads_cas=FakeCAS(),
             github_writer=FakeGitHub(),
             receipt_store=FakeReceiptStore(),
-            agent_platform_bin="/opt/bin/agent-platform",
-            platform_root="/opt/agent-platform",
+            policy_bin="/opt/bin/agent-platform",
+            policy_root="/opt/agent-platform",
             apply_plan=lambda plan, *_args, **_kwargs: (
                 apply_calls.append(plan) or {"status": "green", "applied_operations": 1}
             ),
@@ -786,8 +786,8 @@ class GitHubWorkSyncRuntimeTests(unittest.TestCase):
             beads_cas=FakeCAS(),
             github_writer=FakeGitHub(),
             receipt_store=FakeReceiptStore(),
-            agent_platform_bin="/opt/bin/agent-platform",
-            platform_root="/opt/agent-platform",
+            policy_bin="/opt/bin/agent-platform",
+            policy_root="/opt/agent-platform",
             apply_plan=lambda *_args, **_kwargs: outcomes.pop(0),
         ).run()
 
@@ -807,8 +807,8 @@ class GitHubWorkSyncRuntimeTests(unittest.TestCase):
                 beads_cas=FakeCAS(),
                 github_writer=FakeGitHub(),
                 receipt_store=FakeReceiptStore(),
-                agent_platform_bin="/opt/bin/agent-platform",
-                platform_root="/opt/agent-platform",
+                policy_bin="/opt/bin/agent-platform",
+                policy_root="/opt/agent-platform",
             ).run()
 
     def test_reconciler_allows_canonical_false_only_for_dry_run(self) -> None:
@@ -827,8 +827,8 @@ class GitHubWorkSyncRuntimeTests(unittest.TestCase):
             beads_cas=FakeCAS(),
             github_writer=FakeGitHub(),
             receipt_store=FakeReceiptStore(),
-            agent_platform_bin="/opt/bin/agent-platform",
-            platform_root="/opt/agent-platform",
+            policy_bin="/opt/bin/agent-platform",
+            policy_root="/opt/agent-platform",
             apply_plan=lambda _plan, *_args, **kwargs: (
                 calls.append(bool(kwargs.get("dry_run"))) or {"status": "dry_run"}
             ),
@@ -852,8 +852,8 @@ class GitHubWorkSyncRuntimeTests(unittest.TestCase):
 
         result = work_sync.ContractRunner(run=run).read(
             repository="product",
-            agent_platform_bin="/opt/bin/agent-platform",
-            platform_root="/opt/agent-platform",
+            policy_bin="/opt/bin/agent-platform",
+            policy_root="/opt/agent-platform",
         )
 
         self.assertEqual(result["route"]["repository"], "product")
@@ -1661,8 +1661,8 @@ class GitHubWorkSyncRuntimeTests(unittest.TestCase):
         snapshots = {"beads": [{"title": "private title"}], "issues": []}
         result = work_sync.PlannerRunner(run=run).plan(
             snapshots,
-            agent_platform_bin="/opt/bin/agent-platform",
-            platform_root="/opt/agent-platform",
+            policy_bin="/opt/bin/agent-platform",
+            policy_root="/opt/agent-platform",
         )
 
         self.assertEqual(result["status"], "green")

--- a/github/work-sync/README.md
+++ b/github/work-sync/README.md
@@ -1,0 +1,9 @@
+# GitHub Work Sync Rig Import
+
+This service-free subpack opts one Rig into the native `work-sync` order.
+Import `github` once at City scope for ingress and this subpack only on
+participating Rigs. Both must use the same accepted repository commit.
+
+See the parent [work-sync setup and contract](../README.md#bidirectional-work-sync)
+for runtime requirements, dry-run, exact routing and verification. There is
+one shared implementation and no additional scheduler, service or task store.

--- a/github/work-sync/README.md
+++ b/github/work-sync/README.md
@@ -7,3 +7,13 @@ participating Rigs. Both must use the same accepted repository commit.
 See the parent [work-sync setup and contract](../README.md#bidirectional-work-sync)
 for runtime requirements, dry-run, exact routing and verification. There is
 one shared implementation and no additional scheduler, service or task store.
+
+Each run mints a new installation token for exactly the configured repository
+with the canonical runtime contract's `token_permissions`. Before using it,
+the existing App helper verifies the returned permissions, an expiry within
+one hour, and the effective repository list. An inherited token is never scope
+proof and is not reused. Missing or unverifiable scope fails closed, including
+in dry-run mode. No token or App key is written into work-sync receipts.
+The API must be an HTTPS origin without userinfo, query, or fragment; this is
+checked before JWT signing. Token mint, scope readback, and work-sync REST/GraphQL
+requests reject all redirects, so credentials never follow a redirected URL.

--- a/github/work-sync/orders/scripts/work-sync.sh
+++ b/github/work-sync/orders/scripts/work-sync.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+order_dir="${ORDER_DIR:-$(cd "$script_dir/.." && pwd -P)}"
+# The opt-in Rig order and City ingress share the runtime from the same pinned
+# repository checkout. Do not import the parent service pack into a Rig.
+pack_root="$(cd "$order_dir/../.." && pwd -P)"
+
+args=()
+if [[ "${GC_GITHUB_WORK_SYNC_DRY_RUN:-}" == "1" ]]; then
+  args+=(--dry-run)
+fi
+
+python3 "$pack_root/scripts/github_work_sync.py" "${args[@]}"

--- a/github/work-sync/orders/work-sync.toml
+++ b/github/work-sync/orders/work-sync.toml
@@ -1,0 +1,6 @@
+[order]
+description = "Reconcile one Rig Beads store with its native GitHub Issues and Projects v2"
+trigger = "cooldown"
+interval = "5m"
+exec = '"$ORDER_DIR/scripts/work-sync.sh"'
+timeout = "15m"

--- a/github/work-sync/pack.toml
+++ b/github/work-sync/pack.toml
@@ -1,0 +1,4 @@
+[pack]
+name = "github-work-sync"
+version = "0.1.0"
+schema = 2


### PR DESCRIPTION
GitHub Pack handles intake and delivery commands but has no durable, single-writer bridge between GitHub Issues/Projects v2 and a Rig's Beads graph. This adds one scoped `work-sync` order that reads a policy provider's closed JSON contract, takes an exact native Gas City snapshot, plans reconciliation, applies Beads changes through revision CAS, and updates GitHub with mandatory readback and replay receipts.

## Resulting contract

- provider-neutral policy interface through `GC_WORK_SYNC_POLICY_BIN` and `GC_WORK_SYNC_POLICY_ROOT`
- exact repository-to-City/Rig routing, with independent PackV2 order instances for importing Rigs
- native `gc beads snapshot` and `gc beads update-cas`; no direct database fallback or second task store
- one current managed-block schema; legacy or unknown markers fail before planning or writes and no compatibility migration writer is included
- stable Issue/Project/Bead identities, field ownership, dependency ordering, transactional incoming comments, and fail-closed conflicts
- durable content-free intents and receipts under the target City's existing GitHub service data root for replay and crash recovery
- short-lived, exact-repository GitHub App installation tokens through the existing intake helpers; no PAT or ambient-token fallback
- HTTPS origin validation and redirect rejection before credentials are sent
- canonical `live_mutations=false` and optional environment dry-run both force read-only behavior

Depends on [gastownhall/gascity#6067](https://github.com/gastownhall/gascity/pull/6067) for atomic graph snapshot, whole-row revision CAS, external tracker fields, and transactional comment import. Until that dependency is accepted and pinned, the order fails closed; the PR is ready for review and changes no deployed runtime.

## Validation

- complete affected GitHub Pack suite: **184 passed, 3 skipped, 92 subtests passed**
- native two-Rig composition regression: **3 passed, 2 subtests passed**
- downstream provider integration suite: **17 passed**
- authentication tests cover mint, repository scope proof, expiry, REST/GraphQL transport, and redirect rejection with network I/O replaced
- `git diff --check` and Python compilation pass

The skipped tests are not counted as live deployment coverage. No deployed runtime or downstream accepted pin is changed by this PR.