### PR TITLE
fix: replace deprecated formula contracts

### DIFF
--- a/bmad/formulas/bmad-build.formula.toml
+++ b/bmad/formulas/bmad-build.formula.toml
@@ -7,9 +7,11 @@ epics/stories so it matches the upstream workflow.
 """
 formula = "bmad-build"
 version = 1
-contract = "graph.v2"
 extends = ["build-base"]
 target_required = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "bmad-build"

--- a/bmad/formulas/bmad-code-review-flow.formula.toml
+++ b/bmad/formulas/bmad-code-review-flow.formula.toml
@@ -7,7 +7,9 @@ review lanes, including gap analysis, with synthesis and fix application.
 formula = "bmad-code-review-flow"
 type = "expansion"
 version = 1
-contract = "graph.v2"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/bmad/formulas/bmad-decomposition.formula.toml
+++ b/bmad/formulas/bmad-decomposition.formula.toml
@@ -3,10 +3,12 @@ BMAD implementation of the decomposition-base methodology contract.
 """
 formula = "bmad-decomposition"
 version = 1
-contract = "graph.v2"
 extends = ["decomposition-base"]
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [[steps]]
 id = "decompose"

--- a/bmad/formulas/bmad-fix-loop.formula.toml
+++ b/bmad/formulas/bmad-fix-loop.formula.toml
@@ -3,10 +3,12 @@ BMAD implementation of the fix-loop-base methodology contract.
 """
 formula = "bmad-fix-loop"
 version = 1
-contract = "graph.v2"
 extends = ["fix-loop-base"]
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_formula]

--- a/bmad/formulas/bmad-implementation.formula.toml
+++ b/bmad/formulas/bmad-implementation.formula.toml
@@ -3,10 +3,12 @@ BMAD implementation of the public implement methodology contract.
 """
 formula = "bmad-implementation"
 version = 1
-contract = "graph.v2"
 extends = ["implement"]
 target_required = true
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/bmad/formulas/bmad-planning.formula.toml
+++ b/bmad/formulas/bmad-planning.formula.toml
@@ -3,10 +3,12 @@ BMAD implementation of the planning-base methodology contract.
 """
 formula = "bmad-planning"
 version = 1
-contract = "graph.v2"
 extends = ["planning-base"]
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [[steps]]
 id = "requirements"

--- a/bmad/formulas/bmad-review.formula.toml
+++ b/bmad/formulas/bmad-review.formula.toml
@@ -3,11 +3,13 @@ BMAD implementation of the code-review-base methodology contract.
 """
 formula = "bmad-review"
 version = 1
-contract = "graph.v2"
 extends = ["code-review-base"]
 target_required = false
 internal = true
 mode = "report"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/bmad/formulas/bmad-story-development-item.formula.toml
+++ b/bmad/formulas/bmad-story-development-item.formula.toml
@@ -6,11 +6,13 @@ shared drain lifecycle and serializes item work.
 """
 formula = "bmad-story-development-item"
 version = 1
-contract = "graph.v2"
 extends = ["do-work-item"]
 target_required = true
 internal = true
 single_lane = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [[steps]]
 id = "implement-item"

--- a/bmad/formulas/bmad-story-development.formula.toml
+++ b/bmad/formulas/bmad-story-development.formula.toml
@@ -6,9 +6,11 @@ implementation and review lanes.
 """
 formula = "bmad-story-development"
 version = 1
-contract = "graph.v2"
 extends = ["do-work"]
 target_required = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [[steps]]
 id = "implement"

--- a/compound-engineering/formulas/compound-build.formula.toml
+++ b/compound-engineering/formulas/compound-build.formula.toml
@@ -7,9 +7,11 @@ is a finalize-stage behavior.
 """
 formula = "compound-build"
 version = 1
-contract = "graph.v2"
 extends = ["build-base"]
 target_required = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "compound-build"

--- a/compound-engineering/formulas/compound-code-review.formula.toml
+++ b/compound-engineering/formulas/compound-code-review.formula.toml
@@ -10,7 +10,9 @@ invoked.
 formula = "compound-code-review"
 type = "expansion"
 version = 1
-contract = "graph.v2"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/compound-engineering/formulas/compound-decomposition.formula.toml
+++ b/compound-engineering/formulas/compound-decomposition.formula.toml
@@ -3,10 +3,12 @@ Compound Engineering implementation of the decomposition-base methodology contra
 """
 formula = "compound-decomposition"
 version = 1
-contract = "graph.v2"
 extends = ["decomposition-base"]
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [[steps]]
 id = "decompose"

--- a/compound-engineering/formulas/compound-fix-loop.formula.toml
+++ b/compound-engineering/formulas/compound-fix-loop.formula.toml
@@ -3,10 +3,12 @@ Compound Engineering implementation of the fix-loop-base methodology contract.
 """
 formula = "compound-fix-loop"
 version = 1
-contract = "graph.v2"
 extends = ["fix-loop-base"]
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_formula]

--- a/compound-engineering/formulas/compound-implementation.formula.toml
+++ b/compound-engineering/formulas/compound-implementation.formula.toml
@@ -3,10 +3,12 @@ Compound Engineering implementation of the public implement methodology contract
 """
 formula = "compound-implementation"
 version = 1
