### PR TITLE
feat(smoke-test): derive design-campaign verification from the approved artifact frame

### DIFF
--- a/gascity/README.md
+++ b/gascity/README.md
@@ -113,6 +113,7 @@ The SDLC phases are:
 | Assess a GitHub issue | `github-issue-triage` | Triage report and a sticky issue comment, created or updated; no implementation |
 | Fix a GitHub issue | `github-issue-fix` | Implemented and reviewed issue fix; sticky issue-fix status comment created or updated; optional draft or ready PR |
 | Review a GitHub PR | `github-pr-review` | Review report and a sticky PR comment for the current head, created or updated; no code changes, formal GitHub review, or merge |
+| Smoke-test a deployed app after a change ships | `smoke-test` | Browser-driven verdict in root-bead notes and mail, with screenshots; with a `design_frame`, one check per approved-frame element plus a scope-shrinkage check; no code changes, no GitHub comments |
 
 The normal build continuations use one implementation-plan review gate; a required-changes or blocked verdict stops the continuation. `design-review` and `github-issue-fix` provide review loops that harden an implementation plan. Testing evidence is required; TDD is not. `gc.mayor` can gather the upstream artifact paths needed by the continuation formulas.
 

--- a/gascity/assets/workflows/smoke-test/checklist.md
+++ b/gascity/assets/workflows/smoke-test/checklist.md
@@ -1,0 +1,127 @@
+Turn the change context into 3–8 concrete browser checks — and, when an
+approved design frame is in play, a DESIGN section derived from the FRAME
+(not from the PR) plus one scope-shrinkage check.
+
+Change context: {{change_context}}
+Focus: {{focus}}
+Design frame: {{design_frame}}
+
+`RUN_DIR` is `smoke.run_dir` in the workflow root bead's metadata
+(`gc bd show <root bead id> --json`).
+
+**A. Non-design checks (3–8, capped):**
+
+- If the context references a GitHub PR or issue, read it
+  (`gh pr view <url> --json title,body,files` / `gh issue view <url>`) and
+  derive checks from what actually changed.
+- If the context is empty, write a general smoke: app loads, primary
+  navigation works, the main list/dashboard surfaces render with data, no
+  visible error states on the core pages.
+- Cover three dimensions, at least one check each where the context allows:
+  **intent** (does the shipped change do what was asked), **interface** (do
+  the affected screens look and behave right), **functionality** (do the
+  core flows still complete).
+
+**B. Is a frame in play?** Decide this explicitly and write the answer as
+the first line of checklist.md — `Frame: <artifact URL> #/<page> — mocked on
+<record> (from design_frame | detected from <where>)` or `Frame: none`.
+
+- `design_frame` non-empty → yes; it names the artifact URL, the page anchor
+  and the record the frame is mocked on.
+- `design_frame` empty → still yes if the change context, the PR body, the
+  work bead (the bead id in the PR title / body / branch — `gc bd show <id>`)
+  or the campaign tracker (the bead the work bead names as its campaign)
+  references a design artifact URL, or a campaign tracker bead that names
+  one. Take the URL from wherever it appears, the page from the work bead's
+  "source of truth" line (else the artifact page whose route line matches
+  the changed route), and the record from that route line. Say in
+  checklist.md where you detected it.
+- Neither → `Frame: none`; skip sections C and D.
+
+**C. DESIGN section — only when a frame is in play.** The 3–8 cap above
+does NOT apply here: one check per frame element, however many there are.
+
+1. Open the frame with the artifact reader your session provides (in Claude
+   Code, the Artifact tool's `read` action) — never `curl` the artifact URL:
+   a plain fetch returns the hosting shell, not the design. The read saves
+   the full HTML to a local file path it prints; keep that path (the drive
+   step renders it). If no artifact reader is available, read the saved
+   copy the campaign tracker names; if neither is readable, every design
+   check is `blocked: frame unreadable` — still never curl.
+2. Find the page and its frame container. A design artifact of this kind is
+   a multi-page HTML mock: pages are hash-addressable (`#/<page>`), each
+   page states the app route it is mocked on (a route line at the top of the
+   frame) and wraps the mocked product page in one frame container (for
+   example a `.frame` element that begins with that route line). Use the
+   page's default mock state unless the work bead names a variant. Dynamic
+   containers are filled by the artifact's inline JavaScript — enumerate
+   from the RENDERED frame (render recipe in the drive step), never from
+   empty containers in the markup. Enumerate only what sits INSIDE the frame
+   container — the mocked page. Everything the artifact places OUTSIDE it —
+   its own demo controls (view / phase / state switches), prose, diagnostic
+   tiles, option cards, comparison tables, "what moved" notes — is
+   rationale, not a frame element: a control outside the frame is never a
+   check. Where such a demo control has a product equivalent inside the
+   frame (an A/B/C option selector beside the frame vs the in-frame view
+   switch that ships option A), the check targets the in-frame element,
+   never the demo control.
+3. Live target: the SAME record the frame is mocked on (the route line; a
+   truncated id resolves through the app's own search — the frame usually
+   names the entity). If that record is unreachable, a stand-in in the same
+   state, and say so. Frame viewport = the artifact's content width (its
+   page `max-width`; e.g. 1240px → drive at 1280 wide). Write both down.
+4. Enumerate the frame's regions and elements top-to-bottom (identity
+   block, facts line, score block, each metric tile, an action band and its
+   buttons, each side-rail card, the main region's heading, filters, group
+   headers, row anatomy, footer panels …) and write ONE check per element,
+   id `design-1`, `design-2`, … in frame order, each with three
+   sub-criteria:
+   - **present** — the element exists on the live page;
+   - **placed** — where the frame puts it: region order, column, rail vs
+     main, above/below which neighbour;
+   - **shape** — it carries the frame's data shape: the labels, the counts
+     and bars, the controls (buttons, filters, tabs). Values are the
+     record's own (the mock's figures are a fixture); shape is what is
+     compared. A region that renders empty or as bare numbers where the
+     frame shows rows / bars / filters does not match the shape — even when
+     the cause is production data, that is a frame-vs-page difference to
+     report.
+   Name the CSS selector or landmark of each element in the frame so the
+   drive step can crop it. An element whose shape needs data (rows, groups,
+   bars) is still checked on the frame's own record: if that record renders
+   it empty, the check FAILS on shape (`blocked` is never the answer for an
+   empty frame region) — a same-state stand-in may ADD a note on the
+   anatomy, never replace the frame's record.
+5. Operator-authorised omissions: before writing the checks, read the
+   campaign tracker's notes for operator decisions that refuse a frame
+   element (e.g. "the assignee chips are NOT to be built"). List those
+   elements too, tagged `operator-authorised divergence (tracker: "<quoted
+   line>")` — they are the only omissions that will not fail.
+
+**D. SCOPE-SHRINKAGE check — only when a frame is in play.** One check, id
+`scope-1`. Read three scopes: the work bead's (`gc bd show <work bead>`),
+the campaign tracker's scope line for this change (the bead the work bead
+names as its campaign), and the frame's element list from C. Then read the
+PR body's scope / divergence sections. The check FAILS when the bead or the
+PR scopes LESS than the tracker or the frame without an operator decision
+recorded ON THE TRACKER that authorises that omission. An authorisation is
+a tracker line that records an OPERATOR decision (names the operator, a
+mail id, or "operator approved/decided") and names the omitted element;
+quote it verbatim in the check. A scope one-liner that merely does not
+mention an element is NOT an authorisation —
+silence never authorises, a PR body never does, a bead never does, and a
+later tracker line revokes an earlier one. Write the check as: which
+elements shrank, where (bead vs PR), and either the authorising quote or
+`no operator decision on the tracker → FAIL`. Save the three scopes and the
+PR's scope section verbatim to `$RUN_DIR/scope-1.md` as its evidence.
+
+Write the checklist to `$RUN_DIR/checklist.md`: the `Frame:` line first,
+then one check per line with an id (`intent-1`, `interface-1`,
+`functionality-1`, …; `design-N`; `scope-1`), what to do, and what passing
+looks like.
+
+Close with `gc.outcome=pass`.
+
+**Exit criteria:** `$RUN_DIR/checklist.md` written with 3–8 non-design
+checks and — when a frame is in play — a `Frame:` line, one `design-N`
+check per frame element (uncapped) and one `scope-1` check.

