### PR TITLE
ci(slack): guard darwin-only build breaks and complete the Go cache key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,20 @@ jobs:
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
           go-version-file: slack-full/adapter/go.mod
+          # Every go.sum in the repo, or the cache silently under-covers:
+          # slack-full/adapter's is new (it took its first dependency in #269)
+          # and slack-mini/adapter's was never listed, so both were re-fetched
+          # from the proxy on every run and neither would invalidate the cache
+          # on a future dependency bump. The other three modules
+          # (slack-channel/adapter, runtime-cloudflare/runtime, and the root
+          # module) have no external deps and so no go.sum — nothing to list,
+          # and nothing worth listing speculatively: setup-go hashes these
+          # paths as a set and throws "Some specified paths were not resolved"
+          # if the match comes back empty.
           cache-dependency-path: |
+            slack-full/adapter/go.sum
             slack-full/cli/go.sum
+            slack-mini/adapter/go.sum
 
       - name: Install Python test dependencies
         run: python3 -m pip install PyYAML pytest jsonschema
@@ -107,6 +119,27 @@ jobs:
       - name: Run Slack mini adapter tests
         working-directory: slack-mini/adapter
         run: go test ./...
+
+      # Recurrence guard for #269: the adapter reached main calling
+      # syscall.Openat, which does not exist on darwin, because every Go step
+      # above builds for linux only — a developer on a Mac was the first and
+      # only detector. confined_open.go is security-critical platform-syscall
+      # code, so that break has to surface here instead.
+      #
+      # `go vet` and not `go build`: vet type-checks _test.go files too, and
+      # two of #269's three repairs lived in test files. Refute with a
+      # darwin-only symbol referenced from a _test.go alone — `go build ./...`
+      # stays green, `go vet ./...` fails.
+      #
+      # Cross-compilation, so no macOS runner is needed. It catches the
+      # compile-break class only; darwin *runtime* behavior stays unverified.
+      - name: Cross-compile Go modules for darwin
+        run: |
+          for module in slack-full/adapter slack-full/cli \
+                        slack-channel/adapter slack-mini/adapter; do
+            echo "==> $module"
+            (cd "$module" && GOOS=darwin GOARCH=arm64 go vet ./...)
+          done
 
       - name: Run runtime-cloudflare module tests
         working-directory: runtime-cloudflare/runtime

