### PR TITLE
fix(discord): resolve room-launch seats by the most specific alias match

### DIFF
--- a/discord/scripts/discord_intake_common.py
+++ b/discord/scripts/discord_intake_common.py
@@ -4180,8 +4180,13 @@ def _room_launch_participant_matches_session(participant: dict[str, Any], *, ses
     return False
 
 
-def _alias_matches_qualified_handle(alias: str, qualified_handle: str) -> bool:
-    """Does a platform-stored session alias name the seat `qualified_handle`?
+_ALIAS_MATCH_NONE = 0
+_ALIAS_MATCH_PREFIXED = 1
+_ALIAS_MATCH_EXACT = 2
+
+
+def _alias_match_specificity(alias: str, qualified_handle: str) -> int:
+    """How specifically does a stored alias name the seat `qualified_handle`?
 
     The platform qualifies an explicitly requested alias with the binding it
     resolves under, so the seat we asked to call `meltron` comes back stored
@@ -4190,26 +4195,89 @@ def _alias_matches_qualified_handle(alias: str, qualified_handle: str) -> bool:
     neither crosses a scope: a rig-qualified handle only matches aliases
     under the same rig, and a bare handle only matches bare aliases.
 
-    This is the single tail-match policy — the attach lookup
-    (resolve_existing_session_for_handle) and the publish-side re-pin share
-    it so a seat reachable by @@handle is also re-pinnable, and vice versa.
+    Returns _ALIAS_MATCH_EXACT, _ALIAS_MATCH_PREFIXED, or _ALIAS_MATCH_NONE.
+    Callers that must choose between two matching seats prefer the exact one;
+    a bare boolean cannot express that, which is why this returns a rank.
+
+    The prefixed arm strips *exactly one* leading segment. That encodes the
+    assumption that the platform prepends exactly one pack-namespace segment.
+    If some path ever prepends more, this rule fails **closed** — the seat is
+    not found and the launcher spawns a new one, which is visible. The looser
+    `alias_tail.endswith("." + handle_tail)` rule it replaced failed **open**:
+    `corp/gasburger.zeta.sky` answered to `@@corp/sky`, so a mention reached a
+    different agent than the one it named, silently and with no receipt
+    anomaly. That asymmetry is the argument for strictness — keep the
+    strip-exactly-one-segment shape if this is ever revisited.
     """
     alias_key = str(alias).strip().lower()
     handle_key = str(qualified_handle).strip().lower()
     if not alias_key or not handle_key:
-        return False
+        return _ALIAS_MATCH_NONE
     if alias_key == handle_key:
-        return True
+        return _ALIAS_MATCH_EXACT
     if ("/" in alias_key) != ("/" in handle_key):
-        return False
+        return _ALIAS_MATCH_NONE
     if "/" in handle_key:
         alias_rig, alias_tail = alias_key.split("/", 1)
         handle_rig, handle_tail = handle_key.split("/", 1)
         if alias_rig != handle_rig:
-            return False
+            return _ALIAS_MATCH_NONE
     else:
         alias_tail, handle_tail = alias_key, handle_key
-    return alias_tail == handle_tail or alias_tail.endswith("." + handle_tail)
+    if "." in alias_tail and alias_tail.split(".", 1)[-1] == handle_tail:
+        return _ALIAS_MATCH_PREFIXED
+    return _ALIAS_MATCH_NONE
+
+
+def _alias_matches_qualified_handle(alias: str, qualified_handle: str) -> bool:
+    """Does a platform-stored session alias name the seat `qualified_handle`?
+
+    This is the single tail-match policy — the attach lookup
+    (resolve_existing_session_for_handle) and the publish-side re-pin share
+    it so a seat reachable by @@handle is also re-pinnable, and vice versa.
+    """
+    return _alias_match_specificity(alias, qualified_handle) != _ALIAS_MATCH_NONE
+
+
+def _participant_handle_for_alias(launch: dict[str, Any], alias: str) -> str:
+    """Which launch participant does a publishing session's alias name?
+
+    Exact matches before prefixed ones, because a launch can hold both
+    `R/<seat>` and `R/<pack>.<seat>` and the pack-qualified alias matches
+    both — the exact entry and the strip-one-segment one. Taking the first
+    match in record order would pick whichever sorts first (records
+    round-trip through `sort_keys=True`, so iteration is alphabetical), which
+    for `corp/zulu.alpha` picks `corp/alpha`: the wrong participant's future
+    deliveries get redirected, and the seat that actually needed the re-pin
+    is left stale.
+
+    Returns "" when no participant matches, and also when more than one
+    matches within the winning tier — a re-pin mutates persisted routing
+    state, so an ambiguity is refused and logged rather than guessed. Only
+    participant keys that differ by case or surrounding whitespace can
+    collide within a tier: each tier admits exactly one normalized key.
+    """
+    exact: list[str] = []
+    prefixed: list[str] = []
+    for handle in room_launch_participants(launch):
+        normalized = str(handle).strip()
+        specificity = _alias_match_specificity(alias, normalized)
+        if specificity == _ALIAS_MATCH_EXACT:
+            exact.append(normalized)
+        elif specificity == _ALIAS_MATCH_PREFIXED:
+            prefixed.append(normalized)
+    for tier, candidates in (("exact", exact), ("prefixed", prefixed)):
+        if len(candidates) == 1:
+            return candidates[0]
+        if candidates:
+            print(
+                f"[extmsg] room-launch re-pin skipped: alias {alias!r} matches "
+                f"{len(candidates)} participants {sorted(candidates)!r} ({tier} tier); "
+                "refusing to guess which seat to rebind",
+                flush=True,
+            )
+            return ""
+    return ""
 
 
 def ensure_room_launch_session_for_handle(
@@ -5940,10 +6008,9 @@ def publish_binding_message(
             except GCAPIError:
                 effective_source_alias = ""
         if effective_source_alias:
-            for handle in room_launch_participants(launch_record):
-                if _alias_matches_qualified_handle(effective_source_alias, handle):
-                    effective_source_qualified_handle = str(handle).strip()
-                    break
+            effective_source_qualified_handle = _participant_handle_for_alias(
+                launch_record, effective_source_alias
+            )
     if effective_source_qualified_handle and launch_record:
         repinned = repin_room_launch_participant_for_session(
             str(launch_record.get("launch_id", "")).strip() or str(source_meta.get("launch_id", "")).strip(),

--- a/discord/tests/test_discord_intake_common.py
+++ b/discord/tests/test_discord_intake_common.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import io
 import pathlib
 import socket
@@ -1864,6 +1865,152 @@ class DiscordIntakeCommonTests(unittest.TestCase):
         self.assertEqual(participant["session_name"], "s-gc-old")
         self.assertEqual(participant["delivery_selector"], "s-gc-old")
 
+    def _save_two_seat_launch(self, launch_id: str, root_message_id: str) -> None:
+        # Two dot-suffix-related seats in one launch. The pack-qualified
+        # alias "corp/widget.emma" matches BOTH participants: "corp/emma" by
+        # stripping one leading segment, and "corp/widget.emma" exactly.
+        common.save_room_launch(
+            {
+                "launch_id": launch_id,
+                "launcher_id": "launch-room:22",
+                "guild_id": "1",
+                "conversation_id": "22",
+                "root_message_id": root_message_id,
+                "thread_id": "333",
+                "participants": {
+                    "corp/emma": {
+                        "qualified_handle": "corp/emma",
+                        "session_alias": "corp/emma",
+                        "session_name": "s-emma-live",
+                        "session_id": "gc-emma-live",
+                        "delivery_selector": "s-emma-live",
+                    },
+                    "corp/widget.emma": {
+                        "qualified_handle": "corp/widget.emma",
+                        "session_alias": "corp/widget.emma",
+                        "session_name": "s-widget-stale",
+                        "session_id": "gc-widget-stale",
+                        "delivery_selector": "s-widget-stale",
+                    },
+                },
+            }
+        )
+
+    def test_publish_binding_message_repin_prefers_exact_participant_over_prefixed(self) -> None:
+        # Regression: the re-pin used to take the first tail-matching
+        # participant in record order, and records round-trip through
+        # sort_keys=True, so "corp/emma" sorted ahead of the seat that was
+        # actually publishing and won. That got all three outcomes wrong at
+        # once -- misattributed source, the live sibling's entry hijacked
+        # (its later deliveries redirected to the publisher), and the stale
+        # seat left unrepaired. Exact matches must beat prefixed ones.
+        self._save_two_seat_launch("room-launch:orig-16", "orig-16")
+
+        payload = self._publish_as_session(
+            "room-launch:orig-16", "corp/widget.emma", "msg-launch-16"
+        )
+
+        self.assertEqual(payload["record"]["source_qualified_handle"], "corp/widget.emma")
+        launch = common.load_room_launch("room-launch:orig-16")
+        assert launch is not None
+        repinned = launch["participants"]["corp/widget.emma"]
+        self.assertEqual(repinned["session_id"], "gc-new")
+        self.assertEqual(repinned["session_name"], "pub--sky")
+        sibling = launch["participants"]["corp/emma"]
+        self.assertEqual(sibling["session_id"], "gc-emma-live")
+        self.assertEqual(sibling["session_name"], "s-emma-live")
+        self.assertEqual(sibling["delivery_selector"], "s-emma-live")
+
+    def test_publish_binding_message_skips_repin_when_participants_are_ambiguous(self) -> None:
+        # Fail-safe arm: a re-pin mutates persisted routing state, so when
+        # the winning tier holds more than one candidate the publish must
+        # leave the record alone rather than guess. Each tier admits exactly
+        # one normalized key, so the only way to collide is participant keys
+        # that differ by case -- which is precisely why this is a guard and
+        # not an unreachable branch.
+        common.save_room_launch(
+            {
+                "launch_id": "room-launch:orig-17",
+                "launcher_id": "launch-room:22",
+                "guild_id": "1",
+                "conversation_id": "22",
+                "root_message_id": "orig-17",
+                "thread_id": "333",
+                "participants": {
+                    "corp/Emma": {
+                        "qualified_handle": "corp/Emma",
+                        "session_alias": "corp/Emma",
+                        "session_name": "s-emma-upper",
+                        "session_id": "gc-emma-upper",
+                        "delivery_selector": "s-emma-upper",
+                    },
+                    "corp/emma": {
+                        "qualified_handle": "corp/emma",
+                        "session_alias": "corp/emma",
+                        "session_name": "s-emma-lower",
+                        "session_id": "gc-emma-lower",
+                        "delivery_selector": "s-emma-lower",
+                    },
+                },
+            }
+        )
+
+        with contextlib.redirect_stdout(io.StringIO()) as captured:
+            payload = self._publish_as_session(
+                "room-launch:orig-17", "corp/widget.emma", "msg-launch-17"
+            )
+
+        self.assertEqual(payload["record"]["source_qualified_handle"], "")
+        # The skip is only actionable if the log says which alias collided,
+        # which seats it hit, and which tier -- an operator reading "skipped"
+        # alone cannot tell a de-duplicable participant table from a bug.
+        logged = captured.getvalue()
+        self.assertIn("re-pin skipped", logged)
+        self.assertIn("corp/widget.emma", logged)
+        self.assertIn("corp/Emma", logged)
+        self.assertIn("corp/emma", logged)
+        self.assertIn("prefixed tier", logged)
+        launch = common.load_room_launch("room-launch:orig-17")
+        assert launch is not None
+        self.assertEqual(launch["participants"]["corp/Emma"]["session_id"], "gc-emma-upper")
+        self.assertEqual(launch["participants"]["corp/emma"]["session_id"], "gc-emma-lower")
+
+    def test_participant_handle_for_alias_resolves_the_hijack_table(self) -> None:
+        # The four dot-suffix-related shapes the first-match-wins loop got
+        # right only by alphabetical luck. Two of them (zulu.alpha,
+        # widget.emma) hijacked the sibling before exact-beats-prefixed.
+        def launch_with(handles: list[str]) -> dict[str, object]:
+            return {"participants": {h: {"qualified_handle": h} for h in handles}}
+
+        cases = [
+            ("corp/gasburger.mayor", ["corp/gasburger.mayor", "corp/mayor"], "corp/gasburger.mayor"),
+            ("corp/pack.sky", ["corp/pack.sky", "corp/sky"], "corp/pack.sky"),
+            ("corp/zulu.alpha", ["corp/alpha", "corp/zulu.alpha"], "corp/zulu.alpha"),
+            ("corp/widget.emma", ["corp/emma", "corp/widget.emma"], "corp/widget.emma"),
+        ]
+        for alias, handles, expected in cases:
+            with self.subTest(alias=alias):
+                self.assertEqual(
+                    common._participant_handle_for_alias(launch_with(handles), alias), expected
+                )
+
+        # Single-participant launches still re-pin through the prefixed tier,
+        # and the scope guards still refuse.
+        self.assertEqual(
+            common._participant_handle_for_alias(launch_with(["corp/sky"]), "corp/pack.sky"),
+            "corp/sky",
+        )
+        self.assertEqual(
+            common._participant_handle_for_alias(launch_with(["daytripper/sky"]), "docbook/pack.sky"),
+            "",
+        )
+        # And the F1 misroute is closed on this path too: two leading
+        # segments no longer reach a one-segment participant.
+        self.assertEqual(
+            common._participant_handle_for_alias(launch_with(["corp/sky"]), "corp/gasburger.zeta.sky"),
+            "",
+        )
+
     def test_publish_binding_message_does_not_record_non_thread_launch_publish_target(self) -> None:
         common.set_chat_binding(common.load_config(), "room", "22", ["corp--sky"], guild_id="1")
         binding = common.resolve_chat_binding(common.load_config(), "room:22")
@@ -2453,6 +2600,66 @@ class DiscordIntakeCommonTests(unittest.TestCase):
         self.assertFalse(common._alias_matches_qualified_handle("employees.emmalou", "emma"))
         self.assertFalse(common._alias_matches_qualified_handle("", "emma"))
         self.assertFalse(common._alias_matches_qualified_handle("employees.emma", ""))
+
+    def test_alias_matches_qualified_handle_strips_exactly_one_segment(self) -> None:
+        # The platform prepends exactly one pack-namespace segment, so only
+        # one may be stripped. A rule that accepted any ".<tail>" suffix let
+        # "corp/gasburger.zeta.sky" answer to @@corp/sky -- a different seat
+        # entirely, addressed silently.
+        self.assertTrue(common._alias_matches_qualified_handle("corp/gasburger.sky", "corp/sky"))
+        self.assertFalse(
+            common._alias_matches_qualified_handle("corp/gasburger.zeta.sky", "corp/sky")
+        )
+        self.assertTrue(
+            common._alias_matches_qualified_handle("corp/gasburger.zeta.sky", "corp/zeta.sky")
+        )
+        # Bare (city-scope) aliases follow the same one-segment rule.
+        self.assertTrue(common._alias_matches_qualified_handle("employees.sky", "sky"))
+        self.assertFalse(common._alias_matches_qualified_handle("employees.zeta.sky", "sky"))
+
+    def test_alias_match_specificity_ranks_exact_above_prefixed(self) -> None:
+        # The rank is what lets the publish-side re-pin break a tie; a bare
+        # boolean cannot, which is how the sibling-hijack got in.
+        self.assertEqual(
+            common._alias_match_specificity("corp/sky", "corp/sky"), common._ALIAS_MATCH_EXACT
+        )
+        self.assertEqual(
+            common._alias_match_specificity("corp/pack.sky", "corp/sky"),
+            common._ALIAS_MATCH_PREFIXED,
+        )
+        self.assertEqual(
+            common._alias_match_specificity("corp/pack.zeta.sky", "corp/sky"),
+            common._ALIAS_MATCH_NONE,
+        )
+        self.assertGreater(common._ALIAS_MATCH_EXACT, common._ALIAS_MATCH_PREFIXED)
+        self.assertGreater(common._ALIAS_MATCH_PREFIXED, common._ALIAS_MATCH_NONE)
+
+    def test_resolve_existing_session_prefers_the_named_seat_over_a_dot_suffix_decoy(self) -> None:
+        # Regression: two dot-suffix-related seats, and the intended one is
+        # asleep -- the normal state of an unengaged seat. The old tail rule
+        # matched both, and _session_record_preference ranks by routability,
+        # not by match specificity, so the decoy's "active" state won and
+        # @@corp/sky was delivered to gc-zeta with no receipt anomaly.
+        sessions = [
+            {"id": "gc-sky", "alias": "corp/gasburger.sky",
+             "session_name": "s-gc-sky", "state": "asleep", "running": False},
+            {"id": "gc-zeta", "alias": "corp/gasburger.zeta.sky",
+             "session_name": "s-gc-zeta", "state": "active", "running": True},
+        ]
+        with mock.patch.object(common, "list_city_sessions", return_value=sessions):
+            identity = common.resolve_existing_session_for_handle("corp/sky")
+        self.assertEqual(identity["session_id"], "gc-sky")
+
+        # Control: the decoy is still reachable at its own qualified handle.
+        with mock.patch.object(common, "list_city_sessions", return_value=sessions):
+            identity = common.resolve_existing_session_for_handle("corp/zeta.sky")
+        self.assertEqual(identity["session_id"], "gc-zeta")
+
+        # Control: with the intended seat absent, the decoy must NOT stand in
+        # for it -- the strict rule fails closed (spawn) rather than open.
+        with mock.patch.object(common, "list_city_sessions", return_value=sessions[1:]):
+            identity = common.resolve_existing_session_for_handle("corp/sky")
+        self.assertEqual(identity, {})
 
     def test_room_launch_poll_timeout_defaults_are_unchanged(self) -> None:
         # The injectable seam exists so tests do not pay the deadline;


### PR DESCRIPTION
## Summary

Post-merge review remediation for #262 (reviewed landed head `a0f09d6`). The
review found two gating majors, both in the alias-to-seat matching #262
introduced. They share a root cause and land as one commit: fixing either
alone leaves the other reachable.

## F1 — the tail-match rule failed open across namespace segments

`_alias_matches_qualified_handle` accepted `alias_tail.endswith("." +
handle_tail)`, which matches *any* number of leading segments. So
`corp/gasburger.zeta.sky` answered to `@@corp/sky` — a mention reached a
different agent than the one it named, silently, with no receipt anomaly to
notice it by.

The rule now strips exactly one leading segment. That matches what the platform
actually does: #262's own description records the alias being stored with a
single pack-namespace segment prepended (`dc-<hex>-slug` →
`gasburger.dc-<hex>-slug`). If some path ever prepends more, this now fails
**closed** — the seat is not found and the launcher spawns a new one, which is
visible. Failing open was the defect, and the docstring records that asymmetry
so a future reader doesn't "relax" it back.

## F2 — the publish-side re-pin took the first tail match

A launch can hold both `R/<seat>` and `R/<pack>.<seat>`, and a pack-qualified
alias matches both. `publish_binding_message` took the first match in record
order; records round-trip through `sort_keys=True`, so iteration is
alphabetical. For `corp/zulu.alpha` that picks `corp/alpha` — getting all three
outcomes wrong at once:

- the message is misattributed to the wrong seat,
- the **sibling's** participant entry is rebound, so its later deliveries
  redirect to the publisher,
- and the seat that actually needed the re-pin is left stale.

Matching is now ranked (`_alias_match_specificity`) and the re-pin resolves in
two passes — exact before prefixed — via `_participant_handle_for_alias`.

This also makes the two sides of the "single tail-match policy" agree. The
attach lookup already preferred an exact alias hit over a tail hit
(`alias_match or name_match or id_match or tail_alias_match`); the publish side
did not. Now both rank the same way.

A re-pin mutates persisted routing state, so an ambiguity *within the winning
tier* is refused and logged rather than guessed. Each tier admits exactly one
normalized key, so that guard is only reachable via participant keys differing
by case or surrounding whitespace — reachable and covered by a test, not a dead
branch.

### Hijack table (from the review, all four rows pinned)

| publishing alias | participants | before | after |
|---|---|---|---|
| `corp/gasburger.mayor` | `corp/gasburger.mayor`, `corp/mayor` | `corp/gasburger.mayor` ✅ | `corp/gasburger.mayor` |
| `corp/pack.sky` | `corp/pack.sky`, `corp/sky` | `corp/pack.sky` ✅ | `corp/pack.sky` |
| `corp/zulu.alpha` | `corp/alpha`, `corp/zulu.alpha` | `corp/alpha` ❌ | `corp/zulu.alpha` |
| `corp/widget.emma` | `corp/emma`, `corp/widget.emma` | `corp/emma` ❌ | `corp/widget.emma` |

The two correct rows were correct only by alphabetical luck.

## Test plan

Six new arms in `discord/tests/test_discord_intake_common.py`:

- exact-beats-prefixed at the publish boundary, asserting the sibling entry is
  left untouched
- the logged ambiguity skip, asserting the log names the alias, both colliding
  seats, and the tier
- the four-row hijack table above
- the strip-exactly-one-segment rule, with the landed alias shapes as controls
- the specificity ranking
- the attach lookup preferring the named seat over a dot-suffix decoy

Each arm was checked against a mutation matrix rather than assumed
discriminating:

| arm | result |
|---|---|
| pristine base + base tests | 414 passed (lab control) |
| both fixes reverted | all 6 new arms red |
| F1 reverted only | the 4 rule-level arms red |
| F2 reverted only | exactly the 2 end-to-end publish arms red |
| full fix | all 6 green |

- `python3 -m pytest discord/tests -q` → **420 passed, 4 subtests passed**
- full `ci.yml` pytest → **1586 passed, 39 skipped, 9590 subtests passed**, plus
  one failure (`test_gastown_lint_findings.py::test_every_universal_waiver_entry_is_still_reported`)
  that reproduces identically at pristine `origin/main` with a clean tree — it is
  pre-existing and local-only, not attributable to this change.
- `validate_registry.py --require-git` → ok

## Notes on scope

The review also charged a maintainability major for `publish_binding_message`
crossing a complexity band in #262 (36 → 55). Extracting the re-pin match into
`_participant_handle_for_alias` — which the F2 remedy required anyway — brings
it to **53**. That is a real reduction but does not clear the 50 band, and
closing the rest would mean restructuring a 160-NLOC function well beyond the
required fixes, so it is left for a separate change rather than folded in here.

The reported dead-code finding is likewise not addressed here; this PR carries
only the two gating majors and their regression coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
