### PR TITLE
fix(slack-full): scope run.sh's toolchain refusal to real downloads, harden its /tmp cache fallback

### DIFF
--- a/slack-full/CHANGELOG.md
+++ b/slack-full/CHANGELOG.md
@@ -54,26 +54,79 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   distro Go lands, and which a restricted PATH hides); `GOCACHE` and
   `GOPATH` are defaulted under `TMPDIR` when HOME, `XDG_CACHE_HOME`
   and `GOCACHE` are all unset, which `go build` otherwise rejects
-  outright; and the toolchain is checked against `go.mod`'s `go`
-  directive up front, so a too-old Go under `GOTOOLCHAIN=local` fails
-  with a named remedy instead of a raw compiler error (the default
-  `GOTOOLCHAIN=auto`, which can fetch the required toolchain itself,
-  warns and proceeds).
+  outright — to a per-user, `0700`, ownership-checked directory, since
+  a shared name in world-writable `/tmp` could be pre-created by another
+  local user and Go trusts whatever it finds in those caches; and the
+  toolchain is checked against `go.mod`'s `go` directive up front, so a
+  too-old Go gets a named remedy instead of a raw compiler error (which
+  of warn, refuse, or fail it gets depends on the case — see below).
+
+  **Expect a flap on the first start after a pin bump.** gc gives a
+  starting service about 5 seconds to become ready, then kills it and
+  restarts on a 1-second backoff. A *cold* rebuild does not fit that
+  window (order of 10s on this tree; a warm one is under a second), so
+  the first start after a materialization wiped the binary is normally
+  killed mid-build. It converges on its own: `go build` keeps its
+  per-package results in the build cache, so each retry resumes cheaper
+  until one finishes and publishes the binary. A few
+  `service "slack" did not become ready before timeout` lines right
+  after `gc import install` are expected and self-clearing. Run
+  `cd adapter && go build -o gc-slack-adapter .` once to skip the flap
+  entirely.
+
+  One case cannot converge that way, and is now refused up front: a
+  toolchain *older* than `go.mod` under `GOTOOLCHAIN=auto`, where the
+  build's first act is to download a toolchain. That download keeps no
+  partial progress, so under the supervisor every restart would fetch
+  tens of megabytes from scratch, forever, with no message naming the
+  cause. When `run.sh` detects it is supervised (gc exports
+  `GC_SERVICE_NAME` / `GC_SERVICE_URL_PREFIX`) it now exits immediately
+  with the remedy — install a new enough Go, or prebuild the binary —
+  instead of starting a fetch it cannot finish. Run by hand, where there
+  is no deadline, it still warns and lets Go fetch the toolchain. Under
+  `GOTOOLCHAIN=local`, which cannot fetch at all, it fails as before.
+
+  That refusal is scoped to an actual download, not to the version
+  numbers: an old `go` whose newer toolchain is already in the local
+  module cache builds without touching the network and converges like
+  any other warm rebuild, so refusing it would strand a host that heals
+  fine today. `run.sh` distinguishes the two by asking Go itself,
+  offline — a `GOPROXY=off go version` from the module directory, where
+  the toolchain switch happens — and only refuses when that probe says
+  the toolchain would have to be fetched.
 
 ### Changed
 
 - **Behavior change on upgrade:** the slack service now *exits 1 at
   startup* when `GC_SLACK_ADAPTER_ENV` is set to a path that does not
-  exist, where it previously logged one warning and started on the
-  ambient environment. Pointing the variable at a nonexistent path is
-  this pack's own established idiom for "no env file", so a unit file or
-  wrapper using it that way for the **service** will stop starting after
-  this pin bump. Audit before upgrading with
-  `grep -r GC_SLACK_ADAPTER_ENV` across your unit files and wrappers, and
-  either create the file or unset the variable to fall back to the
-  default. The strict rule is service-only: `slack_chat_*` commands
+  exist. Pointing the variable at a nonexistent path is this pack's own
+  established idiom for "no env file", so a unit file or wrapper using
+  it that way for the **service** will stop starting after this pin
+  bump. Audit before upgrading with `grep -r GC_SLACK_ADAPTER_ENV`
+  across your unit files and wrappers, and either create the file or
+  unset the variable to fall back to the default. The strict rule is
+  `run.sh`-only: `slack_chat_*` commands
   (`scripts/slack_intake_common.py`) still treat a missing path as "no
   env file".
+
+  What is new here is *which process* enforces this, not the rule
+  itself. `run.sh` has always exited 1 on a missing explicitly-named env
+  file — it exited 1 on a missing env file of any kind, see below — and
+  the adapter binary never read `GC_SLACK_ADAPTER_ENV` at all. Since the
+  old service command was the binary, the **service** never consulted an
+  env file before this release; it inherits the rule now that `run.sh`
+  is the service command.
+- **Hand-run `run.sh` no longer refuses to start without an env file.**
+  This is the one genuine loosening in this release, and it runs in the
+  opposite direction from the item above. Previously `run.sh` exited 1
+  whenever the env file was absent, *including* the default
+  `~/.config/gc-slack-adapter/env`. It now warns and continues in that
+  case, matching supervised deployments that legitimately inject the
+  environment another way and relying on the adapter's own fail-fast on
+  a missing required key. If you were using `run.sh`'s refusal as a
+  guard, note that it will now start on the ambient environment and can
+  reach a different Slack workspace than you intended; set
+  `GC_SLACK_ADAPTER_ENV` explicitly to keep a hard failure.
 - Renamed the pack directory from `slack-pack/` to `slack-full/` and the
   `pack.toml` name from `slack` to `slack-full` as part of the Slack pack
   tiering split (`gc-yrw`). This pack is now **Tier 3** of the Slack

--- a/slack-full/adapter/run.sh
+++ b/slack-full/adapter/run.sh
@@ -14,6 +14,26 @@
 # before exec'ing (self-heal, loud logs, idempotent: an existing binary
 # is exec'd directly with no build).
 #