--- a/gascity/assets/workflows/smoke-test/drive.md
+++ b/gascity/assets/workflows/smoke-test/drive.md
@@ -1,0 +1,129 @@
+Walk the app against `$RUN_DIR/checklist.md` in the browser.
+
+Read `smoke.mode`, `smoke.session` and `smoke.run_dir` from the workflow
+root bead's metadata (`gc bd show <root bead id> --json`). In `cloud` mode
+every browser call addresses the remote session `smoke.session`; in `local`
+mode, the local headless browser.
+
+- Start at {{app_url}}. Screenshot every checkpoint into `$RUN_DIR` — one
+  file per check (`<check-id>.png`), referenced by bare filename from the
+  verdict.
+- Record every URL you visit.
+
+**Auth:** in cloud mode you are signed in AS the operator via their profile —
+treat every click as if they made it. If a login screen still appears
+(profile session expired), or in local mode (which has no app sign-ins), do
+NOT attempt credentials — you have none, and never try to satisfy a second
+factor or passkey. Record the check as `blocked: auth`, verify what is
+verifiable unauthenticated (page loads, branding, redirect behaviour), and
+say so in the verdict.
+
+**Safety rails — this is production with real data:**
+- Non-destructive by default. No sending email, no rejections, no votes or
+  decisions, no state mutation — unless the feature under test *is* that
+  action and the change is reversible. Anything you do change goes in
+  `state_changes`.
+- Stay in the app: only the {{app_url}} origin and its sign-in hop.
+- Never capture credentials — no screenshots of account choosers, consent
+  screens, cookies, tokens, or session values.
+
+**Design checks — only when checklist.md has a `Frame:` line:**
+
+- Render the frame for cropping in the LOCAL headless browser. It is
+  separate from the remote session that drives the app; both run at once.
+  With a CDP client (adapt the calls to your harness):
+  1. `Emulation.setDeviceMetricsOverride` with the frame viewport from the
+     checklist (e.g. width 1280, height 900, deviceScaleFactor 1, mobile
+     false);
+  2. open `file://<the saved artifact HTML path>#/<page>` and wait for the
+     inline JavaScript to fill the dynamic containers;
+  3. for each design check, evaluate the element's box in the page —
+     `(function(){var e=document.querySelector(<selector>); if(!e) return null; var b=e.getBoundingClientRect(); return {x:b.x+scrollX,y:b.y+scrollY,width:b.width,height:b.height,scale:1}})()`
+     — and pass it as `clip` to `Page.captureScreenshot` (`format: png`,
+     `captureBeyondViewport: true`); write `$RUN_DIR/design-N-frame.png`.
+     A `null` box means the selector is wrong: fix the selector, never skip
+     the crop.
+- Crop the LIVE page the same way in the session that drives the app: the
+  same `Emulation.setDeviceMetricsOverride` width as the frame, then
+  `Emulation.clearDeviceMetricsOverride` before the non-design checks —
+  into `design-N-live.png`. When the element is ABSENT, crop the region
+  where the frame places it (the neighbouring landmark that does exist, or
+  the whole viewport) so the pair still shows the gap.
+- Every design check gets the PAIR `design-N-frame.png` + `design-N-live.png`
+  under `$RUN_DIR`, both named in that check's `evidence` and both written
+  next to the check in checklist.md.
+- Derive every result and cause fresh from THIS run's crops and the rules in
+  THIS step. Never carry a previous run's checklist.md, verdict.json or
+  causes forward — not for the same deployment, not from your own earlier
+  session: an earlier run's causes were written under earlier rules, and a
+  templated verdict is not a verification.
+- Judge each of the three sub-criteria. A frame element ABSENT from the page
+  is a FAIL — even if the PR body declares it out of scope. A check that
+  fails carries a `cause`; decide it in this order, exactly one:
+  1. `declared divergence (PR body: "<quoted phrase>")` — the PR body
+     documents the omission or the degradation, either by naming the element
+     or by declaring its region / the reframe it belongs to out of scope (a
+     blanket "the page reframe was not built" / "the layout stays as it is"
+     documents every element of that reframe — quote that sentence). This
+     wins over the three below whenever the PR body speaks.
+  2. `missing` — absent, and the PR body is silent about it and its region;
+  3. `misplaced: <where it is> vs <where the frame puts it>` — present, wrong
+     place, undocumented;
+  4. `shape: <what differs, in your own words>` — present, wrong labels /
+     counts / controls, undocumented. Describe THIS element's difference
+     (e.g. `shape: empty activity list, no groups or rows (data: 0 items on
+     this record)`); never reuse an example's wording.
+  A region that is empty on the frame's own record is a `shape:` FAIL, not
+  `blocked` — the frame-vs-page difference is the finding even when the
+  cause is data. `cause` appears only on fails, plus the single passing
+  form `operator-authorised divergence (tracker: "<quoted line>")` — a pass
+  only when the tracker line records the operator's decision naming this
+  element. A behaviour-only conflict (sorts, routes, gating, a state toggle
+  such as disabled-at-ends, a fade vs hidden mechanism) on an element that
+  IS present, placed and shaped is the builder's "shipped truth" territory:
+  `pass`, the divergence in `notes`, no `cause`. Never fold a frame-element
+  divergence into `notes` as an observation: it is a `fail` with a `cause`,
+  so the operator sees the scope decision, not a green tick.
+- `scope-1` follows the checklist's rule: FAIL unless every omission has an
+  authorising tracker quote; put the quote (or `none`) in `authorised_by`
+  and name `scope-1.md` as its evidence.
+
+Write `$RUN_DIR/verdict.json`:
+
+```json
+{
+  "app_url": "{{app_url}}",
+  "verified_at": "<ISO-8601 UTC>",
+  "visited": ["..."],
+  "frame": {"url": "<artifact URL or none>", "section": "<#/page>", "mocked_on": "<record route>",
+            "live_url": "<the page you drove>", "viewport": "1280x900"},
+  "checks": [
+    {"id": "intent-1", "dimension": "intent",
+     "criterion": "<the check, in your words>",
+     "result": "pass|fail|blocked",
+     "notes": "<what you saw>", "evidence": ["intent-1.png"]},
+    {"id": "design-3", "dimension": "design",
+     "element": "<frame element, e.g. metric band — 4 tiles with bars + breakdowns>",
+     "criterion": "present / placed <where the frame puts it> / shape <labels, counts, controls>",
+     "result": "pass|fail|blocked",
+     "cause": "declared divergence (PR body: \"<quoted phrase>\")",
+     "notes": "<what the live page shows there instead>",
+     "evidence": ["design-3-frame.png", "design-3-live.png"]},
+    {"id": "scope-1", "dimension": "scope",
+     "criterion": "bead and PR scope no less than tracker and frame, or an operator decision on the tracker",
+     "result": "pass|fail",
+     "cause": "unauthorised shrink at <bead|PR|bead + PR>: <elements>",
+     "authorised_by": "<verbatim tracker line, or none>",
+     "notes": "<the tracker lines you read>", "evidence": ["scope-1.md"]}
+  ],
+  "state_changes": [],
+  "notes": "<anything the operator should know>"
+}
+```
+
+Close with `gc.outcome=pass` (a failing verdict is this step's output, not a
+failure of this step).
+
+**Exit criteria:** every checklist item has a result in verdict.json with a
+screenshot (a frame + live PAIR for every `design-N`), or a recorded reason
+it was blocked.

