### PR TITLE
feat(gascity): worker workspaces — pre_start worktree script, Workspace section, explicit claim keys (gp-n8v2)

### DIFF
--- a/gascity/README.md
+++ b/gascity/README.md
@@ -235,16 +235,25 @@ pre_start = ["sh {{.CityRoot}}/.gc/scripts/worker-worktree.sh"]
 ```
 
 The script makes `$GC_DIR` a worktree of `$GC_RIG_ROOT`'s repository and
-never touches the rig root's working tree. With a trigger bead it reuses the
-one branch whose name contains the bead id (local or on the remote) or
-creates `<bead id>` from `origin/HEAD`; a branch checked out in another
-worktree is not stolen (the lane is left detached at its tip, with a WARN).
-Nothing is ever deleted: a lane with tracked modifications, or a non-empty
-directory that is not a worktree, is moved to `<lane>.aside-<utc stamp>`
-first. Untracked files (materialized skills, hooks, `node_modules`) do not
-count as modifications. Because the lane is on the bead's branch when the
-worker claims, `gc hook --claim` stamps a correct `gc.work_branch` instead of
-inheriting a stale one. `sh worker-worktree.sh --help` lists the flags.
+never touches the rig root's working tree; the rig root, anything inside it,
+and any ancestor of it are refused up front. Runs on one repository are
+serialized by a lock in its git dir, so concurrent sessions cannot race on a
+branch or a lane. With a trigger bead it reuses the one branch whose name
+contains the bead id as a whole token (local or on the remote) or creates
+`<bead id>` from `origin/HEAD`; a branch checked out in another worktree is
+not stolen (the lane is left detached at its tip, with a WARN). Nothing is
+ever deleted: a lane with tracked modifications, or a non-empty directory
+that is not a git checkout, is moved to `<lane>.aside-<utc stamp>` first; a
+checkout of another repository is refused. Untracked files (materialized
+skills, hooks, `node_modules`) do not count as modifications. `sh
+worker-worktree.sh --help` prints the full contract.
+
+The lane is on the bead's branch when the worker claims. With a gascity that
+resolves the work branch from the session work dir (`hookClaimWorkBranchDir`,
+the companion core change), `gc hook --claim` then stamps a correct
+`gc.work_branch`; older builds read the rig root's branch, so the role prompt
+has the worker compare `gc.work_branch` with its branch after the claim and
+restamp it when they differ.
 
 Two related core behaviors complete the picture:
 

--- a/gascity/README.md
+++ b/gascity/README.md
@@ -204,6 +204,59 @@ Default formula routes use these qualified targets: `gc.run-operator`,
 `gc.implementation-worker`, `gc.gap-analyst`, `gc.implementation-reviewer`,
 and `gc.publisher`.
 
+## Worker workspaces
+
+A rig role agent starts in the rig root unless its `work_dir` says otherwise.
+Rigs whose `AGENTS` rules forbid working in the root (a shared checkout that
+lags `origin/main`, other agents' branches) give each worker its own worktree
+before the first turn, using two core surfaces: `work_dir` (gc creates it,
+starts the session in it, exports it as `$GC_DIR`, and materializes the
+agent's skills and hooks into it because it differs from the scope root) and
+`pre_start` (runs before the session, in `$GC_DIR`, with the session
+environment, including `GC_TRIGGER_BEAD_ID` for a slung bead).
+
+This pack ships `assets/scripts/worker-worktree.sh` for the `pre_start` half.
+Copy it into the city's scripts directory, which gc mirrors into every session
+work dir, and point the agent at it:
+
+```sh
+cp path/to/gascity/assets/scripts/worker-worktree.sh "$CITY/.gc/scripts/"
+```
+
+```toml
+# agents/implementation-worker-codex/agent.toml — a second role instance on
+# another provider (see the repository README, "Codex code workers"); the same
+# two keys work in a [[rigs.patches]] or [[patches.agent]] entry.
+scope = "rig"
+dir = "my-repo"
+provider = "codex"
+work_dir = ".worktrees/{{.Rig}}/lane-{{.AgentBase}}"
+pre_start = ["sh {{.CityRoot}}/.gc/scripts/worker-worktree.sh"]
+```
+
+The script makes `$GC_DIR` a worktree of `$GC_RIG_ROOT`'s repository and
+never touches the rig root's working tree. With a trigger bead it reuses the
+one branch whose name contains the bead id (local or on the remote) or
+creates `<bead id>` from `origin/HEAD`; a branch checked out in another
+worktree is not stolen (the lane is left detached at its tip, with a WARN).
+Nothing is ever deleted: a lane with tracked modifications, or a non-empty
+directory that is not a worktree, is moved to `<lane>.aside-<utc stamp>`
+first. Untracked files (materialized skills, hooks, `node_modules`) do not
+count as modifications. Because the lane is on the bead's branch when the
+worker claims, `gc hook --claim` stamps a correct `gc.work_branch` instead of
+inheriting a stale one. `sh worker-worktree.sh --help` lists the flags.
+
+Two related core behaviors complete the picture:
+
+- A bead carrying `work_dir=<absolute path>` metadata, assigned and in
+  progress, starts its next session in that directory (an existing per-bead
+  worktree wins over the agent's lane). The role prompt tells workers to stamp
+  it, with `gc.work_branch`, before closing a bead whose work continues.
+- Toolchain on the worker PATH belongs to the provider: `[providers.<name>]
+  env = { PATH = "..." }` (values expand `$VAR` against the controller
+  environment) or a command shim that prepends a directory of wrappers. The
+  role prompt does not install package managers.
+
 ## Build Methodology Contract
 
 `build-base` is the virtual full-lifecycle workflow contract. It defines the

--- a/gascity/assets/scripts/worker-worktree.sh
+++ b/gascity/assets/scripts/worker-worktree.sh
@@ -1,0 +1,277 @@
+#!/bin/sh
+# worker-worktree.sh — make a worker session's working directory a git
+# worktree of its rig, before the first turn.
+#
+# Built to run as a Gas City agent `pre_start` command. gc creates `work_dir`,
+# then runs pre_start with cwd = $GC_DIR and the session environment, then
+# stages skills/hooks into the same directory and starts the provider there.
+#
+#   # agents/<name>/agent.toml (or a [[patches.agent]] entry)
+#   work_dir  = ".worktrees/{{.Rig}}/lane-{{.AgentBase}}"
+#   pre_start = ["sh {{.CityRoot}}/.gc/scripts/worker-worktree.sh"]
+#
+# Inputs (flags win over environment):
+#   --workdir DIR    directory to turn into a worktree   (default $GC_DIR, else $PWD)
+#   --rig-root DIR   the rig checkout whose repository to use (default $GC_RIG_ROOT)
+#   --bead ID        bead whose branch to reuse or create (default $GC_TRIGGER_BEAD_ID;
+#                    empty leaves the worktree detached at --base)
+#   --base REF       start point for a new branch (default <remote>/HEAD, else <remote>/main)
+#   --remote NAME    remote to fetch and match branches on (default origin)
+#   --no-fetch       do not fetch before resolving refs
+#
+# Contract:
+#   * The rig root's working tree is never touched: the script only reads
+#     refs, fetches, and registers worktrees from it.
+#   * Nothing is deleted. A work dir that is not a worktree of this repository
+#     and is not empty is moved to <workdir>.aside-<utc stamp>; a worktree with
+#     tracked modifications is moved aside the same way before a fresh one
+#     replaces it. Untracked files (staged skills, hooks, node_modules) do not
+#     count as modifications and ride along on a branch switch.
+#   * Bead branch: exactly one branch (local or on the remote) whose name
+#     contains the bead id is reused. None: a new branch named <bead id> is
+#     created from --base. Several: fail closed and list them.
+#   * A bead branch already checked out in another worktree is not stolen: the
+#     work dir is left detached at that branch's tip and a WARN line names the
+#     other worktree.
+#   * Idempotent. Re-running on a work dir that is already on the right branch
+#     changes nothing (besides the fetch).
+#   * On success prints one line: WORKTREE <dir> <branch|detached> <head sha>.
+
+set -eu
+
+log() { printf 'worker-worktree: %s\n' "$*" >&2; }
+warn() { printf 'worker-worktree: WARN %s\n' "$*" >&2; }
+die() { printf 'worker-worktree: ERROR %s\n' "$*" >&2; exit 1; }
+
+WORKDIR="${GC_DIR:-}"
+RIG_ROOT="${GC_RIG_ROOT:-}"
+BEAD="${GC_TRIGGER_BEAD_ID:-}"
+BASE=""
+REMOTE="origin"
+FETCH=1
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --workdir) [ "$#" -ge 2 ] || die "--workdir needs a value"; WORKDIR="$2"; shift 2 ;;
+        --workdir=*) WORKDIR="${1#--workdir=}"; shift ;;
+        --rig-root) [ "$#" -ge 2 ] || die "--rig-root needs a value"; RIG_ROOT="$2"; shift 2 ;;
+        --rig-root=*) RIG_ROOT="${1#--rig-root=}"; shift ;;
+        --bead) [ "$#" -ge 2 ] || die "--bead needs a value"; BEAD="$2"; shift 2 ;;
+        --bead=*) BEAD="${1#--bead=}"; shift ;;
+        --base) [ "$#" -ge 2 ] || die "--base needs a value"; BASE="$2"; shift 2 ;;
+        --base=*) BASE="${1#--base=}"; shift ;;
+        --remote) [ "$#" -ge 2 ] || die "--remote needs a value"; REMOTE="$2"; shift 2 ;;
+        --remote=*) REMOTE="${1#--remote=}"; shift ;;
+        --no-fetch) FETCH=0; shift ;;
+        -h|--help) sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+        *) die "unknown argument: $1" ;;
+    esac
+done
+
+[ -n "$WORKDIR" ] || WORKDIR="$PWD"
+[ -n "$RIG_ROOT" ] || die "no rig root: pass --rig-root or set GC_RIG_ROOT"
+[ -d "$RIG_ROOT" ] || die "rig root is not a directory: $RIG_ROOT"
+command -v git >/dev/null 2>&1 || die "git is required on PATH"
+
+# Resolve to absolute, physical paths so worktree bookkeeping compares cleanly.
+abs() { (cd "$1" 2>/dev/null && pwd -P); }
+RIG_ROOT="$(abs "$RIG_ROOT")" || die "cannot enter rig root"
+case "$WORKDIR" in
+    /*) ;;
+    *) WORKDIR="$PWD/$WORKDIR" ;;
+esac
+
+RIG_COMMON="$(git -C "$RIG_ROOT" rev-parse --git-common-dir 2>/dev/null)" \
+    || die "rig root is not a git repository: $RIG_ROOT"
+case "$RIG_COMMON" in
+    /*) ;;
+    *) RIG_COMMON="$RIG_ROOT/$RIG_COMMON" ;;
+esac
+RIG_COMMON="$(abs "$RIG_COMMON")" || die "cannot resolve the rig's git dir"
+
+# The work dir must not be the rig root itself or sit inside its checkout.
+if [ -d "$WORKDIR" ]; then
+    WORKDIR_ABS="$(abs "$WORKDIR")"
+    [ "$WORKDIR_ABS" != "$RIG_ROOT" ] || die "work dir is the rig root; give the agent a work_dir outside it"
+    case "$WORKDIR_ABS/" in
+        "$RIG_ROOT"/*) die "work dir $WORKDIR_ABS is inside the rig root $RIG_ROOT" ;;
+    esac
+    WORKDIR="$WORKDIR_ABS"
+fi
+
+git_rig() { git -C "$RIG_ROOT" "$@"; }
+
+if [ "$FETCH" -eq 1 ]; then
+    if ! git_rig fetch --quiet --prune "$REMOTE" 2>/dev/null; then
+        warn "fetch from $REMOTE failed; continuing with the refs already present"
+    fi
+fi
+
+if [ -z "$BASE" ]; then
+    if BASE="$(git_rig symbolic-ref --quiet --short "refs/remotes/$REMOTE/HEAD" 2>/dev/null)"; then
+        :
+    elif git_rig show-ref --verify --quiet "refs/remotes/$REMOTE/main"; then
+        BASE="$REMOTE/main"
+    elif git_rig show-ref --verify --quiet "refs/remotes/$REMOTE/master"; then
+        BASE="$REMOTE/master"
+    else
+        BASE="HEAD"
+        warn "no $REMOTE/HEAD, $REMOTE/main or $REMOTE/master; new branches start at the rig root's HEAD"
+    fi
+fi
+git_rig rev-parse --verify --quiet "$BASE^{commit}" >/dev/null || die "base ref does not resolve: $BASE"
+
+# --- bead branch resolution -------------------------------------------------
+# TARGET_LOCAL: local branch to check out.  TARGET_REMOTE: remote branch to track
+# when no local branch exists.  TARGET_NEW: branch to create from BASE.
+TARGET_LOCAL=""
+TARGET_REMOTE=""
+TARGET_NEW=""
+if [ -n "$BEAD" ]; then
+    candidates="$(
+        {
+            git_rig for-each-ref --format='%(refname:short)' refs/heads
+            git_rig for-each-ref --format='%(refname:short)' "refs/remotes/$REMOTE" \
+                | grep -v "^$REMOTE/HEAD\$" | sed "s|^$REMOTE/||"
+        } | grep -F -- "$BEAD" | sort -u
+    )" || true
+    count="$(printf '%s\n' "$candidates" | grep -c . || true)"
+    if [ "$count" -gt 1 ]; then
+        die "several branches name bead $BEAD; pass --bead with a unique id or --base and no bead: $(printf '%s\n' "$candidates" | tr '\n' ' ')"
+    elif [ "$count" -eq 1 ]; then
+        if git_rig show-ref --verify --quiet "refs/heads/$candidates"; then
+            TARGET_LOCAL="$candidates"
+        else
+            TARGET_REMOTE="$candidates"
+        fi
+    else
+        TARGET_NEW="$BEAD"
+    fi
+fi
+
+# Where (if anywhere) is a local branch checked out?  Prints the worktree path.
+checked_out_at() {
+    git_rig worktree list --porcelain | awk -v want="refs/heads/$1" '
+        $1 == "worktree" { wt = $2 }
+        $1 == "branch" && $2 == want { print wt }
+    '
+}
+
+move_aside() {
+    stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+    aside="$1.aside-$stamp"
+    n=0
+    while [ -e "$aside" ]; do n=$((n + 1)); aside="$1.aside-$stamp-$n"; done
+    if git -C "$1" rev-parse --git-common-dir >/dev/null 2>&1 \
+        && [ "$(abs "$(git -C "$1" rev-parse --git-common-dir)")" = "$RIG_COMMON" ]; then
+        git_rig worktree move "$1" "$aside" >/dev/null 2>&1 || mv "$1" "$aside"
+    else
+        mv "$1" "$aside"
+    fi
+    warn "moved aside $1 -> $aside ($2); nothing was deleted"
+}
+
+# --- classify the work dir ----------------------------------------------------
+IS_WORKTREE=0
+if [ -d "$WORKDIR" ] && [ -e "$WORKDIR/.git" ]; then
+    wd_common="$(git -C "$WORKDIR" rev-parse --git-common-dir 2>/dev/null || true)"
+    case "$wd_common" in
+        "") ;;
+        /*) ;;
+        *) wd_common="$WORKDIR/$wd_common" ;;
+    esac
+    if [ -n "$wd_common" ] && [ -d "$wd_common" ] && [ "$(abs "$wd_common")" = "$RIG_COMMON" ]; then
+        IS_WORKTREE=1
+    fi
+fi
+
+if [ "$IS_WORKTREE" -eq 0 ] && [ -d "$WORKDIR" ]; then
+    if [ -n "$(ls -A "$WORKDIR" 2>/dev/null)" ]; then
+        move_aside "$WORKDIR" "not a worktree of $RIG_ROOT"
+    fi
+fi
+
+if [ "$IS_WORKTREE" -eq 1 ]; then
+    if [ -n "$(git -C "$WORKDIR" status --porcelain --untracked-files=no 2>/dev/null)" ]; then
+        move_aside "$WORKDIR" "tracked modifications present"
+        IS_WORKTREE=0
+    fi
+fi
+
+# --- act ----------------------------------------------------------------------
+add_worktree() {
+    # $1 = mode: local|remote|new|detached
+    [ -d "$WORKDIR" ] || mkdir -p "$WORKDIR"
+    case "$1" in
+        local)    git_rig worktree add --quiet "$WORKDIR" "$TARGET_LOCAL" ;;
+        remote)   git_rig worktree add --quiet --track -b "$TARGET_REMOTE" "$WORKDIR" "$REMOTE/$TARGET_REMOTE" ;;
+        new)      git_rig worktree add --quiet -b "$TARGET_NEW" "$WORKDIR" "$BASE" ;;
+        detached) git_rig worktree add --quiet --detach "$WORKDIR" "$2" ;;
+    esac
+}
+
+switch_worktree() {
+    # $1 = mode as above; the work dir is a clean worktree already.
+    case "$1" in
+        local)    git -C "$WORKDIR" switch --quiet "$TARGET_LOCAL" ;;
+        remote)   git -C "$WORKDIR" switch --quiet -c "$TARGET_REMOTE" --track "$REMOTE/$TARGET_REMOTE" ;;
+        new)      git -C "$WORKDIR" switch --quiet -c "$TARGET_NEW" "$BASE" ;;
+        detached) git -C "$WORKDIR" switch --quiet --detach "$2" ;;
+    esac
+}
+
+MODE=""
+DETACH_AT=""
+if [ -n "$TARGET_LOCAL" ]; then
+    elsewhere="$(checked_out_at "$TARGET_LOCAL" | grep -v -x -F -- "$WORKDIR" || true)"
+    if [ -n "$elsewhere" ]; then
+        MODE="detached"
+        DETACH_AT="$TARGET_LOCAL"
+        warn "branch $TARGET_LOCAL is checked out at $elsewhere; leaving $WORKDIR detached at its tip. Create your own branch before committing, or work in that worktree."
+    else
+        MODE="local"
+    fi
+elif [ -n "$TARGET_REMOTE" ]; then
+    MODE="remote"
+elif [ -n "$TARGET_NEW" ]; then
+    MODE="new"
+else
+    MODE="detached"
+    DETACH_AT="$BASE"
+fi
+
+if [ "$IS_WORKTREE" -eq 1 ]; then
+    current="$(git -C "$WORKDIR" rev-parse --abbrev-ref HEAD 2>/dev/null || echo HEAD)"
+    case "$MODE" in
+        local)  [ "$current" = "$TARGET_LOCAL" ] || switch_worktree local ;;
+        remote) switch_worktree remote ;;
+        new)    if git_rig show-ref --verify --quiet "refs/heads/$TARGET_NEW"; then
+                    # Created by a concurrent run between resolution and now.
+                    TARGET_LOCAL="$TARGET_NEW"; switch_worktree local
+                else
+                    switch_worktree new
+                fi ;;
+        detached)
+                if [ -n "$BEAD" ]; then
+                    switch_worktree detached "$DETACH_AT"
+                elif [ "$current" = "HEAD" ]; then
+                    # No bead and already detached: refresh to the base tip.
+                    switch_worktree detached "$DETACH_AT"
+                fi
+                # No bead and on a branch: leave the lane where a previous
+                # session put it; the worker owns that branch.
+                ;;
+    esac
+else
+    if [ "$MODE" = "detached" ]; then
+        add_worktree detached "$DETACH_AT"
+    else
+        add_worktree "$MODE"
+    fi
+fi
+
+WORKDIR="$(abs "$WORKDIR")"
+branch="$(git -C "$WORKDIR" rev-parse --abbrev-ref HEAD 2>/dev/null || echo HEAD)"
+[ "$branch" != "HEAD" ] || branch="detached"
+sha="$(git -C "$WORKDIR" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+printf 'WORKTREE %s %s %s\n' "$WORKDIR" "$branch" "$sha"

--- a/gascity/assets/scripts/worker-worktree.sh
+++ b/gascity/assets/scripts/worker-worktree.sh
@@ -27,8 +27,9 @@
 #     no owner published for two minutes) is cleared only under a second,
 #     atomic reclaim lock and only after re-checking it is still the same stale
 #     lock, so two contenders cannot both clear it and a live lock is never
-#     removed. Two sessions preparing lanes at once therefore cannot race on
-#     branch creation, on the same lane, or on the aside destination.
+#     removed; a reclaim lock stuck for two minutes fails the run closed. Two
+#     sessions preparing lanes at once therefore cannot race on branch
+#     creation, on the same lane, or on the aside destination.
 #   * The work dir is resolved on the real filesystem: it must exist, or its
 #     parent must exist and its last component must be a plain name (no `.`,
 #     `..`, or deeper missing levels). Symlinks resolve. The rig root itself,
@@ -148,7 +149,9 @@ git_rig() { git -C "$RIG_ROOT" "$@"; }
 # and finds it still stale: a contender that observed the stale lock, lost the
 # race, and arrives late finds a live owner (or no lock) under the reclaim lock
 # and does nothing. So a live lock is never removed by a late contender. A
-# reclaim lock left by a crash ages out after two minutes. Test-only pauses
+# reclaim lock left by a crash is never removed automatically (removing it by
+# age would reopen the same race one level down): after two minutes the script
+# fails closed and names the directory for an operator. Test-only pauses
 # (WORKER_WORKTREE_TEST_PAUSE_BEFORE_RECLAIM / _AFTER_ACQUIRE, seconds) exist so
 # the two-contender interleavings can be exercised deterministically.
 
@@ -181,14 +184,14 @@ RECLAIM="$LOCK.reclaim"
 # lock turned out live or gone, or the reclaim lock itself is stuck).
 reclaim_stale_lock() {
     if ! mkdir "$RECLAIM" 2>/dev/null; then
-        # Someone else is reclaiming; a reclaim lock older than two minutes is a
-        # crash residue and is removed so the next pass can proceed.
+        # Someone else is reclaiming. A reclaim lock older than two minutes is a
+        # crash residue; it is not removed here (two contenders removing it would
+        # race exactly like the primary lock) — fail closed and name it.
         if [ -n "$(find "$RECLAIM" -maxdepth 0 -mmin +2 2>/dev/null)" ]; then
-            rmdir "$RECLAIM" 2>/dev/null || true
+            die "stale reclaim lock $RECLAIM is older than two minutes; remove it by hand after checking no worker-worktree run is alive"
         fi
         return 1
     fi
-    [ -z "${WORKER_WORKTREE_TEST_PAUSE_BEFORE_RECLAIM:-}" ] || sleep "$WORKER_WORKTREE_TEST_PAUSE_BEFORE_RECLAIM"
     cleared=1
     if lock_is_stale; then
         warn "clearing stale lock $LOCK (owner pid ${owner:-none})"
@@ -218,8 +221,11 @@ while :; do
         [ -z "${WORKER_WORKTREE_TEST_PAUSE_AFTER_ACQUIRE:-}" ] || sleep "$WORKER_WORKTREE_TEST_PAUSE_AFTER_ACQUIRE"
         break
     fi
-    if lock_is_stale && reclaim_stale_lock; then
-        continue
+    if lock_is_stale; then
+        [ -z "${WORKER_WORKTREE_TEST_PAUSE_BEFORE_RECLAIM:-}" ] || sleep "$WORKER_WORKTREE_TEST_PAUSE_BEFORE_RECLAIM"
+        if reclaim_stale_lock; then
+            continue
+        fi
     fi
     # Live lock, or a reclaim that did not clear anything: bounded wait.
     [ "$waited" -lt "$LOCK_WAIT" ] || die "another worker-worktree run (pid ${owner:-unknown}) has held $LOCK for ${LOCK_WAIT}s"

--- a/gascity/assets/scripts/worker-worktree.sh
+++ b/gascity/assets/scripts/worker-worktree.sh
@@ -22,10 +22,12 @@
 #
 # Contract:
 #   * One path, serialized. Every run on a repository takes the lock
-#     <git common dir>/worker-worktree.lock before it reads or changes anything
-#     and releases it on exit; a lock whose owning pid is gone is cleared. So
-#     two sessions preparing lanes at once cannot race on branch creation, on
-#     the same lane, or on the aside destination.
+#     <git common dir>/worker-worktree.lock (mkdir) before it reads or changes
+#     anything and releases it on exit. A stale lock (owner dead or a zombie, or
+#     no owner published for two minutes) is reclaimed by an atomic rename, so
+#     two contenders cannot both clear it and a live lock is never removed. Two
+#     sessions preparing lanes at once therefore cannot race on branch
+#     creation, on the same lane, or on the aside destination.
 #   * The work dir is resolved on the real filesystem: it must exist, or its
 #     parent must exist and its last component must be a plain name (no `.`,
 #     `..`, or deeper missing levels). Symlinks resolve. The rig root itself,
@@ -92,9 +94,10 @@ done
 [ -d "$RIG_ROOT" ] || die "rig root is not a directory: $RIG_ROOT"
 command -v git >/dev/null 2>&1 || die "git is required on PATH"
 
-# abs DIR: absolute, symlink-resolved path of an existing directory. Callers
-# check the exit status; a failure is never silently folded into a path.
-abs() { (cd "$1" 2>/dev/null && pwd -P); }
+# abs DIR: absolute, symlink-resolved path of an existing directory, with `..`
+# resolved physically (cd -P), so "<symlink>/.." lands where the kernel puts it.
+# Callers check the exit status; a failure is never silently folded into a path.
+abs() { (cd -P "$1" 2>/dev/null && pwd -P); }
 
 # --- resolve and check paths, before anything else --------------------------------
 
@@ -138,6 +141,12 @@ RIG_COMMON="$(abs "$RIG_COMMON")" || die "cannot resolve the rig's git dir"
 git_rig() { git -C "$RIG_ROOT" "$@"; }
 
 # --- lock: one run per repository at a time -----------------------------------------
+# mkdir is the atomic acquire. A stale lock (owner pid dead or a zombie, or no
+# owner published for over two minutes) is reclaimed by RENAMING it to a
+# private name first: rename is atomic, so of two contenders that both saw the
+# same stale lock only one succeeds and only that one removes what it renamed;
+# the other's rename fails and it simply retries mkdir. Nothing ever removes a
+# lock in place, so a live lock cannot be deleted by a late contender.
 
 LOCK="$RIG_COMMON/worker-worktree.lock"
 LOCKED=0
@@ -146,6 +155,26 @@ release_lock() {
         rm -f "$LOCK/pid" 2>/dev/null || true
         rmdir "$LOCK" 2>/dev/null || true
         LOCKED=0
+    fi
+}
+
+lock_is_stale() {
+    owner="$(cat "$LOCK/pid" 2>/dev/null || true)"
+    if [ -n "$owner" ]; then
+        ! kill -0 "$owner" 2>/dev/null || owner_is_zombie "$owner"
+    else
+        # No owner published: a run died between mkdir and the pid write. Age it
+        # out rather than trusting the gap (a live run publishes within ms).
+        [ -n "$(find "$LOCK" -maxdepth 0 -mmin +2 2>/dev/null)" ]
+    fi
+}
+
+reclaim_stale_lock() {
+    claimed="$LOCK.stale.$$"
+    if mv "$LOCK" "$claimed" 2>/dev/null; then
+        warn "clearing stale lock $LOCK (owner pid ${owner:-none})"
+        rm -f "$claimed/pid" 2>/dev/null || true
+        rmdir "$claimed" 2>/dev/null || true
     fi
 }
 trap 'release_lock' EXIT
@@ -167,13 +196,8 @@ while :; do
         printf '%s\n' "$$" > "$LOCK/pid"
         break
     fi
-    owner="$(cat "$LOCK/pid" 2>/dev/null || true)"
-    # Dead owner: no such process, or a zombie its parent never reaped (kill -0
-    # still succeeds on a zombie; ps reports state Z).
-    if [ -n "$owner" ] && { ! kill -0 "$owner" 2>/dev/null || owner_is_zombie "$owner"; }; then
-        warn "clearing stale lock $LOCK left by pid $owner"
-        rm -f "$LOCK/pid" 2>/dev/null || true
-        rmdir "$LOCK" 2>/dev/null || true
+    if lock_is_stale; then
+        reclaim_stale_lock
         continue
     fi
     [ "$waited" -lt "$LOCK_WAIT" ] || die "another worker-worktree run (pid ${owner:-unknown}) has held $LOCK for ${LOCK_WAIT}s"
@@ -202,7 +226,9 @@ if [ -z "$BASE" ]; then
         warn "no $REMOTE/HEAD, $REMOTE/main or $REMOTE/master; new branches start at the rig root's HEAD"
     fi
 fi
-git_rig rev-parse --verify --quiet "$BASE^{commit}" >/dev/null || die "base ref does not resolve: $BASE"
+# Pin the base to a commit once, in the rig: a symbolic name such as HEAD would
+# otherwise be re-read inside the lane, where it means something else.
+BASE_SHA="$(git_rig rev-parse --verify --quiet "$BASE^{commit}")" || die "base ref does not resolve: $BASE"
 
 # --- helpers ------------------------------------------------------------------------------
 
@@ -262,40 +288,6 @@ move_aside() {
     warn "moved aside $1 -> $aside ($2); nothing was deleted"
 }
 
-# --- resolve what the work dir should have checked out --------------------------------------
-# MODE: local (check out TARGET), remote (track TARGET from the remote),
-# new (create TARGET from BASE), detached (detach at DETACH_AT).
-MODE=""
-TARGET=""
-DETACH_AT=""
-if [ -z "$BEAD" ]; then
-    MODE="detached"
-    DETACH_AT="$BASE"
-else
-    candidates="$(bead_branches)"
-    count="$(printf '%s\n' "$candidates" | grep -c . || true)"
-    if [ "$count" -gt 1 ]; then
-        die "several branches name bead $BEAD; pass --bead with a unique id, or --base and no bead: $(printf '%s\n' "$candidates" | tr '\n' ' ')"
-    elif [ "$count" -eq 0 ]; then
-        MODE="new"
-        TARGET="$BEAD"
-    else
-        TARGET="$candidates"
-        if git_rig show-ref --verify --quiet "refs/heads/$TARGET"; then
-            elsewhere="$(checked_out_at "$TARGET" | grep -v -x -F -- "$WORKDIR" || true)"
-            if [ -n "$elsewhere" ]; then
-                MODE="detached"
-                DETACH_AT="$TARGET"
-                warn "branch $TARGET is checked out at $elsewhere; leaving $WORKDIR detached at its tip. Create your own branch in this work dir before committing."
-            else
-                MODE="local"
-            fi
-        else
-            MODE="remote"
-        fi
-    fi
-fi
-
 # --- classify the work dir ------------------------------------------------------------------
 IS_WORKTREE=0
 if [ -d "$WORKDIR" ]; then
@@ -310,13 +302,50 @@ if [ -d "$WORKDIR" ]; then
     fi
 fi
 
+# --- resolve what the work dir should have checked out --------------------------------------
+# Runs AFTER classification so a worktree just moved aside (which still holds
+# its branch) is seen as "checked out elsewhere" and the detached fallback
+# applies instead of a failing worktree add.
+# MODE: local (check out TARGET), remote (track TARGET from the remote),
+# new (create TARGET from BASE_SHA), detached (detach at DETACH_AT, a commit).
+MODE=""
+TARGET=""
+DETACH_AT=""
+if [ -z "$BEAD" ]; then
+    MODE="detached"
+    DETACH_AT="$BASE_SHA"
+else
+    candidates="$(bead_branches)"
+    count="$(printf '%s\n' "$candidates" | grep -c . || true)"
+    if [ "$count" -gt 1 ]; then
+        die "several branches name bead $BEAD; pass --bead with a unique id, or --base and no bead: $(printf '%s\n' "$candidates" | tr '\n' ' ')"
+    elif [ "$count" -eq 0 ]; then
+        MODE="new"
+        TARGET="$BEAD"
+    else
+        TARGET="$candidates"
+        if git_rig show-ref --verify --quiet "refs/heads/$TARGET"; then
+            elsewhere="$(checked_out_at "$TARGET" | grep -v -x -F -- "$WORKDIR" || true)"
+            if [ -n "$elsewhere" ]; then
+                MODE="detached"
+                DETACH_AT="$(git_rig rev-parse --verify "refs/heads/$TARGET^{commit}")"
+                warn "branch $TARGET is checked out at $elsewhere; leaving $WORKDIR detached at its tip. Create your own branch in this work dir before committing."
+            else
+                MODE="local"
+            fi
+        else
+            MODE="remote"
+        fi
+    fi
+fi
+
 # --- act --------------------------------------------------------------------------------------
 add_worktree() {
     [ -d "$WORKDIR" ] || mkdir -p "$WORKDIR"
     case "$MODE" in
         local)    git_rig worktree add --quiet "$WORKDIR" "$TARGET" ;;
         remote)   git_rig worktree add --quiet --track -b "$TARGET" "$WORKDIR" "$REMOTE/$TARGET" ;;
-        new)      git_rig worktree add --quiet -b "$TARGET" "$WORKDIR" "$BASE" ;;
+        new)      git_rig worktree add --quiet -b "$TARGET" "$WORKDIR" "$BASE_SHA" ;;
         detached) git_rig worktree add --quiet --detach "$WORKDIR" "$DETACH_AT" ;;
     esac
 }
@@ -328,7 +357,7 @@ switch_worktree() {
     case "$MODE" in
         local)    git -C "$WORKDIR" switch --quiet --no-overwrite-ignore "$TARGET" ;;
         remote)   git -C "$WORKDIR" switch --quiet --no-overwrite-ignore -c "$TARGET" --track "$REMOTE/$TARGET" ;;
-        new)      git -C "$WORKDIR" switch --quiet --no-overwrite-ignore -c "$TARGET" "$BASE" ;;
+        new)      git -C "$WORKDIR" switch --quiet --no-overwrite-ignore -c "$TARGET" "$BASE_SHA" ;;
         detached) git -C "$WORKDIR" switch --quiet --no-overwrite-ignore --detach "$DETACH_AT" ;;
     esac
 }
@@ -338,8 +367,7 @@ if [ "$IS_WORKTREE" -eq 1 ]; then
     need_switch=1
     case "$MODE" in
         local)    [ "$current" != "$TARGET" ] || need_switch=0 ;;
-        detached) if [ "$current" = "HEAD" ] \
-                     && [ "$(git -C "$WORKDIR" rev-parse HEAD)" = "$(git_rig rev-parse "$DETACH_AT^{commit}")" ]; then
+        detached) if [ "$current" = "HEAD" ] && [ "$(git -C "$WORKDIR" rev-parse HEAD)" = "$DETACH_AT" ]; then
                       need_switch=0
                   fi ;;
     esac
@@ -360,7 +388,8 @@ is_our_worktree "$WORKDIR" || die "$WORKDIR is not a worktree of $RIG_ROOT after
 branch="$(git -C "$WORKDIR" rev-parse --abbrev-ref HEAD 2>/dev/null || echo HEAD)"
 case "$MODE" in
     local|remote|new) [ "$branch" = "$TARGET" ] || die "$WORKDIR is on $branch, expected $TARGET" ;;
-    detached)         [ "$branch" = "HEAD" ] || die "$WORKDIR is on $branch, expected a detached HEAD" ;;
+    detached)         [ "$branch" = "HEAD" ] || die "$WORKDIR is on $branch, expected a detached HEAD"
+                      [ "$(git -C "$WORKDIR" rev-parse HEAD)" = "$DETACH_AT" ] || die "$WORKDIR is detached at $(git -C "$WORKDIR" rev-parse --short HEAD), expected $DETACH_AT" ;;
 esac
 [ "$branch" != "HEAD" ] || branch="detached"
 sha="$(git -C "$WORKDIR" rev-parse --short HEAD 2>/dev/null || echo unknown)"

--- a/gascity/assets/scripts/worker-worktree.sh
+++ b/gascity/assets/scripts/worker-worktree.sh
@@ -21,18 +21,28 @@
 #
 # Contract:
 #   * The rig root's working tree is never touched: the script only reads
-#     refs, fetches, and registers worktrees from it.
+#     refs, fetches, and registers worktrees from it. A work dir that is the
+#     rig root, inside it, or an ancestor of it is refused before any change.
 #   * Nothing is deleted. A work dir that is not a worktree of this repository
 #     and is not empty is moved to <workdir>.aside-<utc stamp>; a worktree with
 #     tracked modifications is moved aside the same way before a fresh one
-#     replaces it. Untracked files (staged skills, hooks, node_modules) do not
-#     count as modifications and ride along on a branch switch.
+#     replaces it; a branch switch that would overwrite an ignored file
+#     (`git switch --no-overwrite-ignore`) moves the worktree aside instead.
+#     Untracked files (staged skills, hooks, node_modules) do not count as
+#     modifications and ride along on a branch switch. A worktree git refuses
+#     to move (locked) is left in place and the script fails.
 #   * Bead branch: exactly one branch (local or on the remote) whose name
-#     contains the bead id is reused. None: a new branch named <bead id> is
-#     created from --base. Several: fail closed and list them.
+#     contains the bead id as a whole token — `gp-abc1`, `fix/gp-abc1-x`, never
+#     `gp-abc10` — is reused. None: a new branch named <bead id> is created
+#     from --base. Several: fail closed and list them. If another session
+#     creates the branch first, this one falls back the same way it would have
+#     had the branch existed at the start (checkout, or detached when it is
+#     checked out elsewhere).
 #   * A bead branch already checked out in another worktree is not stolen: the
-#     work dir is left detached at that branch's tip and a WARN line names the
-#     other worktree.
+#     work dir is left detached at that branch's tip and a WARN line says so.
+#     Create your own branch in this work dir before committing.
+#   * No bead: the work dir is detached at --base, whatever branch it was on
+#     (the branch itself is kept; nothing is deleted).
 #   * Idempotent. Re-running on a work dir that is already on the right branch
 #     changes nothing (besides the fetch).
 #   * On success prints one line: WORKTREE <dir> <branch|detached> <head sha>.
@@ -63,7 +73,7 @@ while [ "$#" -gt 0 ]; do
         --remote) [ "$#" -ge 2 ] || die "--remote needs a value"; REMOTE="$2"; shift 2 ;;
         --remote=*) REMOTE="${1#--remote=}"; shift ;;
         --no-fetch) FETCH=0; shift ;;
-        -h|--help) sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+        -h|--help) sed -n '2,50p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
         *) die "unknown argument: $1" ;;
     esac
 done
@@ -73,12 +83,41 @@ done
 [ -d "$RIG_ROOT" ] || die "rig root is not a directory: $RIG_ROOT"
 command -v git >/dev/null 2>&1 || die "git is required on PATH"
 
-# Resolve to absolute, physical paths so worktree bookkeeping compares cleanly.
+# abs DIR: absolute, symlink-resolved path of an existing directory.
 abs() { (cd "$1" 2>/dev/null && pwd -P); }
+
+# canon PATH: the same for a path that need not exist yet — resolve the deepest
+# existing ancestor and re-append the rest, so a not-yet-created work dir is
+# compared on the real filesystem location it will occupy.
+canon() {
+    p="$1"
+    case "$p" in
+        /*) ;;
+        *) p="$PWD/$p" ;;
+    esac
+    rest=""
+    while [ ! -d "$p" ]; do
+        base="${p##*/}"
+        parent="${p%/*}"
+        [ -n "$parent" ] || parent="/"
+        [ "$parent" != "$p" ] || die "cannot resolve path: $1"
+        rest="/$base$rest"
+        p="$parent"
+    done
+    printf '%s%s\n' "$(abs "$p")" "$rest"
+}
+
 RIG_ROOT="$(abs "$RIG_ROOT")" || die "cannot enter rig root"
-case "$WORKDIR" in
-    /*) ;;
-    *) WORKDIR="$PWD/$WORKDIR" ;;
+WORKDIR="$(canon "$WORKDIR")"
+
+# Refuse before anything else: the rig root itself, anything inside it, and any
+# ancestor of it (moving an ancestor aside would move the rig).
+[ "$WORKDIR" != "$RIG_ROOT" ] || die "work dir is the rig root; give the agent a work_dir outside it"
+case "$WORKDIR/" in
+    "$RIG_ROOT"/*) die "work dir $WORKDIR is inside the rig root $RIG_ROOT" ;;
+esac
+case "$RIG_ROOT/" in
+    "$WORKDIR"/*) die "work dir $WORKDIR is an ancestor of the rig root $RIG_ROOT" ;;
 esac
 
 RIG_COMMON="$(git -C "$RIG_ROOT" rev-parse --git-common-dir 2>/dev/null)" \
@@ -88,16 +127,6 @@ case "$RIG_COMMON" in
     *) RIG_COMMON="$RIG_ROOT/$RIG_COMMON" ;;
 esac
 RIG_COMMON="$(abs "$RIG_COMMON")" || die "cannot resolve the rig's git dir"
-
-# The work dir must not be the rig root itself or sit inside its checkout.
-if [ -d "$WORKDIR" ]; then
-    WORKDIR_ABS="$(abs "$WORKDIR")"
-    [ "$WORKDIR_ABS" != "$RIG_ROOT" ] || die "work dir is the rig root; give the agent a work_dir outside it"
-    case "$WORKDIR_ABS/" in
-        "$RIG_ROOT"/*) die "work dir $WORKDIR_ABS is inside the rig root $RIG_ROOT" ;;
-    esac
-    WORKDIR="$WORKDIR_ABS"
-fi
 
 git_rig() { git -C "$RIG_ROOT" "$@"; }
 
@@ -121,153 +150,176 @@ if [ -z "$BASE" ]; then
 fi
 git_rig rev-parse --verify --quiet "$BASE^{commit}" >/dev/null || die "base ref does not resolve: $BASE"
 
-# --- bead branch resolution -------------------------------------------------
-# TARGET_LOCAL: local branch to check out.  TARGET_REMOTE: remote branch to track
-# when no local branch exists.  TARGET_NEW: branch to create from BASE.
-TARGET_LOCAL=""
-TARGET_REMOTE=""
-TARGET_NEW=""
-if [ -n "$BEAD" ]; then
-    candidates="$(
-        {
-            git_rig for-each-ref --format='%(refname:short)' refs/heads
-            git_rig for-each-ref --format='%(refname:short)' "refs/remotes/$REMOTE" \
-                | grep -v "^$REMOTE/HEAD\$" | sed "s|^$REMOTE/||"
-        } | grep -F -- "$BEAD" | sort -u
-    )" || true
-    count="$(printf '%s\n' "$candidates" | grep -c . || true)"
-    if [ "$count" -gt 1 ]; then
-        die "several branches name bead $BEAD; pass --bead with a unique id or --base and no bead: $(printf '%s\n' "$candidates" | tr '\n' ' ')"
-    elif [ "$count" -eq 1 ]; then
-        if git_rig show-ref --verify --quiet "refs/heads/$candidates"; then
-            TARGET_LOCAL="$candidates"
-        else
-            TARGET_REMOTE="$candidates"
-        fi
-    else
-        TARGET_NEW="$BEAD"
-    fi
-fi
+# --- helpers -------------------------------------------------------------------
 
-# Where (if anywhere) is a local branch checked out?  Prints the worktree path.
+# bead_branches: every branch name (local, and remote with the remote prefix
+# stripped) containing BEAD as a whole token, one per line, de-duplicated.
+bead_branches() {
+    # Escape the id for an ERE, then require a non-alphanumeric boundary (or
+    # the string edge) on both sides so gp-abc1 never matches gp-abc10.
+    id_re="$(printf '%s' "$BEAD" | sed 's/[][\\.^$*+?(){}|/]/\\&/g')"
+    {
+        git_rig for-each-ref --format='%(refname:short)' refs/heads
+        git_rig for-each-ref --format='%(refname:short)' "refs/remotes/$REMOTE" \
+            | grep -v "^$REMOTE/HEAD\$" | sed "s|^$REMOTE/||"
+    } | grep -E -- "(^|[^A-Za-z0-9])${id_re}([^A-Za-z0-9]|\$)" | sort -u || true
+}
+
+# checked_out_at BRANCH: the worktree path holding BRANCH, if any. Paths may
+# contain spaces, so keep the whole line after the "worktree " key.
 checked_out_at() {
     git_rig worktree list --porcelain | awk -v want="refs/heads/$1" '
-        $1 == "worktree" { wt = $2 }
+        /^worktree / { wt = $0; sub(/^worktree /, "", wt) }
         $1 == "branch" && $2 == want { print wt }
     '
 }
 
+is_our_worktree() {
+    [ -e "$1/.git" ] || return 1
+    c="$(git -C "$1" rev-parse --git-common-dir 2>/dev/null || true)"
+    [ -n "$c" ] || return 1
+    case "$c" in
+        /*) ;;
+        *) c="$1/$c" ;;
+    esac
+    [ -d "$c" ] && [ "$(abs "$c")" = "$RIG_COMMON" ]
+}
+
+# move_aside DIR REASON: relocate DIR out of the way without deleting anything.
+# A registered worktree goes through `git worktree move` so its registration
+# follows it; if git refuses (locked, or otherwise), fail closed rather than
+# mv a registered worktree out from under git.
 move_aside() {
     stamp="$(date -u +%Y%m%dT%H%M%SZ)"
     aside="$1.aside-$stamp"
     n=0
     while [ -e "$aside" ]; do n=$((n + 1)); aside="$1.aside-$stamp-$n"; done
-    if git -C "$1" rev-parse --git-common-dir >/dev/null 2>&1 \
-        && [ "$(abs "$(git -C "$1" rev-parse --git-common-dir)")" = "$RIG_COMMON" ]; then
-        git_rig worktree move "$1" "$aside" >/dev/null 2>&1 || mv "$1" "$aside"
+    if is_our_worktree "$1"; then
+        if ! out="$(git_rig worktree move "$1" "$aside" 2>&1)"; then
+            die "git refused to move the worktree $1 aside ($2): $out"
+        fi
     else
         mv "$1" "$aside"
     fi
     warn "moved aside $1 -> $aside ($2); nothing was deleted"
 }
 
-# --- classify the work dir ----------------------------------------------------
-IS_WORKTREE=0
-if [ -d "$WORKDIR" ] && [ -e "$WORKDIR/.git" ]; then
-    wd_common="$(git -C "$WORKDIR" rev-parse --git-common-dir 2>/dev/null || true)"
-    case "$wd_common" in
-        "") ;;
-        /*) ;;
-        *) wd_common="$WORKDIR/$wd_common" ;;
-    esac
-    if [ -n "$wd_common" ] && [ -d "$wd_common" ] && [ "$(abs "$wd_common")" = "$RIG_COMMON" ]; then
-        IS_WORKTREE=1
-    fi
-fi
-
-if [ "$IS_WORKTREE" -eq 0 ] && [ -d "$WORKDIR" ]; then
-    if [ -n "$(ls -A "$WORKDIR" 2>/dev/null)" ]; then
-        move_aside "$WORKDIR" "not a worktree of $RIG_ROOT"
-    fi
-fi
-
-if [ "$IS_WORKTREE" -eq 1 ]; then
-    if [ -n "$(git -C "$WORKDIR" status --porcelain --untracked-files=no 2>/dev/null)" ]; then
-        move_aside "$WORKDIR" "tracked modifications present"
-        IS_WORKTREE=0
-    fi
-fi
-
-# --- act ----------------------------------------------------------------------
-add_worktree() {
-    # $1 = mode: local|remote|new|detached
-    [ -d "$WORKDIR" ] || mkdir -p "$WORKDIR"
-    case "$1" in
-        local)    git_rig worktree add --quiet "$WORKDIR" "$TARGET_LOCAL" ;;
-        remote)   git_rig worktree add --quiet --track -b "$TARGET_REMOTE" "$WORKDIR" "$REMOTE/$TARGET_REMOTE" ;;
-        new)      git_rig worktree add --quiet -b "$TARGET_NEW" "$WORKDIR" "$BASE" ;;
-        detached) git_rig worktree add --quiet --detach "$WORKDIR" "$2" ;;
-    esac
-}
-
-switch_worktree() {
-    # $1 = mode as above; the work dir is a clean worktree already.
-    case "$1" in
-        local)    git -C "$WORKDIR" switch --quiet "$TARGET_LOCAL" ;;
-        remote)   git -C "$WORKDIR" switch --quiet -c "$TARGET_REMOTE" --track "$REMOTE/$TARGET_REMOTE" ;;
-        new)      git -C "$WORKDIR" switch --quiet -c "$TARGET_NEW" "$BASE" ;;
-        detached) git -C "$WORKDIR" switch --quiet --detach "$2" ;;
-    esac
-}
-
-MODE=""
-DETACH_AT=""
-if [ -n "$TARGET_LOCAL" ]; then
-    elsewhere="$(checked_out_at "$TARGET_LOCAL" | grep -v -x -F -- "$WORKDIR" || true)"
-    if [ -n "$elsewhere" ]; then
+# --- bead branch resolution -----------------------------------------------------
+# MODE: local (check out TARGET), remote (track TARGET from the remote),
+# new (create TARGET from BASE), detached (detach at DETACH_AT).
+resolve_mode() {
+    MODE=""
+    TARGET=""
+    DETACH_AT=""
+    if [ -z "$BEAD" ]; then
         MODE="detached"
-        DETACH_AT="$TARGET_LOCAL"
-        warn "branch $TARGET_LOCAL is checked out at $elsewhere; leaving $WORKDIR detached at its tip. Create your own branch before committing, or work in that worktree."
-    else
-        MODE="local"
+        DETACH_AT="$BASE"
+        return
     fi
-elif [ -n "$TARGET_REMOTE" ]; then
-    MODE="remote"
-elif [ -n "$TARGET_NEW" ]; then
-    MODE="new"
-else
-    MODE="detached"
-    DETACH_AT="$BASE"
+    candidates="$(bead_branches)"
+    count="$(printf '%s\n' "$candidates" | grep -c . || true)"
+    if [ "$count" -gt 1 ]; then
+        die "several branches name bead $BEAD; pass --bead with a unique id, or --base and no bead: $(printf '%s\n' "$candidates" | tr '\n' ' ')"
+    fi
+    if [ "$count" -eq 0 ]; then
+        MODE="new"
+        TARGET="$BEAD"
+        return
+    fi
+    TARGET="$candidates"
+    if git_rig show-ref --verify --quiet "refs/heads/$TARGET"; then
+        elsewhere="$(checked_out_at "$TARGET" | grep -v -x -F -- "$WORKDIR" || true)"
+        if [ -n "$elsewhere" ]; then
+            MODE="detached"
+            DETACH_AT="$TARGET"
+            warn "branch $TARGET is checked out at $elsewhere; leaving $WORKDIR detached at its tip. Create your own branch in this work dir before committing."
+        else
+            MODE="local"
+        fi
+    else
+        MODE="remote"
+    fi
+}
+
+# --- classify the work dir --------------------------------------------------------
+IS_WORKTREE=0
+if [ -d "$WORKDIR" ] && is_our_worktree "$WORKDIR"; then
+    IS_WORKTREE=1
 fi
+
+if [ "$IS_WORKTREE" -eq 0 ] && [ -d "$WORKDIR" ] && [ -n "$(ls -A "$WORKDIR" 2>/dev/null)" ]; then
+    move_aside "$WORKDIR" "not a worktree of $RIG_ROOT"
+fi
+
+if [ "$IS_WORKTREE" -eq 1 ] && [ -n "$(git -C "$WORKDIR" status --porcelain --untracked-files=no 2>/dev/null)" ]; then
+    move_aside "$WORKDIR" "tracked modifications present"
+    IS_WORKTREE=0
+fi
+
+# --- act ----------------------------------------------------------------------------
+add_worktree() {
+    [ -d "$WORKDIR" ] || mkdir -p "$WORKDIR"
+    case "$MODE" in
+        local)    git_rig worktree add --quiet "$WORKDIR" "$TARGET" ;;
+        remote)   git_rig worktree add --quiet --track -b "$TARGET" "$WORKDIR" "$REMOTE/$TARGET" ;;
+        new)      git_rig worktree add --quiet -b "$TARGET" "$WORKDIR" "$BASE" ;;
+        detached) git_rig worktree add --quiet --detach "$WORKDIR" "$DETACH_AT" ;;
+    esac
+}
+
+# switch_worktree: change what a clean worktree has checked out. Never
+# overwrite an ignored file the target tracks; on any refusal the caller moves
+# the worktree aside and adds a fresh one.
+switch_worktree() {
+    case "$MODE" in
+        local)    git -C "$WORKDIR" switch --quiet --no-overwrite-ignore "$TARGET" ;;
+        remote)   git -C "$WORKDIR" switch --quiet --no-overwrite-ignore -c "$TARGET" --track "$REMOTE/$TARGET" ;;
+        new)      git -C "$WORKDIR" switch --quiet --no-overwrite-ignore -c "$TARGET" "$BASE" ;;
+        detached) git -C "$WORKDIR" switch --quiet --no-overwrite-ignore --detach "$DETACH_AT" ;;
+    esac
+}
+
+resolve_mode
+
+# A branch this run meant to create may have been created by a concurrent run
+# between resolution and the git call; re-resolving turns that into the
+# checkout-or-detached path the contract promises instead of a failure.
+attempt() {
+    # $1 = add|switch
+    tries=0
+    while :; do
+        tries=$((tries + 1))
+        if [ "$1" = add ]; then
+            if out="$(add_worktree 2>&1)"; then return 0; fi
+        else
+            if out="$(switch_worktree 2>&1)"; then return 0; fi
+        fi
+        if [ "$MODE" = "new" ] && [ "$tries" -lt 3 ] && git_rig show-ref --verify --quiet "refs/heads/$TARGET"; then
+            log "branch $TARGET appeared while preparing $WORKDIR; re-resolving"
+            resolve_mode
+            continue
+        fi
+        printf '%s\n' "$out" >&2
+        return 1
+    done
+}
 
 if [ "$IS_WORKTREE" -eq 1 ]; then
     current="$(git -C "$WORKDIR" rev-parse --abbrev-ref HEAD 2>/dev/null || echo HEAD)"
+    need_switch=1
     case "$MODE" in
-        local)  [ "$current" = "$TARGET_LOCAL" ] || switch_worktree local ;;
-        remote) switch_worktree remote ;;
-        new)    if git_rig show-ref --verify --quiet "refs/heads/$TARGET_NEW"; then
-                    # Created by a concurrent run between resolution and now.
-                    TARGET_LOCAL="$TARGET_NEW"; switch_worktree local
-                else
-                    switch_worktree new
-                fi ;;
-        detached)
-                if [ -n "$BEAD" ]; then
-                    switch_worktree detached "$DETACH_AT"
-                elif [ "$current" = "HEAD" ]; then
-                    # No bead and already detached: refresh to the base tip.
-                    switch_worktree detached "$DETACH_AT"
-                fi
-                # No bead and on a branch: leave the lane where a previous
-                # session put it; the worker owns that branch.
-                ;;
+        local)    [ "$current" != "$TARGET" ] || need_switch=0 ;;
+        detached) if [ "$current" = "HEAD" ] \
+                     && [ "$(git -C "$WORKDIR" rev-parse HEAD)" = "$(git_rig rev-parse "$DETACH_AT^{commit}")" ]; then
+                      need_switch=0
+                  fi ;;
     esac
-else
-    if [ "$MODE" = "detached" ]; then
-        add_worktree detached "$DETACH_AT"
-    else
-        add_worktree "$MODE"
+    if [ "$need_switch" -eq 1 ] && ! attempt switch; then
+        move_aside "$WORKDIR" "branch switch refused (ignored files in the way, or git error above)"
+        attempt add || die "could not prepare $WORKDIR after moving the previous worktree aside"
     fi
+else
+    attempt add || die "could not create the worktree at $WORKDIR"
 fi
 
 WORKDIR="$(abs "$WORKDIR")"

--- a/gascity/assets/scripts/worker-worktree.sh
+++ b/gascity/assets/scripts/worker-worktree.sh
@@ -24,10 +24,11 @@
 #   * One path, serialized. Every run on a repository takes the lock
 #     <git common dir>/worker-worktree.lock (mkdir) before it reads or changes
 #     anything and releases it on exit. A stale lock (owner dead or a zombie, or
-#     no owner published for two minutes) is reclaimed by an atomic rename, so
-#     two contenders cannot both clear it and a live lock is never removed. Two
-#     sessions preparing lanes at once therefore cannot race on branch
-#     creation, on the same lane, or on the aside destination.
+#     no owner published for two minutes) is cleared only under a second,
+#     atomic reclaim lock and only after re-checking it is still the same stale
+#     lock, so two contenders cannot both clear it and a live lock is never
+#     removed. Two sessions preparing lanes at once therefore cannot race on
+#     branch creation, on the same lane, or on the aside destination.
 #   * The work dir is resolved on the real filesystem: it must exist, or its
 #     parent must exist and its last component must be a plain name (no `.`,
 #     `..`, or deeper missing levels). Symlinks resolve. The rig root itself,
@@ -52,9 +53,9 @@
 #     Create your own branch in this work dir before committing.
 #   * No bead: the work dir is detached at --base, whatever branch it was on
 #     (the branch itself is kept; nothing is deleted).
-#   * Idempotent. Re-running on a work dir that is already on the right branch
-#     changes nothing (besides the fetch). The result is verified before the
-#     script reports success.
+#   * Idempotent for a clean work dir already on the requested branch (or
+#     detached at the requested commit): re-running changes nothing besides
+#     the fetch. The result is verified before the script reports success.
 #   * On success prints one line: WORKTREE <dir> <branch|detached> <head sha>.
 
 set -eu
@@ -142,11 +143,14 @@ git_rig() { git -C "$RIG_ROOT" "$@"; }
 
 # --- lock: one run per repository at a time -----------------------------------------
 # mkdir is the atomic acquire. A stale lock (owner pid dead or a zombie, or no
-# owner published for over two minutes) is reclaimed by RENAMING it to a
-# private name first: rename is atomic, so of two contenders that both saw the
-# same stale lock only one succeeds and only that one removes what it renamed;
-# the other's rename fails and it simply retries mkdir. Nothing ever removes a
-# lock in place, so a live lock cannot be deleted by a late contender.
+# owner published for over two minutes) is cleared only by the contender that
+# wins a second mkdir, the reclaim lock, and only after it re-reads the lock
+# and finds it still stale: a contender that observed the stale lock, lost the
+# race, and arrives late finds a live owner (or no lock) under the reclaim lock
+# and does nothing. So a live lock is never removed by a late contender. A
+# reclaim lock left by a crash ages out after two minutes. Test-only pauses
+# (WORKER_WORKTREE_TEST_PAUSE_BEFORE_RECLAIM / _AFTER_ACQUIRE, seconds) exist so
+# the two-contender interleavings can be exercised deterministically.
 
 LOCK="$RIG_COMMON/worker-worktree.lock"
 LOCKED=0
@@ -158,24 +162,41 @@ release_lock() {
     fi
 }
 
+# lock_is_stale: the lock at $LOCK has a dead/zombie owner, or no owner for
+# over two minutes (a run died between mkdir and the pid write; a live run
+# publishes within milliseconds). Sets `owner`.
 lock_is_stale() {
+    [ -d "$LOCK" ] || return 1
     owner="$(cat "$LOCK/pid" 2>/dev/null || true)"
     if [ -n "$owner" ]; then
         ! kill -0 "$owner" 2>/dev/null || owner_is_zombie "$owner"
     else
-        # No owner published: a run died between mkdir and the pid write. Age it
-        # out rather than trusting the gap (a live run publishes within ms).
         [ -n "$(find "$LOCK" -maxdepth 0 -mmin +2 2>/dev/null)" ]
     fi
 }
 
+RECLAIM="$LOCK.reclaim"
+# reclaim_stale_lock: clear $LOCK if, under the reclaim lock, it is still stale.
+# Returns 0 when something was cleared, 1 otherwise (lost the reclaim race, the
+# lock turned out live or gone, or the reclaim lock itself is stuck).
 reclaim_stale_lock() {
-    claimed="$LOCK.stale.$$"
-    if mv "$LOCK" "$claimed" 2>/dev/null; then
-        warn "clearing stale lock $LOCK (owner pid ${owner:-none})"
-        rm -f "$claimed/pid" 2>/dev/null || true
-        rmdir "$claimed" 2>/dev/null || true
+    if ! mkdir "$RECLAIM" 2>/dev/null; then
+        # Someone else is reclaiming; a reclaim lock older than two minutes is a
+        # crash residue and is removed so the next pass can proceed.
+        if [ -n "$(find "$RECLAIM" -maxdepth 0 -mmin +2 2>/dev/null)" ]; then
+            rmdir "$RECLAIM" 2>/dev/null || true
+        fi
+        return 1
     fi
+    [ -z "${WORKER_WORKTREE_TEST_PAUSE_BEFORE_RECLAIM:-}" ] || sleep "$WORKER_WORKTREE_TEST_PAUSE_BEFORE_RECLAIM"
+    cleared=1
+    if lock_is_stale; then
+        warn "clearing stale lock $LOCK (owner pid ${owner:-none})"
+        rm -f "$LOCK/pid" 2>/dev/null || true
+        rmdir "$LOCK" 2>/dev/null && cleared=0
+    fi
+    rmdir "$RECLAIM" 2>/dev/null || true
+    return "$cleared"
 }
 trap 'release_lock' EXIT
 trap 'release_lock; exit 129' HUP
@@ -194,12 +215,13 @@ while :; do
     if mkdir "$LOCK" 2>/dev/null; then
         LOCKED=1
         printf '%s\n' "$$" > "$LOCK/pid"
+        [ -z "${WORKER_WORKTREE_TEST_PAUSE_AFTER_ACQUIRE:-}" ] || sleep "$WORKER_WORKTREE_TEST_PAUSE_AFTER_ACQUIRE"
         break
     fi
-    if lock_is_stale; then
-        reclaim_stale_lock
+    if lock_is_stale && reclaim_stale_lock; then
         continue
     fi
+    # Live lock, or a reclaim that did not clear anything: bounded wait.
     [ "$waited" -lt "$LOCK_WAIT" ] || die "another worker-worktree run (pid ${owner:-unknown}) has held $LOCK for ${LOCK_WAIT}s"
     [ "$waited" -gt 0 ] || log "waiting for another run on this repository (pid ${owner:-unknown})"
     sleep 1
@@ -241,7 +263,10 @@ bead_branches() {
     {
         git_rig for-each-ref --format='%(refname:short)' refs/heads
         git_rig for-each-ref --format='%(refname:short)' "refs/remotes/$REMOTE" \
-            | grep -v "^$REMOTE/HEAD\$" | sed "s|^$REMOTE/||"
+            | while IFS= read -r ref; do
+                [ "$ref" != "$REMOTE/HEAD" ] || continue
+                printf '%s\n' "${ref#"$REMOTE/"}"
+            done
     } | grep -E -- "(^|[^A-Za-z0-9])${id_re}([^A-Za-z0-9]|\$)" | sort -u || true
 }
 

--- a/gascity/assets/scripts/worker-worktree.sh
+++ b/gascity/assets/scripts/worker-worktree.sh
@@ -222,7 +222,10 @@ while :; do
         break
     fi
     if lock_is_stale; then
-        [ -z "${WORKER_WORKTREE_TEST_PAUSE_BEFORE_RECLAIM:-}" ] || sleep "$WORKER_WORKTREE_TEST_PAUSE_BEFORE_RECLAIM"
+        if [ -n "${WORKER_WORKTREE_TEST_PAUSE_BEFORE_RECLAIM:-}" ]; then
+            log "TEST pausing before reclaim"
+            sleep "$WORKER_WORKTREE_TEST_PAUSE_BEFORE_RECLAIM"
+        fi
         if reclaim_stale_lock; then
             continue
         fi

--- a/gascity/assets/scripts/worker-worktree.sh
+++ b/gascity/assets/scripts/worker-worktree.sh
@@ -18,33 +18,41 @@
 #   --base REF       start point for a new branch (default <remote>/HEAD, else <remote>/main)
 #   --remote NAME    remote to fetch and match branches on (default origin)
 #   --no-fetch       do not fetch before resolving refs
+#   WORKER_WORKTREE_LOCK_WAIT  seconds to wait for another run on the same repository (default 120)
 #
 # Contract:
+#   * One path, serialized. Every run on a repository takes the lock
+#     <git common dir>/worker-worktree.lock before it reads or changes anything
+#     and releases it on exit; a lock whose owning pid is gone is cleared. So
+#     two sessions preparing lanes at once cannot race on branch creation, on
+#     the same lane, or on the aside destination.
+#   * The work dir is resolved on the real filesystem: it must exist, or its
+#     parent must exist and its last component must be a plain name (no `.`,
+#     `..`, or deeper missing levels). Symlinks resolve. The rig root itself,
+#     anything inside it, and any ancestor of it are refused before any change.
 #   * The rig root's working tree is never touched: the script only reads
-#     refs, fetches, and registers worktrees from it. A work dir that is the
-#     rig root, inside it, or an ancestor of it is refused before any change.
-#   * Nothing is deleted. A work dir that is not a worktree of this repository
-#     and is not empty is moved to <workdir>.aside-<utc stamp>; a worktree with
-#     tracked modifications is moved aside the same way before a fresh one
-#     replaces it; a branch switch that would overwrite an ignored file
-#     (`git switch --no-overwrite-ignore`) moves the worktree aside instead.
+#     refs, fetches, and registers worktrees from it.
+#   * Nothing is deleted. A non-empty work dir that is not a git checkout is
+#     moved to <workdir>.aside-<utc stamp>; a worktree of this repository with
+#     tracked modifications is moved aside the same way (through `git worktree
+#     move`, so registration follows; if git refuses, e.g. locked, the script
+#     fails in place); a branch switch that would overwrite an ignored file
+#     (`git switch --no-overwrite-ignore`) moves the worktree aside instead. A
+#     checkout of ANOTHER repository at the work dir is refused, not moved.
 #     Untracked files (staged skills, hooks, node_modules) do not count as
