### PR TITLE
fix(gastown): make boot's wisp lifecycle real, pin the reconcile flags, correct the sibling claim

### DIFF
--- a/gastown/agents/boot/prompt.template.md
+++ b/gastown/agents/boot/prompt.template.md
@@ -37,10 +37,15 @@ Boot was previously shaped as a single-pass agent that ended every wake with
 tokens in 5h, plus a per-second `bead.updated` flood on its own session bead,
 until an operator drained it (gci-fed).
 
-Every other always-mode agent (mayor, deacon, witness) ends its turn without
-draining and lets `idle_timeout` pace the recycle. You do the same. Ending the
-turn leaves the session alive and idle — that is the correct, cheap resting
-state, and the only one that keeps this watchdog off the hot path.
+Ending the turn without draining is the intended contract for every always-mode
+agent, and boot is the first one to actually implement it. Do **not** assume a
+sibling patrol already does it and copy its shape: the deacon still runs
+`gc runtime drain-ack` + `exit 1` whenever it cannot resolve its current wisp
+(`mol-deacon-patrol.toml:563-569`), and since its fallback query is empty in
+steady state that is the path it takes every cycle — the same trap at a slower,
+harder-to-notice cadence (tracked in `mc-x80bo`). Ending the turn leaves the
+session alive and idle — that is the correct, cheap resting state, and the only
+one that keeps this watchdog off the hot path.
 
 ---
 
@@ -61,24 +66,42 @@ Your formula: `mol-boot-patrol`
 # Step 2: Nothing? Check mail for attached work
 gc mail inbox
 
-# Step 3: Still nothing? Create patrol wisp (root-only — no child step beads)
-NEW_WISP=$(gc bd mol wisp mol-boot-patrol --root-only --var binding_prefix={{ .BindingPrefix }} --json | jq -r '.new_epic_id // empty')
+# Step 3: Still nothing? Reuse the queued successor before pouring a duplicate.
+# next-iteration leaves the next wisp assigned and *open* — Step 1 above filters
+# on --status=in_progress, so it cannot see it. Without this leg every recycle
+# pours a second wisp that next-iteration then has to burn as surplus, which is
+# churn, not a leak. --type=molecule --include-infra for the wisps-tier reason
+# spelled out in the reconcile block below.
+NEW_WISP=$(gc bd list --assignee="$GC_AGENT" --status=open --type=molecule --include-infra --limit=1 --json | jq -r '.[0].id // empty')
 if [ -z "$NEW_WISP" ]; then
-  # End the turn here — no drain-ack, no exit. This is the normal startup path,
-  # not the sanctioned crash-recovery exception; the next recycle retries.
-  echo "Could not pour boot patrol wisp; ending turn."
-else
-  # Assign with $GC_AGENT, not $GC_ALIAS: gc sets GC_ALIAS to the alias verbatim
-  # (including empty, when a named session declares none — as boot's does), while
-  # GC_AGENT falls back to the session name and is never empty. An empty
-  # --assignee is honoured as "unassigned", which would orphan this wisp from the
-  # reconcile below and from gc's own crash-recovery probe.
-  if ! gc bd update "$NEW_WISP" --assignee="$GC_AGENT"; then
+  # Nothing queued — pour one (root-only — no child step beads).
+  NEW_WISP=$(gc bd mol wisp mol-boot-patrol --root-only --var binding_prefix={{ .BindingPrefix }} --json | jq -r '.new_epic_id // empty')
+  if [ -z "$NEW_WISP" ]; then
+    # End the turn here — no drain-ack, no exit. This is the normal startup path,
+    # not the sanctioned crash-recovery exception; the next recycle retries.
+    echo "Could not pour boot patrol wisp; ending turn."
+  # Assign with $GC_AGENT: for a configured named session gc sets GC_AGENT and
+  # GC_ALIAS to the same identity, and GC_AGENT is also the form that stays
+  # non-empty on pool paths, so prefer it. An empty --assignee is honoured as
+  # "unassigned", which would orphan this wisp from the reconcile below and from
+  # gc's own crash-recovery probe. Step 1's rendered query matches on $GC_ALIAS,
+  # which is that same value here.
+  elif ! gc bd update "$NEW_WISP" --assignee="$GC_AGENT"; then
     # Unassigned, so no assignee-scoped query below can ever find it. Reclaim
     # it by id, then end the turn.
     echo "Could not assign boot patrol wisp; reclaiming it and ending turn."
     gc bd mol burn "$NEW_WISP" --force || true
