### PR TITLE
fix(gascity): correct worker claim and work record instructions

### DIFF
--- a/gascity/README.md
+++ b/gascity/README.md
@@ -37,10 +37,12 @@ and your project added as a rig (`gc rig add .` inside the repo). See the
    source = "https://github.com/gastownhall/gascity-packs.git//gascity/roles"
    ```
 
-   Both imports are required. The rig-scoped roles pack supplies agents but,
-   by design, rig imports do not register city commands; importing roles alone
-   renders prompts that reference `gc gc claim` without installing that
-   command. Keep the top-level Gas City pack imported at city scope.
+   Both imports are required for the full workflow. The rig-scoped roles pack
+   supplies agents but, by design, rig imports do not register city commands.
+   Worker prompts use the built-in `gc hook --claim --drain-ack --json`, which
+   works with any import alias. Keep the top-level Gas City pack imported at
+   city scope for formulas, the mayor skill, and the optional claim wrapper
+   (`gc <alias> claim`, here `gc gc claim`).
 
    (Contributors hacking on packs can point this source at a local clone.)
 

--- a/gascity/template-fragments/gc-role-worker.template.md
+++ b/gascity/template-fragments/gc-role-worker.template.md
@@ -9,11 +9,11 @@ You are `{{ .AgentName }}`, Gas City `graph.v2` worker for
 First action. Before skills, files, runtime state, or repository inspection:
 
 ```bash
-gc gc claim
+gc hook --claim --drain-ack --json
 ```
 
 This is your only work-discovery command. It atomically claims one routed bead
-through `gc hook --claim --drain-ack --json`. Never discover work through
+regardless of the pack's import alias. Never discover work through
 `gc bd mol current`, broad `gc bd ready`/`gc bd list`, root or parent beads, searches,
 mail, logs, or repository context.
 
@@ -29,6 +29,11 @@ Read its single JSON result:
   assignment, or retry forever. Do not drain or mutate claim state; the command
   may have assigned work before returning an operational failure.
 
+On `action=work`, read `gc bd show "$CLAIMED_BEAD_ID" --json` for the
+description and result contract. If the claim result omits `root_bead_id` or
+`continuation_group`, read `gc.root_bead_id` or `gc.continuation_group` from
+that bead's metadata, respectively; an absent continuation group is empty.
+
 Use no bead id except one from immediately preceding claim. If terminal calls
 do not retain shell variables, substitute the exact saved values; never update
 or close with an empty id. Never choose or assign continuation work.
@@ -40,18 +45,40 @@ the bead's failure contract and close it instead of idling.
 
 ## Close
 
-Honor bead's requested `gc.outcome` metadata. If no failure contract exists,
+`gc.outcome=pass|fail` is the run/step result; honor the bead's requested
+contract. `gc.work_outcome=shipped|no-op|blocked|abandoned` is the separate
+work record required for normal work beads:
+
+- `shipped`: committed a change that satisfies the bead. Also set
+  `gc.work_commit` to that commit's SHA and `gc.work_branch` to a branch
+  containing it. Create a named work branch first if HEAD is detached.
+- `no-op`: no change was needed (already satisfied or duplicate); omit commit
+  and branch metadata.
+- `blocked` or `abandoned`: work could not be completed; record the reason
+  and follow the bead's escalation contract.
+
+Do not substitute `gc.outcome` for `gc.work_outcome`. If no failure contract exists,
 record unrecoverable failure as `gc.outcome=fail` plus concise
 `gc.failure_class` and reason.
 
-Set required metadata before closing same claimed bead:
+Set required metadata before closing same claimed bead. Repeat
+`--set-metadata` once per `key=value` assignment. For a shipped change, from
+the worktree containing the verified commit:
 
 ```bash
+WORK_COMMIT=$(git rev-parse HEAD)
+WORK_BRANCH=$(git branch --show-current)
 gc bd update "$CLAIMED_BEAD_ID" \
   --set-metadata 'gc.outcome=pass' \