-contract = "graph.v2"
 extends = ["implement"]
 target_required = true
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/compound-engineering/formulas/compound-plan-review.formula.toml
+++ b/compound-engineering/formulas/compound-plan-review.formula.toml
@@ -8,7 +8,9 @@ all execution is routed through Gas City `gc.*` agents.
 formula = "compound-plan-review"
 type = "expansion"
 version = 1
-contract = "graph.v2"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [[template]]
 id = "{target}.setup-compound-plan-review"

--- a/compound-engineering/formulas/compound-planning.formula.toml
+++ b/compound-engineering/formulas/compound-planning.formula.toml
@@ -3,10 +3,12 @@ Compound Engineering implementation of the planning-base methodology contract.
 """
 formula = "compound-planning"
 version = 1
-contract = "graph.v2"
 extends = ["planning-base"]
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [[steps]]
 id = "requirements"

--- a/compound-engineering/formulas/compound-resolution.formula.toml
+++ b/compound-engineering/formulas/compound-resolution.formula.toml
@@ -8,7 +8,9 @@ and records a single build-base finalize result.
 formula = "compound-resolution"
 type = "expansion"
 version = 1
-contract = "graph.v2"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [[template]]
 id = "{target}.inventory-artifacts"

--- a/compound-engineering/formulas/compound-review.formula.toml
+++ b/compound-engineering/formulas/compound-review.formula.toml
@@ -3,11 +3,13 @@ Compound Engineering implementation of the code-review-base methodology contract
 """
 formula = "compound-review"
 version = 1
-contract = "graph.v2"
 extends = ["code-review-base"]
 target_required = false
 internal = true
 mode = "report"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/compound-engineering/formulas/compound-work-item.formula.toml
+++ b/compound-engineering/formulas/compound-work-item.formula.toml
@@ -6,11 +6,13 @@ without creating an isolated source-anchor worktree.
 """
 formula = "compound-work-item"
 version = 1
-contract = "graph.v2"
 extends = ["do-work-item"]
 target_required = true
 internal = true
 single_lane = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/compound-engineering/formulas/compound-work.formula.toml
+++ b/compound-engineering/formulas/compound-work.formula.toml
@@ -6,9 +6,11 @@ top of Gas City's source-anchor worktree lifecycle.
 """
 formula = "compound-work"
 version = 1
-contract = "graph.v2"
 extends = ["do-work"]
 target_required = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/gascity/README.md
+++ b/gascity/README.md
@@ -168,7 +168,7 @@ records the entrypoint it started from, and refuses to finalize as a pass when
 review or repair is still blocked — see "Choosing an entrypoint" above for
 which one matches the artifacts you have.
 
-Every formula in this pack uses `contract = "graph.v2"`. Targeted formulas take
+Every formula in this pack requires `formula_compiler = ">=2.0.0"`. Targeted formulas take
 the core-injected reserved convoy target; they do not declare `issue`,
 `bead_id`, or `convoy_id` variables. `drain_policy=separate` is the standalone
 default. Use `same-session` only when preserving one shared worktree and

--- a/gascity/REQUIREMENTS.md
+++ b/gascity/REQUIREMENTS.md
@@ -105,7 +105,7 @@ top-level stages only as anchored extensions:
   delegates to the next suffix through an inherited handoff step.
 - `build-from-*` formulas are cataloged default Gas City wrappers around the
   matching continuation suffix bases.
-- All formulas use `contract = "graph.v2"` and do not redeclare reserved
+- All formulas require `formula_compiler = ">=2.0.0"` and do not redeclare reserved
   runtime variables: `issue`, `bead_id`, or `convoy_id`.
 - Raw-framework subagents are converted to Gas City fanouts, drains, or formula
   steps. The base pack must not preserve subagent functionality as opaque

--- a/gascity/formulas/REQUIREMENTS.md
+++ b/gascity/formulas/REQUIREMENTS.md
@@ -45,7 +45,7 @@ For every formula change:
 
 ## Global Invariants
 
-- Every formula uses `contract = "graph.v2"`.
+- Every formula requires `formula_compiler = ">=2.0.0"`.
 - No formula declares reserved runtime vars `issue`, `bead_id`, or `convoy_id`.
 - Cataloged formulas are user-runnable; internal/base/helper formulas are not
   cataloged unless deliberately promoted.

--- a/gascity/formulas/build-base.formula.toml
+++ b/gascity/formulas/build-base.formula.toml
@@ -27,9 +27,11 @@ Launch inputs:
 """
 formula = "build-base"
 version = 1
-contract = "graph.v2"
 target_required = true
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [metadata.gc.methodology]
 allowed_drain_policies = ["separate", "same-session"]

--- a/gascity/formulas/build-basic-review.formula.toml
+++ b/gascity/formulas/build-basic-review.formula.toml
@@ -8,7 +8,9 @@ synthesize into one fix loop.
 formula = "build-basic-review"
 type = "expansion"
 version = 1
-contract = "graph.v2"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/gascity/formulas/build-basic.formula.toml
+++ b/gascity/formulas/build-basic.formula.toml
@@ -7,9 +7,11 @@ same full-lifecycle stage contract exposed by build-base.
 """
 formula = "build-basic"
 version = 1
