### PR TITLE
fix(slack-full): unalias the dedup receipt header and let publish-to-channel outlast its readback

### DIFF
--- a/slack-full/CHANGELOG.md
+++ b/slack-full/CHANGELOG.md
@@ -10,6 +10,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Post-merge follow-ups to the publish-readback change (#313). The
+  adapter's publish dedup cache no longer hands callers a receipt whose
+  `Metadata` map aliases the cached entry: `/publish` re-verifies a
+  posted-but-unconfirmed receipt by writing that map outside the cache
+  lock, so two concurrent retries on one idempotency key raced on a
+  shared map (a data race, and reachable `fatal error: concurrent map
+  writes`). `gc slack publish-to-channel`'s client budget goes 15s → 30s,
+  above the 22.4s worst case `/publish` now spends on a write plus its
+  readback — under it, the client gave up on a message Slack had already
+  accepted, and because that command published *unkeyed* the operator's
+  retry duplicated it. It now derives a deterministic idempotency key
+  from the session, conversation, kind, thread anchor and body when
+  `--idempotency-key` is omitted (matching `reply-current`), so a retry
+  dedupes; pass an explicit key to send the same text twice on purpose.
+  Because the adapter stamps keyed publishes with the low-visibility
+  `_ref:<12hex>_` marker, `publish-to-channel` messages now carry that
+  footer like `reply-current`'s already do — which is also what lets the
+  readback match them by marker instead of by normalized text.
+  The `SLACK_BOT_TOKEN` row in `README.md` now lists the history scopes
+  (`channels:history`, `groups:history`, `im:history`, `mpim:history`)
+  the readback requires — a token provisioned from that table alone
+  reported every publish as `Delivered:false` / `readback_auth` while
+  the messages were plainly visible in Slack.
 - `gc slack reply-current` now inherits the thread from the latest
   inbound (gp-i62): a thread-reply inbound's transcript entry carries
   the Slack `thread_ts` in `ReplyToMessageID`, and the reply anchors

--- a/slack-full/README.md
+++ b/slack-full/README.md
@@ -367,7 +367,7 @@ package docstring at the top of that file. Summary:
 | Var                    | Purpose                                                            |
 | ---------------------- | ------------------------------------------------------------------ |
 | `SLACK_WORKSPACE_ID`   | Slack team id (e.g. `T0XXXXXXXXX`).                                |
-| `SLACK_BOT_TOKEN`      | `xoxb-…` token. Scopes: `chat:write`, `reactions:write`, `files:write`, and `chat:write.customize` for per-session identity overrides. |
+| `SLACK_BOT_TOKEN`      | `xoxb-…` token. Scopes: `chat:write`, `reactions:write`, `files:write`, `chat:write.customize` for per-session identity overrides, **and a history scope for every conversation kind you bind** — `channels:history` (public channels), `groups:history` (private channels), `im:history` (DMs), `mpim:history` (group DMs). `/publish` confirms each post by reading it back, so a token without history for a bound conversation reports every publish as `Delivered:false` / `readback_auth` even though the message is visible in Slack. `schema/apps.schema.json` is the authoritative scope list. |
 | `SLACK_SIGNING_SECRET` | Used to verify HMAC signatures on `/slack/events` requests.        |
 | `GC_CITY_NAME`         | gc city the adapter posts inbound + session-message traffic to. Matches `[workspace].name` in `city.toml`. No fallback default — the adapter fails fast rather than silently route to a wrong city. |
 

--- a/slack-full/adapter/main.go
+++ b/slack-full/adapter/main.go
@@ -1507,6 +1507,8 @@ func newPublishDedupCache(ttl time.Duration) *publishDedupCache {
 }
 
 // Get returns the cached receipt for key when one is present and unexpired.
+// The receipt it returns shares nothing with the cache entry: callers may write
+// it without holding c.mu.
 func (c *publishDedupCache) Get(key string) (publishReceipt, bool) {
 	if key == "" {
 		return publishReceipt{}, false
@@ -1521,7 +1523,19 @@ func (c *publishDedupCache) Get(key string) (publishReceipt, bool) {
 		delete(c.entries, key)
 		return publishReceipt{}, false
 	}
-	return e.receipt, true
+	// The receipt is copied by value, but Metadata is a map: returning it as
+	// it stands would hand every caller a header aliasing the cache entry's
+	// own map. replayPublishReceipt writes that map (confirmPublishReceipt)
+	// outside this lock, so two retries on one key would race. Clone it.
+	receipt := e.receipt
+	if receipt.Metadata != nil {
+		clone := make(map[string]string, len(receipt.Metadata))
+		for k, v := range receipt.Metadata {
+			clone[k] = v
+		}
+		receipt.Metadata = clone
+	}
+	return receipt, true
 }
 
 // publishReceiptBlocksRepost reports whether a retry on the same idempotency

--- a/slack-full/adapter/main_test.go
+++ b/slack-full/adapter/main_test.go
@@ -909,6 +909,43 @@ func TestPublishDedupCache(t *testing.T) {
 	}
 }
 
+// TestPublishDedupCacheGetDoesNotAliasMetadata pins the property that keeps
+// concurrent same-key retries off a shared map. Get copies the receipt by
+// value, but Metadata is a map, so without an explicit clone every caller
+// holds a header onto the cache entry's own map — and replayPublishReceipt
+// writes that map through confirmPublishReceipt outside the cache lock.
+//
+// This is deterministic on purpose: it fails on every run against an
+// aliasing Get and needs no race detector, unlike a concurrency probe that
+// only reports under -race and only some of the time.
+func TestPublishDedupCacheGetDoesNotAliasMetadata(t *testing.T) {
+	cache := newPublishDedupCache(publishDedupTTL)
+	cache.Put("k", publishReceipt{
+		MessageID: "1700.001",
+		Metadata:  map[string]string{receiptMetadataKeyReadback: slackReadbackUnavailable},
+	})
+	first, ok := cache.Get("k")
+	if !ok {
+		t.Fatal("seeded receipt not found")
+	}
+	// confirmPublishReceipt writes this map on every replay, outside the cache
+	// lock. If Get hands back the cache entry's own map, two concurrent
+	// replays on one key write the same map from two request goroutines.
+	first.Metadata["probe"] = "mutated"
+	delete(first.Metadata, receiptMetadataKeyReadback)
+
+	second, ok := cache.Get("k")
+	if !ok {
+		t.Fatal("seeded receipt not found on re-read")
+	}
+	if _, leaked := second.Metadata["probe"]; leaked {
+		t.Error("Get returned a receipt whose Metadata aliases the cache entry: a write through one caller's copy is visible to the next")
+	}
+	if got := second.Metadata[receiptMetadataKeyReadback]; got != slackReadbackUnavailable {
+		t.Errorf("a delete through one caller's copy mutated the cached receipt: readback = %q, want %q", got, slackReadbackUnavailable)
+	}
+}
+
 // TestReferenceSuffixMatchesCrossLanguageTestVector asserts the same
 // (key, suffix) pair as gas-city's messaging state reconciler.
 func TestReferenceSuffixMatchesCrossLanguageTestVector(t *testing.T) {

--- a/slack-full/commands/publish-to-channel/help.md
+++ b/slack-full/commands/publish-to-channel/help.md
@@ -32,7 +32,13 @@ gc slack publish-to-channel --conversation-id <chan-id> \
 - `--session SID` — session id to attribute the publish to. Defaults
   to `$GC_SESSION_ID`.
 - `--kind` — conversation kind for the envelope (`room` default).
-- `--idempotency-key KEY` — caller-supplied dedup key (optional).
+- `--idempotency-key KEY` — dedup key. Optional: when omitted, one is
+  derived from the session, conversation, kind, thread anchor and body, so
+  re-running the same command after a client timeout replays the original
+  receipt instead of posting the message twice. Pass a distinct value to
+  send the same text twice on purpose. Keyed publishes carry the adapter's
+  low-visibility `_ref:<12hex>_` footer, which is how `/publish` reads the
+  message back to confirm delivery.
 - `--body STR` / `--body-file PATH` — message body. One required.
 
 ## Typical mayor / cos reply flow

--- a/slack-full/scripts/slack_chat_publish_to_channel.py
+++ b/slack-full/scripts/slack_chat_publish_to_channel.py
@@ -15,6 +15,7 @@ identity registry override (visible username + avatar).
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import pathlib
@@ -22,6 +23,29 @@ import sys
 
 import slack_intake_common as common
 import slack_mrkdwn
+
+
+def _derive_idempotency_key(
+    *, session_id: str, conversation_id: str, kind: str, thread_ts: str, body: str
+) -> str:
+    """Derive a stable idempotency key from the publish's identifying fields.
+
+    ``/publish`` can legitimately spend up to
+    ``common.SLACK_PUBLISH_WORST_CASE_SECONDS`` on a write plus its readback,
+    and a client that gives up first does not cancel the adapter goroutine —
+    the post still lands. Unkeyed, the operator's retry takes the no-key path
+    and posts a duplicate. Keying it deterministically means the same logical
+    publish (same session, conversation, kind, thread anchor and body) reuses
+    one key, so the adapter replays the original receipt instead (gpk-lbhl).
+
+    Mirrors ``slack_chat_reply_current._derive_idempotency_key``, including
+    fingerprinting the body *after* the accidental-mrkdwn guard has run: the
+    guarded and ``--raw`` renderings of one input are different messages and
+    must not collapse onto one key.
+    """
+    fingerprint = "\x00".join((session_id, conversation_id, kind, thread_ts, body))
+    digest = hashlib.sha256(fingerprint.encode("utf-8")).hexdigest()
+    return f"publish-to-channel:{digest}"
 
 
 def _load_body(args: argparse.Namespace) -> str:
@@ -57,7 +81,12 @@ def main(argv: list[str]) -> int:
                              "(applies identity override). Defaults to "
                              "$GC_SESSION_ID.")
     parser.add_argument("--idempotency-key", default="",
-                        help="Caller-supplied idempotency key (optional).")
+                        help=("Caller-supplied idempotency key. When omitted, a "
+                              "deterministic key is derived from the session, "
+                              "conversation, kind, thread anchor and body so a "
+                              "retry of the same publish dedupes instead of "
+                              "double-posting. Pass a distinct value to send the "
+                              "same text twice on purpose."))
     parser.add_argument("--body", default="")
     parser.add_argument("--body-file", default="")
     parser.add_argument(
@@ -80,6 +109,16 @@ def main(argv: list[str]) -> int:
     if not os.environ.get("SLACK_WORKSPACE_ID", "").strip():
         raise SystemExit("SLACK_WORKSPACE_ID is not set; cannot construct conversation envelope")
 
+    idempotency_key = args.idempotency_key.strip()
+    if not idempotency_key:
+        idempotency_key = _derive_idempotency_key(
+            session_id=session_id,
+            conversation_id=args.conversation_id,
+            kind=args.kind,
+            thread_ts=args.thread_ts,
+            body=body,
+        )
+
     try:
         result = common.publish_to_channel_via_adapter(
             session_id=session_id,
@@ -87,7 +126,7 @@ def main(argv: list[str]) -> int:
             text=body,
             kind=args.kind,
             thread_ts=args.thread_ts,
-            idempotency_key=args.idempotency_key,
+            idempotency_key=idempotency_key,
         )
     except common.AdapterError as exc:
         raise SystemExit(str(exc)) from exc

--- a/slack-full/scripts/slack_intake_common.py
+++ b/slack-full/scripts/slack_intake_common.py
@@ -23,6 +23,15 @@ DEFAULT_GC_API = "http://127.0.0.1:8372"
 _LEGACY_ADAPTER_PUBLISH = "http://127.0.0.1:8766/publish"  # legacy nohup mode (pre gc-5rz Phase A)
 DEFAULT_ADAPTER_ENV = pathlib.Path.home() / ".config" / "gc-slack-adapter" / "env"
 
+# The adapter's own worst case for one /publish, from the constants in
+# adapter/publish_readback.go: slackPostTimeout + attempts*clientTimeout +
+# (attempts-1)*delay = 10 + 3*4 + 2*0.2. Any client budget at or below this
+# can time out on a message Slack already accepted.
+SLACK_PUBLISH_WORST_CASE_SECONDS = 22.4
+# What direct-to-adapter /publish callers wait. Must stay above the worst
+# case above; 30s also matches _request's default and gc's 30s adapter budget.
+PUBLISH_ADAPTER_TIMEOUT = 30.0
+
 
 def _maybe_load_adapter_env() -> None:
     """Load SLACK_* keys from the adapter's env file if not in os.environ.
@@ -762,7 +771,15 @@ def publish_to_channel_via_adapter(
         method="POST",
     )
     try:
-        with urllib.request.urlopen(req, timeout=15) as resp:
+        # /publish spends its budget on a write plus a readback: worst case
+        # slackPostTimeout + attempts*clientTimeout + (attempts-1)*delay =
+        # 10 + 3*4 + 2*0.2 = 22.4s (adapter/publish_readback.go, pinned by
+        # TestSlackReadbackTimingDefaults). A client budget under that times
+        # out on a message Slack has already accepted — the adapter goroutine
+        # is not cancelled by the disconnect, so the post still lands and the
+        # operator's retry duplicates it. 30s matches _request's default and
+        # gc's own 30s adapter budget.
+        with urllib.request.urlopen(req, timeout=PUBLISH_ADAPTER_TIMEOUT) as resp:
             raw = resp.read()
     except urllib.error.HTTPError as exc:
         detail = exc.read().decode("utf-8", errors="replace")

--- a/slack-full/tests/test_slack_chat_publish_to_channel.py
+++ b/slack-full/tests/test_slack_chat_publish_to_channel.py
@@ -178,3 +178,132 @@ def test_publish_to_channel_raw_flag_skips_guard(
     ])
     assert rc == 0
     assert captured["text"] == "~$58.5k out, ~$16.5k left"
+
+
+# --------------------------------------------------------------------------
+# Retry safety: the client budget must outlast /publish's readback, and an
+# unkeyed publish must still dedupe when the operator retries a timeout.
+# --------------------------------------------------------------------------
+
+def _key_collector(monkeypatch: pytest.MonkeyPatch, common) -> list[str]:
+    """Stub the adapter POST and record each call's idempotency key."""
+    keys: list[str] = []
+
+    def fake_publish(**kwargs):
+        keys.append(kwargs.get("idempotency_key", ""))
+        return {"delivered": True, "message_id": "1700.001"}
+
+    monkeypatch.setattr(common, "publish_to_channel_via_adapter", fake_publish)
+    return keys
+
+
+def test_publish_to_channel_auto_derives_stable_idempotency_key(
+        monkeypatch: pytest.MonkeyPatch) -> None:
+    """With no --idempotency-key, the key is derived and stable.
+
+    Two identical invocations — the shape of an operator retrying after the
+    client gave up on a publish the adapter actually completed — must send
+    the SAME key, so the adapter replays the receipt instead of posting a
+    duplicate. A per-invocation random key would satisfy "a key was sent"
+    while leaving the duplicate window exactly as wide as it was.
+    """
+    pub, common = _import_modules()
+    keys = _key_collector(monkeypatch, common)
+
+    argv = ["--conversation-id", "C0CHAN01", "--session", "gc-1", "--body", "ok"]
+    assert pub.main(argv) == 0
+    assert pub.main(argv) == 0
+    assert keys[0] != ""
+    assert keys[0] == keys[1]
+    assert keys[0].startswith("publish-to-channel:")
+
+
+def test_publish_to_channel_derived_key_varies_with_target_and_body(
+        monkeypatch: pytest.MonkeyPatch) -> None:
+    """Distinct logical publishes must not collapse onto one key."""
+    pub, common = _import_modules()
+    keys = _key_collector(monkeypatch, common)
+
+    base = ["--session", "gc-1", "--conversation-id", "C0CHAN01"]
+    assert pub.main(base + ["--body", "first"]) == 0
+    assert pub.main(base + ["--body", "second"]) == 0
+    assert pub.main(["--session", "gc-1", "--conversation-id", "C0CHAN02",
+                     "--body", "first"]) == 0
+    assert pub.main(base + ["--body", "first", "--thread-ts", "1700.900"]) == 0
+    assert len(set(keys)) == len(keys), f"keys collided: {keys}"
+
+
+def test_publish_to_channel_derived_key_fingerprints_the_sent_body(
+        monkeypatch: pytest.MonkeyPatch) -> None:
+    """The fingerprint runs on the post-guard body, not the raw argv.
+
+    The guarded and --raw renderings of one input are different messages.
+    Fingerprinting before the accidental-mrkdwn guard would give them one
+    key, so sending both would silently drop the second.
+    """
+    pub, common = _import_modules()
+    keys = _key_collector(monkeypatch, common)
+
+    body = "~$58.5k out, ~$16.5k left"
+    base = ["--session", "gc-1", "--conversation-id", "C0CHAN01", "--body", body]
+    assert pub.main(base) == 0
+    assert pub.main(base + ["--raw"]) == 0
+    assert keys[0] != keys[1]
+
+
+def test_publish_to_channel_explicit_idempotency_key_wins(
+        monkeypatch: pytest.MonkeyPatch) -> None:
+    """An explicit key is passed through untouched — the duplicate escape hatch."""
+    pub, common = _import_modules()
+    keys = _key_collector(monkeypatch, common)
+
+    assert pub.main([
+        "--conversation-id", "C0CHAN01",
+        "--session", "gc-1",
+        "--body", "ok",
+        "--idempotency-key", "key-42",
+    ]) == 0
+    assert keys == ["key-42"]
+
+
+def test_publish_adapter_timeout_outlasts_the_readback_worst_case(
+        monkeypatch: pytest.MonkeyPatch) -> None:
+    """The client budget must exceed what /publish is designed to spend.
+
+    /publish costs slackPostTimeout + attempts*clientTimeout +
+    (attempts-1)*delay = 22.4s in the worst case (adapter/publish_readback.go,
+    pinned Go-side by TestSlackReadbackTimingDefaults). A client that gives up
+    first does not cancel the adapter goroutine, so the post lands anyway and
+    the operator sees a spurious error. Pinned as literals: raising the
+    adapter's budget without raising this one re-opens the window.
+    """
+    _pub, common = _import_modules()
+    assert common.SLACK_PUBLISH_WORST_CASE_SECONDS == 22.4
+    assert common.PUBLISH_ADAPTER_TIMEOUT == 30.0
+    assert common.PUBLISH_ADAPTER_TIMEOUT > common.SLACK_PUBLISH_WORST_CASE_SECONDS
+
+    seen: dict[str, Any] = {}
+
+    class _Resp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc):
+            return False
+
+        def read(self):
+            return b'{"delivered": true}'
+
+    def fake_urlopen(_req, **kwargs):
+        seen.update(kwargs)
+        return _Resp()
+
+    monkeypatch.setattr(common.urllib.request, "urlopen", fake_urlopen)
+
+    common.publish_to_channel_via_adapter(
+        session_id="gc-1",
+        conversation_id="C0CHAN01",
+        text="ok",
+    )
+    # Not just declared — actually handed to the socket.
+    assert seen["timeout"] == common.PUBLISH_ADAPTER_TIMEOUT


