### PR TITLE
fix(gastown/witness): make the crashed-polecat handoff survive the gc bd wrapper

### DIFF
--- a/gastown/formulas/mol-witness-patrol.toml
+++ b/gastown/formulas/mol-witness-patrol.toml
@@ -390,12 +390,18 @@ off if the refinery's `--has-metadata-key=branch` query cannot see the work.
 ```bash
 if [ "$HANDOFF_STAGE" = "target_recorded" ] && [ -n "$BRANCH_ON_ORIGIN" ]; then
   REFINERY_TARGET="${GC_RIG:+$GC_RIG/}{{binding_prefix}}refinery"
-  # --force: this is a cross-actor write against the dead polecat's live
-  # in_progress claim, which bd refuses without it (the same claim guard
-  # Step 3's close cites, gastownhall/beads#3734). Step 6 needs no --force
-  # only because the polecat runs it as the bead's own actor.
+  # --if-assignee: this is a cross-actor write against the dead polecat's live
+  # in_progress claim, which bd refuses unguarded (the same claim guard Step 3's
+  # close cites, gastownhall/beads#3734). The CAS -- not --force -- is what
+  # satisfies that guard on `gc bd update`: the wrapper allowlists flags per
+  # subcommand, and --force is registered for close and delete but not for
+  # update, so passing it here aborts in the arg scanner before the call reaches
+  # any store. Naming the dead polecat's own assignee also makes the write
+  # conditional on it still holding the bead, so a claim race falls through to
+  # Step 3b instead of overwriting a live claim. Step 6 needs no guard only
+  # because the polecat runs it as the bead's own actor.
   if gc bd update <bead> --status=open --assignee="$REFINERY_TARGET" \
-       --set-metadata gc.routed_to="" --force; then
+       --set-metadata gc.routed_to="" --if-assignee "$ASSIGNEE"; then
     # Close the crashed polecat's workflow subtree, as Step 3b does. Only the
     # delete-source half: reopen-source would clear the assignee just set.
     # Ordered after the reassignment so the failure arm mutates nothing, and

--- a/gastown/tests/test_gastown_pack_assets.sh
+++ b/gastown/tests/test_gastown_pack_assets.sh
@@ -382,10 +382,25 @@ test_witness_handoff_recovery_is_guarded_and_fail_closed() {
 
     # The claim guard and the fail-closed arm. bd refuses a cross-actor
     # --assignee write against the dead polecat's live in_progress claim
-    # without --force; unchecked, the witness would then mail success, delete
-    # the worktree, and skip the 3b reset that used to recover the bead.
-    printf '%s\n' "$block" | grep -F -- '--set-metadata gc.routed_to="" --force' >/dev/null ||
-        fail "Step 3a's cross-actor reassignment must pass --force"
+    # unguarded; unchecked, the witness would then mail success, delete the
+    # worktree, and skip the 3b reset that used to recover the bead. The guard
+    # must be the --if-assignee CAS: gc bd allowlists flags per subcommand and
+    # registers --force for close and delete but not for update, so a --force
+    # form aborts in the arg scanner before it reaches any store, leaving the
+    # handoff inert behind a green suite.
+    printf '%s\n' "$block" |
+        grep -F -- '--set-metadata gc.routed_to="" --if-assignee "$ASSIGNEE"' >/dev/null ||
+        fail "Step 3a's cross-actor reassignment must guard the write with --if-assignee \"\$ASSIGNEE\""
+    # Paired negative pin: the positive literal above is a prefix of the
+    # --force-appended form, so on its own it stays green over the one
+    # regression most likely to be reattempted -- a pair that is rejected twice
+    # over, first by the arg scanner and then by cobra's force/if-assignee
+    # mutual exclusion. Comment lines are excluded so the rationale above can
+    # name the flag it forbids; the worktree removal's own --force is a
+    # different call and stays allowed.
+    ! printf '%s\n' "$block" | grep -v '^[[:space:]]*#' | grep -F -- '--force' |
+        grep -vF 'git worktree remove' >/dev/null ||
+        fail "Step 3a must not pass --force to gc bd update: gc bd's per-subcommand allowlist rejects it before the store"
     # Failure policy, pinned separately from the ordering signature below so a
     # change to either reports as itself. delete-source runs after the
     # reassignment has already succeeded, so it is best-effort like the


### PR DESCRIPTION
Post-merge review of #322 (landed range `ef28498..b43abe6`) found one **major**
correctness defect that no review lane caught before merge. This PR fixes it.

## The defect

#322 added Step 3a to `mol-witness-patrol` so a polecat killed between
`submit-and-exit` steps 5 and 6 has its handoff completed rather than reset to
the pool. The reassignment shipped as:

```bash
gc bd update <bead> --status=open --assignee="$REFINERY_TARGET" \
     --set-metadata gc.routed_to="" --force