-contract = "graph.v2"
 extends = ["build-base"]
 target_required = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "build-basic"

--- a/gascity/formulas/build-from-convoy-base.formula.toml
+++ b/gascity/formulas/build-from-convoy-base.formula.toml
@@ -7,10 +7,12 @@ to `build-from-review-base` through the inherited `prepare-review` step.
 """
 formula = "build-from-convoy-base"
 version = 1
-contract = "graph.v2"
 extends = ["build-from-review-base"]
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [metadata.gc.methodology]
 allowed_drain_policies = ["separate", "same-session"]

--- a/gascity/formulas/build-from-convoy.formula.toml
+++ b/gascity/formulas/build-from-convoy.formula.toml
@@ -6,9 +6,11 @@ Gas City methodology defaults.
 """
 formula = "build-from-convoy"
 version = 1
-contract = "graph.v2"
 extends = ["build-from-convoy-base"]
 target_required = false
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "build-from-convoy"

--- a/gascity/formulas/build-from-decompose-base.formula.toml
+++ b/gascity/formulas/build-from-decompose-base.formula.toml
@@ -29,10 +29,12 @@ Launch inputs:
 """
 formula = "build-from-decompose-base"
 version = 1
-contract = "graph.v2"
 extends = ["build-from-convoy-base"]
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [metadata.gc.methodology]
 allowed_drain_policies = ["separate", "same-session"]

--- a/gascity/formulas/build-from-decompose.formula.toml
+++ b/gascity/formulas/build-from-decompose.formula.toml
@@ -8,9 +8,11 @@ selectors, routes, drains, or review expansions they need.
 """
 formula = "build-from-decompose"
 version = 1
-contract = "graph.v2"
 extends = ["build-from-decompose-base"]
 target_required = false
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "build-from-decompose"

--- a/gascity/formulas/build-from-plan-base.formula.toml
+++ b/gascity/formulas/build-from-plan-base.formula.toml
@@ -7,10 +7,12 @@ implementation plan and plan-review verdict, then hands off to
 """
 formula = "build-from-plan-base"
 version = 1
-contract = "graph.v2"
 extends = ["build-from-decompose-base"]
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [metadata.gc.methodology]
 allowed_drain_policies = ["separate", "same-session"]

--- a/gascity/formulas/build-from-plan.formula.toml
+++ b/gascity/formulas/build-from-plan.formula.toml
@@ -6,9 +6,11 @@ City methodology defaults.
 """
 formula = "build-from-plan"
 version = 1
-contract = "graph.v2"
 extends = ["build-from-plan-base"]
 target_required = false
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "build-from-plan"

--- a/gascity/formulas/build-from-requirements-base.formula.toml
+++ b/gascity/formulas/build-from-requirements-base.formula.toml
@@ -7,10 +7,12 @@ inherited `prepare-plan` step.
 """
 formula = "build-from-requirements-base"
 version = 1
-contract = "graph.v2"
 extends = ["build-from-plan-base"]
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [metadata.gc.methodology]
 allowed_drain_policies = ["separate", "same-session"]

--- a/gascity/formulas/build-from-requirements.formula.toml
+++ b/gascity/formulas/build-from-requirements.formula.toml
@@ -6,9 +6,11 @@ built-in Gas City methodology defaults.
 """
 formula = "build-from-requirements"
 version = 1
-contract = "graph.v2"
 extends = ["build-from-requirements-base"]
 target_required = false
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "build-from-requirements"

--- a/gascity/formulas/build-from-review-base.formula.toml
+++ b/gascity/formulas/build-from-review-base.formula.toml
@@ -8,9 +8,11 @@ to `prepare-review` after producing implementation evidence.
 """
 formula = "build-from-review-base"
 version = 1
-contract = "graph.v2"
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [metadata.gc.methodology]
 allowed_drain_policies = ["separate", "same-session"]

--- a/gascity/formulas/build-from-review.formula.toml
+++ b/gascity/formulas/build-from-review.formula.toml
@@ -6,9 +6,11 @@ Gas City methodology defaults.
 """
 formula = "build-from-review"
 version = 1
-contract = "graph.v2"
 extends = ["build-from-review-base"]
 target_required = false
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "build-from-review"

--- a/gascity/formulas/code-review-base.formula.toml
+++ b/gascity/formulas/code-review-base.formula.toml
@@ -7,10 +7,12 @@ scoring while entrypoint adapters keep GitHub/comment lifecycle ownership.
 """
 formula = "code-review-base"
 version = 1
-contract = "graph.v2"
 target_required = false
 internal = true
 mode = "report"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.context_path]

--- a/gascity/formulas/decomposition-base.formula.toml
+++ b/gascity/formulas/decomposition-base.formula.toml
@@ -7,9 +7,11 @@ native output uses stories, cards, or another task shape.
 """
 formula = "decomposition-base"
 version = 1
