### PR TITLE
feat(gascity): add isolated Codex gate helper and worker guidance

### DIFF
--- a/docs/ops/citadel-codex-gates.md
+++ b/docs/ops/citadel-codex-gates.md
@@ -64,8 +64,11 @@ test, so both helper modes use exec's separate final-answer file.
 The caller's output file receives that answer; `FILE.log` holds the transcript.
 The helper accepts exactly one final standalone `VERDICT: CLEAN` or
 `VERDICT: BLOCK` line. Exit codes are 0 for CLEAN, 1 for BLOCK, 2 for invalid
-verdict/usage; Codex invocation failures retain their exit status. A stale CLEAN
-answer is cleared before each invocation. Commit changes before review.
+verdict/usage; Codex invocation failures retain their exit status and leave the
+answer file empty. A stale CLEAN answer is cleared before each invocation.
+Review mode rejects empty committed deltas and worktrees with staged, modified,
+or untracked files before invoking Codex. Commit changes before review and keep
+prompt/output files outside the reviewed worktree.
 
 Codex QUICK reviews supplement the required Fable adversarial review for
 Codex-built changes. Publishing a PR does not authorize merging it.

--- a/docs/ops/citadel-codex-gates.md
+++ b/docs/ops/citadel-codex-gates.md
@@ -1,0 +1,85 @@
+# Citadel Codex gates (gp-mj2q)
+
+Afik approved the isolated profile and gate rollout on 2026-09-06
+(message 1788737744.207359): “we should always use codex with astra”.
+Use the city profile with `gpt-6-astra` and `xhigh` reasoning. Existing default
+profile settings are preserved; the default model remains `gpt-5.6-sol`.
+
+## Profile compatibility and measurements
+
+Codex CLI 0.153.3 requires `~/.codex/city.config.toml` for `-p city`.
+It rejects a same-name legacy `[profiles.city]` table in `config.toml`.
+The requested legacy table was tested and removed; the base file is
+byte-identical to its backup, `~/.codex/config.toml.bak-20260906-185000`.
+See [OpenAI profile documentation](https://learn.chatgpt.com/docs/config-file/config-advanced#profiles)
+and the installed CLI's `codex --help`.
+
+The city overlay sets `model = "gpt-6-astra"` and
+`model_reasoning_effort = "xhigh"`. It disables `features.plugins`,
+`features.apps`, `features.recommended_plugins`, and `features.remote_plugin`,
+and sets `enabled = false` for all eleven configured plugins and both configured
+MCP servers (`node_repl` and `computer-use`). The system and user skills remain
+available. Future explicitly configured MCP servers also need a disabled entry
+in this overlay.
+
+Measured in `/tmp` on 2026-09-06, before shortening ego-browser's description:
+
+| Fixed prompt: `reply OK` | Default | City |
+| --- | ---: | ---: |
+| Preamble characters | 19,176 | 11,966 |
+| Skills block characters | 7,210 | 3,554 |
+| Plugin catalogue characters | 3,387 | 0 |
+| Input tokens | 15,679 | 13,125 |
+| Cached input tokens | 11,136 | 11,136 |
+
+Both runs returned `OK`. Preamble size is the sum of model-visible text lengths
+from `codex [-p city] -C /tmp debug prompt-input 'reply OK'`, excluding the last
+user prompt, including the environment message. It excludes hidden model base
+instructions and tool schemas. Tokens are the reported `turn.completed.usage`
+from `codex [-p city] exec --skip-git-repo-check -C /tmp --json 'reply OK'` with
+stdin redirected from `/dev/null`. The profile comparison also changes the model;
+it is an observed before/after result, not a tokenizer-controlled benchmark.
+
+Raw local evidence is in `~/city/assets/ops/gp-mj2q/`. `codex -p city mcp list`
+confirmed both servers disabled. The rendered city prompt has no recommended
+plugin catalogue or plugin skill entries.
+
+## Gate helper
+
+Install `gascity/assets/scripts/codex-gate.sh` at
+`~/city/assets/ops/mayor-tools/codex-gate.sh`. Provision the city profile first.
+
+```bash
+codex-gate.sh review --base origin/main -C "$REPO" --output "$REVIEW_OUTPUT"
+codex-gate.sh exec "$PROMPT_FILE" -C "$REPO" --output "$REVIEW_OUTPUT"
+```
+
+Both modes use `-p city -m gpt-6-astra`, read-only execution, `-C`,
+`--skip-git-repo-check`, and `/dev/null` stdin. `--model MODEL` explicitly
+overrides both the normal model and the optional review model. Review mode
+resolves REF and HEAD to commit IDs, computes their merge base, and asks
+`codex exec` for a QUICK review of that immutable delta. Native `codex review`
+formats its own findings and did not honor the requested VERDICT line in a live
+test, so both helper modes use exec's separate final-answer file.
+The caller's output file receives that answer; `FILE.log` holds the transcript.
+The helper accepts exactly one final standalone `VERDICT: CLEAN` or
+`VERDICT: BLOCK` line. Exit codes are 0 for CLEAN, 1 for BLOCK, 2 for invalid
+verdict/usage; Codex invocation failures retain their exit status. A stale CLEAN
+answer is cleared before each invocation. Commit changes before review.
+
+Codex QUICK reviews supplement the required Fable adversarial review for
+Codex-built changes. Publishing a PR does not authorize merging it.
+
+## Local ego-browser override and provider handoff
+
+The ego-browser description is now `Use when a task needs a real browser session
+on citadel`: 977 → 55 characters. `~/.agents/skills/ego-browser` is a local
+directory with the edited SKILL.md and links to the app's other resources.
+The body and ego app's source file are unchanged. The original directory symlink
+was saved at `~/.agents/ego-browser.bak-20260906-185347`, outside skill discovery.
+Claude-side skills, including superpowers, were not modified.
+
+The mayor owns `city.toml`. Its `codex-astra` provider already pins the model;
+its command and resume command still need `-p city` to select the new profile.
+The plain `codex` provider also needs the explicit Astra model and city profile
+if it is used for city work. No city.toml change is included in this task.

--- a/gascity/assets/scripts/codex-gate.sh
+++ b/gascity/assets/scripts/codex-gate.sh
@@ -57,7 +57,14 @@ if [[ "$mode" == review ]]; then
   # requested VERDICT line. Use exec with the same committed merge-base delta.
   base_commit=$(git -C "$repo" rev-parse --verify --end-of-options "${base}^{commit}") || fail 'invalid review base'
   merge_base=$(git -C "$repo" merge-base "$base_commit" HEAD) || fail 'no merge base with HEAD'
-  head_commit=$(git -C "$repo" rev-parse --verify HEAD)
+  head_commit=$(git -C "$repo" rev-parse --verify HEAD) || fail 'HEAD must resolve to a commit'
+  worktree_status=$(git -C "$repo" status --porcelain --untracked-files=all) || fail 'cannot inspect worktree'
+  [[ -z "$worktree_status" ]] || fail 'worktree has uncommitted or untracked changes; commit before review'
+  if git -C "$repo" diff --quiet "$merge_base" "$head_commit"; then
+    fail 'review requires a nonempty committed delta'
+  else
+    [[ $? -eq 1 ]] || fail 'cannot inspect review delta'
+  fi
   prompt="QUICK code review of committed changes in this repository. Inspect git diff $merge_base $head_commit and the relevant surrounding code. Review only that delta; the immutable base and head are $merge_base and $head_commit. Report actionable correctness and regression findings."
 else
   [[ -z "$base" ]] || fail '--base is only valid for review'
@@ -66,11 +73,12 @@ else
   prompt=$(cat -- "$prompt_file")
 fi
 [[ -d "$(dirname -- "$output")" ]] || fail 'output directory must exist'
+[[ ! -d "$output" ]] || fail 'output must name a file'
 output="$(cd -- "$(dirname -- "$output")" && pwd)/$(basename -- "$output")"
 answer=$(mktemp "${output}.answer.XXXXXX")
 trap 'rm -f -- "$answer"' EXIT
 # Clear any old answer so a failed run cannot leave a stale CLEAN result.
-: > "$output"
+: > "$output" || fail 'cannot write output'
 args+=(exec --skip-git-repo-check --json --output-last-message "$answer")
 args+=(-- "$prompt"$'\n\n'"$contract")
 result=0

--- a/gascity/assets/scripts/codex-gate.sh
+++ b/gascity/assets/scripts/codex-gate.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# gp-mj2q — Afik, 2026-09-06: "we should always use codex with astra";
+# approved the isolated city profile and gate rollout (1788737744.207359).
+# Install on citadel as assets/ops/mayor-tools/codex-gate.sh.
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  codex-gate.sh review --base REF -C REPO --output FILE [--model MODEL]
+  codex-gate.sh exec PROMPT_FILE -C REPO --output FILE [--model MODEL]
+
+Requires the city Codex profile (city.config.toml on Codex 0.153.3).
+Writes the final answer to FILE and the execution transcript to FILE.log.
+Exit: 0 = CLEAN, 1 = BLOCK, 2 = missing/invalid verdict or usage error;
+other Codex failures retain their exit status. Commit before review.
+USAGE
+}
+fail() { printf 'codex-gate: %s\n' "$*" >&2; exit 2; }
+[[ $# -gt 0 ]] || { usage >&2; exit 2; }
+mode=$1; shift
+case "$mode" in
+  -h|--help) usage; exit 0 ;;
+  review|exec) ;;
+  *) fail "unknown mode: $mode" ;;
+esac
+model=gpt-6-astra
+repo= output= base= prompt_file=
+if [[ "$mode" == exec ]]; then
+  [[ $# -gt 0 && "$1" != -* ]] || fail 'exec requires PROMPT_FILE'
+  prompt_file=$1; shift
+fi
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base|-C|--output|--model)
+      [[ $# -ge 2 && -n "$2" ]] || fail "missing value for $1"
+      case "$1" in
+        --base) base=$2 ;;
+        -C) repo=$2 ;;
+        --output) output=$2 ;;
+        --model) model=$2 ;;
+      esac
+      shift 2 ;;
+    *) fail "unknown argument: $1" ;;
+  esac
+done
+[[ -n "$repo" && -d "$repo" ]] || fail '-C must name an existing directory'
+[[ -n "$output" ]] || fail '--output is required'
+[[ "$model" != *'"'* && "$model" != *\\* && "$model" != *$'\n'* ]] || fail 'invalid model name'
+contract='Read-only gate. Do not edit files. Report actionable findings with severity and file:line. End the final answer with exactly one standalone line: VERDICT: CLEAN if there are no critical or major findings, otherwise VERDICT: BLOCK. Do not put the verdict in a code fence or repeat it.'
+args=(-p city -m "$model" -a never -s read-only -C "$repo")
+# review has its own optional model setting; keep --model authoritative there too.
+args+=(-c "review_model=\"$model\"" -c "developer_instructions=\"$contract\"")
+if [[ "$mode" == review ]]; then
+  [[ -n "$base" ]] || fail 'review requires --base REF'
+  # Native `codex review` renders its own finding format and does not honor a
+  # requested VERDICT line. Use exec with the same committed merge-base delta.
+  base_commit=$(git -C "$repo" rev-parse --verify --end-of-options "${base}^{commit}") || fail 'invalid review base'
+  merge_base=$(git -C "$repo" merge-base "$base_commit" HEAD) || fail 'no merge base with HEAD'
+  head_commit=$(git -C "$repo" rev-parse --verify HEAD)
+  prompt="QUICK code review of committed changes in this repository. Inspect git diff $merge_base $head_commit and the relevant surrounding code. Review only that delta; the immutable base and head are $merge_base and $head_commit. Report actionable correctness and regression findings."
+else
+  [[ -z "$base" ]] || fail '--base is only valid for review'
+  [[ -f "$prompt_file" && -r "$prompt_file" && -s "$prompt_file" ]] || fail 'prompt file must be readable and nonempty'
+  [[ ! "$prompt_file" -ef "$output" && ! "$prompt_file" -ef "$output.log" ]] || fail 'output must not overwrite the prompt'
+  prompt=$(cat -- "$prompt_file")
+fi
+[[ -d "$(dirname -- "$output")" ]] || fail 'output directory must exist'
+output="$(cd -- "$(dirname -- "$output")" && pwd)/$(basename -- "$output")"
+answer=$(mktemp "${output}.answer.XXXXXX")
+trap 'rm -f -- "$answer"' EXIT
+# Clear any old answer so a failed run cannot leave a stale CLEAN result.
+: > "$output"
+args+=(exec --skip-git-repo-check --json --output-last-message "$answer")
+args+=(-- "$prompt"$'\n\n'"$contract")
+result=0
+codex "${args[@]}" < /dev/null > "$output.log" 2>&1 || result=$?
+# Failed invocations never publish an answer that might look like CLEAN.
+[[ "$result" -eq 0 ]] || exit "$result"
+cat -- "$answer" > "$output"
+# Read only the final answer, never echoed prompts or tool output in the log.
+verdict=$(awk '
+  NF {last=$0}
+  {
+    candidate=$0
+    sub(/^ {0,3}/, "", candidate)
+    if (candidate ~ /^```/ || candidate ~ /^~~~/) {
+      marker=substr(candidate, 1, 1)
+      tail=candidate
+      if (marker == "`") sub(/^`+/, "", tail)
+      else sub(/^~+/, "", tail)
+      width=length(candidate)-length(tail)
+      if (fence == "") {fence=marker; fence_width=width}
+      else if (marker == fence && width >= fence_width && tail ~ /^[ \t]*$/) fence=""
+    }
+  }
+  /^VERDICT:/ {count++; line=$0; in_fence=(fence != "")}
+  END {if (count == 1 && !in_fence && line == last) print line}
+' "$output")
+case "$verdict" in
+  'VERDICT: CLEAN') exit 0 ;;
+  'VERDICT: BLOCK') exit 1 ;;
+  *) fail "missing or invalid anchored verdict in $output (see $output.log)" ;;
+esac