### PR DESCRIPTION
Post-merge review follow-up for #313 (landed range `cd0078f2..7a9514e6`). Three
gating findings, all fixed here. Non-gating observations from the review were
left for later, and `adapter/publish_readback.go`'s matching, classification and
timing logic is untouched.

## F1 — `publishDedupCache.Get` handed out a header aliasing the cache entry

`Get` returned `publishReceipt` by value, but `Metadata` is a map, so the
returned receipt's header aliased the cache entry's own map.
`replayPublishReceipt` passes that receipt to `confirmPublishReceipt`, which
writes `Metadata` **outside** `c.mu` — so two retries on one idempotency key
write the same map concurrently. In a long-lived adapter daemon that is a real
race, not a theoretical one.

Fixed at the single chokepoint: `Get` clones `Metadata` (nil-guarded) before
returning, and the contract is stated on the method so callers can keep writing
without the lock.

Pinned by `TestPublishDedupCacheGetDoesNotAliasMetadata`, which mutates the
first returned receipt's map and asserts the second is untouched. That is
deterministic — it fails on a plain build, not only under `-race` when the
scheduler cooperates.

## F2 — the client gave up before the adapter was designed to

`/publish` can legitimately spend `slackPostTimeout` + `attempts *
clientTimeout` + `(attempts-1) * delay` = **22.4s** on a write plus its
readback, but `slack_intake_common` posted with a 15s `urlopen` timeout. Past
15s the Python side raised while the adapter goroutine kept going, so the
message still landed and the operator saw an error for a delivered post — and
retried it.