-contract = "graph.v2"
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.context_path]

--- a/gascity/formulas/design-review.formula.toml
+++ b/gascity/formulas/design-review.formula.toml
@@ -8,8 +8,10 @@ graphs while preserving launch and finalization semantics.
 """
 formula = "design-review"
 version = 1
-contract = "graph.v2"
 target_required = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "design-review"

--- a/gascity/formulas/do-work-item.formula.toml
+++ b/gascity/formulas/do-work-item.formula.toml
@@ -8,11 +8,13 @@ Launch inputs:
 """
 formula = "do-work-item"
 version = 1
-contract = "graph.v2"
 extends = ["implementation-item-base"]
 target_required = true
 internal = true
 single_lane = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.context_path]

--- a/gascity/formulas/do-work.formula.toml
+++ b/gascity/formulas/do-work.formula.toml
@@ -10,9 +10,11 @@ Launch inputs:
 """
 formula = "do-work"
 version = 1
-contract = "graph.v2"
 extends = ["implementation-base"]
 target_required = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.context_path]

--- a/gascity/formulas/fix-convoy.formula.toml
+++ b/gascity/formulas/fix-convoy.formula.toml
@@ -8,9 +8,11 @@ Launch inputs:
 """
 formula = "fix-convoy"
 version = 1
-contract = "graph.v2"
 target_required = true
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.report_path]

--- a/gascity/formulas/fix-loop-base.formula.toml
+++ b/gascity/formulas/fix-loop-base.formula.toml
@@ -8,9 +8,11 @@ discipline.
 """
 formula = "fix-loop-base"
 version = 1
-contract = "graph.v2"
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.context_path]

--- a/gascity/formulas/gap-analysis.formula.toml
+++ b/gascity/formulas/gap-analysis.formula.toml
@@ -8,9 +8,11 @@ Launch inputs:
 """
 formula = "gap-analysis"
 version = 1
-contract = "graph.v2"
 target_required = false
 mode = "report"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "gap-analysis"

--- a/gascity/formulas/github-issue-fix-base.formula.toml
+++ b/gascity/formulas/github-issue-fix-base.formula.toml
@@ -27,8 +27,10 @@ Launch inputs:
 """
 formula = "github-issue-fix-base"
 version = 1
-contract = "graph.v2"
 target_required = false
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.github_issue_url]

--- a/gascity/formulas/github-issue-fix-design-review-work.formula.toml
+++ b/gascity/formulas/github-issue-fix-design-review-work.formula.toml
@@ -10,7 +10,9 @@ contract for downstream bead creation.
 formula = "github-issue-fix-design-review-work"
 type = "expansion"
 version = 1
-contract = "graph.v2"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars.mode]
 description = "Issue-fix front-half mode, recorded in artifacts."

--- a/gascity/formulas/github-issue-fix.formula.toml
+++ b/gascity/formulas/github-issue-fix.formula.toml
@@ -18,8 +18,10 @@ Launch inputs:
 formula = "github-issue-fix"
 extends = ["github-issue-fix-base"]
 version = 1
-contract = "graph.v2"
 target_required = false
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "github-issue-fix"

--- a/gascity/formulas/github-issue-triage-base.formula.toml
+++ b/gascity/formulas/github-issue-triage-base.formula.toml
@@ -17,8 +17,10 @@ Launch inputs:
 """
 formula = "github-issue-triage-base"
 version = 1
-contract = "graph.v2"
 target_required = false
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.github_issue_url]

--- a/gascity/formulas/github-issue-triage.formula.toml
+++ b/gascity/formulas/github-issue-triage.formula.toml
@@ -16,8 +16,10 @@ Launch inputs:
 formula = "github-issue-triage"
 extends = ["github-issue-triage-base"]
 version = 1
-contract = "graph.v2"
 target_required = false
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "github-issue-triage"

--- a/gascity/formulas/github-pr-review.formula.toml
+++ b/gascity/formulas/github-pr-review.formula.toml
@@ -19,8 +19,10 @@ Launch inputs:
 """
 formula = "github-pr-review"
 version = 1
-contract = "graph.v2"
 target_required = false
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "github-pr-review"

--- a/gascity/formulas/implement.formula.toml
+++ b/gascity/formulas/implement.formula.toml
@@ -16,9 +16,11 @@ Launch inputs:
 """
 formula = "implement"
 version = 2
-contract = "graph.v2"
 target_required = true
 sling_container_mode = "source"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "implement"

--- a/gascity/formulas/implementation-base.formula.toml
+++ b/gascity/formulas/implementation-base.formula.toml
@@ -8,9 +8,11 @@ source-anchor close contract.
 """
 formula = "implementation-base"
 version = 1
-contract = "graph.v2"
 target_required = true
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.context_path]

--- a/gascity/formulas/implementation-item-base.formula.toml
+++ b/gascity/formulas/implementation-item-base.formula.toml
@@ -7,10 +7,12 @@ per-item procedure while keeping shared-drain sequencing stable.
 """
 formula = "implementation-item-base"
 version = 1