--- a/gascity/assets/workflows/smoke-test/preflight.md
+++ b/gascity/assets/workflows/smoke-test/preflight.md
@@ -1,0 +1,57 @@
+Verify the browser and the app before deriving any checklist.
+
+Resolved app URL: {{app_url}}
+Resolved run root override: {{run_root}} (empty means use the rig artifact root)
+Resolved remote browser profile: {{cloud_profile_id}} (empty means the local browser)
+Resolved report recipient: {{report_to}}
+
+**1. Browser.** Use the browser tooling your city provides to agents (a
+browser skill, a CDP-driven headless Chromium, a remote signed-in browser
+session). The steps of this workflow name the capability they need, not a
+tool: open a URL, run JavaScript in the page, set the viewport size, and
+capture a screenshot of the viewport or of one element.
+
+Prefer a **remote signed-in session** when `{{cloud_profile_id}}` is
+non-empty and your tooling offers one: start it named `smoke-<root bead id>`
+with that profile. On success record `smoke.mode=cloud` and
+`smoke.session=smoke-<root bead id>` in the workflow root bead's metadata,
+and put any live-view URL the session prints in the root bead notes so the
+operator can watch.
+
+If the profile id is empty or the remote start fails (missing auth, API
+error), fall back to the **local headless browser**: record
+`smoke.mode=local` and note that auth-gated checks will be blocked — you
+have no credentials and must not attempt any.
+
+**2. App reachability:**
+
+```bash
+curl -s -o /dev/null -m 15 -w "%{http_code}" "{{app_url}}"
+```
+
+Any HTTP status < 500 counts as reachable (a login redirect or a 404 on the
+bare root is fine — the app is up). Connection failure, DNS failure, or a
+5xx means the deploy itself is down.
+
+**3. Run directory.** Read the current step bead with
+`gc bd show <current-step-bead-id> --json` and take `gc.root_bead_id`; hard-fail
+if it is missing. Resolve a run directory under the artifact root and record
+it on the workflow root:
+
+```bash
+RUN_DIR="$({{pack_root}}/assets/scripts/artifacts.py path --override "{{run_root}}" \
+  --relative "/smoke-runs/$(date -u +%Y%m%d-%H%M%S)-<root bead id>/" --mkdir-parents --directory)"
+gc bd update <root bead id> --set-metadata smoke.run_dir="$RUN_DIR"
+```
+
+Later steps and the operator find everything under `smoke.run_dir`.
+
+**If the browser cannot start or the app is unreachable:** do not continue.
+Mail {{report_to}} with subject `smoke-test BLOCKED: {{app_url}}` and the
+exact failing command output
+(`gc mail send {{report_to}} -s "smoke-test BLOCKED: {{app_url}}" -m "<output>"`),
+then close this step with `gc.outcome=fail` and
+`gc.failure_class=<browser-unavailable|app-unreachable>`.
+
+**Exit criteria:** browser session responding, app URL reachable,
+`smoke.run_dir` recorded on the root bead.