--- a/gascity/template-fragments/gc-role-worker.template.md
+++ b/gascity/template-fragments/gc-role-worker.template.md
@@ -38,6 +38,24 @@ Never ask a human whether to proceed after a successful claim. Do not stop for
 confirmation in a headless workflow. If required task input is missing, record
 the bead's failure contract and close it instead of idling.
 
+## Codex gates
+
+When a bead calls for a Codex gate on citadel, commit the delta, then use the
+installed helper so the final verdict is validated:
+
+```bash
+"$GC_CITY_PATH/assets/ops/mayor-tools/codex-gate.sh" review \
+  --base "$REVIEW_BASE" -C "$REPO_DIR" --output "$REVIEW_OUTPUT" \
+  --model gpt-6-astra
+```
+
+The helper invokes `codex -p city -m gpt-6-astra exec --skip-git-repo-check`
+with read-only execution and stdin from `/dev/null`. For a prompt-file gate,
+replace `review --base "$REVIEW_BASE"` with `exec "$PROMPT_FILE"`.
+Provision the `city` profile and helper on the host before using these commands.
+Honor the bead's reviewer requirements: Codex-built changes still need a Fable
+adversarial review when the bead requests the cross-model gate.
+
 ## Close
 
 Honor bead's requested `gc.outcome` metadata. If no failure contract exists,