+    NEW_WISP=""
   fi
+fi
+
+# Claim the wisp you are about to work. Pouring and assigning both leave it
+# open, and every "what am I working" query in this loop — Step 1 above and the
+# CURRENT_WISP fallback in the reconcile block below — filters on
+# --status=in_progress. Skip this and none of them can ever resolve: the burn
+# arm below becomes dead code and the wisp is only ever reclaimed as surplus.
+if [ -n "$NEW_WISP" ]; then
+  gc bd update "$NEW_WISP" --status=in_progress || true
 fi
 
 # Step 4: Read the formula recipe — these are the steps to execute
@@ -109,6 +132,9 @@ pour again.
 # and matches nothing). They are also ephemeral, so they live in the wisps tier
 # that gc bd list hides without --include-infra; drop that flag and these
 # queries return [] even when a wisp is assigned, and you pour a duplicate.
+# gc never sets GC_BEAD_ID for a named session, so the fallback query is the leg
+# that actually runs — and it resolves only because startup Step 3 claimed the
+# wisp --status=in_progress. Drop that claim and this returns empty every cycle.
 CURRENT_WISP=${GC_BEAD_ID:-}
 if [ -z "$CURRENT_WISP" ]; then
   CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --include-infra --limit=1 --json | jq -r '.[0].id // empty')
@@ -171,7 +197,7 @@ the formula steps and resumes from the already-assigned wisp.
 | Want to... | Correct command |
 |------------|----------------|
 | View deacon output | `{{ cmd }} session peek {{ .BindingPrefix }}deacon --lines 30` |
-| Check deacon work | `gc bd list --assignee={{ .BindingPrefix }}deacon --status=in_progress --include-infra --json` (without the flag the wisps tier is hidden, so a patrol wisp never shows) |
+| Check deacon work | `gc bd list --assignee={{ .BindingPrefix }}deacon --include-infra --json` (no `--status` filter — the deacon does not claim its wisps, so they are only ever open; without `--include-infra` the wisps tier is hidden and a patrol wisp never shows either way) |
 | Nudge deacon | `{{ cmd }} session nudge {{ .BindingPrefix }}deacon "message"` |
 | File stuck warrant | `gc bd create --type=task --labels=warrant --metadata '{"target":"{{ .BindingPrefix }}deacon","reason":"...","requester":"boot","gc.routed_to":"{{ .BindingPrefix }}dog"}'` |
 | Pour next wisp | `gc bd mol wisp mol-boot-patrol --root-only --var binding_prefix='{{ .BindingPrefix }}'` |