--- a/gascity/assets/workflows/smoke-test/report.md
+++ b/gascity/assets/workflows/smoke-test/report.md
@@ -1,0 +1,48 @@
+Deliver the verdict. You report — you do not fix, and you do not post to
+GitHub.
+
+**1. Bead notes.** Write a human-readable summary of verdict.json to the
+workflow root bead's notes (`gc bd update <root bead id> --append-notes "<summary>"`):
+overall pass/fail/blocked, a one-line-per-check table (result, dimension,
+criterion, what the browser saw), state changes if any, and the run
+directory path.
+
+**2. Mail {{report_to}}:**
+
+```bash
+gc mail send {{report_to}} \
+  -s "smoke-test <PASS|FAIL|BLOCKED>: {{app_url}}" \
+  -m "<the same summary; include the run directory so screenshots can be pulled>"
+```
+
+Overall result is FAIL if any check failed, BLOCKED if nothing failed but
+one or more checks were blocked, otherwise PASS. A `design-N` or `scope-1`
+fail is a fail like any other — a declared divergence is a red line, never
+a green tick.
+
+**Frame section** — when verdict.json has a `frame` (both the bead notes
+and the mail carry it, after the check table):
+
+```
+Frame: <artifact URL> #/<page> — mocked on <record>; live <url> @ <viewport>
+FAIL design-3 <element> — declared divergence (PR body: "<quoted phrase>") — design-3-frame.png / design-3-live.png
+FAIL design-5 <element> — missing — design-5-frame.png / design-5-live.png
+FAIL scope-1 — unauthorised shrink at <bead|PR>: <elements> — authorised_by: none
+authorised: design-9 <element> — operator-authorised divergence (tracker: "<quoted line>")
+```
+
+List EVERY design fail with its cause and its screenshot pair, then the
+scope check, then the operator-authorised divergences; never summarise the
+fails away into a count.
+
+**3. Stop the remote browser session** (billing ends when it stops). If the
+root bead's metadata has `smoke.mode=cloud`, stop `smoke.session` and
+confirm it is gone; if it is still alive, stop it once more. A failure here
+is non-fatal, but note it in the root bead.
+
+**4. Close out.** Record `smoke.reported=1` on the workflow root bead and
+close this step with `gc.outcome=pass` whatever the verdict was — the
+verdict is the output, not a failure of this step.
+
+**Exit criteria:** verdict in root bead notes, mail sent, remote session
+stopped (or noted), `smoke.reported=1` on the root bead.