-contract = "graph.v2"
 target_required = true
 internal = true
 single_lane = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.context_path]

--- a/gascity/formulas/planning-base.formula.toml
+++ b/gascity/formulas/planning-base.formula.toml
@@ -8,9 +8,11 @@ artifact paths consumed by entrypoint adapters.
 """
 formula = "planning-base"
 version = 1
-contract = "graph.v2"
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.artifact_root]

--- a/gascity/formulas/publish.formula.toml
+++ b/gascity/formulas/publish.formula.toml
@@ -8,9 +8,11 @@ Launch inputs:
 """
 formula = "publish"
 version = 1
-contract = "graph.v2"
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.final_report]

--- a/gascity/formulas/review.formula.toml
+++ b/gascity/formulas/review.formula.toml
@@ -10,10 +10,12 @@ Launch inputs:
 """
 formula = "review"
 version = 1
-contract = "graph.v2"
 extends = ["code-review-base"]
 target_required = false
 mode = "report"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "review"

--- a/gascity/formulas/same-session-implement.formula.toml
+++ b/gascity/formulas/same-session-implement.formula.toml
@@ -9,9 +9,11 @@ Launch inputs:
 """
 formula = "same-session-implement"
 version = 1
-contract = "graph.v2"
 target_required = true
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.context_path]

--- a/gascity/tests/test_formula_assets.py
+++ b/gascity/tests/test_formula_assets.py
@@ -518,20 +518,20 @@ def resolve_formula(root: pathlib.Path, name: str, seen: tuple[str, ...] = ()) -
         "formula": data["formula"],
         "description": data.get("description", ""),
         "version": data.get("version", 1),
-        "contract": data.get("contract", ""),
+        "requires": {},
         "target_required": data.get("target_required"),
         "vars": {},
         "steps": [],
     }
     for parent in parents:
         parent_data = resolve_formula(root, parent, (*seen, name))
-        if not merged["contract"]:
-            merged["contract"] = parent_data.get("contract", "")
+        merged["requires"].update(parent_data.get("requires", {}))
         if merged["target_required"] is None:
             merged["target_required"] = parent_data.get("target_required")
         merged["vars"].update(parent_data.get("vars", {}))
         merged["steps"].extend(parent_data.get("steps", []))
 
+    merged["requires"].update(data.get("requires", {}))
     merged["vars"].update(data.get("vars", {}))
     merged["steps"] = merged_steps(merged["steps"], data.get("steps", []))
     if data.get("description"):
@@ -551,20 +551,20 @@ def resolve_formula_from_dirs(formula_dirs: list[pathlib.Path], name: str, seen:
         "formula": data["formula"],
         "description": data.get("description", ""),
         "version": data.get("version", 1),
-        "contract": data.get("contract", ""),
+        "requires": {},
         "target_required": data.get("target_required"),
         "vars": {},
         "steps": [],
     }
     for parent in parents:
         parent_data = resolve_formula_from_dirs(formula_dirs, parent, (*seen, name))
-        if not merged["contract"]:
-            merged["contract"] = parent_data.get("contract", "")
+        merged["requires"].update(parent_data.get("requires", {}))
         if merged["target_required"] is None:
             merged["target_required"] = parent_data.get("target_required")
         merged["vars"].update(parent_data.get("vars", {}))
         merged["steps"].extend(parent_data.get("steps", []))
 
+    merged["requires"].update(data.get("requires", {}))
     merged["vars"].update(data.get("vars", {}))
     merged["steps"] = merged_steps(merged["steps"], data.get("steps", []))
     if data.get("description"):
@@ -741,7 +741,8 @@ class FormulaAssetTests(unittest.TestCase):
             data = tomllib.loads(path.read_text(encoding="utf-8"))
             name = path.name.removesuffix(".formula.toml")
             self.assertEqual(data["formula"], name)
-            self.assertEqual(data["contract"], "graph.v2")
+            self.assertNotIn("contract", data)
+            self.assertEqual(data["requires"]["formula_compiler"], ">=2.0.0")
             var_names = set(data.get("vars", {}))
             self.assertNotIn("issue", var_names)
             self.assertNotIn("bead_id", var_names)
@@ -1342,7 +1343,8 @@ class FormulaAssetTests(unittest.TestCase):
             with self.subTest(formula=name):
                 data = load_formula(root, name)
                 self.assertEqual(data["formula"], name)
-                self.assertEqual(data["contract"], "graph.v2")
+                self.assertNotIn("contract", data)
+                self.assertEqual(data["requires"]["formula_compiler"], ">=2.0.0")
                 self.assertTrue(data["internal"])
                 self.assertNotIn("catalog", data)
                 self.assertNotIn("extends", data)
@@ -1925,7 +1927,8 @@ class FormulaAssetTests(unittest.TestCase):
         root = pathlib.Path(__file__).resolve().parents[1]
         review = load_formula(root, "build-basic-review")
         self.assertEqual(review["type"], "expansion")
