### PR TITLE
fix(gastown): refinery-patrol wisp reconcile misses ephemeral wisps

### DIFF
--- a/gastown/formulas/mol-refinery-patrol.toml
+++ b/gastown/formulas/mol-refinery-patrol.toml
@@ -119,7 +119,7 @@ wisp, burn the current wisp, then request a restart:
 ```bash
 CURRENT_WISP=${GC_BEAD_ID:-}
 if [ -z "$CURRENT_WISP" ]; then
-  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
+  CURRENT_WISP=$(gc bd query "ephemeral=true AND assignee="$GC_AGENT" AND status=in_progress" --limit 1 --json | jq -r '.[0].id // empty')
 fi
 NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{target_branch}} --var rig_name={{rig_name}} --var binding_prefix={{binding_prefix}} --json | jq -r '.new_epic_id // empty')
 if [ -z "$NEXT" ]; then
@@ -242,7 +242,7 @@ gc bd update $WORK \
 ```bash
 CURRENT_WISP=${GC_BEAD_ID:-}
 if [ -z "$CURRENT_WISP" ]; then
-  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
+  CURRENT_WISP=$(gc bd query "ephemeral=true AND assignee="$GC_AGENT" AND status=in_progress" --limit 1 --json | jq -r '.[0].id // empty')
 fi
 NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{target_branch}} --var rig_name={{rig_name}} --var binding_prefix={{binding_prefix}} --json | jq -r '.new_epic_id // empty')
 if [ -z "$NEXT" ]; then
@@ -343,7 +343,7 @@ TARGET=$(gc bd show $WORK --json | jq -r '.[0].metadata.target // "{{target_bran
      ```bash
      CURRENT_WISP=${GC_BEAD_ID:-}
      if [ -z "$CURRENT_WISP" ]; then
-       CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
+       CURRENT_WISP=$(gc bd query "ephemeral=true AND assignee="$GC_AGENT" AND status=in_progress" --limit 1 --json | jq -r '.[0].id // empty')
      fi
      NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{target_branch}} --var rig_name={{rig_name}} --var binding_prefix={{binding_prefix}} --json | jq -r '.new_epic_id // empty')
      if [ -z "$NEXT" ]; then
@@ -435,7 +435,7 @@ Branch: $BRANCH
 Target: $TARGET"
   CURRENT_WISP=${GC_BEAD_ID:-}
   if [ -z "$CURRENT_WISP" ]; then
-    CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
+    CURRENT_WISP=$(gc bd query "ephemeral=true AND assignee="$GC_AGENT" AND status=in_progress" --limit 1 --json | jq -r '.[0].id // empty')
   fi
   if [ -z "$CURRENT_WISP" ]; then
     echo "Could not resolve current wisp; not burning."
@@ -1106,8 +1106,9 @@ If the cycle ended early (conflict rejection, no work found), note
 why and what state was left.
 
 This summary is not stored separately — it lives in the wisp's
-closing reason. The next session can find it via `gc bd list --type=molecule
---status=closed --limit=5` if it needs predecessor context."""
+closing reason. The next session can find it via `gc bd query 'ephemeral=true
+AND status=closed' --limit 5` if it needs predecessor context (plain `gc bd
+list` excludes ephemeral wisp beads regardless of --type)."""
 
 [[steps]]
 id = "next-iteration"
@@ -1143,7 +1144,7 @@ If auto_land = "false": skip this entirely.
 ```bash
 CURRENT_WISP=${GC_BEAD_ID:-}
 if [ -z "$CURRENT_WISP" ]; then
-  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=1 --json | jq -r '.[0].id // empty')
+  CURRENT_WISP=$(gc bd query "ephemeral=true AND assignee="$GC_AGENT" AND status=in_progress" --limit 1 --json | jq -r '.[0].id // empty')
 fi
 NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{target_branch}} --var rig_name={{rig_name}} --var binding_prefix={{binding_prefix}} --json | jq -r '.new_epic_id // empty')
 if [ -z "$NEXT" ]; then


### PR DESCRIPTION
## Summary
- `mol-refinery-patrol`'s CURRENT_WISP reconcile uses `gc bd list --type=molecule`, but `gc bd list` excludes ephemeral beads regardless of `--type`, and patrol wisps are `ephemeral=true`. The lookup always returns empty, so any session boundary between "pour next" and "burn current" leaks the previous wisp instead of burning it.
- Switches all 5 reconcile call sites to `gc bd query 'ephemeral=true AND assignee=... AND status=in_progress'`, matching the pattern `mol-witness-patrol` already uses. Also fixes a doc comment pointing at the same broken `gc bd list --type=molecule` command.
- Verified live against a rig with an open ephemeral wisp: `gc bd list --type=molecule` returns `[]`, `gc bd query 'ephemeral=true AND ...'` correctly resolves it.

Note: this pack had an earlier fix (#121, `140730111d`) that corrected an invalid `--type=wisp` filter to `--type=molecule` -- that fix was necessary but not sufficient, since `gc bd list` drops ephemeral beads independent of the type filter. This PR addresses the remaining root cause.

Found via a tenders/gastown.witness patrol report: 10 leaked OPEN patrol wisps piled up on `tenders/gastown.refinery` (2026-09-02 through 2026-09-03) despite the refinery session itself running healthy each cycle.

## Test plan
- [x] `python3 -c "import tomllib; tomllib.load(open('gastown/formulas/mol-refinery-patrol.toml','rb'))"` — file still parses as valid TOML
- [x] Extracted the fixed bash line and ran `bash -n` against it — syntax OK
- [x] Ran the fixed query live against a real rig (`gc bd query 'ephemeral=true AND assignee=<agent> AND status=open'`) — correctly resolves the open wisp that `gc bd list --type=molecule` missed
- [x] One-time cleanup of the 10 already-leaked tenders wisps done separately (authorized by BAA, tracked in this city's gc-p8d7yo, not part of this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ciq2VnDNURS8vudG5SaieT