-  --set-metadata 'example.key=example-value'
+  --set-metadata 'gc.work_outcome=shipped' \
+  --set-metadata "gc.work_commit=$WORK_COMMIT" \
+  --set-metadata "gc.work_branch=$WORK_BRANCH"
 gc bd close "$CLAIMED_BEAD_ID"
 ```
+
+For work that needed no change, use `--set-metadata 'gc.outcome=pass'` and
+`--set-metadata 'gc.work_outcome=no-op'` on the update instead. Workflow-control
+beads use their step result contract; do not invent a shipped work record for them.
 
 Review findings, missing tests, or follow-up usually are output, not execution
 failure. If contract requests `gc.outcome=pass` plus verdict, use pass even for
@@ -71,8 +98,8 @@ After close, inspect `CLAIMED_CONTINUATION_GROUP` before another claim:
 
 - An empty continuation group is a hard session boundary. Run
   `gc runtime drain-ack` and exit so unrelated work starts with clean context.
-- For a non-empty group, run `gc gc claim` again unless the result contract
-  requires final drain. On `action=drain`, exit.
+- For a non-empty group, run `gc hook --claim --drain-ack --json` again unless
+  the result contract requires final drain. On `action=drain`, exit.
 
 Every successful claim result is authoritative. Execute it immediately even if
 its continuation group or root differs from the bead just closed; never drain

--- a/tests/test_gc_role_prompt_integration.py
+++ b/tests/test_gc_role_prompt_integration.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 import json
 import os
 from pathlib import Path
+import shlex
 import subprocess
 import textwrap
 
@@ -126,11 +127,16 @@ def assert_clean_worker_render(prompt: str, persona_heading: str) -> None:
     assert persona_heading in prompt
     assert prompt.count("# GC Role Worker") == 1
     assert '{{ template "gc-role-worker" . }}' not in prompt
-    assert "gc gc claim" in prompt
+    assert "gc hook --claim --drain-ack --json" in prompt
+    assert "gc gc claim" not in prompt
     assert "CLAIMED_BEAD_ID" in prompt
     assert "CLAIMED_ROOT_BEAD_ID" in prompt
     assert "CLAIMED_CONTINUATION_GROUP" in prompt
     assert 'gc bd update "$CLAIMED_BEAD_ID"' in prompt
+    assert "--set-metadata 'gc.outcome=pass'" in prompt
+    assert "--set-metadata 'gc.work_outcome=shipped'" in prompt
+    assert 'gc.work_commit=$WORK_COMMIT' in prompt
+    assert 'gc.work_branch=$WORK_BRANCH' in prompt
     assert "An empty continuation group is a hard session boundary" in prompt
 
 
@@ -155,6 +161,8 @@ def test_city_scoped_gascity_registers_claim_command_from_rig(
     ("city_binding", "pack_path", "agent", "persona_heading"),
     (
         ("gc", "gascity", "gc.implementation-worker", "# GC Role Worker"),
+        ("gascity", "gascity", "gc.implementation-worker", "# GC Role Worker"),
+        ("custom", "gascity", "gc.implementation-worker", "# GC Role Worker"),
         ("bmad", "bmad", "bmad.story-implementer", "# BMAD Story Implementer"),
         (
             "superpowers",
@@ -199,6 +207,16 @@ def test_role_prompts_render_public_worker_fragment(
 
     assert result.returncode == 0, result.stderr
     assert_clean_worker_render(result.stdout, persona_heading)
+
+    # The city command binding may differ from the rig role binding. Exercise
+    # the command actually rendered, without claiming work in the fixture.
+    claim = result.stdout.split("```bash\n", 1)[1].split("\n", 1)[0]
+    command = shlex.split(claim)
+    assert command == ["gc", "hook", "--claim", "--drain-ack", "--json"]
+    help_result = run_gc(gc_test_bin, workspace, *command[1:], "--help")
+    assert help_result.returncode == 0, help_result.stderr
+    assert "--claim" in help_result.stdout
+    assert "--drain-ack" in help_result.stdout
 
 
 def test_registered_claim_command_dispatches_store_aware_show_and_normalizes_json(


### PR DESCRIPTION
Workers in cities importing the pack as `gascity` receive `gc gc claim`, which is not a registered command there. The close example also records only `gc.outcome`, leaving the separate work record absent.

Use the built-in `gc hook --claim --drain-ack --json` for initial and continuation claims. Read missing continuation/root fields from the claimed bead metadata. Explain `gc.outcome=pass|fail` versus `gc.work_outcome=shipped|no-op|blocked|abandoned`, and show a shipped commit with one assignment per repeated `--set-metadata` flag. Update the README and exercise prompt rendering with `gc`, `gascity`, and custom aliases, plus the existing derived-pack personas.

Validation:

- `gc lint gascity` and `gc lint gascity/roles`: passed.
- `GC_TEST_BIN=/Users/tailor512/.local/bin/gc python -m pytest tests/test_gc_role_prompt_integration.py gascity/tests/test_formula_assets.py -q`: 104 passed, 5,968 subtests passed (isolated Python environment; managed-session routing variables unset).
- Rendered Citadel's live worker prime before the change; rendered the modified pack in an isolated city with the same city=`gascity`, rig roles=`gc` alias layout. Executed the resulting command in the assigned session: exit 0, `action=work`, the existing assignment returned.
- `git diff --check`: passed.

Before:

```bash
gc gc claim
# Close example:
gc bd update "$CLAIMED_BEAD_ID" \
  --set-metadata 'gc.outcome=pass' \
  --set-metadata 'example.key=example-value'
```

After:

```bash
gc hook --claim --drain-ack --json
# Close example, after committing the verified change:
WORK_COMMIT=$(git rev-parse HEAD)
WORK_BRANCH=$(git branch --show-current)
gc bd update "$CLAIMED_BEAD_ID" \
  --set-metadata 'gc.outcome=pass' \
  --set-metadata 'gc.work_outcome=shipped' \
  --set-metadata "gc.work_commit=$WORK_COMMIT" \
  --set-metadata "gc.work_branch=$WORK_BRANCH"
```

Work item: gp-pkir. Review class: QUICK. No live pack pins or running-city configuration changed.

Codex QUICK review: **CLEAN**. The review confirmed the claim command, metadata fallback, and separate work-record close contract.
