### PR TITLE
fix(gascity): narrow the check-gate capture-file trap to EXIT so a signal still kills the gate

### DIFF
--- a/gascity/assets/scripts/checks/build-artifact-valid.sh
+++ b/gascity/assets/scripts/checks/build-artifact-valid.sh
@@ -50,10 +50,12 @@ print(value if isinstance(value, str) else "")
 }
 
 GC_ERR="$(mktemp)"
-# EXIT alone does not fire on an untrapped signal, and check gates run under a
-# documented 10m dispatcher budget -- timeout kills are an expected path, not a
-# hypothetical one, so each would leak this capture file. SIGKILL leaks either way.
-trap 'rm -f "$GC_ERR"' EXIT INT TERM HUP
+# EXIT only, and that suffices: bash runs the EXIT trap before re-raising an
+# untrapped fatal signal, so INT/TERM/HUP already reclaim this file while still
+# exiting 130/143/129. Listing them here would only ABSORB them -- the gate would
+# run on and report its own verdict where it used to die. The dispatcher's
+# 10m-budget kill is an untrappable SIGKILL, which no trap list can catch.
+trap 'rm -f "$GC_ERR"' EXIT
 SHOW_JSON="$(gc bd show "$BEAD_ID" --json 2>"$GC_ERR")" \
   || fail "gc bd show $BEAD_ID failed: $(tail -c 400 "$GC_ERR" | tr '\n' ' ')"
 

--- a/gascity/assets/scripts/checks/design-review-approved.sh
+++ b/gascity/assets/scripts/checks/design-review-approved.sh
@@ -44,10 +44,12 @@ if [ -z "$BEAD_ID" ]; then
 fi
 
 GC_ERR="$(mktemp)"