-#     modifications and ride along on a branch switch. A worktree git refuses
-#     to move (locked) is left in place and the script fails.
+#     modifications and ride along on a branch switch.
 #   * Bead branch: exactly one branch (local or on the remote) whose name
 #     contains the bead id as a whole token — `gp-abc1`, `fix/gp-abc1-x`, never
 #     `gp-abc10` — is reused. None: a new branch named <bead id> is created
-#     from --base. Several: fail closed and list them. If another session
-#     creates the branch first, this one falls back the same way it would have
-#     had the branch existed at the start (checkout, or detached when it is
-#     checked out elsewhere).
+#     from --base. Several: fail closed and list them.
 #   * A bead branch already checked out in another worktree is not stolen: the
 #     work dir is left detached at that branch's tip and a WARN line says so.
 #     Create your own branch in this work dir before committing.
 #   * No bead: the work dir is detached at --base, whatever branch it was on
 #     (the branch itself is kept; nothing is deleted).
 #   * Idempotent. Re-running on a work dir that is already on the right branch
-#     changes nothing (besides the fetch).
+#     changes nothing (besides the fetch). The result is verified before the
+#     script reports success.
 #   * On success prints one line: WORKTREE <dir> <branch|detached> <head sha>.
 
 set -eu
@@ -59,6 +67,7 @@ BEAD="${GC_TRIGGER_BEAD_ID:-}"
 BASE=""
 REMOTE="origin"
 FETCH=1