```

`gc bd update ... --force` never reaches the store. The `gc bd` wrapper resolves
write IDs by scanning argv and fails closed on any flag outside its
**per-subcommand** allowlist, and `--force` is registered for `close` and
`delete` but not for `update`:

```
gc bd: cannot safely verify bead IDs (unrecognized flag in args
[update ... --force]); aborting to prevent substring-resolution mutation
of the wrong bead
```

So Step 3a's `if` always fails and control falls through the `else` to exactly
the Step 3b pool reset that #276 exists to avoid. **The whole feature is inert.**

It fails *safely* — the failure arm was deliberately built to mutate nothing, so
nothing regressed against base — but the behavior #322 was written to deliver
never happens, and its 100-line test suite is green over a code path that cannot
execute.

Measured against the deployed `gc`, using a bogus non-`gcg-` id so the
infra-class binding does not mask the wrapper:

| probe | result |
|---|---|
| `gc bd update <id> ... --force` (the shipped shape) | rc=1, arg-scanner abort, never reaches the store |
| same with `-f`, and with `--force` in first position | rc=1, identical — position-independent |
| `gc bd update <id> ... --if-assignee <actor>` | passes the wrapper, reaches the store |
| `gc bd close <id> --force` (pre-existing, `:334`) | passes — the allowlist is per-subcommand |

**Why three review lanes missed it:** each verified `--force` against bare
`bd`'s help, where it is real and documented ("overwrite another actor's live
in_progress claim"). The formula calls `gc bd`. The working `close --force` form
sits a few dozen lines above in the same file and reads like a precedent.

## The fix

Replace `--force` with `--if-assignee "$ASSIGNEE"`. It passes the wrapper and
satisfies the same gastownhall/beads#3734 cross-actor claim guard on its own —
measured: a cross-actor write is rc=0 with the CAS and rc=1 refused without it.
`$ASSIGNEE` is the dead polecat's assignee, already resolved in Step 1.

As a side effect the write becomes a compare-and-swap conditional on the dead
polecat still holding the bead, so a claim race now falls through to Step 3b
instead of overwriting a live claim.

The rationale comment at `:393` is updated: the CAS, not `--force`, is what
satisfies the cross-actor guard here.

> [!WARNING]
> Do **not** "fix" this by adding `--if-assignee` *alongside* `--force`. The
> pair is rejected by the same arg scanner, and by cobra's
> `[force if-assignee]` mutual-exclusion group behind it — while the originally
> shipped pin stays **green**. That is strictly worse than the status quo: a
> silently-green suite over a permanently-dead call.

## Tests

The coupled `grep -F` pin at `test_gastown_pack_assets.sh:387` is repointed to
the new literal **in the same commit** — the formula edit alone reds the suite.

It is also **paired with a negative pin**, because the positive literal is a
*prefix* of the `--force`-appended form and therefore inert against the one
regression most likely to be reattempted. Measured directly: with only the
literal repointed, appending `--force` leaves the suite **rc=0**. With the
negative pin, it reds.

Mutation matrix — each arm run against a green control and reverted after:

| Mutant | Class | Suite |
|---|---|---|
| Revert the formula line to `--force` | deletion | **red** |
| Append `--force` after the CAS | addition | **red** |
| Prepend `--force` before the CAS | addition | **red** |
| Drop the guard entirely | deletion | **red** |

Each red names itself: the first, third and fourth fail on the CAS pin, the
second on the negative pin.

Suites at this head:

- `gastown/tests/test_gastown_pack_assets.sh` — rc=0
- `gastown/tests/test_polecat_push_gate.sh` — rc=0
- `tests/test_gascity_pack_inference_gate.py` — 74 passed

The formula still parses as TOML, and Step 3a's ordering signature is unaffected
(it anchors on the `if gc bd update <bead> ` prefix). The `:334` close and
`:415` worktree-removal `--force` sites are different calls and are untouched;
the negative pin excludes both.

## Scope

Deliberately limited to the one gating finding. Three non-gating issues from the
same review are **not** included here — all pre-existing and byte-identical at
base `ef28498`:

- `mol-witness-patrol.toml:263` resolves the worktree with `.worktree` where
  every writer records `work_dir`, so `$WORKTREE` is always empty and Step 2's
  salvage cases run `cd ""` (rc=0, cwd unchanged).
- `mol-refinery-patrol.toml:233`'s `delete-source`/`reopen-source` cleanup is
  pinned by neither net.
- Step 4's canned pool-reset mail contradicts the `ORPHAN_HANDED_OFF` mail 3a
  sends — reachable only once this PR lands and 3a actually fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