--- a/gascity/formulas/REQUIREMENTS.md
+++ b/gascity/formulas/REQUIREMENTS.md
@@ -10,7 +10,8 @@ Schema: `gc.base-formulas.requirements.v1`
 
 This ledger covers every formula in the base pack. The rows are grouped by
 methodology contract, default implementation, implementation utilities, review
-and fix utilities, GitHub adapters, and publication helpers.
+and fix utilities, design and publish utilities, verification utilities, GitHub
+adapters, and publication helpers.
 
 ## Purpose
 
@@ -183,6 +184,12 @@ this ledger against the `FORMULAS` constant and formula directory.
 | GC-BF-017 | `design-review` | Cataloged targeted design review | Reviews and finalizes a design document through a body scope and cleanup finalizer while preserving notification semantics. | `design-review.formula.toml`; `../tests/test_formula_assets.py` |
 | GC-BF-018 | `publish` | Targetless internal publication helper | Runs publish preflight, no-ops when push/PR authorization is absent, pushes only with positive authorization, and opens a PR only with positive authorization after push behavior is resolved. | `publish.formula.toml`; `../tests/test_formula_assets.py` |
 
+### Verification Utilities
+
+| ID | Formula | Type | Required behavior | Evidence |
+| --- | --- | --- | --- | --- |
+| GC-BF-035 | `smoke-test` | Cataloged targetless verification adapter | Browser-drives a deployed app after a change ships and reports a verdict by root-bead notes and mail; never edits code, pushes, merges, closes PRs, comments on GitHub, or retries a deploy. Derives 3–8 non-design checks from `change_context`. When `design_frame` names an approved design artifact frame, or the change context, PR body, work bead, or campaign tracker cites one, the design checklist is derived from the FRAME, not the PR: the frame is opened through the session's artifact reader (never fetched with curl) and rendered locally; one uncapped `design-N` check (present / placed / shape) is emitted per element inside the frame container, driven on the record the frame is mocked on at the frame's viewport; the artifact's own controls and prose outside the container are never checks. One `scope-1` check fails when the work bead or the PR scopes less than the campaign tracker or the frame without an operator decision recorded on the tracker. An absent frame element fails even when the PR body declares it out of scope, with exactly one cause in the precedence `declared divergence (PR body: "…")`, `missing`, `misplaced:`, `shape:`; `operator-authorised divergence (tracker: "…")` is the only passing cause. Every design check carries a frame-crop / live-crop screenshot pair named in its evidence; results and causes are derived fresh per run and never carried from an earlier verdict; the report carries a Frame section listing every design fail with its cause and pair, then the scope check, then the authorised divergences, never a count. | `smoke-test.formula.toml`; `../assets/workflows/smoke-test/`; `../tests/test_formula_assets.py::FormulaAssetTests::test_smoke_test_derives_design_checks_from_the_frame` |
+
 ### GitHub Adapters
 
 | ID | Formula | Type | Required behavior | Evidence |
@@ -204,6 +211,7 @@ this ledger against the `FORMULAS` constant and formula directory.
 - `gascity/tests/test_formula_assets.py::FormulaAssetTests::test_build_from_decompose_is_suffix_continuation_entrypoint`
 - `gascity/tests/test_formula_assets.py::FormulaAssetTests::test_build_from_decompose_base_is_reusable_suffix_contract`
 - `gascity/tests/test_formula_assets.py::FormulaAssetTests::test_build_basic_v2_uses_approachable_factory_techniques`
+- `gascity/tests/test_formula_assets.py::FormulaAssetTests::test_smoke_test_derives_design_checks_from_the_frame`
 
 ## Maintenance Rules
 