+LOCK_WAIT="${WORKER_WORKTREE_LOCK_WAIT:-120}"
 
 while [ "$#" -gt 0 ]; do
     case "$1" in
@@ -73,7 +82,7 @@ while [ "$#" -gt 0 ]; do
         --remote) [ "$#" -ge 2 ] || die "--remote needs a value"; REMOTE="$2"; shift 2 ;;
         --remote=*) REMOTE="${1#--remote=}"; shift ;;
         --no-fetch) FETCH=0; shift ;;
-        -h|--help) sed -n '2,50p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+        -h|--help) sed -n '2,60p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
         *) die "unknown argument: $1" ;;
     esac
 done
@@ -83,35 +92,33 @@ done
 [ -d "$RIG_ROOT" ] || die "rig root is not a directory: $RIG_ROOT"
 command -v git >/dev/null 2>&1 || die "git is required on PATH"
 
-# abs DIR: absolute, symlink-resolved path of an existing directory.
+# abs DIR: absolute, symlink-resolved path of an existing directory. Callers
+# check the exit status; a failure is never silently folded into a path.
 abs() { (cd "$1" 2>/dev/null && pwd -P); }
 
-# canon PATH: the same for a path that need not exist yet — resolve the deepest
-# existing ancestor and re-append the rest, so a not-yet-created work dir is
-# compared on the real filesystem location it will occupy.
-canon() {
-    p="$1"
-    case "$p" in
-        /*) ;;
-        *) p="$PWD/$p" ;;
+# --- resolve and check paths, before anything else --------------------------------
+
+RIG_ROOT="$(abs "$RIG_ROOT")" || die "cannot enter rig root: $RIG_ROOT"
+
+case "$WORKDIR" in
+    /*) ;;
+    *) WORKDIR="$PWD/$WORKDIR" ;;
+esac
+while [ "${WORKDIR%/}" != "$WORKDIR" ] && [ "$WORKDIR" != "/" ]; do WORKDIR="${WORKDIR%/}"; done
+if [ -d "$WORKDIR" ]; then
+    WORKDIR="$(abs "$WORKDIR")" || die "cannot enter work dir: $WORKDIR"
+else
+    leaf="${WORKDIR##*/}"
+    parent="${WORKDIR%/*}"
+    [ -n "$parent" ] || parent="/"
+    case "$leaf" in
+        ""|.|..) die "work dir must end in a plain directory name: $WORKDIR" ;;
     esac