-        self.assertEqual(review["contract"], "graph.v2")
+        self.assertNotIn("contract", review)
+        self.assertEqual(review["requires"]["formula_compiler"], ">=2.0.0")
         self.assertEqual(
             review["vars"]["implementation_target"]["default"],
             "gc.implementation-worker",
@@ -2378,7 +2381,8 @@ class FormulaAssetTests(unittest.TestCase):
                     expansion = load_formula(pack_root, expansion_name)
                     self.assertEqual(expansion["formula"], expansion_name)
                     self.assertEqual(expansion["type"], "expansion")
-                    self.assertEqual(expansion["contract"], "graph.v2")
+                    self.assertNotIn("contract", expansion)
+                    self.assertEqual(expansion["requires"]["formula_compiler"], ">=2.0.0")
 
                     nodes = formula_nodes(expansion)
                     self.assertGreaterEqual(len(nodes), 4)
@@ -2405,7 +2409,8 @@ class FormulaAssetTests(unittest.TestCase):
             item_formula = load_formula(pack_root, expected["implementation_formula"])
             with self.subTest(pack=pack_name, item_formula=expected["implementation_formula"]):
                 self.assertEqual(item_formula["formula"], expected["implementation_formula"])
-                self.assertEqual(item_formula["contract"], "graph.v2")
+                self.assertNotIn("contract", item_formula)
+                self.assertEqual(item_formula["requires"]["formula_compiler"], ">=2.0.0")
                 self.assertEqual(item_formula["extends"], ["do-work"])
                 self.assertNotEqual(item_formula.get("type"), "expansion")
                 self.assertTrue(item_formula["target_required"])
@@ -2481,7 +2486,8 @@ class FormulaAssetTests(unittest.TestCase):
             shared_item_formula = load_formula(pack_root, expected["implementation_item_formula"])
             with self.subTest(pack=pack_name, item_formula=expected["implementation_item_formula"]):
                 self.assertEqual(shared_item_formula["formula"], expected["implementation_item_formula"])
-                self.assertEqual(shared_item_formula["contract"], "graph.v2")
+                self.assertNotIn("contract", shared_item_formula)
+                self.assertEqual(shared_item_formula["requires"]["formula_compiler"], ">=2.0.0")
                 self.assertEqual(shared_item_formula["extends"], ["do-work-item"])
                 self.assertNotEqual(shared_item_formula.get("type"), "expansion")
                 self.assertTrue(shared_item_formula["target_required"])
@@ -3751,7 +3757,8 @@ class FormulaAssetTests(unittest.TestCase):
         for name, (url_var, optional_vars) in expected.items():
             with self.subTest(name=name):
                 data = resolve_formula(root, name)
-                self.assertEqual(data["contract"], "graph.v2")
+                self.assertNotIn("contract", data)
+                self.assertEqual(data["requires"]["formula_compiler"], ">=2.0.0")
                 self.assertFalse(data["target_required"])
                 self.assertTrue(data["vars"][url_var]["required"])
                 self.assertEqual(set(data["vars"]) - {url_var}, optional_vars)
@@ -3927,8 +3934,10 @@ class FormulaAssetTests(unittest.TestCase):
 formula = "github-issue-fix"
 extends = ["github-issue-fix-base"]
 version = 1
-contract = "graph.v2"
 target_required = false
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "github-issue-fix"
@@ -3948,8 +3957,10 @@ description = "Override sink that preserves the base issue-fix protocol."
 formula = "github-issue-triage"
 extends = ["github-issue-triage-base"]
 version = 1
-contract = "graph.v2"
 target_required = false
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "github-issue-triage"

--- a/gstack/formulas/gstack-build.formula.toml
+++ b/gstack/formulas/gstack-build.formula.toml
@@ -6,9 +6,11 @@ Think -> Plan -> Build -> Review -> Test -> Ship -> Reflect.
 """
 formula = "gstack-build"
 version = 1
-contract = "graph.v2"
 extends = ["build-base"]
 target_required = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "gstack-build"

--- a/gstack/formulas/gstack-code-review.formula.toml
+++ b/gstack/formulas/gstack-code-review.formula.toml
@@ -7,7 +7,9 @@ into explicit Gas City review lanes with synthesis and fix application.
 formula = "gstack-code-review"
 type = "expansion"
 version = 1
-contract = "graph.v2"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/gstack/formulas/gstack-decomposition.formula.toml
+++ b/gstack/formulas/gstack-decomposition.formula.toml
@@ -3,10 +3,12 @@ gstack implementation of the decomposition-base methodology contract.
 """
 formula = "gstack-decomposition"
 version = 1
-contract = "graph.v2"
 extends = ["decomposition-base"]
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [[steps]]
 id = "decompose"

--- a/gstack/formulas/gstack-fix-loop.formula.toml
+++ b/gstack/formulas/gstack-fix-loop.formula.toml
@@ -3,10 +3,12 @@ gstack implementation of the fix-loop-base methodology contract.
 """
 formula = "gstack-fix-loop"
 version = 1
-contract = "graph.v2"
 extends = ["fix-loop-base"]
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_formula]

--- a/gstack/formulas/gstack-implementation.formula.toml
+++ b/gstack/formulas/gstack-implementation.formula.toml
@@ -3,10 +3,12 @@ gstack implementation of the public implement methodology contract.
 """
 formula = "gstack-implementation"
 version = 1
-contract = "graph.v2"
 extends = ["implement"]
 target_required = true
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/gstack/formulas/gstack-plan-review.formula.toml
+++ b/gstack/formulas/gstack-plan-review.formula.toml
@@ -7,7 +7,9 @@ founder, design, engineering, and developer-experience lanes.
 formula = "gstack-plan-review"
 type = "expansion"
 version = 1
-contract = "graph.v2"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/gstack/formulas/gstack-planning.formula.toml
+++ b/gstack/formulas/gstack-planning.formula.toml
@@ -3,10 +3,12 @@ gstack implementation of the planning-base methodology contract.
 """
 formula = "gstack-planning"
 version = 1
-contract = "graph.v2"
 extends = ["planning-base"]
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.interaction_mode]

--- a/gstack/formulas/gstack-qa-review.formula.toml
+++ b/gstack/formulas/gstack-qa-review.formula.toml
@@ -7,7 +7,9 @@ and synthesis lanes.
 formula = "gstack-qa-review"
 type = "expansion"
 version = 1
-contract = "graph.v2"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/gstack/formulas/gstack-release-readiness.formula.toml
+++ b/gstack/formulas/gstack-release-readiness.formula.toml
@@ -7,7 +7,9 @@ explicit Gas City readiness lanes before the build finalize and publish stages.
 formula = "gstack-release-readiness"
 type = "expansion"
 version = 1
-contract = "graph.v2"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.review_mode]

--- a/gstack/formulas/gstack-review.formula.toml
+++ b/gstack/formulas/gstack-review.formula.toml
@@ -3,11 +3,13 @@ gstack implementation of the code-review-base methodology contract.
 """
 formula = "gstack-review"
 version = 1
-contract = "graph.v2"
 extends = ["code-review-base"]
 target_required = false
 internal = true
 mode = "report"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/gstack/formulas/gstack-work-item.formula.toml
+++ b/gstack/formulas/gstack-work-item.formula.toml
@@ -3,11 +3,13 @@ gstack single-lane implementation item formula.
 """
 formula = "gstack-work-item"
 version = 1
-contract = "graph.v2"
 extends = ["do-work-item"]
 target_required = true
 internal = true
 single_lane = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/gstack/formulas/gstack-work.formula.toml
+++ b/gstack/formulas/gstack-work.formula.toml
@@ -3,9 +3,11 @@ gstack implementation item formula.
 """
 formula = "gstack-work"
 version = 1
-contract = "graph.v2"
 extends = ["do-work"]
 target_required = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/profiler/formulas/bench-nullop.formula.toml
+++ b/profiler/formulas/bench-nullop.formula.toml
@@ -8,7 +8,9 @@ Launch: gc sling <operator-target> bench-nullop --formula
 """
 formula = "bench-nullop"
 version = 2
-contract = "graph.v2"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "bench-nullop"

--- a/profiler/formulas/profile-analyze.formula.toml
+++ b/profiler/formulas/profile-analyze.formula.toml
@@ -12,7 +12,9 @@ Launch inputs:
 """
 formula = "profile-analyze"
 version = 2
-contract = "graph.v2"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "profile-analyze"

--- a/scripts/gascity_pack_inference_gate.py
+++ b/scripts/gascity_pack_inference_gate.py
@@ -2592,8 +2592,13 @@ def load_methodology_formula(pack_source: Path, formula_name: str | None, missin
         return None
     if payload.get("formula") != formula_name:
         missing.append(f"{formula_name}: formula field is {payload.get('formula')!r}, want {formula_name!r}")
-    if payload.get("contract") != "graph.v2":
-        missing.append(f"{formula_name}: contract is {payload.get('contract')!r}, want 'graph.v2'")
+    requires = payload.get("requires")
+    if not isinstance(requires, dict) or requires.get("formula_compiler") != ">=2.0.0":
+        missing.append(
+            f"{formula_name}: requires.formula_compiler is "
+            f"{requires.get('formula_compiler') if isinstance(requires, dict) else None!r}, "
+            "want '>=2.0.0'"
+        )
     return payload
 
 

--- a/superpowers/formulas/superpowers-brainstorming.formula.toml
+++ b/superpowers/formulas/superpowers-brainstorming.formula.toml
@@ -9,7 +9,9 @@ and review guidance available through the provider skill directory.
 formula = "superpowers-brainstorming"
 type = "expansion"
 version = 1
-contract = "graph.v2"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.brainstorming_approval_mode]

--- a/superpowers/formulas/superpowers-build.formula.toml
+++ b/superpowers/formulas/superpowers-build.formula.toml
@@ -6,9 +6,11 @@ build-base lifecycle.
 """
 formula = "superpowers-build"
 version = 1
-contract = "graph.v2"
 extends = ["build-base"]
 target_required = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [catalog]
 name = "superpowers-build"

--- a/superpowers/formulas/superpowers-code-review.formula.toml
+++ b/superpowers/formulas/superpowers-code-review.formula.toml
@@ -7,7 +7,9 @@ into explicit Gas City review, gap-analysis, and feedback-processing lanes.
 formula = "superpowers-code-review"
 type = "expansion"
 version = 1
-contract = "graph.v2"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/superpowers/formulas/superpowers-decomposition.formula.toml
+++ b/superpowers/formulas/superpowers-decomposition.formula.toml
@@ -3,10 +3,12 @@ Superpowers implementation of the decomposition-base methodology contract.
 """
 formula = "superpowers-decomposition"
 version = 1
-contract = "graph.v2"
 extends = ["decomposition-base"]
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [[steps]]
 id = "decompose"

--- a/superpowers/formulas/superpowers-development-item.formula.toml
+++ b/superpowers/formulas/superpowers-development-item.formula.toml
@@ -7,11 +7,13 @@ the task scope; this formula carries the execution process.
 """
 formula = "superpowers-development-item"
 version = 1
-contract = "graph.v2"
 extends = ["do-work-item"]
 target_required = true
 internal = true
 single_lane = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/superpowers/formulas/superpowers-development.formula.toml
+++ b/superpowers/formulas/superpowers-development.formula.toml
@@ -7,9 +7,11 @@ scope; this formula carries the execution process.
 """
 formula = "superpowers-development"
 version = 1
-contract = "graph.v2"
 extends = ["do-work"]
 target_required = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/superpowers/formulas/superpowers-fix-loop.formula.toml
+++ b/superpowers/formulas/superpowers-fix-loop.formula.toml
@@ -3,10 +3,12 @@ Superpowers implementation of the fix-loop-base methodology contract.
 """
 formula = "superpowers-fix-loop"
 version = 1
-contract = "graph.v2"
 extends = ["fix-loop-base"]
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_formula]

--- a/superpowers/formulas/superpowers-implementation.formula.toml
+++ b/superpowers/formulas/superpowers-implementation.formula.toml
@@ -3,10 +3,12 @@ Superpowers implementation of the public implement methodology contract.
 """
 formula = "superpowers-implementation"
 version = 1
-contract = "graph.v2"
 extends = ["implement"]
 target_required = true
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/superpowers/formulas/superpowers-plan-review.formula.toml
+++ b/superpowers/formulas/superpowers-plan-review.formula.toml
@@ -7,7 +7,9 @@ City-native review loop.
 formula = "superpowers-plan-review"
 type = "expansion"
 version = 1
-contract = "graph.v2"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [[template]]
 id = "{target}.setup-superpowers-plan-review"

--- a/superpowers/formulas/superpowers-planning.formula.toml
+++ b/superpowers/formulas/superpowers-planning.formula.toml
@@ -3,10 +3,12 @@ Superpowers implementation of the planning-base methodology contract.
 """
 formula = "superpowers-planning"
 version = 1
-contract = "graph.v2"
 extends = ["planning-base"]
 target_required = false
 internal = true
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.brainstorming_approval_mode]

--- a/superpowers/formulas/superpowers-review.formula.toml
+++ b/superpowers/formulas/superpowers-review.formula.toml
@@ -3,11 +3,13 @@ Superpowers implementation of the code-review-base methodology contract.
 """
 formula = "superpowers-review"
 version = 1
-contract = "graph.v2"
 extends = ["code-review-base"]
 target_required = false
 internal = true
 mode = "report"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]