--- a/gascity/formulas/smoke-test.formula.toml
+++ b/gascity/formulas/smoke-test.formula.toml
@@ -1,0 +1,97 @@
+description = """
+Targetless post-deploy smoke-test adapter.
+
+Opens a real browser against a deployed application right after a change
+ships (PR merge or direct commit to the default branch), walks the app
+against a checklist derived from the change context, and reports a verdict
+by root-bead notes and mail.
+
+When the change was built to an approved design artifact frame, the design
+checklist is derived from the FRAME, not from the PR: one check per element
+inside the frame container, one scope-shrinkage check, and a frame/live
+screenshot pair per design check. A frame element the PR body declares out
+of scope still fails — the verdict shows the scope decision as a red line,
+never a green tick; only an operator decision recorded on the campaign
+tracker passes.
+
+Authority: this workflow reports. It never edits code, pushes, merges,
+closes PRs, comments on GitHub, or retries a deploy. A broken app is a
+`fail` check with evidence; the operator decides what happens next.
+
+Launch inputs:
+- app_url: {{app_url}}
+- change_context: {{change_context}} (what shipped: PR URL, commit, issue link, or prose)
+- focus: {{focus}} (optional flows to concentrate on; empty = general smoke)
+- design_frame: {{design_frame}} (design-campaign runs: the approved artifact
+  frame the change was built to — artifact URL + page anchor + the record it
+  is mocked on; empty = no frame unless the change context names one)
+- report_to: {{report_to}}
+- run_root: {{run_root}} (optional override; empty resolves to the rig
+  artifact root with the pack artifact helper)
+- cloud_profile_id: {{cloud_profile_id}} (remote signed-in browser profile
+  when the city's browser tooling offers one; empty forces the local browser)
+"""
+formula = "smoke-test"
+version = 1
+contract = "graph.v2"
+target_required = false
+
+[catalog]
+name = "smoke-test"
+description = "Browser-drive a freshly deployed app against the change context — or the approved design frame — and report a smoke-test verdict."
+
+[vars]
+[vars.app_url]
+description = "Base URL of the deployed app under test, e.g. https://app.example.com."
+required = true
+
+[vars.change_context]
+description = "What just shipped: PR URL, merge commit, issue link, or a prose summary. Drives the non-design checklist. Empty means a general health pass."
+default = ""
+
+[vars.focus]
+description = "Optional focus areas or flows to exercise. Empty means a general smoke across the app's main surfaces."
+default = ""
+
+[vars.design_frame]
+description = "Design-campaign runs only: the approved artifact frame the change was built to — artifact URL + page anchor + the record the frame is mocked on, free text, e.g. 'https://claude.ai/code/artifact/<id> #/<page> — mocked on /app/records/<id>'. Empty means no frame, unless the change context, the PR body, the work bead, or its campaign tracker names a design artifact URL — the checklist step detects that and says so."
+default = ""
+
+[vars.report_to]
+description = "Mail recipient for the verdict: an agent name such as mayor, or human."
+default = "human"
+
+[vars.run_root]
+description = "Optional run-artifact root override (screenshots, checklist, verdict). Empty resolves to the rig artifact root through assets/scripts/artifacts.py."
+default = ""
+
+[vars.cloud_profile_id]
+description = "Profile id for a remote signed-in browser session carrying the operator's app sign-ins, when the city's browser tooling offers one. Empty disables remote mode and forces the local unauthenticated browser."
+default = ""
+
+[[steps]]
+id = "preflight"
+title = "Preflight: browser up, app reachable, run directory ready"
+metadata = { "gc.run_target" = "gc.run-operator" }
+description_file = "../assets/workflows/smoke-test/preflight.md"
+
+[[steps]]
+id = "checklist"
+title = "Derive the smoke checklist from the change context and the design frame"
+needs = ["preflight"]
+metadata = { "gc.run_target" = "gc.run-operator" }
+description_file = "../assets/workflows/smoke-test/checklist.md"
+
+[[steps]]
+id = "drive"
+title = "Drive the live app in the browser"
+needs = ["checklist"]
+metadata = { "gc.run_target" = "gc.run-operator" }
+description_file = "../assets/workflows/smoke-test/drive.md"
+
+[[steps]]
+id = "report"
+title = "Report the verdict"
+needs = ["drive"]
+metadata = { "gc.run_target" = "gc.run-operator" }
+description_file = "../assets/workflows/smoke-test/report.md"