--- a/gastown/formulas/mol-boot-patrol.toml
+++ b/gastown/formulas/mol-boot-patrol.toml
@@ -1,8 +1,18 @@
 description = """
-Boot patrol loop. Poured as a root-only wisp on startup:
+Boot patrol loop. Poured as a root-only wisp on startup, then claimed:
 
   gc bd mol wisp mol-boot-patrol --root-only --var binding_prefix='{{binding_prefix}}'
   gc bd update $WISP --assignee=$GC_AGENT
+  gc bd update $WISP --status=in_progress
+
+The claim is not optional. Pouring and assigning both leave the wisp `open`,
+while every "what am I working" query — the startup protocol's assigned-work
+check and the `CURRENT_WISP` resolution in `next-iteration` — filters on
+`--status=in_progress`. Without the claim none of them can ever resolve, the
+burn arm in `next-iteration` is dead code, and each cycle pours a duplicate
+that the surplus burn then has to reclaim. Startup reuses an already-assigned
+open wisp before pouring, so the successor this formula queues is picked up
+rather than duplicated.
 
 Each wisp is ONE iteration: observe the deacon, decide, act, pour the next
 iteration. On crash, re-read the formula steps and determine where you left
@@ -35,12 +45,17 @@ cadence between wakes. Boot was shaped that way and hot-looped — ~500 fresh
 sessions/hr, ~2.4M output tokens in 5h, plus a per-second `bead.updated`
 flood on its own session bead — until it was drained (gci-fed).
 
-Every other always-mode agent (mayor, deacon, witness) avoids the trap the
-same way, and boot now matches them: run a patrol wisp, end the turn WITHOUT
-`drain-ack`, and let the agent's `idle_timeout` pace the recycle. Idle sleep
-does not apply here — always-mode named sessions are exempt from it — so
-`idle_timeout` is the *only* thing standing between this agent and a hot
-loop.
+Running a patrol wisp, ending the turn WITHOUT `drain-ack`, and letting the
+agent's `idle_timeout` pace the recycle is the intended contract for every
+always-mode agent — but boot is the first one to actually implement it. Do
+NOT reach for a sibling patrol as the reference shape: the deacon still runs
+`gc runtime drain-ack` + `exit 1` when it cannot resolve its current wisp
+(`mol-deacon-patrol.toml:563-569`), and its fallback query is empty in steady
+state, so that is the path it takes every cycle — the same trap boot hit,
+masked by a cycle expensive enough to hide the respawn rate. Tracked in
+`mc-x80bo`; do not fix it from here. Idle sleep does not apply either —
+always-mode named sessions are exempt from it — so `idle_timeout` is the
+*only* thing standing between this agent and a hot loop.
 
 **Do not re-introduce `gc runtime drain-ack` or `exit` into this loop.**
 
@@ -75,10 +90,16 @@ gc session peek {{binding_prefix}}deacon --lines 30
 # --type=molecule --include-infra for the same reason as the reconcile below:
 # an untyped query sets SkipWisps exactly as a bare typed one does, so without
 # the flag this returns a wisp-free set and the wisp-keyed rows in the
-# decision table below can never fire. Note the deacon's *queued successor*
-# wisp is open, not in_progress, so this query legitimately shows nothing in
-# the gap between deacon cycles — read that as "between cycles", not "stuck".
-gc bd list --assignee={{binding_prefix}}deacon --status=in_progress --type=molecule --include-infra --json --limit=5
+# decision table below can never fire.
+# No --status filter, deliberately. The claim boot now performs on its own wisp
+# is boot-scoped; the deacon does not claim its wisps, so a deacon patrol wisp
+# is only ever open. Filtering on in_progress here would return nothing on every
+# healthy cycle and leave the decision table's wisp-keyed rows permanently
+# unkeyed — the failure this flag repair exists to end. `gc bd list` already
+# excludes closed beads unless --all is passed, so this is open + in_progress,
+# never burned history. Judge freshness from created/updated, not from status: a
+# wisp that survives several of your cycles is the stale signal.
+gc bd list --assignee={{binding_prefix}}deacon --type=molecule --include-infra --json --limit=5
 
 # Does the deacon have unread mail? (may explain idle state)
 gc mail count {{binding_prefix}}deacon 2>/dev/null
@@ -87,8 +108,8 @@ gc mail count {{binding_prefix}}deacon 2>/dev/null
 Read the wisp timestamps and pane output. Build a picture:
 - Recent burned wisp → normal patrol loop
 - Active pane output → working
-- Young in-progress wisp with idle pane → likely backoff wait
-- Very stale in-progress wisp with idle/error pane → likely stuck
+- Young wisp (recent created/updated) with idle pane → likely backoff wait
+- Very stale wisp with idle/error pane → likely stuck
 - Idle with unread mail → may need a nudge
 
 **3. Decide.**
@@ -163,7 +184,11 @@ exactly one):**
 
 Reuse an already-queued wisp instead of pouring a duplicate. A prior cycle may
 have poured a next wisp without burning, or a restart may have raced — keep
-one open patrol wisp and burn any surplus, so wisps never accumulate. Wisp
+one open patrol wisp and burn any surplus, so wisps never accumulate. The
+successor stays `open` on purpose: it is the *next* cycle's work, and the
+startup protocol reuses it and claims it `in_progress` when that cycle begins.
+That is what keeps `open` meaning "queued" and `in_progress` meaning "being
+worked", which is the distinction every query in this loop reads. Wisp
 roots are `issue_type=molecule` (never `--type=wisp`, which is not a valid
 gc bd type and matches nothing). They are also ephemeral, so they live in the
 wisps tier that `gc bd list` hides without `--include-infra` — drop that flag
@@ -175,9 +200,13 @@ burn never runs and every cycle pours a duplicate.
 # set GC_BEAD_ID for a named session: the session env carries GC_SESSION_ID,
 # GC_SESSION_NAME, GC_ALIAS, GC_TEMPLATE, GC_SESSION_ORIGIN and GC_AGENT, and
 # GC_BEAD_ID is exported only into ralph check scripts. Boot has no hook-claim
-# block to export it either, so the query below is the load-bearing leg, not a
-# fallback — burning a bare "$GC_BEAD_ID" would burn "" on every cycle and
-# leave this wisp behind. --include-infra for the same wisps-tier reason above.
+# block to export it either, so in practice the ${GC_BEAD_ID:-} seed is always
+# empty and the query below is the leg that runs — burning a bare "$GC_BEAD_ID"
+# would burn "" on every cycle and leave this wisp behind. That query resolves
+# only because the startup protocol claims the wisp --status=in_progress after
+# pouring and assigning it; drop the claim and this returns empty forever, the
+# burn arm in step 3 becomes unreachable, and each cycle silently re-pours.
+# --include-infra for the same wisps-tier reason above.
 CURRENT_WISP=${GC_BEAD_ID:-}
 if [ -z "$CURRENT_WISP" ]; then
   CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --include-infra --limit=1 --json | jq -r '.[0].id // empty')

--- a/gastown/tests/test_gastown_pack_assets.sh
+++ b/gastown/tests/test_gastown_pack_assets.sh
@@ -446,7 +446,7 @@ test_boot_wisp_queries_pin_include_infra() {
     # burn never runs and each cycle pours a fresh wisp while its predecessor
     # leaks. Boot shipped with the bare form on all three sites one commit
     # after the witness fix, so scope this per-agent rather than widening the
-    # witness test: a pack-wide assertion is red either way (measured 10/21 at
+    # witness test: a pack-wide assertion is red either way (measured 11/22 at
     # this commit) because the deacon and refinery sites are still bare and
     # tracked separately in #252.
     total=$(grep -h -- '--type=molecule' "$prompt" "$formula" |
@@ -458,7 +458,7 @@ test_boot_wisp_queries_pin_include_infra() {
     # owns the contract, so the count is a floor that catches a deleted query
     # site, not a cardinality pin that a legitimate fourth query would break.
     [[ "$total" -ge 3 ]] ||
-        fail "expected at least 3 boot --type=molecule wisp queries (5 at this commit: 2 prompt + 3 formula), found $total"
+        fail "expected at least 3 boot --type=molecule wisp queries (6 at this commit: 3 prompt + 3 formula), found $total"
     [[ "$flagged" -eq "$total" ]] ||
         fail "boot --type=molecule wisp queries must pass --include-infra ($flagged/$total do)"
 }
@@ -539,6 +539,81 @@ test_boot_deacon_observation_query_sees_wisps_tier() {
         [[ "$unflagged" -eq 0 ]] ||
             fail "$name deacon-observation queries must pass --include-infra ($unflagged do not)"
     done
+}
+
+test_boot_open_wisps_reconcile_pins_tier_flags() {
+    local asset name live bad total
+
+    # The tier census cannot protect these two lines, and they are the ones that
+    # matter most: the OPEN_WISPS reconcile is the only leg enforcing the
+    # exactly-one-open-wisp invariant, so reverting it to the bare form IS the
+    # leak. That revert drops --type=molecule and --include-infra together, so
+    # the line leaves the census numerator and denominator at once (6/6 -> 5/5)
+    # and the -ge floor absorbs the loss: whole suite green, while at runtime the
+    # query returns [], the surplus burn never runs, and every cycle pours
+    # without ever burning.
+    #
+    # Assert every matching line rather than "at least one". A grep -q form goes
+    # green as soon as one good query exists, so a blind OPEN_WISPS query added
+    # beside a good one would read as covered -- the same addition shape the
+    # bare-burn and deacon-observation guards above exist to catch. The three
+    # flags are matched independently, so a legitimate flag reorder stays green.
+    for asset in "$GASTOWN/agents/boot/prompt.template.md" \
+                 "$GASTOWN/formulas/mol-boot-patrol.toml"; do
+        name=$(basename "$asset")
+
+        # || true is load-bearing: the suite runs under set -euo pipefail, so an
+        # unguarded grep would kill the run with no diagnostic on exactly the
+        # deletion arm the floor below exists to report.
+        #
+        # Commented-out lines are dropped before counting. The tier census above
+        # greps raw lines, so disabling a query with a leading # still reads as
+        # covered there; measured, that arm is green. Stripping them closes the
+        # shape in both directions -- a commented-out good query now falls
+        # through to the floor instead of passing, and a commented-out bad one
+        # no longer raises a failure over dead text.
+        live=$({ grep -- 'OPEN_WISPS=\$(gc bd list' "$asset" || true; } |
+            awk '!/^[[:space:]]*#/')
+
+        # NF guards both counts: printf on an empty $live still emits one blank
+        # line, which would otherwise read as a live query and mask deletion.
+        bad=$(printf '%s\n' "$live" |
+            awk 'NF && !(/--status=open/ && /--type=molecule/ && /--include-infra/)' |
+            wc -l)
+        [[ "$bad" -eq 0 ]] ||
+            fail "$name: OPEN_WISPS reconcile queries must pass --status=open --type=molecule --include-infra ($bad do not)"
+
+        # The floor is not optional: an every-line assertion is vacuously green
+        # once the line is gone, so without it deletion passes.
+        total=$(printf '%s\n' "$live" | awk 'NF' | wc -l)
+        [[ "$total" -ge 1 ]] ||
+            fail "$name: OPEN_WISPS reconcile query missing entirely"
+    done
+}
+
+test_boot_startup_claims_its_wisp() {
+    local prompt formula
+
+    prompt="$GASTOWN/agents/boot/prompt.template.md"
+    formula="$GASTOWN/formulas/mol-boot-patrol.toml"
+
+    # Pour and assign both leave the wisp open, while Step 1's assigned-work
+    # query and the CURRENT_WISP fallback in next-iteration both filter on
+    # --status=in_progress. Without the claim neither can ever resolve: the burn
+    # arm is unreachable, the "could not resolve current wisp" diagnostic prints
+    # on every healthy cycle, and each cycle re-pours. Nothing else in the loop
+    # sets in_progress -- gc exports GC_BEAD_ID only into ralph check scripts and
+    # boot has no hook-claim block -- so this line is the whole lifecycle.
+    grep -qF 'gc bd update "$NEW_WISP" --status=in_progress' "$prompt" ||
+        fail "boot prompt startup must claim the wisp --status=in_progress after pour+assign"
+    grep -qF 'gc bd update $WISP --status=in_progress' "$formula" ||
+        fail "mol-boot-patrol startup contract must document the --status=in_progress claim"
+
+    # The reuse leg is the other half: next-iteration deliberately leaves the
+    # successor assigned and open, so a startup that pours unconditionally
+    # duplicates it every recycle and leans on the surplus burn to clean up.
+    grep -q -- 'NEW_WISP=\$(gc bd list .*--status=open .*--include-infra' "$prompt" ||
+        fail "boot prompt startup must reuse an assigned open wisp before pouring"
 }
 
 test_refinery_direct_merge_is_worktree_safe_and_fail_closed() {
@@ -629,6 +704,8 @@ test_witness_handoff_recovery_is_guarded_and_fail_closed
 test_boot_wisp_queries_pin_include_infra
 test_boot_patrol_burn_resolves_current_wisp
 test_boot_deacon_observation_query_sees_wisps_tier
+test_boot_open_wisps_reconcile_pins_tier_flags
+test_boot_startup_claims_its_wisp
 test_refinery_direct_merge_is_worktree_safe_and_fail_closed
 
 echo "gastown pack asset tests passed"


### PR DESCRIPTION
Remediation for the post-merge review of #261 (`fix(gastown): give boot a patrol loop so the always-mode watchdog stops hot-respawning`). The review returned **request_changes** with three unresolved majors; this applies all three plus the minor that F1's own remedy directs be corrected alongside it.

Based on current `main` (`e013296`), not the reviewed landed head.

## F1 (major) — the wisp lifecycle was inert

The resolution #261 is organized around never actually happened. Pouring and assigning both leave a wisp `open`, and nothing in the loop ever set `in_progress`: `gc` exports `GC_BEAD_ID` only into ralph check scripts, and boot has no hook-claim block. So every "what am I working" query matched nothing, and the consequences were all silent:

- the burn arm in `next-iteration` was unreachable dead code,
- the "could not resolve current boot wisp" diagnostic printed on every *healthy* cycle,
- Step-1 resume after a restart could not happen,
- each cycle re-poured, leaning on the surplus burn to clean up after itself.

Startup now claims the wisp `--status=in_progress` after pour+assign, in both assets. It also reuses an already-assigned *open* wisp before pouring, so the successor `next-iteration` deliberately queues is picked up instead of duplicated. The "load-bearing leg" comments in both assets now name that dependency instead of implying `GC_BEAD_ID` carries it.

**F1(f):** the claim remedy stays boot-scoped, so the deacon-observation query is widened as the review requires. The deacon does not claim its wisps, so filtering them on `--status=in_progress` returned nothing on every healthy cycle and left the decision table's wisp-keyed rows permanently unkeyed. `gc bd list` already excludes closed beads unless `--all` is passed, so dropping the status filter yields open + in_progress and never burned history. The decision table now reads freshness from `created`/`updated` rather than status.

## F2 (major) — the only live no-leak leg was unpinned

The two `OPEN_WISPS` reconcile queries are the sole enforcement of the exactly-one-open-wisp invariant, and nothing pinned them against either revert or addition. The existing tier census counts flagged-over-total, so a revert drops `--type=molecule` and `--include-infra` together and the line leaves numerator and denominator at once — the suite stays green while the query returns `[]` at runtime.

Adds a token-independent every-line pin with a per-asset `>= 1` floor on both assets, plus a pin for the new claim and reuse leg.

### Mutation matrix

Each arm ran in a throwaway detached worktree with the assets restored between arms so mutations never stack. LANDED = the reviewed merge commit `0f35a61`; HEAD = this branch. An arm is only evidence of new coverage if it is green on LANDED and red on HEAD. Both surfaces are green pristine.

| Arm | LANDED | HEAD |
|---|---|---|
| M1 — formula `OPEN_WISPS` reverted to bare | green | **red** |
| M2 — both reconcile sites reverted | green | **red** |
| A1 — blind query added beside a good one | green | **red** |
| DEL — `OPEN_WISPS` line deleted | green | **red** |
| RO — legitimate flag reorder *(must stay green)* | green | green |
| CO1 — good query commented out | green | **red** |
| CO2 — dead commented-out bare query *(must stay green)* | green | green |
| C1 — startup claim dropped | n/a | **red** |
| C2 — startup reuse leg dropped | n/a | **red** |
| C3 — claim dropped from the formula contract | n/a | **red** |

M1/M2/A1/DEL are the arms the review measured as all-green against the landed tests, so this change is the sole source of that coverage. RO is the must-stay-green control: the three flags are matched independently, so reordering them does not trip the pin.

CO1/CO2 fold in the F6 nit, which the review scoped into these per-site pins rather than a separate change: the census greps raw lines, so disabling a query with a leading `#` still reads as covered. The new pin strips comment lines before counting, which closes that in both directions — a commented-out good query now falls through to the floor instead of passing, and a commented-out bad one no longer fails over dead text. The census's own counting behaviour is unchanged.

C1–C3 have no LANDED arm because the lines they delete do not exist there; that absence is the F1 hole itself.

## F3 (major) — the rationale misdirected its own remedy

Both assets asserted that every other always-mode agent avoids the trap the same way, while the named deacon sibling runs `gc runtime drain-ack` + `exit 1` whenever it cannot resolve its current wisp (`mol-deacon-patrol.toml:563-569`) — and its fallback query is empty in steady state, so that is the path it takes every cycle. The canonical write-up of the failure mode was pointing at an instance of the failure mode as the reference shape.

Both assets now state the true contract: ending the turn without draining is the intended pack-wide contract, and boot is the first agent to implement it. The deacon's own instance is tracked in `mc-x80bo`, referenced rather than fixed from here.

## F4 (minor, coupled to F1)

The `$GC_AGENT`/`$GC_ALIAS` comment described the pool alias-deferred path rather than the named-session path — for a named session `gc` sets both to the identity. One reviewer already derived a refuted non-defect from reading it as ground truth. Reworded to the named-session truth, still preferring `$GC_AGENT` because it also stays non-empty on pool paths.

## Test evidence

- `bash gastown/tests/test_gastown_pack_assets.sh` — green; two new tests registered in the runner list.
- CI's full `for test_script in gastown/tests/test_*.sh` loop — 5/5 pass.
- `mol-boot-patrol.toml` parses under `tomllib`; both steps present.
- Every fenced bash block in both assets syntax-checks under `bash -n` after template rendering, including the restructured startup `if`/`elif`.
- `pytest tests -q` — 133 passed, 38 skipped, 1 failed. The single failure is `test_gastown_lint_findings.py::test_every_universal_waiver_entry_is_still_reported`, which reproduces identically in a pristine worktree at base `e013296` (known dev-binary divergence, green in CI). No new waiver rows are needed: the added `gc bd list … | jq -r` sites route through `gc` and `bd list` has a legitimate `-r, --reverse` flag.
- Census figures quoted in the existing test's messages re-measured with that test's own pipeline: boot 5/5 → 6/6, pack-wide 10/21 → 11/22.

## Not carried

F5 (the trailing bare `gc hook`) is left as filed. Out-of-diff items stay out: the deacon's own hot-loop instance (`mc-x80bo`), the witness/refinery prompt-vs-formula end-turn divergence, and the deacon's two `$GC_ALIAS` sites — gemini's orphan premise there was refuted, and propagating `$GC_AGENT` would be a no-op. `mol-deacon-patrol.toml` is not touched.

Follow-ups are filed rather than left in this body: `mc-x80bo` for the deacon's own `drain-ack` + `exit 1` instance, and `gp-7fbvs` for the two items it does not cover — the never-claimed-wisp lifecycle in the deacon/refinery/witness patrols (measured: 2/5/2 reads of `--status=in_progress`, zero writers between them), and the prompt-vs-formula disagreement about ending the turn (refinery 0 vs 41 `drain-ack` mentions; witness 1 vs 0).