+# EXPECT A FLAP ON THE FIRST START AFTER A PIN BUMP — read this before
+# debugging one. gc's supervisor gives a starting proxy_process 5
+# seconds to accept on its socket and answer /healthz, then kills the
+# process group and restarts on a 1s backoff, with no attempt cap. A
+# COLD rebuild does not fit that window (measured on this tree: ~11s
+# cold, ~0.7s warm), so the first start after a materialization wiped
+# the binary is expected to be killed mid-build. It still converges:
+# `go build` checkpoints per-package results in the build cache, so each
+# retry resumes cheaper than the last until one finishes inside the
+# window and publishes the binary. A few
+#   service "slack" did not become ready before timeout
+# lines right after an install are therefore normal and self-clearing.
+# The same message repeating indefinitely is NOT — that means a step
+# with no partial-progress checkpoint keeps restarting from zero, which
+# is why the toolchain check below refuses to start a toolchain DOWNLOAD
+# under the supervisor. To skip the flap entirely, prebuild:
+#   cd adapter && go build -o gc-slack-adapter .
+# The structural fix (a per-service readiness timeout, or building at
+# `gc import install` time) belongs to gc itself, not to this pack.
+#
 # Reads secrets from a sourced env file. Default location:
 #   ~/.config/gc-slack-adapter/env
 # Override via GC_SLACK_ADAPTER_ENV. A missing default is a warning; a
@@ -149,30 +169,54 @@ if [[ -z "$go_bin" ]]; then
   exit 1
 fi
 