- `PUBLISH_ADAPTER_TIMEOUT = 30.0`, with `SLACK_PUBLISH_WORST_CASE_SECONDS =
  22.4` named beside it and the arithmetic written out, so whoever next raises
  the adapter's budget sees the coupling. Both are pinned as literals, and the
  test asserts the value actually reaches `urlopen` rather than merely being
  declared.
- `publish-to-channel` now derives a deterministic idempotency key when none is
  passed (sha256 over session, conversation, kind, thread anchor, body),
  mirroring `slack_chat_reply_current`. The retry only dedupes if the key is
  *stable* — a random per-invocation key would satisfy "a key was sent" while
  leaving the duplicate window exactly as wide — so stability is what the test
  pins. The body is fingerprinted **after** the accidental-mrkdwn guard, since
  the guarded and `--raw` renderings of one input are different messages and
  must not collapse onto one key. An explicit `--idempotency-key` still wins,
  as the escape hatch for sending the same text twice on purpose.

**User-visible side effect, called out deliberately:** keying a publish makes
the adapter append its low-visibility `_ref:<12hex>_` footer, which
`publish-to-channel` did not previously carry. It is disclosed in the CHANGELOG
and `help.md` rather than papered over, and it is what lets `/publish`'s
readback match precisely instead of falling back to text comparison. Every
other keyed publish in the pack already carries it.

## F3 — README understated the bot scopes

Only `chat:write` was listed for `SLACK_BOT_TOKEN`, but the readback path calls
`conversations.history`. Without `channels:history` / `groups:history` /
`im:history` / `mpim:history`, every publish returns `Delivered:false` with
`readback_auth` and reads as a delivery failure. The four scopes are now listed
with that symptom named, pointing at `schema/apps.schema.json` as the
authoritative list.

## Validation

Each fix was checked as a red/green pair in detached scratch worktrees, never in
the shared review tree. The Go pin and 4 of the 5 new Python tests are RED on
the unfixed tree; the fifth is a preservation test for the explicit-key escape
hatch and correctly passes on both.

- `go vet ./...` clean
- `go test -race` ok — adapter and cli
- `pytest` — 460 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