--- a/superpowers/formulas/superpowers-task-review.formula.toml
+++ b/superpowers/formulas/superpowers-task-review.formula.toml
@@ -8,7 +8,9 @@ implementation lane applies findings; provider-native subagents are not used.
 formula = "superpowers-task-review"
 type = "expansion"
 version = 1
-contract = "graph.v2"
+
+[requires]
+formula_compiler = ">=2.0.0"
 
 [vars]
 [vars.implementation_target]


### PR DESCRIPTION
## Summary
- replace every shipped deprecated `contract = "graph.v2"` formula declaration with the compiler requirement form
- add `[requires] formula_compiler = ">=2.0.0"` to 80 affected manifests across all packs
- update formula-resolution tests, methodology validation, and the matching Gas City documentation

## Verification
- `python3 -m pytest gascity/tests/test_formula_assets.py tests/test_gascity_pack_inference_gate.py pr-pipeline/tests/test_pr_pipeline_formulas.py -q`
- `python3 -m pytest profiler/tests -q`
- parsed all 83 manifests that declare `formula_compiler >=2.0.0`
- `gc lint . --json` reports the six affected packs healthy; its remaining 31 errors are pre-existing and confined to unrelated `gastown` and `oversight-rig` packs
- no shipped `*.formula.toml` retains the deprecated declaration

The repository keeps intentional test-canary and historical documentation references to the old declaration so `gc doctor` can continue detecting third-party deprecated packs.