-# Check the toolchain against go.mod's `go` directive before building.
-# That directive is an exact patch floor, and CI installs precisely it
-# (ci.yml uses go-version-file), so CI can never surface a too-old
-# toolchain — the first host to hit it is a production supervisor, and
-# it deserves a named remedy rather than a raw compiler error. Only
-# hard-fail where Go cannot resolve this itself: GOTOOLCHAIN=local pins
-# it to what we found, whereas the default (auto) legitimately fetches
-# the required toolchain, and refusing that would strand hosts that
-# build fine today. An unparseable version on either side skips the
-# check — the compiler is still the backstop.
-go_version="$("$go_bin" version 2>/dev/null || echo 'version unknown')"
-need_go="$(sed -n 's/^go[[:space:]]\{1,\}\([0-9][0-9.]*\).*/\1/p' "$bin_dir/go.mod" 2>/dev/null | head -n1)"
-have_go="$(printf '%s\n' "$go_version" | sed -n 's/^go version go\([0-9][0-9.]*\).*/\1/p')"
-go_too_old=0
-if [[ -n "$need_go" && -n "$have_go" ]] &&
-   (( 10#$(version_key "$have_go") < 10#$(version_key "$need_go") )); then
-  go_too_old=1
-  if [[ "${GOTOOLCHAIN:-auto}" == "local" ]]; then
-    log "ERROR: need Go >= $need_go, found $have_go at $go_bin (GOTOOLCHAIN=local pins this toolchain)"
-    log "manual fix: install Go >= $need_go, unset GOTOOLCHAIN, or prebuild: cd $bin_dir && go build -o gc-slack-adapter ."
-    exit 1
-  fi
-  log "WARNING: $go_bin is $have_go but go.mod needs >= $need_go — Go will try to fetch the required toolchain (needs network and a writable module cache)"
+# Are we running as a gc-supervised service, or by hand? The supervisor
+# exports both of these into every proxy_process it starts, and nothing
+# else in this pack sets them. Only the startup-window rule below cares:
+# supervised means a hard 5s readiness deadline and an uncapped
+# kill/restart loop, so work that cannot make partial progress must not
+# be started here at all.
+supervised=0
+if [[ -n "${GC_SERVICE_NAME:-}" || -n "${GC_SERVICE_URL_PREFIX:-}" ]]; then
+  supervised=1
 fi
+
+# A private, reusable scratch dir under TMPDIR for the Go caches below.
+#
+# PER-USER, because /tmp is world-writable: a fixed shared name like
+# .../gc-slack-adapter-gocache can be pre-created by any other local
+# user, and Go trusts whatever it finds in these caches — a pre-owned
+# GOCACHE can serve object files into a binary that holds the Slack bot
+# token and signing secret, and a pre-owned GOPATH is where a fetched
+# toolchain is unpacked and re-exec'd. The uid suffix takes the name out
+# of the shared namespace, `mkdir` (no -p, so it fails rather than
+# accepts an existing dir) plus -O keeps us from adopting one somebody
+# else got to first, and /tmp's sticky bit stops them swapping it out
+# afterwards, since only the owner can unlink it.
+#
+# STABLE ACROSS RESTARTS, deliberately: warm rebuilds measured ~0.7s
+# against ~11s cold, and it is exactly that reuse between supervisor
+# restarts that lets the header's flap converge. A fresh mktemp dir per
+# start would never converge on the HOME-less hosts this path serves, so
+# it is only the fallback for the anomalous case where the stable name
+# is unusable — availability over speed there, never as the normal path.
+private_cache_dir() {
+  # `$1` and not `$name` in dir=: one `local` expands every right-hand
+  # side before it assigns any of them, so `$name` is still empty here.
+  local name="$1" dir="${TMPDIR:-/tmp}/$1.${EUID}"
+  if mkdir -m 700 "$dir" 2>/dev/null; then
+    printf '%s\n' "$dir"
+    return 0
+  fi
+  if [[ -d "$dir" && ! -L "$dir" && -O "$dir" ]]; then
+    chmod 700 "$dir" 2>/dev/null || true
+    printf '%s\n' "$dir"
+    return 0
+  fi
+  if [[ -e "$dir" || -L "$dir" ]]; then
+    log "WARNING: $dir exists but is not a directory this user owns — refusing to reuse it (another local user could be seeding the Go cache)"
+  fi
+  mktemp -d "${TMPDIR:-/tmp}/$name.XXXXXX" 2>/dev/null
+}
 
 # go build REQUIRES a build cache and can only locate one through
 # GOCACHE, XDG_CACHE_HOME, or HOME. All three can be unset under
@@ -181,8 +225,16 @@ fi
 # located". Fill only that gap: when Go can find a cache on its own,
 # leave it alone so rebuilds keep sharing the normal one.
 if [[ -z "${GOCACHE:-}" && -z "${XDG_CACHE_HOME:-}" && -z "${HOME:-}" ]]; then
-  export GOCACHE="${TMPDIR:-/tmp}/gc-slack-adapter-gocache"
-  log "no HOME / XDG_CACHE_HOME / GOCACHE in the environment — building with GOCACHE=$GOCACHE"
+  gocache_dir="$(private_cache_dir gc-slack-adapter-gocache || true)"
+  if [[ -n "$gocache_dir" ]]; then
+    export GOCACHE="$gocache_dir"
+    log "no HOME / XDG_CACHE_HOME / GOCACHE in the environment — building with GOCACHE=$GOCACHE"
+  else
+    # Leave GOCACHE unset rather than point Go at a path we could not
+    # secure; the build's own "build cache is required" error is a
+    # better diagnostic than a poisoned cache.
+    log "WARNING: could not create a private build cache under ${TMPDIR:-/tmp} — go build will report the cache error itself"
+  fi
 fi
 
 # GOPATH is the same problem one layer down, but it answers a different
@@ -193,8 +245,83 @@ fi
 # previous error — HOME still unset, so the toolchain fetch dies on
 # "module cache not found: neither GOMODCACHE nor GOPATH is set".
 if [[ -z "${GOPATH:-}" && -z "${GOMODCACHE:-}" && -z "${HOME:-}" ]]; then
-  export GOPATH="${TMPDIR:-/tmp}/gc-slack-adapter-gopath"
-  log "no HOME / GOMODCACHE / GOPATH in the environment — building with GOPATH=$GOPATH"
+  gopath_dir="$(private_cache_dir gc-slack-adapter-gopath || true)"
+  if [[ -n "$gopath_dir" ]]; then
+    export GOPATH="$gopath_dir"
+    log "no HOME / GOMODCACHE / GOPATH in the environment — building with GOPATH=$GOPATH"
+  else
+    log "WARNING: could not create a private module cache under ${TMPDIR:-/tmp} — go build will report the module cache error itself"
+  fi
+fi
+
+# Check the toolchain against go.mod's `go` directive before building.
+# That directive is an exact patch floor, and CI installs precisely it
+# (ci.yml uses go-version-file), so CI can never surface a too-old
+# toolchain — the first host to hit it is a production supervisor, and
+# it deserves a named remedy rather than a raw compiler error. Only
+# hard-fail where Go cannot resolve this itself: GOTOOLCHAIN=local pins
+# it to what we found, whereas the default (auto) legitimately fetches
+# the required toolchain, and refusing that would strand hosts that
+# build fine today. An unparseable version on either side skips the
+# check — the compiler is still the backstop.
+#
+# `|| true` on the go.mod read: with a missing go.mod the sed exits 2,
+# pipefail propagates it, and set -e would kill the script AT THE
+# ASSIGNMENT with no message — the one silent exit in an otherwise
+# loudly-logged script. An empty need_go already skips the version gate
+# by design, and the compiler then produces the real diagnostic.
+go_version="$("$go_bin" version 2>/dev/null || echo 'version unknown')"
+need_go="$(sed -n 's/^go[[:space:]]\{1,\}\([0-9][0-9.]*\).*/\1/p' "$bin_dir/go.mod" 2>/dev/null | head -n1 || true)"
+have_go="$(printf '%s\n' "$go_version" | sed -n 's/^go version go\([0-9][0-9.]*\).*/\1/p')"
+go_too_old=0
+if [[ -n "$need_go" && -n "$have_go" ]] &&
+   (( 10#$(version_key "$have_go") < 10#$(version_key "$need_go") )); then
+  go_too_old=1
+  if [[ "${GOTOOLCHAIN:-auto}" == "local" ]]; then
+    log "ERROR: need Go >= $need_go, found $have_go at $go_bin (GOTOOLCHAIN=local pins this toolchain)"
+    log "manual fix: install Go >= $need_go, unset GOTOOLCHAIN, or prebuild: cd $bin_dir && go build -o gc-slack-adapter ."
+    exit 1
+  fi
+  # Supervised, and Go is about to resolve a newer toolchain. If that
+  # means DOWNLOADING one, refuse rather than start it inside a 5s
+  # window it cannot finish in. Unlike a compile, a toolchain fetch keeps
+  # no partial progress: Go downloads it to a temp file and renames, so
+  # every kill throws the whole transfer away and the next restart begins
+  # again from zero. That turns the ordinary flap-then-converge described
+  # in the header into a permanent loop that re-downloads tens of MB
+  # every ~8s forever. Exiting instead makes each cycle cheap and legible
+  # — an early exit takes the supervisor's exited-early path, which skips
+  # the kill and records this script's own stderr as the reason. It does
+  # NOT stop the restart loop (nothing in-repo can); it stops the loop
+  # from burning the network while hiding its cause.
+  #
+  # But only when a download is really required. The toolchain may
+  # already be in the module cache from an earlier hand-run, and that
+  # build needs no network and DOES converge — refusing it would turn
+  # the self-heal this script exists for back into a permanent outage.
+  # Ask Go itself, offline, instead of guessing from version numbers: run
+  # from the module directory so the go command performs its toolchain
+  # switch, with GOPROXY=off so a missing toolchain fails instead of
+  # fetching. rc=0 means the switch resolved from local caches. This runs
+  # after the GOCACHE/GOPATH defaulting above on purpose — the switch
+  # extracts into the module cache, so the probe has to see the same
+  # environment the build will get. `go version` does no module work
+  # beyond that switch, and GOPROXY=off forbids network access outright,
+  # so the probe itself cannot spend the readiness window it is here to
+  # protect — it either exec's a local toolchain or fails immediately.
+  if (( supervised )); then
+    if (cd "$bin_dir" && GOPROXY=off "$go_bin" version >/dev/null 2>&1); then
+      log "WARNING: $go_bin is $have_go but go.mod needs >= $need_go — the required toolchain is already in the local module cache, so the build proceeds without a download"
+    else
+      log "ERROR: need Go >= $need_go, found $have_go at $go_bin, and GOTOOLCHAIN=${GOTOOLCHAIN:-auto} would have to fetch the required toolchain over the network (it is not in the local module cache)"
+      log "refusing to start that download under the gc supervisor: a starting service has ~5s to become ready before it is killed and restarted, and a toolchain fetch cannot resume, so it would re-download from scratch on every restart forever"
+      log "manual fix: install Go >= $need_go on this host, or prebuild once: cd $bin_dir && go build -o gc-slack-adapter ."
+      log "(running this script by hand, outside the supervisor, still lets Go fetch the toolchain)"
+      exit 1
+    fi
+  else
+    log "WARNING: $go_bin is $have_go but go.mod needs >= $need_go — Go will try to fetch the required toolchain (needs network and a writable module cache)"
+  fi
 fi
 
 # Build to a PID-suffixed temp file and mv into place: concurrent

--- a/slack-full/tests/test_adapter_run_sh.py
+++ b/slack-full/tests/test_adapter_run_sh.py
@@ -17,10 +17,14 @@ are fast and hermetic (no real compile, no network):
     missing *explicitly configured* one is fatal (starting on ambient
     credentials would post to whatever workspace is in the environment),
   * the self-heal's failure paths exit 1 and publish nothing: no Go new
-    enough for go.mod under ``GOTOOLCHAIN=local``, and ``go build``
-    failing,
+    enough for go.mod under ``GOTOOLCHAIN=local``, no Go new enough
+    while running *supervised* and the newer toolchain not cached (the
+    fetch it would otherwise start cannot fit the readiness window) —
+    while the same host with that toolchain already cached still
+    builds — and ``go build`` failing,
   * the self-heal survives the minimal supervisor environment it
-    targets (no HOME) by supplying a build cache,
+    targets (no HOME) by supplying a build cache, and that cache is
+    private to this user rather than a shared /tmp name,
   * pack.toml keeps pointing the service at a checked-in command.
 
 The harness owns HOME/XDG_CONFIG_HOME so the *defaulted* env-file path
@@ -46,10 +50,27 @@ GO_STUB = """#!/usr/bin/env bash
 # can pin WHERE the build ran), and on `build` writes an executable at
 # the -o target that prints a marker instead of compiling. Two knobs let
 # tests drive run.sh's failure paths: GO_STUB_VERSION (what `go version`
-# reports, defaulting high enough to satisfy any go.mod directive) and
-# GO_STUB_BUILD_FAILS (make `build` exit non-zero).
+# reports, defaulting high enough to satisfy any go.mod directive),
+# GO_STUB_BUILD_FAILS (make `build` exit non-zero) and
+# GO_STUB_TOOLCHAIN_CACHED (see the toolchain-switch model below).
 echo "go $* cwd=$PWD" >> "$GO_STUB_LOG"
 if [ "$1" = "version" ]; then
+  # Model the toolchain switch. Run inside a module whose go.mod asks
+  # for a newer Go than itself, the real go command resolves that
+  # toolchain before doing anything else — from the local module cache
+  # if it is already there, over the network otherwise. GOPROXY=off
+  # forbids the network, so the call fails outright when the toolchain
+  # is not cached. run.sh uses exactly that combination to tell "this
+  # build would download a toolchain" from "the toolchain is already
+  # local", and only refuses to start in the first case, so the stub has
+  # to distinguish them. GOPROXY=off therefore means "this is the probe"
+  # (the harness clears any inherited GOPROXY so it cannot mean anything
+  # else), and the default answer is the production case F1 is about:
+  # not cached, a download would be required.
+  if [ "${GOPROXY:-}" = "off" ] && [ -z "${GO_STUB_TOOLCHAIN_CACHED:-}" ]; then
+    echo "go: downloading go1.99.0 (unavailable: module lookup disabled by GOPROXY=off)" >&2
+    exit 1
+  fi
   echo "go version go${GO_STUB_VERSION:-99.0.0} stub/stub"
   exit 0
 fi
@@ -84,6 +105,56 @@ def required_go_version() -> str:
     raise AssertionError(f"no `go` directive in {GO_MOD}")
 
 
+# Stub toolchain versions for the two version-gate tests. Both are older
+# than go.mod's directive, but they get there differently and only the
+# pair covers the comparator: "1.0.0" is lower numerically AND lexically,
+# so a plain string compare passes it; "1.9.0" is lower ONLY numerically
+# ("1.9" sorts above "1.25" as text). run.sh's version_key exists for
+# exactly that second case, so a test suite driving only "1.0.0" stays
+# green if the comparator regresses to a string compare.
+OLD_GO_VERSIONS = ["1.0.0", "1.9.0"]
+
+
+def private_tmp(tmpdir: pathlib.Path, name: str) -> str:
+    """The per-user cache path run.sh derives under TMPDIR. The uid
+    suffix is the point: a fixed shared name in world-writable /tmp can
+    be pre-created by another local user, and Go trusts what it finds in
+    these caches.
+
+    Tests that assert on these paths hand run.sh their own TMPDIR — the
+    dirs are deliberately stable across runs, so pointing them at the
+    real /tmp would leave state behind and make the assertions depend on
+    what an earlier run left there."""
+    return f"{str(tmpdir).rstrip('/')}/{name}.{os.geteuid()}"
+
+
+# Where the stub records its invocations. Named once so a test can read
+# the log the harness wrote without re-deriving the path.
+GO_LOG_NAME = "go-invocations.log"
+
+
+def go_version_calls(tmp_path: pathlib.Path) -> list[str]:
+    """The stub's `go version` invocations, each with the cwd it ran in."""
+    log = tmp_path / GO_LOG_NAME
+    if not log.exists():
+        return []
+    return [l for l in log.read_text().splitlines() if l.startswith("go version")]
+
+
+def assert_older_than_go_mod(stub_version: str) -> None:
+    """Pin the parametrization's premise so a future `go` directive bump
+    cannot quietly turn these into no-op tests."""
+    required = required_go_version()
+
+    def key(v: str) -> tuple:
+        return tuple(int(p) for p in (v.split(".") + ["0", "0"])[:3])
+
+    assert key(stub_version) < key(required), (
+        f"test premise broken: stub Go {stub_version} is not older than "
+        f"go.mod's {required}, so the version gate would not fire"
+    )
+
+
 @pytest.fixture()
 def harness(tmp_path: pathlib.Path):
     """Adapter dir holding what a git-only materialization ships —
@@ -107,7 +178,7 @@ def harness(tmp_path: pathlib.Path):
     fake_home = tmp_path / "home"
     (fake_home / ".config").mkdir(parents=True)
 
-    go_log = tmp_path / "go-invocations.log"
+    go_log = tmp_path / GO_LOG_NAME
 
     def run(
         env_file: pathlib.Path | None = None,
@@ -122,6 +193,20 @@ def harness(tmp_path: pathlib.Path):
         # An explicitly set but missing GC_SLACK_ADAPTER_ENV is fatal by
         # design, so the "no env file" baseline is the defaulted path.
         env.pop("GC_SLACK_ADAPTER_ENV", None)
+        # run.sh reads these to decide it is running supervised, which
+        # changes the too-old-toolchain path from warn-and-build to
+        # refuse. The suite itself can run inside a gc service or agent
+        # that exports them, so the baseline must be *unsupervised*
+        # explicitly — inheriting them would flip an unrelated test's
+        # expected outcome depending on who ran pytest.
+        env.pop("GC_SERVICE_NAME", None)
+        env.pop("GC_SERVICE_URL_PREFIX", None)
+        # run.sh sets GOPROXY=off itself, for the single `go version`
+        # call that probes whether the newer toolchain is already
+        # cached. The stub reads GOPROXY=off as "this is that probe"; an
+        # inherited one (a developer building offline, say) would make
+        # every other `go version` look like the probe too.
+        env.pop("GOPROXY", None)
         if env_file is not None:
             env["GC_SLACK_ADAPTER_ENV"] = str(env_file)
         env.update(extra_env or {})
@@ -240,14 +325,17 @@ def test_explicit_env_file_is_still_fatal_when_a_binary_exists(harness):
     assert "PREBUILT_RAN" not in proc.stdout
 
 
-def test_self_heal_builds_when_home_is_unset(harness):
+def test_self_heal_builds_when_home_is_unset(harness, tmp_path):
     """Supervisor environments may not set HOME. Under `set -u` an
     unguarded $HOME aborts before the fast path — and `go build` then
     fails a second way, because it can only locate a build cache via
     GOCACHE, XDG_CACHE_HOME, or HOME. Assert the *build* survives, not
     merely the shell."""
     adapter, run, go_invocations, build_environments = harness
+    cache_tmp = tmp_path / "tmpdir"
+    cache_tmp.mkdir()
     proc = run(
+        extra_env={"TMPDIR": str(cache_tmp)},
         drop_env=[
             "HOME",
             "XDG_CONFIG_HOME",
@@ -267,12 +355,16 @@ def test_self_heal_builds_when_home_is_unset(harness):
     assert len(go_invocations()) == 1, go_invocations()
     # The build was handed a usable cache and module path rather than
     # inheriting neither, which is what actually fails on such a host.
-    tmp = os.environ.get("TMPDIR", "/tmp").rstrip("/")
     assert build_environments() == [
-        f"buildenv GOCACHE={tmp}/gc-slack-adapter-gocache "
-        f"GOPATH={tmp}/gc-slack-adapter-gopath"
+        f"buildenv GOCACHE={private_tmp(cache_tmp, 'gc-slack-adapter-gocache')} "
+        f"GOPATH={private_tmp(cache_tmp, 'gc-slack-adapter-gopath')}"
     ], build_environments()
     assert (adapter / "gc-slack-adapter").exists()
+    # Private to this user, not whatever mode the ambient umask gives.
+    for name in ("gc-slack-adapter-gocache", "gc-slack-adapter-gopath"):
+        created = pathlib.Path(private_tmp(cache_tmp, name))
+        assert created.is_dir(), created
+        assert created.stat().st_mode & 0o077 == 0, oct(created.stat().st_mode)
 
 
 @pytest.mark.parametrize("cache_var", ["XDG_CACHE_HOME", "GOCACHE"])
@@ -287,6 +379,8 @@ def test_gopath_is_defaulted_whenever_home_is_unset(harness, tmp_path, cache_var
     adapter, run, go_invocations, build_environments = harness
     cache_dir = tmp_path / "cache"
     cache_dir.mkdir()
+    cache_tmp = tmp_path / "tmpdir"
+    cache_tmp.mkdir()
     drop = [
         "HOME",
         "XDG_CONFIG_HOME",
@@ -297,16 +391,96 @@ def test_gopath_is_defaulted_whenever_home_is_unset(harness, tmp_path, cache_var
         "GC_SLACK_ADAPTER_ENV",
     ]
     drop.remove(cache_var)  # extra_env is applied before drop_env
-    proc = run(extra_env={cache_var: str(cache_dir)}, drop_env=drop)
+    proc = run(
+        extra_env={cache_var: str(cache_dir), "TMPDIR": str(cache_tmp)},
+        drop_env=drop,
+    )
     assert proc.returncode == 0, proc.stderr
     assert "STUB_ADAPTER_RAN" in proc.stdout
     assert len(go_invocations()) == 1, go_invocations()
-    tmp = os.environ.get("TMPDIR", "/tmp").rstrip("/")
     expected_gocache = str(cache_dir) if cache_var == "GOCACHE" else "unset"
     assert build_environments() == [
         f"buildenv GOCACHE={expected_gocache} "
-        f"GOPATH={tmp}/gc-slack-adapter-gopath"
+        f"GOPATH={private_tmp(cache_tmp, 'gc-slack-adapter-gopath')}"
     ], build_environments()
+
+
+def test_tmp_cache_is_reused_across_starts(harness, tmp_path):
+    """The per-user path must stay STABLE, not be re-derived per start.
+    A cold build does not fit the supervisor's readiness window, and it
+    only converges across the resulting kill/restart cycles because
+    `go build` finds its earlier per-package results still cached — a
+    fresh dir each attempt would loop forever on exactly the HOME-less
+    hosts this fallback serves."""
+    adapter, run, _, build_environments = harness
+    cache_tmp = tmp_path / "tmpdir"
+    cache_tmp.mkdir()
+    drop = [
+        "HOME",
+        "XDG_CONFIG_HOME",
+        "XDG_CACHE_HOME",
+        "GOCACHE",
+        "GOPATH",
+        "GOMODCACHE",
+        "GC_SLACK_ADAPTER_ENV",
+    ]
+    first = run(extra_env={"TMPDIR": str(cache_tmp)}, drop_env=drop)
+    assert first.returncode == 0, first.stderr
+    # Second start would exec the binary the first one published, so
+    # clear it to force another build.
+    (adapter / "gc-slack-adapter").unlink()
+    second = run(extra_env={"TMPDIR": str(cache_tmp)}, drop_env=drop)
+    assert second.returncode == 0, second.stderr
+    envs = build_environments()
+    assert len(envs) == 2, envs
+    assert envs[0] == envs[1], envs
+
+
+def test_squatted_tmp_cache_is_not_adopted(harness, tmp_path):
+    """/tmp is world-writable, so another local user can pre-create the
+    predictable cache path — and Go trusts these caches: a seeded GOCACHE
+    can serve object files into a binary holding the Slack bot token, and
+    GOPATH is where a fetched toolchain is unpacked and re-exec'd. A path
+    we did not create must not be adopted.
+
+    A symlink stands in for the foreign-owned directory, which a test
+    cannot create without a second uid; run.sh rejects both through the
+    same `-O`/`! -L` check."""
+    adapter, run, go_invocations, build_environments = harness
+    cache_tmp = tmp_path / "tmpdir"
+    cache_tmp.mkdir()
+    attacker = tmp_path / "attacker-cache"
+    attacker.mkdir()
+    squatted = pathlib.Path(private_tmp(cache_tmp, "gc-slack-adapter-gocache"))
+    squatted.symlink_to(attacker)
+
+    proc = run(
+        extra_env={"TMPDIR": str(cache_tmp)},
+        drop_env=[
+            "HOME",
+            "XDG_CONFIG_HOME",
+            "XDG_CACHE_HOME",
+            "GOCACHE",
+            "GOPATH",
+            "GOMODCACHE",
+            "GC_SLACK_ADAPTER_ENV",
+        ],
+    )
+    # Availability is preserved — it still builds and starts...
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "STUB_ADAPTER_RAN" in proc.stdout
+    assert len(go_invocations()) == 1, go_invocations()
+    # ...but not through the squatted path, and it says so.
+    assert "refusing to reuse it" in proc.stderr
+    envs = build_environments()
+    assert len(envs) == 1, envs
+    assert f"GOCACHE={squatted}" not in envs[0], envs[0]
+    assert str(attacker) not in envs[0], envs[0]
+    # The fallback is still under TMPDIR, just not the predictable name.
+    assert f"GOCACHE={cache_tmp}/" in envs[0], envs[0]
+    # And the symlink was left alone rather than followed into.
+    assert squatted.is_symlink()
+    assert list(attacker.iterdir()) == []
 
 
 def test_no_default_env_file_path_is_never_advertised(harness):
@@ -343,14 +517,19 @@ def test_shell_function_named_go_does_not_shadow_the_toolchain(harness):
     assert "STUB_ADAPTER_RAN" in proc.stdout
 
 
-def test_toolchain_older_than_go_mod_is_rejected_when_pinned(harness):
+@pytest.mark.parametrize("stub_version", OLD_GO_VERSIONS)
+def test_toolchain_older_than_go_mod_is_rejected_when_pinned(harness, stub_version):
     """GOTOOLCHAIN=local means Go cannot upgrade itself, so a toolchain
     below go.mod's directive can never build: say so with a remedy
-    instead of leaking a raw compiler error."""
+    instead of leaking a raw compiler error.
+
+    Driven with both an all-round-older version and one that is older
+    only numerically, so the gate cannot pass on a string compare."""
+    assert_older_than_go_mod(stub_version)
     adapter, run, go_invocations, _ = harness
-    proc = run(extra_env={"GO_STUB_VERSION": "1.0.0", "GOTOOLCHAIN": "local"})
+    proc = run(extra_env={"GO_STUB_VERSION": stub_version, "GOTOOLCHAIN": "local"})
     assert proc.returncode == 1, proc.stdout + proc.stderr
-    assert f"need Go >= {required_go_version()}, found 1.0.0" in proc.stderr
+    assert f"need Go >= {required_go_version()}, found {stub_version}" in proc.stderr
     assert "GOTOOLCHAIN=local" in proc.stderr
     # Refused before building, and nothing was published.
     assert go_invocations() == []
@@ -358,14 +537,124 @@ def test_toolchain_older_than_go_mod_is_rejected_when_pinned(harness):
     assert not list(adapter.glob("gc-slack-adapter.build.*"))
 
 
-def test_toolchain_older_than_go_mod_still_builds_when_downloadable(harness):
-    """Under the default GOTOOLCHAIN=auto, Go fetches the required
-    toolchain itself. Warn, but do not refuse — hosts that build fine
-    today must keep building."""
+@pytest.mark.parametrize("stub_version", OLD_GO_VERSIONS)
+def test_toolchain_older_than_go_mod_still_builds_when_downloadable(
+    harness, stub_version
+):
+    """Run by hand under the default GOTOOLCHAIN=auto, Go fetches the
+    required toolchain itself. Warn, but do not refuse — there is no
+    readiness deadline here and hosts that build fine today must keep
+    building.
+
+    Same two-version parametrization: "1.9.0" only trips the gate if the
+    comparison is numeric."""
+    assert_older_than_go_mod(stub_version)
     adapter, run, go_invocations, _ = harness
-    proc = run(extra_env={"GO_STUB_VERSION": "1.0.0"}, drop_env=["GOTOOLCHAIN"])
+    proc = run(extra_env={"GO_STUB_VERSION": stub_version}, drop_env=["GOTOOLCHAIN"])
     assert proc.returncode == 0, proc.stderr
-    assert f"go.mod needs >= {required_go_version()}" in proc.stderr
+    assert f"is {stub_version} but go.mod needs >= {required_go_version()}" in proc.stderr
+    assert "STUB_ADAPTER_RAN" in proc.stdout
+    assert len(go_invocations()) == 1, go_invocations()
+
+
+@pytest.mark.parametrize("signal", ["GC_SERVICE_NAME", "GC_SERVICE_URL_PREFIX"])
+def test_toolchain_fetch_is_refused_under_the_supervisor(harness, signal):
+    """A too-old toolchain under GOTOOLCHAIN=auto means the build starts
+    by DOWNLOADING a toolchain. gc gives a starting proxy_process ~5s to
+    become ready, then kills the process group and restarts on a 1s
+    backoff with no cap — and unlike a compile, a toolchain fetch keeps
+    no partial progress, so every cycle would re-download it from
+    scratch, forever. Refuse instead: each cycle then exits immediately
+    with a named remedy on stderr rather than burning the network.
+
+    Either supervisor-exported variable is enough to detect this; gc
+    exports both into every proxy_process."""
+    adapter, run, go_invocations, _ = harness
+    proc = run(
+        extra_env={"GO_STUB_VERSION": "1.9.0", signal: "slack"},
+        drop_env=["GOTOOLCHAIN"],
+    )
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+    assert f"need Go >= {required_go_version()}, found 1.9.0" in proc.stderr
+    assert "it is not in the local module cache" in proc.stderr
+    assert "refusing to start that download under the gc supervisor" in proc.stderr
+    # A named remedy, not a raw failure.
+    assert "manual fix: install Go >=" in proc.stderr
+    # Refused before building, and nothing was published.
+    assert go_invocations() == []
+    assert "STUB_ADAPTER_RAN" not in proc.stdout
+    assert not (adapter / "gc-slack-adapter").exists()
+    assert not list(adapter.glob("gc-slack-adapter.build.*"))
+
+
+def test_supervised_build_proceeds_when_the_toolchain_is_already_cached(
+    harness, tmp_path
+):
+    """The refusal above is about a DOWNLOAD, not about the version
+    numbers. Once the newer toolchain sits in the local module cache
+    (someone prebuilt by hand, or an earlier unsupervised run fetched
+    it), the supervised build needs no network and converges exactly like
+    any other warm rebuild — refusing it on the version comparison alone
+    would turn a self-healing host into a permanently dead service, which
+    is the outage this script exists to prevent.
+
+    run.sh tells the two apart by asking Go itself, offline: a
+    `GOPROXY=off go version` from inside the module directory, where the
+    toolchain switch actually happens. Nothing in the version numbers
+    distinguishes this case from the one above — only that probe does."""
+    adapter, run, go_invocations, _ = harness
+    proc = run(
+        extra_env={
+            "GO_STUB_VERSION": "1.9.0",
+            "GO_STUB_TOOLCHAIN_CACHED": "1",
+            "GC_SERVICE_NAME": "slack",
+        },
+        drop_env=["GOTOOLCHAIN"],
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "already in the local module cache" in proc.stderr
+    assert "refusing to start that download" not in proc.stderr
+    # Built and exec'd, same as any warm supervised rebuild.
+    assert "STUB_ADAPTER_RAN" in proc.stdout
+    assert len(go_invocations()) == 1, go_invocations()
+    # The probe has to run in the module directory: that is the only cwd
+    # where the go command performs the switch this asks about. Probing
+    # from anywhere else answers a different question — "does the local
+    # go run at all" — which is always yes, so the refusal would never
+    # fire again.
+    calls = go_version_calls(tmp_path)
+    probes = [
+        c
+        for c in calls
+        if " cwd=" in c
+        and pathlib.Path(c.split(" cwd=", 1)[1]).resolve() == adapter.resolve()
+    ]
+    assert probes, calls
+
+
+def test_supervised_build_is_untouched_when_the_toolchain_is_new_enough(harness):
+    """The supervised refusal is scoped to the toolchain-fetch case. A
+    host whose Go already satisfies go.mod must still self-heal under the
+    supervisor — that is the outage this whole script exists to fix."""
+    adapter, run, go_invocations, _ = harness
+    proc = run(extra_env={"GC_SERVICE_NAME": "slack"})
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "STUB_ADAPTER_RAN" in proc.stdout
+    assert "refusing to start that download" not in proc.stderr
+    assert len(go_invocations()) == 1, go_invocations()
+
+
+def test_missing_go_mod_does_not_kill_the_script_silently(harness):
+    """go.mod is tracked, so only a corrupted checkout hits this — but
+    the failure mode was the script's one silent exit: under `set -e` +
+    `pipefail` the sed reading go.mod exited 2 with its stderr
+    suppressed, killing run.sh at the assignment with no message. An
+    unreadable directive must just skip the version gate and let the
+    compiler be the backstop."""
+    adapter, run, go_invocations, _ = harness
+    (adapter / "go.mod").unlink()
+    proc = run()
+    assert proc.returncode == 0, proc.stdout + proc.stderr
     assert "STUB_ADAPTER_RAN" in proc.stdout
     assert len(go_invocations()) == 1, go_invocations()
 


### PR DESCRIPTION
Post-merge review remediation for #364, which moved the slack service command to the checked-in `adapter/run.sh` with a build-on-missing self-heal. The reviewed landed head was 2f76d6d; this branch is based on current `main` (2d35f4c), not on that older head.

The change is confined to `slack-full/` — `adapter/run.sh`, its test suite, and the CHANGELOG.

## What the review found

Three issues, none of them reachable from CI. CI installs exactly `go.mod`'s toolchain (via `go-version-file`) and always has `HOME` set, so the first host to meet any of these is a production supervisor.

### 1. An in-window toolchain download cannot converge

The rebuild now sits on the service startup path, inside gc's readiness window. gc gives a starting `proxy_process` 5 seconds to accept on its socket and answer `/healthz`, then kills the process group and restarts on a 1-second backoff with **no attempt cap**.

A cold rebuild does not fit that window — measured on this tree at ~11s cold against ~0.7s warm — so the first start after a pin bump wipes the binary is expected to be killed mid-build. That case *converges*, because `go build` checkpoints per-package results in the build cache and each retry resumes cheaper than the last.

A toolchain **download** does not converge. Go fetches to a temp file and renames, so every kill discards the whole transfer and the next restart begins from zero. On a host whose `go` is older than `go.mod` under `GOTOOLCHAIN=auto`, the service re-downloads tens of megabytes every ~8 seconds, forever, with nothing in the logs naming the cause.

This is not a regression against base — base behavior was a service permanently *dead* after every pin bump — but an expensive, undiagnosable loop is a poor trade for a cheap, legible failure.

**Fix.** When the version gate fires, `GOTOOLCHAIN` is not `local`, and run.sh detects it is supervised (gc exports `GC_SERVICE_NAME` / `GC_SERVICE_URL_PREFIX`), it exits 1 with the remedy — install a new enough Go, or prebuild once — instead of starting a fetch it cannot finish. Each restart cycle then ends immediately with its cause on stderr; an early exit takes the supervisor's exited-early path, which skips the kill and records the script's own stderr. Nothing in-repo can stop the restart loop itself; this stops it from burning the network while hiding why.

**Scoped to an actual download.** Version numbers cannot distinguish "must fetch a toolchain" from "the toolchain is already in the module cache", and refusing the second case would turn a host that heals fine today into a permanently dead service — the same class of defect, in the other direction. So run.sh asks Go instead: a `GOPROXY=off go version` from the module directory, where the toolchain switch happens. `GOPROXY=off` also guarantees the probe cannot itself block on the network, so it cannot spend the window it exists to protect. Hand-run behavior is unchanged (warn, let Go fetch); `GOTOOLCHAIN=local` fails as before.

Flap-then-converge is now documented in the run.sh header and the CHANGELOG, including which log repetition is normal and which is not, so nobody debugs the expected flap.

### 2. World-shared Go cache paths in the HOME-less fallback

The `GOCACHE`/`GOPATH` defaults for HOME-less supervisor environments pointed at fixed, predictable names in world-writable `/tmp`. Any other local user can pre-create them, and Go trusts what it finds in both: a seeded `GOCACHE` can serve object files into a binary that holds the Slack bot token and signing secret, and `GOPATH` is where a fetched toolchain is unpacked and re-exec'd.

**Fix.** Per-user name, `mkdir -m 700` with no `-p` so an existing directory is not silently adopted, an `-O` and `! -L` ownership check before reuse, and a loud refusal plus an unpredictable `mktemp -d` when the name is unusable. `/tmp`'s sticky bit covers the post-creation swap, since only the owner can unlink.

These paths stay **stable across restarts** deliberately: reuse between supervisor restarts is exactly what lets the flap in (1) converge, so a fresh directory per start would never converge on the HOME-less hosts this fallback serves. The per-run `mktemp` is only the anomalous-case fallback — availability over speed there, never the normal path.

### 3. One silent exit

A missing `adapter/go.mod` killed the script with no message. `need_go=` reads it through a pipeline whose `sed` exits 2; `pipefail` propagates that and `set -e` exits at the assignment — the one silent exit in an otherwise loudly-logged script. An empty `need_go` already skips the version gate by design, so the `|| true` restores that and leaves the compiler as the backstop.

### 4. CHANGELOG upgrade note was inverted

The entry warned about an explicit-path strictening that was never new, and omitted the change operators actually need to audit. run.sh has always exited 1 on a missing explicitly-named env file (it exited 1 on a missing env file of *any* kind), and the old service command was the binary, which never read `GC_SLACK_ADAPTER_ENV` at all — so what is new is *which process* enforces the rule, not the rule. Rewritten to say that, and to document the genuine loosening it left out: a hand-run run.sh now warns and continues without an env file where it used to refuse, so it can reach a different Slack workspace than intended.

## Verification

- `slack-full` suite: **409 passed**. `bash -n` clean, `gc lint slack-full` ok, `validate_registry.py --require-git` ok.
- Repo-wide `pytest tests slack-full/tests`: clean apart from `tests/test_gastown_lint_findings.py`, which fails **identically on an untouched checkout of this base**. It pins gastown findings against CI's `gc@latest`; a newer local gc no longer reports five of them. Unrelated to this diff, which touches only `slack-full/`.
- Both version-gate tests are now parametrized with `1.9.0` alongside `1.0.0`. `1.9.0` is below `go.mod`'s directive only *numerically* (`1.9` sorts above `1.25` as text), which is the case `version_key` exists for — the suite previously stayed green if that comparator regressed to a string compare. A helper asserts each stub version really is older than the live `go` directive, so a future directive bump cannot quietly turn these into no-op tests.
- New behavioral tests: the supervised refusal (over both supervisor signals), the supervised build **proceeding** when the toolchain is already cached, an unrelated supervised build left untouched, cache reuse across restarts, a squatted cache path not being adopted, and a missing `go.mod` no longer killing the script.
- Harness hermeticity: `run()` now clears `GC_SERVICE_NAME`, `GC_SERVICE_URL_PREFIX` and `GOPROXY`, so the suite cannot change verdict depending on whether pytest itself ran inside a gc service, and tests that assert on cache paths get their own `TMPDIR` instead of leaving state in the real `/tmp`.
- Mutation-checked. Each mutation reverts one fix and turns exactly the intended tests red: refusing unconditionally on the version compare (fails the cached-toolchain test alone), inverting the probe, dropping its `GOPROXY=off`, dropping its `cd` into the module directory, deleting the supervised fail-fast, dropping `|| true`, dropping the per-uid suffix, swapping the stable cache dir for a per-run `mktemp`, dropping `! -L`, and swapping `version_key` for a lexical compare — which fails only the `1.9.0` parameters, the gap this closes.

## Deliberately not in this PR

- **The structural fix belongs to gc, not to this pack.** A per-service readiness timeout, or building at `gc import install` time, would remove the window race for every pack; run.sh can only refuse the one step that cannot make partial progress. Filed as gastownhall/gascity#6141.
- **The sibling Slack tiers.** The same pin-bump stranding this fixes is still live in `slack-channel` and `slack-mini`, which were extracted from this pack before the run.sh entrypoint existed. Out of diff for this remediation; filed as #404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