--- a/gascity/tests/test_codex_gate.py
+++ b/gascity/tests/test_codex_gate.py
@@ -21,29 +21,40 @@ print('VERDICT: CLEAN')  # A transcript match must never pass the gate.
 sys.exit(int(os.environ.get('CODEX_EXIT', '0')))
 ''')
     binary.chmod(0o755)
-    subprocess.run(['git', 'init', '-q', str(tmp_path)], check=True)
-    subprocess.run(['git', '-C', str(tmp_path), '-c', 'user.name=Gate Test',
+    repo = tmp_path / 'repo'
+    subprocess.run(['git', 'init', '-q', str(repo)], check=True)
+    source = repo / 'source.txt'
+    source.write_text('base\n')
+    subprocess.run(['git', '-C', str(repo), 'add', 'source.txt'], check=True)
+    subprocess.run(['git', '-C', str(repo), '-c', 'user.name=Gate Test',
                     '-c', 'user.email=gate@example.invalid', 'commit',
-                    '--allow-empty', '-qm', 'base'], check=True)
-    subprocess.run(['git', '-C', str(tmp_path), 'branch', 'review-base'], check=True)
-    subprocess.run(['git', '-C', str(tmp_path), '-c', 'user.name=Gate Test',
+                    '-qm', 'base'], check=True)
+    subprocess.run(['git', '-C', str(repo), 'branch', 'review-base'], check=True)
+    source.write_text('delta\n')
+    subprocess.run(['git', '-C', str(repo), '-c', 'user.name=Gate Test',
                     '-c', 'user.email=gate@example.invalid', 'commit',
-                    '--allow-empty', '-qm', 'delta'], check=True)
+                    '-qam', 'delta'], check=True)
     prompt = tmp_path / 'prompt file.txt'
     prompt.write_text('Review a literal `command` and $(touch nope).\nSecond line.')
     output = tmp_path / 'answer file.txt'
     capture = tmp_path / 'capture.json'
 
-    def run(mode='exec', *, answer='VERDICT: CLEAN\n', exit_code=0, extra=()):
+    def run(mode='exec', *, answer='VERDICT: CLEAN\n', exit_code=0, extra=(), dirty=None):
+        if dirty == 'untracked':
+            (repo / 'new.txt').write_text('unreviewed\n')
+        elif dirty:
+            source.write_text('unreviewed\n')
+            if dirty == 'staged':
+                subprocess.run(['git', '-C', str(repo), 'add', 'source.txt'], check=True)
         args = ['exec', str(prompt)] if mode == 'exec' else ['review', '--base', 'review-base']
         result = subprocess.run(
-            ['bash', str(SCRIPT), *args, '-C', str(tmp_path), '--output', str(output), *extra],
+            ['bash', str(SCRIPT), *args, '-C', str(repo), '--output', str(output), *extra],
             input='inherited stdin must not reach Codex', text=True, capture_output=True,
             env={**os.environ, 'PATH': str(tmp_path) + os.pathsep + os.environ['PATH'],
                  'CAPTURE': str(capture), 'ANSWER': answer, 'CODEX_EXIT': str(exit_code)},
             timeout=10,
         )
-        return result, json.loads(capture.read_text()), output
+        return result, json.loads(capture.read_text()) if capture.exists() else None, output
     return run
 
 
@@ -63,8 +74,9 @@ def test_city_astra_invocation_and_stdin(gate, mode):
     assert output.read_text() == 'VERDICT: CLEAN\n'
     if mode == 'review':
         assert 'QUICK code review of committed changes' in args[-1]
-        base = subprocess.check_output(['git', '-C', str(output.parent), 'rev-parse', 'review-base'], text=True).strip()
-        head = subprocess.check_output(['git', '-C', str(output.parent), 'rev-parse', 'HEAD'], text=True).strip()
+        repo = args[args.index('-C') + 1]
+        base = subprocess.check_output(['git', '-C', repo, 'rev-parse', 'review-base'], text=True).strip()
+        head = subprocess.check_output(['git', '-C', repo, 'rev-parse', 'HEAD'], text=True).strip()
         assert base != head
         assert f'git diff {base} {head}' in args[-1]
         assert 'review-base' not in args[-1]
@@ -105,3 +117,18 @@ def test_cli_failure_cannot_pass_or_reuse_stale_verdict(gate):
     result, _, _ = gate(answer='VERDICT: CLEAN\n', exit_code=7)
     assert result.returncode == 7
     assert output.read_text() == ''
+
+
+def test_review_rejects_empty_delta_before_calling_codex(gate):
+    result, call, _ = gate('review', extra=('--base', 'HEAD'))
+    assert result.returncode == 2
+    assert 'nonempty committed delta' in result.stderr
+    assert call is None
+
+
+@pytest.mark.parametrize('dirty', ['untracked', 'modified', 'staged'])
+def test_review_rejects_uncommitted_work_before_calling_codex(gate, dirty):
+    result, call, _ = gate('review', dirty=dirty)
+    assert result.returncode == 2
+    assert 'uncommitted or untracked changes' in result.stderr
+    assert call is None

--- a/gascity/tests/test_codex_gate.py
+++ b/gascity/tests/test_codex_gate.py
@@ -1,0 +1,107 @@
+"""Gate contract checks with a fake CLI; no network or model usage."""
+import json
+import os
+from pathlib import Path
+import subprocess
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[1] / 'assets/scripts/codex-gate.sh'
+
+
+@pytest.fixture
+def gate(tmp_path):
+    binary = tmp_path / 'codex'
+    binary.write_text('''#!/usr/bin/env python3
+import json, os, pathlib, sys
+args = sys.argv[1:]
+pathlib.Path(os.environ['CAPTURE']).write_text(json.dumps({'args': args, 'stdin': sys.stdin.read()}))
+pathlib.Path(args[args.index('--output-last-message')+1]).write_text(os.environ.get('ANSWER', 'VERDICT: CLEAN\\n'))
+print('VERDICT: CLEAN')  # A transcript match must never pass the gate.
+sys.exit(int(os.environ.get('CODEX_EXIT', '0')))
+''')
+    binary.chmod(0o755)
+    subprocess.run(['git', 'init', '-q', str(tmp_path)], check=True)
+    subprocess.run(['git', '-C', str(tmp_path), '-c', 'user.name=Gate Test',
+                    '-c', 'user.email=gate@example.invalid', 'commit',
+                    '--allow-empty', '-qm', 'base'], check=True)
+    subprocess.run(['git', '-C', str(tmp_path), 'branch', 'review-base'], check=True)
+    subprocess.run(['git', '-C', str(tmp_path), '-c', 'user.name=Gate Test',
+                    '-c', 'user.email=gate@example.invalid', 'commit',
+                    '--allow-empty', '-qm', 'delta'], check=True)
+    prompt = tmp_path / 'prompt file.txt'
+    prompt.write_text('Review a literal `command` and $(touch nope).\nSecond line.')
+    output = tmp_path / 'answer file.txt'
+    capture = tmp_path / 'capture.json'
+
+    def run(mode='exec', *, answer='VERDICT: CLEAN\n', exit_code=0, extra=()):
+        args = ['exec', str(prompt)] if mode == 'exec' else ['review', '--base', 'review-base']
+        result = subprocess.run(
+            ['bash', str(SCRIPT), *args, '-C', str(tmp_path), '--output', str(output), *extra],
+            input='inherited stdin must not reach Codex', text=True, capture_output=True,
+            env={**os.environ, 'PATH': str(tmp_path) + os.pathsep + os.environ['PATH'],
+                 'CAPTURE': str(capture), 'ANSWER': answer, 'CODEX_EXIT': str(exit_code)},
+            timeout=10,
+        )
+        return result, json.loads(capture.read_text()), output
+    return run
+
+
+@pytest.mark.parametrize('mode', ['exec', 'review'])
+def test_city_astra_invocation_and_stdin(gate, mode):
+    result, call, output = gate(mode)
+    assert result.returncode == 0, result.stderr
+    args = call['args']
+    assert args[args.index('-p') + 1] == 'city'
+    assert args[args.index('-m') + 1] == 'gpt-6-astra'
+    assert 'review_model="gpt-6-astra"' in args
+    assert args[args.index('-s') + 1] == 'read-only'
+    assert args[args.index('-a') + 1] == 'never'
+    assert any(a.startswith('developer_instructions=') for a in args)
+    assert '--skip-git-repo-check' in args and '-C' in args
+    assert call['stdin'] == ''
+    assert output.read_text() == 'VERDICT: CLEAN\n'
+    if mode == 'review':
+        assert 'QUICK code review of committed changes' in args[-1]
+        base = subprocess.check_output(['git', '-C', str(output.parent), 'rev-parse', 'review-base'], text=True).strip()
+        head = subprocess.check_output(['git', '-C', str(output.parent), 'rev-parse', 'HEAD'], text=True).strip()
+        assert base != head
+        assert f'git diff {base} {head}' in args[-1]
+        assert 'review-base' not in args[-1]
+    else:
+        assert '$(touch nope).\nSecond line.' in args[-1]
+        assert not (output.parent / 'nope').exists()
+
+
+@pytest.mark.parametrize(('answer', 'expected'), [
+    ('VERDICT: BLOCK\n', 1),
+    ('No verdict\n', 2),
+    ('quoted VERDICT: CLEAN\n', 2),
+    ('VERDICT: CLEAN\nVERDICT: BLOCK\n', 2),
+    ('VERDICT: CLEANISH\n', 2),
+    ('VERDICT: CLEAN\nMore findings\n', 2),
+    ('```\nVERDICT: CLEAN\n```\n', 2),
+    ('```\nVERDICT: CLEAN\n', 2),
+    ('   ~~~text\nVERDICT: CLEAN\n', 2),
+    ('````\n```\nVERDICT: CLEAN\n', 2),
+    ('```\n~~~\nVERDICT: CLEAN\n', 2),
+    ('```text\nExample code\n```\nVERDICT: CLEAN\n', 0),
+])
+def test_only_one_exact_anchored_final_verdict_passes(gate, answer, expected):
+    result, _, _ = gate(answer=answer)
+    assert result.returncode == expected
+
+
+def test_model_override_pins_review_model_too(gate):
+    result, call, _ = gate('review', extra=('--model', 'test-model'))
+    assert result.returncode == 0
+    assert call['args'][call['args'].index('-m') + 1] == 'test-model'
+    assert 'review_model="test-model"' in call['args']
+
+
+def test_cli_failure_cannot_pass_or_reuse_stale_verdict(gate):
+    result, _, output = gate()
+    assert result.returncode == 0
+    result, _, _ = gate(answer='VERDICT: CLEAN\n', exit_code=7)
+    assert result.returncode == 7
+    assert output.read_text() == ''

--- a/tests/test_gc_role_prompt_integration.py
+++ b/tests/test_gc_role_prompt_integration.py
@@ -132,6 +132,8 @@ def assert_clean_worker_render(prompt: str, persona_heading: str) -> None:
     assert "CLAIMED_CONTINUATION_GROUP" in prompt
     assert 'gc bd update "$CLAIMED_BEAD_ID"' in prompt
     assert "An empty continuation group is a hard session boundary" in prompt
+    assert '"$GC_CITY_PATH/assets/ops/mayor-tools/codex-gate.sh" review' in prompt
+    assert "codex -p city -m gpt-6-astra exec --skip-git-repo-check" in prompt
 
 
 def test_city_scoped_gascity_registers_claim_command_from_rig(


### PR DESCRIPTION
Codex city gates inherited the desktop profile's plugins, MCP servers, and default model. Add a reusable helper that selects `-p city -m gpt-6-astra`, disconnects stdin, runs read-only, and validates an anchored verdict from the final answer. Workers invoke the installed helper through `$GC_CITY_PATH`, so the command works outside the pack checkout.

The helper supports `review --base REF` and `exec PROMPT_FILE`, with `-C REPO`, `--output FILE`, and optional `--model`. Review mode resolves a committed merge-base/HEAD delta and uses `codex exec`: native review's formatter did not emit the requested verdict in a live check. Tests cover literal multiline prompts, disconnected stdin, model overrides, failed runs and stale answers, relative output handling in live smoke, and rejection of missing, conflicting, transcript-only, or fenced verdicts. Review mode also refuses empty deltas and staged/modified/untracked files before model invocation.

Local rollout evidence is documented in `docs/ops/citadel-codex-gates.md`. Codex 0.153.3 uses `city.config.toml`; the default config is byte-identical to its backup. The city overlay disables all configured plugins and both MCP servers, plus plugin discovery. Fixed-prompt measurements before the ego-browser edit: **19,176 → 11,966 preamble characters; 15,679 → 13,125 input tokens**. The local ego-browser description is **977 → 55 characters**; its body and app-owned source are unchanged. Preamble after both edits: 11,044 characters.

Validation: 28 directly relevant helper/real CLI worker-render tests pass; `gc lint gascity`, `gc lint gascity/roles`, `bash -n`, `git diff --check`, and skill validation pass. Default/city `reply OK`, real helper exec smoke, and registry validation pass. The broader local suite had 102 passing tests and 5,917 passing subtests, with two pre-existing 2-second macOS claim-wrapper timeouts also reproduced on unchanged upstream baseline; the claim wrapper is untouched. Codex QUICK r4 (full change) and r5 (guard follow-up) are CLEAN; Fable 5.1 adversarial r5 is CLEAN with no critical or major findings. Non-blocking minor review notes are retained in the local evidence bundle.

Work bead: gp-mj2q. Afik's approval: 1788737744.207359. City.toml provider selection remains the mayor's handoff. No merge or live pack-pin change is authorized by this PR.

Citadel fork PR: https://github.com/aphexcx/gascity-packs-prs/pull/29