--- a/gascity/tests/test_formula_assets.py
+++ b/gascity/tests/test_formula_assets.py
@@ -45,6 +45,7 @@ FORMULAS = {
     "publish",
     "review",
     "same-session-implement",
+    "smoke-test",
 }
 
 ROLE_AGENTS = {
@@ -78,6 +79,7 @@ CATALOG_FORMULAS = {
     "github-pr-review",
     "implement",
     "review",
+    "smoke-test",
 }
 
 BUILD_BASE_STEPS = [
@@ -3713,6 +3715,66 @@ class FormulaAssetTests(unittest.TestCase):
             self.assertEqual(data["mode"], "report")
             self.assertFalse(data["target_required"])
             self.assertEqual([step["id"] for step in data["steps"]], ["validate-context", "write-report"])
+
+    def test_smoke_test_derives_design_checks_from_the_frame(self) -> None:
+        root = pathlib.Path(__file__).resolve().parents[1]
+        data = load_formula(root, "smoke-test")
+
+        self.assertFalse(data["target_required"])
+        self.assertEqual(data["catalog"]["name"], "smoke-test")
+        self.assertEqual(
+            [step["id"] for step in data["steps"]],
+            ["preflight", "checklist", "drive", "report"],
+        )
+        for step in data["steps"]:
+            with self.subTest(step=step["id"]):
+                self.assertEqual(step["metadata"]["gc.run_target"], "gc.run-operator")
+
+        # The frame is opt-in by launch var and otherwise detected from the
+        # change context; a plain smoke needs nothing.
+        design_frame = data["vars"]["design_frame"]
+        self.assertEqual(design_frame["default"], "")
+        self.assertNotIn("required", design_frame)
+
+        workflows = root / "assets" / "workflows" / "smoke-test"
+        checklist = (workflows / "checklist.md").read_text(encoding="utf-8")
+        drive = (workflows / "drive.md").read_text(encoding="utf-8")
+        report = (workflows / "report.md").read_text(encoding="utf-8")
+
+        # Checklist: the frame decision is written down, design checks come
+        # from the rendered frame container and are uncapped, and only an
+        # operator decision recorded on the tracker authorises an omission.
+        self.assertIn("`Frame: none`", checklist)
+        self.assertIn("never `curl` the artifact URL", checklist)
+        self.assertIn("Enumerate only what sits INSIDE the frame", checklist)
+        self.assertIn("does NOT apply here: one check per frame element", checklist)
+        for criterion in ("**present**", "**placed**", "**shape**"):
+            self.assertIn(criterion, checklist)
+        self.assertIn("`scope-1`", checklist)
+        self.assertIn("silence never authorises, a PR body never does, a bead never does", checklist)
+
+        # Drive: absence fails even when the PR body declares it, the cause
+        # precedence is fixed, a tracker-recorded operator decision is the
+        # only passing cause, every design check has a frame/live pair, and
+        # nothing is carried over from an earlier run.
+        self.assertIn("is a FAIL — even if the PR body declares it out of scope", drive)
+        precedence = [
+            drive.index('`declared divergence (PR body: "<quoted phrase>")`'),
+            drive.index("`missing`"),
+            drive.index("`misplaced:"),
+            drive.index("`shape:"),
+        ]
+        self.assertEqual(precedence, sorted(precedence))
+        self.assertIn('`operator-authorised divergence (tracker: "<quoted line>")`', drive)
+        self.assertIn("`design-N-frame.png` + `design-N-live.png`", drive)
+        self.assertIn("Never carry a previous run's checklist.md, verdict.json or", drive)
+        self.assertIn('"authorised_by"', drive)
+
+        # Report: every design fail is listed with its cause and pair; a
+        # declared divergence is never folded into a count.
+        self.assertIn("Frame: <artifact URL> #/<page>", report)
+        self.assertIn("List EVERY design fail with its cause and its screenshot pair", report)
+        self.assertIn("never summarise the", report)
 
     def test_github_adapter_formulas_are_targetless_url_adapters(self) -> None:
         root = pathlib.Path(__file__).resolve().parents[1]


### PR DESCRIPTION
## Problem

A post-deploy smoke test whose checklist is derived from the change context (the PR body) cannot catch a scope-down that the PR body itself declares. Every check becomes "did the PR do what the PR says". A PR that quietly ships less than the approved design frame — and documents the omissions under a "divergences kept" heading — passes, and the operator reads a green tick where a scope decision should be. A PR-body scope-down is unfalsifiable by PR-derived verification.

## What this adds

The catalog has no browser smoke-test formula, so this PR adds one to the `gascity` pack — `smoke-test`, a cataloged targetless verification adapter (`preflight` → `checklist` → `drive` → `report`, all routed to `gc.run-operator`) — carrying the frame-derived mechanism we landed in our city's local copy:

- **`design_frame` var** — artifact URL + page anchor + the record the frame is mocked on; empty by default. The checklist step also detects a frame on its own when the change context, the PR body, the work bead, or its campaign tracker names a design artifact URL, and writes `Frame: …` / `Frame: none` as the first line of the checklist so the decision is auditable.
- **Frame-derived enumeration.** The frame is opened through the session's artifact reader (never `curl`), rendered locally, and one `design-N` check is emitted per element INSIDE the frame container — present / placed / shape — in frame order, driven on the same record the frame is mocked on, at the frame's viewport. The 3–8 cap applies to the non-design checks only. The artifact's own demo controls, prose and diagnostic tiles outside the container are rationale, never checks.
- **Cause precedence.** An absent frame element FAILS even when the PR body declares it out of scope. Exactly one cause per failing check, decided in order: `declared divergence (PR body: "…")` > `missing` > `misplaced: …` > `shape: …`. The single passing cause is `operator-authorised divergence (tracker: "…")` — a decision recorded on the campaign tracker that names the operator and the element. Behaviour-only conflicts on an element that is present, placed and shaped stay the builder's "shipped truth" territory: pass, divergence in notes.
- **Scope-shrinkage check** (`scope-1`): the work bead's scope vs the campaign tracker's scope line vs the frame's element list vs the PR body's scope section. Fails when the bead or the PR scopes less than the tracker or the frame without an operator decision on the tracker. Silence never authorises; a PR body never does; a bead never does; a later tracker line revokes an earlier one.
- **Screenshot pairs.** Every design check saves `design-N-frame.png` + `design-N-live.png` under the run directory (clipped `Page.captureScreenshot` on the rendered frame and on the live page at the same width), both named in the check's `evidence`; an absent element crops the region where the frame puts it so the pair still shows the gap.
- **Anti-template rule.** Results and causes are derived fresh from this run's crops and this step's rules; a previous run's checklist, verdict or causes are never carried forward, not even for the same deployment — a templated verdict is not a verification.
- **Frame section in the report.** Bead notes and mail list every design fail with its cause and its pair, then the scope check, then the authorised divergences — never a count.

## Evidence

Same deployment, same page, two runs under the two rules. The PR-derived checklist passed 7/7. The frame-derived checklist against that deployment failed 13 design checks — the identity/facts line, the metric band, the action band, the side-rail thumbnails, the list filters, each one documented in the PR body as a kept divergence and recorded as `declared divergence (PR body: "…")` — plus `scope-1` (no operator decision on the tracker for any of them), with 19 frame/live screenshot pairs in the run directory; the one tracker-authorised omission was the only divergence that passed. A second run in the same session then reproduced 23 of the first run's 25 causes verbatim, which is how the anti-template rule earned its place.

## How a city passes `design_frame`

```bash
gc sling gc.run-operator smoke-test --formula \
  --var app_url=https://app.example.com \
  --var 'change_context=https://github.com/<owner>/<repo>/pull/<n>' \
  --var 'design_frame=https://claude.ai/code/artifact/<id> #/<page> — mocked on /app/records/<id>' \
  --var report_to=mayor
```

Leave `design_frame` empty for a plain smoke; the checklist step still detects a frame when the change context, PR body, work bead or campaign tracker names one. `cloud_profile_id` (a remote signed-in browser profile, when the city's browser tooling offers one) and `run_root` (run artifacts; empty resolves to the rig artifact root through the pack's artifact helper) are optional.

## Placement and conventions

- Steps delegate to shadowable assets under `gascity/assets/workflows/smoke-test/`; the formula is targetless and cataloged; run artifacts resolve through `assets/scripts/artifacts.py`; bead access goes through `gc bd`.
- Browser tooling is named by capability (open a URL, run JavaScript, set the viewport, clip a screenshot; a remote signed-in session when the city has one) rather than by a specific harness, so the crop recipe is the CDP calls themselves.
- Ledger row `GC-BF-035` in a new "Verification Utilities" section, a "Focused workflows" README row, and `test_smoke_test_derives_design_checks_from_the_frame` pinning the contract (step shape, opt-in var, cause precedence order, screenshot pairs, anti-template rule, report shape).
- Our per-feature verify formula carries the same mechanism but depends on a city-local stage script, so it is not part of this PR.

## Validation

- `python -m pytest gascity/tests -q` (pytest 9.1.1, PyYAML, jsonschema in a scratch venv): 189 passed, 9460 subtests passed — includes the new `test_smoke_test_derives_design_checks_from_the_frame`.
- `python -m pytest tests/test_no_bare_bd_commands.py tests/test_validate_registry.py tests/test_registry_release.py tests/test_pack_release_compat.py -q`: 38 passed (the new assets are tracked, so the bare-`bd` scanner covered them).
- `python3 validate_registry.py --require-git`: ok.
- `gc lint gascity` and `gc lint gascity/roles` (local dev build of gc): ok.
- `go test .`: ok.
- Real compile: a throwaway city built with `tests/gc_live_city.write_city` (isolated HOME/GC_HOME), then `gc formula list` (lists `smoke-test`) and `gc formula show smoke-test --json`: `ok: true`, steps `smoke-test.preflight` → `.checklist` → `.drive` → `.report` → `.workflow-finalize`, all seven vars rendered into the step text.
- `tomllib` parses the formula.
- Not run: `tests/test_maintained_packs_live_gc.py` (covers the five maintained non-methodology packs, untouched here) and the model-backed inference gate.

One thing to flag from the compile: `checklist.md` (7.6 KB) and `drive.md` (7.3 KB) sit above gc's inline-description limit — the pack's largest existing asset is 5.7 KB — so `gc formula show` compiles those two steps as gc's external-prompt stub (the resolved asset path plus every formula variable resolved) and inlines the other two. That is gc's own path for a large `description_file` and the compile is clean. If you would rather have every step inline, the DESIGN and SCOPE sections can move to a `frame-checklist` step and the crop/cause rules to a `frame-drive` step; I kept the four-step shape so a city that already runs this formula locally can diff against it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