-    rest=""
-    while [ ! -d "$p" ]; do
-        base="${p##*/}"
-        parent="${p%/*}"
-        [ -n "$parent" ] || parent="/"
-        [ "$parent" != "$p" ] || die "cannot resolve path: $1"
-        rest="/$base$rest"
-        p="$parent"
-    done
-    printf '%s%s\n' "$(abs "$p")" "$rest"
-}
+    [ -d "$parent" ] || die "parent of work dir does not exist: $parent (gc creates work_dir before pre_start; create the parent first)"
+    parent="$(abs "$parent")" || die "cannot enter parent of work dir: $parent"
+    WORKDIR="$parent/$leaf"
+fi
 
-RIG_ROOT="$(abs "$RIG_ROOT")" || die "cannot enter rig root"
-WORKDIR="$(canon "$WORKDIR")"
-
-# Refuse before anything else: the rig root itself, anything inside it, and any
-# ancestor of it (moving an ancestor aside would move the rig).
 [ "$WORKDIR" != "$RIG_ROOT" ] || die "work dir is the rig root; give the agent a work_dir outside it"
 case "$WORKDIR/" in
     "$RIG_ROOT"/*) die "work dir $WORKDIR is inside the rig root $RIG_ROOT" ;;
@@ -129,6 +136,53 @@ esac
 RIG_COMMON="$(abs "$RIG_COMMON")" || die "cannot resolve the rig's git dir"
 
 git_rig() { git -C "$RIG_ROOT" "$@"; }
+
+# --- lock: one run per repository at a time -----------------------------------------
+
+LOCK="$RIG_COMMON/worker-worktree.lock"
+LOCKED=0
+release_lock() {
+    if [ "$LOCKED" -eq 1 ]; then
+        rm -f "$LOCK/pid" 2>/dev/null || true
+        rmdir "$LOCK" 2>/dev/null || true
+        LOCKED=0
+    fi
+}
+trap 'release_lock' EXIT
+trap 'release_lock; exit 129' HUP
+trap 'release_lock; exit 130' INT
+trap 'release_lock; exit 143' TERM
+
+owner_is_zombie() {
+    case "$(ps -o stat= -p "$1" 2>/dev/null | tr -d ' ')" in
+        Z*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+waited=0
+while :; do
+    if mkdir "$LOCK" 2>/dev/null; then
+        LOCKED=1
+        printf '%s\n' "$$" > "$LOCK/pid"
+        break
+    fi
+    owner="$(cat "$LOCK/pid" 2>/dev/null || true)"
+    # Dead owner: no such process, or a zombie its parent never reaped (kill -0
+    # still succeeds on a zombie; ps reports state Z).
+    if [ -n "$owner" ] && { ! kill -0 "$owner" 2>/dev/null || owner_is_zombie "$owner"; }; then
+        warn "clearing stale lock $LOCK left by pid $owner"
+        rm -f "$LOCK/pid" 2>/dev/null || true
+        rmdir "$LOCK" 2>/dev/null || true
+        continue
+    fi
+    [ "$waited" -lt "$LOCK_WAIT" ] || die "another worker-worktree run (pid ${owner:-unknown}) has held $LOCK for ${LOCK_WAIT}s"
+    [ "$waited" -gt 0 ] || log "waiting for another run on this repository (pid ${owner:-unknown})"
+    sleep 1
+    waited=$((waited + 1))
+done
+
+# --- refs -------------------------------------------------------------------------------
 
 if [ "$FETCH" -eq 1 ]; then
     if ! git_rig fetch --quiet --prune "$REMOTE" 2>/dev/null; then
@@ -150,7 +204,7 @@ if [ -z "$BASE" ]; then
 fi
 git_rig rev-parse --verify --quiet "$BASE^{commit}" >/dev/null || die "base ref does not resolve: $BASE"
 
-# --- helpers -------------------------------------------------------------------
+# --- helpers ------------------------------------------------------------------------------
 
 # bead_branches: every branch name (local, and remote with the remote prefix
 # stripped) containing BEAD as a whole token, one per line, de-duplicated.
@@ -174,21 +228,23 @@ checked_out_at() {
     '
 }
 
+# is_our_worktree DIR: DIR is a git checkout whose common dir is this rig's.
 is_our_worktree() {
     [ -e "$1/.git" ] || return 1
-    c="$(git -C "$1" rev-parse --git-common-dir 2>/dev/null || true)"
-    [ -n "$c" ] || return 1
+    c="$(git -C "$1" rev-parse --git-common-dir 2>/dev/null)" || return 1
     case "$c" in
         /*) ;;
         *) c="$1/$c" ;;
     esac
-    [ -d "$c" ] && [ "$(abs "$c")" = "$RIG_COMMON" ]
+    c="$(abs "$c")" || return 1
+    [ "$c" = "$RIG_COMMON" ]
 }
 
 # move_aside DIR REASON: relocate DIR out of the way without deleting anything.
-# A registered worktree goes through `git worktree move` so its registration
-# follows it; if git refuses (locked, or otherwise), fail closed rather than
-# mv a registered worktree out from under git.
+# A worktree of this repository goes through `git worktree move` so its
+# registration follows it; if git refuses (locked, or otherwise), fail closed.
+# Anything else that is a git checkout belongs to another repository and is
+# refused. Plain content is moved with mv.
 move_aside() {
     stamp="$(date -u +%Y%m%dT%H%M%SZ)"
     aside="$1.aside-$stamp"
@@ -198,65 +254,63 @@ move_aside() {
         if ! out="$(git_rig worktree move "$1" "$aside" 2>&1)"; then
             die "git refused to move the worktree $1 aside ($2): $out"
         fi
+    elif [ -e "$1/.git" ]; then
+        die "$1 is a git checkout of another repository; refusing to move or replace it ($2)"
     else
         mv "$1" "$aside"
     fi
     warn "moved aside $1 -> $aside ($2); nothing was deleted"
 }
 
-# --- bead branch resolution -----------------------------------------------------
+# --- resolve what the work dir should have checked out --------------------------------------
 # MODE: local (check out TARGET), remote (track TARGET from the remote),
 # new (create TARGET from BASE), detached (detach at DETACH_AT).
-resolve_mode() {
-    MODE=""
-    TARGET=""
-    DETACH_AT=""
-    if [ -z "$BEAD" ]; then
-        MODE="detached"
-        DETACH_AT="$BASE"
-        return
-    fi
+MODE=""
+TARGET=""
+DETACH_AT=""
+if [ -z "$BEAD" ]; then
+    MODE="detached"
+    DETACH_AT="$BASE"
+else
     candidates="$(bead_branches)"
     count="$(printf '%s\n' "$candidates" | grep -c . || true)"
     if [ "$count" -gt 1 ]; then
         die "several branches name bead $BEAD; pass --bead with a unique id, or --base and no bead: $(printf '%s\n' "$candidates" | tr '\n' ' ')"
-    fi
-    if [ "$count" -eq 0 ]; then
+    elif [ "$count" -eq 0 ]; then
         MODE="new"
         TARGET="$BEAD"
-        return
-    fi
-    TARGET="$candidates"
-    if git_rig show-ref --verify --quiet "refs/heads/$TARGET"; then
-        elsewhere="$(checked_out_at "$TARGET" | grep -v -x -F -- "$WORKDIR" || true)"
-        if [ -n "$elsewhere" ]; then
-            MODE="detached"
-            DETACH_AT="$TARGET"
-            warn "branch $TARGET is checked out at $elsewhere; leaving $WORKDIR detached at its tip. Create your own branch in this work dir before committing."
-        else
-            MODE="local"
-        fi
     else
-        MODE="remote"
+        TARGET="$candidates"
+        if git_rig show-ref --verify --quiet "refs/heads/$TARGET"; then
+            elsewhere="$(checked_out_at "$TARGET" | grep -v -x -F -- "$WORKDIR" || true)"
+            if [ -n "$elsewhere" ]; then
+                MODE="detached"
+                DETACH_AT="$TARGET"
+                warn "branch $TARGET is checked out at $elsewhere; leaving $WORKDIR detached at its tip. Create your own branch in this work dir before committing."
+            else
+                MODE="local"
+            fi
+        else
+            MODE="remote"
+        fi
     fi
-}
+fi
 
-# --- classify the work dir --------------------------------------------------------
+# --- classify the work dir ------------------------------------------------------------------
 IS_WORKTREE=0
-if [ -d "$WORKDIR" ] && is_our_worktree "$WORKDIR"; then
-    IS_WORKTREE=1
+if [ -d "$WORKDIR" ]; then
+    if is_our_worktree "$WORKDIR"; then
+        IS_WORKTREE=1
+        if [ -n "$(git -C "$WORKDIR" status --porcelain --untracked-files=no 2>/dev/null)" ]; then
+            move_aside "$WORKDIR" "tracked modifications present"
+            IS_WORKTREE=0
+        fi
+    elif [ -n "$(ls -A "$WORKDIR" 2>/dev/null)" ]; then
+        move_aside "$WORKDIR" "not a worktree of $RIG_ROOT"
+    fi
 fi
 
-if [ "$IS_WORKTREE" -eq 0 ] && [ -d "$WORKDIR" ] && [ -n "$(ls -A "$WORKDIR" 2>/dev/null)" ]; then
-    move_aside "$WORKDIR" "not a worktree of $RIG_ROOT"
-fi
-
-if [ "$IS_WORKTREE" -eq 1 ] && [ -n "$(git -C "$WORKDIR" status --porcelain --untracked-files=no 2>/dev/null)" ]; then
-    move_aside "$WORKDIR" "tracked modifications present"
-    IS_WORKTREE=0
-fi
-
-# --- act ----------------------------------------------------------------------------
+# --- act --------------------------------------------------------------------------------------
 add_worktree() {
     [ -d "$WORKDIR" ] || mkdir -p "$WORKDIR"
     case "$MODE" in
@@ -267,7 +321,7 @@ add_worktree() {
     esac
 }
 
-# switch_worktree: change what a clean worktree has checked out. Never
+# switch_worktree: change what a clean worktree of ours has checked out. Never
 # overwrite an ignored file the target tracks; on any refusal the caller moves
 # the worktree aside and adds a fresh one.
 switch_worktree() {
@@ -277,31 +331,6 @@ switch_worktree() {
         new)      git -C "$WORKDIR" switch --quiet --no-overwrite-ignore -c "$TARGET" "$BASE" ;;
         detached) git -C "$WORKDIR" switch --quiet --no-overwrite-ignore --detach "$DETACH_AT" ;;
     esac
-}
-
-resolve_mode
-
-# A branch this run meant to create may have been created by a concurrent run
-# between resolution and the git call; re-resolving turns that into the
-# checkout-or-detached path the contract promises instead of a failure.
-attempt() {
-    # $1 = add|switch
-    tries=0
-    while :; do
-        tries=$((tries + 1))
-        if [ "$1" = add ]; then
-            if out="$(add_worktree 2>&1)"; then return 0; fi
-        else
-            if out="$(switch_worktree 2>&1)"; then return 0; fi
-        fi
-        if [ "$MODE" = "new" ] && [ "$tries" -lt 3 ] && git_rig show-ref --verify --quiet "refs/heads/$TARGET"; then
-            log "branch $TARGET appeared while preparing $WORKDIR; re-resolving"
-            resolve_mode
-            continue
-        fi
-        printf '%s\n' "$out" >&2
-        return 1
-    done
 }
 
 if [ "$IS_WORKTREE" -eq 1 ]; then
@@ -314,16 +343,25 @@ if [ "$IS_WORKTREE" -eq 1 ]; then
                       need_switch=0
                   fi ;;
     esac
-    if [ "$need_switch" -eq 1 ] && ! attempt switch; then
-        move_aside "$WORKDIR" "branch switch refused (ignored files in the way, or git error above)"
-        attempt add || die "could not prepare $WORKDIR after moving the previous worktree aside"
+    if [ "$need_switch" -eq 1 ]; then
+        if ! out="$(switch_worktree 2>&1)"; then
+            printf '%s\n' "$out" >&2
+            move_aside "$WORKDIR" "branch switch refused (ignored files in the way, or the git error above)"
+            IS_WORKTREE=0
+        fi
     fi
-else
-    attempt add || die "could not create the worktree at $WORKDIR"
+fi
+if [ "$IS_WORKTREE" -eq 0 ]; then
+    out="$(add_worktree 2>&1)" || die "could not create the worktree at $WORKDIR: $out"
 fi
 
-WORKDIR="$(abs "$WORKDIR")"
+# --- verify before reporting ----------------------------------------------------------------
+is_our_worktree "$WORKDIR" || die "$WORKDIR is not a worktree of $RIG_ROOT after preparation"
 branch="$(git -C "$WORKDIR" rev-parse --abbrev-ref HEAD 2>/dev/null || echo HEAD)"
+case "$MODE" in
+    local|remote|new) [ "$branch" = "$TARGET" ] || die "$WORKDIR is on $branch, expected $TARGET" ;;
+    detached)         [ "$branch" = "HEAD" ] || die "$WORKDIR is on $branch, expected a detached HEAD" ;;
+esac
 [ "$branch" != "HEAD" ] || branch="detached"
 sha="$(git -C "$WORKDIR" rev-parse --short HEAD 2>/dev/null || echo unknown)"
 printf 'WORKTREE %s %s %s\n' "$WORKDIR" "$branch" "$sha"

--- a/gascity/template-fragments/gc-role-worker.template.md
+++ b/gascity/template-fragments/gc-role-worker.template.md
@@ -45,15 +45,18 @@ the bead's failure contract and close it instead of idling.
 
 Work in the directory your session started in (`$GC_DIR`); gc materializes
 your skills and hooks there. When a `pre_start` prepared it as a git worktree
-(this pack's `worker-worktree.sh`), it is already on a branch named for the
-claimed bead — or detached, with a WARN in the pre_start log, when that branch
-is checked out in another worktree; then create your branch before committing.
+(this pack's `worker-worktree.sh`), it is on a branch named for the claimed
+bead, or detached (no trigger bead, or that branch is checked out in another
+worktree, WARN in the pre_start log): if `git branch --show-current` prints
+nothing, create your branch in this directory before committing.
 
 If you start in the rig root and the rig forbids working there, create your
 own worktree outside it (`<city>/.worktrees/<rig>/<bead>`) from
 `origin/<default branch>`. If a branch named for the bead already exists,
 check that branch out in the new worktree instead of creating another.
 
+After the claim, compare the bead's `gc.work_branch` with your branch and
+restamp it when they differ (older `gc` builds stamp the rig root's branch).
 Before closing a bead whose work continues elsewhere, stamp its workspace so
 the next session starts there:
 

--- a/gascity/template-fragments/gc-role-worker.template.md
+++ b/gascity/template-fragments/gc-role-worker.template.md
@@ -24,6 +24,9 @@ Read its single JSON result:
   - `bead_id` as `CLAIMED_BEAD_ID`
   - `root_bead_id` as `CLAIMED_ROOT_BEAD_ID`
   - `continuation_group` as `CLAIMED_CONTINUATION_GROUP`
+  - A raw `gc hook --claim --drain-ack --json` line may omit `root_bead_id`
+    and `continuation_group` when they are empty; the claim wrapper prints
+    both. An absent key is an empty value, never a failed claim.
 - `action=drain`: already drain-acked. Exit now.
 - Non-zero exit or malformed result: report failure. Do not search, hand-repair
   assignment, or retry forever. Do not drain or mutate claim state; the command
@@ -37,6 +40,28 @@ A successful claim is authorization to execute immediately.
 Never ask a human whether to proceed after a successful claim. Do not stop for
 confirmation in a headless workflow. If required task input is missing, record
 the bead's failure contract and close it instead of idling.
+
+## Workspace
+
+Work in the directory your session started in (`$GC_DIR`); gc materializes
+your skills and hooks there. When a `pre_start` prepared it as a git worktree
+(this pack's `worker-worktree.sh`), it is already on a branch named for the
+claimed bead — or detached, with a WARN in the pre_start log, when that branch
+is checked out in another worktree; then create your branch before committing.
+
+If you start in the rig root and the rig forbids working there, create your
+own worktree outside it (`<city>/.worktrees/<rig>/<bead>`) from
+`origin/<default branch>`. If a branch named for the bead already exists,
+check that branch out in the new worktree instead of creating another.
+
+Before closing a bead whose work continues elsewhere, stamp its workspace so
+the next session starts there:
+
+```bash
+gc bd update "$CLAIMED_BEAD_ID" \
+  --set-metadata 'work_dir=<absolute worktree path>' \
+  --set-metadata 'gc.work_branch=<branch>'
+```
 
 ## Close
 

--- a/gascity/tests/test_worker_worktree.py
+++ b/gascity/tests/test_worker_worktree.py
@@ -12,8 +12,9 @@ from __future__ import annotations
 import os
 import pathlib
 import subprocess
-import unittest
 import tempfile
+import time
+import unittest
 
 
 SCRIPT = pathlib.Path(__file__).resolve().parents[1] / "assets" / "scripts" / "worker-worktree.sh"
@@ -70,12 +71,14 @@ class Fixture:
         git(scratch, "push", "--quiet", "origin", name)
         return sha
 
-    def run(self, workdir: pathlib.Path, bead: str | None, *extra: str, check: bool = True, mkdir: bool = True) -> subprocess.CompletedProcess[str]:
+    def run(self, workdir: pathlib.Path, bead: str | None, *extra: str, check: bool = True, mkdir: bool = True, env_extra: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
         env = {
             **os.environ,
             "GC_DIR": str(workdir),
             "GC_RIG_ROOT": str(self.rig),
             "GC_CITY": str(self.city),
+            "WORKER_WORKTREE_LOCK_WAIT": "10",
+            **(env_extra or {}),
         }
         env.pop("GC_TRIGGER_BEAD_ID", None)
         if bead is not None:
@@ -128,7 +131,8 @@ class WorkerWorktreeTests(unittest.TestCase):
         self.assertTrue((self.lane / "README.md").is_file())
         self.assertEqual(proc.stdout.split(), ["WORKTREE", str(self.lane), "gp-abc1", self.fx.main_sha[:7]])
 
-    def test_workdir_that_does_not_exist_yet_is_created(self) -> None:
+    def test_workdir_that_does_not_exist_yet_is_created_when_its_parent_does(self) -> None:
+        self.lane.parent.mkdir(parents=True)
         proc = self.fx.run(self.lane, "gp-abc1", mkdir=False)
         self.assert_is_worktree(self.lane)
         self.assertEqual(self.branch_of(self.lane), "gp-abc1")
@@ -323,6 +327,73 @@ class WorkerWorktreeTests(unittest.TestCase):
         self.assertEqual(self.branch_of(self.lane), "HEAD")
         self.assertNotIn("WARN", proc.stderr)
 
+    # --- foreign checkouts and the lock -----------------------------------------------------------
+
+    def test_checkout_of_another_repository_at_the_lane_is_refused_not_moved(self) -> None:
+        self.lane.mkdir(parents=True)
+        subprocess.run(["git", "init", "--quiet", str(self.lane)], check=True)
+        (self.lane / "theirs.txt").write_text("someone else's repo\n", encoding="utf-8")
+        proc = self.fx.run(self.lane, "gp-abc1", check=False)
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("another repository", proc.stderr)
+        self.assertEqual(self.asides(), [])
+        self.assertEqual((self.lane / "theirs.txt").read_text(encoding="utf-8"), "someone else's repo\n")
+
+    def lock_dir(self) -> pathlib.Path:
+        return self.fx.rig / ".git" / "worker-worktree.lock"
+
+    def test_lock_is_taken_and_released(self) -> None:
+        self.fx.run(self.lane, "gp-abc1")
+        self.assertFalse(self.lock_dir().exists())
+
+    def test_stale_lock_from_a_dead_pid_is_cleared(self) -> None:
+        self.lock_dir().mkdir()
+        (self.lock_dir() / "pid").write_text("999999\n", encoding="utf-8")
+        proc = self.fx.run(self.lane, "gp-abc1")
+        self.assertIn("clearing stale lock", proc.stderr)
+        self.assertEqual(self.branch_of(self.lane), "gp-abc1")
+        self.assertFalse(self.lock_dir().exists())
+
+    def orphan_sleep(self, seconds: int) -> int:
+        """Start `sleep` reparented to init so the OS reaps it when it exits."""
+        out = subprocess.run(["sh", "-c", f"sleep {seconds} >/dev/null 2>&1 & echo $!"], check=True, capture_output=True, text=True).stdout
+        return int(out.strip())
+
+    def test_live_lock_is_waited_for(self) -> None:
+        pid = self.orphan_sleep(3)
+        self.lock_dir().mkdir()
+        (self.lock_dir() / "pid").write_text(f"{pid}\n", encoding="utf-8")
+        started = time.monotonic()
+        proc = self.fx.run(self.lane, "gp-abc1")
+        elapsed = time.monotonic() - started
+        self.assertGreaterEqual(elapsed, 2.0)
+        self.assertIn("waiting for another run", proc.stderr)
+        self.assertEqual(self.branch_of(self.lane), "gp-abc1")
+        self.assertFalse(self.lock_dir().exists())
+
+    def test_live_lock_held_too_long_fails_closed(self) -> None:
+        pid = self.orphan_sleep(8)
+        self.lock_dir().mkdir()
+        (self.lock_dir() / "pid").write_text(f"{pid}\n", encoding="utf-8")
+        proc = self.fx.run(self.lane, "gp-abc1", check=False, env_extra={"WORKER_WORKTREE_LOCK_WAIT": "2"})
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("has held", proc.stderr)
+        self.assertFalse((self.lane / ".git").exists())
+        self.assertTrue(self.lock_dir().exists())  # not ours to clear while its owner lives
+        os.kill(pid, 15)
+
+    def test_zombie_lock_owner_counts_as_dead(self) -> None:
+        holder = subprocess.Popen(["sleep", "0"])  # exits at once; not reaped until wait()
+        time.sleep(0.5)
+        self.lock_dir().mkdir()
+        (self.lock_dir() / "pid").write_text(f"{holder.pid}\n", encoding="utf-8")
+        try:
+            proc = self.fx.run(self.lane, "gp-abc1")
+        finally:
+            holder.wait()
+        self.assertIn("clearing stale lock", proc.stderr)
+        self.assertEqual(self.branch_of(self.lane), "gp-abc1")
+
     # --- refusals ----------------------------------------------------------------------------
 
     def test_workdir_inside_rig_root_is_refused_even_if_it_does_not_exist(self) -> None:
@@ -334,6 +405,27 @@ class WorkerWorktreeTests(unittest.TestCase):
         proc = self.fx.run(self.fx.rig, "gp-abc1", check=False)
         self.assertNotEqual(proc.returncode, 0)
         self.assertIn("is the rig root", proc.stderr)
+
+    def test_workdir_whose_parent_does_not_exist_is_refused(self) -> None:
+        deep = self.fx.city / "missing" / "deeper" / "lane"
+        proc = self.fx.run(deep, "gp-abc1", check=False, mkdir=False)
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("parent of work dir does not exist", proc.stderr)
+        self.assertFalse((self.fx.city / "missing").exists())
+
+    def test_dot_dot_cannot_reach_into_the_rig_root(self) -> None:
+        via_existing = self.fx.rig / ".." / "rig" / "nested"
+        proc = self.fx.run(via_existing, "gp-abc1", check=False, mkdir=False)
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("inside the rig root", proc.stderr)
+        self.assertFalse((self.fx.rig / "nested").exists())
+        via_missing = self.fx.root / "nope" / ".." / "rig" / "nested"
+        proc = self.fx.run(via_missing, "gp-abc1", check=False, mkdir=False)
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertFalse((self.fx.rig / "nested").exists())
+        trailing_dots = self.fx.city / "lane" / ".."
+        proc = self.fx.run(trailing_dots, "gp-abc1", check=False, mkdir=False)
+        self.assertNotEqual(proc.returncode, 0)
 
     def test_workdir_that_is_an_ancestor_of_the_rig_root_is_refused(self) -> None:
         proc = self.fx.run(self.fx.root, "gp-abc1", check=False)

--- a/gascity/tests/test_worker_worktree.py
+++ b/gascity/tests/test_worker_worktree.py
@@ -453,7 +453,9 @@ class WorkerWorktreeTests(unittest.TestCase):
             cwd=str(lane_b), env={**base_env, "GC_DIR": str(lane_b), "WORKER_WORKTREE_TEST_PAUSE_BEFORE_RECLAIM": "3"},
             stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
         )
-        time.sleep(0.7)
+        # Start A only once B has observed the stale lock and entered its pause.
+        marker = b.stderr.readline()
+        self.assertIn("TEST pausing before reclaim", marker)
         a_started = time.monotonic()
         a = subprocess.run(
             ["sh", str(SCRIPT), "--no-fetch", "--bead", "gp-aaa1"],

--- a/gascity/tests/test_worker_worktree.py
+++ b/gascity/tests/test_worker_worktree.py
@@ -437,8 +437,9 @@ class WorkerWorktreeTests(unittest.TestCase):
         self.assertEqual(sorted(self.fx.rig.joinpath(".git").glob("worker-worktree.lock*")), [])
 
     def test_two_contenders_reclaiming_one_stale_lock_do_not_run_concurrently(self) -> None:
-        """B sees the stale lock and pauses inside its reclaim; A reclaims, acquires
-        and holds; B must find A's live lock under re-check and wait, not clear it."""
+        """B observes the stale lock and pauses before taking the reclaim lock; A
+        observes it, reclaims, acquires and holds. B must then find A's live lock
+        under its own re-check, leave it alone, and wait for A to release."""
         self.lock_dir().mkdir()
         (self.lock_dir() / "pid").write_text("999999\n", encoding="utf-8")
         lane_a = self.fx.city / "lane-a"
@@ -459,36 +460,35 @@ class WorkerWorktreeTests(unittest.TestCase):
             cwd=str(lane_a), env={**base_env, "GC_DIR": str(lane_a), "WORKER_WORKTREE_TEST_PAUSE_AFTER_ACQUIRE": "4"},
             capture_output=True, text=True,
         )
-        a_finished = time.monotonic()
+        a_elapsed = time.monotonic() - a_started
         b_out, b_err = b.communicate(timeout=60)
-        b_finished = time.monotonic()
         self.assertEqual(a.returncode, 0, a.stderr)
         self.assertEqual(b.returncode, 0, b_err)
-        # Exactly one contender cleared the stale lock, both prepared their lanes,
-        # and B (paused inside its reclaim while A acquired and held) finished
-        # only after A released: it found A's live lock under re-check and waited.
-        cleared = (a.stderr + b_err).count("clearing stale lock")
-        self.assertEqual(cleared, 1, a.stderr + b_err)
-        self.assertGreaterEqual(b_finished, a_finished)
+        # A cleared the stale lock (B was paused before its reclaim); B never did.
+        self.assertIn("clearing stale lock", a.stderr)
+        self.assertNotIn("clearing stale lock", b_err)
+        # B saw A's live lock under re-check and waited for it instead of removing it.
+        self.assertIn("waiting for another run", b_err)
+        self.assertGreater(a_elapsed, 3.5)  # A really held the lock across B's resume
         self.assertEqual(self.branch_of(lane_a), "gp-aaa1")
         self.assertEqual(self.branch_of(lane_b), "gp-bbb1")
         self.assertFalse(self.lock_dir().exists())
         self.assertFalse((self.fx.rig / ".git" / "worker-worktree.lock.reclaim").exists())
-        self.assertGreater(a_finished - a_started, 3.5)  # A really held the lock
 
-    def test_stuck_reclaim_lock_bounds_the_wait_and_ages_out(self) -> None:
+    def test_stuck_reclaim_lock_bounds_the_wait_then_fails_closed_when_old(self) -> None:
         self.lock_dir().mkdir()
         (self.lock_dir() / "pid").write_text("999999\n", encoding="utf-8")
         reclaim = self.fx.rig / ".git" / "worker-worktree.lock.reclaim"
         reclaim.mkdir()
         proc = self.fx.run(self.lane, "gp-abc1", check=False, env_extra={"WORKER_WORKTREE_LOCK_WAIT": "2"})
-        self.assertNotEqual(proc.returncode, 0)  # bounded, not an infinite loop
+        self.assertNotEqual(proc.returncode, 0)  # fresh reclaim lock: bounded wait, not an infinite loop
         self.assertIn("has held", proc.stderr)
         os.utime(reclaim, (time.time() - 300, time.time() - 300))
-        proc = self.fx.run(self.lane, "gp-abc1")
-        self.assertIn("clearing stale lock", proc.stderr)
-        self.assertEqual(self.branch_of(self.lane), "gp-abc1")
-        self.assertFalse(reclaim.exists())
+        proc = self.fx.run(self.lane, "gp-abc1", check=False)
+        self.assertNotEqual(proc.returncode, 0)  # old reclaim lock: fail closed, never auto-removed
+        self.assertIn("stale reclaim lock", proc.stderr)
+        self.assertTrue(reclaim.exists())
+        self.assertFalse((self.lane / ".git").exists())
 
     def test_remote_name_with_metacharacters_still_matches_remote_bead_branches(self) -> None:
         git(self.fx.rig, "remote", "rename", "origin", "team|origin")

--- a/gascity/tests/test_worker_worktree.py
+++ b/gascity/tests/test_worker_worktree.py
@@ -1,0 +1,240 @@
+"""Contract tests for gascity/assets/scripts/worker-worktree.sh.
+
+Each test builds a throwaway "remote" (bare repo) plus a rig checkout, then
+runs the script the way gc runs a pre_start command: cwd = the work dir,
+GC_DIR / GC_RIG_ROOT / GC_TRIGGER_BEAD_ID in the environment.
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import subprocess
+import unittest
+import tempfile
+
+
+SCRIPT = pathlib.Path(__file__).resolve().parents[1] / "assets" / "scripts" / "worker-worktree.sh"
+
+
+def git(cwd: pathlib.Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(cwd), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def commit(repo: pathlib.Path, name: str, content: str, message: str) -> str:
+    (repo / name).write_text(content, encoding="utf-8")
+    git(repo, "add", name)
+    git(
+        repo,
+        "-c", "user.name=t", "-c", "user.email=t@example.invalid",
+        "commit", "--quiet", "-m", message,
+    )
+    return git(repo, "rev-parse", "HEAD")
+
+
+class Fixture:
+    def __init__(self, root: pathlib.Path) -> None:
+        self.root = root
+        self.remote = root / "remote.git"
+        self.rig = root / "rig"
+        self.city = root / "city"
+        subprocess.run(["git", "init", "--quiet", "--bare", "-b", "main", str(self.remote)], check=True)
+        subprocess.run(["git", "init", "--quiet", "-b", "main", str(self.rig)], check=True)
+        git(self.rig, "remote", "add", "origin", str(self.remote))
+        self.main_sha = commit(self.rig, "README.md", "hello\n", "init")
+        git(self.rig, "push", "--quiet", "-u", "origin", "main")
+        git(self.rig, "remote", "set-head", "origin", "main")
+        self.rig_status_before = self.rig_snapshot()
+
+    def rig_snapshot(self) -> tuple[str, str, str]:
+        return (
+            git(self.rig, "rev-parse", "--abbrev-ref", "HEAD"),
+            git(self.rig, "rev-parse", "HEAD"),
+            git(self.rig, "status", "--porcelain"),
+        )
+
+    def push_branch(self, name: str, filename: str = "feature.txt") -> str:
+        """Create a branch on the remote (not present locally in the rig)."""
+        scratch = self.root / f"scratch-{name.replace('/', '_')}"
+        subprocess.run(["git", "clone", "--quiet", str(self.remote), str(scratch)], check=True)
+        git(scratch, "switch", "--quiet", "-c", name)
+        sha = commit(scratch, filename, f"{name}\n", f"work on {name}")
+        git(scratch, "push", "--quiet", "origin", name)
+        return sha
+
+    def run(self, workdir: pathlib.Path, bead: str | None, *extra: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+        env = {
+            **os.environ,
+            "GC_DIR": str(workdir),
+            "GC_RIG_ROOT": str(self.rig),
+            "GC_CITY": str(self.city),
+        }
+        env.pop("GC_TRIGGER_BEAD_ID", None)
+        if bead is not None:
+            env["GC_TRIGGER_BEAD_ID"] = bead
+        workdir.mkdir(parents=True, exist_ok=True)  # gc MkdirAll's work_dir before pre_start
+        proc = subprocess.run(
+            ["sh", str(SCRIPT), *extra],
+            cwd=str(workdir),
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        if check:
+            assert proc.returncode == 0, f"stdout={proc.stdout!r}\nstderr={proc.stderr!r}"
+        return proc
+
+
+class WorkerWorktreeTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.fx = Fixture(pathlib.Path(self._tmp.name).resolve())
+        self.lane = self.fx.city / ".worktrees" / "rig" / "lane-worker"
+
+    def tearDown(self) -> None:
+        # The rig root's working tree is never touched, whatever the case.
+        self.assertEqual(self.fx.rig_snapshot(), self.fx.rig_status_before)
+        self._tmp.cleanup()
+
+    def branch_of(self, path: pathlib.Path) -> str:
+        return git(path, "rev-parse", "--abbrev-ref", "HEAD")
+
+    def assert_is_worktree(self, path: pathlib.Path) -> None:
+        common = pathlib.Path(git(path, "rev-parse", "--git-common-dir"))
+        if not common.is_absolute():
+            common = path / common
+        self.assertEqual(common.resolve(), (self.fx.rig / ".git").resolve())
+
+    def test_empty_workdir_new_bead_creates_branch_from_base(self) -> None:
+        proc = self.fx.run(self.lane, "gp-abc1")
+        self.assert_is_worktree(self.lane)
+        self.assertEqual(self.branch_of(self.lane), "gp-abc1")
+        self.assertEqual(git(self.lane, "rev-parse", "HEAD"), self.fx.main_sha)
+        self.assertTrue((self.lane / "README.md").is_file())
+        self.assertEqual(proc.stdout.split(), ["WORKTREE", str(self.lane), "gp-abc1", self.fx.main_sha[:7]])
+
+    def test_rerun_is_idempotent(self) -> None:
+        self.fx.run(self.lane, "gp-abc1")
+        first = git(self.lane, "rev-parse", "HEAD")
+        proc = self.fx.run(self.lane, "gp-abc1")
+        self.assertEqual(self.branch_of(self.lane), "gp-abc1")
+        self.assertEqual(git(self.lane, "rev-parse", "HEAD"), first)
+        self.assertNotIn("WARN", proc.stderr)
+
+    def test_existing_remote_branch_named_for_bead_is_checked_out_and_tracked(self) -> None:
+        sha = self.fx.push_branch("fix/gp-def2-resume-me")
+        self.fx.run(self.lane, "gp-def2")
+        self.assertEqual(self.branch_of(self.lane), "fix/gp-def2-resume-me")
+        self.assertEqual(git(self.lane, "rev-parse", "HEAD"), sha)
+        self.assertEqual(git(self.lane, "rev-parse", "--abbrev-ref", "@{upstream}"), "origin/fix/gp-def2-resume-me")
+        self.assertTrue((self.lane / "feature.txt").is_file())
+
+    def test_bead_branch_checked_out_elsewhere_is_not_stolen(self) -> None:
+        other = self.fx.root / "other-worktree"
+        git(self.fx.rig, "worktree", "add", "--quiet", "-b", "gp-ghi3-elsewhere", str(other), "origin/main")
+        sha = commit(other, "elsewhere.txt", "x\n", "elsewhere work")
+        proc = self.fx.run(self.lane, "gp-ghi3")
+        self.assertEqual(self.branch_of(self.lane), "HEAD")  # detached
+        self.assertEqual(git(self.lane, "rev-parse", "HEAD"), sha)
+        self.assertIn("WARN", proc.stderr)
+        self.assertIn(str(other), proc.stderr)
+        self.assertEqual(self.branch_of(other), "gp-ghi3-elsewhere")
+        self.assertEqual(proc.stdout.split()[2], "detached")
+
+    def test_clean_lane_on_old_bead_switches_to_new_bead(self) -> None:
+        self.fx.run(self.lane, "gp-old1")
+        commit(self.lane, "old.txt", "old\n", "old bead work")
+        # Untracked files (staged skills, hooks, node_modules) never count as dirt.
+        (self.lane / ".agents").mkdir()
+        (self.lane / ".agents" / "skills.txt").write_text("x", encoding="utf-8")
+        proc = self.fx.run(self.lane, "gp-new2")
+        self.assertEqual(self.branch_of(self.lane), "gp-new2")
+        self.assertEqual(git(self.lane, "rev-parse", "HEAD"), self.fx.main_sha)
+        self.assertFalse((self.lane / "old.txt").exists())
+        self.assertTrue((self.lane / ".agents" / "skills.txt").is_file())
+        self.assertNotIn("aside", proc.stderr)
+        # The old bead's branch and commit survive.
+        self.assertTrue(git(self.fx.rig, "rev-parse", "--verify", "gp-old1"))
+
+    def test_dirty_lane_is_moved_aside_never_reset(self) -> None:
+        self.fx.run(self.lane, "gp-old1")
+        (self.lane / "README.md").write_text("uncommitted edit\n", encoding="utf-8")
+        proc = self.fx.run(self.lane, "gp-new2")
+        self.assertIn("moved aside", proc.stderr)
+        asides = sorted(self.lane.parent.glob("lane-worker.aside-*"))
+        self.assertEqual(len(asides), 1)
+        self.assertEqual((asides[0] / "README.md").read_text(encoding="utf-8"), "uncommitted edit\n")
+        self.assertEqual(self.branch_of(asides[0]), "gp-old1")
+        self.assertEqual(self.branch_of(self.lane), "gp-new2")
+        self.assertEqual((self.lane / "README.md").read_text(encoding="utf-8"), "hello\n")
+        # git still knows both worktrees.
+        listing = git(self.fx.rig, "worktree", "list", "--porcelain")
+        self.assertIn(str(asides[0]), listing)
+        self.assertIn(str(self.lane), listing)
+
+    def test_nonempty_non_worktree_dir_is_moved_aside(self) -> None:
+        self.lane.mkdir(parents=True)
+        (self.lane / "junk.txt").write_text("keep me\n", encoding="utf-8")
+        proc = self.fx.run(self.lane, "gp-abc1")
+        self.assertIn("moved aside", proc.stderr)
+        asides = sorted(self.lane.parent.glob("lane-worker.aside-*"))
+        self.assertEqual(len(asides), 1)
+        self.assertEqual((asides[0] / "junk.txt").read_text(encoding="utf-8"), "keep me\n")
+        self.assert_is_worktree(self.lane)
+        self.assertEqual(self.branch_of(self.lane), "gp-abc1")
+
+    def test_ambiguous_bead_branches_fail_closed(self) -> None:
+        self.fx.push_branch("gp-amb1-first", "a.txt")
+        self.fx.push_branch("gp-amb1-second", "b.txt")
+        proc = self.fx.run(self.lane, "gp-amb1", check=False)
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("several branches", proc.stderr)
+        self.assertIn("gp-amb1-first", proc.stderr)
+        self.assertIn("gp-amb1-second", proc.stderr)
+        self.assertFalse((self.lane / ".git").exists())
+
+    def test_no_bead_leaves_a_detached_worktree_at_base(self) -> None:
+        proc = self.fx.run(self.lane, None)
+        self.assert_is_worktree(self.lane)
+        self.assertEqual(self.branch_of(self.lane), "HEAD")
+        self.assertEqual(git(self.lane, "rev-parse", "HEAD"), self.fx.main_sha)
+        self.assertEqual(proc.stdout.split()[2], "detached")
+
+    def test_no_bead_does_not_move_a_lane_off_its_branch(self) -> None:
+        self.fx.run(self.lane, "gp-old1")
+        self.fx.run(self.lane, None)
+        self.assertEqual(self.branch_of(self.lane), "gp-old1")
+
+    def test_new_branch_tracks_fresh_remote_tip_not_stale_local_main(self) -> None:
+        # The rig checkout lags: origin/main moves on, local main does not.
+        newer = self.fx.push_branch("main-advance", "newer.txt")
+        scratch = self.fx.root / "scratch-main-advance"
+        git(scratch, "push", "--quiet", "origin", "main-advance:main")
+        self.fx.run(self.lane, "gp-abc1")
+        self.assertEqual(git(self.lane, "rev-parse", "HEAD"), newer)
+        self.assertEqual(git(self.fx.rig, "rev-parse", "main"), self.fx.main_sha)
+
+    def test_workdir_inside_rig_root_is_refused(self) -> None:
+        inside = self.fx.rig / "nested"
+        proc = self.fx.run(inside, "gp-abc1", check=False)
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("inside the rig root", proc.stderr)
+        proc = self.fx.run(self.fx.rig, "gp-abc1", check=False)
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("is the rig root", proc.stderr)
+
+    def test_flags_override_environment(self) -> None:
+        lane = self.fx.city / "elsewhere"
+        proc = self.fx.run(self.lane, "gp-env1", "--workdir", str(lane), "--bead", "gp-flag2", "--no-fetch")
+        self.assertEqual(self.branch_of(lane), "gp-flag2")
+        self.assertFalse((self.lane / ".git").exists())
+        self.assertEqual(proc.stdout.split()[1], str(lane))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gascity/tests/test_worker_worktree.py
+++ b/gascity/tests/test_worker_worktree.py
@@ -71,6 +71,11 @@ class Fixture:
         git(scratch, "push", "--quiet", "origin", name)
         return sha
 
+    def push_branch_on(self, remote: str, name: str, filename: str) -> str:
+        sha = self.push_branch(name, filename)
+        git(self.rig, "fetch", "--quiet", remote)
+        return sha
+
     def run(self, workdir: pathlib.Path, bead: str | None, *extra: str, check: bool = True, mkdir: bool = True, env_extra: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
         env = {
             **os.environ,
@@ -430,6 +435,68 @@ class WorkerWorktreeTests(unittest.TestCase):
         self.assertEqual(self.branch_of(self.lane), "gp-abc1")
         self.assertFalse(self.lock_dir().exists())
         self.assertEqual(sorted(self.fx.rig.joinpath(".git").glob("worker-worktree.lock*")), [])
+
+    def test_two_contenders_reclaiming_one_stale_lock_do_not_run_concurrently(self) -> None:
+        """B sees the stale lock and pauses inside its reclaim; A reclaims, acquires
+        and holds; B must find A's live lock under re-check and wait, not clear it."""
+        self.lock_dir().mkdir()
+        (self.lock_dir() / "pid").write_text("999999\n", encoding="utf-8")
+        lane_a = self.fx.city / "lane-a"
+        lane_b = self.fx.city / "lane-b"
+        for lane in (lane_a, lane_b):
+            lane.mkdir(parents=True)
+        base_env = {**os.environ, "GC_RIG_ROOT": str(self.fx.rig), "WORKER_WORKTREE_LOCK_WAIT": "20"}
+        base_env.pop("GC_TRIGGER_BEAD_ID", None)
+        b = subprocess.Popen(
+            ["sh", str(SCRIPT), "--no-fetch", "--bead", "gp-bbb1"],
+            cwd=str(lane_b), env={**base_env, "GC_DIR": str(lane_b), "WORKER_WORKTREE_TEST_PAUSE_BEFORE_RECLAIM": "3"},
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+        )
+        time.sleep(0.7)
+        a_started = time.monotonic()
+        a = subprocess.run(
+            ["sh", str(SCRIPT), "--no-fetch", "--bead", "gp-aaa1"],
+            cwd=str(lane_a), env={**base_env, "GC_DIR": str(lane_a), "WORKER_WORKTREE_TEST_PAUSE_AFTER_ACQUIRE": "4"},
+            capture_output=True, text=True,
+        )
+        a_finished = time.monotonic()
+        b_out, b_err = b.communicate(timeout=60)
+        b_finished = time.monotonic()
+        self.assertEqual(a.returncode, 0, a.stderr)
+        self.assertEqual(b.returncode, 0, b_err)
+        # Exactly one contender cleared the stale lock, both prepared their lanes,
+        # and B (paused inside its reclaim while A acquired and held) finished
+        # only after A released: it found A's live lock under re-check and waited.
+        cleared = (a.stderr + b_err).count("clearing stale lock")
+        self.assertEqual(cleared, 1, a.stderr + b_err)
+        self.assertGreaterEqual(b_finished, a_finished)
+        self.assertEqual(self.branch_of(lane_a), "gp-aaa1")
+        self.assertEqual(self.branch_of(lane_b), "gp-bbb1")
+        self.assertFalse(self.lock_dir().exists())
+        self.assertFalse((self.fx.rig / ".git" / "worker-worktree.lock.reclaim").exists())
+        self.assertGreater(a_finished - a_started, 3.5)  # A really held the lock
+
+    def test_stuck_reclaim_lock_bounds_the_wait_and_ages_out(self) -> None:
+        self.lock_dir().mkdir()
+        (self.lock_dir() / "pid").write_text("999999\n", encoding="utf-8")
+        reclaim = self.fx.rig / ".git" / "worker-worktree.lock.reclaim"
+        reclaim.mkdir()
+        proc = self.fx.run(self.lane, "gp-abc1", check=False, env_extra={"WORKER_WORKTREE_LOCK_WAIT": "2"})
+        self.assertNotEqual(proc.returncode, 0)  # bounded, not an infinite loop
+        self.assertIn("has held", proc.stderr)
+        os.utime(reclaim, (time.time() - 300, time.time() - 300))
+        proc = self.fx.run(self.lane, "gp-abc1")
+        self.assertIn("clearing stale lock", proc.stderr)
+        self.assertEqual(self.branch_of(self.lane), "gp-abc1")
+        self.assertFalse(reclaim.exists())
+
+    def test_remote_name_with_metacharacters_still_matches_remote_bead_branches(self) -> None:
+        git(self.fx.rig, "remote", "rename", "origin", "team|origin")
+        git(self.fx.rig, "remote", "set-head", "team|origin", "main")
+        sha = self.fx.push_branch_on("team|origin", "fix/gp-meta1-x", "m.txt")
+        self.fx.run(self.lane, "gp-meta1", "--remote", "team|origin")
+        self.assertEqual(self.branch_of(self.lane), "fix/gp-meta1-x")
+        self.assertEqual(git(self.lane, "rev-parse", "HEAD"), sha)
 
     # --- refusals ----------------------------------------------------------------------------
 

--- a/gascity/tests/test_worker_worktree.py
+++ b/gascity/tests/test_worker_worktree.py
@@ -394,6 +394,43 @@ class WorkerWorktreeTests(unittest.TestCase):
         self.assertIn("clearing stale lock", proc.stderr)
         self.assertEqual(self.branch_of(self.lane), "gp-abc1")
 
+    def test_dirty_lane_on_the_same_bead_restarts_detached_at_its_tip(self) -> None:
+        self.fx.run(self.lane, "gp-old1")
+        sha = commit(self.lane, "work.txt", "committed\n", "bead work")
+        (self.lane / "README.md").write_text("uncommitted edit\n", encoding="utf-8")
+        proc = self.fx.run(self.lane, "gp-old1")
+        asides = self.asides()
+        self.assertEqual(len(asides), 1)
+        self.assertEqual(self.branch_of(asides[0]), "gp-old1")
+        self.assertEqual((asides[0] / "README.md").read_text(encoding="utf-8"), "uncommitted edit\n")
+        self.assertEqual(self.branch_of(self.lane), "HEAD")
+        self.assertEqual(git(self.lane, "rev-parse", "HEAD"), sha)
+        self.assertIn("checked out at", proc.stderr)
+        self.assertEqual(proc.stdout.split()[2], "detached")
+
+    def test_base_head_fallback_means_the_rig_head_not_the_lane_head(self) -> None:
+        # No usable remote: BASE falls back to HEAD, which must be the rig's.
+        self.fx.run(self.lane, "gp-old1")
+        commit(self.lane, "ahead.txt", "x\n", "lane moved ahead")
+        proc = self.fx.run(self.lane, None, "--remote", "nosuch", "--no-fetch")
+        self.assertIn("new branches start at the rig root's HEAD", proc.stderr)
+        self.assertEqual(self.branch_of(self.lane), "HEAD")
+        self.assertEqual(git(self.lane, "rev-parse", "HEAD"), self.fx.main_sha)
+        proc = self.fx.run(self.lane, "gp-new2", "--remote", "nosuch", "--no-fetch")
+        self.assertEqual(self.branch_of(self.lane), "gp-new2")
+        self.assertEqual(git(self.lane, "rev-parse", "HEAD"), self.fx.main_sha)
+
+    def test_ownerless_old_lock_is_reclaimed_but_a_fresh_one_is_respected(self) -> None:
+        self.lock_dir().mkdir()  # no pid file: a run died between mkdir and publishing
+        proc = self.fx.run(self.lane, "gp-abc1", check=False, env_extra={"WORKER_WORKTREE_LOCK_WAIT": "2"})
+        self.assertNotEqual(proc.returncode, 0)  # fresh: respected
+        os.utime(self.lock_dir(), (time.time() - 300, time.time() - 300))
+        proc = self.fx.run(self.lane, "gp-abc1")
+        self.assertIn("clearing stale lock", proc.stderr)
+        self.assertEqual(self.branch_of(self.lane), "gp-abc1")
+        self.assertFalse(self.lock_dir().exists())
+        self.assertEqual(sorted(self.fx.rig.joinpath(".git").glob("worker-worktree.lock*")), [])
+
     # --- refusals ----------------------------------------------------------------------------
 
     def test_workdir_inside_rig_root_is_refused_even_if_it_does_not_exist(self) -> None:
@@ -440,6 +477,17 @@ class WorkerWorktreeTests(unittest.TestCase):
         proc = self.fx.run(alias / "nested", "gp-abc1", check=False, mkdir=False)
         self.assertNotEqual(proc.returncode, 0)
         self.assertIn("inside the rig root", proc.stderr)
+
+    def test_symlink_then_dot_dot_resolves_physically(self) -> None:
+        # city/tunnel -> rig/sub; "city/tunnel/../nested" is rig/nested on disk,
+        # which is where the kernel (and gc's MkdirAll) would put the session.
+        (self.fx.rig / "sub").mkdir()
+        (self.fx.city / "tunnel").symlink_to(self.fx.rig / "sub")
+        proc = self.fx.run(self.fx.city / "tunnel" / ".." / "nested", "gp-abc1", check=False, mkdir=False)
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("inside the rig root", proc.stderr)
+        self.assertFalse((self.fx.rig / "nested").exists())
+        self.assertFalse((self.fx.city / "nested").exists())
 
     def test_flags_override_environment(self) -> None:
         lane = self.fx.city / "elsewhere"

--- a/gascity/tests/test_worker_worktree.py
+++ b/gascity/tests/test_worker_worktree.py
@@ -2,7 +2,9 @@
 
 Each test builds a throwaway "remote" (bare repo) plus a rig checkout, then
 runs the script the way gc runs a pre_start command: cwd = the work dir,
-GC_DIR / GC_RIG_ROOT / GC_TRIGGER_BEAD_ID in the environment.
+GC_DIR / GC_RIG_ROOT / GC_TRIGGER_BEAD_ID in the environment. One row per
+contract line in the script header; the rig root is checked untouched after
+every case.
 """
 
 from __future__ import annotations
@@ -43,6 +45,7 @@ class Fixture:
         self.remote = root / "remote.git"
         self.rig = root / "rig"
         self.city = root / "city"
+        self.city.mkdir()
         subprocess.run(["git", "init", "--quiet", "--bare", "-b", "main", str(self.remote)], check=True)
         subprocess.run(["git", "init", "--quiet", "-b", "main", str(self.rig)], check=True)
         git(self.rig, "remote", "add", "origin", str(self.remote))
@@ -67,7 +70,7 @@ class Fixture:
         git(scratch, "push", "--quiet", "origin", name)
         return sha
 
-    def run(self, workdir: pathlib.Path, bead: str | None, *extra: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    def run(self, workdir: pathlib.Path, bead: str | None, *extra: str, check: bool = True, mkdir: bool = True) -> subprocess.CompletedProcess[str]:
         env = {
             **os.environ,
             "GC_DIR": str(workdir),
@@ -77,10 +80,11 @@ class Fixture:
         env.pop("GC_TRIGGER_BEAD_ID", None)
         if bead is not None:
             env["GC_TRIGGER_BEAD_ID"] = bead
-        workdir.mkdir(parents=True, exist_ok=True)  # gc MkdirAll's work_dir before pre_start
+        if mkdir:
+            workdir.mkdir(parents=True, exist_ok=True)  # gc MkdirAll's work_dir before pre_start
         proc = subprocess.run(
             ["sh", str(SCRIPT), *extra],
-            cwd=str(workdir),
+            cwd=str(workdir) if workdir.is_dir() else str(self.city),
             env=env,
             capture_output=True,
             text=True,
@@ -110,6 +114,12 @@ class WorkerWorktreeTests(unittest.TestCase):
             common = path / common
         self.assertEqual(common.resolve(), (self.fx.rig / ".git").resolve())
 
+    def asides(self, lane: pathlib.Path | None = None) -> list[pathlib.Path]:
+        lane = lane or self.lane
+        return sorted(lane.parent.glob(f"{lane.name}.aside-*"))
+
+    # --- fresh work dir -----------------------------------------------------------
+
     def test_empty_workdir_new_bead_creates_branch_from_base(self) -> None:
         proc = self.fx.run(self.lane, "gp-abc1")
         self.assert_is_worktree(self.lane)
@@ -118,6 +128,12 @@ class WorkerWorktreeTests(unittest.TestCase):
         self.assertTrue((self.lane / "README.md").is_file())
         self.assertEqual(proc.stdout.split(), ["WORKTREE", str(self.lane), "gp-abc1", self.fx.main_sha[:7]])
 
+    def test_workdir_that_does_not_exist_yet_is_created(self) -> None:
+        proc = self.fx.run(self.lane, "gp-abc1", mkdir=False)
+        self.assert_is_worktree(self.lane)
+        self.assertEqual(self.branch_of(self.lane), "gp-abc1")
+        self.assertEqual(proc.stdout.split()[1], str(self.lane))
+
     def test_rerun_is_idempotent(self) -> None:
         self.fx.run(self.lane, "gp-abc1")
         first = git(self.lane, "rev-parse", "HEAD")
@@ -125,6 +141,18 @@ class WorkerWorktreeTests(unittest.TestCase):
         self.assertEqual(self.branch_of(self.lane), "gp-abc1")
         self.assertEqual(git(self.lane, "rev-parse", "HEAD"), first)
         self.assertNotIn("WARN", proc.stderr)
+        self.assertEqual(self.asides(), [])
+
+    def test_new_branch_tracks_fresh_remote_tip_not_stale_local_main(self) -> None:
+        # The rig checkout lags: origin/main moves on, local main does not.
+        newer = self.fx.push_branch("main-advance", "newer.txt")
+        scratch = self.fx.root / "scratch-main-advance"
+        git(scratch, "push", "--quiet", "origin", "main-advance:main")
+        self.fx.run(self.lane, "gp-abc1")
+        self.assertEqual(git(self.lane, "rev-parse", "HEAD"), newer)
+        self.assertEqual(git(self.fx.rig, "rev-parse", "main"), self.fx.main_sha)
+
+    # --- bead branch resolution -------------------------------------------------------
 
     def test_existing_remote_branch_named_for_bead_is_checked_out_and_tracked(self) -> None:
         sha = self.fx.push_branch("fix/gp-def2-resume-me")
@@ -134,8 +162,40 @@ class WorkerWorktreeTests(unittest.TestCase):
         self.assertEqual(git(self.lane, "rev-parse", "--abbrev-ref", "@{upstream}"), "origin/fix/gp-def2-resume-me")
         self.assertTrue((self.lane / "feature.txt").is_file())
 
+    def test_bead_id_must_match_as_a_whole_token(self) -> None:
+        # gp-abc10 and xgp-abc1 are other beads; gp-abc1 has no branch yet.
+        self.fx.push_branch("fix/gp-abc10-unrelated", "a.txt")
+        self.fx.push_branch("xgp-abc1-unrelated", "b.txt")
+        self.fx.push_branch("gp-abc1x", "c.txt")
+        self.fx.run(self.lane, "gp-abc1")
+        self.assertEqual(self.branch_of(self.lane), "gp-abc1")
+        self.assertEqual(git(self.lane, "rev-parse", "HEAD"), self.fx.main_sha)
+
+    def test_bead_id_matches_with_slash_dash_and_dot_boundaries(self) -> None:
+        for name, filename in (("feat/gp-tok1", "a.txt"),):
+            sha = self.fx.push_branch(name, filename)
+        self.fx.run(self.lane, "gp-tok1")
+        self.assertEqual(self.branch_of(self.lane), "feat/gp-tok1")
+        self.assertEqual(git(self.lane, "rev-parse", "HEAD"), sha)
+
+    def test_bead_id_with_regex_characters_is_matched_literally(self) -> None:
+        self.fx.push_branch("gp-dotxx-other", "a.txt")  # would match 'gp-dot.x' as a regex
+        self.fx.run(self.lane, "gp-dot.x")
+        self.assertEqual(self.branch_of(self.lane), "gp-dot.x")
+        self.assertEqual(git(self.lane, "rev-parse", "HEAD"), self.fx.main_sha)
+
+    def test_ambiguous_bead_branches_fail_closed(self) -> None:
+        self.fx.push_branch("gp-amb1-first", "a.txt")
+        self.fx.push_branch("gp-amb1-second", "b.txt")
+        proc = self.fx.run(self.lane, "gp-amb1", check=False)
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("several branches", proc.stderr)
+        self.assertIn("gp-amb1-first", proc.stderr)
+        self.assertIn("gp-amb1-second", proc.stderr)
+        self.assertFalse((self.lane / ".git").exists())
+
     def test_bead_branch_checked_out_elsewhere_is_not_stolen(self) -> None:
-        other = self.fx.root / "other-worktree"
+        other = self.fx.root / "other worktree"  # a space: the porcelain parser must keep it
         git(self.fx.rig, "worktree", "add", "--quiet", "-b", "gp-ghi3-elsewhere", str(other), "origin/main")
         sha = commit(other, "elsewhere.txt", "x\n", "elsewhere work")
         proc = self.fx.run(self.lane, "gp-ghi3")
@@ -143,8 +203,19 @@ class WorkerWorktreeTests(unittest.TestCase):
         self.assertEqual(git(self.lane, "rev-parse", "HEAD"), sha)
         self.assertIn("WARN", proc.stderr)
         self.assertIn(str(other), proc.stderr)
+        self.assertNotIn("work in that worktree", proc.stderr)
         self.assertEqual(self.branch_of(other), "gp-ghi3-elsewhere")
         self.assertEqual(proc.stdout.split()[2], "detached")
+
+    def test_rerun_under_a_path_with_spaces_keeps_its_own_branch(self) -> None:
+        lane = self.fx.city / "lanes with spaces" / "lane worker"
+        self.fx.run(lane, "gp-spc1")
+        self.assertEqual(self.branch_of(lane), "gp-spc1")
+        proc = self.fx.run(lane, "gp-spc1")
+        self.assertEqual(self.branch_of(lane), "gp-spc1")  # not mis-detected as "elsewhere" and detached
+        self.assertNotIn("WARN", proc.stderr)
+
+    # --- existing lane ------------------------------------------------------------------
 
     def test_clean_lane_on_old_bead_switches_to_new_bead(self) -> None:
         self.fx.run(self.lane, "gp-old1")
@@ -157,7 +228,7 @@ class WorkerWorktreeTests(unittest.TestCase):
         self.assertEqual(git(self.lane, "rev-parse", "HEAD"), self.fx.main_sha)
         self.assertFalse((self.lane / "old.txt").exists())
         self.assertTrue((self.lane / ".agents" / "skills.txt").is_file())
-        self.assertNotIn("aside", proc.stderr)
+        self.assertEqual(self.asides(), [])
         # The old bead's branch and commit survive.
         self.assertTrue(git(self.fx.rig, "rev-parse", "--verify", "gp-old1"))
 
@@ -166,7 +237,7 @@ class WorkerWorktreeTests(unittest.TestCase):
         (self.lane / "README.md").write_text("uncommitted edit\n", encoding="utf-8")
         proc = self.fx.run(self.lane, "gp-new2")
         self.assertIn("moved aside", proc.stderr)
-        asides = sorted(self.lane.parent.glob("lane-worker.aside-*"))
+        asides = self.asides()
         self.assertEqual(len(asides), 1)
         self.assertEqual((asides[0] / "README.md").read_text(encoding="utf-8"), "uncommitted edit\n")
         self.assertEqual(self.branch_of(asides[0]), "gp-old1")
@@ -177,26 +248,58 @@ class WorkerWorktreeTests(unittest.TestCase):
         self.assertIn(str(asides[0]), listing)
         self.assertIn(str(self.lane), listing)
 
+    def test_switch_that_would_overwrite_an_ignored_file_moves_the_lane_aside(self) -> None:
+        # The target branch tracks build/out.txt; the lane has an ignored local
+        # file at that path. git switch would silently clobber it.
+        sha = self.fx.push_branch("gp-ign2-tracks-build", "build-out.txt")
+        scratch = self.fx.root / "scratch-gp-ign2-tracks-build"
+        (scratch / "build").mkdir()
+        (scratch / "build" / "out.txt").write_text("tracked\n", encoding="utf-8")
+        git(scratch, "add", "build/out.txt")
+        git(scratch, "-c", "user.name=t", "-c", "user.email=t@example.invalid", "commit", "--quiet", "-m", "track build/out.txt")
+        git(scratch, "push", "--quiet", "origin", "gp-ign2-tracks-build")
+        self.fx.run(self.lane, "gp-old1")
+        # per-worktree exclude lives in the worktree's git dir (.git here is a file)
+        exclude = pathlib.Path(git(self.lane, "rev-parse", "--git-path", "info/exclude"))
+        if not exclude.is_absolute():
+            exclude = self.lane / exclude
+        exclude.parent.mkdir(parents=True, exist_ok=True)
+        exclude.write_text("build/\n", encoding="utf-8")
+        (self.lane / "build").mkdir()
+        (self.lane / "build" / "out.txt").write_text("local artifact, ignored\n", encoding="utf-8")
+        self.assertEqual(git(self.lane, "status", "--porcelain"), "")
+        proc = self.fx.run(self.lane, "gp-ign2")
+        self.assertIn("moved aside", proc.stderr)
+        asides = self.asides()
+        self.assertEqual(len(asides), 1)
+        self.assertEqual((asides[0] / "build" / "out.txt").read_text(encoding="utf-8"), "local artifact, ignored\n")
+        self.assertEqual(self.branch_of(self.lane), "gp-ign2-tracks-build")
+        self.assertEqual((self.lane / "build" / "out.txt").read_text(encoding="utf-8"), "tracked\n")
+        self.assertNotEqual(sha, "")
+
+    def test_locked_worktree_that_needs_moving_fails_closed(self) -> None:
+        self.fx.run(self.lane, "gp-old1")
+        (self.lane / "README.md").write_text("uncommitted edit\n", encoding="utf-8")
+        git(self.fx.rig, "worktree", "lock", str(self.lane))
+        proc = self.fx.run(self.lane, "gp-new2", check=False)
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("refused to move", proc.stderr)
+        self.assertEqual(self.asides(), [])
+        self.assertEqual(self.branch_of(self.lane), "gp-old1")
+        self.assertEqual((self.lane / "README.md").read_text(encoding="utf-8"), "uncommitted edit\n")
+
     def test_nonempty_non_worktree_dir_is_moved_aside(self) -> None:
         self.lane.mkdir(parents=True)
         (self.lane / "junk.txt").write_text("keep me\n", encoding="utf-8")
         proc = self.fx.run(self.lane, "gp-abc1")
         self.assertIn("moved aside", proc.stderr)
-        asides = sorted(self.lane.parent.glob("lane-worker.aside-*"))
+        asides = self.asides()
         self.assertEqual(len(asides), 1)
         self.assertEqual((asides[0] / "junk.txt").read_text(encoding="utf-8"), "keep me\n")
         self.assert_is_worktree(self.lane)
         self.assertEqual(self.branch_of(self.lane), "gp-abc1")
 
-    def test_ambiguous_bead_branches_fail_closed(self) -> None:
-        self.fx.push_branch("gp-amb1-first", "a.txt")
-        self.fx.push_branch("gp-amb1-second", "b.txt")
-        proc = self.fx.run(self.lane, "gp-amb1", check=False)
-        self.assertNotEqual(proc.returncode, 0)
-        self.assertIn("several branches", proc.stderr)
-        self.assertIn("gp-amb1-first", proc.stderr)
-        self.assertIn("gp-amb1-second", proc.stderr)
-        self.assertFalse((self.lane / ".git").exists())
+    # --- no bead ----------------------------------------------------------------------------
 
     def test_no_bead_leaves_a_detached_worktree_at_base(self) -> None:
         proc = self.fx.run(self.lane, None)
@@ -205,28 +308,46 @@ class WorkerWorktreeTests(unittest.TestCase):
         self.assertEqual(git(self.lane, "rev-parse", "HEAD"), self.fx.main_sha)
         self.assertEqual(proc.stdout.split()[2], "detached")
 
-    def test_no_bead_does_not_move_a_lane_off_its_branch(self) -> None:
+    def test_no_bead_detaches_a_lane_that_was_on_a_branch_and_keeps_the_branch(self) -> None:
         self.fx.run(self.lane, "gp-old1")
+        sha = commit(self.lane, "old.txt", "old\n", "old bead work")
         self.fx.run(self.lane, None)
-        self.assertEqual(self.branch_of(self.lane), "gp-old1")
+        self.assertEqual(self.branch_of(self.lane), "HEAD")
+        self.assertEqual(git(self.lane, "rev-parse", "HEAD"), self.fx.main_sha)
+        self.assertEqual(git(self.fx.rig, "rev-parse", "gp-old1"), sha)
+        self.assertEqual(self.asides(), [])
 
-    def test_new_branch_tracks_fresh_remote_tip_not_stale_local_main(self) -> None:
-        # The rig checkout lags: origin/main moves on, local main does not.
-        newer = self.fx.push_branch("main-advance", "newer.txt")
-        scratch = self.fx.root / "scratch-main-advance"
-        git(scratch, "push", "--quiet", "origin", "main-advance:main")
-        self.fx.run(self.lane, "gp-abc1")
-        self.assertEqual(git(self.lane, "rev-parse", "HEAD"), newer)
-        self.assertEqual(git(self.fx.rig, "rev-parse", "main"), self.fx.main_sha)
+    def test_no_bead_rerun_on_a_detached_lane_is_a_no_op(self) -> None:
+        self.fx.run(self.lane, None)
+        proc = self.fx.run(self.lane, None)
+        self.assertEqual(self.branch_of(self.lane), "HEAD")
+        self.assertNotIn("WARN", proc.stderr)
 
-    def test_workdir_inside_rig_root_is_refused(self) -> None:
+    # --- refusals ----------------------------------------------------------------------------
+
+    def test_workdir_inside_rig_root_is_refused_even_if_it_does_not_exist(self) -> None:
         inside = self.fx.rig / "nested"
-        proc = self.fx.run(inside, "gp-abc1", check=False)
+        proc = self.fx.run(inside, "gp-abc1", check=False, mkdir=False)
         self.assertNotEqual(proc.returncode, 0)
         self.assertIn("inside the rig root", proc.stderr)
+        self.assertFalse(inside.exists())
         proc = self.fx.run(self.fx.rig, "gp-abc1", check=False)
         self.assertNotEqual(proc.returncode, 0)
         self.assertIn("is the rig root", proc.stderr)
+
+    def test_workdir_that_is_an_ancestor_of_the_rig_root_is_refused(self) -> None:
+        proc = self.fx.run(self.fx.root, "gp-abc1", check=False)
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("ancestor of the rig root", proc.stderr)
+        self.assertEqual(self.asides(self.fx.root), [])
+        self.assertTrue(self.fx.rig.is_dir())
+
+    def test_symlink_alias_of_the_rig_root_is_refused(self) -> None:
+        alias = self.fx.root / "rig-alias"
+        alias.symlink_to(self.fx.rig)
+        proc = self.fx.run(alias / "nested", "gp-abc1", check=False, mkdir=False)
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("inside the rig root", proc.stderr)
 
     def test_flags_override_environment(self) -> None:
         lane = self.fx.city / "elsewhere"

--- a/tests/test_gc_role_prompt_integration.py
+++ b/tests/test_gc_role_prompt_integration.py
@@ -190,6 +190,8 @@ def assert_clean_worker_render(prompt: str, persona_heading: str) -> None:
     assert "CLAIMED_ROOT_BEAD_ID" in prompt
     assert "CLAIMED_CONTINUATION_GROUP" in prompt
     assert 'gc bd update "$CLAIMED_BEAD_ID"' in prompt
+    assert "An absent key is an empty value, never a failed claim." in prompt
+    assert prompt.count("## Workspace") == 1
     assert "An empty continuation group is a hard session boundary" in prompt
 
 

--- a/tests/test_gc_role_worker_fragment.py
+++ b/tests/test_gc_role_worker_fragment.py
@@ -1,0 +1,60 @@
+"""Static checks on the shared `gc-role-worker` template fragment.
+
+The rendered-prompt integration tests need a real gc binary (GC_TEST_BIN);
+these run everywhere and pin the fragment text every role worker inherits.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FRAGMENT = REPO_ROOT / "gascity" / "template-fragments" / "gc-role-worker.template.md"
+
+
+def fragment() -> str:
+    return FRAGMENT.read_text(encoding="utf-8")
+
+
+def test_fragment_defines_exactly_one_template() -> None:
+    text = fragment()
+    assert text.count('{{ define "gc-role-worker" -}}') == 1
+    assert text.count("{{- end }}") == 1
+    assert text.count("# GC Role Worker") == 1
+
+
+def test_claim_section_tolerates_omitted_lifecycle_keys() -> None:
+    text = fragment()
+    claim = text.split("## Claim", 1)[1].split("## Workspace", 1)[0]
+    assert "CLAIMED_ROOT_BEAD_ID" in claim
+    assert "CLAIMED_CONTINUATION_GROUP" in claim
+    assert "An absent key is an empty value, never a failed claim." in claim
+
+
+def test_workspace_section_sits_between_claim_and_close() -> None:
+    text = fragment()
+    claim_at = text.index("## Claim")
+    workspace_at = text.index("## Workspace")
+    close_at = text.index("## Close")
+    assert claim_at < workspace_at < close_at
+    workspace = text[workspace_at:close_at]
+    assert "$GC_DIR" in workspace
+    assert "worker-worktree.sh" in workspace
+    assert "<city>/.worktrees/<rig>/<bead>" in workspace
+    assert "check that branch out in the new worktree" in workspace
+    assert "--set-metadata 'work_dir=<absolute worktree path>'" in workspace
+    assert "--set-metadata 'gc.work_branch=<branch>'" in workspace
+
+
+def test_workspace_section_never_names_the_rig_root_as_a_place_to_work() -> None:
+    workspace = fragment().split("## Workspace", 1)[1].split("## Close", 1)[0]
+    assert "rig root and the rig forbids working there" in workspace
+    assert "cd " not in workspace
+
+
+def test_worker_worktree_script_is_shipped_and_executable() -> None:
+    script = REPO_ROOT / "gascity" / "assets" / "scripts" / "worker-worktree.sh"
+    assert script.is_file()
+    assert script.stat().st_mode & 0o111, "worker-worktree.sh must be executable"
+    head = script.read_text(encoding="utf-8").splitlines()[0]
+    assert head == "#!/bin/sh"

--- a/tests/test_gc_role_worker_fragment.py
+++ b/tests/test_gc_role_worker_fragment.py
@@ -42,6 +42,8 @@ def test_workspace_section_sits_between_claim_and_close() -> None:
     assert "worker-worktree.sh" in workspace
     assert "<city>/.worktrees/<rig>/<bead>" in workspace
     assert "check that branch out in the new worktree" in workspace
+    assert "if `git branch --show-current` prints" in workspace
+    assert "restamp it when they differ" in workspace
     assert "--set-metadata 'work_dir=<absolute worktree path>'" in workspace
     assert "--set-metadata 'gc.work_branch=<branch>'" in workspace
 


### PR DESCRIPTION
> Clean re-cut of #413, which shared the fork PR's head and therefore dragged the fork's whole divergence (481 files, conflicting). This branch is cut from gastownhall main and carries only the six-file change. Fork PR: aphexcx/gascity-packs-prs#31 (merged as abb67a2c on 2026-09-09).

## Why

The citadel codex role agents (`implementation-worker-codex`, `implementation-worker-codex-www`: the gascity `implementation-worker` role on a second provider) shipped three beads on 2026-09-09 and filed fourteen papercuts about the environment they start in:

1. **Start cwd = the rig root**, which the rig's AGENTS rules forbid; every worker created or hunted for its own worktree and inherited a stale `gc.work_branch` (pc_4896eeed9151, pc_2ec0145b5108, pc_bbf5bb62f1d0, pc_e268966189e7, pc_a5e273aa994a).
2. **Skills** pointed at the rig root's `.agents/.codex`, absent from a fresh worktree (pc_4896eeed9151, pc_06ee41d251e1).
3. **PATH** had Bun but no pnpm; every run re-discovered `npx -y pnpm@11.20.0` and lint-staged hooks skipped (pc_1ffe2ef3b01a, pc_c00e15baefce, pc_2f81aef95d6e).
4. **Claim output** omitted `root_bead_id` / `continuation_group`, which the role prompt requires the worker to record (pc_b7a878218aac and family).

## What (pack half)

Two core surfaces already do the heavy lifting: agent `work_dir` (gc creates it, starts the session there, exports `$GC_DIR`, and materializes skills + hooks into it because it differs from the scope root, which closes theme 2 for free) and `pre_start` (runs before the session, in `$GC_DIR`, with the session env including `GC_TRIGGER_BEAD_ID`). This PR ships the missing half:

- `gascity/assets/scripts/worker-worktree.sh`: a POSIX `pre_start` that makes `$GC_DIR` a worktree of the rig on the bead's branch (reused when one branch names the bead as a whole token, created from `origin/HEAD` otherwise, fail closed on several, detached with a WARN when the branch is checked out elsewhere). Nothing is deleted: dirty lanes, foreign non-empty dirs, and refused switches (`--no-overwrite-ignore`) are moved to `<dir>.aside-<stamp>`; a locked worktree fails the script in place. Rig root, inside-rig, and ancestor-of-rig paths are refused up front. 23 contract tests (`gascity/tests/test_worker_worktree.py`), one row per header line.
- `gc-role-worker` fragment: a **Workspace** section (work in `$GC_DIR`; create your branch when detached; the rig-root fallback; check an existing bead branch out rather than creating another; restamp `gc.work_branch` after the claim when it differs; stamp `work_dir` + `gc.work_branch` before closing a bead whose work continues, which the core's task work_dir override then honors). The **Claim** contract now says an absent `root_bead_id` / `continuation_group` on the raw hook line is an empty value, never a failed claim (the `gc <binding> claim` wrapper always prints both). Pinned by `tests/test_gc_role_worker_fragment.py` (no gc binary needed) and the rendered-prompt integration test.
- `gascity/README.md`: **Worker workspaces** recipe (agent keys, script install path, bead `work_dir` override, provider-owned toolchain PATH).

## What (city half, applied on citadel, not in this repo)

- `agents/implementation-worker-codex{,-www}/agent.toml`: `work_dir = ".worktrees/{{.Rig}}/lane-{{.AgentBase}}"`, `pre_start = ["sh {{.CityRoot}}/.gc/scripts/worker-worktree.sh"]`; standing note now points at `gc gascity claim`.
- `.gc/shims/codex-astra/codex` prepends `.gc/shims/toolchain` to PATH; `.gc/shims/toolchain/pnpm` installs pnpm once under `.gc/toolchain/` (no machine-wide change; pnpm honors the repo's `packageManager` pin) and execs it. Theme 3.

## Theme 4 decision

Both: the role prompt tolerates absent keys (works with any gc build), and gascity core drops `omitempty` so every `action=work` line carries both keys explicitly (companion PRs: aphexcx/gascity#11 on `integration`, gastownhall/gascity#6189 on `main`; codex gate on that diff CLEAN in one round, two MINOR test-coverage findings addressed). The probe also exposed that the claim stamps `gc.work_branch` from the bead store dir (rig root, `main`) rather than the session work dir; the same core PRs fix that.

## Verification

- Live probe gp-f1rs through `gascity-packs/implementation-worker-codex` (gpt-6-astra) after the city half was applied. The worker's own report: `pwd` = `/Users/tailor512/city/.worktrees/gascity-packs/lane-implementation-worker-codex`; `git branch --show-current` = `gp-f1rs`; `.agents/skills` in the lane with 9 symlinked skills; `command -v pnpm` = `/Users/tailor512/city/.gc/shims/toolchain/pnpm`, `pnpm --version` = 11.20.0; the claim line carried `"root_bead_id":"","continuation_group":""`; `gc.work_branch` stamped `main` (the core bug above). Bead closed by the worker with `gc.outcome=pass`, `gc.work_outcome=no-op`.
- `python3 -m pytest tests gascity/tests -q`: 304 passed, 8 skipped. shellcheck + `dash -n` clean.
- Codex gate (fleet codex 0.146.0, `codex exec --sandbox read-only`), six rounds on the script, each round's findings fixed with a test row per item and re-gated:
  - r1: 8 findings (5 MAJOR) — substring bead match, path guard for nonexistent/ancestor dirs, `git switch` clobbering ignored files, `mv` of registered worktrees, concurrent branch creation, porcelain paths with spaces, no-bead contract, WARN wording.
  - r2: 6 findings (4 MAJOR) — holes around r1's fixes; the shape changed instead of a third patch: one serialized path under a per-repo lock, parent-must-exist path rule, foreign checkouts refused, verify-before-report.
  - r3: 5 findings (4 MAJOR) in the new shape — stale-lock reclaim race, `cd` resolving `..` logically, dirty same-bead restart, `BASE=HEAD` re-read in the lane, ownerless lock.
  - r4: 4 findings (2 MAJOR) — late contender renaming a live lock, unbounded reclaim retry, remote-name metacharacters, idempotence wording. Reclaim now happens under a second atomic lock with a re-check; a deterministic two-contender row exercises it via two test-only pause seams.
  - r5: 2 MINOR — aged reclaim lock removed by age (now fails closed), test pausing in the wrong place.
  - r6: **VERDICT: CLEAN**, one optional MINOR on test synchronization (fixed in the last commit, test-only).
- Pre-existing, unrelated to this diff: `test_city_claim_command_verifies_and_normalizes_claim` fails when pytest runs inside a gc worker session because the test inherits the session's `GC_TEMPLATE` (papercut pc_bb451b289858); identical on `origin/main`, green in CI and in a clean shell.
- 43 script/fragment rows; the full pack suite (`python3 -m pytest tests gascity/tests`) passed at 316 before the last two test-only commits (one load flake under a load average of 49 during the gate runs passed on rerun).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