--- a/slack-full/adapter/run.sh
+++ b/slack-full/adapter/run.sh
@@ -53,6 +53,20 @@ version_key() {
 
 bin_dir="$(cd "$(dirname "$0")" && pwd)"
 
+# Printed by every build-failure path, so the remedy is one string instead
+# of three that drift apart. `go mod download` is not decoration: the
+# adapter took its first dependency (golang.org/x/sys) and the self-heal
+# below now needs a warm module cache or GOPROXY egress the first time it
+# builds. A bare `go build` remedy dead-ends on the same "module lookup
+# disabled by GOPROXY=off" that sent the operator here, so name the
+# precondition in the message they actually read rather than only in the
+# CHANGELOG. $1 is an optional lead-in for callers with a further remedy
+# to offer first.
+log_build_remedy() {
+  log "manual fix: ${1:+$1 }cd $bin_dir && go mod download && go build -o gc-slack-adapter ."
+  log "  (go mod download needs a reachable GOPROXY; on an egress-restricted host point GOPROXY at an allowed proxy or warm the module cache first)"
+}
+
 # A defaulted env-file path and one the operator named explicitly are
 # different cases and must not fail the same way. A missing default is
 # ordinary — supervised deployments often inject the env another way.
@@ -145,7 +159,7 @@ else
 fi
 if [[ -z "$go_bin" ]]; then
   log "ERROR: no Go toolchain found (checked PATH, /opt/homebrew/bin, /usr/local/go/bin, /usr/local/bin, /usr/bin, /bin, ~/go/bin)"
-  log "manual fix: cd $bin_dir && go build -o gc-slack-adapter ."
+  log_build_remedy
   exit 1
 fi
 
@@ -168,7 +182,7 @@ if [[ -n "$need_go" && -n "$have_go" ]] &&
   go_too_old=1
   if [[ "${GOTOOLCHAIN:-auto}" == "local" ]]; then
     log "ERROR: need Go >= $need_go, found $have_go at $go_bin (GOTOOLCHAIN=local pins this toolchain)"
-    log "manual fix: install Go >= $need_go, unset GOTOOLCHAIN, or prebuild: cd $bin_dir && go build -o gc-slack-adapter ."
+    log_build_remedy "install Go >= $need_go, unset GOTOOLCHAIN, or prebuild:"
     exit 1
   fi
   log "WARNING: $go_bin is $have_go but go.mod needs >= $need_go — Go will try to fetch the required toolchain (needs network and a writable module cache)"
@@ -208,7 +222,7 @@ if ! (cd "$bin_dir" && "$go_bin" build -o "$tmp_bin" .); then
   if (( go_too_old )); then
     log "likely cause: $go_bin is $have_go but go.mod needs >= $need_go — install Go >= $need_go or prebuild the binary"
   fi
-  log "manual fix: cd $bin_dir && go build -o gc-slack-adapter ."
+  log_build_remedy
   exit 1
 fi
 mv -f "$tmp_bin" "$adapter_bin"

--- a/slack-full/tests/test_adapter_run_sh.py
+++ b/slack-full/tests/test_adapter_run_sh.py
@@ -379,6 +379,12 @@ def test_go_build_failure_exits_1_and_publishes_nothing(harness):
     assert proc.returncode == 1, proc.stdout + proc.stderr
     assert "go build failed" in proc.stderr
     assert "manual fix: cd " in proc.stderr
+    # The adapter has an external dependency, so a bare `go build` remedy
+    # dead-ends on the same cold-cache/GOPROXY wall that produced the
+    # failure being reported. The remedy must name the module fetch and
+    # the lever that makes it work on an egress-restricted host.
+    assert "go mod download" in proc.stderr
+    assert "GOPROXY" in proc.stderr
     assert "STUB_ADAPTER_RAN" not in proc.stdout
     assert not (adapter / "gc-slack-adapter").exists()
     assert not list(adapter.glob("gc-slack-adapter.build.*"))


### PR DESCRIPTION
Post-merge review remediation for #269 (reviewed range `128002e..f752713`).

The landed change in #269 was correct — it was verified at base and at head by
reproduction and darwin cross-compilation. This follow-up builds the recurrence
guard that #269 did not, plus the two one-line co-edits in the files that guard
already touches. **The reviewed production change is untouched:**
`confined_open.go`, its test fixtures, and `go.mod`/`go.sum` are not modified.

## What this changes

**Darwin cross-compile step in CI (the gating item).** #269 reached `main`
calling `syscall.Openat`, which does not exist on darwin, because every Go step
in the `check` job builds for linux only — a developer on a Mac was the first
and only detector of a break in security-critical syscall code. A new step
cross-compiles `slack-full/adapter`, `slack-full/cli`, `slack-channel/adapter`
and `slack-mini/adapter` for `darwin/arm64`. No macOS runner required.

`go vet` rather than `go build`, because vet also type-checks `_test.go` files
and two of #269's three fixture repairs lived in test files.

**Complete the setup-go cache key.** `cache-dependency-path` listed only
`slack-full/cli/go.sum`. `slack-full/adapter/go.sum` is new in #269 and
`slack-mini/adapter/go.sum` was never listed, so both modules were re-fetched
from the proxy on every run and neither would invalidate the cache on a future
dependency bump. The remaining three modules have no external deps and no
`go.sum`.

**Name the module-fetch precondition in `run.sh`'s remedies.** The adapter's
first dependency means the self-heal build now needs a warm module cache or
GOPROXY egress. #269's CHANGELOG documents this and explicitly concedes that
"the remedy `run.sh` prints on failure hits the same wall" — so an operator on
an egress-restricted host was handed a remedy that dead-ends exactly where they
already are. The three remedy strings are consolidated into one helper so they
cannot drift apart again.

## Verification

The CI step was extracted verbatim from the YAML and run in both directions:

| Arm | Result |
|---|---|
| All four modules at this branch's HEAD | `rc=0` |
| Same step against the pre-fix tree (`128002e`) | `rc=1`, `vet: ./confined_open.go:46:24: undefined: syscall.Openat` |
| Same module, `GOOS=linux`, pre-fix tree | `rc=0` — confirms the failure is darwin-specific |
| Darwin-only symbol referenced from a `_test.go` only | `go build ./...` green, `go vet ./...` fails — confirms the vet-over-build choice |

Also confirmed that `bash -e` (GitHub's default shell) aborts the loop on a
failing module rather than running to the end and reporting success.

Tests:

- `slack-full/tests` — 431 passed
- `tests/test_gascity_pack_inference_gate.py` (reads `ci.yml`) — 63 passed
- The new `run.sh` assertion was mutation-checked: it fails against the
  unfixed `run.sh` and passes against the fixed one, so the pin is live.
- `shellcheck` and `bash -n` clean on `run.sh`; `actionlint` finding count on
  `ci.yml` unchanged from `main` (1 before, 1 after — the pre-existing
  custom `blacksmith-*` runner label); every `cache-dependency-path` entry
  resolves to a file that exists.

## Not in this PR

Two findings from the same review were routed to independent follow-ups rather
than bundled here: converting the two remaining test fixtures to
`tempDirResolved` (it would re-edit the test files #269 just landed), and
migrating four portable `syscall.Open` call sites to `x/sys/unix` (unrelated
churn in security-relevant paths, and they compile on darwin today).

Cross-compilation proves the build, not darwin runtime behavior; that remains
unverified by CI and is called out in the step's comment.