-# EXIT alone does not fire on an untrapped signal, and check gates run under a
-# documented 10m dispatcher budget -- timeout kills are an expected path, not a
-# hypothetical one, so each would leak this capture file. SIGKILL leaks either way.
-trap 'rm -f "$GC_ERR"' EXIT INT TERM HUP
+# EXIT only, and that suffices: bash runs the EXIT trap before re-raising an
+# untrapped fatal signal, so INT/TERM/HUP already reclaim this file while still
+# exiting 130/143/129. Listing them here would only ABSORB them -- the gate would
+# run on and report its own verdict where it used to die. The dispatcher's
+# 10m-budget kill is an untrappable SIGKILL, which no trap list can catch.
+trap 'rm -f "$GC_ERR"' EXIT
 BEAD_JSON=$(gc bd show "$BEAD_ID" --json 2>"$GC_ERR") || {
     echo "ERROR: gc bd show $BEAD_ID failed: $(tail -c 400 "$GC_ERR" | tr '\n' ' ')" >&2
     exit 1

--- a/gascity/assets/scripts/checks/gap-analysis-approved.sh
+++ b/gascity/assets/scripts/checks/gap-analysis-approved.sh
@@ -57,10 +57,12 @@ metadata_value() {
 }
 
 GC_ERR="$(mktemp)"
-# EXIT alone does not fire on an untrapped signal, and check gates run under a
-# documented 10m dispatcher budget -- timeout kills are an expected path, not a
-# hypothetical one, so each would leak this capture file. SIGKILL leaks either way.
-trap 'rm -f "$GC_ERR"' EXIT INT TERM HUP
+# EXIT only, and that suffices: bash runs the EXIT trap before re-raising an
+# untrapped fatal signal, so INT/TERM/HUP already reclaim this file while still
+# exiting 130/143/129. Listing them here would only ABSORB them -- the gate would
+# run on and report its own verdict where it used to die. The dispatcher's
+# 10m-budget kill is an untrappable SIGKILL, which no trap list can catch.
+trap 'rm -f "$GC_ERR"' EXIT
 if ! ROOT_JSON="$(gc bd show "$ROOT_ID" --json 2>"$GC_ERR")"; then
   echo "gap check: note: gc bd show $ROOT_ID failed: $(tail -c 400 "$GC_ERR" | tr '\n' ' ')" >&2
 fi

--- a/gascity/assets/scripts/checks/implementation-review-approved.sh
+++ b/gascity/assets/scripts/checks/implementation-review-approved.sh
@@ -91,10 +91,12 @@ is_approved() {
 }
 
 GC_ERR="$(mktemp)"
-# EXIT alone does not fire on an untrapped signal, and check gates run under a
-# documented 10m dispatcher budget -- timeout kills are an expected path, not a
-# hypothetical one, so each would leak this capture file. SIGKILL leaks either way.
-trap 'rm -f "$GC_ERR"' EXIT INT TERM HUP
+# EXIT only, and that suffices: bash runs the EXIT trap before re-raising an
+# untrapped fatal signal, so INT/TERM/HUP already reclaim this file while still
+# exiting 130/143/129. Listing them here would only ABSORB them -- the gate would
+# run on and report its own verdict where it used to die. The dispatcher's
+# 10m-budget kill is an untrappable SIGKILL, which no trap list can catch.
+trap 'rm -f "$GC_ERR"' EXIT
 if ! ROOT_JSON="$(gc bd show "$ROOT_ID" --json 2>"$GC_ERR")"; then
   echo "review check: note: gc bd show $ROOT_ID failed: $(tail -c 400 "$GC_ERR" | tr '\n' ' ')" >&2
 fi

--- a/gascity/tests/test_formula_assets.py
+++ b/gascity/tests/test_formula_assets.py
@@ -4,8 +4,10 @@ import json
 import os
 import pathlib
 import re
+import signal
 import subprocess
 import tempfile
+import time
 import tomllib
 import unittest
 
@@ -6217,7 +6219,76 @@ description = "Override sink that writes the base triage report contract."
         self.assertEqual(result.returncode, 1)
         self.assertIn("ERROR: gc bd show design-bead failed", result.stderr)
         self.assertIn("DESIGN_SHOW_FAILURE", result.stderr)
-        # `trap 'rm -f "$GC_ERR"' EXIT INT TERM HUP` actually reclaims the file.
+        # `trap 'rm -f "$GC_ERR"' EXIT` actually reclaims the file.
+        self.assertEqual(leaked, [])
+
+    def test_design_review_check_dies_on_signal_instead_of_absorbing_it(self) -> None:
+        # The capture-file trap must stay EXIT-only. Naming INT/TERM/HUP on it
+        # without exiting from the handler absorbs those signals: the gate
+        # survives, runs to completion and reports a verdict of its own where it
+        # previously died, and the handler unlinks $GC_ERR before the error path
+        # can read it. EXIT alone still reclaims the file, because bash runs the
+        # EXIT trap before re-raising an untrapped fatal signal -- so this pins
+        # the signal half of the trap that the file-cleanup assertions cannot.
+        root = pathlib.Path(__file__).resolve().parents[1]
+        script = root / "assets" / "scripts" / "checks" / "design-review-approved.sh"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            bin_dir = pathlib.Path(tmp) / "bin"
+            bin_dir.mkdir()
+            tmpdir = pathlib.Path(tmp) / "tmpdir"
+            tmpdir.mkdir()
+            fake_gc = bin_dir / "gc"
+            # Slow, so the signal lands while the gate is blocked in its first
+            # `gc bd show` -- where a kill would realistically find it. Bounded
+            # at 10s because this child is orphaned once the gate dies; the
+            # signal is sent within ~50ms of the capture file appearing.
+            fake_gc.write_text("#!/bin/sh\nsleep 10\n", encoding="utf-8")
+            fake_gc.chmod(0o755)
+            env = {
+                **os.environ,
+                "GC_BEAD_ID": "design-bead",
+                "TMPDIR": str(tmpdir),
+                "PATH": f"{bin_dir}:{os.environ.get('PATH', '')}",
+            }
+            # DEVNULL rather than PIPE: the `gc` child inherits the pipe and
+            # holds it open after the gate dies, so reading to EOF would outlast
+            # the gate itself and read as absorption when it is not.
+            proc = subprocess.Popen(
+                [str(script)],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                env=env,
+            )
+            try:
+                deadline = time.monotonic() + 15
+                captured = []
+                while time.monotonic() < deadline:
+                    captured = sorted(p.name for p in tmpdir.iterdir())
+                    if captured:
+                        break
+                    time.sleep(0.05)
+                proc.send_signal(signal.SIGTERM)
+                try:
+                    returncode = proc.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    returncode = None
+            finally:
+                if proc.poll() is None:
+                    proc.kill()
+                    proc.wait()
+            leaked = sorted(p.name for p in tmpdir.iterdir())
+
+        # Positive control: the capture file was present when the signal landed,
+        # so an empty TMPDIR below means "reclaimed", not "never created".
+        self.assertEqual(len(captured), 1)
+        self.assertIsNotNone(
+            returncode,
+            "gate absorbed SIGTERM and kept running instead of dying",
+        )
+        # Killed *by* the signal, exactly as it was before stderr capture was
+        # added -- not exiting through its own verdict logic.
+        self.assertEqual(returncode, -signal.SIGTERM)
         self.assertEqual(leaked, [])
 
     def test_implementation_review_check_notes_parent_show_stderr(self) -> None:


### PR DESCRIPTION
Post-merge review follow-up for #255 (reviewed range `2109fd3a..d65abfa`). The
landed change is net-positive and stays; this fixes the one major issue the
review found and corrects a claim in its commit message.

## The problem

#255 added `trap 'rm -f "$GC_ERR"' EXIT INT TERM HUP` to four check gates to
reclaim the ~100-byte stderr capture file. The handler never exits, so trapping
INT/TERM/HUP **absorbs** them — an interrupted gate no longer dies, it runs to
completion and reports a verdict of its own. Measured against the pre-#255
script under a slow fake `gc`:

| script | SIGTERM at 0.7s |
| --- | --- |
| base (pre-#255) | dies immediately, `rc=143` |
| head (#255, on `main`) | survives, runs on, exits `rc=1` through its own logic |

`condition.go:373-377` maps any non-zero exit outside the deadline path to
`GateFail`, and a zero exit to a non-fail outcome — so an interrupted gate can
report a completed, possibly approving, verdict where it previously died. In the
same window the handler unlinks `$GC_ERR` before the error path reads it,
degrading the message to `ERROR: gc bd show <id> failed: ` plus a stray
`tail: cannot open ...`, destroying precisely the diagnostic #255 exists to
deliver.

The trap's justifying comment was wrong in both directions:

- *"timeout kills are an expected path"* — gates run under `exec.CommandContext`
  with no `cmd.Cancel` override (`condition.go:319`), so the 10m budget kill is
  an untrappable **SIGKILL**, and `condition.go:361-363` classifies the deadline
  path as `GateTimeout` before the exit code is consulted. No trap list can
  affect it.
- *"EXIT alone does not fire on an untrapped signal"* — it does. bash runs the
  EXIT trap before re-raising, so EXIT-only still reclaims the file on
  TERM/INT/HUP (measured `rc` 143/130/129, file gone, with a positive control
  asserting the file existed when the signal landed).

So the widened list bought **no** cleanup and cost the gates' signal semantics.

## The fix

Narrow all four traps to `trap 'rm -f "$GC_ERR"' EXIT` and rewrite the four
identical comments to state the measured truth. These are template assets copied
into every rig's `.gc/scripts/checks/` and consumed by ~40 formula steps, so the
comment mattered as much as the code — it was a false rationale positioned to be
copied.

Adds one regression test. #255's commit message claimed "an in-process test
cannot observe a signal-killed gate's temp file", which is why the defect
shipped unpinned; that claim is wrong. The likely cause of the mistake: the
orphaned `gc` child inherits the stdout/stderr pipes and holds them open after
the gate dies, so `communicate()` outlasts the gate and reads as absorption. The
test uses `DEVNULL` + `wait()` instead — the same effect gascity's own runner
documents at `condition.go:328-330` (`cmd.WaitDelay`).

## Validation

- `python3 -m unittest discover -s gascity/tests` — **209 tests, all pass**
  (208 before, +1 new pin).
- Mutation matrix on `design-review-approved.sh`:

  | arm | signal pin | cleanup pin |
  | --- | --- | --- |
  | control (as shipped here) | GREEN | GREEN |
  | restore `EXIT INT TERM HUP` | **RED** | GREEN |
  | delete the trap entirely | RED | RED |
  | `trap '...; exit 1' INT TERM HUP` | **RED** | GREEN |

  The new pin reds precisely on the defect this fixes — which nothing caught
  before — and also on the `exit 1` handler variant, which would fabricate an
  ordinary `GateFail` out of a kill.
- No-signal behaviour is byte-identical to #255: same fail lines, same exit
  codes, empty `TMPDIR`.
- `bash -n` on all four; `shellcheck -S warning` clean apart from the
  pre-existing SC1010; `git diff --check` clean; executable bits preserved.

## Deliberately not included

Pre-existing and out of scope, filed by the same review: `gmol()`'s `mktemp -d`
temp-*directory* leak, the unpinned `tail -c 400` cap, and the jq-stage silent
swallow (the same class #255 fixed for `gc bd show`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
